### PR TITLE
Support UPDATE/DELETE on compressed hypertables.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ accidentally triggering the load of a previous DB version.**
 * #5454 Add support for ON CONFLICT DO UPDATE for compressed hypertables
 * #5344 Enable JOINS for Hierarchical Continuous Aggregates
 * #5417 Refactor and optimize distributed COPY
+* #5339 Support UPDATE/DELETE on compressed hypertables
 
 **Bugfixes**
 * #5396 Fix SEGMENTBY columns predicates to be pushed down

--- a/src/cross_module_fn.h
+++ b/src/cross_module_fn.h
@@ -139,6 +139,7 @@ typedef struct CrossModuleFunctions
 	PGFunction decompress_chunk;
 	void (*decompress_batches_for_insert)(ChunkInsertState *state, Chunk *chunk,
 										  TupleTableSlot *slot);
+	void (*decompress_batches_for_update_delete)(List *chunks, List *predicates);
 	/* The compression functions below are not installed in SQL as part of create extension;
 	 *  They are installed and tested during testing scripts. They are exposed in cross-module
 	 *  functions because they may be very useful for debugging customer problems if the sql

--- a/src/nodes/hypertable_modify.h
+++ b/src/nodes/hypertable_modify.h
@@ -27,6 +27,8 @@ typedef struct HypertableModifyState
 	CustomScanState cscan_state;
 	ModifyTable *mt;
 	List *serveroids;
+	bool comp_chunks_processed;
+	Snapshot snapshot;
 	FdwRoutine *fdwroutine;
 } HypertableModifyState;
 

--- a/tsl/src/compression/compression.h
+++ b/tsl/src/compression/compression.h
@@ -16,6 +16,7 @@
 #include <nodes/execnodes.h>
 #include "segment_meta.h"
 
+#include "compat/compat.h"
 /*
  * Compressed data starts with a specialized varlen type starting with the usual
  * varlen header, and followed by a version specifying which compression
@@ -290,6 +291,9 @@ typedef struct Chunk Chunk;
 typedef struct ChunkInsertState ChunkInsertState;
 extern void decompress_batches_for_insert(ChunkInsertState *cis, Chunk *chunk,
 										  TupleTableSlot *slot);
+#if PG14_GE
+extern void decompress_batches_for_update_delete(List *chunks, List *predicates);
+#endif
 /* CompressSingleRowState methods */
 struct CompressSingleRowState;
 typedef struct CompressSingleRowState CompressSingleRowState;

--- a/tsl/src/init.c
+++ b/tsl/src/init.c
@@ -184,6 +184,11 @@ CrossModuleFunctions tsl_cm_functions = {
 	.compress_chunk = tsl_compress_chunk,
 	.decompress_chunk = tsl_decompress_chunk,
 	.decompress_batches_for_insert = decompress_batches_for_insert,
+#if PG14_GE
+	.decompress_batches_for_update_delete = decompress_batches_for_update_delete,
+#else
+	.decompress_batches_for_update_delete = NULL,
+#endif
 
 	.data_node_add = data_node_add,
 	.data_node_delete = data_node_delete,

--- a/tsl/src/planner.c
+++ b/tsl/src/planner.c
@@ -153,8 +153,12 @@ tsl_set_rel_pathlist_dml(PlannerInfo *root, RelOptInfo *rel, Index rti, RangeTbl
 			return;
 		}
 	}
-#endif
-
+#else
+	/*
+	 * We do not support UPDATE/DELETE operations on compressed hypertables
+	 * on PG versions < 14, because Custom Scan (HypertableModify) node is
+	 * not generated in the plan for UPDATE/DELETE operations on hypertables
+	 */
 	if (ht != NULL && TS_HYPERTABLE_HAS_COMPRESSION_TABLE(ht))
 	{
 		ListCell *lc;
@@ -168,6 +172,7 @@ tsl_set_rel_pathlist_dml(PlannerInfo *root, RelOptInfo *rel, Index rti, RangeTbl
 			}
 		}
 	}
+#endif
 }
 
 /*

--- a/tsl/test/expected/chunk_utils_internal.out
+++ b/tsl/test/expected/chunk_utils_internal.out
@@ -293,10 +293,10 @@ INSERT INTO public.table_to_compress VALUES ('2020-01-01 10:00', 12, 77);
 ERROR:  cannot INSERT into frozen chunk "_hyper_2_3_chunk"
 --touches all chunks
 UPDATE public.table_to_compress SET value = 3;
-ERROR:  cannot update/delete rows from chunk "_hyper_2_3_chunk" as it is frozen
+ERROR:  cannot modify frozen chunk status
 --touches only frozen chunk
 DELETE FROM public.table_to_compress WHERE time < '2020-01-02';
-ERROR:  cannot update/delete rows from chunk "_hyper_2_3_chunk" as it is frozen
+ERROR:  cannot modify frozen chunk status
 \set ON_ERROR_STOP 1
 --try to refreeze
 SELECT  _timescaledb_internal.freeze_chunk( :'CHNAME');

--- a/tsl/test/expected/compression.out
+++ b/tsl/test/expected/compression.out
@@ -167,9 +167,7 @@ BEGIN;
 insert into foo values( 11 , 10 , 20, 120);
 ROLLBACK;
 update foo set b =20 where a = 10;
-ERROR:  cannot update/delete rows from chunk "_hyper_1_2_chunk" as it is compressed
 delete from foo where a = 10;
-ERROR:  cannot update/delete rows from chunk "_hyper_1_2_chunk" as it is compressed
 --TEST2b try complex DML on compressed chunk
 create table foo_join ( a integer, newval integer);
 select table_name from create_hypertable('foo_join', 'a', chunk_time_interval=> 10);
@@ -192,18 +190,15 @@ insert into foo_join select generate_series(0,40, 10), 222;
 update foo
 set b = newval
 from foo_join where foo.a = foo_join.a;
-ERROR:  cannot update/delete rows from chunk "_hyper_1_1_chunk" as it is compressed
 update foo
 set b = newval
 from foo_join where foo.a = foo_join.a and foo_join.a > 10;
-ERROR:  cannot update/delete rows from chunk "_hyper_1_1_chunk" as it is compressed
 --here the chunk gets excluded , so succeeds --
 update foo
 set b = newval
 from foo_join where foo.a = foo_join.a and foo.a > 20;
 update foo
 set b = (select f1.newval from foo_join f1 left join lateral (select newval as newval2 from  foo_join2 f2 where f1.a= f2.a ) subq on true limit 1);
-ERROR:  cannot update/delete rows from chunk "_hyper_1_1_chunk" as it is compressed
 --upsert test --
 insert into foo values(10, 12, 12, 12)
 on conflict( a, b)
@@ -212,8 +207,8 @@ SELECT * from foo ORDER BY a,b;
  a  |  b  | c  | d  
 ----+-----+----+----
  10 |  12 | 12 | 12
- 20 |  11 | 20 |   
- 30 | 222 | 40 |   
+ 20 | 111 | 20 |   
+ 30 | 111 | 40 |   
 (3 rows)
 
 --TEST2c Do DML directly on the chunk.
@@ -224,15 +219,13 @@ SELECT * from foo ORDER BY a,b;
  a  |  b  | c  | d  
 ----+-----+----+----
  10 |  24 | 12 | 12
- 20 |  11 | 20 |   
- 30 | 222 | 40 |   
+ 20 | 111 | 20 |   
+ 30 | 111 | 40 |   
 (3 rows)
 
 update _timescaledb_internal._hyper_1_2_chunk
 set b = 12;
-ERROR:  cannot update/delete rows from chunk "_hyper_1_2_chunk" as it is compressed
 delete from _timescaledb_internal._hyper_1_2_chunk;
-ERROR:  cannot update/delete rows from chunk "_hyper_1_2_chunk" as it is compressed
 --TEST2d decompress the chunk and try DML
 select decompress_chunk( '_timescaledb_internal._hyper_1_2_chunk');
             decompress_chunk            
@@ -242,14 +235,12 @@ select decompress_chunk( '_timescaledb_internal._hyper_1_2_chunk');
 
 insert into foo values( 11 , 10 , 20, 120);
 update foo set b =20 where a = 10;
-ERROR:  duplicate key value violates unique constraint "_hyper_1_2_chunk_foo_uniq"
 select * from _timescaledb_internal._hyper_1_2_chunk order by a,b;
  a  | b  | c  |  d  
 ----+----+----+-----
- 10 | 10 | 20 |    
- 10 | 24 | 12 |  12
+ 10 | 20 | 20 |    
  11 | 10 | 20 | 120
-(3 rows)
+(2 rows)
 
 delete from foo where a = 10;
 select * from _timescaledb_internal._hyper_1_2_chunk order by a,b;
@@ -1018,12 +1009,10 @@ WHERE rescan_test.id = tmp.id AND rescan_test.t = tmp.t AND rescan_test.t >= '20
 UPDATE rescan_test SET val = tmp.val
 FROM (SELECT x.id, x.t, x.val FROM unnest(array[(1, '2000-01-03 00:00:00+00', 2.045)]::rescan_test[]) AS x) AS tmp
 WHERE rescan_test.id = tmp.id AND rescan_test.t = tmp.t;
-ERROR:  cannot update/delete rows from chunk "_hyper_16_36_chunk" as it is compressed
 -- bulk row update with FROM is blocked
 UPDATE rescan_test SET val = tmp.val
 FROM (SELECT x.id, x.t, x.val FROM unnest(array[(1, '2000-01-03 00:00:00+00', 2.045), (1, '2000-01-03 01:00:00+00', 8.045)]::rescan_test[]) AS x) AS tmp
 WHERE rescan_test.id = tmp.id AND rescan_test.t = tmp.t;
-ERROR:  cannot update/delete rows from chunk "_hyper_16_36_chunk" as it is compressed
 \set ON_ERROR_STOP 1
 -- Test FK constraint drop and recreate during compression and decompression on a chunk
 CREATE TABLE meta (device_id INT PRIMARY KEY);
@@ -1073,7 +1062,6 @@ ORDER BY constraint_name;
 -- Delete data from compressed chunk directly fails
 \set ON_ERROR_STOP 0
 DELETE FROM hyper WHERE device_id = 3;
-ERROR:  cannot update/delete rows from chunk "_hyper_18_42_chunk" as it is compressed
 \set ON_ERROR_STOP 0
 -- Delete data from FK-referenced table deletes data from compressed chunk
 SELECT * FROM hyper ORDER BY time, device_id;
@@ -1081,11 +1069,9 @@ SELECT * FROM hyper ORDER BY time, device_id;
 ------+-----------+-----
     1 |         1 |   1
     2 |         2 |   1
-    3 |         3 |   1
-   10 |         3 |   2
    11 |         4 |   2
    11 |         5 |   2
-(6 rows)
+(4 rows)
 
 DELETE FROM meta WHERE device_id = 3;
 SELECT * FROM hyper ORDER BY time, device_id;
@@ -1235,22 +1221,28 @@ WITH compressed AS (
 DELETE FROM uncompressed_ht
 WHERE series_id IN (SELECT series_id FROM compressed);
 ROLLBACK;
-\set ON_ERROR_STOP 0
--- test delete inside CTE is blocked
+-- test delete inside CTE
 WITH compressed AS (
   DELETE FROM compressed_ht RETURNING series_id
 )
 SELECT * FROM uncompressed_ht
 WHERE series_id IN (SELECT series_id FROM compressed);
-ERROR:  cannot update/delete rows from chunk "_hyper_25_51_chunk" as it is compressed
+             time             | value | series_id 
+------------------------------+-------+-----------
+ Mon Apr 20 01:01:00 2020 PDT |   100 |         1
+ Wed May 20 01:01:00 2020 PDT |   100 |         1
+(2 rows)
+
 -- test update inside CTE is blocked
 WITH compressed AS (
   UPDATE compressed_ht SET value = 0.2 RETURNING *
 )
 SELECT * FROM uncompressed_ht
 WHERE series_id IN (SELECT series_id FROM compressed);
-ERROR:  cannot update/delete rows from chunk "_hyper_25_51_chunk" as it is compressed
-\set ON_ERROR_STOP 1
+ time | value | series_id 
+------+-------+-----------
+(0 rows)
+
 DROP TABLE compressed_ht;
 DROP TABLE uncompressed_ht;
 -- Test that pg_stats and pg_class stats for uncompressed chunks are frozen at compression time

--- a/tsl/test/expected/compression_permissions.out
+++ b/tsl/test/expected/compression_permissions.out
@@ -135,7 +135,6 @@ select location from conditions where timec = '2019-04-01 00:00+0';
 update conditions
 set location = 'PNC'
 where location = 'SFO';
-ERROR:  cannot update/delete rows from chunk "_hyper_1_1_chunk" as it is compressed
 delete from conditions
 where timec = '2019-04-01 00:00+0'::timestamp with time zone;
 select location from conditions where timec = '2019-04-01 00:00+0';

--- a/tsl/test/expected/compression_update_delete.out
+++ b/tsl/test/expected/compression_update_delete.out
@@ -1,0 +1,1274 @@
+-- This file and its contents are licensed under the Timescale License.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-TIMESCALE for a copy of the license.
+CREATE OR REPLACE VIEW compressed_chunk_info_view AS
+SELECT
+   h.schema_name AS hypertable_schema,
+   h.table_name AS hypertable_name,
+   c.schema_name as chunk_schema,
+   c.table_name as chunk_name,
+   c.status as chunk_status,
+   comp.schema_name as compressed_chunk_schema,
+   comp.table_name as compressed_chunk_name
+FROM
+   _timescaledb_catalog.hypertable h JOIN
+  _timescaledb_catalog.chunk c ON h.id = c.hypertable_id
+   LEFT JOIN _timescaledb_catalog.chunk comp
+ON comp.id = c.compressed_chunk_id
+;
+CREATE TABLE sample_table (
+       time TIMESTAMP WITH TIME ZONE NOT NULL,
+       sensor_id INTEGER NOT NULL,
+       cpu double precision null,
+       temperature double precision null,
+       name varchar(100) default 'this is a default string value'
+);
+SELECT * FROM create_hypertable('sample_table', 'time',
+       chunk_time_interval => INTERVAL '2 months');
+WARNING:  column type "character varying" used for "name" does not follow best practices
+ hypertable_id | schema_name |  table_name  | created 
+---------------+-------------+--------------+---------
+             1 | public      | sample_table | t
+(1 row)
+
+SELECT '2022-01-28 01:09:53.583252+05:30' as start_date \gset
+INSERT INTO sample_table
+    SELECT
+       	time + (INTERVAL '1 minute' * random()) AS time,
+       		sensor_id,
+       		random() AS cpu,
+       		random()* 100 AS temperature
+       	FROM
+       		generate_series(:'start_date'::timestamptz - INTERVAL '1 months',
+                            :'start_date'::timestamptz - INTERVAL '1 week',
+                            INTERVAL '1 hour') AS g1(time),
+       		generate_series(1, 8, 1 ) AS g2(sensor_id)
+       	ORDER BY
+       		time;
+SELECT '2023-03-17 17:51:11.322998+05:30' as start_date \gset
+-- insert into new chunks
+INSERT INTO sample_table VALUES (:'start_date'::timestamptz, 12, 21.98, 33.123, 'new row1');
+INSERT INTO sample_table VALUES (:'start_date'::timestamptz, 12, 17.66, 13.875, 'new row1');
+INSERT INTO sample_table VALUES (:'start_date'::timestamptz, 13, 21.98, 33.123, 'new row2');
+INSERT INTO sample_table VALUES (:'start_date'::timestamptz, 1, 21.98, 33.123, 'new row2');
+INSERT INTO sample_table VALUES (:'start_date'::timestamptz, 4, 21.98, 33.123, 'new row2');
+INSERT INTO sample_table VALUES (:'start_date'::timestamptz, 5, 0.988, 33.123, 'new row3');
+INSERT INTO sample_table VALUES (:'start_date'::timestamptz, 6, 4.6554, 47, 'new row3');
+-- enable compression
+ALTER TABLE sample_table SET (
+	timescaledb.compress,
+	timescaledb.compress_segmentby = 'sensor_id'
+);
+-- compress all chunks
+SELECT compress_chunk(show_chunks('sample_table'));
+             compress_chunk             
+----------------------------------------
+ _timescaledb_internal._hyper_1_1_chunk
+ _timescaledb_internal._hyper_1_2_chunk
+(2 rows)
+
+-- check chunk compression status
+SELECT chunk_status,
+       chunk_name as "CHUNK_NAME"
+FROM compressed_chunk_info_view
+WHERE hypertable_name = 'sample_table' ORDER BY chunk_name;
+ chunk_status |    CHUNK_NAME    
+--------------+------------------
+            1 | _hyper_1_1_chunk
+            1 | _hyper_1_2_chunk
+(2 rows)
+
+-- test rows visibility
+BEGIN;
+-- report 0 rows
+SELECT count(*) FROM sample_table WHERE name = 'updated row';
+ count 
+-------
+     0
+(1 row)
+
+-- update 4 rows
+UPDATE sample_table SET name = 'updated row' WHERE cpu = 21.98 AND temperature = 33.123;
+-- report 0 rows
+SELECT count(*) FROM sample_table WHERE name = 'updated row';
+ count 
+-------
+     4
+(1 row)
+
+ROLLBACK;
+-- get count of affected rows
+SELECT count(*) FROM sample_table WHERE cpu = 21.98 AND temperature = 33.123;
+ count 
+-------
+     4
+(1 row)
+
+-- do update
+UPDATE sample_table SET name = 'updated row' WHERE cpu = 21.98 AND temperature = 33.123;
+-- get count of updated rows
+SELECT count(*) FROM sample_table WHERE name = 'updated row';
+ count 
+-------
+     4
+(1 row)
+
+-- check chunk compression status
+SELECT chunk_status,
+       chunk_name as "CHUNK_NAME"
+FROM compressed_chunk_info_view
+WHERE hypertable_name = 'sample_table' ORDER BY chunk_name;
+ chunk_status |    CHUNK_NAME    
+--------------+------------------
+            9 | _hyper_1_1_chunk
+            9 | _hyper_1_2_chunk
+(2 rows)
+
+-- recompress the paritial chunks
+CALL recompress_chunk('_timescaledb_internal._hyper_1_1_chunk');
+CALL recompress_chunk('_timescaledb_internal._hyper_1_2_chunk');
+-- check chunk compression status
+SELECT chunk_status,
+       chunk_name as "CHUNK_NAME"
+FROM compressed_chunk_info_view
+WHERE hypertable_name = 'sample_table' ORDER BY chunk_name;
+ chunk_status |    CHUNK_NAME    
+--------------+------------------
+            1 | _hyper_1_1_chunk
+            1 | _hyper_1_2_chunk
+(2 rows)
+
+-- get count of affected rows
+SELECT count(*) FROM sample_table WHERE name = 'updated row';
+ count 
+-------
+     4
+(1 row)
+
+-- do delete
+DELETE FROM sample_table WHERE name = 'updated row';
+-- get count of updated rows
+SELECT count(*) FROM sample_table WHERE name = 'updated row';
+ count 
+-------
+     0
+(1 row)
+
+-- check chunk compression status
+SELECT chunk_status,
+       chunk_name as "CHUNK_NAME"
+FROM compressed_chunk_info_view
+WHERE hypertable_name = 'sample_table' ORDER BY chunk_name;
+ chunk_status |    CHUNK_NAME    
+--------------+------------------
+            9 | _hyper_1_1_chunk
+            9 | _hyper_1_2_chunk
+(2 rows)
+
+-- recompress the paritial chunks
+CALL recompress_chunk('_timescaledb_internal._hyper_1_1_chunk');
+CALL recompress_chunk('_timescaledb_internal._hyper_1_2_chunk');
+-- test for IS NULL checks
+-- should not UPDATE any rows
+UPDATE sample_table SET temperature = 34.21 WHERE sensor_id IS NULL;
+-- check chunk compression status
+SELECT chunk_status,
+       chunk_name as "CHUNK_NAME"
+FROM compressed_chunk_info_view
+WHERE hypertable_name = 'sample_table' ORDER BY chunk_name;
+ chunk_status |    CHUNK_NAME    
+--------------+------------------
+            1 | _hyper_1_1_chunk
+            1 | _hyper_1_2_chunk
+(2 rows)
+
+-- test for IS NOT NULL checks
+-- should UPDATE all rows
+UPDATE sample_table SET temperature = 34.21 WHERE sensor_id IS NOT NULL;
+-- check chunk compression status
+SELECT chunk_status,
+       chunk_name as "CHUNK_NAME"
+FROM compressed_chunk_info_view
+WHERE hypertable_name = 'sample_table' ORDER BY chunk_name;
+ chunk_status |    CHUNK_NAME    
+--------------+------------------
+            9 | _hyper_1_1_chunk
+            9 | _hyper_1_2_chunk
+(2 rows)
+
+-- recompress the paritial chunks
+CALL recompress_chunk('_timescaledb_internal._hyper_1_1_chunk');
+CALL recompress_chunk('_timescaledb_internal._hyper_1_2_chunk');
+-- check chunk compression status
+SELECT chunk_status,
+       chunk_name as "CHUNK_NAME"
+FROM compressed_chunk_info_view
+WHERE hypertable_name = 'sample_table' ORDER BY chunk_name;
+ chunk_status |    CHUNK_NAME    
+--------------+------------------
+            1 | _hyper_1_1_chunk
+            1 | _hyper_1_2_chunk
+(2 rows)
+
+-- report 0 rows
+SELECT COUNT(*) FROM sample_table WHERE name = 'updated row based on < OR > comparison';
+ count 
+-------
+     0
+(1 row)
+
+-- get total count of rows which satifies the condition
+SELECT COUNT(*) as "total_affected_rows" FROM sample_table WHERE
+  time > '2022-01-20 19:10:00.101514+05:30' and
+  time < '2022-01-20 21:10:43.855297+05:30' \gset
+-- perform UPDATE with < and > comparison on SEGMENTBY column
+UPDATE sample_table SET name = 'updated row based on < OR > comparison' WHERE
+  time > '2022-01-20 19:10:00.101514+05:30' and time < '2022-01-20 21:10:43.855297+05:30';
+-- check chunk compression status after UPDATE
+SELECT chunk_status,
+       chunk_name as "CHUNK_NAME"
+FROM compressed_chunk_info_view
+WHERE hypertable_name = 'sample_table' ORDER BY chunk_name;
+ chunk_status |    CHUNK_NAME    
+--------------+------------------
+            9 | _hyper_1_1_chunk
+            1 | _hyper_1_2_chunk
+(2 rows)
+
+-- count should be same
+SELECT COUNT(*) = (:total_affected_rows) FROM sample_table WHERE name = 'updated row based on < OR > comparison';
+ ?column? 
+----------
+ t
+(1 row)
+
+DROP TABLE sample_table;
+-- test to ensure that only required rows from compressed chunks
+-- are extracted if SEGMENTBY column is used in WHERE condition
+CREATE TABLE sample_table(
+    time INT NOT NULL,
+    device_id INT,
+    val INT);
+SELECT * FROM create_hypertable('sample_table', 'time', chunk_time_interval => 10);
+ hypertable_id | schema_name |  table_name  | created 
+---------------+-------------+--------------+---------
+             3 | public      | sample_table | t
+(1 row)
+
+ALTER TABLE sample_table SET (
+    timescaledb.compress,
+    timescaledb.compress_orderby = 'time',
+    timescaledb.compress_segmentby = 'device_id');
+INSERT INTO sample_table VALUES (1, 1, 1), (2, 2, 1), (3, 3, 1), (10, 3, 2), (11, 4, 2), (11, 1, 2);
+-- compress all chunks
+SELECT compress_chunk(show_chunks('sample_table'));
+             compress_chunk             
+----------------------------------------
+ _timescaledb_internal._hyper_3_5_chunk
+ _timescaledb_internal._hyper_3_6_chunk
+(2 rows)
+
+-- get FIRST compressed chunk
+SELECT ch1.schema_name|| '.' || ch1.table_name AS "COMPRESS_CHUNK_1"
+FROM _timescaledb_catalog.chunk ch1, _timescaledb_catalog.hypertable ht
+WHERE ch1.hypertable_id = ht.id AND ch1.table_name LIKE 'compress_%'
+ORDER BY ch1.id LIMIT 1 \gset
+-- get SECOND compressed chunk
+SELECT ch1.schema_name|| '.' || ch1.table_name AS "COMPRESS_CHUNK_2"
+FROM _timescaledb_catalog.chunk ch1, _timescaledb_catalog.hypertable ht
+WHERE ch1.hypertable_id = ht.id AND ch1.table_name LIKE 'compress_%'
+ORDER BY ch1.id DESC LIMIT 1 \gset
+-- there should 2 rows matching the conditions coming from 2 chunks
+SELECT * FROM sample_table WHERE  device_id = 3 ORDER BY time, device_id;
+ time | device_id | val 
+------+-----------+-----
+    3 |         3 |   1
+   10 |         3 |   2
+(2 rows)
+
+-- get total rowcount from compressed chunks
+SELECT COUNT(*) FROM :COMPRESS_CHUNK_1;
+ count 
+-------
+     3
+(1 row)
+
+SELECT COUNT(*) FROM :COMPRESS_CHUNK_2;
+ count 
+-------
+     3
+(1 row)
+
+-- get rowcount from compressed chunks where device_id = 3
+SELECT COUNT(*) FROM :COMPRESS_CHUNK_1 WHERE device_id = 3;
+ count 
+-------
+     1
+(1 row)
+
+SELECT COUNT(*) FROM :COMPRESS_CHUNK_2 WHERE device_id = 3;
+ count 
+-------
+     1
+(1 row)
+
+-- delete rows with device_id = 3
+DELETE FROM sample_table WHERE device_id = 3;
+-- get total rowcount from compressed chunks
+SELECT COUNT(*) FROM :COMPRESS_CHUNK_1;
+ count 
+-------
+     2
+(1 row)
+
+SELECT COUNT(*) FROM :COMPRESS_CHUNK_2;
+ count 
+-------
+     2
+(1 row)
+
+-- get rowcount from compressed chunks where device_id = 3
+SELECT COUNT(*) FROM :COMPRESS_CHUNK_1 WHERE device_id = 3;
+ count 
+-------
+     0
+(1 row)
+
+SELECT COUNT(*) FROM :COMPRESS_CHUNK_2 WHERE device_id = 3;
+ count 
+-------
+     0
+(1 row)
+
+-- there should be no rows
+SELECT * FROM sample_table WHERE  device_id = 3 ORDER BY time, device_id;
+ time | device_id | val 
+------+-----------+-----
+(0 rows)
+
+-- there should 2 rows matching the conditions coming from 2 chunks
+SELECT val FROM sample_table WHERE  1 = device_id ORDER BY time, device_id;
+ val 
+-----
+   1
+   2
+(2 rows)
+
+-- get total rowcount from compressed chunks
+SELECT COUNT(*) FROM :COMPRESS_CHUNK_1;
+ count 
+-------
+     2
+(1 row)
+
+SELECT COUNT(*) FROM :COMPRESS_CHUNK_2;
+ count 
+-------
+     2
+(1 row)
+
+-- get rowcount from compressed chunks where device_id = 1
+SELECT COUNT(*) FROM :COMPRESS_CHUNK_1 WHERE 1 = device_id;
+ count 
+-------
+     1
+(1 row)
+
+SELECT COUNT(*) FROM :COMPRESS_CHUNK_2 WHERE 1 = device_id;
+ count 
+-------
+     1
+(1 row)
+
+-- update rows with device_id = 1
+UPDATE sample_table SET val = 200 WHERE 1 = device_id;
+-- get total rowcount from compressed chunks
+SELECT COUNT(*) FROM :COMPRESS_CHUNK_1;
+ count 
+-------
+     1
+(1 row)
+
+SELECT COUNT(*) FROM :COMPRESS_CHUNK_2;
+ count 
+-------
+     1
+(1 row)
+
+-- get rowcount from compressed chunks where device_id = 1
+SELECT COUNT(*) FROM :COMPRESS_CHUNK_1 WHERE 1 = device_id;
+ count 
+-------
+     0
+(1 row)
+
+SELECT COUNT(*) FROM :COMPRESS_CHUNK_2 WHERE 1 = device_id;
+ count 
+-------
+     0
+(1 row)
+
+-- there should be 2 rows
+SELECT val FROM sample_table WHERE  1 = device_id ORDER BY time, device_id;
+ val 
+-----
+ 200
+ 200
+(2 rows)
+
+DROP TABLE sample_table;
+CREATE TABLE sample_table(
+    time INT NOT NULL,
+    device_id INT,
+    val INT);
+SELECT * FROM create_hypertable('sample_table', 'time', chunk_time_interval => 10);
+ hypertable_id | schema_name |  table_name  | created 
+---------------+-------------+--------------+---------
+             5 | public      | sample_table | t
+(1 row)
+
+ALTER TABLE sample_table SET (
+    timescaledb.compress,
+    timescaledb.compress_segmentby = 'time, val');
+INSERT INTO sample_table VALUES (1, 1, 1), (2, 2, 1), (3, 3, 1), (1, 3, 2), (11, 4, 2), (1, 1, 2);
+-- compress all chunks
+SELECT compress_chunk(show_chunks('sample_table'));
+             compress_chunk              
+-----------------------------------------
+ _timescaledb_internal._hyper_5_9_chunk
+ _timescaledb_internal._hyper_5_10_chunk
+(2 rows)
+
+-- get FIRST compressed chunk
+SELECT ch1.schema_name|| '.' || ch1.table_name AS "COMPRESS_CHUNK_1"
+FROM _timescaledb_catalog.chunk ch1, _timescaledb_catalog.hypertable ht
+WHERE ch1.hypertable_id = ht.id AND ch1.table_name LIKE 'compress_%'
+ORDER BY ch1.id LIMIT 1 \gset
+-- get SECOND compressed chunk
+SELECT ch1.schema_name|| '.' || ch1.table_name AS "COMPRESS_CHUNK_2"
+FROM _timescaledb_catalog.chunk ch1, _timescaledb_catalog.hypertable ht
+WHERE ch1.hypertable_id = ht.id AND ch1.table_name LIKE 'compress_%'
+ORDER BY ch1.id DESC LIMIT 1 \gset
+-- there should 2 rows matching the conditions coming from 2 chunks
+SELECT * FROM sample_table WHERE time = 1 AND val = 2 ORDER BY time, device_id;
+ time | device_id | val 
+------+-----------+-----
+    1 |         1 |   2
+    1 |         3 |   2
+(2 rows)
+
+-- get total rowcount from compressed chunks
+SELECT COUNT(*) FROM :COMPRESS_CHUNK_1;
+ count 
+-------
+     4
+(1 row)
+
+SELECT COUNT(*) FROM :COMPRESS_CHUNK_2;
+ count 
+-------
+     1
+(1 row)
+
+-- get rowcount from compressed chunks where time = 1 AND val = 2
+SELECT COUNT(*) FROM :COMPRESS_CHUNK_1 WHERE time = 1 AND val = 2;
+ count 
+-------
+     1
+(1 row)
+
+SELECT COUNT(*) FROM :COMPRESS_CHUNK_2 WHERE time = 1 AND val = 2;
+ count 
+-------
+     0
+(1 row)
+
+-- delete rows with time = 1 AND val = 2
+EXPLAIN (costs off, verbose) DELETE FROM sample_table WHERE time = 1 AND 2 = val;
+                                    QUERY PLAN                                    
+----------------------------------------------------------------------------------
+ Custom Scan (HypertableModify)
+   ->  Delete on public.sample_table
+         Delete on _timescaledb_internal._hyper_5_9_chunk sample_table_1
+         ->  Seq Scan on _timescaledb_internal._hyper_5_9_chunk sample_table_1
+               Output: sample_table_1.tableoid, sample_table_1.ctid
+               Filter: ((sample_table_1."time" = 1) AND (2 = sample_table_1.val))
+(6 rows)
+
+-- should delete rows from 1 of the compressed chunks
+DELETE FROM sample_table WHERE time = 1 AND 2 = val;
+-- get total rowcount from compressed chunks
+SELECT COUNT(*) FROM :COMPRESS_CHUNK_1;
+ count 
+-------
+     3
+(1 row)
+
+SELECT COUNT(*) FROM :COMPRESS_CHUNK_2;
+ count 
+-------
+     1
+(1 row)
+
+-- get rowcount from compressed chunks wheretime = 1 AND val = 2
+SELECT COUNT(*) FROM :COMPRESS_CHUNK_1 WHERE time = 1 AND val = 2;
+ count 
+-------
+     0
+(1 row)
+
+SELECT COUNT(*) FROM :COMPRESS_CHUNK_2 WHERE time = 1 AND val = 2;
+ count 
+-------
+     0
+(1 row)
+
+-- there should be no rows
+SELECT * FROM sample_table WHERE time = 1 AND val = 2 ORDER BY time, device_id;
+ time | device_id | val 
+------+-----------+-----
+(0 rows)
+
+DROP TABLE sample_table;
+-- Test chunk compile time startup exclusion
+CREATE OR REPLACE FUNCTION now_s()
+RETURNS timestamptz LANGUAGE PLPGSQL STABLE AS
+$BODY$
+BEGIN
+    RETURN '2017-08-22T10:00:00'::timestamptz;
+END;
+$BODY$;
+CREATE TABLE sample_table(time timestamptz NOT NULL, temp float, colorid integer, attr jsonb);
+SELECT create_hypertable('sample_table', 'time', chunk_time_interval => 2628000000000);
+     create_hypertable     
+---------------------------
+ (7,public,sample_table,t)
+(1 row)
+
+-- create three chunks
+INSERT INTO sample_table VALUES ('2017-03-22T09:18:22', 23.5, 1, '{"a": 1, "b": 2}'),
+                                ('2017-03-22T09:18:23', 21.5, 1, '{"a": 1, "b": 2}'),
+                                ('2017-05-22T09:18:22', 36.2, 2, '{"c": 3, "b": 2}'),
+                                ('2017-05-22T09:18:23', 15.2, 2, '{"c": 3}'),
+                                ('2017-08-22T09:18:22', 34.1, 3, '{"c": 4}');
+ALTER TABLE sample_table SET (timescaledb.compress,
+                              timescaledb.compress_segmentby = 'time');
+SELECT compress_chunk(show_chunks('sample_table'));
+             compress_chunk              
+-----------------------------------------
+ _timescaledb_internal._hyper_7_13_chunk
+ _timescaledb_internal._hyper_7_14_chunk
+ _timescaledb_internal._hyper_7_15_chunk
+(3 rows)
+
+-- ensure all chunks are compressed
+SELECT chunk_status,
+       chunk_name as "CHUNK_NAME"
+FROM compressed_chunk_info_view
+WHERE hypertable_name = 'sample_table' ORDER BY chunk_name;
+ chunk_status |    CHUNK_NAME     
+--------------+-------------------
+            1 | _hyper_7_13_chunk
+            1 | _hyper_7_14_chunk
+            1 | _hyper_7_15_chunk
+(3 rows)
+
+-- report 0 rows
+SELECT * FROM sample_table WHERE time > now_s() + '-1 month' AND colorid = 4;
+ time | temp | colorid | attr 
+------+------+---------+------
+(0 rows)
+
+-- update 1 row
+UPDATE sample_table SET colorid = 4 WHERE time > now_s() + '-1 month';
+-- report 1 row
+SELECT * FROM sample_table WHERE time > now_s() + '-1 month' AND colorid = 4;
+             time             | temp | colorid |   attr   
+------------------------------+------+---------+----------
+ Tue Aug 22 09:18:22 2017 PDT | 34.1 |       4 | {"c": 4}
+(1 row)
+
+-- ensure that 1 chunk is partially compressed
+SELECT chunk_status,
+       chunk_name as "CHUNK_NAME"
+FROM compressed_chunk_info_view
+WHERE hypertable_name = 'sample_table' ORDER BY chunk_name;
+ chunk_status |    CHUNK_NAME     
+--------------+-------------------
+            1 | _hyper_7_13_chunk
+            1 | _hyper_7_14_chunk
+            9 | _hyper_7_15_chunk
+(3 rows)
+
+DROP TABLE sample_table;
+-- test for NULL values in SEGMENTBY column
+CREATE TABLE sample_table(
+    time INT,
+    device_id INT,
+    val INT);
+SELECT * FROM create_hypertable('sample_table', 'time', chunk_time_interval => 10);
+NOTICE:  adding not-null constraint to column "time"
+ hypertable_id | schema_name |  table_name  | created 
+---------------+-------------+--------------+---------
+             9 | public      | sample_table | t
+(1 row)
+
+ALTER TABLE sample_table SET (
+    timescaledb.compress,
+    timescaledb.compress_orderby = 'time',
+    timescaledb.compress_segmentby = 'device_id');
+INSERT INTO sample_table VALUES (1, 1, 1), (2, NULL, 1), (3, NULL, 1), (10, NULL, 2), (11, NULL, 2), (11, 1, 2);
+-- compress all chunks
+SELECT compress_chunk(show_chunks('sample_table'));
+             compress_chunk              
+-----------------------------------------
+ _timescaledb_internal._hyper_9_19_chunk
+ _timescaledb_internal._hyper_9_20_chunk
+(2 rows)
+
+-- get FIRST compressed chunk
+SELECT ch1.schema_name|| '.' || ch1.table_name AS "COMPRESS_CHUNK_1"
+FROM _timescaledb_catalog.chunk ch1, _timescaledb_catalog.hypertable ht
+WHERE ch1.hypertable_id = ht.id AND ch1.table_name LIKE 'compress_%'
+ORDER BY ch1.id LIMIT 1 \gset
+-- get SECOND compressed chunk
+SELECT ch1.schema_name|| '.' || ch1.table_name AS "COMPRESS_CHUNK_2"
+FROM _timescaledb_catalog.chunk ch1, _timescaledb_catalog.hypertable ht
+WHERE ch1.hypertable_id = ht.id AND ch1.table_name LIKE 'compress_%'
+ORDER BY ch1.id DESC LIMIT 1 \gset
+-- get total rowcount from compressed chunks
+SELECT COUNT(*) FROM :COMPRESS_CHUNK_1;
+ count 
+-------
+     2
+(1 row)
+
+SELECT COUNT(*) FROM :COMPRESS_CHUNK_2;
+ count 
+-------
+     2
+(1 row)
+
+-- get rowcount from compressed chunks where device_id IS NULL
+SELECT COUNT(*) FROM :COMPRESS_CHUNK_1 WHERE device_id IS NULL;
+ count 
+-------
+     1
+(1 row)
+
+SELECT COUNT(*) FROM :COMPRESS_CHUNK_2 WHERE device_id IS NULL;
+ count 
+-------
+     1
+(1 row)
+
+-- get total count of SEGMENTBY column with NULL values
+SELECT COUNT(*) FROM sample_table WHERE device_id IS NULL;
+ count 
+-------
+     4
+(1 row)
+
+-- delete NULL values in SEGMENTBY column
+DELETE FROM sample_table WHERE device_id IS NULL;
+-- ensure that not all rows are moved to staging area
+-- should have few compressed rows
+SELECT COUNT(*) FROM :COMPRESS_CHUNK_1;
+ count 
+-------
+     1
+(1 row)
+
+SELECT COUNT(*) FROM :COMPRESS_CHUNK_2;
+ count 
+-------
+     1
+(1 row)
+
+-- get rowcount from compressed chunks where device_id IS NULL
+-- should report 0 rows
+SELECT COUNT(*) FROM :COMPRESS_CHUNK_1 WHERE device_id IS NULL;
+ count 
+-------
+     0
+(1 row)
+
+SELECT COUNT(*) FROM :COMPRESS_CHUNK_2 WHERE device_id IS NULL;
+ count 
+-------
+     0
+(1 row)
+
+-- check chunk compression status after DELETE
+SELECT chunk_status,
+       chunk_name as "CHUNK_NAME"
+FROM compressed_chunk_info_view
+WHERE hypertable_name = 'sample_table' ORDER BY chunk_name;
+ chunk_status |    CHUNK_NAME     
+--------------+-------------------
+            9 | _hyper_9_19_chunk
+            9 | _hyper_9_20_chunk
+(2 rows)
+
+DROP TABLE sample_table;
+-- test for IS NOT NULL values in SEGMENTBY column
+CREATE TABLE sample_table(
+    time INT,
+    device_id INT,
+    val INT);
+SELECT * FROM create_hypertable('sample_table', 'time', chunk_time_interval => 10);
+NOTICE:  adding not-null constraint to column "time"
+ hypertable_id | schema_name |  table_name  | created 
+---------------+-------------+--------------+---------
+            11 | public      | sample_table | t
+(1 row)
+
+ALTER TABLE sample_table SET (
+    timescaledb.compress,
+    timescaledb.compress_orderby = 'time',
+    timescaledb.compress_segmentby = 'device_id');
+INSERT INTO sample_table VALUES (1, NULL, 1), (2, NULL, 1), (3, NULL, 1), (10, 3, 2), (11, 2, 2), (11, 1, 2);
+-- compress all chunks
+SELECT compress_chunk(show_chunks('sample_table'));
+              compress_chunk              
+------------------------------------------
+ _timescaledb_internal._hyper_11_23_chunk
+ _timescaledb_internal._hyper_11_24_chunk
+(2 rows)
+
+-- get FIRST compressed chunk
+SELECT ch1.schema_name|| '.' || ch1.table_name AS "COMPRESS_CHUNK_1"
+FROM _timescaledb_catalog.chunk ch1, _timescaledb_catalog.hypertable ht
+WHERE ch1.hypertable_id = ht.id AND ch1.table_name LIKE 'compress_%'
+ORDER BY ch1.id LIMIT 1 \gset
+-- get SECOND compressed chunk
+SELECT ch1.schema_name|| '.' || ch1.table_name AS "COMPRESS_CHUNK_2"
+FROM _timescaledb_catalog.chunk ch1, _timescaledb_catalog.hypertable ht
+WHERE ch1.hypertable_id = ht.id AND ch1.table_name LIKE 'compress_%'
+ORDER BY ch1.id DESC LIMIT 1 \gset
+SELECT COUNT(*) FROM sample_table WHERE val = 1234;
+ count 
+-------
+     0
+(1 row)
+
+-- UPDATE based on IS NOT NULL condition on SEGMENTBY column
+UPDATE sample_table SET val = 1234 WHERE device_id IS NOT NULL;
+-- get total count of SEGMENTBY column with NULL values
+SELECT COUNT(*) FROM sample_table WHERE val = 1234;
+ count 
+-------
+     3
+(1 row)
+
+-- check chunk compression status after DELETE
+SELECT chunk_status,
+       chunk_name as "CHUNK_NAME"
+FROM compressed_chunk_info_view
+WHERE hypertable_name = 'sample_table' ORDER BY chunk_name;
+ chunk_status |     CHUNK_NAME     
+--------------+--------------------
+            1 | _hyper_11_23_chunk
+            9 | _hyper_11_24_chunk
+(2 rows)
+
+DROP TABLE sample_table;
+-- test to for <= AND >= on SEGMENTBY column
+CREATE TABLE sample_table(
+    time INT,
+    device_id INT,
+    val INT);
+SELECT * FROM create_hypertable('sample_table', 'time', chunk_time_interval => 10);
+NOTICE:  adding not-null constraint to column "time"
+ hypertable_id | schema_name |  table_name  | created 
+---------------+-------------+--------------+---------
+            13 | public      | sample_table | t
+(1 row)
+
+ALTER TABLE sample_table SET (
+    timescaledb.compress,
+    timescaledb.compress_orderby = 'time',
+    timescaledb.compress_segmentby = 'device_id, val');
+INSERT INTO sample_table VALUES (1, 1, 1), (2, NULL, 1), (3, 4, 1), (10, NULL, 2), (11, NULL, 2), (11, 1, 2), (13, 5, 3);
+INSERT INTO sample_table VALUES (4, 3, NULL), (6, NULL, NULL), (12, NULL, NULL), (13, 4, NULL);
+-- compress all chunks
+SELECT compress_chunk(show_chunks('sample_table'));
+              compress_chunk              
+------------------------------------------
+ _timescaledb_internal._hyper_13_27_chunk
+ _timescaledb_internal._hyper_13_28_chunk
+(2 rows)
+
+-- test will multiple NULL/NOT NULL columns
+BEGIN;
+-- report 0 row
+SELECT * FROM sample_table WHERE device_id IS NULL AND val = 987;
+ time | device_id | val 
+------+-----------+-----
+(0 rows)
+
+-- these 3 rows will be affected by below UPDATE
+SELECT * FROM sample_table WHERE device_id IS NULL AND val IS NOT NULL ORDER BY 1;
+ time | device_id | val 
+------+-----------+-----
+    2 |           |   1
+   10 |           |   2
+   11 |           |   2
+(3 rows)
+
+-- update 3 rows
+UPDATE sample_table SET val = 987 WHERE device_id IS NULL AND val IS NOT NULL;
+-- report 3 row
+SELECT * FROM sample_table WHERE device_id IS NULL AND val = 987;
+ time | device_id | val 
+------+-----------+-----
+    2 |           | 987
+   10 |           | 987
+   11 |           | 987
+(3 rows)
+
+ROLLBACK;
+-- test will multiple columns
+BEGIN;
+-- report 2 rows
+SELECT * FROM sample_table WHERE device_id IS NULL AND val = 2;
+ time | device_id | val 
+------+-----------+-----
+   10 |           |   2
+   11 |           |   2
+(2 rows)
+
+-- delete 2 rows
+DELETE from sample_table WHERE device_id IS NULL AND val = 2;
+-- report 0 rows
+SELECT * FROM sample_table WHERE device_id IS NULL AND val = 2;
+ time | device_id | val 
+------+-----------+-----
+(0 rows)
+
+ROLLBACK;
+BEGIN;
+-- report 1 row
+SELECT * FROM sample_table WHERE device_id = 3 AND val IS NULL;
+ time | device_id | val 
+------+-----------+-----
+    4 |         3 |    
+(1 row)
+
+-- delete 1 rows
+DELETE from sample_table WHERE device_id = 3 AND val IS NULL;
+-- report 0 rows
+SELECT * FROM sample_table WHERE device_id = 3 AND val IS NULL;
+ time | device_id | val 
+------+-----------+-----
+(0 rows)
+
+ROLLBACK;
+-- get FIRST compressed chunk
+SELECT ch1.schema_name|| '.' || ch1.table_name AS "COMPRESS_CHUNK_1"
+FROM _timescaledb_catalog.chunk ch1, _timescaledb_catalog.hypertable ht
+WHERE ch1.hypertable_id = ht.id AND ch1.table_name LIKE 'compress_%'
+ORDER BY ch1.id LIMIT 1 \gset
+-- get SECOND compressed chunk
+SELECT ch1.schema_name|| '.' || ch1.table_name AS "COMPRESS_CHUNK_2"
+FROM _timescaledb_catalog.chunk ch1, _timescaledb_catalog.hypertable ht
+WHERE ch1.hypertable_id = ht.id AND ch1.table_name LIKE 'compress_%'
+ORDER BY ch1.id DESC LIMIT 1 \gset
+-- get total rowcount from compressed chunks
+SELECT COUNT(*) FROM :COMPRESS_CHUNK_1;
+ count 
+-------
+     5
+(1 row)
+
+SELECT COUNT(*) FROM :COMPRESS_CHUNK_2;
+ count 
+-------
+     5
+(1 row)
+
+-- get rowcount from compressed chunks where device_id >= 4 AND val <= 1
+SELECT COUNT(*) FROM :COMPRESS_CHUNK_1 WHERE device_id >= 4 AND val <= 1;
+ count 
+-------
+     1
+(1 row)
+
+SELECT COUNT(*) FROM :COMPRESS_CHUNK_2 WHERE device_id >= 4 AND val <= 1;
+ count 
+-------
+     0
+(1 row)
+
+-- get total count of SEGMENTBY column with device_id >= 4 AND val <= 1
+SELECT COUNT(*) FROM sample_table WHERE device_id >= 4 AND val <= 1;
+ count 
+-------
+     1
+(1 row)
+
+-- delete NULL values in SEGMENTBY column
+DELETE FROM sample_table WHERE device_id >= 4 AND val <= 1;
+-- ensure that not all rows are moved to staging area
+-- should have few compressed rows
+SELECT COUNT(*) FROM :COMPRESS_CHUNK_1;
+ count 
+-------
+     0
+(1 row)
+
+SELECT COUNT(*) FROM :COMPRESS_CHUNK_2;
+ count 
+-------
+     0
+(1 row)
+
+-- get rowcount from compressed chunks where device_id IS NULL
+-- should report 0 rows
+SELECT COUNT(*) FROM :COMPRESS_CHUNK_1 WHERE device_id >= 4 AND val <= 1;
+ count 
+-------
+     0
+(1 row)
+
+SELECT COUNT(*) FROM :COMPRESS_CHUNK_2 WHERE device_id >= 4 AND val <= 1;
+ count 
+-------
+     0
+(1 row)
+
+-- check chunk compression status after DELETE
+SELECT chunk_status,
+       chunk_name as "CHUNK_NAME"
+FROM compressed_chunk_info_view
+WHERE hypertable_name = 'sample_table' ORDER BY chunk_name;
+ chunk_status |     CHUNK_NAME     
+--------------+--------------------
+            9 | _hyper_13_27_chunk
+            9 | _hyper_13_28_chunk
+(2 rows)
+
+-- added tests for code coverage
+UPDATE sample_table SET time = 21 WHERE (device_id) in ( 30, 51, 72, 53);
+UPDATE sample_table SET time = 21 WHERE device_id + 365 = 8765;
+DROP TABLE sample_table;
+-- test with different physical layout
+CREATE TABLE sample_table(
+    time INT,
+    device_id INT,
+    val INT default 8,
+    a INT default 10,
+    b INT default 11,
+    c INT default 12,
+    d INT,
+    e INT default 13);
+SELECT * FROM create_hypertable('sample_table', 'time', chunk_time_interval => 5);
+NOTICE:  adding not-null constraint to column "time"
+ hypertable_id | schema_name |  table_name  | created 
+---------------+-------------+--------------+---------
+            15 | public      | sample_table | t
+(1 row)
+
+INSERT INTO sample_table (time, device_id, d) VALUES (1, 1, 1), (2, NULL, 1), (3, 4, 1), (10, NULL, 2), (11, NULL, 2), (11, 1, 2), (13, 5, 3);
+ALTER TABLE sample_table DROP COLUMN c;
+ALTER TABLE sample_table SET (
+    timescaledb.compress,
+    timescaledb.compress_segmentby = 'device_id, d');
+-- compress all chunks
+SELECT compress_chunk(show_chunks('sample_table'));
+              compress_chunk              
+------------------------------------------
+ _timescaledb_internal._hyper_15_31_chunk
+ _timescaledb_internal._hyper_15_32_chunk
+(2 rows)
+
+ALTER TABLE sample_table ADD COLUMN c int default 23;
+-- check chunk compression status
+SELECT chunk_status,
+       chunk_name as "CHUNK_NAME"
+FROM compressed_chunk_info_view
+WHERE hypertable_name = 'sample_table' ORDER BY chunk_name;
+ chunk_status |     CHUNK_NAME     
+--------------+--------------------
+            1 | _hyper_15_31_chunk
+            1 | _hyper_15_32_chunk
+(2 rows)
+
+-- get FIRST uncompressed chunk
+SELECT ch1.schema_name|| '.' || ch1.table_name AS "UNCOMPRESS_CHUNK_1"
+FROM _timescaledb_catalog.chunk ch1, _timescaledb_catalog.hypertable ht
+WHERE ch1.hypertable_id = ht.id AND ch1.table_name LIKE '_hyper_%'
+ORDER BY ch1.id LIMIT 1 \gset
+-- get SECOND uncompressed chunk
+SELECT ch1.schema_name|| '.' || ch1.table_name AS "UNCOMPRESS_CHUNK_2"
+FROM _timescaledb_catalog.chunk ch1, _timescaledb_catalog.hypertable ht
+WHERE ch1.hypertable_id = ht.id AND ch1.table_name LIKE '_hyper_%'
+ORDER BY ch1.id DESC LIMIT 1 \gset
+-- get FIRST compressed chunk
+SELECT ch1.schema_name|| '.' || ch1.table_name AS "COMPRESS_CHUNK_1"
+FROM _timescaledb_catalog.chunk ch1, _timescaledb_catalog.hypertable ht
+WHERE ch1.hypertable_id = ht.id AND ch1.table_name LIKE 'compress_%'
+ORDER BY ch1.id LIMIT 1 \gset
+-- get SECOND compressed chunk
+SELECT ch1.schema_name|| '.' || ch1.table_name AS "COMPRESS_CHUNK_2"
+FROM _timescaledb_catalog.chunk ch1, _timescaledb_catalog.hypertable ht
+WHERE ch1.hypertable_id = ht.id AND ch1.table_name LIKE 'compress_%'
+ORDER BY ch1.id DESC LIMIT 1 \gset
+-- ensure segment by column index position in compressed and uncompressed
+-- chunk is different
+SELECT attname, attnum
+FROM pg_attribute
+WHERE attrelid IN (:'COMPRESS_CHUNK_1'::regclass, :'UNCOMPRESS_CHUNK_1'::regclass) AND attname = 'd'
+ORDER BY attnum;
+ attname | attnum 
+---------+--------
+ d       |      6
+ d       |      7
+(2 rows)
+
+SELECT attname, attnum
+FROM pg_attribute
+WHERE attrelid IN (:'COMPRESS_CHUNK_2'::regclass, :'UNCOMPRESS_CHUNK_2'::regclass) AND attname = 'd'
+ORDER BY attnum;
+ attname | attnum 
+---------+--------
+ d       |      6
+ d       |      7
+(2 rows)
+
+-- get total rowcount from compressed chunks
+SELECT COUNT(*) FROM :COMPRESS_CHUNK_1;
+ count 
+-------
+     3
+(1 row)
+
+SELECT COUNT(*) FROM :COMPRESS_CHUNK_2;
+ count 
+-------
+     3
+(1 row)
+
+-- get rowcount from compressed chunks where d = 3
+SELECT COUNT(*) FROM :COMPRESS_CHUNK_1 WHERE d = 3;
+ count 
+-------
+     0
+(1 row)
+
+SELECT COUNT(*) FROM :COMPRESS_CHUNK_2 WHERE d = 3;
+ count 
+-------
+     1
+(1 row)
+
+-- get total count of SEGMENTBY column with d = 3
+SELECT COUNT(*) FROM sample_table WHERE d = 3;
+ count 
+-------
+     1
+(1 row)
+
+-- delete based on SEGMENTBY column
+DELETE FROM sample_table WHERE d = 3;
+-- ensure that not all rows are moved to staging area
+-- should have few compressed rows
+SELECT COUNT(*) FROM :COMPRESS_CHUNK_1;
+ count 
+-------
+     3
+(1 row)
+
+SELECT COUNT(*) FROM :COMPRESS_CHUNK_2;
+ count 
+-------
+     2
+(1 row)
+
+-- get rowcount from compressed chunks where d = 3
+SELECT COUNT(*) FROM :COMPRESS_CHUNK_1 WHERE d = 3;
+ count 
+-------
+     0
+(1 row)
+
+SELECT COUNT(*) FROM :COMPRESS_CHUNK_2 WHERE d = 3;
+ count 
+-------
+     0
+(1 row)
+
+-- check chunk compression status after DELETE
+SELECT chunk_status,
+       chunk_name as "CHUNK_NAME"
+FROM compressed_chunk_info_view
+WHERE hypertable_name = 'sample_table' ORDER BY chunk_name;
+ chunk_status |     CHUNK_NAME     
+--------------+--------------------
+            1 | _hyper_15_31_chunk
+            9 | _hyper_15_32_chunk
+(2 rows)
+
+-- get rowcount from compressed chunks where device_id IS NULL
+SELECT COUNT(*) FROM :COMPRESS_CHUNK_1 WHERE device_id IS NULL;
+ count 
+-------
+     1
+(1 row)
+
+SELECT COUNT(*) FROM :COMPRESS_CHUNK_2 WHERE device_id IS NULL;
+ count 
+-------
+     1
+(1 row)
+
+BEGIN;
+-- report 0 row
+SELECT * FROM sample_table WHERE a = 247;
+ time | device_id | val | a | b | d | e | c 
+------+-----------+-----+---+---+---+---+---
+(0 rows)
+
+-- delete 1 row
+UPDATE sample_table SET a = 247 WHERE device_id IS NULL;
+-- ensure rows are visible
+SELECT * FROM sample_table WHERE a = 247;
+ time | device_id | val |  a  | b  | d | e  | c  
+------+-----------+-----+-----+----+---+----+----
+    2 |           |   8 | 247 | 11 | 1 | 13 | 23
+   11 |           |   8 | 247 | 11 | 2 | 13 | 23
+   10 |           |   8 | 247 | 11 | 2 | 13 | 23
+(3 rows)
+
+ROLLBACK;
+-- report 0 rows
+SELECT COUNT(*) FROM sample_table WHERE a = 247;
+ count 
+-------
+     0
+(1 row)
+
+-- UPDATE based on NULL values in SEGMENTBY column
+UPDATE sample_table SET a = 247 WHERE device_id IS NULL;
+-- report 3 rows
+SELECT COUNT(*) FROM sample_table WHERE a = 247;
+ count 
+-------
+     3
+(1 row)
+
+-- ensure that not all rows are moved to staging area
+-- should have few compressed rows
+SELECT COUNT(*) FROM :COMPRESS_CHUNK_1;
+ count 
+-------
+     2
+(1 row)
+
+SELECT COUNT(*) FROM :COMPRESS_CHUNK_2;
+ count 
+-------
+     1
+(1 row)
+
+-- get rowcount from compressed chunks where device_id IS NULL
+-- should report 0 rows
+SELECT COUNT(*) FROM :COMPRESS_CHUNK_1 WHERE device_id IS NULL;
+ count 
+-------
+     0
+(1 row)
+
+SELECT COUNT(*) FROM :COMPRESS_CHUNK_2 WHERE device_id IS NULL;
+ count 
+-------
+     0
+(1 row)
+
+DROP TABLE sample_table;
+-- test with different physical layout
+CREATE TABLE sample_table(time timestamptz, c1 text, c2 text, c3 text);
+SELECT create_hypertable('sample_table','time');
+NOTICE:  adding not-null constraint to column "time"
+     create_hypertable      
+----------------------------
+ (17,public,sample_table,t)
+(1 row)
+
+INSERT INTO sample_table SELECT '2000-01-01';
+ALTER TABLE sample_table DROP column c3;
+ALTER TABLE sample_table ADD column c4 text;
+INSERT INTO sample_table SELECT '2000-01-01', '1', '2', '3';
+ALTER TABLE sample_table SET (timescaledb.compress,timescaledb.compress_segmentby='c4');
+SELECT compress_chunk(show_chunks('sample_table'));
+              compress_chunk              
+------------------------------------------
+ _timescaledb_internal._hyper_17_35_chunk
+(1 row)
+
+BEGIN;
+-- report 1 row
+SELECT * FROM sample_table WHERE c4 IS NULL;
+             time             | c1 | c2 | c4 
+------------------------------+----+----+----
+ Sat Jan 01 00:00:00 2000 PST |    |    | 
+(1 row)
+
+-- delete 1 row
+DELETE FROM sample_table WHERE c4 IS NULL;
+-- report 0 rows
+SELECT * FROM sample_table WHERE c4 IS NULL;
+ time | c1 | c2 | c4 
+------+----+----+----
+(0 rows)
+
+ROLLBACK;
+-- get FIRST compressed chunk
+SELECT ch1.schema_name|| '.' || ch1.table_name AS "COMPRESS_CHUNK_1"
+FROM _timescaledb_catalog.chunk ch1, _timescaledb_catalog.hypertable ht
+WHERE ch1.hypertable_id = ht.id AND ch1.table_name LIKE 'compress_%'
+ORDER BY ch1.id \gset
+-- report 2 rows
+SELECT COUNT(*) FROM :COMPRESS_CHUNK_1;
+ count 
+-------
+     2
+(1 row)
+
+-- report 1 row
+SELECT COUNT(*) FROM :COMPRESS_CHUNK_1 WHERE c4 IS NULL;
+ count 
+-------
+     1
+(1 row)
+
+-- report 1 row
+SELECT * FROM sample_table WHERE c4 IS NULL;
+             time             | c1 | c2 | c4 
+------------------------------+----+----+----
+ Sat Jan 01 00:00:00 2000 PST |    |    | 
+(1 row)
+
+-- delete 1 row
+DELETE FROM sample_table WHERE c4 IS NULL;
+-- report 0 row
+SELECT * FROM sample_table WHERE c4 IS NULL;
+ time | c1 | c2 | c4 
+------+----+----+----
+(0 rows)
+
+-- report 1 row which ensure that only required row is moved and deleted
+SELECT COUNT(*) FROM :COMPRESS_CHUNK_1;
+ count 
+-------
+     1
+(1 row)
+
+-- report 0 row
+SELECT COUNT(*) FROM :COMPRESS_CHUNK_1 WHERE c4 IS NULL;
+ count 
+-------
+     0
+(1 row)
+
+DROP TABLE sample_table;

--- a/tsl/test/expected/continuous_aggs-12.out
+++ b/tsl/test/expected/continuous_aggs-12.out
@@ -1552,13 +1552,11 @@ SELECT * from search_query_count_3 ORDER BY 1, 2, 3;
 -- more data
 -- ).
 insert into raw_data select '2000-05-01 00:00+0','Q3', 0, 0;
---this one fails now
-\set ON_ERROR_STOP 0
+
 CALL refresh_continuous_aggregate('search_query_count_3', NULL, '2000-06-01 00:00+0'::timestamptz);
-ERROR:  cannot update/delete rows from chunk "_hyper_41_79_chunk" as it is compressed
 CALL refresh_continuous_aggregate('search_query_count_3', '2000-05-01 00:00+0'::timestamptz, '2000-06-01 00:00+0'::timestamptz);
-ERROR:  cannot update/delete rows from chunk "_hyper_41_79_chunk" as it is compressed
-\set ON_ERROR_STOP 1
+NOTICE:  continuous aggregate "search_query_count_3" is already up-to-date
+
 --insert row
 insert into raw_data select '2001-05-10 00:00+0','Q3', 100, 100;
 --this should succeed since it does not refresh any compressed regions in the cagg
@@ -1585,7 +1583,7 @@ WHERE materialization_id = :'MAT_HTID' ORDER BY 1, 2,3;
  materialization_id | lowest_modified_value | greatest_modified_value 
 --------------------+-----------------------+-------------------------
                  41 |  -9223372036854775808 |     -210866803200000001
-                 41 |       946857660000000 |         988675199999999
+                 41 |       959817600000000 |         988675199999999
                  41 |       991353600000000 |     9223372036854775807
 (3 rows)
 

--- a/tsl/test/expected/continuous_aggs-13.out
+++ b/tsl/test/expected/continuous_aggs-13.out
@@ -1552,13 +1552,10 @@ SELECT * from search_query_count_3 ORDER BY 1, 2, 3;
 -- more data
 -- ).
 insert into raw_data select '2000-05-01 00:00+0','Q3', 0, 0;
---this one fails now
-\set ON_ERROR_STOP 0
 CALL refresh_continuous_aggregate('search_query_count_3', NULL, '2000-06-01 00:00+0'::timestamptz);
-ERROR:  cannot update/delete rows from chunk "_hyper_41_79_chunk" as it is compressed
 CALL refresh_continuous_aggregate('search_query_count_3', '2000-05-01 00:00+0'::timestamptz, '2000-06-01 00:00+0'::timestamptz);
-ERROR:  cannot update/delete rows from chunk "_hyper_41_79_chunk" as it is compressed
-\set ON_ERROR_STOP 1
+NOTICE:  continuous aggregate "search_query_count_3" is already up-to-date
+
 --insert row
 insert into raw_data select '2001-05-10 00:00+0','Q3', 100, 100;
 --this should succeed since it does not refresh any compressed regions in the cagg
@@ -1585,7 +1582,7 @@ WHERE materialization_id = :'MAT_HTID' ORDER BY 1, 2,3;
  materialization_id | lowest_modified_value | greatest_modified_value 
 --------------------+-----------------------+-------------------------
                  41 |  -9223372036854775808 |     -210866803200000001
-                 41 |       946857660000000 |         988675199999999
+                 41 |       959817600000000 |         988675199999999
                  41 |       991353600000000 |     9223372036854775807
 (3 rows)
 

--- a/tsl/test/expected/continuous_aggs-14.out
+++ b/tsl/test/expected/continuous_aggs-14.out
@@ -1552,13 +1552,10 @@ SELECT * from search_query_count_3 ORDER BY 1, 2, 3;
 -- more data
 -- ).
 insert into raw_data select '2000-05-01 00:00+0','Q3', 0, 0;
---this one fails now
-\set ON_ERROR_STOP 0
 CALL refresh_continuous_aggregate('search_query_count_3', NULL, '2000-06-01 00:00+0'::timestamptz);
-ERROR:  cannot update/delete rows from chunk "_hyper_41_79_chunk" as it is compressed
 CALL refresh_continuous_aggregate('search_query_count_3', '2000-05-01 00:00+0'::timestamptz, '2000-06-01 00:00+0'::timestamptz);
-ERROR:  cannot update/delete rows from chunk "_hyper_41_79_chunk" as it is compressed
-\set ON_ERROR_STOP 1
+NOTICE:  continuous aggregate "search_query_count_3" is already up-to-date
+
 --insert row
 insert into raw_data select '2001-05-10 00:00+0','Q3', 100, 100;
 --this should succeed since it does not refresh any compressed regions in the cagg
@@ -1585,7 +1582,7 @@ WHERE materialization_id = :'MAT_HTID' ORDER BY 1, 2,3;
  materialization_id | lowest_modified_value | greatest_modified_value 
 --------------------+-----------------------+-------------------------
                  41 |  -9223372036854775808 |     -210866803200000001
-                 41 |       946857660000000 |         988675199999999
+                 41 |       959817600000000 |         988675199999999
                  41 |       991353600000000 |     9223372036854775807
 (3 rows)
 

--- a/tsl/test/expected/continuous_aggs-15.out
+++ b/tsl/test/expected/continuous_aggs-15.out
@@ -1552,13 +1552,10 @@ SELECT * from search_query_count_3 ORDER BY 1, 2, 3;
 -- more data
 -- ).
 insert into raw_data select '2000-05-01 00:00+0','Q3', 0, 0;
---this one fails now
-\set ON_ERROR_STOP 0
 CALL refresh_continuous_aggregate('search_query_count_3', NULL, '2000-06-01 00:00+0'::timestamptz);
-ERROR:  cannot update/delete rows from chunk "_hyper_41_79_chunk" as it is compressed
 CALL refresh_continuous_aggregate('search_query_count_3', '2000-05-01 00:00+0'::timestamptz, '2000-06-01 00:00+0'::timestamptz);
-ERROR:  cannot update/delete rows from chunk "_hyper_41_79_chunk" as it is compressed
-\set ON_ERROR_STOP 1
+NOTICE:  continuous aggregate "search_query_count_3" is already up-to-date
+
 --insert row
 insert into raw_data select '2001-05-10 00:00+0','Q3', 100, 100;
 --this should succeed since it does not refresh any compressed regions in the cagg
@@ -1585,7 +1582,7 @@ WHERE materialization_id = :'MAT_HTID' ORDER BY 1, 2,3;
  materialization_id | lowest_modified_value | greatest_modified_value 
 --------------------+-----------------------+-------------------------
                  41 |  -9223372036854775808 |     -210866803200000001
-                 41 |       946857660000000 |         988675199999999
+                 41 |       959817600000000 |         988675199999999
                  41 |       991353600000000 |     9223372036854775807
 (3 rows)
 

--- a/tsl/test/expected/continuous_aggs_deprecated.out
+++ b/tsl/test/expected/continuous_aggs_deprecated.out
@@ -1590,9 +1590,8 @@ insert into raw_data select '2000-05-01 00:00+0','Q3', 0, 0;
 --this one fails now
 \set ON_ERROR_STOP 0
 CALL refresh_continuous_aggregate('search_query_count_3', NULL, '2000-06-01 00:00+0'::timestamptz);
-ERROR:  cannot update/delete rows from chunk "_hyper_41_81_chunk" as it is compressed
 CALL refresh_continuous_aggregate('search_query_count_3', '2000-05-01 00:00+0'::timestamptz, '2000-06-01 00:00+0'::timestamptz);
-ERROR:  cannot update/delete rows from chunk "_hyper_41_81_chunk" as it is compressed
+NOTICE:  continuous aggregate "search_query_count_3" is already up-to-date
 \set ON_ERROR_STOP 1
 --insert row
 insert into raw_data select '2001-05-10 00:00+0','Q3', 100, 100;
@@ -1620,7 +1619,7 @@ WHERE materialization_id = :'MAT_HTID' ORDER BY 1, 2,3;
  materialization_id | lowest_modified_value | greatest_modified_value 
 --------------------+-----------------------+-------------------------
                  41 |  -9223372036854775808 |     -210866803200000001
-                 41 |       946857660000000 |         988675199999999
+                 41 |       959817600000000 |         988675199999999
                  41 |       991353600000000 |     9223372036854775807
 (3 rows)
 
@@ -1640,13 +1639,10 @@ ERROR:  cannot change configuration on already compressed chunks
 SELECT decompress_chunk(schema_name || '.' || table_name)
 FROM _timescaledb_catalog.chunk
 WHERE hypertable_id = :'MAT_HTID' and status = 1;
-             decompress_chunk             
-------------------------------------------
- _timescaledb_internal._hyper_41_81_chunk
-(1 row)
+ decompress_chunk 
+------------------
+(0 rows)
 
---disable compression on cagg after decompressing all chunks--
-ALTER MATERIALIZED VIEW search_query_count_3 SET (timescaledb.compress = 'false');
 SELECT cagg_name, mat_table_name
 FROM cagg_compression_status where cagg_name = 'search_query_count_3';
       cagg_name       |       mat_table_name        
@@ -1659,7 +1655,7 @@ FROM timescaledb_information.continuous_aggregates
 where view_name = 'search_query_count_3';
       view_name       | materialized_only | compression_enabled 
 ----------------------+-------------------+---------------------
- search_query_count_3 | f                 | f
+ search_query_count_3 | f                 | t
 (1 row)
 
 -- TEST caggs on table with more columns than in the cagg view defn --

--- a/tsl/test/isolation/expected/compression_dml_iso.out
+++ b/tsl/test/isolation/expected/compression_dml_iso.out
@@ -1,0 +1,62 @@
+unused step name: IN1
+unused step name: INc
+unused step name: S1
+unused step name: SA
+unused step name: SC1
+unused step name: SChunkStat
+Parsed test spec with 7 sessions
+
+starting permutation: CA1 CAc SH I1 Ic SH UPD1 UPDc SH DEL1 DELc SH UPD1 UPDc SH
+step CA1: 
+  BEGIN;
+  SELECT
+    CASE WHEN compress_chunk(ch) IS NOT NULL THEN true ELSE false END AS compress
+  FROM show_chunks('ts_device_table') AS ch
+  ORDER BY ch::text;
+
+compress
+--------
+t       
+t       
+t       
+(3 rows)
+
+step CAc: COMMIT;
+step SH: SELECT total_chunks, number_compressed_chunks from hypertable_compression_stats('ts_device_table');
+total_chunks|number_compressed_chunks
+------------+------------------------
+           3|                       3
+(1 row)
+
+step I1: BEGIN; INSERT INTO ts_device_table VALUES (1, 1, 100, 100);
+step Ic: COMMIT;
+step SH: SELECT total_chunks, number_compressed_chunks from hypertable_compression_stats('ts_device_table');
+total_chunks|number_compressed_chunks
+------------+------------------------
+           3|                       3
+(1 row)
+
+step UPD1: BEGIN; UPDATE ts_device_table SET value = 4 WHERE location = 200;
+step UPDc: COMMIT;
+step SH: SELECT total_chunks, number_compressed_chunks from hypertable_compression_stats('ts_device_table');
+total_chunks|number_compressed_chunks
+------------+------------------------
+           3|                       3
+(1 row)
+
+step DEL1: BEGIN; DELETE from ts_device_table WHERE location = 200;
+step DELc: COMMIT;
+step SH: SELECT total_chunks, number_compressed_chunks from hypertable_compression_stats('ts_device_table');
+total_chunks|number_compressed_chunks
+------------+------------------------
+           3|                       3
+(1 row)
+
+step UPD1: BEGIN; UPDATE ts_device_table SET value = 4 WHERE location = 200;
+step UPDc: COMMIT;
+step SH: SELECT total_chunks, number_compressed_chunks from hypertable_compression_stats('ts_device_table');
+total_chunks|number_compressed_chunks
+------------+------------------------
+           3|                       3
+(1 row)
+

--- a/tsl/test/isolation/specs/CMakeLists.txt
+++ b/tsl/test/isolation/specs/CMakeLists.txt
@@ -27,7 +27,8 @@ if(PG_VERSION VERSION_GREATER "12.7"
 endif()
 
 if(PG_VERSION VERSION_GREATER_EQUAL "14.0")
-  list(APPEND TEST_TEMPLATES_MODULE_DEBUG freeze_chunk.spec.in)
+  list(APPEND TEST_TEMPLATES_MODULE_DEBUG freeze_chunk.spec.in
+       compression_dml_iso.spec)
 endif()
 
 list(

--- a/tsl/test/isolation/specs/compression_dml_iso.spec
+++ b/tsl/test/isolation/specs/compression_dml_iso.spec
@@ -1,0 +1,66 @@
+# This file and its contents are licensed under the Timescale License.
+# Please see the included NOTICE for copyright information and
+# LICENSE-TIMESCALE for a copy of the license.
+
+setup
+{
+    CREATE TABLE ts_device_table(time INTEGER, device INTEGER, location INTEGER, value INTEGER);
+    SELECT create_hypertable('ts_device_table', 'time', chunk_time_interval => 10);
+    INSERT INTO ts_device_table SELECT generate_series(0,29,1), 1, 100, 20;
+    ALTER TABLE ts_device_table set(timescaledb.compress, timescaledb.compress_segmentby='location', timescaledb.compress_orderby='time');
+    CREATE FUNCTION lock_chunktable( name text) RETURNS void AS $$
+    BEGIN EXECUTE format( 'lock table %s IN SHARE MODE', name);
+    END; $$ LANGUAGE plpgsql;
+    CREATE FUNCTION count_chunktable(tbl regclass) RETURNS TABLE("count(*)" int, "count(*) only" int) AS $$
+    DECLARE c int;c_only int;
+    BEGIN
+      EXECUTE format('SELECT count(*) FROM %s', tbl) INTO c;
+      EXECUTE format('SELECT count(*) FROM ONLY %s', tbl) INTO c_only;
+      RETURN QUERY SELECT c,c_only;
+    END; $$ LANGUAGE plpgsql;
+}
+teardown
+{
+   DROP TABLE ts_device_table cascade;
+   DROP FUNCTION lock_chunktable;
+   DROP FUNCTION count_chunktable;
+}
+
+session "I"
+step "I1"   { BEGIN; INSERT INTO ts_device_table VALUES (1, 1, 100, 100); }
+step "Ic"   { COMMIT; }
+
+session "IN"
+step "IN1"   { BEGIN; INSERT INTO ts_device_table VALUES (1, 1, 200, 100); }
+step "INc"   { COMMIT; }
+
+session "DEL"
+step "DEL1"   { BEGIN; DELETE from ts_device_table WHERE location = 200; }
+step "DELc"   { COMMIT; }
+
+session "UPD"
+step "UPD1"   { BEGIN; UPDATE ts_device_table SET value = 4 WHERE location = 200; }
+step "UPDc"   { COMMIT; }
+
+session "SI"
+step "SChunkStat" {  SELECT status from _timescaledb_catalog.chunk
+       WHERE id = ( select min(ch.id) FROM _timescaledb_catalog.hypertable ht, _timescaledb_catalog.chunk ch WHERE ch.hypertable_id = ht.id AND ht.table_name like 'ts_device_table'); }
+
+session "S"
+step "S1" { SELECT count(*) from ts_device_table; }
+step "SC1" { SELECT (count_chunktable(ch)).* FROM show_chunks('ts_device_table') AS ch ORDER BY ch::text LIMIT 1; }
+step "SH" { SELECT total_chunks, number_compressed_chunks from hypertable_compression_stats('ts_device_table'); }
+step "SA" { SELECT * FROM ts_device_table; }
+
+session "CompressAll"
+step "CA1" {
+  BEGIN;
+  SELECT
+    CASE WHEN compress_chunk(ch) IS NOT NULL THEN true ELSE false END AS compress
+  FROM show_chunks('ts_device_table') AS ch
+  ORDER BY ch::text;
+}
+step "CAc" { COMMIT; }
+
+# Test concurrent update/delete operations
+permutation "CA1" "CAc" "SH" "I1" "Ic" "SH" "UPD1" "UPDc" "SH" "DEL1" "DELc" "SH" "UPD1" "UPDc" "SH"

--- a/tsl/test/sql/CMakeLists.txt
+++ b/tsl/test/sql/CMakeLists.txt
@@ -14,7 +14,6 @@ set(TEST_FILES
     compressed_collation.sql
     compression_bgw.sql
     compression_conflicts.sql
-    compression_permissions.sql
     compression_qualpushdown.sql
     dist_param.sql
     dist_views.sql
@@ -49,7 +48,6 @@ if(CMAKE_BUILD_TYPE MATCHES Debug)
     compression_merge.sql
     compression_indexscan.sql
     compression_segment_meta.sql
-    compression.sql
     compress_table.sql
     cagg_bgw_drop_chunks.sql
     cagg_bgw.sql
@@ -66,7 +64,6 @@ if(CMAKE_BUILD_TYPE MATCHES Debug)
     cagg_on_cagg_dist_ht.sql
     cagg_on_cagg_joins.sql
     cagg_on_cagg_joins_dist_ht.sql
-    continuous_aggs_deprecated.sql
     cagg_tableam.sql
     cagg_usage.sql
     cagg_policy_run.sql
@@ -108,7 +105,11 @@ endif(CMAKE_BUILD_TYPE MATCHES Debug)
 if((${PG_VERSION_MAJOR} GREATER_EQUAL "14"))
   if(CMAKE_BUILD_TYPE MATCHES Debug)
     list(APPEND TEST_FILES chunk_utils_internal.sql)
+    list(APPEND TEST_TEMPLATES continuous_aggs.sql.in
+         continuous_aggs_deprecated.sql)
   endif()
+  list(APPEND TEST_FILES compression.sql compression_update_delete.sql
+       compression_permissions.sql)
 endif()
 
 set(SOLO_TESTS
@@ -166,7 +167,6 @@ if(CMAKE_BUILD_TYPE MATCHES Debug)
     dist_partial_agg.sql.in
     dist_query.sql.in
     cagg_invalidation_dist_ht.sql.in
-    continuous_aggs.sql.in
     cagg_joins.sql.in)
   if(USE_TELEMETRY)
     list(APPEND TEST_TEMPLATES telemetry_stats.sql.in)

--- a/tsl/test/sql/compression.sql
+++ b/tsl/test/sql/compression.sql
@@ -507,8 +507,7 @@ DELETE FROM uncompressed_ht
 WHERE series_id IN (SELECT series_id FROM compressed);
 ROLLBACK;
 
-\set ON_ERROR_STOP 0
--- test delete inside CTE is blocked
+-- test delete inside CTE
 WITH compressed AS (
   DELETE FROM compressed_ht RETURNING series_id
 )
@@ -521,8 +520,6 @@ WITH compressed AS (
 )
 SELECT * FROM uncompressed_ht
 WHERE series_id IN (SELECT series_id FROM compressed);
-
-\set ON_ERROR_STOP 1
 
 DROP TABLE compressed_ht;
 DROP TABLE uncompressed_ht;

--- a/tsl/test/sql/compression_update_delete.sql
+++ b/tsl/test/sql/compression_update_delete.sql
@@ -1,0 +1,733 @@
+-- This file and its contents are licensed under the Timescale License.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-TIMESCALE for a copy of the license.
+
+CREATE OR REPLACE VIEW compressed_chunk_info_view AS
+SELECT
+   h.schema_name AS hypertable_schema,
+   h.table_name AS hypertable_name,
+   c.schema_name as chunk_schema,
+   c.table_name as chunk_name,
+   c.status as chunk_status,
+   comp.schema_name as compressed_chunk_schema,
+   comp.table_name as compressed_chunk_name
+FROM
+   _timescaledb_catalog.hypertable h JOIN
+  _timescaledb_catalog.chunk c ON h.id = c.hypertable_id
+   LEFT JOIN _timescaledb_catalog.chunk comp
+ON comp.id = c.compressed_chunk_id
+;
+
+CREATE TABLE sample_table (
+       time TIMESTAMP WITH TIME ZONE NOT NULL,
+       sensor_id INTEGER NOT NULL,
+       cpu double precision null,
+       temperature double precision null,
+       name varchar(100) default 'this is a default string value'
+);
+
+SELECT * FROM create_hypertable('sample_table', 'time',
+       chunk_time_interval => INTERVAL '2 months');
+
+SELECT '2022-01-28 01:09:53.583252+05:30' as start_date \gset
+INSERT INTO sample_table
+    SELECT
+       	time + (INTERVAL '1 minute' * random()) AS time,
+       		sensor_id,
+       		random() AS cpu,
+       		random()* 100 AS temperature
+       	FROM
+       		generate_series(:'start_date'::timestamptz - INTERVAL '1 months',
+                            :'start_date'::timestamptz - INTERVAL '1 week',
+                            INTERVAL '1 hour') AS g1(time),
+       		generate_series(1, 8, 1 ) AS g2(sensor_id)
+       	ORDER BY
+       		time;
+
+SELECT '2023-03-17 17:51:11.322998+05:30' as start_date \gset
+-- insert into new chunks
+INSERT INTO sample_table VALUES (:'start_date'::timestamptz, 12, 21.98, 33.123, 'new row1');
+INSERT INTO sample_table VALUES (:'start_date'::timestamptz, 12, 17.66, 13.875, 'new row1');
+INSERT INTO sample_table VALUES (:'start_date'::timestamptz, 13, 21.98, 33.123, 'new row2');
+INSERT INTO sample_table VALUES (:'start_date'::timestamptz, 1, 21.98, 33.123, 'new row2');
+INSERT INTO sample_table VALUES (:'start_date'::timestamptz, 4, 21.98, 33.123, 'new row2');
+INSERT INTO sample_table VALUES (:'start_date'::timestamptz, 5, 0.988, 33.123, 'new row3');
+INSERT INTO sample_table VALUES (:'start_date'::timestamptz, 6, 4.6554, 47, 'new row3');
+
+-- enable compression
+ALTER TABLE sample_table SET (
+	timescaledb.compress,
+	timescaledb.compress_segmentby = 'sensor_id'
+);
+
+-- compress all chunks
+SELECT compress_chunk(show_chunks('sample_table'));
+
+-- check chunk compression status
+SELECT chunk_status,
+       chunk_name as "CHUNK_NAME"
+FROM compressed_chunk_info_view
+WHERE hypertable_name = 'sample_table' ORDER BY chunk_name;
+
+-- test rows visibility
+BEGIN;
+-- report 0 rows
+SELECT count(*) FROM sample_table WHERE name = 'updated row';
+-- update 4 rows
+UPDATE sample_table SET name = 'updated row' WHERE cpu = 21.98 AND temperature = 33.123;
+-- report 0 rows
+SELECT count(*) FROM sample_table WHERE name = 'updated row';
+ROLLBACK;
+
+-- get count of affected rows
+SELECT count(*) FROM sample_table WHERE cpu = 21.98 AND temperature = 33.123;
+-- do update
+UPDATE sample_table SET name = 'updated row' WHERE cpu = 21.98 AND temperature = 33.123;
+-- get count of updated rows
+SELECT count(*) FROM sample_table WHERE name = 'updated row';
+
+-- check chunk compression status
+SELECT chunk_status,
+       chunk_name as "CHUNK_NAME"
+FROM compressed_chunk_info_view
+WHERE hypertable_name = 'sample_table' ORDER BY chunk_name;
+
+-- recompress the paritial chunks
+CALL recompress_chunk('_timescaledb_internal._hyper_1_1_chunk');
+CALL recompress_chunk('_timescaledb_internal._hyper_1_2_chunk');
+
+-- check chunk compression status
+SELECT chunk_status,
+       chunk_name as "CHUNK_NAME"
+FROM compressed_chunk_info_view
+WHERE hypertable_name = 'sample_table' ORDER BY chunk_name;
+
+-- get count of affected rows
+SELECT count(*) FROM sample_table WHERE name = 'updated row';
+-- do delete
+DELETE FROM sample_table WHERE name = 'updated row';
+-- get count of updated rows
+SELECT count(*) FROM sample_table WHERE name = 'updated row';
+
+-- check chunk compression status
+SELECT chunk_status,
+       chunk_name as "CHUNK_NAME"
+FROM compressed_chunk_info_view
+WHERE hypertable_name = 'sample_table' ORDER BY chunk_name;
+
+-- recompress the paritial chunks
+CALL recompress_chunk('_timescaledb_internal._hyper_1_1_chunk');
+CALL recompress_chunk('_timescaledb_internal._hyper_1_2_chunk');
+
+-- test for IS NULL checks
+-- should not UPDATE any rows
+UPDATE sample_table SET temperature = 34.21 WHERE sensor_id IS NULL;
+
+-- check chunk compression status
+SELECT chunk_status,
+       chunk_name as "CHUNK_NAME"
+FROM compressed_chunk_info_view
+WHERE hypertable_name = 'sample_table' ORDER BY chunk_name;
+
+-- test for IS NOT NULL checks
+-- should UPDATE all rows
+UPDATE sample_table SET temperature = 34.21 WHERE sensor_id IS NOT NULL;
+
+-- check chunk compression status
+SELECT chunk_status,
+       chunk_name as "CHUNK_NAME"
+FROM compressed_chunk_info_view
+WHERE hypertable_name = 'sample_table' ORDER BY chunk_name;
+
+-- recompress the paritial chunks
+CALL recompress_chunk('_timescaledb_internal._hyper_1_1_chunk');
+CALL recompress_chunk('_timescaledb_internal._hyper_1_2_chunk');
+
+-- check chunk compression status
+SELECT chunk_status,
+       chunk_name as "CHUNK_NAME"
+FROM compressed_chunk_info_view
+WHERE hypertable_name = 'sample_table' ORDER BY chunk_name;
+
+-- report 0 rows
+SELECT COUNT(*) FROM sample_table WHERE name = 'updated row based on < OR > comparison';
+-- get total count of rows which satifies the condition
+SELECT COUNT(*) as "total_affected_rows" FROM sample_table WHERE
+  time > '2022-01-20 19:10:00.101514+05:30' and
+  time < '2022-01-20 21:10:43.855297+05:30' \gset
+
+-- perform UPDATE with < and > comparison on SEGMENTBY column
+UPDATE sample_table SET name = 'updated row based on < OR > comparison' WHERE
+  time > '2022-01-20 19:10:00.101514+05:30' and time < '2022-01-20 21:10:43.855297+05:30';
+
+-- check chunk compression status after UPDATE
+SELECT chunk_status,
+       chunk_name as "CHUNK_NAME"
+FROM compressed_chunk_info_view
+WHERE hypertable_name = 'sample_table' ORDER BY chunk_name;
+
+-- count should be same
+SELECT COUNT(*) = (:total_affected_rows) FROM sample_table WHERE name = 'updated row based on < OR > comparison';
+
+DROP TABLE sample_table;
+
+-- test to ensure that only required rows from compressed chunks
+-- are extracted if SEGMENTBY column is used in WHERE condition
+CREATE TABLE sample_table(
+    time INT NOT NULL,
+    device_id INT,
+    val INT);
+
+SELECT * FROM create_hypertable('sample_table', 'time', chunk_time_interval => 10);
+
+ALTER TABLE sample_table SET (
+    timescaledb.compress,
+    timescaledb.compress_orderby = 'time',
+    timescaledb.compress_segmentby = 'device_id');
+
+INSERT INTO sample_table VALUES (1, 1, 1), (2, 2, 1), (3, 3, 1), (10, 3, 2), (11, 4, 2), (11, 1, 2);
+
+-- compress all chunks
+SELECT compress_chunk(show_chunks('sample_table'));
+
+-- get FIRST compressed chunk
+SELECT ch1.schema_name|| '.' || ch1.table_name AS "COMPRESS_CHUNK_1"
+FROM _timescaledb_catalog.chunk ch1, _timescaledb_catalog.hypertable ht
+WHERE ch1.hypertable_id = ht.id AND ch1.table_name LIKE 'compress_%'
+ORDER BY ch1.id LIMIT 1 \gset
+
+-- get SECOND compressed chunk
+SELECT ch1.schema_name|| '.' || ch1.table_name AS "COMPRESS_CHUNK_2"
+FROM _timescaledb_catalog.chunk ch1, _timescaledb_catalog.hypertable ht
+WHERE ch1.hypertable_id = ht.id AND ch1.table_name LIKE 'compress_%'
+ORDER BY ch1.id DESC LIMIT 1 \gset
+
+-- there should 2 rows matching the conditions coming from 2 chunks
+SELECT * FROM sample_table WHERE  device_id = 3 ORDER BY time, device_id;
+
+-- get total rowcount from compressed chunks
+SELECT COUNT(*) FROM :COMPRESS_CHUNK_1;
+SELECT COUNT(*) FROM :COMPRESS_CHUNK_2;
+
+-- get rowcount from compressed chunks where device_id = 3
+SELECT COUNT(*) FROM :COMPRESS_CHUNK_1 WHERE device_id = 3;
+SELECT COUNT(*) FROM :COMPRESS_CHUNK_2 WHERE device_id = 3;
+
+-- delete rows with device_id = 3
+DELETE FROM sample_table WHERE device_id = 3;
+
+-- get total rowcount from compressed chunks
+SELECT COUNT(*) FROM :COMPRESS_CHUNK_1;
+SELECT COUNT(*) FROM :COMPRESS_CHUNK_2;
+
+-- get rowcount from compressed chunks where device_id = 3
+SELECT COUNT(*) FROM :COMPRESS_CHUNK_1 WHERE device_id = 3;
+SELECT COUNT(*) FROM :COMPRESS_CHUNK_2 WHERE device_id = 3;
+
+-- there should be no rows
+SELECT * FROM sample_table WHERE  device_id = 3 ORDER BY time, device_id;
+
+-- there should 2 rows matching the conditions coming from 2 chunks
+SELECT val FROM sample_table WHERE  1 = device_id ORDER BY time, device_id;
+
+-- get total rowcount from compressed chunks
+SELECT COUNT(*) FROM :COMPRESS_CHUNK_1;
+SELECT COUNT(*) FROM :COMPRESS_CHUNK_2;
+
+-- get rowcount from compressed chunks where device_id = 1
+SELECT COUNT(*) FROM :COMPRESS_CHUNK_1 WHERE 1 = device_id;
+SELECT COUNT(*) FROM :COMPRESS_CHUNK_2 WHERE 1 = device_id;
+
+-- update rows with device_id = 1
+UPDATE sample_table SET val = 200 WHERE 1 = device_id;
+
+-- get total rowcount from compressed chunks
+SELECT COUNT(*) FROM :COMPRESS_CHUNK_1;
+SELECT COUNT(*) FROM :COMPRESS_CHUNK_2;
+
+-- get rowcount from compressed chunks where device_id = 1
+SELECT COUNT(*) FROM :COMPRESS_CHUNK_1 WHERE 1 = device_id;
+SELECT COUNT(*) FROM :COMPRESS_CHUNK_2 WHERE 1 = device_id;
+
+-- there should be 2 rows
+SELECT val FROM sample_table WHERE  1 = device_id ORDER BY time, device_id;
+
+DROP TABLE sample_table;
+
+CREATE TABLE sample_table(
+    time INT NOT NULL,
+    device_id INT,
+    val INT);
+
+SELECT * FROM create_hypertable('sample_table', 'time', chunk_time_interval => 10);
+
+ALTER TABLE sample_table SET (
+    timescaledb.compress,
+    timescaledb.compress_segmentby = 'time, val');
+
+INSERT INTO sample_table VALUES (1, 1, 1), (2, 2, 1), (3, 3, 1), (1, 3, 2), (11, 4, 2), (1, 1, 2);
+
+-- compress all chunks
+SELECT compress_chunk(show_chunks('sample_table'));
+
+-- get FIRST compressed chunk
+SELECT ch1.schema_name|| '.' || ch1.table_name AS "COMPRESS_CHUNK_1"
+FROM _timescaledb_catalog.chunk ch1, _timescaledb_catalog.hypertable ht
+WHERE ch1.hypertable_id = ht.id AND ch1.table_name LIKE 'compress_%'
+ORDER BY ch1.id LIMIT 1 \gset
+
+-- get SECOND compressed chunk
+SELECT ch1.schema_name|| '.' || ch1.table_name AS "COMPRESS_CHUNK_2"
+FROM _timescaledb_catalog.chunk ch1, _timescaledb_catalog.hypertable ht
+WHERE ch1.hypertable_id = ht.id AND ch1.table_name LIKE 'compress_%'
+ORDER BY ch1.id DESC LIMIT 1 \gset
+
+-- there should 2 rows matching the conditions coming from 2 chunks
+SELECT * FROM sample_table WHERE time = 1 AND val = 2 ORDER BY time, device_id;
+
+-- get total rowcount from compressed chunks
+SELECT COUNT(*) FROM :COMPRESS_CHUNK_1;
+SELECT COUNT(*) FROM :COMPRESS_CHUNK_2;
+
+-- get rowcount from compressed chunks where time = 1 AND val = 2
+SELECT COUNT(*) FROM :COMPRESS_CHUNK_1 WHERE time = 1 AND val = 2;
+SELECT COUNT(*) FROM :COMPRESS_CHUNK_2 WHERE time = 1 AND val = 2;
+
+-- delete rows with time = 1 AND val = 2
+EXPLAIN (costs off, verbose) DELETE FROM sample_table WHERE time = 1 AND 2 = val;
+-- should delete rows from 1 of the compressed chunks
+DELETE FROM sample_table WHERE time = 1 AND 2 = val;
+
+-- get total rowcount from compressed chunks
+SELECT COUNT(*) FROM :COMPRESS_CHUNK_1;
+SELECT COUNT(*) FROM :COMPRESS_CHUNK_2;
+
+-- get rowcount from compressed chunks wheretime = 1 AND val = 2
+SELECT COUNT(*) FROM :COMPRESS_CHUNK_1 WHERE time = 1 AND val = 2;
+SELECT COUNT(*) FROM :COMPRESS_CHUNK_2 WHERE time = 1 AND val = 2;
+
+-- there should be no rows
+SELECT * FROM sample_table WHERE time = 1 AND val = 2 ORDER BY time, device_id;
+DROP TABLE sample_table;
+
+-- Test chunk compile time startup exclusion
+CREATE OR REPLACE FUNCTION now_s()
+RETURNS timestamptz LANGUAGE PLPGSQL STABLE AS
+$BODY$
+BEGIN
+    RETURN '2017-08-22T10:00:00'::timestamptz;
+END;
+$BODY$;
+
+CREATE TABLE sample_table(time timestamptz NOT NULL, temp float, colorid integer, attr jsonb);
+SELECT create_hypertable('sample_table', 'time', chunk_time_interval => 2628000000000);
+
+-- create three chunks
+INSERT INTO sample_table VALUES ('2017-03-22T09:18:22', 23.5, 1, '{"a": 1, "b": 2}'),
+                                ('2017-03-22T09:18:23', 21.5, 1, '{"a": 1, "b": 2}'),
+                                ('2017-05-22T09:18:22', 36.2, 2, '{"c": 3, "b": 2}'),
+                                ('2017-05-22T09:18:23', 15.2, 2, '{"c": 3}'),
+                                ('2017-08-22T09:18:22', 34.1, 3, '{"c": 4}');
+
+ALTER TABLE sample_table SET (timescaledb.compress,
+                              timescaledb.compress_segmentby = 'time');
+
+SELECT compress_chunk(show_chunks('sample_table'));
+-- ensure all chunks are compressed
+SELECT chunk_status,
+       chunk_name as "CHUNK_NAME"
+FROM compressed_chunk_info_view
+WHERE hypertable_name = 'sample_table' ORDER BY chunk_name;
+
+-- report 0 rows
+SELECT * FROM sample_table WHERE time > now_s() + '-1 month' AND colorid = 4;
+-- update 1 row
+UPDATE sample_table SET colorid = 4 WHERE time > now_s() + '-1 month';
+-- report 1 row
+SELECT * FROM sample_table WHERE time > now_s() + '-1 month' AND colorid = 4;
+
+-- ensure that 1 chunk is partially compressed
+SELECT chunk_status,
+       chunk_name as "CHUNK_NAME"
+FROM compressed_chunk_info_view
+WHERE hypertable_name = 'sample_table' ORDER BY chunk_name;
+
+DROP TABLE sample_table;
+
+-- test for NULL values in SEGMENTBY column
+CREATE TABLE sample_table(
+    time INT,
+    device_id INT,
+    val INT);
+
+SELECT * FROM create_hypertable('sample_table', 'time', chunk_time_interval => 10);
+
+ALTER TABLE sample_table SET (
+    timescaledb.compress,
+    timescaledb.compress_orderby = 'time',
+    timescaledb.compress_segmentby = 'device_id');
+
+INSERT INTO sample_table VALUES (1, 1, 1), (2, NULL, 1), (3, NULL, 1), (10, NULL, 2), (11, NULL, 2), (11, 1, 2);
+
+-- compress all chunks
+SELECT compress_chunk(show_chunks('sample_table'));
+
+-- get FIRST compressed chunk
+SELECT ch1.schema_name|| '.' || ch1.table_name AS "COMPRESS_CHUNK_1"
+FROM _timescaledb_catalog.chunk ch1, _timescaledb_catalog.hypertable ht
+WHERE ch1.hypertable_id = ht.id AND ch1.table_name LIKE 'compress_%'
+ORDER BY ch1.id LIMIT 1 \gset
+
+-- get SECOND compressed chunk
+SELECT ch1.schema_name|| '.' || ch1.table_name AS "COMPRESS_CHUNK_2"
+FROM _timescaledb_catalog.chunk ch1, _timescaledb_catalog.hypertable ht
+WHERE ch1.hypertable_id = ht.id AND ch1.table_name LIKE 'compress_%'
+ORDER BY ch1.id DESC LIMIT 1 \gset
+
+-- get total rowcount from compressed chunks
+SELECT COUNT(*) FROM :COMPRESS_CHUNK_1;
+SELECT COUNT(*) FROM :COMPRESS_CHUNK_2;
+
+-- get rowcount from compressed chunks where device_id IS NULL
+SELECT COUNT(*) FROM :COMPRESS_CHUNK_1 WHERE device_id IS NULL;
+SELECT COUNT(*) FROM :COMPRESS_CHUNK_2 WHERE device_id IS NULL;
+
+-- get total count of SEGMENTBY column with NULL values
+SELECT COUNT(*) FROM sample_table WHERE device_id IS NULL;
+
+-- delete NULL values in SEGMENTBY column
+DELETE FROM sample_table WHERE device_id IS NULL;
+
+-- ensure that not all rows are moved to staging area
+-- should have few compressed rows
+SELECT COUNT(*) FROM :COMPRESS_CHUNK_1;
+SELECT COUNT(*) FROM :COMPRESS_CHUNK_2;
+
+-- get rowcount from compressed chunks where device_id IS NULL
+-- should report 0 rows
+SELECT COUNT(*) FROM :COMPRESS_CHUNK_1 WHERE device_id IS NULL;
+SELECT COUNT(*) FROM :COMPRESS_CHUNK_2 WHERE device_id IS NULL;
+
+-- check chunk compression status after DELETE
+SELECT chunk_status,
+       chunk_name as "CHUNK_NAME"
+FROM compressed_chunk_info_view
+WHERE hypertable_name = 'sample_table' ORDER BY chunk_name;
+
+DROP TABLE sample_table;
+
+-- test for IS NOT NULL values in SEGMENTBY column
+CREATE TABLE sample_table(
+    time INT,
+    device_id INT,
+    val INT);
+
+SELECT * FROM create_hypertable('sample_table', 'time', chunk_time_interval => 10);
+
+ALTER TABLE sample_table SET (
+    timescaledb.compress,
+    timescaledb.compress_orderby = 'time',
+    timescaledb.compress_segmentby = 'device_id');
+
+INSERT INTO sample_table VALUES (1, NULL, 1), (2, NULL, 1), (3, NULL, 1), (10, 3, 2), (11, 2, 2), (11, 1, 2);
+
+-- compress all chunks
+SELECT compress_chunk(show_chunks('sample_table'));
+
+-- get FIRST compressed chunk
+SELECT ch1.schema_name|| '.' || ch1.table_name AS "COMPRESS_CHUNK_1"
+FROM _timescaledb_catalog.chunk ch1, _timescaledb_catalog.hypertable ht
+WHERE ch1.hypertable_id = ht.id AND ch1.table_name LIKE 'compress_%'
+ORDER BY ch1.id LIMIT 1 \gset
+
+-- get SECOND compressed chunk
+SELECT ch1.schema_name|| '.' || ch1.table_name AS "COMPRESS_CHUNK_2"
+FROM _timescaledb_catalog.chunk ch1, _timescaledb_catalog.hypertable ht
+WHERE ch1.hypertable_id = ht.id AND ch1.table_name LIKE 'compress_%'
+ORDER BY ch1.id DESC LIMIT 1 \gset
+
+SELECT COUNT(*) FROM sample_table WHERE val = 1234;
+
+-- UPDATE based on IS NOT NULL condition on SEGMENTBY column
+UPDATE sample_table SET val = 1234 WHERE device_id IS NOT NULL;
+
+-- get total count of SEGMENTBY column with NULL values
+SELECT COUNT(*) FROM sample_table WHERE val = 1234;
+
+-- check chunk compression status after DELETE
+SELECT chunk_status,
+       chunk_name as "CHUNK_NAME"
+FROM compressed_chunk_info_view
+WHERE hypertable_name = 'sample_table' ORDER BY chunk_name;
+
+DROP TABLE sample_table;
+
+-- test to for <= AND >= on SEGMENTBY column
+CREATE TABLE sample_table(
+    time INT,
+    device_id INT,
+    val INT);
+
+SELECT * FROM create_hypertable('sample_table', 'time', chunk_time_interval => 10);
+
+ALTER TABLE sample_table SET (
+    timescaledb.compress,
+    timescaledb.compress_orderby = 'time',
+    timescaledb.compress_segmentby = 'device_id, val');
+
+INSERT INTO sample_table VALUES (1, 1, 1), (2, NULL, 1), (3, 4, 1), (10, NULL, 2), (11, NULL, 2), (11, 1, 2), (13, 5, 3);
+INSERT INTO sample_table VALUES (4, 3, NULL), (6, NULL, NULL), (12, NULL, NULL), (13, 4, NULL);
+-- compress all chunks
+SELECT compress_chunk(show_chunks('sample_table'));
+
+-- test will multiple NULL/NOT NULL columns
+BEGIN;
+-- report 0 row
+SELECT * FROM sample_table WHERE device_id IS NULL AND val = 987;
+-- these 3 rows will be affected by below UPDATE
+SELECT * FROM sample_table WHERE device_id IS NULL AND val IS NOT NULL ORDER BY 1;
+-- update 3 rows
+UPDATE sample_table SET val = 987 WHERE device_id IS NULL AND val IS NOT NULL;
+-- report 3 row
+SELECT * FROM sample_table WHERE device_id IS NULL AND val = 987;
+ROLLBACK;
+
+-- test will multiple columns
+BEGIN;
+-- report 2 rows
+SELECT * FROM sample_table WHERE device_id IS NULL AND val = 2;
+-- delete 2 rows
+DELETE from sample_table WHERE device_id IS NULL AND val = 2;
+-- report 0 rows
+SELECT * FROM sample_table WHERE device_id IS NULL AND val = 2;
+ROLLBACK;
+
+BEGIN;
+-- report 1 row
+SELECT * FROM sample_table WHERE device_id = 3 AND val IS NULL;
+-- delete 1 rows
+DELETE from sample_table WHERE device_id = 3 AND val IS NULL;
+-- report 0 rows
+SELECT * FROM sample_table WHERE device_id = 3 AND val IS NULL;
+ROLLBACK;
+
+-- get FIRST compressed chunk
+SELECT ch1.schema_name|| '.' || ch1.table_name AS "COMPRESS_CHUNK_1"
+FROM _timescaledb_catalog.chunk ch1, _timescaledb_catalog.hypertable ht
+WHERE ch1.hypertable_id = ht.id AND ch1.table_name LIKE 'compress_%'
+ORDER BY ch1.id LIMIT 1 \gset
+
+-- get SECOND compressed chunk
+SELECT ch1.schema_name|| '.' || ch1.table_name AS "COMPRESS_CHUNK_2"
+FROM _timescaledb_catalog.chunk ch1, _timescaledb_catalog.hypertable ht
+WHERE ch1.hypertable_id = ht.id AND ch1.table_name LIKE 'compress_%'
+ORDER BY ch1.id DESC LIMIT 1 \gset
+
+-- get total rowcount from compressed chunks
+SELECT COUNT(*) FROM :COMPRESS_CHUNK_1;
+SELECT COUNT(*) FROM :COMPRESS_CHUNK_2;
+
+-- get rowcount from compressed chunks where device_id >= 4 AND val <= 1
+SELECT COUNT(*) FROM :COMPRESS_CHUNK_1 WHERE device_id >= 4 AND val <= 1;
+SELECT COUNT(*) FROM :COMPRESS_CHUNK_2 WHERE device_id >= 4 AND val <= 1;
+
+-- get total count of SEGMENTBY column with device_id >= 4 AND val <= 1
+SELECT COUNT(*) FROM sample_table WHERE device_id >= 4 AND val <= 1;
+
+-- delete NULL values in SEGMENTBY column
+DELETE FROM sample_table WHERE device_id >= 4 AND val <= 1;
+
+-- ensure that not all rows are moved to staging area
+-- should have few compressed rows
+SELECT COUNT(*) FROM :COMPRESS_CHUNK_1;
+SELECT COUNT(*) FROM :COMPRESS_CHUNK_2;
+
+-- get rowcount from compressed chunks where device_id IS NULL
+-- should report 0 rows
+SELECT COUNT(*) FROM :COMPRESS_CHUNK_1 WHERE device_id >= 4 AND val <= 1;
+SELECT COUNT(*) FROM :COMPRESS_CHUNK_2 WHERE device_id >= 4 AND val <= 1;
+
+-- check chunk compression status after DELETE
+SELECT chunk_status,
+       chunk_name as "CHUNK_NAME"
+FROM compressed_chunk_info_view
+WHERE hypertable_name = 'sample_table' ORDER BY chunk_name;
+
+-- added tests for code coverage
+UPDATE sample_table SET time = 21 WHERE (device_id) in ( 30, 51, 72, 53);
+UPDATE sample_table SET time = 21 WHERE device_id + 365 = 8765;
+
+DROP TABLE sample_table;
+
+-- test with different physical layout
+CREATE TABLE sample_table(
+    time INT,
+    device_id INT,
+    val INT default 8,
+    a INT default 10,
+    b INT default 11,
+    c INT default 12,
+    d INT,
+    e INT default 13);
+
+SELECT * FROM create_hypertable('sample_table', 'time', chunk_time_interval => 5);
+INSERT INTO sample_table (time, device_id, d) VALUES (1, 1, 1), (2, NULL, 1), (3, 4, 1), (10, NULL, 2), (11, NULL, 2), (11, 1, 2), (13, 5, 3);
+
+ALTER TABLE sample_table DROP COLUMN c;
+ALTER TABLE sample_table SET (
+    timescaledb.compress,
+    timescaledb.compress_segmentby = 'device_id, d');
+
+-- compress all chunks
+SELECT compress_chunk(show_chunks('sample_table'));
+
+ALTER TABLE sample_table ADD COLUMN c int default 23;
+
+-- check chunk compression status
+SELECT chunk_status,
+       chunk_name as "CHUNK_NAME"
+FROM compressed_chunk_info_view
+WHERE hypertable_name = 'sample_table' ORDER BY chunk_name;
+
+-- get FIRST uncompressed chunk
+SELECT ch1.schema_name|| '.' || ch1.table_name AS "UNCOMPRESS_CHUNK_1"
+FROM _timescaledb_catalog.chunk ch1, _timescaledb_catalog.hypertable ht
+WHERE ch1.hypertable_id = ht.id AND ch1.table_name LIKE '_hyper_%'
+ORDER BY ch1.id LIMIT 1 \gset
+
+-- get SECOND uncompressed chunk
+SELECT ch1.schema_name|| '.' || ch1.table_name AS "UNCOMPRESS_CHUNK_2"
+FROM _timescaledb_catalog.chunk ch1, _timescaledb_catalog.hypertable ht
+WHERE ch1.hypertable_id = ht.id AND ch1.table_name LIKE '_hyper_%'
+ORDER BY ch1.id DESC LIMIT 1 \gset
+
+-- get FIRST compressed chunk
+SELECT ch1.schema_name|| '.' || ch1.table_name AS "COMPRESS_CHUNK_1"
+FROM _timescaledb_catalog.chunk ch1, _timescaledb_catalog.hypertable ht
+WHERE ch1.hypertable_id = ht.id AND ch1.table_name LIKE 'compress_%'
+ORDER BY ch1.id LIMIT 1 \gset
+
+-- get SECOND compressed chunk
+SELECT ch1.schema_name|| '.' || ch1.table_name AS "COMPRESS_CHUNK_2"
+FROM _timescaledb_catalog.chunk ch1, _timescaledb_catalog.hypertable ht
+WHERE ch1.hypertable_id = ht.id AND ch1.table_name LIKE 'compress_%'
+ORDER BY ch1.id DESC LIMIT 1 \gset
+
+-- ensure segment by column index position in compressed and uncompressed
+-- chunk is different
+SELECT attname, attnum
+FROM pg_attribute
+WHERE attrelid IN (:'COMPRESS_CHUNK_1'::regclass, :'UNCOMPRESS_CHUNK_1'::regclass) AND attname = 'd'
+ORDER BY attnum;
+
+SELECT attname, attnum
+FROM pg_attribute
+WHERE attrelid IN (:'COMPRESS_CHUNK_2'::regclass, :'UNCOMPRESS_CHUNK_2'::regclass) AND attname = 'd'
+ORDER BY attnum;
+
+-- get total rowcount from compressed chunks
+SELECT COUNT(*) FROM :COMPRESS_CHUNK_1;
+SELECT COUNT(*) FROM :COMPRESS_CHUNK_2;
+
+-- get rowcount from compressed chunks where d = 3
+SELECT COUNT(*) FROM :COMPRESS_CHUNK_1 WHERE d = 3;
+SELECT COUNT(*) FROM :COMPRESS_CHUNK_2 WHERE d = 3;
+
+-- get total count of SEGMENTBY column with d = 3
+SELECT COUNT(*) FROM sample_table WHERE d = 3;
+
+-- delete based on SEGMENTBY column
+DELETE FROM sample_table WHERE d = 3;
+
+-- ensure that not all rows are moved to staging area
+-- should have few compressed rows
+SELECT COUNT(*) FROM :COMPRESS_CHUNK_1;
+SELECT COUNT(*) FROM :COMPRESS_CHUNK_2;
+
+-- get rowcount from compressed chunks where d = 3
+SELECT COUNT(*) FROM :COMPRESS_CHUNK_1 WHERE d = 3;
+SELECT COUNT(*) FROM :COMPRESS_CHUNK_2 WHERE d = 3;
+
+-- check chunk compression status after DELETE
+SELECT chunk_status,
+       chunk_name as "CHUNK_NAME"
+FROM compressed_chunk_info_view
+WHERE hypertable_name = 'sample_table' ORDER BY chunk_name;
+
+-- get rowcount from compressed chunks where device_id IS NULL
+SELECT COUNT(*) FROM :COMPRESS_CHUNK_1 WHERE device_id IS NULL;
+SELECT COUNT(*) FROM :COMPRESS_CHUNK_2 WHERE device_id IS NULL;
+
+BEGIN;
+-- report 0 row
+SELECT * FROM sample_table WHERE a = 247;
+-- delete 1 row
+UPDATE sample_table SET a = 247 WHERE device_id IS NULL;
+-- ensure rows are visible
+SELECT * FROM sample_table WHERE a = 247;
+ROLLBACK;
+
+-- report 0 rows
+SELECT COUNT(*) FROM sample_table WHERE a = 247;
+
+-- UPDATE based on NULL values in SEGMENTBY column
+UPDATE sample_table SET a = 247 WHERE device_id IS NULL;
+
+-- report 3 rows
+SELECT COUNT(*) FROM sample_table WHERE a = 247;
+
+-- ensure that not all rows are moved to staging area
+-- should have few compressed rows
+SELECT COUNT(*) FROM :COMPRESS_CHUNK_1;
+SELECT COUNT(*) FROM :COMPRESS_CHUNK_2;
+
+-- get rowcount from compressed chunks where device_id IS NULL
+-- should report 0 rows
+SELECT COUNT(*) FROM :COMPRESS_CHUNK_1 WHERE device_id IS NULL;
+SELECT COUNT(*) FROM :COMPRESS_CHUNK_2 WHERE device_id IS NULL;
+
+DROP TABLE sample_table;
+
+-- test with different physical layout
+CREATE TABLE sample_table(time timestamptz, c1 text, c2 text, c3 text);
+SELECT create_hypertable('sample_table','time');
+INSERT INTO sample_table SELECT '2000-01-01';
+ALTER TABLE sample_table DROP column c3;
+ALTER TABLE sample_table ADD column c4 text;
+INSERT INTO sample_table SELECT '2000-01-01', '1', '2', '3';
+ALTER TABLE sample_table SET (timescaledb.compress,timescaledb.compress_segmentby='c4');
+SELECT compress_chunk(show_chunks('sample_table'));
+
+BEGIN;
+-- report 1 row
+SELECT * FROM sample_table WHERE c4 IS NULL;
+-- delete 1 row
+DELETE FROM sample_table WHERE c4 IS NULL;
+-- report 0 rows
+SELECT * FROM sample_table WHERE c4 IS NULL;
+ROLLBACK;
+
+-- get FIRST compressed chunk
+SELECT ch1.schema_name|| '.' || ch1.table_name AS "COMPRESS_CHUNK_1"
+FROM _timescaledb_catalog.chunk ch1, _timescaledb_catalog.hypertable ht
+WHERE ch1.hypertable_id = ht.id AND ch1.table_name LIKE 'compress_%'
+ORDER BY ch1.id \gset
+
+-- report 2 rows
+SELECT COUNT(*) FROM :COMPRESS_CHUNK_1;
+-- report 1 row
+SELECT COUNT(*) FROM :COMPRESS_CHUNK_1 WHERE c4 IS NULL;
+
+-- report 1 row
+SELECT * FROM sample_table WHERE c4 IS NULL;
+-- delete 1 row
+DELETE FROM sample_table WHERE c4 IS NULL;
+-- report 0 row
+SELECT * FROM sample_table WHERE c4 IS NULL;
+
+-- report 1 row which ensure that only required row is moved and deleted
+SELECT COUNT(*) FROM :COMPRESS_CHUNK_1;
+-- report 0 row
+SELECT COUNT(*) FROM :COMPRESS_CHUNK_1 WHERE c4 IS NULL;
+
+DROP TABLE sample_table;

--- a/tsl/test/sql/continuous_aggs.sql.in
+++ b/tsl/test/sql/continuous_aggs.sql.in
@@ -1124,11 +1124,8 @@ SELECT * from search_query_count_3 ORDER BY 1, 2, 3;
 -- ).
 insert into raw_data select '2000-05-01 00:00+0','Q3', 0, 0;
 
---this one fails now
-\set ON_ERROR_STOP 0
 CALL refresh_continuous_aggregate('search_query_count_3', NULL, '2000-06-01 00:00+0'::timestamptz);
 CALL refresh_continuous_aggregate('search_query_count_3', '2000-05-01 00:00+0'::timestamptz, '2000-06-01 00:00+0'::timestamptz);
-\set ON_ERROR_STOP 1
 
 --insert row
 insert into raw_data select '2001-05-10 00:00+0','Q3', 100, 100;

--- a/tsl/test/sql/continuous_aggs_deprecated.sql
+++ b/tsl/test/sql/continuous_aggs_deprecated.sql
@@ -1164,8 +1164,6 @@ SELECT decompress_chunk(schema_name || '.' || table_name)
 FROM _timescaledb_catalog.chunk
 WHERE hypertable_id = :'MAT_HTID' and status = 1;
 
---disable compression on cagg after decompressing all chunks--
-ALTER MATERIALIZED VIEW search_query_count_3 SET (timescaledb.compress = 'false');
 SELECT cagg_name, mat_table_name
 FROM cagg_compression_status where cagg_name = 'search_query_count_3';
 SELECT view_name, materialized_only, compression_enabled


### PR DESCRIPTION
This patch does following:

1. Executor changes to parse qual ExprState to check if SEGMENTBY
   column is specified in WHERE clause.
2. Based on step 1, we build scan keys.  
3. Executor changes to do heapscan on compressed chunk based on
   scan keys and move only those rows which match the WHERE clause
   to staging are aka uncompressed chunk.
4. Mark affected chunk as partially compressed.
5. Perform regular UPDATE/DELETE operations on staging area aka
   uncompressed chunk.
6. Since there is no Custom Scan (HypertableModify) node for
   UPDATE/DELETE operations on PG versions < 14, we don't support this
   feature on PG12 and PG13.
