### PR TITLE
Added coccinelle rule to find strlcpy on NameData

### DIFF
--- a/coccinelle/namedata.cocci
+++ b/coccinelle/namedata.cocci
@@ -1,0 +1,24 @@
+// NameData is a fixed-size type of 64 bytes. Using strlcpy to copy data into a
+// NameData struct can cause problems because any data that follows the initial
+// null-terminated string will also be part of the data.
+
+@rule_var_decl_struct@
+symbol NAMEDATALEN;
+identifier I1, I2;
+@@
+struct I1
+{
+  ...
+- char I2[NAMEDATALEN];
++ /* You are declaring a char of length NAMEDATALEN, please consider using NameData instead. */
++ NameData I2;
+  ...
+}
+
+@rule_namedata_strlcpy@
+expression E1, E2;
+symbol NAMEDATALEN;
+@@
+- strlcpy(E1, E2, NAMEDATALEN);
++ /* You are using strlcpy with NAMEDATALEN, please consider using NameData and namestrcpy instead. */
++ namestrcpy(E1, E2);

--- a/scripts/coccinelle.sh
+++ b/scripts/coccinelle.sh
@@ -7,7 +7,7 @@ FAILED=false
 true > coccinelle.diff
 
 for f in "${SCRIPT_DIR}"/../coccinelle/*.cocci; do
-	find "${SCRIPT_DIR}"/.. -name '*.c' -exec spatch --very-quiet -sp_file "$f" {} + | tee -a coccinelle.diff
+  spatch --very-quiet --include-headers --sp-file "$f" --dir "${SCRIPT_DIR}"/.. | tee -a coccinelle.diff
   rc=$?
   if [ $rc -ne 0 ]; then
     FAILED=true


### PR DESCRIPTION
NameData is a fixed-size type of 64 bytes. Using strlcpy to copy data into a NameData struct can cause problems because any data that follows the initial null-terminated string will also be part of the data.

Note:
Should be merged after #5336, #5345, and #5317

Disable-check: force-changelog-changed