### PR TITLE
Set PortalContext when starting job

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ Sooner to that time, we will announce the specific version of TimescaleDB in whi
 * #5246 Make connection establishment interruptible
 * #5253 Make data node command execution interruptible
 * #5262 Extend enabling compression on a continuous aggregrate with 'compress_segmentby' and 'compress_orderby' parameters
+* #5343 Set PortalContext when starting job
 
 **Bugfixes**
 * #5214 Fix use of prepared statement in async module
@@ -44,6 +45,9 @@ Sooner to that time, we will announce the specific version of TimescaleDB in whi
 
 **Thanks**
 * @henriquegelio for reporting the issue on fixed schedules
+
+**Thanks**
+* @justinozavala for reporting an issue with PL/Python procedures in the background worker
 
 ## 2.9.3 (2023-02-03)
 

--- a/tsl/src/bgw_policy/job.c
+++ b/tsl/src/bgw_policy/job.c
@@ -597,6 +597,7 @@ job_execute(BgwJob *job)
 		portal->visible = false;
 		portal->resowner = CurrentResourceOwner;
 		ActivePortal = portal;
+		PortalContext = portal->portalContext;
 
 		StartTransactionCommand();
 #if (PG12 && PG_VERSION_NUM >= 120008) || (PG13 && PG_VERSION_NUM >= 130004) || PG14_GE
@@ -670,6 +671,7 @@ job_execute(BgwJob *job)
 		CommitTransactionCommand();
 		PortalDrop(portal, false);
 		ActivePortal = NULL;
+		PortalContext = NULL;
 	}
 
 	return true;


### PR DESCRIPTION
When executing functions, SPI assumes that `TopTransactionContext` is used for atomic execution contexts and `PortalContext` is used for non-atomic contexts. Since jobs need to be able to commit and start transactions, they are executing in a non-atomic context hence `PortalContext` will be used, but `PortalContext` is not set when starting the job. This is not a problem for PL/PgSQL executor, but for other executors (such as PL/Python) it would be.

This commit fixes the issue by setting the `PortalContext` variable to the portal context created for the portal and restores it (to NULL) after execution.

Fixes #5326