### PR TITLE
Change bgw_main field length to BGW_MAXLEN

### DIFF
--- a/src/bgw/scheduler.c
+++ b/src/bgw/scheduler.c
@@ -127,7 +127,7 @@ ts_bgw_start_worker(const char *name, const BgwParams *bgw_params)
 
 	strlcpy(worker.bgw_name, name, BGW_MAXLEN);
 	strlcpy(worker.bgw_library_name, ts_extension_get_so_name(), BGW_MAXLEN);
-	strlcpy(worker.bgw_function_name, bgw_params->bgw_main, sizeof(worker.bgw_function_name));
+	strlcpy(worker.bgw_function_name, bgw_params->bgw_main, BGW_MAXLEN);
 
 	memcpy(worker.bgw_extra, bgw_params, sizeof(*bgw_params));
 

--- a/src/bgw/worker.h
+++ b/src/bgw/worker.h
@@ -40,7 +40,7 @@ typedef struct BgwParams
 	int32 ttl;
 
 	/** Name of function to call when starting the background worker. */
-	char bgw_main[NAMEDATALEN];
+	char bgw_main[BGW_MAXLEN];
 } BgwParams;
 
 /**


### PR DESCRIPTION
The content of `bgw_main` is copied into `BackgroundWorker.bgw_function_name`, which [has a length of ](https://github.com/postgres/postgres/blob/c8e1ba736b2b9e8c98d37a5b77c4ed31baf94147/src/include/postmaster/bgworker.h#L97)`BGW_MAXLEN`. This patch ensures that the size of these fields has the same length.

---

Found by: https://github.com/timescale/timescaledb/pull/5340
Disable-check: force-changelog-changed