### PR TITLE
Change usage of term nested to hierarchical

### DIFF
--- a/src/ts_catalog/continuous_agg.h
+++ b/src/ts_catalog/continuous_agg.h
@@ -130,7 +130,7 @@ ContinuousAggIsFinalized(const ContinuousAgg *cagg)
 }
 
 static inline bool
-ContinuousAggIsNested(const ContinuousAgg *cagg)
+ContinuousAggIsHierarchical(const ContinuousAgg *cagg)
 {
 	return (cagg->data.parent_mat_hypertable_id != INVALID_HYPERTABLE_ID);
 }


### PR DESCRIPTION
To don't make developers confused the right name for Continuous Aggregates on top of another Continuous Aggregates is `Hierarchical Continuous Aggregates`, so changed the usage of term `nested` for `hierarchical`.

Disable-check: force-changelog-changed
