### PR TITLE
Increase timeout for PostgreSQL in upgrade tests

### DIFF
--- a/scripts/test_update_from_tag.sh
+++ b/scripts/test_update_from_tag.sh
@@ -139,7 +139,7 @@ docker_run_vol() {
 wait_for_pg() {
     set +e
     for _ in {1..20}; do
-        sleep 0.5
+        sleep 1
 
         if docker_exec $1 "pg_isready -U postgres"
         then
@@ -147,7 +147,7 @@ wait_for_pg() {
             # ideal. Apperently, pg_isready is not always a good
             # indication of whether the DB is actually ready to accept
             # queries
-            sleep 0.2
+            sleep 1
             set -e
             return 0
         fi


### PR DESCRIPTION
The upgrade and downgrade tests are running PostgreSQL in Docker containers. The function 'wait_for_pg' is used to determine if PostgreSQL is ready to accept connections. In contrast to the upgrade tests, the downgrade tests use [more relaxed timeout values](https://github.com/timescale/timescaledb/blob/83fc20f1954c5ff0d22f790cd8ee11309724445a/scripts/test_downgrade_from_tag.sh#L139). The upgrade tests [sometimes fail](https://github.com/timescale/timescaledb/actions/runs/4221187281/jobs/7328191286) because PostgreSQL does not accept connections within the configured time range. This patch applies the more relaxed timeout values also to the upgrade script.

 Disable-check: force-changelog-changed