### PR TITLE
Set name for COPY insert buffer hash table

### DIFF
--- a/src/copy.c
+++ b/src/copy.c
@@ -253,7 +253,7 @@ TSCopyCreateNewInsertBufferHashMap()
 		.hcxt = CurrentMemoryContext,
 	};
 
-	return hash_create("", 20, &hctl, HASH_ELEM | HASH_CONTEXT | HASH_BLOBS);
+	return hash_create("COPY insert buffer", 20, &hctl, HASH_ELEM | HASH_CONTEXT | HASH_BLOBS);
 }
 
 /*


### PR DESCRIPTION
Having the hash table named makes debugging easier as the name is used for the MemoryContext used by the hash table.

Disable-check: force-changelog-changed
