### PR TITLE
Forcefully enable tiered data for CAGGs

### DIFF
--- a/src/guc.h
+++ b/src/guc.h
@@ -25,7 +25,7 @@ extern bool ts_guc_enable_runtime_exclusion;
 extern bool ts_guc_enable_constraint_exclusion;
 extern bool ts_guc_enable_cagg_reorder_groupby;
 extern bool ts_guc_enable_now_constify;
-extern bool ts_guc_enable_osm_reads;
+extern TSDLLEXPORT bool ts_guc_enable_osm_reads;
 extern TSDLLEXPORT bool ts_guc_enable_transparent_decompression;
 extern TSDLLEXPORT bool ts_guc_enable_per_data_node_queries;
 extern TSDLLEXPORT bool ts_guc_enable_parameterized_data_node_scan;

--- a/tsl/src/continuous_aggs/refresh.c
+++ b/tsl/src/continuous_aggs/refresh.c
@@ -711,6 +711,7 @@ continuous_agg_refresh_internal(const ContinuousAgg *cagg,
 	int64 computed_invalidation_threshold;
 	int64 invalidation_threshold;
 	bool is_raw_ht_distributed;
+	bool old_enable_osm_reads = ts_guc_enable_osm_reads;
 	int rc;
 
 	/* Connect to SPI manager due to the underlying SPI calls */
@@ -846,8 +847,13 @@ continuous_agg_refresh_internal(const ContinuousAgg *cagg,
 
 	cagg = ts_continuous_agg_find_by_mat_hypertable_id(mat_id);
 
+	/* Cagg should be able to see tiered data despite the server settings */
+	ts_guc_enable_osm_reads = true;
+
 	if (!process_cagg_invalidations_and_refresh(cagg, &refresh_window, callctx, INVALID_CHUNK_ID))
 		emit_up_to_date_notice(cagg, callctx);
+
+	ts_guc_enable_osm_reads = old_enable_osm_reads;
 
 	if ((rc = SPI_finish()) != SPI_OK_FINISH)
 		elog(ERROR, "SPI_finish failed: %s", SPI_result_code_string(rc));


### PR DESCRIPTION
When cagg refresh occurs and is triggered by the background worker tiered data may be excluded if `timescaledb.enable_tiered_reads` is off on the server level. Also when refresh is triggered manually by a user whether tiered data appears in the cagg or not depends on the user's session settings despite of the server settings.
This PR fixes that by forcefully enabling the `timescaledb.enable_tiered_reads` GUC in the cagg refresh procedure.