### PR TITLE
Restrict the reference join pushdowns to SELECT statements

### DIFF
--- a/tsl/src/fdw/data_node_scan_plan.c
+++ b/tsl/src/fdw/data_node_scan_plan.c
@@ -1176,6 +1176,12 @@ data_node_generate_pushdown_join_paths(PlannerInfo *root, RelOptInfo *joinrel, R
 	if (joinrel->fdw_private)
 		return;
 
+	/* Distributed hypertables are not supported by MERGE at the moment. Ensure that
+	 * we perform our planning only on SELECTs.
+	 */
+	if (root->parse->commandType != CMD_SELECT)
+		return;
+
 #ifdef ENABLE_DEAD_CODE
 	/*
 	 * This code does not work for joins with lateral references, since those

--- a/tsl/test/expected/dist_ref_table_join-12.out
+++ b/tsl/test/expected/dist_ref_table_join-12.out
@@ -1955,6 +1955,25 @@ DEBUG:  join pushdown on reference table is not supported for the used query
 (30 rows)
 
 -------
+-- MERGE is supported in PG >= 15. Currently, it is not supported in TimescaleDB
+-- on distributed hypertables. Perform a MERGE here to check if the join pushdown
+-- can handle the MERGE command properly. ON_ERROR_STOP is disabled for this test.
+-- Older PostgreSQL versions report an error because MERGE is not supported. This
+-- will be ignored due to the setting.
+-------
+\set ON_ERROR_STOP 0
+MERGE INTO metric as target_0
+USING metric as input_0
+    inner join (select id from metric_name as input_1) as subq_0
+      ON (TRUE)
+ON target_0.id = input_0.id
+WHEN MATCHED
+   THEN DO NOTHING
+WHEN NOT MATCHED
+   THEN DO NOTHING;
+ERROR:  syntax error at or near "MERGE" at character 1
+\set ON_ERROR_STOP 1
+-------
 -- Tests without enable_per_data_node_queries (no pushdown supported)
 -------
 SET timescaledb.enable_per_data_node_queries = false;

--- a/tsl/test/expected/dist_ref_table_join-13.out
+++ b/tsl/test/expected/dist_ref_table_join-13.out
@@ -1955,6 +1955,25 @@ DEBUG:  join pushdown on reference table is not supported for the used query
 (30 rows)
 
 -------
+-- MERGE is supported in PG >= 15. Currently, it is not supported in TimescaleDB
+-- on distributed hypertables. Perform a MERGE here to check if the join pushdown
+-- can handle the MERGE command properly. ON_ERROR_STOP is disabled for this test.
+-- Older PostgreSQL versions report an error because MERGE is not supported. This
+-- will be ignored due to the setting.
+-------
+\set ON_ERROR_STOP 0
+MERGE INTO metric as target_0
+USING metric as input_0
+    inner join (select id from metric_name as input_1) as subq_0
+      ON (TRUE)
+ON target_0.id = input_0.id
+WHEN MATCHED
+   THEN DO NOTHING
+WHEN NOT MATCHED
+   THEN DO NOTHING;
+ERROR:  syntax error at or near "MERGE" at character 1
+\set ON_ERROR_STOP 1
+-------
 -- Tests without enable_per_data_node_queries (no pushdown supported)
 -------
 SET timescaledb.enable_per_data_node_queries = false;

--- a/tsl/test/expected/dist_ref_table_join-14.out
+++ b/tsl/test/expected/dist_ref_table_join-14.out
@@ -1955,6 +1955,25 @@ DEBUG:  join pushdown on reference table is not supported for the used query
 (30 rows)
 
 -------
+-- MERGE is supported in PG >= 15. Currently, it is not supported in TimescaleDB
+-- on distributed hypertables. Perform a MERGE here to check if the join pushdown
+-- can handle the MERGE command properly. ON_ERROR_STOP is disabled for this test.
+-- Older PostgreSQL versions report an error because MERGE is not supported. This
+-- will be ignored due to the setting.
+-------
+\set ON_ERROR_STOP 0
+MERGE INTO metric as target_0
+USING metric as input_0
+    inner join (select id from metric_name as input_1) as subq_0
+      ON (TRUE)
+ON target_0.id = input_0.id
+WHEN MATCHED
+   THEN DO NOTHING
+WHEN NOT MATCHED
+   THEN DO NOTHING;
+ERROR:  syntax error at or near "MERGE" at character 1
+\set ON_ERROR_STOP 1
+-------
 -- Tests without enable_per_data_node_queries (no pushdown supported)
 -------
 SET timescaledb.enable_per_data_node_queries = false;

--- a/tsl/test/expected/dist_ref_table_join-15.out
+++ b/tsl/test/expected/dist_ref_table_join-15.out
@@ -1999,6 +1999,34 @@ DEBUG:  join pushdown on reference table is not supported for the used query
 (30 rows)
 
 -------
+-- MERGE is supported in PG >= 15. Currently, it is not supported in TimescaleDB
+-- on distributed hypertables. Perform a MERGE here to check if the join pushdown
+-- can handle the MERGE command properly. ON_ERROR_STOP is disabled for this test.
+-- Older PostgreSQL versions report an error because MERGE is not supported. This
+-- will be ignored due to the setting.
+-------
+\set ON_ERROR_STOP 0
+MERGE INTO metric as target_0
+USING metric as input_0
+    inner join (select id from metric_name as input_1) as subq_0
+      ON (TRUE)
+ON target_0.id = input_0.id
+WHEN MATCHED
+   THEN DO NOTHING
+WHEN NOT MATCHED
+   THEN DO NOTHING;
+LOG:  statement: MERGE INTO metric as target_0
+USING metric as input_0
+    inner join (select id from metric_name as input_1) as subq_0
+      ON (TRUE)
+ON target_0.id = input_0.id
+WHEN MATCHED
+   THEN DO NOTHING
+WHEN NOT MATCHED
+   THEN DO NOTHING;
+ERROR:  The MERGE command does not support hypertables in this version
+\set ON_ERROR_STOP 1
+-------
 -- Tests without enable_per_data_node_queries (no pushdown supported)
 -------
 SET timescaledb.enable_per_data_node_queries = false;

--- a/tsl/test/sql/dist_ref_table_join.sql.in
+++ b/tsl/test/sql/dist_ref_table_join.sql.in
@@ -407,6 +407,25 @@ GROUP BY name
 ORDER BY name;
 
 -------
+-- MERGE is supported in PG >= 15. Currently, it is not supported in TimescaleDB
+-- on distributed hypertables. Perform a MERGE here to check if the join pushdown
+-- can handle the MERGE command properly. ON_ERROR_STOP is disabled for this test.
+-- Older PostgreSQL versions report an error because MERGE is not supported. This
+-- will be ignored due to the setting.
+-------
+\set ON_ERROR_STOP 0
+MERGE INTO metric as target_0
+USING metric as input_0
+    inner join (select id from metric_name as input_1) as subq_0
+      ON (TRUE)
+ON target_0.id = input_0.id
+WHEN MATCHED
+   THEN DO NOTHING
+WHEN NOT MATCHED
+   THEN DO NOTHING;
+\set ON_ERROR_STOP 1
+
+-------
 -- Tests without enable_per_data_node_queries (no pushdown supported)
 -------
 SET timescaledb.enable_per_data_node_queries = false;


### PR DESCRIPTION
At the moment, the `MERGE` command [is not supported](https://github.com/timescale/timescaledb/pull/5150) on distributed hypertables. When the join planner hook is invoked by a `MERGE` command, a few data structures are uninitialized (e.g., `nparts` of a distributed hypertable is set to -1). This patch ensures that the join pushdown code can handle these invocations. The patch restricts the invocations of the code to `SELECT` statements. This restriction can be lifted after `MERGE` is fully supported.

---

Found by SQLSmith: https://github.com/timescale/timescaledb/actions/runs/4253118392/jobs/7397565855
SQLSmith run with fix: https://github.com/timescale/timescaledb/actions/runs/4256142168
Disable-check: force-changelog-changed