### PR TITLE
Fix uninitialized bucket_info variable

### DIFF
--- a/tsl/src/continuous_aggs/create.c
+++ b/tsl/src/continuous_aggs/create.c
@@ -1188,7 +1188,7 @@ static CAggTimebucketInfo
 cagg_validate_query(const Query *query, const bool finalized, const char *cagg_schema,
 					const char *cagg_name)
 {
-	CAggTimebucketInfo bucket_info, bucket_info_parent;
+	CAggTimebucketInfo bucket_info = { 0 }, bucket_info_parent;
 	Cache *hcache;
 	Hypertable *ht = NULL, *ht_parent = NULL;
 	RangeTblRef *rtref = NULL, *rtref_other = NULL;


### PR DESCRIPTION
The `bucket_info` variable is initialized by `caggtimebucketinfo_init` function called inside the following branch:

`if (rte->relkind == RELKIND_RELATION || rte->relkind == RELKIND_VIEW)`

If for some reason we don't enter in this branch then the `bucket_info` will not be initialized leading to an uninitialized variable when returning `bucket_info` at the end of the `cagg_validate_query` function.

Fixed it by initializing with zeros the `bucket_info` variable when declaring it.

Found by coverity scan:
https://scan4.scan.coverity.com/reports.htm#v54116/p12995/fileInstanceId=128875670&defectInstanceId=14557559&mergedDefectId=383108

Disable-check: force-changelog-changed
