### PR TITLE
Make copy fetcher more async

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ accidentally triggering the load of a previous DB version.**
 
 **Bugfixes**
 * #5364 Fix num_chunks inconsistency in hypertables view
+* #5362 Make copy fetcher more async
 * #5336 Use NameData and namestrcpy for names
 * #5317 Fix some incorrect memory handling
 


### PR DESCRIPTION
Make the copy fetcher more asynchronous by separating the sending of the request for data from the receiving of the response. By doing that, the async append node can send the request to each data node before it starts reading the first response. This can massively improve the performance because the response isn't returned until the remote node has finished executing the query and is ready to return the first tuple.