### PR TITLE
Fix for inconsistent num_chunks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ accidentally triggering the load of a previous DB version.**
 ## Unreleased
 
 **Bugfixes**
+* #5364 Fix num_chunks inconsistency in hypertables view
 * #5336 Use NameData and namestrcpy for names
 * #5317 Fix some incorrect memory handling
 

--- a/sql/views.sql
+++ b/sql/views.sql
@@ -11,7 +11,7 @@ SELECT ht.schema_name AS hypertable_schema,
   (
     SELECT count(1)
     FROM _timescaledb_catalog.chunk ch
-    WHERE ch.hypertable_id = ht.id) AS num_chunks,
+    WHERE ch.hypertable_id = ht.id AND ch.dropped IS FALSE AND ch.osm_chunk IS FALSE) AS num_chunks,
   (
     CASE WHEN compression_state = 1 THEN
       TRUE

--- a/tsl/test/expected/information_view_chunk_count.out
+++ b/tsl/test/expected/information_view_chunk_count.out
@@ -1,0 +1,68 @@
+-- This file and its contents are licensed under the Timescale License.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-TIMESCALE for a copy of the license.
+CREATE TABLE sensor_data(
+time timestamptz not null,
+sensor_id integer not null,
+cpu double precision null,
+temperature double precision null);
+SELECT from create_hypertable('sensor_data','time');
+--
+(1 row)
+
+INSERT INTO sensor_data
+SELECT time + (INTERVAL '1 minute' * random()) AS time,
+       sensor_id,
+       random() AS cpu,
+       random() * 100 AS temperature
+FROM
+       generate_series('2018-03-02 1:00'::TIMESTAMPTZ, '2018-03-28 1:00', '1 hour') AS g1(time),
+       generate_series(1, 100, 1 ) AS g2(sensor_id)
+ORDER BY time;
+CREATE materialized VIEW sensor_data_v WITH(timescaledb.continuous) AS
+SELECT sensor_id, time_bucket(INTERVAL '1 day', time) AS bucket,
+AVG(temperature) FROM sensor_data
+GROUP BY sensor_id, bucket;
+NOTICE:  refreshing continuous aggregate "sensor_data_v"
+INSERT INTO sensor_data
+SELECT time + (INTERVAL '1 minute' * random()) AS time,
+       sensor_id, random() AS cpu, random()* 100 AS temperature
+FROM
+       generate_series('2018-03-03 1:00'::TIMESTAMPTZ, '2018-03-31 1:00', '1 hour') AS g1(time),
+       generate_series(1, 100, 1 ) AS g2(sensor_id)
+ORDER BY time;
+SELECT count(*) AS num_chunks FROM show_chunks('sensor_data');
+ num_chunks 
+------------
+          5
+(1 row)
+
+SELECT drop_chunks('sensor_data','2018-03-28'::timestamp);
+              drop_chunks               
+----------------------------------------
+ _timescaledb_internal._hyper_1_1_chunk
+ _timescaledb_internal._hyper_1_2_chunk
+ _timescaledb_internal._hyper_1_3_chunk
+(3 rows)
+
+SELECT count(*) AS num_chunks from timescaledb_information.chunks where hypertable_name = 'sensor_data';
+ num_chunks 
+------------
+          2
+(1 row)
+
+SELECT num_chunks from timescaledb_information.hypertables where hypertable_name = 'sensor_data';
+ num_chunks 
+------------
+          2
+(1 row)
+
+SELECT count(*) AS num_chunks FROM show_chunks('sensor_data');
+ num_chunks 
+------------
+          2
+(1 row)
+
+DROP TABLE sensor_data CASCADE;
+NOTICE:  drop cascades to 3 other objects
+NOTICE:  drop cascades to table _timescaledb_internal._hyper_2_5_chunk

--- a/tsl/test/sql/CMakeLists.txt
+++ b/tsl/test/sql/CMakeLists.txt
@@ -87,6 +87,7 @@ if(CMAKE_BUILD_TYPE MATCHES Debug)
     dist_triggers.sql
     dist_backup.sql
     insert_memory_usage.sql
+    information_view_chunk_count.sql
     read_only.sql
     remote_connection_cache.sql
     remote_connection.sql

--- a/tsl/test/sql/information_view_chunk_count.sql
+++ b/tsl/test/sql/information_view_chunk_count.sql
@@ -1,0 +1,46 @@
+-- This file and its contents are licensed under the Timescale License.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-TIMESCALE for a copy of the license.
+
+CREATE TABLE sensor_data(
+time timestamptz not null,
+sensor_id integer not null,
+cpu double precision null,
+temperature double precision null);
+
+SELECT from create_hypertable('sensor_data','time');
+
+INSERT INTO sensor_data
+SELECT time + (INTERVAL '1 minute' * random()) AS time,
+       sensor_id,
+       random() AS cpu,
+       random() * 100 AS temperature
+FROM
+       generate_series('2018-03-02 1:00'::TIMESTAMPTZ, '2018-03-28 1:00', '1 hour') AS g1(time),
+       generate_series(1, 100, 1 ) AS g2(sensor_id)
+ORDER BY time;
+
+CREATE materialized VIEW sensor_data_v WITH(timescaledb.continuous) AS
+SELECT sensor_id, time_bucket(INTERVAL '1 day', time) AS bucket,
+AVG(temperature) FROM sensor_data
+GROUP BY sensor_id, bucket;
+
+INSERT INTO sensor_data
+SELECT time + (INTERVAL '1 minute' * random()) AS time,
+       sensor_id, random() AS cpu, random()* 100 AS temperature
+FROM
+       generate_series('2018-03-03 1:00'::TIMESTAMPTZ, '2018-03-31 1:00', '1 hour') AS g1(time),
+       generate_series(1, 100, 1 ) AS g2(sensor_id)
+ORDER BY time;
+
+SELECT count(*) AS num_chunks FROM show_chunks('sensor_data');
+
+SELECT drop_chunks('sensor_data','2018-03-28'::timestamp);
+
+SELECT count(*) AS num_chunks from timescaledb_information.chunks where hypertable_name = 'sensor_data';
+
+SELECT num_chunks from timescaledb_information.hypertables where hypertable_name = 'sensor_data';
+
+SELECT count(*) AS num_chunks FROM show_chunks('sensor_data');
+
+DROP TABLE sensor_data CASCADE;


### PR DESCRIPTION
Different num_chunks values reported by
timescaledb_information.hypertables and
timescaledb_information.chunks.
View definition of hypertables was
not filtering dropped and osm_chunks.

Fixes #5338