### PR TITLE
Rename columns in old-style continuous aggregates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,9 +10,12 @@ accidentally triggering the load of a previous DB version.**
 * #5364 Fix num_chunks inconsistency in hypertables view
 * #5336 Use NameData and namestrcpy for names
 * #5317 Fix some incorrect memory handling
+* #5367 Rename columns in old-style continuous aggregates
 
 **Thanks**
 * @Medvecrab for discovering an issue with copying NameData when forming heap tuples.
+* @pushpeepkmonroe for discovering an issue in upgrading old-style
+  continuous aggregates with renamed columns
 
 ## 2.10.0 (2023-02-21)
 

--- a/sql/updates/2.4.1--2.4.2.sql
+++ b/sql/updates/2.4.1--2.4.2.sql
@@ -6,10 +6,11 @@ DROP FUNCTION IF EXISTS _timescaledb_internal.time_col_type_for_chunk(name,name)
 -- in a table.
 CREATE TABLE _timescaledb_internal.rename_tables (
        user_view regclass,
-       new_name text,
-       old_name text,
+       user_column text,
        partial_view regclass,
+       partial_column text,
        direct_view regclass,
+       direct_column text,
        mat_table regclass,
        hypertable_id int
 );
@@ -31,24 +32,32 @@ WITH
         SELECT attrelid, attname, attnum, mat_id
           FROM objs, pg_attribute
          WHERE attrelid = objs.user_view),
+  partial_view AS (
+        SELECT attrelid, attname, attnum, mat_id
+          FROM objs, pg_attribute
+         WHERE attrelid = objs.partial_view),
   direct_view AS (
         SELECT attrelid, attname, attnum, mat_id
           FROM objs, pg_attribute
          WHERE attrelid = objs.direct_view)
 INSERT INTO _timescaledb_internal.rename_tables
 SELECT (SELECT user_view FROM objs WHERE uv.attrelid = user_view),
-       uv.attname AS new_name,
-       dv.attname AS old_name,
+       uv.attname AS user_column,
        (SELECT partial_view FROM objs WHERE uv.attrelid = user_view),
+       pv.attname AS partial_column,
        (SELECT direct_view FROM objs WHERE uv.attrelid = user_view),
+       dv.attname AS direct_column,
        (SELECT mat_table FROM objs WHERE uv.attrelid = user_view),
        (SELECT mat_id FROM objs WHERE uv.attrelid = user_view)
   FROM user_view uv JOIN direct_view dv USING (mat_id, attnum)
+                    JOIN partial_view pv USING (mat_id, attnum)
  WHERE uv.attname != dv.attname;
 
 CREATE PROCEDURE _timescaledb_internal.alter_table_column(cagg regclass, relation regclass, old_column_name name, new_column_name name) AS $$
 BEGIN
-    EXECUTE format('ALTER TABLE %s RENAME COLUMN %I TO %I', relation, old_column_name, new_column_name);
+    IF old_column_name != new_column_name THEN
+        EXECUTE format('ALTER TABLE %s RENAME COLUMN %I TO %I', relation, old_column_name, new_column_name);
+    END IF;
 END;
 $$ LANGUAGE plpgsql;
 
@@ -59,23 +68,24 @@ DO
 $$
 DECLARE
     user_view regclass;
-    new_name name;
-    old_name name;
+    user_column name;
     partial_view regclass;
+    partial_column name;
     direct_view regclass;
+    direct_column name;
     mat_table regclass;
     ht_id int;
 BEGIN
-  FOR user_view, new_name, old_name, partial_view, direct_view, mat_table, ht_id IN
+  FOR user_view, user_column, partial_view, partial_column, direct_view, direct_column, mat_table, ht_id IN
   SELECT * FROM _timescaledb_internal.rename_tables
   LOOP
     -- There is no RENAME COLUMN for views, but we can use ALTER TABLE
     -- to rename a column in a view.
-    CALL _timescaledb_internal.alter_table_column(user_view, partial_view, old_name, new_name);
-    CALL _timescaledb_internal.alter_table_column(user_view, direct_view, old_name, new_name);
-    CALL _timescaledb_internal.alter_table_column(user_view, mat_table, old_name, new_name);
-    UPDATE _timescaledb_catalog.dimension SET column_name = new_name
-     WHERE hypertable_id = ht_id AND column_name = old_name;
+    CALL _timescaledb_internal.alter_table_column(user_view, partial_view, partial_column, user_column);
+    CALL _timescaledb_internal.alter_table_column(user_view, direct_view, direct_column, user_column);
+    CALL _timescaledb_internal.alter_table_column(user_view, mat_table, partial_column, user_column);
+    UPDATE _timescaledb_catalog.dimension SET column_name = user_column
+     WHERE hypertable_id = ht_id AND column_name = direct_column;
   END LOOP;
 END
 $$;


### PR DESCRIPTION
For continuous aggregates with the old-style partial aggregates renaming columns that are not in the group-by clause will generate an error when upgrading to a later version. The reason is that it is implicitly assumed that the name of the column is the same as for the direct view. This holds true for new-style continous aggregates, but is not true for old-style continuous aggregates.

This commit fixes that by extracting the name of the column from the partial view and use that when renaming the partial view column and the materialized table column.

Fixes #5348 