### PR TITLE
Fix perf regression due to DML HA

### DIFF
--- a/tsl/src/data_node.c
+++ b/tsl/src/data_node.c
@@ -1958,10 +1958,10 @@ data_node_get_node_name_list_with_aclcheck(AclMode mode, bool fail_on_aclcheck)
 	return nodes;
 }
 
-void
-data_node_fail_if_nodes_are_unavailable(void)
+bool
+data_node_some_unavailable(void)
 {
-	/* Get a list of data nodes and ensure all of them are available */
+	/* Get a list of data nodes and check if one is unavailable */
 	List *data_node_list = data_node_get_node_name_list_with_aclcheck(ACL_NO_CHECK, false);
 	ListCell *lc;
 
@@ -1972,8 +1972,13 @@ data_node_fail_if_nodes_are_unavailable(void)
 
 		server = data_node_get_foreign_server(node_name, ACL_NO_CHECK, false, false);
 		if (!ts_data_node_is_available_by_server(server))
-			ereport(ERROR, (errmsg("some data nodes are not available")));
+		{
+			list_free(data_node_list);
+			return true;
+		}
 	}
+	list_free(data_node_list);
+	return false;
 }
 
 /*

--- a/tsl/src/data_node.h
+++ b/tsl/src/data_node.h
@@ -35,7 +35,7 @@ extern List *data_node_get_node_name_list_with_aclcheck(AclMode mode, bool fail_
 extern List *data_node_get_filtered_node_name_list(ArrayType *nodearr, AclMode mode,
 												   bool fail_on_aclcheck);
 extern List *data_node_get_node_name_list(void);
-extern void data_node_fail_if_nodes_are_unavailable(void);
+extern bool data_node_some_unavailable(void);
 extern List *data_node_array_to_node_name_list_with_aclcheck(ArrayType *nodearr, AclMode mode,
 															 bool fail_on_aclcheck);
 extern List *data_node_array_to_node_name_list(ArrayType *nodearr);

--- a/tsl/src/dist_backup.c
+++ b/tsl/src/dist_backup.c
@@ -117,7 +117,8 @@ create_distributed_restore_point(PG_FUNCTION_ARGS)
 							 "from there.")));
 
 		/* Ensure all data nodes are available */
-		data_node_fail_if_nodes_are_unavailable();
+		if (data_node_some_unavailable())
+			ereport(ERROR, (errmsg("some data nodes are not available")));
 
 		/*
 		 * In order to achieve synchronization across the multinode cluster,


### PR DESCRIPTION
We added checks via #4846 to handle DML HA when replication factor is
greater than 1 and a datanode is down. Since each insert can go to a different
chunk with a different set of datanodes, we added checks on every insert to check if DNs are unavailable. This increased CPU consumption on the AN leading to a performance regression for RF > 1 code paths.

This patch fixes this regression. We now track if any DN is marked as unavailable at the start of the transaction and use that information to reduce unnecessary checks for each inserted row.