### PR TITLE
Flag test space_constraint.sql.in for release run

### DIFF
--- a/tsl/test/shared/sql/CMakeLists.txt
+++ b/tsl/test/shared/sql/CMakeLists.txt
@@ -19,7 +19,8 @@ set(TEST_TEMPLATES_SHARED
     ordered_append.sql.in
     ordered_append_join.sql.in
     transparent_decompress_chunk.sql.in
-    dist_distinct.sql.in)
+    dist_distinct.sql.in
+    space_constraint.sql.in)
 
 if((${PG_VERSION_MAJOR} GREATER_EQUAL "14"))
   list(APPEND TEST_FILES_SHARED compression_dml.sql memoize.sql)
@@ -28,7 +29,7 @@ endif()
 if(CMAKE_BUILD_TYPE MATCHES Debug)
   list(APPEND TEST_FILES_SHARED dist_parallel_agg.sql dist_queries.sql
        timestamp_limits.sql with_clause_parser.sql)
-  list(APPEND TEST_TEMPLATES_SHARED constify_now.sql.in space_constraint.sql.in
+  list(APPEND TEST_TEMPLATES_SHARED constify_now.sql.in
        dist_remote_error.sql.in)
 endif(CMAKE_BUILD_TYPE MATCHES Debug)
 


### PR DESCRIPTION
It was incorrectly flagged as requiring a debug build.

Disable-check: force-changelog-changed
