### PR TITLE
Adjust ARM64 package test

### DIFF
--- a/.github/workflows/apt-arm-packages.yaml
+++ b/.github/workflows/apt-arm-packages.yaml
@@ -18,8 +18,11 @@ jobs:
       matrix:
         # Debian images:  10 (buster), 11 (bullseye)
         # Ubuntu images:  20.04 LTS (focal), 22.04 (jammy), 22.10 (kinetic)
-        image: [ "debian:10-slim","debian:11-slim","ubuntu:focal", "ubuntu:jammy", "ubuntu:kinetic"]
+        image: [ "debian:10-slim","debian:11-slim","ubuntu:focal", "ubuntu:jammy"]
         pg: [ 12, 13, 14, 15 ]
+        include:
+          - image: "ubuntu:kinetic"
+            pg: 14
 
     steps:
     - name: Setup emulation


### PR DESCRIPTION
We only package timescaledb for ubuntu kinetic on PG14 because there are no prebuilt postgres packages available for the other postgres versions.

Disable-check: force-changelog-changed
