### PR TITLE
Release 2.10.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,19 +6,34 @@ accidentally triggering the load of a previous DB version.**
 
 ## Unreleased
 
+**Features**
+* #5212 Allow pushdown of reference table joins
+* #5312 Add timeout support to the ping_data_node()
+
 **Bugfixes**
-* #5364 Fix num_chunks inconsistency in hypertables view
-* #5362 Make copy fetcher more async
-* #5336 Use NameData and namestrcpy for names
+
+## 2.10.1 (2023-03-07)
+
+This release contains bug fixes since the 2.10.0 release.
+We recommend that you upgrade at the next available opportunity.
+
+**Bugfixes**
+* #5159 Support Continuous Aggregates names in hypertable_(detailed_)size
+* #5226 Fix concurrent locking with chunk_data_node table
 * #5317 Fix some incorrect memory handling
-* #5367 Rename columns in old-style continuous aggregates
+* #5336 Use NameData and namestrcpy for names
+* #5343 Set PortalContext when starting job
+* #5360 Fix uninitialized bucket_info variable
+* #5362 Make copy fetcher more async
+* #5364 Fix num_chunks inconsistency in hypertables view
+* #5367 Fix column name handling in old-style continuous aggregates
+* #5378 Fix multinode DML HA performance regression
 * #5384 Fix Hierarchical Continuous Aggregates chunk_interval_size
-* #5153 Fix concurrent locking with chunk_data_node table
 
 **Thanks**
+* @justinozavala for reporting an issue with PL/Python procedures in the background worker
 * @Medvecrab for discovering an issue with copying NameData when forming heap tuples.
-* @pushpeepkmonroe for discovering an issue in upgrading old-style
-  continuous aggregates with renamed columns
+* @pushpeepkmonroe for discovering an issue in upgrading old-style continuous aggregates with renamed columns
 
 ## 2.10.0 (2023-02-21)
 
@@ -47,9 +62,6 @@ Sooner to that time, we will announce the specific version of TimescaleDB in whi
 * #5246 Make connection establishment interruptible
 * #5253 Make data node command execution interruptible
 * #5262 Extend enabling compression on a continuous aggregrate with 'compress_segmentby' and 'compress_orderby' parameters
-* #5343 Set PortalContext when starting job
-* #5312 Add timeout support to the ping_data_node()
-* #5212 Allow pushdown of reference table joins 
 
 **Bugfixes**
 * #5214 Fix use of prepared statement in async module
@@ -59,9 +71,6 @@ Sooner to that time, we will announce the specific version of TimescaleDB in whi
 
 **Thanks**
 * @henriquegelio for reporting the issue on fixed schedules
-
-**Thanks**
-* @justinozavala for reporting an issue with PL/Python procedures in the background worker
 
 ## 2.9.3 (2023-02-03)
 

--- a/sql/CMakeLists.txt
+++ b/sql/CMakeLists.txt
@@ -44,7 +44,8 @@ set(MOD_FILES
     updates/2.9.0--2.9.1.sql
     updates/2.9.1--2.9.2.sql
     updates/2.9.2--2.9.3.sql
-    updates/2.9.3--2.10.0.sql)
+    updates/2.9.3--2.10.0.sql
+    updates/2.10.0--2.10.1.sql)
 
 # The downgrade file to generate a downgrade script for the current version, as
 # specified in version.config

--- a/version.config
+++ b/version.config
@@ -1,3 +1,3 @@
 version = 2.11.0-dev
-update_from_version = 2.10.0
+update_from_version = 2.10.1
 downgrade_to_version = 2.10.0


### PR DESCRIPTION
This release contains bug fixes since the 2.10.0 release.
We recommend that you upgrade at the next available opportunity.

**Bugfixes**
* #5226 Fix concurrent locking with chunk_data_node table
* #5317 Fix some incorrect memory handling
* #5336 Use NameData and namestrcpy for names
* #5343 Set PortalContext when starting job
* #5360 Fix uninitialized bucket_info variable
* #5362 Make copy fetcher more async
* #5364 Fix num_chunks inconsistency in hypertables view
* #5367 Fix column name handling in old-style continuous aggregates
* #5378 Fix multinode DML HA performance regression
* #5384 Fix Hierarchical Continuous Aggregates chunk_interval_size

**Thanks**
* @justinozavala for reporting an issue with PL/Python procedures in the background worker
* @Medvecrab for discovering an issue with copying NameData when forming heap tuples.
* @pushpeepkmonroe for discovering an issue in upgrading old-style
  continuous aggregates with renamed columns
