### PR TITLE
Code refactoring of invalidations log processing

### DIFF
--- a/sql/cagg_utils.sql
+++ b/sql/cagg_utils.sql
@@ -54,16 +54,16 @@ CREATE OR REPLACE FUNCTION _timescaledb_internal.drop_dist_ht_invalidation_trigg
 -- max_bucket_widths - (Deprecated) This argument is ignored and is present only
 --                     for backward compatibility.
 -- bucket_functions - (Optional) The array of serialized information about bucket functions
-CREATE OR REPLACE FUNCTION _timescaledb_internal.invalidation_process_hypertable_log(
+CREATE OR REPLACE FUNCTION _timescaledb_internal.move_invalidation_logs_from_htlogs_to_cagglogs(
     mat_hypertable_id INTEGER,
     raw_hypertable_id INTEGER,
     dimtype REGTYPE,
     mat_hypertable_ids INTEGER[],
     bucket_widths BIGINT[],
     max_bucket_widths BIGINT[]
-) RETURNS VOID AS '@MODULE_PATHNAME@', 'ts_invalidation_process_hypertable_log' LANGUAGE C STRICT VOLATILE;
+) RETURNS VOID AS '@MODULE_PATHNAME@', 'ts_move_invalidation_logs_from_htlogs_to_cagglogs' LANGUAGE C STRICT VOLATILE;
 
-CREATE OR REPLACE FUNCTION _timescaledb_internal.invalidation_process_hypertable_log(
+CREATE OR REPLACE FUNCTION _timescaledb_internal.move_invalidation_logs_from_htlogs_to_cagglogs(
     mat_hypertable_id INTEGER,
     raw_hypertable_id INTEGER,
     dimtype REGTYPE,
@@ -71,7 +71,7 @@ CREATE OR REPLACE FUNCTION _timescaledb_internal.invalidation_process_hypertable
     bucket_widths BIGINT[],
     max_bucket_widths BIGINT[],
     bucket_functions TEXT[]
-) RETURNS VOID AS '@MODULE_PATHNAME@', 'ts_invalidation_process_hypertable_log' LANGUAGE C STRICT VOLATILE;
+) RETURNS VOID AS '@MODULE_PATHNAME@', 'ts_move_invalidation_logs_from_htlogs_to_cagglogs' LANGUAGE C STRICT VOLATILE;
 
 -- Processes the materialization invalidation log in a data node for the CAGG being refreshed that
 -- belongs to the distributed hypertable with hypertable ID 'raw_hypertable_id' in the Access Node.

--- a/src/cross_module_fn.c
+++ b/src/cross_module_fn.c
@@ -91,7 +91,7 @@ CROSSMODULE_WRAPPER(continuous_agg_refresh);
 CROSSMODULE_WRAPPER(invalidation_cagg_log_add_entry);
 CROSSMODULE_WRAPPER(invalidation_hyper_log_add_entry);
 CROSSMODULE_WRAPPER(drop_dist_ht_invalidation_trigger);
-CROSSMODULE_WRAPPER(invalidation_process_hypertable_log);
+CROSSMODULE_WRAPPER(move_invalidation_logs_from_htlogs_to_cagglogs);
 CROSSMODULE_WRAPPER(invalidation_process_cagg_log);
 CROSSMODULE_WRAPPER(cagg_try_repair);
 
@@ -491,7 +491,7 @@ TSDLLEXPORT CrossModuleFunctions ts_cm_functions_default = {
 	.remote_invalidation_log_delete = NULL,
 	.drop_dist_ht_invalidation_trigger = error_no_default_fn_pg_community,
 	.remote_drop_dist_ht_invalidation_trigger = NULL,
-	.invalidation_process_hypertable_log = error_no_default_fn_pg_community,
+	.move_invalidation_logs_from_htlogs_to_cagglogs = error_no_default_fn_pg_community,
 	.invalidation_process_cagg_log = error_no_default_fn_pg_community,
 	.cagg_try_repair = process_cagg_try_repair,
 

--- a/src/cross_module_fn.h
+++ b/src/cross_module_fn.h
@@ -122,7 +122,7 @@ typedef struct CrossModuleFunctions
 										   ContinuousAggHypertableStatus caggstatus);
 	PGFunction drop_dist_ht_invalidation_trigger;
 	void (*remote_drop_dist_ht_invalidation_trigger)(int32 raw_hypertable_id);
-	PGFunction invalidation_process_hypertable_log;
+	PGFunction move_invalidation_logs_from_htlogs_to_cagglogs;
 	PGFunction invalidation_process_cagg_log;
 	PGFunction cagg_try_repair;
 

--- a/src/ts_catalog/continuous_agg.h
+++ b/src/ts_catalog/continuous_agg.h
@@ -81,7 +81,7 @@ ts_continuous_agg_get_compression_defelems(const WithClauseResult *with_clauses)
  *
  * Serialized data is used as an input of the following procedures:
  *
- * - _timescaledb_internal.invalidation_process_hypertable_log()
+ * - _timescaledb_internal.move_invalidation_logs_from_htlogs_to_cagglogs()
  * - _timescaledb_internal.invalidation_process_cagg_log()
  *
  * See bucket_functions[] argument.

--- a/tsl/src/continuous_aggs/invalidation.h
+++ b/tsl/src/continuous_aggs/invalidation.h
@@ -49,12 +49,12 @@ void remote_invalidation_log_add_entry(const Hypertable *raw_ht,
 									   ContinuousAggHypertableStatus caggstatus, int32 entry_id,
 									   int64 start, int64 end);
 
-extern void invalidation_process_hypertable_log(int32 mat_hypertable_id, int32 raw_hypertable_id,
-												Oid dimtype, const CaggsInfo *all_caggs_info);
-extern void remote_invalidation_process_hypertable_log(int32 mat_hypertable_id,
-													   int32 raw_hypertable_id, Oid dimtype,
-													   const CaggsInfo *all_caggs);
-extern Datum tsl_invalidation_process_hypertable_log(PG_FUNCTION_ARGS);
+extern void move_invalidation_logs_from_htlogs_to_cagglogs(int32 mat_hypertable_id,
+														   int32 raw_hypertable_id, Oid dimtype,
+														   const CaggsInfo *all_caggs_info,
+														   bool raw_ht_distributed);
+extern Datum
+tsl_move_invalidation_logs_from_htlogs_to_cagglogs(PG_FUNCTION_ARGS);
 
 extern InvalidationStore *invalidation_process_cagg_log(
 	int32 mat_hypertable_id, int32 raw_hypertable_id, const InternalTimeRange *refresh_window,

--- a/tsl/src/continuous_aggs/refresh.h
+++ b/tsl/src/continuous_aggs/refresh.h
@@ -30,5 +30,6 @@ extern void continuous_agg_refresh_internal(const ContinuousAgg *cagg,
 											const InternalTimeRange *refresh_window,
 											const CaggRefreshCallContext callctx,
 											const bool start_isnull, const bool end_isnull);
+extern int process_invalidation_logs(const ContinuousAgg *cagg, InternalTimeRange *refresh_window);
 
 #endif /* TIMESCALEDB_TSL_CONTINUOUS_AGGS_REFRESH_H */

--- a/tsl/src/init.c
+++ b/tsl/src/init.c
@@ -159,7 +159,8 @@ CrossModuleFunctions tsl_cm_functions = {
 	.remote_invalidation_log_delete = remote_invalidation_log_delete,
 	.drop_dist_ht_invalidation_trigger = tsl_drop_dist_ht_invalidation_trigger,
 	.remote_drop_dist_ht_invalidation_trigger = remote_drop_dist_ht_invalidation_trigger,
-	.invalidation_process_hypertable_log = tsl_invalidation_process_hypertable_log,
+	.move_invalidation_logs_from_htlogs_to_cagglogs =
+		tsl_move_invalidation_logs_from_htlogs_to_cagglogs,
 	.invalidation_process_cagg_log = tsl_invalidation_process_cagg_log,
 	.cagg_try_repair = tsl_cagg_try_repair,
 


### PR DESCRIPTION
The aim of this refactoring is to make the code more streamlined, modular, and understandable. Now all the processing of invalidation logs are done in one function called process_invalidation_logs.

The other code optimizations, renaming of other related functions are also done in this commit.