### PR TITLE
Don't run sanitizer test on individual PRs

### DIFF
--- a/.github/workflows/sanitizer-build-and-test.yaml
+++ b/.github/workflows/sanitizer-build-and-test.yaml
@@ -1,11 +1,13 @@
 # Run regression tests under memory sanitizer
 name: Sanitizer test
 "on":
+  schedule:
+    # run daily 0:00 on main branch
+    - cron: '0 0 * * *'
   push:
     branches:
       - main
       - prerelease_test
-  pull_request:
 
 env:
   name: "Sanitizer"


### PR DESCRIPTION
Sanitizer tests take a long time to run so we don't want to run them on individual PRs but instead run them nightly and on commits to master.

Disable-check: force-changelog-changed
