### PR TITLE
Revert changing merge driver for CHANGELOG

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,0 @@
-# to avoid frequent conflicts
-CHANGELOG.md text merge=union


### PR DESCRIPTION
This is causing bad merges in the CHANGELOG often resulting in changes being added to previuous releases instead of at the top. I think it's better to error here and have a human review instead of having a CHANGELOG that has entries in random places.