### PR TITLE
Fix SEGMENTBY columns predicates to be pushed down

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ accidentally triggering the load of a previous DB version.**
 * #5312 Add timeout support to the ping_data_node()
 
 **Bugfixes**
+* #5396 Fix SEGMENTBY columns predicates to be pushed down
 
 ## 2.10.1 (2023-03-07)
 
@@ -2774,4 +2775,3 @@ the next release.
 * [72f754a] use PostgreSQL's own `hash_any` function as default partfunc (thanks @robin900)
 * [39f4c0f] Remove sample data instructions and point to docs site
 * [9015314] Revised the `get_general_index_definition` function to handle cases where indexes have definitions other than just `CREATE INDEX` (thanks @bricklen)
-

--- a/tsl/src/nodes/decompress_chunk/qual_pushdown.c
+++ b/tsl/src/nodes/decompress_chunk/qual_pushdown.c
@@ -357,6 +357,7 @@ modify_expression(Node *node, QualPushdownContext *context)
 			/* opexpr will still be checked for segment by columns */
 			break;
 		}
+		case T_CoerceViaIO:
 		case T_RelabelType:
 		case T_ScalarArrayOpExpr:
 		case T_List:

--- a/tsl/test/expected/compression_qualpushdown.out
+++ b/tsl/test/expected/compression_qualpushdown.out
@@ -262,3 +262,83 @@ EXPLAIN (costs off) SELECT * FROM pushdown_relabel WHERE dev_vc = 'varchar'::cha
          Filter: ((dev_vc)::bpchar = 'varchar   '::character(10))
 (4 rows)
 
+-- github issue #5286
+CREATE TABLE deleteme AS
+    SELECT generate_series AS timestamp, 1 AS segment, 0 AS data
+        FROM generate_series('2008-03-01 00:00'::timestamp with time zone,
+                             '2008-03-04 12:00', '1 second');
+SELECT create_hypertable('deleteme', 'timestamp', migrate_data => true);
+NOTICE:  adding not-null constraint to column "timestamp"
+NOTICE:  migrating data to chunks
+   create_hypertable   
+-----------------------
+ (7,public,deleteme,t)
+(1 row)
+
+ALTER TABLE deleteme SET (
+  timescaledb.compress,
+  timescaledb.compress_segmentby = 'segment'
+);
+SELECT compress_chunk(i) FROM show_chunks('deleteme') i;
+             compress_chunk             
+----------------------------------------
+ _timescaledb_internal._hyper_7_8_chunk
+(1 row)
+
+EXPLAIN (costs off) SELECT sum(data) FROM deleteme WHERE segment::text like '%4%';
+                       QUERY PLAN                        
+---------------------------------------------------------
+ Aggregate
+   ->  Custom Scan (DecompressChunk) on _hyper_7_8_chunk
+         ->  Seq Scan on compress_hyper_8_9_chunk
+               Filter: ((segment)::text ~~ '%4%'::text)
+(4 rows)
+
+EXPLAIN (costs off) SELECT sum(data) FROM deleteme WHERE '4' = segment::text;
+                       QUERY PLAN                        
+---------------------------------------------------------
+ Aggregate
+   ->  Custom Scan (DecompressChunk) on _hyper_7_8_chunk
+         ->  Seq Scan on compress_hyper_8_9_chunk
+               Filter: ('4'::text = (segment)::text)
+(4 rows)
+
+CREATE TABLE deleteme_with_bytea(time bigint NOT NULL, bdata bytea);
+SELECT create_hypertable('deleteme_with_bytea', 'time', chunk_time_interval => 1000000);
+        create_hypertable         
+----------------------------------
+ (9,public,deleteme_with_bytea,t)
+(1 row)
+
+INSERT INTO deleteme_with_bytea(time, bdata) VALUES (1001, E'\\x');
+INSERT INTO deleteme_with_bytea(time, bdata) VALUES (1001, NULL);
+ALTER TABLE deleteme_with_bytea SET (
+  timescaledb.compress,
+  timescaledb.compress_segmentby = 'bdata'
+);
+SELECT compress_chunk(i) FROM show_chunks('deleteme_with_bytea') i;
+             compress_chunk              
+-----------------------------------------
+ _timescaledb_internal._hyper_9_10_chunk
+(1 row)
+
+EXPLAIN (costs off) SELECT '1' FROM deleteme_with_bytea WHERE bdata = E'\\x';
+                                                         QUERY PLAN                                                         
+----------------------------------------------------------------------------------------------------------------------------
+ Result
+   ->  Custom Scan (DecompressChunk) on _hyper_9_10_chunk
+         ->  Index Scan using compress_hyper_10_11_chunk__compressed_hypertable_10_bdata__ts_ on compress_hyper_10_11_chunk
+               Index Cond: (bdata = '\x'::bytea)
+(4 rows)
+
+EXPLAIN (costs off) SELECT '1' FROM deleteme_with_bytea WHERE bdata::text = '123';
+                        QUERY PLAN                        
+----------------------------------------------------------
+ Result
+   ->  Custom Scan (DecompressChunk) on _hyper_9_10_chunk
+         ->  Seq Scan on compress_hyper_10_11_chunk
+               Filter: ((bdata)::text = '123'::text)
+(4 rows)
+
+DROP table deleteme;
+DROP table deleteme_with_bytea;

--- a/tsl/test/expected/transparent_decompression-12.out
+++ b/tsl/test/expected/transparent_decompression-12.out
@@ -1505,7 +1505,8 @@ ORDER BY time,
          ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk (actual rows=2520 loops=1)
                Filter: ("time" > ('2000-01-08'::cstring)::timestamp with time zone)
                ->  Seq Scan on compress_hyper_5_16_chunk (actual rows=5 loops=1)
-(10 rows)
+                     Filter: (_ts_meta_max_3 > ('2000-01-08'::cstring)::timestamp with time zone)
+(11 rows)
 
 -- test aggregate
 :PREFIX
@@ -4920,16 +4921,19 @@ ORDER BY time,
          ->  Merge Append (actual rows=0 loops=1)
                ->  Custom Scan (DecompressChunk) on _hyper_2_4_chunk (actual rows=0 loops=1)
                      Filter: ("time" > ('2000-01-08'::cstring)::timestamp with time zone)
-                     Rows Removed by Filter: 360
-                     ->  Seq Scan on compress_hyper_6_17_chunk (actual rows=1 loops=1)
+                     ->  Seq Scan on compress_hyper_6_17_chunk (actual rows=0 loops=1)
+                           Filter: (_ts_meta_max_3 > ('2000-01-08'::cstring)::timestamp with time zone)
+                           Rows Removed by Filter: 1
                ->  Custom Scan (DecompressChunk) on _hyper_2_5_chunk (actual rows=0 loops=1)
                      Filter: ("time" > ('2000-01-08'::cstring)::timestamp with time zone)
-                     Rows Removed by Filter: 1080
-                     ->  Seq Scan on compress_hyper_6_18_chunk (actual rows=3 loops=1)
+                     ->  Seq Scan on compress_hyper_6_18_chunk (actual rows=0 loops=1)
+                           Filter: (_ts_meta_max_3 > ('2000-01-08'::cstring)::timestamp with time zone)
+                           Rows Removed by Filter: 3
                ->  Custom Scan (DecompressChunk) on _hyper_2_6_chunk (actual rows=0 loops=1)
                      Filter: ("time" > ('2000-01-08'::cstring)::timestamp with time zone)
-                     Rows Removed by Filter: 360
-                     ->  Seq Scan on compress_hyper_6_19_chunk (actual rows=1 loops=1)
+                     ->  Seq Scan on compress_hyper_6_19_chunk (actual rows=0 loops=1)
+                           Filter: (_ts_meta_max_3 > ('2000-01-08'::cstring)::timestamp with time zone)
+                           Rows Removed by Filter: 1
          ->  Merge Append (actual rows=1675 loops=1)
                ->  Seq Scan on _hyper_2_7_chunk (actual rows=335 loops=1)
                      Filter: ("time" > ('2000-01-08'::cstring)::timestamp with time zone)
@@ -4943,12 +4947,14 @@ ORDER BY time,
                ->  Custom Scan (DecompressChunk) on _hyper_2_10_chunk (actual rows=504 loops=1)
                      Filter: ("time" > ('2000-01-08'::cstring)::timestamp with time zone)
                      ->  Seq Scan on compress_hyper_6_20_chunk (actual rows=1 loops=1)
+                           Filter: (_ts_meta_max_3 > ('2000-01-08'::cstring)::timestamp with time zone)
                ->  Custom Scan (DecompressChunk) on _hyper_2_11_chunk (actual rows=1512 loops=1)
                      Filter: ("time" > ('2000-01-08'::cstring)::timestamp with time zone)
                      ->  Seq Scan on compress_hyper_6_21_chunk (actual rows=3 loops=1)
+                           Filter: (_ts_meta_max_3 > ('2000-01-08'::cstring)::timestamp with time zone)
                ->  Seq Scan on _hyper_2_12_chunk (actual rows=504 loops=1)
                      Filter: ("time" > ('2000-01-08'::cstring)::timestamp with time zone)
-(35 rows)
+(40 rows)
 
 -- test aggregate
 :PREFIX

--- a/tsl/test/expected/transparent_decompression-13.out
+++ b/tsl/test/expected/transparent_decompression-13.out
@@ -1643,7 +1643,8 @@ ORDER BY time,
                ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk (actual rows=2520 loops=1)
                      Filter: ("time" > ('2000-01-08'::cstring)::timestamp with time zone)
                      ->  Seq Scan on compress_hyper_5_16_chunk (actual rows=5 loops=1)
-(15 rows)
+                           Filter: (_ts_meta_max_3 > ('2000-01-08'::cstring)::timestamp with time zone)
+(16 rows)
 
 -- test aggregate
 :PREFIX
@@ -5735,8 +5736,9 @@ ORDER BY time,
                            Sort Method: quicksort 
                            ->  Custom Scan (DecompressChunk) on _hyper_2_4_chunk (actual rows=0 loops=1)
                                  Filter: ("time" > ('2000-01-08'::cstring)::timestamp with time zone)
-                                 Rows Removed by Filter: 360
-                                 ->  Seq Scan on compress_hyper_6_17_chunk (actual rows=1 loops=1)
+                                 ->  Seq Scan on compress_hyper_6_17_chunk (actual rows=0 loops=1)
+                                       Filter: (_ts_meta_max_3 > ('2000-01-08'::cstring)::timestamp with time zone)
+                                       Rows Removed by Filter: 1
                ->  Sort (actual rows=0 loops=1)
                      Sort Key: _hyper_2_5_chunk."time"
                      Sort Method: quicksort 
@@ -5745,8 +5747,9 @@ ORDER BY time,
                            Sort Method: quicksort 
                            ->  Custom Scan (DecompressChunk) on _hyper_2_5_chunk (actual rows=0 loops=1)
                                  Filter: ("time" > ('2000-01-08'::cstring)::timestamp with time zone)
-                                 Rows Removed by Filter: 1080
-                                 ->  Seq Scan on compress_hyper_6_18_chunk (actual rows=3 loops=1)
+                                 ->  Seq Scan on compress_hyper_6_18_chunk (actual rows=0 loops=1)
+                                       Filter: (_ts_meta_max_3 > ('2000-01-08'::cstring)::timestamp with time zone)
+                                       Rows Removed by Filter: 3
                ->  Sort (actual rows=0 loops=1)
                      Sort Key: _hyper_2_6_chunk."time"
                      Sort Method: quicksort 
@@ -5755,8 +5758,9 @@ ORDER BY time,
                            Sort Method: quicksort 
                            ->  Custom Scan (DecompressChunk) on _hyper_2_6_chunk (actual rows=0 loops=1)
                                  Filter: ("time" > ('2000-01-08'::cstring)::timestamp with time zone)
-                                 Rows Removed by Filter: 360
-                                 ->  Seq Scan on compress_hyper_6_19_chunk (actual rows=1 loops=1)
+                                 ->  Seq Scan on compress_hyper_6_19_chunk (actual rows=0 loops=1)
+                                       Filter: (_ts_meta_max_3 > ('2000-01-08'::cstring)::timestamp with time zone)
+                                       Rows Removed by Filter: 1
          ->  Merge Append (actual rows=1675 loops=1)
                Sort Key: _hyper_2_7_chunk."time"
                ->  Index Scan Backward using _hyper_2_7_chunk_metrics_space_time_idx on _hyper_2_7_chunk (actual rows=335 loops=1)
@@ -5776,6 +5780,7 @@ ORDER BY time,
                            ->  Custom Scan (DecompressChunk) on _hyper_2_10_chunk (actual rows=504 loops=1)
                                  Filter: ("time" > ('2000-01-08'::cstring)::timestamp with time zone)
                                  ->  Seq Scan on compress_hyper_6_20_chunk (actual rows=1 loops=1)
+                                       Filter: (_ts_meta_max_3 > ('2000-01-08'::cstring)::timestamp with time zone)
                ->  Sort (actual rows=1512 loops=1)
                      Sort Key: _hyper_2_11_chunk."time"
                      Sort Method: quicksort 
@@ -5785,9 +5790,10 @@ ORDER BY time,
                            ->  Custom Scan (DecompressChunk) on _hyper_2_11_chunk (actual rows=1512 loops=1)
                                  Filter: ("time" > ('2000-01-08'::cstring)::timestamp with time zone)
                                  ->  Seq Scan on compress_hyper_6_21_chunk (actual rows=3 loops=1)
+                                       Filter: (_ts_meta_max_3 > ('2000-01-08'::cstring)::timestamp with time zone)
                ->  Index Scan Backward using _hyper_2_12_chunk_metrics_space_time_idx on _hyper_2_12_chunk (actual rows=504 loops=1)
                      Index Cond: ("time" > ('2000-01-08'::cstring)::timestamp with time zone)
-(68 rows)
+(73 rows)
 
 -- test aggregate
 :PREFIX

--- a/tsl/test/expected/transparent_decompression-14.out
+++ b/tsl/test/expected/transparent_decompression-14.out
@@ -1643,7 +1643,8 @@ ORDER BY time,
                ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk (actual rows=2520 loops=1)
                      Filter: ("time" > ('2000-01-08'::cstring)::timestamp with time zone)
                      ->  Seq Scan on compress_hyper_5_16_chunk (actual rows=5 loops=1)
-(15 rows)
+                           Filter: (_ts_meta_max_3 > ('2000-01-08'::cstring)::timestamp with time zone)
+(16 rows)
 
 -- test aggregate
 :PREFIX
@@ -5735,8 +5736,9 @@ ORDER BY time,
                            Sort Method: quicksort 
                            ->  Custom Scan (DecompressChunk) on _hyper_2_4_chunk (actual rows=0 loops=1)
                                  Filter: ("time" > ('2000-01-08'::cstring)::timestamp with time zone)
-                                 Rows Removed by Filter: 360
-                                 ->  Seq Scan on compress_hyper_6_17_chunk (actual rows=1 loops=1)
+                                 ->  Seq Scan on compress_hyper_6_17_chunk (actual rows=0 loops=1)
+                                       Filter: (_ts_meta_max_3 > ('2000-01-08'::cstring)::timestamp with time zone)
+                                       Rows Removed by Filter: 1
                ->  Sort (actual rows=0 loops=1)
                      Sort Key: _hyper_2_5_chunk."time"
                      Sort Method: quicksort 
@@ -5745,8 +5747,9 @@ ORDER BY time,
                            Sort Method: quicksort 
                            ->  Custom Scan (DecompressChunk) on _hyper_2_5_chunk (actual rows=0 loops=1)
                                  Filter: ("time" > ('2000-01-08'::cstring)::timestamp with time zone)
-                                 Rows Removed by Filter: 1080
-                                 ->  Seq Scan on compress_hyper_6_18_chunk (actual rows=3 loops=1)
+                                 ->  Seq Scan on compress_hyper_6_18_chunk (actual rows=0 loops=1)
+                                       Filter: (_ts_meta_max_3 > ('2000-01-08'::cstring)::timestamp with time zone)
+                                       Rows Removed by Filter: 3
                ->  Sort (actual rows=0 loops=1)
                      Sort Key: _hyper_2_6_chunk."time"
                      Sort Method: quicksort 
@@ -5755,8 +5758,9 @@ ORDER BY time,
                            Sort Method: quicksort 
                            ->  Custom Scan (DecompressChunk) on _hyper_2_6_chunk (actual rows=0 loops=1)
                                  Filter: ("time" > ('2000-01-08'::cstring)::timestamp with time zone)
-                                 Rows Removed by Filter: 360
-                                 ->  Seq Scan on compress_hyper_6_19_chunk (actual rows=1 loops=1)
+                                 ->  Seq Scan on compress_hyper_6_19_chunk (actual rows=0 loops=1)
+                                       Filter: (_ts_meta_max_3 > ('2000-01-08'::cstring)::timestamp with time zone)
+                                       Rows Removed by Filter: 1
          ->  Merge Append (actual rows=1675 loops=1)
                Sort Key: _hyper_2_7_chunk."time"
                ->  Index Scan Backward using _hyper_2_7_chunk_metrics_space_time_idx on _hyper_2_7_chunk (actual rows=335 loops=1)
@@ -5776,6 +5780,7 @@ ORDER BY time,
                            ->  Custom Scan (DecompressChunk) on _hyper_2_10_chunk (actual rows=504 loops=1)
                                  Filter: ("time" > ('2000-01-08'::cstring)::timestamp with time zone)
                                  ->  Seq Scan on compress_hyper_6_20_chunk (actual rows=1 loops=1)
+                                       Filter: (_ts_meta_max_3 > ('2000-01-08'::cstring)::timestamp with time zone)
                ->  Sort (actual rows=1512 loops=1)
                      Sort Key: _hyper_2_11_chunk."time"
                      Sort Method: quicksort 
@@ -5785,9 +5790,10 @@ ORDER BY time,
                            ->  Custom Scan (DecompressChunk) on _hyper_2_11_chunk (actual rows=1512 loops=1)
                                  Filter: ("time" > ('2000-01-08'::cstring)::timestamp with time zone)
                                  ->  Seq Scan on compress_hyper_6_21_chunk (actual rows=3 loops=1)
+                                       Filter: (_ts_meta_max_3 > ('2000-01-08'::cstring)::timestamp with time zone)
                ->  Index Scan Backward using _hyper_2_12_chunk_metrics_space_time_idx on _hyper_2_12_chunk (actual rows=504 loops=1)
                      Index Cond: ("time" > ('2000-01-08'::cstring)::timestamp with time zone)
-(68 rows)
+(73 rows)
 
 -- test aggregate
 :PREFIX

--- a/tsl/test/expected/transparent_decompression-15.out
+++ b/tsl/test/expected/transparent_decompression-15.out
@@ -1644,7 +1644,8 @@ ORDER BY time,
                ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk (actual rows=2520 loops=1)
                      Filter: ("time" > ('2000-01-08'::cstring)::timestamp with time zone)
                      ->  Seq Scan on compress_hyper_5_16_chunk (actual rows=5 loops=1)
-(15 rows)
+                           Filter: (_ts_meta_max_3 > ('2000-01-08'::cstring)::timestamp with time zone)
+(16 rows)
 
 -- test aggregate
 :PREFIX
@@ -5737,8 +5738,9 @@ ORDER BY time,
                            Sort Method: quicksort 
                            ->  Custom Scan (DecompressChunk) on _hyper_2_4_chunk (actual rows=0 loops=1)
                                  Filter: ("time" > ('2000-01-08'::cstring)::timestamp with time zone)
-                                 Rows Removed by Filter: 360
-                                 ->  Seq Scan on compress_hyper_6_17_chunk (actual rows=1 loops=1)
+                                 ->  Seq Scan on compress_hyper_6_17_chunk (actual rows=0 loops=1)
+                                       Filter: (_ts_meta_max_3 > ('2000-01-08'::cstring)::timestamp with time zone)
+                                       Rows Removed by Filter: 1
                ->  Sort (actual rows=0 loops=1)
                      Sort Key: _hyper_2_5_chunk."time"
                      Sort Method: quicksort 
@@ -5747,8 +5749,9 @@ ORDER BY time,
                            Sort Method: quicksort 
                            ->  Custom Scan (DecompressChunk) on _hyper_2_5_chunk (actual rows=0 loops=1)
                                  Filter: ("time" > ('2000-01-08'::cstring)::timestamp with time zone)
-                                 Rows Removed by Filter: 1080
-                                 ->  Seq Scan on compress_hyper_6_18_chunk (actual rows=3 loops=1)
+                                 ->  Seq Scan on compress_hyper_6_18_chunk (actual rows=0 loops=1)
+                                       Filter: (_ts_meta_max_3 > ('2000-01-08'::cstring)::timestamp with time zone)
+                                       Rows Removed by Filter: 3
                ->  Sort (actual rows=0 loops=1)
                      Sort Key: _hyper_2_6_chunk."time"
                      Sort Method: quicksort 
@@ -5757,8 +5760,9 @@ ORDER BY time,
                            Sort Method: quicksort 
                            ->  Custom Scan (DecompressChunk) on _hyper_2_6_chunk (actual rows=0 loops=1)
                                  Filter: ("time" > ('2000-01-08'::cstring)::timestamp with time zone)
-                                 Rows Removed by Filter: 360
-                                 ->  Seq Scan on compress_hyper_6_19_chunk (actual rows=1 loops=1)
+                                 ->  Seq Scan on compress_hyper_6_19_chunk (actual rows=0 loops=1)
+                                       Filter: (_ts_meta_max_3 > ('2000-01-08'::cstring)::timestamp with time zone)
+                                       Rows Removed by Filter: 1
          ->  Merge Append (actual rows=1675 loops=1)
                Sort Key: _hyper_2_7_chunk."time"
                ->  Index Scan Backward using _hyper_2_7_chunk_metrics_space_time_idx on _hyper_2_7_chunk (actual rows=335 loops=1)
@@ -5778,6 +5782,7 @@ ORDER BY time,
                            ->  Custom Scan (DecompressChunk) on _hyper_2_10_chunk (actual rows=504 loops=1)
                                  Filter: ("time" > ('2000-01-08'::cstring)::timestamp with time zone)
                                  ->  Seq Scan on compress_hyper_6_20_chunk (actual rows=1 loops=1)
+                                       Filter: (_ts_meta_max_3 > ('2000-01-08'::cstring)::timestamp with time zone)
                ->  Sort (actual rows=1512 loops=1)
                      Sort Key: _hyper_2_11_chunk."time"
                      Sort Method: quicksort 
@@ -5787,9 +5792,10 @@ ORDER BY time,
                            ->  Custom Scan (DecompressChunk) on _hyper_2_11_chunk (actual rows=1512 loops=1)
                                  Filter: ("time" > ('2000-01-08'::cstring)::timestamp with time zone)
                                  ->  Seq Scan on compress_hyper_6_21_chunk (actual rows=3 loops=1)
+                                       Filter: (_ts_meta_max_3 > ('2000-01-08'::cstring)::timestamp with time zone)
                ->  Index Scan Backward using _hyper_2_12_chunk_metrics_space_time_idx on _hyper_2_12_chunk (actual rows=504 loops=1)
                      Index Cond: ("time" > ('2000-01-08'::cstring)::timestamp with time zone)
-(68 rows)
+(73 rows)
 
 -- test aggregate
 :PREFIX

--- a/tsl/test/expected/transparent_decompression_ordered_index-12.out
+++ b/tsl/test/expected/transparent_decompression_ordered_index-12.out
@@ -870,18 +870,23 @@ ORDER BY 1,
                                  ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk d_1 (actual rows=480 loops=1)
                                        Filter: ("time" > ('2000-01-01 0:00:00+0'::cstring)::timestamp with time zone)
                                        ->  Seq Scan on compress_hyper_2_6_chunk (actual rows=5 loops=1)
+                                             Filter: (_ts_meta_max_1 > ('2000-01-01 0:00:00+0'::cstring)::timestamp with time zone)
                                  ->  Custom Scan (DecompressChunk) on _hyper_1_2_chunk d_2 (actual rows=960 loops=1)
                                        Filter: ("time" > ('2000-01-01 0:00:00+0'::cstring)::timestamp with time zone)
                                        ->  Seq Scan on compress_hyper_2_7_chunk (actual rows=5 loops=1)
+                                             Filter: (_ts_meta_max_1 > ('2000-01-01 0:00:00+0'::cstring)::timestamp with time zone)
                                  ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk d_3 (actual rows=48 loops=1)
                                        Filter: ("time" > ('2000-01-01 0:00:00+0'::cstring)::timestamp with time zone)
                                        ->  Seq Scan on compress_hyper_2_8_chunk (actual rows=1 loops=1)
+                                             Filter: (_ts_meta_max_1 > ('2000-01-01 0:00:00+0'::cstring)::timestamp with time zone)
                                  ->  Custom Scan (DecompressChunk) on _hyper_1_4_chunk d_4 (actual rows=48 loops=1)
                                        Filter: ("time" > ('2000-01-01 0:00:00+0'::cstring)::timestamp with time zone)
                                        ->  Seq Scan on compress_hyper_2_9_chunk (actual rows=1 loops=1)
+                                             Filter: (_ts_meta_max_1 > ('2000-01-01 0:00:00+0'::cstring)::timestamp with time zone)
                                  ->  Custom Scan (DecompressChunk) on _hyper_1_5_chunk d_5 (actual rows=5 loops=1)
                                        Filter: ("time" > ('2000-01-01 0:00:00+0'::cstring)::timestamp with time zone)
                                        ->  Seq Scan on compress_hyper_2_10_chunk (actual rows=5 loops=1)
+                                             Filter: (_ts_meta_max_1 > ('2000-01-01 0:00:00+0'::cstring)::timestamp with time zone)
                ->  Sort (actual rows=7317 loops=1)
                      Sort Key: m."time"
                      Sort Method: quicksort 
@@ -892,19 +897,24 @@ ORDER BY 1,
                                  ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk m_1 (actual rows=480 loops=1)
                                        Filter: ("time" > ('2000-01-01 0:00:00+0'::cstring)::timestamp with time zone)
                                        ->  Seq Scan on compress_hyper_2_6_chunk compress_hyper_2_6_chunk_1 (actual rows=5 loops=1)
+                                             Filter: (_ts_meta_max_1 > ('2000-01-01 0:00:00+0'::cstring)::timestamp with time zone)
                                  ->  Custom Scan (DecompressChunk) on _hyper_1_2_chunk m_2 (actual rows=960 loops=1)
                                        Filter: ("time" > ('2000-01-01 0:00:00+0'::cstring)::timestamp with time zone)
                                        ->  Seq Scan on compress_hyper_2_7_chunk compress_hyper_2_7_chunk_1 (actual rows=5 loops=1)
+                                             Filter: (_ts_meta_max_1 > ('2000-01-01 0:00:00+0'::cstring)::timestamp with time zone)
                                  ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk m_3 (actual rows=48 loops=1)
                                        Filter: ("time" > ('2000-01-01 0:00:00+0'::cstring)::timestamp with time zone)
                                        ->  Seq Scan on compress_hyper_2_8_chunk compress_hyper_2_8_chunk_1 (actual rows=1 loops=1)
+                                             Filter: (_ts_meta_max_1 > ('2000-01-01 0:00:00+0'::cstring)::timestamp with time zone)
                                  ->  Custom Scan (DecompressChunk) on _hyper_1_4_chunk m_4 (actual rows=48 loops=1)
                                        Filter: ("time" > ('2000-01-01 0:00:00+0'::cstring)::timestamp with time zone)
                                        ->  Seq Scan on compress_hyper_2_9_chunk compress_hyper_2_9_chunk_1 (actual rows=1 loops=1)
+                                             Filter: (_ts_meta_max_1 > ('2000-01-01 0:00:00+0'::cstring)::timestamp with time zone)
                                  ->  Custom Scan (DecompressChunk) on _hyper_1_5_chunk m_5 (actual rows=5 loops=1)
                                        Filter: ("time" > ('2000-01-01 0:00:00+0'::cstring)::timestamp with time zone)
                                        ->  Seq Scan on compress_hyper_2_10_chunk compress_hyper_2_10_chunk_1 (actual rows=5 loops=1)
-(51 rows)
+                                             Filter: (_ts_meta_max_1 > ('2000-01-01 0:00:00+0'::cstring)::timestamp with time zone)
+(61 rows)
 
 --query with all chunks but 1 excluded at plan time --
 :PREFIX
@@ -916,8 +926,8 @@ WHERE m.device_id = d.device_id
     AND m.time > '2019-01-01'
     AND m.time < '2000-01-01 0:00:00+0'::text::timestamptz
 ORDER BY m.v0;
-                                                                               QUERY PLAN                                                                               
-------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                          QUERY PLAN                                                                                          
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Sort (actual rows=0 loops=1)
    Sort Key: m.v0
    Sort Method: quicksort 
@@ -925,12 +935,13 @@ ORDER BY m.v0;
          Hash Cond: (m.device_id = d.device_id)
          ->  Custom Scan (DecompressChunk) on _hyper_1_5_chunk m (actual rows=0 loops=1)
                Filter: (("time" > 'Tue Jan 01 00:00:00 2019 PST'::timestamp with time zone) AND ("time" < ('2000-01-01 0:00:00+0'::cstring)::timestamp with time zone))
-               Rows Removed by Filter: 5
-               ->  Seq Scan on compress_hyper_2_10_chunk (actual rows=5 loops=1)
-                     Filter: (_ts_meta_max_1 > 'Tue Jan 01 00:00:00 2019 PST'::timestamp with time zone)
-         ->  Hash (never executed)
-               ->  Seq Scan on device_tbl d (never executed)
-(12 rows)
+               ->  Seq Scan on compress_hyper_2_10_chunk (actual rows=0 loops=1)
+                     Filter: ((_ts_meta_max_1 > 'Tue Jan 01 00:00:00 2019 PST'::timestamp with time zone) AND (_ts_meta_min_1 < ('2000-01-01 0:00:00+0'::cstring)::timestamp with time zone))
+                     Rows Removed by Filter: 5
+         ->  Hash (actual rows=7 loops=1)
+               Buckets: 1024  Batches: 1 
+               ->  Seq Scan on device_tbl d (actual rows=7 loops=1)
+(13 rows)
 
 -- no matches in metrics_ordered_idx but one row in device_tbl
 :PREFIX
@@ -942,8 +953,8 @@ FROM device_tbl d
     AND m.time < '2000-01-01 0:00:00+0'::text::timestamptz
 WHERE d.device_id = 8
 ORDER BY m.v0;
-                                                                               QUERY PLAN                                                                               
-------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                                    QUERY PLAN                                                                                                    
+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Sort (actual rows=1 loops=1)
    Sort Key: m.v0
    Sort Method: quicksort 
@@ -955,7 +966,7 @@ ORDER BY m.v0;
          ->  Custom Scan (DecompressChunk) on _hyper_1_5_chunk m (actual rows=0 loops=1)
                Filter: (("time" > 'Tue Jan 01 00:00:00 2019 PST'::timestamp with time zone) AND ("time" < ('2000-01-01 0:00:00+0'::cstring)::timestamp with time zone))
                ->  Seq Scan on compress_hyper_2_10_chunk (actual rows=0 loops=1)
-                     Filter: ((_ts_meta_max_1 > 'Tue Jan 01 00:00:00 2019 PST'::timestamp with time zone) AND (device_id = 8))
+                     Filter: ((_ts_meta_max_1 > 'Tue Jan 01 00:00:00 2019 PST'::timestamp with time zone) AND (device_id = 8) AND (_ts_meta_min_1 < ('2000-01-01 0:00:00+0'::cstring)::timestamp with time zone))
                      Rows Removed by Filter: 5
 (13 rows)
 

--- a/tsl/test/expected/transparent_decompression_ordered_index-13.out
+++ b/tsl/test/expected/transparent_decompression_ordered_index-13.out
@@ -872,18 +872,23 @@ ORDER BY 1,
                                  ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk d_1 (actual rows=480 loops=1)
                                        Filter: ("time" > ('2000-01-01 0:00:00+0'::cstring)::timestamp with time zone)
                                        ->  Seq Scan on compress_hyper_2_6_chunk (actual rows=5 loops=1)
+                                             Filter: (_ts_meta_max_1 > ('2000-01-01 0:00:00+0'::cstring)::timestamp with time zone)
                                  ->  Custom Scan (DecompressChunk) on _hyper_1_2_chunk d_2 (actual rows=960 loops=1)
                                        Filter: ("time" > ('2000-01-01 0:00:00+0'::cstring)::timestamp with time zone)
                                        ->  Seq Scan on compress_hyper_2_7_chunk (actual rows=5 loops=1)
+                                             Filter: (_ts_meta_max_1 > ('2000-01-01 0:00:00+0'::cstring)::timestamp with time zone)
                                  ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk d_3 (actual rows=48 loops=1)
                                        Filter: ("time" > ('2000-01-01 0:00:00+0'::cstring)::timestamp with time zone)
                                        ->  Seq Scan on compress_hyper_2_8_chunk (actual rows=1 loops=1)
+                                             Filter: (_ts_meta_max_1 > ('2000-01-01 0:00:00+0'::cstring)::timestamp with time zone)
                                  ->  Custom Scan (DecompressChunk) on _hyper_1_4_chunk d_4 (actual rows=48 loops=1)
                                        Filter: ("time" > ('2000-01-01 0:00:00+0'::cstring)::timestamp with time zone)
                                        ->  Seq Scan on compress_hyper_2_9_chunk (actual rows=1 loops=1)
+                                             Filter: (_ts_meta_max_1 > ('2000-01-01 0:00:00+0'::cstring)::timestamp with time zone)
                                  ->  Custom Scan (DecompressChunk) on _hyper_1_5_chunk d_5 (actual rows=5 loops=1)
                                        Filter: ("time" > ('2000-01-01 0:00:00+0'::cstring)::timestamp with time zone)
                                        ->  Seq Scan on compress_hyper_2_10_chunk (actual rows=5 loops=1)
+                                             Filter: (_ts_meta_max_1 > ('2000-01-01 0:00:00+0'::cstring)::timestamp with time zone)
                ->  Sort (actual rows=7317 loops=1)
                      Sort Key: m."time"
                      Sort Method: quicksort 
@@ -894,19 +899,24 @@ ORDER BY 1,
                                  ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk m_1 (actual rows=480 loops=1)
                                        Filter: ("time" > ('2000-01-01 0:00:00+0'::cstring)::timestamp with time zone)
                                        ->  Seq Scan on compress_hyper_2_6_chunk compress_hyper_2_6_chunk_1 (actual rows=5 loops=1)
+                                             Filter: (_ts_meta_max_1 > ('2000-01-01 0:00:00+0'::cstring)::timestamp with time zone)
                                  ->  Custom Scan (DecompressChunk) on _hyper_1_2_chunk m_2 (actual rows=960 loops=1)
                                        Filter: ("time" > ('2000-01-01 0:00:00+0'::cstring)::timestamp with time zone)
                                        ->  Seq Scan on compress_hyper_2_7_chunk compress_hyper_2_7_chunk_1 (actual rows=5 loops=1)
+                                             Filter: (_ts_meta_max_1 > ('2000-01-01 0:00:00+0'::cstring)::timestamp with time zone)
                                  ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk m_3 (actual rows=48 loops=1)
                                        Filter: ("time" > ('2000-01-01 0:00:00+0'::cstring)::timestamp with time zone)
                                        ->  Seq Scan on compress_hyper_2_8_chunk compress_hyper_2_8_chunk_1 (actual rows=1 loops=1)
+                                             Filter: (_ts_meta_max_1 > ('2000-01-01 0:00:00+0'::cstring)::timestamp with time zone)
                                  ->  Custom Scan (DecompressChunk) on _hyper_1_4_chunk m_4 (actual rows=48 loops=1)
                                        Filter: ("time" > ('2000-01-01 0:00:00+0'::cstring)::timestamp with time zone)
                                        ->  Seq Scan on compress_hyper_2_9_chunk compress_hyper_2_9_chunk_1 (actual rows=1 loops=1)
+                                             Filter: (_ts_meta_max_1 > ('2000-01-01 0:00:00+0'::cstring)::timestamp with time zone)
                                  ->  Custom Scan (DecompressChunk) on _hyper_1_5_chunk m_5 (actual rows=5 loops=1)
                                        Filter: ("time" > ('2000-01-01 0:00:00+0'::cstring)::timestamp with time zone)
                                        ->  Seq Scan on compress_hyper_2_10_chunk compress_hyper_2_10_chunk_1 (actual rows=5 loops=1)
-(52 rows)
+                                             Filter: (_ts_meta_max_1 > ('2000-01-01 0:00:00+0'::cstring)::timestamp with time zone)
+(62 rows)
 
 --query with all chunks but 1 excluded at plan time --
 :PREFIX
@@ -918,8 +928,8 @@ WHERE m.device_id = d.device_id
     AND m.time > '2019-01-01'
     AND m.time < '2000-01-01 0:00:00+0'::text::timestamptz
 ORDER BY m.v0;
-                                                                               QUERY PLAN                                                                               
-------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                          QUERY PLAN                                                                                          
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Sort (actual rows=0 loops=1)
    Sort Key: m.v0
    Sort Method: quicksort 
@@ -927,12 +937,13 @@ ORDER BY m.v0;
          Hash Cond: (m.device_id = d.device_id)
          ->  Custom Scan (DecompressChunk) on _hyper_1_5_chunk m (actual rows=0 loops=1)
                Filter: (("time" > 'Tue Jan 01 00:00:00 2019 PST'::timestamp with time zone) AND ("time" < ('2000-01-01 0:00:00+0'::cstring)::timestamp with time zone))
-               Rows Removed by Filter: 5
-               ->  Seq Scan on compress_hyper_2_10_chunk (actual rows=5 loops=1)
-                     Filter: (_ts_meta_max_1 > 'Tue Jan 01 00:00:00 2019 PST'::timestamp with time zone)
-         ->  Hash (never executed)
-               ->  Seq Scan on device_tbl d (never executed)
-(12 rows)
+               ->  Seq Scan on compress_hyper_2_10_chunk (actual rows=0 loops=1)
+                     Filter: ((_ts_meta_max_1 > 'Tue Jan 01 00:00:00 2019 PST'::timestamp with time zone) AND (_ts_meta_min_1 < ('2000-01-01 0:00:00+0'::cstring)::timestamp with time zone))
+                     Rows Removed by Filter: 5
+         ->  Hash (actual rows=7 loops=1)
+               Buckets: 1024  Batches: 1 
+               ->  Seq Scan on device_tbl d (actual rows=7 loops=1)
+(13 rows)
 
 -- no matches in metrics_ordered_idx but one row in device_tbl
 :PREFIX
@@ -944,8 +955,8 @@ FROM device_tbl d
     AND m.time < '2000-01-01 0:00:00+0'::text::timestamptz
 WHERE d.device_id = 8
 ORDER BY m.v0;
-                                                                               QUERY PLAN                                                                               
-------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                                    QUERY PLAN                                                                                                    
+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Sort (actual rows=1 loops=1)
    Sort Key: m.v0
    Sort Method: quicksort 
@@ -957,7 +968,7 @@ ORDER BY m.v0;
          ->  Custom Scan (DecompressChunk) on _hyper_1_5_chunk m (actual rows=0 loops=1)
                Filter: (("time" > 'Tue Jan 01 00:00:00 2019 PST'::timestamp with time zone) AND ("time" < ('2000-01-01 0:00:00+0'::cstring)::timestamp with time zone))
                ->  Seq Scan on compress_hyper_2_10_chunk (actual rows=0 loops=1)
-                     Filter: ((_ts_meta_max_1 > 'Tue Jan 01 00:00:00 2019 PST'::timestamp with time zone) AND (device_id = 8))
+                     Filter: ((_ts_meta_max_1 > 'Tue Jan 01 00:00:00 2019 PST'::timestamp with time zone) AND (device_id = 8) AND (_ts_meta_min_1 < ('2000-01-01 0:00:00+0'::cstring)::timestamp with time zone))
                      Rows Removed by Filter: 5
 (13 rows)
 

--- a/tsl/test/expected/transparent_decompression_ordered_index-14.out
+++ b/tsl/test/expected/transparent_decompression_ordered_index-14.out
@@ -872,18 +872,23 @@ ORDER BY 1,
                                  ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk d_1 (actual rows=480 loops=1)
                                        Filter: ("time" > ('2000-01-01 0:00:00+0'::cstring)::timestamp with time zone)
                                        ->  Seq Scan on compress_hyper_2_6_chunk (actual rows=5 loops=1)
+                                             Filter: (_ts_meta_max_1 > ('2000-01-01 0:00:00+0'::cstring)::timestamp with time zone)
                                  ->  Custom Scan (DecompressChunk) on _hyper_1_2_chunk d_2 (actual rows=960 loops=1)
                                        Filter: ("time" > ('2000-01-01 0:00:00+0'::cstring)::timestamp with time zone)
                                        ->  Seq Scan on compress_hyper_2_7_chunk (actual rows=5 loops=1)
+                                             Filter: (_ts_meta_max_1 > ('2000-01-01 0:00:00+0'::cstring)::timestamp with time zone)
                                  ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk d_3 (actual rows=48 loops=1)
                                        Filter: ("time" > ('2000-01-01 0:00:00+0'::cstring)::timestamp with time zone)
                                        ->  Seq Scan on compress_hyper_2_8_chunk (actual rows=1 loops=1)
+                                             Filter: (_ts_meta_max_1 > ('2000-01-01 0:00:00+0'::cstring)::timestamp with time zone)
                                  ->  Custom Scan (DecompressChunk) on _hyper_1_4_chunk d_4 (actual rows=48 loops=1)
                                        Filter: ("time" > ('2000-01-01 0:00:00+0'::cstring)::timestamp with time zone)
                                        ->  Seq Scan on compress_hyper_2_9_chunk (actual rows=1 loops=1)
+                                             Filter: (_ts_meta_max_1 > ('2000-01-01 0:00:00+0'::cstring)::timestamp with time zone)
                                  ->  Custom Scan (DecompressChunk) on _hyper_1_5_chunk d_5 (actual rows=5 loops=1)
                                        Filter: ("time" > ('2000-01-01 0:00:00+0'::cstring)::timestamp with time zone)
                                        ->  Seq Scan on compress_hyper_2_10_chunk (actual rows=5 loops=1)
+                                             Filter: (_ts_meta_max_1 > ('2000-01-01 0:00:00+0'::cstring)::timestamp with time zone)
                ->  Sort (actual rows=7317 loops=1)
                      Sort Key: m."time"
                      Sort Method: quicksort 
@@ -894,19 +899,24 @@ ORDER BY 1,
                                  ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk m_1 (actual rows=480 loops=1)
                                        Filter: ("time" > ('2000-01-01 0:00:00+0'::cstring)::timestamp with time zone)
                                        ->  Seq Scan on compress_hyper_2_6_chunk compress_hyper_2_6_chunk_1 (actual rows=5 loops=1)
+                                             Filter: (_ts_meta_max_1 > ('2000-01-01 0:00:00+0'::cstring)::timestamp with time zone)
                                  ->  Custom Scan (DecompressChunk) on _hyper_1_2_chunk m_2 (actual rows=960 loops=1)
                                        Filter: ("time" > ('2000-01-01 0:00:00+0'::cstring)::timestamp with time zone)
                                        ->  Seq Scan on compress_hyper_2_7_chunk compress_hyper_2_7_chunk_1 (actual rows=5 loops=1)
+                                             Filter: (_ts_meta_max_1 > ('2000-01-01 0:00:00+0'::cstring)::timestamp with time zone)
                                  ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk m_3 (actual rows=48 loops=1)
                                        Filter: ("time" > ('2000-01-01 0:00:00+0'::cstring)::timestamp with time zone)
                                        ->  Seq Scan on compress_hyper_2_8_chunk compress_hyper_2_8_chunk_1 (actual rows=1 loops=1)
+                                             Filter: (_ts_meta_max_1 > ('2000-01-01 0:00:00+0'::cstring)::timestamp with time zone)
                                  ->  Custom Scan (DecompressChunk) on _hyper_1_4_chunk m_4 (actual rows=48 loops=1)
                                        Filter: ("time" > ('2000-01-01 0:00:00+0'::cstring)::timestamp with time zone)
                                        ->  Seq Scan on compress_hyper_2_9_chunk compress_hyper_2_9_chunk_1 (actual rows=1 loops=1)
+                                             Filter: (_ts_meta_max_1 > ('2000-01-01 0:00:00+0'::cstring)::timestamp with time zone)
                                  ->  Custom Scan (DecompressChunk) on _hyper_1_5_chunk m_5 (actual rows=5 loops=1)
                                        Filter: ("time" > ('2000-01-01 0:00:00+0'::cstring)::timestamp with time zone)
                                        ->  Seq Scan on compress_hyper_2_10_chunk compress_hyper_2_10_chunk_1 (actual rows=5 loops=1)
-(52 rows)
+                                             Filter: (_ts_meta_max_1 > ('2000-01-01 0:00:00+0'::cstring)::timestamp with time zone)
+(62 rows)
 
 --query with all chunks but 1 excluded at plan time --
 :PREFIX
@@ -918,8 +928,8 @@ WHERE m.device_id = d.device_id
     AND m.time > '2019-01-01'
     AND m.time < '2000-01-01 0:00:00+0'::text::timestamptz
 ORDER BY m.v0;
-                                                                               QUERY PLAN                                                                               
-------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                          QUERY PLAN                                                                                          
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Sort (actual rows=0 loops=1)
    Sort Key: m.v0
    Sort Method: quicksort 
@@ -927,12 +937,13 @@ ORDER BY m.v0;
          Hash Cond: (m.device_id = d.device_id)
          ->  Custom Scan (DecompressChunk) on _hyper_1_5_chunk m (actual rows=0 loops=1)
                Filter: (("time" > 'Tue Jan 01 00:00:00 2019 PST'::timestamp with time zone) AND ("time" < ('2000-01-01 0:00:00+0'::cstring)::timestamp with time zone))
-               Rows Removed by Filter: 5
-               ->  Seq Scan on compress_hyper_2_10_chunk (actual rows=5 loops=1)
-                     Filter: (_ts_meta_max_1 > 'Tue Jan 01 00:00:00 2019 PST'::timestamp with time zone)
-         ->  Hash (never executed)
-               ->  Seq Scan on device_tbl d (never executed)
-(12 rows)
+               ->  Seq Scan on compress_hyper_2_10_chunk (actual rows=0 loops=1)
+                     Filter: ((_ts_meta_max_1 > 'Tue Jan 01 00:00:00 2019 PST'::timestamp with time zone) AND (_ts_meta_min_1 < ('2000-01-01 0:00:00+0'::cstring)::timestamp with time zone))
+                     Rows Removed by Filter: 5
+         ->  Hash (actual rows=7 loops=1)
+               Buckets: 1024  Batches: 1 
+               ->  Seq Scan on device_tbl d (actual rows=7 loops=1)
+(13 rows)
 
 -- no matches in metrics_ordered_idx but one row in device_tbl
 :PREFIX
@@ -944,8 +955,8 @@ FROM device_tbl d
     AND m.time < '2000-01-01 0:00:00+0'::text::timestamptz
 WHERE d.device_id = 8
 ORDER BY m.v0;
-                                                                               QUERY PLAN                                                                               
-------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                                    QUERY PLAN                                                                                                    
+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Sort (actual rows=1 loops=1)
    Sort Key: m.v0
    Sort Method: quicksort 
@@ -957,7 +968,7 @@ ORDER BY m.v0;
          ->  Custom Scan (DecompressChunk) on _hyper_1_5_chunk m (actual rows=0 loops=1)
                Filter: (("time" > 'Tue Jan 01 00:00:00 2019 PST'::timestamp with time zone) AND ("time" < ('2000-01-01 0:00:00+0'::cstring)::timestamp with time zone))
                ->  Seq Scan on compress_hyper_2_10_chunk (actual rows=0 loops=1)
-                     Filter: ((_ts_meta_max_1 > 'Tue Jan 01 00:00:00 2019 PST'::timestamp with time zone) AND (device_id = 8))
+                     Filter: ((_ts_meta_max_1 > 'Tue Jan 01 00:00:00 2019 PST'::timestamp with time zone) AND (device_id = 8) AND (_ts_meta_min_1 < ('2000-01-01 0:00:00+0'::cstring)::timestamp with time zone))
                      Rows Removed by Filter: 5
 (13 rows)
 

--- a/tsl/test/expected/transparent_decompression_ordered_index-15.out
+++ b/tsl/test/expected/transparent_decompression_ordered_index-15.out
@@ -874,18 +874,23 @@ ORDER BY 1,
                                  ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk d_1 (actual rows=480 loops=1)
                                        Filter: ("time" > ('2000-01-01 0:00:00+0'::cstring)::timestamp with time zone)
                                        ->  Seq Scan on compress_hyper_2_6_chunk (actual rows=5 loops=1)
+                                             Filter: (_ts_meta_max_1 > ('2000-01-01 0:00:00+0'::cstring)::timestamp with time zone)
                                  ->  Custom Scan (DecompressChunk) on _hyper_1_2_chunk d_2 (actual rows=960 loops=1)
                                        Filter: ("time" > ('2000-01-01 0:00:00+0'::cstring)::timestamp with time zone)
                                        ->  Seq Scan on compress_hyper_2_7_chunk (actual rows=5 loops=1)
+                                             Filter: (_ts_meta_max_1 > ('2000-01-01 0:00:00+0'::cstring)::timestamp with time zone)
                                  ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk d_3 (actual rows=48 loops=1)
                                        Filter: ("time" > ('2000-01-01 0:00:00+0'::cstring)::timestamp with time zone)
                                        ->  Seq Scan on compress_hyper_2_8_chunk (actual rows=1 loops=1)
+                                             Filter: (_ts_meta_max_1 > ('2000-01-01 0:00:00+0'::cstring)::timestamp with time zone)
                                  ->  Custom Scan (DecompressChunk) on _hyper_1_4_chunk d_4 (actual rows=48 loops=1)
                                        Filter: ("time" > ('2000-01-01 0:00:00+0'::cstring)::timestamp with time zone)
                                        ->  Seq Scan on compress_hyper_2_9_chunk (actual rows=1 loops=1)
+                                             Filter: (_ts_meta_max_1 > ('2000-01-01 0:00:00+0'::cstring)::timestamp with time zone)
                                  ->  Custom Scan (DecompressChunk) on _hyper_1_5_chunk d_5 (actual rows=5 loops=1)
                                        Filter: ("time" > ('2000-01-01 0:00:00+0'::cstring)::timestamp with time zone)
                                        ->  Seq Scan on compress_hyper_2_10_chunk (actual rows=5 loops=1)
+                                             Filter: (_ts_meta_max_1 > ('2000-01-01 0:00:00+0'::cstring)::timestamp with time zone)
                ->  Sort (actual rows=7317 loops=1)
                      Sort Key: m."time"
                      Sort Method: quicksort 
@@ -896,19 +901,24 @@ ORDER BY 1,
                                  ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk m_1 (actual rows=480 loops=1)
                                        Filter: ("time" > ('2000-01-01 0:00:00+0'::cstring)::timestamp with time zone)
                                        ->  Seq Scan on compress_hyper_2_6_chunk compress_hyper_2_6_chunk_1 (actual rows=5 loops=1)
+                                             Filter: (_ts_meta_max_1 > ('2000-01-01 0:00:00+0'::cstring)::timestamp with time zone)
                                  ->  Custom Scan (DecompressChunk) on _hyper_1_2_chunk m_2 (actual rows=960 loops=1)
                                        Filter: ("time" > ('2000-01-01 0:00:00+0'::cstring)::timestamp with time zone)
                                        ->  Seq Scan on compress_hyper_2_7_chunk compress_hyper_2_7_chunk_1 (actual rows=5 loops=1)
+                                             Filter: (_ts_meta_max_1 > ('2000-01-01 0:00:00+0'::cstring)::timestamp with time zone)
                                  ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk m_3 (actual rows=48 loops=1)
                                        Filter: ("time" > ('2000-01-01 0:00:00+0'::cstring)::timestamp with time zone)
                                        ->  Seq Scan on compress_hyper_2_8_chunk compress_hyper_2_8_chunk_1 (actual rows=1 loops=1)
+                                             Filter: (_ts_meta_max_1 > ('2000-01-01 0:00:00+0'::cstring)::timestamp with time zone)
                                  ->  Custom Scan (DecompressChunk) on _hyper_1_4_chunk m_4 (actual rows=48 loops=1)
                                        Filter: ("time" > ('2000-01-01 0:00:00+0'::cstring)::timestamp with time zone)
                                        ->  Seq Scan on compress_hyper_2_9_chunk compress_hyper_2_9_chunk_1 (actual rows=1 loops=1)
+                                             Filter: (_ts_meta_max_1 > ('2000-01-01 0:00:00+0'::cstring)::timestamp with time zone)
                                  ->  Custom Scan (DecompressChunk) on _hyper_1_5_chunk m_5 (actual rows=5 loops=1)
                                        Filter: ("time" > ('2000-01-01 0:00:00+0'::cstring)::timestamp with time zone)
                                        ->  Seq Scan on compress_hyper_2_10_chunk compress_hyper_2_10_chunk_1 (actual rows=5 loops=1)
-(52 rows)
+                                             Filter: (_ts_meta_max_1 > ('2000-01-01 0:00:00+0'::cstring)::timestamp with time zone)
+(62 rows)
 
 --query with all chunks but 1 excluded at plan time --
 :PREFIX
@@ -920,8 +930,8 @@ WHERE m.device_id = d.device_id
     AND m.time > '2019-01-01'
     AND m.time < '2000-01-01 0:00:00+0'::text::timestamptz
 ORDER BY m.v0;
-                                                                               QUERY PLAN                                                                               
-------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                          QUERY PLAN                                                                                          
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Sort (actual rows=0 loops=1)
    Sort Key: m.v0
    Sort Method: quicksort 
@@ -929,12 +939,13 @@ ORDER BY m.v0;
          Hash Cond: (m.device_id = d.device_id)
          ->  Custom Scan (DecompressChunk) on _hyper_1_5_chunk m (actual rows=0 loops=1)
                Filter: (("time" > 'Tue Jan 01 00:00:00 2019 PST'::timestamp with time zone) AND ("time" < ('2000-01-01 0:00:00+0'::cstring)::timestamp with time zone))
-               Rows Removed by Filter: 5
-               ->  Seq Scan on compress_hyper_2_10_chunk (actual rows=5 loops=1)
-                     Filter: (_ts_meta_max_1 > 'Tue Jan 01 00:00:00 2019 PST'::timestamp with time zone)
-         ->  Hash (never executed)
-               ->  Seq Scan on device_tbl d (never executed)
-(12 rows)
+               ->  Seq Scan on compress_hyper_2_10_chunk (actual rows=0 loops=1)
+                     Filter: ((_ts_meta_max_1 > 'Tue Jan 01 00:00:00 2019 PST'::timestamp with time zone) AND (_ts_meta_min_1 < ('2000-01-01 0:00:00+0'::cstring)::timestamp with time zone))
+                     Rows Removed by Filter: 5
+         ->  Hash (actual rows=7 loops=1)
+               Buckets: 1024  Batches: 1 
+               ->  Seq Scan on device_tbl d (actual rows=7 loops=1)
+(13 rows)
 
 -- no matches in metrics_ordered_idx but one row in device_tbl
 :PREFIX
@@ -946,8 +957,8 @@ FROM device_tbl d
     AND m.time < '2000-01-01 0:00:00+0'::text::timestamptz
 WHERE d.device_id = 8
 ORDER BY m.v0;
-                                                                               QUERY PLAN                                                                               
-------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                                    QUERY PLAN                                                                                                    
+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Sort (actual rows=1 loops=1)
    Sort Key: m.v0
    Sort Method: quicksort 
@@ -959,7 +970,7 @@ ORDER BY m.v0;
          ->  Custom Scan (DecompressChunk) on _hyper_1_5_chunk m (actual rows=0 loops=1)
                Filter: (("time" > 'Tue Jan 01 00:00:00 2019 PST'::timestamp with time zone) AND ("time" < ('2000-01-01 0:00:00+0'::cstring)::timestamp with time zone))
                ->  Seq Scan on compress_hyper_2_10_chunk (actual rows=0 loops=1)
-                     Filter: ((_ts_meta_max_1 > 'Tue Jan 01 00:00:00 2019 PST'::timestamp with time zone) AND (device_id = 8))
+                     Filter: ((_ts_meta_max_1 > 'Tue Jan 01 00:00:00 2019 PST'::timestamp with time zone) AND (device_id = 8) AND (_ts_meta_min_1 < ('2000-01-01 0:00:00+0'::cstring)::timestamp with time zone))
                      Rows Removed by Filter: 5
 (13 rows)
 

--- a/tsl/test/shared/expected/constraint_exclusion_prepared.out
+++ b/tsl/test/shared/expected/constraint_exclusion_prepared.out
@@ -1587,11 +1587,13 @@ QUERY PLAN
                Filter: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
                ->  Index Scan Backward using compress_hyper_X_X_chunk__compressed_hypertable_4_device_id__t on compress_hyper_X_X_chunk (actual rows=1 loops=1)
                      Index Cond: (device_id = 1)
+                     Filter: (_ts_meta_min_1 < ('2000-01-10'::cstring)::timestamp with time zone)
          ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (never executed)
                Filter: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
                ->  Index Scan Backward using compress_hyper_X_X_chunk__compressed_hypertable_4_device_id__t on compress_hyper_X_X_chunk (never executed)
                      Index Cond: (device_id = 1)
-(12 rows)
+                     Filter: (_ts_meta_min_1 < ('2000-01-10'::cstring)::timestamp with time zone)
+(14 rows)
 
 :PREFIX EXECUTE prep;
 QUERY PLAN
@@ -1603,11 +1605,13 @@ QUERY PLAN
                Filter: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
                ->  Index Scan Backward using compress_hyper_X_X_chunk__compressed_hypertable_4_device_id__t on compress_hyper_X_X_chunk (actual rows=1 loops=1)
                      Index Cond: (device_id = 1)
+                     Filter: (_ts_meta_min_1 < ('2000-01-10'::cstring)::timestamp with time zone)
          ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (never executed)
                Filter: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
                ->  Index Scan Backward using compress_hyper_X_X_chunk__compressed_hypertable_4_device_id__t on compress_hyper_X_X_chunk (never executed)
                      Index Cond: (device_id = 1)
-(12 rows)
+                     Filter: (_ts_meta_min_1 < ('2000-01-10'::cstring)::timestamp with time zone)
+(14 rows)
 
 :PREFIX EXECUTE prep;
 QUERY PLAN
@@ -1619,11 +1623,13 @@ QUERY PLAN
                Filter: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
                ->  Index Scan Backward using compress_hyper_X_X_chunk__compressed_hypertable_4_device_id__t on compress_hyper_X_X_chunk (actual rows=1 loops=1)
                      Index Cond: (device_id = 1)
+                     Filter: (_ts_meta_min_1 < ('2000-01-10'::cstring)::timestamp with time zone)
          ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (never executed)
                Filter: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
                ->  Index Scan Backward using compress_hyper_X_X_chunk__compressed_hypertable_4_device_id__t on compress_hyper_X_X_chunk (never executed)
                      Index Cond: (device_id = 1)
-(12 rows)
+                     Filter: (_ts_meta_min_1 < ('2000-01-10'::cstring)::timestamp with time zone)
+(14 rows)
 
 :PREFIX EXECUTE prep;
 QUERY PLAN
@@ -1635,11 +1641,13 @@ QUERY PLAN
                Filter: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
                ->  Index Scan Backward using compress_hyper_X_X_chunk__compressed_hypertable_4_device_id__t on compress_hyper_X_X_chunk (actual rows=1 loops=1)
                      Index Cond: (device_id = 1)
+                     Filter: (_ts_meta_min_1 < ('2000-01-10'::cstring)::timestamp with time zone)
          ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (never executed)
                Filter: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
                ->  Index Scan Backward using compress_hyper_X_X_chunk__compressed_hypertable_4_device_id__t on compress_hyper_X_X_chunk (never executed)
                      Index Cond: (device_id = 1)
-(12 rows)
+                     Filter: (_ts_meta_min_1 < ('2000-01-10'::cstring)::timestamp with time zone)
+(14 rows)
 
 :PREFIX EXECUTE prep;
 QUERY PLAN
@@ -1651,11 +1659,13 @@ QUERY PLAN
                Filter: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
                ->  Index Scan Backward using compress_hyper_X_X_chunk__compressed_hypertable_4_device_id__t on compress_hyper_X_X_chunk (actual rows=1 loops=1)
                      Index Cond: (device_id = 1)
+                     Filter: (_ts_meta_min_1 < ('2000-01-10'::cstring)::timestamp with time zone)
          ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (never executed)
                Filter: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
                ->  Index Scan Backward using compress_hyper_X_X_chunk__compressed_hypertable_4_device_id__t on compress_hyper_X_X_chunk (never executed)
                      Index Cond: (device_id = 1)
-(12 rows)
+                     Filter: (_ts_meta_min_1 < ('2000-01-10'::cstring)::timestamp with time zone)
+(14 rows)
 
 DEALLOCATE prep;
 -- runtime exclusion with LATERAL and 2 hypertables
@@ -1864,11 +1874,14 @@ QUERY PLAN
                ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=17990 loops=1)
                      Filter: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
                      ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=20 loops=1)
+                           Filter: (_ts_meta_min_1 < ('2000-01-10'::cstring)::timestamp with time zone)
                ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=15600 loops=1)
                      Filter: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
-                     Rows Removed by Filter: 9590
-                     ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=30 loops=1)
-(13 rows)
+                     Rows Removed by Filter: 4590
+                     ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=25 loops=1)
+                           Filter: (_ts_meta_min_1 < ('2000-01-10'::cstring)::timestamp with time zone)
+                           Rows Removed by Filter: 5
+(16 rows)
 
 :PREFIX EXECUTE prep;
 QUERY PLAN
@@ -1881,11 +1894,14 @@ QUERY PLAN
                ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=17990 loops=1)
                      Filter: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
                      ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=20 loops=1)
+                           Filter: (_ts_meta_min_1 < ('2000-01-10'::cstring)::timestamp with time zone)
                ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=15600 loops=1)
                      Filter: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
-                     Rows Removed by Filter: 9590
-                     ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=30 loops=1)
-(13 rows)
+                     Rows Removed by Filter: 4590
+                     ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=25 loops=1)
+                           Filter: (_ts_meta_min_1 < ('2000-01-10'::cstring)::timestamp with time zone)
+                           Rows Removed by Filter: 5
+(16 rows)
 
 :PREFIX EXECUTE prep;
 QUERY PLAN
@@ -1898,11 +1914,14 @@ QUERY PLAN
                ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=17990 loops=1)
                      Filter: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
                      ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=20 loops=1)
+                           Filter: (_ts_meta_min_1 < ('2000-01-10'::cstring)::timestamp with time zone)
                ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=15600 loops=1)
                      Filter: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
-                     Rows Removed by Filter: 9590
-                     ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=30 loops=1)
-(13 rows)
+                     Rows Removed by Filter: 4590
+                     ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=25 loops=1)
+                           Filter: (_ts_meta_min_1 < ('2000-01-10'::cstring)::timestamp with time zone)
+                           Rows Removed by Filter: 5
+(16 rows)
 
 :PREFIX EXECUTE prep;
 QUERY PLAN
@@ -1915,11 +1934,14 @@ QUERY PLAN
                ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=17990 loops=1)
                      Filter: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
                      ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=20 loops=1)
+                           Filter: (_ts_meta_min_1 < ('2000-01-10'::cstring)::timestamp with time zone)
                ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=15600 loops=1)
                      Filter: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
-                     Rows Removed by Filter: 9590
-                     ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=30 loops=1)
-(13 rows)
+                     Rows Removed by Filter: 4590
+                     ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=25 loops=1)
+                           Filter: (_ts_meta_min_1 < ('2000-01-10'::cstring)::timestamp with time zone)
+                           Rows Removed by Filter: 5
+(16 rows)
 
 :PREFIX EXECUTE prep;
 QUERY PLAN
@@ -1932,11 +1954,14 @@ QUERY PLAN
                ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=17990 loops=1)
                      Filter: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
                      ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=20 loops=1)
+                           Filter: (_ts_meta_min_1 < ('2000-01-10'::cstring)::timestamp with time zone)
                ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=15600 loops=1)
                      Filter: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
-                     Rows Removed by Filter: 9590
-                     ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=30 loops=1)
-(13 rows)
+                     Rows Removed by Filter: 4590
+                     ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=25 loops=1)
+                           Filter: (_ts_meta_min_1 < ('2000-01-10'::cstring)::timestamp with time zone)
+                           Rows Removed by Filter: 5
+(16 rows)
 
 DEALLOCATE prep;
 -- test constraint exclusion for subqueries with ConstraintAwareAppend
@@ -1966,13 +1991,16 @@ QUERY PLAN
                            Sort Key: compress_hyper_X_X_chunk.device_id, compress_hyper_X_X_chunk._ts_meta_sequence_num DESC
                            Sort Method: quicksort 
                            ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=20 loops=1)
+                                 Filter: (_ts_meta_min_1 < ('2000-01-10'::cstring)::timestamp with time zone)
                ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=1 loops=1)
                      Filter: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
                      ->  Sort (actual rows=1 loops=1)
                            Sort Key: compress_hyper_X_X_chunk.device_id, compress_hyper_X_X_chunk._ts_meta_sequence_num DESC
                            Sort Method: quicksort 
-                           ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=30 loops=1)
-(18 rows)
+                           ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=25 loops=1)
+                                 Filter: (_ts_meta_min_1 < ('2000-01-10'::cstring)::timestamp with time zone)
+                                 Rows Removed by Filter: 5
+(21 rows)
 
 :PREFIX EXECUTE prep;
 QUERY PLAN
@@ -1988,13 +2016,16 @@ QUERY PLAN
                            Sort Key: compress_hyper_X_X_chunk.device_id, compress_hyper_X_X_chunk._ts_meta_sequence_num DESC
                            Sort Method: quicksort 
                            ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=20 loops=1)
+                                 Filter: (_ts_meta_min_1 < ('2000-01-10'::cstring)::timestamp with time zone)
                ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=1 loops=1)
                      Filter: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
                      ->  Sort (actual rows=1 loops=1)
                            Sort Key: compress_hyper_X_X_chunk.device_id, compress_hyper_X_X_chunk._ts_meta_sequence_num DESC
                            Sort Method: quicksort 
-                           ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=30 loops=1)
-(18 rows)
+                           ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=25 loops=1)
+                                 Filter: (_ts_meta_min_1 < ('2000-01-10'::cstring)::timestamp with time zone)
+                                 Rows Removed by Filter: 5
+(21 rows)
 
 :PREFIX EXECUTE prep;
 QUERY PLAN
@@ -2010,13 +2041,16 @@ QUERY PLAN
                            Sort Key: compress_hyper_X_X_chunk.device_id, compress_hyper_X_X_chunk._ts_meta_sequence_num DESC
                            Sort Method: quicksort 
                            ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=20 loops=1)
+                                 Filter: (_ts_meta_min_1 < ('2000-01-10'::cstring)::timestamp with time zone)
                ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=1 loops=1)
                      Filter: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
                      ->  Sort (actual rows=1 loops=1)
                            Sort Key: compress_hyper_X_X_chunk.device_id, compress_hyper_X_X_chunk._ts_meta_sequence_num DESC
                            Sort Method: quicksort 
-                           ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=30 loops=1)
-(18 rows)
+                           ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=25 loops=1)
+                                 Filter: (_ts_meta_min_1 < ('2000-01-10'::cstring)::timestamp with time zone)
+                                 Rows Removed by Filter: 5
+(21 rows)
 
 :PREFIX EXECUTE prep;
 QUERY PLAN
@@ -2032,13 +2066,16 @@ QUERY PLAN
                            Sort Key: compress_hyper_X_X_chunk.device_id, compress_hyper_X_X_chunk._ts_meta_sequence_num DESC
                            Sort Method: quicksort 
                            ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=20 loops=1)
+                                 Filter: (_ts_meta_min_1 < ('2000-01-10'::cstring)::timestamp with time zone)
                ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=1 loops=1)
                      Filter: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
                      ->  Sort (actual rows=1 loops=1)
                            Sort Key: compress_hyper_X_X_chunk.device_id, compress_hyper_X_X_chunk._ts_meta_sequence_num DESC
                            Sort Method: quicksort 
-                           ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=30 loops=1)
-(18 rows)
+                           ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=25 loops=1)
+                                 Filter: (_ts_meta_min_1 < ('2000-01-10'::cstring)::timestamp with time zone)
+                                 Rows Removed by Filter: 5
+(21 rows)
 
 :PREFIX EXECUTE prep;
 QUERY PLAN
@@ -2054,13 +2091,16 @@ QUERY PLAN
                            Sort Key: compress_hyper_X_X_chunk.device_id, compress_hyper_X_X_chunk._ts_meta_sequence_num DESC
                            Sort Method: quicksort 
                            ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=20 loops=1)
+                                 Filter: (_ts_meta_min_1 < ('2000-01-10'::cstring)::timestamp with time zone)
                ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=1 loops=1)
                      Filter: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
                      ->  Sort (actual rows=1 loops=1)
                            Sort Key: compress_hyper_X_X_chunk.device_id, compress_hyper_X_X_chunk._ts_meta_sequence_num DESC
                            Sort Method: quicksort 
-                           ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=30 loops=1)
-(18 rows)
+                           ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=25 loops=1)
+                                 Filter: (_ts_meta_min_1 < ('2000-01-10'::cstring)::timestamp with time zone)
+                                 Rows Removed by Filter: 5
+(21 rows)
 
 DEALLOCATE prep;
 RESET timescaledb.enable_chunk_append;
@@ -2297,13 +2337,13 @@ QUERY PLAN
                      Sort Key: compress_hyper_X_X_chunk._ts_meta_sequence_num DESC
                      Sort Method: quicksort 
                      ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=4 loops=1)
-                           Filter: (device_id = 1)
+                           Filter: ((device_id = 1) AND (_ts_meta_min_1 < ('2000-01-10'::cstring)::timestamp with time zone))
          ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (never executed)
                Filter: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
                ->  Sort (never executed)
                      Sort Key: compress_hyper_X_X_chunk._ts_meta_sequence_num DESC
                      ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
-                           Filter: (device_id = 1)
+                           Filter: ((device_id = 1) AND (_ts_meta_min_1 < ('2000-01-10'::cstring)::timestamp with time zone))
 (17 rows)
 
 :PREFIX EXECUTE prep;
@@ -2318,13 +2358,13 @@ QUERY PLAN
                      Sort Key: compress_hyper_X_X_chunk._ts_meta_sequence_num DESC
                      Sort Method: quicksort 
                      ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=4 loops=1)
-                           Filter: (device_id = 1)
+                           Filter: ((device_id = 1) AND (_ts_meta_min_1 < ('2000-01-10'::cstring)::timestamp with time zone))
          ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (never executed)
                Filter: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
                ->  Sort (never executed)
                      Sort Key: compress_hyper_X_X_chunk._ts_meta_sequence_num DESC
                      ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
-                           Filter: (device_id = 1)
+                           Filter: ((device_id = 1) AND (_ts_meta_min_1 < ('2000-01-10'::cstring)::timestamp with time zone))
 (17 rows)
 
 :PREFIX EXECUTE prep;
@@ -2339,13 +2379,13 @@ QUERY PLAN
                      Sort Key: compress_hyper_X_X_chunk._ts_meta_sequence_num DESC
                      Sort Method: quicksort 
                      ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=4 loops=1)
-                           Filter: (device_id = 1)
+                           Filter: ((device_id = 1) AND (_ts_meta_min_1 < ('2000-01-10'::cstring)::timestamp with time zone))
          ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (never executed)
                Filter: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
                ->  Sort (never executed)
                      Sort Key: compress_hyper_X_X_chunk._ts_meta_sequence_num DESC
                      ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
-                           Filter: (device_id = 1)
+                           Filter: ((device_id = 1) AND (_ts_meta_min_1 < ('2000-01-10'::cstring)::timestamp with time zone))
 (17 rows)
 
 :PREFIX EXECUTE prep;
@@ -2360,13 +2400,13 @@ QUERY PLAN
                      Sort Key: compress_hyper_X_X_chunk._ts_meta_sequence_num DESC
                      Sort Method: quicksort 
                      ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=4 loops=1)
-                           Filter: (device_id = 1)
+                           Filter: ((device_id = 1) AND (_ts_meta_min_1 < ('2000-01-10'::cstring)::timestamp with time zone))
          ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (never executed)
                Filter: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
                ->  Sort (never executed)
                      Sort Key: compress_hyper_X_X_chunk._ts_meta_sequence_num DESC
                      ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
-                           Filter: (device_id = 1)
+                           Filter: ((device_id = 1) AND (_ts_meta_min_1 < ('2000-01-10'::cstring)::timestamp with time zone))
 (17 rows)
 
 :PREFIX EXECUTE prep;
@@ -2381,13 +2421,13 @@ QUERY PLAN
                      Sort Key: compress_hyper_X_X_chunk._ts_meta_sequence_num DESC
                      Sort Method: quicksort 
                      ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=4 loops=1)
-                           Filter: (device_id = 1)
+                           Filter: ((device_id = 1) AND (_ts_meta_min_1 < ('2000-01-10'::cstring)::timestamp with time zone))
          ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (never executed)
                Filter: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
                ->  Sort (never executed)
                      Sort Key: compress_hyper_X_X_chunk._ts_meta_sequence_num DESC
                      ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
-                           Filter: (device_id = 1)
+                           Filter: ((device_id = 1) AND (_ts_meta_min_1 < ('2000-01-10'::cstring)::timestamp with time zone))
 (17 rows)
 
 DEALLOCATE prep;
@@ -2717,39 +2757,51 @@ QUERY PLAN
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=3598 loops=1)
                            Filter: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
                            ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=4 loops=1)
+                                 Filter: (_ts_meta_min_1 < ('2000-01-10'::cstring)::timestamp with time zone)
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=10794 loops=1)
                            Filter: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
                            ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=12 loops=1)
+                                 Filter: (_ts_meta_min_1 < ('2000-01-10'::cstring)::timestamp with time zone)
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=3598 loops=1)
                            Filter: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
                            ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=4 loops=1)
+                                 Filter: (_ts_meta_min_1 < ('2000-01-10'::cstring)::timestamp with time zone)
                ->  Merge Append (actual rows=15600 loops=1)
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=3120 loops=1)
                            Filter: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
-                           Rows Removed by Filter: 1918
-                           ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=6 loops=1)
+                           Rows Removed by Filter: 918
+                           ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=5 loops=1)
+                                 Filter: (_ts_meta_min_1 < ('2000-01-10'::cstring)::timestamp with time zone)
+                                 Rows Removed by Filter: 1
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=9360 loops=1)
                            Filter: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
-                           Rows Removed by Filter: 5754
-                           ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=18 loops=1)
+                           Rows Removed by Filter: 2754
+                           ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=15 loops=1)
+                                 Filter: (_ts_meta_min_1 < ('2000-01-10'::cstring)::timestamp with time zone)
+                                 Rows Removed by Filter: 3
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=3120 loops=1)
                            Filter: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
-                           Rows Removed by Filter: 1918
-                           ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=6 loops=1)
+                           Rows Removed by Filter: 918
+                           ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=5 loops=1)
+                                 Filter: (_ts_meta_min_1 < ('2000-01-10'::cstring)::timestamp with time zone)
+                                 Rows Removed by Filter: 1
                ->  Merge Append (actual rows=0 loops=1)
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=0 loops=1)
                            Filter: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
-                           Rows Removed by Filter: 5038
-                           ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=6 loops=1)
+                           ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=0 loops=1)
+                                 Filter: (_ts_meta_min_1 < ('2000-01-10'::cstring)::timestamp with time zone)
+                                 Rows Removed by Filter: 6
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=0 loops=1)
                            Filter: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
-                           Rows Removed by Filter: 15114
-                           ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=18 loops=1)
+                           ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=0 loops=1)
+                                 Filter: (_ts_meta_min_1 < ('2000-01-10'::cstring)::timestamp with time zone)
+                                 Rows Removed by Filter: 18
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=0 loops=1)
                            Filter: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
-                           Rows Removed by Filter: 5038
-                           ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=6 loops=1)
-(41 rows)
+                           ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=0 loops=1)
+                                 Filter: (_ts_meta_min_1 < ('2000-01-10'::cstring)::timestamp with time zone)
+                                 Rows Removed by Filter: 6
+(53 rows)
 
 :PREFIX EXECUTE prep;
 QUERY PLAN
@@ -2762,39 +2814,51 @@ QUERY PLAN
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=3598 loops=1)
                            Filter: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
                            ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=4 loops=1)
+                                 Filter: (_ts_meta_min_1 < ('2000-01-10'::cstring)::timestamp with time zone)
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=10794 loops=1)
                            Filter: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
                            ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=12 loops=1)
+                                 Filter: (_ts_meta_min_1 < ('2000-01-10'::cstring)::timestamp with time zone)
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=3598 loops=1)
                            Filter: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
                            ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=4 loops=1)
+                                 Filter: (_ts_meta_min_1 < ('2000-01-10'::cstring)::timestamp with time zone)
                ->  Merge Append (actual rows=15600 loops=1)
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=3120 loops=1)
                            Filter: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
-                           Rows Removed by Filter: 1918
-                           ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=6 loops=1)
+                           Rows Removed by Filter: 918
+                           ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=5 loops=1)
+                                 Filter: (_ts_meta_min_1 < ('2000-01-10'::cstring)::timestamp with time zone)
+                                 Rows Removed by Filter: 1
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=9360 loops=1)
                            Filter: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
-                           Rows Removed by Filter: 5754
-                           ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=18 loops=1)
+                           Rows Removed by Filter: 2754
+                           ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=15 loops=1)
+                                 Filter: (_ts_meta_min_1 < ('2000-01-10'::cstring)::timestamp with time zone)
+                                 Rows Removed by Filter: 3
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=3120 loops=1)
                            Filter: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
-                           Rows Removed by Filter: 1918
-                           ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=6 loops=1)
+                           Rows Removed by Filter: 918
+                           ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=5 loops=1)
+                                 Filter: (_ts_meta_min_1 < ('2000-01-10'::cstring)::timestamp with time zone)
+                                 Rows Removed by Filter: 1
                ->  Merge Append (actual rows=0 loops=1)
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=0 loops=1)
                            Filter: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
-                           Rows Removed by Filter: 5038
-                           ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=6 loops=1)
+                           ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=0 loops=1)
+                                 Filter: (_ts_meta_min_1 < ('2000-01-10'::cstring)::timestamp with time zone)
+                                 Rows Removed by Filter: 6
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=0 loops=1)
                            Filter: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
-                           Rows Removed by Filter: 15114
-                           ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=18 loops=1)
+                           ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=0 loops=1)
+                                 Filter: (_ts_meta_min_1 < ('2000-01-10'::cstring)::timestamp with time zone)
+                                 Rows Removed by Filter: 18
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=0 loops=1)
                            Filter: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
-                           Rows Removed by Filter: 5038
-                           ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=6 loops=1)
-(41 rows)
+                           ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=0 loops=1)
+                                 Filter: (_ts_meta_min_1 < ('2000-01-10'::cstring)::timestamp with time zone)
+                                 Rows Removed by Filter: 6
+(53 rows)
 
 :PREFIX EXECUTE prep;
 QUERY PLAN
@@ -2807,39 +2871,51 @@ QUERY PLAN
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=3598 loops=1)
                            Filter: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
                            ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=4 loops=1)
+                                 Filter: (_ts_meta_min_1 < ('2000-01-10'::cstring)::timestamp with time zone)
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=10794 loops=1)
                            Filter: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
                            ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=12 loops=1)
+                                 Filter: (_ts_meta_min_1 < ('2000-01-10'::cstring)::timestamp with time zone)
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=3598 loops=1)
                            Filter: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
                            ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=4 loops=1)
+                                 Filter: (_ts_meta_min_1 < ('2000-01-10'::cstring)::timestamp with time zone)
                ->  Merge Append (actual rows=15600 loops=1)
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=3120 loops=1)
                            Filter: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
-                           Rows Removed by Filter: 1918
-                           ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=6 loops=1)
+                           Rows Removed by Filter: 918
+                           ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=5 loops=1)
+                                 Filter: (_ts_meta_min_1 < ('2000-01-10'::cstring)::timestamp with time zone)
+                                 Rows Removed by Filter: 1
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=9360 loops=1)
                            Filter: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
-                           Rows Removed by Filter: 5754
-                           ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=18 loops=1)
+                           Rows Removed by Filter: 2754
+                           ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=15 loops=1)
+                                 Filter: (_ts_meta_min_1 < ('2000-01-10'::cstring)::timestamp with time zone)
+                                 Rows Removed by Filter: 3
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=3120 loops=1)
                            Filter: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
-                           Rows Removed by Filter: 1918
-                           ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=6 loops=1)
+                           Rows Removed by Filter: 918
+                           ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=5 loops=1)
+                                 Filter: (_ts_meta_min_1 < ('2000-01-10'::cstring)::timestamp with time zone)
+                                 Rows Removed by Filter: 1
                ->  Merge Append (actual rows=0 loops=1)
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=0 loops=1)
                            Filter: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
-                           Rows Removed by Filter: 5038
-                           ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=6 loops=1)
+                           ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=0 loops=1)
+                                 Filter: (_ts_meta_min_1 < ('2000-01-10'::cstring)::timestamp with time zone)
+                                 Rows Removed by Filter: 6
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=0 loops=1)
                            Filter: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
-                           Rows Removed by Filter: 15114
-                           ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=18 loops=1)
+                           ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=0 loops=1)
+                                 Filter: (_ts_meta_min_1 < ('2000-01-10'::cstring)::timestamp with time zone)
+                                 Rows Removed by Filter: 18
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=0 loops=1)
                            Filter: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
-                           Rows Removed by Filter: 5038
-                           ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=6 loops=1)
-(41 rows)
+                           ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=0 loops=1)
+                                 Filter: (_ts_meta_min_1 < ('2000-01-10'::cstring)::timestamp with time zone)
+                                 Rows Removed by Filter: 6
+(53 rows)
 
 :PREFIX EXECUTE prep;
 QUERY PLAN
@@ -2852,39 +2928,51 @@ QUERY PLAN
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=3598 loops=1)
                            Filter: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
                            ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=4 loops=1)
+                                 Filter: (_ts_meta_min_1 < ('2000-01-10'::cstring)::timestamp with time zone)
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=10794 loops=1)
                            Filter: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
                            ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=12 loops=1)
+                                 Filter: (_ts_meta_min_1 < ('2000-01-10'::cstring)::timestamp with time zone)
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=3598 loops=1)
                            Filter: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
                            ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=4 loops=1)
+                                 Filter: (_ts_meta_min_1 < ('2000-01-10'::cstring)::timestamp with time zone)
                ->  Merge Append (actual rows=15600 loops=1)
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=3120 loops=1)
                            Filter: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
-                           Rows Removed by Filter: 1918
-                           ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=6 loops=1)
+                           Rows Removed by Filter: 918
+                           ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=5 loops=1)
+                                 Filter: (_ts_meta_min_1 < ('2000-01-10'::cstring)::timestamp with time zone)
+                                 Rows Removed by Filter: 1
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=9360 loops=1)
                            Filter: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
-                           Rows Removed by Filter: 5754
-                           ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=18 loops=1)
+                           Rows Removed by Filter: 2754
+                           ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=15 loops=1)
+                                 Filter: (_ts_meta_min_1 < ('2000-01-10'::cstring)::timestamp with time zone)
+                                 Rows Removed by Filter: 3
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=3120 loops=1)
                            Filter: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
-                           Rows Removed by Filter: 1918
-                           ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=6 loops=1)
+                           Rows Removed by Filter: 918
+                           ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=5 loops=1)
+                                 Filter: (_ts_meta_min_1 < ('2000-01-10'::cstring)::timestamp with time zone)
+                                 Rows Removed by Filter: 1
                ->  Merge Append (actual rows=0 loops=1)
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=0 loops=1)
                            Filter: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
-                           Rows Removed by Filter: 5038
-                           ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=6 loops=1)
+                           ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=0 loops=1)
+                                 Filter: (_ts_meta_min_1 < ('2000-01-10'::cstring)::timestamp with time zone)
+                                 Rows Removed by Filter: 6
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=0 loops=1)
                            Filter: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
-                           Rows Removed by Filter: 15114
-                           ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=18 loops=1)
+                           ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=0 loops=1)
+                                 Filter: (_ts_meta_min_1 < ('2000-01-10'::cstring)::timestamp with time zone)
+                                 Rows Removed by Filter: 18
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=0 loops=1)
                            Filter: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
-                           Rows Removed by Filter: 5038
-                           ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=6 loops=1)
-(41 rows)
+                           ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=0 loops=1)
+                                 Filter: (_ts_meta_min_1 < ('2000-01-10'::cstring)::timestamp with time zone)
+                                 Rows Removed by Filter: 6
+(53 rows)
 
 :PREFIX EXECUTE prep;
 QUERY PLAN
@@ -2897,39 +2985,51 @@ QUERY PLAN
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=3598 loops=1)
                            Filter: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
                            ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=4 loops=1)
+                                 Filter: (_ts_meta_min_1 < ('2000-01-10'::cstring)::timestamp with time zone)
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=10794 loops=1)
                            Filter: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
                            ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=12 loops=1)
+                                 Filter: (_ts_meta_min_1 < ('2000-01-10'::cstring)::timestamp with time zone)
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=3598 loops=1)
                            Filter: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
                            ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=4 loops=1)
+                                 Filter: (_ts_meta_min_1 < ('2000-01-10'::cstring)::timestamp with time zone)
                ->  Merge Append (actual rows=15600 loops=1)
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=3120 loops=1)
                            Filter: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
-                           Rows Removed by Filter: 1918
-                           ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=6 loops=1)
+                           Rows Removed by Filter: 918
+                           ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=5 loops=1)
+                                 Filter: (_ts_meta_min_1 < ('2000-01-10'::cstring)::timestamp with time zone)
+                                 Rows Removed by Filter: 1
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=9360 loops=1)
                            Filter: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
-                           Rows Removed by Filter: 5754
-                           ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=18 loops=1)
+                           Rows Removed by Filter: 2754
+                           ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=15 loops=1)
+                                 Filter: (_ts_meta_min_1 < ('2000-01-10'::cstring)::timestamp with time zone)
+                                 Rows Removed by Filter: 3
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=3120 loops=1)
                            Filter: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
-                           Rows Removed by Filter: 1918
-                           ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=6 loops=1)
+                           Rows Removed by Filter: 918
+                           ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=5 loops=1)
+                                 Filter: (_ts_meta_min_1 < ('2000-01-10'::cstring)::timestamp with time zone)
+                                 Rows Removed by Filter: 1
                ->  Merge Append (actual rows=0 loops=1)
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=0 loops=1)
                            Filter: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
-                           Rows Removed by Filter: 5038
-                           ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=6 loops=1)
+                           ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=0 loops=1)
+                                 Filter: (_ts_meta_min_1 < ('2000-01-10'::cstring)::timestamp with time zone)
+                                 Rows Removed by Filter: 6
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=0 loops=1)
                            Filter: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
-                           Rows Removed by Filter: 15114
-                           ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=18 loops=1)
+                           ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=0 loops=1)
+                                 Filter: (_ts_meta_min_1 < ('2000-01-10'::cstring)::timestamp with time zone)
+                                 Rows Removed by Filter: 18
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=0 loops=1)
                            Filter: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
-                           Rows Removed by Filter: 5038
-                           ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=6 loops=1)
-(41 rows)
+                           ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=0 loops=1)
+                                 Filter: (_ts_meta_min_1 < ('2000-01-10'::cstring)::timestamp with time zone)
+                                 Rows Removed by Filter: 6
+(53 rows)
 
 DEALLOCATE prep;
 -- test constraint exclusion for subqueries with ConstraintAwareAppend
@@ -2959,37 +3059,46 @@ QUERY PLAN
                            Sort Key: compress_hyper_X_X_chunk.device_id, compress_hyper_X_X_chunk._ts_meta_sequence_num DESC
                            Sort Method: quicksort 
                            ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=4 loops=1)
+                                 Filter: (_ts_meta_min_1 < ('2000-01-10'::cstring)::timestamp with time zone)
                ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=1 loops=1)
                      Filter: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
                      ->  Sort (actual rows=1 loops=1)
                            Sort Key: compress_hyper_X_X_chunk.device_id, compress_hyper_X_X_chunk._ts_meta_sequence_num DESC
                            Sort Method: quicksort 
                            ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=12 loops=1)
+                                 Filter: (_ts_meta_min_1 < ('2000-01-10'::cstring)::timestamp with time zone)
                ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=1 loops=1)
                      Filter: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
                      ->  Sort (actual rows=1 loops=1)
                            Sort Key: compress_hyper_X_X_chunk.device_id, compress_hyper_X_X_chunk._ts_meta_sequence_num DESC
                            Sort Method: quicksort 
                            ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=4 loops=1)
+                                 Filter: (_ts_meta_min_1 < ('2000-01-10'::cstring)::timestamp with time zone)
                ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=1 loops=1)
                      Filter: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
                      ->  Sort (actual rows=1 loops=1)
                            Sort Key: compress_hyper_X_X_chunk.device_id, compress_hyper_X_X_chunk._ts_meta_sequence_num DESC
                            Sort Method: quicksort 
-                           ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=6 loops=1)
+                           ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=5 loops=1)
+                                 Filter: (_ts_meta_min_1 < ('2000-01-10'::cstring)::timestamp with time zone)
+                                 Rows Removed by Filter: 1
                ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=1 loops=1)
                      Filter: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
                      ->  Sort (actual rows=1 loops=1)
                            Sort Key: compress_hyper_X_X_chunk.device_id, compress_hyper_X_X_chunk._ts_meta_sequence_num DESC
                            Sort Method: quicksort 
-                           ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=18 loops=1)
+                           ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=15 loops=1)
+                                 Filter: (_ts_meta_min_1 < ('2000-01-10'::cstring)::timestamp with time zone)
+                                 Rows Removed by Filter: 3
                ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=1 loops=1)
                      Filter: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
                      ->  Sort (actual rows=1 loops=1)
                            Sort Key: compress_hyper_X_X_chunk.device_id, compress_hyper_X_X_chunk._ts_meta_sequence_num DESC
                            Sort Method: quicksort 
-                           ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=6 loops=1)
-(42 rows)
+                           ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=5 loops=1)
+                                 Filter: (_ts_meta_min_1 < ('2000-01-10'::cstring)::timestamp with time zone)
+                                 Rows Removed by Filter: 1
+(51 rows)
 
 :PREFIX EXECUTE prep;
 QUERY PLAN
@@ -3005,37 +3114,46 @@ QUERY PLAN
                            Sort Key: compress_hyper_X_X_chunk.device_id, compress_hyper_X_X_chunk._ts_meta_sequence_num DESC
                            Sort Method: quicksort 
                            ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=4 loops=1)
+                                 Filter: (_ts_meta_min_1 < ('2000-01-10'::cstring)::timestamp with time zone)
                ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=1 loops=1)
                      Filter: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
                      ->  Sort (actual rows=1 loops=1)
                            Sort Key: compress_hyper_X_X_chunk.device_id, compress_hyper_X_X_chunk._ts_meta_sequence_num DESC
                            Sort Method: quicksort 
                            ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=12 loops=1)
+                                 Filter: (_ts_meta_min_1 < ('2000-01-10'::cstring)::timestamp with time zone)
                ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=1 loops=1)
                      Filter: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
                      ->  Sort (actual rows=1 loops=1)
                            Sort Key: compress_hyper_X_X_chunk.device_id, compress_hyper_X_X_chunk._ts_meta_sequence_num DESC
                            Sort Method: quicksort 
                            ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=4 loops=1)
+                                 Filter: (_ts_meta_min_1 < ('2000-01-10'::cstring)::timestamp with time zone)
                ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=1 loops=1)
                      Filter: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
                      ->  Sort (actual rows=1 loops=1)
                            Sort Key: compress_hyper_X_X_chunk.device_id, compress_hyper_X_X_chunk._ts_meta_sequence_num DESC
                            Sort Method: quicksort 
-                           ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=6 loops=1)
+                           ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=5 loops=1)
+                                 Filter: (_ts_meta_min_1 < ('2000-01-10'::cstring)::timestamp with time zone)
+                                 Rows Removed by Filter: 1
                ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=1 loops=1)
                      Filter: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
                      ->  Sort (actual rows=1 loops=1)
                            Sort Key: compress_hyper_X_X_chunk.device_id, compress_hyper_X_X_chunk._ts_meta_sequence_num DESC
                            Sort Method: quicksort 
-                           ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=18 loops=1)
+                           ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=15 loops=1)
+                                 Filter: (_ts_meta_min_1 < ('2000-01-10'::cstring)::timestamp with time zone)
+                                 Rows Removed by Filter: 3
                ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=1 loops=1)
                      Filter: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
                      ->  Sort (actual rows=1 loops=1)
                            Sort Key: compress_hyper_X_X_chunk.device_id, compress_hyper_X_X_chunk._ts_meta_sequence_num DESC
                            Sort Method: quicksort 
-                           ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=6 loops=1)
-(42 rows)
+                           ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=5 loops=1)
+                                 Filter: (_ts_meta_min_1 < ('2000-01-10'::cstring)::timestamp with time zone)
+                                 Rows Removed by Filter: 1
+(51 rows)
 
 :PREFIX EXECUTE prep;
 QUERY PLAN
@@ -3051,37 +3169,46 @@ QUERY PLAN
                            Sort Key: compress_hyper_X_X_chunk.device_id, compress_hyper_X_X_chunk._ts_meta_sequence_num DESC
                            Sort Method: quicksort 
                            ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=4 loops=1)
+                                 Filter: (_ts_meta_min_1 < ('2000-01-10'::cstring)::timestamp with time zone)
                ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=1 loops=1)
                      Filter: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
                      ->  Sort (actual rows=1 loops=1)
                            Sort Key: compress_hyper_X_X_chunk.device_id, compress_hyper_X_X_chunk._ts_meta_sequence_num DESC
                            Sort Method: quicksort 
                            ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=12 loops=1)
+                                 Filter: (_ts_meta_min_1 < ('2000-01-10'::cstring)::timestamp with time zone)
                ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=1 loops=1)
                      Filter: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
                      ->  Sort (actual rows=1 loops=1)
                            Sort Key: compress_hyper_X_X_chunk.device_id, compress_hyper_X_X_chunk._ts_meta_sequence_num DESC
                            Sort Method: quicksort 
                            ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=4 loops=1)
+                                 Filter: (_ts_meta_min_1 < ('2000-01-10'::cstring)::timestamp with time zone)
                ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=1 loops=1)
                      Filter: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
                      ->  Sort (actual rows=1 loops=1)
                            Sort Key: compress_hyper_X_X_chunk.device_id, compress_hyper_X_X_chunk._ts_meta_sequence_num DESC
                            Sort Method: quicksort 
-                           ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=6 loops=1)
+                           ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=5 loops=1)
+                                 Filter: (_ts_meta_min_1 < ('2000-01-10'::cstring)::timestamp with time zone)
+                                 Rows Removed by Filter: 1
                ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=1 loops=1)
                      Filter: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
                      ->  Sort (actual rows=1 loops=1)
                            Sort Key: compress_hyper_X_X_chunk.device_id, compress_hyper_X_X_chunk._ts_meta_sequence_num DESC
                            Sort Method: quicksort 
-                           ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=18 loops=1)
+                           ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=15 loops=1)
+                                 Filter: (_ts_meta_min_1 < ('2000-01-10'::cstring)::timestamp with time zone)
+                                 Rows Removed by Filter: 3
                ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=1 loops=1)
                      Filter: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
                      ->  Sort (actual rows=1 loops=1)
                            Sort Key: compress_hyper_X_X_chunk.device_id, compress_hyper_X_X_chunk._ts_meta_sequence_num DESC
                            Sort Method: quicksort 
-                           ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=6 loops=1)
-(42 rows)
+                           ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=5 loops=1)
+                                 Filter: (_ts_meta_min_1 < ('2000-01-10'::cstring)::timestamp with time zone)
+                                 Rows Removed by Filter: 1
+(51 rows)
 
 :PREFIX EXECUTE prep;
 QUERY PLAN
@@ -3097,37 +3224,46 @@ QUERY PLAN
                            Sort Key: compress_hyper_X_X_chunk.device_id, compress_hyper_X_X_chunk._ts_meta_sequence_num DESC
                            Sort Method: quicksort 
                            ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=4 loops=1)
+                                 Filter: (_ts_meta_min_1 < ('2000-01-10'::cstring)::timestamp with time zone)
                ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=1 loops=1)
                      Filter: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
                      ->  Sort (actual rows=1 loops=1)
                            Sort Key: compress_hyper_X_X_chunk.device_id, compress_hyper_X_X_chunk._ts_meta_sequence_num DESC
                            Sort Method: quicksort 
                            ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=12 loops=1)
+                                 Filter: (_ts_meta_min_1 < ('2000-01-10'::cstring)::timestamp with time zone)
                ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=1 loops=1)
                      Filter: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
                      ->  Sort (actual rows=1 loops=1)
                            Sort Key: compress_hyper_X_X_chunk.device_id, compress_hyper_X_X_chunk._ts_meta_sequence_num DESC
                            Sort Method: quicksort 
                            ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=4 loops=1)
+                                 Filter: (_ts_meta_min_1 < ('2000-01-10'::cstring)::timestamp with time zone)
                ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=1 loops=1)
                      Filter: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
                      ->  Sort (actual rows=1 loops=1)
                            Sort Key: compress_hyper_X_X_chunk.device_id, compress_hyper_X_X_chunk._ts_meta_sequence_num DESC
                            Sort Method: quicksort 
-                           ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=6 loops=1)
+                           ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=5 loops=1)
+                                 Filter: (_ts_meta_min_1 < ('2000-01-10'::cstring)::timestamp with time zone)
+                                 Rows Removed by Filter: 1
                ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=1 loops=1)
                      Filter: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
                      ->  Sort (actual rows=1 loops=1)
                            Sort Key: compress_hyper_X_X_chunk.device_id, compress_hyper_X_X_chunk._ts_meta_sequence_num DESC
                            Sort Method: quicksort 
-                           ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=18 loops=1)
+                           ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=15 loops=1)
+                                 Filter: (_ts_meta_min_1 < ('2000-01-10'::cstring)::timestamp with time zone)
+                                 Rows Removed by Filter: 3
                ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=1 loops=1)
                      Filter: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
                      ->  Sort (actual rows=1 loops=1)
                            Sort Key: compress_hyper_X_X_chunk.device_id, compress_hyper_X_X_chunk._ts_meta_sequence_num DESC
                            Sort Method: quicksort 
-                           ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=6 loops=1)
-(42 rows)
+                           ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=5 loops=1)
+                                 Filter: (_ts_meta_min_1 < ('2000-01-10'::cstring)::timestamp with time zone)
+                                 Rows Removed by Filter: 1
+(51 rows)
 
 :PREFIX EXECUTE prep;
 QUERY PLAN
@@ -3143,37 +3279,46 @@ QUERY PLAN
                            Sort Key: compress_hyper_X_X_chunk.device_id, compress_hyper_X_X_chunk._ts_meta_sequence_num DESC
                            Sort Method: quicksort 
                            ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=4 loops=1)
+                                 Filter: (_ts_meta_min_1 < ('2000-01-10'::cstring)::timestamp with time zone)
                ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=1 loops=1)
                      Filter: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
                      ->  Sort (actual rows=1 loops=1)
                            Sort Key: compress_hyper_X_X_chunk.device_id, compress_hyper_X_X_chunk._ts_meta_sequence_num DESC
                            Sort Method: quicksort 
                            ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=12 loops=1)
+                                 Filter: (_ts_meta_min_1 < ('2000-01-10'::cstring)::timestamp with time zone)
                ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=1 loops=1)
                      Filter: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
                      ->  Sort (actual rows=1 loops=1)
                            Sort Key: compress_hyper_X_X_chunk.device_id, compress_hyper_X_X_chunk._ts_meta_sequence_num DESC
                            Sort Method: quicksort 
                            ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=4 loops=1)
+                                 Filter: (_ts_meta_min_1 < ('2000-01-10'::cstring)::timestamp with time zone)
                ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=1 loops=1)
                      Filter: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
                      ->  Sort (actual rows=1 loops=1)
                            Sort Key: compress_hyper_X_X_chunk.device_id, compress_hyper_X_X_chunk._ts_meta_sequence_num DESC
                            Sort Method: quicksort 
-                           ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=6 loops=1)
+                           ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=5 loops=1)
+                                 Filter: (_ts_meta_min_1 < ('2000-01-10'::cstring)::timestamp with time zone)
+                                 Rows Removed by Filter: 1
                ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=1 loops=1)
                      Filter: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
                      ->  Sort (actual rows=1 loops=1)
                            Sort Key: compress_hyper_X_X_chunk.device_id, compress_hyper_X_X_chunk._ts_meta_sequence_num DESC
                            Sort Method: quicksort 
-                           ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=18 loops=1)
+                           ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=15 loops=1)
+                                 Filter: (_ts_meta_min_1 < ('2000-01-10'::cstring)::timestamp with time zone)
+                                 Rows Removed by Filter: 3
                ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=1 loops=1)
                      Filter: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
                      ->  Sort (actual rows=1 loops=1)
                            Sort Key: compress_hyper_X_X_chunk.device_id, compress_hyper_X_X_chunk._ts_meta_sequence_num DESC
                            Sort Method: quicksort 
-                           ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=6 loops=1)
-(42 rows)
+                           ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=5 loops=1)
+                                 Filter: (_ts_meta_min_1 < ('2000-01-10'::cstring)::timestamp with time zone)
+                                 Rows Removed by Filter: 1
+(51 rows)
 
 DEALLOCATE prep;
 RESET timescaledb.enable_chunk_append;

--- a/tsl/test/shared/expected/ordered_append-12.out
+++ b/tsl/test/shared/expected/ordered_append-12.out
@@ -2412,12 +2412,15 @@ QUERY PLAN
                Chunks excluded during startup: 1
                ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=16785 loops=1)
                      Filter: ("time" > ('2000-01-08'::cstring)::timestamp with time zone)
-                     Rows Removed by Filter: 8405
-                     ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=30 loops=1)
+                     Rows Removed by Filter: 3215
+                     ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=20 loops=1)
+                           Filter: (_ts_meta_max_1 > ('2000-01-08'::cstring)::timestamp with time zone)
+                           Rows Removed by Filter: 10
                ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=25190 loops=1)
                      Filter: ("time" > ('2000-01-08'::cstring)::timestamp with time zone)
                      ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=30 loops=1)
-(13 rows)
+                           Filter: (_ts_meta_max_1 > ('2000-01-08'::cstring)::timestamp with time zone)
+(16 rows)
 
 :PREFIX
 SELECT time
@@ -2435,11 +2438,14 @@ QUERY PLAN
                ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=17990 loops=1)
                      Filter: ("time" < ('2000-01-08'::cstring)::timestamp with time zone)
                      ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=20 loops=1)
+                           Filter: (_ts_meta_min_1 < ('2000-01-08'::cstring)::timestamp with time zone)
                ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=8400 loops=1)
                      Filter: ("time" < ('2000-01-08'::cstring)::timestamp with time zone)
-                     Rows Removed by Filter: 16790
-                     ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=30 loops=1)
-(13 rows)
+                     Rows Removed by Filter: 1790
+                     ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=15 loops=1)
+                           Filter: (_ts_meta_min_1 < ('2000-01-08'::cstring)::timestamp with time zone)
+                           Rows Removed by Filter: 15
+(16 rows)
 
 -- test constraint exclusion
 :PREFIX
@@ -2458,10 +2464,10 @@ QUERY PLAN
                Chunks excluded during startup: 1
                ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=7195 loops=1)
                      Filter: (("time" < 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone) AND ("time" > ('2000-01-08'::cstring)::timestamp with time zone))
-                     Rows Removed by Filter: 12995
-                     ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=25 loops=1)
-                           Filter: (_ts_meta_min_1 < 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone)
-                           Rows Removed by Filter: 5
+                     Rows Removed by Filter: 7805
+                     ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=15 loops=1)
+                           Filter: ((_ts_meta_min_1 < 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone) AND (_ts_meta_max_1 > ('2000-01-08'::cstring)::timestamp with time zone))
+                           Rows Removed by Filter: 15
 (12 rows)
 
 :PREFIX
@@ -2480,10 +2486,10 @@ QUERY PLAN
                Chunks excluded during startup: 1
                ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=3595 loops=1)
                      Filter: (("time" > 'Fri Jan 07 00:00:00 2000 PST'::timestamp with time zone) AND ("time" < ('2000-01-08'::cstring)::timestamp with time zone))
-                     Rows Removed by Filter: 21405
-                     ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=25 loops=1)
-                           Filter: (_ts_meta_max_1 > 'Fri Jan 07 00:00:00 2000 PST'::timestamp with time zone)
-                           Rows Removed by Filter: 5
+                     Rows Removed by Filter: 6405
+                     ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=10 loops=1)
+                           Filter: ((_ts_meta_max_1 > 'Fri Jan 07 00:00:00 2000 PST'::timestamp with time zone) AND (_ts_meta_min_1 < ('2000-01-08'::cstring)::timestamp with time zone))
+                           Rows Removed by Filter: 20
 (12 rows)
 
 -- min/max queries
@@ -3424,40 +3430,52 @@ QUERY PLAN
                ->  Merge Append (actual rows=0 loops=1)
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=0 loops=1)
                            Filter: ("time" > ('2000-01-08'::cstring)::timestamp with time zone)
-                           Rows Removed by Filter: 3598
-                           ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=4 loops=1)
+                           ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=0 loops=1)
+                                 Filter: (_ts_meta_max_1 > ('2000-01-08'::cstring)::timestamp with time zone)
+                                 Rows Removed by Filter: 4
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=0 loops=1)
                            Filter: ("time" > ('2000-01-08'::cstring)::timestamp with time zone)
-                           Rows Removed by Filter: 10794
-                           ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=12 loops=1)
+                           ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=0 loops=1)
+                                 Filter: (_ts_meta_max_1 > ('2000-01-08'::cstring)::timestamp with time zone)
+                                 Rows Removed by Filter: 12
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=0 loops=1)
                            Filter: ("time" > ('2000-01-08'::cstring)::timestamp with time zone)
-                           Rows Removed by Filter: 3598
-                           ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=4 loops=1)
+                           ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=0 loops=1)
+                                 Filter: (_ts_meta_max_1 > ('2000-01-08'::cstring)::timestamp with time zone)
+                                 Rows Removed by Filter: 4
                ->  Merge Append (actual rows=16785 loops=1)
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=3357 loops=1)
                            Filter: ("time" > ('2000-01-08'::cstring)::timestamp with time zone)
-                           Rows Removed by Filter: 1681
-                           ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=6 loops=1)
+                           Rows Removed by Filter: 643
+                           ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=4 loops=1)
+                                 Filter: (_ts_meta_max_1 > ('2000-01-08'::cstring)::timestamp with time zone)
+                                 Rows Removed by Filter: 2
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=10071 loops=1)
                            Filter: ("time" > ('2000-01-08'::cstring)::timestamp with time zone)
-                           Rows Removed by Filter: 5043
-                           ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=18 loops=1)
+                           Rows Removed by Filter: 1929
+                           ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=12 loops=1)
+                                 Filter: (_ts_meta_max_1 > ('2000-01-08'::cstring)::timestamp with time zone)
+                                 Rows Removed by Filter: 6
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=3357 loops=1)
                            Filter: ("time" > ('2000-01-08'::cstring)::timestamp with time zone)
-                           Rows Removed by Filter: 1681
-                           ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=6 loops=1)
+                           Rows Removed by Filter: 643
+                           ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=4 loops=1)
+                                 Filter: (_ts_meta_max_1 > ('2000-01-08'::cstring)::timestamp with time zone)
+                                 Rows Removed by Filter: 2
                ->  Merge Append (actual rows=25190 loops=1)
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=5038 loops=1)
                            Filter: ("time" > ('2000-01-08'::cstring)::timestamp with time zone)
                            ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=6 loops=1)
+                                 Filter: (_ts_meta_max_1 > ('2000-01-08'::cstring)::timestamp with time zone)
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=15114 loops=1)
                            Filter: ("time" > ('2000-01-08'::cstring)::timestamp with time zone)
                            ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=18 loops=1)
+                                 Filter: (_ts_meta_max_1 > ('2000-01-08'::cstring)::timestamp with time zone)
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=5038 loops=1)
                            Filter: ("time" > ('2000-01-08'::cstring)::timestamp with time zone)
                            ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=6 loops=1)
-(41 rows)
+                                 Filter: (_ts_meta_max_1 > ('2000-01-08'::cstring)::timestamp with time zone)
+(53 rows)
 
 :PREFIX
 SELECT time
@@ -3475,39 +3493,51 @@ QUERY PLAN
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=3598 loops=1)
                            Filter: ("time" < ('2000-01-08'::cstring)::timestamp with time zone)
                            ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=4 loops=1)
+                                 Filter: (_ts_meta_min_1 < ('2000-01-08'::cstring)::timestamp with time zone)
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=10794 loops=1)
                            Filter: ("time" < ('2000-01-08'::cstring)::timestamp with time zone)
                            ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=12 loops=1)
+                                 Filter: (_ts_meta_min_1 < ('2000-01-08'::cstring)::timestamp with time zone)
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=3598 loops=1)
                            Filter: ("time" < ('2000-01-08'::cstring)::timestamp with time zone)
                            ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=4 loops=1)
+                                 Filter: (_ts_meta_min_1 < ('2000-01-08'::cstring)::timestamp with time zone)
                ->  Merge Append (actual rows=8400 loops=1)
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=1680 loops=1)
                            Filter: ("time" < ('2000-01-08'::cstring)::timestamp with time zone)
-                           Rows Removed by Filter: 3358
-                           ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=6 loops=1)
+                           Rows Removed by Filter: 358
+                           ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=3 loops=1)
+                                 Filter: (_ts_meta_min_1 < ('2000-01-08'::cstring)::timestamp with time zone)
+                                 Rows Removed by Filter: 3
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=5040 loops=1)
                            Filter: ("time" < ('2000-01-08'::cstring)::timestamp with time zone)
-                           Rows Removed by Filter: 10074
-                           ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=18 loops=1)
+                           Rows Removed by Filter: 1074
+                           ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=9 loops=1)
+                                 Filter: (_ts_meta_min_1 < ('2000-01-08'::cstring)::timestamp with time zone)
+                                 Rows Removed by Filter: 9
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=1680 loops=1)
                            Filter: ("time" < ('2000-01-08'::cstring)::timestamp with time zone)
-                           Rows Removed by Filter: 3358
-                           ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=6 loops=1)
+                           Rows Removed by Filter: 358
+                           ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=3 loops=1)
+                                 Filter: (_ts_meta_min_1 < ('2000-01-08'::cstring)::timestamp with time zone)
+                                 Rows Removed by Filter: 3
                ->  Merge Append (actual rows=0 loops=1)
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=0 loops=1)
                            Filter: ("time" < ('2000-01-08'::cstring)::timestamp with time zone)
-                           Rows Removed by Filter: 5038
-                           ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=6 loops=1)
+                           ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=0 loops=1)
+                                 Filter: (_ts_meta_min_1 < ('2000-01-08'::cstring)::timestamp with time zone)
+                                 Rows Removed by Filter: 6
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=0 loops=1)
                            Filter: ("time" < ('2000-01-08'::cstring)::timestamp with time zone)
-                           Rows Removed by Filter: 15114
-                           ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=18 loops=1)
+                           ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=0 loops=1)
+                                 Filter: (_ts_meta_min_1 < ('2000-01-08'::cstring)::timestamp with time zone)
+                                 Rows Removed by Filter: 18
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=0 loops=1)
                            Filter: ("time" < ('2000-01-08'::cstring)::timestamp with time zone)
-                           Rows Removed by Filter: 5038
-                           ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=6 loops=1)
-(41 rows)
+                           ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=0 loops=1)
+                                 Filter: (_ts_meta_min_1 < ('2000-01-08'::cstring)::timestamp with time zone)
+                                 Rows Removed by Filter: 6
+(53 rows)
 
 -- test constraint exclusion
 :PREFIX
@@ -3526,38 +3556,38 @@ QUERY PLAN
                ->  Merge Append (actual rows=0 loops=1)
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=0 loops=1)
                            Filter: (("time" < 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone) AND ("time" > ('2000-01-08'::cstring)::timestamp with time zone))
-                           Rows Removed by Filter: 3598
-                           ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=4 loops=1)
-                                 Filter: (_ts_meta_min_1 < 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone)
+                           ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=0 loops=1)
+                                 Filter: ((_ts_meta_min_1 < 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone) AND (_ts_meta_max_1 > ('2000-01-08'::cstring)::timestamp with time zone))
+                                 Rows Removed by Filter: 4
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=0 loops=1)
                            Filter: (("time" < 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone) AND ("time" > ('2000-01-08'::cstring)::timestamp with time zone))
-                           Rows Removed by Filter: 10794
-                           ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=12 loops=1)
-                                 Filter: (_ts_meta_min_1 < 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone)
+                           ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=0 loops=1)
+                                 Filter: ((_ts_meta_min_1 < 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone) AND (_ts_meta_max_1 > ('2000-01-08'::cstring)::timestamp with time zone))
+                                 Rows Removed by Filter: 12
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=0 loops=1)
                            Filter: (("time" < 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone) AND ("time" > ('2000-01-08'::cstring)::timestamp with time zone))
-                           Rows Removed by Filter: 3598
-                           ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=4 loops=1)
-                                 Filter: (_ts_meta_min_1 < 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone)
+                           ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=0 loops=1)
+                                 Filter: ((_ts_meta_min_1 < 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone) AND (_ts_meta_max_1 > ('2000-01-08'::cstring)::timestamp with time zone))
+                                 Rows Removed by Filter: 4
                ->  Merge Append (actual rows=7195 loops=1)
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=1439 loops=1)
                            Filter: (("time" < 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone) AND ("time" > ('2000-01-08'::cstring)::timestamp with time zone))
-                           Rows Removed by Filter: 2599
-                           ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=5 loops=1)
-                                 Filter: (_ts_meta_min_1 < 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone)
-                                 Rows Removed by Filter: 1
+                           Rows Removed by Filter: 1561
+                           ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=3 loops=1)
+                                 Filter: ((_ts_meta_min_1 < 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone) AND (_ts_meta_max_1 > ('2000-01-08'::cstring)::timestamp with time zone))
+                                 Rows Removed by Filter: 3
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=4317 loops=1)
                            Filter: (("time" < 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone) AND ("time" > ('2000-01-08'::cstring)::timestamp with time zone))
-                           Rows Removed by Filter: 7797
-                           ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=15 loops=1)
-                                 Filter: (_ts_meta_min_1 < 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone)
-                                 Rows Removed by Filter: 3
+                           Rows Removed by Filter: 4683
+                           ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=9 loops=1)
+                                 Filter: ((_ts_meta_min_1 < 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone) AND (_ts_meta_max_1 > ('2000-01-08'::cstring)::timestamp with time zone))
+                                 Rows Removed by Filter: 9
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=1439 loops=1)
                            Filter: (("time" < 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone) AND ("time" > ('2000-01-08'::cstring)::timestamp with time zone))
-                           Rows Removed by Filter: 2599
-                           ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=5 loops=1)
-                                 Filter: (_ts_meta_min_1 < 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone)
-                                 Rows Removed by Filter: 1
+                           Rows Removed by Filter: 1561
+                           ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=3 loops=1)
+                                 Filter: ((_ts_meta_min_1 < 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone) AND (_ts_meta_max_1 > ('2000-01-08'::cstring)::timestamp with time zone))
+                                 Rows Removed by Filter: 3
 (40 rows)
 
 :PREFIX
@@ -3576,38 +3606,38 @@ QUERY PLAN
                ->  Merge Append (actual rows=3595 loops=1)
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=719 loops=1)
                            Filter: (("time" > 'Fri Jan 07 00:00:00 2000 PST'::timestamp with time zone) AND ("time" < ('2000-01-08'::cstring)::timestamp with time zone))
-                           Rows Removed by Filter: 4281
-                           ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=5 loops=1)
-                                 Filter: (_ts_meta_max_1 > 'Fri Jan 07 00:00:00 2000 PST'::timestamp with time zone)
-                                 Rows Removed by Filter: 1
+                           Rows Removed by Filter: 1281
+                           ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=2 loops=1)
+                                 Filter: ((_ts_meta_max_1 > 'Fri Jan 07 00:00:00 2000 PST'::timestamp with time zone) AND (_ts_meta_min_1 < ('2000-01-08'::cstring)::timestamp with time zone))
+                                 Rows Removed by Filter: 4
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=2157 loops=1)
                            Filter: (("time" > 'Fri Jan 07 00:00:00 2000 PST'::timestamp with time zone) AND ("time" < ('2000-01-08'::cstring)::timestamp with time zone))
-                           Rows Removed by Filter: 12843
-                           ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=15 loops=1)
-                                 Filter: (_ts_meta_max_1 > 'Fri Jan 07 00:00:00 2000 PST'::timestamp with time zone)
-                                 Rows Removed by Filter: 3
+                           Rows Removed by Filter: 3843
+                           ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=6 loops=1)
+                                 Filter: ((_ts_meta_max_1 > 'Fri Jan 07 00:00:00 2000 PST'::timestamp with time zone) AND (_ts_meta_min_1 < ('2000-01-08'::cstring)::timestamp with time zone))
+                                 Rows Removed by Filter: 12
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=719 loops=1)
                            Filter: (("time" > 'Fri Jan 07 00:00:00 2000 PST'::timestamp with time zone) AND ("time" < ('2000-01-08'::cstring)::timestamp with time zone))
-                           Rows Removed by Filter: 4281
-                           ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=5 loops=1)
-                                 Filter: (_ts_meta_max_1 > 'Fri Jan 07 00:00:00 2000 PST'::timestamp with time zone)
-                                 Rows Removed by Filter: 1
+                           Rows Removed by Filter: 1281
+                           ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=2 loops=1)
+                                 Filter: ((_ts_meta_max_1 > 'Fri Jan 07 00:00:00 2000 PST'::timestamp with time zone) AND (_ts_meta_min_1 < ('2000-01-08'::cstring)::timestamp with time zone))
+                                 Rows Removed by Filter: 4
                ->  Merge Append (actual rows=0 loops=1)
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=0 loops=1)
                            Filter: (("time" > 'Fri Jan 07 00:00:00 2000 PST'::timestamp with time zone) AND ("time" < ('2000-01-08'::cstring)::timestamp with time zone))
-                           Rows Removed by Filter: 5038
-                           ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=6 loops=1)
-                                 Filter: (_ts_meta_max_1 > 'Fri Jan 07 00:00:00 2000 PST'::timestamp with time zone)
+                           ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=0 loops=1)
+                                 Filter: ((_ts_meta_max_1 > 'Fri Jan 07 00:00:00 2000 PST'::timestamp with time zone) AND (_ts_meta_min_1 < ('2000-01-08'::cstring)::timestamp with time zone))
+                                 Rows Removed by Filter: 6
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=0 loops=1)
                            Filter: (("time" > 'Fri Jan 07 00:00:00 2000 PST'::timestamp with time zone) AND ("time" < ('2000-01-08'::cstring)::timestamp with time zone))
-                           Rows Removed by Filter: 15114
-                           ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=18 loops=1)
-                                 Filter: (_ts_meta_max_1 > 'Fri Jan 07 00:00:00 2000 PST'::timestamp with time zone)
+                           ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=0 loops=1)
+                                 Filter: ((_ts_meta_max_1 > 'Fri Jan 07 00:00:00 2000 PST'::timestamp with time zone) AND (_ts_meta_min_1 < ('2000-01-08'::cstring)::timestamp with time zone))
+                                 Rows Removed by Filter: 18
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=0 loops=1)
                            Filter: (("time" > 'Fri Jan 07 00:00:00 2000 PST'::timestamp with time zone) AND ("time" < ('2000-01-08'::cstring)::timestamp with time zone))
-                           Rows Removed by Filter: 5038
-                           ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=6 loops=1)
-                                 Filter: (_ts_meta_max_1 > 'Fri Jan 07 00:00:00 2000 PST'::timestamp with time zone)
+                           ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=0 loops=1)
+                                 Filter: ((_ts_meta_max_1 > 'Fri Jan 07 00:00:00 2000 PST'::timestamp with time zone) AND (_ts_meta_min_1 < ('2000-01-08'::cstring)::timestamp with time zone))
+                                 Rows Removed by Filter: 6
 (40 rows)
 
 -- min/max queries

--- a/tsl/test/shared/expected/ordered_append-13.out
+++ b/tsl/test/shared/expected/ordered_append-13.out
@@ -2415,12 +2415,15 @@ QUERY PLAN
                Chunks excluded during startup: 1
                ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=16785 loops=1)
                      Filter: ("time" > ('2000-01-08'::cstring)::timestamp with time zone)
-                     Rows Removed by Filter: 8405
-                     ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=30 loops=1)
+                     Rows Removed by Filter: 3215
+                     ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=20 loops=1)
+                           Filter: (_ts_meta_max_1 > ('2000-01-08'::cstring)::timestamp with time zone)
+                           Rows Removed by Filter: 10
                ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=25190 loops=1)
                      Filter: ("time" > ('2000-01-08'::cstring)::timestamp with time zone)
                      ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=30 loops=1)
-(13 rows)
+                           Filter: (_ts_meta_max_1 > ('2000-01-08'::cstring)::timestamp with time zone)
+(16 rows)
 
 :PREFIX
 SELECT time
@@ -2438,11 +2441,14 @@ QUERY PLAN
                ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=17990 loops=1)
                      Filter: ("time" < ('2000-01-08'::cstring)::timestamp with time zone)
                      ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=20 loops=1)
+                           Filter: (_ts_meta_min_1 < ('2000-01-08'::cstring)::timestamp with time zone)
                ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=8400 loops=1)
                      Filter: ("time" < ('2000-01-08'::cstring)::timestamp with time zone)
-                     Rows Removed by Filter: 16790
-                     ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=30 loops=1)
-(13 rows)
+                     Rows Removed by Filter: 1790
+                     ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=15 loops=1)
+                           Filter: (_ts_meta_min_1 < ('2000-01-08'::cstring)::timestamp with time zone)
+                           Rows Removed by Filter: 15
+(16 rows)
 
 -- test constraint exclusion
 :PREFIX
@@ -2461,10 +2467,10 @@ QUERY PLAN
                Chunks excluded during startup: 1
                ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=7195 loops=1)
                      Filter: (("time" < 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone) AND ("time" > ('2000-01-08'::cstring)::timestamp with time zone))
-                     Rows Removed by Filter: 12995
-                     ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=25 loops=1)
-                           Filter: (_ts_meta_min_1 < 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone)
-                           Rows Removed by Filter: 5
+                     Rows Removed by Filter: 7805
+                     ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=15 loops=1)
+                           Filter: ((_ts_meta_min_1 < 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone) AND (_ts_meta_max_1 > ('2000-01-08'::cstring)::timestamp with time zone))
+                           Rows Removed by Filter: 15
 (12 rows)
 
 :PREFIX
@@ -2483,10 +2489,10 @@ QUERY PLAN
                Chunks excluded during startup: 1
                ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=3595 loops=1)
                      Filter: (("time" > 'Fri Jan 07 00:00:00 2000 PST'::timestamp with time zone) AND ("time" < ('2000-01-08'::cstring)::timestamp with time zone))
-                     Rows Removed by Filter: 21405
-                     ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=25 loops=1)
-                           Filter: (_ts_meta_max_1 > 'Fri Jan 07 00:00:00 2000 PST'::timestamp with time zone)
-                           Rows Removed by Filter: 5
+                     Rows Removed by Filter: 6405
+                     ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=10 loops=1)
+                           Filter: ((_ts_meta_max_1 > 'Fri Jan 07 00:00:00 2000 PST'::timestamp with time zone) AND (_ts_meta_min_1 < ('2000-01-08'::cstring)::timestamp with time zone))
+                           Rows Removed by Filter: 20
 (12 rows)
 
 -- min/max queries
@@ -3427,40 +3433,52 @@ QUERY PLAN
                ->  Merge Append (actual rows=0 loops=1)
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=0 loops=1)
                            Filter: ("time" > ('2000-01-08'::cstring)::timestamp with time zone)
-                           Rows Removed by Filter: 3598
-                           ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=4 loops=1)
+                           ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=0 loops=1)
+                                 Filter: (_ts_meta_max_1 > ('2000-01-08'::cstring)::timestamp with time zone)
+                                 Rows Removed by Filter: 4
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=0 loops=1)
                            Filter: ("time" > ('2000-01-08'::cstring)::timestamp with time zone)
-                           Rows Removed by Filter: 10794
-                           ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=12 loops=1)
+                           ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=0 loops=1)
+                                 Filter: (_ts_meta_max_1 > ('2000-01-08'::cstring)::timestamp with time zone)
+                                 Rows Removed by Filter: 12
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=0 loops=1)
                            Filter: ("time" > ('2000-01-08'::cstring)::timestamp with time zone)
-                           Rows Removed by Filter: 3598
-                           ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=4 loops=1)
+                           ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=0 loops=1)
+                                 Filter: (_ts_meta_max_1 > ('2000-01-08'::cstring)::timestamp with time zone)
+                                 Rows Removed by Filter: 4
                ->  Merge Append (actual rows=16785 loops=1)
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=3357 loops=1)
                            Filter: ("time" > ('2000-01-08'::cstring)::timestamp with time zone)
-                           Rows Removed by Filter: 1681
-                           ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=6 loops=1)
+                           Rows Removed by Filter: 643
+                           ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=4 loops=1)
+                                 Filter: (_ts_meta_max_1 > ('2000-01-08'::cstring)::timestamp with time zone)
+                                 Rows Removed by Filter: 2
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=10071 loops=1)
                            Filter: ("time" > ('2000-01-08'::cstring)::timestamp with time zone)
-                           Rows Removed by Filter: 5043
-                           ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=18 loops=1)
+                           Rows Removed by Filter: 1929
+                           ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=12 loops=1)
+                                 Filter: (_ts_meta_max_1 > ('2000-01-08'::cstring)::timestamp with time zone)
+                                 Rows Removed by Filter: 6
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=3357 loops=1)
                            Filter: ("time" > ('2000-01-08'::cstring)::timestamp with time zone)
-                           Rows Removed by Filter: 1681
-                           ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=6 loops=1)
+                           Rows Removed by Filter: 643
+                           ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=4 loops=1)
+                                 Filter: (_ts_meta_max_1 > ('2000-01-08'::cstring)::timestamp with time zone)
+                                 Rows Removed by Filter: 2
                ->  Merge Append (actual rows=25190 loops=1)
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=5038 loops=1)
                            Filter: ("time" > ('2000-01-08'::cstring)::timestamp with time zone)
                            ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=6 loops=1)
+                                 Filter: (_ts_meta_max_1 > ('2000-01-08'::cstring)::timestamp with time zone)
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=15114 loops=1)
                            Filter: ("time" > ('2000-01-08'::cstring)::timestamp with time zone)
                            ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=18 loops=1)
+                                 Filter: (_ts_meta_max_1 > ('2000-01-08'::cstring)::timestamp with time zone)
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=5038 loops=1)
                            Filter: ("time" > ('2000-01-08'::cstring)::timestamp with time zone)
                            ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=6 loops=1)
-(41 rows)
+                                 Filter: (_ts_meta_max_1 > ('2000-01-08'::cstring)::timestamp with time zone)
+(53 rows)
 
 :PREFIX
 SELECT time
@@ -3478,39 +3496,51 @@ QUERY PLAN
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=3598 loops=1)
                            Filter: ("time" < ('2000-01-08'::cstring)::timestamp with time zone)
                            ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=4 loops=1)
+                                 Filter: (_ts_meta_min_1 < ('2000-01-08'::cstring)::timestamp with time zone)
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=10794 loops=1)
                            Filter: ("time" < ('2000-01-08'::cstring)::timestamp with time zone)
                            ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=12 loops=1)
+                                 Filter: (_ts_meta_min_1 < ('2000-01-08'::cstring)::timestamp with time zone)
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=3598 loops=1)
                            Filter: ("time" < ('2000-01-08'::cstring)::timestamp with time zone)
                            ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=4 loops=1)
+                                 Filter: (_ts_meta_min_1 < ('2000-01-08'::cstring)::timestamp with time zone)
                ->  Merge Append (actual rows=8400 loops=1)
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=1680 loops=1)
                            Filter: ("time" < ('2000-01-08'::cstring)::timestamp with time zone)
-                           Rows Removed by Filter: 3358
-                           ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=6 loops=1)
+                           Rows Removed by Filter: 358
+                           ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=3 loops=1)
+                                 Filter: (_ts_meta_min_1 < ('2000-01-08'::cstring)::timestamp with time zone)
+                                 Rows Removed by Filter: 3
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=5040 loops=1)
                            Filter: ("time" < ('2000-01-08'::cstring)::timestamp with time zone)
-                           Rows Removed by Filter: 10074
-                           ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=18 loops=1)
+                           Rows Removed by Filter: 1074
+                           ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=9 loops=1)
+                                 Filter: (_ts_meta_min_1 < ('2000-01-08'::cstring)::timestamp with time zone)
+                                 Rows Removed by Filter: 9
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=1680 loops=1)
                            Filter: ("time" < ('2000-01-08'::cstring)::timestamp with time zone)
-                           Rows Removed by Filter: 3358
-                           ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=6 loops=1)
+                           Rows Removed by Filter: 358
+                           ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=3 loops=1)
+                                 Filter: (_ts_meta_min_1 < ('2000-01-08'::cstring)::timestamp with time zone)
+                                 Rows Removed by Filter: 3
                ->  Merge Append (actual rows=0 loops=1)
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=0 loops=1)
                            Filter: ("time" < ('2000-01-08'::cstring)::timestamp with time zone)
-                           Rows Removed by Filter: 5038
-                           ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=6 loops=1)
+                           ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=0 loops=1)
+                                 Filter: (_ts_meta_min_1 < ('2000-01-08'::cstring)::timestamp with time zone)
+                                 Rows Removed by Filter: 6
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=0 loops=1)
                            Filter: ("time" < ('2000-01-08'::cstring)::timestamp with time zone)
-                           Rows Removed by Filter: 15114
-                           ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=18 loops=1)
+                           ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=0 loops=1)
+                                 Filter: (_ts_meta_min_1 < ('2000-01-08'::cstring)::timestamp with time zone)
+                                 Rows Removed by Filter: 18
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=0 loops=1)
                            Filter: ("time" < ('2000-01-08'::cstring)::timestamp with time zone)
-                           Rows Removed by Filter: 5038
-                           ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=6 loops=1)
-(41 rows)
+                           ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=0 loops=1)
+                                 Filter: (_ts_meta_min_1 < ('2000-01-08'::cstring)::timestamp with time zone)
+                                 Rows Removed by Filter: 6
+(53 rows)
 
 -- test constraint exclusion
 :PREFIX
@@ -3529,38 +3559,38 @@ QUERY PLAN
                ->  Merge Append (actual rows=0 loops=1)
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=0 loops=1)
                            Filter: (("time" < 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone) AND ("time" > ('2000-01-08'::cstring)::timestamp with time zone))
-                           Rows Removed by Filter: 3598
-                           ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=4 loops=1)
-                                 Filter: (_ts_meta_min_1 < 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone)
+                           ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=0 loops=1)
+                                 Filter: ((_ts_meta_min_1 < 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone) AND (_ts_meta_max_1 > ('2000-01-08'::cstring)::timestamp with time zone))
+                                 Rows Removed by Filter: 4
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=0 loops=1)
                            Filter: (("time" < 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone) AND ("time" > ('2000-01-08'::cstring)::timestamp with time zone))
-                           Rows Removed by Filter: 10794
-                           ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=12 loops=1)
-                                 Filter: (_ts_meta_min_1 < 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone)
+                           ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=0 loops=1)
+                                 Filter: ((_ts_meta_min_1 < 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone) AND (_ts_meta_max_1 > ('2000-01-08'::cstring)::timestamp with time zone))
+                                 Rows Removed by Filter: 12
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=0 loops=1)
                            Filter: (("time" < 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone) AND ("time" > ('2000-01-08'::cstring)::timestamp with time zone))
-                           Rows Removed by Filter: 3598
-                           ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=4 loops=1)
-                                 Filter: (_ts_meta_min_1 < 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone)
+                           ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=0 loops=1)
+                                 Filter: ((_ts_meta_min_1 < 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone) AND (_ts_meta_max_1 > ('2000-01-08'::cstring)::timestamp with time zone))
+                                 Rows Removed by Filter: 4
                ->  Merge Append (actual rows=7195 loops=1)
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=1439 loops=1)
                            Filter: (("time" < 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone) AND ("time" > ('2000-01-08'::cstring)::timestamp with time zone))
-                           Rows Removed by Filter: 2599
-                           ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=5 loops=1)
-                                 Filter: (_ts_meta_min_1 < 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone)
-                                 Rows Removed by Filter: 1
+                           Rows Removed by Filter: 1561
+                           ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=3 loops=1)
+                                 Filter: ((_ts_meta_min_1 < 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone) AND (_ts_meta_max_1 > ('2000-01-08'::cstring)::timestamp with time zone))
+                                 Rows Removed by Filter: 3
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=4317 loops=1)
                            Filter: (("time" < 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone) AND ("time" > ('2000-01-08'::cstring)::timestamp with time zone))
-                           Rows Removed by Filter: 7797
-                           ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=15 loops=1)
-                                 Filter: (_ts_meta_min_1 < 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone)
-                                 Rows Removed by Filter: 3
+                           Rows Removed by Filter: 4683
+                           ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=9 loops=1)
+                                 Filter: ((_ts_meta_min_1 < 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone) AND (_ts_meta_max_1 > ('2000-01-08'::cstring)::timestamp with time zone))
+                                 Rows Removed by Filter: 9
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=1439 loops=1)
                            Filter: (("time" < 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone) AND ("time" > ('2000-01-08'::cstring)::timestamp with time zone))
-                           Rows Removed by Filter: 2599
-                           ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=5 loops=1)
-                                 Filter: (_ts_meta_min_1 < 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone)
-                                 Rows Removed by Filter: 1
+                           Rows Removed by Filter: 1561
+                           ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=3 loops=1)
+                                 Filter: ((_ts_meta_min_1 < 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone) AND (_ts_meta_max_1 > ('2000-01-08'::cstring)::timestamp with time zone))
+                                 Rows Removed by Filter: 3
 (40 rows)
 
 :PREFIX
@@ -3579,38 +3609,38 @@ QUERY PLAN
                ->  Merge Append (actual rows=3595 loops=1)
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=719 loops=1)
                            Filter: (("time" > 'Fri Jan 07 00:00:00 2000 PST'::timestamp with time zone) AND ("time" < ('2000-01-08'::cstring)::timestamp with time zone))
-                           Rows Removed by Filter: 4281
-                           ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=5 loops=1)
-                                 Filter: (_ts_meta_max_1 > 'Fri Jan 07 00:00:00 2000 PST'::timestamp with time zone)
-                                 Rows Removed by Filter: 1
+                           Rows Removed by Filter: 1281
+                           ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=2 loops=1)
+                                 Filter: ((_ts_meta_max_1 > 'Fri Jan 07 00:00:00 2000 PST'::timestamp with time zone) AND (_ts_meta_min_1 < ('2000-01-08'::cstring)::timestamp with time zone))
+                                 Rows Removed by Filter: 4
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=2157 loops=1)
                            Filter: (("time" > 'Fri Jan 07 00:00:00 2000 PST'::timestamp with time zone) AND ("time" < ('2000-01-08'::cstring)::timestamp with time zone))
-                           Rows Removed by Filter: 12843
-                           ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=15 loops=1)
-                                 Filter: (_ts_meta_max_1 > 'Fri Jan 07 00:00:00 2000 PST'::timestamp with time zone)
-                                 Rows Removed by Filter: 3
+                           Rows Removed by Filter: 3843
+                           ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=6 loops=1)
+                                 Filter: ((_ts_meta_max_1 > 'Fri Jan 07 00:00:00 2000 PST'::timestamp with time zone) AND (_ts_meta_min_1 < ('2000-01-08'::cstring)::timestamp with time zone))
+                                 Rows Removed by Filter: 12
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=719 loops=1)
                            Filter: (("time" > 'Fri Jan 07 00:00:00 2000 PST'::timestamp with time zone) AND ("time" < ('2000-01-08'::cstring)::timestamp with time zone))
-                           Rows Removed by Filter: 4281
-                           ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=5 loops=1)
-                                 Filter: (_ts_meta_max_1 > 'Fri Jan 07 00:00:00 2000 PST'::timestamp with time zone)
-                                 Rows Removed by Filter: 1
+                           Rows Removed by Filter: 1281
+                           ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=2 loops=1)
+                                 Filter: ((_ts_meta_max_1 > 'Fri Jan 07 00:00:00 2000 PST'::timestamp with time zone) AND (_ts_meta_min_1 < ('2000-01-08'::cstring)::timestamp with time zone))
+                                 Rows Removed by Filter: 4
                ->  Merge Append (actual rows=0 loops=1)
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=0 loops=1)
                            Filter: (("time" > 'Fri Jan 07 00:00:00 2000 PST'::timestamp with time zone) AND ("time" < ('2000-01-08'::cstring)::timestamp with time zone))
-                           Rows Removed by Filter: 5038
-                           ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=6 loops=1)
-                                 Filter: (_ts_meta_max_1 > 'Fri Jan 07 00:00:00 2000 PST'::timestamp with time zone)
+                           ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=0 loops=1)
+                                 Filter: ((_ts_meta_max_1 > 'Fri Jan 07 00:00:00 2000 PST'::timestamp with time zone) AND (_ts_meta_min_1 < ('2000-01-08'::cstring)::timestamp with time zone))
+                                 Rows Removed by Filter: 6
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=0 loops=1)
                            Filter: (("time" > 'Fri Jan 07 00:00:00 2000 PST'::timestamp with time zone) AND ("time" < ('2000-01-08'::cstring)::timestamp with time zone))
-                           Rows Removed by Filter: 15114
-                           ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=18 loops=1)
-                                 Filter: (_ts_meta_max_1 > 'Fri Jan 07 00:00:00 2000 PST'::timestamp with time zone)
+                           ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=0 loops=1)
+                                 Filter: ((_ts_meta_max_1 > 'Fri Jan 07 00:00:00 2000 PST'::timestamp with time zone) AND (_ts_meta_min_1 < ('2000-01-08'::cstring)::timestamp with time zone))
+                                 Rows Removed by Filter: 18
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=0 loops=1)
                            Filter: (("time" > 'Fri Jan 07 00:00:00 2000 PST'::timestamp with time zone) AND ("time" < ('2000-01-08'::cstring)::timestamp with time zone))
-                           Rows Removed by Filter: 5038
-                           ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=6 loops=1)
-                                 Filter: (_ts_meta_max_1 > 'Fri Jan 07 00:00:00 2000 PST'::timestamp with time zone)
+                           ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=0 loops=1)
+                                 Filter: ((_ts_meta_max_1 > 'Fri Jan 07 00:00:00 2000 PST'::timestamp with time zone) AND (_ts_meta_min_1 < ('2000-01-08'::cstring)::timestamp with time zone))
+                                 Rows Removed by Filter: 6
 (40 rows)
 
 -- min/max queries

--- a/tsl/test/shared/expected/ordered_append-14.out
+++ b/tsl/test/shared/expected/ordered_append-14.out
@@ -2415,12 +2415,15 @@ QUERY PLAN
                Chunks excluded during startup: 1
                ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=16785 loops=1)
                      Filter: ("time" > ('2000-01-08'::cstring)::timestamp with time zone)
-                     Rows Removed by Filter: 8405
-                     ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=30 loops=1)
+                     Rows Removed by Filter: 3215
+                     ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=20 loops=1)
+                           Filter: (_ts_meta_max_1 > ('2000-01-08'::cstring)::timestamp with time zone)
+                           Rows Removed by Filter: 10
                ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=25190 loops=1)
                      Filter: ("time" > ('2000-01-08'::cstring)::timestamp with time zone)
                      ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=30 loops=1)
-(13 rows)
+                           Filter: (_ts_meta_max_1 > ('2000-01-08'::cstring)::timestamp with time zone)
+(16 rows)
 
 :PREFIX
 SELECT time
@@ -2438,11 +2441,14 @@ QUERY PLAN
                ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=17990 loops=1)
                      Filter: ("time" < ('2000-01-08'::cstring)::timestamp with time zone)
                      ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=20 loops=1)
+                           Filter: (_ts_meta_min_1 < ('2000-01-08'::cstring)::timestamp with time zone)
                ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=8400 loops=1)
                      Filter: ("time" < ('2000-01-08'::cstring)::timestamp with time zone)
-                     Rows Removed by Filter: 16790
-                     ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=30 loops=1)
-(13 rows)
+                     Rows Removed by Filter: 1790
+                     ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=15 loops=1)
+                           Filter: (_ts_meta_min_1 < ('2000-01-08'::cstring)::timestamp with time zone)
+                           Rows Removed by Filter: 15
+(16 rows)
 
 -- test constraint exclusion
 :PREFIX
@@ -2461,10 +2467,10 @@ QUERY PLAN
                Chunks excluded during startup: 1
                ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=7195 loops=1)
                      Filter: (("time" < 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone) AND ("time" > ('2000-01-08'::cstring)::timestamp with time zone))
-                     Rows Removed by Filter: 12995
-                     ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=25 loops=1)
-                           Filter: (_ts_meta_min_1 < 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone)
-                           Rows Removed by Filter: 5
+                     Rows Removed by Filter: 7805
+                     ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=15 loops=1)
+                           Filter: ((_ts_meta_min_1 < 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone) AND (_ts_meta_max_1 > ('2000-01-08'::cstring)::timestamp with time zone))
+                           Rows Removed by Filter: 15
 (12 rows)
 
 :PREFIX
@@ -2483,10 +2489,10 @@ QUERY PLAN
                Chunks excluded during startup: 1
                ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=3595 loops=1)
                      Filter: (("time" > 'Fri Jan 07 00:00:00 2000 PST'::timestamp with time zone) AND ("time" < ('2000-01-08'::cstring)::timestamp with time zone))
-                     Rows Removed by Filter: 21405
-                     ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=25 loops=1)
-                           Filter: (_ts_meta_max_1 > 'Fri Jan 07 00:00:00 2000 PST'::timestamp with time zone)
-                           Rows Removed by Filter: 5
+                     Rows Removed by Filter: 6405
+                     ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=10 loops=1)
+                           Filter: ((_ts_meta_max_1 > 'Fri Jan 07 00:00:00 2000 PST'::timestamp with time zone) AND (_ts_meta_min_1 < ('2000-01-08'::cstring)::timestamp with time zone))
+                           Rows Removed by Filter: 20
 (12 rows)
 
 -- min/max queries
@@ -3427,40 +3433,52 @@ QUERY PLAN
                ->  Merge Append (actual rows=0 loops=1)
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=0 loops=1)
                            Filter: ("time" > ('2000-01-08'::cstring)::timestamp with time zone)
-                           Rows Removed by Filter: 3598
-                           ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=4 loops=1)
+                           ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=0 loops=1)
+                                 Filter: (_ts_meta_max_1 > ('2000-01-08'::cstring)::timestamp with time zone)
+                                 Rows Removed by Filter: 4
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=0 loops=1)
                            Filter: ("time" > ('2000-01-08'::cstring)::timestamp with time zone)
-                           Rows Removed by Filter: 10794
-                           ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=12 loops=1)
+                           ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=0 loops=1)
+                                 Filter: (_ts_meta_max_1 > ('2000-01-08'::cstring)::timestamp with time zone)
+                                 Rows Removed by Filter: 12
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=0 loops=1)
                            Filter: ("time" > ('2000-01-08'::cstring)::timestamp with time zone)
-                           Rows Removed by Filter: 3598
-                           ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=4 loops=1)
+                           ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=0 loops=1)
+                                 Filter: (_ts_meta_max_1 > ('2000-01-08'::cstring)::timestamp with time zone)
+                                 Rows Removed by Filter: 4
                ->  Merge Append (actual rows=16785 loops=1)
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=3357 loops=1)
                            Filter: ("time" > ('2000-01-08'::cstring)::timestamp with time zone)
-                           Rows Removed by Filter: 1681
-                           ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=6 loops=1)
+                           Rows Removed by Filter: 643
+                           ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=4 loops=1)
+                                 Filter: (_ts_meta_max_1 > ('2000-01-08'::cstring)::timestamp with time zone)
+                                 Rows Removed by Filter: 2
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=10071 loops=1)
                            Filter: ("time" > ('2000-01-08'::cstring)::timestamp with time zone)
-                           Rows Removed by Filter: 5043
-                           ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=18 loops=1)
+                           Rows Removed by Filter: 1929
+                           ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=12 loops=1)
+                                 Filter: (_ts_meta_max_1 > ('2000-01-08'::cstring)::timestamp with time zone)
+                                 Rows Removed by Filter: 6
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=3357 loops=1)
                            Filter: ("time" > ('2000-01-08'::cstring)::timestamp with time zone)
-                           Rows Removed by Filter: 1681
-                           ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=6 loops=1)
+                           Rows Removed by Filter: 643
+                           ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=4 loops=1)
+                                 Filter: (_ts_meta_max_1 > ('2000-01-08'::cstring)::timestamp with time zone)
+                                 Rows Removed by Filter: 2
                ->  Merge Append (actual rows=25190 loops=1)
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=5038 loops=1)
                            Filter: ("time" > ('2000-01-08'::cstring)::timestamp with time zone)
                            ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=6 loops=1)
+                                 Filter: (_ts_meta_max_1 > ('2000-01-08'::cstring)::timestamp with time zone)
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=15114 loops=1)
                            Filter: ("time" > ('2000-01-08'::cstring)::timestamp with time zone)
                            ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=18 loops=1)
+                                 Filter: (_ts_meta_max_1 > ('2000-01-08'::cstring)::timestamp with time zone)
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=5038 loops=1)
                            Filter: ("time" > ('2000-01-08'::cstring)::timestamp with time zone)
                            ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=6 loops=1)
-(41 rows)
+                                 Filter: (_ts_meta_max_1 > ('2000-01-08'::cstring)::timestamp with time zone)
+(53 rows)
 
 :PREFIX
 SELECT time
@@ -3478,39 +3496,51 @@ QUERY PLAN
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=3598 loops=1)
                            Filter: ("time" < ('2000-01-08'::cstring)::timestamp with time zone)
                            ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=4 loops=1)
+                                 Filter: (_ts_meta_min_1 < ('2000-01-08'::cstring)::timestamp with time zone)
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=10794 loops=1)
                            Filter: ("time" < ('2000-01-08'::cstring)::timestamp with time zone)
                            ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=12 loops=1)
+                                 Filter: (_ts_meta_min_1 < ('2000-01-08'::cstring)::timestamp with time zone)
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=3598 loops=1)
                            Filter: ("time" < ('2000-01-08'::cstring)::timestamp with time zone)
                            ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=4 loops=1)
+                                 Filter: (_ts_meta_min_1 < ('2000-01-08'::cstring)::timestamp with time zone)
                ->  Merge Append (actual rows=8400 loops=1)
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=1680 loops=1)
                            Filter: ("time" < ('2000-01-08'::cstring)::timestamp with time zone)
-                           Rows Removed by Filter: 3358
-                           ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=6 loops=1)
+                           Rows Removed by Filter: 358
+                           ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=3 loops=1)
+                                 Filter: (_ts_meta_min_1 < ('2000-01-08'::cstring)::timestamp with time zone)
+                                 Rows Removed by Filter: 3
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=5040 loops=1)
                            Filter: ("time" < ('2000-01-08'::cstring)::timestamp with time zone)
-                           Rows Removed by Filter: 10074
-                           ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=18 loops=1)
+                           Rows Removed by Filter: 1074
+                           ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=9 loops=1)
+                                 Filter: (_ts_meta_min_1 < ('2000-01-08'::cstring)::timestamp with time zone)
+                                 Rows Removed by Filter: 9
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=1680 loops=1)
                            Filter: ("time" < ('2000-01-08'::cstring)::timestamp with time zone)
-                           Rows Removed by Filter: 3358
-                           ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=6 loops=1)
+                           Rows Removed by Filter: 358
+                           ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=3 loops=1)
+                                 Filter: (_ts_meta_min_1 < ('2000-01-08'::cstring)::timestamp with time zone)
+                                 Rows Removed by Filter: 3
                ->  Merge Append (actual rows=0 loops=1)
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=0 loops=1)
                            Filter: ("time" < ('2000-01-08'::cstring)::timestamp with time zone)
-                           Rows Removed by Filter: 5038
-                           ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=6 loops=1)
+                           ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=0 loops=1)
+                                 Filter: (_ts_meta_min_1 < ('2000-01-08'::cstring)::timestamp with time zone)
+                                 Rows Removed by Filter: 6
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=0 loops=1)
                            Filter: ("time" < ('2000-01-08'::cstring)::timestamp with time zone)
-                           Rows Removed by Filter: 15114
-                           ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=18 loops=1)
+                           ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=0 loops=1)
+                                 Filter: (_ts_meta_min_1 < ('2000-01-08'::cstring)::timestamp with time zone)
+                                 Rows Removed by Filter: 18
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=0 loops=1)
                            Filter: ("time" < ('2000-01-08'::cstring)::timestamp with time zone)
-                           Rows Removed by Filter: 5038
-                           ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=6 loops=1)
-(41 rows)
+                           ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=0 loops=1)
+                                 Filter: (_ts_meta_min_1 < ('2000-01-08'::cstring)::timestamp with time zone)
+                                 Rows Removed by Filter: 6
+(53 rows)
 
 -- test constraint exclusion
 :PREFIX
@@ -3529,38 +3559,38 @@ QUERY PLAN
                ->  Merge Append (actual rows=0 loops=1)
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=0 loops=1)
                            Filter: (("time" < 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone) AND ("time" > ('2000-01-08'::cstring)::timestamp with time zone))
-                           Rows Removed by Filter: 3598
-                           ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=4 loops=1)
-                                 Filter: (_ts_meta_min_1 < 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone)
+                           ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=0 loops=1)
+                                 Filter: ((_ts_meta_min_1 < 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone) AND (_ts_meta_max_1 > ('2000-01-08'::cstring)::timestamp with time zone))
+                                 Rows Removed by Filter: 4
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=0 loops=1)
                            Filter: (("time" < 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone) AND ("time" > ('2000-01-08'::cstring)::timestamp with time zone))
-                           Rows Removed by Filter: 10794
-                           ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=12 loops=1)
-                                 Filter: (_ts_meta_min_1 < 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone)
+                           ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=0 loops=1)
+                                 Filter: ((_ts_meta_min_1 < 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone) AND (_ts_meta_max_1 > ('2000-01-08'::cstring)::timestamp with time zone))
+                                 Rows Removed by Filter: 12
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=0 loops=1)
                            Filter: (("time" < 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone) AND ("time" > ('2000-01-08'::cstring)::timestamp with time zone))
-                           Rows Removed by Filter: 3598
-                           ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=4 loops=1)
-                                 Filter: (_ts_meta_min_1 < 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone)
+                           ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=0 loops=1)
+                                 Filter: ((_ts_meta_min_1 < 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone) AND (_ts_meta_max_1 > ('2000-01-08'::cstring)::timestamp with time zone))
+                                 Rows Removed by Filter: 4
                ->  Merge Append (actual rows=7195 loops=1)
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=1439 loops=1)
                            Filter: (("time" < 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone) AND ("time" > ('2000-01-08'::cstring)::timestamp with time zone))
-                           Rows Removed by Filter: 2599
-                           ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=5 loops=1)
-                                 Filter: (_ts_meta_min_1 < 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone)
-                                 Rows Removed by Filter: 1
+                           Rows Removed by Filter: 1561
+                           ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=3 loops=1)
+                                 Filter: ((_ts_meta_min_1 < 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone) AND (_ts_meta_max_1 > ('2000-01-08'::cstring)::timestamp with time zone))
+                                 Rows Removed by Filter: 3
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=4317 loops=1)
                            Filter: (("time" < 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone) AND ("time" > ('2000-01-08'::cstring)::timestamp with time zone))
-                           Rows Removed by Filter: 7797
-                           ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=15 loops=1)
-                                 Filter: (_ts_meta_min_1 < 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone)
-                                 Rows Removed by Filter: 3
+                           Rows Removed by Filter: 4683
+                           ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=9 loops=1)
+                                 Filter: ((_ts_meta_min_1 < 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone) AND (_ts_meta_max_1 > ('2000-01-08'::cstring)::timestamp with time zone))
+                                 Rows Removed by Filter: 9
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=1439 loops=1)
                            Filter: (("time" < 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone) AND ("time" > ('2000-01-08'::cstring)::timestamp with time zone))
-                           Rows Removed by Filter: 2599
-                           ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=5 loops=1)
-                                 Filter: (_ts_meta_min_1 < 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone)
-                                 Rows Removed by Filter: 1
+                           Rows Removed by Filter: 1561
+                           ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=3 loops=1)
+                                 Filter: ((_ts_meta_min_1 < 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone) AND (_ts_meta_max_1 > ('2000-01-08'::cstring)::timestamp with time zone))
+                                 Rows Removed by Filter: 3
 (40 rows)
 
 :PREFIX
@@ -3579,38 +3609,38 @@ QUERY PLAN
                ->  Merge Append (actual rows=3595 loops=1)
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=719 loops=1)
                            Filter: (("time" > 'Fri Jan 07 00:00:00 2000 PST'::timestamp with time zone) AND ("time" < ('2000-01-08'::cstring)::timestamp with time zone))
-                           Rows Removed by Filter: 4281
-                           ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=5 loops=1)
-                                 Filter: (_ts_meta_max_1 > 'Fri Jan 07 00:00:00 2000 PST'::timestamp with time zone)
-                                 Rows Removed by Filter: 1
+                           Rows Removed by Filter: 1281
+                           ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=2 loops=1)
+                                 Filter: ((_ts_meta_max_1 > 'Fri Jan 07 00:00:00 2000 PST'::timestamp with time zone) AND (_ts_meta_min_1 < ('2000-01-08'::cstring)::timestamp with time zone))
+                                 Rows Removed by Filter: 4
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=2157 loops=1)
                            Filter: (("time" > 'Fri Jan 07 00:00:00 2000 PST'::timestamp with time zone) AND ("time" < ('2000-01-08'::cstring)::timestamp with time zone))
-                           Rows Removed by Filter: 12843
-                           ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=15 loops=1)
-                                 Filter: (_ts_meta_max_1 > 'Fri Jan 07 00:00:00 2000 PST'::timestamp with time zone)
-                                 Rows Removed by Filter: 3
+                           Rows Removed by Filter: 3843
+                           ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=6 loops=1)
+                                 Filter: ((_ts_meta_max_1 > 'Fri Jan 07 00:00:00 2000 PST'::timestamp with time zone) AND (_ts_meta_min_1 < ('2000-01-08'::cstring)::timestamp with time zone))
+                                 Rows Removed by Filter: 12
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=719 loops=1)
                            Filter: (("time" > 'Fri Jan 07 00:00:00 2000 PST'::timestamp with time zone) AND ("time" < ('2000-01-08'::cstring)::timestamp with time zone))
-                           Rows Removed by Filter: 4281
-                           ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=5 loops=1)
-                                 Filter: (_ts_meta_max_1 > 'Fri Jan 07 00:00:00 2000 PST'::timestamp with time zone)
-                                 Rows Removed by Filter: 1
+                           Rows Removed by Filter: 1281
+                           ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=2 loops=1)
+                                 Filter: ((_ts_meta_max_1 > 'Fri Jan 07 00:00:00 2000 PST'::timestamp with time zone) AND (_ts_meta_min_1 < ('2000-01-08'::cstring)::timestamp with time zone))
+                                 Rows Removed by Filter: 4
                ->  Merge Append (actual rows=0 loops=1)
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=0 loops=1)
                            Filter: (("time" > 'Fri Jan 07 00:00:00 2000 PST'::timestamp with time zone) AND ("time" < ('2000-01-08'::cstring)::timestamp with time zone))
-                           Rows Removed by Filter: 5038
-                           ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=6 loops=1)
-                                 Filter: (_ts_meta_max_1 > 'Fri Jan 07 00:00:00 2000 PST'::timestamp with time zone)
+                           ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=0 loops=1)
+                                 Filter: ((_ts_meta_max_1 > 'Fri Jan 07 00:00:00 2000 PST'::timestamp with time zone) AND (_ts_meta_min_1 < ('2000-01-08'::cstring)::timestamp with time zone))
+                                 Rows Removed by Filter: 6
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=0 loops=1)
                            Filter: (("time" > 'Fri Jan 07 00:00:00 2000 PST'::timestamp with time zone) AND ("time" < ('2000-01-08'::cstring)::timestamp with time zone))
-                           Rows Removed by Filter: 15114
-                           ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=18 loops=1)
-                                 Filter: (_ts_meta_max_1 > 'Fri Jan 07 00:00:00 2000 PST'::timestamp with time zone)
+                           ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=0 loops=1)
+                                 Filter: ((_ts_meta_max_1 > 'Fri Jan 07 00:00:00 2000 PST'::timestamp with time zone) AND (_ts_meta_min_1 < ('2000-01-08'::cstring)::timestamp with time zone))
+                                 Rows Removed by Filter: 18
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=0 loops=1)
                            Filter: (("time" > 'Fri Jan 07 00:00:00 2000 PST'::timestamp with time zone) AND ("time" < ('2000-01-08'::cstring)::timestamp with time zone))
-                           Rows Removed by Filter: 5038
-                           ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=6 loops=1)
-                                 Filter: (_ts_meta_max_1 > 'Fri Jan 07 00:00:00 2000 PST'::timestamp with time zone)
+                           ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=0 loops=1)
+                                 Filter: ((_ts_meta_max_1 > 'Fri Jan 07 00:00:00 2000 PST'::timestamp with time zone) AND (_ts_meta_min_1 < ('2000-01-08'::cstring)::timestamp with time zone))
+                                 Rows Removed by Filter: 6
 (40 rows)
 
 -- min/max queries

--- a/tsl/test/shared/expected/ordered_append-15.out
+++ b/tsl/test/shared/expected/ordered_append-15.out
@@ -2434,12 +2434,15 @@ QUERY PLAN
                Chunks excluded during startup: 1
                ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=16785 loops=1)
                      Filter: ("time" > ('2000-01-08'::cstring)::timestamp with time zone)
-                     Rows Removed by Filter: 8405
-                     ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=30 loops=1)
+                     Rows Removed by Filter: 3215
+                     ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=20 loops=1)
+                           Filter: (_ts_meta_max_1 > ('2000-01-08'::cstring)::timestamp with time zone)
+                           Rows Removed by Filter: 10
                ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=25190 loops=1)
                      Filter: ("time" > ('2000-01-08'::cstring)::timestamp with time zone)
                      ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=30 loops=1)
-(13 rows)
+                           Filter: (_ts_meta_max_1 > ('2000-01-08'::cstring)::timestamp with time zone)
+(16 rows)
 
 :PREFIX
 SELECT time
@@ -2457,11 +2460,14 @@ QUERY PLAN
                ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=17990 loops=1)
                      Filter: ("time" < ('2000-01-08'::cstring)::timestamp with time zone)
                      ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=20 loops=1)
+                           Filter: (_ts_meta_min_1 < ('2000-01-08'::cstring)::timestamp with time zone)
                ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=8400 loops=1)
                      Filter: ("time" < ('2000-01-08'::cstring)::timestamp with time zone)
-                     Rows Removed by Filter: 16790
-                     ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=30 loops=1)
-(13 rows)
+                     Rows Removed by Filter: 1790
+                     ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=15 loops=1)
+                           Filter: (_ts_meta_min_1 < ('2000-01-08'::cstring)::timestamp with time zone)
+                           Rows Removed by Filter: 15
+(16 rows)
 
 -- test constraint exclusion
 :PREFIX
@@ -2480,10 +2486,10 @@ QUERY PLAN
                Chunks excluded during startup: 1
                ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=7195 loops=1)
                      Filter: (("time" < 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone) AND ("time" > ('2000-01-08'::cstring)::timestamp with time zone))
-                     Rows Removed by Filter: 12995
-                     ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=25 loops=1)
-                           Filter: (_ts_meta_min_1 < 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone)
-                           Rows Removed by Filter: 5
+                     Rows Removed by Filter: 7805
+                     ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=15 loops=1)
+                           Filter: ((_ts_meta_min_1 < 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone) AND (_ts_meta_max_1 > ('2000-01-08'::cstring)::timestamp with time zone))
+                           Rows Removed by Filter: 15
 (12 rows)
 
 :PREFIX
@@ -2502,10 +2508,10 @@ QUERY PLAN
                Chunks excluded during startup: 1
                ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=3595 loops=1)
                      Filter: (("time" > 'Fri Jan 07 00:00:00 2000 PST'::timestamp with time zone) AND ("time" < ('2000-01-08'::cstring)::timestamp with time zone))
-                     Rows Removed by Filter: 21405
-                     ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=25 loops=1)
-                           Filter: (_ts_meta_max_1 > 'Fri Jan 07 00:00:00 2000 PST'::timestamp with time zone)
-                           Rows Removed by Filter: 5
+                     Rows Removed by Filter: 6405
+                     ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=10 loops=1)
+                           Filter: ((_ts_meta_max_1 > 'Fri Jan 07 00:00:00 2000 PST'::timestamp with time zone) AND (_ts_meta_min_1 < ('2000-01-08'::cstring)::timestamp with time zone))
+                           Rows Removed by Filter: 20
 (12 rows)
 
 -- min/max queries
@@ -3447,40 +3453,52 @@ QUERY PLAN
                ->  Merge Append (actual rows=0 loops=1)
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=0 loops=1)
                            Filter: ("time" > ('2000-01-08'::cstring)::timestamp with time zone)
-                           Rows Removed by Filter: 3598
-                           ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=4 loops=1)
+                           ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=0 loops=1)
+                                 Filter: (_ts_meta_max_1 > ('2000-01-08'::cstring)::timestamp with time zone)
+                                 Rows Removed by Filter: 4
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=0 loops=1)
                            Filter: ("time" > ('2000-01-08'::cstring)::timestamp with time zone)
-                           Rows Removed by Filter: 10794
-                           ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=12 loops=1)
+                           ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=0 loops=1)
+                                 Filter: (_ts_meta_max_1 > ('2000-01-08'::cstring)::timestamp with time zone)
+                                 Rows Removed by Filter: 12
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=0 loops=1)
                            Filter: ("time" > ('2000-01-08'::cstring)::timestamp with time zone)
-                           Rows Removed by Filter: 3598
-                           ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=4 loops=1)
+                           ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=0 loops=1)
+                                 Filter: (_ts_meta_max_1 > ('2000-01-08'::cstring)::timestamp with time zone)
+                                 Rows Removed by Filter: 4
                ->  Merge Append (actual rows=16785 loops=1)
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=3357 loops=1)
                            Filter: ("time" > ('2000-01-08'::cstring)::timestamp with time zone)
-                           Rows Removed by Filter: 1681
-                           ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=6 loops=1)
+                           Rows Removed by Filter: 643
+                           ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=4 loops=1)
+                                 Filter: (_ts_meta_max_1 > ('2000-01-08'::cstring)::timestamp with time zone)
+                                 Rows Removed by Filter: 2
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=10071 loops=1)
                            Filter: ("time" > ('2000-01-08'::cstring)::timestamp with time zone)
-                           Rows Removed by Filter: 5043
-                           ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=18 loops=1)
+                           Rows Removed by Filter: 1929
+                           ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=12 loops=1)
+                                 Filter: (_ts_meta_max_1 > ('2000-01-08'::cstring)::timestamp with time zone)
+                                 Rows Removed by Filter: 6
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=3357 loops=1)
                            Filter: ("time" > ('2000-01-08'::cstring)::timestamp with time zone)
-                           Rows Removed by Filter: 1681
-                           ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=6 loops=1)
+                           Rows Removed by Filter: 643
+                           ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=4 loops=1)
+                                 Filter: (_ts_meta_max_1 > ('2000-01-08'::cstring)::timestamp with time zone)
+                                 Rows Removed by Filter: 2
                ->  Merge Append (actual rows=25190 loops=1)
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=5038 loops=1)
                            Filter: ("time" > ('2000-01-08'::cstring)::timestamp with time zone)
                            ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=6 loops=1)
+                                 Filter: (_ts_meta_max_1 > ('2000-01-08'::cstring)::timestamp with time zone)
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=15114 loops=1)
                            Filter: ("time" > ('2000-01-08'::cstring)::timestamp with time zone)
                            ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=18 loops=1)
+                                 Filter: (_ts_meta_max_1 > ('2000-01-08'::cstring)::timestamp with time zone)
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=5038 loops=1)
                            Filter: ("time" > ('2000-01-08'::cstring)::timestamp with time zone)
                            ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=6 loops=1)
-(41 rows)
+                                 Filter: (_ts_meta_max_1 > ('2000-01-08'::cstring)::timestamp with time zone)
+(53 rows)
 
 :PREFIX
 SELECT time
@@ -3498,39 +3516,51 @@ QUERY PLAN
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=3598 loops=1)
                            Filter: ("time" < ('2000-01-08'::cstring)::timestamp with time zone)
                            ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=4 loops=1)
+                                 Filter: (_ts_meta_min_1 < ('2000-01-08'::cstring)::timestamp with time zone)
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=10794 loops=1)
                            Filter: ("time" < ('2000-01-08'::cstring)::timestamp with time zone)
                            ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=12 loops=1)
+                                 Filter: (_ts_meta_min_1 < ('2000-01-08'::cstring)::timestamp with time zone)
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=3598 loops=1)
                            Filter: ("time" < ('2000-01-08'::cstring)::timestamp with time zone)
                            ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=4 loops=1)
+                                 Filter: (_ts_meta_min_1 < ('2000-01-08'::cstring)::timestamp with time zone)
                ->  Merge Append (actual rows=8400 loops=1)
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=1680 loops=1)
                            Filter: ("time" < ('2000-01-08'::cstring)::timestamp with time zone)
-                           Rows Removed by Filter: 3358
-                           ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=6 loops=1)
+                           Rows Removed by Filter: 358
+                           ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=3 loops=1)
+                                 Filter: (_ts_meta_min_1 < ('2000-01-08'::cstring)::timestamp with time zone)
+                                 Rows Removed by Filter: 3
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=5040 loops=1)
                            Filter: ("time" < ('2000-01-08'::cstring)::timestamp with time zone)
-                           Rows Removed by Filter: 10074
-                           ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=18 loops=1)
+                           Rows Removed by Filter: 1074
+                           ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=9 loops=1)
+                                 Filter: (_ts_meta_min_1 < ('2000-01-08'::cstring)::timestamp with time zone)
+                                 Rows Removed by Filter: 9
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=1680 loops=1)
                            Filter: ("time" < ('2000-01-08'::cstring)::timestamp with time zone)
-                           Rows Removed by Filter: 3358
-                           ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=6 loops=1)
+                           Rows Removed by Filter: 358
+                           ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=3 loops=1)
+                                 Filter: (_ts_meta_min_1 < ('2000-01-08'::cstring)::timestamp with time zone)
+                                 Rows Removed by Filter: 3
                ->  Merge Append (actual rows=0 loops=1)
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=0 loops=1)
                            Filter: ("time" < ('2000-01-08'::cstring)::timestamp with time zone)
-                           Rows Removed by Filter: 5038
-                           ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=6 loops=1)
+                           ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=0 loops=1)
+                                 Filter: (_ts_meta_min_1 < ('2000-01-08'::cstring)::timestamp with time zone)
+                                 Rows Removed by Filter: 6
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=0 loops=1)
                            Filter: ("time" < ('2000-01-08'::cstring)::timestamp with time zone)
-                           Rows Removed by Filter: 15114
-                           ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=18 loops=1)
+                           ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=0 loops=1)
+                                 Filter: (_ts_meta_min_1 < ('2000-01-08'::cstring)::timestamp with time zone)
+                                 Rows Removed by Filter: 18
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=0 loops=1)
                            Filter: ("time" < ('2000-01-08'::cstring)::timestamp with time zone)
-                           Rows Removed by Filter: 5038
-                           ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=6 loops=1)
-(41 rows)
+                           ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=0 loops=1)
+                                 Filter: (_ts_meta_min_1 < ('2000-01-08'::cstring)::timestamp with time zone)
+                                 Rows Removed by Filter: 6
+(53 rows)
 
 -- test constraint exclusion
 :PREFIX
@@ -3549,38 +3579,38 @@ QUERY PLAN
                ->  Merge Append (actual rows=0 loops=1)
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=0 loops=1)
                            Filter: (("time" < 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone) AND ("time" > ('2000-01-08'::cstring)::timestamp with time zone))
-                           Rows Removed by Filter: 3598
-                           ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=4 loops=1)
-                                 Filter: (_ts_meta_min_1 < 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone)
+                           ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=0 loops=1)
+                                 Filter: ((_ts_meta_min_1 < 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone) AND (_ts_meta_max_1 > ('2000-01-08'::cstring)::timestamp with time zone))
+                                 Rows Removed by Filter: 4
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=0 loops=1)
                            Filter: (("time" < 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone) AND ("time" > ('2000-01-08'::cstring)::timestamp with time zone))
-                           Rows Removed by Filter: 10794
-                           ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=12 loops=1)
-                                 Filter: (_ts_meta_min_1 < 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone)
+                           ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=0 loops=1)
+                                 Filter: ((_ts_meta_min_1 < 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone) AND (_ts_meta_max_1 > ('2000-01-08'::cstring)::timestamp with time zone))
+                                 Rows Removed by Filter: 12
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=0 loops=1)
                            Filter: (("time" < 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone) AND ("time" > ('2000-01-08'::cstring)::timestamp with time zone))
-                           Rows Removed by Filter: 3598
-                           ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=4 loops=1)
-                                 Filter: (_ts_meta_min_1 < 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone)
+                           ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=0 loops=1)
+                                 Filter: ((_ts_meta_min_1 < 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone) AND (_ts_meta_max_1 > ('2000-01-08'::cstring)::timestamp with time zone))
+                                 Rows Removed by Filter: 4
                ->  Merge Append (actual rows=7195 loops=1)
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=1439 loops=1)
                            Filter: (("time" < 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone) AND ("time" > ('2000-01-08'::cstring)::timestamp with time zone))
-                           Rows Removed by Filter: 2599
-                           ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=5 loops=1)
-                                 Filter: (_ts_meta_min_1 < 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone)
-                                 Rows Removed by Filter: 1
+                           Rows Removed by Filter: 1561
+                           ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=3 loops=1)
+                                 Filter: ((_ts_meta_min_1 < 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone) AND (_ts_meta_max_1 > ('2000-01-08'::cstring)::timestamp with time zone))
+                                 Rows Removed by Filter: 3
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=4317 loops=1)
                            Filter: (("time" < 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone) AND ("time" > ('2000-01-08'::cstring)::timestamp with time zone))
-                           Rows Removed by Filter: 7797
-                           ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=15 loops=1)
-                                 Filter: (_ts_meta_min_1 < 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone)
-                                 Rows Removed by Filter: 3
+                           Rows Removed by Filter: 4683
+                           ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=9 loops=1)
+                                 Filter: ((_ts_meta_min_1 < 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone) AND (_ts_meta_max_1 > ('2000-01-08'::cstring)::timestamp with time zone))
+                                 Rows Removed by Filter: 9
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=1439 loops=1)
                            Filter: (("time" < 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone) AND ("time" > ('2000-01-08'::cstring)::timestamp with time zone))
-                           Rows Removed by Filter: 2599
-                           ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=5 loops=1)
-                                 Filter: (_ts_meta_min_1 < 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone)
-                                 Rows Removed by Filter: 1
+                           Rows Removed by Filter: 1561
+                           ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=3 loops=1)
+                                 Filter: ((_ts_meta_min_1 < 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone) AND (_ts_meta_max_1 > ('2000-01-08'::cstring)::timestamp with time zone))
+                                 Rows Removed by Filter: 3
 (40 rows)
 
 :PREFIX
@@ -3599,38 +3629,38 @@ QUERY PLAN
                ->  Merge Append (actual rows=3595 loops=1)
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=719 loops=1)
                            Filter: (("time" > 'Fri Jan 07 00:00:00 2000 PST'::timestamp with time zone) AND ("time" < ('2000-01-08'::cstring)::timestamp with time zone))
-                           Rows Removed by Filter: 4281
-                           ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=5 loops=1)
-                                 Filter: (_ts_meta_max_1 > 'Fri Jan 07 00:00:00 2000 PST'::timestamp with time zone)
-                                 Rows Removed by Filter: 1
+                           Rows Removed by Filter: 1281
+                           ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=2 loops=1)
+                                 Filter: ((_ts_meta_max_1 > 'Fri Jan 07 00:00:00 2000 PST'::timestamp with time zone) AND (_ts_meta_min_1 < ('2000-01-08'::cstring)::timestamp with time zone))
+                                 Rows Removed by Filter: 4
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=2157 loops=1)
                            Filter: (("time" > 'Fri Jan 07 00:00:00 2000 PST'::timestamp with time zone) AND ("time" < ('2000-01-08'::cstring)::timestamp with time zone))
-                           Rows Removed by Filter: 12843
-                           ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=15 loops=1)
-                                 Filter: (_ts_meta_max_1 > 'Fri Jan 07 00:00:00 2000 PST'::timestamp with time zone)
-                                 Rows Removed by Filter: 3
+                           Rows Removed by Filter: 3843
+                           ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=6 loops=1)
+                                 Filter: ((_ts_meta_max_1 > 'Fri Jan 07 00:00:00 2000 PST'::timestamp with time zone) AND (_ts_meta_min_1 < ('2000-01-08'::cstring)::timestamp with time zone))
+                                 Rows Removed by Filter: 12
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=719 loops=1)
                            Filter: (("time" > 'Fri Jan 07 00:00:00 2000 PST'::timestamp with time zone) AND ("time" < ('2000-01-08'::cstring)::timestamp with time zone))
-                           Rows Removed by Filter: 4281
-                           ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=5 loops=1)
-                                 Filter: (_ts_meta_max_1 > 'Fri Jan 07 00:00:00 2000 PST'::timestamp with time zone)
-                                 Rows Removed by Filter: 1
+                           Rows Removed by Filter: 1281
+                           ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=2 loops=1)
+                                 Filter: ((_ts_meta_max_1 > 'Fri Jan 07 00:00:00 2000 PST'::timestamp with time zone) AND (_ts_meta_min_1 < ('2000-01-08'::cstring)::timestamp with time zone))
+                                 Rows Removed by Filter: 4
                ->  Merge Append (actual rows=0 loops=1)
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=0 loops=1)
                            Filter: (("time" > 'Fri Jan 07 00:00:00 2000 PST'::timestamp with time zone) AND ("time" < ('2000-01-08'::cstring)::timestamp with time zone))
-                           Rows Removed by Filter: 5038
-                           ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=6 loops=1)
-                                 Filter: (_ts_meta_max_1 > 'Fri Jan 07 00:00:00 2000 PST'::timestamp with time zone)
+                           ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=0 loops=1)
+                                 Filter: ((_ts_meta_max_1 > 'Fri Jan 07 00:00:00 2000 PST'::timestamp with time zone) AND (_ts_meta_min_1 < ('2000-01-08'::cstring)::timestamp with time zone))
+                                 Rows Removed by Filter: 6
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=0 loops=1)
                            Filter: (("time" > 'Fri Jan 07 00:00:00 2000 PST'::timestamp with time zone) AND ("time" < ('2000-01-08'::cstring)::timestamp with time zone))
-                           Rows Removed by Filter: 15114
-                           ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=18 loops=1)
-                                 Filter: (_ts_meta_max_1 > 'Fri Jan 07 00:00:00 2000 PST'::timestamp with time zone)
+                           ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=0 loops=1)
+                                 Filter: ((_ts_meta_max_1 > 'Fri Jan 07 00:00:00 2000 PST'::timestamp with time zone) AND (_ts_meta_min_1 < ('2000-01-08'::cstring)::timestamp with time zone))
+                                 Rows Removed by Filter: 18
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=0 loops=1)
                            Filter: (("time" > 'Fri Jan 07 00:00:00 2000 PST'::timestamp with time zone) AND ("time" < ('2000-01-08'::cstring)::timestamp with time zone))
-                           Rows Removed by Filter: 5038
-                           ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=6 loops=1)
-                                 Filter: (_ts_meta_max_1 > 'Fri Jan 07 00:00:00 2000 PST'::timestamp with time zone)
+                           ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=0 loops=1)
+                                 Filter: ((_ts_meta_max_1 > 'Fri Jan 07 00:00:00 2000 PST'::timestamp with time zone) AND (_ts_meta_min_1 < ('2000-01-08'::cstring)::timestamp with time zone))
+                                 Rows Removed by Filter: 6
 (40 rows)
 
 -- min/max queries


### PR DESCRIPTION
WHERE clause with SEGMENTBY column of type text/bytea non-equality operators are not pushed down to Seq Scan node of compressed chunk. This patch fixes this issue.

Fixes #5286