### PR TITLE
Look up compressed column metadata at planning time

### DIFF
--- a/tsl/src/nodes/decompress_chunk/decompress_chunk.h
+++ b/tsl/src/nodes/decompress_chunk/decompress_chunk.h
@@ -49,6 +49,17 @@ typedef struct DecompressChunkPath
 	 * uncompressed chunk, but are still used for decompression.
 	 */
 	List *decompression_map;
+
+	/*
+	 * This Int list is parallel to the compressed scan targetlist, just like
+	 * the above one. The value is true if a given targetlist entry is a
+	 * segmentby column, false otherwise. Has the same length as the above list.
+	 * We have to use the parallel lists and not a list of structs, because the
+	 * Plans have to be copyable by the Postgres _copy functions, and we can't
+	 * do that for a custom struct.
+	 */
+	List *is_segmentby_column;
+
 	List *compressed_pathkeys;
 	bool needs_sequence_num;
 	bool reverse;

--- a/tsl/src/nodes/decompress_chunk/planner.c
+++ b/tsl/src/nodes/decompress_chunk/planner.c
@@ -227,6 +227,9 @@ build_decompression_map(DecompressChunkPath *path, List *scan_tlist, Bitmapset *
 
 		path->decompression_map =
 			lappend_int(path->decompression_map, destination_attno_in_uncompressed_chunk);
+		path->is_segmentby_column =
+			lappend_int(path->is_segmentby_column,
+						compression_info && compression_info->segmentby_column_index != 0);
 	}
 
 	/*
@@ -472,7 +475,8 @@ decompress_chunk_plan_create(PlannerInfo *root, RelOptInfo *rel, CustomPath *pat
 	settings = list_make3_int(dcpath->info->hypertable_id,
 							  dcpath->info->chunk_rte->relid,
 							  dcpath->reverse);
-	decompress_plan->custom_private = list_make2(settings, dcpath->decompression_map);
+	decompress_plan->custom_private =
+		list_make3(settings, dcpath->decompression_map, dcpath->is_segmentby_column);
 
 	return &decompress_plan->scan.plan;
 }


### PR DESCRIPTION
Now we look them up at execution time for each chunk separately, which adds up for tables with a large number of chunks.

This gives about 15% speedup (100 mcs) on a small query on a table from tests with 50 chunks:
`select id, ts, value from metric_compressed order by id, ts limit 100;`

Disable-check: force-changelog-changed