### PR TITLE
Remove unused functions

### DIFF
--- a/src/ts_catalog/catalog.c
+++ b/src/ts_catalog/catalog.c
@@ -709,18 +709,6 @@ ts_catalog_delete_tid(Relation rel, ItemPointer tid)
 	CommandCounterIncrement();
 }
 
-void
-ts_catalog_delete_only(Relation rel, HeapTuple tuple)
-{
-	ts_catalog_delete_tid_only(rel, &tuple->t_self);
-}
-
-void
-ts_catalog_delete(Relation rel, HeapTuple tuple)
-{
-	ts_catalog_delete_tid(rel, &tuple->t_self);
-}
-
 /*
  * Invalidate TimescaleDB catalog caches.
  *

--- a/src/ts_catalog/catalog.h
+++ b/src/ts_catalog/catalog.h
@@ -1472,8 +1472,6 @@ extern TSDLLEXPORT void ts_catalog_update_tid(Relation rel, ItemPointer tid, Hea
 extern TSDLLEXPORT void ts_catalog_update(Relation rel, HeapTuple tuple);
 extern TSDLLEXPORT void ts_catalog_delete_tid_only(Relation rel, ItemPointer tid);
 extern TSDLLEXPORT void ts_catalog_delete_tid(Relation rel, ItemPointer tid);
-extern TSDLLEXPORT void ts_catalog_delete_only(Relation rel, HeapTuple tuple);
-extern TSDLLEXPORT void ts_catalog_delete(Relation rel, HeapTuple tuple);
 extern TSDLLEXPORT void ts_catalog_invalidate_cache(Oid catalog_relid, CmdType operation);
 
 bool TSDLLEXPORT ts_catalog_scan_one(CatalogTable table, int indexid, ScanKeyData *scankey,


### PR DESCRIPTION
We don't use `ts_catalog_delete[_only]` functions anywhere and instead we rely on `ts_catalog_delete_tid[_only]` functions so removing it from our code base.

Disable-check: force-changelog-changed
