### PR TITLE
Out of on_proc_exit slots on guc license change

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,10 +13,12 @@ accidentally triggering the load of a previous DB version.**
 
 **Bugfixes**
 * #5396 Fix SEGMENTBY columns predicates to be pushed down
-* #5410 Fix file trailer handling in the COPY fetcher 
+* #5410 Fix file trailer handling in the COPY fetcher
+* #5233 Out of on_proc_exit slots on guc license change
 
 **Thanks**
 * @nikolaps for reporting an issue with the COPY fetcher
+* @S-imo-n for reporting the issue on Background Worker Scheduler crash
 
 ## 2.10.1 (2023-03-07)
 

--- a/tsl/src/init.c
+++ b/tsl/src/init.c
@@ -255,6 +255,7 @@ TS_FUNCTION_INFO_V1(ts_module_init);
 PGDLLEXPORT Datum
 ts_module_init(PG_FUNCTION_ARGS)
 {
+	bool register_proc_exit = PG_GETARG_BOOL(0);
 	ts_cm_functions = &tsl_cm_functions;
 
 	_continuous_aggs_cache_inval_init();
@@ -264,7 +265,8 @@ ts_module_init(PG_FUNCTION_ARGS)
 	_remote_dist_txn_init();
 	_tsl_process_utility_init();
 	/* Register a cleanup function to be called when the backend exits */
-	on_proc_exit(ts_module_cleanup_on_pg_exit, 0);
+	if (register_proc_exit)
+		on_proc_exit(ts_module_cleanup_on_pg_exit, 0);
 	PG_RETURN_BOOL(true);
 }
 


### PR DESCRIPTION
When the guc timescaledb.license = 'timescale' is set in the conf file
and a SIGHUP is sent to postgress process and a reload of the tsl
module is triggered.

This reload happens in 2 phases 1. tsl_module_load is called which
will load the module only if not already loaded and 2.The
ts_module_init is called for every ts_license_guc_assign_hook
irrespective of if it is new load.This ts_module_init initialization
function also registers a on_proc_exit function to be called on exit.

The list of on_proc_exit methods are maintained in a fixed array
on_proc_exit_list of size MAX_ON_EXITS (20) which gets filled up on
repeated SIGHUPs and hence an error.

Fix:

The fix is to make the ts_module_init() register the on_proc_exit
callback, only in case the module is reloaded and not in every init
call.

Closes #5233
