### PR TITLE
Fix assertion in calculate_chunk_interval for negative target size

### DIFF
--- a/src/chunk_adaptive.c
+++ b/src/chunk_adaptive.c
@@ -429,7 +429,9 @@ ts_calculate_chunk_interval(PG_FUNCTION_ARGS)
 	if (PG_NARGS() != CHUNK_SIZING_FUNC_NARGS)
 		elog(ERROR, "invalid number of arguments");
 
-	Assert(chunk_target_size_bytes >= 0);
+	if (chunk_target_size_bytes < 0)
+		elog(ERROR, "chunk_target_size must be positive");
+
 	elog(DEBUG1, "[adaptive] chunk_target_size_bytes=" UINT64_FORMAT, chunk_target_size_bytes);
 
 	hypertable_id = ts_dimension_get_hypertable_id(dimension_id);

--- a/test/expected/chunk_adaptive.out
+++ b/test/expected/chunk_adaptive.out
@@ -1,6 +1,13 @@
 -- This file and its contents are licensed under the Apache License 2.0.
 -- Please see the included NOTICE for copyright information and
 -- LICENSE-APACHE for a copy of the license.
+-- test error handling _timescaledb_internal.calculate_chunk_interval
+\set ON_ERROR_STOP 0
+SELECT _timescaledb_internal.calculate_chunk_interval(0,0,-0);
+ERROR:  could not find a matching hypertable for dimension 0
+SELECT _timescaledb_internal.calculate_chunk_interval(1,0,-1);
+ERROR:  chunk_target_size must be positive
+\set ON_ERROR_STOP 1
 -- Valid chunk sizing function for testing
 CREATE OR REPLACE FUNCTION calculate_chunk_interval(
         dimension_id INTEGER,

--- a/test/sql/chunk_adaptive.sql
+++ b/test/sql/chunk_adaptive.sql
@@ -2,6 +2,12 @@
 -- Please see the included NOTICE for copyright information and
 -- LICENSE-APACHE for a copy of the license.
 
+-- test error handling _timescaledb_internal.calculate_chunk_interval
+\set ON_ERROR_STOP 0
+SELECT _timescaledb_internal.calculate_chunk_interval(0,0,-0);
+SELECT _timescaledb_internal.calculate_chunk_interval(1,0,-1);
+\set ON_ERROR_STOP 1
+
 -- Valid chunk sizing function for testing
 CREATE OR REPLACE FUNCTION calculate_chunk_interval(
         dimension_id INTEGER,


### PR DESCRIPTION
When called with negative chunk_target_size_bytes calculate_chunk_interval will throw an assertion. This patch adds error handling for this condition. Found by sqlsmith.

Disable-check: force-changelog-changed
