### PR TITLE
Use version checks to decide about RelationGetSmgr backporting

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -504,18 +504,6 @@ if(NOT EXISTS ${PG_INCLUDEDIR}/pg_config.h)
   )
 endif()
 
-# This is currently only available in snapshot branches so we cannot use the
-# normal pg version check to determine availability.
-if(EXISTS ${PG_INCLUDEDIR_SERVER}/utils/rel.h)
-  file(READ ${PG_INCLUDEDIR_SERVER}/utils/rel.h PG_UTILS_REL_H)
-  string(REGEX MATCH "RelationGetSmgr" PG_HAVE_RELATION_GET_SMGR
-               ${PG_UTILS_REL_H})
-endif()
-
-if(PG_HAVE_RELATION_GET_SMGR)
-  add_compile_definitions(PG_HAVE_RELATION_GET_SMGR=1)
-endif()
-
 file(READ ${PG_INCLUDEDIR}/pg_config.h PG_CONFIG_H)
 string(REGEX MATCH "#define USE_ASSERT_CHECKING 1" PG_USE_ASSERT_CHECKING
              ${PG_CONFIG_H})

--- a/src/compat/compat.h
+++ b/src/compat/compat.h
@@ -759,8 +759,8 @@ pg_strtoint64(const char *str)
 						 is_crosspart_update)
 #endif
 
-#if PG13_GE
-#ifndef PG_HAVE_RELATION_GET_SMGR
+#if (PG12 && PG_VERSION_NUM < 120014) || (PG13 && PG_VERSION_NUM < 130010) ||                      \
+	(PG14 && PG_VERSION_NUM < 140007)
 #include <storage/smgr.h>
 /*
  * RelationGetSmgr
@@ -786,7 +786,6 @@ RelationGetSmgr(Relation rel)
 		smgrsetowner(&(rel->rd_smgr), smgropen(rel->rd_node, rel->rd_backend));
 	return rel->rd_smgr;
 }
-#endif
 #endif
 
 #endif /* TIMESCALEDB_COMPAT_H */


### PR DESCRIPTION
Use explicit version checks to decide whether to define backported RelationGetSmgr function or rely on the function being available. This simplifies the cmake code a bit and make the backporting similar to how we handle this for other functions.