### PR TITLE
Refactor and optimize distributed COPY

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ accidentally triggering the load of a previous DB version.**
 * #5312 Add timeout support to ping_data_node()
 * #5454 Add support for ON CONFLICT DO UPDATE for compressed hypertables
 * #5344 Enable JOINS for Hierarchical Continuous Aggregates
+* #5417 Refactor and optimize distributed COPY
 
 **Bugfixes**
 * #5396 Fix SEGMENTBY columns predicates to be pushed down

--- a/tsl/src/fdw/option.c
+++ b/tsl/src/fdw/option.c
@@ -133,7 +133,8 @@ option_validate(List *options_list, Oid catalog)
 			if (fetch_size <= 0)
 				ereport(ERROR,
 						(errcode(ERRCODE_SYNTAX_ERROR),
-						 errmsg("%s requires a non-negative integer value", def->defname)));
+						 errmsg("%s requires a non-zero and positive integer value",
+								def->defname)));
 		}
 		else if (strcmp(def->defname, "available") == 0)
 		{
@@ -144,6 +145,18 @@ option_validate(List *options_list, Oid catalog)
 		{
 			/* check and store list, warn about non existing tables */
 			(void) option_extract_join_ref_table_list(defGetString(def));
+		}
+		else if (strcmp(def->defname, "copy_rows_per_message") == 0)
+		{
+			int copy_rows_per_message;
+
+			copy_rows_per_message = strtol(defGetString(def), NULL, 10);
+
+			if (copy_rows_per_message <= 0)
+				ereport(ERROR,
+						(errcode(ERRCODE_SYNTAX_ERROR),
+						 errmsg("%s requires a non-zero and positive integer value",
+								def->defname)));
 		}
 	}
 }
@@ -170,6 +183,8 @@ init_ts_fdw_options(void)
 		{ "available", ForeignServerRelationId },
 		/* join reference tables */
 		{ "reference_tables", ForeignDataWrapperRelationId },
+		/* Rows per CopyData when ingesting with COPY */
+		{ "copy_rows_per_message", ForeignDataWrapperRelationId },
 		{ NULL, InvalidOid }
 	};
 

--- a/tsl/src/remote/CMakeLists.txt
+++ b/tsl/src/remote/CMakeLists.txt
@@ -21,4 +21,5 @@ set(SOURCES
     ${CMAKE_CURRENT_SOURCE_DIR}/txn_store.c
     ${CMAKE_CURRENT_SOURCE_DIR}/utils.c)
 target_sources(${TSL_LIBRARY_NAME} PRIVATE ${SOURCES})
-target_include_directories(${TSL_LIBRARY_NAME} PRIVATE ${PG_INCLUDEDIR})
+target_include_directories(${TSL_LIBRARY_NAME}
+                           PRIVATE ${PG_INCLUDEDIR} ${PG_INCLUDEDIR}/postgresql)

--- a/tsl/src/remote/connection.c
+++ b/tsl/src/remote/connection.c
@@ -2363,7 +2363,7 @@ err_end_copy:
 	return false;
 }
 
-bool
+int
 remote_connection_put_copy_data(TSConnection *conn, const char *buffer, size_t len,
 								TSConnectionError *err)
 {
@@ -2371,13 +2371,13 @@ remote_connection_put_copy_data(TSConnection *conn, const char *buffer, size_t l
 
 	res = PQputCopyData(remote_connection_get_pg_conn(conn), buffer, len);
 
-	if (res != 1)
+	if (res == -1)
 		return fill_connection_error(err,
 									 ERRCODE_CONNECTION_EXCEPTION,
 									 "could not send COPY data",
 									 conn);
 
-	return true;
+	return res;
 }
 
 static bool

--- a/tsl/src/remote/connection.h
+++ b/tsl/src/remote/connection.h
@@ -150,8 +150,8 @@ extern RemoteConnectionStats *remote_connection_stats_get(void);
 extern bool remote_connection_begin_copy(TSConnection *conn, const char *copycmd, bool binary,
 										 TSConnectionError *err);
 extern bool remote_connection_end_copy(TSConnection *conn, TSConnectionError *err);
-extern bool remote_connection_put_copy_data(TSConnection *conn, const char *buffer, size_t len,
-											TSConnectionError *err);
+extern int remote_connection_put_copy_data(TSConnection *conn, const char *buffer, size_t len,
+										   TSConnectionError *err);
 
 /* Error handling functions for connections */
 extern void remote_connection_get_error(const TSConnection *conn, TSConnectionError *err);

--- a/tsl/src/remote/dist_copy.h
+++ b/tsl/src/remote/dist_copy.h
@@ -19,7 +19,7 @@ extern RemoteCopyContext *remote_copy_begin(const CopyStmt *stmt, Hypertable *ht
 											ExprContext *per_tuple_ctx, List *attnums,
 											bool binary_copy);
 extern void remote_copy_end_on_success(RemoteCopyContext *context);
-extern bool remote_copy_send_slot(RemoteCopyContext *context, TupleTableSlot *slot,
+extern void remote_copy_send_slot(RemoteCopyContext *context, TupleTableSlot *slot,
 								  const ChunkInsertState *cis);
 extern const char *remote_copy_get_copycmd(RemoteCopyContext *context);
 

--- a/tsl/test/expected/dist_copy_format_long.out
+++ b/tsl/test/expected/dist_copy_format_long.out
@@ -31,6 +31,8 @@ SELECT 1 FROM add_data_node('data_node_3', host => 'localhost',
 GRANT USAGE ON FOREIGN SERVER data_node_1, data_node_2, data_node_3 TO PUBLIC;
 -- though user on access node has required GRANTS, this will propagate GRANTS to the connected data nodes
 GRANT CREATE ON SCHEMA public TO :ROLE_1;
+-- buffer a lot of rows per message to test buffer expansion
+ALTER FOREIGN DATA WRAPPER timescaledb_fdw OPTIONS (ADD copy_rows_per_message '1000');
 SET ROLE :ROLE_1;
 -- Aim to about 100 partitions, the data is from 1995 to 2022.
 create table uk_price_paid(price integer, "date" date, postcode1 text, postcode2 text, type smallint, is_new bool, duration smallint, addr1 text, addr2 text, street text, locality text, town text, district text, country text, category smallint);

--- a/tsl/test/expected/dist_remote_error-14.out
+++ b/tsl/test/expected/dist_remote_error-14.out
@@ -322,20 +322,20 @@ select * from metrics_dist_ss;
                Output: metrics_dist_ss_1."time", metrics_dist_ss_1.device_id, metrics_dist_ss_1.v0, metrics_dist_ss_1.v1, metrics_dist_ss_1.v2, metrics_dist_ss_1.v3
                Data node: db_dist_remote_error_1
                Fetcher Type: Prepared statement
-               Chunks: _dist_hyper_5_96_chunk, _dist_hyper_5_99_chunk, _dist_hyper_5_102_chunk
-               Remote SQL: SELECT "time", device_id, v0, v1, v2, v3 FROM public.metrics_dist_ss WHERE _timescaledb_internal.chunks_in(public.metrics_dist_ss.*, ARRAY[54, 55, 56])
+               Chunks: _dist_hyper_5_123_chunk, _dist_hyper_5_126_chunk, _dist_hyper_5_129_chunk
+               Remote SQL: SELECT "time", device_id, v0, v1, v2, v3 FROM public.metrics_dist_ss WHERE _timescaledb_internal.chunks_in(public.metrics_dist_ss.*, ARRAY[57, 58, 59])
          ->  Custom Scan (DataNodeScan) on public.metrics_dist_ss metrics_dist_ss_2 (actual rows=13680 loops=1)
                Output: metrics_dist_ss_2."time", metrics_dist_ss_2.device_id, metrics_dist_ss_2.v0, metrics_dist_ss_2.v1, metrics_dist_ss_2.v2, metrics_dist_ss_2.v3
                Data node: db_dist_remote_error_2
                Fetcher Type: Prepared statement
-               Chunks: _dist_hyper_5_97_chunk, _dist_hyper_5_100_chunk, _dist_hyper_5_103_chunk
-               Remote SQL: SELECT "time", device_id, v0, v1, v2, v3 FROM public.metrics_dist_ss WHERE _timescaledb_internal.chunks_in(public.metrics_dist_ss.*, ARRAY[48, 49, 50])
+               Chunks: _dist_hyper_5_124_chunk, _dist_hyper_5_127_chunk, _dist_hyper_5_130_chunk
+               Remote SQL: SELECT "time", device_id, v0, v1, v2, v3 FROM public.metrics_dist_ss WHERE _timescaledb_internal.chunks_in(public.metrics_dist_ss.*, ARRAY[49, 50, 51])
          ->  Custom Scan (DataNodeScan) on public.metrics_dist_ss metrics_dist_ss_3 (actual rows=4560 loops=1)
                Output: metrics_dist_ss_3."time", metrics_dist_ss_3.device_id, metrics_dist_ss_3.v0, metrics_dist_ss_3.v1, metrics_dist_ss_3.v2, metrics_dist_ss_3.v3
                Data node: db_dist_remote_error_3
                Fetcher Type: Prepared statement
-               Chunks: _dist_hyper_5_98_chunk, _dist_hyper_5_101_chunk, _dist_hyper_5_104_chunk
-               Remote SQL: SELECT "time", device_id, v0, v1, v2, v3 FROM public.metrics_dist_ss WHERE _timescaledb_internal.chunks_in(public.metrics_dist_ss.*, ARRAY[32, 33, 34])
+               Chunks: _dist_hyper_5_125_chunk, _dist_hyper_5_128_chunk, _dist_hyper_5_131_chunk
+               Remote SQL: SELECT "time", device_id, v0, v1, v2, v3 FROM public.metrics_dist_ss WHERE _timescaledb_internal.chunks_in(public.metrics_dist_ss.*, ARRAY[38, 39, 40])
 (21 rows)
 
 set timescaledb.remote_data_fetcher = 'copy';
@@ -350,20 +350,20 @@ select * from metrics_dist_ss;
                Output: metrics_dist_ss_1."time", metrics_dist_ss_1.device_id, metrics_dist_ss_1.v0, metrics_dist_ss_1.v1, metrics_dist_ss_1.v2, metrics_dist_ss_1.v3
                Data node: db_dist_remote_error_1
                Fetcher Type: COPY
-               Chunks: _dist_hyper_5_96_chunk, _dist_hyper_5_99_chunk, _dist_hyper_5_102_chunk
-               Remote SQL: SELECT "time", device_id, v0, v1, v2, v3 FROM public.metrics_dist_ss WHERE _timescaledb_internal.chunks_in(public.metrics_dist_ss.*, ARRAY[54, 55, 56])
+               Chunks: _dist_hyper_5_123_chunk, _dist_hyper_5_126_chunk, _dist_hyper_5_129_chunk
+               Remote SQL: SELECT "time", device_id, v0, v1, v2, v3 FROM public.metrics_dist_ss WHERE _timescaledb_internal.chunks_in(public.metrics_dist_ss.*, ARRAY[57, 58, 59])
          ->  Custom Scan (DataNodeScan) on public.metrics_dist_ss metrics_dist_ss_2 (actual rows=13680 loops=1)
                Output: metrics_dist_ss_2."time", metrics_dist_ss_2.device_id, metrics_dist_ss_2.v0, metrics_dist_ss_2.v1, metrics_dist_ss_2.v2, metrics_dist_ss_2.v3
                Data node: db_dist_remote_error_2
                Fetcher Type: COPY
-               Chunks: _dist_hyper_5_97_chunk, _dist_hyper_5_100_chunk, _dist_hyper_5_103_chunk
-               Remote SQL: SELECT "time", device_id, v0, v1, v2, v3 FROM public.metrics_dist_ss WHERE _timescaledb_internal.chunks_in(public.metrics_dist_ss.*, ARRAY[48, 49, 50])
+               Chunks: _dist_hyper_5_124_chunk, _dist_hyper_5_127_chunk, _dist_hyper_5_130_chunk
+               Remote SQL: SELECT "time", device_id, v0, v1, v2, v3 FROM public.metrics_dist_ss WHERE _timescaledb_internal.chunks_in(public.metrics_dist_ss.*, ARRAY[49, 50, 51])
          ->  Custom Scan (DataNodeScan) on public.metrics_dist_ss metrics_dist_ss_3 (actual rows=4560 loops=1)
                Output: metrics_dist_ss_3."time", metrics_dist_ss_3.device_id, metrics_dist_ss_3.v0, metrics_dist_ss_3.v1, metrics_dist_ss_3.v2, metrics_dist_ss_3.v3
                Data node: db_dist_remote_error_3
                Fetcher Type: COPY
-               Chunks: _dist_hyper_5_98_chunk, _dist_hyper_5_101_chunk, _dist_hyper_5_104_chunk
-               Remote SQL: SELECT "time", device_id, v0, v1, v2, v3 FROM public.metrics_dist_ss WHERE _timescaledb_internal.chunks_in(public.metrics_dist_ss.*, ARRAY[32, 33, 34])
+               Chunks: _dist_hyper_5_125_chunk, _dist_hyper_5_128_chunk, _dist_hyper_5_131_chunk
+               Remote SQL: SELECT "time", device_id, v0, v1, v2, v3 FROM public.metrics_dist_ss WHERE _timescaledb_internal.chunks_in(public.metrics_dist_ss.*, ARRAY[38, 39, 40])
 (21 rows)
 
 set timescaledb.remote_data_fetcher = 'cursor';
@@ -378,20 +378,20 @@ select * from metrics_dist_ss;
                Output: metrics_dist_ss_1."time", metrics_dist_ss_1.device_id, metrics_dist_ss_1.v0, metrics_dist_ss_1.v1, metrics_dist_ss_1.v2, metrics_dist_ss_1.v3
                Data node: db_dist_remote_error_1
                Fetcher Type: Cursor
-               Chunks: _dist_hyper_5_96_chunk, _dist_hyper_5_99_chunk, _dist_hyper_5_102_chunk
-               Remote SQL: SELECT "time", device_id, v0, v1, v2, v3 FROM public.metrics_dist_ss WHERE _timescaledb_internal.chunks_in(public.metrics_dist_ss.*, ARRAY[54, 55, 56])
+               Chunks: _dist_hyper_5_123_chunk, _dist_hyper_5_126_chunk, _dist_hyper_5_129_chunk
+               Remote SQL: SELECT "time", device_id, v0, v1, v2, v3 FROM public.metrics_dist_ss WHERE _timescaledb_internal.chunks_in(public.metrics_dist_ss.*, ARRAY[57, 58, 59])
          ->  Custom Scan (DataNodeScan) on public.metrics_dist_ss metrics_dist_ss_2 (actual rows=13680 loops=1)
                Output: metrics_dist_ss_2."time", metrics_dist_ss_2.device_id, metrics_dist_ss_2.v0, metrics_dist_ss_2.v1, metrics_dist_ss_2.v2, metrics_dist_ss_2.v3
                Data node: db_dist_remote_error_2
                Fetcher Type: Cursor
-               Chunks: _dist_hyper_5_97_chunk, _dist_hyper_5_100_chunk, _dist_hyper_5_103_chunk
-               Remote SQL: SELECT "time", device_id, v0, v1, v2, v3 FROM public.metrics_dist_ss WHERE _timescaledb_internal.chunks_in(public.metrics_dist_ss.*, ARRAY[48, 49, 50])
+               Chunks: _dist_hyper_5_124_chunk, _dist_hyper_5_127_chunk, _dist_hyper_5_130_chunk
+               Remote SQL: SELECT "time", device_id, v0, v1, v2, v3 FROM public.metrics_dist_ss WHERE _timescaledb_internal.chunks_in(public.metrics_dist_ss.*, ARRAY[49, 50, 51])
          ->  Custom Scan (DataNodeScan) on public.metrics_dist_ss metrics_dist_ss_3 (actual rows=4560 loops=1)
                Output: metrics_dist_ss_3."time", metrics_dist_ss_3.device_id, metrics_dist_ss_3.v0, metrics_dist_ss_3.v1, metrics_dist_ss_3.v2, metrics_dist_ss_3.v3
                Data node: db_dist_remote_error_3
                Fetcher Type: Cursor
-               Chunks: _dist_hyper_5_98_chunk, _dist_hyper_5_101_chunk, _dist_hyper_5_104_chunk
-               Remote SQL: SELECT "time", device_id, v0, v1, v2, v3 FROM public.metrics_dist_ss WHERE _timescaledb_internal.chunks_in(public.metrics_dist_ss.*, ARRAY[32, 33, 34])
+               Chunks: _dist_hyper_5_125_chunk, _dist_hyper_5_128_chunk, _dist_hyper_5_131_chunk
+               Remote SQL: SELECT "time", device_id, v0, v1, v2, v3 FROM public.metrics_dist_ss WHERE _timescaledb_internal.chunks_in(public.metrics_dist_ss.*, ARRAY[38, 39, 40])
 (21 rows)
 
 -- Incorrect int output, to cover the error handling in tuplefactory.

--- a/tsl/test/expected/dist_remote_error-15.out
+++ b/tsl/test/expected/dist_remote_error-15.out
@@ -325,20 +325,20 @@ select * from metrics_dist_ss;
                Output: metrics_dist_ss_1."time", metrics_dist_ss_1.device_id, metrics_dist_ss_1.v0, metrics_dist_ss_1.v1, metrics_dist_ss_1.v2, metrics_dist_ss_1.v3
                Data node: db_dist_remote_error_1
                Fetcher Type: Prepared statement
-               Chunks: _dist_hyper_5_96_chunk, _dist_hyper_5_99_chunk, _dist_hyper_5_102_chunk
-               Remote SQL: SELECT "time", device_id, v0, v1, v2, v3 FROM public.metrics_dist_ss WHERE _timescaledb_internal.chunks_in(public.metrics_dist_ss.*, ARRAY[54, 55, 56])
+               Chunks: _dist_hyper_5_123_chunk, _dist_hyper_5_126_chunk, _dist_hyper_5_129_chunk
+               Remote SQL: SELECT "time", device_id, v0, v1, v2, v3 FROM public.metrics_dist_ss WHERE _timescaledb_internal.chunks_in(public.metrics_dist_ss.*, ARRAY[57, 58, 59])
          ->  Custom Scan (DataNodeScan) on public.metrics_dist_ss metrics_dist_ss_2 (actual rows=13680 loops=1)
                Output: metrics_dist_ss_2."time", metrics_dist_ss_2.device_id, metrics_dist_ss_2.v0, metrics_dist_ss_2.v1, metrics_dist_ss_2.v2, metrics_dist_ss_2.v3
                Data node: db_dist_remote_error_2
                Fetcher Type: Prepared statement
-               Chunks: _dist_hyper_5_97_chunk, _dist_hyper_5_100_chunk, _dist_hyper_5_103_chunk
-               Remote SQL: SELECT "time", device_id, v0, v1, v2, v3 FROM public.metrics_dist_ss WHERE _timescaledb_internal.chunks_in(public.metrics_dist_ss.*, ARRAY[48, 49, 50])
+               Chunks: _dist_hyper_5_124_chunk, _dist_hyper_5_127_chunk, _dist_hyper_5_130_chunk
+               Remote SQL: SELECT "time", device_id, v0, v1, v2, v3 FROM public.metrics_dist_ss WHERE _timescaledb_internal.chunks_in(public.metrics_dist_ss.*, ARRAY[49, 50, 51])
          ->  Custom Scan (DataNodeScan) on public.metrics_dist_ss metrics_dist_ss_3 (actual rows=4560 loops=1)
                Output: metrics_dist_ss_3."time", metrics_dist_ss_3.device_id, metrics_dist_ss_3.v0, metrics_dist_ss_3.v1, metrics_dist_ss_3.v2, metrics_dist_ss_3.v3
                Data node: db_dist_remote_error_3
                Fetcher Type: Prepared statement
-               Chunks: _dist_hyper_5_98_chunk, _dist_hyper_5_101_chunk, _dist_hyper_5_104_chunk
-               Remote SQL: SELECT "time", device_id, v0, v1, v2, v3 FROM public.metrics_dist_ss WHERE _timescaledb_internal.chunks_in(public.metrics_dist_ss.*, ARRAY[32, 33, 34])
+               Chunks: _dist_hyper_5_125_chunk, _dist_hyper_5_128_chunk, _dist_hyper_5_131_chunk
+               Remote SQL: SELECT "time", device_id, v0, v1, v2, v3 FROM public.metrics_dist_ss WHERE _timescaledb_internal.chunks_in(public.metrics_dist_ss.*, ARRAY[38, 39, 40])
 (21 rows)
 
 set timescaledb.remote_data_fetcher = 'copy';
@@ -353,20 +353,20 @@ select * from metrics_dist_ss;
                Output: metrics_dist_ss_1."time", metrics_dist_ss_1.device_id, metrics_dist_ss_1.v0, metrics_dist_ss_1.v1, metrics_dist_ss_1.v2, metrics_dist_ss_1.v3
                Data node: db_dist_remote_error_1
                Fetcher Type: COPY
-               Chunks: _dist_hyper_5_96_chunk, _dist_hyper_5_99_chunk, _dist_hyper_5_102_chunk
-               Remote SQL: SELECT "time", device_id, v0, v1, v2, v3 FROM public.metrics_dist_ss WHERE _timescaledb_internal.chunks_in(public.metrics_dist_ss.*, ARRAY[54, 55, 56])
+               Chunks: _dist_hyper_5_123_chunk, _dist_hyper_5_126_chunk, _dist_hyper_5_129_chunk
+               Remote SQL: SELECT "time", device_id, v0, v1, v2, v3 FROM public.metrics_dist_ss WHERE _timescaledb_internal.chunks_in(public.metrics_dist_ss.*, ARRAY[57, 58, 59])
          ->  Custom Scan (DataNodeScan) on public.metrics_dist_ss metrics_dist_ss_2 (actual rows=13680 loops=1)
                Output: metrics_dist_ss_2."time", metrics_dist_ss_2.device_id, metrics_dist_ss_2.v0, metrics_dist_ss_2.v1, metrics_dist_ss_2.v2, metrics_dist_ss_2.v3
                Data node: db_dist_remote_error_2
                Fetcher Type: COPY
-               Chunks: _dist_hyper_5_97_chunk, _dist_hyper_5_100_chunk, _dist_hyper_5_103_chunk
-               Remote SQL: SELECT "time", device_id, v0, v1, v2, v3 FROM public.metrics_dist_ss WHERE _timescaledb_internal.chunks_in(public.metrics_dist_ss.*, ARRAY[48, 49, 50])
+               Chunks: _dist_hyper_5_124_chunk, _dist_hyper_5_127_chunk, _dist_hyper_5_130_chunk
+               Remote SQL: SELECT "time", device_id, v0, v1, v2, v3 FROM public.metrics_dist_ss WHERE _timescaledb_internal.chunks_in(public.metrics_dist_ss.*, ARRAY[49, 50, 51])
          ->  Custom Scan (DataNodeScan) on public.metrics_dist_ss metrics_dist_ss_3 (actual rows=4560 loops=1)
                Output: metrics_dist_ss_3."time", metrics_dist_ss_3.device_id, metrics_dist_ss_3.v0, metrics_dist_ss_3.v1, metrics_dist_ss_3.v2, metrics_dist_ss_3.v3
                Data node: db_dist_remote_error_3
                Fetcher Type: COPY
-               Chunks: _dist_hyper_5_98_chunk, _dist_hyper_5_101_chunk, _dist_hyper_5_104_chunk
-               Remote SQL: SELECT "time", device_id, v0, v1, v2, v3 FROM public.metrics_dist_ss WHERE _timescaledb_internal.chunks_in(public.metrics_dist_ss.*, ARRAY[32, 33, 34])
+               Chunks: _dist_hyper_5_125_chunk, _dist_hyper_5_128_chunk, _dist_hyper_5_131_chunk
+               Remote SQL: SELECT "time", device_id, v0, v1, v2, v3 FROM public.metrics_dist_ss WHERE _timescaledb_internal.chunks_in(public.metrics_dist_ss.*, ARRAY[38, 39, 40])
 (21 rows)
 
 set timescaledb.remote_data_fetcher = 'cursor';
@@ -381,20 +381,20 @@ select * from metrics_dist_ss;
                Output: metrics_dist_ss_1."time", metrics_dist_ss_1.device_id, metrics_dist_ss_1.v0, metrics_dist_ss_1.v1, metrics_dist_ss_1.v2, metrics_dist_ss_1.v3
                Data node: db_dist_remote_error_1
                Fetcher Type: Cursor
-               Chunks: _dist_hyper_5_96_chunk, _dist_hyper_5_99_chunk, _dist_hyper_5_102_chunk
-               Remote SQL: SELECT "time", device_id, v0, v1, v2, v3 FROM public.metrics_dist_ss WHERE _timescaledb_internal.chunks_in(public.metrics_dist_ss.*, ARRAY[54, 55, 56])
+               Chunks: _dist_hyper_5_123_chunk, _dist_hyper_5_126_chunk, _dist_hyper_5_129_chunk
+               Remote SQL: SELECT "time", device_id, v0, v1, v2, v3 FROM public.metrics_dist_ss WHERE _timescaledb_internal.chunks_in(public.metrics_dist_ss.*, ARRAY[57, 58, 59])
          ->  Custom Scan (DataNodeScan) on public.metrics_dist_ss metrics_dist_ss_2 (actual rows=13680 loops=1)
                Output: metrics_dist_ss_2."time", metrics_dist_ss_2.device_id, metrics_dist_ss_2.v0, metrics_dist_ss_2.v1, metrics_dist_ss_2.v2, metrics_dist_ss_2.v3
                Data node: db_dist_remote_error_2
                Fetcher Type: Cursor
-               Chunks: _dist_hyper_5_97_chunk, _dist_hyper_5_100_chunk, _dist_hyper_5_103_chunk
-               Remote SQL: SELECT "time", device_id, v0, v1, v2, v3 FROM public.metrics_dist_ss WHERE _timescaledb_internal.chunks_in(public.metrics_dist_ss.*, ARRAY[48, 49, 50])
+               Chunks: _dist_hyper_5_124_chunk, _dist_hyper_5_127_chunk, _dist_hyper_5_130_chunk
+               Remote SQL: SELECT "time", device_id, v0, v1, v2, v3 FROM public.metrics_dist_ss WHERE _timescaledb_internal.chunks_in(public.metrics_dist_ss.*, ARRAY[49, 50, 51])
          ->  Custom Scan (DataNodeScan) on public.metrics_dist_ss metrics_dist_ss_3 (actual rows=4560 loops=1)
                Output: metrics_dist_ss_3."time", metrics_dist_ss_3.device_id, metrics_dist_ss_3.v0, metrics_dist_ss_3.v1, metrics_dist_ss_3.v2, metrics_dist_ss_3.v3
                Data node: db_dist_remote_error_3
                Fetcher Type: Cursor
-               Chunks: _dist_hyper_5_98_chunk, _dist_hyper_5_101_chunk, _dist_hyper_5_104_chunk
-               Remote SQL: SELECT "time", device_id, v0, v1, v2, v3 FROM public.metrics_dist_ss WHERE _timescaledb_internal.chunks_in(public.metrics_dist_ss.*, ARRAY[32, 33, 34])
+               Chunks: _dist_hyper_5_125_chunk, _dist_hyper_5_128_chunk, _dist_hyper_5_131_chunk
+               Remote SQL: SELECT "time", device_id, v0, v1, v2, v3 FROM public.metrics_dist_ss WHERE _timescaledb_internal.chunks_in(public.metrics_dist_ss.*, ARRAY[38, 39, 40])
 (21 rows)
 
 -- Incorrect int output, to cover the error handling in tuplefactory.

--- a/tsl/test/expected/remote_copy-12.out
+++ b/tsl/test/expected/remote_copy-12.out
@@ -142,14 +142,14 @@ SELECT * FROM _timescaledb_catalog.chunk ORDER BY 1;
   6 |             1 | _timescaledb_internal | _dist_hyper_1_6_chunk  |                     | f       |      0 | f
   7 |             1 | _timescaledb_internal | _dist_hyper_1_7_chunk  |                     | f       |      0 | f
   8 |             1 | _timescaledb_internal | _dist_hyper_1_8_chunk  |                     | f       |      0 | f
-  9 |             1 | _timescaledb_internal | _dist_hyper_1_9_chunk  |                     | f       |      0 | f
- 10 |             1 | _timescaledb_internal | _dist_hyper_1_10_chunk |                     | f       |      0 | f
- 11 |             1 | _timescaledb_internal | _dist_hyper_1_11_chunk |                     | f       |      0 | f
  12 |             1 | _timescaledb_internal | _dist_hyper_1_12_chunk |                     | f       |      0 | f
  13 |             1 | _timescaledb_internal | _dist_hyper_1_13_chunk |                     | f       |      0 | f
  14 |             1 | _timescaledb_internal | _dist_hyper_1_14_chunk |                     | f       |      0 | f
  15 |             1 | _timescaledb_internal | _dist_hyper_1_15_chunk |                     | f       |      0 | f
  16 |             1 | _timescaledb_internal | _dist_hyper_1_16_chunk |                     | f       |      0 | f
+ 17 |             1 | _timescaledb_internal | _dist_hyper_1_17_chunk |                     | f       |      0 | f
+ 18 |             1 | _timescaledb_internal | _dist_hyper_1_18_chunk |                     | f       |      0 | f
+ 19 |             1 | _timescaledb_internal | _dist_hyper_1_19_chunk |                     | f       |      0 | f
 (16 rows)
 
 SELECT * FROM _timescaledb_catalog.chunk_data_node ORDER BY 1, 3;
@@ -171,22 +171,22 @@ SELECT * FROM _timescaledb_catalog.chunk_data_node ORDER BY 1, 3;
         7 |             5 | db_remote_copy_2
         8 |             8 | db_remote_copy_1
         8 |             6 | db_remote_copy_2
-        9 |             9 | db_remote_copy_1
-        9 |             7 | db_remote_copy_2
-       10 |            10 | db_remote_copy_1
-       10 |             8 | db_remote_copy_2
-       11 |            11 | db_remote_copy_1
-       11 |             9 | db_remote_copy_2
-       12 |            12 | db_remote_copy_1
-       12 |            10 | db_remote_copy_2
-       13 |            13 | db_remote_copy_1
-       13 |            11 | db_remote_copy_2
-       14 |            14 | db_remote_copy_1
-       14 |            12 | db_remote_copy_2
-       15 |            15 | db_remote_copy_1
-       15 |            13 | db_remote_copy_2
-       16 |            16 | db_remote_copy_1
-       16 |             3 | db_remote_copy_3
+       12 |            11 | db_remote_copy_1
+       12 |             8 | db_remote_copy_2
+       13 |            12 | db_remote_copy_1
+       13 |             9 | db_remote_copy_2
+       14 |            13 | db_remote_copy_1
+       14 |            10 | db_remote_copy_2
+       15 |            14 | db_remote_copy_1
+       15 |            11 | db_remote_copy_2
+       16 |            15 | db_remote_copy_1
+       16 |            12 | db_remote_copy_2
+       17 |            16 | db_remote_copy_1
+       17 |            13 | db_remote_copy_2
+       18 |            17 | db_remote_copy_1
+       18 |            14 | db_remote_copy_2
+       19 |            18 | db_remote_copy_1
+       19 |             6 | db_remote_copy_3
 (32 rows)
 
 SELECT * FROM _timescaledb_catalog.hypertable_data_node ORDER BY 3;
@@ -208,14 +208,14 @@ select * from show_chunks('"+ri(k33_'')"') ORDER BY 1;
  _timescaledb_internal._dist_hyper_1_6_chunk
  _timescaledb_internal._dist_hyper_1_7_chunk
  _timescaledb_internal._dist_hyper_1_8_chunk
- _timescaledb_internal._dist_hyper_1_9_chunk
- _timescaledb_internal._dist_hyper_1_10_chunk
- _timescaledb_internal._dist_hyper_1_11_chunk
  _timescaledb_internal._dist_hyper_1_12_chunk
  _timescaledb_internal._dist_hyper_1_13_chunk
  _timescaledb_internal._dist_hyper_1_14_chunk
  _timescaledb_internal._dist_hyper_1_15_chunk
  _timescaledb_internal._dist_hyper_1_16_chunk
+ _timescaledb_internal._dist_hyper_1_17_chunk
+ _timescaledb_internal._dist_hyper_1_18_chunk
+ _timescaledb_internal._dist_hyper_1_19_chunk
 (16 rows)
 
 \c :DATA_NODE_1
@@ -253,14 +253,14 @@ select * from show_chunks('"+ri(k33_'')"') ORDER BY 1;
  _timescaledb_internal._dist_hyper_1_6_chunk
  _timescaledb_internal._dist_hyper_1_7_chunk
  _timescaledb_internal._dist_hyper_1_8_chunk
- _timescaledb_internal._dist_hyper_1_9_chunk
- _timescaledb_internal._dist_hyper_1_10_chunk
- _timescaledb_internal._dist_hyper_1_11_chunk
  _timescaledb_internal._dist_hyper_1_12_chunk
  _timescaledb_internal._dist_hyper_1_13_chunk
  _timescaledb_internal._dist_hyper_1_14_chunk
  _timescaledb_internal._dist_hyper_1_15_chunk
  _timescaledb_internal._dist_hyper_1_16_chunk
+ _timescaledb_internal._dist_hyper_1_17_chunk
+ _timescaledb_internal._dist_hyper_1_18_chunk
+ _timescaledb_internal._dist_hyper_1_19_chunk
 (16 rows)
 
 \c :DATA_NODE_2
@@ -293,13 +293,13 @@ select * from show_chunks('"+ri(k33_'')"') ORDER BY 1;
  _timescaledb_internal._dist_hyper_1_6_chunk
  _timescaledb_internal._dist_hyper_1_7_chunk
  _timescaledb_internal._dist_hyper_1_8_chunk
- _timescaledb_internal._dist_hyper_1_9_chunk
- _timescaledb_internal._dist_hyper_1_10_chunk
- _timescaledb_internal._dist_hyper_1_11_chunk
  _timescaledb_internal._dist_hyper_1_12_chunk
  _timescaledb_internal._dist_hyper_1_13_chunk
  _timescaledb_internal._dist_hyper_1_14_chunk
  _timescaledb_internal._dist_hyper_1_15_chunk
+ _timescaledb_internal._dist_hyper_1_16_chunk
+ _timescaledb_internal._dist_hyper_1_17_chunk
+ _timescaledb_internal._dist_hyper_1_18_chunk
 (13 rows)
 
 \c :DATA_NODE_3
@@ -316,7 +316,7 @@ select * from show_chunks('"+ri(k33_'')"') ORDER BY 1;
 ----------------------------------------------
  _timescaledb_internal._dist_hyper_1_1_chunk
  _timescaledb_internal._dist_hyper_1_2_chunk
- _timescaledb_internal._dist_hyper_1_16_chunk
+ _timescaledb_internal._dist_hyper_1_19_chunk
 (3 rows)
 
 \c :TEST_DBNAME :ROLE_SUPERUSER;

--- a/tsl/test/expected/remote_copy-13.out
+++ b/tsl/test/expected/remote_copy-13.out
@@ -142,14 +142,14 @@ SELECT * FROM _timescaledb_catalog.chunk ORDER BY 1;
   6 |             1 | _timescaledb_internal | _dist_hyper_1_6_chunk  |                     | f       |      0 | f
   7 |             1 | _timescaledb_internal | _dist_hyper_1_7_chunk  |                     | f       |      0 | f
   8 |             1 | _timescaledb_internal | _dist_hyper_1_8_chunk  |                     | f       |      0 | f
-  9 |             1 | _timescaledb_internal | _dist_hyper_1_9_chunk  |                     | f       |      0 | f
- 10 |             1 | _timescaledb_internal | _dist_hyper_1_10_chunk |                     | f       |      0 | f
- 11 |             1 | _timescaledb_internal | _dist_hyper_1_11_chunk |                     | f       |      0 | f
  12 |             1 | _timescaledb_internal | _dist_hyper_1_12_chunk |                     | f       |      0 | f
  13 |             1 | _timescaledb_internal | _dist_hyper_1_13_chunk |                     | f       |      0 | f
  14 |             1 | _timescaledb_internal | _dist_hyper_1_14_chunk |                     | f       |      0 | f
  15 |             1 | _timescaledb_internal | _dist_hyper_1_15_chunk |                     | f       |      0 | f
  16 |             1 | _timescaledb_internal | _dist_hyper_1_16_chunk |                     | f       |      0 | f
+ 17 |             1 | _timescaledb_internal | _dist_hyper_1_17_chunk |                     | f       |      0 | f
+ 18 |             1 | _timescaledb_internal | _dist_hyper_1_18_chunk |                     | f       |      0 | f
+ 19 |             1 | _timescaledb_internal | _dist_hyper_1_19_chunk |                     | f       |      0 | f
 (16 rows)
 
 SELECT * FROM _timescaledb_catalog.chunk_data_node ORDER BY 1, 3;
@@ -171,22 +171,22 @@ SELECT * FROM _timescaledb_catalog.chunk_data_node ORDER BY 1, 3;
         7 |             5 | db_remote_copy_2
         8 |             8 | db_remote_copy_1
         8 |             6 | db_remote_copy_2
-        9 |             9 | db_remote_copy_1
-        9 |             7 | db_remote_copy_2
-       10 |            10 | db_remote_copy_1
-       10 |             8 | db_remote_copy_2
-       11 |            11 | db_remote_copy_1
-       11 |             9 | db_remote_copy_2
-       12 |            12 | db_remote_copy_1
-       12 |            10 | db_remote_copy_2
-       13 |            13 | db_remote_copy_1
-       13 |            11 | db_remote_copy_2
-       14 |            14 | db_remote_copy_1
-       14 |            12 | db_remote_copy_2
-       15 |            15 | db_remote_copy_1
-       15 |            13 | db_remote_copy_2
-       16 |            16 | db_remote_copy_1
-       16 |             3 | db_remote_copy_3
+       12 |            11 | db_remote_copy_1
+       12 |             8 | db_remote_copy_2
+       13 |            12 | db_remote_copy_1
+       13 |             9 | db_remote_copy_2
+       14 |            13 | db_remote_copy_1
+       14 |            10 | db_remote_copy_2
+       15 |            14 | db_remote_copy_1
+       15 |            11 | db_remote_copy_2
+       16 |            15 | db_remote_copy_1
+       16 |            12 | db_remote_copy_2
+       17 |            16 | db_remote_copy_1
+       17 |            13 | db_remote_copy_2
+       18 |            17 | db_remote_copy_1
+       18 |            14 | db_remote_copy_2
+       19 |            18 | db_remote_copy_1
+       19 |             6 | db_remote_copy_3
 (32 rows)
 
 SELECT * FROM _timescaledb_catalog.hypertable_data_node ORDER BY 3;
@@ -208,14 +208,14 @@ select * from show_chunks('"+ri(k33_'')"') ORDER BY 1;
  _timescaledb_internal._dist_hyper_1_6_chunk
  _timescaledb_internal._dist_hyper_1_7_chunk
  _timescaledb_internal._dist_hyper_1_8_chunk
- _timescaledb_internal._dist_hyper_1_9_chunk
- _timescaledb_internal._dist_hyper_1_10_chunk
- _timescaledb_internal._dist_hyper_1_11_chunk
  _timescaledb_internal._dist_hyper_1_12_chunk
  _timescaledb_internal._dist_hyper_1_13_chunk
  _timescaledb_internal._dist_hyper_1_14_chunk
  _timescaledb_internal._dist_hyper_1_15_chunk
  _timescaledb_internal._dist_hyper_1_16_chunk
+ _timescaledb_internal._dist_hyper_1_17_chunk
+ _timescaledb_internal._dist_hyper_1_18_chunk
+ _timescaledb_internal._dist_hyper_1_19_chunk
 (16 rows)
 
 \c :DATA_NODE_1
@@ -253,14 +253,14 @@ select * from show_chunks('"+ri(k33_'')"') ORDER BY 1;
  _timescaledb_internal._dist_hyper_1_6_chunk
  _timescaledb_internal._dist_hyper_1_7_chunk
  _timescaledb_internal._dist_hyper_1_8_chunk
- _timescaledb_internal._dist_hyper_1_9_chunk
- _timescaledb_internal._dist_hyper_1_10_chunk
- _timescaledb_internal._dist_hyper_1_11_chunk
  _timescaledb_internal._dist_hyper_1_12_chunk
  _timescaledb_internal._dist_hyper_1_13_chunk
  _timescaledb_internal._dist_hyper_1_14_chunk
  _timescaledb_internal._dist_hyper_1_15_chunk
  _timescaledb_internal._dist_hyper_1_16_chunk
+ _timescaledb_internal._dist_hyper_1_17_chunk
+ _timescaledb_internal._dist_hyper_1_18_chunk
+ _timescaledb_internal._dist_hyper_1_19_chunk
 (16 rows)
 
 \c :DATA_NODE_2
@@ -293,13 +293,13 @@ select * from show_chunks('"+ri(k33_'')"') ORDER BY 1;
  _timescaledb_internal._dist_hyper_1_6_chunk
  _timescaledb_internal._dist_hyper_1_7_chunk
  _timescaledb_internal._dist_hyper_1_8_chunk
- _timescaledb_internal._dist_hyper_1_9_chunk
- _timescaledb_internal._dist_hyper_1_10_chunk
- _timescaledb_internal._dist_hyper_1_11_chunk
  _timescaledb_internal._dist_hyper_1_12_chunk
  _timescaledb_internal._dist_hyper_1_13_chunk
  _timescaledb_internal._dist_hyper_1_14_chunk
  _timescaledb_internal._dist_hyper_1_15_chunk
+ _timescaledb_internal._dist_hyper_1_16_chunk
+ _timescaledb_internal._dist_hyper_1_17_chunk
+ _timescaledb_internal._dist_hyper_1_18_chunk
 (13 rows)
 
 \c :DATA_NODE_3
@@ -316,7 +316,7 @@ select * from show_chunks('"+ri(k33_'')"') ORDER BY 1;
 ----------------------------------------------
  _timescaledb_internal._dist_hyper_1_1_chunk
  _timescaledb_internal._dist_hyper_1_2_chunk
- _timescaledb_internal._dist_hyper_1_16_chunk
+ _timescaledb_internal._dist_hyper_1_19_chunk
 (3 rows)
 
 \c :TEST_DBNAME :ROLE_SUPERUSER;

--- a/tsl/test/expected/remote_copy-14.out
+++ b/tsl/test/expected/remote_copy-14.out
@@ -142,14 +142,14 @@ SELECT * FROM _timescaledb_catalog.chunk ORDER BY 1;
   6 |             1 | _timescaledb_internal | _dist_hyper_1_6_chunk  |                     | f       |      0 | f
   7 |             1 | _timescaledb_internal | _dist_hyper_1_7_chunk  |                     | f       |      0 | f
   8 |             1 | _timescaledb_internal | _dist_hyper_1_8_chunk  |                     | f       |      0 | f
-  9 |             1 | _timescaledb_internal | _dist_hyper_1_9_chunk  |                     | f       |      0 | f
- 10 |             1 | _timescaledb_internal | _dist_hyper_1_10_chunk |                     | f       |      0 | f
- 11 |             1 | _timescaledb_internal | _dist_hyper_1_11_chunk |                     | f       |      0 | f
  12 |             1 | _timescaledb_internal | _dist_hyper_1_12_chunk |                     | f       |      0 | f
  13 |             1 | _timescaledb_internal | _dist_hyper_1_13_chunk |                     | f       |      0 | f
  14 |             1 | _timescaledb_internal | _dist_hyper_1_14_chunk |                     | f       |      0 | f
  15 |             1 | _timescaledb_internal | _dist_hyper_1_15_chunk |                     | f       |      0 | f
  16 |             1 | _timescaledb_internal | _dist_hyper_1_16_chunk |                     | f       |      0 | f
+ 17 |             1 | _timescaledb_internal | _dist_hyper_1_17_chunk |                     | f       |      0 | f
+ 18 |             1 | _timescaledb_internal | _dist_hyper_1_18_chunk |                     | f       |      0 | f
+ 19 |             1 | _timescaledb_internal | _dist_hyper_1_19_chunk |                     | f       |      0 | f
 (16 rows)
 
 SELECT * FROM _timescaledb_catalog.chunk_data_node ORDER BY 1, 3;
@@ -171,22 +171,22 @@ SELECT * FROM _timescaledb_catalog.chunk_data_node ORDER BY 1, 3;
         7 |             5 | db_remote_copy_2
         8 |             8 | db_remote_copy_1
         8 |             6 | db_remote_copy_2
-        9 |             9 | db_remote_copy_1
-        9 |             7 | db_remote_copy_2
-       10 |            10 | db_remote_copy_1
-       10 |             8 | db_remote_copy_2
-       11 |            11 | db_remote_copy_1
-       11 |             9 | db_remote_copy_2
-       12 |            12 | db_remote_copy_1
-       12 |            10 | db_remote_copy_2
-       13 |            13 | db_remote_copy_1
-       13 |            11 | db_remote_copy_2
-       14 |            14 | db_remote_copy_1
-       14 |            12 | db_remote_copy_2
-       15 |            15 | db_remote_copy_1
-       15 |            13 | db_remote_copy_2
-       16 |            16 | db_remote_copy_1
-       16 |             3 | db_remote_copy_3
+       12 |            11 | db_remote_copy_1
+       12 |             8 | db_remote_copy_2
+       13 |            12 | db_remote_copy_1
+       13 |             9 | db_remote_copy_2
+       14 |            13 | db_remote_copy_1
+       14 |            10 | db_remote_copy_2
+       15 |            14 | db_remote_copy_1
+       15 |            11 | db_remote_copy_2
+       16 |            15 | db_remote_copy_1
+       16 |            12 | db_remote_copy_2
+       17 |            16 | db_remote_copy_1
+       17 |            13 | db_remote_copy_2
+       18 |            17 | db_remote_copy_1
+       18 |            14 | db_remote_copy_2
+       19 |            18 | db_remote_copy_1
+       19 |             6 | db_remote_copy_3
 (32 rows)
 
 SELECT * FROM _timescaledb_catalog.hypertable_data_node ORDER BY 3;
@@ -208,14 +208,14 @@ select * from show_chunks('"+ri(k33_'')"') ORDER BY 1;
  _timescaledb_internal._dist_hyper_1_6_chunk
  _timescaledb_internal._dist_hyper_1_7_chunk
  _timescaledb_internal._dist_hyper_1_8_chunk
- _timescaledb_internal._dist_hyper_1_9_chunk
- _timescaledb_internal._dist_hyper_1_10_chunk
- _timescaledb_internal._dist_hyper_1_11_chunk
  _timescaledb_internal._dist_hyper_1_12_chunk
  _timescaledb_internal._dist_hyper_1_13_chunk
  _timescaledb_internal._dist_hyper_1_14_chunk
  _timescaledb_internal._dist_hyper_1_15_chunk
  _timescaledb_internal._dist_hyper_1_16_chunk
+ _timescaledb_internal._dist_hyper_1_17_chunk
+ _timescaledb_internal._dist_hyper_1_18_chunk
+ _timescaledb_internal._dist_hyper_1_19_chunk
 (16 rows)
 
 \c :DATA_NODE_1
@@ -253,14 +253,14 @@ select * from show_chunks('"+ri(k33_'')"') ORDER BY 1;
  _timescaledb_internal._dist_hyper_1_6_chunk
  _timescaledb_internal._dist_hyper_1_7_chunk
  _timescaledb_internal._dist_hyper_1_8_chunk
- _timescaledb_internal._dist_hyper_1_9_chunk
- _timescaledb_internal._dist_hyper_1_10_chunk
- _timescaledb_internal._dist_hyper_1_11_chunk
  _timescaledb_internal._dist_hyper_1_12_chunk
  _timescaledb_internal._dist_hyper_1_13_chunk
  _timescaledb_internal._dist_hyper_1_14_chunk
  _timescaledb_internal._dist_hyper_1_15_chunk
  _timescaledb_internal._dist_hyper_1_16_chunk
+ _timescaledb_internal._dist_hyper_1_17_chunk
+ _timescaledb_internal._dist_hyper_1_18_chunk
+ _timescaledb_internal._dist_hyper_1_19_chunk
 (16 rows)
 
 \c :DATA_NODE_2
@@ -293,13 +293,13 @@ select * from show_chunks('"+ri(k33_'')"') ORDER BY 1;
  _timescaledb_internal._dist_hyper_1_6_chunk
  _timescaledb_internal._dist_hyper_1_7_chunk
  _timescaledb_internal._dist_hyper_1_8_chunk
- _timescaledb_internal._dist_hyper_1_9_chunk
- _timescaledb_internal._dist_hyper_1_10_chunk
- _timescaledb_internal._dist_hyper_1_11_chunk
  _timescaledb_internal._dist_hyper_1_12_chunk
  _timescaledb_internal._dist_hyper_1_13_chunk
  _timescaledb_internal._dist_hyper_1_14_chunk
  _timescaledb_internal._dist_hyper_1_15_chunk
+ _timescaledb_internal._dist_hyper_1_16_chunk
+ _timescaledb_internal._dist_hyper_1_17_chunk
+ _timescaledb_internal._dist_hyper_1_18_chunk
 (13 rows)
 
 \c :DATA_NODE_3
@@ -316,7 +316,7 @@ select * from show_chunks('"+ri(k33_'')"') ORDER BY 1;
 ----------------------------------------------
  _timescaledb_internal._dist_hyper_1_1_chunk
  _timescaledb_internal._dist_hyper_1_2_chunk
- _timescaledb_internal._dist_hyper_1_16_chunk
+ _timescaledb_internal._dist_hyper_1_19_chunk
 (3 rows)
 
 \c :TEST_DBNAME :ROLE_SUPERUSER;

--- a/tsl/test/expected/remote_copy-15.out
+++ b/tsl/test/expected/remote_copy-15.out
@@ -142,14 +142,14 @@ SELECT * FROM _timescaledb_catalog.chunk ORDER BY 1;
   6 |             1 | _timescaledb_internal | _dist_hyper_1_6_chunk  |                     | f       |      0 | f
   7 |             1 | _timescaledb_internal | _dist_hyper_1_7_chunk  |                     | f       |      0 | f
   8 |             1 | _timescaledb_internal | _dist_hyper_1_8_chunk  |                     | f       |      0 | f
-  9 |             1 | _timescaledb_internal | _dist_hyper_1_9_chunk  |                     | f       |      0 | f
- 10 |             1 | _timescaledb_internal | _dist_hyper_1_10_chunk |                     | f       |      0 | f
- 11 |             1 | _timescaledb_internal | _dist_hyper_1_11_chunk |                     | f       |      0 | f
  12 |             1 | _timescaledb_internal | _dist_hyper_1_12_chunk |                     | f       |      0 | f
  13 |             1 | _timescaledb_internal | _dist_hyper_1_13_chunk |                     | f       |      0 | f
  14 |             1 | _timescaledb_internal | _dist_hyper_1_14_chunk |                     | f       |      0 | f
  15 |             1 | _timescaledb_internal | _dist_hyper_1_15_chunk |                     | f       |      0 | f
  16 |             1 | _timescaledb_internal | _dist_hyper_1_16_chunk |                     | f       |      0 | f
+ 17 |             1 | _timescaledb_internal | _dist_hyper_1_17_chunk |                     | f       |      0 | f
+ 18 |             1 | _timescaledb_internal | _dist_hyper_1_18_chunk |                     | f       |      0 | f
+ 19 |             1 | _timescaledb_internal | _dist_hyper_1_19_chunk |                     | f       |      0 | f
 (16 rows)
 
 SELECT * FROM _timescaledb_catalog.chunk_data_node ORDER BY 1, 3;
@@ -171,22 +171,22 @@ SELECT * FROM _timescaledb_catalog.chunk_data_node ORDER BY 1, 3;
         7 |             5 | db_remote_copy_2
         8 |             8 | db_remote_copy_1
         8 |             6 | db_remote_copy_2
-        9 |             9 | db_remote_copy_1
-        9 |             7 | db_remote_copy_2
-       10 |            10 | db_remote_copy_1
-       10 |             8 | db_remote_copy_2
-       11 |            11 | db_remote_copy_1
-       11 |             9 | db_remote_copy_2
-       12 |            12 | db_remote_copy_1
-       12 |            10 | db_remote_copy_2
-       13 |            13 | db_remote_copy_1
-       13 |            11 | db_remote_copy_2
-       14 |            14 | db_remote_copy_1
-       14 |            12 | db_remote_copy_2
-       15 |            15 | db_remote_copy_1
-       15 |            13 | db_remote_copy_2
-       16 |            16 | db_remote_copy_1
-       16 |             3 | db_remote_copy_3
+       12 |            11 | db_remote_copy_1
+       12 |             8 | db_remote_copy_2
+       13 |            12 | db_remote_copy_1
+       13 |             9 | db_remote_copy_2
+       14 |            13 | db_remote_copy_1
+       14 |            10 | db_remote_copy_2
+       15 |            14 | db_remote_copy_1
+       15 |            11 | db_remote_copy_2
+       16 |            15 | db_remote_copy_1
+       16 |            12 | db_remote_copy_2
+       17 |            16 | db_remote_copy_1
+       17 |            13 | db_remote_copy_2
+       18 |            17 | db_remote_copy_1
+       18 |            14 | db_remote_copy_2
+       19 |            18 | db_remote_copy_1
+       19 |             6 | db_remote_copy_3
 (32 rows)
 
 SELECT * FROM _timescaledb_catalog.hypertable_data_node ORDER BY 3;
@@ -208,14 +208,14 @@ select * from show_chunks('"+ri(k33_'')"') ORDER BY 1;
  _timescaledb_internal._dist_hyper_1_6_chunk
  _timescaledb_internal._dist_hyper_1_7_chunk
  _timescaledb_internal._dist_hyper_1_8_chunk
- _timescaledb_internal._dist_hyper_1_9_chunk
- _timescaledb_internal._dist_hyper_1_10_chunk
- _timescaledb_internal._dist_hyper_1_11_chunk
  _timescaledb_internal._dist_hyper_1_12_chunk
  _timescaledb_internal._dist_hyper_1_13_chunk
  _timescaledb_internal._dist_hyper_1_14_chunk
  _timescaledb_internal._dist_hyper_1_15_chunk
  _timescaledb_internal._dist_hyper_1_16_chunk
+ _timescaledb_internal._dist_hyper_1_17_chunk
+ _timescaledb_internal._dist_hyper_1_18_chunk
+ _timescaledb_internal._dist_hyper_1_19_chunk
 (16 rows)
 
 \c :DATA_NODE_1
@@ -253,14 +253,14 @@ select * from show_chunks('"+ri(k33_'')"') ORDER BY 1;
  _timescaledb_internal._dist_hyper_1_6_chunk
  _timescaledb_internal._dist_hyper_1_7_chunk
  _timescaledb_internal._dist_hyper_1_8_chunk
- _timescaledb_internal._dist_hyper_1_9_chunk
- _timescaledb_internal._dist_hyper_1_10_chunk
- _timescaledb_internal._dist_hyper_1_11_chunk
  _timescaledb_internal._dist_hyper_1_12_chunk
  _timescaledb_internal._dist_hyper_1_13_chunk
  _timescaledb_internal._dist_hyper_1_14_chunk
  _timescaledb_internal._dist_hyper_1_15_chunk
  _timescaledb_internal._dist_hyper_1_16_chunk
+ _timescaledb_internal._dist_hyper_1_17_chunk
+ _timescaledb_internal._dist_hyper_1_18_chunk
+ _timescaledb_internal._dist_hyper_1_19_chunk
 (16 rows)
 
 \c :DATA_NODE_2
@@ -293,13 +293,13 @@ select * from show_chunks('"+ri(k33_'')"') ORDER BY 1;
  _timescaledb_internal._dist_hyper_1_6_chunk
  _timescaledb_internal._dist_hyper_1_7_chunk
  _timescaledb_internal._dist_hyper_1_8_chunk
- _timescaledb_internal._dist_hyper_1_9_chunk
- _timescaledb_internal._dist_hyper_1_10_chunk
- _timescaledb_internal._dist_hyper_1_11_chunk
  _timescaledb_internal._dist_hyper_1_12_chunk
  _timescaledb_internal._dist_hyper_1_13_chunk
  _timescaledb_internal._dist_hyper_1_14_chunk
  _timescaledb_internal._dist_hyper_1_15_chunk
+ _timescaledb_internal._dist_hyper_1_16_chunk
+ _timescaledb_internal._dist_hyper_1_17_chunk
+ _timescaledb_internal._dist_hyper_1_18_chunk
 (13 rows)
 
 \c :DATA_NODE_3
@@ -316,7 +316,7 @@ select * from show_chunks('"+ri(k33_'')"') ORDER BY 1;
 ----------------------------------------------
  _timescaledb_internal._dist_hyper_1_1_chunk
  _timescaledb_internal._dist_hyper_1_2_chunk
- _timescaledb_internal._dist_hyper_1_16_chunk
+ _timescaledb_internal._dist_hyper_1_19_chunk
 (3 rows)
 
 \c :TEST_DBNAME :ROLE_SUPERUSER;

--- a/tsl/test/sql/dist_copy_format_long.sql
+++ b/tsl/test/sql/dist_copy_format_long.sql
@@ -20,7 +20,10 @@ SELECT 1 FROM add_data_node('data_node_3', host => 'localhost',
 GRANT USAGE ON FOREIGN SERVER data_node_1, data_node_2, data_node_3 TO PUBLIC;
 -- though user on access node has required GRANTS, this will propagate GRANTS to the connected data nodes
 GRANT CREATE ON SCHEMA public TO :ROLE_1;
+-- buffer a lot of rows per message to test buffer expansion
+ALTER FOREIGN DATA WRAPPER timescaledb_fdw OPTIONS (ADD copy_rows_per_message '1000');
 SET ROLE :ROLE_1;
+
 
 
 -- Aim to about 100 partitions, the data is from 1995 to 2022.

--- a/tsl/test/sql/remote_copy.sql.in
+++ b/tsl/test/sql/remote_copy.sql.in
@@ -16,7 +16,6 @@ FROM (
 ) a;
 GRANT USAGE ON FOREIGN SERVER :DATA_NODE_1, :DATA_NODE_2, :DATA_NODE_3 TO PUBLIC;
 GRANT CREATE ON SCHEMA public TO :ROLE_1;
-
 SET timescaledb.hide_data_node_name_in_errors = 'on';
 
 -- Start out testing text copy code


### PR DESCRIPTION
Refactor the code path that handles remote distributed COPY. The
main changes are:

* Use a hash table to lookup data node connections instead of a list.
* Reduce the number of data copies by accumulating bigger CopyData
  messages directly in the libpq connection buffer instead of doing it
  in a separate buffer which later requires copying the data. To
  achieve this, some internal libpq functions are imported that gives
  more fine-grain control over buffers.
* Add an foreign data wrapper option to set the number of rows to
  send in a CopyData message.