### PR TITLE
Handle user-defined FDW options properly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ accidentally triggering the load of a previous DB version.**
 * #5396 Fix SEGMENTBY columns predicates to be pushed down
 * #5410 Fix file trailer handling in the COPY fetcher
 * #5233 Out of on_proc_exit slots on guc license change
+* #5427 Handle user-defined FDW options properly
 
 **Thanks**
 * @nikolaps for reporting an issue with the COPY fetcher

--- a/tsl/src/fdw/relinfo.c
+++ b/tsl/src/fdw/relinfo.c
@@ -421,21 +421,22 @@ fdw_relinfo_create(PlannerInfo *root, RelOptInfo *rel, Oid server_oid, Oid local
 			appendStringInfo(fpinfo->relation_name, " %s", quote_identifier(rte->eref->aliasname));
 	}
 
+	/*
+	 * Set the default values for startup cost, tuple cost, fetch size and shippable_extensions.
+	 * Note that the per-server settings (applied in apply_fdw_and_server_options()) can override
+	 * these values.
+	 */
+	fpinfo->fdw_startup_cost = DEFAULT_FDW_STARTUP_COST;
+	fpinfo->fdw_tuple_cost = DEFAULT_FDW_TUPLE_COST;
+	fpinfo->fetch_size = DEFAULT_FDW_FETCH_SIZE;
+	fpinfo->shippable_extensions = list_make1_oid(ts_extension_get_oid());
+
 	/* Look up foreign-table catalog info. */
 	if (OidIsValid(server_oid))
 	{
 		fpinfo->server = GetForeignServer(server_oid);
 		apply_fdw_and_server_options(fpinfo);
 	}
-
-	/*
-	 * Extract user-settable option values.  Note that per-table setting
-	 * overrides per-server setting.
-	 */
-	fpinfo->fdw_startup_cost = DEFAULT_FDW_STARTUP_COST;
-	fpinfo->fdw_tuple_cost = DEFAULT_FDW_TUPLE_COST;
-	fpinfo->shippable_extensions = list_make1_oid(ts_extension_get_oid());
-	fpinfo->fetch_size = DEFAULT_FDW_FETCH_SIZE;
 
 	/*
 	 * Identify which baserestrictinfo clauses can be sent to the data

--- a/tsl/test/expected/data_fetcher.out
+++ b/tsl/test/expected/data_fetcher.out
@@ -105,6 +105,116 @@ SELECT count(*), count(value) FROM one_batch_default;
 \o
 -- compare results
 :DIFF_CMD
+-- Test custom FDW settings. Instead of the tests above, we are not interersted
+-- in comparing the results of the fetchers. In the following tests we are
+-- interested in the actual outputs (e.g., costs).
+ANALYZE one_batch;
+SET timescaledb.remote_data_fetcher = 'copy';
+\ir include/data_fetcher_fdw_settings.sql
+-- This file and its contents are licensed under the Timescale License.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-TIMESCALE for a copy of the license.
+-- Default settings
+EXPLAIN (COSTS) SELECT * FROM one_batch;
+                                   QUERY PLAN                                    
+---------------------------------------------------------------------------------
+ Custom Scan (DataNodeScan) on one_batch  (cost=100.00..110.90 rows=99 width=20)
+(1 row)
+
+-- Set custom startup cost
+ALTER FOREIGN DATA WRAPPER timescaledb_fdw OPTIONS (ADD fdw_startup_cost '200');
+EXPLAIN (COSTS) SELECT * FROM one_batch;
+                                   QUERY PLAN                                    
+---------------------------------------------------------------------------------
+ Custom Scan (DataNodeScan) on one_batch  (cost=200.00..210.90 rows=99 width=20)
+(1 row)
+
+-- Set custom tuple cost
+ALTER FOREIGN DATA WRAPPER timescaledb_fdw OPTIONS (ADD fdw_tuple_cost '1');
+EXPLAIN (COSTS) SELECT * FROM one_batch;
+                                   QUERY PLAN                                    
+---------------------------------------------------------------------------------
+ Custom Scan (DataNodeScan) on one_batch  (cost=200.00..301.98 rows=99 width=20)
+(1 row)
+
+-- Update startup cost
+ALTER FOREIGN DATA WRAPPER timescaledb_fdw OPTIONS (SET fdw_startup_cost '2');
+EXPLAIN (COSTS) SELECT * FROM one_batch;
+                                  QUERY PLAN                                   
+-------------------------------------------------------------------------------
+ Custom Scan (DataNodeScan) on one_batch  (cost=2.00..103.98 rows=99 width=20)
+(1 row)
+
+-- Update startup cost
+ALTER FOREIGN DATA WRAPPER timescaledb_fdw OPTIONS (SET fdw_tuple_cost '0.5');
+EXPLAIN (COSTS) SELECT * FROM one_batch;
+                                  QUERY PLAN                                  
+------------------------------------------------------------------------------
+ Custom Scan (DataNodeScan) on one_batch  (cost=2.00..54.48 rows=99 width=20)
+(1 row)
+
+-- Reset custom settings
+ALTER FOREIGN DATA WRAPPER timescaledb_fdw OPTIONS (DROP fdw_startup_cost);
+ALTER FOREIGN DATA WRAPPER timescaledb_fdw OPTIONS (DROP fdw_tuple_cost);
+EXPLAIN (COSTS) SELECT * FROM one_batch;
+                                   QUERY PLAN                                    
+---------------------------------------------------------------------------------
+ Custom Scan (DataNodeScan) on one_batch  (cost=100.00..110.90 rows=99 width=20)
+(1 row)
+
+SET timescaledb.remote_data_fetcher = 'cursor';
+\ir include/data_fetcher_fdw_settings.sql
+-- This file and its contents are licensed under the Timescale License.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-TIMESCALE for a copy of the license.
+-- Default settings
+EXPLAIN (COSTS) SELECT * FROM one_batch;
+                                   QUERY PLAN                                    
+---------------------------------------------------------------------------------
+ Custom Scan (DataNodeScan) on one_batch  (cost=100.00..110.90 rows=99 width=20)
+(1 row)
+
+-- Set custom startup cost
+ALTER FOREIGN DATA WRAPPER timescaledb_fdw OPTIONS (ADD fdw_startup_cost '200');
+EXPLAIN (COSTS) SELECT * FROM one_batch;
+                                   QUERY PLAN                                    
+---------------------------------------------------------------------------------
+ Custom Scan (DataNodeScan) on one_batch  (cost=200.00..210.90 rows=99 width=20)
+(1 row)
+
+-- Set custom tuple cost
+ALTER FOREIGN DATA WRAPPER timescaledb_fdw OPTIONS (ADD fdw_tuple_cost '1');
+EXPLAIN (COSTS) SELECT * FROM one_batch;
+                                   QUERY PLAN                                    
+---------------------------------------------------------------------------------
+ Custom Scan (DataNodeScan) on one_batch  (cost=200.00..301.98 rows=99 width=20)
+(1 row)
+
+-- Update startup cost
+ALTER FOREIGN DATA WRAPPER timescaledb_fdw OPTIONS (SET fdw_startup_cost '2');
+EXPLAIN (COSTS) SELECT * FROM one_batch;
+                                  QUERY PLAN                                   
+-------------------------------------------------------------------------------
+ Custom Scan (DataNodeScan) on one_batch  (cost=2.00..103.98 rows=99 width=20)
+(1 row)
+
+-- Update startup cost
+ALTER FOREIGN DATA WRAPPER timescaledb_fdw OPTIONS (SET fdw_tuple_cost '0.5');
+EXPLAIN (COSTS) SELECT * FROM one_batch;
+                                  QUERY PLAN                                  
+------------------------------------------------------------------------------
+ Custom Scan (DataNodeScan) on one_batch  (cost=2.00..54.48 rows=99 width=20)
+(1 row)
+
+-- Reset custom settings
+ALTER FOREIGN DATA WRAPPER timescaledb_fdw OPTIONS (DROP fdw_startup_cost);
+ALTER FOREIGN DATA WRAPPER timescaledb_fdw OPTIONS (DROP fdw_tuple_cost);
+EXPLAIN (COSTS) SELECT * FROM one_batch;
+                                   QUERY PLAN                                    
+---------------------------------------------------------------------------------
+ Custom Scan (DataNodeScan) on one_batch  (cost=100.00..110.90 rows=99 width=20)
+(1 row)
+
 RESET ROLE;
 DROP DATABASE :DATA_NODE_1;
 DROP DATABASE :DATA_NODE_2;

--- a/tsl/test/sql/data_fetcher.sql
+++ b/tsl/test/sql/data_fetcher.sql
@@ -65,6 +65,18 @@ SET timescaledb.remote_data_fetcher = 'cursor';
 -- compare results
 :DIFF_CMD
 
+-- Test custom FDW settings. Instead of the tests above, we are not interersted
+-- in comparing the results of the fetchers. In the following tests we are
+-- interested in the actual outputs (e.g., costs).
+ANALYZE one_batch;
+
+SET timescaledb.remote_data_fetcher = 'copy';
+\ir include/data_fetcher_fdw_settings.sql
+
+SET timescaledb.remote_data_fetcher = 'cursor';
+\ir include/data_fetcher_fdw_settings.sql
+
+
 RESET ROLE;
 DROP DATABASE :DATA_NODE_1;
 DROP DATABASE :DATA_NODE_2;

--- a/tsl/test/sql/include/data_fetcher_fdw_settings.sql
+++ b/tsl/test/sql/include/data_fetcher_fdw_settings.sql
@@ -1,0 +1,28 @@
+-- This file and its contents are licensed under the Timescale License.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-TIMESCALE for a copy of the license.
+
+-- Default settings
+EXPLAIN (COSTS) SELECT * FROM one_batch;
+
+-- Set custom startup cost
+ALTER FOREIGN DATA WRAPPER timescaledb_fdw OPTIONS (ADD fdw_startup_cost '200');
+EXPLAIN (COSTS) SELECT * FROM one_batch;
+
+-- Set custom tuple cost
+ALTER FOREIGN DATA WRAPPER timescaledb_fdw OPTIONS (ADD fdw_tuple_cost '1');
+EXPLAIN (COSTS) SELECT * FROM one_batch;
+
+-- Update startup cost
+ALTER FOREIGN DATA WRAPPER timescaledb_fdw OPTIONS (SET fdw_startup_cost '2');
+EXPLAIN (COSTS) SELECT * FROM one_batch;
+
+-- Update startup cost
+ALTER FOREIGN DATA WRAPPER timescaledb_fdw OPTIONS (SET fdw_tuple_cost '0.5');
+EXPLAIN (COSTS) SELECT * FROM one_batch;
+
+-- Reset custom settings
+ALTER FOREIGN DATA WRAPPER timescaledb_fdw OPTIONS (DROP fdw_startup_cost);
+ALTER FOREIGN DATA WRAPPER timescaledb_fdw OPTIONS (DROP fdw_tuple_cost);
+EXPLAIN (COSTS) SELECT * FROM one_batch;
+


### PR DESCRIPTION
This patch changes the way user-defined FDW options (e.g., startup costs, per-tuple costs) are handled. So far, these values were retrieved in `apply_fdw_and_server_options()` but reset to default values afterward.