### PR TITLE
Add utility function to map attribute numbers

### DIFF
--- a/src/chunk_adaptive.c
+++ b/src/chunk_adaptive.c
@@ -293,14 +293,6 @@ chunk_get_minmax(Oid relid, Oid atttype, AttrNumber attnum, Datum minmax[2])
 	return res == MINMAX_FOUND;
 }
 
-static AttrNumber
-chunk_get_attno(Oid hypertable_relid, Oid chunk_relid, AttrNumber hypertable_attnum)
-{
-	const char *attname = get_attname(hypertable_relid, hypertable_attnum, false);
-
-	return get_attnum(chunk_relid, attname);
-}
-
 #define CHUNK_SIZING_FUNC_NARGS 3
 #define DEFAULT_CHUNK_WINDOW 3
 
@@ -473,8 +465,7 @@ ts_calculate_chunk_interval(PG_FUNCTION_ARGS)
 			ts_hypercube_get_slice_by_dimension_id(chunk->cube, dimension_id);
 		int64 chunk_size, slice_interval;
 		Datum minmax[2];
-		AttrNumber attno =
-			chunk_get_attno(ht->main_table_relid, chunk->table_id, dim->column_attno);
+		AttrNumber attno = ts_map_attno(ht->main_table_relid, chunk->table_id, dim->column_attno);
 
 		Assert(NULL != slice);
 

--- a/src/chunk_index.c
+++ b/src/chunk_index.c
@@ -106,15 +106,12 @@ adjust_expr_attnos(Oid ht_relid, IndexInfo *ii, Relation chunkrel)
 	{
 		Var *var = lfirst_node(Var, lc);
 
-		char *attname = get_attname(ht_relid, var->varattno, false);
-		var->varattno = get_attnum(chunkrel->rd_id, attname);
+		var->varattno = ts_map_attno(ht_relid, chunkrel->rd_id, var->varattno);
 #if PG13_GE
 		var->varattnosyn = var->varattno;
 #else
 		var->varoattno = var->varattno;
 #endif
-		if (var->varattno == InvalidAttrNumber)
-			elog(ERROR, "index attribute %s not found in chunk", attname);
 	}
 }
 
@@ -135,12 +132,8 @@ chunk_adjust_colref_attnos(IndexInfo *ii, Oid ht_relid, Relation chunkrel)
 		 * are independent of parent relation column names. Instead we need to look
 		 * up the attno of the referenced hypertable column and do the matching
 		 * with the hypertable column name */
-		char *colname = get_attname(ht_relid, ii->ii_IndexAttrNumbers[i], false);
-		AttrNumber attno = get_attnum(chunkrel->rd_id, colname);
-
-		if (attno == InvalidAttrNumber)
-			elog(ERROR, "index attribute %s not found in chunk", colname);
-		ii->ii_IndexAttrNumbers[i] = attno;
+		ii->ii_IndexAttrNumbers[i] =
+			ts_map_attno(ht_relid, chunkrel->rd_id, ii->ii_IndexAttrNumbers[i]);
 	}
 }
 

--- a/src/utils.c
+++ b/src/utils.c
@@ -1325,3 +1325,26 @@ ts_data_node_is_available(const char *name)
 {
 	return ts_data_node_is_available_by_server(GetForeignServerByName(name, false));
 }
+
+/*
+ * Map attno from source relation to target relation by column name
+ */
+AttrNumber
+ts_map_attno(Oid src_rel, Oid dst_rel, AttrNumber attno)
+{
+	char *attname = get_attname(src_rel, attno, false);
+	AttrNumber dst_attno = get_attnum(dst_rel, attname);
+
+	/*
+	 * For any chunk mappings we do this should never happen.
+	 */
+	if (dst_attno == InvalidAttrNumber)
+		elog(ERROR,
+			 "could not map attribute number from relation \"%s\" to \"%s\" for column \"%s\"",
+			 get_rel_name(src_rel),
+			 get_rel_name(dst_rel),
+			 attname);
+
+	pfree(attname);
+	return dst_attno;
+}

--- a/src/utils.h
+++ b/src/utils.h
@@ -205,4 +205,6 @@ extern TSDLLEXPORT void ts_copy_relation_acl(const Oid source_relid, const Oid t
 extern TSDLLEXPORT bool ts_data_node_is_available_by_server(const ForeignServer *server);
 extern TSDLLEXPORT bool ts_data_node_is_available(const char *node_name);
 
+extern TSDLLEXPORT AttrNumber ts_map_attno(Oid src_rel, Oid dst_rel, AttrNumber attno);
+
 #endif /* TIMESCALEDB_UTILS_H */


### PR DESCRIPTION
This patch adds a function ts_map_attno that can be used to map the attribute number from one relation to another by column name.

Disable-check: force-changelog-changed

