### PR TITLE
Add more compression DML tests

### DIFF
--- a/tsl/test/expected/compression_ddl.out
+++ b/tsl/test/expected/compression_ddl.out
@@ -1405,3 +1405,429 @@ ALTER MATERIALIZED VIEW test1_cont_view2 SET (
   timescaledb.compress = false
 );
 DROP TABLE metric CASCADE;
+-- inserting into compressed chunks with different physical layouts
+CREATE TABLE compression_insert(filler_1 int, filler_2 int, filler_3 int, time timestamptz NOT NULL, device_id int, v0 int, v1 int, v2 float, v3 float);
+CREATE INDEX ON compression_insert(time);
+CREATE INDEX ON compression_insert(device_id,time);
+SELECT create_hypertable('compression_insert','time',create_default_indexes:=false);
+        create_hypertable         
+----------------------------------
+ (31,public,compression_insert,t)
+(1 row)
+
+ALTER TABLE compression_insert SET (timescaledb.compress, timescaledb.compress_orderby='time DESC', timescaledb.compress_segmentby='device_id');
+-- test without altering physical layout
+-- this is a baseline test to compare results with
+-- next series of tests which should yield identical results
+-- while changing the physical layouts of chunks
+INSERT INTO compression_insert(time,device_id,v0,v1,v2,v3)
+SELECT time, device_id, device_id+1,  device_id + 2, device_id + 0.5, NULL
+FROM generate_series('2000-01-01 0:00:00+0'::timestamptz,'2000-01-03 23:55:00+0','2m') gtime(time), generate_series(1,5,1) gdevice(device_id);
+SELECT compress_chunk(c.schema_name|| '.' || c.table_name) as "CHUNK_NAME"
+FROM _timescaledb_catalog.chunk c, _timescaledb_catalog.hypertable ht
+WHERE c.hypertable_id = ht.id and ht.table_name = 'compression_insert'
+AND c.compressed_chunk_id IS NULL
+ORDER BY c.table_name DESC \gset
+INSERT INTO compression_insert(time,device_id,v0,v1,v2,v3)
+SELECT time, device_id, device_id+1,  device_id + 2, device_id + 0.5, NULL
+FROM generate_series('2000-01-04 0:00:00+0'::timestamptz,'2000-01-05 23:55:00+0','2m') gtime(time), generate_series(1,5,1) gdevice(device_id);
+SELECT count(*), sum(v0), sum(v1), sum(v2), sum(v3)
+FROM compression_insert
+WHERE time >= '2000-01-01 0:00:00+0'
+AND time <= '2000-01-05 23:55:00+0';
+ count |  sum  |  sum  |  sum  | sum 
+-------+-------+-------+-------+-----
+ 17980 | 71920 | 89900 | 62930 |    
+(1 row)
+
+-- force index scans to check index mapping
+-- this verifies that we are actually using compressed chunk index scans
+-- currently we cannot use indexes on uncompressed chunks due to a bug:
+-- https://github.com/timescale/timescaledb/issues/5432
+--
+-- this check basically makes sure that the indexes are built properly
+-- and there are no issues in attribute mappings while building them
+SET enable_seqscan = off;
+EXPLAIN (costs off) SELECT device_id, count(*)
+FROM compression_insert
+GROUP BY device_id;
+                                                               QUERY PLAN                                                                
+-----------------------------------------------------------------------------------------------------------------------------------------
+ GroupAggregate
+   Group Key: _hyper_31_107_chunk.device_id
+   ->  Sort
+         Sort Key: _hyper_31_107_chunk.device_id
+         ->  Append
+               ->  Custom Scan (DecompressChunk) on _hyper_31_107_chunk
+                     ->  Index Scan using compress_hyper_32_108_chunk__compressed_hypertable_32_device_id on compress_hyper_32_108_chunk
+               ->  Seq Scan on _hyper_31_107_chunk
+(8 rows)
+
+SELECT device_id, count(*)
+FROM compression_insert
+GROUP BY device_id;
+ device_id | count 
+-----------+-------
+         1 |  3596
+         2 |  3596
+         3 |  3596
+         4 |  3596
+         5 |  3596
+(5 rows)
+
+CALL recompress_chunk(:'CHUNK_NAME'::regclass);
+SELECT count(*), sum(v0), sum(v1), sum(v2), sum(v3)
+FROM compression_insert
+WHERE time >= '2000-01-01 0:00:00+0'
+AND time <= '2000-01-05 23:55:00+0';
+ count |  sum  |  sum  |  sum  | sum 
+-------+-------+-------+-------+-----
+ 17980 | 71920 | 89900 | 62930 |    
+(1 row)
+
+SELECT device_id, count(*)
+FROM compression_insert
+GROUP BY device_id;
+ device_id | count 
+-----------+-------
+         1 |  3596
+         2 |  3596
+         3 |  3596
+         4 |  3596
+         5 |  3596
+(5 rows)
+
+SET enable_seqscan = default;
+-- 1. drop column after first insert into chunk, before compressing
+INSERT INTO compression_insert(time,device_id,v0,v1,v2,v3)
+SELECT time, device_id, device_id+1,  device_id + 2, device_id + 0.5, NULL
+FROM generate_series('2000-01-07 0:00:00+0'::timestamptz,'2000-01-09 23:55:00+0','2m') gtime(time), generate_series(1,5,1) gdevice(device_id);
+ALTER TABLE compression_insert DROP COLUMN filler_1;
+SELECT compress_chunk(c.schema_name|| '.' || c.table_name) as "CHUNK_NAME"
+FROM _timescaledb_catalog.chunk c, _timescaledb_catalog.hypertable ht
+WHERE c.hypertable_id = ht.id
+AND ht.table_name = 'compression_insert'
+AND c.compressed_chunk_id IS NULL
+ORDER BY c.table_name DESC \gset
+INSERT INTO compression_insert(time,device_id,v0,v1,v2,v3)
+SELECT time, device_id, device_id+1,  device_id + 2, device_id + 0.5, NULL
+FROM generate_series('2000-01-10 0:00:00+0'::timestamptz,'2000-01-11 23:55:00+0','2m') gtime(time), generate_series(1,5,1) gdevice(device_id);
+SELECT count(*), sum(v0), sum(v1), sum(v2), sum(v3)
+FROM compression_insert
+WHERE time >= '2000-01-07 0:00:00+0'
+AND time <= '2000-01-11 23:55:00+0';
+ count |  sum  |  sum  |  sum  | sum 
+-------+-------+-------+-------+-----
+ 17980 | 71920 | 89900 | 62930 |    
+(1 row)
+
+-- force index scans to check index mapping
+SET enable_seqscan = off;
+EXPLAIN (costs off) SELECT device_id, count(*)
+FROM compression_insert
+GROUP BY device_id;
+                                                               QUERY PLAN                                                                
+-----------------------------------------------------------------------------------------------------------------------------------------
+ GroupAggregate
+   Group Key: _hyper_31_107_chunk.device_id
+   ->  Merge Append
+         Sort Key: _hyper_31_107_chunk.device_id
+         ->  Custom Scan (DecompressChunk) on _hyper_31_107_chunk
+               ->  Index Scan using compress_hyper_32_108_chunk__compressed_hypertable_32_device_id on compress_hyper_32_108_chunk
+         ->  Sort
+               Sort Key: _hyper_31_109_chunk.device_id
+               ->  Custom Scan (DecompressChunk) on _hyper_31_109_chunk
+                     ->  Index Scan using compress_hyper_32_110_chunk__compressed_hypertable_32_device_id on compress_hyper_32_110_chunk
+         ->  Sort
+               Sort Key: _hyper_31_109_chunk.device_id
+               ->  Seq Scan on _hyper_31_109_chunk
+(13 rows)
+
+SELECT device_id, count(*)
+FROM compression_insert
+GROUP BY device_id;
+ device_id | count 
+-----------+-------
+         1 |  7192
+         2 |  7192
+         3 |  7192
+         4 |  7192
+         5 |  7192
+(5 rows)
+
+CALL recompress_chunk(:'CHUNK_NAME'::regclass);
+SELECT count(*), sum(v0), sum(v1), sum(v2), sum(v3)
+FROM compression_insert
+WHERE time >= '2000-01-07 0:00:00+0'
+AND time <= '2000-01-11 23:55:00+0';
+ count |  sum  |  sum  |  sum  | sum 
+-------+-------+-------+-------+-----
+ 17980 | 71920 | 89900 | 62930 |    
+(1 row)
+
+SELECT device_id, count(*)
+FROM compression_insert
+GROUP BY device_id;
+ device_id | count 
+-----------+-------
+         3 |  7192
+         5 |  7192
+         4 |  7192
+         2 |  7192
+         1 |  7192
+(5 rows)
+
+SET enable_seqscan = default;
+-- 2. drop column after compressing chunk
+INSERT INTO compression_insert(time,device_id,v0,v1,v2,v3)
+SELECT time, device_id, device_id+1, device_id + 2, device_id + 0.5, NULL
+FROM generate_series('2000-01-15 0:00:00+0'::timestamptz,'2000-01-17 23:55:00+0','2m') gtime(time), generate_series(1,5,1) gdevice(device_id);
+SELECT compress_chunk(c.schema_name|| '.' || c.table_name) as "CHUNK_NAME"
+FROM _timescaledb_catalog.chunk c, _timescaledb_catalog.hypertable ht
+WHERE c.hypertable_id = ht.id
+AND ht.table_name = 'compression_insert'
+AND c.compressed_chunk_id IS NULL
+ORDER BY c.table_name DESC \gset
+ALTER TABLE compression_insert DROP COLUMN filler_2;
+INSERT INTO compression_insert(time,device_id,v0,v1,v2,v3)
+SELECT time, device_id, device_id+1, device_id + 2, device_id + 0.5, NULL
+FROM generate_series('2000-01-18 0:00:00+0'::timestamptz,'2000-01-19 23:55:00+0','2m') gtime(time), generate_series(1,5,1) gdevice(device_id);
+SELECT count(*), sum(v0), sum(v1), sum(v2), sum(v3)
+FROM compression_insert
+WHERE time >= '2000-01-15 0:00:00+0'
+AND time <= '2000-01-19 23:55:00+0';
+ count |  sum  |  sum  |  sum  | sum 
+-------+-------+-------+-------+-----
+ 17980 | 71920 | 89900 | 62930 |    
+(1 row)
+
+-- force index scans to check index mapping
+SET enable_seqscan = off;
+EXPLAIN (costs off) SELECT device_id, count(*)
+FROM compression_insert
+GROUP BY device_id;
+                                                               QUERY PLAN                                                                
+-----------------------------------------------------------------------------------------------------------------------------------------
+ GroupAggregate
+   Group Key: _hyper_31_107_chunk.device_id
+   ->  Merge Append
+         Sort Key: _hyper_31_107_chunk.device_id
+         ->  Custom Scan (DecompressChunk) on _hyper_31_107_chunk
+               ->  Index Scan using compress_hyper_32_108_chunk__compressed_hypertable_32_device_id on compress_hyper_32_108_chunk
+         ->  Custom Scan (DecompressChunk) on _hyper_31_109_chunk
+               ->  Index Scan using compress_hyper_32_110_chunk__compressed_hypertable_32_device_id on compress_hyper_32_110_chunk
+         ->  Sort
+               Sort Key: _hyper_31_111_chunk.device_id
+               ->  Custom Scan (DecompressChunk) on _hyper_31_111_chunk
+                     ->  Index Scan using compress_hyper_32_112_chunk__compressed_hypertable_32_device_id on compress_hyper_32_112_chunk
+         ->  Sort
+               Sort Key: _hyper_31_111_chunk.device_id
+               ->  Seq Scan on _hyper_31_111_chunk
+(15 rows)
+
+SELECT device_id, count(*)
+FROM compression_insert
+GROUP BY device_id;
+ device_id | count 
+-----------+-------
+         1 | 10788
+         2 | 10788
+         3 | 10788
+         4 | 10788
+         5 | 10788
+(5 rows)
+
+CALL recompress_chunk(:'CHUNK_NAME'::regclass);
+SELECT count(*), sum(v0), sum(v1), sum(v2), sum(v3)
+FROM compression_insert
+WHERE time >= '2000-01-15 0:00:00+0'
+AND time <= '2000-01-19 23:55:00+0';
+ count |  sum  |  sum  |  sum  | sum 
+-------+-------+-------+-------+-----
+ 17980 | 71920 | 89900 | 62930 |    
+(1 row)
+
+SELECT device_id, count(*)
+FROM compression_insert
+GROUP BY device_id;
+ device_id | count 
+-----------+-------
+         3 | 10788
+         5 | 10788
+         4 | 10788
+         2 | 10788
+         1 | 10788
+(5 rows)
+
+SET enable_seqscan = default;
+-- 3. add new column after first insert into chunk, before compressing
+INSERT INTO compression_insert(time,device_id,v0,v1,v2,v3)
+SELECT time, device_id, device_id+1, device_id + 2, device_id + 0.5, NULL
+FROM generate_series('2000-01-22 0:00:00+0'::timestamptz,'2000-01-24 23:55:00+0','2m') gtime(time), generate_series(1,5,1) gdevice(device_id);
+ALTER TABLE compression_insert ADD COLUMN filler_4 int;
+SELECT compress_chunk(c.schema_name|| '.' || c.table_name) as "CHUNK_NAME"
+FROM _timescaledb_catalog.chunk c, _timescaledb_catalog.hypertable ht
+WHERE c.hypertable_id = ht.id
+AND ht.table_name = 'compression_insert'
+AND c.compressed_chunk_id IS NULL
+ORDER BY c.table_name DESC \gset
+INSERT INTO compression_insert(time,device_id,v0,v1,v2,v3)
+SELECT time, device_id, device_id+1, device_id + 2, device_id + 0.5, NULL
+FROM generate_series('2000-01-25 0:00:00+0'::timestamptz,'2000-01-26 23:55:00+0','2m') gtime(time), generate_series(1,5,1) gdevice(device_id);
+SELECT count(*), sum(v0), sum(v1), sum(v2), sum(v3)
+FROM compression_insert
+WHERE time >= '2000-01-22 0:00:00+0'
+AND time <= '2000-01-26 23:55:00+0';
+ count |  sum  |  sum  |  sum  | sum 
+-------+-------+-------+-------+-----
+ 17980 | 71920 | 89900 | 62930 |    
+(1 row)
+
+-- force index scans to check index mapping
+SET enable_seqscan = off;
+EXPLAIN (costs off) SELECT device_id, count(*)
+FROM compression_insert
+GROUP BY device_id;
+                                                               QUERY PLAN                                                                
+-----------------------------------------------------------------------------------------------------------------------------------------
+ GroupAggregate
+   Group Key: _hyper_31_107_chunk.device_id
+   ->  Merge Append
+         Sort Key: _hyper_31_107_chunk.device_id
+         ->  Custom Scan (DecompressChunk) on _hyper_31_107_chunk
+               ->  Index Scan using compress_hyper_32_108_chunk__compressed_hypertable_32_device_id on compress_hyper_32_108_chunk
+         ->  Custom Scan (DecompressChunk) on _hyper_31_109_chunk
+               ->  Index Scan using compress_hyper_32_110_chunk__compressed_hypertable_32_device_id on compress_hyper_32_110_chunk
+         ->  Custom Scan (DecompressChunk) on _hyper_31_111_chunk
+               ->  Index Scan using compress_hyper_32_112_chunk__compressed_hypertable_32_device_id on compress_hyper_32_112_chunk
+         ->  Sort
+               Sort Key: _hyper_31_113_chunk.device_id
+               ->  Custom Scan (DecompressChunk) on _hyper_31_113_chunk
+                     ->  Index Scan using compress_hyper_32_114_chunk__compressed_hypertable_32_device_id on compress_hyper_32_114_chunk
+         ->  Sort
+               Sort Key: _hyper_31_113_chunk.device_id
+               ->  Seq Scan on _hyper_31_113_chunk
+(17 rows)
+
+SELECT device_id, count(*)
+FROM compression_insert
+GROUP BY device_id;
+ device_id | count 
+-----------+-------
+         1 | 14384
+         2 | 14384
+         3 | 14384
+         4 | 14384
+         5 | 14384
+(5 rows)
+
+CALL recompress_chunk(:'CHUNK_NAME'::regclass);
+SELECT count(*), sum(v0), sum(v1), sum(v2), sum(v3)
+FROM compression_insert
+WHERE time >= '2000-01-22 0:00:00+0'
+AND time <= '2000-01-26 23:55:00+0';
+ count |  sum  |  sum  |  sum  | sum 
+-------+-------+-------+-------+-----
+ 17980 | 71920 | 89900 | 62930 |    
+(1 row)
+
+SELECT device_id, count(*)
+FROM compression_insert
+GROUP BY device_id;
+ device_id | count 
+-----------+-------
+         3 | 14384
+         5 | 14384
+         4 | 14384
+         2 | 14384
+         1 | 14384
+(5 rows)
+
+SET enable_seqscan = default;
+-- 4. add new column after compressing chunk
+INSERT INTO compression_insert(time,device_id,v0,v1,v2,v3)
+SELECT time, device_id, device_id+1, device_id + 2, device_id + 0.5, NULL
+FROM generate_series('2000-01-28 0:00:00+0'::timestamptz,'2000-01-30 23:55:00+0','2m') gtime(time), generate_series(1,5,1) gdevice(device_id);
+SELECT compress_chunk(c.schema_name|| '.' || c.table_name) as "CHUNK_NAME"
+FROM _timescaledb_catalog.chunk c, _timescaledb_catalog.hypertable ht
+WHERE c.hypertable_id = ht.id
+AND ht.table_name = 'compression_insert'
+AND c.compressed_chunk_id IS NULL
+ORDER BY c.table_name DESC \gset
+ALTER TABLE compression_insert ADD COLUMN filler_5 int;
+INSERT INTO compression_insert(time,device_id,v0,v1,v2,v3)
+SELECT time, device_id, device_id+1, device_id + 2, device_id + 0.5, NULL
+FROM generate_series('2000-01-31 0:00:00+0'::timestamptz,'2000-02-01 23:55:00+0','2m') gtime(time), generate_series(1,5,1) gdevice(device_id);
+SELECT count(*), sum(v0), sum(v1), sum(v2), sum(v3)
+FROM compression_insert
+WHERE time >= '2000-01-28 0:00:00+0'
+AND time <= '2000-02-01 23:55:00+0';
+ count |  sum  |  sum  |  sum  | sum 
+-------+-------+-------+-------+-----
+ 17980 | 71920 | 89900 | 62930 |    
+(1 row)
+
+-- force index scans to check index mapping
+SET enable_seqscan = off;
+EXPLAIN (costs off) SELECT device_id, count(*)
+FROM compression_insert
+GROUP BY device_id;
+                                                               QUERY PLAN                                                                
+-----------------------------------------------------------------------------------------------------------------------------------------
+ GroupAggregate
+   Group Key: _hyper_31_107_chunk.device_id
+   ->  Merge Append
+         Sort Key: _hyper_31_107_chunk.device_id
+         ->  Custom Scan (DecompressChunk) on _hyper_31_107_chunk
+               ->  Index Scan using compress_hyper_32_108_chunk__compressed_hypertable_32_device_id on compress_hyper_32_108_chunk
+         ->  Custom Scan (DecompressChunk) on _hyper_31_109_chunk
+               ->  Index Scan using compress_hyper_32_110_chunk__compressed_hypertable_32_device_id on compress_hyper_32_110_chunk
+         ->  Custom Scan (DecompressChunk) on _hyper_31_111_chunk
+               ->  Index Scan using compress_hyper_32_112_chunk__compressed_hypertable_32_device_id on compress_hyper_32_112_chunk
+         ->  Custom Scan (DecompressChunk) on _hyper_31_113_chunk
+               ->  Index Scan using compress_hyper_32_114_chunk__compressed_hypertable_32_device_id on compress_hyper_32_114_chunk
+         ->  Sort
+               Sort Key: _hyper_31_115_chunk.device_id
+               ->  Custom Scan (DecompressChunk) on _hyper_31_115_chunk
+                     ->  Index Scan using compress_hyper_32_116_chunk__compressed_hypertable_32_device_id on compress_hyper_32_116_chunk
+         ->  Sort
+               Sort Key: _hyper_31_115_chunk.device_id
+               ->  Seq Scan on _hyper_31_115_chunk
+(19 rows)
+
+SELECT device_id, count(*)
+FROM compression_insert
+GROUP BY device_id;
+ device_id | count 
+-----------+-------
+         1 | 17980
+         2 | 17980
+         3 | 17980
+         4 | 17980
+         5 | 17980
+(5 rows)
+
+CALL recompress_chunk(:'CHUNK_NAME'::regclass);
+SELECT count(*), sum(v0), sum(v1), sum(v2), sum(v3)
+FROM compression_insert
+WHERE time >= '2000-01-28 0:00:00+0'
+AND time <= '2000-02-01 23:55:00+0';
+ count |  sum  |  sum  |  sum  | sum 
+-------+-------+-------+-------+-----
+ 17980 | 71920 | 89900 | 62930 |    
+(1 row)
+
+SELECT device_id, count(*)
+FROM compression_insert
+GROUP BY device_id;
+ device_id | count 
+-----------+-------
+         3 | 17980
+         5 | 17980
+         4 | 17980
+         2 | 17980
+         1 | 17980
+(5 rows)
+
+SET enable_seqscan = default;
+DROP TABLE compression_insert;

--- a/tsl/test/isolation/expected/compression_ddl_iso.out
+++ b/tsl/test/isolation/expected/compression_ddl_iso.out
@@ -331,6 +331,152 @@ status
 (1 row)
 
 
+starting permutation: C1 Cc I1 Ic LockChunkTuple I1 IN1 UnlockChunkTuple INc Ic SChunkStat
+step C1: 
+  BEGIN;
+  SET LOCAL lock_timeout = '500ms';
+  SET LOCAL deadlock_timeout = '10ms';
+  SELECT
+    CASE WHEN compress_chunk(format('%I.%I',ch.schema_name, ch.table_name)) IS NOT NULL THEN true ELSE false END AS compress
+  FROM _timescaledb_catalog.hypertable ht, _timescaledb_catalog.chunk ch
+  WHERE ch.hypertable_id = ht.id AND ht.table_name like 'ts_device_table'
+  ORDER BY ch.id LIMIT 1;
+
+compress
+--------
+t       
+(1 row)
+
+step Cc: COMMIT;
+step I1: BEGIN; INSERT INTO ts_device_table VALUES (1, 1, 100, 100);
+step Ic: COMMIT;
+step LockChunkTuple: 
+  BEGIN;
+  SELECT status as chunk_status from _timescaledb_catalog.chunk
+  WHERE id = ( select min(ch.id) FROM _timescaledb_catalog.hypertable ht, _timescaledb_catalog.chunk ch WHERE ch.hypertable_id = ht.id AND ht.table_name like 'ts_device_table') FOR UPDATE;
+
+chunk_status
+------------
+           9
+(1 row)
+
+step I1: BEGIN; INSERT INTO ts_device_table VALUES (1, 1, 100, 100);
+step IN1: BEGIN; INSERT INTO ts_device_table VALUES (1, 1, 200, 100);
+step UnlockChunkTuple: ROLLBACK;
+step INc: COMMIT;
+step Ic: COMMIT;
+step SChunkStat: SELECT status from _timescaledb_catalog.chunk
+       WHERE id = ( select min(ch.id) FROM _timescaledb_catalog.hypertable ht, _timescaledb_catalog.chunk ch WHERE ch.hypertable_id = ht.id AND ht.table_name like 'ts_device_table');
+status
+------
+     9
+(1 row)
+
+
+starting permutation: C1 Cc LockChunkTuple IR1 INR1 UnlockChunkTuple Ic INc SChunkStat
+step C1: 
+  BEGIN;
+  SET LOCAL lock_timeout = '500ms';
+  SET LOCAL deadlock_timeout = '10ms';
+  SELECT
+    CASE WHEN compress_chunk(format('%I.%I',ch.schema_name, ch.table_name)) IS NOT NULL THEN true ELSE false END AS compress
+  FROM _timescaledb_catalog.hypertable ht, _timescaledb_catalog.chunk ch
+  WHERE ch.hypertable_id = ht.id AND ht.table_name like 'ts_device_table'
+  ORDER BY ch.id LIMIT 1;
+
+compress
+--------
+t       
+(1 row)
+
+step Cc: COMMIT;
+step LockChunkTuple: 
+  BEGIN;
+  SELECT status as chunk_status from _timescaledb_catalog.chunk
+  WHERE id = ( select min(ch.id) FROM _timescaledb_catalog.hypertable ht, _timescaledb_catalog.chunk ch WHERE ch.hypertable_id = ht.id AND ht.table_name like 'ts_device_table') FOR UPDATE;
+
+chunk_status
+------------
+           1
+(1 row)
+
+step IR1: BEGIN; INSERT INTO ts_device_table VALUES (1, 1, 100, 100) RETURNING *; <waiting ...>
+step INR1: BEGIN; INSERT INTO ts_device_table VALUES (1, 1, 200, 100) RETURNING *; <waiting ...>
+step UnlockChunkTuple: ROLLBACK;
+step IR1: <... completed>
+time|device|location|value
+----+------+--------+-----
+   1|     1|     100|  100
+(1 row)
+
+step Ic: COMMIT;
+step INR1: <... completed>
+time|device|location|value
+----+------+--------+-----
+   1|     1|     200|  100
+(1 row)
+
+step INc: COMMIT;
+step SChunkStat: SELECT status from _timescaledb_catalog.chunk
+       WHERE id = ( select min(ch.id) FROM _timescaledb_catalog.hypertable ht, _timescaledb_catalog.chunk ch WHERE ch.hypertable_id = ht.id AND ht.table_name like 'ts_device_table');
+status
+------
+     9
+(1 row)
+
+
+starting permutation: C1 Cc I1 Ic LockChunkTuple IR1 INR1 UnlockChunkTuple INc Ic SChunkStat
+step C1: 
+  BEGIN;
+  SET LOCAL lock_timeout = '500ms';
+  SET LOCAL deadlock_timeout = '10ms';
+  SELECT
+    CASE WHEN compress_chunk(format('%I.%I',ch.schema_name, ch.table_name)) IS NOT NULL THEN true ELSE false END AS compress
+  FROM _timescaledb_catalog.hypertable ht, _timescaledb_catalog.chunk ch
+  WHERE ch.hypertable_id = ht.id AND ht.table_name like 'ts_device_table'
+  ORDER BY ch.id LIMIT 1;
+
+compress
+--------
+t       
+(1 row)
+
+step Cc: COMMIT;
+step I1: BEGIN; INSERT INTO ts_device_table VALUES (1, 1, 100, 100);
+step Ic: COMMIT;
+step LockChunkTuple: 
+  BEGIN;
+  SELECT status as chunk_status from _timescaledb_catalog.chunk
+  WHERE id = ( select min(ch.id) FROM _timescaledb_catalog.hypertable ht, _timescaledb_catalog.chunk ch WHERE ch.hypertable_id = ht.id AND ht.table_name like 'ts_device_table') FOR UPDATE;
+
+chunk_status
+------------
+           9
+(1 row)
+
+step IR1: BEGIN; INSERT INTO ts_device_table VALUES (1, 1, 100, 100) RETURNING *;
+time|device|location|value
+----+------+--------+-----
+   1|     1|     100|  100
+(1 row)
+
+step INR1: BEGIN; INSERT INTO ts_device_table VALUES (1, 1, 200, 100) RETURNING *;
+time|device|location|value
+----+------+--------+-----
+   1|     1|     200|  100
+(1 row)
+
+step UnlockChunkTuple: ROLLBACK;
+step INc: COMMIT;
+step Ic: COMMIT;
+step SChunkStat: SELECT status from _timescaledb_catalog.chunk
+       WHERE id = ( select min(ch.id) FROM _timescaledb_catalog.hypertable ht, _timescaledb_catalog.chunk ch WHERE ch.hypertable_id = ht.id AND ht.table_name like 'ts_device_table');
+status
+------
+     9
+(1 row)
+
+
 starting permutation: CA1 CAc I1 Ic SChunkStat LockChunk1 RC1 IN1 UnlockChunk INc SH SA SChunkStat
 step CA1: 
   BEGIN;
@@ -376,7 +522,7 @@ step RC1:
   BEGIN
   FOR chunk_name IN
       SELECT ch FROM show_chunks('ts_device_table') ch
-       ORDER BY ch::text LIMIT 1
+      LIMIT 1
      LOOP
          CALL recompress_chunk(chunk_name);
      END LOOP;
@@ -483,7 +629,7 @@ step RC1:
   BEGIN
   FOR chunk_name IN
       SELECT ch FROM show_chunks('ts_device_table') ch
-       ORDER BY ch::text LIMIT 1
+      LIMIT 1
      LOOP
          CALL recompress_chunk(chunk_name);
      END LOOP;

--- a/tsl/test/sql/compression_ddl.sql
+++ b/tsl/test/sql/compression_ddl.sql
@@ -610,3 +610,214 @@ ALTER MATERIALIZED VIEW test1_cont_view2 SET (
 );
 
 DROP TABLE metric CASCADE;
+
+-- inserting into compressed chunks with different physical layouts
+CREATE TABLE compression_insert(filler_1 int, filler_2 int, filler_3 int, time timestamptz NOT NULL, device_id int, v0 int, v1 int, v2 float, v3 float);
+CREATE INDEX ON compression_insert(time);
+CREATE INDEX ON compression_insert(device_id,time);
+SELECT create_hypertable('compression_insert','time',create_default_indexes:=false);
+ALTER TABLE compression_insert SET (timescaledb.compress, timescaledb.compress_orderby='time DESC', timescaledb.compress_segmentby='device_id');
+
+-- test without altering physical layout
+-- this is a baseline test to compare results with
+-- next series of tests which should yield identical results
+-- while changing the physical layouts of chunks
+INSERT INTO compression_insert(time,device_id,v0,v1,v2,v3)
+SELECT time, device_id, device_id+1,  device_id + 2, device_id + 0.5, NULL
+FROM generate_series('2000-01-01 0:00:00+0'::timestamptz,'2000-01-03 23:55:00+0','2m') gtime(time), generate_series(1,5,1) gdevice(device_id);
+
+SELECT compress_chunk(c.schema_name|| '.' || c.table_name) as "CHUNK_NAME"
+FROM _timescaledb_catalog.chunk c, _timescaledb_catalog.hypertable ht
+WHERE c.hypertable_id = ht.id and ht.table_name = 'compression_insert'
+AND c.compressed_chunk_id IS NULL
+ORDER BY c.table_name DESC \gset
+
+INSERT INTO compression_insert(time,device_id,v0,v1,v2,v3)
+SELECT time, device_id, device_id+1,  device_id + 2, device_id + 0.5, NULL
+FROM generate_series('2000-01-04 0:00:00+0'::timestamptz,'2000-01-05 23:55:00+0','2m') gtime(time), generate_series(1,5,1) gdevice(device_id);
+SELECT count(*), sum(v0), sum(v1), sum(v2), sum(v3)
+FROM compression_insert
+WHERE time >= '2000-01-01 0:00:00+0'
+AND time <= '2000-01-05 23:55:00+0';
+
+-- force index scans to check index mapping
+-- this verifies that we are actually using compressed chunk index scans
+-- currently we cannot use indexes on uncompressed chunks due to a bug:
+-- https://github.com/timescale/timescaledb/issues/5432
+--
+-- this check basically makes sure that the indexes are built properly
+-- and there are no issues in attribute mappings while building them
+SET enable_seqscan = off;
+EXPLAIN (costs off) SELECT device_id, count(*)
+FROM compression_insert
+GROUP BY device_id;
+SELECT device_id, count(*)
+FROM compression_insert
+GROUP BY device_id;
+CALL recompress_chunk(:'CHUNK_NAME'::regclass);
+SELECT count(*), sum(v0), sum(v1), sum(v2), sum(v3)
+FROM compression_insert
+WHERE time >= '2000-01-01 0:00:00+0'
+AND time <= '2000-01-05 23:55:00+0';
+SELECT device_id, count(*)
+FROM compression_insert
+GROUP BY device_id;
+SET enable_seqscan = default;
+
+-- 1. drop column after first insert into chunk, before compressing
+INSERT INTO compression_insert(time,device_id,v0,v1,v2,v3)
+SELECT time, device_id, device_id+1,  device_id + 2, device_id + 0.5, NULL
+FROM generate_series('2000-01-07 0:00:00+0'::timestamptz,'2000-01-09 23:55:00+0','2m') gtime(time), generate_series(1,5,1) gdevice(device_id);
+
+ALTER TABLE compression_insert DROP COLUMN filler_1;
+SELECT compress_chunk(c.schema_name|| '.' || c.table_name) as "CHUNK_NAME"
+FROM _timescaledb_catalog.chunk c, _timescaledb_catalog.hypertable ht
+WHERE c.hypertable_id = ht.id
+AND ht.table_name = 'compression_insert'
+AND c.compressed_chunk_id IS NULL
+ORDER BY c.table_name DESC \gset
+
+INSERT INTO compression_insert(time,device_id,v0,v1,v2,v3)
+SELECT time, device_id, device_id+1,  device_id + 2, device_id + 0.5, NULL
+FROM generate_series('2000-01-10 0:00:00+0'::timestamptz,'2000-01-11 23:55:00+0','2m') gtime(time), generate_series(1,5,1) gdevice(device_id);
+
+SELECT count(*), sum(v0), sum(v1), sum(v2), sum(v3)
+FROM compression_insert
+WHERE time >= '2000-01-07 0:00:00+0'
+AND time <= '2000-01-11 23:55:00+0';
+
+-- force index scans to check index mapping
+SET enable_seqscan = off;
+EXPLAIN (costs off) SELECT device_id, count(*)
+FROM compression_insert
+GROUP BY device_id;
+SELECT device_id, count(*)
+FROM compression_insert
+GROUP BY device_id;
+CALL recompress_chunk(:'CHUNK_NAME'::regclass);
+SELECT count(*), sum(v0), sum(v1), sum(v2), sum(v3)
+FROM compression_insert
+WHERE time >= '2000-01-07 0:00:00+0'
+AND time <= '2000-01-11 23:55:00+0';
+SELECT device_id, count(*)
+FROM compression_insert
+GROUP BY device_id;
+SET enable_seqscan = default;
+
+-- 2. drop column after compressing chunk
+INSERT INTO compression_insert(time,device_id,v0,v1,v2,v3)
+SELECT time, device_id, device_id+1, device_id + 2, device_id + 0.5, NULL
+FROM generate_series('2000-01-15 0:00:00+0'::timestamptz,'2000-01-17 23:55:00+0','2m') gtime(time), generate_series(1,5,1) gdevice(device_id);
+
+SELECT compress_chunk(c.schema_name|| '.' || c.table_name) as "CHUNK_NAME"
+FROM _timescaledb_catalog.chunk c, _timescaledb_catalog.hypertable ht
+WHERE c.hypertable_id = ht.id
+AND ht.table_name = 'compression_insert'
+AND c.compressed_chunk_id IS NULL
+ORDER BY c.table_name DESC \gset
+
+ALTER TABLE compression_insert DROP COLUMN filler_2;
+INSERT INTO compression_insert(time,device_id,v0,v1,v2,v3)
+SELECT time, device_id, device_id+1, device_id + 2, device_id + 0.5, NULL
+FROM generate_series('2000-01-18 0:00:00+0'::timestamptz,'2000-01-19 23:55:00+0','2m') gtime(time), generate_series(1,5,1) gdevice(device_id);
+SELECT count(*), sum(v0), sum(v1), sum(v2), sum(v3)
+FROM compression_insert
+WHERE time >= '2000-01-15 0:00:00+0'
+AND time <= '2000-01-19 23:55:00+0';
+
+-- force index scans to check index mapping
+SET enable_seqscan = off;
+EXPLAIN (costs off) SELECT device_id, count(*)
+FROM compression_insert
+GROUP BY device_id;
+SELECT device_id, count(*)
+FROM compression_insert
+GROUP BY device_id;
+CALL recompress_chunk(:'CHUNK_NAME'::regclass);
+SELECT count(*), sum(v0), sum(v1), sum(v2), sum(v3)
+FROM compression_insert
+WHERE time >= '2000-01-15 0:00:00+0'
+AND time <= '2000-01-19 23:55:00+0';
+SELECT device_id, count(*)
+FROM compression_insert
+GROUP BY device_id;
+SET enable_seqscan = default;
+
+-- 3. add new column after first insert into chunk, before compressing
+INSERT INTO compression_insert(time,device_id,v0,v1,v2,v3)
+SELECT time, device_id, device_id+1, device_id + 2, device_id + 0.5, NULL
+FROM generate_series('2000-01-22 0:00:00+0'::timestamptz,'2000-01-24 23:55:00+0','2m') gtime(time), generate_series(1,5,1) gdevice(device_id);
+
+ALTER TABLE compression_insert ADD COLUMN filler_4 int;
+SELECT compress_chunk(c.schema_name|| '.' || c.table_name) as "CHUNK_NAME"
+FROM _timescaledb_catalog.chunk c, _timescaledb_catalog.hypertable ht
+WHERE c.hypertable_id = ht.id
+AND ht.table_name = 'compression_insert'
+AND c.compressed_chunk_id IS NULL
+ORDER BY c.table_name DESC \gset
+
+INSERT INTO compression_insert(time,device_id,v0,v1,v2,v3)
+SELECT time, device_id, device_id+1, device_id + 2, device_id + 0.5, NULL
+FROM generate_series('2000-01-25 0:00:00+0'::timestamptz,'2000-01-26 23:55:00+0','2m') gtime(time), generate_series(1,5,1) gdevice(device_id);
+SELECT count(*), sum(v0), sum(v1), sum(v2), sum(v3)
+FROM compression_insert
+WHERE time >= '2000-01-22 0:00:00+0'
+AND time <= '2000-01-26 23:55:00+0';
+
+-- force index scans to check index mapping
+SET enable_seqscan = off;
+EXPLAIN (costs off) SELECT device_id, count(*)
+FROM compression_insert
+GROUP BY device_id;
+SELECT device_id, count(*)
+FROM compression_insert
+GROUP BY device_id;
+CALL recompress_chunk(:'CHUNK_NAME'::regclass);
+SELECT count(*), sum(v0), sum(v1), sum(v2), sum(v3)
+FROM compression_insert
+WHERE time >= '2000-01-22 0:00:00+0'
+AND time <= '2000-01-26 23:55:00+0';
+SELECT device_id, count(*)
+FROM compression_insert
+GROUP BY device_id;
+SET enable_seqscan = default;
+
+-- 4. add new column after compressing chunk
+INSERT INTO compression_insert(time,device_id,v0,v1,v2,v3)
+SELECT time, device_id, device_id+1, device_id + 2, device_id + 0.5, NULL
+FROM generate_series('2000-01-28 0:00:00+0'::timestamptz,'2000-01-30 23:55:00+0','2m') gtime(time), generate_series(1,5,1) gdevice(device_id);
+SELECT compress_chunk(c.schema_name|| '.' || c.table_name) as "CHUNK_NAME"
+FROM _timescaledb_catalog.chunk c, _timescaledb_catalog.hypertable ht
+WHERE c.hypertable_id = ht.id
+AND ht.table_name = 'compression_insert'
+AND c.compressed_chunk_id IS NULL
+ORDER BY c.table_name DESC \gset
+
+ALTER TABLE compression_insert ADD COLUMN filler_5 int;
+INSERT INTO compression_insert(time,device_id,v0,v1,v2,v3)
+SELECT time, device_id, device_id+1, device_id + 2, device_id + 0.5, NULL
+FROM generate_series('2000-01-31 0:00:00+0'::timestamptz,'2000-02-01 23:55:00+0','2m') gtime(time), generate_series(1,5,1) gdevice(device_id);
+SELECT count(*), sum(v0), sum(v1), sum(v2), sum(v3)
+FROM compression_insert
+WHERE time >= '2000-01-28 0:00:00+0'
+AND time <= '2000-02-01 23:55:00+0';
+
+-- force index scans to check index mapping
+SET enable_seqscan = off;
+EXPLAIN (costs off) SELECT device_id, count(*)
+FROM compression_insert
+GROUP BY device_id;
+SELECT device_id, count(*)
+FROM compression_insert
+GROUP BY device_id;
+CALL recompress_chunk(:'CHUNK_NAME'::regclass);
+SELECT count(*), sum(v0), sum(v1), sum(v2), sum(v3)
+FROM compression_insert
+WHERE time >= '2000-01-28 0:00:00+0'
+AND time <= '2000-02-01 23:55:00+0';
+SELECT device_id, count(*)
+FROM compression_insert
+GROUP BY device_id;
+SET enable_seqscan = default;
+
+DROP TABLE compression_insert;


### PR DESCRIPTION
This PR contains a couple of commits that add tests to recent compression DML changes:
- tests with physical layout changes and index mapping while inserting into compressed chunks
- isolation tests to test locking between multiple insert sessions and using RETURNING clause

Disable-check: force-changelog-changed
Disable-check: commit-count