### PR TITLE
Add new clangd cache location to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,7 @@ typedef.list
 /compile_commands.json
 /.DS_Store
 /.clangd
+/.cache
 
 /CMakeSettings.json
 /out/*


### PR DESCRIPTION
Recent versions of clangd store cached data in the `.cache` directory instead of `.clangd`; this PR makes the new directory ignored by Git in addition to the old one.

Disable-check: force-changelog-changed