### PR TITLE
Add missing gitignore entry

### DIFF
--- a/tsl/test/sql/.gitignore
+++ b/tsl/test/sql/.gitignore
@@ -13,6 +13,8 @@
 /dist_partial_agg-*.sql
 /dist_ref_table_join-*.sql
 /dist_ref_table_join-*.sql
+/dist_remote_error-*.sql
+/dist_remote_error.text
 /hypertable_distributed-*.sql
 /jit-*.sql
 /modify_exclusion-*.sql


### PR DESCRIPTION
Pull request #4827 introduced a new template SQL test file but missed to add the properly `.gitignore` entry to ignore generated test files.

Disable-check: force-changelog-changed
