### PR TITLE
Ensure superuser perms during copy/move chunk

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ accidentally triggering the load of a previous DB version.**
 * #5428 Use consistent snapshots when scanning metadata
 * #5442 Decompression may have lost DEFAULT values
 * #5446 Add checks for malloc failure in libpq calls
+* #5470 Ensure superuser perms during copy/move chunk
 
 **Thanks**
 * @nikolaps for reporting an issue with the COPY fetcher


### PR DESCRIPTION
There is a security loophole in current core Postgres, due to which it's possible for a non-superuser to gain superuser access by attaching dependencies like expression indexes, triggers, etc. before logical replication commences.

To avoid this, we now ensure that the chunk objects that get created for the subscription are done so as a superuser. This avoids malicious dependencies by regular users.