### PR TITLE
Fix SELECT query on compressed hypertable having reference to whole-row var expression

### DIFF
--- a/tsl/test/expected/compression.out
+++ b/tsl/test/expected/compression.out
@@ -1696,3 +1696,39 @@ SELECT time, const, numeric,first, avg1, avg2 FROM tidrangescan_expr ORDER BY ti
 
 RESET timescaledb.enable_chunk_append;
 RESET enable_indexscan;
+-- github issue 5458
+DROP TABLE IF EXISTS readings;
+NOTICE:  table "readings" does not exist, skipping
+CREATE TABLE readings(
+    time  TIMESTAMP WITH TIME ZONE NOT NULL,
+    battery_status TEXT,
+    battery_temperature  DOUBLE PRECISION
+);
+INSERT INTO readings (time) VALUES ('2022-11-11 11:11:11');
+INSERT INTO readings VALUES ('2022-11-11 12:12:12', NULL, 1234);
+SELECT create_hypertable('readings', 'time', chunk_time_interval => interval '12 hour', migrate_data=>true);
+NOTICE:  migrating data to chunks
+   create_hypertable    
+------------------------
+ (37,public,readings,t)
+(1 row)
+
+--enable compression
+ALTER TABLE readings SET (timescaledb.compress,timescaledb.compress_segmentby = 'battery_temperature');
+-- compress chunks
+SELECT compress_chunk(show_chunks('readings'));
+              compress_chunk              
+------------------------------------------
+ _timescaledb_internal._hyper_37_71_chunk
+(1 row)
+
+-- drop column such that physical layout of compressed and uncompressed chunks differ
+ALTER TABLE readings drop column battery_status;
+-- SELECT with reference to wholerow Var expression should not crash
+SELECT c from  readings c ORDER BY 1;
+                   c                   
+---------------------------------------
+ ("Fri Nov 11 11:11:11 2022 PST",)
+ ("Fri Nov 11 12:12:12 2022 PST",1234)
+(2 rows)
+


### PR DESCRIPTION
For SELECT query with reference to whole-row var expression, fetching whole row from the compressed chunk scan is not needed, however all dropped attributes should be marked as NULL , else later in call to ExecEvalWholeRowVar() we end up fetching slots which are not filled up and reference a NULL value causing segfault.

Fixes #5458