### PR TITLE
Add timeout argument to the ping_data_node()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -79,6 +79,7 @@ Sooner to that time, we will announce the specific version of TimescaleDB in whi
 * #5253 Make data node command execution interruptible
 * #5262 Extend enabling compression on a continuous aggregrate with 'compress_segmentby' and 'compress_orderby' parameters
 * #5343 Set PortalContext when starting job
+* #5312 Add timeout support to the ping_data_node()
 
 **Bugfixes**
 * #5214 Fix use of prepared statement in async module

--- a/sql/CMakeLists.txt
+++ b/sql/CMakeLists.txt
@@ -49,7 +49,8 @@ set(MOD_FILES
 
 # The downgrade file to generate a downgrade script for the current version, as
 # specified in version.config
-set(CURRENT_REV_FILE 2.10.1--2.10.0.sql)
+set(CURRENT_REV_FILE reverse-dev.sql)
+
 # Files for generating old downgrade scripts. This should only include files for
 # downgrade from one version to its previous version since we do not support
 # skipping versions when downgrading.

--- a/sql/data_node.sql
+++ b/sql/data_node.sql
@@ -3,7 +3,7 @@
 -- LICENSE-APACHE for a copy of the license.
 
 -- Check if a data node is up
-CREATE OR REPLACE FUNCTION _timescaledb_internal.ping_data_node(node_name NAME) RETURNS BOOLEAN
+CREATE OR REPLACE FUNCTION _timescaledb_internal.ping_data_node(node_name NAME, timeout INTERVAL = NULL) RETURNS BOOLEAN
 AS '@MODULE_PATHNAME@', 'ts_data_node_ping' LANGUAGE C VOLATILE;
 
 CREATE OR REPLACE FUNCTION _timescaledb_internal.remote_txn_heal_data_node(foreign_server_oid oid)

--- a/sql/updates/latest-dev.sql
+++ b/sql/updates/latest-dev.sql
@@ -1,0 +1,4 @@
+DROP FUNCTION _timescaledb_internal.ping_data_node(NAME);
+
+CREATE OR REPLACE FUNCTION _timescaledb_internal.ping_data_node(node_name NAME, timeout INTERVAL = NULL) RETURNS BOOLEAN
+AS '@MODULE_PATHNAME@', 'ts_data_node_ping' LANGUAGE C VOLATILE;

--- a/sql/updates/reverse-dev.sql
+++ b/sql/updates/reverse-dev.sql
@@ -1,0 +1,4 @@
+DROP FUNCTION _timescaledb_internal.ping_data_node(NAME, INTERVAL);
+
+CREATE OR REPLACE FUNCTION _timescaledb_internal.ping_data_node(node_name NAME) RETURNS BOOLEAN
+AS '@MODULE_PATHNAME@', 'ts_data_node_ping' LANGUAGE C VOLATILE;

--- a/tsl/src/data_node.c
+++ b/tsl/src/data_node.c
@@ -600,7 +600,7 @@ connect_for_bootstrapping(const char *node_name, const char *const host, int32 p
 	{
 		List *node_options =
 			create_data_node_options(host, port, bootstrap_databases[i], username, password);
-		conn = remote_connection_open(node_name, node_options, &err);
+		conn = remote_connection_open(node_name, node_options, TS_NO_TIMEOUT, &err);
 
 		if (conn)
 			return conn;
@@ -1782,7 +1782,7 @@ drop_data_node_database(const ForeignServer *server)
 		server = data_node_get_foreign_server(nodename, ACL_USAGE, true, false);
 		/* Open a connection to the bootstrap database using the new server options */
 		conn_options = remote_connection_prepare_auth_options(server, userid);
-		conn = remote_connection_open(nodename, conn_options, &err);
+		conn = remote_connection_open(nodename, conn_options, TS_NO_TIMEOUT, &err);
 
 		if (NULL != conn)
 			break;
@@ -2065,6 +2065,9 @@ Datum
 data_node_ping(PG_FUNCTION_ARGS)
 {
 	const char *node_name = PG_ARGISNULL(0) ? NULL : PG_GETARG_CSTRING(0);
+	Interval *timeout = PG_ARGISNULL(1) ? NULL : PG_GETARG_INTERVAL_P(1);
+	TimestampTz endtime = TS_NO_TIMEOUT;
+
 	/* Allow anyone to ping a data node. Otherwise the
 	 * timescaledb_information.data_node view won't work for those users. */
 	ForeignServer *server = data_node_get_foreign_server(node_name, ACL_NO_CHECK, false, false);
@@ -2072,7 +2075,11 @@ data_node_ping(PG_FUNCTION_ARGS)
 
 	Assert(NULL != server);
 
-	success = remote_connection_ping(server->servername);
+	/* Get endtime in microseconds */
+	if (timeout)
+		endtime = GetCurrentTimestamp() + ts_get_interval_period_approx(timeout);
+
+	success = remote_connection_ping(server->servername, endtime);
 
 	PG_RETURN_DATUM(BoolGetDatum(success));
 }

--- a/tsl/src/remote/connection.h
+++ b/tsl/src/remote/connection.h
@@ -58,7 +58,7 @@ typedef struct TSConnectionError
  * `remote_connection_close`
  */
 extern TSConnection *remote_connection_open(const char *node_name, List *connection_options,
-											char **errmsg);
+											TimestampTz endtime, char **errmsg);
 extern TSConnection *remote_connection_open_session(const char *node_name, List *connection_options,
 													bool set_dist_id);
 extern TSConnection *remote_connection_open_session_by_id(TSConnectionId id);
@@ -69,9 +69,11 @@ extern int remote_connection_xact_depth_dec(TSConnection *conn);
 extern void remote_connection_xact_transition_begin(TSConnection *conn);
 extern void remote_connection_xact_transition_end(TSConnection *conn);
 extern bool remote_connection_xact_is_transitioning(const TSConnection *conn);
-extern bool remote_connection_ping(const char *node_name);
+extern bool remote_connection_ping(const char *node_name, TimestampTz endtime);
 extern void remote_connection_close(TSConnection *conn);
-extern PGresult *remote_connection_get_result(const TSConnection *conn);
+extern PGresult *remote_connection_get_result(const TSConnection *conn, TimestampTz endtime);
+extern PGresult *remote_connection_exec_timeout(TSConnection *conn, const char *cmd,
+												TimestampTz endtime);
 extern PGresult *remote_connection_exec(TSConnection *conn, const char *cmd);
 extern PGresult *remote_connection_execf(TSConnection *conn, const char *fmt, ...)
 	pg_attribute_printf(2, 3);

--- a/tsl/test/expected/data_node.out
+++ b/tsl/test/expected/data_node.out
@@ -674,6 +674,25 @@ SELECT * FROM _timescaledb_internal.ping_data_node('data_node_1');
  t
 (1 row)
 
+-- Ensure timeout returned by argument
+SELECT * FROM _timescaledb_internal.ping_data_node('data_node_1', interval '0s');
+ ping_data_node 
+----------------
+ f
+(1 row)
+
+SELECT * FROM _timescaledb_internal.ping_data_node('data_node_1', interval '3s');
+ ping_data_node 
+----------------
+ t
+(1 row)
+
+SELECT * FROM _timescaledb_internal.ping_data_node('data_node_1', interval '1 day');
+ ping_data_node 
+----------------
+ t
+(1 row)
+
 -- Create data node referencing postgres_fdw
 RESET ROLE;
 CREATE EXTENSION postgres_fdw;

--- a/tsl/test/shared/expected/extension.out
+++ b/tsl/test/shared/expected/extension.out
@@ -110,7 +110,7 @@ ORDER BY pronamespace::regnamespace::text COLLATE "C", p.oid::regprocedure::text
  _timescaledb_internal.main_table_from_hypertable(integer)
  _timescaledb_internal.materialization_invalidation_log_delete(integer)
  _timescaledb_internal.partialize_agg(anyelement)
- _timescaledb_internal.ping_data_node(name)
+ _timescaledb_internal.ping_data_node(name,interval)
  _timescaledb_internal.policy_compression(integer,jsonb)
  _timescaledb_internal.policy_compression_check(jsonb)
  _timescaledb_internal.policy_compression_execute(integer,integer,anyelement,integer,boolean,boolean)

--- a/tsl/test/sql/data_node.sql
+++ b/tsl/test/sql/data_node.sql
@@ -340,6 +340,11 @@ SELECT * FROM _timescaledb_catalog.chunk_data_node;
 
 SELECT * FROM _timescaledb_internal.ping_data_node('data_node_1');
 
+-- Ensure timeout returned by argument
+SELECT * FROM _timescaledb_internal.ping_data_node('data_node_1', interval '0s');
+SELECT * FROM _timescaledb_internal.ping_data_node('data_node_1', interval '3s');
+SELECT * FROM _timescaledb_internal.ping_data_node('data_node_1', interval '1 day');
+
 -- Create data node referencing postgres_fdw
 RESET ROLE;
 CREATE EXTENSION postgres_fdw;

--- a/version.config
+++ b/version.config
@@ -1,3 +1,3 @@
-version = 2.10.1
-update_from_version = 2.10.0
-downgrade_to_version = 2.10.0
+version = 2.10.2-dev
+update_from_version = 2.10.1
+downgrade_to_version = 2.10.1


### PR DESCRIPTION
This PR introduces a timeout argument and a new logic to the timescale_internal.ping_data_node() function which allows to handle io timeouts for nodes being unresponsive.

Fix #`5312`

backport of #5313, cherry-picked from f12a361ef