### PR TITLE
Do not segfault on large histogram() parameters

### DIFF
--- a/.github/workflows/linux-32bit-build-and-test.yaml
+++ b/.github/workflows/linux-32bit-build-and-test.yaml
@@ -37,7 +37,7 @@ jobs:
         DEBIAN_FRONTEND: noninteractive
         IGNORES: "append-* debug_notice transparent_decompression-*
           transparent_decompress_chunk-* plan_skip_scan-12 pg_dump"
-        SKIPS: chunk_adaptive
+        SKIPS: chunk_adaptive histogram_test
     strategy:
       fail-fast: false
       matrix:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,11 +25,13 @@ accidentally triggering the load of a previous DB version.**
 * #5446 Add checks for malloc failure in libpq calls
 * #5470 Ensure superuser perms during copy/move chunk
 * #5459 Fix issue creating dimensional constraints
+* #5499 Do not segfault on large histogram() parameters
 
 **Thanks**
 * @nikolaps for reporting an issue with the COPY fetcher
 * @S-imo-n for reporting the issue on Background Worker Scheduler crash
 * @kovetskiy and @DZDomi for reporting peformance regression in Realtime Continuous Aggregates
+* @geezhu for reporting issue on segfault in historgram()
 
 ## 2.10.1 (2023-03-07)
 

--- a/test/expected/histogram_test.out
+++ b/test/expected/histogram_test.out
@@ -97,3 +97,31 @@ SELECT qualify, histogram(score, 0, 10, 5) FROM hitest2 GROUP BY qualify ORDER B
 select histogram(i,10,90,case when i=1 then 1 else 1000000 end) FROM generate_series(1,100) i;
 ERROR:  number of buckets must not change between calls
 \set ON_ERROR_STOP 1
+CREATE TABLE weather (
+       time TIMESTAMPTZ NOT NULL,
+       city TEXT,
+       temperature FLOAT,
+       PRIMARY KEY(time, city)
+);
+-- There is a bug in width_bucket() causing a NaN as a result, so we
+-- check that it is not causing a crash in histogram().
+SELECT * FROM create_hypertable('weather', 'time', 'city', 3);
+ hypertable_id | schema_name | table_name | created 
+---------------+-------------+------------+---------
+             1 | public      | weather    | t
+(1 row)
+
+INSERT INTO weather VALUES
+       ('2023-02-10 09:16:51.133584+00','city1',10.4),
+       ('2023-02-10 11:16:51.611618+00','city1',10.3),
+       ('2023-02-10 06:58:59.999999+00','city1',10.3),
+       ('2023-02-10 01:58:59.999999+00','city1',10.3),
+       ('2023-02-09 01:58:59.999999+00','city1',10.3),
+       ('2023-02-10 08:58:59.999999+00','city1',10.3),
+       ('2023-03-23 06:12:02.73765+00 ','city1', 9.7),
+       ('2023-03-23 06:12:06.990998+00','city1',11.7);
+-- This will currently generate an error.
+\set ON_ERROR_STOP 0
+SELECT histogram(temperature, -1.79769e+308, 1.79769e+308,10) FROM weather GROUP BY city;
+ERROR:  index -2147483648 from "width_bucket" out of range
+\set ON_ERROR_STOP 1


### PR DESCRIPTION
There is a bug in `width_bucket()` causing an overflow and subsequent NaN value as a result of dividing with `+inf`. The NaN value is interpreted as an integer and hence generates an index out of range for the buckets.

This commit fixes this by generating an error rather than segfaulting for bucket indexes that are out of range.

Fixes #5489 