### PR TITLE
Add CI check for missing gitignore entries

### DIFF
--- a/.github/workflows/code_style.yaml
+++ b/.github/workflows/code_style.yaml
@@ -100,7 +100,7 @@ jobs:
           git diff --exit-code
 
   misc_checks:
-    name: Check license, update scripts, and git hooks
+    name: Check license, update scripts, git hooks and missing gitignore entries
     runs-on: ubuntu-22.04
     strategy:
       fail-fast: false
@@ -121,3 +121,6 @@ jobs:
     - name: Check update scripts
       if: always()
       run: ./scripts/check_update_scripts.sh
+    - name: Check for missing gitignore entries for template test files
+      if: always()
+      run: ./scripts/check_missing_gitignore_for_template_tests.sh

--- a/scripts/check_missing_gitignore_for_template_tests.sh
+++ b/scripts/check_missing_gitignore_for_template_tests.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+ERROR=0
+
+for FILE in $(git ls-files | grep '\.sql\.in')
+do
+  DIRNAME=$(dirname "${FILE}")
+  FILENAME=$(basename "${FILE}" .sql.in)
+  GITIGNORE=${DIRNAME}/.gitignore
+  if [ -f "${GITIGNORE}" ]; then
+    if ! grep -F --silent -e "${FILENAME}-*.sql" "${GITIGNORE}"; then
+      echo "Missing entry in ${GITIGNORE} for template file ${FILE}"
+      ERROR=1
+    fi
+  fi
+done
+
+exit ${ERROR}

--- a/test/sql/.gitignore
+++ b/test/sql/.gitignore
@@ -21,3 +21,4 @@
 /query-*.sql
 /rowsecurity-*.sql
 /update-*.sql
+/loader-*.sql


### PR DESCRIPTION
Whenever we create a template sql file (*.sql.in) we should add the respective .gitignore entry for the generated test files.

So added a CI check to check for missing gitignore entries for generated test files.

Disable-check: force-changelog-changed
