### PR TITLE
Fix tablespace for compressed hypertable and corresponding toast 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ accidentally triggering the load of a previous DB version.**
 * #5614 Enable run_job() for telemetry job
 * #5578 Fix on-insert decompression after schema changes
 * #5613 Quote username identifier appropriately
+* #5525 Fix tablespace for compressed hypertable and corresponding toast
 
 **Thanks**
 * @kovetskiy and @DZDomi for reporting peformance regression in Realtime Continuous Aggregates

--- a/tsl/test/expected/compression_ddl.out
+++ b/tsl/test/expected/compression_ddl.out
@@ -629,6 +629,14 @@ WHERE chunk.id IS NULL;
 (1 row)
 
 --can turn compression back on
+-- this will fail because current table owner does not have permission to create compressed hypertable
+-- in the current tablespace, as they do not own it
+\set ON_ERROR_STOP 0
+ALTER TABLE test1 set (timescaledb.compress, timescaledb.compress_segmentby = 'b', timescaledb.compress_orderby = '"Time" DESC');
+ERROR:  permission denied for tablespace "tablespace2" by table owner "default_perm_user_2"
+-- now change the owner and repeat, should work
+ALTER TABLESPACE tablespace2 OWNER TO :ROLE_DEFAULT_PERM_USER_2;
+\set ON_ERROR_STOP 1
 ALTER TABLE test1 set (timescaledb.compress, timescaledb.compress_segmentby = 'b', timescaledb.compress_orderby = '"Time" DESC');
 SELECT COUNT(*) AS count_compressed
 FROM
@@ -645,7 +653,7 @@ AS sub;
 (1 row)
 
 DROP TABLE test1 CASCADE;
-NOTICE:  drop cascades to table _timescaledb_internal.compress_hyper_6_57_chunk
+NOTICE:  drop cascades to table _timescaledb_internal.compress_hyper_7_57_chunk
 NOTICE:  drop cascades to 2 other objects
 NOTICE:  drop cascades to table _timescaledb_internal._hyper_5_56_chunk
 DROP TABLESPACE tablespace1;
@@ -706,9 +714,9 @@ DROP TABLE test1;
 -- github issue 2844
 CREATE TABLE i2844 (created_at timestamptz NOT NULL,c1 float);
 SELECT create_hypertable('i2844', 'created_at', chunk_time_interval => '6 hour'::interval);
- create_hypertable  
---------------------
- (9,public,i2844,t)
+  create_hypertable  
+---------------------
+ (10,public,i2844,t)
 (1 row)
 
 INSERT INTO i2844 SELECT generate_series('2000-01-01'::timestamptz, '2000-01-02'::timestamptz,'1h'::interval);
@@ -716,28 +724,28 @@ CREATE MATERIALIZED VIEW test_agg WITH (timescaledb.continuous) AS SELECT time_b
 NOTICE:  refreshing continuous aggregate "test_agg"
 ALTER TABLE i2844 SET (timescaledb.compress);
 SELECT compress_chunk(show_chunks) AS compressed_chunk FROM show_chunks('i2844');
-            compressed_chunk             
------------------------------------------
- _timescaledb_internal._hyper_9_62_chunk
- _timescaledb_internal._hyper_9_63_chunk
- _timescaledb_internal._hyper_9_64_chunk
- _timescaledb_internal._hyper_9_65_chunk
- _timescaledb_internal._hyper_9_66_chunk
+             compressed_chunk             
+------------------------------------------
+ _timescaledb_internal._hyper_10_62_chunk
+ _timescaledb_internal._hyper_10_63_chunk
+ _timescaledb_internal._hyper_10_64_chunk
+ _timescaledb_internal._hyper_10_65_chunk
+ _timescaledb_internal._hyper_10_66_chunk
 (5 rows)
 
 SELECT drop_chunks('i2844', older_than => '2000-01-01 18:00'::timestamptz);
-               drop_chunks               
------------------------------------------
- _timescaledb_internal._hyper_9_62_chunk
- _timescaledb_internal._hyper_9_63_chunk
- _timescaledb_internal._hyper_9_64_chunk
+               drop_chunks                
+------------------------------------------
+ _timescaledb_internal._hyper_10_62_chunk
+ _timescaledb_internal._hyper_10_63_chunk
+ _timescaledb_internal._hyper_10_64_chunk
 (3 rows)
 
 SELECT decompress_chunk(show_chunks, if_compressed => TRUE) AS decompressed_chunks FROM show_chunks('i2844');
-           decompressed_chunks           
------------------------------------------
- _timescaledb_internal._hyper_9_65_chunk
- _timescaledb_internal._hyper_9_66_chunk
+           decompressed_chunks            
+------------------------------------------
+ _timescaledb_internal._hyper_10_65_chunk
+ _timescaledb_internal._hyper_10_66_chunk
 (2 rows)
 
 ALTER TABLE i2844 SET (timescaledb.compress = FALSE);
@@ -813,12 +821,12 @@ SELECT * FROM _timescaledb_catalog.hypertable_compression
 ORDER BY attname;
  hypertable_id | attname  | compression_algorithm_id | segmentby_column_index | orderby_column_index | orderby_asc | orderby_nullsfirst 
 ---------------+----------+--------------------------+------------------------+----------------------+-------------+--------------------
-            12 | Time     |                        4 |                        |                    1 | f           | t
-            12 | bntcol   |                        0 |                      1 |                      |             | 
-            12 | intcol   |                        4 |                        |                      |             | 
-            12 | new_coli |                        4 |                        |                      |             | 
-            12 | new_colv |                        2 |                        |                      |             | 
-            12 | txtcol   |                        2 |                        |                      |             | 
+            13 | Time     |                        4 |                        |                    1 | f           | t
+            13 | bntcol   |                        0 |                      1 |                      |             | 
+            13 | intcol   |                        4 |                        |                      |             | 
+            13 | new_coli |                        4 |                        |                      |             | 
+            13 | new_colv |                        2 |                        |                      |             | 
+            13 | txtcol   |                        2 |                        |                      |             | 
 (6 rows)
 
 SELECT count(*) from test1 where new_coli is not null;
@@ -910,7 +918,7 @@ WHERE attname = 'new_coli' and hypertable_id = (SELECT id from _timescaledb_cata
                        WHERE table_name = 'test1' );
  hypertable_id | attname  | compression_algorithm_id | segmentby_column_index | orderby_column_index | orderby_asc | orderby_nullsfirst 
 ---------------+----------+--------------------------+------------------------+----------------------+-------------+--------------------
-            12 | new_coli |                        4 |                        |                      |             | 
+            13 | new_coli |                        4 |                        |                      |             | 
 (1 row)
 
 ALTER TABLE test1 RENAME new_coli TO coli;
@@ -919,7 +927,7 @@ WHERE attname = 'coli' and hypertable_id = (SELECT id from _timescaledb_catalog.
                        WHERE table_name = 'test1' );
  hypertable_id | attname | compression_algorithm_id | segmentby_column_index | orderby_column_index | orderby_asc | orderby_nullsfirst 
 ---------------+---------+--------------------------+------------------------+----------------------+-------------+--------------------
-            12 | coli    |                        4 |                        |                      |             | 
+            13 | coli    |                        4 |                        |                      |             | 
 (1 row)
 
 SELECT count(*) from test1 where coli  = 100;
@@ -935,7 +943,7 @@ WHERE attname = 'bigintcol' and hypertable_id = (SELECT id from _timescaledb_cat
                        WHERE table_name = 'test1' );
  hypertable_id |  attname  | compression_algorithm_id | segmentby_column_index | orderby_column_index | orderby_asc | orderby_nullsfirst 
 ---------------+-----------+--------------------------+------------------------+----------------------+-------------+--------------------
-            12 | bigintcol |                        0 |                      1 |                      |             | 
+            13 | bigintcol |                        0 |                      1 |                      |             | 
 (1 row)
 
 --query by segment by column name
@@ -1038,7 +1046,7 @@ CREATE TABLE test_defaults(time timestamptz NOT NULL, device_id int);
 SELECT create_hypertable('test_defaults','time');
       create_hypertable      
 -----------------------------
- (14,public,test_defaults,t)
+ (15,public,test_defaults,t)
 (1 row)
 
 ALTER TABLE test_defaults SET (timescaledb.compress,timescaledb.compress_segmentby='device_id');
@@ -1049,7 +1057,7 @@ INSERT INTO test_defaults SELECT '2001-01-01', 1;
 SELECT compress_chunk(show_chunks) AS compressed_chunk FROM show_chunks('test_defaults') ORDER BY show_chunks::text LIMIT 1;
              compressed_chunk             
 ------------------------------------------
- _timescaledb_internal._hyper_14_89_chunk
+ _timescaledb_internal._hyper_15_89_chunk
 (1 row)
 
 SELECT * FROM test_defaults ORDER BY 1;
@@ -1098,10 +1106,10 @@ SELECT *,assert_equal(c3,43) FROM test_defaults ORDER BY 1,2;
 (3 rows)
 
 select decompress_chunk(show_chunks('test_defaults'),true);
-psql:include/compression_alter.sql:179: NOTICE:  chunk "_hyper_14_90_chunk" is not compressed
+psql:include/compression_alter.sql:179: NOTICE:  chunk "_hyper_15_90_chunk" is not compressed
              decompress_chunk             
 ------------------------------------------
- _timescaledb_internal._hyper_14_89_chunk
+ _timescaledb_internal._hyper_15_89_chunk
  
 (2 rows)
 
@@ -1116,8 +1124,8 @@ SELECT *,assert_equal(c3,43) FROM test_defaults ORDER BY 1,2;
 select compress_chunk(show_chunks('test_defaults'));
               compress_chunk              
 ------------------------------------------
- _timescaledb_internal._hyper_14_89_chunk
- _timescaledb_internal._hyper_14_90_chunk
+ _timescaledb_internal._hyper_15_89_chunk
+ _timescaledb_internal._hyper_15_90_chunk
 (2 rows)
 
 SELECT *,assert_equal(c3,43) FROM test_defaults ORDER BY 1,2;
@@ -1134,7 +1142,7 @@ SELECT create_hypertable('test_drop','time');
 psql:include/compression_alter.sql:186: NOTICE:  adding not-null constraint to column "time"
     create_hypertable    
 -------------------------
- (16,public,test_drop,t)
+ (17,public,test_drop,t)
 (1 row)
 
 ALTER TABLE test_drop SET (timescaledb.compress,timescaledb.compress_segmentby='device',timescaledb.compress_orderby='o1,o2');
@@ -1241,15 +1249,21 @@ SELECT attach_tablespace('tablespace2', 'test2');
 INSERT INTO test2 SELECT t,  gen_rand_minstd(), 22
 FROM generate_series('2018-03-02 1:00'::TIMESTAMPTZ, '2018-03-02 13:00', '1 hour') t;
 ALTER TABLE test2 set (timescaledb.compress, timescaledb.compress_segmentby = 'i', timescaledb.compress_orderby = 'timec');
-SELECT relname FROM pg_class
+-- the toast table and its index will have a different name depending on
+-- the order the tests run, so anonymize it
+SELECT regexp_replace(relname, 'pg_toast_[0-9]+', 'pg_toast_XXX') FROM pg_class
 WHERE reltablespace in
   ( SELECT oid from pg_tablespace WHERE spcname = 'tablespace2') ORDER BY 1;
-               relname               
--------------------------------------
- _hyper_18_104_chunk
- _hyper_18_104_chunk_test2_timec_idx
+                    regexp_replace                     
+-------------------------------------------------------
+ _compressed_hypertable_20
+ _compressed_hypertable_20_i__ts_meta_sequence_num_idx
+ _hyper_19_104_chunk
+ _hyper_19_104_chunk_test2_timec_idx
+ pg_toast_XXX
+ pg_toast_XXX_index
  test2
-(3 rows)
+(7 rows)
 
 -- test compress_chunk() with utility statement (SELECT ... INTO)
 SELECT compress_chunk(ch) INTO compressed_chunks FROM show_chunks('test2') ch;
@@ -1258,7 +1272,7 @@ SELECT decompress_chunk(ch) INTO decompressed_chunks FROM show_chunks('test2') c
 SELECT compress_chunk(ch) FROM show_chunks('test2') ch;
               compress_chunk               
 -------------------------------------------
- _timescaledb_internal._hyper_18_104_chunk
+ _timescaledb_internal._hyper_19_104_chunk
 (1 row)
 
 -- the chunk, compressed chunk + index + toast tables are in tablespace2 now .
@@ -1270,11 +1284,11 @@ WHERE reltablespace in
   ( SELECT oid from pg_tablespace WHERE spcname = 'tablespace2'))q;
  count 
 -------
-     7
+    11
 (1 row)
 
 DROP TABLE test2 CASCADE;
-NOTICE:  drop cascades to table _timescaledb_internal.compress_hyper_19_106_chunk
+NOTICE:  drop cascades to table _timescaledb_internal.compress_hyper_20_106_chunk
 DROP TABLESPACE tablespace2;
 -- Create a table with a compressed table and then delete the
 -- compressed table and see that the drop of the hypertable does not
@@ -1285,7 +1299,7 @@ CREATE TABLE issue4140("time" timestamptz NOT NULL, device_id int);
 SELECT create_hypertable('issue4140', 'time');
     create_hypertable    
 -------------------------
- (20,public,issue4140,t)
+ (21,public,issue4140,t)
 (1 row)
 
 ALTER TABLE issue4140 SET(timescaledb.compress);
@@ -1316,7 +1330,7 @@ SELECT create_hypertable('metric', 'time',
 	create_default_indexes => false);
   create_hypertable   
 ----------------------
- (22,public,metric,t)
+ (23,public,metric,t)
 (1 row)
 
 -- enable compression
@@ -1332,7 +1346,7 @@ INNER JOIN _timescaledb_catalog.hypertable comp_hypertable ON (comp_hypertable.i
 WHERE uc_hypertable.table_name like 'metric' \gset
 -- get definition of compressed hypertable and notice the index
 \d :COMP_SCHEMA_NAME.:COMP_TABLE_NAME
-                    Table "_timescaledb_internal._compressed_hypertable_23"
+                    Table "_timescaledb_internal._compressed_hypertable_24"
         Column         |                 Type                  | Collation | Nullable | Default 
 -----------------------+---------------------------------------+-----------+----------+---------
  time                  | _timescaledb_internal.compressed_data |           |          | 
@@ -1343,9 +1357,9 @@ WHERE uc_hypertable.table_name like 'metric' \gset
  _ts_meta_min_1        | timestamp with time zone              |           |          | 
  _ts_meta_max_1        | timestamp with time zone              |           |          | 
 Indexes:
-    "_compressed_hypertable_23_series_id_value__ts_meta_sequence_idx" btree (series_id, value, _ts_meta_sequence_num)
+    "_compressed_hypertable_24_series_id_value__ts_meta_sequence_idx" btree (series_id, value, _ts_meta_sequence_num)
 Triggers:
-    ts_insert_blocker BEFORE INSERT ON _timescaledb_internal._compressed_hypertable_23 FOR EACH ROW EXECUTE FUNCTION _timescaledb_internal.insert_blocker()
+    ts_insert_blocker BEFORE INSERT ON _timescaledb_internal._compressed_hypertable_24 FOR EACH ROW EXECUTE FUNCTION _timescaledb_internal.insert_blocker()
 
 -- #5290 Compression can't be enabled on caggs
 CREATE TABLE "tEst2" (
@@ -1360,7 +1374,7 @@ SELECT create_hypertable(
 );
   create_hypertable  
 ---------------------
- (24,public,tEst2,t)
+ (25,public,tEst2,t)
 (1 row)
 
 alter table "tEst2" set (timescaledb.compress=true, timescaledb.compress_segmentby='"Id"');
@@ -1419,7 +1433,7 @@ CREATE INDEX ON compression_insert(device_id,time);
 SELECT create_hypertable('compression_insert','time',create_default_indexes:=false);
         create_hypertable         
 ----------------------------------
- (31,public,compression_insert,t)
+ (32,public,compression_insert,t)
 (1 row)
 
 ALTER TABLE compression_insert SET (timescaledb.compress, timescaledb.compress_orderby='time DESC', timescaledb.compress_segmentby='device_id');
@@ -1462,13 +1476,13 @@ ORDER BY device_id;
                                                                QUERY PLAN                                                                
 -----------------------------------------------------------------------------------------------------------------------------------------
  Sort
-   Sort Key: _hyper_31_107_chunk.device_id
+   Sort Key: _hyper_32_107_chunk.device_id
    ->  HashAggregate
-         Group Key: _hyper_31_107_chunk.device_id
+         Group Key: _hyper_32_107_chunk.device_id
          ->  Append
-               ->  Custom Scan (DecompressChunk) on _hyper_31_107_chunk
-                     ->  Index Scan using compress_hyper_32_108_chunk__compressed_hypertable_32_device_id on compress_hyper_32_108_chunk
-               ->  Index Only Scan using _hyper_31_107_chunk_compression_insert_device_id_time_idx on _hyper_31_107_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_32_107_chunk
+                     ->  Index Scan using compress_hyper_33_108_chunk__compressed_hypertable_33_device_id on compress_hyper_33_108_chunk
+               ->  Index Only Scan using _hyper_32_107_chunk_compression_insert_device_id_time_idx on _hyper_32_107_chunk
 (8 rows)
 
 SELECT device_id, count(*)
@@ -1540,15 +1554,15 @@ ORDER BY device_id;
                                                                QUERY PLAN                                                                
 -----------------------------------------------------------------------------------------------------------------------------------------
  Sort
-   Sort Key: _hyper_31_107_chunk.device_id
+   Sort Key: _hyper_32_107_chunk.device_id
    ->  HashAggregate
-         Group Key: _hyper_31_107_chunk.device_id
+         Group Key: _hyper_32_107_chunk.device_id
          ->  Append
-               ->  Custom Scan (DecompressChunk) on _hyper_31_107_chunk
-                     ->  Index Scan using compress_hyper_32_108_chunk__compressed_hypertable_32_device_id on compress_hyper_32_108_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_31_109_chunk
-                     ->  Index Scan using compress_hyper_32_110_chunk__compressed_hypertable_32_device_id on compress_hyper_32_110_chunk
-               ->  Index Only Scan using _hyper_31_109_chunk_compression_insert_device_id_time_idx on _hyper_31_109_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_32_107_chunk
+                     ->  Index Scan using compress_hyper_33_108_chunk__compressed_hypertable_33_device_id on compress_hyper_33_108_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_32_109_chunk
+                     ->  Index Scan using compress_hyper_33_110_chunk__compressed_hypertable_33_device_id on compress_hyper_33_110_chunk
+               ->  Index Only Scan using _hyper_32_109_chunk_compression_insert_device_id_time_idx on _hyper_32_109_chunk
 (10 rows)
 
 SELECT device_id, count(*)
@@ -1620,17 +1634,17 @@ ORDER BY device_id;
                                                                QUERY PLAN                                                                
 -----------------------------------------------------------------------------------------------------------------------------------------
  Sort
-   Sort Key: _hyper_31_107_chunk.device_id
+   Sort Key: _hyper_32_107_chunk.device_id
    ->  HashAggregate
-         Group Key: _hyper_31_107_chunk.device_id
+         Group Key: _hyper_32_107_chunk.device_id
          ->  Append
-               ->  Custom Scan (DecompressChunk) on _hyper_31_107_chunk
-                     ->  Index Scan using compress_hyper_32_108_chunk__compressed_hypertable_32_device_id on compress_hyper_32_108_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_31_109_chunk
-                     ->  Index Scan using compress_hyper_32_110_chunk__compressed_hypertable_32_device_id on compress_hyper_32_110_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_31_111_chunk
-                     ->  Index Scan using compress_hyper_32_112_chunk__compressed_hypertable_32_device_id on compress_hyper_32_112_chunk
-               ->  Index Only Scan using _hyper_31_111_chunk_compression_insert_device_id_time_idx on _hyper_31_111_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_32_107_chunk
+                     ->  Index Scan using compress_hyper_33_108_chunk__compressed_hypertable_33_device_id on compress_hyper_33_108_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_32_109_chunk
+                     ->  Index Scan using compress_hyper_33_110_chunk__compressed_hypertable_33_device_id on compress_hyper_33_110_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_32_111_chunk
+                     ->  Index Scan using compress_hyper_33_112_chunk__compressed_hypertable_33_device_id on compress_hyper_33_112_chunk
+               ->  Index Only Scan using _hyper_32_111_chunk_compression_insert_device_id_time_idx on _hyper_32_111_chunk
 (12 rows)
 
 SELECT device_id, count(*)
@@ -1702,19 +1716,19 @@ ORDER BY device_id;
                                                                QUERY PLAN                                                                
 -----------------------------------------------------------------------------------------------------------------------------------------
  Sort
-   Sort Key: _hyper_31_107_chunk.device_id
+   Sort Key: _hyper_32_107_chunk.device_id
    ->  HashAggregate
-         Group Key: _hyper_31_107_chunk.device_id
+         Group Key: _hyper_32_107_chunk.device_id
          ->  Append
-               ->  Custom Scan (DecompressChunk) on _hyper_31_107_chunk
-                     ->  Index Scan using compress_hyper_32_108_chunk__compressed_hypertable_32_device_id on compress_hyper_32_108_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_31_109_chunk
-                     ->  Index Scan using compress_hyper_32_110_chunk__compressed_hypertable_32_device_id on compress_hyper_32_110_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_31_111_chunk
-                     ->  Index Scan using compress_hyper_32_112_chunk__compressed_hypertable_32_device_id on compress_hyper_32_112_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_31_113_chunk
-                     ->  Index Scan using compress_hyper_32_114_chunk__compressed_hypertable_32_device_id on compress_hyper_32_114_chunk
-               ->  Index Only Scan using _hyper_31_113_chunk_compression_insert_device_id_time_idx on _hyper_31_113_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_32_107_chunk
+                     ->  Index Scan using compress_hyper_33_108_chunk__compressed_hypertable_33_device_id on compress_hyper_33_108_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_32_109_chunk
+                     ->  Index Scan using compress_hyper_33_110_chunk__compressed_hypertable_33_device_id on compress_hyper_33_110_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_32_111_chunk
+                     ->  Index Scan using compress_hyper_33_112_chunk__compressed_hypertable_33_device_id on compress_hyper_33_112_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_32_113_chunk
+                     ->  Index Scan using compress_hyper_33_114_chunk__compressed_hypertable_33_device_id on compress_hyper_33_114_chunk
+               ->  Index Only Scan using _hyper_32_113_chunk_compression_insert_device_id_time_idx on _hyper_32_113_chunk
 (14 rows)
 
 SELECT device_id, count(*)
@@ -1786,21 +1800,21 @@ ORDER BY device_id;
                                                                QUERY PLAN                                                                
 -----------------------------------------------------------------------------------------------------------------------------------------
  Sort
-   Sort Key: _hyper_31_107_chunk.device_id
+   Sort Key: _hyper_32_107_chunk.device_id
    ->  HashAggregate
-         Group Key: _hyper_31_107_chunk.device_id
+         Group Key: _hyper_32_107_chunk.device_id
          ->  Append
-               ->  Custom Scan (DecompressChunk) on _hyper_31_107_chunk
-                     ->  Index Scan using compress_hyper_32_108_chunk__compressed_hypertable_32_device_id on compress_hyper_32_108_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_31_109_chunk
-                     ->  Index Scan using compress_hyper_32_110_chunk__compressed_hypertable_32_device_id on compress_hyper_32_110_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_31_111_chunk
-                     ->  Index Scan using compress_hyper_32_112_chunk__compressed_hypertable_32_device_id on compress_hyper_32_112_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_31_113_chunk
-                     ->  Index Scan using compress_hyper_32_114_chunk__compressed_hypertable_32_device_id on compress_hyper_32_114_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_31_115_chunk
-                     ->  Index Scan using compress_hyper_32_116_chunk__compressed_hypertable_32_device_id on compress_hyper_32_116_chunk
-               ->  Index Only Scan using _hyper_31_115_chunk_compression_insert_device_id_time_idx on _hyper_31_115_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_32_107_chunk
+                     ->  Index Scan using compress_hyper_33_108_chunk__compressed_hypertable_33_device_id on compress_hyper_33_108_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_32_109_chunk
+                     ->  Index Scan using compress_hyper_33_110_chunk__compressed_hypertable_33_device_id on compress_hyper_33_110_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_32_111_chunk
+                     ->  Index Scan using compress_hyper_33_112_chunk__compressed_hypertable_33_device_id on compress_hyper_33_112_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_32_113_chunk
+                     ->  Index Scan using compress_hyper_33_114_chunk__compressed_hypertable_33_device_id on compress_hyper_33_114_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_32_115_chunk
+                     ->  Index Scan using compress_hyper_33_116_chunk__compressed_hypertable_33_device_id on compress_hyper_33_116_chunk
+               ->  Index Only Scan using _hyper_32_115_chunk_compression_insert_device_id_time_idx on _hyper_32_115_chunk
 (16 rows)
 
 SELECT device_id, count(*)


### PR DESCRIPTION
If a hypertable uses a non default tablespace, the compressed hypertable
and its corresponding toast table and index is still created in the
default tablespace.
This PR fixes this unexpected behavior and creates the compressed
hypertable and its toast table and index in the same tablespace as
the hypertable.

Fixes #5520 