### PR TITLE
Properly format license error hint

### DIFF
--- a/src/cross_module_fn.c
+++ b/src/cross_module_fn.c
@@ -167,7 +167,7 @@ error_no_default_fn_community(void)
 			 errmsg("functionality not supported under the current \"%s\" license. Learn more at "
 					"https://timescale.com/.",
 					ts_guc_license),
-			 errhint("To get access to all features, and the best time-series experience try out "
+			 errhint("To access all features and the best time-series experience, try out "
 					 "Timescale Cloud.")));
 }
 

--- a/src/nodes/chunk_dispatch/chunk_dispatch.c
+++ b/src/nodes/chunk_dispatch/chunk_dispatch.c
@@ -160,8 +160,8 @@ ts_chunk_dispatch_get_chunk_insert_state(ChunkDispatch *dispatch, Point *point,
 						 errmsg("functionality not supported under the current \"%s\" license. "
 								"Learn more at https://timescale.com/.",
 								ts_guc_license),
-						 errhint("To get access to all features, and the best time-series "
-								 "experience try out Timescale Cloud")));
+						 errhint("To access all features and the best time-series "
+								 "experience, try out Timescale Cloud")));
 		}
 
 		MemoryContextSwitchTo(old_context);

--- a/test/expected/license.out
+++ b/test/expected/license.out
@@ -54,7 +54,7 @@ SELECT create_hypertable('metrics', 'time');
 
 ALTER TABLE metrics SET (timescaledb.compress);
 ERROR:  functionality not supported under the current "apache" license. Learn more at https://timescale.com/.
-HINT:  To get access to all features, and the best time-series experience try out Timescale Cloud.
+HINT:  To access all features and the best time-series experience, try out Timescale Cloud.
 INSERT INTO metrics
 VALUES ('2022-01-01 00:00:00', 1), ('2022-01-01 01:00:00', 2), ('2022-01-01 02:00:00', 3);
 CREATE MATERIALIZED VIEW metrics_hourly
@@ -67,7 +67,7 @@ FROM metrics
 GROUP BY bucket
 WITH NO DATA;
 ERROR:  functionality not supported under the current "apache" license. Learn more at https://timescale.com/.
-HINT:  To get access to all features, and the best time-series experience try out Timescale Cloud.
+HINT:  To access all features and the best time-series experience, try out Timescale Cloud.
 CREATE MATERIALIZED VIEW metrics_hourly
 AS
 SELECT time_bucket(INTERVAL '1 hour', time) AS bucket,


### PR DESCRIPTION
Commit 57fde383b3dddd0b52263218e65a0135981c2d34 changed the messaging but did not format the error hint correctly. This patch fixes the error hint.