### PR TITLE
Silence WARNING after extension update

### DIFF
--- a/sql/updates/post-update.sql
+++ b/sql/updates/post-update.sql
@@ -142,9 +142,10 @@ BEGIN
         format('%I.%I', user_view_schema, user_view_name)
       FROM _timescaledb_catalog.continuous_agg
       WHERE finalized IS FALSE
+      AND current_setting('server_version_num')::int >= 150000
       ORDER BY 1
     LOOP
-      RAISE WARNING 'Continuous Aggregate: % with old format will not be supported with PG15. You should upgrade to the new format', cagg_name;
+      RAISE WARNING 'Continuous Aggregate: % with old format will not be supported on PostgreSQL version greater or equal to 15. You should upgrade to the new format', cagg_name;
     END LOOP;
 END $$;
 


### PR DESCRIPTION
Commit 8afdddc2da added the first step for deprecating the old format of Continuous Aggregate but just for PostgreSQL 15 and later versions.

During the extension update we emit a message about the deprecation but this has being emited even if the user is using PostgreSQL versions before 15.

Fixed it by emiting the WARNING just when PostgreSQL version is greater or equal to 15.

Disable-check: force-changelog-changed
