### PR TITLE
Fix timestamp out of range refreshing CAgg

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,12 +33,14 @@ accidentally triggering the load of a previous DB version.**
 * #5497 Allow named time_bucket arguments in Cagg definition
 * #5499 Do not segfault on large histogram() parameters
 * #5500 Fix when no FROM clause in continuous aggregate definition
+* #5544 Fix refresh from beginning of Continuous Aggregate with variable time bucket
 
 **Thanks**
 * @nikolaps for reporting an issue with the COPY fetcher
 * @S-imo-n for reporting the issue on Background Worker Scheduler crash
 * @kovetskiy and @DZDomi for reporting peformance regression in Realtime Continuous Aggregates
 * @geezhu for reporting issue on segfault in historgram()
+* @H25E for reporting error refreshing from beginning of a Continuous Aggregate with variable time bucket
 
 ## 2.10.1 (2023-03-07)
 

--- a/src/time_utils.c
+++ b/src/time_utils.c
@@ -420,7 +420,7 @@ ts_time_get_nobegin(Oid timetype)
 	return ts_time_get_nobegin(coerce_to_time_type(timetype));
 }
 
-static int64
+int64
 ts_time_get_nobegin_or_min(Oid timetype)
 {
 	if (IS_TIMESTAMP_TYPE(timetype))

--- a/src/time_utils.h
+++ b/src/time_utils.h
@@ -81,6 +81,7 @@ extern TSDLLEXPORT int64 ts_time_get_max(Oid timetype);
 extern TSDLLEXPORT int64 ts_time_get_end(Oid timetype);
 extern TSDLLEXPORT int64 ts_time_get_end_or_max(Oid timetype);
 extern TSDLLEXPORT int64 ts_time_get_nobegin(Oid timetype);
+extern TSDLLEXPORT int64 ts_time_get_nobegin_or_min(Oid timetype);
 extern TSDLLEXPORT int64 ts_time_get_noend(Oid timetype);
 extern TSDLLEXPORT int64 ts_time_get_noend_or_max(Oid timetype);
 extern TSDLLEXPORT int64 ts_time_saturating_add(int64 timeval, int64 interval, Oid timetype);

--- a/tsl/src/continuous_aggs/refresh.c
+++ b/tsl/src/continuous_aggs/refresh.c
@@ -565,7 +565,22 @@ continuous_agg_refresh(PG_FUNCTION_ARGS)
 													  get_fn_expr_argtype(fcinfo->flinfo, 1),
 													  refresh_window.type);
 	else
-		refresh_window.start = ts_time_get_min(refresh_window.type);
+		/*
+		 * To determine inscribed/circumscribed refresh window for variable-sized
+		 * buckets we should be able to calculate time_bucket(window.begin) and
+		 * time_bucket(window.end). This, however, is not possible in general case.
+		 * As an example, the minimum date is 4714-11-24 BC, which is before any
+		 * reasonable default `origin` value. Thus for variable-sized buckets
+		 * instead of minimum date we use -infinity since time_bucket(-infinity)
+		 * is well-defined as -infinity.
+		 *
+		 * For more details see:
+		 * - ts_compute_inscribed_bucketed_refresh_window_variable()
+		 * - ts_compute_circumscribed_bucketed_refresh_window_variable()
+		 */
+		refresh_window.start = ts_continuous_agg_bucket_width_variable(cagg) ?
+								   ts_time_get_nobegin_or_min(refresh_window.type) :
+								   ts_time_get_min(refresh_window.type);
 
 	if (!PG_ARGISNULL(2))
 		refresh_window.end = ts_time_value_from_arg(PG_GETARG_DATUM(2),

--- a/tsl/test/expected/cagg_ddl.out
+++ b/tsl/test/expected/cagg_ddl.out
@@ -1969,3 +1969,47 @@ CREATE MATERIALIZED VIEW cagg_named_all WITH
 SELECT time_bucket(bucket_width => '1h', ts => time, timezone => 'UTC', origin => '2001-01-03 01:23:45') AS bucket,
 avg(amount) as avg_amount
 FROM transactions GROUP BY 1 WITH NO DATA;
+-- Refreshing from the beginning (NULL) of a CAGG with variable time bucket and
+-- using an INTERVAL for the end timestamp (issue #5534)
+CREATE MATERIALIZED VIEW transactions_montly
+WITH (timescaledb.continuous, timescaledb.materialized_only = true) AS
+SELECT time_bucket(INTERVAL '1 month', time) AS bucket,
+       SUM(fiat_value),
+       MAX(fiat_value),
+       MIN(fiat_value)
+  FROM transactions
+GROUP BY 1
+WITH NO DATA;
+-- No rows
+SELECT * FROM transactions_montly ORDER BY bucket;
+ bucket | sum | max | min 
+--------+-----+-----+-----
+(0 rows)
+
+-- Refresh from beginning of the CAGG for 1 month
+CALL refresh_continuous_aggregate('transactions_montly', NULL, INTERVAL '1 month');
+SELECT * FROM transactions_montly ORDER BY bucket;
+            bucket            | sum | max | min 
+------------------------------+-----+-----+-----
+ Sun Dec 31 16:00:00 2017 PST |  40 |  10 |  10
+ Wed Oct 31 17:00:00 2018 PDT |  70 |  10 |  10
+(2 rows)
+
+TRUNCATE transactions_montly;
+-- Partial refresh the CAGG from beginning to an specific timestamp
+CALL refresh_continuous_aggregate('transactions_montly', NULL, '2018-11-01 11:50:00-08'::timestamptz);
+SELECT * FROM transactions_montly ORDER BY bucket;
+            bucket            | sum | max | min 
+------------------------------+-----+-----+-----
+ Sun Dec 31 16:00:00 2017 PST |  40 |  10 |  10
+(1 row)
+
+-- Full refresh the CAGG
+CALL refresh_continuous_aggregate('transactions_montly', NULL, NULL);
+SELECT * FROM transactions_montly ORDER BY bucket;
+            bucket            | sum | max | min 
+------------------------------+-----+-----+-----
+ Sun Dec 31 16:00:00 2017 PST |  40 |  10 |  10
+ Wed Oct 31 17:00:00 2018 PDT |  70 |  10 |  10
+(2 rows)
+

--- a/tsl/test/expected/cagg_ddl_dist_ht.out
+++ b/tsl/test/expected/cagg_ddl_dist_ht.out
@@ -2012,6 +2012,50 @@ CREATE MATERIALIZED VIEW cagg_named_all WITH
 SELECT time_bucket(bucket_width => '1h', ts => time, timezone => 'UTC', origin => '2001-01-03 01:23:45') AS bucket,
 avg(amount) as avg_amount
 FROM transactions GROUP BY 1 WITH NO DATA;
+-- Refreshing from the beginning (NULL) of a CAGG with variable time bucket and
+-- using an INTERVAL for the end timestamp (issue #5534)
+CREATE MATERIALIZED VIEW transactions_montly
+WITH (timescaledb.continuous, timescaledb.materialized_only = true) AS
+SELECT time_bucket(INTERVAL '1 month', time) AS bucket,
+       SUM(fiat_value),
+       MAX(fiat_value),
+       MIN(fiat_value)
+  FROM transactions
+GROUP BY 1
+WITH NO DATA;
+-- No rows
+SELECT * FROM transactions_montly ORDER BY bucket;
+ bucket | sum | max | min 
+--------+-----+-----+-----
+(0 rows)
+
+-- Refresh from beginning of the CAGG for 1 month
+CALL refresh_continuous_aggregate('transactions_montly', NULL, INTERVAL '1 month');
+SELECT * FROM transactions_montly ORDER BY bucket;
+            bucket            | sum | max | min 
+------------------------------+-----+-----+-----
+ Sun Dec 31 16:00:00 2017 PST |  40 |  10 |  10
+ Wed Oct 31 17:00:00 2018 PDT |  70 |  10 |  10
+(2 rows)
+
+TRUNCATE transactions_montly;
+-- Partial refresh the CAGG from beginning to an specific timestamp
+CALL refresh_continuous_aggregate('transactions_montly', NULL, '2018-11-01 11:50:00-08'::timestamptz);
+SELECT * FROM transactions_montly ORDER BY bucket;
+            bucket            | sum | max | min 
+------------------------------+-----+-----+-----
+ Sun Dec 31 16:00:00 2017 PST |  40 |  10 |  10
+(1 row)
+
+-- Full refresh the CAGG
+CALL refresh_continuous_aggregate('transactions_montly', NULL, NULL);
+SELECT * FROM transactions_montly ORDER BY bucket;
+            bucket            | sum | max | min 
+------------------------------+-----+-----+-----
+ Sun Dec 31 16:00:00 2017 PST |  40 |  10 |  10
+ Wed Oct 31 17:00:00 2018 PDT |  70 |  10 |  10
+(2 rows)
+
 -- cleanup
 \c :TEST_DBNAME :ROLE_CLUSTER_SUPERUSER;
 DROP DATABASE :DATA_NODE_1;


### PR DESCRIPTION
When refreshing from the beginning (window_start=NULL) of a
Continuous Aggregate with variable time bucket we were getting a
`timestamp out of range` error.

Fixed it by setting `-Infinity` when passing `window_start=NULL` when
refreshing a Continuous Aggregate with variable time bucket.

Fixes #5474, #5534