### PR TITLE
Fixed transparent decompress chunk

### DIFF
--- a/.github/gh_matrix_builder.py
+++ b/.github/gh_matrix_builder.py
@@ -139,14 +139,13 @@ def macos_config(overrides):
 
 # common installcheck_args for all pg15 tests
 # partialize_finalize is ignored due to #4937
-pg15_installcheck_args = "IGNORES='partialize_finalize transparent_decompress_chunk-15'"
+pg15_installcheck_args = "IGNORES='partialize_finalize'"
 
-# transparent_decompress_chunk-[12,13,14] is ignored due to #5118
-pg14_installcheck_args = "IGNORES='bgw_db_scheduler bgw_db_scheduler_fixed partialize_finalize transparent_decompress_chunk-14'"
+pg14_installcheck_args = "IGNORES='partialize_finalize transparent_decompress_chunk-14'"
 
-pg13_installcheck_args = "IGNORES='bgw_db_scheduler bgw_db_scheduler_fixed partialize_finalize transparent_decompress_chunk-13'"
+pg13_installcheck_args = "IGNORES='partialize_finalize'"
 
-pg12_installcheck_args = "IGNORES='bgw_db_scheduler bgw_db_scheduler_fixed partialize_finalize transparent_decompress_chunk-12'"
+pg12_installcheck_args = "IGNORES='partialize_finalize'"
 
 # always test debug build on latest of all supported pg versions
 m["include"].append(

--- a/tsl/test/shared/expected/transparent_decompress_chunk-12.out
+++ b/tsl/test/shared/expected/transparent_decompress_chunk-12.out
@@ -655,6 +655,7 @@ QUERY PLAN
 (4 rows)
 
 DROP VIEW compressed_view;
+SET parallel_leader_participation TO off;
 -- test INNER JOIN
 :PREFIX
 SELECT *
@@ -808,28 +809,22 @@ ORDER BY m1.time,
 LIMIT 100;
 QUERY PLAN
  Limit (actual rows=100 loops=1)
-   ->  Gather Merge (actual rows=100 loops=1)
-         Workers Planned: 1
-         Workers Launched: 1
-         ->  Sort (actual rows=90 loops=2)
-               Sort Key: m1."time", m1.device_id, m2."time", m2.device_id
-               Sort Method: top-N heapsort 
-               Worker 0:  Sort Method: top-N heapsort 
-               ->  Parallel Hash Left Join (actual rows=8995 loops=2)
-                     Hash Cond: (m1."time" = m2."time")
-                     Join Filter: (m1.device_id = 1)
-                     Rows Removed by Join Filter: 7196
-                     ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk m1 (actual rows=8995 loops=2)
-                           ->  Parallel Seq Scan on compress_hyper_X_X_chunk (actual rows=10 loops=2)
-                     ->  Parallel Hash (actual rows=1799 loops=2)
-                           Buckets: 4096 (originally 2048)  Batches: 1 (originally 1) 
-                           ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk m2 (actual rows=3598 loops=1)
-                                 ->  Parallel Seq Scan on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (actual rows=4 loops=1)
-                                       Filter: (device_id = 2)
-                                       Rows Removed by Filter: 16
-(20 rows)
+   ->  Sort (actual rows=100 loops=1)
+         Sort Key: m1."time", m1.device_id, m2."time", m2.device_id
+         Sort Method: top-N heapsort 
+         ->  Hash Left Join (actual rows=17990 loops=1)
+               Hash Cond: (m1."time" = m2."time")
+               Join Filter: (m1.device_id = 1)
+               Rows Removed by Join Filter: 14392
+               ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk m1 (actual rows=17990 loops=1)
+                     ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=20 loops=1)
+               ->  Hash (actual rows=3598 loops=1)
+                     Buckets: 4096 (originally 1024)  Batches: 1 (originally 1) 
+                     ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk m2 (actual rows=3598 loops=1)
+                           ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_4_device_id__t on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (actual rows=4 loops=1)
+                                 Index Cond: (device_id = 2)
+(15 rows)
 
-SET parallel_leader_participation TO false;
 -- test implicit self-join
 :PREFIX
 SELECT *

--- a/tsl/test/shared/expected/transparent_decompress_chunk-13.out
+++ b/tsl/test/shared/expected/transparent_decompress_chunk-13.out
@@ -657,6 +657,7 @@ QUERY PLAN
 (4 rows)
 
 DROP VIEW compressed_view;
+SET parallel_leader_participation TO off;
 -- test INNER JOIN
 :PREFIX
 SELECT *
@@ -674,15 +675,14 @@ QUERY PLAN
          ->  Gather Merge (actual rows=10 loops=1)
                Workers Planned: 1
                Workers Launched: 1
-               ->  Sort (actual rows=5 loops=2)
+               ->  Sort (actual rows=1025 loops=1)
                      Sort Key: m1."time", m1.device_id
-                     Sort Method: quicksort 
                      Worker 0:  Sort Method: quicksort 
-                     ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk m1 (actual rows=8995 loops=2)
-                           ->  Parallel Seq Scan on compress_hyper_X_X_chunk (actual rows=10 loops=2)
+                     ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk m1 (actual rows=17990 loops=1)
+                           ->  Parallel Seq Scan on compress_hyper_X_X_chunk (actual rows=20 loops=1)
          ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk m2 (actual rows=17990 loops=10)
                ->  Seq Scan on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (actual rows=20 loops=10)
-(15 rows)
+(14 rows)
 
 :PREFIX
 SELECT *
@@ -705,18 +705,17 @@ QUERY PLAN
                ->  Gather Merge (actual rows=10 loops=1)
                      Workers Planned: 1
                      Workers Launched: 1
-                     ->  Sort (actual rows=5 loops=2)
+                     ->  Sort (actual rows=1025 loops=1)
                            Sort Key: m1."time", m1.device_id
-                           Sort Method: quicksort 
                            Worker 0:  Sort Method: quicksort 
-                           ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk m1 (actual rows=8995 loops=2)
-                                 ->  Parallel Seq Scan on compress_hyper_X_X_chunk (actual rows=10 loops=2)
+                           ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk m1 (actual rows=17990 loops=1)
+                                 ->  Parallel Seq Scan on compress_hyper_X_X_chunk (actual rows=20 loops=1)
                ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk m2 (actual rows=17990 loops=10)
                      ->  Seq Scan on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (actual rows=20 loops=10)
          ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk m3 (actual rows=3598 loops=10)
                ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_4_device_id__t on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_2 (actual rows=4 loops=10)
                      Index Cond: (device_id = 3)
-(21 rows)
+(20 rows)
 
 :PREFIX
 SELECT *
@@ -793,15 +792,14 @@ QUERY PLAN
          ->  Gather Merge (actual rows=10 loops=1)
                Workers Planned: 1
                Workers Launched: 1
-               ->  Sort (actual rows=5 loops=2)
+               ->  Sort (actual rows=1025 loops=1)
                      Sort Key: m1."time", m1.device_id
-                     Sort Method: quicksort 
                      Worker 0:  Sort Method: quicksort 
-                     ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk m1 (actual rows=8995 loops=2)
-                           ->  Parallel Seq Scan on compress_hyper_X_X_chunk (actual rows=10 loops=2)
+                     ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk m1 (actual rows=17990 loops=1)
+                           ->  Parallel Seq Scan on compress_hyper_X_X_chunk (actual rows=20 loops=1)
          ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk m2 (actual rows=17990 loops=10)
                ->  Seq Scan on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (actual rows=20 loops=10)
-(15 rows)
+(14 rows)
 
 :PREFIX
 SELECT *
@@ -837,7 +835,6 @@ QUERY PLAN
                                  Index Cond: (device_id = 2)
 (20 rows)
 
-SET parallel_leader_participation TO false;
 -- test implicit self-join
 :PREFIX
 SELECT *

--- a/tsl/test/shared/expected/transparent_decompress_chunk-14.out
+++ b/tsl/test/shared/expected/transparent_decompress_chunk-14.out
@@ -657,6 +657,7 @@ QUERY PLAN
 (4 rows)
 
 DROP VIEW compressed_view;
+SET parallel_leader_participation TO off;
 -- test INNER JOIN
 :PREFIX
 SELECT *
@@ -674,15 +675,14 @@ QUERY PLAN
          ->  Gather Merge (actual rows=10 loops=1)
                Workers Planned: 1
                Workers Launched: 1
-               ->  Sort (actual rows=5 loops=2)
+               ->  Sort (actual rows=1171 loops=1)
                      Sort Key: m1."time", m1.device_id
-                     Sort Method: quicksort 
                      Worker 0:  Sort Method: quicksort 
-                     ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk m1 (actual rows=8995 loops=2)
-                           ->  Parallel Seq Scan on compress_hyper_X_X_chunk (actual rows=10 loops=2)
+                     ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk m1 (actual rows=17990 loops=1)
+                           ->  Parallel Seq Scan on compress_hyper_X_X_chunk (actual rows=20 loops=1)
          ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk m2 (actual rows=17990 loops=10)
                ->  Seq Scan on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (actual rows=20 loops=10)
-(15 rows)
+(14 rows)
 
 :PREFIX
 SELECT *
@@ -705,18 +705,17 @@ QUERY PLAN
                ->  Gather Merge (actual rows=10 loops=1)
                      Workers Planned: 1
                      Workers Launched: 1
-                     ->  Sort (actual rows=5 loops=2)
+                     ->  Sort (actual rows=1171 loops=1)
                            Sort Key: m1."time", m1.device_id
-                           Sort Method: quicksort 
                            Worker 0:  Sort Method: quicksort 
-                           ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk m1 (actual rows=8995 loops=2)
-                                 ->  Parallel Seq Scan on compress_hyper_X_X_chunk (actual rows=10 loops=2)
+                           ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk m1 (actual rows=17990 loops=1)
+                                 ->  Parallel Seq Scan on compress_hyper_X_X_chunk (actual rows=20 loops=1)
                ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk m2 (actual rows=17990 loops=10)
                      ->  Seq Scan on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (actual rows=20 loops=10)
          ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk m3 (actual rows=3598 loops=10)
                ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_4_device_id__t on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_2 (actual rows=4 loops=10)
                      Index Cond: (device_id = 3)
-(21 rows)
+(20 rows)
 
 :PREFIX
 SELECT *
@@ -793,15 +792,14 @@ QUERY PLAN
          ->  Gather Merge (actual rows=10 loops=1)
                Workers Planned: 1
                Workers Launched: 1
-               ->  Sort (actual rows=5 loops=2)
+               ->  Sort (actual rows=1171 loops=1)
                      Sort Key: m1."time", m1.device_id
-                     Sort Method: quicksort 
                      Worker 0:  Sort Method: quicksort 
-                     ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk m1 (actual rows=8995 loops=2)
-                           ->  Parallel Seq Scan on compress_hyper_X_X_chunk (actual rows=10 loops=2)
+                     ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk m1 (actual rows=17990 loops=1)
+                           ->  Parallel Seq Scan on compress_hyper_X_X_chunk (actual rows=20 loops=1)
          ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk m2 (actual rows=17990 loops=10)
                ->  Seq Scan on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (actual rows=20 loops=10)
-(15 rows)
+(14 rows)
 
 :PREFIX
 SELECT *
@@ -837,7 +835,6 @@ QUERY PLAN
                                  Index Cond: (device_id = 2)
 (20 rows)
 
-SET parallel_leader_participation TO false;
 -- test implicit self-join
 :PREFIX
 SELECT *

--- a/tsl/test/shared/expected/transparent_decompress_chunk-15.out
+++ b/tsl/test/shared/expected/transparent_decompress_chunk-15.out
@@ -659,6 +659,7 @@ QUERY PLAN
 (4 rows)
 
 DROP VIEW compressed_view;
+SET parallel_leader_participation TO off;
 -- test INNER JOIN
 :PREFIX
 SELECT *
@@ -676,15 +677,14 @@ QUERY PLAN
          ->  Gather Merge (actual rows=10 loops=1)
                Workers Planned: 1
                Workers Launched: 1
-               ->  Sort (actual rows=5 loops=2)
+               ->  Sort (actual rows=1170 loops=1)
                      Sort Key: m1."time", m1.device_id
-                     Sort Method: quicksort 
                      Worker 0:  Sort Method: quicksort 
-                     ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk m1 (actual rows=8995 loops=2)
-                           ->  Parallel Seq Scan on compress_hyper_X_X_chunk (actual rows=10 loops=2)
+                     ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk m1 (actual rows=17990 loops=1)
+                           ->  Parallel Seq Scan on compress_hyper_X_X_chunk (actual rows=20 loops=1)
          ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk m2 (actual rows=17990 loops=10)
                ->  Seq Scan on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (actual rows=20 loops=10)
-(15 rows)
+(14 rows)
 
 :PREFIX
 SELECT *
@@ -707,18 +707,17 @@ QUERY PLAN
                ->  Gather Merge (actual rows=10 loops=1)
                      Workers Planned: 1
                      Workers Launched: 1
-                     ->  Sort (actual rows=5 loops=2)
+                     ->  Sort (actual rows=1170 loops=1)
                            Sort Key: m1."time", m1.device_id
-                           Sort Method: quicksort 
                            Worker 0:  Sort Method: quicksort 
-                           ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk m1 (actual rows=8995 loops=2)
-                                 ->  Parallel Seq Scan on compress_hyper_X_X_chunk (actual rows=10 loops=2)
+                           ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk m1 (actual rows=17990 loops=1)
+                                 ->  Parallel Seq Scan on compress_hyper_X_X_chunk (actual rows=20 loops=1)
                ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk m2 (actual rows=17990 loops=10)
                      ->  Seq Scan on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (actual rows=20 loops=10)
          ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk m3 (actual rows=3598 loops=10)
                ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_4_device_id__t on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_2 (actual rows=4 loops=10)
                      Index Cond: (device_id = 3)
-(21 rows)
+(20 rows)
 
 :PREFIX
 SELECT *
@@ -795,15 +794,14 @@ QUERY PLAN
          ->  Gather Merge (actual rows=10 loops=1)
                Workers Planned: 1
                Workers Launched: 1
-               ->  Sort (actual rows=5 loops=2)
+               ->  Sort (actual rows=1170 loops=1)
                      Sort Key: m1."time", m1.device_id
-                     Sort Method: quicksort 
                      Worker 0:  Sort Method: quicksort 
-                     ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk m1 (actual rows=8995 loops=2)
-                           ->  Parallel Seq Scan on compress_hyper_X_X_chunk (actual rows=10 loops=2)
+                     ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk m1 (actual rows=17990 loops=1)
+                           ->  Parallel Seq Scan on compress_hyper_X_X_chunk (actual rows=20 loops=1)
          ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk m2 (actual rows=17990 loops=10)
                ->  Seq Scan on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (actual rows=20 loops=10)
-(15 rows)
+(14 rows)
 
 :PREFIX
 SELECT *
@@ -839,7 +837,6 @@ QUERY PLAN
                                  Index Cond: (device_id = 2)
 (20 rows)
 
-SET parallel_leader_participation TO false;
 -- test implicit self-join
 :PREFIX
 SELECT *

--- a/tsl/test/shared/sql/transparent_decompress_chunk.sql.in
+++ b/tsl/test/shared/sql/transparent_decompress_chunk.sql.in
@@ -186,6 +186,7 @@ CREATE OR REPLACE VIEW compressed_view AS SELECT time, device_id, v1, v2 FROM :T
 
 DROP VIEW compressed_view;
 
+SET parallel_leader_participation TO off;
 -- test INNER JOIN
 :PREFIX
 SELECT *
@@ -253,7 +254,6 @@ ORDER BY m1.time,
     m2.device_id
 LIMIT 100;
 
-SET parallel_leader_participation TO false;
 -- test implicit self-join
 :PREFIX
 SELECT *


### PR DESCRIPTION
Transparent decompress chunk was added into to ignore list due to the side effect of #5118. This issue is to fix the flaky nature of the test.