### PR TITLE
Skip Ordered Append when only 1 child node is present

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,29 +9,30 @@ accidentally triggering the load of a previous DB version.**
 **Features**
 * #5212 Allow pushdown of reference table joins
 * #5221 Improve Realtime Continuous Aggregate performance
-* #5312 Add timeout support to the ping_data_node()
-* #5361 Add parallel support for partialize_agg()
 * #5252 Improve unique constraint support on compressed hypertables
 * #5312 Add timeout support to ping_data_node()
-* #5454 Add support for ON CONFLICT DO UPDATE for compressed hypertables
-* #5344 Enable JOINS for Hierarchical Continuous Aggregates
-* #5417 Refactor and optimize distributed COPY
+* #5312 Add timeout support to the ping_data_node()
 * #5339 Support UPDATE/DELETE on compressed hypertables
+* #5344 Enable JOINS for Hierarchical Continuous Aggregates
+* #5361 Add parallel support for partialize_agg()
+* #5417 Refactor and optimize distributed COPY
+* #5454 Add support for ON CONFLICT DO UPDATE for compressed hypertables
+* #5547 Skip Ordered Append when only 1 child node is present
 
 **Bugfixes**
+* #5233 Out of on_proc_exit slots on guc license change
 * #5396 Fix SEGMENTBY columns predicates to be pushed down
 * #5410 Fix file trailer handling in the COPY fetcher
-* #5233 Out of on_proc_exit slots on guc license change
 * #5427 Handle user-defined FDW options properly
 * #5428 Use consistent snapshots when scanning metadata
 * #5442 Decompression may have lost DEFAULT values
 * #5446 Add checks for malloc failure in libpq calls
-* #5470 Ensure superuser perms during copy/move chunk
 * #5459 Fix issue creating dimensional constraints
-* #5499 Do not segfault on large histogram() parameters
-* #5497 Allow named time_bucket arguments in Cagg definition
-* #5500 Fix when no FROM clause in continuous aggregate definition
 * #5462 Fix segfault after column drop on compressed table
+* #5470 Ensure superuser perms during copy/move chunk
+* #5497 Allow named time_bucket arguments in Cagg definition
+* #5499 Do not segfault on large histogram() parameters
+* #5500 Fix when no FROM clause in continuous aggregate definition
 
 **Thanks**
 * @nikolaps for reporting an issue with the COPY fetcher

--- a/test/expected/agg_bookends-12.out
+++ b/test/expected/agg_bookends-12.out
@@ -51,36 +51,30 @@ SELECT setting, current_setting(setting) AS value from (VALUES ('timescaledb.ena
 (1 row)
 
 :PREFIX SELECT time, gp, temp FROM btest ORDER BY time;
-                                                 QUERY PLAN                                                  
--------------------------------------------------------------------------------------------------------------
- Custom Scan (ChunkAppend) on btest (actual rows=6 loops=1)
-   Order: btest."time"
-   ->  Index Scan Backward using _hyper_1_1_chunk_btest_time_idx on _hyper_1_1_chunk (actual rows=6 loops=1)
-(3 rows)
+                                              QUERY PLAN                                               
+-------------------------------------------------------------------------------------------------------
+ Index Scan Backward using _hyper_1_1_chunk_btest_time_idx on _hyper_1_1_chunk (actual rows=6 loops=1)
+(1 row)
 
 :PREFIX SELECT last(temp, time) FROM btest;
-                                                    QUERY PLAN                                                    
-------------------------------------------------------------------------------------------------------------------
+                                                 QUERY PLAN                                                 
+------------------------------------------------------------------------------------------------------------
  Result (actual rows=1 loops=1)
    InitPlan 1 (returns $0)
      ->  Limit (actual rows=1 loops=1)
-           ->  Custom Scan (ChunkAppend) on btest (actual rows=1 loops=1)
-                 Order: btest."time" DESC
-                 ->  Index Scan using _hyper_1_1_chunk_btest_time_idx on _hyper_1_1_chunk (actual rows=1 loops=1)
-                       Index Cond: ("time" IS NOT NULL)
-(7 rows)
+           ->  Index Scan using _hyper_1_1_chunk_btest_time_idx on _hyper_1_1_chunk (actual rows=1 loops=1)
+                 Index Cond: ("time" IS NOT NULL)
+(5 rows)
 
 :PREFIX SELECT first(temp, time) FROM btest;
-                                                        QUERY PLAN                                                         
----------------------------------------------------------------------------------------------------------------------------
+                                                     QUERY PLAN                                                      
+---------------------------------------------------------------------------------------------------------------------
  Result (actual rows=1 loops=1)
    InitPlan 1 (returns $0)
      ->  Limit (actual rows=1 loops=1)
-           ->  Custom Scan (ChunkAppend) on btest (actual rows=1 loops=1)
-                 Order: btest."time"
-                 ->  Index Scan Backward using _hyper_1_1_chunk_btest_time_idx on _hyper_1_1_chunk (actual rows=1 loops=1)
-                       Index Cond: ("time" IS NOT NULL)
-(7 rows)
+           ->  Index Scan Backward using _hyper_1_1_chunk_btest_time_idx on _hyper_1_1_chunk (actual rows=1 loops=1)
+                 Index Cond: ("time" IS NOT NULL)
+(5 rows)
 
 :PREFIX SELECT last(temp, time_alt) FROM btest;
                          QUERY PLAN                         
@@ -281,16 +275,14 @@ INSERT INTO btest VALUES('2020-01-20T09:00:43', '2020-01-20T09:00:43', 2, 35.3);
 --Previously, some bugs were found with NULLS and numeric types, so test that
 INSERT INTO btest_numeric VALUES ('2019-01-20T09:00:43', NULL);
 :PREFIX SELECT last(quantity, time) FROM btest_numeric;
-                                                        QUERY PLAN                                                        
---------------------------------------------------------------------------------------------------------------------------
+                                                     QUERY PLAN                                                     
+--------------------------------------------------------------------------------------------------------------------
  Result (actual rows=1 loops=1)
    InitPlan 1 (returns $0)
      ->  Limit (actual rows=1 loops=1)
-           ->  Custom Scan (ChunkAppend) on btest_numeric (actual rows=1 loops=1)
-                 Order: btest_numeric."time" DESC
-                 ->  Index Scan using _hyper_2_6_chunk_btest_numeric_time_idx on _hyper_2_6_chunk (actual rows=1 loops=1)
-                       Index Cond: ("time" IS NOT NULL)
-(7 rows)
+           ->  Index Scan using _hyper_2_6_chunk_btest_numeric_time_idx on _hyper_2_6_chunk (actual rows=1 loops=1)
+                 Index Cond: ("time" IS NOT NULL)
+(5 rows)
 
 --check non-null element "overrides" NULL because it comes after.
 INSERT INTO btest_numeric VALUES('2020-01-20T09:00:43', 30.5);

--- a/test/expected/agg_bookends-13.out
+++ b/test/expected/agg_bookends-13.out
@@ -51,36 +51,30 @@ SELECT setting, current_setting(setting) AS value from (VALUES ('timescaledb.ena
 (1 row)
 
 :PREFIX SELECT time, gp, temp FROM btest ORDER BY time;
-                                                 QUERY PLAN                                                  
--------------------------------------------------------------------------------------------------------------
- Custom Scan (ChunkAppend) on btest (actual rows=6 loops=1)
-   Order: btest."time"
-   ->  Index Scan Backward using _hyper_1_1_chunk_btest_time_idx on _hyper_1_1_chunk (actual rows=6 loops=1)
-(3 rows)
+                                              QUERY PLAN                                               
+-------------------------------------------------------------------------------------------------------
+ Index Scan Backward using _hyper_1_1_chunk_btest_time_idx on _hyper_1_1_chunk (actual rows=6 loops=1)
+(1 row)
 
 :PREFIX SELECT last(temp, time) FROM btest;
-                                                    QUERY PLAN                                                    
-------------------------------------------------------------------------------------------------------------------
+                                                 QUERY PLAN                                                 
+------------------------------------------------------------------------------------------------------------
  Result (actual rows=1 loops=1)
    InitPlan 1 (returns $0)
      ->  Limit (actual rows=1 loops=1)
-           ->  Custom Scan (ChunkAppend) on btest (actual rows=1 loops=1)
-                 Order: btest."time" DESC
-                 ->  Index Scan using _hyper_1_1_chunk_btest_time_idx on _hyper_1_1_chunk (actual rows=1 loops=1)
-                       Index Cond: ("time" IS NOT NULL)
-(7 rows)
+           ->  Index Scan using _hyper_1_1_chunk_btest_time_idx on _hyper_1_1_chunk (actual rows=1 loops=1)
+                 Index Cond: ("time" IS NOT NULL)
+(5 rows)
 
 :PREFIX SELECT first(temp, time) FROM btest;
-                                                        QUERY PLAN                                                         
----------------------------------------------------------------------------------------------------------------------------
+                                                     QUERY PLAN                                                      
+---------------------------------------------------------------------------------------------------------------------
  Result (actual rows=1 loops=1)
    InitPlan 1 (returns $0)
      ->  Limit (actual rows=1 loops=1)
-           ->  Custom Scan (ChunkAppend) on btest (actual rows=1 loops=1)
-                 Order: btest."time"
-                 ->  Index Scan Backward using _hyper_1_1_chunk_btest_time_idx on _hyper_1_1_chunk (actual rows=1 loops=1)
-                       Index Cond: ("time" IS NOT NULL)
-(7 rows)
+           ->  Index Scan Backward using _hyper_1_1_chunk_btest_time_idx on _hyper_1_1_chunk (actual rows=1 loops=1)
+                 Index Cond: ("time" IS NOT NULL)
+(5 rows)
 
 :PREFIX SELECT last(temp, time_alt) FROM btest;
                          QUERY PLAN                         
@@ -288,16 +282,14 @@ INSERT INTO btest VALUES('2020-01-20T09:00:43', '2020-01-20T09:00:43', 2, 35.3);
 --Previously, some bugs were found with NULLS and numeric types, so test that
 INSERT INTO btest_numeric VALUES ('2019-01-20T09:00:43', NULL);
 :PREFIX SELECT last(quantity, time) FROM btest_numeric;
-                                                        QUERY PLAN                                                        
---------------------------------------------------------------------------------------------------------------------------
+                                                     QUERY PLAN                                                     
+--------------------------------------------------------------------------------------------------------------------
  Result (actual rows=1 loops=1)
    InitPlan 1 (returns $0)
      ->  Limit (actual rows=1 loops=1)
-           ->  Custom Scan (ChunkAppend) on btest_numeric (actual rows=1 loops=1)
-                 Order: btest_numeric."time" DESC
-                 ->  Index Scan using _hyper_2_6_chunk_btest_numeric_time_idx on _hyper_2_6_chunk (actual rows=1 loops=1)
-                       Index Cond: ("time" IS NOT NULL)
-(7 rows)
+           ->  Index Scan using _hyper_2_6_chunk_btest_numeric_time_idx on _hyper_2_6_chunk (actual rows=1 loops=1)
+                 Index Cond: ("time" IS NOT NULL)
+(5 rows)
 
 --check non-null element "overrides" NULL because it comes after.
 INSERT INTO btest_numeric VALUES('2020-01-20T09:00:43', 30.5);

--- a/test/expected/agg_bookends-14.out
+++ b/test/expected/agg_bookends-14.out
@@ -51,36 +51,30 @@ SELECT setting, current_setting(setting) AS value from (VALUES ('timescaledb.ena
 (1 row)
 
 :PREFIX SELECT time, gp, temp FROM btest ORDER BY time;
-                                                 QUERY PLAN                                                  
--------------------------------------------------------------------------------------------------------------
- Custom Scan (ChunkAppend) on btest (actual rows=6 loops=1)
-   Order: btest."time"
-   ->  Index Scan Backward using _hyper_1_1_chunk_btest_time_idx on _hyper_1_1_chunk (actual rows=6 loops=1)
-(3 rows)
+                                              QUERY PLAN                                               
+-------------------------------------------------------------------------------------------------------
+ Index Scan Backward using _hyper_1_1_chunk_btest_time_idx on _hyper_1_1_chunk (actual rows=6 loops=1)
+(1 row)
 
 :PREFIX SELECT last(temp, time) FROM btest;
-                                                    QUERY PLAN                                                    
-------------------------------------------------------------------------------------------------------------------
+                                                 QUERY PLAN                                                 
+------------------------------------------------------------------------------------------------------------
  Result (actual rows=1 loops=1)
    InitPlan 1 (returns $0)
      ->  Limit (actual rows=1 loops=1)
-           ->  Custom Scan (ChunkAppend) on btest (actual rows=1 loops=1)
-                 Order: btest."time" DESC
-                 ->  Index Scan using _hyper_1_1_chunk_btest_time_idx on _hyper_1_1_chunk (actual rows=1 loops=1)
-                       Index Cond: ("time" IS NOT NULL)
-(7 rows)
+           ->  Index Scan using _hyper_1_1_chunk_btest_time_idx on _hyper_1_1_chunk (actual rows=1 loops=1)
+                 Index Cond: ("time" IS NOT NULL)
+(5 rows)
 
 :PREFIX SELECT first(temp, time) FROM btest;
-                                                        QUERY PLAN                                                         
----------------------------------------------------------------------------------------------------------------------------
+                                                     QUERY PLAN                                                      
+---------------------------------------------------------------------------------------------------------------------
  Result (actual rows=1 loops=1)
    InitPlan 1 (returns $0)
      ->  Limit (actual rows=1 loops=1)
-           ->  Custom Scan (ChunkAppend) on btest (actual rows=1 loops=1)
-                 Order: btest."time"
-                 ->  Index Scan Backward using _hyper_1_1_chunk_btest_time_idx on _hyper_1_1_chunk (actual rows=1 loops=1)
-                       Index Cond: ("time" IS NOT NULL)
-(7 rows)
+           ->  Index Scan Backward using _hyper_1_1_chunk_btest_time_idx on _hyper_1_1_chunk (actual rows=1 loops=1)
+                 Index Cond: ("time" IS NOT NULL)
+(5 rows)
 
 :PREFIX SELECT last(temp, time_alt) FROM btest;
                          QUERY PLAN                         
@@ -288,16 +282,14 @@ INSERT INTO btest VALUES('2020-01-20T09:00:43', '2020-01-20T09:00:43', 2, 35.3);
 --Previously, some bugs were found with NULLS and numeric types, so test that
 INSERT INTO btest_numeric VALUES ('2019-01-20T09:00:43', NULL);
 :PREFIX SELECT last(quantity, time) FROM btest_numeric;
-                                                        QUERY PLAN                                                        
---------------------------------------------------------------------------------------------------------------------------
+                                                     QUERY PLAN                                                     
+--------------------------------------------------------------------------------------------------------------------
  Result (actual rows=1 loops=1)
    InitPlan 1 (returns $0)
      ->  Limit (actual rows=1 loops=1)
-           ->  Custom Scan (ChunkAppend) on btest_numeric (actual rows=1 loops=1)
-                 Order: btest_numeric."time" DESC
-                 ->  Index Scan using _hyper_2_6_chunk_btest_numeric_time_idx on _hyper_2_6_chunk (actual rows=1 loops=1)
-                       Index Cond: ("time" IS NOT NULL)
-(7 rows)
+           ->  Index Scan using _hyper_2_6_chunk_btest_numeric_time_idx on _hyper_2_6_chunk (actual rows=1 loops=1)
+                 Index Cond: ("time" IS NOT NULL)
+(5 rows)
 
 --check non-null element "overrides" NULL because it comes after.
 INSERT INTO btest_numeric VALUES('2020-01-20T09:00:43', 30.5);

--- a/test/expected/agg_bookends-15.out
+++ b/test/expected/agg_bookends-15.out
@@ -51,36 +51,30 @@ SELECT setting, current_setting(setting) AS value from (VALUES ('timescaledb.ena
 (1 row)
 
 :PREFIX SELECT time, gp, temp FROM btest ORDER BY time;
-                                                 QUERY PLAN                                                  
--------------------------------------------------------------------------------------------------------------
- Custom Scan (ChunkAppend) on btest (actual rows=6 loops=1)
-   Order: btest."time"
-   ->  Index Scan Backward using _hyper_1_1_chunk_btest_time_idx on _hyper_1_1_chunk (actual rows=6 loops=1)
-(3 rows)
+                                              QUERY PLAN                                               
+-------------------------------------------------------------------------------------------------------
+ Index Scan Backward using _hyper_1_1_chunk_btest_time_idx on _hyper_1_1_chunk (actual rows=6 loops=1)
+(1 row)
 
 :PREFIX SELECT last(temp, time) FROM btest;
-                                                    QUERY PLAN                                                    
-------------------------------------------------------------------------------------------------------------------
+                                                 QUERY PLAN                                                 
+------------------------------------------------------------------------------------------------------------
  Result (actual rows=1 loops=1)
    InitPlan 1 (returns $0)
      ->  Limit (actual rows=1 loops=1)
-           ->  Custom Scan (ChunkAppend) on btest (actual rows=1 loops=1)
-                 Order: btest."time" DESC
-                 ->  Index Scan using _hyper_1_1_chunk_btest_time_idx on _hyper_1_1_chunk (actual rows=1 loops=1)
-                       Index Cond: ("time" IS NOT NULL)
-(7 rows)
+           ->  Index Scan using _hyper_1_1_chunk_btest_time_idx on _hyper_1_1_chunk (actual rows=1 loops=1)
+                 Index Cond: ("time" IS NOT NULL)
+(5 rows)
 
 :PREFIX SELECT first(temp, time) FROM btest;
-                                                        QUERY PLAN                                                         
----------------------------------------------------------------------------------------------------------------------------
+                                                     QUERY PLAN                                                      
+---------------------------------------------------------------------------------------------------------------------
  Result (actual rows=1 loops=1)
    InitPlan 1 (returns $0)
      ->  Limit (actual rows=1 loops=1)
-           ->  Custom Scan (ChunkAppend) on btest (actual rows=1 loops=1)
-                 Order: btest."time"
-                 ->  Index Scan Backward using _hyper_1_1_chunk_btest_time_idx on _hyper_1_1_chunk (actual rows=1 loops=1)
-                       Index Cond: ("time" IS NOT NULL)
-(7 rows)
+           ->  Index Scan Backward using _hyper_1_1_chunk_btest_time_idx on _hyper_1_1_chunk (actual rows=1 loops=1)
+                 Index Cond: ("time" IS NOT NULL)
+(5 rows)
 
 :PREFIX SELECT last(temp, time_alt) FROM btest;
                          QUERY PLAN                         
@@ -288,16 +282,14 @@ INSERT INTO btest VALUES('2020-01-20T09:00:43', '2020-01-20T09:00:43', 2, 35.3);
 --Previously, some bugs were found with NULLS and numeric types, so test that
 INSERT INTO btest_numeric VALUES ('2019-01-20T09:00:43', NULL);
 :PREFIX SELECT last(quantity, time) FROM btest_numeric;
-                                                        QUERY PLAN                                                        
---------------------------------------------------------------------------------------------------------------------------
+                                                     QUERY PLAN                                                     
+--------------------------------------------------------------------------------------------------------------------
  Result (actual rows=1 loops=1)
    InitPlan 1 (returns $0)
      ->  Limit (actual rows=1 loops=1)
-           ->  Custom Scan (ChunkAppend) on btest_numeric (actual rows=1 loops=1)
-                 Order: btest_numeric."time" DESC
-                 ->  Index Scan using _hyper_2_6_chunk_btest_numeric_time_idx on _hyper_2_6_chunk (actual rows=1 loops=1)
-                       Index Cond: ("time" IS NOT NULL)
-(7 rows)
+           ->  Index Scan using _hyper_2_6_chunk_btest_numeric_time_idx on _hyper_2_6_chunk (actual rows=1 loops=1)
+                 Index Cond: ("time" IS NOT NULL)
+(5 rows)
 
 --check non-null element "overrides" NULL because it comes after.
 INSERT INTO btest_numeric VALUES('2020-01-20T09:00:43', 30.5);

--- a/test/expected/query-12.out
+++ b/test/expected/query-12.out
@@ -125,13 +125,11 @@ SHOW timescaledb.enable_optimizations;
 
 --non-aggregates use MergeAppend in both optimized and non-optimized
 :PREFIX SELECT * FROM hyper_1 ORDER BY "time" DESC limit 2;
-                                  QUERY PLAN                                  
-------------------------------------------------------------------------------
+                               QUERY PLAN                               
+------------------------------------------------------------------------
  Limit
-   ->  Custom Scan (ChunkAppend) on hyper_1
-         Order: hyper_1."time" DESC
-         ->  Index Scan using _hyper_1_1_chunk_time_plain on _hyper_1_1_chunk
-(4 rows)
+   ->  Index Scan using _hyper_1_1_chunk_time_plain on _hyper_1_1_chunk
+(2 rows)
 
 :PREFIX SELECT * FROM hyper_timefunc ORDER BY unix_to_timestamp("time") DESC limit 2;
                                     QUERY PLAN                                     
@@ -146,11 +144,10 @@ SHOW timescaledb.enable_optimizations;
 ------------------------------------------------------------------------------------
  Limit
    ->  GroupAggregate
-         Group Key: (date_trunc('minute'::text, hyper_1."time"))
-         ->  Custom Scan (ChunkAppend) on hyper_1
-               Order: date_trunc('minute'::text, hyper_1."time") DESC
+         Group Key: (date_trunc('minute'::text, _hyper_1_1_chunk."time"))
+         ->  Result
                ->  Index Scan using _hyper_1_1_chunk_time_plain on _hyper_1_1_chunk
-(6 rows)
+(5 rows)
 
 :PREFIX SELECT date_trunc('minute', time) t, avg(series_0), min(series_1), avg(series_2) FROM hyper_1_date GROUP BY t ORDER BY t DESC limit 2;
                                                       QUERY PLAN                                                      
@@ -182,22 +179,20 @@ SHOW timescaledb.enable_optimizations;
 ------------------------------------------------------------------------------------
  Limit
    ->  GroupAggregate
-         Group Key: (date_trunc('minute'::text, hyper_1."time"))
-         ->  Custom Scan (ChunkAppend) on hyper_1
-               Order: date_trunc('minute'::text, hyper_1."time") DESC
+         Group Key: (date_trunc('minute'::text, _hyper_1_1_chunk."time"))
+         ->  Result
                ->  Index Scan using _hyper_1_1_chunk_time_plain on _hyper_1_1_chunk
-(6 rows)
+(5 rows)
 
 :PREFIX SELECT date_trunc('second', time) t, avg(series_0), min(series_1), avg(series_2) FROM hyper_1 GROUP BY t ORDER BY t DESC limit 2;
                                      QUERY PLAN                                     
 ------------------------------------------------------------------------------------
  Limit
    ->  GroupAggregate
-         Group Key: (date_trunc('second'::text, hyper_1."time"))
-         ->  Custom Scan (ChunkAppend) on hyper_1
-               Order: date_trunc('second'::text, hyper_1."time") DESC
+         Group Key: (date_trunc('second'::text, _hyper_1_1_chunk."time"))
+         ->  Result
                ->  Index Scan using _hyper_1_1_chunk_time_plain on _hyper_1_1_chunk
-(6 rows)
+(5 rows)
 
 --test that when index on time used by constraint, still works correctly
 :PREFIX
@@ -252,11 +247,10 @@ BEGIN;
 ---------------------------------------------------------------------------------------------
  Limit
    ->  GroupAggregate
-         Group Key: (date_trunc('minute'::text, hyper_1."time"))
-         ->  Custom Scan (ChunkAppend) on hyper_1
-               Order: date_trunc('minute'::text, hyper_1."time") DESC
+         Group Key: (date_trunc('minute'::text, _hyper_1_1_chunk."time"))
+         ->  Result
                ->  Index Scan Backward using _hyper_1_1_chunk_time_trunc on _hyper_1_1_chunk
-(6 rows)
+(5 rows)
 
   --test that works with both indexes
   CREATE INDEX "time_plain" ON PUBLIC.hyper_1 (time DESC, series_0);
@@ -266,11 +260,10 @@ BEGIN;
 ---------------------------------------------------------------------------------------------
  Limit
    ->  GroupAggregate
-         Group Key: (date_trunc('minute'::text, hyper_1."time"))
-         ->  Custom Scan (ChunkAppend) on hyper_1
-               Order: date_trunc('minute'::text, hyper_1."time") DESC
+         Group Key: (date_trunc('minute'::text, _hyper_1_1_chunk."time"))
+         ->  Result
                ->  Index Scan Backward using _hyper_1_1_chunk_time_trunc on _hyper_1_1_chunk
-(6 rows)
+(5 rows)
 
   :PREFIX SELECT time_bucket('1 minute', time) t, avg(series_0), min(series_1), trunc(avg(series_2)::numeric, 5)
   FROM hyper_1 GROUP BY t ORDER BY t DESC limit 2;
@@ -278,35 +271,32 @@ BEGIN;
 ------------------------------------------------------------------------------------
  Limit
    ->  GroupAggregate
-         Group Key: (time_bucket('@ 1 min'::interval, hyper_1."time"))
-         ->  Custom Scan (ChunkAppend) on hyper_1
-               Order: time_bucket('@ 1 min'::interval, hyper_1."time") DESC
+         Group Key: (time_bucket('@ 1 min'::interval, _hyper_1_1_chunk."time"))
+         ->  Result
                ->  Index Scan using _hyper_1_1_chunk_time_plain on _hyper_1_1_chunk
-(6 rows)
+(5 rows)
 
   :PREFIX SELECT time_bucket('1 minute', time, INTERVAL '30 seconds') t, avg(series_0), min(series_1), trunc(avg(series_2)::numeric,5)
   FROM hyper_1 GROUP BY t ORDER BY t DESC limit 2;
-                                            QUERY PLAN                                             
----------------------------------------------------------------------------------------------------
+                                              QUERY PLAN                                               
+-------------------------------------------------------------------------------------------------------
  Limit
    ->  GroupAggregate
-         Group Key: (time_bucket('@ 1 min'::interval, hyper_1."time", '@ 30 secs'::interval))
-         ->  Custom Scan (ChunkAppend) on hyper_1
-               Order: time_bucket('@ 1 min'::interval, hyper_1."time", '@ 30 secs'::interval) DESC
+         Group Key: (time_bucket('@ 1 min'::interval, _hyper_1_1_chunk."time", '@ 30 secs'::interval))
+         ->  Result
                ->  Index Scan using _hyper_1_1_chunk_time_plain on _hyper_1_1_chunk
-(6 rows)
+(5 rows)
 
   :PREFIX SELECT time_bucket('1 minute', time - INTERVAL '30 seconds') t, avg(series_0), min(series_1), trunc(avg(series_2)::numeric,5)
   FROM hyper_1 GROUP BY t ORDER BY t DESC limit 2;
-                                              QUERY PLAN                                              
-------------------------------------------------------------------------------------------------------
+                                                QUERY PLAN                                                
+----------------------------------------------------------------------------------------------------------
  Limit
    ->  GroupAggregate
-         Group Key: (time_bucket('@ 1 min'::interval, (hyper_1."time" - '@ 30 secs'::interval)))
-         ->  Custom Scan (ChunkAppend) on hyper_1
-               Order: time_bucket('@ 1 min'::interval, (hyper_1."time" - '@ 30 secs'::interval)) DESC
+         Group Key: (time_bucket('@ 1 min'::interval, (_hyper_1_1_chunk."time" - '@ 30 secs'::interval)))
+         ->  Result
                ->  Index Scan using _hyper_1_1_chunk_time_plain on _hyper_1_1_chunk
-(6 rows)
+(5 rows)
 
   :PREFIX SELECT time_bucket('1 minute', time - INTERVAL '30 seconds') + INTERVAL '30 seconds' t, avg(series_0), min(series_1), trunc(avg(series_2)::numeric,5)
   FROM hyper_1 GROUP BY t ORDER BY t DESC limit 2;
@@ -325,11 +315,10 @@ BEGIN;
 ---------------------------------------------------------------------------------------
  Limit
    ->  GroupAggregate
-         Group Key: (time_bucket('@ 1 min'::interval, hyper_1_tz."time"))
-         ->  Custom Scan (ChunkAppend) on hyper_1_tz
-               Order: time_bucket('@ 1 min'::interval, hyper_1_tz."time") DESC
+         Group Key: (time_bucket('@ 1 min'::interval, _hyper_2_2_chunk."time"))
+         ->  Result
                ->  Index Scan using _hyper_2_2_chunk_time_plain_tz on _hyper_2_2_chunk
-(6 rows)
+(5 rows)
 
   :PREFIX SELECT time_bucket('1 minute', time::timestamp) t, avg(series_0), min(series_1), avg(series_2)
   FROM hyper_1_tz GROUP BY t ORDER BY t DESC limit 2;

--- a/test/expected/query-13.out
+++ b/test/expected/query-13.out
@@ -125,13 +125,11 @@ SHOW timescaledb.enable_optimizations;
 
 --non-aggregates use MergeAppend in both optimized and non-optimized
 :PREFIX SELECT * FROM hyper_1 ORDER BY "time" DESC limit 2;
-                                  QUERY PLAN                                  
-------------------------------------------------------------------------------
+                               QUERY PLAN                               
+------------------------------------------------------------------------
  Limit
-   ->  Custom Scan (ChunkAppend) on hyper_1
-         Order: hyper_1."time" DESC
-         ->  Index Scan using _hyper_1_1_chunk_time_plain on _hyper_1_1_chunk
-(4 rows)
+   ->  Index Scan using _hyper_1_1_chunk_time_plain on _hyper_1_1_chunk
+(2 rows)
 
 :PREFIX SELECT * FROM hyper_timefunc ORDER BY unix_to_timestamp("time") DESC limit 2;
                                     QUERY PLAN                                     
@@ -146,11 +144,10 @@ SHOW timescaledb.enable_optimizations;
 ------------------------------------------------------------------------------------
  Limit
    ->  GroupAggregate
-         Group Key: (date_trunc('minute'::text, hyper_1."time"))
-         ->  Custom Scan (ChunkAppend) on hyper_1
-               Order: date_trunc('minute'::text, hyper_1."time") DESC
+         Group Key: (date_trunc('minute'::text, _hyper_1_1_chunk."time"))
+         ->  Result
                ->  Index Scan using _hyper_1_1_chunk_time_plain on _hyper_1_1_chunk
-(6 rows)
+(5 rows)
 
 :PREFIX SELECT date_trunc('minute', time) t, avg(series_0), min(series_1), avg(series_2) FROM hyper_1_date GROUP BY t ORDER BY t DESC limit 2;
                                                       QUERY PLAN                                                      
@@ -182,22 +179,20 @@ SHOW timescaledb.enable_optimizations;
 ------------------------------------------------------------------------------------
  Limit
    ->  GroupAggregate
-         Group Key: (date_trunc('minute'::text, hyper_1."time"))
-         ->  Custom Scan (ChunkAppend) on hyper_1
-               Order: date_trunc('minute'::text, hyper_1."time") DESC
+         Group Key: (date_trunc('minute'::text, _hyper_1_1_chunk."time"))
+         ->  Result
                ->  Index Scan using _hyper_1_1_chunk_time_plain on _hyper_1_1_chunk
-(6 rows)
+(5 rows)
 
 :PREFIX SELECT date_trunc('second', time) t, avg(series_0), min(series_1), avg(series_2) FROM hyper_1 GROUP BY t ORDER BY t DESC limit 2;
                                      QUERY PLAN                                     
 ------------------------------------------------------------------------------------
  Limit
    ->  GroupAggregate
-         Group Key: (date_trunc('second'::text, hyper_1."time"))
-         ->  Custom Scan (ChunkAppend) on hyper_1
-               Order: date_trunc('second'::text, hyper_1."time") DESC
+         Group Key: (date_trunc('second'::text, _hyper_1_1_chunk."time"))
+         ->  Result
                ->  Index Scan using _hyper_1_1_chunk_time_plain on _hyper_1_1_chunk
-(6 rows)
+(5 rows)
 
 --test that when index on time used by constraint, still works correctly
 :PREFIX
@@ -252,11 +247,10 @@ BEGIN;
 ---------------------------------------------------------------------------------------------
  Limit
    ->  GroupAggregate
-         Group Key: (date_trunc('minute'::text, hyper_1."time"))
-         ->  Custom Scan (ChunkAppend) on hyper_1
-               Order: date_trunc('minute'::text, hyper_1."time") DESC
+         Group Key: (date_trunc('minute'::text, _hyper_1_1_chunk."time"))
+         ->  Result
                ->  Index Scan Backward using _hyper_1_1_chunk_time_trunc on _hyper_1_1_chunk
-(6 rows)
+(5 rows)
 
   --test that works with both indexes
   CREATE INDEX "time_plain" ON PUBLIC.hyper_1 (time DESC, series_0);
@@ -266,11 +260,10 @@ BEGIN;
 ---------------------------------------------------------------------------------------------
  Limit
    ->  GroupAggregate
-         Group Key: (date_trunc('minute'::text, hyper_1."time"))
-         ->  Custom Scan (ChunkAppend) on hyper_1
-               Order: date_trunc('minute'::text, hyper_1."time") DESC
+         Group Key: (date_trunc('minute'::text, _hyper_1_1_chunk."time"))
+         ->  Result
                ->  Index Scan Backward using _hyper_1_1_chunk_time_trunc on _hyper_1_1_chunk
-(6 rows)
+(5 rows)
 
   :PREFIX SELECT time_bucket('1 minute', time) t, avg(series_0), min(series_1), trunc(avg(series_2)::numeric, 5)
   FROM hyper_1 GROUP BY t ORDER BY t DESC limit 2;
@@ -278,35 +271,32 @@ BEGIN;
 ------------------------------------------------------------------------------------
  Limit
    ->  GroupAggregate
-         Group Key: (time_bucket('@ 1 min'::interval, hyper_1."time"))
-         ->  Custom Scan (ChunkAppend) on hyper_1
-               Order: time_bucket('@ 1 min'::interval, hyper_1."time") DESC
+         Group Key: (time_bucket('@ 1 min'::interval, _hyper_1_1_chunk."time"))
+         ->  Result
                ->  Index Scan using _hyper_1_1_chunk_time_plain on _hyper_1_1_chunk
-(6 rows)
+(5 rows)
 
   :PREFIX SELECT time_bucket('1 minute', time, INTERVAL '30 seconds') t, avg(series_0), min(series_1), trunc(avg(series_2)::numeric,5)
   FROM hyper_1 GROUP BY t ORDER BY t DESC limit 2;
-                                            QUERY PLAN                                             
----------------------------------------------------------------------------------------------------
+                                              QUERY PLAN                                               
+-------------------------------------------------------------------------------------------------------
  Limit
    ->  GroupAggregate
-         Group Key: (time_bucket('@ 1 min'::interval, hyper_1."time", '@ 30 secs'::interval))
-         ->  Custom Scan (ChunkAppend) on hyper_1
-               Order: time_bucket('@ 1 min'::interval, hyper_1."time", '@ 30 secs'::interval) DESC
+         Group Key: (time_bucket('@ 1 min'::interval, _hyper_1_1_chunk."time", '@ 30 secs'::interval))
+         ->  Result
                ->  Index Scan using _hyper_1_1_chunk_time_plain on _hyper_1_1_chunk
-(6 rows)
+(5 rows)
 
   :PREFIX SELECT time_bucket('1 minute', time - INTERVAL '30 seconds') t, avg(series_0), min(series_1), trunc(avg(series_2)::numeric,5)
   FROM hyper_1 GROUP BY t ORDER BY t DESC limit 2;
-                                              QUERY PLAN                                              
-------------------------------------------------------------------------------------------------------
+                                                QUERY PLAN                                                
+----------------------------------------------------------------------------------------------------------
  Limit
    ->  GroupAggregate
-         Group Key: (time_bucket('@ 1 min'::interval, (hyper_1."time" - '@ 30 secs'::interval)))
-         ->  Custom Scan (ChunkAppend) on hyper_1
-               Order: time_bucket('@ 1 min'::interval, (hyper_1."time" - '@ 30 secs'::interval)) DESC
+         Group Key: (time_bucket('@ 1 min'::interval, (_hyper_1_1_chunk."time" - '@ 30 secs'::interval)))
+         ->  Result
                ->  Index Scan using _hyper_1_1_chunk_time_plain on _hyper_1_1_chunk
-(6 rows)
+(5 rows)
 
   :PREFIX SELECT time_bucket('1 minute', time - INTERVAL '30 seconds') + INTERVAL '30 seconds' t, avg(series_0), min(series_1), trunc(avg(series_2)::numeric,5)
   FROM hyper_1 GROUP BY t ORDER BY t DESC limit 2;
@@ -325,11 +315,10 @@ BEGIN;
 ---------------------------------------------------------------------------------------
  Limit
    ->  GroupAggregate
-         Group Key: (time_bucket('@ 1 min'::interval, hyper_1_tz."time"))
-         ->  Custom Scan (ChunkAppend) on hyper_1_tz
-               Order: time_bucket('@ 1 min'::interval, hyper_1_tz."time") DESC
+         Group Key: (time_bucket('@ 1 min'::interval, _hyper_2_2_chunk."time"))
+         ->  Result
                ->  Index Scan using _hyper_2_2_chunk_time_plain_tz on _hyper_2_2_chunk
-(6 rows)
+(5 rows)
 
   :PREFIX SELECT time_bucket('1 minute', time::timestamp) t, avg(series_0), min(series_1), avg(series_2)
   FROM hyper_1_tz GROUP BY t ORDER BY t DESC limit 2;

--- a/test/expected/query-14.out
+++ b/test/expected/query-14.out
@@ -125,13 +125,11 @@ SHOW timescaledb.enable_optimizations;
 
 --non-aggregates use MergeAppend in both optimized and non-optimized
 :PREFIX SELECT * FROM hyper_1 ORDER BY "time" DESC limit 2;
-                                  QUERY PLAN                                  
-------------------------------------------------------------------------------
+                               QUERY PLAN                               
+------------------------------------------------------------------------
  Limit
-   ->  Custom Scan (ChunkAppend) on hyper_1
-         Order: hyper_1."time" DESC
-         ->  Index Scan using _hyper_1_1_chunk_time_plain on _hyper_1_1_chunk
-(4 rows)
+   ->  Index Scan using _hyper_1_1_chunk_time_plain on _hyper_1_1_chunk
+(2 rows)
 
 :PREFIX SELECT * FROM hyper_timefunc ORDER BY unix_to_timestamp("time") DESC limit 2;
                                     QUERY PLAN                                     
@@ -146,11 +144,10 @@ SHOW timescaledb.enable_optimizations;
 ------------------------------------------------------------------------------------
  Limit
    ->  GroupAggregate
-         Group Key: (date_trunc('minute'::text, hyper_1."time"))
-         ->  Custom Scan (ChunkAppend) on hyper_1
-               Order: date_trunc('minute'::text, hyper_1."time") DESC
+         Group Key: (date_trunc('minute'::text, _hyper_1_1_chunk."time"))
+         ->  Result
                ->  Index Scan using _hyper_1_1_chunk_time_plain on _hyper_1_1_chunk
-(6 rows)
+(5 rows)
 
 :PREFIX SELECT date_trunc('minute', time) t, avg(series_0), min(series_1), avg(series_2) FROM hyper_1_date GROUP BY t ORDER BY t DESC limit 2;
                                                       QUERY PLAN                                                      
@@ -182,22 +179,20 @@ SHOW timescaledb.enable_optimizations;
 ------------------------------------------------------------------------------------
  Limit
    ->  GroupAggregate
-         Group Key: (date_trunc('minute'::text, hyper_1."time"))
-         ->  Custom Scan (ChunkAppend) on hyper_1
-               Order: date_trunc('minute'::text, hyper_1."time") DESC
+         Group Key: (date_trunc('minute'::text, _hyper_1_1_chunk."time"))
+         ->  Result
                ->  Index Scan using _hyper_1_1_chunk_time_plain on _hyper_1_1_chunk
-(6 rows)
+(5 rows)
 
 :PREFIX SELECT date_trunc('second', time) t, avg(series_0), min(series_1), avg(series_2) FROM hyper_1 GROUP BY t ORDER BY t DESC limit 2;
                                      QUERY PLAN                                     
 ------------------------------------------------------------------------------------
  Limit
    ->  GroupAggregate
-         Group Key: (date_trunc('second'::text, hyper_1."time"))
-         ->  Custom Scan (ChunkAppend) on hyper_1
-               Order: date_trunc('second'::text, hyper_1."time") DESC
+         Group Key: (date_trunc('second'::text, _hyper_1_1_chunk."time"))
+         ->  Result
                ->  Index Scan using _hyper_1_1_chunk_time_plain on _hyper_1_1_chunk
-(6 rows)
+(5 rows)
 
 --test that when index on time used by constraint, still works correctly
 :PREFIX
@@ -252,11 +247,10 @@ BEGIN;
 ---------------------------------------------------------------------------------------------
  Limit
    ->  GroupAggregate
-         Group Key: (date_trunc('minute'::text, hyper_1."time"))
-         ->  Custom Scan (ChunkAppend) on hyper_1
-               Order: date_trunc('minute'::text, hyper_1."time") DESC
+         Group Key: (date_trunc('minute'::text, _hyper_1_1_chunk."time"))
+         ->  Result
                ->  Index Scan Backward using _hyper_1_1_chunk_time_trunc on _hyper_1_1_chunk
-(6 rows)
+(5 rows)
 
   --test that works with both indexes
   CREATE INDEX "time_plain" ON PUBLIC.hyper_1 (time DESC, series_0);
@@ -266,11 +260,10 @@ BEGIN;
 ---------------------------------------------------------------------------------------------
  Limit
    ->  GroupAggregate
-         Group Key: (date_trunc('minute'::text, hyper_1."time"))
-         ->  Custom Scan (ChunkAppend) on hyper_1
-               Order: date_trunc('minute'::text, hyper_1."time") DESC
+         Group Key: (date_trunc('minute'::text, _hyper_1_1_chunk."time"))
+         ->  Result
                ->  Index Scan Backward using _hyper_1_1_chunk_time_trunc on _hyper_1_1_chunk
-(6 rows)
+(5 rows)
 
   :PREFIX SELECT time_bucket('1 minute', time) t, avg(series_0), min(series_1), trunc(avg(series_2)::numeric, 5)
   FROM hyper_1 GROUP BY t ORDER BY t DESC limit 2;
@@ -278,35 +271,32 @@ BEGIN;
 ------------------------------------------------------------------------------------
  Limit
    ->  GroupAggregate
-         Group Key: (time_bucket('@ 1 min'::interval, hyper_1."time"))
-         ->  Custom Scan (ChunkAppend) on hyper_1
-               Order: time_bucket('@ 1 min'::interval, hyper_1."time") DESC
+         Group Key: (time_bucket('@ 1 min'::interval, _hyper_1_1_chunk."time"))
+         ->  Result
                ->  Index Scan using _hyper_1_1_chunk_time_plain on _hyper_1_1_chunk
-(6 rows)
+(5 rows)
 
   :PREFIX SELECT time_bucket('1 minute', time, INTERVAL '30 seconds') t, avg(series_0), min(series_1), trunc(avg(series_2)::numeric,5)
   FROM hyper_1 GROUP BY t ORDER BY t DESC limit 2;
-                                            QUERY PLAN                                             
----------------------------------------------------------------------------------------------------
+                                              QUERY PLAN                                               
+-------------------------------------------------------------------------------------------------------
  Limit
    ->  GroupAggregate
-         Group Key: (time_bucket('@ 1 min'::interval, hyper_1."time", '@ 30 secs'::interval))
-         ->  Custom Scan (ChunkAppend) on hyper_1
-               Order: time_bucket('@ 1 min'::interval, hyper_1."time", '@ 30 secs'::interval) DESC
+         Group Key: (time_bucket('@ 1 min'::interval, _hyper_1_1_chunk."time", '@ 30 secs'::interval))
+         ->  Result
                ->  Index Scan using _hyper_1_1_chunk_time_plain on _hyper_1_1_chunk
-(6 rows)
+(5 rows)
 
   :PREFIX SELECT time_bucket('1 minute', time - INTERVAL '30 seconds') t, avg(series_0), min(series_1), trunc(avg(series_2)::numeric,5)
   FROM hyper_1 GROUP BY t ORDER BY t DESC limit 2;
-                                              QUERY PLAN                                              
-------------------------------------------------------------------------------------------------------
+                                                QUERY PLAN                                                
+----------------------------------------------------------------------------------------------------------
  Limit
    ->  GroupAggregate
-         Group Key: (time_bucket('@ 1 min'::interval, (hyper_1."time" - '@ 30 secs'::interval)))
-         ->  Custom Scan (ChunkAppend) on hyper_1
-               Order: time_bucket('@ 1 min'::interval, (hyper_1."time" - '@ 30 secs'::interval)) DESC
+         Group Key: (time_bucket('@ 1 min'::interval, (_hyper_1_1_chunk."time" - '@ 30 secs'::interval)))
+         ->  Result
                ->  Index Scan using _hyper_1_1_chunk_time_plain on _hyper_1_1_chunk
-(6 rows)
+(5 rows)
 
   :PREFIX SELECT time_bucket('1 minute', time - INTERVAL '30 seconds') + INTERVAL '30 seconds' t, avg(series_0), min(series_1), trunc(avg(series_2)::numeric,5)
   FROM hyper_1 GROUP BY t ORDER BY t DESC limit 2;
@@ -325,11 +315,10 @@ BEGIN;
 ---------------------------------------------------------------------------------------
  Limit
    ->  GroupAggregate
-         Group Key: (time_bucket('@ 1 min'::interval, hyper_1_tz."time"))
-         ->  Custom Scan (ChunkAppend) on hyper_1_tz
-               Order: time_bucket('@ 1 min'::interval, hyper_1_tz."time") DESC
+         Group Key: (time_bucket('@ 1 min'::interval, _hyper_2_2_chunk."time"))
+         ->  Result
                ->  Index Scan using _hyper_2_2_chunk_time_plain_tz on _hyper_2_2_chunk
-(6 rows)
+(5 rows)
 
   :PREFIX SELECT time_bucket('1 minute', time::timestamp) t, avg(series_0), min(series_1), avg(series_2)
   FROM hyper_1_tz GROUP BY t ORDER BY t DESC limit 2;

--- a/test/expected/query-15.out
+++ b/test/expected/query-15.out
@@ -125,13 +125,11 @@ SHOW timescaledb.enable_optimizations;
 
 --non-aggregates use MergeAppend in both optimized and non-optimized
 :PREFIX SELECT * FROM hyper_1 ORDER BY "time" DESC limit 2;
-                                  QUERY PLAN                                  
-------------------------------------------------------------------------------
+                               QUERY PLAN                               
+------------------------------------------------------------------------
  Limit
-   ->  Custom Scan (ChunkAppend) on hyper_1
-         Order: hyper_1."time" DESC
-         ->  Index Scan using _hyper_1_1_chunk_time_plain on _hyper_1_1_chunk
-(4 rows)
+   ->  Index Scan using _hyper_1_1_chunk_time_plain on _hyper_1_1_chunk
+(2 rows)
 
 :PREFIX SELECT * FROM hyper_timefunc ORDER BY unix_to_timestamp("time") DESC limit 2;
                                     QUERY PLAN                                     
@@ -142,16 +140,14 @@ SHOW timescaledb.enable_optimizations;
 
 --Aggregates use MergeAppend only in optimized
 :PREFIX SELECT date_trunc('minute', time) t, avg(series_0), min(series_1), avg(series_2) FROM hyper_1 GROUP BY t ORDER BY t DESC limit 2;
-                                        QUERY PLAN                                        
-------------------------------------------------------------------------------------------
+                                     QUERY PLAN                                     
+------------------------------------------------------------------------------------
  Limit
    ->  GroupAggregate
-         Group Key: (date_trunc('minute'::text, hyper_1."time"))
+         Group Key: (date_trunc('minute'::text, _hyper_1_1_chunk."time"))
          ->  Result
-               ->  Custom Scan (ChunkAppend) on hyper_1
-                     Order: date_trunc('minute'::text, hyper_1."time") DESC
-                     ->  Index Scan using _hyper_1_1_chunk_time_plain on _hyper_1_1_chunk
-(7 rows)
+               ->  Index Scan using _hyper_1_1_chunk_time_plain on _hyper_1_1_chunk
+(5 rows)
 
 :PREFIX SELECT date_trunc('minute', time) t, avg(series_0), min(series_1), avg(series_2) FROM hyper_1_date GROUP BY t ORDER BY t DESC limit 2;
                                                       QUERY PLAN                                                      
@@ -179,28 +175,24 @@ SHOW timescaledb.enable_optimizations;
 
 --the minute and second results should be diff
 :PREFIX SELECT date_trunc('minute', time) t, avg(series_0), min(series_1), avg(series_2) FROM hyper_1 GROUP BY t ORDER BY t DESC limit 2;
-                                        QUERY PLAN                                        
-------------------------------------------------------------------------------------------
+                                     QUERY PLAN                                     
+------------------------------------------------------------------------------------
  Limit
    ->  GroupAggregate
-         Group Key: (date_trunc('minute'::text, hyper_1."time"))
+         Group Key: (date_trunc('minute'::text, _hyper_1_1_chunk."time"))
          ->  Result
-               ->  Custom Scan (ChunkAppend) on hyper_1
-                     Order: date_trunc('minute'::text, hyper_1."time") DESC
-                     ->  Index Scan using _hyper_1_1_chunk_time_plain on _hyper_1_1_chunk
-(7 rows)
+               ->  Index Scan using _hyper_1_1_chunk_time_plain on _hyper_1_1_chunk
+(5 rows)
 
 :PREFIX SELECT date_trunc('second', time) t, avg(series_0), min(series_1), avg(series_2) FROM hyper_1 GROUP BY t ORDER BY t DESC limit 2;
-                                        QUERY PLAN                                        
-------------------------------------------------------------------------------------------
+                                     QUERY PLAN                                     
+------------------------------------------------------------------------------------
  Limit
    ->  GroupAggregate
-         Group Key: (date_trunc('second'::text, hyper_1."time"))
+         Group Key: (date_trunc('second'::text, _hyper_1_1_chunk."time"))
          ->  Result
-               ->  Custom Scan (ChunkAppend) on hyper_1
-                     Order: date_trunc('second'::text, hyper_1."time") DESC
-                     ->  Index Scan using _hyper_1_1_chunk_time_plain on _hyper_1_1_chunk
-(7 rows)
+               ->  Index Scan using _hyper_1_1_chunk_time_plain on _hyper_1_1_chunk
+(5 rows)
 
 --test that when index on time used by constraint, still works correctly
 :PREFIX
@@ -252,70 +244,60 @@ BEGIN;
   CREATE INDEX "time_trunc" ON PUBLIC.hyper_1 (date_trunc('minute', time));
   ANALYZE hyper_1;
   :PREFIX SELECT date_trunc('minute', time) t, avg(series_0), min(series_1), avg(series_2) FROM hyper_1 GROUP BY t ORDER BY t DESC limit 2;
-                                            QUERY PLAN                                             
----------------------------------------------------------------------------------------------------
+                                         QUERY PLAN                                          
+---------------------------------------------------------------------------------------------
  Limit
    ->  GroupAggregate
-         Group Key: (date_trunc('minute'::text, hyper_1."time"))
+         Group Key: (date_trunc('minute'::text, _hyper_1_1_chunk."time"))
          ->  Result
-               ->  Custom Scan (ChunkAppend) on hyper_1
-                     Order: date_trunc('minute'::text, hyper_1."time") DESC
-                     ->  Index Scan Backward using _hyper_1_1_chunk_time_trunc on _hyper_1_1_chunk
-(7 rows)
+               ->  Index Scan Backward using _hyper_1_1_chunk_time_trunc on _hyper_1_1_chunk
+(5 rows)
 
   --test that works with both indexes
   CREATE INDEX "time_plain" ON PUBLIC.hyper_1 (time DESC, series_0);
   ANALYZE hyper_1;
   :PREFIX SELECT date_trunc('minute', time) t, avg(series_0), min(series_1), avg(series_2) FROM hyper_1 GROUP BY t ORDER BY t DESC limit 2;
-                                            QUERY PLAN                                             
----------------------------------------------------------------------------------------------------
+                                         QUERY PLAN                                          
+---------------------------------------------------------------------------------------------
  Limit
    ->  GroupAggregate
-         Group Key: (date_trunc('minute'::text, hyper_1."time"))
+         Group Key: (date_trunc('minute'::text, _hyper_1_1_chunk."time"))
          ->  Result
-               ->  Custom Scan (ChunkAppend) on hyper_1
-                     Order: date_trunc('minute'::text, hyper_1."time") DESC
-                     ->  Index Scan Backward using _hyper_1_1_chunk_time_trunc on _hyper_1_1_chunk
-(7 rows)
+               ->  Index Scan Backward using _hyper_1_1_chunk_time_trunc on _hyper_1_1_chunk
+(5 rows)
 
   :PREFIX SELECT time_bucket('1 minute', time) t, avg(series_0), min(series_1), trunc(avg(series_2)::numeric, 5)
   FROM hyper_1 GROUP BY t ORDER BY t DESC limit 2;
-                                        QUERY PLAN                                        
-------------------------------------------------------------------------------------------
+                                     QUERY PLAN                                     
+------------------------------------------------------------------------------------
  Limit
    ->  GroupAggregate
-         Group Key: (time_bucket('@ 1 min'::interval, hyper_1."time"))
+         Group Key: (time_bucket('@ 1 min'::interval, _hyper_1_1_chunk."time"))
          ->  Result
-               ->  Custom Scan (ChunkAppend) on hyper_1
-                     Order: time_bucket('@ 1 min'::interval, hyper_1."time") DESC
-                     ->  Index Scan using _hyper_1_1_chunk_time_plain on _hyper_1_1_chunk
-(7 rows)
+               ->  Index Scan using _hyper_1_1_chunk_time_plain on _hyper_1_1_chunk
+(5 rows)
 
   :PREFIX SELECT time_bucket('1 minute', time, INTERVAL '30 seconds') t, avg(series_0), min(series_1), trunc(avg(series_2)::numeric,5)
   FROM hyper_1 GROUP BY t ORDER BY t DESC limit 2;
-                                               QUERY PLAN                                                
----------------------------------------------------------------------------------------------------------
+                                              QUERY PLAN                                               
+-------------------------------------------------------------------------------------------------------
  Limit
    ->  GroupAggregate
-         Group Key: (time_bucket('@ 1 min'::interval, hyper_1."time", '@ 30 secs'::interval))
+         Group Key: (time_bucket('@ 1 min'::interval, _hyper_1_1_chunk."time", '@ 30 secs'::interval))
          ->  Result
-               ->  Custom Scan (ChunkAppend) on hyper_1
-                     Order: time_bucket('@ 1 min'::interval, hyper_1."time", '@ 30 secs'::interval) DESC
-                     ->  Index Scan using _hyper_1_1_chunk_time_plain on _hyper_1_1_chunk
-(7 rows)
+               ->  Index Scan using _hyper_1_1_chunk_time_plain on _hyper_1_1_chunk
+(5 rows)
 
   :PREFIX SELECT time_bucket('1 minute', time - INTERVAL '30 seconds') t, avg(series_0), min(series_1), trunc(avg(series_2)::numeric,5)
   FROM hyper_1 GROUP BY t ORDER BY t DESC limit 2;
-                                                 QUERY PLAN                                                 
-------------------------------------------------------------------------------------------------------------
+                                                QUERY PLAN                                                
+----------------------------------------------------------------------------------------------------------
  Limit
    ->  GroupAggregate
-         Group Key: (time_bucket('@ 1 min'::interval, (hyper_1."time" - '@ 30 secs'::interval)))
+         Group Key: (time_bucket('@ 1 min'::interval, (_hyper_1_1_chunk."time" - '@ 30 secs'::interval)))
          ->  Result
-               ->  Custom Scan (ChunkAppend) on hyper_1
-                     Order: time_bucket('@ 1 min'::interval, (hyper_1."time" - '@ 30 secs'::interval)) DESC
-                     ->  Index Scan using _hyper_1_1_chunk_time_plain on _hyper_1_1_chunk
-(7 rows)
+               ->  Index Scan using _hyper_1_1_chunk_time_plain on _hyper_1_1_chunk
+(5 rows)
 
   :PREFIX SELECT time_bucket('1 minute', time - INTERVAL '30 seconds') + INTERVAL '30 seconds' t, avg(series_0), min(series_1), trunc(avg(series_2)::numeric,5)
   FROM hyper_1 GROUP BY t ORDER BY t DESC limit 2;
@@ -330,16 +312,14 @@ BEGIN;
 
   :PREFIX SELECT time_bucket('1 minute', time) t, avg(series_0), min(series_1), avg(series_2)
   FROM hyper_1_tz GROUP BY t ORDER BY t DESC limit 2;
-                                         QUERY PLAN                                          
----------------------------------------------------------------------------------------------
+                                      QUERY PLAN                                       
+---------------------------------------------------------------------------------------
  Limit
    ->  GroupAggregate
-         Group Key: (time_bucket('@ 1 min'::interval, hyper_1_tz."time"))
+         Group Key: (time_bucket('@ 1 min'::interval, _hyper_2_2_chunk."time"))
          ->  Result
-               ->  Custom Scan (ChunkAppend) on hyper_1_tz
-                     Order: time_bucket('@ 1 min'::interval, hyper_1_tz."time") DESC
-                     ->  Index Scan using _hyper_2_2_chunk_time_plain_tz on _hyper_2_2_chunk
-(7 rows)
+               ->  Index Scan using _hyper_2_2_chunk_time_plain_tz on _hyper_2_2_chunk
+(5 rows)
 
   :PREFIX SELECT time_bucket('1 minute', time::timestamp) t, avg(series_0), min(series_1), avg(series_2)
   FROM hyper_1_tz GROUP BY t ORDER BY t DESC limit 2;

--- a/tsl/test/expected/compression_insert-12.out
+++ b/tsl/test/expected/compression_insert-12.out
@@ -762,12 +762,10 @@ ALTER TABLE test_ordering SET (timescaledb.compress,timescaledb.compress_orderby
 INSERT INTO test_ordering VALUES (5),(4),(3);
 -- should be ordered append
 :PREFIX SELECT * FROM test_ordering ORDER BY 1;
-                                              QUERY PLAN                                              
-------------------------------------------------------------------------------------------------------
- Custom Scan (ChunkAppend) on test_ordering
-   Order: test_ordering."time"
-   ->  Index Only Scan Backward using _hyper_13_20_chunk_test_ordering_time_idx on _hyper_13_20_chunk
-(3 rows)
+                                           QUERY PLAN                                           
+------------------------------------------------------------------------------------------------
+ Index Only Scan Backward using _hyper_13_20_chunk_test_ordering_time_idx on _hyper_13_20_chunk
+(1 row)
 
 SELECT compress_chunk(format('%I.%I',chunk_schema,chunk_name), true) FROM timescaledb_information.chunks WHERE hypertable_name = 'test_ordering';
               compress_chunk              
@@ -777,15 +775,13 @@ SELECT compress_chunk(format('%I.%I',chunk_schema,chunk_name), true) FROM timesc
 
 -- should be ordered append
 :PREFIX SELECT * FROM test_ordering ORDER BY 1;
-                                  QUERY PLAN                                   
--------------------------------------------------------------------------------
- Custom Scan (ChunkAppend) on test_ordering
-   Order: test_ordering."time"
-   ->  Custom Scan (DecompressChunk) on _hyper_13_20_chunk
-         ->  Sort
-               Sort Key: compress_hyper_14_21_chunk._ts_meta_sequence_num DESC
-               ->  Seq Scan on compress_hyper_14_21_chunk
-(6 rows)
+                               QUERY PLAN                                
+-------------------------------------------------------------------------
+ Custom Scan (DecompressChunk) on _hyper_13_20_chunk
+   ->  Sort
+         Sort Key: compress_hyper_14_21_chunk._ts_meta_sequence_num DESC
+         ->  Seq Scan on compress_hyper_14_21_chunk
+(4 rows)
 
 INSERT INTO test_ordering SELECT 1;
 -- should not be ordered append

--- a/tsl/test/expected/compression_insert-13.out
+++ b/tsl/test/expected/compression_insert-13.out
@@ -762,12 +762,10 @@ ALTER TABLE test_ordering SET (timescaledb.compress,timescaledb.compress_orderby
 INSERT INTO test_ordering VALUES (5),(4),(3);
 -- should be ordered append
 :PREFIX SELECT * FROM test_ordering ORDER BY 1;
-                                              QUERY PLAN                                              
-------------------------------------------------------------------------------------------------------
- Custom Scan (ChunkAppend) on test_ordering
-   Order: test_ordering."time"
-   ->  Index Only Scan Backward using _hyper_13_20_chunk_test_ordering_time_idx on _hyper_13_20_chunk
-(3 rows)
+                                           QUERY PLAN                                           
+------------------------------------------------------------------------------------------------
+ Index Only Scan Backward using _hyper_13_20_chunk_test_ordering_time_idx on _hyper_13_20_chunk
+(1 row)
 
 SELECT compress_chunk(format('%I.%I',chunk_schema,chunk_name), true) FROM timescaledb_information.chunks WHERE hypertable_name = 'test_ordering';
               compress_chunk              
@@ -777,15 +775,13 @@ SELECT compress_chunk(format('%I.%I',chunk_schema,chunk_name), true) FROM timesc
 
 -- should be ordered append
 :PREFIX SELECT * FROM test_ordering ORDER BY 1;
-                                  QUERY PLAN                                   
--------------------------------------------------------------------------------
- Custom Scan (ChunkAppend) on test_ordering
-   Order: test_ordering."time"
-   ->  Custom Scan (DecompressChunk) on _hyper_13_20_chunk
-         ->  Sort
-               Sort Key: compress_hyper_14_21_chunk._ts_meta_sequence_num DESC
-               ->  Seq Scan on compress_hyper_14_21_chunk
-(6 rows)
+                               QUERY PLAN                                
+-------------------------------------------------------------------------
+ Custom Scan (DecompressChunk) on _hyper_13_20_chunk
+   ->  Sort
+         Sort Key: compress_hyper_14_21_chunk._ts_meta_sequence_num DESC
+         ->  Seq Scan on compress_hyper_14_21_chunk
+(4 rows)
 
 INSERT INTO test_ordering SELECT 1;
 -- should not be ordered append

--- a/tsl/test/expected/compression_insert-14.out
+++ b/tsl/test/expected/compression_insert-14.out
@@ -762,12 +762,10 @@ ALTER TABLE test_ordering SET (timescaledb.compress,timescaledb.compress_orderby
 INSERT INTO test_ordering VALUES (5),(4),(3);
 -- should be ordered append
 :PREFIX SELECT * FROM test_ordering ORDER BY 1;
-                                              QUERY PLAN                                              
-------------------------------------------------------------------------------------------------------
- Custom Scan (ChunkAppend) on test_ordering
-   Order: test_ordering."time"
-   ->  Index Only Scan Backward using _hyper_13_20_chunk_test_ordering_time_idx on _hyper_13_20_chunk
-(3 rows)
+                                           QUERY PLAN                                           
+------------------------------------------------------------------------------------------------
+ Index Only Scan Backward using _hyper_13_20_chunk_test_ordering_time_idx on _hyper_13_20_chunk
+(1 row)
 
 SELECT compress_chunk(format('%I.%I',chunk_schema,chunk_name), true) FROM timescaledb_information.chunks WHERE hypertable_name = 'test_ordering';
               compress_chunk              
@@ -777,15 +775,13 @@ SELECT compress_chunk(format('%I.%I',chunk_schema,chunk_name), true) FROM timesc
 
 -- should be ordered append
 :PREFIX SELECT * FROM test_ordering ORDER BY 1;
-                                  QUERY PLAN                                   
--------------------------------------------------------------------------------
- Custom Scan (ChunkAppend) on test_ordering
-   Order: test_ordering."time"
-   ->  Custom Scan (DecompressChunk) on _hyper_13_20_chunk
-         ->  Sort
-               Sort Key: compress_hyper_14_21_chunk._ts_meta_sequence_num DESC
-               ->  Seq Scan on compress_hyper_14_21_chunk
-(6 rows)
+                               QUERY PLAN                                
+-------------------------------------------------------------------------
+ Custom Scan (DecompressChunk) on _hyper_13_20_chunk
+   ->  Sort
+         Sort Key: compress_hyper_14_21_chunk._ts_meta_sequence_num DESC
+         ->  Seq Scan on compress_hyper_14_21_chunk
+(4 rows)
 
 INSERT INTO test_ordering SELECT 1;
 -- should not be ordered append

--- a/tsl/test/expected/compression_insert-15.out
+++ b/tsl/test/expected/compression_insert-15.out
@@ -762,12 +762,10 @@ ALTER TABLE test_ordering SET (timescaledb.compress,timescaledb.compress_orderby
 INSERT INTO test_ordering VALUES (5),(4),(3);
 -- should be ordered append
 :PREFIX SELECT * FROM test_ordering ORDER BY 1;
-                                              QUERY PLAN                                              
-------------------------------------------------------------------------------------------------------
- Custom Scan (ChunkAppend) on test_ordering
-   Order: test_ordering."time"
-   ->  Index Only Scan Backward using _hyper_13_20_chunk_test_ordering_time_idx on _hyper_13_20_chunk
-(3 rows)
+                                           QUERY PLAN                                           
+------------------------------------------------------------------------------------------------
+ Index Only Scan Backward using _hyper_13_20_chunk_test_ordering_time_idx on _hyper_13_20_chunk
+(1 row)
 
 SELECT compress_chunk(format('%I.%I',chunk_schema,chunk_name), true) FROM timescaledb_information.chunks WHERE hypertable_name = 'test_ordering';
               compress_chunk              
@@ -777,15 +775,13 @@ SELECT compress_chunk(format('%I.%I',chunk_schema,chunk_name), true) FROM timesc
 
 -- should be ordered append
 :PREFIX SELECT * FROM test_ordering ORDER BY 1;
-                                  QUERY PLAN                                   
--------------------------------------------------------------------------------
- Custom Scan (ChunkAppend) on test_ordering
-   Order: test_ordering."time"
-   ->  Custom Scan (DecompressChunk) on _hyper_13_20_chunk
-         ->  Sort
-               Sort Key: compress_hyper_14_21_chunk._ts_meta_sequence_num DESC
-               ->  Seq Scan on compress_hyper_14_21_chunk
-(6 rows)
+                               QUERY PLAN                                
+-------------------------------------------------------------------------
+ Custom Scan (DecompressChunk) on _hyper_13_20_chunk
+   ->  Sort
+         Sort Key: compress_hyper_14_21_chunk._ts_meta_sequence_num DESC
+         ->  Seq Scan on compress_hyper_14_21_chunk
+(4 rows)
 
 INSERT INTO test_ordering SELECT 1;
 -- should not be ordered append

--- a/tsl/test/expected/dist_hypertable-12.out
+++ b/tsl/test/expected/dist_hypertable-12.out
@@ -3798,15 +3798,10 @@ SELECT "time", dist_device, temp FROM public.dist_device ORDER BY "time" ASC NUL
    Chunks: _dist_hyper_15_37_chunk
    Remote SQL: SELECT "time", dist_device, temp FROM public.dist_device WHERE _timescaledb_internal.chunks_in(public.dist_device.*, ARRAY[22]) ORDER BY "time" ASC NULLS LAST
    Remote EXPLAIN: 
-     Custom Scan (ChunkAppend) on public.dist_device
-       Output: dist_device."time", dist_device.dist_device, dist_device.temp
-       Order: dist_device."time"
-       Startup Exclusion: false
-       Runtime Exclusion: false
-       ->  Index Scan Backward using _dist_hyper_15_37_chunk_dist_device_time_idx on _timescaledb_internal._dist_hyper_15_37_chunk
-             Output: _dist_hyper_15_37_chunk."time", _dist_hyper_15_37_chunk.dist_device, _dist_hyper_15_37_chunk.temp
+     Index Scan Backward using _dist_hyper_15_37_chunk_dist_device_time_idx on _timescaledb_internal._dist_hyper_15_37_chunk
+       Output: _dist_hyper_15_37_chunk."time", _dist_hyper_15_37_chunk.dist_device, _dist_hyper_15_37_chunk.temp
  
-(14 rows)
+(9 rows)
 
 SELECT * FROM dist_device;
              time             | dist_device | temp 

--- a/tsl/test/expected/dist_hypertable-13.out
+++ b/tsl/test/expected/dist_hypertable-13.out
@@ -3799,15 +3799,10 @@ SELECT "time", dist_device, temp FROM public.dist_device ORDER BY "time" ASC NUL
    Chunks: _dist_hyper_15_37_chunk
    Remote SQL: SELECT "time", dist_device, temp FROM public.dist_device WHERE _timescaledb_internal.chunks_in(public.dist_device.*, ARRAY[22]) ORDER BY "time" ASC NULLS LAST
    Remote EXPLAIN: 
-     Custom Scan (ChunkAppend) on public.dist_device
-       Output: dist_device."time", dist_device.dist_device, dist_device.temp
-       Order: dist_device."time"
-       Startup Exclusion: false
-       Runtime Exclusion: false
-       ->  Index Scan Backward using _dist_hyper_15_37_chunk_dist_device_time_idx on _timescaledb_internal._dist_hyper_15_37_chunk
-             Output: _dist_hyper_15_37_chunk."time", _dist_hyper_15_37_chunk.dist_device, _dist_hyper_15_37_chunk.temp
+     Index Scan Backward using _dist_hyper_15_37_chunk_dist_device_time_idx on _timescaledb_internal._dist_hyper_15_37_chunk
+       Output: _dist_hyper_15_37_chunk."time", _dist_hyper_15_37_chunk.dist_device, _dist_hyper_15_37_chunk.temp
  
-(14 rows)
+(9 rows)
 
 SELECT * FROM dist_device;
              time             | dist_device | temp 

--- a/tsl/test/expected/dist_hypertable-14.out
+++ b/tsl/test/expected/dist_hypertable-14.out
@@ -3806,15 +3806,10 @@ SELECT "time", dist_device, temp FROM public.dist_device ORDER BY "time" ASC NUL
    Chunks: _dist_hyper_15_37_chunk
    Remote SQL: SELECT "time", dist_device, temp FROM public.dist_device WHERE _timescaledb_internal.chunks_in(public.dist_device.*, ARRAY[22]) ORDER BY "time" ASC NULLS LAST
    Remote EXPLAIN: 
-     Custom Scan (ChunkAppend) on public.dist_device
-       Output: dist_device."time", dist_device.dist_device, dist_device.temp
-       Order: dist_device."time"
-       Startup Exclusion: false
-       Runtime Exclusion: false
-       ->  Index Scan Backward using _dist_hyper_15_37_chunk_dist_device_time_idx on _timescaledb_internal._dist_hyper_15_37_chunk
-             Output: _dist_hyper_15_37_chunk."time", _dist_hyper_15_37_chunk.dist_device, _dist_hyper_15_37_chunk.temp
+     Index Scan Backward using _dist_hyper_15_37_chunk_dist_device_time_idx on _timescaledb_internal._dist_hyper_15_37_chunk
+       Output: _dist_hyper_15_37_chunk."time", _dist_hyper_15_37_chunk.dist_device, _dist_hyper_15_37_chunk.temp
  
-(14 rows)
+(9 rows)
 
 SELECT * FROM dist_device;
              time             | dist_device | temp 

--- a/tsl/test/expected/dist_hypertable-15.out
+++ b/tsl/test/expected/dist_hypertable-15.out
@@ -3812,15 +3812,10 @@ SELECT "time", dist_device, temp FROM public.dist_device ORDER BY "time" ASC NUL
    Chunks: _dist_hyper_15_37_chunk
    Remote SQL: SELECT "time", dist_device, temp FROM public.dist_device WHERE _timescaledb_internal.chunks_in(public.dist_device.*, ARRAY[22]) ORDER BY "time" ASC NULLS LAST
    Remote EXPLAIN: 
-     Custom Scan (ChunkAppend) on public.dist_device
-       Output: dist_device."time", dist_device.dist_device, dist_device.temp
-       Order: dist_device."time"
-       Startup Exclusion: false
-       Runtime Exclusion: false
-       ->  Index Scan Backward using _dist_hyper_15_37_chunk_dist_device_time_idx on _timescaledb_internal._dist_hyper_15_37_chunk
-             Output: _dist_hyper_15_37_chunk."time", _dist_hyper_15_37_chunk.dist_device, _dist_hyper_15_37_chunk.temp
+     Index Scan Backward using _dist_hyper_15_37_chunk_dist_device_time_idx on _timescaledb_internal._dist_hyper_15_37_chunk
+       Output: _dist_hyper_15_37_chunk."time", _dist_hyper_15_37_chunk.dist_device, _dist_hyper_15_37_chunk.temp
  
-(14 rows)
+(9 rows)
 
 SELECT * FROM dist_device;
              time             | dist_device | temp 

--- a/tsl/test/expected/transparent_decompression_ordered_index-12.out
+++ b/tsl/test/expected/transparent_decompression_ordered_index-12.out
@@ -141,32 +141,28 @@ ORDER BY c.id;
 --all queries have only prefix of compress_orderby in ORDER BY clause
 -- should have ordered DecompressChunk path because segmentby columns have equality constraints
 :PREFIX SELECT * FROM metrics_ordered_idx2 WHERE device_id = 3 AND device_id_peer = 3 ORDER BY time DESC LIMIT 10;
-                                                                          QUERY PLAN                                                                           
----------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                       QUERY PLAN                                                                        
+---------------------------------------------------------------------------------------------------------------------------------------------------------
  Limit (actual rows=10 loops=1)
-   ->  Custom Scan (ChunkAppend) on metrics_ordered_idx2 (actual rows=10 loops=1)
-         Order: metrics_ordered_idx2."time" DESC
-         ->  Custom Scan (DecompressChunk) on _hyper_3_11_chunk (actual rows=10 loops=1)
-               ->  Sort (actual rows=1 loops=1)
-                     Sort Key: compress_hyper_4_12_chunk._ts_meta_sequence_num DESC
-                     Sort Method: quicksort 
-                     ->  Index Scan using compress_hyper_4_12_chunk__compressed_hypertable_4_device_id_de on compress_hyper_4_12_chunk (actual rows=5 loops=1)
-                           Index Cond: ((device_id = 3) AND (device_id_peer = 3))
-(9 rows)
+   ->  Custom Scan (DecompressChunk) on _hyper_3_11_chunk (actual rows=10 loops=1)
+         ->  Sort (actual rows=1 loops=1)
+               Sort Key: compress_hyper_4_12_chunk._ts_meta_sequence_num DESC
+               Sort Method: quicksort 
+               ->  Index Scan using compress_hyper_4_12_chunk__compressed_hypertable_4_device_id_de on compress_hyper_4_12_chunk (actual rows=5 loops=1)
+                     Index Cond: ((device_id = 3) AND (device_id_peer = 3))
+(7 rows)
 
 :PREFIX SELECT * FROM metrics_ordered_idx2 WHERE device_id = 3 AND device_id_peer = 3 ORDER BY time DESC , v0 asc LIMIT 10;
-                                                                          QUERY PLAN                                                                           
----------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                       QUERY PLAN                                                                        
+---------------------------------------------------------------------------------------------------------------------------------------------------------
  Limit (actual rows=10 loops=1)
-   ->  Custom Scan (ChunkAppend) on metrics_ordered_idx2 (actual rows=10 loops=1)
-         Order: metrics_ordered_idx2."time" DESC, metrics_ordered_idx2.v0
-         ->  Custom Scan (DecompressChunk) on _hyper_3_11_chunk (actual rows=10 loops=1)
-               ->  Sort (actual rows=1 loops=1)
-                     Sort Key: compress_hyper_4_12_chunk._ts_meta_sequence_num DESC
-                     Sort Method: quicksort 
-                     ->  Index Scan using compress_hyper_4_12_chunk__compressed_hypertable_4_device_id_de on compress_hyper_4_12_chunk (actual rows=5 loops=1)
-                           Index Cond: ((device_id = 3) AND (device_id_peer = 3))
-(9 rows)
+   ->  Custom Scan (DecompressChunk) on _hyper_3_11_chunk (actual rows=10 loops=1)
+         ->  Sort (actual rows=1 loops=1)
+               Sort Key: compress_hyper_4_12_chunk._ts_meta_sequence_num DESC
+               Sort Method: quicksort 
+               ->  Index Scan using compress_hyper_4_12_chunk__compressed_hypertable_4_device_id_de on compress_hyper_4_12_chunk (actual rows=5 loops=1)
+                     Index Cond: ((device_id = 3) AND (device_id_peer = 3))
+(7 rows)
 
 :PREFIX SELECT * FROM metrics_ordered_idx2 WHERE device_id = 3 AND device_id_peer = 3 ORDER BY time DESC , v0 desc LIMIT 10;
                                                                        QUERY PLAN                                                                        

--- a/tsl/test/expected/transparent_decompression_ordered_index-13.out
+++ b/tsl/test/expected/transparent_decompression_ordered_index-13.out
@@ -141,32 +141,28 @@ ORDER BY c.id;
 --all queries have only prefix of compress_orderby in ORDER BY clause
 -- should have ordered DecompressChunk path because segmentby columns have equality constraints
 :PREFIX SELECT * FROM metrics_ordered_idx2 WHERE device_id = 3 AND device_id_peer = 3 ORDER BY time DESC LIMIT 10;
-                                                                          QUERY PLAN                                                                           
----------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                       QUERY PLAN                                                                        
+---------------------------------------------------------------------------------------------------------------------------------------------------------
  Limit (actual rows=10 loops=1)
-   ->  Custom Scan (ChunkAppend) on metrics_ordered_idx2 (actual rows=10 loops=1)
-         Order: metrics_ordered_idx2."time" DESC
-         ->  Custom Scan (DecompressChunk) on _hyper_3_11_chunk (actual rows=10 loops=1)
-               ->  Sort (actual rows=1 loops=1)
-                     Sort Key: compress_hyper_4_12_chunk._ts_meta_sequence_num DESC
-                     Sort Method: quicksort 
-                     ->  Index Scan using compress_hyper_4_12_chunk__compressed_hypertable_4_device_id_de on compress_hyper_4_12_chunk (actual rows=5 loops=1)
-                           Index Cond: ((device_id = 3) AND (device_id_peer = 3))
-(9 rows)
+   ->  Custom Scan (DecompressChunk) on _hyper_3_11_chunk (actual rows=10 loops=1)
+         ->  Sort (actual rows=1 loops=1)
+               Sort Key: compress_hyper_4_12_chunk._ts_meta_sequence_num DESC
+               Sort Method: quicksort 
+               ->  Index Scan using compress_hyper_4_12_chunk__compressed_hypertable_4_device_id_de on compress_hyper_4_12_chunk (actual rows=5 loops=1)
+                     Index Cond: ((device_id = 3) AND (device_id_peer = 3))
+(7 rows)
 
 :PREFIX SELECT * FROM metrics_ordered_idx2 WHERE device_id = 3 AND device_id_peer = 3 ORDER BY time DESC , v0 asc LIMIT 10;
-                                                                          QUERY PLAN                                                                           
----------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                       QUERY PLAN                                                                        
+---------------------------------------------------------------------------------------------------------------------------------------------------------
  Limit (actual rows=10 loops=1)
-   ->  Custom Scan (ChunkAppend) on metrics_ordered_idx2 (actual rows=10 loops=1)
-         Order: metrics_ordered_idx2."time" DESC, metrics_ordered_idx2.v0
-         ->  Custom Scan (DecompressChunk) on _hyper_3_11_chunk (actual rows=10 loops=1)
-               ->  Sort (actual rows=1 loops=1)
-                     Sort Key: compress_hyper_4_12_chunk._ts_meta_sequence_num DESC
-                     Sort Method: quicksort 
-                     ->  Index Scan using compress_hyper_4_12_chunk__compressed_hypertable_4_device_id_de on compress_hyper_4_12_chunk (actual rows=5 loops=1)
-                           Index Cond: ((device_id = 3) AND (device_id_peer = 3))
-(9 rows)
+   ->  Custom Scan (DecompressChunk) on _hyper_3_11_chunk (actual rows=10 loops=1)
+         ->  Sort (actual rows=1 loops=1)
+               Sort Key: compress_hyper_4_12_chunk._ts_meta_sequence_num DESC
+               Sort Method: quicksort 
+               ->  Index Scan using compress_hyper_4_12_chunk__compressed_hypertable_4_device_id_de on compress_hyper_4_12_chunk (actual rows=5 loops=1)
+                     Index Cond: ((device_id = 3) AND (device_id_peer = 3))
+(7 rows)
 
 :PREFIX SELECT * FROM metrics_ordered_idx2 WHERE device_id = 3 AND device_id_peer = 3 ORDER BY time DESC , v0 desc LIMIT 10;
                                                                        QUERY PLAN                                                                        

--- a/tsl/test/expected/transparent_decompression_ordered_index-14.out
+++ b/tsl/test/expected/transparent_decompression_ordered_index-14.out
@@ -141,32 +141,28 @@ ORDER BY c.id;
 --all queries have only prefix of compress_orderby in ORDER BY clause
 -- should have ordered DecompressChunk path because segmentby columns have equality constraints
 :PREFIX SELECT * FROM metrics_ordered_idx2 WHERE device_id = 3 AND device_id_peer = 3 ORDER BY time DESC LIMIT 10;
-                                                                          QUERY PLAN                                                                           
----------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                       QUERY PLAN                                                                        
+---------------------------------------------------------------------------------------------------------------------------------------------------------
  Limit (actual rows=10 loops=1)
-   ->  Custom Scan (ChunkAppend) on metrics_ordered_idx2 (actual rows=10 loops=1)
-         Order: metrics_ordered_idx2."time" DESC
-         ->  Custom Scan (DecompressChunk) on _hyper_3_11_chunk (actual rows=10 loops=1)
-               ->  Sort (actual rows=1 loops=1)
-                     Sort Key: compress_hyper_4_12_chunk._ts_meta_sequence_num DESC
-                     Sort Method: quicksort 
-                     ->  Index Scan using compress_hyper_4_12_chunk__compressed_hypertable_4_device_id_de on compress_hyper_4_12_chunk (actual rows=5 loops=1)
-                           Index Cond: ((device_id = 3) AND (device_id_peer = 3))
-(9 rows)
+   ->  Custom Scan (DecompressChunk) on _hyper_3_11_chunk (actual rows=10 loops=1)
+         ->  Sort (actual rows=1 loops=1)
+               Sort Key: compress_hyper_4_12_chunk._ts_meta_sequence_num DESC
+               Sort Method: quicksort 
+               ->  Index Scan using compress_hyper_4_12_chunk__compressed_hypertable_4_device_id_de on compress_hyper_4_12_chunk (actual rows=5 loops=1)
+                     Index Cond: ((device_id = 3) AND (device_id_peer = 3))
+(7 rows)
 
 :PREFIX SELECT * FROM metrics_ordered_idx2 WHERE device_id = 3 AND device_id_peer = 3 ORDER BY time DESC , v0 asc LIMIT 10;
-                                                                          QUERY PLAN                                                                           
----------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                       QUERY PLAN                                                                        
+---------------------------------------------------------------------------------------------------------------------------------------------------------
  Limit (actual rows=10 loops=1)
-   ->  Custom Scan (ChunkAppend) on metrics_ordered_idx2 (actual rows=10 loops=1)
-         Order: metrics_ordered_idx2."time" DESC, metrics_ordered_idx2.v0
-         ->  Custom Scan (DecompressChunk) on _hyper_3_11_chunk (actual rows=10 loops=1)
-               ->  Sort (actual rows=1 loops=1)
-                     Sort Key: compress_hyper_4_12_chunk._ts_meta_sequence_num DESC
-                     Sort Method: quicksort 
-                     ->  Index Scan using compress_hyper_4_12_chunk__compressed_hypertable_4_device_id_de on compress_hyper_4_12_chunk (actual rows=5 loops=1)
-                           Index Cond: ((device_id = 3) AND (device_id_peer = 3))
-(9 rows)
+   ->  Custom Scan (DecompressChunk) on _hyper_3_11_chunk (actual rows=10 loops=1)
+         ->  Sort (actual rows=1 loops=1)
+               Sort Key: compress_hyper_4_12_chunk._ts_meta_sequence_num DESC
+               Sort Method: quicksort 
+               ->  Index Scan using compress_hyper_4_12_chunk__compressed_hypertable_4_device_id_de on compress_hyper_4_12_chunk (actual rows=5 loops=1)
+                     Index Cond: ((device_id = 3) AND (device_id_peer = 3))
+(7 rows)
 
 :PREFIX SELECT * FROM metrics_ordered_idx2 WHERE device_id = 3 AND device_id_peer = 3 ORDER BY time DESC , v0 desc LIMIT 10;
                                                                        QUERY PLAN                                                                        

--- a/tsl/test/expected/transparent_decompression_ordered_index-15.out
+++ b/tsl/test/expected/transparent_decompression_ordered_index-15.out
@@ -141,32 +141,28 @@ ORDER BY c.id;
 --all queries have only prefix of compress_orderby in ORDER BY clause
 -- should have ordered DecompressChunk path because segmentby columns have equality constraints
 :PREFIX SELECT * FROM metrics_ordered_idx2 WHERE device_id = 3 AND device_id_peer = 3 ORDER BY time DESC LIMIT 10;
-                                                                          QUERY PLAN                                                                           
----------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                       QUERY PLAN                                                                        
+---------------------------------------------------------------------------------------------------------------------------------------------------------
  Limit (actual rows=10 loops=1)
-   ->  Custom Scan (ChunkAppend) on metrics_ordered_idx2 (actual rows=10 loops=1)
-         Order: metrics_ordered_idx2."time" DESC
-         ->  Custom Scan (DecompressChunk) on _hyper_3_11_chunk (actual rows=10 loops=1)
-               ->  Sort (actual rows=1 loops=1)
-                     Sort Key: compress_hyper_4_12_chunk._ts_meta_sequence_num DESC
-                     Sort Method: quicksort 
-                     ->  Index Scan using compress_hyper_4_12_chunk__compressed_hypertable_4_device_id_de on compress_hyper_4_12_chunk (actual rows=5 loops=1)
-                           Index Cond: ((device_id = 3) AND (device_id_peer = 3))
-(9 rows)
+   ->  Custom Scan (DecompressChunk) on _hyper_3_11_chunk (actual rows=10 loops=1)
+         ->  Sort (actual rows=1 loops=1)
+               Sort Key: compress_hyper_4_12_chunk._ts_meta_sequence_num DESC
+               Sort Method: quicksort 
+               ->  Index Scan using compress_hyper_4_12_chunk__compressed_hypertable_4_device_id_de on compress_hyper_4_12_chunk (actual rows=5 loops=1)
+                     Index Cond: ((device_id = 3) AND (device_id_peer = 3))
+(7 rows)
 
 :PREFIX SELECT * FROM metrics_ordered_idx2 WHERE device_id = 3 AND device_id_peer = 3 ORDER BY time DESC , v0 asc LIMIT 10;
-                                                                          QUERY PLAN                                                                           
----------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                       QUERY PLAN                                                                        
+---------------------------------------------------------------------------------------------------------------------------------------------------------
  Limit (actual rows=10 loops=1)
-   ->  Custom Scan (ChunkAppend) on metrics_ordered_idx2 (actual rows=10 loops=1)
-         Order: metrics_ordered_idx2."time" DESC, metrics_ordered_idx2.v0
-         ->  Custom Scan (DecompressChunk) on _hyper_3_11_chunk (actual rows=10 loops=1)
-               ->  Sort (actual rows=1 loops=1)
-                     Sort Key: compress_hyper_4_12_chunk._ts_meta_sequence_num DESC
-                     Sort Method: quicksort 
-                     ->  Index Scan using compress_hyper_4_12_chunk__compressed_hypertable_4_device_id_de on compress_hyper_4_12_chunk (actual rows=5 loops=1)
-                           Index Cond: ((device_id = 3) AND (device_id_peer = 3))
-(9 rows)
+   ->  Custom Scan (DecompressChunk) on _hyper_3_11_chunk (actual rows=10 loops=1)
+         ->  Sort (actual rows=1 loops=1)
+               Sort Key: compress_hyper_4_12_chunk._ts_meta_sequence_num DESC
+               Sort Method: quicksort 
+               ->  Index Scan using compress_hyper_4_12_chunk__compressed_hypertable_4_device_id_de on compress_hyper_4_12_chunk (actual rows=5 loops=1)
+                     Index Cond: ((device_id = 3) AND (device_id_peer = 3))
+(7 rows)
 
 :PREFIX SELECT * FROM metrics_ordered_idx2 WHERE device_id = 3 AND device_id_peer = 3 ORDER BY time DESC , v0 desc LIMIT 10;
                                                                        QUERY PLAN                                                                        


### PR DESCRIPTION
This is mostly a cosmetic change. When only 1 child is present there is no need for ordered append. In this situation we might still benefit from a ChunkAppend node here due to runtime chunk exclusion when we have non-immutable constraints, so we still add the ChunkAppend node in that situation even with only 1 child.