### PR TITLE
Fix error message for continuous aggregates

### DIFF
--- a/tsl/src/continuous_aggs/create.c
+++ b/tsl/src/continuous_aggs/create.c
@@ -947,8 +947,8 @@ caggtimebucket_validate(CAggTimebucketInfo *tbinfo, List *groupClause, List *tar
 				ereport(ERROR,
 						(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
 						 errmsg("only immutable expressions allowed in time bucket function"),
-						 errhint("Use an immutable expression as first argument"
-								 " to the time bucket function.")));
+						 errhint("Use an immutable expression as first argument to the time bucket "
+								 "function.")));
 
 			if (tbinfo->interval && tbinfo->interval->month)
 			{
@@ -1271,7 +1271,7 @@ cagg_validate_query(const Query *query, const bool finalized, const char *cagg_s
 			ereport(ERROR,
 					(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
 					 errmsg("old format of continuous aggregate is not supported with joins"),
-					 errhint("set timescaledb.finalized to TRUE")));
+					 errhint("Set timescaledb.finalized to TRUE.")));
 
 		if (list_length(fromList) == CONTINUOUS_AGG_MAX_JOIN_RELATIONS)
 		{
@@ -1280,7 +1280,7 @@ cagg_validate_query(const Query *query, const bool finalized, const char *cagg_s
 						(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
 						 errmsg("invalid continuous aggregate view"),
 						 errdetail(
-							 "from clause can only have one hypertable and one normal table")));
+							 "From clause can only have one hypertable and one normal table.")));
 
 			rtref = linitial_node(RangeTblRef, query->jointree->fromlist);
 			rte = list_nth(query->rtable, rtref->rtindex - 1);
@@ -1307,8 +1307,8 @@ cagg_validate_query(const Query *query, const bool finalized, const char *cagg_s
 								(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
 								 errmsg("invalid continuous aggregate view"),
 								 errdetail(
-									 "joins with using clause in continuous aggregate definition"
-									 " work for Postgres versions 13 and above")));
+									 "Joins with USING clause in continuous aggregate definition"
+									 " work for Postgres versions 13 and above.")));
 #endif
 					jointype = join->jointype;
 					op = (OpExpr *) join->quals;
@@ -1318,7 +1318,7 @@ cagg_validate_query(const Query *query, const bool finalized, const char *cagg_s
 						ereport(ERROR,
 								(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
 								 errmsg("invalid continuous aggregate view"),
-								 errdetail("sub-queries are not supported in FROM clause")));
+								 errdetail("Sub-queries are not supported in FROM clause.")));
 					RangeTblEntry *jrte = rt_fetch(join->rtindex, query->rtable);
 					if (jrte->joinaliasvars == NIL)
 						ereport(ERROR,
@@ -1336,20 +1336,20 @@ cagg_validate_query(const Query *query, const bool finalized, const char *cagg_s
 			ereport(ERROR,
 					(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
 					 errmsg("invalid continuous aggregate view"),
-					 errdetail("lateral are not supported in FROM clause")));
+					 errdetail("Lateral joins are not supported in FROM clause.")));
 		if ((rte->relkind == RELKIND_VIEW && ts_is_hypertable(rte_other->relid)) ||
 			(rte_other->relkind == RELKIND_VIEW && ts_is_hypertable(rte->relid)))
 			ereport(ERROR,
 					(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
 					 errmsg("invalid continuous aggregate view"),
-					 errdetail("views are not supported in FROM clause")));
+					 errdetail("Views are not supported in FROM clause.")));
 		if (rte->relkind != RELKIND_VIEW && rte_other->relkind != RELKIND_VIEW &&
 			(ts_is_hypertable(rte->relid) == ts_is_hypertable(rte_other->relid)))
 			ereport(ERROR,
 					(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
 					 errmsg("invalid continuous aggregate view"),
-					 errdetail("multiple hypertables or normal tables"
-							   " are not supported in FROM clause")));
+					 errdetail("Multiple hypertables or normal tables are not supported in FROM "
+							   "clause.")));
 
 		/* Only inner joins are allowed. */
 		if (jointype != JOIN_INNER)
@@ -1368,14 +1368,14 @@ cagg_validate_query(const Query *query, const bool finalized, const char *cagg_s
 						(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
 						 errmsg("invalid continuous aggregate view"),
 						 errdetail(
-							 "only equality conditions are supported in continuous aggregates")));
+							 "Only equality conditions are supported in continuous aggregates.")));
 		}
 		else
 			ereport(ERROR,
 					(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
 					 errmsg("invalid continuous aggregate view"),
-					 errdetail("unsupported expression in join clause"),
-					 errhint("only equality condition is supported")));
+					 errdetail("Unsupported expression in join clause."),
+					 errhint("Only equality conditions are supported in continuous aggregates.")));
 		/*
 		 * Record the table oid of the normal table. This is required so
 		 * that we know which one is hypertable to carry out the related
@@ -1422,8 +1422,8 @@ cagg_validate_query(const Query *query, const bool finalized, const char *cagg_s
 				ereport(ERROR,
 						(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
 						 errmsg("invalid continuous aggregate query"),
-						 errhint("continuous aggregate needs to query hypertable or another "
-								 "continuous aggregate")));
+						 errhint("Continuous aggregate needs to query hypertable or another "
+								 "continuous aggregate.")));
 			}
 
 			if (!ContinuousAggIsFinalized(cagg_parent))
@@ -1509,8 +1509,8 @@ cagg_validate_query(const Query *query, const bool finalized, const char *cagg_s
 						(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
 						 errmsg("custom time function required on hypertable \"%s\"",
 								get_rel_name(ht->main_table_relid)),
-						 errdetail("An integer-based hypertable requires a custom time"
-								   " function to support continuous aggregates."),
+						 errdetail("An integer-based hypertable requires a custom time function to "
+								   "support continuous aggregates."),
 						 errhint("Set a custom time function on the hypertable.")));
 		}
 
@@ -2871,8 +2871,8 @@ tsl_process_continuous_agg_viewstmt(Node *node, const char *query_string, void *
 			ereport(ERROR,
 					(errcode(ERRCODE_DUPLICATE_TABLE),
 					 errmsg("continuous aggregate \"%s\" already exists", stmt->into->rel->relname),
-					 errhint("Drop or rename the existing continuous aggregate"
-							 " first or use another name.")));
+					 errhint("Drop or rename the existing continuous aggregate first or use "
+							 "another name.")));
 		}
 	}
 
@@ -3081,9 +3081,9 @@ cagg_rebuild_view_definition(ContinuousAgg *agg, Hypertable *mat_ht)
 						"\"%s.%s\"",
 						schema,
 						relname),
-				 errdetail("Continuous aggregate data possibly corrupted.\n"
-						   "You may need to recreate the continuous aggregate with"
-						   "CREATE MATERIALIZED VIEW.")));
+				 errdetail("Continuous aggregate data possibly corrupted."),
+				 errhint("You may need to recreate the continuous aggregate with CREATE "
+						 "MATERIALIZED VIEW.")));
 	}
 	else
 	{

--- a/tsl/test/expected/cagg_joins-12.out
+++ b/tsl/test/expected/cagg_joins-12.out
@@ -243,7 +243,7 @@ SELECT time_bucket(INTERVAL '1 day', day) AS bucket,
 FROM devices JOIN conditions USING (device_id)
 GROUP BY name, bucket;
 ERROR:  invalid continuous aggregate view
-DETAIL:  joins with using clause in continuous aggregate definition work for Postgres versions 13 and above
+DETAIL:  Joins with USING clause in continuous aggregate definition work for Postgres versions 13 and above.
 CREATE MATERIALIZED VIEW conditions_summary_daily_3_reorder
 WITH (timescaledb.continuous) AS
 SELECT time_bucket(INTERVAL '1 day', day) AS bucket,
@@ -254,7 +254,7 @@ SELECT time_bucket(INTERVAL '1 day', day) AS bucket,
 FROM conditions JOIN devices USING (device_id)
 GROUP BY name, bucket;
 ERROR:  invalid continuous aggregate view
-DETAIL:  joins with using clause in continuous aggregate definition work for Postgres versions 13 and above
+DETAIL:  Joins with USING clause in continuous aggregate definition work for Postgres versions 13 and above.
 --Error out for old format cagg definition
 CREATE MATERIALIZED VIEW conditions_summary_daily_cagg
 WITH (timescaledb.continuous, timescaledb.materialized_only = TRUE, timescaledb.finalized = FALSE) AS
@@ -268,7 +268,7 @@ FROM conditions, devices
 WHERE conditions.device_id = devices.device_id
 GROUP BY name, bucket, devices.device_id;
 ERROR:  old format of continuous aggregate is not supported with joins
-HINT:  set timescaledb.finalized to TRUE
+HINT:  Set timescaledb.finalized to TRUE.
 CREATE MATERIALIZED VIEW conditions_summary_daily_cagg
 WITH (timescaledb.continuous, timescaledb.materialized_only = TRUE, timescaledb.finalized = FALSE) AS
 SELECT time_bucket(INTERVAL '1 day', day) AS bucket,
@@ -281,7 +281,7 @@ FROM conditions JOIN devices
 ON conditions.device_id = devices.device_id
 GROUP BY name, bucket, devices.device_id;
 ERROR:  old format of continuous aggregate is not supported with joins
-HINT:  set timescaledb.finalized to TRUE
+HINT:  Set timescaledb.finalized to TRUE.
 CREATE  TABLE mat_t1( a integer, b integer,c TEXT);
 -- Error out LATERAL multiple tables old format
 CREATE MATERIALIZED VIEW mat_m1 WITH (timescaledb.continuous, timescaledb.finalized = false)
@@ -290,7 +290,7 @@ select temperature, count(*) from conditions,
 LATERAL (Select * from mat_t1 where a = conditions.temperature) q
 group by temperature WITH NO DATA;
 ERROR:  old format of continuous aggregate is not supported with joins
-HINT:  set timescaledb.finalized to TRUE
+HINT:  Set timescaledb.finalized to TRUE.
 -- Error out for LATERAL multiple tables in new format
 CREATE MATERIALIZED VIEW mat_m1 WITH (timescaledb.continuous)
 as
@@ -298,7 +298,7 @@ select temperature, count(*) from conditions,
 LATERAL (Select * from mat_t1 where a = conditions.temperature) q
 group by temperature WITH NO DATA;
 ERROR:  invalid continuous aggregate view
-DETAIL:  lateral are not supported in FROM clause
+DETAIL:  Lateral joins are not supported in FROM clause.
 --Error out if from clause has view
 CREATE MATERIALIZED VIEW conditions_summary_daily_view
 WITH (timescaledb.continuous, timescaledb.materialized_only = TRUE) AS
@@ -312,7 +312,7 @@ FROM conditions, devices_view
 WHERE conditions.device_id = devices_view.device_id
 GROUP BY name, bucket, devices_view.device_id;
 ERROR:  invalid continuous aggregate view
-DETAIL:  views are not supported in FROM clause
+DETAIL:  Views are not supported in FROM clause.
 -- Nested CAgg over a CAgg with join
 CREATE MATERIALIZED VIEW cagg_on_cagg
 WITH (timescaledb.continuous, timescaledb.materialized_only=true) AS
@@ -340,7 +340,7 @@ SELECT time_bucket(INTERVAL '1 day', day) AS bucket,
 FROM conditions JOIN (SELECT * FROM devices WHERE location in (SELECT name from cities where currency = 'EUR')) dev ON conditions.device_id = dev.device_id
 GROUP BY name, bucket;
 ERROR:  invalid continuous aggregate view
-DETAIL:  sub-queries are not supported in FROM clause
+DETAIL:  Sub-queries are not supported in FROM clause.
 DROP TABLE cities CASCADE;
 --Error out when join is between two hypertables
 CREATE MATERIALIZED VIEW conditions_summary_daily_ht
@@ -353,7 +353,7 @@ FROM conditions, conditions_dup
 WHERE conditions.device_id = conditions_dup.device_id
 GROUP BY bucket;
 ERROR:  invalid continuous aggregate view
-DETAIL:  multiple hypertables or normal tables are not supported in FROM clause
+DETAIL:  Multiple hypertables or normal tables are not supported in FROM clause.
 --Error out when join is between two normal tables
 CREATE MATERIALIZED VIEW conditions_summary_daily_nt
 WITH (timescaledb.continuous, timescaledb.materialized_only = TRUE) AS
@@ -366,7 +366,7 @@ FROM devices, devices_dup
 WHERE devices.device_id = devices_dup.device_id
 GROUP BY devices.name, devices.location;
 ERROR:  invalid continuous aggregate view
-DETAIL:  multiple hypertables or normal tables are not supported in FROM clause
+DETAIL:  Multiple hypertables or normal tables are not supported in FROM clause.
 --Error out when join is on non-equality condition
 CREATE MATERIALIZED VIEW conditions_summary_daily_unequal
 WITH (timescaledb.continuous, timescaledb.materialized_only = TRUE) AS
@@ -379,7 +379,7 @@ FROM conditions, devices
 WHERE conditions.device_id <> devices.device_id
 GROUP BY name, bucket;
 ERROR:  invalid continuous aggregate view
-DETAIL:  only equality conditions are supported in continuous aggregates
+DETAIL:  Only equality conditions are supported in continuous aggregates.
 --Unsupported join condition
 CREATE MATERIALIZED VIEW conditions_summary_daily_unequal
 WITH (timescaledb.continuous, timescaledb.materialized_only = TRUE) AS
@@ -393,8 +393,8 @@ WHERE conditions.device_id = devices.device_id AND
       conditions.city like '%cow*'
 GROUP BY name, bucket;
 ERROR:  invalid continuous aggregate view
-DETAIL:  unsupported expression in join clause
-HINT:  only equality condition is supported
+DETAIL:  Unsupported expression in join clause.
+HINT:  Only equality conditions are supported in continuous aggregates.
 --Unsupported join condition
 CREATE MATERIALIZED VIEW conditions_summary_daily_unequal
 WITH (timescaledb.continuous, timescaledb.materialized_only = TRUE) AS
@@ -408,8 +408,8 @@ WHERE conditions.device_id = devices.device_id OR
       conditions.city like '%cow*'
 GROUP BY name, bucket;
 ERROR:  invalid continuous aggregate view
-DETAIL:  unsupported expression in join clause
-HINT:  only equality condition is supported
+DETAIL:  Unsupported expression in join clause.
+HINT:  Only equality conditions are supported in continuous aggregates.
 --Error out when join type is not inner
 CREATE MATERIALIZED VIEW conditions_summary_daily_outer
 WITH (timescaledb.continuous, timescaledb.materialized_only = TRUE) AS
@@ -455,7 +455,7 @@ FROM conditions_summary_daily_cagg cagg, conditions
 WHERE cagg.device_id = conditions.device_id
 GROUP BY 1,2,3;
 ERROR:  invalid continuous aggregate view
-DETAIL:  views are not supported in FROM clause
+DETAIL:  Views are not supported in FROM clause.
 \set VERBOSITY terse
 DROP TABLE conditions CASCADE;
 NOTICE:  drop cascades to 15 other objects

--- a/tsl/test/expected/cagg_joins-13.out
+++ b/tsl/test/expected/cagg_joins-13.out
@@ -269,7 +269,7 @@ FROM conditions, devices
 WHERE conditions.device_id = devices.device_id
 GROUP BY name, bucket, devices.device_id;
 ERROR:  old format of continuous aggregate is not supported with joins
-HINT:  set timescaledb.finalized to TRUE
+HINT:  Set timescaledb.finalized to TRUE.
 CREATE MATERIALIZED VIEW conditions_summary_daily_cagg
 WITH (timescaledb.continuous, timescaledb.materialized_only = TRUE, timescaledb.finalized = FALSE) AS
 SELECT time_bucket(INTERVAL '1 day', day) AS bucket,
@@ -282,7 +282,7 @@ FROM conditions JOIN devices
 ON conditions.device_id = devices.device_id
 GROUP BY name, bucket, devices.device_id;
 ERROR:  old format of continuous aggregate is not supported with joins
-HINT:  set timescaledb.finalized to TRUE
+HINT:  Set timescaledb.finalized to TRUE.
 CREATE  TABLE mat_t1( a integer, b integer,c TEXT);
 -- Error out LATERAL multiple tables old format
 CREATE MATERIALIZED VIEW mat_m1 WITH (timescaledb.continuous, timescaledb.finalized = false)
@@ -291,7 +291,7 @@ select temperature, count(*) from conditions,
 LATERAL (Select * from mat_t1 where a = conditions.temperature) q
 group by temperature WITH NO DATA;
 ERROR:  old format of continuous aggregate is not supported with joins
-HINT:  set timescaledb.finalized to TRUE
+HINT:  Set timescaledb.finalized to TRUE.
 -- Error out for LATERAL multiple tables in new format
 CREATE MATERIALIZED VIEW mat_m1 WITH (timescaledb.continuous)
 as
@@ -299,7 +299,7 @@ select temperature, count(*) from conditions,
 LATERAL (Select * from mat_t1 where a = conditions.temperature) q
 group by temperature WITH NO DATA;
 ERROR:  invalid continuous aggregate view
-DETAIL:  lateral are not supported in FROM clause
+DETAIL:  Lateral joins are not supported in FROM clause.
 --Error out if from clause has view
 CREATE MATERIALIZED VIEW conditions_summary_daily_view
 WITH (timescaledb.continuous, timescaledb.materialized_only = TRUE) AS
@@ -313,7 +313,7 @@ FROM conditions, devices_view
 WHERE conditions.device_id = devices_view.device_id
 GROUP BY name, bucket, devices_view.device_id;
 ERROR:  invalid continuous aggregate view
-DETAIL:  views are not supported in FROM clause
+DETAIL:  Views are not supported in FROM clause.
 -- Nested CAgg over a CAgg with join
 CREATE MATERIALIZED VIEW cagg_on_cagg
 WITH (timescaledb.continuous, timescaledb.materialized_only=true) AS
@@ -341,7 +341,7 @@ SELECT time_bucket(INTERVAL '1 day', day) AS bucket,
 FROM conditions JOIN (SELECT * FROM devices WHERE location in (SELECT name from cities where currency = 'EUR')) dev ON conditions.device_id = dev.device_id
 GROUP BY name, bucket;
 ERROR:  invalid continuous aggregate view
-DETAIL:  sub-queries are not supported in FROM clause
+DETAIL:  Sub-queries are not supported in FROM clause.
 DROP TABLE cities CASCADE;
 --Error out when join is between two hypertables
 CREATE MATERIALIZED VIEW conditions_summary_daily_ht
@@ -354,7 +354,7 @@ FROM conditions, conditions_dup
 WHERE conditions.device_id = conditions_dup.device_id
 GROUP BY bucket;
 ERROR:  invalid continuous aggregate view
-DETAIL:  multiple hypertables or normal tables are not supported in FROM clause
+DETAIL:  Multiple hypertables or normal tables are not supported in FROM clause.
 --Error out when join is between two normal tables
 CREATE MATERIALIZED VIEW conditions_summary_daily_nt
 WITH (timescaledb.continuous, timescaledb.materialized_only = TRUE) AS
@@ -367,7 +367,7 @@ FROM devices, devices_dup
 WHERE devices.device_id = devices_dup.device_id
 GROUP BY devices.name, devices.location;
 ERROR:  invalid continuous aggregate view
-DETAIL:  multiple hypertables or normal tables are not supported in FROM clause
+DETAIL:  Multiple hypertables or normal tables are not supported in FROM clause.
 --Error out when join is on non-equality condition
 CREATE MATERIALIZED VIEW conditions_summary_daily_unequal
 WITH (timescaledb.continuous, timescaledb.materialized_only = TRUE) AS
@@ -380,7 +380,7 @@ FROM conditions, devices
 WHERE conditions.device_id <> devices.device_id
 GROUP BY name, bucket;
 ERROR:  invalid continuous aggregate view
-DETAIL:  only equality conditions are supported in continuous aggregates
+DETAIL:  Only equality conditions are supported in continuous aggregates.
 --Unsupported join condition
 CREATE MATERIALIZED VIEW conditions_summary_daily_unequal
 WITH (timescaledb.continuous, timescaledb.materialized_only = TRUE) AS
@@ -394,8 +394,8 @@ WHERE conditions.device_id = devices.device_id AND
       conditions.city like '%cow*'
 GROUP BY name, bucket;
 ERROR:  invalid continuous aggregate view
-DETAIL:  unsupported expression in join clause
-HINT:  only equality condition is supported
+DETAIL:  Unsupported expression in join clause.
+HINT:  Only equality conditions are supported in continuous aggregates.
 --Unsupported join condition
 CREATE MATERIALIZED VIEW conditions_summary_daily_unequal
 WITH (timescaledb.continuous, timescaledb.materialized_only = TRUE) AS
@@ -409,8 +409,8 @@ WHERE conditions.device_id = devices.device_id OR
       conditions.city like '%cow*'
 GROUP BY name, bucket;
 ERROR:  invalid continuous aggregate view
-DETAIL:  unsupported expression in join clause
-HINT:  only equality condition is supported
+DETAIL:  Unsupported expression in join clause.
+HINT:  Only equality conditions are supported in continuous aggregates.
 --Error out when join type is not inner
 CREATE MATERIALIZED VIEW conditions_summary_daily_outer
 WITH (timescaledb.continuous, timescaledb.materialized_only = TRUE) AS
@@ -456,7 +456,7 @@ FROM conditions_summary_daily_cagg cagg, conditions
 WHERE cagg.device_id = conditions.device_id
 GROUP BY 1,2,3;
 ERROR:  invalid continuous aggregate view
-DETAIL:  views are not supported in FROM clause
+DETAIL:  Views are not supported in FROM clause.
 \set VERBOSITY terse
 DROP TABLE conditions CASCADE;
 NOTICE:  drop cascades to 24 other objects

--- a/tsl/test/expected/cagg_joins-14.out
+++ b/tsl/test/expected/cagg_joins-14.out
@@ -269,7 +269,7 @@ FROM conditions, devices
 WHERE conditions.device_id = devices.device_id
 GROUP BY name, bucket, devices.device_id;
 ERROR:  old format of continuous aggregate is not supported with joins
-HINT:  set timescaledb.finalized to TRUE
+HINT:  Set timescaledb.finalized to TRUE.
 CREATE MATERIALIZED VIEW conditions_summary_daily_cagg
 WITH (timescaledb.continuous, timescaledb.materialized_only = TRUE, timescaledb.finalized = FALSE) AS
 SELECT time_bucket(INTERVAL '1 day', day) AS bucket,
@@ -282,7 +282,7 @@ FROM conditions JOIN devices
 ON conditions.device_id = devices.device_id
 GROUP BY name, bucket, devices.device_id;
 ERROR:  old format of continuous aggregate is not supported with joins
-HINT:  set timescaledb.finalized to TRUE
+HINT:  Set timescaledb.finalized to TRUE.
 CREATE  TABLE mat_t1( a integer, b integer,c TEXT);
 -- Error out LATERAL multiple tables old format
 CREATE MATERIALIZED VIEW mat_m1 WITH (timescaledb.continuous, timescaledb.finalized = false)
@@ -291,7 +291,7 @@ select temperature, count(*) from conditions,
 LATERAL (Select * from mat_t1 where a = conditions.temperature) q
 group by temperature WITH NO DATA;
 ERROR:  old format of continuous aggregate is not supported with joins
-HINT:  set timescaledb.finalized to TRUE
+HINT:  Set timescaledb.finalized to TRUE.
 -- Error out for LATERAL multiple tables in new format
 CREATE MATERIALIZED VIEW mat_m1 WITH (timescaledb.continuous)
 as
@@ -299,7 +299,7 @@ select temperature, count(*) from conditions,
 LATERAL (Select * from mat_t1 where a = conditions.temperature) q
 group by temperature WITH NO DATA;
 ERROR:  invalid continuous aggregate view
-DETAIL:  lateral are not supported in FROM clause
+DETAIL:  Lateral joins are not supported in FROM clause.
 --Error out if from clause has view
 CREATE MATERIALIZED VIEW conditions_summary_daily_view
 WITH (timescaledb.continuous, timescaledb.materialized_only = TRUE) AS
@@ -313,7 +313,7 @@ FROM conditions, devices_view
 WHERE conditions.device_id = devices_view.device_id
 GROUP BY name, bucket, devices_view.device_id;
 ERROR:  invalid continuous aggregate view
-DETAIL:  views are not supported in FROM clause
+DETAIL:  Views are not supported in FROM clause.
 -- Nested CAgg over a CAgg with join
 CREATE MATERIALIZED VIEW cagg_on_cagg
 WITH (timescaledb.continuous, timescaledb.materialized_only=true) AS
@@ -341,7 +341,7 @@ SELECT time_bucket(INTERVAL '1 day', day) AS bucket,
 FROM conditions JOIN (SELECT * FROM devices WHERE location in (SELECT name from cities where currency = 'EUR')) dev ON conditions.device_id = dev.device_id
 GROUP BY name, bucket;
 ERROR:  invalid continuous aggregate view
-DETAIL:  sub-queries are not supported in FROM clause
+DETAIL:  Sub-queries are not supported in FROM clause.
 DROP TABLE cities CASCADE;
 --Error out when join is between two hypertables
 CREATE MATERIALIZED VIEW conditions_summary_daily_ht
@@ -354,7 +354,7 @@ FROM conditions, conditions_dup
 WHERE conditions.device_id = conditions_dup.device_id
 GROUP BY bucket;
 ERROR:  invalid continuous aggregate view
-DETAIL:  multiple hypertables or normal tables are not supported in FROM clause
+DETAIL:  Multiple hypertables or normal tables are not supported in FROM clause.
 --Error out when join is between two normal tables
 CREATE MATERIALIZED VIEW conditions_summary_daily_nt
 WITH (timescaledb.continuous, timescaledb.materialized_only = TRUE) AS
@@ -367,7 +367,7 @@ FROM devices, devices_dup
 WHERE devices.device_id = devices_dup.device_id
 GROUP BY devices.name, devices.location;
 ERROR:  invalid continuous aggregate view
-DETAIL:  multiple hypertables or normal tables are not supported in FROM clause
+DETAIL:  Multiple hypertables or normal tables are not supported in FROM clause.
 --Error out when join is on non-equality condition
 CREATE MATERIALIZED VIEW conditions_summary_daily_unequal
 WITH (timescaledb.continuous, timescaledb.materialized_only = TRUE) AS
@@ -380,7 +380,7 @@ FROM conditions, devices
 WHERE conditions.device_id <> devices.device_id
 GROUP BY name, bucket;
 ERROR:  invalid continuous aggregate view
-DETAIL:  only equality conditions are supported in continuous aggregates
+DETAIL:  Only equality conditions are supported in continuous aggregates.
 --Unsupported join condition
 CREATE MATERIALIZED VIEW conditions_summary_daily_unequal
 WITH (timescaledb.continuous, timescaledb.materialized_only = TRUE) AS
@@ -394,8 +394,8 @@ WHERE conditions.device_id = devices.device_id AND
       conditions.city like '%cow*'
 GROUP BY name, bucket;
 ERROR:  invalid continuous aggregate view
-DETAIL:  unsupported expression in join clause
-HINT:  only equality condition is supported
+DETAIL:  Unsupported expression in join clause.
+HINT:  Only equality conditions are supported in continuous aggregates.
 --Unsupported join condition
 CREATE MATERIALIZED VIEW conditions_summary_daily_unequal
 WITH (timescaledb.continuous, timescaledb.materialized_only = TRUE) AS
@@ -409,8 +409,8 @@ WHERE conditions.device_id = devices.device_id OR
       conditions.city like '%cow*'
 GROUP BY name, bucket;
 ERROR:  invalid continuous aggregate view
-DETAIL:  unsupported expression in join clause
-HINT:  only equality condition is supported
+DETAIL:  Unsupported expression in join clause.
+HINT:  Only equality conditions are supported in continuous aggregates.
 --Error out when join type is not inner
 CREATE MATERIALIZED VIEW conditions_summary_daily_outer
 WITH (timescaledb.continuous, timescaledb.materialized_only = TRUE) AS
@@ -456,7 +456,7 @@ FROM conditions_summary_daily_cagg cagg, conditions
 WHERE cagg.device_id = conditions.device_id
 GROUP BY 1,2,3;
 ERROR:  invalid continuous aggregate view
-DETAIL:  views are not supported in FROM clause
+DETAIL:  Views are not supported in FROM clause.
 \set VERBOSITY terse
 DROP TABLE conditions CASCADE;
 NOTICE:  drop cascades to 24 other objects

--- a/tsl/test/expected/cagg_joins-15.out
+++ b/tsl/test/expected/cagg_joins-15.out
@@ -269,7 +269,7 @@ FROM conditions, devices
 WHERE conditions.device_id = devices.device_id
 GROUP BY name, bucket, devices.device_id;
 ERROR:  old format of continuous aggregate is not supported with joins
-HINT:  set timescaledb.finalized to TRUE
+HINT:  Set timescaledb.finalized to TRUE.
 CREATE MATERIALIZED VIEW conditions_summary_daily_cagg
 WITH (timescaledb.continuous, timescaledb.materialized_only = TRUE, timescaledb.finalized = FALSE) AS
 SELECT time_bucket(INTERVAL '1 day', day) AS bucket,
@@ -282,7 +282,7 @@ FROM conditions JOIN devices
 ON conditions.device_id = devices.device_id
 GROUP BY name, bucket, devices.device_id;
 ERROR:  old format of continuous aggregate is not supported with joins
-HINT:  set timescaledb.finalized to TRUE
+HINT:  Set timescaledb.finalized to TRUE.
 CREATE  TABLE mat_t1( a integer, b integer,c TEXT);
 -- Error out LATERAL multiple tables old format
 CREATE MATERIALIZED VIEW mat_m1 WITH (timescaledb.continuous, timescaledb.finalized = false)
@@ -291,7 +291,7 @@ select temperature, count(*) from conditions,
 LATERAL (Select * from mat_t1 where a = conditions.temperature) q
 group by temperature WITH NO DATA;
 ERROR:  old format of continuous aggregate is not supported with joins
-HINT:  set timescaledb.finalized to TRUE
+HINT:  Set timescaledb.finalized to TRUE.
 -- Error out for LATERAL multiple tables in new format
 CREATE MATERIALIZED VIEW mat_m1 WITH (timescaledb.continuous)
 as
@@ -299,7 +299,7 @@ select temperature, count(*) from conditions,
 LATERAL (Select * from mat_t1 where a = conditions.temperature) q
 group by temperature WITH NO DATA;
 ERROR:  invalid continuous aggregate view
-DETAIL:  lateral are not supported in FROM clause
+DETAIL:  Lateral joins are not supported in FROM clause.
 --Error out if from clause has view
 CREATE MATERIALIZED VIEW conditions_summary_daily_view
 WITH (timescaledb.continuous, timescaledb.materialized_only = TRUE) AS
@@ -313,7 +313,7 @@ FROM conditions, devices_view
 WHERE conditions.device_id = devices_view.device_id
 GROUP BY name, bucket, devices_view.device_id;
 ERROR:  invalid continuous aggregate view
-DETAIL:  views are not supported in FROM clause
+DETAIL:  Views are not supported in FROM clause.
 -- Nested CAgg over a CAgg with join
 CREATE MATERIALIZED VIEW cagg_on_cagg
 WITH (timescaledb.continuous, timescaledb.materialized_only=true) AS
@@ -341,7 +341,7 @@ SELECT time_bucket(INTERVAL '1 day', day) AS bucket,
 FROM conditions JOIN (SELECT * FROM devices WHERE location in (SELECT name from cities where currency = 'EUR')) dev ON conditions.device_id = dev.device_id
 GROUP BY name, bucket;
 ERROR:  invalid continuous aggregate view
-DETAIL:  sub-queries are not supported in FROM clause
+DETAIL:  Sub-queries are not supported in FROM clause.
 DROP TABLE cities CASCADE;
 --Error out when join is between two hypertables
 CREATE MATERIALIZED VIEW conditions_summary_daily_ht
@@ -354,7 +354,7 @@ FROM conditions, conditions_dup
 WHERE conditions.device_id = conditions_dup.device_id
 GROUP BY bucket;
 ERROR:  invalid continuous aggregate view
-DETAIL:  multiple hypertables or normal tables are not supported in FROM clause
+DETAIL:  Multiple hypertables or normal tables are not supported in FROM clause.
 --Error out when join is between two normal tables
 CREATE MATERIALIZED VIEW conditions_summary_daily_nt
 WITH (timescaledb.continuous, timescaledb.materialized_only = TRUE) AS
@@ -367,7 +367,7 @@ FROM devices, devices_dup
 WHERE devices.device_id = devices_dup.device_id
 GROUP BY devices.name, devices.location;
 ERROR:  invalid continuous aggregate view
-DETAIL:  multiple hypertables or normal tables are not supported in FROM clause
+DETAIL:  Multiple hypertables or normal tables are not supported in FROM clause.
 --Error out when join is on non-equality condition
 CREATE MATERIALIZED VIEW conditions_summary_daily_unequal
 WITH (timescaledb.continuous, timescaledb.materialized_only = TRUE) AS
@@ -380,7 +380,7 @@ FROM conditions, devices
 WHERE conditions.device_id <> devices.device_id
 GROUP BY name, bucket;
 ERROR:  invalid continuous aggregate view
-DETAIL:  only equality conditions are supported in continuous aggregates
+DETAIL:  Only equality conditions are supported in continuous aggregates.
 --Unsupported join condition
 CREATE MATERIALIZED VIEW conditions_summary_daily_unequal
 WITH (timescaledb.continuous, timescaledb.materialized_only = TRUE) AS
@@ -394,8 +394,8 @@ WHERE conditions.device_id = devices.device_id AND
       conditions.city like '%cow*'
 GROUP BY name, bucket;
 ERROR:  invalid continuous aggregate view
-DETAIL:  unsupported expression in join clause
-HINT:  only equality condition is supported
+DETAIL:  Unsupported expression in join clause.
+HINT:  Only equality conditions are supported in continuous aggregates.
 --Unsupported join condition
 CREATE MATERIALIZED VIEW conditions_summary_daily_unequal
 WITH (timescaledb.continuous, timescaledb.materialized_only = TRUE) AS
@@ -409,8 +409,8 @@ WHERE conditions.device_id = devices.device_id OR
       conditions.city like '%cow*'
 GROUP BY name, bucket;
 ERROR:  invalid continuous aggregate view
-DETAIL:  unsupported expression in join clause
-HINT:  only equality condition is supported
+DETAIL:  Unsupported expression in join clause.
+HINT:  Only equality conditions are supported in continuous aggregates.
 --Error out when join type is not inner
 CREATE MATERIALIZED VIEW conditions_summary_daily_outer
 WITH (timescaledb.continuous, timescaledb.materialized_only = TRUE) AS
@@ -456,7 +456,7 @@ FROM conditions_summary_daily_cagg cagg, conditions
 WHERE cagg.device_id = conditions.device_id
 GROUP BY 1,2,3;
 ERROR:  invalid continuous aggregate view
-DETAIL:  views are not supported in FROM clause
+DETAIL:  Views are not supported in FROM clause.
 \set VERBOSITY terse
 DROP TABLE conditions CASCADE;
 NOTICE:  drop cascades to 24 other objects


### PR DESCRIPTION
Several error messages for continuous aggregates are not following the error message style guidelines at
https://www.postgresql.org/docs/current/error-style-guide.html

In particular, they do not write the hints and detailed messages as full sentences.

Disable-check: force-changelog-changed