### PR TITLE
Fix timescaledb_experimental.policies duplicates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ accidentally triggering the load of a previous DB version.**
 * #5499 Do not segfault on large histogram() parameters
 * #5500 Fix when no FROM clause in continuous aggregate definition
 * #5544 Fix refresh from beginning of Continuous Aggregate with variable time bucket
+* #5556 Fix duplicated entries on timescaledb_experimental.policies view
 
 **Thanks**
 * @nikolaps for reporting an issue with the COPY fetcher
@@ -41,6 +42,7 @@ accidentally triggering the load of a previous DB version.**
 * @kovetskiy and @DZDomi for reporting peformance regression in Realtime Continuous Aggregates
 * @geezhu for reporting issue on segfault in historgram()
 * @H25E for reporting error refreshing from beginning of a Continuous Aggregate with variable time bucket
+* @mwahlhuetter for reporting issue with duplicated entries on timescaledb_experimental.policies view
 
 ## 2.10.1 (2023-03-07)
 

--- a/sql/views_experimental.sql
+++ b/sql/views_experimental.sql
@@ -26,18 +26,16 @@ GROUP BY h.id, c.id, hypertable_schema, hypertable_name, chunk_schema, chunk_nam
 ORDER BY h.id, c.id, hypertable_schema, hypertable_name, chunk_schema, chunk_name;
 
 CREATE OR REPLACE VIEW timescaledb_experimental.policies AS
-SELECT ca.view_name AS relation_name,
-  ca.view_schema AS relation_schema,
+SELECT ca.user_view_name AS relation_name,
+  ca.user_view_schema AS relation_schema,
   j.schedule_interval,
   j.proc_schema,
   j.proc_name,
   j.config,
   ht.schema_name AS hypertable_schema,
   ht.table_name AS hypertable_name
-FROM _timescaledb_config.bgw_job j, timescaledb_information.continuous_aggregates ca,
- _timescaledb_catalog.hypertable ht
-WHERE ht.id = j.hypertable_id
-AND ca.view_schema = hypertable_schema
-AND ca.hypertable_name <> ht.table_name;
+FROM _timescaledb_config.bgw_job j
+  JOIN _timescaledb_catalog.continuous_agg ca ON ca.mat_hypertable_id = j.hypertable_id
+  JOIN _timescaledb_catalog.hypertable ht ON ht.id = ca.mat_hypertable_id;
 
 GRANT SELECT ON ALL TABLES IN SCHEMA timescaledb_experimental TO PUBLIC;

--- a/tsl/test/expected/cagg_policy.out
+++ b/tsl/test/expected/cagg_policy.out
@@ -104,6 +104,41 @@ SELECT remove_retention_policy('int_tab');
  
 (1 row)
 
+-- Test for duplicated policies (issue #5492)
+CREATE MATERIALIZED VIEW mat_m2( a, sumb )
+WITH (timescaledb.continuous, timescaledb.materialized_only=true)
+as
+SELECT a, sum(b)
+FROM int_tab
+GROUP BY time_bucket(1, a), a WITH NO DATA;
+-- add refresh policy
+SELECT timescaledb_experimental.add_policies('mat_m2', refresh_start_offset => 10, refresh_end_offset => 1);
+ add_policies 
+--------------
+ t
+(1 row)
+
+SELECT timescaledb_experimental.show_policies('mat_m2');
+                                                                show_policies                                                                
+---------------------------------------------------------------------------------------------------------------------------------------------
+ {"policy_name": "policy_refresh_continuous_aggregate", "refresh_interval": "@ 1 hour", "refresh_end_offset": 1, "refresh_start_offset": 10}
+(1 row)
+
+-- check for only one refresh policy for each cagg
+SELECT * FROM timescaledb_experimental.policies WHERE proc_name ~ 'refresh' ORDER BY relation_name, proc_name;
+ relation_name | relation_schema | schedule_interval |      proc_schema      |              proc_name              |                            config                             |   hypertable_schema   |      hypertable_name       
+---------------+-----------------+-------------------+-----------------------+-------------------------------------+---------------------------------------------------------------+-----------------------+----------------------------
+ mat_m1        | public          | @ 1 hour          | _timescaledb_internal | policy_refresh_continuous_aggregate | {"end_offset": 1, "start_offset": 10, "mat_hypertable_id": 2} | _timescaledb_internal | _materialized_hypertable_2
+ mat_m2        | public          | @ 1 hour          | _timescaledb_internal | policy_refresh_continuous_aggregate | {"end_offset": 1, "start_offset": 10, "mat_hypertable_id": 4} | _timescaledb_internal | _materialized_hypertable_4
+(2 rows)
+
+SELECT timescaledb_experimental.remove_all_policies('mat_m2');
+ remove_all_policies 
+---------------------
+ t
+(1 row)
+
+DROP MATERIALIZED VIEW mat_m2;
 -- Alter policies
 SELECT timescaledb_experimental.alter_policies('mat_m1',  refresh_start_offset => 11, compress_after=>13, drop_after => 25);
  alter_policies 
@@ -197,7 +232,7 @@ SELECT add_continuous_aggregate_policy('mat_m1', 20, 10, '1h'::interval) as job_
 --adding again should warn/error
 SELECT add_continuous_aggregate_policy('mat_m1', 20, 10, '1h'::interval, if_not_exists=>false);
 ERROR:  continuous aggregate policy already exists for "mat_m1"
-DETAIL:  Only one continuous aggregate policy can be created per continuous aggregate and a policy with job id 1008 already exists for "mat_m1".
+DETAIL:  Only one continuous aggregate policy can be created per continuous aggregate and a policy with job id 1009 already exists for "mat_m1".
 SELECT add_continuous_aggregate_policy('mat_m1', 20, 15, '1h'::interval, if_not_exists=>true);
 WARNING:  continuous aggregate policy already exists for "mat_m1"
 DETAIL:  A policy already exists with different arguments.
@@ -272,7 +307,7 @@ SELECT create_hypertable('continuous_agg_max_mat_date', 'time');
 NOTICE:  adding not-null constraint to column "time"
             create_hypertable             
 ------------------------------------------
- (4,public,continuous_agg_max_mat_date,t)
+ (5,public,continuous_agg_max_mat_date,t)
 (1 row)
 
 CREATE MATERIALIZED VIEW max_mat_view_date
@@ -488,7 +523,7 @@ SELECT timescaledb_experimental.show_policies('max_mat_view_date');
 SELECT add_retention_policy('continuous_agg_max_mat_date', '25 days'::interval);
  add_retention_policy 
 ----------------------
-                 1024
+                 1025
 (1 row)
 
 SELECT timescaledb_experimental.alter_policies('max_mat_view_date', refresh_start_offset =>'25 days'::interval);
@@ -545,8 +580,8 @@ SELECT timescaledb_experimental.show_policies('max_mat_view_date');
 SELECT * FROM timescaledb_experimental.policies ORDER BY relation_name, proc_name;
    relation_name   | relation_schema | schedule_interval |      proc_schema      |              proc_name              |                                     config                                     |   hypertable_schema   |      hypertable_name       
 -------------------+-----------------+-------------------+-----------------------+-------------------------------------+--------------------------------------------------------------------------------+-----------------------+----------------------------
- max_mat_view_date | public          | @ 1 hour          | _timescaledb_internal | policy_refresh_continuous_aggregate | {"end_offset": "@ 1 day", "start_offset": "@ 15 days", "mat_hypertable_id": 5} | _timescaledb_internal | _materialized_hypertable_5
- max_mat_view_date | public          | @ 1 day           | _timescaledb_internal | policy_retention                    | {"drop_after": "@ 25 days", "hypertable_id": 5}                                | _timescaledb_internal | _materialized_hypertable_5
+ max_mat_view_date | public          | @ 1 hour          | _timescaledb_internal | policy_refresh_continuous_aggregate | {"end_offset": "@ 1 day", "start_offset": "@ 15 days", "mat_hypertable_id": 6} | _timescaledb_internal | _materialized_hypertable_6
+ max_mat_view_date | public          | @ 1 day           | _timescaledb_internal | policy_retention                    | {"drop_after": "@ 25 days", "hypertable_id": 6}                                | _timescaledb_internal | _materialized_hypertable_6
 (2 rows)
 
 SELECT timescaledb_experimental.remove_all_policies(NULL); -- should fail
@@ -578,13 +613,13 @@ SELECT add_job('custom_func','1h', config:='{"type":"function"}'::jsonb, initial
 SELECT _timescaledb_internal.alter_job_set_hypertable_id( :job_id, 'max_mat_view_date'::regclass);
  alter_job_set_hypertable_id 
 -----------------------------
-                        1026
+                        1027
 (1 row)
 
 SELECT * FROM timescaledb_information.jobs WHERE job_id != 1 ORDER BY 1;
  job_id |      application_name      | schedule_interval | max_runtime | max_retries | retry_period | proc_schema |  proc_name  |       owner       | scheduled | fixed_schedule |        config        |          next_start          |        initial_start         |   hypertable_schema   |      hypertable_name       | check_schema | check_name 
 --------+----------------------------+-------------------+-------------+-------------+--------------+-------------+-------------+-------------------+-----------+----------------+----------------------+------------------------------+------------------------------+-----------------------+----------------------------+--------------+------------
-   1026 | User-Defined Action [1026] | @ 1 hour          | @ 0         |          -1 | @ 5 mins     | public      | custom_func | default_perm_user | t         | t              | {"type": "function"} | Fri Dec 31 16:00:00 1999 PST | Fri Dec 31 16:00:00 1999 PST | _timescaledb_internal | _materialized_hypertable_5 |              | 
+   1027 | User-Defined Action [1027] | @ 1 hour          | @ 0         |          -1 | @ 5 mins     | public      | custom_func | default_perm_user | t         | t              | {"type": "function"} | Fri Dec 31 16:00:00 1999 PST | Fri Dec 31 16:00:00 1999 PST | _timescaledb_internal | _materialized_hypertable_6 |              | 
 (1 row)
 
 SELECT timescaledb_experimental.remove_all_policies('max_mat_view_date', true); -- ignore custom job
@@ -630,7 +665,7 @@ DETAIL:  The start and end offsets must cover at least two buckets in the valid 
 SELECT add_continuous_aggregate_policy('max_mat_view_date', '13 days', '-1 day', '1 day'::interval);
  add_continuous_aggregate_policy 
 ---------------------------------
-                            1027
+                            1028
 (1 row)
 
 SELECT remove_continuous_aggregate_policy('max_mat_view_date');
@@ -643,7 +678,7 @@ SELECT remove_continuous_aggregate_policy('max_mat_view_date');
 SELECT add_continuous_aggregate_policy('max_mat_view_date', NULL, NULL, '1 day'::interval);
  add_continuous_aggregate_policy 
 ---------------------------------
-                            1028
+                            1029
 (1 row)
 
 SELECT remove_continuous_aggregate_policy('max_mat_view_date');
@@ -657,7 +692,7 @@ SELECT config FROM _timescaledb_config.bgw_job
 WHERE id = :job_id;
                                      config                                     
 --------------------------------------------------------------------------------
- {"end_offset": "@ 1 day", "start_offset": "@ 15 days", "mat_hypertable_id": 5}
+ {"end_offset": "@ 1 day", "start_offset": "@ 15 days", "mat_hypertable_id": 6}
 (1 row)
 
 INSERT INTO continuous_agg_max_mat_date
@@ -673,7 +708,7 @@ WARNING:  column type "timestamp without time zone" used for "time" does not fol
 NOTICE:  adding not-null constraint to column "time"
            create_hypertable           
 ---------------------------------------
- (7,public,continuous_agg_timestamp,t)
+ (8,public,continuous_agg_timestamp,t)
 (1 row)
 
 CREATE MATERIALIZED VIEW max_mat_view_timestamp
@@ -686,7 +721,7 @@ CREATE MATERIALIZED VIEW max_mat_view_timestamp
 SELECT add_continuous_aggregate_policy('max_mat_view_timestamp', '1000000 years', '1 day' , '1 h'::interval);
  add_continuous_aggregate_policy 
 ---------------------------------
-                            1030
+                            1031
 (1 row)
 
 SELECT remove_continuous_aggregate_policy('max_mat_view_timestamp');
@@ -716,7 +751,7 @@ SELECT config FROM _timescaledb_config.bgw_job
 WHERE id = :job_id;
                                      config                                      
 ---------------------------------------------------------------------------------
- {"end_offset": "@ 1 hour", "start_offset": "@ 15 days", "mat_hypertable_id": 8}
+ {"end_offset": "@ 1 hour", "start_offset": "@ 15 days", "mat_hypertable_id": 9}
 (1 row)
 
 \c :TEST_DBNAME :ROLE_SUPERUSER
@@ -1051,13 +1086,13 @@ ERROR:  compress_after value for compression policy should be greater than the s
 SELECT add_compression_policy('mat_smallint', 5::smallint);
  add_compression_policy 
 ------------------------
-                   1050
+                   1051
 (1 row)
 
 SELECT add_compression_policy('mat_bigint', 20::bigint);
  add_compression_policy 
 ------------------------
-                   1051
+                   1052
 (1 row)
 
 -- end of coverage tests
@@ -1074,7 +1109,7 @@ CREATE TABLE metrics (
 SELECT create_hypertable('metrics', 'time');
    create_hypertable   
 -----------------------
- (17,public,metrics,t)
+ (18,public,metrics,t)
 (1 row)
 
 INSERT INTO metrics (time, device_id, device_id_peer, v0, v1, v2, v3)
@@ -1091,7 +1126,7 @@ ALTER TABLE metrics SET ( timescaledb.compress );
 SELECT compress_chunk(ch) FROM show_chunks('metrics') ch;
               compress_chunk              
 ------------------------------------------
- _timescaledb_internal._hyper_17_19_chunk
+ _timescaledb_internal._hyper_18_19_chunk
 (1 row)
 
 CREATE MATERIALIZED VIEW metrics_cagg WITH (timescaledb.continuous,
@@ -1117,7 +1152,7 @@ NOTICE:  defaulting compress_orderby to dayb
 SELECT add_compression_policy('metrics_cagg', '8 day'::interval) AS "COMP_JOB" ;
  COMP_JOB 
 ----------
-     1053
+     1054
 (1 row)
 
 SELECT remove_compression_policy('metrics_cagg');
@@ -1183,7 +1218,7 @@ cpu DOUBLE PRECISION);
 SELECT create_hypertable('sensor_data','time');
      create_hypertable     
 ---------------------------
- (21,public,sensor_data,t)
+ (22,public,sensor_data,t)
 (1 row)
 
 INSERT INTO sensor_data(time, sensor_id, cpu, temperature)


### PR DESCRIPTION
Commit 16fdb6ca5e introduced `timescaledb_experimental.policies` view to expose the Continuous Aggregate policies but the current JOINS over our catalog are not accurate.

Fixed it by properly JOIN the underlying catalog tables to expose the correct information without duplicates about the Continuous Aggregate policies.

Fixes #5492