### PR TITLE
Index scan support during UPDATE/DELETE on compressed hypertables.

### DIFF
--- a/.unreleased/PR_5586
+++ b/.unreleased/PR_5586
@@ -1,0 +1,1 @@
+Implements: #5586 Index scan support during UPDATE/DELETE

--- a/tsl/src/compression/compression.c
+++ b/tsl/src/compression/compression.c
@@ -11,6 +11,7 @@
 #include <access/heapam.h>
 #include <access/htup_details.h>
 #include <access/multixact.h>
+#include <access/valid.h>
 #include <access/xact.h>
 #include <catalog/heap.h>
 #include <catalog/index.h>
@@ -19,6 +20,7 @@
 #include <catalog/pg_attribute.h>
 #include <catalog/pg_type.h>
 #include <common/base64.h>
+#include <executor/nodeIndexscan.h>
 #include <executor/tuptable.h>
 #include <funcapi.h>
 #include <libpq/pqformat.h>
@@ -2438,6 +2440,248 @@ add_filter_column_strategy(char *column_name, StrategyNumber strategy, Const *va
 
 	return segment_filter;
 }
+
+/*
+ * Convert an expression to a Var referencing the index column.
+ * This method does following:
+ * 1. Change attribute numbers to match against index column position.
+ * 2. Set Var nodes varno to INDEX_VAR.
+ *
+ * For details refer: match_clause_to_index() and fix_indexqual_operand()
+ */
+static void
+fix_index_qual(Relation comp_chunk_rel, Relation index_rel, Var *var, List **pred,
+			   char *column_name, Node *node, Oid opno)
+{
+	int i = 0;
+	Bitmapset *key_columns = RelationGetIndexAttrBitmap(comp_chunk_rel, INDEX_ATTR_BITMAP_ALL);
+
+	for (i = 0; i < index_rel->rd_index->indnatts; i++)
+	{
+		AttrNumber attnum = index_rel->rd_index->indkey.values[i];
+		char *colname = get_attname(RelationGetRelid(comp_chunk_rel), attnum, true);
+		if (strcmp(colname, column_name) == 0)
+		{
+			Oid opfamily = index_rel->rd_opfamily[i];
+			/* assert if operator opno is not a member of opfamily */
+			if (opno && !op_in_opfamily(opno, opfamily))
+				Assert(false);
+			var->varattno = i + 1;
+			break;
+		}
+	}
+	/* mark this as an index column */
+	var->varno = INDEX_VAR;
+	i = -1;
+	/*
+	 * save predicates in the same order as that of columns
+	 * defined in the index.
+	 */
+	while ((i = bms_next_member(key_columns, i)) > 0)
+	{
+		AttrNumber attno = i + FirstLowInvalidHeapAttributeNumber;
+		char *attname = get_attname(comp_chunk_rel->rd_id, attno, false);
+		if (strcmp(attname, column_name) == 0)
+		{
+			pred[attno] = lappend(pred[attno], node);
+			break;
+		}
+	}
+}
+
+/*
+ * This method will fix index qualifiers and also reorder
+ * index quals to match against the column order in the index.
+ *
+ * For example:
+ * for a given condition like "WHERE y = 10 AND x = 8"
+ * if matched index is defined as index (a,x,y)
+ * then WHERE condition should be rearraged as
+ * "WHERE x = 8 AND y = 10"
+ *
+ * This method will return, fixed and reordered index
+ * qualifier list.
+ */
+static List *
+fix_and_reorder_index_filters(Relation comp_chunk_rel, Relation index_rel,
+							  List *segmentby_predicates, List *index_filters)
+{
+	List *ordered_index_filters = NIL;
+	List *idx_filters[INDEX_MAX_KEYS];
+
+	for (int i = 0; i < INDEX_MAX_KEYS; i++)
+		idx_filters[i] = NIL;
+
+	ListCell *lp;
+	ListCell *lf;
+	forboth (lp, segmentby_predicates, lf, index_filters)
+	{
+		Node *node = lfirst(lp);
+		SegmentFilter *sf = lfirst(lf);
+
+		if (node == NULL)
+			continue;
+
+		Var *var;
+		Oid opno;
+		switch (nodeTag(node))
+		{
+			case T_OpExpr:
+			{
+				OpExpr *opexpr = (OpExpr *) node;
+				Expr *leftop, *rightop;
+				Const *arg_value;
+				bool switch_operands = false;
+
+				opno = opexpr->opno;
+				leftop = linitial(opexpr->args);
+				rightop = lsecond(opexpr->args);
+
+				if (IsA(leftop, RelabelType))
+					leftop = ((RelabelType *) leftop)->arg;
+				if (IsA(rightop, RelabelType))
+					rightop = ((RelabelType *) rightop)->arg;
+
+				if (IsA(leftop, Var) && IsA(rightop, Const))
+				{
+					var = (Var *) leftop;
+					arg_value = (Const *) rightop;
+				}
+				else if (IsA(rightop, Var) && IsA(leftop, Const))
+				{
+					switch_operands = true;
+					var = (Var *) rightop;
+					arg_value = (Const *) leftop;
+				}
+				else
+					continue;
+				OpExpr *newclause = NULL;
+				Expr *newvar = NULL;
+				newclause = makeNode(OpExpr);
+				memcpy(newclause, opexpr, sizeof(OpExpr));
+				newvar = (Expr *) copyObject(var);
+				/*
+				 * Index quals always should be in <operand> op <value> form. If
+				 * user specifies qual as <value> op <operand>, we will convert to
+				 * <operand> op <value> form and change opno and opfamily accordingly
+				 */
+				linitial(newclause->args) = newvar;
+				lsecond(newclause->args) = arg_value;
+				if (switch_operands)
+				{
+					newclause->opno = get_commutator(opno);
+					newclause->opfuncid = get_opcode(newclause->opno);
+					opno = newclause->opno;
+				}
+				fix_index_qual(comp_chunk_rel,
+							   index_rel,
+							   (Var *) newvar,
+							   idx_filters,
+							   sf->column_name.data,
+							   (Node *) newclause,
+							   opno);
+			}
+			break;
+			case T_NullTest:
+			{
+				NullTest *ntest = (NullTest *) node;
+				if (IsA(ntest->arg, Var))
+				{
+					var = (Var *) ntest->arg;
+					OpExpr *newclause = copyObject((OpExpr *) node);
+					Expr *newvar = (Expr *) copyObject(var);
+					((NullTest *) newclause)->arg = newvar;
+					fix_index_qual(comp_chunk_rel,
+								   index_rel,
+								   (Var *) newvar,
+								   idx_filters,
+								   sf->column_name.data,
+								   (Node *) newclause,
+								   0);
+				}
+			}
+			break;
+			default:
+				break;
+		}
+	}
+	/* Reorder the Var nodes to align with column order in indexes */
+	for (int i = 0; i < INDEX_MAX_KEYS; i++)
+	{
+		if (idx_filters[i])
+		{
+			ListCell *c;
+			foreach (c, idx_filters[i])
+			{
+				ordered_index_filters = lappend(ordered_index_filters, lfirst(c));
+			}
+		}
+	}
+	return ordered_index_filters;
+}
+
+/*
+ * A compressed chunk can have multiple indexes. For a given list
+ * of columns in index_filters, find the matching index which has
+ * all of the columns.
+ * Return matching index if found else return NULL.
+ *
+ * Note: This method will not find the best matching index.
+ * For example
+ * for a given condition like "WHERE X = 10 AND Y = 8"
+ * if there are multiple indexes like
+ * 1. index (a,b,c,x)
+ * 2. index (a,x,y)
+ * 3. index (x)
+ * 4. index (x,y)
+ * In this case 2nd index is returned.
+ */
+static Relation
+find_matching_index(Relation comp_chunk_rel, List *index_filters)
+{
+	List *index_oids;
+	ListCell *lc;
+	int total_filters = index_filters->length;
+
+	/* get list of indexes defined on compressed chunk */
+	index_oids = RelationGetIndexList(comp_chunk_rel);
+	foreach (lc, index_oids)
+	{
+		int match_count = 0;
+		Relation index_rel = index_open(lfirst_oid(lc), AccessShareLock);
+		if (index_rel->rd_index->indnatts < total_filters)
+		{
+			/* skip all indexes which can never match */
+			index_close(index_rel, AccessShareLock);
+			continue;
+		}
+		ListCell *li;
+		foreach (li, index_filters)
+		{
+			for (int i = 0; i < index_rel->rd_index->indnatts; i++)
+			{
+				AttrNumber attnum = index_rel->rd_index->indkey.values[i];
+				char *attname = get_attname(RelationGetRelid(comp_chunk_rel), attnum, false);
+				SegmentFilter *sf = lfirst(li);
+				/* ensure column exists in index relation */
+				if (!strcmp(attname, sf->column_name.data))
+				{
+					match_count++;
+					break;
+				}
+			}
+		}
+		if (match_count == total_filters)
+		{
+			elog(DEBUG2, "index \"%s\" is used for scan. ", RelationGetRelationName(index_rel));
+			/* found index which has all columns specified in WHERE */
+			return index_rel;
+		}
+		index_close(index_rel, AccessShareLock);
+	}
+	return NULL;
+}
+
 /*
  * This method will evaluate the predicates, extract
  * left and right operands, check if one of the operands is
@@ -2448,7 +2692,8 @@ add_filter_column_strategy(char *column_name, StrategyNumber strategy, Const *va
  * be used to build scan keys later.
  */
 static void
-fill_predicate_context(Chunk *ch, List *predicates, List **filters, List **is_null)
+fill_predicate_context(Chunk *ch, List *predicates, List **filters, List **index_filters,
+					   List **segmentby_predicates, List **is_null)
 {
 	ListCell *lc;
 	foreach (lc, predicates)
@@ -2505,12 +2750,13 @@ fill_predicate_context(Chunk *ch, List *predicates, List **filters, List **is_nu
 						{
 							/* save segment by column name and its corresponding value specified in
 							 * WHERE */
-							*filters =
-								lappend(*filters,
+							*index_filters =
+								lappend(*index_filters,
 										add_filter_column_strategy(column_name,
 																   op_strategy,
 																   arg_value,
 																   false)); /* is_null_check */
+							*segmentby_predicates = lappend(*segmentby_predicates, node);
 						}
 					}
 				}
@@ -2573,12 +2819,13 @@ fill_predicate_context(Chunk *ch, List *predicates, List **filters, List **is_nu
 						ts_hypertable_compression_get_by_pkey(ch->fd.hypertable_id, column_name);
 					if (COMPRESSIONCOL_IS_SEGMENT_BY(fd))
 					{
-						*filters = lappend(*filters,
-										   add_filter_column_strategy(column_name,
-																	  InvalidStrategy,
-																	  NULL,
-																	  true)); /* is_null_check */
-
+						*index_filters =
+							lappend(*index_filters,
+									add_filter_column_strategy(column_name,
+															   InvalidStrategy,
+															   NULL,
+															   true)); /* is_null_check */
+						*segmentby_predicates = lappend(*segmentby_predicates, node);
 						if (ntest->nulltesttype == IS_NULL)
 							*is_null = lappend_int(*is_null, 1);
 						else
@@ -2638,6 +2885,62 @@ build_update_delete_scankeys(RowDecompressor *decompressor, List *filters, int *
 	return scankeys;
 }
 
+static TM_Result
+delete_compressed_tuple(RowDecompressor *decompressor, HeapTuple compressed_tuple)
+{
+	TM_FailureData tmfd;
+	TM_Result result;
+	result = table_tuple_delete(decompressor->in_rel,
+								&compressed_tuple->t_self,
+								decompressor->mycid,
+								GetTransactionSnapshot(),
+								InvalidSnapshot,
+								true,
+								&tmfd,
+								false);
+	return result;
+}
+
+static void
+report_error(TM_Result result)
+{
+	switch (result)
+	{
+		case TM_Deleted:
+		{
+			if (IsolationUsesXactSnapshot())
+			{
+				/* For Repeatable Read isolation level report error */
+				ereport(ERROR,
+						(errcode(ERRCODE_T_R_SERIALIZATION_FAILURE),
+						 errmsg("could not serialize access due to concurrent update")));
+			}
+		}
+		break;
+		/*
+		 * If another transaction is updating the compressed data,
+		 * we have to abort the transaction to keep consistency.
+		 */
+		case TM_Updated:
+		{
+			elog(ERROR, "tuple concurrently updated");
+		}
+		break;
+		case TM_Invisible:
+		{
+			elog(ERROR, "attempted to lock invisible tuple");
+		}
+		break;
+		case TM_Ok:
+			break;
+		default:
+		{
+			elog(ERROR, "unexpected tuple operation result: %d", result);
+		}
+		break;
+	}
+}
+
 /*
  * This method will:
  *  1.scan compressed chunk
@@ -2654,6 +2957,7 @@ static bool
 decompress_batches(RowDecompressor *decompressor, ScanKeyData *scankeys, int num_scankeys,
 				   Bitmapset *null_columns, List *is_nulls, bool *chunk_status_changed)
 {
+	TM_Result result;
 	HeapTuple compressed_tuple;
 	Snapshot snapshot = GetTransactionSnapshot();
 
@@ -2689,58 +2993,11 @@ decompress_batches(RowDecompressor *decompressor, ScanKeyData *scankeys, int num
 						  decompressor->compressed_datums,
 						  decompressor->compressed_is_nulls);
 
-		TM_FailureData tmfd;
-		TM_Result result;
-		result = table_tuple_delete(decompressor->in_rel,
-									&compressed_tuple->t_self,
-									decompressor->mycid,
-									snapshot,
-									InvalidSnapshot,
-									true,
-									&tmfd,
-									false);
-
-		switch (result)
+		result = delete_compressed_tuple(decompressor, compressed_tuple);
+		if (result != TM_Ok)
 		{
-			/* If the tuple has been already deleted, most likely somebody
-			 * decompressed the tuple already */
-			case TM_Deleted:
-			{
-				if (IsolationUsesXactSnapshot())
-				{
-					/* For Repeatable Read isolation level report error */
-					table_endscan(heapScan);
-					ereport(ERROR,
-							(errcode(ERRCODE_T_R_SERIALIZATION_FAILURE),
-							 errmsg("could not serialize access due to concurrent update")));
-				}
-				continue;
-			}
-			break;
-			/*
-			 * If another transaction is updating the compressed data,
-			 * we have to abort the transaction to keep consistency.
-			 */
-			case TM_Updated:
-			{
-				table_endscan(heapScan);
-				elog(ERROR, "tuple concurrently updated");
-			}
-			break;
-			case TM_Invisible:
-			{
-				table_endscan(heapScan);
-				elog(ERROR, "attempted to lock invisible tuple");
-			}
-			break;
-			case TM_Ok:
-				break;
-			default:
-			{
-				table_endscan(heapScan);
-				elog(ERROR, "unexpected tuple operation result: %d", result);
-			}
-			break;
+			table_endscan(heapScan);
+			report_error(result);
 		}
 		row_decompressor_decompress_row(decompressor, NULL);
 		*chunk_status_changed = true;
@@ -2748,6 +3005,122 @@ decompress_batches(RowDecompressor *decompressor, ScanKeyData *scankeys, int num
 	if (scankeys)
 		pfree(scankeys);
 	table_endscan(heapScan);
+	return true;
+}
+
+/*
+ * This method will build scan keys required to do index
+ * scans on compressed chunks.
+ */
+static ScanKeyData *
+build_index_scankeys(Relation in_rel, Relation index_rel, List *predicates, int *num_scankeys,
+					 EState *estate)
+{
+	IndexScan *node = makeNode(IndexScan);
+	Plan *plan = &node->scan.plan;
+
+	plan->qual = predicates;
+	node->scan.scanrelid = in_rel->rd_id;
+	node->indexid = index_rel->rd_id;
+	node->indexqual = predicates;
+	node->indexorderdir = ForwardScanDirection;
+
+	IndexScanState *indexstate;
+	indexstate = makeNode(IndexScanState);
+	indexstate->ss.ps.plan = (Plan *) node;
+	indexstate->ss.ps.state = estate;
+	indexstate->iss_RelationDesc = index_rel;
+
+	ExecIndexBuildScanKeys((PlanState *) indexstate,
+						   indexstate->iss_RelationDesc,
+						   node->indexqual,
+						   false,
+						   &indexstate->iss_ScanKeys,
+						   &indexstate->iss_NumScanKeys,
+						   &indexstate->iss_RuntimeKeys,
+						   &indexstate->iss_NumRuntimeKeys,
+						   NULL, /* no ArrayKeys */
+						   NULL);
+
+	*num_scankeys = indexstate->iss_NumScanKeys;
+	return indexstate->iss_ScanKeys;
+}
+
+/*
+ * This method will:
+ *  1.Scan the index created with SEGMENT BY columns.
+ *  2.Fetch matching rows and decompress the row
+ *  3.insert decompressed rows to uncompressed chunk
+ *  4.delete this row from compressed chunk
+ */
+static bool
+decompress_batches_using_index(RowDecompressor *decompressor, Relation index_rel,
+							   ScanKeyData *index_scankeys, int num_index_scankeys,
+							   ScanKeyData *scankeys, int num_scankeys, bool *chunk_status_changed)
+{
+	HeapTuple compressed_tuple;
+	Snapshot snapshot;
+	int num_segmentby_filtered_rows = 0;
+	int num_orderby_filtered_rows = 0;
+
+	snapshot = GetTransactionSnapshot();
+	IndexScanDesc scan =
+		index_beginscan(decompressor->in_rel, index_rel, snapshot, num_index_scankeys, 0);
+	TupleTableSlot *slot = table_slot_create(decompressor->in_rel, NULL);
+	index_rescan(scan, index_scankeys, num_index_scankeys, NULL, 0);
+	while (index_getnext_slot(scan, ForwardScanDirection, slot))
+	{
+		bool valid = false;
+		TM_Result result;
+		/* Deconstruct the tuple */
+		slot_getallattrs(slot);
+		compressed_tuple =
+			heap_form_tuple(slot->tts_tupleDescriptor, slot->tts_values, slot->tts_isnull);
+		compressed_tuple->t_self = slot->tts_tid;
+		num_segmentby_filtered_rows++;
+		if (num_scankeys)
+		{
+			/* filter tuple based on compress_orderby columns */
+			HeapKeyTest(compressed_tuple,
+						RelationGetDescr(decompressor->in_rel),
+						num_scankeys,
+						scankeys,
+						valid);
+			if (!valid)
+			{
+				num_orderby_filtered_rows++;
+				continue;
+			}
+		}
+		heap_deform_tuple(compressed_tuple,
+						  decompressor->in_desc,
+						  decompressor->compressed_datums,
+						  decompressor->compressed_is_nulls);
+
+		result = delete_compressed_tuple(decompressor, compressed_tuple);
+		/* skip reporting error if isolation level is < Repeatable Read */
+		if (result == TM_Deleted && !IsolationUsesXactSnapshot())
+			continue;
+		if (result != TM_Ok)
+		{
+			heap_freetuple(compressed_tuple);
+			index_endscan(scan);
+			index_close(index_rel, AccessShareLock);
+			report_error(result);
+		}
+		row_decompressor_decompress_row(decompressor, NULL);
+		heap_freetuple(compressed_tuple);
+		*chunk_status_changed = true;
+	}
+	elog(DEBUG1,
+		 "Number of compressed rows fetched from index: %d. "
+		 "Number of compressed rows filtered by orderby columns: %d.",
+		 num_segmentby_filtered_rows,
+		 num_orderby_filtered_rows);
+
+	ExecDropSingleTupleTableSlot(slot);
+	index_endscan(scan);
+	CommandCounterIncrement();
 	return true;
 }
 
@@ -2760,11 +3133,13 @@ decompress_batches(RowDecompressor *decompressor, ScanKeyData *scankeys, int num
  *  4. Update catalog table to change status of moved chunk.
  */
 static void
-decompress_batches_for_update_delete(Chunk *chunk, List *predicates)
+decompress_batches_for_update_delete(Chunk *chunk, List *predicates, EState *estate)
 {
 	/* process each chunk with its corresponding predicates */
 
 	List *filters = NIL;
+	List *index_filters = NIL;
+	List *segmentby_predicates = NIL;
 	List *is_null = NIL;
 	ListCell *lc = NULL;
 	Relation chunk_rel;
@@ -2777,8 +3152,15 @@ decompress_batches_for_update_delete(Chunk *chunk, List *predicates)
 	ScanKeyData *scankeys = NULL;
 	Bitmapset *null_columns = NULL;
 	int num_scankeys = 0;
+	ScanKeyData *index_scankeys = NULL;
+	int num_index_scankeys = 0;
 
-	fill_predicate_context(chunk, predicates, &filters, &is_null);
+	fill_predicate_context(chunk,
+						   predicates,
+						   &filters,
+						   &index_filters,
+						   &segmentby_predicates,
+						   &is_null);
 
 	chunk_rel = table_open(chunk->table_id, RowExclusiveLock);
 	comp_chunk = ts_chunk_get_by_id(chunk->fd.compressed_chunk_id, true);
@@ -2790,20 +3172,45 @@ decompress_batches_for_update_delete(Chunk *chunk, List *predicates)
 		scankeys =
 			build_update_delete_scankeys(&decompressor, filters, &num_scankeys, &null_columns);
 	}
-	if (decompress_batches(&decompressor,
+	if (index_filters)
+	{
+		List *ordered_index_filters = NIL;
+		Relation matching_index_rel = find_matching_index(comp_chunk_rel, index_filters);
+		Assert(matching_index_rel);
+		ordered_index_filters = fix_and_reorder_index_filters(comp_chunk_rel,
+															  matching_index_rel,
+															  segmentby_predicates,
+															  index_filters);
+		index_scankeys = build_index_scankeys(decompressor.in_rel,
+											  matching_index_rel,
+											  ordered_index_filters,
+											  &num_index_scankeys,
+											  estate);
+		decompress_batches_using_index(&decompressor,
+									   matching_index_rel,
+									   index_scankeys,
+									   num_index_scankeys,
+									   scankeys,
+									   num_scankeys,
+									   &chunk_status_changed);
+		/* close the selected index */
+		index_close(matching_index_rel, AccessShareLock);
+	}
+	else
+	{
+		decompress_batches(&decompressor,
 						   scankeys,
 						   num_scankeys,
 						   null_columns,
 						   is_null,
-						   &chunk_status_changed))
-	{
-		/*
-		 * tuples from compressed chunk has been decompressed and moved
-		 * to staging area, thus mark this chunk as partially compressed
-		 */
-		if (chunk_status_changed == true)
-			ts_chunk_set_partial(chunk);
+						   &chunk_status_changed);
 	}
+	/*
+	 * tuples from compressed chunk has been decompressed and moved
+	 * to staging area, thus mark this chunk as partially compressed
+	 */
+	if (chunk_status_changed == true)
+		ts_chunk_set_partial(chunk);
 
 	ts_catalog_close_indexes(decompressor.indexstate);
 	FreeBulkInsertState(decompressor.bistate);
@@ -2898,7 +3305,7 @@ decompress_chunk_walker(PlanState *ps, List *relids)
 							 errmsg("UPDATE/DELETE is disabled on compressed chunks"),
 							 errhint("Set timescaledb.enable_dml_decompression to TRUE.")));
 
-				decompress_batches_for_update_delete(current_chunk, predicates);
+				decompress_batches_for_update_delete(current_chunk, predicates, ps->state);
 
 				/* This is a workaround specifically for bitmap heap scans:
 				 * during node initialization, initialize the scan state with the active snapshot

--- a/tsl/test/expected/compression_update_delete.out
+++ b/tsl/test/expected/compression_update_delete.out
@@ -1308,9 +1308,12 @@ FROM _timescaledb_catalog.chunk ch1, _timescaledb_catalog.hypertable ht
 WHERE ch1.hypertable_id = ht.id AND ch1.table_name LIKE 'compress_%'
 ORDER BY ch1.id LIMIT 1 \gset
 -- check that you uncompress and delete only for exact SEGMENTBY value
+SET client_min_messages TO DEBUG1;
 BEGIN;
+LOG:  statement: BEGIN;
 -- report 10 rows
 SELECT COUNT(*) FROM :COMPRESS_CHUNK_1 where c4 = 5;
+LOG:  statement: SELECT COUNT(*) FROM _timescaledb_internal.compress_hyper_20_38_chunk where c4 = 5;
  count 
 -------
     10
@@ -1318,6 +1321,7 @@ SELECT COUNT(*) FROM :COMPRESS_CHUNK_1 where c4 = 5;
 
 -- report 10k rows
 SELECT COUNT(*) FROM sample_table WHERE c4 = 5;
+LOG:  statement: SELECT COUNT(*) FROM sample_table WHERE c4 = 5;
  count 
 -------
  10000
@@ -1325,11 +1329,16 @@ SELECT COUNT(*) FROM sample_table WHERE c4 = 5;
 
 -- fetch total and number of affected rows
 SELECT COUNT(*) AS "total_rows" FROM sample_table \gset
+LOG:  statement: SELECT COUNT(*) AS "total_rows" FROM sample_table 
 SELECT COUNT(*) AS "total_affected_rows" FROM sample_table WHERE c4 = 5 \gset
+LOG:  statement: SELECT COUNT(*) AS "total_affected_rows" FROM sample_table WHERE c4 = 5 
 -- delete 10k rows
 DELETE FROM sample_table WHERE c4 = 5;
+LOG:  statement: DELETE FROM sample_table WHERE c4 = 5;
+DEBUG:  Number of compressed rows fetched from index: 10. Number of compressed rows filtered by orderby columns: 0.
 -- report 0 rows
 SELECT count(*) FROM sample_table WHERE c4 = 5;
+LOG:  statement: SELECT count(*) FROM sample_table WHERE c4 = 5;
  count 
 -------
      0
@@ -1337,6 +1346,7 @@ SELECT count(*) FROM sample_table WHERE c4 = 5;
 
 -- report 0 rows in uncompressed chunk
 SELECT COUNT(*) FROM ONLY :CHUNK_1;
+LOG:  statement: SELECT COUNT(*) FROM ONLY _timescaledb_internal._hyper_19_37_chunk;
  count 
 -------
      0
@@ -1344,6 +1354,7 @@ SELECT COUNT(*) FROM ONLY :CHUNK_1;
 
 -- report 0 rows in compressed chunk
 SELECT COUNT(*) FROM :COMPRESS_CHUNK_1 where c4 = 5;
+LOG:  statement: SELECT COUNT(*) FROM _timescaledb_internal.compress_hyper_20_38_chunk where c4 = 5;
  count 
 -------
      0
@@ -1352,16 +1363,20 @@ SELECT COUNT(*) FROM :COMPRESS_CHUNK_1 where c4 = 5;
 -- validate correct number of rows was deleted
 -- report true
 SELECT COUNT(*) = :total_rows - :total_affected_rows FROM sample_table;
+LOG:  statement: SELECT COUNT(*) = 100000 - 10000 FROM sample_table;
  ?column? 
 ----------
  t
 (1 row)
 
 ROLLBACK;
+LOG:  statement: ROLLBACK;
 -- check that you uncompress and delete only for less than SEGMENTBY value
 BEGIN;
+LOG:  statement: BEGIN;
 -- report 50 rows
 SELECT COUNT(*) FROM :COMPRESS_CHUNK_1 where c4 < 5;
+LOG:  statement: SELECT COUNT(*) FROM _timescaledb_internal.compress_hyper_20_38_chunk where c4 < 5;
  count 
 -------
     50
@@ -1369,6 +1384,7 @@ SELECT COUNT(*) FROM :COMPRESS_CHUNK_1 where c4 < 5;
 
 -- report 50k rows
 SELECT COUNT(*) FROM sample_table WHERE c4 < 5;
+LOG:  statement: SELECT COUNT(*) FROM sample_table WHERE c4 < 5;
  count 
 -------
  50000
@@ -1376,11 +1392,16 @@ SELECT COUNT(*) FROM sample_table WHERE c4 < 5;
 
 -- fetch total and number of affected rows
 SELECT COUNT(*) AS "total_rows" FROM sample_table \gset
+LOG:  statement: SELECT COUNT(*) AS "total_rows" FROM sample_table 
 SELECT COUNT(*) AS "total_affected_rows" FROM sample_table WHERE c4 < 5 \gset
+LOG:  statement: SELECT COUNT(*) AS "total_affected_rows" FROM sample_table WHERE c4 < 5 
 -- delete 50k rows
 DELETE FROM sample_table WHERE c4 < 5;
+LOG:  statement: DELETE FROM sample_table WHERE c4 < 5;
+DEBUG:  Number of compressed rows fetched from index: 50. Number of compressed rows filtered by orderby columns: 0.
 -- report 0 rows
 SELECT count(*) FROM sample_table WHERE c4 < 5;
+LOG:  statement: SELECT count(*) FROM sample_table WHERE c4 < 5;
  count 
 -------
      0
@@ -1388,6 +1409,7 @@ SELECT count(*) FROM sample_table WHERE c4 < 5;
 
 -- report 0 rows in uncompressed chunk
 SELECT COUNT(*) FROM ONLY :CHUNK_1;
+LOG:  statement: SELECT COUNT(*) FROM ONLY _timescaledb_internal._hyper_19_37_chunk;
  count 
 -------
      0
@@ -1395,6 +1417,7 @@ SELECT COUNT(*) FROM ONLY :CHUNK_1;
 
 -- report 0 rows in compressed chunk
 SELECT COUNT(*) FROM :COMPRESS_CHUNK_1 where c4 < 5;
+LOG:  statement: SELECT COUNT(*) FROM _timescaledb_internal.compress_hyper_20_38_chunk where c4 < 5;
  count 
 -------
      0
@@ -1403,16 +1426,20 @@ SELECT COUNT(*) FROM :COMPRESS_CHUNK_1 where c4 < 5;
 -- validate correct number of rows was deleted
 -- report true
 SELECT COUNT(*) = :total_rows - :total_affected_rows FROM sample_table;
+LOG:  statement: SELECT COUNT(*) = 100000 - 50000 FROM sample_table;
  ?column? 
 ----------
  t
 (1 row)
 
 ROLLBACK;
+LOG:  statement: ROLLBACK;
 -- check that you uncompress and delete only for greater and equal than SEGMENTBY value
 BEGIN;
+LOG:  statement: BEGIN;
 -- report 50 rows
 SELECT COUNT(*) FROM :COMPRESS_CHUNK_1 where c4 >= 5;
+LOG:  statement: SELECT COUNT(*) FROM _timescaledb_internal.compress_hyper_20_38_chunk where c4 >= 5;
  count 
 -------
     50
@@ -1420,6 +1447,7 @@ SELECT COUNT(*) FROM :COMPRESS_CHUNK_1 where c4 >= 5;
 
 -- report 50k rows
 SELECT COUNT(*) FROM sample_table WHERE c4 >= 5;
+LOG:  statement: SELECT COUNT(*) FROM sample_table WHERE c4 >= 5;
  count 
 -------
  50000
@@ -1427,11 +1455,16 @@ SELECT COUNT(*) FROM sample_table WHERE c4 >= 5;
 
 -- fetch total and number of affected rows
 SELECT COUNT(*) AS "total_rows" FROM sample_table \gset
+LOG:  statement: SELECT COUNT(*) AS "total_rows" FROM sample_table 
 SELECT COUNT(*) AS "total_affected_rows" FROM sample_table WHERE c4 >= 5 \gset
+LOG:  statement: SELECT COUNT(*) AS "total_affected_rows" FROM sample_table WHERE c4 >= 5 
 -- delete 50k rows
 DELETE FROM sample_table WHERE c4 >= 5;
+LOG:  statement: DELETE FROM sample_table WHERE c4 >= 5;
+DEBUG:  Number of compressed rows fetched from index: 50. Number of compressed rows filtered by orderby columns: 0.
 -- report 0 rows
 SELECT count(*) FROM sample_table WHERE c4 >= 5;
+LOG:  statement: SELECT count(*) FROM sample_table WHERE c4 >= 5;
  count 
 -------
      0
@@ -1439,6 +1472,7 @@ SELECT count(*) FROM sample_table WHERE c4 >= 5;
 
 -- report 0 rows in uncompressed chunk
 SELECT COUNT(*) FROM ONLY :CHUNK_1;
+LOG:  statement: SELECT COUNT(*) FROM ONLY _timescaledb_internal._hyper_19_37_chunk;
  count 
 -------
      0
@@ -1446,6 +1480,7 @@ SELECT COUNT(*) FROM ONLY :CHUNK_1;
 
 -- report 0 rows in compressed chunk
 SELECT COUNT(*) FROM :COMPRESS_CHUNK_1 where c4 >= 5;
+LOG:  statement: SELECT COUNT(*) FROM _timescaledb_internal.compress_hyper_20_38_chunk where c4 >= 5;
  count 
 -------
      0
@@ -1454,17 +1489,21 @@ SELECT COUNT(*) FROM :COMPRESS_CHUNK_1 where c4 >= 5;
 -- validate correct number of rows was deleted
 -- report true
 SELECT COUNT(*) = :total_rows - :total_affected_rows FROM sample_table;
+LOG:  statement: SELECT COUNT(*) = 100000 - 50000 FROM sample_table;
  ?column? 
 ----------
  t
 (1 row)
 
 ROLLBACK;
+LOG:  statement: ROLLBACK;
 -- check that you uncompress and delete only for exact ORDERBY value
 -- this will uncompress segments which have min <= value and max >= value
 BEGIN;
+LOG:  statement: BEGIN;
 -- report 10k rows
 SELECT COUNT(*) FROM sample_table WHERE c2 = 3;
+LOG:  statement: SELECT COUNT(*) FROM sample_table WHERE c2 = 3;
  count 
 -------
  10000
@@ -1472,6 +1511,7 @@ SELECT COUNT(*) FROM sample_table WHERE c2 = 3;
 
 -- report 100 rows
 SELECT COUNT(*) FROM :COMPRESS_CHUNK_1 WHERE _ts_meta_min_2 <= 3 and _ts_meta_max_2 >= 3;
+LOG:  statement: SELECT COUNT(*) FROM _timescaledb_internal.compress_hyper_20_38_chunk WHERE _ts_meta_min_2 <= 3 and _ts_meta_max_2 >= 3;
  count 
 -------
    100
@@ -1479,11 +1519,15 @@ SELECT COUNT(*) FROM :COMPRESS_CHUNK_1 WHERE _ts_meta_min_2 <= 3 and _ts_meta_ma
 
 -- fetch total and number of affected rows
 SELECT COUNT(*) AS "total_rows" FROM sample_table \gset
+LOG:  statement: SELECT COUNT(*) AS "total_rows" FROM sample_table 
 SELECT COUNT(*) AS "total_affected_rows" FROM sample_table WHERE c2 = 3 \gset
+LOG:  statement: SELECT COUNT(*) AS "total_affected_rows" FROM sample_table WHERE c2 = 3 
 -- delete 10k rows
 DELETE FROM sample_table WHERE c2 = 3;
+LOG:  statement: DELETE FROM sample_table WHERE c2 = 3;
 -- report 0 rows
 SELECT count(*) FROM sample_table WHERE c2 = 3;
+LOG:  statement: SELECT count(*) FROM sample_table WHERE c2 = 3;
  count 
 -------
      0
@@ -1491,6 +1535,7 @@ SELECT count(*) FROM sample_table WHERE c2 = 3;
 
 -- report 90k rows in uncompressed chunk
 SELECT COUNT(*) FROM ONLY :CHUNK_1;
+LOG:  statement: SELECT COUNT(*) FROM ONLY _timescaledb_internal._hyper_19_37_chunk;
  count 
 -------
  90000
@@ -1498,6 +1543,7 @@ SELECT COUNT(*) FROM ONLY :CHUNK_1;
 
 -- report 0 rows
 SELECT COUNT(*) FROM :COMPRESS_CHUNK_1 WHERE _ts_meta_min_2 <= 3 and _ts_meta_max_2 >= 3;
+LOG:  statement: SELECT COUNT(*) FROM _timescaledb_internal.compress_hyper_20_38_chunk WHERE _ts_meta_min_2 <= 3 and _ts_meta_max_2 >= 3;
  count 
 -------
      0
@@ -1506,17 +1552,21 @@ SELECT COUNT(*) FROM :COMPRESS_CHUNK_1 WHERE _ts_meta_min_2 <= 3 and _ts_meta_ma
 -- validate correct number of rows was deleted
 -- report true
 SELECT COUNT(*) = :total_rows - :total_affected_rows FROM sample_table;
+LOG:  statement: SELECT COUNT(*) = 100000 - 10000 FROM sample_table;
  ?column? 
 ----------
  t
 (1 row)
 
 ROLLBACK;
+LOG:  statement: ROLLBACK;
 -- check that you uncompress and delete only for less then ORDERBY value
 -- this will uncompress segments which have min < value
 BEGIN;
+LOG:  statement: BEGIN;
 -- report 20k rows
 SELECT COUNT(*) FROM sample_table WHERE c1 < 2;
+LOG:  statement: SELECT COUNT(*) FROM sample_table WHERE c1 < 2;
  count 
 -------
  20000
@@ -1524,6 +1574,7 @@ SELECT COUNT(*) FROM sample_table WHERE c1 < 2;
 
 -- report 20 rows
 SELECT COUNT(*) FROM :COMPRESS_CHUNK_1 WHERE _ts_meta_max_1 < 2;
+LOG:  statement: SELECT COUNT(*) FROM _timescaledb_internal.compress_hyper_20_38_chunk WHERE _ts_meta_max_1 < 2;
  count 
 -------
     20
@@ -1531,11 +1582,15 @@ SELECT COUNT(*) FROM :COMPRESS_CHUNK_1 WHERE _ts_meta_max_1 < 2;
 
 -- fetch total and number of affected rows
 SELECT COUNT(*) AS "total_rows" FROM sample_table \gset
+LOG:  statement: SELECT COUNT(*) AS "total_rows" FROM sample_table 
 SELECT COUNT(*) AS "total_affected_rows" FROM sample_table WHERE c1 < 2 \gset
+LOG:  statement: SELECT COUNT(*) AS "total_affected_rows" FROM sample_table WHERE c1 < 2 
 -- delete 20k rows
 DELETE FROM sample_table WHERE c1 < 2;
+LOG:  statement: DELETE FROM sample_table WHERE c1 < 2;
 -- report 0 rows
 SELECT count(*) FROM sample_table WHERE c1 < 2;
+LOG:  statement: SELECT count(*) FROM sample_table WHERE c1 < 2;
  count 
 -------
      0
@@ -1543,6 +1598,7 @@ SELECT count(*) FROM sample_table WHERE c1 < 2;
 
 -- report 0 rows in uncompressed chunk
 SELECT COUNT(*) FROM ONLY :CHUNK_1;
+LOG:  statement: SELECT COUNT(*) FROM ONLY _timescaledb_internal._hyper_19_37_chunk;
  count 
 -------
      0
@@ -1550,6 +1606,7 @@ SELECT COUNT(*) FROM ONLY :CHUNK_1;
 
 -- report 0 rows in compressed chunk
 SELECT COUNT(*) FROM :COMPRESS_CHUNK_1 WHERE _ts_meta_max_1 < 2;
+LOG:  statement: SELECT COUNT(*) FROM _timescaledb_internal.compress_hyper_20_38_chunk WHERE _ts_meta_max_1 < 2;
  count 
 -------
      0
@@ -1558,17 +1615,21 @@ SELECT COUNT(*) FROM :COMPRESS_CHUNK_1 WHERE _ts_meta_max_1 < 2;
 -- validate correct number of rows was deleted
 -- report true
 SELECT COUNT(*) = :total_rows - :total_affected_rows FROM sample_table;
+LOG:  statement: SELECT COUNT(*) = 100000 - 20000 FROM sample_table;
  ?column? 
 ----------
  t
 (1 row)
 
 ROLLBACK;
+LOG:  statement: ROLLBACK;
 -- check that you uncompress and delete only for greater or equal then ORDERBY value
 -- this will uncompress segments which have max >= value
 BEGIN;
+LOG:  statement: BEGIN;
 -- report 30k rows
 SELECT COUNT(*) FROM sample_table WHERE c1 >= 7;
+LOG:  statement: SELECT COUNT(*) FROM sample_table WHERE c1 >= 7;
  count 
 -------
  30000
@@ -1576,6 +1637,7 @@ SELECT COUNT(*) FROM sample_table WHERE c1 >= 7;
 
 -- report 30 rows
 SELECT COUNT(*) FROM :COMPRESS_CHUNK_1 WHERE _ts_meta_min_1 >= 7;
+LOG:  statement: SELECT COUNT(*) FROM _timescaledb_internal.compress_hyper_20_38_chunk WHERE _ts_meta_min_1 >= 7;
  count 
 -------
     30
@@ -1583,11 +1645,15 @@ SELECT COUNT(*) FROM :COMPRESS_CHUNK_1 WHERE _ts_meta_min_1 >= 7;
 
 -- fetch total and number of affected rows
 SELECT COUNT(*) AS "total_rows" FROM sample_table \gset
+LOG:  statement: SELECT COUNT(*) AS "total_rows" FROM sample_table 
 SELECT COUNT(*) AS "total_affected_rows" FROM sample_table WHERE c1 >= 7 \gset
+LOG:  statement: SELECT COUNT(*) AS "total_affected_rows" FROM sample_table WHERE c1 >= 7 
 -- delete 30k rows
 DELETE FROM sample_table WHERE c1 >= 7;
+LOG:  statement: DELETE FROM sample_table WHERE c1 >= 7;
 -- report 0 rows
 SELECT count(*) FROM sample_table WHERE c1 >= 7;
+LOG:  statement: SELECT count(*) FROM sample_table WHERE c1 >= 7;
  count 
 -------
      0
@@ -1595,6 +1661,7 @@ SELECT count(*) FROM sample_table WHERE c1 >= 7;
 
 -- report 0 rows in uncompressed chunk
 SELECT COUNT(*) FROM ONLY :CHUNK_1;
+LOG:  statement: SELECT COUNT(*) FROM ONLY _timescaledb_internal._hyper_19_37_chunk;
  count 
 -------
      0
@@ -1602,6 +1669,7 @@ SELECT COUNT(*) FROM ONLY :CHUNK_1;
 
 -- report 0 rows in compressed chunks
 SELECT COUNT(*) FROM :COMPRESS_CHUNK_1 WHERE _ts_meta_min_1 >= 7;
+LOG:  statement: SELECT COUNT(*) FROM _timescaledb_internal.compress_hyper_20_38_chunk WHERE _ts_meta_min_1 >= 7;
  count 
 -------
      0
@@ -1610,18 +1678,22 @@ SELECT COUNT(*) FROM :COMPRESS_CHUNK_1 WHERE _ts_meta_min_1 >= 7;
 -- validate correct number of rows was deleted
 -- report true
 SELECT COUNT(*) = :total_rows - :total_affected_rows FROM sample_table;
+LOG:  statement: SELECT COUNT(*) = 100000 - 30000 FROM sample_table;
  ?column? 
 ----------
  t
 (1 row)
 
 ROLLBACK;
+LOG:  statement: ROLLBACK;
 -- check that you uncompress and delete only tuples which satisfy SEGMENTBY
 -- and ORDERBY qualifiers, segments only contain one distinct value for
 -- these qualifiers, everything should be deleted that was decompressed
 BEGIN;
+LOG:  statement: BEGIN;
 -- report 1k rows
 SELECT COUNT(*) FROM sample_table WHERE c4 = 5 and c1 = 5;
+LOG:  statement: SELECT COUNT(*) FROM sample_table WHERE c4 = 5 and c1 = 5;
  count 
 -------
   1000
@@ -1629,6 +1701,7 @@ SELECT COUNT(*) FROM sample_table WHERE c4 = 5 and c1 = 5;
 
 -- report 1 row in compressed chunks
 SELECT COUNT(*) FROM :COMPRESS_CHUNK_1 WHERE c4 = 5 AND _ts_meta_min_1 <= 5 and _ts_meta_max_1 >= 5;
+LOG:  statement: SELECT COUNT(*) FROM _timescaledb_internal.compress_hyper_20_38_chunk WHERE c4 = 5 AND _ts_meta_min_1 <= 5 and _ts_meta_max_1 >= 5;
  count 
 -------
      1
@@ -1636,11 +1709,16 @@ SELECT COUNT(*) FROM :COMPRESS_CHUNK_1 WHERE c4 = 5 AND _ts_meta_min_1 <= 5 and 
 
 -- fetch total and number of affected rows
 SELECT COUNT(*) AS "total_rows" FROM sample_table \gset
+LOG:  statement: SELECT COUNT(*) AS "total_rows" FROM sample_table 
 SELECT COUNT(*) AS "total_affected_rows" FROM sample_table WHERE c4 = 5 and c1 = 5 \gset
+LOG:  statement: SELECT COUNT(*) AS "total_affected_rows" FROM sample_table WHERE c4 = 5 and c1 = 5 
 -- delete 1k rows
 DELETE FROM sample_table WHERE c4 = 5 and c1 = 5;
+LOG:  statement: DELETE FROM sample_table WHERE c4 = 5 and c1 = 5;
+DEBUG:  Number of compressed rows fetched from index: 10. Number of compressed rows filtered by orderby columns: 9.
 -- report 0 rows
 SELECT count(*) FROM sample_table WHERE c4 = 5 and c1 = 5;
+LOG:  statement: SELECT count(*) FROM sample_table WHERE c4 = 5 and c1 = 5;
  count 
 -------
      0
@@ -1648,6 +1726,7 @@ SELECT count(*) FROM sample_table WHERE c4 = 5 and c1 = 5;
 
 -- report 0 rows in uncompressed chunk
 SELECT COUNT(*) FROM ONLY :CHUNK_1;
+LOG:  statement: SELECT COUNT(*) FROM ONLY _timescaledb_internal._hyper_19_37_chunk;
  count 
 -------
      0
@@ -1655,6 +1734,7 @@ SELECT COUNT(*) FROM ONLY :CHUNK_1;
 
 -- report 0 rows in compressed chunks
 SELECT COUNT(*) FROM :COMPRESS_CHUNK_1 WHERE c4 = 5 AND _ts_meta_min_1 <= 5 and _ts_meta_max_1 >= 5;
+LOG:  statement: SELECT COUNT(*) FROM _timescaledb_internal.compress_hyper_20_38_chunk WHERE c4 = 5 AND _ts_meta_min_1 <= 5 and _ts_meta_max_1 >= 5;
  count 
 -------
      0
@@ -1663,18 +1743,22 @@ SELECT COUNT(*) FROM :COMPRESS_CHUNK_1 WHERE c4 = 5 AND _ts_meta_min_1 <= 5 and 
 -- validate correct number of rows was deleted
 -- report true
 SELECT COUNT(*) = :total_rows - :total_affected_rows FROM sample_table;
+LOG:  statement: SELECT COUNT(*) = 100000 - 1000 FROM sample_table;
  ?column? 
 ----------
  t
 (1 row)
 
 ROLLBACK;
+LOG:  statement: ROLLBACK;
 -- check that you uncompress and delete only tuples which satisfy SEGMENTBY
 -- and ORDERBY qualifiers, segments contain more than one distinct value for
 -- these qualifiers, not everything should be deleted that was decompressed
 BEGIN;
+LOG:  statement: BEGIN;
 -- report 4k rows
 SELECT COUNT(*) FROM sample_table WHERE c4 > 5 and c2 = 5;
+LOG:  statement: SELECT COUNT(*) FROM sample_table WHERE c4 > 5 and c2 = 5;
  count 
 -------
   4000
@@ -1682,6 +1766,7 @@ SELECT COUNT(*) FROM sample_table WHERE c4 > 5 and c2 = 5;
 
 -- report 40 rows in compressed chunks
 SELECT COUNT(*) FROM :COMPRESS_CHUNK_1 WHERE c4 > 5 AND _ts_meta_min_2 <= 5 and _ts_meta_max_2 >= 5;
+LOG:  statement: SELECT COUNT(*) FROM _timescaledb_internal.compress_hyper_20_38_chunk WHERE c4 > 5 AND _ts_meta_min_2 <= 5 and _ts_meta_max_2 >= 5;
  count 
 -------
     40
@@ -1689,11 +1774,16 @@ SELECT COUNT(*) FROM :COMPRESS_CHUNK_1 WHERE c4 > 5 AND _ts_meta_min_2 <= 5 and 
 
 -- fetch total and number of affected rows
 SELECT COUNT(*) AS "total_rows" FROM sample_table \gset
+LOG:  statement: SELECT COUNT(*) AS "total_rows" FROM sample_table 
 SELECT COUNT(*) AS "total_affected_rows" FROM sample_table WHERE c4 > 5 and c2 = 5 \gset
+LOG:  statement: SELECT COUNT(*) AS "total_affected_rows" FROM sample_table WHERE c4 > 5 and c2 = 5 
 -- delete 4k rows
 DELETE FROM sample_table WHERE c4 > 5 and c2 = 5;
+LOG:  statement: DELETE FROM sample_table WHERE c4 > 5 and c2 = 5;
+DEBUG:  Number of compressed rows fetched from index: 40. Number of compressed rows filtered by orderby columns: 0.
 -- report 0 rows
 SELECT count(*) FROM sample_table WHERE c4 > 5 and c2 = 5;
+LOG:  statement: SELECT count(*) FROM sample_table WHERE c4 > 5 and c2 = 5;
  count 
 -------
      0
@@ -1701,6 +1791,7 @@ SELECT count(*) FROM sample_table WHERE c4 > 5 and c2 = 5;
 
 -- report 36k rows in uncompressed chunk
 SELECT COUNT(*) FROM ONLY :CHUNK_1;
+LOG:  statement: SELECT COUNT(*) FROM ONLY _timescaledb_internal._hyper_19_37_chunk;
  count 
 -------
  36000
@@ -1708,6 +1799,7 @@ SELECT COUNT(*) FROM ONLY :CHUNK_1;
 
 -- report 0 rows in compressed chunks
 SELECT COUNT(*) FROM :COMPRESS_CHUNK_1 WHERE c4 > 5 AND _ts_meta_min_2 <= 5 and _ts_meta_max_2 >= 5;
+LOG:  statement: SELECT COUNT(*) FROM _timescaledb_internal.compress_hyper_20_38_chunk WHERE c4 > 5 AND _ts_meta_min_2 <= 5 and _ts_meta_max_2 >= 5;
  count 
 -------
      0
@@ -1716,12 +1808,74 @@ SELECT COUNT(*) FROM :COMPRESS_CHUNK_1 WHERE c4 > 5 AND _ts_meta_min_2 <= 5 and 
 -- validate correct number of rows was deleted
 -- report true
 SELECT COUNT(*) = :total_rows - :total_affected_rows FROM sample_table;
+LOG:  statement: SELECT COUNT(*) = 100000 - 4000 FROM sample_table;
  ?column? 
 ----------
  t
 (1 row)
 
 ROLLBACK;
+LOG:  statement: ROLLBACK;
+-- check that you uncompress and delete only tuples which satisfy SEGMENTBY
+-- and ORDERBY qualifiers.
+-- no: of rows satisfying SEGMENTBY qualifiers is 10
+-- no: of rows satisfying ORDERBY qualifiers is 3
+-- Once both qualifiers are applied ensure that only 7 rows are present in
+-- compressed chunk
+BEGIN;
+LOG:  statement: BEGIN;
+-- report 0 rows in uncompressed chunk
+SELECT COUNT(*) FROM ONLY :CHUNK_1;
+LOG:  statement: SELECT COUNT(*) FROM ONLY _timescaledb_internal._hyper_19_37_chunk;
+ count 
+-------
+     0
+(1 row)
+
+-- report 10 compressed rows for given condition c4 = 4
+SELECT COUNT(*) FROM :COMPRESS_CHUNK_1 WHERE c4 = 4;
+LOG:  statement: SELECT COUNT(*) FROM _timescaledb_internal.compress_hyper_20_38_chunk WHERE c4 = 4;
+ count 
+-------
+    10
+(1 row)
+
+-- report 3 compressed rows for given condition c4 = 4 and c1 >= 7
+SELECT COUNT(*) FROM :COMPRESS_CHUNK_1 WHERE c4 = 4 AND _ts_meta_max_1 >= 7;
+LOG:  statement: SELECT COUNT(*) FROM _timescaledb_internal.compress_hyper_20_38_chunk WHERE c4 = 4 AND _ts_meta_max_1 >= 7;
+ count 
+-------
+     3
+(1 row)
+
+SELECT COUNT(*) AS "total_rows" FROM :COMPRESS_CHUNK_1 WHERE c4 = 4 \gset
+LOG:  statement: SELECT COUNT(*) AS "total_rows" FROM _timescaledb_internal.compress_hyper_20_38_chunk WHERE c4 = 4 
+SELECT COUNT(*) AS "total_affected_rows" FROM :COMPRESS_CHUNK_1 WHERE c4 = 4 AND _ts_meta_max_1 >= 7 \gset
+LOG:  statement: SELECT COUNT(*) AS "total_affected_rows" FROM _timescaledb_internal.compress_hyper_20_38_chunk WHERE c4 = 4 AND _ts_meta_max_1 >= 7 
+UPDATE sample_table SET c3 = c3 + 0 WHERE c4 = 4 AND c1 >= 7;
+LOG:  statement: UPDATE sample_table SET c3 = c3 + 0 WHERE c4 = 4 AND c1 >= 7;
+DEBUG:  Number of compressed rows fetched from index: 10. Number of compressed rows filtered by orderby columns: 7.
+-- report 7 rows
+SELECT COUNT(*) FROM :COMPRESS_CHUNK_1 WHERE c4 = 4;
+LOG:  statement: SELECT COUNT(*) FROM _timescaledb_internal.compress_hyper_20_38_chunk WHERE c4 = 4;
+ count 
+-------
+     7
+(1 row)
+
+-- ensure correct number of rows are moved from compressed chunk
+-- report true
+SELECT COUNT(*) = :total_rows - :total_affected_rows FROM :COMPRESS_CHUNK_1 WHERE c4 = 4;
+LOG:  statement: SELECT COUNT(*) = 10 - 3 FROM _timescaledb_internal.compress_hyper_20_38_chunk WHERE c4 = 4;
+ ?column? 
+----------
+ t
+(1 row)
+
+ROLLBACK;
+LOG:  statement: ROLLBACK;
+RESET client_min_messages;
+LOG:  statement: RESET client_min_messages;
 --github issue: 5640
 CREATE TABLE tab1(filler_1 int, filler_2 int, filler_3 int, time timestamptz NOT NULL, device_id int, v0 int, v1 int, v2 float, v3 float);
 CREATE INDEX ON tab1(time);
@@ -2294,3 +2448,89 @@ ERROR:  UPDATE/DELETE is disabled on compressed chunks
 DELETE FROM sample_table WHERE time >= '2023-03-17 00:00:00-00'::timestamptz;
 ERROR:  UPDATE/DELETE is disabled on compressed chunks
 \set ON_ERROR_STOP 1
+--github issue: 5586
+--testcase with multiple indexes
+\c :TEST_DBNAME :ROLE_SUPERUSER
+DROP DATABASE IF EXISTS test;
+NOTICE:  database "test" does not exist, skipping
+CREATE DATABASE test;
+\c test :ROLE_SUPERUSER
+SET client_min_messages = ERROR;
+CREATE EXTENSION timescaledb CASCADE;
+CREATE TABLE tab1(filler_1 int, filler_2 int, filler_3 int, time timestamptz NOT NULL, device_id int, v0 int, v1 int, v2 float, v3 float);
+SELECT create_hypertable('tab1','time',create_default_indexes:=false);
+ create_hypertable 
+-------------------
+ (1,public,tab1,t)
+(1 row)
+
+INSERT INTO tab1(filler_1, filler_2, filler_3,time,device_id,v0,v1,v2,v3) SELECT device_id, device_id+1,  device_id + 2, time, device_id, device_id+1,  device_id + 2, device_id + 0.5, NULL FROM generate_series('2000-01-01 0:00:00+0'::timestamptz,'2000-01-05 23:55:00+0','2m') gtime(time), generate_series(1,5,1) gdevice(device_id);
+ALTER TABLE tab1 SET (timescaledb.compress, timescaledb.compress_orderby='time DESC', timescaledb.compress_segmentby='device_id, filler_1, filler_2, filler_3');
+-- create multiple indexes on compressed hypertable
+DROP INDEX _timescaledb_internal._compressed_hypertable_2_device_id_filler_1_filler_2_filler_idx;
+CREATE INDEX ON _timescaledb_internal._compressed_hypertable_2 (_ts_meta_min_1);
+CREATE INDEX ON _timescaledb_internal._compressed_hypertable_2 (_ts_meta_min_1, _ts_meta_sequence_num);
+CREATE INDEX ON _timescaledb_internal._compressed_hypertable_2 (_ts_meta_min_1, _ts_meta_max_1, filler_1);
+CREATE INDEX filler_1 ON _timescaledb_internal._compressed_hypertable_2 (filler_1);
+CREATE INDEX filler_2 ON _timescaledb_internal._compressed_hypertable_2 (filler_2);
+CREATE INDEX filler_3 ON _timescaledb_internal._compressed_hypertable_2 (filler_3);
+-- below indexes should be selected
+CREATE INDEX filler_1_filler_2 ON _timescaledb_internal._compressed_hypertable_2 (filler_1, filler_2);
+CREATE INDEX filler_2_filler_3 ON _timescaledb_internal._compressed_hypertable_2 (filler_2, filler_3);
+SELECT compress_chunk(show_chunks('tab1'));
+             compress_chunk             
+----------------------------------------
+ _timescaledb_internal._hyper_1_1_chunk
+(1 row)
+
+SET client_min_messages TO DEBUG2;
+BEGIN;
+LOG:  statement: BEGIN;
+SELECT COUNT(*) FROM tab1 WHERE filler_3 = 5 AND filler_2 = 4;
+LOG:  statement: SELECT COUNT(*) FROM tab1 WHERE filler_3 = 5 AND filler_2 = 4;
+ count 
+-------
+  3598
+(1 row)
+
+UPDATE tab1 SET v0 = v1 + v2 WHERE filler_3 = 5 AND filler_2 = 4;
+LOG:  statement: UPDATE tab1 SET v0 = v1 + v2 WHERE filler_3 = 5 AND filler_2 = 4;
+DEBUG:  index "compress_hyper_2_2_chunk_filler_2_filler_3" is used for scan. 
+DEBUG:  Number of compressed rows fetched from index: 4. Number of compressed rows filtered by orderby columns: 0.
+ROLLBACK;
+LOG:  statement: ROLLBACK;
+BEGIN;
+LOG:  statement: BEGIN;
+SELECT COUNT(*) FROM tab1 WHERE filler_1 < 5 AND filler_2 = 4;
+LOG:  statement: SELECT COUNT(*) FROM tab1 WHERE filler_1 < 5 AND filler_2 = 4;
+ count 
+-------
+  3598
+(1 row)
+
+UPDATE tab1 SET v0 = v1 + v2 WHERE filler_1 < 5 AND filler_2 = 4;
+LOG:  statement: UPDATE tab1 SET v0 = v1 + v2 WHERE filler_1 < 5 AND filler_2 = 4;
+DEBUG:  index "compress_hyper_2_2_chunk_filler_1_filler_2" is used for scan. 
+DEBUG:  Number of compressed rows fetched from index: 4. Number of compressed rows filtered by orderby columns: 0.
+ROLLBACK;
+LOG:  statement: ROLLBACK;
+-- idealy filler_1 index should be selected,
+-- instead first matching index is selected
+BEGIN;
+LOG:  statement: BEGIN;
+SELECT COUNT(*) FROM tab1 WHERE filler_1 < 5;
+LOG:  statement: SELECT COUNT(*) FROM tab1 WHERE filler_1 < 5;
+ count 
+-------
+ 14392
+(1 row)
+
+UPDATE tab1 SET v0 = v1 + v2 WHERE filler_1 < 5;
+LOG:  statement: UPDATE tab1 SET v0 = v1 + v2 WHERE filler_1 < 5;
+DEBUG:  index "compress_hyper_2_2_chunk__compressed_hypertable_2__ts_meta_mi_2" is used for scan. 
+DEBUG:  Number of compressed rows fetched from index: 16. Number of compressed rows filtered by orderby columns: 0.
+ROLLBACK;
+LOG:  statement: ROLLBACK;
+RESET client_min_messages;
+LOG:  statement: RESET client_min_messages;
+DROP TABLE tab1;


### PR DESCRIPTION
During UPDATE/DELETE on compressed hypertables, we do a sequential scan which can be improved by supporting index scans.

In this patch for a given UPDATE/DELETE query, if there are any WHERE conditions specified using SEGMENT BY columns, we use index scan to fetch all matching rows. Fetched rows will be decompressed and moved to uncompressed chunk and a regular UPDATE/DELETE is performed on the uncompressed chunk.