### PR TITLE
Improve changelog handling

### DIFF
--- a/.github/workflows/check_changelog_file.yaml
+++ b/.github/workflows/check_changelog_file.yaml
@@ -1,0 +1,50 @@
+name: Check Changelog File
+
+on:
+  pull_request:
+    types: [opened]
+
+jobs:
+  # Check if the PR creates a sperate changelog file in the ".unreleased" folder
+  # This check can be disabled by adding the following line in the PR text
+  #
+  # Disable-check: force-changelog-file
+  #
+  # The change log file should have ".md" extension and if exists, check
+  # that if the file is of the expected format of bugfix/features/thanks
+  # sections.
+  checkfor-changelog-file:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Check changelog
+        run: |
+          folder=`.unreleased/features`
+          folder2=`.unreleased/bugfixes`
+          folder3=`.unreleased/thanks`
+          shell: bash --norc --noprofile {0}
+          # Get the list of modified files in this pull request
+          files=$(git --no-pager diff --name-only HEAD $(git merge-base HEAD ${{ github.event.pull_request.base.sha }}))
+          if echo "${{ github.event.pull_request.body }}" | egrep -qsi "Disable-check:[[:space:]]*force-changelog-file"; then
+            # skip changelog checks if forced
+            exit 0
+          else
+            # check if the files in ".unreleased" folder
+            if echo "${files}" | grep -Eq "^(${folder1}|${folder2})"; then
+              exit 0
+            else
+              # no changelog files found, and the PR does not have the force disable check option
+              echo "No changelog file created."
+              echo
+              echo "To disable changelog updated check, add this trailer to pull request message:"
+              echo
+              echo "Disable-check: force-changelog-file"
+              echo
+              echo "Trailers follow RFC2822 conventions, so no whitespace"
+              echo "before field name and the check is case-insensitive for"
+              echo "both the field name and the field body."
+              exit 1
+            fi
+          fi

--- a/scripts/merge_change_logs.sh
+++ b/scripts/merge_change_logs.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+cat << EOF
+Please add the following to the changelog:
+
+### Features ###
+$(for file in .unreleased/features/*; do test -f "$file" && cat "$file"; done)
+
+### Bug Fixes ###
+$(for file in .unreleased/bugfixes/*; do test -f "$file" && cat "$file"; done)
+
+### Thanks ###
+$(for file in .unreleased/thanks/*; do test -f "$file" && cat "$file"; done)
+
+EOF


### PR DESCRIPTION
Every PR to have its own changelog in the folder ".unreleased/features" or ".unreleased/bugfixes" and optionally in ".unreleased/thanks". The changes in this commit
1. workflow action to check if the PR has its own changelog file.
2. script to merge the individual changelogs.