### PR TITLE
Reduce decompression during UPDATE/DELETE

### DIFF
--- a/tsl/src/compression/compression.h
+++ b/tsl/src/compression/compression.h
@@ -252,6 +252,19 @@ typedef struct RowCompressor
 	bool first_iteration;
 } RowCompressor;
 
+/* SegmentFilter is used for filtering segments based on qualifiers */
+typedef struct SegmentFilter
+{
+	/* Column which we use for filtering */
+	NameData column_name;
+	/* Filter operation used */
+	StrategyNumber strategy;
+	/* Value to compare with */
+	Const *value;
+	/* IS NULL or IS NOT NULL */
+	bool is_null_check;
+} SegmentFilter;
+
 extern Datum tsl_compressed_data_decompress_forward(PG_FUNCTION_ARGS);
 extern Datum tsl_compressed_data_decompress_reverse(PG_FUNCTION_ARGS);
 extern Datum tsl_compressed_data_send(PG_FUNCTION_ARGS);

--- a/tsl/test/expected/compression_update_delete.out
+++ b/tsl/test/expected/compression_update_delete.out
@@ -124,7 +124,7 @@ WHERE hypertable_name = 'sample_table' ORDER BY chunk_name;
             9 | _hyper_1_2_chunk
 (2 rows)
 
--- recompress the paritial chunks
+-- recompress the partial chunks
 CALL recompress_chunk('_timescaledb_internal._hyper_1_1_chunk');
 CALL recompress_chunk('_timescaledb_internal._hyper_1_2_chunk');
 -- check chunk compression status
@@ -914,13 +914,13 @@ DELETE FROM sample_table WHERE device_id >= 4 AND val <= 1;
 SELECT COUNT(*) FROM :COMPRESS_CHUNK_1;
  count 
 -------
-     0
+     4
 (1 row)
 
 SELECT COUNT(*) FROM :COMPRESS_CHUNK_2;
  count 
 -------
-     0
+     5
 (1 row)
 
 -- get rowcount from compressed chunks where device_id IS NULL
@@ -945,7 +945,7 @@ WHERE hypertable_name = 'sample_table' ORDER BY chunk_name;
  chunk_status |     CHUNK_NAME     
 --------------+--------------------
             9 | _hyper_13_27_chunk
-            9 | _hyper_13_28_chunk
+            1 | _hyper_13_28_chunk
 (2 rows)
 
 -- added tests for code coverage
@@ -1272,3 +1272,453 @@ SELECT COUNT(*) FROM :COMPRESS_CHUNK_1 WHERE c4 IS NULL;
 (1 row)
 
 DROP TABLE sample_table;
+-- test filtering with ORDER BY columns
+CREATE TABLE sample_table(time timestamptz, c1 int, c2 int, c3 int, c4 int);
+SELECT create_hypertable('sample_table','time');
+NOTICE:  adding not-null constraint to column "time"
+     create_hypertable      
+----------------------------
+ (19,public,sample_table,t)
+(1 row)
+
+ALTER TABLE sample_table SET (timescaledb.compress,timescaledb.compress_segmentby='c4', timescaledb.compress_orderby='c1,c2,time');
+INSERT INTO sample_table
+SELECT t, c1, c2, c3, c4
+FROM generate_series(:'start_date'::timestamptz - INTERVAL '9 hours',
+            :'start_date'::timestamptz,
+            INTERVAL '1 hour') t,
+    generate_series(0,9,1) c1,
+    generate_series(0,9,1) c2,
+    generate_series(0,9,1) c3,
+    generate_series(0,9,1) c4;
+SELECT compress_chunk(show_chunks('sample_table'));
+              compress_chunk              
+------------------------------------------
+ _timescaledb_internal._hyper_19_37_chunk
+(1 row)
+
+-- get FIRST chunk
+SELECT ch1.schema_name|| '.' || ch1.table_name AS "CHUNK_1"
+FROM _timescaledb_catalog.chunk ch1, _timescaledb_catalog.hypertable ht
+WHERE ch1.hypertable_id = ht.id AND ch1.table_name LIKE '_hyper_%'
+ORDER BY ch1.id \gset
+-- get FIRST compressed chunk
+SELECT ch1.schema_name|| '.' || ch1.table_name AS "COMPRESS_CHUNK_1"
+FROM _timescaledb_catalog.chunk ch1, _timescaledb_catalog.hypertable ht
+WHERE ch1.hypertable_id = ht.id AND ch1.table_name LIKE 'compress_%'
+ORDER BY ch1.id \gset
+-- check that you uncompress and delete only for exact SEGMENTBY value
+BEGIN;
+-- report 10 rows
+SELECT COUNT(*) FROM :COMPRESS_CHUNK_1 where c4 = 5;
+ count 
+-------
+    10
+(1 row)
+
+-- report 10k rows
+SELECT COUNT(*) FROM sample_table WHERE c4 = 5;
+ count 
+-------
+ 10000
+(1 row)
+
+-- fetch total and number of affected rows
+SELECT COUNT(*) AS "total_rows" FROM sample_table \gset
+SELECT COUNT(*) AS "total_affected_rows" FROM sample_table WHERE c4 = 5 \gset
+-- delete 10k rows
+DELETE FROM sample_table WHERE c4 = 5;
+-- report 0 rows
+SELECT count(*) FROM sample_table WHERE c4 = 5;
+ count 
+-------
+     0
+(1 row)
+
+-- report 0 rows in uncompressed chunk
+SELECT COUNT(*) FROM ONLY :CHUNK_1;
+ count 
+-------
+     0
+(1 row)
+
+-- report 0 rows in compressed chunk
+SELECT COUNT(*) FROM :COMPRESS_CHUNK_1 where c4 = 5;
+ count 
+-------
+     0
+(1 row)
+
+-- validate correct number of rows was deleted
+-- report true
+SELECT COUNT(*) = :total_rows - :total_affected_rows FROM sample_table;
+ ?column? 
+----------
+ t
+(1 row)
+
+ROLLBACK;
+-- check that you uncompress and delete only for less than SEGMENTBY value
+BEGIN;
+-- report 50 rows
+SELECT COUNT(*) FROM :COMPRESS_CHUNK_1 where c4 < 5;
+ count 
+-------
+    50
+(1 row)
+
+-- report 50k rows
+SELECT COUNT(*) FROM sample_table WHERE c4 < 5;
+ count 
+-------
+ 50000
+(1 row)
+
+-- fetch total and number of affected rows
+SELECT COUNT(*) AS "total_rows" FROM sample_table \gset
+SELECT COUNT(*) AS "total_affected_rows" FROM sample_table WHERE c4 < 5 \gset
+-- delete 50k rows
+DELETE FROM sample_table WHERE c4 < 5;
+-- report 0 rows
+SELECT count(*) FROM sample_table WHERE c4 < 5;
+ count 
+-------
+     0
+(1 row)
+
+-- report 0 rows in uncompressed chunk
+SELECT COUNT(*) FROM ONLY :CHUNK_1;
+ count 
+-------
+     0
+(1 row)
+
+-- report 0 rows in compressed chunk
+SELECT COUNT(*) FROM :COMPRESS_CHUNK_1 where c4 < 5;
+ count 
+-------
+     0
+(1 row)
+
+-- validate correct number of rows was deleted
+-- report true
+SELECT COUNT(*) = :total_rows - :total_affected_rows FROM sample_table;
+ ?column? 
+----------
+ t
+(1 row)
+
+ROLLBACK;
+-- check that you uncompress and delete only for greater and equal than SEGMENTBY value
+BEGIN;
+-- report 50 rows
+SELECT COUNT(*) FROM :COMPRESS_CHUNK_1 where c4 >= 5;
+ count 
+-------
+    50
+(1 row)
+
+-- report 50k rows
+SELECT COUNT(*) FROM sample_table WHERE c4 >= 5;
+ count 
+-------
+ 50000
+(1 row)
+
+-- fetch total and number of affected rows
+SELECT COUNT(*) AS "total_rows" FROM sample_table \gset
+SELECT COUNT(*) AS "total_affected_rows" FROM sample_table WHERE c4 >= 5 \gset
+-- delete 50k rows
+DELETE FROM sample_table WHERE c4 >= 5;
+-- report 0 rows
+SELECT count(*) FROM sample_table WHERE c4 >= 5;
+ count 
+-------
+     0
+(1 row)
+
+-- report 0 rows in uncompressed chunk
+SELECT COUNT(*) FROM ONLY :CHUNK_1;
+ count 
+-------
+     0
+(1 row)
+
+-- report 0 rows in compressed chunk
+SELECT COUNT(*) FROM :COMPRESS_CHUNK_1 where c4 >= 5;
+ count 
+-------
+     0
+(1 row)
+
+-- validate correct number of rows was deleted
+-- report true
+SELECT COUNT(*) = :total_rows - :total_affected_rows FROM sample_table;
+ ?column? 
+----------
+ t
+(1 row)
+
+ROLLBACK;
+-- check that you uncompress and delete only for exact ORDERBY value
+-- this will uncompress segments which have min <= value and max >= value
+BEGIN;
+-- report 10k rows
+SELECT COUNT(*) FROM sample_table WHERE c2 = 3;
+ count 
+-------
+ 10000
+(1 row)
+
+-- report 100 rows
+SELECT COUNT(*) FROM :COMPRESS_CHUNK_1 WHERE _ts_meta_min_2 <= 3 and _ts_meta_max_2 >= 3;
+ count 
+-------
+   100
+(1 row)
+
+-- fetch total and number of affected rows
+SELECT COUNT(*) AS "total_rows" FROM sample_table \gset
+SELECT COUNT(*) AS "total_affected_rows" FROM sample_table WHERE c2 = 3 \gset
+-- delete 10k rows
+DELETE FROM sample_table WHERE c2 = 3;
+-- report 0 rows
+SELECT count(*) FROM sample_table WHERE c2 = 3;
+ count 
+-------
+     0
+(1 row)
+
+-- report 90k rows in uncompressed chunk
+SELECT COUNT(*) FROM ONLY :CHUNK_1;
+ count 
+-------
+ 90000
+(1 row)
+
+-- report 0 rows
+SELECT COUNT(*) FROM :COMPRESS_CHUNK_1 WHERE _ts_meta_min_2 <= 3 and _ts_meta_max_2 >= 3;
+ count 
+-------
+     0
+(1 row)
+
+-- validate correct number of rows was deleted
+-- report true
+SELECT COUNT(*) = :total_rows - :total_affected_rows FROM sample_table;
+ ?column? 
+----------
+ t
+(1 row)
+
+ROLLBACK;
+-- check that you uncompress and delete only for less then ORDERBY value
+-- this will uncompress segments which have min < value
+BEGIN;
+-- report 20k rows
+SELECT COUNT(*) FROM sample_table WHERE c1 < 2;
+ count 
+-------
+ 20000
+(1 row)
+
+-- report 20 rows
+SELECT COUNT(*) FROM :COMPRESS_CHUNK_1 WHERE _ts_meta_max_1 < 2;
+ count 
+-------
+    20
+(1 row)
+
+-- fetch total and number of affected rows
+SELECT COUNT(*) AS "total_rows" FROM sample_table \gset
+SELECT COUNT(*) AS "total_affected_rows" FROM sample_table WHERE c1 < 2 \gset
+-- delete 20k rows
+DELETE FROM sample_table WHERE c1 < 2;
+-- report 0 rows
+SELECT count(*) FROM sample_table WHERE c1 < 2;
+ count 
+-------
+     0
+(1 row)
+
+-- report 0 rows in uncompressed chunk
+SELECT COUNT(*) FROM ONLY :CHUNK_1;
+ count 
+-------
+     0
+(1 row)
+
+-- report 0 rows in compressed chunk
+SELECT COUNT(*) FROM :COMPRESS_CHUNK_1 WHERE _ts_meta_max_1 < 2;
+ count 
+-------
+     0
+(1 row)
+
+-- validate correct number of rows was deleted
+-- report true
+SELECT COUNT(*) = :total_rows - :total_affected_rows FROM sample_table;
+ ?column? 
+----------
+ t
+(1 row)
+
+ROLLBACK;
+-- check that you uncompress and delete only for greater or equal then ORDERBY value
+-- this will uncompress segments which have max >= value
+BEGIN;
+-- report 30k rows
+SELECT COUNT(*) FROM sample_table WHERE c1 >= 7;
+ count 
+-------
+ 30000
+(1 row)
+
+-- report 30 rows
+SELECT COUNT(*) FROM :COMPRESS_CHUNK_1 WHERE _ts_meta_min_1 >= 7;
+ count 
+-------
+    30
+(1 row)
+
+-- fetch total and number of affected rows
+SELECT COUNT(*) AS "total_rows" FROM sample_table \gset
+SELECT COUNT(*) AS "total_affected_rows" FROM sample_table WHERE c1 >= 7 \gset
+-- delete 30k rows
+DELETE FROM sample_table WHERE c1 >= 7;
+-- report 0 rows
+SELECT count(*) FROM sample_table WHERE c1 >= 7;
+ count 
+-------
+     0
+(1 row)
+
+-- report 0 rows in uncompressed chunk
+SELECT COUNT(*) FROM ONLY :CHUNK_1;
+ count 
+-------
+     0
+(1 row)
+
+-- report 0 rows in compressed chunks
+SELECT COUNT(*) FROM :COMPRESS_CHUNK_1 WHERE _ts_meta_min_1 >= 7;
+ count 
+-------
+     0
+(1 row)
+
+-- validate correct number of rows was deleted
+-- report true
+SELECT COUNT(*) = :total_rows - :total_affected_rows FROM sample_table;
+ ?column? 
+----------
+ t
+(1 row)
+
+ROLLBACK;
+-- check that you uncompress and delete only tuples which satisfy SEGMENTBY
+-- and ORDERBY qualifiers, segments only contain one distinct value for
+-- these qualifiers, everything should be deleted that was decompressed
+BEGIN;
+-- report 1k rows
+SELECT COUNT(*) FROM sample_table WHERE c4 = 5 and c1 = 5;
+ count 
+-------
+  1000
+(1 row)
+
+-- report 1 row in compressed chunks
+SELECT COUNT(*) FROM :COMPRESS_CHUNK_1 WHERE c4 = 5 AND _ts_meta_min_1 <= 5 and _ts_meta_max_1 >= 5;
+ count 
+-------
+     1
+(1 row)
+
+-- fetch total and number of affected rows
+SELECT COUNT(*) AS "total_rows" FROM sample_table \gset
+SELECT COUNT(*) AS "total_affected_rows" FROM sample_table WHERE c4 = 5 and c1 = 5 \gset
+-- delete 1k rows
+DELETE FROM sample_table WHERE c4 = 5 and c1 = 5;
+-- report 0 rows
+SELECT count(*) FROM sample_table WHERE c4 = 5 and c1 = 5;
+ count 
+-------
+     0
+(1 row)
+
+-- report 0 rows in uncompressed chunk
+SELECT COUNT(*) FROM ONLY :CHUNK_1;
+ count 
+-------
+     0
+(1 row)
+
+-- report 0 rows in compressed chunks
+SELECT COUNT(*) FROM :COMPRESS_CHUNK_1 WHERE c4 = 5 AND _ts_meta_min_1 <= 5 and _ts_meta_max_1 >= 5;
+ count 
+-------
+     0
+(1 row)
+
+-- validate correct number of rows was deleted
+-- report true
+SELECT COUNT(*) = :total_rows - :total_affected_rows FROM sample_table;
+ ?column? 
+----------
+ t
+(1 row)
+
+ROLLBACK;
+-- check that you uncompress and delete only tuples which satisfy SEGMENTBY
+-- and ORDERBY qualifiers, segments contain more than one distinct value for
+-- these qualifiers, not everything should be deleted that was decompressed
+BEGIN;
+-- report 4k rows
+SELECT COUNT(*) FROM sample_table WHERE c4 > 5 and c2 = 5;
+ count 
+-------
+  4000
+(1 row)
+
+-- report 40 rows in compressed chunks
+SELECT COUNT(*) FROM :COMPRESS_CHUNK_1 WHERE c4 > 5 AND _ts_meta_min_2 <= 5 and _ts_meta_max_2 >= 5;
+ count 
+-------
+    40
+(1 row)
+
+-- fetch total and number of affected rows
+SELECT COUNT(*) AS "total_rows" FROM sample_table \gset
+SELECT COUNT(*) AS "total_affected_rows" FROM sample_table WHERE c4 > 5 and c2 = 5 \gset
+-- delete 4k rows
+DELETE FROM sample_table WHERE c4 > 5 and c2 = 5;
+-- report 0 rows
+SELECT count(*) FROM sample_table WHERE c4 > 5 and c2 = 5;
+ count 
+-------
+     0
+(1 row)
+
+-- report 36k rows in uncompressed chunk
+SELECT COUNT(*) FROM ONLY :CHUNK_1;
+ count 
+-------
+ 36000
+(1 row)
+
+-- report 0 rows in compressed chunks
+SELECT COUNT(*) FROM :COMPRESS_CHUNK_1 WHERE c4 > 5 AND _ts_meta_min_2 <= 5 and _ts_meta_max_2 >= 5;
+ count 
+-------
+     0
+(1 row)
+
+-- validate correct number of rows was deleted
+-- report true
+SELECT COUNT(*) = :total_rows - :total_affected_rows FROM sample_table;
+ ?column? 
+----------
+ t
+(1 row)
+
+ROLLBACK;


### PR DESCRIPTION
When updating or deleting tuples from a compressed chunk, we first need to decompress the matching tuples then proceed with the operation. This optimization reduces the amount of data decompressed by using compressed metadata to decompress only the affected segments.

Disable-check: force-changelog-changed