### PR TITLE
Make compression metadata column names reusable

### DIFF
--- a/tsl/src/compression/create.c
+++ b/tsl/src/compression/create.c
@@ -106,18 +106,14 @@ get_default_algorithm_id(Oid typeoid)
 }
 
 static char *
-compression_column_segment_metadata_name(const FormData_hypertable_compression *fd,
-										 const char *type)
+compression_column_segment_metadata_name(int16 column_index, const char *type)
 {
 	char *buf = palloc(sizeof(char) * NAMEDATALEN);
 	int ret;
 
-	Assert(fd->orderby_column_index > 0);
-	ret = snprintf(buf,
-				   NAMEDATALEN,
-				   COMPRESSION_COLUMN_METADATA_PREFIX "%s_%d",
-				   type,
-				   fd->orderby_column_index);
+	Assert(column_index > 0);
+	ret =
+		snprintf(buf, NAMEDATALEN, COMPRESSION_COLUMN_METADATA_PREFIX "%s_%d", type, column_index);
 	if (ret < 0 || ret > NAMEDATALEN)
 	{
 		ereport(ERROR,
@@ -127,15 +123,29 @@ compression_column_segment_metadata_name(const FormData_hypertable_compression *
 }
 
 char *
+column_segment_min_name(int16 column_index)
+{
+	return compression_column_segment_metadata_name(column_index,
+													COMPRESSION_COLUMN_METADATA_MIN_COLUMN_NAME);
+}
+
+char *
+column_segment_max_name(int16 column_index)
+{
+	return compression_column_segment_metadata_name(column_index,
+													COMPRESSION_COLUMN_METADATA_MAX_COLUMN_NAME);
+}
+
+char *
 compression_column_segment_min_name(const FormData_hypertable_compression *fd)
 {
-	return compression_column_segment_metadata_name(fd, "min");
+	return column_segment_min_name(fd->orderby_column_index);
 }
 
 char *
 compression_column_segment_max_name(const FormData_hypertable_compression *fd)
 {
-	return compression_column_segment_metadata_name(fd, "max");
+	return column_segment_max_name(fd->orderby_column_index);
 }
 
 static void

--- a/tsl/src/compression/create.h
+++ b/tsl/src/compression/create.h
@@ -15,6 +15,8 @@
 #define COMPRESSION_COLUMN_METADATA_COUNT_NAME COMPRESSION_COLUMN_METADATA_PREFIX "count"
 #define COMPRESSION_COLUMN_METADATA_SEQUENCE_NUM_NAME                                              \
 	COMPRESSION_COLUMN_METADATA_PREFIX "sequence_num"
+#define COMPRESSION_COLUMN_METADATA_MIN_COLUMN_NAME "min"
+#define COMPRESSION_COLUMN_METADATA_MAX_COLUMN_NAME "max"
 
 bool tsl_process_compress_table(AlterTableCmd *cmd, Hypertable *ht,
 								WithClauseResult *with_clause_options);
@@ -25,5 +27,8 @@ Chunk *create_compress_chunk(Hypertable *compress_ht, Chunk *src_chunk, Oid tabl
 
 char *compression_column_segment_min_name(const FormData_hypertable_compression *fd);
 char *compression_column_segment_max_name(const FormData_hypertable_compression *fd);
+
+char *column_segment_min_name(int16 column_index);
+char *column_segment_max_name(int16 column_index);
 
 #endif /* TIMESCALEDB_TSL_COMPRESSION_CREATE_H */


### PR DESCRIPTION
Move the creation of metadata column names for min/max values to separate functions to make the code reusable.

Disable-check: force-changelog-changed