### PR TITLE
Enable compressed merge append for partial chunks

### DIFF
--- a/tsl/src/nodes/decompress_chunk/decompress_chunk.c
+++ b/tsl/src/nodes/decompress_chunk/decompress_chunk.c
@@ -489,7 +489,7 @@ can_sorted_merge_append(PlannerInfo *root, CompressionInfo *info, Chunk *chunk)
 	MergeBatchResult merge_result = SCAN_FORWARD;
 
 	/* Ensure that we have path keys and the chunk is ordered */
-	if (pathkeys == NIL || ts_chunk_is_unordered(chunk) || ts_chunk_is_partial(chunk))
+	if (pathkeys == NIL || ts_chunk_is_unordered(chunk))
 		return MERGE_NOT_POSSIBLE;
 
 	int nkeys = list_length(pathkeys);
@@ -720,24 +720,31 @@ ts_decompress_chunk_generate_paths(PlannerInfo *root, RelOptInfo *chunk_rel, Hyp
 		 * down the sort to the compressed chunk. If we can push down the sort, the batches can be
 		 * directly consumed in this order and we don't need to use this optimization.
 		 */
+		DecompressChunkPath *batch_merge_path = NULL;
+
 		if (ts_guc_enable_decompression_sorted_merge && !sort_info.can_pushdown_sort)
 		{
 			MergeBatchResult merge_result = can_sorted_merge_append(root, info, chunk);
 			if (merge_result != MERGE_NOT_POSSIBLE)
 			{
-				DecompressChunkPath *dcpath =
-					copy_decompress_chunk_path((DecompressChunkPath *) path);
+				batch_merge_path = copy_decompress_chunk_path((DecompressChunkPath *) path);
 
-				dcpath->reverse = (merge_result != SCAN_FORWARD);
-				dcpath->sorted_merge_append = true;
+				batch_merge_path->reverse = (merge_result != SCAN_FORWARD);
+				batch_merge_path->sorted_merge_append = true;
 
 				/* The segment by optimization is only enabled if it can deliver the tuples in the
 				 * same order as the query requested it. So, we can just copy the pathkeys of the
 				 * query here.
 				 */
-				dcpath->cpath.path.pathkeys = root->query_pathkeys;
-				cost_decompress_sorted_merge_append(root, dcpath, child_path);
-				add_path(chunk_rel, &dcpath->cpath.path);
+				batch_merge_path->cpath.path.pathkeys = root->query_pathkeys;
+				cost_decompress_sorted_merge_append(root, batch_merge_path, child_path);
+
+				/* If the chunk is partially compressed, prepare the path only and add it later
+				 * to a merge append path when we are able to generate the ordered result for the
+				 * compressed and uncompressed part of the chunk.
+				 */
+				if (!ts_chunk_is_partial(chunk))
+					add_path(chunk_rel, &batch_merge_path->cpath.path);
 			}
 		}
 
@@ -806,6 +813,24 @@ ts_decompress_chunk_generate_paths(PlannerInfo *root, RelOptInfo *chunk_rel, Hyp
 				uncompressed_path = reparameterize_path(root, uncompressed_path, req_outer, 1.0);
 				if (!uncompressed_path)
 					continue;
+			}
+
+			/* If we were able to generate a batch merge path, create a merge append path
+			 * that combines the result of the compressed and uncompressed part of the chunk. The
+			 * uncompressed part will be sorted, the batch_merge_path is already properly sorted.
+			 */
+			if (batch_merge_path != NULL)
+			{
+				Path *merge_append_path =
+					(Path *) create_merge_append_path_compat(root,
+															 chunk_rel,
+															 list_make2(batch_merge_path,
+																		uncompressed_path),
+															 root->query_pathkeys,
+															 req_outer,
+															 NIL);
+
+				add_path(chunk_rel, merge_append_path);
 			}
 
 			/*

--- a/tsl/test/expected/compression_insert-12.out
+++ b/tsl/test/expected/compression_insert-12.out
@@ -750,6 +750,14 @@ SELECT * FROM trigger_test ORDER BY 1 ,2, 5;
 ROLLBACK;
 DROP TABLE trigger_test;
 -- test interaction between newly inserted batches and pathkeys/ordered append
+--
+-- The following test operates on a small relation. By using the
+-- timescaledb.enable_decompression_sorted_merge optimization, we are pushing a sort node
+-- below the DecompressChunk node, which operates on the batches. This could lead to flaky
+-- tests because the input data is small and PostgreSQL switches from IndexScans to
+-- SequentialScans. Disable the optimization for the following test to ensure we have
+-- stable query plans in all CI environments.
+SET timescaledb.enable_decompression_sorted_merge = 0;
 CREATE TABLE test_ordering(time int);
 SELECT table_name FROM create_hypertable('test_ordering','time',chunk_time_interval:=100);
 NOTICE:  adding not-null constraint to column "time"
@@ -883,6 +891,7 @@ NOTICE:  chunk "_hyper_13_20_chunk" is already compressed
                ->  Seq Scan on compress_hyper_14_23_chunk
 (15 rows)
 
+SET timescaledb.enable_decompression_sorted_merge = 1;
 -- TEST cagg triggers with insert into compressed chunk
 CREATE TABLE conditions (
       timec        TIMESTAMPTZ       NOT NULL,

--- a/tsl/test/expected/compression_insert-13.out
+++ b/tsl/test/expected/compression_insert-13.out
@@ -750,6 +750,14 @@ SELECT * FROM trigger_test ORDER BY 1 ,2, 5;
 ROLLBACK;
 DROP TABLE trigger_test;
 -- test interaction between newly inserted batches and pathkeys/ordered append
+--
+-- The following test operates on a small relation. By using the
+-- timescaledb.enable_decompression_sorted_merge optimization, we are pushing a sort node
+-- below the DecompressChunk node, which operates on the batches. This could lead to flaky
+-- tests because the input data is small and PostgreSQL switches from IndexScans to
+-- SequentialScans. Disable the optimization for the following test to ensure we have
+-- stable query plans in all CI environments.
+SET timescaledb.enable_decompression_sorted_merge = 0;
 CREATE TABLE test_ordering(time int);
 SELECT table_name FROM create_hypertable('test_ordering','time',chunk_time_interval:=100);
 NOTICE:  adding not-null constraint to column "time"
@@ -883,6 +891,7 @@ NOTICE:  chunk "_hyper_13_20_chunk" is already compressed
                ->  Seq Scan on compress_hyper_14_23_chunk
 (15 rows)
 
+SET timescaledb.enable_decompression_sorted_merge = 1;
 -- TEST cagg triggers with insert into compressed chunk
 CREATE TABLE conditions (
       timec        TIMESTAMPTZ       NOT NULL,

--- a/tsl/test/expected/compression_insert-14.out
+++ b/tsl/test/expected/compression_insert-14.out
@@ -750,6 +750,14 @@ SELECT * FROM trigger_test ORDER BY 1 ,2, 5;
 ROLLBACK;
 DROP TABLE trigger_test;
 -- test interaction between newly inserted batches and pathkeys/ordered append
+--
+-- The following test operates on a small relation. By using the
+-- timescaledb.enable_decompression_sorted_merge optimization, we are pushing a sort node
+-- below the DecompressChunk node, which operates on the batches. This could lead to flaky
+-- tests because the input data is small and PostgreSQL switches from IndexScans to
+-- SequentialScans. Disable the optimization for the following test to ensure we have
+-- stable query plans in all CI environments.
+SET timescaledb.enable_decompression_sorted_merge = 0;
 CREATE TABLE test_ordering(time int);
 SELECT table_name FROM create_hypertable('test_ordering','time',chunk_time_interval:=100);
 NOTICE:  adding not-null constraint to column "time"
@@ -883,6 +891,7 @@ NOTICE:  chunk "_hyper_13_20_chunk" is already compressed
                ->  Seq Scan on compress_hyper_14_23_chunk
 (15 rows)
 
+SET timescaledb.enable_decompression_sorted_merge = 1;
 -- TEST cagg triggers with insert into compressed chunk
 CREATE TABLE conditions (
       timec        TIMESTAMPTZ       NOT NULL,

--- a/tsl/test/expected/compression_insert-15.out
+++ b/tsl/test/expected/compression_insert-15.out
@@ -750,6 +750,14 @@ SELECT * FROM trigger_test ORDER BY 1 ,2, 5;
 ROLLBACK;
 DROP TABLE trigger_test;
 -- test interaction between newly inserted batches and pathkeys/ordered append
+--
+-- The following test operates on a small relation. By using the
+-- timescaledb.enable_decompression_sorted_merge optimization, we are pushing a sort node
+-- below the DecompressChunk node, which operates on the batches. This could lead to flaky
+-- tests because the input data is small and PostgreSQL switches from IndexScans to
+-- SequentialScans. Disable the optimization for the following test to ensure we have
+-- stable query plans in all CI environments.
+SET timescaledb.enable_decompression_sorted_merge = 0;
 CREATE TABLE test_ordering(time int);
 SELECT table_name FROM create_hypertable('test_ordering','time',chunk_time_interval:=100);
 NOTICE:  adding not-null constraint to column "time"
@@ -883,6 +891,7 @@ NOTICE:  chunk "_hyper_13_20_chunk" is already compressed
                ->  Seq Scan on compress_hyper_14_23_chunk
 (15 rows)
 
+SET timescaledb.enable_decompression_sorted_merge = 1;
 -- TEST cagg triggers with insert into compressed chunk
 CREATE TABLE conditions (
       timec        TIMESTAMPTZ       NOT NULL,

--- a/tsl/test/expected/compression_sorted_merge-12.out
+++ b/tsl/test/expected/compression_sorted_merge-12.out
@@ -1026,30 +1026,9 @@ SELECT * FROM test_with_defined_null ORDER BY x2 DESC NULLS FIRST;
 (4 rows)
 
 ------
--- Tests based on chunk state
+-- Tests based on compressed chunk state
 ------
-BEGIN TRANSACTION;
-INSERT INTO test1 (time, x1, x2, x3, x4, x5) values('2000-01-01 02:01:00-00', 10, 20, 30, 40, 50);
--- Should not be optimized because of the partially compressed chunk
-:PREFIX
-SELECT * FROM test1 ORDER BY time ASC NULLS LAST;
-                                                                                                                                                                                                                                                                              QUERY PLAN                                                                                                                                                                                                                                                                               
------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
- Sort (actual rows=5 loops=1)
-   Output: _hyper_1_1_chunk."time", _hyper_1_1_chunk.x1, _hyper_1_1_chunk.x2, _hyper_1_1_chunk.x3, _hyper_1_1_chunk.x4, _hyper_1_1_chunk.x5, _hyper_1_1_chunk.c1, _hyper_1_1_chunk.c2
-   Sort Key: _hyper_1_1_chunk."time"
-   Sort Method: quicksort 
-   ->  Append (actual rows=5 loops=1)
-         ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_1_chunk (actual rows=4 loops=1)
-               Output: _hyper_1_1_chunk."time", _hyper_1_1_chunk.x1, _hyper_1_1_chunk.x2, _hyper_1_1_chunk.x3, _hyper_1_1_chunk.x4, _hyper_1_1_chunk.x5, _hyper_1_1_chunk.c1, _hyper_1_1_chunk.c2
-               ->  Seq Scan on _timescaledb_internal.compress_hyper_2_7_chunk (actual rows=3 loops=1)
-                     Output: compress_hyper_2_7_chunk."time", compress_hyper_2_7_chunk._ts_meta_min_1, compress_hyper_2_7_chunk._ts_meta_max_1, compress_hyper_2_7_chunk.x1, compress_hyper_2_7_chunk.x2, compress_hyper_2_7_chunk.x3, compress_hyper_2_7_chunk._ts_meta_min_2, compress_hyper_2_7_chunk._ts_meta_max_2, compress_hyper_2_7_chunk.x4, compress_hyper_2_7_chunk._ts_meta_min_3, compress_hyper_2_7_chunk._ts_meta_max_3, compress_hyper_2_7_chunk.x5, compress_hyper_2_7_chunk.c1, compress_hyper_2_7_chunk.c2, compress_hyper_2_7_chunk._ts_meta_count
-         ->  Seq Scan on _timescaledb_internal._hyper_1_1_chunk (actual rows=1 loops=1)
-               Output: _hyper_1_1_chunk."time", _hyper_1_1_chunk.x1, _hyper_1_1_chunk.x2, _hyper_1_1_chunk.x3, _hyper_1_1_chunk.x4, _hyper_1_1_chunk.x5, _hyper_1_1_chunk.c1, _hyper_1_1_chunk.c2
-(11 rows)
-
-ROLLBACK;
--- Should be optimized again
+-- Should be optimized
 :PREFIX
 SELECT * FROM test1 ORDER BY time ASC NULLS LAST;
                                                                                                                                                                                                                                                                            QUERY PLAN                                                                                                                                                                                                                                                                            
@@ -1065,6 +1044,49 @@ SELECT * FROM test1 ORDER BY time ASC NULLS LAST;
                Output: compress_hyper_2_7_chunk."time", compress_hyper_2_7_chunk._ts_meta_min_1, compress_hyper_2_7_chunk._ts_meta_max_1, compress_hyper_2_7_chunk.x1, compress_hyper_2_7_chunk.x2, compress_hyper_2_7_chunk.x3, compress_hyper_2_7_chunk._ts_meta_min_2, compress_hyper_2_7_chunk._ts_meta_max_2, compress_hyper_2_7_chunk.x4, compress_hyper_2_7_chunk._ts_meta_min_3, compress_hyper_2_7_chunk._ts_meta_max_3, compress_hyper_2_7_chunk.x5, compress_hyper_2_7_chunk.c1, compress_hyper_2_7_chunk.c2, compress_hyper_2_7_chunk._ts_meta_count
 (9 rows)
 
+BEGIN TRANSACTION;
+INSERT INTO test1 (time, x1, x2, x3, x4, x5) values('2000-01-01 02:01:00-00', 10, 20, 30, 40, 50);
+-- Should be optimized using a merge append path between the compressed and uncompressed part of the chunk
+:PREFIX
+SELECT * FROM test1 ORDER BY time ASC NULLS LAST;
+                                                                                                                                                                                                                                                                                 QUERY PLAN                                                                                                                                                                                                                                                                                  
+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Custom Scan (ChunkAppend) on public.test1 (actual rows=5 loops=1)
+   Output: test1."time", test1.x1, test1.x2, test1.x3, test1.x4, test1.x5, test1.c1, test1.c2
+   Order: test1."time"
+   Startup Exclusion: false
+   Runtime Exclusion: false
+   ->  Merge Append (actual rows=5 loops=1)
+         Sort Key: _hyper_1_1_chunk."time"
+         ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_1_chunk (actual rows=4 loops=1)
+               Output: _hyper_1_1_chunk."time", _hyper_1_1_chunk.x1, _hyper_1_1_chunk.x2, _hyper_1_1_chunk.x3, _hyper_1_1_chunk.x4, _hyper_1_1_chunk.x5, _hyper_1_1_chunk.c1, _hyper_1_1_chunk.c2
+               Sorted merge append: true
+               ->  Sort (actual rows=3 loops=1)
+                     Output: compress_hyper_2_7_chunk."time", compress_hyper_2_7_chunk._ts_meta_min_1, compress_hyper_2_7_chunk._ts_meta_max_1, compress_hyper_2_7_chunk.x1, compress_hyper_2_7_chunk.x2, compress_hyper_2_7_chunk.x3, compress_hyper_2_7_chunk._ts_meta_min_2, compress_hyper_2_7_chunk._ts_meta_max_2, compress_hyper_2_7_chunk.x4, compress_hyper_2_7_chunk._ts_meta_min_3, compress_hyper_2_7_chunk._ts_meta_max_3, compress_hyper_2_7_chunk.x5, compress_hyper_2_7_chunk.c1, compress_hyper_2_7_chunk.c2, compress_hyper_2_7_chunk._ts_meta_count
+                     Sort Key: compress_hyper_2_7_chunk._ts_meta_min_1
+                     Sort Method: quicksort 
+                     ->  Seq Scan on _timescaledb_internal.compress_hyper_2_7_chunk (actual rows=3 loops=1)
+                           Output: compress_hyper_2_7_chunk."time", compress_hyper_2_7_chunk._ts_meta_min_1, compress_hyper_2_7_chunk._ts_meta_max_1, compress_hyper_2_7_chunk.x1, compress_hyper_2_7_chunk.x2, compress_hyper_2_7_chunk.x3, compress_hyper_2_7_chunk._ts_meta_min_2, compress_hyper_2_7_chunk._ts_meta_max_2, compress_hyper_2_7_chunk.x4, compress_hyper_2_7_chunk._ts_meta_min_3, compress_hyper_2_7_chunk._ts_meta_max_3, compress_hyper_2_7_chunk.x5, compress_hyper_2_7_chunk.c1, compress_hyper_2_7_chunk.c2, compress_hyper_2_7_chunk._ts_meta_count
+         ->  Sort (actual rows=1 loops=1)
+               Output: _hyper_1_1_chunk."time", _hyper_1_1_chunk.x1, _hyper_1_1_chunk.x2, _hyper_1_1_chunk.x3, _hyper_1_1_chunk.x4, _hyper_1_1_chunk.x5, _hyper_1_1_chunk.c1, _hyper_1_1_chunk.c2
+               Sort Key: _hyper_1_1_chunk."time"
+               Sort Method: quicksort 
+               ->  Seq Scan on _timescaledb_internal._hyper_1_1_chunk (actual rows=1 loops=1)
+                     Output: _hyper_1_1_chunk."time", _hyper_1_1_chunk.x1, _hyper_1_1_chunk.x2, _hyper_1_1_chunk.x3, _hyper_1_1_chunk.x4, _hyper_1_1_chunk.x5, _hyper_1_1_chunk.c1, _hyper_1_1_chunk.c2
+(22 rows)
+
+-- The inserted value should be visible
+SELECT * FROM test1 ORDER BY time ASC NULLS LAST;
+             time             | x1 | x2 | x3 | x4 | x5 | c1 | c2 
+------------------------------+----+----+----+----+----+----+----
+ Fri Dec 31 16:00:00 1999 PST |  1 |  2 |  1 |  1 |  0 |    | 43
+ Fri Dec 31 17:00:00 1999 PST |  1 |  3 |  2 |  2 |  0 |    | 43
+ Fri Dec 31 18:00:00 1999 PST |  2 |  1 |  3 |  3 |  0 |    | 43
+ Fri Dec 31 18:01:00 1999 PST | 10 | 20 | 30 | 40 | 50 |    | 43
+ Fri Dec 31 19:00:00 1999 PST |  1 |  2 |  4 |  4 |  0 |    | 43
+(5 rows)
+
+ROLLBACK;
 ------
 -- Tests on a larger relation
 ------

--- a/tsl/test/expected/compression_sorted_merge-13.out
+++ b/tsl/test/expected/compression_sorted_merge-13.out
@@ -1026,30 +1026,9 @@ SELECT * FROM test_with_defined_null ORDER BY x2 DESC NULLS FIRST;
 (4 rows)
 
 ------
--- Tests based on chunk state
+-- Tests based on compressed chunk state
 ------
-BEGIN TRANSACTION;
-INSERT INTO test1 (time, x1, x2, x3, x4, x5) values('2000-01-01 02:01:00-00', 10, 20, 30, 40, 50);
--- Should not be optimized because of the partially compressed chunk
-:PREFIX
-SELECT * FROM test1 ORDER BY time ASC NULLS LAST;
-                                                                                                                                                                                                                                                                              QUERY PLAN                                                                                                                                                                                                                                                                               
------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
- Sort (actual rows=5 loops=1)
-   Output: _hyper_1_1_chunk."time", _hyper_1_1_chunk.x1, _hyper_1_1_chunk.x2, _hyper_1_1_chunk.x3, _hyper_1_1_chunk.x4, _hyper_1_1_chunk.x5, _hyper_1_1_chunk.c1, _hyper_1_1_chunk.c2
-   Sort Key: _hyper_1_1_chunk."time"
-   Sort Method: quicksort 
-   ->  Append (actual rows=5 loops=1)
-         ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_1_chunk (actual rows=4 loops=1)
-               Output: _hyper_1_1_chunk."time", _hyper_1_1_chunk.x1, _hyper_1_1_chunk.x2, _hyper_1_1_chunk.x3, _hyper_1_1_chunk.x4, _hyper_1_1_chunk.x5, _hyper_1_1_chunk.c1, _hyper_1_1_chunk.c2
-               ->  Seq Scan on _timescaledb_internal.compress_hyper_2_7_chunk (actual rows=3 loops=1)
-                     Output: compress_hyper_2_7_chunk."time", compress_hyper_2_7_chunk._ts_meta_min_1, compress_hyper_2_7_chunk._ts_meta_max_1, compress_hyper_2_7_chunk.x1, compress_hyper_2_7_chunk.x2, compress_hyper_2_7_chunk.x3, compress_hyper_2_7_chunk._ts_meta_min_2, compress_hyper_2_7_chunk._ts_meta_max_2, compress_hyper_2_7_chunk.x4, compress_hyper_2_7_chunk._ts_meta_min_3, compress_hyper_2_7_chunk._ts_meta_max_3, compress_hyper_2_7_chunk.x5, compress_hyper_2_7_chunk.c1, compress_hyper_2_7_chunk.c2, compress_hyper_2_7_chunk._ts_meta_count
-         ->  Seq Scan on _timescaledb_internal._hyper_1_1_chunk (actual rows=1 loops=1)
-               Output: _hyper_1_1_chunk."time", _hyper_1_1_chunk.x1, _hyper_1_1_chunk.x2, _hyper_1_1_chunk.x3, _hyper_1_1_chunk.x4, _hyper_1_1_chunk.x5, _hyper_1_1_chunk.c1, _hyper_1_1_chunk.c2
-(11 rows)
-
-ROLLBACK;
--- Should be optimized again
+-- Should be optimized
 :PREFIX
 SELECT * FROM test1 ORDER BY time ASC NULLS LAST;
                                                                                                                                                                                                                                                                            QUERY PLAN                                                                                                                                                                                                                                                                            
@@ -1065,6 +1044,49 @@ SELECT * FROM test1 ORDER BY time ASC NULLS LAST;
                Output: compress_hyper_2_7_chunk."time", compress_hyper_2_7_chunk._ts_meta_min_1, compress_hyper_2_7_chunk._ts_meta_max_1, compress_hyper_2_7_chunk.x1, compress_hyper_2_7_chunk.x2, compress_hyper_2_7_chunk.x3, compress_hyper_2_7_chunk._ts_meta_min_2, compress_hyper_2_7_chunk._ts_meta_max_2, compress_hyper_2_7_chunk.x4, compress_hyper_2_7_chunk._ts_meta_min_3, compress_hyper_2_7_chunk._ts_meta_max_3, compress_hyper_2_7_chunk.x5, compress_hyper_2_7_chunk.c1, compress_hyper_2_7_chunk.c2, compress_hyper_2_7_chunk._ts_meta_count
 (9 rows)
 
+BEGIN TRANSACTION;
+INSERT INTO test1 (time, x1, x2, x3, x4, x5) values('2000-01-01 02:01:00-00', 10, 20, 30, 40, 50);
+-- Should be optimized using a merge append path between the compressed and uncompressed part of the chunk
+:PREFIX
+SELECT * FROM test1 ORDER BY time ASC NULLS LAST;
+                                                                                                                                                                                                                                                                                 QUERY PLAN                                                                                                                                                                                                                                                                                  
+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Custom Scan (ChunkAppend) on public.test1 (actual rows=5 loops=1)
+   Output: test1."time", test1.x1, test1.x2, test1.x3, test1.x4, test1.x5, test1.c1, test1.c2
+   Order: test1."time"
+   Startup Exclusion: false
+   Runtime Exclusion: false
+   ->  Merge Append (actual rows=5 loops=1)
+         Sort Key: _hyper_1_1_chunk."time"
+         ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_1_chunk (actual rows=4 loops=1)
+               Output: _hyper_1_1_chunk."time", _hyper_1_1_chunk.x1, _hyper_1_1_chunk.x2, _hyper_1_1_chunk.x3, _hyper_1_1_chunk.x4, _hyper_1_1_chunk.x5, _hyper_1_1_chunk.c1, _hyper_1_1_chunk.c2
+               Sorted merge append: true
+               ->  Sort (actual rows=3 loops=1)
+                     Output: compress_hyper_2_7_chunk."time", compress_hyper_2_7_chunk._ts_meta_min_1, compress_hyper_2_7_chunk._ts_meta_max_1, compress_hyper_2_7_chunk.x1, compress_hyper_2_7_chunk.x2, compress_hyper_2_7_chunk.x3, compress_hyper_2_7_chunk._ts_meta_min_2, compress_hyper_2_7_chunk._ts_meta_max_2, compress_hyper_2_7_chunk.x4, compress_hyper_2_7_chunk._ts_meta_min_3, compress_hyper_2_7_chunk._ts_meta_max_3, compress_hyper_2_7_chunk.x5, compress_hyper_2_7_chunk.c1, compress_hyper_2_7_chunk.c2, compress_hyper_2_7_chunk._ts_meta_count
+                     Sort Key: compress_hyper_2_7_chunk._ts_meta_min_1
+                     Sort Method: quicksort 
+                     ->  Seq Scan on _timescaledb_internal.compress_hyper_2_7_chunk (actual rows=3 loops=1)
+                           Output: compress_hyper_2_7_chunk."time", compress_hyper_2_7_chunk._ts_meta_min_1, compress_hyper_2_7_chunk._ts_meta_max_1, compress_hyper_2_7_chunk.x1, compress_hyper_2_7_chunk.x2, compress_hyper_2_7_chunk.x3, compress_hyper_2_7_chunk._ts_meta_min_2, compress_hyper_2_7_chunk._ts_meta_max_2, compress_hyper_2_7_chunk.x4, compress_hyper_2_7_chunk._ts_meta_min_3, compress_hyper_2_7_chunk._ts_meta_max_3, compress_hyper_2_7_chunk.x5, compress_hyper_2_7_chunk.c1, compress_hyper_2_7_chunk.c2, compress_hyper_2_7_chunk._ts_meta_count
+         ->  Sort (actual rows=1 loops=1)
+               Output: _hyper_1_1_chunk."time", _hyper_1_1_chunk.x1, _hyper_1_1_chunk.x2, _hyper_1_1_chunk.x3, _hyper_1_1_chunk.x4, _hyper_1_1_chunk.x5, _hyper_1_1_chunk.c1, _hyper_1_1_chunk.c2
+               Sort Key: _hyper_1_1_chunk."time"
+               Sort Method: quicksort 
+               ->  Seq Scan on _timescaledb_internal._hyper_1_1_chunk (actual rows=1 loops=1)
+                     Output: _hyper_1_1_chunk."time", _hyper_1_1_chunk.x1, _hyper_1_1_chunk.x2, _hyper_1_1_chunk.x3, _hyper_1_1_chunk.x4, _hyper_1_1_chunk.x5, _hyper_1_1_chunk.c1, _hyper_1_1_chunk.c2
+(22 rows)
+
+-- The inserted value should be visible
+SELECT * FROM test1 ORDER BY time ASC NULLS LAST;
+             time             | x1 | x2 | x3 | x4 | x5 | c1 | c2 
+------------------------------+----+----+----+----+----+----+----
+ Fri Dec 31 16:00:00 1999 PST |  1 |  2 |  1 |  1 |  0 |    | 43
+ Fri Dec 31 17:00:00 1999 PST |  1 |  3 |  2 |  2 |  0 |    | 43
+ Fri Dec 31 18:00:00 1999 PST |  2 |  1 |  3 |  3 |  0 |    | 43
+ Fri Dec 31 18:01:00 1999 PST | 10 | 20 | 30 | 40 | 50 |    | 43
+ Fri Dec 31 19:00:00 1999 PST |  1 |  2 |  4 |  4 |  0 |    | 43
+(5 rows)
+
+ROLLBACK;
 ------
 -- Tests on a larger relation
 ------

--- a/tsl/test/expected/compression_sorted_merge-14.out
+++ b/tsl/test/expected/compression_sorted_merge-14.out
@@ -1026,30 +1026,9 @@ SELECT * FROM test_with_defined_null ORDER BY x2 DESC NULLS FIRST;
 (4 rows)
 
 ------
--- Tests based on chunk state
+-- Tests based on compressed chunk state
 ------
-BEGIN TRANSACTION;
-INSERT INTO test1 (time, x1, x2, x3, x4, x5) values('2000-01-01 02:01:00-00', 10, 20, 30, 40, 50);
--- Should not be optimized because of the partially compressed chunk
-:PREFIX
-SELECT * FROM test1 ORDER BY time ASC NULLS LAST;
-                                                                                                                                                                                                                                                                              QUERY PLAN                                                                                                                                                                                                                                                                               
------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
- Sort (actual rows=5 loops=1)
-   Output: _hyper_1_1_chunk."time", _hyper_1_1_chunk.x1, _hyper_1_1_chunk.x2, _hyper_1_1_chunk.x3, _hyper_1_1_chunk.x4, _hyper_1_1_chunk.x5, _hyper_1_1_chunk.c1, _hyper_1_1_chunk.c2
-   Sort Key: _hyper_1_1_chunk."time"
-   Sort Method: quicksort 
-   ->  Append (actual rows=5 loops=1)
-         ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_1_chunk (actual rows=4 loops=1)
-               Output: _hyper_1_1_chunk."time", _hyper_1_1_chunk.x1, _hyper_1_1_chunk.x2, _hyper_1_1_chunk.x3, _hyper_1_1_chunk.x4, _hyper_1_1_chunk.x5, _hyper_1_1_chunk.c1, _hyper_1_1_chunk.c2
-               ->  Seq Scan on _timescaledb_internal.compress_hyper_2_7_chunk (actual rows=3 loops=1)
-                     Output: compress_hyper_2_7_chunk."time", compress_hyper_2_7_chunk._ts_meta_min_1, compress_hyper_2_7_chunk._ts_meta_max_1, compress_hyper_2_7_chunk.x1, compress_hyper_2_7_chunk.x2, compress_hyper_2_7_chunk.x3, compress_hyper_2_7_chunk._ts_meta_min_2, compress_hyper_2_7_chunk._ts_meta_max_2, compress_hyper_2_7_chunk.x4, compress_hyper_2_7_chunk._ts_meta_min_3, compress_hyper_2_7_chunk._ts_meta_max_3, compress_hyper_2_7_chunk.x5, compress_hyper_2_7_chunk.c1, compress_hyper_2_7_chunk.c2, compress_hyper_2_7_chunk._ts_meta_count
-         ->  Seq Scan on _timescaledb_internal._hyper_1_1_chunk (actual rows=1 loops=1)
-               Output: _hyper_1_1_chunk."time", _hyper_1_1_chunk.x1, _hyper_1_1_chunk.x2, _hyper_1_1_chunk.x3, _hyper_1_1_chunk.x4, _hyper_1_1_chunk.x5, _hyper_1_1_chunk.c1, _hyper_1_1_chunk.c2
-(11 rows)
-
-ROLLBACK;
--- Should be optimized again
+-- Should be optimized
 :PREFIX
 SELECT * FROM test1 ORDER BY time ASC NULLS LAST;
                                                                                                                                                                                                                                                                            QUERY PLAN                                                                                                                                                                                                                                                                            
@@ -1065,6 +1044,49 @@ SELECT * FROM test1 ORDER BY time ASC NULLS LAST;
                Output: compress_hyper_2_7_chunk."time", compress_hyper_2_7_chunk._ts_meta_min_1, compress_hyper_2_7_chunk._ts_meta_max_1, compress_hyper_2_7_chunk.x1, compress_hyper_2_7_chunk.x2, compress_hyper_2_7_chunk.x3, compress_hyper_2_7_chunk._ts_meta_min_2, compress_hyper_2_7_chunk._ts_meta_max_2, compress_hyper_2_7_chunk.x4, compress_hyper_2_7_chunk._ts_meta_min_3, compress_hyper_2_7_chunk._ts_meta_max_3, compress_hyper_2_7_chunk.x5, compress_hyper_2_7_chunk.c1, compress_hyper_2_7_chunk.c2, compress_hyper_2_7_chunk._ts_meta_count
 (9 rows)
 
+BEGIN TRANSACTION;
+INSERT INTO test1 (time, x1, x2, x3, x4, x5) values('2000-01-01 02:01:00-00', 10, 20, 30, 40, 50);
+-- Should be optimized using a merge append path between the compressed and uncompressed part of the chunk
+:PREFIX
+SELECT * FROM test1 ORDER BY time ASC NULLS LAST;
+                                                                                                                                                                                                                                                                                 QUERY PLAN                                                                                                                                                                                                                                                                                  
+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Custom Scan (ChunkAppend) on public.test1 (actual rows=5 loops=1)
+   Output: test1."time", test1.x1, test1.x2, test1.x3, test1.x4, test1.x5, test1.c1, test1.c2
+   Order: test1."time"
+   Startup Exclusion: false
+   Runtime Exclusion: false
+   ->  Merge Append (actual rows=5 loops=1)
+         Sort Key: _hyper_1_1_chunk."time"
+         ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_1_chunk (actual rows=4 loops=1)
+               Output: _hyper_1_1_chunk."time", _hyper_1_1_chunk.x1, _hyper_1_1_chunk.x2, _hyper_1_1_chunk.x3, _hyper_1_1_chunk.x4, _hyper_1_1_chunk.x5, _hyper_1_1_chunk.c1, _hyper_1_1_chunk.c2
+               Sorted merge append: true
+               ->  Sort (actual rows=3 loops=1)
+                     Output: compress_hyper_2_7_chunk."time", compress_hyper_2_7_chunk._ts_meta_min_1, compress_hyper_2_7_chunk._ts_meta_max_1, compress_hyper_2_7_chunk.x1, compress_hyper_2_7_chunk.x2, compress_hyper_2_7_chunk.x3, compress_hyper_2_7_chunk._ts_meta_min_2, compress_hyper_2_7_chunk._ts_meta_max_2, compress_hyper_2_7_chunk.x4, compress_hyper_2_7_chunk._ts_meta_min_3, compress_hyper_2_7_chunk._ts_meta_max_3, compress_hyper_2_7_chunk.x5, compress_hyper_2_7_chunk.c1, compress_hyper_2_7_chunk.c2, compress_hyper_2_7_chunk._ts_meta_count
+                     Sort Key: compress_hyper_2_7_chunk._ts_meta_min_1
+                     Sort Method: quicksort 
+                     ->  Seq Scan on _timescaledb_internal.compress_hyper_2_7_chunk (actual rows=3 loops=1)
+                           Output: compress_hyper_2_7_chunk."time", compress_hyper_2_7_chunk._ts_meta_min_1, compress_hyper_2_7_chunk._ts_meta_max_1, compress_hyper_2_7_chunk.x1, compress_hyper_2_7_chunk.x2, compress_hyper_2_7_chunk.x3, compress_hyper_2_7_chunk._ts_meta_min_2, compress_hyper_2_7_chunk._ts_meta_max_2, compress_hyper_2_7_chunk.x4, compress_hyper_2_7_chunk._ts_meta_min_3, compress_hyper_2_7_chunk._ts_meta_max_3, compress_hyper_2_7_chunk.x5, compress_hyper_2_7_chunk.c1, compress_hyper_2_7_chunk.c2, compress_hyper_2_7_chunk._ts_meta_count
+         ->  Sort (actual rows=1 loops=1)
+               Output: _hyper_1_1_chunk."time", _hyper_1_1_chunk.x1, _hyper_1_1_chunk.x2, _hyper_1_1_chunk.x3, _hyper_1_1_chunk.x4, _hyper_1_1_chunk.x5, _hyper_1_1_chunk.c1, _hyper_1_1_chunk.c2
+               Sort Key: _hyper_1_1_chunk."time"
+               Sort Method: quicksort 
+               ->  Seq Scan on _timescaledb_internal._hyper_1_1_chunk (actual rows=1 loops=1)
+                     Output: _hyper_1_1_chunk."time", _hyper_1_1_chunk.x1, _hyper_1_1_chunk.x2, _hyper_1_1_chunk.x3, _hyper_1_1_chunk.x4, _hyper_1_1_chunk.x5, _hyper_1_1_chunk.c1, _hyper_1_1_chunk.c2
+(22 rows)
+
+-- The inserted value should be visible
+SELECT * FROM test1 ORDER BY time ASC NULLS LAST;
+             time             | x1 | x2 | x3 | x4 | x5 | c1 | c2 
+------------------------------+----+----+----+----+----+----+----
+ Fri Dec 31 16:00:00 1999 PST |  1 |  2 |  1 |  1 |  0 |    | 43
+ Fri Dec 31 17:00:00 1999 PST |  1 |  3 |  2 |  2 |  0 |    | 43
+ Fri Dec 31 18:00:00 1999 PST |  2 |  1 |  3 |  3 |  0 |    | 43
+ Fri Dec 31 18:01:00 1999 PST | 10 | 20 | 30 | 40 | 50 |    | 43
+ Fri Dec 31 19:00:00 1999 PST |  1 |  2 |  4 |  4 |  0 |    | 43
+(5 rows)
+
+ROLLBACK;
 ------
 -- Tests on a larger relation
 ------

--- a/tsl/test/expected/compression_sorted_merge-15.out
+++ b/tsl/test/expected/compression_sorted_merge-15.out
@@ -1026,30 +1026,9 @@ SELECT * FROM test_with_defined_null ORDER BY x2 DESC NULLS FIRST;
 (4 rows)
 
 ------
--- Tests based on chunk state
+-- Tests based on compressed chunk state
 ------
-BEGIN TRANSACTION;
-INSERT INTO test1 (time, x1, x2, x3, x4, x5) values('2000-01-01 02:01:00-00', 10, 20, 30, 40, 50);
--- Should not be optimized because of the partially compressed chunk
-:PREFIX
-SELECT * FROM test1 ORDER BY time ASC NULLS LAST;
-                                                                                                                                                                                                                                                                              QUERY PLAN                                                                                                                                                                                                                                                                               
------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
- Sort (actual rows=5 loops=1)
-   Output: _hyper_1_1_chunk."time", _hyper_1_1_chunk.x1, _hyper_1_1_chunk.x2, _hyper_1_1_chunk.x3, _hyper_1_1_chunk.x4, _hyper_1_1_chunk.x5, _hyper_1_1_chunk.c1, _hyper_1_1_chunk.c2
-   Sort Key: _hyper_1_1_chunk."time"
-   Sort Method: quicksort 
-   ->  Append (actual rows=5 loops=1)
-         ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_1_chunk (actual rows=4 loops=1)
-               Output: _hyper_1_1_chunk."time", _hyper_1_1_chunk.x1, _hyper_1_1_chunk.x2, _hyper_1_1_chunk.x3, _hyper_1_1_chunk.x4, _hyper_1_1_chunk.x5, _hyper_1_1_chunk.c1, _hyper_1_1_chunk.c2
-               ->  Seq Scan on _timescaledb_internal.compress_hyper_2_7_chunk (actual rows=3 loops=1)
-                     Output: compress_hyper_2_7_chunk."time", compress_hyper_2_7_chunk._ts_meta_min_1, compress_hyper_2_7_chunk._ts_meta_max_1, compress_hyper_2_7_chunk.x1, compress_hyper_2_7_chunk.x2, compress_hyper_2_7_chunk.x3, compress_hyper_2_7_chunk._ts_meta_min_2, compress_hyper_2_7_chunk._ts_meta_max_2, compress_hyper_2_7_chunk.x4, compress_hyper_2_7_chunk._ts_meta_min_3, compress_hyper_2_7_chunk._ts_meta_max_3, compress_hyper_2_7_chunk.x5, compress_hyper_2_7_chunk.c1, compress_hyper_2_7_chunk.c2, compress_hyper_2_7_chunk._ts_meta_count
-         ->  Seq Scan on _timescaledb_internal._hyper_1_1_chunk (actual rows=1 loops=1)
-               Output: _hyper_1_1_chunk."time", _hyper_1_1_chunk.x1, _hyper_1_1_chunk.x2, _hyper_1_1_chunk.x3, _hyper_1_1_chunk.x4, _hyper_1_1_chunk.x5, _hyper_1_1_chunk.c1, _hyper_1_1_chunk.c2
-(11 rows)
-
-ROLLBACK;
--- Should be optimized again
+-- Should be optimized
 :PREFIX
 SELECT * FROM test1 ORDER BY time ASC NULLS LAST;
                                                                                                                                                                                                                                                                            QUERY PLAN                                                                                                                                                                                                                                                                            
@@ -1065,6 +1044,49 @@ SELECT * FROM test1 ORDER BY time ASC NULLS LAST;
                Output: compress_hyper_2_7_chunk."time", compress_hyper_2_7_chunk._ts_meta_min_1, compress_hyper_2_7_chunk._ts_meta_max_1, compress_hyper_2_7_chunk.x1, compress_hyper_2_7_chunk.x2, compress_hyper_2_7_chunk.x3, compress_hyper_2_7_chunk._ts_meta_min_2, compress_hyper_2_7_chunk._ts_meta_max_2, compress_hyper_2_7_chunk.x4, compress_hyper_2_7_chunk._ts_meta_min_3, compress_hyper_2_7_chunk._ts_meta_max_3, compress_hyper_2_7_chunk.x5, compress_hyper_2_7_chunk.c1, compress_hyper_2_7_chunk.c2, compress_hyper_2_7_chunk._ts_meta_count
 (9 rows)
 
+BEGIN TRANSACTION;
+INSERT INTO test1 (time, x1, x2, x3, x4, x5) values('2000-01-01 02:01:00-00', 10, 20, 30, 40, 50);
+-- Should be optimized using a merge append path between the compressed and uncompressed part of the chunk
+:PREFIX
+SELECT * FROM test1 ORDER BY time ASC NULLS LAST;
+                                                                                                                                                                                                                                                                                 QUERY PLAN                                                                                                                                                                                                                                                                                  
+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Custom Scan (ChunkAppend) on public.test1 (actual rows=5 loops=1)
+   Output: test1."time", test1.x1, test1.x2, test1.x3, test1.x4, test1.x5, test1.c1, test1.c2
+   Order: test1."time"
+   Startup Exclusion: false
+   Runtime Exclusion: false
+   ->  Merge Append (actual rows=5 loops=1)
+         Sort Key: _hyper_1_1_chunk."time"
+         ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_1_chunk (actual rows=4 loops=1)
+               Output: _hyper_1_1_chunk."time", _hyper_1_1_chunk.x1, _hyper_1_1_chunk.x2, _hyper_1_1_chunk.x3, _hyper_1_1_chunk.x4, _hyper_1_1_chunk.x5, _hyper_1_1_chunk.c1, _hyper_1_1_chunk.c2
+               Sorted merge append: true
+               ->  Sort (actual rows=3 loops=1)
+                     Output: compress_hyper_2_7_chunk."time", compress_hyper_2_7_chunk._ts_meta_min_1, compress_hyper_2_7_chunk._ts_meta_max_1, compress_hyper_2_7_chunk.x1, compress_hyper_2_7_chunk.x2, compress_hyper_2_7_chunk.x3, compress_hyper_2_7_chunk._ts_meta_min_2, compress_hyper_2_7_chunk._ts_meta_max_2, compress_hyper_2_7_chunk.x4, compress_hyper_2_7_chunk._ts_meta_min_3, compress_hyper_2_7_chunk._ts_meta_max_3, compress_hyper_2_7_chunk.x5, compress_hyper_2_7_chunk.c1, compress_hyper_2_7_chunk.c2, compress_hyper_2_7_chunk._ts_meta_count
+                     Sort Key: compress_hyper_2_7_chunk._ts_meta_min_1
+                     Sort Method: quicksort 
+                     ->  Seq Scan on _timescaledb_internal.compress_hyper_2_7_chunk (actual rows=3 loops=1)
+                           Output: compress_hyper_2_7_chunk."time", compress_hyper_2_7_chunk._ts_meta_min_1, compress_hyper_2_7_chunk._ts_meta_max_1, compress_hyper_2_7_chunk.x1, compress_hyper_2_7_chunk.x2, compress_hyper_2_7_chunk.x3, compress_hyper_2_7_chunk._ts_meta_min_2, compress_hyper_2_7_chunk._ts_meta_max_2, compress_hyper_2_7_chunk.x4, compress_hyper_2_7_chunk._ts_meta_min_3, compress_hyper_2_7_chunk._ts_meta_max_3, compress_hyper_2_7_chunk.x5, compress_hyper_2_7_chunk.c1, compress_hyper_2_7_chunk.c2, compress_hyper_2_7_chunk._ts_meta_count
+         ->  Sort (actual rows=1 loops=1)
+               Output: _hyper_1_1_chunk."time", _hyper_1_1_chunk.x1, _hyper_1_1_chunk.x2, _hyper_1_1_chunk.x3, _hyper_1_1_chunk.x4, _hyper_1_1_chunk.x5, _hyper_1_1_chunk.c1, _hyper_1_1_chunk.c2
+               Sort Key: _hyper_1_1_chunk."time"
+               Sort Method: quicksort 
+               ->  Seq Scan on _timescaledb_internal._hyper_1_1_chunk (actual rows=1 loops=1)
+                     Output: _hyper_1_1_chunk."time", _hyper_1_1_chunk.x1, _hyper_1_1_chunk.x2, _hyper_1_1_chunk.x3, _hyper_1_1_chunk.x4, _hyper_1_1_chunk.x5, _hyper_1_1_chunk.c1, _hyper_1_1_chunk.c2
+(22 rows)
+
+-- The inserted value should be visible
+SELECT * FROM test1 ORDER BY time ASC NULLS LAST;
+             time             | x1 | x2 | x3 | x4 | x5 | c1 | c2 
+------------------------------+----+----+----+----+----+----+----
+ Fri Dec 31 16:00:00 1999 PST |  1 |  2 |  1 |  1 |  0 |    | 43
+ Fri Dec 31 17:00:00 1999 PST |  1 |  3 |  2 |  2 |  0 |    | 43
+ Fri Dec 31 18:00:00 1999 PST |  2 |  1 |  3 |  3 |  0 |    | 43
+ Fri Dec 31 18:01:00 1999 PST | 10 | 20 | 30 | 40 | 50 |    | 43
+ Fri Dec 31 19:00:00 1999 PST |  1 |  2 |  4 |  4 |  0 |    | 43
+(5 rows)
+
+ROLLBACK;
 ------
 -- Tests on a larger relation
 ------

--- a/tsl/test/sql/compression_insert.sql.in
+++ b/tsl/test/sql/compression_insert.sql.in
@@ -517,6 +517,15 @@ ROLLBACK;
 DROP TABLE trigger_test;
 
 -- test interaction between newly inserted batches and pathkeys/ordered append
+--
+-- The following test operates on a small relation. By using the
+-- timescaledb.enable_decompression_sorted_merge optimization, we are pushing a sort node
+-- below the DecompressChunk node, which operates on the batches. This could lead to flaky
+-- tests because the input data is small and PostgreSQL switches from IndexScans to
+-- SequentialScans. Disable the optimization for the following test to ensure we have
+-- stable query plans in all CI environments.
+SET timescaledb.enable_decompression_sorted_merge = 0;
+
 CREATE TABLE test_ordering(time int);
 SELECT table_name FROM create_hypertable('test_ordering','time',chunk_time_interval:=100);
 ALTER TABLE test_ordering SET (timescaledb.compress,timescaledb.compress_orderby='time desc');
@@ -555,6 +564,7 @@ SELECT compress_chunk(format('%I.%I',chunk_schema,chunk_name), true) FROM timesc
 
 -- should be ordered append
 :PREFIX SELECT * FROM test_ordering ORDER BY 1;
+SET timescaledb.enable_decompression_sorted_merge = 1;
 
 -- TEST cagg triggers with insert into compressed chunk
 CREATE TABLE conditions (

--- a/tsl/test/sql/compression_sorted_merge.sql.in
+++ b/tsl/test/sql/compression_sorted_merge.sql.in
@@ -313,22 +313,25 @@ SELECT * FROM test_with_defined_null ORDER BY x2 ASC NULLS LAST;
 SELECT * FROM test_with_defined_null ORDER BY x2 DESC NULLS FIRST;
 
 ------
--- Tests based on chunk state
+-- Tests based on compressed chunk state
 ------
 
+-- Should be optimized
+:PREFIX
+SELECT * FROM test1 ORDER BY time ASC NULLS LAST;
+
 BEGIN TRANSACTION;
+
 INSERT INTO test1 (time, x1, x2, x3, x4, x5) values('2000-01-01 02:01:00-00', 10, 20, 30, 40, 50);
 
--- Should not be optimized because of the partially compressed chunk
+-- Should be optimized using a merge append path between the compressed and uncompressed part of the chunk
 :PREFIX
+SELECT * FROM test1 ORDER BY time ASC NULLS LAST;
+
+-- The inserted value should be visible
 SELECT * FROM test1 ORDER BY time ASC NULLS LAST;
 
 ROLLBACK;
-
--- Should be optimized again
-:PREFIX
-SELECT * FROM test1 ORDER BY time ASC NULLS LAST;
-
 
 ------
 -- Tests on a larger relation


### PR DESCRIPTION
This patch enables the compressed merge optimization also for partially compressed chunks.

Disable-check: force-changelog-file