### PR TITLE
Quote username identifier appropriately

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ accidentally triggering the load of a previous DB version.**
 * #5615 Add permission checks to run_job()
 * #5614 Enable run_job() for telemetry job
 * #5578 Fix on-insert decompression after schema changes
+* #5613 Quote username identifier appropriately
 
 **Thanks**
 * @kovetskiy and @DZDomi for reporting peformance regression in Realtime Continuous Aggregates

--- a/sql/job_error_log_retention.sql
+++ b/sql/job_error_log_retention.sql
@@ -65,7 +65,7 @@ VALUES
     INTERVAL '1h',
     '_timescaledb_internal',
     'policy_job_error_retention',
-    current_role::regrole,
+    pg_catalog.quote_ident(current_role)::regrole,
     true,
     '{"drop_after":"1 month"}',
     '_timescaledb_internal',

--- a/sql/pre_install/tables.sql
+++ b/sql/pre_install/tables.sql
@@ -280,7 +280,7 @@ CREATE TABLE _timescaledb_config.bgw_job (
   retry_period interval NOT NULL,
   proc_schema name NOT NULL,
   proc_name name NOT NULL,
-  owner regrole NOT NULL DEFAULT current_role::regrole,
+  owner regrole NOT NULL DEFAULT pg_catalog.quote_ident(current_role)::regrole,
   scheduled bool NOT NULL DEFAULT TRUE,
   fixed_schedule bool not null default true,
   initial_start timestamptz,

--- a/sql/updates/latest-dev.sql
+++ b/sql/updates/latest-dev.sql
@@ -53,3 +53,5 @@ ALTER FUNCTION _timescaledb_internal.compressed_data_recv(internal) SET SCHEMA _
 ALTER FUNCTION _timescaledb_internal.rxid_in(cstring) SET SCHEMA _timescaledb_functions;
 ALTER FUNCTION _timescaledb_internal.rxid_out(@extschema@.rxid) SET SCHEMA _timescaledb_functions;
 
+ALTER TABLE _timescaledb_config.bgw_job
+    ALTER COLUMN owner SET DEFAULT pg_catalog.quote_ident(current_role)::regrole;

--- a/sql/updates/reverse-dev.sql
+++ b/sql/updates/reverse-dev.sql
@@ -197,3 +197,5 @@ BEGIN
 END
 $BODY$ SET search_path TO pg_catalog, pg_temp;
 
+ALTER TABLE _timescaledb_config.bgw_job
+    ALTER COLUMN owner SET DEFAULT current_role::regrole;

--- a/sql/with_telemetry.sql
+++ b/sql/with_telemetry.sql
@@ -7,5 +7,5 @@ CREATE OR REPLACE FUNCTION @extschema@.get_telemetry_report() RETURNS jsonb
 	LANGUAGE C STABLE PARALLEL SAFE;
 
 INSERT INTO _timescaledb_config.bgw_job (id, application_name, schedule_interval, max_runtime, max_retries, retry_period, proc_schema, proc_name, owner, scheduled, fixed_schedule) VALUES
-(1, 'Telemetry Reporter [1]', INTERVAL '24h', INTERVAL '100s', -1, INTERVAL '1h', '_timescaledb_internal', 'policy_telemetry', current_role::regrole, true, false)
+(1, 'Telemetry Reporter [1]', INTERVAL '24h', INTERVAL '100s', -1, INTERVAL '1h', '_timescaledb_internal', 'policy_telemetry', pg_catalog.quote_ident(current_role)::regrole, true, false)
 ON CONFLICT (id) DO NOTHING;

--- a/test/expected/extension_scripts.out
+++ b/test/expected/extension_scripts.out
@@ -46,6 +46,13 @@ CREATE OR REPLACE FUNCTION show_chunks(relation regclass, older_than "any" DEFAU
 CREATE EXTENSION timescaledb;
 ERROR:  function "show_chunks" already exists with same argument types
 DROP FUNCTION show_chunks;
+-- Create a user that is not all-lowercase
+CREATE USER "FooBar" WITH SUPERUSER;
+\c :TEST_DBNAME "FooBar"
+SET client_min_messages TO error;
+CREATE EXTENSION timescaledb;
+DROP EXTENSION timescaledb;
+RESET client_min_messages;
 \c :TEST_DBNAME :ROLE_SUPERUSER
 SET client_min_messages TO ERROR;
 CREATE EXTENSION timescaledb;

--- a/test/sql/extension_scripts.sql
+++ b/test/sql/extension_scripts.sql
@@ -48,6 +48,15 @@ CREATE OR REPLACE FUNCTION show_chunks(relation regclass, older_than "any" DEFAU
 CREATE EXTENSION timescaledb;
 DROP FUNCTION show_chunks;
 
+-- Create a user that is not all-lowercase
+CREATE USER "FooBar" WITH SUPERUSER;
+
+\c :TEST_DBNAME "FooBar"
+SET client_min_messages TO error;
+CREATE EXTENSION timescaledb;
+DROP EXTENSION timescaledb;
+RESET client_min_messages;
+
 \c :TEST_DBNAME :ROLE_SUPERUSER
 SET client_min_messages TO ERROR;
 CREATE EXTENSION timescaledb;

--- a/tsl/test/expected/bgw_db_scheduler_fixed.out
+++ b/tsl/test/expected/bgw_db_scheduler_fixed.out
@@ -24,7 +24,7 @@ CREATE OR REPLACE FUNCTION insert_job(
        schedule_interval INTERVAL,
        max_runtime INTERVAL,
        retry_period INTERVAL,
-       owner regrole DEFAULT current_role::regrole,
+       owner regrole DEFAULT pg_catalog.quote_ident(current_role)::regrole,
        scheduled BOOL DEFAULT true,
        fixed_schedule BOOL DEFAULT true
 )

--- a/tsl/test/sql/bgw_db_scheduler_fixed.sql
+++ b/tsl/test/sql/bgw_db_scheduler_fixed.sql
@@ -30,7 +30,7 @@ CREATE OR REPLACE FUNCTION insert_job(
        schedule_interval INTERVAL,
        max_runtime INTERVAL,
        retry_period INTERVAL,
-       owner regrole DEFAULT current_role::regrole,
+       owner regrole DEFAULT pg_catalog.quote_ident(current_role)::regrole,
        scheduled BOOL DEFAULT true,
        fixed_schedule BOOL DEFAULT true
 )


### PR DESCRIPTION
Need to use quote_ident() on the user roles. Otherwise the extension scripts will fail.