### PR TITLE
Fix CI ignored regression workflows

### DIFF
--- a/.github/workflows/linux-build-and-test-ignored.yaml
+++ b/.github/workflows/linux-build-and-test-ignored.yaml
@@ -36,6 +36,8 @@ jobs:
         fi
 
   regress:
+    name: PG${{ matrix.pg }}${{ matrix.snapshot }} ${{ matrix.name }} ${{ matrix.os }}
+    needs: matrixbuilder
     runs-on: ubuntu-latest
     steps:
       - run: |


### PR DESCRIPTION
We defined some paths to ignore regression test workflows when, for example, we change the CHANGELOG.md and others. But in fact it was not happening because we didn't define a proper name in the fake regression workflow that fake to the CI that some required status passed.

Fixed it defining a proper regression name like we do for the regular regression workflow and also added a path to ignore changes in the YAML file that define the workflow.

Disable-check: force-changelog-changed
