### PR TITLE
Fix ALTER TABLE SET with normal tables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ accidentally triggering the load of a previous DB version.**
 * #5578 Fix on-insert decompression after schema changes
 * #5613 Quote username identifier appropriately
 * #5525 Fix tablespace for compressed hypertable and corresponding toast
+* #5642 Fix ALTER TABLE SET with normal tables
 
 **Thanks**
 * @kovetskiy and @DZDomi for reporting peformance regression in Realtime Continuous Aggregates

--- a/src/process_utility.c
+++ b/src/process_utility.c
@@ -3412,15 +3412,15 @@ process_altertable_start_table(ProcessUtilityArgs *args)
 			}
 			case AT_SetRelOptions:
 			{
-				if (num_cmds != 1)
-				{
-					ereport(ERROR,
-							(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
-							 errmsg("ALTER TABLE <hypertable> SET does not support multiple "
-									"clauses")));
-				}
 				if (ht != NULL)
 				{
+					if (num_cmds != 1)
+					{
+						ereport(ERROR,
+								(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
+								 errmsg("ALTER TABLE <hypertable> SET does not support multiple "
+										"clauses")));
+					}
 					EventTriggerAlterTableStart(args->parsetree);
 					result = process_altertable_set_options(cmd, ht);
 				}

--- a/test/expected/reloptions.out
+++ b/test/expected/reloptions.out
@@ -22,6 +22,10 @@ WHERE relname ~ '^_hyper.*' AND relkind = 'r';
 
 -- Alter reloptions
 ALTER TABLE reloptions_test SET (fillfactor=80, parallel_workers=8);
+\set ON_ERROR_STOP 0
+ALTER TABLE reloptions_test SET (fillfactor=80), SET (parallel_workers=8);
+ERROR:  ALTER TABLE <hypertable> SET does not support multiple clauses
+\set ON_ERROR_STOP 1
 SELECT relname, reloptions FROM pg_class
 WHERE relname ~ '^_hyper.*' AND relkind = 'r';
      relname      |                             reloptions                             
@@ -39,3 +43,8 @@ WHERE relname ~ '^_hyper.*' AND relkind = 'r';
  _hyper_1_2_chunk | {autovacuum_vacuum_threshold=100,parallel_workers=8}
 (2 rows)
 
+-- Test reloptions on a regular table
+CREATE TABLE reloptions_test2(time integer, temp float8, color integer);
+ALTER TABLE reloptions_test2 SET (fillfactor=80, parallel_workers=8);
+ALTER TABLE reloptions_test2 SET (fillfactor=80), SET (parallel_workers=8);
+DROP TABLE reloptions_test2;

--- a/test/sql/reloptions.sql
+++ b/test/sql/reloptions.sql
@@ -16,6 +16,10 @@ WHERE relname ~ '^_hyper.*' AND relkind = 'r';
 -- Alter reloptions
 ALTER TABLE reloptions_test SET (fillfactor=80, parallel_workers=8);
 
+\set ON_ERROR_STOP 0
+ALTER TABLE reloptions_test SET (fillfactor=80), SET (parallel_workers=8);
+\set ON_ERROR_STOP 1
+
 SELECT relname, reloptions FROM pg_class
 WHERE relname ~ '^_hyper.*' AND relkind = 'r';
 
@@ -23,3 +27,9 @@ ALTER TABLE reloptions_test RESET (fillfactor);
 
 SELECT relname, reloptions FROM pg_class
 WHERE relname ~ '^_hyper.*' AND relkind = 'r';
+
+-- Test reloptions on a regular table
+CREATE TABLE reloptions_test2(time integer, temp float8, color integer);
+ALTER TABLE reloptions_test2 SET (fillfactor=80, parallel_workers=8);
+ALTER TABLE reloptions_test2 SET (fillfactor=80), SET (parallel_workers=8);
+DROP TABLE reloptions_test2;


### PR DESCRIPTION
Running ALTER TABLE SET with multiple SET clauses on a regular PostreSQL table produces irrelevant error when timescaledb extension is installed.

Fix #5641