### PR TITLE
Fix segfault when deleting from compressed chunk

### DIFF
--- a/src/cross_module_fn.h
+++ b/src/cross_module_fn.h
@@ -139,7 +139,7 @@ typedef struct CrossModuleFunctions
 	PGFunction decompress_chunk;
 	void (*decompress_batches_for_insert)(ChunkInsertState *state, Chunk *chunk,
 										  TupleTableSlot *slot);
-	void (*decompress_batches_for_update_delete)(List *chunks, List *predicates);
+	bool (*decompress_target_segments)(PlanState *ps);
 	/* The compression functions below are not installed in SQL as part of create extension;
 	 *  They are installed and tested during testing scripts. They are exposed in cross-module
 	 *  functions because they may be very useful for debugging customer problems if the sql

--- a/tsl/src/compression/compression.h
+++ b/tsl/src/compression/compression.h
@@ -307,7 +307,7 @@ typedef struct ChunkInsertState ChunkInsertState;
 extern void decompress_batches_for_insert(ChunkInsertState *cis, Chunk *chunk,
 										  TupleTableSlot *slot);
 #if PG14_GE
-extern void decompress_batches_for_update_delete(List *chunks, List *predicates);
+extern bool decompress_target_segments(PlanState *ps);
 #endif
 /* CompressSingleRowState methods */
 struct CompressSingleRowState;

--- a/tsl/src/init.c
+++ b/tsl/src/init.c
@@ -185,9 +185,9 @@ CrossModuleFunctions tsl_cm_functions = {
 	.decompress_chunk = tsl_decompress_chunk,
 	.decompress_batches_for_insert = decompress_batches_for_insert,
 #if PG14_GE
-	.decompress_batches_for_update_delete = decompress_batches_for_update_delete,
+	.decompress_target_segments = decompress_target_segments,
 #else
-	.decompress_batches_for_update_delete = NULL,
+	.decompress_target_segments = NULL,
 #endif
 
 	.data_node_add = data_node_add,

--- a/tsl/test/expected/compression.out
+++ b/tsl/test/expected/compression.out
@@ -206,10 +206,11 @@ do update set b = excluded.b;
 SELECT * from foo ORDER BY a,b;
  a  |  b  | c  | d  
 ----+-----+----+----
+  3 | 111 | 20 |   
  10 |  12 | 12 | 12
  20 | 111 | 20 |   
  30 | 111 | 40 |   
-(3 rows)
+(4 rows)
 
 --TEST2c Do DML directly on the chunk.
 insert into _timescaledb_internal._hyper_1_2_chunk values(10, 12, 12, 12)
@@ -218,10 +219,11 @@ do update set b = excluded.b + 12;
 SELECT * from foo ORDER BY a,b;
  a  |  b  | c  | d  
 ----+-----+----+----
+  3 | 111 | 20 |   
  10 |  24 | 12 | 12
  20 | 111 | 20 |   
  30 | 111 | 40 |   
-(3 rows)
+(4 rows)
 
 update _timescaledb_internal._hyper_1_2_chunk
 set b = 12;
@@ -238,9 +240,8 @@ update foo set b =20 where a = 10;
 select * from _timescaledb_internal._hyper_1_2_chunk order by a,b;
  a  | b  | c  |  d  
 ----+----+----+-----
- 10 | 20 | 20 |    
  11 | 10 | 20 | 120
-(2 rows)
+(1 row)
 
 delete from foo where a = 10;
 select * from _timescaledb_internal._hyper_1_2_chunk order by a,b;
@@ -444,15 +445,6 @@ vacuum full conditions;
 -- After vacuum, table_bytes is 0, but any associated index/toast storage is not
 -- completely reclaimed. Sets it at 8K (page size). So a chunk which has
 -- been compressed still incurs an overhead of n * 8KB (for every index + toast table) storage on the original uncompressed chunk.
-select pg_size_pretty(table_bytes), pg_size_pretty(index_bytes),
-pg_size_pretty(toast_bytes), pg_size_pretty(total_bytes)
-from hypertable_detailed_size('foo');
--[ RECORD 1 ]--+-----------
-pg_size_pretty | 32 kB
-pg_size_pretty | 144 kB
-pg_size_pretty | 8192 bytes
-pg_size_pretty | 184 kB
-
 select pg_size_pretty(table_bytes), pg_size_pretty(index_bytes),
 pg_size_pretty(toast_bytes), pg_size_pretty(total_bytes)
 from hypertable_detailed_size('conditions');

--- a/tsl/test/expected/compression_update_delete.out
+++ b/tsl/test/expected/compression_update_delete.out
@@ -1722,3 +1722,108 @@ SELECT COUNT(*) = :total_rows - :total_affected_rows FROM sample_table;
 (1 row)
 
 ROLLBACK;
+--github issue: 5640
+CREATE TABLE tab1(filler_1 int, filler_2 int, filler_3 int, time timestamptz NOT NULL, device_id int, v0 int, v1 int, v2 float, v3 float);
+CREATE INDEX ON tab1(time);
+CREATE INDEX ON tab1(device_id,time);
+SELECT create_hypertable('tab1','time',create_default_indexes:=false);
+ create_hypertable  
+--------------------
+ (21,public,tab1,t)
+(1 row)
+
+ALTER TABLE tab1 DROP COLUMN filler_1;
+INSERT INTO tab1(time,device_id,v0,v1,v2,v3) SELECT time, device_id, device_id+1,  device_id + 2, device_id + 0.5, NULL FROM generate_series('2000-01-01 0:00:00+0'::timestamptz,'2000-01-05 23:55:00+0','57m') gtime(time), generate_series(1,1,1) gdevice(device_id);
+ALTER TABLE tab1 DROP COLUMN filler_2;
+INSERT INTO tab1(time,device_id,v0,v1,v2,v3) SELECT time, device_id, device_id-1, device_id + 2, device_id + 0.5, NULL FROM generate_series('2000-01-06 0:00:00+0'::timestamptz,'2000-01-12 23:55:00+0','58m') gtime(time), generate_series(1,1,1) gdevice(device_id);
+ALTER TABLE tab1 DROP COLUMN filler_3;
+INSERT INTO tab1(time,device_id,v0,v1,v2,v3) SELECT time, device_id, device_id, device_id + 2, device_id + 0.5, NULL FROM generate_series('2000-01-13 0:00:00+0'::timestamptz,'2000-01-19 23:55:00+0','59m') gtime(time), generate_series(1,1,1) gdevice(device_id);
+ANALYZE tab1;
+-- compress chunks
+ALTER TABLE tab1 SET (timescaledb.compress, timescaledb.compress_orderby='time DESC', timescaledb.compress_segmentby='device_id');
+SELECT compress_chunk(show_chunks('tab1'));
+              compress_chunk              
+------------------------------------------
+ _timescaledb_internal._hyper_21_39_chunk
+ _timescaledb_internal._hyper_21_40_chunk
+ _timescaledb_internal._hyper_21_41_chunk
+(3 rows)
+
+-- ensure there is an index scan generated for below DELETE query
+BEGIN;
+SELECT count(*) FROM tab1 WHERE device_id = 1;
+ count 
+-------
+   472
+(1 row)
+
+INSERT INTO tab1(time,device_id,v0,v1,v2,v3) SELECT time, device_id, device_id+1,  device_id + 2, device_id + 1000, NULL FROM generate_series('2000-01-01 0:00:00+0'::timestamptz,'2000-01-05 23:55:00+0','2m') gtime(time), generate_series(1,5,1) gdevice(device_id);
+SELECT count(*) FROM tab1 WHERE device_id = 1;
+ count 
+-------
+  4070
+(1 row)
+
+ANALYZE tab1;
+EXPLAIN (costs off) DELETE FROM public.tab1 WHERE public.tab1.device_id = 1;
+                                                 QUERY PLAN                                                 
+------------------------------------------------------------------------------------------------------------
+ Custom Scan (HypertableModify)
+   ->  Delete on tab1
+         Delete on _hyper_21_39_chunk tab1_1
+         Delete on _hyper_21_40_chunk tab1_2
+         Delete on _hyper_21_41_chunk tab1_3
+         ->  Append
+               ->  Index Scan using _hyper_21_39_chunk_tab1_device_id_time_idx on _hyper_21_39_chunk tab1_1
+                     Index Cond: (device_id = 1)
+               ->  Seq Scan on _hyper_21_40_chunk tab1_2
+                     Filter: (device_id = 1)
+               ->  Seq Scan on _hyper_21_41_chunk tab1_3
+                     Filter: (device_id = 1)
+(12 rows)
+
+DELETE FROM tab1 WHERE tab1.device_id = 1;
+SELECT count(*) FROM tab1 WHERE device_id = 1;
+ count 
+-------
+     0
+(1 row)
+
+ROLLBACK;
+-- create hypertable with space partitioning and compression
+CREATE TABLE tab2(filler_1 int, filler_2 int, filler_3 int, time timestamptz NOT NULL, device_id int, v0 int, v1 int, v2 float, v3 float);
+CREATE INDEX ON tab2(time);
+CREATE INDEX ON tab2(device_id,time);
+SELECT create_hypertable('tab2','time','device_id',3,create_default_indexes:=false);
+ create_hypertable  
+--------------------
+ (23,public,tab2,t)
+(1 row)
+
+ALTER TABLE tab2 DROP COLUMN filler_1;
+INSERT INTO tab2(time,device_id,v0,v1,v2,v3) SELECT time, device_id, device_id+1, device_id + 2, device_id + 0.5, NULL FROM generate_series('2000-01-01 0:00:00+0'::timestamptz,'2000-01-05 23:55:00+0','35m') gtime(time), generate_series(1,1,1) gdevice(device_id);
+ALTER TABLE tab2 DROP COLUMN filler_2;
+INSERT INTO tab2(time,device_id,v0,v1,v2,v3) SELECT time, device_id, device_id+1, device_id + 2, device_id + 0.5, NULL FROM generate_series('2000-01-06 0:00:00+0'::timestamptz,'2000-01-12 23:55:00+0','45m') gtime(time), generate_series(1,1,1) gdevice(device_id);
+ALTER TABLE tab2 DROP COLUMN filler_3;
+INSERT INTO tab2(time,device_id,v0,v1,v2,v3) SELECT time, device_id, device_id+1, device_id + 2, device_id + 0.5, NULL FROM generate_series('2000-01-13 0:00:00+0'::timestamptz,'2000-01-19 23:55:00+0','55m') gtime(time), generate_series(1,1,1) gdevice(device_id);
+ANALYZE tab2;
+-- compress chunks
+ALTER TABLE tab2 SET (timescaledb.compress, timescaledb.compress_orderby='time DESC', timescaledb.compress_segmentby='device_id');
+SELECT compress_chunk(show_chunks('tab2'));
+              compress_chunk              
+------------------------------------------
+ _timescaledb_internal._hyper_23_45_chunk
+ _timescaledb_internal._hyper_23_46_chunk
+ _timescaledb_internal._hyper_23_47_chunk
+(3 rows)
+
+-- below test will cause chunks of tab2 to get decompressed
+-- without fix for issue #5460
+SET timescaledb.enable_optimizations = OFF;
+BEGIN;
+DELETE FROM tab1 t1 USING tab2 t2 WHERE t1.device_id = t2.device_id AND t2.time > '2000-01-01';
+ROLLBACK;
+--cleanup
+RESET timescaledb.enable_optimizations;
+DROP table tab1;
+DROP table tab2;

--- a/tsl/test/sql/compression.sql
+++ b/tsl/test/sql/compression.sql
@@ -184,9 +184,6 @@ vacuum full conditions;
 -- been compressed still incurs an overhead of n * 8KB (for every index + toast table) storage on the original uncompressed chunk.
 select pg_size_pretty(table_bytes), pg_size_pretty(index_bytes),
 pg_size_pretty(toast_bytes), pg_size_pretty(total_bytes)
-from hypertable_detailed_size('foo');
-select pg_size_pretty(table_bytes), pg_size_pretty(index_bytes),
-pg_size_pretty(toast_bytes), pg_size_pretty(total_bytes)
 from hypertable_detailed_size('conditions');
 select * from timescaledb_information.hypertables
 where hypertable_name like 'foo' or hypertable_name like 'conditions'


### PR DESCRIPTION
During UPDATE/DELETE on compressed hypertables, we iterate over plan
tree to collect all scan nodes. For each scan nodes there can be
filter conditions.

Prior to this patch we collect only first filter condition and use
for first chunk which may be wrong. In this patch as and when we
encounter a target scan node, we immediately process those chunks.

Fixes #5640