### PR TITLE
Fix JOIN handling in UPDATE/DELETE on compressed chunks

### DIFF
--- a/src/cross_module_fn.h
+++ b/src/cross_module_fn.h
@@ -139,7 +139,7 @@ typedef struct CrossModuleFunctions
 	PGFunction decompress_chunk;
 	void (*decompress_batches_for_insert)(ChunkInsertState *state, Chunk *chunk,
 										  TupleTableSlot *slot);
-	bool (*decompress_target_segments)(PlanState *ps);
+	bool (*decompress_target_segments)(ModifyTableState *ps);
 	/* The compression functions below are not installed in SQL as part of create extension;
 	 *  They are installed and tested during testing scripts. They are exposed in cross-module
 	 *  functions because they may be very useful for debugging customer problems if the sql

--- a/src/nodes/hypertable_modify.c
+++ b/src/nodes/hypertable_modify.c
@@ -754,7 +754,7 @@ ExecModifyTable(CustomScanState *cs_node, PlanState *pstate)
 	{
 		if (ts_cm_functions->decompress_target_segments)
 		{
-			ts_cm_functions->decompress_target_segments(pstate);
+			ts_cm_functions->decompress_target_segments(node);
 			ht_state->comp_chunks_processed = true;
 			/*
 			 * save snapshot set during ExecutorStart(), since this is the same

--- a/tsl/src/compression/compression.h
+++ b/tsl/src/compression/compression.h
@@ -307,7 +307,7 @@ typedef struct ChunkInsertState ChunkInsertState;
 extern void decompress_batches_for_insert(ChunkInsertState *cis, Chunk *chunk,
 										  TupleTableSlot *slot);
 #if PG14_GE
-extern bool decompress_target_segments(PlanState *ps);
+extern bool decompress_target_segments(ModifyTableState *ps);
 #endif
 /* CompressSingleRowState methods */
 struct CompressSingleRowState;

--- a/tsl/test/expected/compression_update_delete.out
+++ b/tsl/test/expected/compression_update_delete.out
@@ -1827,3 +1827,150 @@ ROLLBACK;
 RESET timescaledb.enable_optimizations;
 DROP table tab1;
 DROP table tab2;
+-- test joins with UPDATE/DELETE on compression chunks
+CREATE TABLE join_test1(time timestamptz NOT NULL,device text, value float);
+CREATE TABLE join_test2(time timestamptz NOT NULL,device text, value float);
+CREATE VIEW chunk_status AS SELECT ht.table_name AS hypertable, ch.table_name AS chunk,ch.status from _timescaledb_catalog.chunk ch INNER JOIN _timescaledb_catalog.hypertable ht ON ht.id=ch.hypertable_id AND ht.table_name IN ('join_test1','join_test2') ORDER BY ht.id, ch.id;
+SELECT table_name FROM create_hypertable('join_test1', 'time');
+ table_name 
+------------
+ join_test1
+(1 row)
+
+SELECT table_name FROM create_hypertable('join_test2', 'time');
+ table_name 
+------------
+ join_test2
+(1 row)
+
+ALTER TABLE join_test1 SET (timescaledb.compress, timescaledb.compress_segmentby='device');
+ALTER TABLE join_test2 SET (timescaledb.compress, timescaledb.compress_segmentby='device');
+INSERT INTO join_test1 VALUES ('2000-01-01','d1',0.1), ('2000-02-01','d1',0.1), ('2000-03-01','d1',0.1);
+INSERT INTO join_test2 VALUES ('2000-02-01','d1',0.1), ('2000-02-01','d2',0.1), ('2000-02-01','d3',0.1);
+SELECT compress_chunk(show_chunks('join_test1'));
+              compress_chunk              
+------------------------------------------
+ _timescaledb_internal._hyper_25_51_chunk
+ _timescaledb_internal._hyper_25_52_chunk
+ _timescaledb_internal._hyper_25_53_chunk
+(3 rows)
+
+SELECT compress_chunk(show_chunks('join_test2'));
+              compress_chunk              
+------------------------------------------
+ _timescaledb_internal._hyper_26_54_chunk
+(1 row)
+
+SELECT * FROM chunk_status;
+ hypertable |       chunk        | status 
+------------+--------------------+--------
+ join_test1 | _hyper_25_51_chunk |      1
+ join_test1 | _hyper_25_52_chunk |      1
+ join_test1 | _hyper_25_53_chunk |      1
+ join_test2 | _hyper_26_54_chunk |      1
+(4 rows)
+
+BEGIN;
+DELETE FROM join_test1 USING join_test2;
+-- only join_test1 chunks should have status 9
+SELECT * FROM chunk_status;
+ hypertable |       chunk        | status 
+------------+--------------------+--------
+ join_test1 | _hyper_25_51_chunk |      9
+ join_test1 | _hyper_25_52_chunk |      9
+ join_test1 | _hyper_25_53_chunk |      9
+ join_test2 | _hyper_26_54_chunk |      1
+(4 rows)
+
+ROLLBACK;
+BEGIN;
+DELETE FROM join_test2 USING join_test1;
+-- only join_test2 chunks should have status 9
+SELECT * FROM chunk_status;
+ hypertable |       chunk        | status 
+------------+--------------------+--------
+ join_test1 | _hyper_25_51_chunk |      1
+ join_test1 | _hyper_25_52_chunk |      1
+ join_test1 | _hyper_25_53_chunk |      1
+ join_test2 | _hyper_26_54_chunk |      9
+(4 rows)
+
+ROLLBACK;
+BEGIN;
+DELETE FROM join_test1 t1 USING join_test1 t2 WHERE t1.time = '2000-01-01';
+-- only first chunk of join_test1 should have status change
+SELECT * FROM chunk_status;
+ hypertable |       chunk        | status 
+------------+--------------------+--------
+ join_test1 | _hyper_25_51_chunk |      9
+ join_test1 | _hyper_25_52_chunk |      1
+ join_test1 | _hyper_25_53_chunk |      1
+ join_test2 | _hyper_26_54_chunk |      1
+(4 rows)
+
+ROLLBACK;
+BEGIN;
+DELETE FROM join_test1 t1 USING join_test1 t2 WHERE t2.time = '2000-01-01';
+-- all chunks of join_test1 should have status 9
+SELECT * FROM chunk_status;
+ hypertable |       chunk        | status 
+------------+--------------------+--------
+ join_test1 | _hyper_25_51_chunk |      9
+ join_test1 | _hyper_25_52_chunk |      9
+ join_test1 | _hyper_25_53_chunk |      9
+ join_test2 | _hyper_26_54_chunk |      1
+(4 rows)
+
+ROLLBACK;
+BEGIN;
+UPDATE join_test1 t1 SET value = t1.value + 1 FROM join_test2 t2;
+-- only join_test1 chunks should have status 9
+SELECT * FROM chunk_status;
+ hypertable |       chunk        | status 
+------------+--------------------+--------
+ join_test1 | _hyper_25_51_chunk |      9
+ join_test1 | _hyper_25_52_chunk |      9
+ join_test1 | _hyper_25_53_chunk |      9
+ join_test2 | _hyper_26_54_chunk |      1
+(4 rows)
+
+ROLLBACK;
+BEGIN;
+UPDATE join_test2 t1 SET value = t1.value + 1 FROM join_test1 t2;
+-- only join_test2 chunks should have status 9
+SELECT * FROM chunk_status;
+ hypertable |       chunk        | status 
+------------+--------------------+--------
+ join_test1 | _hyper_25_51_chunk |      1
+ join_test1 | _hyper_25_52_chunk |      1
+ join_test1 | _hyper_25_53_chunk |      1
+ join_test2 | _hyper_26_54_chunk |      9
+(4 rows)
+
+ROLLBACK;
+BEGIN;
+UPDATE join_test1 t1 SET value = t1.value + 1 FROM join_test1 t2 WHERE t1.time = '2000-01-01';
+-- only first chunk of join_test1 should have status 9
+SELECT * FROM chunk_status;
+ hypertable |       chunk        | status 
+------------+--------------------+--------
+ join_test1 | _hyper_25_51_chunk |      9
+ join_test1 | _hyper_25_52_chunk |      1
+ join_test1 | _hyper_25_53_chunk |      1
+ join_test2 | _hyper_26_54_chunk |      1
+(4 rows)
+
+ROLLBACK;
+BEGIN;
+UPDATE join_test1 t1 SET value = t1.value + 1 FROM join_test1 t2 WHERE t2.time = '2000-01-01';
+-- all chunks of join_test1 should have status 9
+SELECT * FROM chunk_status;
+ hypertable |       chunk        | status 
+------------+--------------------+--------
+ join_test1 | _hyper_25_51_chunk |      9
+ join_test1 | _hyper_25_52_chunk |      9
+ join_test1 | _hyper_25_53_chunk |      9
+ join_test2 | _hyper_26_54_chunk |      1
+(4 rows)
+
+ROLLBACK;


### PR DESCRIPTION
When JOINs were present during UPDATE/DELETE on compressed chunks
the code would decompress other hypertables that were not the
target of the UPDATE/DELETE operations and in the case of self-JOINs
potentially decompress chunks not required to be decompressed.

Disable-check: force-changelog-changed
