### PR TITLE
Compression fuzzing in CI

### DIFF
--- a/.github/workflows/libfuzzer.yaml
+++ b/.github/workflows/libfuzzer.yaml
@@ -1,0 +1,175 @@
+name: Libfuzzer
+"on":
+  push:
+    branches:
+      - main
+      - prerelease_test
+  pull_request:
+    paths: .github/workflows/libfuzzer.yaml
+
+jobs:
+  fuzz:
+    name: Fuzz decompression
+    runs-on: ubuntu-22.04
+    env:
+      PG_SRC_DIR: pgbuild
+      PG_INSTALL_DIR: postgresql
+
+    steps:
+    - name: Install Linux Dependencies
+      run: |
+        # Don't add ddebs here because the ddebs mirror is always 503 Service Unavailable.
+        # If needed, install them before opening the core dump.
+        sudo apt-get update
+        sudo apt-get install clang lld llvm flex bison lcov systemd-coredump gdb libipc-run-perl \
+          libtest-most-perl
+
+    - name: Checkout TimescaleDB
+      uses: actions/checkout@v3
+
+    - name: Read configuration
+      id: config
+      run: python .github/gh_config_reader.py
+
+    # We are going to rebuild Postgres daily, so that it doesn't suddenly break
+    # ages after the original problem.
+    - name: Get date for build caching
+      id: get-date
+      run: |
+        echo "date=$(date +"%d")" >> $GITHUB_OUTPUT
+
+    # we cache the build directory instead of the install directory here
+    # because extension installation will write files to install directory
+    # leading to a tainted cache
+    - name: Cache PostgreSQL
+      id: cache-postgresql
+      uses: actions/cache@v3
+      with:
+        path: ~/${{ env.PG_SRC_DIR }}
+        key: "postgresql-libfuzzer-${{ steps.get-date.outputs.date }}-${{ hashFiles('.github/**') }}"
+
+    - name: Build PostgreSQL
+      if: steps.cache-postgresql.outputs.cache-hit != 'true'
+      run: |
+       wget -q -O postgresql.tar.bz2 \
+         https://ftp.postgresql.org/pub/source/v${{ steps.config.outputs.PG15_LATEST }}/postgresql-${{ steps.config.outputs.PG15_LATEST }}.tar.bz2
+        mkdir -p ~/$PG_SRC_DIR
+        tar --extract --file postgresql.tar.bz2 --directory ~/$PG_SRC_DIR --strip-components 1
+        cd ~/$PG_SRC_DIR
+        CC=clang ./configure --prefix=$HOME/$PG_INSTALL_DIR --with-openssl \
+          --without-readline --without-zlib --without-libxml --enable-cassert \
+          --enable-debug CC=clang \
+          CFLAGS="-DTS_COMPRESSION_FUZZING=1 -fuse-ld=lld -ggdb3 -Og -fno-omit-frame-pointer"
+        make -j$(nproc)
+
+    - name: Install PostgreSQL
+      run: |
+        make -C ~/$PG_SRC_DIR install
+        make -C ~/$PG_SRC_DIR/contrib/postgres_fdw install
+
+    - name: Upload config.log
+      if: always()
+      uses: actions/upload-artifact@v3
+      with:
+        name: config.log for PostgreSQL
+        path: ~/${{ env.PG_SRC_DIR }}/config.log
+
+    - name: Build TimescaleDB
+      run: |
+        set -e
+
+        export LIBFUZZER_PATH=$(dirname "$(find $(llvm-config --libdir) -name libclang_rt.fuzzer_no_main-x86_64.a | head -1)")
+
+        cmake -B build -S . -DASSERTIONS=ON -DLINTER=OFF -DCMAKE_VERBOSE_MAKEFILE=1 \
+            -DWARNINGS_AS_ERRORS=1 -DCMAKE_BUILD_TYPE=Debug -DCMAKE_C_COMPILER=clang \
+            -DCMAKE_C_FLAGS="-fsanitize=fuzzer-no-link -lstdc++ -L$LIBFUZZER_PATH -l:libclang_rt.fuzzer_no_main-x86_64.a -static-libsan" \
+            -DPG_PATH=$HOME/$PG_INSTALL_DIR
+
+        make -C build -j$(nproc) install
+
+    - name: Run libfuzzer for compression
+      run: |
+        set -xeu
+
+        mkdir db
+        export PGDATA=db
+        export PGPORT=5432
+        export PGDATABASE=postgres
+        export PATH=$HOME/$PG_INSTALL_DIR/bin:$PATH
+        initdb
+        echo "shared_preload_libraries = 'timescaledb'" >> $PGDATA/postgresql.conf
+        pg_ctl -l postmaster.log start
+
+        psql -c "create extension timescaledb;"
+
+        # Create the fuzzing function
+        export MODULE_NAME=$(basename $(find $HOME/$PG_INSTALL_DIR -name "timescaledb-tsl-*.so"))
+        psql -a -c "create or replace function fuzz(algo cstring, type regtype, runs int) returns int as '"$MODULE_NAME"', 'ts_fuzz_compression' language c;"
+
+        # Symlink the corpus directory to the database directory.
+        ln -sf $(readlink -e tsl/test/fuzzing/compression/gorilla-float8) $PGDATA/corpus
+
+        # The LLVM fuzzing driver calls exit(), so we expect to lose the connection.
+        ret=0
+        psql -v ON_ERROR_STOP=1 -c "select fuzz('gorilla', 'float8', 100000000);" || ret=$?
+        if ! [ $ret -eq 2 ]
+        then
+            >&2 echo "Unexpected psql exit code $ret"
+            exit 1
+        fi
+
+        # Check that the server is still alive.
+        psql -c "select 1"
+
+
+    - name: Collect the logs
+      if: always()
+      id: collectlogs
+      run: |
+        find . -name postmaster.log -exec cat {} + > postgres.log
+        # wait in case there are in-progress coredumps
+        sleep 10
+        if coredumpctl -q list >/dev/null; then echo "coredumps=true" >>$GITHUB_OUTPUT; fi
+        # print OOM killer information
+        sudo journalctl --system -q --facility=kern --grep "Killed process" || true
+
+    - name: Save PostgreSQL log
+      if: always()
+      uses: actions/upload-artifact@v3
+      with:
+        name: PostgreSQL log
+        path: postgres.log
+
+    - name: Save fuzzer-generated cases
+      if: always()
+      uses: actions/upload-artifact@v3
+      with:
+        name: Fuzzer-generated cases
+        path: db/crash-*
+
+    - name: Stack trace
+      if: always() && steps.collectlogs.outputs.coredumps == 'true'
+      run: |
+        sudo coredumpctl gdb <<<"
+          set verbose on
+          set trace-commands on
+          show debug-file-directory
+          printf "'"'"query = '%s'\n\n"'"'", debug_query_string
+          frame function ExceptionalCondition
+          printf "'"'"condition = '%s'\n"'"'", conditionName
+          up 1
+          l
+          info args
+          info locals
+          bt full
+        " 2>&1 | tee stacktrace.log
+        ./scripts/bundle_coredumps.sh
+        grep -C40 "was terminated by signal" postgres.log > postgres-failure.log ||:
+        exit 1 # Fail the job if we have core dumps.
+
+    - name: Upload core dumps
+      if: always() && steps.collectlogs.outputs.coredumps == 'true'
+      uses: actions/upload-artifact@v3
+      with:
+        name: Coredumps
+        path: coredumps

--- a/.github/workflows/linux-32bit-build-and-test.yaml
+++ b/.github/workflows/linux-32bit-build-and-test.yaml
@@ -37,7 +37,7 @@ jobs:
         DEBIAN_FRONTEND: noninteractive
         IGNORES: "append-* debug_notice transparent_decompression-*
           transparent_decompress_chunk-* plan_skip_scan-12 pg_dump 
-          dist_move_chunk dist_param dist_insert remote_txn"
+          dist_move_chunk dist_param dist_insert remote_txn telemetry"
         SKIPS: chunk_adaptive histogram_test
     strategy:
       fail-fast: false

--- a/.github/workflows/linux-build-and-test.yaml
+++ b/.github/workflows/linux-build-and-test.yaml
@@ -161,7 +161,8 @@ jobs:
       id: installcheck
       run: |
         set -o pipefail
-        make -k -C build installcheck ${{ matrix.installcheck_args }} | tee installcheck.log
+        make -k -C build installcheck IGNORES="${{ join(matrix.ignored_tests, ' ') }}" \
+            SKIPS="${{ join(matrix.skipped_tests, ' ') }}" ${{ matrix.installcheck_args }} | tee installcheck.log
 
     - name: pginstallcheck
       if: matrix.pginstallcheck

--- a/.github/workflows/windows-build-and-test.yaml
+++ b/.github/workflows/windows-build-and-test.yaml
@@ -52,7 +52,7 @@ jobs:
         pg: [ 12, 13, 14, 15 ]
         os: [ windows-2022 ]
         build_type: ${{ fromJson(needs.config.outputs.build_type) }}
-        ignores: ["chunk_adaptive metadata"]
+        ignores: ["chunk_adaptive metadata telemetry"]
         tsl_ignores: ["compression_algos remote_connection telemetry_stats-13 telemetry_stats-14 dist_move_chunk dist_param dist_insert dist_backup dist_cagg"]
         tsl_skips: ["bgw_db_scheduler bgw_db_scheduler_fixed cagg_ddl_dist_ht
           data_fetcher dist_compression dist_remote_error remote_txn"]

--- a/tsl/src/compression/compression.c
+++ b/tsl/src/compression/compression.c
@@ -2272,6 +2272,108 @@ ts_read_compressed_data_directory(PG_FUNCTION_ARGS)
 
 #endif
 
+#ifdef TS_COMPRESSION_FUZZING
+
+/*
+ * This is our test function that will be called by the libfuzzer driver. It
+ * has to catch the postgres exceptions normally produced for corrupt data.
+ */
+static int
+llvm_fuzz_target_generic(int (*target)(const uint8_t *Data, size_t Size, bool check_compression),
+						 const uint8_t *Data, size_t Size)
+{
+	MemoryContextReset(CurrentMemoryContext);
+
+	PG_TRY();
+	{
+		CHECK_FOR_INTERRUPTS();
+		target(Data, Size, /* check_compression = */ false);
+	}
+	PG_CATCH();
+	{
+		FlushErrorState();
+	}
+	PG_END_TRY();
+
+	/* We always return 0, and -1 would mean "don't include it into corpus". */
+	return 0;
+}
+
+static int
+llvm_fuzz_target_gorilla_float8(const uint8_t *Data, size_t Size)
+{
+	return llvm_fuzz_target_generic(decompress_gorilla_float8, Data, Size);
+}
+static int
+llvm_fuzz_target_deltadelta_int64(const uint8_t *Data, size_t Size)
+{
+	return llvm_fuzz_target_generic(decompress_deltadelta_int64, Data, Size);
+}
+
+/*
+ * libfuzzer fuzzing driver that we import from LLVM libraries. It will run our
+ * test functions with random inputs.
+ */
+extern int LLVMFuzzerRunDriver(int *argc, char ***argv,
+							   int (*UserCb)(const uint8_t *Data, size_t Size));
+
+/*
+ * The SQL function to perform fuzzing.
+ */
+TS_FUNCTION_INFO_V1(ts_fuzz_compression);
+
+Datum
+ts_fuzz_compression(PG_FUNCTION_ARGS)
+{
+	/*
+	 * We use the memory context size larger than default here, so that all data
+	 * allocated by fuzzing fit into the first chunk. The first chunk is not
+	 * deallocated when the memory context is reset, so this reduces overhead
+	 * caused by repeated reallocations.
+	 * The particular value of 8MB is somewhat arbitrary and large. In practice,
+	 * we have inputs of 1k rows max here, which decompress to 8 kB max.
+	 */
+	MemoryContext fuzzing_context =
+		AllocSetContextCreate(CurrentMemoryContext, "fuzzing", 0, 8 * 1024 * 1024, 8 * 1024 * 1024);
+	MemoryContext old_context = MemoryContextSwitchTo(fuzzing_context);
+
+	char *argvdata[] = { "PostgresFuzzer",
+						 "-verbosity=1",
+						 "-timeout=1",
+						 "-report_slow_units=1",
+						 "-use_value_profile=1",
+						 "-reload=1",
+						 psprintf("-runs=%d", PG_GETARG_INT32(2)),
+						 "corpus" /* in the database directory */,
+						 NULL };
+	char **argv = argvdata;
+	int argc = sizeof(argvdata) / sizeof(*argvdata) - 1;
+
+	int algo = get_compression_algorithm(PG_GETARG_CSTRING(0));
+	Oid type = PG_GETARG_OID(1);
+	int (*target)(const uint8_t *, size_t);
+	if (algo == COMPRESSION_ALGORITHM_GORILLA && type == FLOAT8OID)
+	{
+		target = llvm_fuzz_target_gorilla_float8;
+	}
+	else if (algo == COMPRESSION_ALGORITHM_DELTADELTA && type == INT8OID)
+	{
+		target = llvm_fuzz_target_deltadelta_int64;
+	}
+	else
+	{
+		elog(ERROR, "no llvm fuzz target for compression algorithm %d and type %d", algo, type);
+	}
+
+	int res = LLVMFuzzerRunDriver(&argc, &argv, target);
+
+	MemoryContextSwitchTo(old_context);
+
+	PG_RETURN_INT32(res);
+}
+
+#endif
+
 #if PG14_GE
 static SegmentFilter *
 add_filter_column_strategy(char *column_name, StrategyNumber strategy, Const *value,


### PR DESCRIPTION
This serves as a way to exercise the decompression fuzzing code, which will be useful when we need to change the decompression functions. Also this way we'll have a check in CI that uses libfuzzer, and it will be easier to apply it to other areas of code in the future.


Disable-check: force-changelog-file
Disable-check: commit-count