### PR TITLE
Improve the number of parallel workers for decompression

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ accidentally triggering the load of a previous DB version.**
 * #5578 Fix on-insert decompression after schema changes
 * #5613 Quote username identifier appropriately
 * #5525 Fix tablespace for compressed hypertable and corresponding toast
+* #5664 Improve the number of parallel workers for decompression
 
 **Thanks**
 * @kovetskiy and @DZDomi for reporting peformance regression in Realtime Continuous Aggregates

--- a/src/cross_module_fn.h
+++ b/src/cross_module_fn.h
@@ -139,7 +139,7 @@ typedef struct CrossModuleFunctions
 	PGFunction decompress_chunk;
 	void (*decompress_batches_for_insert)(ChunkInsertState *state, Chunk *chunk,
 										  TupleTableSlot *slot);
-	void (*decompress_batches_for_update_delete)(List *chunks, List *predicates);
+	bool (*decompress_target_segments)(PlanState *ps);
 	/* The compression functions below are not installed in SQL as part of create extension;
 	 *  They are installed and tested during testing scripts. They are exposed in cross-module
 	 *  functions because they may be very useful for debugging customer problems if the sql

--- a/tsl/src/compression/compression.h
+++ b/tsl/src/compression/compression.h
@@ -307,7 +307,7 @@ typedef struct ChunkInsertState ChunkInsertState;
 extern void decompress_batches_for_insert(ChunkInsertState *cis, Chunk *chunk,
 										  TupleTableSlot *slot);
 #if PG14_GE
-extern void decompress_batches_for_update_delete(List *chunks, List *predicates);
+extern bool decompress_target_segments(PlanState *ps);
 #endif
 /* CompressSingleRowState methods */
 struct CompressSingleRowState;

--- a/tsl/src/init.c
+++ b/tsl/src/init.c
@@ -185,9 +185,9 @@ CrossModuleFunctions tsl_cm_functions = {
 	.decompress_chunk = tsl_decompress_chunk,
 	.decompress_batches_for_insert = decompress_batches_for_insert,
 #if PG14_GE
-	.decompress_batches_for_update_delete = decompress_batches_for_update_delete,
+	.decompress_target_segments = decompress_target_segments,
 #else
-	.decompress_batches_for_update_delete = NULL,
+	.decompress_target_segments = NULL,
 #endif
 
 	.data_node_add = data_node_add,

--- a/tsl/src/nodes/decompress_chunk/decompress_chunk.c
+++ b/tsl/src/nodes/decompress_chunk/decompress_chunk.c
@@ -578,10 +578,12 @@ ts_decompress_chunk_generate_paths(PlannerInfo *root, RelOptInfo *chunk_rel, Hyp
 
 	/*
 	 * since we rely on parallel coordination from the scan below
-	 * this node it is probably not beneficial to have more
-	 * than a single worker per chunk
+	 * request the same amount of parallel workers here as 
+	 * PostgreSQL uses for the parallel scan on the compressed chunk
 	 */
-	int parallel_workers = 1;
+	int parallel_workers = compute_parallel_worker(chunk_rel, chunk_rel->pages, -1, 
+											   max_parallel_workers_per_gather);
+
 	SortInfo sort_info = build_sortinfo(chunk, chunk_rel, info, root->query_pathkeys);
 
 	Assert(chunk->fd.compressed_chunk_id > 0);

--- a/tsl/test/expected/compression.out
+++ b/tsl/test/expected/compression.out
@@ -206,10 +206,11 @@ do update set b = excluded.b;
 SELECT * from foo ORDER BY a,b;
  a  |  b  | c  | d  
 ----+-----+----+----
+  3 | 111 | 20 |   
  10 |  12 | 12 | 12
  20 | 111 | 20 |   
  30 | 111 | 40 |   
-(3 rows)
+(4 rows)
 
 --TEST2c Do DML directly on the chunk.
 insert into _timescaledb_internal._hyper_1_2_chunk values(10, 12, 12, 12)
@@ -218,10 +219,11 @@ do update set b = excluded.b + 12;
 SELECT * from foo ORDER BY a,b;
  a  |  b  | c  | d  
 ----+-----+----+----
+  3 | 111 | 20 |   
  10 |  24 | 12 | 12
  20 | 111 | 20 |   
  30 | 111 | 40 |   
-(3 rows)
+(4 rows)
 
 update _timescaledb_internal._hyper_1_2_chunk
 set b = 12;
@@ -238,9 +240,8 @@ update foo set b =20 where a = 10;
 select * from _timescaledb_internal._hyper_1_2_chunk order by a,b;
  a  | b  | c  |  d  
 ----+----+----+-----
- 10 | 20 | 20 |    
  11 | 10 | 20 | 120
-(2 rows)
+(1 row)
 
 delete from foo where a = 10;
 select * from _timescaledb_internal._hyper_1_2_chunk order by a,b;
@@ -444,15 +445,6 @@ vacuum full conditions;
 -- After vacuum, table_bytes is 0, but any associated index/toast storage is not
 -- completely reclaimed. Sets it at 8K (page size). So a chunk which has
 -- been compressed still incurs an overhead of n * 8KB (for every index + toast table) storage on the original uncompressed chunk.
-select pg_size_pretty(table_bytes), pg_size_pretty(index_bytes),
-pg_size_pretty(toast_bytes), pg_size_pretty(total_bytes)
-from hypertable_detailed_size('foo');
--[ RECORD 1 ]--+-----------
-pg_size_pretty | 32 kB
-pg_size_pretty | 144 kB
-pg_size_pretty | 8192 bytes
-pg_size_pretty | 184 kB
-
 select pg_size_pretty(table_bytes), pg_size_pretty(index_bytes),
 pg_size_pretty(toast_bytes), pg_size_pretty(total_bytes)
 from hypertable_detailed_size('conditions');
@@ -1719,3 +1711,168 @@ SELECT time, const, numeric,first, avg1, avg2 FROM tidrangescan_expr ORDER BY ti
 
 RESET timescaledb.enable_chunk_append;
 RESET enable_indexscan;
+-- Improve the number of parallel workers for decompression
+-- Test that a parallel plan is generated
+-- with different number of parallel workers
+CREATE TABLE f_sensor_data(
+      time timestamptz not null,
+      sensor_id integer not null,
+      cpu double precision null,
+      temperature double precision null 
+    );
+SELECT FROM create_hypertable('f_sensor_data','time');
+--
+(1 row)
+
+SELECT set_chunk_time_interval('f_sensor_data', INTERVAL '1 year');
+ set_chunk_time_interval 
+-------------------------
+ 
+(1 row)
+
+SELECT * FROM _timescaledb_internal.create_chunk('f_sensor_data',' {"time": [181900977000000, 515024000000000]}');
+ chunk_id | hypertable_id |      schema_name      |     table_name     | relkind |                    slices                    | created 
+----------+---------------+-----------------------+--------------------+---------+----------------------------------------------+---------
+       71 |            37 | _timescaledb_internal | _hyper_37_71_chunk | r       | {"time": [181900977000000, 515024000000000]} | t
+(1 row)
+
+INSERT INTO f_sensor_data
+SELECT
+    time AS time,
+    sensor_id,
+    100.0,
+    36.6
+FROM
+    generate_series('1980-01-01 00:00'::timestamp, '1980-12-31 12:00', INTERVAL '1 day') AS g1(time),
+    generate_series(1, 700, 1 ) AS g2(sensor_id)
+ORDER BY
+    time;
+SELECT c.chunk_name,c.range_start,c.range_end,c.is_compressed,pg_size_pretty(d.total_bytes) 
+FROM public.chunks_detailed_size('public.f_sensor_data') d, timescaledb_information.chunks c 
+WHERE d.chunk_name=c.chunk_name 
+ORDER BY c.range_start;
+     chunk_name     |         range_start          |          range_end           | is_compressed | pg_size_pretty 
+--------------------+------------------------------+------------------------------+---------------+----------------
+ _hyper_37_71_chunk | Tue Oct 07 01:02:57 1975 PDT | Sun Apr 27 15:13:20 1986 PDT | f             | 18 MB
+(1 row)
+
+ALTER TABLE f_sensor_data SET (timescaledb.compress, timescaledb.compress_segmentby='sensor_id' ,timescaledb.compress_orderby = 'time DESC');
+SELECT add_compression_policy('f_sensor_data','1 minute'::INTERVAL);
+ add_compression_policy 
+------------------------
+                   1000
+(1 row)
+
+SELECT compress_chunk(i) FROM show_chunks('f_sensor_data') i;
+              compress_chunk              
+------------------------------------------
+ _timescaledb_internal._hyper_37_71_chunk
+(1 row)
+
+SELECT c.chunk_name,c.range_start,c.range_end,c.is_compressed,pg_size_pretty(d.total_bytes) 
+FROM public.chunks_detailed_size('public.f_sensor_data') d, timescaledb_information.chunks c 
+WHERE d.chunk_name=c.chunk_name 
+ORDER BY c.range_start;
+     chunk_name     |         range_start          |          range_end           | is_compressed | pg_size_pretty 
+--------------------+------------------------------+------------------------------+---------------+----------------
+ _hyper_37_71_chunk | Tue Oct 07 01:02:57 1975 PDT | Sun Apr 27 15:13:20 1986 PDT | t             | 448 kB
+(1 row)
+
+-- Encourage use of parallel plans
+SET parallel_setup_cost = 0;
+SET parallel_tuple_cost = 0;
+SET min_parallel_table_scan_size TO '1';
+\set explain 'EXPLAIN (VERBOSE, COSTS OFF)'
+SHOW min_parallel_table_scan_size;
+ min_parallel_table_scan_size 
+------------------------------
+ 8kB
+(1 row)
+
+SHOW max_parallel_workers;
+ max_parallel_workers 
+----------------------
+ 8
+(1 row)
+
+SHOW max_parallel_workers_per_gather;
+ max_parallel_workers_per_gather 
+---------------------------------
+ 2
+(1 row)
+
+set max_parallel_workers_per_gather = 1;
+SHOW max_parallel_workers_per_gather;
+ max_parallel_workers_per_gather 
+---------------------------------
+ 1
+(1 row)
+
+:explain
+select sum(cpu) from f_sensor_data;
+                                                                                                                                                                                 QUERY PLAN                                                                                                                                                                                 
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Finalize Aggregate
+   Output: sum(_hyper_37_71_chunk.cpu)
+   ->  Gather
+         Output: (PARTIAL sum(_hyper_37_71_chunk.cpu))
+         Workers Planned: 1
+         ->  Partial Aggregate
+               Output: PARTIAL sum(_hyper_37_71_chunk.cpu)
+               ->  Parallel Append
+                     ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_37_71_chunk
+                           Output: _hyper_37_71_chunk.cpu
+                           ->  Parallel Seq Scan on _timescaledb_internal.compress_hyper_38_72_chunk
+                                 Output: compress_hyper_38_72_chunk."time", compress_hyper_38_72_chunk.sensor_id, compress_hyper_38_72_chunk.cpu, compress_hyper_38_72_chunk.temperature, compress_hyper_38_72_chunk._ts_meta_count, compress_hyper_38_72_chunk._ts_meta_sequence_num, compress_hyper_38_72_chunk._ts_meta_min_1, compress_hyper_38_72_chunk._ts_meta_max_1
+(12 rows)
+
+set max_parallel_workers_per_gather = 2;
+SHOW max_parallel_workers_per_gather;
+ max_parallel_workers_per_gather 
+---------------------------------
+ 2
+(1 row)
+
+:explain
+select sum(cpu) from f_sensor_data;
+                                                                                                                                                                                 QUERY PLAN                                                                                                                                                                                 
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Finalize Aggregate
+   Output: sum(_hyper_37_71_chunk.cpu)
+   ->  Gather
+         Output: (PARTIAL sum(_hyper_37_71_chunk.cpu))
+         Workers Planned: 2
+         ->  Partial Aggregate
+               Output: PARTIAL sum(_hyper_37_71_chunk.cpu)
+               ->  Parallel Append
+                     ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_37_71_chunk
+                           Output: _hyper_37_71_chunk.cpu
+                           ->  Parallel Seq Scan on _timescaledb_internal.compress_hyper_38_72_chunk
+                                 Output: compress_hyper_38_72_chunk."time", compress_hyper_38_72_chunk.sensor_id, compress_hyper_38_72_chunk.cpu, compress_hyper_38_72_chunk.temperature, compress_hyper_38_72_chunk._ts_meta_count, compress_hyper_38_72_chunk._ts_meta_sequence_num, compress_hyper_38_72_chunk._ts_meta_min_1, compress_hyper_38_72_chunk._ts_meta_max_1
+(12 rows)
+
+set max_parallel_workers_per_gather = 4;
+SHOW max_parallel_workers_per_gather;
+ max_parallel_workers_per_gather 
+---------------------------------
+ 4
+(1 row)
+
+:explain
+select sum(cpu) from f_sensor_data;
+                                                                                                                                                                                 QUERY PLAN                                                                                                                                                                                 
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Finalize Aggregate
+   Output: sum(_hyper_37_71_chunk.cpu)
+   ->  Gather
+         Output: (PARTIAL sum(_hyper_37_71_chunk.cpu))
+         Workers Planned: 3
+         ->  Partial Aggregate
+               Output: PARTIAL sum(_hyper_37_71_chunk.cpu)
+               ->  Parallel Append
+                     ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_37_71_chunk
+                           Output: _hyper_37_71_chunk.cpu
+                           ->  Parallel Seq Scan on _timescaledb_internal.compress_hyper_38_72_chunk
+                                 Output: compress_hyper_38_72_chunk."time", compress_hyper_38_72_chunk.sensor_id, compress_hyper_38_72_chunk.cpu, compress_hyper_38_72_chunk.temperature, compress_hyper_38_72_chunk._ts_meta_count, compress_hyper_38_72_chunk._ts_meta_sequence_num, compress_hyper_38_72_chunk._ts_meta_min_1, compress_hyper_38_72_chunk._ts_meta_max_1
+(12 rows)
+

--- a/tsl/test/expected/compression_update_delete.out
+++ b/tsl/test/expected/compression_update_delete.out
@@ -1722,3 +1722,108 @@ SELECT COUNT(*) = :total_rows - :total_affected_rows FROM sample_table;
 (1 row)
 
 ROLLBACK;
+--github issue: 5640
+CREATE TABLE tab1(filler_1 int, filler_2 int, filler_3 int, time timestamptz NOT NULL, device_id int, v0 int, v1 int, v2 float, v3 float);
+CREATE INDEX ON tab1(time);
+CREATE INDEX ON tab1(device_id,time);
+SELECT create_hypertable('tab1','time',create_default_indexes:=false);
+ create_hypertable  
+--------------------
+ (21,public,tab1,t)
+(1 row)
+
+ALTER TABLE tab1 DROP COLUMN filler_1;
+INSERT INTO tab1(time,device_id,v0,v1,v2,v3) SELECT time, device_id, device_id+1,  device_id + 2, device_id + 0.5, NULL FROM generate_series('2000-01-01 0:00:00+0'::timestamptz,'2000-01-05 23:55:00+0','57m') gtime(time), generate_series(1,1,1) gdevice(device_id);
+ALTER TABLE tab1 DROP COLUMN filler_2;
+INSERT INTO tab1(time,device_id,v0,v1,v2,v3) SELECT time, device_id, device_id-1, device_id + 2, device_id + 0.5, NULL FROM generate_series('2000-01-06 0:00:00+0'::timestamptz,'2000-01-12 23:55:00+0','58m') gtime(time), generate_series(1,1,1) gdevice(device_id);
+ALTER TABLE tab1 DROP COLUMN filler_3;
+INSERT INTO tab1(time,device_id,v0,v1,v2,v3) SELECT time, device_id, device_id, device_id + 2, device_id + 0.5, NULL FROM generate_series('2000-01-13 0:00:00+0'::timestamptz,'2000-01-19 23:55:00+0','59m') gtime(time), generate_series(1,1,1) gdevice(device_id);
+ANALYZE tab1;
+-- compress chunks
+ALTER TABLE tab1 SET (timescaledb.compress, timescaledb.compress_orderby='time DESC', timescaledb.compress_segmentby='device_id');
+SELECT compress_chunk(show_chunks('tab1'));
+              compress_chunk              
+------------------------------------------
+ _timescaledb_internal._hyper_21_39_chunk
+ _timescaledb_internal._hyper_21_40_chunk
+ _timescaledb_internal._hyper_21_41_chunk
+(3 rows)
+
+-- ensure there is an index scan generated for below DELETE query
+BEGIN;
+SELECT count(*) FROM tab1 WHERE device_id = 1;
+ count 
+-------
+   472
+(1 row)
+
+INSERT INTO tab1(time,device_id,v0,v1,v2,v3) SELECT time, device_id, device_id+1,  device_id + 2, device_id + 1000, NULL FROM generate_series('2000-01-01 0:00:00+0'::timestamptz,'2000-01-05 23:55:00+0','2m') gtime(time), generate_series(1,5,1) gdevice(device_id);
+SELECT count(*) FROM tab1 WHERE device_id = 1;
+ count 
+-------
+  4070
+(1 row)
+
+ANALYZE tab1;
+EXPLAIN (costs off) DELETE FROM public.tab1 WHERE public.tab1.device_id = 1;
+                                                 QUERY PLAN                                                 
+------------------------------------------------------------------------------------------------------------
+ Custom Scan (HypertableModify)
+   ->  Delete on tab1
+         Delete on _hyper_21_39_chunk tab1_1
+         Delete on _hyper_21_40_chunk tab1_2
+         Delete on _hyper_21_41_chunk tab1_3
+         ->  Append
+               ->  Index Scan using _hyper_21_39_chunk_tab1_device_id_time_idx on _hyper_21_39_chunk tab1_1
+                     Index Cond: (device_id = 1)
+               ->  Seq Scan on _hyper_21_40_chunk tab1_2
+                     Filter: (device_id = 1)
+               ->  Seq Scan on _hyper_21_41_chunk tab1_3
+                     Filter: (device_id = 1)
+(12 rows)
+
+DELETE FROM tab1 WHERE tab1.device_id = 1;
+SELECT count(*) FROM tab1 WHERE device_id = 1;
+ count 
+-------
+     0
+(1 row)
+
+ROLLBACK;
+-- create hypertable with space partitioning and compression
+CREATE TABLE tab2(filler_1 int, filler_2 int, filler_3 int, time timestamptz NOT NULL, device_id int, v0 int, v1 int, v2 float, v3 float);
+CREATE INDEX ON tab2(time);
+CREATE INDEX ON tab2(device_id,time);
+SELECT create_hypertable('tab2','time','device_id',3,create_default_indexes:=false);
+ create_hypertable  
+--------------------
+ (23,public,tab2,t)
+(1 row)
+
+ALTER TABLE tab2 DROP COLUMN filler_1;
+INSERT INTO tab2(time,device_id,v0,v1,v2,v3) SELECT time, device_id, device_id+1, device_id + 2, device_id + 0.5, NULL FROM generate_series('2000-01-01 0:00:00+0'::timestamptz,'2000-01-05 23:55:00+0','35m') gtime(time), generate_series(1,1,1) gdevice(device_id);
+ALTER TABLE tab2 DROP COLUMN filler_2;
+INSERT INTO tab2(time,device_id,v0,v1,v2,v3) SELECT time, device_id, device_id+1, device_id + 2, device_id + 0.5, NULL FROM generate_series('2000-01-06 0:00:00+0'::timestamptz,'2000-01-12 23:55:00+0','45m') gtime(time), generate_series(1,1,1) gdevice(device_id);
+ALTER TABLE tab2 DROP COLUMN filler_3;
+INSERT INTO tab2(time,device_id,v0,v1,v2,v3) SELECT time, device_id, device_id+1, device_id + 2, device_id + 0.5, NULL FROM generate_series('2000-01-13 0:00:00+0'::timestamptz,'2000-01-19 23:55:00+0','55m') gtime(time), generate_series(1,1,1) gdevice(device_id);
+ANALYZE tab2;
+-- compress chunks
+ALTER TABLE tab2 SET (timescaledb.compress, timescaledb.compress_orderby='time DESC', timescaledb.compress_segmentby='device_id');
+SELECT compress_chunk(show_chunks('tab2'));
+              compress_chunk              
+------------------------------------------
+ _timescaledb_internal._hyper_23_45_chunk
+ _timescaledb_internal._hyper_23_46_chunk
+ _timescaledb_internal._hyper_23_47_chunk
+(3 rows)
+
+-- below test will cause chunks of tab2 to get decompressed
+-- without fix for issue #5460
+SET timescaledb.enable_optimizations = OFF;
+BEGIN;
+DELETE FROM tab1 t1 USING tab2 t2 WHERE t1.device_id = t2.device_id AND t2.time > '2000-01-01';
+ROLLBACK;
+--cleanup
+RESET timescaledb.enable_optimizations;
+DROP table tab1;
+DROP table tab2;

--- a/tsl/test/shared/expected/transparent_decompress_chunk-13.out
+++ b/tsl/test/shared/expected/transparent_decompress_chunk-13.out
@@ -670,16 +670,16 @@ FROM :TEST_TABLE m1
     LIMIT 10;
 QUERY PLAN
  Limit
-   ->  Nested Loop
-         Join Filter: ((m1."time" = m2."time") AND (m1.device_id = m2.device_id))
-         ->  Gather Merge
-               Workers Planned: 1
-               ->  Sort
-                     Sort Key: m1."time", m1.device_id
-                     ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk m1
-                           ->  Parallel Seq Scan on compress_hyper_X_X_chunk
-         ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk m2
-               ->  Seq Scan on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1
+   ->  Merge Join
+         Merge Cond: ((m1."time" = m2."time") AND (m1.device_id = m2.device_id))
+         ->  Sort
+               Sort Key: m1."time", m1.device_id
+               ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk m1
+                     ->  Seq Scan on compress_hyper_X_X_chunk
+         ->  Sort
+               Sort Key: m2."time", m2.device_id
+               ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk m2
+                     ->  Seq Scan on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1
 (11 rows)
 
 :PREFIX_NO_VERBOSE
@@ -696,16 +696,16 @@ QUERY PLAN
  Limit
    ->  Nested Loop
          Join Filter: (m1."time" = m3."time")
-         ->  Nested Loop
-               Join Filter: ((m1."time" = m2."time") AND (m1.device_id = m2.device_id))
-               ->  Gather Merge
-                     Workers Planned: 1
-                     ->  Sort
-                           Sort Key: m1."time", m1.device_id
-                           ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk m1
-                                 ->  Parallel Seq Scan on compress_hyper_X_X_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk m2
-                     ->  Seq Scan on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1
+         ->  Merge Join
+               Merge Cond: ((m1."time" = m2."time") AND (m1.device_id = m2.device_id))
+               ->  Sort
+                     Sort Key: m1."time", m1.device_id
+                     ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk m1
+                           ->  Seq Scan on compress_hyper_X_X_chunk
+               ->  Sort
+                     Sort Key: m2."time", m2.device_id
+                     ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk m2
+                           ->  Seq Scan on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1
          ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk m3
                ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_4_device_id__t on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_2
                      Index Cond: (device_id = 3)
@@ -780,16 +780,16 @@ ORDER BY m1.time,
 LIMIT 10;
 QUERY PLAN
  Limit
-   ->  Nested Loop Left Join
-         Join Filter: ((m1."time" = m2."time") AND (m1.device_id = m2.device_id))
-         ->  Gather Merge
-               Workers Planned: 1
-               ->  Sort
-                     Sort Key: m1."time", m1.device_id
-                     ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk m1
-                           ->  Parallel Seq Scan on compress_hyper_X_X_chunk
-         ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk m2
-               ->  Seq Scan on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1
+   ->  Merge Left Join
+         Merge Cond: ((m1."time" = m2."time") AND (m1.device_id = m2.device_id))
+         ->  Sort
+               Sort Key: m1."time", m1.device_id
+               ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk m1
+                     ->  Seq Scan on compress_hyper_X_X_chunk
+         ->  Sort
+               Sort Key: m2."time", m2.device_id
+               ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk m2
+                     ->  Seq Scan on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1
 (11 rows)
 
 :PREFIX_NO_VERBOSE

--- a/tsl/test/shared/expected/transparent_decompress_chunk-14.out
+++ b/tsl/test/shared/expected/transparent_decompress_chunk-14.out
@@ -670,16 +670,16 @@ FROM :TEST_TABLE m1
     LIMIT 10;
 QUERY PLAN
  Limit
-   ->  Nested Loop
-         Join Filter: ((m1."time" = m2."time") AND (m1.device_id = m2.device_id))
-         ->  Gather Merge
-               Workers Planned: 1
-               ->  Sort
-                     Sort Key: m1."time", m1.device_id
-                     ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk m1
-                           ->  Parallel Seq Scan on compress_hyper_X_X_chunk
-         ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk m2
-               ->  Seq Scan on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1
+   ->  Merge Join
+         Merge Cond: ((m1."time" = m2."time") AND (m1.device_id = m2.device_id))
+         ->  Sort
+               Sort Key: m1."time", m1.device_id
+               ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk m1
+                     ->  Seq Scan on compress_hyper_X_X_chunk
+         ->  Sort
+               Sort Key: m2."time", m2.device_id
+               ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk m2
+                     ->  Seq Scan on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1
 (11 rows)
 
 :PREFIX_NO_VERBOSE
@@ -696,16 +696,16 @@ QUERY PLAN
  Limit
    ->  Nested Loop
          Join Filter: (m1."time" = m3."time")
-         ->  Nested Loop
-               Join Filter: ((m1."time" = m2."time") AND (m1.device_id = m2.device_id))
-               ->  Gather Merge
-                     Workers Planned: 1
-                     ->  Sort
-                           Sort Key: m1."time", m1.device_id
-                           ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk m1
-                                 ->  Parallel Seq Scan on compress_hyper_X_X_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk m2
-                     ->  Seq Scan on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1
+         ->  Merge Join
+               Merge Cond: ((m1."time" = m2."time") AND (m1.device_id = m2.device_id))
+               ->  Sort
+                     Sort Key: m1."time", m1.device_id
+                     ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk m1
+                           ->  Seq Scan on compress_hyper_X_X_chunk
+               ->  Sort
+                     Sort Key: m2."time", m2.device_id
+                     ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk m2
+                           ->  Seq Scan on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1
          ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk m3
                ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_4_device_id__t on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_2
                      Index Cond: (device_id = 3)
@@ -780,16 +780,16 @@ ORDER BY m1.time,
 LIMIT 10;
 QUERY PLAN
  Limit
-   ->  Nested Loop Left Join
-         Join Filter: ((m1."time" = m2."time") AND (m1.device_id = m2.device_id))
-         ->  Gather Merge
-               Workers Planned: 1
-               ->  Sort
-                     Sort Key: m1."time", m1.device_id
-                     ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk m1
-                           ->  Parallel Seq Scan on compress_hyper_X_X_chunk
-         ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk m2
-               ->  Seq Scan on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1
+   ->  Merge Left Join
+         Merge Cond: ((m1."time" = m2."time") AND (m1.device_id = m2.device_id))
+         ->  Sort
+               Sort Key: m1."time", m1.device_id
+               ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk m1
+                     ->  Seq Scan on compress_hyper_X_X_chunk
+         ->  Sort
+               Sort Key: m2."time", m2.device_id
+               ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk m2
+                     ->  Seq Scan on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1
 (11 rows)
 
 :PREFIX_NO_VERBOSE

--- a/tsl/test/shared/expected/transparent_decompress_chunk-15.out
+++ b/tsl/test/shared/expected/transparent_decompress_chunk-15.out
@@ -672,16 +672,16 @@ FROM :TEST_TABLE m1
     LIMIT 10;
 QUERY PLAN
  Limit
-   ->  Nested Loop
-         Join Filter: ((m1."time" = m2."time") AND (m1.device_id = m2.device_id))
-         ->  Gather Merge
-               Workers Planned: 1
-               ->  Sort
-                     Sort Key: m1."time", m1.device_id
-                     ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk m1
-                           ->  Parallel Seq Scan on compress_hyper_X_X_chunk
-         ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk m2
-               ->  Seq Scan on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1
+   ->  Merge Join
+         Merge Cond: ((m1."time" = m2."time") AND (m1.device_id = m2.device_id))
+         ->  Sort
+               Sort Key: m1."time", m1.device_id
+               ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk m1
+                     ->  Seq Scan on compress_hyper_X_X_chunk
+         ->  Sort
+               Sort Key: m2."time", m2.device_id
+               ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk m2
+                     ->  Seq Scan on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1
 (11 rows)
 
 :PREFIX_NO_VERBOSE
@@ -698,16 +698,16 @@ QUERY PLAN
  Limit
    ->  Nested Loop
          Join Filter: (m1."time" = m3."time")
-         ->  Nested Loop
-               Join Filter: ((m1."time" = m2."time") AND (m1.device_id = m2.device_id))
-               ->  Gather Merge
-                     Workers Planned: 1
-                     ->  Sort
-                           Sort Key: m1."time", m1.device_id
-                           ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk m1
-                                 ->  Parallel Seq Scan on compress_hyper_X_X_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk m2
-                     ->  Seq Scan on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1
+         ->  Merge Join
+               Merge Cond: ((m1."time" = m2."time") AND (m1.device_id = m2.device_id))
+               ->  Sort
+                     Sort Key: m1."time", m1.device_id
+                     ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk m1
+                           ->  Seq Scan on compress_hyper_X_X_chunk
+               ->  Sort
+                     Sort Key: m2."time", m2.device_id
+                     ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk m2
+                           ->  Seq Scan on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1
          ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk m3
                ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_4_device_id__t on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_2
                      Index Cond: (device_id = 3)
@@ -782,16 +782,16 @@ ORDER BY m1.time,
 LIMIT 10;
 QUERY PLAN
  Limit
-   ->  Nested Loop Left Join
-         Join Filter: ((m1."time" = m2."time") AND (m1.device_id = m2.device_id))
-         ->  Gather Merge
-               Workers Planned: 1
-               ->  Sort
-                     Sort Key: m1."time", m1.device_id
-                     ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk m1
-                           ->  Parallel Seq Scan on compress_hyper_X_X_chunk
-         ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk m2
-               ->  Seq Scan on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1
+   ->  Merge Left Join
+         Merge Cond: ((m1."time" = m2."time") AND (m1.device_id = m2.device_id))
+         ->  Sort
+               Sort Key: m1."time", m1.device_id
+               ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk m1
+                     ->  Seq Scan on compress_hyper_X_X_chunk
+         ->  Sort
+               Sort Key: m2."time", m2.device_id
+               ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk m2
+                     ->  Seq Scan on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1
 (11 rows)
 
 :PREFIX_NO_VERBOSE


### PR DESCRIPTION
Planner may also choose parallel plans when decompressing chunks.
Can use for decompression as many workers wants per chunk.

Co-authored-by: Jan Kristof Nidzwetzki <jan@timescale.com>