### PR TITLE
Create hypertable using storage options

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -27,6 +27,7 @@ set(SOURCES
     hypertable.c
     hypertable_cache.c
     hypertable_restrict_info.c
+    hypertable_with_clause.c
     indexing.c
     init.c
     jsonb_utils.c

--- a/src/chunk_adaptive.h
+++ b/src/chunk_adaptive.h
@@ -28,5 +28,6 @@ extern void ts_chunk_sizing_func_validate(regproc func, ChunkSizingInfo *info);
 extern TSDLLEXPORT ChunkSizingInfo *ts_chunk_sizing_info_get_default_disabled(Oid table_relid);
 
 extern TSDLLEXPORT int64 ts_chunk_calculate_initial_chunk_target_size(void);
+extern TSDLLEXPORT Datum ts_calculate_chunk_interval(PG_FUNCTION_ARGS);
 
 #endif /* TIMESCALEDB_CHUNK_ADAPTIVE_H */

--- a/src/cross_module_fn.c
+++ b/src/cross_module_fn.c
@@ -194,8 +194,7 @@ job_execute_default_fn(BgwJob *job)
 }
 
 static bool
-process_compress_table_default(AlterTableCmd *cmd, Hypertable *ht,
-							   WithClauseResult *with_clause_options)
+process_compress_table_default(Hypertable *ht, WithClauseResult *with_clause_options)
 {
 	error_no_default_fn_community();
 	pg_unreachable();

--- a/src/cross_module_fn.h
+++ b/src/cross_module_fn.h
@@ -130,8 +130,7 @@ typedef struct CrossModuleFunctions
 	PGFunction compressed_data_recv;
 	PGFunction compressed_data_in;
 	PGFunction compressed_data_out;
-	bool (*process_compress_table)(AlterTableCmd *cmd, Hypertable *ht,
-								   WithClauseResult *with_clause_options);
+	bool (*process_compress_table)(Hypertable *ht, WithClauseResult *with_clause_options);
 	void (*process_altertable_cmd)(Hypertable *ht, const AlterTableCmd *cmd);
 	void (*process_rename_cmd)(Oid relid, Cache *hcache, const RenameStmt *stmt);
 	PGFunction create_compressed_chunk;

--- a/src/dimension.h
+++ b/src/dimension.h
@@ -121,6 +121,7 @@ extern TSDLLEXPORT Dimension *
 ts_hyperspace_get_mutable_dimension_by_name(Hyperspace *hs, DimensionType type, const char *name);
 extern DimensionVec *ts_dimension_get_slices(const Dimension *dim);
 extern int32 ts_dimension_get_hypertable_id(int32 dimension_id);
+extern Datum ts_dimension_set_interval_internal(PG_FUNCTION_ARGS, Datum interval, Oid interval_type);
 extern int ts_dimension_set_type(Dimension *dim, Oid newtype);
 extern TSDLLEXPORT Oid ts_dimension_get_partition_type(const Dimension *dim);
 extern int ts_dimension_set_name(Dimension *dim, const char *newname);

--- a/src/hypertable.h
+++ b/src/hypertable.h
@@ -94,6 +94,8 @@ typedef enum HypertableType
 	HYPERTABLE_DISTRIBUTED
 } HypertableType;
 
+extern TSDLLEXPORT Datum ts_hypertable_create_internal(PG_FUNCTION_ARGS, Datum interval,
+													   Oid interval_type, bool is_dist_call);
 extern TSDLLEXPORT bool ts_hypertable_create_from_info(
 	Oid table_relid, int32 hypertable_id, uint32 flags, DimensionInfo *time_dim_info,
 	DimensionInfo *space_dim_info, Name associated_schema_name, Name associated_table_prefix,

--- a/src/hypertable_with_clause.c
+++ b/src/hypertable_with_clause.c
@@ -1,0 +1,379 @@
+/*
+ * This file and its contents are licensed under the Apache License 2.0.
+ * Please see the included NOTICE for copyright information and
+ * LICENSE-APACHE for a copy of the license.
+ */
+#include <postgres.h>
+#include <fmgr.h>
+#include <access/htup_details.h>
+#include <catalog/dependency.h>
+#include <catalog/namespace.h>
+#include <catalog/pg_type.h>
+#include <catalog/pg_trigger.h>
+#include <commands/trigger.h>
+#include <storage/lmgr.h>
+#include <utils/builtins.h>
+#include <utils/lsyscache.h>
+#include <parser/parser.h>
+#include <parser/parse_func.h>
+
+#include "extension.h"
+#include "utils.h"
+#include "compat/compat.h"
+#include "hypertable.h"
+#include "hypertable_cache.h"
+#include "hypertable_with_clause.h"
+#include "compression_with_clause.h"
+#include "cross_module_fn.h"
+
+typedef enum HypertableOption
+{
+	HypertableEnabled,
+
+	/* create_hypetable function arguments
+	 * in the same order */
+	HypertableTimeColumn,
+	HypertablePartitioningColumn,
+	HypertableNumberPartitions,
+	HypertableAssociatedSchemaName,
+	HypertableAssociatedTablePrefix,
+	HypertableChunkTimeInterval,
+	HypertableCreateDefaultIndexes,
+	HypertableIfNotExists,
+	HypertablePartitioningFunc,
+	HypertableMigrateData,
+	HypertableChunkTargetSize,
+	HypertableChunkSizingFunc,
+	HypertableTimePartitioningFunc,
+	HypertableReplicationFactor,
+	HypertableDataNodes,
+	HypertableDistributed,
+
+	/* compression options */
+	HypertableCompressEnabled,
+	HypertableCompressSegmentBy,
+	HypertableCompressOrderBy,
+	HypertableCompressChunkTimeInterval,
+
+	/* set_chunk_interval */
+	HypertableDimension
+
+} HypertableOption;
+
+#define HypertableOptionsMax (HypertableDistributed + 1)
+
+/*
+	relation                REGCLASS,
+	time_column_name        NAME,
+	partitioning_column     NAME = NULL,
+	number_partitions       INTEGER = NULL,
+	associated_schema_name  NAME = NULL,
+	associated_table_prefix NAME = NULL,
+	chunk_time_interval     ANYELEMENT = NULL::bigint,
+	create_default_indexes  BOOLEAN = TRUE,
+	if_not_exists           BOOLEAN = FALSE,
+	partitioning_func       REGPROC = NULL,
+	migrate_data            BOOLEAN = FALSE,
+	chunk_target_size       TEXT = NULL,
+	chunk_sizing_func       REGPROC = '_timescaledb_internal.calculate_chunk_interval'::regproc,
+	time_partitioning_func  REGPROC = NULL,
+	replication_factor      INTEGER = NULL,
+	data_nodes              NAME[] = NULL,
+	distributed             BOOLEAN = NULL
+*/
+
+static const WithClauseDefinition hypertable_with_clause_def[] = {
+		[HypertableEnabled] = {
+			.arg_name = "hypertable",
+			.type_id = BOOLOID,
+			.default_val = BoolGetDatum(true),
+		},
+		[HypertableTimeColumn] = {
+			.arg_name = "time_column",
+			.type_id = NAMEOID,
+		},
+		[HypertablePartitioningColumn] = {
+			.arg_name = "partitioning_column",
+			.type_id = NAMEOID,
+		},
+		[HypertableNumberPartitions] = {
+			.arg_name = "number_partitions",
+			.type_id = INT4OID,
+		},
+		[HypertableAssociatedSchemaName] = {
+			.arg_name = "associated_schema_name",
+			.type_id = NAMEOID,
+		},
+		[HypertableAssociatedTablePrefix] = {
+			.arg_name = "associated_table_prefix",
+			.type_id = NAMEOID,
+		},
+		[HypertableChunkTimeInterval] = {
+			.arg_name = "chunk_time_interval",
+			.type_id = TEXTOID,
+		},
+		[HypertableCreateDefaultIndexes] = {
+			.arg_name = "create_default_indexes",
+			.type_id = BOOLOID,
+		},
+		[HypertableIfNotExists] = {
+			.arg_name = "if_not_exists",
+			.type_id = BOOLOID,
+			.default_val = BoolGetDatum(true),
+		},
+		[HypertablePartitioningFunc] = {
+			.arg_name = "partitioning_func",
+			.type_id = REGPROCOID,
+		},
+		[HypertableMigrateData] = {
+			.arg_name = "migrate_data",
+			.type_id = BOOLOID,
+		},
+		[HypertableChunkTargetSize] = {
+			.arg_name = "chunk_target_size",
+			.type_id = TEXTOID,
+		},
+		[HypertableChunkSizingFunc] = {
+			.arg_name = "chunk_sizing_func",
+			.type_id = REGPROCOID,
+		},
+		[HypertableTimePartitioningFunc] = {
+			.arg_name = "time_partitioning_func",
+			.type_id = REGPROCOID,
+		},
+		[HypertableReplicationFactor] = {
+			.arg_name = "replication_factor",
+			.type_id = INT4OID,
+		},
+		[HypertableDataNodes] = {
+			.arg_name = "data_nodes",
+			.type_id = NAMEARRAYOID,
+		},
+		[HypertableDistributed] = {
+			.arg_name = "distributed",
+			.type_id = BOOLOID,
+		},
+		[HypertableCompressEnabled] = {
+			.arg_name = "compress",
+			.type_id = BOOLOID,
+			.default_val = BoolGetDatum(false),
+		},
+		[HypertableCompressSegmentBy] = {
+			 .arg_name = "compress_segmentby",
+			 .type_id = TEXTOID,
+		},
+		[HypertableCompressOrderBy] = {
+			 .arg_name = "compress_orderby",
+			 .type_id = TEXTOID,
+		},
+		[HypertableCompressChunkTimeInterval] = {
+			 .arg_name = "compress_chunk_time_interval",
+			 .type_id = INTERVALOID,
+		},
+		[HypertableDimension] = {
+			 .arg_name = "dimension",
+			 .type_id = TEXTOID,
+		}
+};
+
+static Oid
+get_chunk_sizing_func_oid(void)
+{
+	Oid argtype[] = { INT4OID, INT8OID, INT8OID };
+	return ts_get_function_oid("calculate_chunk_interval", "_timescaledb_internal", 3, argtype);
+}
+
+static Oid
+get_create_hypertable_func_oid(void)
+{
+	Oid argtype[] = { REGCLASSOID,	 NAMEOID,	 NAMEOID, INT4OID,		NAMEOID, NAMEOID,
+					  ANYELEMENTOID, BOOLOID,	 BOOLOID, REGPROCOID,	BOOLOID, TEXTOID,
+					  REGPROCOID,	 REGPROCOID, INT4OID, NAMEARRAYOID, BOOLOID };
+	return ts_get_function_oid("create_hypertable", ts_extension_schema_name(), 17, argtype);
+}
+
+static Oid
+get_set_chunk_interval_func_oid(void)
+{
+	Oid argtype[] = { REGCLASSOID, ANYELEMENTOID, NAMEOID };
+	return ts_get_function_oid("set_chunk_time_interval", ts_extension_schema_name(), 3, argtype);
+}
+
+void
+ts_hypertable_create_using_set_clause(Oid relid, const List *defelems)
+{
+	WithClauseResult *args;
+	WithClauseResult *args_compress;
+	Cache *hcache;
+	Hypertable *ht;
+
+	args = ts_with_clauses_parse(defelems,
+								 hypertable_with_clause_def,
+								 TS_ARRAY_LEN(hypertable_with_clause_def));
+
+	if (args[HypertableTimeColumn].is_default)
+		ereport(ERROR,
+				(errcode(ERRCODE_INVALID_PARAMETER_VALUE), errmsg("time column cannot be NULL")));
+
+	/* set default chunk sizing function, if it was not provided */
+	if (args[HypertableChunkSizingFunc].is_default)
+	{
+		args[HypertableChunkSizingFunc].is_default = false;
+		args[HypertableChunkSizingFunc].parsed = get_chunk_sizing_func_oid();
+	}
+
+	/* convert chunk_time_interval either to interval time or integer */
+	Datum interval = 0;
+	Oid interval_type = 0;
+	if (!args[HypertableChunkTimeInterval].is_default)
+	{
+		char *arg = TextDatumGetCString(args[HypertableChunkTimeInterval].parsed);
+		char *arg_end = NULL;
+		int64 interval_int;
+
+		errno = 0;
+		interval_int = strtoll(arg, &arg_end, 10);
+		if (errno == ERANGE || *arg_end != '\0')
+		{
+			/* integer conversion was not success, assuming it is Interval type */
+			interval = DirectFunctionCall3(interval_in, CStringGetDatum(arg), InvalidOid, -1);
+			interval_type = INTERVALOID;
+		}
+		else
+		{
+			interval = Int64GetDatum(interval_int);
+			interval_type = INT8OID;
+		}
+	}
+
+	/* find create_hypertable function */
+	Oid create_hypertable_oid = get_create_hypertable_func_oid();
+
+	/* prepare function call context */
+	FmgrInfo flinfo;
+	fmgr_info(create_hypertable_oid, &flinfo);
+
+	LOCAL_FCINFO(fcinfo, HypertableOptionsMax);
+	InitFunctionCallInfoData(*fcinfo, &flinfo, HypertableOptionsMax, InvalidOid, NULL, NULL);
+
+	/* set arguments to the function call */
+	FC_SET_ARG(fcinfo, 0, ObjectIdGetDatum(relid));
+	int i = 1;
+	for (; i < HypertableOptionsMax; i++)
+	{
+		if (args[i].is_default)
+			FC_SET_NULL(fcinfo, i);
+		else
+			FC_SET_ARG(fcinfo, i, args[i].parsed);
+	}
+
+	/* call internval function to create hypertable */
+	ts_hypertable_create_internal(fcinfo, interval, interval_type, false);
+
+	/* handle compression options */
+	if (args[HypertableCompressEnabled].is_default)
+	{
+		if (!args[HypertableCompressChunkTimeInterval].is_default ||
+			!args[HypertableCompressOrderBy].is_default ||
+			!args[HypertableCompressSegmentBy].is_default)
+			ereport(ERROR,
+					(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
+					 errmsg("the option timescaledb.compress must be set to true to enable "
+							"compression")));
+		return;
+	}
+
+	/* copy options and make them compatible with
+	 * CompressHypertableOption format */
+	args_compress = palloc0(sizeof(WithClauseResult) * CompressOptionMax);
+	memcpy(args_compress,
+		   &args[HypertableCompressEnabled],
+		   sizeof(WithClauseResult) * CompressOptionMax);
+
+	/* compress hypertable */
+	hcache = ts_hypertable_cache_pin();
+	ht = ts_hypertable_cache_get_entry(hcache, relid, 0);
+	ts_cm_functions->process_compress_table(ht, args_compress);
+	ts_cache_release(hcache);
+}
+
+void
+ts_hypertable_alter_using_set_clause(Hypertable *ht, const List *defelems)
+{
+	WithClauseResult *args;
+	WithClauseResult *args_compress;
+
+	args = ts_with_clauses_parse(defelems,
+								 hypertable_with_clause_def,
+								 TS_ARRAY_LEN(hypertable_with_clause_def));
+
+	/* set chunk_time_interval either to interval time or integer */
+	if (!args[HypertableChunkTimeInterval].is_default)
+	{
+		char *arg = TextDatumGetCString(args[HypertableChunkTimeInterval].parsed);
+		char *arg_end = NULL;
+		Oid interval_type = 0;
+		Datum interval = 0;
+		int64 interval_int;
+
+		errno = 0;
+		interval_int = strtoll(arg, &arg_end, 10);
+		if (errno == ERANGE || *arg_end != '\0')
+		{
+			/* integer conversion was not success, assuming it is Interval type */
+			interval = DirectFunctionCall3(interval_in, CStringGetDatum(arg), InvalidOid, -1);
+			interval_type = INTERVALOID;
+		}
+		else
+		{
+			interval = Int64GetDatum(interval_int);
+			interval_type = INT8OID;
+		}
+
+		/* find set_chunk_interval function */
+		Oid set_chunk_interval_oid = get_set_chunk_interval_func_oid();
+
+		/* prepare function call context */
+		FmgrInfo flinfo;
+		fmgr_info(set_chunk_interval_oid, &flinfo);
+
+		LOCAL_FCINFO(fcinfo, 3);
+		InitFunctionCallInfoData(*fcinfo, &flinfo, 3, InvalidOid, NULL, NULL);
+
+		/* set arguments to the function call */
+
+		/* hypertable */
+		FC_SET_ARG(fcinfo, 0, ObjectIdGetDatum(ht->main_table_relid));
+
+		/* dimenision */
+		if (args[HypertableDimension].is_default)
+			FC_SET_NULL(fcinfo, 2);
+		else
+			FC_SET_ARG(fcinfo, 2, args[HypertableDimension].parsed);
+
+		ts_dimension_set_interval_internal(fcinfo, interval, interval_type);
+	}
+
+	/* handle compression options */
+	if (args[HypertableCompressEnabled].is_default)
+	{
+		if (!args[HypertableCompressChunkTimeInterval].is_default ||
+			!args[HypertableCompressOrderBy].is_default ||
+			!args[HypertableCompressSegmentBy].is_default)
+			ereport(ERROR,
+					(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
+					 errmsg("the option timescaledb.compress must be set to true to enable "
+							"compression")));
+		return;
+	}
+
+	/* copy options and make them compatible with
+	 * CompressHypertableOption format */
+	args_compress = palloc0(sizeof(WithClauseResult) * CompressOptionMax);
+	memcpy(args_compress,
+		   &args[HypertableCompressEnabled],
+		   sizeof(WithClauseResult) * CompressOptionMax);
+
+	/* compress hypertable */
+	ts_cm_functions->process_compress_table(ht, args_compress);
+}

--- a/src/hypertable_with_clause.h
+++ b/src/hypertable_with_clause.h
@@ -1,0 +1,18 @@
+/*
+ * This file and its contents are licensed under the Apache License 2.0.
+ * Please see the included NOTICE for copyright information and
+ * LICENSE-APACHE for a copy of the license.
+ */
+#ifndef TIMESCALEDB_HYPERTABLE_WITH_CLAUSE_H
+#define TIMESCALEDB_HYPERTABLE_WITH_CLAUSE_H
+
+#include <postgres.h>
+#include <catalog/pg_type.h>
+#include "ts_catalog/catalog.h"
+#include "chunk.h"
+#include "with_clause_parser.h"
+
+extern TSDLLEXPORT void ts_hypertable_create_using_set_clause(Oid relid, const List *defelems);
+extern TSDLLEXPORT void ts_hypertable_alter_using_set_clause(Hypertable *ht, const List *defelems);
+
+#endif

--- a/test/expected/reloptions.out
+++ b/test/expected/reloptions.out
@@ -48,3 +48,186 @@ CREATE TABLE reloptions_test2(time integer, temp float8, color integer);
 ALTER TABLE reloptions_test2 SET (fillfactor=80, parallel_workers=8);
 ALTER TABLE reloptions_test2 SET (fillfactor=80), SET (parallel_workers=8);
 DROP TABLE reloptions_test2;
+-- Test hypertable creation using storage options
+-- time column
+CREATE TABLE test(time timestamptz NOT NULL, device_id int);
+ALTER TABLE test
+SET (timescaledb.hypertable, timescaledb.time_column = 'time');
+INSERT INTO test VALUES ('2004-10-10 00:00:00+00', 1);
+INSERT INTO test VALUES ('2004-10-20 00:00:00+00', 2);
+SELECT show_chunks('test');
+              show_chunks               
+----------------------------------------
+ _timescaledb_internal._hyper_2_3_chunk
+ _timescaledb_internal._hyper_2_4_chunk
+(2 rows)
+
+DROP TABLE test;
+-- partitioning column
+CREATE TABLE test(time timestamptz NOT NULL, device_id int);
+ALTER TABLE test
+SET (timescaledb.hypertable,
+     timescaledb.time_column = 'time',
+     timescaledb.partitioning_column = 'device_id',
+     timescaledb.number_partitions = '4');
+INSERT INTO test VALUES ('2004-10-10 00:00:00+00', 1);
+INSERT INTO test VALUES ('2004-10-20 00:00:00+00', 2);
+INSERT INTO test VALUES ('2004-10-30 00:00:00+00', 3);
+INSERT INTO test VALUES ('2004-11-10 00:00:00+00', 4);
+SELECT show_chunks('test');
+              show_chunks               
+----------------------------------------
+ _timescaledb_internal._hyper_3_5_chunk
+ _timescaledb_internal._hyper_3_6_chunk
+ _timescaledb_internal._hyper_3_7_chunk
+ _timescaledb_internal._hyper_3_8_chunk
+(4 rows)
+
+DROP TABLE test;
+-- time_partitioning_func
+CREATE TABLE test(time text NOT NULL);
+CREATE OR REPLACE FUNCTION time_partfunc(source text)
+    RETURNS TIMESTAMPTZ LANGUAGE PLPGSQL IMMUTABLE AS
+$BODY$
+BEGIN
+    RETURN timezone('UTC', to_timestamp(source));
+END
+$BODY$;
+ALTER TABLE test
+SET (timescaledb.hypertable,
+     timescaledb.time_column = 'time',
+     timescaledb.time_partitioning_func = 'time_partfunc');
+DROP TABLE test;
+-- chunk_time_interval
+-- integer
+CREATE TABLE test(time timestamptz NOT NULL, device_id int);
+ALTER TABLE test
+SET (timescaledb.hypertable,
+     timescaledb.time_column = 'time',
+     timescaledb.chunk_time_interval = '123');
+WARNING:  unexpected interval: smaller than one second
+INSERT INTO test VALUES ('2004-10-10 00:00:00+00', 1);
+INSERT INTO test VALUES ('2004-10-20 00:00:00+00', 2);
+SELECT show_chunks('test');
+               show_chunks               
+-----------------------------------------
+ _timescaledb_internal._hyper_5_9_chunk
+ _timescaledb_internal._hyper_5_10_chunk
+(2 rows)
+
+SELECT interval_length
+FROM _timescaledb_catalog.dimension d
+LEFT JOIN _timescaledb_catalog.hypertable h ON (d.hypertable_id = h.id)
+WHERE h.schema_name = 'public' AND h.table_name = 'test'
+ORDER BY d.id;
+ interval_length 
+-----------------
+             123
+(1 row)
+
+DROP TABLE test;
+-- interval
+CREATE TABLE test(time timestamptz NOT NULL, device_id int);
+ALTER TABLE test
+SET (timescaledb.hypertable,
+     timescaledb.time_column = 'time',
+     timescaledb.chunk_time_interval = '1 day');
+INSERT INTO test VALUES ('2004-10-10 00:00:00+00', 1);
+INSERT INTO test VALUES ('2004-10-20 00:00:00+00', 2);
+SELECT show_chunks('test');
+               show_chunks               
+-----------------------------------------
+ _timescaledb_internal._hyper_6_11_chunk
+ _timescaledb_internal._hyper_6_12_chunk
+(2 rows)
+
+SELECT interval_length
+FROM _timescaledb_catalog.dimension d
+LEFT JOIN _timescaledb_catalog.hypertable h ON (d.hypertable_id = h.id)
+WHERE h.schema_name = 'public' AND h.table_name = 'test'
+ORDER BY d.id;
+ interval_length 
+-----------------
+     86400000000
+(1 row)
+
+DROP TABLE test;
+-- test CREATE TABLE WITH ()
+-- time column
+CREATE TABLE test_with(time timestamptz NOT NULL, device_id int)
+WITH (timescaledb.hypertable, timescaledb.time_column = 'time');
+INSERT INTO test_with VALUES ('2004-10-10 00:00:00+00', 1);
+INSERT INTO test_with VALUES ('2004-10-20 00:00:00+00', 2);
+SELECT show_chunks('test_with');
+               show_chunks               
+-----------------------------------------
+ _timescaledb_internal._hyper_7_13_chunk
+ _timescaledb_internal._hyper_7_14_chunk
+(2 rows)
+
+DROP TABLE test_with;
+-- interval
+CREATE TABLE test_with(time timestamptz NOT NULL, device_id int)
+WITH (timescaledb.hypertable,
+      timescaledb.time_column = 'time',
+      timescaledb.chunk_time_interval = '1 day');
+INSERT INTO test_with VALUES ('2004-10-10 00:00:00+00', 1);
+INSERT INTO test_with VALUES ('2004-10-20 00:00:00+00', 2);
+SELECT show_chunks('test_with');
+               show_chunks               
+-----------------------------------------
+ _timescaledb_internal._hyper_8_15_chunk
+ _timescaledb_internal._hyper_8_16_chunk
+(2 rows)
+
+SELECT interval_length
+FROM _timescaledb_catalog.dimension d
+LEFT JOIN _timescaledb_catalog.hypertable h ON (d.hypertable_id = h.id)
+WHERE h.schema_name = 'public' AND h.table_name = 'test_with'
+ORDER BY d.id;
+ interval_length 
+-----------------
+     86400000000
+(1 row)
+
+DROP TABLE test_with;
+-- Test ALTER TABLE SET (chunk_time_interval)
+CREATE TABLE test(time timestamptz NOT NULL, device_id int);
+ALTER TABLE test
+SET (timescaledb.hypertable,
+     timescaledb.time_column = 'time',
+     timescaledb.chunk_time_interval = '123');
+WARNING:  unexpected interval: smaller than one second
+INSERT INTO test VALUES ('2004-10-10 00:00:00+00', 1);
+INSERT INTO test VALUES ('2004-10-20 00:00:00+00', 2);
+SELECT show_chunks('test');
+               show_chunks               
+-----------------------------------------
+ _timescaledb_internal._hyper_9_17_chunk
+ _timescaledb_internal._hyper_9_18_chunk
+(2 rows)
+
+SELECT interval_length
+FROM _timescaledb_catalog.dimension d
+LEFT JOIN _timescaledb_catalog.hypertable h ON (d.hypertable_id = h.id)
+WHERE h.schema_name = 'public' AND h.table_name = 'test'
+ORDER BY d.id;
+ interval_length 
+-----------------
+             123
+(1 row)
+
+ALTER TABLE test
+SET (timescaledb.chunk_time_interval = '321');
+WARNING:  unexpected interval: smaller than one second
+SELECT interval_length
+FROM _timescaledb_catalog.dimension d
+LEFT JOIN _timescaledb_catalog.hypertable h ON (d.hypertable_id = h.id)
+WHERE h.schema_name = 'public' AND h.table_name = 'test'
+ORDER BY d.id;
+ interval_length 
+-----------------
+             321
+(1 row)
+
+DROP TABLE test;

--- a/test/sql/reloptions.sql
+++ b/test/sql/reloptions.sql
@@ -33,3 +33,156 @@ CREATE TABLE reloptions_test2(time integer, temp float8, color integer);
 ALTER TABLE reloptions_test2 SET (fillfactor=80, parallel_workers=8);
 ALTER TABLE reloptions_test2 SET (fillfactor=80), SET (parallel_workers=8);
 DROP TABLE reloptions_test2;
+
+-- Test hypertable creation using storage options
+
+-- time column
+CREATE TABLE test(time timestamptz NOT NULL, device_id int);
+ALTER TABLE test
+SET (timescaledb.hypertable, timescaledb.time_column = 'time');
+
+INSERT INTO test VALUES ('2004-10-10 00:00:00+00', 1);
+INSERT INTO test VALUES ('2004-10-20 00:00:00+00', 2);
+
+SELECT show_chunks('test');
+
+DROP TABLE test;
+
+-- partitioning column
+CREATE TABLE test(time timestamptz NOT NULL, device_id int);
+ALTER TABLE test
+SET (timescaledb.hypertable,
+     timescaledb.time_column = 'time',
+     timescaledb.partitioning_column = 'device_id',
+     timescaledb.number_partitions = '4');
+
+INSERT INTO test VALUES ('2004-10-10 00:00:00+00', 1);
+INSERT INTO test VALUES ('2004-10-20 00:00:00+00', 2);
+INSERT INTO test VALUES ('2004-10-30 00:00:00+00', 3);
+INSERT INTO test VALUES ('2004-11-10 00:00:00+00', 4);
+
+SELECT show_chunks('test');
+
+DROP TABLE test;
+
+-- time_partitioning_func
+CREATE TABLE test(time text NOT NULL);
+
+CREATE OR REPLACE FUNCTION time_partfunc(source text)
+    RETURNS TIMESTAMPTZ LANGUAGE PLPGSQL IMMUTABLE AS
+$BODY$
+BEGIN
+    RETURN timezone('UTC', to_timestamp(source));
+END
+$BODY$;
+
+ALTER TABLE test
+SET (timescaledb.hypertable,
+     timescaledb.time_column = 'time',
+     timescaledb.time_partitioning_func = 'time_partfunc');
+
+DROP TABLE test;
+
+-- chunk_time_interval
+
+-- integer
+CREATE TABLE test(time timestamptz NOT NULL, device_id int);
+ALTER TABLE test
+SET (timescaledb.hypertable,
+     timescaledb.time_column = 'time',
+     timescaledb.chunk_time_interval = '123');
+
+INSERT INTO test VALUES ('2004-10-10 00:00:00+00', 1);
+INSERT INTO test VALUES ('2004-10-20 00:00:00+00', 2);
+
+SELECT show_chunks('test');
+
+SELECT interval_length
+FROM _timescaledb_catalog.dimension d
+LEFT JOIN _timescaledb_catalog.hypertable h ON (d.hypertable_id = h.id)
+WHERE h.schema_name = 'public' AND h.table_name = 'test'
+ORDER BY d.id;
+
+DROP TABLE test;
+
+-- interval
+CREATE TABLE test(time timestamptz NOT NULL, device_id int);
+ALTER TABLE test
+SET (timescaledb.hypertable,
+     timescaledb.time_column = 'time',
+     timescaledb.chunk_time_interval = '1 day');
+
+INSERT INTO test VALUES ('2004-10-10 00:00:00+00', 1);
+INSERT INTO test VALUES ('2004-10-20 00:00:00+00', 2);
+
+SELECT show_chunks('test');
+
+SELECT interval_length
+FROM _timescaledb_catalog.dimension d
+LEFT JOIN _timescaledb_catalog.hypertable h ON (d.hypertable_id = h.id)
+WHERE h.schema_name = 'public' AND h.table_name = 'test'
+ORDER BY d.id;
+
+DROP TABLE test;
+
+-- test CREATE TABLE WITH ()
+
+-- time column
+CREATE TABLE test_with(time timestamptz NOT NULL, device_id int)
+WITH (timescaledb.hypertable, timescaledb.time_column = 'time');
+
+INSERT INTO test_with VALUES ('2004-10-10 00:00:00+00', 1);
+INSERT INTO test_with VALUES ('2004-10-20 00:00:00+00', 2);
+
+SELECT show_chunks('test_with');
+
+DROP TABLE test_with;
+
+-- interval
+CREATE TABLE test_with(time timestamptz NOT NULL, device_id int)
+WITH (timescaledb.hypertable,
+      timescaledb.time_column = 'time',
+      timescaledb.chunk_time_interval = '1 day');
+
+INSERT INTO test_with VALUES ('2004-10-10 00:00:00+00', 1);
+INSERT INTO test_with VALUES ('2004-10-20 00:00:00+00', 2);
+
+SELECT show_chunks('test_with');
+
+SELECT interval_length
+FROM _timescaledb_catalog.dimension d
+LEFT JOIN _timescaledb_catalog.hypertable h ON (d.hypertable_id = h.id)
+WHERE h.schema_name = 'public' AND h.table_name = 'test_with'
+ORDER BY d.id;
+
+DROP TABLE test_with;
+
+-- Test ALTER TABLE SET (chunk_time_interval)
+
+CREATE TABLE test(time timestamptz NOT NULL, device_id int);
+ALTER TABLE test
+SET (timescaledb.hypertable,
+     timescaledb.time_column = 'time',
+     timescaledb.chunk_time_interval = '123');
+
+INSERT INTO test VALUES ('2004-10-10 00:00:00+00', 1);
+INSERT INTO test VALUES ('2004-10-20 00:00:00+00', 2);
+
+SELECT show_chunks('test');
+
+SELECT interval_length
+FROM _timescaledb_catalog.dimension d
+LEFT JOIN _timescaledb_catalog.hypertable h ON (d.hypertable_id = h.id)
+WHERE h.schema_name = 'public' AND h.table_name = 'test'
+ORDER BY d.id;
+
+ALTER TABLE test
+SET (timescaledb.chunk_time_interval = '321');
+
+SELECT interval_length
+FROM _timescaledb_catalog.dimension d
+LEFT JOIN _timescaledb_catalog.hypertable h ON (d.hypertable_id = h.id)
+WHERE h.schema_name = 'public' AND h.table_name = 'test'
+ORDER BY d.id;
+
+DROP TABLE test;

--- a/tsl/src/compression/create.c
+++ b/tsl/src/compression/create.c
@@ -1086,8 +1086,7 @@ update_compress_chunk_time_interval(Hypertable *ht, WithClauseResult *with_claus
  * 4. Copy constraints to internal compression table
  */
 bool
-tsl_process_compress_table(AlterTableCmd *cmd, Hypertable *ht,
-						   WithClauseResult *with_clause_options)
+tsl_process_compress_table(Hypertable *ht, WithClauseResult *with_clause_options)
 {
 	int32 compress_htid;
 	struct CompressColInfo compress_cols;

--- a/tsl/src/compression/create.h
+++ b/tsl/src/compression/create.h
@@ -18,8 +18,7 @@
 #define COMPRESSION_COLUMN_METADATA_MIN_COLUMN_NAME "min"
 #define COMPRESSION_COLUMN_METADATA_MAX_COLUMN_NAME "max"
 
-bool tsl_process_compress_table(AlterTableCmd *cmd, Hypertable *ht,
-								WithClauseResult *with_clause_options);
+bool tsl_process_compress_table(Hypertable *ht, WithClauseResult *with_clause_options);
 void tsl_process_compress_table_add_column(Hypertable *ht, ColumnDef *orig_def);
 void tsl_process_compress_table_drop_column(Hypertable *ht, char *name);
 void tsl_process_compress_table_rename_column(Hypertable *ht, const RenameStmt *stmt);

--- a/tsl/src/continuous_aggs/options.c
+++ b/tsl/src/continuous_aggs/options.c
@@ -226,13 +226,7 @@ cagg_alter_compression(ContinuousAgg *agg, Hypertable *mat_ht, List *compress_de
 		}
 	}
 
-	AlterTableCmd alter_cmd = {
-		.type = T_AlterTableCmd,
-		.subtype = AT_SetRelOptions,
-		.def = (Node *) compress_defelems,
-	};
-
-	tsl_process_compress_table(&alter_cmd, mat_ht, with_clause_options);
+	tsl_process_compress_table(mat_ht, with_clause_options);
 }
 
 void

--- a/tsl/test/expected/compression.out
+++ b/tsl/test/expected/compression.out
@@ -1877,3 +1877,68 @@ SELECT * FROM f_sensor_data WHERE sensor_id > 100;
                Index Cond: (_hyper_37_71_chunk.sensor_id > 100)
 (13 rows)
 
+-- test creating compressed hypertable using ALTER TABLE command
+CREATE TABLE relopt_test(a integer, b integer, c integer, d integer);
+ALTER TABLE relopt_test
+SET (timescaledb.hypertable,
+     timescaledb.time_column = 'a',
+     timescaledb.chunk_time_interval = '10',
+     timescaledb.compress,
+     timescaledb.compress_segmentby = 'a,b',
+     timescaledb.compress_orderby = 'c desc, d asc nulls last');
+NOTICE:  adding not-null constraint to column "a"
+SELECT id, schema_name, table_name, compression_state as compressed, compressed_hypertable_id
+FROM
+  _timescaledb_catalog.hypertable
+WHERE
+  table_name = 'relopt_test';
+ id | schema_name | table_name  | compressed | compressed_hypertable_id 
+----+-------------+-------------+------------+--------------------------
+ 39 | public      | relopt_test |          1 |                       40
+(1 row)
+
+SELECT * FROM
+  timescaledb_information.compression_settings
+WHERE
+  hypertable_name = 'relopt_test';
+ hypertable_schema | hypertable_name | attname | segmentby_column_index | orderby_column_index | orderby_asc | orderby_nullsfirst 
+-------------------+-----------------+---------+------------------------+----------------------+-------------+--------------------
+ public            | relopt_test     | a       |                      1 |                      |             | 
+ public            | relopt_test     | b       |                      2 |                      |             | 
+ public            | relopt_test     | c       |                        |                    1 | f           | t
+ public            | relopt_test     | d       |                        |                    2 | t           | f
+(4 rows)
+
+DROP TABLE relopt_test;
+-- test creating compressed hypertable using CREATE TABLE WITH command
+CREATE TABLE relopt_test_with(a integer, b integer, c integer, d integer)
+WITH (timescaledb.hypertable,
+      timescaledb.time_column = 'a',
+      timescaledb.chunk_time_interval = '10',
+      timescaledb.compress,
+      timescaledb.compress_segmentby = 'a,b',
+      timescaledb.compress_orderby = 'c desc, d asc nulls last');
+NOTICE:  adding not-null constraint to column "a"
+SELECT id, schema_name, table_name, compression_state as compressed, compressed_hypertable_id
+FROM
+  _timescaledb_catalog.hypertable
+WHERE
+  table_name = 'relopt_test_with';
+ id | schema_name |    table_name    | compressed | compressed_hypertable_id 
+----+-------------+------------------+------------+--------------------------
+ 41 | public      | relopt_test_with |          1 |                       42
+(1 row)
+
+SELECT * FROM
+  timescaledb_information.compression_settings
+WHERE
+  hypertable_name = 'relopt_test_with';
+ hypertable_schema | hypertable_name  | attname | segmentby_column_index | orderby_column_index | orderby_asc | orderby_nullsfirst 
+-------------------+------------------+---------+------------------------+----------------------+-------------+--------------------
+ public            | relopt_test_with | a       |                      1 |                      |             | 
+ public            | relopt_test_with | b       |                      2 |                      |             | 
+ public            | relopt_test_with | c       |                        |                    1 | f           | t
+ public            | relopt_test_with | d       |                        |                    2 | t           | f
+(4 rows)
+
+DROP TABLE relopt_test_with;


### PR DESCRIPTION
This change introduces a way to use tables storage parameters to create a hypertable using `CREATE TABLE WITH` and `ALTER TABLE SET` commands.

`ALTER TABLE SET` command recognizes timescaledb arguments of the `create_hypertable()` function and calls it to create hypertable.

`CREATE TABLE WITH` implemented as a wrapper for the ALTER command.

`chunk_time_interval` argument requires explicit type. This type information cannot be provided explicitly to storage options, we are trying to guess which type been passed by first converting it to integer and then to Interval.

Additional support for changing hypertable parameters using storage options:

- `ALTER TABLE hypertable SET (chunk_time_interval)`