### PR TITLE
Improve number of parallel workers for decompression

### DIFF
--- a/tsl/src/nodes/decompress_chunk/decompress_chunk.c
+++ b/tsl/src/nodes/decompress_chunk/decompress_chunk.c
@@ -578,10 +578,12 @@ ts_decompress_chunk_generate_paths(PlannerInfo *root, RelOptInfo *chunk_rel, Hyp
 
 	/*
 	 * since we rely on parallel coordination from the scan below
-	 * this node it is probably not beneficial to have more
-	 * than a single worker per chunk
+	 * request the same amount of parallel workers here as 
+	 * PostgreSQL uses for the parallel scan on the compressed chunk
 	 */
-	int parallel_workers = 1;
+	int parallel_workers = compute_parallel_worker(chunk_rel, chunk_rel->pages, -1, 
+											   max_parallel_workers_per_gather);
+
 	SortInfo sort_info = build_sortinfo(chunk, chunk_rel, info, root->query_pathkeys);
 
 	Assert(chunk->fd.compressed_chunk_id > 0);

--- a/tsl/test/shared/expected/transparent_decompress_chunk-13.out
+++ b/tsl/test/shared/expected/transparent_decompress_chunk-13.out
@@ -670,16 +670,16 @@ FROM :TEST_TABLE m1
     LIMIT 10;
 QUERY PLAN
  Limit
-   ->  Nested Loop
-         Join Filter: ((m1."time" = m2."time") AND (m1.device_id = m2.device_id))
-         ->  Gather Merge
-               Workers Planned: 1
-               ->  Sort
-                     Sort Key: m1."time", m1.device_id
-                     ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk m1
-                           ->  Parallel Seq Scan on compress_hyper_X_X_chunk
-         ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk m2
-               ->  Seq Scan on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1
+   ->  Merge Join
+         Merge Cond: ((m1."time" = m2."time") AND (m1.device_id = m2.device_id))
+         ->  Sort
+               Sort Key: m1."time", m1.device_id
+               ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk m1
+                     ->  Seq Scan on compress_hyper_X_X_chunk
+         ->  Sort
+               Sort Key: m2."time", m2.device_id
+               ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk m2
+                     ->  Seq Scan on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1
 (11 rows)
 
 :PREFIX_NO_VERBOSE

--- a/tsl/test/shared/expected/transparent_decompress_chunk-14.out
+++ b/tsl/test/shared/expected/transparent_decompress_chunk-14.out
@@ -670,16 +670,16 @@ FROM :TEST_TABLE m1
     LIMIT 10;
 QUERY PLAN
  Limit
-   ->  Nested Loop
-         Join Filter: ((m1."time" = m2."time") AND (m1.device_id = m2.device_id))
-         ->  Gather Merge
-               Workers Planned: 1
-               ->  Sort
-                     Sort Key: m1."time", m1.device_id
-                     ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk m1
-                           ->  Parallel Seq Scan on compress_hyper_X_X_chunk
-         ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk m2
-               ->  Seq Scan on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1
+   ->  Merge Join
+         Merge Cond: ((m1."time" = m2."time") AND (m1.device_id = m2.device_id))
+         ->  Sort
+               Sort Key: m1."time", m1.device_id
+               ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk m1
+                     ->  Seq Scan on compress_hyper_X_X_chunk
+         ->  Sort
+               Sort Key: m2."time", m2.device_id
+               ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk m2
+                     ->  Seq Scan on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1
 (11 rows)
 
 :PREFIX_NO_VERBOSE
@@ -696,16 +696,16 @@ QUERY PLAN
  Limit
    ->  Nested Loop
          Join Filter: (m1."time" = m3."time")
-         ->  Nested Loop
-               Join Filter: ((m1."time" = m2."time") AND (m1.device_id = m2.device_id))
-               ->  Gather Merge
-                     Workers Planned: 1
-                     ->  Sort
-                           Sort Key: m1."time", m1.device_id
-                           ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk m1
-                                 ->  Parallel Seq Scan on compress_hyper_X_X_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk m2
-                     ->  Seq Scan on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1
+         ->  Merge Join
+               Merge Cond: ((m1."time" = m2."time") AND (m1.device_id = m2.device_id))
+               ->  Sort
+                     Sort Key: m1."time", m1.device_id
+                     ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk m1
+                           ->  Seq Scan on compress_hyper_X_X_chunk
+               ->  Sort
+                     Sort Key: m2."time", m2.device_id
+                     ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk m2
+                           ->  Seq Scan on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1
          ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk m3
                ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_4_device_id__t on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_2
                      Index Cond: (device_id = 3)
@@ -780,16 +780,16 @@ ORDER BY m1.time,
 LIMIT 10;
 QUERY PLAN
  Limit
-   ->  Nested Loop Left Join
-         Join Filter: ((m1."time" = m2."time") AND (m1.device_id = m2.device_id))
-         ->  Gather Merge
-               Workers Planned: 1
-               ->  Sort
-                     Sort Key: m1."time", m1.device_id
-                     ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk m1
-                           ->  Parallel Seq Scan on compress_hyper_X_X_chunk
-         ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk m2
-               ->  Seq Scan on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1
+   ->  Merge Left Join
+         Merge Cond: ((m1."time" = m2."time") AND (m1.device_id = m2.device_id))
+         ->  Sort
+               Sort Key: m1."time", m1.device_id
+               ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk m1
+                     ->  Seq Scan on compress_hyper_X_X_chunk
+         ->  Sort
+               Sort Key: m2."time", m2.device_id
+               ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk m2
+                     ->  Seq Scan on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1
 (11 rows)
 
 :PREFIX_NO_VERBOSE

--- a/tsl/test/shared/expected/transparent_decompress_chunk-15.out
+++ b/tsl/test/shared/expected/transparent_decompress_chunk-15.out
@@ -672,16 +672,16 @@ FROM :TEST_TABLE m1
     LIMIT 10;
 QUERY PLAN
  Limit
-   ->  Nested Loop
-         Join Filter: ((m1."time" = m2."time") AND (m1.device_id = m2.device_id))
-         ->  Gather Merge
-               Workers Planned: 1
-               ->  Sort
-                     Sort Key: m1."time", m1.device_id
-                     ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk m1
-                           ->  Parallel Seq Scan on compress_hyper_X_X_chunk
-         ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk m2
-               ->  Seq Scan on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1
+   ->  Merge Join
+         Merge Cond: ((m1."time" = m2."time") AND (m1.device_id = m2.device_id))
+         ->  Sort
+               Sort Key: m1."time", m1.device_id
+               ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk m1
+                     ->  Seq Scan on compress_hyper_X_X_chunk
+         ->  Sort
+               Sort Key: m2."time", m2.device_id
+               ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk m2
+                     ->  Seq Scan on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1
 (11 rows)
 
 :PREFIX_NO_VERBOSE
@@ -698,16 +698,16 @@ QUERY PLAN
  Limit
    ->  Nested Loop
          Join Filter: (m1."time" = m3."time")
-         ->  Nested Loop
-               Join Filter: ((m1."time" = m2."time") AND (m1.device_id = m2.device_id))
-               ->  Gather Merge
-                     Workers Planned: 1
-                     ->  Sort
-                           Sort Key: m1."time", m1.device_id
-                           ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk m1
-                                 ->  Parallel Seq Scan on compress_hyper_X_X_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk m2
-                     ->  Seq Scan on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1
+         ->  Merge Join
+               Merge Cond: ((m1."time" = m2."time") AND (m1.device_id = m2.device_id))
+               ->  Sort
+                     Sort Key: m1."time", m1.device_id
+                     ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk m1
+                           ->  Seq Scan on compress_hyper_X_X_chunk
+               ->  Sort
+                     Sort Key: m2."time", m2.device_id
+                     ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk m2
+                           ->  Seq Scan on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1
          ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk m3
                ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_4_device_id__t on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_2
                      Index Cond: (device_id = 3)
@@ -782,16 +782,16 @@ ORDER BY m1.time,
 LIMIT 10;
 QUERY PLAN
  Limit
-   ->  Nested Loop Left Join
-         Join Filter: ((m1."time" = m2."time") AND (m1.device_id = m2.device_id))
-         ->  Gather Merge
-               Workers Planned: 1
-               ->  Sort
-                     Sort Key: m1."time", m1.device_id
-                     ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk m1
-                           ->  Parallel Seq Scan on compress_hyper_X_X_chunk
-         ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk m2
-               ->  Seq Scan on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1
+   ->  Merge Left Join
+         Merge Cond: ((m1."time" = m2."time") AND (m1.device_id = m2.device_id))
+         ->  Sort
+               Sort Key: m1."time", m1.device_id
+               ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk m1
+                     ->  Seq Scan on compress_hyper_X_X_chunk
+         ->  Sort
+               Sort Key: m2."time", m2.device_id
+               ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk m2
+                     ->  Seq Scan on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1
 (11 rows)
 
 :PREFIX_NO_VERBOSE

--- a/tsl/test/sql/compression.sql
+++ b/tsl/test/sql/compression.sql
@@ -757,3 +757,75 @@ SET enable_indexscan to off;
 SELECT time, const, numeric,first, avg1, avg2 FROM tidrangescan_expr ORDER BY time LIMIT 5;
 RESET timescaledb.enable_chunk_append;
 RESET enable_indexscan;
+
+
+-- Improve the number of parallel workers for decompression
+
+-- Test that a parallel plan is generated
+-- with different number of parallel workers
+
+CREATE TABLE f_sensor_data(
+      time timestamptz not null,
+      sensor_id integer not null,
+      cpu double precision null,
+      temperature double precision null 
+    );
+
+SELECT FROM create_hypertable('f_sensor_data','time');
+SELECT set_chunk_time_interval('f_sensor_data', INTERVAL '1 year');
+
+SELECT * FROM _timescaledb_internal.create_chunk('f_sensor_data',' {"time": [181900977000000, 515024000000000]}');
+
+INSERT INTO f_sensor_data
+SELECT
+    time AS time,
+    sensor_id,
+    100.0,
+    36.6
+FROM
+    generate_series('1980-01-01 00:00'::timestamp, '1980-12-31 12:00', INTERVAL '1 day') AS g1(time),
+    generate_series(1, 700, 1 ) AS g2(sensor_id)
+ORDER BY
+    time;
+
+SELECT c.chunk_name,c.range_start,c.range_end,c.is_compressed,pg_size_pretty(d.total_bytes) 
+FROM public.chunks_detailed_size('public.f_sensor_data') d, timescaledb_information.chunks c 
+WHERE d.chunk_name=c.chunk_name 
+ORDER BY c.range_start;
+
+ALTER TABLE f_sensor_data SET (timescaledb.compress, timescaledb.compress_segmentby='sensor_id' ,timescaledb.compress_orderby = 'time DESC');
+
+SELECT add_compression_policy('f_sensor_data','1 minute'::INTERVAL);
+SELECT compress_chunk(i) FROM show_chunks('f_sensor_data') i;
+
+SELECT c.chunk_name,c.range_start,c.range_end,c.is_compressed,pg_size_pretty(d.total_bytes) 
+FROM public.chunks_detailed_size('public.f_sensor_data') d, timescaledb_information.chunks c 
+WHERE d.chunk_name=c.chunk_name 
+ORDER BY c.range_start;
+
+-- Encourage use of parallel plans
+SET parallel_setup_cost = 0;
+SET parallel_tuple_cost = 0;
+
+SET min_parallel_table_scan_size TO '1';
+
+\set explain 'EXPLAIN (VERBOSE, COSTS OFF)'
+
+SHOW min_parallel_table_scan_size;
+SHOW max_parallel_workers;
+SHOW max_parallel_workers_per_gather;
+
+set max_parallel_workers_per_gather = 1;
+SHOW max_parallel_workers_per_gather;
+:explain
+select sum(cpu) from f_sensor_data;
+
+set max_parallel_workers_per_gather = 2;
+SHOW max_parallel_workers_per_gather;
+:explain
+select sum(cpu) from f_sensor_data;
+
+set max_parallel_workers_per_gather = 4;
+SHOW max_parallel_workers_per_gather;
+:explain
+select sum(cpu) from f_sensor_data;


### PR DESCRIPTION
Planner may also choose parallel plans when decompressing chunks.
Can use for decompression as many workers wants per chunk.

Co-authored-by: Jan Kristof Nidzwetzki <jan@timescale.com>