### PR TITLE
Fix DML decompression issues with bitmap heap scan

### DIFF
--- a/tsl/test/expected/compression_update_delete.out
+++ b/tsl/test/expected/compression_update_delete.out
@@ -1790,6 +1790,53 @@ SELECT count(*) FROM tab1 WHERE device_id = 1;
 (1 row)
 
 ROLLBACK;
+-- github issue 5658
+-- verify that bitmap heap scans work on all the correct data and
+-- none of it left over after the dml command
+BEGIN;
+SELECT count(*) FROM tab1 WHERE device_id = 1;
+ count 
+-------
+   472
+(1 row)
+
+INSERT INTO tab1(time,device_id,v0,v1,v2,v3) SELECT time, device_id, device_id+1,  device_id + 2, device_id + 1000, NULL FROM generate_series('2000-01-01 0:00:00+0'::timestamptz,'2000-01-05 23:55:00+0','2m') gtime(time), generate_series(1,5,1) gdevice(device_id);
+SELECT count(*) FROM tab1 WHERE device_id = 1;
+ count 
+-------
+  4070
+(1 row)
+
+ANALYZE tab1;
+SET enable_seqscan = off;
+SET enable_indexscan = off;
+EXPLAIN (costs off) DELETE FROM tab1 WHERE tab1.device_id = 1;
+                                       QUERY PLAN                                        
+-----------------------------------------------------------------------------------------
+ Custom Scan (HypertableModify)
+   ->  Delete on tab1
+         Delete on _hyper_21_39_chunk tab1_1
+         Delete on _hyper_21_40_chunk tab1_2
+         Delete on _hyper_21_41_chunk tab1_3
+         ->  Append
+               ->  Bitmap Heap Scan on _hyper_21_39_chunk tab1_1
+                     Recheck Cond: (device_id = 1)
+                     ->  Bitmap Index Scan on _hyper_21_39_chunk_tab1_device_id_time_idx
+                           Index Cond: (device_id = 1)
+               ->  Seq Scan on _hyper_21_40_chunk tab1_2
+                     Filter: (device_id = 1)
+               ->  Seq Scan on _hyper_21_41_chunk tab1_3
+                     Filter: (device_id = 1)
+(14 rows)
+
+DELETE FROM tab1 WHERE tab1.device_id = 1;
+SELECT count(*) FROM tab1 WHERE device_id = 1;
+ count 
+-------
+     0
+(1 row)
+
+ROLLBACK;
 -- create hypertable with space partitioning and compression
 CREATE TABLE tab2(filler_1 int, filler_2 int, filler_3 int, time timestamptz NOT NULL, device_id int, v0 int, v1 int, v2 float, v3 float);
 CREATE INDEX ON tab2(time);


### PR DESCRIPTION
Bitmap heap scans are specific in that they store scan state during node initialization. This means they would not pick up on any data that might have been decompressed during a DML command from the compressed chunk. To avoid this, we update the snapshot on the node scan state and issue a rescan to update the internal state.

Fixes #5658 

Disable-check: force-changelog-changed