### PR TITLE
Fix leak during concurrent UPDATE/DELETE

### DIFF
--- a/tsl/test/isolation/expected/compression_dml_iso.out
+++ b/tsl/test/isolation/expected/compression_dml_iso.out
@@ -1,5 +1,3 @@
-unused step name: IN1
-unused step name: INc
 unused step name: S1
 unused step name: SA
 unused step name: SC1
@@ -58,5 +56,487 @@ step SH: SELECT total_chunks, number_compressed_chunks from hypertable_compressi
 total_chunks|number_compressed_chunks
 ------------+------------------------
            3|                       3
+(1 row)
+
+
+starting permutation: IN1 INc CA1 CAc SH SS DEL1 UPD1 DELc UPDc SH SS
+step IN1: BEGIN; INSERT INTO ts_device_table VALUES (1, 1, 200, 100);
+step INc: COMMIT;
+step CA1: 
+  BEGIN;
+  SELECT
+    CASE WHEN compress_chunk(ch) IS NOT NULL THEN true ELSE false END AS compress
+  FROM show_chunks('ts_device_table') AS ch
+  ORDER BY ch::text;
+
+compress
+--------
+t       
+t       
+t       
+(3 rows)
+
+step CAc: COMMIT;
+step SH: SELECT total_chunks, number_compressed_chunks from hypertable_compression_stats('ts_device_table');
+total_chunks|number_compressed_chunks
+------------+------------------------
+           3|                       3
+(1 row)
+
+step SS: SELECT * FROM ts_device_table WHERE location = 200;
+time|device|location|value
+----+------+--------+-----
+   1|     1|     200|  100
+(1 row)
+
+step DEL1: BEGIN; DELETE from ts_device_table WHERE location = 200;
+step UPD1: BEGIN; UPDATE ts_device_table SET value = 4 WHERE location = 200; <waiting ...>
+step DELc: COMMIT;
+step UPD1: <... completed>
+step UPDc: COMMIT;
+step SH: SELECT total_chunks, number_compressed_chunks from hypertable_compression_stats('ts_device_table');
+total_chunks|number_compressed_chunks
+------------+------------------------
+           3|                       3
+(1 row)
+
+step SS: SELECT * FROM ts_device_table WHERE location = 200;
+time|device|location|value
+----+------+--------+-----
+(0 rows)
+
+
+starting permutation: IN1 INc CA1 CAc SH SS UPD1 DEL1 UPDc DELc SH SS
+step IN1: BEGIN; INSERT INTO ts_device_table VALUES (1, 1, 200, 100);
+step INc: COMMIT;
+step CA1: 
+  BEGIN;
+  SELECT
+    CASE WHEN compress_chunk(ch) IS NOT NULL THEN true ELSE false END AS compress
+  FROM show_chunks('ts_device_table') AS ch
+  ORDER BY ch::text;
+
+compress
+--------
+t       
+t       
+t       
+(3 rows)
+
+step CAc: COMMIT;
+step SH: SELECT total_chunks, number_compressed_chunks from hypertable_compression_stats('ts_device_table');
+total_chunks|number_compressed_chunks
+------------+------------------------
+           3|                       3
+(1 row)
+
+step SS: SELECT * FROM ts_device_table WHERE location = 200;
+time|device|location|value
+----+------+--------+-----
+   1|     1|     200|  100
+(1 row)
+
+step UPD1: BEGIN; UPDATE ts_device_table SET value = 4 WHERE location = 200;
+step DEL1: BEGIN; DELETE from ts_device_table WHERE location = 200; <waiting ...>
+step UPDc: COMMIT;
+step DEL1: <... completed>
+step DELc: COMMIT;
+step SH: SELECT total_chunks, number_compressed_chunks from hypertable_compression_stats('ts_device_table');
+total_chunks|number_compressed_chunks
+------------+------------------------
+           3|                       3
+(1 row)
+
+step SS: SELECT * FROM ts_device_table WHERE location = 200;
+time|device|location|value
+----+------+--------+-----
+(0 rows)
+
+
+starting permutation: IN1 INc CA1 CAc SH SS DEL1 UPDrr DELc UPDc SH SS
+step IN1: BEGIN; INSERT INTO ts_device_table VALUES (1, 1, 200, 100);
+step INc: COMMIT;
+step CA1: 
+  BEGIN;
+  SELECT
+    CASE WHEN compress_chunk(ch) IS NOT NULL THEN true ELSE false END AS compress
+  FROM show_chunks('ts_device_table') AS ch
+  ORDER BY ch::text;
+
+compress
+--------
+t       
+t       
+t       
+(3 rows)
+
+step CAc: COMMIT;
+step SH: SELECT total_chunks, number_compressed_chunks from hypertable_compression_stats('ts_device_table');
+total_chunks|number_compressed_chunks
+------------+------------------------
+           3|                       3
+(1 row)
+
+step SS: SELECT * FROM ts_device_table WHERE location = 200;
+time|device|location|value
+----+------+--------+-----
+   1|     1|     200|  100
+(1 row)
+
+step DEL1: BEGIN; DELETE from ts_device_table WHERE location = 200;
+step UPDrr: BEGIN TRANSACTION ISOLATION LEVEL REPEATABLE READ; UPDATE ts_device_table SET value = 4 WHERE location = 200; <waiting ...>
+step DELc: COMMIT;
+step UPDrr: <... completed>
+ERROR:  could not serialize access due to concurrent update
+step UPDc: COMMIT;
+step SH: SELECT total_chunks, number_compressed_chunks from hypertable_compression_stats('ts_device_table');
+total_chunks|number_compressed_chunks
+------------+------------------------
+           3|                       3
+(1 row)
+
+step SS: SELECT * FROM ts_device_table WHERE location = 200;
+time|device|location|value
+----+------+--------+-----
+(0 rows)
+
+
+starting permutation: IN1 INc CA1 CAc SH SS UPD1 DELrr UPDc DELc SH SS
+step IN1: BEGIN; INSERT INTO ts_device_table VALUES (1, 1, 200, 100);
+step INc: COMMIT;
+step CA1: 
+  BEGIN;
+  SELECT
+    CASE WHEN compress_chunk(ch) IS NOT NULL THEN true ELSE false END AS compress
+  FROM show_chunks('ts_device_table') AS ch
+  ORDER BY ch::text;
+
+compress
+--------
+t       
+t       
+t       
+(3 rows)
+
+step CAc: COMMIT;
+step SH: SELECT total_chunks, number_compressed_chunks from hypertable_compression_stats('ts_device_table');
+total_chunks|number_compressed_chunks
+------------+------------------------
+           3|                       3
+(1 row)
+
+step SS: SELECT * FROM ts_device_table WHERE location = 200;
+time|device|location|value
+----+------+--------+-----
+   1|     1|     200|  100
+(1 row)
+
+step UPD1: BEGIN; UPDATE ts_device_table SET value = 4 WHERE location = 200;
+step DELrr: BEGIN TRANSACTION ISOLATION LEVEL REPEATABLE READ; DELETE from ts_device_table WHERE location = 200; <waiting ...>
+step UPDc: COMMIT;
+step DELrr: <... completed>
+ERROR:  could not serialize access due to concurrent update
+step DELc: COMMIT;
+step SH: SELECT total_chunks, number_compressed_chunks from hypertable_compression_stats('ts_device_table');
+total_chunks|number_compressed_chunks
+------------+------------------------
+           3|                       3
+(1 row)
+
+step SS: SELECT * FROM ts_device_table WHERE location = 200;
+time|device|location|value
+----+------+--------+-----
+   1|     1|     200|    4
+(1 row)
+
+
+starting permutation: IN1 INc CA1 CAc SH SS DELrr UPDrr DELc UPDc SH SS
+step IN1: BEGIN; INSERT INTO ts_device_table VALUES (1, 1, 200, 100);
+step INc: COMMIT;
+step CA1: 
+  BEGIN;
+  SELECT
+    CASE WHEN compress_chunk(ch) IS NOT NULL THEN true ELSE false END AS compress
+  FROM show_chunks('ts_device_table') AS ch
+  ORDER BY ch::text;
+
+compress
+--------
+t       
+t       
+t       
+(3 rows)
+
+step CAc: COMMIT;
+step SH: SELECT total_chunks, number_compressed_chunks from hypertable_compression_stats('ts_device_table');
+total_chunks|number_compressed_chunks
+------------+------------------------
+           3|                       3
+(1 row)
+
+step SS: SELECT * FROM ts_device_table WHERE location = 200;
+time|device|location|value
+----+------+--------+-----
+   1|     1|     200|  100
+(1 row)
+
+step DELrr: BEGIN TRANSACTION ISOLATION LEVEL REPEATABLE READ; DELETE from ts_device_table WHERE location = 200;
+step UPDrr: BEGIN TRANSACTION ISOLATION LEVEL REPEATABLE READ; UPDATE ts_device_table SET value = 4 WHERE location = 200; <waiting ...>
+step DELc: COMMIT;
+step UPDrr: <... completed>
+ERROR:  could not serialize access due to concurrent update
+step UPDc: COMMIT;
+step SH: SELECT total_chunks, number_compressed_chunks from hypertable_compression_stats('ts_device_table');
+total_chunks|number_compressed_chunks
+------------+------------------------
+           3|                       3
+(1 row)
+
+step SS: SELECT * FROM ts_device_table WHERE location = 200;
+time|device|location|value
+----+------+--------+-----
+(0 rows)
+
+
+starting permutation: IN1 INc CA1 CAc SH SS UPDrr DELrr UPDc DELc SH SS
+step IN1: BEGIN; INSERT INTO ts_device_table VALUES (1, 1, 200, 100);
+step INc: COMMIT;
+step CA1: 
+  BEGIN;
+  SELECT
+    CASE WHEN compress_chunk(ch) IS NOT NULL THEN true ELSE false END AS compress
+  FROM show_chunks('ts_device_table') AS ch
+  ORDER BY ch::text;
+
+compress
+--------
+t       
+t       
+t       
+(3 rows)
+
+step CAc: COMMIT;
+step SH: SELECT total_chunks, number_compressed_chunks from hypertable_compression_stats('ts_device_table');
+total_chunks|number_compressed_chunks
+------------+------------------------
+           3|                       3
+(1 row)
+
+step SS: SELECT * FROM ts_device_table WHERE location = 200;
+time|device|location|value
+----+------+--------+-----
+   1|     1|     200|  100
+(1 row)
+
+step UPDrr: BEGIN TRANSACTION ISOLATION LEVEL REPEATABLE READ; UPDATE ts_device_table SET value = 4 WHERE location = 200;
+step DELrr: BEGIN TRANSACTION ISOLATION LEVEL REPEATABLE READ; DELETE from ts_device_table WHERE location = 200; <waiting ...>
+step UPDc: COMMIT;
+step DELrr: <... completed>
+ERROR:  could not serialize access due to concurrent update
+step DELc: COMMIT;
+step SH: SELECT total_chunks, number_compressed_chunks from hypertable_compression_stats('ts_device_table');
+total_chunks|number_compressed_chunks
+------------+------------------------
+           3|                       3
+(1 row)
+
+step SS: SELECT * FROM ts_device_table WHERE location = 200;
+time|device|location|value
+----+------+--------+-----
+   1|     1|     200|    4
+(1 row)
+
+
+starting permutation: IN1 INc CA1 CAc SH SS DELrr UPDs DELc UPDc SH SS
+step IN1: BEGIN; INSERT INTO ts_device_table VALUES (1, 1, 200, 100);
+step INc: COMMIT;
+step CA1: 
+  BEGIN;
+  SELECT
+    CASE WHEN compress_chunk(ch) IS NOT NULL THEN true ELSE false END AS compress
+  FROM show_chunks('ts_device_table') AS ch
+  ORDER BY ch::text;
+
+compress
+--------
+t       
+t       
+t       
+(3 rows)
+
+step CAc: COMMIT;
+step SH: SELECT total_chunks, number_compressed_chunks from hypertable_compression_stats('ts_device_table');
+total_chunks|number_compressed_chunks
+------------+------------------------
+           3|                       3
+(1 row)
+
+step SS: SELECT * FROM ts_device_table WHERE location = 200;
+time|device|location|value
+----+------+--------+-----
+   1|     1|     200|  100
+(1 row)
+
+step DELrr: BEGIN TRANSACTION ISOLATION LEVEL REPEATABLE READ; DELETE from ts_device_table WHERE location = 200;
+step UPDs: BEGIN TRANSACTION ISOLATION LEVEL SERIALIZABLE; UPDATE ts_device_table SET value = 4 WHERE location = 200; <waiting ...>
+step DELc: COMMIT;
+step UPDs: <... completed>
+ERROR:  could not serialize access due to concurrent update
+step UPDc: COMMIT;
+step SH: SELECT total_chunks, number_compressed_chunks from hypertable_compression_stats('ts_device_table');
+total_chunks|number_compressed_chunks
+------------+------------------------
+           3|                       3
+(1 row)
+
+step SS: SELECT * FROM ts_device_table WHERE location = 200;
+time|device|location|value
+----+------+--------+-----
+(0 rows)
+
+
+starting permutation: IN1 INc CA1 CAc SH SS UPDrr DELs UPDc DELc SH SS
+step IN1: BEGIN; INSERT INTO ts_device_table VALUES (1, 1, 200, 100);
+step INc: COMMIT;
+step CA1: 
+  BEGIN;
+  SELECT
+    CASE WHEN compress_chunk(ch) IS NOT NULL THEN true ELSE false END AS compress
+  FROM show_chunks('ts_device_table') AS ch
+  ORDER BY ch::text;
+
+compress
+--------
+t       
+t       
+t       
+(3 rows)
+
+step CAc: COMMIT;
+step SH: SELECT total_chunks, number_compressed_chunks from hypertable_compression_stats('ts_device_table');
+total_chunks|number_compressed_chunks
+------------+------------------------
+           3|                       3
+(1 row)
+
+step SS: SELECT * FROM ts_device_table WHERE location = 200;
+time|device|location|value
+----+------+--------+-----
+   1|     1|     200|  100
+(1 row)
+
+step UPDrr: BEGIN TRANSACTION ISOLATION LEVEL REPEATABLE READ; UPDATE ts_device_table SET value = 4 WHERE location = 200;
+step DELs: BEGIN TRANSACTION ISOLATION LEVEL SERIALIZABLE; DELETE from ts_device_table WHERE location = 200; <waiting ...>
+step UPDc: COMMIT;
+step DELs: <... completed>
+ERROR:  could not serialize access due to concurrent update
+step DELc: COMMIT;
+step SH: SELECT total_chunks, number_compressed_chunks from hypertable_compression_stats('ts_device_table');
+total_chunks|number_compressed_chunks
+------------+------------------------
+           3|                       3
+(1 row)
+
+step SS: SELECT * FROM ts_device_table WHERE location = 200;
+time|device|location|value
+----+------+--------+-----
+   1|     1|     200|    4
+(1 row)
+
+
+starting permutation: IN1 INc CA1 CAc SH SS DELs UPDrr DELc UPDc SH SS
+step IN1: BEGIN; INSERT INTO ts_device_table VALUES (1, 1, 200, 100);
+step INc: COMMIT;
+step CA1: 
+  BEGIN;
+  SELECT
+    CASE WHEN compress_chunk(ch) IS NOT NULL THEN true ELSE false END AS compress
+  FROM show_chunks('ts_device_table') AS ch
+  ORDER BY ch::text;
+
+compress
+--------
+t       
+t       
+t       
+(3 rows)
+
+step CAc: COMMIT;
+step SH: SELECT total_chunks, number_compressed_chunks from hypertable_compression_stats('ts_device_table');
+total_chunks|number_compressed_chunks
+------------+------------------------
+           3|                       3
+(1 row)
+
+step SS: SELECT * FROM ts_device_table WHERE location = 200;
+time|device|location|value
+----+------+--------+-----
+   1|     1|     200|  100
+(1 row)
+
+step DELs: BEGIN TRANSACTION ISOLATION LEVEL SERIALIZABLE; DELETE from ts_device_table WHERE location = 200;
+step UPDrr: BEGIN TRANSACTION ISOLATION LEVEL REPEATABLE READ; UPDATE ts_device_table SET value = 4 WHERE location = 200; <waiting ...>
+step DELc: COMMIT;
+step UPDrr: <... completed>
+ERROR:  could not serialize access due to concurrent update
+step UPDc: COMMIT;
+step SH: SELECT total_chunks, number_compressed_chunks from hypertable_compression_stats('ts_device_table');
+total_chunks|number_compressed_chunks
+------------+------------------------
+           3|                       3
+(1 row)
+
+step SS: SELECT * FROM ts_device_table WHERE location = 200;
+time|device|location|value
+----+------+--------+-----
+(0 rows)
+
+
+starting permutation: IN1 INc CA1 CAc SH SS UPDs DELrr UPDc DELc SH SS
+step IN1: BEGIN; INSERT INTO ts_device_table VALUES (1, 1, 200, 100);
+step INc: COMMIT;
+step CA1: 
+  BEGIN;
+  SELECT
+    CASE WHEN compress_chunk(ch) IS NOT NULL THEN true ELSE false END AS compress
+  FROM show_chunks('ts_device_table') AS ch
+  ORDER BY ch::text;
+
+compress
+--------
+t       
+t       
+t       
+(3 rows)
+
+step CAc: COMMIT;
+step SH: SELECT total_chunks, number_compressed_chunks from hypertable_compression_stats('ts_device_table');
+total_chunks|number_compressed_chunks
+------------+------------------------
+           3|                       3
+(1 row)
+
+step SS: SELECT * FROM ts_device_table WHERE location = 200;
+time|device|location|value
+----+------+--------+-----
+   1|     1|     200|  100
+(1 row)
+
+step UPDs: BEGIN TRANSACTION ISOLATION LEVEL SERIALIZABLE; UPDATE ts_device_table SET value = 4 WHERE location = 200;
+step DELrr: BEGIN TRANSACTION ISOLATION LEVEL REPEATABLE READ; DELETE from ts_device_table WHERE location = 200; <waiting ...>
+step UPDc: COMMIT;
+step DELrr: <... completed>
+ERROR:  could not serialize access due to concurrent update
+step DELc: COMMIT;
+step SH: SELECT total_chunks, number_compressed_chunks from hypertable_compression_stats('ts_device_table');
+total_chunks|number_compressed_chunks
+------------+------------------------
+           3|                       3
+(1 row)
+
+step SS: SELECT * FROM ts_device_table WHERE location = 200;
+time|device|location|value
+----+------+--------+-----
+   1|     1|     200|    4
 (1 row)
 

--- a/tsl/test/isolation/specs/compression_dml_iso.spec
+++ b/tsl/test/isolation/specs/compression_dml_iso.spec
@@ -36,10 +36,14 @@ step "INc"   { COMMIT; }
 
 session "DEL"
 step "DEL1"   { BEGIN; DELETE from ts_device_table WHERE location = 200; }
+step "DELrr"  { BEGIN TRANSACTION ISOLATION LEVEL REPEATABLE READ; DELETE from ts_device_table WHERE location = 200; }
+step "DELs"   { BEGIN TRANSACTION ISOLATION LEVEL SERIALIZABLE; DELETE from ts_device_table WHERE location = 200; }
 step "DELc"   { COMMIT; }
 
 session "UPD"
 step "UPD1"   { BEGIN; UPDATE ts_device_table SET value = 4 WHERE location = 200; }
+step "UPDrr"  { BEGIN TRANSACTION ISOLATION LEVEL REPEATABLE READ; UPDATE ts_device_table SET value = 4 WHERE location = 200; }
+step "UPDs"   { BEGIN TRANSACTION ISOLATION LEVEL SERIALIZABLE; UPDATE ts_device_table SET value = 4 WHERE location = 200; }
 step "UPDc"   { COMMIT; }
 
 session "SI"
@@ -51,6 +55,7 @@ step "S1" { SELECT count(*) from ts_device_table; }
 step "SC1" { SELECT (count_chunktable(ch)).* FROM show_chunks('ts_device_table') AS ch ORDER BY ch::text LIMIT 1; }
 step "SH" { SELECT total_chunks, number_compressed_chunks from hypertable_compression_stats('ts_device_table'); }
 step "SA" { SELECT * FROM ts_device_table; }
+step "SS" { SELECT * FROM ts_device_table WHERE location = 200; }
 
 session "CompressAll"
 step "CA1" {
@@ -64,3 +69,15 @@ step "CAc" { COMMIT; }
 
 # Test concurrent update/delete operations
 permutation "CA1" "CAc" "SH" "I1" "Ic" "SH" "UPD1" "UPDc" "SH" "DEL1" "DELc" "SH" "UPD1" "UPDc" "SH"
+permutation "IN1" "INc" "CA1" "CAc" "SH" "SS" "DEL1" "UPD1" "DELc" "UPDc" "SH" "SS"
+permutation "IN1" "INc" "CA1" "CAc" "SH" "SS" "UPD1" "DEL1" "UPDc" "DELc" "SH" "SS"
+
+#Test interaction with upper isolation levels
+permutation "IN1" "INc" "CA1" "CAc" "SH" "SS" "DEL1" "UPDrr"  "DELc" "UPDc" "SH" "SS"
+permutation "IN1" "INc" "CA1" "CAc" "SH" "SS" "UPD1" "DELrr"  "UPDc" "DELc" "SH" "SS"
+permutation "IN1" "INc" "CA1" "CAc" "SH" "SS" "DELrr" "UPDrr"  "DELc" "UPDc" "SH" "SS"
+permutation "IN1" "INc" "CA1" "CAc" "SH" "SS" "UPDrr" "DELrr"  "UPDc" "DELc" "SH" "SS"
+permutation "IN1" "INc" "CA1" "CAc" "SH" "SS" "DELrr" "UPDs"  "DELc" "UPDc" "SH" "SS"
+permutation "IN1" "INc" "CA1" "CAc" "SH" "SS" "UPDrr" "DELs"  "UPDc" "DELc" "SH" "SS"
+permutation "IN1" "INc" "CA1" "CAc" "SH" "SS" "DELs" "UPDrr"  "DELc" "UPDc" "SH" "SS"
+permutation "IN1" "INc" "CA1" "CAc" "SH" "SS" "UPDs" "DELrr"  "UPDc" "DELc" "SH" "SS"


### PR DESCRIPTION
When updating and deleting the same tuple while both transactions are running at the same time, we end up with reference leak. This is because one of the query in a transaction fails and we take error path. However we fail to close the table.

This patch fixes the above mentioned problem by closing the required tables.

Fixes #5674

Disable-check: force-changelog-changed