### PR TITLE
Use environment variables for workflows

### DIFF
--- a/.github/workflows/changelog-check.yaml
+++ b/.github/workflows/changelog-check.yaml
@@ -30,11 +30,11 @@ jobs:
           fetch-depth: 0
       - name: Check CHANGELOG.md updated by pull request
         shell: bash --norc --noprofile {0}
+        env:
+          BODY: ${{ github.event.pull_request.body }}
         run: |
           diff=$(git diff --name-status origin/main | grep "CHANGELOG.md")
-          cat << "EOF" | egrep -qsi '^disable-check:.*\<force-changelog-changed\>'
-          ${{ github.event.pull_request.body }}
-          EOF
+          echo "$BODY" | egrep -qsi '^disable-check:.*\<force-changelog-changed\>'
           if [[ $? -ne 0 ]]; then
             if [[ $diff == '' ]]; then
               echo

--- a/.github/workflows/pr-validation.yaml
+++ b/.github/workflows/pr-validation.yaml
@@ -32,12 +32,10 @@ jobs:
         echo "GITHUB_CONTEXT: $GITHUB_CONTEXT"
     - name: Check number of commits
       shell: bash --norc --noprofile {0}
-      # If this becomes more advanced, we might be better of using,
-      # e.g., Perl.
+      env:
+        BODY: ${{ github.event.pull_request.body }}
       run: |
-        cat << "EOF" | egrep -qsi '^disable-check:.*\<commit-count\>'
-        ${{ github.event.pull_request.body }}
-        EOF
+        echo "$BODY" | egrep -qsi '^disable-check:.*\<commit-count\>'
         if [[ $? -ne 0 ]]; then
           base=${{ github.event.pull_request.base.sha }}
           head=${{ github.event.pull_request.head.sha }}

--- a/.github/workflows/windows-build-and-test.yaml
+++ b/.github/workflows/windows-build-and-test.yaml
@@ -53,7 +53,7 @@ jobs:
         os: [ windows-2022 ]
         build_type: ${{ fromJson(needs.config.outputs.build_type) }}
         ignores: ["chunk_adaptive metadata"]
-        tsl_ignores: ["compression_algos remote_connection telemetry_stats-13 telemetry_stats-14 dist_move_chunk dist_param dist_insert"]
+        tsl_ignores: ["compression_algos remote_connection telemetry_stats-13 telemetry_stats-14 dist_move_chunk dist_param dist_insert dist_backup dist_cagg"]
         tsl_skips: ["bgw_db_scheduler bgw_db_scheduler_fixed cagg_ddl_dist_ht
           data_fetcher dist_compression dist_remote_error remote_txn"]
         pg_config: ["-cfsync=off -cstatement_timeout=60s"]


### PR DESCRIPTION
Remove GitHub variables from locations where they are expanded in place.

See https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#using-an-intermediate-environment-variable

Disable-check: force-changelog-changed