### PR TITLE
Fix occasional scheduler quit with `delete_job`

### DIFF
--- a/.unreleased/bugfix_5705
+++ b/.unreleased/bugfix_5705
@@ -1,0 +1,1 @@
+Fixes: #5711 Scheduler accidentally getting killed when calling `delete_job`

--- a/src/bgw/job.h
+++ b/src/bgw/job.h
@@ -14,6 +14,7 @@
 #include "ts_catalog/catalog.h"
 
 #define TELEMETRY_INITIAL_NUM_RUNS 12
+#define SCHEDULER_APPNAME "TimescaleDB Background Worker Scheduler"
 
 typedef struct BgwJob
 {

--- a/src/bgw/scheduler.c
+++ b/src/bgw/scheduler.c
@@ -41,7 +41,6 @@
 #include "version.h"
 #include "worker.h"
 
-#define SCHEDULER_APPNAME "TimescaleDB Background Worker Scheduler"
 #define START_RETRY_MS (1 * INT64CONST(1000)) /* 1 seconds */
 
 static TimestampTz


### PR DESCRIPTION
Previously it was possible to send pg_cancel to the scheduler
instead of the background worker for the job.
That was because we attempted to take an advisory lock on the
job id, which was assumed to be held by the background worker
for the job. However, it is possible either for the job's
worker or for the scheduler to
be the one holding the lock. The scheduler takes this lock after
the job's worker has exited, to update the job's scheduled
status.
This patch adds a check to determine if the background worker
holding the lock is the scheduler. If it's the scheduler, wait
for the lock to be released without canceling the worker.

Fixes #5711, #5224