### PR TITLE
Introduce utility function ts_get_relation_relid

### DIFF
--- a/src/chunk.c
+++ b/src/chunk.c
@@ -1691,8 +1691,8 @@ chunk_tuple_found(TupleInfo *ti, void *arg)
 	 * ts_chunk_build_from_tuple_and_stub() since chunk_resurrect() also uses
 	 * that function and, in that case, the chunk object is needed to create
 	 * the data table and related objects. */
-	chunk->table_id = get_relname_relid(chunk->fd.table_name.data,
-										get_namespace_oid(chunk->fd.schema_name.data, true));
+	chunk->table_id =
+		ts_get_relation_relid(NameStr(chunk->fd.schema_name), NameStr(chunk->fd.table_name), true);
 	chunk->hypertable_relid = ts_hypertable_id_to_relid(chunk->fd.hypertable_id);
 	chunk->relkind = get_rel_relkind(chunk->table_id);
 
@@ -2804,12 +2804,8 @@ ts_chunk_get_relid(int32 chunk_id, bool missing_ok)
 	Oid relid = InvalidOid;
 
 	if (chunk_simple_scan_by_id(chunk_id, &form, missing_ok))
-	{
-		Oid schemaid = get_namespace_oid(NameStr(form.schema_name), missing_ok);
-
-		if (OidIsValid(schemaid))
-			relid = get_relname_relid(NameStr(form.table_name), schemaid);
-	}
+		relid =
+			ts_get_relation_relid(NameStr(form.schema_name), NameStr(form.table_name), missing_ok);
 
 	if (!OidIsValid(relid) && !missing_ok)
 		ereport(ERROR,

--- a/src/chunk_scan.c
+++ b/src/chunk_scan.c
@@ -19,6 +19,7 @@
 #include "chunk.h"
 #include "chunk_constraint.h"
 #include "ts_catalog/chunk_data_node.h"
+#include "utils.h"
 
 /*
  * Scan for chunks matching a query.
@@ -117,7 +118,6 @@ ts_chunk_scan_by_chunk_ids(const Hyperspace *hs, const List *chunk_ids, unsigned
 	 * Schema oid isn't likely to change, so cache it.
 	 */
 	char *last_schema_name = NULL;
-	Oid last_schema_oid = InvalidOid;
 	for (int i = 0; i < unlocked_chunk_count; i++)
 	{
 		Chunk *chunk = unlocked_chunks[i];
@@ -126,10 +126,10 @@ ts_chunk_scan_by_chunk_ids(const Hyperspace *hs, const List *chunk_ids, unsigned
 		if (last_schema_name == NULL || strcmp(last_schema_name, current_schema_name) != 0)
 		{
 			last_schema_name = current_schema_name;
-			last_schema_oid = get_namespace_oid(current_schema_name, false);
 		}
 
-		chunk->table_id = get_relname_relid(NameStr(chunk->fd.table_name), last_schema_oid);
+		chunk->table_id =
+			ts_get_relation_relid(last_schema_name, NameStr(chunk->fd.table_name), false);
 		Assert(OidIsValid(chunk->table_id));
 	}
 

--- a/src/extension_utils.c
+++ b/src/extension_utils.c
@@ -28,6 +28,7 @@
 
 #include "compat/compat.h"
 #include "extension_constants.h"
+#include "utils.h"
 
 #define EXTENSION_PROXY_TABLE "cache_inval_extension"
 
@@ -114,12 +115,7 @@ extension_version(void)
 static Oid
 get_proxy_table_relid()
 {
-	Oid nsid = get_namespace_oid(CACHE_SCHEMA_NAME, true);
-
-	if (!OidIsValid(nsid))
-		return InvalidOid;
-
-	return get_relname_relid(EXTENSION_PROXY_TABLE, nsid);
+	return ts_get_relation_relid(CACHE_SCHEMA_NAME, EXTENSION_PROXY_TABLE, true);
 }
 
 inline static bool

--- a/src/hypertable.c
+++ b/src/hypertable.c
@@ -243,12 +243,11 @@ ts_hypertable_formdata_fill(FormData_hypertable *fd, const TupleInfo *ti)
 Hypertable *
 ts_hypertable_from_tupleinfo(const TupleInfo *ti)
 {
-	Oid namespace_oid;
 	Hypertable *h = MemoryContextAllocZero(ti->mctx, sizeof(Hypertable));
 
 	ts_hypertable_formdata_fill(&h->fd, ti);
-	namespace_oid = get_namespace_oid(NameStr(h->fd.schema_name), false);
-	h->main_table_relid = get_relname_relid(NameStr(h->fd.table_name), namespace_oid);
+	h->main_table_relid =
+		ts_get_relation_relid(NameStr(h->fd.schema_name), NameStr(h->fd.table_name), false);
 	h->space = ts_dimension_scan(h->fd.id, h->main_table_relid, h->fd.num_dimensions, ti->mctx);
 	h->chunk_cache =
 		ts_subspace_store_init(h->space, ti->mctx, ts_guc_max_cached_chunks_per_hypertable);

--- a/src/process_utility.c
+++ b/src/process_utility.c
@@ -3178,8 +3178,7 @@ process_alter_column_type_end(Hypertable *ht, AlterTableCmd *cmd)
 static void
 process_altertable_clusteron_end(Hypertable *ht, AlterTableCmd *cmd)
 {
-	Oid index_relid =
-		get_relname_relid(cmd->name, get_namespace_oid(NameStr(ht->fd.schema_name), false));
+	Oid index_relid = ts_get_relation_relid(NameStr(ht->fd.schema_name), cmd->name, false);
 
 	/* If this is part of changing the type of a column that is used in a clustered index
 	 * the above lookup might fail. But in this case we don't need to mark the index clustered

--- a/src/ts_catalog/continuous_agg.c
+++ b/src/ts_catalog/continuous_agg.c
@@ -39,6 +39,7 @@
 #include "ts_catalog/catalog.h"
 #include "errors.h"
 #include "compression_with_clause.h"
+#include "utils.h"
 
 #define BUCKET_FUNCTION_SERIALIZE_VERSION 1
 #define CHECK_NAME_MATCH(name1, name2) (namestrcmp(name1, name2) == 0)
@@ -1824,13 +1825,13 @@ ts_continuous_agg_get_query(ContinuousAgg *cagg)
 	 * the user view doesn't have the "GROUP BY" clause anymore.
 	 */
 	if (ContinuousAggIsFinalized(cagg))
-		cagg_view_oid =
-			get_relname_relid(NameStr(cagg->data.direct_view_name),
-							  get_namespace_oid(NameStr(cagg->data.direct_view_schema), false));
+		cagg_view_oid = ts_get_relation_relid(NameStr(cagg->data.direct_view_schema),
+											  NameStr(cagg->data.direct_view_name),
+											  false);
 	else
-		cagg_view_oid =
-			get_relname_relid(NameStr(cagg->data.user_view_name),
-							  get_namespace_oid(NameStr(cagg->data.user_view_schema), false));
+		cagg_view_oid = ts_get_relation_relid(NameStr(cagg->data.user_view_schema),
+											  NameStr(cagg->data.user_view_name),
+											  false);
 
 	cagg_view_rel = table_open(cagg_view_oid, AccessShareLock);
 	cagg_view_rules = cagg_view_rel->rd_rules;

--- a/src/utils.h
+++ b/src/utils.h
@@ -9,6 +9,7 @@
 #include <postgres.h>
 #include <access/htup_details.h>
 #include <catalog/pg_proc.h>
+#include <catalog/namespace.h>
 #include <common/int.h>
 #include <foreign/foreign.h>
 #include <nodes/pathnodes.h>
@@ -214,5 +215,19 @@ extern TSDLLEXPORT bool ts_data_node_is_available_by_server(const ForeignServer 
 extern TSDLLEXPORT bool ts_data_node_is_available(const char *node_name);
 
 extern TSDLLEXPORT AttrNumber ts_map_attno(Oid src_rel, Oid dst_rel, AttrNumber attno);
+
+/*
+ * Return Oid for a schema-qualified relation.
+ */
+static inline Oid
+ts_get_relation_relid(char *schema_name, char *relation_name, bool schema_missing_ok)
+{
+	Oid schema_oid = get_namespace_oid(schema_name, schema_missing_ok);
+
+	if (OidIsValid(schema_oid))
+		return get_relname_relid(relation_name, schema_oid);
+
+	return InvalidOid;
+}
 
 #endif /* TIMESCALEDB_UTILS_H */

--- a/test/src/bgw/log.c
+++ b/test/src/bgw/log.c
@@ -15,6 +15,7 @@
 #include "scanner.h"
 #include "params.h"
 #include "ts_catalog/catalog.h"
+#include "utils.h"
 
 #include "compat/compat.h"
 
@@ -52,7 +53,7 @@ static void
 bgw_log_insert(char *msg)
 {
 	Relation rel;
-	Oid log_oid = get_relname_relid("bgw_log", get_namespace_oid("public", false));
+	Oid log_oid = ts_get_relation_relid("public", "bgw_log", false);
 
 	rel = table_open(log_oid, RowExclusiveLock);
 	bgw_log_insert_relation(rel, msg);

--- a/test/src/bgw/params.c
+++ b/test/src/bgw/params.c
@@ -21,6 +21,7 @@
 #include "log.h"
 #include "scanner.h"
 #include "ts_catalog/catalog.h"
+#include "utils.h"
 
 typedef struct FormData_bgw_dsm_handle
 {
@@ -37,7 +38,7 @@ typedef struct TestParamsWrapper
 static Oid
 get_dsm_handle_table_oid()
 {
-	return get_relname_relid("bgw_dsm_handle_store", get_namespace_oid("public", false));
+	return ts_get_relation_relid("public", "bgw_dsm_handle_store", false);
 }
 
 static void

--- a/tsl/src/bgw_policy/job.c
+++ b/tsl/src/bgw_policy/job.c
@@ -185,8 +185,7 @@ check_valid_index(Hypertable *ht, const char *index_name)
 	HeapTuple idxtuple;
 	Form_pg_index index_form;
 
-	index_oid =
-		get_relname_relid(index_name, get_namespace_oid(NameStr(ht->fd.schema_name), false));
+	index_oid = ts_get_relation_relid(NameStr(ht->fd.schema_name), (char *) index_name, false);
 	idxtuple = SearchSysCache1(INDEXRELID, ObjectIdGetDatum(index_oid));
 	if (!HeapTupleIsValid(idxtuple))
 		ereport(ERROR,
@@ -266,7 +265,7 @@ policy_reorder_read_and_validate_config(Jsonb *config, PolicyReorderData *policy
 	{
 		policy->hypertable = ht;
 		policy->index_relid =
-			get_relname_relid(index_name, get_namespace_oid(NameStr(ht->fd.schema_name), false));
+			ts_get_relation_relid(NameStr(ht->fd.schema_name), (char *) index_name, false);
 	}
 }
 
@@ -316,9 +315,9 @@ policy_retention_read_and_validate_config(Jsonb *config, PolicyRetentionData *po
 	cagg = ts_continuous_agg_find_by_mat_hypertable_id(hypertable->fd.id);
 	if (cagg)
 	{
-		const char *const view_name = NameStr(cagg->data.user_view_name);
-		const char *const schema_name = NameStr(cagg->data.user_view_schema);
-		object_relid = get_relname_relid(view_name, get_namespace_oid(schema_name, false));
+		object_relid = ts_get_relation_relid(NameStr(cagg->data.user_view_schema),
+											 NameStr(cagg->data.user_view_name),
+											 false);
 	}
 
 	ts_cache_release(hcache);

--- a/tsl/src/bgw_policy/reorder_api.c
+++ b/tsl/src/bgw_policy/reorder_api.c
@@ -91,8 +91,7 @@ check_valid_index(Hypertable *ht, Name index_name)
 	HeapTuple idxtuple;
 	Form_pg_index indexForm;
 
-	index_oid = get_relname_relid(NameStr(*index_name),
-								  get_namespace_oid(NameStr(ht->fd.schema_name), false));
+	index_oid = ts_get_relation_relid(NameStr(ht->fd.schema_name), NameStr(*index_name), false);
 	idxtuple = SearchSysCache1(INDEXRELID, ObjectIdGetDatum(index_oid));
 	if (!HeapTupleIsValid(idxtuple))
 		ereport(ERROR, (errcode(ERRCODE_INVALID_PARAMETER_VALUE), errmsg("invalid reorder index")));


### PR DESCRIPTION
In several places of our code base we use a combination of
`get_namespace_oid` and `get_relname_relid` to return the Oid of a
schema qualified relation, so refactored the code to encapsulate this
behavior in a single function.

Disable-check: force-changelog-file