### PR TITLE
Ensure tlist is present in decompress chunk plan

### DIFF
--- a/.unreleased/bugfix_5750
+++ b/.unreleased/bugfix_5750
@@ -1,0 +1,1 @@
+Fixes: #5750 Ensure tlist is present in decompress chunk plan 

--- a/src/import/planner.h
+++ b/src/import/planner.h
@@ -53,7 +53,7 @@ extern TSDLLEXPORT PathKey *
 ts_make_pathkey_from_sortinfo(PlannerInfo *root, Expr *expr, Relids nullable_relids, Oid opfamily,
 							  Oid opcintype, Oid collation, bool reverse_sort, bool nulls_first,
 							  Index sortref, Relids rel, bool create_it);
-extern List *ts_build_path_tlist(PlannerInfo *root, Path *path);
+extern TSDLLEXPORT List *ts_build_path_tlist(PlannerInfo *root, Path *path);
 
 extern void ts_ExecSetTupleBound(int64 tuples_needed, PlanState *child_node);
 

--- a/tsl/src/nodes/decompress_chunk/planner.c
+++ b/tsl/src/nodes/decompress_chunk/planner.c
@@ -501,6 +501,15 @@ decompress_chunk_plan_create(PlannerInfo *root, RelOptInfo *rel, CustomPath *pat
 		bool *nullsFirst = NULL;
 		int numsortkeys = 0;
 
+		/* We need a targetlist at this point to build the sort info below. If the target list is
+		 * not populated by PostgreSQL already, populate it here.
+		 */
+		if (decompress_plan->scan.plan.targetlist == NIL)
+			decompress_plan->scan.plan.targetlist = ts_build_path_tlist(root, (Path *) path);
+
+		Assert(decompress_plan->scan.plan.targetlist != NIL);
+		Assert(dcpath->cpath.path.pathkeys != NIL);
+
 		ts_prepare_sort_from_pathkeys(&decompress_plan->scan.plan,
 									  dcpath->cpath.path.pathkeys,
 									  bms_make_singleton(dcpath->info->chunk_rel->relid),

--- a/tsl/test/expected/compression_sorted_merge-12.out
+++ b/tsl/test/expected/compression_sorted_merge-12.out
@@ -1346,3 +1346,66 @@ SELECT time, segment_by, x1 FROM test_costs WHERE segment_by > 900 and segment_b
                Index Cond: ((compress_hyper_10_22_chunk.segment_by > 900) AND (compress_hyper_10_22_chunk.segment_by < 999))
 (10 rows)
 
+-- Target list creation - Issue 5738
+CREATE TABLE bugtab(
+ time timestamp without time zone,
+ hin   character varying(128) NOT NULL,
+ model character varying(128) NOT NULL,
+ block character varying(128) NOT NULL,
+ message_name character varying(128) NOT NULL,
+ signal_name  character varying(128) NOT NULL,
+ signal_numeric_value double precision,
+ signal_string_value character varying(128)
+);
+SELECT create_hypertable('bugtab', 'time');
+WARNING:  column type "timestamp without time zone" used for "time" does not follow best practices
+WARNING:  column type "character varying" used for "hin" does not follow best practices
+WARNING:  column type "character varying" used for "model" does not follow best practices
+WARNING:  column type "character varying" used for "block" does not follow best practices
+WARNING:  column type "character varying" used for "message_name" does not follow best practices
+WARNING:  column type "character varying" used for "signal_name" does not follow best practices
+WARNING:  column type "character varying" used for "signal_string_value" does not follow best practices
+NOTICE:  adding not-null constraint to column "time"
+  create_hypertable   
+----------------------
+ (11,public,bugtab,t)
+(1 row)
+
+INSERT INTO bugtab values('2020-01-01 10:00', 'hin1111', 'model111', 'blok111', 'message_here', 'signal1', 12.34, '12.34');
+ALTER TABLE bugtab SET (timescaledb.compress, timescaledb.compress_segmentby = 'hin, signal_name', timescaledb.compress_orderby = 'time');
+SELECT chunk_schema || '.' || chunk_name AS "chunk_table_bugtab"
+       FROM timescaledb_information.chunks
+       WHERE hypertable_name = 'bugtab' ORDER BY range_start LIMIT 1 \gset
+SELECT compress_chunk(i) FROM show_chunks('bugtab') i;
+              compress_chunk              
+------------------------------------------
+ _timescaledb_internal._hyper_11_23_chunk
+(1 row)
+
+:PREFIX
+SELECT "time","hin"::text,"model"::text,"block"::text,"message_name"::text,"signal_name"::text,"signal_numeric_value","signal_string_value"::text FROM :chunk_table_bugtab ORDER BY "time" DESC;
+                                                                                                                                                                                                                                                            QUERY PLAN                                                                                                                                                                                                                                                            
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_11_23_chunk (actual rows=1 loops=1)
+   Output: _hyper_11_23_chunk."time", (_hyper_11_23_chunk.hin)::text, (_hyper_11_23_chunk.model)::text, (_hyper_11_23_chunk.block)::text, (_hyper_11_23_chunk.message_name)::text, (_hyper_11_23_chunk.signal_name)::text, _hyper_11_23_chunk.signal_numeric_value, (_hyper_11_23_chunk.signal_string_value)::text
+   Sorted merge append: true
+   ->  Sort (actual rows=1 loops=1)
+         Output: compress_hyper_12_24_chunk."time", compress_hyper_12_24_chunk.hin, compress_hyper_12_24_chunk.model, compress_hyper_12_24_chunk.block, compress_hyper_12_24_chunk.message_name, compress_hyper_12_24_chunk.signal_name, compress_hyper_12_24_chunk.signal_numeric_value, compress_hyper_12_24_chunk.signal_string_value, compress_hyper_12_24_chunk._ts_meta_count, compress_hyper_12_24_chunk._ts_meta_sequence_num, compress_hyper_12_24_chunk._ts_meta_min_1, compress_hyper_12_24_chunk._ts_meta_max_1
+         Sort Key: compress_hyper_12_24_chunk._ts_meta_max_1 DESC
+         Sort Method: quicksort 
+         ->  Seq Scan on _timescaledb_internal.compress_hyper_12_24_chunk (actual rows=1 loops=1)
+               Output: compress_hyper_12_24_chunk."time", compress_hyper_12_24_chunk.hin, compress_hyper_12_24_chunk.model, compress_hyper_12_24_chunk.block, compress_hyper_12_24_chunk.message_name, compress_hyper_12_24_chunk.signal_name, compress_hyper_12_24_chunk.signal_numeric_value, compress_hyper_12_24_chunk.signal_string_value, compress_hyper_12_24_chunk._ts_meta_count, compress_hyper_12_24_chunk._ts_meta_sequence_num, compress_hyper_12_24_chunk._ts_meta_min_1, compress_hyper_12_24_chunk._ts_meta_max_1
+(9 rows)
+
+SELECT "time","hin"::text,"model"::text,"block"::text,"message_name"::text,"signal_name"::text,"signal_numeric_value","signal_string_value"::text FROM :chunk_table_bugtab ORDER BY "time" DESC;
+           time           |   hin   |  model   |  block  | message_name | signal_name | signal_numeric_value | signal_string_value 
+--------------------------+---------+----------+---------+--------------+-------------+----------------------+---------------------
+ Wed Jan 01 10:00:00 2020 | hin1111 | model111 | blok111 | message_here | signal1     |                12.34 | 12.34
+(1 row)
+
+SELECT "time","hin"::text,"model"::text,"block"::text,"message_name"::text,"signal_name"::text,"signal_numeric_value","signal_string_value"::text FROM bugtab ORDER BY "time" DESC;
+           time           |   hin   |  model   |  block  | message_name | signal_name | signal_numeric_value | signal_string_value 
+--------------------------+---------+----------+---------+--------------+-------------+----------------------+---------------------
+ Wed Jan 01 10:00:00 2020 | hin1111 | model111 | blok111 | message_here | signal1     |                12.34 | 12.34
+(1 row)
+

--- a/tsl/test/expected/compression_sorted_merge-13.out
+++ b/tsl/test/expected/compression_sorted_merge-13.out
@@ -1346,3 +1346,66 @@ SELECT time, segment_by, x1 FROM test_costs WHERE segment_by > 900 and segment_b
                Index Cond: ((compress_hyper_10_22_chunk.segment_by > 900) AND (compress_hyper_10_22_chunk.segment_by < 999))
 (10 rows)
 
+-- Target list creation - Issue 5738
+CREATE TABLE bugtab(
+ time timestamp without time zone,
+ hin   character varying(128) NOT NULL,
+ model character varying(128) NOT NULL,
+ block character varying(128) NOT NULL,
+ message_name character varying(128) NOT NULL,
+ signal_name  character varying(128) NOT NULL,
+ signal_numeric_value double precision,
+ signal_string_value character varying(128)
+);
+SELECT create_hypertable('bugtab', 'time');
+WARNING:  column type "timestamp without time zone" used for "time" does not follow best practices
+WARNING:  column type "character varying" used for "hin" does not follow best practices
+WARNING:  column type "character varying" used for "model" does not follow best practices
+WARNING:  column type "character varying" used for "block" does not follow best practices
+WARNING:  column type "character varying" used for "message_name" does not follow best practices
+WARNING:  column type "character varying" used for "signal_name" does not follow best practices
+WARNING:  column type "character varying" used for "signal_string_value" does not follow best practices
+NOTICE:  adding not-null constraint to column "time"
+  create_hypertable   
+----------------------
+ (11,public,bugtab,t)
+(1 row)
+
+INSERT INTO bugtab values('2020-01-01 10:00', 'hin1111', 'model111', 'blok111', 'message_here', 'signal1', 12.34, '12.34');
+ALTER TABLE bugtab SET (timescaledb.compress, timescaledb.compress_segmentby = 'hin, signal_name', timescaledb.compress_orderby = 'time');
+SELECT chunk_schema || '.' || chunk_name AS "chunk_table_bugtab"
+       FROM timescaledb_information.chunks
+       WHERE hypertable_name = 'bugtab' ORDER BY range_start LIMIT 1 \gset
+SELECT compress_chunk(i) FROM show_chunks('bugtab') i;
+              compress_chunk              
+------------------------------------------
+ _timescaledb_internal._hyper_11_23_chunk
+(1 row)
+
+:PREFIX
+SELECT "time","hin"::text,"model"::text,"block"::text,"message_name"::text,"signal_name"::text,"signal_numeric_value","signal_string_value"::text FROM :chunk_table_bugtab ORDER BY "time" DESC;
+                                                                                                                                                                                                                                                            QUERY PLAN                                                                                                                                                                                                                                                            
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_11_23_chunk (actual rows=1 loops=1)
+   Output: _hyper_11_23_chunk."time", (_hyper_11_23_chunk.hin)::text, (_hyper_11_23_chunk.model)::text, (_hyper_11_23_chunk.block)::text, (_hyper_11_23_chunk.message_name)::text, (_hyper_11_23_chunk.signal_name)::text, _hyper_11_23_chunk.signal_numeric_value, (_hyper_11_23_chunk.signal_string_value)::text
+   Sorted merge append: true
+   ->  Sort (actual rows=1 loops=1)
+         Output: compress_hyper_12_24_chunk."time", compress_hyper_12_24_chunk.hin, compress_hyper_12_24_chunk.model, compress_hyper_12_24_chunk.block, compress_hyper_12_24_chunk.message_name, compress_hyper_12_24_chunk.signal_name, compress_hyper_12_24_chunk.signal_numeric_value, compress_hyper_12_24_chunk.signal_string_value, compress_hyper_12_24_chunk._ts_meta_count, compress_hyper_12_24_chunk._ts_meta_sequence_num, compress_hyper_12_24_chunk._ts_meta_min_1, compress_hyper_12_24_chunk._ts_meta_max_1
+         Sort Key: compress_hyper_12_24_chunk._ts_meta_max_1 DESC
+         Sort Method: quicksort 
+         ->  Seq Scan on _timescaledb_internal.compress_hyper_12_24_chunk (actual rows=1 loops=1)
+               Output: compress_hyper_12_24_chunk."time", compress_hyper_12_24_chunk.hin, compress_hyper_12_24_chunk.model, compress_hyper_12_24_chunk.block, compress_hyper_12_24_chunk.message_name, compress_hyper_12_24_chunk.signal_name, compress_hyper_12_24_chunk.signal_numeric_value, compress_hyper_12_24_chunk.signal_string_value, compress_hyper_12_24_chunk._ts_meta_count, compress_hyper_12_24_chunk._ts_meta_sequence_num, compress_hyper_12_24_chunk._ts_meta_min_1, compress_hyper_12_24_chunk._ts_meta_max_1
+(9 rows)
+
+SELECT "time","hin"::text,"model"::text,"block"::text,"message_name"::text,"signal_name"::text,"signal_numeric_value","signal_string_value"::text FROM :chunk_table_bugtab ORDER BY "time" DESC;
+           time           |   hin   |  model   |  block  | message_name | signal_name | signal_numeric_value | signal_string_value 
+--------------------------+---------+----------+---------+--------------+-------------+----------------------+---------------------
+ Wed Jan 01 10:00:00 2020 | hin1111 | model111 | blok111 | message_here | signal1     |                12.34 | 12.34
+(1 row)
+
+SELECT "time","hin"::text,"model"::text,"block"::text,"message_name"::text,"signal_name"::text,"signal_numeric_value","signal_string_value"::text FROM bugtab ORDER BY "time" DESC;
+           time           |   hin   |  model   |  block  | message_name | signal_name | signal_numeric_value | signal_string_value 
+--------------------------+---------+----------+---------+--------------+-------------+----------------------+---------------------
+ Wed Jan 01 10:00:00 2020 | hin1111 | model111 | blok111 | message_here | signal1     |                12.34 | 12.34
+(1 row)
+

--- a/tsl/test/expected/compression_sorted_merge-14.out
+++ b/tsl/test/expected/compression_sorted_merge-14.out
@@ -1346,3 +1346,66 @@ SELECT time, segment_by, x1 FROM test_costs WHERE segment_by > 900 and segment_b
                Index Cond: ((compress_hyper_10_22_chunk.segment_by > 900) AND (compress_hyper_10_22_chunk.segment_by < 999))
 (10 rows)
 
+-- Target list creation - Issue 5738
+CREATE TABLE bugtab(
+ time timestamp without time zone,
+ hin   character varying(128) NOT NULL,
+ model character varying(128) NOT NULL,
+ block character varying(128) NOT NULL,
+ message_name character varying(128) NOT NULL,
+ signal_name  character varying(128) NOT NULL,
+ signal_numeric_value double precision,
+ signal_string_value character varying(128)
+);
+SELECT create_hypertable('bugtab', 'time');
+WARNING:  column type "timestamp without time zone" used for "time" does not follow best practices
+WARNING:  column type "character varying" used for "hin" does not follow best practices
+WARNING:  column type "character varying" used for "model" does not follow best practices
+WARNING:  column type "character varying" used for "block" does not follow best practices
+WARNING:  column type "character varying" used for "message_name" does not follow best practices
+WARNING:  column type "character varying" used for "signal_name" does not follow best practices
+WARNING:  column type "character varying" used for "signal_string_value" does not follow best practices
+NOTICE:  adding not-null constraint to column "time"
+  create_hypertable   
+----------------------
+ (11,public,bugtab,t)
+(1 row)
+
+INSERT INTO bugtab values('2020-01-01 10:00', 'hin1111', 'model111', 'blok111', 'message_here', 'signal1', 12.34, '12.34');
+ALTER TABLE bugtab SET (timescaledb.compress, timescaledb.compress_segmentby = 'hin, signal_name', timescaledb.compress_orderby = 'time');
+SELECT chunk_schema || '.' || chunk_name AS "chunk_table_bugtab"
+       FROM timescaledb_information.chunks
+       WHERE hypertable_name = 'bugtab' ORDER BY range_start LIMIT 1 \gset
+SELECT compress_chunk(i) FROM show_chunks('bugtab') i;
+              compress_chunk              
+------------------------------------------
+ _timescaledb_internal._hyper_11_23_chunk
+(1 row)
+
+:PREFIX
+SELECT "time","hin"::text,"model"::text,"block"::text,"message_name"::text,"signal_name"::text,"signal_numeric_value","signal_string_value"::text FROM :chunk_table_bugtab ORDER BY "time" DESC;
+                                                                                                                                                                                                                                                            QUERY PLAN                                                                                                                                                                                                                                                            
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_11_23_chunk (actual rows=1 loops=1)
+   Output: _hyper_11_23_chunk."time", (_hyper_11_23_chunk.hin)::text, (_hyper_11_23_chunk.model)::text, (_hyper_11_23_chunk.block)::text, (_hyper_11_23_chunk.message_name)::text, (_hyper_11_23_chunk.signal_name)::text, _hyper_11_23_chunk.signal_numeric_value, (_hyper_11_23_chunk.signal_string_value)::text
+   Sorted merge append: true
+   ->  Sort (actual rows=1 loops=1)
+         Output: compress_hyper_12_24_chunk."time", compress_hyper_12_24_chunk.hin, compress_hyper_12_24_chunk.model, compress_hyper_12_24_chunk.block, compress_hyper_12_24_chunk.message_name, compress_hyper_12_24_chunk.signal_name, compress_hyper_12_24_chunk.signal_numeric_value, compress_hyper_12_24_chunk.signal_string_value, compress_hyper_12_24_chunk._ts_meta_count, compress_hyper_12_24_chunk._ts_meta_sequence_num, compress_hyper_12_24_chunk._ts_meta_min_1, compress_hyper_12_24_chunk._ts_meta_max_1
+         Sort Key: compress_hyper_12_24_chunk._ts_meta_max_1 DESC
+         Sort Method: quicksort 
+         ->  Seq Scan on _timescaledb_internal.compress_hyper_12_24_chunk (actual rows=1 loops=1)
+               Output: compress_hyper_12_24_chunk."time", compress_hyper_12_24_chunk.hin, compress_hyper_12_24_chunk.model, compress_hyper_12_24_chunk.block, compress_hyper_12_24_chunk.message_name, compress_hyper_12_24_chunk.signal_name, compress_hyper_12_24_chunk.signal_numeric_value, compress_hyper_12_24_chunk.signal_string_value, compress_hyper_12_24_chunk._ts_meta_count, compress_hyper_12_24_chunk._ts_meta_sequence_num, compress_hyper_12_24_chunk._ts_meta_min_1, compress_hyper_12_24_chunk._ts_meta_max_1
+(9 rows)
+
+SELECT "time","hin"::text,"model"::text,"block"::text,"message_name"::text,"signal_name"::text,"signal_numeric_value","signal_string_value"::text FROM :chunk_table_bugtab ORDER BY "time" DESC;
+           time           |   hin   |  model   |  block  | message_name | signal_name | signal_numeric_value | signal_string_value 
+--------------------------+---------+----------+---------+--------------+-------------+----------------------+---------------------
+ Wed Jan 01 10:00:00 2020 | hin1111 | model111 | blok111 | message_here | signal1     |                12.34 | 12.34
+(1 row)
+
+SELECT "time","hin"::text,"model"::text,"block"::text,"message_name"::text,"signal_name"::text,"signal_numeric_value","signal_string_value"::text FROM bugtab ORDER BY "time" DESC;
+           time           |   hin   |  model   |  block  | message_name | signal_name | signal_numeric_value | signal_string_value 
+--------------------------+---------+----------+---------+--------------+-------------+----------------------+---------------------
+ Wed Jan 01 10:00:00 2020 | hin1111 | model111 | blok111 | message_here | signal1     |                12.34 | 12.34
+(1 row)
+

--- a/tsl/test/expected/compression_sorted_merge-15.out
+++ b/tsl/test/expected/compression_sorted_merge-15.out
@@ -1346,3 +1346,68 @@ SELECT time, segment_by, x1 FROM test_costs WHERE segment_by > 900 and segment_b
                Index Cond: ((compress_hyper_10_22_chunk.segment_by > 900) AND (compress_hyper_10_22_chunk.segment_by < 999))
 (10 rows)
 
+-- Target list creation - Issue 5738
+CREATE TABLE bugtab(
+ time timestamp without time zone,
+ hin   character varying(128) NOT NULL,
+ model character varying(128) NOT NULL,
+ block character varying(128) NOT NULL,
+ message_name character varying(128) NOT NULL,
+ signal_name  character varying(128) NOT NULL,
+ signal_numeric_value double precision,
+ signal_string_value character varying(128)
+);
+SELECT create_hypertable('bugtab', 'time');
+WARNING:  column type "timestamp without time zone" used for "time" does not follow best practices
+WARNING:  column type "character varying" used for "hin" does not follow best practices
+WARNING:  column type "character varying" used for "model" does not follow best practices
+WARNING:  column type "character varying" used for "block" does not follow best practices
+WARNING:  column type "character varying" used for "message_name" does not follow best practices
+WARNING:  column type "character varying" used for "signal_name" does not follow best practices
+WARNING:  column type "character varying" used for "signal_string_value" does not follow best practices
+NOTICE:  adding not-null constraint to column "time"
+  create_hypertable   
+----------------------
+ (11,public,bugtab,t)
+(1 row)
+
+INSERT INTO bugtab values('2020-01-01 10:00', 'hin1111', 'model111', 'blok111', 'message_here', 'signal1', 12.34, '12.34');
+ALTER TABLE bugtab SET (timescaledb.compress, timescaledb.compress_segmentby = 'hin, signal_name', timescaledb.compress_orderby = 'time');
+SELECT chunk_schema || '.' || chunk_name AS "chunk_table_bugtab"
+       FROM timescaledb_information.chunks
+       WHERE hypertable_name = 'bugtab' ORDER BY range_start LIMIT 1 \gset
+SELECT compress_chunk(i) FROM show_chunks('bugtab') i;
+              compress_chunk              
+------------------------------------------
+ _timescaledb_internal._hyper_11_23_chunk
+(1 row)
+
+:PREFIX
+SELECT "time","hin"::text,"model"::text,"block"::text,"message_name"::text,"signal_name"::text,"signal_numeric_value","signal_string_value"::text FROM :chunk_table_bugtab ORDER BY "time" DESC;
+                                                                                                                                                                                                                                                               QUERY PLAN                                                                                                                                                                                                                                                               
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Result (actual rows=1 loops=1)
+   Output: _hyper_11_23_chunk."time", (_hyper_11_23_chunk.hin)::text, (_hyper_11_23_chunk.model)::text, (_hyper_11_23_chunk.block)::text, (_hyper_11_23_chunk.message_name)::text, (_hyper_11_23_chunk.signal_name)::text, _hyper_11_23_chunk.signal_numeric_value, (_hyper_11_23_chunk.signal_string_value)::text
+   ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_11_23_chunk (actual rows=1 loops=1)
+         Output: _hyper_11_23_chunk."time", _hyper_11_23_chunk.hin, _hyper_11_23_chunk.model, _hyper_11_23_chunk.block, _hyper_11_23_chunk.message_name, _hyper_11_23_chunk.signal_name, _hyper_11_23_chunk.signal_numeric_value, _hyper_11_23_chunk.signal_string_value
+         Sorted merge append: true
+         ->  Sort (actual rows=1 loops=1)
+               Output: compress_hyper_12_24_chunk."time", compress_hyper_12_24_chunk.hin, compress_hyper_12_24_chunk.model, compress_hyper_12_24_chunk.block, compress_hyper_12_24_chunk.message_name, compress_hyper_12_24_chunk.signal_name, compress_hyper_12_24_chunk.signal_numeric_value, compress_hyper_12_24_chunk.signal_string_value, compress_hyper_12_24_chunk._ts_meta_count, compress_hyper_12_24_chunk._ts_meta_sequence_num, compress_hyper_12_24_chunk._ts_meta_min_1, compress_hyper_12_24_chunk._ts_meta_max_1
+               Sort Key: compress_hyper_12_24_chunk._ts_meta_max_1 DESC
+               Sort Method: quicksort 
+               ->  Seq Scan on _timescaledb_internal.compress_hyper_12_24_chunk (actual rows=1 loops=1)
+                     Output: compress_hyper_12_24_chunk."time", compress_hyper_12_24_chunk.hin, compress_hyper_12_24_chunk.model, compress_hyper_12_24_chunk.block, compress_hyper_12_24_chunk.message_name, compress_hyper_12_24_chunk.signal_name, compress_hyper_12_24_chunk.signal_numeric_value, compress_hyper_12_24_chunk.signal_string_value, compress_hyper_12_24_chunk._ts_meta_count, compress_hyper_12_24_chunk._ts_meta_sequence_num, compress_hyper_12_24_chunk._ts_meta_min_1, compress_hyper_12_24_chunk._ts_meta_max_1
+(11 rows)
+
+SELECT "time","hin"::text,"model"::text,"block"::text,"message_name"::text,"signal_name"::text,"signal_numeric_value","signal_string_value"::text FROM :chunk_table_bugtab ORDER BY "time" DESC;
+           time           |   hin   |  model   |  block  | message_name | signal_name | signal_numeric_value | signal_string_value 
+--------------------------+---------+----------+---------+--------------+-------------+----------------------+---------------------
+ Wed Jan 01 10:00:00 2020 | hin1111 | model111 | blok111 | message_here | signal1     |                12.34 | 12.34
+(1 row)
+
+SELECT "time","hin"::text,"model"::text,"block"::text,"message_name"::text,"signal_name"::text,"signal_numeric_value","signal_string_value"::text FROM bugtab ORDER BY "time" DESC;
+           time           |   hin   |  model   |  block  | message_name | signal_name | signal_numeric_value | signal_string_value 
+--------------------------+---------+----------+---------+--------------+-------------+----------------------+---------------------
+ Wed Jan 01 10:00:00 2020 | hin1111 | model111 | blok111 | message_here | signal1     |                12.34 | 12.34
+(1 row)
+

--- a/tsl/test/sql/compression_sorted_merge.sql.in
+++ b/tsl/test/sql/compression_sorted_merge.sql.in
@@ -467,3 +467,34 @@ SELECT time, segment_by, x1 FROM test_costs ORDER BY time DESC;
 -- Test query plan with predicate (query should be optimized due to ~100 segments)
 :PREFIX
 SELECT time, segment_by, x1 FROM test_costs WHERE segment_by > 900 and segment_by < 999 ORDER BY time DESC;
+
+-- Target list creation - Issue 5738
+CREATE TABLE bugtab(
+ time timestamp without time zone,
+ hin   character varying(128) NOT NULL,
+ model character varying(128) NOT NULL,
+ block character varying(128) NOT NULL,
+ message_name character varying(128) NOT NULL,
+ signal_name  character varying(128) NOT NULL,
+ signal_numeric_value double precision,
+ signal_string_value character varying(128)
+);
+
+SELECT create_hypertable('bugtab', 'time');
+
+INSERT INTO bugtab values('2020-01-01 10:00', 'hin1111', 'model111', 'blok111', 'message_here', 'signal1', 12.34, '12.34');
+
+ALTER TABLE bugtab SET (timescaledb.compress, timescaledb.compress_segmentby = 'hin, signal_name', timescaledb.compress_orderby = 'time');
+
+SELECT chunk_schema || '.' || chunk_name AS "chunk_table_bugtab"
+       FROM timescaledb_information.chunks
+       WHERE hypertable_name = 'bugtab' ORDER BY range_start LIMIT 1 \gset
+
+SELECT compress_chunk(i) FROM show_chunks('bugtab') i;
+
+:PREFIX
+SELECT "time","hin"::text,"model"::text,"block"::text,"message_name"::text,"signal_name"::text,"signal_numeric_value","signal_string_value"::text FROM :chunk_table_bugtab ORDER BY "time" DESC;
+
+SELECT "time","hin"::text,"model"::text,"block"::text,"message_name"::text,"signal_name"::text,"signal_numeric_value","signal_string_value"::text FROM :chunk_table_bugtab ORDER BY "time" DESC;
+
+SELECT "time","hin"::text,"model"::text,"block"::text,"message_name"::text,"signal_name"::text,"signal_numeric_value","signal_string_value"::text FROM bugtab ORDER BY "time" DESC;


### PR DESCRIPTION
In PostgreSQL < 15, CustomScan nodes are projection capable per default. The planner invokes create_plan_recurse with the flag `CP_IGNORE_TLIST`. So, the target list of a CustomScan node can be NIL. However, we rely on the target list to derive information for sorting.

This patch ensures that the target list is always populated before the sort functions are called.

Fixes: #5738