### PR TITLE
PG16

### DIFF
--- a/src/compat/compat.h
+++ b/src/compat/compat.h
@@ -27,20 +27,22 @@
 #define is_supported_pg_version_13(version) ((version >= 130002) && (version < 140000))
 #define is_supported_pg_version_14(version) ((version >= 140000) && (version < 150000))
 #define is_supported_pg_version_15(version) ((version >= 150000) && (version < 160000))
+#define is_supported_pg_version_16(version) ((version >= 160000) && (version < 170000))
 
 /*
- * PG15 is in fact not yet supported, but we are working on this. The user will
- * be unable to compile aginst this version unless he/she explicitly uses
- * -DEXPERIMENTAL=ON. This is checked by our CMakeLists.txt.
+ * PG16 support is a WIP and not complete yet.
+ * To compile with PG16, use -DEXPERIMENTAL=ON with cmake.
  */
 #define is_supported_pg_version(version)                                                           \
 	(is_supported_pg_version_12(version) || is_supported_pg_version_13(version) ||                 \
-	 is_supported_pg_version_14(version) || is_supported_pg_version_15(version))
+	 is_supported_pg_version_14(version) || is_supported_pg_version_15(version) ||                 \
+	 is_supported_pg_version_16(version))
 
 #define PG12 is_supported_pg_version_12(PG_VERSION_NUM)
 #define PG13 is_supported_pg_version_13(PG_VERSION_NUM)
 #define PG14 is_supported_pg_version_14(PG_VERSION_NUM)
 #define PG15 is_supported_pg_version_15(PG_VERSION_NUM)
+#define PG16 is_supported_pg_version_16(PG_VERSION_NUM)
 
 #define PG13_LT (PG_VERSION_NUM < 130000)
 #define PG13_GE (PG_VERSION_NUM >= 130000)
@@ -48,6 +50,8 @@
 #define PG14_GE (PG_VERSION_NUM >= 140000)
 #define PG15_LT (PG_VERSION_NUM < 150000)
 #define PG15_GE (PG_VERSION_NUM >= 150000)
+#define PG16_LT (PG_VERSION_NUM < 160000)
+#define PG16_GE (PG_VERSION_NUM >= 160000)
 
 #if !(is_supported_pg_version(PG_VERSION_NUM))
 #error "Unsupported PostgreSQL version"

--- a/src/export.h
+++ b/src/export.h
@@ -12,24 +12,21 @@
 
 /* Definitions for symbol exports */
 
-#define TS_CAT(x, y) x##y
-
-#define TS_EMPTY(x) (TS_CAT(x, 87628) == 87628)
-
 #if defined(_WIN32) && !defined(WIN32)
 #define WIN32
 #endif
 
-#if !defined(WIN32) && !defined(__CYGWIN__)
+/*
+ * PGDLLEXPORT is defined as en empty macro until PG15.
+ * Since PG16, a macro HAVE_VISIBILITY_ATTRIBUTE is defined if the compiler has
+ * support for visibility attribute and the PGDLLEXPORT macro is defined as the
+ * same. So, skip redefining PGDLLEXPORT if HAVE_VISIBILITY_ATTRIBUTE is defined.
+ * If not, undef the empty PGDLLEXPORT macro and redefine it properly.
+ */
+#if !defined(WIN32) && !defined(__CYGWIN__) && !defined(HAVE_VISIBILITY_ATTRIBUTE)
 #if __GNUC__ >= 4
-#if defined(PGDLLEXPORT)
-#if TS_EMPTY(PGDLLEXPORT)
-/* PGDLLEXPORT is defined but empty. We can safely undef it. */
+/* PGDLLEXPORT is defined but will be empty. Redefine it. */
 #undef PGDLLEXPORT
-#else
-#error "PGDLLEXPORT is already defined"
-#endif
-#endif /* defined(PGDLLEXPORT) */
 #define PGDLLEXPORT __attribute__((visibility("default")))
 #else
 #error "Unsupported GNUC version"


### PR DESCRIPTION
[Mark PG16 as a supported version](https://github.com/timescale/timescaledb/commit/221e02781abd71d649d12cc4e34775020eec0c19) 

Note that this change in combination with -DEXPERIMENTAL=ON cmake flag will just allow us to compile timescaledb code with PG16 and this doesn't mean PG16 is supported by the extension.

[PG16: Refactor handling of PGDLLEXPORT macro definition](https://github.com/timescale/timescaledb/commit/9b0ba698e46700c3c714f7919ab5da5837048077) 

PG16 defines the PGDLLEXPORT macro as a proper visibility attribute. In the previous versions from PG12 to PG16, the PGDLLEXPORT was always defined as an empty macro. Considering all this, the code has been now updated to skip defining PGDLLEXPORT if it has been already defined properly. If not, the macro is redefined without any additional checks.

https://github.com/postgres/postgres/commit/089480c

Disable-check: force-changelog-file
Disable-check: commit-count