### PR TITLE
Fixed handling of NULL values in bookend_sfunc

### DIFF
--- a/.unreleased/bugfix_5754
+++ b/.unreleased/bugfix_5754
@@ -1,0 +1,1 @@
+Fixes: #5754 Fixed handling of NULL values in bookend_sfunc 

--- a/src/agg_bookend.c
+++ b/src/agg_bookend.c
@@ -340,10 +340,10 @@ bookend_sfunc(MemoryContext aggcontext, InternalCmpAggStore *state, PolyDatum va
 		typeinfocache_polydatumcopy(&cache->value_type_cache, value, &state->value);
 		typeinfocache_polydatumcopy(&cache->cmp_type_cache, cmp, &state->cmp);
 	}
-	else
+	else if (!cmp.is_null)
 	{
 		/* only do comparison if cmp is not NULL */
-		if (!cmp.is_null && cmpproc_cmp(&cache->cmp_proc, fcinfo, cmp, state->cmp))
+		if (state->cmp.is_null || cmpproc_cmp(&cache->cmp_proc, fcinfo, cmp, state->cmp))
 		{
 			typeinfocache_polydatumcopy(&cache->value_type_cache, value, &state->value);
 			typeinfocache_polydatumcopy(&cache->cmp_type_cache, cmp, &state->cmp);

--- a/test/expected/agg_bookends-12.out
+++ b/test/expected/agg_bookends-12.out
@@ -669,6 +669,165 @@ CREATE INDEX btest_time_alt_idx ON btest(time_alt);
 (10 rows)
 
 ROLLBACK;
+-- Test with NULL numeric values
+BEGIN;
+TRUNCATE btest_numeric;
+-- Empty table
+:PREFIX SELECT first(btest_numeric, time) FROM btest_numeric;
+              QUERY PLAN              
+--------------------------------------
+ Aggregate (actual rows=1 loops=1)
+   ->  Result (actual rows=0 loops=1)
+         One-Time Filter: false
+(3 rows)
+
+:PREFIX SELECT last(btest_numeric, time) FROM btest_numeric;
+              QUERY PLAN              
+--------------------------------------
+ Aggregate (actual rows=1 loops=1)
+   ->  Result (actual rows=0 loops=1)
+         One-Time Filter: false
+(3 rows)
+
+-- Only NULL values
+INSERT INTO btest_numeric VALUES('2018-01-20T09:00:43', NULL);
+INSERT INTO btest_numeric VALUES('2018-01-20T09:00:43', NULL);
+:PREFIX SELECT first(quantity, time) FROM btest_numeric;
+                                                         QUERY PLAN                                                          
+-----------------------------------------------------------------------------------------------------------------------------
+ Result (actual rows=1 loops=1)
+   InitPlan 1 (returns $0)
+     ->  Limit (actual rows=1 loops=1)
+           ->  Index Scan Backward using _hyper_2_8_chunk_btest_numeric_time_idx on _hyper_2_8_chunk (actual rows=1 loops=1)
+                 Index Cond: ("time" IS NOT NULL)
+(5 rows)
+
+:PREFIX SELECT last(quantity, time) FROM btest_numeric;
+                                                     QUERY PLAN                                                     
+--------------------------------------------------------------------------------------------------------------------
+ Result (actual rows=1 loops=1)
+   InitPlan 1 (returns $0)
+     ->  Limit (actual rows=1 loops=1)
+           ->  Index Scan using _hyper_2_8_chunk_btest_numeric_time_idx on _hyper_2_8_chunk (actual rows=1 loops=1)
+                 Index Cond: ("time" IS NOT NULL)
+(5 rows)
+
+:PREFIX SELECT first(time, quantity) FROM btest_numeric;
+                         QUERY PLAN                         
+------------------------------------------------------------
+ Aggregate (actual rows=1 loops=1)
+   ->  Seq Scan on _hyper_2_8_chunk (actual rows=2 loops=1)
+(2 rows)
+
+:PREFIX SELECT last(time, quantity) FROM btest_numeric;
+                         QUERY PLAN                         
+------------------------------------------------------------
+ Aggregate (actual rows=1 loops=1)
+   ->  Seq Scan on _hyper_2_8_chunk (actual rows=2 loops=1)
+(2 rows)
+
+-- NULL values followed by non-NULL values
+INSERT INTO btest_numeric VALUES('2019-01-20T09:00:43', 1);
+INSERT INTO btest_numeric VALUES('2019-01-20T09:00:43', 2);
+:PREFIX SELECT first(quantity, time) FROM btest_numeric;
+                                                            QUERY PLAN                                                             
+-----------------------------------------------------------------------------------------------------------------------------------
+ Result (actual rows=1 loops=1)
+   InitPlan 1 (returns $0)
+     ->  Limit (actual rows=1 loops=1)
+           ->  Custom Scan (ChunkAppend) on btest_numeric (actual rows=1 loops=1)
+                 Order: btest_numeric."time"
+                 ->  Index Scan Backward using _hyper_2_8_chunk_btest_numeric_time_idx on _hyper_2_8_chunk (actual rows=1 loops=1)
+                       Index Cond: ("time" IS NOT NULL)
+                 ->  Index Scan Backward using _hyper_2_9_chunk_btest_numeric_time_idx on _hyper_2_9_chunk (never executed)
+                       Index Cond: ("time" IS NOT NULL)
+(9 rows)
+
+:PREFIX SELECT last(quantity, time) FROM btest_numeric;
+                                                        QUERY PLAN                                                        
+--------------------------------------------------------------------------------------------------------------------------
+ Result (actual rows=1 loops=1)
+   InitPlan 1 (returns $0)
+     ->  Limit (actual rows=1 loops=1)
+           ->  Custom Scan (ChunkAppend) on btest_numeric (actual rows=1 loops=1)
+                 Order: btest_numeric."time" DESC
+                 ->  Index Scan using _hyper_2_9_chunk_btest_numeric_time_idx on _hyper_2_9_chunk (actual rows=1 loops=1)
+                       Index Cond: ("time" IS NOT NULL)
+                 ->  Index Scan using _hyper_2_8_chunk_btest_numeric_time_idx on _hyper_2_8_chunk (never executed)
+                       Index Cond: ("time" IS NOT NULL)
+(9 rows)
+
+:PREFIX SELECT first(time, quantity) FROM btest_numeric;
+                            QUERY PLAN                            
+------------------------------------------------------------------
+ Aggregate (actual rows=1 loops=1)
+   ->  Append (actual rows=4 loops=1)
+         ->  Seq Scan on _hyper_2_8_chunk (actual rows=2 loops=1)
+         ->  Seq Scan on _hyper_2_9_chunk (actual rows=2 loops=1)
+(4 rows)
+
+:PREFIX SELECT last(time, quantity) FROM btest_numeric;
+                            QUERY PLAN                            
+------------------------------------------------------------------
+ Aggregate (actual rows=1 loops=1)
+   ->  Append (actual rows=4 loops=1)
+         ->  Seq Scan on _hyper_2_8_chunk (actual rows=2 loops=1)
+         ->  Seq Scan on _hyper_2_9_chunk (actual rows=2 loops=1)
+(4 rows)
+
+TRUNCATE btest_numeric;
+-- non-NULL values followed by NULL values
+INSERT INTO btest_numeric VALUES('2019-01-20T09:00:43', 1);
+INSERT INTO btest_numeric VALUES('2019-01-20T09:00:43', 2);
+INSERT INTO btest_numeric VALUES('2018-01-20T09:00:43', NULL);
+INSERT INTO btest_numeric VALUES('2018-01-20T09:00:43', NULL);
+:PREFIX SELECT first(quantity, time) FROM btest_numeric;
+                                                             QUERY PLAN                                                              
+-------------------------------------------------------------------------------------------------------------------------------------
+ Result (actual rows=1 loops=1)
+   InitPlan 1 (returns $0)
+     ->  Limit (actual rows=1 loops=1)
+           ->  Custom Scan (ChunkAppend) on btest_numeric (actual rows=1 loops=1)
+                 Order: btest_numeric."time"
+                 ->  Index Scan Backward using _hyper_2_11_chunk_btest_numeric_time_idx on _hyper_2_11_chunk (actual rows=1 loops=1)
+                       Index Cond: ("time" IS NOT NULL)
+                 ->  Index Scan Backward using _hyper_2_10_chunk_btest_numeric_time_idx on _hyper_2_10_chunk (never executed)
+                       Index Cond: ("time" IS NOT NULL)
+(9 rows)
+
+:PREFIX SELECT last(quantity, time) FROM btest_numeric;
+                                                         QUERY PLAN                                                         
+----------------------------------------------------------------------------------------------------------------------------
+ Result (actual rows=1 loops=1)
+   InitPlan 1 (returns $0)
+     ->  Limit (actual rows=1 loops=1)
+           ->  Custom Scan (ChunkAppend) on btest_numeric (actual rows=1 loops=1)
+                 Order: btest_numeric."time" DESC
+                 ->  Index Scan using _hyper_2_10_chunk_btest_numeric_time_idx on _hyper_2_10_chunk (actual rows=1 loops=1)
+                       Index Cond: ("time" IS NOT NULL)
+                 ->  Index Scan using _hyper_2_11_chunk_btest_numeric_time_idx on _hyper_2_11_chunk (never executed)
+                       Index Cond: ("time" IS NOT NULL)
+(9 rows)
+
+:PREFIX SELECT first(time, quantity) FROM btest_numeric;
+                            QUERY PLAN                             
+-------------------------------------------------------------------
+ Aggregate (actual rows=1 loops=1)
+   ->  Append (actual rows=4 loops=1)
+         ->  Seq Scan on _hyper_2_10_chunk (actual rows=2 loops=1)
+         ->  Seq Scan on _hyper_2_11_chunk (actual rows=2 loops=1)
+(4 rows)
+
+:PREFIX SELECT last(time, quantity) FROM btest_numeric;
+                            QUERY PLAN                             
+-------------------------------------------------------------------
+ Aggregate (actual rows=1 loops=1)
+   ->  Append (actual rows=4 loops=1)
+         ->  Seq Scan on _hyper_2_10_chunk (actual rows=2 loops=1)
+         ->  Seq Scan on _hyper_2_11_chunk (actual rows=2 loops=1)
+(4 rows)
+
+ROLLBACK;
 -- we want test results as part of the output too to make sure we produce correct output
 \set PREFIX ''
 \ir :TEST_QUERY_NAME
@@ -980,6 +1139,107 @@ CREATE INDEX btest_time_alt_idx ON btest(time_alt);
 (1 row)
 
 ROLLBACK;
+-- Test with NULL numeric values
+BEGIN;
+TRUNCATE btest_numeric;
+-- Empty table
+:PREFIX SELECT first(btest_numeric, time) FROM btest_numeric;
+ first 
+-------
+ 
+(1 row)
+
+:PREFIX SELECT last(btest_numeric, time) FROM btest_numeric;
+ last 
+------
+ 
+(1 row)
+
+-- Only NULL values
+INSERT INTO btest_numeric VALUES('2018-01-20T09:00:43', NULL);
+INSERT INTO btest_numeric VALUES('2018-01-20T09:00:43', NULL);
+:PREFIX SELECT first(quantity, time) FROM btest_numeric;
+ first 
+-------
+      
+(1 row)
+
+:PREFIX SELECT last(quantity, time) FROM btest_numeric;
+ last 
+------
+     
+(1 row)
+
+:PREFIX SELECT first(time, quantity) FROM btest_numeric;
+ first 
+-------
+ 
+(1 row)
+
+:PREFIX SELECT last(time, quantity) FROM btest_numeric;
+ last 
+------
+ 
+(1 row)
+
+-- NULL values followed by non-NULL values
+INSERT INTO btest_numeric VALUES('2019-01-20T09:00:43', 1);
+INSERT INTO btest_numeric VALUES('2019-01-20T09:00:43', 2);
+:PREFIX SELECT first(quantity, time) FROM btest_numeric;
+ first 
+-------
+      
+(1 row)
+
+:PREFIX SELECT last(quantity, time) FROM btest_numeric;
+ last 
+------
+    1
+(1 row)
+
+:PREFIX SELECT first(time, quantity) FROM btest_numeric;
+          first           
+--------------------------
+ Sun Jan 20 09:00:43 2019
+(1 row)
+
+:PREFIX SELECT last(time, quantity) FROM btest_numeric;
+           last           
+--------------------------
+ Sun Jan 20 09:00:43 2019
+(1 row)
+
+TRUNCATE btest_numeric;
+-- non-NULL values followed by NULL values
+INSERT INTO btest_numeric VALUES('2019-01-20T09:00:43', 1);
+INSERT INTO btest_numeric VALUES('2019-01-20T09:00:43', 2);
+INSERT INTO btest_numeric VALUES('2018-01-20T09:00:43', NULL);
+INSERT INTO btest_numeric VALUES('2018-01-20T09:00:43', NULL);
+:PREFIX SELECT first(quantity, time) FROM btest_numeric;
+ first 
+-------
+      
+(1 row)
+
+:PREFIX SELECT last(quantity, time) FROM btest_numeric;
+ last 
+------
+    1
+(1 row)
+
+:PREFIX SELECT first(time, quantity) FROM btest_numeric;
+          first           
+--------------------------
+ Sun Jan 20 09:00:43 2019
+(1 row)
+
+:PREFIX SELECT last(time, quantity) FROM btest_numeric;
+           last           
+--------------------------
+ Sun Jan 20 09:00:43 2019
+(1 row)
+
+ROLLBACK;
 -- diff results with optimizations disabled and enabled
 \o :TEST_RESULTS_UNOPTIMIZED
 SET timescaledb.enable_optimizations TO false;
@@ -1069,6 +1329,37 @@ CREATE INDEX btest_time_alt_idx ON btest(time_alt);
 -- test nested FIRST/LAST in ORDER BY - no optimization possible
 :PREFIX SELECT abs(last(temp, time)) FROM btest ORDER BY abs(last(temp,time));
 ROLLBACK;
+-- Test with NULL numeric values
+BEGIN;
+TRUNCATE btest_numeric;
+-- Empty table
+:PREFIX SELECT first(btest_numeric, time) FROM btest_numeric;
+:PREFIX SELECT last(btest_numeric, time) FROM btest_numeric;
+-- Only NULL values
+INSERT INTO btest_numeric VALUES('2018-01-20T09:00:43', NULL);
+INSERT INTO btest_numeric VALUES('2018-01-20T09:00:43', NULL);
+:PREFIX SELECT first(quantity, time) FROM btest_numeric;
+:PREFIX SELECT last(quantity, time) FROM btest_numeric;
+:PREFIX SELECT first(time, quantity) FROM btest_numeric;
+:PREFIX SELECT last(time, quantity) FROM btest_numeric;
+-- NULL values followed by non-NULL values
+INSERT INTO btest_numeric VALUES('2019-01-20T09:00:43', 1);
+INSERT INTO btest_numeric VALUES('2019-01-20T09:00:43', 2);
+:PREFIX SELECT first(quantity, time) FROM btest_numeric;
+:PREFIX SELECT last(quantity, time) FROM btest_numeric;
+:PREFIX SELECT first(time, quantity) FROM btest_numeric;
+:PREFIX SELECT last(time, quantity) FROM btest_numeric;
+TRUNCATE btest_numeric;
+-- non-NULL values followed by NULL values
+INSERT INTO btest_numeric VALUES('2019-01-20T09:00:43', 1);
+INSERT INTO btest_numeric VALUES('2019-01-20T09:00:43', 2);
+INSERT INTO btest_numeric VALUES('2018-01-20T09:00:43', NULL);
+INSERT INTO btest_numeric VALUES('2018-01-20T09:00:43', NULL);
+:PREFIX SELECT first(quantity, time) FROM btest_numeric;
+:PREFIX SELECT last(quantity, time) FROM btest_numeric;
+:PREFIX SELECT first(time, quantity) FROM btest_numeric;
+:PREFIX SELECT last(time, quantity) FROM btest_numeric;
+ROLLBACK;
 \o
 \o :TEST_RESULTS_OPTIMIZED
 SET timescaledb.enable_optimizations TO true;
@@ -1157,6 +1448,37 @@ CREATE INDEX btest_time_alt_idx ON btest(time_alt);
 :PREFIX SELECT abs(last(temp, time)) FROM btest;
 -- test nested FIRST/LAST in ORDER BY - no optimization possible
 :PREFIX SELECT abs(last(temp, time)) FROM btest ORDER BY abs(last(temp,time));
+ROLLBACK;
+-- Test with NULL numeric values
+BEGIN;
+TRUNCATE btest_numeric;
+-- Empty table
+:PREFIX SELECT first(btest_numeric, time) FROM btest_numeric;
+:PREFIX SELECT last(btest_numeric, time) FROM btest_numeric;
+-- Only NULL values
+INSERT INTO btest_numeric VALUES('2018-01-20T09:00:43', NULL);
+INSERT INTO btest_numeric VALUES('2018-01-20T09:00:43', NULL);
+:PREFIX SELECT first(quantity, time) FROM btest_numeric;
+:PREFIX SELECT last(quantity, time) FROM btest_numeric;
+:PREFIX SELECT first(time, quantity) FROM btest_numeric;
+:PREFIX SELECT last(time, quantity) FROM btest_numeric;
+-- NULL values followed by non-NULL values
+INSERT INTO btest_numeric VALUES('2019-01-20T09:00:43', 1);
+INSERT INTO btest_numeric VALUES('2019-01-20T09:00:43', 2);
+:PREFIX SELECT first(quantity, time) FROM btest_numeric;
+:PREFIX SELECT last(quantity, time) FROM btest_numeric;
+:PREFIX SELECT first(time, quantity) FROM btest_numeric;
+:PREFIX SELECT last(time, quantity) FROM btest_numeric;
+TRUNCATE btest_numeric;
+-- non-NULL values followed by NULL values
+INSERT INTO btest_numeric VALUES('2019-01-20T09:00:43', 1);
+INSERT INTO btest_numeric VALUES('2019-01-20T09:00:43', 2);
+INSERT INTO btest_numeric VALUES('2018-01-20T09:00:43', NULL);
+INSERT INTO btest_numeric VALUES('2018-01-20T09:00:43', NULL);
+:PREFIX SELECT first(quantity, time) FROM btest_numeric;
+:PREFIX SELECT last(quantity, time) FROM btest_numeric;
+:PREFIX SELECT first(time, quantity) FROM btest_numeric;
+:PREFIX SELECT last(time, quantity) FROM btest_numeric;
 ROLLBACK;
 \o
 :DIFF_CMD

--- a/test/expected/agg_bookends-13.out
+++ b/test/expected/agg_bookends-13.out
@@ -677,6 +677,165 @@ CREATE INDEX btest_time_alt_idx ON btest(time_alt);
 (10 rows)
 
 ROLLBACK;
+-- Test with NULL numeric values
+BEGIN;
+TRUNCATE btest_numeric;
+-- Empty table
+:PREFIX SELECT first(btest_numeric, time) FROM btest_numeric;
+              QUERY PLAN              
+--------------------------------------
+ Aggregate (actual rows=1 loops=1)
+   ->  Result (actual rows=0 loops=1)
+         One-Time Filter: false
+(3 rows)
+
+:PREFIX SELECT last(btest_numeric, time) FROM btest_numeric;
+              QUERY PLAN              
+--------------------------------------
+ Aggregate (actual rows=1 loops=1)
+   ->  Result (actual rows=0 loops=1)
+         One-Time Filter: false
+(3 rows)
+
+-- Only NULL values
+INSERT INTO btest_numeric VALUES('2018-01-20T09:00:43', NULL);
+INSERT INTO btest_numeric VALUES('2018-01-20T09:00:43', NULL);
+:PREFIX SELECT first(quantity, time) FROM btest_numeric;
+                                                         QUERY PLAN                                                          
+-----------------------------------------------------------------------------------------------------------------------------
+ Result (actual rows=1 loops=1)
+   InitPlan 1 (returns $0)
+     ->  Limit (actual rows=1 loops=1)
+           ->  Index Scan Backward using _hyper_2_8_chunk_btest_numeric_time_idx on _hyper_2_8_chunk (actual rows=1 loops=1)
+                 Index Cond: ("time" IS NOT NULL)
+(5 rows)
+
+:PREFIX SELECT last(quantity, time) FROM btest_numeric;
+                                                     QUERY PLAN                                                     
+--------------------------------------------------------------------------------------------------------------------
+ Result (actual rows=1 loops=1)
+   InitPlan 1 (returns $0)
+     ->  Limit (actual rows=1 loops=1)
+           ->  Index Scan using _hyper_2_8_chunk_btest_numeric_time_idx on _hyper_2_8_chunk (actual rows=1 loops=1)
+                 Index Cond: ("time" IS NOT NULL)
+(5 rows)
+
+:PREFIX SELECT first(time, quantity) FROM btest_numeric;
+                         QUERY PLAN                         
+------------------------------------------------------------
+ Aggregate (actual rows=1 loops=1)
+   ->  Seq Scan on _hyper_2_8_chunk (actual rows=2 loops=1)
+(2 rows)
+
+:PREFIX SELECT last(time, quantity) FROM btest_numeric;
+                         QUERY PLAN                         
+------------------------------------------------------------
+ Aggregate (actual rows=1 loops=1)
+   ->  Seq Scan on _hyper_2_8_chunk (actual rows=2 loops=1)
+(2 rows)
+
+-- NULL values followed by non-NULL values
+INSERT INTO btest_numeric VALUES('2019-01-20T09:00:43', 1);
+INSERT INTO btest_numeric VALUES('2019-01-20T09:00:43', 2);
+:PREFIX SELECT first(quantity, time) FROM btest_numeric;
+                                                            QUERY PLAN                                                             
+-----------------------------------------------------------------------------------------------------------------------------------
+ Result (actual rows=1 loops=1)
+   InitPlan 1 (returns $0)
+     ->  Limit (actual rows=1 loops=1)
+           ->  Custom Scan (ChunkAppend) on btest_numeric (actual rows=1 loops=1)
+                 Order: btest_numeric."time"
+                 ->  Index Scan Backward using _hyper_2_8_chunk_btest_numeric_time_idx on _hyper_2_8_chunk (actual rows=1 loops=1)
+                       Index Cond: ("time" IS NOT NULL)
+                 ->  Index Scan Backward using _hyper_2_9_chunk_btest_numeric_time_idx on _hyper_2_9_chunk (never executed)
+                       Index Cond: ("time" IS NOT NULL)
+(9 rows)
+
+:PREFIX SELECT last(quantity, time) FROM btest_numeric;
+                                                        QUERY PLAN                                                        
+--------------------------------------------------------------------------------------------------------------------------
+ Result (actual rows=1 loops=1)
+   InitPlan 1 (returns $0)
+     ->  Limit (actual rows=1 loops=1)
+           ->  Custom Scan (ChunkAppend) on btest_numeric (actual rows=1 loops=1)
+                 Order: btest_numeric."time" DESC
+                 ->  Index Scan using _hyper_2_9_chunk_btest_numeric_time_idx on _hyper_2_9_chunk (actual rows=1 loops=1)
+                       Index Cond: ("time" IS NOT NULL)
+                 ->  Index Scan using _hyper_2_8_chunk_btest_numeric_time_idx on _hyper_2_8_chunk (never executed)
+                       Index Cond: ("time" IS NOT NULL)
+(9 rows)
+
+:PREFIX SELECT first(time, quantity) FROM btest_numeric;
+                            QUERY PLAN                            
+------------------------------------------------------------------
+ Aggregate (actual rows=1 loops=1)
+   ->  Append (actual rows=4 loops=1)
+         ->  Seq Scan on _hyper_2_8_chunk (actual rows=2 loops=1)
+         ->  Seq Scan on _hyper_2_9_chunk (actual rows=2 loops=1)
+(4 rows)
+
+:PREFIX SELECT last(time, quantity) FROM btest_numeric;
+                            QUERY PLAN                            
+------------------------------------------------------------------
+ Aggregate (actual rows=1 loops=1)
+   ->  Append (actual rows=4 loops=1)
+         ->  Seq Scan on _hyper_2_8_chunk (actual rows=2 loops=1)
+         ->  Seq Scan on _hyper_2_9_chunk (actual rows=2 loops=1)
+(4 rows)
+
+TRUNCATE btest_numeric;
+-- non-NULL values followed by NULL values
+INSERT INTO btest_numeric VALUES('2019-01-20T09:00:43', 1);
+INSERT INTO btest_numeric VALUES('2019-01-20T09:00:43', 2);
+INSERT INTO btest_numeric VALUES('2018-01-20T09:00:43', NULL);
+INSERT INTO btest_numeric VALUES('2018-01-20T09:00:43', NULL);
+:PREFIX SELECT first(quantity, time) FROM btest_numeric;
+                                                             QUERY PLAN                                                              
+-------------------------------------------------------------------------------------------------------------------------------------
+ Result (actual rows=1 loops=1)
+   InitPlan 1 (returns $0)
+     ->  Limit (actual rows=1 loops=1)
+           ->  Custom Scan (ChunkAppend) on btest_numeric (actual rows=1 loops=1)
+                 Order: btest_numeric."time"
+                 ->  Index Scan Backward using _hyper_2_11_chunk_btest_numeric_time_idx on _hyper_2_11_chunk (actual rows=1 loops=1)
+                       Index Cond: ("time" IS NOT NULL)
+                 ->  Index Scan Backward using _hyper_2_10_chunk_btest_numeric_time_idx on _hyper_2_10_chunk (never executed)
+                       Index Cond: ("time" IS NOT NULL)
+(9 rows)
+
+:PREFIX SELECT last(quantity, time) FROM btest_numeric;
+                                                         QUERY PLAN                                                         
+----------------------------------------------------------------------------------------------------------------------------
+ Result (actual rows=1 loops=1)
+   InitPlan 1 (returns $0)
+     ->  Limit (actual rows=1 loops=1)
+           ->  Custom Scan (ChunkAppend) on btest_numeric (actual rows=1 loops=1)
+                 Order: btest_numeric."time" DESC
+                 ->  Index Scan using _hyper_2_10_chunk_btest_numeric_time_idx on _hyper_2_10_chunk (actual rows=1 loops=1)
+                       Index Cond: ("time" IS NOT NULL)
+                 ->  Index Scan using _hyper_2_11_chunk_btest_numeric_time_idx on _hyper_2_11_chunk (never executed)
+                       Index Cond: ("time" IS NOT NULL)
+(9 rows)
+
+:PREFIX SELECT first(time, quantity) FROM btest_numeric;
+                            QUERY PLAN                             
+-------------------------------------------------------------------
+ Aggregate (actual rows=1 loops=1)
+   ->  Append (actual rows=4 loops=1)
+         ->  Seq Scan on _hyper_2_10_chunk (actual rows=2 loops=1)
+         ->  Seq Scan on _hyper_2_11_chunk (actual rows=2 loops=1)
+(4 rows)
+
+:PREFIX SELECT last(time, quantity) FROM btest_numeric;
+                            QUERY PLAN                             
+-------------------------------------------------------------------
+ Aggregate (actual rows=1 loops=1)
+   ->  Append (actual rows=4 loops=1)
+         ->  Seq Scan on _hyper_2_10_chunk (actual rows=2 loops=1)
+         ->  Seq Scan on _hyper_2_11_chunk (actual rows=2 loops=1)
+(4 rows)
+
+ROLLBACK;
 -- we want test results as part of the output too to make sure we produce correct output
 \set PREFIX ''
 \ir :TEST_QUERY_NAME
@@ -988,6 +1147,107 @@ CREATE INDEX btest_time_alt_idx ON btest(time_alt);
 (1 row)
 
 ROLLBACK;
+-- Test with NULL numeric values
+BEGIN;
+TRUNCATE btest_numeric;
+-- Empty table
+:PREFIX SELECT first(btest_numeric, time) FROM btest_numeric;
+ first 
+-------
+ 
+(1 row)
+
+:PREFIX SELECT last(btest_numeric, time) FROM btest_numeric;
+ last 
+------
+ 
+(1 row)
+
+-- Only NULL values
+INSERT INTO btest_numeric VALUES('2018-01-20T09:00:43', NULL);
+INSERT INTO btest_numeric VALUES('2018-01-20T09:00:43', NULL);
+:PREFIX SELECT first(quantity, time) FROM btest_numeric;
+ first 
+-------
+      
+(1 row)
+
+:PREFIX SELECT last(quantity, time) FROM btest_numeric;
+ last 
+------
+     
+(1 row)
+
+:PREFIX SELECT first(time, quantity) FROM btest_numeric;
+ first 
+-------
+ 
+(1 row)
+
+:PREFIX SELECT last(time, quantity) FROM btest_numeric;
+ last 
+------
+ 
+(1 row)
+
+-- NULL values followed by non-NULL values
+INSERT INTO btest_numeric VALUES('2019-01-20T09:00:43', 1);
+INSERT INTO btest_numeric VALUES('2019-01-20T09:00:43', 2);
+:PREFIX SELECT first(quantity, time) FROM btest_numeric;
+ first 
+-------
+      
+(1 row)
+
+:PREFIX SELECT last(quantity, time) FROM btest_numeric;
+ last 
+------
+    1
+(1 row)
+
+:PREFIX SELECT first(time, quantity) FROM btest_numeric;
+          first           
+--------------------------
+ Sun Jan 20 09:00:43 2019
+(1 row)
+
+:PREFIX SELECT last(time, quantity) FROM btest_numeric;
+           last           
+--------------------------
+ Sun Jan 20 09:00:43 2019
+(1 row)
+
+TRUNCATE btest_numeric;
+-- non-NULL values followed by NULL values
+INSERT INTO btest_numeric VALUES('2019-01-20T09:00:43', 1);
+INSERT INTO btest_numeric VALUES('2019-01-20T09:00:43', 2);
+INSERT INTO btest_numeric VALUES('2018-01-20T09:00:43', NULL);
+INSERT INTO btest_numeric VALUES('2018-01-20T09:00:43', NULL);
+:PREFIX SELECT first(quantity, time) FROM btest_numeric;
+ first 
+-------
+      
+(1 row)
+
+:PREFIX SELECT last(quantity, time) FROM btest_numeric;
+ last 
+------
+    1
+(1 row)
+
+:PREFIX SELECT first(time, quantity) FROM btest_numeric;
+          first           
+--------------------------
+ Sun Jan 20 09:00:43 2019
+(1 row)
+
+:PREFIX SELECT last(time, quantity) FROM btest_numeric;
+           last           
+--------------------------
+ Sun Jan 20 09:00:43 2019
+(1 row)
+
+ROLLBACK;
 -- diff results with optimizations disabled and enabled
 \o :TEST_RESULTS_UNOPTIMIZED
 SET timescaledb.enable_optimizations TO false;
@@ -1077,6 +1337,37 @@ CREATE INDEX btest_time_alt_idx ON btest(time_alt);
 -- test nested FIRST/LAST in ORDER BY - no optimization possible
 :PREFIX SELECT abs(last(temp, time)) FROM btest ORDER BY abs(last(temp,time));
 ROLLBACK;
+-- Test with NULL numeric values
+BEGIN;
+TRUNCATE btest_numeric;
+-- Empty table
+:PREFIX SELECT first(btest_numeric, time) FROM btest_numeric;
+:PREFIX SELECT last(btest_numeric, time) FROM btest_numeric;
+-- Only NULL values
+INSERT INTO btest_numeric VALUES('2018-01-20T09:00:43', NULL);
+INSERT INTO btest_numeric VALUES('2018-01-20T09:00:43', NULL);
+:PREFIX SELECT first(quantity, time) FROM btest_numeric;
+:PREFIX SELECT last(quantity, time) FROM btest_numeric;
+:PREFIX SELECT first(time, quantity) FROM btest_numeric;
+:PREFIX SELECT last(time, quantity) FROM btest_numeric;
+-- NULL values followed by non-NULL values
+INSERT INTO btest_numeric VALUES('2019-01-20T09:00:43', 1);
+INSERT INTO btest_numeric VALUES('2019-01-20T09:00:43', 2);
+:PREFIX SELECT first(quantity, time) FROM btest_numeric;
+:PREFIX SELECT last(quantity, time) FROM btest_numeric;
+:PREFIX SELECT first(time, quantity) FROM btest_numeric;
+:PREFIX SELECT last(time, quantity) FROM btest_numeric;
+TRUNCATE btest_numeric;
+-- non-NULL values followed by NULL values
+INSERT INTO btest_numeric VALUES('2019-01-20T09:00:43', 1);
+INSERT INTO btest_numeric VALUES('2019-01-20T09:00:43', 2);
+INSERT INTO btest_numeric VALUES('2018-01-20T09:00:43', NULL);
+INSERT INTO btest_numeric VALUES('2018-01-20T09:00:43', NULL);
+:PREFIX SELECT first(quantity, time) FROM btest_numeric;
+:PREFIX SELECT last(quantity, time) FROM btest_numeric;
+:PREFIX SELECT first(time, quantity) FROM btest_numeric;
+:PREFIX SELECT last(time, quantity) FROM btest_numeric;
+ROLLBACK;
 \o
 \o :TEST_RESULTS_OPTIMIZED
 SET timescaledb.enable_optimizations TO true;
@@ -1165,6 +1456,37 @@ CREATE INDEX btest_time_alt_idx ON btest(time_alt);
 :PREFIX SELECT abs(last(temp, time)) FROM btest;
 -- test nested FIRST/LAST in ORDER BY - no optimization possible
 :PREFIX SELECT abs(last(temp, time)) FROM btest ORDER BY abs(last(temp,time));
+ROLLBACK;
+-- Test with NULL numeric values
+BEGIN;
+TRUNCATE btest_numeric;
+-- Empty table
+:PREFIX SELECT first(btest_numeric, time) FROM btest_numeric;
+:PREFIX SELECT last(btest_numeric, time) FROM btest_numeric;
+-- Only NULL values
+INSERT INTO btest_numeric VALUES('2018-01-20T09:00:43', NULL);
+INSERT INTO btest_numeric VALUES('2018-01-20T09:00:43', NULL);
+:PREFIX SELECT first(quantity, time) FROM btest_numeric;
+:PREFIX SELECT last(quantity, time) FROM btest_numeric;
+:PREFIX SELECT first(time, quantity) FROM btest_numeric;
+:PREFIX SELECT last(time, quantity) FROM btest_numeric;
+-- NULL values followed by non-NULL values
+INSERT INTO btest_numeric VALUES('2019-01-20T09:00:43', 1);
+INSERT INTO btest_numeric VALUES('2019-01-20T09:00:43', 2);
+:PREFIX SELECT first(quantity, time) FROM btest_numeric;
+:PREFIX SELECT last(quantity, time) FROM btest_numeric;
+:PREFIX SELECT first(time, quantity) FROM btest_numeric;
+:PREFIX SELECT last(time, quantity) FROM btest_numeric;
+TRUNCATE btest_numeric;
+-- non-NULL values followed by NULL values
+INSERT INTO btest_numeric VALUES('2019-01-20T09:00:43', 1);
+INSERT INTO btest_numeric VALUES('2019-01-20T09:00:43', 2);
+INSERT INTO btest_numeric VALUES('2018-01-20T09:00:43', NULL);
+INSERT INTO btest_numeric VALUES('2018-01-20T09:00:43', NULL);
+:PREFIX SELECT first(quantity, time) FROM btest_numeric;
+:PREFIX SELECT last(quantity, time) FROM btest_numeric;
+:PREFIX SELECT first(time, quantity) FROM btest_numeric;
+:PREFIX SELECT last(time, quantity) FROM btest_numeric;
 ROLLBACK;
 \o
 :DIFF_CMD

--- a/test/expected/agg_bookends-14.out
+++ b/test/expected/agg_bookends-14.out
@@ -677,6 +677,165 @@ CREATE INDEX btest_time_alt_idx ON btest(time_alt);
 (10 rows)
 
 ROLLBACK;
+-- Test with NULL numeric values
+BEGIN;
+TRUNCATE btest_numeric;
+-- Empty table
+:PREFIX SELECT first(btest_numeric, time) FROM btest_numeric;
+              QUERY PLAN              
+--------------------------------------
+ Aggregate (actual rows=1 loops=1)
+   ->  Result (actual rows=0 loops=1)
+         One-Time Filter: false
+(3 rows)
+
+:PREFIX SELECT last(btest_numeric, time) FROM btest_numeric;
+              QUERY PLAN              
+--------------------------------------
+ Aggregate (actual rows=1 loops=1)
+   ->  Result (actual rows=0 loops=1)
+         One-Time Filter: false
+(3 rows)
+
+-- Only NULL values
+INSERT INTO btest_numeric VALUES('2018-01-20T09:00:43', NULL);
+INSERT INTO btest_numeric VALUES('2018-01-20T09:00:43', NULL);
+:PREFIX SELECT first(quantity, time) FROM btest_numeric;
+                                                         QUERY PLAN                                                          
+-----------------------------------------------------------------------------------------------------------------------------
+ Result (actual rows=1 loops=1)
+   InitPlan 1 (returns $0)
+     ->  Limit (actual rows=1 loops=1)
+           ->  Index Scan Backward using _hyper_2_8_chunk_btest_numeric_time_idx on _hyper_2_8_chunk (actual rows=1 loops=1)
+                 Index Cond: ("time" IS NOT NULL)
+(5 rows)
+
+:PREFIX SELECT last(quantity, time) FROM btest_numeric;
+                                                     QUERY PLAN                                                     
+--------------------------------------------------------------------------------------------------------------------
+ Result (actual rows=1 loops=1)
+   InitPlan 1 (returns $0)
+     ->  Limit (actual rows=1 loops=1)
+           ->  Index Scan using _hyper_2_8_chunk_btest_numeric_time_idx on _hyper_2_8_chunk (actual rows=1 loops=1)
+                 Index Cond: ("time" IS NOT NULL)
+(5 rows)
+
+:PREFIX SELECT first(time, quantity) FROM btest_numeric;
+                         QUERY PLAN                         
+------------------------------------------------------------
+ Aggregate (actual rows=1 loops=1)
+   ->  Seq Scan on _hyper_2_8_chunk (actual rows=2 loops=1)
+(2 rows)
+
+:PREFIX SELECT last(time, quantity) FROM btest_numeric;
+                         QUERY PLAN                         
+------------------------------------------------------------
+ Aggregate (actual rows=1 loops=1)
+   ->  Seq Scan on _hyper_2_8_chunk (actual rows=2 loops=1)
+(2 rows)
+
+-- NULL values followed by non-NULL values
+INSERT INTO btest_numeric VALUES('2019-01-20T09:00:43', 1);
+INSERT INTO btest_numeric VALUES('2019-01-20T09:00:43', 2);
+:PREFIX SELECT first(quantity, time) FROM btest_numeric;
+                                                            QUERY PLAN                                                             
+-----------------------------------------------------------------------------------------------------------------------------------
+ Result (actual rows=1 loops=1)
+   InitPlan 1 (returns $0)
+     ->  Limit (actual rows=1 loops=1)
+           ->  Custom Scan (ChunkAppend) on btest_numeric (actual rows=1 loops=1)
+                 Order: btest_numeric."time"
+                 ->  Index Scan Backward using _hyper_2_8_chunk_btest_numeric_time_idx on _hyper_2_8_chunk (actual rows=1 loops=1)
+                       Index Cond: ("time" IS NOT NULL)
+                 ->  Index Scan Backward using _hyper_2_9_chunk_btest_numeric_time_idx on _hyper_2_9_chunk (never executed)
+                       Index Cond: ("time" IS NOT NULL)
+(9 rows)
+
+:PREFIX SELECT last(quantity, time) FROM btest_numeric;
+                                                        QUERY PLAN                                                        
+--------------------------------------------------------------------------------------------------------------------------
+ Result (actual rows=1 loops=1)
+   InitPlan 1 (returns $0)
+     ->  Limit (actual rows=1 loops=1)
+           ->  Custom Scan (ChunkAppend) on btest_numeric (actual rows=1 loops=1)
+                 Order: btest_numeric."time" DESC
+                 ->  Index Scan using _hyper_2_9_chunk_btest_numeric_time_idx on _hyper_2_9_chunk (actual rows=1 loops=1)
+                       Index Cond: ("time" IS NOT NULL)
+                 ->  Index Scan using _hyper_2_8_chunk_btest_numeric_time_idx on _hyper_2_8_chunk (never executed)
+                       Index Cond: ("time" IS NOT NULL)
+(9 rows)
+
+:PREFIX SELECT first(time, quantity) FROM btest_numeric;
+                            QUERY PLAN                            
+------------------------------------------------------------------
+ Aggregate (actual rows=1 loops=1)
+   ->  Append (actual rows=4 loops=1)
+         ->  Seq Scan on _hyper_2_8_chunk (actual rows=2 loops=1)
+         ->  Seq Scan on _hyper_2_9_chunk (actual rows=2 loops=1)
+(4 rows)
+
+:PREFIX SELECT last(time, quantity) FROM btest_numeric;
+                            QUERY PLAN                            
+------------------------------------------------------------------
+ Aggregate (actual rows=1 loops=1)
+   ->  Append (actual rows=4 loops=1)
+         ->  Seq Scan on _hyper_2_8_chunk (actual rows=2 loops=1)
+         ->  Seq Scan on _hyper_2_9_chunk (actual rows=2 loops=1)
+(4 rows)
+
+TRUNCATE btest_numeric;
+-- non-NULL values followed by NULL values
+INSERT INTO btest_numeric VALUES('2019-01-20T09:00:43', 1);
+INSERT INTO btest_numeric VALUES('2019-01-20T09:00:43', 2);
+INSERT INTO btest_numeric VALUES('2018-01-20T09:00:43', NULL);
+INSERT INTO btest_numeric VALUES('2018-01-20T09:00:43', NULL);
+:PREFIX SELECT first(quantity, time) FROM btest_numeric;
+                                                             QUERY PLAN                                                              
+-------------------------------------------------------------------------------------------------------------------------------------
+ Result (actual rows=1 loops=1)
+   InitPlan 1 (returns $0)
+     ->  Limit (actual rows=1 loops=1)
+           ->  Custom Scan (ChunkAppend) on btest_numeric (actual rows=1 loops=1)
+                 Order: btest_numeric."time"
+                 ->  Index Scan Backward using _hyper_2_11_chunk_btest_numeric_time_idx on _hyper_2_11_chunk (actual rows=1 loops=1)
+                       Index Cond: ("time" IS NOT NULL)
+                 ->  Index Scan Backward using _hyper_2_10_chunk_btest_numeric_time_idx on _hyper_2_10_chunk (never executed)
+                       Index Cond: ("time" IS NOT NULL)
+(9 rows)
+
+:PREFIX SELECT last(quantity, time) FROM btest_numeric;
+                                                         QUERY PLAN                                                         
+----------------------------------------------------------------------------------------------------------------------------
+ Result (actual rows=1 loops=1)
+   InitPlan 1 (returns $0)
+     ->  Limit (actual rows=1 loops=1)
+           ->  Custom Scan (ChunkAppend) on btest_numeric (actual rows=1 loops=1)
+                 Order: btest_numeric."time" DESC
+                 ->  Index Scan using _hyper_2_10_chunk_btest_numeric_time_idx on _hyper_2_10_chunk (actual rows=1 loops=1)
+                       Index Cond: ("time" IS NOT NULL)
+                 ->  Index Scan using _hyper_2_11_chunk_btest_numeric_time_idx on _hyper_2_11_chunk (never executed)
+                       Index Cond: ("time" IS NOT NULL)
+(9 rows)
+
+:PREFIX SELECT first(time, quantity) FROM btest_numeric;
+                            QUERY PLAN                             
+-------------------------------------------------------------------
+ Aggregate (actual rows=1 loops=1)
+   ->  Append (actual rows=4 loops=1)
+         ->  Seq Scan on _hyper_2_10_chunk (actual rows=2 loops=1)
+         ->  Seq Scan on _hyper_2_11_chunk (actual rows=2 loops=1)
+(4 rows)
+
+:PREFIX SELECT last(time, quantity) FROM btest_numeric;
+                            QUERY PLAN                             
+-------------------------------------------------------------------
+ Aggregate (actual rows=1 loops=1)
+   ->  Append (actual rows=4 loops=1)
+         ->  Seq Scan on _hyper_2_10_chunk (actual rows=2 loops=1)
+         ->  Seq Scan on _hyper_2_11_chunk (actual rows=2 loops=1)
+(4 rows)
+
+ROLLBACK;
 -- we want test results as part of the output too to make sure we produce correct output
 \set PREFIX ''
 \ir :TEST_QUERY_NAME
@@ -988,6 +1147,107 @@ CREATE INDEX btest_time_alt_idx ON btest(time_alt);
 (1 row)
 
 ROLLBACK;
+-- Test with NULL numeric values
+BEGIN;
+TRUNCATE btest_numeric;
+-- Empty table
+:PREFIX SELECT first(btest_numeric, time) FROM btest_numeric;
+ first 
+-------
+ 
+(1 row)
+
+:PREFIX SELECT last(btest_numeric, time) FROM btest_numeric;
+ last 
+------
+ 
+(1 row)
+
+-- Only NULL values
+INSERT INTO btest_numeric VALUES('2018-01-20T09:00:43', NULL);
+INSERT INTO btest_numeric VALUES('2018-01-20T09:00:43', NULL);
+:PREFIX SELECT first(quantity, time) FROM btest_numeric;
+ first 
+-------
+      
+(1 row)
+
+:PREFIX SELECT last(quantity, time) FROM btest_numeric;
+ last 
+------
+     
+(1 row)
+
+:PREFIX SELECT first(time, quantity) FROM btest_numeric;
+ first 
+-------
+ 
+(1 row)
+
+:PREFIX SELECT last(time, quantity) FROM btest_numeric;
+ last 
+------
+ 
+(1 row)
+
+-- NULL values followed by non-NULL values
+INSERT INTO btest_numeric VALUES('2019-01-20T09:00:43', 1);
+INSERT INTO btest_numeric VALUES('2019-01-20T09:00:43', 2);
+:PREFIX SELECT first(quantity, time) FROM btest_numeric;
+ first 
+-------
+      
+(1 row)
+
+:PREFIX SELECT last(quantity, time) FROM btest_numeric;
+ last 
+------
+    1
+(1 row)
+
+:PREFIX SELECT first(time, quantity) FROM btest_numeric;
+          first           
+--------------------------
+ Sun Jan 20 09:00:43 2019
+(1 row)
+
+:PREFIX SELECT last(time, quantity) FROM btest_numeric;
+           last           
+--------------------------
+ Sun Jan 20 09:00:43 2019
+(1 row)
+
+TRUNCATE btest_numeric;
+-- non-NULL values followed by NULL values
+INSERT INTO btest_numeric VALUES('2019-01-20T09:00:43', 1);
+INSERT INTO btest_numeric VALUES('2019-01-20T09:00:43', 2);
+INSERT INTO btest_numeric VALUES('2018-01-20T09:00:43', NULL);
+INSERT INTO btest_numeric VALUES('2018-01-20T09:00:43', NULL);
+:PREFIX SELECT first(quantity, time) FROM btest_numeric;
+ first 
+-------
+      
+(1 row)
+
+:PREFIX SELECT last(quantity, time) FROM btest_numeric;
+ last 
+------
+    1
+(1 row)
+
+:PREFIX SELECT first(time, quantity) FROM btest_numeric;
+          first           
+--------------------------
+ Sun Jan 20 09:00:43 2019
+(1 row)
+
+:PREFIX SELECT last(time, quantity) FROM btest_numeric;
+           last           
+--------------------------
+ Sun Jan 20 09:00:43 2019
+(1 row)
+
+ROLLBACK;
 -- diff results with optimizations disabled and enabled
 \o :TEST_RESULTS_UNOPTIMIZED
 SET timescaledb.enable_optimizations TO false;
@@ -1077,6 +1337,37 @@ CREATE INDEX btest_time_alt_idx ON btest(time_alt);
 -- test nested FIRST/LAST in ORDER BY - no optimization possible
 :PREFIX SELECT abs(last(temp, time)) FROM btest ORDER BY abs(last(temp,time));
 ROLLBACK;
+-- Test with NULL numeric values
+BEGIN;
+TRUNCATE btest_numeric;
+-- Empty table
+:PREFIX SELECT first(btest_numeric, time) FROM btest_numeric;
+:PREFIX SELECT last(btest_numeric, time) FROM btest_numeric;
+-- Only NULL values
+INSERT INTO btest_numeric VALUES('2018-01-20T09:00:43', NULL);
+INSERT INTO btest_numeric VALUES('2018-01-20T09:00:43', NULL);
+:PREFIX SELECT first(quantity, time) FROM btest_numeric;
+:PREFIX SELECT last(quantity, time) FROM btest_numeric;
+:PREFIX SELECT first(time, quantity) FROM btest_numeric;
+:PREFIX SELECT last(time, quantity) FROM btest_numeric;
+-- NULL values followed by non-NULL values
+INSERT INTO btest_numeric VALUES('2019-01-20T09:00:43', 1);
+INSERT INTO btest_numeric VALUES('2019-01-20T09:00:43', 2);
+:PREFIX SELECT first(quantity, time) FROM btest_numeric;
+:PREFIX SELECT last(quantity, time) FROM btest_numeric;
+:PREFIX SELECT first(time, quantity) FROM btest_numeric;
+:PREFIX SELECT last(time, quantity) FROM btest_numeric;
+TRUNCATE btest_numeric;
+-- non-NULL values followed by NULL values
+INSERT INTO btest_numeric VALUES('2019-01-20T09:00:43', 1);
+INSERT INTO btest_numeric VALUES('2019-01-20T09:00:43', 2);
+INSERT INTO btest_numeric VALUES('2018-01-20T09:00:43', NULL);
+INSERT INTO btest_numeric VALUES('2018-01-20T09:00:43', NULL);
+:PREFIX SELECT first(quantity, time) FROM btest_numeric;
+:PREFIX SELECT last(quantity, time) FROM btest_numeric;
+:PREFIX SELECT first(time, quantity) FROM btest_numeric;
+:PREFIX SELECT last(time, quantity) FROM btest_numeric;
+ROLLBACK;
 \o
 \o :TEST_RESULTS_OPTIMIZED
 SET timescaledb.enable_optimizations TO true;
@@ -1165,6 +1456,37 @@ CREATE INDEX btest_time_alt_idx ON btest(time_alt);
 :PREFIX SELECT abs(last(temp, time)) FROM btest;
 -- test nested FIRST/LAST in ORDER BY - no optimization possible
 :PREFIX SELECT abs(last(temp, time)) FROM btest ORDER BY abs(last(temp,time));
+ROLLBACK;
+-- Test with NULL numeric values
+BEGIN;
+TRUNCATE btest_numeric;
+-- Empty table
+:PREFIX SELECT first(btest_numeric, time) FROM btest_numeric;
+:PREFIX SELECT last(btest_numeric, time) FROM btest_numeric;
+-- Only NULL values
+INSERT INTO btest_numeric VALUES('2018-01-20T09:00:43', NULL);
+INSERT INTO btest_numeric VALUES('2018-01-20T09:00:43', NULL);
+:PREFIX SELECT first(quantity, time) FROM btest_numeric;
+:PREFIX SELECT last(quantity, time) FROM btest_numeric;
+:PREFIX SELECT first(time, quantity) FROM btest_numeric;
+:PREFIX SELECT last(time, quantity) FROM btest_numeric;
+-- NULL values followed by non-NULL values
+INSERT INTO btest_numeric VALUES('2019-01-20T09:00:43', 1);
+INSERT INTO btest_numeric VALUES('2019-01-20T09:00:43', 2);
+:PREFIX SELECT first(quantity, time) FROM btest_numeric;
+:PREFIX SELECT last(quantity, time) FROM btest_numeric;
+:PREFIX SELECT first(time, quantity) FROM btest_numeric;
+:PREFIX SELECT last(time, quantity) FROM btest_numeric;
+TRUNCATE btest_numeric;
+-- non-NULL values followed by NULL values
+INSERT INTO btest_numeric VALUES('2019-01-20T09:00:43', 1);
+INSERT INTO btest_numeric VALUES('2019-01-20T09:00:43', 2);
+INSERT INTO btest_numeric VALUES('2018-01-20T09:00:43', NULL);
+INSERT INTO btest_numeric VALUES('2018-01-20T09:00:43', NULL);
+:PREFIX SELECT first(quantity, time) FROM btest_numeric;
+:PREFIX SELECT last(quantity, time) FROM btest_numeric;
+:PREFIX SELECT first(time, quantity) FROM btest_numeric;
+:PREFIX SELECT last(time, quantity) FROM btest_numeric;
 ROLLBACK;
 \o
 :DIFF_CMD

--- a/test/expected/agg_bookends-15.out
+++ b/test/expected/agg_bookends-15.out
@@ -677,6 +677,165 @@ CREATE INDEX btest_time_alt_idx ON btest(time_alt);
 (10 rows)
 
 ROLLBACK;
+-- Test with NULL numeric values
+BEGIN;
+TRUNCATE btest_numeric;
+-- Empty table
+:PREFIX SELECT first(btest_numeric, time) FROM btest_numeric;
+              QUERY PLAN              
+--------------------------------------
+ Aggregate (actual rows=1 loops=1)
+   ->  Result (actual rows=0 loops=1)
+         One-Time Filter: false
+(3 rows)
+
+:PREFIX SELECT last(btest_numeric, time) FROM btest_numeric;
+              QUERY PLAN              
+--------------------------------------
+ Aggregate (actual rows=1 loops=1)
+   ->  Result (actual rows=0 loops=1)
+         One-Time Filter: false
+(3 rows)
+
+-- Only NULL values
+INSERT INTO btest_numeric VALUES('2018-01-20T09:00:43', NULL);
+INSERT INTO btest_numeric VALUES('2018-01-20T09:00:43', NULL);
+:PREFIX SELECT first(quantity, time) FROM btest_numeric;
+                                                         QUERY PLAN                                                          
+-----------------------------------------------------------------------------------------------------------------------------
+ Result (actual rows=1 loops=1)
+   InitPlan 1 (returns $0)
+     ->  Limit (actual rows=1 loops=1)
+           ->  Index Scan Backward using _hyper_2_8_chunk_btest_numeric_time_idx on _hyper_2_8_chunk (actual rows=1 loops=1)
+                 Index Cond: ("time" IS NOT NULL)
+(5 rows)
+
+:PREFIX SELECT last(quantity, time) FROM btest_numeric;
+                                                     QUERY PLAN                                                     
+--------------------------------------------------------------------------------------------------------------------
+ Result (actual rows=1 loops=1)
+   InitPlan 1 (returns $0)
+     ->  Limit (actual rows=1 loops=1)
+           ->  Index Scan using _hyper_2_8_chunk_btest_numeric_time_idx on _hyper_2_8_chunk (actual rows=1 loops=1)
+                 Index Cond: ("time" IS NOT NULL)
+(5 rows)
+
+:PREFIX SELECT first(time, quantity) FROM btest_numeric;
+                         QUERY PLAN                         
+------------------------------------------------------------
+ Aggregate (actual rows=1 loops=1)
+   ->  Seq Scan on _hyper_2_8_chunk (actual rows=2 loops=1)
+(2 rows)
+
+:PREFIX SELECT last(time, quantity) FROM btest_numeric;
+                         QUERY PLAN                         
+------------------------------------------------------------
+ Aggregate (actual rows=1 loops=1)
+   ->  Seq Scan on _hyper_2_8_chunk (actual rows=2 loops=1)
+(2 rows)
+
+-- NULL values followed by non-NULL values
+INSERT INTO btest_numeric VALUES('2019-01-20T09:00:43', 1);
+INSERT INTO btest_numeric VALUES('2019-01-20T09:00:43', 2);
+:PREFIX SELECT first(quantity, time) FROM btest_numeric;
+                                                            QUERY PLAN                                                             
+-----------------------------------------------------------------------------------------------------------------------------------
+ Result (actual rows=1 loops=1)
+   InitPlan 1 (returns $0)
+     ->  Limit (actual rows=1 loops=1)
+           ->  Custom Scan (ChunkAppend) on btest_numeric (actual rows=1 loops=1)
+                 Order: btest_numeric."time"
+                 ->  Index Scan Backward using _hyper_2_8_chunk_btest_numeric_time_idx on _hyper_2_8_chunk (actual rows=1 loops=1)
+                       Index Cond: ("time" IS NOT NULL)
+                 ->  Index Scan Backward using _hyper_2_9_chunk_btest_numeric_time_idx on _hyper_2_9_chunk (never executed)
+                       Index Cond: ("time" IS NOT NULL)
+(9 rows)
+
+:PREFIX SELECT last(quantity, time) FROM btest_numeric;
+                                                        QUERY PLAN                                                        
+--------------------------------------------------------------------------------------------------------------------------
+ Result (actual rows=1 loops=1)
+   InitPlan 1 (returns $0)
+     ->  Limit (actual rows=1 loops=1)
+           ->  Custom Scan (ChunkAppend) on btest_numeric (actual rows=1 loops=1)
+                 Order: btest_numeric."time" DESC
+                 ->  Index Scan using _hyper_2_9_chunk_btest_numeric_time_idx on _hyper_2_9_chunk (actual rows=1 loops=1)
+                       Index Cond: ("time" IS NOT NULL)
+                 ->  Index Scan using _hyper_2_8_chunk_btest_numeric_time_idx on _hyper_2_8_chunk (never executed)
+                       Index Cond: ("time" IS NOT NULL)
+(9 rows)
+
+:PREFIX SELECT first(time, quantity) FROM btest_numeric;
+                            QUERY PLAN                            
+------------------------------------------------------------------
+ Aggregate (actual rows=1 loops=1)
+   ->  Append (actual rows=4 loops=1)
+         ->  Seq Scan on _hyper_2_8_chunk (actual rows=2 loops=1)
+         ->  Seq Scan on _hyper_2_9_chunk (actual rows=2 loops=1)
+(4 rows)
+
+:PREFIX SELECT last(time, quantity) FROM btest_numeric;
+                            QUERY PLAN                            
+------------------------------------------------------------------
+ Aggregate (actual rows=1 loops=1)
+   ->  Append (actual rows=4 loops=1)
+         ->  Seq Scan on _hyper_2_8_chunk (actual rows=2 loops=1)
+         ->  Seq Scan on _hyper_2_9_chunk (actual rows=2 loops=1)
+(4 rows)
+
+TRUNCATE btest_numeric;
+-- non-NULL values followed by NULL values
+INSERT INTO btest_numeric VALUES('2019-01-20T09:00:43', 1);
+INSERT INTO btest_numeric VALUES('2019-01-20T09:00:43', 2);
+INSERT INTO btest_numeric VALUES('2018-01-20T09:00:43', NULL);
+INSERT INTO btest_numeric VALUES('2018-01-20T09:00:43', NULL);
+:PREFIX SELECT first(quantity, time) FROM btest_numeric;
+                                                             QUERY PLAN                                                              
+-------------------------------------------------------------------------------------------------------------------------------------
+ Result (actual rows=1 loops=1)
+   InitPlan 1 (returns $0)
+     ->  Limit (actual rows=1 loops=1)
+           ->  Custom Scan (ChunkAppend) on btest_numeric (actual rows=1 loops=1)
+                 Order: btest_numeric."time"
+                 ->  Index Scan Backward using _hyper_2_11_chunk_btest_numeric_time_idx on _hyper_2_11_chunk (actual rows=1 loops=1)
+                       Index Cond: ("time" IS NOT NULL)
+                 ->  Index Scan Backward using _hyper_2_10_chunk_btest_numeric_time_idx on _hyper_2_10_chunk (never executed)
+                       Index Cond: ("time" IS NOT NULL)
+(9 rows)
+
+:PREFIX SELECT last(quantity, time) FROM btest_numeric;
+                                                         QUERY PLAN                                                         
+----------------------------------------------------------------------------------------------------------------------------
+ Result (actual rows=1 loops=1)
+   InitPlan 1 (returns $0)
+     ->  Limit (actual rows=1 loops=1)
+           ->  Custom Scan (ChunkAppend) on btest_numeric (actual rows=1 loops=1)
+                 Order: btest_numeric."time" DESC
+                 ->  Index Scan using _hyper_2_10_chunk_btest_numeric_time_idx on _hyper_2_10_chunk (actual rows=1 loops=1)
+                       Index Cond: ("time" IS NOT NULL)
+                 ->  Index Scan using _hyper_2_11_chunk_btest_numeric_time_idx on _hyper_2_11_chunk (never executed)
+                       Index Cond: ("time" IS NOT NULL)
+(9 rows)
+
+:PREFIX SELECT first(time, quantity) FROM btest_numeric;
+                            QUERY PLAN                             
+-------------------------------------------------------------------
+ Aggregate (actual rows=1 loops=1)
+   ->  Append (actual rows=4 loops=1)
+         ->  Seq Scan on _hyper_2_10_chunk (actual rows=2 loops=1)
+         ->  Seq Scan on _hyper_2_11_chunk (actual rows=2 loops=1)
+(4 rows)
+
+:PREFIX SELECT last(time, quantity) FROM btest_numeric;
+                            QUERY PLAN                             
+-------------------------------------------------------------------
+ Aggregate (actual rows=1 loops=1)
+   ->  Append (actual rows=4 loops=1)
+         ->  Seq Scan on _hyper_2_10_chunk (actual rows=2 loops=1)
+         ->  Seq Scan on _hyper_2_11_chunk (actual rows=2 loops=1)
+(4 rows)
+
+ROLLBACK;
 -- we want test results as part of the output too to make sure we produce correct output
 \set PREFIX ''
 \ir :TEST_QUERY_NAME
@@ -988,6 +1147,107 @@ CREATE INDEX btest_time_alt_idx ON btest(time_alt);
 (1 row)
 
 ROLLBACK;
+-- Test with NULL numeric values
+BEGIN;
+TRUNCATE btest_numeric;
+-- Empty table
+:PREFIX SELECT first(btest_numeric, time) FROM btest_numeric;
+ first 
+-------
+ 
+(1 row)
+
+:PREFIX SELECT last(btest_numeric, time) FROM btest_numeric;
+ last 
+------
+ 
+(1 row)
+
+-- Only NULL values
+INSERT INTO btest_numeric VALUES('2018-01-20T09:00:43', NULL);
+INSERT INTO btest_numeric VALUES('2018-01-20T09:00:43', NULL);
+:PREFIX SELECT first(quantity, time) FROM btest_numeric;
+ first 
+-------
+      
+(1 row)
+
+:PREFIX SELECT last(quantity, time) FROM btest_numeric;
+ last 
+------
+     
+(1 row)
+
+:PREFIX SELECT first(time, quantity) FROM btest_numeric;
+ first 
+-------
+ 
+(1 row)
+
+:PREFIX SELECT last(time, quantity) FROM btest_numeric;
+ last 
+------
+ 
+(1 row)
+
+-- NULL values followed by non-NULL values
+INSERT INTO btest_numeric VALUES('2019-01-20T09:00:43', 1);
+INSERT INTO btest_numeric VALUES('2019-01-20T09:00:43', 2);
+:PREFIX SELECT first(quantity, time) FROM btest_numeric;
+ first 
+-------
+      
+(1 row)
+
+:PREFIX SELECT last(quantity, time) FROM btest_numeric;
+ last 
+------
+    1
+(1 row)
+
+:PREFIX SELECT first(time, quantity) FROM btest_numeric;
+          first           
+--------------------------
+ Sun Jan 20 09:00:43 2019
+(1 row)
+
+:PREFIX SELECT last(time, quantity) FROM btest_numeric;
+           last           
+--------------------------
+ Sun Jan 20 09:00:43 2019
+(1 row)
+
+TRUNCATE btest_numeric;
+-- non-NULL values followed by NULL values
+INSERT INTO btest_numeric VALUES('2019-01-20T09:00:43', 1);
+INSERT INTO btest_numeric VALUES('2019-01-20T09:00:43', 2);
+INSERT INTO btest_numeric VALUES('2018-01-20T09:00:43', NULL);
+INSERT INTO btest_numeric VALUES('2018-01-20T09:00:43', NULL);
+:PREFIX SELECT first(quantity, time) FROM btest_numeric;
+ first 
+-------
+      
+(1 row)
+
+:PREFIX SELECT last(quantity, time) FROM btest_numeric;
+ last 
+------
+    1
+(1 row)
+
+:PREFIX SELECT first(time, quantity) FROM btest_numeric;
+          first           
+--------------------------
+ Sun Jan 20 09:00:43 2019
+(1 row)
+
+:PREFIX SELECT last(time, quantity) FROM btest_numeric;
+           last           
+--------------------------
+ Sun Jan 20 09:00:43 2019
+(1 row)
+
+ROLLBACK;
 -- diff results with optimizations disabled and enabled
 \o :TEST_RESULTS_UNOPTIMIZED
 SET timescaledb.enable_optimizations TO false;
@@ -1077,6 +1337,37 @@ CREATE INDEX btest_time_alt_idx ON btest(time_alt);
 -- test nested FIRST/LAST in ORDER BY - no optimization possible
 :PREFIX SELECT abs(last(temp, time)) FROM btest ORDER BY abs(last(temp,time));
 ROLLBACK;
+-- Test with NULL numeric values
+BEGIN;
+TRUNCATE btest_numeric;
+-- Empty table
+:PREFIX SELECT first(btest_numeric, time) FROM btest_numeric;
+:PREFIX SELECT last(btest_numeric, time) FROM btest_numeric;
+-- Only NULL values
+INSERT INTO btest_numeric VALUES('2018-01-20T09:00:43', NULL);
+INSERT INTO btest_numeric VALUES('2018-01-20T09:00:43', NULL);
+:PREFIX SELECT first(quantity, time) FROM btest_numeric;
+:PREFIX SELECT last(quantity, time) FROM btest_numeric;
+:PREFIX SELECT first(time, quantity) FROM btest_numeric;
+:PREFIX SELECT last(time, quantity) FROM btest_numeric;
+-- NULL values followed by non-NULL values
+INSERT INTO btest_numeric VALUES('2019-01-20T09:00:43', 1);
+INSERT INTO btest_numeric VALUES('2019-01-20T09:00:43', 2);
+:PREFIX SELECT first(quantity, time) FROM btest_numeric;
+:PREFIX SELECT last(quantity, time) FROM btest_numeric;
+:PREFIX SELECT first(time, quantity) FROM btest_numeric;
+:PREFIX SELECT last(time, quantity) FROM btest_numeric;
+TRUNCATE btest_numeric;
+-- non-NULL values followed by NULL values
+INSERT INTO btest_numeric VALUES('2019-01-20T09:00:43', 1);
+INSERT INTO btest_numeric VALUES('2019-01-20T09:00:43', 2);
+INSERT INTO btest_numeric VALUES('2018-01-20T09:00:43', NULL);
+INSERT INTO btest_numeric VALUES('2018-01-20T09:00:43', NULL);
+:PREFIX SELECT first(quantity, time) FROM btest_numeric;
+:PREFIX SELECT last(quantity, time) FROM btest_numeric;
+:PREFIX SELECT first(time, quantity) FROM btest_numeric;
+:PREFIX SELECT last(time, quantity) FROM btest_numeric;
+ROLLBACK;
 \o
 \o :TEST_RESULTS_OPTIMIZED
 SET timescaledb.enable_optimizations TO true;
@@ -1165,6 +1456,37 @@ CREATE INDEX btest_time_alt_idx ON btest(time_alt);
 :PREFIX SELECT abs(last(temp, time)) FROM btest;
 -- test nested FIRST/LAST in ORDER BY - no optimization possible
 :PREFIX SELECT abs(last(temp, time)) FROM btest ORDER BY abs(last(temp,time));
+ROLLBACK;
+-- Test with NULL numeric values
+BEGIN;
+TRUNCATE btest_numeric;
+-- Empty table
+:PREFIX SELECT first(btest_numeric, time) FROM btest_numeric;
+:PREFIX SELECT last(btest_numeric, time) FROM btest_numeric;
+-- Only NULL values
+INSERT INTO btest_numeric VALUES('2018-01-20T09:00:43', NULL);
+INSERT INTO btest_numeric VALUES('2018-01-20T09:00:43', NULL);
+:PREFIX SELECT first(quantity, time) FROM btest_numeric;
+:PREFIX SELECT last(quantity, time) FROM btest_numeric;
+:PREFIX SELECT first(time, quantity) FROM btest_numeric;
+:PREFIX SELECT last(time, quantity) FROM btest_numeric;
+-- NULL values followed by non-NULL values
+INSERT INTO btest_numeric VALUES('2019-01-20T09:00:43', 1);
+INSERT INTO btest_numeric VALUES('2019-01-20T09:00:43', 2);
+:PREFIX SELECT first(quantity, time) FROM btest_numeric;
+:PREFIX SELECT last(quantity, time) FROM btest_numeric;
+:PREFIX SELECT first(time, quantity) FROM btest_numeric;
+:PREFIX SELECT last(time, quantity) FROM btest_numeric;
+TRUNCATE btest_numeric;
+-- non-NULL values followed by NULL values
+INSERT INTO btest_numeric VALUES('2019-01-20T09:00:43', 1);
+INSERT INTO btest_numeric VALUES('2019-01-20T09:00:43', 2);
+INSERT INTO btest_numeric VALUES('2018-01-20T09:00:43', NULL);
+INSERT INTO btest_numeric VALUES('2018-01-20T09:00:43', NULL);
+:PREFIX SELECT first(quantity, time) FROM btest_numeric;
+:PREFIX SELECT last(quantity, time) FROM btest_numeric;
+:PREFIX SELECT first(time, quantity) FROM btest_numeric;
+:PREFIX SELECT last(time, quantity) FROM btest_numeric;
 ROLLBACK;
 \o
 :DIFF_CMD

--- a/test/sql/include/agg_bookends_query.sql
+++ b/test/sql/include/agg_bookends_query.sql
@@ -118,3 +118,40 @@ CREATE INDEX btest_time_alt_idx ON btest(time_alt);
 
 ROLLBACK;
 
+-- Test with NULL numeric values
+BEGIN;
+TRUNCATE btest_numeric;
+
+-- Empty table
+:PREFIX SELECT first(btest_numeric, time) FROM btest_numeric;
+:PREFIX SELECT last(btest_numeric, time) FROM btest_numeric;
+
+-- Only NULL values
+INSERT INTO btest_numeric VALUES('2018-01-20T09:00:43', NULL);
+INSERT INTO btest_numeric VALUES('2018-01-20T09:00:43', NULL);
+:PREFIX SELECT first(quantity, time) FROM btest_numeric;
+:PREFIX SELECT last(quantity, time) FROM btest_numeric;
+:PREFIX SELECT first(time, quantity) FROM btest_numeric;
+:PREFIX SELECT last(time, quantity) FROM btest_numeric;
+
+-- NULL values followed by non-NULL values
+INSERT INTO btest_numeric VALUES('2019-01-20T09:00:43', 1);
+INSERT INTO btest_numeric VALUES('2019-01-20T09:00:43', 2);
+:PREFIX SELECT first(quantity, time) FROM btest_numeric;
+:PREFIX SELECT last(quantity, time) FROM btest_numeric;
+:PREFIX SELECT first(time, quantity) FROM btest_numeric;
+:PREFIX SELECT last(time, quantity) FROM btest_numeric;
+
+TRUNCATE btest_numeric;
+
+-- non-NULL values followed by NULL values
+INSERT INTO btest_numeric VALUES('2019-01-20T09:00:43', 1);
+INSERT INTO btest_numeric VALUES('2019-01-20T09:00:43', 2);
+INSERT INTO btest_numeric VALUES('2018-01-20T09:00:43', NULL);
+INSERT INTO btest_numeric VALUES('2018-01-20T09:00:43', NULL);
+:PREFIX SELECT first(quantity, time) FROM btest_numeric;
+:PREFIX SELECT last(quantity, time) FROM btest_numeric;
+:PREFIX SELECT first(time, quantity) FROM btest_numeric;
+:PREFIX SELECT last(time, quantity) FROM btest_numeric;
+
+ROLLBACK;


### PR DESCRIPTION
In the function `bookend_sfunc` values are compared. If the first processed value is a `NULL` value, it was copied into the state of the sfunc. A following comparison between the NULL value of the state and a non-NULL value could lead to a crash.

This patch improves the handling of NULL values in bookend_sfunc.