### PR TITLE
Fix issues with scripts/test_update_smoke.sh

### DIFF
--- a/test/sql/updates/cleanup.multinode.sql
+++ b/test/sql/updates/cleanup.multinode.sql
@@ -3,4 +3,5 @@
 -- LICENSE-APACHE for a copy of the license.
 
 DROP TABLE disthyper;
-SELECT drop_data_node('dn1');
+SELECT delete_data_node('dn1');
+drop database if exists dn1;


### PR DESCRIPTION
The test was failing on first run by leaving a database behind as a sideeffect.
Between two steps the extension was dropped; without a proper cleanup. A non-existent sql function was called during cleanup.

This patch also removes the "debug mode" and every execution will leave the logs/etc in the /tmp directory for further inspection.

Disable-check: force-changelog-file