### PR TITLE
Small improvements of bulk decompression

### DIFF
--- a/.github/workflows/libfuzzer.yaml
+++ b/.github/workflows/libfuzzer.yaml
@@ -1,5 +1,8 @@
 name: Libfuzzer
 "on":
+  schedule:
+    # run daily 1:00 on main branch
+    - cron: '0 1 * * *'
   push:
     branches:
       - main

--- a/src/adts/bit_array_impl.h
+++ b/src/adts/bit_array_impl.h
@@ -112,21 +112,12 @@ bit_array_recv(const StringInfo buffer)
 			.num_elements = num_elements,
 			.max_elements = num_elements,
 			.ctx = CurrentMemoryContext,
-			/* Add one-element padding so that we can relax the checks for incorrect data. */
-			.data = palloc((num_elements + 1) * sizeof(uint64)),
+			.data = palloc(num_elements * sizeof(uint64)),
 		},
 	};
 
 	for (i = 0; i < num_elements; i++)
 		array.buckets.data[i] = pq_getmsgint64(buffer);
-
-	/* Zero out the padding for more predictable behavior under fuzzing. */
-	array.buckets.data[num_elements] = 0;
-	if (num_elements > 0)
-	{
-		CheckCompressedData(bits_used_in_last_bucket > 0);
-		array.buckets.data[num_elements - 1] &= -1ULL >> (64 - bits_used_in_last_bucket);
-	}
 
 	return array;
 }
@@ -249,15 +240,11 @@ bit_array_iter_next(BitArrayIterator *iter, uint8 num_bits)
 	uint8 num_bits_from_next_bucket;
 	uint64 value = 0;
 	uint64 value_from_next_bucket;
-	Assert(num_bits <= 64);
+	CheckCompressedData(num_bits <= 64);
 	if (num_bits == 0)
 		return 0;
 
 	CheckCompressedData(iter->current_bucket < iter->array->buckets.num_elements);
-	if (iter->current_bucket == iter->array->buckets.num_elements - 1)
-	{
-		Assert(iter->bits_used_in_current_bucket <= iter->array->bits_used_in_last_bucket);
-	}
 
 	bits_remaining_in_current_bucket = 64 - iter->bits_used_in_current_bucket;
 	if (bits_remaining_in_current_bucket >= num_bits)
@@ -267,11 +254,6 @@ bit_array_iter_next(BitArrayIterator *iter, uint8 num_bits)
 		value &= bit_array_low_bits_mask(num_bits);
 		iter->bits_used_in_current_bucket += num_bits;
 
-		if (iter->current_bucket == iter->array->buckets.num_elements - 1)
-		{
-			CheckCompressedData(iter->bits_used_in_current_bucket <=
-								iter->array->bits_used_in_last_bucket);
-		}
 		return value;
 	}
 
@@ -293,11 +275,6 @@ bit_array_iter_next(BitArrayIterator *iter, uint8 num_bits)
 	iter->current_bucket += 1;
 	iter->bits_used_in_current_bucket = num_bits_from_next_bucket;
 
-	if (iter->current_bucket == iter->array->buckets.num_elements - 1)
-	{
-		CheckCompressedData(iter->bits_used_in_current_bucket <=
-							iter->array->bits_used_in_last_bucket);
-	}
 	return value;
 }
 

--- a/tsl/src/compression/arrow_c_data_interface.h
+++ b/tsl/src/compression/arrow_c_data_interface.h
@@ -109,7 +109,7 @@ typedef struct ArrowArray
 
 /*
  * We don't use the schema but have to define it for completeness because we're
- * defining ARROW_C_DATA_INTERFACE macro.
+ * defining the ARROW_C_DATA_INTERFACE macro.
  */
 struct ArrowSchema
 {
@@ -135,22 +135,22 @@ struct ArrowSchema
 #endif
 
 static pg_attribute_always_inline bool
-arrow_row_is_valid(const uint64 *bitmap, int row_number)
+arrow_row_is_valid(const uint64 *bitmap, size_t row_number)
 {
-	const int qword_index = row_number / 64;
-	const int bit_index = row_number % 64;
+	const size_t qword_index = row_number / 64;
+	const size_t bit_index = row_number % 64;
 	const uint64 mask = 1ull << bit_index;
-	return (bitmap[qword_index] & mask) ? 1 : 0;
+	return bitmap[qword_index] & mask;
 }
 
 static pg_attribute_always_inline void
-arrow_set_row_validity(uint64 *bitmap, int row_number, bool value)
+arrow_set_row_validity(uint64 *bitmap, size_t row_number, bool value)
 {
-	const int qword_index = row_number / 64;
-	const int bit_index = row_number % 64;
+	const size_t qword_index = row_number / 64;
+	const size_t bit_index = row_number % 64;
 	const uint64 mask = 1ull << bit_index;
 
-	bitmap[qword_index] = (bitmap[qword_index] & ~mask) | (((uint64) !!value) << bit_index);
+	bitmap[qword_index] = (bitmap[qword_index] & ~mask) | ((-(uint64) value) & mask);
 
 	Assert(arrow_row_is_valid(bitmap, row_number) == value);
 }

--- a/tsl/src/compression/compression.c
+++ b/tsl/src/compression/compression.c
@@ -90,18 +90,13 @@ DecompressionIterator *(*tsl_get_decompression_iterator_init(CompressionAlgorith
 		return definitions[algorithm].iterator_init_forward;
 }
 
-ArrowArray *
-tsl_try_decompress_all(CompressionAlgorithms algorithm, Datum compressed_data, Oid element_type)
+DecompressAllFunction
+tsl_get_decompress_all_function(CompressionAlgorithms algorithm)
 {
 	if (algorithm >= _END_COMPRESSION_ALGORITHMS)
 		elog(ERROR, "invalid compression algorithm %d", algorithm);
 
-	if (definitions[algorithm].decompress_all)
-	{
-		return definitions[algorithm].decompress_all(compressed_data, element_type);
-	}
-
-	return NULL;
+	return definitions[algorithm].decompress_all;
 }
 
 static Tuplesortstate *compress_chunk_sort_relation(Relation in_rel, int n_keys,

--- a/tsl/src/compression/compression.h
+++ b/tsl/src/compression/compression.h
@@ -164,11 +164,14 @@ typedef enum
 	TOAST_STORAGE_EXTENDED
 } CompressionStorage;
 
+typedef ArrowArray *(*DecompressAllFunction)(Datum compressed, Oid element_type,
+											 MemoryContext dest_mctx);
+
 typedef struct CompressionAlgorithmDefinition
 {
 	DecompressionIterator *(*iterator_init_forward)(Datum, Oid element_type);
 	DecompressionIterator *(*iterator_init_reverse)(Datum, Oid element_type);
-	ArrowArray *(*decompress_all)(Datum, Oid element_type);
+	DecompressAllFunction decompress_all;
 	void (*compressed_data_send)(CompressedDataHeader *, StringInfo);
 	Datum (*compressed_data_recv)(StringInfo);
 
@@ -313,8 +316,7 @@ extern void decompress_chunk(Oid in_table, Oid out_table);
 extern DecompressionIterator *(*tsl_get_decompression_iterator_init(
 	CompressionAlgorithms algorithm, bool reverse))(Datum, Oid element_type);
 
-extern ArrowArray *tsl_try_decompress_all(CompressionAlgorithms algorithm, Datum compressed_data,
-										  Oid element_type);
+extern DecompressAllFunction tsl_get_decompress_all_function(CompressionAlgorithms algorithm);
 
 typedef struct Chunk Chunk;
 typedef struct ChunkInsertState ChunkInsertState;
@@ -373,7 +375,7 @@ extern RowDecompressor build_decompressor(Relation in_rel, Relation out_rel);
 #endif
 
 #define CheckCompressedData(X)                                                                     \
-	if (!(X))                                                                                      \
+	if (unlikely(!(X)))                                                                            \
 	ereport(ERROR, CORRUPT_DATA_MESSAGE)
 
 inline static void *

--- a/tsl/src/compression/deltadelta.c
+++ b/tsl/src/compression/deltadelta.c
@@ -588,19 +588,19 @@ delta_delta_decompression_iterator_try_next_forward(DecompressionIterator *iter)
 #undef ELEMENT_TYPE
 
 ArrowArray *
-delta_delta_decompress_all(Datum compressed_data, Oid element_type)
+delta_delta_decompress_all(Datum compressed_data, Oid element_type, MemoryContext dest_mctx)
 {
 	switch (element_type)
 	{
 		case INT8OID:
 		case TIMESTAMPOID:
 		case TIMESTAMPTZOID:
-			return delta_delta_decompress_all_uint64(compressed_data);
+			return delta_delta_decompress_all_uint64(compressed_data, dest_mctx);
 		case INT4OID:
 		case DATEOID:
-			return delta_delta_decompress_all_uint32(compressed_data);
+			return delta_delta_decompress_all_uint32(compressed_data, dest_mctx);
 		case INT2OID:
-			return delta_delta_decompress_all_uint16(compressed_data);
+			return delta_delta_decompress_all_uint16(compressed_data, dest_mctx);
 		default:
 			elog(ERROR,
 				 "type '%s' is not supported for deltadelta decompression",

--- a/tsl/src/compression/deltadelta.h
+++ b/tsl/src/compression/deltadelta.h
@@ -43,7 +43,8 @@ delta_delta_decompression_iterator_from_datum_reverse(Datum deltadelta_compresse
 extern DecompressResult
 delta_delta_decompression_iterator_try_next_forward(DecompressionIterator *iter);
 
-extern ArrowArray *delta_delta_decompress_all(Datum compressed_data, Oid element_type);
+extern ArrowArray *delta_delta_decompress_all(Datum compressed_data, Oid element_type,
+											  MemoryContext dest_mctx);
 
 extern DecompressResult
 delta_delta_decompression_iterator_try_next_reverse(DecompressionIterator *iter);

--- a/tsl/src/compression/gorilla.c
+++ b/tsl/src/compression/gorilla.c
@@ -826,13 +826,15 @@ gorilla_decompression_iterator_try_next_reverse(DecompressionIterator *iter_base
 								 iter_base->element_type);
 }
 
-#define MAX_NUM_LEADING_ZEROS_PADDED (((GLOBAL_MAX_ROWS_PER_COMPRESSION + 63) / 64) * 64)
+#define MAX_NUM_LEADING_ZEROS_PADDED_N64 (((GLOBAL_MAX_ROWS_PER_COMPRESSION + 63) / 64) * 64)
+
+int16 unpack_leading_zeros_array(BitArray *bitarray, uint8 *restrict dest);
 
 /*
  * Decompress packed 6bit values in lanes that contain a round number of both
  * packed and unpacked bytes -- 4 6-bit values are packed into 3 8-bit values.
  */
-pg_attribute_always_inline static int16
+int16
 unpack_leading_zeros_array(BitArray *bitarray, uint8 *restrict dest)
 {
 #define LANE_INPUTS 3
@@ -851,7 +853,7 @@ unpack_leading_zeros_array(BitArray *bitarray, uint8 *restrict dest)
 	const int16 n_bytes_packed = bitarray->buckets.num_elements * sizeof(uint64);
 	const int16 n_lanes = (n_bytes_packed + LANE_INPUTS - 1) / LANE_INPUTS;
 	const int16 n_outputs = n_lanes * LANE_OUTPUTS;
-	CheckCompressedData(n_outputs <= MAX_NUM_LEADING_ZEROS_PADDED);
+	CheckCompressedData(n_outputs <= MAX_NUM_LEADING_ZEROS_PADDED_N64);
 
 	for (int lane = 0; lane < n_lanes; lane++)
 	{
@@ -894,7 +896,7 @@ unpack_leading_zeros_array(BitArray *bitarray, uint8 *restrict dest)
 #undef ELEMENT_TYPE
 
 ArrowArray *
-gorilla_decompress_all(Datum datum, Oid element_type)
+gorilla_decompress_all(Datum datum, Oid element_type, MemoryContext dest_mctx)
 {
 	CompressedGorillaData gorilla_data;
 	compressed_gorilla_data_init_from_datum(&gorilla_data, datum);
@@ -902,9 +904,9 @@ gorilla_decompress_all(Datum datum, Oid element_type)
 	switch (element_type)
 	{
 		case FLOAT8OID:
-			return gorilla_decompress_all_uint64(&gorilla_data);
+			return gorilla_decompress_all_uint64(&gorilla_data, dest_mctx);
 		case FLOAT4OID:
-			return gorilla_decompress_all_uint32(&gorilla_data);
+			return gorilla_decompress_all_uint32(&gorilla_data, dest_mctx);
 		default:
 			elog(ERROR,
 				 "type '%s' is not supported for gorilla decompression",

--- a/tsl/src/compression/gorilla.h
+++ b/tsl/src/compression/gorilla.h
@@ -87,7 +87,7 @@ extern DecompressionIterator *
 gorilla_decompression_iterator_from_datum_reverse(Datum gorilla_compressed, Oid element_type);
 extern DecompressResult
 gorilla_decompression_iterator_try_next_reverse(DecompressionIterator *iter);
-extern ArrowArray *gorilla_decompress_all(Datum datum, Oid element_type);
+extern ArrowArray *gorilla_decompress_all(Datum datum, Oid element_type, MemoryContext dest_mctx);
 
 extern void gorilla_compressed_send(CompressedDataHeader *header, StringInfo buffer);
 extern Datum gorilla_compressed_recv(StringInfo buf);

--- a/tsl/src/compression/simple8b_rle_bitmap.h
+++ b/tsl/src/compression/simple8b_rle_bitmap.h
@@ -15,20 +15,27 @@
 
 typedef struct Simple8bRleBitmap
 {
-	char *bitmap_bools_;
-	int16 num_elements;
-	int16 num_ones;
+	/* Either the bools or prefix sums, depending on the decompression method. */
+	void *data;
+
+	uint16 num_elements;
+	uint16 num_ones;
 } Simple8bRleBitmap;
 
 pg_attribute_always_inline static bool
-simple8brle_bitmap_get_at(Simple8bRleBitmap *bitmap, int i)
+simple8brle_bitmap_get_at(Simple8bRleBitmap *bitmap, uint16 i)
 {
-	Assert(i >= 0);
-
 	/* We have some padding on the right but we shouldn't overrun it. */
 	Assert(i < ((bitmap->num_elements + 63) / 64 + 1) * 64);
 
-	return bitmap->bitmap_bools_[i];
+	return ((bool *restrict) bitmap->data)[i];
+}
+
+pg_attribute_always_inline static uint16
+simple8brle_bitmap_prefix_sum(Simple8bRleBitmap *bitmap, uint16 i)
+{
+	Assert(i < ((bitmap->num_elements + 63) / 64 + 1) * 64);
+	return ((uint16 *restrict) bitmap->data)[i];
 }
 
 pg_attribute_always_inline static uint16
@@ -37,19 +44,23 @@ simple8brle_bitmap_num_ones(Simple8bRleBitmap *bitmap)
 	return bitmap->num_ones;
 }
 
-static Simple8bRleBitmap
-simple8brle_bitmap_decompress(Simple8bRleSerialized *compressed)
-{
-	Simple8bRleBitmap result;
-	result.num_elements = compressed->num_elements;
+/*
+ * Calculate prefix sum of bits instead of bitmap itself, because it's more
+ * useful for gorilla decompression. Can be unused by other users of this
+ * header.
+ */
+static Simple8bRleBitmap simple8brle_bitmap_prefixsums(Simple8bRleSerialized *compressed)
+	pg_attribute_unused();
 
+static Simple8bRleBitmap
+simple8brle_bitmap_prefixsums(Simple8bRleSerialized *compressed)
+{
 	CheckCompressedData(compressed->num_elements <= GLOBAL_MAX_ROWS_PER_COMPRESSION);
 	CheckCompressedData(compressed->num_blocks <= GLOBAL_MAX_ROWS_PER_COMPRESSION);
 
-	const int16 num_elements = compressed->num_elements;
-	int16 num_ones = 0;
+	const uint16 num_elements = compressed->num_elements;
 
-	const int16 num_selector_slots =
+	const uint16 num_selector_slots =
 		simple8brle_num_selector_slots_for_num_blocks(compressed->num_blocks);
 	const uint64 *compressed_data = compressed->slots + num_selector_slots;
 
@@ -58,15 +69,17 @@ simple8brle_bitmap_decompress(Simple8bRleSerialized *compressed)
 	 * decompression loop and the get() function. Note that for get() we need at
 	 * least one byte of padding, hence the next multiple.
 	 */
-	const int16 num_elements_padded = ((num_elements + 63) / 64 + 1) * 64;
-	const int16 num_blocks = compressed->num_blocks;
+	const uint16 num_elements_padded = ((num_elements + 63) / 64 + 1) * 64;
+	const uint16 num_blocks = compressed->num_blocks;
 
-	char *restrict bitmap_bools_ = palloc(num_elements_padded);
-	int16 decompressed_index = 0;
-	for (int16 block_index = 0; block_index < num_blocks; block_index++)
+	uint16 *restrict prefix_sums = palloc(sizeof(uint16) * num_elements_padded);
+
+	uint16 current_prefix_sum = 0;
+	uint16 decompressed_index = 0;
+	for (uint16 block_index = 0; block_index < num_blocks; block_index++)
 	{
-		const int selector_slot = block_index / SIMPLE8B_SELECTORS_PER_SELECTOR_SLOT;
-		const int selector_pos_in_slot = block_index % SIMPLE8B_SELECTORS_PER_SELECTOR_SLOT;
+		const uint16 selector_slot = block_index / SIMPLE8B_SELECTORS_PER_SELECTOR_SLOT;
+		const uint16 selector_pos_in_slot = block_index % SIMPLE8B_SELECTORS_PER_SELECTOR_SLOT;
 		const uint64 slot_value = compressed->slots[selector_slot];
 		const uint8 selector_shift = selector_pos_in_slot * SIMPLE8B_BITS_PER_SELECTOR;
 		const uint64 selector_mask = 0xFULL << selector_shift;
@@ -80,38 +93,31 @@ simple8brle_bitmap_decompress(Simple8bRleSerialized *compressed)
 			/*
 			 * RLE block.
 			 */
-			const int32 n_block_values = simple8brle_rledata_repeatcount(block_data);
+			const size_t n_block_values = simple8brle_rledata_repeatcount(block_data);
 			CheckCompressedData(n_block_values <= GLOBAL_MAX_ROWS_PER_COMPRESSION);
 
-			const uint8 repeated_value = simple8brle_rledata_value(block_data);
-			CheckCompressedData(repeated_value <= 1);
+			const bool repeated_value = simple8brle_rledata_value(block_data);
 
 			CheckCompressedData(decompressed_index + n_block_values <= num_elements);
 
-			/*
-			 * If we see an RLE-encoded block in bitmap, this means we had more
-			 * than 64 consecutive bits, otherwise it would be inefficient to
-			 * use RLE. Work in batches of 64 values and then process the tail
-			 * separately. This affects performance on some synthetic data sets.
-			 */
-			const int16 full_qword_values = (n_block_values / 64) * 64;
-			for (int16 outer = 0; outer < full_qword_values; outer += 64)
+			if (repeated_value)
 			{
-				for (int16 inner = 0; inner < 64; inner++)
+				for (uint16 i = 0; i < n_block_values; i++)
 				{
-					bitmap_bools_[decompressed_index + outer + inner] = repeated_value;
+					prefix_sums[decompressed_index + i] = current_prefix_sum + i + 1;
 				}
+				current_prefix_sum += n_block_values;
 			}
-
-			for (int16 i = 0; i < n_block_values - full_qword_values; i++)
+			else
 			{
-				bitmap_bools_[decompressed_index + full_qword_values + i] = repeated_value;
+				for (uint16 i = 0; i < n_block_values; i++)
+				{
+					prefix_sums[decompressed_index + i] = current_prefix_sum;
+				}
 			}
 
 			decompressed_index += n_block_values;
 			Assert(decompressed_index <= num_elements);
-
-			num_ones += repeated_value * n_block_values;
 		}
 		else
 		{
@@ -126,15 +132,171 @@ simple8brle_bitmap_decompress(Simple8bRleSerialized *compressed)
 			Assert(SIMPLE8B_BIT_LENGTH[selector_value] == 1);
 			Assert(SIMPLE8B_NUM_ELEMENTS[selector_value] == 64);
 
-			/* Have to zero out the unused bits, so that the popcnt works properly. */
-			const int elements_this_block = Min(64, num_elements - decompressed_index);
-			Assert(elements_this_block <= 64);
 			/*
 			 * We should require at least one element from the block. Previous
 			 * blocks might have had incorrect lengths, so this is not an
 			 * assertion.
 			 */
-			CheckCompressedData(elements_this_block > 0);
+			CheckCompressedData(decompressed_index < num_elements);
+
+			/* Have to zero out the unused bits, so that the popcnt works properly. */
+			const int elements_this_block = Min(64, num_elements - decompressed_index);
+			Assert(elements_this_block <= 64);
+			Assert(elements_this_block > 0);
+			block_data &= (-1ULL) >> (64 - elements_this_block);
+
+			/*
+			 * The number of block elements should fit within padding. Previous
+			 * blocks might have had incorrect lengths, so this is not an
+			 * assertion.
+			 */
+			CheckCompressedData(decompressed_index + 64 < num_elements_padded);
+
+#ifdef HAVE__BUILTIN_POPCOUNT
+			for (uint16 i = 0; i < 64; i++)
+			{
+				const uint16 word_prefix_sum =
+					__builtin_popcountll(block_data & (-1ULL >> (63 - i)));
+				prefix_sums[decompressed_index + i] = current_prefix_sum + word_prefix_sum;
+			}
+			current_prefix_sum += __builtin_popcountll(block_data);
+#else
+			/*
+			 * Unfortunatly, we have to have this fallback for Windows.
+			 */
+			for (uint16 i = 0; i < 64; i++)
+			{
+				const bool this_bit = (block_data >> i) & 1;
+				current_prefix_sum += this_bit;
+				prefix_sums[decompressed_index + i] = current_prefix_sum;
+			}
+#endif
+			decompressed_index += 64;
+		}
+	}
+
+	/*
+	 * We might have unpacked more because we work in full blocks, but at least
+	 * we shouldn't have unpacked less.
+	 */
+	CheckCompressedData(decompressed_index >= num_elements);
+	Assert(decompressed_index <= num_elements_padded);
+
+	/*
+	 * Might happen if we have stray ones in the higher unused bits of the last
+	 * block.
+	 */
+	CheckCompressedData(current_prefix_sum <= num_elements);
+
+	Simple8bRleBitmap result = {
+		.data = prefix_sums,
+		.num_elements = num_elements,
+		.num_ones = current_prefix_sum,
+	};
+
+	return result;
+}
+
+static Simple8bRleBitmap
+simple8brle_bitmap_decompress(Simple8bRleSerialized *compressed)
+{
+	CheckCompressedData(compressed->num_elements <= GLOBAL_MAX_ROWS_PER_COMPRESSION);
+	CheckCompressedData(compressed->num_blocks <= GLOBAL_MAX_ROWS_PER_COMPRESSION);
+
+	const uint16 num_elements = compressed->num_elements;
+	uint16 num_ones = 0;
+
+	const uint16 num_selector_slots =
+		simple8brle_num_selector_slots_for_num_blocks(compressed->num_blocks);
+	const uint64 *compressed_data = compressed->slots + num_selector_slots;
+
+	/*
+	 * Pad to next multiple of 64 bytes on the right, so that we can simplify the
+	 * decompression loop and the get() function. Note that for get() we need at
+	 * least one byte of padding, hence the next multiple.
+	 */
+	const uint16 num_elements_padded = ((num_elements + 63) / 64 + 1) * 64;
+	const uint16 num_blocks = compressed->num_blocks;
+
+	bool *restrict bitmap_bools_ = palloc(sizeof(bool) * num_elements_padded);
+	uint16 decompressed_index = 0;
+	for (uint16 block_index = 0; block_index < num_blocks; block_index++)
+	{
+		const uint16 selector_slot = block_index / SIMPLE8B_SELECTORS_PER_SELECTOR_SLOT;
+		const uint16 selector_pos_in_slot = block_index % SIMPLE8B_SELECTORS_PER_SELECTOR_SLOT;
+		const uint64 slot_value = compressed->slots[selector_slot];
+		const uint8 selector_shift = selector_pos_in_slot * SIMPLE8B_BITS_PER_SELECTOR;
+		const uint64 selector_mask = 0xFULL << selector_shift;
+		const uint8 selector_value = (slot_value & selector_mask) >> selector_shift;
+		Assert(selector_value < 16);
+
+		uint64 block_data = compressed_data[block_index];
+
+		if (simple8brle_selector_is_rle(selector_value))
+		{
+			/*
+			 * RLE block.
+			 */
+			const uint16 n_block_values = simple8brle_rledata_repeatcount(block_data);
+			CheckCompressedData(n_block_values <= GLOBAL_MAX_ROWS_PER_COMPRESSION);
+
+			/*
+			 * We might get an incorrect value from the corrupt data. Explicitly
+			 * truncate it to 0/1 in case the bool is not a standard bool type
+			 * which would have done it for us.
+			 */
+			const bool repeated_value = simple8brle_rledata_value(block_data) & 1;
+
+			CheckCompressedData(decompressed_index + n_block_values <= num_elements);
+
+			/*
+			 * Write out the loop for both true and false, so that it becomes a
+			 * simple memset.
+			 */
+			if (repeated_value)
+			{
+				for (uint16 i = 0; i < n_block_values; i++)
+				{
+					bitmap_bools_[decompressed_index + i] = true;
+				}
+
+				num_ones += n_block_values;
+			}
+			else
+			{
+				for (uint16 i = 0; i < n_block_values; i++)
+				{
+					bitmap_bools_[decompressed_index + i] = false;
+				}
+			}
+
+			decompressed_index += n_block_values;
+			Assert(decompressed_index <= num_elements);
+		}
+		else
+		{
+			/*
+			 * Bit-packed block. Since this is a bitmap, this block has 64 bits
+			 * packed. The last block might contain less than maximal possible
+			 * number of elements, but we have 64 bytes of padding on the right
+			 * so we don't care.
+			 */
+			CheckCompressedData(selector_value == 1);
+
+			Assert(SIMPLE8B_BIT_LENGTH[selector_value] == 1);
+			Assert(SIMPLE8B_NUM_ELEMENTS[selector_value] == 64);
+
+			/*
+			 * We should require at least one element from the block. Previous
+			 * blocks might have had incorrect lengths, so this is not an
+			 * assertion.
+			 */
+			CheckCompressedData(decompressed_index < num_elements);
+
+			/* Have to zero out the unused bits, so that the popcnt works properly. */
+			const int elements_this_block = Min(64, num_elements - decompressed_index);
+			Assert(elements_this_block <= 64);
+			Assert(elements_this_block > 0);
 			block_data &= (-1ULL) >> (64 - elements_this_block);
 
 			/*
@@ -147,7 +309,7 @@ simple8brle_bitmap_decompress(Simple8bRleSerialized *compressed)
 #ifdef HAVE__BUILTIN_POPCOUNT
 			num_ones += __builtin_popcountll(block_data);
 #endif
-			for (int16 i = 0; i < 64; i++)
+			for (uint16 i = 0; i < 64; i++)
 			{
 				const uint64 value = (block_data >> i) & 1;
 				bitmap_bools_[decompressed_index + i] = value;
@@ -172,8 +334,11 @@ simple8brle_bitmap_decompress(Simple8bRleSerialized *compressed)
 	 */
 	CheckCompressedData(num_ones <= num_elements);
 
-	result.bitmap_bools_ = bitmap_bools_;
-	result.num_ones = num_ones;
+	Simple8bRleBitmap result = {
+		.num_elements = num_elements,
+		.data = bitmap_bools_,
+		.num_ones = num_ones,
+	};
 
 	/* Sanity check. */
 #ifdef USE_ASSERT_CHECKING

--- a/tsl/src/nodes/decompress_chunk/exec.h
+++ b/tsl/src/nodes/decompress_chunk/exec.h
@@ -65,8 +65,8 @@ typedef struct DecompressChunkColumnState
 			DecompressionIterator *iterator;
 
 			/* For entire batch decompression, mutually exclusive with the above. */
-			Datum *datums;
-			bool *nulls;
+			ArrowArray *arrow;
+			int value_bytes;
 		} compressed;
 	};
 } DecompressChunkColumnState;
@@ -84,7 +84,6 @@ typedef struct DecompressBatchState
 	int total_batch_rows;
 	int current_batch_row;
 	MemoryContext per_batch_context;
-	MemoryContext arrow_context;
 } DecompressBatchState;
 
 typedef struct DecompressChunkState
@@ -110,6 +109,12 @@ typedef struct DecompressChunkState
 	SortSupportData *sortkeys;	   /* Sort keys for binary heap compare function */
 
 	bool using_bulk_decompression; /* For EXPLAIN ANALYZE. */
+
+	/*
+	 * Scratch space for bulk decompression which might need a lot of temporary
+	 * data.
+	 */
+	MemoryContext bulk_decompression_context;
 
 	/*
 	 * Make non-refcounted copies of the tupdesc for reuse across all batch states

--- a/tsl/test/expected/compression_algos.out
+++ b/tsl/test/expected/compression_algos.out
@@ -1550,9 +1550,9 @@ from ts_read_compressed_data_directory('gorilla', 'float8', (:'TEST_INPUT_DIR' |
 group by 2 order by 1 desc;
  count | result 
 -------+--------
-   227 | XX001
-    53 | true
-    22 | 08P01
+   224 | XX001
+    55 | true
+    23 | 08P01
 (3 rows)
 
 select count(*), coalesce((rows >= 0)::text, sqlstate) result

--- a/tsl/test/shared/expected/transparent_decompress_chunk-12.out
+++ b/tsl/test/shared/expected/transparent_decompress_chunk-12.out
@@ -14,7 +14,7 @@ QUERY PLAN
    Output: _hyper_X_X_chunk."time", _hyper_X_X_chunk.device_id, _hyper_X_X_chunk.v0, _hyper_X_X_chunk.v1, _hyper_X_X_chunk.v2, _hyper_X_X_chunk.v3
    ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_X_X_chunk (actual rows=5 loops=1)
          Output: _hyper_X_X_chunk."time", _hyper_X_X_chunk.device_id, _hyper_X_X_chunk.v0, _hyper_X_X_chunk.v1, _hyper_X_X_chunk.v2, _hyper_X_X_chunk.v3
-         Bulk Decompression: false
+         Bulk Decompression: true
          ->  Index Scan Backward using compress_hyper_X_X_chunk__compressed_hypertable_4_device_id__t on _timescaledb_internal.compress_hyper_X_X_chunk (actual rows=1 loops=1)
                Output: compress_hyper_X_X_chunk."time", compress_hyper_X_X_chunk.device_id, compress_hyper_X_X_chunk.v0, compress_hyper_X_X_chunk.v1, compress_hyper_X_X_chunk.v2, compress_hyper_X_X_chunk.v3, compress_hyper_X_X_chunk._ts_meta_count, compress_hyper_X_X_chunk._ts_meta_sequence_num, compress_hyper_X_X_chunk._ts_meta_min_1, compress_hyper_X_X_chunk._ts_meta_max_1
                Index Cond: (compress_hyper_X_X_chunk.device_id = 1)
@@ -380,7 +380,7 @@ QUERY PLAN
          Output: _hyper_X_X_chunk."time", _hyper_X_X_chunk.device_id, _hyper_X_X_chunk.v0, _hyper_X_X_chunk.v1, _hyper_X_X_chunk.v2, _hyper_X_X_chunk.v3
          Filter: (_hyper_X_X_chunk."time" > 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
          Rows Removed by Filter: 31
-         Bulk Decompression: false
+         Bulk Decompression: true
          ->  Index Scan Backward using compress_hyper_X_X_chunk__compressed_hypertable_4_device_id__t on _timescaledb_internal.compress_hyper_X_X_chunk (actual rows=1 loops=1)
                Output: compress_hyper_X_X_chunk."time", compress_hyper_X_X_chunk.device_id, compress_hyper_X_X_chunk.v0, compress_hyper_X_X_chunk.v1, compress_hyper_X_X_chunk.v2, compress_hyper_X_X_chunk.v3, compress_hyper_X_X_chunk._ts_meta_count, compress_hyper_X_X_chunk._ts_meta_sequence_num, compress_hyper_X_X_chunk._ts_meta_min_1, compress_hyper_X_X_chunk._ts_meta_max_1
                Index Cond: (compress_hyper_X_X_chunk.device_id = 1)
@@ -517,7 +517,7 @@ SET enable_seqscan TO FALSE;
 QUERY PLAN
  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_X_X_chunk (actual rows=3598 loops=1)
    Output: _hyper_X_X_chunk."time", _hyper_X_X_chunk.device_id
-   Bulk Decompression: false
+   Bulk Decompression: true
    ->  Index Scan Backward using compress_hyper_X_X_chunk__compressed_hypertable_4_device_id__t on _timescaledb_internal.compress_hyper_X_X_chunk (actual rows=4 loops=1)
          Output: compress_hyper_X_X_chunk."time", compress_hyper_X_X_chunk.device_id, compress_hyper_X_X_chunk.v0, compress_hyper_X_X_chunk.v1, compress_hyper_X_X_chunk.v2, compress_hyper_X_X_chunk.v3, compress_hyper_X_X_chunk._ts_meta_count, compress_hyper_X_X_chunk._ts_meta_sequence_num, compress_hyper_X_X_chunk._ts_meta_min_1, compress_hyper_X_X_chunk._ts_meta_max_1
          Index Cond: (compress_hyper_X_X_chunk.device_id = 1)
@@ -528,7 +528,7 @@ QUERY PLAN
 QUERY PLAN
  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_X_X_chunk (actual rows=3598 loops=1)
    Output: _hyper_X_X_chunk."time", _hyper_X_X_chunk.device_id, _hyper_X_X_chunk.v0, _hyper_X_X_chunk.v1, _hyper_X_X_chunk.v2, _hyper_X_X_chunk.v3
-   Bulk Decompression: false
+   Bulk Decompression: true
    ->  Index Scan Backward using compress_hyper_X_X_chunk__compressed_hypertable_4_device_id__t on _timescaledb_internal.compress_hyper_X_X_chunk (actual rows=4 loops=1)
          Output: compress_hyper_X_X_chunk."time", compress_hyper_X_X_chunk.device_id, compress_hyper_X_X_chunk.v0, compress_hyper_X_X_chunk.v1, compress_hyper_X_X_chunk.v2, compress_hyper_X_X_chunk.v3, compress_hyper_X_X_chunk._ts_meta_count, compress_hyper_X_X_chunk._ts_meta_sequence_num, compress_hyper_X_X_chunk._ts_meta_min_1, compress_hyper_X_X_chunk._ts_meta_max_1
          Index Cond: (compress_hyper_X_X_chunk.device_id = 1)
@@ -539,7 +539,7 @@ QUERY PLAN
 QUERY PLAN
  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_X_X_chunk test_table (actual rows=3598 loops=1)
    Output: test_table.*, test_table.device_id, test_table."time"
-   Bulk Decompression: false
+   Bulk Decompression: true
    ->  Index Scan Backward using compress_hyper_X_X_chunk__compressed_hypertable_4_device_id__t on _timescaledb_internal.compress_hyper_X_X_chunk (actual rows=4 loops=1)
          Output: compress_hyper_X_X_chunk."time", compress_hyper_X_X_chunk.device_id, compress_hyper_X_X_chunk.v0, compress_hyper_X_X_chunk.v1, compress_hyper_X_X_chunk.v2, compress_hyper_X_X_chunk.v3, compress_hyper_X_X_chunk._ts_meta_count, compress_hyper_X_X_chunk._ts_meta_sequence_num, compress_hyper_X_X_chunk._ts_meta_min_1, compress_hyper_X_X_chunk._ts_meta_max_1
          Index Cond: (compress_hyper_X_X_chunk.device_id = 1)

--- a/tsl/test/shared/expected/transparent_decompress_chunk-13.out
+++ b/tsl/test/shared/expected/transparent_decompress_chunk-13.out
@@ -14,7 +14,7 @@ QUERY PLAN
    Output: _hyper_X_X_chunk."time", _hyper_X_X_chunk.device_id, _hyper_X_X_chunk.v0, _hyper_X_X_chunk.v1, _hyper_X_X_chunk.v2, _hyper_X_X_chunk.v3
    ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_X_X_chunk (actual rows=5 loops=1)
          Output: _hyper_X_X_chunk."time", _hyper_X_X_chunk.device_id, _hyper_X_X_chunk.v0, _hyper_X_X_chunk.v1, _hyper_X_X_chunk.v2, _hyper_X_X_chunk.v3
-         Bulk Decompression: false
+         Bulk Decompression: true
          ->  Index Scan Backward using compress_hyper_X_X_chunk__compressed_hypertable_4_device_id__t on _timescaledb_internal.compress_hyper_X_X_chunk (actual rows=1 loops=1)
                Output: compress_hyper_X_X_chunk."time", compress_hyper_X_X_chunk.device_id, compress_hyper_X_X_chunk.v0, compress_hyper_X_X_chunk.v1, compress_hyper_X_X_chunk.v2, compress_hyper_X_X_chunk.v3, compress_hyper_X_X_chunk._ts_meta_count, compress_hyper_X_X_chunk._ts_meta_sequence_num, compress_hyper_X_X_chunk._ts_meta_min_1, compress_hyper_X_X_chunk._ts_meta_max_1
                Index Cond: (compress_hyper_X_X_chunk.device_id = 1)
@@ -380,7 +380,7 @@ QUERY PLAN
          Output: _hyper_X_X_chunk."time", _hyper_X_X_chunk.device_id, _hyper_X_X_chunk.v0, _hyper_X_X_chunk.v1, _hyper_X_X_chunk.v2, _hyper_X_X_chunk.v3
          Filter: (_hyper_X_X_chunk."time" > 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
          Rows Removed by Filter: 31
-         Bulk Decompression: false
+         Bulk Decompression: true
          ->  Index Scan Backward using compress_hyper_X_X_chunk__compressed_hypertable_4_device_id__t on _timescaledb_internal.compress_hyper_X_X_chunk (actual rows=1 loops=1)
                Output: compress_hyper_X_X_chunk."time", compress_hyper_X_X_chunk.device_id, compress_hyper_X_X_chunk.v0, compress_hyper_X_X_chunk.v1, compress_hyper_X_X_chunk.v2, compress_hyper_X_X_chunk.v3, compress_hyper_X_X_chunk._ts_meta_count, compress_hyper_X_X_chunk._ts_meta_sequence_num, compress_hyper_X_X_chunk._ts_meta_min_1, compress_hyper_X_X_chunk._ts_meta_max_1
                Index Cond: (compress_hyper_X_X_chunk.device_id = 1)
@@ -519,7 +519,7 @@ SET enable_seqscan TO FALSE;
 QUERY PLAN
  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_X_X_chunk (actual rows=3598 loops=1)
    Output: _hyper_X_X_chunk."time", _hyper_X_X_chunk.device_id
-   Bulk Decompression: false
+   Bulk Decompression: true
    ->  Index Scan Backward using compress_hyper_X_X_chunk__compressed_hypertable_4_device_id__t on _timescaledb_internal.compress_hyper_X_X_chunk (actual rows=4 loops=1)
          Output: compress_hyper_X_X_chunk."time", compress_hyper_X_X_chunk.device_id, compress_hyper_X_X_chunk.v0, compress_hyper_X_X_chunk.v1, compress_hyper_X_X_chunk.v2, compress_hyper_X_X_chunk.v3, compress_hyper_X_X_chunk._ts_meta_count, compress_hyper_X_X_chunk._ts_meta_sequence_num, compress_hyper_X_X_chunk._ts_meta_min_1, compress_hyper_X_X_chunk._ts_meta_max_1
          Index Cond: (compress_hyper_X_X_chunk.device_id = 1)
@@ -530,7 +530,7 @@ QUERY PLAN
 QUERY PLAN
  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_X_X_chunk (actual rows=3598 loops=1)
    Output: _hyper_X_X_chunk."time", _hyper_X_X_chunk.device_id, _hyper_X_X_chunk.v0, _hyper_X_X_chunk.v1, _hyper_X_X_chunk.v2, _hyper_X_X_chunk.v3
-   Bulk Decompression: false
+   Bulk Decompression: true
    ->  Index Scan Backward using compress_hyper_X_X_chunk__compressed_hypertable_4_device_id__t on _timescaledb_internal.compress_hyper_X_X_chunk (actual rows=4 loops=1)
          Output: compress_hyper_X_X_chunk."time", compress_hyper_X_X_chunk.device_id, compress_hyper_X_X_chunk.v0, compress_hyper_X_X_chunk.v1, compress_hyper_X_X_chunk.v2, compress_hyper_X_X_chunk.v3, compress_hyper_X_X_chunk._ts_meta_count, compress_hyper_X_X_chunk._ts_meta_sequence_num, compress_hyper_X_X_chunk._ts_meta_min_1, compress_hyper_X_X_chunk._ts_meta_max_1
          Index Cond: (compress_hyper_X_X_chunk.device_id = 1)
@@ -541,7 +541,7 @@ QUERY PLAN
 QUERY PLAN
  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_X_X_chunk test_table (actual rows=3598 loops=1)
    Output: test_table.*, test_table.device_id, test_table."time"
-   Bulk Decompression: false
+   Bulk Decompression: true
    ->  Index Scan Backward using compress_hyper_X_X_chunk__compressed_hypertable_4_device_id__t on _timescaledb_internal.compress_hyper_X_X_chunk (actual rows=4 loops=1)
          Output: compress_hyper_X_X_chunk."time", compress_hyper_X_X_chunk.device_id, compress_hyper_X_X_chunk.v0, compress_hyper_X_X_chunk.v1, compress_hyper_X_X_chunk.v2, compress_hyper_X_X_chunk.v3, compress_hyper_X_X_chunk._ts_meta_count, compress_hyper_X_X_chunk._ts_meta_sequence_num, compress_hyper_X_X_chunk._ts_meta_min_1, compress_hyper_X_X_chunk._ts_meta_max_1
          Index Cond: (compress_hyper_X_X_chunk.device_id = 1)

--- a/tsl/test/shared/expected/transparent_decompress_chunk-14.out
+++ b/tsl/test/shared/expected/transparent_decompress_chunk-14.out
@@ -14,7 +14,7 @@ QUERY PLAN
    Output: _hyper_X_X_chunk."time", _hyper_X_X_chunk.device_id, _hyper_X_X_chunk.v0, _hyper_X_X_chunk.v1, _hyper_X_X_chunk.v2, _hyper_X_X_chunk.v3
    ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_X_X_chunk (actual rows=5 loops=1)
          Output: _hyper_X_X_chunk."time", _hyper_X_X_chunk.device_id, _hyper_X_X_chunk.v0, _hyper_X_X_chunk.v1, _hyper_X_X_chunk.v2, _hyper_X_X_chunk.v3
-         Bulk Decompression: false
+         Bulk Decompression: true
          ->  Index Scan Backward using compress_hyper_X_X_chunk__compressed_hypertable_4_device_id__t on _timescaledb_internal.compress_hyper_X_X_chunk (actual rows=1 loops=1)
                Output: compress_hyper_X_X_chunk."time", compress_hyper_X_X_chunk.device_id, compress_hyper_X_X_chunk.v0, compress_hyper_X_X_chunk.v1, compress_hyper_X_X_chunk.v2, compress_hyper_X_X_chunk.v3, compress_hyper_X_X_chunk._ts_meta_count, compress_hyper_X_X_chunk._ts_meta_sequence_num, compress_hyper_X_X_chunk._ts_meta_min_1, compress_hyper_X_X_chunk._ts_meta_max_1
                Index Cond: (compress_hyper_X_X_chunk.device_id = 1)
@@ -380,7 +380,7 @@ QUERY PLAN
          Output: _hyper_X_X_chunk."time", _hyper_X_X_chunk.device_id, _hyper_X_X_chunk.v0, _hyper_X_X_chunk.v1, _hyper_X_X_chunk.v2, _hyper_X_X_chunk.v3
          Filter: (_hyper_X_X_chunk."time" > 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
          Rows Removed by Filter: 31
-         Bulk Decompression: false
+         Bulk Decompression: true
          ->  Index Scan Backward using compress_hyper_X_X_chunk__compressed_hypertable_4_device_id__t on _timescaledb_internal.compress_hyper_X_X_chunk (actual rows=1 loops=1)
                Output: compress_hyper_X_X_chunk."time", compress_hyper_X_X_chunk.device_id, compress_hyper_X_X_chunk.v0, compress_hyper_X_X_chunk.v1, compress_hyper_X_X_chunk.v2, compress_hyper_X_X_chunk.v3, compress_hyper_X_X_chunk._ts_meta_count, compress_hyper_X_X_chunk._ts_meta_sequence_num, compress_hyper_X_X_chunk._ts_meta_min_1, compress_hyper_X_X_chunk._ts_meta_max_1
                Index Cond: (compress_hyper_X_X_chunk.device_id = 1)
@@ -519,7 +519,7 @@ SET enable_seqscan TO FALSE;
 QUERY PLAN
  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_X_X_chunk (actual rows=3598 loops=1)
    Output: _hyper_X_X_chunk."time", _hyper_X_X_chunk.device_id
-   Bulk Decompression: false
+   Bulk Decompression: true
    ->  Index Scan Backward using compress_hyper_X_X_chunk__compressed_hypertable_4_device_id__t on _timescaledb_internal.compress_hyper_X_X_chunk (actual rows=4 loops=1)
          Output: compress_hyper_X_X_chunk."time", compress_hyper_X_X_chunk.device_id, compress_hyper_X_X_chunk.v0, compress_hyper_X_X_chunk.v1, compress_hyper_X_X_chunk.v2, compress_hyper_X_X_chunk.v3, compress_hyper_X_X_chunk._ts_meta_count, compress_hyper_X_X_chunk._ts_meta_sequence_num, compress_hyper_X_X_chunk._ts_meta_min_1, compress_hyper_X_X_chunk._ts_meta_max_1
          Index Cond: (compress_hyper_X_X_chunk.device_id = 1)
@@ -530,7 +530,7 @@ QUERY PLAN
 QUERY PLAN
  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_X_X_chunk (actual rows=3598 loops=1)
    Output: _hyper_X_X_chunk."time", _hyper_X_X_chunk.device_id, _hyper_X_X_chunk.v0, _hyper_X_X_chunk.v1, _hyper_X_X_chunk.v2, _hyper_X_X_chunk.v3
-   Bulk Decompression: false
+   Bulk Decompression: true
    ->  Index Scan Backward using compress_hyper_X_X_chunk__compressed_hypertable_4_device_id__t on _timescaledb_internal.compress_hyper_X_X_chunk (actual rows=4 loops=1)
          Output: compress_hyper_X_X_chunk."time", compress_hyper_X_X_chunk.device_id, compress_hyper_X_X_chunk.v0, compress_hyper_X_X_chunk.v1, compress_hyper_X_X_chunk.v2, compress_hyper_X_X_chunk.v3, compress_hyper_X_X_chunk._ts_meta_count, compress_hyper_X_X_chunk._ts_meta_sequence_num, compress_hyper_X_X_chunk._ts_meta_min_1, compress_hyper_X_X_chunk._ts_meta_max_1
          Index Cond: (compress_hyper_X_X_chunk.device_id = 1)
@@ -541,7 +541,7 @@ QUERY PLAN
 QUERY PLAN
  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_X_X_chunk test_table (actual rows=3598 loops=1)
    Output: test_table.*, test_table.device_id, test_table."time"
-   Bulk Decompression: false
+   Bulk Decompression: true
    ->  Index Scan Backward using compress_hyper_X_X_chunk__compressed_hypertable_4_device_id__t on _timescaledb_internal.compress_hyper_X_X_chunk (actual rows=4 loops=1)
          Output: compress_hyper_X_X_chunk."time", compress_hyper_X_X_chunk.device_id, compress_hyper_X_X_chunk.v0, compress_hyper_X_X_chunk.v1, compress_hyper_X_X_chunk.v2, compress_hyper_X_X_chunk.v3, compress_hyper_X_X_chunk._ts_meta_count, compress_hyper_X_X_chunk._ts_meta_sequence_num, compress_hyper_X_X_chunk._ts_meta_min_1, compress_hyper_X_X_chunk._ts_meta_max_1
          Index Cond: (compress_hyper_X_X_chunk.device_id = 1)

--- a/tsl/test/shared/expected/transparent_decompress_chunk-15.out
+++ b/tsl/test/shared/expected/transparent_decompress_chunk-15.out
@@ -14,7 +14,7 @@ QUERY PLAN
    Output: _hyper_X_X_chunk."time", _hyper_X_X_chunk.device_id, _hyper_X_X_chunk.v0, _hyper_X_X_chunk.v1, _hyper_X_X_chunk.v2, _hyper_X_X_chunk.v3
    ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_X_X_chunk (actual rows=5 loops=1)
          Output: _hyper_X_X_chunk."time", _hyper_X_X_chunk.device_id, _hyper_X_X_chunk.v0, _hyper_X_X_chunk.v1, _hyper_X_X_chunk.v2, _hyper_X_X_chunk.v3
-         Bulk Decompression: false
+         Bulk Decompression: true
          ->  Index Scan Backward using compress_hyper_X_X_chunk__compressed_hypertable_4_device_id__t on _timescaledb_internal.compress_hyper_X_X_chunk (actual rows=1 loops=1)
                Output: compress_hyper_X_X_chunk."time", compress_hyper_X_X_chunk.device_id, compress_hyper_X_X_chunk.v0, compress_hyper_X_X_chunk.v1, compress_hyper_X_X_chunk.v2, compress_hyper_X_X_chunk.v3, compress_hyper_X_X_chunk._ts_meta_count, compress_hyper_X_X_chunk._ts_meta_sequence_num, compress_hyper_X_X_chunk._ts_meta_min_1, compress_hyper_X_X_chunk._ts_meta_max_1
                Index Cond: (compress_hyper_X_X_chunk.device_id = 1)
@@ -382,7 +382,7 @@ QUERY PLAN
          Output: _hyper_X_X_chunk."time", _hyper_X_X_chunk.device_id, _hyper_X_X_chunk.v0, _hyper_X_X_chunk.v1, _hyper_X_X_chunk.v2, _hyper_X_X_chunk.v3
          Filter: (_hyper_X_X_chunk."time" > 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
          Rows Removed by Filter: 31
-         Bulk Decompression: false
+         Bulk Decompression: true
          ->  Index Scan Backward using compress_hyper_X_X_chunk__compressed_hypertable_4_device_id__t on _timescaledb_internal.compress_hyper_X_X_chunk (actual rows=1 loops=1)
                Output: compress_hyper_X_X_chunk."time", compress_hyper_X_X_chunk.device_id, compress_hyper_X_X_chunk.v0, compress_hyper_X_X_chunk.v1, compress_hyper_X_X_chunk.v2, compress_hyper_X_X_chunk.v3, compress_hyper_X_X_chunk._ts_meta_count, compress_hyper_X_X_chunk._ts_meta_sequence_num, compress_hyper_X_X_chunk._ts_meta_min_1, compress_hyper_X_X_chunk._ts_meta_max_1
                Index Cond: (compress_hyper_X_X_chunk.device_id = 1)
@@ -521,7 +521,7 @@ SET enable_seqscan TO FALSE;
 QUERY PLAN
  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_X_X_chunk (actual rows=3598 loops=1)
    Output: _hyper_X_X_chunk."time", _hyper_X_X_chunk.device_id
-   Bulk Decompression: false
+   Bulk Decompression: true
    ->  Index Scan Backward using compress_hyper_X_X_chunk__compressed_hypertable_4_device_id__t on _timescaledb_internal.compress_hyper_X_X_chunk (actual rows=4 loops=1)
          Output: compress_hyper_X_X_chunk."time", compress_hyper_X_X_chunk.device_id, compress_hyper_X_X_chunk.v0, compress_hyper_X_X_chunk.v1, compress_hyper_X_X_chunk.v2, compress_hyper_X_X_chunk.v3, compress_hyper_X_X_chunk._ts_meta_count, compress_hyper_X_X_chunk._ts_meta_sequence_num, compress_hyper_X_X_chunk._ts_meta_min_1, compress_hyper_X_X_chunk._ts_meta_max_1
          Index Cond: (compress_hyper_X_X_chunk.device_id = 1)
@@ -532,7 +532,7 @@ QUERY PLAN
 QUERY PLAN
  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_X_X_chunk (actual rows=3598 loops=1)
    Output: _hyper_X_X_chunk."time", _hyper_X_X_chunk.device_id, _hyper_X_X_chunk.v0, _hyper_X_X_chunk.v1, _hyper_X_X_chunk.v2, _hyper_X_X_chunk.v3
-   Bulk Decompression: false
+   Bulk Decompression: true
    ->  Index Scan Backward using compress_hyper_X_X_chunk__compressed_hypertable_4_device_id__t on _timescaledb_internal.compress_hyper_X_X_chunk (actual rows=4 loops=1)
          Output: compress_hyper_X_X_chunk."time", compress_hyper_X_X_chunk.device_id, compress_hyper_X_X_chunk.v0, compress_hyper_X_X_chunk.v1, compress_hyper_X_X_chunk.v2, compress_hyper_X_X_chunk.v3, compress_hyper_X_X_chunk._ts_meta_count, compress_hyper_X_X_chunk._ts_meta_sequence_num, compress_hyper_X_X_chunk._ts_meta_min_1, compress_hyper_X_X_chunk._ts_meta_max_1
          Index Cond: (compress_hyper_X_X_chunk.device_id = 1)
@@ -543,7 +543,7 @@ QUERY PLAN
 QUERY PLAN
  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_X_X_chunk test_table (actual rows=3598 loops=1)
    Output: test_table.*, test_table.device_id, test_table."time"
-   Bulk Decompression: false
+   Bulk Decompression: true
    ->  Index Scan Backward using compress_hyper_X_X_chunk__compressed_hypertable_4_device_id__t on _timescaledb_internal.compress_hyper_X_X_chunk (actual rows=4 loops=1)
          Output: compress_hyper_X_X_chunk."time", compress_hyper_X_X_chunk.device_id, compress_hyper_X_X_chunk.v0, compress_hyper_X_X_chunk.v1, compress_hyper_X_X_chunk.v2, compress_hyper_X_X_chunk.v3, compress_hyper_X_X_chunk._ts_meta_count, compress_hyper_X_X_chunk._ts_meta_sequence_num, compress_hyper_X_X_chunk._ts_meta_min_1, compress_hyper_X_X_chunk._ts_meta_max_1
          Index Cond: (compress_hyper_X_X_chunk.device_id = 1)

--- a/tsl/test/src/test_compression.c
+++ b/tsl/test/src/test_compression.c
@@ -392,7 +392,8 @@ test_gorilla_double(bool have_nulls, bool have_random)
 	/* Forward decompression. */
 	DecompressionIterator *iter =
 		gorilla_decompression_iterator_from_datum_forward(PointerGetDatum(compressed), FLOAT8OID);
-	ArrowArray *bulk_result = gorilla_decompress_all(PointerGetDatum(compressed), FLOAT8OID);
+	ArrowArray *bulk_result =
+		gorilla_decompress_all(PointerGetDatum(compressed), FLOAT8OID, CurrentMemoryContext);
 	for (int i = 0; i < TEST_ELEMENTS; i++)
 	{
 		DecompressResult r = gorilla_decompression_iterator_try_next_forward(iter);
@@ -550,7 +551,8 @@ test_delta3(bool have_nulls, bool have_random)
 	/* Forward decompression. */
 	DecompressionIterator *iter =
 		delta_delta_decompression_iterator_from_datum_forward(PointerGetDatum(compressed), INT8OID);
-	ArrowArray *bulk_result = delta_delta_decompress_all(PointerGetDatum(compressed), INT8OID);
+	ArrowArray *bulk_result =
+		delta_delta_decompress_all(PointerGetDatum(compressed), INT8OID, CurrentMemoryContext);
 	for (int i = 0; i < TEST_ELEMENTS; i++)
 	{
 		DecompressResult r = delta_delta_decompression_iterator_try_next_forward(iter);
@@ -592,6 +594,42 @@ test_delta3(bool have_nulls, bool have_random)
 	TestAssertTrue(r.is_done);
 }
 
+static int32 test_delta4_case1[] = { -603979776, 1462059044 };
+
+static int32 test_delta4_case2[] = {
+	0x7979fd07, 0x79797979, 0x79797979, 0x79797979, 0x79797979, 0x79797979, 0x79797979,
+	0x79797979, 0x79797979, 0x79797979, 0x79797979, 0x79797979, 0x79797979, 0x79797979,
+	0x79797979, 0x50505050, 0xc4c4c4c4, 0xc4c4c4c4, 0x50505050, 0x50505050, 0xc4c4c4c4,
+};
+
+static void
+test_delta4(const int32 *values, int n)
+{
+	Compressor *compressor = delta_delta_compressor_for_type(INT4OID);
+	for (int i = 0; i < n; i++)
+	{
+		compressor->append_val(compressor, Int32GetDatum(values[i]));
+	}
+	Datum compressed = (Datum) compressor->finish(compressor);
+
+	ArrowArray *arrow = delta_delta_decompress_all(compressed, INT4OID, CurrentMemoryContext);
+	DecompressionIterator *iter =
+		delta_delta_decompression_iterator_from_datum_forward(compressed, INT4OID);
+	int i = 0;
+	for (DecompressResult r = delta_delta_decompression_iterator_try_next_forward(iter); !r.is_done;
+		 r = delta_delta_decompression_iterator_try_next_forward(iter))
+	{
+		TestAssertTrue(!r.is_null);
+		TestAssertTrue(i < arrow->length);
+		TestAssertTrue(((int32 *) arrow->buffers[1])[i] == DatumGetInt32(r.val));
+		TestAssertTrue(arrow_row_is_valid(arrow->buffers[0], i));
+		TestAssertTrue(values[i] == DatumGetInt32(r.val));
+		i++;
+	}
+	TestAssertTrue(i == arrow->length);
+	TestAssertTrue(i == n);
+}
+
 Datum
 ts_test_compression(PG_FUNCTION_ARGS)
 {
@@ -611,6 +649,11 @@ ts_test_compression(PG_FUNCTION_ARGS)
 	test_delta3(/* have_nulls = */ false, /* have_random = */ true);
 	test_delta3(/* have_nulls = */ true, /* have_random = */ false);
 	test_delta3(/* have_nulls = */ true, /* have_random = */ true);
+
+	/* Some tests for zig-zag encoding overflowing the original element width. */
+	test_delta4(test_delta4_case1, sizeof(test_delta4_case1) / sizeof(*test_delta4_case1));
+	test_delta4(test_delta4_case2, sizeof(test_delta4_case2) / sizeof(*test_delta4_case2));
+
 	PG_RETURN_VOID();
 }
 


### PR DESCRIPTION
Do some cleanup and support decompression in the reverse direction.

In tsbench it improves the first/last queries, by using the old sizes for the per-batch memory context: https://grafana.ops.savannah-dev.timescale.com/d/fasYic_4z/compare-akuzm?orgId=1&var-branch=All&var-run1=2477&var-run2=2478&var-threshold=0.05

Disable-check: force-changelog-file