### PR TITLE
Renamed need-more-info label

### DIFF
--- a/.github/workflows/procedural.yaml
+++ b/.github/workflows/procedural.yaml
@@ -22,7 +22,7 @@ jobs:
     name: Waiting for Author
     runs-on: ubuntu-latest
     if: github.event_name == 'issues' && github.event.action == 'labeled'
-      && github.event.label.name == 'need-more-info'
+      && github.event.label.name == 'waiting-for-author'
     steps:
       - uses: leonsteinhaeuser/project-beta-automations@v2.0.0
         with:
@@ -36,7 +36,7 @@ jobs:
     name: Waiting for Engineering
     runs-on: ubuntu-latest
     if: github.event_name == 'issue_comment' && !github.event.issue.pull_request
-      && contains(github.event.issue.labels.*.name, 'need-more-info')
+      && contains(github.event.issue.labels.*.name, 'waiting-for-author')
     steps:
       - name: Check if organization member
         uses: tspascoal/get-user-teams-membership@v2
@@ -46,11 +46,11 @@ jobs:
          organization: timescale
          team: 'database-eng'
          GITHUB_TOKEN: ${{ secrets.ORG_AUTOMATION_TOKEN }}
-      - name: Remove need-more-info label
+      - name: Remove waiting-for-author label
         if: ${{ steps.checkUserMember.outputs.isTeamMember == 'false' }}
         uses: andymckay/labeler@3a4296e9dcdf9576b0456050db78cfd34853f260
         with:
-          remove-labels: 'need-more-info, no-activity'
+          remove-labels: 'waiting-for-author, no-activity'
           repo-token: ${{ secrets.ORG_AUTOMATION_TOKEN }}
       - name: Move to waiting for engineering column
         if: ${{ steps.checkUserMember.outputs.isTeamMember == 'false' }}

--- a/.github/workflows/stalebot.yaml
+++ b/.github/workflows/stalebot.yaml
@@ -42,8 +42,8 @@ jobs:
           # Add this label after 'days-before-issue-stale' days to mark it as stale
           stale-issue-label: 'no-activity'
 
-          # Process only issues that contain the label 'need-more-info'
-          only-labels: 'need-more-info'
+          # Process only issues that contain the label 'waiting-for-author'
+          only-labels: 'waiting-for-author'
 
           # Stale only issues with one of these labels
           any-of-issue-labels: 'bug,enhancement'


### PR DESCRIPTION
We plan to rename the need-more-info label to waiting-for-author.
This PR performs the needed adjustments in our GitHub actions.