### PR TITLE
Make validate_chunk_status_for_operation accept Chunk as argument

### DIFF
--- a/src/chunk.h
+++ b/src/chunk.h
@@ -207,8 +207,7 @@ extern TSDLLEXPORT bool ts_chunk_is_unordered(const Chunk *chunk);
 extern TSDLLEXPORT bool ts_chunk_is_partial(const Chunk *chunk);
 extern TSDLLEXPORT bool ts_chunk_is_compressed(const Chunk *chunk);
 extern TSDLLEXPORT bool ts_chunk_is_distributed(const Chunk *chunk);
-extern TSDLLEXPORT bool ts_chunk_validate_chunk_status_for_operation(Oid chunk_relid,
-																	 int32 chunk_status,
+extern TSDLLEXPORT bool ts_chunk_validate_chunk_status_for_operation(const Chunk *chunk,
 																	 ChunkOperation cmd,
 																	 bool throw_error);
 

--- a/src/nodes/chunk_dispatch/chunk_insert_state.c
+++ b/src/nodes/chunk_dispatch/chunk_insert_state.c
@@ -592,10 +592,7 @@ ts_chunk_insert_state_create(const Chunk *chunk, ChunkDispatch *dispatch)
 				 errmsg("hypertables do not support row-level security")));
 	Assert(chunk->relkind == RELKIND_RELATION || chunk->relkind == RELKIND_FOREIGN_TABLE);
 
-	ts_chunk_validate_chunk_status_for_operation(chunk->table_id,
-												 chunk->fd.status,
-												 CHUNK_INSERT,
-												 true);
+	ts_chunk_validate_chunk_status_for_operation(chunk, CHUNK_INSERT, true);
 
 	rel = table_open(chunk->table_id, RowExclusiveLock);
 

--- a/tsl/src/compression/api.c
+++ b/tsl/src/compression/api.c
@@ -310,10 +310,7 @@ compresschunkcxt_init(CompressChunkCxt *cxt, Cache *hcache, Oid hypertable_relid
 				(errcode(ERRCODE_INTERNAL_ERROR), errmsg("missing hyperspace for hypertable")));
 	/* refetch the srcchunk with all attributes filled in */
 	srcchunk = ts_chunk_get_by_relid(chunk_relid, true);
-	ts_chunk_validate_chunk_status_for_operation(srcchunk->table_id,
-												 srcchunk->fd.status,
-												 CHUNK_COMPRESS,
-												 true);
+	ts_chunk_validate_chunk_status_for_operation(srcchunk, CHUNK_COMPRESS, true);
 	cxt->srcht = srcht;
 	cxt->compress_ht = compress_ht;
 	cxt->srcht_chunk = srcchunk;
@@ -471,10 +468,7 @@ compress_chunk_impl(Oid hypertable_relid, Oid chunk_relid)
 	Chunk *chunk_state_after_lock = ts_chunk_get_by_relid(chunk_relid, true);
 
 	/* Throw error if chunk has invalid status for operation */
-	ts_chunk_validate_chunk_status_for_operation(chunk_state_after_lock->table_id,
-												 chunk_state_after_lock->fd.status,
-												 CHUNK_COMPRESS,
-												 true);
+	ts_chunk_validate_chunk_status_for_operation(chunk_state_after_lock, CHUNK_COMPRESS, true);
 
 	/* get compression properties for hypertable */
 	htcols_list = ts_hypertable_compression_get(cxt.srcht->fd.id);
@@ -598,10 +592,7 @@ decompress_chunk_impl(Oid uncompressed_hypertable_relid, Oid uncompressed_chunk_
 		return false;
 	}
 
-	ts_chunk_validate_chunk_status_for_operation(uncompressed_chunk_relid,
-												 uncompressed_chunk->fd.status,
-												 CHUNK_DECOMPRESS,
-												 true);
+	ts_chunk_validate_chunk_status_for_operation(uncompressed_chunk, CHUNK_DECOMPRESS, true);
 	compressed_chunk = ts_chunk_get_by_id(uncompressed_chunk->fd.compressed_chunk_id, true);
 
 	/* acquire locks on src and compress hypertable and src chunk */
@@ -642,10 +633,7 @@ decompress_chunk_impl(Oid uncompressed_hypertable_relid, Oid uncompressed_chunk_
 	Chunk *chunk_state_after_lock = ts_chunk_get_by_relid(uncompressed_chunk_relid, true);
 
 	/* Throw error if chunk has invalid status for operation */
-	ts_chunk_validate_chunk_status_for_operation(chunk_state_after_lock->table_id,
-												 chunk_state_after_lock->fd.status,
-												 CHUNK_DECOMPRESS,
-												 true);
+	ts_chunk_validate_chunk_status_for_operation(chunk_state_after_lock, CHUNK_DECOMPRESS, true);
 
 	decompress_chunk(compressed_chunk->table_id, uncompressed_chunk->table_id);
 


### PR DESCRIPTION
* passing a `Chunk` is more straightforward/cleaner
* easier to extend the checks later (if needed)

Disable-check: force-changelog-file