### PR TITLE
PG16 : Function renames

### DIFF
--- a/src/cache.c
+++ b/src/cache.c
@@ -46,7 +46,7 @@ ts_cache_init(Cache *cache)
 	 * The cache object should have been created in its own context so that
 	 * cache_destroy can just delete the context to free everything.
 	 */
-	Assert(MemoryContextContains(ts_cache_memory_ctx(cache), cache));
+	Assert(GetMemoryChunkContext(cache) == ts_cache_memory_ctx(cache));
 
 	/*
 	 * We always want to be explicit about the memory context our hash table

--- a/src/copy.c
+++ b/src/copy.c
@@ -800,7 +800,11 @@ copyfrom(CopyChunkState *ccstate, List *range_table, Hypertable *ht, MemoryConte
 	 */
 	/* createSubid is creation check, newRelfilenodeSubid is truncation check */
 	if (ccstate->rel->rd_createSubid != InvalidSubTransactionId ||
+#if PG16_LT
 		ccstate->rel->rd_newRelfilenodeSubid != InvalidSubTransactionId)
+#else
+		ccstate->rel->rd_newRelfilelocatorSubid != InvalidSubTransactionId)
+#endif
 	{
 		ti_options |= HEAP_INSERT_SKIP_FSM;
 #if PG13_LT

--- a/src/process_utility.c
+++ b/src/process_utility.c
@@ -820,10 +820,18 @@ ts_get_all_vacuum_rels(bool is_vacuumcmd)
 		relid = classform->oid;
 
 		/* check permissions of relation */
+#if PG16_LT
 		if (!vacuum_is_relation_owner(relid,
 									  classform,
 									  is_vacuumcmd ? VACOPT_VACUUM : VACOPT_ANALYZE))
 			continue;
+
+#else
+		if (!vacuum_is_permitted_for_relation(relid,
+											  classform,
+											  is_vacuumcmd ? VACOPT_VACUUM : VACOPT_ANALYZE))
+			continue;
+#endif
 
 		/*
 		 * We include partitioned tables here; depending on which operation is

--- a/tsl/src/compression/compression.c
+++ b/tsl/src/compression/compression.c
@@ -35,6 +35,7 @@
 #include <utils/lsyscache.h>
 #include <utils/memutils.h>
 #include <utils/rel.h>
+#include <utils/relcache.h>
 #include <utils/snapmgr.h>
 #include <utils/syscache.h>
 #include <utils/tuplesort.h>
@@ -152,7 +153,11 @@ truncate_relation(Oid table_oid)
 
 	CheckTableForSerializableConflictIn(rel);
 
+#if PG16_LT
 	RelationSetNewRelfilenode(rel, rel->rd_rel->relpersistence);
+#else
+	RelationSetNewRelfilenumber(rel, rel->rd_rel->relpersistence);
+#endif
 
 	toast_relid = rel->rd_rel->reltoastrelid;
 
@@ -161,7 +166,11 @@ truncate_relation(Oid table_oid)
 	if (OidIsValid(toast_relid))
 	{
 		rel = table_open(toast_relid, AccessExclusiveLock);
+#if PG16_LT
 		RelationSetNewRelfilenode(rel, rel->rd_rel->relpersistence);
+#else
+		RelationSetNewRelfilenumber(rel, rel->rd_rel->relpersistence);
+#endif
 		Assert(rel->rd_rel->relpersistence != RELPERSISTENCE_UNLOGGED);
 		table_close(rel, NoLock);
 	}


### PR DESCRIPTION
This PR consists of the following 3 commits :

[PG16: Remove MemoryContextContains usage](https://github.com/timescale/timescaledb/commit/c1b2fbd715e1564246d9bd908e8470a2c4128353) 

Remove the usage of MemoryContextContains as it has been removed in PG16.

https://github.com/postgres/postgres/commit/9543eff

---

[PG16: Rename RelFileNode references to RelFileNumber or RelFileLocator](https://github.com/timescale/timescaledb/commit/2a1f3cb6524ca535f520b740806df5fb7905717c) 

https://github.com/postgres/postgres/commit/b0a55e4

---

[PG16: Use new function to check vacuum permission](https://github.com/timescale/timescaledb/commit/100ebb6848bb8eadf2bef7b75117a74bad628201) 

https://github.com/postgres/postgres/commit/b5d63824

Disable-check: force-changelog-file
Disable-check: commit-count