### PR TITLE
PG16 : Updates to aclcheck and ownercheck functions

### DIFF
--- a/src/compat/compat.h
+++ b/src/compat/compat.h
@@ -880,6 +880,23 @@ object_aclcheck(Oid classid, Oid objectid, Oid roleid, AclMode mode)
 	}
 	return ACLCHECK_NOT_OWNER;
 }
+
+/*
+ * PG16 replaces pg_foo_ownercheck() functions with a common object_ownercheck() function
+ * https://github.com/postgres/postgres/commit/afbfc029
+ */
+static inline bool
+object_ownercheck(Oid classid, Oid objectid, Oid roleid)
+{
+	switch (classid)
+	{
+		case RelationRelationId:
+			return pg_class_ownercheck(objectid, roleid);
+		default:
+			Assert(false);
+	}
+	return false;
+}
 #endif
 
 #endif /* TIMESCALEDB_COMPAT_H */

--- a/src/compat/compat.h
+++ b/src/compat/compat.h
@@ -848,4 +848,38 @@ RelationGetSmgr(Relation rel)
 				quiet)
 #endif
 
+#if PG16_LT
+#include <catalog/pg_database_d.h>
+#include <catalog/pg_foreign_server_d.h>
+#include <catalog/pg_namespace_d.h>
+#include <catalog/pg_proc_d.h>
+#include <catalog/pg_tablespace_d.h>
+#include <utils/acl.h>
+
+/*
+ * PG16 replaces most aclcheck functions with a common object_aclcheck() function
+ * https://github.com/postgres/postgres/commit/c727f511
+ */
+static inline AclResult
+object_aclcheck(Oid classid, Oid objectid, Oid roleid, AclMode mode)
+{
+	switch (classid)
+	{
+		case DatabaseRelationId:
+			return pg_database_aclcheck(objectid, roleid, mode);
+		case ForeignServerRelationId:
+			return pg_foreign_server_aclcheck(objectid, roleid, mode);
+		case NamespaceRelationId:
+			return pg_namespace_aclcheck(objectid, roleid, mode);
+		case ProcedureRelationId:
+			return pg_proc_aclcheck(objectid, roleid, mode);
+		case TableSpaceRelationId:
+			return pg_tablespace_aclcheck(objectid, roleid, mode);
+		default:
+			Assert(false);
+	}
+	return ACLCHECK_NOT_OWNER;
+}
+#endif
+
 #endif /* TIMESCALEDB_COMPAT_H */

--- a/src/hypertable.c
+++ b/src/hypertable.c
@@ -11,7 +11,9 @@
 #include <catalog/namespace.h>
 #include <catalog/pg_collation.h>
 #include <catalog/pg_constraint.h>
+#include <catalog/pg_database_d.h>
 #include <catalog/pg_inherits.h>
+#include <catalog/pg_namespace_d.h>
 #include <catalog/pg_proc.h>
 #include <catalog/pg_type.h>
 #include <commands/dbcommands.h>
@@ -1369,14 +1371,14 @@ hypertable_check_associated_schema_permissions(const char *schema_name, Oid user
 		 * Schema does not exist, so we must check that the user has
 		 * privileges to create the schema in the current database
 		 */
-		if (pg_database_aclcheck(MyDatabaseId, user_oid, ACL_CREATE) != ACLCHECK_OK)
+		if (object_aclcheck(DatabaseRelationId, MyDatabaseId, user_oid, ACL_CREATE) != ACLCHECK_OK)
 			ereport(ERROR,
 					(errcode(ERRCODE_INSUFFICIENT_PRIVILEGE),
 					 errmsg("permissions denied: cannot create schema \"%s\" in database \"%s\"",
 							schema_name,
 							get_database_name(MyDatabaseId))));
 	}
-	else if (pg_namespace_aclcheck(schema_oid, user_oid, ACL_CREATE) != ACLCHECK_OK)
+	else if (object_aclcheck(NamespaceRelationId, schema_oid, user_oid, ACL_CREATE) != ACLCHECK_OK)
 		ereport(ERROR,
 				(errcode(ERRCODE_INSUFFICIENT_PRIVILEGE),
 				 errmsg("permissions denied: cannot create chunks in schema \"%s\"", schema_name)));
@@ -2573,7 +2575,7 @@ ts_hypertable_set_integer_now_func(PG_FUNCTION_ARGS)
 
 	integer_now_func_validate(now_func_oid, open_dim_type);
 
-	aclresult = pg_proc_aclcheck(now_func_oid, GetUserId(), ACL_EXECUTE);
+	aclresult = object_aclcheck(ProcedureRelationId, now_func_oid, GetUserId(), ACL_EXECUTE);
 	if (aclresult != ACLCHECK_OK)
 		ereport(ERROR,
 				(errcode(ERRCODE_INSUFFICIENT_PRIVILEGE),

--- a/src/partitioning.c
+++ b/src/partitioning.c
@@ -75,7 +75,7 @@ ts_partitioning_func_is_valid(regproc funcoid, DimensionType dimtype, Oid argtyp
 	if (!HeapTupleIsValid(tuple))
 		elog(ERROR, "cache lookup failed for function %u", funcoid);
 
-	aclresult = pg_proc_aclcheck(funcoid, GetUserId(), ACL_EXECUTE);
+	aclresult = object_aclcheck(ProcedureRelationId, funcoid, GetUserId(), ACL_EXECUTE);
 	if (aclresult != ACLCHECK_OK)
 		ereport(ERROR,
 				(errcode(ERRCODE_INSUFFICIENT_PRIVILEGE),

--- a/src/ts_catalog/hypertable_data_node.c
+++ b/src/ts_catalog/hypertable_data_node.c
@@ -10,6 +10,7 @@
 #include <utils/acl.h>
 #include <foreign/foreign.h>
 #include <miscadmin.h>
+#include <catalog/pg_foreign_server_d.h>
 
 #include "ts_catalog/hypertable_data_node.h"
 #include "scanner.h"
@@ -57,7 +58,10 @@ ts_hypertable_data_node_insert_multi(List *hypertable_data_nodes)
 		AclResult aclresult;
 
 		/* Must also have usage on the server object */
-		aclresult = pg_foreign_server_aclcheck(node->foreign_server_oid, curuserid, ACL_USAGE);
+		aclresult = object_aclcheck(ForeignServerRelationId,
+									node->foreign_server_oid,
+									curuserid,
+									ACL_USAGE);
 
 		if (aclresult != ACLCHECK_OK)
 		{

--- a/src/ts_catalog/tablespace.c
+++ b/src/ts_catalog/tablespace.c
@@ -10,6 +10,7 @@
 #include <utils/acl.h>
 #include <utils/builtins.h>
 #include <utils/fmgroids.h>
+#include <catalog/pg_tablespace_d.h>
 #include <commands/tablespace.h>
 #include <commands/tablecmds.h>
 #include <access/xact.h>
@@ -191,7 +192,7 @@ tablespace_validate_revoke_internal(const char *tspcname, tuple_found_func tuple
 static void
 validate_revoke_create(Oid tspcoid, Oid role, Oid relid)
 {
-	AclResult aclresult = pg_tablespace_aclcheck(tspcoid, role, ACL_CREATE);
+	AclResult aclresult = object_aclcheck(TableSpaceRelationId, tspcoid, role, ACL_CREATE);
 
 	if (aclresult != ACLCHECK_OK)
 		ereport(ERROR,
@@ -554,7 +555,7 @@ ts_tablespace_attach_internal(Name tspcname, Oid hypertable_oid, bool if_not_att
 		 * user here, since we're not actually creating a table using this
 		 * tablespace at this point
 		 */
-		aclresult = pg_tablespace_aclcheck(tspc_oid, ownerid, ACL_CREATE);
+		aclresult = object_aclcheck(TableSpaceRelationId, tspc_oid, ownerid, ACL_CREATE);
 
 		if (aclresult != ACLCHECK_OK)
 			ereport(ERROR,

--- a/tsl/src/bgw_policy/job_api.c
+++ b/tsl/src/bgw_policy/job_api.c
@@ -125,7 +125,7 @@ job_add(PG_FUNCTION_ARGS)
 				(errcode(ERRCODE_UNDEFINED_OBJECT),
 				 errmsg("function or procedure with OID %u does not exist", proc)));
 
-	if (pg_proc_aclcheck(proc, owner, ACL_EXECUTE) != ACLCHECK_OK)
+	if (object_aclcheck(ProcedureRelationId, proc, owner, ACL_EXECUTE) != ACLCHECK_OK)
 		ereport(ERROR,
 				(errcode(ERRCODE_INSUFFICIENT_PRIVILEGE),
 				 errmsg("permission denied for function \"%s\"", func_name),
@@ -139,7 +139,7 @@ job_add(PG_FUNCTION_ARGS)
 					(errcode(ERRCODE_UNDEFINED_OBJECT),
 					 errmsg("function with OID %d does not exist", check)));
 
-		if (pg_proc_aclcheck(check, owner, ACL_EXECUTE) != ACLCHECK_OK)
+		if (object_aclcheck(ProcedureRelationId, check, owner, ACL_EXECUTE) != ACLCHECK_OK)
 			ereport(ERROR,
 					(errcode(ERRCODE_INSUFFICIENT_PRIVILEGE),
 					 errmsg("permission denied for function \"%s\"", check_name_str),
@@ -365,7 +365,8 @@ job_alter(PG_FUNCTION_ARGS)
 						(errcode(ERRCODE_UNDEFINED_OBJECT),
 						 errmsg("function with OID %d does not exist", check)));
 
-			if (pg_proc_aclcheck(check, GetUserId(), ACL_EXECUTE) != ACLCHECK_OK)
+			if (object_aclcheck(ProcedureRelationId, check, GetUserId(), ACL_EXECUTE) !=
+				ACLCHECK_OK)
 				ereport(ERROR,
 						(errcode(ERRCODE_INSUFFICIENT_PRIVILEGE),
 						 errmsg("permission denied for function \"%s\"", check_name_str),

--- a/tsl/src/continuous_aggs/refresh.c
+++ b/tsl/src/continuous_aggs/refresh.c
@@ -778,7 +778,7 @@ continuous_agg_refresh_internal(const ContinuousAgg *cagg,
 		ereport(ERROR, (errcode(ERRCODE_INTERNAL_ERROR), (errmsg("could not set search_path"))));
 
 	/* Like regular materialized views, require owner to refresh. */
-	if (!pg_class_ownercheck(cagg->relid, GetUserId()))
+	if (!object_ownercheck(RelationRelationId, cagg->relid, GetUserId()))
 		aclcheck_error(ACLCHECK_NOT_OWNER,
 					   get_relkind_objtype(get_rel_relkind(cagg->relid)),
 					   get_rel_name(cagg->relid));

--- a/tsl/src/data_node.c
+++ b/tsl/src/data_node.c
@@ -152,7 +152,7 @@ validate_foreign_server(const ForeignServer *server, AclMode const mode, bool fa
 		return true;
 
 	/* Must have permissions on the server object */
-	aclresult = pg_foreign_server_aclcheck(server->serverid, curuserid, mode);
+	aclresult = object_aclcheck(ForeignServerRelationId, server->serverid, curuserid, mode);
 
 	valid = (aclresult == ACLCHECK_OK);
 
@@ -2136,7 +2136,7 @@ data_node_name_list_check_acl(List *data_node_names, AclMode mode)
 		if (mode != ACL_NO_CHECK)
 		{
 			/* Must have permissions on the server object */
-			aclresult = pg_foreign_server_aclcheck(server->serverid, curuserid, mode);
+			aclresult = object_aclcheck(ForeignServerRelationId, server->serverid, curuserid, mode);
 
 			if (aclresult != ACLCHECK_OK)
 				aclcheck_error(aclresult, OBJECT_FOREIGN_SERVER, server->servername);

--- a/tsl/src/reorder.c
+++ b/tsl/src/reorder.c
@@ -30,6 +30,7 @@
 #include <catalog/namespace.h>
 #include <catalog/objectaccess.h>
 #include <catalog/pg_am.h>
+#include <catalog/pg_tablespace_d.h>
 #include <catalog/toasting.h>
 #include <commands/cluster.h>
 #include <commands/tablecmds.h>
@@ -449,7 +450,8 @@ reorder_chunk(Oid chunk_id, Oid index_id, bool verbose, Oid wait_id, Oid destina
 	{
 		AclResult aclresult;
 
-		aclresult = pg_tablespace_aclcheck(destination_tablespace, GetUserId(), ACL_CREATE);
+		aclresult =
+			object_aclcheck(TableSpaceRelationId, destination_tablespace, GetUserId(), ACL_CREATE);
 		if (aclresult != ACLCHECK_OK)
 			ereport(ERROR,
 					(errcode(ERRCODE_INSUFFICIENT_PRIVILEGE),
@@ -462,7 +464,8 @@ reorder_chunk(Oid chunk_id, Oid index_id, bool verbose, Oid wait_id, Oid destina
 	{
 		AclResult aclresult;
 
-		aclresult = pg_tablespace_aclcheck(index_tablespace, GetUserId(), ACL_CREATE);
+		aclresult =
+			object_aclcheck(TableSpaceRelationId, index_tablespace, GetUserId(), ACL_CREATE);
 		if (aclresult != ACLCHECK_OK)
 			ereport(ERROR,
 					(errcode(ERRCODE_INSUFFICIENT_PRIVILEGE),

--- a/tsl/src/reorder.c
+++ b/tsl/src/reorder.c
@@ -416,7 +416,7 @@ reorder_chunk(Oid chunk_id, Oid index_id, bool verbose, Oid wait_id, Oid destina
 	/* Our check gives better error messages, but keep the original one too. */
 	ts_hypertable_permissions_check(ht->main_table_relid, GetUserId());
 
-	if (!pg_class_ownercheck(ht->main_table_relid, GetUserId()))
+	if (!object_ownercheck(RelationRelationId, ht->main_table_relid, GetUserId()))
 	{
 		Oid main_table_relid = ht->main_table_relid;
 
@@ -565,7 +565,7 @@ reorder_rel(Oid tableOid, Oid indexOid, bool verbose, Oid wait_id, Oid destinati
 	 * that the relation still is what we think it is.
 	 */
 	/* Check that the user still owns the relation */
-	if (!pg_class_ownercheck(tableOid, GetUserId()))
+	if (!object_ownercheck(RelationRelationId, tableOid, GetUserId()))
 	{
 		relation_close(OldHeap, ExclusiveLock);
 		ereport(WARNING, (errcode(ERRCODE_WARNING), errmsg("ownership changed during reorder")));


### PR DESCRIPTION
[PG16: Make aclcheck function calls compatible with PG16](https://github.com/timescale/timescaledb/commit/679719a1369cc22c293c2f63ce0f688fbcd95de1) 

PG16 replaced most of the aclcheck functions with a common object_aclcheck
function. Updated the various aclcheck calls in the code to use the new
function when compiled with PG16.

https://github.com/postgres/postgres/commit/c727f511

---

[PG16: Replace pg_class_ownercheck() with object_ownercheck](https://github.com/timescale/timescaledb/commit/32918ce76b55b44080f809ba4cccf4a67b628fe0) 

PG16 replaces pg_foo_ownercheck() functions with a common
object_ownercheck() function. Added a new compat function for
pg_class_ownercheck() function affected by this change and replaced all
its callers.

https://github.com/postgres/postgres/commit/afbfc029
___

Disable-check: force-changelog-file
Disable-check: commit-count