### PR TITLE
Chunk_create must add existing table or fail

### DIFF
--- a/.unreleased/bugfix_chunk_create
+++ b/.unreleased/bugfix_chunk_create
@@ -1,0 +1,1 @@
+Fixes: #5788 Chunk_create must add existing table or fail

--- a/src/chunk.c
+++ b/src/chunk.c
@@ -1374,7 +1374,7 @@ ts_chunk_find_or_create_without_cuts(const Hypertable *ht, Hypercube *hc, const 
 
 	/* We can only use an existing chunk if it has identical dimensional
 	 * constraints. Otherwise, throw an error */
-	if (!ts_hypercube_equal(stub->cube, hc))
+	if (OidIsValid(chunk_table_relid) || !ts_hypercube_equal(stub->cube, hc))
 		ereport(ERROR,
 				(errcode(ERRCODE_TS_CHUNK_COLLISION),
 				 errmsg("chunk creation failed due to collision")));

--- a/tsl/test/expected/chunk_api.out
+++ b/tsl/test/expected/chunk_api.out
@@ -936,12 +936,19 @@ ERROR:  child table is missing constraint "chunkapi_temp_check"
 -- Add the missing CHECK constraint. Note that the name must be the
 -- same as on the parent table.
 ALTER TABLE newchunk ADD CONSTRAINT chunkapi_temp_check CHECK (temp > 0);
+CREATE TABLE newchunk2 as select * from newchunk;
+ALTER TABLE newchunk2 ADD CONSTRAINT chunkapi_temp_check CHECK (temp > 0);
 SELECT * FROM _timescaledb_internal.create_chunk('chunkapi', :'SLICES', :'CHUNK_SCHEMA', :'CHUNK_NAME', 'newchunk');
  chunk_id | hypertable_id |      schema_name      |     table_name     | relkind |                     slices                     | created 
 ----------+---------------+-----------------------+--------------------+---------+------------------------------------------------+---------
        13 |            11 | _timescaledb_internal | _hyper_10_10_chunk | r       | {"time": [1514419200000000, 1515024000000000]} | t
 (1 row)
 
+-- adding an existing table to an exiting range must fail
+\set ON_ERROR_STOP 0
+SELECT * FROM _timescaledb_internal.create_chunk('chunkapi', :'SLICES', :'CHUNK_SCHEMA', :'CHUNK_NAME', 'newchunk2');
+ERROR:  chunk creation failed due to collision
+\set ON_ERROR_STOP 1
 -- Show the chunk and that names are what we'd expect
 SELECT
 	:'CHUNK_SCHEMA' AS expected_schema,

--- a/tsl/test/sql/chunk_api.sql
+++ b/tsl/test/sql/chunk_api.sql
@@ -487,7 +487,13 @@ SELECT * FROM _timescaledb_internal.create_chunk('chunkapi', :'SLICES', :'CHUNK_
 -- Add the missing CHECK constraint. Note that the name must be the
 -- same as on the parent table.
 ALTER TABLE newchunk ADD CONSTRAINT chunkapi_temp_check CHECK (temp > 0);
+CREATE TABLE newchunk2 as select * from newchunk;
+ALTER TABLE newchunk2 ADD CONSTRAINT chunkapi_temp_check CHECK (temp > 0);
 SELECT * FROM _timescaledb_internal.create_chunk('chunkapi', :'SLICES', :'CHUNK_SCHEMA', :'CHUNK_NAME', 'newchunk');
+-- adding an existing table to an exiting range must fail
+\set ON_ERROR_STOP 0
+SELECT * FROM _timescaledb_internal.create_chunk('chunkapi', :'SLICES', :'CHUNK_SCHEMA', :'CHUNK_NAME', 'newchunk2');
+\set ON_ERROR_STOP 1
 
 -- Show the chunk and that names are what we'd expect
 SELECT


### PR DESCRIPTION
Earlier this function have completed successfully if the requested range already existed - regardless an existing table was supplied or not.