### PR TITLE
Fixed the naming of the Windows GitHub action

### DIFF
--- a/.github/workflows/windows-build-and-test-ignored.yaml
+++ b/.github/workflows/windows-build-and-test-ignored.yaml
@@ -37,6 +37,7 @@ jobs:
           echo "build_type=['Debug','Release']" >>$GITHUB_OUTPUT
         fi
   build:
+    name: PG${{ matrix.pg }} ${{ matrix.build_type }} ${{ matrix.os }}
     runs-on: ubuntu-latest
     needs: config
     strategy:


### PR DESCRIPTION
The ignored workflow for windows-build-and-test does not set the name of the actions properly. Therefore, these actions use the default naming. For example, 'Regression Windows / build (15, windows-2022, Debug)'. However, our CI expects names like 'PG15 Debug windows-2022' in the required checks. This PR corrects the name of the jobs.

Link to a PR with a missing check: https://github.com/timescale/timescaledb/pull/5777

Disable-check: force-changelog-file