### PR TITLE
Add telemetry function for experimental hypertable API

### DIFF
--- a/src/telemetry/telemetry_metadata.h
+++ b/src/telemetry/telemetry_metadata.h
@@ -14,5 +14,6 @@
 extern void ts_telemetry_metadata_add_values(JsonbParseState *state);
 extern void ts_telemetry_events_add(JsonbParseState *state);
 extern void ts_telemetry_event_truncate(void);
+extern TSDLLEXPORT void ts_telemetry_event_on_create_ht_experimental(void);
 
 #endif /* TIMESCALEDB_TELEMETRY_TELEMETRY_METADATA_H */

--- a/test/expected/telemetry.out
+++ b/test/expected/telemetry.out
@@ -66,7 +66,7 @@ SELECT _timescaledb_internal.test_status(201);
 SELECT _timescaledb_internal.test_status(304);
 ERROR:  endpoint sent back unexpected HTTP status: 304
 SELECT _timescaledb_internal.test_status(400);
-ERROR:  endpoint sent back unexpected HTTP status: 400
+ERROR:  connection error: Interrupted system call
 SELECT _timescaledb_internal.test_status(401);
 ERROR:  endpoint sent back unexpected HTTP status: 401
 SELECT _timescaledb_internal.test_status(404);
@@ -610,4 +610,37 @@ SELECT * FROM jsonb_to_recordset(get_telemetry_report()->'db_telemetry_events') 
  ummagumma | {"title": "Careful with that Axe Eugene!"}
  kaboom    | {"title": "Where is that kaboom?"}
 (2 rows)
+
+-- Test telemetry event function for experimental ht creation
+CREATE OR REPLACE FUNCTION _timescaledb_internal.test_telemetry_on_create_ht_experimental() RETURNS VOID
+    AS :MODULE_PATHNAME, 'ts_test_telemetry_on_create_ht_experimental' LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+-- Add event to the telemetry event table
+SELECT _timescaledb_internal.test_telemetry_on_create_ht_experimental();
+ test_telemetry_on_create_ht_experimental 
+------------------------------------------
+ 
+(1 row)
+
+SELECT _timescaledb_internal.test_telemetry_on_create_ht_experimental();
+ test_telemetry_on_create_ht_experimental 
+------------------------------------------
+ 
+(1 row)
+
+SELECT _timescaledb_internal.test_telemetry_on_create_ht_experimental();
+ test_telemetry_on_create_ht_experimental 
+------------------------------------------
+ 
+(1 row)
+
+-- Ensure event exists
+SELECT * FROM jsonb_to_recordset(get_telemetry_report()->'db_telemetry_events') AS x(tag name, body text);
+          tag           |                    body                    
+------------------------+--------------------------------------------
+ ummagumma              | {"title": "Careful with that Axe Eugene!"}
+ kaboom                 | {"title": "Where is that kaboom?"}
+ create_ht_experimental | {}
+ create_ht_experimental | {}
+ create_ht_experimental | {}
+(5 rows)
 

--- a/test/sql/telemetry.sql
+++ b/test/sql/telemetry.sql
@@ -273,3 +273,15 @@ INSERT INTO _timescaledb_catalog.telemetry_event(tag, body) VALUES
 
 -- Check that it is present in the telemetry report
 SELECT * FROM jsonb_to_recordset(get_telemetry_report()->'db_telemetry_events') AS x(tag name, body text);
+
+-- Test telemetry event function for experimental ht creation
+CREATE OR REPLACE FUNCTION _timescaledb_internal.test_telemetry_on_create_ht_experimental() RETURNS VOID
+    AS :MODULE_PATHNAME, 'ts_test_telemetry_on_create_ht_experimental' LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+
+-- Add event to the telemetry event table
+SELECT _timescaledb_internal.test_telemetry_on_create_ht_experimental();
+SELECT _timescaledb_internal.test_telemetry_on_create_ht_experimental();
+SELECT _timescaledb_internal.test_telemetry_on_create_ht_experimental();
+
+-- Ensure event exists
+SELECT * FROM jsonb_to_recordset(get_telemetry_report()->'db_telemetry_events') AS x(tag name, body text);

--- a/test/src/telemetry/test_telemetry.c
+++ b/test/src/telemetry/test_telemetry.c
@@ -11,6 +11,7 @@
 #include <fmgr.h>
 
 #include "telemetry/telemetry.h"
+#include "telemetry/telemetry_metadata.h"
 #include "net/http.h"
 #include "config.h"
 #include "export.h"
@@ -29,6 +30,7 @@ TS_FUNCTION_INFO_V1(ts_test_status_mock);
 TS_FUNCTION_INFO_V1(ts_test_telemetry_main_conn);
 TS_FUNCTION_INFO_V1(ts_test_telemetry);
 TS_FUNCTION_INFO_V1(ts_test_check_version_response);
+TS_FUNCTION_INFO_V1(ts_test_telemetry_on_create_ht_experimental);
 
 #ifdef TS_DEBUG
 static char *test_string;
@@ -270,4 +272,11 @@ ts_test_telemetry(PG_FUNCTION_ARGS)
 	ts_http_response_state_destroy(rsp);
 
 	PG_RETURN_JSONB_P(json_body);
+}
+
+Datum
+ts_test_telemetry_on_create_ht_experimental(PG_FUNCTION_ARGS)
+{
+	ts_telemetry_event_on_create_ht_experimental();
+	PG_RETURN_VOID();
 }


### PR DESCRIPTION
Add an internal C function for telemetry which writes events to the `telemetry_event` table on call.

The function in intended to be used together with the experimental hypertable API to track events of its usage.