### PR TITLE
Warn on usage of hierarchical realtime caggs

### DIFF
--- a/tsl/src/continuous_aggs/create.c
+++ b/tsl/src/continuous_aggs/create.c
@@ -717,6 +717,8 @@ cagg_create(const CreateTableAsStmt *create_stmt, ViewStmt *stmt, Query *panquer
 
 	finalqinfo.finalized = finalized;
 
+	warn_if_hierarchical_realtime_cagg(bucket_info->parent_mat_hypertable_id, materialized_only);
+
 	/*
 	 * Assign the column_name aliases in CREATE VIEW to the query.
 	 * No other modifications to panquery.

--- a/tsl/src/continuous_aggs/options.h
+++ b/tsl/src/continuous_aggs/options.h
@@ -12,5 +12,6 @@
 
 extern void continuous_agg_update_options(ContinuousAgg *cagg,
 										  WithClauseResult *with_clause_options);
+void warn_if_hierarchical_realtime_cagg(int32 parent_mat_hypertable_id, bool materialized_only);
 
 #endif /* TIMESCALEDB_TSL_CONTINUOUS_AGGS_OPTIONS_H */

--- a/tsl/test/expected/cagg_on_cagg.out
+++ b/tsl/test/expected/cagg_on_cagg.out
@@ -193,6 +193,7 @@ SELECT * FROM :CAGG_NAME_2TH_LEVEL ORDER BY bucket, temperature;
 -- Turn CAGGs into Realtime
 ALTER MATERIALIZED VIEW :CAGG_NAME_1ST_LEVEL SET (timescaledb.materialized_only=false);
 ALTER MATERIALIZED VIEW :CAGG_NAME_2TH_LEVEL SET (timescaledb.materialized_only=false);
+psql:include/cagg_on_cagg_common.sql:84: WARNING:  Nested realtime continous aggregates may increase planning and execution time significantly
 --ALTER MATERIALIZED VIEW :CAGG_NAME_3TH_LEVEL SET (timescaledb.materialized_only=false);
 -- Realtime data
 SELECT * FROM :CAGG_NAME_1ST_LEVEL ORDER BY bucket;
@@ -276,8 +277,10 @@ SELECT * FROM :CAGG_NAME_3TH_LEVEL ORDER BY bucket;
 
 -- Turn CAGGs into Realtime
 ALTER MATERIALIZED VIEW :CAGG_NAME_1ST_LEVEL SET (timescaledb.materialized_only=false);
-ALTER MATERIALIZED VIEW :CAGG_NAME_2TH_LEVEL SET (timescaledb.materialized_only=false);
 ALTER MATERIALIZED VIEW :CAGG_NAME_3TH_LEVEL SET (timescaledb.materialized_only=false);
+psql:include/cagg_on_cagg_common.sql:126: WARNING:  Nested realtime continous aggregates may increase planning and execution time significantly
+ALTER MATERIALIZED VIEW :CAGG_NAME_2TH_LEVEL SET (timescaledb.materialized_only=false);
+psql:include/cagg_on_cagg_common.sql:127: WARNING:  Nested realtime continous aggregates may increase planning and execution time significantly
 -- Realtime changes, just new region
 SELECT * FROM :CAGG_NAME_1ST_LEVEL ORDER BY bucket;
  bucket | temperature | device_id 
@@ -610,6 +613,7 @@ SELECT * FROM :CAGG_NAME_2TH_LEVEL ORDER BY bucket, temperature;
 -- Turn CAGGs into Realtime
 ALTER MATERIALIZED VIEW :CAGG_NAME_1ST_LEVEL SET (timescaledb.materialized_only=false);
 ALTER MATERIALIZED VIEW :CAGG_NAME_2TH_LEVEL SET (timescaledb.materialized_only=false);
+psql:include/cagg_on_cagg_common.sql:84: WARNING:  Nested realtime continous aggregates may increase planning and execution time significantly
 --ALTER MATERIALIZED VIEW :CAGG_NAME_3TH_LEVEL SET (timescaledb.materialized_only=false);
 -- Realtime data
 SELECT * FROM :CAGG_NAME_1ST_LEVEL ORDER BY bucket;
@@ -693,8 +697,10 @@ SELECT * FROM :CAGG_NAME_3TH_LEVEL ORDER BY bucket;
 
 -- Turn CAGGs into Realtime
 ALTER MATERIALIZED VIEW :CAGG_NAME_1ST_LEVEL SET (timescaledb.materialized_only=false);
-ALTER MATERIALIZED VIEW :CAGG_NAME_2TH_LEVEL SET (timescaledb.materialized_only=false);
 ALTER MATERIALIZED VIEW :CAGG_NAME_3TH_LEVEL SET (timescaledb.materialized_only=false);
+psql:include/cagg_on_cagg_common.sql:126: WARNING:  Nested realtime continous aggregates may increase planning and execution time significantly
+ALTER MATERIALIZED VIEW :CAGG_NAME_2TH_LEVEL SET (timescaledb.materialized_only=false);
+psql:include/cagg_on_cagg_common.sql:127: WARNING:  Nested realtime continous aggregates may increase planning and execution time significantly
 -- Realtime changes, just new region
 SELECT * FROM :CAGG_NAME_1ST_LEVEL ORDER BY bucket;
  bucket | temperature | device_id 
@@ -995,6 +1001,8 @@ SELECT
 FROM :CAGG_NAME_1ST_LEVEL
 GROUP BY 1
 WITH NO DATA;
+psql:include/cagg_on_cagg_validations.sql:43: WARNING:  Nested realtime continous aggregates may increase planning and execution time significantly
+HINT:  consider using materialized_only=true
 \d+ :CAGG_NAME_2TH_LEVEL
                        View "public.conditions_summary_2"
    Column    |  Type   | Collation | Nullable | Default | Storage | Description 
@@ -1278,6 +1286,7 @@ SELECT * FROM :CAGG_NAME_2TH_LEVEL ORDER BY bucket, temperature;
 -- Turn CAGGs into Realtime
 ALTER MATERIALIZED VIEW :CAGG_NAME_1ST_LEVEL SET (timescaledb.materialized_only=false);
 ALTER MATERIALIZED VIEW :CAGG_NAME_2TH_LEVEL SET (timescaledb.materialized_only=false);
+psql:include/cagg_on_cagg_common.sql:84: WARNING:  Nested realtime continous aggregates may increase planning and execution time significantly
 --ALTER MATERIALIZED VIEW :CAGG_NAME_3TH_LEVEL SET (timescaledb.materialized_only=false);
 -- Realtime data
 SELECT * FROM :CAGG_NAME_1ST_LEVEL ORDER BY bucket;
@@ -1361,8 +1370,10 @@ SELECT * FROM :CAGG_NAME_3TH_LEVEL ORDER BY bucket;
 
 -- Turn CAGGs into Realtime
 ALTER MATERIALIZED VIEW :CAGG_NAME_1ST_LEVEL SET (timescaledb.materialized_only=false);
-ALTER MATERIALIZED VIEW :CAGG_NAME_2TH_LEVEL SET (timescaledb.materialized_only=false);
 ALTER MATERIALIZED VIEW :CAGG_NAME_3TH_LEVEL SET (timescaledb.materialized_only=false);
+psql:include/cagg_on_cagg_common.sql:126: WARNING:  Nested realtime continous aggregates may increase planning and execution time significantly
+ALTER MATERIALIZED VIEW :CAGG_NAME_2TH_LEVEL SET (timescaledb.materialized_only=false);
+psql:include/cagg_on_cagg_common.sql:127: WARNING:  Nested realtime continous aggregates may increase planning and execution time significantly
 -- Realtime changes, just new region
 SELECT * FROM :CAGG_NAME_1ST_LEVEL ORDER BY bucket;
           bucket          | temperature | device_id 
@@ -1691,6 +1702,7 @@ SELECT * FROM :CAGG_NAME_2TH_LEVEL ORDER BY bucket, temperature;
 -- Turn CAGGs into Realtime
 ALTER MATERIALIZED VIEW :CAGG_NAME_1ST_LEVEL SET (timescaledb.materialized_only=false);
 ALTER MATERIALIZED VIEW :CAGG_NAME_2TH_LEVEL SET (timescaledb.materialized_only=false);
+psql:include/cagg_on_cagg_common.sql:84: WARNING:  Nested realtime continous aggregates may increase planning and execution time significantly
 --ALTER MATERIALIZED VIEW :CAGG_NAME_3TH_LEVEL SET (timescaledb.materialized_only=false);
 -- Realtime data
 SELECT * FROM :CAGG_NAME_1ST_LEVEL ORDER BY bucket;
@@ -1774,8 +1786,10 @@ SELECT * FROM :CAGG_NAME_3TH_LEVEL ORDER BY bucket;
 
 -- Turn CAGGs into Realtime
 ALTER MATERIALIZED VIEW :CAGG_NAME_1ST_LEVEL SET (timescaledb.materialized_only=false);
-ALTER MATERIALIZED VIEW :CAGG_NAME_2TH_LEVEL SET (timescaledb.materialized_only=false);
 ALTER MATERIALIZED VIEW :CAGG_NAME_3TH_LEVEL SET (timescaledb.materialized_only=false);
+psql:include/cagg_on_cagg_common.sql:126: WARNING:  Nested realtime continous aggregates may increase planning and execution time significantly
+ALTER MATERIALIZED VIEW :CAGG_NAME_2TH_LEVEL SET (timescaledb.materialized_only=false);
+psql:include/cagg_on_cagg_common.sql:127: WARNING:  Nested realtime continous aggregates may increase planning and execution time significantly
 -- Realtime changes, just new region
 SELECT * FROM :CAGG_NAME_1ST_LEVEL ORDER BY bucket;
           bucket          | temperature | device_id 
@@ -2152,6 +2166,8 @@ SELECT
 FROM :CAGG_NAME_1ST_LEVEL
 GROUP BY 1
 WITH NO DATA;
+psql:include/cagg_on_cagg_validations.sql:43: WARNING:  Nested realtime continous aggregates may increase planning and execution time significantly
+HINT:  consider using materialized_only=true
 \d+ :CAGG_NAME_2TH_LEVEL
                                  View "public.conditions_summary_2"
    Column    |            Type             | Collation | Nullable | Default | Storage | Description 
@@ -2434,6 +2450,7 @@ SELECT * FROM :CAGG_NAME_2TH_LEVEL ORDER BY bucket, temperature;
 -- Turn CAGGs into Realtime
 ALTER MATERIALIZED VIEW :CAGG_NAME_1ST_LEVEL SET (timescaledb.materialized_only=false);
 ALTER MATERIALIZED VIEW :CAGG_NAME_2TH_LEVEL SET (timescaledb.materialized_only=false);
+psql:include/cagg_on_cagg_common.sql:84: WARNING:  Nested realtime continous aggregates may increase planning and execution time significantly
 --ALTER MATERIALIZED VIEW :CAGG_NAME_3TH_LEVEL SET (timescaledb.materialized_only=false);
 -- Realtime data
 SELECT * FROM :CAGG_NAME_1ST_LEVEL ORDER BY bucket;
@@ -2517,8 +2534,10 @@ SELECT * FROM :CAGG_NAME_3TH_LEVEL ORDER BY bucket;
 
 -- Turn CAGGs into Realtime
 ALTER MATERIALIZED VIEW :CAGG_NAME_1ST_LEVEL SET (timescaledb.materialized_only=false);
-ALTER MATERIALIZED VIEW :CAGG_NAME_2TH_LEVEL SET (timescaledb.materialized_only=false);
 ALTER MATERIALIZED VIEW :CAGG_NAME_3TH_LEVEL SET (timescaledb.materialized_only=false);
+psql:include/cagg_on_cagg_common.sql:126: WARNING:  Nested realtime continous aggregates may increase planning and execution time significantly
+ALTER MATERIALIZED VIEW :CAGG_NAME_2TH_LEVEL SET (timescaledb.materialized_only=false);
+psql:include/cagg_on_cagg_common.sql:127: WARNING:  Nested realtime continous aggregates may increase planning and execution time significantly
 -- Realtime changes, just new region
 SELECT * FROM :CAGG_NAME_1ST_LEVEL ORDER BY bucket;
             bucket            | temperature | device_id 
@@ -2846,6 +2865,7 @@ SELECT * FROM :CAGG_NAME_2TH_LEVEL ORDER BY bucket, temperature;
 -- Turn CAGGs into Realtime
 ALTER MATERIALIZED VIEW :CAGG_NAME_1ST_LEVEL SET (timescaledb.materialized_only=false);
 ALTER MATERIALIZED VIEW :CAGG_NAME_2TH_LEVEL SET (timescaledb.materialized_only=false);
+psql:include/cagg_on_cagg_common.sql:84: WARNING:  Nested realtime continous aggregates may increase planning and execution time significantly
 --ALTER MATERIALIZED VIEW :CAGG_NAME_3TH_LEVEL SET (timescaledb.materialized_only=false);
 -- Realtime data
 SELECT * FROM :CAGG_NAME_1ST_LEVEL ORDER BY bucket;
@@ -2929,8 +2949,10 @@ SELECT * FROM :CAGG_NAME_3TH_LEVEL ORDER BY bucket;
 
 -- Turn CAGGs into Realtime
 ALTER MATERIALIZED VIEW :CAGG_NAME_1ST_LEVEL SET (timescaledb.materialized_only=false);
-ALTER MATERIALIZED VIEW :CAGG_NAME_2TH_LEVEL SET (timescaledb.materialized_only=false);
 ALTER MATERIALIZED VIEW :CAGG_NAME_3TH_LEVEL SET (timescaledb.materialized_only=false);
+psql:include/cagg_on_cagg_common.sql:126: WARNING:  Nested realtime continous aggregates may increase planning and execution time significantly
+ALTER MATERIALIZED VIEW :CAGG_NAME_2TH_LEVEL SET (timescaledb.materialized_only=false);
+psql:include/cagg_on_cagg_common.sql:127: WARNING:  Nested realtime continous aggregates may increase planning and execution time significantly
 -- Realtime changes, just new region
 SELECT * FROM :CAGG_NAME_1ST_LEVEL ORDER BY bucket;
             bucket            | temperature | device_id 
@@ -3307,6 +3329,8 @@ SELECT
 FROM :CAGG_NAME_1ST_LEVEL
 GROUP BY 1
 WITH NO DATA;
+psql:include/cagg_on_cagg_validations.sql:43: WARNING:  Nested realtime continous aggregates may increase planning and execution time significantly
+HINT:  consider using materialized_only=true
 \d+ :CAGG_NAME_2TH_LEVEL
                                View "public.conditions_summary_2"
    Column    |           Type           | Collation | Nullable | Default | Storage | Description 
@@ -3478,6 +3502,8 @@ SELECT
 FROM :CAGG_NAME_1ST_LEVEL
 GROUP BY 1
 WITH NO DATA;
+psql:include/cagg_on_cagg_validations.sql:43: WARNING:  Nested realtime continous aggregates may increase planning and execution time significantly
+HINT:  consider using materialized_only=true
 \d+ :CAGG_NAME_2TH_LEVEL
                                View "public.conditions_summary_2"
    Column    |           Type           | Collation | Nullable | Default | Storage | Description 
@@ -3641,6 +3667,8 @@ SELECT
 FROM :CAGG_NAME_1ST_LEVEL
 GROUP BY 1
 WITH NO DATA;
+psql:include/cagg_on_cagg_validations.sql:43: WARNING:  Nested realtime continous aggregates may increase planning and execution time significantly
+HINT:  consider using materialized_only=true
 \d+ :CAGG_NAME_2TH_LEVEL
                                View "public.conditions_summary_2"
    Column    |           Type           | Collation | Nullable | Default | Storage | Description 
@@ -3732,6 +3760,8 @@ SELECT
 FROM :CAGG_NAME_1ST_LEVEL
 GROUP BY 1
 WITH NO DATA;
+psql:include/cagg_on_cagg_validations.sql:43: WARNING:  Nested realtime continous aggregates may increase planning and execution time significantly
+HINT:  consider using materialized_only=true
 \d+ :CAGG_NAME_2TH_LEVEL
                                View "public.conditions_summary_2"
    Column    |           Type           | Collation | Nullable | Default | Storage | Description 
@@ -3824,6 +3854,8 @@ SELECT
 FROM :CAGG_NAME_1ST_LEVEL
 GROUP BY 1
 WITH NO DATA;
+psql:include/cagg_on_cagg_validations.sql:43: WARNING:  Nested realtime continous aggregates may increase planning and execution time significantly
+HINT:  consider using materialized_only=true
 \d+ :CAGG_NAME_2TH_LEVEL
                                View "public.conditions_summary_2"
    Column    |           Type           | Collation | Nullable | Default | Storage | Description 
@@ -3916,6 +3948,8 @@ SELECT
 FROM :CAGG_NAME_1ST_LEVEL
 GROUP BY 1
 WITH NO DATA;
+psql:include/cagg_on_cagg_validations.sql:43: WARNING:  Nested realtime continous aggregates may increase planning and execution time significantly
+HINT:  consider using materialized_only=true
 \d+ :CAGG_NAME_2TH_LEVEL
                                View "public.conditions_summary_2"
    Column    |           Type           | Collation | Nullable | Default | Storage | Description 
@@ -4007,6 +4041,8 @@ SELECT
 FROM :CAGG_NAME_1ST_LEVEL
 GROUP BY 1
 WITH NO DATA;
+psql:include/cagg_on_cagg_validations.sql:43: WARNING:  Nested realtime continous aggregates may increase planning and execution time significantly
+HINT:  consider using materialized_only=true
 \d+ :CAGG_NAME_2TH_LEVEL
                                View "public.conditions_summary_2"
    Column    |           Type           | Collation | Nullable | Default | Storage | Description 
@@ -4092,6 +4128,8 @@ SELECT
 FROM :CAGG_NAME_1ST_LEVEL
 GROUP BY 1
 WITH NO DATA;
+psql:include/cagg_on_cagg_validations.sql:43: WARNING:  Nested realtime continous aggregates may increase planning and execution time significantly
+HINT:  consider using materialized_only=true
 \d+ :CAGG_NAME_2TH_LEVEL
                                View "public.conditions_summary_2"
    Column    |           Type           | Collation | Nullable | Default | Storage | Description 
@@ -4177,6 +4215,8 @@ SELECT
 FROM :CAGG_NAME_1ST_LEVEL
 GROUP BY 1
 WITH NO DATA;
+psql:include/cagg_on_cagg_validations.sql:43: WARNING:  Nested realtime continous aggregates may increase planning and execution time significantly
+HINT:  consider using materialized_only=true
 \d+ :CAGG_NAME_2TH_LEVEL
                                View "public.conditions_summary_2"
    Column    |           Type           | Collation | Nullable | Default | Storage | Description 
@@ -4408,6 +4448,8 @@ SELECT
 FROM :CAGG_NAME_1ST_LEVEL
 GROUP BY 1
 WITH NO DATA;
+psql:include/cagg_on_cagg_validations.sql:43: WARNING:  Nested realtime continous aggregates may increase planning and execution time significantly
+HINT:  consider using materialized_only=true
 \d+ :CAGG_NAME_2TH_LEVEL
                                View "public.conditions_summary_2"
    Column    |           Type           | Collation | Nullable | Default | Storage | Description 
@@ -4493,6 +4535,8 @@ SELECT
 FROM :CAGG_NAME_1ST_LEVEL
 GROUP BY 1
 WITH NO DATA;
+psql:include/cagg_on_cagg_validations.sql:43: WARNING:  Nested realtime continous aggregates may increase planning and execution time significantly
+HINT:  consider using materialized_only=true
 \d+ :CAGG_NAME_2TH_LEVEL
                                View "public.conditions_summary_2"
    Column    |           Type           | Collation | Nullable | Default | Storage | Description 
@@ -4578,6 +4622,8 @@ SELECT
 FROM :CAGG_NAME_1ST_LEVEL
 GROUP BY 1
 WITH NO DATA;
+psql:include/cagg_on_cagg_validations.sql:43: WARNING:  Nested realtime continous aggregates may increase planning and execution time significantly
+HINT:  consider using materialized_only=true
 \d+ :CAGG_NAME_2TH_LEVEL
                                View "public.conditions_summary_2"
    Column    |           Type           | Collation | Nullable | Default | Storage | Description 
@@ -4664,6 +4710,8 @@ SELECT
 FROM :CAGG_NAME_1ST_LEVEL
 GROUP BY 1
 WITH NO DATA;
+psql:include/cagg_on_cagg_validations.sql:43: WARNING:  Nested realtime continous aggregates may increase planning and execution time significantly
+HINT:  consider using materialized_only=true
 \d+ :CAGG_NAME_2TH_LEVEL
                                View "public.conditions_summary_2"
    Column    |           Type           | Collation | Nullable | Default | Storage | Description 

--- a/tsl/test/expected/cagg_on_cagg_dist_ht.out
+++ b/tsl/test/expected/cagg_on_cagg_dist_ht.out
@@ -227,6 +227,7 @@ SELECT * FROM :CAGG_NAME_2TH_LEVEL ORDER BY bucket, temperature;
 -- Turn CAGGs into Realtime
 ALTER MATERIALIZED VIEW :CAGG_NAME_1ST_LEVEL SET (timescaledb.materialized_only=false);
 ALTER MATERIALIZED VIEW :CAGG_NAME_2TH_LEVEL SET (timescaledb.materialized_only=false);
+psql:include/cagg_on_cagg_common.sql:84: WARNING:  Nested realtime continous aggregates may increase planning and execution time significantly
 --ALTER MATERIALIZED VIEW :CAGG_NAME_3TH_LEVEL SET (timescaledb.materialized_only=false);
 -- Realtime data
 SELECT * FROM :CAGG_NAME_1ST_LEVEL ORDER BY bucket;
@@ -310,8 +311,10 @@ SELECT * FROM :CAGG_NAME_3TH_LEVEL ORDER BY bucket;
 
 -- Turn CAGGs into Realtime
 ALTER MATERIALIZED VIEW :CAGG_NAME_1ST_LEVEL SET (timescaledb.materialized_only=false);
-ALTER MATERIALIZED VIEW :CAGG_NAME_2TH_LEVEL SET (timescaledb.materialized_only=false);
 ALTER MATERIALIZED VIEW :CAGG_NAME_3TH_LEVEL SET (timescaledb.materialized_only=false);
+psql:include/cagg_on_cagg_common.sql:126: WARNING:  Nested realtime continous aggregates may increase planning and execution time significantly
+ALTER MATERIALIZED VIEW :CAGG_NAME_2TH_LEVEL SET (timescaledb.materialized_only=false);
+psql:include/cagg_on_cagg_common.sql:127: WARNING:  Nested realtime continous aggregates may increase planning and execution time significantly
 -- Realtime changes, just new region
 SELECT * FROM :CAGG_NAME_1ST_LEVEL ORDER BY bucket;
  bucket | temperature | device_id 
@@ -644,6 +647,7 @@ SELECT * FROM :CAGG_NAME_2TH_LEVEL ORDER BY bucket, temperature;
 -- Turn CAGGs into Realtime
 ALTER MATERIALIZED VIEW :CAGG_NAME_1ST_LEVEL SET (timescaledb.materialized_only=false);
 ALTER MATERIALIZED VIEW :CAGG_NAME_2TH_LEVEL SET (timescaledb.materialized_only=false);
+psql:include/cagg_on_cagg_common.sql:84: WARNING:  Nested realtime continous aggregates may increase planning and execution time significantly
 --ALTER MATERIALIZED VIEW :CAGG_NAME_3TH_LEVEL SET (timescaledb.materialized_only=false);
 -- Realtime data
 SELECT * FROM :CAGG_NAME_1ST_LEVEL ORDER BY bucket;
@@ -727,8 +731,10 @@ SELECT * FROM :CAGG_NAME_3TH_LEVEL ORDER BY bucket;
 
 -- Turn CAGGs into Realtime
 ALTER MATERIALIZED VIEW :CAGG_NAME_1ST_LEVEL SET (timescaledb.materialized_only=false);
-ALTER MATERIALIZED VIEW :CAGG_NAME_2TH_LEVEL SET (timescaledb.materialized_only=false);
 ALTER MATERIALIZED VIEW :CAGG_NAME_3TH_LEVEL SET (timescaledb.materialized_only=false);
+psql:include/cagg_on_cagg_common.sql:126: WARNING:  Nested realtime continous aggregates may increase planning and execution time significantly
+ALTER MATERIALIZED VIEW :CAGG_NAME_2TH_LEVEL SET (timescaledb.materialized_only=false);
+psql:include/cagg_on_cagg_common.sql:127: WARNING:  Nested realtime continous aggregates may increase planning and execution time significantly
 -- Realtime changes, just new region
 SELECT * FROM :CAGG_NAME_1ST_LEVEL ORDER BY bucket;
  bucket | temperature | device_id 
@@ -1029,6 +1035,8 @@ SELECT
 FROM :CAGG_NAME_1ST_LEVEL
 GROUP BY 1
 WITH NO DATA;
+psql:include/cagg_on_cagg_validations.sql:43: WARNING:  Nested realtime continous aggregates may increase planning and execution time significantly
+HINT:  consider using materialized_only=true
 \d+ :CAGG_NAME_2TH_LEVEL
                        View "public.conditions_summary_2"
    Column    |  Type   | Collation | Nullable | Default | Storage | Description 
@@ -1315,6 +1323,7 @@ SELECT * FROM :CAGG_NAME_2TH_LEVEL ORDER BY bucket, temperature;
 -- Turn CAGGs into Realtime
 ALTER MATERIALIZED VIEW :CAGG_NAME_1ST_LEVEL SET (timescaledb.materialized_only=false);
 ALTER MATERIALIZED VIEW :CAGG_NAME_2TH_LEVEL SET (timescaledb.materialized_only=false);
+psql:include/cagg_on_cagg_common.sql:84: WARNING:  Nested realtime continous aggregates may increase planning and execution time significantly
 --ALTER MATERIALIZED VIEW :CAGG_NAME_3TH_LEVEL SET (timescaledb.materialized_only=false);
 -- Realtime data
 SELECT * FROM :CAGG_NAME_1ST_LEVEL ORDER BY bucket;
@@ -1398,8 +1407,10 @@ SELECT * FROM :CAGG_NAME_3TH_LEVEL ORDER BY bucket;
 
 -- Turn CAGGs into Realtime
 ALTER MATERIALIZED VIEW :CAGG_NAME_1ST_LEVEL SET (timescaledb.materialized_only=false);
-ALTER MATERIALIZED VIEW :CAGG_NAME_2TH_LEVEL SET (timescaledb.materialized_only=false);
 ALTER MATERIALIZED VIEW :CAGG_NAME_3TH_LEVEL SET (timescaledb.materialized_only=false);
+psql:include/cagg_on_cagg_common.sql:126: WARNING:  Nested realtime continous aggregates may increase planning and execution time significantly
+ALTER MATERIALIZED VIEW :CAGG_NAME_2TH_LEVEL SET (timescaledb.materialized_only=false);
+psql:include/cagg_on_cagg_common.sql:127: WARNING:  Nested realtime continous aggregates may increase planning and execution time significantly
 -- Realtime changes, just new region
 SELECT * FROM :CAGG_NAME_1ST_LEVEL ORDER BY bucket;
           bucket          | temperature | device_id 
@@ -1728,6 +1739,7 @@ SELECT * FROM :CAGG_NAME_2TH_LEVEL ORDER BY bucket, temperature;
 -- Turn CAGGs into Realtime
 ALTER MATERIALIZED VIEW :CAGG_NAME_1ST_LEVEL SET (timescaledb.materialized_only=false);
 ALTER MATERIALIZED VIEW :CAGG_NAME_2TH_LEVEL SET (timescaledb.materialized_only=false);
+psql:include/cagg_on_cagg_common.sql:84: WARNING:  Nested realtime continous aggregates may increase planning and execution time significantly
 --ALTER MATERIALIZED VIEW :CAGG_NAME_3TH_LEVEL SET (timescaledb.materialized_only=false);
 -- Realtime data
 SELECT * FROM :CAGG_NAME_1ST_LEVEL ORDER BY bucket;
@@ -1811,8 +1823,10 @@ SELECT * FROM :CAGG_NAME_3TH_LEVEL ORDER BY bucket;
 
 -- Turn CAGGs into Realtime
 ALTER MATERIALIZED VIEW :CAGG_NAME_1ST_LEVEL SET (timescaledb.materialized_only=false);
-ALTER MATERIALIZED VIEW :CAGG_NAME_2TH_LEVEL SET (timescaledb.materialized_only=false);
 ALTER MATERIALIZED VIEW :CAGG_NAME_3TH_LEVEL SET (timescaledb.materialized_only=false);
+psql:include/cagg_on_cagg_common.sql:126: WARNING:  Nested realtime continous aggregates may increase planning and execution time significantly
+ALTER MATERIALIZED VIEW :CAGG_NAME_2TH_LEVEL SET (timescaledb.materialized_only=false);
+psql:include/cagg_on_cagg_common.sql:127: WARNING:  Nested realtime continous aggregates may increase planning and execution time significantly
 -- Realtime changes, just new region
 SELECT * FROM :CAGG_NAME_1ST_LEVEL ORDER BY bucket;
           bucket          | temperature | device_id 
@@ -2189,6 +2203,8 @@ SELECT
 FROM :CAGG_NAME_1ST_LEVEL
 GROUP BY 1
 WITH NO DATA;
+psql:include/cagg_on_cagg_validations.sql:43: WARNING:  Nested realtime continous aggregates may increase planning and execution time significantly
+HINT:  consider using materialized_only=true
 \d+ :CAGG_NAME_2TH_LEVEL
                                  View "public.conditions_summary_2"
    Column    |            Type             | Collation | Nullable | Default | Storage | Description 
@@ -2471,6 +2487,7 @@ SELECT * FROM :CAGG_NAME_2TH_LEVEL ORDER BY bucket, temperature;
 -- Turn CAGGs into Realtime
 ALTER MATERIALIZED VIEW :CAGG_NAME_1ST_LEVEL SET (timescaledb.materialized_only=false);
 ALTER MATERIALIZED VIEW :CAGG_NAME_2TH_LEVEL SET (timescaledb.materialized_only=false);
+psql:include/cagg_on_cagg_common.sql:84: WARNING:  Nested realtime continous aggregates may increase planning and execution time significantly
 --ALTER MATERIALIZED VIEW :CAGG_NAME_3TH_LEVEL SET (timescaledb.materialized_only=false);
 -- Realtime data
 SELECT * FROM :CAGG_NAME_1ST_LEVEL ORDER BY bucket;
@@ -2554,8 +2571,10 @@ SELECT * FROM :CAGG_NAME_3TH_LEVEL ORDER BY bucket;
 
 -- Turn CAGGs into Realtime
 ALTER MATERIALIZED VIEW :CAGG_NAME_1ST_LEVEL SET (timescaledb.materialized_only=false);
-ALTER MATERIALIZED VIEW :CAGG_NAME_2TH_LEVEL SET (timescaledb.materialized_only=false);
 ALTER MATERIALIZED VIEW :CAGG_NAME_3TH_LEVEL SET (timescaledb.materialized_only=false);
+psql:include/cagg_on_cagg_common.sql:126: WARNING:  Nested realtime continous aggregates may increase planning and execution time significantly
+ALTER MATERIALIZED VIEW :CAGG_NAME_2TH_LEVEL SET (timescaledb.materialized_only=false);
+psql:include/cagg_on_cagg_common.sql:127: WARNING:  Nested realtime continous aggregates may increase planning and execution time significantly
 -- Realtime changes, just new region
 SELECT * FROM :CAGG_NAME_1ST_LEVEL ORDER BY bucket;
             bucket            | temperature | device_id 
@@ -2883,6 +2902,7 @@ SELECT * FROM :CAGG_NAME_2TH_LEVEL ORDER BY bucket, temperature;
 -- Turn CAGGs into Realtime
 ALTER MATERIALIZED VIEW :CAGG_NAME_1ST_LEVEL SET (timescaledb.materialized_only=false);
 ALTER MATERIALIZED VIEW :CAGG_NAME_2TH_LEVEL SET (timescaledb.materialized_only=false);
+psql:include/cagg_on_cagg_common.sql:84: WARNING:  Nested realtime continous aggregates may increase planning and execution time significantly
 --ALTER MATERIALIZED VIEW :CAGG_NAME_3TH_LEVEL SET (timescaledb.materialized_only=false);
 -- Realtime data
 SELECT * FROM :CAGG_NAME_1ST_LEVEL ORDER BY bucket;
@@ -2966,8 +2986,10 @@ SELECT * FROM :CAGG_NAME_3TH_LEVEL ORDER BY bucket;
 
 -- Turn CAGGs into Realtime
 ALTER MATERIALIZED VIEW :CAGG_NAME_1ST_LEVEL SET (timescaledb.materialized_only=false);
-ALTER MATERIALIZED VIEW :CAGG_NAME_2TH_LEVEL SET (timescaledb.materialized_only=false);
 ALTER MATERIALIZED VIEW :CAGG_NAME_3TH_LEVEL SET (timescaledb.materialized_only=false);
+psql:include/cagg_on_cagg_common.sql:126: WARNING:  Nested realtime continous aggregates may increase planning and execution time significantly
+ALTER MATERIALIZED VIEW :CAGG_NAME_2TH_LEVEL SET (timescaledb.materialized_only=false);
+psql:include/cagg_on_cagg_common.sql:127: WARNING:  Nested realtime continous aggregates may increase planning and execution time significantly
 -- Realtime changes, just new region
 SELECT * FROM :CAGG_NAME_1ST_LEVEL ORDER BY bucket;
             bucket            | temperature | device_id 
@@ -3344,6 +3366,8 @@ SELECT
 FROM :CAGG_NAME_1ST_LEVEL
 GROUP BY 1
 WITH NO DATA;
+psql:include/cagg_on_cagg_validations.sql:43: WARNING:  Nested realtime continous aggregates may increase planning and execution time significantly
+HINT:  consider using materialized_only=true
 \d+ :CAGG_NAME_2TH_LEVEL
                                View "public.conditions_summary_2"
    Column    |           Type           | Collation | Nullable | Default | Storage | Description 
@@ -3515,6 +3539,8 @@ SELECT
 FROM :CAGG_NAME_1ST_LEVEL
 GROUP BY 1
 WITH NO DATA;
+psql:include/cagg_on_cagg_validations.sql:43: WARNING:  Nested realtime continous aggregates may increase planning and execution time significantly
+HINT:  consider using materialized_only=true
 \d+ :CAGG_NAME_2TH_LEVEL
                                View "public.conditions_summary_2"
    Column    |           Type           | Collation | Nullable | Default | Storage | Description 
@@ -3678,6 +3704,8 @@ SELECT
 FROM :CAGG_NAME_1ST_LEVEL
 GROUP BY 1
 WITH NO DATA;
+psql:include/cagg_on_cagg_validations.sql:43: WARNING:  Nested realtime continous aggregates may increase planning and execution time significantly
+HINT:  consider using materialized_only=true
 \d+ :CAGG_NAME_2TH_LEVEL
                                View "public.conditions_summary_2"
    Column    |           Type           | Collation | Nullable | Default | Storage | Description 
@@ -3769,6 +3797,8 @@ SELECT
 FROM :CAGG_NAME_1ST_LEVEL
 GROUP BY 1
 WITH NO DATA;
+psql:include/cagg_on_cagg_validations.sql:43: WARNING:  Nested realtime continous aggregates may increase planning and execution time significantly
+HINT:  consider using materialized_only=true
 \d+ :CAGG_NAME_2TH_LEVEL
                                View "public.conditions_summary_2"
    Column    |           Type           | Collation | Nullable | Default | Storage | Description 
@@ -3861,6 +3891,8 @@ SELECT
 FROM :CAGG_NAME_1ST_LEVEL
 GROUP BY 1
 WITH NO DATA;
+psql:include/cagg_on_cagg_validations.sql:43: WARNING:  Nested realtime continous aggregates may increase planning and execution time significantly
+HINT:  consider using materialized_only=true
 \d+ :CAGG_NAME_2TH_LEVEL
                                View "public.conditions_summary_2"
    Column    |           Type           | Collation | Nullable | Default | Storage | Description 
@@ -3953,6 +3985,8 @@ SELECT
 FROM :CAGG_NAME_1ST_LEVEL
 GROUP BY 1
 WITH NO DATA;
+psql:include/cagg_on_cagg_validations.sql:43: WARNING:  Nested realtime continous aggregates may increase planning and execution time significantly
+HINT:  consider using materialized_only=true
 \d+ :CAGG_NAME_2TH_LEVEL
                                View "public.conditions_summary_2"
    Column    |           Type           | Collation | Nullable | Default | Storage | Description 
@@ -4039,6 +4073,8 @@ SELECT
 FROM :CAGG_NAME_1ST_LEVEL
 GROUP BY 1
 WITH NO DATA;
+psql:include/cagg_on_cagg_validations.sql:43: WARNING:  Nested realtime continous aggregates may increase planning and execution time significantly
+HINT:  consider using materialized_only=true
 \d+ :CAGG_NAME_2TH_LEVEL
                                View "public.conditions_summary_2"
    Column    |           Type           | Collation | Nullable | Default | Storage | Description 
@@ -4124,6 +4160,8 @@ SELECT
 FROM :CAGG_NAME_1ST_LEVEL
 GROUP BY 1
 WITH NO DATA;
+psql:include/cagg_on_cagg_validations.sql:43: WARNING:  Nested realtime continous aggregates may increase planning and execution time significantly
+HINT:  consider using materialized_only=true
 \d+ :CAGG_NAME_2TH_LEVEL
                                View "public.conditions_summary_2"
    Column    |           Type           | Collation | Nullable | Default | Storage | Description 
@@ -4209,6 +4247,8 @@ SELECT
 FROM :CAGG_NAME_1ST_LEVEL
 GROUP BY 1
 WITH NO DATA;
+psql:include/cagg_on_cagg_validations.sql:43: WARNING:  Nested realtime continous aggregates may increase planning and execution time significantly
+HINT:  consider using materialized_only=true
 \d+ :CAGG_NAME_2TH_LEVEL
                                View "public.conditions_summary_2"
    Column    |           Type           | Collation | Nullable | Default | Storage | Description 
@@ -4440,6 +4480,8 @@ SELECT
 FROM :CAGG_NAME_1ST_LEVEL
 GROUP BY 1
 WITH NO DATA;
+psql:include/cagg_on_cagg_validations.sql:43: WARNING:  Nested realtime continous aggregates may increase planning and execution time significantly
+HINT:  consider using materialized_only=true
 \d+ :CAGG_NAME_2TH_LEVEL
                                View "public.conditions_summary_2"
    Column    |           Type           | Collation | Nullable | Default | Storage | Description 
@@ -4525,6 +4567,8 @@ SELECT
 FROM :CAGG_NAME_1ST_LEVEL
 GROUP BY 1
 WITH NO DATA;
+psql:include/cagg_on_cagg_validations.sql:43: WARNING:  Nested realtime continous aggregates may increase planning and execution time significantly
+HINT:  consider using materialized_only=true
 \d+ :CAGG_NAME_2TH_LEVEL
                                View "public.conditions_summary_2"
    Column    |           Type           | Collation | Nullable | Default | Storage | Description 
@@ -4610,6 +4654,8 @@ SELECT
 FROM :CAGG_NAME_1ST_LEVEL
 GROUP BY 1
 WITH NO DATA;
+psql:include/cagg_on_cagg_validations.sql:43: WARNING:  Nested realtime continous aggregates may increase planning and execution time significantly
+HINT:  consider using materialized_only=true
 \d+ :CAGG_NAME_2TH_LEVEL
                                View "public.conditions_summary_2"
    Column    |           Type           | Collation | Nullable | Default | Storage | Description 
@@ -4696,6 +4742,8 @@ SELECT
 FROM :CAGG_NAME_1ST_LEVEL
 GROUP BY 1
 WITH NO DATA;
+psql:include/cagg_on_cagg_validations.sql:43: WARNING:  Nested realtime continous aggregates may increase planning and execution time significantly
+HINT:  consider using materialized_only=true
 \d+ :CAGG_NAME_2TH_LEVEL
                                View "public.conditions_summary_2"
    Column    |           Type           | Collation | Nullable | Default | Storage | Description 

--- a/tsl/test/expected/cagg_on_cagg_joins.out
+++ b/tsl/test/expected/cagg_on_cagg_joins.out
@@ -194,6 +194,7 @@ SELECT * FROM :CAGG_NAME_2TH_LEVEL ORDER BY bucket, temperature;
 -- Turn CAGGs into Realtime
 ALTER MATERIALIZED VIEW :CAGG_NAME_1ST_LEVEL SET (timescaledb.materialized_only=false);
 ALTER MATERIALIZED VIEW :CAGG_NAME_2TH_LEVEL SET (timescaledb.materialized_only=false);
+psql:include/cagg_on_cagg_common.sql:84: WARNING:  Nested realtime continous aggregates may increase planning and execution time significantly
 --ALTER MATERIALIZED VIEW :CAGG_NAME_3TH_LEVEL SET (timescaledb.materialized_only=false);
 -- Realtime data
 SELECT * FROM :CAGG_NAME_1ST_LEVEL ORDER BY bucket;
@@ -284,8 +285,10 @@ SELECT * FROM :CAGG_NAME_3TH_LEVEL ORDER BY bucket;
 
 -- Turn CAGGs into Realtime
 ALTER MATERIALIZED VIEW :CAGG_NAME_1ST_LEVEL SET (timescaledb.materialized_only=false);
-ALTER MATERIALIZED VIEW :CAGG_NAME_2TH_LEVEL SET (timescaledb.materialized_only=false);
 ALTER MATERIALIZED VIEW :CAGG_NAME_3TH_LEVEL SET (timescaledb.materialized_only=false);
+psql:include/cagg_on_cagg_common.sql:126: WARNING:  Nested realtime continous aggregates may increase planning and execution time significantly
+ALTER MATERIALIZED VIEW :CAGG_NAME_2TH_LEVEL SET (timescaledb.materialized_only=false);
+psql:include/cagg_on_cagg_common.sql:127: WARNING:  Nested realtime continous aggregates may increase planning and execution time significantly
 -- Realtime changes, just new region
 SELECT * FROM :CAGG_NAME_1ST_LEVEL ORDER BY bucket;
  bucket | temperature | device_id 
@@ -622,6 +625,7 @@ SELECT * FROM :CAGG_NAME_2TH_LEVEL ORDER BY bucket, temperature;
 -- Turn CAGGs into Realtime
 ALTER MATERIALIZED VIEW :CAGG_NAME_1ST_LEVEL SET (timescaledb.materialized_only=false);
 ALTER MATERIALIZED VIEW :CAGG_NAME_2TH_LEVEL SET (timescaledb.materialized_only=false);
+psql:include/cagg_on_cagg_common.sql:84: WARNING:  Nested realtime continous aggregates may increase planning and execution time significantly
 --ALTER MATERIALIZED VIEW :CAGG_NAME_3TH_LEVEL SET (timescaledb.materialized_only=false);
 -- Realtime data
 SELECT * FROM :CAGG_NAME_1ST_LEVEL ORDER BY bucket;
@@ -712,8 +716,10 @@ SELECT * FROM :CAGG_NAME_3TH_LEVEL ORDER BY bucket;
 
 -- Turn CAGGs into Realtime
 ALTER MATERIALIZED VIEW :CAGG_NAME_1ST_LEVEL SET (timescaledb.materialized_only=false);
-ALTER MATERIALIZED VIEW :CAGG_NAME_2TH_LEVEL SET (timescaledb.materialized_only=false);
 ALTER MATERIALIZED VIEW :CAGG_NAME_3TH_LEVEL SET (timescaledb.materialized_only=false);
+psql:include/cagg_on_cagg_common.sql:126: WARNING:  Nested realtime continous aggregates may increase planning and execution time significantly
+ALTER MATERIALIZED VIEW :CAGG_NAME_2TH_LEVEL SET (timescaledb.materialized_only=false);
+psql:include/cagg_on_cagg_common.sql:127: WARNING:  Nested realtime continous aggregates may increase planning and execution time significantly
 -- Realtime changes, just new region
 SELECT * FROM :CAGG_NAME_1ST_LEVEL ORDER BY bucket;
  bucket | temperature | device_id 
@@ -1019,6 +1025,8 @@ SELECT
 FROM :CAGG_NAME_1ST_LEVEL
 GROUP BY 1
 WITH NO DATA;
+psql:include/cagg_on_cagg_validations.sql:43: WARNING:  Nested realtime continous aggregates may increase planning and execution time significantly
+HINT:  consider using materialized_only=true
 \d+ :CAGG_NAME_2TH_LEVEL
                        View "public.conditions_summary_2"
    Column    |  Type   | Collation | Nullable | Default | Storage | Description 
@@ -1304,6 +1312,7 @@ SELECT * FROM :CAGG_NAME_2TH_LEVEL ORDER BY bucket, temperature;
 -- Turn CAGGs into Realtime
 ALTER MATERIALIZED VIEW :CAGG_NAME_1ST_LEVEL SET (timescaledb.materialized_only=false);
 ALTER MATERIALIZED VIEW :CAGG_NAME_2TH_LEVEL SET (timescaledb.materialized_only=false);
+psql:include/cagg_on_cagg_common.sql:84: WARNING:  Nested realtime continous aggregates may increase planning and execution time significantly
 --ALTER MATERIALIZED VIEW :CAGG_NAME_3TH_LEVEL SET (timescaledb.materialized_only=false);
 -- Realtime data
 SELECT * FROM :CAGG_NAME_1ST_LEVEL ORDER BY bucket;
@@ -1394,8 +1403,10 @@ SELECT * FROM :CAGG_NAME_3TH_LEVEL ORDER BY bucket;
 
 -- Turn CAGGs into Realtime
 ALTER MATERIALIZED VIEW :CAGG_NAME_1ST_LEVEL SET (timescaledb.materialized_only=false);
-ALTER MATERIALIZED VIEW :CAGG_NAME_2TH_LEVEL SET (timescaledb.materialized_only=false);
 ALTER MATERIALIZED VIEW :CAGG_NAME_3TH_LEVEL SET (timescaledb.materialized_only=false);
+psql:include/cagg_on_cagg_common.sql:126: WARNING:  Nested realtime continous aggregates may increase planning and execution time significantly
+ALTER MATERIALIZED VIEW :CAGG_NAME_2TH_LEVEL SET (timescaledb.materialized_only=false);
+psql:include/cagg_on_cagg_common.sql:127: WARNING:  Nested realtime continous aggregates may increase planning and execution time significantly
 -- Realtime changes, just new region
 SELECT * FROM :CAGG_NAME_1ST_LEVEL ORDER BY bucket;
           bucket          | temperature | device_id 
@@ -1727,6 +1738,7 @@ SELECT * FROM :CAGG_NAME_2TH_LEVEL ORDER BY bucket, temperature;
 -- Turn CAGGs into Realtime
 ALTER MATERIALIZED VIEW :CAGG_NAME_1ST_LEVEL SET (timescaledb.materialized_only=false);
 ALTER MATERIALIZED VIEW :CAGG_NAME_2TH_LEVEL SET (timescaledb.materialized_only=false);
+psql:include/cagg_on_cagg_common.sql:84: WARNING:  Nested realtime continous aggregates may increase planning and execution time significantly
 --ALTER MATERIALIZED VIEW :CAGG_NAME_3TH_LEVEL SET (timescaledb.materialized_only=false);
 -- Realtime data
 SELECT * FROM :CAGG_NAME_1ST_LEVEL ORDER BY bucket;
@@ -1817,8 +1829,10 @@ SELECT * FROM :CAGG_NAME_3TH_LEVEL ORDER BY bucket;
 
 -- Turn CAGGs into Realtime
 ALTER MATERIALIZED VIEW :CAGG_NAME_1ST_LEVEL SET (timescaledb.materialized_only=false);
-ALTER MATERIALIZED VIEW :CAGG_NAME_2TH_LEVEL SET (timescaledb.materialized_only=false);
 ALTER MATERIALIZED VIEW :CAGG_NAME_3TH_LEVEL SET (timescaledb.materialized_only=false);
+psql:include/cagg_on_cagg_common.sql:126: WARNING:  Nested realtime continous aggregates may increase planning and execution time significantly
+ALTER MATERIALIZED VIEW :CAGG_NAME_2TH_LEVEL SET (timescaledb.materialized_only=false);
+psql:include/cagg_on_cagg_common.sql:127: WARNING:  Nested realtime continous aggregates may increase planning and execution time significantly
 -- Realtime changes, just new region
 SELECT * FROM :CAGG_NAME_1ST_LEVEL ORDER BY bucket;
           bucket          | temperature | device_id 
@@ -2201,6 +2215,8 @@ SELECT
 FROM :CAGG_NAME_1ST_LEVEL
 GROUP BY 1
 WITH NO DATA;
+psql:include/cagg_on_cagg_validations.sql:43: WARNING:  Nested realtime continous aggregates may increase planning and execution time significantly
+HINT:  consider using materialized_only=true
 \d+ :CAGG_NAME_2TH_LEVEL
                                  View "public.conditions_summary_2"
    Column    |            Type             | Collation | Nullable | Default | Storage | Description 
@@ -2485,6 +2501,7 @@ SELECT * FROM :CAGG_NAME_2TH_LEVEL ORDER BY bucket, temperature;
 -- Turn CAGGs into Realtime
 ALTER MATERIALIZED VIEW :CAGG_NAME_1ST_LEVEL SET (timescaledb.materialized_only=false);
 ALTER MATERIALIZED VIEW :CAGG_NAME_2TH_LEVEL SET (timescaledb.materialized_only=false);
+psql:include/cagg_on_cagg_common.sql:84: WARNING:  Nested realtime continous aggregates may increase planning and execution time significantly
 --ALTER MATERIALIZED VIEW :CAGG_NAME_3TH_LEVEL SET (timescaledb.materialized_only=false);
 -- Realtime data
 SELECT * FROM :CAGG_NAME_1ST_LEVEL ORDER BY bucket;
@@ -2575,8 +2592,10 @@ SELECT * FROM :CAGG_NAME_3TH_LEVEL ORDER BY bucket;
 
 -- Turn CAGGs into Realtime
 ALTER MATERIALIZED VIEW :CAGG_NAME_1ST_LEVEL SET (timescaledb.materialized_only=false);
-ALTER MATERIALIZED VIEW :CAGG_NAME_2TH_LEVEL SET (timescaledb.materialized_only=false);
 ALTER MATERIALIZED VIEW :CAGG_NAME_3TH_LEVEL SET (timescaledb.materialized_only=false);
+psql:include/cagg_on_cagg_common.sql:126: WARNING:  Nested realtime continous aggregates may increase planning and execution time significantly
+ALTER MATERIALIZED VIEW :CAGG_NAME_2TH_LEVEL SET (timescaledb.materialized_only=false);
+psql:include/cagg_on_cagg_common.sql:127: WARNING:  Nested realtime continous aggregates may increase planning and execution time significantly
 -- Realtime changes, just new region
 SELECT * FROM :CAGG_NAME_1ST_LEVEL ORDER BY bucket;
             bucket            | temperature | device_id 
@@ -2908,6 +2927,7 @@ SELECT * FROM :CAGG_NAME_2TH_LEVEL ORDER BY bucket, temperature;
 -- Turn CAGGs into Realtime
 ALTER MATERIALIZED VIEW :CAGG_NAME_1ST_LEVEL SET (timescaledb.materialized_only=false);
 ALTER MATERIALIZED VIEW :CAGG_NAME_2TH_LEVEL SET (timescaledb.materialized_only=false);
+psql:include/cagg_on_cagg_common.sql:84: WARNING:  Nested realtime continous aggregates may increase planning and execution time significantly
 --ALTER MATERIALIZED VIEW :CAGG_NAME_3TH_LEVEL SET (timescaledb.materialized_only=false);
 -- Realtime data
 SELECT * FROM :CAGG_NAME_1ST_LEVEL ORDER BY bucket;
@@ -2998,8 +3018,10 @@ SELECT * FROM :CAGG_NAME_3TH_LEVEL ORDER BY bucket;
 
 -- Turn CAGGs into Realtime
 ALTER MATERIALIZED VIEW :CAGG_NAME_1ST_LEVEL SET (timescaledb.materialized_only=false);
-ALTER MATERIALIZED VIEW :CAGG_NAME_2TH_LEVEL SET (timescaledb.materialized_only=false);
 ALTER MATERIALIZED VIEW :CAGG_NAME_3TH_LEVEL SET (timescaledb.materialized_only=false);
+psql:include/cagg_on_cagg_common.sql:126: WARNING:  Nested realtime continous aggregates may increase planning and execution time significantly
+ALTER MATERIALIZED VIEW :CAGG_NAME_2TH_LEVEL SET (timescaledb.materialized_only=false);
+psql:include/cagg_on_cagg_common.sql:127: WARNING:  Nested realtime continous aggregates may increase planning and execution time significantly
 -- Realtime changes, just new region
 SELECT * FROM :CAGG_NAME_1ST_LEVEL ORDER BY bucket;
             bucket            | temperature | device_id 
@@ -3382,6 +3404,8 @@ SELECT
 FROM :CAGG_NAME_1ST_LEVEL
 GROUP BY 1
 WITH NO DATA;
+psql:include/cagg_on_cagg_validations.sql:43: WARNING:  Nested realtime continous aggregates may increase planning and execution time significantly
+HINT:  consider using materialized_only=true
 \d+ :CAGG_NAME_2TH_LEVEL
                                View "public.conditions_summary_2"
    Column    |           Type           | Collation | Nullable | Default | Storage | Description 
@@ -3555,6 +3579,8 @@ SELECT
 FROM :CAGG_NAME_1ST_LEVEL
 GROUP BY 1
 WITH NO DATA;
+psql:include/cagg_on_cagg_validations.sql:43: WARNING:  Nested realtime continous aggregates may increase planning and execution time significantly
+HINT:  consider using materialized_only=true
 \d+ :CAGG_NAME_2TH_LEVEL
                                View "public.conditions_summary_2"
    Column    |           Type           | Collation | Nullable | Default | Storage | Description 
@@ -3718,6 +3744,8 @@ SELECT
 FROM :CAGG_NAME_1ST_LEVEL
 GROUP BY 1
 WITH NO DATA;
+psql:include/cagg_on_cagg_validations.sql:43: WARNING:  Nested realtime continous aggregates may increase planning and execution time significantly
+HINT:  consider using materialized_only=true
 \d+ :CAGG_NAME_2TH_LEVEL
                                View "public.conditions_summary_2"
    Column    |           Type           | Collation | Nullable | Default | Storage | Description 
@@ -3809,6 +3837,8 @@ SELECT
 FROM :CAGG_NAME_1ST_LEVEL
 GROUP BY 1
 WITH NO DATA;
+psql:include/cagg_on_cagg_validations.sql:43: WARNING:  Nested realtime continous aggregates may increase planning and execution time significantly
+HINT:  consider using materialized_only=true
 \d+ :CAGG_NAME_2TH_LEVEL
                                View "public.conditions_summary_2"
    Column    |           Type           | Collation | Nullable | Default | Storage | Description 
@@ -3901,6 +3931,8 @@ SELECT
 FROM :CAGG_NAME_1ST_LEVEL
 GROUP BY 1
 WITH NO DATA;
+psql:include/cagg_on_cagg_validations.sql:43: WARNING:  Nested realtime continous aggregates may increase planning and execution time significantly
+HINT:  consider using materialized_only=true
 \d+ :CAGG_NAME_2TH_LEVEL
                                View "public.conditions_summary_2"
    Column    |           Type           | Collation | Nullable | Default | Storage | Description 
@@ -3993,6 +4025,8 @@ SELECT
 FROM :CAGG_NAME_1ST_LEVEL
 GROUP BY 1
 WITH NO DATA;
+psql:include/cagg_on_cagg_validations.sql:43: WARNING:  Nested realtime continous aggregates may increase planning and execution time significantly
+HINT:  consider using materialized_only=true
 \d+ :CAGG_NAME_2TH_LEVEL
                                View "public.conditions_summary_2"
    Column    |           Type           | Collation | Nullable | Default | Storage | Description 
@@ -4084,6 +4118,8 @@ SELECT
 FROM :CAGG_NAME_1ST_LEVEL
 GROUP BY 1
 WITH NO DATA;
+psql:include/cagg_on_cagg_validations.sql:43: WARNING:  Nested realtime continous aggregates may increase planning and execution time significantly
+HINT:  consider using materialized_only=true
 \d+ :CAGG_NAME_2TH_LEVEL
                                View "public.conditions_summary_2"
    Column    |           Type           | Collation | Nullable | Default | Storage | Description 
@@ -4169,6 +4205,8 @@ SELECT
 FROM :CAGG_NAME_1ST_LEVEL
 GROUP BY 1
 WITH NO DATA;
+psql:include/cagg_on_cagg_validations.sql:43: WARNING:  Nested realtime continous aggregates may increase planning and execution time significantly
+HINT:  consider using materialized_only=true
 \d+ :CAGG_NAME_2TH_LEVEL
                                View "public.conditions_summary_2"
    Column    |           Type           | Collation | Nullable | Default | Storage | Description 
@@ -4254,6 +4292,8 @@ SELECT
 FROM :CAGG_NAME_1ST_LEVEL
 GROUP BY 1
 WITH NO DATA;
+psql:include/cagg_on_cagg_validations.sql:43: WARNING:  Nested realtime continous aggregates may increase planning and execution time significantly
+HINT:  consider using materialized_only=true
 \d+ :CAGG_NAME_2TH_LEVEL
                                View "public.conditions_summary_2"
    Column    |           Type           | Collation | Nullable | Default | Storage | Description 

--- a/tsl/test/expected/cagg_on_cagg_joins_dist_ht.out
+++ b/tsl/test/expected/cagg_on_cagg_joins_dist_ht.out
@@ -228,6 +228,7 @@ SELECT * FROM :CAGG_NAME_2TH_LEVEL ORDER BY bucket, temperature;
 -- Turn CAGGs into Realtime
 ALTER MATERIALIZED VIEW :CAGG_NAME_1ST_LEVEL SET (timescaledb.materialized_only=false);
 ALTER MATERIALIZED VIEW :CAGG_NAME_2TH_LEVEL SET (timescaledb.materialized_only=false);
+psql:include/cagg_on_cagg_common.sql:84: WARNING:  Nested realtime continous aggregates may increase planning and execution time significantly
 --ALTER MATERIALIZED VIEW :CAGG_NAME_3TH_LEVEL SET (timescaledb.materialized_only=false);
 -- Realtime data
 SELECT * FROM :CAGG_NAME_1ST_LEVEL ORDER BY bucket;
@@ -318,8 +319,10 @@ SELECT * FROM :CAGG_NAME_3TH_LEVEL ORDER BY bucket;
 
 -- Turn CAGGs into Realtime
 ALTER MATERIALIZED VIEW :CAGG_NAME_1ST_LEVEL SET (timescaledb.materialized_only=false);
-ALTER MATERIALIZED VIEW :CAGG_NAME_2TH_LEVEL SET (timescaledb.materialized_only=false);
 ALTER MATERIALIZED VIEW :CAGG_NAME_3TH_LEVEL SET (timescaledb.materialized_only=false);
+psql:include/cagg_on_cagg_common.sql:126: WARNING:  Nested realtime continous aggregates may increase planning and execution time significantly
+ALTER MATERIALIZED VIEW :CAGG_NAME_2TH_LEVEL SET (timescaledb.materialized_only=false);
+psql:include/cagg_on_cagg_common.sql:127: WARNING:  Nested realtime continous aggregates may increase planning and execution time significantly
 -- Realtime changes, just new region
 SELECT * FROM :CAGG_NAME_1ST_LEVEL ORDER BY bucket;
  bucket | temperature | device_id 
@@ -655,6 +658,7 @@ SELECT * FROM :CAGG_NAME_2TH_LEVEL ORDER BY bucket, temperature;
 -- Turn CAGGs into Realtime
 ALTER MATERIALIZED VIEW :CAGG_NAME_1ST_LEVEL SET (timescaledb.materialized_only=false);
 ALTER MATERIALIZED VIEW :CAGG_NAME_2TH_LEVEL SET (timescaledb.materialized_only=false);
+psql:include/cagg_on_cagg_common.sql:84: WARNING:  Nested realtime continous aggregates may increase planning and execution time significantly
 --ALTER MATERIALIZED VIEW :CAGG_NAME_3TH_LEVEL SET (timescaledb.materialized_only=false);
 -- Realtime data
 SELECT * FROM :CAGG_NAME_1ST_LEVEL ORDER BY bucket;
@@ -745,8 +749,10 @@ SELECT * FROM :CAGG_NAME_3TH_LEVEL ORDER BY bucket;
 
 -- Turn CAGGs into Realtime
 ALTER MATERIALIZED VIEW :CAGG_NAME_1ST_LEVEL SET (timescaledb.materialized_only=false);
-ALTER MATERIALIZED VIEW :CAGG_NAME_2TH_LEVEL SET (timescaledb.materialized_only=false);
 ALTER MATERIALIZED VIEW :CAGG_NAME_3TH_LEVEL SET (timescaledb.materialized_only=false);
+psql:include/cagg_on_cagg_common.sql:126: WARNING:  Nested realtime continous aggregates may increase planning and execution time significantly
+ALTER MATERIALIZED VIEW :CAGG_NAME_2TH_LEVEL SET (timescaledb.materialized_only=false);
+psql:include/cagg_on_cagg_common.sql:127: WARNING:  Nested realtime continous aggregates may increase planning and execution time significantly
 -- Realtime changes, just new region
 SELECT * FROM :CAGG_NAME_1ST_LEVEL ORDER BY bucket;
  bucket | temperature | device_id 
@@ -1050,6 +1056,8 @@ SELECT
 FROM :CAGG_NAME_1ST_LEVEL
 GROUP BY 1
 WITH NO DATA;
+psql:include/cagg_on_cagg_validations.sql:43: WARNING:  Nested realtime continous aggregates may increase planning and execution time significantly
+HINT:  consider using materialized_only=true
 \d+ :CAGG_NAME_2TH_LEVEL
                        View "public.conditions_summary_2"
    Column    |  Type   | Collation | Nullable | Default | Storage | Description 
@@ -1336,6 +1344,7 @@ SELECT * FROM :CAGG_NAME_2TH_LEVEL ORDER BY bucket, temperature;
 -- Turn CAGGs into Realtime
 ALTER MATERIALIZED VIEW :CAGG_NAME_1ST_LEVEL SET (timescaledb.materialized_only=false);
 ALTER MATERIALIZED VIEW :CAGG_NAME_2TH_LEVEL SET (timescaledb.materialized_only=false);
+psql:include/cagg_on_cagg_common.sql:84: WARNING:  Nested realtime continous aggregates may increase planning and execution time significantly
 --ALTER MATERIALIZED VIEW :CAGG_NAME_3TH_LEVEL SET (timescaledb.materialized_only=false);
 -- Realtime data
 SELECT * FROM :CAGG_NAME_1ST_LEVEL ORDER BY bucket;
@@ -1426,8 +1435,10 @@ SELECT * FROM :CAGG_NAME_3TH_LEVEL ORDER BY bucket;
 
 -- Turn CAGGs into Realtime
 ALTER MATERIALIZED VIEW :CAGG_NAME_1ST_LEVEL SET (timescaledb.materialized_only=false);
-ALTER MATERIALIZED VIEW :CAGG_NAME_2TH_LEVEL SET (timescaledb.materialized_only=false);
 ALTER MATERIALIZED VIEW :CAGG_NAME_3TH_LEVEL SET (timescaledb.materialized_only=false);
+psql:include/cagg_on_cagg_common.sql:126: WARNING:  Nested realtime continous aggregates may increase planning and execution time significantly
+ALTER MATERIALIZED VIEW :CAGG_NAME_2TH_LEVEL SET (timescaledb.materialized_only=false);
+psql:include/cagg_on_cagg_common.sql:127: WARNING:  Nested realtime continous aggregates may increase planning and execution time significantly
 -- Realtime changes, just new region
 SELECT * FROM :CAGG_NAME_1ST_LEVEL ORDER BY bucket;
           bucket          | temperature | device_id 
@@ -1759,6 +1770,7 @@ SELECT * FROM :CAGG_NAME_2TH_LEVEL ORDER BY bucket, temperature;
 -- Turn CAGGs into Realtime
 ALTER MATERIALIZED VIEW :CAGG_NAME_1ST_LEVEL SET (timescaledb.materialized_only=false);
 ALTER MATERIALIZED VIEW :CAGG_NAME_2TH_LEVEL SET (timescaledb.materialized_only=false);
+psql:include/cagg_on_cagg_common.sql:84: WARNING:  Nested realtime continous aggregates may increase planning and execution time significantly
 --ALTER MATERIALIZED VIEW :CAGG_NAME_3TH_LEVEL SET (timescaledb.materialized_only=false);
 -- Realtime data
 SELECT * FROM :CAGG_NAME_1ST_LEVEL ORDER BY bucket;
@@ -1849,8 +1861,10 @@ SELECT * FROM :CAGG_NAME_3TH_LEVEL ORDER BY bucket;
 
 -- Turn CAGGs into Realtime
 ALTER MATERIALIZED VIEW :CAGG_NAME_1ST_LEVEL SET (timescaledb.materialized_only=false);
-ALTER MATERIALIZED VIEW :CAGG_NAME_2TH_LEVEL SET (timescaledb.materialized_only=false);
 ALTER MATERIALIZED VIEW :CAGG_NAME_3TH_LEVEL SET (timescaledb.materialized_only=false);
+psql:include/cagg_on_cagg_common.sql:126: WARNING:  Nested realtime continous aggregates may increase planning and execution time significantly
+ALTER MATERIALIZED VIEW :CAGG_NAME_2TH_LEVEL SET (timescaledb.materialized_only=false);
+psql:include/cagg_on_cagg_common.sql:127: WARNING:  Nested realtime continous aggregates may increase planning and execution time significantly
 -- Realtime changes, just new region
 SELECT * FROM :CAGG_NAME_1ST_LEVEL ORDER BY bucket;
           bucket          | temperature | device_id 
@@ -2230,6 +2244,8 @@ SELECT
 FROM :CAGG_NAME_1ST_LEVEL
 GROUP BY 1
 WITH NO DATA;
+psql:include/cagg_on_cagg_validations.sql:43: WARNING:  Nested realtime continous aggregates may increase planning and execution time significantly
+HINT:  consider using materialized_only=true
 \d+ :CAGG_NAME_2TH_LEVEL
                                  View "public.conditions_summary_2"
    Column    |            Type             | Collation | Nullable | Default | Storage | Description 
@@ -2512,6 +2528,7 @@ SELECT * FROM :CAGG_NAME_2TH_LEVEL ORDER BY bucket, temperature;
 -- Turn CAGGs into Realtime
 ALTER MATERIALIZED VIEW :CAGG_NAME_1ST_LEVEL SET (timescaledb.materialized_only=false);
 ALTER MATERIALIZED VIEW :CAGG_NAME_2TH_LEVEL SET (timescaledb.materialized_only=false);
+psql:include/cagg_on_cagg_common.sql:84: WARNING:  Nested realtime continous aggregates may increase planning and execution time significantly
 --ALTER MATERIALIZED VIEW :CAGG_NAME_3TH_LEVEL SET (timescaledb.materialized_only=false);
 -- Realtime data
 SELECT * FROM :CAGG_NAME_1ST_LEVEL ORDER BY bucket;
@@ -2602,8 +2619,10 @@ SELECT * FROM :CAGG_NAME_3TH_LEVEL ORDER BY bucket;
 
 -- Turn CAGGs into Realtime
 ALTER MATERIALIZED VIEW :CAGG_NAME_1ST_LEVEL SET (timescaledb.materialized_only=false);
-ALTER MATERIALIZED VIEW :CAGG_NAME_2TH_LEVEL SET (timescaledb.materialized_only=false);
 ALTER MATERIALIZED VIEW :CAGG_NAME_3TH_LEVEL SET (timescaledb.materialized_only=false);
+psql:include/cagg_on_cagg_common.sql:126: WARNING:  Nested realtime continous aggregates may increase planning and execution time significantly
+ALTER MATERIALIZED VIEW :CAGG_NAME_2TH_LEVEL SET (timescaledb.materialized_only=false);
+psql:include/cagg_on_cagg_common.sql:127: WARNING:  Nested realtime continous aggregates may increase planning and execution time significantly
 -- Realtime changes, just new region
 SELECT * FROM :CAGG_NAME_1ST_LEVEL ORDER BY bucket;
             bucket            | temperature | device_id 
@@ -2934,6 +2953,7 @@ SELECT * FROM :CAGG_NAME_2TH_LEVEL ORDER BY bucket, temperature;
 -- Turn CAGGs into Realtime
 ALTER MATERIALIZED VIEW :CAGG_NAME_1ST_LEVEL SET (timescaledb.materialized_only=false);
 ALTER MATERIALIZED VIEW :CAGG_NAME_2TH_LEVEL SET (timescaledb.materialized_only=false);
+psql:include/cagg_on_cagg_common.sql:84: WARNING:  Nested realtime continous aggregates may increase planning and execution time significantly
 --ALTER MATERIALIZED VIEW :CAGG_NAME_3TH_LEVEL SET (timescaledb.materialized_only=false);
 -- Realtime data
 SELECT * FROM :CAGG_NAME_1ST_LEVEL ORDER BY bucket;
@@ -3024,8 +3044,10 @@ SELECT * FROM :CAGG_NAME_3TH_LEVEL ORDER BY bucket;
 
 -- Turn CAGGs into Realtime
 ALTER MATERIALIZED VIEW :CAGG_NAME_1ST_LEVEL SET (timescaledb.materialized_only=false);
-ALTER MATERIALIZED VIEW :CAGG_NAME_2TH_LEVEL SET (timescaledb.materialized_only=false);
 ALTER MATERIALIZED VIEW :CAGG_NAME_3TH_LEVEL SET (timescaledb.materialized_only=false);
+psql:include/cagg_on_cagg_common.sql:126: WARNING:  Nested realtime continous aggregates may increase planning and execution time significantly
+ALTER MATERIALIZED VIEW :CAGG_NAME_2TH_LEVEL SET (timescaledb.materialized_only=false);
+psql:include/cagg_on_cagg_common.sql:127: WARNING:  Nested realtime continous aggregates may increase planning and execution time significantly
 -- Realtime changes, just new region
 SELECT * FROM :CAGG_NAME_1ST_LEVEL ORDER BY bucket;
             bucket            | temperature | device_id 
@@ -3405,6 +3427,8 @@ SELECT
 FROM :CAGG_NAME_1ST_LEVEL
 GROUP BY 1
 WITH NO DATA;
+psql:include/cagg_on_cagg_validations.sql:43: WARNING:  Nested realtime continous aggregates may increase planning and execution time significantly
+HINT:  consider using materialized_only=true
 \d+ :CAGG_NAME_2TH_LEVEL
                                View "public.conditions_summary_2"
    Column    |           Type           | Collation | Nullable | Default | Storage | Description 
@@ -3576,6 +3600,8 @@ SELECT
 FROM :CAGG_NAME_1ST_LEVEL
 GROUP BY 1
 WITH NO DATA;
+psql:include/cagg_on_cagg_validations.sql:43: WARNING:  Nested realtime continous aggregates may increase planning and execution time significantly
+HINT:  consider using materialized_only=true
 \d+ :CAGG_NAME_2TH_LEVEL
                                View "public.conditions_summary_2"
    Column    |           Type           | Collation | Nullable | Default | Storage | Description 
@@ -3739,6 +3765,8 @@ SELECT
 FROM :CAGG_NAME_1ST_LEVEL
 GROUP BY 1
 WITH NO DATA;
+psql:include/cagg_on_cagg_validations.sql:43: WARNING:  Nested realtime continous aggregates may increase planning and execution time significantly
+HINT:  consider using materialized_only=true
 \d+ :CAGG_NAME_2TH_LEVEL
                                View "public.conditions_summary_2"
    Column    |           Type           | Collation | Nullable | Default | Storage | Description 
@@ -3830,6 +3858,8 @@ SELECT
 FROM :CAGG_NAME_1ST_LEVEL
 GROUP BY 1
 WITH NO DATA;
+psql:include/cagg_on_cagg_validations.sql:43: WARNING:  Nested realtime continous aggregates may increase planning and execution time significantly
+HINT:  consider using materialized_only=true
 \d+ :CAGG_NAME_2TH_LEVEL
                                View "public.conditions_summary_2"
    Column    |           Type           | Collation | Nullable | Default | Storage | Description 
@@ -3922,6 +3952,8 @@ SELECT
 FROM :CAGG_NAME_1ST_LEVEL
 GROUP BY 1
 WITH NO DATA;
+psql:include/cagg_on_cagg_validations.sql:43: WARNING:  Nested realtime continous aggregates may increase planning and execution time significantly
+HINT:  consider using materialized_only=true
 \d+ :CAGG_NAME_2TH_LEVEL
                                View "public.conditions_summary_2"
    Column    |           Type           | Collation | Nullable | Default | Storage | Description 
@@ -4014,6 +4046,8 @@ SELECT
 FROM :CAGG_NAME_1ST_LEVEL
 GROUP BY 1
 WITH NO DATA;
+psql:include/cagg_on_cagg_validations.sql:43: WARNING:  Nested realtime continous aggregates may increase planning and execution time significantly
+HINT:  consider using materialized_only=true
 \d+ :CAGG_NAME_2TH_LEVEL
                                View "public.conditions_summary_2"
    Column    |           Type           | Collation | Nullable | Default | Storage | Description 
@@ -4100,6 +4134,8 @@ SELECT
 FROM :CAGG_NAME_1ST_LEVEL
 GROUP BY 1
 WITH NO DATA;
+psql:include/cagg_on_cagg_validations.sql:43: WARNING:  Nested realtime continous aggregates may increase planning and execution time significantly
+HINT:  consider using materialized_only=true
 \d+ :CAGG_NAME_2TH_LEVEL
                                View "public.conditions_summary_2"
    Column    |           Type           | Collation | Nullable | Default | Storage | Description 
@@ -4185,6 +4221,8 @@ SELECT
 FROM :CAGG_NAME_1ST_LEVEL
 GROUP BY 1
 WITH NO DATA;
+psql:include/cagg_on_cagg_validations.sql:43: WARNING:  Nested realtime continous aggregates may increase planning and execution time significantly
+HINT:  consider using materialized_only=true
 \d+ :CAGG_NAME_2TH_LEVEL
                                View "public.conditions_summary_2"
    Column    |           Type           | Collation | Nullable | Default | Storage | Description 
@@ -4270,6 +4308,8 @@ SELECT
 FROM :CAGG_NAME_1ST_LEVEL
 GROUP BY 1
 WITH NO DATA;
+psql:include/cagg_on_cagg_validations.sql:43: WARNING:  Nested realtime continous aggregates may increase planning and execution time significantly
+HINT:  consider using materialized_only=true
 \d+ :CAGG_NAME_2TH_LEVEL
                                View "public.conditions_summary_2"
    Column    |           Type           | Collation | Nullable | Default | Storage | Description 
@@ -4501,6 +4541,8 @@ SELECT
 FROM :CAGG_NAME_1ST_LEVEL
 GROUP BY 1
 WITH NO DATA;
+psql:include/cagg_on_cagg_validations.sql:43: WARNING:  Nested realtime continous aggregates may increase planning and execution time significantly
+HINT:  consider using materialized_only=true
 \d+ :CAGG_NAME_2TH_LEVEL
                                View "public.conditions_summary_2"
    Column    |           Type           | Collation | Nullable | Default | Storage | Description 
@@ -4586,6 +4628,8 @@ SELECT
 FROM :CAGG_NAME_1ST_LEVEL
 GROUP BY 1
 WITH NO DATA;
+psql:include/cagg_on_cagg_validations.sql:43: WARNING:  Nested realtime continous aggregates may increase planning and execution time significantly
+HINT:  consider using materialized_only=true
 \d+ :CAGG_NAME_2TH_LEVEL
                                View "public.conditions_summary_2"
    Column    |           Type           | Collation | Nullable | Default | Storage | Description 
@@ -4671,6 +4715,8 @@ SELECT
 FROM :CAGG_NAME_1ST_LEVEL
 GROUP BY 1
 WITH NO DATA;
+psql:include/cagg_on_cagg_validations.sql:43: WARNING:  Nested realtime continous aggregates may increase planning and execution time significantly
+HINT:  consider using materialized_only=true
 \d+ :CAGG_NAME_2TH_LEVEL
                                View "public.conditions_summary_2"
    Column    |           Type           | Collation | Nullable | Default | Storage | Description 
@@ -4757,6 +4803,8 @@ SELECT
 FROM :CAGG_NAME_1ST_LEVEL
 GROUP BY 1
 WITH NO DATA;
+psql:include/cagg_on_cagg_validations.sql:43: WARNING:  Nested realtime continous aggregates may increase planning and execution time significantly
+HINT:  consider using materialized_only=true
 \d+ :CAGG_NAME_2TH_LEVEL
                                View "public.conditions_summary_2"
    Column    |           Type           | Collation | Nullable | Default | Storage | Description 

--- a/tsl/test/sql/include/cagg_on_cagg_common.sql
+++ b/tsl/test/sql/include/cagg_on_cagg_common.sql
@@ -123,8 +123,8 @@ SELECT * FROM :CAGG_NAME_3TH_LEVEL ORDER BY bucket;
 
 -- Turn CAGGs into Realtime
 ALTER MATERIALIZED VIEW :CAGG_NAME_1ST_LEVEL SET (timescaledb.materialized_only=false);
-ALTER MATERIALIZED VIEW :CAGG_NAME_2TH_LEVEL SET (timescaledb.materialized_only=false);
 ALTER MATERIALIZED VIEW :CAGG_NAME_3TH_LEVEL SET (timescaledb.materialized_only=false);
+ALTER MATERIALIZED VIEW :CAGG_NAME_2TH_LEVEL SET (timescaledb.materialized_only=false);
 
 -- Realtime changes, just new region
 SELECT * FROM :CAGG_NAME_1ST_LEVEL ORDER BY bucket;


### PR DESCRIPTION
If hierarchical realtime caggs are being used the planning time might
    increase significantly. Although its valid to create realtime caggs
    over realtime cagg - this sideeffect might not be obvious.
    Giving a hint to the user might help to use it correctly.
    
Fixes: #5690

Disable-check: force-changelog-file