### PR TITLE
Fix flaky test bgw_db_scheduler_fixed

### DIFF
--- a/tsl/test/expected/bgw_db_scheduler_fixed.out
+++ b/tsl/test/expected/bgw_db_scheduler_fixed.out
@@ -1626,7 +1626,7 @@ INSERT INTO test_table_scheduler values
 (now() - interval '4 years', 1, 1),
 (now() - interval '2 years', 1, 1),
 (now() - interval '1 years', 2, 2),
-(now() - interval '4 months', 3, 3),
+(now() - interval '6 months', 3, 3),
 (now() - interval '3 months', 4, 4);
 CREATE MATERIALIZED VIEW cagg_scheduler(time, avg_a)
 WITH (timescaledb.continuous) AS

--- a/tsl/test/sql/bgw_db_scheduler_fixed.sql
+++ b/tsl/test/sql/bgw_db_scheduler_fixed.sql
@@ -703,7 +703,7 @@ INSERT INTO test_table_scheduler values
 (now() - interval '4 years', 1, 1),
 (now() - interval '2 years', 1, 1),
 (now() - interval '1 years', 2, 2),
-(now() - interval '4 months', 3, 3),
+(now() - interval '6 months', 3, 3),
 (now() - interval '3 months', 4, 4);
 
 CREATE MATERIALIZED VIEW cagg_scheduler(time, avg_a)


### PR DESCRIPTION
The flakiness was due to two inserts falling into the
same chunk instead of distinct ones, so inserted data
further apart to ensure they fall in different chunks.