### PR TITLE
Added perltidy make target

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -442,13 +442,34 @@ if(CMAKE_FORMAT)
                          ${PROJECT_SOURCE_DIR}/scripts/cmake_format_all.sh)
 endif()
 
-if(TARGET clang-format OR TARGET cmake-format)
+find_program(
+  PERLTIDY
+  NAMES perltidy
+  PATHS /bin /usr/bin /usr/local/bin /usr/local/opt/ /opt/bin
+  DOC "The path to perltidy")
+
+if(PERLTIDY)
+  message(STATUS "Using perltidy ${PERLTIDY}")
+  add_custom_target(
+    perltidy
+    COMMAND
+      ${CMAKE_COMMAND} -E env PERLTIDY=${PERLTIDY}
+      PERLTIDY_CONFIG="${PROJECT_SOURCE_DIR}/.perltidyrc"
+      ${PROJECT_SOURCE_DIR}/scripts/perltidy_format_all.sh)
+endif()
+
+if(TARGET clang-format
+   OR TARGET cmake-format
+   OR TARGET perltidy)
   add_custom_target(format)
   if(TARGET clang-format)
     add_dependencies(format clang-format)
   endif()
   if(TARGET cmake-format)
     add_dependencies(format cmake-format)
+  endif()
+  if(TARGET perltidy)
+    add_dependencies(format perltidy)
   endif()
 endif()
 

--- a/scripts/perltidy_format_all.sh
+++ b/scripts/perltidy_format_all.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+SCRIPTDIR=$(cd "$(dirname $0)" || exit; pwd)
+BASEDIR=$(dirname $SCRIPTDIR)
+
+PERLTIDY=${PERLTIDY:-perltidy}
+PERLTIDY_CONFIG=${PERLTIDY_CONFIG:-$BASEDIR/.perltidyrc}
+
+if [ ! -f "$PERLTIDY_CONFIG" ]; then
+   echo "perltidy config '$PERLTIDY_CONFIG' not found"
+   exit 1
+fi
+
+find "$BASEDIR"/test -name '*.p[lm]' -exec "$PERLTIDY" --profile="$PERLTIDY_CONFIG" -b -bext=/ {} +
+find "$BASEDIR"/tsl/test -name '*.p[lm]' -exec "$PERLTIDY" --profile="$PERLTIDY_CONFIG" -b -bext=/ {} +
+

--- a/test/perl/TimescaleNode.pm
+++ b/test/perl/TimescaleNode.pm
@@ -6,11 +6,21 @@
 # routines for setup.
 
 package TimescaleNode;
+
+# Using linebreaks here to prevent perltidy from performing vertical alignment.
+# This functionality has changed in recent perltidy versions (e.g., 2021 10 29)
+# and would restrict the versions of perltidy that can be used to format the
+# sources.
+
 use if $ENV{PG_VERSION_MAJOR} >= 15, 'parent', qw(PostgreSQL::Test::Cluster);
-use if $ENV{PG_VERSION_MAJOR} < 15,  'parent', qw(PostgresNode);
+
+use if $ENV{PG_VERSION_MAJOR} < 15, 'parent', qw(PostgresNode);
+
 use
   if $ENV{PG_VERSION_MAJOR} >= 15, 'PostgreSQL::Test::Utils', qw(slurp_file);
+
 use if $ENV{PG_VERSION_MAJOR} < 15, 'TestLib', qw(slurp_file);
+
 use strict;
 use warnings;
 


### PR DESCRIPTION
This patch introduces the make target 'perltidy' to format Perl files with perltidy. In addition, calling perltidy is added to 'make format'.


Disable-check: force-changelog-file
