### PR TITLE
Fix coverity issue reported in hypertable_modify.c

### DIFF
--- a/.unreleased/bugfix_5827
+++ b/.unreleased/bugfix_5827
@@ -1,0 +1,1 @@
+Fixes #5827: Fix coverity issue reported in hypertable_modify.c

--- a/src/nodes/hypertable_modify.c
+++ b/src/nodes/hypertable_modify.c
@@ -983,7 +983,8 @@ ExecModifyTable(CustomScanState *cs_node, PlanState *pstate)
 				if (unlikely(!resultRelInfo->ri_projectNewInfoValid))
 					ExecInitInsertProjection(node, resultRelInfo);
 				slot = ExecGetInsertNewTuple(resultRelInfo, context.planSlot);
-				slot = ExecInsert(&context, cds->rri, slot, node->canSetTag);
+				Assert(cds);
+				slot = ExecInsert(&context, (cds ? cds->rri : NULL), slot, node->canSetTag);
 				break;
 			case CMD_UPDATE:
 				/* Initialize projection info if first time for this table */


### PR DESCRIPTION
Data structure cds (aka chunk dispatch state) can never be NULL
in case of INSERT. Thus checking if cds is NULL or not before
dereferencing it.