### PR TITLE
Fixed location (and name) of .perltidyrc

### DIFF
--- a/test/perl/README.md
+++ b/test/perl/README.md
@@ -15,7 +15,7 @@ Note that all tests and test tools should have perltidy run on them
 using perltidy, for example:
 
 ```
-perltidy --profile=$TS_SRC_DIR/scripts/perltidyrc /path/to/taptest
+perltidy --profile=$TS_SRC_DIR/.perltidyrc /path/to/taptest
 ```
 
 ## Writing tests


### PR DESCRIPTION
Updated the location and name of .perltidyrc in the README

After the recent change (https://github.com/timescale/timescaledb/commit/f1726790224e5444a2a2cb8c66155e4fb0b54e95) the location and name of perltitdyrc has changed.

Disable-check: force-changelog-file