### PR TITLE
Fixed output ordering of merge_changelogs.sh script

### DIFF
--- a/scripts/merge_changelogs.sh
+++ b/scripts/merge_changelogs.sh
@@ -1,11 +1,11 @@
 #!/bin/bash
 
 # skip the template file
-echo "**Bugfixes**"
-grep -i '^Fixes:' .unreleased/* | grep -v '.unreleased/template.rfc822' | cut -d: -f3- | sort | uniq | sed -e 's/^[[:space:]]*//' -e 's/^/* /'
-
 echo "**Features**"
 grep -i '^Implements:' .unreleased/* | grep -v '.unreleased/template.rfc822' | cut -d: -f3- | sort | uniq | sed -e 's/^[[:space:]]*//' -e 's/^/* /'
+
+echo "**Bugfixes**"
+grep -i '^Fixes:' .unreleased/* | grep -v '.unreleased/template.rfc822' | cut -d: -f3- | sort | uniq | sed -e 's/^[[:space:]]*//' -e 's/^/* /'
 
 echo "**Thanks**"
 grep -i '^Thanks:' .unreleased/* | grep -v '.unreleased/template.rfc822' | cut -d: -f3- | sort | sed -e 's/^[[:space:]]*//' -e 's/^/* /'


### PR DESCRIPTION
The [CHANGELOG.md](https://github.com/timescale/timescaledb/blob/main/CHANGELOG.md) file contains the sections features, bugfixes, and thanks. This patch adjusts the script merge_changelogs.sh to produce the sections in the same order.

Disable-check: force-changelog-file