### PR TITLE
Remove Ubuntu Kinetic check on ARM64

### DIFF
--- a/.github/workflows/apt-arm-packages.yaml
+++ b/.github/workflows/apt-arm-packages.yaml
@@ -17,12 +17,9 @@ jobs:
       fail-fast: false
       matrix:
         # Debian images:  10 (buster), 11 (bullseye)
-        # Ubuntu images:  20.04 LTS (focal), 22.04 (jammy), 22.10 (kinetic)
+        # Ubuntu images:  20.04 LTS (focal), 22.04 (jammy)
         image: [ "debian:10-slim","debian:11-slim","ubuntu:focal", "ubuntu:jammy"]
         pg: [ 12, 13, 14, 15 ]
-        include:
-          - image: "ubuntu:kinetic"
-            pg: 14
 
     steps:
     - name: Setup emulation


### PR DESCRIPTION
We stopped to build packages for Ubuntu Kinetic on ARM64 due to the limited support of PostgreSQL versions and the EOL of Kinetic in a few weeks. This patch removes the check for up-to-date packages for this version.