### PR TITLE
Support CAGG names in chunk_detailed_size

### DIFF
--- a/.unreleased/PR_5839
+++ b/.unreleased/PR_5839
@@ -1,0 +1,1 @@
+Implements: #5839 Support CAGG names in chunk_detailed_size

--- a/tsl/test/expected/size_utils_tsl.out
+++ b/tsl/test/expected/size_utils_tsl.out
@@ -30,6 +30,11 @@ SELECT * FROM hypertable_detailed_size(:'MAT_HYPERTABLE_NAME') ORDER BY node_nam
            0 |        8192 |        8192 |       16384 | 
 (1 row)
 
+SELECT * FROM chunks_detailed_size(:'MAT_HYPERTABLE_NAME') ORDER BY node_name;
+ chunk_schema | chunk_name | table_bytes | index_bytes | toast_bytes | total_bytes | node_name 
+--------------+------------+-------------+-------------+-------------+-------------+-----------
+(0 rows)
+
 SELECT * FROM hypertable_size('hypersize_cagg');
  hypertable_size 
 -----------------
@@ -41,6 +46,11 @@ SELECT * FROM hypertable_detailed_size('hypersize_cagg') ORDER BY node_name;
 -------------+-------------+-------------+-------------+-----------
            0 |        8192 |        8192 |       16384 | 
 (1 row)
+
+SELECT * FROM chunks_detailed_size('hypersize_cagg') ORDER BY node_name;
+ chunk_schema | chunk_name | table_bytes | index_bytes | toast_bytes | total_bytes | node_name 
+--------------+------------+-------------+-------------+-------------+-------------+-----------
+(0 rows)
 
 -- Test size functions on non-empty countinuous aggregate
 CALL refresh_continuous_aggregate('hypersize_cagg', NULL, NULL);
@@ -56,6 +66,12 @@ SELECT * FROM hypertable_detailed_size('hypersize_cagg') ORDER BY node_name;
         8192 |       24576 |       16384 |       49152 | 
 (1 row)
 
+SELECT * FROM chunks_detailed_size('hypersize_cagg') ORDER BY node_name;
+     chunk_schema      |    chunk_name    | table_bytes | index_bytes | toast_bytes | total_bytes | node_name 
+-----------------------+------------------+-------------+-------------+-------------+-------------+-----------
+ _timescaledb_internal | _hyper_2_2_chunk |        8192 |       16384 |        8192 |       32768 | 
+(1 row)
+
 SELECT * FROM hypertable_size(:'MAT_HYPERTABLE_NAME');
  hypertable_size 
 -----------------
@@ -66,5 +82,11 @@ SELECT * FROM hypertable_detailed_size(:'MAT_HYPERTABLE_NAME') ORDER BY node_nam
  table_bytes | index_bytes | toast_bytes | total_bytes | node_name 
 -------------+-------------+-------------+-------------+-----------
         8192 |       24576 |       16384 |       49152 | 
+(1 row)
+
+SELECT * FROM chunks_detailed_size(:'MAT_HYPERTABLE_NAME') ORDER BY node_name;
+     chunk_schema      |    chunk_name    | table_bytes | index_bytes | toast_bytes | total_bytes | node_name 
+-----------------------+------------------+-------------+-------------+-------------+-------------+-----------
+ _timescaledb_internal | _hyper_2_2_chunk |        8192 |       16384 |        8192 |       32768 | 
 (1 row)
 

--- a/tsl/test/sql/size_utils_tsl.sql
+++ b/tsl/test/sql/size_utils_tsl.sql
@@ -17,13 +17,16 @@ WHERE user_view_name = 'hypersize_cagg'
 
 SELECT * FROM hypertable_size(:'MAT_HYPERTABLE_NAME');
 SELECT * FROM hypertable_detailed_size(:'MAT_HYPERTABLE_NAME') ORDER BY node_name;
+SELECT * FROM chunks_detailed_size(:'MAT_HYPERTABLE_NAME') ORDER BY node_name;
 SELECT * FROM hypertable_size('hypersize_cagg');
 SELECT * FROM hypertable_detailed_size('hypersize_cagg') ORDER BY node_name;
+SELECT * FROM chunks_detailed_size('hypersize_cagg') ORDER BY node_name;
 
 -- Test size functions on non-empty countinuous aggregate
 CALL refresh_continuous_aggregate('hypersize_cagg', NULL, NULL);
 SELECT * FROM hypertable_size('hypersize_cagg');
 SELECT * FROM hypertable_detailed_size('hypersize_cagg') ORDER BY node_name;
+SELECT * FROM chunks_detailed_size('hypersize_cagg') ORDER BY node_name;
 SELECT * FROM hypertable_size(:'MAT_HYPERTABLE_NAME');
 SELECT * FROM hypertable_detailed_size(:'MAT_HYPERTABLE_NAME') ORDER BY node_name;
-
+SELECT * FROM chunks_detailed_size(:'MAT_HYPERTABLE_NAME') ORDER BY node_name;


### PR DESCRIPTION
This patch adds support to pass continuous aggregate names to `chunk_detailed_size` to align it to the behavior of other functions such as `show_chunks`, `drop_chunks`, `hypertable_size`.