### PR TITLE
Create compressed chunks at insert time

### DIFF
--- a/.github/workflows/linux-32bit-build-and-test.yaml
+++ b/.github/workflows/linux-32bit-build-and-test.yaml
@@ -68,7 +68,7 @@ jobs:
         echo '/tmp/core.%h.%e.%t' > /proc/sys/kernel/core_pattern
         apt-get install -y gcc make cmake libssl-dev libkrb5-dev libipc-run-perl \
           libtest-most-perl sudo gdb git wget gawk lbzip2 flex bison lcov base-files \
-          locales clang-14 llvm-14 llvm-14-dev llvm-14-tools
+          locales clang-14 llvm-14 llvm-14-dev llvm-14-tools postgresql-client
 
     - name: Checkout TimescaleDB
       uses: actions/checkout@v3

--- a/.unreleased/PR_5849
+++ b/.unreleased/PR_5849
@@ -1,0 +1,1 @@
+Implements: #5849 Create compressed chunks at insert time

--- a/sql/maintenance_utils.sql
+++ b/sql/maintenance_utils.sql
@@ -32,6 +32,10 @@ CREATE OR REPLACE FUNCTION _timescaledb_functions.create_compressed_chunk(
     numrows_post_compression BIGINT
 ) RETURNS REGCLASS AS '@MODULE_PATHNAME@', 'ts_create_compressed_chunk' LANGUAGE C STRICT VOLATILE;
 
+CREATE OR REPLACE FUNCTION _timescaledb_functions.create_compressed_chunks_for_hypertable(
+    hypertable REGCLASS
+) RETURNS VOID AS '@MODULE_PATHNAME@', 'ts_create_compressed_chunks_for_hypertable' LANGUAGE C STRICT VOLATILE;
+
 CREATE OR REPLACE FUNCTION @extschema@.compress_chunk(
     uncompressed_chunk REGCLASS,
     if_not_compressed BOOLEAN = false

--- a/sql/size_utils.sql
+++ b/sql/size_utils.sql
@@ -515,10 +515,10 @@ SELECT
     srcht.table_name AS hypertable_name,
     srcch.schema_name AS chunk_schema,
     srcch.table_name AS chunk_name,
-    CASE WHEN srcch.compressed_chunk_id IS NULL THEN
-        'Uncompressed'::text
-    ELSE
+    CASE WHEN srcch.status & 1 > 0 THEN
         'Compressed'::text
+    ELSE
+        'Uncompressed'::text
     END AS compression_status,
     map.uncompressed_heap_size,
     map.uncompressed_index_size,

--- a/sql/updates/latest-dev.sql
+++ b/sql/updates/latest-dev.sql
@@ -167,3 +167,6 @@ ALTER FUNCTION _timescaledb_internal.finalize_agg_ffunc(internal,text,name,name,
 ALTER FUNCTION _timescaledb_internal.finalize_agg_sfunc(internal,text,name,name,name[],bytea,anyelement) SET SCHEMA _timescaledb_functions;
 ALTER FUNCTION _timescaledb_internal.partialize_agg(anyelement) SET SCHEMA _timescaledb_functions;
 
+CREATE OR REPLACE FUNCTION _timescaledb_functions.create_compressed_chunks_for_hypertable(
+    hypertable REGCLASS
+) RETURNS VOID AS '@MODULE_PATHNAME@', 'ts_create_compressed_chunks_for_hypertable' LANGUAGE C STRICT VOLATILE;

--- a/sql/updates/post-update.sql
+++ b/sql/updates/post-update.sql
@@ -194,3 +194,17 @@ BEGIN
 END;
 $$;
 
+-- create compressed chunks for all uncompressed chunks for all hypertables that have compression enabled
+DO $$
+DECLARE
+  schema name;
+  ht_name name;
+BEGIN
+  FOR schema, ht_name IN
+  SELECT schema_name, table_name FROM _timescaledb_catalog.hypertable
+  WHERE compressed_hypertable_id IS NOT NULL
+  LOOP
+    PERFORM _timescaledb_functions.create_compressed_chunks_for_hypertable(schema || '.' || ht_name);
+  END LOOP;
+END;
+$$;

--- a/src/chunk.h
+++ b/src/chunk.h
@@ -150,6 +150,8 @@ extern Chunk *ts_chunk_create_for_point(const Hypertable *ht, const Point *p, bo
 List *ts_chunk_id_find_in_subspace(Hypertable *ht, List *dimension_vecs);
 
 extern TSDLLEXPORT Chunk *ts_chunk_create_base(int32 id, int16 num_constraints, const char relkind);
+extern TSDLLEXPORT Chunk *ts_chunk_create_compress_chunk(Hypertable *compress_ht, Chunk *src_chunk,
+														 Oid table_id);
 extern TSDLLEXPORT ChunkStub *ts_chunk_stub_create(int32 id, int16 num_constraints);
 extern TSDLLEXPORT Chunk *ts_chunk_copy(const Chunk *chunk);
 extern TSDLLEXPORT Chunk *ts_chunk_get_by_name_with_memory_context(const char *schema_name,
@@ -188,13 +190,14 @@ extern TSDLLEXPORT List *ts_chunk_get_window(int32 dimension_id, int64 point, in
 											 MemoryContext mctx);
 extern void ts_chunks_rename_schema_name(char *old_schema, char *new_schema);
 
+extern TSDLLEXPORT bool ts_chunk_set_uncompressed(Chunk *chunk);
+extern TSDLLEXPORT bool ts_chunk_set_compressed(Chunk *chunk);
 extern TSDLLEXPORT bool ts_chunk_set_partial(Chunk *chunk);
 extern TSDLLEXPORT bool ts_chunk_set_unordered(Chunk *chunk);
 extern TSDLLEXPORT bool ts_chunk_set_frozen(Chunk *chunk);
 extern TSDLLEXPORT bool ts_chunk_unset_frozen(Chunk *chunk);
 extern TSDLLEXPORT bool ts_chunk_is_frozen(Chunk *chunk);
 extern TSDLLEXPORT bool ts_chunk_set_compressed_chunk(Chunk *chunk, int32 compressed_chunk_id);
-extern TSDLLEXPORT bool ts_chunk_clear_compressed_chunk(Chunk *chunk);
 extern TSDLLEXPORT void ts_chunk_drop(const Chunk *chunk, DropBehavior behavior, int32 log_level);
 extern TSDLLEXPORT void ts_chunk_drop_preserve_catalog_row(const Chunk *chunk,
 														   DropBehavior behavior, int32 log_level);

--- a/src/cross_module_fn.c
+++ b/src/cross_module_fn.c
@@ -82,6 +82,7 @@ CROSSMODULE_WRAPPER(dictionary_compressor_finish);
 CROSSMODULE_WRAPPER(array_compressor_append);
 CROSSMODULE_WRAPPER(array_compressor_finish);
 CROSSMODULE_WRAPPER(create_compressed_chunk);
+CROSSMODULE_WRAPPER(create_compressed_chunks_for_hypertable);
 CROSSMODULE_WRAPPER(compress_chunk);
 CROSSMODULE_WRAPPER(decompress_chunk);
 

--- a/src/cross_module_fn.h
+++ b/src/cross_module_fn.h
@@ -135,6 +135,7 @@ typedef struct CrossModuleFunctions
 	void (*process_altertable_cmd)(Hypertable *ht, const AlterTableCmd *cmd);
 	void (*process_rename_cmd)(Oid relid, Cache *hcache, const RenameStmt *stmt);
 	PGFunction create_compressed_chunk;
+	PGFunction create_compressed_chunks_for_hypertable;
 	PGFunction compress_chunk;
 	PGFunction decompress_chunk;
 	void (*decompress_batches_for_insert)(ChunkInsertState *state, Chunk *chunk,

--- a/src/planner/planner.c
+++ b/src/planner/planner.c
@@ -1318,7 +1318,7 @@ timescaledb_get_relation_info_hook(PlannerInfo *root, Oid relation_objectid, boo
 				RangeTblEntry *chunk_rte = planner_rt_fetch(rel->relid, root);
 				Chunk *chunk = ts_chunk_get_by_relid(chunk_rte->relid, true);
 
-				if (chunk->fd.compressed_chunk_id != INVALID_CHUNK_ID)
+				if (ts_chunk_is_compressed(chunk))
 				{
 					/* Planning indexes is expensive, and if this is a fully compressed chunk, we
 					 * know we'll never need to use indexes on the uncompressed version, since

--- a/test/sql/updates/post.compression.sql
+++ b/test/sql/updates/post.compression.sql
@@ -9,13 +9,12 @@ SELECT g, 'QW', g::text, 2, 0, (100,4)::custom_type_for_compression, false
 FROM generate_series('2019-11-01 00:00'::timestamp, '2019-12-15 00:00'::timestamp, '1 day') g;
 
 SELECT
-  count(compress_chunk(chunk.schema_name || '.' || chunk.table_name)) AS count_compressed
+  count(compress_chunk(chunks.chunk_schema || '.' || chunks.chunk_name)) AS count_compressed
 FROM
-  _timescaledb_catalog.chunk chunk
-  INNER JOIN _timescaledb_catalog.hypertable hypertable ON (chunk.hypertable_id = hypertable.id)
+  timescaledb_information.chunks
 WHERE
-  hypertable.table_name = 'compress'
-  AND chunk.compressed_chunk_id IS NULL;
+  hypertable_name = 'compress'
+  AND NOT is_compressed;
 
 SELECT * FROM compress ORDER BY time DESC, small_cardinality, large_cardinality, some_double, some_int, some_custom, some_bool;
 

--- a/test/sql/updates/setup.compression.sql
+++ b/test/sql/updates/setup.compression.sql
@@ -30,11 +30,9 @@ FROM generate_series('2018-11-01 00:00'::timestamp, '2018-12-15 00:00'::timestam
 
 ALTER TABLE compress SET (timescaledb.compress, timescaledb.compress_segmentby='small_cardinality');
 
-SELECT compress_chunk(chunk.schema_name|| '.' || chunk.table_name) as count_compressed
-FROM _timescaledb_catalog.chunk chunk
-INNER JOIN _timescaledb_catalog.hypertable hypertable ON (chunk.hypertable_id = hypertable.id)
-WHERE hypertable.table_name = 'compress' and chunk.compressed_chunk_id IS NULL
-ORDER BY chunk.id;
+SELECT count(compress_chunk(chunks.chunk_schema|| '.' || chunks.chunk_name)) as count_compressed
+FROM timescaledb_information.chunks
+WHERE hypertable_name = 'compress' and NOT is_compressed;
 
 \if :WITH_ROLES
 GRANT SELECT ON compress TO tsdbadmin;

--- a/tsl/src/compression/api.h
+++ b/tsl/src/compression/api.h
@@ -10,6 +10,7 @@
 #include <fmgr.h>
 
 extern Datum tsl_create_compressed_chunk(PG_FUNCTION_ARGS);
+extern Datum tsl_create_compressed_chunks_for_hypertable(PG_FUNCTION_ARGS);
 extern Datum tsl_compress_chunk(PG_FUNCTION_ARGS);
 extern Datum tsl_decompress_chunk(PG_FUNCTION_ARGS);
 extern Datum tsl_recompress_chunk(PG_FUNCTION_ARGS);

--- a/tsl/src/compression/compression.c
+++ b/tsl/src/compression/compression.c
@@ -1443,6 +1443,7 @@ decompress_chunk(Oid in_table, Oid out_table)
 	FreeBulkInsertState(decompressor.bistate);
 	MemoryContextDelete(decompressor.per_compressed_row_ctx);
 	ts_catalog_close_indexes(decompressor.indexstate);
+	truncate_relation(in_table);
 
 	table_close(out_rel, NoLock);
 	table_close(in_rel, NoLock);

--- a/tsl/src/compression/create.h
+++ b/tsl/src/compression/create.h
@@ -23,7 +23,6 @@ bool tsl_process_compress_table(AlterTableCmd *cmd, Hypertable *ht,
 void tsl_process_compress_table_add_column(Hypertable *ht, ColumnDef *orig_def);
 void tsl_process_compress_table_drop_column(Hypertable *ht, char *name);
 void tsl_process_compress_table_rename_column(Hypertable *ht, const RenameStmt *stmt);
-Chunk *create_compress_chunk(Hypertable *compress_ht, Chunk *src_chunk, Oid table_id);
 
 char *compression_column_segment_min_name(const FormData_hypertable_compression *fd);
 char *compression_column_segment_max_name(const FormData_hypertable_compression *fd);

--- a/tsl/src/init.c
+++ b/tsl/src/init.c
@@ -202,6 +202,7 @@ CrossModuleFunctions tsl_cm_functions = {
 	.chunk_set_default_data_node = chunk_set_default_data_node,
 	.show_chunk = chunk_show,
 	.create_compressed_chunk = tsl_create_compressed_chunk,
+	.create_compressed_chunks_for_hypertable = tsl_create_compressed_chunks_for_hypertable,
 	.create_chunk = chunk_create,
 	.create_chunk_on_data_nodes = chunk_api_create_on_data_nodes,
 	.chunk_drop_replica = chunk_drop_replica,

--- a/tsl/src/planner.c
+++ b/tsl/src/planner.c
@@ -150,7 +150,7 @@ tsl_set_rel_pathlist_query(PlannerInfo *root, RelOptInfo *rel, Index rti, RangeT
 				ts_chunk_get_by_relid(rte->relid, /* fail_if_not_found = */ true);
 		}
 
-		if (fdw_private->cached_chunk_struct->fd.compressed_chunk_id != INVALID_CHUNK_ID)
+		if (ts_chunk_is_compressed(fdw_private->cached_chunk_struct))
 			ts_decompress_chunk_generate_paths(root, rel, ht, fdw_private->cached_chunk_struct);
 	}
 }
@@ -184,7 +184,7 @@ tsl_set_rel_pathlist_dml(PlannerInfo *root, RelOptInfo *rel, Index rti, RangeTbl
 	{
 		ListCell *lc;
 		Chunk *chunk = ts_chunk_get_by_relid(rte->relid, true);
-		if (chunk->fd.compressed_chunk_id != INVALID_CHUNK_ID)
+		if (ts_chunk_is_compressed(chunk))
 		{
 			foreach (lc, rel->pathlist)
 			{

--- a/tsl/test/expected/bgw_custom.out
+++ b/tsl/test/expected/bgw_custom.out
@@ -437,8 +437,8 @@ SELECT * FROM _timescaledb_internal.compressed_chunk_stats ORDER BY chunk_name;
  hypertable_schema | hypertable_name |     chunk_schema      |    chunk_name    | compression_status | uncompressed_heap_size | uncompressed_index_size | uncompressed_toast_size | uncompressed_total_size | compressed_heap_size | compressed_index_size | compressed_toast_size | compressed_total_size 
 -------------------+-----------------+-----------------------+------------------+--------------------+------------------------+-------------------------+-------------------------+-------------------------+----------------------+-----------------------+-----------------------+-----------------------
  public            | conditions      | _timescaledb_internal | _hyper_1_1_chunk | Uncompressed       |                        |                         |                         |                         |                      |                       |                       |                      
- public            | conditions      | _timescaledb_internal | _hyper_1_2_chunk | Uncompressed       |                        |                         |                         |                         |                      |                       |                       |                      
  public            | conditions      | _timescaledb_internal | _hyper_1_3_chunk | Uncompressed       |                        |                         |                         |                         |                      |                       |                       |                      
+ public            | conditions      | _timescaledb_internal | _hyper_1_5_chunk | Uncompressed       |                        |                         |                         |                         |                      |                       |                       |                      
 (3 rows)
 
 -- Compression policy
@@ -454,8 +454,8 @@ SELECT * FROM _timescaledb_internal.compressed_chunk_stats ORDER BY chunk_name;
  hypertable_schema | hypertable_name |     chunk_schema      |    chunk_name    | compression_status | uncompressed_heap_size | uncompressed_index_size | uncompressed_toast_size | uncompressed_total_size | compressed_heap_size | compressed_index_size | compressed_toast_size | compressed_total_size 
 -------------------+-----------------+-----------------------+------------------+--------------------+------------------------+-------------------------+-------------------------+-------------------------+----------------------+-----------------------+-----------------------+-----------------------
  public            | conditions      | _timescaledb_internal | _hyper_1_1_chunk | Compressed         |                   8192 |                   16384 |                    8192 |                   32768 |                 8192 |                 16384 |                  8192 |                 32768
- public            | conditions      | _timescaledb_internal | _hyper_1_2_chunk | Compressed         |                   8192 |                   16384 |                    8192 |                   32768 |                 8192 |                 16384 |                  8192 |                 32768
  public            | conditions      | _timescaledb_internal | _hyper_1_3_chunk | Compressed         |                   8192 |                   16384 |                    8192 |                   32768 |                 8192 |                 16384 |                  8192 |                 32768
+ public            | conditions      | _timescaledb_internal | _hyper_1_5_chunk | Compressed         |                   8192 |                   16384 |                    8192 |                   32768 |                 8192 |                 16384 |                  8192 |                 32768
 (3 rows)
 
 --TEST compression job after inserting data into previously compressed chunk
@@ -468,8 +468,8 @@ order by id;
  id |    table_name    | status 
 ----+------------------+--------
   1 | _hyper_1_1_chunk |      9
-  2 | _hyper_1_2_chunk |      9
   3 | _hyper_1_3_chunk |      9
+  5 | _hyper_1_5_chunk |      9
 (3 rows)
 
 --running job second time, wait for it to complete
@@ -492,8 +492,8 @@ order by id;
  id |    table_name    | status 
 ----+------------------+--------
   1 | _hyper_1_1_chunk |      1
-  2 | _hyper_1_2_chunk |      1
   3 | _hyper_1_3_chunk |      1
+  5 | _hyper_1_5_chunk |      1
 (3 rows)
 
 -- Drop the compression job
@@ -508,8 +508,8 @@ SELECT decompress_chunk(c) FROM show_chunks('conditions') c;
             decompress_chunk            
 ----------------------------------------
  _timescaledb_internal._hyper_1_1_chunk
- _timescaledb_internal._hyper_1_2_chunk
  _timescaledb_internal._hyper_1_3_chunk
+ _timescaledb_internal._hyper_1_5_chunk
 (3 rows)
 
 -- TEST Continuous Aggregate job
@@ -572,7 +572,7 @@ FROM _timescaledb_config.bgw_job WHERE id = :job_id_5;
 
 --verify that job is dropped when cagg is dropped
 DROP MATERIALIZED VIEW conditions_summary_daily;
-NOTICE:  drop cascades to table _timescaledb_internal._hyper_3_10_chunk
+NOTICE:  drop cascades to table _timescaledb_internal._hyper_3_7_chunk
 SELECT id, proc_name, hypertable_id
 FROM _timescaledb_config.bgw_job WHERE id = :job_id_5;
  id | proc_name | hypertable_id 
@@ -913,15 +913,6 @@ INSERT INTO sensor_data
 		time;
 -- enable compression
 ALTER TABLE sensor_data SET (timescaledb.compress, timescaledb.compress_orderby = 'time DESC');
--- add new compression policy job
-SELECT add_compression_policy('sensor_data', INTERVAL '1' minute) AS compressjob_id \gset
--- set recompress to true
-SELECT alter_job(id,config:=jsonb_set(config,'{recompress}', 'true')) FROM _timescaledb_config.bgw_job WHERE id = :compressjob_id;
-                                                                                           alter_job                                                                                            
-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
- (1014,"@ 3 days 12 hours","@ 0",-1,"@ 1 hour",t,"{""recompress"": true, ""hypertable_id"": 4, ""compress_after"": ""@ 1 min""}",-infinity,_timescaledb_functions.policy_compression_check,f,,)
-(1 row)
-
 -- create new chunks
 INSERT INTO sensor_data
 	SELECT
@@ -938,8 +929,8 @@ INSERT INTO sensor_data
 SELECT chunk_name AS new_uncompressed_chunk_name
   FROM timescaledb_information.chunks
   WHERE hypertable_name = 'sensor_data' AND NOT is_compressed LIMIT 1 \gset
--- change compression status so that this chunk is skipped when policy is run
-update _timescaledb_catalog.chunk set status=3 where table_name = :'new_uncompressed_chunk_name';
+-- change compression status to invalid value so that this chunk is skipped when policy is run
+update _timescaledb_catalog.chunk set status=-1 where table_name = :'new_uncompressed_chunk_name';
 -- verify that there are other uncompressed new chunks that need to be compressed
 SELECT count(*) > 1
   FROM timescaledb_information.chunks
@@ -947,6 +938,15 @@ SELECT count(*) > 1
  ?column? 
 ----------
  t
+(1 row)
+
+-- add new compression policy job
+SELECT add_compression_policy('sensor_data', INTERVAL '1' minute) AS compressjob_id \gset
+-- set recompress to true
+SELECT alter_job(id,config:=jsonb_set(config,'{recompress}', 'true')) FROM _timescaledb_config.bgw_job WHERE id = :compressjob_id;
+                                                                                           alter_job                                                                                            
+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ (1014,"@ 3 days 12 hours","@ 0",-1,"@ 1 hour",t,"{""recompress"": true, ""hypertable_id"": 4, ""compress_after"": ""@ 1 min""}",-infinity,_timescaledb_functions.policy_compression_check,f,,)
 (1 row)
 
 -- disable notice/warning as the new_uncompressed_chunk_name
@@ -958,7 +958,7 @@ SET client_min_messages TO NOTICE;
 SELECT status FROM _timescaledb_catalog.chunk where table_name = :'new_uncompressed_chunk_name';
  status 
 --------
-      3
+     -1
 (1 row)
 
 -- confirm all the other new chunks are now compressed despite

--- a/tsl/test/expected/bgw_db_scheduler_fixed.out
+++ b/tsl/test/expected/bgw_db_scheduler_fixed.out
@@ -1731,7 +1731,7 @@ select hypertable_schema, hypertable_name, chunk_schema, chunk_name, is_compress
  public                | test_table_scheduler       | _timescaledb_internal | _hyper_1_6_chunk  | f
  public                | test_table_scheduler       | _timescaledb_internal | _hyper_1_7_chunk  | f
  public                | test_table_scheduler       | _timescaledb_internal | _hyper_1_8_chunk  | f
- _timescaledb_internal | _materialized_hypertable_2 | _timescaledb_internal | _hyper_2_10_chunk | f
+ _timescaledb_internal | _materialized_hypertable_2 | _timescaledb_internal | _hyper_2_17_chunk | f
 (5 rows)
 
 select avg_a from cagg_scheduler ORDER BY 1;

--- a/tsl/test/expected/cagg_ddl.out
+++ b/tsl/test/expected/cagg_ddl.out
@@ -1910,8 +1910,8 @@ Indexes:
     "_materialized_hypertable_47_bucket_idx" btree (bucket DESC)
 Triggers:
     ts_insert_blocker BEFORE INSERT ON _timescaledb_internal._materialized_hypertable_47 FOR EACH ROW EXECUTE FUNCTION _timescaledb_functions.insert_blocker()
-Child tables: _timescaledb_internal._hyper_47_52_chunk,
-              _timescaledb_internal._hyper_47_53_chunk
+Child tables: _timescaledb_internal._hyper_47_56_chunk,
+              _timescaledb_internal._hyper_47_57_chunk
 
 \d+ 'cashflows'
                                     View "public.cashflows"

--- a/tsl/test/expected/cagg_ddl_dist_ht.out
+++ b/tsl/test/expected/cagg_ddl_dist_ht.out
@@ -1708,6 +1708,7 @@ SELECT count(*) from test_setting_cagg ORDER BY 1;
 --now set it back to false --
 ALTER MATERIALIZED VIEW test_setting_cagg SET (timescaledb.materialized_only = 'false', timescaledb.compress='true');
 psql:include/cagg_ddl_common.sql:1149: NOTICE:  defaulting compress_orderby to time_bucket
+psql:include/cagg_ddl_common.sql:1149: NOTICE:  drop cascades to table _timescaledb_internal.compress_hyper_41_49_chunk
 SELECT view_name, compression_enabled, materialized_only
 FROM timescaledb_information.continuous_aggregates
 where view_name = 'test_setting_cagg';
@@ -1724,6 +1725,7 @@ SELECT count(*) from test_setting_cagg ORDER BY 1;
 (1 row)
 
 ALTER MATERIALIZED VIEW test_setting_cagg SET (timescaledb.materialized_only = 'true', timescaledb.compress='false');
+psql:include/cagg_ddl_common.sql:1156: NOTICE:  drop cascades to table _timescaledb_internal.compress_hyper_42_50_chunk
 SELECT view_name, compression_enabled, materialized_only
 FROM timescaledb_information.continuous_aggregates
 where view_name = 'test_setting_cagg';
@@ -1793,6 +1795,7 @@ SELECT count(*) from test_setting_cagg ORDER BY 1;
 --now set it back to false --
 ALTER MATERIALIZED VIEW test_setting_cagg SET (timescaledb.materialized_only = 'true', timescaledb.compress='true');
 psql:include/cagg_ddl_common.sql:1193: NOTICE:  defaulting compress_orderby to time_bucket
+psql:include/cagg_ddl_common.sql:1193: NOTICE:  drop cascades to table _timescaledb_internal.compress_hyper_44_52_chunk
 SELECT view_name, compression_enabled, materialized_only
 FROM timescaledb_information.continuous_aggregates
 where view_name = 'test_setting_cagg';
@@ -1809,6 +1812,7 @@ SELECT count(*) from test_setting_cagg ORDER BY 1;
 (1 row)
 
 ALTER MATERIALIZED VIEW test_setting_cagg SET (timescaledb.materialized_only = 'false', timescaledb.compress='false');
+psql:include/cagg_ddl_common.sql:1200: NOTICE:  drop cascades to table _timescaledb_internal.compress_hyper_45_53_chunk
 SELECT view_name, compression_enabled, materialized_only
 FROM timescaledb_information.continuous_aggregates
 where view_name = 'test_setting_cagg';
@@ -1953,8 +1957,8 @@ Indexes:
     "_materialized_hypertable_47_bucket_idx" btree (bucket DESC)
 Triggers:
     ts_insert_blocker BEFORE INSERT ON _timescaledb_internal._materialized_hypertable_47 FOR EACH ROW EXECUTE FUNCTION _timescaledb_functions.insert_blocker()
-Child tables: _timescaledb_internal._hyper_47_52_chunk,
-              _timescaledb_internal._hyper_47_53_chunk
+Child tables: _timescaledb_internal._hyper_47_56_chunk,
+              _timescaledb_internal._hyper_47_57_chunk
 
 \d+ 'cashflows'
                                     View "public.cashflows"

--- a/tsl/test/expected/cagg_migrate.out
+++ b/tsl/test/expected/cagg_migrate.out
@@ -379,16 +379,16 @@ SELECT compress_chunk(c) FROM show_chunks('conditions_summary_daily') c ORDER BY
 SELECT compress_chunk(c) FROM show_chunks('conditions_summary_daily_new') c ORDER BY c::regclass::text;
               compress_chunk              
 ------------------------------------------
- _timescaledb_internal._hyper_6_122_chunk
- _timescaledb_internal._hyper_6_123_chunk
- _timescaledb_internal._hyper_6_124_chunk
- _timescaledb_internal._hyper_6_125_chunk
- _timescaledb_internal._hyper_6_126_chunk
- _timescaledb_internal._hyper_6_127_chunk
- _timescaledb_internal._hyper_6_128_chunk
- _timescaledb_internal._hyper_6_129_chunk
- _timescaledb_internal._hyper_6_130_chunk
- _timescaledb_internal._hyper_6_131_chunk
+ _timescaledb_internal._hyper_6_132_chunk
+ _timescaledb_internal._hyper_6_134_chunk
+ _timescaledb_internal._hyper_6_136_chunk
+ _timescaledb_internal._hyper_6_138_chunk
+ _timescaledb_internal._hyper_6_140_chunk
+ _timescaledb_internal._hyper_6_142_chunk
+ _timescaledb_internal._hyper_6_144_chunk
+ _timescaledb_internal._hyper_6_146_chunk
+ _timescaledb_internal._hyper_6_148_chunk
+ _timescaledb_internal._hyper_6_150_chunk
 (10 rows)
 
 -- check migrated data after compression. should return 0 (zero) rows
@@ -1056,23 +1056,23 @@ SELECT * FROM conditions_summary_daily_new;
 SELECT compress_chunk(c) FROM show_chunks('conditions_summary_daily') c ORDER BY c::regclass::text;
               compress_chunk               
 -------------------------------------------
- _timescaledb_internal._hyper_16_245_chunk
- _timescaledb_internal._hyper_16_246_chunk
- _timescaledb_internal._hyper_16_247_chunk
- _timescaledb_internal._hyper_16_248_chunk
- _timescaledb_internal._hyper_16_249_chunk
- _timescaledb_internal._hyper_16_250_chunk
+ _timescaledb_internal._hyper_16_265_chunk
+ _timescaledb_internal._hyper_16_266_chunk
+ _timescaledb_internal._hyper_16_267_chunk
+ _timescaledb_internal._hyper_16_268_chunk
+ _timescaledb_internal._hyper_16_269_chunk
+ _timescaledb_internal._hyper_16_270_chunk
 (6 rows)
 
 SELECT compress_chunk(c) FROM show_chunks('conditions_summary_daily_new') c ORDER BY c::regclass::text;
               compress_chunk               
 -------------------------------------------
- _timescaledb_internal._hyper_19_257_chunk
- _timescaledb_internal._hyper_19_258_chunk
- _timescaledb_internal._hyper_19_259_chunk
- _timescaledb_internal._hyper_19_260_chunk
- _timescaledb_internal._hyper_19_261_chunk
- _timescaledb_internal._hyper_19_262_chunk
+ _timescaledb_internal._hyper_19_283_chunk
+ _timescaledb_internal._hyper_19_285_chunk
+ _timescaledb_internal._hyper_19_287_chunk
+ _timescaledb_internal._hyper_19_289_chunk
+ _timescaledb_internal._hyper_19_291_chunk
+ _timescaledb_internal._hyper_19_293_chunk
 (6 rows)
 
 -- check migrated data after compression. should return 0 (zero) rows
@@ -1735,23 +1735,23 @@ SELECT * FROM conditions_summary_daily_new;
 SELECT compress_chunk(c) FROM show_chunks('conditions_summary_daily') c ORDER BY c::regclass::text;
               compress_chunk               
 -------------------------------------------
- _timescaledb_internal._hyper_29_352_chunk
- _timescaledb_internal._hyper_29_353_chunk
- _timescaledb_internal._hyper_29_354_chunk
- _timescaledb_internal._hyper_29_355_chunk
- _timescaledb_internal._hyper_29_356_chunk
- _timescaledb_internal._hyper_29_357_chunk
+ _timescaledb_internal._hyper_29_384_chunk
+ _timescaledb_internal._hyper_29_385_chunk
+ _timescaledb_internal._hyper_29_386_chunk
+ _timescaledb_internal._hyper_29_387_chunk
+ _timescaledb_internal._hyper_29_388_chunk
+ _timescaledb_internal._hyper_29_389_chunk
 (6 rows)
 
 SELECT compress_chunk(c) FROM show_chunks('conditions_summary_daily_new') c ORDER BY c::regclass::text;
               compress_chunk               
 -------------------------------------------
- _timescaledb_internal._hyper_32_364_chunk
- _timescaledb_internal._hyper_32_365_chunk
- _timescaledb_internal._hyper_32_366_chunk
- _timescaledb_internal._hyper_32_367_chunk
- _timescaledb_internal._hyper_32_368_chunk
- _timescaledb_internal._hyper_32_369_chunk
+ _timescaledb_internal._hyper_32_402_chunk
+ _timescaledb_internal._hyper_32_404_chunk
+ _timescaledb_internal._hyper_32_406_chunk
+ _timescaledb_internal._hyper_32_408_chunk
+ _timescaledb_internal._hyper_32_410_chunk
+ _timescaledb_internal._hyper_32_412_chunk
 (6 rows)
 
 -- check migrated data after compression. should return 0 (zero) rows

--- a/tsl/test/expected/cagg_migrate_dist_ht.out
+++ b/tsl/test/expected/cagg_migrate_dist_ht.out
@@ -414,16 +414,16 @@ SELECT compress_chunk(c) FROM show_chunks('conditions_summary_daily') c ORDER BY
 SELECT compress_chunk(c) FROM show_chunks('conditions_summary_daily_new') c ORDER BY c::regclass::text;
               compress_chunk              
 ------------------------------------------
- _timescaledb_internal._hyper_6_122_chunk
- _timescaledb_internal._hyper_6_123_chunk
- _timescaledb_internal._hyper_6_124_chunk
- _timescaledb_internal._hyper_6_125_chunk
- _timescaledb_internal._hyper_6_126_chunk
- _timescaledb_internal._hyper_6_127_chunk
- _timescaledb_internal._hyper_6_128_chunk
- _timescaledb_internal._hyper_6_129_chunk
- _timescaledb_internal._hyper_6_130_chunk
- _timescaledb_internal._hyper_6_131_chunk
+ _timescaledb_internal._hyper_6_132_chunk
+ _timescaledb_internal._hyper_6_134_chunk
+ _timescaledb_internal._hyper_6_136_chunk
+ _timescaledb_internal._hyper_6_138_chunk
+ _timescaledb_internal._hyper_6_140_chunk
+ _timescaledb_internal._hyper_6_142_chunk
+ _timescaledb_internal._hyper_6_144_chunk
+ _timescaledb_internal._hyper_6_146_chunk
+ _timescaledb_internal._hyper_6_148_chunk
+ _timescaledb_internal._hyper_6_150_chunk
 (10 rows)
 
 -- check migrated data after compression. should return 0 (zero) rows
@@ -1091,23 +1091,23 @@ SELECT * FROM conditions_summary_daily_new;
 SELECT compress_chunk(c) FROM show_chunks('conditions_summary_daily') c ORDER BY c::regclass::text;
               compress_chunk               
 -------------------------------------------
- _timescaledb_internal._hyper_16_245_chunk
- _timescaledb_internal._hyper_16_246_chunk
- _timescaledb_internal._hyper_16_247_chunk
- _timescaledb_internal._hyper_16_248_chunk
- _timescaledb_internal._hyper_16_249_chunk
- _timescaledb_internal._hyper_16_250_chunk
+ _timescaledb_internal._hyper_16_265_chunk
+ _timescaledb_internal._hyper_16_266_chunk
+ _timescaledb_internal._hyper_16_267_chunk
+ _timescaledb_internal._hyper_16_268_chunk
+ _timescaledb_internal._hyper_16_269_chunk
+ _timescaledb_internal._hyper_16_270_chunk
 (6 rows)
 
 SELECT compress_chunk(c) FROM show_chunks('conditions_summary_daily_new') c ORDER BY c::regclass::text;
               compress_chunk               
 -------------------------------------------
- _timescaledb_internal._hyper_19_257_chunk
- _timescaledb_internal._hyper_19_258_chunk
- _timescaledb_internal._hyper_19_259_chunk
- _timescaledb_internal._hyper_19_260_chunk
- _timescaledb_internal._hyper_19_261_chunk
- _timescaledb_internal._hyper_19_262_chunk
+ _timescaledb_internal._hyper_19_283_chunk
+ _timescaledb_internal._hyper_19_285_chunk
+ _timescaledb_internal._hyper_19_287_chunk
+ _timescaledb_internal._hyper_19_289_chunk
+ _timescaledb_internal._hyper_19_291_chunk
+ _timescaledb_internal._hyper_19_293_chunk
 (6 rows)
 
 -- check migrated data after compression. should return 0 (zero) rows
@@ -1770,23 +1770,23 @@ SELECT * FROM conditions_summary_daily_new;
 SELECT compress_chunk(c) FROM show_chunks('conditions_summary_daily') c ORDER BY c::regclass::text;
               compress_chunk               
 -------------------------------------------
- _timescaledb_internal._hyper_29_352_chunk
- _timescaledb_internal._hyper_29_353_chunk
- _timescaledb_internal._hyper_29_354_chunk
- _timescaledb_internal._hyper_29_355_chunk
- _timescaledb_internal._hyper_29_356_chunk
- _timescaledb_internal._hyper_29_357_chunk
+ _timescaledb_internal._hyper_29_384_chunk
+ _timescaledb_internal._hyper_29_385_chunk
+ _timescaledb_internal._hyper_29_386_chunk
+ _timescaledb_internal._hyper_29_387_chunk
+ _timescaledb_internal._hyper_29_388_chunk
+ _timescaledb_internal._hyper_29_389_chunk
 (6 rows)
 
 SELECT compress_chunk(c) FROM show_chunks('conditions_summary_daily_new') c ORDER BY c::regclass::text;
               compress_chunk               
 -------------------------------------------
- _timescaledb_internal._hyper_32_364_chunk
- _timescaledb_internal._hyper_32_365_chunk
- _timescaledb_internal._hyper_32_366_chunk
- _timescaledb_internal._hyper_32_367_chunk
- _timescaledb_internal._hyper_32_368_chunk
- _timescaledb_internal._hyper_32_369_chunk
+ _timescaledb_internal._hyper_32_402_chunk
+ _timescaledb_internal._hyper_32_404_chunk
+ _timescaledb_internal._hyper_32_406_chunk
+ _timescaledb_internal._hyper_32_408_chunk
+ _timescaledb_internal._hyper_32_410_chunk
+ _timescaledb_internal._hyper_32_412_chunk
 (6 rows)
 
 -- check migrated data after compression. should return 0 (zero) rows

--- a/tsl/test/expected/cagg_policy.out
+++ b/tsl/test/expected/cagg_policy.out
@@ -1126,7 +1126,7 @@ ALTER TABLE metrics SET ( timescaledb.compress );
 SELECT compress_chunk(ch) FROM show_chunks('metrics') ch;
               compress_chunk              
 ------------------------------------------
- _timescaledb_internal._hyper_18_19_chunk
+ _timescaledb_internal._hyper_18_24_chunk
 (1 row)
 
 CREATE MATERIALIZED VIEW metrics_cagg WITH (timescaledb.continuous,

--- a/tsl/test/expected/chunk_merge.out
+++ b/tsl/test/expected/chunk_merge.out
@@ -36,31 +36,37 @@ NOTICE:  adding not-null constraint to column "Time"
 -- This creates chunks 7 - 9 on second hypertable.
 INSERT INTO test2 SELECT t, 1, 1.0 FROM generate_series('2018-03-02 1:00'::TIMESTAMPTZ, '2018-03-02 3:00', '1 minute') t;
 SELECT * FROM _timescaledb_catalog.chunk;
- id | hypertable_id |      schema_name      |    table_name    | compressed_chunk_id | dropped | status | osm_chunk 
-----+---------------+-----------------------+------------------+---------------------+---------+--------+-----------
-  1 |             1 | _timescaledb_internal | _hyper_1_1_chunk |                     | f       |      0 | f
-  2 |             1 | _timescaledb_internal | _hyper_1_2_chunk |                     | f       |      0 | f
-  3 |             1 | _timescaledb_internal | _hyper_1_3_chunk |                     | f       |      0 | f
-  4 |             1 | _timescaledb_internal | _hyper_1_4_chunk |                     | f       |      0 | f
-  5 |             1 | _timescaledb_internal | _hyper_1_5_chunk |                     | f       |      0 | f
-  6 |             1 | _timescaledb_internal | _hyper_1_6_chunk |                     | f       |      0 | f
-  7 |             3 | _timescaledb_internal | _hyper_3_7_chunk |                     | f       |      0 | f
-  8 |             3 | _timescaledb_internal | _hyper_3_8_chunk |                     | f       |      0 | f
-  9 |             3 | _timescaledb_internal | _hyper_3_9_chunk |                     | f       |      0 | f
-(9 rows)
+ id | hypertable_id |      schema_name      |        table_name         | compressed_chunk_id | dropped | status | osm_chunk 
+----+---------------+-----------------------+---------------------------+---------------------+---------+--------+-----------
+  2 |             2 | _timescaledb_internal | compress_hyper_2_2_chunk  |                     | f       |      0 | f
+  1 |             1 | _timescaledb_internal | _hyper_1_1_chunk          |                   2 | f       |      0 | f
+  4 |             2 | _timescaledb_internal | compress_hyper_2_4_chunk  |                     | f       |      0 | f
+  3 |             1 | _timescaledb_internal | _hyper_1_3_chunk          |                   4 | f       |      0 | f
+  6 |             2 | _timescaledb_internal | compress_hyper_2_6_chunk  |                     | f       |      0 | f
+  5 |             1 | _timescaledb_internal | _hyper_1_5_chunk          |                   6 | f       |      0 | f
+  8 |             2 | _timescaledb_internal | compress_hyper_2_8_chunk  |                     | f       |      0 | f
+  7 |             1 | _timescaledb_internal | _hyper_1_7_chunk          |                   8 | f       |      0 | f
+ 10 |             2 | _timescaledb_internal | compress_hyper_2_10_chunk |                     | f       |      0 | f
+  9 |             1 | _timescaledb_internal | _hyper_1_9_chunk          |                  10 | f       |      0 | f
+ 12 |             2 | _timescaledb_internal | compress_hyper_2_12_chunk |                     | f       |      0 | f
+ 11 |             1 | _timescaledb_internal | _hyper_1_11_chunk         |                  12 | f       |      0 | f
+ 13 |             3 | _timescaledb_internal | _hyper_3_13_chunk         |                     | f       |      0 | f
+ 14 |             3 | _timescaledb_internal | _hyper_3_14_chunk         |                     | f       |      0 | f
+ 15 |             3 | _timescaledb_internal | _hyper_3_15_chunk         |                     | f       |      0 | f
+(15 rows)
 
 \set ON_ERROR_STOP 0
 -- Cannot merge chunks from different hypertables
-SELECT _timescaledb_internal.test_merge_chunks_on_dimension('_timescaledb_internal._hyper_1_1_chunk','_timescaledb_internal._hyper_3_7_chunk', 1);
+SELECT _timescaledb_internal.test_merge_chunks_on_dimension('_timescaledb_internal._hyper_1_1_chunk','_timescaledb_internal._hyper_3_13_chunk', 1);
 ERROR:  cannot merge chunks from different hypertables
 -- Cannot merge non-adjacent chunks
-SELECT _timescaledb_internal.test_merge_chunks_on_dimension('_timescaledb_internal._hyper_1_1_chunk','_timescaledb_internal._hyper_1_3_chunk', 1);
+SELECT _timescaledb_internal.test_merge_chunks_on_dimension('_timescaledb_internal._hyper_1_1_chunk','_timescaledb_internal._hyper_1_5_chunk', 1);
 ERROR:  cannot merge non-adjacent chunks over supplied dimension
 -- Cannot merge same chunk to itself (its not adjacent to itself).
 SELECT _timescaledb_internal.test_merge_chunks_on_dimension('_timescaledb_internal._hyper_1_1_chunk','_timescaledb_internal._hyper_1_1_chunk', 1);
 ERROR:  cannot merge non-adjacent chunks over supplied dimension
 -- Cannot merge chunks on with different partitioning schemas.
-SELECT _timescaledb_internal.test_merge_chunks_on_dimension('_timescaledb_internal._hyper_1_1_chunk','_timescaledb_internal._hyper_1_4_chunk', 1);
+SELECT _timescaledb_internal.test_merge_chunks_on_dimension('_timescaledb_internal._hyper_1_1_chunk','_timescaledb_internal._hyper_1_7_chunk', 1);
 ERROR:  cannot merge chunks with different partitioning schemas
 -- Cannot merge chunks on with non-existant dimension slice.
 -- NOTE: we are merging the same chunk just so they have the exact same partitioning schema and we don't hit the previous test error.
@@ -68,14 +74,14 @@ SELECT _timescaledb_internal.test_merge_chunks_on_dimension('_timescaledb_intern
 ERROR:  cannot find slice for merging dimension
 \set ON_ERROR_STOP 1
 -- Merge on open (time) dimension.
-SELECT _timescaledb_internal.test_merge_chunks_on_dimension('_timescaledb_internal._hyper_1_5_chunk','_timescaledb_internal._hyper_1_6_chunk', 1);
+SELECT _timescaledb_internal.test_merge_chunks_on_dimension('_timescaledb_internal._hyper_1_9_chunk','_timescaledb_internal._hyper_1_11_chunk', 1);
  test_merge_chunks_on_dimension 
 --------------------------------
  
 (1 row)
 
 -- Merge on closed dimension.
-SELECT _timescaledb_internal.test_merge_chunks_on_dimension('_timescaledb_internal._hyper_1_1_chunk','_timescaledb_internal._hyper_1_4_chunk', 2);
+SELECT _timescaledb_internal.test_merge_chunks_on_dimension('_timescaledb_internal._hyper_1_1_chunk','_timescaledb_internal._hyper_1_7_chunk', 2);
  test_merge_chunks_on_dimension 
 --------------------------------
  
@@ -85,14 +91,14 @@ SELECT compress_chunk(i) FROM show_chunks('test1') i;
              compress_chunk             
 ----------------------------------------
  _timescaledb_internal._hyper_1_1_chunk
- _timescaledb_internal._hyper_1_2_chunk
- _timescaledb_internal._hyper_1_2_chunk
- _timescaledb_internal._hyper_1_5_chunk
+ _timescaledb_internal._hyper_1_3_chunk
+ _timescaledb_internal._hyper_1_3_chunk
+ _timescaledb_internal._hyper_1_9_chunk
 (4 rows)
 
 \set ON_ERROR_STOP 0
 -- Cannot merge chunks internal compressed chunks, no dimensions on them.
-SELECT _timescaledb_internal.test_merge_chunks_on_dimension('_timescaledb_internal.compress_hyper_2_10_chunk','_timescaledb_internal.compress_hyper_2_11_chunk', 1);
+SELECT _timescaledb_internal.test_merge_chunks_on_dimension('_timescaledb_internal.compress_hyper_2_2_chunk','_timescaledb_internal.compress_hyper_2_4_chunk', 1);
 ERROR:  cannot find slice for merging dimension
 \set ON_ERROR_STOP 1
 -- This creates more data so caggs has multiple chunks.

--- a/tsl/test/expected/chunk_utils_compression.out
+++ b/tsl/test/expected/chunk_utils_compression.out
@@ -44,19 +44,19 @@ SELECT show_chunks('public.uncompressed_table');
 (6 rows)
 
 SELECT show_chunks('public.table_to_compress');
-              show_chunks               
-----------------------------------------
+               show_chunks               
+-----------------------------------------
  _timescaledb_internal._hyper_2_7_chunk
- _timescaledb_internal._hyper_2_8_chunk
  _timescaledb_internal._hyper_2_9_chunk
+ _timescaledb_internal._hyper_2_11_chunk
 (3 rows)
 
 SELECT show_chunks('public.table_to_compress', older_than=>'1 day'::interval);
-              show_chunks               
-----------------------------------------
+               show_chunks               
+-----------------------------------------
  _timescaledb_internal._hyper_2_7_chunk
- _timescaledb_internal._hyper_2_8_chunk
  _timescaledb_internal._hyper_2_9_chunk
+ _timescaledb_internal._hyper_2_11_chunk
 (3 rows)
 
 SELECT show_chunks('public.table_to_compress', newer_than=>'1 day'::interval);
@@ -66,11 +66,11 @@ SELECT show_chunks('public.table_to_compress', newer_than=>'1 day'::interval);
 
 -- compress all chunks of the table:
 SELECT compress_chunk(show_chunks('public.table_to_compress'));
-             compress_chunk             
-----------------------------------------
+             compress_chunk              
+-----------------------------------------
  _timescaledb_internal._hyper_2_7_chunk
- _timescaledb_internal._hyper_2_8_chunk
  _timescaledb_internal._hyper_2_9_chunk
+ _timescaledb_internal._hyper_2_11_chunk
 (3 rows)
 
 -- and run the queries again to make sure results are the same
@@ -86,19 +86,19 @@ SELECT show_chunks('public.uncompressed_table');
 (6 rows)
 
 SELECT show_chunks('public.table_to_compress');
-              show_chunks               
-----------------------------------------
+               show_chunks               
+-----------------------------------------
  _timescaledb_internal._hyper_2_7_chunk
- _timescaledb_internal._hyper_2_8_chunk
  _timescaledb_internal._hyper_2_9_chunk
+ _timescaledb_internal._hyper_2_11_chunk
 (3 rows)
 
 SELECT show_chunks('public.table_to_compress', older_than=>'1 day'::interval);
-              show_chunks               
-----------------------------------------
+               show_chunks               
+-----------------------------------------
  _timescaledb_internal._hyper_2_7_chunk
- _timescaledb_internal._hyper_2_8_chunk
  _timescaledb_internal._hyper_2_9_chunk
+ _timescaledb_internal._hyper_2_11_chunk
 (3 rows)
 
 SELECT show_chunks('public.table_to_compress', newer_than=>'1 day'::interval);
@@ -130,8 +130,8 @@ SELECT drop_chunks(table_name::regclass, older_than=>'1 day'::interval)
   FROM _timescaledb_catalog.hypertable
  WHERE schema_name = current_schema()
 ORDER BY table_name DESC;
-              drop_chunks               
-----------------------------------------
+               drop_chunks               
+-----------------------------------------
  _timescaledb_internal._hyper_1_1_chunk
  _timescaledb_internal._hyper_1_2_chunk
  _timescaledb_internal._hyper_1_3_chunk
@@ -139,8 +139,8 @@ ORDER BY table_name DESC;
  _timescaledb_internal._hyper_1_5_chunk
  _timescaledb_internal._hyper_1_6_chunk
  _timescaledb_internal._hyper_2_7_chunk
- _timescaledb_internal._hyper_2_8_chunk
  _timescaledb_internal._hyper_2_9_chunk
+ _timescaledb_internal._hyper_2_11_chunk
 (9 rows)
 
 SELECT show_chunks('public.uncompressed_table');

--- a/tsl/test/expected/chunk_utils_internal.out
+++ b/tsl/test/expected/chunk_utils_internal.out
@@ -256,8 +256,8 @@ SELECT show_chunks('public.table_to_compress');
               show_chunks               
 ----------------------------------------
  _timescaledb_internal._hyper_2_3_chunk
- _timescaledb_internal._hyper_2_4_chunk
  _timescaledb_internal._hyper_2_5_chunk
+ _timescaledb_internal._hyper_2_7_chunk
 (3 rows)
 
 SELECT chunk_schema || '.' ||  chunk_name as "CHNAME", chunk_name as "CHUNK_NAME"
@@ -326,8 +326,8 @@ SELECT * from public.table_to_compress ORDER BY 1, 3;
 SELECT drop_chunks('table_to_compress', older_than=> '1 day'::interval);
               drop_chunks               
 ----------------------------------------
- _timescaledb_internal._hyper_2_4_chunk
  _timescaledb_internal._hyper_2_5_chunk
+ _timescaledb_internal._hyper_2_7_chunk
 (2 rows)
 
 --unfreeze and drop it
@@ -359,14 +359,14 @@ SELECT  _timescaledb_functions.freeze_chunk( :'CHNAME');
 
 \set ON_ERROR_STOP 0
 SELECT  compress_chunk( :'CHNAME');
-ERROR:  compress_chunk not permitted on frozen chunk "_hyper_2_7_chunk" 
+ERROR:  compress_chunk not permitted on frozen chunk "_hyper_2_9_chunk" 
 \set ON_ERROR_STOP 1
 --TEST dropping a frozen chunk
 --DO NOT CHANGE this behavior ---
 -- frozen chunks cannot be dropped.
 \set ON_ERROR_STOP 0
 SELECT _timescaledb_functions.drop_chunk(:'CHNAME');
-ERROR:  drop_chunk not permitted on frozen chunk "_hyper_2_7_chunk" 
+ERROR:  drop_chunk not permitted on frozen chunk "_hyper_2_9_chunk" 
 \set ON_ERROR_STOP 1
 -- Prepare table for CAGG tests
 TRUNCATE test1.hyper1;
@@ -405,7 +405,7 @@ SELECT  _timescaledb_functions.freeze_chunk( :'CHNAME1');
 --cannot drop frozen chunk
 \set ON_ERROR_STOP 0
 SELECT  _timescaledb_functions.drop_chunk( :'CHNAME1');
-ERROR:  drop_chunk not permitted on frozen chunk "_hyper_1_8_chunk" 
+ERROR:  drop_chunk not permitted on frozen chunk "_hyper_1_11_chunk" 
 \set ON_ERROR_STOP 1
 -- unfreeze the chunk, then drop the single chunk
 SELECT  _timescaledb_functions.unfreeze_chunk( :'CHNAME1');
@@ -448,7 +448,7 @@ SELECT ts_setup_osm_hook();
 
 BEGIN;
 DROP MATERIALIZED VIEW hyper1_cagg CASCADE;
-NOTICE:  drop cascades to table _timescaledb_internal._hyper_4_9_chunk
+NOTICE:  drop cascades to table _timescaledb_internal._hyper_4_12_chunk
 NOTICE:  hypertable_drop_hook
 DROP TABLE test1.hyper1;
 NOTICE:  hypertable_drop_hook
@@ -456,7 +456,7 @@ ROLLBACK;
 BEGIN;
 DROP TABLE test1.hyper1 CASCADE;
 NOTICE:  drop cascades to 3 other objects
-NOTICE:  drop cascades to table _timescaledb_internal._hyper_4_9_chunk
+NOTICE:  drop cascades to table _timescaledb_internal._hyper_4_12_chunk
 NOTICE:  hypertable_drop_hook
 NOTICE:  hypertable_drop_hook
 ROLLBACK;
@@ -526,7 +526,7 @@ FROM timescaledb_information.chunks
 WHERE hypertable_name = 'ht_try' ORDER BY 1;
     chunk_name     |         range_start          |          range_end           
 -------------------+------------------------------+------------------------------
- _hyper_5_10_chunk | Wed May 04 17:00:00 2022 PDT | Thu May 05 17:00:00 2022 PDT
+ _hyper_5_13_chunk | Wed May 04 17:00:00 2022 PDT | Thu May 05 17:00:00 2022 PDT
 (1 row)
 
 SELECT chunk_name, range_start, range_end
@@ -535,7 +535,7 @@ WHERE hypertable_name = 'ht_try'
 ORDER BY chunk_name;
     chunk_name     |          range_start           |          range_end           
 -------------------+--------------------------------+------------------------------
- _hyper_5_10_chunk | Wed May 04 17:00:00 2022 PDT   | Thu May 05 17:00:00 2022 PDT
+ _hyper_5_13_chunk | Wed May 04 17:00:00 2022 PDT   | Thu May 05 17:00:00 2022 PDT
  child_fdw_table   | Thu Dec 31 16:00:00 294246 PST | infinity
 (2 rows)
 
@@ -552,7 +552,7 @@ WHERE relname in ( select chunk_name FROM chunk_view
 ORDER BY relname;
       relname      |  relowner   
 -------------------+-------------
- _hyper_5_10_chunk | test_role_4
+ _hyper_5_13_chunk | test_role_4
  child_fdw_table   | test_role_4
 (2 rows)
 
@@ -561,7 +561,7 @@ FROM pg_inherits WHERE inhparent = 'ht_try'::regclass ORDER BY 1;
                 inhrelid                 
 -----------------------------------------
  child_fdw_table
- _timescaledb_internal._hyper_5_10_chunk
+ _timescaledb_internal._hyper_5_13_chunk
 (2 rows)
 
 --TEST chunk exclusion code does not filter out OSM chunk
@@ -601,20 +601,20 @@ SET timescaledb.enable_tiered_reads=false;
 EXPLAIN (COSTS OFF) SELECT * from ht_try;
           QUERY PLAN           
 -------------------------------
- Seq Scan on _hyper_5_10_chunk
+ Seq Scan on _hyper_5_13_chunk
 (1 row)
 
 EXPLAIN (COSTS OFF) SELECT * from ht_try WHERE timec > '2022-01-01 01:00';
                                     QUERY PLAN                                    
 ----------------------------------------------------------------------------------
- Index Scan using _hyper_5_10_chunk_ht_try_timec_idx on _hyper_5_10_chunk
+ Index Scan using _hyper_5_13_chunk_ht_try_timec_idx on _hyper_5_13_chunk
    Index Cond: (timec > 'Sat Jan 01 01:00:00 2022 PST'::timestamp with time zone)
 (2 rows)
 
 EXPLAIN (COSTS OFF) SELECT * from ht_try WHERE timec < '2023-01-01 01:00';
                                     QUERY PLAN                                    
 ----------------------------------------------------------------------------------
- Index Scan using _hyper_5_10_chunk_ht_try_timec_idx on _hyper_5_10_chunk
+ Index Scan using _hyper_5_13_chunk_ht_try_timec_idx on _hyper_5_13_chunk
    Index Cond: (timec < 'Sun Jan 01 01:00:00 2023 PST'::timestamp with time zone)
 (2 rows)
 
@@ -624,7 +624,7 @@ EXPLAIN (COSTS OFF) SELECT * from ht_try;
 ---------------------------------------
  Append
    ->  Foreign Scan on child_fdw_table
-   ->  Seq Scan on _hyper_5_10_chunk
+   ->  Seq Scan on _hyper_5_13_chunk
 (3 rows)
 
 EXPLAIN (COSTS OFF) SELECT * from ht_try WHERE timec > '2022-01-01 01:00';
@@ -632,7 +632,7 @@ EXPLAIN (COSTS OFF) SELECT * from ht_try WHERE timec > '2022-01-01 01:00';
 ----------------------------------------------------------------------------------------
  Append
    ->  Foreign Scan on child_fdw_table
-   ->  Index Scan using _hyper_5_10_chunk_ht_try_timec_idx on _hyper_5_10_chunk
+   ->  Index Scan using _hyper_5_13_chunk_ht_try_timec_idx on _hyper_5_13_chunk
          Index Cond: (timec > 'Sat Jan 01 01:00:00 2022 PST'::timestamp with time zone)
 (4 rows)
 
@@ -641,7 +641,7 @@ EXPLAIN (COSTS OFF) SELECT * from ht_try WHERE timec < '2023-01-01 01:00';
 ----------------------------------------------------------------------------------------
  Append
    ->  Foreign Scan on child_fdw_table
-   ->  Index Scan using _hyper_5_10_chunk_ht_try_timec_idx on _hyper_5_10_chunk
+   ->  Index Scan using _hyper_5_13_chunk_ht_try_timec_idx on _hyper_5_13_chunk
          Index Cond: (timec < 'Sun Jan 01 01:00:00 2023 PST'::timestamp with time zone)
 (4 rows)
 
@@ -726,9 +726,9 @@ ORDER BY chunk_name LIMIT 1
 \gset
 \set ON_ERROR_STOP 0
 SELECT  _timescaledb_functions.freeze_chunk( :'CHNAME3');
-ERROR:  operation not supported on distributed chunk or foreign table "_dist_hyper_6_12_chunk"
+ERROR:  operation not supported on distributed chunk or foreign table "_dist_hyper_6_15_chunk"
 SELECT  _timescaledb_functions.unfreeze_chunk( :'CHNAME3');
-ERROR:  operation not supported on distributed chunk or foreign table "_dist_hyper_6_12_chunk"
+ERROR:  operation not supported on distributed chunk or foreign table "_dist_hyper_6_15_chunk"
 \set ON_ERROR_STOP 1
 -- TEST can create OSM chunk if there are constraints on the hypertable
 \c :TEST_DBNAME :ROLE_4
@@ -768,7 +768,7 @@ WHERE hypertable_id IN (SELECT id from _timescaledb_catalog.hypertable
 ORDER BY table_name;
      table_name     | status | osm_chunk 
 --------------------+--------+-----------
- _hyper_7_13_chunk  |      0 | f
+ _hyper_7_16_chunk  |      0 | f
  child_hyper_constr |      0 | t
 (2 rows)
 
@@ -837,13 +837,13 @@ SELECT table_name, status
 FROM _timescaledb_catalog.chunk WHERE table_name = :'COPY_CHUNK_NAME';
     table_name     | status 
 -------------------+--------
- _hyper_8_15_chunk |      4
+ _hyper_8_18_chunk |      4
 (1 row)
 
 \set ON_ERROR_STOP 0
 -- Copy should fail because one of che chunks is frozen
 COPY test1.copy_test FROM STDIN DELIMITER ',';
-ERROR:  cannot INSERT into frozen chunk "_hyper_8_15_chunk"
+ERROR:  cannot INSERT into frozen chunk "_hyper_8_18_chunk"
 \set ON_ERROR_STOP 1
 -- Count existing rows
 SELECT COUNT(*) FROM test1.copy_test;
@@ -857,13 +857,13 @@ SELECT table_name, status
 FROM _timescaledb_catalog.chunk WHERE table_name = :'COPY_CHUNK_NAME';
     table_name     | status 
 -------------------+--------
- _hyper_8_15_chunk |      4
+ _hyper_8_18_chunk |      4
 (1 row)
 
 \set ON_ERROR_STOP 0
 -- Copy should fail because one of che chunks is frozen
 COPY test1.copy_test FROM STDIN DELIMITER ',';
-ERROR:  cannot INSERT into frozen chunk "_hyper_8_15_chunk"
+ERROR:  cannot INSERT into frozen chunk "_hyper_8_18_chunk"
 \set ON_ERROR_STOP 1
 -- Count existing rows
 SELECT COUNT(*) FROM test1.copy_test;
@@ -884,7 +884,7 @@ SELECT table_name, status
 FROM _timescaledb_catalog.chunk WHERE table_name = :'COPY_CHUNK_NAME';
     table_name     | status 
 -------------------+--------
- _hyper_8_15_chunk |      0
+ _hyper_8_18_chunk |      0
 (1 row)
 
 -- Copy should work now

--- a/tsl/test/expected/compress_bgw_reorder_drop_chunks.out
+++ b/tsl/test/expected/compress_bgw_reorder_drop_chunks.out
@@ -97,7 +97,7 @@ ALTER TABLE test_retention_table set (timescaledb.compress, timescaledb.compress
 SELECT count(compress_chunk(chunk.schema_name|| '.' || chunk.table_name)) as count_compressed
 FROM _timescaledb_catalog.chunk chunk
 INNER JOIN _timescaledb_catalog.hypertable hypertable ON (chunk.hypertable_id = hypertable.id)
-WHERE hypertable.table_name like 'test_retention_table' and chunk.compressed_chunk_id IS NULL;
+WHERE hypertable.table_name like 'test_retention_table' and chunk.status & 1 = 0;
  count_compressed 
 ------------------
                 5
@@ -210,9 +210,10 @@ WHERE hypertable.table_name like 'test_reorder_chunks_table';
 -- and 2 compressed ones:
 SELECT count(*) as count_chunks_compressed
 FROM _timescaledb_catalog.chunk chunk
-INNER JOIN _timescaledb_catalog.hypertable comp_hyper ON (chunk.hypertable_id = comp_hyper.id)
-INNER JOIN _timescaledb_catalog.hypertable uncomp_hyper ON (comp_hyper.id = uncomp_hyper.compressed_hypertable_id)
-WHERE uncomp_hyper.table_name like 'test_reorder_chunks_table';
+INNER JOIN _timescaledb_catalog.hypertable uncomp_hyper ON (chunk.hypertable_id = uncomp_hyper.id)
+INNER JOIN _timescaledb_catalog.hypertable comp_hyper ON (comp_hyper.id = uncomp_hyper.compressed_hypertable_id)
+WHERE uncomp_hyper.table_name like 'test_reorder_chunks_table'
+AND chunk.status & 1 > 0;
  count_chunks_compressed 
 -------------------------
                        2

--- a/tsl/test/expected/compression.out
+++ b/tsl/test/expected/compression.out
@@ -126,7 +126,7 @@ select * from _timescaledb_catalog.compression_chunk_size
 order by chunk_id;
 -[ RECORD 1 ]------------+------
 chunk_id                 | 1
-compressed_chunk_id      | 6
+compressed_chunk_id      | 5
 uncompressed_heap_size   | 8192
 uncompressed_toast_size  | 0
 uncompressed_index_size  | 32768
@@ -137,7 +137,7 @@ numrows_pre_compression  | 1
 numrows_post_compression | 1
 -[ RECORD 2 ]------------+------
 chunk_id                 | 2
-compressed_chunk_id      | 5
+compressed_chunk_id      | 6
 uncompressed_heap_size   | 8192
 uncompressed_toast_size  | 0
 uncompressed_index_size  | 32768
@@ -154,9 +154,11 @@ _timescaledb_catalog.chunk ch1, _timescaledb_catalog.chunk ch2
 where ch1.compressed_chunk_id = ch2.id;
  id |      schema_name      |    table_name    |      compress_table      
 ----+-----------------------+------------------+--------------------------
-  2 | _timescaledb_internal | _hyper_1_2_chunk | compress_hyper_2_5_chunk
-  1 | _timescaledb_internal | _hyper_1_1_chunk | compress_hyper_2_6_chunk
-(2 rows)
+  3 | _timescaledb_internal | _hyper_1_3_chunk | compress_hyper_2_7_chunk
+  4 | _timescaledb_internal | _hyper_1_4_chunk | compress_hyper_2_8_chunk
+  2 | _timescaledb_internal | _hyper_1_2_chunk | compress_hyper_2_6_chunk
+  1 | _timescaledb_internal | _hyper_1_1_chunk | compress_hyper_2_5_chunk
+(4 rows)
 
 \set ON_ERROR_STOP 0
 --cannot recompress the chunk the second time around
@@ -307,15 +309,15 @@ SELECT count(*) as "ORIGINAL_CHUNK_COUNT" from :CHUNK_NAME \gset
 select tableoid::regclass, count(*) from conditions group by tableoid order by tableoid;
                 tableoid                 | count 
 -----------------------------------------+-------
- _timescaledb_internal._hyper_5_12_chunk |    42
- _timescaledb_internal._hyper_5_13_chunk |    20
+ _timescaledb_internal._hyper_5_14_chunk |    42
+ _timescaledb_internal._hyper_5_16_chunk |    20
 (2 rows)
 
 select  compress_chunk(ch1.schema_name|| '.' || ch1.table_name)
 FROM _timescaledb_catalog.chunk ch1, _timescaledb_catalog.hypertable ht where ch1.hypertable_id = ht.id and ht.table_name like 'conditions' ORDER BY ch1.id limit 1;
              compress_chunk              
 -----------------------------------------
- _timescaledb_internal._hyper_5_12_chunk
+ _timescaledb_internal._hyper_5_14_chunk
 (1 row)
 
 --test that only one chunk was affected
@@ -323,14 +325,14 @@ FROM _timescaledb_catalog.chunk ch1, _timescaledb_catalog.hypertable ht where ch
 select tableoid::regclass, count(*) from conditions group by tableoid order by tableoid;
                 tableoid                 | count 
 -----------------------------------------+-------
- _timescaledb_internal._hyper_5_13_chunk |    20
+ _timescaledb_internal._hyper_5_16_chunk |    20
 (1 row)
 
 select  compress_chunk(ch1.schema_name|| '.' || ch1.table_name)
-FROM _timescaledb_catalog.chunk ch1, _timescaledb_catalog.hypertable ht where ch1.hypertable_id = ht.id and ht.table_name like 'conditions' and ch1.compressed_chunk_id IS NULL;
+FROM _timescaledb_catalog.chunk ch1, _timescaledb_catalog.hypertable ht where ch1.hypertable_id = ht.id and ht.table_name like 'conditions' and ch1.status & 1 = 0;
              compress_chunk              
 -----------------------------------------
- _timescaledb_internal._hyper_5_13_chunk
+ _timescaledb_internal._hyper_5_16_chunk
 (1 row)
 
 select tableoid::regclass, count(*) from conditions group by tableoid order by tableoid;
@@ -375,11 +377,11 @@ WHERE map.chunk_id = srcch.id and srcht.id = srcch.hypertable_id
        and srcht.table_name like 'conditions'
 order by chunk_id;
 -[ RECORD 1 ]------------+---
-chunk_id                 | 12
+chunk_id                 | 14
 numrows_pre_compression  | 42
 numrows_post_compression | 2
 -[ RECORD 2 ]------------+---
-chunk_id                 | 13
+chunk_id                 | 16
 numrows_pre_compression  | 20
 numrows_post_compression | 2
 
@@ -387,7 +389,7 @@ select * from chunk_compression_stats('conditions')
 order by chunk_name;
 -[ RECORD 1 ]------------------+----------------------
 chunk_schema                   | _timescaledb_internal
-chunk_name                     | _hyper_5_12_chunk
+chunk_name                     | _hyper_5_14_chunk
 compression_status             | Compressed
 before_compression_table_bytes | 8192
 before_compression_index_bytes | 16384
@@ -400,7 +402,7 @@ after_compression_total_bytes  | 32768
 node_name                      | 
 -[ RECORD 2 ]------------------+----------------------
 chunk_schema                   | _timescaledb_internal
-chunk_name                     | _hyper_5_13_chunk
+chunk_name                     | _hyper_5_16_chunk
 compression_status             | Compressed
 before_compression_table_bytes | 8192
 before_compression_index_bytes | 16384
@@ -487,8 +489,8 @@ WHERE ch1.hypertable_id = ht.id and ht.table_name LIKE 'conditions'
 ORDER BY chunk;
                   chunk                  
 -----------------------------------------
- _timescaledb_internal._hyper_5_12_chunk
- _timescaledb_internal._hyper_5_13_chunk
+ _timescaledb_internal._hyper_5_14_chunk
+ _timescaledb_internal._hyper_5_16_chunk
 (2 rows)
 
 SELECT count(*), count(*) = :'ORIGINAL_CHUNK_COUNT' from :CHUNK_NAME;
@@ -497,11 +499,13 @@ SELECT count(*), count(*) = :'ORIGINAL_CHUNK_COUNT' from :CHUNK_NAME;
     42 | t
 (1 row)
 
---check that the compressed chunk is dropped
-\set ON_ERROR_STOP 0
+--check that the compressed chunk is empty
 SELECT count(*) from :COMPRESSED_CHUNK_NAME;
-ERROR:  relation "_timescaledb_internal.compress_hyper_6_14_chunk" does not exist at character 22
-\set ON_ERROR_STOP 1
+ count 
+-------
+     0
+(1 row)
+
 --size information is gone too
 select count(*)
 FROM _timescaledb_catalog.chunk ch1, _timescaledb_catalog.hypertable ht,
@@ -514,7 +518,7 @@ and map.chunk_id = ch1.id;
 (1 row)
 
 --make sure  compressed_chunk_id  is reset to NULL
-select ch1.compressed_chunk_id IS NULL
+select ch1.status & 1 = 0
 FROM _timescaledb_catalog.chunk ch1, _timescaledb_catalog.hypertable ht where ch1.hypertable_id = ht.id and ht.table_name like 'conditions';
  ?column? 
 ----------
@@ -561,7 +565,7 @@ SELECT tableoid::regclass AS "CHUNK_NAME" FROM plan_inval ORDER BY time LIMIT 1
 SELECT compress_chunk(:'CHUNK_NAME');
              compress_chunk              
 -----------------------------------------
- _timescaledb_internal._hyper_7_16_chunk
+ _timescaledb_internal._hyper_7_18_chunk
 (1 row)
 
 EXECUTE prep_plan;
@@ -575,9 +579,9 @@ EXPLAIN (COSTS OFF) EXECUTE prep_plan;
 ----------------------------------------------------------------
  Aggregate
    ->  Append
-         ->  Custom Scan (DecompressChunk) on _hyper_7_16_chunk
-               ->  Seq Scan on compress_hyper_8_18_chunk
-         ->  Seq Scan on _hyper_7_17_chunk
+         ->  Custom Scan (DecompressChunk) on _hyper_7_18_chunk
+               ->  Seq Scan on compress_hyper_8_19_chunk
+         ->  Seq Scan on _hyper_7_20_chunk
 (5 rows)
 
 CREATE TABLE test_collation (
@@ -612,8 +616,8 @@ FROM _timescaledb_catalog.chunk ch1, _timescaledb_catalog.hypertable ht where ch
 and ht.table_name like 'test_collation' ORDER BY ch1.id LIMIT 2;
              compress_chunk              
 -----------------------------------------
- _timescaledb_internal._hyper_9_19_chunk
- _timescaledb_internal._hyper_9_20_chunk
+ _timescaledb_internal._hyper_9_22_chunk
+ _timescaledb_internal._hyper_9_24_chunk
 (2 rows)
 
 CREATE OR REPLACE PROCEDURE reindex_compressed_hypertable(hypertable REGCLASS)
@@ -635,27 +639,27 @@ EXPLAIN (costs off) SELECT * FROM test_collation WHERE device_id < 'a';
                         QUERY PLAN                        
 ----------------------------------------------------------
  Append
-   ->  Custom Scan (DecompressChunk) on _hyper_9_19_chunk
-         ->  Seq Scan on compress_hyper_10_29_chunk
+   ->  Custom Scan (DecompressChunk) on _hyper_9_22_chunk
+         ->  Seq Scan on compress_hyper_10_23_chunk
                Filter: (device_id < 'a'::text)
-   ->  Custom Scan (DecompressChunk) on _hyper_9_20_chunk
-         ->  Seq Scan on compress_hyper_10_30_chunk
+   ->  Custom Scan (DecompressChunk) on _hyper_9_24_chunk
+         ->  Seq Scan on compress_hyper_10_25_chunk
                Filter: (device_id < 'a'::text)
-   ->  Seq Scan on _hyper_9_21_chunk
-         Filter: (device_id < 'a'::text)
-   ->  Seq Scan on _hyper_9_22_chunk
-         Filter: (device_id < 'a'::text)
-   ->  Seq Scan on _hyper_9_23_chunk
-         Filter: (device_id < 'a'::text)
-   ->  Seq Scan on _hyper_9_24_chunk
-         Filter: (device_id < 'a'::text)
-   ->  Seq Scan on _hyper_9_25_chunk
-         Filter: (device_id < 'a'::text)
    ->  Seq Scan on _hyper_9_26_chunk
          Filter: (device_id < 'a'::text)
-   ->  Seq Scan on _hyper_9_27_chunk
-         Filter: (device_id < 'a'::text)
    ->  Seq Scan on _hyper_9_28_chunk
+         Filter: (device_id < 'a'::text)
+   ->  Seq Scan on _hyper_9_30_chunk
+         Filter: (device_id < 'a'::text)
+   ->  Seq Scan on _hyper_9_32_chunk
+         Filter: (device_id < 'a'::text)
+   ->  Seq Scan on _hyper_9_34_chunk
+         Filter: (device_id < 'a'::text)
+   ->  Seq Scan on _hyper_9_36_chunk
+         Filter: (device_id < 'a'::text)
+   ->  Seq Scan on _hyper_9_38_chunk
+         Filter: (device_id < 'a'::text)
+   ->  Seq Scan on _hyper_9_40_chunk
          Filter: (device_id < 'a'::text)
 (23 rows)
 
@@ -663,27 +667,27 @@ EXPLAIN (costs off) SELECT * FROM test_collation WHERE device_id < 'a' COLLATE "
                           QUERY PLAN                           
 ---------------------------------------------------------------
  Append
-   ->  Custom Scan (DecompressChunk) on _hyper_9_19_chunk
-         ->  Seq Scan on compress_hyper_10_29_chunk
+   ->  Custom Scan (DecompressChunk) on _hyper_9_22_chunk
+         ->  Seq Scan on compress_hyper_10_23_chunk
                Filter: (device_id < 'a'::text COLLATE "POSIX")
-   ->  Custom Scan (DecompressChunk) on _hyper_9_20_chunk
-         ->  Seq Scan on compress_hyper_10_30_chunk
+   ->  Custom Scan (DecompressChunk) on _hyper_9_24_chunk
+         ->  Seq Scan on compress_hyper_10_25_chunk
                Filter: (device_id < 'a'::text COLLATE "POSIX")
-   ->  Seq Scan on _hyper_9_21_chunk
-         Filter: (device_id < 'a'::text COLLATE "POSIX")
-   ->  Seq Scan on _hyper_9_22_chunk
-         Filter: (device_id < 'a'::text COLLATE "POSIX")
-   ->  Seq Scan on _hyper_9_23_chunk
-         Filter: (device_id < 'a'::text COLLATE "POSIX")
-   ->  Seq Scan on _hyper_9_24_chunk
-         Filter: (device_id < 'a'::text COLLATE "POSIX")
-   ->  Seq Scan on _hyper_9_25_chunk
-         Filter: (device_id < 'a'::text COLLATE "POSIX")
    ->  Seq Scan on _hyper_9_26_chunk
          Filter: (device_id < 'a'::text COLLATE "POSIX")
-   ->  Seq Scan on _hyper_9_27_chunk
-         Filter: (device_id < 'a'::text COLLATE "POSIX")
    ->  Seq Scan on _hyper_9_28_chunk
+         Filter: (device_id < 'a'::text COLLATE "POSIX")
+   ->  Seq Scan on _hyper_9_30_chunk
+         Filter: (device_id < 'a'::text COLLATE "POSIX")
+   ->  Seq Scan on _hyper_9_32_chunk
+         Filter: (device_id < 'a'::text COLLATE "POSIX")
+   ->  Seq Scan on _hyper_9_34_chunk
+         Filter: (device_id < 'a'::text COLLATE "POSIX")
+   ->  Seq Scan on _hyper_9_36_chunk
+         Filter: (device_id < 'a'::text COLLATE "POSIX")
+   ->  Seq Scan on _hyper_9_38_chunk
+         Filter: (device_id < 'a'::text COLLATE "POSIX")
+   ->  Seq Scan on _hyper_9_40_chunk
          Filter: (device_id < 'a'::text COLLATE "POSIX")
 (23 rows)
 
@@ -699,29 +703,29 @@ EXPLAIN (costs off) SELECT * FROM test_collation WHERE val_1 < 'a';
                         QUERY PLAN                        
 ----------------------------------------------------------
  Append
-   ->  Custom Scan (DecompressChunk) on _hyper_9_19_chunk
+   ->  Custom Scan (DecompressChunk) on _hyper_9_22_chunk
          Filter: (val_1 < 'a'::text)
-         ->  Seq Scan on compress_hyper_10_29_chunk
+         ->  Seq Scan on compress_hyper_10_23_chunk
                Filter: (_ts_meta_min_1 < 'a'::text)
-   ->  Custom Scan (DecompressChunk) on _hyper_9_20_chunk
+   ->  Custom Scan (DecompressChunk) on _hyper_9_24_chunk
          Filter: (val_1 < 'a'::text)
-         ->  Seq Scan on compress_hyper_10_30_chunk
+         ->  Seq Scan on compress_hyper_10_25_chunk
                Filter: (_ts_meta_min_1 < 'a'::text)
-   ->  Seq Scan on _hyper_9_21_chunk
-         Filter: (val_1 < 'a'::text)
-   ->  Seq Scan on _hyper_9_22_chunk
-         Filter: (val_1 < 'a'::text)
-   ->  Seq Scan on _hyper_9_23_chunk
-         Filter: (val_1 < 'a'::text)
-   ->  Seq Scan on _hyper_9_24_chunk
-         Filter: (val_1 < 'a'::text)
-   ->  Seq Scan on _hyper_9_25_chunk
-         Filter: (val_1 < 'a'::text)
    ->  Seq Scan on _hyper_9_26_chunk
          Filter: (val_1 < 'a'::text)
-   ->  Seq Scan on _hyper_9_27_chunk
-         Filter: (val_1 < 'a'::text)
    ->  Seq Scan on _hyper_9_28_chunk
+         Filter: (val_1 < 'a'::text)
+   ->  Seq Scan on _hyper_9_30_chunk
+         Filter: (val_1 < 'a'::text)
+   ->  Seq Scan on _hyper_9_32_chunk
+         Filter: (val_1 < 'a'::text)
+   ->  Seq Scan on _hyper_9_34_chunk
+         Filter: (val_1 < 'a'::text)
+   ->  Seq Scan on _hyper_9_36_chunk
+         Filter: (val_1 < 'a'::text)
+   ->  Seq Scan on _hyper_9_38_chunk
+         Filter: (val_1 < 'a'::text)
+   ->  Seq Scan on _hyper_9_40_chunk
          Filter: (val_1 < 'a'::text)
 (25 rows)
 
@@ -729,29 +733,29 @@ EXPLAIN (costs off) SELECT * FROM test_collation WHERE val_2 < 'a';
                         QUERY PLAN                        
 ----------------------------------------------------------
  Append
-   ->  Custom Scan (DecompressChunk) on _hyper_9_19_chunk
+   ->  Custom Scan (DecompressChunk) on _hyper_9_22_chunk
          Filter: (val_2 < 'a'::text)
-         ->  Seq Scan on compress_hyper_10_29_chunk
+         ->  Seq Scan on compress_hyper_10_23_chunk
                Filter: (_ts_meta_min_2 < 'a'::text)
-   ->  Custom Scan (DecompressChunk) on _hyper_9_20_chunk
+   ->  Custom Scan (DecompressChunk) on _hyper_9_24_chunk
          Filter: (val_2 < 'a'::text)
-         ->  Seq Scan on compress_hyper_10_30_chunk
+         ->  Seq Scan on compress_hyper_10_25_chunk
                Filter: (_ts_meta_min_2 < 'a'::text)
-   ->  Seq Scan on _hyper_9_21_chunk
-         Filter: (val_2 < 'a'::text)
-   ->  Seq Scan on _hyper_9_22_chunk
-         Filter: (val_2 < 'a'::text)
-   ->  Seq Scan on _hyper_9_23_chunk
-         Filter: (val_2 < 'a'::text)
-   ->  Seq Scan on _hyper_9_24_chunk
-         Filter: (val_2 < 'a'::text)
-   ->  Seq Scan on _hyper_9_25_chunk
-         Filter: (val_2 < 'a'::text)
    ->  Seq Scan on _hyper_9_26_chunk
          Filter: (val_2 < 'a'::text)
-   ->  Seq Scan on _hyper_9_27_chunk
-         Filter: (val_2 < 'a'::text)
    ->  Seq Scan on _hyper_9_28_chunk
+         Filter: (val_2 < 'a'::text)
+   ->  Seq Scan on _hyper_9_30_chunk
+         Filter: (val_2 < 'a'::text)
+   ->  Seq Scan on _hyper_9_32_chunk
+         Filter: (val_2 < 'a'::text)
+   ->  Seq Scan on _hyper_9_34_chunk
+         Filter: (val_2 < 'a'::text)
+   ->  Seq Scan on _hyper_9_36_chunk
+         Filter: (val_2 < 'a'::text)
+   ->  Seq Scan on _hyper_9_38_chunk
+         Filter: (val_2 < 'a'::text)
+   ->  Seq Scan on _hyper_9_40_chunk
          Filter: (val_2 < 'a'::text)
 (25 rows)
 
@@ -759,29 +763,29 @@ EXPLAIN (costs off) SELECT * FROM test_collation WHERE val_1 < 'a' COLLATE "C";
                            QUERY PLAN                           
 ----------------------------------------------------------------
  Append
-   ->  Custom Scan (DecompressChunk) on _hyper_9_19_chunk
+   ->  Custom Scan (DecompressChunk) on _hyper_9_22_chunk
          Filter: (val_1 < 'a'::text COLLATE "C")
-         ->  Seq Scan on compress_hyper_10_29_chunk
+         ->  Seq Scan on compress_hyper_10_23_chunk
                Filter: (_ts_meta_min_1 < 'a'::text COLLATE "C")
-   ->  Custom Scan (DecompressChunk) on _hyper_9_20_chunk
+   ->  Custom Scan (DecompressChunk) on _hyper_9_24_chunk
          Filter: (val_1 < 'a'::text COLLATE "C")
-         ->  Seq Scan on compress_hyper_10_30_chunk
+         ->  Seq Scan on compress_hyper_10_25_chunk
                Filter: (_ts_meta_min_1 < 'a'::text COLLATE "C")
-   ->  Seq Scan on _hyper_9_21_chunk
-         Filter: (val_1 < 'a'::text COLLATE "C")
-   ->  Seq Scan on _hyper_9_22_chunk
-         Filter: (val_1 < 'a'::text COLLATE "C")
-   ->  Seq Scan on _hyper_9_23_chunk
-         Filter: (val_1 < 'a'::text COLLATE "C")
-   ->  Seq Scan on _hyper_9_24_chunk
-         Filter: (val_1 < 'a'::text COLLATE "C")
-   ->  Seq Scan on _hyper_9_25_chunk
-         Filter: (val_1 < 'a'::text COLLATE "C")
    ->  Seq Scan on _hyper_9_26_chunk
          Filter: (val_1 < 'a'::text COLLATE "C")
-   ->  Seq Scan on _hyper_9_27_chunk
-         Filter: (val_1 < 'a'::text COLLATE "C")
    ->  Seq Scan on _hyper_9_28_chunk
+         Filter: (val_1 < 'a'::text COLLATE "C")
+   ->  Seq Scan on _hyper_9_30_chunk
+         Filter: (val_1 < 'a'::text COLLATE "C")
+   ->  Seq Scan on _hyper_9_32_chunk
+         Filter: (val_1 < 'a'::text COLLATE "C")
+   ->  Seq Scan on _hyper_9_34_chunk
+         Filter: (val_1 < 'a'::text COLLATE "C")
+   ->  Seq Scan on _hyper_9_36_chunk
+         Filter: (val_1 < 'a'::text COLLATE "C")
+   ->  Seq Scan on _hyper_9_38_chunk
+         Filter: (val_1 < 'a'::text COLLATE "C")
+   ->  Seq Scan on _hyper_9_40_chunk
          Filter: (val_1 < 'a'::text COLLATE "C")
 (25 rows)
 
@@ -789,29 +793,29 @@ EXPLAIN (costs off) SELECT * FROM test_collation WHERE val_2 < 'a' COLLATE "POSI
                              QUERY PLAN                             
 --------------------------------------------------------------------
  Append
-   ->  Custom Scan (DecompressChunk) on _hyper_9_19_chunk
+   ->  Custom Scan (DecompressChunk) on _hyper_9_22_chunk
          Filter: (val_2 < 'a'::text COLLATE "POSIX")
-         ->  Seq Scan on compress_hyper_10_29_chunk
+         ->  Seq Scan on compress_hyper_10_23_chunk
                Filter: (_ts_meta_min_2 < 'a'::text COLLATE "POSIX")
-   ->  Custom Scan (DecompressChunk) on _hyper_9_20_chunk
+   ->  Custom Scan (DecompressChunk) on _hyper_9_24_chunk
          Filter: (val_2 < 'a'::text COLLATE "POSIX")
-         ->  Seq Scan on compress_hyper_10_30_chunk
+         ->  Seq Scan on compress_hyper_10_25_chunk
                Filter: (_ts_meta_min_2 < 'a'::text COLLATE "POSIX")
-   ->  Seq Scan on _hyper_9_21_chunk
-         Filter: (val_2 < 'a'::text COLLATE "POSIX")
-   ->  Seq Scan on _hyper_9_22_chunk
-         Filter: (val_2 < 'a'::text COLLATE "POSIX")
-   ->  Seq Scan on _hyper_9_23_chunk
-         Filter: (val_2 < 'a'::text COLLATE "POSIX")
-   ->  Seq Scan on _hyper_9_24_chunk
-         Filter: (val_2 < 'a'::text COLLATE "POSIX")
-   ->  Seq Scan on _hyper_9_25_chunk
-         Filter: (val_2 < 'a'::text COLLATE "POSIX")
    ->  Seq Scan on _hyper_9_26_chunk
          Filter: (val_2 < 'a'::text COLLATE "POSIX")
-   ->  Seq Scan on _hyper_9_27_chunk
-         Filter: (val_2 < 'a'::text COLLATE "POSIX")
    ->  Seq Scan on _hyper_9_28_chunk
+         Filter: (val_2 < 'a'::text COLLATE "POSIX")
+   ->  Seq Scan on _hyper_9_30_chunk
+         Filter: (val_2 < 'a'::text COLLATE "POSIX")
+   ->  Seq Scan on _hyper_9_32_chunk
+         Filter: (val_2 < 'a'::text COLLATE "POSIX")
+   ->  Seq Scan on _hyper_9_34_chunk
+         Filter: (val_2 < 'a'::text COLLATE "POSIX")
+   ->  Seq Scan on _hyper_9_36_chunk
+         Filter: (val_2 < 'a'::text COLLATE "POSIX")
+   ->  Seq Scan on _hyper_9_38_chunk
+         Filter: (val_2 < 'a'::text COLLATE "POSIX")
+   ->  Seq Scan on _hyper_9_40_chunk
          Filter: (val_2 < 'a'::text COLLATE "POSIX")
 (25 rows)
 
@@ -820,27 +824,27 @@ EXPLAIN (costs off) SELECT * FROM test_collation WHERE val_1 < 'a' COLLATE "POSI
                         QUERY PLAN                        
 ----------------------------------------------------------
  Append
-   ->  Custom Scan (DecompressChunk) on _hyper_9_19_chunk
+   ->  Custom Scan (DecompressChunk) on _hyper_9_22_chunk
          Filter: (val_1 < 'a'::text COLLATE "POSIX")
-         ->  Seq Scan on compress_hyper_10_29_chunk
-   ->  Custom Scan (DecompressChunk) on _hyper_9_20_chunk
+         ->  Seq Scan on compress_hyper_10_23_chunk
+   ->  Custom Scan (DecompressChunk) on _hyper_9_24_chunk
          Filter: (val_1 < 'a'::text COLLATE "POSIX")
-         ->  Seq Scan on compress_hyper_10_30_chunk
-   ->  Seq Scan on _hyper_9_21_chunk
-         Filter: (val_1 < 'a'::text COLLATE "POSIX")
-   ->  Seq Scan on _hyper_9_22_chunk
-         Filter: (val_1 < 'a'::text COLLATE "POSIX")
-   ->  Seq Scan on _hyper_9_23_chunk
-         Filter: (val_1 < 'a'::text COLLATE "POSIX")
-   ->  Seq Scan on _hyper_9_24_chunk
-         Filter: (val_1 < 'a'::text COLLATE "POSIX")
-   ->  Seq Scan on _hyper_9_25_chunk
-         Filter: (val_1 < 'a'::text COLLATE "POSIX")
+         ->  Seq Scan on compress_hyper_10_25_chunk
    ->  Seq Scan on _hyper_9_26_chunk
          Filter: (val_1 < 'a'::text COLLATE "POSIX")
-   ->  Seq Scan on _hyper_9_27_chunk
-         Filter: (val_1 < 'a'::text COLLATE "POSIX")
    ->  Seq Scan on _hyper_9_28_chunk
+         Filter: (val_1 < 'a'::text COLLATE "POSIX")
+   ->  Seq Scan on _hyper_9_30_chunk
+         Filter: (val_1 < 'a'::text COLLATE "POSIX")
+   ->  Seq Scan on _hyper_9_32_chunk
+         Filter: (val_1 < 'a'::text COLLATE "POSIX")
+   ->  Seq Scan on _hyper_9_34_chunk
+         Filter: (val_1 < 'a'::text COLLATE "POSIX")
+   ->  Seq Scan on _hyper_9_36_chunk
+         Filter: (val_1 < 'a'::text COLLATE "POSIX")
+   ->  Seq Scan on _hyper_9_38_chunk
+         Filter: (val_1 < 'a'::text COLLATE "POSIX")
+   ->  Seq Scan on _hyper_9_40_chunk
          Filter: (val_1 < 'a'::text COLLATE "POSIX")
 (23 rows)
 
@@ -848,27 +852,27 @@ EXPLAIN (costs off) SELECT * FROM test_collation WHERE val_2 < 'a' COLLATE "C";
                         QUERY PLAN                        
 ----------------------------------------------------------
  Append
-   ->  Custom Scan (DecompressChunk) on _hyper_9_19_chunk
+   ->  Custom Scan (DecompressChunk) on _hyper_9_22_chunk
          Filter: (val_2 < 'a'::text COLLATE "C")
-         ->  Seq Scan on compress_hyper_10_29_chunk
-   ->  Custom Scan (DecompressChunk) on _hyper_9_20_chunk
+         ->  Seq Scan on compress_hyper_10_23_chunk
+   ->  Custom Scan (DecompressChunk) on _hyper_9_24_chunk
          Filter: (val_2 < 'a'::text COLLATE "C")
-         ->  Seq Scan on compress_hyper_10_30_chunk
-   ->  Seq Scan on _hyper_9_21_chunk
-         Filter: (val_2 < 'a'::text COLLATE "C")
-   ->  Seq Scan on _hyper_9_22_chunk
-         Filter: (val_2 < 'a'::text COLLATE "C")
-   ->  Seq Scan on _hyper_9_23_chunk
-         Filter: (val_2 < 'a'::text COLLATE "C")
-   ->  Seq Scan on _hyper_9_24_chunk
-         Filter: (val_2 < 'a'::text COLLATE "C")
-   ->  Seq Scan on _hyper_9_25_chunk
-         Filter: (val_2 < 'a'::text COLLATE "C")
+         ->  Seq Scan on compress_hyper_10_25_chunk
    ->  Seq Scan on _hyper_9_26_chunk
          Filter: (val_2 < 'a'::text COLLATE "C")
-   ->  Seq Scan on _hyper_9_27_chunk
-         Filter: (val_2 < 'a'::text COLLATE "C")
    ->  Seq Scan on _hyper_9_28_chunk
+         Filter: (val_2 < 'a'::text COLLATE "C")
+   ->  Seq Scan on _hyper_9_30_chunk
+         Filter: (val_2 < 'a'::text COLLATE "C")
+   ->  Seq Scan on _hyper_9_32_chunk
+         Filter: (val_2 < 'a'::text COLLATE "C")
+   ->  Seq Scan on _hyper_9_34_chunk
+         Filter: (val_2 < 'a'::text COLLATE "C")
+   ->  Seq Scan on _hyper_9_36_chunk
+         Filter: (val_2 < 'a'::text COLLATE "C")
+   ->  Seq Scan on _hyper_9_38_chunk
+         Filter: (val_2 < 'a'::text COLLATE "C")
+   ->  Seq Scan on _hyper_9_40_chunk
          Filter: (val_2 < 'a'::text COLLATE "C")
 (23 rows)
 
@@ -903,7 +907,7 @@ FROM _timescaledb_catalog.chunk ch1, _timescaledb_catalog.hypertable ht where ch
 and ht.table_name like 'datatype_test' ORDER BY ch1.id;
               compress_chunk              
 ------------------------------------------
- _timescaledb_internal._hyper_11_31_chunk
+ _timescaledb_internal._hyper_11_42_chunk
 (1 row)
 
 SELECT
@@ -992,7 +996,7 @@ FROM _timescaledb_catalog.chunk ch1, _timescaledb_catalog.hypertable ht where ch
 and ht.table_name like 'rescan_test' ORDER BY ch1.id LIMIT 1;
               compress_chunk              
 ------------------------------------------
- _timescaledb_internal._hyper_16_36_chunk
+ _timescaledb_internal._hyper_16_49_chunk
 (1 row)
 
 -- count should be equal to count before compression
@@ -1048,13 +1052,13 @@ WHERE table_name = :'CHUNK_NAME' AND constraint_type = 'FOREIGN KEY'
 ORDER BY constraint_name;
    constraint_schema   |      constraint_name      |     table_schema      |     table_name     | constraint_type 
 -----------------------+---------------------------+-----------------------+--------------------+-----------------
- _timescaledb_internal | 42_6_hyper_device_id_fkey | _timescaledb_internal | _hyper_18_42_chunk | FOREIGN KEY
+ _timescaledb_internal | 59_7_hyper_device_id_fkey | _timescaledb_internal | _hyper_18_59_chunk | FOREIGN KEY
 (1 row)
 
 SELECT compress_chunk(:'CHUNK_FULL_NAME');
               compress_chunk              
 ------------------------------------------
- _timescaledb_internal._hyper_18_42_chunk
+ _timescaledb_internal._hyper_18_59_chunk
 (1 row)
 
 SELECT constraint_schema, constraint_name, table_schema, table_name, constraint_type
@@ -1092,16 +1096,16 @@ SELECT * FROM hyper ORDER BY time, device_id;
 SELECT decompress_chunk(:'CHUNK_FULL_NAME');
              decompress_chunk             
 ------------------------------------------
- _timescaledb_internal._hyper_18_42_chunk
+ _timescaledb_internal._hyper_18_59_chunk
 (1 row)
 
 SELECT constraint_schema, constraint_name, table_schema, table_name, constraint_type
 FROM information_schema.table_constraints
 WHERE table_name = :'CHUNK_NAME' AND constraint_type = 'FOREIGN KEY'
 ORDER BY constraint_name;
-   constraint_schema   |      constraint_name      |     table_schema      |     table_name     | constraint_type 
------------------------+---------------------------+-----------------------+--------------------+-----------------
- _timescaledb_internal | 42_9_hyper_device_id_fkey | _timescaledb_internal | _hyper_18_42_chunk | FOREIGN KEY
+   constraint_schema   |      constraint_name       |     table_schema      |     table_name     | constraint_type 
+-----------------------+----------------------------+-----------------------+--------------------+-----------------
+ _timescaledb_internal | 59_10_hyper_device_id_fkey | _timescaledb_internal | _hyper_18_59_chunk | FOREIGN KEY
 (1 row)
 
 -- create hypertable with 2 chunks
@@ -1119,21 +1123,21 @@ ALTER TABLE ht5 SET (timescaledb.compress);
 SELECT compress_chunk(i) FROM show_chunks('ht5') i;
               compress_chunk              
 ------------------------------------------
- _timescaledb_internal._hyper_20_45_chunk
- _timescaledb_internal._hyper_20_46_chunk
+ _timescaledb_internal._hyper_20_63_chunk
+ _timescaledb_internal._hyper_20_64_chunk
 (2 rows)
 
 SELECT drop_chunks('ht5', newer_than => '2000-01-01'::TIMESTAMPTZ);
                drop_chunks                
 ------------------------------------------
- _timescaledb_internal._hyper_20_46_chunk
+ _timescaledb_internal._hyper_20_64_chunk
 (1 row)
 
 select chunk_name from chunk_compression_stats('ht5')
 order by chunk_name;
      chunk_name     
 --------------------
- _hyper_20_45_chunk
+ _hyper_20_63_chunk
 (1 row)
 
 -- Test enabling compression for a table with compound foreign key
@@ -1214,8 +1218,8 @@ WHERE ch1.hypertable_id = ht.id
 ORDER BY ch1.id;
               compress_chunk              
 ------------------------------------------
- _timescaledb_internal._hyper_25_51_chunk
- _timescaledb_internal._hyper_25_52_chunk
+ _timescaledb_internal._hyper_25_69_chunk
+ _timescaledb_internal._hyper_25_71_chunk
 (2 rows)
 
 BEGIN;
@@ -1278,7 +1282,7 @@ SELECT approximate_row_count('stattest');
 SELECT compress_chunk(c) FROM show_chunks('stattest') c;
               compress_chunk              
 ------------------------------------------
- _timescaledb_internal._hyper_27_55_chunk
+ _timescaledb_internal._hyper_27_73_chunk
 (1 row)
 
 SELECT approximate_row_count('stattest');
@@ -1382,7 +1386,7 @@ SELECT reloptions FROM pg_class WHERE relname = :statchunk;
 SELECT decompress_chunk(c) FROM show_chunks('stattest') c;
              decompress_chunk             
 ------------------------------------------
- _timescaledb_internal._hyper_27_55_chunk
+ _timescaledb_internal._hyper_27_73_chunk
 (1 row)
 
 SELECT reloptions FROM pg_class WHERE relname = :statchunk;
@@ -1394,7 +1398,7 @@ SELECT reloptions FROM pg_class WHERE relname = :statchunk;
 SELECT compress_chunk(c) FROM show_chunks('stattest') c;
               compress_chunk              
 ------------------------------------------
- _timescaledb_internal._hyper_27_55_chunk
+ _timescaledb_internal._hyper_27_73_chunk
 (1 row)
 
 SELECT reloptions FROM pg_class WHERE relname = :statchunk;
@@ -1407,7 +1411,7 @@ ALTER TABLE stattest SET (autovacuum_enabled = false);
 SELECT decompress_chunk(c) FROM show_chunks('stattest') c;
              decompress_chunk             
 ------------------------------------------
- _timescaledb_internal._hyper_27_55_chunk
+ _timescaledb_internal._hyper_27_73_chunk
 (1 row)
 
 SELECT reloptions FROM pg_class WHERE relname = :statchunk;
@@ -1451,7 +1455,7 @@ WHERE ch1.hypertable_id = ht.id and ht.table_name like 'stattest2'
  ORDER BY ch1.id limit 1;
               compress_chunk              
 ------------------------------------------
- _timescaledb_internal._hyper_29_58_chunk
+ _timescaledb_internal._hyper_29_75_chunk
 (1 row)
 
 -- reltuples is initially -1 on PG14 before VACUUM/ANALYZE has been run
@@ -1462,8 +1466,8 @@ SELECT relname, CASE WHEN reltuples > 0 THEN reltuples ELSE 0 END AS reltuples, 
 order by relname;
       relname       | reltuples | relpages | relallvisible 
 --------------------+-----------+----------+---------------
- _hyper_29_58_chunk |         0 |        0 |             0
- _hyper_29_59_chunk |         0 |        0 |             0
+ _hyper_29_75_chunk |         0 |        0 |             0
+ _hyper_29_77_chunk |         0 |        0 |             0
 (2 rows)
 
 \c :TEST_DBNAME :ROLE_SUPERUSER
@@ -1484,8 +1488,8 @@ SELECT relname, CASE WHEN reltuples > 0 THEN reltuples ELSE 0 END AS reltuples, 
 order by relname;
       relname       | reltuples | relpages | relallvisible 
 --------------------+-----------+----------+---------------
- _hyper_29_58_chunk |         0 |        0 |             0
- _hyper_29_59_chunk |         0 |        0 |             0
+ _hyper_29_75_chunk |         0 |        0 |             0
+ _hyper_29_77_chunk |         0 |        0 |             0
 (2 rows)
 
 SELECT '_timescaledb_internal.' || compht.table_name as "STAT_COMP_TABLE",
@@ -1502,8 +1506,8 @@ SELECT relname, CASE WHEN reltuples > 0 THEN reltuples ELSE 0 END AS reltuples, 
 ORDER BY relname;
       relname       | reltuples | relpages | relallvisible 
 --------------------+-----------+----------+---------------
- _hyper_29_58_chunk |         0 |        0 |             0
- _hyper_29_59_chunk |         0 |        0 |             0
+ _hyper_29_75_chunk |         0 |        0 |             0
+ _hyper_29_77_chunk |         0 |        0 |             0
 (2 rows)
 
 SELECT relname, reltuples, relpages, relallvisible FROM pg_class
@@ -1513,8 +1517,9 @@ SELECT relname, reltuples, relpages, relallvisible FROM pg_class
 ORDER BY relname;
           relname           | reltuples | relpages | relallvisible 
 ----------------------------+-----------+----------+---------------
- compress_hyper_30_60_chunk |         1 |        1 |             0
-(1 row)
+ compress_hyper_30_76_chunk |         1 |        1 |             0
+ compress_hyper_30_78_chunk |         0 |        0 |             0
+(2 rows)
 
 --analyze on stattest2 should not overwrite
 ANALYZE stattest2;
@@ -1525,8 +1530,8 @@ SELECT relname, reltuples, relpages, relallvisible FROM pg_class
 ORDER BY relname;
       relname       | reltuples | relpages | relallvisible 
 --------------------+-----------+----------+---------------
- _hyper_29_58_chunk |         0 |        0 |             0
- _hyper_29_59_chunk |       200 |        2 |             0
+ _hyper_29_75_chunk |         0 |        0 |             0
+ _hyper_29_77_chunk |       200 |        2 |             0
 (2 rows)
 
 SELECT relname, reltuples, relpages, relallvisible FROM pg_class
@@ -1536,8 +1541,9 @@ SELECT relname, reltuples, relpages, relallvisible FROM pg_class
 ORDER BY relname;
           relname           | reltuples | relpages | relallvisible 
 ----------------------------+-----------+----------+---------------
- compress_hyper_30_60_chunk |         1 |        1 |             0
-(1 row)
+ compress_hyper_30_76_chunk |         1 |        1 |             0
+ compress_hyper_30_78_chunk |         0 |        0 |             0
+(2 rows)
 
 -- analyze on compressed hypertable should restore stats
 -- Test approximate_row_count() with compressed hypertable
@@ -1584,8 +1590,8 @@ FROM (SELECT compress_chunk(ch) FROM show_chunks('metrics') ch ) q;
 SELECT drop_chunks('metrics', older_than=>'1 day'::interval);
                drop_chunks                
 ------------------------------------------
- _timescaledb_internal._hyper_13_33_chunk
- _timescaledb_internal._hyper_13_34_chunk
+ _timescaledb_internal._hyper_13_44_chunk
+ _timescaledb_internal._hyper_13_45_chunk
 (2 rows)
 
 SELECT
@@ -1596,8 +1602,8 @@ WHERE h.id = c.hypertable_id and h.table_name = 'metrics'
 ORDER BY 1;
      chunk_name     | chunk_status | dropped | comp_id 
 --------------------+--------------+---------+---------
- _hyper_13_33_chunk |            0 | t       |        
- _hyper_13_34_chunk |            0 | t       |        
+ _hyper_13_44_chunk |            0 | t       |        
+ _hyper_13_45_chunk |            0 | t       |        
 (2 rows)
 
 SELECT "time", cnt  FROM cagg_expr ORDER BY time LIMIT 5;
@@ -1628,8 +1634,8 @@ WHERE h.id = c.hypertable_id and h.table_name = 'metrics'
 ORDER BY 1;
      chunk_name     | chunk_status | dropped | comp_id 
 --------------------+--------------+---------+---------
- _hyper_13_33_chunk |            1 | f       |      64
- _hyper_13_34_chunk |            1 | f       |      65
+ _hyper_13_44_chunk |            1 | f       |      81
+ _hyper_13_45_chunk |            1 | f       |      82
 (2 rows)
 
 SELECT count(*) FROM metrics;
@@ -1656,7 +1662,7 @@ INSERT INTO local_seq SELECT '2000-01-01', generate_series(5,8);
 SELECT compress_chunk(c) FROM show_chunks('local_seq') c;
               compress_chunk              
 ------------------------------------------
- _timescaledb_internal._hyper_33_66_chunk
+ _timescaledb_internal._hyper_33_83_chunk
 (1 row)
 
 SELECT
@@ -1748,7 +1754,7 @@ SELECT set_chunk_time_interval('f_sensor_data', INTERVAL '1 year');
 SELECT * FROM _timescaledb_functions.create_chunk('f_sensor_data',' {"time": [181900977000000, 515024000000000]}');
  chunk_id | hypertable_id |      schema_name      |     table_name     | relkind |                    slices                    | created 
 ----------+---------------+-----------------------+--------------------+---------+----------------------------------------------+---------
-       71 |            37 | _timescaledb_internal | _hyper_37_71_chunk | r       | {"time": [181900977000000, 515024000000000]} | t
+       88 |            37 | _timescaledb_internal | _hyper_37_88_chunk | r       | {"time": [181900977000000, 515024000000000]} | t
 (1 row)
 
 INSERT INTO f_sensor_data
@@ -1766,7 +1772,7 @@ ALTER TABLE f_sensor_data SET (timescaledb.compress, timescaledb.compress_segmen
 SELECT compress_chunk(i) FROM show_chunks('f_sensor_data') i;
               compress_chunk              
 ------------------------------------------
- _timescaledb_internal._hyper_37_71_chunk
+ _timescaledb_internal._hyper_37_88_chunk
 (1 row)
 
 CALL reindex_compressed_hypertable('f_sensor_data');
@@ -1808,16 +1814,16 @@ SELECT sum(cpu) FROM f_sensor_data;
                                                                                                                                                                               QUERY PLAN                                                                                                                                                                              
 ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Finalize Aggregate
-   Output: sum(_hyper_37_71_chunk.cpu)
+   Output: sum(_hyper_37_88_chunk.cpu)
    ->  Gather
-         Output: (PARTIAL sum(_hyper_37_71_chunk.cpu))
+         Output: (PARTIAL sum(_hyper_37_88_chunk.cpu))
          Workers Planned: 4
          ->  Partial Aggregate
-               Output: PARTIAL sum(_hyper_37_71_chunk.cpu)
-               ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_37_71_chunk
-                     Output: _hyper_37_71_chunk.cpu
-                     ->  Parallel Seq Scan on _timescaledb_internal.compress_hyper_38_72_chunk
-                           Output: compress_hyper_38_72_chunk."time", compress_hyper_38_72_chunk.sensor_id, compress_hyper_38_72_chunk.cpu, compress_hyper_38_72_chunk.temperature, compress_hyper_38_72_chunk._ts_meta_count, compress_hyper_38_72_chunk._ts_meta_sequence_num, compress_hyper_38_72_chunk._ts_meta_min_1, compress_hyper_38_72_chunk._ts_meta_max_1
+               Output: PARTIAL sum(_hyper_37_88_chunk.cpu)
+               ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_37_88_chunk
+                     Output: _hyper_37_88_chunk.cpu
+                     ->  Parallel Seq Scan on _timescaledb_internal.compress_hyper_38_89_chunk
+                           Output: compress_hyper_38_89_chunk."time", compress_hyper_38_89_chunk.sensor_id, compress_hyper_38_89_chunk.cpu, compress_hyper_38_89_chunk.temperature, compress_hyper_38_89_chunk._ts_meta_count, compress_hyper_38_89_chunk._ts_meta_sequence_num, compress_hyper_38_89_chunk._ts_meta_min_1, compress_hyper_38_89_chunk._ts_meta_max_1
 (11 rows)
 
 -- Encourage use of Index Scan
@@ -1831,13 +1837,13 @@ SELECT * FROM f_sensor_data WHERE sensor_id > 100;
                                                                                                                                                                         QUERY PLAN                                                                                                                                                                        
 ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Gather
-   Output: _hyper_37_71_chunk."time", _hyper_37_71_chunk.sensor_id, _hyper_37_71_chunk.cpu, _hyper_37_71_chunk.temperature
+   Output: _hyper_37_88_chunk."time", _hyper_37_88_chunk.sensor_id, _hyper_37_88_chunk.cpu, _hyper_37_88_chunk.temperature
    Workers Planned: 2
-   ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_37_71_chunk
-         Output: _hyper_37_71_chunk."time", _hyper_37_71_chunk.sensor_id, _hyper_37_71_chunk.cpu, _hyper_37_71_chunk.temperature
-         ->  Parallel Index Scan using compress_hyper_38_72_chunk__compressed_hypertable_38_sensor_id_ on _timescaledb_internal.compress_hyper_38_72_chunk
-               Output: compress_hyper_38_72_chunk."time", compress_hyper_38_72_chunk.sensor_id, compress_hyper_38_72_chunk.cpu, compress_hyper_38_72_chunk.temperature, compress_hyper_38_72_chunk._ts_meta_count, compress_hyper_38_72_chunk._ts_meta_sequence_num, compress_hyper_38_72_chunk._ts_meta_min_1, compress_hyper_38_72_chunk._ts_meta_max_1
-               Index Cond: (compress_hyper_38_72_chunk.sensor_id > 100)
+   ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_37_88_chunk
+         Output: _hyper_37_88_chunk."time", _hyper_37_88_chunk.sensor_id, _hyper_37_88_chunk.cpu, _hyper_37_88_chunk.temperature
+         ->  Parallel Index Scan using compress_hyper_38_89_chunk__compressed_hypertable_38_sensor_id_ on _timescaledb_internal.compress_hyper_38_89_chunk
+               Output: compress_hyper_38_89_chunk."time", compress_hyper_38_89_chunk.sensor_id, compress_hyper_38_89_chunk.cpu, compress_hyper_38_89_chunk.temperature, compress_hyper_38_89_chunk._ts_meta_count, compress_hyper_38_89_chunk._ts_meta_sequence_num, compress_hyper_38_89_chunk._ts_meta_min_1, compress_hyper_38_89_chunk._ts_meta_max_1
+               Index Cond: (compress_hyper_38_89_chunk.sensor_id > 100)
 (8 rows)
 
 RESET enable_parallel_append;
@@ -1858,19 +1864,19 @@ SELECT sum(cpu) FROM f_sensor_data;
                                                                                                                                                                                  QUERY PLAN                                                                                                                                                                                 
 ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Finalize Aggregate
-   Output: sum(_hyper_37_71_chunk.cpu)
+   Output: sum(_hyper_37_88_chunk.cpu)
    ->  Gather
-         Output: (PARTIAL sum(_hyper_37_71_chunk.cpu))
+         Output: (PARTIAL sum(_hyper_37_88_chunk.cpu))
          Workers Planned: 4
          ->  Partial Aggregate
-               Output: PARTIAL sum(_hyper_37_71_chunk.cpu)
+               Output: PARTIAL sum(_hyper_37_88_chunk.cpu)
                ->  Parallel Append
-                     ->  Parallel Seq Scan on _timescaledb_internal._hyper_37_71_chunk
-                           Output: _hyper_37_71_chunk.cpu
-                     ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_37_71_chunk
-                           Output: _hyper_37_71_chunk.cpu
-                           ->  Parallel Seq Scan on _timescaledb_internal.compress_hyper_38_72_chunk
-                                 Output: compress_hyper_38_72_chunk."time", compress_hyper_38_72_chunk.sensor_id, compress_hyper_38_72_chunk.cpu, compress_hyper_38_72_chunk.temperature, compress_hyper_38_72_chunk._ts_meta_count, compress_hyper_38_72_chunk._ts_meta_sequence_num, compress_hyper_38_72_chunk._ts_meta_min_1, compress_hyper_38_72_chunk._ts_meta_max_1
+                     ->  Parallel Seq Scan on _timescaledb_internal._hyper_37_88_chunk
+                           Output: _hyper_37_88_chunk.cpu
+                     ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_37_88_chunk
+                           Output: _hyper_37_88_chunk.cpu
+                           ->  Parallel Seq Scan on _timescaledb_internal.compress_hyper_38_89_chunk
+                                 Output: compress_hyper_38_89_chunk."time", compress_hyper_38_89_chunk.sensor_id, compress_hyper_38_89_chunk.cpu, compress_hyper_38_89_chunk.temperature, compress_hyper_38_89_chunk._ts_meta_count, compress_hyper_38_89_chunk._ts_meta_sequence_num, compress_hyper_38_89_chunk._ts_meta_min_1, compress_hyper_38_89_chunk._ts_meta_max_1
 (14 rows)
 
 :explain
@@ -1878,18 +1884,18 @@ SELECT * FROM f_sensor_data WHERE sensor_id > 100;
                                                                                                                                                                            QUERY PLAN                                                                                                                                                                           
 ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Gather
-   Output: _hyper_37_71_chunk."time", _hyper_37_71_chunk.sensor_id, _hyper_37_71_chunk.cpu, _hyper_37_71_chunk.temperature
+   Output: _hyper_37_88_chunk."time", _hyper_37_88_chunk.sensor_id, _hyper_37_88_chunk.cpu, _hyper_37_88_chunk.temperature
    Workers Planned: 3
    ->  Parallel Append
-         ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_37_71_chunk
-               Output: _hyper_37_71_chunk."time", _hyper_37_71_chunk.sensor_id, _hyper_37_71_chunk.cpu, _hyper_37_71_chunk.temperature
-               Filter: (_hyper_37_71_chunk.sensor_id > 100)
-               ->  Parallel Index Scan using compress_hyper_38_72_chunk__compressed_hypertable_38_sensor_id_ on _timescaledb_internal.compress_hyper_38_72_chunk
-                     Output: compress_hyper_38_72_chunk."time", compress_hyper_38_72_chunk.sensor_id, compress_hyper_38_72_chunk.cpu, compress_hyper_38_72_chunk.temperature, compress_hyper_38_72_chunk._ts_meta_count, compress_hyper_38_72_chunk._ts_meta_sequence_num, compress_hyper_38_72_chunk._ts_meta_min_1, compress_hyper_38_72_chunk._ts_meta_max_1
-                     Index Cond: (compress_hyper_38_72_chunk.sensor_id > 100)
-         ->  Parallel Index Scan using _hyper_37_71_chunk_f_sensor_data_time_sensor_id_idx on _timescaledb_internal._hyper_37_71_chunk
-               Output: _hyper_37_71_chunk."time", _hyper_37_71_chunk.sensor_id, _hyper_37_71_chunk.cpu, _hyper_37_71_chunk.temperature
-               Index Cond: (_hyper_37_71_chunk.sensor_id > 100)
+         ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_37_88_chunk
+               Output: _hyper_37_88_chunk."time", _hyper_37_88_chunk.sensor_id, _hyper_37_88_chunk.cpu, _hyper_37_88_chunk.temperature
+               Filter: (_hyper_37_88_chunk.sensor_id > 100)
+               ->  Parallel Index Scan using compress_hyper_38_89_chunk__compressed_hypertable_38_sensor_id_ on _timescaledb_internal.compress_hyper_38_89_chunk
+                     Output: compress_hyper_38_89_chunk."time", compress_hyper_38_89_chunk.sensor_id, compress_hyper_38_89_chunk.cpu, compress_hyper_38_89_chunk.temperature, compress_hyper_38_89_chunk._ts_meta_count, compress_hyper_38_89_chunk._ts_meta_sequence_num, compress_hyper_38_89_chunk._ts_meta_min_1, compress_hyper_38_89_chunk._ts_meta_max_1
+                     Index Cond: (compress_hyper_38_89_chunk.sensor_id > 100)
+         ->  Parallel Index Scan using _hyper_37_88_chunk_f_sensor_data_time_sensor_id_idx on _timescaledb_internal._hyper_37_88_chunk
+               Output: _hyper_37_88_chunk."time", _hyper_37_88_chunk.sensor_id, _hyper_37_88_chunk.cpu, _hyper_37_88_chunk.temperature
+               Index Cond: (_hyper_37_88_chunk.sensor_id > 100)
 (13 rows)
 
 -- Test non-partial paths below append are not executed multiple times
@@ -1962,8 +1968,8 @@ SELECT time, device, device * 0.1 FROM
 SELECT compress_chunk(c) FROM show_chunks('ht_metrics_partially_compressed') c;
               compress_chunk              
 ------------------------------------------
- _timescaledb_internal._hyper_41_75_chunk
- _timescaledb_internal._hyper_41_76_chunk
+ _timescaledb_internal._hyper_41_92_chunk
+ _timescaledb_internal._hyper_41_94_chunk
 (2 rows)
 
 INSERT INTO ht_metrics_partially_compressed VALUES ('2020-01-01'::timestamptz, 1, 0.1);
@@ -1979,25 +1985,25 @@ SELECT * FROM ht_metrics_partially_compressed ORDER BY time DESC, device LIMIT 1
          Startup Exclusion: false
          Runtime Exclusion: false
          ->  Sort
-               Output: _hyper_41_76_chunk."time", _hyper_41_76_chunk.device, _hyper_41_76_chunk.value
-               Sort Key: _hyper_41_76_chunk."time" DESC, _hyper_41_76_chunk.device
-               ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_41_76_chunk
-                     Output: _hyper_41_76_chunk."time", _hyper_41_76_chunk.device, _hyper_41_76_chunk.value
-                     ->  Seq Scan on _timescaledb_internal.compress_hyper_42_78_chunk
-                           Output: compress_hyper_42_78_chunk."time", compress_hyper_42_78_chunk.device, compress_hyper_42_78_chunk.value, compress_hyper_42_78_chunk._ts_meta_count, compress_hyper_42_78_chunk._ts_meta_sequence_num, compress_hyper_42_78_chunk._ts_meta_min_1, compress_hyper_42_78_chunk._ts_meta_max_1
+               Output: _hyper_41_94_chunk."time", _hyper_41_94_chunk.device, _hyper_41_94_chunk.value
+               Sort Key: _hyper_41_94_chunk."time" DESC, _hyper_41_94_chunk.device
+               ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_41_94_chunk
+                     Output: _hyper_41_94_chunk."time", _hyper_41_94_chunk.device, _hyper_41_94_chunk.value
+                     ->  Seq Scan on _timescaledb_internal.compress_hyper_42_95_chunk
+                           Output: compress_hyper_42_95_chunk."time", compress_hyper_42_95_chunk.device, compress_hyper_42_95_chunk.value, compress_hyper_42_95_chunk._ts_meta_count, compress_hyper_42_95_chunk._ts_meta_sequence_num, compress_hyper_42_95_chunk._ts_meta_min_1, compress_hyper_42_95_chunk._ts_meta_max_1
          ->  Merge Append
-               Sort Key: _hyper_41_75_chunk."time" DESC, _hyper_41_75_chunk.device
+               Sort Key: _hyper_41_92_chunk."time" DESC, _hyper_41_92_chunk.device
                ->  Sort
-                     Output: _hyper_41_75_chunk."time", _hyper_41_75_chunk.device, _hyper_41_75_chunk.value
-                     Sort Key: _hyper_41_75_chunk."time" DESC, _hyper_41_75_chunk.device
-                     ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_41_75_chunk
-                           Output: _hyper_41_75_chunk."time", _hyper_41_75_chunk.device, _hyper_41_75_chunk.value
-                           ->  Seq Scan on _timescaledb_internal.compress_hyper_42_77_chunk
-                                 Output: compress_hyper_42_77_chunk."time", compress_hyper_42_77_chunk.device, compress_hyper_42_77_chunk.value, compress_hyper_42_77_chunk._ts_meta_count, compress_hyper_42_77_chunk._ts_meta_sequence_num, compress_hyper_42_77_chunk._ts_meta_min_1, compress_hyper_42_77_chunk._ts_meta_max_1
+                     Output: _hyper_41_92_chunk."time", _hyper_41_92_chunk.device, _hyper_41_92_chunk.value
+                     Sort Key: _hyper_41_92_chunk."time" DESC, _hyper_41_92_chunk.device
+                     ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_41_92_chunk
+                           Output: _hyper_41_92_chunk."time", _hyper_41_92_chunk.device, _hyper_41_92_chunk.value
+                           ->  Seq Scan on _timescaledb_internal.compress_hyper_42_93_chunk
+                                 Output: compress_hyper_42_93_chunk."time", compress_hyper_42_93_chunk.device, compress_hyper_42_93_chunk.value, compress_hyper_42_93_chunk._ts_meta_count, compress_hyper_42_93_chunk._ts_meta_sequence_num, compress_hyper_42_93_chunk._ts_meta_min_1, compress_hyper_42_93_chunk._ts_meta_max_1
                ->  Sort
-                     Output: _hyper_41_75_chunk."time", _hyper_41_75_chunk.device, _hyper_41_75_chunk.value
-                     Sort Key: _hyper_41_75_chunk."time" DESC, _hyper_41_75_chunk.device
-                     ->  Seq Scan on _timescaledb_internal._hyper_41_75_chunk
-                           Output: _hyper_41_75_chunk."time", _hyper_41_75_chunk.device, _hyper_41_75_chunk.value
+                     Output: _hyper_41_92_chunk."time", _hyper_41_92_chunk.device, _hyper_41_92_chunk.value
+                     Sort Key: _hyper_41_92_chunk."time" DESC, _hyper_41_92_chunk.device
+                     ->  Seq Scan on _timescaledb_internal._hyper_41_92_chunk
+                           Output: _hyper_41_92_chunk."time", _hyper_41_92_chunk.device, _hyper_41_92_chunk.value
 (28 rows)
 

--- a/tsl/test/expected/compression_bgw.out
+++ b/tsl/test/expected/compression_bgw.out
@@ -75,11 +75,13 @@ from chunk_compression_stats('conditions') where compression_status like 'Compre
 SELECT * FROM _timescaledb_catalog.chunk ORDER BY id;
  id | hypertable_id |      schema_name      |        table_name        | compressed_chunk_id | dropped | status | osm_chunk 
 ----+---------------+-----------------------+--------------------------+---------------------+---------+--------+-----------
-  1 |             1 | _timescaledb_internal | _hyper_1_1_chunk         |                   4 | f       |      1 | f
-  2 |             1 | _timescaledb_internal | _hyper_1_2_chunk         |                     | f       |      0 | f
-  3 |             1 | _timescaledb_internal | _hyper_1_3_chunk         |                     | f       |      0 | f
+  1 |             1 | _timescaledb_internal | _hyper_1_1_chunk         |                   2 | f       |      1 | f
+  2 |             2 | _timescaledb_internal | compress_hyper_2_2_chunk |                     | f       |      0 | f
+  3 |             1 | _timescaledb_internal | _hyper_1_3_chunk         |                   4 | f       |      0 | f
   4 |             2 | _timescaledb_internal | compress_hyper_2_4_chunk |                     | f       |      0 | f
-(4 rows)
+  5 |             1 | _timescaledb_internal | _hyper_1_5_chunk         |                   6 | f       |      0 | f
+  6 |             2 | _timescaledb_internal | compress_hyper_2_6_chunk |                     | f       |      0 | f
+(6 rows)
 
 -- TEST 4 --
 --cannot set another policy
@@ -131,7 +133,7 @@ ERROR:  relation is not a hypertable or continuous aggregate
 \set ON_ERROR_STOP 1
 -- We're done with the table, so drop it.
 DROP TABLE IF EXISTS conditions CASCADE;
-NOTICE:  drop cascades to table _timescaledb_internal.compress_hyper_2_4_chunk
+NOTICE:  drop cascades to 3 other objects
 NOTICE:  drop cascades to view dummyv1
 --TEST 7
 --compression policy for smallint, integer or bigint based partition hypertable
@@ -172,8 +174,8 @@ WHERE compression_status LIKE 'Compressed'
 ORDER BY chunk_name;
     chunk_name    | before_compression_total_bytes | after_compression_total_bytes 
 ------------------+--------------------------------+-------------------------------
- _hyper_3_5_chunk |                          24576 |                         16384
- _hyper_3_6_chunk |                          24576 |                         16384
+ _hyper_3_7_chunk |                          24576 |                         16384
+ _hyper_3_8_chunk |                          24576 |                         16384
 (2 rows)
 
 --integer tests
@@ -209,8 +211,8 @@ WHERE compression_status LIKE 'Compressed'
 ORDER BY chunk_name;
     chunk_name     | before_compression_total_bytes | after_compression_total_bytes 
 -------------------+--------------------------------+-------------------------------
- _hyper_5_12_chunk |                          24576 |                         16384
- _hyper_5_13_chunk |                          24576 |                         16384
+ _hyper_5_17_chunk |                          24576 |                         16384
+ _hyper_5_18_chunk |                          24576 |                         16384
 (2 rows)
 
 --bigint test
@@ -246,8 +248,8 @@ WHERE compression_status LIKE 'Compressed'
 ORDER BY chunk_name;
     chunk_name     | before_compression_total_bytes | after_compression_total_bytes 
 -------------------+--------------------------------+-------------------------------
- _hyper_7_19_chunk |                          24576 |                         16384
- _hyper_7_20_chunk |                          24576 |                         16384
+ _hyper_7_27_chunk |                          24576 |                         16384
+ _hyper_7_28_chunk |                          24576 |                         16384
 (2 rows)
 
 --TEST 8
@@ -345,7 +347,7 @@ SELECT alter_job(id,config:=jsonb_set(config,'{verbose_log}', 'true'))
 set client_min_messages TO LOG;
 CALL run_job(:job_id);
 LOG:  statement: CALL run_job(1004);
-LOG:  job 1004 completed processing chunk _timescaledb_internal._hyper_11_40_chunk
+LOG:  job 1004 completed processing chunk _timescaledb_internal._hyper_11_51_chunk
 set client_min_messages TO NOTICE;
 LOG:  statement: set client_min_messages TO NOTICE;
 SELECT count(*) FROM timescaledb_information.chunks
@@ -388,9 +390,9 @@ timescaledb.compress_segmentby = 'b',
 timescaledb.compress_orderby = 'timec DESC');
 SELECT compress_chunk(c)
 FROM show_chunks('test2') c;
-              compress_chunk              
-------------------------------------------
- _timescaledb_internal._hyper_14_62_chunk
+              compress_chunk               
+-------------------------------------------
+ _timescaledb_internal._hyper_14_103_chunk
 (1 row)
 
 ---insert into the middle of the range ---
@@ -415,9 +417,9 @@ SELECT chunk_status,
        chunk_name as "CHUNK_NAME"
 FROM compressed_chunk_info_view
 WHERE hypertable_name = 'test2' ORDER BY chunk_name;
- chunk_status |     CHUNK_NAME     
---------------+--------------------
-            9 | _hyper_14_62_chunk
+ chunk_status |     CHUNK_NAME      
+--------------+---------------------
+            9 | _hyper_14_103_chunk
 (1 row)
 
 SELECT compressed_chunk_schema || '.' || compressed_chunk_name as "COMP_CHUNK_NAME",
@@ -452,9 +454,9 @@ SELECT chunk_status,
        chunk_name as "CHUNK_NAME"
 FROM compressed_chunk_info_view
 WHERE hypertable_name = 'test2' ORDER BY chunk_name;
- chunk_status |     CHUNK_NAME     
---------------+--------------------
-            1 | _hyper_14_62_chunk
+ chunk_status |     CHUNK_NAME      
+--------------+---------------------
+            1 | _hyper_14_103_chunk
 (1 row)
 
 --- insert into a compressed chunk again + a new chunk--
@@ -479,10 +481,10 @@ SELECT chunk_status,
        chunk_name as "CHUNK_NAME"
 FROM compressed_chunk_info_view
 WHERE hypertable_name = 'test2' ORDER BY chunk_name;
- chunk_status |     CHUNK_NAME     
---------------+--------------------
-            9 | _hyper_14_62_chunk
-            0 | _hyper_14_64_chunk
+ chunk_status |     CHUNK_NAME      
+--------------+---------------------
+            9 | _hyper_14_103_chunk
+            0 | _hyper_14_105_chunk
 (2 rows)
 
 SELECT add_compression_policy AS job_id
@@ -494,24 +496,24 @@ SELECT chunk_status,
        chunk_name as "CHUNK_NAME"
 FROM compressed_chunk_info_view
 WHERE hypertable_name = 'test2' ORDER BY chunk_name;
- chunk_status |     CHUNK_NAME     
---------------+--------------------
-            1 | _hyper_14_62_chunk
-            1 | _hyper_14_64_chunk
+ chunk_status |     CHUNK_NAME      
+--------------+---------------------
+            1 | _hyper_14_103_chunk
+            1 | _hyper_14_105_chunk
 (2 rows)
 
 \set ON_ERROR_STOP 0
 -- call recompress_chunk when status is not unordered
 CALL recompress_chunk(:'CHUNK_NAME'::regclass, true);
-psql:include/recompress_basic.sql:110: NOTICE:  nothing to recompress in chunk "_hyper_14_62_chunk"
+psql:include/recompress_basic.sql:110: NOTICE:  nothing to recompress in chunk "_hyper_14_103_chunk"
 -- This will succeed and compress the chunk for the test below.
 CALL recompress_chunk(:'CHUNK_NAME'::regclass, false);
-psql:include/recompress_basic.sql:113: ERROR:  nothing to recompress in chunk "_hyper_14_62_chunk"
+psql:include/recompress_basic.sql:113: ERROR:  nothing to recompress in chunk "_hyper_14_103_chunk"
 --now decompress it , then try and recompress
 SELECT decompress_chunk(:'CHUNK_NAME'::regclass);
-             decompress_chunk             
-------------------------------------------
- _timescaledb_internal._hyper_14_62_chunk
+             decompress_chunk              
+-------------------------------------------
+ _timescaledb_internal._hyper_14_103_chunk
 (1 row)
 
 CALL recompress_chunk(:'CHUNK_NAME'::regclass);

--- a/tsl/test/expected/compression_create_chunks.out
+++ b/tsl/test/expected/compression_create_chunks.out
@@ -1,0 +1,74 @@
+-- This file and its contents are licensed under the Timescale License.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-TIMESCALE for a copy of the license.
+\c :TEST_DBNAME :ROLE_SUPERUSER
+CREATE TABLE conditions (
+    "time" TIMESTAMPTZ NOT NULL,
+    city TEXT NOT NULL,
+    temperature INTEGER NOT NULL,
+    device_id INTEGER NOT NULL
+);
+SELECT table_name FROM create_hypertable('conditions', 'time');
+ table_name 
+------------
+ conditions
+(1 row)
+
+INSERT INTO
+    conditions ("time", city, temperature, device_id)
+VALUES
+  ('2021-06-14 00:00:00-00', 'Moscow', 26,1),
+  ('2021-06-15 00:00:00-00', 'Berlin', 22,2),
+  ('2021-06-16 00:00:00-00', 'Stockholm', 24,3),
+  ('2021-06-17 00:00:00-00', 'London', 24,4),
+  ('2021-06-18 00:00:00-00', 'London', 27,4),
+  ('2021-06-19 00:00:00-00', 'Moscow', 28,4);
+ALTER TABLE conditions SET (timescaledb.compress);
+SELECT * FROM _timescaledb_catalog.chunk ORDER BY 1,2;
+ id | hypertable_id |      schema_name      |        table_name        | compressed_chunk_id | dropped | status | osm_chunk 
+----+---------------+-----------------------+--------------------------+---------------------+---------+--------+-----------
+  1 |             1 | _timescaledb_internal | _hyper_1_1_chunk         |                   3 | f       |      0 | f
+  2 |             1 | _timescaledb_internal | _hyper_1_2_chunk         |                   4 | f       |      0 | f
+  3 |             2 | _timescaledb_internal | compress_hyper_2_3_chunk |                     | f       |      0 | f
+  4 |             2 | _timescaledb_internal | compress_hyper_2_4_chunk |                     | f       |      0 | f
+(4 rows)
+
+UPDATE _timescaledb_catalog.chunk SET compressed_chunk_id = NULL WHERE id = 1;
+SELECT * FROM _timescaledb_catalog.chunk ORDER BY 1,2;
+ id | hypertable_id |      schema_name      |        table_name        | compressed_chunk_id | dropped | status | osm_chunk 
+----+---------------+-----------------------+--------------------------+---------------------+---------+--------+-----------
+  1 |             1 | _timescaledb_internal | _hyper_1_1_chunk         |                     | f       |      0 | f
+  2 |             1 | _timescaledb_internal | _hyper_1_2_chunk         |                   4 | f       |      0 | f
+  3 |             2 | _timescaledb_internal | compress_hyper_2_3_chunk |                     | f       |      0 | f
+  4 |             2 | _timescaledb_internal | compress_hyper_2_4_chunk |                     | f       |      0 | f
+(4 rows)
+
+SELECT _timescaledb_functions.create_compressed_chunks_for_hypertable('conditions');
+ create_compressed_chunks_for_hypertable 
+-----------------------------------------
+ 
+(1 row)
+
+SELECT * FROM _timescaledb_catalog.chunk;
+ id | hypertable_id |      schema_name      |        table_name        | compressed_chunk_id | dropped | status | osm_chunk 
+----+---------------+-----------------------+--------------------------+---------------------+---------+--------+-----------
+  3 |             2 | _timescaledb_internal | compress_hyper_2_3_chunk |                     | f       |      0 | f
+  4 |             2 | _timescaledb_internal | compress_hyper_2_4_chunk |                     | f       |      0 | f
+  2 |             1 | _timescaledb_internal | _hyper_1_2_chunk         |                   4 | f       |      0 | f
+  5 |             2 | _timescaledb_internal | compress_hyper_2_5_chunk |                     | f       |      0 | f
+  1 |             1 | _timescaledb_internal | _hyper_1_1_chunk         |                   5 | f       |      0 | f
+(5 rows)
+
+SELECT * FROM _timescaledb_catalog.hypertable;
+ id |      schema_name      |        table_name        | associated_schema_name | associated_table_prefix | num_dimensions | chunk_sizing_func_schema |  chunk_sizing_func_name  | chunk_target_size | compression_state | compressed_hypertable_id | replication_factor 
+----+-----------------------+--------------------------+------------------------+-------------------------+----------------+--------------------------+--------------------------+-------------------+-------------------+--------------------------+--------------------
+  2 | _timescaledb_internal | _compressed_hypertable_2 | _timescaledb_internal  | _hyper_2                |              0 | _timescaledb_functions   | calculate_chunk_interval |                 0 |                 2 |                          |                   
+  1 | public                | conditions               | _timescaledb_internal  | _hyper_1                |              1 | _timescaledb_functions   | calculate_chunk_interval |                 0 |                 1 |                        2 |                   
+(2 rows)
+
+\set ON_ERROR_STOP 0
+SELECT _timescaledb_functions.create_compressed_chunks_for_hypertable('_timescaledb_internal._compressed_hypertable_2');
+ERROR:  hypertable doesn't have compression enabled
+SELECT _timescaledb_functions.create_compressed_chunks_for_hypertable('nonexistant');
+ERROR:  relation "nonexistant" does not exist at character 71
+\set ON_ERROR_STOP 1

--- a/tsl/test/expected/compression_ddl.out
+++ b/tsl/test/expected/compression_ddl.out
@@ -46,7 +46,7 @@ FROM
 SELECT compress_chunk(chunk.schema_name|| '.' || chunk.table_name)
 FROM _timescaledb_catalog.chunk chunk
 INNER JOIN _timescaledb_catalog.hypertable hypertable ON (chunk.hypertable_id = hypertable.id)
-WHERE hypertable.table_name like 'test1' and chunk.compressed_chunk_id IS NULL ORDER BY chunk.id
+WHERE hypertable.table_name like 'test1' and chunk.status & 1 = 0 ORDER BY chunk.id
 )
 AS sub;
  count_compressed 
@@ -199,26 +199,27 @@ SELECT decompress_chunk(:'UNCOMPRESSED_CHUNK_NAME');
  _timescaledb_internal._hyper_1_1_chunk
 (1 row)
 
---the compresse chunk was dropped by decompression
+--the compressed chunk remains (empty) after decompression
 SELECT count(*)
 FROM pg_tables WHERE tablespace = 'tablespace1';
  count 
 -------
-     1
+     2
 (1 row)
 
 SELECT move_chunk(chunk=>:'UNCOMPRESSED_CHUNK_NAME', destination_tablespace=>'tablespace1', index_destination_tablespace=>'tablespace1',  reorder_index=>'_timescaledb_internal."_hyper_1_1_chunk_test1_Time_idx"');
+NOTICE:  ignoring index parameter
  move_chunk 
 ------------
  
 (1 row)
 
---the uncompressed chunks has now been moved
+--the chunks has now been moved
 SELECT count(*)
 FROM pg_tables WHERE tablespace = 'tablespace1';
  count 
 -------
-     1
+     2
 (1 row)
 
 SELECT compress_chunk(:'UNCOMPRESSED_CHUNK_NAME');
@@ -227,7 +228,7 @@ SELECT compress_chunk(:'UNCOMPRESSED_CHUNK_NAME');
  _timescaledb_internal._hyper_1_1_chunk
 (1 row)
 
---the compressed chunk is now in the same tablespace as the uncompressed one
+--the compressed chunk is in the same tablespace as the uncompressed one, was moved previously
 SELECT count(*)
 FROM pg_tables WHERE tablespace = 'tablespace1';
  count 
@@ -574,7 +575,7 @@ FROM
 SELECT decompress_chunk(chunk.schema_name|| '.' || chunk.table_name)
 FROM _timescaledb_catalog.chunk chunk
 INNER JOIN _timescaledb_catalog.hypertable hypertable ON (chunk.hypertable_id = hypertable.id)
-WHERE hypertable.table_name like 'test1' and chunk.compressed_chunk_id IS NOT NULL ORDER BY chunk.id
+WHERE hypertable.table_name like 'test1' and chunk.status & 1 > 0 ORDER BY chunk.id
 )
 AS sub;
  count_compressed 
@@ -644,7 +645,7 @@ FROM
 SELECT compress_chunk(chunk.schema_name|| '.' || chunk.table_name)
 FROM _timescaledb_catalog.chunk chunk
 INNER JOIN _timescaledb_catalog.hypertable hypertable ON (chunk.hypertable_id = hypertable.id)
-WHERE hypertable.table_name like 'test1' and chunk.compressed_chunk_id IS NULL ORDER BY chunk.id
+WHERE hypertable.table_name like 'test1' and chunk.status & 1 = 0 ORDER BY chunk.id
 )
 AS sub;
  count_compressed 
@@ -653,9 +654,9 @@ AS sub;
 (1 row)
 
 DROP TABLE test1 CASCADE;
-NOTICE:  drop cascades to table _timescaledb_internal.compress_hyper_7_57_chunk
+NOTICE:  drop cascades to table _timescaledb_internal.compress_hyper_7_56_chunk
 NOTICE:  drop cascades to 2 other objects
-NOTICE:  drop cascades to table _timescaledb_internal._hyper_5_56_chunk
+NOTICE:  drop cascades to table _timescaledb_internal._hyper_5_55_chunk
 DROP TABLESPACE tablespace1;
 -- Triggers are NOT fired for compress/decompress
 CREATE TABLE test1 ("Time" timestamptz, i integer);
@@ -692,7 +693,7 @@ SELECT COUNT(*) AS count_compressed FROM
 SELECT compress_chunk(chunk.schema_name|| '.' || chunk.table_name)
 FROM _timescaledb_catalog.chunk chunk
 INNER JOIN _timescaledb_catalog.hypertable hypertable ON (chunk.hypertable_id = hypertable.id)
-WHERE hypertable.table_name like 'test1' and chunk.compressed_chunk_id IS NULL ORDER BY chunk.id) AS subq;
+WHERE hypertable.table_name like 'test1' and chunk.status & 1 = 0 ORDER BY chunk.id) AS subq;
  count_compressed 
 ------------------
                 2
@@ -726,26 +727,26 @@ ALTER TABLE i2844 SET (timescaledb.compress);
 SELECT compress_chunk(show_chunks) AS compressed_chunk FROM show_chunks('i2844');
              compressed_chunk             
 ------------------------------------------
+ _timescaledb_internal._hyper_10_61_chunk
  _timescaledb_internal._hyper_10_62_chunk
  _timescaledb_internal._hyper_10_63_chunk
  _timescaledb_internal._hyper_10_64_chunk
  _timescaledb_internal._hyper_10_65_chunk
- _timescaledb_internal._hyper_10_66_chunk
 (5 rows)
 
 SELECT drop_chunks('i2844', older_than => '2000-01-01 18:00'::timestamptz);
                drop_chunks                
 ------------------------------------------
+ _timescaledb_internal._hyper_10_61_chunk
  _timescaledb_internal._hyper_10_62_chunk
  _timescaledb_internal._hyper_10_63_chunk
- _timescaledb_internal._hyper_10_64_chunk
 (3 rows)
 
 SELECT decompress_chunk(show_chunks, if_compressed => TRUE) AS decompressed_chunks FROM show_chunks('i2844');
            decompressed_chunks            
 ------------------------------------------
+ _timescaledb_internal._hyper_10_64_chunk
  _timescaledb_internal._hyper_10_65_chunk
- _timescaledb_internal._hyper_10_66_chunk
 (2 rows)
 
 ALTER TABLE i2844 SET (timescaledb.compress = FALSE);
@@ -806,7 +807,7 @@ FROM
 SELECT compress_chunk(chunk.schema_name|| '.' || chunk.table_name)
 FROM _timescaledb_catalog.chunk chunk
 INNER JOIN _timescaledb_catalog.hypertable hypertable ON (chunk.hypertable_id = hypertable.id)
-WHERE hypertable.table_name like 'test1' and chunk.compressed_chunk_id IS NULL ORDER BY chunk.id
+WHERE hypertable.table_name like 'test1' and chunk.status & 1 = 0 ORDER BY chunk.id
 )
 AS sub;
  count_compressed 
@@ -848,7 +849,7 @@ FROM
 SELECT decompress_chunk(chunk.schema_name|| '.' || chunk.table_name)
 FROM _timescaledb_catalog.chunk chunk
 INNER JOIN _timescaledb_catalog.hypertable hypertable ON (chunk.hypertable_id = hypertable.id)
-WHERE hypertable.table_name like 'test1' and chunk.compressed_chunk_id IS NOT NULL ORDER BY chunk.id
+WHERE hypertable.table_name like 'test1' and chunk.status & 1 > 0 ORDER BY chunk.id
 LIMIT 1
 )
 AS sub;
@@ -891,7 +892,7 @@ FROM
 SELECT compress_chunk(chunk.schema_name|| '.' || chunk.table_name)
 FROM _timescaledb_catalog.chunk chunk
 INNER JOIN _timescaledb_catalog.hypertable hypertable ON (chunk.hypertable_id = hypertable.id)
-WHERE hypertable.table_name like 'test1' and chunk.compressed_chunk_id IS NULL ORDER BY chunk.id
+WHERE hypertable.table_name like 'test1' and chunk.status & 1 = 0 ORDER BY chunk.id
 )
 AS sub;
  count_compressed 
@@ -966,7 +967,7 @@ FROM
 SELECT compress_chunk(chunk.schema_name|| '.' || chunk.table_name)
 FROM _timescaledb_catalog.chunk chunk
 INNER JOIN _timescaledb_catalog.hypertable hypertable ON (chunk.hypertable_id = hypertable.id)
-WHERE hypertable.table_name = 'test1' and chunk.compressed_chunk_id IS NULL ORDER BY chunk.id
+WHERE hypertable.table_name = 'test1' and chunk.status & 1 = 0 ORDER BY chunk.id
 ) q;
  count_compressed 
 ------------------
@@ -1057,7 +1058,7 @@ INSERT INTO test_defaults SELECT '2001-01-01', 1;
 SELECT compress_chunk(show_chunks) AS compressed_chunk FROM show_chunks('test_defaults') ORDER BY show_chunks::text LIMIT 1;
              compressed_chunk             
 ------------------------------------------
- _timescaledb_internal._hyper_15_89_chunk
+ _timescaledb_internal._hyper_15_87_chunk
 (1 row)
 
 SELECT * FROM test_defaults ORDER BY 1;
@@ -1106,10 +1107,10 @@ SELECT *,assert_equal(c3,43) FROM test_defaults ORDER BY 1,2;
 (3 rows)
 
 select decompress_chunk(show_chunks('test_defaults'),true);
-psql:include/compression_alter.sql:179: NOTICE:  chunk "_hyper_15_90_chunk" is not compressed
+psql:include/compression_alter.sql:179: NOTICE:  chunk "_hyper_15_89_chunk" is already decompressed
              decompress_chunk             
 ------------------------------------------
- _timescaledb_internal._hyper_15_89_chunk
+ _timescaledb_internal._hyper_15_87_chunk
  
 (2 rows)
 
@@ -1124,8 +1125,8 @@ SELECT *,assert_equal(c3,43) FROM test_defaults ORDER BY 1,2;
 select compress_chunk(show_chunks('test_defaults'));
               compress_chunk              
 ------------------------------------------
+ _timescaledb_internal._hyper_15_87_chunk
  _timescaledb_internal._hyper_15_89_chunk
- _timescaledb_internal._hyper_15_90_chunk
 (2 rows)
 
 SELECT *,assert_equal(c3,43) FROM test_defaults ORDER BY 1,2;
@@ -1254,16 +1255,20 @@ ALTER TABLE test2 set (timescaledb.compress, timescaledb.compress_segmentby = 'i
 SELECT regexp_replace(relname, 'pg_toast_[0-9]+', 'pg_toast_XXX') FROM pg_class
 WHERE reltablespace in
   ( SELECT oid from pg_tablespace WHERE spcname = 'tablespace2') ORDER BY 1;
-                    regexp_replace                     
--------------------------------------------------------
+                         regexp_replace                          
+-----------------------------------------------------------------
  _compressed_hypertable_20
  _compressed_hypertable_20_i__ts_meta_sequence_num_idx
- _hyper_19_104_chunk
- _hyper_19_104_chunk_test2_timec_idx
+ _hyper_19_101_chunk
+ _hyper_19_101_chunk_test2_timec_idx
+ compress_hyper_20_102_chunk
+ compress_hyper_20_102_chunk__compressed_hypertable_20_i__ts_met
+ pg_toast_XXX
  pg_toast_XXX
  pg_toast_XXX_index
+ pg_toast_XXX_index
  test2
-(7 rows)
+(11 rows)
 
 -- test compress_chunk() with utility statement (SELECT ... INTO)
 SELECT compress_chunk(ch) INTO compressed_chunks FROM show_chunks('test2') ch;
@@ -1272,7 +1277,7 @@ SELECT decompress_chunk(ch) INTO decompressed_chunks FROM show_chunks('test2') c
 SELECT compress_chunk(ch) FROM show_chunks('test2') ch;
               compress_chunk               
 -------------------------------------------
- _timescaledb_internal._hyper_19_104_chunk
+ _timescaledb_internal._hyper_19_101_chunk
 (1 row)
 
 -- the chunk, compressed chunk + index + toast tables are in tablespace2 now .
@@ -1288,7 +1293,7 @@ WHERE reltablespace in
 (1 row)
 
 DROP TABLE test2 CASCADE;
-NOTICE:  drop cascades to table _timescaledb_internal.compress_hyper_20_106_chunk
+NOTICE:  drop cascades to table _timescaledb_internal.compress_hyper_20_102_chunk
 DROP TABLESPACE tablespace2;
 -- Create a table with a compressed table and then delete the
 -- compressed table and see that the drop of the hypertable does not
@@ -1447,7 +1452,7 @@ FROM generate_series('2000-01-01 0:00:00+0'::timestamptz,'2000-01-03 23:55:00+0'
 SELECT compress_chunk(c.schema_name|| '.' || c.table_name) as "CHUNK_NAME"
 FROM _timescaledb_catalog.chunk c, _timescaledb_catalog.hypertable ht
 WHERE c.hypertable_id = ht.id and ht.table_name = 'compression_insert'
-AND c.compressed_chunk_id IS NULL
+AND c.status & 1 = 0
 ORDER BY c.table_name DESC \gset
 INSERT INTO compression_insert(time,device_id,v0,v1,v2,v3)
 SELECT time, device_id, device_id+1,  device_id + 2, device_id + 0.5, NULL
@@ -1476,13 +1481,13 @@ ORDER BY device_id;
                                                                QUERY PLAN                                                                
 -----------------------------------------------------------------------------------------------------------------------------------------
  Sort
-   Sort Key: _hyper_32_107_chunk.device_id
+   Sort Key: _hyper_32_103_chunk.device_id
    ->  HashAggregate
-         Group Key: _hyper_32_107_chunk.device_id
+         Group Key: _hyper_32_103_chunk.device_id
          ->  Append
-               ->  Custom Scan (DecompressChunk) on _hyper_32_107_chunk
-                     ->  Index Scan using compress_hyper_33_108_chunk__compressed_hypertable_33_device_id on compress_hyper_33_108_chunk
-               ->  Index Only Scan using _hyper_32_107_chunk_compression_insert_device_id_time_idx on _hyper_32_107_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_32_103_chunk
+                     ->  Index Scan using compress_hyper_33_104_chunk__compressed_hypertable_33_device_id on compress_hyper_33_104_chunk
+               ->  Index Only Scan using _hyper_32_103_chunk_compression_insert_device_id_time_idx on _hyper_32_103_chunk
 (8 rows)
 
 SELECT device_id, count(*)
@@ -1531,7 +1536,7 @@ SELECT compress_chunk(c.schema_name|| '.' || c.table_name) as "CHUNK_NAME"
 FROM _timescaledb_catalog.chunk c, _timescaledb_catalog.hypertable ht
 WHERE c.hypertable_id = ht.id
 AND ht.table_name = 'compression_insert'
-AND c.compressed_chunk_id IS NULL
+AND c.status & 1 = 0
 ORDER BY c.table_name DESC \gset
 INSERT INTO compression_insert(time,device_id,v0,v1,v2,v3)
 SELECT time, device_id, device_id+1,  device_id + 2, device_id + 0.5, NULL
@@ -1554,15 +1559,15 @@ ORDER BY device_id;
                                                                QUERY PLAN                                                                
 -----------------------------------------------------------------------------------------------------------------------------------------
  Sort
-   Sort Key: _hyper_32_107_chunk.device_id
+   Sort Key: _hyper_32_103_chunk.device_id
    ->  HashAggregate
-         Group Key: _hyper_32_107_chunk.device_id
+         Group Key: _hyper_32_103_chunk.device_id
          ->  Append
-               ->  Custom Scan (DecompressChunk) on _hyper_32_107_chunk
-                     ->  Index Scan using compress_hyper_33_108_chunk__compressed_hypertable_33_device_id on compress_hyper_33_108_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_32_109_chunk
-                     ->  Index Scan using compress_hyper_33_110_chunk__compressed_hypertable_33_device_id on compress_hyper_33_110_chunk
-               ->  Index Only Scan using _hyper_32_109_chunk_compression_insert_device_id_time_idx on _hyper_32_109_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_32_103_chunk
+                     ->  Index Scan using compress_hyper_33_104_chunk__compressed_hypertable_33_device_id on compress_hyper_33_104_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_32_105_chunk
+                     ->  Index Scan using compress_hyper_33_106_chunk__compressed_hypertable_33_device_id on compress_hyper_33_106_chunk
+               ->  Index Only Scan using _hyper_32_105_chunk_compression_insert_device_id_time_idx on _hyper_32_105_chunk
 (10 rows)
 
 SELECT device_id, count(*)
@@ -1610,7 +1615,7 @@ SELECT compress_chunk(c.schema_name|| '.' || c.table_name) as "CHUNK_NAME"
 FROM _timescaledb_catalog.chunk c, _timescaledb_catalog.hypertable ht
 WHERE c.hypertable_id = ht.id
 AND ht.table_name = 'compression_insert'
-AND c.compressed_chunk_id IS NULL
+AND c.status & 1 = 0
 ORDER BY c.table_name DESC \gset
 ALTER TABLE compression_insert DROP COLUMN filler_2;
 INSERT INTO compression_insert(time,device_id,v0,v1,v2,v3)
@@ -1634,17 +1639,17 @@ ORDER BY device_id;
                                                                QUERY PLAN                                                                
 -----------------------------------------------------------------------------------------------------------------------------------------
  Sort
-   Sort Key: _hyper_32_107_chunk.device_id
+   Sort Key: _hyper_32_103_chunk.device_id
    ->  HashAggregate
-         Group Key: _hyper_32_107_chunk.device_id
+         Group Key: _hyper_32_103_chunk.device_id
          ->  Append
+               ->  Custom Scan (DecompressChunk) on _hyper_32_103_chunk
+                     ->  Index Scan using compress_hyper_33_104_chunk__compressed_hypertable_33_device_id on compress_hyper_33_104_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_32_105_chunk
+                     ->  Index Scan using compress_hyper_33_106_chunk__compressed_hypertable_33_device_id on compress_hyper_33_106_chunk
                ->  Custom Scan (DecompressChunk) on _hyper_32_107_chunk
                      ->  Index Scan using compress_hyper_33_108_chunk__compressed_hypertable_33_device_id on compress_hyper_33_108_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_32_109_chunk
-                     ->  Index Scan using compress_hyper_33_110_chunk__compressed_hypertable_33_device_id on compress_hyper_33_110_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_32_111_chunk
-                     ->  Index Scan using compress_hyper_33_112_chunk__compressed_hypertable_33_device_id on compress_hyper_33_112_chunk
-               ->  Index Only Scan using _hyper_32_111_chunk_compression_insert_device_id_time_idx on _hyper_32_111_chunk
+               ->  Index Only Scan using _hyper_32_107_chunk_compression_insert_device_id_time_idx on _hyper_32_107_chunk
 (12 rows)
 
 SELECT device_id, count(*)
@@ -1693,7 +1698,7 @@ SELECT compress_chunk(c.schema_name|| '.' || c.table_name) as "CHUNK_NAME"
 FROM _timescaledb_catalog.chunk c, _timescaledb_catalog.hypertable ht
 WHERE c.hypertable_id = ht.id
 AND ht.table_name = 'compression_insert'
-AND c.compressed_chunk_id IS NULL
+AND c.status & 1 = 0
 ORDER BY c.table_name DESC \gset
 INSERT INTO compression_insert(time,device_id,v0,v1,v2,v3)
 SELECT time, device_id, device_id+1, device_id + 2, device_id + 0.5, NULL
@@ -1716,19 +1721,19 @@ ORDER BY device_id;
                                                                QUERY PLAN                                                                
 -----------------------------------------------------------------------------------------------------------------------------------------
  Sort
-   Sort Key: _hyper_32_107_chunk.device_id
+   Sort Key: _hyper_32_103_chunk.device_id
    ->  HashAggregate
-         Group Key: _hyper_32_107_chunk.device_id
+         Group Key: _hyper_32_103_chunk.device_id
          ->  Append
+               ->  Custom Scan (DecompressChunk) on _hyper_32_103_chunk
+                     ->  Index Scan using compress_hyper_33_104_chunk__compressed_hypertable_33_device_id on compress_hyper_33_104_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_32_105_chunk
+                     ->  Index Scan using compress_hyper_33_106_chunk__compressed_hypertable_33_device_id on compress_hyper_33_106_chunk
                ->  Custom Scan (DecompressChunk) on _hyper_32_107_chunk
                      ->  Index Scan using compress_hyper_33_108_chunk__compressed_hypertable_33_device_id on compress_hyper_33_108_chunk
                ->  Custom Scan (DecompressChunk) on _hyper_32_109_chunk
                      ->  Index Scan using compress_hyper_33_110_chunk__compressed_hypertable_33_device_id on compress_hyper_33_110_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_32_111_chunk
-                     ->  Index Scan using compress_hyper_33_112_chunk__compressed_hypertable_33_device_id on compress_hyper_33_112_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_32_113_chunk
-                     ->  Index Scan using compress_hyper_33_114_chunk__compressed_hypertable_33_device_id on compress_hyper_33_114_chunk
-               ->  Index Only Scan using _hyper_32_113_chunk_compression_insert_device_id_time_idx on _hyper_32_113_chunk
+               ->  Index Only Scan using _hyper_32_109_chunk_compression_insert_device_id_time_idx on _hyper_32_109_chunk
 (14 rows)
 
 SELECT device_id, count(*)
@@ -1776,7 +1781,7 @@ SELECT compress_chunk(c.schema_name|| '.' || c.table_name) as "CHUNK_NAME"
 FROM _timescaledb_catalog.chunk c, _timescaledb_catalog.hypertable ht
 WHERE c.hypertable_id = ht.id
 AND ht.table_name = 'compression_insert'
-AND c.compressed_chunk_id IS NULL
+AND c.status & 1 = 0
 ORDER BY c.table_name DESC \gset
 ALTER TABLE compression_insert ADD COLUMN filler_5 int;
 INSERT INTO compression_insert(time,device_id,v0,v1,v2,v3)
@@ -1800,21 +1805,21 @@ ORDER BY device_id;
                                                                QUERY PLAN                                                                
 -----------------------------------------------------------------------------------------------------------------------------------------
  Sort
-   Sort Key: _hyper_32_107_chunk.device_id
+   Sort Key: _hyper_32_103_chunk.device_id
    ->  HashAggregate
-         Group Key: _hyper_32_107_chunk.device_id
+         Group Key: _hyper_32_103_chunk.device_id
          ->  Append
+               ->  Custom Scan (DecompressChunk) on _hyper_32_103_chunk
+                     ->  Index Scan using compress_hyper_33_104_chunk__compressed_hypertable_33_device_id on compress_hyper_33_104_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_32_105_chunk
+                     ->  Index Scan using compress_hyper_33_106_chunk__compressed_hypertable_33_device_id on compress_hyper_33_106_chunk
                ->  Custom Scan (DecompressChunk) on _hyper_32_107_chunk
                      ->  Index Scan using compress_hyper_33_108_chunk__compressed_hypertable_33_device_id on compress_hyper_33_108_chunk
                ->  Custom Scan (DecompressChunk) on _hyper_32_109_chunk
                      ->  Index Scan using compress_hyper_33_110_chunk__compressed_hypertable_33_device_id on compress_hyper_33_110_chunk
                ->  Custom Scan (DecompressChunk) on _hyper_32_111_chunk
                      ->  Index Scan using compress_hyper_33_112_chunk__compressed_hypertable_33_device_id on compress_hyper_33_112_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_32_113_chunk
-                     ->  Index Scan using compress_hyper_33_114_chunk__compressed_hypertable_33_device_id on compress_hyper_33_114_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_32_115_chunk
-                     ->  Index Scan using compress_hyper_33_116_chunk__compressed_hypertable_33_device_id on compress_hyper_33_116_chunk
-               ->  Index Only Scan using _hyper_32_115_chunk_compression_insert_device_id_time_idx on _hyper_32_115_chunk
+               ->  Index Only Scan using _hyper_32_111_chunk_compression_insert_device_id_time_idx on _hyper_32_111_chunk
 (16 rows)
 
 SELECT device_id, count(*)
@@ -1880,9 +1885,9 @@ ALTER TABLE test_partials SET (timescaledb.compress);
 SELECT compress_chunk(show_chunks('test_partials'));
               compress_chunk               
 -------------------------------------------
- _timescaledb_internal._hyper_34_117_chunk
- _timescaledb_internal._hyper_34_118_chunk
- _timescaledb_internal._hyper_34_119_chunk
+ _timescaledb_internal._hyper_34_113_chunk
+ _timescaledb_internal._hyper_34_114_chunk
+ _timescaledb_internal._hyper_34_115_chunk
 (3 rows)
 
 -- fully compressed
@@ -1891,18 +1896,18 @@ EXPLAIN (costs off) SELECT * FROM test_partials ORDER BY time;
 --------------------------------------------------------------------------------
  Custom Scan (ChunkAppend) on test_partials
    Order: test_partials."time"
-   ->  Custom Scan (DecompressChunk) on _hyper_34_117_chunk
+   ->  Custom Scan (DecompressChunk) on _hyper_34_113_chunk
          ->  Sort
-               Sort Key: compress_hyper_35_120_chunk._ts_meta_sequence_num DESC
-               ->  Seq Scan on compress_hyper_35_120_chunk
-   ->  Custom Scan (DecompressChunk) on _hyper_34_118_chunk
+               Sort Key: compress_hyper_35_116_chunk._ts_meta_sequence_num DESC
+               ->  Seq Scan on compress_hyper_35_116_chunk
+   ->  Custom Scan (DecompressChunk) on _hyper_34_114_chunk
          ->  Sort
-               Sort Key: compress_hyper_35_121_chunk._ts_meta_sequence_num DESC
-               ->  Seq Scan on compress_hyper_35_121_chunk
-   ->  Custom Scan (DecompressChunk) on _hyper_34_119_chunk
+               Sort Key: compress_hyper_35_117_chunk._ts_meta_sequence_num DESC
+               ->  Seq Scan on compress_hyper_35_117_chunk
+   ->  Custom Scan (DecompressChunk) on _hyper_34_115_chunk
          ->  Sort
-               Sort Key: compress_hyper_35_122_chunk._ts_meta_sequence_num DESC
-               ->  Seq Scan on compress_hyper_35_122_chunk
+               Sort Key: compress_hyper_35_118_chunk._ts_meta_sequence_num DESC
+               ->  Seq Scan on compress_hyper_35_118_chunk
 (14 rows)
 
 -- test P, F, F
@@ -1913,22 +1918,22 @@ EXPLAIN (costs off) SELECT * FROM test_partials ORDER BY time;
  Custom Scan (ChunkAppend) on test_partials
    Order: test_partials."time"
    ->  Merge Append
-         Sort Key: _hyper_34_117_chunk."time"
-         ->  Custom Scan (DecompressChunk) on _hyper_34_117_chunk
+         Sort Key: _hyper_34_113_chunk."time"
+         ->  Custom Scan (DecompressChunk) on _hyper_34_113_chunk
                ->  Sort
-                     Sort Key: compress_hyper_35_120_chunk._ts_meta_sequence_num DESC
-                     ->  Seq Scan on compress_hyper_35_120_chunk
+                     Sort Key: compress_hyper_35_116_chunk._ts_meta_sequence_num DESC
+                     ->  Seq Scan on compress_hyper_35_116_chunk
          ->  Sort
-               Sort Key: _hyper_34_117_chunk."time"
-               ->  Seq Scan on _hyper_34_117_chunk
-   ->  Custom Scan (DecompressChunk) on _hyper_34_118_chunk
+               Sort Key: _hyper_34_113_chunk."time"
+               ->  Seq Scan on _hyper_34_113_chunk
+   ->  Custom Scan (DecompressChunk) on _hyper_34_114_chunk
          ->  Sort
-               Sort Key: compress_hyper_35_121_chunk._ts_meta_sequence_num DESC
-               ->  Seq Scan on compress_hyper_35_121_chunk
-   ->  Custom Scan (DecompressChunk) on _hyper_34_119_chunk
+               Sort Key: compress_hyper_35_117_chunk._ts_meta_sequence_num DESC
+               ->  Seq Scan on compress_hyper_35_117_chunk
+   ->  Custom Scan (DecompressChunk) on _hyper_34_115_chunk
          ->  Sort
-               Sort Key: compress_hyper_35_122_chunk._ts_meta_sequence_num DESC
-               ->  Seq Scan on compress_hyper_35_122_chunk
+               Sort Key: compress_hyper_35_118_chunk._ts_meta_sequence_num DESC
+               ->  Seq Scan on compress_hyper_35_118_chunk
 (19 rows)
 
 -- verify correct results
@@ -1954,27 +1959,27 @@ EXPLAIN (costs off) SELECT * FROM test_partials ORDER BY time;
  Custom Scan (ChunkAppend) on test_partials
    Order: test_partials."time"
    ->  Merge Append
-         Sort Key: _hyper_34_117_chunk."time"
-         ->  Custom Scan (DecompressChunk) on _hyper_34_117_chunk
+         Sort Key: _hyper_34_113_chunk."time"
+         ->  Custom Scan (DecompressChunk) on _hyper_34_113_chunk
                ->  Sort
-                     Sort Key: compress_hyper_35_120_chunk._ts_meta_sequence_num DESC
-                     ->  Seq Scan on compress_hyper_35_120_chunk
+                     Sort Key: compress_hyper_35_116_chunk._ts_meta_sequence_num DESC
+                     ->  Seq Scan on compress_hyper_35_116_chunk
          ->  Sort
-               Sort Key: _hyper_34_117_chunk."time"
-               ->  Seq Scan on _hyper_34_117_chunk
+               Sort Key: _hyper_34_113_chunk."time"
+               ->  Seq Scan on _hyper_34_113_chunk
    ->  Merge Append
-         Sort Key: _hyper_34_118_chunk."time"
-         ->  Custom Scan (DecompressChunk) on _hyper_34_118_chunk
+         Sort Key: _hyper_34_114_chunk."time"
+         ->  Custom Scan (DecompressChunk) on _hyper_34_114_chunk
                ->  Sort
-                     Sort Key: compress_hyper_35_121_chunk._ts_meta_sequence_num DESC
-                     ->  Seq Scan on compress_hyper_35_121_chunk
+                     Sort Key: compress_hyper_35_117_chunk._ts_meta_sequence_num DESC
+                     ->  Seq Scan on compress_hyper_35_117_chunk
          ->  Sort
-               Sort Key: _hyper_34_118_chunk."time"
-               ->  Seq Scan on _hyper_34_118_chunk
-   ->  Custom Scan (DecompressChunk) on _hyper_34_119_chunk
+               Sort Key: _hyper_34_114_chunk."time"
+               ->  Seq Scan on _hyper_34_114_chunk
+   ->  Custom Scan (DecompressChunk) on _hyper_34_115_chunk
          ->  Sort
-               Sort Key: compress_hyper_35_122_chunk._ts_meta_sequence_num DESC
-               ->  Seq Scan on compress_hyper_35_122_chunk
+               Sort Key: compress_hyper_35_118_chunk._ts_meta_sequence_num DESC
+               ->  Seq Scan on compress_hyper_35_118_chunk
 (24 rows)
 
 -- verify correct results
@@ -2002,33 +2007,33 @@ EXPLAIN (costs off) SELECT * FROM test_partials ORDER BY time;
  Custom Scan (ChunkAppend) on test_partials
    Order: test_partials."time"
    ->  Merge Append
-         Sort Key: _hyper_34_117_chunk."time"
-         ->  Custom Scan (DecompressChunk) on _hyper_34_117_chunk
+         Sort Key: _hyper_34_113_chunk."time"
+         ->  Custom Scan (DecompressChunk) on _hyper_34_113_chunk
                ->  Sort
-                     Sort Key: compress_hyper_35_120_chunk._ts_meta_sequence_num DESC
-                     ->  Seq Scan on compress_hyper_35_120_chunk
+                     Sort Key: compress_hyper_35_116_chunk._ts_meta_sequence_num DESC
+                     ->  Seq Scan on compress_hyper_35_116_chunk
          ->  Sort
-               Sort Key: _hyper_34_117_chunk."time"
-               ->  Seq Scan on _hyper_34_117_chunk
+               Sort Key: _hyper_34_113_chunk."time"
+               ->  Seq Scan on _hyper_34_113_chunk
    ->  Merge Append
-         Sort Key: _hyper_34_118_chunk."time"
-         ->  Custom Scan (DecompressChunk) on _hyper_34_118_chunk
+         Sort Key: _hyper_34_114_chunk."time"
+         ->  Custom Scan (DecompressChunk) on _hyper_34_114_chunk
                ->  Sort
-                     Sort Key: compress_hyper_35_121_chunk._ts_meta_sequence_num DESC
-                     ->  Seq Scan on compress_hyper_35_121_chunk
+                     Sort Key: compress_hyper_35_117_chunk._ts_meta_sequence_num DESC
+                     ->  Seq Scan on compress_hyper_35_117_chunk
          ->  Sort
-               Sort Key: _hyper_34_118_chunk."time"
-               ->  Seq Scan on _hyper_34_118_chunk
+               Sort Key: _hyper_34_114_chunk."time"
+               ->  Seq Scan on _hyper_34_114_chunk
    ->  Merge Append
-         Sort Key: _hyper_34_119_chunk."time"
-         ->  Custom Scan (DecompressChunk) on _hyper_34_119_chunk
+         Sort Key: _hyper_34_115_chunk."time"
+         ->  Custom Scan (DecompressChunk) on _hyper_34_115_chunk
                ->  Sort
-                     Sort Key: compress_hyper_35_122_chunk._ts_meta_sequence_num DESC
-                     ->  Seq Scan on compress_hyper_35_122_chunk
+                     Sort Key: compress_hyper_35_118_chunk._ts_meta_sequence_num DESC
+                     ->  Seq Scan on compress_hyper_35_118_chunk
          ->  Sort
-               Sort Key: _hyper_34_119_chunk."time"
-               ->  Seq Scan on _hyper_34_119_chunk
-   ->  Index Scan Backward using _hyper_34_123_chunk_test_partials_time_idx on _hyper_34_123_chunk
+               Sort Key: _hyper_34_115_chunk."time"
+               ->  Seq Scan on _hyper_34_115_chunk
+   ->  Index Scan Backward using _hyper_34_119_chunk_test_partials_time_idx on _hyper_34_119_chunk
 (30 rows)
 
 -- F, F, P, U
@@ -2039,7 +2044,7 @@ DECLARE
 BEGIN
   FOR chunk IN
   SELECT format('%I.%I', schema_name, table_name)::regclass
-    FROM _timescaledb_catalog.chunk WHERE status = 9 and compressed_chunk_id IS NOT NULL AND NOT dropped
+    FROM _timescaledb_catalog.chunk WHERE status = 9 AND NOT dropped
   LOOP
     EXECUTE format('select decompress_chunk(''%s'');', chunk::text);
     EXECUTE format('select compress_chunk(''%s'');', chunk::text);
@@ -2052,24 +2057,24 @@ EXPLAIN (COSTS OFF) SELECT * FROM test_partials ORDER BY time;
 ---------------------------------------------------------------------------------------------------
  Custom Scan (ChunkAppend) on test_partials
    Order: test_partials."time"
-   ->  Custom Scan (DecompressChunk) on _hyper_34_117_chunk
+   ->  Custom Scan (DecompressChunk) on _hyper_34_113_chunk
          ->  Sort
-               Sort Key: compress_hyper_35_124_chunk._ts_meta_sequence_num DESC
-               ->  Seq Scan on compress_hyper_35_124_chunk
-   ->  Custom Scan (DecompressChunk) on _hyper_34_118_chunk
+               Sort Key: compress_hyper_35_116_chunk._ts_meta_sequence_num DESC
+               ->  Seq Scan on compress_hyper_35_116_chunk
+   ->  Custom Scan (DecompressChunk) on _hyper_34_114_chunk
          ->  Sort
-               Sort Key: compress_hyper_35_125_chunk._ts_meta_sequence_num DESC
-               ->  Seq Scan on compress_hyper_35_125_chunk
+               Sort Key: compress_hyper_35_117_chunk._ts_meta_sequence_num DESC
+               ->  Seq Scan on compress_hyper_35_117_chunk
    ->  Merge Append
-         Sort Key: _hyper_34_119_chunk."time"
-         ->  Custom Scan (DecompressChunk) on _hyper_34_119_chunk
+         Sort Key: _hyper_34_115_chunk."time"
+         ->  Custom Scan (DecompressChunk) on _hyper_34_115_chunk
                ->  Sort
-                     Sort Key: compress_hyper_35_126_chunk._ts_meta_sequence_num DESC
-                     ->  Seq Scan on compress_hyper_35_126_chunk
+                     Sort Key: compress_hyper_35_118_chunk._ts_meta_sequence_num DESC
+                     ->  Seq Scan on compress_hyper_35_118_chunk
          ->  Sort
-               Sort Key: _hyper_34_119_chunk."time"
-               ->  Seq Scan on _hyper_34_119_chunk
-   ->  Index Scan Backward using _hyper_34_123_chunk_test_partials_time_idx on _hyper_34_123_chunk
+               Sort Key: _hyper_34_115_chunk."time"
+               ->  Seq Scan on _hyper_34_115_chunk
+   ->  Index Scan Backward using _hyper_34_119_chunk_test_partials_time_idx on _hyper_34_119_chunk
 (20 rows)
 
 -- F, F, P, F, F
@@ -2077,8 +2082,8 @@ INSERT INTO test_partials VALUES ('2024-01-01 00:02', 1, 2);
 SELECT compress_chunk(c) FROM show_chunks('test_partials', newer_than => '2022-01-01') c;
               compress_chunk               
 -------------------------------------------
- _timescaledb_internal._hyper_34_123_chunk
- _timescaledb_internal._hyper_34_127_chunk
+ _timescaledb_internal._hyper_34_119_chunk
+ _timescaledb_internal._hyper_34_121_chunk
 (2 rows)
 
 EXPLAIN (costs off) SELECT * FROM test_partials ORDER BY time;
@@ -2086,31 +2091,31 @@ EXPLAIN (costs off) SELECT * FROM test_partials ORDER BY time;
 --------------------------------------------------------------------------------------
  Custom Scan (ChunkAppend) on test_partials
    Order: test_partials."time"
-   ->  Custom Scan (DecompressChunk) on _hyper_34_117_chunk
+   ->  Custom Scan (DecompressChunk) on _hyper_34_113_chunk
          ->  Sort
-               Sort Key: compress_hyper_35_124_chunk._ts_meta_sequence_num DESC
-               ->  Seq Scan on compress_hyper_35_124_chunk
-   ->  Custom Scan (DecompressChunk) on _hyper_34_118_chunk
+               Sort Key: compress_hyper_35_116_chunk._ts_meta_sequence_num DESC
+               ->  Seq Scan on compress_hyper_35_116_chunk
+   ->  Custom Scan (DecompressChunk) on _hyper_34_114_chunk
          ->  Sort
-               Sort Key: compress_hyper_35_125_chunk._ts_meta_sequence_num DESC
-               ->  Seq Scan on compress_hyper_35_125_chunk
+               Sort Key: compress_hyper_35_117_chunk._ts_meta_sequence_num DESC
+               ->  Seq Scan on compress_hyper_35_117_chunk
    ->  Merge Append
-         Sort Key: _hyper_34_119_chunk."time"
-         ->  Custom Scan (DecompressChunk) on _hyper_34_119_chunk
+         Sort Key: _hyper_34_115_chunk."time"
+         ->  Custom Scan (DecompressChunk) on _hyper_34_115_chunk
                ->  Sort
-                     Sort Key: compress_hyper_35_126_chunk._ts_meta_sequence_num DESC
-                     ->  Seq Scan on compress_hyper_35_126_chunk
+                     Sort Key: compress_hyper_35_118_chunk._ts_meta_sequence_num DESC
+                     ->  Seq Scan on compress_hyper_35_118_chunk
          ->  Sort
-               Sort Key: _hyper_34_119_chunk."time"
-               ->  Seq Scan on _hyper_34_119_chunk
-   ->  Custom Scan (DecompressChunk) on _hyper_34_123_chunk
+               Sort Key: _hyper_34_115_chunk."time"
+               ->  Seq Scan on _hyper_34_115_chunk
+   ->  Custom Scan (DecompressChunk) on _hyper_34_119_chunk
          ->  Sort
-               Sort Key: compress_hyper_35_128_chunk._ts_meta_sequence_num DESC
-               ->  Seq Scan on compress_hyper_35_128_chunk
-   ->  Custom Scan (DecompressChunk) on _hyper_34_127_chunk
+               Sort Key: compress_hyper_35_120_chunk._ts_meta_sequence_num DESC
+               ->  Seq Scan on compress_hyper_35_120_chunk
+   ->  Custom Scan (DecompressChunk) on _hyper_34_121_chunk
          ->  Sort
-               Sort Key: compress_hyper_35_129_chunk._ts_meta_sequence_num DESC
-               ->  Seq Scan on compress_hyper_35_129_chunk
+               Sort Key: compress_hyper_35_122_chunk._ts_meta_sequence_num DESC
+               ->  Seq Scan on compress_hyper_35_122_chunk
 (27 rows)
 
 -- verify result correctness
@@ -2158,8 +2163,8 @@ ALTER TABLE space_part SET (timescaledb.compress);
 SELECT compress_chunk(show_chunks('space_part'));
               compress_chunk               
 -------------------------------------------
- _timescaledb_internal._hyper_36_130_chunk
- _timescaledb_internal._hyper_36_131_chunk
+ _timescaledb_internal._hyper_36_123_chunk
+ _timescaledb_internal._hyper_36_124_chunk
 (2 rows)
 
 -- make first chunk partial
@@ -2181,18 +2186,18 @@ EXPLAIN (COSTS OFF) SELECT * FROM space_part ORDER BY time;
  Custom Scan (ChunkAppend) on space_part
    Order: space_part."time"
    ->  Merge Append
-         Sort Key: _hyper_36_130_chunk."time"
-         ->  Custom Scan (DecompressChunk) on _hyper_36_130_chunk
+         Sort Key: _hyper_36_123_chunk."time"
+         ->  Custom Scan (DecompressChunk) on _hyper_36_123_chunk
                ->  Sort
-                     Sort Key: compress_hyper_37_132_chunk._ts_meta_sequence_num DESC
-                     ->  Seq Scan on compress_hyper_37_132_chunk
+                     Sort Key: compress_hyper_37_125_chunk._ts_meta_sequence_num DESC
+                     ->  Seq Scan on compress_hyper_37_125_chunk
          ->  Sort
-               Sort Key: _hyper_36_130_chunk."time"
-               ->  Seq Scan on _hyper_36_130_chunk
-   ->  Custom Scan (DecompressChunk) on _hyper_36_131_chunk
+               Sort Key: _hyper_36_123_chunk."time"
+               ->  Seq Scan on _hyper_36_123_chunk
+   ->  Custom Scan (DecompressChunk) on _hyper_36_124_chunk
          ->  Sort
-               Sort Key: compress_hyper_37_133_chunk._ts_meta_sequence_num DESC
-               ->  Seq Scan on compress_hyper_37_133_chunk
+               Sort Key: compress_hyper_37_126_chunk._ts_meta_sequence_num DESC
+               ->  Seq Scan on compress_hyper_37_126_chunk
 (15 rows)
 
 -- now add more chunks that do adhere to the new space partitioning
@@ -2209,34 +2214,34 @@ EXPLAIN (COSTS OFF) SELECT * FROM space_part ORDER BY time;
  Custom Scan (ChunkAppend) on space_part
    Order: space_part."time"
    ->  Merge Append
-         Sort Key: _hyper_36_130_chunk."time"
-         ->  Custom Scan (DecompressChunk) on _hyper_36_130_chunk
+         Sort Key: _hyper_36_123_chunk."time"
+         ->  Custom Scan (DecompressChunk) on _hyper_36_123_chunk
                ->  Sort
-                     Sort Key: compress_hyper_37_132_chunk._ts_meta_sequence_num DESC
-                     ->  Seq Scan on compress_hyper_37_132_chunk
+                     Sort Key: compress_hyper_37_125_chunk._ts_meta_sequence_num DESC
+                     ->  Seq Scan on compress_hyper_37_125_chunk
          ->  Sort
-               Sort Key: _hyper_36_130_chunk."time"
-               ->  Seq Scan on _hyper_36_130_chunk
-   ->  Custom Scan (DecompressChunk) on _hyper_36_131_chunk
+               Sort Key: _hyper_36_123_chunk."time"
+               ->  Seq Scan on _hyper_36_123_chunk
+   ->  Custom Scan (DecompressChunk) on _hyper_36_124_chunk
          ->  Sort
-               Sort Key: compress_hyper_37_133_chunk._ts_meta_sequence_num DESC
-               ->  Seq Scan on compress_hyper_37_133_chunk
+               Sort Key: compress_hyper_37_126_chunk._ts_meta_sequence_num DESC
+               ->  Seq Scan on compress_hyper_37_126_chunk
    ->  Merge Append
-         Sort Key: _hyper_36_134_chunk."time"
-         ->  Index Scan Backward using _hyper_36_134_chunk_space_part_time_idx on _hyper_36_134_chunk
-         ->  Index Scan Backward using _hyper_36_135_chunk_space_part_time_idx on _hyper_36_135_chunk
+         Sort Key: _hyper_36_127_chunk."time"
+         ->  Index Scan Backward using _hyper_36_127_chunk_space_part_time_idx on _hyper_36_127_chunk
+         ->  Index Scan Backward using _hyper_36_129_chunk_space_part_time_idx on _hyper_36_129_chunk
 (19 rows)
 
 -- compress them
 SELECT compress_chunk(c, if_not_compressed=>true) FROM show_chunks('space_part') c;
-NOTICE:  chunk "_hyper_36_130_chunk" is already compressed
-NOTICE:  chunk "_hyper_36_131_chunk" is already compressed
+NOTICE:  chunk "_hyper_36_123_chunk" is already compressed
+NOTICE:  chunk "_hyper_36_124_chunk" is already compressed
               compress_chunk               
 -------------------------------------------
- _timescaledb_internal._hyper_36_130_chunk
- _timescaledb_internal._hyper_36_131_chunk
- _timescaledb_internal._hyper_36_134_chunk
- _timescaledb_internal._hyper_36_135_chunk
+ _timescaledb_internal._hyper_36_123_chunk
+ _timescaledb_internal._hyper_36_124_chunk
+ _timescaledb_internal._hyper_36_127_chunk
+ _timescaledb_internal._hyper_36_129_chunk
 (4 rows)
 
 -- plan still ok
@@ -2246,28 +2251,28 @@ EXPLAIN (COSTS OFF) SELECT * FROM space_part ORDER BY time;
  Custom Scan (ChunkAppend) on space_part
    Order: space_part."time"
    ->  Merge Append
-         Sort Key: _hyper_36_130_chunk."time"
-         ->  Custom Scan (DecompressChunk) on _hyper_36_130_chunk
+         Sort Key: _hyper_36_123_chunk."time"
+         ->  Custom Scan (DecompressChunk) on _hyper_36_123_chunk
                ->  Sort
-                     Sort Key: compress_hyper_37_132_chunk._ts_meta_sequence_num DESC
-                     ->  Seq Scan on compress_hyper_37_132_chunk
+                     Sort Key: compress_hyper_37_125_chunk._ts_meta_sequence_num DESC
+                     ->  Seq Scan on compress_hyper_37_125_chunk
          ->  Sort
-               Sort Key: _hyper_36_130_chunk."time"
-               ->  Seq Scan on _hyper_36_130_chunk
-   ->  Custom Scan (DecompressChunk) on _hyper_36_131_chunk
+               Sort Key: _hyper_36_123_chunk."time"
+               ->  Seq Scan on _hyper_36_123_chunk
+   ->  Custom Scan (DecompressChunk) on _hyper_36_124_chunk
          ->  Sort
-               Sort Key: compress_hyper_37_133_chunk._ts_meta_sequence_num DESC
-               ->  Seq Scan on compress_hyper_37_133_chunk
+               Sort Key: compress_hyper_37_126_chunk._ts_meta_sequence_num DESC
+               ->  Seq Scan on compress_hyper_37_126_chunk
    ->  Merge Append
-         Sort Key: _hyper_36_134_chunk."time"
-         ->  Custom Scan (DecompressChunk) on _hyper_36_134_chunk
+         Sort Key: _hyper_36_127_chunk."time"
+         ->  Custom Scan (DecompressChunk) on _hyper_36_127_chunk
                ->  Sort
-                     Sort Key: compress_hyper_37_136_chunk._ts_meta_sequence_num DESC
-                     ->  Seq Scan on compress_hyper_37_136_chunk
-         ->  Custom Scan (DecompressChunk) on _hyper_36_135_chunk
+                     Sort Key: compress_hyper_37_128_chunk._ts_meta_sequence_num DESC
+                     ->  Seq Scan on compress_hyper_37_128_chunk
+         ->  Custom Scan (DecompressChunk) on _hyper_36_129_chunk
                ->  Sort
-                     Sort Key: compress_hyper_37_137_chunk._ts_meta_sequence_num DESC
-                     ->  Seq Scan on compress_hyper_37_137_chunk
+                     Sort Key: compress_hyper_37_130_chunk._ts_meta_sequence_num DESC
+                     ->  Seq Scan on compress_hyper_37_130_chunk
 (25 rows)
 
 -- make second one of them partial
@@ -2280,33 +2285,33 @@ EXPLAIN (COSTS OFF) SELECT * FROM space_part ORDER BY time;
  Custom Scan (ChunkAppend) on space_part
    Order: space_part."time"
    ->  Merge Append
-         Sort Key: _hyper_36_130_chunk."time"
-         ->  Custom Scan (DecompressChunk) on _hyper_36_130_chunk
+         Sort Key: _hyper_36_123_chunk."time"
+         ->  Custom Scan (DecompressChunk) on _hyper_36_123_chunk
                ->  Sort
-                     Sort Key: compress_hyper_37_132_chunk._ts_meta_sequence_num DESC
-                     ->  Seq Scan on compress_hyper_37_132_chunk
+                     Sort Key: compress_hyper_37_125_chunk._ts_meta_sequence_num DESC
+                     ->  Seq Scan on compress_hyper_37_125_chunk
          ->  Sort
-               Sort Key: _hyper_36_130_chunk."time"
-               ->  Seq Scan on _hyper_36_130_chunk
-   ->  Custom Scan (DecompressChunk) on _hyper_36_131_chunk
+               Sort Key: _hyper_36_123_chunk."time"
+               ->  Seq Scan on _hyper_36_123_chunk
+   ->  Custom Scan (DecompressChunk) on _hyper_36_124_chunk
          ->  Sort
-               Sort Key: compress_hyper_37_133_chunk._ts_meta_sequence_num DESC
-               ->  Seq Scan on compress_hyper_37_133_chunk
+               Sort Key: compress_hyper_37_126_chunk._ts_meta_sequence_num DESC
+               ->  Seq Scan on compress_hyper_37_126_chunk
    ->  Merge Append
-         Sort Key: _hyper_36_134_chunk."time"
-         ->  Custom Scan (DecompressChunk) on _hyper_36_134_chunk
+         Sort Key: _hyper_36_127_chunk."time"
+         ->  Custom Scan (DecompressChunk) on _hyper_36_127_chunk
                ->  Sort
-                     Sort Key: compress_hyper_37_136_chunk._ts_meta_sequence_num DESC
-                     ->  Seq Scan on compress_hyper_37_136_chunk
-         ->  Custom Scan (DecompressChunk) on _hyper_36_135_chunk
+                     Sort Key: compress_hyper_37_128_chunk._ts_meta_sequence_num DESC
+                     ->  Seq Scan on compress_hyper_37_128_chunk
+         ->  Custom Scan (DecompressChunk) on _hyper_36_129_chunk
                ->  Sort
-                     Sort Key: compress_hyper_37_137_chunk._ts_meta_sequence_num DESC
-                     ->  Seq Scan on compress_hyper_37_137_chunk
+                     Sort Key: compress_hyper_37_130_chunk._ts_meta_sequence_num DESC
+                     ->  Seq Scan on compress_hyper_37_130_chunk
          ->  Sort
-               Sort Key: _hyper_36_135_chunk."time"
+               Sort Key: _hyper_36_129_chunk."time"
                ->  Sort
-                     Sort Key: _hyper_36_135_chunk."time"
-                     ->  Seq Scan on _hyper_36_135_chunk
+                     Sort Key: _hyper_36_129_chunk."time"
+                     ->  Seq Scan on _hyper_36_129_chunk
 (30 rows)
 
 -- make other one partial too
@@ -2318,37 +2323,37 @@ EXPLAIN (COSTS OFF) SELECT * FROM space_part ORDER BY time;
  Custom Scan (ChunkAppend) on space_part
    Order: space_part."time"
    ->  Merge Append
-         Sort Key: _hyper_36_130_chunk."time"
-         ->  Custom Scan (DecompressChunk) on _hyper_36_130_chunk
+         Sort Key: _hyper_36_123_chunk."time"
+         ->  Custom Scan (DecompressChunk) on _hyper_36_123_chunk
                ->  Sort
-                     Sort Key: compress_hyper_37_132_chunk._ts_meta_sequence_num DESC
-                     ->  Seq Scan on compress_hyper_37_132_chunk
+                     Sort Key: compress_hyper_37_125_chunk._ts_meta_sequence_num DESC
+                     ->  Seq Scan on compress_hyper_37_125_chunk
          ->  Sort
-               Sort Key: _hyper_36_130_chunk."time"
-               ->  Seq Scan on _hyper_36_130_chunk
-   ->  Custom Scan (DecompressChunk) on _hyper_36_131_chunk
+               Sort Key: _hyper_36_123_chunk."time"
+               ->  Seq Scan on _hyper_36_123_chunk
+   ->  Custom Scan (DecompressChunk) on _hyper_36_124_chunk
          ->  Sort
-               Sort Key: compress_hyper_37_133_chunk._ts_meta_sequence_num DESC
-               ->  Seq Scan on compress_hyper_37_133_chunk
+               Sort Key: compress_hyper_37_126_chunk._ts_meta_sequence_num DESC
+               ->  Seq Scan on compress_hyper_37_126_chunk
    ->  Merge Append
-         Sort Key: _hyper_36_134_chunk."time"
-         ->  Custom Scan (DecompressChunk) on _hyper_36_134_chunk
+         Sort Key: _hyper_36_127_chunk."time"
+         ->  Custom Scan (DecompressChunk) on _hyper_36_127_chunk
                ->  Sort
-                     Sort Key: compress_hyper_37_136_chunk._ts_meta_sequence_num DESC
-                     ->  Seq Scan on compress_hyper_37_136_chunk
+                     Sort Key: compress_hyper_37_128_chunk._ts_meta_sequence_num DESC
+                     ->  Seq Scan on compress_hyper_37_128_chunk
          ->  Sort
-               Sort Key: _hyper_36_134_chunk."time"
+               Sort Key: _hyper_36_127_chunk."time"
                ->  Sort
-                     Sort Key: _hyper_36_134_chunk."time"
-                     ->  Seq Scan on _hyper_36_134_chunk
-         ->  Custom Scan (DecompressChunk) on _hyper_36_135_chunk
+                     Sort Key: _hyper_36_127_chunk."time"
+                     ->  Seq Scan on _hyper_36_127_chunk
+         ->  Custom Scan (DecompressChunk) on _hyper_36_129_chunk
                ->  Sort
-                     Sort Key: compress_hyper_37_137_chunk._ts_meta_sequence_num DESC
-                     ->  Seq Scan on compress_hyper_37_137_chunk
+                     Sort Key: compress_hyper_37_130_chunk._ts_meta_sequence_num DESC
+                     ->  Seq Scan on compress_hyper_37_130_chunk
          ->  Sort
-               Sort Key: _hyper_36_135_chunk."time"
+               Sort Key: _hyper_36_129_chunk."time"
                ->  Sort
-                     Sort Key: _hyper_36_135_chunk."time"
-                     ->  Seq Scan on _hyper_36_135_chunk
+                     Sort Key: _hyper_36_129_chunk."time"
+                     ->  Seq Scan on _hyper_36_129_chunk
 (35 rows)
 

--- a/tsl/test/expected/compression_errors.out
+++ b/tsl/test/expected/compression_errors.out
@@ -226,15 +226,15 @@ select hc.* from _timescaledb_catalog.hypertable_compression hc inner join _time
 
 select decompress_chunk(ch1.schema_name|| '.' || ch1.table_name)
 FROM _timescaledb_catalog.chunk ch1, _timescaledb_catalog.hypertable ht where ch1.hypertable_id = ht.id and ht.table_name like 'foo' ORDER BY ch1.id limit 1;
-ERROR:  chunk "_hyper_15_2_chunk" is not compressed
+ERROR:  chunk "_hyper_15_2_chunk" is already decompressed
 --test changing the segment by columns
 ALTER TABLE foo set (timescaledb.compress, timescaledb.compress_orderby = 'a', timescaledb.compress_segmentby = 'b');
 select ch1.schema_name|| '.' || ch1.table_name AS "CHUNK_NAME"
 FROM _timescaledb_catalog.chunk ch1, _timescaledb_catalog.hypertable ht where ch1.hypertable_id = ht.id and ht.table_name like 'foo' ORDER BY ch1.id limit 1 \gset
 select decompress_chunk(:'CHUNK_NAME');
-ERROR:  chunk "_hyper_15_2_chunk" is not compressed
+ERROR:  chunk "_hyper_15_2_chunk" is already decompressed
 select decompress_chunk(:'CHUNK_NAME', if_compressed=>true);
-NOTICE:  chunk "_hyper_15_2_chunk" is not compressed
+NOTICE:  chunk "_hyper_15_2_chunk" is already decompressed
  decompress_chunk 
 ------------------
  
@@ -274,7 +274,7 @@ FROM _timescaledb_catalog.chunk ch1, _timescaledb_catalog.hypertable ht where ch
 ERROR:  missing compressed hypertable
 --should succeed
 select decompress_chunk(ch1.schema_name|| '.' || ch1.table_name)
-FROM _timescaledb_catalog.chunk ch1, _timescaledb_catalog.hypertable ht where ch1.hypertable_id = ht.id and ht.table_name like 'foo' and ch1.compressed_chunk_id IS NOT NULL;
+FROM _timescaledb_catalog.chunk ch1, _timescaledb_catalog.hypertable ht where ch1.hypertable_id = ht.id and ht.table_name like 'foo' and ch1.status & 1 > 0;
             decompress_chunk             
 -----------------------------------------
  _timescaledb_internal._hyper_15_2_chunk
@@ -388,9 +388,9 @@ where ch1.hypertable_id = ht.id and ht.table_name like 'table_constr'
 ORDER BY ch1.id limit 1 \gset
 -- we have 1 compressed and 1 uncompressed chunk after this.
 select compress_chunk(:'CHUNK_NAME');
-             compress_chunk              
------------------------------------------
- _timescaledb_internal._hyper_19_7_chunk
+              compress_chunk              
+------------------------------------------
+ _timescaledb_internal._hyper_19_18_chunk
 (1 row)
 
 SELECT  total_chunks , number_compressed_chunks
@@ -427,7 +427,7 @@ WHERE ch1.hypertable_id = ht.id and ht.table_name like 'table_constr2' \gset
 SELECT compress_chunk(:'CHUNK_NAME');
               compress_chunk              
 ------------------------------------------
- _timescaledb_internal._hyper_25_10_chunk
+ _timescaledb_internal._hyper_25_22_chunk
 (1 row)
 
 ALTER TABLE table_constr2 set (timescaledb.compress=false);
@@ -437,7 +437,7 @@ DETAIL:  There are compressed chunks that prevent changing the existing compress
 SELECT decompress_chunk(:'CHUNK_NAME');
              decompress_chunk             
 ------------------------------------------
- _timescaledb_internal._hyper_25_10_chunk
+ _timescaledb_internal._hyper_25_22_chunk
 (1 row)
 
 ALTER TABLE table_constr2 SET (timescaledb.compress=false);
@@ -532,7 +532,7 @@ FROM generate_series('2021-08-17 00:00:00'::timestamp,
 SELECT compress_chunk(show_chunks('metric'));
               compress_chunk              
 ------------------------------------------
- _timescaledb_internal._hyper_29_17_chunk
+ _timescaledb_internal._hyper_29_34_chunk
 (1 row)
 
 -- column does not exist the first time
@@ -583,14 +583,14 @@ EXPLAIN SELECT DISTINCT 1 FROM test;
 ----------------------------------------------------------------------------------
  Unique  (cost=0.00..50.80 rows=1 width=4)
    ->  Result  (cost=0.00..50.80 rows=2040 width=4)
-         ->  Seq Scan on _hyper_31_19_chunk  (cost=0.00..30.40 rows=2040 width=0)
+         ->  Seq Scan on _hyper_31_36_chunk  (cost=0.00..30.40 rows=2040 width=0)
 (3 rows)
 
 --compress chunks
 SELECT COMPRESS_CHUNK(X) FROM SHOW_CHUNKS('test') X;
               compress_chunk              
 ------------------------------------------
- _timescaledb_internal._hyper_31_19_chunk
+ _timescaledb_internal._hyper_31_36_chunk
 (1 row)
 
 ANALYZE test;
@@ -607,8 +607,8 @@ EXPLAIN SELECT DISTINCT 1 FROM test;
 ------------------------------------------------------------------------------------------------------
  Unique  (cost=0.51..21.02 rows=1 width=4)
    ->  Result  (cost=0.51..21.02 rows=2000 width=4)
-         ->  Custom Scan (DecompressChunk) on _hyper_31_19_chunk  (cost=0.51..1.02 rows=2000 width=0)
-               ->  Seq Scan on compress_hyper_32_20_chunk  (cost=0.00..1.02 rows=2 width=4)
+         ->  Custom Scan (DecompressChunk) on _hyper_31_36_chunk  (cost=0.51..1.02 rows=2000 width=0)
+               ->  Seq Scan on compress_hyper_32_37_chunk  (cost=0.00..1.02 rows=2 width=4)
 (4 rows)
 
 --github issue 4398
@@ -632,6 +632,7 @@ INSERT INTO ts_table SELECT * FROM data_table;
 --cleanup tables
 DROP TABLE data_table cascade;
 DROP TABLE ts_table cascade;
+NOTICE:  drop cascades to table _timescaledb_internal.compress_hyper_34_39_chunk
 -- #5458 invalid reads for row expressions after column dropped on compressed tables
 CREATE TABLE readings(
     "time"  TIMESTAMPTZ NOT NULL,
@@ -651,7 +652,7 @@ ALTER TABLE readings SET (timescaledb.compress,timescaledb.compress_segmentby = 
 SELECT compress_chunk(show_chunks('readings'));
               compress_chunk              
 ------------------------------------------
- _timescaledb_internal._hyper_35_22_chunk
+ _timescaledb_internal._hyper_35_40_chunk
 (1 row)
 
 ALTER TABLE readings DROP COLUMN battery_status;
@@ -665,25 +666,25 @@ SELECT readings FROM readings;
 
 -- #5577 On-insert decompression after schema changes may not work properly
 SELECT decompress_chunk(show_chunks('readings'),true);
-NOTICE:  chunk "_hyper_35_24_chunk" is not compressed
+NOTICE:  chunk "_hyper_35_42_chunk" is already decompressed
              decompress_chunk             
 ------------------------------------------
- _timescaledb_internal._hyper_35_22_chunk
+ _timescaledb_internal._hyper_35_40_chunk
  
 (2 rows)
 
 SELECT compress_chunk(show_chunks('readings'),true);
               compress_chunk              
 ------------------------------------------
- _timescaledb_internal._hyper_35_22_chunk
- _timescaledb_internal._hyper_35_24_chunk
+ _timescaledb_internal._hyper_35_40_chunk
+ _timescaledb_internal._hyper_35_42_chunk
 (2 rows)
 
 \set ON_ERROR_STOP 0
 INSERT INTO readings ("time", battery_temperature) VALUES
     ('2022-11-11 11:11:11',0.2) -- same record as inserted
 ;
-ERROR:  duplicate key value violates unique constraint "_hyper_35_24_chunk_readings_uniq_idx"
+ERROR:  duplicate key value violates unique constraint "_hyper_35_42_chunk_readings_uniq_idx"
 \set ON_ERROR_STOP 1
 SELECT * from readings;
              time             | battery_temperature 
@@ -702,8 +703,8 @@ SELECT assert_equal(count(1), 2::bigint) FROM readings;
 SELECT decompress_chunk(show_chunks('readings'),true);
              decompress_chunk             
 ------------------------------------------
- _timescaledb_internal._hyper_35_22_chunk
- _timescaledb_internal._hyper_35_24_chunk
+ _timescaledb_internal._hyper_35_40_chunk
+ _timescaledb_internal._hyper_35_42_chunk
 (2 rows)
 
 -- #5553 Unique constraints are not always respected on compressed tables
@@ -725,19 +726,19 @@ ALTER TABLE main_table SET (
 SELECT compress_chunk(show_chunks('main_table'));
               compress_chunk              
 ------------------------------------------
- _timescaledb_internal._hyper_37_27_chunk
+ _timescaledb_internal._hyper_37_44_chunk
 (1 row)
 
 -- insert rejected
 \set ON_ERROR_STOP 0
 INSERT INTO main_table VALUES
     ('2011-11-11 11:11:11', 'foo');
-ERROR:  duplicate key value violates unique constraint "_hyper_37_27_chunk_xm"
+ERROR:  duplicate key value violates unique constraint "_hyper_37_44_chunk_xm"
 -- insert rejected in case 1st row doesn't violate constraint with different segmentby
 INSERT INTO main_table VALUES
     ('2011-11-11 11:12:11', 'bar'),
     ('2011-11-11 11:11:11', 'foo');
-ERROR:  duplicate key value violates unique constraint "_hyper_37_27_chunk_xm"
+ERROR:  duplicate key value violates unique constraint "_hyper_37_44_chunk_xm"
 \set ON_ERROR_STOP 1
 SELECT assert_equal(count(1), 1::bigint) FROM main_table;
  assert_equal 
@@ -749,7 +750,7 @@ SELECT assert_equal(count(1), 1::bigint) FROM main_table;
 SELECT decompress_chunk(show_chunks('main_table'), TRUE);
              decompress_chunk             
 ------------------------------------------
- _timescaledb_internal._hyper_37_27_chunk
+ _timescaledb_internal._hyper_37_44_chunk
 (1 row)
 
 DROP TABLE IF EXISTS readings;
@@ -775,7 +776,7 @@ INSERT INTO readings("time", candy, battery_temperature)
 SELECT compress_chunk(show_chunks('readings'), TRUE);
               compress_chunk              
 ------------------------------------------
- _timescaledb_internal._hyper_39_29_chunk
+ _timescaledb_internal._hyper_39_46_chunk
 (1 row)
 
 -- no error happens

--- a/tsl/test/expected/compression_hypertable.out
+++ b/tsl/test/expected/compression_hypertable.out
@@ -171,8 +171,8 @@ select * from _timescaledb_internal._hyper_1_10_chunk;
  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_10_chunk (actual rows=24 loops=1)
    Output: _hyper_1_10_chunk."Time", _hyper_1_10_chunk.i, _hyper_1_10_chunk.b, _hyper_1_10_chunk.t
    Bulk Decompression: true
-   ->  Seq Scan on _timescaledb_internal.compress_hyper_2_55_chunk (actual rows=1 loops=1)
-         Output: compress_hyper_2_55_chunk."Time", compress_hyper_2_55_chunk.i, compress_hyper_2_55_chunk.b, compress_hyper_2_55_chunk.t, compress_hyper_2_55_chunk._ts_meta_count, compress_hyper_2_55_chunk._ts_meta_sequence_num, compress_hyper_2_55_chunk._ts_meta_min_1, compress_hyper_2_55_chunk._ts_meta_max_1
+   ->  Seq Scan on _timescaledb_internal.compress_hyper_2_37_chunk (actual rows=1 loops=1)
+         Output: compress_hyper_2_37_chunk."Time", compress_hyper_2_37_chunk.i, compress_hyper_2_37_chunk.b, compress_hyper_2_37_chunk.t, compress_hyper_2_37_chunk._ts_meta_count, compress_hyper_2_37_chunk._ts_meta_sequence_num, compress_hyper_2_37_chunk._ts_meta_min_1, compress_hyper_2_37_chunk._ts_meta_max_1
 (5 rows)
 
 set timescaledb.enable_bulk_decompression to false;
@@ -183,8 +183,8 @@ select * from _timescaledb_internal._hyper_1_10_chunk;
  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_10_chunk (actual rows=24 loops=1)
    Output: _hyper_1_10_chunk."Time", _hyper_1_10_chunk.i, _hyper_1_10_chunk.b, _hyper_1_10_chunk.t
    Bulk Decompression: false
-   ->  Seq Scan on _timescaledb_internal.compress_hyper_2_55_chunk (actual rows=1 loops=1)
-         Output: compress_hyper_2_55_chunk."Time", compress_hyper_2_55_chunk.i, compress_hyper_2_55_chunk.b, compress_hyper_2_55_chunk.t, compress_hyper_2_55_chunk._ts_meta_count, compress_hyper_2_55_chunk._ts_meta_sequence_num, compress_hyper_2_55_chunk._ts_meta_min_1, compress_hyper_2_55_chunk._ts_meta_max_1
+   ->  Seq Scan on _timescaledb_internal.compress_hyper_2_37_chunk (actual rows=1 loops=1)
+         Output: compress_hyper_2_37_chunk."Time", compress_hyper_2_37_chunk.i, compress_hyper_2_37_chunk.b, compress_hyper_2_37_chunk.t, compress_hyper_2_37_chunk._ts_meta_count, compress_hyper_2_37_chunk._ts_meta_sequence_num, compress_hyper_2_37_chunk._ts_meta_min_1, compress_hyper_2_37_chunk._ts_meta_max_1
 (5 rows)
 
 reset timescaledb.enable_bulk_decompression;
@@ -693,12 +693,12 @@ insert into test8
 select compress_chunk(x) from show_chunks('test8') x;
               compress_chunk               
 -------------------------------------------
- _timescaledb_internal._hyper_13_148_chunk
- _timescaledb_internal._hyper_13_149_chunk
- _timescaledb_internal._hyper_13_150_chunk
- _timescaledb_internal._hyper_13_151_chunk
- _timescaledb_internal._hyper_13_152_chunk
- _timescaledb_internal._hyper_13_153_chunk
+ _timescaledb_internal._hyper_13_99_chunk
+ _timescaledb_internal._hyper_13_101_chunk
+ _timescaledb_internal._hyper_13_103_chunk
+ _timescaledb_internal._hyper_13_105_chunk
+ _timescaledb_internal._hyper_13_107_chunk
+ _timescaledb_internal._hyper_13_109_chunk
 (6 rows)
 
 select distinct on (id) * from test8

--- a/tsl/test/expected/compression_indexscan.out
+++ b/tsl/test/expected/compression_indexscan.out
@@ -653,16 +653,16 @@ INFO:  compress_chunk_tuplesort_start
 
 SET timescaledb.enable_compression_indexscan = 'ON';
 SELECT compress_chunk(show_chunks('tab2'));
-INFO:  compress_chunk_indexscan_start matched index "_hyper_2_81_chunk_idx2_asc_null_first"
-INFO:  compress_chunk_indexscan_start matched index "_hyper_2_82_chunk_idx2_asc_null_first"
-INFO:  compress_chunk_indexscan_start matched index "_hyper_2_83_chunk_idx2_asc_null_first"
-INFO:  compress_chunk_indexscan_start matched index "_hyper_2_84_chunk_idx2_asc_null_first"
+INFO:  compress_chunk_indexscan_start matched index "_hyper_2_73_chunk_idx2_asc_null_first"
+INFO:  compress_chunk_indexscan_start matched index "_hyper_2_74_chunk_idx2_asc_null_first"
+INFO:  compress_chunk_indexscan_start matched index "_hyper_2_75_chunk_idx2_asc_null_first"
+INFO:  compress_chunk_indexscan_start matched index "_hyper_2_76_chunk_idx2_asc_null_first"
              compress_chunk              
 -----------------------------------------
- _timescaledb_internal._hyper_2_81_chunk
- _timescaledb_internal._hyper_2_82_chunk
- _timescaledb_internal._hyper_2_83_chunk
- _timescaledb_internal._hyper_2_84_chunk
+ _timescaledb_internal._hyper_2_73_chunk
+ _timescaledb_internal._hyper_2_74_chunk
+ _timescaledb_internal._hyper_2_75_chunk
+ _timescaledb_internal._hyper_2_76_chunk
 (4 rows)
 
 SELECT id, time from tab1 EXCEPT SELECT id, time from tab2;
@@ -682,10 +682,10 @@ SELECT decompress_chunk(show_chunks('tab1'));
 SELECT decompress_chunk(show_chunks('tab2'));
             decompress_chunk             
 -----------------------------------------
- _timescaledb_internal._hyper_2_81_chunk
- _timescaledb_internal._hyper_2_82_chunk
- _timescaledb_internal._hyper_2_83_chunk
- _timescaledb_internal._hyper_2_84_chunk
+ _timescaledb_internal._hyper_2_73_chunk
+ _timescaledb_internal._hyper_2_74_chunk
+ _timescaledb_internal._hyper_2_75_chunk
+ _timescaledb_internal._hyper_2_76_chunk
 (4 rows)
 
 DROP INDEX idx2_asc_null_first;
@@ -719,42 +719,42 @@ INFO:  compress_chunk_tuplesort_start
 INFO:  compress_chunk_tuplesort_start
               compress_chunk              
 ------------------------------------------
- _timescaledb_internal._hyper_22_93_chunk
- _timescaledb_internal._hyper_22_94_chunk
- _timescaledb_internal._hyper_22_95_chunk
- _timescaledb_internal._hyper_22_96_chunk
+ _timescaledb_internal._hyper_22_85_chunk
+ _timescaledb_internal._hyper_22_86_chunk
+ _timescaledb_internal._hyper_22_87_chunk
+ _timescaledb_internal._hyper_22_88_chunk
 (4 rows)
 
 SELECT decompress_chunk(show_chunks('tab3'));
              decompress_chunk             
 ------------------------------------------
- _timescaledb_internal._hyper_22_93_chunk
- _timescaledb_internal._hyper_22_94_chunk
- _timescaledb_internal._hyper_22_95_chunk
- _timescaledb_internal._hyper_22_96_chunk
+ _timescaledb_internal._hyper_22_85_chunk
+ _timescaledb_internal._hyper_22_86_chunk
+ _timescaledb_internal._hyper_22_87_chunk
+ _timescaledb_internal._hyper_22_88_chunk
 (4 rows)
 
 CREATE INDEX idxcol_asc_null_first ON tab3(name, time ASC NULLS FIRST);
 SELECT compress_chunk(show_chunks('tab3'));
-INFO:  compress_chunk_indexscan_start matched index "_hyper_22_93_chunk_idxcol_asc_null_first"
-INFO:  compress_chunk_indexscan_start matched index "_hyper_22_94_chunk_idxcol_asc_null_first"
-INFO:  compress_chunk_indexscan_start matched index "_hyper_22_95_chunk_idxcol_asc_null_first"
-INFO:  compress_chunk_indexscan_start matched index "_hyper_22_96_chunk_idxcol_asc_null_first"
+INFO:  compress_chunk_indexscan_start matched index "_hyper_22_85_chunk_idxcol_asc_null_first"
+INFO:  compress_chunk_indexscan_start matched index "_hyper_22_86_chunk_idxcol_asc_null_first"
+INFO:  compress_chunk_indexscan_start matched index "_hyper_22_87_chunk_idxcol_asc_null_first"
+INFO:  compress_chunk_indexscan_start matched index "_hyper_22_88_chunk_idxcol_asc_null_first"
               compress_chunk              
 ------------------------------------------
- _timescaledb_internal._hyper_22_93_chunk
- _timescaledb_internal._hyper_22_94_chunk
- _timescaledb_internal._hyper_22_95_chunk
- _timescaledb_internal._hyper_22_96_chunk
+ _timescaledb_internal._hyper_22_85_chunk
+ _timescaledb_internal._hyper_22_86_chunk
+ _timescaledb_internal._hyper_22_87_chunk
+ _timescaledb_internal._hyper_22_88_chunk
 (4 rows)
 
 SELECT decompress_chunk(show_chunks('tab3'));
              decompress_chunk             
 ------------------------------------------
- _timescaledb_internal._hyper_22_93_chunk
- _timescaledb_internal._hyper_22_94_chunk
- _timescaledb_internal._hyper_22_95_chunk
- _timescaledb_internal._hyper_22_96_chunk
+ _timescaledb_internal._hyper_22_85_chunk
+ _timescaledb_internal._hyper_22_86_chunk
+ _timescaledb_internal._hyper_22_87_chunk
+ _timescaledb_internal._hyper_22_88_chunk
 (4 rows)
 
 DROP INDEX idx_asc_null_first;
@@ -769,42 +769,42 @@ INFO:  compress_chunk_tuplesort_start
 INFO:  compress_chunk_tuplesort_start
               compress_chunk              
 ------------------------------------------
- _timescaledb_internal._hyper_22_93_chunk
- _timescaledb_internal._hyper_22_94_chunk
- _timescaledb_internal._hyper_22_95_chunk
- _timescaledb_internal._hyper_22_96_chunk
+ _timescaledb_internal._hyper_22_85_chunk
+ _timescaledb_internal._hyper_22_86_chunk
+ _timescaledb_internal._hyper_22_87_chunk
+ _timescaledb_internal._hyper_22_88_chunk
 (4 rows)
 
 SELECT decompress_chunk(show_chunks('tab3'));
              decompress_chunk             
 ------------------------------------------
- _timescaledb_internal._hyper_22_93_chunk
- _timescaledb_internal._hyper_22_94_chunk
- _timescaledb_internal._hyper_22_95_chunk
- _timescaledb_internal._hyper_22_96_chunk
+ _timescaledb_internal._hyper_22_85_chunk
+ _timescaledb_internal._hyper_22_86_chunk
+ _timescaledb_internal._hyper_22_87_chunk
+ _timescaledb_internal._hyper_22_88_chunk
 (4 rows)
 
 CREATE INDEX idxcol_asc_null_first ON tab3(name, time ASC NULLS FIRST);
 SELECT compress_chunk(show_chunks('tab3'));
-INFO:  compress_chunk_indexscan_start matched index "_hyper_22_93_chunk_idxcol_asc_null_first"
-INFO:  compress_chunk_indexscan_start matched index "_hyper_22_94_chunk_idxcol_asc_null_first"
-INFO:  compress_chunk_indexscan_start matched index "_hyper_22_95_chunk_idxcol_asc_null_first"
-INFO:  compress_chunk_indexscan_start matched index "_hyper_22_96_chunk_idxcol_asc_null_first"
+INFO:  compress_chunk_indexscan_start matched index "_hyper_22_85_chunk_idxcol_asc_null_first"
+INFO:  compress_chunk_indexscan_start matched index "_hyper_22_86_chunk_idxcol_asc_null_first"
+INFO:  compress_chunk_indexscan_start matched index "_hyper_22_87_chunk_idxcol_asc_null_first"
+INFO:  compress_chunk_indexscan_start matched index "_hyper_22_88_chunk_idxcol_asc_null_first"
               compress_chunk              
 ------------------------------------------
- _timescaledb_internal._hyper_22_93_chunk
- _timescaledb_internal._hyper_22_94_chunk
- _timescaledb_internal._hyper_22_95_chunk
- _timescaledb_internal._hyper_22_96_chunk
+ _timescaledb_internal._hyper_22_85_chunk
+ _timescaledb_internal._hyper_22_86_chunk
+ _timescaledb_internal._hyper_22_87_chunk
+ _timescaledb_internal._hyper_22_88_chunk
 (4 rows)
 
 SELECT decompress_chunk(show_chunks('tab3'));
              decompress_chunk             
 ------------------------------------------
- _timescaledb_internal._hyper_22_93_chunk
- _timescaledb_internal._hyper_22_94_chunk
- _timescaledb_internal._hyper_22_95_chunk
- _timescaledb_internal._hyper_22_96_chunk
+ _timescaledb_internal._hyper_22_85_chunk
+ _timescaledb_internal._hyper_22_86_chunk
+ _timescaledb_internal._hyper_22_87_chunk
+ _timescaledb_internal._hyper_22_88_chunk
 (4 rows)
 
 DROP INDEX idx_asc_null_first;

--- a/tsl/test/expected/compression_insert.out
+++ b/tsl/test/expected/compression_insert.out
@@ -418,7 +418,7 @@ FROM show_chunks('test_gen') c;
              compress_chunk              
 -----------------------------------------
  _timescaledb_internal._hyper_9_11_chunk
- _timescaledb_internal._hyper_9_12_chunk
+ _timescaledb_internal._hyper_9_13_chunk
 (2 rows)
 
 INSERT INTO test_gen (payload) values(17);
@@ -718,7 +718,7 @@ NOTICE:  chunk "_hyper_11_15_chunk" is already compressed
               compress_chunk              
 ------------------------------------------
  _timescaledb_internal._hyper_11_15_chunk
- _timescaledb_internal._hyper_11_18_chunk
+ _timescaledb_internal._hyper_11_19_chunk
 (2 rows)
 
 CREATE TRIGGER t1_mod BEFORE INSERT ON trigger_test FOR EACH ROW EXECUTE FUNCTION row_trig_value_mod();
@@ -733,7 +733,7 @@ INSERT INTO trigger_test VALUES
                    ( '2000-01-01',1,11, 'eleven', 111),
                    ( '2010-01-01',10,10, 'ten', 222);
 NOTICE:  Trigger t1_mod BEFORE INSERT ROW on _hyper_11_15_chunk: ("Sat Jan 01 00:00:00 2000 PST",1,11,eleven,111) <NULL>
-NOTICE:  Trigger t1_mod BEFORE INSERT ROW on _hyper_11_18_chunk: ("Fri Jan 01 00:00:00 2010 PST",10,10,ten,222) <NULL>
+NOTICE:  Trigger t1_mod BEFORE INSERT ROW on _hyper_11_19_chunk: ("Fri Jan 01 00:00:00 2010 PST",10,10,ten,222) <NULL>
 SELECT * FROM trigger_test ORDER BY 1 ,2, 3, 5;
              time             | device | value | addcolv | addcoli 
 ------------------------------+--------+-------+---------+---------
@@ -772,23 +772,23 @@ INSERT INTO test_ordering VALUES (5),(4),(3);
 :PREFIX SELECT * FROM test_ordering ORDER BY 1;
                                            QUERY PLAN                                           
 ------------------------------------------------------------------------------------------------
- Index Only Scan Backward using _hyper_13_20_chunk_test_ordering_time_idx on _hyper_13_20_chunk
+ Index Only Scan Backward using _hyper_13_21_chunk_test_ordering_time_idx on _hyper_13_21_chunk
 (1 row)
 
 SELECT compress_chunk(format('%I.%I',chunk_schema,chunk_name), true) FROM timescaledb_information.chunks WHERE hypertable_name = 'test_ordering';
               compress_chunk              
 ------------------------------------------
- _timescaledb_internal._hyper_13_20_chunk
+ _timescaledb_internal._hyper_13_21_chunk
 (1 row)
 
 -- should be ordered append
 :PREFIX SELECT * FROM test_ordering ORDER BY 1;
                                QUERY PLAN                                
 -------------------------------------------------------------------------
- Custom Scan (DecompressChunk) on _hyper_13_20_chunk
+ Custom Scan (DecompressChunk) on _hyper_13_21_chunk
    ->  Sort
-         Sort Key: compress_hyper_14_21_chunk._ts_meta_sequence_num DESC
-         ->  Seq Scan on compress_hyper_14_21_chunk
+         Sort Key: compress_hyper_14_22_chunk._ts_meta_sequence_num DESC
+         ->  Seq Scan on compress_hyper_14_22_chunk
 (4 rows)
 
 INSERT INTO test_ordering SELECT 1;
@@ -805,14 +805,14 @@ INSERT INTO test_ordering SELECT 1;
  Custom Scan (ChunkAppend) on test_ordering
    Order: test_ordering."time"
    ->  Merge Append
-         Sort Key: _hyper_13_20_chunk."time"
-         ->  Custom Scan (DecompressChunk) on _hyper_13_20_chunk
+         Sort Key: _hyper_13_21_chunk."time"
+         ->  Custom Scan (DecompressChunk) on _hyper_13_21_chunk
                ->  Sort
-                     Sort Key: compress_hyper_14_21_chunk._ts_meta_sequence_num DESC
-                     ->  Seq Scan on compress_hyper_14_21_chunk
+                     Sort Key: compress_hyper_14_22_chunk._ts_meta_sequence_num DESC
+                     ->  Seq Scan on compress_hyper_14_22_chunk
          ->  Sort
-               Sort Key: _hyper_13_20_chunk."time"
-               ->  Seq Scan on _hyper_13_20_chunk
+               Sort Key: _hyper_13_21_chunk."time"
+               ->  Seq Scan on _hyper_13_21_chunk
 (11 rows)
 
 INSERT INTO test_ordering VALUES (105),(104),(103);
@@ -823,15 +823,15 @@ INSERT INTO test_ordering VALUES (105),(104),(103);
  Custom Scan (ChunkAppend) on test_ordering
    Order: test_ordering."time"
    ->  Merge Append
-         Sort Key: _hyper_13_20_chunk."time"
-         ->  Custom Scan (DecompressChunk) on _hyper_13_20_chunk
+         Sort Key: _hyper_13_21_chunk."time"
+         ->  Custom Scan (DecompressChunk) on _hyper_13_21_chunk
                ->  Sort
-                     Sort Key: compress_hyper_14_21_chunk._ts_meta_sequence_num DESC
-                     ->  Seq Scan on compress_hyper_14_21_chunk
+                     Sort Key: compress_hyper_14_22_chunk._ts_meta_sequence_num DESC
+                     ->  Seq Scan on compress_hyper_14_22_chunk
          ->  Sort
-               Sort Key: _hyper_13_20_chunk."time"
-               ->  Seq Scan on _hyper_13_20_chunk
-   ->  Index Only Scan Backward using _hyper_13_22_chunk_test_ordering_time_idx on _hyper_13_22_chunk
+               Sort Key: _hyper_13_21_chunk."time"
+               ->  Seq Scan on _hyper_13_21_chunk
+   ->  Index Only Scan Backward using _hyper_13_23_chunk_test_ordering_time_idx on _hyper_13_23_chunk
 (12 rows)
 
 --insert into compressed + uncompressed chunk
@@ -860,17 +860,17 @@ INSERT INTO test_ordering VALUES (23), (24), (115) RETURNING *;
 INSERT INTO test_ordering VALUES (23), (24), (115) RETURNING tableoid::regclass, *;
                  tableoid                 | time 
 ------------------------------------------+------
- _timescaledb_internal._hyper_13_20_chunk |   23
- _timescaledb_internal._hyper_13_20_chunk |   24
- _timescaledb_internal._hyper_13_22_chunk |  115
+ _timescaledb_internal._hyper_13_21_chunk |   23
+ _timescaledb_internal._hyper_13_21_chunk |   24
+ _timescaledb_internal._hyper_13_23_chunk |  115
 (3 rows)
 
 SELECT compress_chunk(format('%I.%I',chunk_schema,chunk_name), true) FROM timescaledb_information.chunks WHERE hypertable_name = 'test_ordering';
-NOTICE:  chunk "_hyper_13_20_chunk" is already compressed
+NOTICE:  chunk "_hyper_13_21_chunk" is already compressed
               compress_chunk              
 ------------------------------------------
- _timescaledb_internal._hyper_13_20_chunk
- _timescaledb_internal._hyper_13_22_chunk
+ _timescaledb_internal._hyper_13_21_chunk
+ _timescaledb_internal._hyper_13_23_chunk
 (2 rows)
 
 -- should be ordered append
@@ -880,18 +880,18 @@ NOTICE:  chunk "_hyper_13_20_chunk" is already compressed
  Custom Scan (ChunkAppend) on test_ordering
    Order: test_ordering."time"
    ->  Merge Append
-         Sort Key: _hyper_13_20_chunk."time"
-         ->  Custom Scan (DecompressChunk) on _hyper_13_20_chunk
+         Sort Key: _hyper_13_21_chunk."time"
+         ->  Custom Scan (DecompressChunk) on _hyper_13_21_chunk
                ->  Sort
-                     Sort Key: compress_hyper_14_21_chunk._ts_meta_sequence_num DESC
-                     ->  Seq Scan on compress_hyper_14_21_chunk
+                     Sort Key: compress_hyper_14_22_chunk._ts_meta_sequence_num DESC
+                     ->  Seq Scan on compress_hyper_14_22_chunk
          ->  Sort
-               Sort Key: _hyper_13_20_chunk."time"
-               ->  Seq Scan on _hyper_13_20_chunk
-   ->  Custom Scan (DecompressChunk) on _hyper_13_22_chunk
+               Sort Key: _hyper_13_21_chunk."time"
+               ->  Seq Scan on _hyper_13_21_chunk
+   ->  Custom Scan (DecompressChunk) on _hyper_13_23_chunk
          ->  Sort
-               Sort Key: compress_hyper_14_23_chunk._ts_meta_sequence_num DESC
-               ->  Seq Scan on compress_hyper_14_23_chunk
+               Sort Key: compress_hyper_14_24_chunk._ts_meta_sequence_num DESC
+               ->  Seq Scan on compress_hyper_14_24_chunk
 (15 rows)
 
 SET timescaledb.enable_decompression_sorted_merge = 1;
@@ -926,7 +926,7 @@ ALTER TABLE conditions SET (timescaledb.compress);
 SELECT  compress_chunk(ch) FROM show_chunks('conditions') ch;
               compress_chunk              
 ------------------------------------------
- _timescaledb_internal._hyper_15_24_chunk
+ _timescaledb_internal._hyper_15_25_chunk
 (1 row)
 
 SELECT chunk_name, range_start, range_end, is_compressed
@@ -934,7 +934,7 @@ FROM timescaledb_information.chunks
 WHERE hypertable_name = 'conditions';
      chunk_name     |         range_start          |          range_end           | is_compressed 
 --------------------+------------------------------+------------------------------+---------------
- _hyper_15_24_chunk | Wed Dec 30 16:00:00 2009 PST | Wed Jan 06 16:00:00 2010 PST | t
+ _hyper_15_25_chunk | Wed Dec 30 16:00:00 2009 PST | Wed Jan 06 16:00:00 2010 PST | t
 (1 row)
 
 --now insert into compressed chunk

--- a/tsl/test/expected/compression_merge.out
+++ b/tsl/test/expected/compression_merge.out
@@ -260,14 +260,23 @@ SELECT
 SELECT compress_chunk(i) FROM show_chunks('test5') i LIMIT 4;
               compress_chunk              
 ------------------------------------------
- _timescaledb_internal._hyper_9_163_chunk
- _timescaledb_internal._hyper_9_163_chunk
- _timescaledb_internal._hyper_9_163_chunk
- _timescaledb_internal._hyper_9_163_chunk
+ _timescaledb_internal._hyper_9_147_chunk
+ _timescaledb_internal._hyper_9_147_chunk
+ _timescaledb_internal._hyper_9_147_chunk
+ _timescaledb_internal._hyper_9_147_chunk
 (4 rows)
 
+SELECT cc.schema_name || '.' || cc.table_name AS "COMPRESSED_CHUNK_NAME"
+FROM _timescaledb_catalog.hypertable h
+INNER JOIN _timescaledb_catalog.chunk c
+ON h.id = c.hypertable_id
+INNER JOIN _timescaledb_catalog.chunk cc
+ON cc.id = c.compressed_chunk_id
+WHERE h.table_name = 'test5'
+AND c.status = 1
+LIMIT 1 \gset
 -- Make sure sequence numbers are correctly fetched from index.
-SELECT _ts_meta_sequence_num FROM _timescaledb_internal.compress_hyper_10_187_chunk where i = 1;
+SELECT _ts_meta_sequence_num FROM :COMPRESSED_CHUNK_NAME where i = 1;
  _ts_meta_sequence_num 
 -----------------------
                     10
@@ -285,18 +294,18 @@ DROP INDEX :INDEXNAME;
 -- We dropped the index from compressed chunk thats needed to determine sequence numbers
 -- during merge, merging will fallback to doing heap scans and work just fine.
 SELECT compress_chunk(i, true) FROM show_chunks('test5') i LIMIT 5;
-NOTICE:  chunk "_hyper_9_163_chunk" is already compressed
+NOTICE:  chunk "_hyper_9_147_chunk" is already compressed
               compress_chunk              
 ------------------------------------------
- _timescaledb_internal._hyper_9_163_chunk
- _timescaledb_internal._hyper_9_163_chunk
- _timescaledb_internal._hyper_9_163_chunk
- _timescaledb_internal._hyper_9_163_chunk
- _timescaledb_internal._hyper_9_163_chunk
+ _timescaledb_internal._hyper_9_147_chunk
+ _timescaledb_internal._hyper_9_147_chunk
+ _timescaledb_internal._hyper_9_147_chunk
+ _timescaledb_internal._hyper_9_147_chunk
+ _timescaledb_internal._hyper_9_147_chunk
 (5 rows)
 
 -- Make sure sequence numbers are correctly fetched from heap.
-SELECT _ts_meta_sequence_num FROM _timescaledb_internal.compress_hyper_10_187_chunk where i = 1;
+SELECT _ts_meta_sequence_num FROM :COMPRESSED_CHUNK_NAME where i = 1;
  _ts_meta_sequence_num 
 -----------------------
                     10
@@ -315,7 +324,7 @@ SELECT 'test5' AS "HYPERTABLE_NAME" \gset
 -- Please see the included NOTICE for copyright information and
 -- LICENSE-TIMESCALE for a copy of the license.
 \set ECHO errors
-psql:include/compression_test_merge.sql:12: NOTICE:  chunk "_hyper_9_163_chunk" is already compressed
+psql:include/compression_test_merge.sql:12: NOTICE:  chunk "_hyper_9_147_chunk" is already compressed
  count_compressed 
 ------------------
                17
@@ -355,30 +364,30 @@ ALTER TABLE test6 set (timescaledb.compress, timescaledb.compress_segmentby='i',
 SELECT compress_chunk(i) FROM show_chunks('test6') i;
               compress_chunk               
 -------------------------------------------
- _timescaledb_internal._hyper_11_188_chunk
- _timescaledb_internal._hyper_11_188_chunk
- _timescaledb_internal._hyper_11_190_chunk
- _timescaledb_internal._hyper_11_190_chunk
- _timescaledb_internal._hyper_11_192_chunk
- _timescaledb_internal._hyper_11_192_chunk
- _timescaledb_internal._hyper_11_194_chunk
- _timescaledb_internal._hyper_11_194_chunk
- _timescaledb_internal._hyper_11_196_chunk
- _timescaledb_internal._hyper_11_196_chunk
- _timescaledb_internal._hyper_11_198_chunk
- _timescaledb_internal._hyper_11_198_chunk
- _timescaledb_internal._hyper_11_200_chunk
- _timescaledb_internal._hyper_11_200_chunk
- _timescaledb_internal._hyper_11_202_chunk
- _timescaledb_internal._hyper_11_202_chunk
- _timescaledb_internal._hyper_11_204_chunk
- _timescaledb_internal._hyper_11_204_chunk
- _timescaledb_internal._hyper_11_206_chunk
- _timescaledb_internal._hyper_11_206_chunk
- _timescaledb_internal._hyper_11_208_chunk
- _timescaledb_internal._hyper_11_208_chunk
- _timescaledb_internal._hyper_11_210_chunk
- _timescaledb_internal._hyper_11_210_chunk
+ _timescaledb_internal._hyper_11_195_chunk
+ _timescaledb_internal._hyper_11_195_chunk
+ _timescaledb_internal._hyper_11_197_chunk
+ _timescaledb_internal._hyper_11_197_chunk
+ _timescaledb_internal._hyper_11_199_chunk
+ _timescaledb_internal._hyper_11_199_chunk
+ _timescaledb_internal._hyper_11_201_chunk
+ _timescaledb_internal._hyper_11_201_chunk
+ _timescaledb_internal._hyper_11_203_chunk
+ _timescaledb_internal._hyper_11_203_chunk
+ _timescaledb_internal._hyper_11_205_chunk
+ _timescaledb_internal._hyper_11_205_chunk
+ _timescaledb_internal._hyper_11_207_chunk
+ _timescaledb_internal._hyper_11_207_chunk
+ _timescaledb_internal._hyper_11_209_chunk
+ _timescaledb_internal._hyper_11_209_chunk
+ _timescaledb_internal._hyper_11_211_chunk
+ _timescaledb_internal._hyper_11_211_chunk
+ _timescaledb_internal._hyper_11_213_chunk
+ _timescaledb_internal._hyper_11_213_chunk
+ _timescaledb_internal._hyper_11_215_chunk
+ _timescaledb_internal._hyper_11_215_chunk
+ _timescaledb_internal._hyper_11_217_chunk
+ _timescaledb_internal._hyper_11_217_chunk
 (24 rows)
 
 SELECT count(*) as number_of_chunks FROM show_chunks('test6');
@@ -395,56 +404,56 @@ CROSS JOIN generate_series(1, 5, 1) i;
 -- Altering compress chunk time interval will cause us to create 6 chunks from the additional 24 chunks.
 ALTER TABLE test6 set (timescaledb.compress_chunk_time_interval='4 hours');
 SELECT compress_chunk(i, true) FROM show_chunks('test6') i;
-NOTICE:  chunk "_hyper_11_188_chunk" is already compressed
-NOTICE:  chunk "_hyper_11_190_chunk" is already compressed
-NOTICE:  chunk "_hyper_11_192_chunk" is already compressed
-NOTICE:  chunk "_hyper_11_194_chunk" is already compressed
-NOTICE:  chunk "_hyper_11_196_chunk" is already compressed
-NOTICE:  chunk "_hyper_11_198_chunk" is already compressed
-NOTICE:  chunk "_hyper_11_200_chunk" is already compressed
-NOTICE:  chunk "_hyper_11_202_chunk" is already compressed
-NOTICE:  chunk "_hyper_11_204_chunk" is already compressed
-NOTICE:  chunk "_hyper_11_206_chunk" is already compressed
-NOTICE:  chunk "_hyper_11_208_chunk" is already compressed
-NOTICE:  chunk "_hyper_11_210_chunk" is already compressed
+NOTICE:  chunk "_hyper_11_195_chunk" is already compressed
+NOTICE:  chunk "_hyper_11_197_chunk" is already compressed
+NOTICE:  chunk "_hyper_11_199_chunk" is already compressed
+NOTICE:  chunk "_hyper_11_201_chunk" is already compressed
+NOTICE:  chunk "_hyper_11_203_chunk" is already compressed
+NOTICE:  chunk "_hyper_11_205_chunk" is already compressed
+NOTICE:  chunk "_hyper_11_207_chunk" is already compressed
+NOTICE:  chunk "_hyper_11_209_chunk" is already compressed
+NOTICE:  chunk "_hyper_11_211_chunk" is already compressed
+NOTICE:  chunk "_hyper_11_213_chunk" is already compressed
+NOTICE:  chunk "_hyper_11_215_chunk" is already compressed
+NOTICE:  chunk "_hyper_11_217_chunk" is already compressed
               compress_chunk               
 -------------------------------------------
- _timescaledb_internal._hyper_11_188_chunk
- _timescaledb_internal._hyper_11_190_chunk
- _timescaledb_internal._hyper_11_192_chunk
- _timescaledb_internal._hyper_11_194_chunk
- _timescaledb_internal._hyper_11_196_chunk
- _timescaledb_internal._hyper_11_198_chunk
- _timescaledb_internal._hyper_11_200_chunk
- _timescaledb_internal._hyper_11_202_chunk
- _timescaledb_internal._hyper_11_204_chunk
- _timescaledb_internal._hyper_11_206_chunk
- _timescaledb_internal._hyper_11_208_chunk
- _timescaledb_internal._hyper_11_210_chunk
- _timescaledb_internal._hyper_11_210_chunk
- _timescaledb_internal._hyper_11_210_chunk
- _timescaledb_internal._hyper_11_226_chunk
- _timescaledb_internal._hyper_11_226_chunk
- _timescaledb_internal._hyper_11_226_chunk
- _timescaledb_internal._hyper_11_226_chunk
- _timescaledb_internal._hyper_11_230_chunk
- _timescaledb_internal._hyper_11_230_chunk
- _timescaledb_internal._hyper_11_230_chunk
- _timescaledb_internal._hyper_11_230_chunk
- _timescaledb_internal._hyper_11_234_chunk
- _timescaledb_internal._hyper_11_234_chunk
- _timescaledb_internal._hyper_11_234_chunk
- _timescaledb_internal._hyper_11_234_chunk
- _timescaledb_internal._hyper_11_238_chunk
- _timescaledb_internal._hyper_11_238_chunk
- _timescaledb_internal._hyper_11_238_chunk
- _timescaledb_internal._hyper_11_238_chunk
- _timescaledb_internal._hyper_11_242_chunk
- _timescaledb_internal._hyper_11_242_chunk
- _timescaledb_internal._hyper_11_242_chunk
- _timescaledb_internal._hyper_11_242_chunk
- _timescaledb_internal._hyper_11_246_chunk
- _timescaledb_internal._hyper_11_246_chunk
+ _timescaledb_internal._hyper_11_195_chunk
+ _timescaledb_internal._hyper_11_197_chunk
+ _timescaledb_internal._hyper_11_199_chunk
+ _timescaledb_internal._hyper_11_201_chunk
+ _timescaledb_internal._hyper_11_203_chunk
+ _timescaledb_internal._hyper_11_205_chunk
+ _timescaledb_internal._hyper_11_207_chunk
+ _timescaledb_internal._hyper_11_209_chunk
+ _timescaledb_internal._hyper_11_211_chunk
+ _timescaledb_internal._hyper_11_213_chunk
+ _timescaledb_internal._hyper_11_215_chunk
+ _timescaledb_internal._hyper_11_217_chunk
+ _timescaledb_internal._hyper_11_217_chunk
+ _timescaledb_internal._hyper_11_217_chunk
+ _timescaledb_internal._hyper_11_247_chunk
+ _timescaledb_internal._hyper_11_247_chunk
+ _timescaledb_internal._hyper_11_247_chunk
+ _timescaledb_internal._hyper_11_247_chunk
+ _timescaledb_internal._hyper_11_255_chunk
+ _timescaledb_internal._hyper_11_255_chunk
+ _timescaledb_internal._hyper_11_255_chunk
+ _timescaledb_internal._hyper_11_255_chunk
+ _timescaledb_internal._hyper_11_263_chunk
+ _timescaledb_internal._hyper_11_263_chunk
+ _timescaledb_internal._hyper_11_263_chunk
+ _timescaledb_internal._hyper_11_263_chunk
+ _timescaledb_internal._hyper_11_271_chunk
+ _timescaledb_internal._hyper_11_271_chunk
+ _timescaledb_internal._hyper_11_271_chunk
+ _timescaledb_internal._hyper_11_271_chunk
+ _timescaledb_internal._hyper_11_279_chunk
+ _timescaledb_internal._hyper_11_279_chunk
+ _timescaledb_internal._hyper_11_279_chunk
+ _timescaledb_internal._hyper_11_279_chunk
+ _timescaledb_internal._hyper_11_287_chunk
+ _timescaledb_internal._hyper_11_287_chunk
 (36 rows)
 
 SELECT count(*) as number_of_chunks FROM show_chunks('test6');
@@ -463,47 +472,47 @@ CROSS JOIN generate_series(1, 5, 1) i;
 ALTER TABLE test6 set (timescaledb.compress_chunk_time_interval='30 minutes');
 WARNING:  compress chunk interval is not a multiple of chunk interval, you should use a factor of chunk interval to merge as much as possible
 SELECT compress_chunk(i, true) FROM show_chunks('test6') i;
-NOTICE:  chunk "_hyper_11_188_chunk" is already compressed
-NOTICE:  chunk "_hyper_11_190_chunk" is already compressed
-NOTICE:  chunk "_hyper_11_192_chunk" is already compressed
-NOTICE:  chunk "_hyper_11_194_chunk" is already compressed
-NOTICE:  chunk "_hyper_11_196_chunk" is already compressed
-NOTICE:  chunk "_hyper_11_198_chunk" is already compressed
-NOTICE:  chunk "_hyper_11_200_chunk" is already compressed
-NOTICE:  chunk "_hyper_11_202_chunk" is already compressed
-NOTICE:  chunk "_hyper_11_204_chunk" is already compressed
-NOTICE:  chunk "_hyper_11_206_chunk" is already compressed
-NOTICE:  chunk "_hyper_11_208_chunk" is already compressed
-NOTICE:  chunk "_hyper_11_210_chunk" is already compressed
-NOTICE:  chunk "_hyper_11_226_chunk" is already compressed
-NOTICE:  chunk "_hyper_11_230_chunk" is already compressed
-NOTICE:  chunk "_hyper_11_234_chunk" is already compressed
-NOTICE:  chunk "_hyper_11_238_chunk" is already compressed
-NOTICE:  chunk "_hyper_11_242_chunk" is already compressed
-NOTICE:  chunk "_hyper_11_246_chunk" is already compressed
+NOTICE:  chunk "_hyper_11_195_chunk" is already compressed
+NOTICE:  chunk "_hyper_11_197_chunk" is already compressed
+NOTICE:  chunk "_hyper_11_199_chunk" is already compressed
+NOTICE:  chunk "_hyper_11_201_chunk" is already compressed
+NOTICE:  chunk "_hyper_11_203_chunk" is already compressed
+NOTICE:  chunk "_hyper_11_205_chunk" is already compressed
+NOTICE:  chunk "_hyper_11_207_chunk" is already compressed
+NOTICE:  chunk "_hyper_11_209_chunk" is already compressed
+NOTICE:  chunk "_hyper_11_211_chunk" is already compressed
+NOTICE:  chunk "_hyper_11_213_chunk" is already compressed
+NOTICE:  chunk "_hyper_11_215_chunk" is already compressed
+NOTICE:  chunk "_hyper_11_217_chunk" is already compressed
+NOTICE:  chunk "_hyper_11_247_chunk" is already compressed
+NOTICE:  chunk "_hyper_11_255_chunk" is already compressed
+NOTICE:  chunk "_hyper_11_263_chunk" is already compressed
+NOTICE:  chunk "_hyper_11_271_chunk" is already compressed
+NOTICE:  chunk "_hyper_11_279_chunk" is already compressed
+NOTICE:  chunk "_hyper_11_287_chunk" is already compressed
               compress_chunk               
 -------------------------------------------
- _timescaledb_internal._hyper_11_188_chunk
- _timescaledb_internal._hyper_11_190_chunk
- _timescaledb_internal._hyper_11_192_chunk
- _timescaledb_internal._hyper_11_194_chunk
- _timescaledb_internal._hyper_11_196_chunk
- _timescaledb_internal._hyper_11_198_chunk
- _timescaledb_internal._hyper_11_200_chunk
- _timescaledb_internal._hyper_11_202_chunk
- _timescaledb_internal._hyper_11_204_chunk
- _timescaledb_internal._hyper_11_206_chunk
- _timescaledb_internal._hyper_11_208_chunk
- _timescaledb_internal._hyper_11_210_chunk
- _timescaledb_internal._hyper_11_226_chunk
- _timescaledb_internal._hyper_11_230_chunk
- _timescaledb_internal._hyper_11_234_chunk
- _timescaledb_internal._hyper_11_238_chunk
- _timescaledb_internal._hyper_11_242_chunk
- _timescaledb_internal._hyper_11_246_chunk
- _timescaledb_internal._hyper_11_254_chunk
+ _timescaledb_internal._hyper_11_195_chunk
+ _timescaledb_internal._hyper_11_197_chunk
+ _timescaledb_internal._hyper_11_199_chunk
+ _timescaledb_internal._hyper_11_201_chunk
+ _timescaledb_internal._hyper_11_203_chunk
+ _timescaledb_internal._hyper_11_205_chunk
+ _timescaledb_internal._hyper_11_207_chunk
+ _timescaledb_internal._hyper_11_209_chunk
+ _timescaledb_internal._hyper_11_211_chunk
+ _timescaledb_internal._hyper_11_213_chunk
+ _timescaledb_internal._hyper_11_215_chunk
+ _timescaledb_internal._hyper_11_217_chunk
+ _timescaledb_internal._hyper_11_247_chunk
  _timescaledb_internal._hyper_11_255_chunk
- _timescaledb_internal._hyper_11_256_chunk
+ _timescaledb_internal._hyper_11_263_chunk
+ _timescaledb_internal._hyper_11_271_chunk
+ _timescaledb_internal._hyper_11_279_chunk
+ _timescaledb_internal._hyper_11_287_chunk
+ _timescaledb_internal._hyper_11_291_chunk
+ _timescaledb_internal._hyper_11_293_chunk
+ _timescaledb_internal._hyper_11_295_chunk
 (21 rows)
 
 SELECT count(*) as number_of_chunks FROM show_chunks('test6');
@@ -521,53 +530,53 @@ CROSS JOIN generate_series(1, 5, 1) i;
 -- Setting compressed chunk to anything less than chunk interval should disable merging chunks.
 ALTER TABLE test6 set (timescaledb.compress_chunk_time_interval=0);
 SELECT compress_chunk(i, true) FROM show_chunks('test6') i;
-NOTICE:  chunk "_hyper_11_188_chunk" is already compressed
-NOTICE:  chunk "_hyper_11_190_chunk" is already compressed
-NOTICE:  chunk "_hyper_11_192_chunk" is already compressed
-NOTICE:  chunk "_hyper_11_194_chunk" is already compressed
-NOTICE:  chunk "_hyper_11_196_chunk" is already compressed
-NOTICE:  chunk "_hyper_11_198_chunk" is already compressed
-NOTICE:  chunk "_hyper_11_200_chunk" is already compressed
-NOTICE:  chunk "_hyper_11_202_chunk" is already compressed
-NOTICE:  chunk "_hyper_11_204_chunk" is already compressed
-NOTICE:  chunk "_hyper_11_206_chunk" is already compressed
-NOTICE:  chunk "_hyper_11_208_chunk" is already compressed
-NOTICE:  chunk "_hyper_11_210_chunk" is already compressed
-NOTICE:  chunk "_hyper_11_226_chunk" is already compressed
-NOTICE:  chunk "_hyper_11_230_chunk" is already compressed
-NOTICE:  chunk "_hyper_11_234_chunk" is already compressed
-NOTICE:  chunk "_hyper_11_238_chunk" is already compressed
-NOTICE:  chunk "_hyper_11_242_chunk" is already compressed
-NOTICE:  chunk "_hyper_11_246_chunk" is already compressed
-NOTICE:  chunk "_hyper_11_254_chunk" is already compressed
+NOTICE:  chunk "_hyper_11_195_chunk" is already compressed
+NOTICE:  chunk "_hyper_11_197_chunk" is already compressed
+NOTICE:  chunk "_hyper_11_199_chunk" is already compressed
+NOTICE:  chunk "_hyper_11_201_chunk" is already compressed
+NOTICE:  chunk "_hyper_11_203_chunk" is already compressed
+NOTICE:  chunk "_hyper_11_205_chunk" is already compressed
+NOTICE:  chunk "_hyper_11_207_chunk" is already compressed
+NOTICE:  chunk "_hyper_11_209_chunk" is already compressed
+NOTICE:  chunk "_hyper_11_211_chunk" is already compressed
+NOTICE:  chunk "_hyper_11_213_chunk" is already compressed
+NOTICE:  chunk "_hyper_11_215_chunk" is already compressed
+NOTICE:  chunk "_hyper_11_217_chunk" is already compressed
+NOTICE:  chunk "_hyper_11_247_chunk" is already compressed
 NOTICE:  chunk "_hyper_11_255_chunk" is already compressed
-NOTICE:  chunk "_hyper_11_256_chunk" is already compressed
+NOTICE:  chunk "_hyper_11_263_chunk" is already compressed
+NOTICE:  chunk "_hyper_11_271_chunk" is already compressed
+NOTICE:  chunk "_hyper_11_279_chunk" is already compressed
+NOTICE:  chunk "_hyper_11_287_chunk" is already compressed
+NOTICE:  chunk "_hyper_11_291_chunk" is already compressed
+NOTICE:  chunk "_hyper_11_293_chunk" is already compressed
+NOTICE:  chunk "_hyper_11_295_chunk" is already compressed
               compress_chunk               
 -------------------------------------------
- _timescaledb_internal._hyper_11_188_chunk
- _timescaledb_internal._hyper_11_190_chunk
- _timescaledb_internal._hyper_11_192_chunk
- _timescaledb_internal._hyper_11_194_chunk
- _timescaledb_internal._hyper_11_196_chunk
- _timescaledb_internal._hyper_11_198_chunk
- _timescaledb_internal._hyper_11_200_chunk
- _timescaledb_internal._hyper_11_202_chunk
- _timescaledb_internal._hyper_11_204_chunk
- _timescaledb_internal._hyper_11_206_chunk
- _timescaledb_internal._hyper_11_208_chunk
- _timescaledb_internal._hyper_11_210_chunk
- _timescaledb_internal._hyper_11_226_chunk
- _timescaledb_internal._hyper_11_230_chunk
- _timescaledb_internal._hyper_11_234_chunk
- _timescaledb_internal._hyper_11_238_chunk
- _timescaledb_internal._hyper_11_242_chunk
- _timescaledb_internal._hyper_11_246_chunk
- _timescaledb_internal._hyper_11_254_chunk
+ _timescaledb_internal._hyper_11_195_chunk
+ _timescaledb_internal._hyper_11_197_chunk
+ _timescaledb_internal._hyper_11_199_chunk
+ _timescaledb_internal._hyper_11_201_chunk
+ _timescaledb_internal._hyper_11_203_chunk
+ _timescaledb_internal._hyper_11_205_chunk
+ _timescaledb_internal._hyper_11_207_chunk
+ _timescaledb_internal._hyper_11_209_chunk
+ _timescaledb_internal._hyper_11_211_chunk
+ _timescaledb_internal._hyper_11_213_chunk
+ _timescaledb_internal._hyper_11_215_chunk
+ _timescaledb_internal._hyper_11_217_chunk
+ _timescaledb_internal._hyper_11_247_chunk
  _timescaledb_internal._hyper_11_255_chunk
- _timescaledb_internal._hyper_11_256_chunk
- _timescaledb_internal._hyper_11_260_chunk
- _timescaledb_internal._hyper_11_261_chunk
- _timescaledb_internal._hyper_11_262_chunk
+ _timescaledb_internal._hyper_11_263_chunk
+ _timescaledb_internal._hyper_11_271_chunk
+ _timescaledb_internal._hyper_11_279_chunk
+ _timescaledb_internal._hyper_11_287_chunk
+ _timescaledb_internal._hyper_11_291_chunk
+ _timescaledb_internal._hyper_11_293_chunk
+ _timescaledb_internal._hyper_11_295_chunk
+ _timescaledb_internal._hyper_11_297_chunk
+ _timescaledb_internal._hyper_11_299_chunk
+ _timescaledb_internal._hyper_11_301_chunk
 (24 rows)
 
 SELECT count(*) as number_of_chunks FROM show_chunks('test6');
@@ -644,10 +653,10 @@ INSERT INTO test8 (time, series_id, value) SELECT t, s, 1 FROM generate_series(N
 SELECT compress_chunk(c, true) FROM show_chunks('test8') c LIMIT 4;
               compress_chunk               
 -------------------------------------------
- _timescaledb_internal._hyper_15_314_chunk
- _timescaledb_internal._hyper_15_314_chunk
- _timescaledb_internal._hyper_15_314_chunk
- _timescaledb_internal._hyper_15_314_chunk
+ _timescaledb_internal._hyper_15_351_chunk
+ _timescaledb_internal._hyper_15_351_chunk
+ _timescaledb_internal._hyper_15_351_chunk
+ _timescaledb_internal._hyper_15_351_chunk
 (4 rows)
 
 SET enable_indexscan TO OFF;

--- a/tsl/test/expected/compression_permissions.out
+++ b/tsl/test/expected/compression_permissions.out
@@ -59,7 +59,7 @@ ERROR:  must be owner of table conditions
 --- compress_chunks and decompress_chunks fail without correct perm --
 \c :TEST_DBNAME :ROLE_DEFAULT_PERM_USER_2
 select  compress_chunk(ch1.schema_name|| '.' || ch1.table_name)
-FROM _timescaledb_catalog.chunk ch1, _timescaledb_catalog.hypertable ht where ch1.hypertable_id = ht.id and ht.table_name like 'conditions' and ch1.compressed_chunk_id IS NULL;
+FROM _timescaledb_catalog.chunk ch1, _timescaledb_catalog.hypertable ht where ch1.hypertable_id = ht.id and ht.table_name like 'conditions' and ch1.status & 1 = 0;
 ERROR:  must be owner of hypertable "conditions"
 select decompress_chunk(ch1.schema_name|| '.' || ch1.table_name)
 FROM _timescaledb_catalog.chunk ch1, _timescaledb_catalog.hypertable ht where ch1.hypertable_id = ht.id and ht.table_name like 'conditions';
@@ -83,7 +83,7 @@ ERROR:  must be owner of hypertable "conditions"
 GRANT SELECT on conditions to :ROLE_DEFAULT_PERM_USER_2;
 select count(*) from
 (select  compress_chunk(ch1.schema_name|| '.' || ch1.table_name)
-FROM _timescaledb_catalog.chunk ch1, _timescaledb_catalog.hypertable ht where ch1.hypertable_id = ht.id and ht.table_name like 'conditions' and ch1.compressed_chunk_id IS NULL ) as subq;
+FROM _timescaledb_catalog.chunk ch1, _timescaledb_catalog.hypertable ht where ch1.hypertable_id = ht.id and ht.table_name like 'conditions' and ch1.status & 1 = 0 ) as subq;
  count 
 -------
      2
@@ -157,7 +157,7 @@ select count(*) from v2;
 ERROR:  permission denied for table conditions
 \c :TEST_DBNAME :ROLE_SUPERUSER
 DROP TABLE conditions CASCADE;
-NOTICE:  drop cascades to 2 other objects
+NOTICE:  drop cascades to 3 other objects
 NOTICE:  drop cascades to view v2
 -- Testing that permissions propagate to compressed hypertables and to
 -- compressed chunks.
@@ -185,11 +185,11 @@ SELECT generate_series('2018-12-01 00:00'::timestamp, '2018-12-31 00:00'::timest
 SELECT compress_chunk(show_chunks('conditions'));
              compress_chunk              
 -----------------------------------------
- _timescaledb_internal._hyper_3_6_chunk
  _timescaledb_internal._hyper_3_7_chunk
- _timescaledb_internal._hyper_3_8_chunk
  _timescaledb_internal._hyper_3_9_chunk
- _timescaledb_internal._hyper_3_10_chunk
+ _timescaledb_internal._hyper_3_11_chunk
+ _timescaledb_internal._hyper_3_13_chunk
+ _timescaledb_internal._hyper_3_15_chunk
 (5 rows)
 
 -- Check that ACL propagates to compressed hypertable.  We could prune
@@ -209,7 +209,7 @@ ORDER BY hypertable, chunk;
 -[ RECORD 1 ]--+------------------------------------------------
 hypertable     | public.conditions
 hypertable_acl | 
-chunk          | _timescaledb_internal.compress_hyper_4_11_chunk
+chunk          | _timescaledb_internal.compress_hyper_4_10_chunk
 chunk_acl      | 
 -[ RECORD 2 ]--+------------------------------------------------
 hypertable     | public.conditions
@@ -219,17 +219,17 @@ chunk_acl      |
 -[ RECORD 3 ]--+------------------------------------------------
 hypertable     | public.conditions
 hypertable_acl | 
-chunk          | _timescaledb_internal.compress_hyper_4_13_chunk
+chunk          | _timescaledb_internal.compress_hyper_4_14_chunk
 chunk_acl      | 
 -[ RECORD 4 ]--+------------------------------------------------
 hypertable     | public.conditions
 hypertable_acl | 
-chunk          | _timescaledb_internal.compress_hyper_4_14_chunk
+chunk          | _timescaledb_internal.compress_hyper_4_16_chunk
 chunk_acl      | 
 -[ RECORD 5 ]--+------------------------------------------------
 hypertable     | public.conditions
 hypertable_acl | 
-chunk          | _timescaledb_internal.compress_hyper_4_15_chunk
+chunk          | _timescaledb_internal.compress_hyper_4_8_chunk
 chunk_acl      | 
 
 GRANT SELECT ON conditions TO :ROLE_DEFAULT_PERM_USER;
@@ -246,7 +246,7 @@ ORDER BY hypertable, chunk;
 -[ RECORD 1 ]--+---------------------------------------------------------------
 hypertable     | public.conditions
 hypertable_acl | {super_user=arwdDxt/super_user,default_perm_user=r/super_user}
-chunk          | _timescaledb_internal.compress_hyper_4_11_chunk
+chunk          | _timescaledb_internal.compress_hyper_4_10_chunk
 chunk_acl      | {super_user=arwdDxt/super_user,default_perm_user=r/super_user}
 -[ RECORD 2 ]--+---------------------------------------------------------------
 hypertable     | public.conditions
@@ -256,17 +256,17 @@ chunk_acl      | {super_user=arwdDxt/super_user,default_perm_user=r/super_user}
 -[ RECORD 3 ]--+---------------------------------------------------------------
 hypertable     | public.conditions
 hypertable_acl | {super_user=arwdDxt/super_user,default_perm_user=r/super_user}
-chunk          | _timescaledb_internal.compress_hyper_4_13_chunk
+chunk          | _timescaledb_internal.compress_hyper_4_14_chunk
 chunk_acl      | {super_user=arwdDxt/super_user,default_perm_user=r/super_user}
 -[ RECORD 4 ]--+---------------------------------------------------------------
 hypertable     | public.conditions
 hypertable_acl | {super_user=arwdDxt/super_user,default_perm_user=r/super_user}
-chunk          | _timescaledb_internal.compress_hyper_4_14_chunk
+chunk          | _timescaledb_internal.compress_hyper_4_16_chunk
 chunk_acl      | {super_user=arwdDxt/super_user,default_perm_user=r/super_user}
 -[ RECORD 5 ]--+---------------------------------------------------------------
 hypertable     | public.conditions
 hypertable_acl | {super_user=arwdDxt/super_user,default_perm_user=r/super_user}
-chunk          | _timescaledb_internal.compress_hyper_4_15_chunk
+chunk          | _timescaledb_internal.compress_hyper_4_8_chunk
 chunk_acl      | {super_user=arwdDxt/super_user,default_perm_user=r/super_user}
 
 -- Add some new data and compress the chunks. The chunks should get
@@ -276,17 +276,17 @@ INSERT INTO conditions
 SELECT generate_series('2019-01-07 00:00'::timestamp, '2019-02-07 00:00'::timestamp, '1 day'), 'XYZ', 47, 11;
 SELECT compress_chunk(show_chunks('conditions', newer_than => '2019-01-01'));
 -[ RECORD 1 ]--+----------------------------------------
-compress_chunk | _timescaledb_internal._hyper_3_16_chunk
--[ RECORD 2 ]--+----------------------------------------
 compress_chunk | _timescaledb_internal._hyper_3_17_chunk
--[ RECORD 3 ]--+----------------------------------------
-compress_chunk | _timescaledb_internal._hyper_3_18_chunk
--[ RECORD 4 ]--+----------------------------------------
+-[ RECORD 2 ]--+----------------------------------------
 compress_chunk | _timescaledb_internal._hyper_3_19_chunk
--[ RECORD 5 ]--+----------------------------------------
-compress_chunk | _timescaledb_internal._hyper_3_20_chunk
--[ RECORD 6 ]--+----------------------------------------
+-[ RECORD 3 ]--+----------------------------------------
 compress_chunk | _timescaledb_internal._hyper_3_21_chunk
+-[ RECORD 4 ]--+----------------------------------------
+compress_chunk | _timescaledb_internal._hyper_3_23_chunk
+-[ RECORD 5 ]--+----------------------------------------
+compress_chunk | _timescaledb_internal._hyper_3_25_chunk
+-[ RECORD 6 ]--+----------------------------------------
+compress_chunk | _timescaledb_internal._hyper_3_27_chunk
 
 SELECT htd.hypertable, htd.hypertable_acl, chunk, chunk_acl
   FROM chunk_details chd JOIN hypertable_details htd ON chd.hypertable = htd.compressed
@@ -294,7 +294,7 @@ ORDER BY hypertable, chunk;
 -[ RECORD 1 ]--+---------------------------------------------------------------
 hypertable     | public.conditions
 hypertable_acl | {super_user=arwdDxt/super_user,default_perm_user=r/super_user}
-chunk          | _timescaledb_internal.compress_hyper_4_11_chunk
+chunk          | _timescaledb_internal.compress_hyper_4_10_chunk
 chunk_acl      | {super_user=arwdDxt/super_user,default_perm_user=r/super_user}
 -[ RECORD 2 ]--+---------------------------------------------------------------
 hypertable     | public.conditions
@@ -304,27 +304,27 @@ chunk_acl      | {super_user=arwdDxt/super_user,default_perm_user=r/super_user}
 -[ RECORD 3 ]--+---------------------------------------------------------------
 hypertable     | public.conditions
 hypertable_acl | {super_user=arwdDxt/super_user,default_perm_user=r/super_user}
-chunk          | _timescaledb_internal.compress_hyper_4_13_chunk
+chunk          | _timescaledb_internal.compress_hyper_4_14_chunk
 chunk_acl      | {super_user=arwdDxt/super_user,default_perm_user=r/super_user}
 -[ RECORD 4 ]--+---------------------------------------------------------------
 hypertable     | public.conditions
 hypertable_acl | {super_user=arwdDxt/super_user,default_perm_user=r/super_user}
-chunk          | _timescaledb_internal.compress_hyper_4_14_chunk
+chunk          | _timescaledb_internal.compress_hyper_4_16_chunk
 chunk_acl      | {super_user=arwdDxt/super_user,default_perm_user=r/super_user}
 -[ RECORD 5 ]--+---------------------------------------------------------------
 hypertable     | public.conditions
 hypertable_acl | {super_user=arwdDxt/super_user,default_perm_user=r/super_user}
-chunk          | _timescaledb_internal.compress_hyper_4_15_chunk
+chunk          | _timescaledb_internal.compress_hyper_4_18_chunk
 chunk_acl      | {super_user=arwdDxt/super_user,default_perm_user=r/super_user}
 -[ RECORD 6 ]--+---------------------------------------------------------------
 hypertable     | public.conditions
 hypertable_acl | {super_user=arwdDxt/super_user,default_perm_user=r/super_user}
-chunk          | _timescaledb_internal.compress_hyper_4_22_chunk
+chunk          | _timescaledb_internal.compress_hyper_4_20_chunk
 chunk_acl      | {super_user=arwdDxt/super_user,default_perm_user=r/super_user}
 -[ RECORD 7 ]--+---------------------------------------------------------------
 hypertable     | public.conditions
 hypertable_acl | {super_user=arwdDxt/super_user,default_perm_user=r/super_user}
-chunk          | _timescaledb_internal.compress_hyper_4_23_chunk
+chunk          | _timescaledb_internal.compress_hyper_4_22_chunk
 chunk_acl      | {super_user=arwdDxt/super_user,default_perm_user=r/super_user}
 -[ RECORD 8 ]--+---------------------------------------------------------------
 hypertable     | public.conditions
@@ -334,17 +334,17 @@ chunk_acl      | {super_user=arwdDxt/super_user,default_perm_user=r/super_user}
 -[ RECORD 9 ]--+---------------------------------------------------------------
 hypertable     | public.conditions
 hypertable_acl | {super_user=arwdDxt/super_user,default_perm_user=r/super_user}
-chunk          | _timescaledb_internal.compress_hyper_4_25_chunk
+chunk          | _timescaledb_internal.compress_hyper_4_26_chunk
 chunk_acl      | {super_user=arwdDxt/super_user,default_perm_user=r/super_user}
 -[ RECORD 10 ]-+---------------------------------------------------------------
 hypertable     | public.conditions
 hypertable_acl | {super_user=arwdDxt/super_user,default_perm_user=r/super_user}
-chunk          | _timescaledb_internal.compress_hyper_4_26_chunk
+chunk          | _timescaledb_internal.compress_hyper_4_28_chunk
 chunk_acl      | {super_user=arwdDxt/super_user,default_perm_user=r/super_user}
 -[ RECORD 11 ]-+---------------------------------------------------------------
 hypertable     | public.conditions
 hypertable_acl | {super_user=arwdDxt/super_user,default_perm_user=r/super_user}
-chunk          | _timescaledb_internal.compress_hyper_4_27_chunk
+chunk          | _timescaledb_internal.compress_hyper_4_8_chunk
 chunk_acl      | {super_user=arwdDxt/super_user,default_perm_user=r/super_user}
 
 \x off

--- a/tsl/test/expected/compression_qualpushdown.out
+++ b/tsl/test/expected/compression_qualpushdown.out
@@ -39,9 +39,9 @@ WHERE time > 2::bigint and time < 4;
 ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_1_chunk
    Filter: ((_hyper_1_1_chunk."time" > '2'::bigint) AND (_hyper_1_1_chunk."time" < 4))
-   ->  Seq Scan on _timescaledb_internal.compress_hyper_2_3_chunk
-         Output: compress_hyper_2_3_chunk."time", compress_hyper_2_3_chunk.device_id, compress_hyper_2_3_chunk.val, compress_hyper_2_3_chunk._ts_meta_count, compress_hyper_2_3_chunk._ts_meta_sequence_num, compress_hyper_2_3_chunk._ts_meta_min_1, compress_hyper_2_3_chunk._ts_meta_max_1
-         Filter: ((compress_hyper_2_3_chunk._ts_meta_max_1 > '2'::bigint) AND (compress_hyper_2_3_chunk._ts_meta_min_1 < 4))
+   ->  Seq Scan on _timescaledb_internal.compress_hyper_2_2_chunk
+         Output: compress_hyper_2_2_chunk."time", compress_hyper_2_2_chunk.device_id, compress_hyper_2_2_chunk.val, compress_hyper_2_2_chunk._ts_meta_count, compress_hyper_2_2_chunk._ts_meta_sequence_num, compress_hyper_2_2_chunk._ts_meta_min_1, compress_hyper_2_2_chunk._ts_meta_max_1
+         Filter: ((compress_hyper_2_2_chunk._ts_meta_max_1 > '2'::bigint) AND (compress_hyper_2_2_chunk._ts_meta_min_1 < 4))
 (5 rows)
 
 explain (costs off, verbose)
@@ -52,9 +52,9 @@ WHERE time = 3::bigint;
 ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_1_chunk
    Filter: (_hyper_1_1_chunk."time" = '3'::bigint)
-   ->  Seq Scan on _timescaledb_internal.compress_hyper_2_3_chunk
-         Output: compress_hyper_2_3_chunk."time", compress_hyper_2_3_chunk.device_id, compress_hyper_2_3_chunk.val, compress_hyper_2_3_chunk._ts_meta_count, compress_hyper_2_3_chunk._ts_meta_sequence_num, compress_hyper_2_3_chunk._ts_meta_min_1, compress_hyper_2_3_chunk._ts_meta_max_1
-         Filter: ((compress_hyper_2_3_chunk._ts_meta_min_1 <= '3'::bigint) AND (compress_hyper_2_3_chunk._ts_meta_max_1 >= '3'::bigint))
+   ->  Seq Scan on _timescaledb_internal.compress_hyper_2_2_chunk
+         Output: compress_hyper_2_2_chunk."time", compress_hyper_2_2_chunk.device_id, compress_hyper_2_2_chunk.val, compress_hyper_2_2_chunk._ts_meta_count, compress_hyper_2_2_chunk._ts_meta_sequence_num, compress_hyper_2_2_chunk._ts_meta_min_1, compress_hyper_2_2_chunk._ts_meta_max_1
+         Filter: ((compress_hyper_2_2_chunk._ts_meta_min_1 <= '3'::bigint) AND (compress_hyper_2_2_chunk._ts_meta_max_1 >= '3'::bigint))
 (5 rows)
 
 SELECT *
@@ -105,7 +105,7 @@ INSERT INTO metaseg_tab values (56,0,'2012-12-10 09:45:00','2012-12-10 09:50:00'
 SELECT compress_chunk(i) from show_chunks('metaseg_tab') i;
              compress_chunk             
 ----------------------------------------
- _timescaledb_internal._hyper_3_4_chunk
+ _timescaledb_internal._hyper_3_5_chunk
 (1 row)
 
 select factorid, end_dt, logret
@@ -127,14 +127,14 @@ order by factorid, end_dt;
                                                                                                                                                                                                                         QUERY PLAN                                                                                                                                                                                                                         
 -----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Sort
-   Output: _hyper_3_4_chunk.factorid, _hyper_3_4_chunk.end_dt, _hyper_3_4_chunk.logret
-   Sort Key: _hyper_3_4_chunk.factorid, _hyper_3_4_chunk.end_dt
-   ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_3_4_chunk
-         Output: _hyper_3_4_chunk.factorid, _hyper_3_4_chunk.end_dt, _hyper_3_4_chunk.logret
-         Filter: ((_hyper_3_4_chunk.end_dt >= '12-10-2012'::date) AND (_hyper_3_4_chunk.end_dt <= '12-11-2012'::date) AND (_hyper_3_4_chunk.fmid = 56))
-         ->  Seq Scan on _timescaledb_internal.compress_hyper_4_5_chunk
-               Output: compress_hyper_4_5_chunk.fmid, compress_hyper_4_5_chunk.factorid, compress_hyper_4_5_chunk.start_dt, compress_hyper_4_5_chunk.end_dt, compress_hyper_4_5_chunk.interval_number, compress_hyper_4_5_chunk.logret, compress_hyper_4_5_chunk.knowledge_date, compress_hyper_4_5_chunk._ts_meta_count, compress_hyper_4_5_chunk._ts_meta_sequence_num, compress_hyper_4_5_chunk._ts_meta_min_1, compress_hyper_4_5_chunk._ts_meta_max_1
-               Filter: ((compress_hyper_4_5_chunk._ts_meta_max_1 >= '12-10-2012'::date) AND (compress_hyper_4_5_chunk._ts_meta_min_1 <= '12-11-2012'::date))
+   Output: _hyper_3_5_chunk.factorid, _hyper_3_5_chunk.end_dt, _hyper_3_5_chunk.logret
+   Sort Key: _hyper_3_5_chunk.factorid, _hyper_3_5_chunk.end_dt
+   ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_3_5_chunk
+         Output: _hyper_3_5_chunk.factorid, _hyper_3_5_chunk.end_dt, _hyper_3_5_chunk.logret
+         Filter: ((_hyper_3_5_chunk.end_dt >= '12-10-2012'::date) AND (_hyper_3_5_chunk.end_dt <= '12-11-2012'::date) AND (_hyper_3_5_chunk.fmid = 56))
+         ->  Seq Scan on _timescaledb_internal.compress_hyper_4_6_chunk
+               Output: compress_hyper_4_6_chunk.fmid, compress_hyper_4_6_chunk.factorid, compress_hyper_4_6_chunk.start_dt, compress_hyper_4_6_chunk.end_dt, compress_hyper_4_6_chunk.interval_number, compress_hyper_4_6_chunk.logret, compress_hyper_4_6_chunk.knowledge_date, compress_hyper_4_6_chunk._ts_meta_count, compress_hyper_4_6_chunk._ts_meta_sequence_num, compress_hyper_4_6_chunk._ts_meta_min_1, compress_hyper_4_6_chunk._ts_meta_max_1
+               Filter: ((compress_hyper_4_6_chunk._ts_meta_max_1 >= '12-10-2012'::date) AND (compress_hyper_4_6_chunk._ts_meta_min_1 <= '12-11-2012'::date))
 (9 rows)
 
 --no pushdown here
@@ -157,13 +157,13 @@ order by factorid, end_dt;
                                                                                                                                                                                                                         QUERY PLAN                                                                                                                                                                                                                         
 -----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Sort
-   Output: _hyper_3_4_chunk.factorid, _hyper_3_4_chunk.end_dt, _hyper_3_4_chunk.logret
-   Sort Key: _hyper_3_4_chunk.factorid, _hyper_3_4_chunk.end_dt
-   ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_3_4_chunk
-         Output: _hyper_3_4_chunk.factorid, _hyper_3_4_chunk.end_dt, _hyper_3_4_chunk.logret
-         Filter: ((_hyper_3_4_chunk.fmid = 56) AND ((_hyper_3_4_chunk.end_dt)::date >= 'Mon Dec 10 00:00:00 2012'::timestamp without time zone) AND ((_hyper_3_4_chunk.end_dt)::date <= '12-11-2012'::date))
-         ->  Seq Scan on _timescaledb_internal.compress_hyper_4_5_chunk
-               Output: compress_hyper_4_5_chunk.fmid, compress_hyper_4_5_chunk.factorid, compress_hyper_4_5_chunk.start_dt, compress_hyper_4_5_chunk.end_dt, compress_hyper_4_5_chunk.interval_number, compress_hyper_4_5_chunk.logret, compress_hyper_4_5_chunk.knowledge_date, compress_hyper_4_5_chunk._ts_meta_count, compress_hyper_4_5_chunk._ts_meta_sequence_num, compress_hyper_4_5_chunk._ts_meta_min_1, compress_hyper_4_5_chunk._ts_meta_max_1
+   Output: _hyper_3_5_chunk.factorid, _hyper_3_5_chunk.end_dt, _hyper_3_5_chunk.logret
+   Sort Key: _hyper_3_5_chunk.factorid, _hyper_3_5_chunk.end_dt
+   ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_3_5_chunk
+         Output: _hyper_3_5_chunk.factorid, _hyper_3_5_chunk.end_dt, _hyper_3_5_chunk.logret
+         Filter: ((_hyper_3_5_chunk.fmid = 56) AND ((_hyper_3_5_chunk.end_dt)::date >= 'Mon Dec 10 00:00:00 2012'::timestamp without time zone) AND ((_hyper_3_5_chunk.end_dt)::date <= '12-11-2012'::date))
+         ->  Seq Scan on _timescaledb_internal.compress_hyper_4_6_chunk
+               Output: compress_hyper_4_6_chunk.fmid, compress_hyper_4_6_chunk.factorid, compress_hyper_4_6_chunk.start_dt, compress_hyper_4_6_chunk.end_dt, compress_hyper_4_6_chunk.interval_number, compress_hyper_4_6_chunk.logret, compress_hyper_4_6_chunk.knowledge_date, compress_hyper_4_6_chunk._ts_meta_count, compress_hyper_4_6_chunk._ts_meta_sequence_num, compress_hyper_4_6_chunk._ts_meta_min_1, compress_hyper_4_6_chunk._ts_meta_max_1
 (8 rows)
 
 --should fail
@@ -192,39 +192,39 @@ INSERT INTO pushdown_relabel SELECT '2000-01-01','varchar','char';
 SELECT compress_chunk(i) from show_chunks('pushdown_relabel') i;
              compress_chunk             
 ----------------------------------------
- _timescaledb_internal._hyper_5_6_chunk
+ _timescaledb_internal._hyper_5_7_chunk
 (1 row)
 
 ANALYZE pushdown_relabel;
 EXPLAIN (costs off) SELECT * FROM pushdown_relabel WHERE dev_vc = 'varchar';
                      QUERY PLAN                     
 ----------------------------------------------------
- Custom Scan (DecompressChunk) on _hyper_5_6_chunk
-   ->  Seq Scan on compress_hyper_6_7_chunk
+ Custom Scan (DecompressChunk) on _hyper_5_7_chunk
+   ->  Seq Scan on compress_hyper_6_8_chunk
          Filter: ((dev_vc)::text = 'varchar'::text)
 (3 rows)
 
 EXPLAIN (costs off) SELECT * FROM pushdown_relabel WHERE dev_c = 'char';
                     QUERY PLAN                     
 ---------------------------------------------------
- Custom Scan (DecompressChunk) on _hyper_5_6_chunk
-   ->  Seq Scan on compress_hyper_6_7_chunk
+ Custom Scan (DecompressChunk) on _hyper_5_7_chunk
+   ->  Seq Scan on compress_hyper_6_8_chunk
          Filter: (dev_c = 'char'::bpchar)
 (3 rows)
 
 EXPLAIN (costs off) SELECT * FROM pushdown_relabel WHERE dev_vc = 'varchar' AND dev_c = 'char';
                                     QUERY PLAN                                     
 -----------------------------------------------------------------------------------
- Custom Scan (DecompressChunk) on _hyper_5_6_chunk
-   ->  Seq Scan on compress_hyper_6_7_chunk
+ Custom Scan (DecompressChunk) on _hyper_5_7_chunk
+   ->  Seq Scan on compress_hyper_6_8_chunk
          Filter: (((dev_vc)::text = 'varchar'::text) AND (dev_c = 'char'::bpchar))
 (3 rows)
 
 EXPLAIN (costs off) SELECT * FROM pushdown_relabel WHERE dev_vc = 'varchar'::char(10) AND dev_c = 'char'::varchar;
                                            QUERY PLAN                                            
 -------------------------------------------------------------------------------------------------
- Custom Scan (DecompressChunk) on _hyper_5_6_chunk
-   ->  Seq Scan on compress_hyper_6_7_chunk
+ Custom Scan (DecompressChunk) on _hyper_5_7_chunk
+   ->  Seq Scan on compress_hyper_6_8_chunk
          Filter: (((dev_vc)::bpchar = 'varchar   '::character(10)) AND (dev_c = 'char'::bpchar))
 (3 rows)
 
@@ -233,32 +233,32 @@ SET enable_seqscan TO false;
 EXPLAIN (costs off) SELECT * FROM pushdown_relabel WHERE dev_vc = 'varchar';
                                                      QUERY PLAN                                                     
 --------------------------------------------------------------------------------------------------------------------
- Custom Scan (DecompressChunk) on _hyper_5_6_chunk
-   ->  Index Scan using compress_hyper_6_7_chunk__compressed_hypertable_6_dev_vc_dev_c_ on compress_hyper_6_7_chunk
+ Custom Scan (DecompressChunk) on _hyper_5_7_chunk
+   ->  Index Scan using compress_hyper_6_8_chunk__compressed_hypertable_6_dev_vc_dev_c_ on compress_hyper_6_8_chunk
          Index Cond: ((dev_vc)::text = 'varchar'::text)
 (3 rows)
 
 EXPLAIN (costs off) SELECT * FROM pushdown_relabel WHERE dev_c = 'char';
                                                      QUERY PLAN                                                     
 --------------------------------------------------------------------------------------------------------------------
- Custom Scan (DecompressChunk) on _hyper_5_6_chunk
-   ->  Index Scan using compress_hyper_6_7_chunk__compressed_hypertable_6_dev_vc_dev_c_ on compress_hyper_6_7_chunk
+ Custom Scan (DecompressChunk) on _hyper_5_7_chunk
+   ->  Index Scan using compress_hyper_6_8_chunk__compressed_hypertable_6_dev_vc_dev_c_ on compress_hyper_6_8_chunk
          Index Cond: (dev_c = 'char'::bpchar)
 (3 rows)
 
 EXPLAIN (costs off) SELECT * FROM pushdown_relabel WHERE dev_vc = 'varchar' AND dev_c = 'char';
                                                      QUERY PLAN                                                     
 --------------------------------------------------------------------------------------------------------------------
- Custom Scan (DecompressChunk) on _hyper_5_6_chunk
-   ->  Index Scan using compress_hyper_6_7_chunk__compressed_hypertable_6_dev_vc_dev_c_ on compress_hyper_6_7_chunk
+ Custom Scan (DecompressChunk) on _hyper_5_7_chunk
+   ->  Index Scan using compress_hyper_6_8_chunk__compressed_hypertable_6_dev_vc_dev_c_ on compress_hyper_6_8_chunk
          Index Cond: (((dev_vc)::text = 'varchar'::text) AND (dev_c = 'char'::bpchar))
 (3 rows)
 
 EXPLAIN (costs off) SELECT * FROM pushdown_relabel WHERE dev_vc = 'varchar'::char(10) AND dev_c = 'char'::varchar;
                                                      QUERY PLAN                                                     
 --------------------------------------------------------------------------------------------------------------------
- Custom Scan (DecompressChunk) on _hyper_5_6_chunk
-   ->  Index Scan using compress_hyper_6_7_chunk__compressed_hypertable_6_dev_vc_dev_c_ on compress_hyper_6_7_chunk
+ Custom Scan (DecompressChunk) on _hyper_5_7_chunk
+   ->  Index Scan using compress_hyper_6_8_chunk__compressed_hypertable_6_dev_vc_dev_c_ on compress_hyper_6_8_chunk
          Index Cond: (dev_c = 'char'::bpchar)
          Filter: ((dev_vc)::bpchar = 'varchar   '::character(10))
 (4 rows)
@@ -283,15 +283,15 @@ ALTER TABLE deleteme SET (
 SELECT compress_chunk(i) FROM show_chunks('deleteme') i;
              compress_chunk             
 ----------------------------------------
- _timescaledb_internal._hyper_7_8_chunk
+ _timescaledb_internal._hyper_7_9_chunk
 (1 row)
 
 EXPLAIN (costs off) SELECT sum(data) FROM deleteme WHERE segment::text like '%4%';
                        QUERY PLAN                        
 ---------------------------------------------------------
  Aggregate
-   ->  Custom Scan (DecompressChunk) on _hyper_7_8_chunk
-         ->  Seq Scan on compress_hyper_8_9_chunk
+   ->  Custom Scan (DecompressChunk) on _hyper_7_9_chunk
+         ->  Seq Scan on compress_hyper_8_10_chunk
                Filter: ((segment)::text ~~ '%4%'::text)
 (4 rows)
 
@@ -299,8 +299,8 @@ EXPLAIN (costs off) SELECT sum(data) FROM deleteme WHERE '4' = segment::text;
                        QUERY PLAN                        
 ---------------------------------------------------------
  Aggregate
-   ->  Custom Scan (DecompressChunk) on _hyper_7_8_chunk
-         ->  Seq Scan on compress_hyper_8_9_chunk
+   ->  Custom Scan (DecompressChunk) on _hyper_7_9_chunk
+         ->  Seq Scan on compress_hyper_8_10_chunk
                Filter: ('4'::text = (segment)::text)
 (4 rows)
 
@@ -320,15 +320,15 @@ ALTER TABLE deleteme_with_bytea SET (
 SELECT compress_chunk(i) FROM show_chunks('deleteme_with_bytea') i;
              compress_chunk              
 -----------------------------------------
- _timescaledb_internal._hyper_9_10_chunk
+ _timescaledb_internal._hyper_9_11_chunk
 (1 row)
 
 EXPLAIN (costs off) SELECT '1' FROM deleteme_with_bytea WHERE bdata = E'\\x';
                                                          QUERY PLAN                                                         
 ----------------------------------------------------------------------------------------------------------------------------
  Result
-   ->  Custom Scan (DecompressChunk) on _hyper_9_10_chunk
-         ->  Index Scan using compress_hyper_10_11_chunk__compressed_hypertable_10_bdata__ts_ on compress_hyper_10_11_chunk
+   ->  Custom Scan (DecompressChunk) on _hyper_9_11_chunk
+         ->  Index Scan using compress_hyper_10_12_chunk__compressed_hypertable_10_bdata__ts_ on compress_hyper_10_12_chunk
                Index Cond: (bdata = '\x'::bytea)
 (4 rows)
 
@@ -336,8 +336,8 @@ EXPLAIN (costs off) SELECT '1' FROM deleteme_with_bytea WHERE bdata::text = '123
                         QUERY PLAN                        
 ----------------------------------------------------------
  Result
-   ->  Custom Scan (DecompressChunk) on _hyper_9_10_chunk
-         ->  Seq Scan on compress_hyper_10_11_chunk
+   ->  Custom Scan (DecompressChunk) on _hyper_9_11_chunk
+         ->  Seq Scan on compress_hyper_10_12_chunk
                Filter: ((bdata)::text = '123'::text)
 (4 rows)
 

--- a/tsl/test/expected/compression_sorted_merge-13.out
+++ b/tsl/test/expected/compression_sorted_merge-13.out
@@ -934,11 +934,11 @@ SELECT * FROM test1 ORDER BY time DESC;
    Sorted merge append: true
    Bulk Decompression: false
    ->  Sort (actual rows=3 loops=1)
-         Output: compress_hyper_2_7_chunk."time", compress_hyper_2_7_chunk._ts_meta_min_1, compress_hyper_2_7_chunk._ts_meta_max_1, compress_hyper_2_7_chunk.x1, compress_hyper_2_7_chunk.x2, compress_hyper_2_7_chunk.x3, compress_hyper_2_7_chunk._ts_meta_min_2, compress_hyper_2_7_chunk._ts_meta_max_2, compress_hyper_2_7_chunk.x4, compress_hyper_2_7_chunk._ts_meta_min_3, compress_hyper_2_7_chunk._ts_meta_max_3, compress_hyper_2_7_chunk.x5, compress_hyper_2_7_chunk.c1, compress_hyper_2_7_chunk.c2, compress_hyper_2_7_chunk._ts_meta_count
-         Sort Key: compress_hyper_2_7_chunk._ts_meta_max_1 DESC
+         Output: compress_hyper_2_2_chunk."time", compress_hyper_2_2_chunk._ts_meta_min_1, compress_hyper_2_2_chunk._ts_meta_max_1, compress_hyper_2_2_chunk.x1, compress_hyper_2_2_chunk.x2, compress_hyper_2_2_chunk.x3, compress_hyper_2_2_chunk._ts_meta_min_2, compress_hyper_2_2_chunk._ts_meta_max_2, compress_hyper_2_2_chunk.x4, compress_hyper_2_2_chunk._ts_meta_min_3, compress_hyper_2_2_chunk._ts_meta_max_3, compress_hyper_2_2_chunk.x5, compress_hyper_2_2_chunk.c1, compress_hyper_2_2_chunk.c2, compress_hyper_2_2_chunk._ts_meta_count
+         Sort Key: compress_hyper_2_2_chunk._ts_meta_max_1 DESC
          Sort Method: quicksort 
-         ->  Seq Scan on _timescaledb_internal.compress_hyper_2_7_chunk (actual rows=3 loops=1)
-               Output: compress_hyper_2_7_chunk."time", compress_hyper_2_7_chunk._ts_meta_min_1, compress_hyper_2_7_chunk._ts_meta_max_1, compress_hyper_2_7_chunk.x1, compress_hyper_2_7_chunk.x2, compress_hyper_2_7_chunk.x3, compress_hyper_2_7_chunk._ts_meta_min_2, compress_hyper_2_7_chunk._ts_meta_max_2, compress_hyper_2_7_chunk.x4, compress_hyper_2_7_chunk._ts_meta_min_3, compress_hyper_2_7_chunk._ts_meta_max_3, compress_hyper_2_7_chunk.x5, compress_hyper_2_7_chunk.c1, compress_hyper_2_7_chunk.c2, compress_hyper_2_7_chunk._ts_meta_count
+         ->  Seq Scan on _timescaledb_internal.compress_hyper_2_2_chunk (actual rows=3 loops=1)
+               Output: compress_hyper_2_2_chunk."time", compress_hyper_2_2_chunk._ts_meta_min_1, compress_hyper_2_2_chunk._ts_meta_max_1, compress_hyper_2_2_chunk.x1, compress_hyper_2_2_chunk.x2, compress_hyper_2_2_chunk.x3, compress_hyper_2_2_chunk._ts_meta_min_2, compress_hyper_2_2_chunk._ts_meta_max_2, compress_hyper_2_2_chunk.x4, compress_hyper_2_2_chunk._ts_meta_min_3, compress_hyper_2_2_chunk._ts_meta_max_3, compress_hyper_2_2_chunk.x5, compress_hyper_2_2_chunk.c1, compress_hyper_2_2_chunk.c2, compress_hyper_2_2_chunk._ts_meta_count
 (10 rows)
 
 SELECT * FROM test1 ORDER BY time DESC;
@@ -960,11 +960,11 @@ SELECT time, x2, x1, c2 FROM test1 ORDER BY time DESC;
    Sorted merge append: true
    Bulk Decompression: false
    ->  Sort (actual rows=3 loops=1)
-         Output: compress_hyper_2_7_chunk."time", compress_hyper_2_7_chunk._ts_meta_min_1, compress_hyper_2_7_chunk._ts_meta_max_1, compress_hyper_2_7_chunk.x2, compress_hyper_2_7_chunk.x1, compress_hyper_2_7_chunk.c2, compress_hyper_2_7_chunk._ts_meta_count
-         Sort Key: compress_hyper_2_7_chunk._ts_meta_max_1 DESC
+         Output: compress_hyper_2_2_chunk."time", compress_hyper_2_2_chunk._ts_meta_min_1, compress_hyper_2_2_chunk._ts_meta_max_1, compress_hyper_2_2_chunk.x2, compress_hyper_2_2_chunk.x1, compress_hyper_2_2_chunk.c2, compress_hyper_2_2_chunk._ts_meta_count
+         Sort Key: compress_hyper_2_2_chunk._ts_meta_max_1 DESC
          Sort Method: quicksort 
-         ->  Seq Scan on _timescaledb_internal.compress_hyper_2_7_chunk (actual rows=3 loops=1)
-               Output: compress_hyper_2_7_chunk."time", compress_hyper_2_7_chunk._ts_meta_min_1, compress_hyper_2_7_chunk._ts_meta_max_1, compress_hyper_2_7_chunk.x2, compress_hyper_2_7_chunk.x1, compress_hyper_2_7_chunk.c2, compress_hyper_2_7_chunk._ts_meta_count
+         ->  Seq Scan on _timescaledb_internal.compress_hyper_2_2_chunk (actual rows=3 loops=1)
+               Output: compress_hyper_2_2_chunk."time", compress_hyper_2_2_chunk._ts_meta_min_1, compress_hyper_2_2_chunk._ts_meta_max_1, compress_hyper_2_2_chunk.x2, compress_hyper_2_2_chunk.x1, compress_hyper_2_2_chunk.c2, compress_hyper_2_2_chunk._ts_meta_count
 (10 rows)
 
 SELECT time, x2, x1, c2 FROM test1 ORDER BY time DESC;
@@ -986,11 +986,11 @@ SELECT x2, x1, c2, time FROM test1 ORDER BY time DESC;
    Sorted merge append: true
    Bulk Decompression: false
    ->  Sort (actual rows=3 loops=1)
-         Output: compress_hyper_2_7_chunk.x2, compress_hyper_2_7_chunk.x1, compress_hyper_2_7_chunk.c2, compress_hyper_2_7_chunk."time", compress_hyper_2_7_chunk._ts_meta_min_1, compress_hyper_2_7_chunk._ts_meta_max_1, compress_hyper_2_7_chunk._ts_meta_count
-         Sort Key: compress_hyper_2_7_chunk._ts_meta_max_1 DESC
+         Output: compress_hyper_2_2_chunk.x2, compress_hyper_2_2_chunk.x1, compress_hyper_2_2_chunk.c2, compress_hyper_2_2_chunk."time", compress_hyper_2_2_chunk._ts_meta_min_1, compress_hyper_2_2_chunk._ts_meta_max_1, compress_hyper_2_2_chunk._ts_meta_count
+         Sort Key: compress_hyper_2_2_chunk._ts_meta_max_1 DESC
          Sort Method: quicksort 
-         ->  Seq Scan on _timescaledb_internal.compress_hyper_2_7_chunk (actual rows=3 loops=1)
-               Output: compress_hyper_2_7_chunk.x2, compress_hyper_2_7_chunk.x1, compress_hyper_2_7_chunk.c2, compress_hyper_2_7_chunk."time", compress_hyper_2_7_chunk._ts_meta_min_1, compress_hyper_2_7_chunk._ts_meta_max_1, compress_hyper_2_7_chunk._ts_meta_count
+         ->  Seq Scan on _timescaledb_internal.compress_hyper_2_2_chunk (actual rows=3 loops=1)
+               Output: compress_hyper_2_2_chunk.x2, compress_hyper_2_2_chunk.x1, compress_hyper_2_2_chunk.c2, compress_hyper_2_2_chunk."time", compress_hyper_2_2_chunk._ts_meta_min_1, compress_hyper_2_2_chunk._ts_meta_max_1, compress_hyper_2_2_chunk._ts_meta_count
 (10 rows)
 
 SELECT x2, x1, c2, time FROM test1 ORDER BY time DESC;
@@ -1014,11 +1014,11 @@ SELECT 1 as one, 2 as two, 3 as three, x2, x1, c2, time FROM test1 ORDER BY time
          Sorted merge append: true
          Bulk Decompression: false
          ->  Sort (actual rows=3 loops=1)
-               Output: compress_hyper_2_7_chunk.x2, compress_hyper_2_7_chunk.x1, compress_hyper_2_7_chunk.c2, compress_hyper_2_7_chunk."time", compress_hyper_2_7_chunk._ts_meta_min_1, compress_hyper_2_7_chunk._ts_meta_max_1, compress_hyper_2_7_chunk._ts_meta_count
-               Sort Key: compress_hyper_2_7_chunk._ts_meta_max_1 DESC
+               Output: compress_hyper_2_2_chunk.x2, compress_hyper_2_2_chunk.x1, compress_hyper_2_2_chunk.c2, compress_hyper_2_2_chunk."time", compress_hyper_2_2_chunk._ts_meta_min_1, compress_hyper_2_2_chunk._ts_meta_max_1, compress_hyper_2_2_chunk._ts_meta_count
+               Sort Key: compress_hyper_2_2_chunk._ts_meta_max_1 DESC
                Sort Method: quicksort 
-               ->  Seq Scan on _timescaledb_internal.compress_hyper_2_7_chunk (actual rows=3 loops=1)
-                     Output: compress_hyper_2_7_chunk.x2, compress_hyper_2_7_chunk.x1, compress_hyper_2_7_chunk.c2, compress_hyper_2_7_chunk."time", compress_hyper_2_7_chunk._ts_meta_min_1, compress_hyper_2_7_chunk._ts_meta_max_1, compress_hyper_2_7_chunk._ts_meta_count
+               ->  Seq Scan on _timescaledb_internal.compress_hyper_2_2_chunk (actual rows=3 loops=1)
+                     Output: compress_hyper_2_2_chunk.x2, compress_hyper_2_2_chunk.x1, compress_hyper_2_2_chunk.c2, compress_hyper_2_2_chunk."time", compress_hyper_2_2_chunk._ts_meta_min_1, compress_hyper_2_2_chunk._ts_meta_max_1, compress_hyper_2_2_chunk._ts_meta_count
 (12 rows)
 
 SELECT 1 as one, 2 as two, 3 as three, x2, x1, c2, time FROM test1 ORDER BY time DESC;
@@ -1080,11 +1080,11 @@ SELECT * FROM test1 ORDER BY time ASC NULLS LAST;
    Sorted merge append: true
    Bulk Decompression: false
    ->  Sort (actual rows=3 loops=1)
-         Output: compress_hyper_2_7_chunk."time", compress_hyper_2_7_chunk._ts_meta_min_1, compress_hyper_2_7_chunk._ts_meta_max_1, compress_hyper_2_7_chunk.x1, compress_hyper_2_7_chunk.x2, compress_hyper_2_7_chunk.x3, compress_hyper_2_7_chunk._ts_meta_min_2, compress_hyper_2_7_chunk._ts_meta_max_2, compress_hyper_2_7_chunk.x4, compress_hyper_2_7_chunk._ts_meta_min_3, compress_hyper_2_7_chunk._ts_meta_max_3, compress_hyper_2_7_chunk.x5, compress_hyper_2_7_chunk.c1, compress_hyper_2_7_chunk.c2, compress_hyper_2_7_chunk._ts_meta_count
-         Sort Key: compress_hyper_2_7_chunk._ts_meta_min_1
+         Output: compress_hyper_2_2_chunk."time", compress_hyper_2_2_chunk._ts_meta_min_1, compress_hyper_2_2_chunk._ts_meta_max_1, compress_hyper_2_2_chunk.x1, compress_hyper_2_2_chunk.x2, compress_hyper_2_2_chunk.x3, compress_hyper_2_2_chunk._ts_meta_min_2, compress_hyper_2_2_chunk._ts_meta_max_2, compress_hyper_2_2_chunk.x4, compress_hyper_2_2_chunk._ts_meta_min_3, compress_hyper_2_2_chunk._ts_meta_max_3, compress_hyper_2_2_chunk.x5, compress_hyper_2_2_chunk.c1, compress_hyper_2_2_chunk.c2, compress_hyper_2_2_chunk._ts_meta_count
+         Sort Key: compress_hyper_2_2_chunk._ts_meta_min_1
          Sort Method: quicksort 
-         ->  Seq Scan on _timescaledb_internal.compress_hyper_2_7_chunk (actual rows=3 loops=1)
-               Output: compress_hyper_2_7_chunk."time", compress_hyper_2_7_chunk._ts_meta_min_1, compress_hyper_2_7_chunk._ts_meta_max_1, compress_hyper_2_7_chunk.x1, compress_hyper_2_7_chunk.x2, compress_hyper_2_7_chunk.x3, compress_hyper_2_7_chunk._ts_meta_min_2, compress_hyper_2_7_chunk._ts_meta_max_2, compress_hyper_2_7_chunk.x4, compress_hyper_2_7_chunk._ts_meta_min_3, compress_hyper_2_7_chunk._ts_meta_max_3, compress_hyper_2_7_chunk.x5, compress_hyper_2_7_chunk.c1, compress_hyper_2_7_chunk.c2, compress_hyper_2_7_chunk._ts_meta_count
+         ->  Seq Scan on _timescaledb_internal.compress_hyper_2_2_chunk (actual rows=3 loops=1)
+               Output: compress_hyper_2_2_chunk."time", compress_hyper_2_2_chunk._ts_meta_min_1, compress_hyper_2_2_chunk._ts_meta_max_1, compress_hyper_2_2_chunk.x1, compress_hyper_2_2_chunk.x2, compress_hyper_2_2_chunk.x3, compress_hyper_2_2_chunk._ts_meta_min_2, compress_hyper_2_2_chunk._ts_meta_max_2, compress_hyper_2_2_chunk.x4, compress_hyper_2_2_chunk._ts_meta_min_3, compress_hyper_2_2_chunk._ts_meta_max_3, compress_hyper_2_2_chunk.x5, compress_hyper_2_2_chunk.c1, compress_hyper_2_2_chunk.c2, compress_hyper_2_2_chunk._ts_meta_count
 (10 rows)
 
 BEGIN TRANSACTION;
@@ -1106,11 +1106,11 @@ SELECT * FROM test1 ORDER BY time ASC NULLS LAST;
                Sorted merge append: true
                Bulk Decompression: false
                ->  Sort (actual rows=3 loops=1)
-                     Output: compress_hyper_2_7_chunk."time", compress_hyper_2_7_chunk._ts_meta_min_1, compress_hyper_2_7_chunk._ts_meta_max_1, compress_hyper_2_7_chunk.x1, compress_hyper_2_7_chunk.x2, compress_hyper_2_7_chunk.x3, compress_hyper_2_7_chunk._ts_meta_min_2, compress_hyper_2_7_chunk._ts_meta_max_2, compress_hyper_2_7_chunk.x4, compress_hyper_2_7_chunk._ts_meta_min_3, compress_hyper_2_7_chunk._ts_meta_max_3, compress_hyper_2_7_chunk.x5, compress_hyper_2_7_chunk.c1, compress_hyper_2_7_chunk.c2, compress_hyper_2_7_chunk._ts_meta_count
-                     Sort Key: compress_hyper_2_7_chunk._ts_meta_min_1
+                     Output: compress_hyper_2_2_chunk."time", compress_hyper_2_2_chunk._ts_meta_min_1, compress_hyper_2_2_chunk._ts_meta_max_1, compress_hyper_2_2_chunk.x1, compress_hyper_2_2_chunk.x2, compress_hyper_2_2_chunk.x3, compress_hyper_2_2_chunk._ts_meta_min_2, compress_hyper_2_2_chunk._ts_meta_max_2, compress_hyper_2_2_chunk.x4, compress_hyper_2_2_chunk._ts_meta_min_3, compress_hyper_2_2_chunk._ts_meta_max_3, compress_hyper_2_2_chunk.x5, compress_hyper_2_2_chunk.c1, compress_hyper_2_2_chunk.c2, compress_hyper_2_2_chunk._ts_meta_count
+                     Sort Key: compress_hyper_2_2_chunk._ts_meta_min_1
                      Sort Method: quicksort 
-                     ->  Seq Scan on _timescaledb_internal.compress_hyper_2_7_chunk (actual rows=3 loops=1)
-                           Output: compress_hyper_2_7_chunk."time", compress_hyper_2_7_chunk._ts_meta_min_1, compress_hyper_2_7_chunk._ts_meta_max_1, compress_hyper_2_7_chunk.x1, compress_hyper_2_7_chunk.x2, compress_hyper_2_7_chunk.x3, compress_hyper_2_7_chunk._ts_meta_min_2, compress_hyper_2_7_chunk._ts_meta_max_2, compress_hyper_2_7_chunk.x4, compress_hyper_2_7_chunk._ts_meta_min_3, compress_hyper_2_7_chunk._ts_meta_max_3, compress_hyper_2_7_chunk.x5, compress_hyper_2_7_chunk.c1, compress_hyper_2_7_chunk.c2, compress_hyper_2_7_chunk._ts_meta_count
+                     ->  Seq Scan on _timescaledb_internal.compress_hyper_2_2_chunk (actual rows=3 loops=1)
+                           Output: compress_hyper_2_2_chunk."time", compress_hyper_2_2_chunk._ts_meta_min_1, compress_hyper_2_2_chunk._ts_meta_max_1, compress_hyper_2_2_chunk.x1, compress_hyper_2_2_chunk.x2, compress_hyper_2_2_chunk.x3, compress_hyper_2_2_chunk._ts_meta_min_2, compress_hyper_2_2_chunk._ts_meta_max_2, compress_hyper_2_2_chunk.x4, compress_hyper_2_2_chunk._ts_meta_min_3, compress_hyper_2_2_chunk._ts_meta_max_3, compress_hyper_2_2_chunk.x5, compress_hyper_2_2_chunk.c1, compress_hyper_2_2_chunk.c2, compress_hyper_2_2_chunk._ts_meta_count
          ->  Sort (actual rows=1 loops=1)
                Output: _hyper_1_1_chunk."time", _hyper_1_1_chunk.x1, _hyper_1_1_chunk.x2, _hyper_1_1_chunk.x3, _hyper_1_1_chunk.x4, _hyper_1_1_chunk.x5, _hyper_1_1_chunk.c1, _hyper_1_1_chunk.c2
                Sort Key: _hyper_1_1_chunk."time"
@@ -1164,12 +1164,12 @@ SELECT add_compression_policy('sensor_data','1 minute'::INTERVAL);
 SELECT compress_chunk(i) FROM show_chunks('sensor_data') i;
              compress_chunk              
 -----------------------------------------
+ _timescaledb_internal._hyper_7_7_chunk
  _timescaledb_internal._hyper_7_8_chunk
  _timescaledb_internal._hyper_7_9_chunk
  _timescaledb_internal._hyper_7_10_chunk
  _timescaledb_internal._hyper_7_11_chunk
  _timescaledb_internal._hyper_7_12_chunk
- _timescaledb_internal._hyper_7_13_chunk
 (6 rows)
 
 -- Ensure the optimization is used for queries on this table
@@ -1184,24 +1184,15 @@ SELECT * FROM sensor_data ORDER BY time DESC LIMIT 1;
          Order: sensor_data."time" DESC
          Startup Exclusion: false
          Runtime Exclusion: false
-         ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_7_13_chunk (actual rows=1 loops=1)
-               Output: _hyper_7_13_chunk."time", _hyper_7_13_chunk.sensor_id, _hyper_7_13_chunk.cpu, _hyper_7_13_chunk.temperature
-               Sorted merge append: true
-               Bulk Decompression: false
-               ->  Sort (actual rows=2 loops=1)
-                     Output: compress_hyper_8_19_chunk."time", compress_hyper_8_19_chunk.sensor_id, compress_hyper_8_19_chunk.cpu, compress_hyper_8_19_chunk.temperature, compress_hyper_8_19_chunk._ts_meta_count, compress_hyper_8_19_chunk._ts_meta_sequence_num, compress_hyper_8_19_chunk._ts_meta_min_1, compress_hyper_8_19_chunk._ts_meta_max_1
-                     Sort Key: compress_hyper_8_19_chunk._ts_meta_max_1 DESC
-                     Sort Method: quicksort 
-                     ->  Seq Scan on _timescaledb_internal.compress_hyper_8_19_chunk (actual rows=100 loops=1)
-                           Output: compress_hyper_8_19_chunk."time", compress_hyper_8_19_chunk.sensor_id, compress_hyper_8_19_chunk.cpu, compress_hyper_8_19_chunk.temperature, compress_hyper_8_19_chunk._ts_meta_count, compress_hyper_8_19_chunk._ts_meta_sequence_num, compress_hyper_8_19_chunk._ts_meta_min_1, compress_hyper_8_19_chunk._ts_meta_max_1
-         ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_7_12_chunk (never executed)
+         ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_7_12_chunk (actual rows=1 loops=1)
                Output: _hyper_7_12_chunk."time", _hyper_7_12_chunk.sensor_id, _hyper_7_12_chunk.cpu, _hyper_7_12_chunk.temperature
                Sorted merge append: true
                Bulk Decompression: false
-               ->  Sort (never executed)
+               ->  Sort (actual rows=2 loops=1)
                      Output: compress_hyper_8_18_chunk."time", compress_hyper_8_18_chunk.sensor_id, compress_hyper_8_18_chunk.cpu, compress_hyper_8_18_chunk.temperature, compress_hyper_8_18_chunk._ts_meta_count, compress_hyper_8_18_chunk._ts_meta_sequence_num, compress_hyper_8_18_chunk._ts_meta_min_1, compress_hyper_8_18_chunk._ts_meta_max_1
                      Sort Key: compress_hyper_8_18_chunk._ts_meta_max_1 DESC
-                     ->  Seq Scan on _timescaledb_internal.compress_hyper_8_18_chunk (never executed)
+                     Sort Method: quicksort 
+                     ->  Seq Scan on _timescaledb_internal.compress_hyper_8_18_chunk (actual rows=100 loops=1)
                            Output: compress_hyper_8_18_chunk."time", compress_hyper_8_18_chunk.sensor_id, compress_hyper_8_18_chunk.cpu, compress_hyper_8_18_chunk.temperature, compress_hyper_8_18_chunk._ts_meta_count, compress_hyper_8_18_chunk._ts_meta_sequence_num, compress_hyper_8_18_chunk._ts_meta_min_1, compress_hyper_8_18_chunk._ts_meta_max_1
          ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_7_11_chunk (never executed)
                Output: _hyper_7_11_chunk."time", _hyper_7_11_chunk.sensor_id, _hyper_7_11_chunk.cpu, _hyper_7_11_chunk.temperature
@@ -1239,6 +1230,15 @@ SELECT * FROM sensor_data ORDER BY time DESC LIMIT 1;
                      Sort Key: compress_hyper_8_14_chunk._ts_meta_max_1 DESC
                      ->  Seq Scan on _timescaledb_internal.compress_hyper_8_14_chunk (never executed)
                            Output: compress_hyper_8_14_chunk."time", compress_hyper_8_14_chunk.sensor_id, compress_hyper_8_14_chunk.cpu, compress_hyper_8_14_chunk.temperature, compress_hyper_8_14_chunk._ts_meta_count, compress_hyper_8_14_chunk._ts_meta_sequence_num, compress_hyper_8_14_chunk._ts_meta_min_1, compress_hyper_8_14_chunk._ts_meta_max_1
+         ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_7_7_chunk (never executed)
+               Output: _hyper_7_7_chunk."time", _hyper_7_7_chunk.sensor_id, _hyper_7_7_chunk.cpu, _hyper_7_7_chunk.temperature
+               Sorted merge append: true
+               Bulk Decompression: false
+               ->  Sort (never executed)
+                     Output: compress_hyper_8_13_chunk."time", compress_hyper_8_13_chunk.sensor_id, compress_hyper_8_13_chunk.cpu, compress_hyper_8_13_chunk.temperature, compress_hyper_8_13_chunk._ts_meta_count, compress_hyper_8_13_chunk._ts_meta_sequence_num, compress_hyper_8_13_chunk._ts_meta_min_1, compress_hyper_8_13_chunk._ts_meta_max_1
+                     Sort Key: compress_hyper_8_13_chunk._ts_meta_max_1 DESC
+                     ->  Seq Scan on _timescaledb_internal.compress_hyper_8_13_chunk (never executed)
+                           Output: compress_hyper_8_13_chunk."time", compress_hyper_8_13_chunk.sensor_id, compress_hyper_8_13_chunk.cpu, compress_hyper_8_13_chunk.temperature, compress_hyper_8_13_chunk._ts_meta_count, compress_hyper_8_13_chunk._ts_meta_sequence_num, compress_hyper_8_13_chunk._ts_meta_min_1, compress_hyper_8_13_chunk._ts_meta_max_1
 (62 rows)
 
 -- Verify that we produce the same order without and with the optimization
@@ -1329,7 +1329,7 @@ SELECT add_compression_policy('test_costs','1 minute'::INTERVAL);
 SELECT compress_chunk(i) FROM show_chunks('test_costs') i;
              compress_chunk              
 -----------------------------------------
- _timescaledb_internal._hyper_9_20_chunk
+ _timescaledb_internal._hyper_9_19_chunk
 (1 row)
 
 ANALYZE test_costs;
@@ -1345,23 +1345,23 @@ SELECT count(*) FROM (SELECT segment_by from test_costs group by segment_by) AS 
 SELECT time, segment_by, x1 FROM test_costs ORDER BY time DESC;
                                                                                                                                                                                                QUERY PLAN                                                                                                                                                                                               
 --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
- Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_9_20_chunk (actual rows=100 loops=1)
-   Output: _hyper_9_20_chunk."time", _hyper_9_20_chunk.segment_by, _hyper_9_20_chunk.x1
+ Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_9_19_chunk (actual rows=100 loops=1)
+   Output: _hyper_9_19_chunk."time", _hyper_9_19_chunk.segment_by, _hyper_9_19_chunk.x1
    Sorted merge append: true
    Bulk Decompression: false
    ->  Sort (actual rows=100 loops=1)
-         Output: compress_hyper_10_21_chunk."time", compress_hyper_10_21_chunk.segment_by, compress_hyper_10_21_chunk.x1, compress_hyper_10_21_chunk._ts_meta_count, compress_hyper_10_21_chunk._ts_meta_sequence_num, compress_hyper_10_21_chunk._ts_meta_min_1, compress_hyper_10_21_chunk._ts_meta_max_1, compress_hyper_10_21_chunk._ts_meta_min_2, compress_hyper_10_21_chunk._ts_meta_max_2
-         Sort Key: compress_hyper_10_21_chunk._ts_meta_max_1 DESC
+         Output: compress_hyper_10_20_chunk."time", compress_hyper_10_20_chunk.segment_by, compress_hyper_10_20_chunk.x1, compress_hyper_10_20_chunk._ts_meta_count, compress_hyper_10_20_chunk._ts_meta_sequence_num, compress_hyper_10_20_chunk._ts_meta_min_1, compress_hyper_10_20_chunk._ts_meta_max_1, compress_hyper_10_20_chunk._ts_meta_min_2, compress_hyper_10_20_chunk._ts_meta_max_2
+         Sort Key: compress_hyper_10_20_chunk._ts_meta_max_1 DESC
          Sort Method: quicksort 
-         ->  Seq Scan on _timescaledb_internal.compress_hyper_10_21_chunk (actual rows=100 loops=1)
-               Output: compress_hyper_10_21_chunk."time", compress_hyper_10_21_chunk.segment_by, compress_hyper_10_21_chunk.x1, compress_hyper_10_21_chunk._ts_meta_count, compress_hyper_10_21_chunk._ts_meta_sequence_num, compress_hyper_10_21_chunk._ts_meta_min_1, compress_hyper_10_21_chunk._ts_meta_max_1, compress_hyper_10_21_chunk._ts_meta_min_2, compress_hyper_10_21_chunk._ts_meta_max_2
+         ->  Seq Scan on _timescaledb_internal.compress_hyper_10_20_chunk (actual rows=100 loops=1)
+               Output: compress_hyper_10_20_chunk."time", compress_hyper_10_20_chunk.segment_by, compress_hyper_10_20_chunk.x1, compress_hyper_10_20_chunk._ts_meta_count, compress_hyper_10_20_chunk._ts_meta_sequence_num, compress_hyper_10_20_chunk._ts_meta_min_1, compress_hyper_10_20_chunk._ts_meta_max_1, compress_hyper_10_20_chunk._ts_meta_min_2, compress_hyper_10_20_chunk._ts_meta_max_2
 (10 rows)
 
 -- Decompress chunk
 SELECT decompress_chunk(i) FROM show_chunks('test_costs') i;
             decompress_chunk             
 -----------------------------------------
- _timescaledb_internal._hyper_9_20_chunk
+ _timescaledb_internal._hyper_9_19_chunk
 (1 row)
 
 -- Add 900 segments (1000 segments total)
@@ -1377,7 +1377,7 @@ ORDER BY time;
 SELECT compress_chunk(i) FROM show_chunks('test_costs') i;
              compress_chunk              
 -----------------------------------------
- _timescaledb_internal._hyper_9_20_chunk
+ _timescaledb_internal._hyper_9_19_chunk
 (1 row)
 
 ANALYZE test_costs;
@@ -1394,14 +1394,14 @@ SELECT time, segment_by, x1 FROM test_costs ORDER BY time DESC;
                                                                                                                                                                                                QUERY PLAN                                                                                                                                                                                               
 --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Sort (actual rows=1001 loops=1)
-   Output: _hyper_9_20_chunk."time", _hyper_9_20_chunk.segment_by, _hyper_9_20_chunk.x1
-   Sort Key: _hyper_9_20_chunk."time" DESC
+   Output: _hyper_9_19_chunk."time", _hyper_9_19_chunk.segment_by, _hyper_9_19_chunk.x1
+   Sort Key: _hyper_9_19_chunk."time" DESC
    Sort Method: quicksort 
-   ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_9_20_chunk (actual rows=1001 loops=1)
-         Output: _hyper_9_20_chunk."time", _hyper_9_20_chunk.segment_by, _hyper_9_20_chunk.x1
+   ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_9_19_chunk (actual rows=1001 loops=1)
+         Output: _hyper_9_19_chunk."time", _hyper_9_19_chunk.segment_by, _hyper_9_19_chunk.x1
          Bulk Decompression: true
-         ->  Seq Scan on _timescaledb_internal.compress_hyper_10_22_chunk (actual rows=1000 loops=1)
-               Output: compress_hyper_10_22_chunk."time", compress_hyper_10_22_chunk.segment_by, compress_hyper_10_22_chunk.x1, compress_hyper_10_22_chunk._ts_meta_count, compress_hyper_10_22_chunk._ts_meta_sequence_num, compress_hyper_10_22_chunk._ts_meta_min_1, compress_hyper_10_22_chunk._ts_meta_max_1, compress_hyper_10_22_chunk._ts_meta_min_2, compress_hyper_10_22_chunk._ts_meta_max_2
+         ->  Seq Scan on _timescaledb_internal.compress_hyper_10_20_chunk (actual rows=1000 loops=1)
+               Output: compress_hyper_10_20_chunk."time", compress_hyper_10_20_chunk.segment_by, compress_hyper_10_20_chunk.x1, compress_hyper_10_20_chunk._ts_meta_count, compress_hyper_10_20_chunk._ts_meta_sequence_num, compress_hyper_10_20_chunk._ts_meta_min_1, compress_hyper_10_20_chunk._ts_meta_max_1, compress_hyper_10_20_chunk._ts_meta_min_2, compress_hyper_10_20_chunk._ts_meta_max_2
 (9 rows)
 
 -- Test query plan with predicate (query should be optimized due to ~100 segments)
@@ -1409,17 +1409,17 @@ SELECT time, segment_by, x1 FROM test_costs ORDER BY time DESC;
 SELECT time, segment_by, x1 FROM test_costs WHERE segment_by > 900 and segment_by < 999 ORDER BY time DESC;
                                                                                                                                                                                                QUERY PLAN                                                                                                                                                                                               
 --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
- Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_9_20_chunk (actual rows=98 loops=1)
-   Output: _hyper_9_20_chunk."time", _hyper_9_20_chunk.segment_by, _hyper_9_20_chunk.x1
+ Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_9_19_chunk (actual rows=98 loops=1)
+   Output: _hyper_9_19_chunk."time", _hyper_9_19_chunk.segment_by, _hyper_9_19_chunk.x1
    Sorted merge append: true
    Bulk Decompression: false
    ->  Sort (actual rows=98 loops=1)
-         Output: compress_hyper_10_22_chunk."time", compress_hyper_10_22_chunk.segment_by, compress_hyper_10_22_chunk.x1, compress_hyper_10_22_chunk._ts_meta_count, compress_hyper_10_22_chunk._ts_meta_sequence_num, compress_hyper_10_22_chunk._ts_meta_min_1, compress_hyper_10_22_chunk._ts_meta_max_1, compress_hyper_10_22_chunk._ts_meta_min_2, compress_hyper_10_22_chunk._ts_meta_max_2
-         Sort Key: compress_hyper_10_22_chunk._ts_meta_max_1 DESC
+         Output: compress_hyper_10_20_chunk."time", compress_hyper_10_20_chunk.segment_by, compress_hyper_10_20_chunk.x1, compress_hyper_10_20_chunk._ts_meta_count, compress_hyper_10_20_chunk._ts_meta_sequence_num, compress_hyper_10_20_chunk._ts_meta_min_1, compress_hyper_10_20_chunk._ts_meta_max_1, compress_hyper_10_20_chunk._ts_meta_min_2, compress_hyper_10_20_chunk._ts_meta_max_2
+         Sort Key: compress_hyper_10_20_chunk._ts_meta_max_1 DESC
          Sort Method: quicksort 
-         ->  Index Scan using compress_hyper_10_22_chunk__compressed_hypertable_10_segment_by on _timescaledb_internal.compress_hyper_10_22_chunk (actual rows=98 loops=1)
-               Output: compress_hyper_10_22_chunk."time", compress_hyper_10_22_chunk.segment_by, compress_hyper_10_22_chunk.x1, compress_hyper_10_22_chunk._ts_meta_count, compress_hyper_10_22_chunk._ts_meta_sequence_num, compress_hyper_10_22_chunk._ts_meta_min_1, compress_hyper_10_22_chunk._ts_meta_max_1, compress_hyper_10_22_chunk._ts_meta_min_2, compress_hyper_10_22_chunk._ts_meta_max_2
-               Index Cond: ((compress_hyper_10_22_chunk.segment_by > 900) AND (compress_hyper_10_22_chunk.segment_by < 999))
+         ->  Index Scan using compress_hyper_10_20_chunk__compressed_hypertable_10_segment_by on _timescaledb_internal.compress_hyper_10_20_chunk (actual rows=98 loops=1)
+               Output: compress_hyper_10_20_chunk."time", compress_hyper_10_20_chunk.segment_by, compress_hyper_10_20_chunk.x1, compress_hyper_10_20_chunk._ts_meta_count, compress_hyper_10_20_chunk._ts_meta_sequence_num, compress_hyper_10_20_chunk._ts_meta_min_1, compress_hyper_10_20_chunk._ts_meta_max_1, compress_hyper_10_20_chunk._ts_meta_min_2, compress_hyper_10_20_chunk._ts_meta_max_2
+               Index Cond: ((compress_hyper_10_20_chunk.segment_by > 900) AND (compress_hyper_10_20_chunk.segment_by < 999))
 (11 rows)
 
 -- Target list creation - Issue 5738
@@ -1455,23 +1455,23 @@ SELECT chunk_schema || '.' || chunk_name AS "chunk_table_bugtab"
 SELECT compress_chunk(i) FROM show_chunks('bugtab') i;
               compress_chunk              
 ------------------------------------------
- _timescaledb_internal._hyper_11_23_chunk
+ _timescaledb_internal._hyper_11_21_chunk
 (1 row)
 
 :PREFIX
 SELECT "time","hin"::text,"model"::text,"block"::text,"message_name"::text,"signal_name"::text,"signal_numeric_value","signal_string_value"::text FROM :chunk_table_bugtab ORDER BY "time" DESC;
                                                                                                                                                                                                                                                             QUERY PLAN                                                                                                                                                                                                                                                            
 ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
- Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_11_23_chunk (actual rows=1 loops=1)
-   Output: _hyper_11_23_chunk."time", (_hyper_11_23_chunk.hin)::text, (_hyper_11_23_chunk.model)::text, (_hyper_11_23_chunk.block)::text, (_hyper_11_23_chunk.message_name)::text, (_hyper_11_23_chunk.signal_name)::text, _hyper_11_23_chunk.signal_numeric_value, (_hyper_11_23_chunk.signal_string_value)::text
+ Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_11_21_chunk (actual rows=1 loops=1)
+   Output: _hyper_11_21_chunk."time", (_hyper_11_21_chunk.hin)::text, (_hyper_11_21_chunk.model)::text, (_hyper_11_21_chunk.block)::text, (_hyper_11_21_chunk.message_name)::text, (_hyper_11_21_chunk.signal_name)::text, _hyper_11_21_chunk.signal_numeric_value, (_hyper_11_21_chunk.signal_string_value)::text
    Sorted merge append: true
    Bulk Decompression: false
    ->  Sort (actual rows=1 loops=1)
-         Output: compress_hyper_12_24_chunk."time", compress_hyper_12_24_chunk.hin, compress_hyper_12_24_chunk.model, compress_hyper_12_24_chunk.block, compress_hyper_12_24_chunk.message_name, compress_hyper_12_24_chunk.signal_name, compress_hyper_12_24_chunk.signal_numeric_value, compress_hyper_12_24_chunk.signal_string_value, compress_hyper_12_24_chunk._ts_meta_count, compress_hyper_12_24_chunk._ts_meta_sequence_num, compress_hyper_12_24_chunk._ts_meta_min_1, compress_hyper_12_24_chunk._ts_meta_max_1
-         Sort Key: compress_hyper_12_24_chunk._ts_meta_max_1 DESC
+         Output: compress_hyper_12_22_chunk."time", compress_hyper_12_22_chunk.hin, compress_hyper_12_22_chunk.model, compress_hyper_12_22_chunk.block, compress_hyper_12_22_chunk.message_name, compress_hyper_12_22_chunk.signal_name, compress_hyper_12_22_chunk.signal_numeric_value, compress_hyper_12_22_chunk.signal_string_value, compress_hyper_12_22_chunk._ts_meta_count, compress_hyper_12_22_chunk._ts_meta_sequence_num, compress_hyper_12_22_chunk._ts_meta_min_1, compress_hyper_12_22_chunk._ts_meta_max_1
+         Sort Key: compress_hyper_12_22_chunk._ts_meta_max_1 DESC
          Sort Method: quicksort 
-         ->  Seq Scan on _timescaledb_internal.compress_hyper_12_24_chunk (actual rows=1 loops=1)
-               Output: compress_hyper_12_24_chunk."time", compress_hyper_12_24_chunk.hin, compress_hyper_12_24_chunk.model, compress_hyper_12_24_chunk.block, compress_hyper_12_24_chunk.message_name, compress_hyper_12_24_chunk.signal_name, compress_hyper_12_24_chunk.signal_numeric_value, compress_hyper_12_24_chunk.signal_string_value, compress_hyper_12_24_chunk._ts_meta_count, compress_hyper_12_24_chunk._ts_meta_sequence_num, compress_hyper_12_24_chunk._ts_meta_min_1, compress_hyper_12_24_chunk._ts_meta_max_1
+         ->  Seq Scan on _timescaledb_internal.compress_hyper_12_22_chunk (actual rows=1 loops=1)
+               Output: compress_hyper_12_22_chunk."time", compress_hyper_12_22_chunk.hin, compress_hyper_12_22_chunk.model, compress_hyper_12_22_chunk.block, compress_hyper_12_22_chunk.message_name, compress_hyper_12_22_chunk.signal_name, compress_hyper_12_22_chunk.signal_numeric_value, compress_hyper_12_22_chunk.signal_string_value, compress_hyper_12_22_chunk._ts_meta_count, compress_hyper_12_22_chunk._ts_meta_sequence_num, compress_hyper_12_22_chunk._ts_meta_min_1, compress_hyper_12_22_chunk._ts_meta_max_1
 (10 rows)
 
 SELECT "time","hin"::text,"model"::text,"block"::text,"message_name"::text,"signal_name"::text,"signal_numeric_value","signal_string_value"::text FROM :chunk_table_bugtab ORDER BY "time" DESC;
@@ -1593,7 +1593,7 @@ VALUES  (109288, '2023-05-25 23:12:13.000000', 130, 14499, 13, 0.132165698840012
 SELECT compress_chunk(show_chunks('test', older_than => INTERVAL '1 week'), true);
               compress_chunk              
 ------------------------------------------
- _timescaledb_internal._hyper_13_25_chunk
+ _timescaledb_internal._hyper_13_23_chunk
 (1 row)
 
 SELECT t.dttm FROM test t WHERE t.dttm > '2023-05-25T14:23:12' ORDER BY t.dttm;

--- a/tsl/test/expected/compression_sorted_merge-14.out
+++ b/tsl/test/expected/compression_sorted_merge-14.out
@@ -934,11 +934,11 @@ SELECT * FROM test1 ORDER BY time DESC;
    Sorted merge append: true
    Bulk Decompression: false
    ->  Sort (actual rows=3 loops=1)
-         Output: compress_hyper_2_7_chunk."time", compress_hyper_2_7_chunk._ts_meta_min_1, compress_hyper_2_7_chunk._ts_meta_max_1, compress_hyper_2_7_chunk.x1, compress_hyper_2_7_chunk.x2, compress_hyper_2_7_chunk.x3, compress_hyper_2_7_chunk._ts_meta_min_2, compress_hyper_2_7_chunk._ts_meta_max_2, compress_hyper_2_7_chunk.x4, compress_hyper_2_7_chunk._ts_meta_min_3, compress_hyper_2_7_chunk._ts_meta_max_3, compress_hyper_2_7_chunk.x5, compress_hyper_2_7_chunk.c1, compress_hyper_2_7_chunk.c2, compress_hyper_2_7_chunk._ts_meta_count
-         Sort Key: compress_hyper_2_7_chunk._ts_meta_max_1 DESC
+         Output: compress_hyper_2_2_chunk."time", compress_hyper_2_2_chunk._ts_meta_min_1, compress_hyper_2_2_chunk._ts_meta_max_1, compress_hyper_2_2_chunk.x1, compress_hyper_2_2_chunk.x2, compress_hyper_2_2_chunk.x3, compress_hyper_2_2_chunk._ts_meta_min_2, compress_hyper_2_2_chunk._ts_meta_max_2, compress_hyper_2_2_chunk.x4, compress_hyper_2_2_chunk._ts_meta_min_3, compress_hyper_2_2_chunk._ts_meta_max_3, compress_hyper_2_2_chunk.x5, compress_hyper_2_2_chunk.c1, compress_hyper_2_2_chunk.c2, compress_hyper_2_2_chunk._ts_meta_count
+         Sort Key: compress_hyper_2_2_chunk._ts_meta_max_1 DESC
          Sort Method: quicksort 
-         ->  Seq Scan on _timescaledb_internal.compress_hyper_2_7_chunk (actual rows=3 loops=1)
-               Output: compress_hyper_2_7_chunk."time", compress_hyper_2_7_chunk._ts_meta_min_1, compress_hyper_2_7_chunk._ts_meta_max_1, compress_hyper_2_7_chunk.x1, compress_hyper_2_7_chunk.x2, compress_hyper_2_7_chunk.x3, compress_hyper_2_7_chunk._ts_meta_min_2, compress_hyper_2_7_chunk._ts_meta_max_2, compress_hyper_2_7_chunk.x4, compress_hyper_2_7_chunk._ts_meta_min_3, compress_hyper_2_7_chunk._ts_meta_max_3, compress_hyper_2_7_chunk.x5, compress_hyper_2_7_chunk.c1, compress_hyper_2_7_chunk.c2, compress_hyper_2_7_chunk._ts_meta_count
+         ->  Seq Scan on _timescaledb_internal.compress_hyper_2_2_chunk (actual rows=3 loops=1)
+               Output: compress_hyper_2_2_chunk."time", compress_hyper_2_2_chunk._ts_meta_min_1, compress_hyper_2_2_chunk._ts_meta_max_1, compress_hyper_2_2_chunk.x1, compress_hyper_2_2_chunk.x2, compress_hyper_2_2_chunk.x3, compress_hyper_2_2_chunk._ts_meta_min_2, compress_hyper_2_2_chunk._ts_meta_max_2, compress_hyper_2_2_chunk.x4, compress_hyper_2_2_chunk._ts_meta_min_3, compress_hyper_2_2_chunk._ts_meta_max_3, compress_hyper_2_2_chunk.x5, compress_hyper_2_2_chunk.c1, compress_hyper_2_2_chunk.c2, compress_hyper_2_2_chunk._ts_meta_count
 (10 rows)
 
 SELECT * FROM test1 ORDER BY time DESC;
@@ -960,11 +960,11 @@ SELECT time, x2, x1, c2 FROM test1 ORDER BY time DESC;
    Sorted merge append: true
    Bulk Decompression: false
    ->  Sort (actual rows=3 loops=1)
-         Output: compress_hyper_2_7_chunk."time", compress_hyper_2_7_chunk._ts_meta_min_1, compress_hyper_2_7_chunk._ts_meta_max_1, compress_hyper_2_7_chunk.x2, compress_hyper_2_7_chunk.x1, compress_hyper_2_7_chunk.c2, compress_hyper_2_7_chunk._ts_meta_count
-         Sort Key: compress_hyper_2_7_chunk._ts_meta_max_1 DESC
+         Output: compress_hyper_2_2_chunk."time", compress_hyper_2_2_chunk._ts_meta_min_1, compress_hyper_2_2_chunk._ts_meta_max_1, compress_hyper_2_2_chunk.x2, compress_hyper_2_2_chunk.x1, compress_hyper_2_2_chunk.c2, compress_hyper_2_2_chunk._ts_meta_count
+         Sort Key: compress_hyper_2_2_chunk._ts_meta_max_1 DESC
          Sort Method: quicksort 
-         ->  Seq Scan on _timescaledb_internal.compress_hyper_2_7_chunk (actual rows=3 loops=1)
-               Output: compress_hyper_2_7_chunk."time", compress_hyper_2_7_chunk._ts_meta_min_1, compress_hyper_2_7_chunk._ts_meta_max_1, compress_hyper_2_7_chunk.x2, compress_hyper_2_7_chunk.x1, compress_hyper_2_7_chunk.c2, compress_hyper_2_7_chunk._ts_meta_count
+         ->  Seq Scan on _timescaledb_internal.compress_hyper_2_2_chunk (actual rows=3 loops=1)
+               Output: compress_hyper_2_2_chunk."time", compress_hyper_2_2_chunk._ts_meta_min_1, compress_hyper_2_2_chunk._ts_meta_max_1, compress_hyper_2_2_chunk.x2, compress_hyper_2_2_chunk.x1, compress_hyper_2_2_chunk.c2, compress_hyper_2_2_chunk._ts_meta_count
 (10 rows)
 
 SELECT time, x2, x1, c2 FROM test1 ORDER BY time DESC;
@@ -986,11 +986,11 @@ SELECT x2, x1, c2, time FROM test1 ORDER BY time DESC;
    Sorted merge append: true
    Bulk Decompression: false
    ->  Sort (actual rows=3 loops=1)
-         Output: compress_hyper_2_7_chunk.x2, compress_hyper_2_7_chunk.x1, compress_hyper_2_7_chunk.c2, compress_hyper_2_7_chunk."time", compress_hyper_2_7_chunk._ts_meta_min_1, compress_hyper_2_7_chunk._ts_meta_max_1, compress_hyper_2_7_chunk._ts_meta_count
-         Sort Key: compress_hyper_2_7_chunk._ts_meta_max_1 DESC
+         Output: compress_hyper_2_2_chunk.x2, compress_hyper_2_2_chunk.x1, compress_hyper_2_2_chunk.c2, compress_hyper_2_2_chunk."time", compress_hyper_2_2_chunk._ts_meta_min_1, compress_hyper_2_2_chunk._ts_meta_max_1, compress_hyper_2_2_chunk._ts_meta_count
+         Sort Key: compress_hyper_2_2_chunk._ts_meta_max_1 DESC
          Sort Method: quicksort 
-         ->  Seq Scan on _timescaledb_internal.compress_hyper_2_7_chunk (actual rows=3 loops=1)
-               Output: compress_hyper_2_7_chunk.x2, compress_hyper_2_7_chunk.x1, compress_hyper_2_7_chunk.c2, compress_hyper_2_7_chunk."time", compress_hyper_2_7_chunk._ts_meta_min_1, compress_hyper_2_7_chunk._ts_meta_max_1, compress_hyper_2_7_chunk._ts_meta_count
+         ->  Seq Scan on _timescaledb_internal.compress_hyper_2_2_chunk (actual rows=3 loops=1)
+               Output: compress_hyper_2_2_chunk.x2, compress_hyper_2_2_chunk.x1, compress_hyper_2_2_chunk.c2, compress_hyper_2_2_chunk."time", compress_hyper_2_2_chunk._ts_meta_min_1, compress_hyper_2_2_chunk._ts_meta_max_1, compress_hyper_2_2_chunk._ts_meta_count
 (10 rows)
 
 SELECT x2, x1, c2, time FROM test1 ORDER BY time DESC;
@@ -1014,11 +1014,11 @@ SELECT 1 as one, 2 as two, 3 as three, x2, x1, c2, time FROM test1 ORDER BY time
          Sorted merge append: true
          Bulk Decompression: false
          ->  Sort (actual rows=3 loops=1)
-               Output: compress_hyper_2_7_chunk.x2, compress_hyper_2_7_chunk.x1, compress_hyper_2_7_chunk.c2, compress_hyper_2_7_chunk."time", compress_hyper_2_7_chunk._ts_meta_min_1, compress_hyper_2_7_chunk._ts_meta_max_1, compress_hyper_2_7_chunk._ts_meta_count
-               Sort Key: compress_hyper_2_7_chunk._ts_meta_max_1 DESC
+               Output: compress_hyper_2_2_chunk.x2, compress_hyper_2_2_chunk.x1, compress_hyper_2_2_chunk.c2, compress_hyper_2_2_chunk."time", compress_hyper_2_2_chunk._ts_meta_min_1, compress_hyper_2_2_chunk._ts_meta_max_1, compress_hyper_2_2_chunk._ts_meta_count
+               Sort Key: compress_hyper_2_2_chunk._ts_meta_max_1 DESC
                Sort Method: quicksort 
-               ->  Seq Scan on _timescaledb_internal.compress_hyper_2_7_chunk (actual rows=3 loops=1)
-                     Output: compress_hyper_2_7_chunk.x2, compress_hyper_2_7_chunk.x1, compress_hyper_2_7_chunk.c2, compress_hyper_2_7_chunk."time", compress_hyper_2_7_chunk._ts_meta_min_1, compress_hyper_2_7_chunk._ts_meta_max_1, compress_hyper_2_7_chunk._ts_meta_count
+               ->  Seq Scan on _timescaledb_internal.compress_hyper_2_2_chunk (actual rows=3 loops=1)
+                     Output: compress_hyper_2_2_chunk.x2, compress_hyper_2_2_chunk.x1, compress_hyper_2_2_chunk.c2, compress_hyper_2_2_chunk."time", compress_hyper_2_2_chunk._ts_meta_min_1, compress_hyper_2_2_chunk._ts_meta_max_1, compress_hyper_2_2_chunk._ts_meta_count
 (12 rows)
 
 SELECT 1 as one, 2 as two, 3 as three, x2, x1, c2, time FROM test1 ORDER BY time DESC;
@@ -1080,11 +1080,11 @@ SELECT * FROM test1 ORDER BY time ASC NULLS LAST;
    Sorted merge append: true
    Bulk Decompression: false
    ->  Sort (actual rows=3 loops=1)
-         Output: compress_hyper_2_7_chunk."time", compress_hyper_2_7_chunk._ts_meta_min_1, compress_hyper_2_7_chunk._ts_meta_max_1, compress_hyper_2_7_chunk.x1, compress_hyper_2_7_chunk.x2, compress_hyper_2_7_chunk.x3, compress_hyper_2_7_chunk._ts_meta_min_2, compress_hyper_2_7_chunk._ts_meta_max_2, compress_hyper_2_7_chunk.x4, compress_hyper_2_7_chunk._ts_meta_min_3, compress_hyper_2_7_chunk._ts_meta_max_3, compress_hyper_2_7_chunk.x5, compress_hyper_2_7_chunk.c1, compress_hyper_2_7_chunk.c2, compress_hyper_2_7_chunk._ts_meta_count
-         Sort Key: compress_hyper_2_7_chunk._ts_meta_min_1
+         Output: compress_hyper_2_2_chunk."time", compress_hyper_2_2_chunk._ts_meta_min_1, compress_hyper_2_2_chunk._ts_meta_max_1, compress_hyper_2_2_chunk.x1, compress_hyper_2_2_chunk.x2, compress_hyper_2_2_chunk.x3, compress_hyper_2_2_chunk._ts_meta_min_2, compress_hyper_2_2_chunk._ts_meta_max_2, compress_hyper_2_2_chunk.x4, compress_hyper_2_2_chunk._ts_meta_min_3, compress_hyper_2_2_chunk._ts_meta_max_3, compress_hyper_2_2_chunk.x5, compress_hyper_2_2_chunk.c1, compress_hyper_2_2_chunk.c2, compress_hyper_2_2_chunk._ts_meta_count
+         Sort Key: compress_hyper_2_2_chunk._ts_meta_min_1
          Sort Method: quicksort 
-         ->  Seq Scan on _timescaledb_internal.compress_hyper_2_7_chunk (actual rows=3 loops=1)
-               Output: compress_hyper_2_7_chunk."time", compress_hyper_2_7_chunk._ts_meta_min_1, compress_hyper_2_7_chunk._ts_meta_max_1, compress_hyper_2_7_chunk.x1, compress_hyper_2_7_chunk.x2, compress_hyper_2_7_chunk.x3, compress_hyper_2_7_chunk._ts_meta_min_2, compress_hyper_2_7_chunk._ts_meta_max_2, compress_hyper_2_7_chunk.x4, compress_hyper_2_7_chunk._ts_meta_min_3, compress_hyper_2_7_chunk._ts_meta_max_3, compress_hyper_2_7_chunk.x5, compress_hyper_2_7_chunk.c1, compress_hyper_2_7_chunk.c2, compress_hyper_2_7_chunk._ts_meta_count
+         ->  Seq Scan on _timescaledb_internal.compress_hyper_2_2_chunk (actual rows=3 loops=1)
+               Output: compress_hyper_2_2_chunk."time", compress_hyper_2_2_chunk._ts_meta_min_1, compress_hyper_2_2_chunk._ts_meta_max_1, compress_hyper_2_2_chunk.x1, compress_hyper_2_2_chunk.x2, compress_hyper_2_2_chunk.x3, compress_hyper_2_2_chunk._ts_meta_min_2, compress_hyper_2_2_chunk._ts_meta_max_2, compress_hyper_2_2_chunk.x4, compress_hyper_2_2_chunk._ts_meta_min_3, compress_hyper_2_2_chunk._ts_meta_max_3, compress_hyper_2_2_chunk.x5, compress_hyper_2_2_chunk.c1, compress_hyper_2_2_chunk.c2, compress_hyper_2_2_chunk._ts_meta_count
 (10 rows)
 
 BEGIN TRANSACTION;
@@ -1106,11 +1106,11 @@ SELECT * FROM test1 ORDER BY time ASC NULLS LAST;
                Sorted merge append: true
                Bulk Decompression: false
                ->  Sort (actual rows=3 loops=1)
-                     Output: compress_hyper_2_7_chunk."time", compress_hyper_2_7_chunk._ts_meta_min_1, compress_hyper_2_7_chunk._ts_meta_max_1, compress_hyper_2_7_chunk.x1, compress_hyper_2_7_chunk.x2, compress_hyper_2_7_chunk.x3, compress_hyper_2_7_chunk._ts_meta_min_2, compress_hyper_2_7_chunk._ts_meta_max_2, compress_hyper_2_7_chunk.x4, compress_hyper_2_7_chunk._ts_meta_min_3, compress_hyper_2_7_chunk._ts_meta_max_3, compress_hyper_2_7_chunk.x5, compress_hyper_2_7_chunk.c1, compress_hyper_2_7_chunk.c2, compress_hyper_2_7_chunk._ts_meta_count
-                     Sort Key: compress_hyper_2_7_chunk._ts_meta_min_1
+                     Output: compress_hyper_2_2_chunk."time", compress_hyper_2_2_chunk._ts_meta_min_1, compress_hyper_2_2_chunk._ts_meta_max_1, compress_hyper_2_2_chunk.x1, compress_hyper_2_2_chunk.x2, compress_hyper_2_2_chunk.x3, compress_hyper_2_2_chunk._ts_meta_min_2, compress_hyper_2_2_chunk._ts_meta_max_2, compress_hyper_2_2_chunk.x4, compress_hyper_2_2_chunk._ts_meta_min_3, compress_hyper_2_2_chunk._ts_meta_max_3, compress_hyper_2_2_chunk.x5, compress_hyper_2_2_chunk.c1, compress_hyper_2_2_chunk.c2, compress_hyper_2_2_chunk._ts_meta_count
+                     Sort Key: compress_hyper_2_2_chunk._ts_meta_min_1
                      Sort Method: quicksort 
-                     ->  Seq Scan on _timescaledb_internal.compress_hyper_2_7_chunk (actual rows=3 loops=1)
-                           Output: compress_hyper_2_7_chunk."time", compress_hyper_2_7_chunk._ts_meta_min_1, compress_hyper_2_7_chunk._ts_meta_max_1, compress_hyper_2_7_chunk.x1, compress_hyper_2_7_chunk.x2, compress_hyper_2_7_chunk.x3, compress_hyper_2_7_chunk._ts_meta_min_2, compress_hyper_2_7_chunk._ts_meta_max_2, compress_hyper_2_7_chunk.x4, compress_hyper_2_7_chunk._ts_meta_min_3, compress_hyper_2_7_chunk._ts_meta_max_3, compress_hyper_2_7_chunk.x5, compress_hyper_2_7_chunk.c1, compress_hyper_2_7_chunk.c2, compress_hyper_2_7_chunk._ts_meta_count
+                     ->  Seq Scan on _timescaledb_internal.compress_hyper_2_2_chunk (actual rows=3 loops=1)
+                           Output: compress_hyper_2_2_chunk."time", compress_hyper_2_2_chunk._ts_meta_min_1, compress_hyper_2_2_chunk._ts_meta_max_1, compress_hyper_2_2_chunk.x1, compress_hyper_2_2_chunk.x2, compress_hyper_2_2_chunk.x3, compress_hyper_2_2_chunk._ts_meta_min_2, compress_hyper_2_2_chunk._ts_meta_max_2, compress_hyper_2_2_chunk.x4, compress_hyper_2_2_chunk._ts_meta_min_3, compress_hyper_2_2_chunk._ts_meta_max_3, compress_hyper_2_2_chunk.x5, compress_hyper_2_2_chunk.c1, compress_hyper_2_2_chunk.c2, compress_hyper_2_2_chunk._ts_meta_count
          ->  Sort (actual rows=1 loops=1)
                Output: _hyper_1_1_chunk."time", _hyper_1_1_chunk.x1, _hyper_1_1_chunk.x2, _hyper_1_1_chunk.x3, _hyper_1_1_chunk.x4, _hyper_1_1_chunk.x5, _hyper_1_1_chunk.c1, _hyper_1_1_chunk.c2
                Sort Key: _hyper_1_1_chunk."time"
@@ -1164,12 +1164,12 @@ SELECT add_compression_policy('sensor_data','1 minute'::INTERVAL);
 SELECT compress_chunk(i) FROM show_chunks('sensor_data') i;
              compress_chunk              
 -----------------------------------------
+ _timescaledb_internal._hyper_7_7_chunk
  _timescaledb_internal._hyper_7_8_chunk
  _timescaledb_internal._hyper_7_9_chunk
  _timescaledb_internal._hyper_7_10_chunk
  _timescaledb_internal._hyper_7_11_chunk
  _timescaledb_internal._hyper_7_12_chunk
- _timescaledb_internal._hyper_7_13_chunk
 (6 rows)
 
 -- Ensure the optimization is used for queries on this table
@@ -1184,24 +1184,15 @@ SELECT * FROM sensor_data ORDER BY time DESC LIMIT 1;
          Order: sensor_data."time" DESC
          Startup Exclusion: false
          Runtime Exclusion: false
-         ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_7_13_chunk (actual rows=1 loops=1)
-               Output: _hyper_7_13_chunk."time", _hyper_7_13_chunk.sensor_id, _hyper_7_13_chunk.cpu, _hyper_7_13_chunk.temperature
-               Sorted merge append: true
-               Bulk Decompression: false
-               ->  Sort (actual rows=2 loops=1)
-                     Output: compress_hyper_8_19_chunk."time", compress_hyper_8_19_chunk.sensor_id, compress_hyper_8_19_chunk.cpu, compress_hyper_8_19_chunk.temperature, compress_hyper_8_19_chunk._ts_meta_count, compress_hyper_8_19_chunk._ts_meta_sequence_num, compress_hyper_8_19_chunk._ts_meta_min_1, compress_hyper_8_19_chunk._ts_meta_max_1
-                     Sort Key: compress_hyper_8_19_chunk._ts_meta_max_1 DESC
-                     Sort Method: quicksort 
-                     ->  Seq Scan on _timescaledb_internal.compress_hyper_8_19_chunk (actual rows=100 loops=1)
-                           Output: compress_hyper_8_19_chunk."time", compress_hyper_8_19_chunk.sensor_id, compress_hyper_8_19_chunk.cpu, compress_hyper_8_19_chunk.temperature, compress_hyper_8_19_chunk._ts_meta_count, compress_hyper_8_19_chunk._ts_meta_sequence_num, compress_hyper_8_19_chunk._ts_meta_min_1, compress_hyper_8_19_chunk._ts_meta_max_1
-         ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_7_12_chunk (never executed)
+         ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_7_12_chunk (actual rows=1 loops=1)
                Output: _hyper_7_12_chunk."time", _hyper_7_12_chunk.sensor_id, _hyper_7_12_chunk.cpu, _hyper_7_12_chunk.temperature
                Sorted merge append: true
                Bulk Decompression: false
-               ->  Sort (never executed)
+               ->  Sort (actual rows=2 loops=1)
                      Output: compress_hyper_8_18_chunk."time", compress_hyper_8_18_chunk.sensor_id, compress_hyper_8_18_chunk.cpu, compress_hyper_8_18_chunk.temperature, compress_hyper_8_18_chunk._ts_meta_count, compress_hyper_8_18_chunk._ts_meta_sequence_num, compress_hyper_8_18_chunk._ts_meta_min_1, compress_hyper_8_18_chunk._ts_meta_max_1
                      Sort Key: compress_hyper_8_18_chunk._ts_meta_max_1 DESC
-                     ->  Seq Scan on _timescaledb_internal.compress_hyper_8_18_chunk (never executed)
+                     Sort Method: quicksort 
+                     ->  Seq Scan on _timescaledb_internal.compress_hyper_8_18_chunk (actual rows=100 loops=1)
                            Output: compress_hyper_8_18_chunk."time", compress_hyper_8_18_chunk.sensor_id, compress_hyper_8_18_chunk.cpu, compress_hyper_8_18_chunk.temperature, compress_hyper_8_18_chunk._ts_meta_count, compress_hyper_8_18_chunk._ts_meta_sequence_num, compress_hyper_8_18_chunk._ts_meta_min_1, compress_hyper_8_18_chunk._ts_meta_max_1
          ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_7_11_chunk (never executed)
                Output: _hyper_7_11_chunk."time", _hyper_7_11_chunk.sensor_id, _hyper_7_11_chunk.cpu, _hyper_7_11_chunk.temperature
@@ -1239,6 +1230,15 @@ SELECT * FROM sensor_data ORDER BY time DESC LIMIT 1;
                      Sort Key: compress_hyper_8_14_chunk._ts_meta_max_1 DESC
                      ->  Seq Scan on _timescaledb_internal.compress_hyper_8_14_chunk (never executed)
                            Output: compress_hyper_8_14_chunk."time", compress_hyper_8_14_chunk.sensor_id, compress_hyper_8_14_chunk.cpu, compress_hyper_8_14_chunk.temperature, compress_hyper_8_14_chunk._ts_meta_count, compress_hyper_8_14_chunk._ts_meta_sequence_num, compress_hyper_8_14_chunk._ts_meta_min_1, compress_hyper_8_14_chunk._ts_meta_max_1
+         ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_7_7_chunk (never executed)
+               Output: _hyper_7_7_chunk."time", _hyper_7_7_chunk.sensor_id, _hyper_7_7_chunk.cpu, _hyper_7_7_chunk.temperature
+               Sorted merge append: true
+               Bulk Decompression: false
+               ->  Sort (never executed)
+                     Output: compress_hyper_8_13_chunk."time", compress_hyper_8_13_chunk.sensor_id, compress_hyper_8_13_chunk.cpu, compress_hyper_8_13_chunk.temperature, compress_hyper_8_13_chunk._ts_meta_count, compress_hyper_8_13_chunk._ts_meta_sequence_num, compress_hyper_8_13_chunk._ts_meta_min_1, compress_hyper_8_13_chunk._ts_meta_max_1
+                     Sort Key: compress_hyper_8_13_chunk._ts_meta_max_1 DESC
+                     ->  Seq Scan on _timescaledb_internal.compress_hyper_8_13_chunk (never executed)
+                           Output: compress_hyper_8_13_chunk."time", compress_hyper_8_13_chunk.sensor_id, compress_hyper_8_13_chunk.cpu, compress_hyper_8_13_chunk.temperature, compress_hyper_8_13_chunk._ts_meta_count, compress_hyper_8_13_chunk._ts_meta_sequence_num, compress_hyper_8_13_chunk._ts_meta_min_1, compress_hyper_8_13_chunk._ts_meta_max_1
 (62 rows)
 
 -- Verify that we produce the same order without and with the optimization
@@ -1329,7 +1329,7 @@ SELECT add_compression_policy('test_costs','1 minute'::INTERVAL);
 SELECT compress_chunk(i) FROM show_chunks('test_costs') i;
              compress_chunk              
 -----------------------------------------
- _timescaledb_internal._hyper_9_20_chunk
+ _timescaledb_internal._hyper_9_19_chunk
 (1 row)
 
 ANALYZE test_costs;
@@ -1345,23 +1345,23 @@ SELECT count(*) FROM (SELECT segment_by from test_costs group by segment_by) AS 
 SELECT time, segment_by, x1 FROM test_costs ORDER BY time DESC;
                                                                                                                                                                                                QUERY PLAN                                                                                                                                                                                               
 --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
- Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_9_20_chunk (actual rows=100 loops=1)
-   Output: _hyper_9_20_chunk."time", _hyper_9_20_chunk.segment_by, _hyper_9_20_chunk.x1
+ Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_9_19_chunk (actual rows=100 loops=1)
+   Output: _hyper_9_19_chunk."time", _hyper_9_19_chunk.segment_by, _hyper_9_19_chunk.x1
    Sorted merge append: true
    Bulk Decompression: false
    ->  Sort (actual rows=100 loops=1)
-         Output: compress_hyper_10_21_chunk."time", compress_hyper_10_21_chunk.segment_by, compress_hyper_10_21_chunk.x1, compress_hyper_10_21_chunk._ts_meta_count, compress_hyper_10_21_chunk._ts_meta_sequence_num, compress_hyper_10_21_chunk._ts_meta_min_1, compress_hyper_10_21_chunk._ts_meta_max_1, compress_hyper_10_21_chunk._ts_meta_min_2, compress_hyper_10_21_chunk._ts_meta_max_2
-         Sort Key: compress_hyper_10_21_chunk._ts_meta_max_1 DESC
+         Output: compress_hyper_10_20_chunk."time", compress_hyper_10_20_chunk.segment_by, compress_hyper_10_20_chunk.x1, compress_hyper_10_20_chunk._ts_meta_count, compress_hyper_10_20_chunk._ts_meta_sequence_num, compress_hyper_10_20_chunk._ts_meta_min_1, compress_hyper_10_20_chunk._ts_meta_max_1, compress_hyper_10_20_chunk._ts_meta_min_2, compress_hyper_10_20_chunk._ts_meta_max_2
+         Sort Key: compress_hyper_10_20_chunk._ts_meta_max_1 DESC
          Sort Method: quicksort 
-         ->  Seq Scan on _timescaledb_internal.compress_hyper_10_21_chunk (actual rows=100 loops=1)
-               Output: compress_hyper_10_21_chunk."time", compress_hyper_10_21_chunk.segment_by, compress_hyper_10_21_chunk.x1, compress_hyper_10_21_chunk._ts_meta_count, compress_hyper_10_21_chunk._ts_meta_sequence_num, compress_hyper_10_21_chunk._ts_meta_min_1, compress_hyper_10_21_chunk._ts_meta_max_1, compress_hyper_10_21_chunk._ts_meta_min_2, compress_hyper_10_21_chunk._ts_meta_max_2
+         ->  Seq Scan on _timescaledb_internal.compress_hyper_10_20_chunk (actual rows=100 loops=1)
+               Output: compress_hyper_10_20_chunk."time", compress_hyper_10_20_chunk.segment_by, compress_hyper_10_20_chunk.x1, compress_hyper_10_20_chunk._ts_meta_count, compress_hyper_10_20_chunk._ts_meta_sequence_num, compress_hyper_10_20_chunk._ts_meta_min_1, compress_hyper_10_20_chunk._ts_meta_max_1, compress_hyper_10_20_chunk._ts_meta_min_2, compress_hyper_10_20_chunk._ts_meta_max_2
 (10 rows)
 
 -- Decompress chunk
 SELECT decompress_chunk(i) FROM show_chunks('test_costs') i;
             decompress_chunk             
 -----------------------------------------
- _timescaledb_internal._hyper_9_20_chunk
+ _timescaledb_internal._hyper_9_19_chunk
 (1 row)
 
 -- Add 900 segments (1000 segments total)
@@ -1377,7 +1377,7 @@ ORDER BY time;
 SELECT compress_chunk(i) FROM show_chunks('test_costs') i;
              compress_chunk              
 -----------------------------------------
- _timescaledb_internal._hyper_9_20_chunk
+ _timescaledb_internal._hyper_9_19_chunk
 (1 row)
 
 ANALYZE test_costs;
@@ -1394,14 +1394,14 @@ SELECT time, segment_by, x1 FROM test_costs ORDER BY time DESC;
                                                                                                                                                                                                QUERY PLAN                                                                                                                                                                                               
 --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Sort (actual rows=1001 loops=1)
-   Output: _hyper_9_20_chunk."time", _hyper_9_20_chunk.segment_by, _hyper_9_20_chunk.x1
-   Sort Key: _hyper_9_20_chunk."time" DESC
+   Output: _hyper_9_19_chunk."time", _hyper_9_19_chunk.segment_by, _hyper_9_19_chunk.x1
+   Sort Key: _hyper_9_19_chunk."time" DESC
    Sort Method: quicksort 
-   ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_9_20_chunk (actual rows=1001 loops=1)
-         Output: _hyper_9_20_chunk."time", _hyper_9_20_chunk.segment_by, _hyper_9_20_chunk.x1
+   ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_9_19_chunk (actual rows=1001 loops=1)
+         Output: _hyper_9_19_chunk."time", _hyper_9_19_chunk.segment_by, _hyper_9_19_chunk.x1
          Bulk Decompression: true
-         ->  Seq Scan on _timescaledb_internal.compress_hyper_10_22_chunk (actual rows=1000 loops=1)
-               Output: compress_hyper_10_22_chunk."time", compress_hyper_10_22_chunk.segment_by, compress_hyper_10_22_chunk.x1, compress_hyper_10_22_chunk._ts_meta_count, compress_hyper_10_22_chunk._ts_meta_sequence_num, compress_hyper_10_22_chunk._ts_meta_min_1, compress_hyper_10_22_chunk._ts_meta_max_1, compress_hyper_10_22_chunk._ts_meta_min_2, compress_hyper_10_22_chunk._ts_meta_max_2
+         ->  Seq Scan on _timescaledb_internal.compress_hyper_10_20_chunk (actual rows=1000 loops=1)
+               Output: compress_hyper_10_20_chunk."time", compress_hyper_10_20_chunk.segment_by, compress_hyper_10_20_chunk.x1, compress_hyper_10_20_chunk._ts_meta_count, compress_hyper_10_20_chunk._ts_meta_sequence_num, compress_hyper_10_20_chunk._ts_meta_min_1, compress_hyper_10_20_chunk._ts_meta_max_1, compress_hyper_10_20_chunk._ts_meta_min_2, compress_hyper_10_20_chunk._ts_meta_max_2
 (9 rows)
 
 -- Test query plan with predicate (query should be optimized due to ~100 segments)
@@ -1409,17 +1409,17 @@ SELECT time, segment_by, x1 FROM test_costs ORDER BY time DESC;
 SELECT time, segment_by, x1 FROM test_costs WHERE segment_by > 900 and segment_by < 999 ORDER BY time DESC;
                                                                                                                                                                                                QUERY PLAN                                                                                                                                                                                               
 --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
- Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_9_20_chunk (actual rows=98 loops=1)
-   Output: _hyper_9_20_chunk."time", _hyper_9_20_chunk.segment_by, _hyper_9_20_chunk.x1
+ Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_9_19_chunk (actual rows=98 loops=1)
+   Output: _hyper_9_19_chunk."time", _hyper_9_19_chunk.segment_by, _hyper_9_19_chunk.x1
    Sorted merge append: true
    Bulk Decompression: false
    ->  Sort (actual rows=98 loops=1)
-         Output: compress_hyper_10_22_chunk."time", compress_hyper_10_22_chunk.segment_by, compress_hyper_10_22_chunk.x1, compress_hyper_10_22_chunk._ts_meta_count, compress_hyper_10_22_chunk._ts_meta_sequence_num, compress_hyper_10_22_chunk._ts_meta_min_1, compress_hyper_10_22_chunk._ts_meta_max_1, compress_hyper_10_22_chunk._ts_meta_min_2, compress_hyper_10_22_chunk._ts_meta_max_2
-         Sort Key: compress_hyper_10_22_chunk._ts_meta_max_1 DESC
+         Output: compress_hyper_10_20_chunk."time", compress_hyper_10_20_chunk.segment_by, compress_hyper_10_20_chunk.x1, compress_hyper_10_20_chunk._ts_meta_count, compress_hyper_10_20_chunk._ts_meta_sequence_num, compress_hyper_10_20_chunk._ts_meta_min_1, compress_hyper_10_20_chunk._ts_meta_max_1, compress_hyper_10_20_chunk._ts_meta_min_2, compress_hyper_10_20_chunk._ts_meta_max_2
+         Sort Key: compress_hyper_10_20_chunk._ts_meta_max_1 DESC
          Sort Method: quicksort 
-         ->  Index Scan using compress_hyper_10_22_chunk__compressed_hypertable_10_segment_by on _timescaledb_internal.compress_hyper_10_22_chunk (actual rows=98 loops=1)
-               Output: compress_hyper_10_22_chunk."time", compress_hyper_10_22_chunk.segment_by, compress_hyper_10_22_chunk.x1, compress_hyper_10_22_chunk._ts_meta_count, compress_hyper_10_22_chunk._ts_meta_sequence_num, compress_hyper_10_22_chunk._ts_meta_min_1, compress_hyper_10_22_chunk._ts_meta_max_1, compress_hyper_10_22_chunk._ts_meta_min_2, compress_hyper_10_22_chunk._ts_meta_max_2
-               Index Cond: ((compress_hyper_10_22_chunk.segment_by > 900) AND (compress_hyper_10_22_chunk.segment_by < 999))
+         ->  Index Scan using compress_hyper_10_20_chunk__compressed_hypertable_10_segment_by on _timescaledb_internal.compress_hyper_10_20_chunk (actual rows=98 loops=1)
+               Output: compress_hyper_10_20_chunk."time", compress_hyper_10_20_chunk.segment_by, compress_hyper_10_20_chunk.x1, compress_hyper_10_20_chunk._ts_meta_count, compress_hyper_10_20_chunk._ts_meta_sequence_num, compress_hyper_10_20_chunk._ts_meta_min_1, compress_hyper_10_20_chunk._ts_meta_max_1, compress_hyper_10_20_chunk._ts_meta_min_2, compress_hyper_10_20_chunk._ts_meta_max_2
+               Index Cond: ((compress_hyper_10_20_chunk.segment_by > 900) AND (compress_hyper_10_20_chunk.segment_by < 999))
 (11 rows)
 
 -- Target list creation - Issue 5738
@@ -1455,23 +1455,23 @@ SELECT chunk_schema || '.' || chunk_name AS "chunk_table_bugtab"
 SELECT compress_chunk(i) FROM show_chunks('bugtab') i;
               compress_chunk              
 ------------------------------------------
- _timescaledb_internal._hyper_11_23_chunk
+ _timescaledb_internal._hyper_11_21_chunk
 (1 row)
 
 :PREFIX
 SELECT "time","hin"::text,"model"::text,"block"::text,"message_name"::text,"signal_name"::text,"signal_numeric_value","signal_string_value"::text FROM :chunk_table_bugtab ORDER BY "time" DESC;
                                                                                                                                                                                                                                                             QUERY PLAN                                                                                                                                                                                                                                                            
 ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
- Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_11_23_chunk (actual rows=1 loops=1)
-   Output: _hyper_11_23_chunk."time", (_hyper_11_23_chunk.hin)::text, (_hyper_11_23_chunk.model)::text, (_hyper_11_23_chunk.block)::text, (_hyper_11_23_chunk.message_name)::text, (_hyper_11_23_chunk.signal_name)::text, _hyper_11_23_chunk.signal_numeric_value, (_hyper_11_23_chunk.signal_string_value)::text
+ Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_11_21_chunk (actual rows=1 loops=1)
+   Output: _hyper_11_21_chunk."time", (_hyper_11_21_chunk.hin)::text, (_hyper_11_21_chunk.model)::text, (_hyper_11_21_chunk.block)::text, (_hyper_11_21_chunk.message_name)::text, (_hyper_11_21_chunk.signal_name)::text, _hyper_11_21_chunk.signal_numeric_value, (_hyper_11_21_chunk.signal_string_value)::text
    Sorted merge append: true
    Bulk Decompression: false
    ->  Sort (actual rows=1 loops=1)
-         Output: compress_hyper_12_24_chunk."time", compress_hyper_12_24_chunk.hin, compress_hyper_12_24_chunk.model, compress_hyper_12_24_chunk.block, compress_hyper_12_24_chunk.message_name, compress_hyper_12_24_chunk.signal_name, compress_hyper_12_24_chunk.signal_numeric_value, compress_hyper_12_24_chunk.signal_string_value, compress_hyper_12_24_chunk._ts_meta_count, compress_hyper_12_24_chunk._ts_meta_sequence_num, compress_hyper_12_24_chunk._ts_meta_min_1, compress_hyper_12_24_chunk._ts_meta_max_1
-         Sort Key: compress_hyper_12_24_chunk._ts_meta_max_1 DESC
+         Output: compress_hyper_12_22_chunk."time", compress_hyper_12_22_chunk.hin, compress_hyper_12_22_chunk.model, compress_hyper_12_22_chunk.block, compress_hyper_12_22_chunk.message_name, compress_hyper_12_22_chunk.signal_name, compress_hyper_12_22_chunk.signal_numeric_value, compress_hyper_12_22_chunk.signal_string_value, compress_hyper_12_22_chunk._ts_meta_count, compress_hyper_12_22_chunk._ts_meta_sequence_num, compress_hyper_12_22_chunk._ts_meta_min_1, compress_hyper_12_22_chunk._ts_meta_max_1
+         Sort Key: compress_hyper_12_22_chunk._ts_meta_max_1 DESC
          Sort Method: quicksort 
-         ->  Seq Scan on _timescaledb_internal.compress_hyper_12_24_chunk (actual rows=1 loops=1)
-               Output: compress_hyper_12_24_chunk."time", compress_hyper_12_24_chunk.hin, compress_hyper_12_24_chunk.model, compress_hyper_12_24_chunk.block, compress_hyper_12_24_chunk.message_name, compress_hyper_12_24_chunk.signal_name, compress_hyper_12_24_chunk.signal_numeric_value, compress_hyper_12_24_chunk.signal_string_value, compress_hyper_12_24_chunk._ts_meta_count, compress_hyper_12_24_chunk._ts_meta_sequence_num, compress_hyper_12_24_chunk._ts_meta_min_1, compress_hyper_12_24_chunk._ts_meta_max_1
+         ->  Seq Scan on _timescaledb_internal.compress_hyper_12_22_chunk (actual rows=1 loops=1)
+               Output: compress_hyper_12_22_chunk."time", compress_hyper_12_22_chunk.hin, compress_hyper_12_22_chunk.model, compress_hyper_12_22_chunk.block, compress_hyper_12_22_chunk.message_name, compress_hyper_12_22_chunk.signal_name, compress_hyper_12_22_chunk.signal_numeric_value, compress_hyper_12_22_chunk.signal_string_value, compress_hyper_12_22_chunk._ts_meta_count, compress_hyper_12_22_chunk._ts_meta_sequence_num, compress_hyper_12_22_chunk._ts_meta_min_1, compress_hyper_12_22_chunk._ts_meta_max_1
 (10 rows)
 
 SELECT "time","hin"::text,"model"::text,"block"::text,"message_name"::text,"signal_name"::text,"signal_numeric_value","signal_string_value"::text FROM :chunk_table_bugtab ORDER BY "time" DESC;
@@ -1593,7 +1593,7 @@ VALUES  (109288, '2023-05-25 23:12:13.000000', 130, 14499, 13, 0.132165698840012
 SELECT compress_chunk(show_chunks('test', older_than => INTERVAL '1 week'), true);
               compress_chunk              
 ------------------------------------------
- _timescaledb_internal._hyper_13_25_chunk
+ _timescaledb_internal._hyper_13_23_chunk
 (1 row)
 
 SELECT t.dttm FROM test t WHERE t.dttm > '2023-05-25T14:23:12' ORDER BY t.dttm;

--- a/tsl/test/expected/compression_sorted_merge-15.out
+++ b/tsl/test/expected/compression_sorted_merge-15.out
@@ -934,11 +934,11 @@ SELECT * FROM test1 ORDER BY time DESC;
    Sorted merge append: true
    Bulk Decompression: false
    ->  Sort (actual rows=3 loops=1)
-         Output: compress_hyper_2_7_chunk."time", compress_hyper_2_7_chunk._ts_meta_min_1, compress_hyper_2_7_chunk._ts_meta_max_1, compress_hyper_2_7_chunk.x1, compress_hyper_2_7_chunk.x2, compress_hyper_2_7_chunk.x3, compress_hyper_2_7_chunk._ts_meta_min_2, compress_hyper_2_7_chunk._ts_meta_max_2, compress_hyper_2_7_chunk.x4, compress_hyper_2_7_chunk._ts_meta_min_3, compress_hyper_2_7_chunk._ts_meta_max_3, compress_hyper_2_7_chunk.x5, compress_hyper_2_7_chunk.c1, compress_hyper_2_7_chunk.c2, compress_hyper_2_7_chunk._ts_meta_count
-         Sort Key: compress_hyper_2_7_chunk._ts_meta_max_1 DESC
+         Output: compress_hyper_2_2_chunk."time", compress_hyper_2_2_chunk._ts_meta_min_1, compress_hyper_2_2_chunk._ts_meta_max_1, compress_hyper_2_2_chunk.x1, compress_hyper_2_2_chunk.x2, compress_hyper_2_2_chunk.x3, compress_hyper_2_2_chunk._ts_meta_min_2, compress_hyper_2_2_chunk._ts_meta_max_2, compress_hyper_2_2_chunk.x4, compress_hyper_2_2_chunk._ts_meta_min_3, compress_hyper_2_2_chunk._ts_meta_max_3, compress_hyper_2_2_chunk.x5, compress_hyper_2_2_chunk.c1, compress_hyper_2_2_chunk.c2, compress_hyper_2_2_chunk._ts_meta_count
+         Sort Key: compress_hyper_2_2_chunk._ts_meta_max_1 DESC
          Sort Method: quicksort 
-         ->  Seq Scan on _timescaledb_internal.compress_hyper_2_7_chunk (actual rows=3 loops=1)
-               Output: compress_hyper_2_7_chunk."time", compress_hyper_2_7_chunk._ts_meta_min_1, compress_hyper_2_7_chunk._ts_meta_max_1, compress_hyper_2_7_chunk.x1, compress_hyper_2_7_chunk.x2, compress_hyper_2_7_chunk.x3, compress_hyper_2_7_chunk._ts_meta_min_2, compress_hyper_2_7_chunk._ts_meta_max_2, compress_hyper_2_7_chunk.x4, compress_hyper_2_7_chunk._ts_meta_min_3, compress_hyper_2_7_chunk._ts_meta_max_3, compress_hyper_2_7_chunk.x5, compress_hyper_2_7_chunk.c1, compress_hyper_2_7_chunk.c2, compress_hyper_2_7_chunk._ts_meta_count
+         ->  Seq Scan on _timescaledb_internal.compress_hyper_2_2_chunk (actual rows=3 loops=1)
+               Output: compress_hyper_2_2_chunk."time", compress_hyper_2_2_chunk._ts_meta_min_1, compress_hyper_2_2_chunk._ts_meta_max_1, compress_hyper_2_2_chunk.x1, compress_hyper_2_2_chunk.x2, compress_hyper_2_2_chunk.x3, compress_hyper_2_2_chunk._ts_meta_min_2, compress_hyper_2_2_chunk._ts_meta_max_2, compress_hyper_2_2_chunk.x4, compress_hyper_2_2_chunk._ts_meta_min_3, compress_hyper_2_2_chunk._ts_meta_max_3, compress_hyper_2_2_chunk.x5, compress_hyper_2_2_chunk.c1, compress_hyper_2_2_chunk.c2, compress_hyper_2_2_chunk._ts_meta_count
 (10 rows)
 
 SELECT * FROM test1 ORDER BY time DESC;
@@ -960,11 +960,11 @@ SELECT time, x2, x1, c2 FROM test1 ORDER BY time DESC;
    Sorted merge append: true
    Bulk Decompression: false
    ->  Sort (actual rows=3 loops=1)
-         Output: compress_hyper_2_7_chunk."time", compress_hyper_2_7_chunk._ts_meta_min_1, compress_hyper_2_7_chunk._ts_meta_max_1, compress_hyper_2_7_chunk.x2, compress_hyper_2_7_chunk.x1, compress_hyper_2_7_chunk.c2, compress_hyper_2_7_chunk._ts_meta_count
-         Sort Key: compress_hyper_2_7_chunk._ts_meta_max_1 DESC
+         Output: compress_hyper_2_2_chunk."time", compress_hyper_2_2_chunk._ts_meta_min_1, compress_hyper_2_2_chunk._ts_meta_max_1, compress_hyper_2_2_chunk.x2, compress_hyper_2_2_chunk.x1, compress_hyper_2_2_chunk.c2, compress_hyper_2_2_chunk._ts_meta_count
+         Sort Key: compress_hyper_2_2_chunk._ts_meta_max_1 DESC
          Sort Method: quicksort 
-         ->  Seq Scan on _timescaledb_internal.compress_hyper_2_7_chunk (actual rows=3 loops=1)
-               Output: compress_hyper_2_7_chunk."time", compress_hyper_2_7_chunk._ts_meta_min_1, compress_hyper_2_7_chunk._ts_meta_max_1, compress_hyper_2_7_chunk.x2, compress_hyper_2_7_chunk.x1, compress_hyper_2_7_chunk.c2, compress_hyper_2_7_chunk._ts_meta_count
+         ->  Seq Scan on _timescaledb_internal.compress_hyper_2_2_chunk (actual rows=3 loops=1)
+               Output: compress_hyper_2_2_chunk."time", compress_hyper_2_2_chunk._ts_meta_min_1, compress_hyper_2_2_chunk._ts_meta_max_1, compress_hyper_2_2_chunk.x2, compress_hyper_2_2_chunk.x1, compress_hyper_2_2_chunk.c2, compress_hyper_2_2_chunk._ts_meta_count
 (10 rows)
 
 SELECT time, x2, x1, c2 FROM test1 ORDER BY time DESC;
@@ -986,11 +986,11 @@ SELECT x2, x1, c2, time FROM test1 ORDER BY time DESC;
    Sorted merge append: true
    Bulk Decompression: false
    ->  Sort (actual rows=3 loops=1)
-         Output: compress_hyper_2_7_chunk.x2, compress_hyper_2_7_chunk.x1, compress_hyper_2_7_chunk.c2, compress_hyper_2_7_chunk."time", compress_hyper_2_7_chunk._ts_meta_min_1, compress_hyper_2_7_chunk._ts_meta_max_1, compress_hyper_2_7_chunk._ts_meta_count
-         Sort Key: compress_hyper_2_7_chunk._ts_meta_max_1 DESC
+         Output: compress_hyper_2_2_chunk.x2, compress_hyper_2_2_chunk.x1, compress_hyper_2_2_chunk.c2, compress_hyper_2_2_chunk."time", compress_hyper_2_2_chunk._ts_meta_min_1, compress_hyper_2_2_chunk._ts_meta_max_1, compress_hyper_2_2_chunk._ts_meta_count
+         Sort Key: compress_hyper_2_2_chunk._ts_meta_max_1 DESC
          Sort Method: quicksort 
-         ->  Seq Scan on _timescaledb_internal.compress_hyper_2_7_chunk (actual rows=3 loops=1)
-               Output: compress_hyper_2_7_chunk.x2, compress_hyper_2_7_chunk.x1, compress_hyper_2_7_chunk.c2, compress_hyper_2_7_chunk."time", compress_hyper_2_7_chunk._ts_meta_min_1, compress_hyper_2_7_chunk._ts_meta_max_1, compress_hyper_2_7_chunk._ts_meta_count
+         ->  Seq Scan on _timescaledb_internal.compress_hyper_2_2_chunk (actual rows=3 loops=1)
+               Output: compress_hyper_2_2_chunk.x2, compress_hyper_2_2_chunk.x1, compress_hyper_2_2_chunk.c2, compress_hyper_2_2_chunk."time", compress_hyper_2_2_chunk._ts_meta_min_1, compress_hyper_2_2_chunk._ts_meta_max_1, compress_hyper_2_2_chunk._ts_meta_count
 (10 rows)
 
 SELECT x2, x1, c2, time FROM test1 ORDER BY time DESC;
@@ -1014,11 +1014,11 @@ SELECT 1 as one, 2 as two, 3 as three, x2, x1, c2, time FROM test1 ORDER BY time
          Sorted merge append: true
          Bulk Decompression: false
          ->  Sort (actual rows=3 loops=1)
-               Output: compress_hyper_2_7_chunk.x2, compress_hyper_2_7_chunk.x1, compress_hyper_2_7_chunk.c2, compress_hyper_2_7_chunk."time", compress_hyper_2_7_chunk._ts_meta_min_1, compress_hyper_2_7_chunk._ts_meta_max_1, compress_hyper_2_7_chunk._ts_meta_count
-               Sort Key: compress_hyper_2_7_chunk._ts_meta_max_1 DESC
+               Output: compress_hyper_2_2_chunk.x2, compress_hyper_2_2_chunk.x1, compress_hyper_2_2_chunk.c2, compress_hyper_2_2_chunk."time", compress_hyper_2_2_chunk._ts_meta_min_1, compress_hyper_2_2_chunk._ts_meta_max_1, compress_hyper_2_2_chunk._ts_meta_count
+               Sort Key: compress_hyper_2_2_chunk._ts_meta_max_1 DESC
                Sort Method: quicksort 
-               ->  Seq Scan on _timescaledb_internal.compress_hyper_2_7_chunk (actual rows=3 loops=1)
-                     Output: compress_hyper_2_7_chunk.x2, compress_hyper_2_7_chunk.x1, compress_hyper_2_7_chunk.c2, compress_hyper_2_7_chunk."time", compress_hyper_2_7_chunk._ts_meta_min_1, compress_hyper_2_7_chunk._ts_meta_max_1, compress_hyper_2_7_chunk._ts_meta_count
+               ->  Seq Scan on _timescaledb_internal.compress_hyper_2_2_chunk (actual rows=3 loops=1)
+                     Output: compress_hyper_2_2_chunk.x2, compress_hyper_2_2_chunk.x1, compress_hyper_2_2_chunk.c2, compress_hyper_2_2_chunk."time", compress_hyper_2_2_chunk._ts_meta_min_1, compress_hyper_2_2_chunk._ts_meta_max_1, compress_hyper_2_2_chunk._ts_meta_count
 (12 rows)
 
 SELECT 1 as one, 2 as two, 3 as three, x2, x1, c2, time FROM test1 ORDER BY time DESC;
@@ -1080,11 +1080,11 @@ SELECT * FROM test1 ORDER BY time ASC NULLS LAST;
    Sorted merge append: true
    Bulk Decompression: false
    ->  Sort (actual rows=3 loops=1)
-         Output: compress_hyper_2_7_chunk."time", compress_hyper_2_7_chunk._ts_meta_min_1, compress_hyper_2_7_chunk._ts_meta_max_1, compress_hyper_2_7_chunk.x1, compress_hyper_2_7_chunk.x2, compress_hyper_2_7_chunk.x3, compress_hyper_2_7_chunk._ts_meta_min_2, compress_hyper_2_7_chunk._ts_meta_max_2, compress_hyper_2_7_chunk.x4, compress_hyper_2_7_chunk._ts_meta_min_3, compress_hyper_2_7_chunk._ts_meta_max_3, compress_hyper_2_7_chunk.x5, compress_hyper_2_7_chunk.c1, compress_hyper_2_7_chunk.c2, compress_hyper_2_7_chunk._ts_meta_count
-         Sort Key: compress_hyper_2_7_chunk._ts_meta_min_1
+         Output: compress_hyper_2_2_chunk."time", compress_hyper_2_2_chunk._ts_meta_min_1, compress_hyper_2_2_chunk._ts_meta_max_1, compress_hyper_2_2_chunk.x1, compress_hyper_2_2_chunk.x2, compress_hyper_2_2_chunk.x3, compress_hyper_2_2_chunk._ts_meta_min_2, compress_hyper_2_2_chunk._ts_meta_max_2, compress_hyper_2_2_chunk.x4, compress_hyper_2_2_chunk._ts_meta_min_3, compress_hyper_2_2_chunk._ts_meta_max_3, compress_hyper_2_2_chunk.x5, compress_hyper_2_2_chunk.c1, compress_hyper_2_2_chunk.c2, compress_hyper_2_2_chunk._ts_meta_count
+         Sort Key: compress_hyper_2_2_chunk._ts_meta_min_1
          Sort Method: quicksort 
-         ->  Seq Scan on _timescaledb_internal.compress_hyper_2_7_chunk (actual rows=3 loops=1)
-               Output: compress_hyper_2_7_chunk."time", compress_hyper_2_7_chunk._ts_meta_min_1, compress_hyper_2_7_chunk._ts_meta_max_1, compress_hyper_2_7_chunk.x1, compress_hyper_2_7_chunk.x2, compress_hyper_2_7_chunk.x3, compress_hyper_2_7_chunk._ts_meta_min_2, compress_hyper_2_7_chunk._ts_meta_max_2, compress_hyper_2_7_chunk.x4, compress_hyper_2_7_chunk._ts_meta_min_3, compress_hyper_2_7_chunk._ts_meta_max_3, compress_hyper_2_7_chunk.x5, compress_hyper_2_7_chunk.c1, compress_hyper_2_7_chunk.c2, compress_hyper_2_7_chunk._ts_meta_count
+         ->  Seq Scan on _timescaledb_internal.compress_hyper_2_2_chunk (actual rows=3 loops=1)
+               Output: compress_hyper_2_2_chunk."time", compress_hyper_2_2_chunk._ts_meta_min_1, compress_hyper_2_2_chunk._ts_meta_max_1, compress_hyper_2_2_chunk.x1, compress_hyper_2_2_chunk.x2, compress_hyper_2_2_chunk.x3, compress_hyper_2_2_chunk._ts_meta_min_2, compress_hyper_2_2_chunk._ts_meta_max_2, compress_hyper_2_2_chunk.x4, compress_hyper_2_2_chunk._ts_meta_min_3, compress_hyper_2_2_chunk._ts_meta_max_3, compress_hyper_2_2_chunk.x5, compress_hyper_2_2_chunk.c1, compress_hyper_2_2_chunk.c2, compress_hyper_2_2_chunk._ts_meta_count
 (10 rows)
 
 BEGIN TRANSACTION;
@@ -1106,11 +1106,11 @@ SELECT * FROM test1 ORDER BY time ASC NULLS LAST;
                Sorted merge append: true
                Bulk Decompression: false
                ->  Sort (actual rows=3 loops=1)
-                     Output: compress_hyper_2_7_chunk."time", compress_hyper_2_7_chunk._ts_meta_min_1, compress_hyper_2_7_chunk._ts_meta_max_1, compress_hyper_2_7_chunk.x1, compress_hyper_2_7_chunk.x2, compress_hyper_2_7_chunk.x3, compress_hyper_2_7_chunk._ts_meta_min_2, compress_hyper_2_7_chunk._ts_meta_max_2, compress_hyper_2_7_chunk.x4, compress_hyper_2_7_chunk._ts_meta_min_3, compress_hyper_2_7_chunk._ts_meta_max_3, compress_hyper_2_7_chunk.x5, compress_hyper_2_7_chunk.c1, compress_hyper_2_7_chunk.c2, compress_hyper_2_7_chunk._ts_meta_count
-                     Sort Key: compress_hyper_2_7_chunk._ts_meta_min_1
+                     Output: compress_hyper_2_2_chunk."time", compress_hyper_2_2_chunk._ts_meta_min_1, compress_hyper_2_2_chunk._ts_meta_max_1, compress_hyper_2_2_chunk.x1, compress_hyper_2_2_chunk.x2, compress_hyper_2_2_chunk.x3, compress_hyper_2_2_chunk._ts_meta_min_2, compress_hyper_2_2_chunk._ts_meta_max_2, compress_hyper_2_2_chunk.x4, compress_hyper_2_2_chunk._ts_meta_min_3, compress_hyper_2_2_chunk._ts_meta_max_3, compress_hyper_2_2_chunk.x5, compress_hyper_2_2_chunk.c1, compress_hyper_2_2_chunk.c2, compress_hyper_2_2_chunk._ts_meta_count
+                     Sort Key: compress_hyper_2_2_chunk._ts_meta_min_1
                      Sort Method: quicksort 
-                     ->  Seq Scan on _timescaledb_internal.compress_hyper_2_7_chunk (actual rows=3 loops=1)
-                           Output: compress_hyper_2_7_chunk."time", compress_hyper_2_7_chunk._ts_meta_min_1, compress_hyper_2_7_chunk._ts_meta_max_1, compress_hyper_2_7_chunk.x1, compress_hyper_2_7_chunk.x2, compress_hyper_2_7_chunk.x3, compress_hyper_2_7_chunk._ts_meta_min_2, compress_hyper_2_7_chunk._ts_meta_max_2, compress_hyper_2_7_chunk.x4, compress_hyper_2_7_chunk._ts_meta_min_3, compress_hyper_2_7_chunk._ts_meta_max_3, compress_hyper_2_7_chunk.x5, compress_hyper_2_7_chunk.c1, compress_hyper_2_7_chunk.c2, compress_hyper_2_7_chunk._ts_meta_count
+                     ->  Seq Scan on _timescaledb_internal.compress_hyper_2_2_chunk (actual rows=3 loops=1)
+                           Output: compress_hyper_2_2_chunk."time", compress_hyper_2_2_chunk._ts_meta_min_1, compress_hyper_2_2_chunk._ts_meta_max_1, compress_hyper_2_2_chunk.x1, compress_hyper_2_2_chunk.x2, compress_hyper_2_2_chunk.x3, compress_hyper_2_2_chunk._ts_meta_min_2, compress_hyper_2_2_chunk._ts_meta_max_2, compress_hyper_2_2_chunk.x4, compress_hyper_2_2_chunk._ts_meta_min_3, compress_hyper_2_2_chunk._ts_meta_max_3, compress_hyper_2_2_chunk.x5, compress_hyper_2_2_chunk.c1, compress_hyper_2_2_chunk.c2, compress_hyper_2_2_chunk._ts_meta_count
          ->  Sort (actual rows=1 loops=1)
                Output: _hyper_1_1_chunk."time", _hyper_1_1_chunk.x1, _hyper_1_1_chunk.x2, _hyper_1_1_chunk.x3, _hyper_1_1_chunk.x4, _hyper_1_1_chunk.x5, _hyper_1_1_chunk.c1, _hyper_1_1_chunk.c2
                Sort Key: _hyper_1_1_chunk."time"
@@ -1164,12 +1164,12 @@ SELECT add_compression_policy('sensor_data','1 minute'::INTERVAL);
 SELECT compress_chunk(i) FROM show_chunks('sensor_data') i;
              compress_chunk              
 -----------------------------------------
+ _timescaledb_internal._hyper_7_7_chunk
  _timescaledb_internal._hyper_7_8_chunk
  _timescaledb_internal._hyper_7_9_chunk
  _timescaledb_internal._hyper_7_10_chunk
  _timescaledb_internal._hyper_7_11_chunk
  _timescaledb_internal._hyper_7_12_chunk
- _timescaledb_internal._hyper_7_13_chunk
 (6 rows)
 
 -- Ensure the optimization is used for queries on this table
@@ -1184,24 +1184,15 @@ SELECT * FROM sensor_data ORDER BY time DESC LIMIT 1;
          Order: sensor_data."time" DESC
          Startup Exclusion: false
          Runtime Exclusion: false
-         ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_7_13_chunk (actual rows=1 loops=1)
-               Output: _hyper_7_13_chunk."time", _hyper_7_13_chunk.sensor_id, _hyper_7_13_chunk.cpu, _hyper_7_13_chunk.temperature
-               Sorted merge append: true
-               Bulk Decompression: false
-               ->  Sort (actual rows=2 loops=1)
-                     Output: compress_hyper_8_19_chunk."time", compress_hyper_8_19_chunk.sensor_id, compress_hyper_8_19_chunk.cpu, compress_hyper_8_19_chunk.temperature, compress_hyper_8_19_chunk._ts_meta_count, compress_hyper_8_19_chunk._ts_meta_sequence_num, compress_hyper_8_19_chunk._ts_meta_min_1, compress_hyper_8_19_chunk._ts_meta_max_1
-                     Sort Key: compress_hyper_8_19_chunk._ts_meta_max_1 DESC
-                     Sort Method: quicksort 
-                     ->  Seq Scan on _timescaledb_internal.compress_hyper_8_19_chunk (actual rows=100 loops=1)
-                           Output: compress_hyper_8_19_chunk."time", compress_hyper_8_19_chunk.sensor_id, compress_hyper_8_19_chunk.cpu, compress_hyper_8_19_chunk.temperature, compress_hyper_8_19_chunk._ts_meta_count, compress_hyper_8_19_chunk._ts_meta_sequence_num, compress_hyper_8_19_chunk._ts_meta_min_1, compress_hyper_8_19_chunk._ts_meta_max_1
-         ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_7_12_chunk (never executed)
+         ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_7_12_chunk (actual rows=1 loops=1)
                Output: _hyper_7_12_chunk."time", _hyper_7_12_chunk.sensor_id, _hyper_7_12_chunk.cpu, _hyper_7_12_chunk.temperature
                Sorted merge append: true
                Bulk Decompression: false
-               ->  Sort (never executed)
+               ->  Sort (actual rows=2 loops=1)
                      Output: compress_hyper_8_18_chunk."time", compress_hyper_8_18_chunk.sensor_id, compress_hyper_8_18_chunk.cpu, compress_hyper_8_18_chunk.temperature, compress_hyper_8_18_chunk._ts_meta_count, compress_hyper_8_18_chunk._ts_meta_sequence_num, compress_hyper_8_18_chunk._ts_meta_min_1, compress_hyper_8_18_chunk._ts_meta_max_1
                      Sort Key: compress_hyper_8_18_chunk._ts_meta_max_1 DESC
-                     ->  Seq Scan on _timescaledb_internal.compress_hyper_8_18_chunk (never executed)
+                     Sort Method: quicksort 
+                     ->  Seq Scan on _timescaledb_internal.compress_hyper_8_18_chunk (actual rows=100 loops=1)
                            Output: compress_hyper_8_18_chunk."time", compress_hyper_8_18_chunk.sensor_id, compress_hyper_8_18_chunk.cpu, compress_hyper_8_18_chunk.temperature, compress_hyper_8_18_chunk._ts_meta_count, compress_hyper_8_18_chunk._ts_meta_sequence_num, compress_hyper_8_18_chunk._ts_meta_min_1, compress_hyper_8_18_chunk._ts_meta_max_1
          ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_7_11_chunk (never executed)
                Output: _hyper_7_11_chunk."time", _hyper_7_11_chunk.sensor_id, _hyper_7_11_chunk.cpu, _hyper_7_11_chunk.temperature
@@ -1239,6 +1230,15 @@ SELECT * FROM sensor_data ORDER BY time DESC LIMIT 1;
                      Sort Key: compress_hyper_8_14_chunk._ts_meta_max_1 DESC
                      ->  Seq Scan on _timescaledb_internal.compress_hyper_8_14_chunk (never executed)
                            Output: compress_hyper_8_14_chunk."time", compress_hyper_8_14_chunk.sensor_id, compress_hyper_8_14_chunk.cpu, compress_hyper_8_14_chunk.temperature, compress_hyper_8_14_chunk._ts_meta_count, compress_hyper_8_14_chunk._ts_meta_sequence_num, compress_hyper_8_14_chunk._ts_meta_min_1, compress_hyper_8_14_chunk._ts_meta_max_1
+         ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_7_7_chunk (never executed)
+               Output: _hyper_7_7_chunk."time", _hyper_7_7_chunk.sensor_id, _hyper_7_7_chunk.cpu, _hyper_7_7_chunk.temperature
+               Sorted merge append: true
+               Bulk Decompression: false
+               ->  Sort (never executed)
+                     Output: compress_hyper_8_13_chunk."time", compress_hyper_8_13_chunk.sensor_id, compress_hyper_8_13_chunk.cpu, compress_hyper_8_13_chunk.temperature, compress_hyper_8_13_chunk._ts_meta_count, compress_hyper_8_13_chunk._ts_meta_sequence_num, compress_hyper_8_13_chunk._ts_meta_min_1, compress_hyper_8_13_chunk._ts_meta_max_1
+                     Sort Key: compress_hyper_8_13_chunk._ts_meta_max_1 DESC
+                     ->  Seq Scan on _timescaledb_internal.compress_hyper_8_13_chunk (never executed)
+                           Output: compress_hyper_8_13_chunk."time", compress_hyper_8_13_chunk.sensor_id, compress_hyper_8_13_chunk.cpu, compress_hyper_8_13_chunk.temperature, compress_hyper_8_13_chunk._ts_meta_count, compress_hyper_8_13_chunk._ts_meta_sequence_num, compress_hyper_8_13_chunk._ts_meta_min_1, compress_hyper_8_13_chunk._ts_meta_max_1
 (62 rows)
 
 -- Verify that we produce the same order without and with the optimization
@@ -1329,7 +1329,7 @@ SELECT add_compression_policy('test_costs','1 minute'::INTERVAL);
 SELECT compress_chunk(i) FROM show_chunks('test_costs') i;
              compress_chunk              
 -----------------------------------------
- _timescaledb_internal._hyper_9_20_chunk
+ _timescaledb_internal._hyper_9_19_chunk
 (1 row)
 
 ANALYZE test_costs;
@@ -1345,23 +1345,23 @@ SELECT count(*) FROM (SELECT segment_by from test_costs group by segment_by) AS 
 SELECT time, segment_by, x1 FROM test_costs ORDER BY time DESC;
                                                                                                                                                                                                QUERY PLAN                                                                                                                                                                                               
 --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
- Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_9_20_chunk (actual rows=100 loops=1)
-   Output: _hyper_9_20_chunk."time", _hyper_9_20_chunk.segment_by, _hyper_9_20_chunk.x1
+ Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_9_19_chunk (actual rows=100 loops=1)
+   Output: _hyper_9_19_chunk."time", _hyper_9_19_chunk.segment_by, _hyper_9_19_chunk.x1
    Sorted merge append: true
    Bulk Decompression: false
    ->  Sort (actual rows=100 loops=1)
-         Output: compress_hyper_10_21_chunk."time", compress_hyper_10_21_chunk.segment_by, compress_hyper_10_21_chunk.x1, compress_hyper_10_21_chunk._ts_meta_count, compress_hyper_10_21_chunk._ts_meta_sequence_num, compress_hyper_10_21_chunk._ts_meta_min_1, compress_hyper_10_21_chunk._ts_meta_max_1, compress_hyper_10_21_chunk._ts_meta_min_2, compress_hyper_10_21_chunk._ts_meta_max_2
-         Sort Key: compress_hyper_10_21_chunk._ts_meta_max_1 DESC
+         Output: compress_hyper_10_20_chunk."time", compress_hyper_10_20_chunk.segment_by, compress_hyper_10_20_chunk.x1, compress_hyper_10_20_chunk._ts_meta_count, compress_hyper_10_20_chunk._ts_meta_sequence_num, compress_hyper_10_20_chunk._ts_meta_min_1, compress_hyper_10_20_chunk._ts_meta_max_1, compress_hyper_10_20_chunk._ts_meta_min_2, compress_hyper_10_20_chunk._ts_meta_max_2
+         Sort Key: compress_hyper_10_20_chunk._ts_meta_max_1 DESC
          Sort Method: quicksort 
-         ->  Seq Scan on _timescaledb_internal.compress_hyper_10_21_chunk (actual rows=100 loops=1)
-               Output: compress_hyper_10_21_chunk."time", compress_hyper_10_21_chunk.segment_by, compress_hyper_10_21_chunk.x1, compress_hyper_10_21_chunk._ts_meta_count, compress_hyper_10_21_chunk._ts_meta_sequence_num, compress_hyper_10_21_chunk._ts_meta_min_1, compress_hyper_10_21_chunk._ts_meta_max_1, compress_hyper_10_21_chunk._ts_meta_min_2, compress_hyper_10_21_chunk._ts_meta_max_2
+         ->  Seq Scan on _timescaledb_internal.compress_hyper_10_20_chunk (actual rows=100 loops=1)
+               Output: compress_hyper_10_20_chunk."time", compress_hyper_10_20_chunk.segment_by, compress_hyper_10_20_chunk.x1, compress_hyper_10_20_chunk._ts_meta_count, compress_hyper_10_20_chunk._ts_meta_sequence_num, compress_hyper_10_20_chunk._ts_meta_min_1, compress_hyper_10_20_chunk._ts_meta_max_1, compress_hyper_10_20_chunk._ts_meta_min_2, compress_hyper_10_20_chunk._ts_meta_max_2
 (10 rows)
 
 -- Decompress chunk
 SELECT decompress_chunk(i) FROM show_chunks('test_costs') i;
             decompress_chunk             
 -----------------------------------------
- _timescaledb_internal._hyper_9_20_chunk
+ _timescaledb_internal._hyper_9_19_chunk
 (1 row)
 
 -- Add 900 segments (1000 segments total)
@@ -1377,7 +1377,7 @@ ORDER BY time;
 SELECT compress_chunk(i) FROM show_chunks('test_costs') i;
              compress_chunk              
 -----------------------------------------
- _timescaledb_internal._hyper_9_20_chunk
+ _timescaledb_internal._hyper_9_19_chunk
 (1 row)
 
 ANALYZE test_costs;
@@ -1394,14 +1394,14 @@ SELECT time, segment_by, x1 FROM test_costs ORDER BY time DESC;
                                                                                                                                                                                                QUERY PLAN                                                                                                                                                                                               
 --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Sort (actual rows=1001 loops=1)
-   Output: _hyper_9_20_chunk."time", _hyper_9_20_chunk.segment_by, _hyper_9_20_chunk.x1
-   Sort Key: _hyper_9_20_chunk."time" DESC
+   Output: _hyper_9_19_chunk."time", _hyper_9_19_chunk.segment_by, _hyper_9_19_chunk.x1
+   Sort Key: _hyper_9_19_chunk."time" DESC
    Sort Method: quicksort 
-   ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_9_20_chunk (actual rows=1001 loops=1)
-         Output: _hyper_9_20_chunk."time", _hyper_9_20_chunk.segment_by, _hyper_9_20_chunk.x1
+   ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_9_19_chunk (actual rows=1001 loops=1)
+         Output: _hyper_9_19_chunk."time", _hyper_9_19_chunk.segment_by, _hyper_9_19_chunk.x1
          Bulk Decompression: true
-         ->  Seq Scan on _timescaledb_internal.compress_hyper_10_22_chunk (actual rows=1000 loops=1)
-               Output: compress_hyper_10_22_chunk."time", compress_hyper_10_22_chunk.segment_by, compress_hyper_10_22_chunk.x1, compress_hyper_10_22_chunk._ts_meta_count, compress_hyper_10_22_chunk._ts_meta_sequence_num, compress_hyper_10_22_chunk._ts_meta_min_1, compress_hyper_10_22_chunk._ts_meta_max_1, compress_hyper_10_22_chunk._ts_meta_min_2, compress_hyper_10_22_chunk._ts_meta_max_2
+         ->  Seq Scan on _timescaledb_internal.compress_hyper_10_20_chunk (actual rows=1000 loops=1)
+               Output: compress_hyper_10_20_chunk."time", compress_hyper_10_20_chunk.segment_by, compress_hyper_10_20_chunk.x1, compress_hyper_10_20_chunk._ts_meta_count, compress_hyper_10_20_chunk._ts_meta_sequence_num, compress_hyper_10_20_chunk._ts_meta_min_1, compress_hyper_10_20_chunk._ts_meta_max_1, compress_hyper_10_20_chunk._ts_meta_min_2, compress_hyper_10_20_chunk._ts_meta_max_2
 (9 rows)
 
 -- Test query plan with predicate (query should be optimized due to ~100 segments)
@@ -1409,17 +1409,17 @@ SELECT time, segment_by, x1 FROM test_costs ORDER BY time DESC;
 SELECT time, segment_by, x1 FROM test_costs WHERE segment_by > 900 and segment_by < 999 ORDER BY time DESC;
                                                                                                                                                                                                QUERY PLAN                                                                                                                                                                                               
 --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
- Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_9_20_chunk (actual rows=98 loops=1)
-   Output: _hyper_9_20_chunk."time", _hyper_9_20_chunk.segment_by, _hyper_9_20_chunk.x1
+ Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_9_19_chunk (actual rows=98 loops=1)
+   Output: _hyper_9_19_chunk."time", _hyper_9_19_chunk.segment_by, _hyper_9_19_chunk.x1
    Sorted merge append: true
    Bulk Decompression: false
    ->  Sort (actual rows=98 loops=1)
-         Output: compress_hyper_10_22_chunk."time", compress_hyper_10_22_chunk.segment_by, compress_hyper_10_22_chunk.x1, compress_hyper_10_22_chunk._ts_meta_count, compress_hyper_10_22_chunk._ts_meta_sequence_num, compress_hyper_10_22_chunk._ts_meta_min_1, compress_hyper_10_22_chunk._ts_meta_max_1, compress_hyper_10_22_chunk._ts_meta_min_2, compress_hyper_10_22_chunk._ts_meta_max_2
-         Sort Key: compress_hyper_10_22_chunk._ts_meta_max_1 DESC
+         Output: compress_hyper_10_20_chunk."time", compress_hyper_10_20_chunk.segment_by, compress_hyper_10_20_chunk.x1, compress_hyper_10_20_chunk._ts_meta_count, compress_hyper_10_20_chunk._ts_meta_sequence_num, compress_hyper_10_20_chunk._ts_meta_min_1, compress_hyper_10_20_chunk._ts_meta_max_1, compress_hyper_10_20_chunk._ts_meta_min_2, compress_hyper_10_20_chunk._ts_meta_max_2
+         Sort Key: compress_hyper_10_20_chunk._ts_meta_max_1 DESC
          Sort Method: quicksort 
-         ->  Index Scan using compress_hyper_10_22_chunk__compressed_hypertable_10_segment_by on _timescaledb_internal.compress_hyper_10_22_chunk (actual rows=98 loops=1)
-               Output: compress_hyper_10_22_chunk."time", compress_hyper_10_22_chunk.segment_by, compress_hyper_10_22_chunk.x1, compress_hyper_10_22_chunk._ts_meta_count, compress_hyper_10_22_chunk._ts_meta_sequence_num, compress_hyper_10_22_chunk._ts_meta_min_1, compress_hyper_10_22_chunk._ts_meta_max_1, compress_hyper_10_22_chunk._ts_meta_min_2, compress_hyper_10_22_chunk._ts_meta_max_2
-               Index Cond: ((compress_hyper_10_22_chunk.segment_by > 900) AND (compress_hyper_10_22_chunk.segment_by < 999))
+         ->  Index Scan using compress_hyper_10_20_chunk__compressed_hypertable_10_segment_by on _timescaledb_internal.compress_hyper_10_20_chunk (actual rows=98 loops=1)
+               Output: compress_hyper_10_20_chunk."time", compress_hyper_10_20_chunk.segment_by, compress_hyper_10_20_chunk.x1, compress_hyper_10_20_chunk._ts_meta_count, compress_hyper_10_20_chunk._ts_meta_sequence_num, compress_hyper_10_20_chunk._ts_meta_min_1, compress_hyper_10_20_chunk._ts_meta_max_1, compress_hyper_10_20_chunk._ts_meta_min_2, compress_hyper_10_20_chunk._ts_meta_max_2
+               Index Cond: ((compress_hyper_10_20_chunk.segment_by > 900) AND (compress_hyper_10_20_chunk.segment_by < 999))
 (11 rows)
 
 -- Target list creation - Issue 5738
@@ -1455,7 +1455,7 @@ SELECT chunk_schema || '.' || chunk_name AS "chunk_table_bugtab"
 SELECT compress_chunk(i) FROM show_chunks('bugtab') i;
               compress_chunk              
 ------------------------------------------
- _timescaledb_internal._hyper_11_23_chunk
+ _timescaledb_internal._hyper_11_21_chunk
 (1 row)
 
 :PREFIX
@@ -1463,17 +1463,17 @@ SELECT "time","hin"::text,"model"::text,"block"::text,"message_name"::text,"sign
                                                                                                                                                                                                                                                                QUERY PLAN                                                                                                                                                                                                                                                               
 ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Result (actual rows=1 loops=1)
-   Output: _hyper_11_23_chunk."time", (_hyper_11_23_chunk.hin)::text, (_hyper_11_23_chunk.model)::text, (_hyper_11_23_chunk.block)::text, (_hyper_11_23_chunk.message_name)::text, (_hyper_11_23_chunk.signal_name)::text, _hyper_11_23_chunk.signal_numeric_value, (_hyper_11_23_chunk.signal_string_value)::text
-   ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_11_23_chunk (actual rows=1 loops=1)
-         Output: _hyper_11_23_chunk."time", _hyper_11_23_chunk.hin, _hyper_11_23_chunk.model, _hyper_11_23_chunk.block, _hyper_11_23_chunk.message_name, _hyper_11_23_chunk.signal_name, _hyper_11_23_chunk.signal_numeric_value, _hyper_11_23_chunk.signal_string_value
+   Output: _hyper_11_21_chunk."time", (_hyper_11_21_chunk.hin)::text, (_hyper_11_21_chunk.model)::text, (_hyper_11_21_chunk.block)::text, (_hyper_11_21_chunk.message_name)::text, (_hyper_11_21_chunk.signal_name)::text, _hyper_11_21_chunk.signal_numeric_value, (_hyper_11_21_chunk.signal_string_value)::text
+   ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_11_21_chunk (actual rows=1 loops=1)
+         Output: _hyper_11_21_chunk."time", _hyper_11_21_chunk.hin, _hyper_11_21_chunk.model, _hyper_11_21_chunk.block, _hyper_11_21_chunk.message_name, _hyper_11_21_chunk.signal_name, _hyper_11_21_chunk.signal_numeric_value, _hyper_11_21_chunk.signal_string_value
          Sorted merge append: true
          Bulk Decompression: false
          ->  Sort (actual rows=1 loops=1)
-               Output: compress_hyper_12_24_chunk."time", compress_hyper_12_24_chunk.hin, compress_hyper_12_24_chunk.model, compress_hyper_12_24_chunk.block, compress_hyper_12_24_chunk.message_name, compress_hyper_12_24_chunk.signal_name, compress_hyper_12_24_chunk.signal_numeric_value, compress_hyper_12_24_chunk.signal_string_value, compress_hyper_12_24_chunk._ts_meta_count, compress_hyper_12_24_chunk._ts_meta_sequence_num, compress_hyper_12_24_chunk._ts_meta_min_1, compress_hyper_12_24_chunk._ts_meta_max_1
-               Sort Key: compress_hyper_12_24_chunk._ts_meta_max_1 DESC
+               Output: compress_hyper_12_22_chunk."time", compress_hyper_12_22_chunk.hin, compress_hyper_12_22_chunk.model, compress_hyper_12_22_chunk.block, compress_hyper_12_22_chunk.message_name, compress_hyper_12_22_chunk.signal_name, compress_hyper_12_22_chunk.signal_numeric_value, compress_hyper_12_22_chunk.signal_string_value, compress_hyper_12_22_chunk._ts_meta_count, compress_hyper_12_22_chunk._ts_meta_sequence_num, compress_hyper_12_22_chunk._ts_meta_min_1, compress_hyper_12_22_chunk._ts_meta_max_1
+               Sort Key: compress_hyper_12_22_chunk._ts_meta_max_1 DESC
                Sort Method: quicksort 
-               ->  Seq Scan on _timescaledb_internal.compress_hyper_12_24_chunk (actual rows=1 loops=1)
-                     Output: compress_hyper_12_24_chunk."time", compress_hyper_12_24_chunk.hin, compress_hyper_12_24_chunk.model, compress_hyper_12_24_chunk.block, compress_hyper_12_24_chunk.message_name, compress_hyper_12_24_chunk.signal_name, compress_hyper_12_24_chunk.signal_numeric_value, compress_hyper_12_24_chunk.signal_string_value, compress_hyper_12_24_chunk._ts_meta_count, compress_hyper_12_24_chunk._ts_meta_sequence_num, compress_hyper_12_24_chunk._ts_meta_min_1, compress_hyper_12_24_chunk._ts_meta_max_1
+               ->  Seq Scan on _timescaledb_internal.compress_hyper_12_22_chunk (actual rows=1 loops=1)
+                     Output: compress_hyper_12_22_chunk."time", compress_hyper_12_22_chunk.hin, compress_hyper_12_22_chunk.model, compress_hyper_12_22_chunk.block, compress_hyper_12_22_chunk.message_name, compress_hyper_12_22_chunk.signal_name, compress_hyper_12_22_chunk.signal_numeric_value, compress_hyper_12_22_chunk.signal_string_value, compress_hyper_12_22_chunk._ts_meta_count, compress_hyper_12_22_chunk._ts_meta_sequence_num, compress_hyper_12_22_chunk._ts_meta_min_1, compress_hyper_12_22_chunk._ts_meta_max_1
 (12 rows)
 
 SELECT "time","hin"::text,"model"::text,"block"::text,"message_name"::text,"signal_name"::text,"signal_numeric_value","signal_string_value"::text FROM :chunk_table_bugtab ORDER BY "time" DESC;
@@ -1595,7 +1595,7 @@ VALUES  (109288, '2023-05-25 23:12:13.000000', 130, 14499, 13, 0.132165698840012
 SELECT compress_chunk(show_chunks('test', older_than => INTERVAL '1 week'), true);
               compress_chunk              
 ------------------------------------------
- _timescaledb_internal._hyper_13_25_chunk
+ _timescaledb_internal._hyper_13_23_chunk
 (1 row)
 
 SELECT t.dttm FROM test t WHERE t.dttm > '2023-05-25T14:23:12' ORDER BY t.dttm;

--- a/tsl/test/expected/compression_update_delete.out
+++ b/tsl/test/expected/compression_update_delete.out
@@ -265,7 +265,7 @@ SELECT compress_chunk(show_chunks('sample_table'));
              compress_chunk             
 ----------------------------------------
  _timescaledb_internal._hyper_3_5_chunk
- _timescaledb_internal._hyper_3_6_chunk
+ _timescaledb_internal._hyper_3_7_chunk
 (2 rows)
 
 -- get FIRST compressed chunk
@@ -436,7 +436,7 @@ SELECT compress_chunk(show_chunks('sample_table'));
              compress_chunk              
 -----------------------------------------
  _timescaledb_internal._hyper_5_9_chunk
- _timescaledb_internal._hyper_5_10_chunk
+ _timescaledb_internal._hyper_5_11_chunk
 (2 rows)
 
 -- get FIRST compressed chunk
@@ -623,7 +623,7 @@ SELECT compress_chunk(show_chunks('sample_table'));
              compress_chunk              
 -----------------------------------------
  _timescaledb_internal._hyper_9_19_chunk
- _timescaledb_internal._hyper_9_20_chunk
+ _timescaledb_internal._hyper_9_21_chunk
 (2 rows)
 
 -- get FIRST compressed chunk
@@ -707,7 +707,7 @@ WHERE hypertable_name = 'sample_table' ORDER BY chunk_name;
  chunk_status |    CHUNK_NAME     
 --------------+-------------------
             9 | _hyper_9_19_chunk
-            9 | _hyper_9_20_chunk
+            9 | _hyper_9_21_chunk
 (2 rows)
 
 DROP TABLE sample_table;
@@ -733,7 +733,7 @@ SELECT compress_chunk(show_chunks('sample_table'));
               compress_chunk              
 ------------------------------------------
  _timescaledb_internal._hyper_11_23_chunk
- _timescaledb_internal._hyper_11_24_chunk
+ _timescaledb_internal._hyper_11_25_chunk
 (2 rows)
 
 -- get FIRST compressed chunk
@@ -769,7 +769,7 @@ WHERE hypertable_name = 'sample_table' ORDER BY chunk_name;
  chunk_status |     CHUNK_NAME     
 --------------+--------------------
             1 | _hyper_11_23_chunk
-            9 | _hyper_11_24_chunk
+            9 | _hyper_11_25_chunk
 (2 rows)
 
 DROP TABLE sample_table;
@@ -796,7 +796,7 @@ SELECT compress_chunk(show_chunks('sample_table'));
               compress_chunk              
 ------------------------------------------
  _timescaledb_internal._hyper_13_27_chunk
- _timescaledb_internal._hyper_13_28_chunk
+ _timescaledb_internal._hyper_13_29_chunk
 (2 rows)
 
 -- test will multiple NULL/NOT NULL columns
@@ -945,7 +945,7 @@ WHERE hypertable_name = 'sample_table' ORDER BY chunk_name;
  chunk_status |     CHUNK_NAME     
 --------------+--------------------
             9 | _hyper_13_27_chunk
-            1 | _hyper_13_28_chunk
+            1 | _hyper_13_29_chunk
 (2 rows)
 
 -- added tests for code coverage
@@ -994,26 +994,16 @@ WHERE hypertable_name = 'sample_table' ORDER BY chunk_name;
             1 | _hyper_15_32_chunk
 (2 rows)
 
--- get FIRST uncompressed chunk
-SELECT ch1.schema_name|| '.' || ch1.table_name AS "UNCOMPRESS_CHUNK_1"
-FROM _timescaledb_catalog.chunk ch1, _timescaledb_catalog.hypertable ht
-WHERE ch1.hypertable_id = ht.id AND ch1.table_name LIKE '_hyper_%'
-ORDER BY ch1.id LIMIT 1 \gset
--- get SECOND uncompressed chunk
-SELECT ch1.schema_name|| '.' || ch1.table_name AS "UNCOMPRESS_CHUNK_2"
-FROM _timescaledb_catalog.chunk ch1, _timescaledb_catalog.hypertable ht
-WHERE ch1.hypertable_id = ht.id AND ch1.table_name LIKE '_hyper_%'
-ORDER BY ch1.id DESC LIMIT 1 \gset
--- get FIRST compressed chunk
-SELECT ch1.schema_name|| '.' || ch1.table_name AS "COMPRESS_CHUNK_1"
-FROM _timescaledb_catalog.chunk ch1, _timescaledb_catalog.hypertable ht
-WHERE ch1.hypertable_id = ht.id AND ch1.table_name LIKE 'compress_%'
-ORDER BY ch1.id LIMIT 1 \gset
--- get SECOND compressed chunk
-SELECT ch1.schema_name|| '.' || ch1.table_name AS "COMPRESS_CHUNK_2"
-FROM _timescaledb_catalog.chunk ch1, _timescaledb_catalog.hypertable ht
-WHERE ch1.hypertable_id = ht.id AND ch1.table_name LIKE 'compress_%'
-ORDER BY ch1.id DESC LIMIT 1 \gset
+-- get FIRST chunk
+SELECT ch.schema_name || '.' || ch.table_name AS "UNCOMPRESS_CHUNK_1", ch1.schema_name || '.' || ch1.table_name AS "COMPRESS_CHUNK_1"
+FROM _timescaledb_catalog.chunk ch1, _timescaledb_catalog.chunk ch, _timescaledb_catalog.hypertable ht
+WHERE ch.hypertable_id = ht.id AND ht.table_name = 'sample_table' and ch.compressed_chunk_id = ch1.id
+ORDER BY ch.id LIMIT 1 \gset
+-- get SECOND chunk
+SELECT ch.schema_name || '.' || ch.table_name AS "UNCOMPRESS_CHUNK_2", ch1.schema_name || '.' || ch1.table_name AS "COMPRESS_CHUNK_2"
+FROM _timescaledb_catalog.chunk ch1, _timescaledb_catalog.chunk ch, _timescaledb_catalog.hypertable ht
+WHERE ch.hypertable_id = ht.id AND ht.table_name = 'sample_table' and ch.compressed_chunk_id = ch1.id
+ORDER BY ch.id DESC LIMIT 1 \gset
 -- ensure segment by column index position in compressed and uncompressed
 -- chunk is different
 SELECT attname, attnum
@@ -2052,23 +2042,23 @@ SELECT compress_chunk(show_chunks('join_test1'));
               compress_chunk              
 ------------------------------------------
  _timescaledb_internal._hyper_25_51_chunk
- _timescaledb_internal._hyper_25_52_chunk
  _timescaledb_internal._hyper_25_53_chunk
+ _timescaledb_internal._hyper_25_55_chunk
 (3 rows)
 
 SELECT compress_chunk(show_chunks('join_test2'));
               compress_chunk              
 ------------------------------------------
- _timescaledb_internal._hyper_26_54_chunk
+ _timescaledb_internal._hyper_26_57_chunk
 (1 row)
 
 SELECT * FROM chunk_status;
  hypertable |       chunk        | status 
 ------------+--------------------+--------
  join_test1 | _hyper_25_51_chunk |      1
- join_test1 | _hyper_25_52_chunk |      1
  join_test1 | _hyper_25_53_chunk |      1
- join_test2 | _hyper_26_54_chunk |      1
+ join_test1 | _hyper_25_55_chunk |      1
+ join_test2 | _hyper_26_57_chunk |      1
 (4 rows)
 
 BEGIN;
@@ -2078,9 +2068,9 @@ SELECT * FROM chunk_status;
  hypertable |       chunk        | status 
 ------------+--------------------+--------
  join_test1 | _hyper_25_51_chunk |      9
- join_test1 | _hyper_25_52_chunk |      9
  join_test1 | _hyper_25_53_chunk |      9
- join_test2 | _hyper_26_54_chunk |      1
+ join_test1 | _hyper_25_55_chunk |      9
+ join_test2 | _hyper_26_57_chunk |      1
 (4 rows)
 
 ROLLBACK;
@@ -2091,9 +2081,9 @@ SELECT * FROM chunk_status;
  hypertable |       chunk        | status 
 ------------+--------------------+--------
  join_test1 | _hyper_25_51_chunk |      1
- join_test1 | _hyper_25_52_chunk |      1
  join_test1 | _hyper_25_53_chunk |      1
- join_test2 | _hyper_26_54_chunk |      9
+ join_test1 | _hyper_25_55_chunk |      1
+ join_test2 | _hyper_26_57_chunk |      9
 (4 rows)
 
 ROLLBACK;
@@ -2104,9 +2094,9 @@ SELECT * FROM chunk_status;
  hypertable |       chunk        | status 
 ------------+--------------------+--------
  join_test1 | _hyper_25_51_chunk |      9
- join_test1 | _hyper_25_52_chunk |      1
  join_test1 | _hyper_25_53_chunk |      1
- join_test2 | _hyper_26_54_chunk |      1
+ join_test1 | _hyper_25_55_chunk |      1
+ join_test2 | _hyper_26_57_chunk |      1
 (4 rows)
 
 ROLLBACK;
@@ -2117,9 +2107,9 @@ SELECT * FROM chunk_status;
  hypertable |       chunk        | status 
 ------------+--------------------+--------
  join_test1 | _hyper_25_51_chunk |      9
- join_test1 | _hyper_25_52_chunk |      9
  join_test1 | _hyper_25_53_chunk |      9
- join_test2 | _hyper_26_54_chunk |      1
+ join_test1 | _hyper_25_55_chunk |      9
+ join_test2 | _hyper_26_57_chunk |      1
 (4 rows)
 
 ROLLBACK;
@@ -2130,9 +2120,9 @@ SELECT * FROM chunk_status;
  hypertable |       chunk        | status 
 ------------+--------------------+--------
  join_test1 | _hyper_25_51_chunk |      9
- join_test1 | _hyper_25_52_chunk |      9
  join_test1 | _hyper_25_53_chunk |      9
- join_test2 | _hyper_26_54_chunk |      1
+ join_test1 | _hyper_25_55_chunk |      9
+ join_test2 | _hyper_26_57_chunk |      1
 (4 rows)
 
 ROLLBACK;
@@ -2143,9 +2133,9 @@ SELECT * FROM chunk_status;
  hypertable |       chunk        | status 
 ------------+--------------------+--------
  join_test1 | _hyper_25_51_chunk |      1
- join_test1 | _hyper_25_52_chunk |      1
  join_test1 | _hyper_25_53_chunk |      1
- join_test2 | _hyper_26_54_chunk |      9
+ join_test1 | _hyper_25_55_chunk |      1
+ join_test2 | _hyper_26_57_chunk |      9
 (4 rows)
 
 ROLLBACK;
@@ -2156,9 +2146,9 @@ SELECT * FROM chunk_status;
  hypertable |       chunk        | status 
 ------------+--------------------+--------
  join_test1 | _hyper_25_51_chunk |      9
- join_test1 | _hyper_25_52_chunk |      1
  join_test1 | _hyper_25_53_chunk |      1
- join_test2 | _hyper_26_54_chunk |      1
+ join_test1 | _hyper_25_55_chunk |      1
+ join_test2 | _hyper_26_57_chunk |      1
 (4 rows)
 
 ROLLBACK;
@@ -2169,9 +2159,9 @@ SELECT * FROM chunk_status;
  hypertable |       chunk        | status 
 ------------+--------------------+--------
  join_test1 | _hyper_25_51_chunk |      9
- join_test1 | _hyper_25_52_chunk |      9
  join_test1 | _hyper_25_53_chunk |      9
- join_test2 | _hyper_26_54_chunk |      1
+ join_test1 | _hyper_25_55_chunk |      9
+ join_test2 | _hyper_26_57_chunk |      1
 (4 rows)
 
 ROLLBACK;

--- a/tsl/test/expected/continuous_aggs-13.out
+++ b/tsl/test/expected/continuous_aggs-13.out
@@ -1648,7 +1648,7 @@ NOTICE:  defaulting compress_orderby to time_bucket
 SELECT compress_chunk(ch) FROM show_chunks('test_morecols_cagg') ch;
               compress_chunk              
 ------------------------------------------
- _timescaledb_internal._hyper_44_89_chunk
+ _timescaledb_internal._hyper_44_90_chunk
 (1 row)
 
 SELECT * FROM test_morecols_cagg ORDER BY time_bucket;
@@ -1901,7 +1901,7 @@ SELECT * FROM mat_m1 ORDER BY 1, 2;
 
 -- ordered set aggr
 DROP MATERIALIZED VIEW mat_m1;
-NOTICE:  drop cascades to table _timescaledb_internal._hyper_55_116_chunk
+NOTICE:  drop cascades to table _timescaledb_internal._hyper_55_117_chunk
 CREATE MATERIALIZED VIEW mat_m1 WITH (timescaledb.continuous)
 AS
 SELECT
@@ -2042,10 +2042,10 @@ EXPLAIN (COSTS OFF) SELECT * FROM mat_m1;
          Hypertable: _materialized_hypertable_59
          Chunks excluded during startup: 0
          ->  Merge Append
-               Sort Key: _hyper_59_123_chunk.sum DESC
-               ->  Index Scan Backward using _hyper_59_123_chunk__materialized_hypertable_59_sum_time_bucket on _hyper_59_123_chunk
-                     Index Cond: (time_bucket < COALESCE(_timescaledb_functions.to_timestamp(_timescaledb_functions.cagg_watermark(59)), '-infinity'::timestamp with time zone))
+               Sort Key: _hyper_59_124_chunk.sum DESC
                ->  Index Scan Backward using _hyper_59_124_chunk__materialized_hypertable_59_sum_time_bucket on _hyper_59_124_chunk
+                     Index Cond: (time_bucket < COALESCE(_timescaledb_functions.to_timestamp(_timescaledb_functions.cagg_watermark(59)), '-infinity'::timestamp with time zone))
+               ->  Index Scan Backward using _hyper_59_125_chunk__materialized_hypertable_59_sum_time_bucket on _hyper_59_125_chunk
                      Index Cond: (time_bucket < COALESCE(_timescaledb_functions.to_timestamp(_timescaledb_functions.cagg_watermark(59)), '-infinity'::timestamp with time zone))
    ->  Sort
          Sort Key: (sum(conditions.temperature)) DESC
@@ -2053,9 +2053,9 @@ EXPLAIN (COSTS OFF) SELECT * FROM mat_m1;
                Group Key: time_bucket('@ 7 days'::interval, conditions.timec)
                ->  Custom Scan (ChunkAppend) on conditions
                      Chunks excluded during startup: 1
-                     ->  Index Scan Backward using _hyper_52_111_chunk_conditions_timec_idx on _hyper_52_111_chunk
+                     ->  Index Scan Backward using _hyper_52_112_chunk_conditions_timec_idx on _hyper_52_112_chunk
                            Index Cond: (timec >= COALESCE(_timescaledb_functions.to_timestamp(_timescaledb_functions.cagg_watermark(59)), '-infinity'::timestamp with time zone))
-                     ->  Index Scan Backward using _hyper_52_125_chunk_conditions_timec_idx on _hyper_52_125_chunk
+                     ->  Index Scan Backward using _hyper_52_126_chunk_conditions_timec_idx on _hyper_52_126_chunk
                            Index Cond: (timec >= COALESCE(_timescaledb_functions.to_timestamp(_timescaledb_functions.cagg_watermark(59)), '-infinity'::timestamp with time zone))
 (21 rows)
 
@@ -2080,10 +2080,10 @@ EXPLAIN (COSTS OFF) SELECT * FROM mat_m1 ORDER BY count;
                Hypertable: _materialized_hypertable_59
                Chunks excluded during startup: 0
                ->  Merge Append
-                     Sort Key: _hyper_59_123_chunk.sum DESC
-                     ->  Index Scan Backward using _hyper_59_123_chunk__materialized_hypertable_59_sum_time_bucket on _hyper_59_123_chunk
-                           Index Cond: (time_bucket < COALESCE(_timescaledb_functions.to_timestamp(_timescaledb_functions.cagg_watermark(59)), '-infinity'::timestamp with time zone))
+                     Sort Key: _hyper_59_124_chunk.sum DESC
                      ->  Index Scan Backward using _hyper_59_124_chunk__materialized_hypertable_59_sum_time_bucket on _hyper_59_124_chunk
+                           Index Cond: (time_bucket < COALESCE(_timescaledb_functions.to_timestamp(_timescaledb_functions.cagg_watermark(59)), '-infinity'::timestamp with time zone))
+                     ->  Index Scan Backward using _hyper_59_125_chunk__materialized_hypertable_59_sum_time_bucket on _hyper_59_125_chunk
                            Index Cond: (time_bucket < COALESCE(_timescaledb_functions.to_timestamp(_timescaledb_functions.cagg_watermark(59)), '-infinity'::timestamp with time zone))
          ->  Sort
                Sort Key: (sum(conditions.temperature)) DESC
@@ -2091,9 +2091,9 @@ EXPLAIN (COSTS OFF) SELECT * FROM mat_m1 ORDER BY count;
                      Group Key: time_bucket('@ 7 days'::interval, conditions.timec)
                      ->  Custom Scan (ChunkAppend) on conditions
                            Chunks excluded during startup: 1
-                           ->  Index Scan Backward using _hyper_52_111_chunk_conditions_timec_idx on _hyper_52_111_chunk
+                           ->  Index Scan Backward using _hyper_52_112_chunk_conditions_timec_idx on _hyper_52_112_chunk
                                  Index Cond: (timec >= COALESCE(_timescaledb_functions.to_timestamp(_timescaledb_functions.cagg_watermark(59)), '-infinity'::timestamp with time zone))
-                           ->  Index Scan Backward using _hyper_52_125_chunk_conditions_timec_idx on _hyper_52_125_chunk
+                           ->  Index Scan Backward using _hyper_52_126_chunk_conditions_timec_idx on _hyper_52_126_chunk
                                  Index Cond: (timec >= COALESCE(_timescaledb_functions.to_timestamp(_timescaledb_functions.cagg_watermark(59)), '-infinity'::timestamp with time zone))
 (23 rows)
 
@@ -2125,9 +2125,9 @@ EXPLAIN (COSTS OFF) SELECT * FROM mat_m1;
                                                        QUERY PLAN                                                       
 ------------------------------------------------------------------------------------------------------------------------
  Merge Append
-   Sort Key: _hyper_59_123_chunk.sum DESC
-   ->  Index Scan Backward using _hyper_59_123_chunk__materialized_hypertable_59_sum_time_bucket on _hyper_59_123_chunk
+   Sort Key: _hyper_59_124_chunk.sum DESC
    ->  Index Scan Backward using _hyper_59_124_chunk__materialized_hypertable_59_sum_time_bucket on _hyper_59_124_chunk
+   ->  Index Scan Backward using _hyper_59_125_chunk__materialized_hypertable_59_sum_time_bucket on _hyper_59_125_chunk
 (4 rows)
 
 -- Ordering by another column
@@ -2143,11 +2143,11 @@ EXPLAIN (COSTS OFF) SELECT * FROM mat_m1 ORDER BY count;
                                                           QUERY PLAN                                                          
 ------------------------------------------------------------------------------------------------------------------------------
  Sort
-   Sort Key: _hyper_59_123_chunk.count
+   Sort Key: _hyper_59_124_chunk.count
    ->  Merge Append
-         Sort Key: _hyper_59_123_chunk.sum DESC
-         ->  Index Scan Backward using _hyper_59_123_chunk__materialized_hypertable_59_sum_time_bucket on _hyper_59_123_chunk
+         Sort Key: _hyper_59_124_chunk.sum DESC
          ->  Index Scan Backward using _hyper_59_124_chunk__materialized_hypertable_59_sum_time_bucket on _hyper_59_124_chunk
+         ->  Index Scan Backward using _hyper_59_125_chunk__materialized_hypertable_59_sum_time_bucket on _hyper_59_125_chunk
 (6 rows)
 
 SELECT h.schema_name AS "MAT_SCHEMA_NAME",
@@ -2323,11 +2323,11 @@ EXPLAIN (COSTS OFF, TIMING OFF) SELECT * FROM conditions_daily WHERE time_bucket
          Sort Key: _materialized_hypertable_64.sum DESC
          ->  Custom Scan (ChunkAppend) on _materialized_hypertable_64
                Chunks excluded during startup: 0
-               ->  Index Scan using _hyper_64_185_chunk__materialized_hypertable_64_time_bucket_idx on _hyper_64_185_chunk
-                     Index Cond: ((time_bucket < COALESCE(_timescaledb_functions.to_timestamp(_timescaledb_functions.cagg_watermark(64)), '-infinity'::timestamp with time zone)) AND (time_bucket >= 'Sat Jul 01 00:00:00 2023 PDT'::timestamp with time zone))
-               ->  Index Scan using _hyper_64_189_chunk__materialized_hypertable_64_time_bucket_idx on _hyper_64_189_chunk
+               ->  Index Scan using _hyper_64_186_chunk__materialized_hypertable_64_time_bucket_idx on _hyper_64_186_chunk
                      Index Cond: ((time_bucket < COALESCE(_timescaledb_functions.to_timestamp(_timescaledb_functions.cagg_watermark(64)), '-infinity'::timestamp with time zone)) AND (time_bucket >= 'Sat Jul 01 00:00:00 2023 PDT'::timestamp with time zone))
                ->  Index Scan using _hyper_64_190_chunk__materialized_hypertable_64_time_bucket_idx on _hyper_64_190_chunk
+                     Index Cond: ((time_bucket < COALESCE(_timescaledb_functions.to_timestamp(_timescaledb_functions.cagg_watermark(64)), '-infinity'::timestamp with time zone)) AND (time_bucket >= 'Sat Jul 01 00:00:00 2023 PDT'::timestamp with time zone))
+               ->  Index Scan using _hyper_64_191_chunk__materialized_hypertable_64_time_bucket_idx on _hyper_64_191_chunk
                      Index Cond: ((time_bucket < COALESCE(_timescaledb_functions.to_timestamp(_timescaledb_functions.cagg_watermark(64)), '-infinity'::timestamp with time zone)) AND (time_bucket >= 'Sat Jul 01 00:00:00 2023 PDT'::timestamp with time zone))
    ->  Sort
          Sort Key: (sum(conditions.temperature)) DESC
@@ -2335,7 +2335,7 @@ EXPLAIN (COSTS OFF, TIMING OFF) SELECT * FROM conditions_daily WHERE time_bucket
                Group Key: time_bucket('@ 1 day'::interval, conditions.timec)
                ->  Custom Scan (ChunkAppend) on conditions
                      Chunks excluded during startup: 26
-                     ->  Index Scan Backward using _hyper_63_184_chunk_conditions_timec_idx on _hyper_63_184_chunk
+                     ->  Index Scan Backward using _hyper_63_185_chunk_conditions_timec_idx on _hyper_63_185_chunk
                            Index Cond: ((timec >= COALESCE(_timescaledb_functions.to_timestamp(_timescaledb_functions.cagg_watermark(64)), '-infinity'::timestamp with time zone)) AND (timec >= 'Sat Jul 01 00:00:00 2023 PDT'::timestamp with time zone))
                            Filter: (time_bucket('@ 1 day'::interval, timec) >= 'Sat Jul 01 00:00:00 2023 PDT'::timestamp with time zone)
 (21 rows)

--- a/tsl/test/expected/continuous_aggs-14.out
+++ b/tsl/test/expected/continuous_aggs-14.out
@@ -1647,7 +1647,7 @@ NOTICE:  defaulting compress_orderby to time_bucket
 SELECT compress_chunk(ch) FROM show_chunks('test_morecols_cagg') ch;
               compress_chunk              
 ------------------------------------------
- _timescaledb_internal._hyper_44_89_chunk
+ _timescaledb_internal._hyper_44_90_chunk
 (1 row)
 
 SELECT * FROM test_morecols_cagg ORDER BY time_bucket;
@@ -1900,7 +1900,7 @@ SELECT * FROM mat_m1 ORDER BY 1, 2;
 
 -- ordered set aggr
 DROP MATERIALIZED VIEW mat_m1;
-NOTICE:  drop cascades to table _timescaledb_internal._hyper_55_116_chunk
+NOTICE:  drop cascades to table _timescaledb_internal._hyper_55_117_chunk
 CREATE MATERIALIZED VIEW mat_m1 WITH (timescaledb.continuous)
 AS
 SELECT
@@ -2041,10 +2041,10 @@ EXPLAIN (COSTS OFF) SELECT * FROM mat_m1;
          Hypertable: _materialized_hypertable_59
          Chunks excluded during startup: 0
          ->  Merge Append
-               Sort Key: _hyper_59_123_chunk.sum DESC
-               ->  Index Scan Backward using _hyper_59_123_chunk__materialized_hypertable_59_sum_time_bucket on _hyper_59_123_chunk
-                     Index Cond: (time_bucket < COALESCE(_timescaledb_functions.to_timestamp(_timescaledb_functions.cagg_watermark(59)), '-infinity'::timestamp with time zone))
+               Sort Key: _hyper_59_124_chunk.sum DESC
                ->  Index Scan Backward using _hyper_59_124_chunk__materialized_hypertable_59_sum_time_bucket on _hyper_59_124_chunk
+                     Index Cond: (time_bucket < COALESCE(_timescaledb_functions.to_timestamp(_timescaledb_functions.cagg_watermark(59)), '-infinity'::timestamp with time zone))
+               ->  Index Scan Backward using _hyper_59_125_chunk__materialized_hypertable_59_sum_time_bucket on _hyper_59_125_chunk
                      Index Cond: (time_bucket < COALESCE(_timescaledb_functions.to_timestamp(_timescaledb_functions.cagg_watermark(59)), '-infinity'::timestamp with time zone))
    ->  Sort
          Sort Key: (sum(conditions.temperature)) DESC
@@ -2052,9 +2052,9 @@ EXPLAIN (COSTS OFF) SELECT * FROM mat_m1;
                Group Key: time_bucket('@ 7 days'::interval, conditions.timec)
                ->  Custom Scan (ChunkAppend) on conditions
                      Chunks excluded during startup: 1
-                     ->  Index Scan Backward using _hyper_52_111_chunk_conditions_timec_idx on _hyper_52_111_chunk
+                     ->  Index Scan Backward using _hyper_52_112_chunk_conditions_timec_idx on _hyper_52_112_chunk
                            Index Cond: (timec >= COALESCE(_timescaledb_functions.to_timestamp(_timescaledb_functions.cagg_watermark(59)), '-infinity'::timestamp with time zone))
-                     ->  Index Scan Backward using _hyper_52_125_chunk_conditions_timec_idx on _hyper_52_125_chunk
+                     ->  Index Scan Backward using _hyper_52_126_chunk_conditions_timec_idx on _hyper_52_126_chunk
                            Index Cond: (timec >= COALESCE(_timescaledb_functions.to_timestamp(_timescaledb_functions.cagg_watermark(59)), '-infinity'::timestamp with time zone))
 (21 rows)
 
@@ -2079,10 +2079,10 @@ EXPLAIN (COSTS OFF) SELECT * FROM mat_m1 ORDER BY count;
                Hypertable: _materialized_hypertable_59
                Chunks excluded during startup: 0
                ->  Merge Append
-                     Sort Key: _hyper_59_123_chunk.sum DESC
-                     ->  Index Scan Backward using _hyper_59_123_chunk__materialized_hypertable_59_sum_time_bucket on _hyper_59_123_chunk
-                           Index Cond: (time_bucket < COALESCE(_timescaledb_functions.to_timestamp(_timescaledb_functions.cagg_watermark(59)), '-infinity'::timestamp with time zone))
+                     Sort Key: _hyper_59_124_chunk.sum DESC
                      ->  Index Scan Backward using _hyper_59_124_chunk__materialized_hypertable_59_sum_time_bucket on _hyper_59_124_chunk
+                           Index Cond: (time_bucket < COALESCE(_timescaledb_functions.to_timestamp(_timescaledb_functions.cagg_watermark(59)), '-infinity'::timestamp with time zone))
+                     ->  Index Scan Backward using _hyper_59_125_chunk__materialized_hypertable_59_sum_time_bucket on _hyper_59_125_chunk
                            Index Cond: (time_bucket < COALESCE(_timescaledb_functions.to_timestamp(_timescaledb_functions.cagg_watermark(59)), '-infinity'::timestamp with time zone))
          ->  Sort
                Sort Key: (sum(conditions.temperature)) DESC
@@ -2090,9 +2090,9 @@ EXPLAIN (COSTS OFF) SELECT * FROM mat_m1 ORDER BY count;
                      Group Key: time_bucket('@ 7 days'::interval, conditions.timec)
                      ->  Custom Scan (ChunkAppend) on conditions
                            Chunks excluded during startup: 1
-                           ->  Index Scan Backward using _hyper_52_111_chunk_conditions_timec_idx on _hyper_52_111_chunk
+                           ->  Index Scan Backward using _hyper_52_112_chunk_conditions_timec_idx on _hyper_52_112_chunk
                                  Index Cond: (timec >= COALESCE(_timescaledb_functions.to_timestamp(_timescaledb_functions.cagg_watermark(59)), '-infinity'::timestamp with time zone))
-                           ->  Index Scan Backward using _hyper_52_125_chunk_conditions_timec_idx on _hyper_52_125_chunk
+                           ->  Index Scan Backward using _hyper_52_126_chunk_conditions_timec_idx on _hyper_52_126_chunk
                                  Index Cond: (timec >= COALESCE(_timescaledb_functions.to_timestamp(_timescaledb_functions.cagg_watermark(59)), '-infinity'::timestamp with time zone))
 (23 rows)
 
@@ -2124,9 +2124,9 @@ EXPLAIN (COSTS OFF) SELECT * FROM mat_m1;
                                                        QUERY PLAN                                                       
 ------------------------------------------------------------------------------------------------------------------------
  Merge Append
-   Sort Key: _hyper_59_123_chunk.sum DESC
-   ->  Index Scan Backward using _hyper_59_123_chunk__materialized_hypertable_59_sum_time_bucket on _hyper_59_123_chunk
+   Sort Key: _hyper_59_124_chunk.sum DESC
    ->  Index Scan Backward using _hyper_59_124_chunk__materialized_hypertable_59_sum_time_bucket on _hyper_59_124_chunk
+   ->  Index Scan Backward using _hyper_59_125_chunk__materialized_hypertable_59_sum_time_bucket on _hyper_59_125_chunk
 (4 rows)
 
 -- Ordering by another column
@@ -2142,11 +2142,11 @@ EXPLAIN (COSTS OFF) SELECT * FROM mat_m1 ORDER BY count;
                                                           QUERY PLAN                                                          
 ------------------------------------------------------------------------------------------------------------------------------
  Sort
-   Sort Key: _hyper_59_123_chunk.count
+   Sort Key: _hyper_59_124_chunk.count
    ->  Merge Append
-         Sort Key: _hyper_59_123_chunk.sum DESC
-         ->  Index Scan Backward using _hyper_59_123_chunk__materialized_hypertable_59_sum_time_bucket on _hyper_59_123_chunk
+         Sort Key: _hyper_59_124_chunk.sum DESC
          ->  Index Scan Backward using _hyper_59_124_chunk__materialized_hypertable_59_sum_time_bucket on _hyper_59_124_chunk
+         ->  Index Scan Backward using _hyper_59_125_chunk__materialized_hypertable_59_sum_time_bucket on _hyper_59_125_chunk
 (6 rows)
 
 SELECT h.schema_name AS "MAT_SCHEMA_NAME",
@@ -2322,11 +2322,11 @@ EXPLAIN (COSTS OFF, TIMING OFF) SELECT * FROM conditions_daily WHERE time_bucket
          Sort Key: _materialized_hypertable_64.sum DESC
          ->  Custom Scan (ChunkAppend) on _materialized_hypertable_64
                Chunks excluded during startup: 0
-               ->  Index Scan using _hyper_64_185_chunk__materialized_hypertable_64_time_bucket_idx on _hyper_64_185_chunk
-                     Index Cond: ((time_bucket < COALESCE(_timescaledb_functions.to_timestamp(_timescaledb_functions.cagg_watermark(64)), '-infinity'::timestamp with time zone)) AND (time_bucket >= 'Sat Jul 01 00:00:00 2023 PDT'::timestamp with time zone))
-               ->  Index Scan using _hyper_64_189_chunk__materialized_hypertable_64_time_bucket_idx on _hyper_64_189_chunk
+               ->  Index Scan using _hyper_64_186_chunk__materialized_hypertable_64_time_bucket_idx on _hyper_64_186_chunk
                      Index Cond: ((time_bucket < COALESCE(_timescaledb_functions.to_timestamp(_timescaledb_functions.cagg_watermark(64)), '-infinity'::timestamp with time zone)) AND (time_bucket >= 'Sat Jul 01 00:00:00 2023 PDT'::timestamp with time zone))
                ->  Index Scan using _hyper_64_190_chunk__materialized_hypertable_64_time_bucket_idx on _hyper_64_190_chunk
+                     Index Cond: ((time_bucket < COALESCE(_timescaledb_functions.to_timestamp(_timescaledb_functions.cagg_watermark(64)), '-infinity'::timestamp with time zone)) AND (time_bucket >= 'Sat Jul 01 00:00:00 2023 PDT'::timestamp with time zone))
+               ->  Index Scan using _hyper_64_191_chunk__materialized_hypertable_64_time_bucket_idx on _hyper_64_191_chunk
                      Index Cond: ((time_bucket < COALESCE(_timescaledb_functions.to_timestamp(_timescaledb_functions.cagg_watermark(64)), '-infinity'::timestamp with time zone)) AND (time_bucket >= 'Sat Jul 01 00:00:00 2023 PDT'::timestamp with time zone))
    ->  Sort
          Sort Key: (sum(conditions.temperature)) DESC
@@ -2334,7 +2334,7 @@ EXPLAIN (COSTS OFF, TIMING OFF) SELECT * FROM conditions_daily WHERE time_bucket
                Group Key: time_bucket('@ 1 day'::interval, conditions.timec)
                ->  Custom Scan (ChunkAppend) on conditions
                      Chunks excluded during startup: 26
-                     ->  Index Scan Backward using _hyper_63_184_chunk_conditions_timec_idx on _hyper_63_184_chunk
+                     ->  Index Scan Backward using _hyper_63_185_chunk_conditions_timec_idx on _hyper_63_185_chunk
                            Index Cond: ((timec >= COALESCE(_timescaledb_functions.to_timestamp(_timescaledb_functions.cagg_watermark(64)), '-infinity'::timestamp with time zone)) AND (timec >= 'Sat Jul 01 00:00:00 2023 PDT'::timestamp with time zone))
                            Filter: (time_bucket('@ 1 day'::interval, timec) >= 'Sat Jul 01 00:00:00 2023 PDT'::timestamp with time zone)
 (21 rows)

--- a/tsl/test/expected/continuous_aggs-15.out
+++ b/tsl/test/expected/continuous_aggs-15.out
@@ -1647,7 +1647,7 @@ NOTICE:  defaulting compress_orderby to time_bucket
 SELECT compress_chunk(ch) FROM show_chunks('test_morecols_cagg') ch;
               compress_chunk              
 ------------------------------------------
- _timescaledb_internal._hyper_44_89_chunk
+ _timescaledb_internal._hyper_44_90_chunk
 (1 row)
 
 SELECT * FROM test_morecols_cagg ORDER BY time_bucket;
@@ -1900,7 +1900,7 @@ SELECT * FROM mat_m1 ORDER BY 1, 2;
 
 -- ordered set aggr
 DROP MATERIALIZED VIEW mat_m1;
-NOTICE:  drop cascades to table _timescaledb_internal._hyper_55_116_chunk
+NOTICE:  drop cascades to table _timescaledb_internal._hyper_55_117_chunk
 CREATE MATERIALIZED VIEW mat_m1 WITH (timescaledb.continuous)
 AS
 SELECT
@@ -2041,10 +2041,10 @@ EXPLAIN (COSTS OFF) SELECT * FROM mat_m1;
          Hypertable: _materialized_hypertable_59
          Chunks excluded during startup: 0
          ->  Merge Append
-               Sort Key: _hyper_59_123_chunk.sum DESC
-               ->  Index Scan Backward using _hyper_59_123_chunk__materialized_hypertable_59_sum_time_bucket on _hyper_59_123_chunk
-                     Index Cond: (time_bucket < COALESCE(_timescaledb_functions.to_timestamp(_timescaledb_functions.cagg_watermark(59)), '-infinity'::timestamp with time zone))
+               Sort Key: _hyper_59_124_chunk.sum DESC
                ->  Index Scan Backward using _hyper_59_124_chunk__materialized_hypertable_59_sum_time_bucket on _hyper_59_124_chunk
+                     Index Cond: (time_bucket < COALESCE(_timescaledb_functions.to_timestamp(_timescaledb_functions.cagg_watermark(59)), '-infinity'::timestamp with time zone))
+               ->  Index Scan Backward using _hyper_59_125_chunk__materialized_hypertable_59_sum_time_bucket on _hyper_59_125_chunk
                      Index Cond: (time_bucket < COALESCE(_timescaledb_functions.to_timestamp(_timescaledb_functions.cagg_watermark(59)), '-infinity'::timestamp with time zone))
    ->  Sort
          Sort Key: (sum(conditions.temperature)) DESC
@@ -2053,9 +2053,9 @@ EXPLAIN (COSTS OFF) SELECT * FROM mat_m1;
                ->  Result
                      ->  Custom Scan (ChunkAppend) on conditions
                            Chunks excluded during startup: 1
-                           ->  Index Scan Backward using _hyper_52_111_chunk_conditions_timec_idx on _hyper_52_111_chunk
+                           ->  Index Scan Backward using _hyper_52_112_chunk_conditions_timec_idx on _hyper_52_112_chunk
                                  Index Cond: (timec >= COALESCE(_timescaledb_functions.to_timestamp(_timescaledb_functions.cagg_watermark(59)), '-infinity'::timestamp with time zone))
-                           ->  Index Scan Backward using _hyper_52_125_chunk_conditions_timec_idx on _hyper_52_125_chunk
+                           ->  Index Scan Backward using _hyper_52_126_chunk_conditions_timec_idx on _hyper_52_126_chunk
                                  Index Cond: (timec >= COALESCE(_timescaledb_functions.to_timestamp(_timescaledb_functions.cagg_watermark(59)), '-infinity'::timestamp with time zone))
 (22 rows)
 
@@ -2080,10 +2080,10 @@ EXPLAIN (COSTS OFF) SELECT * FROM mat_m1 ORDER BY count;
                Hypertable: _materialized_hypertable_59
                Chunks excluded during startup: 0
                ->  Merge Append
-                     Sort Key: _hyper_59_123_chunk.sum DESC
-                     ->  Index Scan Backward using _hyper_59_123_chunk__materialized_hypertable_59_sum_time_bucket on _hyper_59_123_chunk
-                           Index Cond: (time_bucket < COALESCE(_timescaledb_functions.to_timestamp(_timescaledb_functions.cagg_watermark(59)), '-infinity'::timestamp with time zone))
+                     Sort Key: _hyper_59_124_chunk.sum DESC
                      ->  Index Scan Backward using _hyper_59_124_chunk__materialized_hypertable_59_sum_time_bucket on _hyper_59_124_chunk
+                           Index Cond: (time_bucket < COALESCE(_timescaledb_functions.to_timestamp(_timescaledb_functions.cagg_watermark(59)), '-infinity'::timestamp with time zone))
+                     ->  Index Scan Backward using _hyper_59_125_chunk__materialized_hypertable_59_sum_time_bucket on _hyper_59_125_chunk
                            Index Cond: (time_bucket < COALESCE(_timescaledb_functions.to_timestamp(_timescaledb_functions.cagg_watermark(59)), '-infinity'::timestamp with time zone))
          ->  Sort
                Sort Key: (sum(conditions.temperature)) DESC
@@ -2092,9 +2092,9 @@ EXPLAIN (COSTS OFF) SELECT * FROM mat_m1 ORDER BY count;
                      ->  Result
                            ->  Custom Scan (ChunkAppend) on conditions
                                  Chunks excluded during startup: 1
-                                 ->  Index Scan Backward using _hyper_52_111_chunk_conditions_timec_idx on _hyper_52_111_chunk
+                                 ->  Index Scan Backward using _hyper_52_112_chunk_conditions_timec_idx on _hyper_52_112_chunk
                                        Index Cond: (timec >= COALESCE(_timescaledb_functions.to_timestamp(_timescaledb_functions.cagg_watermark(59)), '-infinity'::timestamp with time zone))
-                                 ->  Index Scan Backward using _hyper_52_125_chunk_conditions_timec_idx on _hyper_52_125_chunk
+                                 ->  Index Scan Backward using _hyper_52_126_chunk_conditions_timec_idx on _hyper_52_126_chunk
                                        Index Cond: (timec >= COALESCE(_timescaledb_functions.to_timestamp(_timescaledb_functions.cagg_watermark(59)), '-infinity'::timestamp with time zone))
 (24 rows)
 
@@ -2126,9 +2126,9 @@ EXPLAIN (COSTS OFF) SELECT * FROM mat_m1;
                                                        QUERY PLAN                                                       
 ------------------------------------------------------------------------------------------------------------------------
  Merge Append
-   Sort Key: _hyper_59_123_chunk.sum DESC
-   ->  Index Scan Backward using _hyper_59_123_chunk__materialized_hypertable_59_sum_time_bucket on _hyper_59_123_chunk
+   Sort Key: _hyper_59_124_chunk.sum DESC
    ->  Index Scan Backward using _hyper_59_124_chunk__materialized_hypertable_59_sum_time_bucket on _hyper_59_124_chunk
+   ->  Index Scan Backward using _hyper_59_125_chunk__materialized_hypertable_59_sum_time_bucket on _hyper_59_125_chunk
 (4 rows)
 
 -- Ordering by another column
@@ -2144,11 +2144,11 @@ EXPLAIN (COSTS OFF) SELECT * FROM mat_m1 ORDER BY count;
                                                           QUERY PLAN                                                          
 ------------------------------------------------------------------------------------------------------------------------------
  Sort
-   Sort Key: _hyper_59_123_chunk.count
+   Sort Key: _hyper_59_124_chunk.count
    ->  Merge Append
-         Sort Key: _hyper_59_123_chunk.sum DESC
-         ->  Index Scan Backward using _hyper_59_123_chunk__materialized_hypertable_59_sum_time_bucket on _hyper_59_123_chunk
+         Sort Key: _hyper_59_124_chunk.sum DESC
          ->  Index Scan Backward using _hyper_59_124_chunk__materialized_hypertable_59_sum_time_bucket on _hyper_59_124_chunk
+         ->  Index Scan Backward using _hyper_59_125_chunk__materialized_hypertable_59_sum_time_bucket on _hyper_59_125_chunk
 (6 rows)
 
 SELECT h.schema_name AS "MAT_SCHEMA_NAME",
@@ -2324,11 +2324,11 @@ EXPLAIN (COSTS OFF, TIMING OFF) SELECT * FROM conditions_daily WHERE time_bucket
          Sort Key: _materialized_hypertable_64.sum DESC
          ->  Custom Scan (ChunkAppend) on _materialized_hypertable_64
                Chunks excluded during startup: 0
-               ->  Index Scan using _hyper_64_185_chunk__materialized_hypertable_64_time_bucket_idx on _hyper_64_185_chunk
-                     Index Cond: ((time_bucket < COALESCE(_timescaledb_functions.to_timestamp(_timescaledb_functions.cagg_watermark(64)), '-infinity'::timestamp with time zone)) AND (time_bucket >= 'Sat Jul 01 00:00:00 2023 PDT'::timestamp with time zone))
-               ->  Index Scan using _hyper_64_189_chunk__materialized_hypertable_64_time_bucket_idx on _hyper_64_189_chunk
+               ->  Index Scan using _hyper_64_186_chunk__materialized_hypertable_64_time_bucket_idx on _hyper_64_186_chunk
                      Index Cond: ((time_bucket < COALESCE(_timescaledb_functions.to_timestamp(_timescaledb_functions.cagg_watermark(64)), '-infinity'::timestamp with time zone)) AND (time_bucket >= 'Sat Jul 01 00:00:00 2023 PDT'::timestamp with time zone))
                ->  Index Scan using _hyper_64_190_chunk__materialized_hypertable_64_time_bucket_idx on _hyper_64_190_chunk
+                     Index Cond: ((time_bucket < COALESCE(_timescaledb_functions.to_timestamp(_timescaledb_functions.cagg_watermark(64)), '-infinity'::timestamp with time zone)) AND (time_bucket >= 'Sat Jul 01 00:00:00 2023 PDT'::timestamp with time zone))
+               ->  Index Scan using _hyper_64_191_chunk__materialized_hypertable_64_time_bucket_idx on _hyper_64_191_chunk
                      Index Cond: ((time_bucket < COALESCE(_timescaledb_functions.to_timestamp(_timescaledb_functions.cagg_watermark(64)), '-infinity'::timestamp with time zone)) AND (time_bucket >= 'Sat Jul 01 00:00:00 2023 PDT'::timestamp with time zone))
    ->  Sort
          Sort Key: (sum(conditions.temperature)) DESC
@@ -2337,7 +2337,7 @@ EXPLAIN (COSTS OFF, TIMING OFF) SELECT * FROM conditions_daily WHERE time_bucket
                ->  Result
                      ->  Custom Scan (ChunkAppend) on conditions
                            Chunks excluded during startup: 26
-                           ->  Index Scan Backward using _hyper_63_184_chunk_conditions_timec_idx on _hyper_63_184_chunk
+                           ->  Index Scan Backward using _hyper_63_185_chunk_conditions_timec_idx on _hyper_63_185_chunk
                                  Index Cond: ((timec >= COALESCE(_timescaledb_functions.to_timestamp(_timescaledb_functions.cagg_watermark(64)), '-infinity'::timestamp with time zone)) AND (timec >= 'Sat Jul 01 00:00:00 2023 PDT'::timestamp with time zone))
                                  Filter: (time_bucket('@ 1 day'::interval, timec) >= 'Sat Jul 01 00:00:00 2023 PDT'::timestamp with time zone)
 (22 rows)

--- a/tsl/test/expected/continuous_aggs_deprecated-13.out
+++ b/tsl/test/expected/continuous_aggs_deprecated-13.out
@@ -1681,7 +1681,7 @@ NOTICE:  defaulting compress_orderby to time_bucket
 SELECT compress_chunk(ch) FROM show_chunks('test_morecols_cagg') ch;
               compress_chunk              
 ------------------------------------------
- _timescaledb_internal._hyper_44_91_chunk
+ _timescaledb_internal._hyper_44_92_chunk
 (1 row)
 
 SELECT * FROM test_morecols_cagg;
@@ -1954,8 +1954,8 @@ Indexes:
     "_materialized_hypertable_53_bucket_idx" btree (bucket DESC)
 Triggers:
     ts_insert_blocker BEFORE INSERT ON _timescaledb_internal._materialized_hypertable_53 FOR EACH ROW EXECUTE FUNCTION _timescaledb_functions.insert_blocker()
-Child tables: _timescaledb_internal._hyper_53_114_chunk,
-              _timescaledb_internal._hyper_53_115_chunk
+Child tables: _timescaledb_internal._hyper_53_115_chunk,
+              _timescaledb_internal._hyper_53_116_chunk
 
 \d+ 'cashflows'
                                     View "public.cashflows"

--- a/tsl/test/expected/continuous_aggs_deprecated-14.out
+++ b/tsl/test/expected/continuous_aggs_deprecated-14.out
@@ -1679,7 +1679,7 @@ NOTICE:  defaulting compress_orderby to time_bucket
 SELECT compress_chunk(ch) FROM show_chunks('test_morecols_cagg') ch;
               compress_chunk              
 ------------------------------------------
- _timescaledb_internal._hyper_44_91_chunk
+ _timescaledb_internal._hyper_44_92_chunk
 (1 row)
 
 SELECT * FROM test_morecols_cagg;
@@ -1952,8 +1952,8 @@ Indexes:
     "_materialized_hypertable_53_bucket_idx" btree (bucket DESC)
 Triggers:
     ts_insert_blocker BEFORE INSERT ON _timescaledb_internal._materialized_hypertable_53 FOR EACH ROW EXECUTE FUNCTION _timescaledb_functions.insert_blocker()
-Child tables: _timescaledb_internal._hyper_53_114_chunk,
-              _timescaledb_internal._hyper_53_115_chunk
+Child tables: _timescaledb_internal._hyper_53_115_chunk,
+              _timescaledb_internal._hyper_53_116_chunk
 
 \d+ 'cashflows'
                                     View "public.cashflows"

--- a/tsl/test/expected/continuous_aggs_deprecated-15.out
+++ b/tsl/test/expected/continuous_aggs_deprecated-15.out
@@ -1679,7 +1679,7 @@ NOTICE:  defaulting compress_orderby to time_bucket
 SELECT compress_chunk(ch) FROM show_chunks('test_morecols_cagg') ch;
               compress_chunk              
 ------------------------------------------
- _timescaledb_internal._hyper_44_91_chunk
+ _timescaledb_internal._hyper_44_92_chunk
 (1 row)
 
 SELECT * FROM test_morecols_cagg;
@@ -1952,8 +1952,8 @@ Indexes:
     "_materialized_hypertable_53_bucket_idx" btree (bucket DESC)
 Triggers:
     ts_insert_blocker BEFORE INSERT ON _timescaledb_internal._materialized_hypertable_53 FOR EACH ROW EXECUTE FUNCTION _timescaledb_functions.insert_blocker()
-Child tables: _timescaledb_internal._hyper_53_114_chunk,
-              _timescaledb_internal._hyper_53_115_chunk
+Child tables: _timescaledb_internal._hyper_53_115_chunk,
+              _timescaledb_internal._hyper_53_116_chunk
 
 \d+ 'cashflows'
                                     View "public.cashflows"

--- a/tsl/test/expected/dist_compression.out
+++ b/tsl/test/expected/dist_compression.out
@@ -294,10 +294,10 @@ SELECT * FROM _timescaledb_catalog.chunk ORDER BY id
 NOTICE:  [db_dist_compression_1]:
 id|hypertable_id|schema_name          |table_name              |compressed_chunk_id|dropped|status|osm_chunk
 --+-------------+---------------------+------------------------+-------------------+-------+------+---------
- 1|            1|_timescaledb_internal|_dist_hyper_1_1_chunk   |                  5|f      |     1|f        
- 2|            1|_timescaledb_internal|_dist_hyper_1_3_chunk   |                  6|f      |     1|f        
- 5|            2|_timescaledb_internal|compress_hyper_2_5_chunk|                   |f      |     0|f        
- 6|            2|_timescaledb_internal|compress_hyper_2_6_chunk|                   |f      |     0|f        
+ 1|            1|_timescaledb_internal|_dist_hyper_1_1_chunk   |                  3|f      |     1|f        
+ 2|            1|_timescaledb_internal|_dist_hyper_1_3_chunk   |                  4|f      |     1|f        
+ 3|            2|_timescaledb_internal|compress_hyper_2_3_chunk|                   |f      |     0|f        
+ 4|            2|_timescaledb_internal|compress_hyper_2_4_chunk|                   |f      |     0|f        
 (4 rows)
 
 
@@ -306,10 +306,10 @@ SELECT * FROM _timescaledb_catalog.chunk ORDER BY id
 NOTICE:  [db_dist_compression_2]:
 id|hypertable_id|schema_name          |table_name              |compressed_chunk_id|dropped|status|osm_chunk
 --+-------------+---------------------+------------------------+-------------------+-------+------+---------
- 1|            1|_timescaledb_internal|_dist_hyper_1_1_chunk   |                  5|f      |     1|f        
- 2|            1|_timescaledb_internal|_dist_hyper_1_2_chunk   |                  6|f      |     1|f        
- 5|            2|_timescaledb_internal|compress_hyper_2_5_chunk|                   |f      |     0|f        
- 6|            2|_timescaledb_internal|compress_hyper_2_6_chunk|                   |f      |     0|f        
+ 1|            1|_timescaledb_internal|_dist_hyper_1_1_chunk   |                  3|f      |     1|f        
+ 2|            1|_timescaledb_internal|_dist_hyper_1_2_chunk   |                  4|f      |     1|f        
+ 3|            2|_timescaledb_internal|compress_hyper_2_3_chunk|                   |f      |     0|f        
+ 4|            2|_timescaledb_internal|compress_hyper_2_4_chunk|                   |f      |     0|f        
 (4 rows)
 
 
@@ -318,8 +318,8 @@ SELECT * FROM _timescaledb_catalog.chunk ORDER BY id
 NOTICE:  [db_dist_compression_3]:
 id|hypertable_id|schema_name          |table_name              |compressed_chunk_id|dropped|status|osm_chunk
 --+-------------+---------------------+------------------------+-------------------+-------+------+---------
- 1|            1|_timescaledb_internal|_dist_hyper_1_2_chunk   |                  4|f      |     1|f        
- 2|            1|_timescaledb_internal|_dist_hyper_1_3_chunk   |                  3|f      |     1|f        
+ 1|            1|_timescaledb_internal|_dist_hyper_1_2_chunk   |                  3|f      |     1|f        
+ 2|            1|_timescaledb_internal|_dist_hyper_1_3_chunk   |                  4|f      |     1|f        
  3|            2|_timescaledb_internal|compress_hyper_2_3_chunk|                   |f      |     0|f        
  4|            2|_timescaledb_internal|compress_hyper_2_4_chunk|                   |f      |     0|f        
 (4 rows)
@@ -455,20 +455,20 @@ SELECT * FROM chunks_detailed_size('compressed'::regclass)
 ORDER BY chunk_name, node_name;
      chunk_schema      |      chunk_name       | table_bytes | index_bytes | toast_bytes | total_bytes |       node_name       
 -----------------------+-----------------------+-------------+-------------+-------------+-------------+-----------------------
- _timescaledb_internal | _dist_hyper_1_1_chunk |        8192 |       32768 |           0 |       40960 | db_dist_compression_1
- _timescaledb_internal | _dist_hyper_1_1_chunk |        8192 |       32768 |           0 |       40960 | db_dist_compression_2
- _timescaledb_internal | _dist_hyper_1_2_chunk |        8192 |       32768 |           0 |       40960 | db_dist_compression_2
- _timescaledb_internal | _dist_hyper_1_2_chunk |        8192 |       32768 |           0 |       40960 | db_dist_compression_3
- _timescaledb_internal | _dist_hyper_1_3_chunk |        8192 |       32768 |           0 |       40960 | db_dist_compression_1
- _timescaledb_internal | _dist_hyper_1_3_chunk |        8192 |       32768 |           0 |       40960 | db_dist_compression_3
+ _timescaledb_internal | _dist_hyper_1_1_chunk |        8192 |       40960 |        8192 |       57344 | db_dist_compression_1
+ _timescaledb_internal | _dist_hyper_1_1_chunk |        8192 |       40960 |        8192 |       57344 | db_dist_compression_2
+ _timescaledb_internal | _dist_hyper_1_2_chunk |        8192 |       40960 |        8192 |       57344 | db_dist_compression_2
+ _timescaledb_internal | _dist_hyper_1_2_chunk |        8192 |       40960 |        8192 |       57344 | db_dist_compression_3
+ _timescaledb_internal | _dist_hyper_1_3_chunk |        8192 |       40960 |        8192 |       57344 | db_dist_compression_1
+ _timescaledb_internal | _dist_hyper_1_3_chunk |        8192 |       40960 |        8192 |       57344 | db_dist_compression_3
 (6 rows)
 
 SELECT * FROM hypertable_detailed_size('compressed'::regclass) ORDER BY node_name;
  table_bytes | index_bytes | toast_bytes | total_bytes |       node_name       
 -------------+-------------+-------------+-------------+-----------------------
-       16384 |       81920 |           0 |       98304 | db_dist_compression_1
-       16384 |       81920 |           0 |       98304 | db_dist_compression_2
-       16384 |       81920 |           0 |       98304 | db_dist_compression_3
+       16384 |       98304 |       16384 |      131072 | db_dist_compression_1
+       16384 |       98304 |       16384 |      131072 | db_dist_compression_2
+       16384 |       98304 |       16384 |      131072 | db_dist_compression_3
            0 |       16384 |           0 |       16384 | 
 (4 rows)
 
@@ -555,12 +555,12 @@ FROM
 SELECT compress_chunk(chunk.schema_name|| '.' || chunk.table_name, true)
 FROM _timescaledb_catalog.chunk chunk
 INNER JOIN _timescaledb_catalog.hypertable hypertable ON (chunk.hypertable_id = hypertable.id)
-WHERE hypertable.table_name like 'compressed' and chunk.compressed_chunk_id IS NULL ORDER BY chunk.id
+WHERE hypertable.table_name like 'compressed' and chunk.status & 1 = 0 ORDER BY chunk.id
 )
 AS sub;
  count_compressed 
 ------------------
-                4
+                3
 (1 row)
 
 SELECT * from compressed where new_coli is not null;

--- a/tsl/test/expected/dist_ddl.out
+++ b/tsl/test/expected/dist_ddl.out
@@ -3328,7 +3328,9 @@ SELECT id, table_name FROM _timescaledb_catalog.chunk ORDER BY id, table_name;
  32 | _dist_hyper_35_39_chunk
  33 | _dist_hyper_35_40_chunk
  34 | compress_hyper_33_34_chunk
-(4 rows)
+ 35 | compress_hyper_33_35_chunk
+ 36 | compress_hyper_33_36_chunk
+(6 rows)
 
 SELECT * from show_chunks('dist_test');
                   show_chunks                  
@@ -3404,11 +3406,13 @@ SELECT _timescaledb_functions.drop_stale_chunks(:'DATA_NODE_3');
 
 \c :DATA_NODE_1
 SELECT id, table_name FROM _timescaledb_catalog.chunk ORDER BY id, table_name;
- id |       table_name        
-----+-------------------------
+ id |         table_name         
+----+----------------------------
  32 | _dist_hyper_35_39_chunk
  33 | _dist_hyper_35_40_chunk
-(2 rows)
+ 35 | compress_hyper_33_35_chunk
+ 36 | compress_hyper_33_36_chunk
+(4 rows)
 
 SELECT * from show_chunks('dist_test');
                   show_chunks                  
@@ -3494,11 +3498,11 @@ DROP FOREIGN TABLE _timescaledb_internal._dist_hyper_36_42_chunk;
 SELECT id, table_name FROM _timescaledb_catalog.chunk ORDER BY id, table_name;
  id |       table_name        
 ----+-------------------------
- 35 | _dist_hyper_36_41_chunk
- 36 | _dist_hyper_36_42_chunk
- 37 | _dist_hyper_36_43_chunk
- 38 | _dist_hyper_36_44_chunk
- 39 | _dist_hyper_36_45_chunk
+ 37 | _dist_hyper_36_41_chunk
+ 38 | _dist_hyper_36_42_chunk
+ 39 | _dist_hyper_36_43_chunk
+ 40 | _dist_hyper_36_44_chunk
+ 41 | _dist_hyper_36_45_chunk
 (5 rows)
 
 SELECT * from show_chunks('dist_test');
@@ -3523,9 +3527,9 @@ SELECT alter_data_node(:'DATA_NODE_1', available => true);
 SELECT id, table_name FROM _timescaledb_catalog.chunk ORDER BY id, table_name;
  id |       table_name        
 ----+-------------------------
- 37 | _dist_hyper_36_43_chunk
- 38 | _dist_hyper_36_44_chunk
- 39 | _dist_hyper_36_45_chunk
+ 39 | _dist_hyper_36_43_chunk
+ 40 | _dist_hyper_36_44_chunk
+ 41 | _dist_hyper_36_45_chunk
 (3 rows)
 
 SELECT * from show_chunks('dist_test');

--- a/tsl/test/expected/dist_move_chunk.out
+++ b/tsl/test/expected/dist_move_chunk.out
@@ -411,10 +411,10 @@ JOIN _timescaledb_catalog.chunk c2 ON (c1.compressed_chunk_id = c2.id)
 WHERE c1.table_name = '_dist_hyper_3_12_chunk';
         table_name        
 --------------------------
- compress_hyper_3_6_chunk
+ compress_hyper_3_7_chunk
 (1 row)
 
-SELECT * FROM _timescaledb_internal.compress_hyper_3_6_chunk ORDER BY device, _ts_meta_min_1;
+SELECT * FROM _timescaledb_internal.compress_hyper_3_7_chunk ORDER BY device, _ts_meta_min_1;
                            time                           | device |                                                                       temp                                                                       | _ts_meta_count | _ts_meta_sequence_num |      _ts_meta_min_1      |      _ts_meta_max_1      
 ----------------------------------------------------------+--------+--------------------------------------------------------------------------------------------------------------------------------------------------+----------------+-----------------------+--------------------------+--------------------------
  BAAAAgna9rUEAAACCdr2tQQAAAAAAQAAAAEAAAAAAAAADgAEE7XtaggA |      1 | AwA/uZmZmZmZmgAAAAEAAAABAAAAAAAAAAEAAAAAAAAAAQAAAAEAAAABAAAAAAAAAAEAAAAAAAAAAQAAAAEGAAAAAAAAAAIAAAABAAAAAQAAAAAAAAAGAAAAAAAAAD0AAAABPR/czMzMzMzN |              1 |                    10 | Thu Mar 08 01:00:00 2018 | Thu Mar 08 01:00:00 2018
@@ -454,11 +454,11 @@ JOIN _timescaledb_catalog.chunk c2 ON (c1.compressed_chunk_id = c2.id)
 WHERE c1.table_name = '_dist_hyper_3_12_chunk';
         table_name        
 --------------------------
- compress_hyper_3_6_chunk
+ compress_hyper_3_7_chunk
 (1 row)
 
 -- Try to query hypertable member with compressed chunk
-SELECT * FROM _timescaledb_internal.compress_hyper_3_6_chunk ORDER BY device, _ts_meta_min_1;
+SELECT * FROM _timescaledb_internal.compress_hyper_3_7_chunk ORDER BY device, _ts_meta_min_1;
                            time                           | device |                                                                       temp                                                                       | _ts_meta_count | _ts_meta_sequence_num |      _ts_meta_min_1      |      _ts_meta_max_1      
 ----------------------------------------------------------+--------+--------------------------------------------------------------------------------------------------------------------------------------------------+----------------+-----------------------+--------------------------+--------------------------
  BAAAAgna9rUEAAACCdr2tQQAAAAAAQAAAAEAAAAAAAAADgAEE7XtaggA |      1 | AwA/uZmZmZmZmgAAAAEAAAABAAAAAAAAAAEAAAAAAAAAAQAAAAEAAAABAAAAAAAAAAEAAAAAAAAAAQAAAAEGAAAAAAAAAAIAAAABAAAAAQAAAAAAAAAGAAAAAAAAAD0AAAABPR/czMzMzMzN |              1 |                    10 | Thu Mar 08 01:00:00 2018 | Thu Mar 08 01:00:00 2018
@@ -490,8 +490,8 @@ WHERE c1.table_name = '_dist_hyper_3_12_chunk';
 (0 rows)
 
 \set ON_ERROR_STOP 0
-SELECT * FROM _timescaledb_internal.compress_hyper_3_6_chunk ORDER BY device, _ts_meta_min_1;
-ERROR:  relation "_timescaledb_internal.compress_hyper_3_6_chunk" does not exist at character 15
+SELECT * FROM _timescaledb_internal.compress_hyper_3_7_chunk ORDER BY device, _ts_meta_min_1;
+ERROR:  relation "_timescaledb_internal.compress_hyper_3_7_chunk" does not exist at character 15
 SELECT * FROM _timescaledb_internal._dist_hyper_3_12_chunk ORDER BY time;
 ERROR:  relation "_timescaledb_internal._dist_hyper_3_12_chunk" does not exist at character 15
 \set ON_ERROR_STOP 1
@@ -575,10 +575,10 @@ JOIN _timescaledb_catalog.chunk c2 ON (c1.compressed_chunk_id = c2.id)
 WHERE c1.table_name = '_dist_hyper_3_12_chunk';
         table_name        
 --------------------------
- compress_hyper_3_6_chunk
+ compress_hyper_3_7_chunk
 (1 row)
 
-SELECT * FROM _timescaledb_internal.compress_hyper_3_6_chunk ORDER BY device, _ts_meta_min_1;
+SELECT * FROM _timescaledb_internal.compress_hyper_3_7_chunk ORDER BY device, _ts_meta_min_1;
                            time                           | device |                                                                       temp                                                                       | _ts_meta_count | _ts_meta_sequence_num |      _ts_meta_min_1      |      _ts_meta_max_1      
 ----------------------------------------------------------+--------+--------------------------------------------------------------------------------------------------------------------------------------------------+----------------+-----------------------+--------------------------+--------------------------
  BAAAAgna9rUEAAACCdr2tQQAAAAAAQAAAAEAAAAAAAAADgAEE7XtaggA |      1 | AwA/uZmZmZmZmgAAAAEAAAABAAAAAAAAAAEAAAAAAAAAAQAAAAEAAAABAAAAAAAAAAEAAAAAAAAAAQAAAAEGAAAAAAAAAAIAAAABAAAAAQAAAAAAAAAGAAAAAAAAAD0AAAABPR/czMzMzMzN |              1 |                    10 | Thu Mar 08 01:00:00 2018 | Thu Mar 08 01:00:00 2018

--- a/tsl/test/expected/dist_util.out
+++ b/tsl/test/expected/dist_util.out
@@ -747,43 +747,43 @@ SET (timescaledb.compress,
 SELECT * FROM hypertable_size('disttable');
  hypertable_size 
 -----------------
-           98304
+          147456
 (1 row)
 
 SELECT * FROM hypertable_size('nondisttable');
  hypertable_size 
 -----------------
-           81920
+          131072
 (1 row)
 
 SELECT * FROM hypertable_detailed_size('disttable') ORDER BY node_name;
  table_bytes | index_bytes | toast_bytes | total_bytes |  node_name  
 -------------+-------------+-------------+-------------+-------------
-       16384 |       40960 |           0 |       57344 | data_node_1
-        8192 |       24576 |           0 |       32768 | data_node_2
+       16384 |       57344 |       16384 |       90112 | data_node_1
+        8192 |       32768 |        8192 |       49152 | data_node_2
            0 |        8192 |           0 |        8192 | 
 (3 rows)
 
 SELECT * FROM hypertable_detailed_size('nondisttable') ORDER BY node_name;
  table_bytes | index_bytes | toast_bytes | total_bytes | node_name 
 -------------+-------------+-------------+-------------+-----------
-       24576 |       57344 |           0 |       81920 | 
+       24576 |       81920 |       24576 |      131072 | 
 (1 row)
 
 SELECT * FROM chunks_detailed_size('disttable') ORDER BY chunk_schema, chunk_name, node_name;
      chunk_schema      |      chunk_name       | table_bytes | index_bytes | toast_bytes | total_bytes |  node_name  
 -----------------------+-----------------------+-------------+-------------+-------------+-------------+-------------
- _timescaledb_internal | _dist_hyper_2_2_chunk |        8192 |       16384 |           0 |       24576 | data_node_1
- _timescaledb_internal | _dist_hyper_2_5_chunk |        8192 |       16384 |           0 |       24576 | data_node_2
- _timescaledb_internal | _dist_hyper_2_6_chunk |        8192 |       16384 |           0 |       24576 | data_node_1
+ _timescaledb_internal | _dist_hyper_2_2_chunk |        8192 |       24576 |        8192 |       40960 | data_node_1
+ _timescaledb_internal | _dist_hyper_2_5_chunk |        8192 |       24576 |        8192 |       40960 | data_node_2
+ _timescaledb_internal | _dist_hyper_2_6_chunk |        8192 |       24576 |        8192 |       40960 | data_node_1
 (3 rows)
 
 SELECT * FROM chunks_detailed_size('nondisttable') ORDER BY chunk_schema, chunk_name, node_name;
      chunk_schema      |    chunk_name    | table_bytes | index_bytes | toast_bytes | total_bytes | node_name 
 -----------------------+------------------+-------------+-------------+-------------+-------------+-----------
- _timescaledb_internal | _hyper_1_1_chunk |        8192 |       16384 |           0 |       24576 | 
- _timescaledb_internal | _hyper_1_3_chunk |        8192 |       16384 |           0 |       24576 | 
- _timescaledb_internal | _hyper_1_4_chunk |        8192 |       16384 |           0 |       24576 | 
+ _timescaledb_internal | _hyper_1_1_chunk |        8192 |       24576 |        8192 |       40960 | 
+ _timescaledb_internal | _hyper_1_3_chunk |        8192 |       24576 |        8192 |       40960 | 
+ _timescaledb_internal | _hyper_1_4_chunk |        8192 |       24576 |        8192 |       40960 | 
 (3 rows)
 
 SELECT * FROM hypertable_compression_stats('disttable') ORDER BY node_name;
@@ -849,19 +849,19 @@ LIMIT 2;
 SELECT * FROM hypertable_size('disttable');
  hypertable_size 
 -----------------
-          131072
+          147456
 (1 row)
 
 SELECT * FROM hypertable_size('nondisttable');
  hypertable_size 
 -----------------
-          114688
+          131072
 (1 row)
 
 SELECT * FROM hypertable_detailed_size('disttable') ORDER BY node_name;
  table_bytes | index_bytes | toast_bytes | total_bytes |  node_name  
 -------------+-------------+-------------+-------------+-------------
-       16384 |       49152 |        8192 |       73728 | data_node_1
+       16384 |       57344 |       16384 |       90112 | data_node_1
         8192 |       32768 |        8192 |       49152 | data_node_2
            0 |        8192 |           0 |        8192 | 
 (3 rows)
@@ -869,7 +869,7 @@ SELECT * FROM hypertable_detailed_size('disttable') ORDER BY node_name;
 SELECT * FROM hypertable_detailed_size('nondisttable') ORDER BY node_name;
  table_bytes | index_bytes | toast_bytes | total_bytes | node_name 
 -------------+-------------+-------------+-------------+-----------
-       24576 |       73728 |       16384 |      114688 | 
+       24576 |       81920 |       24576 |      131072 | 
 (1 row)
 
 SELECT * FROM chunks_detailed_size('disttable') ORDER BY chunk_schema, chunk_name, node_name;
@@ -877,7 +877,7 @@ SELECT * FROM chunks_detailed_size('disttable') ORDER BY chunk_schema, chunk_nam
 -----------------------+-----------------------+-------------+-------------+-------------+-------------+-------------
  _timescaledb_internal | _dist_hyper_2_2_chunk |        8192 |       24576 |        8192 |       40960 | data_node_1
  _timescaledb_internal | _dist_hyper_2_5_chunk |        8192 |       24576 |        8192 |       40960 | data_node_2
- _timescaledb_internal | _dist_hyper_2_6_chunk |        8192 |       16384 |           0 |       24576 | data_node_1
+ _timescaledb_internal | _dist_hyper_2_6_chunk |        8192 |       24576 |        8192 |       40960 | data_node_1
 (3 rows)
 
 SELECT * FROM chunks_detailed_size('nondisttable') ORDER BY chunk_schema, chunk_name, node_name;
@@ -885,7 +885,7 @@ SELECT * FROM chunks_detailed_size('nondisttable') ORDER BY chunk_schema, chunk_
 -----------------------+------------------+-------------+-------------+-------------+-------------+-----------
  _timescaledb_internal | _hyper_1_1_chunk |        8192 |       24576 |        8192 |       40960 | 
  _timescaledb_internal | _hyper_1_3_chunk |        8192 |       24576 |        8192 |       40960 | 
- _timescaledb_internal | _hyper_1_4_chunk |        8192 |       16384 |           0 |       24576 | 
+ _timescaledb_internal | _hyper_1_4_chunk |        8192 |       24576 |        8192 |       40960 | 
 (3 rows)
 
 SELECT * FROM hypertable_compression_stats('disttable') ORDER BY node_name;
@@ -976,7 +976,7 @@ SELECT * FROM chunks_detailed_size('disttable') ORDER BY chunk_schema, chunk_nam
 -----------------------+-----------------------+-------------+-------------+-------------+-------------+-------------
  _timescaledb_internal | _dist_hyper_2_2_chunk |        8192 |       24576 |        8192 |       40960 | data_node_1
  _timescaledb_internal | _dist_hyper_2_5_chunk |        8192 |       24576 |        8192 |       40960 | data_node_2
- _timescaledb_internal | _dist_hyper_2_6_chunk |        8192 |       16384 |           0 |       24576 | data_node_1
+ _timescaledb_internal | _dist_hyper_2_6_chunk |        8192 |       24576 |        8192 |       40960 | data_node_1
 (3 rows)
 
 SELECT * FROM chunks_detailed_size('nondisttable') ORDER BY chunk_schema, chunk_name, node_name;
@@ -984,7 +984,7 @@ SELECT * FROM chunks_detailed_size('nondisttable') ORDER BY chunk_schema, chunk_
 -----------------------+------------------+-------------+-------------+-------------+-------------+-----------
  _timescaledb_internal | _hyper_1_1_chunk |        8192 |       24576 |        8192 |       40960 | 
  _timescaledb_internal | _hyper_1_3_chunk |        8192 |       24576 |        8192 |       40960 | 
- _timescaledb_internal | _hyper_1_4_chunk |        8192 |       16384 |           0 |       24576 | 
+ _timescaledb_internal | _hyper_1_4_chunk |        8192 |       24576 |        8192 |       40960 | 
 (3 rows)
 
 SELECT * FROM hypertable_compression_stats('disttable') ORDER BY node_name;
@@ -1043,19 +1043,19 @@ SELECT count(*) FROM disttable;
 SELECT * FROM hypertable_size('disttable');
  hypertable_size 
 -----------------
-          131072
+          147456
 (1 row)
 
 SELECT * FROM hypertable_size('nondisttable');
  hypertable_size 
 -----------------
-          114688
+          131072
 (1 row)
 
 SELECT * FROM hypertable_detailed_size('disttable') ORDER BY node_name;
  table_bytes | index_bytes | toast_bytes | total_bytes |  node_name  
 -------------+-------------+-------------+-------------+-------------
-       16384 |       49152 |        8192 |       73728 | data_node_1
+       16384 |       57344 |       16384 |       90112 | data_node_1
         8192 |       32768 |        8192 |       49152 | data_node_2
            0 |        8192 |           0 |        8192 | 
 (3 rows)
@@ -1063,7 +1063,7 @@ SELECT * FROM hypertable_detailed_size('disttable') ORDER BY node_name;
 SELECT * FROM hypertable_detailed_size('nondisttable') ORDER BY node_name;
  table_bytes | index_bytes | toast_bytes | total_bytes | node_name 
 -------------+-------------+-------------+-------------+-----------
-       24576 |       73728 |       16384 |      114688 | 
+       24576 |       81920 |       24576 |      131072 | 
 (1 row)
 
 -- Make sure timescaledb.ssl_dir and passfile gucs can be read by a non-superuser

--- a/tsl/test/expected/dist_views.out
+++ b/tsl/test/expected/dist_views.out
@@ -88,19 +88,19 @@ ORDER BY chunk_name, node_name;
 -----------------------+-----------------------+-------------+-------------+-------------+-------------+-----------------
  _timescaledb_internal | _dist_hyper_1_1_chunk |        8192 |       32768 |        8192 |       49152 | db_dist_views_1
  _timescaledb_internal | _dist_hyper_1_1_chunk |        8192 |       32768 |        8192 |       49152 | db_dist_views_2
- _timescaledb_internal | _dist_hyper_1_2_chunk |        8192 |       32768 |           0 |       40960 | db_dist_views_2
- _timescaledb_internal | _dist_hyper_1_2_chunk |        8192 |       32768 |           0 |       40960 | db_dist_views_3
- _timescaledb_internal | _dist_hyper_1_3_chunk |        8192 |       32768 |           0 |       40960 | db_dist_views_1
- _timescaledb_internal | _dist_hyper_1_3_chunk |        8192 |       32768 |           0 |       40960 | db_dist_views_3
+ _timescaledb_internal | _dist_hyper_1_2_chunk |        8192 |       40960 |        8192 |       57344 | db_dist_views_2
+ _timescaledb_internal | _dist_hyper_1_2_chunk |        8192 |       40960 |        8192 |       57344 | db_dist_views_3
+ _timescaledb_internal | _dist_hyper_1_3_chunk |        8192 |       40960 |        8192 |       57344 | db_dist_views_1
+ _timescaledb_internal | _dist_hyper_1_3_chunk |        8192 |       40960 |        8192 |       57344 | db_dist_views_3
 (6 rows)
 
 SELECT * FROM hypertable_detailed_size('dist_table'::regclass)
 ORDER BY node_name;;
  table_bytes | index_bytes | toast_bytes | total_bytes |    node_name    
 -------------+-------------+-------------+-------------+-----------------
-       16384 |       81920 |        8192 |      106496 | db_dist_views_1
-       16384 |       81920 |        8192 |      106496 | db_dist_views_2
-       16384 |       81920 |           0 |       98304 | db_dist_views_3
+       16384 |       90112 |       16384 |      122880 | db_dist_views_1
+       16384 |       90112 |       16384 |      122880 | db_dist_views_2
+       16384 |       98304 |       16384 |      131072 | db_dist_views_3
            0 |       16384 |           0 |       16384 | 
 (4 rows)
 

--- a/tsl/test/expected/exp_cagg_origin.out
+++ b/tsl/test/expected/exp_cagg_origin.out
@@ -703,7 +703,7 @@ ORDER BY month, city;
 -- Clean up
 DROP TABLE conditions_empty CASCADE;
 NOTICE:  drop cascades to 2 other objects
-NOTICE:  drop cascades to table _timescaledb_internal._hyper_11_225_chunk
+NOTICE:  drop cascades to table _timescaledb_internal._hyper_11_227_chunk
 -- Make sure add_continuous_aggregate_policy() works
 CREATE TABLE conditions_policy(
   day DATE NOT NULL,
@@ -770,7 +770,7 @@ SELECT add_continuous_aggregate_policy('conditions_summary_policy',
 -- Clean up
 DROP TABLE conditions_policy CASCADE;
 NOTICE:  drop cascades to 2 other objects
-NOTICE:  drop cascades to table _timescaledb_internal._hyper_13_240_chunk
+NOTICE:  drop cascades to table _timescaledb_internal._hyper_13_242_chunk
 -- Make sure CAGGs with custom origin work for timestamp type
 CREATE TABLE conditions_timestamp(
   tstamp TIMESTAMP NOT NULL,
@@ -845,8 +845,8 @@ ALTER TABLE conditions_timestamp SET (
 SELECT compress_chunk(ch) FROM show_chunks('conditions_timestamp') AS ch;
               compress_chunk               
 -------------------------------------------
- _timescaledb_internal._hyper_14_241_chunk
  _timescaledb_internal._hyper_14_243_chunk
+ _timescaledb_internal._hyper_14_245_chunk
 (2 rows)
 
 -- New data is seen because the cagg is real-time
@@ -896,7 +896,7 @@ SELECT add_continuous_aggregate_policy('conditions_summary_timestamp',
 DROP TABLE conditions_timestamp CASCADE;
 NOTICE:  drop cascades to 2 other objects
 NOTICE:  drop cascades to 3 other objects
-NOTICE:  drop cascades to table _timescaledb_internal._hyper_15_242_chunk
+NOTICE:  drop cascades to table _timescaledb_internal._hyper_15_244_chunk
 -- Make sure CAGGs with custom origin work for timestamptz type
 CREATE TABLE conditions_timestamptz(
   tstamp TIMESTAMPTZ NOT NULL,
@@ -1059,9 +1059,9 @@ ALTER TABLE conditions_timestamptz SET (
 SELECT compress_chunk(ch) FROM show_chunks('conditions_timestamptz') AS ch;
               compress_chunk               
 -------------------------------------------
- _timescaledb_internal._hyper_17_246_chunk
- _timescaledb_internal._hyper_17_247_chunk
+ _timescaledb_internal._hyper_17_248_chunk
  _timescaledb_internal._hyper_17_249_chunk
+ _timescaledb_internal._hyper_17_251_chunk
 (3 rows)
 
 -- New data is seen because the cagg is real-time
@@ -1111,7 +1111,7 @@ SELECT add_continuous_aggregate_policy('conditions_summary_timestamptz',
 DROP TABLE conditions_timestamptz CASCADE;
 NOTICE:  drop cascades to 3 other objects
 NOTICE:  drop cascades to 3 other objects
-NOTICE:  drop cascades to table _timescaledb_internal._hyper_19_248_chunk
+NOTICE:  drop cascades to table _timescaledb_internal._hyper_19_250_chunk
 \c :TEST_DBNAME :ROLE_CLUSTER_SUPERUSER
 DROP DATABASE :DATA_NODE_1;
 DROP DATABASE :DATA_NODE_2;

--- a/tsl/test/expected/merge_append_partially_compressed-13.out
+++ b/tsl/test/expected/merge_append_partially_compressed-13.out
@@ -23,8 +23,8 @@ SELECT compress_chunk(c) FROM show_chunks('ht_metrics_compressed') c;
              compress_chunk             
 ----------------------------------------
  _timescaledb_internal._hyper_1_1_chunk
- _timescaledb_internal._hyper_1_2_chunk
  _timescaledb_internal._hyper_1_3_chunk
+ _timescaledb_internal._hyper_1_5_chunk
 (3 rows)
 
 -- make them partially compressed
@@ -41,31 +41,31 @@ generate_series(1,3) device;
    ->  Custom Scan (ChunkAppend) on ht_metrics_compressed (actual rows=1 loops=1)
          Order: ht_metrics_compressed."time" DESC, ht_metrics_compressed.device
          ->  Merge Append (actual rows=1 loops=1)
-               Sort Key: _hyper_1_3_chunk."time" DESC, _hyper_1_3_chunk.device
+               Sort Key: _hyper_1_5_chunk."time" DESC, _hyper_1_5_chunk.device
                ->  Sort (actual rows=1 loops=1)
-                     Sort Key: _hyper_1_3_chunk."time" DESC, _hyper_1_3_chunk.device
+                     Sort Key: _hyper_1_5_chunk."time" DESC, _hyper_1_5_chunk.device
                      Sort Method: top-N heapsort 
-                     ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk (actual rows=30 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_1_5_chunk (actual rows=30 loops=1)
                            ->  Seq Scan on compress_hyper_2_6_chunk (actual rows=3 loops=1)
                ->  Sort (actual rows=1 loops=1)
-                     Sort Key: _hyper_1_3_chunk."time" DESC, _hyper_1_3_chunk.device
+                     Sort Key: _hyper_1_5_chunk."time" DESC, _hyper_1_5_chunk.device
                      Sort Method: top-N heapsort 
-                     ->  Seq Scan on _hyper_1_3_chunk (actual rows=18 loops=1)
+                     ->  Seq Scan on _hyper_1_5_chunk (actual rows=18 loops=1)
          ->  Merge Append (never executed)
-               Sort Key: _hyper_1_2_chunk."time" DESC, _hyper_1_2_chunk.device
+               Sort Key: _hyper_1_3_chunk."time" DESC, _hyper_1_3_chunk.device
                ->  Sort (never executed)
-                     Sort Key: _hyper_1_2_chunk."time" DESC, _hyper_1_2_chunk.device
-                     ->  Custom Scan (DecompressChunk) on _hyper_1_2_chunk (never executed)
-                           ->  Seq Scan on compress_hyper_2_5_chunk (never executed)
+                     Sort Key: _hyper_1_3_chunk."time" DESC, _hyper_1_3_chunk.device
+                     ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk (never executed)
+                           ->  Seq Scan on compress_hyper_2_4_chunk (never executed)
                ->  Sort (never executed)
-                     Sort Key: _hyper_1_2_chunk."time" DESC, _hyper_1_2_chunk.device
-                     ->  Seq Scan on _hyper_1_2_chunk (never executed)
+                     Sort Key: _hyper_1_3_chunk."time" DESC, _hyper_1_3_chunk.device
+                     ->  Seq Scan on _hyper_1_3_chunk (never executed)
          ->  Merge Append (never executed)
                Sort Key: _hyper_1_1_chunk."time" DESC, _hyper_1_1_chunk.device
                ->  Sort (never executed)
                      Sort Key: _hyper_1_1_chunk."time" DESC, _hyper_1_1_chunk.device
                      ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk (never executed)
-                           ->  Seq Scan on compress_hyper_2_4_chunk (never executed)
+                           ->  Seq Scan on compress_hyper_2_2_chunk (never executed)
                ->  Sort (never executed)
                      Sort Key: _hyper_1_1_chunk."time" DESC, _hyper_1_1_chunk.device
                      ->  Seq Scan on _hyper_1_1_chunk (never executed)
@@ -81,29 +81,29 @@ generate_series(1,3) device;
                Sort Key: (time_bucket('@ 1 day'::interval, _hyper_1_1_chunk."time")) DESC, _hyper_1_1_chunk.device
                Sort Method: top-N heapsort 
                ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk (actual rows=81 loops=1)
-                     ->  Seq Scan on compress_hyper_2_4_chunk (actual rows=3 loops=1)
+                     ->  Seq Scan on compress_hyper_2_2_chunk (actual rows=3 loops=1)
          ->  Sort (actual rows=1 loops=1)
                Sort Key: (time_bucket('@ 1 day'::interval, _hyper_1_1_chunk."time")) DESC, _hyper_1_1_chunk.device
                Sort Method: top-N heapsort 
                ->  Seq Scan on _hyper_1_1_chunk (actual rows=54 loops=1)
          ->  Sort (actual rows=1 loops=1)
-               Sort Key: (time_bucket('@ 1 day'::interval, _hyper_1_2_chunk."time")) DESC, _hyper_1_2_chunk.device
+               Sort Key: (time_bucket('@ 1 day'::interval, _hyper_1_3_chunk."time")) DESC, _hyper_1_3_chunk.device
                Sort Method: top-N heapsort 
-               ->  Custom Scan (DecompressChunk) on _hyper_1_2_chunk (actual rows=84 loops=1)
-                     ->  Seq Scan on compress_hyper_2_5_chunk (actual rows=3 loops=1)
-         ->  Sort (actual rows=1 loops=1)
-               Sort Key: (time_bucket('@ 1 day'::interval, _hyper_1_2_chunk."time")) DESC, _hyper_1_2_chunk.device
-               Sort Method: top-N heapsort 
-               ->  Seq Scan on _hyper_1_2_chunk (actual rows=57 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk (actual rows=84 loops=1)
+                     ->  Seq Scan on compress_hyper_2_4_chunk (actual rows=3 loops=1)
          ->  Sort (actual rows=1 loops=1)
                Sort Key: (time_bucket('@ 1 day'::interval, _hyper_1_3_chunk."time")) DESC, _hyper_1_3_chunk.device
                Sort Method: top-N heapsort 
-               ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk (actual rows=30 loops=1)
+               ->  Seq Scan on _hyper_1_3_chunk (actual rows=57 loops=1)
+         ->  Sort (actual rows=1 loops=1)
+               Sort Key: (time_bucket('@ 1 day'::interval, _hyper_1_5_chunk."time")) DESC, _hyper_1_5_chunk.device
+               Sort Method: top-N heapsort 
+               ->  Custom Scan (DecompressChunk) on _hyper_1_5_chunk (actual rows=30 loops=1)
                      ->  Seq Scan on compress_hyper_2_6_chunk (actual rows=3 loops=1)
          ->  Sort (actual rows=1 loops=1)
-               Sort Key: (time_bucket('@ 1 day'::interval, _hyper_1_3_chunk."time")) DESC, _hyper_1_3_chunk.device
+               Sort Key: (time_bucket('@ 1 day'::interval, _hyper_1_5_chunk."time")) DESC, _hyper_1_5_chunk.device
                Sort Method: top-N heapsort 
-               ->  Seq Scan on _hyper_1_3_chunk (actual rows=18 loops=1)
+               ->  Seq Scan on _hyper_1_5_chunk (actual rows=18 loops=1)
 (30 rows)
 
 :PREFIX SELECT * FROM ht_metrics_compressed ORDER BY time desc limit 10;
@@ -113,31 +113,31 @@ generate_series(1,3) device;
    ->  Custom Scan (ChunkAppend) on ht_metrics_compressed (actual rows=10 loops=1)
          Order: ht_metrics_compressed."time" DESC
          ->  Merge Append (actual rows=10 loops=1)
-               Sort Key: _hyper_1_3_chunk."time" DESC
+               Sort Key: _hyper_1_5_chunk."time" DESC
                ->  Sort (actual rows=7 loops=1)
-                     Sort Key: _hyper_1_3_chunk."time" DESC
+                     Sort Key: _hyper_1_5_chunk."time" DESC
                      Sort Method: top-N heapsort 
-                     ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk (actual rows=30 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_1_5_chunk (actual rows=30 loops=1)
                            ->  Seq Scan on compress_hyper_2_6_chunk (actual rows=3 loops=1)
                ->  Sort (actual rows=4 loops=1)
-                     Sort Key: _hyper_1_3_chunk."time" DESC
+                     Sort Key: _hyper_1_5_chunk."time" DESC
                      Sort Method: quicksort 
-                     ->  Seq Scan on _hyper_1_3_chunk (actual rows=18 loops=1)
+                     ->  Seq Scan on _hyper_1_5_chunk (actual rows=18 loops=1)
          ->  Merge Append (never executed)
-               Sort Key: _hyper_1_2_chunk."time" DESC
+               Sort Key: _hyper_1_3_chunk."time" DESC
                ->  Sort (never executed)
-                     Sort Key: _hyper_1_2_chunk."time" DESC
-                     ->  Custom Scan (DecompressChunk) on _hyper_1_2_chunk (never executed)
-                           ->  Seq Scan on compress_hyper_2_5_chunk (never executed)
+                     Sort Key: _hyper_1_3_chunk."time" DESC
+                     ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk (never executed)
+                           ->  Seq Scan on compress_hyper_2_4_chunk (never executed)
                ->  Sort (never executed)
-                     Sort Key: _hyper_1_2_chunk."time" DESC
-                     ->  Seq Scan on _hyper_1_2_chunk (never executed)
+                     Sort Key: _hyper_1_3_chunk."time" DESC
+                     ->  Seq Scan on _hyper_1_3_chunk (never executed)
          ->  Merge Append (never executed)
                Sort Key: _hyper_1_1_chunk."time" DESC
                ->  Sort (never executed)
                      Sort Key: _hyper_1_1_chunk."time" DESC
                      ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk (never executed)
-                           ->  Seq Scan on compress_hyper_2_4_chunk (never executed)
+                           ->  Seq Scan on compress_hyper_2_2_chunk (never executed)
                ->  Sort (never executed)
                      Sort Key: _hyper_1_1_chunk."time" DESC
                      ->  Seq Scan on _hyper_1_1_chunk (never executed)
@@ -150,31 +150,31 @@ generate_series(1,3) device;
    ->  Custom Scan (ChunkAppend) on ht_metrics_compressed (actual rows=1 loops=1)
          Order: time_bucket('@ 2 days'::interval, ht_metrics_compressed."time") DESC
          ->  Merge Append (actual rows=1 loops=1)
-               Sort Key: (time_bucket('@ 2 days'::interval, _hyper_1_3_chunk."time")) DESC
+               Sort Key: (time_bucket('@ 2 days'::interval, _hyper_1_5_chunk."time")) DESC
                ->  Sort (actual rows=1 loops=1)
-                     Sort Key: (time_bucket('@ 2 days'::interval, _hyper_1_3_chunk."time")) DESC
+                     Sort Key: (time_bucket('@ 2 days'::interval, _hyper_1_5_chunk."time")) DESC
                      Sort Method: top-N heapsort 
-                     ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk (actual rows=30 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_1_5_chunk (actual rows=30 loops=1)
                            ->  Seq Scan on compress_hyper_2_6_chunk (actual rows=3 loops=1)
                ->  Sort (actual rows=1 loops=1)
-                     Sort Key: (time_bucket('@ 2 days'::interval, _hyper_1_3_chunk."time")) DESC
+                     Sort Key: (time_bucket('@ 2 days'::interval, _hyper_1_5_chunk."time")) DESC
                      Sort Method: top-N heapsort 
-                     ->  Seq Scan on _hyper_1_3_chunk (actual rows=18 loops=1)
+                     ->  Seq Scan on _hyper_1_5_chunk (actual rows=18 loops=1)
          ->  Merge Append (never executed)
-               Sort Key: (time_bucket('@ 2 days'::interval, _hyper_1_2_chunk."time")) DESC
+               Sort Key: (time_bucket('@ 2 days'::interval, _hyper_1_3_chunk."time")) DESC
                ->  Sort (never executed)
-                     Sort Key: (time_bucket('@ 2 days'::interval, _hyper_1_2_chunk."time")) DESC
-                     ->  Custom Scan (DecompressChunk) on _hyper_1_2_chunk (never executed)
-                           ->  Seq Scan on compress_hyper_2_5_chunk (never executed)
+                     Sort Key: (time_bucket('@ 2 days'::interval, _hyper_1_3_chunk."time")) DESC
+                     ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk (never executed)
+                           ->  Seq Scan on compress_hyper_2_4_chunk (never executed)
                ->  Sort (never executed)
-                     Sort Key: (time_bucket('@ 2 days'::interval, _hyper_1_2_chunk."time")) DESC
-                     ->  Seq Scan on _hyper_1_2_chunk (never executed)
+                     Sort Key: (time_bucket('@ 2 days'::interval, _hyper_1_3_chunk."time")) DESC
+                     ->  Seq Scan on _hyper_1_3_chunk (never executed)
          ->  Merge Append (never executed)
                Sort Key: (time_bucket('@ 2 days'::interval, _hyper_1_1_chunk."time")) DESC
                ->  Sort (never executed)
                      Sort Key: (time_bucket('@ 2 days'::interval, _hyper_1_1_chunk."time")) DESC
                      ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk (never executed)
-                           ->  Seq Scan on compress_hyper_2_4_chunk (never executed)
+                           ->  Seq Scan on compress_hyper_2_2_chunk (never executed)
                ->  Sort (never executed)
                      Sort Key: (time_bucket('@ 2 days'::interval, _hyper_1_1_chunk."time")) DESC
                      ->  Seq Scan on _hyper_1_1_chunk (never executed)
@@ -187,30 +187,30 @@ generate_series(1,3) device;
    ->  Custom Scan (ChunkAppend) on ht_metrics_compressed (actual rows=1 loops=1)
          Order: ht_metrics_compressed."time" DESC
          ->  Merge Append (actual rows=1 loops=1)
-               Sort Key: _hyper_1_3_chunk."time" DESC
+               Sort Key: _hyper_1_5_chunk."time" DESC
                ->  Sort (actual rows=1 loops=1)
-                     Sort Key: _hyper_1_3_chunk."time" DESC
+                     Sort Key: _hyper_1_5_chunk."time" DESC
                      Sort Method: top-N heapsort 
-                     ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk (actual rows=30 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_1_5_chunk (actual rows=30 loops=1)
                            Filter: (device = ANY ('{1,2,3}'::integer[]))
                            ->  Index Scan using compress_hyper_2_6_chunk__compressed_hypertable_2_device__ts_me on compress_hyper_2_6_chunk (actual rows=3 loops=1)
                                  Index Cond: (device = ANY ('{1,2,3}'::integer[]))
                ->  Sort (actual rows=1 loops=1)
-                     Sort Key: _hyper_1_3_chunk."time" DESC
+                     Sort Key: _hyper_1_5_chunk."time" DESC
                      Sort Method: top-N heapsort 
-                     ->  Seq Scan on _hyper_1_3_chunk (actual rows=18 loops=1)
+                     ->  Seq Scan on _hyper_1_5_chunk (actual rows=18 loops=1)
                            Filter: (device = ANY ('{1,2,3}'::integer[]))
          ->  Merge Append (never executed)
-               Sort Key: _hyper_1_2_chunk."time" DESC
+               Sort Key: _hyper_1_3_chunk."time" DESC
                ->  Sort (never executed)
-                     Sort Key: _hyper_1_2_chunk."time" DESC
-                     ->  Custom Scan (DecompressChunk) on _hyper_1_2_chunk (never executed)
+                     Sort Key: _hyper_1_3_chunk."time" DESC
+                     ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk (never executed)
                            Filter: (device = ANY ('{1,2,3}'::integer[]))
-                           ->  Index Scan using compress_hyper_2_5_chunk__compressed_hypertable_2_device__ts_me on compress_hyper_2_5_chunk (never executed)
+                           ->  Index Scan using compress_hyper_2_4_chunk__compressed_hypertable_2_device__ts_me on compress_hyper_2_4_chunk (never executed)
                                  Index Cond: (device = ANY ('{1,2,3}'::integer[]))
                ->  Sort (never executed)
-                     Sort Key: _hyper_1_2_chunk."time" DESC
-                     ->  Seq Scan on _hyper_1_2_chunk (never executed)
+                     Sort Key: _hyper_1_3_chunk."time" DESC
+                     ->  Seq Scan on _hyper_1_3_chunk (never executed)
                            Filter: (device = ANY ('{1,2,3}'::integer[]))
          ->  Merge Append (never executed)
                Sort Key: _hyper_1_1_chunk."time" DESC
@@ -218,7 +218,7 @@ generate_series(1,3) device;
                      Sort Key: _hyper_1_1_chunk."time" DESC
                      ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk (never executed)
                            Filter: (device = ANY ('{1,2,3}'::integer[]))
-                           ->  Index Scan using compress_hyper_2_4_chunk__compressed_hypertable_2_device__ts_me on compress_hyper_2_4_chunk (never executed)
+                           ->  Index Scan using compress_hyper_2_2_chunk__compressed_hypertable_2_device__ts_me on compress_hyper_2_2_chunk (never executed)
                                  Index Cond: (device = ANY ('{1,2,3}'::integer[]))
                ->  Sort (never executed)
                      Sort Key: _hyper_1_1_chunk."time" DESC
@@ -239,7 +239,7 @@ generate_series(1,3) device;
                      Sort Method: top-N heapsort 
                      ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk (actual rows=81 loops=1)
                            Filter: (device = ANY ('{1,2,3}'::integer[]))
-                           ->  Index Scan using compress_hyper_2_4_chunk__compressed_hypertable_2_device__ts_me on compress_hyper_2_4_chunk (actual rows=3 loops=1)
+                           ->  Index Scan using compress_hyper_2_2_chunk__compressed_hypertable_2_device__ts_me on compress_hyper_2_2_chunk (actual rows=3 loops=1)
                                  Index Cond: (device = ANY ('{1,2,3}'::integer[]))
                ->  Sort (actual rows=1 loops=1)
                      Sort Key: _hyper_1_1_chunk."time", _hyper_1_1_chunk.device DESC
@@ -247,28 +247,28 @@ generate_series(1,3) device;
                      ->  Seq Scan on _hyper_1_1_chunk (actual rows=54 loops=1)
                            Filter: (device = ANY ('{1,2,3}'::integer[]))
          ->  Merge Append (never executed)
-               Sort Key: _hyper_1_2_chunk."time", _hyper_1_2_chunk.device DESC
-               ->  Sort (never executed)
-                     Sort Key: _hyper_1_2_chunk."time", _hyper_1_2_chunk.device DESC
-                     ->  Custom Scan (DecompressChunk) on _hyper_1_2_chunk (never executed)
-                           Filter: (device = ANY ('{1,2,3}'::integer[]))
-                           ->  Index Scan using compress_hyper_2_5_chunk__compressed_hypertable_2_device__ts_me on compress_hyper_2_5_chunk (never executed)
-                                 Index Cond: (device = ANY ('{1,2,3}'::integer[]))
-               ->  Sort (never executed)
-                     Sort Key: _hyper_1_2_chunk."time", _hyper_1_2_chunk.device DESC
-                     ->  Seq Scan on _hyper_1_2_chunk (never executed)
-                           Filter: (device = ANY ('{1,2,3}'::integer[]))
-         ->  Merge Append (never executed)
                Sort Key: _hyper_1_3_chunk."time", _hyper_1_3_chunk.device DESC
                ->  Sort (never executed)
                      Sort Key: _hyper_1_3_chunk."time", _hyper_1_3_chunk.device DESC
                      ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk (never executed)
                            Filter: (device = ANY ('{1,2,3}'::integer[]))
-                           ->  Index Scan using compress_hyper_2_6_chunk__compressed_hypertable_2_device__ts_me on compress_hyper_2_6_chunk (never executed)
+                           ->  Index Scan using compress_hyper_2_4_chunk__compressed_hypertable_2_device__ts_me on compress_hyper_2_4_chunk (never executed)
                                  Index Cond: (device = ANY ('{1,2,3}'::integer[]))
                ->  Sort (never executed)
                      Sort Key: _hyper_1_3_chunk."time", _hyper_1_3_chunk.device DESC
                      ->  Seq Scan on _hyper_1_3_chunk (never executed)
+                           Filter: (device = ANY ('{1,2,3}'::integer[]))
+         ->  Merge Append (never executed)
+               Sort Key: _hyper_1_5_chunk."time", _hyper_1_5_chunk.device DESC
+               ->  Sort (never executed)
+                     Sort Key: _hyper_1_5_chunk."time", _hyper_1_5_chunk.device DESC
+                     ->  Custom Scan (DecompressChunk) on _hyper_1_5_chunk (never executed)
+                           Filter: (device = ANY ('{1,2,3}'::integer[]))
+                           ->  Index Scan using compress_hyper_2_6_chunk__compressed_hypertable_2_device__ts_me on compress_hyper_2_6_chunk (never executed)
+                                 Index Cond: (device = ANY ('{1,2,3}'::integer[]))
+               ->  Sort (never executed)
+                     Sort Key: _hyper_1_5_chunk."time", _hyper_1_5_chunk.device DESC
+                     ->  Seq Scan on _hyper_1_5_chunk (never executed)
                            Filter: (device = ANY ('{1,2,3}'::integer[]))
 (41 rows)
 
@@ -280,32 +280,32 @@ generate_series(1,3) device;
    ->  Custom Scan (ChunkAppend) on ht_metrics_compressed (actual rows=1 loops=1)
          Order: ht_metrics_compressed."time" DESC
          ->  Merge Append (actual rows=1 loops=1)
-               Sort Key: _hyper_1_3_chunk."time" DESC
-               ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk (actual rows=1 loops=1)
+               Sort Key: _hyper_1_5_chunk."time" DESC
+               ->  Custom Scan (DecompressChunk) on _hyper_1_5_chunk (actual rows=1 loops=1)
                      Filter: (device = 3)
                      ->  Index Scan Backward using compress_hyper_2_6_chunk__compressed_hypertable_2_device__ts_me on compress_hyper_2_6_chunk (actual rows=1 loops=1)
                            Index Cond: (device = 3)
                ->  Sort (actual rows=1 loops=1)
-                     Sort Key: _hyper_1_3_chunk."time" DESC
+                     Sort Key: _hyper_1_5_chunk."time" DESC
                      Sort Method: top-N heapsort 
-                     ->  Seq Scan on _hyper_1_3_chunk (actual rows=6 loops=1)
+                     ->  Seq Scan on _hyper_1_5_chunk (actual rows=6 loops=1)
                            Filter: (device = 3)
                            Rows Removed by Filter: 12
          ->  Merge Append (never executed)
-               Sort Key: _hyper_1_2_chunk."time" DESC
-               ->  Custom Scan (DecompressChunk) on _hyper_1_2_chunk (never executed)
+               Sort Key: _hyper_1_3_chunk."time" DESC
+               ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk (never executed)
                      Filter: (device = 3)
-                     ->  Index Scan Backward using compress_hyper_2_5_chunk__compressed_hypertable_2_device__ts_me on compress_hyper_2_5_chunk (never executed)
+                     ->  Index Scan Backward using compress_hyper_2_4_chunk__compressed_hypertable_2_device__ts_me on compress_hyper_2_4_chunk (never executed)
                            Index Cond: (device = 3)
                ->  Sort (never executed)
-                     Sort Key: _hyper_1_2_chunk."time" DESC
-                     ->  Seq Scan on _hyper_1_2_chunk (never executed)
+                     Sort Key: _hyper_1_3_chunk."time" DESC
+                     ->  Seq Scan on _hyper_1_3_chunk (never executed)
                            Filter: (device = 3)
          ->  Merge Append (never executed)
                Sort Key: _hyper_1_1_chunk."time" DESC
                ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk (never executed)
                      Filter: (device = 3)
-                     ->  Index Scan Backward using compress_hyper_2_4_chunk__compressed_hypertable_2_device__ts_me on compress_hyper_2_4_chunk (never executed)
+                     ->  Index Scan Backward using compress_hyper_2_2_chunk__compressed_hypertable_2_device__ts_me on compress_hyper_2_2_chunk (never executed)
                            Index Cond: (device = 3)
                ->  Sort (never executed)
                      Sort Key: _hyper_1_1_chunk."time" DESC
@@ -327,7 +327,7 @@ SELECT * FROM ht_metrics_compressed WHERE device = 3 ORDER BY time DESC LIMIT 1;
          Sort Key: _hyper_1_1_chunk."time" DESC
          ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk (actual rows=1 loops=1)
                Filter: (device = 3)
-               ->  Index Scan Backward using compress_hyper_2_4_chunk__compressed_hypertable_2_device__ts_me on compress_hyper_2_4_chunk (actual rows=1 loops=1)
+               ->  Index Scan Backward using compress_hyper_2_2_chunk__compressed_hypertable_2_device__ts_me on compress_hyper_2_2_chunk (actual rows=1 loops=1)
                      Index Cond: (device = 3)
          ->  Sort (actual rows=1 loops=1)
                Sort Key: _hyper_1_1_chunk."time" DESC
@@ -335,24 +335,24 @@ SELECT * FROM ht_metrics_compressed WHERE device = 3 ORDER BY time DESC LIMIT 1;
                ->  Seq Scan on _hyper_1_1_chunk (actual rows=18 loops=1)
                      Filter: (device = 3)
                      Rows Removed by Filter: 36
-         ->  Custom Scan (DecompressChunk) on _hyper_1_2_chunk (actual rows=1 loops=1)
-               Filter: (device = 3)
-               ->  Index Scan Backward using compress_hyper_2_5_chunk__compressed_hypertable_2_device__ts_me on compress_hyper_2_5_chunk (actual rows=1 loops=1)
-                     Index Cond: (device = 3)
-         ->  Sort (actual rows=1 loops=1)
-               Sort Key: _hyper_1_2_chunk."time" DESC
-               Sort Method: top-N heapsort 
-               ->  Seq Scan on _hyper_1_2_chunk (actual rows=19 loops=1)
-                     Filter: (device = 3)
-                     Rows Removed by Filter: 38
          ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk (actual rows=1 loops=1)
                Filter: (device = 3)
-               ->  Index Scan Backward using compress_hyper_2_6_chunk__compressed_hypertable_2_device__ts_me on compress_hyper_2_6_chunk (actual rows=1 loops=1)
+               ->  Index Scan Backward using compress_hyper_2_4_chunk__compressed_hypertable_2_device__ts_me on compress_hyper_2_4_chunk (actual rows=1 loops=1)
                      Index Cond: (device = 3)
          ->  Sort (actual rows=1 loops=1)
                Sort Key: _hyper_1_3_chunk."time" DESC
                Sort Method: top-N heapsort 
-               ->  Seq Scan on _hyper_1_3_chunk (actual rows=6 loops=1)
+               ->  Seq Scan on _hyper_1_3_chunk (actual rows=19 loops=1)
+                     Filter: (device = 3)
+                     Rows Removed by Filter: 38
+         ->  Custom Scan (DecompressChunk) on _hyper_1_5_chunk (actual rows=1 loops=1)
+               Filter: (device = 3)
+               ->  Index Scan Backward using compress_hyper_2_6_chunk__compressed_hypertable_2_device__ts_me on compress_hyper_2_6_chunk (actual rows=1 loops=1)
+                     Index Cond: (device = 3)
+         ->  Sort (actual rows=1 loops=1)
+               Sort Key: _hyper_1_5_chunk."time" DESC
+               Sort Method: top-N heapsort 
+               ->  Seq Scan on _hyper_1_5_chunk (actual rows=6 loops=1)
                      Filter: (device = 3)
                      Rows Removed by Filter: 12
 (33 rows)
@@ -373,7 +373,7 @@ SELECT * FROM ht_metrics_compressed WHERE device = 3 ORDER BY device, time DESC 
                Sort Key: _hyper_1_1_chunk."time"
                ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk (actual rows=1 loops=1)
                      Filter: (device = 3)
-                     ->  Index Scan using compress_hyper_2_4_chunk__compressed_hypertable_2_device__ts_me on compress_hyper_2_4_chunk (actual rows=1 loops=1)
+                     ->  Index Scan using compress_hyper_2_2_chunk__compressed_hypertable_2_device__ts_me on compress_hyper_2_2_chunk (actual rows=1 loops=1)
                            Index Cond: (device = 3)
                ->  Sort (actual rows=1 loops=1)
                      Sort Key: _hyper_1_1_chunk."time"
@@ -382,24 +382,24 @@ SELECT * FROM ht_metrics_compressed WHERE device = 3 ORDER BY device, time DESC 
                            Filter: (device = 3)
                            Rows Removed by Filter: 36
          ->  Merge Append (never executed)
-               Sort Key: _hyper_1_2_chunk."time"
-               ->  Custom Scan (DecompressChunk) on _hyper_1_2_chunk (never executed)
-                     Filter: (device = 3)
-                     ->  Index Scan using compress_hyper_2_5_chunk__compressed_hypertable_2_device__ts_me on compress_hyper_2_5_chunk (never executed)
-                           Index Cond: (device = 3)
-               ->  Sort (never executed)
-                     Sort Key: _hyper_1_2_chunk."time"
-                     ->  Seq Scan on _hyper_1_2_chunk (never executed)
-                           Filter: (device = 3)
-         ->  Merge Append (never executed)
                Sort Key: _hyper_1_3_chunk."time"
                ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk (never executed)
                      Filter: (device = 3)
-                     ->  Index Scan using compress_hyper_2_6_chunk__compressed_hypertable_2_device__ts_me on compress_hyper_2_6_chunk (never executed)
+                     ->  Index Scan using compress_hyper_2_4_chunk__compressed_hypertable_2_device__ts_me on compress_hyper_2_4_chunk (never executed)
                            Index Cond: (device = 3)
                ->  Sort (never executed)
                      Sort Key: _hyper_1_3_chunk."time"
                      ->  Seq Scan on _hyper_1_3_chunk (never executed)
+                           Filter: (device = 3)
+         ->  Merge Append (never executed)
+               Sort Key: _hyper_1_5_chunk."time"
+               ->  Custom Scan (DecompressChunk) on _hyper_1_5_chunk (never executed)
+                     Filter: (device = 3)
+                     ->  Index Scan using compress_hyper_2_6_chunk__compressed_hypertable_2_device__ts_me on compress_hyper_2_6_chunk (never executed)
+                           Index Cond: (device = 3)
+               ->  Sort (never executed)
+                     Sort Key: _hyper_1_5_chunk."time"
+                     ->  Seq Scan on _hyper_1_5_chunk (never executed)
                            Filter: (device = 3)
 (35 rows)
 
@@ -418,31 +418,31 @@ SELECT * FROM ht_metrics_compressed WHERE device = 3 ORDER BY time, device DESC 
          Sort Key: _hyper_1_1_chunk.device, _hyper_1_1_chunk."time" DESC
          ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk (actual rows=1 loops=1)
                ->  Sort (actual rows=1 loops=1)
-                     Sort Key: compress_hyper_2_4_chunk.device, compress_hyper_2_4_chunk._ts_meta_sequence_num DESC
+                     Sort Key: compress_hyper_2_2_chunk.device, compress_hyper_2_2_chunk._ts_meta_sequence_num DESC
                      Sort Method: quicksort 
-                     ->  Seq Scan on compress_hyper_2_4_chunk (actual rows=3 loops=1)
+                     ->  Seq Scan on compress_hyper_2_2_chunk (actual rows=3 loops=1)
          ->  Sort (actual rows=1 loops=1)
                Sort Key: _hyper_1_1_chunk.device, _hyper_1_1_chunk."time" DESC
                Sort Method: top-N heapsort 
                ->  Seq Scan on _hyper_1_1_chunk (actual rows=54 loops=1)
-         ->  Custom Scan (DecompressChunk) on _hyper_1_2_chunk (actual rows=1 loops=1)
-               ->  Sort (actual rows=1 loops=1)
-                     Sort Key: compress_hyper_2_5_chunk.device, compress_hyper_2_5_chunk._ts_meta_sequence_num DESC
-                     Sort Method: quicksort 
-                     ->  Seq Scan on compress_hyper_2_5_chunk (actual rows=3 loops=1)
-         ->  Sort (actual rows=1 loops=1)
-               Sort Key: _hyper_1_2_chunk.device, _hyper_1_2_chunk."time" DESC
-               Sort Method: top-N heapsort 
-               ->  Seq Scan on _hyper_1_2_chunk (actual rows=57 loops=1)
          ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk (actual rows=1 loops=1)
+               ->  Sort (actual rows=1 loops=1)
+                     Sort Key: compress_hyper_2_4_chunk.device, compress_hyper_2_4_chunk._ts_meta_sequence_num DESC
+                     Sort Method: quicksort 
+                     ->  Seq Scan on compress_hyper_2_4_chunk (actual rows=3 loops=1)
+         ->  Sort (actual rows=1 loops=1)
+               Sort Key: _hyper_1_3_chunk.device, _hyper_1_3_chunk."time" DESC
+               Sort Method: top-N heapsort 
+               ->  Seq Scan on _hyper_1_3_chunk (actual rows=57 loops=1)
+         ->  Custom Scan (DecompressChunk) on _hyper_1_5_chunk (actual rows=1 loops=1)
                ->  Sort (actual rows=1 loops=1)
                      Sort Key: compress_hyper_2_6_chunk.device, compress_hyper_2_6_chunk._ts_meta_sequence_num DESC
                      Sort Method: quicksort 
                      ->  Seq Scan on compress_hyper_2_6_chunk (actual rows=3 loops=1)
          ->  Sort (actual rows=1 loops=1)
-               Sort Key: _hyper_1_3_chunk.device, _hyper_1_3_chunk."time" DESC
+               Sort Key: _hyper_1_5_chunk.device, _hyper_1_5_chunk."time" DESC
                Sort Method: top-N heapsort 
-               ->  Seq Scan on _hyper_1_3_chunk (actual rows=18 loops=1)
+               ->  Seq Scan on _hyper_1_5_chunk (actual rows=18 loops=1)
 (30 rows)
 
 :PREFIX SELECT * FROM ht_metrics_compressed WHERE device IN (1,2,3) ORDER BY device, time DESC LIMIT 1; -- with pushdown
@@ -454,28 +454,28 @@ SELECT * FROM ht_metrics_compressed WHERE device = 3 ORDER BY time, device DESC 
          ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk (actual rows=1 loops=1)
                Filter: (device = ANY ('{1,2,3}'::integer[]))
                ->  Sort (actual rows=1 loops=1)
-                     Sort Key: compress_hyper_2_4_chunk.device, compress_hyper_2_4_chunk._ts_meta_sequence_num DESC
+                     Sort Key: compress_hyper_2_2_chunk.device, compress_hyper_2_2_chunk._ts_meta_sequence_num DESC
                      Sort Method: quicksort 
-                     ->  Index Scan using compress_hyper_2_4_chunk__compressed_hypertable_2_device__ts_me on compress_hyper_2_4_chunk (actual rows=3 loops=1)
+                     ->  Index Scan using compress_hyper_2_2_chunk__compressed_hypertable_2_device__ts_me on compress_hyper_2_2_chunk (actual rows=3 loops=1)
                            Index Cond: (device = ANY ('{1,2,3}'::integer[]))
          ->  Sort (actual rows=1 loops=1)
                Sort Key: _hyper_1_1_chunk.device, _hyper_1_1_chunk."time" DESC
                Sort Method: top-N heapsort 
                ->  Seq Scan on _hyper_1_1_chunk (actual rows=54 loops=1)
                      Filter: (device = ANY ('{1,2,3}'::integer[]))
-         ->  Custom Scan (DecompressChunk) on _hyper_1_2_chunk (actual rows=1 loops=1)
+         ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk (actual rows=1 loops=1)
                Filter: (device = ANY ('{1,2,3}'::integer[]))
                ->  Sort (actual rows=1 loops=1)
-                     Sort Key: compress_hyper_2_5_chunk.device, compress_hyper_2_5_chunk._ts_meta_sequence_num DESC
+                     Sort Key: compress_hyper_2_4_chunk.device, compress_hyper_2_4_chunk._ts_meta_sequence_num DESC
                      Sort Method: quicksort 
-                     ->  Index Scan using compress_hyper_2_5_chunk__compressed_hypertable_2_device__ts_me on compress_hyper_2_5_chunk (actual rows=3 loops=1)
+                     ->  Index Scan using compress_hyper_2_4_chunk__compressed_hypertable_2_device__ts_me on compress_hyper_2_4_chunk (actual rows=3 loops=1)
                            Index Cond: (device = ANY ('{1,2,3}'::integer[]))
          ->  Sort (actual rows=1 loops=1)
-               Sort Key: _hyper_1_2_chunk.device, _hyper_1_2_chunk."time" DESC
+               Sort Key: _hyper_1_3_chunk.device, _hyper_1_3_chunk."time" DESC
                Sort Method: top-N heapsort 
-               ->  Seq Scan on _hyper_1_2_chunk (actual rows=57 loops=1)
+               ->  Seq Scan on _hyper_1_3_chunk (actual rows=57 loops=1)
                      Filter: (device = ANY ('{1,2,3}'::integer[]))
-         ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk (actual rows=1 loops=1)
+         ->  Custom Scan (DecompressChunk) on _hyper_1_5_chunk (actual rows=1 loops=1)
                Filter: (device = ANY ('{1,2,3}'::integer[]))
                ->  Sort (actual rows=1 loops=1)
                      Sort Key: compress_hyper_2_6_chunk.device, compress_hyper_2_6_chunk._ts_meta_sequence_num DESC
@@ -483,9 +483,9 @@ SELECT * FROM ht_metrics_compressed WHERE device = 3 ORDER BY time, device DESC 
                      ->  Index Scan using compress_hyper_2_6_chunk__compressed_hypertable_2_device__ts_me on compress_hyper_2_6_chunk (actual rows=3 loops=1)
                            Index Cond: (device = ANY ('{1,2,3}'::integer[]))
          ->  Sort (actual rows=1 loops=1)
-               Sort Key: _hyper_1_3_chunk.device, _hyper_1_3_chunk."time" DESC
+               Sort Key: _hyper_1_5_chunk.device, _hyper_1_5_chunk."time" DESC
                Sort Method: top-N heapsort 
-               ->  Seq Scan on _hyper_1_3_chunk (actual rows=18 loops=1)
+               ->  Seq Scan on _hyper_1_5_chunk (actual rows=18 loops=1)
                      Filter: (device = ANY ('{1,2,3}'::integer[]))
 (39 rows)
 
@@ -895,7 +895,7 @@ SELECT compress_chunk(i) FROM show_chunks('test2') i;
              compress_chunk              
 -----------------------------------------
  _timescaledb_internal._hyper_5_9_chunk
- _timescaledb_internal._hyper_5_10_chunk
+ _timescaledb_internal._hyper_5_11_chunk
 (2 rows)
 
 -- make them partially compressed
@@ -910,22 +910,22 @@ set enable_indexscan = off;
    Sort Key: _hyper_5_9_chunk.x1, _hyper_5_9_chunk.x2, _hyper_5_9_chunk.x5, _hyper_5_9_chunk.x3
    ->  Custom Scan (DecompressChunk) on _hyper_5_9_chunk (actual rows=4 loops=1)
          ->  Sort (actual rows=3 loops=1)
-               Sort Key: compress_hyper_6_11_chunk.x1, compress_hyper_6_11_chunk.x2, compress_hyper_6_11_chunk.x5, compress_hyper_6_11_chunk._ts_meta_sequence_num
+               Sort Key: compress_hyper_6_10_chunk.x1, compress_hyper_6_10_chunk.x2, compress_hyper_6_10_chunk.x5, compress_hyper_6_10_chunk._ts_meta_sequence_num
                Sort Method: quicksort 
-               ->  Seq Scan on compress_hyper_6_11_chunk (actual rows=3 loops=1)
+               ->  Seq Scan on compress_hyper_6_10_chunk (actual rows=3 loops=1)
    ->  Sort (actual rows=1 loops=1)
          Sort Key: _hyper_5_9_chunk.x1, _hyper_5_9_chunk.x2, _hyper_5_9_chunk.x5, _hyper_5_9_chunk.x3
          Sort Method: quicksort 
          ->  Seq Scan on _hyper_5_9_chunk (actual rows=1 loops=1)
-   ->  Custom Scan (DecompressChunk) on _hyper_5_10_chunk (actual rows=4 loops=1)
+   ->  Custom Scan (DecompressChunk) on _hyper_5_11_chunk (actual rows=4 loops=1)
          ->  Sort (actual rows=3 loops=1)
                Sort Key: compress_hyper_6_12_chunk.x1, compress_hyper_6_12_chunk.x2, compress_hyper_6_12_chunk.x5, compress_hyper_6_12_chunk._ts_meta_sequence_num
                Sort Method: quicksort 
                ->  Seq Scan on compress_hyper_6_12_chunk (actual rows=3 loops=1)
    ->  Sort (actual rows=1 loops=1)
-         Sort Key: _hyper_5_10_chunk.x1, _hyper_5_10_chunk.x2, _hyper_5_10_chunk.x5, _hyper_5_10_chunk.x3
+         Sort Key: _hyper_5_11_chunk.x1, _hyper_5_11_chunk.x2, _hyper_5_11_chunk.x5, _hyper_5_11_chunk.x3
          Sort Method: quicksort 
-         ->  Seq Scan on _hyper_5_10_chunk (actual rows=1 loops=1)
+         ->  Seq Scan on _hyper_5_11_chunk (actual rows=1 loops=1)
 (20 rows)
 
 SELECT * FROM test2 ORDER BY x1, x2, x5, x3;
@@ -950,22 +950,22 @@ SELECT * FROM test2 ORDER BY x1, x2, x5, x3;
    Sort Key: _hyper_5_9_chunk.x1, _hyper_5_9_chunk.x2, _hyper_5_9_chunk.x5, _hyper_5_9_chunk.x3, _hyper_5_9_chunk.x4
    ->  Custom Scan (DecompressChunk) on _hyper_5_9_chunk (actual rows=4 loops=1)
          ->  Sort (actual rows=3 loops=1)
-               Sort Key: compress_hyper_6_11_chunk.x1, compress_hyper_6_11_chunk.x2, compress_hyper_6_11_chunk.x5, compress_hyper_6_11_chunk._ts_meta_sequence_num
+               Sort Key: compress_hyper_6_10_chunk.x1, compress_hyper_6_10_chunk.x2, compress_hyper_6_10_chunk.x5, compress_hyper_6_10_chunk._ts_meta_sequence_num
                Sort Method: quicksort 
-               ->  Seq Scan on compress_hyper_6_11_chunk (actual rows=3 loops=1)
+               ->  Seq Scan on compress_hyper_6_10_chunk (actual rows=3 loops=1)
    ->  Sort (actual rows=1 loops=1)
          Sort Key: _hyper_5_9_chunk.x1, _hyper_5_9_chunk.x2, _hyper_5_9_chunk.x5, _hyper_5_9_chunk.x3, _hyper_5_9_chunk.x4
          Sort Method: quicksort 
          ->  Seq Scan on _hyper_5_9_chunk (actual rows=1 loops=1)
-   ->  Custom Scan (DecompressChunk) on _hyper_5_10_chunk (actual rows=4 loops=1)
+   ->  Custom Scan (DecompressChunk) on _hyper_5_11_chunk (actual rows=4 loops=1)
          ->  Sort (actual rows=3 loops=1)
                Sort Key: compress_hyper_6_12_chunk.x1, compress_hyper_6_12_chunk.x2, compress_hyper_6_12_chunk.x5, compress_hyper_6_12_chunk._ts_meta_sequence_num
                Sort Method: quicksort 
                ->  Seq Scan on compress_hyper_6_12_chunk (actual rows=3 loops=1)
    ->  Sort (actual rows=1 loops=1)
-         Sort Key: _hyper_5_10_chunk.x1, _hyper_5_10_chunk.x2, _hyper_5_10_chunk.x5, _hyper_5_10_chunk.x3, _hyper_5_10_chunk.x4
+         Sort Key: _hyper_5_11_chunk.x1, _hyper_5_11_chunk.x2, _hyper_5_11_chunk.x5, _hyper_5_11_chunk.x3, _hyper_5_11_chunk.x4
          Sort Method: quicksort 
-         ->  Seq Scan on _hyper_5_10_chunk (actual rows=1 loops=1)
+         ->  Seq Scan on _hyper_5_11_chunk (actual rows=1 loops=1)
 (20 rows)
 
 SELECT * FROM test2 ORDER BY x1, x2, x5, x3, x4;
@@ -993,20 +993,20 @@ SELECT * FROM test2 ORDER BY x1, x2, x5, x3, x4;
          Sort Key: _hyper_5_9_chunk.x1, _hyper_5_9_chunk.x2, _hyper_5_9_chunk.x3
          Sort Method: quicksort 
          ->  Custom Scan (DecompressChunk) on _hyper_5_9_chunk (actual rows=4 loops=1)
-               ->  Seq Scan on compress_hyper_6_11_chunk (actual rows=3 loops=1)
+               ->  Seq Scan on compress_hyper_6_10_chunk (actual rows=3 loops=1)
    ->  Sort (actual rows=1 loops=1)
          Sort Key: _hyper_5_9_chunk.x1, _hyper_5_9_chunk.x2, _hyper_5_9_chunk.x3
          Sort Method: quicksort 
          ->  Seq Scan on _hyper_5_9_chunk (actual rows=1 loops=1)
    ->  Sort (actual rows=4 loops=1)
-         Sort Key: _hyper_5_10_chunk.x1, _hyper_5_10_chunk.x2, _hyper_5_10_chunk.x3
+         Sort Key: _hyper_5_11_chunk.x1, _hyper_5_11_chunk.x2, _hyper_5_11_chunk.x3
          Sort Method: quicksort 
-         ->  Custom Scan (DecompressChunk) on _hyper_5_10_chunk (actual rows=4 loops=1)
+         ->  Custom Scan (DecompressChunk) on _hyper_5_11_chunk (actual rows=4 loops=1)
                ->  Seq Scan on compress_hyper_6_12_chunk (actual rows=3 loops=1)
    ->  Sort (actual rows=1 loops=1)
-         Sort Key: _hyper_5_10_chunk.x1, _hyper_5_10_chunk.x2, _hyper_5_10_chunk.x3
+         Sort Key: _hyper_5_11_chunk.x1, _hyper_5_11_chunk.x2, _hyper_5_11_chunk.x3
          Sort Method: quicksort 
-         ->  Seq Scan on _hyper_5_10_chunk (actual rows=1 loops=1)
+         ->  Seq Scan on _hyper_5_11_chunk (actual rows=1 loops=1)
 (20 rows)
 
 SELECT * FROM test2 ORDER BY x1, x2, x3;
@@ -1033,20 +1033,20 @@ SELECT * FROM test2 ORDER BY x1, x2, x3;
          Sort Key: _hyper_5_9_chunk.x1, _hyper_5_9_chunk.x2, _hyper_5_9_chunk.x5, _hyper_5_9_chunk.x4
          Sort Method: quicksort 
          ->  Custom Scan (DecompressChunk) on _hyper_5_9_chunk (actual rows=4 loops=1)
-               ->  Seq Scan on compress_hyper_6_11_chunk (actual rows=3 loops=1)
+               ->  Seq Scan on compress_hyper_6_10_chunk (actual rows=3 loops=1)
    ->  Sort (actual rows=1 loops=1)
          Sort Key: _hyper_5_9_chunk.x1, _hyper_5_9_chunk.x2, _hyper_5_9_chunk.x5, _hyper_5_9_chunk.x4
          Sort Method: quicksort 
          ->  Seq Scan on _hyper_5_9_chunk (actual rows=1 loops=1)
    ->  Sort (actual rows=4 loops=1)
-         Sort Key: _hyper_5_10_chunk.x1, _hyper_5_10_chunk.x2, _hyper_5_10_chunk.x5, _hyper_5_10_chunk.x4
+         Sort Key: _hyper_5_11_chunk.x1, _hyper_5_11_chunk.x2, _hyper_5_11_chunk.x5, _hyper_5_11_chunk.x4
          Sort Method: quicksort 
-         ->  Custom Scan (DecompressChunk) on _hyper_5_10_chunk (actual rows=4 loops=1)
+         ->  Custom Scan (DecompressChunk) on _hyper_5_11_chunk (actual rows=4 loops=1)
                ->  Seq Scan on compress_hyper_6_12_chunk (actual rows=3 loops=1)
    ->  Sort (actual rows=1 loops=1)
-         Sort Key: _hyper_5_10_chunk.x1, _hyper_5_10_chunk.x2, _hyper_5_10_chunk.x5, _hyper_5_10_chunk.x4
+         Sort Key: _hyper_5_11_chunk.x1, _hyper_5_11_chunk.x2, _hyper_5_11_chunk.x5, _hyper_5_11_chunk.x4
          Sort Method: quicksort 
-         ->  Seq Scan on _hyper_5_10_chunk (actual rows=1 loops=1)
+         ->  Seq Scan on _hyper_5_11_chunk (actual rows=1 loops=1)
 (20 rows)
 
 SELECT * FROM test2 ORDER BY x1, x2, x5, x4;
@@ -1073,20 +1073,20 @@ SELECT * FROM test2 ORDER BY x1, x2, x5, x4;
          Sort Key: _hyper_5_9_chunk.x1, _hyper_5_9_chunk.x2, _hyper_5_9_chunk.x5, _hyper_5_9_chunk."time"
          Sort Method: quicksort 
          ->  Custom Scan (DecompressChunk) on _hyper_5_9_chunk (actual rows=4 loops=1)
-               ->  Seq Scan on compress_hyper_6_11_chunk (actual rows=3 loops=1)
+               ->  Seq Scan on compress_hyper_6_10_chunk (actual rows=3 loops=1)
    ->  Sort (actual rows=1 loops=1)
          Sort Key: _hyper_5_9_chunk.x1, _hyper_5_9_chunk.x2, _hyper_5_9_chunk.x5, _hyper_5_9_chunk."time"
          Sort Method: quicksort 
          ->  Seq Scan on _hyper_5_9_chunk (actual rows=1 loops=1)
    ->  Sort (actual rows=4 loops=1)
-         Sort Key: _hyper_5_10_chunk.x1, _hyper_5_10_chunk.x2, _hyper_5_10_chunk.x5, _hyper_5_10_chunk."time"
+         Sort Key: _hyper_5_11_chunk.x1, _hyper_5_11_chunk.x2, _hyper_5_11_chunk.x5, _hyper_5_11_chunk."time"
          Sort Method: quicksort 
-         ->  Custom Scan (DecompressChunk) on _hyper_5_10_chunk (actual rows=4 loops=1)
+         ->  Custom Scan (DecompressChunk) on _hyper_5_11_chunk (actual rows=4 loops=1)
                ->  Seq Scan on compress_hyper_6_12_chunk (actual rows=3 loops=1)
    ->  Sort (actual rows=1 loops=1)
-         Sort Key: _hyper_5_10_chunk.x1, _hyper_5_10_chunk.x2, _hyper_5_10_chunk.x5, _hyper_5_10_chunk."time"
+         Sort Key: _hyper_5_11_chunk.x1, _hyper_5_11_chunk.x2, _hyper_5_11_chunk.x5, _hyper_5_11_chunk."time"
          Sort Method: quicksort 
-         ->  Seq Scan on _hyper_5_10_chunk (actual rows=1 loops=1)
+         ->  Seq Scan on _hyper_5_11_chunk (actual rows=1 loops=1)
 (20 rows)
 
 SELECT * FROM test2 ORDER BY x1, x2, x5, time;
@@ -1138,9 +1138,9 @@ SELECT compress_chunk(i) FROM show_chunks('test3') i;
              compress_chunk              
 -----------------------------------------
  _timescaledb_internal._hyper_7_13_chunk
- _timescaledb_internal._hyper_7_14_chunk
  _timescaledb_internal._hyper_7_15_chunk
- _timescaledb_internal._hyper_7_16_chunk
+ _timescaledb_internal._hyper_7_17_chunk
+ _timescaledb_internal._hyper_7_19_chunk
 (4 rows)
 
 -- make them partially compressed
@@ -1155,28 +1155,28 @@ set enable_indexscan = off;
    Sort Key: _hyper_7_13_chunk.x1, _hyper_7_13_chunk.x2, _hyper_7_13_chunk.x5, _hyper_7_13_chunk.x3
    ->  Custom Scan (DecompressChunk) on _hyper_7_13_chunk (actual rows=3 loops=1)
          ->  Sort (actual rows=2 loops=1)
-               Sort Key: compress_hyper_8_17_chunk.x1, compress_hyper_8_17_chunk.x2, compress_hyper_8_17_chunk.x5, compress_hyper_8_17_chunk._ts_meta_sequence_num
+               Sort Key: compress_hyper_8_14_chunk.x1, compress_hyper_8_14_chunk.x2, compress_hyper_8_14_chunk.x5, compress_hyper_8_14_chunk._ts_meta_sequence_num
                Sort Method: quicksort 
-               ->  Seq Scan on compress_hyper_8_17_chunk (actual rows=2 loops=1)
+               ->  Seq Scan on compress_hyper_8_14_chunk (actual rows=2 loops=1)
    ->  Sort (actual rows=1 loops=1)
          Sort Key: _hyper_7_13_chunk.x1, _hyper_7_13_chunk.x2, _hyper_7_13_chunk.x5, _hyper_7_13_chunk.x3
          Sort Method: quicksort 
          ->  Seq Scan on _hyper_7_13_chunk (actual rows=1 loops=1)
-   ->  Custom Scan (DecompressChunk) on _hyper_7_14_chunk (actual rows=1 loops=1)
+   ->  Custom Scan (DecompressChunk) on _hyper_7_15_chunk (actual rows=1 loops=1)
          ->  Sort (actual rows=1 loops=1)
+               Sort Key: compress_hyper_8_16_chunk.x1, compress_hyper_8_16_chunk.x2, compress_hyper_8_16_chunk.x5, compress_hyper_8_16_chunk._ts_meta_sequence_num
+               Sort Method: quicksort 
+               ->  Seq Scan on compress_hyper_8_16_chunk (actual rows=1 loops=1)
+   ->  Custom Scan (DecompressChunk) on _hyper_7_17_chunk (actual rows=3 loops=1)
+         ->  Sort (actual rows=2 loops=1)
                Sort Key: compress_hyper_8_18_chunk.x1, compress_hyper_8_18_chunk.x2, compress_hyper_8_18_chunk.x5, compress_hyper_8_18_chunk._ts_meta_sequence_num
                Sort Method: quicksort 
-               ->  Seq Scan on compress_hyper_8_18_chunk (actual rows=1 loops=1)
-   ->  Custom Scan (DecompressChunk) on _hyper_7_15_chunk (actual rows=3 loops=1)
-         ->  Sort (actual rows=2 loops=1)
-               Sort Key: compress_hyper_8_19_chunk.x1, compress_hyper_8_19_chunk.x2, compress_hyper_8_19_chunk.x5, compress_hyper_8_19_chunk._ts_meta_sequence_num
-               Sort Method: quicksort 
-               ->  Seq Scan on compress_hyper_8_19_chunk (actual rows=2 loops=1)
+               ->  Seq Scan on compress_hyper_8_18_chunk (actual rows=2 loops=1)
    ->  Sort (actual rows=1 loops=1)
-         Sort Key: _hyper_7_15_chunk.x1, _hyper_7_15_chunk.x2, _hyper_7_15_chunk.x5, _hyper_7_15_chunk.x3
+         Sort Key: _hyper_7_17_chunk.x1, _hyper_7_17_chunk.x2, _hyper_7_17_chunk.x5, _hyper_7_17_chunk.x3
          Sort Method: quicksort 
-         ->  Seq Scan on _hyper_7_15_chunk (actual rows=1 loops=1)
-   ->  Custom Scan (DecompressChunk) on _hyper_7_16_chunk (actual rows=1 loops=1)
+         ->  Seq Scan on _hyper_7_17_chunk (actual rows=1 loops=1)
+   ->  Custom Scan (DecompressChunk) on _hyper_7_19_chunk (actual rows=1 loops=1)
          ->  Sort (actual rows=1 loops=1)
                Sort Key: compress_hyper_8_20_chunk.x1, compress_hyper_8_20_chunk.x2, compress_hyper_8_20_chunk.x5, compress_hyper_8_20_chunk._ts_meta_sequence_num
                Sort Method: quicksort 
@@ -1205,28 +1205,28 @@ SELECT * FROM test3 ORDER BY x1, x2, x5, x3;
    Sort Key: _hyper_7_13_chunk.x1, _hyper_7_13_chunk.x2, _hyper_7_13_chunk.x5, _hyper_7_13_chunk.x3, _hyper_7_13_chunk.x4
    ->  Custom Scan (DecompressChunk) on _hyper_7_13_chunk (actual rows=3 loops=1)
          ->  Sort (actual rows=2 loops=1)
-               Sort Key: compress_hyper_8_17_chunk.x1, compress_hyper_8_17_chunk.x2, compress_hyper_8_17_chunk.x5, compress_hyper_8_17_chunk._ts_meta_sequence_num
+               Sort Key: compress_hyper_8_14_chunk.x1, compress_hyper_8_14_chunk.x2, compress_hyper_8_14_chunk.x5, compress_hyper_8_14_chunk._ts_meta_sequence_num
                Sort Method: quicksort 
-               ->  Seq Scan on compress_hyper_8_17_chunk (actual rows=2 loops=1)
+               ->  Seq Scan on compress_hyper_8_14_chunk (actual rows=2 loops=1)
    ->  Sort (actual rows=1 loops=1)
          Sort Key: _hyper_7_13_chunk.x1, _hyper_7_13_chunk.x2, _hyper_7_13_chunk.x5, _hyper_7_13_chunk.x3, _hyper_7_13_chunk.x4
          Sort Method: quicksort 
          ->  Seq Scan on _hyper_7_13_chunk (actual rows=1 loops=1)
-   ->  Custom Scan (DecompressChunk) on _hyper_7_14_chunk (actual rows=1 loops=1)
+   ->  Custom Scan (DecompressChunk) on _hyper_7_15_chunk (actual rows=1 loops=1)
          ->  Sort (actual rows=1 loops=1)
+               Sort Key: compress_hyper_8_16_chunk.x1, compress_hyper_8_16_chunk.x2, compress_hyper_8_16_chunk.x5, compress_hyper_8_16_chunk._ts_meta_sequence_num
+               Sort Method: quicksort 
+               ->  Seq Scan on compress_hyper_8_16_chunk (actual rows=1 loops=1)
+   ->  Custom Scan (DecompressChunk) on _hyper_7_17_chunk (actual rows=3 loops=1)
+         ->  Sort (actual rows=2 loops=1)
                Sort Key: compress_hyper_8_18_chunk.x1, compress_hyper_8_18_chunk.x2, compress_hyper_8_18_chunk.x5, compress_hyper_8_18_chunk._ts_meta_sequence_num
                Sort Method: quicksort 
-               ->  Seq Scan on compress_hyper_8_18_chunk (actual rows=1 loops=1)
-   ->  Custom Scan (DecompressChunk) on _hyper_7_15_chunk (actual rows=3 loops=1)
-         ->  Sort (actual rows=2 loops=1)
-               Sort Key: compress_hyper_8_19_chunk.x1, compress_hyper_8_19_chunk.x2, compress_hyper_8_19_chunk.x5, compress_hyper_8_19_chunk._ts_meta_sequence_num
-               Sort Method: quicksort 
-               ->  Seq Scan on compress_hyper_8_19_chunk (actual rows=2 loops=1)
+               ->  Seq Scan on compress_hyper_8_18_chunk (actual rows=2 loops=1)
    ->  Sort (actual rows=1 loops=1)
-         Sort Key: _hyper_7_15_chunk.x1, _hyper_7_15_chunk.x2, _hyper_7_15_chunk.x5, _hyper_7_15_chunk.x3, _hyper_7_15_chunk.x4
+         Sort Key: _hyper_7_17_chunk.x1, _hyper_7_17_chunk.x2, _hyper_7_17_chunk.x5, _hyper_7_17_chunk.x3, _hyper_7_17_chunk.x4
          Sort Method: quicksort 
-         ->  Seq Scan on _hyper_7_15_chunk (actual rows=1 loops=1)
-   ->  Custom Scan (DecompressChunk) on _hyper_7_16_chunk (actual rows=1 loops=1)
+         ->  Seq Scan on _hyper_7_17_chunk (actual rows=1 loops=1)
+   ->  Custom Scan (DecompressChunk) on _hyper_7_19_chunk (actual rows=1 loops=1)
          ->  Sort (actual rows=1 loops=1)
                Sort Key: compress_hyper_8_20_chunk.x1, compress_hyper_8_20_chunk.x2, compress_hyper_8_20_chunk.x5, compress_hyper_8_20_chunk._ts_meta_sequence_num
                Sort Method: quicksort 
@@ -1258,29 +1258,29 @@ SELECT * FROM test3 ORDER BY x1, x2, x5, x3, x4;
          Sort Key: _hyper_7_13_chunk.x1, _hyper_7_13_chunk.x2, _hyper_7_13_chunk.x3
          Sort Method: quicksort 
          ->  Custom Scan (DecompressChunk) on _hyper_7_13_chunk (actual rows=3 loops=1)
-               ->  Seq Scan on compress_hyper_8_17_chunk (actual rows=2 loops=1)
+               ->  Seq Scan on compress_hyper_8_14_chunk (actual rows=2 loops=1)
    ->  Sort (actual rows=1 loops=1)
          Sort Key: _hyper_7_13_chunk.x1, _hyper_7_13_chunk.x2, _hyper_7_13_chunk.x3
          Sort Method: quicksort 
          ->  Seq Scan on _hyper_7_13_chunk (actual rows=1 loops=1)
    ->  Sort (actual rows=1 loops=1)
-         Sort Key: _hyper_7_14_chunk.x1, _hyper_7_14_chunk.x2, _hyper_7_14_chunk.x3
+         Sort Key: _hyper_7_15_chunk.x1, _hyper_7_15_chunk.x2, _hyper_7_15_chunk.x3
          Sort Method: quicksort 
-         ->  Custom Scan (DecompressChunk) on _hyper_7_14_chunk (actual rows=1 loops=1)
-               ->  Seq Scan on compress_hyper_8_18_chunk (actual rows=1 loops=1)
+         ->  Custom Scan (DecompressChunk) on _hyper_7_15_chunk (actual rows=1 loops=1)
+               ->  Seq Scan on compress_hyper_8_16_chunk (actual rows=1 loops=1)
    ->  Sort (actual rows=3 loops=1)
-         Sort Key: _hyper_7_15_chunk.x1, _hyper_7_15_chunk.x2, _hyper_7_15_chunk.x3
+         Sort Key: _hyper_7_17_chunk.x1, _hyper_7_17_chunk.x2, _hyper_7_17_chunk.x3
          Sort Method: quicksort 
-         ->  Custom Scan (DecompressChunk) on _hyper_7_15_chunk (actual rows=3 loops=1)
-               ->  Seq Scan on compress_hyper_8_19_chunk (actual rows=2 loops=1)
+         ->  Custom Scan (DecompressChunk) on _hyper_7_17_chunk (actual rows=3 loops=1)
+               ->  Seq Scan on compress_hyper_8_18_chunk (actual rows=2 loops=1)
    ->  Sort (actual rows=1 loops=1)
-         Sort Key: _hyper_7_15_chunk.x1, _hyper_7_15_chunk.x2, _hyper_7_15_chunk.x3
+         Sort Key: _hyper_7_17_chunk.x1, _hyper_7_17_chunk.x2, _hyper_7_17_chunk.x3
          Sort Method: quicksort 
-         ->  Seq Scan on _hyper_7_15_chunk (actual rows=1 loops=1)
+         ->  Seq Scan on _hyper_7_17_chunk (actual rows=1 loops=1)
    ->  Sort (actual rows=1 loops=1)
-         Sort Key: _hyper_7_16_chunk.x1, _hyper_7_16_chunk.x2, _hyper_7_16_chunk.x3
+         Sort Key: _hyper_7_19_chunk.x1, _hyper_7_19_chunk.x2, _hyper_7_19_chunk.x3
          Sort Method: quicksort 
-         ->  Custom Scan (DecompressChunk) on _hyper_7_16_chunk (actual rows=1 loops=1)
+         ->  Custom Scan (DecompressChunk) on _hyper_7_19_chunk (actual rows=1 loops=1)
                ->  Seq Scan on compress_hyper_8_20_chunk (actual rows=1 loops=1)
 (30 rows)
 
@@ -1308,29 +1308,29 @@ SELECT * FROM test3 ORDER BY x1, x2, x3;
          Sort Key: _hyper_7_13_chunk.x1, _hyper_7_13_chunk.x2, _hyper_7_13_chunk.x5, _hyper_7_13_chunk.x4
          Sort Method: quicksort 
          ->  Custom Scan (DecompressChunk) on _hyper_7_13_chunk (actual rows=3 loops=1)
-               ->  Seq Scan on compress_hyper_8_17_chunk (actual rows=2 loops=1)
+               ->  Seq Scan on compress_hyper_8_14_chunk (actual rows=2 loops=1)
    ->  Sort (actual rows=1 loops=1)
          Sort Key: _hyper_7_13_chunk.x1, _hyper_7_13_chunk.x2, _hyper_7_13_chunk.x5, _hyper_7_13_chunk.x4
          Sort Method: quicksort 
          ->  Seq Scan on _hyper_7_13_chunk (actual rows=1 loops=1)
    ->  Sort (actual rows=1 loops=1)
-         Sort Key: _hyper_7_14_chunk.x1, _hyper_7_14_chunk.x2, _hyper_7_14_chunk.x5, _hyper_7_14_chunk.x4
+         Sort Key: _hyper_7_15_chunk.x1, _hyper_7_15_chunk.x2, _hyper_7_15_chunk.x5, _hyper_7_15_chunk.x4
          Sort Method: quicksort 
-         ->  Custom Scan (DecompressChunk) on _hyper_7_14_chunk (actual rows=1 loops=1)
-               ->  Seq Scan on compress_hyper_8_18_chunk (actual rows=1 loops=1)
+         ->  Custom Scan (DecompressChunk) on _hyper_7_15_chunk (actual rows=1 loops=1)
+               ->  Seq Scan on compress_hyper_8_16_chunk (actual rows=1 loops=1)
    ->  Sort (actual rows=3 loops=1)
-         Sort Key: _hyper_7_15_chunk.x1, _hyper_7_15_chunk.x2, _hyper_7_15_chunk.x5, _hyper_7_15_chunk.x4
+         Sort Key: _hyper_7_17_chunk.x1, _hyper_7_17_chunk.x2, _hyper_7_17_chunk.x5, _hyper_7_17_chunk.x4
          Sort Method: quicksort 
-         ->  Custom Scan (DecompressChunk) on _hyper_7_15_chunk (actual rows=3 loops=1)
-               ->  Seq Scan on compress_hyper_8_19_chunk (actual rows=2 loops=1)
+         ->  Custom Scan (DecompressChunk) on _hyper_7_17_chunk (actual rows=3 loops=1)
+               ->  Seq Scan on compress_hyper_8_18_chunk (actual rows=2 loops=1)
    ->  Sort (actual rows=1 loops=1)
-         Sort Key: _hyper_7_15_chunk.x1, _hyper_7_15_chunk.x2, _hyper_7_15_chunk.x5, _hyper_7_15_chunk.x4
+         Sort Key: _hyper_7_17_chunk.x1, _hyper_7_17_chunk.x2, _hyper_7_17_chunk.x5, _hyper_7_17_chunk.x4
          Sort Method: quicksort 
-         ->  Seq Scan on _hyper_7_15_chunk (actual rows=1 loops=1)
+         ->  Seq Scan on _hyper_7_17_chunk (actual rows=1 loops=1)
    ->  Sort (actual rows=1 loops=1)
-         Sort Key: _hyper_7_16_chunk.x1, _hyper_7_16_chunk.x2, _hyper_7_16_chunk.x5, _hyper_7_16_chunk.x4
+         Sort Key: _hyper_7_19_chunk.x1, _hyper_7_19_chunk.x2, _hyper_7_19_chunk.x5, _hyper_7_19_chunk.x4
          Sort Method: quicksort 
-         ->  Custom Scan (DecompressChunk) on _hyper_7_16_chunk (actual rows=1 loops=1)
+         ->  Custom Scan (DecompressChunk) on _hyper_7_19_chunk (actual rows=1 loops=1)
                ->  Seq Scan on compress_hyper_8_20_chunk (actual rows=1 loops=1)
 (30 rows)
 
@@ -1358,29 +1358,29 @@ SELECT * FROM test3 ORDER BY x1, x2, x5, x4;
          Sort Key: _hyper_7_13_chunk.x1, _hyper_7_13_chunk.x2, _hyper_7_13_chunk.x5, _hyper_7_13_chunk."time"
          Sort Method: quicksort 
          ->  Custom Scan (DecompressChunk) on _hyper_7_13_chunk (actual rows=3 loops=1)
-               ->  Seq Scan on compress_hyper_8_17_chunk (actual rows=2 loops=1)
+               ->  Seq Scan on compress_hyper_8_14_chunk (actual rows=2 loops=1)
    ->  Sort (actual rows=1 loops=1)
          Sort Key: _hyper_7_13_chunk.x1, _hyper_7_13_chunk.x2, _hyper_7_13_chunk.x5, _hyper_7_13_chunk."time"
          Sort Method: quicksort 
          ->  Seq Scan on _hyper_7_13_chunk (actual rows=1 loops=1)
    ->  Sort (actual rows=1 loops=1)
-         Sort Key: _hyper_7_14_chunk.x1, _hyper_7_14_chunk.x2, _hyper_7_14_chunk.x5, _hyper_7_14_chunk."time"
+         Sort Key: _hyper_7_15_chunk.x1, _hyper_7_15_chunk.x2, _hyper_7_15_chunk.x5, _hyper_7_15_chunk."time"
          Sort Method: quicksort 
-         ->  Custom Scan (DecompressChunk) on _hyper_7_14_chunk (actual rows=1 loops=1)
-               ->  Seq Scan on compress_hyper_8_18_chunk (actual rows=1 loops=1)
+         ->  Custom Scan (DecompressChunk) on _hyper_7_15_chunk (actual rows=1 loops=1)
+               ->  Seq Scan on compress_hyper_8_16_chunk (actual rows=1 loops=1)
    ->  Sort (actual rows=3 loops=1)
-         Sort Key: _hyper_7_15_chunk.x1, _hyper_7_15_chunk.x2, _hyper_7_15_chunk.x5, _hyper_7_15_chunk."time"
+         Sort Key: _hyper_7_17_chunk.x1, _hyper_7_17_chunk.x2, _hyper_7_17_chunk.x5, _hyper_7_17_chunk."time"
          Sort Method: quicksort 
-         ->  Custom Scan (DecompressChunk) on _hyper_7_15_chunk (actual rows=3 loops=1)
-               ->  Seq Scan on compress_hyper_8_19_chunk (actual rows=2 loops=1)
+         ->  Custom Scan (DecompressChunk) on _hyper_7_17_chunk (actual rows=3 loops=1)
+               ->  Seq Scan on compress_hyper_8_18_chunk (actual rows=2 loops=1)
    ->  Sort (actual rows=1 loops=1)
-         Sort Key: _hyper_7_15_chunk.x1, _hyper_7_15_chunk.x2, _hyper_7_15_chunk.x5, _hyper_7_15_chunk."time"
+         Sort Key: _hyper_7_17_chunk.x1, _hyper_7_17_chunk.x2, _hyper_7_17_chunk.x5, _hyper_7_17_chunk."time"
          Sort Method: quicksort 
-         ->  Seq Scan on _hyper_7_15_chunk (actual rows=1 loops=1)
+         ->  Seq Scan on _hyper_7_17_chunk (actual rows=1 loops=1)
    ->  Sort (actual rows=1 loops=1)
-         Sort Key: _hyper_7_16_chunk.x1, _hyper_7_16_chunk.x2, _hyper_7_16_chunk.x5, _hyper_7_16_chunk."time"
+         Sort Key: _hyper_7_19_chunk.x1, _hyper_7_19_chunk.x2, _hyper_7_19_chunk.x5, _hyper_7_19_chunk."time"
          Sort Method: quicksort 
-         ->  Custom Scan (DecompressChunk) on _hyper_7_16_chunk (actual rows=1 loops=1)
+         ->  Custom Scan (DecompressChunk) on _hyper_7_19_chunk (actual rows=1 loops=1)
                ->  Seq Scan on compress_hyper_8_20_chunk (actual rows=1 loops=1)
 (30 rows)
 

--- a/tsl/test/expected/merge_append_partially_compressed-14.out
+++ b/tsl/test/expected/merge_append_partially_compressed-14.out
@@ -23,8 +23,8 @@ SELECT compress_chunk(c) FROM show_chunks('ht_metrics_compressed') c;
              compress_chunk             
 ----------------------------------------
  _timescaledb_internal._hyper_1_1_chunk
- _timescaledb_internal._hyper_1_2_chunk
  _timescaledb_internal._hyper_1_3_chunk
+ _timescaledb_internal._hyper_1_5_chunk
 (3 rows)
 
 -- make them partially compressed
@@ -41,31 +41,31 @@ generate_series(1,3) device;
    ->  Custom Scan (ChunkAppend) on ht_metrics_compressed (actual rows=1 loops=1)
          Order: ht_metrics_compressed."time" DESC, ht_metrics_compressed.device
          ->  Merge Append (actual rows=1 loops=1)
-               Sort Key: _hyper_1_3_chunk."time" DESC, _hyper_1_3_chunk.device
+               Sort Key: _hyper_1_5_chunk."time" DESC, _hyper_1_5_chunk.device
                ->  Sort (actual rows=1 loops=1)
-                     Sort Key: _hyper_1_3_chunk."time" DESC, _hyper_1_3_chunk.device
+                     Sort Key: _hyper_1_5_chunk."time" DESC, _hyper_1_5_chunk.device
                      Sort Method: top-N heapsort 
-                     ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk (actual rows=30 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_1_5_chunk (actual rows=30 loops=1)
                            ->  Seq Scan on compress_hyper_2_6_chunk (actual rows=3 loops=1)
                ->  Sort (actual rows=1 loops=1)
-                     Sort Key: _hyper_1_3_chunk."time" DESC, _hyper_1_3_chunk.device
+                     Sort Key: _hyper_1_5_chunk."time" DESC, _hyper_1_5_chunk.device
                      Sort Method: top-N heapsort 
-                     ->  Seq Scan on _hyper_1_3_chunk (actual rows=18 loops=1)
+                     ->  Seq Scan on _hyper_1_5_chunk (actual rows=18 loops=1)
          ->  Merge Append (never executed)
-               Sort Key: _hyper_1_2_chunk."time" DESC, _hyper_1_2_chunk.device
+               Sort Key: _hyper_1_3_chunk."time" DESC, _hyper_1_3_chunk.device
                ->  Sort (never executed)
-                     Sort Key: _hyper_1_2_chunk."time" DESC, _hyper_1_2_chunk.device
-                     ->  Custom Scan (DecompressChunk) on _hyper_1_2_chunk (never executed)
-                           ->  Seq Scan on compress_hyper_2_5_chunk (never executed)
+                     Sort Key: _hyper_1_3_chunk."time" DESC, _hyper_1_3_chunk.device
+                     ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk (never executed)
+                           ->  Seq Scan on compress_hyper_2_4_chunk (never executed)
                ->  Sort (never executed)
-                     Sort Key: _hyper_1_2_chunk."time" DESC, _hyper_1_2_chunk.device
-                     ->  Seq Scan on _hyper_1_2_chunk (never executed)
+                     Sort Key: _hyper_1_3_chunk."time" DESC, _hyper_1_3_chunk.device
+                     ->  Seq Scan on _hyper_1_3_chunk (never executed)
          ->  Merge Append (never executed)
                Sort Key: _hyper_1_1_chunk."time" DESC, _hyper_1_1_chunk.device
                ->  Sort (never executed)
                      Sort Key: _hyper_1_1_chunk."time" DESC, _hyper_1_1_chunk.device
                      ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk (never executed)
-                           ->  Seq Scan on compress_hyper_2_4_chunk (never executed)
+                           ->  Seq Scan on compress_hyper_2_2_chunk (never executed)
                ->  Sort (never executed)
                      Sort Key: _hyper_1_1_chunk."time" DESC, _hyper_1_1_chunk.device
                      ->  Seq Scan on _hyper_1_1_chunk (never executed)
@@ -81,29 +81,29 @@ generate_series(1,3) device;
                Sort Key: (time_bucket('@ 1 day'::interval, _hyper_1_1_chunk."time")) DESC, _hyper_1_1_chunk.device
                Sort Method: top-N heapsort 
                ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk (actual rows=81 loops=1)
-                     ->  Seq Scan on compress_hyper_2_4_chunk (actual rows=3 loops=1)
+                     ->  Seq Scan on compress_hyper_2_2_chunk (actual rows=3 loops=1)
          ->  Sort (actual rows=1 loops=1)
                Sort Key: (time_bucket('@ 1 day'::interval, _hyper_1_1_chunk."time")) DESC, _hyper_1_1_chunk.device
                Sort Method: top-N heapsort 
                ->  Seq Scan on _hyper_1_1_chunk (actual rows=54 loops=1)
          ->  Sort (actual rows=1 loops=1)
-               Sort Key: (time_bucket('@ 1 day'::interval, _hyper_1_2_chunk."time")) DESC, _hyper_1_2_chunk.device
+               Sort Key: (time_bucket('@ 1 day'::interval, _hyper_1_3_chunk."time")) DESC, _hyper_1_3_chunk.device
                Sort Method: top-N heapsort 
-               ->  Custom Scan (DecompressChunk) on _hyper_1_2_chunk (actual rows=84 loops=1)
-                     ->  Seq Scan on compress_hyper_2_5_chunk (actual rows=3 loops=1)
-         ->  Sort (actual rows=1 loops=1)
-               Sort Key: (time_bucket('@ 1 day'::interval, _hyper_1_2_chunk."time")) DESC, _hyper_1_2_chunk.device
-               Sort Method: top-N heapsort 
-               ->  Seq Scan on _hyper_1_2_chunk (actual rows=57 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk (actual rows=84 loops=1)
+                     ->  Seq Scan on compress_hyper_2_4_chunk (actual rows=3 loops=1)
          ->  Sort (actual rows=1 loops=1)
                Sort Key: (time_bucket('@ 1 day'::interval, _hyper_1_3_chunk."time")) DESC, _hyper_1_3_chunk.device
                Sort Method: top-N heapsort 
-               ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk (actual rows=30 loops=1)
+               ->  Seq Scan on _hyper_1_3_chunk (actual rows=57 loops=1)
+         ->  Sort (actual rows=1 loops=1)
+               Sort Key: (time_bucket('@ 1 day'::interval, _hyper_1_5_chunk."time")) DESC, _hyper_1_5_chunk.device
+               Sort Method: top-N heapsort 
+               ->  Custom Scan (DecompressChunk) on _hyper_1_5_chunk (actual rows=30 loops=1)
                      ->  Seq Scan on compress_hyper_2_6_chunk (actual rows=3 loops=1)
          ->  Sort (actual rows=1 loops=1)
-               Sort Key: (time_bucket('@ 1 day'::interval, _hyper_1_3_chunk."time")) DESC, _hyper_1_3_chunk.device
+               Sort Key: (time_bucket('@ 1 day'::interval, _hyper_1_5_chunk."time")) DESC, _hyper_1_5_chunk.device
                Sort Method: top-N heapsort 
-               ->  Seq Scan on _hyper_1_3_chunk (actual rows=18 loops=1)
+               ->  Seq Scan on _hyper_1_5_chunk (actual rows=18 loops=1)
 (30 rows)
 
 :PREFIX SELECT * FROM ht_metrics_compressed ORDER BY time desc limit 10;
@@ -113,31 +113,31 @@ generate_series(1,3) device;
    ->  Custom Scan (ChunkAppend) on ht_metrics_compressed (actual rows=10 loops=1)
          Order: ht_metrics_compressed."time" DESC
          ->  Merge Append (actual rows=10 loops=1)
-               Sort Key: _hyper_1_3_chunk."time" DESC
+               Sort Key: _hyper_1_5_chunk."time" DESC
                ->  Sort (actual rows=7 loops=1)
-                     Sort Key: _hyper_1_3_chunk."time" DESC
+                     Sort Key: _hyper_1_5_chunk."time" DESC
                      Sort Method: top-N heapsort 
-                     ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk (actual rows=30 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_1_5_chunk (actual rows=30 loops=1)
                            ->  Seq Scan on compress_hyper_2_6_chunk (actual rows=3 loops=1)
                ->  Sort (actual rows=4 loops=1)
-                     Sort Key: _hyper_1_3_chunk."time" DESC
+                     Sort Key: _hyper_1_5_chunk."time" DESC
                      Sort Method: quicksort 
-                     ->  Seq Scan on _hyper_1_3_chunk (actual rows=18 loops=1)
+                     ->  Seq Scan on _hyper_1_5_chunk (actual rows=18 loops=1)
          ->  Merge Append (never executed)
-               Sort Key: _hyper_1_2_chunk."time" DESC
+               Sort Key: _hyper_1_3_chunk."time" DESC
                ->  Sort (never executed)
-                     Sort Key: _hyper_1_2_chunk."time" DESC
-                     ->  Custom Scan (DecompressChunk) on _hyper_1_2_chunk (never executed)
-                           ->  Seq Scan on compress_hyper_2_5_chunk (never executed)
+                     Sort Key: _hyper_1_3_chunk."time" DESC
+                     ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk (never executed)
+                           ->  Seq Scan on compress_hyper_2_4_chunk (never executed)
                ->  Sort (never executed)
-                     Sort Key: _hyper_1_2_chunk."time" DESC
-                     ->  Seq Scan on _hyper_1_2_chunk (never executed)
+                     Sort Key: _hyper_1_3_chunk."time" DESC
+                     ->  Seq Scan on _hyper_1_3_chunk (never executed)
          ->  Merge Append (never executed)
                Sort Key: _hyper_1_1_chunk."time" DESC
                ->  Sort (never executed)
                      Sort Key: _hyper_1_1_chunk."time" DESC
                      ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk (never executed)
-                           ->  Seq Scan on compress_hyper_2_4_chunk (never executed)
+                           ->  Seq Scan on compress_hyper_2_2_chunk (never executed)
                ->  Sort (never executed)
                      Sort Key: _hyper_1_1_chunk."time" DESC
                      ->  Seq Scan on _hyper_1_1_chunk (never executed)
@@ -150,31 +150,31 @@ generate_series(1,3) device;
    ->  Custom Scan (ChunkAppend) on ht_metrics_compressed (actual rows=1 loops=1)
          Order: time_bucket('@ 2 days'::interval, ht_metrics_compressed."time") DESC
          ->  Merge Append (actual rows=1 loops=1)
-               Sort Key: (time_bucket('@ 2 days'::interval, _hyper_1_3_chunk."time")) DESC
+               Sort Key: (time_bucket('@ 2 days'::interval, _hyper_1_5_chunk."time")) DESC
                ->  Sort (actual rows=1 loops=1)
-                     Sort Key: (time_bucket('@ 2 days'::interval, _hyper_1_3_chunk."time")) DESC
+                     Sort Key: (time_bucket('@ 2 days'::interval, _hyper_1_5_chunk."time")) DESC
                      Sort Method: top-N heapsort 
-                     ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk (actual rows=30 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_1_5_chunk (actual rows=30 loops=1)
                            ->  Seq Scan on compress_hyper_2_6_chunk (actual rows=3 loops=1)
                ->  Sort (actual rows=1 loops=1)
-                     Sort Key: (time_bucket('@ 2 days'::interval, _hyper_1_3_chunk."time")) DESC
+                     Sort Key: (time_bucket('@ 2 days'::interval, _hyper_1_5_chunk."time")) DESC
                      Sort Method: top-N heapsort 
-                     ->  Seq Scan on _hyper_1_3_chunk (actual rows=18 loops=1)
+                     ->  Seq Scan on _hyper_1_5_chunk (actual rows=18 loops=1)
          ->  Merge Append (never executed)
-               Sort Key: (time_bucket('@ 2 days'::interval, _hyper_1_2_chunk."time")) DESC
+               Sort Key: (time_bucket('@ 2 days'::interval, _hyper_1_3_chunk."time")) DESC
                ->  Sort (never executed)
-                     Sort Key: (time_bucket('@ 2 days'::interval, _hyper_1_2_chunk."time")) DESC
-                     ->  Custom Scan (DecompressChunk) on _hyper_1_2_chunk (never executed)
-                           ->  Seq Scan on compress_hyper_2_5_chunk (never executed)
+                     Sort Key: (time_bucket('@ 2 days'::interval, _hyper_1_3_chunk."time")) DESC
+                     ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk (never executed)
+                           ->  Seq Scan on compress_hyper_2_4_chunk (never executed)
                ->  Sort (never executed)
-                     Sort Key: (time_bucket('@ 2 days'::interval, _hyper_1_2_chunk."time")) DESC
-                     ->  Seq Scan on _hyper_1_2_chunk (never executed)
+                     Sort Key: (time_bucket('@ 2 days'::interval, _hyper_1_3_chunk."time")) DESC
+                     ->  Seq Scan on _hyper_1_3_chunk (never executed)
          ->  Merge Append (never executed)
                Sort Key: (time_bucket('@ 2 days'::interval, _hyper_1_1_chunk."time")) DESC
                ->  Sort (never executed)
                      Sort Key: (time_bucket('@ 2 days'::interval, _hyper_1_1_chunk."time")) DESC
                      ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk (never executed)
-                           ->  Seq Scan on compress_hyper_2_4_chunk (never executed)
+                           ->  Seq Scan on compress_hyper_2_2_chunk (never executed)
                ->  Sort (never executed)
                      Sort Key: (time_bucket('@ 2 days'::interval, _hyper_1_1_chunk."time")) DESC
                      ->  Seq Scan on _hyper_1_1_chunk (never executed)
@@ -187,30 +187,30 @@ generate_series(1,3) device;
    ->  Custom Scan (ChunkAppend) on ht_metrics_compressed (actual rows=1 loops=1)
          Order: ht_metrics_compressed."time" DESC
          ->  Merge Append (actual rows=1 loops=1)
-               Sort Key: _hyper_1_3_chunk."time" DESC
+               Sort Key: _hyper_1_5_chunk."time" DESC
                ->  Sort (actual rows=1 loops=1)
-                     Sort Key: _hyper_1_3_chunk."time" DESC
+                     Sort Key: _hyper_1_5_chunk."time" DESC
                      Sort Method: top-N heapsort 
-                     ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk (actual rows=30 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_1_5_chunk (actual rows=30 loops=1)
                            Filter: (device = ANY ('{1,2,3}'::integer[]))
                            ->  Index Scan using compress_hyper_2_6_chunk__compressed_hypertable_2_device__ts_me on compress_hyper_2_6_chunk (actual rows=3 loops=1)
                                  Index Cond: (device = ANY ('{1,2,3}'::integer[]))
                ->  Sort (actual rows=1 loops=1)
-                     Sort Key: _hyper_1_3_chunk."time" DESC
+                     Sort Key: _hyper_1_5_chunk."time" DESC
                      Sort Method: top-N heapsort 
-                     ->  Seq Scan on _hyper_1_3_chunk (actual rows=18 loops=1)
+                     ->  Seq Scan on _hyper_1_5_chunk (actual rows=18 loops=1)
                            Filter: (device = ANY ('{1,2,3}'::integer[]))
          ->  Merge Append (never executed)
-               Sort Key: _hyper_1_2_chunk."time" DESC
+               Sort Key: _hyper_1_3_chunk."time" DESC
                ->  Sort (never executed)
-                     Sort Key: _hyper_1_2_chunk."time" DESC
-                     ->  Custom Scan (DecompressChunk) on _hyper_1_2_chunk (never executed)
+                     Sort Key: _hyper_1_3_chunk."time" DESC
+                     ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk (never executed)
                            Filter: (device = ANY ('{1,2,3}'::integer[]))
-                           ->  Index Scan using compress_hyper_2_5_chunk__compressed_hypertable_2_device__ts_me on compress_hyper_2_5_chunk (never executed)
+                           ->  Index Scan using compress_hyper_2_4_chunk__compressed_hypertable_2_device__ts_me on compress_hyper_2_4_chunk (never executed)
                                  Index Cond: (device = ANY ('{1,2,3}'::integer[]))
                ->  Sort (never executed)
-                     Sort Key: _hyper_1_2_chunk."time" DESC
-                     ->  Seq Scan on _hyper_1_2_chunk (never executed)
+                     Sort Key: _hyper_1_3_chunk."time" DESC
+                     ->  Seq Scan on _hyper_1_3_chunk (never executed)
                            Filter: (device = ANY ('{1,2,3}'::integer[]))
          ->  Merge Append (never executed)
                Sort Key: _hyper_1_1_chunk."time" DESC
@@ -218,7 +218,7 @@ generate_series(1,3) device;
                      Sort Key: _hyper_1_1_chunk."time" DESC
                      ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk (never executed)
                            Filter: (device = ANY ('{1,2,3}'::integer[]))
-                           ->  Index Scan using compress_hyper_2_4_chunk__compressed_hypertable_2_device__ts_me on compress_hyper_2_4_chunk (never executed)
+                           ->  Index Scan using compress_hyper_2_2_chunk__compressed_hypertable_2_device__ts_me on compress_hyper_2_2_chunk (never executed)
                                  Index Cond: (device = ANY ('{1,2,3}'::integer[]))
                ->  Sort (never executed)
                      Sort Key: _hyper_1_1_chunk."time" DESC
@@ -239,7 +239,7 @@ generate_series(1,3) device;
                      Sort Method: top-N heapsort 
                      ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk (actual rows=81 loops=1)
                            Filter: (device = ANY ('{1,2,3}'::integer[]))
-                           ->  Index Scan using compress_hyper_2_4_chunk__compressed_hypertable_2_device__ts_me on compress_hyper_2_4_chunk (actual rows=3 loops=1)
+                           ->  Index Scan using compress_hyper_2_2_chunk__compressed_hypertable_2_device__ts_me on compress_hyper_2_2_chunk (actual rows=3 loops=1)
                                  Index Cond: (device = ANY ('{1,2,3}'::integer[]))
                ->  Sort (actual rows=1 loops=1)
                      Sort Key: _hyper_1_1_chunk."time", _hyper_1_1_chunk.device DESC
@@ -247,28 +247,28 @@ generate_series(1,3) device;
                      ->  Seq Scan on _hyper_1_1_chunk (actual rows=54 loops=1)
                            Filter: (device = ANY ('{1,2,3}'::integer[]))
          ->  Merge Append (never executed)
-               Sort Key: _hyper_1_2_chunk."time", _hyper_1_2_chunk.device DESC
-               ->  Sort (never executed)
-                     Sort Key: _hyper_1_2_chunk."time", _hyper_1_2_chunk.device DESC
-                     ->  Custom Scan (DecompressChunk) on _hyper_1_2_chunk (never executed)
-                           Filter: (device = ANY ('{1,2,3}'::integer[]))
-                           ->  Index Scan using compress_hyper_2_5_chunk__compressed_hypertable_2_device__ts_me on compress_hyper_2_5_chunk (never executed)
-                                 Index Cond: (device = ANY ('{1,2,3}'::integer[]))
-               ->  Sort (never executed)
-                     Sort Key: _hyper_1_2_chunk."time", _hyper_1_2_chunk.device DESC
-                     ->  Seq Scan on _hyper_1_2_chunk (never executed)
-                           Filter: (device = ANY ('{1,2,3}'::integer[]))
-         ->  Merge Append (never executed)
                Sort Key: _hyper_1_3_chunk."time", _hyper_1_3_chunk.device DESC
                ->  Sort (never executed)
                      Sort Key: _hyper_1_3_chunk."time", _hyper_1_3_chunk.device DESC
                      ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk (never executed)
                            Filter: (device = ANY ('{1,2,3}'::integer[]))
-                           ->  Index Scan using compress_hyper_2_6_chunk__compressed_hypertable_2_device__ts_me on compress_hyper_2_6_chunk (never executed)
+                           ->  Index Scan using compress_hyper_2_4_chunk__compressed_hypertable_2_device__ts_me on compress_hyper_2_4_chunk (never executed)
                                  Index Cond: (device = ANY ('{1,2,3}'::integer[]))
                ->  Sort (never executed)
                      Sort Key: _hyper_1_3_chunk."time", _hyper_1_3_chunk.device DESC
                      ->  Seq Scan on _hyper_1_3_chunk (never executed)
+                           Filter: (device = ANY ('{1,2,3}'::integer[]))
+         ->  Merge Append (never executed)
+               Sort Key: _hyper_1_5_chunk."time", _hyper_1_5_chunk.device DESC
+               ->  Sort (never executed)
+                     Sort Key: _hyper_1_5_chunk."time", _hyper_1_5_chunk.device DESC
+                     ->  Custom Scan (DecompressChunk) on _hyper_1_5_chunk (never executed)
+                           Filter: (device = ANY ('{1,2,3}'::integer[]))
+                           ->  Index Scan using compress_hyper_2_6_chunk__compressed_hypertable_2_device__ts_me on compress_hyper_2_6_chunk (never executed)
+                                 Index Cond: (device = ANY ('{1,2,3}'::integer[]))
+               ->  Sort (never executed)
+                     Sort Key: _hyper_1_5_chunk."time", _hyper_1_5_chunk.device DESC
+                     ->  Seq Scan on _hyper_1_5_chunk (never executed)
                            Filter: (device = ANY ('{1,2,3}'::integer[]))
 (41 rows)
 
@@ -280,32 +280,32 @@ generate_series(1,3) device;
    ->  Custom Scan (ChunkAppend) on ht_metrics_compressed (actual rows=1 loops=1)
          Order: ht_metrics_compressed."time" DESC
          ->  Merge Append (actual rows=1 loops=1)
-               Sort Key: _hyper_1_3_chunk."time" DESC
-               ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk (actual rows=1 loops=1)
+               Sort Key: _hyper_1_5_chunk."time" DESC
+               ->  Custom Scan (DecompressChunk) on _hyper_1_5_chunk (actual rows=1 loops=1)
                      Filter: (device = 3)
                      ->  Index Scan Backward using compress_hyper_2_6_chunk__compressed_hypertable_2_device__ts_me on compress_hyper_2_6_chunk (actual rows=1 loops=1)
                            Index Cond: (device = 3)
                ->  Sort (actual rows=1 loops=1)
-                     Sort Key: _hyper_1_3_chunk."time" DESC
+                     Sort Key: _hyper_1_5_chunk."time" DESC
                      Sort Method: top-N heapsort 
-                     ->  Seq Scan on _hyper_1_3_chunk (actual rows=6 loops=1)
+                     ->  Seq Scan on _hyper_1_5_chunk (actual rows=6 loops=1)
                            Filter: (device = 3)
                            Rows Removed by Filter: 12
          ->  Merge Append (never executed)
-               Sort Key: _hyper_1_2_chunk."time" DESC
-               ->  Custom Scan (DecompressChunk) on _hyper_1_2_chunk (never executed)
+               Sort Key: _hyper_1_3_chunk."time" DESC
+               ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk (never executed)
                      Filter: (device = 3)
-                     ->  Index Scan Backward using compress_hyper_2_5_chunk__compressed_hypertable_2_device__ts_me on compress_hyper_2_5_chunk (never executed)
+                     ->  Index Scan Backward using compress_hyper_2_4_chunk__compressed_hypertable_2_device__ts_me on compress_hyper_2_4_chunk (never executed)
                            Index Cond: (device = 3)
                ->  Sort (never executed)
-                     Sort Key: _hyper_1_2_chunk."time" DESC
-                     ->  Seq Scan on _hyper_1_2_chunk (never executed)
+                     Sort Key: _hyper_1_3_chunk."time" DESC
+                     ->  Seq Scan on _hyper_1_3_chunk (never executed)
                            Filter: (device = 3)
          ->  Merge Append (never executed)
                Sort Key: _hyper_1_1_chunk."time" DESC
                ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk (never executed)
                      Filter: (device = 3)
-                     ->  Index Scan Backward using compress_hyper_2_4_chunk__compressed_hypertable_2_device__ts_me on compress_hyper_2_4_chunk (never executed)
+                     ->  Index Scan Backward using compress_hyper_2_2_chunk__compressed_hypertable_2_device__ts_me on compress_hyper_2_2_chunk (never executed)
                            Index Cond: (device = 3)
                ->  Sort (never executed)
                      Sort Key: _hyper_1_1_chunk."time" DESC
@@ -327,7 +327,7 @@ SELECT * FROM ht_metrics_compressed WHERE device = 3 ORDER BY time DESC LIMIT 1;
          Sort Key: _hyper_1_1_chunk."time" DESC
          ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk (actual rows=1 loops=1)
                Filter: (device = 3)
-               ->  Index Scan Backward using compress_hyper_2_4_chunk__compressed_hypertable_2_device__ts_me on compress_hyper_2_4_chunk (actual rows=1 loops=1)
+               ->  Index Scan Backward using compress_hyper_2_2_chunk__compressed_hypertable_2_device__ts_me on compress_hyper_2_2_chunk (actual rows=1 loops=1)
                      Index Cond: (device = 3)
          ->  Sort (actual rows=1 loops=1)
                Sort Key: _hyper_1_1_chunk."time" DESC
@@ -335,24 +335,24 @@ SELECT * FROM ht_metrics_compressed WHERE device = 3 ORDER BY time DESC LIMIT 1;
                ->  Seq Scan on _hyper_1_1_chunk (actual rows=18 loops=1)
                      Filter: (device = 3)
                      Rows Removed by Filter: 36
-         ->  Custom Scan (DecompressChunk) on _hyper_1_2_chunk (actual rows=1 loops=1)
-               Filter: (device = 3)
-               ->  Index Scan Backward using compress_hyper_2_5_chunk__compressed_hypertable_2_device__ts_me on compress_hyper_2_5_chunk (actual rows=1 loops=1)
-                     Index Cond: (device = 3)
-         ->  Sort (actual rows=1 loops=1)
-               Sort Key: _hyper_1_2_chunk."time" DESC
-               Sort Method: top-N heapsort 
-               ->  Seq Scan on _hyper_1_2_chunk (actual rows=19 loops=1)
-                     Filter: (device = 3)
-                     Rows Removed by Filter: 38
          ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk (actual rows=1 loops=1)
                Filter: (device = 3)
-               ->  Index Scan Backward using compress_hyper_2_6_chunk__compressed_hypertable_2_device__ts_me on compress_hyper_2_6_chunk (actual rows=1 loops=1)
+               ->  Index Scan Backward using compress_hyper_2_4_chunk__compressed_hypertable_2_device__ts_me on compress_hyper_2_4_chunk (actual rows=1 loops=1)
                      Index Cond: (device = 3)
          ->  Sort (actual rows=1 loops=1)
                Sort Key: _hyper_1_3_chunk."time" DESC
                Sort Method: top-N heapsort 
-               ->  Seq Scan on _hyper_1_3_chunk (actual rows=6 loops=1)
+               ->  Seq Scan on _hyper_1_3_chunk (actual rows=19 loops=1)
+                     Filter: (device = 3)
+                     Rows Removed by Filter: 38
+         ->  Custom Scan (DecompressChunk) on _hyper_1_5_chunk (actual rows=1 loops=1)
+               Filter: (device = 3)
+               ->  Index Scan Backward using compress_hyper_2_6_chunk__compressed_hypertable_2_device__ts_me on compress_hyper_2_6_chunk (actual rows=1 loops=1)
+                     Index Cond: (device = 3)
+         ->  Sort (actual rows=1 loops=1)
+               Sort Key: _hyper_1_5_chunk."time" DESC
+               Sort Method: top-N heapsort 
+               ->  Seq Scan on _hyper_1_5_chunk (actual rows=6 loops=1)
                      Filter: (device = 3)
                      Rows Removed by Filter: 12
 (33 rows)
@@ -373,7 +373,7 @@ SELECT * FROM ht_metrics_compressed WHERE device = 3 ORDER BY device, time DESC 
                Sort Key: _hyper_1_1_chunk."time"
                ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk (actual rows=1 loops=1)
                      Filter: (device = 3)
-                     ->  Index Scan using compress_hyper_2_4_chunk__compressed_hypertable_2_device__ts_me on compress_hyper_2_4_chunk (actual rows=1 loops=1)
+                     ->  Index Scan using compress_hyper_2_2_chunk__compressed_hypertable_2_device__ts_me on compress_hyper_2_2_chunk (actual rows=1 loops=1)
                            Index Cond: (device = 3)
                ->  Sort (actual rows=1 loops=1)
                      Sort Key: _hyper_1_1_chunk."time"
@@ -382,24 +382,24 @@ SELECT * FROM ht_metrics_compressed WHERE device = 3 ORDER BY device, time DESC 
                            Filter: (device = 3)
                            Rows Removed by Filter: 36
          ->  Merge Append (never executed)
-               Sort Key: _hyper_1_2_chunk."time"
-               ->  Custom Scan (DecompressChunk) on _hyper_1_2_chunk (never executed)
-                     Filter: (device = 3)
-                     ->  Index Scan using compress_hyper_2_5_chunk__compressed_hypertable_2_device__ts_me on compress_hyper_2_5_chunk (never executed)
-                           Index Cond: (device = 3)
-               ->  Sort (never executed)
-                     Sort Key: _hyper_1_2_chunk."time"
-                     ->  Seq Scan on _hyper_1_2_chunk (never executed)
-                           Filter: (device = 3)
-         ->  Merge Append (never executed)
                Sort Key: _hyper_1_3_chunk."time"
                ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk (never executed)
                      Filter: (device = 3)
-                     ->  Index Scan using compress_hyper_2_6_chunk__compressed_hypertable_2_device__ts_me on compress_hyper_2_6_chunk (never executed)
+                     ->  Index Scan using compress_hyper_2_4_chunk__compressed_hypertable_2_device__ts_me on compress_hyper_2_4_chunk (never executed)
                            Index Cond: (device = 3)
                ->  Sort (never executed)
                      Sort Key: _hyper_1_3_chunk."time"
                      ->  Seq Scan on _hyper_1_3_chunk (never executed)
+                           Filter: (device = 3)
+         ->  Merge Append (never executed)
+               Sort Key: _hyper_1_5_chunk."time"
+               ->  Custom Scan (DecompressChunk) on _hyper_1_5_chunk (never executed)
+                     Filter: (device = 3)
+                     ->  Index Scan using compress_hyper_2_6_chunk__compressed_hypertable_2_device__ts_me on compress_hyper_2_6_chunk (never executed)
+                           Index Cond: (device = 3)
+               ->  Sort (never executed)
+                     Sort Key: _hyper_1_5_chunk."time"
+                     ->  Seq Scan on _hyper_1_5_chunk (never executed)
                            Filter: (device = 3)
 (35 rows)
 
@@ -418,31 +418,31 @@ SELECT * FROM ht_metrics_compressed WHERE device = 3 ORDER BY time, device DESC 
          Sort Key: _hyper_1_1_chunk.device, _hyper_1_1_chunk."time" DESC
          ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk (actual rows=1 loops=1)
                ->  Sort (actual rows=1 loops=1)
-                     Sort Key: compress_hyper_2_4_chunk.device, compress_hyper_2_4_chunk._ts_meta_sequence_num DESC
+                     Sort Key: compress_hyper_2_2_chunk.device, compress_hyper_2_2_chunk._ts_meta_sequence_num DESC
                      Sort Method: quicksort 
-                     ->  Seq Scan on compress_hyper_2_4_chunk (actual rows=3 loops=1)
+                     ->  Seq Scan on compress_hyper_2_2_chunk (actual rows=3 loops=1)
          ->  Sort (actual rows=1 loops=1)
                Sort Key: _hyper_1_1_chunk.device, _hyper_1_1_chunk."time" DESC
                Sort Method: top-N heapsort 
                ->  Seq Scan on _hyper_1_1_chunk (actual rows=54 loops=1)
-         ->  Custom Scan (DecompressChunk) on _hyper_1_2_chunk (actual rows=1 loops=1)
-               ->  Sort (actual rows=1 loops=1)
-                     Sort Key: compress_hyper_2_5_chunk.device, compress_hyper_2_5_chunk._ts_meta_sequence_num DESC
-                     Sort Method: quicksort 
-                     ->  Seq Scan on compress_hyper_2_5_chunk (actual rows=3 loops=1)
-         ->  Sort (actual rows=1 loops=1)
-               Sort Key: _hyper_1_2_chunk.device, _hyper_1_2_chunk."time" DESC
-               Sort Method: top-N heapsort 
-               ->  Seq Scan on _hyper_1_2_chunk (actual rows=57 loops=1)
          ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk (actual rows=1 loops=1)
+               ->  Sort (actual rows=1 loops=1)
+                     Sort Key: compress_hyper_2_4_chunk.device, compress_hyper_2_4_chunk._ts_meta_sequence_num DESC
+                     Sort Method: quicksort 
+                     ->  Seq Scan on compress_hyper_2_4_chunk (actual rows=3 loops=1)
+         ->  Sort (actual rows=1 loops=1)
+               Sort Key: _hyper_1_3_chunk.device, _hyper_1_3_chunk."time" DESC
+               Sort Method: top-N heapsort 
+               ->  Seq Scan on _hyper_1_3_chunk (actual rows=57 loops=1)
+         ->  Custom Scan (DecompressChunk) on _hyper_1_5_chunk (actual rows=1 loops=1)
                ->  Sort (actual rows=1 loops=1)
                      Sort Key: compress_hyper_2_6_chunk.device, compress_hyper_2_6_chunk._ts_meta_sequence_num DESC
                      Sort Method: quicksort 
                      ->  Seq Scan on compress_hyper_2_6_chunk (actual rows=3 loops=1)
          ->  Sort (actual rows=1 loops=1)
-               Sort Key: _hyper_1_3_chunk.device, _hyper_1_3_chunk."time" DESC
+               Sort Key: _hyper_1_5_chunk.device, _hyper_1_5_chunk."time" DESC
                Sort Method: top-N heapsort 
-               ->  Seq Scan on _hyper_1_3_chunk (actual rows=18 loops=1)
+               ->  Seq Scan on _hyper_1_5_chunk (actual rows=18 loops=1)
 (30 rows)
 
 :PREFIX SELECT * FROM ht_metrics_compressed WHERE device IN (1,2,3) ORDER BY device, time DESC LIMIT 1; -- with pushdown
@@ -454,28 +454,28 @@ SELECT * FROM ht_metrics_compressed WHERE device = 3 ORDER BY time, device DESC 
          ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk (actual rows=1 loops=1)
                Filter: (device = ANY ('{1,2,3}'::integer[]))
                ->  Sort (actual rows=1 loops=1)
-                     Sort Key: compress_hyper_2_4_chunk.device, compress_hyper_2_4_chunk._ts_meta_sequence_num DESC
+                     Sort Key: compress_hyper_2_2_chunk.device, compress_hyper_2_2_chunk._ts_meta_sequence_num DESC
                      Sort Method: quicksort 
-                     ->  Index Scan using compress_hyper_2_4_chunk__compressed_hypertable_2_device__ts_me on compress_hyper_2_4_chunk (actual rows=3 loops=1)
+                     ->  Index Scan using compress_hyper_2_2_chunk__compressed_hypertable_2_device__ts_me on compress_hyper_2_2_chunk (actual rows=3 loops=1)
                            Index Cond: (device = ANY ('{1,2,3}'::integer[]))
          ->  Sort (actual rows=1 loops=1)
                Sort Key: _hyper_1_1_chunk.device, _hyper_1_1_chunk."time" DESC
                Sort Method: top-N heapsort 
                ->  Seq Scan on _hyper_1_1_chunk (actual rows=54 loops=1)
                      Filter: (device = ANY ('{1,2,3}'::integer[]))
-         ->  Custom Scan (DecompressChunk) on _hyper_1_2_chunk (actual rows=1 loops=1)
+         ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk (actual rows=1 loops=1)
                Filter: (device = ANY ('{1,2,3}'::integer[]))
                ->  Sort (actual rows=1 loops=1)
-                     Sort Key: compress_hyper_2_5_chunk.device, compress_hyper_2_5_chunk._ts_meta_sequence_num DESC
+                     Sort Key: compress_hyper_2_4_chunk.device, compress_hyper_2_4_chunk._ts_meta_sequence_num DESC
                      Sort Method: quicksort 
-                     ->  Index Scan using compress_hyper_2_5_chunk__compressed_hypertable_2_device__ts_me on compress_hyper_2_5_chunk (actual rows=3 loops=1)
+                     ->  Index Scan using compress_hyper_2_4_chunk__compressed_hypertable_2_device__ts_me on compress_hyper_2_4_chunk (actual rows=3 loops=1)
                            Index Cond: (device = ANY ('{1,2,3}'::integer[]))
          ->  Sort (actual rows=1 loops=1)
-               Sort Key: _hyper_1_2_chunk.device, _hyper_1_2_chunk."time" DESC
+               Sort Key: _hyper_1_3_chunk.device, _hyper_1_3_chunk."time" DESC
                Sort Method: top-N heapsort 
-               ->  Seq Scan on _hyper_1_2_chunk (actual rows=57 loops=1)
+               ->  Seq Scan on _hyper_1_3_chunk (actual rows=57 loops=1)
                      Filter: (device = ANY ('{1,2,3}'::integer[]))
-         ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk (actual rows=1 loops=1)
+         ->  Custom Scan (DecompressChunk) on _hyper_1_5_chunk (actual rows=1 loops=1)
                Filter: (device = ANY ('{1,2,3}'::integer[]))
                ->  Sort (actual rows=1 loops=1)
                      Sort Key: compress_hyper_2_6_chunk.device, compress_hyper_2_6_chunk._ts_meta_sequence_num DESC
@@ -483,9 +483,9 @@ SELECT * FROM ht_metrics_compressed WHERE device = 3 ORDER BY time, device DESC 
                      ->  Index Scan using compress_hyper_2_6_chunk__compressed_hypertable_2_device__ts_me on compress_hyper_2_6_chunk (actual rows=3 loops=1)
                            Index Cond: (device = ANY ('{1,2,3}'::integer[]))
          ->  Sort (actual rows=1 loops=1)
-               Sort Key: _hyper_1_3_chunk.device, _hyper_1_3_chunk."time" DESC
+               Sort Key: _hyper_1_5_chunk.device, _hyper_1_5_chunk."time" DESC
                Sort Method: top-N heapsort 
-               ->  Seq Scan on _hyper_1_3_chunk (actual rows=18 loops=1)
+               ->  Seq Scan on _hyper_1_5_chunk (actual rows=18 loops=1)
                      Filter: (device = ANY ('{1,2,3}'::integer[]))
 (39 rows)
 
@@ -903,7 +903,7 @@ SELECT compress_chunk(i) FROM show_chunks('test2') i;
              compress_chunk              
 -----------------------------------------
  _timescaledb_internal._hyper_5_9_chunk
- _timescaledb_internal._hyper_5_10_chunk
+ _timescaledb_internal._hyper_5_11_chunk
 (2 rows)
 
 -- make them partially compressed
@@ -918,22 +918,22 @@ set enable_indexscan = off;
    Sort Key: _hyper_5_9_chunk.x1, _hyper_5_9_chunk.x2, _hyper_5_9_chunk.x5, _hyper_5_9_chunk.x3
    ->  Custom Scan (DecompressChunk) on _hyper_5_9_chunk (actual rows=4 loops=1)
          ->  Sort (actual rows=3 loops=1)
-               Sort Key: compress_hyper_6_11_chunk.x1, compress_hyper_6_11_chunk.x2, compress_hyper_6_11_chunk.x5, compress_hyper_6_11_chunk._ts_meta_sequence_num
+               Sort Key: compress_hyper_6_10_chunk.x1, compress_hyper_6_10_chunk.x2, compress_hyper_6_10_chunk.x5, compress_hyper_6_10_chunk._ts_meta_sequence_num
                Sort Method: quicksort 
-               ->  Seq Scan on compress_hyper_6_11_chunk (actual rows=3 loops=1)
+               ->  Seq Scan on compress_hyper_6_10_chunk (actual rows=3 loops=1)
    ->  Sort (actual rows=1 loops=1)
          Sort Key: _hyper_5_9_chunk.x1, _hyper_5_9_chunk.x2, _hyper_5_9_chunk.x5, _hyper_5_9_chunk.x3
          Sort Method: quicksort 
          ->  Seq Scan on _hyper_5_9_chunk (actual rows=1 loops=1)
-   ->  Custom Scan (DecompressChunk) on _hyper_5_10_chunk (actual rows=4 loops=1)
+   ->  Custom Scan (DecompressChunk) on _hyper_5_11_chunk (actual rows=4 loops=1)
          ->  Sort (actual rows=3 loops=1)
                Sort Key: compress_hyper_6_12_chunk.x1, compress_hyper_6_12_chunk.x2, compress_hyper_6_12_chunk.x5, compress_hyper_6_12_chunk._ts_meta_sequence_num
                Sort Method: quicksort 
                ->  Seq Scan on compress_hyper_6_12_chunk (actual rows=3 loops=1)
    ->  Sort (actual rows=1 loops=1)
-         Sort Key: _hyper_5_10_chunk.x1, _hyper_5_10_chunk.x2, _hyper_5_10_chunk.x5, _hyper_5_10_chunk.x3
+         Sort Key: _hyper_5_11_chunk.x1, _hyper_5_11_chunk.x2, _hyper_5_11_chunk.x5, _hyper_5_11_chunk.x3
          Sort Method: quicksort 
-         ->  Seq Scan on _hyper_5_10_chunk (actual rows=1 loops=1)
+         ->  Seq Scan on _hyper_5_11_chunk (actual rows=1 loops=1)
 (20 rows)
 
 SELECT * FROM test2 ORDER BY x1, x2, x5, x3;
@@ -958,22 +958,22 @@ SELECT * FROM test2 ORDER BY x1, x2, x5, x3;
    Sort Key: _hyper_5_9_chunk.x1, _hyper_5_9_chunk.x2, _hyper_5_9_chunk.x5, _hyper_5_9_chunk.x3, _hyper_5_9_chunk.x4
    ->  Custom Scan (DecompressChunk) on _hyper_5_9_chunk (actual rows=4 loops=1)
          ->  Sort (actual rows=3 loops=1)
-               Sort Key: compress_hyper_6_11_chunk.x1, compress_hyper_6_11_chunk.x2, compress_hyper_6_11_chunk.x5, compress_hyper_6_11_chunk._ts_meta_sequence_num
+               Sort Key: compress_hyper_6_10_chunk.x1, compress_hyper_6_10_chunk.x2, compress_hyper_6_10_chunk.x5, compress_hyper_6_10_chunk._ts_meta_sequence_num
                Sort Method: quicksort 
-               ->  Seq Scan on compress_hyper_6_11_chunk (actual rows=3 loops=1)
+               ->  Seq Scan on compress_hyper_6_10_chunk (actual rows=3 loops=1)
    ->  Sort (actual rows=1 loops=1)
          Sort Key: _hyper_5_9_chunk.x1, _hyper_5_9_chunk.x2, _hyper_5_9_chunk.x5, _hyper_5_9_chunk.x3, _hyper_5_9_chunk.x4
          Sort Method: quicksort 
          ->  Seq Scan on _hyper_5_9_chunk (actual rows=1 loops=1)
-   ->  Custom Scan (DecompressChunk) on _hyper_5_10_chunk (actual rows=4 loops=1)
+   ->  Custom Scan (DecompressChunk) on _hyper_5_11_chunk (actual rows=4 loops=1)
          ->  Sort (actual rows=3 loops=1)
                Sort Key: compress_hyper_6_12_chunk.x1, compress_hyper_6_12_chunk.x2, compress_hyper_6_12_chunk.x5, compress_hyper_6_12_chunk._ts_meta_sequence_num
                Sort Method: quicksort 
                ->  Seq Scan on compress_hyper_6_12_chunk (actual rows=3 loops=1)
    ->  Sort (actual rows=1 loops=1)
-         Sort Key: _hyper_5_10_chunk.x1, _hyper_5_10_chunk.x2, _hyper_5_10_chunk.x5, _hyper_5_10_chunk.x3, _hyper_5_10_chunk.x4
+         Sort Key: _hyper_5_11_chunk.x1, _hyper_5_11_chunk.x2, _hyper_5_11_chunk.x5, _hyper_5_11_chunk.x3, _hyper_5_11_chunk.x4
          Sort Method: quicksort 
-         ->  Seq Scan on _hyper_5_10_chunk (actual rows=1 loops=1)
+         ->  Seq Scan on _hyper_5_11_chunk (actual rows=1 loops=1)
 (20 rows)
 
 SELECT * FROM test2 ORDER BY x1, x2, x5, x3, x4;
@@ -1001,20 +1001,20 @@ SELECT * FROM test2 ORDER BY x1, x2, x5, x3, x4;
          Sort Key: _hyper_5_9_chunk.x1, _hyper_5_9_chunk.x2, _hyper_5_9_chunk.x3
          Sort Method: quicksort 
          ->  Custom Scan (DecompressChunk) on _hyper_5_9_chunk (actual rows=4 loops=1)
-               ->  Seq Scan on compress_hyper_6_11_chunk (actual rows=3 loops=1)
+               ->  Seq Scan on compress_hyper_6_10_chunk (actual rows=3 loops=1)
    ->  Sort (actual rows=1 loops=1)
          Sort Key: _hyper_5_9_chunk.x1, _hyper_5_9_chunk.x2, _hyper_5_9_chunk.x3
          Sort Method: quicksort 
          ->  Seq Scan on _hyper_5_9_chunk (actual rows=1 loops=1)
    ->  Sort (actual rows=4 loops=1)
-         Sort Key: _hyper_5_10_chunk.x1, _hyper_5_10_chunk.x2, _hyper_5_10_chunk.x3
+         Sort Key: _hyper_5_11_chunk.x1, _hyper_5_11_chunk.x2, _hyper_5_11_chunk.x3
          Sort Method: quicksort 
-         ->  Custom Scan (DecompressChunk) on _hyper_5_10_chunk (actual rows=4 loops=1)
+         ->  Custom Scan (DecompressChunk) on _hyper_5_11_chunk (actual rows=4 loops=1)
                ->  Seq Scan on compress_hyper_6_12_chunk (actual rows=3 loops=1)
    ->  Sort (actual rows=1 loops=1)
-         Sort Key: _hyper_5_10_chunk.x1, _hyper_5_10_chunk.x2, _hyper_5_10_chunk.x3
+         Sort Key: _hyper_5_11_chunk.x1, _hyper_5_11_chunk.x2, _hyper_5_11_chunk.x3
          Sort Method: quicksort 
-         ->  Seq Scan on _hyper_5_10_chunk (actual rows=1 loops=1)
+         ->  Seq Scan on _hyper_5_11_chunk (actual rows=1 loops=1)
 (20 rows)
 
 SELECT * FROM test2 ORDER BY x1, x2, x3;
@@ -1041,20 +1041,20 @@ SELECT * FROM test2 ORDER BY x1, x2, x3;
          Sort Key: _hyper_5_9_chunk.x1, _hyper_5_9_chunk.x2, _hyper_5_9_chunk.x5, _hyper_5_9_chunk.x4
          Sort Method: quicksort 
          ->  Custom Scan (DecompressChunk) on _hyper_5_9_chunk (actual rows=4 loops=1)
-               ->  Seq Scan on compress_hyper_6_11_chunk (actual rows=3 loops=1)
+               ->  Seq Scan on compress_hyper_6_10_chunk (actual rows=3 loops=1)
    ->  Sort (actual rows=1 loops=1)
          Sort Key: _hyper_5_9_chunk.x1, _hyper_5_9_chunk.x2, _hyper_5_9_chunk.x5, _hyper_5_9_chunk.x4
          Sort Method: quicksort 
          ->  Seq Scan on _hyper_5_9_chunk (actual rows=1 loops=1)
    ->  Sort (actual rows=4 loops=1)
-         Sort Key: _hyper_5_10_chunk.x1, _hyper_5_10_chunk.x2, _hyper_5_10_chunk.x5, _hyper_5_10_chunk.x4
+         Sort Key: _hyper_5_11_chunk.x1, _hyper_5_11_chunk.x2, _hyper_5_11_chunk.x5, _hyper_5_11_chunk.x4
          Sort Method: quicksort 
-         ->  Custom Scan (DecompressChunk) on _hyper_5_10_chunk (actual rows=4 loops=1)
+         ->  Custom Scan (DecompressChunk) on _hyper_5_11_chunk (actual rows=4 loops=1)
                ->  Seq Scan on compress_hyper_6_12_chunk (actual rows=3 loops=1)
    ->  Sort (actual rows=1 loops=1)
-         Sort Key: _hyper_5_10_chunk.x1, _hyper_5_10_chunk.x2, _hyper_5_10_chunk.x5, _hyper_5_10_chunk.x4
+         Sort Key: _hyper_5_11_chunk.x1, _hyper_5_11_chunk.x2, _hyper_5_11_chunk.x5, _hyper_5_11_chunk.x4
          Sort Method: quicksort 
-         ->  Seq Scan on _hyper_5_10_chunk (actual rows=1 loops=1)
+         ->  Seq Scan on _hyper_5_11_chunk (actual rows=1 loops=1)
 (20 rows)
 
 SELECT * FROM test2 ORDER BY x1, x2, x5, x4;
@@ -1081,20 +1081,20 @@ SELECT * FROM test2 ORDER BY x1, x2, x5, x4;
          Sort Key: _hyper_5_9_chunk.x1, _hyper_5_9_chunk.x2, _hyper_5_9_chunk.x5, _hyper_5_9_chunk."time"
          Sort Method: quicksort 
          ->  Custom Scan (DecompressChunk) on _hyper_5_9_chunk (actual rows=4 loops=1)
-               ->  Seq Scan on compress_hyper_6_11_chunk (actual rows=3 loops=1)
+               ->  Seq Scan on compress_hyper_6_10_chunk (actual rows=3 loops=1)
    ->  Sort (actual rows=1 loops=1)
          Sort Key: _hyper_5_9_chunk.x1, _hyper_5_9_chunk.x2, _hyper_5_9_chunk.x5, _hyper_5_9_chunk."time"
          Sort Method: quicksort 
          ->  Seq Scan on _hyper_5_9_chunk (actual rows=1 loops=1)
    ->  Sort (actual rows=4 loops=1)
-         Sort Key: _hyper_5_10_chunk.x1, _hyper_5_10_chunk.x2, _hyper_5_10_chunk.x5, _hyper_5_10_chunk."time"
+         Sort Key: _hyper_5_11_chunk.x1, _hyper_5_11_chunk.x2, _hyper_5_11_chunk.x5, _hyper_5_11_chunk."time"
          Sort Method: quicksort 
-         ->  Custom Scan (DecompressChunk) on _hyper_5_10_chunk (actual rows=4 loops=1)
+         ->  Custom Scan (DecompressChunk) on _hyper_5_11_chunk (actual rows=4 loops=1)
                ->  Seq Scan on compress_hyper_6_12_chunk (actual rows=3 loops=1)
    ->  Sort (actual rows=1 loops=1)
-         Sort Key: _hyper_5_10_chunk.x1, _hyper_5_10_chunk.x2, _hyper_5_10_chunk.x5, _hyper_5_10_chunk."time"
+         Sort Key: _hyper_5_11_chunk.x1, _hyper_5_11_chunk.x2, _hyper_5_11_chunk.x5, _hyper_5_11_chunk."time"
          Sort Method: quicksort 
-         ->  Seq Scan on _hyper_5_10_chunk (actual rows=1 loops=1)
+         ->  Seq Scan on _hyper_5_11_chunk (actual rows=1 loops=1)
 (20 rows)
 
 SELECT * FROM test2 ORDER BY x1, x2, x5, time;
@@ -1146,9 +1146,9 @@ SELECT compress_chunk(i) FROM show_chunks('test3') i;
              compress_chunk              
 -----------------------------------------
  _timescaledb_internal._hyper_7_13_chunk
- _timescaledb_internal._hyper_7_14_chunk
  _timescaledb_internal._hyper_7_15_chunk
- _timescaledb_internal._hyper_7_16_chunk
+ _timescaledb_internal._hyper_7_17_chunk
+ _timescaledb_internal._hyper_7_19_chunk
 (4 rows)
 
 -- make them partially compressed
@@ -1163,28 +1163,28 @@ set enable_indexscan = off;
    Sort Key: _hyper_7_13_chunk.x1, _hyper_7_13_chunk.x2, _hyper_7_13_chunk.x5, _hyper_7_13_chunk.x3
    ->  Custom Scan (DecompressChunk) on _hyper_7_13_chunk (actual rows=3 loops=1)
          ->  Sort (actual rows=2 loops=1)
-               Sort Key: compress_hyper_8_17_chunk.x1, compress_hyper_8_17_chunk.x2, compress_hyper_8_17_chunk.x5, compress_hyper_8_17_chunk._ts_meta_sequence_num
+               Sort Key: compress_hyper_8_14_chunk.x1, compress_hyper_8_14_chunk.x2, compress_hyper_8_14_chunk.x5, compress_hyper_8_14_chunk._ts_meta_sequence_num
                Sort Method: quicksort 
-               ->  Seq Scan on compress_hyper_8_17_chunk (actual rows=2 loops=1)
+               ->  Seq Scan on compress_hyper_8_14_chunk (actual rows=2 loops=1)
    ->  Sort (actual rows=1 loops=1)
          Sort Key: _hyper_7_13_chunk.x1, _hyper_7_13_chunk.x2, _hyper_7_13_chunk.x5, _hyper_7_13_chunk.x3
          Sort Method: quicksort 
          ->  Seq Scan on _hyper_7_13_chunk (actual rows=1 loops=1)
-   ->  Custom Scan (DecompressChunk) on _hyper_7_14_chunk (actual rows=1 loops=1)
+   ->  Custom Scan (DecompressChunk) on _hyper_7_15_chunk (actual rows=1 loops=1)
          ->  Sort (actual rows=1 loops=1)
+               Sort Key: compress_hyper_8_16_chunk.x1, compress_hyper_8_16_chunk.x2, compress_hyper_8_16_chunk.x5, compress_hyper_8_16_chunk._ts_meta_sequence_num
+               Sort Method: quicksort 
+               ->  Seq Scan on compress_hyper_8_16_chunk (actual rows=1 loops=1)
+   ->  Custom Scan (DecompressChunk) on _hyper_7_17_chunk (actual rows=3 loops=1)
+         ->  Sort (actual rows=2 loops=1)
                Sort Key: compress_hyper_8_18_chunk.x1, compress_hyper_8_18_chunk.x2, compress_hyper_8_18_chunk.x5, compress_hyper_8_18_chunk._ts_meta_sequence_num
                Sort Method: quicksort 
-               ->  Seq Scan on compress_hyper_8_18_chunk (actual rows=1 loops=1)
-   ->  Custom Scan (DecompressChunk) on _hyper_7_15_chunk (actual rows=3 loops=1)
-         ->  Sort (actual rows=2 loops=1)
-               Sort Key: compress_hyper_8_19_chunk.x1, compress_hyper_8_19_chunk.x2, compress_hyper_8_19_chunk.x5, compress_hyper_8_19_chunk._ts_meta_sequence_num
-               Sort Method: quicksort 
-               ->  Seq Scan on compress_hyper_8_19_chunk (actual rows=2 loops=1)
+               ->  Seq Scan on compress_hyper_8_18_chunk (actual rows=2 loops=1)
    ->  Sort (actual rows=1 loops=1)
-         Sort Key: _hyper_7_15_chunk.x1, _hyper_7_15_chunk.x2, _hyper_7_15_chunk.x5, _hyper_7_15_chunk.x3
+         Sort Key: _hyper_7_17_chunk.x1, _hyper_7_17_chunk.x2, _hyper_7_17_chunk.x5, _hyper_7_17_chunk.x3
          Sort Method: quicksort 
-         ->  Seq Scan on _hyper_7_15_chunk (actual rows=1 loops=1)
-   ->  Custom Scan (DecompressChunk) on _hyper_7_16_chunk (actual rows=1 loops=1)
+         ->  Seq Scan on _hyper_7_17_chunk (actual rows=1 loops=1)
+   ->  Custom Scan (DecompressChunk) on _hyper_7_19_chunk (actual rows=1 loops=1)
          ->  Sort (actual rows=1 loops=1)
                Sort Key: compress_hyper_8_20_chunk.x1, compress_hyper_8_20_chunk.x2, compress_hyper_8_20_chunk.x5, compress_hyper_8_20_chunk._ts_meta_sequence_num
                Sort Method: quicksort 
@@ -1213,28 +1213,28 @@ SELECT * FROM test3 ORDER BY x1, x2, x5, x3;
    Sort Key: _hyper_7_13_chunk.x1, _hyper_7_13_chunk.x2, _hyper_7_13_chunk.x5, _hyper_7_13_chunk.x3, _hyper_7_13_chunk.x4
    ->  Custom Scan (DecompressChunk) on _hyper_7_13_chunk (actual rows=3 loops=1)
          ->  Sort (actual rows=2 loops=1)
-               Sort Key: compress_hyper_8_17_chunk.x1, compress_hyper_8_17_chunk.x2, compress_hyper_8_17_chunk.x5, compress_hyper_8_17_chunk._ts_meta_sequence_num
+               Sort Key: compress_hyper_8_14_chunk.x1, compress_hyper_8_14_chunk.x2, compress_hyper_8_14_chunk.x5, compress_hyper_8_14_chunk._ts_meta_sequence_num
                Sort Method: quicksort 
-               ->  Seq Scan on compress_hyper_8_17_chunk (actual rows=2 loops=1)
+               ->  Seq Scan on compress_hyper_8_14_chunk (actual rows=2 loops=1)
    ->  Sort (actual rows=1 loops=1)
          Sort Key: _hyper_7_13_chunk.x1, _hyper_7_13_chunk.x2, _hyper_7_13_chunk.x5, _hyper_7_13_chunk.x3, _hyper_7_13_chunk.x4
          Sort Method: quicksort 
          ->  Seq Scan on _hyper_7_13_chunk (actual rows=1 loops=1)
-   ->  Custom Scan (DecompressChunk) on _hyper_7_14_chunk (actual rows=1 loops=1)
+   ->  Custom Scan (DecompressChunk) on _hyper_7_15_chunk (actual rows=1 loops=1)
          ->  Sort (actual rows=1 loops=1)
+               Sort Key: compress_hyper_8_16_chunk.x1, compress_hyper_8_16_chunk.x2, compress_hyper_8_16_chunk.x5, compress_hyper_8_16_chunk._ts_meta_sequence_num
+               Sort Method: quicksort 
+               ->  Seq Scan on compress_hyper_8_16_chunk (actual rows=1 loops=1)
+   ->  Custom Scan (DecompressChunk) on _hyper_7_17_chunk (actual rows=3 loops=1)
+         ->  Sort (actual rows=2 loops=1)
                Sort Key: compress_hyper_8_18_chunk.x1, compress_hyper_8_18_chunk.x2, compress_hyper_8_18_chunk.x5, compress_hyper_8_18_chunk._ts_meta_sequence_num
                Sort Method: quicksort 
-               ->  Seq Scan on compress_hyper_8_18_chunk (actual rows=1 loops=1)
-   ->  Custom Scan (DecompressChunk) on _hyper_7_15_chunk (actual rows=3 loops=1)
-         ->  Sort (actual rows=2 loops=1)
-               Sort Key: compress_hyper_8_19_chunk.x1, compress_hyper_8_19_chunk.x2, compress_hyper_8_19_chunk.x5, compress_hyper_8_19_chunk._ts_meta_sequence_num
-               Sort Method: quicksort 
-               ->  Seq Scan on compress_hyper_8_19_chunk (actual rows=2 loops=1)
+               ->  Seq Scan on compress_hyper_8_18_chunk (actual rows=2 loops=1)
    ->  Sort (actual rows=1 loops=1)
-         Sort Key: _hyper_7_15_chunk.x1, _hyper_7_15_chunk.x2, _hyper_7_15_chunk.x5, _hyper_7_15_chunk.x3, _hyper_7_15_chunk.x4
+         Sort Key: _hyper_7_17_chunk.x1, _hyper_7_17_chunk.x2, _hyper_7_17_chunk.x5, _hyper_7_17_chunk.x3, _hyper_7_17_chunk.x4
          Sort Method: quicksort 
-         ->  Seq Scan on _hyper_7_15_chunk (actual rows=1 loops=1)
-   ->  Custom Scan (DecompressChunk) on _hyper_7_16_chunk (actual rows=1 loops=1)
+         ->  Seq Scan on _hyper_7_17_chunk (actual rows=1 loops=1)
+   ->  Custom Scan (DecompressChunk) on _hyper_7_19_chunk (actual rows=1 loops=1)
          ->  Sort (actual rows=1 loops=1)
                Sort Key: compress_hyper_8_20_chunk.x1, compress_hyper_8_20_chunk.x2, compress_hyper_8_20_chunk.x5, compress_hyper_8_20_chunk._ts_meta_sequence_num
                Sort Method: quicksort 
@@ -1266,29 +1266,29 @@ SELECT * FROM test3 ORDER BY x1, x2, x5, x3, x4;
          Sort Key: _hyper_7_13_chunk.x1, _hyper_7_13_chunk.x2, _hyper_7_13_chunk.x3
          Sort Method: quicksort 
          ->  Custom Scan (DecompressChunk) on _hyper_7_13_chunk (actual rows=3 loops=1)
-               ->  Seq Scan on compress_hyper_8_17_chunk (actual rows=2 loops=1)
+               ->  Seq Scan on compress_hyper_8_14_chunk (actual rows=2 loops=1)
    ->  Sort (actual rows=1 loops=1)
          Sort Key: _hyper_7_13_chunk.x1, _hyper_7_13_chunk.x2, _hyper_7_13_chunk.x3
          Sort Method: quicksort 
          ->  Seq Scan on _hyper_7_13_chunk (actual rows=1 loops=1)
    ->  Sort (actual rows=1 loops=1)
-         Sort Key: _hyper_7_14_chunk.x1, _hyper_7_14_chunk.x2, _hyper_7_14_chunk.x3
+         Sort Key: _hyper_7_15_chunk.x1, _hyper_7_15_chunk.x2, _hyper_7_15_chunk.x3
          Sort Method: quicksort 
-         ->  Custom Scan (DecompressChunk) on _hyper_7_14_chunk (actual rows=1 loops=1)
-               ->  Seq Scan on compress_hyper_8_18_chunk (actual rows=1 loops=1)
+         ->  Custom Scan (DecompressChunk) on _hyper_7_15_chunk (actual rows=1 loops=1)
+               ->  Seq Scan on compress_hyper_8_16_chunk (actual rows=1 loops=1)
    ->  Sort (actual rows=3 loops=1)
-         Sort Key: _hyper_7_15_chunk.x1, _hyper_7_15_chunk.x2, _hyper_7_15_chunk.x3
+         Sort Key: _hyper_7_17_chunk.x1, _hyper_7_17_chunk.x2, _hyper_7_17_chunk.x3
          Sort Method: quicksort 
-         ->  Custom Scan (DecompressChunk) on _hyper_7_15_chunk (actual rows=3 loops=1)
-               ->  Seq Scan on compress_hyper_8_19_chunk (actual rows=2 loops=1)
+         ->  Custom Scan (DecompressChunk) on _hyper_7_17_chunk (actual rows=3 loops=1)
+               ->  Seq Scan on compress_hyper_8_18_chunk (actual rows=2 loops=1)
    ->  Sort (actual rows=1 loops=1)
-         Sort Key: _hyper_7_15_chunk.x1, _hyper_7_15_chunk.x2, _hyper_7_15_chunk.x3
+         Sort Key: _hyper_7_17_chunk.x1, _hyper_7_17_chunk.x2, _hyper_7_17_chunk.x3
          Sort Method: quicksort 
-         ->  Seq Scan on _hyper_7_15_chunk (actual rows=1 loops=1)
+         ->  Seq Scan on _hyper_7_17_chunk (actual rows=1 loops=1)
    ->  Sort (actual rows=1 loops=1)
-         Sort Key: _hyper_7_16_chunk.x1, _hyper_7_16_chunk.x2, _hyper_7_16_chunk.x3
+         Sort Key: _hyper_7_19_chunk.x1, _hyper_7_19_chunk.x2, _hyper_7_19_chunk.x3
          Sort Method: quicksort 
-         ->  Custom Scan (DecompressChunk) on _hyper_7_16_chunk (actual rows=1 loops=1)
+         ->  Custom Scan (DecompressChunk) on _hyper_7_19_chunk (actual rows=1 loops=1)
                ->  Seq Scan on compress_hyper_8_20_chunk (actual rows=1 loops=1)
 (30 rows)
 
@@ -1316,29 +1316,29 @@ SELECT * FROM test3 ORDER BY x1, x2, x3;
          Sort Key: _hyper_7_13_chunk.x1, _hyper_7_13_chunk.x2, _hyper_7_13_chunk.x5, _hyper_7_13_chunk.x4
          Sort Method: quicksort 
          ->  Custom Scan (DecompressChunk) on _hyper_7_13_chunk (actual rows=3 loops=1)
-               ->  Seq Scan on compress_hyper_8_17_chunk (actual rows=2 loops=1)
+               ->  Seq Scan on compress_hyper_8_14_chunk (actual rows=2 loops=1)
    ->  Sort (actual rows=1 loops=1)
          Sort Key: _hyper_7_13_chunk.x1, _hyper_7_13_chunk.x2, _hyper_7_13_chunk.x5, _hyper_7_13_chunk.x4
          Sort Method: quicksort 
          ->  Seq Scan on _hyper_7_13_chunk (actual rows=1 loops=1)
    ->  Sort (actual rows=1 loops=1)
-         Sort Key: _hyper_7_14_chunk.x1, _hyper_7_14_chunk.x2, _hyper_7_14_chunk.x5, _hyper_7_14_chunk.x4
+         Sort Key: _hyper_7_15_chunk.x1, _hyper_7_15_chunk.x2, _hyper_7_15_chunk.x5, _hyper_7_15_chunk.x4
          Sort Method: quicksort 
-         ->  Custom Scan (DecompressChunk) on _hyper_7_14_chunk (actual rows=1 loops=1)
-               ->  Seq Scan on compress_hyper_8_18_chunk (actual rows=1 loops=1)
+         ->  Custom Scan (DecompressChunk) on _hyper_7_15_chunk (actual rows=1 loops=1)
+               ->  Seq Scan on compress_hyper_8_16_chunk (actual rows=1 loops=1)
    ->  Sort (actual rows=3 loops=1)
-         Sort Key: _hyper_7_15_chunk.x1, _hyper_7_15_chunk.x2, _hyper_7_15_chunk.x5, _hyper_7_15_chunk.x4
+         Sort Key: _hyper_7_17_chunk.x1, _hyper_7_17_chunk.x2, _hyper_7_17_chunk.x5, _hyper_7_17_chunk.x4
          Sort Method: quicksort 
-         ->  Custom Scan (DecompressChunk) on _hyper_7_15_chunk (actual rows=3 loops=1)
-               ->  Seq Scan on compress_hyper_8_19_chunk (actual rows=2 loops=1)
+         ->  Custom Scan (DecompressChunk) on _hyper_7_17_chunk (actual rows=3 loops=1)
+               ->  Seq Scan on compress_hyper_8_18_chunk (actual rows=2 loops=1)
    ->  Sort (actual rows=1 loops=1)
-         Sort Key: _hyper_7_15_chunk.x1, _hyper_7_15_chunk.x2, _hyper_7_15_chunk.x5, _hyper_7_15_chunk.x4
+         Sort Key: _hyper_7_17_chunk.x1, _hyper_7_17_chunk.x2, _hyper_7_17_chunk.x5, _hyper_7_17_chunk.x4
          Sort Method: quicksort 
-         ->  Seq Scan on _hyper_7_15_chunk (actual rows=1 loops=1)
+         ->  Seq Scan on _hyper_7_17_chunk (actual rows=1 loops=1)
    ->  Sort (actual rows=1 loops=1)
-         Sort Key: _hyper_7_16_chunk.x1, _hyper_7_16_chunk.x2, _hyper_7_16_chunk.x5, _hyper_7_16_chunk.x4
+         Sort Key: _hyper_7_19_chunk.x1, _hyper_7_19_chunk.x2, _hyper_7_19_chunk.x5, _hyper_7_19_chunk.x4
          Sort Method: quicksort 
-         ->  Custom Scan (DecompressChunk) on _hyper_7_16_chunk (actual rows=1 loops=1)
+         ->  Custom Scan (DecompressChunk) on _hyper_7_19_chunk (actual rows=1 loops=1)
                ->  Seq Scan on compress_hyper_8_20_chunk (actual rows=1 loops=1)
 (30 rows)
 
@@ -1366,29 +1366,29 @@ SELECT * FROM test3 ORDER BY x1, x2, x5, x4;
          Sort Key: _hyper_7_13_chunk.x1, _hyper_7_13_chunk.x2, _hyper_7_13_chunk.x5, _hyper_7_13_chunk."time"
          Sort Method: quicksort 
          ->  Custom Scan (DecompressChunk) on _hyper_7_13_chunk (actual rows=3 loops=1)
-               ->  Seq Scan on compress_hyper_8_17_chunk (actual rows=2 loops=1)
+               ->  Seq Scan on compress_hyper_8_14_chunk (actual rows=2 loops=1)
    ->  Sort (actual rows=1 loops=1)
          Sort Key: _hyper_7_13_chunk.x1, _hyper_7_13_chunk.x2, _hyper_7_13_chunk.x5, _hyper_7_13_chunk."time"
          Sort Method: quicksort 
          ->  Seq Scan on _hyper_7_13_chunk (actual rows=1 loops=1)
    ->  Sort (actual rows=1 loops=1)
-         Sort Key: _hyper_7_14_chunk.x1, _hyper_7_14_chunk.x2, _hyper_7_14_chunk.x5, _hyper_7_14_chunk."time"
+         Sort Key: _hyper_7_15_chunk.x1, _hyper_7_15_chunk.x2, _hyper_7_15_chunk.x5, _hyper_7_15_chunk."time"
          Sort Method: quicksort 
-         ->  Custom Scan (DecompressChunk) on _hyper_7_14_chunk (actual rows=1 loops=1)
-               ->  Seq Scan on compress_hyper_8_18_chunk (actual rows=1 loops=1)
+         ->  Custom Scan (DecompressChunk) on _hyper_7_15_chunk (actual rows=1 loops=1)
+               ->  Seq Scan on compress_hyper_8_16_chunk (actual rows=1 loops=1)
    ->  Sort (actual rows=3 loops=1)
-         Sort Key: _hyper_7_15_chunk.x1, _hyper_7_15_chunk.x2, _hyper_7_15_chunk.x5, _hyper_7_15_chunk."time"
+         Sort Key: _hyper_7_17_chunk.x1, _hyper_7_17_chunk.x2, _hyper_7_17_chunk.x5, _hyper_7_17_chunk."time"
          Sort Method: quicksort 
-         ->  Custom Scan (DecompressChunk) on _hyper_7_15_chunk (actual rows=3 loops=1)
-               ->  Seq Scan on compress_hyper_8_19_chunk (actual rows=2 loops=1)
+         ->  Custom Scan (DecompressChunk) on _hyper_7_17_chunk (actual rows=3 loops=1)
+               ->  Seq Scan on compress_hyper_8_18_chunk (actual rows=2 loops=1)
    ->  Sort (actual rows=1 loops=1)
-         Sort Key: _hyper_7_15_chunk.x1, _hyper_7_15_chunk.x2, _hyper_7_15_chunk.x5, _hyper_7_15_chunk."time"
+         Sort Key: _hyper_7_17_chunk.x1, _hyper_7_17_chunk.x2, _hyper_7_17_chunk.x5, _hyper_7_17_chunk."time"
          Sort Method: quicksort 
-         ->  Seq Scan on _hyper_7_15_chunk (actual rows=1 loops=1)
+         ->  Seq Scan on _hyper_7_17_chunk (actual rows=1 loops=1)
    ->  Sort (actual rows=1 loops=1)
-         Sort Key: _hyper_7_16_chunk.x1, _hyper_7_16_chunk.x2, _hyper_7_16_chunk.x5, _hyper_7_16_chunk."time"
+         Sort Key: _hyper_7_19_chunk.x1, _hyper_7_19_chunk.x2, _hyper_7_19_chunk.x5, _hyper_7_19_chunk."time"
          Sort Method: quicksort 
-         ->  Custom Scan (DecompressChunk) on _hyper_7_16_chunk (actual rows=1 loops=1)
+         ->  Custom Scan (DecompressChunk) on _hyper_7_19_chunk (actual rows=1 loops=1)
                ->  Seq Scan on compress_hyper_8_20_chunk (actual rows=1 loops=1)
 (30 rows)
 

--- a/tsl/test/expected/merge_append_partially_compressed-15.out
+++ b/tsl/test/expected/merge_append_partially_compressed-15.out
@@ -23,8 +23,8 @@ SELECT compress_chunk(c) FROM show_chunks('ht_metrics_compressed') c;
              compress_chunk             
 ----------------------------------------
  _timescaledb_internal._hyper_1_1_chunk
- _timescaledb_internal._hyper_1_2_chunk
  _timescaledb_internal._hyper_1_3_chunk
+ _timescaledb_internal._hyper_1_5_chunk
 (3 rows)
 
 -- make them partially compressed
@@ -41,31 +41,31 @@ generate_series(1,3) device;
    ->  Custom Scan (ChunkAppend) on ht_metrics_compressed (actual rows=1 loops=1)
          Order: ht_metrics_compressed."time" DESC, ht_metrics_compressed.device
          ->  Merge Append (actual rows=1 loops=1)
-               Sort Key: _hyper_1_3_chunk."time" DESC, _hyper_1_3_chunk.device
+               Sort Key: _hyper_1_5_chunk."time" DESC, _hyper_1_5_chunk.device
                ->  Sort (actual rows=1 loops=1)
-                     Sort Key: _hyper_1_3_chunk."time" DESC, _hyper_1_3_chunk.device
+                     Sort Key: _hyper_1_5_chunk."time" DESC, _hyper_1_5_chunk.device
                      Sort Method: top-N heapsort 
-                     ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk (actual rows=30 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_1_5_chunk (actual rows=30 loops=1)
                            ->  Seq Scan on compress_hyper_2_6_chunk (actual rows=3 loops=1)
                ->  Sort (actual rows=1 loops=1)
-                     Sort Key: _hyper_1_3_chunk."time" DESC, _hyper_1_3_chunk.device
+                     Sort Key: _hyper_1_5_chunk."time" DESC, _hyper_1_5_chunk.device
                      Sort Method: top-N heapsort 
-                     ->  Seq Scan on _hyper_1_3_chunk (actual rows=18 loops=1)
+                     ->  Seq Scan on _hyper_1_5_chunk (actual rows=18 loops=1)
          ->  Merge Append (never executed)
-               Sort Key: _hyper_1_2_chunk."time" DESC, _hyper_1_2_chunk.device
+               Sort Key: _hyper_1_3_chunk."time" DESC, _hyper_1_3_chunk.device
                ->  Sort (never executed)
-                     Sort Key: _hyper_1_2_chunk."time" DESC, _hyper_1_2_chunk.device
-                     ->  Custom Scan (DecompressChunk) on _hyper_1_2_chunk (never executed)
-                           ->  Seq Scan on compress_hyper_2_5_chunk (never executed)
+                     Sort Key: _hyper_1_3_chunk."time" DESC, _hyper_1_3_chunk.device
+                     ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk (never executed)
+                           ->  Seq Scan on compress_hyper_2_4_chunk (never executed)
                ->  Sort (never executed)
-                     Sort Key: _hyper_1_2_chunk."time" DESC, _hyper_1_2_chunk.device
-                     ->  Seq Scan on _hyper_1_2_chunk (never executed)
+                     Sort Key: _hyper_1_3_chunk."time" DESC, _hyper_1_3_chunk.device
+                     ->  Seq Scan on _hyper_1_3_chunk (never executed)
          ->  Merge Append (never executed)
                Sort Key: _hyper_1_1_chunk."time" DESC, _hyper_1_1_chunk.device
                ->  Sort (never executed)
                      Sort Key: _hyper_1_1_chunk."time" DESC, _hyper_1_1_chunk.device
                      ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk (never executed)
-                           ->  Seq Scan on compress_hyper_2_4_chunk (never executed)
+                           ->  Seq Scan on compress_hyper_2_2_chunk (never executed)
                ->  Sort (never executed)
                      Sort Key: _hyper_1_1_chunk."time" DESC, _hyper_1_1_chunk.device
                      ->  Seq Scan on _hyper_1_1_chunk (never executed)
@@ -82,31 +82,31 @@ generate_series(1,3) device;
                Sort Method: top-N heapsort 
                ->  Result (actual rows=81 loops=1)
                      ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk (actual rows=81 loops=1)
-                           ->  Seq Scan on compress_hyper_2_4_chunk (actual rows=3 loops=1)
+                           ->  Seq Scan on compress_hyper_2_2_chunk (actual rows=3 loops=1)
          ->  Sort (actual rows=1 loops=1)
                Sort Key: (time_bucket('@ 1 day'::interval, _hyper_1_1_chunk."time")) DESC, _hyper_1_1_chunk.device
                Sort Method: top-N heapsort 
                ->  Seq Scan on _hyper_1_1_chunk (actual rows=54 loops=1)
          ->  Sort (actual rows=1 loops=1)
-               Sort Key: (time_bucket('@ 1 day'::interval, _hyper_1_2_chunk."time")) DESC, _hyper_1_2_chunk.device
+               Sort Key: (time_bucket('@ 1 day'::interval, _hyper_1_3_chunk."time")) DESC, _hyper_1_3_chunk.device
                Sort Method: top-N heapsort 
                ->  Result (actual rows=84 loops=1)
-                     ->  Custom Scan (DecompressChunk) on _hyper_1_2_chunk (actual rows=84 loops=1)
-                           ->  Seq Scan on compress_hyper_2_5_chunk (actual rows=3 loops=1)
-         ->  Sort (actual rows=1 loops=1)
-               Sort Key: (time_bucket('@ 1 day'::interval, _hyper_1_2_chunk."time")) DESC, _hyper_1_2_chunk.device
-               Sort Method: top-N heapsort 
-               ->  Seq Scan on _hyper_1_2_chunk (actual rows=57 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk (actual rows=84 loops=1)
+                           ->  Seq Scan on compress_hyper_2_4_chunk (actual rows=3 loops=1)
          ->  Sort (actual rows=1 loops=1)
                Sort Key: (time_bucket('@ 1 day'::interval, _hyper_1_3_chunk."time")) DESC, _hyper_1_3_chunk.device
+               Sort Method: top-N heapsort 
+               ->  Seq Scan on _hyper_1_3_chunk (actual rows=57 loops=1)
+         ->  Sort (actual rows=1 loops=1)
+               Sort Key: (time_bucket('@ 1 day'::interval, _hyper_1_5_chunk."time")) DESC, _hyper_1_5_chunk.device
                Sort Method: top-N heapsort 
                ->  Result (actual rows=30 loops=1)
-                     ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk (actual rows=30 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_1_5_chunk (actual rows=30 loops=1)
                            ->  Seq Scan on compress_hyper_2_6_chunk (actual rows=3 loops=1)
          ->  Sort (actual rows=1 loops=1)
-               Sort Key: (time_bucket('@ 1 day'::interval, _hyper_1_3_chunk."time")) DESC, _hyper_1_3_chunk.device
+               Sort Key: (time_bucket('@ 1 day'::interval, _hyper_1_5_chunk."time")) DESC, _hyper_1_5_chunk.device
                Sort Method: top-N heapsort 
-               ->  Seq Scan on _hyper_1_3_chunk (actual rows=18 loops=1)
+               ->  Seq Scan on _hyper_1_5_chunk (actual rows=18 loops=1)
 (33 rows)
 
 :PREFIX SELECT * FROM ht_metrics_compressed ORDER BY time desc limit 10;
@@ -116,31 +116,31 @@ generate_series(1,3) device;
    ->  Custom Scan (ChunkAppend) on ht_metrics_compressed (actual rows=10 loops=1)
          Order: ht_metrics_compressed."time" DESC
          ->  Merge Append (actual rows=10 loops=1)
-               Sort Key: _hyper_1_3_chunk."time" DESC
+               Sort Key: _hyper_1_5_chunk."time" DESC
                ->  Sort (actual rows=7 loops=1)
-                     Sort Key: _hyper_1_3_chunk."time" DESC
+                     Sort Key: _hyper_1_5_chunk."time" DESC
                      Sort Method: top-N heapsort 
-                     ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk (actual rows=30 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_1_5_chunk (actual rows=30 loops=1)
                            ->  Seq Scan on compress_hyper_2_6_chunk (actual rows=3 loops=1)
                ->  Sort (actual rows=4 loops=1)
-                     Sort Key: _hyper_1_3_chunk."time" DESC
+                     Sort Key: _hyper_1_5_chunk."time" DESC
                      Sort Method: quicksort 
-                     ->  Seq Scan on _hyper_1_3_chunk (actual rows=18 loops=1)
+                     ->  Seq Scan on _hyper_1_5_chunk (actual rows=18 loops=1)
          ->  Merge Append (never executed)
-               Sort Key: _hyper_1_2_chunk."time" DESC
+               Sort Key: _hyper_1_3_chunk."time" DESC
                ->  Sort (never executed)
-                     Sort Key: _hyper_1_2_chunk."time" DESC
-                     ->  Custom Scan (DecompressChunk) on _hyper_1_2_chunk (never executed)
-                           ->  Seq Scan on compress_hyper_2_5_chunk (never executed)
+                     Sort Key: _hyper_1_3_chunk."time" DESC
+                     ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk (never executed)
+                           ->  Seq Scan on compress_hyper_2_4_chunk (never executed)
                ->  Sort (never executed)
-                     Sort Key: _hyper_1_2_chunk."time" DESC
-                     ->  Seq Scan on _hyper_1_2_chunk (never executed)
+                     Sort Key: _hyper_1_3_chunk."time" DESC
+                     ->  Seq Scan on _hyper_1_3_chunk (never executed)
          ->  Merge Append (never executed)
                Sort Key: _hyper_1_1_chunk."time" DESC
                ->  Sort (never executed)
                      Sort Key: _hyper_1_1_chunk."time" DESC
                      ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk (never executed)
-                           ->  Seq Scan on compress_hyper_2_4_chunk (never executed)
+                           ->  Seq Scan on compress_hyper_2_2_chunk (never executed)
                ->  Sort (never executed)
                      Sort Key: _hyper_1_1_chunk."time" DESC
                      ->  Seq Scan on _hyper_1_1_chunk (never executed)
@@ -153,34 +153,34 @@ generate_series(1,3) device;
    ->  Custom Scan (ChunkAppend) on ht_metrics_compressed (actual rows=1 loops=1)
          Order: time_bucket('@ 2 days'::interval, ht_metrics_compressed."time") DESC
          ->  Merge Append (actual rows=1 loops=1)
-               Sort Key: (time_bucket('@ 2 days'::interval, _hyper_1_3_chunk."time")) DESC
+               Sort Key: (time_bucket('@ 2 days'::interval, _hyper_1_5_chunk."time")) DESC
                ->  Sort (actual rows=1 loops=1)
-                     Sort Key: (time_bucket('@ 2 days'::interval, _hyper_1_3_chunk."time")) DESC
+                     Sort Key: (time_bucket('@ 2 days'::interval, _hyper_1_5_chunk."time")) DESC
                      Sort Method: top-N heapsort 
                      ->  Result (actual rows=30 loops=1)
-                           ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk (actual rows=30 loops=1)
+                           ->  Custom Scan (DecompressChunk) on _hyper_1_5_chunk (actual rows=30 loops=1)
                                  ->  Seq Scan on compress_hyper_2_6_chunk (actual rows=3 loops=1)
                ->  Sort (actual rows=1 loops=1)
-                     Sort Key: (time_bucket('@ 2 days'::interval, _hyper_1_3_chunk."time")) DESC
+                     Sort Key: (time_bucket('@ 2 days'::interval, _hyper_1_5_chunk."time")) DESC
                      Sort Method: top-N heapsort 
-                     ->  Seq Scan on _hyper_1_3_chunk (actual rows=18 loops=1)
+                     ->  Seq Scan on _hyper_1_5_chunk (actual rows=18 loops=1)
          ->  Merge Append (never executed)
-               Sort Key: (time_bucket('@ 2 days'::interval, _hyper_1_2_chunk."time")) DESC
+               Sort Key: (time_bucket('@ 2 days'::interval, _hyper_1_3_chunk."time")) DESC
                ->  Sort (never executed)
-                     Sort Key: (time_bucket('@ 2 days'::interval, _hyper_1_2_chunk."time")) DESC
+                     Sort Key: (time_bucket('@ 2 days'::interval, _hyper_1_3_chunk."time")) DESC
                      ->  Result (never executed)
-                           ->  Custom Scan (DecompressChunk) on _hyper_1_2_chunk (never executed)
-                                 ->  Seq Scan on compress_hyper_2_5_chunk (never executed)
+                           ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk (never executed)
+                                 ->  Seq Scan on compress_hyper_2_4_chunk (never executed)
                ->  Sort (never executed)
-                     Sort Key: (time_bucket('@ 2 days'::interval, _hyper_1_2_chunk."time")) DESC
-                     ->  Seq Scan on _hyper_1_2_chunk (never executed)
+                     Sort Key: (time_bucket('@ 2 days'::interval, _hyper_1_3_chunk."time")) DESC
+                     ->  Seq Scan on _hyper_1_3_chunk (never executed)
          ->  Merge Append (never executed)
                Sort Key: (time_bucket('@ 2 days'::interval, _hyper_1_1_chunk."time")) DESC
                ->  Sort (never executed)
                      Sort Key: (time_bucket('@ 2 days'::interval, _hyper_1_1_chunk."time")) DESC
                      ->  Result (never executed)
                            ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk (never executed)
-                                 ->  Seq Scan on compress_hyper_2_4_chunk (never executed)
+                                 ->  Seq Scan on compress_hyper_2_2_chunk (never executed)
                ->  Sort (never executed)
                      Sort Key: (time_bucket('@ 2 days'::interval, _hyper_1_1_chunk."time")) DESC
                      ->  Seq Scan on _hyper_1_1_chunk (never executed)
@@ -193,30 +193,30 @@ generate_series(1,3) device;
    ->  Custom Scan (ChunkAppend) on ht_metrics_compressed (actual rows=1 loops=1)
          Order: ht_metrics_compressed."time" DESC
          ->  Merge Append (actual rows=1 loops=1)
-               Sort Key: _hyper_1_3_chunk."time" DESC
+               Sort Key: _hyper_1_5_chunk."time" DESC
                ->  Sort (actual rows=1 loops=1)
-                     Sort Key: _hyper_1_3_chunk."time" DESC
+                     Sort Key: _hyper_1_5_chunk."time" DESC
                      Sort Method: top-N heapsort 
-                     ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk (actual rows=30 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_1_5_chunk (actual rows=30 loops=1)
                            Filter: (device = ANY ('{1,2,3}'::integer[]))
                            ->  Index Scan using compress_hyper_2_6_chunk__compressed_hypertable_2_device__ts_me on compress_hyper_2_6_chunk (actual rows=3 loops=1)
                                  Index Cond: (device = ANY ('{1,2,3}'::integer[]))
                ->  Sort (actual rows=1 loops=1)
-                     Sort Key: _hyper_1_3_chunk."time" DESC
+                     Sort Key: _hyper_1_5_chunk."time" DESC
                      Sort Method: top-N heapsort 
-                     ->  Seq Scan on _hyper_1_3_chunk (actual rows=18 loops=1)
+                     ->  Seq Scan on _hyper_1_5_chunk (actual rows=18 loops=1)
                            Filter: (device = ANY ('{1,2,3}'::integer[]))
          ->  Merge Append (never executed)
-               Sort Key: _hyper_1_2_chunk."time" DESC
+               Sort Key: _hyper_1_3_chunk."time" DESC
                ->  Sort (never executed)
-                     Sort Key: _hyper_1_2_chunk."time" DESC
-                     ->  Custom Scan (DecompressChunk) on _hyper_1_2_chunk (never executed)
+                     Sort Key: _hyper_1_3_chunk."time" DESC
+                     ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk (never executed)
                            Filter: (device = ANY ('{1,2,3}'::integer[]))
-                           ->  Index Scan using compress_hyper_2_5_chunk__compressed_hypertable_2_device__ts_me on compress_hyper_2_5_chunk (never executed)
+                           ->  Index Scan using compress_hyper_2_4_chunk__compressed_hypertable_2_device__ts_me on compress_hyper_2_4_chunk (never executed)
                                  Index Cond: (device = ANY ('{1,2,3}'::integer[]))
                ->  Sort (never executed)
-                     Sort Key: _hyper_1_2_chunk."time" DESC
-                     ->  Seq Scan on _hyper_1_2_chunk (never executed)
+                     Sort Key: _hyper_1_3_chunk."time" DESC
+                     ->  Seq Scan on _hyper_1_3_chunk (never executed)
                            Filter: (device = ANY ('{1,2,3}'::integer[]))
          ->  Merge Append (never executed)
                Sort Key: _hyper_1_1_chunk."time" DESC
@@ -224,7 +224,7 @@ generate_series(1,3) device;
                      Sort Key: _hyper_1_1_chunk."time" DESC
                      ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk (never executed)
                            Filter: (device = ANY ('{1,2,3}'::integer[]))
-                           ->  Index Scan using compress_hyper_2_4_chunk__compressed_hypertable_2_device__ts_me on compress_hyper_2_4_chunk (never executed)
+                           ->  Index Scan using compress_hyper_2_2_chunk__compressed_hypertable_2_device__ts_me on compress_hyper_2_2_chunk (never executed)
                                  Index Cond: (device = ANY ('{1,2,3}'::integer[]))
                ->  Sort (never executed)
                      Sort Key: _hyper_1_1_chunk."time" DESC
@@ -245,7 +245,7 @@ generate_series(1,3) device;
                      Sort Method: top-N heapsort 
                      ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk (actual rows=81 loops=1)
                            Filter: (device = ANY ('{1,2,3}'::integer[]))
-                           ->  Index Scan using compress_hyper_2_4_chunk__compressed_hypertable_2_device__ts_me on compress_hyper_2_4_chunk (actual rows=3 loops=1)
+                           ->  Index Scan using compress_hyper_2_2_chunk__compressed_hypertable_2_device__ts_me on compress_hyper_2_2_chunk (actual rows=3 loops=1)
                                  Index Cond: (device = ANY ('{1,2,3}'::integer[]))
                ->  Sort (actual rows=1 loops=1)
                      Sort Key: _hyper_1_1_chunk."time", _hyper_1_1_chunk.device DESC
@@ -253,28 +253,28 @@ generate_series(1,3) device;
                      ->  Seq Scan on _hyper_1_1_chunk (actual rows=54 loops=1)
                            Filter: (device = ANY ('{1,2,3}'::integer[]))
          ->  Merge Append (never executed)
-               Sort Key: _hyper_1_2_chunk."time", _hyper_1_2_chunk.device DESC
-               ->  Sort (never executed)
-                     Sort Key: _hyper_1_2_chunk."time", _hyper_1_2_chunk.device DESC
-                     ->  Custom Scan (DecompressChunk) on _hyper_1_2_chunk (never executed)
-                           Filter: (device = ANY ('{1,2,3}'::integer[]))
-                           ->  Index Scan using compress_hyper_2_5_chunk__compressed_hypertable_2_device__ts_me on compress_hyper_2_5_chunk (never executed)
-                                 Index Cond: (device = ANY ('{1,2,3}'::integer[]))
-               ->  Sort (never executed)
-                     Sort Key: _hyper_1_2_chunk."time", _hyper_1_2_chunk.device DESC
-                     ->  Seq Scan on _hyper_1_2_chunk (never executed)
-                           Filter: (device = ANY ('{1,2,3}'::integer[]))
-         ->  Merge Append (never executed)
                Sort Key: _hyper_1_3_chunk."time", _hyper_1_3_chunk.device DESC
                ->  Sort (never executed)
                      Sort Key: _hyper_1_3_chunk."time", _hyper_1_3_chunk.device DESC
                      ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk (never executed)
                            Filter: (device = ANY ('{1,2,3}'::integer[]))
-                           ->  Index Scan using compress_hyper_2_6_chunk__compressed_hypertable_2_device__ts_me on compress_hyper_2_6_chunk (never executed)
+                           ->  Index Scan using compress_hyper_2_4_chunk__compressed_hypertable_2_device__ts_me on compress_hyper_2_4_chunk (never executed)
                                  Index Cond: (device = ANY ('{1,2,3}'::integer[]))
                ->  Sort (never executed)
                      Sort Key: _hyper_1_3_chunk."time", _hyper_1_3_chunk.device DESC
                      ->  Seq Scan on _hyper_1_3_chunk (never executed)
+                           Filter: (device = ANY ('{1,2,3}'::integer[]))
+         ->  Merge Append (never executed)
+               Sort Key: _hyper_1_5_chunk."time", _hyper_1_5_chunk.device DESC
+               ->  Sort (never executed)
+                     Sort Key: _hyper_1_5_chunk."time", _hyper_1_5_chunk.device DESC
+                     ->  Custom Scan (DecompressChunk) on _hyper_1_5_chunk (never executed)
+                           Filter: (device = ANY ('{1,2,3}'::integer[]))
+                           ->  Index Scan using compress_hyper_2_6_chunk__compressed_hypertable_2_device__ts_me on compress_hyper_2_6_chunk (never executed)
+                                 Index Cond: (device = ANY ('{1,2,3}'::integer[]))
+               ->  Sort (never executed)
+                     Sort Key: _hyper_1_5_chunk."time", _hyper_1_5_chunk.device DESC
+                     ->  Seq Scan on _hyper_1_5_chunk (never executed)
                            Filter: (device = ANY ('{1,2,3}'::integer[]))
 (41 rows)
 
@@ -286,32 +286,32 @@ generate_series(1,3) device;
    ->  Custom Scan (ChunkAppend) on ht_metrics_compressed (actual rows=1 loops=1)
          Order: ht_metrics_compressed."time" DESC
          ->  Merge Append (actual rows=1 loops=1)
-               Sort Key: _hyper_1_3_chunk."time" DESC
-               ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk (actual rows=1 loops=1)
+               Sort Key: _hyper_1_5_chunk."time" DESC
+               ->  Custom Scan (DecompressChunk) on _hyper_1_5_chunk (actual rows=1 loops=1)
                      Filter: (device = 3)
                      ->  Index Scan Backward using compress_hyper_2_6_chunk__compressed_hypertable_2_device__ts_me on compress_hyper_2_6_chunk (actual rows=1 loops=1)
                            Index Cond: (device = 3)
                ->  Sort (actual rows=1 loops=1)
-                     Sort Key: _hyper_1_3_chunk."time" DESC
+                     Sort Key: _hyper_1_5_chunk."time" DESC
                      Sort Method: top-N heapsort 
-                     ->  Seq Scan on _hyper_1_3_chunk (actual rows=6 loops=1)
+                     ->  Seq Scan on _hyper_1_5_chunk (actual rows=6 loops=1)
                            Filter: (device = 3)
                            Rows Removed by Filter: 12
          ->  Merge Append (never executed)
-               Sort Key: _hyper_1_2_chunk."time" DESC
-               ->  Custom Scan (DecompressChunk) on _hyper_1_2_chunk (never executed)
+               Sort Key: _hyper_1_3_chunk."time" DESC
+               ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk (never executed)
                      Filter: (device = 3)
-                     ->  Index Scan Backward using compress_hyper_2_5_chunk__compressed_hypertable_2_device__ts_me on compress_hyper_2_5_chunk (never executed)
+                     ->  Index Scan Backward using compress_hyper_2_4_chunk__compressed_hypertable_2_device__ts_me on compress_hyper_2_4_chunk (never executed)
                            Index Cond: (device = 3)
                ->  Sort (never executed)
-                     Sort Key: _hyper_1_2_chunk."time" DESC
-                     ->  Seq Scan on _hyper_1_2_chunk (never executed)
+                     Sort Key: _hyper_1_3_chunk."time" DESC
+                     ->  Seq Scan on _hyper_1_3_chunk (never executed)
                            Filter: (device = 3)
          ->  Merge Append (never executed)
                Sort Key: _hyper_1_1_chunk."time" DESC
                ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk (never executed)
                      Filter: (device = 3)
-                     ->  Index Scan Backward using compress_hyper_2_4_chunk__compressed_hypertable_2_device__ts_me on compress_hyper_2_4_chunk (never executed)
+                     ->  Index Scan Backward using compress_hyper_2_2_chunk__compressed_hypertable_2_device__ts_me on compress_hyper_2_2_chunk (never executed)
                            Index Cond: (device = 3)
                ->  Sort (never executed)
                      Sort Key: _hyper_1_1_chunk."time" DESC
@@ -333,7 +333,7 @@ SELECT * FROM ht_metrics_compressed WHERE device = 3 ORDER BY time DESC LIMIT 1;
          Sort Key: _hyper_1_1_chunk."time" DESC
          ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk (actual rows=1 loops=1)
                Filter: (device = 3)
-               ->  Index Scan Backward using compress_hyper_2_4_chunk__compressed_hypertable_2_device__ts_me on compress_hyper_2_4_chunk (actual rows=1 loops=1)
+               ->  Index Scan Backward using compress_hyper_2_2_chunk__compressed_hypertable_2_device__ts_me on compress_hyper_2_2_chunk (actual rows=1 loops=1)
                      Index Cond: (device = 3)
          ->  Sort (actual rows=1 loops=1)
                Sort Key: _hyper_1_1_chunk."time" DESC
@@ -341,24 +341,24 @@ SELECT * FROM ht_metrics_compressed WHERE device = 3 ORDER BY time DESC LIMIT 1;
                ->  Seq Scan on _hyper_1_1_chunk (actual rows=18 loops=1)
                      Filter: (device = 3)
                      Rows Removed by Filter: 36
-         ->  Custom Scan (DecompressChunk) on _hyper_1_2_chunk (actual rows=1 loops=1)
-               Filter: (device = 3)
-               ->  Index Scan Backward using compress_hyper_2_5_chunk__compressed_hypertable_2_device__ts_me on compress_hyper_2_5_chunk (actual rows=1 loops=1)
-                     Index Cond: (device = 3)
-         ->  Sort (actual rows=1 loops=1)
-               Sort Key: _hyper_1_2_chunk."time" DESC
-               Sort Method: top-N heapsort 
-               ->  Seq Scan on _hyper_1_2_chunk (actual rows=19 loops=1)
-                     Filter: (device = 3)
-                     Rows Removed by Filter: 38
          ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk (actual rows=1 loops=1)
                Filter: (device = 3)
-               ->  Index Scan Backward using compress_hyper_2_6_chunk__compressed_hypertable_2_device__ts_me on compress_hyper_2_6_chunk (actual rows=1 loops=1)
+               ->  Index Scan Backward using compress_hyper_2_4_chunk__compressed_hypertable_2_device__ts_me on compress_hyper_2_4_chunk (actual rows=1 loops=1)
                      Index Cond: (device = 3)
          ->  Sort (actual rows=1 loops=1)
                Sort Key: _hyper_1_3_chunk."time" DESC
                Sort Method: top-N heapsort 
-               ->  Seq Scan on _hyper_1_3_chunk (actual rows=6 loops=1)
+               ->  Seq Scan on _hyper_1_3_chunk (actual rows=19 loops=1)
+                     Filter: (device = 3)
+                     Rows Removed by Filter: 38
+         ->  Custom Scan (DecompressChunk) on _hyper_1_5_chunk (actual rows=1 loops=1)
+               Filter: (device = 3)
+               ->  Index Scan Backward using compress_hyper_2_6_chunk__compressed_hypertable_2_device__ts_me on compress_hyper_2_6_chunk (actual rows=1 loops=1)
+                     Index Cond: (device = 3)
+         ->  Sort (actual rows=1 loops=1)
+               Sort Key: _hyper_1_5_chunk."time" DESC
+               Sort Method: top-N heapsort 
+               ->  Seq Scan on _hyper_1_5_chunk (actual rows=6 loops=1)
                      Filter: (device = 3)
                      Rows Removed by Filter: 12
 (33 rows)
@@ -379,7 +379,7 @@ SELECT * FROM ht_metrics_compressed WHERE device = 3 ORDER BY device, time DESC 
                Sort Key: _hyper_1_1_chunk."time"
                ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk (actual rows=1 loops=1)
                      Filter: (device = 3)
-                     ->  Index Scan using compress_hyper_2_4_chunk__compressed_hypertable_2_device__ts_me on compress_hyper_2_4_chunk (actual rows=1 loops=1)
+                     ->  Index Scan using compress_hyper_2_2_chunk__compressed_hypertable_2_device__ts_me on compress_hyper_2_2_chunk (actual rows=1 loops=1)
                            Index Cond: (device = 3)
                ->  Sort (actual rows=1 loops=1)
                      Sort Key: _hyper_1_1_chunk."time"
@@ -388,24 +388,24 @@ SELECT * FROM ht_metrics_compressed WHERE device = 3 ORDER BY device, time DESC 
                            Filter: (device = 3)
                            Rows Removed by Filter: 36
          ->  Merge Append (never executed)
-               Sort Key: _hyper_1_2_chunk."time"
-               ->  Custom Scan (DecompressChunk) on _hyper_1_2_chunk (never executed)
-                     Filter: (device = 3)
-                     ->  Index Scan using compress_hyper_2_5_chunk__compressed_hypertable_2_device__ts_me on compress_hyper_2_5_chunk (never executed)
-                           Index Cond: (device = 3)
-               ->  Sort (never executed)
-                     Sort Key: _hyper_1_2_chunk."time"
-                     ->  Seq Scan on _hyper_1_2_chunk (never executed)
-                           Filter: (device = 3)
-         ->  Merge Append (never executed)
                Sort Key: _hyper_1_3_chunk."time"
                ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk (never executed)
                      Filter: (device = 3)
-                     ->  Index Scan using compress_hyper_2_6_chunk__compressed_hypertable_2_device__ts_me on compress_hyper_2_6_chunk (never executed)
+                     ->  Index Scan using compress_hyper_2_4_chunk__compressed_hypertable_2_device__ts_me on compress_hyper_2_4_chunk (never executed)
                            Index Cond: (device = 3)
                ->  Sort (never executed)
                      Sort Key: _hyper_1_3_chunk."time"
                      ->  Seq Scan on _hyper_1_3_chunk (never executed)
+                           Filter: (device = 3)
+         ->  Merge Append (never executed)
+               Sort Key: _hyper_1_5_chunk."time"
+               ->  Custom Scan (DecompressChunk) on _hyper_1_5_chunk (never executed)
+                     Filter: (device = 3)
+                     ->  Index Scan using compress_hyper_2_6_chunk__compressed_hypertable_2_device__ts_me on compress_hyper_2_6_chunk (never executed)
+                           Index Cond: (device = 3)
+               ->  Sort (never executed)
+                     Sort Key: _hyper_1_5_chunk."time"
+                     ->  Seq Scan on _hyper_1_5_chunk (never executed)
                            Filter: (device = 3)
 (35 rows)
 
@@ -424,31 +424,31 @@ SELECT * FROM ht_metrics_compressed WHERE device = 3 ORDER BY time, device DESC 
          Sort Key: _hyper_1_1_chunk.device, _hyper_1_1_chunk."time" DESC
          ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk (actual rows=1 loops=1)
                ->  Sort (actual rows=1 loops=1)
-                     Sort Key: compress_hyper_2_4_chunk.device, compress_hyper_2_4_chunk._ts_meta_sequence_num DESC
+                     Sort Key: compress_hyper_2_2_chunk.device, compress_hyper_2_2_chunk._ts_meta_sequence_num DESC
                      Sort Method: quicksort 
-                     ->  Seq Scan on compress_hyper_2_4_chunk (actual rows=3 loops=1)
+                     ->  Seq Scan on compress_hyper_2_2_chunk (actual rows=3 loops=1)
          ->  Sort (actual rows=1 loops=1)
                Sort Key: _hyper_1_1_chunk.device, _hyper_1_1_chunk."time" DESC
                Sort Method: top-N heapsort 
                ->  Seq Scan on _hyper_1_1_chunk (actual rows=54 loops=1)
-         ->  Custom Scan (DecompressChunk) on _hyper_1_2_chunk (actual rows=1 loops=1)
-               ->  Sort (actual rows=1 loops=1)
-                     Sort Key: compress_hyper_2_5_chunk.device, compress_hyper_2_5_chunk._ts_meta_sequence_num DESC
-                     Sort Method: quicksort 
-                     ->  Seq Scan on compress_hyper_2_5_chunk (actual rows=3 loops=1)
-         ->  Sort (actual rows=1 loops=1)
-               Sort Key: _hyper_1_2_chunk.device, _hyper_1_2_chunk."time" DESC
-               Sort Method: top-N heapsort 
-               ->  Seq Scan on _hyper_1_2_chunk (actual rows=57 loops=1)
          ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk (actual rows=1 loops=1)
+               ->  Sort (actual rows=1 loops=1)
+                     Sort Key: compress_hyper_2_4_chunk.device, compress_hyper_2_4_chunk._ts_meta_sequence_num DESC
+                     Sort Method: quicksort 
+                     ->  Seq Scan on compress_hyper_2_4_chunk (actual rows=3 loops=1)
+         ->  Sort (actual rows=1 loops=1)
+               Sort Key: _hyper_1_3_chunk.device, _hyper_1_3_chunk."time" DESC
+               Sort Method: top-N heapsort 
+               ->  Seq Scan on _hyper_1_3_chunk (actual rows=57 loops=1)
+         ->  Custom Scan (DecompressChunk) on _hyper_1_5_chunk (actual rows=1 loops=1)
                ->  Sort (actual rows=1 loops=1)
                      Sort Key: compress_hyper_2_6_chunk.device, compress_hyper_2_6_chunk._ts_meta_sequence_num DESC
                      Sort Method: quicksort 
                      ->  Seq Scan on compress_hyper_2_6_chunk (actual rows=3 loops=1)
          ->  Sort (actual rows=1 loops=1)
-               Sort Key: _hyper_1_3_chunk.device, _hyper_1_3_chunk."time" DESC
+               Sort Key: _hyper_1_5_chunk.device, _hyper_1_5_chunk."time" DESC
                Sort Method: top-N heapsort 
-               ->  Seq Scan on _hyper_1_3_chunk (actual rows=18 loops=1)
+               ->  Seq Scan on _hyper_1_5_chunk (actual rows=18 loops=1)
 (30 rows)
 
 :PREFIX SELECT * FROM ht_metrics_compressed WHERE device IN (1,2,3) ORDER BY device, time DESC LIMIT 1; -- with pushdown
@@ -460,28 +460,28 @@ SELECT * FROM ht_metrics_compressed WHERE device = 3 ORDER BY time, device DESC 
          ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk (actual rows=1 loops=1)
                Filter: (device = ANY ('{1,2,3}'::integer[]))
                ->  Sort (actual rows=1 loops=1)
-                     Sort Key: compress_hyper_2_4_chunk.device, compress_hyper_2_4_chunk._ts_meta_sequence_num DESC
+                     Sort Key: compress_hyper_2_2_chunk.device, compress_hyper_2_2_chunk._ts_meta_sequence_num DESC
                      Sort Method: quicksort 
-                     ->  Index Scan using compress_hyper_2_4_chunk__compressed_hypertable_2_device__ts_me on compress_hyper_2_4_chunk (actual rows=3 loops=1)
+                     ->  Index Scan using compress_hyper_2_2_chunk__compressed_hypertable_2_device__ts_me on compress_hyper_2_2_chunk (actual rows=3 loops=1)
                            Index Cond: (device = ANY ('{1,2,3}'::integer[]))
          ->  Sort (actual rows=1 loops=1)
                Sort Key: _hyper_1_1_chunk.device, _hyper_1_1_chunk."time" DESC
                Sort Method: top-N heapsort 
                ->  Seq Scan on _hyper_1_1_chunk (actual rows=54 loops=1)
                      Filter: (device = ANY ('{1,2,3}'::integer[]))
-         ->  Custom Scan (DecompressChunk) on _hyper_1_2_chunk (actual rows=1 loops=1)
+         ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk (actual rows=1 loops=1)
                Filter: (device = ANY ('{1,2,3}'::integer[]))
                ->  Sort (actual rows=1 loops=1)
-                     Sort Key: compress_hyper_2_5_chunk.device, compress_hyper_2_5_chunk._ts_meta_sequence_num DESC
+                     Sort Key: compress_hyper_2_4_chunk.device, compress_hyper_2_4_chunk._ts_meta_sequence_num DESC
                      Sort Method: quicksort 
-                     ->  Index Scan using compress_hyper_2_5_chunk__compressed_hypertable_2_device__ts_me on compress_hyper_2_5_chunk (actual rows=3 loops=1)
+                     ->  Index Scan using compress_hyper_2_4_chunk__compressed_hypertable_2_device__ts_me on compress_hyper_2_4_chunk (actual rows=3 loops=1)
                            Index Cond: (device = ANY ('{1,2,3}'::integer[]))
          ->  Sort (actual rows=1 loops=1)
-               Sort Key: _hyper_1_2_chunk.device, _hyper_1_2_chunk."time" DESC
+               Sort Key: _hyper_1_3_chunk.device, _hyper_1_3_chunk."time" DESC
                Sort Method: top-N heapsort 
-               ->  Seq Scan on _hyper_1_2_chunk (actual rows=57 loops=1)
+               ->  Seq Scan on _hyper_1_3_chunk (actual rows=57 loops=1)
                      Filter: (device = ANY ('{1,2,3}'::integer[]))
-         ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk (actual rows=1 loops=1)
+         ->  Custom Scan (DecompressChunk) on _hyper_1_5_chunk (actual rows=1 loops=1)
                Filter: (device = ANY ('{1,2,3}'::integer[]))
                ->  Sort (actual rows=1 loops=1)
                      Sort Key: compress_hyper_2_6_chunk.device, compress_hyper_2_6_chunk._ts_meta_sequence_num DESC
@@ -489,9 +489,9 @@ SELECT * FROM ht_metrics_compressed WHERE device = 3 ORDER BY time, device DESC 
                      ->  Index Scan using compress_hyper_2_6_chunk__compressed_hypertable_2_device__ts_me on compress_hyper_2_6_chunk (actual rows=3 loops=1)
                            Index Cond: (device = ANY ('{1,2,3}'::integer[]))
          ->  Sort (actual rows=1 loops=1)
-               Sort Key: _hyper_1_3_chunk.device, _hyper_1_3_chunk."time" DESC
+               Sort Key: _hyper_1_5_chunk.device, _hyper_1_5_chunk."time" DESC
                Sort Method: top-N heapsort 
-               ->  Seq Scan on _hyper_1_3_chunk (actual rows=18 loops=1)
+               ->  Seq Scan on _hyper_1_5_chunk (actual rows=18 loops=1)
                      Filter: (device = ANY ('{1,2,3}'::integer[]))
 (39 rows)
 
@@ -909,7 +909,7 @@ SELECT compress_chunk(i) FROM show_chunks('test2') i;
              compress_chunk              
 -----------------------------------------
  _timescaledb_internal._hyper_5_9_chunk
- _timescaledb_internal._hyper_5_10_chunk
+ _timescaledb_internal._hyper_5_11_chunk
 (2 rows)
 
 -- make them partially compressed
@@ -924,22 +924,22 @@ set enable_indexscan = off;
    Sort Key: _hyper_5_9_chunk.x1, _hyper_5_9_chunk.x2, _hyper_5_9_chunk.x5, _hyper_5_9_chunk.x3
    ->  Custom Scan (DecompressChunk) on _hyper_5_9_chunk (actual rows=4 loops=1)
          ->  Sort (actual rows=3 loops=1)
-               Sort Key: compress_hyper_6_11_chunk.x1, compress_hyper_6_11_chunk.x2, compress_hyper_6_11_chunk.x5, compress_hyper_6_11_chunk._ts_meta_sequence_num
+               Sort Key: compress_hyper_6_10_chunk.x1, compress_hyper_6_10_chunk.x2, compress_hyper_6_10_chunk.x5, compress_hyper_6_10_chunk._ts_meta_sequence_num
                Sort Method: quicksort 
-               ->  Seq Scan on compress_hyper_6_11_chunk (actual rows=3 loops=1)
+               ->  Seq Scan on compress_hyper_6_10_chunk (actual rows=3 loops=1)
    ->  Sort (actual rows=1 loops=1)
          Sort Key: _hyper_5_9_chunk.x1, _hyper_5_9_chunk.x2, _hyper_5_9_chunk.x5, _hyper_5_9_chunk.x3
          Sort Method: quicksort 
          ->  Seq Scan on _hyper_5_9_chunk (actual rows=1 loops=1)
-   ->  Custom Scan (DecompressChunk) on _hyper_5_10_chunk (actual rows=4 loops=1)
+   ->  Custom Scan (DecompressChunk) on _hyper_5_11_chunk (actual rows=4 loops=1)
          ->  Sort (actual rows=3 loops=1)
                Sort Key: compress_hyper_6_12_chunk.x1, compress_hyper_6_12_chunk.x2, compress_hyper_6_12_chunk.x5, compress_hyper_6_12_chunk._ts_meta_sequence_num
                Sort Method: quicksort 
                ->  Seq Scan on compress_hyper_6_12_chunk (actual rows=3 loops=1)
    ->  Sort (actual rows=1 loops=1)
-         Sort Key: _hyper_5_10_chunk.x1, _hyper_5_10_chunk.x2, _hyper_5_10_chunk.x5, _hyper_5_10_chunk.x3
+         Sort Key: _hyper_5_11_chunk.x1, _hyper_5_11_chunk.x2, _hyper_5_11_chunk.x5, _hyper_5_11_chunk.x3
          Sort Method: quicksort 
-         ->  Seq Scan on _hyper_5_10_chunk (actual rows=1 loops=1)
+         ->  Seq Scan on _hyper_5_11_chunk (actual rows=1 loops=1)
 (20 rows)
 
 SELECT * FROM test2 ORDER BY x1, x2, x5, x3;
@@ -964,22 +964,22 @@ SELECT * FROM test2 ORDER BY x1, x2, x5, x3;
    Sort Key: _hyper_5_9_chunk.x1, _hyper_5_9_chunk.x2, _hyper_5_9_chunk.x5, _hyper_5_9_chunk.x3, _hyper_5_9_chunk.x4
    ->  Custom Scan (DecompressChunk) on _hyper_5_9_chunk (actual rows=4 loops=1)
          ->  Sort (actual rows=3 loops=1)
-               Sort Key: compress_hyper_6_11_chunk.x1, compress_hyper_6_11_chunk.x2, compress_hyper_6_11_chunk.x5, compress_hyper_6_11_chunk._ts_meta_sequence_num
+               Sort Key: compress_hyper_6_10_chunk.x1, compress_hyper_6_10_chunk.x2, compress_hyper_6_10_chunk.x5, compress_hyper_6_10_chunk._ts_meta_sequence_num
                Sort Method: quicksort 
-               ->  Seq Scan on compress_hyper_6_11_chunk (actual rows=3 loops=1)
+               ->  Seq Scan on compress_hyper_6_10_chunk (actual rows=3 loops=1)
    ->  Sort (actual rows=1 loops=1)
          Sort Key: _hyper_5_9_chunk.x1, _hyper_5_9_chunk.x2, _hyper_5_9_chunk.x5, _hyper_5_9_chunk.x3, _hyper_5_9_chunk.x4
          Sort Method: quicksort 
          ->  Seq Scan on _hyper_5_9_chunk (actual rows=1 loops=1)
-   ->  Custom Scan (DecompressChunk) on _hyper_5_10_chunk (actual rows=4 loops=1)
+   ->  Custom Scan (DecompressChunk) on _hyper_5_11_chunk (actual rows=4 loops=1)
          ->  Sort (actual rows=3 loops=1)
                Sort Key: compress_hyper_6_12_chunk.x1, compress_hyper_6_12_chunk.x2, compress_hyper_6_12_chunk.x5, compress_hyper_6_12_chunk._ts_meta_sequence_num
                Sort Method: quicksort 
                ->  Seq Scan on compress_hyper_6_12_chunk (actual rows=3 loops=1)
    ->  Sort (actual rows=1 loops=1)
-         Sort Key: _hyper_5_10_chunk.x1, _hyper_5_10_chunk.x2, _hyper_5_10_chunk.x5, _hyper_5_10_chunk.x3, _hyper_5_10_chunk.x4
+         Sort Key: _hyper_5_11_chunk.x1, _hyper_5_11_chunk.x2, _hyper_5_11_chunk.x5, _hyper_5_11_chunk.x3, _hyper_5_11_chunk.x4
          Sort Method: quicksort 
-         ->  Seq Scan on _hyper_5_10_chunk (actual rows=1 loops=1)
+         ->  Seq Scan on _hyper_5_11_chunk (actual rows=1 loops=1)
 (20 rows)
 
 SELECT * FROM test2 ORDER BY x1, x2, x5, x3, x4;
@@ -1007,20 +1007,20 @@ SELECT * FROM test2 ORDER BY x1, x2, x5, x3, x4;
          Sort Key: _hyper_5_9_chunk.x1, _hyper_5_9_chunk.x2, _hyper_5_9_chunk.x3
          Sort Method: quicksort 
          ->  Custom Scan (DecompressChunk) on _hyper_5_9_chunk (actual rows=4 loops=1)
-               ->  Seq Scan on compress_hyper_6_11_chunk (actual rows=3 loops=1)
+               ->  Seq Scan on compress_hyper_6_10_chunk (actual rows=3 loops=1)
    ->  Sort (actual rows=1 loops=1)
          Sort Key: _hyper_5_9_chunk.x1, _hyper_5_9_chunk.x2, _hyper_5_9_chunk.x3
          Sort Method: quicksort 
          ->  Seq Scan on _hyper_5_9_chunk (actual rows=1 loops=1)
    ->  Sort (actual rows=4 loops=1)
-         Sort Key: _hyper_5_10_chunk.x1, _hyper_5_10_chunk.x2, _hyper_5_10_chunk.x3
+         Sort Key: _hyper_5_11_chunk.x1, _hyper_5_11_chunk.x2, _hyper_5_11_chunk.x3
          Sort Method: quicksort 
-         ->  Custom Scan (DecompressChunk) on _hyper_5_10_chunk (actual rows=4 loops=1)
+         ->  Custom Scan (DecompressChunk) on _hyper_5_11_chunk (actual rows=4 loops=1)
                ->  Seq Scan on compress_hyper_6_12_chunk (actual rows=3 loops=1)
    ->  Sort (actual rows=1 loops=1)
-         Sort Key: _hyper_5_10_chunk.x1, _hyper_5_10_chunk.x2, _hyper_5_10_chunk.x3
+         Sort Key: _hyper_5_11_chunk.x1, _hyper_5_11_chunk.x2, _hyper_5_11_chunk.x3
          Sort Method: quicksort 
-         ->  Seq Scan on _hyper_5_10_chunk (actual rows=1 loops=1)
+         ->  Seq Scan on _hyper_5_11_chunk (actual rows=1 loops=1)
 (20 rows)
 
 SELECT * FROM test2 ORDER BY x1, x2, x3;
@@ -1047,20 +1047,20 @@ SELECT * FROM test2 ORDER BY x1, x2, x3;
          Sort Key: _hyper_5_9_chunk.x1, _hyper_5_9_chunk.x2, _hyper_5_9_chunk.x5, _hyper_5_9_chunk.x4
          Sort Method: quicksort 
          ->  Custom Scan (DecompressChunk) on _hyper_5_9_chunk (actual rows=4 loops=1)
-               ->  Seq Scan on compress_hyper_6_11_chunk (actual rows=3 loops=1)
+               ->  Seq Scan on compress_hyper_6_10_chunk (actual rows=3 loops=1)
    ->  Sort (actual rows=1 loops=1)
          Sort Key: _hyper_5_9_chunk.x1, _hyper_5_9_chunk.x2, _hyper_5_9_chunk.x5, _hyper_5_9_chunk.x4
          Sort Method: quicksort 
          ->  Seq Scan on _hyper_5_9_chunk (actual rows=1 loops=1)
    ->  Sort (actual rows=4 loops=1)
-         Sort Key: _hyper_5_10_chunk.x1, _hyper_5_10_chunk.x2, _hyper_5_10_chunk.x5, _hyper_5_10_chunk.x4
+         Sort Key: _hyper_5_11_chunk.x1, _hyper_5_11_chunk.x2, _hyper_5_11_chunk.x5, _hyper_5_11_chunk.x4
          Sort Method: quicksort 
-         ->  Custom Scan (DecompressChunk) on _hyper_5_10_chunk (actual rows=4 loops=1)
+         ->  Custom Scan (DecompressChunk) on _hyper_5_11_chunk (actual rows=4 loops=1)
                ->  Seq Scan on compress_hyper_6_12_chunk (actual rows=3 loops=1)
    ->  Sort (actual rows=1 loops=1)
-         Sort Key: _hyper_5_10_chunk.x1, _hyper_5_10_chunk.x2, _hyper_5_10_chunk.x5, _hyper_5_10_chunk.x4
+         Sort Key: _hyper_5_11_chunk.x1, _hyper_5_11_chunk.x2, _hyper_5_11_chunk.x5, _hyper_5_11_chunk.x4
          Sort Method: quicksort 
-         ->  Seq Scan on _hyper_5_10_chunk (actual rows=1 loops=1)
+         ->  Seq Scan on _hyper_5_11_chunk (actual rows=1 loops=1)
 (20 rows)
 
 SELECT * FROM test2 ORDER BY x1, x2, x5, x4;
@@ -1087,20 +1087,20 @@ SELECT * FROM test2 ORDER BY x1, x2, x5, x4;
          Sort Key: _hyper_5_9_chunk.x1, _hyper_5_9_chunk.x2, _hyper_5_9_chunk.x5, _hyper_5_9_chunk."time"
          Sort Method: quicksort 
          ->  Custom Scan (DecompressChunk) on _hyper_5_9_chunk (actual rows=4 loops=1)
-               ->  Seq Scan on compress_hyper_6_11_chunk (actual rows=3 loops=1)
+               ->  Seq Scan on compress_hyper_6_10_chunk (actual rows=3 loops=1)
    ->  Sort (actual rows=1 loops=1)
          Sort Key: _hyper_5_9_chunk.x1, _hyper_5_9_chunk.x2, _hyper_5_9_chunk.x5, _hyper_5_9_chunk."time"
          Sort Method: quicksort 
          ->  Seq Scan on _hyper_5_9_chunk (actual rows=1 loops=1)
    ->  Sort (actual rows=4 loops=1)
-         Sort Key: _hyper_5_10_chunk.x1, _hyper_5_10_chunk.x2, _hyper_5_10_chunk.x5, _hyper_5_10_chunk."time"
+         Sort Key: _hyper_5_11_chunk.x1, _hyper_5_11_chunk.x2, _hyper_5_11_chunk.x5, _hyper_5_11_chunk."time"
          Sort Method: quicksort 
-         ->  Custom Scan (DecompressChunk) on _hyper_5_10_chunk (actual rows=4 loops=1)
+         ->  Custom Scan (DecompressChunk) on _hyper_5_11_chunk (actual rows=4 loops=1)
                ->  Seq Scan on compress_hyper_6_12_chunk (actual rows=3 loops=1)
    ->  Sort (actual rows=1 loops=1)
-         Sort Key: _hyper_5_10_chunk.x1, _hyper_5_10_chunk.x2, _hyper_5_10_chunk.x5, _hyper_5_10_chunk."time"
+         Sort Key: _hyper_5_11_chunk.x1, _hyper_5_11_chunk.x2, _hyper_5_11_chunk.x5, _hyper_5_11_chunk."time"
          Sort Method: quicksort 
-         ->  Seq Scan on _hyper_5_10_chunk (actual rows=1 loops=1)
+         ->  Seq Scan on _hyper_5_11_chunk (actual rows=1 loops=1)
 (20 rows)
 
 SELECT * FROM test2 ORDER BY x1, x2, x5, time;
@@ -1152,9 +1152,9 @@ SELECT compress_chunk(i) FROM show_chunks('test3') i;
              compress_chunk              
 -----------------------------------------
  _timescaledb_internal._hyper_7_13_chunk
- _timescaledb_internal._hyper_7_14_chunk
  _timescaledb_internal._hyper_7_15_chunk
- _timescaledb_internal._hyper_7_16_chunk
+ _timescaledb_internal._hyper_7_17_chunk
+ _timescaledb_internal._hyper_7_19_chunk
 (4 rows)
 
 -- make them partially compressed
@@ -1169,28 +1169,28 @@ set enable_indexscan = off;
    Sort Key: _hyper_7_13_chunk.x1, _hyper_7_13_chunk.x2, _hyper_7_13_chunk.x5, _hyper_7_13_chunk.x3
    ->  Custom Scan (DecompressChunk) on _hyper_7_13_chunk (actual rows=3 loops=1)
          ->  Sort (actual rows=2 loops=1)
-               Sort Key: compress_hyper_8_17_chunk.x1, compress_hyper_8_17_chunk.x2, compress_hyper_8_17_chunk.x5, compress_hyper_8_17_chunk._ts_meta_sequence_num
+               Sort Key: compress_hyper_8_14_chunk.x1, compress_hyper_8_14_chunk.x2, compress_hyper_8_14_chunk.x5, compress_hyper_8_14_chunk._ts_meta_sequence_num
                Sort Method: quicksort 
-               ->  Seq Scan on compress_hyper_8_17_chunk (actual rows=2 loops=1)
+               ->  Seq Scan on compress_hyper_8_14_chunk (actual rows=2 loops=1)
    ->  Sort (actual rows=1 loops=1)
          Sort Key: _hyper_7_13_chunk.x1, _hyper_7_13_chunk.x2, _hyper_7_13_chunk.x5, _hyper_7_13_chunk.x3
          Sort Method: quicksort 
          ->  Seq Scan on _hyper_7_13_chunk (actual rows=1 loops=1)
-   ->  Custom Scan (DecompressChunk) on _hyper_7_14_chunk (actual rows=1 loops=1)
+   ->  Custom Scan (DecompressChunk) on _hyper_7_15_chunk (actual rows=1 loops=1)
          ->  Sort (actual rows=1 loops=1)
+               Sort Key: compress_hyper_8_16_chunk.x1, compress_hyper_8_16_chunk.x2, compress_hyper_8_16_chunk.x5, compress_hyper_8_16_chunk._ts_meta_sequence_num
+               Sort Method: quicksort 
+               ->  Seq Scan on compress_hyper_8_16_chunk (actual rows=1 loops=1)
+   ->  Custom Scan (DecompressChunk) on _hyper_7_17_chunk (actual rows=3 loops=1)
+         ->  Sort (actual rows=2 loops=1)
                Sort Key: compress_hyper_8_18_chunk.x1, compress_hyper_8_18_chunk.x2, compress_hyper_8_18_chunk.x5, compress_hyper_8_18_chunk._ts_meta_sequence_num
                Sort Method: quicksort 
-               ->  Seq Scan on compress_hyper_8_18_chunk (actual rows=1 loops=1)
-   ->  Custom Scan (DecompressChunk) on _hyper_7_15_chunk (actual rows=3 loops=1)
-         ->  Sort (actual rows=2 loops=1)
-               Sort Key: compress_hyper_8_19_chunk.x1, compress_hyper_8_19_chunk.x2, compress_hyper_8_19_chunk.x5, compress_hyper_8_19_chunk._ts_meta_sequence_num
-               Sort Method: quicksort 
-               ->  Seq Scan on compress_hyper_8_19_chunk (actual rows=2 loops=1)
+               ->  Seq Scan on compress_hyper_8_18_chunk (actual rows=2 loops=1)
    ->  Sort (actual rows=1 loops=1)
-         Sort Key: _hyper_7_15_chunk.x1, _hyper_7_15_chunk.x2, _hyper_7_15_chunk.x5, _hyper_7_15_chunk.x3
+         Sort Key: _hyper_7_17_chunk.x1, _hyper_7_17_chunk.x2, _hyper_7_17_chunk.x5, _hyper_7_17_chunk.x3
          Sort Method: quicksort 
-         ->  Seq Scan on _hyper_7_15_chunk (actual rows=1 loops=1)
-   ->  Custom Scan (DecompressChunk) on _hyper_7_16_chunk (actual rows=1 loops=1)
+         ->  Seq Scan on _hyper_7_17_chunk (actual rows=1 loops=1)
+   ->  Custom Scan (DecompressChunk) on _hyper_7_19_chunk (actual rows=1 loops=1)
          ->  Sort (actual rows=1 loops=1)
                Sort Key: compress_hyper_8_20_chunk.x1, compress_hyper_8_20_chunk.x2, compress_hyper_8_20_chunk.x5, compress_hyper_8_20_chunk._ts_meta_sequence_num
                Sort Method: quicksort 
@@ -1219,28 +1219,28 @@ SELECT * FROM test3 ORDER BY x1, x2, x5, x3;
    Sort Key: _hyper_7_13_chunk.x1, _hyper_7_13_chunk.x2, _hyper_7_13_chunk.x5, _hyper_7_13_chunk.x3, _hyper_7_13_chunk.x4
    ->  Custom Scan (DecompressChunk) on _hyper_7_13_chunk (actual rows=3 loops=1)
          ->  Sort (actual rows=2 loops=1)
-               Sort Key: compress_hyper_8_17_chunk.x1, compress_hyper_8_17_chunk.x2, compress_hyper_8_17_chunk.x5, compress_hyper_8_17_chunk._ts_meta_sequence_num
+               Sort Key: compress_hyper_8_14_chunk.x1, compress_hyper_8_14_chunk.x2, compress_hyper_8_14_chunk.x5, compress_hyper_8_14_chunk._ts_meta_sequence_num
                Sort Method: quicksort 
-               ->  Seq Scan on compress_hyper_8_17_chunk (actual rows=2 loops=1)
+               ->  Seq Scan on compress_hyper_8_14_chunk (actual rows=2 loops=1)
    ->  Sort (actual rows=1 loops=1)
          Sort Key: _hyper_7_13_chunk.x1, _hyper_7_13_chunk.x2, _hyper_7_13_chunk.x5, _hyper_7_13_chunk.x3, _hyper_7_13_chunk.x4
          Sort Method: quicksort 
          ->  Seq Scan on _hyper_7_13_chunk (actual rows=1 loops=1)
-   ->  Custom Scan (DecompressChunk) on _hyper_7_14_chunk (actual rows=1 loops=1)
+   ->  Custom Scan (DecompressChunk) on _hyper_7_15_chunk (actual rows=1 loops=1)
          ->  Sort (actual rows=1 loops=1)
+               Sort Key: compress_hyper_8_16_chunk.x1, compress_hyper_8_16_chunk.x2, compress_hyper_8_16_chunk.x5, compress_hyper_8_16_chunk._ts_meta_sequence_num
+               Sort Method: quicksort 
+               ->  Seq Scan on compress_hyper_8_16_chunk (actual rows=1 loops=1)
+   ->  Custom Scan (DecompressChunk) on _hyper_7_17_chunk (actual rows=3 loops=1)
+         ->  Sort (actual rows=2 loops=1)
                Sort Key: compress_hyper_8_18_chunk.x1, compress_hyper_8_18_chunk.x2, compress_hyper_8_18_chunk.x5, compress_hyper_8_18_chunk._ts_meta_sequence_num
                Sort Method: quicksort 
-               ->  Seq Scan on compress_hyper_8_18_chunk (actual rows=1 loops=1)
-   ->  Custom Scan (DecompressChunk) on _hyper_7_15_chunk (actual rows=3 loops=1)
-         ->  Sort (actual rows=2 loops=1)
-               Sort Key: compress_hyper_8_19_chunk.x1, compress_hyper_8_19_chunk.x2, compress_hyper_8_19_chunk.x5, compress_hyper_8_19_chunk._ts_meta_sequence_num
-               Sort Method: quicksort 
-               ->  Seq Scan on compress_hyper_8_19_chunk (actual rows=2 loops=1)
+               ->  Seq Scan on compress_hyper_8_18_chunk (actual rows=2 loops=1)
    ->  Sort (actual rows=1 loops=1)
-         Sort Key: _hyper_7_15_chunk.x1, _hyper_7_15_chunk.x2, _hyper_7_15_chunk.x5, _hyper_7_15_chunk.x3, _hyper_7_15_chunk.x4
+         Sort Key: _hyper_7_17_chunk.x1, _hyper_7_17_chunk.x2, _hyper_7_17_chunk.x5, _hyper_7_17_chunk.x3, _hyper_7_17_chunk.x4
          Sort Method: quicksort 
-         ->  Seq Scan on _hyper_7_15_chunk (actual rows=1 loops=1)
-   ->  Custom Scan (DecompressChunk) on _hyper_7_16_chunk (actual rows=1 loops=1)
+         ->  Seq Scan on _hyper_7_17_chunk (actual rows=1 loops=1)
+   ->  Custom Scan (DecompressChunk) on _hyper_7_19_chunk (actual rows=1 loops=1)
          ->  Sort (actual rows=1 loops=1)
                Sort Key: compress_hyper_8_20_chunk.x1, compress_hyper_8_20_chunk.x2, compress_hyper_8_20_chunk.x5, compress_hyper_8_20_chunk._ts_meta_sequence_num
                Sort Method: quicksort 
@@ -1272,29 +1272,29 @@ SELECT * FROM test3 ORDER BY x1, x2, x5, x3, x4;
          Sort Key: _hyper_7_13_chunk.x1, _hyper_7_13_chunk.x2, _hyper_7_13_chunk.x3
          Sort Method: quicksort 
          ->  Custom Scan (DecompressChunk) on _hyper_7_13_chunk (actual rows=3 loops=1)
-               ->  Seq Scan on compress_hyper_8_17_chunk (actual rows=2 loops=1)
+               ->  Seq Scan on compress_hyper_8_14_chunk (actual rows=2 loops=1)
    ->  Sort (actual rows=1 loops=1)
          Sort Key: _hyper_7_13_chunk.x1, _hyper_7_13_chunk.x2, _hyper_7_13_chunk.x3
          Sort Method: quicksort 
          ->  Seq Scan on _hyper_7_13_chunk (actual rows=1 loops=1)
    ->  Sort (actual rows=1 loops=1)
-         Sort Key: _hyper_7_14_chunk.x1, _hyper_7_14_chunk.x2, _hyper_7_14_chunk.x3
+         Sort Key: _hyper_7_15_chunk.x1, _hyper_7_15_chunk.x2, _hyper_7_15_chunk.x3
          Sort Method: quicksort 
-         ->  Custom Scan (DecompressChunk) on _hyper_7_14_chunk (actual rows=1 loops=1)
-               ->  Seq Scan on compress_hyper_8_18_chunk (actual rows=1 loops=1)
+         ->  Custom Scan (DecompressChunk) on _hyper_7_15_chunk (actual rows=1 loops=1)
+               ->  Seq Scan on compress_hyper_8_16_chunk (actual rows=1 loops=1)
    ->  Sort (actual rows=3 loops=1)
-         Sort Key: _hyper_7_15_chunk.x1, _hyper_7_15_chunk.x2, _hyper_7_15_chunk.x3
+         Sort Key: _hyper_7_17_chunk.x1, _hyper_7_17_chunk.x2, _hyper_7_17_chunk.x3
          Sort Method: quicksort 
-         ->  Custom Scan (DecompressChunk) on _hyper_7_15_chunk (actual rows=3 loops=1)
-               ->  Seq Scan on compress_hyper_8_19_chunk (actual rows=2 loops=1)
+         ->  Custom Scan (DecompressChunk) on _hyper_7_17_chunk (actual rows=3 loops=1)
+               ->  Seq Scan on compress_hyper_8_18_chunk (actual rows=2 loops=1)
    ->  Sort (actual rows=1 loops=1)
-         Sort Key: _hyper_7_15_chunk.x1, _hyper_7_15_chunk.x2, _hyper_7_15_chunk.x3
+         Sort Key: _hyper_7_17_chunk.x1, _hyper_7_17_chunk.x2, _hyper_7_17_chunk.x3
          Sort Method: quicksort 
-         ->  Seq Scan on _hyper_7_15_chunk (actual rows=1 loops=1)
+         ->  Seq Scan on _hyper_7_17_chunk (actual rows=1 loops=1)
    ->  Sort (actual rows=1 loops=1)
-         Sort Key: _hyper_7_16_chunk.x1, _hyper_7_16_chunk.x2, _hyper_7_16_chunk.x3
+         Sort Key: _hyper_7_19_chunk.x1, _hyper_7_19_chunk.x2, _hyper_7_19_chunk.x3
          Sort Method: quicksort 
-         ->  Custom Scan (DecompressChunk) on _hyper_7_16_chunk (actual rows=1 loops=1)
+         ->  Custom Scan (DecompressChunk) on _hyper_7_19_chunk (actual rows=1 loops=1)
                ->  Seq Scan on compress_hyper_8_20_chunk (actual rows=1 loops=1)
 (30 rows)
 
@@ -1322,29 +1322,29 @@ SELECT * FROM test3 ORDER BY x1, x2, x3;
          Sort Key: _hyper_7_13_chunk.x1, _hyper_7_13_chunk.x2, _hyper_7_13_chunk.x5, _hyper_7_13_chunk.x4
          Sort Method: quicksort 
          ->  Custom Scan (DecompressChunk) on _hyper_7_13_chunk (actual rows=3 loops=1)
-               ->  Seq Scan on compress_hyper_8_17_chunk (actual rows=2 loops=1)
+               ->  Seq Scan on compress_hyper_8_14_chunk (actual rows=2 loops=1)
    ->  Sort (actual rows=1 loops=1)
          Sort Key: _hyper_7_13_chunk.x1, _hyper_7_13_chunk.x2, _hyper_7_13_chunk.x5, _hyper_7_13_chunk.x4
          Sort Method: quicksort 
          ->  Seq Scan on _hyper_7_13_chunk (actual rows=1 loops=1)
    ->  Sort (actual rows=1 loops=1)
-         Sort Key: _hyper_7_14_chunk.x1, _hyper_7_14_chunk.x2, _hyper_7_14_chunk.x5, _hyper_7_14_chunk.x4
+         Sort Key: _hyper_7_15_chunk.x1, _hyper_7_15_chunk.x2, _hyper_7_15_chunk.x5, _hyper_7_15_chunk.x4
          Sort Method: quicksort 
-         ->  Custom Scan (DecompressChunk) on _hyper_7_14_chunk (actual rows=1 loops=1)
-               ->  Seq Scan on compress_hyper_8_18_chunk (actual rows=1 loops=1)
+         ->  Custom Scan (DecompressChunk) on _hyper_7_15_chunk (actual rows=1 loops=1)
+               ->  Seq Scan on compress_hyper_8_16_chunk (actual rows=1 loops=1)
    ->  Sort (actual rows=3 loops=1)
-         Sort Key: _hyper_7_15_chunk.x1, _hyper_7_15_chunk.x2, _hyper_7_15_chunk.x5, _hyper_7_15_chunk.x4
+         Sort Key: _hyper_7_17_chunk.x1, _hyper_7_17_chunk.x2, _hyper_7_17_chunk.x5, _hyper_7_17_chunk.x4
          Sort Method: quicksort 
-         ->  Custom Scan (DecompressChunk) on _hyper_7_15_chunk (actual rows=3 loops=1)
-               ->  Seq Scan on compress_hyper_8_19_chunk (actual rows=2 loops=1)
+         ->  Custom Scan (DecompressChunk) on _hyper_7_17_chunk (actual rows=3 loops=1)
+               ->  Seq Scan on compress_hyper_8_18_chunk (actual rows=2 loops=1)
    ->  Sort (actual rows=1 loops=1)
-         Sort Key: _hyper_7_15_chunk.x1, _hyper_7_15_chunk.x2, _hyper_7_15_chunk.x5, _hyper_7_15_chunk.x4
+         Sort Key: _hyper_7_17_chunk.x1, _hyper_7_17_chunk.x2, _hyper_7_17_chunk.x5, _hyper_7_17_chunk.x4
          Sort Method: quicksort 
-         ->  Seq Scan on _hyper_7_15_chunk (actual rows=1 loops=1)
+         ->  Seq Scan on _hyper_7_17_chunk (actual rows=1 loops=1)
    ->  Sort (actual rows=1 loops=1)
-         Sort Key: _hyper_7_16_chunk.x1, _hyper_7_16_chunk.x2, _hyper_7_16_chunk.x5, _hyper_7_16_chunk.x4
+         Sort Key: _hyper_7_19_chunk.x1, _hyper_7_19_chunk.x2, _hyper_7_19_chunk.x5, _hyper_7_19_chunk.x4
          Sort Method: quicksort 
-         ->  Custom Scan (DecompressChunk) on _hyper_7_16_chunk (actual rows=1 loops=1)
+         ->  Custom Scan (DecompressChunk) on _hyper_7_19_chunk (actual rows=1 loops=1)
                ->  Seq Scan on compress_hyper_8_20_chunk (actual rows=1 loops=1)
 (30 rows)
 
@@ -1372,29 +1372,29 @@ SELECT * FROM test3 ORDER BY x1, x2, x5, x4;
          Sort Key: _hyper_7_13_chunk.x1, _hyper_7_13_chunk.x2, _hyper_7_13_chunk.x5, _hyper_7_13_chunk."time"
          Sort Method: quicksort 
          ->  Custom Scan (DecompressChunk) on _hyper_7_13_chunk (actual rows=3 loops=1)
-               ->  Seq Scan on compress_hyper_8_17_chunk (actual rows=2 loops=1)
+               ->  Seq Scan on compress_hyper_8_14_chunk (actual rows=2 loops=1)
    ->  Sort (actual rows=1 loops=1)
          Sort Key: _hyper_7_13_chunk.x1, _hyper_7_13_chunk.x2, _hyper_7_13_chunk.x5, _hyper_7_13_chunk."time"
          Sort Method: quicksort 
          ->  Seq Scan on _hyper_7_13_chunk (actual rows=1 loops=1)
    ->  Sort (actual rows=1 loops=1)
-         Sort Key: _hyper_7_14_chunk.x1, _hyper_7_14_chunk.x2, _hyper_7_14_chunk.x5, _hyper_7_14_chunk."time"
+         Sort Key: _hyper_7_15_chunk.x1, _hyper_7_15_chunk.x2, _hyper_7_15_chunk.x5, _hyper_7_15_chunk."time"
          Sort Method: quicksort 
-         ->  Custom Scan (DecompressChunk) on _hyper_7_14_chunk (actual rows=1 loops=1)
-               ->  Seq Scan on compress_hyper_8_18_chunk (actual rows=1 loops=1)
+         ->  Custom Scan (DecompressChunk) on _hyper_7_15_chunk (actual rows=1 loops=1)
+               ->  Seq Scan on compress_hyper_8_16_chunk (actual rows=1 loops=1)
    ->  Sort (actual rows=3 loops=1)
-         Sort Key: _hyper_7_15_chunk.x1, _hyper_7_15_chunk.x2, _hyper_7_15_chunk.x5, _hyper_7_15_chunk."time"
+         Sort Key: _hyper_7_17_chunk.x1, _hyper_7_17_chunk.x2, _hyper_7_17_chunk.x5, _hyper_7_17_chunk."time"
          Sort Method: quicksort 
-         ->  Custom Scan (DecompressChunk) on _hyper_7_15_chunk (actual rows=3 loops=1)
-               ->  Seq Scan on compress_hyper_8_19_chunk (actual rows=2 loops=1)
+         ->  Custom Scan (DecompressChunk) on _hyper_7_17_chunk (actual rows=3 loops=1)
+               ->  Seq Scan on compress_hyper_8_18_chunk (actual rows=2 loops=1)
    ->  Sort (actual rows=1 loops=1)
-         Sort Key: _hyper_7_15_chunk.x1, _hyper_7_15_chunk.x2, _hyper_7_15_chunk.x5, _hyper_7_15_chunk."time"
+         Sort Key: _hyper_7_17_chunk.x1, _hyper_7_17_chunk.x2, _hyper_7_17_chunk.x5, _hyper_7_17_chunk."time"
          Sort Method: quicksort 
-         ->  Seq Scan on _hyper_7_15_chunk (actual rows=1 loops=1)
+         ->  Seq Scan on _hyper_7_17_chunk (actual rows=1 loops=1)
    ->  Sort (actual rows=1 loops=1)
-         Sort Key: _hyper_7_16_chunk.x1, _hyper_7_16_chunk.x2, _hyper_7_16_chunk.x5, _hyper_7_16_chunk."time"
+         Sort Key: _hyper_7_19_chunk.x1, _hyper_7_19_chunk.x2, _hyper_7_19_chunk.x5, _hyper_7_19_chunk."time"
          Sort Method: quicksort 
-         ->  Custom Scan (DecompressChunk) on _hyper_7_16_chunk (actual rows=1 loops=1)
+         ->  Custom Scan (DecompressChunk) on _hyper_7_19_chunk (actual rows=1 loops=1)
                ->  Seq Scan on compress_hyper_8_20_chunk (actual rows=1 loops=1)
 (30 rows)
 

--- a/tsl/test/expected/merge_compress.out
+++ b/tsl/test/expected/merge_compress.out
@@ -29,7 +29,7 @@ INSERT INTO target (series_id, value, partition_column)
 -- compress chunks
 SELECT count(compress_chunk(c.schema_name|| '.' || c.table_name))
   FROM _timescaledb_catalog.chunk c, _timescaledb_catalog.hypertable ht where
-    c.hypertable_id = ht.id and ht.table_name = 'target' and c.compressed_chunk_id IS NULL;
+    c.hypertable_id = ht.id and ht.table_name = 'target' and c.status & 1 = 0;
  count 
 -------
      4

--- a/tsl/test/expected/modify_exclusion-14.out
+++ b/tsl/test/expected/modify_exclusion-14.out
@@ -1892,8 +1892,8 @@ BEGIN;
    ->  Delete on public.metrics_compressed (actual rows=0 loops=1)
          Delete on _timescaledb_internal._hyper_8_33_chunk metrics_compressed
          Delete on _timescaledb_internal._hyper_8_35_chunk metrics_compressed_1
-         Delete on _timescaledb_internal._hyper_8_36_chunk metrics_compressed_2
-         Delete on _timescaledb_internal._hyper_8_37_chunk metrics_compressed_3
+         Delete on _timescaledb_internal._hyper_8_37_chunk metrics_compressed_2
+         Delete on _timescaledb_internal._hyper_8_39_chunk metrics_compressed_3
          ->  Custom Scan (ChunkAppend) on public.metrics_compressed (actual rows=3 loops=1)
                Startup Exclusion: true
                Runtime Exclusion: false
@@ -1901,10 +1901,10 @@ BEGIN;
                ->  Index Scan using _hyper_8_35_chunk_metrics_compressed_time_idx on _timescaledb_internal._hyper_8_35_chunk metrics_compressed_1 (actual rows=1 loops=1)
                      Output: metrics_compressed_1.tableoid, metrics_compressed_1.ctid
                      Index Cond: (metrics_compressed_1."time" > ('2005-01-01'::cstring)::timestamp with time zone)
-               ->  Index Scan using _hyper_8_36_chunk_metrics_compressed_time_idx on _timescaledb_internal._hyper_8_36_chunk metrics_compressed_2 (actual rows=1 loops=1)
+               ->  Index Scan using _hyper_8_37_chunk_metrics_compressed_time_idx on _timescaledb_internal._hyper_8_37_chunk metrics_compressed_2 (actual rows=1 loops=1)
                      Output: metrics_compressed_2.tableoid, metrics_compressed_2.ctid
                      Index Cond: (metrics_compressed_2."time" > ('2005-01-01'::cstring)::timestamp with time zone)
-               ->  Index Scan using _hyper_8_37_chunk_metrics_compressed_time_idx on _timescaledb_internal._hyper_8_37_chunk metrics_compressed_3 (actual rows=1 loops=1)
+               ->  Index Scan using _hyper_8_39_chunk_metrics_compressed_time_idx on _timescaledb_internal._hyper_8_39_chunk metrics_compressed_3 (actual rows=1 loops=1)
                      Output: metrics_compressed_3.tableoid, metrics_compressed_3.ctid
                      Index Cond: (metrics_compressed_3."time" > ('2005-01-01'::cstring)::timestamp with time zone)
 (19 rows)
@@ -1919,8 +1919,8 @@ BEGIN;
    ->  Update on public.metrics_compressed (actual rows=0 loops=1)
          Update on _timescaledb_internal._hyper_8_33_chunk metrics_compressed
          Update on _timescaledb_internal._hyper_8_35_chunk metrics_compressed_1
-         Update on _timescaledb_internal._hyper_8_36_chunk metrics_compressed_2
-         Update on _timescaledb_internal._hyper_8_37_chunk metrics_compressed_3
+         Update on _timescaledb_internal._hyper_8_37_chunk metrics_compressed_2
+         Update on _timescaledb_internal._hyper_8_39_chunk metrics_compressed_3
          ->  Custom Scan (ChunkAppend) on public.metrics_compressed (actual rows=3 loops=1)
                Output: ('2'::double precision * metrics_compressed.value), metrics_compressed.tableoid, metrics_compressed.ctid
                Startup Exclusion: true
@@ -1929,10 +1929,10 @@ BEGIN;
                ->  Index Scan using _hyper_8_35_chunk_metrics_compressed_time_idx on _timescaledb_internal._hyper_8_35_chunk metrics_compressed_1 (actual rows=1 loops=1)
                      Output: metrics_compressed_1.value, metrics_compressed_1.tableoid, metrics_compressed_1.ctid
                      Index Cond: (metrics_compressed_1."time" > ('2005-01-01'::cstring)::timestamp with time zone)
-               ->  Index Scan using _hyper_8_36_chunk_metrics_compressed_time_idx on _timescaledb_internal._hyper_8_36_chunk metrics_compressed_2 (actual rows=1 loops=1)
+               ->  Index Scan using _hyper_8_37_chunk_metrics_compressed_time_idx on _timescaledb_internal._hyper_8_37_chunk metrics_compressed_2 (actual rows=1 loops=1)
                      Output: metrics_compressed_2.value, metrics_compressed_2.tableoid, metrics_compressed_2.ctid
                      Index Cond: (metrics_compressed_2."time" > ('2005-01-01'::cstring)::timestamp with time zone)
-               ->  Index Scan using _hyper_8_37_chunk_metrics_compressed_time_idx on _timescaledb_internal._hyper_8_37_chunk metrics_compressed_3 (actual rows=1 loops=1)
+               ->  Index Scan using _hyper_8_39_chunk_metrics_compressed_time_idx on _timescaledb_internal._hyper_8_39_chunk metrics_compressed_3 (actual rows=1 loops=1)
                      Output: metrics_compressed_3.value, metrics_compressed_3.tableoid, metrics_compressed_3.ctid
                      Index Cond: (metrics_compressed_3."time" > ('2005-01-01'::cstring)::timestamp with time zone)
 (20 rows)

--- a/tsl/test/expected/modify_exclusion-15.out
+++ b/tsl/test/expected/modify_exclusion-15.out
@@ -1936,8 +1936,8 @@ BEGIN;
    ->  Delete on public.metrics_compressed (actual rows=0 loops=1)
          Delete on _timescaledb_internal._hyper_8_33_chunk metrics_compressed
          Delete on _timescaledb_internal._hyper_8_35_chunk metrics_compressed_1
-         Delete on _timescaledb_internal._hyper_8_36_chunk metrics_compressed_2
-         Delete on _timescaledb_internal._hyper_8_37_chunk metrics_compressed_3
+         Delete on _timescaledb_internal._hyper_8_37_chunk metrics_compressed_2
+         Delete on _timescaledb_internal._hyper_8_39_chunk metrics_compressed_3
          ->  Custom Scan (ChunkAppend) on public.metrics_compressed (actual rows=3 loops=1)
                Startup Exclusion: true
                Runtime Exclusion: false
@@ -1945,10 +1945,10 @@ BEGIN;
                ->  Index Scan using _hyper_8_35_chunk_metrics_compressed_time_idx on _timescaledb_internal._hyper_8_35_chunk metrics_compressed_1 (actual rows=1 loops=1)
                      Output: metrics_compressed_1.tableoid, metrics_compressed_1.ctid
                      Index Cond: (metrics_compressed_1."time" > ('2005-01-01'::cstring)::timestamp with time zone)
-               ->  Index Scan using _hyper_8_36_chunk_metrics_compressed_time_idx on _timescaledb_internal._hyper_8_36_chunk metrics_compressed_2 (actual rows=1 loops=1)
+               ->  Index Scan using _hyper_8_37_chunk_metrics_compressed_time_idx on _timescaledb_internal._hyper_8_37_chunk metrics_compressed_2 (actual rows=1 loops=1)
                      Output: metrics_compressed_2.tableoid, metrics_compressed_2.ctid
                      Index Cond: (metrics_compressed_2."time" > ('2005-01-01'::cstring)::timestamp with time zone)
-               ->  Index Scan using _hyper_8_37_chunk_metrics_compressed_time_idx on _timescaledb_internal._hyper_8_37_chunk metrics_compressed_3 (actual rows=1 loops=1)
+               ->  Index Scan using _hyper_8_39_chunk_metrics_compressed_time_idx on _timescaledb_internal._hyper_8_39_chunk metrics_compressed_3 (actual rows=1 loops=1)
                      Output: metrics_compressed_3.tableoid, metrics_compressed_3.ctid
                      Index Cond: (metrics_compressed_3."time" > ('2005-01-01'::cstring)::timestamp with time zone)
 (19 rows)
@@ -1963,8 +1963,8 @@ BEGIN;
    ->  Update on public.metrics_compressed (actual rows=0 loops=1)
          Update on _timescaledb_internal._hyper_8_33_chunk metrics_compressed
          Update on _timescaledb_internal._hyper_8_35_chunk metrics_compressed_1
-         Update on _timescaledb_internal._hyper_8_36_chunk metrics_compressed_2
-         Update on _timescaledb_internal._hyper_8_37_chunk metrics_compressed_3
+         Update on _timescaledb_internal._hyper_8_37_chunk metrics_compressed_2
+         Update on _timescaledb_internal._hyper_8_39_chunk metrics_compressed_3
          ->  Result (actual rows=3 loops=1)
                Output: ('2'::double precision * metrics_compressed.value), metrics_compressed.tableoid, metrics_compressed.ctid
                ->  Custom Scan (ChunkAppend) on public.metrics_compressed (actual rows=3 loops=1)
@@ -1975,10 +1975,10 @@ BEGIN;
                      ->  Index Scan using _hyper_8_35_chunk_metrics_compressed_time_idx on _timescaledb_internal._hyper_8_35_chunk metrics_compressed_1 (actual rows=1 loops=1)
                            Output: metrics_compressed_1.value, metrics_compressed_1.tableoid, metrics_compressed_1.ctid
                            Index Cond: (metrics_compressed_1."time" > ('2005-01-01'::cstring)::timestamp with time zone)
-                     ->  Index Scan using _hyper_8_36_chunk_metrics_compressed_time_idx on _timescaledb_internal._hyper_8_36_chunk metrics_compressed_2 (actual rows=1 loops=1)
+                     ->  Index Scan using _hyper_8_37_chunk_metrics_compressed_time_idx on _timescaledb_internal._hyper_8_37_chunk metrics_compressed_2 (actual rows=1 loops=1)
                            Output: metrics_compressed_2.value, metrics_compressed_2.tableoid, metrics_compressed_2.ctid
                            Index Cond: (metrics_compressed_2."time" > ('2005-01-01'::cstring)::timestamp with time zone)
-                     ->  Index Scan using _hyper_8_37_chunk_metrics_compressed_time_idx on _timescaledb_internal._hyper_8_37_chunk metrics_compressed_3 (actual rows=1 loops=1)
+                     ->  Index Scan using _hyper_8_39_chunk_metrics_compressed_time_idx on _timescaledb_internal._hyper_8_39_chunk metrics_compressed_3 (actual rows=1 loops=1)
                            Output: metrics_compressed_3.value, metrics_compressed_3.tableoid, metrics_compressed_3.ctid
                            Index Cond: (metrics_compressed_3."time" > ('2005-01-01'::cstring)::timestamp with time zone)
 (22 rows)

--- a/tsl/test/expected/move.out
+++ b/tsl/test/expected/move.out
@@ -482,6 +482,7 @@ SELECT * FROM test.show_indexesp('_timescaledb_internal._hyper%_chunk');
 SELECT * FROM test.show_indexesp('_timescaledb_internal.compress_hyper%_chunk');
                      Table                      |                                         Index                                         |             Columns              | Expr | Unique | Primary | Exclusion | Tablespace  
 ------------------------------------------------+---------------------------------------------------------------------------------------+----------------------------------+------+--------+---------+-----------+-------------
- _timescaledb_internal.compress_hyper_2_3_chunk | _timescaledb_internal.compress_hyper_2_3_chunk__compressed_hypertable_2_location__ts_ | {location,_ts_meta_sequence_num} |      | f      | f       | f         | tablespace1
-(1 row)
+ _timescaledb_internal.compress_hyper_2_3_chunk | _timescaledb_internal.compress_hyper_2_3_chunk__compressed_hypertable_2_location__ts_ | {location,_ts_meta_sequence_num} |      | f      | f       | f         | 
+ _timescaledb_internal.compress_hyper_2_4_chunk | _timescaledb_internal.compress_hyper_2_4_chunk__compressed_hypertable_2_location__ts_ | {location,_ts_meta_sequence_num} |      | f      | f       | f         | tablespace1
+(2 rows)
 

--- a/tsl/test/expected/plan_skip_scan-13.out
+++ b/tsl/test/expected/plan_skip_scan-13.out
@@ -3919,19 +3919,19 @@ SELECT table_name FROM create_hypertable('i3629', 'time');
 
 INSERT INTO i3629 SELECT i, '2020-04-01'::date-10-i from generate_series(1,20) i;
 EXPLAIN (SUMMARY OFF, COSTS OFF) SELECT DISTINCT ON (a) * FROM i3629 WHERE a in (2) ORDER BY a ASC, time DESC;
-                   QUERY PLAN                   
-------------------------------------------------
+                   QUERY PLAN                    
+-------------------------------------------------
  Unique
    ->  Sort
-         Sort Key: _hyper_3_6_chunk."time" DESC
+         Sort Key: _hyper_3_9_chunk."time" DESC
          ->  Append
-               ->  Seq Scan on _hyper_3_6_chunk
-                     Filter: (a = 2)
-               ->  Seq Scan on _hyper_3_7_chunk
-                     Filter: (a = 2)
-               ->  Seq Scan on _hyper_3_8_chunk
-                     Filter: (a = 2)
                ->  Seq Scan on _hyper_3_9_chunk
+                     Filter: (a = 2)
+               ->  Seq Scan on _hyper_3_10_chunk
+                     Filter: (a = 2)
+               ->  Seq Scan on _hyper_3_11_chunk
+                     Filter: (a = 2)
+               ->  Seq Scan on _hyper_3_12_chunk
                      Filter: (a = 2)
 (12 rows)
 
@@ -3959,8 +3959,8 @@ ANALYZE i3720;
                                                       QUERY PLAN                                                      
 ----------------------------------------------------------------------------------------------------------------------
  Unique (actual rows=3 loops=1)
-   ->  Custom Scan (SkipScan) on _hyper_4_10_chunk (actual rows=3 loops=1)
-         ->  Index Only Scan using _hyper_4_10_chunk_i3720_data_time_idx on _hyper_4_10_chunk (actual rows=3 loops=1)
+   ->  Custom Scan (SkipScan) on _hyper_4_13_chunk (actual rows=3 loops=1)
+         ->  Index Only Scan using _hyper_4_13_chunk_i3720_data_time_idx on _hyper_4_13_chunk (actual rows=3 loops=1)
                Index Cond: (data > NULL::text)
                Heap Fetches: 3
 (5 rows)

--- a/tsl/test/expected/plan_skip_scan-14.out
+++ b/tsl/test/expected/plan_skip_scan-14.out
@@ -3917,19 +3917,19 @@ SELECT table_name FROM create_hypertable('i3629', 'time');
 
 INSERT INTO i3629 SELECT i, '2020-04-01'::date-10-i from generate_series(1,20) i;
 EXPLAIN (SUMMARY OFF, COSTS OFF) SELECT DISTINCT ON (a) * FROM i3629 WHERE a in (2) ORDER BY a ASC, time DESC;
-                   QUERY PLAN                   
-------------------------------------------------
+                   QUERY PLAN                    
+-------------------------------------------------
  Unique
    ->  Sort
-         Sort Key: _hyper_3_6_chunk."time" DESC
+         Sort Key: _hyper_3_9_chunk."time" DESC
          ->  Append
-               ->  Seq Scan on _hyper_3_6_chunk
-                     Filter: (a = 2)
-               ->  Seq Scan on _hyper_3_7_chunk
-                     Filter: (a = 2)
-               ->  Seq Scan on _hyper_3_8_chunk
-                     Filter: (a = 2)
                ->  Seq Scan on _hyper_3_9_chunk
+                     Filter: (a = 2)
+               ->  Seq Scan on _hyper_3_10_chunk
+                     Filter: (a = 2)
+               ->  Seq Scan on _hyper_3_11_chunk
+                     Filter: (a = 2)
+               ->  Seq Scan on _hyper_3_12_chunk
                      Filter: (a = 2)
 (12 rows)
 
@@ -3957,8 +3957,8 @@ ANALYZE i3720;
                                                       QUERY PLAN                                                      
 ----------------------------------------------------------------------------------------------------------------------
  Unique (actual rows=3 loops=1)
-   ->  Custom Scan (SkipScan) on _hyper_4_10_chunk (actual rows=3 loops=1)
-         ->  Index Only Scan using _hyper_4_10_chunk_i3720_data_time_idx on _hyper_4_10_chunk (actual rows=3 loops=1)
+   ->  Custom Scan (SkipScan) on _hyper_4_13_chunk (actual rows=3 loops=1)
+         ->  Index Only Scan using _hyper_4_13_chunk_i3720_data_time_idx on _hyper_4_13_chunk (actual rows=3 loops=1)
                Index Cond: (data > NULL::text)
                Heap Fetches: 3
 (5 rows)

--- a/tsl/test/expected/plan_skip_scan-15.out
+++ b/tsl/test/expected/plan_skip_scan-15.out
@@ -3917,19 +3917,19 @@ SELECT table_name FROM create_hypertable('i3629', 'time');
 
 INSERT INTO i3629 SELECT i, '2020-04-01'::date-10-i from generate_series(1,20) i;
 EXPLAIN (SUMMARY OFF, COSTS OFF) SELECT DISTINCT ON (a) * FROM i3629 WHERE a in (2) ORDER BY a ASC, time DESC;
-                   QUERY PLAN                   
-------------------------------------------------
+                   QUERY PLAN                    
+-------------------------------------------------
  Unique
    ->  Sort
-         Sort Key: _hyper_3_6_chunk."time" DESC
+         Sort Key: _hyper_3_9_chunk."time" DESC
          ->  Append
-               ->  Seq Scan on _hyper_3_6_chunk
-                     Filter: (a = 2)
-               ->  Seq Scan on _hyper_3_7_chunk
-                     Filter: (a = 2)
-               ->  Seq Scan on _hyper_3_8_chunk
-                     Filter: (a = 2)
                ->  Seq Scan on _hyper_3_9_chunk
+                     Filter: (a = 2)
+               ->  Seq Scan on _hyper_3_10_chunk
+                     Filter: (a = 2)
+               ->  Seq Scan on _hyper_3_11_chunk
+                     Filter: (a = 2)
+               ->  Seq Scan on _hyper_3_12_chunk
                      Filter: (a = 2)
 (12 rows)
 
@@ -3957,8 +3957,8 @@ ANALYZE i3720;
                                                       QUERY PLAN                                                      
 ----------------------------------------------------------------------------------------------------------------------
  Unique (actual rows=3 loops=1)
-   ->  Custom Scan (SkipScan) on _hyper_4_10_chunk (actual rows=3 loops=1)
-         ->  Index Only Scan using _hyper_4_10_chunk_i3720_data_time_idx on _hyper_4_10_chunk (actual rows=3 loops=1)
+   ->  Custom Scan (SkipScan) on _hyper_4_13_chunk (actual rows=3 loops=1)
+         ->  Index Only Scan using _hyper_4_13_chunk_i3720_data_time_idx on _hyper_4_13_chunk (actual rows=3 loops=1)
                Index Cond: (data > NULL::text)
                Heap Fetches: 3
 (5 rows)

--- a/tsl/test/expected/recompress_chunk_segmentwise.out
+++ b/tsl/test/expected/recompress_chunk_segmentwise.out
@@ -318,7 +318,7 @@ select show_chunks as chunk_to_compress_prep from show_chunks('mytab_prep') limi
 SELECT compress_chunk(:'chunk_to_compress_prep'); -- the output of the prepared plan would change before and after compress
              compress_chunk              
 -----------------------------------------
- _timescaledb_internal._hyper_9_10_chunk
+ _timescaledb_internal._hyper_9_11_chunk
 (1 row)
 
 INSERT INTO mytab_prep VALUES ('2023-01-01'::timestamptz, 2, 3, 2);
@@ -327,9 +327,9 @@ EXPLAIN (COSTS OFF) EXECUTE p1;
                         QUERY PLAN                        
 ----------------------------------------------------------
  Append
-   ->  Custom Scan (DecompressChunk) on _hyper_9_10_chunk
-         ->  Seq Scan on compress_hyper_10_11_chunk
-   ->  Seq Scan on _hyper_9_10_chunk
+   ->  Custom Scan (DecompressChunk) on _hyper_9_11_chunk
+         ->  Seq Scan on compress_hyper_10_12_chunk
+   ->  Seq Scan on _hyper_9_11_chunk
 (4 rows)
 
 EXECUTE p1;
@@ -345,8 +345,8 @@ CALL recompress_chunk(:'chunk_to_compress_prep');
 EXPLAIN (COSTS OFF) EXECUTE p1;
                      QUERY PLAN                     
 ----------------------------------------------------
- Custom Scan (DecompressChunk) on _hyper_9_10_chunk
-   ->  Seq Scan on compress_hyper_10_11_chunk
+ Custom Scan (DecompressChunk) on _hyper_9_11_chunk
+   ->  Seq Scan on compress_hyper_10_12_chunk
 (2 rows)
 
 EXECUTE p1;
@@ -377,7 +377,7 @@ alter table mytab set (timescaledb.compress, timescaledb.compress_segmentby = 'a
 select compress_chunk(show_chunks('mytab'));
               compress_chunk              
 ------------------------------------------
- _timescaledb_internal._hyper_11_12_chunk
+ _timescaledb_internal._hyper_11_13_chunk
 (1 row)
 
 select compressed_chunk_name as compressed_chunk_name_before_recompression from compressed_chunk_info_view where hypertable_name = 'mytab' \gset
@@ -388,13 +388,13 @@ select compressed_chunk_name as compressed_chunk_name_after_recompression from c
 select :'compressed_chunk_name_before_recompression' as before_segmentwise_recompression, :'compressed_chunk_name_after_recompression' as after_segmentwise_recompression;
  before_segmentwise_recompression | after_segmentwise_recompression 
 ----------------------------------+---------------------------------
- compress_hyper_12_13_chunk       | compress_hyper_12_13_chunk
+ compress_hyper_12_14_chunk       | compress_hyper_12_14_chunk
 (1 row)
 
 SELECT decompress_chunk(show_chunks('mytab'));
              decompress_chunk             
 ------------------------------------------
- _timescaledb_internal._hyper_11_12_chunk
+ _timescaledb_internal._hyper_11_13_chunk
 (1 row)
 
 alter table mytab set (timescaledb.compress = false);
@@ -402,7 +402,7 @@ alter table mytab set (timescaledb.compress);
 select compress_chunk(show_chunks('mytab'));
               compress_chunk              
 ------------------------------------------
- _timescaledb_internal._hyper_11_12_chunk
+ _timescaledb_internal._hyper_11_13_chunk
 (1 row)
 
 select compressed_chunk_name as compressed_chunk_name_before_recompression from compressed_chunk_info_view where hypertable_name = 'mytab' \gset
@@ -413,7 +413,7 @@ select compressed_chunk_name as compressed_chunk_name_after_recompression from c
 select :'compressed_chunk_name_before_recompression' as before_recompression, :'compressed_chunk_name_after_recompression' as after_recompression;
     before_recompression    |    after_recompression     
 ----------------------------+----------------------------
- compress_hyper_13_14_chunk | compress_hyper_13_15_chunk
+ compress_hyper_13_15_chunk | compress_hyper_13_15_chunk
 (1 row)
 
 -- check behavior with NULL values in segmentby columns

--- a/tsl/test/expected/telemetry_stats-13.out
+++ b/tsl/test/expected/telemetry_stats-13.out
@@ -760,10 +760,10 @@ SELECT compress_chunk(c)
 FROM show_chunks('disthyper') c ORDER BY c LIMIT 4;
                 compress_chunk                
 ----------------------------------------------
- _timescaledb_internal._dist_hyper_6_19_chunk
- _timescaledb_internal._dist_hyper_6_20_chunk
- _timescaledb_internal._dist_hyper_6_21_chunk
- _timescaledb_internal._dist_hyper_6_22_chunk
+ _timescaledb_internal._dist_hyper_6_25_chunk
+ _timescaledb_internal._dist_hyper_6_26_chunk
+ _timescaledb_internal._dist_hyper_6_27_chunk
+ _timescaledb_internal._dist_hyper_6_28_chunk
 (4 rows)
 
 ANALYZE disthyper;

--- a/tsl/test/expected/telemetry_stats-14.out
+++ b/tsl/test/expected/telemetry_stats-14.out
@@ -760,10 +760,10 @@ SELECT compress_chunk(c)
 FROM show_chunks('disthyper') c ORDER BY c LIMIT 4;
                 compress_chunk                
 ----------------------------------------------
- _timescaledb_internal._dist_hyper_6_19_chunk
- _timescaledb_internal._dist_hyper_6_20_chunk
- _timescaledb_internal._dist_hyper_6_21_chunk
- _timescaledb_internal._dist_hyper_6_22_chunk
+ _timescaledb_internal._dist_hyper_6_25_chunk
+ _timescaledb_internal._dist_hyper_6_26_chunk
+ _timescaledb_internal._dist_hyper_6_27_chunk
+ _timescaledb_internal._dist_hyper_6_28_chunk
 (4 rows)
 
 ANALYZE disthyper;

--- a/tsl/test/expected/telemetry_stats-15.out
+++ b/tsl/test/expected/telemetry_stats-15.out
@@ -760,10 +760,10 @@ SELECT compress_chunk(c)
 FROM show_chunks('disthyper') c ORDER BY c LIMIT 4;
                 compress_chunk                
 ----------------------------------------------
- _timescaledb_internal._dist_hyper_6_19_chunk
- _timescaledb_internal._dist_hyper_6_20_chunk
- _timescaledb_internal._dist_hyper_6_21_chunk
- _timescaledb_internal._dist_hyper_6_22_chunk
+ _timescaledb_internal._dist_hyper_6_25_chunk
+ _timescaledb_internal._dist_hyper_6_26_chunk
+ _timescaledb_internal._dist_hyper_6_27_chunk
+ _timescaledb_internal._dist_hyper_6_28_chunk
 (4 rows)
 
 ANALYZE disthyper;

--- a/tsl/test/expected/transparent_decompression-13.out
+++ b/tsl/test/expected/transparent_decompression-13.out
@@ -254,9 +254,9 @@ LIMIT 5;
                ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_3_chunk (never executed)
                      Output: _hyper_1_3_chunk."time", _hyper_1_3_chunk.device_id, _hyper_1_3_chunk.device_id_peer, _hyper_1_3_chunk.v0, _hyper_1_3_chunk.v1, _hyper_1_3_chunk.v2, _hyper_1_3_chunk.v3
                      Bulk Decompression: true
-                     ->  Seq Scan on _timescaledb_internal.compress_hyper_5_16_chunk (never executed)
-                           Output: compress_hyper_5_16_chunk."time", compress_hyper_5_16_chunk.device_id, compress_hyper_5_16_chunk.device_id_peer, compress_hyper_5_16_chunk.v0, compress_hyper_5_16_chunk.v1, compress_hyper_5_16_chunk.v2, compress_hyper_5_16_chunk.v3, compress_hyper_5_16_chunk._ts_meta_count, compress_hyper_5_16_chunk._ts_meta_sequence_num, compress_hyper_5_16_chunk._ts_meta_min_3, compress_hyper_5_16_chunk._ts_meta_max_3, compress_hyper_5_16_chunk._ts_meta_min_1, compress_hyper_5_16_chunk._ts_meta_max_1, compress_hyper_5_16_chunk._ts_meta_min_2, compress_hyper_5_16_chunk._ts_meta_max_2
-                           Filter: (compress_hyper_5_16_chunk.device_id = 1)
+                     ->  Seq Scan on _timescaledb_internal.compress_hyper_5_17_chunk (never executed)
+                           Output: compress_hyper_5_17_chunk."time", compress_hyper_5_17_chunk.device_id, compress_hyper_5_17_chunk.device_id_peer, compress_hyper_5_17_chunk.v0, compress_hyper_5_17_chunk.v1, compress_hyper_5_17_chunk.v2, compress_hyper_5_17_chunk.v3, compress_hyper_5_17_chunk._ts_meta_count, compress_hyper_5_17_chunk._ts_meta_sequence_num, compress_hyper_5_17_chunk._ts_meta_min_3, compress_hyper_5_17_chunk._ts_meta_max_3, compress_hyper_5_17_chunk._ts_meta_min_1, compress_hyper_5_17_chunk._ts_meta_max_1, compress_hyper_5_17_chunk._ts_meta_min_2, compress_hyper_5_17_chunk._ts_meta_max_2
+                           Filter: (compress_hyper_5_17_chunk.device_id = 1)
 (30 rows)
 
 -- test RECORD by itself
@@ -283,7 +283,7 @@ ORDER BY time;
          Sort Key: _hyper_1_3_chunk."time"
          Sort Method: quicksort 
          ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk (actual rows=504 loops=1)
-               ->  Seq Scan on compress_hyper_5_16_chunk (actual rows=1 loops=1)
+               ->  Seq Scan on compress_hyper_5_17_chunk (actual rows=1 loops=1)
                      Filter: (device_id = 1)
                      Rows Removed by Filter: 4
 (19 rows)
@@ -322,7 +322,7 @@ ORDER BY time,
                Sort Key: _hyper_1_3_chunk."time"
                Sort Method: quicksort 
                ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk (actual rows=1008 loops=1)
-                     ->  Seq Scan on compress_hyper_5_16_chunk (actual rows=2 loops=1)
+                     ->  Seq Scan on compress_hyper_5_17_chunk (actual rows=2 loops=1)
                            Filter: (device_id = ANY ('{1,2}'::integer[]))
                            Rows Removed by Filter: 3
 (23 rows)
@@ -338,7 +338,7 @@ FROM :TEST_TABLE;
          ->  Seq Scan on compress_hyper_5_15_chunk (actual rows=5 loops=1)
    ->  Seq Scan on _hyper_1_2_chunk (actual rows=2520 loops=1)
    ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk (actual rows=2520 loops=1)
-         ->  Seq Scan on compress_hyper_5_16_chunk (actual rows=5 loops=1)
+         ->  Seq Scan on compress_hyper_5_17_chunk (actual rows=5 loops=1)
 (6 rows)
 
 -- test empty resultset
@@ -357,7 +357,7 @@ WHERE device_id < 0;
          Filter: (device_id < 0)
          Rows Removed by Filter: 2520
    ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk (actual rows=0 loops=1)
-         ->  Seq Scan on compress_hyper_5_16_chunk (actual rows=0 loops=1)
+         ->  Seq Scan on compress_hyper_5_17_chunk (actual rows=0 loops=1)
                Filter: (device_id < 0)
                Rows Removed by Filter: 5
 (12 rows)
@@ -374,7 +374,7 @@ FROM :TEST_TABLE;
                ->  Seq Scan on compress_hyper_5_15_chunk (actual rows=5 loops=1)
          ->  Seq Scan on _hyper_1_2_chunk (actual rows=2520 loops=1)
          ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk (actual rows=2520 loops=1)
-               ->  Seq Scan on compress_hyper_5_16_chunk (actual rows=5 loops=1)
+               ->  Seq Scan on compress_hyper_5_17_chunk (actual rows=5 loops=1)
 (7 rows)
 
 -- test constraints not present in targetlist
@@ -397,7 +397,7 @@ ORDER BY v1;
                Filter: (device_id = 1)
                Rows Removed by Filter: 2016
          ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk (actual rows=504 loops=1)
-               ->  Seq Scan on compress_hyper_5_16_chunk (actual rows=1 loops=1)
+               ->  Seq Scan on compress_hyper_5_17_chunk (actual rows=1 loops=1)
                      Filter: (device_id = 1)
                      Rows Removed by Filter: 4
 (15 rows)
@@ -422,7 +422,7 @@ ORDER BY v1;
                Filter: (device_id = 1)
                Rows Removed by Filter: 2016
          ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk (actual rows=504 loops=1)
-               ->  Seq Scan on compress_hyper_5_16_chunk (actual rows=1 loops=1)
+               ->  Seq Scan on compress_hyper_5_17_chunk (actual rows=1 loops=1)
                      Filter: (device_id = 1)
                      Rows Removed by Filter: 4
 (15 rows)
@@ -443,7 +443,7 @@ WHERE device_id = 1;
          Filter: (device_id = 1)
          Rows Removed by Filter: 2016
    ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk (actual rows=504 loops=1)
-         ->  Seq Scan on compress_hyper_5_16_chunk (actual rows=1 loops=1)
+         ->  Seq Scan on compress_hyper_5_17_chunk (actual rows=1 loops=1)
                Filter: (device_id = 1)
                Rows Removed by Filter: 4
 (12 rows)
@@ -493,8 +493,8 @@ ORDER BY time,
                      Filter: (_hyper_1_3_chunk.v3 > '10'::double precision)
                      Rows Removed by Filter: 2520
                      Bulk Decompression: true
-                     ->  Seq Scan on _timescaledb_internal.compress_hyper_5_16_chunk (actual rows=5 loops=1)
-                           Output: compress_hyper_5_16_chunk."time", compress_hyper_5_16_chunk.device_id, compress_hyper_5_16_chunk.device_id_peer, compress_hyper_5_16_chunk.v0, compress_hyper_5_16_chunk.v1, compress_hyper_5_16_chunk.v2, compress_hyper_5_16_chunk.v3, compress_hyper_5_16_chunk._ts_meta_count, compress_hyper_5_16_chunk._ts_meta_sequence_num, compress_hyper_5_16_chunk._ts_meta_min_3, compress_hyper_5_16_chunk._ts_meta_max_3, compress_hyper_5_16_chunk._ts_meta_min_1, compress_hyper_5_16_chunk._ts_meta_max_1, compress_hyper_5_16_chunk._ts_meta_min_2, compress_hyper_5_16_chunk._ts_meta_max_2
+                     ->  Seq Scan on _timescaledb_internal.compress_hyper_5_17_chunk (actual rows=5 loops=1)
+                           Output: compress_hyper_5_17_chunk."time", compress_hyper_5_17_chunk.device_id, compress_hyper_5_17_chunk.device_id_peer, compress_hyper_5_17_chunk.v0, compress_hyper_5_17_chunk.v1, compress_hyper_5_17_chunk.v2, compress_hyper_5_17_chunk.v3, compress_hyper_5_17_chunk._ts_meta_count, compress_hyper_5_17_chunk._ts_meta_sequence_num, compress_hyper_5_17_chunk._ts_meta_min_3, compress_hyper_5_17_chunk._ts_meta_max_3, compress_hyper_5_17_chunk._ts_meta_min_1, compress_hyper_5_17_chunk._ts_meta_max_1, compress_hyper_5_17_chunk._ts_meta_min_2, compress_hyper_5_17_chunk._ts_meta_max_2
 (35 rows)
 
 -- device_id constraint should be pushed down
@@ -522,7 +522,7 @@ LIMIT 10;
          ->  Sort (never executed)
                Sort Key: _hyper_1_3_chunk."time"
                ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk (never executed)
-                     ->  Seq Scan on compress_hyper_5_16_chunk (never executed)
+                     ->  Seq Scan on compress_hyper_5_17_chunk (never executed)
                            Filter: (device_id = 1)
 (17 rows)
 
@@ -554,7 +554,7 @@ LIMIT 10;
                ->  Sort (never executed)
                      Sort Key: _hyper_1_3_chunk."time"
                      ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk (never executed)
-                           ->  Seq Scan on compress_hyper_5_16_chunk (never executed)
+                           ->  Seq Scan on compress_hyper_5_17_chunk (never executed)
                                  Filter: (device_id IS NOT NULL)
 (20 rows)
 
@@ -580,7 +580,7 @@ LIMIT 10;
                      Filter: (device_id IS NULL)
                      Rows Removed by Filter: 2520
                ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk (actual rows=0 loops=1)
-                     ->  Seq Scan on compress_hyper_5_16_chunk (actual rows=0 loops=1)
+                     ->  Seq Scan on compress_hyper_5_17_chunk (actual rows=0 loops=1)
                            Filter: (device_id IS NULL)
                            Rows Removed by Filter: 5
 (16 rows)
@@ -614,7 +614,7 @@ LIMIT 10;
                ->  Sort (never executed)
                      Sort Key: _hyper_1_3_chunk."time"
                      ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk (never executed)
-                           ->  Seq Scan on compress_hyper_5_16_chunk (never executed)
+                           ->  Seq Scan on compress_hyper_5_17_chunk (never executed)
                                  Filter: (device_id = ANY ('{1,2}'::integer[]))
 (21 rows)
 
@@ -643,7 +643,7 @@ LIMIT 10;
          ->  Sort (never executed)
                Sort Key: _hyper_1_3_chunk."time"
                ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk (never executed)
-                     ->  Seq Scan on compress_hyper_5_16_chunk (never executed)
+                     ->  Seq Scan on compress_hyper_5_17_chunk (never executed)
                            Filter: (device_id = 1)
 (17 rows)
 
@@ -678,7 +678,7 @@ LIMIT 10;
                      Sort Key: _hyper_1_3_chunk."time"
                      Sort Method: quicksort 
                      ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk (actual rows=0 loops=1)
-                           ->  Seq Scan on compress_hyper_5_16_chunk (actual rows=0 loops=1)
+                           ->  Seq Scan on compress_hyper_5_17_chunk (actual rows=0 loops=1)
                                  Filter: (device_id = device_id_peer)
                                  Rows Removed by Filter: 5
 (24 rows)
@@ -710,7 +710,7 @@ LIMIT 10;
                ->  Sort (never executed)
                      Sort Key: _hyper_1_3_chunk."time"
                      ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk (never executed)
-                           ->  Seq Scan on compress_hyper_5_16_chunk (never executed)
+                           ->  Seq Scan on compress_hyper_5_17_chunk (never executed)
                                  Filter: (device_id_peer < device_id)
 (20 rows)
 
@@ -739,7 +739,7 @@ LIMIT 10;
          ->  Sort (never executed)
                Sort Key: _hyper_1_3_chunk."time"
                ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk (never executed)
-                     ->  Seq Scan on compress_hyper_5_16_chunk (never executed)
+                     ->  Seq Scan on compress_hyper_5_17_chunk (never executed)
                            Filter: (device_id = 3)
 (17 rows)
 
@@ -771,7 +771,7 @@ LIMIT 10;
                Sort Key: _hyper_1_3_chunk."time"
                ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk (never executed)
                      Filter: (device_id = length("substring"(version(), 1, 3)))
-                     ->  Seq Scan on compress_hyper_5_16_chunk (never executed)
+                     ->  Seq Scan on compress_hyper_5_17_chunk (never executed)
 (18 rows)
 
 --
@@ -868,7 +868,7 @@ LIMIT 10;
                      Sort Key: _hyper_1_3_chunk."time"
                      ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk (never executed)
                            Filter: ("time" >= 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
-                           ->  Seq Scan on compress_hyper_5_16_chunk (never executed)
+                           ->  Seq Scan on compress_hyper_5_17_chunk (never executed)
                                  Filter: (_ts_meta_max_3 >= 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
 (23 rows)
 
@@ -902,7 +902,7 @@ LIMIT 10;
                      Sort Key: _hyper_1_3_chunk."time"
                      ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk (never executed)
                            Filter: ("time" > 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
-                           ->  Seq Scan on compress_hyper_5_16_chunk (never executed)
+                           ->  Seq Scan on compress_hyper_5_17_chunk (never executed)
                                  Filter: (_ts_meta_max_3 > 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
 (23 rows)
 
@@ -936,7 +936,7 @@ LIMIT 10;
                      Sort Key: _hyper_1_3_chunk."time"
                      ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk (never executed)
                            Filter: ('Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone < "time")
-                           ->  Seq Scan on compress_hyper_5_16_chunk (never executed)
+                           ->  Seq Scan on compress_hyper_5_17_chunk (never executed)
                                  Filter: (_ts_meta_max_3 > 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
 (23 rows)
 
@@ -972,7 +972,7 @@ LIMIT 10;
                      Sort Key: _hyper_1_3_chunk."time"
                      ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk (never executed)
                            Filter: (v0 < 1)
-                           ->  Seq Scan on compress_hyper_5_16_chunk (never executed)
+                           ->  Seq Scan on compress_hyper_5_17_chunk (never executed)
                                  Filter: (_ts_meta_min_1 < 1)
 (24 rows)
 
@@ -1006,7 +1006,7 @@ LIMIT 10;
                      Sort Key: _hyper_1_3_chunk."time"
                      ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk (never executed)
                            Filter: (v0 < device_id)
-                           ->  Seq Scan on compress_hyper_5_16_chunk (never executed)
+                           ->  Seq Scan on compress_hyper_5_17_chunk (never executed)
                                  Filter: (_ts_meta_min_1 < device_id)
 (23 rows)
 
@@ -1039,7 +1039,7 @@ LIMIT 10;
                      Sort Key: _hyper_1_3_chunk."time"
                      ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk (never executed)
                            Filter: (device_id < v0)
-                           ->  Seq Scan on compress_hyper_5_16_chunk (never executed)
+                           ->  Seq Scan on compress_hyper_5_17_chunk (never executed)
                                  Filter: (_ts_meta_max_1 > device_id)
 (22 rows)
 
@@ -1075,7 +1075,7 @@ LIMIT 10;
                      Sort Method: quicksort 
                      ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk (actual rows=0 loops=1)
                            Filter: (v1 = device_id)
-                           ->  Seq Scan on compress_hyper_5_16_chunk (actual rows=0 loops=1)
+                           ->  Seq Scan on compress_hyper_5_17_chunk (actual rows=0 loops=1)
                                  Filter: ((_ts_meta_min_2 <= device_id) AND (_ts_meta_max_2 >= device_id))
                                  Rows Removed by Filter: 5
 (26 rows)
@@ -1113,7 +1113,7 @@ LIMIT 10;
                      ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk (actual rows=0 loops=1)
                            Filter: (v0 = v1)
                            Rows Removed by Filter: 2520
-                           ->  Seq Scan on compress_hyper_5_16_chunk (actual rows=5 loops=1)
+                           ->  Seq Scan on compress_hyper_5_17_chunk (actual rows=5 loops=1)
 (24 rows)
 
 --pushdown of quals on order by and segment by cols anded together
@@ -1158,9 +1158,9 @@ LIMIT 10;
                      Output: _hyper_1_3_chunk."time", _hyper_1_3_chunk.device_id, _hyper_1_3_chunk.device_id_peer, _hyper_1_3_chunk.v0, _hyper_1_3_chunk.v1, _hyper_1_3_chunk.v2, _hyper_1_3_chunk.v3
                      Filter: (_hyper_1_3_chunk."time" > 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
                      Bulk Decompression: true
-                     ->  Seq Scan on _timescaledb_internal.compress_hyper_5_16_chunk (never executed)
-                           Output: compress_hyper_5_16_chunk."time", compress_hyper_5_16_chunk.device_id, compress_hyper_5_16_chunk.device_id_peer, compress_hyper_5_16_chunk.v0, compress_hyper_5_16_chunk.v1, compress_hyper_5_16_chunk.v2, compress_hyper_5_16_chunk.v3, compress_hyper_5_16_chunk._ts_meta_count, compress_hyper_5_16_chunk._ts_meta_sequence_num, compress_hyper_5_16_chunk._ts_meta_min_3, compress_hyper_5_16_chunk._ts_meta_max_3, compress_hyper_5_16_chunk._ts_meta_min_1, compress_hyper_5_16_chunk._ts_meta_max_1, compress_hyper_5_16_chunk._ts_meta_min_2, compress_hyper_5_16_chunk._ts_meta_max_2
-                           Filter: ((compress_hyper_5_16_chunk._ts_meta_max_3 > 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone) AND (compress_hyper_5_16_chunk.device_id = 1))
+                     ->  Seq Scan on _timescaledb_internal.compress_hyper_5_17_chunk (never executed)
+                           Output: compress_hyper_5_17_chunk."time", compress_hyper_5_17_chunk.device_id, compress_hyper_5_17_chunk.device_id_peer, compress_hyper_5_17_chunk.v0, compress_hyper_5_17_chunk.v1, compress_hyper_5_17_chunk.v2, compress_hyper_5_17_chunk.v3, compress_hyper_5_17_chunk._ts_meta_count, compress_hyper_5_17_chunk._ts_meta_sequence_num, compress_hyper_5_17_chunk._ts_meta_min_3, compress_hyper_5_17_chunk._ts_meta_max_3, compress_hyper_5_17_chunk._ts_meta_min_1, compress_hyper_5_17_chunk._ts_meta_max_1, compress_hyper_5_17_chunk._ts_meta_min_2, compress_hyper_5_17_chunk._ts_meta_max_2
+                           Filter: ((compress_hyper_5_17_chunk._ts_meta_max_3 > 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone) AND (compress_hyper_5_17_chunk.device_id = 1))
 (34 rows)
 
 --pushdown of quals on order by and segment by cols or together (not pushed down)
@@ -1194,7 +1194,7 @@ LIMIT 10;
                      Sort Key: _hyper_1_3_chunk."time"
                      ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk (never executed)
                            Filter: (("time" > 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone) OR (device_id = 1))
-                           ->  Seq Scan on compress_hyper_5_16_chunk (never executed)
+                           ->  Seq Scan on compress_hyper_5_17_chunk (never executed)
 (21 rows)
 
 --functions not yet optimized
@@ -1227,7 +1227,7 @@ LIMIT 10;
                      Sort Key: _hyper_1_3_chunk."time"
                      ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk (never executed)
                            Filter: ("time" < now())
-                           ->  Seq Scan on compress_hyper_5_16_chunk (never executed)
+                           ->  Seq Scan on compress_hyper_5_17_chunk (never executed)
 (21 rows)
 
 -- test sort optimization interaction
@@ -1245,7 +1245,7 @@ LIMIT 10;
                Sort Key: _hyper_1_3_chunk."time" DESC
                Sort Method: top-N heapsort 
                ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk (actual rows=2520 loops=1)
-                     ->  Seq Scan on compress_hyper_5_16_chunk (actual rows=5 loops=1)
+                     ->  Seq Scan on compress_hyper_5_17_chunk (actual rows=5 loops=1)
          ->  Index Only Scan using _hyper_1_2_chunk_metrics_time_idx on _hyper_1_2_chunk (never executed)
                Heap Fetches: 0
          ->  Sort (never executed)
@@ -1274,7 +1274,7 @@ LIMIT 10;
                      Sort Key: _hyper_1_3_chunk."time" DESC
                      Sort Method: quicksort 
                      ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk (actual rows=2520 loops=1)
-                           ->  Seq Scan on compress_hyper_5_16_chunk (actual rows=5 loops=1)
+                           ->  Seq Scan on compress_hyper_5_17_chunk (actual rows=5 loops=1)
                ->  Index Scan using _hyper_1_2_chunk_metrics_time_idx on _hyper_1_2_chunk (never executed)
                ->  Sort (never executed)
                      Sort Key: _hyper_1_1_chunk."time" DESC
@@ -1300,7 +1300,7 @@ LIMIT 10;
                      ->  Seq Scan on compress_hyper_5_15_chunk (actual rows=5 loops=1)
                ->  Seq Scan on _hyper_1_2_chunk (actual rows=2520 loops=1)
                ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk (actual rows=2520 loops=1)
-                     ->  Seq Scan on compress_hyper_5_16_chunk (actual rows=5 loops=1)
+                     ->  Seq Scan on compress_hyper_5_17_chunk (actual rows=5 loops=1)
 (10 rows)
 
 --
@@ -1336,9 +1336,9 @@ ORDER BY time,
                      Output: _hyper_1_3_chunk."time", _hyper_1_3_chunk.device_id, _hyper_1_3_chunk.device_id_peer, _hyper_1_3_chunk.v0, _hyper_1_3_chunk.v1, _hyper_1_3_chunk.v2, _hyper_1_3_chunk.v3
                      Filter: (_hyper_1_3_chunk."time" > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
                      Bulk Decompression: true
-                     ->  Seq Scan on _timescaledb_internal.compress_hyper_5_16_chunk (actual rows=5 loops=1)
-                           Output: compress_hyper_5_16_chunk."time", compress_hyper_5_16_chunk.device_id, compress_hyper_5_16_chunk.device_id_peer, compress_hyper_5_16_chunk.v0, compress_hyper_5_16_chunk.v1, compress_hyper_5_16_chunk.v2, compress_hyper_5_16_chunk.v3, compress_hyper_5_16_chunk._ts_meta_count, compress_hyper_5_16_chunk._ts_meta_sequence_num, compress_hyper_5_16_chunk._ts_meta_min_3, compress_hyper_5_16_chunk._ts_meta_max_3, compress_hyper_5_16_chunk._ts_meta_min_1, compress_hyper_5_16_chunk._ts_meta_max_1, compress_hyper_5_16_chunk._ts_meta_min_2, compress_hyper_5_16_chunk._ts_meta_max_2
-                           Filter: (compress_hyper_5_16_chunk._ts_meta_max_3 > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
+                     ->  Seq Scan on _timescaledb_internal.compress_hyper_5_17_chunk (actual rows=5 loops=1)
+                           Output: compress_hyper_5_17_chunk."time", compress_hyper_5_17_chunk.device_id, compress_hyper_5_17_chunk.device_id_peer, compress_hyper_5_17_chunk.v0, compress_hyper_5_17_chunk.v1, compress_hyper_5_17_chunk.v2, compress_hyper_5_17_chunk.v3, compress_hyper_5_17_chunk._ts_meta_count, compress_hyper_5_17_chunk._ts_meta_sequence_num, compress_hyper_5_17_chunk._ts_meta_min_3, compress_hyper_5_17_chunk._ts_meta_max_3, compress_hyper_5_17_chunk._ts_meta_min_1, compress_hyper_5_17_chunk._ts_meta_max_1, compress_hyper_5_17_chunk._ts_meta_min_2, compress_hyper_5_17_chunk._ts_meta_max_2
+                           Filter: (compress_hyper_5_17_chunk._ts_meta_max_3 > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
 (24 rows)
 
 -- should produce ordered path
@@ -1367,9 +1367,9 @@ ORDER BY device_id,
          Output: _hyper_1_3_chunk."time", _hyper_1_3_chunk.device_id, _hyper_1_3_chunk.device_id_peer, _hyper_1_3_chunk.v0, _hyper_1_3_chunk.v1, _hyper_1_3_chunk.v2, _hyper_1_3_chunk.v3
          Filter: (_hyper_1_3_chunk."time" > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
          Bulk Decompression: true
-         ->  Index Scan using compress_hyper_5_16_chunk__compressed_hypertable_5_device_id_de on _timescaledb_internal.compress_hyper_5_16_chunk (actual rows=5 loops=1)
-               Output: compress_hyper_5_16_chunk."time", compress_hyper_5_16_chunk.device_id, compress_hyper_5_16_chunk.device_id_peer, compress_hyper_5_16_chunk.v0, compress_hyper_5_16_chunk.v1, compress_hyper_5_16_chunk.v2, compress_hyper_5_16_chunk.v3, compress_hyper_5_16_chunk._ts_meta_count, compress_hyper_5_16_chunk._ts_meta_sequence_num, compress_hyper_5_16_chunk._ts_meta_min_3, compress_hyper_5_16_chunk._ts_meta_max_3, compress_hyper_5_16_chunk._ts_meta_min_1, compress_hyper_5_16_chunk._ts_meta_max_1, compress_hyper_5_16_chunk._ts_meta_min_2, compress_hyper_5_16_chunk._ts_meta_max_2
-               Filter: (compress_hyper_5_16_chunk._ts_meta_max_3 > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
+         ->  Index Scan using compress_hyper_5_17_chunk__compressed_hypertable_5_device_id_de on _timescaledb_internal.compress_hyper_5_17_chunk (actual rows=5 loops=1)
+               Output: compress_hyper_5_17_chunk."time", compress_hyper_5_17_chunk.device_id, compress_hyper_5_17_chunk.device_id_peer, compress_hyper_5_17_chunk.v0, compress_hyper_5_17_chunk.v1, compress_hyper_5_17_chunk.v2, compress_hyper_5_17_chunk.v3, compress_hyper_5_17_chunk._ts_meta_count, compress_hyper_5_17_chunk._ts_meta_sequence_num, compress_hyper_5_17_chunk._ts_meta_min_3, compress_hyper_5_17_chunk._ts_meta_max_3, compress_hyper_5_17_chunk._ts_meta_min_1, compress_hyper_5_17_chunk._ts_meta_max_1, compress_hyper_5_17_chunk._ts_meta_min_2, compress_hyper_5_17_chunk._ts_meta_max_2
+               Filter: (compress_hyper_5_17_chunk._ts_meta_max_3 > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
 (17 rows)
 
 -- test order by columns not in targetlist
@@ -1402,9 +1402,9 @@ LIMIT 100;
                Output: _hyper_1_3_chunk.device_id, _hyper_1_3_chunk.device_id_peer, _hyper_1_3_chunk.v0, _hyper_1_3_chunk.v1, _hyper_1_3_chunk."time"
                Filter: (_hyper_1_3_chunk."time" > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
                Bulk Decompression: true
-               ->  Index Scan using compress_hyper_5_16_chunk__compressed_hypertable_5_device_id_de on _timescaledb_internal.compress_hyper_5_16_chunk (actual rows=1 loops=1)
-                     Output: compress_hyper_5_16_chunk."time", compress_hyper_5_16_chunk.device_id, compress_hyper_5_16_chunk.device_id_peer, compress_hyper_5_16_chunk.v0, compress_hyper_5_16_chunk.v1, compress_hyper_5_16_chunk.v2, compress_hyper_5_16_chunk.v3, compress_hyper_5_16_chunk._ts_meta_count, compress_hyper_5_16_chunk._ts_meta_sequence_num, compress_hyper_5_16_chunk._ts_meta_min_3, compress_hyper_5_16_chunk._ts_meta_max_3, compress_hyper_5_16_chunk._ts_meta_min_1, compress_hyper_5_16_chunk._ts_meta_max_1, compress_hyper_5_16_chunk._ts_meta_min_2, compress_hyper_5_16_chunk._ts_meta_max_2
-                     Filter: (compress_hyper_5_16_chunk._ts_meta_max_3 > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
+               ->  Index Scan using compress_hyper_5_17_chunk__compressed_hypertable_5_device_id_de on _timescaledb_internal.compress_hyper_5_17_chunk (actual rows=1 loops=1)
+                     Output: compress_hyper_5_17_chunk."time", compress_hyper_5_17_chunk.device_id, compress_hyper_5_17_chunk.device_id_peer, compress_hyper_5_17_chunk.v0, compress_hyper_5_17_chunk.v1, compress_hyper_5_17_chunk.v2, compress_hyper_5_17_chunk.v3, compress_hyper_5_17_chunk._ts_meta_count, compress_hyper_5_17_chunk._ts_meta_sequence_num, compress_hyper_5_17_chunk._ts_meta_min_3, compress_hyper_5_17_chunk._ts_meta_max_3, compress_hyper_5_17_chunk._ts_meta_min_1, compress_hyper_5_17_chunk._ts_meta_max_1, compress_hyper_5_17_chunk._ts_meta_min_2, compress_hyper_5_17_chunk._ts_meta_max_2
+                     Filter: (compress_hyper_5_17_chunk._ts_meta_max_3 > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
 (19 rows)
 
 -- test ordering only by segmentby columns
@@ -1435,9 +1435,9 @@ LIMIT 100;
                Output: _hyper_1_3_chunk.device_id, _hyper_1_3_chunk.device_id_peer
                Filter: (_hyper_1_3_chunk."time" > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
                Bulk Decompression: true
-               ->  Index Scan using compress_hyper_5_16_chunk__compressed_hypertable_5_device_id_de on _timescaledb_internal.compress_hyper_5_16_chunk (actual rows=1 loops=1)
-                     Output: compress_hyper_5_16_chunk."time", compress_hyper_5_16_chunk.device_id, compress_hyper_5_16_chunk.device_id_peer, compress_hyper_5_16_chunk.v0, compress_hyper_5_16_chunk.v1, compress_hyper_5_16_chunk.v2, compress_hyper_5_16_chunk.v3, compress_hyper_5_16_chunk._ts_meta_count, compress_hyper_5_16_chunk._ts_meta_sequence_num, compress_hyper_5_16_chunk._ts_meta_min_3, compress_hyper_5_16_chunk._ts_meta_max_3, compress_hyper_5_16_chunk._ts_meta_min_1, compress_hyper_5_16_chunk._ts_meta_max_1, compress_hyper_5_16_chunk._ts_meta_min_2, compress_hyper_5_16_chunk._ts_meta_max_2
-                     Filter: (compress_hyper_5_16_chunk._ts_meta_max_3 > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
+               ->  Index Scan using compress_hyper_5_17_chunk__compressed_hypertable_5_device_id_de on _timescaledb_internal.compress_hyper_5_17_chunk (actual rows=1 loops=1)
+                     Output: compress_hyper_5_17_chunk."time", compress_hyper_5_17_chunk.device_id, compress_hyper_5_17_chunk.device_id_peer, compress_hyper_5_17_chunk.v0, compress_hyper_5_17_chunk.v1, compress_hyper_5_17_chunk.v2, compress_hyper_5_17_chunk.v3, compress_hyper_5_17_chunk._ts_meta_count, compress_hyper_5_17_chunk._ts_meta_sequence_num, compress_hyper_5_17_chunk._ts_meta_min_3, compress_hyper_5_17_chunk._ts_meta_max_3, compress_hyper_5_17_chunk._ts_meta_min_1, compress_hyper_5_17_chunk._ts_meta_max_1, compress_hyper_5_17_chunk._ts_meta_min_2, compress_hyper_5_17_chunk._ts_meta_max_2
+                     Filter: (compress_hyper_5_17_chunk._ts_meta_max_3 > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
 (19 rows)
 
 -- should produce ordered path
@@ -1467,9 +1467,9 @@ ORDER BY device_id,
          Output: _hyper_1_3_chunk.device_id, _hyper_1_3_chunk.device_id_peer, _hyper_1_3_chunk.v0
          Filter: (_hyper_1_3_chunk."time" > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
          Bulk Decompression: true
-         ->  Index Scan using compress_hyper_5_16_chunk__compressed_hypertable_5_device_id_de on _timescaledb_internal.compress_hyper_5_16_chunk (actual rows=5 loops=1)
-               Output: compress_hyper_5_16_chunk."time", compress_hyper_5_16_chunk.device_id, compress_hyper_5_16_chunk.device_id_peer, compress_hyper_5_16_chunk.v0, compress_hyper_5_16_chunk.v1, compress_hyper_5_16_chunk.v2, compress_hyper_5_16_chunk.v3, compress_hyper_5_16_chunk._ts_meta_count, compress_hyper_5_16_chunk._ts_meta_sequence_num, compress_hyper_5_16_chunk._ts_meta_min_3, compress_hyper_5_16_chunk._ts_meta_max_3, compress_hyper_5_16_chunk._ts_meta_min_1, compress_hyper_5_16_chunk._ts_meta_max_1, compress_hyper_5_16_chunk._ts_meta_min_2, compress_hyper_5_16_chunk._ts_meta_max_2
-               Filter: (compress_hyper_5_16_chunk._ts_meta_max_3 > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
+         ->  Index Scan using compress_hyper_5_17_chunk__compressed_hypertable_5_device_id_de on _timescaledb_internal.compress_hyper_5_17_chunk (actual rows=5 loops=1)
+               Output: compress_hyper_5_17_chunk."time", compress_hyper_5_17_chunk.device_id, compress_hyper_5_17_chunk.device_id_peer, compress_hyper_5_17_chunk.v0, compress_hyper_5_17_chunk.v1, compress_hyper_5_17_chunk.v2, compress_hyper_5_17_chunk.v3, compress_hyper_5_17_chunk._ts_meta_count, compress_hyper_5_17_chunk._ts_meta_sequence_num, compress_hyper_5_17_chunk._ts_meta_min_3, compress_hyper_5_17_chunk._ts_meta_max_3, compress_hyper_5_17_chunk._ts_meta_min_1, compress_hyper_5_17_chunk._ts_meta_max_1, compress_hyper_5_17_chunk._ts_meta_min_2, compress_hyper_5_17_chunk._ts_meta_max_2
+               Filter: (compress_hyper_5_17_chunk._ts_meta_max_3 > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
 (17 rows)
 
 -- should produce ordered path
@@ -1501,9 +1501,9 @@ ORDER BY device_id,
          Output: _hyper_1_3_chunk.device_id, _hyper_1_3_chunk.device_id_peer, _hyper_1_3_chunk.v0, _hyper_1_3_chunk.v1
          Filter: (_hyper_1_3_chunk."time" > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
          Bulk Decompression: true
-         ->  Index Scan using compress_hyper_5_16_chunk__compressed_hypertable_5_device_id_de on _timescaledb_internal.compress_hyper_5_16_chunk (actual rows=5 loops=1)
-               Output: compress_hyper_5_16_chunk."time", compress_hyper_5_16_chunk.device_id, compress_hyper_5_16_chunk.device_id_peer, compress_hyper_5_16_chunk.v0, compress_hyper_5_16_chunk.v1, compress_hyper_5_16_chunk.v2, compress_hyper_5_16_chunk.v3, compress_hyper_5_16_chunk._ts_meta_count, compress_hyper_5_16_chunk._ts_meta_sequence_num, compress_hyper_5_16_chunk._ts_meta_min_3, compress_hyper_5_16_chunk._ts_meta_max_3, compress_hyper_5_16_chunk._ts_meta_min_1, compress_hyper_5_16_chunk._ts_meta_max_1, compress_hyper_5_16_chunk._ts_meta_min_2, compress_hyper_5_16_chunk._ts_meta_max_2
-               Filter: (compress_hyper_5_16_chunk._ts_meta_max_3 > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
+         ->  Index Scan using compress_hyper_5_17_chunk__compressed_hypertable_5_device_id_de on _timescaledb_internal.compress_hyper_5_17_chunk (actual rows=5 loops=1)
+               Output: compress_hyper_5_17_chunk."time", compress_hyper_5_17_chunk.device_id, compress_hyper_5_17_chunk.device_id_peer, compress_hyper_5_17_chunk.v0, compress_hyper_5_17_chunk.v1, compress_hyper_5_17_chunk.v2, compress_hyper_5_17_chunk.v3, compress_hyper_5_17_chunk._ts_meta_count, compress_hyper_5_17_chunk._ts_meta_sequence_num, compress_hyper_5_17_chunk._ts_meta_min_3, compress_hyper_5_17_chunk._ts_meta_max_3, compress_hyper_5_17_chunk._ts_meta_min_1, compress_hyper_5_17_chunk._ts_meta_max_1, compress_hyper_5_17_chunk._ts_meta_min_2, compress_hyper_5_17_chunk._ts_meta_max_2
+               Filter: (compress_hyper_5_17_chunk._ts_meta_max_3 > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
 (17 rows)
 
 -- should not produce ordered path
@@ -1532,9 +1532,9 @@ ORDER BY device_id,
                Output: _hyper_1_3_chunk."time", _hyper_1_3_chunk.device_id, _hyper_1_3_chunk.device_id_peer, _hyper_1_3_chunk.v0, _hyper_1_3_chunk.v1, _hyper_1_3_chunk.v2, _hyper_1_3_chunk.v3
                Filter: (_hyper_1_3_chunk."time" > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
                Bulk Decompression: true
-               ->  Seq Scan on _timescaledb_internal.compress_hyper_5_16_chunk (actual rows=5 loops=1)
-                     Output: compress_hyper_5_16_chunk."time", compress_hyper_5_16_chunk.device_id, compress_hyper_5_16_chunk.device_id_peer, compress_hyper_5_16_chunk.v0, compress_hyper_5_16_chunk.v1, compress_hyper_5_16_chunk.v2, compress_hyper_5_16_chunk.v3, compress_hyper_5_16_chunk._ts_meta_count, compress_hyper_5_16_chunk._ts_meta_sequence_num, compress_hyper_5_16_chunk._ts_meta_min_3, compress_hyper_5_16_chunk._ts_meta_max_3, compress_hyper_5_16_chunk._ts_meta_min_1, compress_hyper_5_16_chunk._ts_meta_max_1, compress_hyper_5_16_chunk._ts_meta_min_2, compress_hyper_5_16_chunk._ts_meta_max_2
-                     Filter: (compress_hyper_5_16_chunk._ts_meta_max_3 > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
+               ->  Seq Scan on _timescaledb_internal.compress_hyper_5_17_chunk (actual rows=5 loops=1)
+                     Output: compress_hyper_5_17_chunk."time", compress_hyper_5_17_chunk.device_id, compress_hyper_5_17_chunk.device_id_peer, compress_hyper_5_17_chunk.v0, compress_hyper_5_17_chunk.v1, compress_hyper_5_17_chunk.v2, compress_hyper_5_17_chunk.v3, compress_hyper_5_17_chunk._ts_meta_count, compress_hyper_5_17_chunk._ts_meta_sequence_num, compress_hyper_5_17_chunk._ts_meta_min_3, compress_hyper_5_17_chunk._ts_meta_max_3, compress_hyper_5_17_chunk._ts_meta_min_1, compress_hyper_5_17_chunk._ts_meta_max_1, compress_hyper_5_17_chunk._ts_meta_min_2, compress_hyper_5_17_chunk._ts_meta_max_2
+                     Filter: (compress_hyper_5_17_chunk._ts_meta_max_3 > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
 (16 rows)
 
 -- should produce ordered path
@@ -1565,12 +1565,12 @@ ORDER BY device_id DESC,
          Filter: (_hyper_1_3_chunk."time" > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
          Bulk Decompression: true
          ->  Sort (actual rows=5 loops=1)
-               Output: compress_hyper_5_16_chunk."time", compress_hyper_5_16_chunk.device_id, compress_hyper_5_16_chunk.device_id_peer, compress_hyper_5_16_chunk.v0, compress_hyper_5_16_chunk.v1, compress_hyper_5_16_chunk.v2, compress_hyper_5_16_chunk.v3, compress_hyper_5_16_chunk._ts_meta_count, compress_hyper_5_16_chunk._ts_meta_sequence_num, compress_hyper_5_16_chunk._ts_meta_min_3, compress_hyper_5_16_chunk._ts_meta_max_3, compress_hyper_5_16_chunk._ts_meta_min_1, compress_hyper_5_16_chunk._ts_meta_max_1, compress_hyper_5_16_chunk._ts_meta_min_2, compress_hyper_5_16_chunk._ts_meta_max_2
-               Sort Key: compress_hyper_5_16_chunk.device_id DESC, compress_hyper_5_16_chunk.device_id_peer DESC, compress_hyper_5_16_chunk._ts_meta_sequence_num
+               Output: compress_hyper_5_17_chunk."time", compress_hyper_5_17_chunk.device_id, compress_hyper_5_17_chunk.device_id_peer, compress_hyper_5_17_chunk.v0, compress_hyper_5_17_chunk.v1, compress_hyper_5_17_chunk.v2, compress_hyper_5_17_chunk.v3, compress_hyper_5_17_chunk._ts_meta_count, compress_hyper_5_17_chunk._ts_meta_sequence_num, compress_hyper_5_17_chunk._ts_meta_min_3, compress_hyper_5_17_chunk._ts_meta_max_3, compress_hyper_5_17_chunk._ts_meta_min_1, compress_hyper_5_17_chunk._ts_meta_max_1, compress_hyper_5_17_chunk._ts_meta_min_2, compress_hyper_5_17_chunk._ts_meta_max_2
+               Sort Key: compress_hyper_5_17_chunk.device_id DESC, compress_hyper_5_17_chunk.device_id_peer DESC, compress_hyper_5_17_chunk._ts_meta_sequence_num
                Sort Method: quicksort 
-               ->  Seq Scan on _timescaledb_internal.compress_hyper_5_16_chunk (actual rows=5 loops=1)
-                     Output: compress_hyper_5_16_chunk."time", compress_hyper_5_16_chunk.device_id, compress_hyper_5_16_chunk.device_id_peer, compress_hyper_5_16_chunk.v0, compress_hyper_5_16_chunk.v1, compress_hyper_5_16_chunk.v2, compress_hyper_5_16_chunk.v3, compress_hyper_5_16_chunk._ts_meta_count, compress_hyper_5_16_chunk._ts_meta_sequence_num, compress_hyper_5_16_chunk._ts_meta_min_3, compress_hyper_5_16_chunk._ts_meta_max_3, compress_hyper_5_16_chunk._ts_meta_min_1, compress_hyper_5_16_chunk._ts_meta_max_1, compress_hyper_5_16_chunk._ts_meta_min_2, compress_hyper_5_16_chunk._ts_meta_max_2
-                     Filter: (compress_hyper_5_16_chunk._ts_meta_max_3 > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
+               ->  Seq Scan on _timescaledb_internal.compress_hyper_5_17_chunk (actual rows=5 loops=1)
+                     Output: compress_hyper_5_17_chunk."time", compress_hyper_5_17_chunk.device_id, compress_hyper_5_17_chunk.device_id_peer, compress_hyper_5_17_chunk.v0, compress_hyper_5_17_chunk.v1, compress_hyper_5_17_chunk.v2, compress_hyper_5_17_chunk.v3, compress_hyper_5_17_chunk._ts_meta_count, compress_hyper_5_17_chunk._ts_meta_sequence_num, compress_hyper_5_17_chunk._ts_meta_min_3, compress_hyper_5_17_chunk._ts_meta_max_3, compress_hyper_5_17_chunk._ts_meta_min_1, compress_hyper_5_17_chunk._ts_meta_max_1, compress_hyper_5_17_chunk._ts_meta_min_2, compress_hyper_5_17_chunk._ts_meta_max_2
+                     Filter: (compress_hyper_5_17_chunk._ts_meta_max_3 > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
 (21 rows)
 
 -- should not produce ordered path
@@ -1598,9 +1598,9 @@ ORDER BY device_id DESC,
                Output: _hyper_1_3_chunk."time", _hyper_1_3_chunk.device_id, _hyper_1_3_chunk.device_id_peer, _hyper_1_3_chunk.v0, _hyper_1_3_chunk.v1, _hyper_1_3_chunk.v2, _hyper_1_3_chunk.v3
                Filter: (_hyper_1_3_chunk."time" > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
                Bulk Decompression: true
-               ->  Seq Scan on _timescaledb_internal.compress_hyper_5_16_chunk (actual rows=5 loops=1)
-                     Output: compress_hyper_5_16_chunk."time", compress_hyper_5_16_chunk.device_id, compress_hyper_5_16_chunk.device_id_peer, compress_hyper_5_16_chunk.v0, compress_hyper_5_16_chunk.v1, compress_hyper_5_16_chunk.v2, compress_hyper_5_16_chunk.v3, compress_hyper_5_16_chunk._ts_meta_count, compress_hyper_5_16_chunk._ts_meta_sequence_num, compress_hyper_5_16_chunk._ts_meta_min_3, compress_hyper_5_16_chunk._ts_meta_max_3, compress_hyper_5_16_chunk._ts_meta_min_1, compress_hyper_5_16_chunk._ts_meta_max_1, compress_hyper_5_16_chunk._ts_meta_min_2, compress_hyper_5_16_chunk._ts_meta_max_2
-                     Filter: (compress_hyper_5_16_chunk._ts_meta_max_3 > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
+               ->  Seq Scan on _timescaledb_internal.compress_hyper_5_17_chunk (actual rows=5 loops=1)
+                     Output: compress_hyper_5_17_chunk."time", compress_hyper_5_17_chunk.device_id, compress_hyper_5_17_chunk.device_id_peer, compress_hyper_5_17_chunk.v0, compress_hyper_5_17_chunk.v1, compress_hyper_5_17_chunk.v2, compress_hyper_5_17_chunk.v3, compress_hyper_5_17_chunk._ts_meta_count, compress_hyper_5_17_chunk._ts_meta_sequence_num, compress_hyper_5_17_chunk._ts_meta_min_3, compress_hyper_5_17_chunk._ts_meta_max_3, compress_hyper_5_17_chunk._ts_meta_min_1, compress_hyper_5_17_chunk._ts_meta_max_1, compress_hyper_5_17_chunk._ts_meta_min_2, compress_hyper_5_17_chunk._ts_meta_max_2
+                     Filter: (compress_hyper_5_17_chunk._ts_meta_max_3 > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
 (16 rows)
 
 --
@@ -1629,7 +1629,7 @@ ORDER BY time,
                Sort Method: quicksort 
                ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk (actual rows=2520 loops=1)
                      Filter: ("time" > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
-                     ->  Seq Scan on compress_hyper_5_16_chunk (actual rows=5 loops=1)
+                     ->  Seq Scan on compress_hyper_5_17_chunk (actual rows=5 loops=1)
                            Filter: (_ts_meta_max_3 > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
 (15 rows)
 
@@ -1657,7 +1657,7 @@ ORDER BY time,
                Sort Method: quicksort 
                ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk (actual rows=2520 loops=1)
                      Filter: ("time" > ('2000-01-08'::cstring)::timestamp with time zone)
-                     ->  Seq Scan on compress_hyper_5_16_chunk (actual rows=5 loops=1)
+                     ->  Seq Scan on compress_hyper_5_17_chunk (actual rows=5 loops=1)
                            Filter: (_ts_meta_max_3 > ('2000-01-08'::cstring)::timestamp with time zone)
 (16 rows)
 
@@ -1673,7 +1673,7 @@ FROM :TEST_TABLE;
                ->  Seq Scan on compress_hyper_5_15_chunk (actual rows=5 loops=1)
          ->  Seq Scan on _hyper_1_2_chunk (actual rows=2520 loops=1)
          ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk (actual rows=2520 loops=1)
-               ->  Seq Scan on compress_hyper_5_16_chunk (actual rows=5 loops=1)
+               ->  Seq Scan on compress_hyper_5_17_chunk (actual rows=5 loops=1)
 (7 rows)
 
 -- test aggregate with GROUP BY
@@ -1695,7 +1695,7 @@ ORDER BY device_id;
                      ->  Seq Scan on compress_hyper_5_15_chunk (actual rows=5 loops=1)
                ->  Seq Scan on _hyper_1_2_chunk (actual rows=2520 loops=1)
                ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk (actual rows=2520 loops=1)
-                     ->  Seq Scan on compress_hyper_5_16_chunk (actual rows=5 loops=1)
+                     ->  Seq Scan on compress_hyper_5_17_chunk (actual rows=5 loops=1)
 (12 rows)
 
 -- test window functions with GROUP BY
@@ -1718,7 +1718,7 @@ ORDER BY device_id;
                            ->  Seq Scan on compress_hyper_5_15_chunk (actual rows=5 loops=1)
                      ->  Seq Scan on _hyper_1_2_chunk (actual rows=2520 loops=1)
                      ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk (actual rows=2520 loops=1)
-                           ->  Seq Scan on compress_hyper_5_16_chunk (actual rows=5 loops=1)
+                           ->  Seq Scan on compress_hyper_5_17_chunk (actual rows=5 loops=1)
 (13 rows)
 
 -- test CTE
@@ -1748,7 +1748,7 @@ ORDER BY v1;
                      Sort Key: _hyper_1_3_chunk."time"
                      Sort Method: quicksort 
                      ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk (actual rows=2520 loops=1)
-                           ->  Seq Scan on compress_hyper_5_16_chunk (actual rows=5 loops=1)
+                           ->  Seq Scan on compress_hyper_5_17_chunk (actual rows=5 loops=1)
 (17 rows)
 
 -- test CTE join
@@ -1790,7 +1790,7 @@ ORDER BY q1.time;
                Sort Key: _hyper_1_3_chunk."time"
                Sort Method: quicksort 
                ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk (actual rows=504 loops=1)
-                     ->  Seq Scan on compress_hyper_5_16_chunk (actual rows=1 loops=1)
+                     ->  Seq Scan on compress_hyper_5_17_chunk (actual rows=1 loops=1)
                            Filter: (device_id = 1)
                            Rows Removed by Filter: 4
    ->  Materialize (actual rows=1368 loops=1)
@@ -1810,7 +1810,7 @@ ORDER BY q1.time;
                      Sort Key: _hyper_1_3_chunk_1."time"
                      Sort Method: quicksort 
                      ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk _hyper_1_3_chunk_1 (actual rows=504 loops=1)
-                           ->  Seq Scan on compress_hyper_5_16_chunk compress_hyper_5_16_chunk_1 (actual rows=1 loops=1)
+                           ->  Seq Scan on compress_hyper_5_17_chunk compress_hyper_5_17_chunk_1 (actual rows=1 loops=1)
                                  Filter: (device_id = 2)
                                  Rows Removed by Filter: 4
 (41 rows)
@@ -1833,7 +1833,7 @@ WHERE device_id = 1;
                Filter: (device_id = 1)
                Rows Removed by Filter: 2016
          ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk (actual rows=504 loops=1)
-               ->  Seq Scan on compress_hyper_5_16_chunk (actual rows=1 loops=1)
+               ->  Seq Scan on compress_hyper_5_17_chunk (actual rows=1 loops=1)
                      Filter: (device_id = 1)
                      Rows Removed by Filter: 4
 (13 rows)
@@ -1912,9 +1912,9 @@ ORDER BY device_id,
          ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_3_chunk (actual rows=504 loops=1)
                Output: _hyper_1_3_chunk."time", _hyper_1_3_chunk.device_id
                Bulk Decompression: true
-               ->  Index Scan using compress_hyper_5_16_chunk_c_index_2 on _timescaledb_internal.compress_hyper_5_16_chunk (actual rows=1 loops=1)
-                     Output: compress_hyper_5_16_chunk."time", compress_hyper_5_16_chunk.device_id, compress_hyper_5_16_chunk.device_id_peer, compress_hyper_5_16_chunk.v0, compress_hyper_5_16_chunk.v1, compress_hyper_5_16_chunk.v2, compress_hyper_5_16_chunk.v3, compress_hyper_5_16_chunk._ts_meta_count, compress_hyper_5_16_chunk._ts_meta_sequence_num, compress_hyper_5_16_chunk._ts_meta_min_3, compress_hyper_5_16_chunk._ts_meta_max_3, compress_hyper_5_16_chunk._ts_meta_min_1, compress_hyper_5_16_chunk._ts_meta_max_1, compress_hyper_5_16_chunk._ts_meta_min_2, compress_hyper_5_16_chunk._ts_meta_max_2
-                     Index Cond: (compress_hyper_5_16_chunk.device_id = 1)
+               ->  Index Scan using compress_hyper_5_17_chunk_c_index_2 on _timescaledb_internal.compress_hyper_5_17_chunk (actual rows=1 loops=1)
+                     Output: compress_hyper_5_17_chunk."time", compress_hyper_5_17_chunk.device_id, compress_hyper_5_17_chunk.device_id_peer, compress_hyper_5_17_chunk.v0, compress_hyper_5_17_chunk.v1, compress_hyper_5_17_chunk.v2, compress_hyper_5_17_chunk.v3, compress_hyper_5_17_chunk._ts_meta_count, compress_hyper_5_17_chunk._ts_meta_sequence_num, compress_hyper_5_17_chunk._ts_meta_min_3, compress_hyper_5_17_chunk._ts_meta_max_3, compress_hyper_5_17_chunk._ts_meta_min_1, compress_hyper_5_17_chunk._ts_meta_max_1, compress_hyper_5_17_chunk._ts_meta_min_2, compress_hyper_5_17_chunk._ts_meta_max_2
+                     Index Cond: (compress_hyper_5_17_chunk.device_id = 1)
 (26 rows)
 
 -- globs should not plan IndexOnlyScans
@@ -1949,9 +1949,9 @@ ORDER BY device_id,
          ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_3_chunk (actual rows=504 loops=1)
                Output: _hyper_1_3_chunk."time", _hyper_1_3_chunk.device_id, _hyper_1_3_chunk.device_id_peer, _hyper_1_3_chunk.v0, _hyper_1_3_chunk.v1, _hyper_1_3_chunk.v2, _hyper_1_3_chunk.v3
                Bulk Decompression: true
-               ->  Index Scan using compress_hyper_5_16_chunk_c_index_2 on _timescaledb_internal.compress_hyper_5_16_chunk (actual rows=1 loops=1)
-                     Output: compress_hyper_5_16_chunk."time", compress_hyper_5_16_chunk.device_id, compress_hyper_5_16_chunk.device_id_peer, compress_hyper_5_16_chunk.v0, compress_hyper_5_16_chunk.v1, compress_hyper_5_16_chunk.v2, compress_hyper_5_16_chunk.v3, compress_hyper_5_16_chunk._ts_meta_count, compress_hyper_5_16_chunk._ts_meta_sequence_num, compress_hyper_5_16_chunk._ts_meta_min_3, compress_hyper_5_16_chunk._ts_meta_max_3, compress_hyper_5_16_chunk._ts_meta_min_1, compress_hyper_5_16_chunk._ts_meta_max_1, compress_hyper_5_16_chunk._ts_meta_min_2, compress_hyper_5_16_chunk._ts_meta_max_2
-                     Index Cond: (compress_hyper_5_16_chunk.device_id = 1)
+               ->  Index Scan using compress_hyper_5_17_chunk_c_index_2 on _timescaledb_internal.compress_hyper_5_17_chunk (actual rows=1 loops=1)
+                     Output: compress_hyper_5_17_chunk."time", compress_hyper_5_17_chunk.device_id, compress_hyper_5_17_chunk.device_id_peer, compress_hyper_5_17_chunk.v0, compress_hyper_5_17_chunk.v1, compress_hyper_5_17_chunk.v2, compress_hyper_5_17_chunk.v3, compress_hyper_5_17_chunk._ts_meta_count, compress_hyper_5_17_chunk._ts_meta_sequence_num, compress_hyper_5_17_chunk._ts_meta_min_3, compress_hyper_5_17_chunk._ts_meta_max_3, compress_hyper_5_17_chunk._ts_meta_min_1, compress_hyper_5_17_chunk._ts_meta_max_1, compress_hyper_5_17_chunk._ts_meta_min_2, compress_hyper_5_17_chunk._ts_meta_max_2
+                     Index Cond: (compress_hyper_5_17_chunk.device_id = 1)
 (26 rows)
 
 -- whole row reference should work
@@ -1986,9 +1986,9 @@ ORDER BY device_id,
          ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_3_chunk test_table_3 (actual rows=504 loops=1)
                Output: test_table_3.*, test_table_3.device_id, test_table_3."time"
                Bulk Decompression: true
-               ->  Index Scan using compress_hyper_5_16_chunk_c_index_2 on _timescaledb_internal.compress_hyper_5_16_chunk (actual rows=1 loops=1)
-                     Output: compress_hyper_5_16_chunk."time", compress_hyper_5_16_chunk.device_id, compress_hyper_5_16_chunk.device_id_peer, compress_hyper_5_16_chunk.v0, compress_hyper_5_16_chunk.v1, compress_hyper_5_16_chunk.v2, compress_hyper_5_16_chunk.v3, compress_hyper_5_16_chunk._ts_meta_count, compress_hyper_5_16_chunk._ts_meta_sequence_num, compress_hyper_5_16_chunk._ts_meta_min_3, compress_hyper_5_16_chunk._ts_meta_max_3, compress_hyper_5_16_chunk._ts_meta_min_1, compress_hyper_5_16_chunk._ts_meta_max_1, compress_hyper_5_16_chunk._ts_meta_min_2, compress_hyper_5_16_chunk._ts_meta_max_2
-                     Index Cond: (compress_hyper_5_16_chunk.device_id = 1)
+               ->  Index Scan using compress_hyper_5_17_chunk_c_index_2 on _timescaledb_internal.compress_hyper_5_17_chunk (actual rows=1 loops=1)
+                     Output: compress_hyper_5_17_chunk."time", compress_hyper_5_17_chunk.device_id, compress_hyper_5_17_chunk.device_id_peer, compress_hyper_5_17_chunk.v0, compress_hyper_5_17_chunk.v1, compress_hyper_5_17_chunk.v2, compress_hyper_5_17_chunk.v3, compress_hyper_5_17_chunk._ts_meta_count, compress_hyper_5_17_chunk._ts_meta_sequence_num, compress_hyper_5_17_chunk._ts_meta_min_3, compress_hyper_5_17_chunk._ts_meta_max_3, compress_hyper_5_17_chunk._ts_meta_min_1, compress_hyper_5_17_chunk._ts_meta_max_1, compress_hyper_5_17_chunk._ts_meta_min_2, compress_hyper_5_17_chunk._ts_meta_max_2
+                     Index Cond: (compress_hyper_5_17_chunk.device_id = 1)
 (26 rows)
 
 -- even when we select only a segmentby column, we still need count
@@ -2014,9 +2014,9 @@ ORDER BY device_id;
    ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_3_chunk (actual rows=504 loops=1)
          Output: _hyper_1_3_chunk.device_id
          Bulk Decompression: false
-         ->  Index Only Scan using compress_hyper_5_16_chunk_c_index_2 on _timescaledb_internal.compress_hyper_5_16_chunk (actual rows=1 loops=1)
-               Output: compress_hyper_5_16_chunk.device_id, compress_hyper_5_16_chunk._ts_meta_count
-               Index Cond: (compress_hyper_5_16_chunk.device_id = 1)
+         ->  Index Only Scan using compress_hyper_5_17_chunk_c_index_2 on _timescaledb_internal.compress_hyper_5_17_chunk (actual rows=1 loops=1)
+               Output: compress_hyper_5_17_chunk.device_id, compress_hyper_5_17_chunk._ts_meta_count
+               Index Cond: (compress_hyper_5_17_chunk.device_id = 1)
                Heap Fetches: 1
 (19 rows)
 
@@ -2040,9 +2040,9 @@ WHERE device_id = 1;
                Rows Removed by Filter: 2016
          ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_3_chunk (actual rows=504 loops=1)
                Bulk Decompression: false
-               ->  Index Only Scan using compress_hyper_5_16_chunk_c_index_2 on _timescaledb_internal.compress_hyper_5_16_chunk (actual rows=1 loops=1)
-                     Output: compress_hyper_5_16_chunk.device_id, compress_hyper_5_16_chunk._ts_meta_count
-                     Index Cond: (compress_hyper_5_16_chunk.device_id = 1)
+               ->  Index Only Scan using compress_hyper_5_17_chunk_c_index_2 on _timescaledb_internal.compress_hyper_5_17_chunk (actual rows=1 loops=1)
+                     Output: compress_hyper_5_17_chunk.device_id, compress_hyper_5_17_chunk._ts_meta_count
+                     Index Cond: (compress_hyper_5_17_chunk.device_id = 1)
                      Heap Fetches: 1
 (18 rows)
 
@@ -2068,8 +2068,8 @@ ORDER BY device_id;
    ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_3_chunk (actual rows=2520 loops=1)
          Output: _hyper_1_3_chunk.device_id
          Bulk Decompression: false
-         ->  Index Only Scan using compress_hyper_5_16_chunk_c_index_2 on _timescaledb_internal.compress_hyper_5_16_chunk (actual rows=5 loops=1)
-               Output: compress_hyper_5_16_chunk.device_id, compress_hyper_5_16_chunk._ts_meta_count
+         ->  Index Only Scan using compress_hyper_5_17_chunk_c_index_2 on _timescaledb_internal.compress_hyper_5_17_chunk (actual rows=5 loops=1)
+               Output: compress_hyper_5_17_chunk.device_id, compress_hyper_5_17_chunk._ts_meta_count
                Heap Fetches: 5
 (17 rows)
 
@@ -2101,9 +2101,9 @@ ORDER BY device_id_peer,
          ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_3_chunk (actual rows=0 loops=1)
                Output: _hyper_1_3_chunk."time", _hyper_1_3_chunk.device_id, _hyper_1_3_chunk.device_id_peer, _hyper_1_3_chunk.v0, _hyper_1_3_chunk.v1, _hyper_1_3_chunk.v2, _hyper_1_3_chunk.v3
                Bulk Decompression: true
-               ->  Index Scan using compress_hyper_5_16_chunk__compressed_hypertable_5_device_id_pe on _timescaledb_internal.compress_hyper_5_16_chunk (actual rows=0 loops=1)
-                     Output: compress_hyper_5_16_chunk."time", compress_hyper_5_16_chunk.device_id, compress_hyper_5_16_chunk.device_id_peer, compress_hyper_5_16_chunk.v0, compress_hyper_5_16_chunk.v1, compress_hyper_5_16_chunk.v2, compress_hyper_5_16_chunk.v3, compress_hyper_5_16_chunk._ts_meta_count, compress_hyper_5_16_chunk._ts_meta_sequence_num, compress_hyper_5_16_chunk._ts_meta_min_3, compress_hyper_5_16_chunk._ts_meta_max_3, compress_hyper_5_16_chunk._ts_meta_min_1, compress_hyper_5_16_chunk._ts_meta_max_1, compress_hyper_5_16_chunk._ts_meta_min_2, compress_hyper_5_16_chunk._ts_meta_max_2
-                     Index Cond: (compress_hyper_5_16_chunk.device_id_peer = 1)
+               ->  Index Scan using compress_hyper_5_17_chunk__compressed_hypertable_5_device_id_pe on _timescaledb_internal.compress_hyper_5_17_chunk (actual rows=0 loops=1)
+                     Output: compress_hyper_5_17_chunk."time", compress_hyper_5_17_chunk.device_id, compress_hyper_5_17_chunk.device_id_peer, compress_hyper_5_17_chunk.v0, compress_hyper_5_17_chunk.v1, compress_hyper_5_17_chunk.v2, compress_hyper_5_17_chunk.v3, compress_hyper_5_17_chunk._ts_meta_count, compress_hyper_5_17_chunk._ts_meta_sequence_num, compress_hyper_5_17_chunk._ts_meta_min_3, compress_hyper_5_17_chunk._ts_meta_max_3, compress_hyper_5_17_chunk._ts_meta_min_1, compress_hyper_5_17_chunk._ts_meta_max_1, compress_hyper_5_17_chunk._ts_meta_min_2, compress_hyper_5_17_chunk._ts_meta_max_2
+                     Index Cond: (compress_hyper_5_17_chunk.device_id_peer = 1)
 (21 rows)
 
 :PREFIX_VERBOSE
@@ -2127,9 +2127,9 @@ ORDER BY device_id_peer;
    ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_3_chunk (actual rows=0 loops=1)
          Output: _hyper_1_3_chunk.device_id_peer
          Bulk Decompression: false
-         ->  Index Scan using compress_hyper_5_16_chunk__compressed_hypertable_5_device_id_pe on _timescaledb_internal.compress_hyper_5_16_chunk (actual rows=0 loops=1)
-               Output: compress_hyper_5_16_chunk."time", compress_hyper_5_16_chunk.device_id, compress_hyper_5_16_chunk.device_id_peer, compress_hyper_5_16_chunk.v0, compress_hyper_5_16_chunk.v1, compress_hyper_5_16_chunk.v2, compress_hyper_5_16_chunk.v3, compress_hyper_5_16_chunk._ts_meta_count, compress_hyper_5_16_chunk._ts_meta_sequence_num, compress_hyper_5_16_chunk._ts_meta_min_3, compress_hyper_5_16_chunk._ts_meta_max_3, compress_hyper_5_16_chunk._ts_meta_min_1, compress_hyper_5_16_chunk._ts_meta_max_1, compress_hyper_5_16_chunk._ts_meta_min_2, compress_hyper_5_16_chunk._ts_meta_max_2
-               Index Cond: (compress_hyper_5_16_chunk.device_id_peer = 1)
+         ->  Index Scan using compress_hyper_5_17_chunk__compressed_hypertable_5_device_id_pe on _timescaledb_internal.compress_hyper_5_17_chunk (actual rows=0 loops=1)
+               Output: compress_hyper_5_17_chunk."time", compress_hyper_5_17_chunk.device_id, compress_hyper_5_17_chunk.device_id_peer, compress_hyper_5_17_chunk.v0, compress_hyper_5_17_chunk.v1, compress_hyper_5_17_chunk.v2, compress_hyper_5_17_chunk.v3, compress_hyper_5_17_chunk._ts_meta_count, compress_hyper_5_17_chunk._ts_meta_sequence_num, compress_hyper_5_17_chunk._ts_meta_min_3, compress_hyper_5_17_chunk._ts_meta_max_3, compress_hyper_5_17_chunk._ts_meta_min_1, compress_hyper_5_17_chunk._ts_meta_max_1, compress_hyper_5_17_chunk._ts_meta_min_2, compress_hyper_5_17_chunk._ts_meta_max_2
+               Index Cond: (compress_hyper_5_17_chunk.device_id_peer = 1)
 (17 rows)
 
 --ensure that we can get a nested loop
@@ -2157,9 +2157,9 @@ WHERE device_id_peer IN (
    ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_3_chunk (actual rows=0 loops=1)
          Output: _hyper_1_3_chunk.device_id_peer
          Bulk Decompression: false
-         ->  Seq Scan on _timescaledb_internal.compress_hyper_5_16_chunk (actual rows=0 loops=1)
-               Output: compress_hyper_5_16_chunk."time", compress_hyper_5_16_chunk.device_id, compress_hyper_5_16_chunk.device_id_peer, compress_hyper_5_16_chunk.v0, compress_hyper_5_16_chunk.v1, compress_hyper_5_16_chunk.v2, compress_hyper_5_16_chunk.v3, compress_hyper_5_16_chunk._ts_meta_count, compress_hyper_5_16_chunk._ts_meta_sequence_num, compress_hyper_5_16_chunk._ts_meta_min_3, compress_hyper_5_16_chunk._ts_meta_max_3, compress_hyper_5_16_chunk._ts_meta_min_1, compress_hyper_5_16_chunk._ts_meta_max_1, compress_hyper_5_16_chunk._ts_meta_min_2, compress_hyper_5_16_chunk._ts_meta_max_2
-               Filter: (compress_hyper_5_16_chunk.device_id_peer = 1)
+         ->  Seq Scan on _timescaledb_internal.compress_hyper_5_17_chunk (actual rows=0 loops=1)
+               Output: compress_hyper_5_17_chunk."time", compress_hyper_5_17_chunk.device_id, compress_hyper_5_17_chunk.device_id_peer, compress_hyper_5_17_chunk.v0, compress_hyper_5_17_chunk.v1, compress_hyper_5_17_chunk.v2, compress_hyper_5_17_chunk.v3, compress_hyper_5_17_chunk._ts_meta_count, compress_hyper_5_17_chunk._ts_meta_sequence_num, compress_hyper_5_17_chunk._ts_meta_min_3, compress_hyper_5_17_chunk._ts_meta_max_3, compress_hyper_5_17_chunk._ts_meta_min_1, compress_hyper_5_17_chunk._ts_meta_max_1, compress_hyper_5_17_chunk._ts_meta_min_2, compress_hyper_5_17_chunk._ts_meta_max_2
+               Filter: (compress_hyper_5_17_chunk.device_id_peer = 1)
                Rows Removed by Filter: 5
 (19 rows)
 
@@ -2196,9 +2196,9 @@ WHERE device_id_peer IN (
          ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_3_chunk (actual rows=0 loops=2)
                Output: _hyper_1_3_chunk.device_id_peer
                Bulk Decompression: false
-               ->  Index Scan using compress_hyper_5_16_chunk__compressed_hypertable_5_device_id_pe on _timescaledb_internal.compress_hyper_5_16_chunk (actual rows=0 loops=2)
-                     Output: compress_hyper_5_16_chunk."time", compress_hyper_5_16_chunk.device_id, compress_hyper_5_16_chunk.device_id_peer, compress_hyper_5_16_chunk.v0, compress_hyper_5_16_chunk.v1, compress_hyper_5_16_chunk.v2, compress_hyper_5_16_chunk.v3, compress_hyper_5_16_chunk._ts_meta_count, compress_hyper_5_16_chunk._ts_meta_sequence_num, compress_hyper_5_16_chunk._ts_meta_min_3, compress_hyper_5_16_chunk._ts_meta_max_3, compress_hyper_5_16_chunk._ts_meta_min_1, compress_hyper_5_16_chunk._ts_meta_max_1, compress_hyper_5_16_chunk._ts_meta_min_2, compress_hyper_5_16_chunk._ts_meta_max_2
-                     Index Cond: (compress_hyper_5_16_chunk.device_id_peer = "*VALUES*".column1)
+               ->  Index Scan using compress_hyper_5_17_chunk__compressed_hypertable_5_device_id_pe on _timescaledb_internal.compress_hyper_5_17_chunk (actual rows=0 loops=2)
+                     Output: compress_hyper_5_17_chunk."time", compress_hyper_5_17_chunk.device_id, compress_hyper_5_17_chunk.device_id_peer, compress_hyper_5_17_chunk.v0, compress_hyper_5_17_chunk.v1, compress_hyper_5_17_chunk.v2, compress_hyper_5_17_chunk.v3, compress_hyper_5_17_chunk._ts_meta_count, compress_hyper_5_17_chunk._ts_meta_sequence_num, compress_hyper_5_17_chunk._ts_meta_min_3, compress_hyper_5_17_chunk._ts_meta_max_3, compress_hyper_5_17_chunk._ts_meta_min_1, compress_hyper_5_17_chunk._ts_meta_max_1, compress_hyper_5_17_chunk._ts_meta_min_2, compress_hyper_5_17_chunk._ts_meta_max_2
+                     Index Cond: (compress_hyper_5_17_chunk.device_id_peer = "*VALUES*".column1)
 (27 rows)
 
 RESET enable_hashjoin;
@@ -2224,9 +2224,9 @@ WHERE device_id IN (
    ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_3_chunk (actual rows=504 loops=1)
          Output: _hyper_1_3_chunk.device_id_peer
          Bulk Decompression: false
-         ->  Seq Scan on _timescaledb_internal.compress_hyper_5_16_chunk (actual rows=1 loops=1)
-               Output: compress_hyper_5_16_chunk."time", compress_hyper_5_16_chunk.device_id, compress_hyper_5_16_chunk.device_id_peer, compress_hyper_5_16_chunk.v0, compress_hyper_5_16_chunk.v1, compress_hyper_5_16_chunk.v2, compress_hyper_5_16_chunk.v3, compress_hyper_5_16_chunk._ts_meta_count, compress_hyper_5_16_chunk._ts_meta_sequence_num, compress_hyper_5_16_chunk._ts_meta_min_3, compress_hyper_5_16_chunk._ts_meta_max_3, compress_hyper_5_16_chunk._ts_meta_min_1, compress_hyper_5_16_chunk._ts_meta_max_1, compress_hyper_5_16_chunk._ts_meta_min_2, compress_hyper_5_16_chunk._ts_meta_max_2
-               Filter: (compress_hyper_5_16_chunk.device_id = 1)
+         ->  Seq Scan on _timescaledb_internal.compress_hyper_5_17_chunk (actual rows=1 loops=1)
+               Output: compress_hyper_5_17_chunk."time", compress_hyper_5_17_chunk.device_id, compress_hyper_5_17_chunk.device_id_peer, compress_hyper_5_17_chunk.v0, compress_hyper_5_17_chunk.v1, compress_hyper_5_17_chunk.v2, compress_hyper_5_17_chunk.v3, compress_hyper_5_17_chunk._ts_meta_count, compress_hyper_5_17_chunk._ts_meta_sequence_num, compress_hyper_5_17_chunk._ts_meta_min_3, compress_hyper_5_17_chunk._ts_meta_max_3, compress_hyper_5_17_chunk._ts_meta_min_1, compress_hyper_5_17_chunk._ts_meta_max_1, compress_hyper_5_17_chunk._ts_meta_min_2, compress_hyper_5_17_chunk._ts_meta_max_2
+               Filter: (compress_hyper_5_17_chunk.device_id = 1)
                Rows Removed by Filter: 4
 (19 rows)
 
@@ -2263,9 +2263,9 @@ WHERE device_id IN (
          ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_3_chunk (actual rows=504 loops=2)
                Output: _hyper_1_3_chunk.device_id_peer, _hyper_1_3_chunk.device_id
                Bulk Decompression: false
-               ->  Index Scan using compress_hyper_5_16_chunk_c_index_2 on _timescaledb_internal.compress_hyper_5_16_chunk (actual rows=1 loops=2)
-                     Output: compress_hyper_5_16_chunk."time", compress_hyper_5_16_chunk.device_id, compress_hyper_5_16_chunk.device_id_peer, compress_hyper_5_16_chunk.v0, compress_hyper_5_16_chunk.v1, compress_hyper_5_16_chunk.v2, compress_hyper_5_16_chunk.v3, compress_hyper_5_16_chunk._ts_meta_count, compress_hyper_5_16_chunk._ts_meta_sequence_num, compress_hyper_5_16_chunk._ts_meta_min_3, compress_hyper_5_16_chunk._ts_meta_max_3, compress_hyper_5_16_chunk._ts_meta_min_1, compress_hyper_5_16_chunk._ts_meta_max_1, compress_hyper_5_16_chunk._ts_meta_min_2, compress_hyper_5_16_chunk._ts_meta_max_2
-                     Index Cond: (compress_hyper_5_16_chunk.device_id = "*VALUES*".column1)
+               ->  Index Scan using compress_hyper_5_17_chunk_c_index_2 on _timescaledb_internal.compress_hyper_5_17_chunk (actual rows=1 loops=2)
+                     Output: compress_hyper_5_17_chunk."time", compress_hyper_5_17_chunk.device_id, compress_hyper_5_17_chunk.device_id_peer, compress_hyper_5_17_chunk.v0, compress_hyper_5_17_chunk.v1, compress_hyper_5_17_chunk.v2, compress_hyper_5_17_chunk.v3, compress_hyper_5_17_chunk._ts_meta_count, compress_hyper_5_17_chunk._ts_meta_sequence_num, compress_hyper_5_17_chunk._ts_meta_min_3, compress_hyper_5_17_chunk._ts_meta_max_3, compress_hyper_5_17_chunk._ts_meta_min_1, compress_hyper_5_17_chunk._ts_meta_max_1, compress_hyper_5_17_chunk._ts_meta_min_2, compress_hyper_5_17_chunk._ts_meta_max_2
+                     Index Cond: (compress_hyper_5_17_chunk.device_id = "*VALUES*".column1)
 (27 rows)
 
 SET seq_page_cost = 100;
@@ -2290,8 +2290,8 @@ WHERE device_id IN (
                Output: _hyper_1_2_chunk.device_id_peer, _hyper_1_2_chunk.device_id
          ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_3_chunk
                Output: _hyper_1_3_chunk.device_id_peer, _hyper_1_3_chunk.device_id
-               ->  Index Scan using compress_hyper_5_16_chunk_c_index_2 on _timescaledb_internal.compress_hyper_5_16_chunk
-                     Output: compress_hyper_5_16_chunk."time", compress_hyper_5_16_chunk.device_id, compress_hyper_5_16_chunk.device_id_peer, compress_hyper_5_16_chunk.v0, compress_hyper_5_16_chunk.v1, compress_hyper_5_16_chunk.v2, compress_hyper_5_16_chunk.v3, compress_hyper_5_16_chunk._ts_meta_count, compress_hyper_5_16_chunk._ts_meta_sequence_num, compress_hyper_5_16_chunk._ts_meta_min_3, compress_hyper_5_16_chunk._ts_meta_max_3, compress_hyper_5_16_chunk._ts_meta_min_1, compress_hyper_5_16_chunk._ts_meta_max_1, compress_hyper_5_16_chunk._ts_meta_min_2, compress_hyper_5_16_chunk._ts_meta_max_2
+               ->  Index Scan using compress_hyper_5_17_chunk_c_index_2 on _timescaledb_internal.compress_hyper_5_17_chunk
+                     Output: compress_hyper_5_17_chunk."time", compress_hyper_5_17_chunk.device_id, compress_hyper_5_17_chunk.device_id_peer, compress_hyper_5_17_chunk.v0, compress_hyper_5_17_chunk.v1, compress_hyper_5_17_chunk.v2, compress_hyper_5_17_chunk.v3, compress_hyper_5_17_chunk._ts_meta_count, compress_hyper_5_17_chunk._ts_meta_sequence_num, compress_hyper_5_17_chunk._ts_meta_min_3, compress_hyper_5_17_chunk._ts_meta_max_3, compress_hyper_5_17_chunk._ts_meta_min_1, compress_hyper_5_17_chunk._ts_meta_max_1, compress_hyper_5_17_chunk._ts_meta_min_2, compress_hyper_5_17_chunk._ts_meta_max_2
    ->  Hash
          Output: "*VALUES*".column1
          ->  Values Scan on "*VALUES*"
@@ -2321,9 +2321,9 @@ WHERE device_id IN (
    ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_3_chunk (actual rows=504 loops=1)
          Output: _hyper_1_3_chunk.device_id_peer
          Bulk Decompression: false
-         ->  Seq Scan on _timescaledb_internal.compress_hyper_5_16_chunk (actual rows=1 loops=1)
-               Output: compress_hyper_5_16_chunk."time", compress_hyper_5_16_chunk.device_id, compress_hyper_5_16_chunk.device_id_peer, compress_hyper_5_16_chunk.v0, compress_hyper_5_16_chunk.v1, compress_hyper_5_16_chunk.v2, compress_hyper_5_16_chunk.v3, compress_hyper_5_16_chunk._ts_meta_count, compress_hyper_5_16_chunk._ts_meta_sequence_num, compress_hyper_5_16_chunk._ts_meta_min_3, compress_hyper_5_16_chunk._ts_meta_max_3, compress_hyper_5_16_chunk._ts_meta_min_1, compress_hyper_5_16_chunk._ts_meta_max_1, compress_hyper_5_16_chunk._ts_meta_min_2, compress_hyper_5_16_chunk._ts_meta_max_2
-               Filter: (compress_hyper_5_16_chunk.device_id = 1)
+         ->  Seq Scan on _timescaledb_internal.compress_hyper_5_17_chunk (actual rows=1 loops=1)
+               Output: compress_hyper_5_17_chunk."time", compress_hyper_5_17_chunk.device_id, compress_hyper_5_17_chunk.device_id_peer, compress_hyper_5_17_chunk.v0, compress_hyper_5_17_chunk.v1, compress_hyper_5_17_chunk.v2, compress_hyper_5_17_chunk.v3, compress_hyper_5_17_chunk._ts_meta_count, compress_hyper_5_17_chunk._ts_meta_sequence_num, compress_hyper_5_17_chunk._ts_meta_min_3, compress_hyper_5_17_chunk._ts_meta_max_3, compress_hyper_5_17_chunk._ts_meta_min_1, compress_hyper_5_17_chunk._ts_meta_max_1, compress_hyper_5_17_chunk._ts_meta_min_2, compress_hyper_5_17_chunk._ts_meta_max_2
+               Filter: (compress_hyper_5_17_chunk.device_id = 1)
                Rows Removed by Filter: 4
 (19 rows)
 
@@ -2359,9 +2359,9 @@ WHERE device_id IN (
          ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_3_chunk (actual rows=504 loops=2)
                Output: _hyper_1_3_chunk.device_id_peer, _hyper_1_3_chunk.device_id
                Bulk Decompression: false
-               ->  Index Scan using compress_hyper_5_16_chunk_c_index_2 on _timescaledb_internal.compress_hyper_5_16_chunk (actual rows=1 loops=2)
-                     Output: compress_hyper_5_16_chunk."time", compress_hyper_5_16_chunk.device_id, compress_hyper_5_16_chunk.device_id_peer, compress_hyper_5_16_chunk.v0, compress_hyper_5_16_chunk.v1, compress_hyper_5_16_chunk.v2, compress_hyper_5_16_chunk.v3, compress_hyper_5_16_chunk._ts_meta_count, compress_hyper_5_16_chunk._ts_meta_sequence_num, compress_hyper_5_16_chunk._ts_meta_min_3, compress_hyper_5_16_chunk._ts_meta_max_3, compress_hyper_5_16_chunk._ts_meta_min_1, compress_hyper_5_16_chunk._ts_meta_max_1, compress_hyper_5_16_chunk._ts_meta_min_2, compress_hyper_5_16_chunk._ts_meta_max_2
-                     Index Cond: (compress_hyper_5_16_chunk.device_id = "*VALUES*".column1)
+               ->  Index Scan using compress_hyper_5_17_chunk_c_index_2 on _timescaledb_internal.compress_hyper_5_17_chunk (actual rows=1 loops=2)
+                     Output: compress_hyper_5_17_chunk."time", compress_hyper_5_17_chunk.device_id, compress_hyper_5_17_chunk.device_id_peer, compress_hyper_5_17_chunk.v0, compress_hyper_5_17_chunk.v1, compress_hyper_5_17_chunk.v2, compress_hyper_5_17_chunk.v3, compress_hyper_5_17_chunk._ts_meta_count, compress_hyper_5_17_chunk._ts_meta_sequence_num, compress_hyper_5_17_chunk._ts_meta_min_3, compress_hyper_5_17_chunk._ts_meta_max_3, compress_hyper_5_17_chunk._ts_meta_min_1, compress_hyper_5_17_chunk._ts_meta_max_1, compress_hyper_5_17_chunk._ts_meta_min_2, compress_hyper_5_17_chunk._ts_meta_max_2
+                     Index Cond: (compress_hyper_5_17_chunk.device_id = "*VALUES*".column1)
 (27 rows)
 
 -- test view
@@ -2386,7 +2386,7 @@ LIMIT 10;
                Sort Key: _hyper_1_3_chunk."time" DESC
                Sort Method: top-N heapsort 
                ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk (actual rows=504 loops=1)
-                     ->  Seq Scan on compress_hyper_5_16_chunk (actual rows=1 loops=1)
+                     ->  Seq Scan on compress_hyper_5_17_chunk (actual rows=1 loops=1)
                            Filter: (device_id = 1)
                            Rows Removed by Filter: 4
          ->  Index Scan using _hyper_1_2_chunk_metrics_time_idx on _hyper_1_2_chunk (never executed)
@@ -2430,7 +2430,7 @@ FROM :TEST_TABLE m1
                      ->  Sort (never executed)
                            Sort Key: m1_3."time"
                            ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk m1_3 (never executed)
-                                 ->  Seq Scan on compress_hyper_5_16_chunk (never executed)
+                                 ->  Seq Scan on compress_hyper_5_17_chunk (never executed)
                ->  Materialize (actual rows=51 loops=1)
                      ->  Custom Scan (ChunkAppend) on metrics m2 (actual rows=11 loops=1)
                            Order: m2."time"
@@ -2443,7 +2443,7 @@ FROM :TEST_TABLE m1
                            ->  Sort (never executed)
                                  Sort Key: m2_3."time"
                                  ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk m2_3 (never executed)
-                                       ->  Seq Scan on compress_hyper_5_16_chunk compress_hyper_5_16_chunk_1 (never executed)
+                                       ->  Seq Scan on compress_hyper_5_17_chunk compress_hyper_5_17_chunk_1 (never executed)
 (34 rows)
 
 :PREFIX
@@ -2480,7 +2480,7 @@ FROM :TEST_TABLE m1
                            ->  Sort (never executed)
                                  Sort Key: m1_3."time"
                                  ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk m1_3 (never executed)
-                                       ->  Seq Scan on compress_hyper_5_16_chunk (never executed)
+                                       ->  Seq Scan on compress_hyper_5_17_chunk (never executed)
                      ->  Materialize (actual rows=51 loops=1)
                            ->  Custom Scan (ChunkAppend) on metrics m2 (actual rows=11 loops=1)
                                  Order: m2."time"
@@ -2493,7 +2493,7 @@ FROM :TEST_TABLE m1
                                  ->  Sort (never executed)
                                        Sort Key: m2_3."time"
                                        ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk m2_3 (never executed)
-                                             ->  Seq Scan on compress_hyper_5_16_chunk compress_hyper_5_16_chunk_1 (never executed)
+                                             ->  Seq Scan on compress_hyper_5_17_chunk compress_hyper_5_17_chunk_1 (never executed)
                ->  Materialize (actual rows=11 loops=1)
                      ->  Merge Append (actual rows=3 loops=1)
                            Sort Key: m3_1."time"
@@ -2511,7 +2511,7 @@ FROM :TEST_TABLE m1
                                  Sort Key: m3_3."time"
                                  Sort Method: quicksort 
                                  ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk m3_3 (actual rows=504 loops=1)
-                                       ->  Seq Scan on compress_hyper_5_16_chunk compress_hyper_5_16_chunk_2 (actual rows=1 loops=1)
+                                       ->  Seq Scan on compress_hyper_5_17_chunk compress_hyper_5_17_chunk_2 (actual rows=1 loops=1)
                                              Filter: (device_id = 3)
                                              Rows Removed by Filter: 4
 (56 rows)
@@ -2546,7 +2546,7 @@ FROM :TEST_TABLE m1
                ->  Sort (never executed)
                      Sort Key: m1_3."time"
                      ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk m1_3 (never executed)
-                           ->  Seq Scan on compress_hyper_5_16_chunk (never executed)
+                           ->  Seq Scan on compress_hyper_5_17_chunk (never executed)
                                  Filter: (device_id = 1)
          ->  Materialize (actual rows=100 loops=1)
                ->  Custom Scan (ChunkAppend) on metrics m2 (actual rows=100 loops=1)
@@ -2563,7 +2563,7 @@ FROM :TEST_TABLE m1
                      ->  Sort (never executed)
                            Sort Key: m2_3."time"
                            ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk m2_3 (never executed)
-                                 ->  Seq Scan on compress_hyper_5_16_chunk compress_hyper_5_16_chunk_1 (never executed)
+                                 ->  Seq Scan on compress_hyper_5_17_chunk compress_hyper_5_17_chunk_1 (never executed)
                                        Filter: (device_id = 2)
 (36 rows)
 
@@ -2597,7 +2597,7 @@ FROM metrics m1
                ->  Sort (never executed)
                      Sort Key: m1_3."time"
                      ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk m1_3 (never executed)
-                           ->  Seq Scan on compress_hyper_5_16_chunk (never executed)
+                           ->  Seq Scan on compress_hyper_5_17_chunk (never executed)
                                  Filter: (device_id = 1)
          ->  Materialize (actual rows=100 loops=1)
                ->  Custom Scan (ChunkAppend) on metrics_space m2 (actual rows=100 loops=1)
@@ -2606,7 +2606,7 @@ FROM metrics m1
                            Sort Key: m2_1."time"
                            Sort Method: quicksort 
                            ->  Custom Scan (DecompressChunk) on _hyper_2_5_chunk m2_1 (actual rows=360 loops=1)
-                                 ->  Seq Scan on compress_hyper_6_18_chunk (actual rows=1 loops=1)
+                                 ->  Seq Scan on compress_hyper_6_19_chunk (actual rows=1 loops=1)
                                        Filter: (device_id = 2)
                                        Rows Removed by Filter: 2
                      ->  Index Scan Backward using _hyper_2_8_chunk_metrics_space_device_id_time_idx on _hyper_2_8_chunk m2_2 (never executed)
@@ -2614,7 +2614,7 @@ FROM metrics m1
                      ->  Sort (never executed)
                            Sort Key: m2_3."time"
                            ->  Custom Scan (DecompressChunk) on _hyper_2_11_chunk m2_3 (never executed)
-                                 ->  Seq Scan on compress_hyper_6_21_chunk (never executed)
+                                 ->  Seq Scan on compress_hyper_6_25_chunk (never executed)
                                        Filter: (device_id = 2)
 (36 rows)
 
@@ -2649,7 +2649,7 @@ LIMIT 10;
                      ->  Sort (never executed)
                            Sort Key: m1_3."time"
                            ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk m1_3 (never executed)
-                                 ->  Seq Scan on compress_hyper_5_16_chunk (never executed)
+                                 ->  Seq Scan on compress_hyper_5_17_chunk (never executed)
                ->  Materialize (actual rows=51 loops=1)
                      ->  Custom Scan (ChunkAppend) on metrics m2 (actual rows=11 loops=1)
                            Order: m2."time"
@@ -2662,7 +2662,7 @@ LIMIT 10;
                            ->  Sort (never executed)
                                  Sort Key: m2_3."time"
                                  ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk m2_3 (never executed)
-                                       ->  Seq Scan on compress_hyper_5_16_chunk compress_hyper_5_16_chunk_1 (never executed)
+                                       ->  Seq Scan on compress_hyper_5_17_chunk compress_hyper_5_17_chunk_1 (never executed)
 (34 rows)
 
 :PREFIX
@@ -2698,7 +2698,7 @@ LIMIT 100;
                      ->  Sort (never executed)
                            Sort Key: m1_3."time"
                            ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk m1_3 (never executed)
-                                 ->  Seq Scan on compress_hyper_5_16_chunk (never executed)
+                                 ->  Seq Scan on compress_hyper_5_17_chunk (never executed)
                ->  Materialize (actual rows=102 loops=1)
                      ->  Custom Scan (ChunkAppend) on metrics m2 (actual rows=22 loops=1)
                            Order: m2."time"
@@ -2714,7 +2714,7 @@ LIMIT 100;
                            ->  Sort (never executed)
                                  Sort Key: m2_3."time"
                                  ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk m2_3 (never executed)
-                                       ->  Seq Scan on compress_hyper_5_16_chunk compress_hyper_5_16_chunk_1 (never executed)
+                                       ->  Seq Scan on compress_hyper_5_17_chunk compress_hyper_5_17_chunk_1 (never executed)
                                              Filter: (device_id = 2)
 (38 rows)
 
@@ -2751,7 +2751,7 @@ LIMIT 100;
                      ->  Sort (never executed)
                            Sort Key: m1_3."time"
                            ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk m1_3 (never executed)
-                                 ->  Seq Scan on compress_hyper_5_16_chunk (never executed)
+                                 ->  Seq Scan on compress_hyper_5_17_chunk (never executed)
                ->  Materialize (actual rows=102 loops=1)
                      ->  Custom Scan (ChunkAppend) on metrics_space m2 (actual rows=22 loops=1)
                            Order: m2."time"
@@ -2764,7 +2764,7 @@ LIMIT 100;
                                              Sort Key: m2_1."time"
                                              Sort Method: quicksort 
                                              ->  Custom Scan (DecompressChunk) on _hyper_2_4_chunk m2_1 (actual rows=0 loops=1)
-                                                   ->  Seq Scan on compress_hyper_6_17_chunk (actual rows=0 loops=1)
+                                                   ->  Seq Scan on compress_hyper_6_18_chunk (actual rows=0 loops=1)
                                                          Filter: (device_id = 2)
                                                          Rows Removed by Filter: 1
                                  ->  Sort (actual rows=22 loops=1)
@@ -2774,7 +2774,7 @@ LIMIT 100;
                                              Sort Key: m2_2."time"
                                              Sort Method: quicksort 
                                              ->  Custom Scan (DecompressChunk) on _hyper_2_5_chunk m2_2 (actual rows=360 loops=1)
-                                                   ->  Seq Scan on compress_hyper_6_18_chunk (actual rows=1 loops=1)
+                                                   ->  Seq Scan on compress_hyper_6_19_chunk (actual rows=1 loops=1)
                                                          Filter: (device_id = 2)
                                                          Rows Removed by Filter: 2
                                  ->  Sort (actual rows=0 loops=1)
@@ -2784,7 +2784,7 @@ LIMIT 100;
                                              Sort Key: m2_3."time"
                                              Sort Method: quicksort 
                                              ->  Custom Scan (DecompressChunk) on _hyper_2_6_chunk m2_3 (actual rows=0 loops=1)
-                                                   ->  Seq Scan on compress_hyper_6_19_chunk (actual rows=0 loops=1)
+                                                   ->  Seq Scan on compress_hyper_6_20_chunk (actual rows=0 loops=1)
                                                          Filter: (device_id = 2)
                                                          Rows Removed by Filter: 1
                            ->  Merge Append (never executed)
@@ -2802,14 +2802,14 @@ LIMIT 100;
                                        ->  Sort (never executed)
                                              Sort Key: m2_7."time"
                                              ->  Custom Scan (DecompressChunk) on _hyper_2_10_chunk m2_7 (never executed)
-                                                   ->  Seq Scan on compress_hyper_6_20_chunk (never executed)
+                                                   ->  Seq Scan on compress_hyper_6_24_chunk (never executed)
                                                          Filter: (device_id = 2)
                                  ->  Sort (never executed)
                                        Sort Key: m2_8."time"
                                        ->  Sort (never executed)
                                              Sort Key: m2_8."time"
                                              ->  Custom Scan (DecompressChunk) on _hyper_2_11_chunk m2_8 (never executed)
-                                                   ->  Seq Scan on compress_hyper_6_21_chunk (never executed)
+                                                   ->  Seq Scan on compress_hyper_6_25_chunk (never executed)
                                                          Filter: (device_id = 2)
                                  ->  Index Scan Backward using _hyper_2_12_chunk_metrics_space_time_idx on _hyper_2_12_chunk m2_9 (never executed)
                                        Filter: (device_id = 2)
@@ -2846,7 +2846,7 @@ LIMIT 20;
                      ->  Sort (never executed)
                            Sort Key: m1_3."time"
                            ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk m1_3 (never executed)
-                                 ->  Seq Scan on compress_hyper_5_16_chunk (never executed)
+                                 ->  Seq Scan on compress_hyper_5_17_chunk (never executed)
                ->  Materialize (actual rows=26 loops=1)
                      ->  Custom Scan (ChunkAppend) on metrics m2 (actual rows=6 loops=1)
                            Order: m2."time"
@@ -2859,7 +2859,7 @@ LIMIT 20;
                            ->  Sort (never executed)
                                  Sort Key: m2_3."time"
                                  ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk m2_3 (never executed)
-                                       ->  Seq Scan on compress_hyper_5_16_chunk compress_hyper_5_16_chunk_1 (never executed)
+                                       ->  Seq Scan on compress_hyper_5_17_chunk compress_hyper_5_17_chunk_1 (never executed)
 (32 rows)
 
 -- test self-join with sub-query
@@ -2895,7 +2895,7 @@ LIMIT 10;
                      ->  Sort (never executed)
                            Sort Key: m1_3."time"
                            ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk m1_3 (never executed)
-                                 ->  Seq Scan on compress_hyper_5_16_chunk (never executed)
+                                 ->  Seq Scan on compress_hyper_5_17_chunk (never executed)
                ->  Materialize (actual rows=26 loops=1)
                      ->  Custom Scan (ChunkAppend) on metrics m2 (actual rows=6 loops=1)
                            Order: m2."time"
@@ -2908,7 +2908,7 @@ LIMIT 10;
                            ->  Sort (never executed)
                                  Sort Key: m2_3."time"
                                  ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk m2_3 (never executed)
-                                       ->  Seq Scan on compress_hyper_5_16_chunk compress_hyper_5_16_chunk_1 (never executed)
+                                       ->  Seq Scan on compress_hyper_5_17_chunk compress_hyper_5_17_chunk_1 (never executed)
 (32 rows)
 
 :PREFIX
@@ -2937,7 +2937,7 @@ FROM generate_series('2000-01-01'::timestamptz, '2000-02-01'::timestamptz, '1d':
                ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk m1_3 (actual rows=1 loops=7)
                      Filter: ("time" = g."time")
                      Rows Removed by Filter: 240
-                     ->  Seq Scan on compress_hyper_5_16_chunk (actual rows=1 loops=7)
+                     ->  Seq Scan on compress_hyper_5_17_chunk (actual rows=1 loops=7)
                            Filter: ((_ts_meta_min_3 <= g."time") AND (_ts_meta_max_3 >= g."time"))
 (18 rows)
 
@@ -2970,7 +2970,7 @@ FROM generate_series('2000-01-01'::timestamptz, '2000-02-01'::timestamptz, '1d':
                ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk m1_3 (actual rows=1 loops=7)
                      Filter: ("time" = g."time")
                      Rows Removed by Filter: 240
-                     ->  Seq Scan on compress_hyper_5_16_chunk (actual rows=1 loops=7)
+                     ->  Seq Scan on compress_hyper_5_17_chunk (actual rows=1 loops=7)
                            Filter: ((_ts_meta_min_3 <= g."time") AND (_ts_meta_max_3 >= g."time") AND (device_id = 1))
 (18 rows)
 
@@ -2995,7 +2995,7 @@ FROM generate_series('2000-01-01'::timestamptz, '2000-02-01'::timestamptz, '1d':
                ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk m1_3 (actual rows=1 loops=7)
                      Filter: ("time" = g."time")
                      Rows Removed by Filter: 240
-                     ->  Seq Scan on compress_hyper_5_16_chunk (actual rows=1 loops=7)
+                     ->  Seq Scan on compress_hyper_5_17_chunk (actual rows=1 loops=7)
                            Filter: ((_ts_meta_min_3 <= g."time") AND (_ts_meta_max_3 >= g."time") AND (device_id = 2))
                            Rows Removed by Filter: 1
 (21 rows)
@@ -3161,18 +3161,18 @@ WHERE metrics.time > metrics_space.time
  Nested Loop (actual rows=0 loops=1)
    ->  Append (actual rows=6840 loops=1)
          ->  Custom Scan (DecompressChunk) on _hyper_2_4_chunk (actual rows=360 loops=1)
-               ->  Index Scan using compress_hyper_6_17_chunk_c_space_index_2 on compress_hyper_6_17_chunk (actual rows=1 loops=1)
+               ->  Index Scan using compress_hyper_6_18_chunk_c_space_index_2 on compress_hyper_6_18_chunk (actual rows=1 loops=1)
          ->  Custom Scan (DecompressChunk) on _hyper_2_5_chunk (actual rows=1080 loops=1)
-               ->  Index Scan using compress_hyper_6_18_chunk_c_space_index_2 on compress_hyper_6_18_chunk (actual rows=3 loops=1)
+               ->  Index Scan using compress_hyper_6_19_chunk_c_space_index_2 on compress_hyper_6_19_chunk (actual rows=3 loops=1)
          ->  Custom Scan (DecompressChunk) on _hyper_2_6_chunk (actual rows=360 loops=1)
-               ->  Index Scan using compress_hyper_6_19_chunk_c_space_index_2 on compress_hyper_6_19_chunk (actual rows=1 loops=1)
+               ->  Index Scan using compress_hyper_6_20_chunk_c_space_index_2 on compress_hyper_6_20_chunk (actual rows=1 loops=1)
          ->  Index Scan Backward using _hyper_2_7_chunk_metrics_space_device_id_device_id_peer_v0_v1_2 on _hyper_2_7_chunk (actual rows=504 loops=1)
          ->  Index Scan Backward using _hyper_2_8_chunk_metrics_space_device_id_device_id_peer_v0_v1_2 on _hyper_2_8_chunk (actual rows=1512 loops=1)
          ->  Index Scan Backward using _hyper_2_9_chunk_metrics_space_device_id_device_id_peer_v0_v1_2 on _hyper_2_9_chunk (actual rows=504 loops=1)
          ->  Custom Scan (DecompressChunk) on _hyper_2_10_chunk (actual rows=504 loops=1)
-               ->  Index Scan using compress_hyper_6_20_chunk_c_space_index_2 on compress_hyper_6_20_chunk (actual rows=1 loops=1)
+               ->  Index Scan using compress_hyper_6_24_chunk_c_space_index_2 on compress_hyper_6_24_chunk (actual rows=1 loops=1)
          ->  Custom Scan (DecompressChunk) on _hyper_2_11_chunk (actual rows=1512 loops=1)
-               ->  Index Scan using compress_hyper_6_21_chunk_c_space_index_2 on compress_hyper_6_21_chunk (actual rows=3 loops=1)
+               ->  Index Scan using compress_hyper_6_25_chunk_c_space_index_2 on compress_hyper_6_25_chunk (actual rows=3 loops=1)
          ->  Index Scan Backward using _hyper_2_12_chunk_metrics_space_device_id_device_id_peer_v0_v_2 on _hyper_2_12_chunk (actual rows=504 loops=1)
    ->  Append (actual rows=0 loops=6840)
          ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk (actual rows=0 loops=6840)
@@ -3186,7 +3186,7 @@ WHERE metrics.time > metrics_space.time
          ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk (actual rows=0 loops=6840)
                Filter: (("time" > _hyper_2_4_chunk."time") AND ("time" < _hyper_2_4_chunk."time"))
                Rows Removed by Filter: 504
-               ->  Index Scan using compress_hyper_5_16_chunk_c_index_2 on compress_hyper_5_16_chunk (actual rows=1 loops=6840)
+               ->  Index Scan using compress_hyper_5_17_chunk_c_index_2 on compress_hyper_5_17_chunk (actual rows=1 loops=6840)
                      Index Cond: (device_id = _hyper_2_4_chunk.device_id)
 (30 rows)
 
@@ -3224,9 +3224,9 @@ LIMIT 5;
                ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_4_chunk (actual rows=360 loops=1)
                      Output: _hyper_2_4_chunk."time", _hyper_2_4_chunk.device_id, _hyper_2_4_chunk.device_id_peer, _hyper_2_4_chunk.v0, _hyper_2_4_chunk.v1, _hyper_2_4_chunk.v2, _hyper_2_4_chunk.v3
                      Bulk Decompression: true
-                     ->  Seq Scan on _timescaledb_internal.compress_hyper_6_17_chunk (actual rows=1 loops=1)
-                           Output: compress_hyper_6_17_chunk."time", compress_hyper_6_17_chunk.device_id, compress_hyper_6_17_chunk.device_id_peer, compress_hyper_6_17_chunk.v0, compress_hyper_6_17_chunk.v1, compress_hyper_6_17_chunk.v2, compress_hyper_6_17_chunk.v3, compress_hyper_6_17_chunk._ts_meta_count, compress_hyper_6_17_chunk._ts_meta_sequence_num, compress_hyper_6_17_chunk._ts_meta_min_3, compress_hyper_6_17_chunk._ts_meta_max_3, compress_hyper_6_17_chunk._ts_meta_min_1, compress_hyper_6_17_chunk._ts_meta_max_1, compress_hyper_6_17_chunk._ts_meta_min_2, compress_hyper_6_17_chunk._ts_meta_max_2
-                           Filter: (compress_hyper_6_17_chunk.device_id = 1)
+                     ->  Seq Scan on _timescaledb_internal.compress_hyper_6_18_chunk (actual rows=1 loops=1)
+                           Output: compress_hyper_6_18_chunk."time", compress_hyper_6_18_chunk.device_id, compress_hyper_6_18_chunk.device_id_peer, compress_hyper_6_18_chunk.v0, compress_hyper_6_18_chunk.v1, compress_hyper_6_18_chunk.v2, compress_hyper_6_18_chunk.v3, compress_hyper_6_18_chunk._ts_meta_count, compress_hyper_6_18_chunk._ts_meta_sequence_num, compress_hyper_6_18_chunk._ts_meta_min_3, compress_hyper_6_18_chunk._ts_meta_max_3, compress_hyper_6_18_chunk._ts_meta_min_1, compress_hyper_6_18_chunk._ts_meta_max_1, compress_hyper_6_18_chunk._ts_meta_min_2, compress_hyper_6_18_chunk._ts_meta_max_2
+                           Filter: (compress_hyper_6_18_chunk.device_id = 1)
          ->  Index Scan Backward using _hyper_2_7_chunk_metrics_space_time_idx on _timescaledb_internal._hyper_2_7_chunk (never executed)
                Output: _hyper_2_7_chunk."time", _hyper_2_7_chunk.device_id, _hyper_2_7_chunk.device_id_peer, _hyper_2_7_chunk.v0, _hyper_2_7_chunk.v1, _hyper_2_7_chunk.v2, _hyper_2_7_chunk.v3
                Filter: (_hyper_2_7_chunk.device_id = 1)
@@ -3236,9 +3236,9 @@ LIMIT 5;
                ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_10_chunk (never executed)
                      Output: _hyper_2_10_chunk."time", _hyper_2_10_chunk.device_id, _hyper_2_10_chunk.device_id_peer, _hyper_2_10_chunk.v0, _hyper_2_10_chunk.v1, _hyper_2_10_chunk.v2, _hyper_2_10_chunk.v3
                      Bulk Decompression: true
-                     ->  Seq Scan on _timescaledb_internal.compress_hyper_6_20_chunk (never executed)
-                           Output: compress_hyper_6_20_chunk."time", compress_hyper_6_20_chunk.device_id, compress_hyper_6_20_chunk.device_id_peer, compress_hyper_6_20_chunk.v0, compress_hyper_6_20_chunk.v1, compress_hyper_6_20_chunk.v2, compress_hyper_6_20_chunk.v3, compress_hyper_6_20_chunk._ts_meta_count, compress_hyper_6_20_chunk._ts_meta_sequence_num, compress_hyper_6_20_chunk._ts_meta_min_3, compress_hyper_6_20_chunk._ts_meta_max_3, compress_hyper_6_20_chunk._ts_meta_min_1, compress_hyper_6_20_chunk._ts_meta_max_1, compress_hyper_6_20_chunk._ts_meta_min_2, compress_hyper_6_20_chunk._ts_meta_max_2
-                           Filter: (compress_hyper_6_20_chunk.device_id = 1)
+                     ->  Seq Scan on _timescaledb_internal.compress_hyper_6_24_chunk (never executed)
+                           Output: compress_hyper_6_24_chunk."time", compress_hyper_6_24_chunk.device_id, compress_hyper_6_24_chunk.device_id_peer, compress_hyper_6_24_chunk.v0, compress_hyper_6_24_chunk.v1, compress_hyper_6_24_chunk.v2, compress_hyper_6_24_chunk.v3, compress_hyper_6_24_chunk._ts_meta_count, compress_hyper_6_24_chunk._ts_meta_sequence_num, compress_hyper_6_24_chunk._ts_meta_min_3, compress_hyper_6_24_chunk._ts_meta_max_3, compress_hyper_6_24_chunk._ts_meta_min_1, compress_hyper_6_24_chunk._ts_meta_max_1, compress_hyper_6_24_chunk._ts_meta_min_2, compress_hyper_6_24_chunk._ts_meta_max_2
+                           Filter: (compress_hyper_6_24_chunk.device_id = 1)
 (29 rows)
 
 -- test RECORD by itself
@@ -3255,7 +3255,7 @@ ORDER BY time;
          Sort Key: _hyper_2_4_chunk."time"
          Sort Method: quicksort 
          ->  Custom Scan (DecompressChunk) on _hyper_2_4_chunk (actual rows=360 loops=1)
-               ->  Seq Scan on compress_hyper_6_17_chunk (actual rows=1 loops=1)
+               ->  Seq Scan on compress_hyper_6_18_chunk (actual rows=1 loops=1)
                      Filter: (device_id = 1)
    ->  Index Scan Backward using _hyper_2_7_chunk_metrics_space_time_idx on _hyper_2_7_chunk (actual rows=504 loops=1)
          Filter: (device_id = 1)
@@ -3263,7 +3263,7 @@ ORDER BY time;
          Sort Key: _hyper_2_10_chunk."time"
          Sort Method: quicksort 
          ->  Custom Scan (DecompressChunk) on _hyper_2_10_chunk (actual rows=504 loops=1)
-               ->  Seq Scan on compress_hyper_6_20_chunk (actual rows=1 loops=1)
+               ->  Seq Scan on compress_hyper_6_24_chunk (actual rows=1 loops=1)
                      Filter: (device_id = 1)
 (16 rows)
 
@@ -3287,10 +3287,10 @@ ORDER BY time,
    ->  Result (actual rows=2736 loops=1)
          ->  Append (actual rows=2736 loops=1)
                ->  Custom Scan (DecompressChunk) on _hyper_2_4_chunk (actual rows=360 loops=1)
-                     ->  Seq Scan on compress_hyper_6_17_chunk (actual rows=1 loops=1)
+                     ->  Seq Scan on compress_hyper_6_18_chunk (actual rows=1 loops=1)
                            Filter: (device_id = ANY ('{1,2}'::integer[]))
                ->  Custom Scan (DecompressChunk) on _hyper_2_5_chunk (actual rows=360 loops=1)
-                     ->  Seq Scan on compress_hyper_6_18_chunk (actual rows=1 loops=1)
+                     ->  Seq Scan on compress_hyper_6_19_chunk (actual rows=1 loops=1)
                            Filter: (device_id = ANY ('{1,2}'::integer[]))
                            Rows Removed by Filter: 2
                ->  Seq Scan on _hyper_2_7_chunk (actual rows=504 loops=1)
@@ -3298,10 +3298,10 @@ ORDER BY time,
                ->  Index Scan using _hyper_2_8_chunk_metrics_space_device_id_device_id_peer_v0_v1_2 on _hyper_2_8_chunk (actual rows=504 loops=1)
                      Index Cond: (device_id = ANY ('{1,2}'::integer[]))
                ->  Custom Scan (DecompressChunk) on _hyper_2_10_chunk (actual rows=504 loops=1)
-                     ->  Seq Scan on compress_hyper_6_20_chunk (actual rows=1 loops=1)
+                     ->  Seq Scan on compress_hyper_6_24_chunk (actual rows=1 loops=1)
                            Filter: (device_id = ANY ('{1,2}'::integer[]))
                ->  Custom Scan (DecompressChunk) on _hyper_2_11_chunk (actual rows=504 loops=1)
-                     ->  Seq Scan on compress_hyper_6_21_chunk (actual rows=1 loops=1)
+                     ->  Seq Scan on compress_hyper_6_25_chunk (actual rows=1 loops=1)
                            Filter: (device_id = ANY ('{1,2}'::integer[]))
                            Rows Removed by Filter: 2
 (23 rows)
@@ -3314,18 +3314,18 @@ FROM :TEST_TABLE;
 -------------------------------------------------------------------------------------
  Append (actual rows=6840 loops=1)
    ->  Custom Scan (DecompressChunk) on _hyper_2_4_chunk (actual rows=360 loops=1)
-         ->  Seq Scan on compress_hyper_6_17_chunk (actual rows=1 loops=1)
+         ->  Seq Scan on compress_hyper_6_18_chunk (actual rows=1 loops=1)
    ->  Custom Scan (DecompressChunk) on _hyper_2_5_chunk (actual rows=1080 loops=1)
-         ->  Seq Scan on compress_hyper_6_18_chunk (actual rows=3 loops=1)
+         ->  Seq Scan on compress_hyper_6_19_chunk (actual rows=3 loops=1)
    ->  Custom Scan (DecompressChunk) on _hyper_2_6_chunk (actual rows=360 loops=1)
-         ->  Seq Scan on compress_hyper_6_19_chunk (actual rows=1 loops=1)
+         ->  Seq Scan on compress_hyper_6_20_chunk (actual rows=1 loops=1)
    ->  Seq Scan on _hyper_2_7_chunk (actual rows=504 loops=1)
    ->  Seq Scan on _hyper_2_8_chunk (actual rows=1512 loops=1)
    ->  Seq Scan on _hyper_2_9_chunk (actual rows=504 loops=1)
    ->  Custom Scan (DecompressChunk) on _hyper_2_10_chunk (actual rows=504 loops=1)
-         ->  Seq Scan on compress_hyper_6_20_chunk (actual rows=1 loops=1)
+         ->  Seq Scan on compress_hyper_6_24_chunk (actual rows=1 loops=1)
    ->  Custom Scan (DecompressChunk) on _hyper_2_11_chunk (actual rows=1512 loops=1)
-         ->  Seq Scan on compress_hyper_6_21_chunk (actual rows=3 loops=1)
+         ->  Seq Scan on compress_hyper_6_25_chunk (actual rows=3 loops=1)
    ->  Seq Scan on _hyper_2_12_chunk (actual rows=504 loops=1)
 (15 rows)
 
@@ -3338,15 +3338,15 @@ WHERE device_id < 0;
 -------------------------------------------------------------------------------------------------------------------------------------
  Append (actual rows=0 loops=1)
    ->  Custom Scan (DecompressChunk) on _hyper_2_4_chunk (actual rows=0 loops=1)
-         ->  Seq Scan on compress_hyper_6_17_chunk (actual rows=0 loops=1)
+         ->  Seq Scan on compress_hyper_6_18_chunk (actual rows=0 loops=1)
                Filter: (device_id < 0)
                Rows Removed by Filter: 1
    ->  Custom Scan (DecompressChunk) on _hyper_2_5_chunk (actual rows=0 loops=1)
-         ->  Seq Scan on compress_hyper_6_18_chunk (actual rows=0 loops=1)
+         ->  Seq Scan on compress_hyper_6_19_chunk (actual rows=0 loops=1)
                Filter: (device_id < 0)
                Rows Removed by Filter: 3
    ->  Custom Scan (DecompressChunk) on _hyper_2_6_chunk (actual rows=0 loops=1)
-         ->  Seq Scan on compress_hyper_6_19_chunk (actual rows=0 loops=1)
+         ->  Seq Scan on compress_hyper_6_20_chunk (actual rows=0 loops=1)
                Filter: (device_id < 0)
                Rows Removed by Filter: 1
    ->  Index Scan using _hyper_2_7_chunk_metrics_space_device_id_device_id_peer_v0_v1_2 on _hyper_2_7_chunk (actual rows=0 loops=1)
@@ -3356,11 +3356,11 @@ WHERE device_id < 0;
    ->  Index Scan using _hyper_2_9_chunk_metrics_space_device_id_device_id_peer_v0_v1_2 on _hyper_2_9_chunk (actual rows=0 loops=1)
          Index Cond: (device_id < 0)
    ->  Custom Scan (DecompressChunk) on _hyper_2_10_chunk (actual rows=0 loops=1)
-         ->  Seq Scan on compress_hyper_6_20_chunk (actual rows=0 loops=1)
+         ->  Seq Scan on compress_hyper_6_24_chunk (actual rows=0 loops=1)
                Filter: (device_id < 0)
                Rows Removed by Filter: 1
    ->  Custom Scan (DecompressChunk) on _hyper_2_11_chunk (actual rows=0 loops=1)
-         ->  Seq Scan on compress_hyper_6_21_chunk (actual rows=0 loops=1)
+         ->  Seq Scan on compress_hyper_6_25_chunk (actual rows=0 loops=1)
                Filter: (device_id < 0)
                Rows Removed by Filter: 3
    ->  Index Scan using _hyper_2_12_chunk_metrics_space_device_id_device_id_peer_v0_v_2 on _hyper_2_12_chunk (actual rows=0 loops=1)
@@ -3376,18 +3376,18 @@ FROM :TEST_TABLE;
  Result (actual rows=6840 loops=1)
    ->  Append (actual rows=6840 loops=1)
          ->  Custom Scan (DecompressChunk) on _hyper_2_4_chunk (actual rows=360 loops=1)
-               ->  Seq Scan on compress_hyper_6_17_chunk (actual rows=1 loops=1)
+               ->  Seq Scan on compress_hyper_6_18_chunk (actual rows=1 loops=1)
          ->  Custom Scan (DecompressChunk) on _hyper_2_5_chunk (actual rows=1080 loops=1)
-               ->  Seq Scan on compress_hyper_6_18_chunk (actual rows=3 loops=1)
+               ->  Seq Scan on compress_hyper_6_19_chunk (actual rows=3 loops=1)
          ->  Custom Scan (DecompressChunk) on _hyper_2_6_chunk (actual rows=360 loops=1)
-               ->  Seq Scan on compress_hyper_6_19_chunk (actual rows=1 loops=1)
+               ->  Seq Scan on compress_hyper_6_20_chunk (actual rows=1 loops=1)
          ->  Seq Scan on _hyper_2_7_chunk (actual rows=504 loops=1)
          ->  Seq Scan on _hyper_2_8_chunk (actual rows=1512 loops=1)
          ->  Seq Scan on _hyper_2_9_chunk (actual rows=504 loops=1)
          ->  Custom Scan (DecompressChunk) on _hyper_2_10_chunk (actual rows=504 loops=1)
-               ->  Seq Scan on compress_hyper_6_20_chunk (actual rows=1 loops=1)
+               ->  Seq Scan on compress_hyper_6_24_chunk (actual rows=1 loops=1)
          ->  Custom Scan (DecompressChunk) on _hyper_2_11_chunk (actual rows=1512 loops=1)
-               ->  Seq Scan on compress_hyper_6_21_chunk (actual rows=3 loops=1)
+               ->  Seq Scan on compress_hyper_6_25_chunk (actual rows=3 loops=1)
          ->  Seq Scan on _hyper_2_12_chunk (actual rows=504 loops=1)
 (16 rows)
 
@@ -3404,12 +3404,12 @@ ORDER BY v1;
    Sort Method: quicksort 
    ->  Append (actual rows=1368 loops=1)
          ->  Custom Scan (DecompressChunk) on _hyper_2_4_chunk (actual rows=360 loops=1)
-               ->  Seq Scan on compress_hyper_6_17_chunk (actual rows=1 loops=1)
+               ->  Seq Scan on compress_hyper_6_18_chunk (actual rows=1 loops=1)
                      Filter: (device_id = 1)
          ->  Seq Scan on _hyper_2_7_chunk (actual rows=504 loops=1)
                Filter: (device_id = 1)
          ->  Custom Scan (DecompressChunk) on _hyper_2_10_chunk (actual rows=504 loops=1)
-               ->  Seq Scan on compress_hyper_6_20_chunk (actual rows=1 loops=1)
+               ->  Seq Scan on compress_hyper_6_24_chunk (actual rows=1 loops=1)
                      Filter: (device_id = 1)
 (12 rows)
 
@@ -3426,12 +3426,12 @@ ORDER BY v1;
    Sort Method: quicksort 
    ->  Append (actual rows=1368 loops=1)
          ->  Custom Scan (DecompressChunk) on _hyper_2_4_chunk (actual rows=360 loops=1)
-               ->  Seq Scan on compress_hyper_6_17_chunk (actual rows=1 loops=1)
+               ->  Seq Scan on compress_hyper_6_18_chunk (actual rows=1 loops=1)
                      Filter: (device_id = 1)
          ->  Seq Scan on _hyper_2_7_chunk (actual rows=504 loops=1)
                Filter: (device_id = 1)
          ->  Custom Scan (DecompressChunk) on _hyper_2_10_chunk (actual rows=504 loops=1)
-               ->  Seq Scan on compress_hyper_6_20_chunk (actual rows=1 loops=1)
+               ->  Seq Scan on compress_hyper_6_24_chunk (actual rows=1 loops=1)
                      Filter: (device_id = 1)
 (12 rows)
 
@@ -3444,12 +3444,12 @@ WHERE device_id = 1;
 ------------------------------------------------------------------------------------
  Append (actual rows=1368 loops=1)
    ->  Custom Scan (DecompressChunk) on _hyper_2_4_chunk (actual rows=360 loops=1)
-         ->  Seq Scan on compress_hyper_6_17_chunk (actual rows=1 loops=1)
+         ->  Seq Scan on compress_hyper_6_18_chunk (actual rows=1 loops=1)
                Filter: (device_id = 1)
    ->  Seq Scan on _hyper_2_7_chunk (actual rows=504 loops=1)
          Filter: (device_id = 1)
    ->  Custom Scan (DecompressChunk) on _hyper_2_10_chunk (actual rows=504 loops=1)
-         ->  Seq Scan on compress_hyper_6_20_chunk (actual rows=1 loops=1)
+         ->  Seq Scan on compress_hyper_6_24_chunk (actual rows=1 loops=1)
                Filter: (device_id = 1)
 (9 rows)
 
@@ -3475,22 +3475,22 @@ ORDER BY time,
                Filter: (_hyper_2_4_chunk.v3 > '10'::double precision)
                Rows Removed by Filter: 360
                Bulk Decompression: true
-               ->  Seq Scan on _timescaledb_internal.compress_hyper_6_17_chunk (actual rows=1 loops=1)
-                     Output: compress_hyper_6_17_chunk."time", compress_hyper_6_17_chunk.device_id, compress_hyper_6_17_chunk.device_id_peer, compress_hyper_6_17_chunk.v0, compress_hyper_6_17_chunk.v1, compress_hyper_6_17_chunk.v2, compress_hyper_6_17_chunk.v3, compress_hyper_6_17_chunk._ts_meta_count, compress_hyper_6_17_chunk._ts_meta_sequence_num, compress_hyper_6_17_chunk._ts_meta_min_3, compress_hyper_6_17_chunk._ts_meta_max_3, compress_hyper_6_17_chunk._ts_meta_min_1, compress_hyper_6_17_chunk._ts_meta_max_1, compress_hyper_6_17_chunk._ts_meta_min_2, compress_hyper_6_17_chunk._ts_meta_max_2
+               ->  Seq Scan on _timescaledb_internal.compress_hyper_6_18_chunk (actual rows=1 loops=1)
+                     Output: compress_hyper_6_18_chunk."time", compress_hyper_6_18_chunk.device_id, compress_hyper_6_18_chunk.device_id_peer, compress_hyper_6_18_chunk.v0, compress_hyper_6_18_chunk.v1, compress_hyper_6_18_chunk.v2, compress_hyper_6_18_chunk.v3, compress_hyper_6_18_chunk._ts_meta_count, compress_hyper_6_18_chunk._ts_meta_sequence_num, compress_hyper_6_18_chunk._ts_meta_min_3, compress_hyper_6_18_chunk._ts_meta_max_3, compress_hyper_6_18_chunk._ts_meta_min_1, compress_hyper_6_18_chunk._ts_meta_max_1, compress_hyper_6_18_chunk._ts_meta_min_2, compress_hyper_6_18_chunk._ts_meta_max_2
          ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_5_chunk (actual rows=0 loops=1)
                Output: _hyper_2_5_chunk."time", _hyper_2_5_chunk.device_id, _hyper_2_5_chunk.device_id_peer, _hyper_2_5_chunk.v0, _hyper_2_5_chunk.v1, _hyper_2_5_chunk.v2, _hyper_2_5_chunk.v3
                Filter: (_hyper_2_5_chunk.v3 > '10'::double precision)
                Rows Removed by Filter: 1080
                Bulk Decompression: true
-               ->  Seq Scan on _timescaledb_internal.compress_hyper_6_18_chunk (actual rows=3 loops=1)
-                     Output: compress_hyper_6_18_chunk."time", compress_hyper_6_18_chunk.device_id, compress_hyper_6_18_chunk.device_id_peer, compress_hyper_6_18_chunk.v0, compress_hyper_6_18_chunk.v1, compress_hyper_6_18_chunk.v2, compress_hyper_6_18_chunk.v3, compress_hyper_6_18_chunk._ts_meta_count, compress_hyper_6_18_chunk._ts_meta_sequence_num, compress_hyper_6_18_chunk._ts_meta_min_3, compress_hyper_6_18_chunk._ts_meta_max_3, compress_hyper_6_18_chunk._ts_meta_min_1, compress_hyper_6_18_chunk._ts_meta_max_1, compress_hyper_6_18_chunk._ts_meta_min_2, compress_hyper_6_18_chunk._ts_meta_max_2
+               ->  Seq Scan on _timescaledb_internal.compress_hyper_6_19_chunk (actual rows=3 loops=1)
+                     Output: compress_hyper_6_19_chunk."time", compress_hyper_6_19_chunk.device_id, compress_hyper_6_19_chunk.device_id_peer, compress_hyper_6_19_chunk.v0, compress_hyper_6_19_chunk.v1, compress_hyper_6_19_chunk.v2, compress_hyper_6_19_chunk.v3, compress_hyper_6_19_chunk._ts_meta_count, compress_hyper_6_19_chunk._ts_meta_sequence_num, compress_hyper_6_19_chunk._ts_meta_min_3, compress_hyper_6_19_chunk._ts_meta_max_3, compress_hyper_6_19_chunk._ts_meta_min_1, compress_hyper_6_19_chunk._ts_meta_max_1, compress_hyper_6_19_chunk._ts_meta_min_2, compress_hyper_6_19_chunk._ts_meta_max_2
          ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_6_chunk (actual rows=0 loops=1)
                Output: _hyper_2_6_chunk."time", _hyper_2_6_chunk.device_id, _hyper_2_6_chunk.device_id_peer, _hyper_2_6_chunk.v0, _hyper_2_6_chunk.v1, _hyper_2_6_chunk.v2, _hyper_2_6_chunk.v3
                Filter: (_hyper_2_6_chunk.v3 > '10'::double precision)
                Rows Removed by Filter: 360
                Bulk Decompression: true
-               ->  Seq Scan on _timescaledb_internal.compress_hyper_6_19_chunk (actual rows=1 loops=1)
-                     Output: compress_hyper_6_19_chunk."time", compress_hyper_6_19_chunk.device_id, compress_hyper_6_19_chunk.device_id_peer, compress_hyper_6_19_chunk.v0, compress_hyper_6_19_chunk.v1, compress_hyper_6_19_chunk.v2, compress_hyper_6_19_chunk.v3, compress_hyper_6_19_chunk._ts_meta_count, compress_hyper_6_19_chunk._ts_meta_sequence_num, compress_hyper_6_19_chunk._ts_meta_min_3, compress_hyper_6_19_chunk._ts_meta_max_3, compress_hyper_6_19_chunk._ts_meta_min_1, compress_hyper_6_19_chunk._ts_meta_max_1, compress_hyper_6_19_chunk._ts_meta_min_2, compress_hyper_6_19_chunk._ts_meta_max_2
+               ->  Seq Scan on _timescaledb_internal.compress_hyper_6_20_chunk (actual rows=1 loops=1)
+                     Output: compress_hyper_6_20_chunk."time", compress_hyper_6_20_chunk.device_id, compress_hyper_6_20_chunk.device_id_peer, compress_hyper_6_20_chunk.v0, compress_hyper_6_20_chunk.v1, compress_hyper_6_20_chunk.v2, compress_hyper_6_20_chunk.v3, compress_hyper_6_20_chunk._ts_meta_count, compress_hyper_6_20_chunk._ts_meta_sequence_num, compress_hyper_6_20_chunk._ts_meta_min_3, compress_hyper_6_20_chunk._ts_meta_max_3, compress_hyper_6_20_chunk._ts_meta_min_1, compress_hyper_6_20_chunk._ts_meta_max_1, compress_hyper_6_20_chunk._ts_meta_min_2, compress_hyper_6_20_chunk._ts_meta_max_2
          ->  Seq Scan on _timescaledb_internal._hyper_2_7_chunk (actual rows=0 loops=1)
                Output: _hyper_2_7_chunk."time", _hyper_2_7_chunk.device_id, _hyper_2_7_chunk.device_id_peer, _hyper_2_7_chunk.v0, _hyper_2_7_chunk.v1, _hyper_2_7_chunk.v2, _hyper_2_7_chunk.v3
                Filter: (_hyper_2_7_chunk.v3 > '10'::double precision)
@@ -3508,15 +3508,15 @@ ORDER BY time,
                Filter: (_hyper_2_10_chunk.v3 > '10'::double precision)
                Rows Removed by Filter: 504
                Bulk Decompression: true
-               ->  Seq Scan on _timescaledb_internal.compress_hyper_6_20_chunk (actual rows=1 loops=1)
-                     Output: compress_hyper_6_20_chunk."time", compress_hyper_6_20_chunk.device_id, compress_hyper_6_20_chunk.device_id_peer, compress_hyper_6_20_chunk.v0, compress_hyper_6_20_chunk.v1, compress_hyper_6_20_chunk.v2, compress_hyper_6_20_chunk.v3, compress_hyper_6_20_chunk._ts_meta_count, compress_hyper_6_20_chunk._ts_meta_sequence_num, compress_hyper_6_20_chunk._ts_meta_min_3, compress_hyper_6_20_chunk._ts_meta_max_3, compress_hyper_6_20_chunk._ts_meta_min_1, compress_hyper_6_20_chunk._ts_meta_max_1, compress_hyper_6_20_chunk._ts_meta_min_2, compress_hyper_6_20_chunk._ts_meta_max_2
+               ->  Seq Scan on _timescaledb_internal.compress_hyper_6_24_chunk (actual rows=1 loops=1)
+                     Output: compress_hyper_6_24_chunk."time", compress_hyper_6_24_chunk.device_id, compress_hyper_6_24_chunk.device_id_peer, compress_hyper_6_24_chunk.v0, compress_hyper_6_24_chunk.v1, compress_hyper_6_24_chunk.v2, compress_hyper_6_24_chunk.v3, compress_hyper_6_24_chunk._ts_meta_count, compress_hyper_6_24_chunk._ts_meta_sequence_num, compress_hyper_6_24_chunk._ts_meta_min_3, compress_hyper_6_24_chunk._ts_meta_max_3, compress_hyper_6_24_chunk._ts_meta_min_1, compress_hyper_6_24_chunk._ts_meta_max_1, compress_hyper_6_24_chunk._ts_meta_min_2, compress_hyper_6_24_chunk._ts_meta_max_2
          ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_11_chunk (actual rows=0 loops=1)
                Output: _hyper_2_11_chunk."time", _hyper_2_11_chunk.device_id, _hyper_2_11_chunk.device_id_peer, _hyper_2_11_chunk.v0, _hyper_2_11_chunk.v1, _hyper_2_11_chunk.v2, _hyper_2_11_chunk.v3
                Filter: (_hyper_2_11_chunk.v3 > '10'::double precision)
                Rows Removed by Filter: 1512
                Bulk Decompression: true
-               ->  Seq Scan on _timescaledb_internal.compress_hyper_6_21_chunk (actual rows=3 loops=1)
-                     Output: compress_hyper_6_21_chunk."time", compress_hyper_6_21_chunk.device_id, compress_hyper_6_21_chunk.device_id_peer, compress_hyper_6_21_chunk.v0, compress_hyper_6_21_chunk.v1, compress_hyper_6_21_chunk.v2, compress_hyper_6_21_chunk.v3, compress_hyper_6_21_chunk._ts_meta_count, compress_hyper_6_21_chunk._ts_meta_sequence_num, compress_hyper_6_21_chunk._ts_meta_min_3, compress_hyper_6_21_chunk._ts_meta_max_3, compress_hyper_6_21_chunk._ts_meta_min_1, compress_hyper_6_21_chunk._ts_meta_max_1, compress_hyper_6_21_chunk._ts_meta_min_2, compress_hyper_6_21_chunk._ts_meta_max_2
+               ->  Seq Scan on _timescaledb_internal.compress_hyper_6_25_chunk (actual rows=3 loops=1)
+                     Output: compress_hyper_6_25_chunk."time", compress_hyper_6_25_chunk.device_id, compress_hyper_6_25_chunk.device_id_peer, compress_hyper_6_25_chunk.v0, compress_hyper_6_25_chunk.v1, compress_hyper_6_25_chunk.v2, compress_hyper_6_25_chunk.v3, compress_hyper_6_25_chunk._ts_meta_count, compress_hyper_6_25_chunk._ts_meta_sequence_num, compress_hyper_6_25_chunk._ts_meta_min_3, compress_hyper_6_25_chunk._ts_meta_max_3, compress_hyper_6_25_chunk._ts_meta_min_1, compress_hyper_6_25_chunk._ts_meta_max_1, compress_hyper_6_25_chunk._ts_meta_min_2, compress_hyper_6_25_chunk._ts_meta_max_2
          ->  Seq Scan on _timescaledb_internal._hyper_2_12_chunk (actual rows=0 loops=1)
                Output: _hyper_2_12_chunk."time", _hyper_2_12_chunk.device_id, _hyper_2_12_chunk.device_id_peer, _hyper_2_12_chunk.v0, _hyper_2_12_chunk.v1, _hyper_2_12_chunk.v2, _hyper_2_12_chunk.v3
                Filter: (_hyper_2_12_chunk.v3 > '10'::double precision)
@@ -3540,14 +3540,14 @@ LIMIT 10;
                Sort Key: _hyper_2_4_chunk."time"
                Sort Method: top-N heapsort 
                ->  Custom Scan (DecompressChunk) on _hyper_2_4_chunk (actual rows=360 loops=1)
-                     ->  Seq Scan on compress_hyper_6_17_chunk (actual rows=1 loops=1)
+                     ->  Seq Scan on compress_hyper_6_18_chunk (actual rows=1 loops=1)
                            Filter: (device_id = 1)
          ->  Index Scan Backward using _hyper_2_7_chunk_metrics_space_time_idx on _hyper_2_7_chunk (never executed)
                Filter: (device_id = 1)
          ->  Sort (never executed)
                Sort Key: _hyper_2_10_chunk."time"
                ->  Custom Scan (DecompressChunk) on _hyper_2_10_chunk (never executed)
-                     ->  Seq Scan on compress_hyper_6_20_chunk (never executed)
+                     ->  Seq Scan on compress_hyper_6_24_chunk (never executed)
                            Filter: (device_id = 1)
 (16 rows)
 
@@ -3577,7 +3577,7 @@ LIMIT 10;
                                  Sort Key: _hyper_2_4_chunk."time"
                                  Sort Method: quicksort 
                                  ->  Custom Scan (DecompressChunk) on _hyper_2_4_chunk (actual rows=360 loops=1)
-                                       ->  Seq Scan on compress_hyper_6_17_chunk (actual rows=1 loops=1)
+                                       ->  Seq Scan on compress_hyper_6_18_chunk (actual rows=1 loops=1)
                                              Filter: (device_id IS NOT NULL)
                      ->  Sort (actual rows=7 loops=1)
                            Sort Key: _hyper_2_5_chunk."time"
@@ -3586,7 +3586,7 @@ LIMIT 10;
                                  Sort Key: _hyper_2_5_chunk."time"
                                  Sort Method: quicksort 
                                  ->  Custom Scan (DecompressChunk) on _hyper_2_5_chunk (actual rows=1080 loops=1)
-                                       ->  Seq Scan on compress_hyper_6_18_chunk (actual rows=3 loops=1)
+                                       ->  Seq Scan on compress_hyper_6_19_chunk (actual rows=3 loops=1)
                                              Filter: (device_id IS NOT NULL)
                      ->  Sort (actual rows=3 loops=1)
                            Sort Key: _hyper_2_6_chunk."time"
@@ -3595,7 +3595,7 @@ LIMIT 10;
                                  Sort Key: _hyper_2_6_chunk."time"
                                  Sort Method: quicksort 
                                  ->  Custom Scan (DecompressChunk) on _hyper_2_6_chunk (actual rows=360 loops=1)
-                                       ->  Seq Scan on compress_hyper_6_19_chunk (actual rows=1 loops=1)
+                                       ->  Seq Scan on compress_hyper_6_20_chunk (actual rows=1 loops=1)
                                              Filter: (device_id IS NOT NULL)
                ->  Merge Append (never executed)
                      Sort Key: _hyper_2_7_chunk."time"
@@ -3612,14 +3612,14 @@ LIMIT 10;
                            ->  Sort (never executed)
                                  Sort Key: _hyper_2_10_chunk."time"
                                  ->  Custom Scan (DecompressChunk) on _hyper_2_10_chunk (never executed)
-                                       ->  Seq Scan on compress_hyper_6_20_chunk (never executed)
+                                       ->  Seq Scan on compress_hyper_6_24_chunk (never executed)
                                              Filter: (device_id IS NOT NULL)
                      ->  Sort (never executed)
                            Sort Key: _hyper_2_11_chunk."time"
                            ->  Sort (never executed)
                                  Sort Key: _hyper_2_11_chunk."time"
                                  ->  Custom Scan (DecompressChunk) on _hyper_2_11_chunk (never executed)
-                                       ->  Seq Scan on compress_hyper_6_21_chunk (never executed)
+                                       ->  Seq Scan on compress_hyper_6_25_chunk (never executed)
                                              Filter: (device_id IS NOT NULL)
                      ->  Index Scan Backward using _hyper_2_12_chunk_metrics_space_time_idx on _hyper_2_12_chunk (never executed)
                            Filter: (device_id IS NOT NULL)
@@ -3640,15 +3640,15 @@ LIMIT 10;
          Sort Method: quicksort 
          ->  Append (actual rows=0 loops=1)
                ->  Custom Scan (DecompressChunk) on _hyper_2_4_chunk (actual rows=0 loops=1)
-                     ->  Seq Scan on compress_hyper_6_17_chunk (actual rows=0 loops=1)
+                     ->  Seq Scan on compress_hyper_6_18_chunk (actual rows=0 loops=1)
                            Filter: (device_id IS NULL)
                            Rows Removed by Filter: 1
                ->  Custom Scan (DecompressChunk) on _hyper_2_5_chunk (actual rows=0 loops=1)
-                     ->  Seq Scan on compress_hyper_6_18_chunk (actual rows=0 loops=1)
+                     ->  Seq Scan on compress_hyper_6_19_chunk (actual rows=0 loops=1)
                            Filter: (device_id IS NULL)
                            Rows Removed by Filter: 3
                ->  Custom Scan (DecompressChunk) on _hyper_2_6_chunk (actual rows=0 loops=1)
-                     ->  Seq Scan on compress_hyper_6_19_chunk (actual rows=0 loops=1)
+                     ->  Seq Scan on compress_hyper_6_20_chunk (actual rows=0 loops=1)
                            Filter: (device_id IS NULL)
                            Rows Removed by Filter: 1
                ->  Index Scan using _hyper_2_7_chunk_metrics_space_device_id_device_id_peer_v0_v1_2 on _hyper_2_7_chunk (actual rows=0 loops=1)
@@ -3658,11 +3658,11 @@ LIMIT 10;
                ->  Index Scan using _hyper_2_9_chunk_metrics_space_device_id_device_id_peer_v0_v1_2 on _hyper_2_9_chunk (actual rows=0 loops=1)
                      Index Cond: (device_id IS NULL)
                ->  Custom Scan (DecompressChunk) on _hyper_2_10_chunk (actual rows=0 loops=1)
-                     ->  Seq Scan on compress_hyper_6_20_chunk (actual rows=0 loops=1)
+                     ->  Seq Scan on compress_hyper_6_24_chunk (actual rows=0 loops=1)
                            Filter: (device_id IS NULL)
                            Rows Removed by Filter: 1
                ->  Custom Scan (DecompressChunk) on _hyper_2_11_chunk (actual rows=0 loops=1)
-                     ->  Seq Scan on compress_hyper_6_21_chunk (actual rows=0 loops=1)
+                     ->  Seq Scan on compress_hyper_6_25_chunk (actual rows=0 loops=1)
                            Filter: (device_id IS NULL)
                            Rows Removed by Filter: 3
                ->  Index Scan using _hyper_2_12_chunk_metrics_space_device_id_device_id_peer_v0_v_2 on _hyper_2_12_chunk (actual rows=0 loops=1)
@@ -3695,7 +3695,7 @@ LIMIT 10;
                                  Sort Key: _hyper_2_4_chunk."time"
                                  Sort Method: quicksort 
                                  ->  Custom Scan (DecompressChunk) on _hyper_2_4_chunk (actual rows=360 loops=1)
-                                       ->  Seq Scan on compress_hyper_6_17_chunk (actual rows=1 loops=1)
+                                       ->  Seq Scan on compress_hyper_6_18_chunk (actual rows=1 loops=1)
                                              Filter: (device_id = ANY ('{1,2}'::integer[]))
                      ->  Sort (actual rows=6 loops=1)
                            Sort Key: _hyper_2_5_chunk."time"
@@ -3704,7 +3704,7 @@ LIMIT 10;
                                  Sort Key: _hyper_2_5_chunk."time"
                                  Sort Method: quicksort 
                                  ->  Custom Scan (DecompressChunk) on _hyper_2_5_chunk (actual rows=360 loops=1)
-                                       ->  Seq Scan on compress_hyper_6_18_chunk (actual rows=1 loops=1)
+                                       ->  Seq Scan on compress_hyper_6_19_chunk (actual rows=1 loops=1)
                                              Filter: (device_id = ANY ('{1,2}'::integer[]))
                                              Rows Removed by Filter: 2
                ->  Merge Append (never executed)
@@ -3720,14 +3720,14 @@ LIMIT 10;
                            ->  Sort (never executed)
                                  Sort Key: _hyper_2_10_chunk."time"
                                  ->  Custom Scan (DecompressChunk) on _hyper_2_10_chunk (never executed)
-                                       ->  Seq Scan on compress_hyper_6_20_chunk (never executed)
+                                       ->  Seq Scan on compress_hyper_6_24_chunk (never executed)
                                              Filter: (device_id = ANY ('{1,2}'::integer[]))
                      ->  Sort (never executed)
                            Sort Key: _hyper_2_11_chunk."time"
                            ->  Sort (never executed)
                                  Sort Key: _hyper_2_11_chunk."time"
                                  ->  Custom Scan (DecompressChunk) on _hyper_2_11_chunk (never executed)
-                                       ->  Seq Scan on compress_hyper_6_21_chunk (never executed)
+                                       ->  Seq Scan on compress_hyper_6_25_chunk (never executed)
                                              Filter: (device_id = ANY ('{1,2}'::integer[]))
 (50 rows)
 
@@ -3748,14 +3748,14 @@ LIMIT 10;
                Sort Key: _hyper_2_4_chunk."time"
                Sort Method: top-N heapsort 
                ->  Custom Scan (DecompressChunk) on _hyper_2_4_chunk (actual rows=360 loops=1)
-                     ->  Seq Scan on compress_hyper_6_17_chunk (actual rows=1 loops=1)
+                     ->  Seq Scan on compress_hyper_6_18_chunk (actual rows=1 loops=1)
                            Filter: (device_id = 1)
          ->  Index Scan Backward using _hyper_2_7_chunk_metrics_space_time_idx on _hyper_2_7_chunk (never executed)
                Filter: (device_id = 1)
          ->  Sort (never executed)
                Sort Key: _hyper_2_10_chunk."time"
                ->  Custom Scan (DecompressChunk) on _hyper_2_10_chunk (never executed)
-                     ->  Seq Scan on compress_hyper_6_20_chunk (never executed)
+                     ->  Seq Scan on compress_hyper_6_24_chunk (never executed)
                            Filter: (device_id = 1)
 (16 rows)
 
@@ -3785,7 +3785,7 @@ LIMIT 10;
                                  Sort Key: _hyper_2_4_chunk."time"
                                  Sort Method: quicksort 
                                  ->  Custom Scan (DecompressChunk) on _hyper_2_4_chunk (actual rows=0 loops=1)
-                                       ->  Seq Scan on compress_hyper_6_17_chunk (actual rows=0 loops=1)
+                                       ->  Seq Scan on compress_hyper_6_18_chunk (actual rows=0 loops=1)
                                              Filter: (device_id = device_id_peer)
                                              Rows Removed by Filter: 1
                      ->  Sort (actual rows=0 loops=1)
@@ -3795,7 +3795,7 @@ LIMIT 10;
                                  Sort Key: _hyper_2_5_chunk."time"
                                  Sort Method: quicksort 
                                  ->  Custom Scan (DecompressChunk) on _hyper_2_5_chunk (actual rows=0 loops=1)
-                                       ->  Seq Scan on compress_hyper_6_18_chunk (actual rows=0 loops=1)
+                                       ->  Seq Scan on compress_hyper_6_19_chunk (actual rows=0 loops=1)
                                              Filter: (device_id = device_id_peer)
                                              Rows Removed by Filter: 3
                      ->  Sort (actual rows=0 loops=1)
@@ -3805,7 +3805,7 @@ LIMIT 10;
                                  Sort Key: _hyper_2_6_chunk."time"
                                  Sort Method: quicksort 
                                  ->  Custom Scan (DecompressChunk) on _hyper_2_6_chunk (actual rows=0 loops=1)
-                                       ->  Seq Scan on compress_hyper_6_19_chunk (actual rows=0 loops=1)
+                                       ->  Seq Scan on compress_hyper_6_20_chunk (actual rows=0 loops=1)
                                              Filter: (device_id = device_id_peer)
                                              Rows Removed by Filter: 1
                ->  Merge Append (actual rows=0 loops=1)
@@ -3828,7 +3828,7 @@ LIMIT 10;
                                  Sort Key: _hyper_2_10_chunk."time"
                                  Sort Method: quicksort 
                                  ->  Custom Scan (DecompressChunk) on _hyper_2_10_chunk (actual rows=0 loops=1)
-                                       ->  Seq Scan on compress_hyper_6_20_chunk (actual rows=0 loops=1)
+                                       ->  Seq Scan on compress_hyper_6_24_chunk (actual rows=0 loops=1)
                                              Filter: (device_id = device_id_peer)
                                              Rows Removed by Filter: 1
                      ->  Sort (actual rows=0 loops=1)
@@ -3838,7 +3838,7 @@ LIMIT 10;
                                  Sort Key: _hyper_2_11_chunk."time"
                                  Sort Method: quicksort 
                                  ->  Custom Scan (DecompressChunk) on _hyper_2_11_chunk (actual rows=0 loops=1)
-                                       ->  Seq Scan on compress_hyper_6_21_chunk (actual rows=0 loops=1)
+                                       ->  Seq Scan on compress_hyper_6_25_chunk (actual rows=0 loops=1)
                                              Filter: (device_id = device_id_peer)
                                              Rows Removed by Filter: 3
                      ->  Index Scan Backward using _hyper_2_12_chunk_metrics_space_time_idx on _hyper_2_12_chunk (actual rows=0 loops=1)
@@ -3871,7 +3871,7 @@ LIMIT 10;
                                  Sort Key: _hyper_2_4_chunk."time"
                                  Sort Method: quicksort 
                                  ->  Custom Scan (DecompressChunk) on _hyper_2_4_chunk (actual rows=360 loops=1)
-                                       ->  Seq Scan on compress_hyper_6_17_chunk (actual rows=1 loops=1)
+                                       ->  Seq Scan on compress_hyper_6_18_chunk (actual rows=1 loops=1)
                                              Filter: (device_id_peer < device_id)
                      ->  Sort (actual rows=7 loops=1)
                            Sort Key: _hyper_2_5_chunk."time"
@@ -3880,7 +3880,7 @@ LIMIT 10;
                                  Sort Key: _hyper_2_5_chunk."time"
                                  Sort Method: quicksort 
                                  ->  Custom Scan (DecompressChunk) on _hyper_2_5_chunk (actual rows=1080 loops=1)
-                                       ->  Seq Scan on compress_hyper_6_18_chunk (actual rows=3 loops=1)
+                                       ->  Seq Scan on compress_hyper_6_19_chunk (actual rows=3 loops=1)
                                              Filter: (device_id_peer < device_id)
                      ->  Sort (actual rows=3 loops=1)
                            Sort Key: _hyper_2_6_chunk."time"
@@ -3889,7 +3889,7 @@ LIMIT 10;
                                  Sort Key: _hyper_2_6_chunk."time"
                                  Sort Method: quicksort 
                                  ->  Custom Scan (DecompressChunk) on _hyper_2_6_chunk (actual rows=360 loops=1)
-                                       ->  Seq Scan on compress_hyper_6_19_chunk (actual rows=1 loops=1)
+                                       ->  Seq Scan on compress_hyper_6_20_chunk (actual rows=1 loops=1)
                                              Filter: (device_id_peer < device_id)
                ->  Merge Append (never executed)
                      Sort Key: _hyper_2_7_chunk."time"
@@ -3906,14 +3906,14 @@ LIMIT 10;
                            ->  Sort (never executed)
                                  Sort Key: _hyper_2_10_chunk."time"
                                  ->  Custom Scan (DecompressChunk) on _hyper_2_10_chunk (never executed)
-                                       ->  Seq Scan on compress_hyper_6_20_chunk (never executed)
+                                       ->  Seq Scan on compress_hyper_6_24_chunk (never executed)
                                              Filter: (device_id_peer < device_id)
                      ->  Sort (never executed)
                            Sort Key: _hyper_2_11_chunk."time"
                            ->  Sort (never executed)
                                  Sort Key: _hyper_2_11_chunk."time"
                                  ->  Custom Scan (DecompressChunk) on _hyper_2_11_chunk (never executed)
-                                       ->  Seq Scan on compress_hyper_6_21_chunk (never executed)
+                                       ->  Seq Scan on compress_hyper_6_25_chunk (never executed)
                                              Filter: (device_id_peer < device_id)
                      ->  Index Scan Backward using _hyper_2_12_chunk_metrics_space_time_idx on _hyper_2_12_chunk (never executed)
                            Filter: (device_id_peer < device_id)
@@ -3936,7 +3936,7 @@ LIMIT 10;
                Sort Key: _hyper_2_6_chunk."time"
                Sort Method: top-N heapsort 
                ->  Custom Scan (DecompressChunk) on _hyper_2_6_chunk (actual rows=360 loops=1)
-                     ->  Seq Scan on compress_hyper_6_19_chunk (actual rows=1 loops=1)
+                     ->  Seq Scan on compress_hyper_6_20_chunk (actual rows=1 loops=1)
                            Filter: (device_id = 3)
          ->  Index Scan Backward using _hyper_2_9_chunk_metrics_space_time_idx on _hyper_2_9_chunk (never executed)
                Filter: (device_id = 3)
@@ -3969,7 +3969,7 @@ LIMIT 10;
                            ->  Custom Scan (DecompressChunk) on _hyper_2_4_chunk (actual rows=0 loops=1)
                                  Filter: (device_id = length("substring"(version(), 1, 3)))
                                  Rows Removed by Filter: 360
-                                 ->  Seq Scan on compress_hyper_6_17_chunk (actual rows=1 loops=1)
+                                 ->  Seq Scan on compress_hyper_6_18_chunk (actual rows=1 loops=1)
                ->  Sort (actual rows=0 loops=1)
                      Sort Key: _hyper_2_5_chunk."time"
                      Sort Method: quicksort 
@@ -3979,7 +3979,7 @@ LIMIT 10;
                            ->  Custom Scan (DecompressChunk) on _hyper_2_5_chunk (actual rows=0 loops=1)
                                  Filter: (device_id = length("substring"(version(), 1, 3)))
                                  Rows Removed by Filter: 1080
-                                 ->  Seq Scan on compress_hyper_6_18_chunk (actual rows=3 loops=1)
+                                 ->  Seq Scan on compress_hyper_6_19_chunk (actual rows=3 loops=1)
                ->  Sort (actual rows=10 loops=1)
                      Sort Key: _hyper_2_6_chunk."time"
                      Sort Method: top-N heapsort 
@@ -3988,7 +3988,7 @@ LIMIT 10;
                            Sort Method: quicksort 
                            ->  Custom Scan (DecompressChunk) on _hyper_2_6_chunk (actual rows=360 loops=1)
                                  Filter: (device_id = length("substring"(version(), 1, 3)))
-                                 ->  Seq Scan on compress_hyper_6_19_chunk (actual rows=1 loops=1)
+                                 ->  Seq Scan on compress_hyper_6_20_chunk (actual rows=1 loops=1)
          ->  Merge Append (never executed)
                Sort Key: _hyper_2_7_chunk."time"
                ->  Index Scan Backward using _hyper_2_7_chunk_metrics_space_device_id_time_idx on _hyper_2_7_chunk (never executed)
@@ -4005,14 +4005,14 @@ LIMIT 10;
                            Sort Key: _hyper_2_10_chunk."time"
                            ->  Custom Scan (DecompressChunk) on _hyper_2_10_chunk (never executed)
                                  Filter: (device_id = length("substring"(version(), 1, 3)))
-                                 ->  Seq Scan on compress_hyper_6_20_chunk (never executed)
+                                 ->  Seq Scan on compress_hyper_6_24_chunk (never executed)
                ->  Sort (never executed)
                      Sort Key: _hyper_2_11_chunk."time"
                      ->  Sort (never executed)
                            Sort Key: _hyper_2_11_chunk."time"
                            ->  Custom Scan (DecompressChunk) on _hyper_2_11_chunk (never executed)
                                  Filter: (device_id = length("substring"(version(), 1, 3)))
-                                 ->  Seq Scan on compress_hyper_6_21_chunk (never executed)
+                                 ->  Seq Scan on compress_hyper_6_25_chunk (never executed)
                ->  Index Scan Backward using _hyper_2_12_chunk_metrics_space_device_id_time_idx on _hyper_2_12_chunk (never executed)
                      Index Cond: (device_id = length("substring"(version(), 1, 3)))
 (60 rows)
@@ -4037,25 +4037,25 @@ LIMIT 10;
                Filter: ("time" = 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
                Rows Removed by Filter: 359
                ->  Sort (actual rows=1 loops=1)
-                     Sort Key: compress_hyper_6_17_chunk.device_id
+                     Sort Key: compress_hyper_6_18_chunk.device_id
                      Sort Method: quicksort 
-                     ->  Seq Scan on compress_hyper_6_17_chunk (actual rows=1 loops=1)
+                     ->  Seq Scan on compress_hyper_6_18_chunk (actual rows=1 loops=1)
                            Filter: ((_ts_meta_min_3 <= 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone) AND (_ts_meta_max_3 >= 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone))
          ->  Custom Scan (DecompressChunk) on _hyper_2_5_chunk (actual rows=3 loops=1)
                Filter: ("time" = 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
                Rows Removed by Filter: 1077
                ->  Sort (actual rows=3 loops=1)
-                     Sort Key: compress_hyper_6_18_chunk.device_id
+                     Sort Key: compress_hyper_6_19_chunk.device_id
                      Sort Method: quicksort 
-                     ->  Seq Scan on compress_hyper_6_18_chunk (actual rows=3 loops=1)
+                     ->  Seq Scan on compress_hyper_6_19_chunk (actual rows=3 loops=1)
                            Filter: ((_ts_meta_min_3 <= 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone) AND (_ts_meta_max_3 >= 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone))
          ->  Custom Scan (DecompressChunk) on _hyper_2_6_chunk (actual rows=1 loops=1)
                Filter: ("time" = 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
                Rows Removed by Filter: 359
                ->  Sort (actual rows=1 loops=1)
-                     Sort Key: compress_hyper_6_19_chunk.device_id
+                     Sort Key: compress_hyper_6_20_chunk.device_id
                      Sort Method: quicksort 
-                     ->  Seq Scan on compress_hyper_6_19_chunk (actual rows=1 loops=1)
+                     ->  Seq Scan on compress_hyper_6_20_chunk (actual rows=1 loops=1)
                            Filter: ((_ts_meta_min_3 <= 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone) AND (_ts_meta_max_3 >= 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone))
 (27 rows)
 
@@ -4076,17 +4076,17 @@ LIMIT 10;
                ->  Custom Scan (DecompressChunk) on _hyper_2_4_chunk (actual rows=3 loops=1)
                      Filter: ("time" < 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
                      Rows Removed by Filter: 357
-                     ->  Seq Scan on compress_hyper_6_17_chunk (actual rows=1 loops=1)
+                     ->  Seq Scan on compress_hyper_6_18_chunk (actual rows=1 loops=1)
                            Filter: (_ts_meta_min_3 < 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
                ->  Custom Scan (DecompressChunk) on _hyper_2_5_chunk (actual rows=9 loops=1)
                      Filter: ("time" < 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
                      Rows Removed by Filter: 1071
-                     ->  Seq Scan on compress_hyper_6_18_chunk (actual rows=3 loops=1)
+                     ->  Seq Scan on compress_hyper_6_19_chunk (actual rows=3 loops=1)
                            Filter: (_ts_meta_min_3 < 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
                ->  Custom Scan (DecompressChunk) on _hyper_2_6_chunk (actual rows=3 loops=1)
                      Filter: ("time" < 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
                      Rows Removed by Filter: 357
-                     ->  Seq Scan on compress_hyper_6_19_chunk (actual rows=1 loops=1)
+                     ->  Seq Scan on compress_hyper_6_20_chunk (actual rows=1 loops=1)
                            Filter: (_ts_meta_min_3 < 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
 (20 rows)
 
@@ -4107,17 +4107,17 @@ LIMIT 10;
                ->  Custom Scan (DecompressChunk) on _hyper_2_4_chunk (actual rows=4 loops=1)
                      Filter: ("time" <= 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
                      Rows Removed by Filter: 356
-                     ->  Seq Scan on compress_hyper_6_17_chunk (actual rows=1 loops=1)
+                     ->  Seq Scan on compress_hyper_6_18_chunk (actual rows=1 loops=1)
                            Filter: (_ts_meta_min_3 <= 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
                ->  Custom Scan (DecompressChunk) on _hyper_2_5_chunk (actual rows=12 loops=1)
                      Filter: ("time" <= 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
                      Rows Removed by Filter: 1068
-                     ->  Seq Scan on compress_hyper_6_18_chunk (actual rows=3 loops=1)
+                     ->  Seq Scan on compress_hyper_6_19_chunk (actual rows=3 loops=1)
                            Filter: (_ts_meta_min_3 <= 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
                ->  Custom Scan (DecompressChunk) on _hyper_2_6_chunk (actual rows=4 loops=1)
                      Filter: ("time" <= 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
                      Rows Removed by Filter: 356
-                     ->  Seq Scan on compress_hyper_6_19_chunk (actual rows=1 loops=1)
+                     ->  Seq Scan on compress_hyper_6_20_chunk (actual rows=1 loops=1)
                            Filter: (_ts_meta_min_3 <= 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
 (20 rows)
 
@@ -4148,7 +4148,7 @@ LIMIT 10;
                                  ->  Custom Scan (DecompressChunk) on _hyper_2_4_chunk (actual rows=357 loops=1)
                                        Filter: ("time" >= 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
                                        Rows Removed by Filter: 3
-                                       ->  Seq Scan on compress_hyper_6_17_chunk (actual rows=1 loops=1)
+                                       ->  Seq Scan on compress_hyper_6_18_chunk (actual rows=1 loops=1)
                                              Filter: (_ts_meta_max_3 >= 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
                      ->  Sort (actual rows=7 loops=1)
                            Sort Key: _hyper_2_5_chunk."time"
@@ -4159,7 +4159,7 @@ LIMIT 10;
                                  ->  Custom Scan (DecompressChunk) on _hyper_2_5_chunk (actual rows=1071 loops=1)
                                        Filter: ("time" >= 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
                                        Rows Removed by Filter: 9
-                                       ->  Seq Scan on compress_hyper_6_18_chunk (actual rows=3 loops=1)
+                                       ->  Seq Scan on compress_hyper_6_19_chunk (actual rows=3 loops=1)
                                              Filter: (_ts_meta_max_3 >= 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
                      ->  Sort (actual rows=3 loops=1)
                            Sort Key: _hyper_2_6_chunk."time"
@@ -4170,7 +4170,7 @@ LIMIT 10;
                                  ->  Custom Scan (DecompressChunk) on _hyper_2_6_chunk (actual rows=357 loops=1)
                                        Filter: ("time" >= 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
                                        Rows Removed by Filter: 3
-                                       ->  Seq Scan on compress_hyper_6_19_chunk (actual rows=1 loops=1)
+                                       ->  Seq Scan on compress_hyper_6_20_chunk (actual rows=1 loops=1)
                                              Filter: (_ts_meta_max_3 >= 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
                ->  Merge Append (never executed)
                      Sort Key: _hyper_2_7_chunk."time"
@@ -4188,7 +4188,7 @@ LIMIT 10;
                                  Sort Key: _hyper_2_10_chunk."time"
                                  ->  Custom Scan (DecompressChunk) on _hyper_2_10_chunk (never executed)
                                        Filter: ("time" >= 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
-                                       ->  Seq Scan on compress_hyper_6_20_chunk (never executed)
+                                       ->  Seq Scan on compress_hyper_6_24_chunk (never executed)
                                              Filter: (_ts_meta_max_3 >= 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
                      ->  Sort (never executed)
                            Sort Key: _hyper_2_11_chunk."time"
@@ -4196,7 +4196,7 @@ LIMIT 10;
                                  Sort Key: _hyper_2_11_chunk."time"
                                  ->  Custom Scan (DecompressChunk) on _hyper_2_11_chunk (never executed)
                                        Filter: ("time" >= 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
-                                       ->  Seq Scan on compress_hyper_6_21_chunk (never executed)
+                                       ->  Seq Scan on compress_hyper_6_25_chunk (never executed)
                                              Filter: (_ts_meta_max_3 >= 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
                      ->  Index Scan Backward using _hyper_2_12_chunk_metrics_space_time_idx on _hyper_2_12_chunk (never executed)
                            Index Cond: ("time" >= 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
@@ -4229,7 +4229,7 @@ LIMIT 10;
                                  ->  Custom Scan (DecompressChunk) on _hyper_2_4_chunk (actual rows=356 loops=1)
                                        Filter: ("time" > 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
                                        Rows Removed by Filter: 4
-                                       ->  Seq Scan on compress_hyper_6_17_chunk (actual rows=1 loops=1)
+                                       ->  Seq Scan on compress_hyper_6_18_chunk (actual rows=1 loops=1)
                                              Filter: (_ts_meta_max_3 > 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
                      ->  Sort (actual rows=7 loops=1)
                            Sort Key: _hyper_2_5_chunk."time"
@@ -4240,7 +4240,7 @@ LIMIT 10;
                                  ->  Custom Scan (DecompressChunk) on _hyper_2_5_chunk (actual rows=1068 loops=1)
                                        Filter: ("time" > 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
                                        Rows Removed by Filter: 12
-                                       ->  Seq Scan on compress_hyper_6_18_chunk (actual rows=3 loops=1)
+                                       ->  Seq Scan on compress_hyper_6_19_chunk (actual rows=3 loops=1)
                                              Filter: (_ts_meta_max_3 > 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
                      ->  Sort (actual rows=3 loops=1)
                            Sort Key: _hyper_2_6_chunk."time"
@@ -4251,7 +4251,7 @@ LIMIT 10;
                                  ->  Custom Scan (DecompressChunk) on _hyper_2_6_chunk (actual rows=356 loops=1)
                                        Filter: ("time" > 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
                                        Rows Removed by Filter: 4
-                                       ->  Seq Scan on compress_hyper_6_19_chunk (actual rows=1 loops=1)
+                                       ->  Seq Scan on compress_hyper_6_20_chunk (actual rows=1 loops=1)
                                              Filter: (_ts_meta_max_3 > 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
                ->  Merge Append (never executed)
                      Sort Key: _hyper_2_7_chunk."time"
@@ -4269,7 +4269,7 @@ LIMIT 10;
                                  Sort Key: _hyper_2_10_chunk."time"
                                  ->  Custom Scan (DecompressChunk) on _hyper_2_10_chunk (never executed)
                                        Filter: ("time" > 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
-                                       ->  Seq Scan on compress_hyper_6_20_chunk (never executed)
+                                       ->  Seq Scan on compress_hyper_6_24_chunk (never executed)
                                              Filter: (_ts_meta_max_3 > 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
                      ->  Sort (never executed)
                            Sort Key: _hyper_2_11_chunk."time"
@@ -4277,7 +4277,7 @@ LIMIT 10;
                                  Sort Key: _hyper_2_11_chunk."time"
                                  ->  Custom Scan (DecompressChunk) on _hyper_2_11_chunk (never executed)
                                        Filter: ("time" > 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
-                                       ->  Seq Scan on compress_hyper_6_21_chunk (never executed)
+                                       ->  Seq Scan on compress_hyper_6_25_chunk (never executed)
                                              Filter: (_ts_meta_max_3 > 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
                      ->  Index Scan Backward using _hyper_2_12_chunk_metrics_space_time_idx on _hyper_2_12_chunk (never executed)
                            Index Cond: ("time" > 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
@@ -4310,7 +4310,7 @@ LIMIT 10;
                                  ->  Custom Scan (DecompressChunk) on _hyper_2_4_chunk (actual rows=356 loops=1)
                                        Filter: ('Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone < "time")
                                        Rows Removed by Filter: 4
-                                       ->  Seq Scan on compress_hyper_6_17_chunk (actual rows=1 loops=1)
+                                       ->  Seq Scan on compress_hyper_6_18_chunk (actual rows=1 loops=1)
                                              Filter: (_ts_meta_max_3 > 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
                      ->  Sort (actual rows=7 loops=1)
                            Sort Key: _hyper_2_5_chunk."time"
@@ -4321,7 +4321,7 @@ LIMIT 10;
                                  ->  Custom Scan (DecompressChunk) on _hyper_2_5_chunk (actual rows=1068 loops=1)
                                        Filter: ('Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone < "time")
                                        Rows Removed by Filter: 12
-                                       ->  Seq Scan on compress_hyper_6_18_chunk (actual rows=3 loops=1)
+                                       ->  Seq Scan on compress_hyper_6_19_chunk (actual rows=3 loops=1)
                                              Filter: (_ts_meta_max_3 > 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
                      ->  Sort (actual rows=3 loops=1)
                            Sort Key: _hyper_2_6_chunk."time"
@@ -4332,7 +4332,7 @@ LIMIT 10;
                                  ->  Custom Scan (DecompressChunk) on _hyper_2_6_chunk (actual rows=356 loops=1)
                                        Filter: ('Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone < "time")
                                        Rows Removed by Filter: 4
-                                       ->  Seq Scan on compress_hyper_6_19_chunk (actual rows=1 loops=1)
+                                       ->  Seq Scan on compress_hyper_6_20_chunk (actual rows=1 loops=1)
                                              Filter: (_ts_meta_max_3 > 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
                ->  Merge Append (never executed)
                      Sort Key: _hyper_2_7_chunk."time"
@@ -4350,7 +4350,7 @@ LIMIT 10;
                                  Sort Key: _hyper_2_10_chunk."time"
                                  ->  Custom Scan (DecompressChunk) on _hyper_2_10_chunk (never executed)
                                        Filter: ('Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone < "time")
-                                       ->  Seq Scan on compress_hyper_6_20_chunk (never executed)
+                                       ->  Seq Scan on compress_hyper_6_24_chunk (never executed)
                                              Filter: (_ts_meta_max_3 > 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
                      ->  Sort (never executed)
                            Sort Key: _hyper_2_11_chunk."time"
@@ -4358,7 +4358,7 @@ LIMIT 10;
                                  Sort Key: _hyper_2_11_chunk."time"
                                  ->  Custom Scan (DecompressChunk) on _hyper_2_11_chunk (never executed)
                                        Filter: ('Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone < "time")
-                                       ->  Seq Scan on compress_hyper_6_21_chunk (never executed)
+                                       ->  Seq Scan on compress_hyper_6_25_chunk (never executed)
                                              Filter: (_ts_meta_max_3 > 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
                      ->  Index Scan Backward using _hyper_2_12_chunk_metrics_space_time_idx on _hyper_2_12_chunk (never executed)
                            Index Cond: ("time" > 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
@@ -4381,17 +4381,17 @@ LIMIT 10;
          ->  Append (actual rows=0 loops=1)
                ->  Custom Scan (DecompressChunk) on _hyper_2_4_chunk (actual rows=0 loops=1)
                      Filter: (v0 < 1)
-                     ->  Seq Scan on compress_hyper_6_17_chunk (actual rows=0 loops=1)
+                     ->  Seq Scan on compress_hyper_6_18_chunk (actual rows=0 loops=1)
                            Filter: (_ts_meta_min_1 < 1)
                            Rows Removed by Filter: 1
                ->  Custom Scan (DecompressChunk) on _hyper_2_5_chunk (actual rows=0 loops=1)
                      Filter: (v0 < 1)
-                     ->  Seq Scan on compress_hyper_6_18_chunk (actual rows=0 loops=1)
+                     ->  Seq Scan on compress_hyper_6_19_chunk (actual rows=0 loops=1)
                            Filter: (_ts_meta_min_1 < 1)
                            Rows Removed by Filter: 3
                ->  Custom Scan (DecompressChunk) on _hyper_2_6_chunk (actual rows=0 loops=1)
                      Filter: (v0 < 1)
-                     ->  Seq Scan on compress_hyper_6_19_chunk (actual rows=0 loops=1)
+                     ->  Seq Scan on compress_hyper_6_20_chunk (actual rows=0 loops=1)
                            Filter: (_ts_meta_min_1 < 1)
                            Rows Removed by Filter: 1
                ->  Index Scan using _hyper_2_7_chunk_metrics_space_device_id_device_id_peer_v0_v1_2 on _hyper_2_7_chunk (actual rows=0 loops=1)
@@ -4402,12 +4402,12 @@ LIMIT 10;
                      Index Cond: (v0 < 1)
                ->  Custom Scan (DecompressChunk) on _hyper_2_10_chunk (actual rows=0 loops=1)
                      Filter: (v0 < 1)
-                     ->  Seq Scan on compress_hyper_6_20_chunk (actual rows=0 loops=1)
+                     ->  Seq Scan on compress_hyper_6_24_chunk (actual rows=0 loops=1)
                            Filter: (_ts_meta_min_1 < 1)
                            Rows Removed by Filter: 1
                ->  Custom Scan (DecompressChunk) on _hyper_2_11_chunk (actual rows=0 loops=1)
                      Filter: (v0 < 1)
-                     ->  Seq Scan on compress_hyper_6_21_chunk (actual rows=0 loops=1)
+                     ->  Seq Scan on compress_hyper_6_25_chunk (actual rows=0 loops=1)
                            Filter: (_ts_meta_min_1 < 1)
                            Rows Removed by Filter: 3
                ->  Index Scan using _hyper_2_12_chunk_metrics_space_device_id_device_id_peer_v0_v_2 on _hyper_2_12_chunk (actual rows=0 loops=1)
@@ -4440,7 +4440,7 @@ LIMIT 10;
                                  Sort Method: quicksort 
                                  ->  Custom Scan (DecompressChunk) on _hyper_2_4_chunk (actual rows=0 loops=1)
                                        Filter: (v0 < device_id)
-                                       ->  Seq Scan on compress_hyper_6_17_chunk (actual rows=0 loops=1)
+                                       ->  Seq Scan on compress_hyper_6_18_chunk (actual rows=0 loops=1)
                                              Filter: (_ts_meta_min_1 < device_id)
                                              Rows Removed by Filter: 1
                      ->  Sort (actual rows=0 loops=1)
@@ -4451,7 +4451,7 @@ LIMIT 10;
                                  Sort Method: quicksort 
                                  ->  Custom Scan (DecompressChunk) on _hyper_2_5_chunk (actual rows=0 loops=1)
                                        Filter: (v0 < device_id)
-                                       ->  Seq Scan on compress_hyper_6_18_chunk (actual rows=0 loops=1)
+                                       ->  Seq Scan on compress_hyper_6_19_chunk (actual rows=0 loops=1)
                                              Filter: (_ts_meta_min_1 < device_id)
                                              Rows Removed by Filter: 3
                      ->  Sort (actual rows=0 loops=1)
@@ -4462,7 +4462,7 @@ LIMIT 10;
                                  Sort Method: quicksort 
                                  ->  Custom Scan (DecompressChunk) on _hyper_2_6_chunk (actual rows=0 loops=1)
                                        Filter: (v0 < device_id)
-                                       ->  Seq Scan on compress_hyper_6_19_chunk (actual rows=0 loops=1)
+                                       ->  Seq Scan on compress_hyper_6_20_chunk (actual rows=0 loops=1)
                                              Filter: (_ts_meta_min_1 < device_id)
                                              Rows Removed by Filter: 1
                ->  Merge Append (actual rows=0 loops=1)
@@ -4486,7 +4486,7 @@ LIMIT 10;
                                  Sort Method: quicksort 
                                  ->  Custom Scan (DecompressChunk) on _hyper_2_10_chunk (actual rows=0 loops=1)
                                        Filter: (v0 < device_id)
-                                       ->  Seq Scan on compress_hyper_6_20_chunk (actual rows=0 loops=1)
+                                       ->  Seq Scan on compress_hyper_6_24_chunk (actual rows=0 loops=1)
                                              Filter: (_ts_meta_min_1 < device_id)
                                              Rows Removed by Filter: 1
                      ->  Sort (actual rows=0 loops=1)
@@ -4497,7 +4497,7 @@ LIMIT 10;
                                  Sort Method: quicksort 
                                  ->  Custom Scan (DecompressChunk) on _hyper_2_11_chunk (actual rows=0 loops=1)
                                        Filter: (v0 < device_id)
-                                       ->  Seq Scan on compress_hyper_6_21_chunk (actual rows=0 loops=1)
+                                       ->  Seq Scan on compress_hyper_6_25_chunk (actual rows=0 loops=1)
                                              Filter: (_ts_meta_min_1 < device_id)
                                              Rows Removed by Filter: 3
                      ->  Index Scan Backward using _hyper_2_12_chunk_metrics_space_time_idx on _hyper_2_12_chunk (actual rows=0 loops=1)
@@ -4531,7 +4531,7 @@ LIMIT 10;
                                  Sort Method: quicksort 
                                  ->  Custom Scan (DecompressChunk) on _hyper_2_4_chunk (actual rows=360 loops=1)
                                        Filter: (device_id < v0)
-                                       ->  Seq Scan on compress_hyper_6_17_chunk (actual rows=1 loops=1)
+                                       ->  Seq Scan on compress_hyper_6_18_chunk (actual rows=1 loops=1)
                                              Filter: (_ts_meta_max_1 > device_id)
                      ->  Sort (actual rows=7 loops=1)
                            Sort Key: _hyper_2_5_chunk."time"
@@ -4541,7 +4541,7 @@ LIMIT 10;
                                  Sort Method: quicksort 
                                  ->  Custom Scan (DecompressChunk) on _hyper_2_5_chunk (actual rows=1080 loops=1)
                                        Filter: (device_id < v0)
-                                       ->  Seq Scan on compress_hyper_6_18_chunk (actual rows=3 loops=1)
+                                       ->  Seq Scan on compress_hyper_6_19_chunk (actual rows=3 loops=1)
                                              Filter: (_ts_meta_max_1 > device_id)
                      ->  Sort (actual rows=3 loops=1)
                            Sort Key: _hyper_2_6_chunk."time"
@@ -4551,7 +4551,7 @@ LIMIT 10;
                                  Sort Method: quicksort 
                                  ->  Custom Scan (DecompressChunk) on _hyper_2_6_chunk (actual rows=360 loops=1)
                                        Filter: (device_id < v0)
-                                       ->  Seq Scan on compress_hyper_6_19_chunk (actual rows=1 loops=1)
+                                       ->  Seq Scan on compress_hyper_6_20_chunk (actual rows=1 loops=1)
                                              Filter: (_ts_meta_max_1 > device_id)
                ->  Merge Append (never executed)
                      Sort Key: _hyper_2_7_chunk."time"
@@ -4569,7 +4569,7 @@ LIMIT 10;
                                  Sort Key: _hyper_2_10_chunk."time"
                                  ->  Custom Scan (DecompressChunk) on _hyper_2_10_chunk (never executed)
                                        Filter: (device_id < v0)
-                                       ->  Seq Scan on compress_hyper_6_20_chunk (never executed)
+                                       ->  Seq Scan on compress_hyper_6_24_chunk (never executed)
                                              Filter: (_ts_meta_max_1 > device_id)
                      ->  Sort (never executed)
                            Sort Key: _hyper_2_11_chunk."time"
@@ -4577,7 +4577,7 @@ LIMIT 10;
                                  Sort Key: _hyper_2_11_chunk."time"
                                  ->  Custom Scan (DecompressChunk) on _hyper_2_11_chunk (never executed)
                                        Filter: (device_id < v0)
-                                       ->  Seq Scan on compress_hyper_6_21_chunk (never executed)
+                                       ->  Seq Scan on compress_hyper_6_25_chunk (never executed)
                                              Filter: (_ts_meta_max_1 > device_id)
                      ->  Index Scan Backward using _hyper_2_12_chunk_metrics_space_time_idx on _hyper_2_12_chunk (never executed)
                            Filter: (device_id < v0)
@@ -4610,7 +4610,7 @@ LIMIT 10;
                                  ->  Custom Scan (DecompressChunk) on _hyper_2_4_chunk (actual rows=0 loops=1)
                                        Filter: (v1 = (device_id)::double precision)
                                        Rows Removed by Filter: 360
-                                       ->  Seq Scan on compress_hyper_6_17_chunk (actual rows=1 loops=1)
+                                       ->  Seq Scan on compress_hyper_6_18_chunk (actual rows=1 loops=1)
                      ->  Sort (actual rows=0 loops=1)
                            Sort Key: _hyper_2_5_chunk."time"
                            Sort Method: quicksort 
@@ -4620,7 +4620,7 @@ LIMIT 10;
                                  ->  Custom Scan (DecompressChunk) on _hyper_2_5_chunk (actual rows=0 loops=1)
                                        Filter: (v1 = (device_id)::double precision)
                                        Rows Removed by Filter: 1080
-                                       ->  Seq Scan on compress_hyper_6_18_chunk (actual rows=3 loops=1)
+                                       ->  Seq Scan on compress_hyper_6_19_chunk (actual rows=3 loops=1)
                      ->  Sort (actual rows=0 loops=1)
                            Sort Key: _hyper_2_6_chunk."time"
                            Sort Method: quicksort 
@@ -4630,7 +4630,7 @@ LIMIT 10;
                                  ->  Custom Scan (DecompressChunk) on _hyper_2_6_chunk (actual rows=0 loops=1)
                                        Filter: (v1 = (device_id)::double precision)
                                        Rows Removed by Filter: 360
-                                       ->  Seq Scan on compress_hyper_6_19_chunk (actual rows=1 loops=1)
+                                       ->  Seq Scan on compress_hyper_6_20_chunk (actual rows=1 loops=1)
                ->  Merge Append (actual rows=0 loops=1)
                      Sort Key: _hyper_2_7_chunk."time"
                      ->  Index Scan Backward using _hyper_2_7_chunk_metrics_space_time_idx on _hyper_2_7_chunk (actual rows=0 loops=1)
@@ -4653,7 +4653,7 @@ LIMIT 10;
                                  ->  Custom Scan (DecompressChunk) on _hyper_2_10_chunk (actual rows=0 loops=1)
                                        Filter: (v1 = (device_id)::double precision)
                                        Rows Removed by Filter: 504
-                                       ->  Seq Scan on compress_hyper_6_20_chunk (actual rows=1 loops=1)
+                                       ->  Seq Scan on compress_hyper_6_24_chunk (actual rows=1 loops=1)
                      ->  Sort (actual rows=0 loops=1)
                            Sort Key: _hyper_2_11_chunk."time"
                            Sort Method: quicksort 
@@ -4663,7 +4663,7 @@ LIMIT 10;
                                  ->  Custom Scan (DecompressChunk) on _hyper_2_11_chunk (actual rows=0 loops=1)
                                        Filter: (v1 = (device_id)::double precision)
                                        Rows Removed by Filter: 1512
-                                       ->  Seq Scan on compress_hyper_6_21_chunk (actual rows=3 loops=1)
+                                       ->  Seq Scan on compress_hyper_6_25_chunk (actual rows=3 loops=1)
                      ->  Index Scan Backward using _hyper_2_12_chunk_metrics_space_time_idx on _hyper_2_12_chunk (actual rows=0 loops=1)
                            Filter: (v1 = (device_id)::double precision)
                            Rows Removed by Filter: 504
@@ -4697,7 +4697,7 @@ LIMIT 10;
                                  ->  Custom Scan (DecompressChunk) on _hyper_2_4_chunk (actual rows=0 loops=1)
                                        Filter: ((v0)::double precision = v1)
                                        Rows Removed by Filter: 360
-                                       ->  Seq Scan on compress_hyper_6_17_chunk (actual rows=1 loops=1)
+                                       ->  Seq Scan on compress_hyper_6_18_chunk (actual rows=1 loops=1)
                      ->  Sort (actual rows=0 loops=1)
                            Sort Key: _hyper_2_5_chunk."time"
                            Sort Method: quicksort 
@@ -4707,7 +4707,7 @@ LIMIT 10;
                                  ->  Custom Scan (DecompressChunk) on _hyper_2_5_chunk (actual rows=0 loops=1)
                                        Filter: ((v0)::double precision = v1)
                                        Rows Removed by Filter: 1080
-                                       ->  Seq Scan on compress_hyper_6_18_chunk (actual rows=3 loops=1)
+                                       ->  Seq Scan on compress_hyper_6_19_chunk (actual rows=3 loops=1)
                      ->  Sort (actual rows=0 loops=1)
                            Sort Key: _hyper_2_6_chunk."time"
                            Sort Method: quicksort 
@@ -4717,7 +4717,7 @@ LIMIT 10;
                                  ->  Custom Scan (DecompressChunk) on _hyper_2_6_chunk (actual rows=0 loops=1)
                                        Filter: ((v0)::double precision = v1)
                                        Rows Removed by Filter: 360
-                                       ->  Seq Scan on compress_hyper_6_19_chunk (actual rows=1 loops=1)
+                                       ->  Seq Scan on compress_hyper_6_20_chunk (actual rows=1 loops=1)
                ->  Merge Append (actual rows=0 loops=1)
                      Sort Key: _hyper_2_7_chunk."time"
                      ->  Index Scan Backward using _hyper_2_7_chunk_metrics_space_time_idx on _hyper_2_7_chunk (actual rows=0 loops=1)
@@ -4740,7 +4740,7 @@ LIMIT 10;
                                  ->  Custom Scan (DecompressChunk) on _hyper_2_10_chunk (actual rows=0 loops=1)
                                        Filter: ((v0)::double precision = v1)
                                        Rows Removed by Filter: 504
-                                       ->  Seq Scan on compress_hyper_6_20_chunk (actual rows=1 loops=1)
+                                       ->  Seq Scan on compress_hyper_6_24_chunk (actual rows=1 loops=1)
                      ->  Sort (actual rows=0 loops=1)
                            Sort Key: _hyper_2_11_chunk."time"
                            Sort Method: quicksort 
@@ -4750,7 +4750,7 @@ LIMIT 10;
                                  ->  Custom Scan (DecompressChunk) on _hyper_2_11_chunk (actual rows=0 loops=1)
                                        Filter: ((v0)::double precision = v1)
                                        Rows Removed by Filter: 1512
-                                       ->  Seq Scan on compress_hyper_6_21_chunk (actual rows=3 loops=1)
+                                       ->  Seq Scan on compress_hyper_6_25_chunk (actual rows=3 loops=1)
                      ->  Index Scan Backward using _hyper_2_12_chunk_metrics_space_time_idx on _hyper_2_12_chunk (actual rows=0 loops=1)
                            Filter: ((v0)::double precision = v1)
                            Rows Removed by Filter: 504
@@ -4783,9 +4783,9 @@ LIMIT 10;
                      Filter: (_hyper_2_4_chunk."time" > 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
                      Rows Removed by Filter: 4
                      Bulk Decompression: true
-                     ->  Seq Scan on _timescaledb_internal.compress_hyper_6_17_chunk (actual rows=1 loops=1)
-                           Output: compress_hyper_6_17_chunk."time", compress_hyper_6_17_chunk.device_id, compress_hyper_6_17_chunk.device_id_peer, compress_hyper_6_17_chunk.v0, compress_hyper_6_17_chunk.v1, compress_hyper_6_17_chunk.v2, compress_hyper_6_17_chunk.v3, compress_hyper_6_17_chunk._ts_meta_count, compress_hyper_6_17_chunk._ts_meta_sequence_num, compress_hyper_6_17_chunk._ts_meta_min_3, compress_hyper_6_17_chunk._ts_meta_max_3, compress_hyper_6_17_chunk._ts_meta_min_1, compress_hyper_6_17_chunk._ts_meta_max_1, compress_hyper_6_17_chunk._ts_meta_min_2, compress_hyper_6_17_chunk._ts_meta_max_2
-                           Filter: ((compress_hyper_6_17_chunk._ts_meta_max_3 > 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone) AND (compress_hyper_6_17_chunk.device_id = 1))
+                     ->  Seq Scan on _timescaledb_internal.compress_hyper_6_18_chunk (actual rows=1 loops=1)
+                           Output: compress_hyper_6_18_chunk."time", compress_hyper_6_18_chunk.device_id, compress_hyper_6_18_chunk.device_id_peer, compress_hyper_6_18_chunk.v0, compress_hyper_6_18_chunk.v1, compress_hyper_6_18_chunk.v2, compress_hyper_6_18_chunk.v3, compress_hyper_6_18_chunk._ts_meta_count, compress_hyper_6_18_chunk._ts_meta_sequence_num, compress_hyper_6_18_chunk._ts_meta_min_3, compress_hyper_6_18_chunk._ts_meta_max_3, compress_hyper_6_18_chunk._ts_meta_min_1, compress_hyper_6_18_chunk._ts_meta_max_1, compress_hyper_6_18_chunk._ts_meta_min_2, compress_hyper_6_18_chunk._ts_meta_max_2
+                           Filter: ((compress_hyper_6_18_chunk._ts_meta_max_3 > 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone) AND (compress_hyper_6_18_chunk.device_id = 1))
          ->  Index Scan Backward using _hyper_2_7_chunk_metrics_space_time_idx on _timescaledb_internal._hyper_2_7_chunk (never executed)
                Output: _hyper_2_7_chunk."time", _hyper_2_7_chunk.device_id, _hyper_2_7_chunk.device_id_peer, _hyper_2_7_chunk.v0, _hyper_2_7_chunk.v1, _hyper_2_7_chunk.v2, _hyper_2_7_chunk.v3
                Index Cond: (_hyper_2_7_chunk."time" > 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
@@ -4797,9 +4797,9 @@ LIMIT 10;
                      Output: _hyper_2_10_chunk."time", _hyper_2_10_chunk.device_id, _hyper_2_10_chunk.device_id_peer, _hyper_2_10_chunk.v0, _hyper_2_10_chunk.v1, _hyper_2_10_chunk.v2, _hyper_2_10_chunk.v3
                      Filter: (_hyper_2_10_chunk."time" > 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
                      Bulk Decompression: true
-                     ->  Seq Scan on _timescaledb_internal.compress_hyper_6_20_chunk (never executed)
-                           Output: compress_hyper_6_20_chunk."time", compress_hyper_6_20_chunk.device_id, compress_hyper_6_20_chunk.device_id_peer, compress_hyper_6_20_chunk.v0, compress_hyper_6_20_chunk.v1, compress_hyper_6_20_chunk.v2, compress_hyper_6_20_chunk.v3, compress_hyper_6_20_chunk._ts_meta_count, compress_hyper_6_20_chunk._ts_meta_sequence_num, compress_hyper_6_20_chunk._ts_meta_min_3, compress_hyper_6_20_chunk._ts_meta_max_3, compress_hyper_6_20_chunk._ts_meta_min_1, compress_hyper_6_20_chunk._ts_meta_max_1, compress_hyper_6_20_chunk._ts_meta_min_2, compress_hyper_6_20_chunk._ts_meta_max_2
-                           Filter: ((compress_hyper_6_20_chunk._ts_meta_max_3 > 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone) AND (compress_hyper_6_20_chunk.device_id = 1))
+                     ->  Seq Scan on _timescaledb_internal.compress_hyper_6_24_chunk (never executed)
+                           Output: compress_hyper_6_24_chunk."time", compress_hyper_6_24_chunk.device_id, compress_hyper_6_24_chunk.device_id_peer, compress_hyper_6_24_chunk.v0, compress_hyper_6_24_chunk.v1, compress_hyper_6_24_chunk.v2, compress_hyper_6_24_chunk.v3, compress_hyper_6_24_chunk._ts_meta_count, compress_hyper_6_24_chunk._ts_meta_sequence_num, compress_hyper_6_24_chunk._ts_meta_min_3, compress_hyper_6_24_chunk._ts_meta_max_3, compress_hyper_6_24_chunk._ts_meta_min_1, compress_hyper_6_24_chunk._ts_meta_max_1, compress_hyper_6_24_chunk._ts_meta_min_2, compress_hyper_6_24_chunk._ts_meta_max_2
+                           Filter: ((compress_hyper_6_24_chunk._ts_meta_max_3 > 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone) AND (compress_hyper_6_24_chunk.device_id = 1))
 (33 rows)
 
 --pushdown of quals on order by and segment by cols or together (not pushed down)
@@ -4830,7 +4830,7 @@ LIMIT 10;
                                  Sort Method: quicksort 
                                  ->  Custom Scan (DecompressChunk) on _hyper_2_4_chunk (actual rows=360 loops=1)
                                        Filter: (("time" > 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone) OR (device_id = 1))
-                                       ->  Seq Scan on compress_hyper_6_17_chunk (actual rows=1 loops=1)
+                                       ->  Seq Scan on compress_hyper_6_18_chunk (actual rows=1 loops=1)
                      ->  Sort (actual rows=7 loops=1)
                            Sort Key: _hyper_2_5_chunk."time"
                            Sort Method: quicksort 
@@ -4840,7 +4840,7 @@ LIMIT 10;
                                  ->  Custom Scan (DecompressChunk) on _hyper_2_5_chunk (actual rows=1068 loops=1)
                                        Filter: (("time" > 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone) OR (device_id = 1))
                                        Rows Removed by Filter: 12
-                                       ->  Seq Scan on compress_hyper_6_18_chunk (actual rows=3 loops=1)
+                                       ->  Seq Scan on compress_hyper_6_19_chunk (actual rows=3 loops=1)
                      ->  Sort (actual rows=3 loops=1)
                            Sort Key: _hyper_2_6_chunk."time"
                            Sort Method: quicksort 
@@ -4850,7 +4850,7 @@ LIMIT 10;
                                  ->  Custom Scan (DecompressChunk) on _hyper_2_6_chunk (actual rows=356 loops=1)
                                        Filter: (("time" > 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone) OR (device_id = 1))
                                        Rows Removed by Filter: 4
-                                       ->  Seq Scan on compress_hyper_6_19_chunk (actual rows=1 loops=1)
+                                       ->  Seq Scan on compress_hyper_6_20_chunk (actual rows=1 loops=1)
                ->  Merge Append (never executed)
                      Sort Key: _hyper_2_7_chunk."time"
                      ->  Index Scan Backward using _hyper_2_7_chunk_metrics_space_time_idx on _hyper_2_7_chunk (never executed)
@@ -4867,14 +4867,14 @@ LIMIT 10;
                                  Sort Key: _hyper_2_10_chunk."time"
                                  ->  Custom Scan (DecompressChunk) on _hyper_2_10_chunk (never executed)
                                        Filter: (("time" > 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone) OR (device_id = 1))
-                                       ->  Seq Scan on compress_hyper_6_20_chunk (never executed)
+                                       ->  Seq Scan on compress_hyper_6_24_chunk (never executed)
                      ->  Sort (never executed)
                            Sort Key: _hyper_2_11_chunk."time"
                            ->  Sort (never executed)
                                  Sort Key: _hyper_2_11_chunk."time"
                                  ->  Custom Scan (DecompressChunk) on _hyper_2_11_chunk (never executed)
                                        Filter: (("time" > 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone) OR (device_id = 1))
-                                       ->  Seq Scan on compress_hyper_6_21_chunk (never executed)
+                                       ->  Seq Scan on compress_hyper_6_25_chunk (never executed)
                      ->  Index Scan Backward using _hyper_2_12_chunk_metrics_space_time_idx on _hyper_2_12_chunk (never executed)
                            Filter: (("time" > 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone) OR (device_id = 1))
 (64 rows)
@@ -4906,7 +4906,7 @@ LIMIT 10;
                                  Sort Method: quicksort 
                                  ->  Custom Scan (DecompressChunk) on _hyper_2_4_chunk (actual rows=360 loops=1)
                                        Filter: ("time" < now())
-                                       ->  Seq Scan on compress_hyper_6_17_chunk (actual rows=1 loops=1)
+                                       ->  Seq Scan on compress_hyper_6_18_chunk (actual rows=1 loops=1)
                      ->  Sort (actual rows=7 loops=1)
                            Sort Key: _hyper_2_5_chunk."time"
                            Sort Method: quicksort 
@@ -4915,7 +4915,7 @@ LIMIT 10;
                                  Sort Method: quicksort 
                                  ->  Custom Scan (DecompressChunk) on _hyper_2_5_chunk (actual rows=1080 loops=1)
                                        Filter: ("time" < now())
-                                       ->  Seq Scan on compress_hyper_6_18_chunk (actual rows=3 loops=1)
+                                       ->  Seq Scan on compress_hyper_6_19_chunk (actual rows=3 loops=1)
                      ->  Sort (actual rows=3 loops=1)
                            Sort Key: _hyper_2_6_chunk."time"
                            Sort Method: quicksort 
@@ -4924,7 +4924,7 @@ LIMIT 10;
                                  Sort Method: quicksort 
                                  ->  Custom Scan (DecompressChunk) on _hyper_2_6_chunk (actual rows=360 loops=1)
                                        Filter: ("time" < now())
-                                       ->  Seq Scan on compress_hyper_6_19_chunk (actual rows=1 loops=1)
+                                       ->  Seq Scan on compress_hyper_6_20_chunk (actual rows=1 loops=1)
                ->  Merge Append (never executed)
                      Sort Key: _hyper_2_7_chunk."time"
                      ->  Index Scan Backward using _hyper_2_7_chunk_metrics_space_time_idx on _hyper_2_7_chunk (never executed)
@@ -4941,14 +4941,14 @@ LIMIT 10;
                                  Sort Key: _hyper_2_10_chunk."time"
                                  ->  Custom Scan (DecompressChunk) on _hyper_2_10_chunk (never executed)
                                        Filter: ("time" < now())
-                                       ->  Seq Scan on compress_hyper_6_20_chunk (never executed)
+                                       ->  Seq Scan on compress_hyper_6_24_chunk (never executed)
                      ->  Sort (never executed)
                            Sort Key: _hyper_2_11_chunk."time"
                            ->  Sort (never executed)
                                  Sort Key: _hyper_2_11_chunk."time"
                                  ->  Custom Scan (DecompressChunk) on _hyper_2_11_chunk (never executed)
                                        Filter: ("time" < now())
-                                       ->  Seq Scan on compress_hyper_6_21_chunk (never executed)
+                                       ->  Seq Scan on compress_hyper_6_25_chunk (never executed)
                      ->  Index Scan Backward using _hyper_2_12_chunk_metrics_space_time_idx on _hyper_2_12_chunk (never executed)
                            Index Cond: ("time" < now())
 (62 rows)
@@ -4975,7 +4975,7 @@ LIMIT 10;
                            Sort Key: _hyper_2_11_chunk."time" DESC
                            Sort Method: quicksort 
                            ->  Custom Scan (DecompressChunk) on _hyper_2_11_chunk (actual rows=1512 loops=1)
-                                 ->  Seq Scan on compress_hyper_6_21_chunk (actual rows=3 loops=1)
+                                 ->  Seq Scan on compress_hyper_6_25_chunk (actual rows=3 loops=1)
                ->  Sort (actual rows=3 loops=1)
                      Sort Key: _hyper_2_10_chunk."time" DESC
                      Sort Method: top-N heapsort 
@@ -4983,7 +4983,7 @@ LIMIT 10;
                            Sort Key: _hyper_2_10_chunk."time" DESC
                            Sort Method: quicksort 
                            ->  Custom Scan (DecompressChunk) on _hyper_2_10_chunk (actual rows=504 loops=1)
-                                 ->  Seq Scan on compress_hyper_6_20_chunk (actual rows=1 loops=1)
+                                 ->  Seq Scan on compress_hyper_6_24_chunk (actual rows=1 loops=1)
          ->  Merge Append (never executed)
                Sort Key: _hyper_2_9_chunk."time" DESC
                ->  Index Only Scan using _hyper_2_9_chunk_metrics_space_time_idx on _hyper_2_9_chunk (never executed)
@@ -4999,19 +4999,19 @@ LIMIT 10;
                      ->  Sort (never executed)
                            Sort Key: _hyper_2_6_chunk."time" DESC
                            ->  Custom Scan (DecompressChunk) on _hyper_2_6_chunk (never executed)
-                                 ->  Seq Scan on compress_hyper_6_19_chunk (never executed)
+                                 ->  Seq Scan on compress_hyper_6_20_chunk (never executed)
                ->  Sort (never executed)
                      Sort Key: _hyper_2_5_chunk."time" DESC
                      ->  Sort (never executed)
                            Sort Key: _hyper_2_5_chunk."time" DESC
                            ->  Custom Scan (DecompressChunk) on _hyper_2_5_chunk (never executed)
-                                 ->  Seq Scan on compress_hyper_6_18_chunk (never executed)
+                                 ->  Seq Scan on compress_hyper_6_19_chunk (never executed)
                ->  Sort (never executed)
                      Sort Key: _hyper_2_4_chunk."time" DESC
                      ->  Sort (never executed)
                            Sort Key: _hyper_2_4_chunk."time" DESC
                            ->  Custom Scan (DecompressChunk) on _hyper_2_4_chunk (never executed)
-                                 ->  Seq Scan on compress_hyper_6_17_chunk (never executed)
+                                 ->  Seq Scan on compress_hyper_6_18_chunk (never executed)
 (51 rows)
 
 :PREFIX
@@ -5040,7 +5040,7 @@ LIMIT 10;
                                  Sort Key: _hyper_2_11_chunk."time" DESC
                                  Sort Method: quicksort 
                                  ->  Custom Scan (DecompressChunk) on _hyper_2_11_chunk (actual rows=1512 loops=1)
-                                       ->  Seq Scan on compress_hyper_6_21_chunk (actual rows=3 loops=1)
+                                       ->  Seq Scan on compress_hyper_6_25_chunk (actual rows=3 loops=1)
                      ->  Sort (actual rows=3 loops=1)
                            Sort Key: _hyper_2_10_chunk."time" DESC
                            Sort Method: quicksort 
@@ -5048,7 +5048,7 @@ LIMIT 10;
                                  Sort Key: _hyper_2_10_chunk."time" DESC
                                  Sort Method: quicksort 
                                  ->  Custom Scan (DecompressChunk) on _hyper_2_10_chunk (actual rows=504 loops=1)
-                                       ->  Seq Scan on compress_hyper_6_20_chunk (actual rows=1 loops=1)
+                                       ->  Seq Scan on compress_hyper_6_24_chunk (actual rows=1 loops=1)
                ->  Merge Append (never executed)
                      Sort Key: _hyper_2_9_chunk."time" DESC
                      ->  Index Scan using _hyper_2_9_chunk_metrics_space_time_idx on _hyper_2_9_chunk (never executed)
@@ -5061,19 +5061,19 @@ LIMIT 10;
                            ->  Sort (never executed)
                                  Sort Key: _hyper_2_6_chunk."time" DESC
                                  ->  Custom Scan (DecompressChunk) on _hyper_2_6_chunk (never executed)
-                                       ->  Seq Scan on compress_hyper_6_19_chunk (never executed)
+                                       ->  Seq Scan on compress_hyper_6_20_chunk (never executed)
                      ->  Sort (never executed)
                            Sort Key: _hyper_2_5_chunk."time" DESC
                            ->  Sort (never executed)
                                  Sort Key: _hyper_2_5_chunk."time" DESC
                                  ->  Custom Scan (DecompressChunk) on _hyper_2_5_chunk (never executed)
-                                       ->  Seq Scan on compress_hyper_6_18_chunk (never executed)
+                                       ->  Seq Scan on compress_hyper_6_19_chunk (never executed)
                      ->  Sort (never executed)
                            Sort Key: _hyper_2_4_chunk."time" DESC
                            ->  Sort (never executed)
                                  Sort Key: _hyper_2_4_chunk."time" DESC
                                  ->  Custom Scan (DecompressChunk) on _hyper_2_4_chunk (never executed)
-                                       ->  Seq Scan on compress_hyper_6_17_chunk (never executed)
+                                       ->  Seq Scan on compress_hyper_6_18_chunk (never executed)
 (51 rows)
 
 :PREFIX
@@ -5092,17 +5092,17 @@ LIMIT 10;
                Sort Key: _hyper_2_4_chunk.device_id, _hyper_2_4_chunk."time" DESC
                Sort Method: top-N heapsort 
                ->  Custom Scan (DecompressChunk) on _hyper_2_4_chunk (actual rows=360 loops=1)
-                     ->  Seq Scan on compress_hyper_6_17_chunk (actual rows=1 loops=1)
+                     ->  Seq Scan on compress_hyper_6_18_chunk (actual rows=1 loops=1)
          ->  Sort (actual rows=1 loops=1)
                Sort Key: _hyper_2_5_chunk.device_id, _hyper_2_5_chunk."time" DESC
                Sort Method: top-N heapsort 
                ->  Custom Scan (DecompressChunk) on _hyper_2_5_chunk (actual rows=1080 loops=1)
-                     ->  Seq Scan on compress_hyper_6_18_chunk (actual rows=3 loops=1)
+                     ->  Seq Scan on compress_hyper_6_19_chunk (actual rows=3 loops=1)
          ->  Sort (actual rows=1 loops=1)
                Sort Key: _hyper_2_6_chunk.device_id, _hyper_2_6_chunk."time" DESC
                Sort Method: top-N heapsort 
                ->  Custom Scan (DecompressChunk) on _hyper_2_6_chunk (actual rows=360 loops=1)
-                     ->  Seq Scan on compress_hyper_6_19_chunk (actual rows=1 loops=1)
+                     ->  Seq Scan on compress_hyper_6_20_chunk (actual rows=1 loops=1)
          ->  Index Only Scan using _hyper_2_7_chunk_metrics_space_device_id_time_idx on _hyper_2_7_chunk (actual rows=1 loops=1)
                Heap Fetches: 1
          ->  Index Only Scan using _hyper_2_8_chunk_metrics_space_device_id_time_idx on _hyper_2_8_chunk (actual rows=1 loops=1)
@@ -5113,12 +5113,12 @@ LIMIT 10;
                Sort Key: _hyper_2_10_chunk.device_id, _hyper_2_10_chunk."time" DESC
                Sort Method: top-N heapsort 
                ->  Custom Scan (DecompressChunk) on _hyper_2_10_chunk (actual rows=504 loops=1)
-                     ->  Seq Scan on compress_hyper_6_20_chunk (actual rows=1 loops=1)
+                     ->  Seq Scan on compress_hyper_6_24_chunk (actual rows=1 loops=1)
          ->  Sort (actual rows=1 loops=1)
                Sort Key: _hyper_2_11_chunk.device_id, _hyper_2_11_chunk."time" DESC
                Sort Method: top-N heapsort 
                ->  Custom Scan (DecompressChunk) on _hyper_2_11_chunk (actual rows=1512 loops=1)
-                     ->  Seq Scan on compress_hyper_6_21_chunk (actual rows=3 loops=1)
+                     ->  Seq Scan on compress_hyper_6_25_chunk (actual rows=3 loops=1)
          ->  Index Only Scan using _hyper_2_12_chunk_metrics_space_device_id_time_idx on _hyper_2_12_chunk (actual rows=1 loops=1)
                Heap Fetches: 1
 (36 rows)
@@ -5156,16 +5156,16 @@ ORDER BY time,
                Output: _hyper_2_10_chunk."time", _hyper_2_10_chunk.device_id, _hyper_2_10_chunk.device_id_peer, _hyper_2_10_chunk.v0, _hyper_2_10_chunk.v1, _hyper_2_10_chunk.v2, _hyper_2_10_chunk.v3
                Filter: (_hyper_2_10_chunk."time" > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
                Bulk Decompression: true
-               ->  Seq Scan on _timescaledb_internal.compress_hyper_6_20_chunk (actual rows=1 loops=1)
-                     Output: compress_hyper_6_20_chunk."time", compress_hyper_6_20_chunk.device_id, compress_hyper_6_20_chunk.device_id_peer, compress_hyper_6_20_chunk.v0, compress_hyper_6_20_chunk.v1, compress_hyper_6_20_chunk.v2, compress_hyper_6_20_chunk.v3, compress_hyper_6_20_chunk._ts_meta_count, compress_hyper_6_20_chunk._ts_meta_sequence_num, compress_hyper_6_20_chunk._ts_meta_min_3, compress_hyper_6_20_chunk._ts_meta_max_3, compress_hyper_6_20_chunk._ts_meta_min_1, compress_hyper_6_20_chunk._ts_meta_max_1, compress_hyper_6_20_chunk._ts_meta_min_2, compress_hyper_6_20_chunk._ts_meta_max_2
-                     Filter: (compress_hyper_6_20_chunk._ts_meta_max_3 > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
+               ->  Seq Scan on _timescaledb_internal.compress_hyper_6_24_chunk (actual rows=1 loops=1)
+                     Output: compress_hyper_6_24_chunk."time", compress_hyper_6_24_chunk.device_id, compress_hyper_6_24_chunk.device_id_peer, compress_hyper_6_24_chunk.v0, compress_hyper_6_24_chunk.v1, compress_hyper_6_24_chunk.v2, compress_hyper_6_24_chunk.v3, compress_hyper_6_24_chunk._ts_meta_count, compress_hyper_6_24_chunk._ts_meta_sequence_num, compress_hyper_6_24_chunk._ts_meta_min_3, compress_hyper_6_24_chunk._ts_meta_max_3, compress_hyper_6_24_chunk._ts_meta_min_1, compress_hyper_6_24_chunk._ts_meta_max_1, compress_hyper_6_24_chunk._ts_meta_min_2, compress_hyper_6_24_chunk._ts_meta_max_2
+                     Filter: (compress_hyper_6_24_chunk._ts_meta_max_3 > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
          ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_11_chunk (actual rows=1512 loops=1)
                Output: _hyper_2_11_chunk."time", _hyper_2_11_chunk.device_id, _hyper_2_11_chunk.device_id_peer, _hyper_2_11_chunk.v0, _hyper_2_11_chunk.v1, _hyper_2_11_chunk.v2, _hyper_2_11_chunk.v3
                Filter: (_hyper_2_11_chunk."time" > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
                Bulk Decompression: true
-               ->  Seq Scan on _timescaledb_internal.compress_hyper_6_21_chunk (actual rows=3 loops=1)
-                     Output: compress_hyper_6_21_chunk."time", compress_hyper_6_21_chunk.device_id, compress_hyper_6_21_chunk.device_id_peer, compress_hyper_6_21_chunk.v0, compress_hyper_6_21_chunk.v1, compress_hyper_6_21_chunk.v2, compress_hyper_6_21_chunk.v3, compress_hyper_6_21_chunk._ts_meta_count, compress_hyper_6_21_chunk._ts_meta_sequence_num, compress_hyper_6_21_chunk._ts_meta_min_3, compress_hyper_6_21_chunk._ts_meta_max_3, compress_hyper_6_21_chunk._ts_meta_min_1, compress_hyper_6_21_chunk._ts_meta_max_1, compress_hyper_6_21_chunk._ts_meta_min_2, compress_hyper_6_21_chunk._ts_meta_max_2
-                     Filter: (compress_hyper_6_21_chunk._ts_meta_max_3 > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
+               ->  Seq Scan on _timescaledb_internal.compress_hyper_6_25_chunk (actual rows=3 loops=1)
+                     Output: compress_hyper_6_25_chunk."time", compress_hyper_6_25_chunk.device_id, compress_hyper_6_25_chunk.device_id_peer, compress_hyper_6_25_chunk.v0, compress_hyper_6_25_chunk.v1, compress_hyper_6_25_chunk.v2, compress_hyper_6_25_chunk.v3, compress_hyper_6_25_chunk._ts_meta_count, compress_hyper_6_25_chunk._ts_meta_sequence_num, compress_hyper_6_25_chunk._ts_meta_min_3, compress_hyper_6_25_chunk._ts_meta_max_3, compress_hyper_6_25_chunk._ts_meta_min_1, compress_hyper_6_25_chunk._ts_meta_max_1, compress_hyper_6_25_chunk._ts_meta_min_2, compress_hyper_6_25_chunk._ts_meta_max_2
+                     Filter: (compress_hyper_6_25_chunk._ts_meta_max_3 > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
          ->  Seq Scan on _timescaledb_internal._hyper_2_12_chunk (actual rows=504 loops=1)
                Output: _hyper_2_12_chunk."time", _hyper_2_12_chunk.device_id, _hyper_2_12_chunk.device_id_peer, _hyper_2_12_chunk.v0, _hyper_2_12_chunk.v1, _hyper_2_12_chunk.v2, _hyper_2_12_chunk.v3
                Filter: (_hyper_2_12_chunk."time" > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
@@ -5198,16 +5198,16 @@ ORDER BY device_id,
          Output: _hyper_2_10_chunk."time", _hyper_2_10_chunk.device_id, _hyper_2_10_chunk.device_id_peer, _hyper_2_10_chunk.v0, _hyper_2_10_chunk.v1, _hyper_2_10_chunk.v2, _hyper_2_10_chunk.v3
          Filter: (_hyper_2_10_chunk."time" > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
          Bulk Decompression: true
-         ->  Index Scan using compress_hyper_6_20_chunk__compressed_hypertable_6_device_id_de on _timescaledb_internal.compress_hyper_6_20_chunk (actual rows=1 loops=1)
-               Output: compress_hyper_6_20_chunk."time", compress_hyper_6_20_chunk.device_id, compress_hyper_6_20_chunk.device_id_peer, compress_hyper_6_20_chunk.v0, compress_hyper_6_20_chunk.v1, compress_hyper_6_20_chunk.v2, compress_hyper_6_20_chunk.v3, compress_hyper_6_20_chunk._ts_meta_count, compress_hyper_6_20_chunk._ts_meta_sequence_num, compress_hyper_6_20_chunk._ts_meta_min_3, compress_hyper_6_20_chunk._ts_meta_max_3, compress_hyper_6_20_chunk._ts_meta_min_1, compress_hyper_6_20_chunk._ts_meta_max_1, compress_hyper_6_20_chunk._ts_meta_min_2, compress_hyper_6_20_chunk._ts_meta_max_2
-               Filter: (compress_hyper_6_20_chunk._ts_meta_max_3 > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
+         ->  Index Scan using compress_hyper_6_24_chunk__compressed_hypertable_6_device_id_de on _timescaledb_internal.compress_hyper_6_24_chunk (actual rows=1 loops=1)
+               Output: compress_hyper_6_24_chunk."time", compress_hyper_6_24_chunk.device_id, compress_hyper_6_24_chunk.device_id_peer, compress_hyper_6_24_chunk.v0, compress_hyper_6_24_chunk.v1, compress_hyper_6_24_chunk.v2, compress_hyper_6_24_chunk.v3, compress_hyper_6_24_chunk._ts_meta_count, compress_hyper_6_24_chunk._ts_meta_sequence_num, compress_hyper_6_24_chunk._ts_meta_min_3, compress_hyper_6_24_chunk._ts_meta_max_3, compress_hyper_6_24_chunk._ts_meta_min_1, compress_hyper_6_24_chunk._ts_meta_max_1, compress_hyper_6_24_chunk._ts_meta_min_2, compress_hyper_6_24_chunk._ts_meta_max_2
+               Filter: (compress_hyper_6_24_chunk._ts_meta_max_3 > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
    ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_11_chunk (actual rows=1512 loops=1)
          Output: _hyper_2_11_chunk."time", _hyper_2_11_chunk.device_id, _hyper_2_11_chunk.device_id_peer, _hyper_2_11_chunk.v0, _hyper_2_11_chunk.v1, _hyper_2_11_chunk.v2, _hyper_2_11_chunk.v3
          Filter: (_hyper_2_11_chunk."time" > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
          Bulk Decompression: true
-         ->  Index Scan using compress_hyper_6_21_chunk__compressed_hypertable_6_device_id_de on _timescaledb_internal.compress_hyper_6_21_chunk (actual rows=3 loops=1)
-               Output: compress_hyper_6_21_chunk."time", compress_hyper_6_21_chunk.device_id, compress_hyper_6_21_chunk.device_id_peer, compress_hyper_6_21_chunk.v0, compress_hyper_6_21_chunk.v1, compress_hyper_6_21_chunk.v2, compress_hyper_6_21_chunk.v3, compress_hyper_6_21_chunk._ts_meta_count, compress_hyper_6_21_chunk._ts_meta_sequence_num, compress_hyper_6_21_chunk._ts_meta_min_3, compress_hyper_6_21_chunk._ts_meta_max_3, compress_hyper_6_21_chunk._ts_meta_min_1, compress_hyper_6_21_chunk._ts_meta_max_1, compress_hyper_6_21_chunk._ts_meta_min_2, compress_hyper_6_21_chunk._ts_meta_max_2
-               Filter: (compress_hyper_6_21_chunk._ts_meta_max_3 > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
+         ->  Index Scan using compress_hyper_6_25_chunk__compressed_hypertable_6_device_id_de on _timescaledb_internal.compress_hyper_6_25_chunk (actual rows=3 loops=1)
+               Output: compress_hyper_6_25_chunk."time", compress_hyper_6_25_chunk.device_id, compress_hyper_6_25_chunk.device_id_peer, compress_hyper_6_25_chunk.v0, compress_hyper_6_25_chunk.v1, compress_hyper_6_25_chunk.v2, compress_hyper_6_25_chunk.v3, compress_hyper_6_25_chunk._ts_meta_count, compress_hyper_6_25_chunk._ts_meta_sequence_num, compress_hyper_6_25_chunk._ts_meta_min_3, compress_hyper_6_25_chunk._ts_meta_max_3, compress_hyper_6_25_chunk._ts_meta_min_1, compress_hyper_6_25_chunk._ts_meta_max_1, compress_hyper_6_25_chunk._ts_meta_min_2, compress_hyper_6_25_chunk._ts_meta_max_2
+               Filter: (compress_hyper_6_25_chunk._ts_meta_max_3 > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
    ->  Index Scan using _hyper_2_12_chunk_metrics_space_device_id_device_id_peer_v0_v1_ on _timescaledb_internal._hyper_2_12_chunk (actual rows=504 loops=1)
          Output: _hyper_2_12_chunk."time", _hyper_2_12_chunk.device_id, _hyper_2_12_chunk.device_id_peer, _hyper_2_12_chunk.v0, _hyper_2_12_chunk.v1, _hyper_2_12_chunk.v2, _hyper_2_12_chunk.v3
          Index Cond: (_hyper_2_12_chunk."time" > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
@@ -5248,23 +5248,23 @@ LIMIT 100;
                Filter: (_hyper_2_10_chunk."time" > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
                Bulk Decompression: true
                ->  Sort (actual rows=1 loops=1)
-                     Output: compress_hyper_6_20_chunk."time", compress_hyper_6_20_chunk.device_id, compress_hyper_6_20_chunk.device_id_peer, compress_hyper_6_20_chunk.v0, compress_hyper_6_20_chunk.v1, compress_hyper_6_20_chunk.v2, compress_hyper_6_20_chunk.v3, compress_hyper_6_20_chunk._ts_meta_count, compress_hyper_6_20_chunk._ts_meta_sequence_num, compress_hyper_6_20_chunk._ts_meta_min_3, compress_hyper_6_20_chunk._ts_meta_max_3, compress_hyper_6_20_chunk._ts_meta_min_1, compress_hyper_6_20_chunk._ts_meta_max_1, compress_hyper_6_20_chunk._ts_meta_min_2, compress_hyper_6_20_chunk._ts_meta_max_2
-                     Sort Key: compress_hyper_6_20_chunk.device_id, compress_hyper_6_20_chunk.device_id_peer, compress_hyper_6_20_chunk._ts_meta_sequence_num
+                     Output: compress_hyper_6_24_chunk."time", compress_hyper_6_24_chunk.device_id, compress_hyper_6_24_chunk.device_id_peer, compress_hyper_6_24_chunk.v0, compress_hyper_6_24_chunk.v1, compress_hyper_6_24_chunk.v2, compress_hyper_6_24_chunk.v3, compress_hyper_6_24_chunk._ts_meta_count, compress_hyper_6_24_chunk._ts_meta_sequence_num, compress_hyper_6_24_chunk._ts_meta_min_3, compress_hyper_6_24_chunk._ts_meta_max_3, compress_hyper_6_24_chunk._ts_meta_min_1, compress_hyper_6_24_chunk._ts_meta_max_1, compress_hyper_6_24_chunk._ts_meta_min_2, compress_hyper_6_24_chunk._ts_meta_max_2
+                     Sort Key: compress_hyper_6_24_chunk.device_id, compress_hyper_6_24_chunk.device_id_peer, compress_hyper_6_24_chunk._ts_meta_sequence_num
                      Sort Method: quicksort 
-                     ->  Seq Scan on _timescaledb_internal.compress_hyper_6_20_chunk (actual rows=1 loops=1)
-                           Output: compress_hyper_6_20_chunk."time", compress_hyper_6_20_chunk.device_id, compress_hyper_6_20_chunk.device_id_peer, compress_hyper_6_20_chunk.v0, compress_hyper_6_20_chunk.v1, compress_hyper_6_20_chunk.v2, compress_hyper_6_20_chunk.v3, compress_hyper_6_20_chunk._ts_meta_count, compress_hyper_6_20_chunk._ts_meta_sequence_num, compress_hyper_6_20_chunk._ts_meta_min_3, compress_hyper_6_20_chunk._ts_meta_max_3, compress_hyper_6_20_chunk._ts_meta_min_1, compress_hyper_6_20_chunk._ts_meta_max_1, compress_hyper_6_20_chunk._ts_meta_min_2, compress_hyper_6_20_chunk._ts_meta_max_2
-                           Filter: (compress_hyper_6_20_chunk._ts_meta_max_3 > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
+                     ->  Seq Scan on _timescaledb_internal.compress_hyper_6_24_chunk (actual rows=1 loops=1)
+                           Output: compress_hyper_6_24_chunk."time", compress_hyper_6_24_chunk.device_id, compress_hyper_6_24_chunk.device_id_peer, compress_hyper_6_24_chunk.v0, compress_hyper_6_24_chunk.v1, compress_hyper_6_24_chunk.v2, compress_hyper_6_24_chunk.v3, compress_hyper_6_24_chunk._ts_meta_count, compress_hyper_6_24_chunk._ts_meta_sequence_num, compress_hyper_6_24_chunk._ts_meta_min_3, compress_hyper_6_24_chunk._ts_meta_max_3, compress_hyper_6_24_chunk._ts_meta_min_1, compress_hyper_6_24_chunk._ts_meta_max_1, compress_hyper_6_24_chunk._ts_meta_min_2, compress_hyper_6_24_chunk._ts_meta_max_2
+                           Filter: (compress_hyper_6_24_chunk._ts_meta_max_3 > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
          ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_11_chunk (actual rows=1 loops=1)
                Output: _hyper_2_11_chunk.device_id, _hyper_2_11_chunk.device_id_peer, _hyper_2_11_chunk.v0, _hyper_2_11_chunk.v1, _hyper_2_11_chunk."time"
                Filter: (_hyper_2_11_chunk."time" > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
                Bulk Decompression: true
                ->  Sort (actual rows=1 loops=1)
-                     Output: compress_hyper_6_21_chunk."time", compress_hyper_6_21_chunk.device_id, compress_hyper_6_21_chunk.device_id_peer, compress_hyper_6_21_chunk.v0, compress_hyper_6_21_chunk.v1, compress_hyper_6_21_chunk.v2, compress_hyper_6_21_chunk.v3, compress_hyper_6_21_chunk._ts_meta_count, compress_hyper_6_21_chunk._ts_meta_sequence_num, compress_hyper_6_21_chunk._ts_meta_min_3, compress_hyper_6_21_chunk._ts_meta_max_3, compress_hyper_6_21_chunk._ts_meta_min_1, compress_hyper_6_21_chunk._ts_meta_max_1, compress_hyper_6_21_chunk._ts_meta_min_2, compress_hyper_6_21_chunk._ts_meta_max_2
-                     Sort Key: compress_hyper_6_21_chunk.device_id, compress_hyper_6_21_chunk.device_id_peer, compress_hyper_6_21_chunk._ts_meta_sequence_num
+                     Output: compress_hyper_6_25_chunk."time", compress_hyper_6_25_chunk.device_id, compress_hyper_6_25_chunk.device_id_peer, compress_hyper_6_25_chunk.v0, compress_hyper_6_25_chunk.v1, compress_hyper_6_25_chunk.v2, compress_hyper_6_25_chunk.v3, compress_hyper_6_25_chunk._ts_meta_count, compress_hyper_6_25_chunk._ts_meta_sequence_num, compress_hyper_6_25_chunk._ts_meta_min_3, compress_hyper_6_25_chunk._ts_meta_max_3, compress_hyper_6_25_chunk._ts_meta_min_1, compress_hyper_6_25_chunk._ts_meta_max_1, compress_hyper_6_25_chunk._ts_meta_min_2, compress_hyper_6_25_chunk._ts_meta_max_2
+                     Sort Key: compress_hyper_6_25_chunk.device_id, compress_hyper_6_25_chunk.device_id_peer, compress_hyper_6_25_chunk._ts_meta_sequence_num
                      Sort Method: quicksort 
-                     ->  Seq Scan on _timescaledb_internal.compress_hyper_6_21_chunk (actual rows=3 loops=1)
-                           Output: compress_hyper_6_21_chunk."time", compress_hyper_6_21_chunk.device_id, compress_hyper_6_21_chunk.device_id_peer, compress_hyper_6_21_chunk.v0, compress_hyper_6_21_chunk.v1, compress_hyper_6_21_chunk.v2, compress_hyper_6_21_chunk.v3, compress_hyper_6_21_chunk._ts_meta_count, compress_hyper_6_21_chunk._ts_meta_sequence_num, compress_hyper_6_21_chunk._ts_meta_min_3, compress_hyper_6_21_chunk._ts_meta_max_3, compress_hyper_6_21_chunk._ts_meta_min_1, compress_hyper_6_21_chunk._ts_meta_max_1, compress_hyper_6_21_chunk._ts_meta_min_2, compress_hyper_6_21_chunk._ts_meta_max_2
-                           Filter: (compress_hyper_6_21_chunk._ts_meta_max_3 > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
+                     ->  Seq Scan on _timescaledb_internal.compress_hyper_6_25_chunk (actual rows=3 loops=1)
+                           Output: compress_hyper_6_25_chunk."time", compress_hyper_6_25_chunk.device_id, compress_hyper_6_25_chunk.device_id_peer, compress_hyper_6_25_chunk.v0, compress_hyper_6_25_chunk.v1, compress_hyper_6_25_chunk.v2, compress_hyper_6_25_chunk.v3, compress_hyper_6_25_chunk._ts_meta_count, compress_hyper_6_25_chunk._ts_meta_sequence_num, compress_hyper_6_25_chunk._ts_meta_min_3, compress_hyper_6_25_chunk._ts_meta_max_3, compress_hyper_6_25_chunk._ts_meta_min_1, compress_hyper_6_25_chunk._ts_meta_max_1, compress_hyper_6_25_chunk._ts_meta_min_2, compress_hyper_6_25_chunk._ts_meta_max_2
+                           Filter: (compress_hyper_6_25_chunk._ts_meta_max_3 > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
          ->  Index Only Scan using _hyper_2_12_chunk_metrics_space_device_id_device_id_peer_v0_v1_ on _timescaledb_internal._hyper_2_12_chunk (actual rows=1 loops=1)
                Output: _hyper_2_12_chunk.device_id, _hyper_2_12_chunk.device_id_peer, _hyper_2_12_chunk.v0, _hyper_2_12_chunk.v1, _hyper_2_12_chunk."time"
                Index Cond: (_hyper_2_12_chunk."time" > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
@@ -5304,23 +5304,23 @@ LIMIT 100;
                Filter: (_hyper_2_10_chunk."time" > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
                Bulk Decompression: true
                ->  Sort (actual rows=1 loops=1)
-                     Output: compress_hyper_6_20_chunk."time", compress_hyper_6_20_chunk.device_id, compress_hyper_6_20_chunk.device_id_peer, compress_hyper_6_20_chunk.v0, compress_hyper_6_20_chunk.v1, compress_hyper_6_20_chunk.v2, compress_hyper_6_20_chunk.v3, compress_hyper_6_20_chunk._ts_meta_count, compress_hyper_6_20_chunk._ts_meta_sequence_num, compress_hyper_6_20_chunk._ts_meta_min_3, compress_hyper_6_20_chunk._ts_meta_max_3, compress_hyper_6_20_chunk._ts_meta_min_1, compress_hyper_6_20_chunk._ts_meta_max_1, compress_hyper_6_20_chunk._ts_meta_min_2, compress_hyper_6_20_chunk._ts_meta_max_2
-                     Sort Key: compress_hyper_6_20_chunk.device_id, compress_hyper_6_20_chunk.device_id_peer
+                     Output: compress_hyper_6_24_chunk."time", compress_hyper_6_24_chunk.device_id, compress_hyper_6_24_chunk.device_id_peer, compress_hyper_6_24_chunk.v0, compress_hyper_6_24_chunk.v1, compress_hyper_6_24_chunk.v2, compress_hyper_6_24_chunk.v3, compress_hyper_6_24_chunk._ts_meta_count, compress_hyper_6_24_chunk._ts_meta_sequence_num, compress_hyper_6_24_chunk._ts_meta_min_3, compress_hyper_6_24_chunk._ts_meta_max_3, compress_hyper_6_24_chunk._ts_meta_min_1, compress_hyper_6_24_chunk._ts_meta_max_1, compress_hyper_6_24_chunk._ts_meta_min_2, compress_hyper_6_24_chunk._ts_meta_max_2
+                     Sort Key: compress_hyper_6_24_chunk.device_id, compress_hyper_6_24_chunk.device_id_peer
                      Sort Method: quicksort 
-                     ->  Seq Scan on _timescaledb_internal.compress_hyper_6_20_chunk (actual rows=1 loops=1)
-                           Output: compress_hyper_6_20_chunk."time", compress_hyper_6_20_chunk.device_id, compress_hyper_6_20_chunk.device_id_peer, compress_hyper_6_20_chunk.v0, compress_hyper_6_20_chunk.v1, compress_hyper_6_20_chunk.v2, compress_hyper_6_20_chunk.v3, compress_hyper_6_20_chunk._ts_meta_count, compress_hyper_6_20_chunk._ts_meta_sequence_num, compress_hyper_6_20_chunk._ts_meta_min_3, compress_hyper_6_20_chunk._ts_meta_max_3, compress_hyper_6_20_chunk._ts_meta_min_1, compress_hyper_6_20_chunk._ts_meta_max_1, compress_hyper_6_20_chunk._ts_meta_min_2, compress_hyper_6_20_chunk._ts_meta_max_2
-                           Filter: (compress_hyper_6_20_chunk._ts_meta_max_3 > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
+                     ->  Seq Scan on _timescaledb_internal.compress_hyper_6_24_chunk (actual rows=1 loops=1)
+                           Output: compress_hyper_6_24_chunk."time", compress_hyper_6_24_chunk.device_id, compress_hyper_6_24_chunk.device_id_peer, compress_hyper_6_24_chunk.v0, compress_hyper_6_24_chunk.v1, compress_hyper_6_24_chunk.v2, compress_hyper_6_24_chunk.v3, compress_hyper_6_24_chunk._ts_meta_count, compress_hyper_6_24_chunk._ts_meta_sequence_num, compress_hyper_6_24_chunk._ts_meta_min_3, compress_hyper_6_24_chunk._ts_meta_max_3, compress_hyper_6_24_chunk._ts_meta_min_1, compress_hyper_6_24_chunk._ts_meta_max_1, compress_hyper_6_24_chunk._ts_meta_min_2, compress_hyper_6_24_chunk._ts_meta_max_2
+                           Filter: (compress_hyper_6_24_chunk._ts_meta_max_3 > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
          ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_11_chunk (actual rows=1 loops=1)
                Output: _hyper_2_11_chunk.device_id, _hyper_2_11_chunk.device_id_peer
                Filter: (_hyper_2_11_chunk."time" > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
                Bulk Decompression: true
                ->  Sort (actual rows=1 loops=1)
-                     Output: compress_hyper_6_21_chunk."time", compress_hyper_6_21_chunk.device_id, compress_hyper_6_21_chunk.device_id_peer, compress_hyper_6_21_chunk.v0, compress_hyper_6_21_chunk.v1, compress_hyper_6_21_chunk.v2, compress_hyper_6_21_chunk.v3, compress_hyper_6_21_chunk._ts_meta_count, compress_hyper_6_21_chunk._ts_meta_sequence_num, compress_hyper_6_21_chunk._ts_meta_min_3, compress_hyper_6_21_chunk._ts_meta_max_3, compress_hyper_6_21_chunk._ts_meta_min_1, compress_hyper_6_21_chunk._ts_meta_max_1, compress_hyper_6_21_chunk._ts_meta_min_2, compress_hyper_6_21_chunk._ts_meta_max_2
-                     Sort Key: compress_hyper_6_21_chunk.device_id, compress_hyper_6_21_chunk.device_id_peer
+                     Output: compress_hyper_6_25_chunk."time", compress_hyper_6_25_chunk.device_id, compress_hyper_6_25_chunk.device_id_peer, compress_hyper_6_25_chunk.v0, compress_hyper_6_25_chunk.v1, compress_hyper_6_25_chunk.v2, compress_hyper_6_25_chunk.v3, compress_hyper_6_25_chunk._ts_meta_count, compress_hyper_6_25_chunk._ts_meta_sequence_num, compress_hyper_6_25_chunk._ts_meta_min_3, compress_hyper_6_25_chunk._ts_meta_max_3, compress_hyper_6_25_chunk._ts_meta_min_1, compress_hyper_6_25_chunk._ts_meta_max_1, compress_hyper_6_25_chunk._ts_meta_min_2, compress_hyper_6_25_chunk._ts_meta_max_2
+                     Sort Key: compress_hyper_6_25_chunk.device_id, compress_hyper_6_25_chunk.device_id_peer
                      Sort Method: quicksort 
-                     ->  Seq Scan on _timescaledb_internal.compress_hyper_6_21_chunk (actual rows=3 loops=1)
-                           Output: compress_hyper_6_21_chunk."time", compress_hyper_6_21_chunk.device_id, compress_hyper_6_21_chunk.device_id_peer, compress_hyper_6_21_chunk.v0, compress_hyper_6_21_chunk.v1, compress_hyper_6_21_chunk.v2, compress_hyper_6_21_chunk.v3, compress_hyper_6_21_chunk._ts_meta_count, compress_hyper_6_21_chunk._ts_meta_sequence_num, compress_hyper_6_21_chunk._ts_meta_min_3, compress_hyper_6_21_chunk._ts_meta_max_3, compress_hyper_6_21_chunk._ts_meta_min_1, compress_hyper_6_21_chunk._ts_meta_max_1, compress_hyper_6_21_chunk._ts_meta_min_2, compress_hyper_6_21_chunk._ts_meta_max_2
-                           Filter: (compress_hyper_6_21_chunk._ts_meta_max_3 > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
+                     ->  Seq Scan on _timescaledb_internal.compress_hyper_6_25_chunk (actual rows=3 loops=1)
+                           Output: compress_hyper_6_25_chunk."time", compress_hyper_6_25_chunk.device_id, compress_hyper_6_25_chunk.device_id_peer, compress_hyper_6_25_chunk.v0, compress_hyper_6_25_chunk.v1, compress_hyper_6_25_chunk.v2, compress_hyper_6_25_chunk.v3, compress_hyper_6_25_chunk._ts_meta_count, compress_hyper_6_25_chunk._ts_meta_sequence_num, compress_hyper_6_25_chunk._ts_meta_min_3, compress_hyper_6_25_chunk._ts_meta_max_3, compress_hyper_6_25_chunk._ts_meta_min_1, compress_hyper_6_25_chunk._ts_meta_max_1, compress_hyper_6_25_chunk._ts_meta_min_2, compress_hyper_6_25_chunk._ts_meta_max_2
+                           Filter: (compress_hyper_6_25_chunk._ts_meta_max_3 > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
          ->  Index Only Scan Backward using _hyper_2_12_chunk_metrics_space_device_id_device_id_peer_v0_v_2 on _timescaledb_internal._hyper_2_12_chunk (actual rows=1 loops=1)
                Output: _hyper_2_12_chunk.device_id, _hyper_2_12_chunk.device_id_peer
                Index Cond: (_hyper_2_12_chunk."time" > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
@@ -5358,16 +5358,16 @@ ORDER BY device_id,
          Output: _hyper_2_10_chunk.device_id, _hyper_2_10_chunk.device_id_peer, _hyper_2_10_chunk.v0
          Filter: (_hyper_2_10_chunk."time" > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
          Bulk Decompression: true
-         ->  Index Scan using compress_hyper_6_20_chunk__compressed_hypertable_6_device_id_de on _timescaledb_internal.compress_hyper_6_20_chunk (actual rows=1 loops=1)
-               Output: compress_hyper_6_20_chunk."time", compress_hyper_6_20_chunk.device_id, compress_hyper_6_20_chunk.device_id_peer, compress_hyper_6_20_chunk.v0, compress_hyper_6_20_chunk.v1, compress_hyper_6_20_chunk.v2, compress_hyper_6_20_chunk.v3, compress_hyper_6_20_chunk._ts_meta_count, compress_hyper_6_20_chunk._ts_meta_sequence_num, compress_hyper_6_20_chunk._ts_meta_min_3, compress_hyper_6_20_chunk._ts_meta_max_3, compress_hyper_6_20_chunk._ts_meta_min_1, compress_hyper_6_20_chunk._ts_meta_max_1, compress_hyper_6_20_chunk._ts_meta_min_2, compress_hyper_6_20_chunk._ts_meta_max_2
-               Filter: (compress_hyper_6_20_chunk._ts_meta_max_3 > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
+         ->  Index Scan using compress_hyper_6_24_chunk__compressed_hypertable_6_device_id_de on _timescaledb_internal.compress_hyper_6_24_chunk (actual rows=1 loops=1)
+               Output: compress_hyper_6_24_chunk."time", compress_hyper_6_24_chunk.device_id, compress_hyper_6_24_chunk.device_id_peer, compress_hyper_6_24_chunk.v0, compress_hyper_6_24_chunk.v1, compress_hyper_6_24_chunk.v2, compress_hyper_6_24_chunk.v3, compress_hyper_6_24_chunk._ts_meta_count, compress_hyper_6_24_chunk._ts_meta_sequence_num, compress_hyper_6_24_chunk._ts_meta_min_3, compress_hyper_6_24_chunk._ts_meta_max_3, compress_hyper_6_24_chunk._ts_meta_min_1, compress_hyper_6_24_chunk._ts_meta_max_1, compress_hyper_6_24_chunk._ts_meta_min_2, compress_hyper_6_24_chunk._ts_meta_max_2
+               Filter: (compress_hyper_6_24_chunk._ts_meta_max_3 > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
    ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_11_chunk (actual rows=1512 loops=1)
          Output: _hyper_2_11_chunk.device_id, _hyper_2_11_chunk.device_id_peer, _hyper_2_11_chunk.v0
          Filter: (_hyper_2_11_chunk."time" > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
          Bulk Decompression: true
-         ->  Index Scan using compress_hyper_6_21_chunk__compressed_hypertable_6_device_id_de on _timescaledb_internal.compress_hyper_6_21_chunk (actual rows=3 loops=1)
-               Output: compress_hyper_6_21_chunk."time", compress_hyper_6_21_chunk.device_id, compress_hyper_6_21_chunk.device_id_peer, compress_hyper_6_21_chunk.v0, compress_hyper_6_21_chunk.v1, compress_hyper_6_21_chunk.v2, compress_hyper_6_21_chunk.v3, compress_hyper_6_21_chunk._ts_meta_count, compress_hyper_6_21_chunk._ts_meta_sequence_num, compress_hyper_6_21_chunk._ts_meta_min_3, compress_hyper_6_21_chunk._ts_meta_max_3, compress_hyper_6_21_chunk._ts_meta_min_1, compress_hyper_6_21_chunk._ts_meta_max_1, compress_hyper_6_21_chunk._ts_meta_min_2, compress_hyper_6_21_chunk._ts_meta_max_2
-               Filter: (compress_hyper_6_21_chunk._ts_meta_max_3 > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
+         ->  Index Scan using compress_hyper_6_25_chunk__compressed_hypertable_6_device_id_de on _timescaledb_internal.compress_hyper_6_25_chunk (actual rows=3 loops=1)
+               Output: compress_hyper_6_25_chunk."time", compress_hyper_6_25_chunk.device_id, compress_hyper_6_25_chunk.device_id_peer, compress_hyper_6_25_chunk.v0, compress_hyper_6_25_chunk.v1, compress_hyper_6_25_chunk.v2, compress_hyper_6_25_chunk.v3, compress_hyper_6_25_chunk._ts_meta_count, compress_hyper_6_25_chunk._ts_meta_sequence_num, compress_hyper_6_25_chunk._ts_meta_min_3, compress_hyper_6_25_chunk._ts_meta_max_3, compress_hyper_6_25_chunk._ts_meta_min_1, compress_hyper_6_25_chunk._ts_meta_max_1, compress_hyper_6_25_chunk._ts_meta_min_2, compress_hyper_6_25_chunk._ts_meta_max_2
+               Filter: (compress_hyper_6_25_chunk._ts_meta_max_3 > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
    ->  Index Only Scan using _hyper_2_12_chunk_metrics_space_device_id_device_id_peer_v0_v1_ on _timescaledb_internal._hyper_2_12_chunk (actual rows=504 loops=1)
          Output: _hyper_2_12_chunk.device_id, _hyper_2_12_chunk.device_id_peer, _hyper_2_12_chunk.v0
          Index Cond: (_hyper_2_12_chunk."time" > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
@@ -5407,16 +5407,16 @@ ORDER BY device_id,
          Output: _hyper_2_10_chunk.device_id, _hyper_2_10_chunk.device_id_peer, _hyper_2_10_chunk.v0, _hyper_2_10_chunk.v1
          Filter: (_hyper_2_10_chunk."time" > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
          Bulk Decompression: true
-         ->  Index Scan using compress_hyper_6_20_chunk__compressed_hypertable_6_device_id_de on _timescaledb_internal.compress_hyper_6_20_chunk (actual rows=1 loops=1)
-               Output: compress_hyper_6_20_chunk."time", compress_hyper_6_20_chunk.device_id, compress_hyper_6_20_chunk.device_id_peer, compress_hyper_6_20_chunk.v0, compress_hyper_6_20_chunk.v1, compress_hyper_6_20_chunk.v2, compress_hyper_6_20_chunk.v3, compress_hyper_6_20_chunk._ts_meta_count, compress_hyper_6_20_chunk._ts_meta_sequence_num, compress_hyper_6_20_chunk._ts_meta_min_3, compress_hyper_6_20_chunk._ts_meta_max_3, compress_hyper_6_20_chunk._ts_meta_min_1, compress_hyper_6_20_chunk._ts_meta_max_1, compress_hyper_6_20_chunk._ts_meta_min_2, compress_hyper_6_20_chunk._ts_meta_max_2
-               Filter: (compress_hyper_6_20_chunk._ts_meta_max_3 > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
+         ->  Index Scan using compress_hyper_6_24_chunk__compressed_hypertable_6_device_id_de on _timescaledb_internal.compress_hyper_6_24_chunk (actual rows=1 loops=1)
+               Output: compress_hyper_6_24_chunk."time", compress_hyper_6_24_chunk.device_id, compress_hyper_6_24_chunk.device_id_peer, compress_hyper_6_24_chunk.v0, compress_hyper_6_24_chunk.v1, compress_hyper_6_24_chunk.v2, compress_hyper_6_24_chunk.v3, compress_hyper_6_24_chunk._ts_meta_count, compress_hyper_6_24_chunk._ts_meta_sequence_num, compress_hyper_6_24_chunk._ts_meta_min_3, compress_hyper_6_24_chunk._ts_meta_max_3, compress_hyper_6_24_chunk._ts_meta_min_1, compress_hyper_6_24_chunk._ts_meta_max_1, compress_hyper_6_24_chunk._ts_meta_min_2, compress_hyper_6_24_chunk._ts_meta_max_2
+               Filter: (compress_hyper_6_24_chunk._ts_meta_max_3 > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
    ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_11_chunk (actual rows=1512 loops=1)
          Output: _hyper_2_11_chunk.device_id, _hyper_2_11_chunk.device_id_peer, _hyper_2_11_chunk.v0, _hyper_2_11_chunk.v1
          Filter: (_hyper_2_11_chunk."time" > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
          Bulk Decompression: true
-         ->  Index Scan using compress_hyper_6_21_chunk__compressed_hypertable_6_device_id_de on _timescaledb_internal.compress_hyper_6_21_chunk (actual rows=3 loops=1)
-               Output: compress_hyper_6_21_chunk."time", compress_hyper_6_21_chunk.device_id, compress_hyper_6_21_chunk.device_id_peer, compress_hyper_6_21_chunk.v0, compress_hyper_6_21_chunk.v1, compress_hyper_6_21_chunk.v2, compress_hyper_6_21_chunk.v3, compress_hyper_6_21_chunk._ts_meta_count, compress_hyper_6_21_chunk._ts_meta_sequence_num, compress_hyper_6_21_chunk._ts_meta_min_3, compress_hyper_6_21_chunk._ts_meta_max_3, compress_hyper_6_21_chunk._ts_meta_min_1, compress_hyper_6_21_chunk._ts_meta_max_1, compress_hyper_6_21_chunk._ts_meta_min_2, compress_hyper_6_21_chunk._ts_meta_max_2
-               Filter: (compress_hyper_6_21_chunk._ts_meta_max_3 > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
+         ->  Index Scan using compress_hyper_6_25_chunk__compressed_hypertable_6_device_id_de on _timescaledb_internal.compress_hyper_6_25_chunk (actual rows=3 loops=1)
+               Output: compress_hyper_6_25_chunk."time", compress_hyper_6_25_chunk.device_id, compress_hyper_6_25_chunk.device_id_peer, compress_hyper_6_25_chunk.v0, compress_hyper_6_25_chunk.v1, compress_hyper_6_25_chunk.v2, compress_hyper_6_25_chunk.v3, compress_hyper_6_25_chunk._ts_meta_count, compress_hyper_6_25_chunk._ts_meta_sequence_num, compress_hyper_6_25_chunk._ts_meta_min_3, compress_hyper_6_25_chunk._ts_meta_max_3, compress_hyper_6_25_chunk._ts_meta_min_1, compress_hyper_6_25_chunk._ts_meta_max_1, compress_hyper_6_25_chunk._ts_meta_min_2, compress_hyper_6_25_chunk._ts_meta_max_2
+               Filter: (compress_hyper_6_25_chunk._ts_meta_max_3 > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
    ->  Index Only Scan using _hyper_2_12_chunk_metrics_space_device_id_device_id_peer_v0_v1_ on _timescaledb_internal._hyper_2_12_chunk (actual rows=504 loops=1)
          Output: _hyper_2_12_chunk.device_id, _hyper_2_12_chunk.device_id_peer, _hyper_2_12_chunk.v0, _hyper_2_12_chunk.v1
          Index Cond: (_hyper_2_12_chunk."time" > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
@@ -5457,16 +5457,16 @@ ORDER BY device_id,
                Output: _hyper_2_10_chunk."time", _hyper_2_10_chunk.device_id, _hyper_2_10_chunk.device_id_peer, _hyper_2_10_chunk.v0, _hyper_2_10_chunk.v1, _hyper_2_10_chunk.v2, _hyper_2_10_chunk.v3
                Filter: (_hyper_2_10_chunk."time" > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
                Bulk Decompression: true
-               ->  Seq Scan on _timescaledb_internal.compress_hyper_6_20_chunk (actual rows=1 loops=1)
-                     Output: compress_hyper_6_20_chunk."time", compress_hyper_6_20_chunk.device_id, compress_hyper_6_20_chunk.device_id_peer, compress_hyper_6_20_chunk.v0, compress_hyper_6_20_chunk.v1, compress_hyper_6_20_chunk.v2, compress_hyper_6_20_chunk.v3, compress_hyper_6_20_chunk._ts_meta_count, compress_hyper_6_20_chunk._ts_meta_sequence_num, compress_hyper_6_20_chunk._ts_meta_min_3, compress_hyper_6_20_chunk._ts_meta_max_3, compress_hyper_6_20_chunk._ts_meta_min_1, compress_hyper_6_20_chunk._ts_meta_max_1, compress_hyper_6_20_chunk._ts_meta_min_2, compress_hyper_6_20_chunk._ts_meta_max_2
-                     Filter: (compress_hyper_6_20_chunk._ts_meta_max_3 > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
+               ->  Seq Scan on _timescaledb_internal.compress_hyper_6_24_chunk (actual rows=1 loops=1)
+                     Output: compress_hyper_6_24_chunk."time", compress_hyper_6_24_chunk.device_id, compress_hyper_6_24_chunk.device_id_peer, compress_hyper_6_24_chunk.v0, compress_hyper_6_24_chunk.v1, compress_hyper_6_24_chunk.v2, compress_hyper_6_24_chunk.v3, compress_hyper_6_24_chunk._ts_meta_count, compress_hyper_6_24_chunk._ts_meta_sequence_num, compress_hyper_6_24_chunk._ts_meta_min_3, compress_hyper_6_24_chunk._ts_meta_max_3, compress_hyper_6_24_chunk._ts_meta_min_1, compress_hyper_6_24_chunk._ts_meta_max_1, compress_hyper_6_24_chunk._ts_meta_min_2, compress_hyper_6_24_chunk._ts_meta_max_2
+                     Filter: (compress_hyper_6_24_chunk._ts_meta_max_3 > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
          ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_11_chunk (actual rows=1512 loops=1)
                Output: _hyper_2_11_chunk."time", _hyper_2_11_chunk.device_id, _hyper_2_11_chunk.device_id_peer, _hyper_2_11_chunk.v0, _hyper_2_11_chunk.v1, _hyper_2_11_chunk.v2, _hyper_2_11_chunk.v3
                Filter: (_hyper_2_11_chunk."time" > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
                Bulk Decompression: true
-               ->  Seq Scan on _timescaledb_internal.compress_hyper_6_21_chunk (actual rows=3 loops=1)
-                     Output: compress_hyper_6_21_chunk."time", compress_hyper_6_21_chunk.device_id, compress_hyper_6_21_chunk.device_id_peer, compress_hyper_6_21_chunk.v0, compress_hyper_6_21_chunk.v1, compress_hyper_6_21_chunk.v2, compress_hyper_6_21_chunk.v3, compress_hyper_6_21_chunk._ts_meta_count, compress_hyper_6_21_chunk._ts_meta_sequence_num, compress_hyper_6_21_chunk._ts_meta_min_3, compress_hyper_6_21_chunk._ts_meta_max_3, compress_hyper_6_21_chunk._ts_meta_min_1, compress_hyper_6_21_chunk._ts_meta_max_1, compress_hyper_6_21_chunk._ts_meta_min_2, compress_hyper_6_21_chunk._ts_meta_max_2
-                     Filter: (compress_hyper_6_21_chunk._ts_meta_max_3 > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
+               ->  Seq Scan on _timescaledb_internal.compress_hyper_6_25_chunk (actual rows=3 loops=1)
+                     Output: compress_hyper_6_25_chunk."time", compress_hyper_6_25_chunk.device_id, compress_hyper_6_25_chunk.device_id_peer, compress_hyper_6_25_chunk.v0, compress_hyper_6_25_chunk.v1, compress_hyper_6_25_chunk.v2, compress_hyper_6_25_chunk.v3, compress_hyper_6_25_chunk._ts_meta_count, compress_hyper_6_25_chunk._ts_meta_sequence_num, compress_hyper_6_25_chunk._ts_meta_min_3, compress_hyper_6_25_chunk._ts_meta_max_3, compress_hyper_6_25_chunk._ts_meta_min_1, compress_hyper_6_25_chunk._ts_meta_max_1, compress_hyper_6_25_chunk._ts_meta_min_2, compress_hyper_6_25_chunk._ts_meta_max_2
+                     Filter: (compress_hyper_6_25_chunk._ts_meta_max_3 > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
          ->  Seq Scan on _timescaledb_internal._hyper_2_12_chunk (actual rows=504 loops=1)
                Output: _hyper_2_12_chunk."time", _hyper_2_12_chunk.device_id, _hyper_2_12_chunk.device_id_peer, _hyper_2_12_chunk.v0, _hyper_2_12_chunk.v1, _hyper_2_12_chunk.v2, _hyper_2_12_chunk.v3
                Filter: (_hyper_2_12_chunk."time" > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
@@ -5501,23 +5501,23 @@ ORDER BY device_id DESC,
          Filter: (_hyper_2_10_chunk."time" > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
          Bulk Decompression: true
          ->  Sort (actual rows=1 loops=1)
-               Output: compress_hyper_6_20_chunk."time", compress_hyper_6_20_chunk.device_id, compress_hyper_6_20_chunk.device_id_peer, compress_hyper_6_20_chunk.v0, compress_hyper_6_20_chunk.v1, compress_hyper_6_20_chunk.v2, compress_hyper_6_20_chunk.v3, compress_hyper_6_20_chunk._ts_meta_count, compress_hyper_6_20_chunk._ts_meta_sequence_num, compress_hyper_6_20_chunk._ts_meta_min_3, compress_hyper_6_20_chunk._ts_meta_max_3, compress_hyper_6_20_chunk._ts_meta_min_1, compress_hyper_6_20_chunk._ts_meta_max_1, compress_hyper_6_20_chunk._ts_meta_min_2, compress_hyper_6_20_chunk._ts_meta_max_2
-               Sort Key: compress_hyper_6_20_chunk.device_id DESC, compress_hyper_6_20_chunk.device_id_peer DESC, compress_hyper_6_20_chunk._ts_meta_sequence_num
+               Output: compress_hyper_6_24_chunk."time", compress_hyper_6_24_chunk.device_id, compress_hyper_6_24_chunk.device_id_peer, compress_hyper_6_24_chunk.v0, compress_hyper_6_24_chunk.v1, compress_hyper_6_24_chunk.v2, compress_hyper_6_24_chunk.v3, compress_hyper_6_24_chunk._ts_meta_count, compress_hyper_6_24_chunk._ts_meta_sequence_num, compress_hyper_6_24_chunk._ts_meta_min_3, compress_hyper_6_24_chunk._ts_meta_max_3, compress_hyper_6_24_chunk._ts_meta_min_1, compress_hyper_6_24_chunk._ts_meta_max_1, compress_hyper_6_24_chunk._ts_meta_min_2, compress_hyper_6_24_chunk._ts_meta_max_2
+               Sort Key: compress_hyper_6_24_chunk.device_id DESC, compress_hyper_6_24_chunk.device_id_peer DESC, compress_hyper_6_24_chunk._ts_meta_sequence_num
                Sort Method: quicksort 
-               ->  Seq Scan on _timescaledb_internal.compress_hyper_6_20_chunk (actual rows=1 loops=1)
-                     Output: compress_hyper_6_20_chunk."time", compress_hyper_6_20_chunk.device_id, compress_hyper_6_20_chunk.device_id_peer, compress_hyper_6_20_chunk.v0, compress_hyper_6_20_chunk.v1, compress_hyper_6_20_chunk.v2, compress_hyper_6_20_chunk.v3, compress_hyper_6_20_chunk._ts_meta_count, compress_hyper_6_20_chunk._ts_meta_sequence_num, compress_hyper_6_20_chunk._ts_meta_min_3, compress_hyper_6_20_chunk._ts_meta_max_3, compress_hyper_6_20_chunk._ts_meta_min_1, compress_hyper_6_20_chunk._ts_meta_max_1, compress_hyper_6_20_chunk._ts_meta_min_2, compress_hyper_6_20_chunk._ts_meta_max_2
-                     Filter: (compress_hyper_6_20_chunk._ts_meta_max_3 > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
+               ->  Seq Scan on _timescaledb_internal.compress_hyper_6_24_chunk (actual rows=1 loops=1)
+                     Output: compress_hyper_6_24_chunk."time", compress_hyper_6_24_chunk.device_id, compress_hyper_6_24_chunk.device_id_peer, compress_hyper_6_24_chunk.v0, compress_hyper_6_24_chunk.v1, compress_hyper_6_24_chunk.v2, compress_hyper_6_24_chunk.v3, compress_hyper_6_24_chunk._ts_meta_count, compress_hyper_6_24_chunk._ts_meta_sequence_num, compress_hyper_6_24_chunk._ts_meta_min_3, compress_hyper_6_24_chunk._ts_meta_max_3, compress_hyper_6_24_chunk._ts_meta_min_1, compress_hyper_6_24_chunk._ts_meta_max_1, compress_hyper_6_24_chunk._ts_meta_min_2, compress_hyper_6_24_chunk._ts_meta_max_2
+                     Filter: (compress_hyper_6_24_chunk._ts_meta_max_3 > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
    ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_11_chunk (actual rows=1512 loops=1)
          Output: _hyper_2_11_chunk."time", _hyper_2_11_chunk.device_id, _hyper_2_11_chunk.device_id_peer, _hyper_2_11_chunk.v0, _hyper_2_11_chunk.v1, _hyper_2_11_chunk.v2, _hyper_2_11_chunk.v3
          Filter: (_hyper_2_11_chunk."time" > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
          Bulk Decompression: true
          ->  Sort (actual rows=3 loops=1)
-               Output: compress_hyper_6_21_chunk."time", compress_hyper_6_21_chunk.device_id, compress_hyper_6_21_chunk.device_id_peer, compress_hyper_6_21_chunk.v0, compress_hyper_6_21_chunk.v1, compress_hyper_6_21_chunk.v2, compress_hyper_6_21_chunk.v3, compress_hyper_6_21_chunk._ts_meta_count, compress_hyper_6_21_chunk._ts_meta_sequence_num, compress_hyper_6_21_chunk._ts_meta_min_3, compress_hyper_6_21_chunk._ts_meta_max_3, compress_hyper_6_21_chunk._ts_meta_min_1, compress_hyper_6_21_chunk._ts_meta_max_1, compress_hyper_6_21_chunk._ts_meta_min_2, compress_hyper_6_21_chunk._ts_meta_max_2
-               Sort Key: compress_hyper_6_21_chunk.device_id DESC, compress_hyper_6_21_chunk.device_id_peer DESC, compress_hyper_6_21_chunk._ts_meta_sequence_num
+               Output: compress_hyper_6_25_chunk."time", compress_hyper_6_25_chunk.device_id, compress_hyper_6_25_chunk.device_id_peer, compress_hyper_6_25_chunk.v0, compress_hyper_6_25_chunk.v1, compress_hyper_6_25_chunk.v2, compress_hyper_6_25_chunk.v3, compress_hyper_6_25_chunk._ts_meta_count, compress_hyper_6_25_chunk._ts_meta_sequence_num, compress_hyper_6_25_chunk._ts_meta_min_3, compress_hyper_6_25_chunk._ts_meta_max_3, compress_hyper_6_25_chunk._ts_meta_min_1, compress_hyper_6_25_chunk._ts_meta_max_1, compress_hyper_6_25_chunk._ts_meta_min_2, compress_hyper_6_25_chunk._ts_meta_max_2
+               Sort Key: compress_hyper_6_25_chunk.device_id DESC, compress_hyper_6_25_chunk.device_id_peer DESC, compress_hyper_6_25_chunk._ts_meta_sequence_num
                Sort Method: quicksort 
-               ->  Seq Scan on _timescaledb_internal.compress_hyper_6_21_chunk (actual rows=3 loops=1)
-                     Output: compress_hyper_6_21_chunk."time", compress_hyper_6_21_chunk.device_id, compress_hyper_6_21_chunk.device_id_peer, compress_hyper_6_21_chunk.v0, compress_hyper_6_21_chunk.v1, compress_hyper_6_21_chunk.v2, compress_hyper_6_21_chunk.v3, compress_hyper_6_21_chunk._ts_meta_count, compress_hyper_6_21_chunk._ts_meta_sequence_num, compress_hyper_6_21_chunk._ts_meta_min_3, compress_hyper_6_21_chunk._ts_meta_max_3, compress_hyper_6_21_chunk._ts_meta_min_1, compress_hyper_6_21_chunk._ts_meta_max_1, compress_hyper_6_21_chunk._ts_meta_min_2, compress_hyper_6_21_chunk._ts_meta_max_2
-                     Filter: (compress_hyper_6_21_chunk._ts_meta_max_3 > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
+               ->  Seq Scan on _timescaledb_internal.compress_hyper_6_25_chunk (actual rows=3 loops=1)
+                     Output: compress_hyper_6_25_chunk."time", compress_hyper_6_25_chunk.device_id, compress_hyper_6_25_chunk.device_id_peer, compress_hyper_6_25_chunk.v0, compress_hyper_6_25_chunk.v1, compress_hyper_6_25_chunk.v2, compress_hyper_6_25_chunk.v3, compress_hyper_6_25_chunk._ts_meta_count, compress_hyper_6_25_chunk._ts_meta_sequence_num, compress_hyper_6_25_chunk._ts_meta_min_3, compress_hyper_6_25_chunk._ts_meta_max_3, compress_hyper_6_25_chunk._ts_meta_min_1, compress_hyper_6_25_chunk._ts_meta_max_1, compress_hyper_6_25_chunk._ts_meta_min_2, compress_hyper_6_25_chunk._ts_meta_max_2
+                     Filter: (compress_hyper_6_25_chunk._ts_meta_max_3 > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
    ->  Index Scan using _hyper_2_12_chunk_metrics_space_device_id_device_id_peer_v0_v_2 on _timescaledb_internal._hyper_2_12_chunk (actual rows=504 loops=1)
          Output: _hyper_2_12_chunk."time", _hyper_2_12_chunk.device_id, _hyper_2_12_chunk.device_id_peer, _hyper_2_12_chunk.v0, _hyper_2_12_chunk.v1, _hyper_2_12_chunk.v2, _hyper_2_12_chunk.v3
          Index Cond: (_hyper_2_12_chunk."time" > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
@@ -5556,16 +5556,16 @@ ORDER BY device_id DESC,
                Output: _hyper_2_10_chunk."time", _hyper_2_10_chunk.device_id, _hyper_2_10_chunk.device_id_peer, _hyper_2_10_chunk.v0, _hyper_2_10_chunk.v1, _hyper_2_10_chunk.v2, _hyper_2_10_chunk.v3
                Filter: (_hyper_2_10_chunk."time" > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
                Bulk Decompression: true
-               ->  Seq Scan on _timescaledb_internal.compress_hyper_6_20_chunk (actual rows=1 loops=1)
-                     Output: compress_hyper_6_20_chunk."time", compress_hyper_6_20_chunk.device_id, compress_hyper_6_20_chunk.device_id_peer, compress_hyper_6_20_chunk.v0, compress_hyper_6_20_chunk.v1, compress_hyper_6_20_chunk.v2, compress_hyper_6_20_chunk.v3, compress_hyper_6_20_chunk._ts_meta_count, compress_hyper_6_20_chunk._ts_meta_sequence_num, compress_hyper_6_20_chunk._ts_meta_min_3, compress_hyper_6_20_chunk._ts_meta_max_3, compress_hyper_6_20_chunk._ts_meta_min_1, compress_hyper_6_20_chunk._ts_meta_max_1, compress_hyper_6_20_chunk._ts_meta_min_2, compress_hyper_6_20_chunk._ts_meta_max_2
-                     Filter: (compress_hyper_6_20_chunk._ts_meta_max_3 > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
+               ->  Seq Scan on _timescaledb_internal.compress_hyper_6_24_chunk (actual rows=1 loops=1)
+                     Output: compress_hyper_6_24_chunk."time", compress_hyper_6_24_chunk.device_id, compress_hyper_6_24_chunk.device_id_peer, compress_hyper_6_24_chunk.v0, compress_hyper_6_24_chunk.v1, compress_hyper_6_24_chunk.v2, compress_hyper_6_24_chunk.v3, compress_hyper_6_24_chunk._ts_meta_count, compress_hyper_6_24_chunk._ts_meta_sequence_num, compress_hyper_6_24_chunk._ts_meta_min_3, compress_hyper_6_24_chunk._ts_meta_max_3, compress_hyper_6_24_chunk._ts_meta_min_1, compress_hyper_6_24_chunk._ts_meta_max_1, compress_hyper_6_24_chunk._ts_meta_min_2, compress_hyper_6_24_chunk._ts_meta_max_2
+                     Filter: (compress_hyper_6_24_chunk._ts_meta_max_3 > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
          ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_11_chunk (actual rows=1512 loops=1)
                Output: _hyper_2_11_chunk."time", _hyper_2_11_chunk.device_id, _hyper_2_11_chunk.device_id_peer, _hyper_2_11_chunk.v0, _hyper_2_11_chunk.v1, _hyper_2_11_chunk.v2, _hyper_2_11_chunk.v3
                Filter: (_hyper_2_11_chunk."time" > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
                Bulk Decompression: true
-               ->  Seq Scan on _timescaledb_internal.compress_hyper_6_21_chunk (actual rows=3 loops=1)
-                     Output: compress_hyper_6_21_chunk."time", compress_hyper_6_21_chunk.device_id, compress_hyper_6_21_chunk.device_id_peer, compress_hyper_6_21_chunk.v0, compress_hyper_6_21_chunk.v1, compress_hyper_6_21_chunk.v2, compress_hyper_6_21_chunk.v3, compress_hyper_6_21_chunk._ts_meta_count, compress_hyper_6_21_chunk._ts_meta_sequence_num, compress_hyper_6_21_chunk._ts_meta_min_3, compress_hyper_6_21_chunk._ts_meta_max_3, compress_hyper_6_21_chunk._ts_meta_min_1, compress_hyper_6_21_chunk._ts_meta_max_1, compress_hyper_6_21_chunk._ts_meta_min_2, compress_hyper_6_21_chunk._ts_meta_max_2
-                     Filter: (compress_hyper_6_21_chunk._ts_meta_max_3 > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
+               ->  Seq Scan on _timescaledb_internal.compress_hyper_6_25_chunk (actual rows=3 loops=1)
+                     Output: compress_hyper_6_25_chunk."time", compress_hyper_6_25_chunk.device_id, compress_hyper_6_25_chunk.device_id_peer, compress_hyper_6_25_chunk.v0, compress_hyper_6_25_chunk.v1, compress_hyper_6_25_chunk.v2, compress_hyper_6_25_chunk.v3, compress_hyper_6_25_chunk._ts_meta_count, compress_hyper_6_25_chunk._ts_meta_sequence_num, compress_hyper_6_25_chunk._ts_meta_min_3, compress_hyper_6_25_chunk._ts_meta_max_3, compress_hyper_6_25_chunk._ts_meta_min_1, compress_hyper_6_25_chunk._ts_meta_max_1, compress_hyper_6_25_chunk._ts_meta_min_2, compress_hyper_6_25_chunk._ts_meta_max_2
+                     Filter: (compress_hyper_6_25_chunk._ts_meta_max_3 > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
          ->  Seq Scan on _timescaledb_internal._hyper_2_12_chunk (actual rows=504 loops=1)
                Output: _hyper_2_12_chunk."time", _hyper_2_12_chunk.device_id, _hyper_2_12_chunk.device_id_peer, _hyper_2_12_chunk.v0, _hyper_2_12_chunk.v1, _hyper_2_12_chunk.v2, _hyper_2_12_chunk.v3
                Filter: (_hyper_2_12_chunk."time" > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
@@ -5599,11 +5599,11 @@ ORDER BY time,
                Rows Removed by Filter: 169
          ->  Custom Scan (DecompressChunk) on _hyper_2_10_chunk (actual rows=504 loops=1)
                Filter: ("time" > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
-               ->  Seq Scan on compress_hyper_6_20_chunk (actual rows=1 loops=1)
+               ->  Seq Scan on compress_hyper_6_24_chunk (actual rows=1 loops=1)
                      Filter: (_ts_meta_max_3 > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
          ->  Custom Scan (DecompressChunk) on _hyper_2_11_chunk (actual rows=1512 loops=1)
                Filter: ("time" > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
-               ->  Seq Scan on compress_hyper_6_21_chunk (actual rows=3 loops=1)
+               ->  Seq Scan on compress_hyper_6_25_chunk (actual rows=3 loops=1)
                      Filter: (_ts_meta_max_3 > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
          ->  Seq Scan on _hyper_2_12_chunk (actual rows=504 loops=1)
                Filter: ("time" > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
@@ -5626,17 +5626,17 @@ ORDER BY time,
          ->  Merge Append (actual rows=0 loops=1)
                ->  Custom Scan (DecompressChunk) on _hyper_2_4_chunk (actual rows=0 loops=1)
                      Filter: ("time" > ('2000-01-08'::cstring)::timestamp with time zone)
-                     ->  Seq Scan on compress_hyper_6_17_chunk (actual rows=0 loops=1)
+                     ->  Seq Scan on compress_hyper_6_18_chunk (actual rows=0 loops=1)
                            Filter: (_ts_meta_max_3 > ('2000-01-08'::cstring)::timestamp with time zone)
                            Rows Removed by Filter: 1
                ->  Custom Scan (DecompressChunk) on _hyper_2_5_chunk (actual rows=0 loops=1)
                      Filter: ("time" > ('2000-01-08'::cstring)::timestamp with time zone)
-                     ->  Seq Scan on compress_hyper_6_18_chunk (actual rows=0 loops=1)
+                     ->  Seq Scan on compress_hyper_6_19_chunk (actual rows=0 loops=1)
                            Filter: (_ts_meta_max_3 > ('2000-01-08'::cstring)::timestamp with time zone)
                            Rows Removed by Filter: 3
                ->  Custom Scan (DecompressChunk) on _hyper_2_6_chunk (actual rows=0 loops=1)
                      Filter: ("time" > ('2000-01-08'::cstring)::timestamp with time zone)
-                     ->  Seq Scan on compress_hyper_6_19_chunk (actual rows=0 loops=1)
+                     ->  Seq Scan on compress_hyper_6_20_chunk (actual rows=0 loops=1)
                            Filter: (_ts_meta_max_3 > ('2000-01-08'::cstring)::timestamp with time zone)
                            Rows Removed by Filter: 1
          ->  Merge Append (actual rows=1675 loops=1)
@@ -5651,11 +5651,11 @@ ORDER BY time,
          ->  Merge Append (actual rows=2520 loops=1)
                ->  Custom Scan (DecompressChunk) on _hyper_2_10_chunk (actual rows=504 loops=1)
                      Filter: ("time" > ('2000-01-08'::cstring)::timestamp with time zone)
-                     ->  Seq Scan on compress_hyper_6_20_chunk (actual rows=1 loops=1)
+                     ->  Seq Scan on compress_hyper_6_24_chunk (actual rows=1 loops=1)
                            Filter: (_ts_meta_max_3 > ('2000-01-08'::cstring)::timestamp with time zone)
                ->  Custom Scan (DecompressChunk) on _hyper_2_11_chunk (actual rows=1512 loops=1)
                      Filter: ("time" > ('2000-01-08'::cstring)::timestamp with time zone)
-                     ->  Seq Scan on compress_hyper_6_21_chunk (actual rows=3 loops=1)
+                     ->  Seq Scan on compress_hyper_6_25_chunk (actual rows=3 loops=1)
                            Filter: (_ts_meta_max_3 > ('2000-01-08'::cstring)::timestamp with time zone)
                ->  Seq Scan on _hyper_2_12_chunk (actual rows=504 loops=1)
                      Filter: ("time" > ('2000-01-08'::cstring)::timestamp with time zone)
@@ -5670,18 +5670,18 @@ FROM :TEST_TABLE;
  Aggregate (actual rows=1 loops=1)
    ->  Append (actual rows=6840 loops=1)
          ->  Custom Scan (DecompressChunk) on _hyper_2_4_chunk (actual rows=360 loops=1)
-               ->  Seq Scan on compress_hyper_6_17_chunk (actual rows=1 loops=1)
+               ->  Seq Scan on compress_hyper_6_18_chunk (actual rows=1 loops=1)
          ->  Custom Scan (DecompressChunk) on _hyper_2_5_chunk (actual rows=1080 loops=1)
-               ->  Seq Scan on compress_hyper_6_18_chunk (actual rows=3 loops=1)
+               ->  Seq Scan on compress_hyper_6_19_chunk (actual rows=3 loops=1)
          ->  Custom Scan (DecompressChunk) on _hyper_2_6_chunk (actual rows=360 loops=1)
-               ->  Seq Scan on compress_hyper_6_19_chunk (actual rows=1 loops=1)
+               ->  Seq Scan on compress_hyper_6_20_chunk (actual rows=1 loops=1)
          ->  Seq Scan on _hyper_2_7_chunk (actual rows=504 loops=1)
          ->  Seq Scan on _hyper_2_8_chunk (actual rows=1512 loops=1)
          ->  Seq Scan on _hyper_2_9_chunk (actual rows=504 loops=1)
          ->  Custom Scan (DecompressChunk) on _hyper_2_10_chunk (actual rows=504 loops=1)
-               ->  Seq Scan on compress_hyper_6_20_chunk (actual rows=1 loops=1)
+               ->  Seq Scan on compress_hyper_6_24_chunk (actual rows=1 loops=1)
          ->  Custom Scan (DecompressChunk) on _hyper_2_11_chunk (actual rows=1512 loops=1)
-               ->  Seq Scan on compress_hyper_6_21_chunk (actual rows=3 loops=1)
+               ->  Seq Scan on compress_hyper_6_25_chunk (actual rows=3 loops=1)
          ->  Seq Scan on _hyper_2_12_chunk (actual rows=504 loops=1)
 (16 rows)
 
@@ -5701,18 +5701,18 @@ ORDER BY device_id;
          Batches: 1 
          ->  Append (actual rows=6840 loops=1)
                ->  Custom Scan (DecompressChunk) on _hyper_2_4_chunk (actual rows=360 loops=1)
-                     ->  Seq Scan on compress_hyper_6_17_chunk (actual rows=1 loops=1)
+                     ->  Seq Scan on compress_hyper_6_18_chunk (actual rows=1 loops=1)
                ->  Custom Scan (DecompressChunk) on _hyper_2_5_chunk (actual rows=1080 loops=1)
-                     ->  Seq Scan on compress_hyper_6_18_chunk (actual rows=3 loops=1)
+                     ->  Seq Scan on compress_hyper_6_19_chunk (actual rows=3 loops=1)
                ->  Custom Scan (DecompressChunk) on _hyper_2_6_chunk (actual rows=360 loops=1)
-                     ->  Seq Scan on compress_hyper_6_19_chunk (actual rows=1 loops=1)
+                     ->  Seq Scan on compress_hyper_6_20_chunk (actual rows=1 loops=1)
                ->  Seq Scan on _hyper_2_7_chunk (actual rows=504 loops=1)
                ->  Seq Scan on _hyper_2_8_chunk (actual rows=1512 loops=1)
                ->  Seq Scan on _hyper_2_9_chunk (actual rows=504 loops=1)
                ->  Custom Scan (DecompressChunk) on _hyper_2_10_chunk (actual rows=504 loops=1)
-                     ->  Seq Scan on compress_hyper_6_20_chunk (actual rows=1 loops=1)
+                     ->  Seq Scan on compress_hyper_6_24_chunk (actual rows=1 loops=1)
                ->  Custom Scan (DecompressChunk) on _hyper_2_11_chunk (actual rows=1512 loops=1)
-                     ->  Seq Scan on compress_hyper_6_21_chunk (actual rows=3 loops=1)
+                     ->  Seq Scan on compress_hyper_6_25_chunk (actual rows=3 loops=1)
                ->  Seq Scan on _hyper_2_12_chunk (actual rows=504 loops=1)
 (21 rows)
 
@@ -5733,18 +5733,18 @@ ORDER BY device_id;
                Batches: 1 
                ->  Append (actual rows=6840 loops=1)
                      ->  Custom Scan (DecompressChunk) on _hyper_2_4_chunk (actual rows=360 loops=1)
-                           ->  Seq Scan on compress_hyper_6_17_chunk (actual rows=1 loops=1)
+                           ->  Seq Scan on compress_hyper_6_18_chunk (actual rows=1 loops=1)
                      ->  Custom Scan (DecompressChunk) on _hyper_2_5_chunk (actual rows=1080 loops=1)
-                           ->  Seq Scan on compress_hyper_6_18_chunk (actual rows=3 loops=1)
+                           ->  Seq Scan on compress_hyper_6_19_chunk (actual rows=3 loops=1)
                      ->  Custom Scan (DecompressChunk) on _hyper_2_6_chunk (actual rows=360 loops=1)
-                           ->  Seq Scan on compress_hyper_6_19_chunk (actual rows=1 loops=1)
+                           ->  Seq Scan on compress_hyper_6_20_chunk (actual rows=1 loops=1)
                      ->  Seq Scan on _hyper_2_7_chunk (actual rows=504 loops=1)
                      ->  Seq Scan on _hyper_2_8_chunk (actual rows=1512 loops=1)
                      ->  Seq Scan on _hyper_2_9_chunk (actual rows=504 loops=1)
                      ->  Custom Scan (DecompressChunk) on _hyper_2_10_chunk (actual rows=504 loops=1)
-                           ->  Seq Scan on compress_hyper_6_20_chunk (actual rows=1 loops=1)
+                           ->  Seq Scan on compress_hyper_6_24_chunk (actual rows=1 loops=1)
                      ->  Custom Scan (DecompressChunk) on _hyper_2_11_chunk (actual rows=1512 loops=1)
-                           ->  Seq Scan on compress_hyper_6_21_chunk (actual rows=3 loops=1)
+                           ->  Seq Scan on compress_hyper_6_25_chunk (actual rows=3 loops=1)
                      ->  Seq Scan on _hyper_2_12_chunk (actual rows=504 loops=1)
 (22 rows)
 
@@ -5774,7 +5774,7 @@ ORDER BY v1;
                                  Sort Key: _hyper_2_4_chunk."time"
                                  Sort Method: quicksort 
                                  ->  Custom Scan (DecompressChunk) on _hyper_2_4_chunk (actual rows=360 loops=1)
-                                       ->  Seq Scan on compress_hyper_6_17_chunk (actual rows=1 loops=1)
+                                       ->  Seq Scan on compress_hyper_6_18_chunk (actual rows=1 loops=1)
                      ->  Sort (actual rows=1080 loops=1)
                            Sort Key: _hyper_2_5_chunk."time"
                            Sort Method: quicksort 
@@ -5782,7 +5782,7 @@ ORDER BY v1;
                                  Sort Key: _hyper_2_5_chunk."time"
                                  Sort Method: quicksort 
                                  ->  Custom Scan (DecompressChunk) on _hyper_2_5_chunk (actual rows=1080 loops=1)
-                                       ->  Seq Scan on compress_hyper_6_18_chunk (actual rows=3 loops=1)
+                                       ->  Seq Scan on compress_hyper_6_19_chunk (actual rows=3 loops=1)
                      ->  Sort (actual rows=360 loops=1)
                            Sort Key: _hyper_2_6_chunk."time"
                            Sort Method: quicksort 
@@ -5790,7 +5790,7 @@ ORDER BY v1;
                                  Sort Key: _hyper_2_6_chunk."time"
                                  Sort Method: quicksort 
                                  ->  Custom Scan (DecompressChunk) on _hyper_2_6_chunk (actual rows=360 loops=1)
-                                       ->  Seq Scan on compress_hyper_6_19_chunk (actual rows=1 loops=1)
+                                       ->  Seq Scan on compress_hyper_6_20_chunk (actual rows=1 loops=1)
                ->  Merge Append (actual rows=2520 loops=1)
                      Sort Key: _hyper_2_7_chunk."time"
                      ->  Index Scan Backward using _hyper_2_7_chunk_metrics_space_time_idx on _hyper_2_7_chunk (actual rows=504 loops=1)
@@ -5805,7 +5805,7 @@ ORDER BY v1;
                                  Sort Key: _hyper_2_10_chunk."time"
                                  Sort Method: quicksort 
                                  ->  Custom Scan (DecompressChunk) on _hyper_2_10_chunk (actual rows=504 loops=1)
-                                       ->  Seq Scan on compress_hyper_6_20_chunk (actual rows=1 loops=1)
+                                       ->  Seq Scan on compress_hyper_6_24_chunk (actual rows=1 loops=1)
                      ->  Sort (actual rows=1512 loops=1)
                            Sort Key: _hyper_2_11_chunk."time"
                            Sort Method: quicksort 
@@ -5813,7 +5813,7 @@ ORDER BY v1;
                                  Sort Key: _hyper_2_11_chunk."time"
                                  Sort Method: quicksort 
                                  ->  Custom Scan (DecompressChunk) on _hyper_2_11_chunk (actual rows=1512 loops=1)
-                                       ->  Seq Scan on compress_hyper_6_21_chunk (actual rows=3 loops=1)
+                                       ->  Seq Scan on compress_hyper_6_25_chunk (actual rows=3 loops=1)
                      ->  Index Scan Backward using _hyper_2_12_chunk_metrics_space_time_idx on _hyper_2_12_chunk (actual rows=504 loops=1)
 (56 rows)
 
@@ -5846,7 +5846,7 @@ ORDER BY q1.time;
                Sort Key: _hyper_2_4_chunk."time"
                Sort Method: quicksort 
                ->  Custom Scan (DecompressChunk) on _hyper_2_4_chunk (actual rows=360 loops=1)
-                     ->  Seq Scan on compress_hyper_6_17_chunk (actual rows=1 loops=1)
+                     ->  Seq Scan on compress_hyper_6_18_chunk (actual rows=1 loops=1)
                            Filter: (device_id = 1)
          ->  Index Scan Backward using _hyper_2_7_chunk_metrics_space_time_idx on _hyper_2_7_chunk (actual rows=504 loops=1)
                Filter: (device_id = 1)
@@ -5854,7 +5854,7 @@ ORDER BY q1.time;
                Sort Key: _hyper_2_10_chunk."time"
                Sort Method: quicksort 
                ->  Custom Scan (DecompressChunk) on _hyper_2_10_chunk (actual rows=504 loops=1)
-                     ->  Seq Scan on compress_hyper_6_20_chunk (actual rows=1 loops=1)
+                     ->  Seq Scan on compress_hyper_6_24_chunk (actual rows=1 loops=1)
                            Filter: (device_id = 1)
    ->  Materialize (actual rows=1368 loops=1)
          ->  Custom Scan (ChunkAppend) on metrics_space metrics_space_1 (actual rows=1368 loops=1)
@@ -5863,7 +5863,7 @@ ORDER BY q1.time;
                      Sort Key: _hyper_2_5_chunk."time"
                      Sort Method: quicksort 
                      ->  Custom Scan (DecompressChunk) on _hyper_2_5_chunk (actual rows=360 loops=1)
-                           ->  Seq Scan on compress_hyper_6_18_chunk (actual rows=1 loops=1)
+                           ->  Seq Scan on compress_hyper_6_19_chunk (actual rows=1 loops=1)
                                  Filter: (device_id = 2)
                                  Rows Removed by Filter: 2
                ->  Index Scan Backward using _hyper_2_8_chunk_metrics_space_device_id_time_idx on _hyper_2_8_chunk (actual rows=504 loops=1)
@@ -5872,7 +5872,7 @@ ORDER BY q1.time;
                      Sort Key: _hyper_2_11_chunk."time"
                      Sort Method: quicksort 
                      ->  Custom Scan (DecompressChunk) on _hyper_2_11_chunk (actual rows=504 loops=1)
-                           ->  Seq Scan on compress_hyper_6_21_chunk (actual rows=1 loops=1)
+                           ->  Seq Scan on compress_hyper_6_25_chunk (actual rows=1 loops=1)
                                  Filter: (device_id = 2)
                                  Rows Removed by Filter: 2
 (37 rows)
@@ -5888,12 +5888,12 @@ WHERE device_id = 1;
  Aggregate (actual rows=1 loops=1)
    ->  Append (actual rows=1368 loops=1)
          ->  Custom Scan (DecompressChunk) on _hyper_2_4_chunk (actual rows=360 loops=1)
-               ->  Seq Scan on compress_hyper_6_17_chunk (actual rows=1 loops=1)
+               ->  Seq Scan on compress_hyper_6_18_chunk (actual rows=1 loops=1)
                      Filter: (device_id = 1)
          ->  Seq Scan on _hyper_2_7_chunk (actual rows=504 loops=1)
                Filter: (device_id = 1)
          ->  Custom Scan (DecompressChunk) on _hyper_2_10_chunk (actual rows=504 loops=1)
-               ->  Seq Scan on compress_hyper_6_20_chunk (actual rows=1 loops=1)
+               ->  Seq Scan on compress_hyper_6_24_chunk (actual rows=1 loops=1)
                      Filter: (device_id = 1)
 (10 rows)
 
@@ -5957,9 +5957,9 @@ ORDER BY device_id,
          ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_4_chunk (actual rows=360 loops=1)
                Output: _hyper_2_4_chunk."time", _hyper_2_4_chunk.device_id
                Bulk Decompression: true
-               ->  Index Scan using compress_hyper_6_17_chunk_c_space_index_2 on _timescaledb_internal.compress_hyper_6_17_chunk (actual rows=1 loops=1)
-                     Output: compress_hyper_6_17_chunk."time", compress_hyper_6_17_chunk.device_id, compress_hyper_6_17_chunk.device_id_peer, compress_hyper_6_17_chunk.v0, compress_hyper_6_17_chunk.v1, compress_hyper_6_17_chunk.v2, compress_hyper_6_17_chunk.v3, compress_hyper_6_17_chunk._ts_meta_count, compress_hyper_6_17_chunk._ts_meta_sequence_num, compress_hyper_6_17_chunk._ts_meta_min_3, compress_hyper_6_17_chunk._ts_meta_max_3, compress_hyper_6_17_chunk._ts_meta_min_1, compress_hyper_6_17_chunk._ts_meta_max_1, compress_hyper_6_17_chunk._ts_meta_min_2, compress_hyper_6_17_chunk._ts_meta_max_2
-                     Index Cond: (compress_hyper_6_17_chunk.device_id = 1)
+               ->  Index Scan using compress_hyper_6_18_chunk_c_space_index_2 on _timescaledb_internal.compress_hyper_6_18_chunk (actual rows=1 loops=1)
+                     Output: compress_hyper_6_18_chunk."time", compress_hyper_6_18_chunk.device_id, compress_hyper_6_18_chunk.device_id_peer, compress_hyper_6_18_chunk.v0, compress_hyper_6_18_chunk.v1, compress_hyper_6_18_chunk.v2, compress_hyper_6_18_chunk.v3, compress_hyper_6_18_chunk._ts_meta_count, compress_hyper_6_18_chunk._ts_meta_sequence_num, compress_hyper_6_18_chunk._ts_meta_min_3, compress_hyper_6_18_chunk._ts_meta_max_3, compress_hyper_6_18_chunk._ts_meta_min_1, compress_hyper_6_18_chunk._ts_meta_max_1, compress_hyper_6_18_chunk._ts_meta_min_2, compress_hyper_6_18_chunk._ts_meta_max_2
+                     Index Cond: (compress_hyper_6_18_chunk.device_id = 1)
    ->  Index Scan Backward using _hyper_2_7_chunk_metrics_space_time_idx on _timescaledb_internal._hyper_2_7_chunk (actual rows=504 loops=1)
          Output: _hyper_2_7_chunk."time", _hyper_2_7_chunk.device_id
          Filter: (_hyper_2_7_chunk.device_id = 1)
@@ -5970,9 +5970,9 @@ ORDER BY device_id,
          ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_10_chunk (actual rows=504 loops=1)
                Output: _hyper_2_10_chunk."time", _hyper_2_10_chunk.device_id
                Bulk Decompression: true
-               ->  Index Scan using compress_hyper_6_20_chunk_c_space_index_2 on _timescaledb_internal.compress_hyper_6_20_chunk (actual rows=1 loops=1)
-                     Output: compress_hyper_6_20_chunk."time", compress_hyper_6_20_chunk.device_id, compress_hyper_6_20_chunk.device_id_peer, compress_hyper_6_20_chunk.v0, compress_hyper_6_20_chunk.v1, compress_hyper_6_20_chunk.v2, compress_hyper_6_20_chunk.v3, compress_hyper_6_20_chunk._ts_meta_count, compress_hyper_6_20_chunk._ts_meta_sequence_num, compress_hyper_6_20_chunk._ts_meta_min_3, compress_hyper_6_20_chunk._ts_meta_max_3, compress_hyper_6_20_chunk._ts_meta_min_1, compress_hyper_6_20_chunk._ts_meta_max_1, compress_hyper_6_20_chunk._ts_meta_min_2, compress_hyper_6_20_chunk._ts_meta_max_2
-                     Index Cond: (compress_hyper_6_20_chunk.device_id = 1)
+               ->  Index Scan using compress_hyper_6_24_chunk_c_space_index_2 on _timescaledb_internal.compress_hyper_6_24_chunk (actual rows=1 loops=1)
+                     Output: compress_hyper_6_24_chunk."time", compress_hyper_6_24_chunk.device_id, compress_hyper_6_24_chunk.device_id_peer, compress_hyper_6_24_chunk.v0, compress_hyper_6_24_chunk.v1, compress_hyper_6_24_chunk.v2, compress_hyper_6_24_chunk.v3, compress_hyper_6_24_chunk._ts_meta_count, compress_hyper_6_24_chunk._ts_meta_sequence_num, compress_hyper_6_24_chunk._ts_meta_min_3, compress_hyper_6_24_chunk._ts_meta_max_3, compress_hyper_6_24_chunk._ts_meta_min_1, compress_hyper_6_24_chunk._ts_meta_max_1, compress_hyper_6_24_chunk._ts_meta_min_2, compress_hyper_6_24_chunk._ts_meta_max_2
+                     Index Cond: (compress_hyper_6_24_chunk.device_id = 1)
 (25 rows)
 
 -- globs should not plan IndexOnlyScans
@@ -5993,9 +5993,9 @@ ORDER BY device_id,
          ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_4_chunk (actual rows=360 loops=1)
                Output: _hyper_2_4_chunk."time", _hyper_2_4_chunk.device_id, _hyper_2_4_chunk.device_id_peer, _hyper_2_4_chunk.v0, _hyper_2_4_chunk.v1, _hyper_2_4_chunk.v2, _hyper_2_4_chunk.v3
                Bulk Decompression: true
-               ->  Index Scan using compress_hyper_6_17_chunk_c_space_index_2 on _timescaledb_internal.compress_hyper_6_17_chunk (actual rows=1 loops=1)
-                     Output: compress_hyper_6_17_chunk."time", compress_hyper_6_17_chunk.device_id, compress_hyper_6_17_chunk.device_id_peer, compress_hyper_6_17_chunk.v0, compress_hyper_6_17_chunk.v1, compress_hyper_6_17_chunk.v2, compress_hyper_6_17_chunk.v3, compress_hyper_6_17_chunk._ts_meta_count, compress_hyper_6_17_chunk._ts_meta_sequence_num, compress_hyper_6_17_chunk._ts_meta_min_3, compress_hyper_6_17_chunk._ts_meta_max_3, compress_hyper_6_17_chunk._ts_meta_min_1, compress_hyper_6_17_chunk._ts_meta_max_1, compress_hyper_6_17_chunk._ts_meta_min_2, compress_hyper_6_17_chunk._ts_meta_max_2
-                     Index Cond: (compress_hyper_6_17_chunk.device_id = 1)
+               ->  Index Scan using compress_hyper_6_18_chunk_c_space_index_2 on _timescaledb_internal.compress_hyper_6_18_chunk (actual rows=1 loops=1)
+                     Output: compress_hyper_6_18_chunk."time", compress_hyper_6_18_chunk.device_id, compress_hyper_6_18_chunk.device_id_peer, compress_hyper_6_18_chunk.v0, compress_hyper_6_18_chunk.v1, compress_hyper_6_18_chunk.v2, compress_hyper_6_18_chunk.v3, compress_hyper_6_18_chunk._ts_meta_count, compress_hyper_6_18_chunk._ts_meta_sequence_num, compress_hyper_6_18_chunk._ts_meta_min_3, compress_hyper_6_18_chunk._ts_meta_max_3, compress_hyper_6_18_chunk._ts_meta_min_1, compress_hyper_6_18_chunk._ts_meta_max_1, compress_hyper_6_18_chunk._ts_meta_min_2, compress_hyper_6_18_chunk._ts_meta_max_2
+                     Index Cond: (compress_hyper_6_18_chunk.device_id = 1)
    ->  Index Scan Backward using _hyper_2_7_chunk_metrics_space_time_idx on _timescaledb_internal._hyper_2_7_chunk (actual rows=504 loops=1)
          Output: _hyper_2_7_chunk."time", _hyper_2_7_chunk.device_id, _hyper_2_7_chunk.device_id_peer, _hyper_2_7_chunk.v0, _hyper_2_7_chunk.v1, _hyper_2_7_chunk.v2, _hyper_2_7_chunk.v3
          Filter: (_hyper_2_7_chunk.device_id = 1)
@@ -6006,9 +6006,9 @@ ORDER BY device_id,
          ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_10_chunk (actual rows=504 loops=1)
                Output: _hyper_2_10_chunk."time", _hyper_2_10_chunk.device_id, _hyper_2_10_chunk.device_id_peer, _hyper_2_10_chunk.v0, _hyper_2_10_chunk.v1, _hyper_2_10_chunk.v2, _hyper_2_10_chunk.v3
                Bulk Decompression: true
-               ->  Index Scan using compress_hyper_6_20_chunk_c_space_index_2 on _timescaledb_internal.compress_hyper_6_20_chunk (actual rows=1 loops=1)
-                     Output: compress_hyper_6_20_chunk."time", compress_hyper_6_20_chunk.device_id, compress_hyper_6_20_chunk.device_id_peer, compress_hyper_6_20_chunk.v0, compress_hyper_6_20_chunk.v1, compress_hyper_6_20_chunk.v2, compress_hyper_6_20_chunk.v3, compress_hyper_6_20_chunk._ts_meta_count, compress_hyper_6_20_chunk._ts_meta_sequence_num, compress_hyper_6_20_chunk._ts_meta_min_3, compress_hyper_6_20_chunk._ts_meta_max_3, compress_hyper_6_20_chunk._ts_meta_min_1, compress_hyper_6_20_chunk._ts_meta_max_1, compress_hyper_6_20_chunk._ts_meta_min_2, compress_hyper_6_20_chunk._ts_meta_max_2
-                     Index Cond: (compress_hyper_6_20_chunk.device_id = 1)
+               ->  Index Scan using compress_hyper_6_24_chunk_c_space_index_2 on _timescaledb_internal.compress_hyper_6_24_chunk (actual rows=1 loops=1)
+                     Output: compress_hyper_6_24_chunk."time", compress_hyper_6_24_chunk.device_id, compress_hyper_6_24_chunk.device_id_peer, compress_hyper_6_24_chunk.v0, compress_hyper_6_24_chunk.v1, compress_hyper_6_24_chunk.v2, compress_hyper_6_24_chunk.v3, compress_hyper_6_24_chunk._ts_meta_count, compress_hyper_6_24_chunk._ts_meta_sequence_num, compress_hyper_6_24_chunk._ts_meta_min_3, compress_hyper_6_24_chunk._ts_meta_max_3, compress_hyper_6_24_chunk._ts_meta_min_1, compress_hyper_6_24_chunk._ts_meta_max_1, compress_hyper_6_24_chunk._ts_meta_min_2, compress_hyper_6_24_chunk._ts_meta_max_2
+                     Index Cond: (compress_hyper_6_24_chunk.device_id = 1)
 (25 rows)
 
 -- whole row reference should work
@@ -6029,9 +6029,9 @@ ORDER BY device_id,
          ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_4_chunk test_table_1 (actual rows=360 loops=1)
                Output: test_table_1.*, test_table_1.device_id, test_table_1."time"
                Bulk Decompression: true
-               ->  Index Scan using compress_hyper_6_17_chunk_c_space_index_2 on _timescaledb_internal.compress_hyper_6_17_chunk (actual rows=1 loops=1)
-                     Output: compress_hyper_6_17_chunk."time", compress_hyper_6_17_chunk.device_id, compress_hyper_6_17_chunk.device_id_peer, compress_hyper_6_17_chunk.v0, compress_hyper_6_17_chunk.v1, compress_hyper_6_17_chunk.v2, compress_hyper_6_17_chunk.v3, compress_hyper_6_17_chunk._ts_meta_count, compress_hyper_6_17_chunk._ts_meta_sequence_num, compress_hyper_6_17_chunk._ts_meta_min_3, compress_hyper_6_17_chunk._ts_meta_max_3, compress_hyper_6_17_chunk._ts_meta_min_1, compress_hyper_6_17_chunk._ts_meta_max_1, compress_hyper_6_17_chunk._ts_meta_min_2, compress_hyper_6_17_chunk._ts_meta_max_2
-                     Index Cond: (compress_hyper_6_17_chunk.device_id = 1)
+               ->  Index Scan using compress_hyper_6_18_chunk_c_space_index_2 on _timescaledb_internal.compress_hyper_6_18_chunk (actual rows=1 loops=1)
+                     Output: compress_hyper_6_18_chunk."time", compress_hyper_6_18_chunk.device_id, compress_hyper_6_18_chunk.device_id_peer, compress_hyper_6_18_chunk.v0, compress_hyper_6_18_chunk.v1, compress_hyper_6_18_chunk.v2, compress_hyper_6_18_chunk.v3, compress_hyper_6_18_chunk._ts_meta_count, compress_hyper_6_18_chunk._ts_meta_sequence_num, compress_hyper_6_18_chunk._ts_meta_min_3, compress_hyper_6_18_chunk._ts_meta_max_3, compress_hyper_6_18_chunk._ts_meta_min_1, compress_hyper_6_18_chunk._ts_meta_max_1, compress_hyper_6_18_chunk._ts_meta_min_2, compress_hyper_6_18_chunk._ts_meta_max_2
+                     Index Cond: (compress_hyper_6_18_chunk.device_id = 1)
    ->  Index Scan Backward using _hyper_2_7_chunk_metrics_space_time_idx on _timescaledb_internal._hyper_2_7_chunk test_table_2 (actual rows=504 loops=1)
          Output: test_table_2.*, test_table_2.device_id, test_table_2."time"
          Filter: (test_table_2.device_id = 1)
@@ -6042,9 +6042,9 @@ ORDER BY device_id,
          ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_10_chunk test_table_3 (actual rows=504 loops=1)
                Output: test_table_3.*, test_table_3.device_id, test_table_3."time"
                Bulk Decompression: true
-               ->  Index Scan using compress_hyper_6_20_chunk_c_space_index_2 on _timescaledb_internal.compress_hyper_6_20_chunk (actual rows=1 loops=1)
-                     Output: compress_hyper_6_20_chunk."time", compress_hyper_6_20_chunk.device_id, compress_hyper_6_20_chunk.device_id_peer, compress_hyper_6_20_chunk.v0, compress_hyper_6_20_chunk.v1, compress_hyper_6_20_chunk.v2, compress_hyper_6_20_chunk.v3, compress_hyper_6_20_chunk._ts_meta_count, compress_hyper_6_20_chunk._ts_meta_sequence_num, compress_hyper_6_20_chunk._ts_meta_min_3, compress_hyper_6_20_chunk._ts_meta_max_3, compress_hyper_6_20_chunk._ts_meta_min_1, compress_hyper_6_20_chunk._ts_meta_max_1, compress_hyper_6_20_chunk._ts_meta_min_2, compress_hyper_6_20_chunk._ts_meta_max_2
-                     Index Cond: (compress_hyper_6_20_chunk.device_id = 1)
+               ->  Index Scan using compress_hyper_6_24_chunk_c_space_index_2 on _timescaledb_internal.compress_hyper_6_24_chunk (actual rows=1 loops=1)
+                     Output: compress_hyper_6_24_chunk."time", compress_hyper_6_24_chunk.device_id, compress_hyper_6_24_chunk.device_id_peer, compress_hyper_6_24_chunk.v0, compress_hyper_6_24_chunk.v1, compress_hyper_6_24_chunk.v2, compress_hyper_6_24_chunk.v3, compress_hyper_6_24_chunk._ts_meta_count, compress_hyper_6_24_chunk._ts_meta_sequence_num, compress_hyper_6_24_chunk._ts_meta_min_3, compress_hyper_6_24_chunk._ts_meta_max_3, compress_hyper_6_24_chunk._ts_meta_min_1, compress_hyper_6_24_chunk._ts_meta_max_1, compress_hyper_6_24_chunk._ts_meta_min_2, compress_hyper_6_24_chunk._ts_meta_max_2
+                     Index Cond: (compress_hyper_6_24_chunk.device_id = 1)
 (25 rows)
 
 -- even when we select only a segmentby column, we still need count
@@ -6059,9 +6059,9 @@ ORDER BY device_id;
    ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_4_chunk (actual rows=360 loops=1)
          Output: _hyper_2_4_chunk.device_id
          Bulk Decompression: false
-         ->  Index Only Scan using compress_hyper_6_17_chunk_c_space_index_2 on _timescaledb_internal.compress_hyper_6_17_chunk (actual rows=1 loops=1)
-               Output: compress_hyper_6_17_chunk.device_id, compress_hyper_6_17_chunk._ts_meta_count
-               Index Cond: (compress_hyper_6_17_chunk.device_id = 1)
+         ->  Index Only Scan using compress_hyper_6_18_chunk_c_space_index_2 on _timescaledb_internal.compress_hyper_6_18_chunk (actual rows=1 loops=1)
+               Output: compress_hyper_6_18_chunk.device_id, compress_hyper_6_18_chunk._ts_meta_count
+               Index Cond: (compress_hyper_6_18_chunk.device_id = 1)
                Heap Fetches: 1
    ->  Index Only Scan using _hyper_2_7_chunk_metrics_space_device_id_device_id_peer_v0_v1_2 on _timescaledb_internal._hyper_2_7_chunk (actual rows=504 loops=1)
          Output: _hyper_2_7_chunk.device_id
@@ -6070,9 +6070,9 @@ ORDER BY device_id;
    ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_10_chunk (actual rows=504 loops=1)
          Output: _hyper_2_10_chunk.device_id
          Bulk Decompression: false
-         ->  Index Only Scan using compress_hyper_6_20_chunk_c_space_index_2 on _timescaledb_internal.compress_hyper_6_20_chunk (actual rows=1 loops=1)
-               Output: compress_hyper_6_20_chunk.device_id, compress_hyper_6_20_chunk._ts_meta_count
-               Index Cond: (compress_hyper_6_20_chunk.device_id = 1)
+         ->  Index Only Scan using compress_hyper_6_24_chunk_c_space_index_2 on _timescaledb_internal.compress_hyper_6_24_chunk (actual rows=1 loops=1)
+               Output: compress_hyper_6_24_chunk.device_id, compress_hyper_6_24_chunk._ts_meta_count
+               Index Cond: (compress_hyper_6_24_chunk.device_id = 1)
                Heap Fetches: 1
 (19 rows)
 
@@ -6087,18 +6087,18 @@ WHERE device_id = 1;
    ->  Append (actual rows=1368 loops=1)
          ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_4_chunk (actual rows=360 loops=1)
                Bulk Decompression: false
-               ->  Index Only Scan using compress_hyper_6_17_chunk_c_space_index_2 on _timescaledb_internal.compress_hyper_6_17_chunk (actual rows=1 loops=1)
-                     Output: compress_hyper_6_17_chunk.device_id, compress_hyper_6_17_chunk._ts_meta_count
-                     Index Cond: (compress_hyper_6_17_chunk.device_id = 1)
+               ->  Index Only Scan using compress_hyper_6_18_chunk_c_space_index_2 on _timescaledb_internal.compress_hyper_6_18_chunk (actual rows=1 loops=1)
+                     Output: compress_hyper_6_18_chunk.device_id, compress_hyper_6_18_chunk._ts_meta_count
+                     Index Cond: (compress_hyper_6_18_chunk.device_id = 1)
                      Heap Fetches: 1
          ->  Index Only Scan using _hyper_2_7_chunk_metrics_space_device_id_device_id_peer_v0_v1_2 on _timescaledb_internal._hyper_2_7_chunk (actual rows=504 loops=1)
                Index Cond: (_hyper_2_7_chunk.device_id = 1)
                Heap Fetches: 504
          ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_10_chunk (actual rows=504 loops=1)
                Bulk Decompression: false
-               ->  Index Only Scan using compress_hyper_6_20_chunk_c_space_index_2 on _timescaledb_internal.compress_hyper_6_20_chunk (actual rows=1 loops=1)
-                     Output: compress_hyper_6_20_chunk.device_id, compress_hyper_6_20_chunk._ts_meta_count
-                     Index Cond: (compress_hyper_6_20_chunk.device_id = 1)
+               ->  Index Only Scan using compress_hyper_6_24_chunk_c_space_index_2 on _timescaledb_internal.compress_hyper_6_24_chunk (actual rows=1 loops=1)
+                     Output: compress_hyper_6_24_chunk.device_id, compress_hyper_6_24_chunk._ts_meta_count
+                     Index Cond: (compress_hyper_6_24_chunk.device_id = 1)
                      Heap Fetches: 1
 (18 rows)
 
@@ -6115,20 +6115,20 @@ ORDER BY device_id;
    ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_4_chunk (actual rows=360 loops=1)
          Output: _hyper_2_4_chunk.device_id
          Bulk Decompression: false
-         ->  Index Only Scan using compress_hyper_6_17_chunk_c_space_index_2 on _timescaledb_internal.compress_hyper_6_17_chunk (actual rows=1 loops=1)
-               Output: compress_hyper_6_17_chunk.device_id, compress_hyper_6_17_chunk._ts_meta_count
+         ->  Index Only Scan using compress_hyper_6_18_chunk_c_space_index_2 on _timescaledb_internal.compress_hyper_6_18_chunk (actual rows=1 loops=1)
+               Output: compress_hyper_6_18_chunk.device_id, compress_hyper_6_18_chunk._ts_meta_count
                Heap Fetches: 1
    ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_5_chunk (actual rows=1080 loops=1)
          Output: _hyper_2_5_chunk.device_id
          Bulk Decompression: false
-         ->  Index Only Scan using compress_hyper_6_18_chunk_c_space_index_2 on _timescaledb_internal.compress_hyper_6_18_chunk (actual rows=3 loops=1)
-               Output: compress_hyper_6_18_chunk.device_id, compress_hyper_6_18_chunk._ts_meta_count
+         ->  Index Only Scan using compress_hyper_6_19_chunk_c_space_index_2 on _timescaledb_internal.compress_hyper_6_19_chunk (actual rows=3 loops=1)
+               Output: compress_hyper_6_19_chunk.device_id, compress_hyper_6_19_chunk._ts_meta_count
                Heap Fetches: 3
    ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_6_chunk (actual rows=360 loops=1)
          Output: _hyper_2_6_chunk.device_id
          Bulk Decompression: false
-         ->  Index Only Scan using compress_hyper_6_19_chunk_c_space_index_2 on _timescaledb_internal.compress_hyper_6_19_chunk (actual rows=1 loops=1)
-               Output: compress_hyper_6_19_chunk.device_id, compress_hyper_6_19_chunk._ts_meta_count
+         ->  Index Only Scan using compress_hyper_6_20_chunk_c_space_index_2 on _timescaledb_internal.compress_hyper_6_20_chunk (actual rows=1 loops=1)
+               Output: compress_hyper_6_20_chunk.device_id, compress_hyper_6_20_chunk._ts_meta_count
                Heap Fetches: 1
    ->  Index Only Scan using _hyper_2_7_chunk_tmp_idx on _timescaledb_internal._hyper_2_7_chunk (actual rows=504 loops=1)
          Output: _hyper_2_7_chunk.device_id
@@ -6142,14 +6142,14 @@ ORDER BY device_id;
    ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_10_chunk (actual rows=504 loops=1)
          Output: _hyper_2_10_chunk.device_id
          Bulk Decompression: false
-         ->  Index Only Scan using compress_hyper_6_20_chunk_c_space_index_2 on _timescaledb_internal.compress_hyper_6_20_chunk (actual rows=1 loops=1)
-               Output: compress_hyper_6_20_chunk.device_id, compress_hyper_6_20_chunk._ts_meta_count
+         ->  Index Only Scan using compress_hyper_6_24_chunk_c_space_index_2 on _timescaledb_internal.compress_hyper_6_24_chunk (actual rows=1 loops=1)
+               Output: compress_hyper_6_24_chunk.device_id, compress_hyper_6_24_chunk._ts_meta_count
                Heap Fetches: 1
    ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_11_chunk (actual rows=1512 loops=1)
          Output: _hyper_2_11_chunk.device_id
          Bulk Decompression: false
-         ->  Index Only Scan using compress_hyper_6_21_chunk_c_space_index_2 on _timescaledb_internal.compress_hyper_6_21_chunk (actual rows=3 loops=1)
-               Output: compress_hyper_6_21_chunk.device_id, compress_hyper_6_21_chunk._ts_meta_count
+         ->  Index Only Scan using compress_hyper_6_25_chunk_c_space_index_2 on _timescaledb_internal.compress_hyper_6_25_chunk (actual rows=3 loops=1)
+               Output: compress_hyper_6_25_chunk.device_id, compress_hyper_6_25_chunk._ts_meta_count
                Heap Fetches: 3
    ->  Index Only Scan using _hyper_2_12_chunk_tmp_idx on _timescaledb_internal._hyper_2_12_chunk (actual rows=504 loops=1)
          Output: _hyper_2_12_chunk.device_id
@@ -6174,21 +6174,21 @@ ORDER BY device_id_peer,
          ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_4_chunk (actual rows=0 loops=1)
                Output: _hyper_2_4_chunk."time", _hyper_2_4_chunk.device_id, _hyper_2_4_chunk.device_id_peer, _hyper_2_4_chunk.v0, _hyper_2_4_chunk.v1, _hyper_2_4_chunk.v2, _hyper_2_4_chunk.v3
                Bulk Decompression: true
-               ->  Index Scan using compress_hyper_6_17_chunk__compressed_hypertable_6_device_id_pe on _timescaledb_internal.compress_hyper_6_17_chunk (actual rows=0 loops=1)
-                     Output: compress_hyper_6_17_chunk."time", compress_hyper_6_17_chunk.device_id, compress_hyper_6_17_chunk.device_id_peer, compress_hyper_6_17_chunk.v0, compress_hyper_6_17_chunk.v1, compress_hyper_6_17_chunk.v2, compress_hyper_6_17_chunk.v3, compress_hyper_6_17_chunk._ts_meta_count, compress_hyper_6_17_chunk._ts_meta_sequence_num, compress_hyper_6_17_chunk._ts_meta_min_3, compress_hyper_6_17_chunk._ts_meta_max_3, compress_hyper_6_17_chunk._ts_meta_min_1, compress_hyper_6_17_chunk._ts_meta_max_1, compress_hyper_6_17_chunk._ts_meta_min_2, compress_hyper_6_17_chunk._ts_meta_max_2
-                     Index Cond: (compress_hyper_6_17_chunk.device_id_peer = 1)
-         ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_5_chunk (actual rows=0 loops=1)
-               Output: _hyper_2_5_chunk."time", _hyper_2_5_chunk.device_id, _hyper_2_5_chunk.device_id_peer, _hyper_2_5_chunk.v0, _hyper_2_5_chunk.v1, _hyper_2_5_chunk.v2, _hyper_2_5_chunk.v3
-               Bulk Decompression: true
                ->  Index Scan using compress_hyper_6_18_chunk__compressed_hypertable_6_device_id_pe on _timescaledb_internal.compress_hyper_6_18_chunk (actual rows=0 loops=1)
                      Output: compress_hyper_6_18_chunk."time", compress_hyper_6_18_chunk.device_id, compress_hyper_6_18_chunk.device_id_peer, compress_hyper_6_18_chunk.v0, compress_hyper_6_18_chunk.v1, compress_hyper_6_18_chunk.v2, compress_hyper_6_18_chunk.v3, compress_hyper_6_18_chunk._ts_meta_count, compress_hyper_6_18_chunk._ts_meta_sequence_num, compress_hyper_6_18_chunk._ts_meta_min_3, compress_hyper_6_18_chunk._ts_meta_max_3, compress_hyper_6_18_chunk._ts_meta_min_1, compress_hyper_6_18_chunk._ts_meta_max_1, compress_hyper_6_18_chunk._ts_meta_min_2, compress_hyper_6_18_chunk._ts_meta_max_2
                      Index Cond: (compress_hyper_6_18_chunk.device_id_peer = 1)
-         ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_6_chunk (actual rows=0 loops=1)
-               Output: _hyper_2_6_chunk."time", _hyper_2_6_chunk.device_id, _hyper_2_6_chunk.device_id_peer, _hyper_2_6_chunk.v0, _hyper_2_6_chunk.v1, _hyper_2_6_chunk.v2, _hyper_2_6_chunk.v3
+         ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_5_chunk (actual rows=0 loops=1)
+               Output: _hyper_2_5_chunk."time", _hyper_2_5_chunk.device_id, _hyper_2_5_chunk.device_id_peer, _hyper_2_5_chunk.v0, _hyper_2_5_chunk.v1, _hyper_2_5_chunk.v2, _hyper_2_5_chunk.v3
                Bulk Decompression: true
                ->  Index Scan using compress_hyper_6_19_chunk__compressed_hypertable_6_device_id_pe on _timescaledb_internal.compress_hyper_6_19_chunk (actual rows=0 loops=1)
                      Output: compress_hyper_6_19_chunk."time", compress_hyper_6_19_chunk.device_id, compress_hyper_6_19_chunk.device_id_peer, compress_hyper_6_19_chunk.v0, compress_hyper_6_19_chunk.v1, compress_hyper_6_19_chunk.v2, compress_hyper_6_19_chunk.v3, compress_hyper_6_19_chunk._ts_meta_count, compress_hyper_6_19_chunk._ts_meta_sequence_num, compress_hyper_6_19_chunk._ts_meta_min_3, compress_hyper_6_19_chunk._ts_meta_max_3, compress_hyper_6_19_chunk._ts_meta_min_1, compress_hyper_6_19_chunk._ts_meta_max_1, compress_hyper_6_19_chunk._ts_meta_min_2, compress_hyper_6_19_chunk._ts_meta_max_2
                      Index Cond: (compress_hyper_6_19_chunk.device_id_peer = 1)
+         ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_6_chunk (actual rows=0 loops=1)
+               Output: _hyper_2_6_chunk."time", _hyper_2_6_chunk.device_id, _hyper_2_6_chunk.device_id_peer, _hyper_2_6_chunk.v0, _hyper_2_6_chunk.v1, _hyper_2_6_chunk.v2, _hyper_2_6_chunk.v3
+               Bulk Decompression: true
+               ->  Index Scan using compress_hyper_6_20_chunk__compressed_hypertable_6_device_id_pe on _timescaledb_internal.compress_hyper_6_20_chunk (actual rows=0 loops=1)
+                     Output: compress_hyper_6_20_chunk."time", compress_hyper_6_20_chunk.device_id, compress_hyper_6_20_chunk.device_id_peer, compress_hyper_6_20_chunk.v0, compress_hyper_6_20_chunk.v1, compress_hyper_6_20_chunk.v2, compress_hyper_6_20_chunk.v3, compress_hyper_6_20_chunk._ts_meta_count, compress_hyper_6_20_chunk._ts_meta_sequence_num, compress_hyper_6_20_chunk._ts_meta_min_3, compress_hyper_6_20_chunk._ts_meta_max_3, compress_hyper_6_20_chunk._ts_meta_min_1, compress_hyper_6_20_chunk._ts_meta_max_1, compress_hyper_6_20_chunk._ts_meta_min_2, compress_hyper_6_20_chunk._ts_meta_max_2
+                     Index Cond: (compress_hyper_6_20_chunk.device_id_peer = 1)
          ->  Index Scan using _hyper_2_7_chunk_metrics_space_device_id_device_id_peer_v0_v1_2 on _timescaledb_internal._hyper_2_7_chunk (actual rows=0 loops=1)
                Output: _hyper_2_7_chunk."time", _hyper_2_7_chunk.device_id, _hyper_2_7_chunk.device_id_peer, _hyper_2_7_chunk.v0, _hyper_2_7_chunk.v1, _hyper_2_7_chunk.v2, _hyper_2_7_chunk.v3
                Index Cond: (_hyper_2_7_chunk.device_id_peer = 1)
@@ -6201,15 +6201,15 @@ ORDER BY device_id_peer,
          ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_10_chunk (actual rows=0 loops=1)
                Output: _hyper_2_10_chunk."time", _hyper_2_10_chunk.device_id, _hyper_2_10_chunk.device_id_peer, _hyper_2_10_chunk.v0, _hyper_2_10_chunk.v1, _hyper_2_10_chunk.v2, _hyper_2_10_chunk.v3
                Bulk Decompression: true
-               ->  Index Scan using compress_hyper_6_20_chunk__compressed_hypertable_6_device_id_pe on _timescaledb_internal.compress_hyper_6_20_chunk (actual rows=0 loops=1)
-                     Output: compress_hyper_6_20_chunk."time", compress_hyper_6_20_chunk.device_id, compress_hyper_6_20_chunk.device_id_peer, compress_hyper_6_20_chunk.v0, compress_hyper_6_20_chunk.v1, compress_hyper_6_20_chunk.v2, compress_hyper_6_20_chunk.v3, compress_hyper_6_20_chunk._ts_meta_count, compress_hyper_6_20_chunk._ts_meta_sequence_num, compress_hyper_6_20_chunk._ts_meta_min_3, compress_hyper_6_20_chunk._ts_meta_max_3, compress_hyper_6_20_chunk._ts_meta_min_1, compress_hyper_6_20_chunk._ts_meta_max_1, compress_hyper_6_20_chunk._ts_meta_min_2, compress_hyper_6_20_chunk._ts_meta_max_2
-                     Index Cond: (compress_hyper_6_20_chunk.device_id_peer = 1)
+               ->  Index Scan using compress_hyper_6_24_chunk__compressed_hypertable_6_device_id_pe on _timescaledb_internal.compress_hyper_6_24_chunk (actual rows=0 loops=1)
+                     Output: compress_hyper_6_24_chunk."time", compress_hyper_6_24_chunk.device_id, compress_hyper_6_24_chunk.device_id_peer, compress_hyper_6_24_chunk.v0, compress_hyper_6_24_chunk.v1, compress_hyper_6_24_chunk.v2, compress_hyper_6_24_chunk.v3, compress_hyper_6_24_chunk._ts_meta_count, compress_hyper_6_24_chunk._ts_meta_sequence_num, compress_hyper_6_24_chunk._ts_meta_min_3, compress_hyper_6_24_chunk._ts_meta_max_3, compress_hyper_6_24_chunk._ts_meta_min_1, compress_hyper_6_24_chunk._ts_meta_max_1, compress_hyper_6_24_chunk._ts_meta_min_2, compress_hyper_6_24_chunk._ts_meta_max_2
+                     Index Cond: (compress_hyper_6_24_chunk.device_id_peer = 1)
          ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_11_chunk (actual rows=0 loops=1)
                Output: _hyper_2_11_chunk."time", _hyper_2_11_chunk.device_id, _hyper_2_11_chunk.device_id_peer, _hyper_2_11_chunk.v0, _hyper_2_11_chunk.v1, _hyper_2_11_chunk.v2, _hyper_2_11_chunk.v3
                Bulk Decompression: true
-               ->  Index Scan using compress_hyper_6_21_chunk__compressed_hypertable_6_device_id_pe on _timescaledb_internal.compress_hyper_6_21_chunk (actual rows=0 loops=1)
-                     Output: compress_hyper_6_21_chunk."time", compress_hyper_6_21_chunk.device_id, compress_hyper_6_21_chunk.device_id_peer, compress_hyper_6_21_chunk.v0, compress_hyper_6_21_chunk.v1, compress_hyper_6_21_chunk.v2, compress_hyper_6_21_chunk.v3, compress_hyper_6_21_chunk._ts_meta_count, compress_hyper_6_21_chunk._ts_meta_sequence_num, compress_hyper_6_21_chunk._ts_meta_min_3, compress_hyper_6_21_chunk._ts_meta_max_3, compress_hyper_6_21_chunk._ts_meta_min_1, compress_hyper_6_21_chunk._ts_meta_max_1, compress_hyper_6_21_chunk._ts_meta_min_2, compress_hyper_6_21_chunk._ts_meta_max_2
-                     Index Cond: (compress_hyper_6_21_chunk.device_id_peer = 1)
+               ->  Index Scan using compress_hyper_6_25_chunk__compressed_hypertable_6_device_id_pe on _timescaledb_internal.compress_hyper_6_25_chunk (actual rows=0 loops=1)
+                     Output: compress_hyper_6_25_chunk."time", compress_hyper_6_25_chunk.device_id, compress_hyper_6_25_chunk.device_id_peer, compress_hyper_6_25_chunk.v0, compress_hyper_6_25_chunk.v1, compress_hyper_6_25_chunk.v2, compress_hyper_6_25_chunk.v3, compress_hyper_6_25_chunk._ts_meta_count, compress_hyper_6_25_chunk._ts_meta_sequence_num, compress_hyper_6_25_chunk._ts_meta_min_3, compress_hyper_6_25_chunk._ts_meta_max_3, compress_hyper_6_25_chunk._ts_meta_min_1, compress_hyper_6_25_chunk._ts_meta_max_1, compress_hyper_6_25_chunk._ts_meta_min_2, compress_hyper_6_25_chunk._ts_meta_max_2
+                     Index Cond: (compress_hyper_6_25_chunk.device_id_peer = 1)
          ->  Index Scan using _hyper_2_12_chunk_metrics_space_device_id_device_id_peer_v0_v_2 on _timescaledb_internal._hyper_2_12_chunk (actual rows=0 loops=1)
                Output: _hyper_2_12_chunk."time", _hyper_2_12_chunk.device_id, _hyper_2_12_chunk.device_id_peer, _hyper_2_12_chunk.v0, _hyper_2_12_chunk.v1, _hyper_2_12_chunk.v2, _hyper_2_12_chunk.v3
                Index Cond: (_hyper_2_12_chunk.device_id_peer = 1)
@@ -6226,21 +6226,21 @@ ORDER BY device_id_peer;
    ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_4_chunk (actual rows=0 loops=1)
          Output: _hyper_2_4_chunk.device_id_peer
          Bulk Decompression: false
-         ->  Index Scan using compress_hyper_6_17_chunk__compressed_hypertable_6_device_id_pe on _timescaledb_internal.compress_hyper_6_17_chunk (actual rows=0 loops=1)
-               Output: compress_hyper_6_17_chunk."time", compress_hyper_6_17_chunk.device_id, compress_hyper_6_17_chunk.device_id_peer, compress_hyper_6_17_chunk.v0, compress_hyper_6_17_chunk.v1, compress_hyper_6_17_chunk.v2, compress_hyper_6_17_chunk.v3, compress_hyper_6_17_chunk._ts_meta_count, compress_hyper_6_17_chunk._ts_meta_sequence_num, compress_hyper_6_17_chunk._ts_meta_min_3, compress_hyper_6_17_chunk._ts_meta_max_3, compress_hyper_6_17_chunk._ts_meta_min_1, compress_hyper_6_17_chunk._ts_meta_max_1, compress_hyper_6_17_chunk._ts_meta_min_2, compress_hyper_6_17_chunk._ts_meta_max_2
-               Index Cond: (compress_hyper_6_17_chunk.device_id_peer = 1)
-   ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_5_chunk (actual rows=0 loops=1)
-         Output: _hyper_2_5_chunk.device_id_peer
-         Bulk Decompression: false
          ->  Index Scan using compress_hyper_6_18_chunk__compressed_hypertable_6_device_id_pe on _timescaledb_internal.compress_hyper_6_18_chunk (actual rows=0 loops=1)
                Output: compress_hyper_6_18_chunk."time", compress_hyper_6_18_chunk.device_id, compress_hyper_6_18_chunk.device_id_peer, compress_hyper_6_18_chunk.v0, compress_hyper_6_18_chunk.v1, compress_hyper_6_18_chunk.v2, compress_hyper_6_18_chunk.v3, compress_hyper_6_18_chunk._ts_meta_count, compress_hyper_6_18_chunk._ts_meta_sequence_num, compress_hyper_6_18_chunk._ts_meta_min_3, compress_hyper_6_18_chunk._ts_meta_max_3, compress_hyper_6_18_chunk._ts_meta_min_1, compress_hyper_6_18_chunk._ts_meta_max_1, compress_hyper_6_18_chunk._ts_meta_min_2, compress_hyper_6_18_chunk._ts_meta_max_2
                Index Cond: (compress_hyper_6_18_chunk.device_id_peer = 1)
-   ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_6_chunk (actual rows=0 loops=1)
-         Output: _hyper_2_6_chunk.device_id_peer
+   ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_5_chunk (actual rows=0 loops=1)
+         Output: _hyper_2_5_chunk.device_id_peer
          Bulk Decompression: false
          ->  Index Scan using compress_hyper_6_19_chunk__compressed_hypertable_6_device_id_pe on _timescaledb_internal.compress_hyper_6_19_chunk (actual rows=0 loops=1)
                Output: compress_hyper_6_19_chunk."time", compress_hyper_6_19_chunk.device_id, compress_hyper_6_19_chunk.device_id_peer, compress_hyper_6_19_chunk.v0, compress_hyper_6_19_chunk.v1, compress_hyper_6_19_chunk.v2, compress_hyper_6_19_chunk.v3, compress_hyper_6_19_chunk._ts_meta_count, compress_hyper_6_19_chunk._ts_meta_sequence_num, compress_hyper_6_19_chunk._ts_meta_min_3, compress_hyper_6_19_chunk._ts_meta_max_3, compress_hyper_6_19_chunk._ts_meta_min_1, compress_hyper_6_19_chunk._ts_meta_max_1, compress_hyper_6_19_chunk._ts_meta_min_2, compress_hyper_6_19_chunk._ts_meta_max_2
                Index Cond: (compress_hyper_6_19_chunk.device_id_peer = 1)
+   ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_6_chunk (actual rows=0 loops=1)
+         Output: _hyper_2_6_chunk.device_id_peer
+         Bulk Decompression: false
+         ->  Index Scan using compress_hyper_6_20_chunk__compressed_hypertable_6_device_id_pe on _timescaledb_internal.compress_hyper_6_20_chunk (actual rows=0 loops=1)
+               Output: compress_hyper_6_20_chunk."time", compress_hyper_6_20_chunk.device_id, compress_hyper_6_20_chunk.device_id_peer, compress_hyper_6_20_chunk.v0, compress_hyper_6_20_chunk.v1, compress_hyper_6_20_chunk.v2, compress_hyper_6_20_chunk.v3, compress_hyper_6_20_chunk._ts_meta_count, compress_hyper_6_20_chunk._ts_meta_sequence_num, compress_hyper_6_20_chunk._ts_meta_min_3, compress_hyper_6_20_chunk._ts_meta_max_3, compress_hyper_6_20_chunk._ts_meta_min_1, compress_hyper_6_20_chunk._ts_meta_max_1, compress_hyper_6_20_chunk._ts_meta_min_2, compress_hyper_6_20_chunk._ts_meta_max_2
+               Index Cond: (compress_hyper_6_20_chunk.device_id_peer = 1)
    ->  Index Only Scan using _hyper_2_7_chunk_metrics_space_device_id_device_id_peer_v0_v1_2 on _timescaledb_internal._hyper_2_7_chunk (actual rows=0 loops=1)
          Output: _hyper_2_7_chunk.device_id_peer
          Index Cond: (_hyper_2_7_chunk.device_id_peer = 1)
@@ -6256,15 +6256,15 @@ ORDER BY device_id_peer;
    ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_10_chunk (actual rows=0 loops=1)
          Output: _hyper_2_10_chunk.device_id_peer
          Bulk Decompression: false
-         ->  Index Scan using compress_hyper_6_20_chunk__compressed_hypertable_6_device_id_pe on _timescaledb_internal.compress_hyper_6_20_chunk (actual rows=0 loops=1)
-               Output: compress_hyper_6_20_chunk."time", compress_hyper_6_20_chunk.device_id, compress_hyper_6_20_chunk.device_id_peer, compress_hyper_6_20_chunk.v0, compress_hyper_6_20_chunk.v1, compress_hyper_6_20_chunk.v2, compress_hyper_6_20_chunk.v3, compress_hyper_6_20_chunk._ts_meta_count, compress_hyper_6_20_chunk._ts_meta_sequence_num, compress_hyper_6_20_chunk._ts_meta_min_3, compress_hyper_6_20_chunk._ts_meta_max_3, compress_hyper_6_20_chunk._ts_meta_min_1, compress_hyper_6_20_chunk._ts_meta_max_1, compress_hyper_6_20_chunk._ts_meta_min_2, compress_hyper_6_20_chunk._ts_meta_max_2
-               Index Cond: (compress_hyper_6_20_chunk.device_id_peer = 1)
+         ->  Index Scan using compress_hyper_6_24_chunk__compressed_hypertable_6_device_id_pe on _timescaledb_internal.compress_hyper_6_24_chunk (actual rows=0 loops=1)
+               Output: compress_hyper_6_24_chunk."time", compress_hyper_6_24_chunk.device_id, compress_hyper_6_24_chunk.device_id_peer, compress_hyper_6_24_chunk.v0, compress_hyper_6_24_chunk.v1, compress_hyper_6_24_chunk.v2, compress_hyper_6_24_chunk.v3, compress_hyper_6_24_chunk._ts_meta_count, compress_hyper_6_24_chunk._ts_meta_sequence_num, compress_hyper_6_24_chunk._ts_meta_min_3, compress_hyper_6_24_chunk._ts_meta_max_3, compress_hyper_6_24_chunk._ts_meta_min_1, compress_hyper_6_24_chunk._ts_meta_max_1, compress_hyper_6_24_chunk._ts_meta_min_2, compress_hyper_6_24_chunk._ts_meta_max_2
+               Index Cond: (compress_hyper_6_24_chunk.device_id_peer = 1)
    ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_11_chunk (actual rows=0 loops=1)
          Output: _hyper_2_11_chunk.device_id_peer
          Bulk Decompression: false
-         ->  Index Scan using compress_hyper_6_21_chunk__compressed_hypertable_6_device_id_pe on _timescaledb_internal.compress_hyper_6_21_chunk (actual rows=0 loops=1)
-               Output: compress_hyper_6_21_chunk."time", compress_hyper_6_21_chunk.device_id, compress_hyper_6_21_chunk.device_id_peer, compress_hyper_6_21_chunk.v0, compress_hyper_6_21_chunk.v1, compress_hyper_6_21_chunk.v2, compress_hyper_6_21_chunk.v3, compress_hyper_6_21_chunk._ts_meta_count, compress_hyper_6_21_chunk._ts_meta_sequence_num, compress_hyper_6_21_chunk._ts_meta_min_3, compress_hyper_6_21_chunk._ts_meta_max_3, compress_hyper_6_21_chunk._ts_meta_min_1, compress_hyper_6_21_chunk._ts_meta_max_1, compress_hyper_6_21_chunk._ts_meta_min_2, compress_hyper_6_21_chunk._ts_meta_max_2
-               Index Cond: (compress_hyper_6_21_chunk.device_id_peer = 1)
+         ->  Index Scan using compress_hyper_6_25_chunk__compressed_hypertable_6_device_id_pe on _timescaledb_internal.compress_hyper_6_25_chunk (actual rows=0 loops=1)
+               Output: compress_hyper_6_25_chunk."time", compress_hyper_6_25_chunk.device_id, compress_hyper_6_25_chunk.device_id_peer, compress_hyper_6_25_chunk.v0, compress_hyper_6_25_chunk.v1, compress_hyper_6_25_chunk.v2, compress_hyper_6_25_chunk.v3, compress_hyper_6_25_chunk._ts_meta_count, compress_hyper_6_25_chunk._ts_meta_sequence_num, compress_hyper_6_25_chunk._ts_meta_min_3, compress_hyper_6_25_chunk._ts_meta_max_3, compress_hyper_6_25_chunk._ts_meta_min_1, compress_hyper_6_25_chunk._ts_meta_max_1, compress_hyper_6_25_chunk._ts_meta_min_2, compress_hyper_6_25_chunk._ts_meta_max_2
+               Index Cond: (compress_hyper_6_25_chunk.device_id_peer = 1)
    ->  Index Only Scan using _hyper_2_12_chunk_metrics_space_device_id_device_id_peer_v0_v_2 on _timescaledb_internal._hyper_2_12_chunk (actual rows=0 loops=1)
          Output: _hyper_2_12_chunk.device_id_peer
          Index Cond: (_hyper_2_12_chunk.device_id_peer = 1)
@@ -6285,23 +6285,23 @@ WHERE device_id_peer IN (
    ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_4_chunk (actual rows=0 loops=1)
          Output: _hyper_2_4_chunk.device_id_peer
          Bulk Decompression: false
-         ->  Seq Scan on _timescaledb_internal.compress_hyper_6_17_chunk (actual rows=0 loops=1)
-               Output: compress_hyper_6_17_chunk."time", compress_hyper_6_17_chunk.device_id, compress_hyper_6_17_chunk.device_id_peer, compress_hyper_6_17_chunk.v0, compress_hyper_6_17_chunk.v1, compress_hyper_6_17_chunk.v2, compress_hyper_6_17_chunk.v3, compress_hyper_6_17_chunk._ts_meta_count, compress_hyper_6_17_chunk._ts_meta_sequence_num, compress_hyper_6_17_chunk._ts_meta_min_3, compress_hyper_6_17_chunk._ts_meta_max_3, compress_hyper_6_17_chunk._ts_meta_min_1, compress_hyper_6_17_chunk._ts_meta_max_1, compress_hyper_6_17_chunk._ts_meta_min_2, compress_hyper_6_17_chunk._ts_meta_max_2
-               Filter: (compress_hyper_6_17_chunk.device_id_peer = 1)
+         ->  Seq Scan on _timescaledb_internal.compress_hyper_6_18_chunk (actual rows=0 loops=1)
+               Output: compress_hyper_6_18_chunk."time", compress_hyper_6_18_chunk.device_id, compress_hyper_6_18_chunk.device_id_peer, compress_hyper_6_18_chunk.v0, compress_hyper_6_18_chunk.v1, compress_hyper_6_18_chunk.v2, compress_hyper_6_18_chunk.v3, compress_hyper_6_18_chunk._ts_meta_count, compress_hyper_6_18_chunk._ts_meta_sequence_num, compress_hyper_6_18_chunk._ts_meta_min_3, compress_hyper_6_18_chunk._ts_meta_max_3, compress_hyper_6_18_chunk._ts_meta_min_1, compress_hyper_6_18_chunk._ts_meta_max_1, compress_hyper_6_18_chunk._ts_meta_min_2, compress_hyper_6_18_chunk._ts_meta_max_2
+               Filter: (compress_hyper_6_18_chunk.device_id_peer = 1)
                Rows Removed by Filter: 1
    ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_5_chunk (actual rows=0 loops=1)
          Output: _hyper_2_5_chunk.device_id_peer
          Bulk Decompression: false
-         ->  Seq Scan on _timescaledb_internal.compress_hyper_6_18_chunk (actual rows=0 loops=1)
-               Output: compress_hyper_6_18_chunk."time", compress_hyper_6_18_chunk.device_id, compress_hyper_6_18_chunk.device_id_peer, compress_hyper_6_18_chunk.v0, compress_hyper_6_18_chunk.v1, compress_hyper_6_18_chunk.v2, compress_hyper_6_18_chunk.v3, compress_hyper_6_18_chunk._ts_meta_count, compress_hyper_6_18_chunk._ts_meta_sequence_num, compress_hyper_6_18_chunk._ts_meta_min_3, compress_hyper_6_18_chunk._ts_meta_max_3, compress_hyper_6_18_chunk._ts_meta_min_1, compress_hyper_6_18_chunk._ts_meta_max_1, compress_hyper_6_18_chunk._ts_meta_min_2, compress_hyper_6_18_chunk._ts_meta_max_2
-               Filter: (compress_hyper_6_18_chunk.device_id_peer = 1)
+         ->  Seq Scan on _timescaledb_internal.compress_hyper_6_19_chunk (actual rows=0 loops=1)
+               Output: compress_hyper_6_19_chunk."time", compress_hyper_6_19_chunk.device_id, compress_hyper_6_19_chunk.device_id_peer, compress_hyper_6_19_chunk.v0, compress_hyper_6_19_chunk.v1, compress_hyper_6_19_chunk.v2, compress_hyper_6_19_chunk.v3, compress_hyper_6_19_chunk._ts_meta_count, compress_hyper_6_19_chunk._ts_meta_sequence_num, compress_hyper_6_19_chunk._ts_meta_min_3, compress_hyper_6_19_chunk._ts_meta_max_3, compress_hyper_6_19_chunk._ts_meta_min_1, compress_hyper_6_19_chunk._ts_meta_max_1, compress_hyper_6_19_chunk._ts_meta_min_2, compress_hyper_6_19_chunk._ts_meta_max_2
+               Filter: (compress_hyper_6_19_chunk.device_id_peer = 1)
                Rows Removed by Filter: 3
    ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_6_chunk (actual rows=0 loops=1)
          Output: _hyper_2_6_chunk.device_id_peer
          Bulk Decompression: false
-         ->  Seq Scan on _timescaledb_internal.compress_hyper_6_19_chunk (actual rows=0 loops=1)
-               Output: compress_hyper_6_19_chunk."time", compress_hyper_6_19_chunk.device_id, compress_hyper_6_19_chunk.device_id_peer, compress_hyper_6_19_chunk.v0, compress_hyper_6_19_chunk.v1, compress_hyper_6_19_chunk.v2, compress_hyper_6_19_chunk.v3, compress_hyper_6_19_chunk._ts_meta_count, compress_hyper_6_19_chunk._ts_meta_sequence_num, compress_hyper_6_19_chunk._ts_meta_min_3, compress_hyper_6_19_chunk._ts_meta_max_3, compress_hyper_6_19_chunk._ts_meta_min_1, compress_hyper_6_19_chunk._ts_meta_max_1, compress_hyper_6_19_chunk._ts_meta_min_2, compress_hyper_6_19_chunk._ts_meta_max_2
-               Filter: (compress_hyper_6_19_chunk.device_id_peer = 1)
+         ->  Seq Scan on _timescaledb_internal.compress_hyper_6_20_chunk (actual rows=0 loops=1)
+               Output: compress_hyper_6_20_chunk."time", compress_hyper_6_20_chunk.device_id, compress_hyper_6_20_chunk.device_id_peer, compress_hyper_6_20_chunk.v0, compress_hyper_6_20_chunk.v1, compress_hyper_6_20_chunk.v2, compress_hyper_6_20_chunk.v3, compress_hyper_6_20_chunk._ts_meta_count, compress_hyper_6_20_chunk._ts_meta_sequence_num, compress_hyper_6_20_chunk._ts_meta_min_3, compress_hyper_6_20_chunk._ts_meta_max_3, compress_hyper_6_20_chunk._ts_meta_min_1, compress_hyper_6_20_chunk._ts_meta_max_1, compress_hyper_6_20_chunk._ts_meta_min_2, compress_hyper_6_20_chunk._ts_meta_max_2
+               Filter: (compress_hyper_6_20_chunk.device_id_peer = 1)
                Rows Removed by Filter: 1
    ->  Index Only Scan using _hyper_2_7_chunk_metrics_space_device_id_device_id_peer_v0_v1_2 on _timescaledb_internal._hyper_2_7_chunk (actual rows=0 loops=1)
          Output: _hyper_2_7_chunk.device_id_peer
@@ -6318,16 +6318,16 @@ WHERE device_id_peer IN (
    ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_10_chunk (actual rows=0 loops=1)
          Output: _hyper_2_10_chunk.device_id_peer
          Bulk Decompression: false
-         ->  Seq Scan on _timescaledb_internal.compress_hyper_6_20_chunk (actual rows=0 loops=1)
-               Output: compress_hyper_6_20_chunk."time", compress_hyper_6_20_chunk.device_id, compress_hyper_6_20_chunk.device_id_peer, compress_hyper_6_20_chunk.v0, compress_hyper_6_20_chunk.v1, compress_hyper_6_20_chunk.v2, compress_hyper_6_20_chunk.v3, compress_hyper_6_20_chunk._ts_meta_count, compress_hyper_6_20_chunk._ts_meta_sequence_num, compress_hyper_6_20_chunk._ts_meta_min_3, compress_hyper_6_20_chunk._ts_meta_max_3, compress_hyper_6_20_chunk._ts_meta_min_1, compress_hyper_6_20_chunk._ts_meta_max_1, compress_hyper_6_20_chunk._ts_meta_min_2, compress_hyper_6_20_chunk._ts_meta_max_2
-               Filter: (compress_hyper_6_20_chunk.device_id_peer = 1)
+         ->  Seq Scan on _timescaledb_internal.compress_hyper_6_24_chunk (actual rows=0 loops=1)
+               Output: compress_hyper_6_24_chunk."time", compress_hyper_6_24_chunk.device_id, compress_hyper_6_24_chunk.device_id_peer, compress_hyper_6_24_chunk.v0, compress_hyper_6_24_chunk.v1, compress_hyper_6_24_chunk.v2, compress_hyper_6_24_chunk.v3, compress_hyper_6_24_chunk._ts_meta_count, compress_hyper_6_24_chunk._ts_meta_sequence_num, compress_hyper_6_24_chunk._ts_meta_min_3, compress_hyper_6_24_chunk._ts_meta_max_3, compress_hyper_6_24_chunk._ts_meta_min_1, compress_hyper_6_24_chunk._ts_meta_max_1, compress_hyper_6_24_chunk._ts_meta_min_2, compress_hyper_6_24_chunk._ts_meta_max_2
+               Filter: (compress_hyper_6_24_chunk.device_id_peer = 1)
                Rows Removed by Filter: 1
    ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_11_chunk (actual rows=0 loops=1)
          Output: _hyper_2_11_chunk.device_id_peer
          Bulk Decompression: false
-         ->  Seq Scan on _timescaledb_internal.compress_hyper_6_21_chunk (actual rows=0 loops=1)
-               Output: compress_hyper_6_21_chunk."time", compress_hyper_6_21_chunk.device_id, compress_hyper_6_21_chunk.device_id_peer, compress_hyper_6_21_chunk.v0, compress_hyper_6_21_chunk.v1, compress_hyper_6_21_chunk.v2, compress_hyper_6_21_chunk.v3, compress_hyper_6_21_chunk._ts_meta_count, compress_hyper_6_21_chunk._ts_meta_sequence_num, compress_hyper_6_21_chunk._ts_meta_min_3, compress_hyper_6_21_chunk._ts_meta_max_3, compress_hyper_6_21_chunk._ts_meta_min_1, compress_hyper_6_21_chunk._ts_meta_max_1, compress_hyper_6_21_chunk._ts_meta_min_2, compress_hyper_6_21_chunk._ts_meta_max_2
-               Filter: (compress_hyper_6_21_chunk.device_id_peer = 1)
+         ->  Seq Scan on _timescaledb_internal.compress_hyper_6_25_chunk (actual rows=0 loops=1)
+               Output: compress_hyper_6_25_chunk."time", compress_hyper_6_25_chunk.device_id, compress_hyper_6_25_chunk.device_id_peer, compress_hyper_6_25_chunk.v0, compress_hyper_6_25_chunk.v1, compress_hyper_6_25_chunk.v2, compress_hyper_6_25_chunk.v3, compress_hyper_6_25_chunk._ts_meta_count, compress_hyper_6_25_chunk._ts_meta_sequence_num, compress_hyper_6_25_chunk._ts_meta_min_3, compress_hyper_6_25_chunk._ts_meta_max_3, compress_hyper_6_25_chunk._ts_meta_min_1, compress_hyper_6_25_chunk._ts_meta_max_1, compress_hyper_6_25_chunk._ts_meta_min_2, compress_hyper_6_25_chunk._ts_meta_max_2
+               Filter: (compress_hyper_6_25_chunk.device_id_peer = 1)
                Rows Removed by Filter: 3
    ->  Index Only Scan using _hyper_2_12_chunk_metrics_space_device_id_device_id_peer_v0_v_2 on _timescaledb_internal._hyper_2_12_chunk (actual rows=0 loops=1)
          Output: _hyper_2_12_chunk.device_id_peer
@@ -6352,18 +6352,18 @@ WHERE device_id_peer IN (
          ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_4_chunk (actual rows=360 loops=1)
                Output: _hyper_2_4_chunk.device_id_peer
                Bulk Decompression: false
-               ->  Seq Scan on _timescaledb_internal.compress_hyper_6_17_chunk (actual rows=1 loops=1)
-                     Output: compress_hyper_6_17_chunk."time", compress_hyper_6_17_chunk.device_id, compress_hyper_6_17_chunk.device_id_peer, compress_hyper_6_17_chunk.v0, compress_hyper_6_17_chunk.v1, compress_hyper_6_17_chunk.v2, compress_hyper_6_17_chunk.v3, compress_hyper_6_17_chunk._ts_meta_count, compress_hyper_6_17_chunk._ts_meta_sequence_num, compress_hyper_6_17_chunk._ts_meta_min_3, compress_hyper_6_17_chunk._ts_meta_max_3, compress_hyper_6_17_chunk._ts_meta_min_1, compress_hyper_6_17_chunk._ts_meta_max_1, compress_hyper_6_17_chunk._ts_meta_min_2, compress_hyper_6_17_chunk._ts_meta_max_2
+               ->  Seq Scan on _timescaledb_internal.compress_hyper_6_18_chunk (actual rows=1 loops=1)
+                     Output: compress_hyper_6_18_chunk."time", compress_hyper_6_18_chunk.device_id, compress_hyper_6_18_chunk.device_id_peer, compress_hyper_6_18_chunk.v0, compress_hyper_6_18_chunk.v1, compress_hyper_6_18_chunk.v2, compress_hyper_6_18_chunk.v3, compress_hyper_6_18_chunk._ts_meta_count, compress_hyper_6_18_chunk._ts_meta_sequence_num, compress_hyper_6_18_chunk._ts_meta_min_3, compress_hyper_6_18_chunk._ts_meta_max_3, compress_hyper_6_18_chunk._ts_meta_min_1, compress_hyper_6_18_chunk._ts_meta_max_1, compress_hyper_6_18_chunk._ts_meta_min_2, compress_hyper_6_18_chunk._ts_meta_max_2
          ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_5_chunk (actual rows=1080 loops=1)
                Output: _hyper_2_5_chunk.device_id_peer
                Bulk Decompression: false
-               ->  Seq Scan on _timescaledb_internal.compress_hyper_6_18_chunk (actual rows=3 loops=1)
-                     Output: compress_hyper_6_18_chunk."time", compress_hyper_6_18_chunk.device_id, compress_hyper_6_18_chunk.device_id_peer, compress_hyper_6_18_chunk.v0, compress_hyper_6_18_chunk.v1, compress_hyper_6_18_chunk.v2, compress_hyper_6_18_chunk.v3, compress_hyper_6_18_chunk._ts_meta_count, compress_hyper_6_18_chunk._ts_meta_sequence_num, compress_hyper_6_18_chunk._ts_meta_min_3, compress_hyper_6_18_chunk._ts_meta_max_3, compress_hyper_6_18_chunk._ts_meta_min_1, compress_hyper_6_18_chunk._ts_meta_max_1, compress_hyper_6_18_chunk._ts_meta_min_2, compress_hyper_6_18_chunk._ts_meta_max_2
+               ->  Seq Scan on _timescaledb_internal.compress_hyper_6_19_chunk (actual rows=3 loops=1)
+                     Output: compress_hyper_6_19_chunk."time", compress_hyper_6_19_chunk.device_id, compress_hyper_6_19_chunk.device_id_peer, compress_hyper_6_19_chunk.v0, compress_hyper_6_19_chunk.v1, compress_hyper_6_19_chunk.v2, compress_hyper_6_19_chunk.v3, compress_hyper_6_19_chunk._ts_meta_count, compress_hyper_6_19_chunk._ts_meta_sequence_num, compress_hyper_6_19_chunk._ts_meta_min_3, compress_hyper_6_19_chunk._ts_meta_max_3, compress_hyper_6_19_chunk._ts_meta_min_1, compress_hyper_6_19_chunk._ts_meta_max_1, compress_hyper_6_19_chunk._ts_meta_min_2, compress_hyper_6_19_chunk._ts_meta_max_2
          ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_6_chunk (actual rows=360 loops=1)
                Output: _hyper_2_6_chunk.device_id_peer
                Bulk Decompression: false
-               ->  Seq Scan on _timescaledb_internal.compress_hyper_6_19_chunk (actual rows=1 loops=1)
-                     Output: compress_hyper_6_19_chunk."time", compress_hyper_6_19_chunk.device_id, compress_hyper_6_19_chunk.device_id_peer, compress_hyper_6_19_chunk.v0, compress_hyper_6_19_chunk.v1, compress_hyper_6_19_chunk.v2, compress_hyper_6_19_chunk.v3, compress_hyper_6_19_chunk._ts_meta_count, compress_hyper_6_19_chunk._ts_meta_sequence_num, compress_hyper_6_19_chunk._ts_meta_min_3, compress_hyper_6_19_chunk._ts_meta_max_3, compress_hyper_6_19_chunk._ts_meta_min_1, compress_hyper_6_19_chunk._ts_meta_max_1, compress_hyper_6_19_chunk._ts_meta_min_2, compress_hyper_6_19_chunk._ts_meta_max_2
+               ->  Seq Scan on _timescaledb_internal.compress_hyper_6_20_chunk (actual rows=1 loops=1)
+                     Output: compress_hyper_6_20_chunk."time", compress_hyper_6_20_chunk.device_id, compress_hyper_6_20_chunk.device_id_peer, compress_hyper_6_20_chunk.v0, compress_hyper_6_20_chunk.v1, compress_hyper_6_20_chunk.v2, compress_hyper_6_20_chunk.v3, compress_hyper_6_20_chunk._ts_meta_count, compress_hyper_6_20_chunk._ts_meta_sequence_num, compress_hyper_6_20_chunk._ts_meta_min_3, compress_hyper_6_20_chunk._ts_meta_max_3, compress_hyper_6_20_chunk._ts_meta_min_1, compress_hyper_6_20_chunk._ts_meta_max_1, compress_hyper_6_20_chunk._ts_meta_min_2, compress_hyper_6_20_chunk._ts_meta_max_2
          ->  Seq Scan on _timescaledb_internal._hyper_2_7_chunk (actual rows=504 loops=1)
                Output: _hyper_2_7_chunk.device_id_peer
          ->  Seq Scan on _timescaledb_internal._hyper_2_8_chunk (actual rows=1512 loops=1)
@@ -6373,13 +6373,13 @@ WHERE device_id_peer IN (
          ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_10_chunk (actual rows=504 loops=1)
                Output: _hyper_2_10_chunk.device_id_peer
                Bulk Decompression: false
-               ->  Seq Scan on _timescaledb_internal.compress_hyper_6_20_chunk (actual rows=1 loops=1)
-                     Output: compress_hyper_6_20_chunk."time", compress_hyper_6_20_chunk.device_id, compress_hyper_6_20_chunk.device_id_peer, compress_hyper_6_20_chunk.v0, compress_hyper_6_20_chunk.v1, compress_hyper_6_20_chunk.v2, compress_hyper_6_20_chunk.v3, compress_hyper_6_20_chunk._ts_meta_count, compress_hyper_6_20_chunk._ts_meta_sequence_num, compress_hyper_6_20_chunk._ts_meta_min_3, compress_hyper_6_20_chunk._ts_meta_max_3, compress_hyper_6_20_chunk._ts_meta_min_1, compress_hyper_6_20_chunk._ts_meta_max_1, compress_hyper_6_20_chunk._ts_meta_min_2, compress_hyper_6_20_chunk._ts_meta_max_2
+               ->  Seq Scan on _timescaledb_internal.compress_hyper_6_24_chunk (actual rows=1 loops=1)
+                     Output: compress_hyper_6_24_chunk."time", compress_hyper_6_24_chunk.device_id, compress_hyper_6_24_chunk.device_id_peer, compress_hyper_6_24_chunk.v0, compress_hyper_6_24_chunk.v1, compress_hyper_6_24_chunk.v2, compress_hyper_6_24_chunk.v3, compress_hyper_6_24_chunk._ts_meta_count, compress_hyper_6_24_chunk._ts_meta_sequence_num, compress_hyper_6_24_chunk._ts_meta_min_3, compress_hyper_6_24_chunk._ts_meta_max_3, compress_hyper_6_24_chunk._ts_meta_min_1, compress_hyper_6_24_chunk._ts_meta_max_1, compress_hyper_6_24_chunk._ts_meta_min_2, compress_hyper_6_24_chunk._ts_meta_max_2
          ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_11_chunk (actual rows=1512 loops=1)
                Output: _hyper_2_11_chunk.device_id_peer
                Bulk Decompression: false
-               ->  Seq Scan on _timescaledb_internal.compress_hyper_6_21_chunk (actual rows=3 loops=1)
-                     Output: compress_hyper_6_21_chunk."time", compress_hyper_6_21_chunk.device_id, compress_hyper_6_21_chunk.device_id_peer, compress_hyper_6_21_chunk.v0, compress_hyper_6_21_chunk.v1, compress_hyper_6_21_chunk.v2, compress_hyper_6_21_chunk.v3, compress_hyper_6_21_chunk._ts_meta_count, compress_hyper_6_21_chunk._ts_meta_sequence_num, compress_hyper_6_21_chunk._ts_meta_min_3, compress_hyper_6_21_chunk._ts_meta_max_3, compress_hyper_6_21_chunk._ts_meta_min_1, compress_hyper_6_21_chunk._ts_meta_max_1, compress_hyper_6_21_chunk._ts_meta_min_2, compress_hyper_6_21_chunk._ts_meta_max_2
+               ->  Seq Scan on _timescaledb_internal.compress_hyper_6_25_chunk (actual rows=3 loops=1)
+                     Output: compress_hyper_6_25_chunk."time", compress_hyper_6_25_chunk.device_id, compress_hyper_6_25_chunk.device_id_peer, compress_hyper_6_25_chunk.v0, compress_hyper_6_25_chunk.v1, compress_hyper_6_25_chunk.v2, compress_hyper_6_25_chunk.v3, compress_hyper_6_25_chunk._ts_meta_count, compress_hyper_6_25_chunk._ts_meta_sequence_num, compress_hyper_6_25_chunk._ts_meta_min_3, compress_hyper_6_25_chunk._ts_meta_max_3, compress_hyper_6_25_chunk._ts_meta_min_1, compress_hyper_6_25_chunk._ts_meta_max_1, compress_hyper_6_25_chunk._ts_meta_min_2, compress_hyper_6_25_chunk._ts_meta_max_2
          ->  Seq Scan on _timescaledb_internal._hyper_2_12_chunk (actual rows=504 loops=1)
                Output: _hyper_2_12_chunk.device_id_peer
    ->  Materialize (actual rows=2 loops=6840)
@@ -6400,18 +6400,18 @@ WHERE device_id IN (
    ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_4_chunk (actual rows=360 loops=1)
          Output: _hyper_2_4_chunk.device_id_peer
          Bulk Decompression: false
-         ->  Seq Scan on _timescaledb_internal.compress_hyper_6_17_chunk (actual rows=1 loops=1)
-               Output: compress_hyper_6_17_chunk."time", compress_hyper_6_17_chunk.device_id, compress_hyper_6_17_chunk.device_id_peer, compress_hyper_6_17_chunk.v0, compress_hyper_6_17_chunk.v1, compress_hyper_6_17_chunk.v2, compress_hyper_6_17_chunk.v3, compress_hyper_6_17_chunk._ts_meta_count, compress_hyper_6_17_chunk._ts_meta_sequence_num, compress_hyper_6_17_chunk._ts_meta_min_3, compress_hyper_6_17_chunk._ts_meta_max_3, compress_hyper_6_17_chunk._ts_meta_min_1, compress_hyper_6_17_chunk._ts_meta_max_1, compress_hyper_6_17_chunk._ts_meta_min_2, compress_hyper_6_17_chunk._ts_meta_max_2
-               Filter: (compress_hyper_6_17_chunk.device_id = 1)
+         ->  Seq Scan on _timescaledb_internal.compress_hyper_6_18_chunk (actual rows=1 loops=1)
+               Output: compress_hyper_6_18_chunk."time", compress_hyper_6_18_chunk.device_id, compress_hyper_6_18_chunk.device_id_peer, compress_hyper_6_18_chunk.v0, compress_hyper_6_18_chunk.v1, compress_hyper_6_18_chunk.v2, compress_hyper_6_18_chunk.v3, compress_hyper_6_18_chunk._ts_meta_count, compress_hyper_6_18_chunk._ts_meta_sequence_num, compress_hyper_6_18_chunk._ts_meta_min_3, compress_hyper_6_18_chunk._ts_meta_max_3, compress_hyper_6_18_chunk._ts_meta_min_1, compress_hyper_6_18_chunk._ts_meta_max_1, compress_hyper_6_18_chunk._ts_meta_min_2, compress_hyper_6_18_chunk._ts_meta_max_2
+               Filter: (compress_hyper_6_18_chunk.device_id = 1)
    ->  Seq Scan on _timescaledb_internal._hyper_2_7_chunk (actual rows=504 loops=1)
          Output: _hyper_2_7_chunk.device_id_peer
          Filter: (_hyper_2_7_chunk.device_id = 1)
    ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_10_chunk (actual rows=504 loops=1)
          Output: _hyper_2_10_chunk.device_id_peer
          Bulk Decompression: false
-         ->  Seq Scan on _timescaledb_internal.compress_hyper_6_20_chunk (actual rows=1 loops=1)
-               Output: compress_hyper_6_20_chunk."time", compress_hyper_6_20_chunk.device_id, compress_hyper_6_20_chunk.device_id_peer, compress_hyper_6_20_chunk.v0, compress_hyper_6_20_chunk.v1, compress_hyper_6_20_chunk.v2, compress_hyper_6_20_chunk.v3, compress_hyper_6_20_chunk._ts_meta_count, compress_hyper_6_20_chunk._ts_meta_sequence_num, compress_hyper_6_20_chunk._ts_meta_min_3, compress_hyper_6_20_chunk._ts_meta_max_3, compress_hyper_6_20_chunk._ts_meta_min_1, compress_hyper_6_20_chunk._ts_meta_max_1, compress_hyper_6_20_chunk._ts_meta_min_2, compress_hyper_6_20_chunk._ts_meta_max_2
-               Filter: (compress_hyper_6_20_chunk.device_id = 1)
+         ->  Seq Scan on _timescaledb_internal.compress_hyper_6_24_chunk (actual rows=1 loops=1)
+               Output: compress_hyper_6_24_chunk."time", compress_hyper_6_24_chunk.device_id, compress_hyper_6_24_chunk.device_id_peer, compress_hyper_6_24_chunk.v0, compress_hyper_6_24_chunk.v1, compress_hyper_6_24_chunk.v2, compress_hyper_6_24_chunk.v3, compress_hyper_6_24_chunk._ts_meta_count, compress_hyper_6_24_chunk._ts_meta_sequence_num, compress_hyper_6_24_chunk._ts_meta_min_3, compress_hyper_6_24_chunk._ts_meta_max_3, compress_hyper_6_24_chunk._ts_meta_min_1, compress_hyper_6_24_chunk._ts_meta_max_1, compress_hyper_6_24_chunk._ts_meta_min_2, compress_hyper_6_24_chunk._ts_meta_max_2
+               Filter: (compress_hyper_6_24_chunk.device_id = 1)
 (16 rows)
 
 --with multiple values can get a semi-join or nested loop depending on seq_page_cost.
@@ -6430,18 +6430,18 @@ WHERE device_id IN (
          ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_4_chunk (actual rows=360 loops=1)
                Output: _hyper_2_4_chunk.device_id_peer, _hyper_2_4_chunk.device_id
                Bulk Decompression: false
-               ->  Seq Scan on _timescaledb_internal.compress_hyper_6_17_chunk (actual rows=1 loops=1)
-                     Output: compress_hyper_6_17_chunk."time", compress_hyper_6_17_chunk.device_id, compress_hyper_6_17_chunk.device_id_peer, compress_hyper_6_17_chunk.v0, compress_hyper_6_17_chunk.v1, compress_hyper_6_17_chunk.v2, compress_hyper_6_17_chunk.v3, compress_hyper_6_17_chunk._ts_meta_count, compress_hyper_6_17_chunk._ts_meta_sequence_num, compress_hyper_6_17_chunk._ts_meta_min_3, compress_hyper_6_17_chunk._ts_meta_max_3, compress_hyper_6_17_chunk._ts_meta_min_1, compress_hyper_6_17_chunk._ts_meta_max_1, compress_hyper_6_17_chunk._ts_meta_min_2, compress_hyper_6_17_chunk._ts_meta_max_2
+               ->  Seq Scan on _timescaledb_internal.compress_hyper_6_18_chunk (actual rows=1 loops=1)
+                     Output: compress_hyper_6_18_chunk."time", compress_hyper_6_18_chunk.device_id, compress_hyper_6_18_chunk.device_id_peer, compress_hyper_6_18_chunk.v0, compress_hyper_6_18_chunk.v1, compress_hyper_6_18_chunk.v2, compress_hyper_6_18_chunk.v3, compress_hyper_6_18_chunk._ts_meta_count, compress_hyper_6_18_chunk._ts_meta_sequence_num, compress_hyper_6_18_chunk._ts_meta_min_3, compress_hyper_6_18_chunk._ts_meta_max_3, compress_hyper_6_18_chunk._ts_meta_min_1, compress_hyper_6_18_chunk._ts_meta_max_1, compress_hyper_6_18_chunk._ts_meta_min_2, compress_hyper_6_18_chunk._ts_meta_max_2
          ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_5_chunk (actual rows=1080 loops=1)
                Output: _hyper_2_5_chunk.device_id_peer, _hyper_2_5_chunk.device_id
                Bulk Decompression: false
-               ->  Seq Scan on _timescaledb_internal.compress_hyper_6_18_chunk (actual rows=3 loops=1)
-                     Output: compress_hyper_6_18_chunk."time", compress_hyper_6_18_chunk.device_id, compress_hyper_6_18_chunk.device_id_peer, compress_hyper_6_18_chunk.v0, compress_hyper_6_18_chunk.v1, compress_hyper_6_18_chunk.v2, compress_hyper_6_18_chunk.v3, compress_hyper_6_18_chunk._ts_meta_count, compress_hyper_6_18_chunk._ts_meta_sequence_num, compress_hyper_6_18_chunk._ts_meta_min_3, compress_hyper_6_18_chunk._ts_meta_max_3, compress_hyper_6_18_chunk._ts_meta_min_1, compress_hyper_6_18_chunk._ts_meta_max_1, compress_hyper_6_18_chunk._ts_meta_min_2, compress_hyper_6_18_chunk._ts_meta_max_2
+               ->  Seq Scan on _timescaledb_internal.compress_hyper_6_19_chunk (actual rows=3 loops=1)
+                     Output: compress_hyper_6_19_chunk."time", compress_hyper_6_19_chunk.device_id, compress_hyper_6_19_chunk.device_id_peer, compress_hyper_6_19_chunk.v0, compress_hyper_6_19_chunk.v1, compress_hyper_6_19_chunk.v2, compress_hyper_6_19_chunk.v3, compress_hyper_6_19_chunk._ts_meta_count, compress_hyper_6_19_chunk._ts_meta_sequence_num, compress_hyper_6_19_chunk._ts_meta_min_3, compress_hyper_6_19_chunk._ts_meta_max_3, compress_hyper_6_19_chunk._ts_meta_min_1, compress_hyper_6_19_chunk._ts_meta_max_1, compress_hyper_6_19_chunk._ts_meta_min_2, compress_hyper_6_19_chunk._ts_meta_max_2
          ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_6_chunk (actual rows=360 loops=1)
                Output: _hyper_2_6_chunk.device_id_peer, _hyper_2_6_chunk.device_id
                Bulk Decompression: false
-               ->  Seq Scan on _timescaledb_internal.compress_hyper_6_19_chunk (actual rows=1 loops=1)
-                     Output: compress_hyper_6_19_chunk."time", compress_hyper_6_19_chunk.device_id, compress_hyper_6_19_chunk.device_id_peer, compress_hyper_6_19_chunk.v0, compress_hyper_6_19_chunk.v1, compress_hyper_6_19_chunk.v2, compress_hyper_6_19_chunk.v3, compress_hyper_6_19_chunk._ts_meta_count, compress_hyper_6_19_chunk._ts_meta_sequence_num, compress_hyper_6_19_chunk._ts_meta_min_3, compress_hyper_6_19_chunk._ts_meta_max_3, compress_hyper_6_19_chunk._ts_meta_min_1, compress_hyper_6_19_chunk._ts_meta_max_1, compress_hyper_6_19_chunk._ts_meta_min_2, compress_hyper_6_19_chunk._ts_meta_max_2
+               ->  Seq Scan on _timescaledb_internal.compress_hyper_6_20_chunk (actual rows=1 loops=1)
+                     Output: compress_hyper_6_20_chunk."time", compress_hyper_6_20_chunk.device_id, compress_hyper_6_20_chunk.device_id_peer, compress_hyper_6_20_chunk.v0, compress_hyper_6_20_chunk.v1, compress_hyper_6_20_chunk.v2, compress_hyper_6_20_chunk.v3, compress_hyper_6_20_chunk._ts_meta_count, compress_hyper_6_20_chunk._ts_meta_sequence_num, compress_hyper_6_20_chunk._ts_meta_min_3, compress_hyper_6_20_chunk._ts_meta_max_3, compress_hyper_6_20_chunk._ts_meta_min_1, compress_hyper_6_20_chunk._ts_meta_max_1, compress_hyper_6_20_chunk._ts_meta_min_2, compress_hyper_6_20_chunk._ts_meta_max_2
          ->  Seq Scan on _timescaledb_internal._hyper_2_7_chunk (actual rows=504 loops=1)
                Output: _hyper_2_7_chunk.device_id_peer, _hyper_2_7_chunk.device_id
          ->  Seq Scan on _timescaledb_internal._hyper_2_8_chunk (actual rows=1512 loops=1)
@@ -6451,13 +6451,13 @@ WHERE device_id IN (
          ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_10_chunk (actual rows=504 loops=1)
                Output: _hyper_2_10_chunk.device_id_peer, _hyper_2_10_chunk.device_id
                Bulk Decompression: false
-               ->  Seq Scan on _timescaledb_internal.compress_hyper_6_20_chunk (actual rows=1 loops=1)
-                     Output: compress_hyper_6_20_chunk."time", compress_hyper_6_20_chunk.device_id, compress_hyper_6_20_chunk.device_id_peer, compress_hyper_6_20_chunk.v0, compress_hyper_6_20_chunk.v1, compress_hyper_6_20_chunk.v2, compress_hyper_6_20_chunk.v3, compress_hyper_6_20_chunk._ts_meta_count, compress_hyper_6_20_chunk._ts_meta_sequence_num, compress_hyper_6_20_chunk._ts_meta_min_3, compress_hyper_6_20_chunk._ts_meta_max_3, compress_hyper_6_20_chunk._ts_meta_min_1, compress_hyper_6_20_chunk._ts_meta_max_1, compress_hyper_6_20_chunk._ts_meta_min_2, compress_hyper_6_20_chunk._ts_meta_max_2
+               ->  Seq Scan on _timescaledb_internal.compress_hyper_6_24_chunk (actual rows=1 loops=1)
+                     Output: compress_hyper_6_24_chunk."time", compress_hyper_6_24_chunk.device_id, compress_hyper_6_24_chunk.device_id_peer, compress_hyper_6_24_chunk.v0, compress_hyper_6_24_chunk.v1, compress_hyper_6_24_chunk.v2, compress_hyper_6_24_chunk.v3, compress_hyper_6_24_chunk._ts_meta_count, compress_hyper_6_24_chunk._ts_meta_sequence_num, compress_hyper_6_24_chunk._ts_meta_min_3, compress_hyper_6_24_chunk._ts_meta_max_3, compress_hyper_6_24_chunk._ts_meta_min_1, compress_hyper_6_24_chunk._ts_meta_max_1, compress_hyper_6_24_chunk._ts_meta_min_2, compress_hyper_6_24_chunk._ts_meta_max_2
          ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_11_chunk (actual rows=1512 loops=1)
                Output: _hyper_2_11_chunk.device_id_peer, _hyper_2_11_chunk.device_id
                Bulk Decompression: false
-               ->  Seq Scan on _timescaledb_internal.compress_hyper_6_21_chunk (actual rows=3 loops=1)
-                     Output: compress_hyper_6_21_chunk."time", compress_hyper_6_21_chunk.device_id, compress_hyper_6_21_chunk.device_id_peer, compress_hyper_6_21_chunk.v0, compress_hyper_6_21_chunk.v1, compress_hyper_6_21_chunk.v2, compress_hyper_6_21_chunk.v3, compress_hyper_6_21_chunk._ts_meta_count, compress_hyper_6_21_chunk._ts_meta_sequence_num, compress_hyper_6_21_chunk._ts_meta_min_3, compress_hyper_6_21_chunk._ts_meta_max_3, compress_hyper_6_21_chunk._ts_meta_min_1, compress_hyper_6_21_chunk._ts_meta_max_1, compress_hyper_6_21_chunk._ts_meta_min_2, compress_hyper_6_21_chunk._ts_meta_max_2
+               ->  Seq Scan on _timescaledb_internal.compress_hyper_6_25_chunk (actual rows=3 loops=1)
+                     Output: compress_hyper_6_25_chunk."time", compress_hyper_6_25_chunk.device_id, compress_hyper_6_25_chunk.device_id_peer, compress_hyper_6_25_chunk.v0, compress_hyper_6_25_chunk.v1, compress_hyper_6_25_chunk.v2, compress_hyper_6_25_chunk.v3, compress_hyper_6_25_chunk._ts_meta_count, compress_hyper_6_25_chunk._ts_meta_sequence_num, compress_hyper_6_25_chunk._ts_meta_min_3, compress_hyper_6_25_chunk._ts_meta_max_3, compress_hyper_6_25_chunk._ts_meta_min_1, compress_hyper_6_25_chunk._ts_meta_max_1, compress_hyper_6_25_chunk._ts_meta_min_2, compress_hyper_6_25_chunk._ts_meta_max_2
          ->  Seq Scan on _timescaledb_internal._hyper_2_12_chunk (actual rows=504 loops=1)
                Output: _hyper_2_12_chunk.device_id_peer, _hyper_2_12_chunk.device_id
    ->  Hash (actual rows=2 loops=1)
@@ -6489,19 +6489,19 @@ WHERE device_id IN (
    ->  Append
          ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_4_chunk
                Output: _hyper_2_4_chunk.device_id_peer, _hyper_2_4_chunk.device_id
-               ->  Index Scan using compress_hyper_6_17_chunk_c_space_index_2 on _timescaledb_internal.compress_hyper_6_17_chunk
-                     Output: compress_hyper_6_17_chunk."time", compress_hyper_6_17_chunk.device_id, compress_hyper_6_17_chunk.device_id_peer, compress_hyper_6_17_chunk.v0, compress_hyper_6_17_chunk.v1, compress_hyper_6_17_chunk.v2, compress_hyper_6_17_chunk.v3, compress_hyper_6_17_chunk._ts_meta_count, compress_hyper_6_17_chunk._ts_meta_sequence_num, compress_hyper_6_17_chunk._ts_meta_min_3, compress_hyper_6_17_chunk._ts_meta_max_3, compress_hyper_6_17_chunk._ts_meta_min_1, compress_hyper_6_17_chunk._ts_meta_max_1, compress_hyper_6_17_chunk._ts_meta_min_2, compress_hyper_6_17_chunk._ts_meta_max_2
-                     Index Cond: (compress_hyper_6_17_chunk.device_id = "*VALUES*".column1)
-         ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_5_chunk
-               Output: _hyper_2_5_chunk.device_id_peer, _hyper_2_5_chunk.device_id
                ->  Index Scan using compress_hyper_6_18_chunk_c_space_index_2 on _timescaledb_internal.compress_hyper_6_18_chunk
                      Output: compress_hyper_6_18_chunk."time", compress_hyper_6_18_chunk.device_id, compress_hyper_6_18_chunk.device_id_peer, compress_hyper_6_18_chunk.v0, compress_hyper_6_18_chunk.v1, compress_hyper_6_18_chunk.v2, compress_hyper_6_18_chunk.v3, compress_hyper_6_18_chunk._ts_meta_count, compress_hyper_6_18_chunk._ts_meta_sequence_num, compress_hyper_6_18_chunk._ts_meta_min_3, compress_hyper_6_18_chunk._ts_meta_max_3, compress_hyper_6_18_chunk._ts_meta_min_1, compress_hyper_6_18_chunk._ts_meta_max_1, compress_hyper_6_18_chunk._ts_meta_min_2, compress_hyper_6_18_chunk._ts_meta_max_2
                      Index Cond: (compress_hyper_6_18_chunk.device_id = "*VALUES*".column1)
-         ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_6_chunk
-               Output: _hyper_2_6_chunk.device_id_peer, _hyper_2_6_chunk.device_id
+         ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_5_chunk
+               Output: _hyper_2_5_chunk.device_id_peer, _hyper_2_5_chunk.device_id
                ->  Index Scan using compress_hyper_6_19_chunk_c_space_index_2 on _timescaledb_internal.compress_hyper_6_19_chunk
                      Output: compress_hyper_6_19_chunk."time", compress_hyper_6_19_chunk.device_id, compress_hyper_6_19_chunk.device_id_peer, compress_hyper_6_19_chunk.v0, compress_hyper_6_19_chunk.v1, compress_hyper_6_19_chunk.v2, compress_hyper_6_19_chunk.v3, compress_hyper_6_19_chunk._ts_meta_count, compress_hyper_6_19_chunk._ts_meta_sequence_num, compress_hyper_6_19_chunk._ts_meta_min_3, compress_hyper_6_19_chunk._ts_meta_max_3, compress_hyper_6_19_chunk._ts_meta_min_1, compress_hyper_6_19_chunk._ts_meta_max_1, compress_hyper_6_19_chunk._ts_meta_min_2, compress_hyper_6_19_chunk._ts_meta_max_2
                      Index Cond: (compress_hyper_6_19_chunk.device_id = "*VALUES*".column1)
+         ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_6_chunk
+               Output: _hyper_2_6_chunk.device_id_peer, _hyper_2_6_chunk.device_id
+               ->  Index Scan using compress_hyper_6_20_chunk_c_space_index_2 on _timescaledb_internal.compress_hyper_6_20_chunk
+                     Output: compress_hyper_6_20_chunk."time", compress_hyper_6_20_chunk.device_id, compress_hyper_6_20_chunk.device_id_peer, compress_hyper_6_20_chunk.v0, compress_hyper_6_20_chunk.v1, compress_hyper_6_20_chunk.v2, compress_hyper_6_20_chunk.v3, compress_hyper_6_20_chunk._ts_meta_count, compress_hyper_6_20_chunk._ts_meta_sequence_num, compress_hyper_6_20_chunk._ts_meta_min_3, compress_hyper_6_20_chunk._ts_meta_max_3, compress_hyper_6_20_chunk._ts_meta_min_1, compress_hyper_6_20_chunk._ts_meta_max_1, compress_hyper_6_20_chunk._ts_meta_min_2, compress_hyper_6_20_chunk._ts_meta_max_2
+                     Index Cond: (compress_hyper_6_20_chunk.device_id = "*VALUES*".column1)
          ->  Index Only Scan using _hyper_2_7_chunk_metrics_space_device_id_device_id_peer_v0_v1_2 on _timescaledb_internal._hyper_2_7_chunk
                Output: _hyper_2_7_chunk.device_id_peer, _hyper_2_7_chunk.device_id
                Index Cond: (_hyper_2_7_chunk.device_id = "*VALUES*".column1)
@@ -6513,14 +6513,14 @@ WHERE device_id IN (
                Index Cond: (_hyper_2_9_chunk.device_id = "*VALUES*".column1)
          ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_10_chunk
                Output: _hyper_2_10_chunk.device_id_peer, _hyper_2_10_chunk.device_id
-               ->  Index Scan using compress_hyper_6_20_chunk_c_space_index_2 on _timescaledb_internal.compress_hyper_6_20_chunk
-                     Output: compress_hyper_6_20_chunk."time", compress_hyper_6_20_chunk.device_id, compress_hyper_6_20_chunk.device_id_peer, compress_hyper_6_20_chunk.v0, compress_hyper_6_20_chunk.v1, compress_hyper_6_20_chunk.v2, compress_hyper_6_20_chunk.v3, compress_hyper_6_20_chunk._ts_meta_count, compress_hyper_6_20_chunk._ts_meta_sequence_num, compress_hyper_6_20_chunk._ts_meta_min_3, compress_hyper_6_20_chunk._ts_meta_max_3, compress_hyper_6_20_chunk._ts_meta_min_1, compress_hyper_6_20_chunk._ts_meta_max_1, compress_hyper_6_20_chunk._ts_meta_min_2, compress_hyper_6_20_chunk._ts_meta_max_2
-                     Index Cond: (compress_hyper_6_20_chunk.device_id = "*VALUES*".column1)
+               ->  Index Scan using compress_hyper_6_24_chunk_c_space_index_2 on _timescaledb_internal.compress_hyper_6_24_chunk
+                     Output: compress_hyper_6_24_chunk."time", compress_hyper_6_24_chunk.device_id, compress_hyper_6_24_chunk.device_id_peer, compress_hyper_6_24_chunk.v0, compress_hyper_6_24_chunk.v1, compress_hyper_6_24_chunk.v2, compress_hyper_6_24_chunk.v3, compress_hyper_6_24_chunk._ts_meta_count, compress_hyper_6_24_chunk._ts_meta_sequence_num, compress_hyper_6_24_chunk._ts_meta_min_3, compress_hyper_6_24_chunk._ts_meta_max_3, compress_hyper_6_24_chunk._ts_meta_min_1, compress_hyper_6_24_chunk._ts_meta_max_1, compress_hyper_6_24_chunk._ts_meta_min_2, compress_hyper_6_24_chunk._ts_meta_max_2
+                     Index Cond: (compress_hyper_6_24_chunk.device_id = "*VALUES*".column1)
          ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_11_chunk
                Output: _hyper_2_11_chunk.device_id_peer, _hyper_2_11_chunk.device_id
-               ->  Index Scan using compress_hyper_6_21_chunk_c_space_index_2 on _timescaledb_internal.compress_hyper_6_21_chunk
-                     Output: compress_hyper_6_21_chunk."time", compress_hyper_6_21_chunk.device_id, compress_hyper_6_21_chunk.device_id_peer, compress_hyper_6_21_chunk.v0, compress_hyper_6_21_chunk.v1, compress_hyper_6_21_chunk.v2, compress_hyper_6_21_chunk.v3, compress_hyper_6_21_chunk._ts_meta_count, compress_hyper_6_21_chunk._ts_meta_sequence_num, compress_hyper_6_21_chunk._ts_meta_min_3, compress_hyper_6_21_chunk._ts_meta_max_3, compress_hyper_6_21_chunk._ts_meta_min_1, compress_hyper_6_21_chunk._ts_meta_max_1, compress_hyper_6_21_chunk._ts_meta_min_2, compress_hyper_6_21_chunk._ts_meta_max_2
-                     Index Cond: (compress_hyper_6_21_chunk.device_id = "*VALUES*".column1)
+               ->  Index Scan using compress_hyper_6_25_chunk_c_space_index_2 on _timescaledb_internal.compress_hyper_6_25_chunk
+                     Output: compress_hyper_6_25_chunk."time", compress_hyper_6_25_chunk.device_id, compress_hyper_6_25_chunk.device_id_peer, compress_hyper_6_25_chunk.v0, compress_hyper_6_25_chunk.v1, compress_hyper_6_25_chunk.v2, compress_hyper_6_25_chunk.v3, compress_hyper_6_25_chunk._ts_meta_count, compress_hyper_6_25_chunk._ts_meta_sequence_num, compress_hyper_6_25_chunk._ts_meta_min_3, compress_hyper_6_25_chunk._ts_meta_max_3, compress_hyper_6_25_chunk._ts_meta_min_1, compress_hyper_6_25_chunk._ts_meta_max_1, compress_hyper_6_25_chunk._ts_meta_min_2, compress_hyper_6_25_chunk._ts_meta_max_2
+                     Index Cond: (compress_hyper_6_25_chunk.device_id = "*VALUES*".column1)
          ->  Index Only Scan using _hyper_2_12_chunk_metrics_space_device_id_device_id_peer_v0_v_2 on _timescaledb_internal._hyper_2_12_chunk
                Output: _hyper_2_12_chunk.device_id_peer, _hyper_2_12_chunk.device_id
                Index Cond: (_hyper_2_12_chunk.device_id = "*VALUES*".column1)
@@ -6538,18 +6538,18 @@ WHERE device_id IN (
    ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_4_chunk (actual rows=360 loops=1)
          Output: _hyper_2_4_chunk.device_id_peer
          Bulk Decompression: false
-         ->  Seq Scan on _timescaledb_internal.compress_hyper_6_17_chunk (actual rows=1 loops=1)
-               Output: compress_hyper_6_17_chunk."time", compress_hyper_6_17_chunk.device_id, compress_hyper_6_17_chunk.device_id_peer, compress_hyper_6_17_chunk.v0, compress_hyper_6_17_chunk.v1, compress_hyper_6_17_chunk.v2, compress_hyper_6_17_chunk.v3, compress_hyper_6_17_chunk._ts_meta_count, compress_hyper_6_17_chunk._ts_meta_sequence_num, compress_hyper_6_17_chunk._ts_meta_min_3, compress_hyper_6_17_chunk._ts_meta_max_3, compress_hyper_6_17_chunk._ts_meta_min_1, compress_hyper_6_17_chunk._ts_meta_max_1, compress_hyper_6_17_chunk._ts_meta_min_2, compress_hyper_6_17_chunk._ts_meta_max_2
-               Filter: (compress_hyper_6_17_chunk.device_id = 1)
+         ->  Seq Scan on _timescaledb_internal.compress_hyper_6_18_chunk (actual rows=1 loops=1)
+               Output: compress_hyper_6_18_chunk."time", compress_hyper_6_18_chunk.device_id, compress_hyper_6_18_chunk.device_id_peer, compress_hyper_6_18_chunk.v0, compress_hyper_6_18_chunk.v1, compress_hyper_6_18_chunk.v2, compress_hyper_6_18_chunk.v3, compress_hyper_6_18_chunk._ts_meta_count, compress_hyper_6_18_chunk._ts_meta_sequence_num, compress_hyper_6_18_chunk._ts_meta_min_3, compress_hyper_6_18_chunk._ts_meta_max_3, compress_hyper_6_18_chunk._ts_meta_min_1, compress_hyper_6_18_chunk._ts_meta_max_1, compress_hyper_6_18_chunk._ts_meta_min_2, compress_hyper_6_18_chunk._ts_meta_max_2
+               Filter: (compress_hyper_6_18_chunk.device_id = 1)
    ->  Seq Scan on _timescaledb_internal._hyper_2_7_chunk (actual rows=504 loops=1)
          Output: _hyper_2_7_chunk.device_id_peer
          Filter: (_hyper_2_7_chunk.device_id = 1)
    ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_10_chunk (actual rows=504 loops=1)
          Output: _hyper_2_10_chunk.device_id_peer
          Bulk Decompression: false
-         ->  Seq Scan on _timescaledb_internal.compress_hyper_6_20_chunk (actual rows=1 loops=1)
-               Output: compress_hyper_6_20_chunk."time", compress_hyper_6_20_chunk.device_id, compress_hyper_6_20_chunk.device_id_peer, compress_hyper_6_20_chunk.v0, compress_hyper_6_20_chunk.v1, compress_hyper_6_20_chunk.v2, compress_hyper_6_20_chunk.v3, compress_hyper_6_20_chunk._ts_meta_count, compress_hyper_6_20_chunk._ts_meta_sequence_num, compress_hyper_6_20_chunk._ts_meta_min_3, compress_hyper_6_20_chunk._ts_meta_max_3, compress_hyper_6_20_chunk._ts_meta_min_1, compress_hyper_6_20_chunk._ts_meta_max_1, compress_hyper_6_20_chunk._ts_meta_min_2, compress_hyper_6_20_chunk._ts_meta_max_2
-               Filter: (compress_hyper_6_20_chunk.device_id = 1)
+         ->  Seq Scan on _timescaledb_internal.compress_hyper_6_24_chunk (actual rows=1 loops=1)
+               Output: compress_hyper_6_24_chunk."time", compress_hyper_6_24_chunk.device_id, compress_hyper_6_24_chunk.device_id_peer, compress_hyper_6_24_chunk.v0, compress_hyper_6_24_chunk.v1, compress_hyper_6_24_chunk.v2, compress_hyper_6_24_chunk.v3, compress_hyper_6_24_chunk._ts_meta_count, compress_hyper_6_24_chunk._ts_meta_sequence_num, compress_hyper_6_24_chunk._ts_meta_min_3, compress_hyper_6_24_chunk._ts_meta_max_3, compress_hyper_6_24_chunk._ts_meta_min_1, compress_hyper_6_24_chunk._ts_meta_max_1, compress_hyper_6_24_chunk._ts_meta_min_2, compress_hyper_6_24_chunk._ts_meta_max_2
+               Filter: (compress_hyper_6_24_chunk.device_id = 1)
 (16 rows)
 
 :PREFIX_VERBOSE
@@ -6567,18 +6567,18 @@ WHERE device_id IN (
          ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_4_chunk (actual rows=360 loops=1)
                Output: _hyper_2_4_chunk.device_id_peer, _hyper_2_4_chunk.device_id
                Bulk Decompression: false
-               ->  Seq Scan on _timescaledb_internal.compress_hyper_6_17_chunk (actual rows=1 loops=1)
-                     Output: compress_hyper_6_17_chunk."time", compress_hyper_6_17_chunk.device_id, compress_hyper_6_17_chunk.device_id_peer, compress_hyper_6_17_chunk.v0, compress_hyper_6_17_chunk.v1, compress_hyper_6_17_chunk.v2, compress_hyper_6_17_chunk.v3, compress_hyper_6_17_chunk._ts_meta_count, compress_hyper_6_17_chunk._ts_meta_sequence_num, compress_hyper_6_17_chunk._ts_meta_min_3, compress_hyper_6_17_chunk._ts_meta_max_3, compress_hyper_6_17_chunk._ts_meta_min_1, compress_hyper_6_17_chunk._ts_meta_max_1, compress_hyper_6_17_chunk._ts_meta_min_2, compress_hyper_6_17_chunk._ts_meta_max_2
+               ->  Seq Scan on _timescaledb_internal.compress_hyper_6_18_chunk (actual rows=1 loops=1)
+                     Output: compress_hyper_6_18_chunk."time", compress_hyper_6_18_chunk.device_id, compress_hyper_6_18_chunk.device_id_peer, compress_hyper_6_18_chunk.v0, compress_hyper_6_18_chunk.v1, compress_hyper_6_18_chunk.v2, compress_hyper_6_18_chunk.v3, compress_hyper_6_18_chunk._ts_meta_count, compress_hyper_6_18_chunk._ts_meta_sequence_num, compress_hyper_6_18_chunk._ts_meta_min_3, compress_hyper_6_18_chunk._ts_meta_max_3, compress_hyper_6_18_chunk._ts_meta_min_1, compress_hyper_6_18_chunk._ts_meta_max_1, compress_hyper_6_18_chunk._ts_meta_min_2, compress_hyper_6_18_chunk._ts_meta_max_2
          ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_5_chunk (actual rows=1080 loops=1)
                Output: _hyper_2_5_chunk.device_id_peer, _hyper_2_5_chunk.device_id
                Bulk Decompression: false
-               ->  Seq Scan on _timescaledb_internal.compress_hyper_6_18_chunk (actual rows=3 loops=1)
-                     Output: compress_hyper_6_18_chunk."time", compress_hyper_6_18_chunk.device_id, compress_hyper_6_18_chunk.device_id_peer, compress_hyper_6_18_chunk.v0, compress_hyper_6_18_chunk.v1, compress_hyper_6_18_chunk.v2, compress_hyper_6_18_chunk.v3, compress_hyper_6_18_chunk._ts_meta_count, compress_hyper_6_18_chunk._ts_meta_sequence_num, compress_hyper_6_18_chunk._ts_meta_min_3, compress_hyper_6_18_chunk._ts_meta_max_3, compress_hyper_6_18_chunk._ts_meta_min_1, compress_hyper_6_18_chunk._ts_meta_max_1, compress_hyper_6_18_chunk._ts_meta_min_2, compress_hyper_6_18_chunk._ts_meta_max_2
+               ->  Seq Scan on _timescaledb_internal.compress_hyper_6_19_chunk (actual rows=3 loops=1)
+                     Output: compress_hyper_6_19_chunk."time", compress_hyper_6_19_chunk.device_id, compress_hyper_6_19_chunk.device_id_peer, compress_hyper_6_19_chunk.v0, compress_hyper_6_19_chunk.v1, compress_hyper_6_19_chunk.v2, compress_hyper_6_19_chunk.v3, compress_hyper_6_19_chunk._ts_meta_count, compress_hyper_6_19_chunk._ts_meta_sequence_num, compress_hyper_6_19_chunk._ts_meta_min_3, compress_hyper_6_19_chunk._ts_meta_max_3, compress_hyper_6_19_chunk._ts_meta_min_1, compress_hyper_6_19_chunk._ts_meta_max_1, compress_hyper_6_19_chunk._ts_meta_min_2, compress_hyper_6_19_chunk._ts_meta_max_2
          ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_6_chunk (actual rows=360 loops=1)
                Output: _hyper_2_6_chunk.device_id_peer, _hyper_2_6_chunk.device_id
                Bulk Decompression: false
-               ->  Seq Scan on _timescaledb_internal.compress_hyper_6_19_chunk (actual rows=1 loops=1)
-                     Output: compress_hyper_6_19_chunk."time", compress_hyper_6_19_chunk.device_id, compress_hyper_6_19_chunk.device_id_peer, compress_hyper_6_19_chunk.v0, compress_hyper_6_19_chunk.v1, compress_hyper_6_19_chunk.v2, compress_hyper_6_19_chunk.v3, compress_hyper_6_19_chunk._ts_meta_count, compress_hyper_6_19_chunk._ts_meta_sequence_num, compress_hyper_6_19_chunk._ts_meta_min_3, compress_hyper_6_19_chunk._ts_meta_max_3, compress_hyper_6_19_chunk._ts_meta_min_1, compress_hyper_6_19_chunk._ts_meta_max_1, compress_hyper_6_19_chunk._ts_meta_min_2, compress_hyper_6_19_chunk._ts_meta_max_2
+               ->  Seq Scan on _timescaledb_internal.compress_hyper_6_20_chunk (actual rows=1 loops=1)
+                     Output: compress_hyper_6_20_chunk."time", compress_hyper_6_20_chunk.device_id, compress_hyper_6_20_chunk.device_id_peer, compress_hyper_6_20_chunk.v0, compress_hyper_6_20_chunk.v1, compress_hyper_6_20_chunk.v2, compress_hyper_6_20_chunk.v3, compress_hyper_6_20_chunk._ts_meta_count, compress_hyper_6_20_chunk._ts_meta_sequence_num, compress_hyper_6_20_chunk._ts_meta_min_3, compress_hyper_6_20_chunk._ts_meta_max_3, compress_hyper_6_20_chunk._ts_meta_min_1, compress_hyper_6_20_chunk._ts_meta_max_1, compress_hyper_6_20_chunk._ts_meta_min_2, compress_hyper_6_20_chunk._ts_meta_max_2
          ->  Seq Scan on _timescaledb_internal._hyper_2_7_chunk (actual rows=504 loops=1)
                Output: _hyper_2_7_chunk.device_id_peer, _hyper_2_7_chunk.device_id
          ->  Seq Scan on _timescaledb_internal._hyper_2_8_chunk (actual rows=1512 loops=1)
@@ -6588,13 +6588,13 @@ WHERE device_id IN (
          ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_10_chunk (actual rows=504 loops=1)
                Output: _hyper_2_10_chunk.device_id_peer, _hyper_2_10_chunk.device_id
                Bulk Decompression: false
-               ->  Seq Scan on _timescaledb_internal.compress_hyper_6_20_chunk (actual rows=1 loops=1)
-                     Output: compress_hyper_6_20_chunk."time", compress_hyper_6_20_chunk.device_id, compress_hyper_6_20_chunk.device_id_peer, compress_hyper_6_20_chunk.v0, compress_hyper_6_20_chunk.v1, compress_hyper_6_20_chunk.v2, compress_hyper_6_20_chunk.v3, compress_hyper_6_20_chunk._ts_meta_count, compress_hyper_6_20_chunk._ts_meta_sequence_num, compress_hyper_6_20_chunk._ts_meta_min_3, compress_hyper_6_20_chunk._ts_meta_max_3, compress_hyper_6_20_chunk._ts_meta_min_1, compress_hyper_6_20_chunk._ts_meta_max_1, compress_hyper_6_20_chunk._ts_meta_min_2, compress_hyper_6_20_chunk._ts_meta_max_2
+               ->  Seq Scan on _timescaledb_internal.compress_hyper_6_24_chunk (actual rows=1 loops=1)
+                     Output: compress_hyper_6_24_chunk."time", compress_hyper_6_24_chunk.device_id, compress_hyper_6_24_chunk.device_id_peer, compress_hyper_6_24_chunk.v0, compress_hyper_6_24_chunk.v1, compress_hyper_6_24_chunk.v2, compress_hyper_6_24_chunk.v3, compress_hyper_6_24_chunk._ts_meta_count, compress_hyper_6_24_chunk._ts_meta_sequence_num, compress_hyper_6_24_chunk._ts_meta_min_3, compress_hyper_6_24_chunk._ts_meta_max_3, compress_hyper_6_24_chunk._ts_meta_min_1, compress_hyper_6_24_chunk._ts_meta_max_1, compress_hyper_6_24_chunk._ts_meta_min_2, compress_hyper_6_24_chunk._ts_meta_max_2
          ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_11_chunk (actual rows=1512 loops=1)
                Output: _hyper_2_11_chunk.device_id_peer, _hyper_2_11_chunk.device_id
                Bulk Decompression: false
-               ->  Seq Scan on _timescaledb_internal.compress_hyper_6_21_chunk (actual rows=3 loops=1)
-                     Output: compress_hyper_6_21_chunk."time", compress_hyper_6_21_chunk.device_id, compress_hyper_6_21_chunk.device_id_peer, compress_hyper_6_21_chunk.v0, compress_hyper_6_21_chunk.v1, compress_hyper_6_21_chunk.v2, compress_hyper_6_21_chunk.v3, compress_hyper_6_21_chunk._ts_meta_count, compress_hyper_6_21_chunk._ts_meta_sequence_num, compress_hyper_6_21_chunk._ts_meta_min_3, compress_hyper_6_21_chunk._ts_meta_max_3, compress_hyper_6_21_chunk._ts_meta_min_1, compress_hyper_6_21_chunk._ts_meta_max_1, compress_hyper_6_21_chunk._ts_meta_min_2, compress_hyper_6_21_chunk._ts_meta_max_2
+               ->  Seq Scan on _timescaledb_internal.compress_hyper_6_25_chunk (actual rows=3 loops=1)
+                     Output: compress_hyper_6_25_chunk."time", compress_hyper_6_25_chunk.device_id, compress_hyper_6_25_chunk.device_id_peer, compress_hyper_6_25_chunk.v0, compress_hyper_6_25_chunk.v1, compress_hyper_6_25_chunk.v2, compress_hyper_6_25_chunk.v3, compress_hyper_6_25_chunk._ts_meta_count, compress_hyper_6_25_chunk._ts_meta_sequence_num, compress_hyper_6_25_chunk._ts_meta_min_3, compress_hyper_6_25_chunk._ts_meta_max_3, compress_hyper_6_25_chunk._ts_meta_min_1, compress_hyper_6_25_chunk._ts_meta_max_1, compress_hyper_6_25_chunk._ts_meta_min_2, compress_hyper_6_25_chunk._ts_meta_max_2
          ->  Seq Scan on _timescaledb_internal._hyper_2_12_chunk (actual rows=504 loops=1)
                Output: _hyper_2_12_chunk.device_id_peer, _hyper_2_12_chunk.device_id
    ->  Hash (actual rows=2 loops=1)
@@ -6626,14 +6626,14 @@ LIMIT 10;
                Sort Key: _hyper_2_10_chunk."time" DESC
                Sort Method: top-N heapsort 
                ->  Custom Scan (DecompressChunk) on _hyper_2_10_chunk (actual rows=504 loops=1)
-                     ->  Seq Scan on compress_hyper_6_20_chunk (actual rows=1 loops=1)
+                     ->  Seq Scan on compress_hyper_6_24_chunk (actual rows=1 loops=1)
                            Filter: (device_id = 1)
          ->  Index Scan using _hyper_2_7_chunk_metrics_space_time_idx on _hyper_2_7_chunk (never executed)
                Filter: (device_id = 1)
          ->  Sort (never executed)
                Sort Key: _hyper_2_4_chunk."time" DESC
                ->  Custom Scan (DecompressChunk) on _hyper_2_4_chunk (never executed)
-                     ->  Seq Scan on compress_hyper_6_17_chunk (never executed)
+                     ->  Seq Scan on compress_hyper_6_18_chunk (never executed)
                            Filter: (device_id = 1)
 (16 rows)
 
@@ -6669,7 +6669,7 @@ FROM :TEST_TABLE m1
                                        Sort Key: m1_1."time"
                                        Sort Method: quicksort 
                                        ->  Custom Scan (DecompressChunk) on _hyper_2_4_chunk m1_1 (actual rows=360 loops=1)
-                                             ->  Seq Scan on compress_hyper_6_17_chunk (actual rows=1 loops=1)
+                                             ->  Seq Scan on compress_hyper_6_18_chunk (actual rows=1 loops=1)
                            ->  Sort (actual rows=7 loops=1)
                                  Sort Key: m1_2."time"
                                  Sort Method: quicksort 
@@ -6677,7 +6677,7 @@ FROM :TEST_TABLE m1
                                        Sort Key: m1_2."time"
                                        Sort Method: quicksort 
                                        ->  Custom Scan (DecompressChunk) on _hyper_2_5_chunk m1_2 (actual rows=1080 loops=1)
-                                             ->  Seq Scan on compress_hyper_6_18_chunk (actual rows=3 loops=1)
+                                             ->  Seq Scan on compress_hyper_6_19_chunk (actual rows=3 loops=1)
                            ->  Sort (actual rows=3 loops=1)
                                  Sort Key: m1_3."time"
                                  Sort Method: quicksort 
@@ -6685,7 +6685,7 @@ FROM :TEST_TABLE m1
                                        Sort Key: m1_3."time"
                                        Sort Method: quicksort 
                                        ->  Custom Scan (DecompressChunk) on _hyper_2_6_chunk m1_3 (actual rows=360 loops=1)
-                                             ->  Seq Scan on compress_hyper_6_19_chunk (actual rows=1 loops=1)
+                                             ->  Seq Scan on compress_hyper_6_20_chunk (actual rows=1 loops=1)
                      ->  Merge Append (never executed)
                            Sort Key: m1_4."time"
                            ->  Index Scan Backward using _hyper_2_7_chunk_metrics_space_time_idx on _hyper_2_7_chunk m1_4 (never executed)
@@ -6698,13 +6698,13 @@ FROM :TEST_TABLE m1
                                  ->  Sort (never executed)
                                        Sort Key: m1_7."time"
                                        ->  Custom Scan (DecompressChunk) on _hyper_2_10_chunk m1_7 (never executed)
-                                             ->  Seq Scan on compress_hyper_6_20_chunk (never executed)
+                                             ->  Seq Scan on compress_hyper_6_24_chunk (never executed)
                            ->  Sort (never executed)
                                  Sort Key: m1_8."time"
                                  ->  Sort (never executed)
                                        Sort Key: m1_8."time"
                                        ->  Custom Scan (DecompressChunk) on _hyper_2_11_chunk m1_8 (never executed)
-                                             ->  Seq Scan on compress_hyper_6_21_chunk (never executed)
+                                             ->  Seq Scan on compress_hyper_6_25_chunk (never executed)
                            ->  Index Scan Backward using _hyper_2_12_chunk_metrics_space_time_idx on _hyper_2_12_chunk m1_9 (never executed)
                ->  Materialize (actual rows=51 loops=1)
                      ->  Custom Scan (ChunkAppend) on metrics_space m2 (actual rows=11 loops=1)
@@ -6718,7 +6718,7 @@ FROM :TEST_TABLE m1
                                              Sort Key: m2_1."time"
                                              Sort Method: quicksort 
                                              ->  Custom Scan (DecompressChunk) on _hyper_2_4_chunk m2_1 (actual rows=360 loops=1)
-                                                   ->  Seq Scan on compress_hyper_6_17_chunk compress_hyper_6_17_chunk_1 (actual rows=1 loops=1)
+                                                   ->  Seq Scan on compress_hyper_6_18_chunk compress_hyper_6_18_chunk_1 (actual rows=1 loops=1)
                                  ->  Sort (actual rows=7 loops=1)
                                        Sort Key: m2_2."time"
                                        Sort Method: quicksort 
@@ -6726,7 +6726,7 @@ FROM :TEST_TABLE m1
                                              Sort Key: m2_2."time"
                                              Sort Method: quicksort 
                                              ->  Custom Scan (DecompressChunk) on _hyper_2_5_chunk m2_2 (actual rows=1080 loops=1)
-                                                   ->  Seq Scan on compress_hyper_6_18_chunk compress_hyper_6_18_chunk_1 (actual rows=3 loops=1)
+                                                   ->  Seq Scan on compress_hyper_6_19_chunk compress_hyper_6_19_chunk_1 (actual rows=3 loops=1)
                                  ->  Sort (actual rows=3 loops=1)
                                        Sort Key: m2_3."time"
                                        Sort Method: quicksort 
@@ -6734,7 +6734,7 @@ FROM :TEST_TABLE m1
                                              Sort Key: m2_3."time"
                                              Sort Method: quicksort 
                                              ->  Custom Scan (DecompressChunk) on _hyper_2_6_chunk m2_3 (actual rows=360 loops=1)
-                                                   ->  Seq Scan on compress_hyper_6_19_chunk compress_hyper_6_19_chunk_1 (actual rows=1 loops=1)
+                                                   ->  Seq Scan on compress_hyper_6_20_chunk compress_hyper_6_20_chunk_1 (actual rows=1 loops=1)
                            ->  Merge Append (never executed)
                                  Sort Key: m2_4."time"
                                  ->  Index Scan Backward using _hyper_2_7_chunk_metrics_space_time_idx on _hyper_2_7_chunk m2_4 (never executed)
@@ -6747,13 +6747,13 @@ FROM :TEST_TABLE m1
                                        ->  Sort (never executed)
                                              Sort Key: m2_7."time"
                                              ->  Custom Scan (DecompressChunk) on _hyper_2_10_chunk m2_7 (never executed)
-                                                   ->  Seq Scan on compress_hyper_6_20_chunk compress_hyper_6_20_chunk_1 (never executed)
+                                                   ->  Seq Scan on compress_hyper_6_24_chunk compress_hyper_6_24_chunk_1 (never executed)
                                  ->  Sort (never executed)
                                        Sort Key: m2_8."time"
                                        ->  Sort (never executed)
                                              Sort Key: m2_8."time"
                                              ->  Custom Scan (DecompressChunk) on _hyper_2_11_chunk m2_8 (never executed)
-                                                   ->  Seq Scan on compress_hyper_6_21_chunk compress_hyper_6_21_chunk_1 (never executed)
+                                                   ->  Seq Scan on compress_hyper_6_25_chunk compress_hyper_6_25_chunk_1 (never executed)
                                  ->  Index Scan Backward using _hyper_2_12_chunk_metrics_space_time_idx on _hyper_2_12_chunk m2_9 (never executed)
 (106 rows)
 
@@ -6789,7 +6789,7 @@ FROM :TEST_TABLE m1
                                        Sort Key: m2_1."time"
                                        Sort Method: quicksort 
                                        ->  Custom Scan (DecompressChunk) on _hyper_2_4_chunk m2_1 (actual rows=360 loops=1)
-                                             ->  Seq Scan on compress_hyper_6_17_chunk compress_hyper_6_17_chunk_1 (actual rows=1 loops=1)
+                                             ->  Seq Scan on compress_hyper_6_18_chunk compress_hyper_6_18_chunk_1 (actual rows=1 loops=1)
                            ->  Sort (actual rows=7 loops=1)
                                  Sort Key: m2_2."time"
                                  Sort Method: quicksort 
@@ -6797,7 +6797,7 @@ FROM :TEST_TABLE m1
                                        Sort Key: m2_2."time"
                                        Sort Method: quicksort 
                                        ->  Custom Scan (DecompressChunk) on _hyper_2_5_chunk m2_2 (actual rows=1080 loops=1)
-                                             ->  Seq Scan on compress_hyper_6_18_chunk compress_hyper_6_18_chunk_1 (actual rows=3 loops=1)
+                                             ->  Seq Scan on compress_hyper_6_19_chunk compress_hyper_6_19_chunk_1 (actual rows=3 loops=1)
                            ->  Sort (actual rows=3 loops=1)
                                  Sort Key: m2_3."time"
                                  Sort Method: quicksort 
@@ -6805,7 +6805,7 @@ FROM :TEST_TABLE m1
                                        Sort Key: m2_3."time"
                                        Sort Method: quicksort 
                                        ->  Custom Scan (DecompressChunk) on _hyper_2_6_chunk m2_3 (actual rows=360 loops=1)
-                                             ->  Seq Scan on compress_hyper_6_19_chunk compress_hyper_6_19_chunk_1 (actual rows=1 loops=1)
+                                             ->  Seq Scan on compress_hyper_6_20_chunk compress_hyper_6_20_chunk_1 (actual rows=1 loops=1)
                      ->  Merge Append (never executed)
                            Sort Key: m2_4."time"
                            ->  Index Scan Backward using _hyper_2_7_chunk_metrics_space_time_idx on _hyper_2_7_chunk m2_4 (never executed)
@@ -6818,13 +6818,13 @@ FROM :TEST_TABLE m1
                                  ->  Sort (never executed)
                                        Sort Key: m2_7."time"
                                        ->  Custom Scan (DecompressChunk) on _hyper_2_10_chunk m2_7 (never executed)
-                                             ->  Seq Scan on compress_hyper_6_20_chunk compress_hyper_6_20_chunk_1 (never executed)
+                                             ->  Seq Scan on compress_hyper_6_24_chunk compress_hyper_6_24_chunk_1 (never executed)
                            ->  Sort (never executed)
                                  Sort Key: m2_8."time"
                                  ->  Sort (never executed)
                                        Sort Key: m2_8."time"
                                        ->  Custom Scan (DecompressChunk) on _hyper_2_11_chunk m2_8 (never executed)
-                                             ->  Seq Scan on compress_hyper_6_21_chunk compress_hyper_6_21_chunk_1 (never executed)
+                                             ->  Seq Scan on compress_hyper_6_25_chunk compress_hyper_6_25_chunk_1 (never executed)
                            ->  Index Scan Backward using _hyper_2_12_chunk_metrics_space_time_idx on _hyper_2_12_chunk m2_9 (never executed)
                ->  Materialize (actual rows=51 loops=1)
                      ->  Merge Join (actual rows=11 loops=1)
@@ -6835,7 +6835,7 @@ FROM :TEST_TABLE m1
                                        Sort Key: m3_1."time"
                                        Sort Method: quicksort 
                                        ->  Custom Scan (DecompressChunk) on _hyper_2_6_chunk m3_1 (actual rows=360 loops=1)
-                                             ->  Seq Scan on compress_hyper_6_19_chunk compress_hyper_6_19_chunk_2 (actual rows=1 loops=1)
+                                             ->  Seq Scan on compress_hyper_6_20_chunk compress_hyper_6_20_chunk_2 (actual rows=1 loops=1)
                                                    Filter: (device_id = 3)
                                  ->  Index Scan Backward using _hyper_2_9_chunk_metrics_space_time_idx on _hyper_2_9_chunk m3_2 (actual rows=1 loops=1)
                                        Filter: (device_id = 3)
@@ -6853,7 +6853,7 @@ FROM :TEST_TABLE m1
                                                          Sort Key: m1_1."time"
                                                          Sort Method: quicksort 
                                                          ->  Custom Scan (DecompressChunk) on _hyper_2_4_chunk m1_1 (actual rows=360 loops=1)
-                                                               ->  Seq Scan on compress_hyper_6_17_chunk (actual rows=1 loops=1)
+                                                               ->  Seq Scan on compress_hyper_6_18_chunk (actual rows=1 loops=1)
                                              ->  Sort (actual rows=7 loops=1)
                                                    Sort Key: m1_2."time"
                                                    Sort Method: quicksort 
@@ -6861,7 +6861,7 @@ FROM :TEST_TABLE m1
                                                          Sort Key: m1_2."time"
                                                          Sort Method: quicksort 
                                                          ->  Custom Scan (DecompressChunk) on _hyper_2_5_chunk m1_2 (actual rows=1080 loops=1)
-                                                               ->  Seq Scan on compress_hyper_6_18_chunk (actual rows=3 loops=1)
+                                                               ->  Seq Scan on compress_hyper_6_19_chunk (actual rows=3 loops=1)
                                              ->  Sort (actual rows=3 loops=1)
                                                    Sort Key: m1_3."time"
                                                    Sort Method: quicksort 
@@ -6869,7 +6869,7 @@ FROM :TEST_TABLE m1
                                                          Sort Key: m1_3."time"
                                                          Sort Method: quicksort 
                                                          ->  Custom Scan (DecompressChunk) on _hyper_2_6_chunk m1_3 (actual rows=360 loops=1)
-                                                               ->  Seq Scan on compress_hyper_6_19_chunk (actual rows=1 loops=1)
+                                                               ->  Seq Scan on compress_hyper_6_20_chunk (actual rows=1 loops=1)
                                        ->  Merge Append (never executed)
                                              Sort Key: m1_4."time"
                                              ->  Index Scan Backward using _hyper_2_7_chunk_metrics_space_time_idx on _hyper_2_7_chunk m1_4 (never executed)
@@ -6882,13 +6882,13 @@ FROM :TEST_TABLE m1
                                                    ->  Sort (never executed)
                                                          Sort Key: m1_7."time"
                                                          ->  Custom Scan (DecompressChunk) on _hyper_2_10_chunk m1_7 (never executed)
-                                                               ->  Seq Scan on compress_hyper_6_20_chunk (never executed)
+                                                               ->  Seq Scan on compress_hyper_6_24_chunk (never executed)
                                              ->  Sort (never executed)
                                                    Sort Key: m1_8."time"
                                                    ->  Sort (never executed)
                                                          Sort Key: m1_8."time"
                                                          ->  Custom Scan (DecompressChunk) on _hyper_2_11_chunk m1_8 (never executed)
-                                                               ->  Seq Scan on compress_hyper_6_21_chunk (never executed)
+                                                               ->  Seq Scan on compress_hyper_6_25_chunk (never executed)
                                              ->  Index Scan Backward using _hyper_2_12_chunk_metrics_space_time_idx on _hyper_2_12_chunk m1_9 (never executed)
 (121 rows)
 
@@ -6914,14 +6914,14 @@ FROM :TEST_TABLE m1
                      Sort Key: m1_1."time"
                      Sort Method: quicksort 
                      ->  Custom Scan (DecompressChunk) on _hyper_2_4_chunk m1_1 (actual rows=360 loops=1)
-                           ->  Seq Scan on compress_hyper_6_17_chunk (actual rows=1 loops=1)
+                           ->  Seq Scan on compress_hyper_6_18_chunk (actual rows=1 loops=1)
                                  Filter: (device_id = 1)
                ->  Index Scan Backward using _hyper_2_7_chunk_metrics_space_time_idx on _hyper_2_7_chunk m1_2 (never executed)
                      Filter: (device_id = 1)
                ->  Sort (never executed)
                      Sort Key: m1_3."time"
                      ->  Custom Scan (DecompressChunk) on _hyper_2_10_chunk m1_3 (never executed)
-                           ->  Seq Scan on compress_hyper_6_20_chunk (never executed)
+                           ->  Seq Scan on compress_hyper_6_24_chunk (never executed)
                                  Filter: (device_id = 1)
          ->  Materialize (actual rows=100 loops=1)
                ->  Custom Scan (ChunkAppend) on metrics_space m2 (actual rows=100 loops=1)
@@ -6930,7 +6930,7 @@ FROM :TEST_TABLE m1
                            Sort Key: m2_1."time"
                            Sort Method: quicksort 
                            ->  Custom Scan (DecompressChunk) on _hyper_2_5_chunk m2_1 (actual rows=360 loops=1)
-                                 ->  Seq Scan on compress_hyper_6_18_chunk (actual rows=1 loops=1)
+                                 ->  Seq Scan on compress_hyper_6_19_chunk (actual rows=1 loops=1)
                                        Filter: (device_id = 2)
                                        Rows Removed by Filter: 2
                      ->  Index Scan Backward using _hyper_2_8_chunk_metrics_space_device_id_time_idx on _hyper_2_8_chunk m2_2 (never executed)
@@ -6938,7 +6938,7 @@ FROM :TEST_TABLE m1
                      ->  Sort (never executed)
                            Sort Key: m2_3."time"
                            ->  Custom Scan (DecompressChunk) on _hyper_2_11_chunk m2_3 (never executed)
-                                 ->  Seq Scan on compress_hyper_6_21_chunk (never executed)
+                                 ->  Seq Scan on compress_hyper_6_25_chunk (never executed)
                                        Filter: (device_id = 2)
 (35 rows)
 
@@ -6972,7 +6972,7 @@ FROM metrics m1
                ->  Sort (never executed)
                      Sort Key: m1_3."time"
                      ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk m1_3 (never executed)
-                           ->  Seq Scan on compress_hyper_5_16_chunk (never executed)
+                           ->  Seq Scan on compress_hyper_5_17_chunk (never executed)
                                  Filter: (device_id = 1)
          ->  Materialize (actual rows=100 loops=1)
                ->  Custom Scan (ChunkAppend) on metrics_space m2 (actual rows=100 loops=1)
@@ -6981,7 +6981,7 @@ FROM metrics m1
                            Sort Key: m2_1."time"
                            Sort Method: quicksort 
                            ->  Custom Scan (DecompressChunk) on _hyper_2_5_chunk m2_1 (actual rows=360 loops=1)
-                                 ->  Seq Scan on compress_hyper_6_18_chunk (actual rows=1 loops=1)
+                                 ->  Seq Scan on compress_hyper_6_19_chunk (actual rows=1 loops=1)
                                        Filter: (device_id = 2)
                                        Rows Removed by Filter: 2
                      ->  Index Scan Backward using _hyper_2_8_chunk_metrics_space_device_id_time_idx on _hyper_2_8_chunk m2_2 (never executed)
@@ -6989,7 +6989,7 @@ FROM metrics m1
                      ->  Sort (never executed)
                            Sort Key: m2_3."time"
                            ->  Custom Scan (DecompressChunk) on _hyper_2_11_chunk m2_3 (never executed)
-                                 ->  Seq Scan on compress_hyper_6_21_chunk (never executed)
+                                 ->  Seq Scan on compress_hyper_6_25_chunk (never executed)
                                        Filter: (device_id = 2)
 (36 rows)
 
@@ -7024,7 +7024,7 @@ LIMIT 10;
                                        Sort Key: m1_1."time"
                                        Sort Method: quicksort 
                                        ->  Custom Scan (DecompressChunk) on _hyper_2_4_chunk m1_1 (actual rows=360 loops=1)
-                                             ->  Seq Scan on compress_hyper_6_17_chunk (actual rows=1 loops=1)
+                                             ->  Seq Scan on compress_hyper_6_18_chunk (actual rows=1 loops=1)
                            ->  Sort (actual rows=7 loops=1)
                                  Sort Key: m1_2."time"
                                  Sort Method: quicksort 
@@ -7032,7 +7032,7 @@ LIMIT 10;
                                        Sort Key: m1_2."time"
                                        Sort Method: quicksort 
                                        ->  Custom Scan (DecompressChunk) on _hyper_2_5_chunk m1_2 (actual rows=1080 loops=1)
-                                             ->  Seq Scan on compress_hyper_6_18_chunk (actual rows=3 loops=1)
+                                             ->  Seq Scan on compress_hyper_6_19_chunk (actual rows=3 loops=1)
                            ->  Sort (actual rows=3 loops=1)
                                  Sort Key: m1_3."time"
                                  Sort Method: quicksort 
@@ -7040,7 +7040,7 @@ LIMIT 10;
                                        Sort Key: m1_3."time"
                                        Sort Method: quicksort 
                                        ->  Custom Scan (DecompressChunk) on _hyper_2_6_chunk m1_3 (actual rows=360 loops=1)
-                                             ->  Seq Scan on compress_hyper_6_19_chunk (actual rows=1 loops=1)
+                                             ->  Seq Scan on compress_hyper_6_20_chunk (actual rows=1 loops=1)
                      ->  Merge Append (never executed)
                            Sort Key: m1_4."time"
                            ->  Index Scan Backward using _hyper_2_7_chunk_metrics_space_time_idx on _hyper_2_7_chunk m1_4 (never executed)
@@ -7053,13 +7053,13 @@ LIMIT 10;
                                  ->  Sort (never executed)
                                        Sort Key: m1_7."time"
                                        ->  Custom Scan (DecompressChunk) on _hyper_2_10_chunk m1_7 (never executed)
-                                             ->  Seq Scan on compress_hyper_6_20_chunk (never executed)
+                                             ->  Seq Scan on compress_hyper_6_24_chunk (never executed)
                            ->  Sort (never executed)
                                  Sort Key: m1_8."time"
                                  ->  Sort (never executed)
                                        Sort Key: m1_8."time"
                                        ->  Custom Scan (DecompressChunk) on _hyper_2_11_chunk m1_8 (never executed)
-                                             ->  Seq Scan on compress_hyper_6_21_chunk (never executed)
+                                             ->  Seq Scan on compress_hyper_6_25_chunk (never executed)
                            ->  Index Scan Backward using _hyper_2_12_chunk_metrics_space_time_idx on _hyper_2_12_chunk m1_9 (never executed)
                ->  Materialize (actual rows=51 loops=1)
                      ->  Custom Scan (ChunkAppend) on metrics_space m2 (actual rows=11 loops=1)
@@ -7073,7 +7073,7 @@ LIMIT 10;
                                              Sort Key: m2_1."time"
                                              Sort Method: quicksort 
                                              ->  Custom Scan (DecompressChunk) on _hyper_2_4_chunk m2_1 (actual rows=360 loops=1)
-                                                   ->  Seq Scan on compress_hyper_6_17_chunk compress_hyper_6_17_chunk_1 (actual rows=1 loops=1)
+                                                   ->  Seq Scan on compress_hyper_6_18_chunk compress_hyper_6_18_chunk_1 (actual rows=1 loops=1)
                                  ->  Sort (actual rows=7 loops=1)
                                        Sort Key: m2_2."time"
                                        Sort Method: quicksort 
@@ -7081,7 +7081,7 @@ LIMIT 10;
                                              Sort Key: m2_2."time"
                                              Sort Method: quicksort 
                                              ->  Custom Scan (DecompressChunk) on _hyper_2_5_chunk m2_2 (actual rows=1080 loops=1)
-                                                   ->  Seq Scan on compress_hyper_6_18_chunk compress_hyper_6_18_chunk_1 (actual rows=3 loops=1)
+                                                   ->  Seq Scan on compress_hyper_6_19_chunk compress_hyper_6_19_chunk_1 (actual rows=3 loops=1)
                                  ->  Sort (actual rows=3 loops=1)
                                        Sort Key: m2_3."time"
                                        Sort Method: quicksort 
@@ -7089,7 +7089,7 @@ LIMIT 10;
                                              Sort Key: m2_3."time"
                                              Sort Method: quicksort 
                                              ->  Custom Scan (DecompressChunk) on _hyper_2_6_chunk m2_3 (actual rows=360 loops=1)
-                                                   ->  Seq Scan on compress_hyper_6_19_chunk compress_hyper_6_19_chunk_1 (actual rows=1 loops=1)
+                                                   ->  Seq Scan on compress_hyper_6_20_chunk compress_hyper_6_20_chunk_1 (actual rows=1 loops=1)
                            ->  Merge Append (never executed)
                                  Sort Key: m2_4."time"
                                  ->  Index Scan Backward using _hyper_2_7_chunk_metrics_space_time_idx on _hyper_2_7_chunk m2_4 (never executed)
@@ -7102,13 +7102,13 @@ LIMIT 10;
                                        ->  Sort (never executed)
                                              Sort Key: m2_7."time"
                                              ->  Custom Scan (DecompressChunk) on _hyper_2_10_chunk m2_7 (never executed)
-                                                   ->  Seq Scan on compress_hyper_6_20_chunk compress_hyper_6_20_chunk_1 (never executed)
+                                                   ->  Seq Scan on compress_hyper_6_24_chunk compress_hyper_6_24_chunk_1 (never executed)
                                  ->  Sort (never executed)
                                        Sort Key: m2_8."time"
                                        ->  Sort (never executed)
                                              Sort Key: m2_8."time"
                                              ->  Custom Scan (DecompressChunk) on _hyper_2_11_chunk m2_8 (never executed)
-                                                   ->  Seq Scan on compress_hyper_6_21_chunk compress_hyper_6_21_chunk_1 (never executed)
+                                                   ->  Seq Scan on compress_hyper_6_25_chunk compress_hyper_6_25_chunk_1 (never executed)
                                  ->  Index Scan Backward using _hyper_2_12_chunk_metrics_space_time_idx on _hyper_2_12_chunk m2_9 (never executed)
 (106 rows)
 
@@ -7145,7 +7145,7 @@ LIMIT 100;
                                        Sort Key: m1_1."time"
                                        Sort Method: quicksort 
                                        ->  Custom Scan (DecompressChunk) on _hyper_2_4_chunk m1_1 (actual rows=360 loops=1)
-                                             ->  Seq Scan on compress_hyper_6_17_chunk (actual rows=1 loops=1)
+                                             ->  Seq Scan on compress_hyper_6_18_chunk (actual rows=1 loops=1)
                            ->  Sort (actual rows=61 loops=1)
                                  Sort Key: m1_2."time"
                                  Sort Method: quicksort 
@@ -7153,7 +7153,7 @@ LIMIT 100;
                                        Sort Key: m1_2."time"
                                        Sort Method: quicksort 
                                        ->  Custom Scan (DecompressChunk) on _hyper_2_5_chunk m1_2 (actual rows=1080 loops=1)
-                                             ->  Seq Scan on compress_hyper_6_18_chunk (actual rows=3 loops=1)
+                                             ->  Seq Scan on compress_hyper_6_19_chunk (actual rows=3 loops=1)
                            ->  Sort (actual rows=21 loops=1)
                                  Sort Key: m1_3."time"
                                  Sort Method: quicksort 
@@ -7161,7 +7161,7 @@ LIMIT 100;
                                        Sort Key: m1_3."time"
                                        Sort Method: quicksort 
                                        ->  Custom Scan (DecompressChunk) on _hyper_2_6_chunk m1_3 (actual rows=360 loops=1)
-                                             ->  Seq Scan on compress_hyper_6_19_chunk (actual rows=1 loops=1)
+                                             ->  Seq Scan on compress_hyper_6_20_chunk (actual rows=1 loops=1)
                      ->  Merge Append (never executed)
                            Sort Key: m1_4."time"
                            ->  Index Scan Backward using _hyper_2_7_chunk_metrics_space_time_idx on _hyper_2_7_chunk m1_4 (never executed)
@@ -7174,13 +7174,13 @@ LIMIT 100;
                                  ->  Sort (never executed)
                                        Sort Key: m1_7."time"
                                        ->  Custom Scan (DecompressChunk) on _hyper_2_10_chunk m1_7 (never executed)
-                                             ->  Seq Scan on compress_hyper_6_20_chunk (never executed)
+                                             ->  Seq Scan on compress_hyper_6_24_chunk (never executed)
                            ->  Sort (never executed)
                                  Sort Key: m1_8."time"
                                  ->  Sort (never executed)
                                        Sort Key: m1_8."time"
                                        ->  Custom Scan (DecompressChunk) on _hyper_2_11_chunk m1_8 (never executed)
-                                             ->  Seq Scan on compress_hyper_6_21_chunk (never executed)
+                                             ->  Seq Scan on compress_hyper_6_25_chunk (never executed)
                            ->  Index Scan Backward using _hyper_2_12_chunk_metrics_space_time_idx on _hyper_2_12_chunk m1_9 (never executed)
                ->  Materialize (actual rows=102 loops=1)
                      ->  Custom Scan (ChunkAppend) on metrics_space m2 (actual rows=22 loops=1)
@@ -7194,7 +7194,7 @@ LIMIT 100;
                                              Sort Key: m2_1."time"
                                              Sort Method: quicksort 
                                              ->  Custom Scan (DecompressChunk) on _hyper_2_4_chunk m2_1 (actual rows=0 loops=1)
-                                                   ->  Seq Scan on compress_hyper_6_17_chunk compress_hyper_6_17_chunk_1 (actual rows=0 loops=1)
+                                                   ->  Seq Scan on compress_hyper_6_18_chunk compress_hyper_6_18_chunk_1 (actual rows=0 loops=1)
                                                          Filter: (device_id = 2)
                                                          Rows Removed by Filter: 1
                                  ->  Sort (actual rows=22 loops=1)
@@ -7204,7 +7204,7 @@ LIMIT 100;
                                              Sort Key: m2_2."time"
                                              Sort Method: quicksort 
                                              ->  Custom Scan (DecompressChunk) on _hyper_2_5_chunk m2_2 (actual rows=360 loops=1)
-                                                   ->  Seq Scan on compress_hyper_6_18_chunk compress_hyper_6_18_chunk_1 (actual rows=1 loops=1)
+                                                   ->  Seq Scan on compress_hyper_6_19_chunk compress_hyper_6_19_chunk_1 (actual rows=1 loops=1)
                                                          Filter: (device_id = 2)
                                                          Rows Removed by Filter: 2
                                  ->  Sort (actual rows=0 loops=1)
@@ -7214,7 +7214,7 @@ LIMIT 100;
                                              Sort Key: m2_3."time"
                                              Sort Method: quicksort 
                                              ->  Custom Scan (DecompressChunk) on _hyper_2_6_chunk m2_3 (actual rows=0 loops=1)
-                                                   ->  Seq Scan on compress_hyper_6_19_chunk compress_hyper_6_19_chunk_1 (actual rows=0 loops=1)
+                                                   ->  Seq Scan on compress_hyper_6_20_chunk compress_hyper_6_20_chunk_1 (actual rows=0 loops=1)
                                                          Filter: (device_id = 2)
                                                          Rows Removed by Filter: 1
                            ->  Merge Append (never executed)
@@ -7232,14 +7232,14 @@ LIMIT 100;
                                        ->  Sort (never executed)
                                              Sort Key: m2_7."time"
                                              ->  Custom Scan (DecompressChunk) on _hyper_2_10_chunk m2_7 (never executed)
-                                                   ->  Seq Scan on compress_hyper_6_20_chunk compress_hyper_6_20_chunk_1 (never executed)
+                                                   ->  Seq Scan on compress_hyper_6_24_chunk compress_hyper_6_24_chunk_1 (never executed)
                                                          Filter: (device_id = 2)
                                  ->  Sort (never executed)
                                        Sort Key: m2_8."time"
                                        ->  Sort (never executed)
                                              Sort Key: m2_8."time"
                                              ->  Custom Scan (DecompressChunk) on _hyper_2_11_chunk m2_8 (never executed)
-                                                   ->  Seq Scan on compress_hyper_6_21_chunk compress_hyper_6_21_chunk_1 (never executed)
+                                                   ->  Seq Scan on compress_hyper_6_25_chunk compress_hyper_6_25_chunk_1 (never executed)
                                                          Filter: (device_id = 2)
                                  ->  Index Scan Backward using _hyper_2_12_chunk_metrics_space_time_idx on _hyper_2_12_chunk m2_9 (never executed)
                                        Filter: (device_id = 2)
@@ -7278,7 +7278,7 @@ LIMIT 100;
                      ->  Sort (never executed)
                            Sort Key: m1_3."time"
                            ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk m1_3 (never executed)
-                                 ->  Seq Scan on compress_hyper_5_16_chunk (never executed)
+                                 ->  Seq Scan on compress_hyper_5_17_chunk (never executed)
                ->  Materialize (actual rows=102 loops=1)
                      ->  Custom Scan (ChunkAppend) on metrics_space m2 (actual rows=22 loops=1)
                            Order: m2."time"
@@ -7291,7 +7291,7 @@ LIMIT 100;
                                              Sort Key: m2_1."time"
                                              Sort Method: quicksort 
                                              ->  Custom Scan (DecompressChunk) on _hyper_2_4_chunk m2_1 (actual rows=0 loops=1)
-                                                   ->  Seq Scan on compress_hyper_6_17_chunk (actual rows=0 loops=1)
+                                                   ->  Seq Scan on compress_hyper_6_18_chunk (actual rows=0 loops=1)
                                                          Filter: (device_id = 2)
                                                          Rows Removed by Filter: 1
                                  ->  Sort (actual rows=22 loops=1)
@@ -7301,7 +7301,7 @@ LIMIT 100;
                                              Sort Key: m2_2."time"
                                              Sort Method: quicksort 
                                              ->  Custom Scan (DecompressChunk) on _hyper_2_5_chunk m2_2 (actual rows=360 loops=1)
-                                                   ->  Seq Scan on compress_hyper_6_18_chunk (actual rows=1 loops=1)
+                                                   ->  Seq Scan on compress_hyper_6_19_chunk (actual rows=1 loops=1)
                                                          Filter: (device_id = 2)
                                                          Rows Removed by Filter: 2
                                  ->  Sort (actual rows=0 loops=1)
@@ -7311,7 +7311,7 @@ LIMIT 100;
                                              Sort Key: m2_3."time"
                                              Sort Method: quicksort 
                                              ->  Custom Scan (DecompressChunk) on _hyper_2_6_chunk m2_3 (actual rows=0 loops=1)
-                                                   ->  Seq Scan on compress_hyper_6_19_chunk (actual rows=0 loops=1)
+                                                   ->  Seq Scan on compress_hyper_6_20_chunk (actual rows=0 loops=1)
                                                          Filter: (device_id = 2)
                                                          Rows Removed by Filter: 1
                            ->  Merge Append (never executed)
@@ -7329,14 +7329,14 @@ LIMIT 100;
                                        ->  Sort (never executed)
                                              Sort Key: m2_7."time"
                                              ->  Custom Scan (DecompressChunk) on _hyper_2_10_chunk m2_7 (never executed)
-                                                   ->  Seq Scan on compress_hyper_6_20_chunk (never executed)
+                                                   ->  Seq Scan on compress_hyper_6_24_chunk (never executed)
                                                          Filter: (device_id = 2)
                                  ->  Sort (never executed)
                                        Sort Key: m2_8."time"
                                        ->  Sort (never executed)
                                              Sort Key: m2_8."time"
                                              ->  Custom Scan (DecompressChunk) on _hyper_2_11_chunk m2_8 (never executed)
-                                                   ->  Seq Scan on compress_hyper_6_21_chunk (never executed)
+                                                   ->  Seq Scan on compress_hyper_6_25_chunk (never executed)
                                                          Filter: (device_id = 2)
                                  ->  Index Scan Backward using _hyper_2_12_chunk_metrics_space_time_idx on _hyper_2_12_chunk m2_9 (never executed)
                                        Filter: (device_id = 2)
@@ -7373,7 +7373,7 @@ LIMIT 20;
                                        Sort Key: m1_1."time"
                                        Sort Method: quicksort 
                                        ->  Custom Scan (DecompressChunk) on _hyper_2_4_chunk m1_1 (actual rows=360 loops=1)
-                                             ->  Seq Scan on compress_hyper_6_17_chunk (actual rows=1 loops=1)
+                                             ->  Seq Scan on compress_hyper_6_18_chunk (actual rows=1 loops=1)
                            ->  Sort (actual rows=4 loops=1)
                                  Sort Key: m1_2."time"
                                  Sort Method: quicksort 
@@ -7381,7 +7381,7 @@ LIMIT 20;
                                        Sort Key: m1_2."time"
                                        Sort Method: quicksort 
                                        ->  Custom Scan (DecompressChunk) on _hyper_2_5_chunk m1_2 (actual rows=1080 loops=1)
-                                             ->  Seq Scan on compress_hyper_6_18_chunk (actual rows=3 loops=1)
+                                             ->  Seq Scan on compress_hyper_6_19_chunk (actual rows=3 loops=1)
                            ->  Sort (actual rows=2 loops=1)
                                  Sort Key: m1_3."time"
                                  Sort Method: quicksort 
@@ -7389,7 +7389,7 @@ LIMIT 20;
                                        Sort Key: m1_3."time"
                                        Sort Method: quicksort 
                                        ->  Custom Scan (DecompressChunk) on _hyper_2_6_chunk m1_3 (actual rows=360 loops=1)
-                                             ->  Seq Scan on compress_hyper_6_19_chunk (actual rows=1 loops=1)
+                                             ->  Seq Scan on compress_hyper_6_20_chunk (actual rows=1 loops=1)
                      ->  Merge Append (never executed)
                            Sort Key: m1_4."time"
                            ->  Index Scan Backward using _hyper_2_7_chunk_metrics_space_time_idx on _hyper_2_7_chunk m1_4 (never executed)
@@ -7402,13 +7402,13 @@ LIMIT 20;
                                  ->  Sort (never executed)
                                        Sort Key: m1_7."time"
                                        ->  Custom Scan (DecompressChunk) on _hyper_2_10_chunk m1_7 (never executed)
-                                             ->  Seq Scan on compress_hyper_6_20_chunk (never executed)
+                                             ->  Seq Scan on compress_hyper_6_24_chunk (never executed)
                            ->  Sort (never executed)
                                  Sort Key: m1_8."time"
                                  ->  Sort (never executed)
                                        Sort Key: m1_8."time"
                                        ->  Custom Scan (DecompressChunk) on _hyper_2_11_chunk m1_8 (never executed)
-                                             ->  Seq Scan on compress_hyper_6_21_chunk (never executed)
+                                             ->  Seq Scan on compress_hyper_6_25_chunk (never executed)
                            ->  Index Scan Backward using _hyper_2_12_chunk_metrics_space_time_idx on _hyper_2_12_chunk m1_9 (never executed)
                ->  Materialize (actual rows=26 loops=1)
                      ->  Custom Scan (ChunkAppend) on metrics_space m2 (actual rows=6 loops=1)
@@ -7422,7 +7422,7 @@ LIMIT 20;
                                              Sort Key: m2_1."time"
                                              Sort Method: quicksort 
                                              ->  Custom Scan (DecompressChunk) on _hyper_2_4_chunk m2_1 (actual rows=360 loops=1)
-                                                   ->  Seq Scan on compress_hyper_6_17_chunk compress_hyper_6_17_chunk_1 (actual rows=1 loops=1)
+                                                   ->  Seq Scan on compress_hyper_6_18_chunk compress_hyper_6_18_chunk_1 (actual rows=1 loops=1)
                                  ->  Sort (actual rows=4 loops=1)
                                        Sort Key: m2_2."time"
                                        Sort Method: quicksort 
@@ -7430,7 +7430,7 @@ LIMIT 20;
                                              Sort Key: m2_2."time"
                                              Sort Method: quicksort 
                                              ->  Custom Scan (DecompressChunk) on _hyper_2_5_chunk m2_2 (actual rows=1080 loops=1)
-                                                   ->  Seq Scan on compress_hyper_6_18_chunk compress_hyper_6_18_chunk_1 (actual rows=3 loops=1)
+                                                   ->  Seq Scan on compress_hyper_6_19_chunk compress_hyper_6_19_chunk_1 (actual rows=3 loops=1)
                                  ->  Sort (actual rows=2 loops=1)
                                        Sort Key: m2_3."time"
                                        Sort Method: quicksort 
@@ -7438,7 +7438,7 @@ LIMIT 20;
                                              Sort Key: m2_3."time"
                                              Sort Method: quicksort 
                                              ->  Custom Scan (DecompressChunk) on _hyper_2_6_chunk m2_3 (actual rows=360 loops=1)
-                                                   ->  Seq Scan on compress_hyper_6_19_chunk compress_hyper_6_19_chunk_1 (actual rows=1 loops=1)
+                                                   ->  Seq Scan on compress_hyper_6_20_chunk compress_hyper_6_20_chunk_1 (actual rows=1 loops=1)
                            ->  Merge Append (never executed)
                                  Sort Key: m2_4."time"
                                  ->  Index Scan Backward using _hyper_2_7_chunk_metrics_space_time_idx on _hyper_2_7_chunk m2_4 (never executed)
@@ -7451,13 +7451,13 @@ LIMIT 20;
                                        ->  Sort (never executed)
                                              Sort Key: m2_7."time"
                                              ->  Custom Scan (DecompressChunk) on _hyper_2_10_chunk m2_7 (never executed)
-                                                   ->  Seq Scan on compress_hyper_6_20_chunk compress_hyper_6_20_chunk_1 (never executed)
+                                                   ->  Seq Scan on compress_hyper_6_24_chunk compress_hyper_6_24_chunk_1 (never executed)
                                  ->  Sort (never executed)
                                        Sort Key: m2_8."time"
                                        ->  Sort (never executed)
                                              Sort Key: m2_8."time"
                                              ->  Custom Scan (DecompressChunk) on _hyper_2_11_chunk m2_8 (never executed)
-                                                   ->  Seq Scan on compress_hyper_6_21_chunk compress_hyper_6_21_chunk_1 (never executed)
+                                                   ->  Seq Scan on compress_hyper_6_25_chunk compress_hyper_6_25_chunk_1 (never executed)
                                  ->  Index Scan Backward using _hyper_2_12_chunk_metrics_space_time_idx on _hyper_2_12_chunk m2_9 (never executed)
 (104 rows)
 
@@ -7494,7 +7494,7 @@ LIMIT 10;
                                        Sort Key: m1_1."time"
                                        Sort Method: quicksort 
                                        ->  Custom Scan (DecompressChunk) on _hyper_2_4_chunk m1_1 (actual rows=360 loops=1)
-                                             ->  Seq Scan on compress_hyper_6_17_chunk (actual rows=1 loops=1)
+                                             ->  Seq Scan on compress_hyper_6_18_chunk (actual rows=1 loops=1)
                            ->  Sort (actual rows=4 loops=1)
                                  Sort Key: m1_2."time"
                                  Sort Method: quicksort 
@@ -7502,7 +7502,7 @@ LIMIT 10;
                                        Sort Key: m1_2."time"
                                        Sort Method: quicksort 
                                        ->  Custom Scan (DecompressChunk) on _hyper_2_5_chunk m1_2 (actual rows=1080 loops=1)
-                                             ->  Seq Scan on compress_hyper_6_18_chunk (actual rows=3 loops=1)
+                                             ->  Seq Scan on compress_hyper_6_19_chunk (actual rows=3 loops=1)
                            ->  Sort (actual rows=2 loops=1)
                                  Sort Key: m1_3."time"
                                  Sort Method: quicksort 
@@ -7510,7 +7510,7 @@ LIMIT 10;
                                        Sort Key: m1_3."time"
                                        Sort Method: quicksort 
                                        ->  Custom Scan (DecompressChunk) on _hyper_2_6_chunk m1_3 (actual rows=360 loops=1)
-                                             ->  Seq Scan on compress_hyper_6_19_chunk (actual rows=1 loops=1)
+                                             ->  Seq Scan on compress_hyper_6_20_chunk (actual rows=1 loops=1)
                      ->  Merge Append (never executed)
                            Sort Key: m1_4."time"
                            ->  Index Scan Backward using _hyper_2_7_chunk_metrics_space_time_idx on _hyper_2_7_chunk m1_4 (never executed)
@@ -7523,13 +7523,13 @@ LIMIT 10;
                                  ->  Sort (never executed)
                                        Sort Key: m1_7."time"
                                        ->  Custom Scan (DecompressChunk) on _hyper_2_10_chunk m1_7 (never executed)
-                                             ->  Seq Scan on compress_hyper_6_20_chunk (never executed)
+                                             ->  Seq Scan on compress_hyper_6_24_chunk (never executed)
                            ->  Sort (never executed)
                                  Sort Key: m1_8."time"
                                  ->  Sort (never executed)
                                        Sort Key: m1_8."time"
                                        ->  Custom Scan (DecompressChunk) on _hyper_2_11_chunk m1_8 (never executed)
-                                             ->  Seq Scan on compress_hyper_6_21_chunk (never executed)
+                                             ->  Seq Scan on compress_hyper_6_25_chunk (never executed)
                            ->  Index Scan Backward using _hyper_2_12_chunk_metrics_space_time_idx on _hyper_2_12_chunk m1_9 (never executed)
                ->  Materialize (actual rows=26 loops=1)
                      ->  Custom Scan (ChunkAppend) on metrics_space m2 (actual rows=6 loops=1)
@@ -7543,7 +7543,7 @@ LIMIT 10;
                                              Sort Key: m2_1."time"
                                              Sort Method: quicksort 
                                              ->  Custom Scan (DecompressChunk) on _hyper_2_4_chunk m2_1 (actual rows=360 loops=1)
-                                                   ->  Seq Scan on compress_hyper_6_17_chunk compress_hyper_6_17_chunk_1 (actual rows=1 loops=1)
+                                                   ->  Seq Scan on compress_hyper_6_18_chunk compress_hyper_6_18_chunk_1 (actual rows=1 loops=1)
                                  ->  Sort (actual rows=4 loops=1)
                                        Sort Key: m2_2."time"
                                        Sort Method: quicksort 
@@ -7551,7 +7551,7 @@ LIMIT 10;
                                              Sort Key: m2_2."time"
                                              Sort Method: quicksort 
                                              ->  Custom Scan (DecompressChunk) on _hyper_2_5_chunk m2_2 (actual rows=1080 loops=1)
-                                                   ->  Seq Scan on compress_hyper_6_18_chunk compress_hyper_6_18_chunk_1 (actual rows=3 loops=1)
+                                                   ->  Seq Scan on compress_hyper_6_19_chunk compress_hyper_6_19_chunk_1 (actual rows=3 loops=1)
                                  ->  Sort (actual rows=2 loops=1)
                                        Sort Key: m2_3."time"
                                        Sort Method: quicksort 
@@ -7559,7 +7559,7 @@ LIMIT 10;
                                              Sort Key: m2_3."time"
                                              Sort Method: quicksort 
                                              ->  Custom Scan (DecompressChunk) on _hyper_2_6_chunk m2_3 (actual rows=360 loops=1)
-                                                   ->  Seq Scan on compress_hyper_6_19_chunk compress_hyper_6_19_chunk_1 (actual rows=1 loops=1)
+                                                   ->  Seq Scan on compress_hyper_6_20_chunk compress_hyper_6_20_chunk_1 (actual rows=1 loops=1)
                            ->  Merge Append (never executed)
                                  Sort Key: m2_4."time"
                                  ->  Index Scan Backward using _hyper_2_7_chunk_metrics_space_time_idx on _hyper_2_7_chunk m2_4 (never executed)
@@ -7572,13 +7572,13 @@ LIMIT 10;
                                        ->  Sort (never executed)
                                              Sort Key: m2_7."time"
                                              ->  Custom Scan (DecompressChunk) on _hyper_2_10_chunk m2_7 (never executed)
-                                                   ->  Seq Scan on compress_hyper_6_20_chunk compress_hyper_6_20_chunk_1 (never executed)
+                                                   ->  Seq Scan on compress_hyper_6_24_chunk compress_hyper_6_24_chunk_1 (never executed)
                                  ->  Sort (never executed)
                                        Sort Key: m2_8."time"
                                        ->  Sort (never executed)
                                              Sort Key: m2_8."time"
                                              ->  Custom Scan (DecompressChunk) on _hyper_2_11_chunk m2_8 (never executed)
-                                                   ->  Seq Scan on compress_hyper_6_21_chunk compress_hyper_6_21_chunk_1 (never executed)
+                                                   ->  Seq Scan on compress_hyper_6_25_chunk compress_hyper_6_25_chunk_1 (never executed)
                                  ->  Index Scan Backward using _hyper_2_12_chunk_metrics_space_time_idx on _hyper_2_12_chunk m2_9 (never executed)
 (104 rows)
 
@@ -7600,15 +7600,15 @@ FROM generate_series('2000-01-01'::timestamptz, '2000-02-01'::timestamptz, '1d':
                ->  Custom Scan (DecompressChunk) on _hyper_2_4_chunk m1_1 (actual rows=1 loops=5)
                      Filter: ("time" = g."time")
                      Rows Removed by Filter: 168
-                     ->  Seq Scan on compress_hyper_6_17_chunk (actual rows=1 loops=5)
+                     ->  Seq Scan on compress_hyper_6_18_chunk (actual rows=1 loops=5)
                            Filter: ((_ts_meta_min_3 <= g."time") AND (_ts_meta_max_3 >= g."time"))
                ->  Custom Scan (DecompressChunk) on _hyper_2_5_chunk m1_2 (never executed)
                      Filter: ("time" = g."time")
-                     ->  Seq Scan on compress_hyper_6_18_chunk (never executed)
+                     ->  Seq Scan on compress_hyper_6_19_chunk (never executed)
                            Filter: ((_ts_meta_min_3 <= g."time") AND (_ts_meta_max_3 >= g."time"))
                ->  Custom Scan (DecompressChunk) on _hyper_2_6_chunk m1_3 (never executed)
                      Filter: ("time" = g."time")
-                     ->  Seq Scan on compress_hyper_6_19_chunk (never executed)
+                     ->  Seq Scan on compress_hyper_6_20_chunk (never executed)
                            Filter: ((_ts_meta_min_3 <= g."time") AND (_ts_meta_max_3 >= g."time"))
                ->  Index Only Scan using _hyper_2_7_chunk_metrics_space_time_idx on _hyper_2_7_chunk m1_4 (actual rows=1 loops=7)
                      Index Cond: ("time" = g."time")
@@ -7622,11 +7622,11 @@ FROM generate_series('2000-01-01'::timestamptz, '2000-02-01'::timestamptz, '1d':
                ->  Custom Scan (DecompressChunk) on _hyper_2_10_chunk m1_7 (actual rows=1 loops=7)
                      Filter: ("time" = g."time")
                      Rows Removed by Filter: 240
-                     ->  Seq Scan on compress_hyper_6_20_chunk (actual rows=1 loops=7)
+                     ->  Seq Scan on compress_hyper_6_24_chunk (actual rows=1 loops=7)
                            Filter: ((_ts_meta_min_3 <= g."time") AND (_ts_meta_max_3 >= g."time"))
                ->  Custom Scan (DecompressChunk) on _hyper_2_11_chunk m1_8 (never executed)
                      Filter: ("time" = g."time")
-                     ->  Seq Scan on compress_hyper_6_21_chunk (never executed)
+                     ->  Seq Scan on compress_hyper_6_25_chunk (never executed)
                            Filter: ((_ts_meta_min_3 <= g."time") AND (_ts_meta_max_3 >= g."time"))
                ->  Index Only Scan using _hyper_2_12_chunk_metrics_space_time_idx on _hyper_2_12_chunk m1_9 (never executed)
                      Index Cond: ("time" = g."time")
@@ -7654,7 +7654,7 @@ FROM generate_series('2000-01-01'::timestamptz, '2000-02-01'::timestamptz, '1d':
                ->  Custom Scan (DecompressChunk) on _hyper_2_4_chunk m1_1 (actual rows=1 loops=5)
                      Filter: ("time" = g."time")
                      Rows Removed by Filter: 168
-                     ->  Seq Scan on compress_hyper_6_17_chunk (actual rows=1 loops=5)
+                     ->  Seq Scan on compress_hyper_6_18_chunk (actual rows=1 loops=5)
                            Filter: ((_ts_meta_min_3 <= g."time") AND (_ts_meta_max_3 >= g."time") AND (device_id = 1))
                ->  Index Only Scan using _hyper_2_7_chunk_metrics_space_device_id_time_idx on _hyper_2_7_chunk m1_2 (actual rows=1 loops=7)
                      Index Cond: ((device_id = 1) AND ("time" = g."time"))
@@ -7662,7 +7662,7 @@ FROM generate_series('2000-01-01'::timestamptz, '2000-02-01'::timestamptz, '1d':
                ->  Custom Scan (DecompressChunk) on _hyper_2_10_chunk m1_3 (actual rows=1 loops=7)
                      Filter: ("time" = g."time")
                      Rows Removed by Filter: 240
-                     ->  Seq Scan on compress_hyper_6_20_chunk (actual rows=1 loops=7)
+                     ->  Seq Scan on compress_hyper_6_24_chunk (actual rows=1 loops=7)
                            Filter: ((_ts_meta_min_3 <= g."time") AND (_ts_meta_max_3 >= g."time") AND (device_id = 1))
 (18 rows)
 
@@ -7677,7 +7677,7 @@ FROM generate_series('2000-01-01'::timestamptz, '2000-02-01'::timestamptz, '1d':
                ->  Custom Scan (DecompressChunk) on _hyper_2_5_chunk m1_1 (actual rows=1 loops=5)
                      Filter: ("time" = g."time")
                      Rows Removed by Filter: 168
-                     ->  Seq Scan on compress_hyper_6_18_chunk (actual rows=1 loops=5)
+                     ->  Seq Scan on compress_hyper_6_19_chunk (actual rows=1 loops=5)
                            Filter: ((_ts_meta_min_3 <= g."time") AND (_ts_meta_max_3 >= g."time") AND (device_id = 2))
                ->  Index Only Scan using _hyper_2_8_chunk_metrics_space_device_id_time_idx on _hyper_2_8_chunk m1_2 (actual rows=1 loops=7)
                      Index Cond: ((device_id = 2) AND ("time" = g."time"))
@@ -7685,7 +7685,7 @@ FROM generate_series('2000-01-01'::timestamptz, '2000-02-01'::timestamptz, '1d':
                ->  Custom Scan (DecompressChunk) on _hyper_2_11_chunk m1_3 (actual rows=1 loops=7)
                      Filter: ("time" = g."time")
                      Rows Removed by Filter: 240
-                     ->  Seq Scan on compress_hyper_6_21_chunk (actual rows=1 loops=7)
+                     ->  Seq Scan on compress_hyper_6_25_chunk (actual rows=1 loops=7)
                            Filter: ((_ts_meta_min_3 <= g."time") AND (_ts_meta_max_3 >= g."time") AND (device_id = 2))
 (18 rows)
 
@@ -7850,18 +7850,18 @@ WHERE metrics.time > metrics_space.time
  Nested Loop (actual rows=0 loops=1)
    ->  Append (actual rows=6840 loops=1)
          ->  Custom Scan (DecompressChunk) on _hyper_2_4_chunk (actual rows=360 loops=1)
-               ->  Index Scan using compress_hyper_6_17_chunk_c_space_index_2 on compress_hyper_6_17_chunk (actual rows=1 loops=1)
+               ->  Index Scan using compress_hyper_6_18_chunk_c_space_index_2 on compress_hyper_6_18_chunk (actual rows=1 loops=1)
          ->  Custom Scan (DecompressChunk) on _hyper_2_5_chunk (actual rows=1080 loops=1)
-               ->  Index Scan using compress_hyper_6_18_chunk_c_space_index_2 on compress_hyper_6_18_chunk (actual rows=3 loops=1)
+               ->  Index Scan using compress_hyper_6_19_chunk_c_space_index_2 on compress_hyper_6_19_chunk (actual rows=3 loops=1)
          ->  Custom Scan (DecompressChunk) on _hyper_2_6_chunk (actual rows=360 loops=1)
-               ->  Index Scan using compress_hyper_6_19_chunk_c_space_index_2 on compress_hyper_6_19_chunk (actual rows=1 loops=1)
+               ->  Index Scan using compress_hyper_6_20_chunk_c_space_index_2 on compress_hyper_6_20_chunk (actual rows=1 loops=1)
          ->  Index Scan Backward using _hyper_2_7_chunk_metrics_space_device_id_device_id_peer_v0_v1_2 on _hyper_2_7_chunk (actual rows=504 loops=1)
          ->  Index Scan Backward using _hyper_2_8_chunk_metrics_space_device_id_device_id_peer_v0_v1_2 on _hyper_2_8_chunk (actual rows=1512 loops=1)
          ->  Index Scan Backward using _hyper_2_9_chunk_metrics_space_device_id_device_id_peer_v0_v1_2 on _hyper_2_9_chunk (actual rows=504 loops=1)
          ->  Custom Scan (DecompressChunk) on _hyper_2_10_chunk (actual rows=504 loops=1)
-               ->  Index Scan using compress_hyper_6_20_chunk_c_space_index_2 on compress_hyper_6_20_chunk (actual rows=1 loops=1)
+               ->  Index Scan using compress_hyper_6_24_chunk_c_space_index_2 on compress_hyper_6_24_chunk (actual rows=1 loops=1)
          ->  Custom Scan (DecompressChunk) on _hyper_2_11_chunk (actual rows=1512 loops=1)
-               ->  Index Scan using compress_hyper_6_21_chunk_c_space_index_2 on compress_hyper_6_21_chunk (actual rows=3 loops=1)
+               ->  Index Scan using compress_hyper_6_25_chunk_c_space_index_2 on compress_hyper_6_25_chunk (actual rows=3 loops=1)
          ->  Index Scan Backward using _hyper_2_12_chunk_metrics_space_device_id_device_id_peer_v0_v_2 on _hyper_2_12_chunk (actual rows=504 loops=1)
    ->  Append (actual rows=0 loops=6840)
          ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk (actual rows=0 loops=6840)
@@ -7875,7 +7875,7 @@ WHERE metrics.time > metrics_space.time
          ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk (actual rows=0 loops=6840)
                Filter: (("time" > _hyper_2_4_chunk."time") AND ("time" < _hyper_2_4_chunk."time"))
                Rows Removed by Filter: 504
-               ->  Index Scan using compress_hyper_5_16_chunk_c_index_2 on compress_hyper_5_16_chunk (actual rows=1 loops=6840)
+               ->  Index Scan using compress_hyper_5_17_chunk_c_index_2 on compress_hyper_5_17_chunk (actual rows=1 loops=6840)
                      Index Cond: (device_id = _hyper_2_4_chunk.device_id)
 (30 rows)
 
@@ -7912,9 +7912,9 @@ WHERE ht.table_name = 'metrics_ordered'
 ORDER BY c.id;
               compress_chunk              
 ------------------------------------------
- _timescaledb_internal._hyper_11_26_chunk
- _timescaledb_internal._hyper_11_27_chunk
- _timescaledb_internal._hyper_11_28_chunk
+ _timescaledb_internal._hyper_11_31_chunk
+ _timescaledb_internal._hyper_11_33_chunk
+ _timescaledb_internal._hyper_11_35_chunk
 (3 rows)
 
 -- reindexing compressed hypertable to update statistics
@@ -7938,19 +7938,19 @@ $$;
  Limit (actual rows=10 loops=1)
    ->  Custom Scan (ChunkAppend) on metrics_ordered (actual rows=10 loops=1)
          Order: metrics_ordered."time" DESC
-         ->  Custom Scan (DecompressChunk) on _hyper_11_28_chunk (actual rows=10 loops=1)
+         ->  Custom Scan (DecompressChunk) on _hyper_11_35_chunk (actual rows=10 loops=1)
                ->  Sort (actual rows=5 loops=1)
-                     Sort Key: compress_hyper_12_31_chunk._ts_meta_max_1 DESC
+                     Sort Key: compress_hyper_12_36_chunk._ts_meta_max_1 DESC
                      Sort Method: quicksort 
-                     ->  Seq Scan on compress_hyper_12_31_chunk (actual rows=5 loops=1)
-         ->  Custom Scan (DecompressChunk) on _hyper_11_27_chunk (never executed)
+                     ->  Seq Scan on compress_hyper_12_36_chunk (actual rows=5 loops=1)
+         ->  Custom Scan (DecompressChunk) on _hyper_11_33_chunk (never executed)
                ->  Sort (never executed)
-                     Sort Key: compress_hyper_12_30_chunk._ts_meta_max_1 DESC
-                     ->  Seq Scan on compress_hyper_12_30_chunk (never executed)
-         ->  Custom Scan (DecompressChunk) on _hyper_11_26_chunk (never executed)
+                     Sort Key: compress_hyper_12_34_chunk._ts_meta_max_1 DESC
+                     ->  Seq Scan on compress_hyper_12_34_chunk (never executed)
+         ->  Custom Scan (DecompressChunk) on _hyper_11_31_chunk (never executed)
                ->  Sort (never executed)
-                     Sort Key: compress_hyper_12_29_chunk._ts_meta_max_1 DESC
-                     ->  Seq Scan on compress_hyper_12_29_chunk (never executed)
+                     Sort Key: compress_hyper_12_32_chunk._ts_meta_max_1 DESC
+                     ->  Seq Scan on compress_hyper_12_32_chunk (never executed)
 (16 rows)
 
 -- should have ordered DecompressChunk path because segmentby columns have equality constraints
@@ -7960,25 +7960,25 @@ $$;
  Limit (actual rows=0 loops=1)
    ->  Custom Scan (ChunkAppend) on metrics_ordered (actual rows=0 loops=1)
          Order: metrics_ordered."time" DESC
-         ->  Custom Scan (DecompressChunk) on _hyper_11_28_chunk (actual rows=0 loops=1)
+         ->  Custom Scan (DecompressChunk) on _hyper_11_35_chunk (actual rows=0 loops=1)
                ->  Sort (actual rows=0 loops=1)
-                     Sort Key: compress_hyper_12_31_chunk._ts_meta_sequence_num
+                     Sort Key: compress_hyper_12_36_chunk._ts_meta_sequence_num
                      Sort Method: quicksort 
-                     ->  Seq Scan on compress_hyper_12_31_chunk (actual rows=0 loops=1)
+                     ->  Seq Scan on compress_hyper_12_36_chunk (actual rows=0 loops=1)
                            Filter: ((device_id = 1) AND (device_id_peer = 3))
                            Rows Removed by Filter: 5
-         ->  Custom Scan (DecompressChunk) on _hyper_11_27_chunk (actual rows=0 loops=1)
+         ->  Custom Scan (DecompressChunk) on _hyper_11_33_chunk (actual rows=0 loops=1)
                ->  Sort (actual rows=0 loops=1)
-                     Sort Key: compress_hyper_12_30_chunk._ts_meta_sequence_num
+                     Sort Key: compress_hyper_12_34_chunk._ts_meta_sequence_num
                      Sort Method: quicksort 
-                     ->  Seq Scan on compress_hyper_12_30_chunk (actual rows=0 loops=1)
+                     ->  Seq Scan on compress_hyper_12_34_chunk (actual rows=0 loops=1)
                            Filter: ((device_id = 1) AND (device_id_peer = 3))
                            Rows Removed by Filter: 5
-         ->  Custom Scan (DecompressChunk) on _hyper_11_26_chunk (actual rows=0 loops=1)
+         ->  Custom Scan (DecompressChunk) on _hyper_11_31_chunk (actual rows=0 loops=1)
                ->  Sort (actual rows=0 loops=1)
-                     Sort Key: compress_hyper_12_29_chunk._ts_meta_sequence_num
+                     Sort Key: compress_hyper_12_32_chunk._ts_meta_sequence_num
                      Sort Method: quicksort 
-                     ->  Seq Scan on compress_hyper_12_29_chunk (actual rows=0 loops=1)
+                     ->  Seq Scan on compress_hyper_12_32_chunk (actual rows=0 loops=1)
                            Filter: ((device_id = 1) AND (device_id_peer = 3))
                            Rows Removed by Filter: 5
 (24 rows)
@@ -7990,35 +7990,35 @@ $$;
    ->  Nested Loop (actual rows=0 loops=1)
          ->  Merge Append (actual rows=6840 loops=1)
                Sort Key: d_1.device_id
-               ->  Custom Scan (DecompressChunk) on _hyper_11_26_chunk d_1 (actual rows=1800 loops=1)
-                     ->  Index Scan using compress_hyper_12_29_chunk__compressed_hypertable_12_device_id_ on compress_hyper_12_29_chunk (actual rows=5 loops=1)
-               ->  Custom Scan (DecompressChunk) on _hyper_11_27_chunk d_2 (actual rows=2520 loops=1)
-                     ->  Index Scan using compress_hyper_12_30_chunk__compressed_hypertable_12_device_id_ on compress_hyper_12_30_chunk (actual rows=5 loops=1)
-               ->  Custom Scan (DecompressChunk) on _hyper_11_28_chunk d_3 (actual rows=2520 loops=1)
-                     ->  Index Scan using compress_hyper_12_31_chunk__compressed_hypertable_12_device_id_ on compress_hyper_12_31_chunk (actual rows=5 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_11_31_chunk d_1 (actual rows=1800 loops=1)
+                     ->  Index Scan using compress_hyper_12_32_chunk__compressed_hypertable_12_device_id_ on compress_hyper_12_32_chunk (actual rows=5 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_11_33_chunk d_2 (actual rows=2520 loops=1)
+                     ->  Index Scan using compress_hyper_12_34_chunk__compressed_hypertable_12_device_id_ on compress_hyper_12_34_chunk (actual rows=5 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_11_35_chunk d_3 (actual rows=2520 loops=1)
+                     ->  Index Scan using compress_hyper_12_36_chunk__compressed_hypertable_12_device_id_ on compress_hyper_12_36_chunk (actual rows=5 loops=1)
          ->  Limit (actual rows=0 loops=6840)
                ->  Custom Scan (ChunkAppend) on metrics_ordered m (actual rows=0 loops=6840)
                      Order: m."time" DESC
                      Hypertables excluded during runtime: 0
-                     ->  Custom Scan (DecompressChunk) on _hyper_11_28_chunk m_1 (actual rows=0 loops=6840)
+                     ->  Custom Scan (DecompressChunk) on _hyper_11_35_chunk m_1 (actual rows=0 loops=6840)
                            ->  Sort (actual rows=0 loops=6840)
-                                 Sort Key: compress_hyper_12_31_chunk_1._ts_meta_sequence_num
+                                 Sort Key: compress_hyper_12_36_chunk_1._ts_meta_sequence_num
                                  Sort Method: quicksort 
-                                 ->  Seq Scan on compress_hyper_12_31_chunk compress_hyper_12_31_chunk_1 (actual rows=0 loops=6840)
+                                 ->  Seq Scan on compress_hyper_12_36_chunk compress_hyper_12_36_chunk_1 (actual rows=0 loops=6840)
                                        Filter: ((device_id = d_1.device_id) AND (device_id_peer = 3))
                                        Rows Removed by Filter: 5
-                     ->  Custom Scan (DecompressChunk) on _hyper_11_27_chunk m_2 (actual rows=0 loops=6840)
+                     ->  Custom Scan (DecompressChunk) on _hyper_11_33_chunk m_2 (actual rows=0 loops=6840)
                            ->  Sort (actual rows=0 loops=6840)
-                                 Sort Key: compress_hyper_12_30_chunk_1._ts_meta_sequence_num
+                                 Sort Key: compress_hyper_12_34_chunk_1._ts_meta_sequence_num
                                  Sort Method: quicksort 
-                                 ->  Seq Scan on compress_hyper_12_30_chunk compress_hyper_12_30_chunk_1 (actual rows=0 loops=6840)
+                                 ->  Seq Scan on compress_hyper_12_34_chunk compress_hyper_12_34_chunk_1 (actual rows=0 loops=6840)
                                        Filter: ((device_id = d_1.device_id) AND (device_id_peer = 3))
                                        Rows Removed by Filter: 5
-                     ->  Custom Scan (DecompressChunk) on _hyper_11_26_chunk m_3 (actual rows=0 loops=6840)
+                     ->  Custom Scan (DecompressChunk) on _hyper_11_31_chunk m_3 (actual rows=0 loops=6840)
                            ->  Sort (actual rows=0 loops=6840)
-                                 Sort Key: compress_hyper_12_29_chunk_1._ts_meta_sequence_num
+                                 Sort Key: compress_hyper_12_32_chunk_1._ts_meta_sequence_num
                                  Sort Method: quicksort 
-                                 ->  Seq Scan on compress_hyper_12_29_chunk compress_hyper_12_29_chunk_1 (actual rows=0 loops=6840)
+                                 ->  Seq Scan on compress_hyper_12_32_chunk compress_hyper_12_32_chunk_1 (actual rows=0 loops=6840)
                                        Filter: ((device_id = d_1.device_id) AND (device_id_peer = 3))
                                        Rows Removed by Filter: 5
 (35 rows)
@@ -8098,7 +8098,7 @@ PREPARE tableoid_prep AS SELECT tableoid::regclass FROM :TEST_TABLE WHERE device
          ->  Sort (never executed)
                Sort Key: _hyper_1_3_chunk."time"
                ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk (never executed)
-                     ->  Seq Scan on compress_hyper_5_16_chunk (never executed)
+                     ->  Seq Scan on compress_hyper_5_17_chunk (never executed)
                            Filter: (device_id = 1)
 (17 rows)
 
@@ -8155,7 +8155,7 @@ INSERT into readings select g, 1, 1.3 from generate_series('2001-03-01 01:01:01'
 SELECT count(compress_chunk(chunk.schema_name|| '.' || chunk.table_name))
 FROM _timescaledb_catalog.chunk chunk
 INNER JOIN _timescaledb_catalog.hypertable hypertable ON (chunk.hypertable_id = hypertable.id)
-WHERE hypertable.table_name = 'readings' and chunk.compressed_chunk_id IS NULL;
+WHERE hypertable.table_name = 'readings' and chunk.status & 1 = 0;
  count 
 -------
    703
@@ -8165,1419 +8165,1419 @@ EXPLAIN (costs off) SELECT t.fleet as fleet, min(r.fuel_consumption) AS avg_fuel
 FROM tags t
 INNER JOIN LATERAL(SELECT tags_id, fuel_consumption FROM readings r WHERE r.tags_id = t.id ) r ON true
 GROUP BY fleet;
-                                  QUERY PLAN                                  
-------------------------------------------------------------------------------
+                                  QUERY PLAN                                   
+-------------------------------------------------------------------------------
  HashAggregate
    Group Key: t.fleet
    ->  Hash Join
          Hash Cond: (r_1.tags_id = t.id)
          ->  Append
-               ->  Custom Scan (DecompressChunk) on _hyper_13_32_chunk r_1
-                     ->  Seq Scan on compress_hyper_14_735_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_33_chunk r_2
+               ->  Custom Scan (DecompressChunk) on _hyper_13_37_chunk r_1
+                     ->  Seq Scan on compress_hyper_14_38_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_39_chunk r_2
+                     ->  Seq Scan on compress_hyper_14_40_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_41_chunk r_3
+                     ->  Seq Scan on compress_hyper_14_42_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_43_chunk r_4
+                     ->  Seq Scan on compress_hyper_14_44_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_45_chunk r_5
+                     ->  Seq Scan on compress_hyper_14_46_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_47_chunk r_6
+                     ->  Seq Scan on compress_hyper_14_48_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_49_chunk r_7
+                     ->  Seq Scan on compress_hyper_14_50_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_51_chunk r_8
+                     ->  Seq Scan on compress_hyper_14_52_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_53_chunk r_9
+                     ->  Seq Scan on compress_hyper_14_54_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_55_chunk r_10
+                     ->  Seq Scan on compress_hyper_14_56_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_57_chunk r_11
+                     ->  Seq Scan on compress_hyper_14_58_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_59_chunk r_12
+                     ->  Seq Scan on compress_hyper_14_60_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_61_chunk r_13
+                     ->  Seq Scan on compress_hyper_14_62_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_63_chunk r_14
+                     ->  Seq Scan on compress_hyper_14_64_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_65_chunk r_15
+                     ->  Seq Scan on compress_hyper_14_66_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_67_chunk r_16
+                     ->  Seq Scan on compress_hyper_14_68_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_69_chunk r_17
+                     ->  Seq Scan on compress_hyper_14_70_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_71_chunk r_18
+                     ->  Seq Scan on compress_hyper_14_72_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_73_chunk r_19
+                     ->  Seq Scan on compress_hyper_14_74_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_75_chunk r_20
+                     ->  Seq Scan on compress_hyper_14_76_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_77_chunk r_21
+                     ->  Seq Scan on compress_hyper_14_78_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_79_chunk r_22
+                     ->  Seq Scan on compress_hyper_14_80_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_81_chunk r_23
+                     ->  Seq Scan on compress_hyper_14_82_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_83_chunk r_24
+                     ->  Seq Scan on compress_hyper_14_84_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_85_chunk r_25
+                     ->  Seq Scan on compress_hyper_14_86_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_87_chunk r_26
+                     ->  Seq Scan on compress_hyper_14_88_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_89_chunk r_27
+                     ->  Seq Scan on compress_hyper_14_90_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_91_chunk r_28
+                     ->  Seq Scan on compress_hyper_14_92_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_93_chunk r_29
+                     ->  Seq Scan on compress_hyper_14_94_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_95_chunk r_30
+                     ->  Seq Scan on compress_hyper_14_96_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_97_chunk r_31
+                     ->  Seq Scan on compress_hyper_14_98_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_99_chunk r_32
+                     ->  Seq Scan on compress_hyper_14_100_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_101_chunk r_33
+                     ->  Seq Scan on compress_hyper_14_102_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_103_chunk r_34
+                     ->  Seq Scan on compress_hyper_14_104_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_105_chunk r_35
+                     ->  Seq Scan on compress_hyper_14_106_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_107_chunk r_36
+                     ->  Seq Scan on compress_hyper_14_108_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_109_chunk r_37
+                     ->  Seq Scan on compress_hyper_14_110_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_111_chunk r_38
+                     ->  Seq Scan on compress_hyper_14_112_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_113_chunk r_39
+                     ->  Seq Scan on compress_hyper_14_114_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_115_chunk r_40
+                     ->  Seq Scan on compress_hyper_14_116_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_117_chunk r_41
+                     ->  Seq Scan on compress_hyper_14_118_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_119_chunk r_42
+                     ->  Seq Scan on compress_hyper_14_120_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_121_chunk r_43
+                     ->  Seq Scan on compress_hyper_14_122_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_123_chunk r_44
+                     ->  Seq Scan on compress_hyper_14_124_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_125_chunk r_45
+                     ->  Seq Scan on compress_hyper_14_126_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_127_chunk r_46
+                     ->  Seq Scan on compress_hyper_14_128_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_129_chunk r_47
+                     ->  Seq Scan on compress_hyper_14_130_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_131_chunk r_48
+                     ->  Seq Scan on compress_hyper_14_132_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_133_chunk r_49
+                     ->  Seq Scan on compress_hyper_14_134_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_135_chunk r_50
+                     ->  Seq Scan on compress_hyper_14_136_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_137_chunk r_51
+                     ->  Seq Scan on compress_hyper_14_138_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_139_chunk r_52
+                     ->  Seq Scan on compress_hyper_14_140_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_141_chunk r_53
+                     ->  Seq Scan on compress_hyper_14_142_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_143_chunk r_54
+                     ->  Seq Scan on compress_hyper_14_144_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_145_chunk r_55
+                     ->  Seq Scan on compress_hyper_14_146_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_147_chunk r_56
+                     ->  Seq Scan on compress_hyper_14_148_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_149_chunk r_57
+                     ->  Seq Scan on compress_hyper_14_150_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_151_chunk r_58
+                     ->  Seq Scan on compress_hyper_14_152_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_153_chunk r_59
+                     ->  Seq Scan on compress_hyper_14_154_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_155_chunk r_60
+                     ->  Seq Scan on compress_hyper_14_156_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_157_chunk r_61
+                     ->  Seq Scan on compress_hyper_14_158_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_159_chunk r_62
+                     ->  Seq Scan on compress_hyper_14_160_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_161_chunk r_63
+                     ->  Seq Scan on compress_hyper_14_162_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_163_chunk r_64
+                     ->  Seq Scan on compress_hyper_14_164_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_165_chunk r_65
+                     ->  Seq Scan on compress_hyper_14_166_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_167_chunk r_66
+                     ->  Seq Scan on compress_hyper_14_168_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_169_chunk r_67
+                     ->  Seq Scan on compress_hyper_14_170_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_171_chunk r_68
+                     ->  Seq Scan on compress_hyper_14_172_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_173_chunk r_69
+                     ->  Seq Scan on compress_hyper_14_174_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_175_chunk r_70
+                     ->  Seq Scan on compress_hyper_14_176_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_177_chunk r_71
+                     ->  Seq Scan on compress_hyper_14_178_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_179_chunk r_72
+                     ->  Seq Scan on compress_hyper_14_180_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_181_chunk r_73
+                     ->  Seq Scan on compress_hyper_14_182_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_183_chunk r_74
+                     ->  Seq Scan on compress_hyper_14_184_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_185_chunk r_75
+                     ->  Seq Scan on compress_hyper_14_186_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_187_chunk r_76
+                     ->  Seq Scan on compress_hyper_14_188_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_189_chunk r_77
+                     ->  Seq Scan on compress_hyper_14_190_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_191_chunk r_78
+                     ->  Seq Scan on compress_hyper_14_192_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_193_chunk r_79
+                     ->  Seq Scan on compress_hyper_14_194_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_195_chunk r_80
+                     ->  Seq Scan on compress_hyper_14_196_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_197_chunk r_81
+                     ->  Seq Scan on compress_hyper_14_198_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_199_chunk r_82
+                     ->  Seq Scan on compress_hyper_14_200_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_201_chunk r_83
+                     ->  Seq Scan on compress_hyper_14_202_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_203_chunk r_84
+                     ->  Seq Scan on compress_hyper_14_204_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_205_chunk r_85
+                     ->  Seq Scan on compress_hyper_14_206_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_207_chunk r_86
+                     ->  Seq Scan on compress_hyper_14_208_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_209_chunk r_87
+                     ->  Seq Scan on compress_hyper_14_210_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_211_chunk r_88
+                     ->  Seq Scan on compress_hyper_14_212_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_213_chunk r_89
+                     ->  Seq Scan on compress_hyper_14_214_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_215_chunk r_90
+                     ->  Seq Scan on compress_hyper_14_216_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_217_chunk r_91
+                     ->  Seq Scan on compress_hyper_14_218_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_219_chunk r_92
+                     ->  Seq Scan on compress_hyper_14_220_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_221_chunk r_93
+                     ->  Seq Scan on compress_hyper_14_222_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_223_chunk r_94
+                     ->  Seq Scan on compress_hyper_14_224_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_225_chunk r_95
+                     ->  Seq Scan on compress_hyper_14_226_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_227_chunk r_96
+                     ->  Seq Scan on compress_hyper_14_228_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_229_chunk r_97
+                     ->  Seq Scan on compress_hyper_14_230_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_231_chunk r_98
+                     ->  Seq Scan on compress_hyper_14_232_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_233_chunk r_99
+                     ->  Seq Scan on compress_hyper_14_234_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_235_chunk r_100
+                     ->  Seq Scan on compress_hyper_14_236_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_237_chunk r_101
+                     ->  Seq Scan on compress_hyper_14_238_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_239_chunk r_102
+                     ->  Seq Scan on compress_hyper_14_240_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_241_chunk r_103
+                     ->  Seq Scan on compress_hyper_14_242_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_243_chunk r_104
+                     ->  Seq Scan on compress_hyper_14_244_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_245_chunk r_105
+                     ->  Seq Scan on compress_hyper_14_246_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_247_chunk r_106
+                     ->  Seq Scan on compress_hyper_14_248_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_249_chunk r_107
+                     ->  Seq Scan on compress_hyper_14_250_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_251_chunk r_108
+                     ->  Seq Scan on compress_hyper_14_252_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_253_chunk r_109
+                     ->  Seq Scan on compress_hyper_14_254_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_255_chunk r_110
+                     ->  Seq Scan on compress_hyper_14_256_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_257_chunk r_111
+                     ->  Seq Scan on compress_hyper_14_258_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_259_chunk r_112
+                     ->  Seq Scan on compress_hyper_14_260_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_261_chunk r_113
+                     ->  Seq Scan on compress_hyper_14_262_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_263_chunk r_114
+                     ->  Seq Scan on compress_hyper_14_264_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_265_chunk r_115
+                     ->  Seq Scan on compress_hyper_14_266_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_267_chunk r_116
+                     ->  Seq Scan on compress_hyper_14_268_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_269_chunk r_117
+                     ->  Seq Scan on compress_hyper_14_270_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_271_chunk r_118
+                     ->  Seq Scan on compress_hyper_14_272_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_273_chunk r_119
+                     ->  Seq Scan on compress_hyper_14_274_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_275_chunk r_120
+                     ->  Seq Scan on compress_hyper_14_276_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_277_chunk r_121
+                     ->  Seq Scan on compress_hyper_14_278_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_279_chunk r_122
+                     ->  Seq Scan on compress_hyper_14_280_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_281_chunk r_123
+                     ->  Seq Scan on compress_hyper_14_282_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_283_chunk r_124
+                     ->  Seq Scan on compress_hyper_14_284_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_285_chunk r_125
+                     ->  Seq Scan on compress_hyper_14_286_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_287_chunk r_126
+                     ->  Seq Scan on compress_hyper_14_288_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_289_chunk r_127
+                     ->  Seq Scan on compress_hyper_14_290_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_291_chunk r_128
+                     ->  Seq Scan on compress_hyper_14_292_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_293_chunk r_129
+                     ->  Seq Scan on compress_hyper_14_294_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_295_chunk r_130
+                     ->  Seq Scan on compress_hyper_14_296_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_297_chunk r_131
+                     ->  Seq Scan on compress_hyper_14_298_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_299_chunk r_132
+                     ->  Seq Scan on compress_hyper_14_300_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_301_chunk r_133
+                     ->  Seq Scan on compress_hyper_14_302_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_303_chunk r_134
+                     ->  Seq Scan on compress_hyper_14_304_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_305_chunk r_135
+                     ->  Seq Scan on compress_hyper_14_306_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_307_chunk r_136
+                     ->  Seq Scan on compress_hyper_14_308_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_309_chunk r_137
+                     ->  Seq Scan on compress_hyper_14_310_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_311_chunk r_138
+                     ->  Seq Scan on compress_hyper_14_312_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_313_chunk r_139
+                     ->  Seq Scan on compress_hyper_14_314_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_315_chunk r_140
+                     ->  Seq Scan on compress_hyper_14_316_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_317_chunk r_141
+                     ->  Seq Scan on compress_hyper_14_318_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_319_chunk r_142
+                     ->  Seq Scan on compress_hyper_14_320_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_321_chunk r_143
+                     ->  Seq Scan on compress_hyper_14_322_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_323_chunk r_144
+                     ->  Seq Scan on compress_hyper_14_324_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_325_chunk r_145
+                     ->  Seq Scan on compress_hyper_14_326_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_327_chunk r_146
+                     ->  Seq Scan on compress_hyper_14_328_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_329_chunk r_147
+                     ->  Seq Scan on compress_hyper_14_330_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_331_chunk r_148
+                     ->  Seq Scan on compress_hyper_14_332_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_333_chunk r_149
+                     ->  Seq Scan on compress_hyper_14_334_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_335_chunk r_150
+                     ->  Seq Scan on compress_hyper_14_336_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_337_chunk r_151
+                     ->  Seq Scan on compress_hyper_14_338_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_339_chunk r_152
+                     ->  Seq Scan on compress_hyper_14_340_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_341_chunk r_153
+                     ->  Seq Scan on compress_hyper_14_342_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_343_chunk r_154
+                     ->  Seq Scan on compress_hyper_14_344_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_345_chunk r_155
+                     ->  Seq Scan on compress_hyper_14_346_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_347_chunk r_156
+                     ->  Seq Scan on compress_hyper_14_348_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_349_chunk r_157
+                     ->  Seq Scan on compress_hyper_14_350_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_351_chunk r_158
+                     ->  Seq Scan on compress_hyper_14_352_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_353_chunk r_159
+                     ->  Seq Scan on compress_hyper_14_354_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_355_chunk r_160
+                     ->  Seq Scan on compress_hyper_14_356_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_357_chunk r_161
+                     ->  Seq Scan on compress_hyper_14_358_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_359_chunk r_162
+                     ->  Seq Scan on compress_hyper_14_360_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_361_chunk r_163
+                     ->  Seq Scan on compress_hyper_14_362_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_363_chunk r_164
+                     ->  Seq Scan on compress_hyper_14_364_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_365_chunk r_165
+                     ->  Seq Scan on compress_hyper_14_366_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_367_chunk r_166
+                     ->  Seq Scan on compress_hyper_14_368_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_369_chunk r_167
+                     ->  Seq Scan on compress_hyper_14_370_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_371_chunk r_168
+                     ->  Seq Scan on compress_hyper_14_372_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_373_chunk r_169
+                     ->  Seq Scan on compress_hyper_14_374_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_375_chunk r_170
+                     ->  Seq Scan on compress_hyper_14_376_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_377_chunk r_171
+                     ->  Seq Scan on compress_hyper_14_378_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_379_chunk r_172
+                     ->  Seq Scan on compress_hyper_14_380_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_381_chunk r_173
+                     ->  Seq Scan on compress_hyper_14_382_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_383_chunk r_174
+                     ->  Seq Scan on compress_hyper_14_384_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_385_chunk r_175
+                     ->  Seq Scan on compress_hyper_14_386_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_387_chunk r_176
+                     ->  Seq Scan on compress_hyper_14_388_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_389_chunk r_177
+                     ->  Seq Scan on compress_hyper_14_390_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_391_chunk r_178
+                     ->  Seq Scan on compress_hyper_14_392_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_393_chunk r_179
+                     ->  Seq Scan on compress_hyper_14_394_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_395_chunk r_180
+                     ->  Seq Scan on compress_hyper_14_396_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_397_chunk r_181
+                     ->  Seq Scan on compress_hyper_14_398_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_399_chunk r_182
+                     ->  Seq Scan on compress_hyper_14_400_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_401_chunk r_183
+                     ->  Seq Scan on compress_hyper_14_402_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_403_chunk r_184
+                     ->  Seq Scan on compress_hyper_14_404_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_405_chunk r_185
+                     ->  Seq Scan on compress_hyper_14_406_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_407_chunk r_186
+                     ->  Seq Scan on compress_hyper_14_408_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_409_chunk r_187
+                     ->  Seq Scan on compress_hyper_14_410_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_411_chunk r_188
+                     ->  Seq Scan on compress_hyper_14_412_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_413_chunk r_189
+                     ->  Seq Scan on compress_hyper_14_414_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_415_chunk r_190
+                     ->  Seq Scan on compress_hyper_14_416_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_417_chunk r_191
+                     ->  Seq Scan on compress_hyper_14_418_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_419_chunk r_192
+                     ->  Seq Scan on compress_hyper_14_420_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_421_chunk r_193
+                     ->  Seq Scan on compress_hyper_14_422_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_423_chunk r_194
+                     ->  Seq Scan on compress_hyper_14_424_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_425_chunk r_195
+                     ->  Seq Scan on compress_hyper_14_426_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_427_chunk r_196
+                     ->  Seq Scan on compress_hyper_14_428_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_429_chunk r_197
+                     ->  Seq Scan on compress_hyper_14_430_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_431_chunk r_198
+                     ->  Seq Scan on compress_hyper_14_432_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_433_chunk r_199
+                     ->  Seq Scan on compress_hyper_14_434_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_435_chunk r_200
+                     ->  Seq Scan on compress_hyper_14_436_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_437_chunk r_201
+                     ->  Seq Scan on compress_hyper_14_438_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_439_chunk r_202
+                     ->  Seq Scan on compress_hyper_14_440_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_441_chunk r_203
+                     ->  Seq Scan on compress_hyper_14_442_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_443_chunk r_204
+                     ->  Seq Scan on compress_hyper_14_444_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_445_chunk r_205
+                     ->  Seq Scan on compress_hyper_14_446_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_447_chunk r_206
+                     ->  Seq Scan on compress_hyper_14_448_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_449_chunk r_207
+                     ->  Seq Scan on compress_hyper_14_450_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_451_chunk r_208
+                     ->  Seq Scan on compress_hyper_14_452_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_453_chunk r_209
+                     ->  Seq Scan on compress_hyper_14_454_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_455_chunk r_210
+                     ->  Seq Scan on compress_hyper_14_456_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_457_chunk r_211
+                     ->  Seq Scan on compress_hyper_14_458_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_459_chunk r_212
+                     ->  Seq Scan on compress_hyper_14_460_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_461_chunk r_213
+                     ->  Seq Scan on compress_hyper_14_462_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_463_chunk r_214
+                     ->  Seq Scan on compress_hyper_14_464_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_465_chunk r_215
+                     ->  Seq Scan on compress_hyper_14_466_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_467_chunk r_216
+                     ->  Seq Scan on compress_hyper_14_468_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_469_chunk r_217
+                     ->  Seq Scan on compress_hyper_14_470_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_471_chunk r_218
+                     ->  Seq Scan on compress_hyper_14_472_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_473_chunk r_219
+                     ->  Seq Scan on compress_hyper_14_474_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_475_chunk r_220
+                     ->  Seq Scan on compress_hyper_14_476_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_477_chunk r_221
+                     ->  Seq Scan on compress_hyper_14_478_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_479_chunk r_222
+                     ->  Seq Scan on compress_hyper_14_480_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_481_chunk r_223
+                     ->  Seq Scan on compress_hyper_14_482_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_483_chunk r_224
+                     ->  Seq Scan on compress_hyper_14_484_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_485_chunk r_225
+                     ->  Seq Scan on compress_hyper_14_486_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_487_chunk r_226
+                     ->  Seq Scan on compress_hyper_14_488_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_489_chunk r_227
+                     ->  Seq Scan on compress_hyper_14_490_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_491_chunk r_228
+                     ->  Seq Scan on compress_hyper_14_492_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_493_chunk r_229
+                     ->  Seq Scan on compress_hyper_14_494_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_495_chunk r_230
+                     ->  Seq Scan on compress_hyper_14_496_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_497_chunk r_231
+                     ->  Seq Scan on compress_hyper_14_498_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_499_chunk r_232
+                     ->  Seq Scan on compress_hyper_14_500_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_501_chunk r_233
+                     ->  Seq Scan on compress_hyper_14_502_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_503_chunk r_234
+                     ->  Seq Scan on compress_hyper_14_504_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_505_chunk r_235
+                     ->  Seq Scan on compress_hyper_14_506_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_507_chunk r_236
+                     ->  Seq Scan on compress_hyper_14_508_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_509_chunk r_237
+                     ->  Seq Scan on compress_hyper_14_510_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_511_chunk r_238
+                     ->  Seq Scan on compress_hyper_14_512_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_513_chunk r_239
+                     ->  Seq Scan on compress_hyper_14_514_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_515_chunk r_240
+                     ->  Seq Scan on compress_hyper_14_516_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_517_chunk r_241
+                     ->  Seq Scan on compress_hyper_14_518_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_519_chunk r_242
+                     ->  Seq Scan on compress_hyper_14_520_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_521_chunk r_243
+                     ->  Seq Scan on compress_hyper_14_522_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_523_chunk r_244
+                     ->  Seq Scan on compress_hyper_14_524_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_525_chunk r_245
+                     ->  Seq Scan on compress_hyper_14_526_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_527_chunk r_246
+                     ->  Seq Scan on compress_hyper_14_528_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_529_chunk r_247
+                     ->  Seq Scan on compress_hyper_14_530_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_531_chunk r_248
+                     ->  Seq Scan on compress_hyper_14_532_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_533_chunk r_249
+                     ->  Seq Scan on compress_hyper_14_534_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_535_chunk r_250
+                     ->  Seq Scan on compress_hyper_14_536_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_537_chunk r_251
+                     ->  Seq Scan on compress_hyper_14_538_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_539_chunk r_252
+                     ->  Seq Scan on compress_hyper_14_540_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_541_chunk r_253
+                     ->  Seq Scan on compress_hyper_14_542_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_543_chunk r_254
+                     ->  Seq Scan on compress_hyper_14_544_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_545_chunk r_255
+                     ->  Seq Scan on compress_hyper_14_546_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_547_chunk r_256
+                     ->  Seq Scan on compress_hyper_14_548_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_549_chunk r_257
+                     ->  Seq Scan on compress_hyper_14_550_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_551_chunk r_258
+                     ->  Seq Scan on compress_hyper_14_552_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_553_chunk r_259
+                     ->  Seq Scan on compress_hyper_14_554_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_555_chunk r_260
+                     ->  Seq Scan on compress_hyper_14_556_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_557_chunk r_261
+                     ->  Seq Scan on compress_hyper_14_558_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_559_chunk r_262
+                     ->  Seq Scan on compress_hyper_14_560_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_561_chunk r_263
+                     ->  Seq Scan on compress_hyper_14_562_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_563_chunk r_264
+                     ->  Seq Scan on compress_hyper_14_564_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_565_chunk r_265
+                     ->  Seq Scan on compress_hyper_14_566_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_567_chunk r_266
+                     ->  Seq Scan on compress_hyper_14_568_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_569_chunk r_267
+                     ->  Seq Scan on compress_hyper_14_570_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_571_chunk r_268
+                     ->  Seq Scan on compress_hyper_14_572_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_573_chunk r_269
+                     ->  Seq Scan on compress_hyper_14_574_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_575_chunk r_270
+                     ->  Seq Scan on compress_hyper_14_576_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_577_chunk r_271
+                     ->  Seq Scan on compress_hyper_14_578_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_579_chunk r_272
+                     ->  Seq Scan on compress_hyper_14_580_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_581_chunk r_273
+                     ->  Seq Scan on compress_hyper_14_582_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_583_chunk r_274
+                     ->  Seq Scan on compress_hyper_14_584_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_585_chunk r_275
+                     ->  Seq Scan on compress_hyper_14_586_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_587_chunk r_276
+                     ->  Seq Scan on compress_hyper_14_588_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_589_chunk r_277
+                     ->  Seq Scan on compress_hyper_14_590_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_591_chunk r_278
+                     ->  Seq Scan on compress_hyper_14_592_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_593_chunk r_279
+                     ->  Seq Scan on compress_hyper_14_594_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_595_chunk r_280
+                     ->  Seq Scan on compress_hyper_14_596_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_597_chunk r_281
+                     ->  Seq Scan on compress_hyper_14_598_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_599_chunk r_282
+                     ->  Seq Scan on compress_hyper_14_600_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_601_chunk r_283
+                     ->  Seq Scan on compress_hyper_14_602_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_603_chunk r_284
+                     ->  Seq Scan on compress_hyper_14_604_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_605_chunk r_285
+                     ->  Seq Scan on compress_hyper_14_606_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_607_chunk r_286
+                     ->  Seq Scan on compress_hyper_14_608_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_609_chunk r_287
+                     ->  Seq Scan on compress_hyper_14_610_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_611_chunk r_288
+                     ->  Seq Scan on compress_hyper_14_612_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_613_chunk r_289
+                     ->  Seq Scan on compress_hyper_14_614_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_615_chunk r_290
+                     ->  Seq Scan on compress_hyper_14_616_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_617_chunk r_291
+                     ->  Seq Scan on compress_hyper_14_618_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_619_chunk r_292
+                     ->  Seq Scan on compress_hyper_14_620_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_621_chunk r_293
+                     ->  Seq Scan on compress_hyper_14_622_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_623_chunk r_294
+                     ->  Seq Scan on compress_hyper_14_624_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_625_chunk r_295
+                     ->  Seq Scan on compress_hyper_14_626_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_627_chunk r_296
+                     ->  Seq Scan on compress_hyper_14_628_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_629_chunk r_297
+                     ->  Seq Scan on compress_hyper_14_630_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_631_chunk r_298
+                     ->  Seq Scan on compress_hyper_14_632_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_633_chunk r_299
+                     ->  Seq Scan on compress_hyper_14_634_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_635_chunk r_300
+                     ->  Seq Scan on compress_hyper_14_636_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_637_chunk r_301
+                     ->  Seq Scan on compress_hyper_14_638_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_639_chunk r_302
+                     ->  Seq Scan on compress_hyper_14_640_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_641_chunk r_303
+                     ->  Seq Scan on compress_hyper_14_642_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_643_chunk r_304
+                     ->  Seq Scan on compress_hyper_14_644_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_645_chunk r_305
+                     ->  Seq Scan on compress_hyper_14_646_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_647_chunk r_306
+                     ->  Seq Scan on compress_hyper_14_648_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_649_chunk r_307
+                     ->  Seq Scan on compress_hyper_14_650_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_651_chunk r_308
+                     ->  Seq Scan on compress_hyper_14_652_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_653_chunk r_309
+                     ->  Seq Scan on compress_hyper_14_654_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_655_chunk r_310
+                     ->  Seq Scan on compress_hyper_14_656_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_657_chunk r_311
+                     ->  Seq Scan on compress_hyper_14_658_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_659_chunk r_312
+                     ->  Seq Scan on compress_hyper_14_660_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_661_chunk r_313
+                     ->  Seq Scan on compress_hyper_14_662_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_663_chunk r_314
+                     ->  Seq Scan on compress_hyper_14_664_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_665_chunk r_315
+                     ->  Seq Scan on compress_hyper_14_666_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_667_chunk r_316
+                     ->  Seq Scan on compress_hyper_14_668_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_669_chunk r_317
+                     ->  Seq Scan on compress_hyper_14_670_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_671_chunk r_318
+                     ->  Seq Scan on compress_hyper_14_672_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_673_chunk r_319
+                     ->  Seq Scan on compress_hyper_14_674_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_675_chunk r_320
+                     ->  Seq Scan on compress_hyper_14_676_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_677_chunk r_321
+                     ->  Seq Scan on compress_hyper_14_678_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_679_chunk r_322
+                     ->  Seq Scan on compress_hyper_14_680_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_681_chunk r_323
+                     ->  Seq Scan on compress_hyper_14_682_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_683_chunk r_324
+                     ->  Seq Scan on compress_hyper_14_684_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_685_chunk r_325
+                     ->  Seq Scan on compress_hyper_14_686_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_687_chunk r_326
+                     ->  Seq Scan on compress_hyper_14_688_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_689_chunk r_327
+                     ->  Seq Scan on compress_hyper_14_690_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_691_chunk r_328
+                     ->  Seq Scan on compress_hyper_14_692_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_693_chunk r_329
+                     ->  Seq Scan on compress_hyper_14_694_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_695_chunk r_330
+                     ->  Seq Scan on compress_hyper_14_696_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_697_chunk r_331
+                     ->  Seq Scan on compress_hyper_14_698_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_699_chunk r_332
+                     ->  Seq Scan on compress_hyper_14_700_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_701_chunk r_333
+                     ->  Seq Scan on compress_hyper_14_702_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_703_chunk r_334
+                     ->  Seq Scan on compress_hyper_14_704_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_705_chunk r_335
+                     ->  Seq Scan on compress_hyper_14_706_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_707_chunk r_336
+                     ->  Seq Scan on compress_hyper_14_708_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_709_chunk r_337
+                     ->  Seq Scan on compress_hyper_14_710_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_711_chunk r_338
+                     ->  Seq Scan on compress_hyper_14_712_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_713_chunk r_339
+                     ->  Seq Scan on compress_hyper_14_714_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_715_chunk r_340
+                     ->  Seq Scan on compress_hyper_14_716_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_717_chunk r_341
+                     ->  Seq Scan on compress_hyper_14_718_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_719_chunk r_342
+                     ->  Seq Scan on compress_hyper_14_720_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_721_chunk r_343
+                     ->  Seq Scan on compress_hyper_14_722_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_723_chunk r_344
+                     ->  Seq Scan on compress_hyper_14_724_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_725_chunk r_345
+                     ->  Seq Scan on compress_hyper_14_726_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_727_chunk r_346
+                     ->  Seq Scan on compress_hyper_14_728_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_729_chunk r_347
+                     ->  Seq Scan on compress_hyper_14_730_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_731_chunk r_348
+                     ->  Seq Scan on compress_hyper_14_732_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_733_chunk r_349
+                     ->  Seq Scan on compress_hyper_14_734_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_735_chunk r_350
                      ->  Seq Scan on compress_hyper_14_736_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_34_chunk r_3
-                     ->  Seq Scan on compress_hyper_14_737_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_35_chunk r_4
+               ->  Custom Scan (DecompressChunk) on _hyper_13_737_chunk r_351
                      ->  Seq Scan on compress_hyper_14_738_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_36_chunk r_5
-                     ->  Seq Scan on compress_hyper_14_739_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_37_chunk r_6
+               ->  Custom Scan (DecompressChunk) on _hyper_13_739_chunk r_352
                      ->  Seq Scan on compress_hyper_14_740_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_38_chunk r_7
-                     ->  Seq Scan on compress_hyper_14_741_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_39_chunk r_8
+               ->  Custom Scan (DecompressChunk) on _hyper_13_741_chunk r_353
                      ->  Seq Scan on compress_hyper_14_742_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_40_chunk r_9
-                     ->  Seq Scan on compress_hyper_14_743_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_41_chunk r_10
+               ->  Custom Scan (DecompressChunk) on _hyper_13_743_chunk r_354
                      ->  Seq Scan on compress_hyper_14_744_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_42_chunk r_11
-                     ->  Seq Scan on compress_hyper_14_745_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_43_chunk r_12
+               ->  Custom Scan (DecompressChunk) on _hyper_13_745_chunk r_355
                      ->  Seq Scan on compress_hyper_14_746_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_44_chunk r_13
-                     ->  Seq Scan on compress_hyper_14_747_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_45_chunk r_14
+               ->  Custom Scan (DecompressChunk) on _hyper_13_747_chunk r_356
                      ->  Seq Scan on compress_hyper_14_748_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_46_chunk r_15
-                     ->  Seq Scan on compress_hyper_14_749_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_47_chunk r_16
+               ->  Custom Scan (DecompressChunk) on _hyper_13_749_chunk r_357
                      ->  Seq Scan on compress_hyper_14_750_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_48_chunk r_17
-                     ->  Seq Scan on compress_hyper_14_751_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_49_chunk r_18
+               ->  Custom Scan (DecompressChunk) on _hyper_13_751_chunk r_358
                      ->  Seq Scan on compress_hyper_14_752_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_50_chunk r_19
-                     ->  Seq Scan on compress_hyper_14_753_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_51_chunk r_20
+               ->  Custom Scan (DecompressChunk) on _hyper_13_753_chunk r_359
                      ->  Seq Scan on compress_hyper_14_754_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_52_chunk r_21
-                     ->  Seq Scan on compress_hyper_14_755_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_53_chunk r_22
+               ->  Custom Scan (DecompressChunk) on _hyper_13_755_chunk r_360
                      ->  Seq Scan on compress_hyper_14_756_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_54_chunk r_23
-                     ->  Seq Scan on compress_hyper_14_757_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_55_chunk r_24
+               ->  Custom Scan (DecompressChunk) on _hyper_13_757_chunk r_361
                      ->  Seq Scan on compress_hyper_14_758_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_56_chunk r_25
-                     ->  Seq Scan on compress_hyper_14_759_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_57_chunk r_26
+               ->  Custom Scan (DecompressChunk) on _hyper_13_759_chunk r_362
                      ->  Seq Scan on compress_hyper_14_760_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_58_chunk r_27
-                     ->  Seq Scan on compress_hyper_14_761_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_59_chunk r_28
+               ->  Custom Scan (DecompressChunk) on _hyper_13_761_chunk r_363
                      ->  Seq Scan on compress_hyper_14_762_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_60_chunk r_29
-                     ->  Seq Scan on compress_hyper_14_763_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_61_chunk r_30
+               ->  Custom Scan (DecompressChunk) on _hyper_13_763_chunk r_364
                      ->  Seq Scan on compress_hyper_14_764_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_62_chunk r_31
-                     ->  Seq Scan on compress_hyper_14_765_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_63_chunk r_32
+               ->  Custom Scan (DecompressChunk) on _hyper_13_765_chunk r_365
                      ->  Seq Scan on compress_hyper_14_766_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_64_chunk r_33
-                     ->  Seq Scan on compress_hyper_14_767_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_65_chunk r_34
+               ->  Custom Scan (DecompressChunk) on _hyper_13_767_chunk r_366
                      ->  Seq Scan on compress_hyper_14_768_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_66_chunk r_35
-                     ->  Seq Scan on compress_hyper_14_769_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_67_chunk r_36
+               ->  Custom Scan (DecompressChunk) on _hyper_13_769_chunk r_367
                      ->  Seq Scan on compress_hyper_14_770_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_68_chunk r_37
-                     ->  Seq Scan on compress_hyper_14_771_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_69_chunk r_38
+               ->  Custom Scan (DecompressChunk) on _hyper_13_771_chunk r_368
                      ->  Seq Scan on compress_hyper_14_772_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_70_chunk r_39
-                     ->  Seq Scan on compress_hyper_14_773_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_71_chunk r_40
+               ->  Custom Scan (DecompressChunk) on _hyper_13_773_chunk r_369
                      ->  Seq Scan on compress_hyper_14_774_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_72_chunk r_41
-                     ->  Seq Scan on compress_hyper_14_775_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_73_chunk r_42
+               ->  Custom Scan (DecompressChunk) on _hyper_13_775_chunk r_370
                      ->  Seq Scan on compress_hyper_14_776_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_74_chunk r_43
-                     ->  Seq Scan on compress_hyper_14_777_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_75_chunk r_44
+               ->  Custom Scan (DecompressChunk) on _hyper_13_777_chunk r_371
                      ->  Seq Scan on compress_hyper_14_778_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_76_chunk r_45
-                     ->  Seq Scan on compress_hyper_14_779_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_77_chunk r_46
+               ->  Custom Scan (DecompressChunk) on _hyper_13_779_chunk r_372
                      ->  Seq Scan on compress_hyper_14_780_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_78_chunk r_47
-                     ->  Seq Scan on compress_hyper_14_781_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_79_chunk r_48
+               ->  Custom Scan (DecompressChunk) on _hyper_13_781_chunk r_373
                      ->  Seq Scan on compress_hyper_14_782_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_80_chunk r_49
-                     ->  Seq Scan on compress_hyper_14_783_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_81_chunk r_50
+               ->  Custom Scan (DecompressChunk) on _hyper_13_783_chunk r_374
                      ->  Seq Scan on compress_hyper_14_784_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_82_chunk r_51
-                     ->  Seq Scan on compress_hyper_14_785_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_83_chunk r_52
+               ->  Custom Scan (DecompressChunk) on _hyper_13_785_chunk r_375
                      ->  Seq Scan on compress_hyper_14_786_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_84_chunk r_53
-                     ->  Seq Scan on compress_hyper_14_787_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_85_chunk r_54
+               ->  Custom Scan (DecompressChunk) on _hyper_13_787_chunk r_376
                      ->  Seq Scan on compress_hyper_14_788_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_86_chunk r_55
-                     ->  Seq Scan on compress_hyper_14_789_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_87_chunk r_56
+               ->  Custom Scan (DecompressChunk) on _hyper_13_789_chunk r_377
                      ->  Seq Scan on compress_hyper_14_790_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_88_chunk r_57
-                     ->  Seq Scan on compress_hyper_14_791_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_89_chunk r_58
+               ->  Custom Scan (DecompressChunk) on _hyper_13_791_chunk r_378
                      ->  Seq Scan on compress_hyper_14_792_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_90_chunk r_59
-                     ->  Seq Scan on compress_hyper_14_793_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_91_chunk r_60
+               ->  Custom Scan (DecompressChunk) on _hyper_13_793_chunk r_379
                      ->  Seq Scan on compress_hyper_14_794_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_92_chunk r_61
-                     ->  Seq Scan on compress_hyper_14_795_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_93_chunk r_62
+               ->  Custom Scan (DecompressChunk) on _hyper_13_795_chunk r_380
                      ->  Seq Scan on compress_hyper_14_796_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_94_chunk r_63
-                     ->  Seq Scan on compress_hyper_14_797_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_95_chunk r_64
+               ->  Custom Scan (DecompressChunk) on _hyper_13_797_chunk r_381
                      ->  Seq Scan on compress_hyper_14_798_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_96_chunk r_65
-                     ->  Seq Scan on compress_hyper_14_799_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_97_chunk r_66
+               ->  Custom Scan (DecompressChunk) on _hyper_13_799_chunk r_382
                      ->  Seq Scan on compress_hyper_14_800_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_98_chunk r_67
-                     ->  Seq Scan on compress_hyper_14_801_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_99_chunk r_68
+               ->  Custom Scan (DecompressChunk) on _hyper_13_801_chunk r_383
                      ->  Seq Scan on compress_hyper_14_802_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_100_chunk r_69
-                     ->  Seq Scan on compress_hyper_14_803_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_101_chunk r_70
+               ->  Custom Scan (DecompressChunk) on _hyper_13_803_chunk r_384
                      ->  Seq Scan on compress_hyper_14_804_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_102_chunk r_71
-                     ->  Seq Scan on compress_hyper_14_805_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_103_chunk r_72
+               ->  Custom Scan (DecompressChunk) on _hyper_13_805_chunk r_385
                      ->  Seq Scan on compress_hyper_14_806_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_104_chunk r_73
-                     ->  Seq Scan on compress_hyper_14_807_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_105_chunk r_74
+               ->  Custom Scan (DecompressChunk) on _hyper_13_807_chunk r_386
                      ->  Seq Scan on compress_hyper_14_808_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_106_chunk r_75
-                     ->  Seq Scan on compress_hyper_14_809_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_107_chunk r_76
+               ->  Custom Scan (DecompressChunk) on _hyper_13_809_chunk r_387
                      ->  Seq Scan on compress_hyper_14_810_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_108_chunk r_77
-                     ->  Seq Scan on compress_hyper_14_811_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_109_chunk r_78
+               ->  Custom Scan (DecompressChunk) on _hyper_13_811_chunk r_388
                      ->  Seq Scan on compress_hyper_14_812_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_110_chunk r_79
-                     ->  Seq Scan on compress_hyper_14_813_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_111_chunk r_80
+               ->  Custom Scan (DecompressChunk) on _hyper_13_813_chunk r_389
                      ->  Seq Scan on compress_hyper_14_814_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_112_chunk r_81
-                     ->  Seq Scan on compress_hyper_14_815_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_113_chunk r_82
+               ->  Custom Scan (DecompressChunk) on _hyper_13_815_chunk r_390
                      ->  Seq Scan on compress_hyper_14_816_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_114_chunk r_83
-                     ->  Seq Scan on compress_hyper_14_817_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_115_chunk r_84
+               ->  Custom Scan (DecompressChunk) on _hyper_13_817_chunk r_391
                      ->  Seq Scan on compress_hyper_14_818_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_116_chunk r_85
-                     ->  Seq Scan on compress_hyper_14_819_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_117_chunk r_86
+               ->  Custom Scan (DecompressChunk) on _hyper_13_819_chunk r_392
                      ->  Seq Scan on compress_hyper_14_820_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_118_chunk r_87
-                     ->  Seq Scan on compress_hyper_14_821_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_119_chunk r_88
+               ->  Custom Scan (DecompressChunk) on _hyper_13_821_chunk r_393
                      ->  Seq Scan on compress_hyper_14_822_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_120_chunk r_89
-                     ->  Seq Scan on compress_hyper_14_823_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_121_chunk r_90
+               ->  Custom Scan (DecompressChunk) on _hyper_13_823_chunk r_394
                      ->  Seq Scan on compress_hyper_14_824_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_122_chunk r_91
-                     ->  Seq Scan on compress_hyper_14_825_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_123_chunk r_92
+               ->  Custom Scan (DecompressChunk) on _hyper_13_825_chunk r_395
                      ->  Seq Scan on compress_hyper_14_826_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_124_chunk r_93
-                     ->  Seq Scan on compress_hyper_14_827_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_125_chunk r_94
+               ->  Custom Scan (DecompressChunk) on _hyper_13_827_chunk r_396
                      ->  Seq Scan on compress_hyper_14_828_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_126_chunk r_95
-                     ->  Seq Scan on compress_hyper_14_829_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_127_chunk r_96
+               ->  Custom Scan (DecompressChunk) on _hyper_13_829_chunk r_397
                      ->  Seq Scan on compress_hyper_14_830_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_128_chunk r_97
-                     ->  Seq Scan on compress_hyper_14_831_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_129_chunk r_98
+               ->  Custom Scan (DecompressChunk) on _hyper_13_831_chunk r_398
                      ->  Seq Scan on compress_hyper_14_832_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_130_chunk r_99
-                     ->  Seq Scan on compress_hyper_14_833_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_131_chunk r_100
+               ->  Custom Scan (DecompressChunk) on _hyper_13_833_chunk r_399
                      ->  Seq Scan on compress_hyper_14_834_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_132_chunk r_101
-                     ->  Seq Scan on compress_hyper_14_835_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_133_chunk r_102
+               ->  Custom Scan (DecompressChunk) on _hyper_13_835_chunk r_400
                      ->  Seq Scan on compress_hyper_14_836_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_134_chunk r_103
-                     ->  Seq Scan on compress_hyper_14_837_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_135_chunk r_104
+               ->  Custom Scan (DecompressChunk) on _hyper_13_837_chunk r_401
                      ->  Seq Scan on compress_hyper_14_838_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_136_chunk r_105
-                     ->  Seq Scan on compress_hyper_14_839_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_137_chunk r_106
+               ->  Custom Scan (DecompressChunk) on _hyper_13_839_chunk r_402
                      ->  Seq Scan on compress_hyper_14_840_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_138_chunk r_107
-                     ->  Seq Scan on compress_hyper_14_841_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_139_chunk r_108
+               ->  Custom Scan (DecompressChunk) on _hyper_13_841_chunk r_403
                      ->  Seq Scan on compress_hyper_14_842_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_140_chunk r_109
-                     ->  Seq Scan on compress_hyper_14_843_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_141_chunk r_110
+               ->  Custom Scan (DecompressChunk) on _hyper_13_843_chunk r_404
                      ->  Seq Scan on compress_hyper_14_844_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_142_chunk r_111
-                     ->  Seq Scan on compress_hyper_14_845_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_143_chunk r_112
+               ->  Custom Scan (DecompressChunk) on _hyper_13_845_chunk r_405
                      ->  Seq Scan on compress_hyper_14_846_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_144_chunk r_113
-                     ->  Seq Scan on compress_hyper_14_847_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_145_chunk r_114
+               ->  Custom Scan (DecompressChunk) on _hyper_13_847_chunk r_406
                      ->  Seq Scan on compress_hyper_14_848_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_146_chunk r_115
-                     ->  Seq Scan on compress_hyper_14_849_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_147_chunk r_116
+               ->  Custom Scan (DecompressChunk) on _hyper_13_849_chunk r_407
                      ->  Seq Scan on compress_hyper_14_850_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_148_chunk r_117
-                     ->  Seq Scan on compress_hyper_14_851_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_149_chunk r_118
+               ->  Custom Scan (DecompressChunk) on _hyper_13_851_chunk r_408
                      ->  Seq Scan on compress_hyper_14_852_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_150_chunk r_119
-                     ->  Seq Scan on compress_hyper_14_853_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_151_chunk r_120
+               ->  Custom Scan (DecompressChunk) on _hyper_13_853_chunk r_409
                      ->  Seq Scan on compress_hyper_14_854_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_152_chunk r_121
-                     ->  Seq Scan on compress_hyper_14_855_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_153_chunk r_122
+               ->  Custom Scan (DecompressChunk) on _hyper_13_855_chunk r_410
                      ->  Seq Scan on compress_hyper_14_856_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_154_chunk r_123
-                     ->  Seq Scan on compress_hyper_14_857_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_155_chunk r_124
+               ->  Custom Scan (DecompressChunk) on _hyper_13_857_chunk r_411
                      ->  Seq Scan on compress_hyper_14_858_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_156_chunk r_125
-                     ->  Seq Scan on compress_hyper_14_859_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_157_chunk r_126
+               ->  Custom Scan (DecompressChunk) on _hyper_13_859_chunk r_412
                      ->  Seq Scan on compress_hyper_14_860_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_158_chunk r_127
-                     ->  Seq Scan on compress_hyper_14_861_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_159_chunk r_128
+               ->  Custom Scan (DecompressChunk) on _hyper_13_861_chunk r_413
                      ->  Seq Scan on compress_hyper_14_862_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_160_chunk r_129
-                     ->  Seq Scan on compress_hyper_14_863_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_161_chunk r_130
+               ->  Custom Scan (DecompressChunk) on _hyper_13_863_chunk r_414
                      ->  Seq Scan on compress_hyper_14_864_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_162_chunk r_131
-                     ->  Seq Scan on compress_hyper_14_865_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_163_chunk r_132
+               ->  Custom Scan (DecompressChunk) on _hyper_13_865_chunk r_415
                      ->  Seq Scan on compress_hyper_14_866_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_164_chunk r_133
-                     ->  Seq Scan on compress_hyper_14_867_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_165_chunk r_134
+               ->  Custom Scan (DecompressChunk) on _hyper_13_867_chunk r_416
                      ->  Seq Scan on compress_hyper_14_868_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_166_chunk r_135
-                     ->  Seq Scan on compress_hyper_14_869_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_167_chunk r_136
+               ->  Custom Scan (DecompressChunk) on _hyper_13_869_chunk r_417
                      ->  Seq Scan on compress_hyper_14_870_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_168_chunk r_137
-                     ->  Seq Scan on compress_hyper_14_871_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_169_chunk r_138
+               ->  Custom Scan (DecompressChunk) on _hyper_13_871_chunk r_418
                      ->  Seq Scan on compress_hyper_14_872_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_170_chunk r_139
-                     ->  Seq Scan on compress_hyper_14_873_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_171_chunk r_140
+               ->  Custom Scan (DecompressChunk) on _hyper_13_873_chunk r_419
                      ->  Seq Scan on compress_hyper_14_874_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_172_chunk r_141
-                     ->  Seq Scan on compress_hyper_14_875_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_173_chunk r_142
+               ->  Custom Scan (DecompressChunk) on _hyper_13_875_chunk r_420
                      ->  Seq Scan on compress_hyper_14_876_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_174_chunk r_143
-                     ->  Seq Scan on compress_hyper_14_877_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_175_chunk r_144
+               ->  Custom Scan (DecompressChunk) on _hyper_13_877_chunk r_421
                      ->  Seq Scan on compress_hyper_14_878_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_176_chunk r_145
-                     ->  Seq Scan on compress_hyper_14_879_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_177_chunk r_146
+               ->  Custom Scan (DecompressChunk) on _hyper_13_879_chunk r_422
                      ->  Seq Scan on compress_hyper_14_880_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_178_chunk r_147
-                     ->  Seq Scan on compress_hyper_14_881_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_179_chunk r_148
+               ->  Custom Scan (DecompressChunk) on _hyper_13_881_chunk r_423
                      ->  Seq Scan on compress_hyper_14_882_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_180_chunk r_149
-                     ->  Seq Scan on compress_hyper_14_883_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_181_chunk r_150
+               ->  Custom Scan (DecompressChunk) on _hyper_13_883_chunk r_424
                      ->  Seq Scan on compress_hyper_14_884_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_182_chunk r_151
-                     ->  Seq Scan on compress_hyper_14_885_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_183_chunk r_152
+               ->  Custom Scan (DecompressChunk) on _hyper_13_885_chunk r_425
                      ->  Seq Scan on compress_hyper_14_886_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_184_chunk r_153
-                     ->  Seq Scan on compress_hyper_14_887_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_185_chunk r_154
+               ->  Custom Scan (DecompressChunk) on _hyper_13_887_chunk r_426
                      ->  Seq Scan on compress_hyper_14_888_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_186_chunk r_155
-                     ->  Seq Scan on compress_hyper_14_889_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_187_chunk r_156
+               ->  Custom Scan (DecompressChunk) on _hyper_13_889_chunk r_427
                      ->  Seq Scan on compress_hyper_14_890_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_188_chunk r_157
-                     ->  Seq Scan on compress_hyper_14_891_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_189_chunk r_158
+               ->  Custom Scan (DecompressChunk) on _hyper_13_891_chunk r_428
                      ->  Seq Scan on compress_hyper_14_892_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_190_chunk r_159
-                     ->  Seq Scan on compress_hyper_14_893_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_191_chunk r_160
+               ->  Custom Scan (DecompressChunk) on _hyper_13_893_chunk r_429
                      ->  Seq Scan on compress_hyper_14_894_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_192_chunk r_161
-                     ->  Seq Scan on compress_hyper_14_895_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_193_chunk r_162
+               ->  Custom Scan (DecompressChunk) on _hyper_13_895_chunk r_430
                      ->  Seq Scan on compress_hyper_14_896_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_194_chunk r_163
-                     ->  Seq Scan on compress_hyper_14_897_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_195_chunk r_164
+               ->  Custom Scan (DecompressChunk) on _hyper_13_897_chunk r_431
                      ->  Seq Scan on compress_hyper_14_898_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_196_chunk r_165
-                     ->  Seq Scan on compress_hyper_14_899_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_197_chunk r_166
+               ->  Custom Scan (DecompressChunk) on _hyper_13_899_chunk r_432
                      ->  Seq Scan on compress_hyper_14_900_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_198_chunk r_167
-                     ->  Seq Scan on compress_hyper_14_901_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_199_chunk r_168
+               ->  Custom Scan (DecompressChunk) on _hyper_13_901_chunk r_433
                      ->  Seq Scan on compress_hyper_14_902_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_200_chunk r_169
-                     ->  Seq Scan on compress_hyper_14_903_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_201_chunk r_170
+               ->  Custom Scan (DecompressChunk) on _hyper_13_903_chunk r_434
                      ->  Seq Scan on compress_hyper_14_904_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_202_chunk r_171
-                     ->  Seq Scan on compress_hyper_14_905_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_203_chunk r_172
+               ->  Custom Scan (DecompressChunk) on _hyper_13_905_chunk r_435
                      ->  Seq Scan on compress_hyper_14_906_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_204_chunk r_173
-                     ->  Seq Scan on compress_hyper_14_907_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_205_chunk r_174
+               ->  Custom Scan (DecompressChunk) on _hyper_13_907_chunk r_436
                      ->  Seq Scan on compress_hyper_14_908_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_206_chunk r_175
-                     ->  Seq Scan on compress_hyper_14_909_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_207_chunk r_176
+               ->  Custom Scan (DecompressChunk) on _hyper_13_909_chunk r_437
                      ->  Seq Scan on compress_hyper_14_910_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_208_chunk r_177
-                     ->  Seq Scan on compress_hyper_14_911_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_209_chunk r_178
+               ->  Custom Scan (DecompressChunk) on _hyper_13_911_chunk r_438
                      ->  Seq Scan on compress_hyper_14_912_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_210_chunk r_179
-                     ->  Seq Scan on compress_hyper_14_913_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_211_chunk r_180
+               ->  Custom Scan (DecompressChunk) on _hyper_13_913_chunk r_439
                      ->  Seq Scan on compress_hyper_14_914_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_212_chunk r_181
-                     ->  Seq Scan on compress_hyper_14_915_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_213_chunk r_182
+               ->  Custom Scan (DecompressChunk) on _hyper_13_915_chunk r_440
                      ->  Seq Scan on compress_hyper_14_916_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_214_chunk r_183
-                     ->  Seq Scan on compress_hyper_14_917_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_215_chunk r_184
+               ->  Custom Scan (DecompressChunk) on _hyper_13_917_chunk r_441
                      ->  Seq Scan on compress_hyper_14_918_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_216_chunk r_185
-                     ->  Seq Scan on compress_hyper_14_919_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_217_chunk r_186
+               ->  Custom Scan (DecompressChunk) on _hyper_13_919_chunk r_442
                      ->  Seq Scan on compress_hyper_14_920_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_218_chunk r_187
-                     ->  Seq Scan on compress_hyper_14_921_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_219_chunk r_188
+               ->  Custom Scan (DecompressChunk) on _hyper_13_921_chunk r_443
                      ->  Seq Scan on compress_hyper_14_922_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_220_chunk r_189
-                     ->  Seq Scan on compress_hyper_14_923_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_221_chunk r_190
+               ->  Custom Scan (DecompressChunk) on _hyper_13_923_chunk r_444
                      ->  Seq Scan on compress_hyper_14_924_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_222_chunk r_191
-                     ->  Seq Scan on compress_hyper_14_925_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_223_chunk r_192
+               ->  Custom Scan (DecompressChunk) on _hyper_13_925_chunk r_445
                      ->  Seq Scan on compress_hyper_14_926_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_224_chunk r_193
-                     ->  Seq Scan on compress_hyper_14_927_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_225_chunk r_194
+               ->  Custom Scan (DecompressChunk) on _hyper_13_927_chunk r_446
                      ->  Seq Scan on compress_hyper_14_928_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_226_chunk r_195
-                     ->  Seq Scan on compress_hyper_14_929_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_227_chunk r_196
+               ->  Custom Scan (DecompressChunk) on _hyper_13_929_chunk r_447
                      ->  Seq Scan on compress_hyper_14_930_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_228_chunk r_197
-                     ->  Seq Scan on compress_hyper_14_931_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_229_chunk r_198
+               ->  Custom Scan (DecompressChunk) on _hyper_13_931_chunk r_448
                      ->  Seq Scan on compress_hyper_14_932_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_230_chunk r_199
-                     ->  Seq Scan on compress_hyper_14_933_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_231_chunk r_200
+               ->  Custom Scan (DecompressChunk) on _hyper_13_933_chunk r_449
                      ->  Seq Scan on compress_hyper_14_934_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_232_chunk r_201
-                     ->  Seq Scan on compress_hyper_14_935_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_233_chunk r_202
+               ->  Custom Scan (DecompressChunk) on _hyper_13_935_chunk r_450
                      ->  Seq Scan on compress_hyper_14_936_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_234_chunk r_203
-                     ->  Seq Scan on compress_hyper_14_937_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_235_chunk r_204
+               ->  Custom Scan (DecompressChunk) on _hyper_13_937_chunk r_451
                      ->  Seq Scan on compress_hyper_14_938_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_236_chunk r_205
-                     ->  Seq Scan on compress_hyper_14_939_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_237_chunk r_206
+               ->  Custom Scan (DecompressChunk) on _hyper_13_939_chunk r_452
                      ->  Seq Scan on compress_hyper_14_940_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_238_chunk r_207
-                     ->  Seq Scan on compress_hyper_14_941_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_239_chunk r_208
+               ->  Custom Scan (DecompressChunk) on _hyper_13_941_chunk r_453
                      ->  Seq Scan on compress_hyper_14_942_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_240_chunk r_209
-                     ->  Seq Scan on compress_hyper_14_943_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_241_chunk r_210
+               ->  Custom Scan (DecompressChunk) on _hyper_13_943_chunk r_454
                      ->  Seq Scan on compress_hyper_14_944_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_242_chunk r_211
-                     ->  Seq Scan on compress_hyper_14_945_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_243_chunk r_212
+               ->  Custom Scan (DecompressChunk) on _hyper_13_945_chunk r_455
                      ->  Seq Scan on compress_hyper_14_946_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_244_chunk r_213
-                     ->  Seq Scan on compress_hyper_14_947_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_245_chunk r_214
+               ->  Custom Scan (DecompressChunk) on _hyper_13_947_chunk r_456
                      ->  Seq Scan on compress_hyper_14_948_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_246_chunk r_215
-                     ->  Seq Scan on compress_hyper_14_949_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_247_chunk r_216
+               ->  Custom Scan (DecompressChunk) on _hyper_13_949_chunk r_457
                      ->  Seq Scan on compress_hyper_14_950_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_248_chunk r_217
-                     ->  Seq Scan on compress_hyper_14_951_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_249_chunk r_218
+               ->  Custom Scan (DecompressChunk) on _hyper_13_951_chunk r_458
                      ->  Seq Scan on compress_hyper_14_952_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_250_chunk r_219
-                     ->  Seq Scan on compress_hyper_14_953_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_251_chunk r_220
+               ->  Custom Scan (DecompressChunk) on _hyper_13_953_chunk r_459
                      ->  Seq Scan on compress_hyper_14_954_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_252_chunk r_221
-                     ->  Seq Scan on compress_hyper_14_955_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_253_chunk r_222
+               ->  Custom Scan (DecompressChunk) on _hyper_13_955_chunk r_460
                      ->  Seq Scan on compress_hyper_14_956_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_254_chunk r_223
-                     ->  Seq Scan on compress_hyper_14_957_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_255_chunk r_224
+               ->  Custom Scan (DecompressChunk) on _hyper_13_957_chunk r_461
                      ->  Seq Scan on compress_hyper_14_958_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_256_chunk r_225
-                     ->  Seq Scan on compress_hyper_14_959_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_257_chunk r_226
+               ->  Custom Scan (DecompressChunk) on _hyper_13_959_chunk r_462
                      ->  Seq Scan on compress_hyper_14_960_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_258_chunk r_227
-                     ->  Seq Scan on compress_hyper_14_961_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_259_chunk r_228
+               ->  Custom Scan (DecompressChunk) on _hyper_13_961_chunk r_463
                      ->  Seq Scan on compress_hyper_14_962_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_260_chunk r_229
-                     ->  Seq Scan on compress_hyper_14_963_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_261_chunk r_230
+               ->  Custom Scan (DecompressChunk) on _hyper_13_963_chunk r_464
                      ->  Seq Scan on compress_hyper_14_964_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_262_chunk r_231
-                     ->  Seq Scan on compress_hyper_14_965_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_263_chunk r_232
+               ->  Custom Scan (DecompressChunk) on _hyper_13_965_chunk r_465
                      ->  Seq Scan on compress_hyper_14_966_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_264_chunk r_233
-                     ->  Seq Scan on compress_hyper_14_967_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_265_chunk r_234
+               ->  Custom Scan (DecompressChunk) on _hyper_13_967_chunk r_466
                      ->  Seq Scan on compress_hyper_14_968_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_266_chunk r_235
-                     ->  Seq Scan on compress_hyper_14_969_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_267_chunk r_236
+               ->  Custom Scan (DecompressChunk) on _hyper_13_969_chunk r_467
                      ->  Seq Scan on compress_hyper_14_970_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_268_chunk r_237
-                     ->  Seq Scan on compress_hyper_14_971_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_269_chunk r_238
+               ->  Custom Scan (DecompressChunk) on _hyper_13_971_chunk r_468
                      ->  Seq Scan on compress_hyper_14_972_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_270_chunk r_239
-                     ->  Seq Scan on compress_hyper_14_973_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_271_chunk r_240
+               ->  Custom Scan (DecompressChunk) on _hyper_13_973_chunk r_469
                      ->  Seq Scan on compress_hyper_14_974_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_272_chunk r_241
-                     ->  Seq Scan on compress_hyper_14_975_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_273_chunk r_242
+               ->  Custom Scan (DecompressChunk) on _hyper_13_975_chunk r_470
                      ->  Seq Scan on compress_hyper_14_976_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_274_chunk r_243
-                     ->  Seq Scan on compress_hyper_14_977_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_275_chunk r_244
+               ->  Custom Scan (DecompressChunk) on _hyper_13_977_chunk r_471
                      ->  Seq Scan on compress_hyper_14_978_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_276_chunk r_245
-                     ->  Seq Scan on compress_hyper_14_979_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_277_chunk r_246
+               ->  Custom Scan (DecompressChunk) on _hyper_13_979_chunk r_472
                      ->  Seq Scan on compress_hyper_14_980_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_278_chunk r_247
-                     ->  Seq Scan on compress_hyper_14_981_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_279_chunk r_248
+               ->  Custom Scan (DecompressChunk) on _hyper_13_981_chunk r_473
                      ->  Seq Scan on compress_hyper_14_982_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_280_chunk r_249
-                     ->  Seq Scan on compress_hyper_14_983_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_281_chunk r_250
+               ->  Custom Scan (DecompressChunk) on _hyper_13_983_chunk r_474
                      ->  Seq Scan on compress_hyper_14_984_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_282_chunk r_251
-                     ->  Seq Scan on compress_hyper_14_985_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_283_chunk r_252
+               ->  Custom Scan (DecompressChunk) on _hyper_13_985_chunk r_475
                      ->  Seq Scan on compress_hyper_14_986_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_284_chunk r_253
-                     ->  Seq Scan on compress_hyper_14_987_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_285_chunk r_254
+               ->  Custom Scan (DecompressChunk) on _hyper_13_987_chunk r_476
                      ->  Seq Scan on compress_hyper_14_988_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_286_chunk r_255
-                     ->  Seq Scan on compress_hyper_14_989_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_287_chunk r_256
+               ->  Custom Scan (DecompressChunk) on _hyper_13_989_chunk r_477
                      ->  Seq Scan on compress_hyper_14_990_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_288_chunk r_257
-                     ->  Seq Scan on compress_hyper_14_991_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_289_chunk r_258
+               ->  Custom Scan (DecompressChunk) on _hyper_13_991_chunk r_478
                      ->  Seq Scan on compress_hyper_14_992_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_290_chunk r_259
-                     ->  Seq Scan on compress_hyper_14_993_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_291_chunk r_260
+               ->  Custom Scan (DecompressChunk) on _hyper_13_993_chunk r_479
                      ->  Seq Scan on compress_hyper_14_994_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_292_chunk r_261
-                     ->  Seq Scan on compress_hyper_14_995_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_293_chunk r_262
+               ->  Custom Scan (DecompressChunk) on _hyper_13_995_chunk r_480
                      ->  Seq Scan on compress_hyper_14_996_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_294_chunk r_263
-                     ->  Seq Scan on compress_hyper_14_997_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_295_chunk r_264
+               ->  Custom Scan (DecompressChunk) on _hyper_13_997_chunk r_481
                      ->  Seq Scan on compress_hyper_14_998_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_296_chunk r_265
-                     ->  Seq Scan on compress_hyper_14_999_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_297_chunk r_266
+               ->  Custom Scan (DecompressChunk) on _hyper_13_999_chunk r_482
                      ->  Seq Scan on compress_hyper_14_1000_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_298_chunk r_267
-                     ->  Seq Scan on compress_hyper_14_1001_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_299_chunk r_268
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1001_chunk r_483
                      ->  Seq Scan on compress_hyper_14_1002_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_300_chunk r_269
-                     ->  Seq Scan on compress_hyper_14_1003_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_301_chunk r_270
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1003_chunk r_484
                      ->  Seq Scan on compress_hyper_14_1004_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_302_chunk r_271
-                     ->  Seq Scan on compress_hyper_14_1005_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_303_chunk r_272
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1005_chunk r_485
                      ->  Seq Scan on compress_hyper_14_1006_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_304_chunk r_273
-                     ->  Seq Scan on compress_hyper_14_1007_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_305_chunk r_274
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1007_chunk r_486
                      ->  Seq Scan on compress_hyper_14_1008_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_306_chunk r_275
-                     ->  Seq Scan on compress_hyper_14_1009_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_307_chunk r_276
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1009_chunk r_487
                      ->  Seq Scan on compress_hyper_14_1010_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_308_chunk r_277
-                     ->  Seq Scan on compress_hyper_14_1011_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_309_chunk r_278
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1011_chunk r_488
                      ->  Seq Scan on compress_hyper_14_1012_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_310_chunk r_279
-                     ->  Seq Scan on compress_hyper_14_1013_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_311_chunk r_280
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1013_chunk r_489
                      ->  Seq Scan on compress_hyper_14_1014_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_312_chunk r_281
-                     ->  Seq Scan on compress_hyper_14_1015_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_313_chunk r_282
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1015_chunk r_490
                      ->  Seq Scan on compress_hyper_14_1016_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_314_chunk r_283
-                     ->  Seq Scan on compress_hyper_14_1017_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_315_chunk r_284
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1017_chunk r_491
                      ->  Seq Scan on compress_hyper_14_1018_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_316_chunk r_285
-                     ->  Seq Scan on compress_hyper_14_1019_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_317_chunk r_286
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1019_chunk r_492
                      ->  Seq Scan on compress_hyper_14_1020_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_318_chunk r_287
-                     ->  Seq Scan on compress_hyper_14_1021_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_319_chunk r_288
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1021_chunk r_493
                      ->  Seq Scan on compress_hyper_14_1022_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_320_chunk r_289
-                     ->  Seq Scan on compress_hyper_14_1023_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_321_chunk r_290
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1023_chunk r_494
                      ->  Seq Scan on compress_hyper_14_1024_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_322_chunk r_291
-                     ->  Seq Scan on compress_hyper_14_1025_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_323_chunk r_292
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1025_chunk r_495
                      ->  Seq Scan on compress_hyper_14_1026_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_324_chunk r_293
-                     ->  Seq Scan on compress_hyper_14_1027_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_325_chunk r_294
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1027_chunk r_496
                      ->  Seq Scan on compress_hyper_14_1028_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_326_chunk r_295
-                     ->  Seq Scan on compress_hyper_14_1029_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_327_chunk r_296
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1029_chunk r_497
                      ->  Seq Scan on compress_hyper_14_1030_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_328_chunk r_297
-                     ->  Seq Scan on compress_hyper_14_1031_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_329_chunk r_298
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1031_chunk r_498
                      ->  Seq Scan on compress_hyper_14_1032_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_330_chunk r_299
-                     ->  Seq Scan on compress_hyper_14_1033_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_331_chunk r_300
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1033_chunk r_499
                      ->  Seq Scan on compress_hyper_14_1034_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_332_chunk r_301
-                     ->  Seq Scan on compress_hyper_14_1035_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_333_chunk r_302
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1035_chunk r_500
                      ->  Seq Scan on compress_hyper_14_1036_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_334_chunk r_303
-                     ->  Seq Scan on compress_hyper_14_1037_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_335_chunk r_304
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1037_chunk r_501
                      ->  Seq Scan on compress_hyper_14_1038_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_336_chunk r_305
-                     ->  Seq Scan on compress_hyper_14_1039_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_337_chunk r_306
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1039_chunk r_502
                      ->  Seq Scan on compress_hyper_14_1040_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_338_chunk r_307
-                     ->  Seq Scan on compress_hyper_14_1041_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_339_chunk r_308
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1041_chunk r_503
                      ->  Seq Scan on compress_hyper_14_1042_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_340_chunk r_309
-                     ->  Seq Scan on compress_hyper_14_1043_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_341_chunk r_310
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1043_chunk r_504
                      ->  Seq Scan on compress_hyper_14_1044_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_342_chunk r_311
-                     ->  Seq Scan on compress_hyper_14_1045_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_343_chunk r_312
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1045_chunk r_505
                      ->  Seq Scan on compress_hyper_14_1046_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_344_chunk r_313
-                     ->  Seq Scan on compress_hyper_14_1047_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_345_chunk r_314
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1047_chunk r_506
                      ->  Seq Scan on compress_hyper_14_1048_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_346_chunk r_315
-                     ->  Seq Scan on compress_hyper_14_1049_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_347_chunk r_316
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1049_chunk r_507
                      ->  Seq Scan on compress_hyper_14_1050_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_348_chunk r_317
-                     ->  Seq Scan on compress_hyper_14_1051_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_349_chunk r_318
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1051_chunk r_508
                      ->  Seq Scan on compress_hyper_14_1052_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_350_chunk r_319
-                     ->  Seq Scan on compress_hyper_14_1053_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_351_chunk r_320
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1053_chunk r_509
                      ->  Seq Scan on compress_hyper_14_1054_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_352_chunk r_321
-                     ->  Seq Scan on compress_hyper_14_1055_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_353_chunk r_322
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1055_chunk r_510
                      ->  Seq Scan on compress_hyper_14_1056_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_354_chunk r_323
-                     ->  Seq Scan on compress_hyper_14_1057_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_355_chunk r_324
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1057_chunk r_511
                      ->  Seq Scan on compress_hyper_14_1058_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_356_chunk r_325
-                     ->  Seq Scan on compress_hyper_14_1059_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_357_chunk r_326
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1059_chunk r_512
                      ->  Seq Scan on compress_hyper_14_1060_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_358_chunk r_327
-                     ->  Seq Scan on compress_hyper_14_1061_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_359_chunk r_328
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1061_chunk r_513
                      ->  Seq Scan on compress_hyper_14_1062_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_360_chunk r_329
-                     ->  Seq Scan on compress_hyper_14_1063_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_361_chunk r_330
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1063_chunk r_514
                      ->  Seq Scan on compress_hyper_14_1064_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_362_chunk r_331
-                     ->  Seq Scan on compress_hyper_14_1065_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_363_chunk r_332
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1065_chunk r_515
                      ->  Seq Scan on compress_hyper_14_1066_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_364_chunk r_333
-                     ->  Seq Scan on compress_hyper_14_1067_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_365_chunk r_334
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1067_chunk r_516
                      ->  Seq Scan on compress_hyper_14_1068_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_366_chunk r_335
-                     ->  Seq Scan on compress_hyper_14_1069_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_367_chunk r_336
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1069_chunk r_517
                      ->  Seq Scan on compress_hyper_14_1070_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_368_chunk r_337
-                     ->  Seq Scan on compress_hyper_14_1071_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_369_chunk r_338
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1071_chunk r_518
                      ->  Seq Scan on compress_hyper_14_1072_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_370_chunk r_339
-                     ->  Seq Scan on compress_hyper_14_1073_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_371_chunk r_340
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1073_chunk r_519
                      ->  Seq Scan on compress_hyper_14_1074_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_372_chunk r_341
-                     ->  Seq Scan on compress_hyper_14_1075_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_373_chunk r_342
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1075_chunk r_520
                      ->  Seq Scan on compress_hyper_14_1076_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_374_chunk r_343
-                     ->  Seq Scan on compress_hyper_14_1077_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_375_chunk r_344
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1077_chunk r_521
                      ->  Seq Scan on compress_hyper_14_1078_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_376_chunk r_345
-                     ->  Seq Scan on compress_hyper_14_1079_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_377_chunk r_346
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1079_chunk r_522
                      ->  Seq Scan on compress_hyper_14_1080_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_378_chunk r_347
-                     ->  Seq Scan on compress_hyper_14_1081_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_379_chunk r_348
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1081_chunk r_523
                      ->  Seq Scan on compress_hyper_14_1082_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_380_chunk r_349
-                     ->  Seq Scan on compress_hyper_14_1083_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_381_chunk r_350
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1083_chunk r_524
                      ->  Seq Scan on compress_hyper_14_1084_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_382_chunk r_351
-                     ->  Seq Scan on compress_hyper_14_1085_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_383_chunk r_352
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1085_chunk r_525
                      ->  Seq Scan on compress_hyper_14_1086_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_384_chunk r_353
-                     ->  Seq Scan on compress_hyper_14_1087_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_385_chunk r_354
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1087_chunk r_526
                      ->  Seq Scan on compress_hyper_14_1088_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_386_chunk r_355
-                     ->  Seq Scan on compress_hyper_14_1089_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_387_chunk r_356
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1089_chunk r_527
                      ->  Seq Scan on compress_hyper_14_1090_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_388_chunk r_357
-                     ->  Seq Scan on compress_hyper_14_1091_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_389_chunk r_358
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1091_chunk r_528
                      ->  Seq Scan on compress_hyper_14_1092_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_390_chunk r_359
-                     ->  Seq Scan on compress_hyper_14_1093_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_391_chunk r_360
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1093_chunk r_529
                      ->  Seq Scan on compress_hyper_14_1094_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_392_chunk r_361
-                     ->  Seq Scan on compress_hyper_14_1095_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_393_chunk r_362
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1095_chunk r_530
                      ->  Seq Scan on compress_hyper_14_1096_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_394_chunk r_363
-                     ->  Seq Scan on compress_hyper_14_1097_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_395_chunk r_364
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1097_chunk r_531
                      ->  Seq Scan on compress_hyper_14_1098_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_396_chunk r_365
-                     ->  Seq Scan on compress_hyper_14_1099_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_397_chunk r_366
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1099_chunk r_532
                      ->  Seq Scan on compress_hyper_14_1100_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_398_chunk r_367
-                     ->  Seq Scan on compress_hyper_14_1101_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_399_chunk r_368
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1101_chunk r_533
                      ->  Seq Scan on compress_hyper_14_1102_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_400_chunk r_369
-                     ->  Seq Scan on compress_hyper_14_1103_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_401_chunk r_370
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1103_chunk r_534
                      ->  Seq Scan on compress_hyper_14_1104_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_402_chunk r_371
-                     ->  Seq Scan on compress_hyper_14_1105_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_403_chunk r_372
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1105_chunk r_535
                      ->  Seq Scan on compress_hyper_14_1106_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_404_chunk r_373
-                     ->  Seq Scan on compress_hyper_14_1107_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_405_chunk r_374
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1107_chunk r_536
                      ->  Seq Scan on compress_hyper_14_1108_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_406_chunk r_375
-                     ->  Seq Scan on compress_hyper_14_1109_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_407_chunk r_376
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1109_chunk r_537
                      ->  Seq Scan on compress_hyper_14_1110_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_408_chunk r_377
-                     ->  Seq Scan on compress_hyper_14_1111_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_409_chunk r_378
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1111_chunk r_538
                      ->  Seq Scan on compress_hyper_14_1112_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_410_chunk r_379
-                     ->  Seq Scan on compress_hyper_14_1113_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_411_chunk r_380
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1113_chunk r_539
                      ->  Seq Scan on compress_hyper_14_1114_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_412_chunk r_381
-                     ->  Seq Scan on compress_hyper_14_1115_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_413_chunk r_382
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1115_chunk r_540
                      ->  Seq Scan on compress_hyper_14_1116_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_414_chunk r_383
-                     ->  Seq Scan on compress_hyper_14_1117_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_415_chunk r_384
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1117_chunk r_541
                      ->  Seq Scan on compress_hyper_14_1118_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_416_chunk r_385
-                     ->  Seq Scan on compress_hyper_14_1119_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_417_chunk r_386
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1119_chunk r_542
                      ->  Seq Scan on compress_hyper_14_1120_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_418_chunk r_387
-                     ->  Seq Scan on compress_hyper_14_1121_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_419_chunk r_388
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1121_chunk r_543
                      ->  Seq Scan on compress_hyper_14_1122_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_420_chunk r_389
-                     ->  Seq Scan on compress_hyper_14_1123_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_421_chunk r_390
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1123_chunk r_544
                      ->  Seq Scan on compress_hyper_14_1124_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_422_chunk r_391
-                     ->  Seq Scan on compress_hyper_14_1125_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_423_chunk r_392
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1125_chunk r_545
                      ->  Seq Scan on compress_hyper_14_1126_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_424_chunk r_393
-                     ->  Seq Scan on compress_hyper_14_1127_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_425_chunk r_394
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1127_chunk r_546
                      ->  Seq Scan on compress_hyper_14_1128_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_426_chunk r_395
-                     ->  Seq Scan on compress_hyper_14_1129_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_427_chunk r_396
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1129_chunk r_547
                      ->  Seq Scan on compress_hyper_14_1130_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_428_chunk r_397
-                     ->  Seq Scan on compress_hyper_14_1131_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_429_chunk r_398
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1131_chunk r_548
                      ->  Seq Scan on compress_hyper_14_1132_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_430_chunk r_399
-                     ->  Seq Scan on compress_hyper_14_1133_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_431_chunk r_400
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1133_chunk r_549
                      ->  Seq Scan on compress_hyper_14_1134_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_432_chunk r_401
-                     ->  Seq Scan on compress_hyper_14_1135_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_433_chunk r_402
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1135_chunk r_550
                      ->  Seq Scan on compress_hyper_14_1136_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_434_chunk r_403
-                     ->  Seq Scan on compress_hyper_14_1137_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_435_chunk r_404
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1137_chunk r_551
                      ->  Seq Scan on compress_hyper_14_1138_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_436_chunk r_405
-                     ->  Seq Scan on compress_hyper_14_1139_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_437_chunk r_406
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1139_chunk r_552
                      ->  Seq Scan on compress_hyper_14_1140_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_438_chunk r_407
-                     ->  Seq Scan on compress_hyper_14_1141_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_439_chunk r_408
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1141_chunk r_553
                      ->  Seq Scan on compress_hyper_14_1142_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_440_chunk r_409
-                     ->  Seq Scan on compress_hyper_14_1143_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_441_chunk r_410
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1143_chunk r_554
                      ->  Seq Scan on compress_hyper_14_1144_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_442_chunk r_411
-                     ->  Seq Scan on compress_hyper_14_1145_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_443_chunk r_412
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1145_chunk r_555
                      ->  Seq Scan on compress_hyper_14_1146_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_444_chunk r_413
-                     ->  Seq Scan on compress_hyper_14_1147_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_445_chunk r_414
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1147_chunk r_556
                      ->  Seq Scan on compress_hyper_14_1148_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_446_chunk r_415
-                     ->  Seq Scan on compress_hyper_14_1149_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_447_chunk r_416
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1149_chunk r_557
                      ->  Seq Scan on compress_hyper_14_1150_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_448_chunk r_417
-                     ->  Seq Scan on compress_hyper_14_1151_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_449_chunk r_418
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1151_chunk r_558
                      ->  Seq Scan on compress_hyper_14_1152_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_450_chunk r_419
-                     ->  Seq Scan on compress_hyper_14_1153_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_451_chunk r_420
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1153_chunk r_559
                      ->  Seq Scan on compress_hyper_14_1154_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_452_chunk r_421
-                     ->  Seq Scan on compress_hyper_14_1155_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_453_chunk r_422
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1155_chunk r_560
                      ->  Seq Scan on compress_hyper_14_1156_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_454_chunk r_423
-                     ->  Seq Scan on compress_hyper_14_1157_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_455_chunk r_424
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1157_chunk r_561
                      ->  Seq Scan on compress_hyper_14_1158_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_456_chunk r_425
-                     ->  Seq Scan on compress_hyper_14_1159_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_457_chunk r_426
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1159_chunk r_562
                      ->  Seq Scan on compress_hyper_14_1160_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_458_chunk r_427
-                     ->  Seq Scan on compress_hyper_14_1161_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_459_chunk r_428
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1161_chunk r_563
                      ->  Seq Scan on compress_hyper_14_1162_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_460_chunk r_429
-                     ->  Seq Scan on compress_hyper_14_1163_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_461_chunk r_430
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1163_chunk r_564
                      ->  Seq Scan on compress_hyper_14_1164_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_462_chunk r_431
-                     ->  Seq Scan on compress_hyper_14_1165_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_463_chunk r_432
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1165_chunk r_565
                      ->  Seq Scan on compress_hyper_14_1166_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_464_chunk r_433
-                     ->  Seq Scan on compress_hyper_14_1167_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_465_chunk r_434
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1167_chunk r_566
                      ->  Seq Scan on compress_hyper_14_1168_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_466_chunk r_435
-                     ->  Seq Scan on compress_hyper_14_1169_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_467_chunk r_436
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1169_chunk r_567
                      ->  Seq Scan on compress_hyper_14_1170_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_468_chunk r_437
-                     ->  Seq Scan on compress_hyper_14_1171_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_469_chunk r_438
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1171_chunk r_568
                      ->  Seq Scan on compress_hyper_14_1172_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_470_chunk r_439
-                     ->  Seq Scan on compress_hyper_14_1173_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_471_chunk r_440
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1173_chunk r_569
                      ->  Seq Scan on compress_hyper_14_1174_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_472_chunk r_441
-                     ->  Seq Scan on compress_hyper_14_1175_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_473_chunk r_442
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1175_chunk r_570
                      ->  Seq Scan on compress_hyper_14_1176_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_474_chunk r_443
-                     ->  Seq Scan on compress_hyper_14_1177_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_475_chunk r_444
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1177_chunk r_571
                      ->  Seq Scan on compress_hyper_14_1178_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_476_chunk r_445
-                     ->  Seq Scan on compress_hyper_14_1179_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_477_chunk r_446
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1179_chunk r_572
                      ->  Seq Scan on compress_hyper_14_1180_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_478_chunk r_447
-                     ->  Seq Scan on compress_hyper_14_1181_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_479_chunk r_448
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1181_chunk r_573
                      ->  Seq Scan on compress_hyper_14_1182_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_480_chunk r_449
-                     ->  Seq Scan on compress_hyper_14_1183_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_481_chunk r_450
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1183_chunk r_574
                      ->  Seq Scan on compress_hyper_14_1184_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_482_chunk r_451
-                     ->  Seq Scan on compress_hyper_14_1185_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_483_chunk r_452
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1185_chunk r_575
                      ->  Seq Scan on compress_hyper_14_1186_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_484_chunk r_453
-                     ->  Seq Scan on compress_hyper_14_1187_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_485_chunk r_454
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1187_chunk r_576
                      ->  Seq Scan on compress_hyper_14_1188_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_486_chunk r_455
-                     ->  Seq Scan on compress_hyper_14_1189_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_487_chunk r_456
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1189_chunk r_577
                      ->  Seq Scan on compress_hyper_14_1190_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_488_chunk r_457
-                     ->  Seq Scan on compress_hyper_14_1191_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_489_chunk r_458
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1191_chunk r_578
                      ->  Seq Scan on compress_hyper_14_1192_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_490_chunk r_459
-                     ->  Seq Scan on compress_hyper_14_1193_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_491_chunk r_460
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1193_chunk r_579
                      ->  Seq Scan on compress_hyper_14_1194_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_492_chunk r_461
-                     ->  Seq Scan on compress_hyper_14_1195_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_493_chunk r_462
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1195_chunk r_580
                      ->  Seq Scan on compress_hyper_14_1196_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_494_chunk r_463
-                     ->  Seq Scan on compress_hyper_14_1197_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_495_chunk r_464
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1197_chunk r_581
                      ->  Seq Scan on compress_hyper_14_1198_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_496_chunk r_465
-                     ->  Seq Scan on compress_hyper_14_1199_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_497_chunk r_466
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1199_chunk r_582
                      ->  Seq Scan on compress_hyper_14_1200_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_498_chunk r_467
-                     ->  Seq Scan on compress_hyper_14_1201_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_499_chunk r_468
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1201_chunk r_583
                      ->  Seq Scan on compress_hyper_14_1202_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_500_chunk r_469
-                     ->  Seq Scan on compress_hyper_14_1203_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_501_chunk r_470
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1203_chunk r_584
                      ->  Seq Scan on compress_hyper_14_1204_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_502_chunk r_471
-                     ->  Seq Scan on compress_hyper_14_1205_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_503_chunk r_472
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1205_chunk r_585
                      ->  Seq Scan on compress_hyper_14_1206_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_504_chunk r_473
-                     ->  Seq Scan on compress_hyper_14_1207_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_505_chunk r_474
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1207_chunk r_586
                      ->  Seq Scan on compress_hyper_14_1208_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_506_chunk r_475
-                     ->  Seq Scan on compress_hyper_14_1209_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_507_chunk r_476
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1209_chunk r_587
                      ->  Seq Scan on compress_hyper_14_1210_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_508_chunk r_477
-                     ->  Seq Scan on compress_hyper_14_1211_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_509_chunk r_478
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1211_chunk r_588
                      ->  Seq Scan on compress_hyper_14_1212_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_510_chunk r_479
-                     ->  Seq Scan on compress_hyper_14_1213_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_511_chunk r_480
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1213_chunk r_589
                      ->  Seq Scan on compress_hyper_14_1214_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_512_chunk r_481
-                     ->  Seq Scan on compress_hyper_14_1215_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_513_chunk r_482
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1215_chunk r_590
                      ->  Seq Scan on compress_hyper_14_1216_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_514_chunk r_483
-                     ->  Seq Scan on compress_hyper_14_1217_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_515_chunk r_484
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1217_chunk r_591
                      ->  Seq Scan on compress_hyper_14_1218_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_516_chunk r_485
-                     ->  Seq Scan on compress_hyper_14_1219_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_517_chunk r_486
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1219_chunk r_592
                      ->  Seq Scan on compress_hyper_14_1220_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_518_chunk r_487
-                     ->  Seq Scan on compress_hyper_14_1221_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_519_chunk r_488
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1221_chunk r_593
                      ->  Seq Scan on compress_hyper_14_1222_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_520_chunk r_489
-                     ->  Seq Scan on compress_hyper_14_1223_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_521_chunk r_490
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1223_chunk r_594
                      ->  Seq Scan on compress_hyper_14_1224_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_522_chunk r_491
-                     ->  Seq Scan on compress_hyper_14_1225_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_523_chunk r_492
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1225_chunk r_595
                      ->  Seq Scan on compress_hyper_14_1226_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_524_chunk r_493
-                     ->  Seq Scan on compress_hyper_14_1227_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_525_chunk r_494
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1227_chunk r_596
                      ->  Seq Scan on compress_hyper_14_1228_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_526_chunk r_495
-                     ->  Seq Scan on compress_hyper_14_1229_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_527_chunk r_496
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1229_chunk r_597
                      ->  Seq Scan on compress_hyper_14_1230_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_528_chunk r_497
-                     ->  Seq Scan on compress_hyper_14_1231_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_529_chunk r_498
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1231_chunk r_598
                      ->  Seq Scan on compress_hyper_14_1232_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_530_chunk r_499
-                     ->  Seq Scan on compress_hyper_14_1233_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_531_chunk r_500
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1233_chunk r_599
                      ->  Seq Scan on compress_hyper_14_1234_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_532_chunk r_501
-                     ->  Seq Scan on compress_hyper_14_1235_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_533_chunk r_502
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1235_chunk r_600
                      ->  Seq Scan on compress_hyper_14_1236_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_534_chunk r_503
-                     ->  Seq Scan on compress_hyper_14_1237_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_535_chunk r_504
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1237_chunk r_601
                      ->  Seq Scan on compress_hyper_14_1238_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_536_chunk r_505
-                     ->  Seq Scan on compress_hyper_14_1239_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_537_chunk r_506
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1239_chunk r_602
                      ->  Seq Scan on compress_hyper_14_1240_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_538_chunk r_507
-                     ->  Seq Scan on compress_hyper_14_1241_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_539_chunk r_508
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1241_chunk r_603
                      ->  Seq Scan on compress_hyper_14_1242_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_540_chunk r_509
-                     ->  Seq Scan on compress_hyper_14_1243_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_541_chunk r_510
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1243_chunk r_604
                      ->  Seq Scan on compress_hyper_14_1244_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_542_chunk r_511
-                     ->  Seq Scan on compress_hyper_14_1245_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_543_chunk r_512
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1245_chunk r_605
                      ->  Seq Scan on compress_hyper_14_1246_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_544_chunk r_513
-                     ->  Seq Scan on compress_hyper_14_1247_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_545_chunk r_514
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1247_chunk r_606
                      ->  Seq Scan on compress_hyper_14_1248_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_546_chunk r_515
-                     ->  Seq Scan on compress_hyper_14_1249_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_547_chunk r_516
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1249_chunk r_607
                      ->  Seq Scan on compress_hyper_14_1250_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_548_chunk r_517
-                     ->  Seq Scan on compress_hyper_14_1251_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_549_chunk r_518
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1251_chunk r_608
                      ->  Seq Scan on compress_hyper_14_1252_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_550_chunk r_519
-                     ->  Seq Scan on compress_hyper_14_1253_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_551_chunk r_520
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1253_chunk r_609
                      ->  Seq Scan on compress_hyper_14_1254_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_552_chunk r_521
-                     ->  Seq Scan on compress_hyper_14_1255_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_553_chunk r_522
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1255_chunk r_610
                      ->  Seq Scan on compress_hyper_14_1256_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_554_chunk r_523
-                     ->  Seq Scan on compress_hyper_14_1257_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_555_chunk r_524
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1257_chunk r_611
                      ->  Seq Scan on compress_hyper_14_1258_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_556_chunk r_525
-                     ->  Seq Scan on compress_hyper_14_1259_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_557_chunk r_526
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1259_chunk r_612
                      ->  Seq Scan on compress_hyper_14_1260_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_558_chunk r_527
-                     ->  Seq Scan on compress_hyper_14_1261_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_559_chunk r_528
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1261_chunk r_613
                      ->  Seq Scan on compress_hyper_14_1262_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_560_chunk r_529
-                     ->  Seq Scan on compress_hyper_14_1263_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_561_chunk r_530
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1263_chunk r_614
                      ->  Seq Scan on compress_hyper_14_1264_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_562_chunk r_531
-                     ->  Seq Scan on compress_hyper_14_1265_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_563_chunk r_532
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1265_chunk r_615
                      ->  Seq Scan on compress_hyper_14_1266_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_564_chunk r_533
-                     ->  Seq Scan on compress_hyper_14_1267_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_565_chunk r_534
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1267_chunk r_616
                      ->  Seq Scan on compress_hyper_14_1268_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_566_chunk r_535
-                     ->  Seq Scan on compress_hyper_14_1269_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_567_chunk r_536
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1269_chunk r_617
                      ->  Seq Scan on compress_hyper_14_1270_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_568_chunk r_537
-                     ->  Seq Scan on compress_hyper_14_1271_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_569_chunk r_538
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1271_chunk r_618
                      ->  Seq Scan on compress_hyper_14_1272_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_570_chunk r_539
-                     ->  Seq Scan on compress_hyper_14_1273_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_571_chunk r_540
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1273_chunk r_619
                      ->  Seq Scan on compress_hyper_14_1274_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_572_chunk r_541
-                     ->  Seq Scan on compress_hyper_14_1275_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_573_chunk r_542
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1275_chunk r_620
                      ->  Seq Scan on compress_hyper_14_1276_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_574_chunk r_543
-                     ->  Seq Scan on compress_hyper_14_1277_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_575_chunk r_544
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1277_chunk r_621
                      ->  Seq Scan on compress_hyper_14_1278_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_576_chunk r_545
-                     ->  Seq Scan on compress_hyper_14_1279_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_577_chunk r_546
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1279_chunk r_622
                      ->  Seq Scan on compress_hyper_14_1280_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_578_chunk r_547
-                     ->  Seq Scan on compress_hyper_14_1281_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_579_chunk r_548
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1281_chunk r_623
                      ->  Seq Scan on compress_hyper_14_1282_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_580_chunk r_549
-                     ->  Seq Scan on compress_hyper_14_1283_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_581_chunk r_550
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1283_chunk r_624
                      ->  Seq Scan on compress_hyper_14_1284_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_582_chunk r_551
-                     ->  Seq Scan on compress_hyper_14_1285_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_583_chunk r_552
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1285_chunk r_625
                      ->  Seq Scan on compress_hyper_14_1286_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_584_chunk r_553
-                     ->  Seq Scan on compress_hyper_14_1287_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_585_chunk r_554
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1287_chunk r_626
                      ->  Seq Scan on compress_hyper_14_1288_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_586_chunk r_555
-                     ->  Seq Scan on compress_hyper_14_1289_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_587_chunk r_556
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1289_chunk r_627
                      ->  Seq Scan on compress_hyper_14_1290_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_588_chunk r_557
-                     ->  Seq Scan on compress_hyper_14_1291_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_589_chunk r_558
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1291_chunk r_628
                      ->  Seq Scan on compress_hyper_14_1292_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_590_chunk r_559
-                     ->  Seq Scan on compress_hyper_14_1293_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_591_chunk r_560
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1293_chunk r_629
                      ->  Seq Scan on compress_hyper_14_1294_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_592_chunk r_561
-                     ->  Seq Scan on compress_hyper_14_1295_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_593_chunk r_562
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1295_chunk r_630
                      ->  Seq Scan on compress_hyper_14_1296_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_594_chunk r_563
-                     ->  Seq Scan on compress_hyper_14_1297_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_595_chunk r_564
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1297_chunk r_631
                      ->  Seq Scan on compress_hyper_14_1298_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_596_chunk r_565
-                     ->  Seq Scan on compress_hyper_14_1299_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_597_chunk r_566
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1299_chunk r_632
                      ->  Seq Scan on compress_hyper_14_1300_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_598_chunk r_567
-                     ->  Seq Scan on compress_hyper_14_1301_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_599_chunk r_568
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1301_chunk r_633
                      ->  Seq Scan on compress_hyper_14_1302_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_600_chunk r_569
-                     ->  Seq Scan on compress_hyper_14_1303_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_601_chunk r_570
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1303_chunk r_634
                      ->  Seq Scan on compress_hyper_14_1304_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_602_chunk r_571
-                     ->  Seq Scan on compress_hyper_14_1305_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_603_chunk r_572
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1305_chunk r_635
                      ->  Seq Scan on compress_hyper_14_1306_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_604_chunk r_573
-                     ->  Seq Scan on compress_hyper_14_1307_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_605_chunk r_574
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1307_chunk r_636
                      ->  Seq Scan on compress_hyper_14_1308_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_606_chunk r_575
-                     ->  Seq Scan on compress_hyper_14_1309_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_607_chunk r_576
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1309_chunk r_637
                      ->  Seq Scan on compress_hyper_14_1310_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_608_chunk r_577
-                     ->  Seq Scan on compress_hyper_14_1311_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_609_chunk r_578
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1311_chunk r_638
                      ->  Seq Scan on compress_hyper_14_1312_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_610_chunk r_579
-                     ->  Seq Scan on compress_hyper_14_1313_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_611_chunk r_580
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1313_chunk r_639
                      ->  Seq Scan on compress_hyper_14_1314_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_612_chunk r_581
-                     ->  Seq Scan on compress_hyper_14_1315_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_613_chunk r_582
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1315_chunk r_640
                      ->  Seq Scan on compress_hyper_14_1316_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_614_chunk r_583
-                     ->  Seq Scan on compress_hyper_14_1317_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_615_chunk r_584
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1317_chunk r_641
                      ->  Seq Scan on compress_hyper_14_1318_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_616_chunk r_585
-                     ->  Seq Scan on compress_hyper_14_1319_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_617_chunk r_586
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1319_chunk r_642
                      ->  Seq Scan on compress_hyper_14_1320_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_618_chunk r_587
-                     ->  Seq Scan on compress_hyper_14_1321_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_619_chunk r_588
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1321_chunk r_643
                      ->  Seq Scan on compress_hyper_14_1322_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_620_chunk r_589
-                     ->  Seq Scan on compress_hyper_14_1323_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_621_chunk r_590
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1323_chunk r_644
                      ->  Seq Scan on compress_hyper_14_1324_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_622_chunk r_591
-                     ->  Seq Scan on compress_hyper_14_1325_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_623_chunk r_592
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1325_chunk r_645
                      ->  Seq Scan on compress_hyper_14_1326_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_624_chunk r_593
-                     ->  Seq Scan on compress_hyper_14_1327_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_625_chunk r_594
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1327_chunk r_646
                      ->  Seq Scan on compress_hyper_14_1328_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_626_chunk r_595
-                     ->  Seq Scan on compress_hyper_14_1329_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_627_chunk r_596
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1329_chunk r_647
                      ->  Seq Scan on compress_hyper_14_1330_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_628_chunk r_597
-                     ->  Seq Scan on compress_hyper_14_1331_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_629_chunk r_598
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1331_chunk r_648
                      ->  Seq Scan on compress_hyper_14_1332_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_630_chunk r_599
-                     ->  Seq Scan on compress_hyper_14_1333_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_631_chunk r_600
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1333_chunk r_649
                      ->  Seq Scan on compress_hyper_14_1334_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_632_chunk r_601
-                     ->  Seq Scan on compress_hyper_14_1335_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_633_chunk r_602
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1335_chunk r_650
                      ->  Seq Scan on compress_hyper_14_1336_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_634_chunk r_603
-                     ->  Seq Scan on compress_hyper_14_1337_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_635_chunk r_604
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1337_chunk r_651
                      ->  Seq Scan on compress_hyper_14_1338_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_636_chunk r_605
-                     ->  Seq Scan on compress_hyper_14_1339_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_637_chunk r_606
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1339_chunk r_652
                      ->  Seq Scan on compress_hyper_14_1340_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_638_chunk r_607
-                     ->  Seq Scan on compress_hyper_14_1341_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_639_chunk r_608
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1341_chunk r_653
                      ->  Seq Scan on compress_hyper_14_1342_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_640_chunk r_609
-                     ->  Seq Scan on compress_hyper_14_1343_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_641_chunk r_610
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1343_chunk r_654
                      ->  Seq Scan on compress_hyper_14_1344_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_642_chunk r_611
-                     ->  Seq Scan on compress_hyper_14_1345_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_643_chunk r_612
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1345_chunk r_655
                      ->  Seq Scan on compress_hyper_14_1346_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_644_chunk r_613
-                     ->  Seq Scan on compress_hyper_14_1347_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_645_chunk r_614
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1347_chunk r_656
                      ->  Seq Scan on compress_hyper_14_1348_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_646_chunk r_615
-                     ->  Seq Scan on compress_hyper_14_1349_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_647_chunk r_616
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1349_chunk r_657
                      ->  Seq Scan on compress_hyper_14_1350_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_648_chunk r_617
-                     ->  Seq Scan on compress_hyper_14_1351_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_649_chunk r_618
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1351_chunk r_658
                      ->  Seq Scan on compress_hyper_14_1352_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_650_chunk r_619
-                     ->  Seq Scan on compress_hyper_14_1353_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_651_chunk r_620
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1353_chunk r_659
                      ->  Seq Scan on compress_hyper_14_1354_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_652_chunk r_621
-                     ->  Seq Scan on compress_hyper_14_1355_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_653_chunk r_622
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1355_chunk r_660
                      ->  Seq Scan on compress_hyper_14_1356_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_654_chunk r_623
-                     ->  Seq Scan on compress_hyper_14_1357_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_655_chunk r_624
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1357_chunk r_661
                      ->  Seq Scan on compress_hyper_14_1358_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_656_chunk r_625
-                     ->  Seq Scan on compress_hyper_14_1359_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_657_chunk r_626
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1359_chunk r_662
                      ->  Seq Scan on compress_hyper_14_1360_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_658_chunk r_627
-                     ->  Seq Scan on compress_hyper_14_1361_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_659_chunk r_628
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1361_chunk r_663
                      ->  Seq Scan on compress_hyper_14_1362_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_660_chunk r_629
-                     ->  Seq Scan on compress_hyper_14_1363_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_661_chunk r_630
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1363_chunk r_664
                      ->  Seq Scan on compress_hyper_14_1364_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_662_chunk r_631
-                     ->  Seq Scan on compress_hyper_14_1365_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_663_chunk r_632
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1365_chunk r_665
                      ->  Seq Scan on compress_hyper_14_1366_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_664_chunk r_633
-                     ->  Seq Scan on compress_hyper_14_1367_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_665_chunk r_634
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1367_chunk r_666
                      ->  Seq Scan on compress_hyper_14_1368_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_666_chunk r_635
-                     ->  Seq Scan on compress_hyper_14_1369_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_667_chunk r_636
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1369_chunk r_667
                      ->  Seq Scan on compress_hyper_14_1370_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_668_chunk r_637
-                     ->  Seq Scan on compress_hyper_14_1371_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_669_chunk r_638
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1371_chunk r_668
                      ->  Seq Scan on compress_hyper_14_1372_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_670_chunk r_639
-                     ->  Seq Scan on compress_hyper_14_1373_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_671_chunk r_640
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1373_chunk r_669
                      ->  Seq Scan on compress_hyper_14_1374_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_672_chunk r_641
-                     ->  Seq Scan on compress_hyper_14_1375_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_673_chunk r_642
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1375_chunk r_670
                      ->  Seq Scan on compress_hyper_14_1376_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_674_chunk r_643
-                     ->  Seq Scan on compress_hyper_14_1377_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_675_chunk r_644
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1377_chunk r_671
                      ->  Seq Scan on compress_hyper_14_1378_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_676_chunk r_645
-                     ->  Seq Scan on compress_hyper_14_1379_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_677_chunk r_646
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1379_chunk r_672
                      ->  Seq Scan on compress_hyper_14_1380_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_678_chunk r_647
-                     ->  Seq Scan on compress_hyper_14_1381_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_679_chunk r_648
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1381_chunk r_673
                      ->  Seq Scan on compress_hyper_14_1382_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_680_chunk r_649
-                     ->  Seq Scan on compress_hyper_14_1383_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_681_chunk r_650
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1383_chunk r_674
                      ->  Seq Scan on compress_hyper_14_1384_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_682_chunk r_651
-                     ->  Seq Scan on compress_hyper_14_1385_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_683_chunk r_652
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1385_chunk r_675
                      ->  Seq Scan on compress_hyper_14_1386_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_684_chunk r_653
-                     ->  Seq Scan on compress_hyper_14_1387_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_685_chunk r_654
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1387_chunk r_676
                      ->  Seq Scan on compress_hyper_14_1388_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_686_chunk r_655
-                     ->  Seq Scan on compress_hyper_14_1389_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_687_chunk r_656
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1389_chunk r_677
                      ->  Seq Scan on compress_hyper_14_1390_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_688_chunk r_657
-                     ->  Seq Scan on compress_hyper_14_1391_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_689_chunk r_658
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1391_chunk r_678
                      ->  Seq Scan on compress_hyper_14_1392_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_690_chunk r_659
-                     ->  Seq Scan on compress_hyper_14_1393_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_691_chunk r_660
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1393_chunk r_679
                      ->  Seq Scan on compress_hyper_14_1394_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_692_chunk r_661
-                     ->  Seq Scan on compress_hyper_14_1395_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_693_chunk r_662
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1395_chunk r_680
                      ->  Seq Scan on compress_hyper_14_1396_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_694_chunk r_663
-                     ->  Seq Scan on compress_hyper_14_1397_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_695_chunk r_664
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1397_chunk r_681
                      ->  Seq Scan on compress_hyper_14_1398_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_696_chunk r_665
-                     ->  Seq Scan on compress_hyper_14_1399_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_697_chunk r_666
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1399_chunk r_682
                      ->  Seq Scan on compress_hyper_14_1400_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_698_chunk r_667
-                     ->  Seq Scan on compress_hyper_14_1401_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_699_chunk r_668
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1401_chunk r_683
                      ->  Seq Scan on compress_hyper_14_1402_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_700_chunk r_669
-                     ->  Seq Scan on compress_hyper_14_1403_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_701_chunk r_670
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1403_chunk r_684
                      ->  Seq Scan on compress_hyper_14_1404_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_702_chunk r_671
-                     ->  Seq Scan on compress_hyper_14_1405_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_703_chunk r_672
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1405_chunk r_685
                      ->  Seq Scan on compress_hyper_14_1406_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_704_chunk r_673
-                     ->  Seq Scan on compress_hyper_14_1407_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_705_chunk r_674
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1407_chunk r_686
                      ->  Seq Scan on compress_hyper_14_1408_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_706_chunk r_675
-                     ->  Seq Scan on compress_hyper_14_1409_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_707_chunk r_676
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1409_chunk r_687
                      ->  Seq Scan on compress_hyper_14_1410_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_708_chunk r_677
-                     ->  Seq Scan on compress_hyper_14_1411_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_709_chunk r_678
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1411_chunk r_688
                      ->  Seq Scan on compress_hyper_14_1412_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_710_chunk r_679
-                     ->  Seq Scan on compress_hyper_14_1413_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_711_chunk r_680
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1413_chunk r_689
                      ->  Seq Scan on compress_hyper_14_1414_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_712_chunk r_681
-                     ->  Seq Scan on compress_hyper_14_1415_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_713_chunk r_682
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1415_chunk r_690
                      ->  Seq Scan on compress_hyper_14_1416_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_714_chunk r_683
-                     ->  Seq Scan on compress_hyper_14_1417_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_715_chunk r_684
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1417_chunk r_691
                      ->  Seq Scan on compress_hyper_14_1418_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_716_chunk r_685
-                     ->  Seq Scan on compress_hyper_14_1419_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_717_chunk r_686
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1419_chunk r_692
                      ->  Seq Scan on compress_hyper_14_1420_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_718_chunk r_687
-                     ->  Seq Scan on compress_hyper_14_1421_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_719_chunk r_688
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1421_chunk r_693
                      ->  Seq Scan on compress_hyper_14_1422_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_720_chunk r_689
-                     ->  Seq Scan on compress_hyper_14_1423_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_721_chunk r_690
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1423_chunk r_694
                      ->  Seq Scan on compress_hyper_14_1424_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_722_chunk r_691
-                     ->  Seq Scan on compress_hyper_14_1425_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_723_chunk r_692
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1425_chunk r_695
                      ->  Seq Scan on compress_hyper_14_1426_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_724_chunk r_693
-                     ->  Seq Scan on compress_hyper_14_1427_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_725_chunk r_694
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1427_chunk r_696
                      ->  Seq Scan on compress_hyper_14_1428_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_726_chunk r_695
-                     ->  Seq Scan on compress_hyper_14_1429_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_727_chunk r_696
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1429_chunk r_697
                      ->  Seq Scan on compress_hyper_14_1430_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_728_chunk r_697
-                     ->  Seq Scan on compress_hyper_14_1431_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_729_chunk r_698
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1431_chunk r_698
                      ->  Seq Scan on compress_hyper_14_1432_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_730_chunk r_699
-                     ->  Seq Scan on compress_hyper_14_1433_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_731_chunk r_700
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1433_chunk r_699
                      ->  Seq Scan on compress_hyper_14_1434_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_732_chunk r_701
-                     ->  Seq Scan on compress_hyper_14_1435_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_733_chunk r_702
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1435_chunk r_700
                      ->  Seq Scan on compress_hyper_14_1436_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_734_chunk r_703
-                     ->  Seq Scan on compress_hyper_14_1437_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1437_chunk r_701
+                     ->  Seq Scan on compress_hyper_14_1438_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1439_chunk r_702
+                     ->  Seq Scan on compress_hyper_14_1440_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1441_chunk r_703
+                     ->  Seq Scan on compress_hyper_14_1442_chunk
          ->  Hash
                ->  Seq Scan on tags t
 (1413 rows)
@@ -9599,7 +9599,7 @@ EXPLAIN (costs off) SELECT * FROM metrics ORDER BY time, device_id;
                ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk
                      ->  Parallel Seq Scan on compress_hyper_5_15_chunk
                ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk
-                     ->  Parallel Seq Scan on compress_hyper_5_16_chunk
+                     ->  Parallel Seq Scan on compress_hyper_5_17_chunk
                ->  Parallel Seq Scan on _hyper_1_2_chunk
 (10 rows)
 
@@ -9617,7 +9617,7 @@ EXPLAIN (costs off) SELECT time_bucket('10 minutes', time) bucket, avg(v0) avg_v
                            ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk
                                  ->  Parallel Seq Scan on compress_hyper_5_15_chunk
                            ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk
-                                 ->  Parallel Seq Scan on compress_hyper_5_16_chunk
+                                 ->  Parallel Seq Scan on compress_hyper_5_17_chunk
                            ->  Parallel Seq Scan on _hyper_1_2_chunk
 (13 rows)
 
@@ -9630,15 +9630,15 @@ EXPLAIN (costs off) SELECT * FROM metrics_space ORDER BY time, device_id;
          Sort Key: _hyper_2_4_chunk."time", _hyper_2_4_chunk.device_id
          ->  Parallel Append
                ->  Custom Scan (DecompressChunk) on _hyper_2_4_chunk
-                     ->  Parallel Seq Scan on compress_hyper_6_17_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_2_6_chunk
-                     ->  Parallel Seq Scan on compress_hyper_6_19_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_2_10_chunk
-                     ->  Parallel Seq Scan on compress_hyper_6_20_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_2_5_chunk
                      ->  Parallel Seq Scan on compress_hyper_6_18_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_2_6_chunk
+                     ->  Parallel Seq Scan on compress_hyper_6_20_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_2_10_chunk
+                     ->  Parallel Seq Scan on compress_hyper_6_24_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_2_5_chunk
+                     ->  Parallel Seq Scan on compress_hyper_6_19_chunk
                ->  Custom Scan (DecompressChunk) on _hyper_2_11_chunk
-                     ->  Parallel Seq Scan on compress_hyper_6_21_chunk
+                     ->  Parallel Seq Scan on compress_hyper_6_25_chunk
                ->  Parallel Seq Scan on _hyper_2_8_chunk
                ->  Parallel Seq Scan on _hyper_2_7_chunk
                ->  Parallel Seq Scan on _hyper_2_9_chunk
@@ -9662,7 +9662,7 @@ EXPLAIN (costs off) SELECT * FROM metrics WHERE time > '2000-01-08' ORDER BY dev
                Index Cond: ("time" > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
    ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk
          Filter: ("time" > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
-         ->  Index Scan using compress_hyper_5_16_chunk_c_index_2 on compress_hyper_5_16_chunk
+         ->  Index Scan using compress_hyper_5_17_chunk_c_index_2 on compress_hyper_5_17_chunk
                Filter: (_ts_meta_max_3 > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
 (10 rows)
 
@@ -9679,11 +9679,11 @@ EXPLAIN (costs off) SELECT * FROM metrics_space WHERE time > '2000-01-08' ORDER 
          Index Cond: ("time" > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
    ->  Custom Scan (DecompressChunk) on _hyper_2_10_chunk
          Filter: ("time" > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
-         ->  Index Scan using compress_hyper_6_20_chunk_c_space_index_2 on compress_hyper_6_20_chunk
+         ->  Index Scan using compress_hyper_6_24_chunk_c_space_index_2 on compress_hyper_6_24_chunk
                Filter: (_ts_meta_max_3 > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
    ->  Custom Scan (DecompressChunk) on _hyper_2_11_chunk
          Filter: ("time" > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
-         ->  Index Scan using compress_hyper_6_21_chunk_c_space_index_2 on compress_hyper_6_21_chunk
+         ->  Index Scan using compress_hyper_6_25_chunk_c_space_index_2 on compress_hyper_6_25_chunk
                Filter: (_ts_meta_max_3 > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
    ->  Index Scan Backward using _hyper_2_12_chunk_metrics_space_device_id_device_id_peer_v0_v_2 on _hyper_2_12_chunk
          Index Cond: ("time" > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
@@ -9719,7 +9719,7 @@ $sql$;
          ->  Seq Scan on compress_hyper_5_15_chunk (actual rows=5 loops=1)
    ->  Seq Scan on _hyper_1_2_chunk (actual rows=2520 loops=1)
    ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk (actual rows=2520 loops=1)
-         ->  Seq Scan on compress_hyper_5_16_chunk (actual rows=5 loops=1)
+         ->  Seq Scan on compress_hyper_5_17_chunk (actual rows=5 loops=1)
 (6 rows)
 
 \c
@@ -9732,7 +9732,7 @@ $sql$;
          ->  Seq Scan on compress_hyper_5_15_chunk (actual rows=5 loops=1)
    ->  Seq Scan on _hyper_1_2_chunk (actual rows=2520 loops=1)
    ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk (actual rows=2520 loops=1)
-         ->  Seq Scan on compress_hyper_5_16_chunk (actual rows=5 loops=1)
+         ->  Seq Scan on compress_hyper_5_17_chunk (actual rows=5 loops=1)
 (6 rows)
 
 -- repro for core dump related to total_table_pages setting that get
@@ -9788,7 +9788,7 @@ FROM ( SELECT chunk_schema || '.' || chunk_name as chunk_table
        WHERE hypertable_name = 'motion_table' ORDER BY range_start limit 1 ) q;
                compress_chunk               
 --------------------------------------------
- _timescaledb_internal._hyper_15_1438_chunk
+ _timescaledb_internal._hyper_15_1443_chunk
 (1 row)
 
 --call to decompress chunk on 1 of the chunks

--- a/tsl/test/expected/transparent_decompression-14.out
+++ b/tsl/test/expected/transparent_decompression-14.out
@@ -254,9 +254,9 @@ LIMIT 5;
                ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_3_chunk (never executed)
                      Output: _hyper_1_3_chunk."time", _hyper_1_3_chunk.device_id, _hyper_1_3_chunk.device_id_peer, _hyper_1_3_chunk.v0, _hyper_1_3_chunk.v1, _hyper_1_3_chunk.v2, _hyper_1_3_chunk.v3
                      Bulk Decompression: true
-                     ->  Seq Scan on _timescaledb_internal.compress_hyper_5_16_chunk (never executed)
-                           Output: compress_hyper_5_16_chunk."time", compress_hyper_5_16_chunk.device_id, compress_hyper_5_16_chunk.device_id_peer, compress_hyper_5_16_chunk.v0, compress_hyper_5_16_chunk.v1, compress_hyper_5_16_chunk.v2, compress_hyper_5_16_chunk.v3, compress_hyper_5_16_chunk._ts_meta_count, compress_hyper_5_16_chunk._ts_meta_sequence_num, compress_hyper_5_16_chunk._ts_meta_min_3, compress_hyper_5_16_chunk._ts_meta_max_3, compress_hyper_5_16_chunk._ts_meta_min_1, compress_hyper_5_16_chunk._ts_meta_max_1, compress_hyper_5_16_chunk._ts_meta_min_2, compress_hyper_5_16_chunk._ts_meta_max_2
-                           Filter: (compress_hyper_5_16_chunk.device_id = 1)
+                     ->  Seq Scan on _timescaledb_internal.compress_hyper_5_17_chunk (never executed)
+                           Output: compress_hyper_5_17_chunk."time", compress_hyper_5_17_chunk.device_id, compress_hyper_5_17_chunk.device_id_peer, compress_hyper_5_17_chunk.v0, compress_hyper_5_17_chunk.v1, compress_hyper_5_17_chunk.v2, compress_hyper_5_17_chunk.v3, compress_hyper_5_17_chunk._ts_meta_count, compress_hyper_5_17_chunk._ts_meta_sequence_num, compress_hyper_5_17_chunk._ts_meta_min_3, compress_hyper_5_17_chunk._ts_meta_max_3, compress_hyper_5_17_chunk._ts_meta_min_1, compress_hyper_5_17_chunk._ts_meta_max_1, compress_hyper_5_17_chunk._ts_meta_min_2, compress_hyper_5_17_chunk._ts_meta_max_2
+                           Filter: (compress_hyper_5_17_chunk.device_id = 1)
 (30 rows)
 
 -- test RECORD by itself
@@ -283,7 +283,7 @@ ORDER BY time;
          Sort Key: _hyper_1_3_chunk."time"
          Sort Method: quicksort 
          ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk (actual rows=504 loops=1)
-               ->  Seq Scan on compress_hyper_5_16_chunk (actual rows=1 loops=1)
+               ->  Seq Scan on compress_hyper_5_17_chunk (actual rows=1 loops=1)
                      Filter: (device_id = 1)
                      Rows Removed by Filter: 4
 (19 rows)
@@ -322,7 +322,7 @@ ORDER BY time,
                Sort Key: _hyper_1_3_chunk."time"
                Sort Method: quicksort 
                ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk (actual rows=1008 loops=1)
-                     ->  Seq Scan on compress_hyper_5_16_chunk (actual rows=2 loops=1)
+                     ->  Seq Scan on compress_hyper_5_17_chunk (actual rows=2 loops=1)
                            Filter: (device_id = ANY ('{1,2}'::integer[]))
                            Rows Removed by Filter: 3
 (23 rows)
@@ -338,7 +338,7 @@ FROM :TEST_TABLE;
          ->  Seq Scan on compress_hyper_5_15_chunk (actual rows=5 loops=1)
    ->  Seq Scan on _hyper_1_2_chunk (actual rows=2520 loops=1)
    ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk (actual rows=2520 loops=1)
-         ->  Seq Scan on compress_hyper_5_16_chunk (actual rows=5 loops=1)
+         ->  Seq Scan on compress_hyper_5_17_chunk (actual rows=5 loops=1)
 (6 rows)
 
 -- test empty resultset
@@ -357,7 +357,7 @@ WHERE device_id < 0;
          Filter: (device_id < 0)
          Rows Removed by Filter: 2520
    ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk (actual rows=0 loops=1)
-         ->  Seq Scan on compress_hyper_5_16_chunk (actual rows=0 loops=1)
+         ->  Seq Scan on compress_hyper_5_17_chunk (actual rows=0 loops=1)
                Filter: (device_id < 0)
                Rows Removed by Filter: 5
 (12 rows)
@@ -374,7 +374,7 @@ FROM :TEST_TABLE;
                ->  Seq Scan on compress_hyper_5_15_chunk (actual rows=5 loops=1)
          ->  Seq Scan on _hyper_1_2_chunk (actual rows=2520 loops=1)
          ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk (actual rows=2520 loops=1)
-               ->  Seq Scan on compress_hyper_5_16_chunk (actual rows=5 loops=1)
+               ->  Seq Scan on compress_hyper_5_17_chunk (actual rows=5 loops=1)
 (7 rows)
 
 -- test constraints not present in targetlist
@@ -397,7 +397,7 @@ ORDER BY v1;
                Filter: (device_id = 1)
                Rows Removed by Filter: 2016
          ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk (actual rows=504 loops=1)
-               ->  Seq Scan on compress_hyper_5_16_chunk (actual rows=1 loops=1)
+               ->  Seq Scan on compress_hyper_5_17_chunk (actual rows=1 loops=1)
                      Filter: (device_id = 1)
                      Rows Removed by Filter: 4
 (15 rows)
@@ -422,7 +422,7 @@ ORDER BY v1;
                Filter: (device_id = 1)
                Rows Removed by Filter: 2016
          ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk (actual rows=504 loops=1)
-               ->  Seq Scan on compress_hyper_5_16_chunk (actual rows=1 loops=1)
+               ->  Seq Scan on compress_hyper_5_17_chunk (actual rows=1 loops=1)
                      Filter: (device_id = 1)
                      Rows Removed by Filter: 4
 (15 rows)
@@ -443,7 +443,7 @@ WHERE device_id = 1;
          Filter: (device_id = 1)
          Rows Removed by Filter: 2016
    ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk (actual rows=504 loops=1)
-         ->  Seq Scan on compress_hyper_5_16_chunk (actual rows=1 loops=1)
+         ->  Seq Scan on compress_hyper_5_17_chunk (actual rows=1 loops=1)
                Filter: (device_id = 1)
                Rows Removed by Filter: 4
 (12 rows)
@@ -493,8 +493,8 @@ ORDER BY time,
                      Filter: (_hyper_1_3_chunk.v3 > '10'::double precision)
                      Rows Removed by Filter: 2520
                      Bulk Decompression: true
-                     ->  Seq Scan on _timescaledb_internal.compress_hyper_5_16_chunk (actual rows=5 loops=1)
-                           Output: compress_hyper_5_16_chunk."time", compress_hyper_5_16_chunk.device_id, compress_hyper_5_16_chunk.device_id_peer, compress_hyper_5_16_chunk.v0, compress_hyper_5_16_chunk.v1, compress_hyper_5_16_chunk.v2, compress_hyper_5_16_chunk.v3, compress_hyper_5_16_chunk._ts_meta_count, compress_hyper_5_16_chunk._ts_meta_sequence_num, compress_hyper_5_16_chunk._ts_meta_min_3, compress_hyper_5_16_chunk._ts_meta_max_3, compress_hyper_5_16_chunk._ts_meta_min_1, compress_hyper_5_16_chunk._ts_meta_max_1, compress_hyper_5_16_chunk._ts_meta_min_2, compress_hyper_5_16_chunk._ts_meta_max_2
+                     ->  Seq Scan on _timescaledb_internal.compress_hyper_5_17_chunk (actual rows=5 loops=1)
+                           Output: compress_hyper_5_17_chunk."time", compress_hyper_5_17_chunk.device_id, compress_hyper_5_17_chunk.device_id_peer, compress_hyper_5_17_chunk.v0, compress_hyper_5_17_chunk.v1, compress_hyper_5_17_chunk.v2, compress_hyper_5_17_chunk.v3, compress_hyper_5_17_chunk._ts_meta_count, compress_hyper_5_17_chunk._ts_meta_sequence_num, compress_hyper_5_17_chunk._ts_meta_min_3, compress_hyper_5_17_chunk._ts_meta_max_3, compress_hyper_5_17_chunk._ts_meta_min_1, compress_hyper_5_17_chunk._ts_meta_max_1, compress_hyper_5_17_chunk._ts_meta_min_2, compress_hyper_5_17_chunk._ts_meta_max_2
 (35 rows)
 
 -- device_id constraint should be pushed down
@@ -522,7 +522,7 @@ LIMIT 10;
          ->  Sort (never executed)
                Sort Key: _hyper_1_3_chunk."time"
                ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk (never executed)
-                     ->  Seq Scan on compress_hyper_5_16_chunk (never executed)
+                     ->  Seq Scan on compress_hyper_5_17_chunk (never executed)
                            Filter: (device_id = 1)
 (17 rows)
 
@@ -554,7 +554,7 @@ LIMIT 10;
                ->  Sort (never executed)
                      Sort Key: _hyper_1_3_chunk."time"
                      ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk (never executed)
-                           ->  Seq Scan on compress_hyper_5_16_chunk (never executed)
+                           ->  Seq Scan on compress_hyper_5_17_chunk (never executed)
                                  Filter: (device_id IS NOT NULL)
 (20 rows)
 
@@ -580,7 +580,7 @@ LIMIT 10;
                      Filter: (device_id IS NULL)
                      Rows Removed by Filter: 2520
                ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk (actual rows=0 loops=1)
-                     ->  Seq Scan on compress_hyper_5_16_chunk (actual rows=0 loops=1)
+                     ->  Seq Scan on compress_hyper_5_17_chunk (actual rows=0 loops=1)
                            Filter: (device_id IS NULL)
                            Rows Removed by Filter: 5
 (16 rows)
@@ -614,7 +614,7 @@ LIMIT 10;
                ->  Sort (never executed)
                      Sort Key: _hyper_1_3_chunk."time"
                      ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk (never executed)
-                           ->  Seq Scan on compress_hyper_5_16_chunk (never executed)
+                           ->  Seq Scan on compress_hyper_5_17_chunk (never executed)
                                  Filter: (device_id = ANY ('{1,2}'::integer[]))
 (21 rows)
 
@@ -643,7 +643,7 @@ LIMIT 10;
          ->  Sort (never executed)
                Sort Key: _hyper_1_3_chunk."time"
                ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk (never executed)
-                     ->  Seq Scan on compress_hyper_5_16_chunk (never executed)
+                     ->  Seq Scan on compress_hyper_5_17_chunk (never executed)
                            Filter: (device_id = 1)
 (17 rows)
 
@@ -678,7 +678,7 @@ LIMIT 10;
                      Sort Key: _hyper_1_3_chunk."time"
                      Sort Method: quicksort 
                      ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk (actual rows=0 loops=1)
-                           ->  Seq Scan on compress_hyper_5_16_chunk (actual rows=0 loops=1)
+                           ->  Seq Scan on compress_hyper_5_17_chunk (actual rows=0 loops=1)
                                  Filter: (device_id = device_id_peer)
                                  Rows Removed by Filter: 5
 (24 rows)
@@ -710,7 +710,7 @@ LIMIT 10;
                ->  Sort (never executed)
                      Sort Key: _hyper_1_3_chunk."time"
                      ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk (never executed)
-                           ->  Seq Scan on compress_hyper_5_16_chunk (never executed)
+                           ->  Seq Scan on compress_hyper_5_17_chunk (never executed)
                                  Filter: (device_id_peer < device_id)
 (20 rows)
 
@@ -739,7 +739,7 @@ LIMIT 10;
          ->  Sort (never executed)
                Sort Key: _hyper_1_3_chunk."time"
                ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk (never executed)
-                     ->  Seq Scan on compress_hyper_5_16_chunk (never executed)
+                     ->  Seq Scan on compress_hyper_5_17_chunk (never executed)
                            Filter: (device_id = 3)
 (17 rows)
 
@@ -771,7 +771,7 @@ LIMIT 10;
                Sort Key: _hyper_1_3_chunk."time"
                ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk (never executed)
                      Filter: (device_id = length("substring"(version(), 1, 3)))
-                     ->  Seq Scan on compress_hyper_5_16_chunk (never executed)
+                     ->  Seq Scan on compress_hyper_5_17_chunk (never executed)
 (18 rows)
 
 --
@@ -868,7 +868,7 @@ LIMIT 10;
                      Sort Key: _hyper_1_3_chunk."time"
                      ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk (never executed)
                            Filter: ("time" >= 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
-                           ->  Seq Scan on compress_hyper_5_16_chunk (never executed)
+                           ->  Seq Scan on compress_hyper_5_17_chunk (never executed)
                                  Filter: (_ts_meta_max_3 >= 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
 (23 rows)
 
@@ -902,7 +902,7 @@ LIMIT 10;
                      Sort Key: _hyper_1_3_chunk."time"
                      ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk (never executed)
                            Filter: ("time" > 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
-                           ->  Seq Scan on compress_hyper_5_16_chunk (never executed)
+                           ->  Seq Scan on compress_hyper_5_17_chunk (never executed)
                                  Filter: (_ts_meta_max_3 > 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
 (23 rows)
 
@@ -936,7 +936,7 @@ LIMIT 10;
                      Sort Key: _hyper_1_3_chunk."time"
                      ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk (never executed)
                            Filter: ('Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone < "time")
-                           ->  Seq Scan on compress_hyper_5_16_chunk (never executed)
+                           ->  Seq Scan on compress_hyper_5_17_chunk (never executed)
                                  Filter: (_ts_meta_max_3 > 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
 (23 rows)
 
@@ -972,7 +972,7 @@ LIMIT 10;
                      Sort Key: _hyper_1_3_chunk."time"
                      ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk (never executed)
                            Filter: (v0 < 1)
-                           ->  Seq Scan on compress_hyper_5_16_chunk (never executed)
+                           ->  Seq Scan on compress_hyper_5_17_chunk (never executed)
                                  Filter: (_ts_meta_min_1 < 1)
 (24 rows)
 
@@ -1006,7 +1006,7 @@ LIMIT 10;
                      Sort Key: _hyper_1_3_chunk."time"
                      ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk (never executed)
                            Filter: (v0 < device_id)
-                           ->  Seq Scan on compress_hyper_5_16_chunk (never executed)
+                           ->  Seq Scan on compress_hyper_5_17_chunk (never executed)
                                  Filter: (_ts_meta_min_1 < device_id)
 (23 rows)
 
@@ -1039,7 +1039,7 @@ LIMIT 10;
                      Sort Key: _hyper_1_3_chunk."time"
                      ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk (never executed)
                            Filter: (device_id < v0)
-                           ->  Seq Scan on compress_hyper_5_16_chunk (never executed)
+                           ->  Seq Scan on compress_hyper_5_17_chunk (never executed)
                                  Filter: (_ts_meta_max_1 > device_id)
 (22 rows)
 
@@ -1075,7 +1075,7 @@ LIMIT 10;
                      Sort Method: quicksort 
                      ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk (actual rows=0 loops=1)
                            Filter: (v1 = device_id)
-                           ->  Seq Scan on compress_hyper_5_16_chunk (actual rows=0 loops=1)
+                           ->  Seq Scan on compress_hyper_5_17_chunk (actual rows=0 loops=1)
                                  Filter: ((_ts_meta_min_2 <= device_id) AND (_ts_meta_max_2 >= device_id))
                                  Rows Removed by Filter: 5
 (26 rows)
@@ -1113,7 +1113,7 @@ LIMIT 10;
                      ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk (actual rows=0 loops=1)
                            Filter: (v0 = v1)
                            Rows Removed by Filter: 2520
-                           ->  Seq Scan on compress_hyper_5_16_chunk (actual rows=5 loops=1)
+                           ->  Seq Scan on compress_hyper_5_17_chunk (actual rows=5 loops=1)
 (24 rows)
 
 --pushdown of quals on order by and segment by cols anded together
@@ -1158,9 +1158,9 @@ LIMIT 10;
                      Output: _hyper_1_3_chunk."time", _hyper_1_3_chunk.device_id, _hyper_1_3_chunk.device_id_peer, _hyper_1_3_chunk.v0, _hyper_1_3_chunk.v1, _hyper_1_3_chunk.v2, _hyper_1_3_chunk.v3
                      Filter: (_hyper_1_3_chunk."time" > 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
                      Bulk Decompression: true
-                     ->  Seq Scan on _timescaledb_internal.compress_hyper_5_16_chunk (never executed)
-                           Output: compress_hyper_5_16_chunk."time", compress_hyper_5_16_chunk.device_id, compress_hyper_5_16_chunk.device_id_peer, compress_hyper_5_16_chunk.v0, compress_hyper_5_16_chunk.v1, compress_hyper_5_16_chunk.v2, compress_hyper_5_16_chunk.v3, compress_hyper_5_16_chunk._ts_meta_count, compress_hyper_5_16_chunk._ts_meta_sequence_num, compress_hyper_5_16_chunk._ts_meta_min_3, compress_hyper_5_16_chunk._ts_meta_max_3, compress_hyper_5_16_chunk._ts_meta_min_1, compress_hyper_5_16_chunk._ts_meta_max_1, compress_hyper_5_16_chunk._ts_meta_min_2, compress_hyper_5_16_chunk._ts_meta_max_2
-                           Filter: ((compress_hyper_5_16_chunk._ts_meta_max_3 > 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone) AND (compress_hyper_5_16_chunk.device_id = 1))
+                     ->  Seq Scan on _timescaledb_internal.compress_hyper_5_17_chunk (never executed)
+                           Output: compress_hyper_5_17_chunk."time", compress_hyper_5_17_chunk.device_id, compress_hyper_5_17_chunk.device_id_peer, compress_hyper_5_17_chunk.v0, compress_hyper_5_17_chunk.v1, compress_hyper_5_17_chunk.v2, compress_hyper_5_17_chunk.v3, compress_hyper_5_17_chunk._ts_meta_count, compress_hyper_5_17_chunk._ts_meta_sequence_num, compress_hyper_5_17_chunk._ts_meta_min_3, compress_hyper_5_17_chunk._ts_meta_max_3, compress_hyper_5_17_chunk._ts_meta_min_1, compress_hyper_5_17_chunk._ts_meta_max_1, compress_hyper_5_17_chunk._ts_meta_min_2, compress_hyper_5_17_chunk._ts_meta_max_2
+                           Filter: ((compress_hyper_5_17_chunk._ts_meta_max_3 > 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone) AND (compress_hyper_5_17_chunk.device_id = 1))
 (34 rows)
 
 --pushdown of quals on order by and segment by cols or together (not pushed down)
@@ -1194,7 +1194,7 @@ LIMIT 10;
                      Sort Key: _hyper_1_3_chunk."time"
                      ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk (never executed)
                            Filter: (("time" > 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone) OR (device_id = 1))
-                           ->  Seq Scan on compress_hyper_5_16_chunk (never executed)
+                           ->  Seq Scan on compress_hyper_5_17_chunk (never executed)
 (21 rows)
 
 --functions not yet optimized
@@ -1227,7 +1227,7 @@ LIMIT 10;
                      Sort Key: _hyper_1_3_chunk."time"
                      ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk (never executed)
                            Filter: ("time" < now())
-                           ->  Seq Scan on compress_hyper_5_16_chunk (never executed)
+                           ->  Seq Scan on compress_hyper_5_17_chunk (never executed)
 (21 rows)
 
 -- test sort optimization interaction
@@ -1245,7 +1245,7 @@ LIMIT 10;
                Sort Key: _hyper_1_3_chunk."time" DESC
                Sort Method: top-N heapsort 
                ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk (actual rows=2520 loops=1)
-                     ->  Seq Scan on compress_hyper_5_16_chunk (actual rows=5 loops=1)
+                     ->  Seq Scan on compress_hyper_5_17_chunk (actual rows=5 loops=1)
          ->  Index Only Scan using _hyper_1_2_chunk_metrics_time_idx on _hyper_1_2_chunk (never executed)
                Heap Fetches: 0
          ->  Sort (never executed)
@@ -1274,7 +1274,7 @@ LIMIT 10;
                      Sort Key: _hyper_1_3_chunk."time" DESC
                      Sort Method: quicksort 
                      ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk (actual rows=2520 loops=1)
-                           ->  Seq Scan on compress_hyper_5_16_chunk (actual rows=5 loops=1)
+                           ->  Seq Scan on compress_hyper_5_17_chunk (actual rows=5 loops=1)
                ->  Index Scan using _hyper_1_2_chunk_metrics_time_idx on _hyper_1_2_chunk (never executed)
                ->  Sort (never executed)
                      Sort Key: _hyper_1_1_chunk."time" DESC
@@ -1300,7 +1300,7 @@ LIMIT 10;
                      ->  Seq Scan on compress_hyper_5_15_chunk (actual rows=5 loops=1)
                ->  Seq Scan on _hyper_1_2_chunk (actual rows=2520 loops=1)
                ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk (actual rows=2520 loops=1)
-                     ->  Seq Scan on compress_hyper_5_16_chunk (actual rows=5 loops=1)
+                     ->  Seq Scan on compress_hyper_5_17_chunk (actual rows=5 loops=1)
 (10 rows)
 
 --
@@ -1336,9 +1336,9 @@ ORDER BY time,
                      Output: _hyper_1_3_chunk."time", _hyper_1_3_chunk.device_id, _hyper_1_3_chunk.device_id_peer, _hyper_1_3_chunk.v0, _hyper_1_3_chunk.v1, _hyper_1_3_chunk.v2, _hyper_1_3_chunk.v3
                      Filter: (_hyper_1_3_chunk."time" > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
                      Bulk Decompression: true
-                     ->  Seq Scan on _timescaledb_internal.compress_hyper_5_16_chunk (actual rows=5 loops=1)
-                           Output: compress_hyper_5_16_chunk."time", compress_hyper_5_16_chunk.device_id, compress_hyper_5_16_chunk.device_id_peer, compress_hyper_5_16_chunk.v0, compress_hyper_5_16_chunk.v1, compress_hyper_5_16_chunk.v2, compress_hyper_5_16_chunk.v3, compress_hyper_5_16_chunk._ts_meta_count, compress_hyper_5_16_chunk._ts_meta_sequence_num, compress_hyper_5_16_chunk._ts_meta_min_3, compress_hyper_5_16_chunk._ts_meta_max_3, compress_hyper_5_16_chunk._ts_meta_min_1, compress_hyper_5_16_chunk._ts_meta_max_1, compress_hyper_5_16_chunk._ts_meta_min_2, compress_hyper_5_16_chunk._ts_meta_max_2
-                           Filter: (compress_hyper_5_16_chunk._ts_meta_max_3 > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
+                     ->  Seq Scan on _timescaledb_internal.compress_hyper_5_17_chunk (actual rows=5 loops=1)
+                           Output: compress_hyper_5_17_chunk."time", compress_hyper_5_17_chunk.device_id, compress_hyper_5_17_chunk.device_id_peer, compress_hyper_5_17_chunk.v0, compress_hyper_5_17_chunk.v1, compress_hyper_5_17_chunk.v2, compress_hyper_5_17_chunk.v3, compress_hyper_5_17_chunk._ts_meta_count, compress_hyper_5_17_chunk._ts_meta_sequence_num, compress_hyper_5_17_chunk._ts_meta_min_3, compress_hyper_5_17_chunk._ts_meta_max_3, compress_hyper_5_17_chunk._ts_meta_min_1, compress_hyper_5_17_chunk._ts_meta_max_1, compress_hyper_5_17_chunk._ts_meta_min_2, compress_hyper_5_17_chunk._ts_meta_max_2
+                           Filter: (compress_hyper_5_17_chunk._ts_meta_max_3 > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
 (24 rows)
 
 -- should produce ordered path
@@ -1367,9 +1367,9 @@ ORDER BY device_id,
          Output: _hyper_1_3_chunk."time", _hyper_1_3_chunk.device_id, _hyper_1_3_chunk.device_id_peer, _hyper_1_3_chunk.v0, _hyper_1_3_chunk.v1, _hyper_1_3_chunk.v2, _hyper_1_3_chunk.v3
          Filter: (_hyper_1_3_chunk."time" > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
          Bulk Decompression: true
-         ->  Index Scan using compress_hyper_5_16_chunk__compressed_hypertable_5_device_id_de on _timescaledb_internal.compress_hyper_5_16_chunk (actual rows=5 loops=1)
-               Output: compress_hyper_5_16_chunk."time", compress_hyper_5_16_chunk.device_id, compress_hyper_5_16_chunk.device_id_peer, compress_hyper_5_16_chunk.v0, compress_hyper_5_16_chunk.v1, compress_hyper_5_16_chunk.v2, compress_hyper_5_16_chunk.v3, compress_hyper_5_16_chunk._ts_meta_count, compress_hyper_5_16_chunk._ts_meta_sequence_num, compress_hyper_5_16_chunk._ts_meta_min_3, compress_hyper_5_16_chunk._ts_meta_max_3, compress_hyper_5_16_chunk._ts_meta_min_1, compress_hyper_5_16_chunk._ts_meta_max_1, compress_hyper_5_16_chunk._ts_meta_min_2, compress_hyper_5_16_chunk._ts_meta_max_2
-               Filter: (compress_hyper_5_16_chunk._ts_meta_max_3 > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
+         ->  Index Scan using compress_hyper_5_17_chunk__compressed_hypertable_5_device_id_de on _timescaledb_internal.compress_hyper_5_17_chunk (actual rows=5 loops=1)
+               Output: compress_hyper_5_17_chunk."time", compress_hyper_5_17_chunk.device_id, compress_hyper_5_17_chunk.device_id_peer, compress_hyper_5_17_chunk.v0, compress_hyper_5_17_chunk.v1, compress_hyper_5_17_chunk.v2, compress_hyper_5_17_chunk.v3, compress_hyper_5_17_chunk._ts_meta_count, compress_hyper_5_17_chunk._ts_meta_sequence_num, compress_hyper_5_17_chunk._ts_meta_min_3, compress_hyper_5_17_chunk._ts_meta_max_3, compress_hyper_5_17_chunk._ts_meta_min_1, compress_hyper_5_17_chunk._ts_meta_max_1, compress_hyper_5_17_chunk._ts_meta_min_2, compress_hyper_5_17_chunk._ts_meta_max_2
+               Filter: (compress_hyper_5_17_chunk._ts_meta_max_3 > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
 (17 rows)
 
 -- test order by columns not in targetlist
@@ -1402,9 +1402,9 @@ LIMIT 100;
                Output: _hyper_1_3_chunk.device_id, _hyper_1_3_chunk.device_id_peer, _hyper_1_3_chunk.v0, _hyper_1_3_chunk.v1, _hyper_1_3_chunk."time"
                Filter: (_hyper_1_3_chunk."time" > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
                Bulk Decompression: true
-               ->  Index Scan using compress_hyper_5_16_chunk__compressed_hypertable_5_device_id_de on _timescaledb_internal.compress_hyper_5_16_chunk (actual rows=1 loops=1)
-                     Output: compress_hyper_5_16_chunk."time", compress_hyper_5_16_chunk.device_id, compress_hyper_5_16_chunk.device_id_peer, compress_hyper_5_16_chunk.v0, compress_hyper_5_16_chunk.v1, compress_hyper_5_16_chunk.v2, compress_hyper_5_16_chunk.v3, compress_hyper_5_16_chunk._ts_meta_count, compress_hyper_5_16_chunk._ts_meta_sequence_num, compress_hyper_5_16_chunk._ts_meta_min_3, compress_hyper_5_16_chunk._ts_meta_max_3, compress_hyper_5_16_chunk._ts_meta_min_1, compress_hyper_5_16_chunk._ts_meta_max_1, compress_hyper_5_16_chunk._ts_meta_min_2, compress_hyper_5_16_chunk._ts_meta_max_2
-                     Filter: (compress_hyper_5_16_chunk._ts_meta_max_3 > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
+               ->  Index Scan using compress_hyper_5_17_chunk__compressed_hypertable_5_device_id_de on _timescaledb_internal.compress_hyper_5_17_chunk (actual rows=1 loops=1)
+                     Output: compress_hyper_5_17_chunk."time", compress_hyper_5_17_chunk.device_id, compress_hyper_5_17_chunk.device_id_peer, compress_hyper_5_17_chunk.v0, compress_hyper_5_17_chunk.v1, compress_hyper_5_17_chunk.v2, compress_hyper_5_17_chunk.v3, compress_hyper_5_17_chunk._ts_meta_count, compress_hyper_5_17_chunk._ts_meta_sequence_num, compress_hyper_5_17_chunk._ts_meta_min_3, compress_hyper_5_17_chunk._ts_meta_max_3, compress_hyper_5_17_chunk._ts_meta_min_1, compress_hyper_5_17_chunk._ts_meta_max_1, compress_hyper_5_17_chunk._ts_meta_min_2, compress_hyper_5_17_chunk._ts_meta_max_2
+                     Filter: (compress_hyper_5_17_chunk._ts_meta_max_3 > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
 (19 rows)
 
 -- test ordering only by segmentby columns
@@ -1435,9 +1435,9 @@ LIMIT 100;
                Output: _hyper_1_3_chunk.device_id, _hyper_1_3_chunk.device_id_peer
                Filter: (_hyper_1_3_chunk."time" > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
                Bulk Decompression: true
-               ->  Index Scan using compress_hyper_5_16_chunk__compressed_hypertable_5_device_id_de on _timescaledb_internal.compress_hyper_5_16_chunk (actual rows=1 loops=1)
-                     Output: compress_hyper_5_16_chunk."time", compress_hyper_5_16_chunk.device_id, compress_hyper_5_16_chunk.device_id_peer, compress_hyper_5_16_chunk.v0, compress_hyper_5_16_chunk.v1, compress_hyper_5_16_chunk.v2, compress_hyper_5_16_chunk.v3, compress_hyper_5_16_chunk._ts_meta_count, compress_hyper_5_16_chunk._ts_meta_sequence_num, compress_hyper_5_16_chunk._ts_meta_min_3, compress_hyper_5_16_chunk._ts_meta_max_3, compress_hyper_5_16_chunk._ts_meta_min_1, compress_hyper_5_16_chunk._ts_meta_max_1, compress_hyper_5_16_chunk._ts_meta_min_2, compress_hyper_5_16_chunk._ts_meta_max_2
-                     Filter: (compress_hyper_5_16_chunk._ts_meta_max_3 > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
+               ->  Index Scan using compress_hyper_5_17_chunk__compressed_hypertable_5_device_id_de on _timescaledb_internal.compress_hyper_5_17_chunk (actual rows=1 loops=1)
+                     Output: compress_hyper_5_17_chunk."time", compress_hyper_5_17_chunk.device_id, compress_hyper_5_17_chunk.device_id_peer, compress_hyper_5_17_chunk.v0, compress_hyper_5_17_chunk.v1, compress_hyper_5_17_chunk.v2, compress_hyper_5_17_chunk.v3, compress_hyper_5_17_chunk._ts_meta_count, compress_hyper_5_17_chunk._ts_meta_sequence_num, compress_hyper_5_17_chunk._ts_meta_min_3, compress_hyper_5_17_chunk._ts_meta_max_3, compress_hyper_5_17_chunk._ts_meta_min_1, compress_hyper_5_17_chunk._ts_meta_max_1, compress_hyper_5_17_chunk._ts_meta_min_2, compress_hyper_5_17_chunk._ts_meta_max_2
+                     Filter: (compress_hyper_5_17_chunk._ts_meta_max_3 > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
 (19 rows)
 
 -- should produce ordered path
@@ -1467,9 +1467,9 @@ ORDER BY device_id,
          Output: _hyper_1_3_chunk.device_id, _hyper_1_3_chunk.device_id_peer, _hyper_1_3_chunk.v0
          Filter: (_hyper_1_3_chunk."time" > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
          Bulk Decompression: true
-         ->  Index Scan using compress_hyper_5_16_chunk__compressed_hypertable_5_device_id_de on _timescaledb_internal.compress_hyper_5_16_chunk (actual rows=5 loops=1)
-               Output: compress_hyper_5_16_chunk."time", compress_hyper_5_16_chunk.device_id, compress_hyper_5_16_chunk.device_id_peer, compress_hyper_5_16_chunk.v0, compress_hyper_5_16_chunk.v1, compress_hyper_5_16_chunk.v2, compress_hyper_5_16_chunk.v3, compress_hyper_5_16_chunk._ts_meta_count, compress_hyper_5_16_chunk._ts_meta_sequence_num, compress_hyper_5_16_chunk._ts_meta_min_3, compress_hyper_5_16_chunk._ts_meta_max_3, compress_hyper_5_16_chunk._ts_meta_min_1, compress_hyper_5_16_chunk._ts_meta_max_1, compress_hyper_5_16_chunk._ts_meta_min_2, compress_hyper_5_16_chunk._ts_meta_max_2
-               Filter: (compress_hyper_5_16_chunk._ts_meta_max_3 > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
+         ->  Index Scan using compress_hyper_5_17_chunk__compressed_hypertable_5_device_id_de on _timescaledb_internal.compress_hyper_5_17_chunk (actual rows=5 loops=1)
+               Output: compress_hyper_5_17_chunk."time", compress_hyper_5_17_chunk.device_id, compress_hyper_5_17_chunk.device_id_peer, compress_hyper_5_17_chunk.v0, compress_hyper_5_17_chunk.v1, compress_hyper_5_17_chunk.v2, compress_hyper_5_17_chunk.v3, compress_hyper_5_17_chunk._ts_meta_count, compress_hyper_5_17_chunk._ts_meta_sequence_num, compress_hyper_5_17_chunk._ts_meta_min_3, compress_hyper_5_17_chunk._ts_meta_max_3, compress_hyper_5_17_chunk._ts_meta_min_1, compress_hyper_5_17_chunk._ts_meta_max_1, compress_hyper_5_17_chunk._ts_meta_min_2, compress_hyper_5_17_chunk._ts_meta_max_2
+               Filter: (compress_hyper_5_17_chunk._ts_meta_max_3 > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
 (17 rows)
 
 -- should produce ordered path
@@ -1501,9 +1501,9 @@ ORDER BY device_id,
          Output: _hyper_1_3_chunk.device_id, _hyper_1_3_chunk.device_id_peer, _hyper_1_3_chunk.v0, _hyper_1_3_chunk.v1
          Filter: (_hyper_1_3_chunk."time" > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
          Bulk Decompression: true
-         ->  Index Scan using compress_hyper_5_16_chunk__compressed_hypertable_5_device_id_de on _timescaledb_internal.compress_hyper_5_16_chunk (actual rows=5 loops=1)
-               Output: compress_hyper_5_16_chunk."time", compress_hyper_5_16_chunk.device_id, compress_hyper_5_16_chunk.device_id_peer, compress_hyper_5_16_chunk.v0, compress_hyper_5_16_chunk.v1, compress_hyper_5_16_chunk.v2, compress_hyper_5_16_chunk.v3, compress_hyper_5_16_chunk._ts_meta_count, compress_hyper_5_16_chunk._ts_meta_sequence_num, compress_hyper_5_16_chunk._ts_meta_min_3, compress_hyper_5_16_chunk._ts_meta_max_3, compress_hyper_5_16_chunk._ts_meta_min_1, compress_hyper_5_16_chunk._ts_meta_max_1, compress_hyper_5_16_chunk._ts_meta_min_2, compress_hyper_5_16_chunk._ts_meta_max_2
-               Filter: (compress_hyper_5_16_chunk._ts_meta_max_3 > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
+         ->  Index Scan using compress_hyper_5_17_chunk__compressed_hypertable_5_device_id_de on _timescaledb_internal.compress_hyper_5_17_chunk (actual rows=5 loops=1)
+               Output: compress_hyper_5_17_chunk."time", compress_hyper_5_17_chunk.device_id, compress_hyper_5_17_chunk.device_id_peer, compress_hyper_5_17_chunk.v0, compress_hyper_5_17_chunk.v1, compress_hyper_5_17_chunk.v2, compress_hyper_5_17_chunk.v3, compress_hyper_5_17_chunk._ts_meta_count, compress_hyper_5_17_chunk._ts_meta_sequence_num, compress_hyper_5_17_chunk._ts_meta_min_3, compress_hyper_5_17_chunk._ts_meta_max_3, compress_hyper_5_17_chunk._ts_meta_min_1, compress_hyper_5_17_chunk._ts_meta_max_1, compress_hyper_5_17_chunk._ts_meta_min_2, compress_hyper_5_17_chunk._ts_meta_max_2
+               Filter: (compress_hyper_5_17_chunk._ts_meta_max_3 > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
 (17 rows)
 
 -- should not produce ordered path
@@ -1532,9 +1532,9 @@ ORDER BY device_id,
                Output: _hyper_1_3_chunk."time", _hyper_1_3_chunk.device_id, _hyper_1_3_chunk.device_id_peer, _hyper_1_3_chunk.v0, _hyper_1_3_chunk.v1, _hyper_1_3_chunk.v2, _hyper_1_3_chunk.v3
                Filter: (_hyper_1_3_chunk."time" > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
                Bulk Decompression: true
-               ->  Seq Scan on _timescaledb_internal.compress_hyper_5_16_chunk (actual rows=5 loops=1)
-                     Output: compress_hyper_5_16_chunk."time", compress_hyper_5_16_chunk.device_id, compress_hyper_5_16_chunk.device_id_peer, compress_hyper_5_16_chunk.v0, compress_hyper_5_16_chunk.v1, compress_hyper_5_16_chunk.v2, compress_hyper_5_16_chunk.v3, compress_hyper_5_16_chunk._ts_meta_count, compress_hyper_5_16_chunk._ts_meta_sequence_num, compress_hyper_5_16_chunk._ts_meta_min_3, compress_hyper_5_16_chunk._ts_meta_max_3, compress_hyper_5_16_chunk._ts_meta_min_1, compress_hyper_5_16_chunk._ts_meta_max_1, compress_hyper_5_16_chunk._ts_meta_min_2, compress_hyper_5_16_chunk._ts_meta_max_2
-                     Filter: (compress_hyper_5_16_chunk._ts_meta_max_3 > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
+               ->  Seq Scan on _timescaledb_internal.compress_hyper_5_17_chunk (actual rows=5 loops=1)
+                     Output: compress_hyper_5_17_chunk."time", compress_hyper_5_17_chunk.device_id, compress_hyper_5_17_chunk.device_id_peer, compress_hyper_5_17_chunk.v0, compress_hyper_5_17_chunk.v1, compress_hyper_5_17_chunk.v2, compress_hyper_5_17_chunk.v3, compress_hyper_5_17_chunk._ts_meta_count, compress_hyper_5_17_chunk._ts_meta_sequence_num, compress_hyper_5_17_chunk._ts_meta_min_3, compress_hyper_5_17_chunk._ts_meta_max_3, compress_hyper_5_17_chunk._ts_meta_min_1, compress_hyper_5_17_chunk._ts_meta_max_1, compress_hyper_5_17_chunk._ts_meta_min_2, compress_hyper_5_17_chunk._ts_meta_max_2
+                     Filter: (compress_hyper_5_17_chunk._ts_meta_max_3 > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
 (16 rows)
 
 -- should produce ordered path
@@ -1565,12 +1565,12 @@ ORDER BY device_id DESC,
          Filter: (_hyper_1_3_chunk."time" > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
          Bulk Decompression: true
          ->  Sort (actual rows=5 loops=1)
-               Output: compress_hyper_5_16_chunk."time", compress_hyper_5_16_chunk.device_id, compress_hyper_5_16_chunk.device_id_peer, compress_hyper_5_16_chunk.v0, compress_hyper_5_16_chunk.v1, compress_hyper_5_16_chunk.v2, compress_hyper_5_16_chunk.v3, compress_hyper_5_16_chunk._ts_meta_count, compress_hyper_5_16_chunk._ts_meta_sequence_num, compress_hyper_5_16_chunk._ts_meta_min_3, compress_hyper_5_16_chunk._ts_meta_max_3, compress_hyper_5_16_chunk._ts_meta_min_1, compress_hyper_5_16_chunk._ts_meta_max_1, compress_hyper_5_16_chunk._ts_meta_min_2, compress_hyper_5_16_chunk._ts_meta_max_2
-               Sort Key: compress_hyper_5_16_chunk.device_id DESC, compress_hyper_5_16_chunk.device_id_peer DESC, compress_hyper_5_16_chunk._ts_meta_sequence_num
+               Output: compress_hyper_5_17_chunk."time", compress_hyper_5_17_chunk.device_id, compress_hyper_5_17_chunk.device_id_peer, compress_hyper_5_17_chunk.v0, compress_hyper_5_17_chunk.v1, compress_hyper_5_17_chunk.v2, compress_hyper_5_17_chunk.v3, compress_hyper_5_17_chunk._ts_meta_count, compress_hyper_5_17_chunk._ts_meta_sequence_num, compress_hyper_5_17_chunk._ts_meta_min_3, compress_hyper_5_17_chunk._ts_meta_max_3, compress_hyper_5_17_chunk._ts_meta_min_1, compress_hyper_5_17_chunk._ts_meta_max_1, compress_hyper_5_17_chunk._ts_meta_min_2, compress_hyper_5_17_chunk._ts_meta_max_2
+               Sort Key: compress_hyper_5_17_chunk.device_id DESC, compress_hyper_5_17_chunk.device_id_peer DESC, compress_hyper_5_17_chunk._ts_meta_sequence_num
                Sort Method: quicksort 
-               ->  Seq Scan on _timescaledb_internal.compress_hyper_5_16_chunk (actual rows=5 loops=1)
-                     Output: compress_hyper_5_16_chunk."time", compress_hyper_5_16_chunk.device_id, compress_hyper_5_16_chunk.device_id_peer, compress_hyper_5_16_chunk.v0, compress_hyper_5_16_chunk.v1, compress_hyper_5_16_chunk.v2, compress_hyper_5_16_chunk.v3, compress_hyper_5_16_chunk._ts_meta_count, compress_hyper_5_16_chunk._ts_meta_sequence_num, compress_hyper_5_16_chunk._ts_meta_min_3, compress_hyper_5_16_chunk._ts_meta_max_3, compress_hyper_5_16_chunk._ts_meta_min_1, compress_hyper_5_16_chunk._ts_meta_max_1, compress_hyper_5_16_chunk._ts_meta_min_2, compress_hyper_5_16_chunk._ts_meta_max_2
-                     Filter: (compress_hyper_5_16_chunk._ts_meta_max_3 > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
+               ->  Seq Scan on _timescaledb_internal.compress_hyper_5_17_chunk (actual rows=5 loops=1)
+                     Output: compress_hyper_5_17_chunk."time", compress_hyper_5_17_chunk.device_id, compress_hyper_5_17_chunk.device_id_peer, compress_hyper_5_17_chunk.v0, compress_hyper_5_17_chunk.v1, compress_hyper_5_17_chunk.v2, compress_hyper_5_17_chunk.v3, compress_hyper_5_17_chunk._ts_meta_count, compress_hyper_5_17_chunk._ts_meta_sequence_num, compress_hyper_5_17_chunk._ts_meta_min_3, compress_hyper_5_17_chunk._ts_meta_max_3, compress_hyper_5_17_chunk._ts_meta_min_1, compress_hyper_5_17_chunk._ts_meta_max_1, compress_hyper_5_17_chunk._ts_meta_min_2, compress_hyper_5_17_chunk._ts_meta_max_2
+                     Filter: (compress_hyper_5_17_chunk._ts_meta_max_3 > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
 (21 rows)
 
 -- should not produce ordered path
@@ -1598,9 +1598,9 @@ ORDER BY device_id DESC,
                Output: _hyper_1_3_chunk."time", _hyper_1_3_chunk.device_id, _hyper_1_3_chunk.device_id_peer, _hyper_1_3_chunk.v0, _hyper_1_3_chunk.v1, _hyper_1_3_chunk.v2, _hyper_1_3_chunk.v3
                Filter: (_hyper_1_3_chunk."time" > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
                Bulk Decompression: true
-               ->  Seq Scan on _timescaledb_internal.compress_hyper_5_16_chunk (actual rows=5 loops=1)
-                     Output: compress_hyper_5_16_chunk."time", compress_hyper_5_16_chunk.device_id, compress_hyper_5_16_chunk.device_id_peer, compress_hyper_5_16_chunk.v0, compress_hyper_5_16_chunk.v1, compress_hyper_5_16_chunk.v2, compress_hyper_5_16_chunk.v3, compress_hyper_5_16_chunk._ts_meta_count, compress_hyper_5_16_chunk._ts_meta_sequence_num, compress_hyper_5_16_chunk._ts_meta_min_3, compress_hyper_5_16_chunk._ts_meta_max_3, compress_hyper_5_16_chunk._ts_meta_min_1, compress_hyper_5_16_chunk._ts_meta_max_1, compress_hyper_5_16_chunk._ts_meta_min_2, compress_hyper_5_16_chunk._ts_meta_max_2
-                     Filter: (compress_hyper_5_16_chunk._ts_meta_max_3 > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
+               ->  Seq Scan on _timescaledb_internal.compress_hyper_5_17_chunk (actual rows=5 loops=1)
+                     Output: compress_hyper_5_17_chunk."time", compress_hyper_5_17_chunk.device_id, compress_hyper_5_17_chunk.device_id_peer, compress_hyper_5_17_chunk.v0, compress_hyper_5_17_chunk.v1, compress_hyper_5_17_chunk.v2, compress_hyper_5_17_chunk.v3, compress_hyper_5_17_chunk._ts_meta_count, compress_hyper_5_17_chunk._ts_meta_sequence_num, compress_hyper_5_17_chunk._ts_meta_min_3, compress_hyper_5_17_chunk._ts_meta_max_3, compress_hyper_5_17_chunk._ts_meta_min_1, compress_hyper_5_17_chunk._ts_meta_max_1, compress_hyper_5_17_chunk._ts_meta_min_2, compress_hyper_5_17_chunk._ts_meta_max_2
+                     Filter: (compress_hyper_5_17_chunk._ts_meta_max_3 > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
 (16 rows)
 
 --
@@ -1629,7 +1629,7 @@ ORDER BY time,
                Sort Method: quicksort 
                ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk (actual rows=2520 loops=1)
                      Filter: ("time" > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
-                     ->  Seq Scan on compress_hyper_5_16_chunk (actual rows=5 loops=1)
+                     ->  Seq Scan on compress_hyper_5_17_chunk (actual rows=5 loops=1)
                            Filter: (_ts_meta_max_3 > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
 (15 rows)
 
@@ -1657,7 +1657,7 @@ ORDER BY time,
                Sort Method: quicksort 
                ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk (actual rows=2520 loops=1)
                      Filter: ("time" > ('2000-01-08'::cstring)::timestamp with time zone)
-                     ->  Seq Scan on compress_hyper_5_16_chunk (actual rows=5 loops=1)
+                     ->  Seq Scan on compress_hyper_5_17_chunk (actual rows=5 loops=1)
                            Filter: (_ts_meta_max_3 > ('2000-01-08'::cstring)::timestamp with time zone)
 (16 rows)
 
@@ -1673,7 +1673,7 @@ FROM :TEST_TABLE;
                ->  Seq Scan on compress_hyper_5_15_chunk (actual rows=5 loops=1)
          ->  Seq Scan on _hyper_1_2_chunk (actual rows=2520 loops=1)
          ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk (actual rows=2520 loops=1)
-               ->  Seq Scan on compress_hyper_5_16_chunk (actual rows=5 loops=1)
+               ->  Seq Scan on compress_hyper_5_17_chunk (actual rows=5 loops=1)
 (7 rows)
 
 -- test aggregate with GROUP BY
@@ -1695,7 +1695,7 @@ ORDER BY device_id;
                      ->  Seq Scan on compress_hyper_5_15_chunk (actual rows=5 loops=1)
                ->  Seq Scan on _hyper_1_2_chunk (actual rows=2520 loops=1)
                ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk (actual rows=2520 loops=1)
-                     ->  Seq Scan on compress_hyper_5_16_chunk (actual rows=5 loops=1)
+                     ->  Seq Scan on compress_hyper_5_17_chunk (actual rows=5 loops=1)
 (12 rows)
 
 -- test window functions with GROUP BY
@@ -1718,7 +1718,7 @@ ORDER BY device_id;
                            ->  Seq Scan on compress_hyper_5_15_chunk (actual rows=5 loops=1)
                      ->  Seq Scan on _hyper_1_2_chunk (actual rows=2520 loops=1)
                      ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk (actual rows=2520 loops=1)
-                           ->  Seq Scan on compress_hyper_5_16_chunk (actual rows=5 loops=1)
+                           ->  Seq Scan on compress_hyper_5_17_chunk (actual rows=5 loops=1)
 (13 rows)
 
 -- test CTE
@@ -1748,7 +1748,7 @@ ORDER BY v1;
                      Sort Key: _hyper_1_3_chunk."time"
                      Sort Method: quicksort 
                      ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk (actual rows=2520 loops=1)
-                           ->  Seq Scan on compress_hyper_5_16_chunk (actual rows=5 loops=1)
+                           ->  Seq Scan on compress_hyper_5_17_chunk (actual rows=5 loops=1)
 (17 rows)
 
 -- test CTE join
@@ -1790,7 +1790,7 @@ ORDER BY q1.time;
                Sort Key: _hyper_1_3_chunk."time"
                Sort Method: quicksort 
                ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk (actual rows=504 loops=1)
-                     ->  Seq Scan on compress_hyper_5_16_chunk (actual rows=1 loops=1)
+                     ->  Seq Scan on compress_hyper_5_17_chunk (actual rows=1 loops=1)
                            Filter: (device_id = 1)
                            Rows Removed by Filter: 4
    ->  Materialize (actual rows=1368 loops=1)
@@ -1810,7 +1810,7 @@ ORDER BY q1.time;
                      Sort Key: _hyper_1_3_chunk_1."time"
                      Sort Method: quicksort 
                      ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk _hyper_1_3_chunk_1 (actual rows=504 loops=1)
-                           ->  Seq Scan on compress_hyper_5_16_chunk compress_hyper_5_16_chunk_1 (actual rows=1 loops=1)
+                           ->  Seq Scan on compress_hyper_5_17_chunk compress_hyper_5_17_chunk_1 (actual rows=1 loops=1)
                                  Filter: (device_id = 2)
                                  Rows Removed by Filter: 4
 (41 rows)
@@ -1833,7 +1833,7 @@ WHERE device_id = 1;
                Filter: (device_id = 1)
                Rows Removed by Filter: 2016
          ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk (actual rows=504 loops=1)
-               ->  Seq Scan on compress_hyper_5_16_chunk (actual rows=1 loops=1)
+               ->  Seq Scan on compress_hyper_5_17_chunk (actual rows=1 loops=1)
                      Filter: (device_id = 1)
                      Rows Removed by Filter: 4
 (13 rows)
@@ -1912,9 +1912,9 @@ ORDER BY device_id,
          ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_3_chunk (actual rows=504 loops=1)
                Output: _hyper_1_3_chunk."time", _hyper_1_3_chunk.device_id
                Bulk Decompression: true
-               ->  Index Scan using compress_hyper_5_16_chunk_c_index_2 on _timescaledb_internal.compress_hyper_5_16_chunk (actual rows=1 loops=1)
-                     Output: compress_hyper_5_16_chunk."time", compress_hyper_5_16_chunk.device_id, compress_hyper_5_16_chunk.device_id_peer, compress_hyper_5_16_chunk.v0, compress_hyper_5_16_chunk.v1, compress_hyper_5_16_chunk.v2, compress_hyper_5_16_chunk.v3, compress_hyper_5_16_chunk._ts_meta_count, compress_hyper_5_16_chunk._ts_meta_sequence_num, compress_hyper_5_16_chunk._ts_meta_min_3, compress_hyper_5_16_chunk._ts_meta_max_3, compress_hyper_5_16_chunk._ts_meta_min_1, compress_hyper_5_16_chunk._ts_meta_max_1, compress_hyper_5_16_chunk._ts_meta_min_2, compress_hyper_5_16_chunk._ts_meta_max_2
-                     Index Cond: (compress_hyper_5_16_chunk.device_id = 1)
+               ->  Index Scan using compress_hyper_5_17_chunk_c_index_2 on _timescaledb_internal.compress_hyper_5_17_chunk (actual rows=1 loops=1)
+                     Output: compress_hyper_5_17_chunk."time", compress_hyper_5_17_chunk.device_id, compress_hyper_5_17_chunk.device_id_peer, compress_hyper_5_17_chunk.v0, compress_hyper_5_17_chunk.v1, compress_hyper_5_17_chunk.v2, compress_hyper_5_17_chunk.v3, compress_hyper_5_17_chunk._ts_meta_count, compress_hyper_5_17_chunk._ts_meta_sequence_num, compress_hyper_5_17_chunk._ts_meta_min_3, compress_hyper_5_17_chunk._ts_meta_max_3, compress_hyper_5_17_chunk._ts_meta_min_1, compress_hyper_5_17_chunk._ts_meta_max_1, compress_hyper_5_17_chunk._ts_meta_min_2, compress_hyper_5_17_chunk._ts_meta_max_2
+                     Index Cond: (compress_hyper_5_17_chunk.device_id = 1)
 (26 rows)
 
 -- globs should not plan IndexOnlyScans
@@ -1949,9 +1949,9 @@ ORDER BY device_id,
          ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_3_chunk (actual rows=504 loops=1)
                Output: _hyper_1_3_chunk."time", _hyper_1_3_chunk.device_id, _hyper_1_3_chunk.device_id_peer, _hyper_1_3_chunk.v0, _hyper_1_3_chunk.v1, _hyper_1_3_chunk.v2, _hyper_1_3_chunk.v3
                Bulk Decompression: true
-               ->  Index Scan using compress_hyper_5_16_chunk_c_index_2 on _timescaledb_internal.compress_hyper_5_16_chunk (actual rows=1 loops=1)
-                     Output: compress_hyper_5_16_chunk."time", compress_hyper_5_16_chunk.device_id, compress_hyper_5_16_chunk.device_id_peer, compress_hyper_5_16_chunk.v0, compress_hyper_5_16_chunk.v1, compress_hyper_5_16_chunk.v2, compress_hyper_5_16_chunk.v3, compress_hyper_5_16_chunk._ts_meta_count, compress_hyper_5_16_chunk._ts_meta_sequence_num, compress_hyper_5_16_chunk._ts_meta_min_3, compress_hyper_5_16_chunk._ts_meta_max_3, compress_hyper_5_16_chunk._ts_meta_min_1, compress_hyper_5_16_chunk._ts_meta_max_1, compress_hyper_5_16_chunk._ts_meta_min_2, compress_hyper_5_16_chunk._ts_meta_max_2
-                     Index Cond: (compress_hyper_5_16_chunk.device_id = 1)
+               ->  Index Scan using compress_hyper_5_17_chunk_c_index_2 on _timescaledb_internal.compress_hyper_5_17_chunk (actual rows=1 loops=1)
+                     Output: compress_hyper_5_17_chunk."time", compress_hyper_5_17_chunk.device_id, compress_hyper_5_17_chunk.device_id_peer, compress_hyper_5_17_chunk.v0, compress_hyper_5_17_chunk.v1, compress_hyper_5_17_chunk.v2, compress_hyper_5_17_chunk.v3, compress_hyper_5_17_chunk._ts_meta_count, compress_hyper_5_17_chunk._ts_meta_sequence_num, compress_hyper_5_17_chunk._ts_meta_min_3, compress_hyper_5_17_chunk._ts_meta_max_3, compress_hyper_5_17_chunk._ts_meta_min_1, compress_hyper_5_17_chunk._ts_meta_max_1, compress_hyper_5_17_chunk._ts_meta_min_2, compress_hyper_5_17_chunk._ts_meta_max_2
+                     Index Cond: (compress_hyper_5_17_chunk.device_id = 1)
 (26 rows)
 
 -- whole row reference should work
@@ -1986,9 +1986,9 @@ ORDER BY device_id,
          ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_3_chunk test_table_3 (actual rows=504 loops=1)
                Output: test_table_3.*, test_table_3.device_id, test_table_3."time"
                Bulk Decompression: true
-               ->  Index Scan using compress_hyper_5_16_chunk_c_index_2 on _timescaledb_internal.compress_hyper_5_16_chunk (actual rows=1 loops=1)
-                     Output: compress_hyper_5_16_chunk."time", compress_hyper_5_16_chunk.device_id, compress_hyper_5_16_chunk.device_id_peer, compress_hyper_5_16_chunk.v0, compress_hyper_5_16_chunk.v1, compress_hyper_5_16_chunk.v2, compress_hyper_5_16_chunk.v3, compress_hyper_5_16_chunk._ts_meta_count, compress_hyper_5_16_chunk._ts_meta_sequence_num, compress_hyper_5_16_chunk._ts_meta_min_3, compress_hyper_5_16_chunk._ts_meta_max_3, compress_hyper_5_16_chunk._ts_meta_min_1, compress_hyper_5_16_chunk._ts_meta_max_1, compress_hyper_5_16_chunk._ts_meta_min_2, compress_hyper_5_16_chunk._ts_meta_max_2
-                     Index Cond: (compress_hyper_5_16_chunk.device_id = 1)
+               ->  Index Scan using compress_hyper_5_17_chunk_c_index_2 on _timescaledb_internal.compress_hyper_5_17_chunk (actual rows=1 loops=1)
+                     Output: compress_hyper_5_17_chunk."time", compress_hyper_5_17_chunk.device_id, compress_hyper_5_17_chunk.device_id_peer, compress_hyper_5_17_chunk.v0, compress_hyper_5_17_chunk.v1, compress_hyper_5_17_chunk.v2, compress_hyper_5_17_chunk.v3, compress_hyper_5_17_chunk._ts_meta_count, compress_hyper_5_17_chunk._ts_meta_sequence_num, compress_hyper_5_17_chunk._ts_meta_min_3, compress_hyper_5_17_chunk._ts_meta_max_3, compress_hyper_5_17_chunk._ts_meta_min_1, compress_hyper_5_17_chunk._ts_meta_max_1, compress_hyper_5_17_chunk._ts_meta_min_2, compress_hyper_5_17_chunk._ts_meta_max_2
+                     Index Cond: (compress_hyper_5_17_chunk.device_id = 1)
 (26 rows)
 
 -- even when we select only a segmentby column, we still need count
@@ -2014,9 +2014,9 @@ ORDER BY device_id;
    ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_3_chunk (actual rows=504 loops=1)
          Output: _hyper_1_3_chunk.device_id
          Bulk Decompression: false
-         ->  Index Only Scan using compress_hyper_5_16_chunk_c_index_2 on _timescaledb_internal.compress_hyper_5_16_chunk (actual rows=1 loops=1)
-               Output: compress_hyper_5_16_chunk.device_id, compress_hyper_5_16_chunk._ts_meta_count
-               Index Cond: (compress_hyper_5_16_chunk.device_id = 1)
+         ->  Index Only Scan using compress_hyper_5_17_chunk_c_index_2 on _timescaledb_internal.compress_hyper_5_17_chunk (actual rows=1 loops=1)
+               Output: compress_hyper_5_17_chunk.device_id, compress_hyper_5_17_chunk._ts_meta_count
+               Index Cond: (compress_hyper_5_17_chunk.device_id = 1)
                Heap Fetches: 1
 (19 rows)
 
@@ -2040,9 +2040,9 @@ WHERE device_id = 1;
                Rows Removed by Filter: 2016
          ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_3_chunk (actual rows=504 loops=1)
                Bulk Decompression: false
-               ->  Index Only Scan using compress_hyper_5_16_chunk_c_index_2 on _timescaledb_internal.compress_hyper_5_16_chunk (actual rows=1 loops=1)
-                     Output: compress_hyper_5_16_chunk.device_id, compress_hyper_5_16_chunk._ts_meta_count
-                     Index Cond: (compress_hyper_5_16_chunk.device_id = 1)
+               ->  Index Only Scan using compress_hyper_5_17_chunk_c_index_2 on _timescaledb_internal.compress_hyper_5_17_chunk (actual rows=1 loops=1)
+                     Output: compress_hyper_5_17_chunk.device_id, compress_hyper_5_17_chunk._ts_meta_count
+                     Index Cond: (compress_hyper_5_17_chunk.device_id = 1)
                      Heap Fetches: 1
 (18 rows)
 
@@ -2068,8 +2068,8 @@ ORDER BY device_id;
    ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_3_chunk (actual rows=2520 loops=1)
          Output: _hyper_1_3_chunk.device_id
          Bulk Decompression: false
-         ->  Index Only Scan using compress_hyper_5_16_chunk_c_index_2 on _timescaledb_internal.compress_hyper_5_16_chunk (actual rows=5 loops=1)
-               Output: compress_hyper_5_16_chunk.device_id, compress_hyper_5_16_chunk._ts_meta_count
+         ->  Index Only Scan using compress_hyper_5_17_chunk_c_index_2 on _timescaledb_internal.compress_hyper_5_17_chunk (actual rows=5 loops=1)
+               Output: compress_hyper_5_17_chunk.device_id, compress_hyper_5_17_chunk._ts_meta_count
                Heap Fetches: 5
 (17 rows)
 
@@ -2101,9 +2101,9 @@ ORDER BY device_id_peer,
          ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_3_chunk (actual rows=0 loops=1)
                Output: _hyper_1_3_chunk."time", _hyper_1_3_chunk.device_id, _hyper_1_3_chunk.device_id_peer, _hyper_1_3_chunk.v0, _hyper_1_3_chunk.v1, _hyper_1_3_chunk.v2, _hyper_1_3_chunk.v3
                Bulk Decompression: true
-               ->  Index Scan using compress_hyper_5_16_chunk__compressed_hypertable_5_device_id_pe on _timescaledb_internal.compress_hyper_5_16_chunk (actual rows=0 loops=1)
-                     Output: compress_hyper_5_16_chunk."time", compress_hyper_5_16_chunk.device_id, compress_hyper_5_16_chunk.device_id_peer, compress_hyper_5_16_chunk.v0, compress_hyper_5_16_chunk.v1, compress_hyper_5_16_chunk.v2, compress_hyper_5_16_chunk.v3, compress_hyper_5_16_chunk._ts_meta_count, compress_hyper_5_16_chunk._ts_meta_sequence_num, compress_hyper_5_16_chunk._ts_meta_min_3, compress_hyper_5_16_chunk._ts_meta_max_3, compress_hyper_5_16_chunk._ts_meta_min_1, compress_hyper_5_16_chunk._ts_meta_max_1, compress_hyper_5_16_chunk._ts_meta_min_2, compress_hyper_5_16_chunk._ts_meta_max_2
-                     Index Cond: (compress_hyper_5_16_chunk.device_id_peer = 1)
+               ->  Index Scan using compress_hyper_5_17_chunk__compressed_hypertable_5_device_id_pe on _timescaledb_internal.compress_hyper_5_17_chunk (actual rows=0 loops=1)
+                     Output: compress_hyper_5_17_chunk."time", compress_hyper_5_17_chunk.device_id, compress_hyper_5_17_chunk.device_id_peer, compress_hyper_5_17_chunk.v0, compress_hyper_5_17_chunk.v1, compress_hyper_5_17_chunk.v2, compress_hyper_5_17_chunk.v3, compress_hyper_5_17_chunk._ts_meta_count, compress_hyper_5_17_chunk._ts_meta_sequence_num, compress_hyper_5_17_chunk._ts_meta_min_3, compress_hyper_5_17_chunk._ts_meta_max_3, compress_hyper_5_17_chunk._ts_meta_min_1, compress_hyper_5_17_chunk._ts_meta_max_1, compress_hyper_5_17_chunk._ts_meta_min_2, compress_hyper_5_17_chunk._ts_meta_max_2
+                     Index Cond: (compress_hyper_5_17_chunk.device_id_peer = 1)
 (21 rows)
 
 :PREFIX_VERBOSE
@@ -2127,9 +2127,9 @@ ORDER BY device_id_peer;
    ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_3_chunk (actual rows=0 loops=1)
          Output: _hyper_1_3_chunk.device_id_peer
          Bulk Decompression: false
-         ->  Index Scan using compress_hyper_5_16_chunk__compressed_hypertable_5_device_id_pe on _timescaledb_internal.compress_hyper_5_16_chunk (actual rows=0 loops=1)
-               Output: compress_hyper_5_16_chunk."time", compress_hyper_5_16_chunk.device_id, compress_hyper_5_16_chunk.device_id_peer, compress_hyper_5_16_chunk.v0, compress_hyper_5_16_chunk.v1, compress_hyper_5_16_chunk.v2, compress_hyper_5_16_chunk.v3, compress_hyper_5_16_chunk._ts_meta_count, compress_hyper_5_16_chunk._ts_meta_sequence_num, compress_hyper_5_16_chunk._ts_meta_min_3, compress_hyper_5_16_chunk._ts_meta_max_3, compress_hyper_5_16_chunk._ts_meta_min_1, compress_hyper_5_16_chunk._ts_meta_max_1, compress_hyper_5_16_chunk._ts_meta_min_2, compress_hyper_5_16_chunk._ts_meta_max_2
-               Index Cond: (compress_hyper_5_16_chunk.device_id_peer = 1)
+         ->  Index Scan using compress_hyper_5_17_chunk__compressed_hypertable_5_device_id_pe on _timescaledb_internal.compress_hyper_5_17_chunk (actual rows=0 loops=1)
+               Output: compress_hyper_5_17_chunk."time", compress_hyper_5_17_chunk.device_id, compress_hyper_5_17_chunk.device_id_peer, compress_hyper_5_17_chunk.v0, compress_hyper_5_17_chunk.v1, compress_hyper_5_17_chunk.v2, compress_hyper_5_17_chunk.v3, compress_hyper_5_17_chunk._ts_meta_count, compress_hyper_5_17_chunk._ts_meta_sequence_num, compress_hyper_5_17_chunk._ts_meta_min_3, compress_hyper_5_17_chunk._ts_meta_max_3, compress_hyper_5_17_chunk._ts_meta_min_1, compress_hyper_5_17_chunk._ts_meta_max_1, compress_hyper_5_17_chunk._ts_meta_min_2, compress_hyper_5_17_chunk._ts_meta_max_2
+               Index Cond: (compress_hyper_5_17_chunk.device_id_peer = 1)
 (17 rows)
 
 --ensure that we can get a nested loop
@@ -2157,9 +2157,9 @@ WHERE device_id_peer IN (
    ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_3_chunk (actual rows=0 loops=1)
          Output: _hyper_1_3_chunk.device_id_peer
          Bulk Decompression: false
-         ->  Seq Scan on _timescaledb_internal.compress_hyper_5_16_chunk (actual rows=0 loops=1)
-               Output: compress_hyper_5_16_chunk."time", compress_hyper_5_16_chunk.device_id, compress_hyper_5_16_chunk.device_id_peer, compress_hyper_5_16_chunk.v0, compress_hyper_5_16_chunk.v1, compress_hyper_5_16_chunk.v2, compress_hyper_5_16_chunk.v3, compress_hyper_5_16_chunk._ts_meta_count, compress_hyper_5_16_chunk._ts_meta_sequence_num, compress_hyper_5_16_chunk._ts_meta_min_3, compress_hyper_5_16_chunk._ts_meta_max_3, compress_hyper_5_16_chunk._ts_meta_min_1, compress_hyper_5_16_chunk._ts_meta_max_1, compress_hyper_5_16_chunk._ts_meta_min_2, compress_hyper_5_16_chunk._ts_meta_max_2
-               Filter: (compress_hyper_5_16_chunk.device_id_peer = 1)
+         ->  Seq Scan on _timescaledb_internal.compress_hyper_5_17_chunk (actual rows=0 loops=1)
+               Output: compress_hyper_5_17_chunk."time", compress_hyper_5_17_chunk.device_id, compress_hyper_5_17_chunk.device_id_peer, compress_hyper_5_17_chunk.v0, compress_hyper_5_17_chunk.v1, compress_hyper_5_17_chunk.v2, compress_hyper_5_17_chunk.v3, compress_hyper_5_17_chunk._ts_meta_count, compress_hyper_5_17_chunk._ts_meta_sequence_num, compress_hyper_5_17_chunk._ts_meta_min_3, compress_hyper_5_17_chunk._ts_meta_max_3, compress_hyper_5_17_chunk._ts_meta_min_1, compress_hyper_5_17_chunk._ts_meta_max_1, compress_hyper_5_17_chunk._ts_meta_min_2, compress_hyper_5_17_chunk._ts_meta_max_2
+               Filter: (compress_hyper_5_17_chunk.device_id_peer = 1)
                Rows Removed by Filter: 5
 (19 rows)
 
@@ -2196,9 +2196,9 @@ WHERE device_id_peer IN (
          ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_3_chunk (actual rows=0 loops=2)
                Output: _hyper_1_3_chunk.device_id_peer
                Bulk Decompression: false
-               ->  Index Scan using compress_hyper_5_16_chunk__compressed_hypertable_5_device_id_pe on _timescaledb_internal.compress_hyper_5_16_chunk (actual rows=0 loops=2)
-                     Output: compress_hyper_5_16_chunk."time", compress_hyper_5_16_chunk.device_id, compress_hyper_5_16_chunk.device_id_peer, compress_hyper_5_16_chunk.v0, compress_hyper_5_16_chunk.v1, compress_hyper_5_16_chunk.v2, compress_hyper_5_16_chunk.v3, compress_hyper_5_16_chunk._ts_meta_count, compress_hyper_5_16_chunk._ts_meta_sequence_num, compress_hyper_5_16_chunk._ts_meta_min_3, compress_hyper_5_16_chunk._ts_meta_max_3, compress_hyper_5_16_chunk._ts_meta_min_1, compress_hyper_5_16_chunk._ts_meta_max_1, compress_hyper_5_16_chunk._ts_meta_min_2, compress_hyper_5_16_chunk._ts_meta_max_2
-                     Index Cond: (compress_hyper_5_16_chunk.device_id_peer = "*VALUES*".column1)
+               ->  Index Scan using compress_hyper_5_17_chunk__compressed_hypertable_5_device_id_pe on _timescaledb_internal.compress_hyper_5_17_chunk (actual rows=0 loops=2)
+                     Output: compress_hyper_5_17_chunk."time", compress_hyper_5_17_chunk.device_id, compress_hyper_5_17_chunk.device_id_peer, compress_hyper_5_17_chunk.v0, compress_hyper_5_17_chunk.v1, compress_hyper_5_17_chunk.v2, compress_hyper_5_17_chunk.v3, compress_hyper_5_17_chunk._ts_meta_count, compress_hyper_5_17_chunk._ts_meta_sequence_num, compress_hyper_5_17_chunk._ts_meta_min_3, compress_hyper_5_17_chunk._ts_meta_max_3, compress_hyper_5_17_chunk._ts_meta_min_1, compress_hyper_5_17_chunk._ts_meta_max_1, compress_hyper_5_17_chunk._ts_meta_min_2, compress_hyper_5_17_chunk._ts_meta_max_2
+                     Index Cond: (compress_hyper_5_17_chunk.device_id_peer = "*VALUES*".column1)
 (27 rows)
 
 RESET enable_hashjoin;
@@ -2224,9 +2224,9 @@ WHERE device_id IN (
    ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_3_chunk (actual rows=504 loops=1)
          Output: _hyper_1_3_chunk.device_id_peer
          Bulk Decompression: false
-         ->  Seq Scan on _timescaledb_internal.compress_hyper_5_16_chunk (actual rows=1 loops=1)
-               Output: compress_hyper_5_16_chunk."time", compress_hyper_5_16_chunk.device_id, compress_hyper_5_16_chunk.device_id_peer, compress_hyper_5_16_chunk.v0, compress_hyper_5_16_chunk.v1, compress_hyper_5_16_chunk.v2, compress_hyper_5_16_chunk.v3, compress_hyper_5_16_chunk._ts_meta_count, compress_hyper_5_16_chunk._ts_meta_sequence_num, compress_hyper_5_16_chunk._ts_meta_min_3, compress_hyper_5_16_chunk._ts_meta_max_3, compress_hyper_5_16_chunk._ts_meta_min_1, compress_hyper_5_16_chunk._ts_meta_max_1, compress_hyper_5_16_chunk._ts_meta_min_2, compress_hyper_5_16_chunk._ts_meta_max_2
-               Filter: (compress_hyper_5_16_chunk.device_id = 1)
+         ->  Seq Scan on _timescaledb_internal.compress_hyper_5_17_chunk (actual rows=1 loops=1)
+               Output: compress_hyper_5_17_chunk."time", compress_hyper_5_17_chunk.device_id, compress_hyper_5_17_chunk.device_id_peer, compress_hyper_5_17_chunk.v0, compress_hyper_5_17_chunk.v1, compress_hyper_5_17_chunk.v2, compress_hyper_5_17_chunk.v3, compress_hyper_5_17_chunk._ts_meta_count, compress_hyper_5_17_chunk._ts_meta_sequence_num, compress_hyper_5_17_chunk._ts_meta_min_3, compress_hyper_5_17_chunk._ts_meta_max_3, compress_hyper_5_17_chunk._ts_meta_min_1, compress_hyper_5_17_chunk._ts_meta_max_1, compress_hyper_5_17_chunk._ts_meta_min_2, compress_hyper_5_17_chunk._ts_meta_max_2
+               Filter: (compress_hyper_5_17_chunk.device_id = 1)
                Rows Removed by Filter: 4
 (19 rows)
 
@@ -2263,9 +2263,9 @@ WHERE device_id IN (
          ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_3_chunk (actual rows=504 loops=2)
                Output: _hyper_1_3_chunk.device_id_peer, _hyper_1_3_chunk.device_id
                Bulk Decompression: false
-               ->  Index Scan using compress_hyper_5_16_chunk_c_index_2 on _timescaledb_internal.compress_hyper_5_16_chunk (actual rows=1 loops=2)
-                     Output: compress_hyper_5_16_chunk."time", compress_hyper_5_16_chunk.device_id, compress_hyper_5_16_chunk.device_id_peer, compress_hyper_5_16_chunk.v0, compress_hyper_5_16_chunk.v1, compress_hyper_5_16_chunk.v2, compress_hyper_5_16_chunk.v3, compress_hyper_5_16_chunk._ts_meta_count, compress_hyper_5_16_chunk._ts_meta_sequence_num, compress_hyper_5_16_chunk._ts_meta_min_3, compress_hyper_5_16_chunk._ts_meta_max_3, compress_hyper_5_16_chunk._ts_meta_min_1, compress_hyper_5_16_chunk._ts_meta_max_1, compress_hyper_5_16_chunk._ts_meta_min_2, compress_hyper_5_16_chunk._ts_meta_max_2
-                     Index Cond: (compress_hyper_5_16_chunk.device_id = "*VALUES*".column1)
+               ->  Index Scan using compress_hyper_5_17_chunk_c_index_2 on _timescaledb_internal.compress_hyper_5_17_chunk (actual rows=1 loops=2)
+                     Output: compress_hyper_5_17_chunk."time", compress_hyper_5_17_chunk.device_id, compress_hyper_5_17_chunk.device_id_peer, compress_hyper_5_17_chunk.v0, compress_hyper_5_17_chunk.v1, compress_hyper_5_17_chunk.v2, compress_hyper_5_17_chunk.v3, compress_hyper_5_17_chunk._ts_meta_count, compress_hyper_5_17_chunk._ts_meta_sequence_num, compress_hyper_5_17_chunk._ts_meta_min_3, compress_hyper_5_17_chunk._ts_meta_max_3, compress_hyper_5_17_chunk._ts_meta_min_1, compress_hyper_5_17_chunk._ts_meta_max_1, compress_hyper_5_17_chunk._ts_meta_min_2, compress_hyper_5_17_chunk._ts_meta_max_2
+                     Index Cond: (compress_hyper_5_17_chunk.device_id = "*VALUES*".column1)
 (27 rows)
 
 SET seq_page_cost = 100;
@@ -2290,8 +2290,8 @@ WHERE device_id IN (
                Output: _hyper_1_2_chunk.device_id_peer, _hyper_1_2_chunk.device_id
          ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_3_chunk
                Output: _hyper_1_3_chunk.device_id_peer, _hyper_1_3_chunk.device_id
-               ->  Index Scan using compress_hyper_5_16_chunk_c_index_2 on _timescaledb_internal.compress_hyper_5_16_chunk
-                     Output: compress_hyper_5_16_chunk."time", compress_hyper_5_16_chunk.device_id, compress_hyper_5_16_chunk.device_id_peer, compress_hyper_5_16_chunk.v0, compress_hyper_5_16_chunk.v1, compress_hyper_5_16_chunk.v2, compress_hyper_5_16_chunk.v3, compress_hyper_5_16_chunk._ts_meta_count, compress_hyper_5_16_chunk._ts_meta_sequence_num, compress_hyper_5_16_chunk._ts_meta_min_3, compress_hyper_5_16_chunk._ts_meta_max_3, compress_hyper_5_16_chunk._ts_meta_min_1, compress_hyper_5_16_chunk._ts_meta_max_1, compress_hyper_5_16_chunk._ts_meta_min_2, compress_hyper_5_16_chunk._ts_meta_max_2
+               ->  Index Scan using compress_hyper_5_17_chunk_c_index_2 on _timescaledb_internal.compress_hyper_5_17_chunk
+                     Output: compress_hyper_5_17_chunk."time", compress_hyper_5_17_chunk.device_id, compress_hyper_5_17_chunk.device_id_peer, compress_hyper_5_17_chunk.v0, compress_hyper_5_17_chunk.v1, compress_hyper_5_17_chunk.v2, compress_hyper_5_17_chunk.v3, compress_hyper_5_17_chunk._ts_meta_count, compress_hyper_5_17_chunk._ts_meta_sequence_num, compress_hyper_5_17_chunk._ts_meta_min_3, compress_hyper_5_17_chunk._ts_meta_max_3, compress_hyper_5_17_chunk._ts_meta_min_1, compress_hyper_5_17_chunk._ts_meta_max_1, compress_hyper_5_17_chunk._ts_meta_min_2, compress_hyper_5_17_chunk._ts_meta_max_2
    ->  Hash
          Output: "*VALUES*".column1
          ->  Values Scan on "*VALUES*"
@@ -2321,9 +2321,9 @@ WHERE device_id IN (
    ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_3_chunk (actual rows=504 loops=1)
          Output: _hyper_1_3_chunk.device_id_peer
          Bulk Decompression: false
-         ->  Seq Scan on _timescaledb_internal.compress_hyper_5_16_chunk (actual rows=1 loops=1)
-               Output: compress_hyper_5_16_chunk."time", compress_hyper_5_16_chunk.device_id, compress_hyper_5_16_chunk.device_id_peer, compress_hyper_5_16_chunk.v0, compress_hyper_5_16_chunk.v1, compress_hyper_5_16_chunk.v2, compress_hyper_5_16_chunk.v3, compress_hyper_5_16_chunk._ts_meta_count, compress_hyper_5_16_chunk._ts_meta_sequence_num, compress_hyper_5_16_chunk._ts_meta_min_3, compress_hyper_5_16_chunk._ts_meta_max_3, compress_hyper_5_16_chunk._ts_meta_min_1, compress_hyper_5_16_chunk._ts_meta_max_1, compress_hyper_5_16_chunk._ts_meta_min_2, compress_hyper_5_16_chunk._ts_meta_max_2
-               Filter: (compress_hyper_5_16_chunk.device_id = 1)
+         ->  Seq Scan on _timescaledb_internal.compress_hyper_5_17_chunk (actual rows=1 loops=1)
+               Output: compress_hyper_5_17_chunk."time", compress_hyper_5_17_chunk.device_id, compress_hyper_5_17_chunk.device_id_peer, compress_hyper_5_17_chunk.v0, compress_hyper_5_17_chunk.v1, compress_hyper_5_17_chunk.v2, compress_hyper_5_17_chunk.v3, compress_hyper_5_17_chunk._ts_meta_count, compress_hyper_5_17_chunk._ts_meta_sequence_num, compress_hyper_5_17_chunk._ts_meta_min_3, compress_hyper_5_17_chunk._ts_meta_max_3, compress_hyper_5_17_chunk._ts_meta_min_1, compress_hyper_5_17_chunk._ts_meta_max_1, compress_hyper_5_17_chunk._ts_meta_min_2, compress_hyper_5_17_chunk._ts_meta_max_2
+               Filter: (compress_hyper_5_17_chunk.device_id = 1)
                Rows Removed by Filter: 4
 (19 rows)
 
@@ -2359,9 +2359,9 @@ WHERE device_id IN (
          ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_3_chunk (actual rows=504 loops=2)
                Output: _hyper_1_3_chunk.device_id_peer, _hyper_1_3_chunk.device_id
                Bulk Decompression: false
-               ->  Index Scan using compress_hyper_5_16_chunk_c_index_2 on _timescaledb_internal.compress_hyper_5_16_chunk (actual rows=1 loops=2)
-                     Output: compress_hyper_5_16_chunk."time", compress_hyper_5_16_chunk.device_id, compress_hyper_5_16_chunk.device_id_peer, compress_hyper_5_16_chunk.v0, compress_hyper_5_16_chunk.v1, compress_hyper_5_16_chunk.v2, compress_hyper_5_16_chunk.v3, compress_hyper_5_16_chunk._ts_meta_count, compress_hyper_5_16_chunk._ts_meta_sequence_num, compress_hyper_5_16_chunk._ts_meta_min_3, compress_hyper_5_16_chunk._ts_meta_max_3, compress_hyper_5_16_chunk._ts_meta_min_1, compress_hyper_5_16_chunk._ts_meta_max_1, compress_hyper_5_16_chunk._ts_meta_min_2, compress_hyper_5_16_chunk._ts_meta_max_2
-                     Index Cond: (compress_hyper_5_16_chunk.device_id = "*VALUES*".column1)
+               ->  Index Scan using compress_hyper_5_17_chunk_c_index_2 on _timescaledb_internal.compress_hyper_5_17_chunk (actual rows=1 loops=2)
+                     Output: compress_hyper_5_17_chunk."time", compress_hyper_5_17_chunk.device_id, compress_hyper_5_17_chunk.device_id_peer, compress_hyper_5_17_chunk.v0, compress_hyper_5_17_chunk.v1, compress_hyper_5_17_chunk.v2, compress_hyper_5_17_chunk.v3, compress_hyper_5_17_chunk._ts_meta_count, compress_hyper_5_17_chunk._ts_meta_sequence_num, compress_hyper_5_17_chunk._ts_meta_min_3, compress_hyper_5_17_chunk._ts_meta_max_3, compress_hyper_5_17_chunk._ts_meta_min_1, compress_hyper_5_17_chunk._ts_meta_max_1, compress_hyper_5_17_chunk._ts_meta_min_2, compress_hyper_5_17_chunk._ts_meta_max_2
+                     Index Cond: (compress_hyper_5_17_chunk.device_id = "*VALUES*".column1)
 (27 rows)
 
 -- test view
@@ -2386,7 +2386,7 @@ LIMIT 10;
                Sort Key: _hyper_1_3_chunk."time" DESC
                Sort Method: top-N heapsort 
                ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk (actual rows=504 loops=1)
-                     ->  Seq Scan on compress_hyper_5_16_chunk (actual rows=1 loops=1)
+                     ->  Seq Scan on compress_hyper_5_17_chunk (actual rows=1 loops=1)
                            Filter: (device_id = 1)
                            Rows Removed by Filter: 4
          ->  Index Scan using _hyper_1_2_chunk_metrics_time_idx on _hyper_1_2_chunk (never executed)
@@ -2430,7 +2430,7 @@ FROM :TEST_TABLE m1
                      ->  Sort (never executed)
                            Sort Key: m1_3."time"
                            ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk m1_3 (never executed)
-                                 ->  Seq Scan on compress_hyper_5_16_chunk (never executed)
+                                 ->  Seq Scan on compress_hyper_5_17_chunk (never executed)
                ->  Materialize (actual rows=51 loops=1)
                      ->  Custom Scan (ChunkAppend) on metrics m2 (actual rows=11 loops=1)
                            Order: m2."time"
@@ -2443,7 +2443,7 @@ FROM :TEST_TABLE m1
                            ->  Sort (never executed)
                                  Sort Key: m2_3."time"
                                  ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk m2_3 (never executed)
-                                       ->  Seq Scan on compress_hyper_5_16_chunk compress_hyper_5_16_chunk_1 (never executed)
+                                       ->  Seq Scan on compress_hyper_5_17_chunk compress_hyper_5_17_chunk_1 (never executed)
 (34 rows)
 
 :PREFIX
@@ -2480,7 +2480,7 @@ FROM :TEST_TABLE m1
                            ->  Sort (never executed)
                                  Sort Key: m1_3."time"
                                  ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk m1_3 (never executed)
-                                       ->  Seq Scan on compress_hyper_5_16_chunk (never executed)
+                                       ->  Seq Scan on compress_hyper_5_17_chunk (never executed)
                      ->  Materialize (actual rows=51 loops=1)
                            ->  Custom Scan (ChunkAppend) on metrics m2 (actual rows=11 loops=1)
                                  Order: m2."time"
@@ -2493,7 +2493,7 @@ FROM :TEST_TABLE m1
                                  ->  Sort (never executed)
                                        Sort Key: m2_3."time"
                                        ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk m2_3 (never executed)
-                                             ->  Seq Scan on compress_hyper_5_16_chunk compress_hyper_5_16_chunk_1 (never executed)
+                                             ->  Seq Scan on compress_hyper_5_17_chunk compress_hyper_5_17_chunk_1 (never executed)
                ->  Materialize (actual rows=11 loops=1)
                      ->  Merge Append (actual rows=3 loops=1)
                            Sort Key: m3_1."time"
@@ -2511,7 +2511,7 @@ FROM :TEST_TABLE m1
                                  Sort Key: m3_3."time"
                                  Sort Method: quicksort 
                                  ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk m3_3 (actual rows=504 loops=1)
-                                       ->  Seq Scan on compress_hyper_5_16_chunk compress_hyper_5_16_chunk_2 (actual rows=1 loops=1)
+                                       ->  Seq Scan on compress_hyper_5_17_chunk compress_hyper_5_17_chunk_2 (actual rows=1 loops=1)
                                              Filter: (device_id = 3)
                                              Rows Removed by Filter: 4
 (56 rows)
@@ -2546,7 +2546,7 @@ FROM :TEST_TABLE m1
                ->  Sort (never executed)
                      Sort Key: m1_3."time"
                      ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk m1_3 (never executed)
-                           ->  Seq Scan on compress_hyper_5_16_chunk (never executed)
+                           ->  Seq Scan on compress_hyper_5_17_chunk (never executed)
                                  Filter: (device_id = 1)
          ->  Materialize (actual rows=100 loops=1)
                ->  Custom Scan (ChunkAppend) on metrics m2 (actual rows=100 loops=1)
@@ -2563,7 +2563,7 @@ FROM :TEST_TABLE m1
                      ->  Sort (never executed)
                            Sort Key: m2_3."time"
                            ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk m2_3 (never executed)
-                                 ->  Seq Scan on compress_hyper_5_16_chunk compress_hyper_5_16_chunk_1 (never executed)
+                                 ->  Seq Scan on compress_hyper_5_17_chunk compress_hyper_5_17_chunk_1 (never executed)
                                        Filter: (device_id = 2)
 (36 rows)
 
@@ -2597,7 +2597,7 @@ FROM metrics m1
                ->  Sort (never executed)
                      Sort Key: m1_3."time"
                      ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk m1_3 (never executed)
-                           ->  Seq Scan on compress_hyper_5_16_chunk (never executed)
+                           ->  Seq Scan on compress_hyper_5_17_chunk (never executed)
                                  Filter: (device_id = 1)
          ->  Materialize (actual rows=100 loops=1)
                ->  Custom Scan (ChunkAppend) on metrics_space m2 (actual rows=100 loops=1)
@@ -2606,7 +2606,7 @@ FROM metrics m1
                            Sort Key: m2_1."time"
                            Sort Method: quicksort 
                            ->  Custom Scan (DecompressChunk) on _hyper_2_5_chunk m2_1 (actual rows=360 loops=1)
-                                 ->  Seq Scan on compress_hyper_6_18_chunk (actual rows=1 loops=1)
+                                 ->  Seq Scan on compress_hyper_6_19_chunk (actual rows=1 loops=1)
                                        Filter: (device_id = 2)
                                        Rows Removed by Filter: 2
                      ->  Index Scan Backward using _hyper_2_8_chunk_metrics_space_device_id_time_idx on _hyper_2_8_chunk m2_2 (never executed)
@@ -2614,7 +2614,7 @@ FROM metrics m1
                      ->  Sort (never executed)
                            Sort Key: m2_3."time"
                            ->  Custom Scan (DecompressChunk) on _hyper_2_11_chunk m2_3 (never executed)
-                                 ->  Seq Scan on compress_hyper_6_21_chunk (never executed)
+                                 ->  Seq Scan on compress_hyper_6_25_chunk (never executed)
                                        Filter: (device_id = 2)
 (36 rows)
 
@@ -2649,7 +2649,7 @@ LIMIT 10;
                      ->  Sort (never executed)
                            Sort Key: m1_3."time"
                            ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk m1_3 (never executed)
-                                 ->  Seq Scan on compress_hyper_5_16_chunk (never executed)
+                                 ->  Seq Scan on compress_hyper_5_17_chunk (never executed)
                ->  Materialize (actual rows=51 loops=1)
                      ->  Custom Scan (ChunkAppend) on metrics m2 (actual rows=11 loops=1)
                            Order: m2."time"
@@ -2662,7 +2662,7 @@ LIMIT 10;
                            ->  Sort (never executed)
                                  Sort Key: m2_3."time"
                                  ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk m2_3 (never executed)
-                                       ->  Seq Scan on compress_hyper_5_16_chunk compress_hyper_5_16_chunk_1 (never executed)
+                                       ->  Seq Scan on compress_hyper_5_17_chunk compress_hyper_5_17_chunk_1 (never executed)
 (34 rows)
 
 :PREFIX
@@ -2698,7 +2698,7 @@ LIMIT 100;
                      ->  Sort (never executed)
                            Sort Key: m1_3."time"
                            ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk m1_3 (never executed)
-                                 ->  Seq Scan on compress_hyper_5_16_chunk (never executed)
+                                 ->  Seq Scan on compress_hyper_5_17_chunk (never executed)
                ->  Materialize (actual rows=102 loops=1)
                      ->  Custom Scan (ChunkAppend) on metrics m2 (actual rows=22 loops=1)
                            Order: m2."time"
@@ -2714,7 +2714,7 @@ LIMIT 100;
                            ->  Sort (never executed)
                                  Sort Key: m2_3."time"
                                  ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk m2_3 (never executed)
-                                       ->  Seq Scan on compress_hyper_5_16_chunk compress_hyper_5_16_chunk_1 (never executed)
+                                       ->  Seq Scan on compress_hyper_5_17_chunk compress_hyper_5_17_chunk_1 (never executed)
                                              Filter: (device_id = 2)
 (38 rows)
 
@@ -2751,7 +2751,7 @@ LIMIT 100;
                      ->  Sort (never executed)
                            Sort Key: m1_3."time"
                            ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk m1_3 (never executed)
-                                 ->  Seq Scan on compress_hyper_5_16_chunk (never executed)
+                                 ->  Seq Scan on compress_hyper_5_17_chunk (never executed)
                ->  Materialize (actual rows=102 loops=1)
                      ->  Custom Scan (ChunkAppend) on metrics_space m2 (actual rows=22 loops=1)
                            Order: m2."time"
@@ -2764,7 +2764,7 @@ LIMIT 100;
                                              Sort Key: m2_1."time"
                                              Sort Method: quicksort 
                                              ->  Custom Scan (DecompressChunk) on _hyper_2_4_chunk m2_1 (actual rows=0 loops=1)
-                                                   ->  Seq Scan on compress_hyper_6_17_chunk (actual rows=0 loops=1)
+                                                   ->  Seq Scan on compress_hyper_6_18_chunk (actual rows=0 loops=1)
                                                          Filter: (device_id = 2)
                                                          Rows Removed by Filter: 1
                                  ->  Sort (actual rows=22 loops=1)
@@ -2774,7 +2774,7 @@ LIMIT 100;
                                              Sort Key: m2_2."time"
                                              Sort Method: quicksort 
                                              ->  Custom Scan (DecompressChunk) on _hyper_2_5_chunk m2_2 (actual rows=360 loops=1)
-                                                   ->  Seq Scan on compress_hyper_6_18_chunk (actual rows=1 loops=1)
+                                                   ->  Seq Scan on compress_hyper_6_19_chunk (actual rows=1 loops=1)
                                                          Filter: (device_id = 2)
                                                          Rows Removed by Filter: 2
                                  ->  Sort (actual rows=0 loops=1)
@@ -2784,7 +2784,7 @@ LIMIT 100;
                                              Sort Key: m2_3."time"
                                              Sort Method: quicksort 
                                              ->  Custom Scan (DecompressChunk) on _hyper_2_6_chunk m2_3 (actual rows=0 loops=1)
-                                                   ->  Seq Scan on compress_hyper_6_19_chunk (actual rows=0 loops=1)
+                                                   ->  Seq Scan on compress_hyper_6_20_chunk (actual rows=0 loops=1)
                                                          Filter: (device_id = 2)
                                                          Rows Removed by Filter: 1
                            ->  Merge Append (never executed)
@@ -2802,14 +2802,14 @@ LIMIT 100;
                                        ->  Sort (never executed)
                                              Sort Key: m2_7."time"
                                              ->  Custom Scan (DecompressChunk) on _hyper_2_10_chunk m2_7 (never executed)
-                                                   ->  Seq Scan on compress_hyper_6_20_chunk (never executed)
+                                                   ->  Seq Scan on compress_hyper_6_24_chunk (never executed)
                                                          Filter: (device_id = 2)
                                  ->  Sort (never executed)
                                        Sort Key: m2_8."time"
                                        ->  Sort (never executed)
                                              Sort Key: m2_8."time"
                                              ->  Custom Scan (DecompressChunk) on _hyper_2_11_chunk m2_8 (never executed)
-                                                   ->  Seq Scan on compress_hyper_6_21_chunk (never executed)
+                                                   ->  Seq Scan on compress_hyper_6_25_chunk (never executed)
                                                          Filter: (device_id = 2)
                                  ->  Index Scan Backward using _hyper_2_12_chunk_metrics_space_time_idx on _hyper_2_12_chunk m2_9 (never executed)
                                        Filter: (device_id = 2)
@@ -2846,7 +2846,7 @@ LIMIT 20;
                      ->  Sort (never executed)
                            Sort Key: m1_3."time"
                            ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk m1_3 (never executed)
-                                 ->  Seq Scan on compress_hyper_5_16_chunk (never executed)
+                                 ->  Seq Scan on compress_hyper_5_17_chunk (never executed)
                ->  Materialize (actual rows=26 loops=1)
                      ->  Custom Scan (ChunkAppend) on metrics m2 (actual rows=6 loops=1)
                            Order: m2."time"
@@ -2859,7 +2859,7 @@ LIMIT 20;
                            ->  Sort (never executed)
                                  Sort Key: m2_3."time"
                                  ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk m2_3 (never executed)
-                                       ->  Seq Scan on compress_hyper_5_16_chunk compress_hyper_5_16_chunk_1 (never executed)
+                                       ->  Seq Scan on compress_hyper_5_17_chunk compress_hyper_5_17_chunk_1 (never executed)
 (32 rows)
 
 -- test self-join with sub-query
@@ -2895,7 +2895,7 @@ LIMIT 10;
                      ->  Sort (never executed)
                            Sort Key: m1_3."time"
                            ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk m1_3 (never executed)
-                                 ->  Seq Scan on compress_hyper_5_16_chunk (never executed)
+                                 ->  Seq Scan on compress_hyper_5_17_chunk (never executed)
                ->  Materialize (actual rows=26 loops=1)
                      ->  Custom Scan (ChunkAppend) on metrics m2 (actual rows=6 loops=1)
                            Order: m2."time"
@@ -2908,7 +2908,7 @@ LIMIT 10;
                            ->  Sort (never executed)
                                  Sort Key: m2_3."time"
                                  ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk m2_3 (never executed)
-                                       ->  Seq Scan on compress_hyper_5_16_chunk compress_hyper_5_16_chunk_1 (never executed)
+                                       ->  Seq Scan on compress_hyper_5_17_chunk compress_hyper_5_17_chunk_1 (never executed)
 (32 rows)
 
 :PREFIX
@@ -2937,7 +2937,7 @@ FROM generate_series('2000-01-01'::timestamptz, '2000-02-01'::timestamptz, '1d':
                ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk m1_3 (actual rows=1 loops=7)
                      Filter: ("time" = g."time")
                      Rows Removed by Filter: 240
-                     ->  Seq Scan on compress_hyper_5_16_chunk (actual rows=1 loops=7)
+                     ->  Seq Scan on compress_hyper_5_17_chunk (actual rows=1 loops=7)
                            Filter: ((_ts_meta_min_3 <= g."time") AND (_ts_meta_max_3 >= g."time"))
 (18 rows)
 
@@ -2970,7 +2970,7 @@ FROM generate_series('2000-01-01'::timestamptz, '2000-02-01'::timestamptz, '1d':
                ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk m1_3 (actual rows=1 loops=7)
                      Filter: ("time" = g."time")
                      Rows Removed by Filter: 240
-                     ->  Seq Scan on compress_hyper_5_16_chunk (actual rows=1 loops=7)
+                     ->  Seq Scan on compress_hyper_5_17_chunk (actual rows=1 loops=7)
                            Filter: ((_ts_meta_min_3 <= g."time") AND (_ts_meta_max_3 >= g."time") AND (device_id = 1))
 (18 rows)
 
@@ -2995,7 +2995,7 @@ FROM generate_series('2000-01-01'::timestamptz, '2000-02-01'::timestamptz, '1d':
                ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk m1_3 (actual rows=1 loops=7)
                      Filter: ("time" = g."time")
                      Rows Removed by Filter: 240
-                     ->  Seq Scan on compress_hyper_5_16_chunk (actual rows=1 loops=7)
+                     ->  Seq Scan on compress_hyper_5_17_chunk (actual rows=1 loops=7)
                            Filter: ((_ts_meta_min_3 <= g."time") AND (_ts_meta_max_3 >= g."time") AND (device_id = 2))
                            Rows Removed by Filter: 1
 (21 rows)
@@ -3161,18 +3161,18 @@ WHERE metrics.time > metrics_space.time
  Nested Loop (actual rows=0 loops=1)
    ->  Append (actual rows=6840 loops=1)
          ->  Custom Scan (DecompressChunk) on _hyper_2_4_chunk (actual rows=360 loops=1)
-               ->  Index Scan using compress_hyper_6_17_chunk_c_space_index_2 on compress_hyper_6_17_chunk (actual rows=1 loops=1)
+               ->  Index Scan using compress_hyper_6_18_chunk_c_space_index_2 on compress_hyper_6_18_chunk (actual rows=1 loops=1)
          ->  Custom Scan (DecompressChunk) on _hyper_2_5_chunk (actual rows=1080 loops=1)
-               ->  Index Scan using compress_hyper_6_18_chunk_c_space_index_2 on compress_hyper_6_18_chunk (actual rows=3 loops=1)
+               ->  Index Scan using compress_hyper_6_19_chunk_c_space_index_2 on compress_hyper_6_19_chunk (actual rows=3 loops=1)
          ->  Custom Scan (DecompressChunk) on _hyper_2_6_chunk (actual rows=360 loops=1)
-               ->  Index Scan using compress_hyper_6_19_chunk_c_space_index_2 on compress_hyper_6_19_chunk (actual rows=1 loops=1)
+               ->  Index Scan using compress_hyper_6_20_chunk_c_space_index_2 on compress_hyper_6_20_chunk (actual rows=1 loops=1)
          ->  Index Scan Backward using _hyper_2_7_chunk_metrics_space_device_id_device_id_peer_v0_v1_2 on _hyper_2_7_chunk (actual rows=504 loops=1)
          ->  Index Scan Backward using _hyper_2_8_chunk_metrics_space_device_id_device_id_peer_v0_v1_2 on _hyper_2_8_chunk (actual rows=1512 loops=1)
          ->  Index Scan Backward using _hyper_2_9_chunk_metrics_space_device_id_device_id_peer_v0_v1_2 on _hyper_2_9_chunk (actual rows=504 loops=1)
          ->  Custom Scan (DecompressChunk) on _hyper_2_10_chunk (actual rows=504 loops=1)
-               ->  Index Scan using compress_hyper_6_20_chunk_c_space_index_2 on compress_hyper_6_20_chunk (actual rows=1 loops=1)
+               ->  Index Scan using compress_hyper_6_24_chunk_c_space_index_2 on compress_hyper_6_24_chunk (actual rows=1 loops=1)
          ->  Custom Scan (DecompressChunk) on _hyper_2_11_chunk (actual rows=1512 loops=1)
-               ->  Index Scan using compress_hyper_6_21_chunk_c_space_index_2 on compress_hyper_6_21_chunk (actual rows=3 loops=1)
+               ->  Index Scan using compress_hyper_6_25_chunk_c_space_index_2 on compress_hyper_6_25_chunk (actual rows=3 loops=1)
          ->  Index Scan Backward using _hyper_2_12_chunk_metrics_space_device_id_device_id_peer_v0_v_2 on _hyper_2_12_chunk (actual rows=504 loops=1)
    ->  Append (actual rows=0 loops=6840)
          ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk (actual rows=0 loops=6840)
@@ -3186,7 +3186,7 @@ WHERE metrics.time > metrics_space.time
          ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk (actual rows=0 loops=6840)
                Filter: (("time" > _hyper_2_4_chunk."time") AND ("time" < _hyper_2_4_chunk."time"))
                Rows Removed by Filter: 504
-               ->  Index Scan using compress_hyper_5_16_chunk_c_index_2 on compress_hyper_5_16_chunk (actual rows=1 loops=6840)
+               ->  Index Scan using compress_hyper_5_17_chunk_c_index_2 on compress_hyper_5_17_chunk (actual rows=1 loops=6840)
                      Index Cond: (device_id = _hyper_2_4_chunk.device_id)
 (30 rows)
 
@@ -3224,9 +3224,9 @@ LIMIT 5;
                ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_4_chunk (actual rows=360 loops=1)
                      Output: _hyper_2_4_chunk."time", _hyper_2_4_chunk.device_id, _hyper_2_4_chunk.device_id_peer, _hyper_2_4_chunk.v0, _hyper_2_4_chunk.v1, _hyper_2_4_chunk.v2, _hyper_2_4_chunk.v3
                      Bulk Decompression: true
-                     ->  Seq Scan on _timescaledb_internal.compress_hyper_6_17_chunk (actual rows=1 loops=1)
-                           Output: compress_hyper_6_17_chunk."time", compress_hyper_6_17_chunk.device_id, compress_hyper_6_17_chunk.device_id_peer, compress_hyper_6_17_chunk.v0, compress_hyper_6_17_chunk.v1, compress_hyper_6_17_chunk.v2, compress_hyper_6_17_chunk.v3, compress_hyper_6_17_chunk._ts_meta_count, compress_hyper_6_17_chunk._ts_meta_sequence_num, compress_hyper_6_17_chunk._ts_meta_min_3, compress_hyper_6_17_chunk._ts_meta_max_3, compress_hyper_6_17_chunk._ts_meta_min_1, compress_hyper_6_17_chunk._ts_meta_max_1, compress_hyper_6_17_chunk._ts_meta_min_2, compress_hyper_6_17_chunk._ts_meta_max_2
-                           Filter: (compress_hyper_6_17_chunk.device_id = 1)
+                     ->  Seq Scan on _timescaledb_internal.compress_hyper_6_18_chunk (actual rows=1 loops=1)
+                           Output: compress_hyper_6_18_chunk."time", compress_hyper_6_18_chunk.device_id, compress_hyper_6_18_chunk.device_id_peer, compress_hyper_6_18_chunk.v0, compress_hyper_6_18_chunk.v1, compress_hyper_6_18_chunk.v2, compress_hyper_6_18_chunk.v3, compress_hyper_6_18_chunk._ts_meta_count, compress_hyper_6_18_chunk._ts_meta_sequence_num, compress_hyper_6_18_chunk._ts_meta_min_3, compress_hyper_6_18_chunk._ts_meta_max_3, compress_hyper_6_18_chunk._ts_meta_min_1, compress_hyper_6_18_chunk._ts_meta_max_1, compress_hyper_6_18_chunk._ts_meta_min_2, compress_hyper_6_18_chunk._ts_meta_max_2
+                           Filter: (compress_hyper_6_18_chunk.device_id = 1)
          ->  Index Scan Backward using _hyper_2_7_chunk_metrics_space_time_idx on _timescaledb_internal._hyper_2_7_chunk (never executed)
                Output: _hyper_2_7_chunk."time", _hyper_2_7_chunk.device_id, _hyper_2_7_chunk.device_id_peer, _hyper_2_7_chunk.v0, _hyper_2_7_chunk.v1, _hyper_2_7_chunk.v2, _hyper_2_7_chunk.v3
                Filter: (_hyper_2_7_chunk.device_id = 1)
@@ -3236,9 +3236,9 @@ LIMIT 5;
                ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_10_chunk (never executed)
                      Output: _hyper_2_10_chunk."time", _hyper_2_10_chunk.device_id, _hyper_2_10_chunk.device_id_peer, _hyper_2_10_chunk.v0, _hyper_2_10_chunk.v1, _hyper_2_10_chunk.v2, _hyper_2_10_chunk.v3
                      Bulk Decompression: true
-                     ->  Seq Scan on _timescaledb_internal.compress_hyper_6_20_chunk (never executed)
-                           Output: compress_hyper_6_20_chunk."time", compress_hyper_6_20_chunk.device_id, compress_hyper_6_20_chunk.device_id_peer, compress_hyper_6_20_chunk.v0, compress_hyper_6_20_chunk.v1, compress_hyper_6_20_chunk.v2, compress_hyper_6_20_chunk.v3, compress_hyper_6_20_chunk._ts_meta_count, compress_hyper_6_20_chunk._ts_meta_sequence_num, compress_hyper_6_20_chunk._ts_meta_min_3, compress_hyper_6_20_chunk._ts_meta_max_3, compress_hyper_6_20_chunk._ts_meta_min_1, compress_hyper_6_20_chunk._ts_meta_max_1, compress_hyper_6_20_chunk._ts_meta_min_2, compress_hyper_6_20_chunk._ts_meta_max_2
-                           Filter: (compress_hyper_6_20_chunk.device_id = 1)
+                     ->  Seq Scan on _timescaledb_internal.compress_hyper_6_24_chunk (never executed)
+                           Output: compress_hyper_6_24_chunk."time", compress_hyper_6_24_chunk.device_id, compress_hyper_6_24_chunk.device_id_peer, compress_hyper_6_24_chunk.v0, compress_hyper_6_24_chunk.v1, compress_hyper_6_24_chunk.v2, compress_hyper_6_24_chunk.v3, compress_hyper_6_24_chunk._ts_meta_count, compress_hyper_6_24_chunk._ts_meta_sequence_num, compress_hyper_6_24_chunk._ts_meta_min_3, compress_hyper_6_24_chunk._ts_meta_max_3, compress_hyper_6_24_chunk._ts_meta_min_1, compress_hyper_6_24_chunk._ts_meta_max_1, compress_hyper_6_24_chunk._ts_meta_min_2, compress_hyper_6_24_chunk._ts_meta_max_2
+                           Filter: (compress_hyper_6_24_chunk.device_id = 1)
 (29 rows)
 
 -- test RECORD by itself
@@ -3255,7 +3255,7 @@ ORDER BY time;
          Sort Key: _hyper_2_4_chunk."time"
          Sort Method: quicksort 
          ->  Custom Scan (DecompressChunk) on _hyper_2_4_chunk (actual rows=360 loops=1)
-               ->  Seq Scan on compress_hyper_6_17_chunk (actual rows=1 loops=1)
+               ->  Seq Scan on compress_hyper_6_18_chunk (actual rows=1 loops=1)
                      Filter: (device_id = 1)
    ->  Index Scan Backward using _hyper_2_7_chunk_metrics_space_time_idx on _hyper_2_7_chunk (actual rows=504 loops=1)
          Filter: (device_id = 1)
@@ -3263,7 +3263,7 @@ ORDER BY time;
          Sort Key: _hyper_2_10_chunk."time"
          Sort Method: quicksort 
          ->  Custom Scan (DecompressChunk) on _hyper_2_10_chunk (actual rows=504 loops=1)
-               ->  Seq Scan on compress_hyper_6_20_chunk (actual rows=1 loops=1)
+               ->  Seq Scan on compress_hyper_6_24_chunk (actual rows=1 loops=1)
                      Filter: (device_id = 1)
 (16 rows)
 
@@ -3296,7 +3296,7 @@ ORDER BY time,
                            Sort Key: _hyper_2_4_chunk."time"
                            Sort Method: quicksort 
                            ->  Custom Scan (DecompressChunk) on _hyper_2_4_chunk (actual rows=360 loops=1)
-                                 ->  Seq Scan on compress_hyper_6_17_chunk (actual rows=1 loops=1)
+                                 ->  Seq Scan on compress_hyper_6_18_chunk (actual rows=1 loops=1)
                                        Filter: (device_id = ANY ('{1,2}'::integer[]))
                ->  Sort (actual rows=360 loops=1)
                      Sort Key: _hyper_2_5_chunk."time"
@@ -3305,7 +3305,7 @@ ORDER BY time,
                            Sort Key: _hyper_2_5_chunk."time"
                            Sort Method: quicksort 
                            ->  Custom Scan (DecompressChunk) on _hyper_2_5_chunk (actual rows=360 loops=1)
-                                 ->  Seq Scan on compress_hyper_6_18_chunk (actual rows=1 loops=1)
+                                 ->  Seq Scan on compress_hyper_6_19_chunk (actual rows=1 loops=1)
                                        Filter: (device_id = ANY ('{1,2}'::integer[]))
                                        Rows Removed by Filter: 2
          ->  Merge Append (actual rows=1008 loops=1)
@@ -3324,7 +3324,7 @@ ORDER BY time,
                            Sort Key: _hyper_2_10_chunk."time"
                            Sort Method: quicksort 
                            ->  Custom Scan (DecompressChunk) on _hyper_2_10_chunk (actual rows=504 loops=1)
-                                 ->  Seq Scan on compress_hyper_6_20_chunk (actual rows=1 loops=1)
+                                 ->  Seq Scan on compress_hyper_6_24_chunk (actual rows=1 loops=1)
                                        Filter: (device_id = ANY ('{1,2}'::integer[]))
                ->  Sort (actual rows=504 loops=1)
                      Sort Key: _hyper_2_11_chunk."time"
@@ -3333,7 +3333,7 @@ ORDER BY time,
                            Sort Key: _hyper_2_11_chunk."time"
                            Sort Method: quicksort 
                            ->  Custom Scan (DecompressChunk) on _hyper_2_11_chunk (actual rows=504 loops=1)
-                                 ->  Seq Scan on compress_hyper_6_21_chunk (actual rows=1 loops=1)
+                                 ->  Seq Scan on compress_hyper_6_25_chunk (actual rows=1 loops=1)
                                        Filter: (device_id = ANY ('{1,2}'::integer[]))
                                        Rows Removed by Filter: 2
 (55 rows)
@@ -3346,18 +3346,18 @@ FROM :TEST_TABLE;
 -------------------------------------------------------------------------------------
  Append (actual rows=6840 loops=1)
    ->  Custom Scan (DecompressChunk) on _hyper_2_4_chunk (actual rows=360 loops=1)
-         ->  Seq Scan on compress_hyper_6_17_chunk (actual rows=1 loops=1)
+         ->  Seq Scan on compress_hyper_6_18_chunk (actual rows=1 loops=1)
    ->  Custom Scan (DecompressChunk) on _hyper_2_5_chunk (actual rows=1080 loops=1)
-         ->  Seq Scan on compress_hyper_6_18_chunk (actual rows=3 loops=1)
+         ->  Seq Scan on compress_hyper_6_19_chunk (actual rows=3 loops=1)
    ->  Custom Scan (DecompressChunk) on _hyper_2_6_chunk (actual rows=360 loops=1)
-         ->  Seq Scan on compress_hyper_6_19_chunk (actual rows=1 loops=1)
+         ->  Seq Scan on compress_hyper_6_20_chunk (actual rows=1 loops=1)
    ->  Seq Scan on _hyper_2_7_chunk (actual rows=504 loops=1)
    ->  Seq Scan on _hyper_2_8_chunk (actual rows=1512 loops=1)
    ->  Seq Scan on _hyper_2_9_chunk (actual rows=504 loops=1)
    ->  Custom Scan (DecompressChunk) on _hyper_2_10_chunk (actual rows=504 loops=1)
-         ->  Seq Scan on compress_hyper_6_20_chunk (actual rows=1 loops=1)
+         ->  Seq Scan on compress_hyper_6_24_chunk (actual rows=1 loops=1)
    ->  Custom Scan (DecompressChunk) on _hyper_2_11_chunk (actual rows=1512 loops=1)
-         ->  Seq Scan on compress_hyper_6_21_chunk (actual rows=3 loops=1)
+         ->  Seq Scan on compress_hyper_6_25_chunk (actual rows=3 loops=1)
    ->  Seq Scan on _hyper_2_12_chunk (actual rows=504 loops=1)
 (15 rows)
 
@@ -3370,15 +3370,15 @@ WHERE device_id < 0;
 -------------------------------------------------------------------------------------------------------------------------------------
  Append (actual rows=0 loops=1)
    ->  Custom Scan (DecompressChunk) on _hyper_2_4_chunk (actual rows=0 loops=1)
-         ->  Seq Scan on compress_hyper_6_17_chunk (actual rows=0 loops=1)
+         ->  Seq Scan on compress_hyper_6_18_chunk (actual rows=0 loops=1)
                Filter: (device_id < 0)
                Rows Removed by Filter: 1
    ->  Custom Scan (DecompressChunk) on _hyper_2_5_chunk (actual rows=0 loops=1)
-         ->  Seq Scan on compress_hyper_6_18_chunk (actual rows=0 loops=1)
+         ->  Seq Scan on compress_hyper_6_19_chunk (actual rows=0 loops=1)
                Filter: (device_id < 0)
                Rows Removed by Filter: 3
    ->  Custom Scan (DecompressChunk) on _hyper_2_6_chunk (actual rows=0 loops=1)
-         ->  Seq Scan on compress_hyper_6_19_chunk (actual rows=0 loops=1)
+         ->  Seq Scan on compress_hyper_6_20_chunk (actual rows=0 loops=1)
                Filter: (device_id < 0)
                Rows Removed by Filter: 1
    ->  Index Scan using _hyper_2_7_chunk_metrics_space_device_id_device_id_peer_v0_v1_2 on _hyper_2_7_chunk (actual rows=0 loops=1)
@@ -3388,11 +3388,11 @@ WHERE device_id < 0;
    ->  Index Scan using _hyper_2_9_chunk_metrics_space_device_id_device_id_peer_v0_v1_2 on _hyper_2_9_chunk (actual rows=0 loops=1)
          Index Cond: (device_id < 0)
    ->  Custom Scan (DecompressChunk) on _hyper_2_10_chunk (actual rows=0 loops=1)
-         ->  Seq Scan on compress_hyper_6_20_chunk (actual rows=0 loops=1)
+         ->  Seq Scan on compress_hyper_6_24_chunk (actual rows=0 loops=1)
                Filter: (device_id < 0)
                Rows Removed by Filter: 1
    ->  Custom Scan (DecompressChunk) on _hyper_2_11_chunk (actual rows=0 loops=1)
-         ->  Seq Scan on compress_hyper_6_21_chunk (actual rows=0 loops=1)
+         ->  Seq Scan on compress_hyper_6_25_chunk (actual rows=0 loops=1)
                Filter: (device_id < 0)
                Rows Removed by Filter: 3
    ->  Index Scan using _hyper_2_12_chunk_metrics_space_device_id_device_id_peer_v0_v_2 on _hyper_2_12_chunk (actual rows=0 loops=1)
@@ -3408,18 +3408,18 @@ FROM :TEST_TABLE;
  Result (actual rows=6840 loops=1)
    ->  Append (actual rows=6840 loops=1)
          ->  Custom Scan (DecompressChunk) on _hyper_2_4_chunk (actual rows=360 loops=1)
-               ->  Seq Scan on compress_hyper_6_17_chunk (actual rows=1 loops=1)
+               ->  Seq Scan on compress_hyper_6_18_chunk (actual rows=1 loops=1)
          ->  Custom Scan (DecompressChunk) on _hyper_2_5_chunk (actual rows=1080 loops=1)
-               ->  Seq Scan on compress_hyper_6_18_chunk (actual rows=3 loops=1)
+               ->  Seq Scan on compress_hyper_6_19_chunk (actual rows=3 loops=1)
          ->  Custom Scan (DecompressChunk) on _hyper_2_6_chunk (actual rows=360 loops=1)
-               ->  Seq Scan on compress_hyper_6_19_chunk (actual rows=1 loops=1)
+               ->  Seq Scan on compress_hyper_6_20_chunk (actual rows=1 loops=1)
          ->  Seq Scan on _hyper_2_7_chunk (actual rows=504 loops=1)
          ->  Seq Scan on _hyper_2_8_chunk (actual rows=1512 loops=1)
          ->  Seq Scan on _hyper_2_9_chunk (actual rows=504 loops=1)
          ->  Custom Scan (DecompressChunk) on _hyper_2_10_chunk (actual rows=504 loops=1)
-               ->  Seq Scan on compress_hyper_6_20_chunk (actual rows=1 loops=1)
+               ->  Seq Scan on compress_hyper_6_24_chunk (actual rows=1 loops=1)
          ->  Custom Scan (DecompressChunk) on _hyper_2_11_chunk (actual rows=1512 loops=1)
-               ->  Seq Scan on compress_hyper_6_21_chunk (actual rows=3 loops=1)
+               ->  Seq Scan on compress_hyper_6_25_chunk (actual rows=3 loops=1)
          ->  Seq Scan on _hyper_2_12_chunk (actual rows=504 loops=1)
 (16 rows)
 
@@ -3436,12 +3436,12 @@ ORDER BY v1;
    Sort Method: quicksort 
    ->  Append (actual rows=1368 loops=1)
          ->  Custom Scan (DecompressChunk) on _hyper_2_4_chunk (actual rows=360 loops=1)
-               ->  Seq Scan on compress_hyper_6_17_chunk (actual rows=1 loops=1)
+               ->  Seq Scan on compress_hyper_6_18_chunk (actual rows=1 loops=1)
                      Filter: (device_id = 1)
          ->  Seq Scan on _hyper_2_7_chunk (actual rows=504 loops=1)
                Filter: (device_id = 1)
          ->  Custom Scan (DecompressChunk) on _hyper_2_10_chunk (actual rows=504 loops=1)
-               ->  Seq Scan on compress_hyper_6_20_chunk (actual rows=1 loops=1)
+               ->  Seq Scan on compress_hyper_6_24_chunk (actual rows=1 loops=1)
                      Filter: (device_id = 1)
 (12 rows)
 
@@ -3458,12 +3458,12 @@ ORDER BY v1;
    Sort Method: quicksort 
    ->  Append (actual rows=1368 loops=1)
          ->  Custom Scan (DecompressChunk) on _hyper_2_4_chunk (actual rows=360 loops=1)
-               ->  Seq Scan on compress_hyper_6_17_chunk (actual rows=1 loops=1)
+               ->  Seq Scan on compress_hyper_6_18_chunk (actual rows=1 loops=1)
                      Filter: (device_id = 1)
          ->  Seq Scan on _hyper_2_7_chunk (actual rows=504 loops=1)
                Filter: (device_id = 1)
          ->  Custom Scan (DecompressChunk) on _hyper_2_10_chunk (actual rows=504 loops=1)
-               ->  Seq Scan on compress_hyper_6_20_chunk (actual rows=1 loops=1)
+               ->  Seq Scan on compress_hyper_6_24_chunk (actual rows=1 loops=1)
                      Filter: (device_id = 1)
 (12 rows)
 
@@ -3476,12 +3476,12 @@ WHERE device_id = 1;
 ------------------------------------------------------------------------------------
  Append (actual rows=1368 loops=1)
    ->  Custom Scan (DecompressChunk) on _hyper_2_4_chunk (actual rows=360 loops=1)
-         ->  Seq Scan on compress_hyper_6_17_chunk (actual rows=1 loops=1)
+         ->  Seq Scan on compress_hyper_6_18_chunk (actual rows=1 loops=1)
                Filter: (device_id = 1)
    ->  Seq Scan on _hyper_2_7_chunk (actual rows=504 loops=1)
          Filter: (device_id = 1)
    ->  Custom Scan (DecompressChunk) on _hyper_2_10_chunk (actual rows=504 loops=1)
-         ->  Seq Scan on compress_hyper_6_20_chunk (actual rows=1 loops=1)
+         ->  Seq Scan on compress_hyper_6_24_chunk (actual rows=1 loops=1)
                Filter: (device_id = 1)
 (9 rows)
 
@@ -3507,22 +3507,22 @@ ORDER BY time,
                Filter: (_hyper_2_4_chunk.v3 > '10'::double precision)
                Rows Removed by Filter: 360
                Bulk Decompression: true
-               ->  Seq Scan on _timescaledb_internal.compress_hyper_6_17_chunk (actual rows=1 loops=1)
-                     Output: compress_hyper_6_17_chunk."time", compress_hyper_6_17_chunk.device_id, compress_hyper_6_17_chunk.device_id_peer, compress_hyper_6_17_chunk.v0, compress_hyper_6_17_chunk.v1, compress_hyper_6_17_chunk.v2, compress_hyper_6_17_chunk.v3, compress_hyper_6_17_chunk._ts_meta_count, compress_hyper_6_17_chunk._ts_meta_sequence_num, compress_hyper_6_17_chunk._ts_meta_min_3, compress_hyper_6_17_chunk._ts_meta_max_3, compress_hyper_6_17_chunk._ts_meta_min_1, compress_hyper_6_17_chunk._ts_meta_max_1, compress_hyper_6_17_chunk._ts_meta_min_2, compress_hyper_6_17_chunk._ts_meta_max_2
+               ->  Seq Scan on _timescaledb_internal.compress_hyper_6_18_chunk (actual rows=1 loops=1)
+                     Output: compress_hyper_6_18_chunk."time", compress_hyper_6_18_chunk.device_id, compress_hyper_6_18_chunk.device_id_peer, compress_hyper_6_18_chunk.v0, compress_hyper_6_18_chunk.v1, compress_hyper_6_18_chunk.v2, compress_hyper_6_18_chunk.v3, compress_hyper_6_18_chunk._ts_meta_count, compress_hyper_6_18_chunk._ts_meta_sequence_num, compress_hyper_6_18_chunk._ts_meta_min_3, compress_hyper_6_18_chunk._ts_meta_max_3, compress_hyper_6_18_chunk._ts_meta_min_1, compress_hyper_6_18_chunk._ts_meta_max_1, compress_hyper_6_18_chunk._ts_meta_min_2, compress_hyper_6_18_chunk._ts_meta_max_2
          ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_5_chunk (actual rows=0 loops=1)
                Output: _hyper_2_5_chunk."time", _hyper_2_5_chunk.device_id, _hyper_2_5_chunk.device_id_peer, _hyper_2_5_chunk.v0, _hyper_2_5_chunk.v1, _hyper_2_5_chunk.v2, _hyper_2_5_chunk.v3
                Filter: (_hyper_2_5_chunk.v3 > '10'::double precision)
                Rows Removed by Filter: 1080
                Bulk Decompression: true
-               ->  Seq Scan on _timescaledb_internal.compress_hyper_6_18_chunk (actual rows=3 loops=1)
-                     Output: compress_hyper_6_18_chunk."time", compress_hyper_6_18_chunk.device_id, compress_hyper_6_18_chunk.device_id_peer, compress_hyper_6_18_chunk.v0, compress_hyper_6_18_chunk.v1, compress_hyper_6_18_chunk.v2, compress_hyper_6_18_chunk.v3, compress_hyper_6_18_chunk._ts_meta_count, compress_hyper_6_18_chunk._ts_meta_sequence_num, compress_hyper_6_18_chunk._ts_meta_min_3, compress_hyper_6_18_chunk._ts_meta_max_3, compress_hyper_6_18_chunk._ts_meta_min_1, compress_hyper_6_18_chunk._ts_meta_max_1, compress_hyper_6_18_chunk._ts_meta_min_2, compress_hyper_6_18_chunk._ts_meta_max_2
+               ->  Seq Scan on _timescaledb_internal.compress_hyper_6_19_chunk (actual rows=3 loops=1)
+                     Output: compress_hyper_6_19_chunk."time", compress_hyper_6_19_chunk.device_id, compress_hyper_6_19_chunk.device_id_peer, compress_hyper_6_19_chunk.v0, compress_hyper_6_19_chunk.v1, compress_hyper_6_19_chunk.v2, compress_hyper_6_19_chunk.v3, compress_hyper_6_19_chunk._ts_meta_count, compress_hyper_6_19_chunk._ts_meta_sequence_num, compress_hyper_6_19_chunk._ts_meta_min_3, compress_hyper_6_19_chunk._ts_meta_max_3, compress_hyper_6_19_chunk._ts_meta_min_1, compress_hyper_6_19_chunk._ts_meta_max_1, compress_hyper_6_19_chunk._ts_meta_min_2, compress_hyper_6_19_chunk._ts_meta_max_2
          ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_6_chunk (actual rows=0 loops=1)
                Output: _hyper_2_6_chunk."time", _hyper_2_6_chunk.device_id, _hyper_2_6_chunk.device_id_peer, _hyper_2_6_chunk.v0, _hyper_2_6_chunk.v1, _hyper_2_6_chunk.v2, _hyper_2_6_chunk.v3
                Filter: (_hyper_2_6_chunk.v3 > '10'::double precision)
                Rows Removed by Filter: 360
                Bulk Decompression: true
-               ->  Seq Scan on _timescaledb_internal.compress_hyper_6_19_chunk (actual rows=1 loops=1)
-                     Output: compress_hyper_6_19_chunk."time", compress_hyper_6_19_chunk.device_id, compress_hyper_6_19_chunk.device_id_peer, compress_hyper_6_19_chunk.v0, compress_hyper_6_19_chunk.v1, compress_hyper_6_19_chunk.v2, compress_hyper_6_19_chunk.v3, compress_hyper_6_19_chunk._ts_meta_count, compress_hyper_6_19_chunk._ts_meta_sequence_num, compress_hyper_6_19_chunk._ts_meta_min_3, compress_hyper_6_19_chunk._ts_meta_max_3, compress_hyper_6_19_chunk._ts_meta_min_1, compress_hyper_6_19_chunk._ts_meta_max_1, compress_hyper_6_19_chunk._ts_meta_min_2, compress_hyper_6_19_chunk._ts_meta_max_2
+               ->  Seq Scan on _timescaledb_internal.compress_hyper_6_20_chunk (actual rows=1 loops=1)
+                     Output: compress_hyper_6_20_chunk."time", compress_hyper_6_20_chunk.device_id, compress_hyper_6_20_chunk.device_id_peer, compress_hyper_6_20_chunk.v0, compress_hyper_6_20_chunk.v1, compress_hyper_6_20_chunk.v2, compress_hyper_6_20_chunk.v3, compress_hyper_6_20_chunk._ts_meta_count, compress_hyper_6_20_chunk._ts_meta_sequence_num, compress_hyper_6_20_chunk._ts_meta_min_3, compress_hyper_6_20_chunk._ts_meta_max_3, compress_hyper_6_20_chunk._ts_meta_min_1, compress_hyper_6_20_chunk._ts_meta_max_1, compress_hyper_6_20_chunk._ts_meta_min_2, compress_hyper_6_20_chunk._ts_meta_max_2
          ->  Seq Scan on _timescaledb_internal._hyper_2_7_chunk (actual rows=0 loops=1)
                Output: _hyper_2_7_chunk."time", _hyper_2_7_chunk.device_id, _hyper_2_7_chunk.device_id_peer, _hyper_2_7_chunk.v0, _hyper_2_7_chunk.v1, _hyper_2_7_chunk.v2, _hyper_2_7_chunk.v3
                Filter: (_hyper_2_7_chunk.v3 > '10'::double precision)
@@ -3540,15 +3540,15 @@ ORDER BY time,
                Filter: (_hyper_2_10_chunk.v3 > '10'::double precision)
                Rows Removed by Filter: 504
                Bulk Decompression: true
-               ->  Seq Scan on _timescaledb_internal.compress_hyper_6_20_chunk (actual rows=1 loops=1)
-                     Output: compress_hyper_6_20_chunk."time", compress_hyper_6_20_chunk.device_id, compress_hyper_6_20_chunk.device_id_peer, compress_hyper_6_20_chunk.v0, compress_hyper_6_20_chunk.v1, compress_hyper_6_20_chunk.v2, compress_hyper_6_20_chunk.v3, compress_hyper_6_20_chunk._ts_meta_count, compress_hyper_6_20_chunk._ts_meta_sequence_num, compress_hyper_6_20_chunk._ts_meta_min_3, compress_hyper_6_20_chunk._ts_meta_max_3, compress_hyper_6_20_chunk._ts_meta_min_1, compress_hyper_6_20_chunk._ts_meta_max_1, compress_hyper_6_20_chunk._ts_meta_min_2, compress_hyper_6_20_chunk._ts_meta_max_2
+               ->  Seq Scan on _timescaledb_internal.compress_hyper_6_24_chunk (actual rows=1 loops=1)
+                     Output: compress_hyper_6_24_chunk."time", compress_hyper_6_24_chunk.device_id, compress_hyper_6_24_chunk.device_id_peer, compress_hyper_6_24_chunk.v0, compress_hyper_6_24_chunk.v1, compress_hyper_6_24_chunk.v2, compress_hyper_6_24_chunk.v3, compress_hyper_6_24_chunk._ts_meta_count, compress_hyper_6_24_chunk._ts_meta_sequence_num, compress_hyper_6_24_chunk._ts_meta_min_3, compress_hyper_6_24_chunk._ts_meta_max_3, compress_hyper_6_24_chunk._ts_meta_min_1, compress_hyper_6_24_chunk._ts_meta_max_1, compress_hyper_6_24_chunk._ts_meta_min_2, compress_hyper_6_24_chunk._ts_meta_max_2
          ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_11_chunk (actual rows=0 loops=1)
                Output: _hyper_2_11_chunk."time", _hyper_2_11_chunk.device_id, _hyper_2_11_chunk.device_id_peer, _hyper_2_11_chunk.v0, _hyper_2_11_chunk.v1, _hyper_2_11_chunk.v2, _hyper_2_11_chunk.v3
                Filter: (_hyper_2_11_chunk.v3 > '10'::double precision)
                Rows Removed by Filter: 1512
                Bulk Decompression: true
-               ->  Seq Scan on _timescaledb_internal.compress_hyper_6_21_chunk (actual rows=3 loops=1)
-                     Output: compress_hyper_6_21_chunk."time", compress_hyper_6_21_chunk.device_id, compress_hyper_6_21_chunk.device_id_peer, compress_hyper_6_21_chunk.v0, compress_hyper_6_21_chunk.v1, compress_hyper_6_21_chunk.v2, compress_hyper_6_21_chunk.v3, compress_hyper_6_21_chunk._ts_meta_count, compress_hyper_6_21_chunk._ts_meta_sequence_num, compress_hyper_6_21_chunk._ts_meta_min_3, compress_hyper_6_21_chunk._ts_meta_max_3, compress_hyper_6_21_chunk._ts_meta_min_1, compress_hyper_6_21_chunk._ts_meta_max_1, compress_hyper_6_21_chunk._ts_meta_min_2, compress_hyper_6_21_chunk._ts_meta_max_2
+               ->  Seq Scan on _timescaledb_internal.compress_hyper_6_25_chunk (actual rows=3 loops=1)
+                     Output: compress_hyper_6_25_chunk."time", compress_hyper_6_25_chunk.device_id, compress_hyper_6_25_chunk.device_id_peer, compress_hyper_6_25_chunk.v0, compress_hyper_6_25_chunk.v1, compress_hyper_6_25_chunk.v2, compress_hyper_6_25_chunk.v3, compress_hyper_6_25_chunk._ts_meta_count, compress_hyper_6_25_chunk._ts_meta_sequence_num, compress_hyper_6_25_chunk._ts_meta_min_3, compress_hyper_6_25_chunk._ts_meta_max_3, compress_hyper_6_25_chunk._ts_meta_min_1, compress_hyper_6_25_chunk._ts_meta_max_1, compress_hyper_6_25_chunk._ts_meta_min_2, compress_hyper_6_25_chunk._ts_meta_max_2
          ->  Seq Scan on _timescaledb_internal._hyper_2_12_chunk (actual rows=0 loops=1)
                Output: _hyper_2_12_chunk."time", _hyper_2_12_chunk.device_id, _hyper_2_12_chunk.device_id_peer, _hyper_2_12_chunk.v0, _hyper_2_12_chunk.v1, _hyper_2_12_chunk.v2, _hyper_2_12_chunk.v3
                Filter: (_hyper_2_12_chunk.v3 > '10'::double precision)
@@ -3572,14 +3572,14 @@ LIMIT 10;
                Sort Key: _hyper_2_4_chunk."time"
                Sort Method: top-N heapsort 
                ->  Custom Scan (DecompressChunk) on _hyper_2_4_chunk (actual rows=360 loops=1)
-                     ->  Seq Scan on compress_hyper_6_17_chunk (actual rows=1 loops=1)
+                     ->  Seq Scan on compress_hyper_6_18_chunk (actual rows=1 loops=1)
                            Filter: (device_id = 1)
          ->  Index Scan Backward using _hyper_2_7_chunk_metrics_space_time_idx on _hyper_2_7_chunk (never executed)
                Filter: (device_id = 1)
          ->  Sort (never executed)
                Sort Key: _hyper_2_10_chunk."time"
                ->  Custom Scan (DecompressChunk) on _hyper_2_10_chunk (never executed)
-                     ->  Seq Scan on compress_hyper_6_20_chunk (never executed)
+                     ->  Seq Scan on compress_hyper_6_24_chunk (never executed)
                            Filter: (device_id = 1)
 (16 rows)
 
@@ -3609,7 +3609,7 @@ LIMIT 10;
                                  Sort Key: _hyper_2_4_chunk."time"
                                  Sort Method: quicksort 
                                  ->  Custom Scan (DecompressChunk) on _hyper_2_4_chunk (actual rows=360 loops=1)
-                                       ->  Seq Scan on compress_hyper_6_17_chunk (actual rows=1 loops=1)
+                                       ->  Seq Scan on compress_hyper_6_18_chunk (actual rows=1 loops=1)
                                              Filter: (device_id IS NOT NULL)
                      ->  Sort (actual rows=7 loops=1)
                            Sort Key: _hyper_2_5_chunk."time"
@@ -3618,7 +3618,7 @@ LIMIT 10;
                                  Sort Key: _hyper_2_5_chunk."time"
                                  Sort Method: quicksort 
                                  ->  Custom Scan (DecompressChunk) on _hyper_2_5_chunk (actual rows=1080 loops=1)
-                                       ->  Seq Scan on compress_hyper_6_18_chunk (actual rows=3 loops=1)
+                                       ->  Seq Scan on compress_hyper_6_19_chunk (actual rows=3 loops=1)
                                              Filter: (device_id IS NOT NULL)
                      ->  Sort (actual rows=3 loops=1)
                            Sort Key: _hyper_2_6_chunk."time"
@@ -3627,7 +3627,7 @@ LIMIT 10;
                                  Sort Key: _hyper_2_6_chunk."time"
                                  Sort Method: quicksort 
                                  ->  Custom Scan (DecompressChunk) on _hyper_2_6_chunk (actual rows=360 loops=1)
-                                       ->  Seq Scan on compress_hyper_6_19_chunk (actual rows=1 loops=1)
+                                       ->  Seq Scan on compress_hyper_6_20_chunk (actual rows=1 loops=1)
                                              Filter: (device_id IS NOT NULL)
                ->  Merge Append (never executed)
                      Sort Key: _hyper_2_7_chunk."time"
@@ -3644,14 +3644,14 @@ LIMIT 10;
                            ->  Sort (never executed)
                                  Sort Key: _hyper_2_10_chunk."time"
                                  ->  Custom Scan (DecompressChunk) on _hyper_2_10_chunk (never executed)
-                                       ->  Seq Scan on compress_hyper_6_20_chunk (never executed)
+                                       ->  Seq Scan on compress_hyper_6_24_chunk (never executed)
                                              Filter: (device_id IS NOT NULL)
                      ->  Sort (never executed)
                            Sort Key: _hyper_2_11_chunk."time"
                            ->  Sort (never executed)
                                  Sort Key: _hyper_2_11_chunk."time"
                                  ->  Custom Scan (DecompressChunk) on _hyper_2_11_chunk (never executed)
-                                       ->  Seq Scan on compress_hyper_6_21_chunk (never executed)
+                                       ->  Seq Scan on compress_hyper_6_25_chunk (never executed)
                                              Filter: (device_id IS NOT NULL)
                      ->  Index Scan Backward using _hyper_2_12_chunk_metrics_space_time_idx on _hyper_2_12_chunk (never executed)
                            Filter: (device_id IS NOT NULL)
@@ -3682,7 +3682,7 @@ LIMIT 10;
                                  Sort Key: _hyper_2_4_chunk."time"
                                  Sort Method: quicksort 
                                  ->  Custom Scan (DecompressChunk) on _hyper_2_4_chunk (actual rows=0 loops=1)
-                                       ->  Seq Scan on compress_hyper_6_17_chunk (actual rows=0 loops=1)
+                                       ->  Seq Scan on compress_hyper_6_18_chunk (actual rows=0 loops=1)
                                              Filter: (device_id IS NULL)
                                              Rows Removed by Filter: 1
                      ->  Sort (actual rows=0 loops=1)
@@ -3692,7 +3692,7 @@ LIMIT 10;
                                  Sort Key: _hyper_2_5_chunk."time"
                                  Sort Method: quicksort 
                                  ->  Custom Scan (DecompressChunk) on _hyper_2_5_chunk (actual rows=0 loops=1)
-                                       ->  Seq Scan on compress_hyper_6_18_chunk (actual rows=0 loops=1)
+                                       ->  Seq Scan on compress_hyper_6_19_chunk (actual rows=0 loops=1)
                                              Filter: (device_id IS NULL)
                                              Rows Removed by Filter: 3
                      ->  Sort (actual rows=0 loops=1)
@@ -3702,7 +3702,7 @@ LIMIT 10;
                                  Sort Key: _hyper_2_6_chunk."time"
                                  Sort Method: quicksort 
                                  ->  Custom Scan (DecompressChunk) on _hyper_2_6_chunk (actual rows=0 loops=1)
-                                       ->  Seq Scan on compress_hyper_6_19_chunk (actual rows=0 loops=1)
+                                       ->  Seq Scan on compress_hyper_6_20_chunk (actual rows=0 loops=1)
                                              Filter: (device_id IS NULL)
                                              Rows Removed by Filter: 1
                ->  Merge Append (actual rows=0 loops=1)
@@ -3725,7 +3725,7 @@ LIMIT 10;
                                  Sort Key: _hyper_2_10_chunk."time"
                                  Sort Method: quicksort 
                                  ->  Custom Scan (DecompressChunk) on _hyper_2_10_chunk (actual rows=0 loops=1)
-                                       ->  Seq Scan on compress_hyper_6_20_chunk (actual rows=0 loops=1)
+                                       ->  Seq Scan on compress_hyper_6_24_chunk (actual rows=0 loops=1)
                                              Filter: (device_id IS NULL)
                                              Rows Removed by Filter: 1
                      ->  Sort (actual rows=0 loops=1)
@@ -3735,7 +3735,7 @@ LIMIT 10;
                                  Sort Key: _hyper_2_11_chunk."time"
                                  Sort Method: quicksort 
                                  ->  Custom Scan (DecompressChunk) on _hyper_2_11_chunk (actual rows=0 loops=1)
-                                       ->  Seq Scan on compress_hyper_6_21_chunk (actual rows=0 loops=1)
+                                       ->  Seq Scan on compress_hyper_6_25_chunk (actual rows=0 loops=1)
                                              Filter: (device_id IS NULL)
                                              Rows Removed by Filter: 3
                      ->  Index Scan Backward using _hyper_2_12_chunk_metrics_space_time_idx on _hyper_2_12_chunk (actual rows=0 loops=1)
@@ -3769,7 +3769,7 @@ LIMIT 10;
                                  Sort Key: _hyper_2_4_chunk."time"
                                  Sort Method: quicksort 
                                  ->  Custom Scan (DecompressChunk) on _hyper_2_4_chunk (actual rows=360 loops=1)
-                                       ->  Seq Scan on compress_hyper_6_17_chunk (actual rows=1 loops=1)
+                                       ->  Seq Scan on compress_hyper_6_18_chunk (actual rows=1 loops=1)
                                              Filter: (device_id = ANY ('{1,2}'::integer[]))
                      ->  Sort (actual rows=6 loops=1)
                            Sort Key: _hyper_2_5_chunk."time"
@@ -3778,7 +3778,7 @@ LIMIT 10;
                                  Sort Key: _hyper_2_5_chunk."time"
                                  Sort Method: quicksort 
                                  ->  Custom Scan (DecompressChunk) on _hyper_2_5_chunk (actual rows=360 loops=1)
-                                       ->  Seq Scan on compress_hyper_6_18_chunk (actual rows=1 loops=1)
+                                       ->  Seq Scan on compress_hyper_6_19_chunk (actual rows=1 loops=1)
                                              Filter: (device_id = ANY ('{1,2}'::integer[]))
                                              Rows Removed by Filter: 2
                ->  Merge Append (never executed)
@@ -3794,14 +3794,14 @@ LIMIT 10;
                            ->  Sort (never executed)
                                  Sort Key: _hyper_2_10_chunk."time"
                                  ->  Custom Scan (DecompressChunk) on _hyper_2_10_chunk (never executed)
-                                       ->  Seq Scan on compress_hyper_6_20_chunk (never executed)
+                                       ->  Seq Scan on compress_hyper_6_24_chunk (never executed)
                                              Filter: (device_id = ANY ('{1,2}'::integer[]))
                      ->  Sort (never executed)
                            Sort Key: _hyper_2_11_chunk."time"
                            ->  Sort (never executed)
                                  Sort Key: _hyper_2_11_chunk."time"
                                  ->  Custom Scan (DecompressChunk) on _hyper_2_11_chunk (never executed)
-                                       ->  Seq Scan on compress_hyper_6_21_chunk (never executed)
+                                       ->  Seq Scan on compress_hyper_6_25_chunk (never executed)
                                              Filter: (device_id = ANY ('{1,2}'::integer[]))
 (50 rows)
 
@@ -3822,14 +3822,14 @@ LIMIT 10;
                Sort Key: _hyper_2_4_chunk."time"
                Sort Method: top-N heapsort 
                ->  Custom Scan (DecompressChunk) on _hyper_2_4_chunk (actual rows=360 loops=1)
-                     ->  Seq Scan on compress_hyper_6_17_chunk (actual rows=1 loops=1)
+                     ->  Seq Scan on compress_hyper_6_18_chunk (actual rows=1 loops=1)
                            Filter: (device_id = 1)
          ->  Index Scan Backward using _hyper_2_7_chunk_metrics_space_time_idx on _hyper_2_7_chunk (never executed)
                Filter: (device_id = 1)
          ->  Sort (never executed)
                Sort Key: _hyper_2_10_chunk."time"
                ->  Custom Scan (DecompressChunk) on _hyper_2_10_chunk (never executed)
-                     ->  Seq Scan on compress_hyper_6_20_chunk (never executed)
+                     ->  Seq Scan on compress_hyper_6_24_chunk (never executed)
                            Filter: (device_id = 1)
 (16 rows)
 
@@ -3859,7 +3859,7 @@ LIMIT 10;
                                  Sort Key: _hyper_2_4_chunk."time"
                                  Sort Method: quicksort 
                                  ->  Custom Scan (DecompressChunk) on _hyper_2_4_chunk (actual rows=0 loops=1)
-                                       ->  Seq Scan on compress_hyper_6_17_chunk (actual rows=0 loops=1)
+                                       ->  Seq Scan on compress_hyper_6_18_chunk (actual rows=0 loops=1)
                                              Filter: (device_id = device_id_peer)
                                              Rows Removed by Filter: 1
                      ->  Sort (actual rows=0 loops=1)
@@ -3869,7 +3869,7 @@ LIMIT 10;
                                  Sort Key: _hyper_2_5_chunk."time"
                                  Sort Method: quicksort 
                                  ->  Custom Scan (DecompressChunk) on _hyper_2_5_chunk (actual rows=0 loops=1)
-                                       ->  Seq Scan on compress_hyper_6_18_chunk (actual rows=0 loops=1)
+                                       ->  Seq Scan on compress_hyper_6_19_chunk (actual rows=0 loops=1)
                                              Filter: (device_id = device_id_peer)
                                              Rows Removed by Filter: 3
                      ->  Sort (actual rows=0 loops=1)
@@ -3879,7 +3879,7 @@ LIMIT 10;
                                  Sort Key: _hyper_2_6_chunk."time"
                                  Sort Method: quicksort 
                                  ->  Custom Scan (DecompressChunk) on _hyper_2_6_chunk (actual rows=0 loops=1)
-                                       ->  Seq Scan on compress_hyper_6_19_chunk (actual rows=0 loops=1)
+                                       ->  Seq Scan on compress_hyper_6_20_chunk (actual rows=0 loops=1)
                                              Filter: (device_id = device_id_peer)
                                              Rows Removed by Filter: 1
                ->  Merge Append (actual rows=0 loops=1)
@@ -3902,7 +3902,7 @@ LIMIT 10;
                                  Sort Key: _hyper_2_10_chunk."time"
                                  Sort Method: quicksort 
                                  ->  Custom Scan (DecompressChunk) on _hyper_2_10_chunk (actual rows=0 loops=1)
-                                       ->  Seq Scan on compress_hyper_6_20_chunk (actual rows=0 loops=1)
+                                       ->  Seq Scan on compress_hyper_6_24_chunk (actual rows=0 loops=1)
                                              Filter: (device_id = device_id_peer)
                                              Rows Removed by Filter: 1
                      ->  Sort (actual rows=0 loops=1)
@@ -3912,7 +3912,7 @@ LIMIT 10;
                                  Sort Key: _hyper_2_11_chunk."time"
                                  Sort Method: quicksort 
                                  ->  Custom Scan (DecompressChunk) on _hyper_2_11_chunk (actual rows=0 loops=1)
-                                       ->  Seq Scan on compress_hyper_6_21_chunk (actual rows=0 loops=1)
+                                       ->  Seq Scan on compress_hyper_6_25_chunk (actual rows=0 loops=1)
                                              Filter: (device_id = device_id_peer)
                                              Rows Removed by Filter: 3
                      ->  Index Scan Backward using _hyper_2_12_chunk_metrics_space_time_idx on _hyper_2_12_chunk (actual rows=0 loops=1)
@@ -3945,7 +3945,7 @@ LIMIT 10;
                                  Sort Key: _hyper_2_4_chunk."time"
                                  Sort Method: quicksort 
                                  ->  Custom Scan (DecompressChunk) on _hyper_2_4_chunk (actual rows=360 loops=1)
-                                       ->  Seq Scan on compress_hyper_6_17_chunk (actual rows=1 loops=1)
+                                       ->  Seq Scan on compress_hyper_6_18_chunk (actual rows=1 loops=1)
                                              Filter: (device_id_peer < device_id)
                      ->  Sort (actual rows=7 loops=1)
                            Sort Key: _hyper_2_5_chunk."time"
@@ -3954,7 +3954,7 @@ LIMIT 10;
                                  Sort Key: _hyper_2_5_chunk."time"
                                  Sort Method: quicksort 
                                  ->  Custom Scan (DecompressChunk) on _hyper_2_5_chunk (actual rows=1080 loops=1)
-                                       ->  Seq Scan on compress_hyper_6_18_chunk (actual rows=3 loops=1)
+                                       ->  Seq Scan on compress_hyper_6_19_chunk (actual rows=3 loops=1)
                                              Filter: (device_id_peer < device_id)
                      ->  Sort (actual rows=3 loops=1)
                            Sort Key: _hyper_2_6_chunk."time"
@@ -3963,7 +3963,7 @@ LIMIT 10;
                                  Sort Key: _hyper_2_6_chunk."time"
                                  Sort Method: quicksort 
                                  ->  Custom Scan (DecompressChunk) on _hyper_2_6_chunk (actual rows=360 loops=1)
-                                       ->  Seq Scan on compress_hyper_6_19_chunk (actual rows=1 loops=1)
+                                       ->  Seq Scan on compress_hyper_6_20_chunk (actual rows=1 loops=1)
                                              Filter: (device_id_peer < device_id)
                ->  Merge Append (never executed)
                      Sort Key: _hyper_2_7_chunk."time"
@@ -3980,14 +3980,14 @@ LIMIT 10;
                            ->  Sort (never executed)
                                  Sort Key: _hyper_2_10_chunk."time"
                                  ->  Custom Scan (DecompressChunk) on _hyper_2_10_chunk (never executed)
-                                       ->  Seq Scan on compress_hyper_6_20_chunk (never executed)
+                                       ->  Seq Scan on compress_hyper_6_24_chunk (never executed)
                                              Filter: (device_id_peer < device_id)
                      ->  Sort (never executed)
                            Sort Key: _hyper_2_11_chunk."time"
                            ->  Sort (never executed)
                                  Sort Key: _hyper_2_11_chunk."time"
                                  ->  Custom Scan (DecompressChunk) on _hyper_2_11_chunk (never executed)
-                                       ->  Seq Scan on compress_hyper_6_21_chunk (never executed)
+                                       ->  Seq Scan on compress_hyper_6_25_chunk (never executed)
                                              Filter: (device_id_peer < device_id)
                      ->  Index Scan Backward using _hyper_2_12_chunk_metrics_space_time_idx on _hyper_2_12_chunk (never executed)
                            Filter: (device_id_peer < device_id)
@@ -4010,7 +4010,7 @@ LIMIT 10;
                Sort Key: _hyper_2_6_chunk."time"
                Sort Method: top-N heapsort 
                ->  Custom Scan (DecompressChunk) on _hyper_2_6_chunk (actual rows=360 loops=1)
-                     ->  Seq Scan on compress_hyper_6_19_chunk (actual rows=1 loops=1)
+                     ->  Seq Scan on compress_hyper_6_20_chunk (actual rows=1 loops=1)
                            Filter: (device_id = 3)
          ->  Index Scan Backward using _hyper_2_9_chunk_metrics_space_time_idx on _hyper_2_9_chunk (never executed)
                Filter: (device_id = 3)
@@ -4043,7 +4043,7 @@ LIMIT 10;
                            ->  Custom Scan (DecompressChunk) on _hyper_2_4_chunk (actual rows=0 loops=1)
                                  Filter: (device_id = length("substring"(version(), 1, 3)))
                                  Rows Removed by Filter: 360
-                                 ->  Seq Scan on compress_hyper_6_17_chunk (actual rows=1 loops=1)
+                                 ->  Seq Scan on compress_hyper_6_18_chunk (actual rows=1 loops=1)
                ->  Sort (actual rows=0 loops=1)
                      Sort Key: _hyper_2_5_chunk."time"
                      Sort Method: quicksort 
@@ -4053,7 +4053,7 @@ LIMIT 10;
                            ->  Custom Scan (DecompressChunk) on _hyper_2_5_chunk (actual rows=0 loops=1)
                                  Filter: (device_id = length("substring"(version(), 1, 3)))
                                  Rows Removed by Filter: 1080
-                                 ->  Seq Scan on compress_hyper_6_18_chunk (actual rows=3 loops=1)
+                                 ->  Seq Scan on compress_hyper_6_19_chunk (actual rows=3 loops=1)
                ->  Sort (actual rows=10 loops=1)
                      Sort Key: _hyper_2_6_chunk."time"
                      Sort Method: top-N heapsort 
@@ -4062,7 +4062,7 @@ LIMIT 10;
                            Sort Method: quicksort 
                            ->  Custom Scan (DecompressChunk) on _hyper_2_6_chunk (actual rows=360 loops=1)
                                  Filter: (device_id = length("substring"(version(), 1, 3)))
-                                 ->  Seq Scan on compress_hyper_6_19_chunk (actual rows=1 loops=1)
+                                 ->  Seq Scan on compress_hyper_6_20_chunk (actual rows=1 loops=1)
          ->  Merge Append (never executed)
                Sort Key: _hyper_2_7_chunk."time"
                ->  Index Scan Backward using _hyper_2_7_chunk_metrics_space_device_id_time_idx on _hyper_2_7_chunk (never executed)
@@ -4079,14 +4079,14 @@ LIMIT 10;
                            Sort Key: _hyper_2_10_chunk."time"
                            ->  Custom Scan (DecompressChunk) on _hyper_2_10_chunk (never executed)
                                  Filter: (device_id = length("substring"(version(), 1, 3)))
-                                 ->  Seq Scan on compress_hyper_6_20_chunk (never executed)
+                                 ->  Seq Scan on compress_hyper_6_24_chunk (never executed)
                ->  Sort (never executed)
                      Sort Key: _hyper_2_11_chunk."time"
                      ->  Sort (never executed)
                            Sort Key: _hyper_2_11_chunk."time"
                            ->  Custom Scan (DecompressChunk) on _hyper_2_11_chunk (never executed)
                                  Filter: (device_id = length("substring"(version(), 1, 3)))
-                                 ->  Seq Scan on compress_hyper_6_21_chunk (never executed)
+                                 ->  Seq Scan on compress_hyper_6_25_chunk (never executed)
                ->  Index Scan Backward using _hyper_2_12_chunk_metrics_space_device_id_time_idx on _hyper_2_12_chunk (never executed)
                      Index Cond: (device_id = length("substring"(version(), 1, 3)))
 (60 rows)
@@ -4111,25 +4111,25 @@ LIMIT 10;
                Filter: ("time" = 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
                Rows Removed by Filter: 359
                ->  Sort (actual rows=1 loops=1)
-                     Sort Key: compress_hyper_6_17_chunk.device_id
+                     Sort Key: compress_hyper_6_18_chunk.device_id
                      Sort Method: quicksort 
-                     ->  Seq Scan on compress_hyper_6_17_chunk (actual rows=1 loops=1)
+                     ->  Seq Scan on compress_hyper_6_18_chunk (actual rows=1 loops=1)
                            Filter: ((_ts_meta_min_3 <= 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone) AND (_ts_meta_max_3 >= 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone))
          ->  Custom Scan (DecompressChunk) on _hyper_2_5_chunk (actual rows=3 loops=1)
                Filter: ("time" = 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
                Rows Removed by Filter: 1077
                ->  Sort (actual rows=3 loops=1)
-                     Sort Key: compress_hyper_6_18_chunk.device_id
+                     Sort Key: compress_hyper_6_19_chunk.device_id
                      Sort Method: quicksort 
-                     ->  Seq Scan on compress_hyper_6_18_chunk (actual rows=3 loops=1)
+                     ->  Seq Scan on compress_hyper_6_19_chunk (actual rows=3 loops=1)
                            Filter: ((_ts_meta_min_3 <= 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone) AND (_ts_meta_max_3 >= 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone))
          ->  Custom Scan (DecompressChunk) on _hyper_2_6_chunk (actual rows=1 loops=1)
                Filter: ("time" = 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
                Rows Removed by Filter: 359
                ->  Sort (actual rows=1 loops=1)
-                     Sort Key: compress_hyper_6_19_chunk.device_id
+                     Sort Key: compress_hyper_6_20_chunk.device_id
                      Sort Method: quicksort 
-                     ->  Seq Scan on compress_hyper_6_19_chunk (actual rows=1 loops=1)
+                     ->  Seq Scan on compress_hyper_6_20_chunk (actual rows=1 loops=1)
                            Filter: ((_ts_meta_min_3 <= 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone) AND (_ts_meta_max_3 >= 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone))
 (27 rows)
 
@@ -4150,17 +4150,17 @@ LIMIT 10;
                ->  Custom Scan (DecompressChunk) on _hyper_2_4_chunk (actual rows=3 loops=1)
                      Filter: ("time" < 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
                      Rows Removed by Filter: 357
-                     ->  Seq Scan on compress_hyper_6_17_chunk (actual rows=1 loops=1)
+                     ->  Seq Scan on compress_hyper_6_18_chunk (actual rows=1 loops=1)
                            Filter: (_ts_meta_min_3 < 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
                ->  Custom Scan (DecompressChunk) on _hyper_2_5_chunk (actual rows=9 loops=1)
                      Filter: ("time" < 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
                      Rows Removed by Filter: 1071
-                     ->  Seq Scan on compress_hyper_6_18_chunk (actual rows=3 loops=1)
+                     ->  Seq Scan on compress_hyper_6_19_chunk (actual rows=3 loops=1)
                            Filter: (_ts_meta_min_3 < 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
                ->  Custom Scan (DecompressChunk) on _hyper_2_6_chunk (actual rows=3 loops=1)
                      Filter: ("time" < 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
                      Rows Removed by Filter: 357
-                     ->  Seq Scan on compress_hyper_6_19_chunk (actual rows=1 loops=1)
+                     ->  Seq Scan on compress_hyper_6_20_chunk (actual rows=1 loops=1)
                            Filter: (_ts_meta_min_3 < 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
 (20 rows)
 
@@ -4181,17 +4181,17 @@ LIMIT 10;
                ->  Custom Scan (DecompressChunk) on _hyper_2_4_chunk (actual rows=4 loops=1)
                      Filter: ("time" <= 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
                      Rows Removed by Filter: 356
-                     ->  Seq Scan on compress_hyper_6_17_chunk (actual rows=1 loops=1)
+                     ->  Seq Scan on compress_hyper_6_18_chunk (actual rows=1 loops=1)
                            Filter: (_ts_meta_min_3 <= 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
                ->  Custom Scan (DecompressChunk) on _hyper_2_5_chunk (actual rows=12 loops=1)
                      Filter: ("time" <= 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
                      Rows Removed by Filter: 1068
-                     ->  Seq Scan on compress_hyper_6_18_chunk (actual rows=3 loops=1)
+                     ->  Seq Scan on compress_hyper_6_19_chunk (actual rows=3 loops=1)
                            Filter: (_ts_meta_min_3 <= 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
                ->  Custom Scan (DecompressChunk) on _hyper_2_6_chunk (actual rows=4 loops=1)
                      Filter: ("time" <= 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
                      Rows Removed by Filter: 356
-                     ->  Seq Scan on compress_hyper_6_19_chunk (actual rows=1 loops=1)
+                     ->  Seq Scan on compress_hyper_6_20_chunk (actual rows=1 loops=1)
                            Filter: (_ts_meta_min_3 <= 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
 (20 rows)
 
@@ -4222,7 +4222,7 @@ LIMIT 10;
                                  ->  Custom Scan (DecompressChunk) on _hyper_2_4_chunk (actual rows=357 loops=1)
                                        Filter: ("time" >= 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
                                        Rows Removed by Filter: 3
-                                       ->  Seq Scan on compress_hyper_6_17_chunk (actual rows=1 loops=1)
+                                       ->  Seq Scan on compress_hyper_6_18_chunk (actual rows=1 loops=1)
                                              Filter: (_ts_meta_max_3 >= 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
                      ->  Sort (actual rows=7 loops=1)
                            Sort Key: _hyper_2_5_chunk."time"
@@ -4233,7 +4233,7 @@ LIMIT 10;
                                  ->  Custom Scan (DecompressChunk) on _hyper_2_5_chunk (actual rows=1071 loops=1)
                                        Filter: ("time" >= 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
                                        Rows Removed by Filter: 9
-                                       ->  Seq Scan on compress_hyper_6_18_chunk (actual rows=3 loops=1)
+                                       ->  Seq Scan on compress_hyper_6_19_chunk (actual rows=3 loops=1)
                                              Filter: (_ts_meta_max_3 >= 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
                      ->  Sort (actual rows=3 loops=1)
                            Sort Key: _hyper_2_6_chunk."time"
@@ -4244,7 +4244,7 @@ LIMIT 10;
                                  ->  Custom Scan (DecompressChunk) on _hyper_2_6_chunk (actual rows=357 loops=1)
                                        Filter: ("time" >= 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
                                        Rows Removed by Filter: 3
-                                       ->  Seq Scan on compress_hyper_6_19_chunk (actual rows=1 loops=1)
+                                       ->  Seq Scan on compress_hyper_6_20_chunk (actual rows=1 loops=1)
                                              Filter: (_ts_meta_max_3 >= 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
                ->  Merge Append (never executed)
                      Sort Key: _hyper_2_7_chunk."time"
@@ -4262,7 +4262,7 @@ LIMIT 10;
                                  Sort Key: _hyper_2_10_chunk."time"
                                  ->  Custom Scan (DecompressChunk) on _hyper_2_10_chunk (never executed)
                                        Filter: ("time" >= 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
-                                       ->  Seq Scan on compress_hyper_6_20_chunk (never executed)
+                                       ->  Seq Scan on compress_hyper_6_24_chunk (never executed)
                                              Filter: (_ts_meta_max_3 >= 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
                      ->  Sort (never executed)
                            Sort Key: _hyper_2_11_chunk."time"
@@ -4270,7 +4270,7 @@ LIMIT 10;
                                  Sort Key: _hyper_2_11_chunk."time"
                                  ->  Custom Scan (DecompressChunk) on _hyper_2_11_chunk (never executed)
                                        Filter: ("time" >= 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
-                                       ->  Seq Scan on compress_hyper_6_21_chunk (never executed)
+                                       ->  Seq Scan on compress_hyper_6_25_chunk (never executed)
                                              Filter: (_ts_meta_max_3 >= 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
                      ->  Index Scan Backward using _hyper_2_12_chunk_metrics_space_time_idx on _hyper_2_12_chunk (never executed)
                            Index Cond: ("time" >= 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
@@ -4303,7 +4303,7 @@ LIMIT 10;
                                  ->  Custom Scan (DecompressChunk) on _hyper_2_4_chunk (actual rows=356 loops=1)
                                        Filter: ("time" > 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
                                        Rows Removed by Filter: 4
-                                       ->  Seq Scan on compress_hyper_6_17_chunk (actual rows=1 loops=1)
+                                       ->  Seq Scan on compress_hyper_6_18_chunk (actual rows=1 loops=1)
                                              Filter: (_ts_meta_max_3 > 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
                      ->  Sort (actual rows=7 loops=1)
                            Sort Key: _hyper_2_5_chunk."time"
@@ -4314,7 +4314,7 @@ LIMIT 10;
                                  ->  Custom Scan (DecompressChunk) on _hyper_2_5_chunk (actual rows=1068 loops=1)
                                        Filter: ("time" > 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
                                        Rows Removed by Filter: 12
-                                       ->  Seq Scan on compress_hyper_6_18_chunk (actual rows=3 loops=1)
+                                       ->  Seq Scan on compress_hyper_6_19_chunk (actual rows=3 loops=1)
                                              Filter: (_ts_meta_max_3 > 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
                      ->  Sort (actual rows=3 loops=1)
                            Sort Key: _hyper_2_6_chunk."time"
@@ -4325,7 +4325,7 @@ LIMIT 10;
                                  ->  Custom Scan (DecompressChunk) on _hyper_2_6_chunk (actual rows=356 loops=1)
                                        Filter: ("time" > 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
                                        Rows Removed by Filter: 4
-                                       ->  Seq Scan on compress_hyper_6_19_chunk (actual rows=1 loops=1)
+                                       ->  Seq Scan on compress_hyper_6_20_chunk (actual rows=1 loops=1)
                                              Filter: (_ts_meta_max_3 > 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
                ->  Merge Append (never executed)
                      Sort Key: _hyper_2_7_chunk."time"
@@ -4343,7 +4343,7 @@ LIMIT 10;
                                  Sort Key: _hyper_2_10_chunk."time"
                                  ->  Custom Scan (DecompressChunk) on _hyper_2_10_chunk (never executed)
                                        Filter: ("time" > 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
-                                       ->  Seq Scan on compress_hyper_6_20_chunk (never executed)
+                                       ->  Seq Scan on compress_hyper_6_24_chunk (never executed)
                                              Filter: (_ts_meta_max_3 > 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
                      ->  Sort (never executed)
                            Sort Key: _hyper_2_11_chunk."time"
@@ -4351,7 +4351,7 @@ LIMIT 10;
                                  Sort Key: _hyper_2_11_chunk."time"
                                  ->  Custom Scan (DecompressChunk) on _hyper_2_11_chunk (never executed)
                                        Filter: ("time" > 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
-                                       ->  Seq Scan on compress_hyper_6_21_chunk (never executed)
+                                       ->  Seq Scan on compress_hyper_6_25_chunk (never executed)
                                              Filter: (_ts_meta_max_3 > 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
                      ->  Index Scan Backward using _hyper_2_12_chunk_metrics_space_time_idx on _hyper_2_12_chunk (never executed)
                            Index Cond: ("time" > 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
@@ -4384,7 +4384,7 @@ LIMIT 10;
                                  ->  Custom Scan (DecompressChunk) on _hyper_2_4_chunk (actual rows=356 loops=1)
                                        Filter: ('Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone < "time")
                                        Rows Removed by Filter: 4
-                                       ->  Seq Scan on compress_hyper_6_17_chunk (actual rows=1 loops=1)
+                                       ->  Seq Scan on compress_hyper_6_18_chunk (actual rows=1 loops=1)
                                              Filter: (_ts_meta_max_3 > 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
                      ->  Sort (actual rows=7 loops=1)
                            Sort Key: _hyper_2_5_chunk."time"
@@ -4395,7 +4395,7 @@ LIMIT 10;
                                  ->  Custom Scan (DecompressChunk) on _hyper_2_5_chunk (actual rows=1068 loops=1)
                                        Filter: ('Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone < "time")
                                        Rows Removed by Filter: 12
-                                       ->  Seq Scan on compress_hyper_6_18_chunk (actual rows=3 loops=1)
+                                       ->  Seq Scan on compress_hyper_6_19_chunk (actual rows=3 loops=1)
                                              Filter: (_ts_meta_max_3 > 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
                      ->  Sort (actual rows=3 loops=1)
                            Sort Key: _hyper_2_6_chunk."time"
@@ -4406,7 +4406,7 @@ LIMIT 10;
                                  ->  Custom Scan (DecompressChunk) on _hyper_2_6_chunk (actual rows=356 loops=1)
                                        Filter: ('Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone < "time")
                                        Rows Removed by Filter: 4
-                                       ->  Seq Scan on compress_hyper_6_19_chunk (actual rows=1 loops=1)
+                                       ->  Seq Scan on compress_hyper_6_20_chunk (actual rows=1 loops=1)
                                              Filter: (_ts_meta_max_3 > 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
                ->  Merge Append (never executed)
                      Sort Key: _hyper_2_7_chunk."time"
@@ -4424,7 +4424,7 @@ LIMIT 10;
                                  Sort Key: _hyper_2_10_chunk."time"
                                  ->  Custom Scan (DecompressChunk) on _hyper_2_10_chunk (never executed)
                                        Filter: ('Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone < "time")
-                                       ->  Seq Scan on compress_hyper_6_20_chunk (never executed)
+                                       ->  Seq Scan on compress_hyper_6_24_chunk (never executed)
                                              Filter: (_ts_meta_max_3 > 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
                      ->  Sort (never executed)
                            Sort Key: _hyper_2_11_chunk."time"
@@ -4432,7 +4432,7 @@ LIMIT 10;
                                  Sort Key: _hyper_2_11_chunk."time"
                                  ->  Custom Scan (DecompressChunk) on _hyper_2_11_chunk (never executed)
                                        Filter: ('Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone < "time")
-                                       ->  Seq Scan on compress_hyper_6_21_chunk (never executed)
+                                       ->  Seq Scan on compress_hyper_6_25_chunk (never executed)
                                              Filter: (_ts_meta_max_3 > 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
                      ->  Index Scan Backward using _hyper_2_12_chunk_metrics_space_time_idx on _hyper_2_12_chunk (never executed)
                            Index Cond: ("time" > 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
@@ -4465,7 +4465,7 @@ LIMIT 10;
                                  Sort Method: quicksort 
                                  ->  Custom Scan (DecompressChunk) on _hyper_2_4_chunk (actual rows=0 loops=1)
                                        Filter: (v0 < 1)
-                                       ->  Seq Scan on compress_hyper_6_17_chunk (actual rows=0 loops=1)
+                                       ->  Seq Scan on compress_hyper_6_18_chunk (actual rows=0 loops=1)
                                              Filter: (_ts_meta_min_1 < 1)
                                              Rows Removed by Filter: 1
                      ->  Sort (actual rows=0 loops=1)
@@ -4476,7 +4476,7 @@ LIMIT 10;
                                  Sort Method: quicksort 
                                  ->  Custom Scan (DecompressChunk) on _hyper_2_5_chunk (actual rows=0 loops=1)
                                        Filter: (v0 < 1)
-                                       ->  Seq Scan on compress_hyper_6_18_chunk (actual rows=0 loops=1)
+                                       ->  Seq Scan on compress_hyper_6_19_chunk (actual rows=0 loops=1)
                                              Filter: (_ts_meta_min_1 < 1)
                                              Rows Removed by Filter: 3
                      ->  Sort (actual rows=0 loops=1)
@@ -4487,7 +4487,7 @@ LIMIT 10;
                                  Sort Method: quicksort 
                                  ->  Custom Scan (DecompressChunk) on _hyper_2_6_chunk (actual rows=0 loops=1)
                                        Filter: (v0 < 1)
-                                       ->  Seq Scan on compress_hyper_6_19_chunk (actual rows=0 loops=1)
+                                       ->  Seq Scan on compress_hyper_6_20_chunk (actual rows=0 loops=1)
                                              Filter: (_ts_meta_min_1 < 1)
                                              Rows Removed by Filter: 1
                ->  Merge Append (actual rows=0 loops=1)
@@ -4511,7 +4511,7 @@ LIMIT 10;
                                  Sort Method: quicksort 
                                  ->  Custom Scan (DecompressChunk) on _hyper_2_10_chunk (actual rows=0 loops=1)
                                        Filter: (v0 < 1)
-                                       ->  Seq Scan on compress_hyper_6_20_chunk (actual rows=0 loops=1)
+                                       ->  Seq Scan on compress_hyper_6_24_chunk (actual rows=0 loops=1)
                                              Filter: (_ts_meta_min_1 < 1)
                                              Rows Removed by Filter: 1
                      ->  Sort (actual rows=0 loops=1)
@@ -4522,7 +4522,7 @@ LIMIT 10;
                                  Sort Method: quicksort 
                                  ->  Custom Scan (DecompressChunk) on _hyper_2_11_chunk (actual rows=0 loops=1)
                                        Filter: (v0 < 1)
-                                       ->  Seq Scan on compress_hyper_6_21_chunk (actual rows=0 loops=1)
+                                       ->  Seq Scan on compress_hyper_6_25_chunk (actual rows=0 loops=1)
                                              Filter: (_ts_meta_min_1 < 1)
                                              Rows Removed by Filter: 3
                      ->  Index Scan Backward using _hyper_2_12_chunk_metrics_space_time_idx on _hyper_2_12_chunk (actual rows=0 loops=1)
@@ -4556,7 +4556,7 @@ LIMIT 10;
                                  Sort Method: quicksort 
                                  ->  Custom Scan (DecompressChunk) on _hyper_2_4_chunk (actual rows=0 loops=1)
                                        Filter: (v0 < device_id)
-                                       ->  Seq Scan on compress_hyper_6_17_chunk (actual rows=0 loops=1)
+                                       ->  Seq Scan on compress_hyper_6_18_chunk (actual rows=0 loops=1)
                                              Filter: (_ts_meta_min_1 < device_id)
                                              Rows Removed by Filter: 1
                      ->  Sort (actual rows=0 loops=1)
@@ -4567,7 +4567,7 @@ LIMIT 10;
                                  Sort Method: quicksort 
                                  ->  Custom Scan (DecompressChunk) on _hyper_2_5_chunk (actual rows=0 loops=1)
                                        Filter: (v0 < device_id)
-                                       ->  Seq Scan on compress_hyper_6_18_chunk (actual rows=0 loops=1)
+                                       ->  Seq Scan on compress_hyper_6_19_chunk (actual rows=0 loops=1)
                                              Filter: (_ts_meta_min_1 < device_id)
                                              Rows Removed by Filter: 3
                      ->  Sort (actual rows=0 loops=1)
@@ -4578,7 +4578,7 @@ LIMIT 10;
                                  Sort Method: quicksort 
                                  ->  Custom Scan (DecompressChunk) on _hyper_2_6_chunk (actual rows=0 loops=1)
                                        Filter: (v0 < device_id)
-                                       ->  Seq Scan on compress_hyper_6_19_chunk (actual rows=0 loops=1)
+                                       ->  Seq Scan on compress_hyper_6_20_chunk (actual rows=0 loops=1)
                                              Filter: (_ts_meta_min_1 < device_id)
                                              Rows Removed by Filter: 1
                ->  Merge Append (actual rows=0 loops=1)
@@ -4602,7 +4602,7 @@ LIMIT 10;
                                  Sort Method: quicksort 
                                  ->  Custom Scan (DecompressChunk) on _hyper_2_10_chunk (actual rows=0 loops=1)
                                        Filter: (v0 < device_id)
-                                       ->  Seq Scan on compress_hyper_6_20_chunk (actual rows=0 loops=1)
+                                       ->  Seq Scan on compress_hyper_6_24_chunk (actual rows=0 loops=1)
                                              Filter: (_ts_meta_min_1 < device_id)
                                              Rows Removed by Filter: 1
                      ->  Sort (actual rows=0 loops=1)
@@ -4613,7 +4613,7 @@ LIMIT 10;
                                  Sort Method: quicksort 
                                  ->  Custom Scan (DecompressChunk) on _hyper_2_11_chunk (actual rows=0 loops=1)
                                        Filter: (v0 < device_id)
-                                       ->  Seq Scan on compress_hyper_6_21_chunk (actual rows=0 loops=1)
+                                       ->  Seq Scan on compress_hyper_6_25_chunk (actual rows=0 loops=1)
                                              Filter: (_ts_meta_min_1 < device_id)
                                              Rows Removed by Filter: 3
                      ->  Index Scan Backward using _hyper_2_12_chunk_metrics_space_time_idx on _hyper_2_12_chunk (actual rows=0 loops=1)
@@ -4647,7 +4647,7 @@ LIMIT 10;
                                  Sort Method: quicksort 
                                  ->  Custom Scan (DecompressChunk) on _hyper_2_4_chunk (actual rows=360 loops=1)
                                        Filter: (device_id < v0)
-                                       ->  Seq Scan on compress_hyper_6_17_chunk (actual rows=1 loops=1)
+                                       ->  Seq Scan on compress_hyper_6_18_chunk (actual rows=1 loops=1)
                                              Filter: (_ts_meta_max_1 > device_id)
                      ->  Sort (actual rows=7 loops=1)
                            Sort Key: _hyper_2_5_chunk."time"
@@ -4657,7 +4657,7 @@ LIMIT 10;
                                  Sort Method: quicksort 
                                  ->  Custom Scan (DecompressChunk) on _hyper_2_5_chunk (actual rows=1080 loops=1)
                                        Filter: (device_id < v0)
-                                       ->  Seq Scan on compress_hyper_6_18_chunk (actual rows=3 loops=1)
+                                       ->  Seq Scan on compress_hyper_6_19_chunk (actual rows=3 loops=1)
                                              Filter: (_ts_meta_max_1 > device_id)
                      ->  Sort (actual rows=3 loops=1)
                            Sort Key: _hyper_2_6_chunk."time"
@@ -4667,7 +4667,7 @@ LIMIT 10;
                                  Sort Method: quicksort 
                                  ->  Custom Scan (DecompressChunk) on _hyper_2_6_chunk (actual rows=360 loops=1)
                                        Filter: (device_id < v0)
-                                       ->  Seq Scan on compress_hyper_6_19_chunk (actual rows=1 loops=1)
+                                       ->  Seq Scan on compress_hyper_6_20_chunk (actual rows=1 loops=1)
                                              Filter: (_ts_meta_max_1 > device_id)
                ->  Merge Append (never executed)
                      Sort Key: _hyper_2_7_chunk."time"
@@ -4685,7 +4685,7 @@ LIMIT 10;
                                  Sort Key: _hyper_2_10_chunk."time"
                                  ->  Custom Scan (DecompressChunk) on _hyper_2_10_chunk (never executed)
                                        Filter: (device_id < v0)
-                                       ->  Seq Scan on compress_hyper_6_20_chunk (never executed)
+                                       ->  Seq Scan on compress_hyper_6_24_chunk (never executed)
                                              Filter: (_ts_meta_max_1 > device_id)
                      ->  Sort (never executed)
                            Sort Key: _hyper_2_11_chunk."time"
@@ -4693,7 +4693,7 @@ LIMIT 10;
                                  Sort Key: _hyper_2_11_chunk."time"
                                  ->  Custom Scan (DecompressChunk) on _hyper_2_11_chunk (never executed)
                                        Filter: (device_id < v0)
-                                       ->  Seq Scan on compress_hyper_6_21_chunk (never executed)
+                                       ->  Seq Scan on compress_hyper_6_25_chunk (never executed)
                                              Filter: (_ts_meta_max_1 > device_id)
                      ->  Index Scan Backward using _hyper_2_12_chunk_metrics_space_time_idx on _hyper_2_12_chunk (never executed)
                            Filter: (device_id < v0)
@@ -4726,7 +4726,7 @@ LIMIT 10;
                                  ->  Custom Scan (DecompressChunk) on _hyper_2_4_chunk (actual rows=0 loops=1)
                                        Filter: (v1 = (device_id)::double precision)
                                        Rows Removed by Filter: 360
-                                       ->  Seq Scan on compress_hyper_6_17_chunk (actual rows=1 loops=1)
+                                       ->  Seq Scan on compress_hyper_6_18_chunk (actual rows=1 loops=1)
                      ->  Sort (actual rows=0 loops=1)
                            Sort Key: _hyper_2_5_chunk."time"
                            Sort Method: quicksort 
@@ -4736,7 +4736,7 @@ LIMIT 10;
                                  ->  Custom Scan (DecompressChunk) on _hyper_2_5_chunk (actual rows=0 loops=1)
                                        Filter: (v1 = (device_id)::double precision)
                                        Rows Removed by Filter: 1080
-                                       ->  Seq Scan on compress_hyper_6_18_chunk (actual rows=3 loops=1)
+                                       ->  Seq Scan on compress_hyper_6_19_chunk (actual rows=3 loops=1)
                      ->  Sort (actual rows=0 loops=1)
                            Sort Key: _hyper_2_6_chunk."time"
                            Sort Method: quicksort 
@@ -4746,7 +4746,7 @@ LIMIT 10;
                                  ->  Custom Scan (DecompressChunk) on _hyper_2_6_chunk (actual rows=0 loops=1)
                                        Filter: (v1 = (device_id)::double precision)
                                        Rows Removed by Filter: 360
-                                       ->  Seq Scan on compress_hyper_6_19_chunk (actual rows=1 loops=1)
+                                       ->  Seq Scan on compress_hyper_6_20_chunk (actual rows=1 loops=1)
                ->  Merge Append (actual rows=0 loops=1)
                      Sort Key: _hyper_2_7_chunk."time"
                      ->  Index Scan Backward using _hyper_2_7_chunk_metrics_space_time_idx on _hyper_2_7_chunk (actual rows=0 loops=1)
@@ -4769,7 +4769,7 @@ LIMIT 10;
                                  ->  Custom Scan (DecompressChunk) on _hyper_2_10_chunk (actual rows=0 loops=1)
                                        Filter: (v1 = (device_id)::double precision)
                                        Rows Removed by Filter: 504
-                                       ->  Seq Scan on compress_hyper_6_20_chunk (actual rows=1 loops=1)
+                                       ->  Seq Scan on compress_hyper_6_24_chunk (actual rows=1 loops=1)
                      ->  Sort (actual rows=0 loops=1)
                            Sort Key: _hyper_2_11_chunk."time"
                            Sort Method: quicksort 
@@ -4779,7 +4779,7 @@ LIMIT 10;
                                  ->  Custom Scan (DecompressChunk) on _hyper_2_11_chunk (actual rows=0 loops=1)
                                        Filter: (v1 = (device_id)::double precision)
                                        Rows Removed by Filter: 1512
-                                       ->  Seq Scan on compress_hyper_6_21_chunk (actual rows=3 loops=1)
+                                       ->  Seq Scan on compress_hyper_6_25_chunk (actual rows=3 loops=1)
                      ->  Index Scan Backward using _hyper_2_12_chunk_metrics_space_time_idx on _hyper_2_12_chunk (actual rows=0 loops=1)
                            Filter: (v1 = (device_id)::double precision)
                            Rows Removed by Filter: 504
@@ -4813,7 +4813,7 @@ LIMIT 10;
                                  ->  Custom Scan (DecompressChunk) on _hyper_2_4_chunk (actual rows=0 loops=1)
                                        Filter: ((v0)::double precision = v1)
                                        Rows Removed by Filter: 360
-                                       ->  Seq Scan on compress_hyper_6_17_chunk (actual rows=1 loops=1)
+                                       ->  Seq Scan on compress_hyper_6_18_chunk (actual rows=1 loops=1)
                      ->  Sort (actual rows=0 loops=1)
                            Sort Key: _hyper_2_5_chunk."time"
                            Sort Method: quicksort 
@@ -4823,7 +4823,7 @@ LIMIT 10;
                                  ->  Custom Scan (DecompressChunk) on _hyper_2_5_chunk (actual rows=0 loops=1)
                                        Filter: ((v0)::double precision = v1)
                                        Rows Removed by Filter: 1080
-                                       ->  Seq Scan on compress_hyper_6_18_chunk (actual rows=3 loops=1)
+                                       ->  Seq Scan on compress_hyper_6_19_chunk (actual rows=3 loops=1)
                      ->  Sort (actual rows=0 loops=1)
                            Sort Key: _hyper_2_6_chunk."time"
                            Sort Method: quicksort 
@@ -4833,7 +4833,7 @@ LIMIT 10;
                                  ->  Custom Scan (DecompressChunk) on _hyper_2_6_chunk (actual rows=0 loops=1)
                                        Filter: ((v0)::double precision = v1)
                                        Rows Removed by Filter: 360
-                                       ->  Seq Scan on compress_hyper_6_19_chunk (actual rows=1 loops=1)
+                                       ->  Seq Scan on compress_hyper_6_20_chunk (actual rows=1 loops=1)
                ->  Merge Append (actual rows=0 loops=1)
                      Sort Key: _hyper_2_7_chunk."time"
                      ->  Index Scan Backward using _hyper_2_7_chunk_metrics_space_time_idx on _hyper_2_7_chunk (actual rows=0 loops=1)
@@ -4856,7 +4856,7 @@ LIMIT 10;
                                  ->  Custom Scan (DecompressChunk) on _hyper_2_10_chunk (actual rows=0 loops=1)
                                        Filter: ((v0)::double precision = v1)
                                        Rows Removed by Filter: 504
-                                       ->  Seq Scan on compress_hyper_6_20_chunk (actual rows=1 loops=1)
+                                       ->  Seq Scan on compress_hyper_6_24_chunk (actual rows=1 loops=1)
                      ->  Sort (actual rows=0 loops=1)
                            Sort Key: _hyper_2_11_chunk."time"
                            Sort Method: quicksort 
@@ -4866,7 +4866,7 @@ LIMIT 10;
                                  ->  Custom Scan (DecompressChunk) on _hyper_2_11_chunk (actual rows=0 loops=1)
                                        Filter: ((v0)::double precision = v1)
                                        Rows Removed by Filter: 1512
-                                       ->  Seq Scan on compress_hyper_6_21_chunk (actual rows=3 loops=1)
+                                       ->  Seq Scan on compress_hyper_6_25_chunk (actual rows=3 loops=1)
                      ->  Index Scan Backward using _hyper_2_12_chunk_metrics_space_time_idx on _hyper_2_12_chunk (actual rows=0 loops=1)
                            Filter: ((v0)::double precision = v1)
                            Rows Removed by Filter: 504
@@ -4899,9 +4899,9 @@ LIMIT 10;
                      Filter: (_hyper_2_4_chunk."time" > 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
                      Rows Removed by Filter: 4
                      Bulk Decompression: true
-                     ->  Seq Scan on _timescaledb_internal.compress_hyper_6_17_chunk (actual rows=1 loops=1)
-                           Output: compress_hyper_6_17_chunk."time", compress_hyper_6_17_chunk.device_id, compress_hyper_6_17_chunk.device_id_peer, compress_hyper_6_17_chunk.v0, compress_hyper_6_17_chunk.v1, compress_hyper_6_17_chunk.v2, compress_hyper_6_17_chunk.v3, compress_hyper_6_17_chunk._ts_meta_count, compress_hyper_6_17_chunk._ts_meta_sequence_num, compress_hyper_6_17_chunk._ts_meta_min_3, compress_hyper_6_17_chunk._ts_meta_max_3, compress_hyper_6_17_chunk._ts_meta_min_1, compress_hyper_6_17_chunk._ts_meta_max_1, compress_hyper_6_17_chunk._ts_meta_min_2, compress_hyper_6_17_chunk._ts_meta_max_2
-                           Filter: ((compress_hyper_6_17_chunk._ts_meta_max_3 > 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone) AND (compress_hyper_6_17_chunk.device_id = 1))
+                     ->  Seq Scan on _timescaledb_internal.compress_hyper_6_18_chunk (actual rows=1 loops=1)
+                           Output: compress_hyper_6_18_chunk."time", compress_hyper_6_18_chunk.device_id, compress_hyper_6_18_chunk.device_id_peer, compress_hyper_6_18_chunk.v0, compress_hyper_6_18_chunk.v1, compress_hyper_6_18_chunk.v2, compress_hyper_6_18_chunk.v3, compress_hyper_6_18_chunk._ts_meta_count, compress_hyper_6_18_chunk._ts_meta_sequence_num, compress_hyper_6_18_chunk._ts_meta_min_3, compress_hyper_6_18_chunk._ts_meta_max_3, compress_hyper_6_18_chunk._ts_meta_min_1, compress_hyper_6_18_chunk._ts_meta_max_1, compress_hyper_6_18_chunk._ts_meta_min_2, compress_hyper_6_18_chunk._ts_meta_max_2
+                           Filter: ((compress_hyper_6_18_chunk._ts_meta_max_3 > 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone) AND (compress_hyper_6_18_chunk.device_id = 1))
          ->  Index Scan Backward using _hyper_2_7_chunk_metrics_space_time_idx on _timescaledb_internal._hyper_2_7_chunk (never executed)
                Output: _hyper_2_7_chunk."time", _hyper_2_7_chunk.device_id, _hyper_2_7_chunk.device_id_peer, _hyper_2_7_chunk.v0, _hyper_2_7_chunk.v1, _hyper_2_7_chunk.v2, _hyper_2_7_chunk.v3
                Index Cond: (_hyper_2_7_chunk."time" > 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
@@ -4913,9 +4913,9 @@ LIMIT 10;
                      Output: _hyper_2_10_chunk."time", _hyper_2_10_chunk.device_id, _hyper_2_10_chunk.device_id_peer, _hyper_2_10_chunk.v0, _hyper_2_10_chunk.v1, _hyper_2_10_chunk.v2, _hyper_2_10_chunk.v3
                      Filter: (_hyper_2_10_chunk."time" > 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
                      Bulk Decompression: true
-                     ->  Seq Scan on _timescaledb_internal.compress_hyper_6_20_chunk (never executed)
-                           Output: compress_hyper_6_20_chunk."time", compress_hyper_6_20_chunk.device_id, compress_hyper_6_20_chunk.device_id_peer, compress_hyper_6_20_chunk.v0, compress_hyper_6_20_chunk.v1, compress_hyper_6_20_chunk.v2, compress_hyper_6_20_chunk.v3, compress_hyper_6_20_chunk._ts_meta_count, compress_hyper_6_20_chunk._ts_meta_sequence_num, compress_hyper_6_20_chunk._ts_meta_min_3, compress_hyper_6_20_chunk._ts_meta_max_3, compress_hyper_6_20_chunk._ts_meta_min_1, compress_hyper_6_20_chunk._ts_meta_max_1, compress_hyper_6_20_chunk._ts_meta_min_2, compress_hyper_6_20_chunk._ts_meta_max_2
-                           Filter: ((compress_hyper_6_20_chunk._ts_meta_max_3 > 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone) AND (compress_hyper_6_20_chunk.device_id = 1))
+                     ->  Seq Scan on _timescaledb_internal.compress_hyper_6_24_chunk (never executed)
+                           Output: compress_hyper_6_24_chunk."time", compress_hyper_6_24_chunk.device_id, compress_hyper_6_24_chunk.device_id_peer, compress_hyper_6_24_chunk.v0, compress_hyper_6_24_chunk.v1, compress_hyper_6_24_chunk.v2, compress_hyper_6_24_chunk.v3, compress_hyper_6_24_chunk._ts_meta_count, compress_hyper_6_24_chunk._ts_meta_sequence_num, compress_hyper_6_24_chunk._ts_meta_min_3, compress_hyper_6_24_chunk._ts_meta_max_3, compress_hyper_6_24_chunk._ts_meta_min_1, compress_hyper_6_24_chunk._ts_meta_max_1, compress_hyper_6_24_chunk._ts_meta_min_2, compress_hyper_6_24_chunk._ts_meta_max_2
+                           Filter: ((compress_hyper_6_24_chunk._ts_meta_max_3 > 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone) AND (compress_hyper_6_24_chunk.device_id = 1))
 (33 rows)
 
 --pushdown of quals on order by and segment by cols or together (not pushed down)
@@ -4946,7 +4946,7 @@ LIMIT 10;
                                  Sort Method: quicksort 
                                  ->  Custom Scan (DecompressChunk) on _hyper_2_4_chunk (actual rows=360 loops=1)
                                        Filter: (("time" > 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone) OR (device_id = 1))
-                                       ->  Seq Scan on compress_hyper_6_17_chunk (actual rows=1 loops=1)
+                                       ->  Seq Scan on compress_hyper_6_18_chunk (actual rows=1 loops=1)
                      ->  Sort (actual rows=7 loops=1)
                            Sort Key: _hyper_2_5_chunk."time"
                            Sort Method: quicksort 
@@ -4956,7 +4956,7 @@ LIMIT 10;
                                  ->  Custom Scan (DecompressChunk) on _hyper_2_5_chunk (actual rows=1068 loops=1)
                                        Filter: (("time" > 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone) OR (device_id = 1))
                                        Rows Removed by Filter: 12
-                                       ->  Seq Scan on compress_hyper_6_18_chunk (actual rows=3 loops=1)
+                                       ->  Seq Scan on compress_hyper_6_19_chunk (actual rows=3 loops=1)
                      ->  Sort (actual rows=3 loops=1)
                            Sort Key: _hyper_2_6_chunk."time"
                            Sort Method: quicksort 
@@ -4966,7 +4966,7 @@ LIMIT 10;
                                  ->  Custom Scan (DecompressChunk) on _hyper_2_6_chunk (actual rows=356 loops=1)
                                        Filter: (("time" > 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone) OR (device_id = 1))
                                        Rows Removed by Filter: 4
-                                       ->  Seq Scan on compress_hyper_6_19_chunk (actual rows=1 loops=1)
+                                       ->  Seq Scan on compress_hyper_6_20_chunk (actual rows=1 loops=1)
                ->  Merge Append (never executed)
                      Sort Key: _hyper_2_7_chunk."time"
                      ->  Index Scan Backward using _hyper_2_7_chunk_metrics_space_time_idx on _hyper_2_7_chunk (never executed)
@@ -4983,14 +4983,14 @@ LIMIT 10;
                                  Sort Key: _hyper_2_10_chunk."time"
                                  ->  Custom Scan (DecompressChunk) on _hyper_2_10_chunk (never executed)
                                        Filter: (("time" > 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone) OR (device_id = 1))
-                                       ->  Seq Scan on compress_hyper_6_20_chunk (never executed)
+                                       ->  Seq Scan on compress_hyper_6_24_chunk (never executed)
                      ->  Sort (never executed)
                            Sort Key: _hyper_2_11_chunk."time"
                            ->  Sort (never executed)
                                  Sort Key: _hyper_2_11_chunk."time"
                                  ->  Custom Scan (DecompressChunk) on _hyper_2_11_chunk (never executed)
                                        Filter: (("time" > 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone) OR (device_id = 1))
-                                       ->  Seq Scan on compress_hyper_6_21_chunk (never executed)
+                                       ->  Seq Scan on compress_hyper_6_25_chunk (never executed)
                      ->  Index Scan Backward using _hyper_2_12_chunk_metrics_space_time_idx on _hyper_2_12_chunk (never executed)
                            Filter: (("time" > 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone) OR (device_id = 1))
 (64 rows)
@@ -5022,7 +5022,7 @@ LIMIT 10;
                                  Sort Method: quicksort 
                                  ->  Custom Scan (DecompressChunk) on _hyper_2_4_chunk (actual rows=360 loops=1)
                                        Filter: ("time" < now())
-                                       ->  Seq Scan on compress_hyper_6_17_chunk (actual rows=1 loops=1)
+                                       ->  Seq Scan on compress_hyper_6_18_chunk (actual rows=1 loops=1)
                      ->  Sort (actual rows=7 loops=1)
                            Sort Key: _hyper_2_5_chunk."time"
                            Sort Method: quicksort 
@@ -5031,7 +5031,7 @@ LIMIT 10;
                                  Sort Method: quicksort 
                                  ->  Custom Scan (DecompressChunk) on _hyper_2_5_chunk (actual rows=1080 loops=1)
                                        Filter: ("time" < now())
-                                       ->  Seq Scan on compress_hyper_6_18_chunk (actual rows=3 loops=1)
+                                       ->  Seq Scan on compress_hyper_6_19_chunk (actual rows=3 loops=1)
                      ->  Sort (actual rows=3 loops=1)
                            Sort Key: _hyper_2_6_chunk."time"
                            Sort Method: quicksort 
@@ -5040,7 +5040,7 @@ LIMIT 10;
                                  Sort Method: quicksort 
                                  ->  Custom Scan (DecompressChunk) on _hyper_2_6_chunk (actual rows=360 loops=1)
                                        Filter: ("time" < now())
-                                       ->  Seq Scan on compress_hyper_6_19_chunk (actual rows=1 loops=1)
+                                       ->  Seq Scan on compress_hyper_6_20_chunk (actual rows=1 loops=1)
                ->  Merge Append (never executed)
                      Sort Key: _hyper_2_7_chunk."time"
                      ->  Index Scan Backward using _hyper_2_7_chunk_metrics_space_time_idx on _hyper_2_7_chunk (never executed)
@@ -5057,14 +5057,14 @@ LIMIT 10;
                                  Sort Key: _hyper_2_10_chunk."time"
                                  ->  Custom Scan (DecompressChunk) on _hyper_2_10_chunk (never executed)
                                        Filter: ("time" < now())
-                                       ->  Seq Scan on compress_hyper_6_20_chunk (never executed)
+                                       ->  Seq Scan on compress_hyper_6_24_chunk (never executed)
                      ->  Sort (never executed)
                            Sort Key: _hyper_2_11_chunk."time"
                            ->  Sort (never executed)
                                  Sort Key: _hyper_2_11_chunk."time"
                                  ->  Custom Scan (DecompressChunk) on _hyper_2_11_chunk (never executed)
                                        Filter: ("time" < now())
-                                       ->  Seq Scan on compress_hyper_6_21_chunk (never executed)
+                                       ->  Seq Scan on compress_hyper_6_25_chunk (never executed)
                      ->  Index Scan Backward using _hyper_2_12_chunk_metrics_space_time_idx on _hyper_2_12_chunk (never executed)
                            Index Cond: ("time" < now())
 (62 rows)
@@ -5091,7 +5091,7 @@ LIMIT 10;
                            Sort Key: _hyper_2_11_chunk."time" DESC
                            Sort Method: quicksort 
                            ->  Custom Scan (DecompressChunk) on _hyper_2_11_chunk (actual rows=1512 loops=1)
-                                 ->  Seq Scan on compress_hyper_6_21_chunk (actual rows=3 loops=1)
+                                 ->  Seq Scan on compress_hyper_6_25_chunk (actual rows=3 loops=1)
                ->  Sort (actual rows=3 loops=1)
                      Sort Key: _hyper_2_10_chunk."time" DESC
                      Sort Method: top-N heapsort 
@@ -5099,7 +5099,7 @@ LIMIT 10;
                            Sort Key: _hyper_2_10_chunk."time" DESC
                            Sort Method: quicksort 
                            ->  Custom Scan (DecompressChunk) on _hyper_2_10_chunk (actual rows=504 loops=1)
-                                 ->  Seq Scan on compress_hyper_6_20_chunk (actual rows=1 loops=1)
+                                 ->  Seq Scan on compress_hyper_6_24_chunk (actual rows=1 loops=1)
          ->  Merge Append (never executed)
                Sort Key: _hyper_2_9_chunk."time" DESC
                ->  Index Only Scan using _hyper_2_9_chunk_metrics_space_time_idx on _hyper_2_9_chunk (never executed)
@@ -5115,19 +5115,19 @@ LIMIT 10;
                      ->  Sort (never executed)
                            Sort Key: _hyper_2_6_chunk."time" DESC
                            ->  Custom Scan (DecompressChunk) on _hyper_2_6_chunk (never executed)
-                                 ->  Seq Scan on compress_hyper_6_19_chunk (never executed)
+                                 ->  Seq Scan on compress_hyper_6_20_chunk (never executed)
                ->  Sort (never executed)
                      Sort Key: _hyper_2_5_chunk."time" DESC
                      ->  Sort (never executed)
                            Sort Key: _hyper_2_5_chunk."time" DESC
                            ->  Custom Scan (DecompressChunk) on _hyper_2_5_chunk (never executed)
-                                 ->  Seq Scan on compress_hyper_6_18_chunk (never executed)
+                                 ->  Seq Scan on compress_hyper_6_19_chunk (never executed)
                ->  Sort (never executed)
                      Sort Key: _hyper_2_4_chunk."time" DESC
                      ->  Sort (never executed)
                            Sort Key: _hyper_2_4_chunk."time" DESC
                            ->  Custom Scan (DecompressChunk) on _hyper_2_4_chunk (never executed)
-                                 ->  Seq Scan on compress_hyper_6_17_chunk (never executed)
+                                 ->  Seq Scan on compress_hyper_6_18_chunk (never executed)
 (51 rows)
 
 :PREFIX
@@ -5156,7 +5156,7 @@ LIMIT 10;
                                  Sort Key: _hyper_2_11_chunk."time" DESC
                                  Sort Method: quicksort 
                                  ->  Custom Scan (DecompressChunk) on _hyper_2_11_chunk (actual rows=1512 loops=1)
-                                       ->  Seq Scan on compress_hyper_6_21_chunk (actual rows=3 loops=1)
+                                       ->  Seq Scan on compress_hyper_6_25_chunk (actual rows=3 loops=1)
                      ->  Sort (actual rows=3 loops=1)
                            Sort Key: _hyper_2_10_chunk."time" DESC
                            Sort Method: quicksort 
@@ -5164,7 +5164,7 @@ LIMIT 10;
                                  Sort Key: _hyper_2_10_chunk."time" DESC
                                  Sort Method: quicksort 
                                  ->  Custom Scan (DecompressChunk) on _hyper_2_10_chunk (actual rows=504 loops=1)
-                                       ->  Seq Scan on compress_hyper_6_20_chunk (actual rows=1 loops=1)
+                                       ->  Seq Scan on compress_hyper_6_24_chunk (actual rows=1 loops=1)
                ->  Merge Append (never executed)
                      Sort Key: _hyper_2_9_chunk."time" DESC
                      ->  Index Scan using _hyper_2_9_chunk_metrics_space_time_idx on _hyper_2_9_chunk (never executed)
@@ -5177,19 +5177,19 @@ LIMIT 10;
                            ->  Sort (never executed)
                                  Sort Key: _hyper_2_6_chunk."time" DESC
                                  ->  Custom Scan (DecompressChunk) on _hyper_2_6_chunk (never executed)
-                                       ->  Seq Scan on compress_hyper_6_19_chunk (never executed)
+                                       ->  Seq Scan on compress_hyper_6_20_chunk (never executed)
                      ->  Sort (never executed)
                            Sort Key: _hyper_2_5_chunk."time" DESC
                            ->  Sort (never executed)
                                  Sort Key: _hyper_2_5_chunk."time" DESC
                                  ->  Custom Scan (DecompressChunk) on _hyper_2_5_chunk (never executed)
-                                       ->  Seq Scan on compress_hyper_6_18_chunk (never executed)
+                                       ->  Seq Scan on compress_hyper_6_19_chunk (never executed)
                      ->  Sort (never executed)
                            Sort Key: _hyper_2_4_chunk."time" DESC
                            ->  Sort (never executed)
                                  Sort Key: _hyper_2_4_chunk."time" DESC
                                  ->  Custom Scan (DecompressChunk) on _hyper_2_4_chunk (never executed)
-                                       ->  Seq Scan on compress_hyper_6_17_chunk (never executed)
+                                       ->  Seq Scan on compress_hyper_6_18_chunk (never executed)
 (51 rows)
 
 :PREFIX
@@ -5208,17 +5208,17 @@ LIMIT 10;
                Sort Key: _hyper_2_4_chunk.device_id, _hyper_2_4_chunk."time" DESC
                Sort Method: top-N heapsort 
                ->  Custom Scan (DecompressChunk) on _hyper_2_4_chunk (actual rows=360 loops=1)
-                     ->  Seq Scan on compress_hyper_6_17_chunk (actual rows=1 loops=1)
+                     ->  Seq Scan on compress_hyper_6_18_chunk (actual rows=1 loops=1)
          ->  Sort (actual rows=1 loops=1)
                Sort Key: _hyper_2_5_chunk.device_id, _hyper_2_5_chunk."time" DESC
                Sort Method: top-N heapsort 
                ->  Custom Scan (DecompressChunk) on _hyper_2_5_chunk (actual rows=1080 loops=1)
-                     ->  Seq Scan on compress_hyper_6_18_chunk (actual rows=3 loops=1)
+                     ->  Seq Scan on compress_hyper_6_19_chunk (actual rows=3 loops=1)
          ->  Sort (actual rows=1 loops=1)
                Sort Key: _hyper_2_6_chunk.device_id, _hyper_2_6_chunk."time" DESC
                Sort Method: top-N heapsort 
                ->  Custom Scan (DecompressChunk) on _hyper_2_6_chunk (actual rows=360 loops=1)
-                     ->  Seq Scan on compress_hyper_6_19_chunk (actual rows=1 loops=1)
+                     ->  Seq Scan on compress_hyper_6_20_chunk (actual rows=1 loops=1)
          ->  Index Only Scan using _hyper_2_7_chunk_metrics_space_device_id_time_idx on _hyper_2_7_chunk (actual rows=1 loops=1)
                Heap Fetches: 1
          ->  Index Only Scan using _hyper_2_8_chunk_metrics_space_device_id_time_idx on _hyper_2_8_chunk (actual rows=1 loops=1)
@@ -5229,12 +5229,12 @@ LIMIT 10;
                Sort Key: _hyper_2_10_chunk.device_id, _hyper_2_10_chunk."time" DESC
                Sort Method: top-N heapsort 
                ->  Custom Scan (DecompressChunk) on _hyper_2_10_chunk (actual rows=504 loops=1)
-                     ->  Seq Scan on compress_hyper_6_20_chunk (actual rows=1 loops=1)
+                     ->  Seq Scan on compress_hyper_6_24_chunk (actual rows=1 loops=1)
          ->  Sort (actual rows=1 loops=1)
                Sort Key: _hyper_2_11_chunk.device_id, _hyper_2_11_chunk."time" DESC
                Sort Method: top-N heapsort 
                ->  Custom Scan (DecompressChunk) on _hyper_2_11_chunk (actual rows=1512 loops=1)
-                     ->  Seq Scan on compress_hyper_6_21_chunk (actual rows=3 loops=1)
+                     ->  Seq Scan on compress_hyper_6_25_chunk (actual rows=3 loops=1)
          ->  Index Only Scan using _hyper_2_12_chunk_metrics_space_device_id_time_idx on _hyper_2_12_chunk (actual rows=1 loops=1)
                Heap Fetches: 1
 (36 rows)
@@ -5286,9 +5286,9 @@ ORDER BY time,
                                  Output: _hyper_2_10_chunk."time", _hyper_2_10_chunk.device_id, _hyper_2_10_chunk.device_id_peer, _hyper_2_10_chunk.v0, _hyper_2_10_chunk.v1, _hyper_2_10_chunk.v2, _hyper_2_10_chunk.v3
                                  Filter: (_hyper_2_10_chunk."time" > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
                                  Bulk Decompression: true
-                                 ->  Seq Scan on _timescaledb_internal.compress_hyper_6_20_chunk (actual rows=1 loops=1)
-                                       Output: compress_hyper_6_20_chunk."time", compress_hyper_6_20_chunk.device_id, compress_hyper_6_20_chunk.device_id_peer, compress_hyper_6_20_chunk.v0, compress_hyper_6_20_chunk.v1, compress_hyper_6_20_chunk.v2, compress_hyper_6_20_chunk.v3, compress_hyper_6_20_chunk._ts_meta_count, compress_hyper_6_20_chunk._ts_meta_sequence_num, compress_hyper_6_20_chunk._ts_meta_min_3, compress_hyper_6_20_chunk._ts_meta_max_3, compress_hyper_6_20_chunk._ts_meta_min_1, compress_hyper_6_20_chunk._ts_meta_max_1, compress_hyper_6_20_chunk._ts_meta_min_2, compress_hyper_6_20_chunk._ts_meta_max_2
-                                       Filter: (compress_hyper_6_20_chunk._ts_meta_max_3 > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
+                                 ->  Seq Scan on _timescaledb_internal.compress_hyper_6_24_chunk (actual rows=1 loops=1)
+                                       Output: compress_hyper_6_24_chunk."time", compress_hyper_6_24_chunk.device_id, compress_hyper_6_24_chunk.device_id_peer, compress_hyper_6_24_chunk.v0, compress_hyper_6_24_chunk.v1, compress_hyper_6_24_chunk.v2, compress_hyper_6_24_chunk.v3, compress_hyper_6_24_chunk._ts_meta_count, compress_hyper_6_24_chunk._ts_meta_sequence_num, compress_hyper_6_24_chunk._ts_meta_min_3, compress_hyper_6_24_chunk._ts_meta_max_3, compress_hyper_6_24_chunk._ts_meta_min_1, compress_hyper_6_24_chunk._ts_meta_max_1, compress_hyper_6_24_chunk._ts_meta_min_2, compress_hyper_6_24_chunk._ts_meta_max_2
+                                       Filter: (compress_hyper_6_24_chunk._ts_meta_max_3 > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
                ->  Sort (actual rows=1512 loops=1)
                      Output: _hyper_2_11_chunk."time", _hyper_2_11_chunk.device_id, _hyper_2_11_chunk.device_id_peer, _hyper_2_11_chunk.v0, _hyper_2_11_chunk.v1, _hyper_2_11_chunk.v2, _hyper_2_11_chunk.v3
                      Sort Key: _hyper_2_11_chunk."time"
@@ -5301,9 +5301,9 @@ ORDER BY time,
                                  Output: _hyper_2_11_chunk."time", _hyper_2_11_chunk.device_id, _hyper_2_11_chunk.device_id_peer, _hyper_2_11_chunk.v0, _hyper_2_11_chunk.v1, _hyper_2_11_chunk.v2, _hyper_2_11_chunk.v3
                                  Filter: (_hyper_2_11_chunk."time" > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
                                  Bulk Decompression: true
-                                 ->  Seq Scan on _timescaledb_internal.compress_hyper_6_21_chunk (actual rows=3 loops=1)
-                                       Output: compress_hyper_6_21_chunk."time", compress_hyper_6_21_chunk.device_id, compress_hyper_6_21_chunk.device_id_peer, compress_hyper_6_21_chunk.v0, compress_hyper_6_21_chunk.v1, compress_hyper_6_21_chunk.v2, compress_hyper_6_21_chunk.v3, compress_hyper_6_21_chunk._ts_meta_count, compress_hyper_6_21_chunk._ts_meta_sequence_num, compress_hyper_6_21_chunk._ts_meta_min_3, compress_hyper_6_21_chunk._ts_meta_max_3, compress_hyper_6_21_chunk._ts_meta_min_1, compress_hyper_6_21_chunk._ts_meta_max_1, compress_hyper_6_21_chunk._ts_meta_min_2, compress_hyper_6_21_chunk._ts_meta_max_2
-                                       Filter: (compress_hyper_6_21_chunk._ts_meta_max_3 > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
+                                 ->  Seq Scan on _timescaledb_internal.compress_hyper_6_25_chunk (actual rows=3 loops=1)
+                                       Output: compress_hyper_6_25_chunk."time", compress_hyper_6_25_chunk.device_id, compress_hyper_6_25_chunk.device_id_peer, compress_hyper_6_25_chunk.v0, compress_hyper_6_25_chunk.v1, compress_hyper_6_25_chunk.v2, compress_hyper_6_25_chunk.v3, compress_hyper_6_25_chunk._ts_meta_count, compress_hyper_6_25_chunk._ts_meta_sequence_num, compress_hyper_6_25_chunk._ts_meta_min_3, compress_hyper_6_25_chunk._ts_meta_max_3, compress_hyper_6_25_chunk._ts_meta_min_1, compress_hyper_6_25_chunk._ts_meta_max_1, compress_hyper_6_25_chunk._ts_meta_min_2, compress_hyper_6_25_chunk._ts_meta_max_2
+                                       Filter: (compress_hyper_6_25_chunk._ts_meta_max_3 > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
                ->  Index Scan Backward using _hyper_2_12_chunk_metrics_space_time_idx on _timescaledb_internal._hyper_2_12_chunk (actual rows=504 loops=1)
                      Output: _hyper_2_12_chunk."time", _hyper_2_12_chunk.device_id, _hyper_2_12_chunk.device_id_peer, _hyper_2_12_chunk.v0, _hyper_2_12_chunk.v1, _hyper_2_12_chunk.v2, _hyper_2_12_chunk.v3
                      Index Cond: (_hyper_2_12_chunk."time" > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
@@ -5336,16 +5336,16 @@ ORDER BY device_id,
          Output: _hyper_2_10_chunk."time", _hyper_2_10_chunk.device_id, _hyper_2_10_chunk.device_id_peer, _hyper_2_10_chunk.v0, _hyper_2_10_chunk.v1, _hyper_2_10_chunk.v2, _hyper_2_10_chunk.v3
          Filter: (_hyper_2_10_chunk."time" > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
          Bulk Decompression: true
-         ->  Index Scan using compress_hyper_6_20_chunk__compressed_hypertable_6_device_id_de on _timescaledb_internal.compress_hyper_6_20_chunk (actual rows=1 loops=1)
-               Output: compress_hyper_6_20_chunk."time", compress_hyper_6_20_chunk.device_id, compress_hyper_6_20_chunk.device_id_peer, compress_hyper_6_20_chunk.v0, compress_hyper_6_20_chunk.v1, compress_hyper_6_20_chunk.v2, compress_hyper_6_20_chunk.v3, compress_hyper_6_20_chunk._ts_meta_count, compress_hyper_6_20_chunk._ts_meta_sequence_num, compress_hyper_6_20_chunk._ts_meta_min_3, compress_hyper_6_20_chunk._ts_meta_max_3, compress_hyper_6_20_chunk._ts_meta_min_1, compress_hyper_6_20_chunk._ts_meta_max_1, compress_hyper_6_20_chunk._ts_meta_min_2, compress_hyper_6_20_chunk._ts_meta_max_2
-               Filter: (compress_hyper_6_20_chunk._ts_meta_max_3 > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
+         ->  Index Scan using compress_hyper_6_24_chunk__compressed_hypertable_6_device_id_de on _timescaledb_internal.compress_hyper_6_24_chunk (actual rows=1 loops=1)
+               Output: compress_hyper_6_24_chunk."time", compress_hyper_6_24_chunk.device_id, compress_hyper_6_24_chunk.device_id_peer, compress_hyper_6_24_chunk.v0, compress_hyper_6_24_chunk.v1, compress_hyper_6_24_chunk.v2, compress_hyper_6_24_chunk.v3, compress_hyper_6_24_chunk._ts_meta_count, compress_hyper_6_24_chunk._ts_meta_sequence_num, compress_hyper_6_24_chunk._ts_meta_min_3, compress_hyper_6_24_chunk._ts_meta_max_3, compress_hyper_6_24_chunk._ts_meta_min_1, compress_hyper_6_24_chunk._ts_meta_max_1, compress_hyper_6_24_chunk._ts_meta_min_2, compress_hyper_6_24_chunk._ts_meta_max_2
+               Filter: (compress_hyper_6_24_chunk._ts_meta_max_3 > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
    ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_11_chunk (actual rows=1512 loops=1)
          Output: _hyper_2_11_chunk."time", _hyper_2_11_chunk.device_id, _hyper_2_11_chunk.device_id_peer, _hyper_2_11_chunk.v0, _hyper_2_11_chunk.v1, _hyper_2_11_chunk.v2, _hyper_2_11_chunk.v3
          Filter: (_hyper_2_11_chunk."time" > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
          Bulk Decompression: true
-         ->  Index Scan using compress_hyper_6_21_chunk__compressed_hypertable_6_device_id_de on _timescaledb_internal.compress_hyper_6_21_chunk (actual rows=3 loops=1)
-               Output: compress_hyper_6_21_chunk."time", compress_hyper_6_21_chunk.device_id, compress_hyper_6_21_chunk.device_id_peer, compress_hyper_6_21_chunk.v0, compress_hyper_6_21_chunk.v1, compress_hyper_6_21_chunk.v2, compress_hyper_6_21_chunk.v3, compress_hyper_6_21_chunk._ts_meta_count, compress_hyper_6_21_chunk._ts_meta_sequence_num, compress_hyper_6_21_chunk._ts_meta_min_3, compress_hyper_6_21_chunk._ts_meta_max_3, compress_hyper_6_21_chunk._ts_meta_min_1, compress_hyper_6_21_chunk._ts_meta_max_1, compress_hyper_6_21_chunk._ts_meta_min_2, compress_hyper_6_21_chunk._ts_meta_max_2
-               Filter: (compress_hyper_6_21_chunk._ts_meta_max_3 > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
+         ->  Index Scan using compress_hyper_6_25_chunk__compressed_hypertable_6_device_id_de on _timescaledb_internal.compress_hyper_6_25_chunk (actual rows=3 loops=1)
+               Output: compress_hyper_6_25_chunk."time", compress_hyper_6_25_chunk.device_id, compress_hyper_6_25_chunk.device_id_peer, compress_hyper_6_25_chunk.v0, compress_hyper_6_25_chunk.v1, compress_hyper_6_25_chunk.v2, compress_hyper_6_25_chunk.v3, compress_hyper_6_25_chunk._ts_meta_count, compress_hyper_6_25_chunk._ts_meta_sequence_num, compress_hyper_6_25_chunk._ts_meta_min_3, compress_hyper_6_25_chunk._ts_meta_max_3, compress_hyper_6_25_chunk._ts_meta_min_1, compress_hyper_6_25_chunk._ts_meta_max_1, compress_hyper_6_25_chunk._ts_meta_min_2, compress_hyper_6_25_chunk._ts_meta_max_2
+               Filter: (compress_hyper_6_25_chunk._ts_meta_max_3 > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
    ->  Index Scan using _hyper_2_12_chunk_metrics_space_device_id_device_id_peer_v0_v1_ on _timescaledb_internal._hyper_2_12_chunk (actual rows=504 loops=1)
          Output: _hyper_2_12_chunk."time", _hyper_2_12_chunk.device_id, _hyper_2_12_chunk.device_id_peer, _hyper_2_12_chunk.v0, _hyper_2_12_chunk.v1, _hyper_2_12_chunk.v2, _hyper_2_12_chunk.v3
          Index Cond: (_hyper_2_12_chunk."time" > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
@@ -5386,23 +5386,23 @@ LIMIT 100;
                Filter: (_hyper_2_10_chunk."time" > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
                Bulk Decompression: true
                ->  Sort (actual rows=1 loops=1)
-                     Output: compress_hyper_6_20_chunk."time", compress_hyper_6_20_chunk.device_id, compress_hyper_6_20_chunk.device_id_peer, compress_hyper_6_20_chunk.v0, compress_hyper_6_20_chunk.v1, compress_hyper_6_20_chunk.v2, compress_hyper_6_20_chunk.v3, compress_hyper_6_20_chunk._ts_meta_count, compress_hyper_6_20_chunk._ts_meta_sequence_num, compress_hyper_6_20_chunk._ts_meta_min_3, compress_hyper_6_20_chunk._ts_meta_max_3, compress_hyper_6_20_chunk._ts_meta_min_1, compress_hyper_6_20_chunk._ts_meta_max_1, compress_hyper_6_20_chunk._ts_meta_min_2, compress_hyper_6_20_chunk._ts_meta_max_2
-                     Sort Key: compress_hyper_6_20_chunk.device_id, compress_hyper_6_20_chunk.device_id_peer, compress_hyper_6_20_chunk._ts_meta_sequence_num
+                     Output: compress_hyper_6_24_chunk."time", compress_hyper_6_24_chunk.device_id, compress_hyper_6_24_chunk.device_id_peer, compress_hyper_6_24_chunk.v0, compress_hyper_6_24_chunk.v1, compress_hyper_6_24_chunk.v2, compress_hyper_6_24_chunk.v3, compress_hyper_6_24_chunk._ts_meta_count, compress_hyper_6_24_chunk._ts_meta_sequence_num, compress_hyper_6_24_chunk._ts_meta_min_3, compress_hyper_6_24_chunk._ts_meta_max_3, compress_hyper_6_24_chunk._ts_meta_min_1, compress_hyper_6_24_chunk._ts_meta_max_1, compress_hyper_6_24_chunk._ts_meta_min_2, compress_hyper_6_24_chunk._ts_meta_max_2
+                     Sort Key: compress_hyper_6_24_chunk.device_id, compress_hyper_6_24_chunk.device_id_peer, compress_hyper_6_24_chunk._ts_meta_sequence_num
                      Sort Method: quicksort 
-                     ->  Seq Scan on _timescaledb_internal.compress_hyper_6_20_chunk (actual rows=1 loops=1)
-                           Output: compress_hyper_6_20_chunk."time", compress_hyper_6_20_chunk.device_id, compress_hyper_6_20_chunk.device_id_peer, compress_hyper_6_20_chunk.v0, compress_hyper_6_20_chunk.v1, compress_hyper_6_20_chunk.v2, compress_hyper_6_20_chunk.v3, compress_hyper_6_20_chunk._ts_meta_count, compress_hyper_6_20_chunk._ts_meta_sequence_num, compress_hyper_6_20_chunk._ts_meta_min_3, compress_hyper_6_20_chunk._ts_meta_max_3, compress_hyper_6_20_chunk._ts_meta_min_1, compress_hyper_6_20_chunk._ts_meta_max_1, compress_hyper_6_20_chunk._ts_meta_min_2, compress_hyper_6_20_chunk._ts_meta_max_2
-                           Filter: (compress_hyper_6_20_chunk._ts_meta_max_3 > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
+                     ->  Seq Scan on _timescaledb_internal.compress_hyper_6_24_chunk (actual rows=1 loops=1)
+                           Output: compress_hyper_6_24_chunk."time", compress_hyper_6_24_chunk.device_id, compress_hyper_6_24_chunk.device_id_peer, compress_hyper_6_24_chunk.v0, compress_hyper_6_24_chunk.v1, compress_hyper_6_24_chunk.v2, compress_hyper_6_24_chunk.v3, compress_hyper_6_24_chunk._ts_meta_count, compress_hyper_6_24_chunk._ts_meta_sequence_num, compress_hyper_6_24_chunk._ts_meta_min_3, compress_hyper_6_24_chunk._ts_meta_max_3, compress_hyper_6_24_chunk._ts_meta_min_1, compress_hyper_6_24_chunk._ts_meta_max_1, compress_hyper_6_24_chunk._ts_meta_min_2, compress_hyper_6_24_chunk._ts_meta_max_2
+                           Filter: (compress_hyper_6_24_chunk._ts_meta_max_3 > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
          ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_11_chunk (actual rows=1 loops=1)
                Output: _hyper_2_11_chunk.device_id, _hyper_2_11_chunk.device_id_peer, _hyper_2_11_chunk.v0, _hyper_2_11_chunk.v1, _hyper_2_11_chunk."time"
                Filter: (_hyper_2_11_chunk."time" > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
                Bulk Decompression: true
                ->  Sort (actual rows=1 loops=1)
-                     Output: compress_hyper_6_21_chunk."time", compress_hyper_6_21_chunk.device_id, compress_hyper_6_21_chunk.device_id_peer, compress_hyper_6_21_chunk.v0, compress_hyper_6_21_chunk.v1, compress_hyper_6_21_chunk.v2, compress_hyper_6_21_chunk.v3, compress_hyper_6_21_chunk._ts_meta_count, compress_hyper_6_21_chunk._ts_meta_sequence_num, compress_hyper_6_21_chunk._ts_meta_min_3, compress_hyper_6_21_chunk._ts_meta_max_3, compress_hyper_6_21_chunk._ts_meta_min_1, compress_hyper_6_21_chunk._ts_meta_max_1, compress_hyper_6_21_chunk._ts_meta_min_2, compress_hyper_6_21_chunk._ts_meta_max_2
-                     Sort Key: compress_hyper_6_21_chunk.device_id, compress_hyper_6_21_chunk.device_id_peer, compress_hyper_6_21_chunk._ts_meta_sequence_num
+                     Output: compress_hyper_6_25_chunk."time", compress_hyper_6_25_chunk.device_id, compress_hyper_6_25_chunk.device_id_peer, compress_hyper_6_25_chunk.v0, compress_hyper_6_25_chunk.v1, compress_hyper_6_25_chunk.v2, compress_hyper_6_25_chunk.v3, compress_hyper_6_25_chunk._ts_meta_count, compress_hyper_6_25_chunk._ts_meta_sequence_num, compress_hyper_6_25_chunk._ts_meta_min_3, compress_hyper_6_25_chunk._ts_meta_max_3, compress_hyper_6_25_chunk._ts_meta_min_1, compress_hyper_6_25_chunk._ts_meta_max_1, compress_hyper_6_25_chunk._ts_meta_min_2, compress_hyper_6_25_chunk._ts_meta_max_2
+                     Sort Key: compress_hyper_6_25_chunk.device_id, compress_hyper_6_25_chunk.device_id_peer, compress_hyper_6_25_chunk._ts_meta_sequence_num
                      Sort Method: quicksort 
-                     ->  Seq Scan on _timescaledb_internal.compress_hyper_6_21_chunk (actual rows=3 loops=1)
-                           Output: compress_hyper_6_21_chunk."time", compress_hyper_6_21_chunk.device_id, compress_hyper_6_21_chunk.device_id_peer, compress_hyper_6_21_chunk.v0, compress_hyper_6_21_chunk.v1, compress_hyper_6_21_chunk.v2, compress_hyper_6_21_chunk.v3, compress_hyper_6_21_chunk._ts_meta_count, compress_hyper_6_21_chunk._ts_meta_sequence_num, compress_hyper_6_21_chunk._ts_meta_min_3, compress_hyper_6_21_chunk._ts_meta_max_3, compress_hyper_6_21_chunk._ts_meta_min_1, compress_hyper_6_21_chunk._ts_meta_max_1, compress_hyper_6_21_chunk._ts_meta_min_2, compress_hyper_6_21_chunk._ts_meta_max_2
-                           Filter: (compress_hyper_6_21_chunk._ts_meta_max_3 > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
+                     ->  Seq Scan on _timescaledb_internal.compress_hyper_6_25_chunk (actual rows=3 loops=1)
+                           Output: compress_hyper_6_25_chunk."time", compress_hyper_6_25_chunk.device_id, compress_hyper_6_25_chunk.device_id_peer, compress_hyper_6_25_chunk.v0, compress_hyper_6_25_chunk.v1, compress_hyper_6_25_chunk.v2, compress_hyper_6_25_chunk.v3, compress_hyper_6_25_chunk._ts_meta_count, compress_hyper_6_25_chunk._ts_meta_sequence_num, compress_hyper_6_25_chunk._ts_meta_min_3, compress_hyper_6_25_chunk._ts_meta_max_3, compress_hyper_6_25_chunk._ts_meta_min_1, compress_hyper_6_25_chunk._ts_meta_max_1, compress_hyper_6_25_chunk._ts_meta_min_2, compress_hyper_6_25_chunk._ts_meta_max_2
+                           Filter: (compress_hyper_6_25_chunk._ts_meta_max_3 > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
          ->  Index Only Scan using _hyper_2_12_chunk_metrics_space_device_id_device_id_peer_v0_v1_ on _timescaledb_internal._hyper_2_12_chunk (actual rows=1 loops=1)
                Output: _hyper_2_12_chunk.device_id, _hyper_2_12_chunk.device_id_peer, _hyper_2_12_chunk.v0, _hyper_2_12_chunk.v1, _hyper_2_12_chunk."time"
                Index Cond: (_hyper_2_12_chunk."time" > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
@@ -5442,23 +5442,23 @@ LIMIT 100;
                Filter: (_hyper_2_10_chunk."time" > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
                Bulk Decompression: true
                ->  Sort (actual rows=1 loops=1)
-                     Output: compress_hyper_6_20_chunk."time", compress_hyper_6_20_chunk.device_id, compress_hyper_6_20_chunk.device_id_peer, compress_hyper_6_20_chunk.v0, compress_hyper_6_20_chunk.v1, compress_hyper_6_20_chunk.v2, compress_hyper_6_20_chunk.v3, compress_hyper_6_20_chunk._ts_meta_count, compress_hyper_6_20_chunk._ts_meta_sequence_num, compress_hyper_6_20_chunk._ts_meta_min_3, compress_hyper_6_20_chunk._ts_meta_max_3, compress_hyper_6_20_chunk._ts_meta_min_1, compress_hyper_6_20_chunk._ts_meta_max_1, compress_hyper_6_20_chunk._ts_meta_min_2, compress_hyper_6_20_chunk._ts_meta_max_2
-                     Sort Key: compress_hyper_6_20_chunk.device_id, compress_hyper_6_20_chunk.device_id_peer
+                     Output: compress_hyper_6_24_chunk."time", compress_hyper_6_24_chunk.device_id, compress_hyper_6_24_chunk.device_id_peer, compress_hyper_6_24_chunk.v0, compress_hyper_6_24_chunk.v1, compress_hyper_6_24_chunk.v2, compress_hyper_6_24_chunk.v3, compress_hyper_6_24_chunk._ts_meta_count, compress_hyper_6_24_chunk._ts_meta_sequence_num, compress_hyper_6_24_chunk._ts_meta_min_3, compress_hyper_6_24_chunk._ts_meta_max_3, compress_hyper_6_24_chunk._ts_meta_min_1, compress_hyper_6_24_chunk._ts_meta_max_1, compress_hyper_6_24_chunk._ts_meta_min_2, compress_hyper_6_24_chunk._ts_meta_max_2
+                     Sort Key: compress_hyper_6_24_chunk.device_id, compress_hyper_6_24_chunk.device_id_peer
                      Sort Method: quicksort 
-                     ->  Seq Scan on _timescaledb_internal.compress_hyper_6_20_chunk (actual rows=1 loops=1)
-                           Output: compress_hyper_6_20_chunk."time", compress_hyper_6_20_chunk.device_id, compress_hyper_6_20_chunk.device_id_peer, compress_hyper_6_20_chunk.v0, compress_hyper_6_20_chunk.v1, compress_hyper_6_20_chunk.v2, compress_hyper_6_20_chunk.v3, compress_hyper_6_20_chunk._ts_meta_count, compress_hyper_6_20_chunk._ts_meta_sequence_num, compress_hyper_6_20_chunk._ts_meta_min_3, compress_hyper_6_20_chunk._ts_meta_max_3, compress_hyper_6_20_chunk._ts_meta_min_1, compress_hyper_6_20_chunk._ts_meta_max_1, compress_hyper_6_20_chunk._ts_meta_min_2, compress_hyper_6_20_chunk._ts_meta_max_2
-                           Filter: (compress_hyper_6_20_chunk._ts_meta_max_3 > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
+                     ->  Seq Scan on _timescaledb_internal.compress_hyper_6_24_chunk (actual rows=1 loops=1)
+                           Output: compress_hyper_6_24_chunk."time", compress_hyper_6_24_chunk.device_id, compress_hyper_6_24_chunk.device_id_peer, compress_hyper_6_24_chunk.v0, compress_hyper_6_24_chunk.v1, compress_hyper_6_24_chunk.v2, compress_hyper_6_24_chunk.v3, compress_hyper_6_24_chunk._ts_meta_count, compress_hyper_6_24_chunk._ts_meta_sequence_num, compress_hyper_6_24_chunk._ts_meta_min_3, compress_hyper_6_24_chunk._ts_meta_max_3, compress_hyper_6_24_chunk._ts_meta_min_1, compress_hyper_6_24_chunk._ts_meta_max_1, compress_hyper_6_24_chunk._ts_meta_min_2, compress_hyper_6_24_chunk._ts_meta_max_2
+                           Filter: (compress_hyper_6_24_chunk._ts_meta_max_3 > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
          ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_11_chunk (actual rows=1 loops=1)
                Output: _hyper_2_11_chunk.device_id, _hyper_2_11_chunk.device_id_peer
                Filter: (_hyper_2_11_chunk."time" > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
                Bulk Decompression: true
                ->  Sort (actual rows=1 loops=1)
-                     Output: compress_hyper_6_21_chunk."time", compress_hyper_6_21_chunk.device_id, compress_hyper_6_21_chunk.device_id_peer, compress_hyper_6_21_chunk.v0, compress_hyper_6_21_chunk.v1, compress_hyper_6_21_chunk.v2, compress_hyper_6_21_chunk.v3, compress_hyper_6_21_chunk._ts_meta_count, compress_hyper_6_21_chunk._ts_meta_sequence_num, compress_hyper_6_21_chunk._ts_meta_min_3, compress_hyper_6_21_chunk._ts_meta_max_3, compress_hyper_6_21_chunk._ts_meta_min_1, compress_hyper_6_21_chunk._ts_meta_max_1, compress_hyper_6_21_chunk._ts_meta_min_2, compress_hyper_6_21_chunk._ts_meta_max_2
-                     Sort Key: compress_hyper_6_21_chunk.device_id, compress_hyper_6_21_chunk.device_id_peer
+                     Output: compress_hyper_6_25_chunk."time", compress_hyper_6_25_chunk.device_id, compress_hyper_6_25_chunk.device_id_peer, compress_hyper_6_25_chunk.v0, compress_hyper_6_25_chunk.v1, compress_hyper_6_25_chunk.v2, compress_hyper_6_25_chunk.v3, compress_hyper_6_25_chunk._ts_meta_count, compress_hyper_6_25_chunk._ts_meta_sequence_num, compress_hyper_6_25_chunk._ts_meta_min_3, compress_hyper_6_25_chunk._ts_meta_max_3, compress_hyper_6_25_chunk._ts_meta_min_1, compress_hyper_6_25_chunk._ts_meta_max_1, compress_hyper_6_25_chunk._ts_meta_min_2, compress_hyper_6_25_chunk._ts_meta_max_2
+                     Sort Key: compress_hyper_6_25_chunk.device_id, compress_hyper_6_25_chunk.device_id_peer
                      Sort Method: quicksort 
-                     ->  Seq Scan on _timescaledb_internal.compress_hyper_6_21_chunk (actual rows=3 loops=1)
-                           Output: compress_hyper_6_21_chunk."time", compress_hyper_6_21_chunk.device_id, compress_hyper_6_21_chunk.device_id_peer, compress_hyper_6_21_chunk.v0, compress_hyper_6_21_chunk.v1, compress_hyper_6_21_chunk.v2, compress_hyper_6_21_chunk.v3, compress_hyper_6_21_chunk._ts_meta_count, compress_hyper_6_21_chunk._ts_meta_sequence_num, compress_hyper_6_21_chunk._ts_meta_min_3, compress_hyper_6_21_chunk._ts_meta_max_3, compress_hyper_6_21_chunk._ts_meta_min_1, compress_hyper_6_21_chunk._ts_meta_max_1, compress_hyper_6_21_chunk._ts_meta_min_2, compress_hyper_6_21_chunk._ts_meta_max_2
-                           Filter: (compress_hyper_6_21_chunk._ts_meta_max_3 > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
+                     ->  Seq Scan on _timescaledb_internal.compress_hyper_6_25_chunk (actual rows=3 loops=1)
+                           Output: compress_hyper_6_25_chunk."time", compress_hyper_6_25_chunk.device_id, compress_hyper_6_25_chunk.device_id_peer, compress_hyper_6_25_chunk.v0, compress_hyper_6_25_chunk.v1, compress_hyper_6_25_chunk.v2, compress_hyper_6_25_chunk.v3, compress_hyper_6_25_chunk._ts_meta_count, compress_hyper_6_25_chunk._ts_meta_sequence_num, compress_hyper_6_25_chunk._ts_meta_min_3, compress_hyper_6_25_chunk._ts_meta_max_3, compress_hyper_6_25_chunk._ts_meta_min_1, compress_hyper_6_25_chunk._ts_meta_max_1, compress_hyper_6_25_chunk._ts_meta_min_2, compress_hyper_6_25_chunk._ts_meta_max_2
+                           Filter: (compress_hyper_6_25_chunk._ts_meta_max_3 > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
          ->  Index Only Scan Backward using _hyper_2_12_chunk_metrics_space_device_id_device_id_peer_v0_v_2 on _timescaledb_internal._hyper_2_12_chunk (actual rows=1 loops=1)
                Output: _hyper_2_12_chunk.device_id, _hyper_2_12_chunk.device_id_peer
                Index Cond: (_hyper_2_12_chunk."time" > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
@@ -5496,16 +5496,16 @@ ORDER BY device_id,
          Output: _hyper_2_10_chunk.device_id, _hyper_2_10_chunk.device_id_peer, _hyper_2_10_chunk.v0
          Filter: (_hyper_2_10_chunk."time" > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
          Bulk Decompression: true
-         ->  Index Scan using compress_hyper_6_20_chunk__compressed_hypertable_6_device_id_de on _timescaledb_internal.compress_hyper_6_20_chunk (actual rows=1 loops=1)
-               Output: compress_hyper_6_20_chunk."time", compress_hyper_6_20_chunk.device_id, compress_hyper_6_20_chunk.device_id_peer, compress_hyper_6_20_chunk.v0, compress_hyper_6_20_chunk.v1, compress_hyper_6_20_chunk.v2, compress_hyper_6_20_chunk.v3, compress_hyper_6_20_chunk._ts_meta_count, compress_hyper_6_20_chunk._ts_meta_sequence_num, compress_hyper_6_20_chunk._ts_meta_min_3, compress_hyper_6_20_chunk._ts_meta_max_3, compress_hyper_6_20_chunk._ts_meta_min_1, compress_hyper_6_20_chunk._ts_meta_max_1, compress_hyper_6_20_chunk._ts_meta_min_2, compress_hyper_6_20_chunk._ts_meta_max_2
-               Filter: (compress_hyper_6_20_chunk._ts_meta_max_3 > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
+         ->  Index Scan using compress_hyper_6_24_chunk__compressed_hypertable_6_device_id_de on _timescaledb_internal.compress_hyper_6_24_chunk (actual rows=1 loops=1)
+               Output: compress_hyper_6_24_chunk."time", compress_hyper_6_24_chunk.device_id, compress_hyper_6_24_chunk.device_id_peer, compress_hyper_6_24_chunk.v0, compress_hyper_6_24_chunk.v1, compress_hyper_6_24_chunk.v2, compress_hyper_6_24_chunk.v3, compress_hyper_6_24_chunk._ts_meta_count, compress_hyper_6_24_chunk._ts_meta_sequence_num, compress_hyper_6_24_chunk._ts_meta_min_3, compress_hyper_6_24_chunk._ts_meta_max_3, compress_hyper_6_24_chunk._ts_meta_min_1, compress_hyper_6_24_chunk._ts_meta_max_1, compress_hyper_6_24_chunk._ts_meta_min_2, compress_hyper_6_24_chunk._ts_meta_max_2
+               Filter: (compress_hyper_6_24_chunk._ts_meta_max_3 > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
    ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_11_chunk (actual rows=1512 loops=1)
          Output: _hyper_2_11_chunk.device_id, _hyper_2_11_chunk.device_id_peer, _hyper_2_11_chunk.v0
          Filter: (_hyper_2_11_chunk."time" > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
          Bulk Decompression: true
-         ->  Index Scan using compress_hyper_6_21_chunk__compressed_hypertable_6_device_id_de on _timescaledb_internal.compress_hyper_6_21_chunk (actual rows=3 loops=1)
-               Output: compress_hyper_6_21_chunk."time", compress_hyper_6_21_chunk.device_id, compress_hyper_6_21_chunk.device_id_peer, compress_hyper_6_21_chunk.v0, compress_hyper_6_21_chunk.v1, compress_hyper_6_21_chunk.v2, compress_hyper_6_21_chunk.v3, compress_hyper_6_21_chunk._ts_meta_count, compress_hyper_6_21_chunk._ts_meta_sequence_num, compress_hyper_6_21_chunk._ts_meta_min_3, compress_hyper_6_21_chunk._ts_meta_max_3, compress_hyper_6_21_chunk._ts_meta_min_1, compress_hyper_6_21_chunk._ts_meta_max_1, compress_hyper_6_21_chunk._ts_meta_min_2, compress_hyper_6_21_chunk._ts_meta_max_2
-               Filter: (compress_hyper_6_21_chunk._ts_meta_max_3 > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
+         ->  Index Scan using compress_hyper_6_25_chunk__compressed_hypertable_6_device_id_de on _timescaledb_internal.compress_hyper_6_25_chunk (actual rows=3 loops=1)
+               Output: compress_hyper_6_25_chunk."time", compress_hyper_6_25_chunk.device_id, compress_hyper_6_25_chunk.device_id_peer, compress_hyper_6_25_chunk.v0, compress_hyper_6_25_chunk.v1, compress_hyper_6_25_chunk.v2, compress_hyper_6_25_chunk.v3, compress_hyper_6_25_chunk._ts_meta_count, compress_hyper_6_25_chunk._ts_meta_sequence_num, compress_hyper_6_25_chunk._ts_meta_min_3, compress_hyper_6_25_chunk._ts_meta_max_3, compress_hyper_6_25_chunk._ts_meta_min_1, compress_hyper_6_25_chunk._ts_meta_max_1, compress_hyper_6_25_chunk._ts_meta_min_2, compress_hyper_6_25_chunk._ts_meta_max_2
+               Filter: (compress_hyper_6_25_chunk._ts_meta_max_3 > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
    ->  Index Only Scan using _hyper_2_12_chunk_metrics_space_device_id_device_id_peer_v0_v1_ on _timescaledb_internal._hyper_2_12_chunk (actual rows=504 loops=1)
          Output: _hyper_2_12_chunk.device_id, _hyper_2_12_chunk.device_id_peer, _hyper_2_12_chunk.v0
          Index Cond: (_hyper_2_12_chunk."time" > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
@@ -5545,16 +5545,16 @@ ORDER BY device_id,
          Output: _hyper_2_10_chunk.device_id, _hyper_2_10_chunk.device_id_peer, _hyper_2_10_chunk.v0, _hyper_2_10_chunk.v1
          Filter: (_hyper_2_10_chunk."time" > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
          Bulk Decompression: true
-         ->  Index Scan using compress_hyper_6_20_chunk__compressed_hypertable_6_device_id_de on _timescaledb_internal.compress_hyper_6_20_chunk (actual rows=1 loops=1)
-               Output: compress_hyper_6_20_chunk."time", compress_hyper_6_20_chunk.device_id, compress_hyper_6_20_chunk.device_id_peer, compress_hyper_6_20_chunk.v0, compress_hyper_6_20_chunk.v1, compress_hyper_6_20_chunk.v2, compress_hyper_6_20_chunk.v3, compress_hyper_6_20_chunk._ts_meta_count, compress_hyper_6_20_chunk._ts_meta_sequence_num, compress_hyper_6_20_chunk._ts_meta_min_3, compress_hyper_6_20_chunk._ts_meta_max_3, compress_hyper_6_20_chunk._ts_meta_min_1, compress_hyper_6_20_chunk._ts_meta_max_1, compress_hyper_6_20_chunk._ts_meta_min_2, compress_hyper_6_20_chunk._ts_meta_max_2
-               Filter: (compress_hyper_6_20_chunk._ts_meta_max_3 > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
+         ->  Index Scan using compress_hyper_6_24_chunk__compressed_hypertable_6_device_id_de on _timescaledb_internal.compress_hyper_6_24_chunk (actual rows=1 loops=1)
+               Output: compress_hyper_6_24_chunk."time", compress_hyper_6_24_chunk.device_id, compress_hyper_6_24_chunk.device_id_peer, compress_hyper_6_24_chunk.v0, compress_hyper_6_24_chunk.v1, compress_hyper_6_24_chunk.v2, compress_hyper_6_24_chunk.v3, compress_hyper_6_24_chunk._ts_meta_count, compress_hyper_6_24_chunk._ts_meta_sequence_num, compress_hyper_6_24_chunk._ts_meta_min_3, compress_hyper_6_24_chunk._ts_meta_max_3, compress_hyper_6_24_chunk._ts_meta_min_1, compress_hyper_6_24_chunk._ts_meta_max_1, compress_hyper_6_24_chunk._ts_meta_min_2, compress_hyper_6_24_chunk._ts_meta_max_2
+               Filter: (compress_hyper_6_24_chunk._ts_meta_max_3 > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
    ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_11_chunk (actual rows=1512 loops=1)
          Output: _hyper_2_11_chunk.device_id, _hyper_2_11_chunk.device_id_peer, _hyper_2_11_chunk.v0, _hyper_2_11_chunk.v1
          Filter: (_hyper_2_11_chunk."time" > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
          Bulk Decompression: true
-         ->  Index Scan using compress_hyper_6_21_chunk__compressed_hypertable_6_device_id_de on _timescaledb_internal.compress_hyper_6_21_chunk (actual rows=3 loops=1)
-               Output: compress_hyper_6_21_chunk."time", compress_hyper_6_21_chunk.device_id, compress_hyper_6_21_chunk.device_id_peer, compress_hyper_6_21_chunk.v0, compress_hyper_6_21_chunk.v1, compress_hyper_6_21_chunk.v2, compress_hyper_6_21_chunk.v3, compress_hyper_6_21_chunk._ts_meta_count, compress_hyper_6_21_chunk._ts_meta_sequence_num, compress_hyper_6_21_chunk._ts_meta_min_3, compress_hyper_6_21_chunk._ts_meta_max_3, compress_hyper_6_21_chunk._ts_meta_min_1, compress_hyper_6_21_chunk._ts_meta_max_1, compress_hyper_6_21_chunk._ts_meta_min_2, compress_hyper_6_21_chunk._ts_meta_max_2
-               Filter: (compress_hyper_6_21_chunk._ts_meta_max_3 > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
+         ->  Index Scan using compress_hyper_6_25_chunk__compressed_hypertable_6_device_id_de on _timescaledb_internal.compress_hyper_6_25_chunk (actual rows=3 loops=1)
+               Output: compress_hyper_6_25_chunk."time", compress_hyper_6_25_chunk.device_id, compress_hyper_6_25_chunk.device_id_peer, compress_hyper_6_25_chunk.v0, compress_hyper_6_25_chunk.v1, compress_hyper_6_25_chunk.v2, compress_hyper_6_25_chunk.v3, compress_hyper_6_25_chunk._ts_meta_count, compress_hyper_6_25_chunk._ts_meta_sequence_num, compress_hyper_6_25_chunk._ts_meta_min_3, compress_hyper_6_25_chunk._ts_meta_max_3, compress_hyper_6_25_chunk._ts_meta_min_1, compress_hyper_6_25_chunk._ts_meta_max_1, compress_hyper_6_25_chunk._ts_meta_min_2, compress_hyper_6_25_chunk._ts_meta_max_2
+               Filter: (compress_hyper_6_25_chunk._ts_meta_max_3 > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
    ->  Index Only Scan using _hyper_2_12_chunk_metrics_space_device_id_device_id_peer_v0_v1_ on _timescaledb_internal._hyper_2_12_chunk (actual rows=504 loops=1)
          Output: _hyper_2_12_chunk.device_id, _hyper_2_12_chunk.device_id_peer, _hyper_2_12_chunk.v0, _hyper_2_12_chunk.v1
          Index Cond: (_hyper_2_12_chunk."time" > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
@@ -5598,9 +5598,9 @@ ORDER BY device_id,
                      Output: _hyper_2_10_chunk."time", _hyper_2_10_chunk.device_id, _hyper_2_10_chunk.device_id_peer, _hyper_2_10_chunk.v0, _hyper_2_10_chunk.v1, _hyper_2_10_chunk.v2, _hyper_2_10_chunk.v3
                      Filter: (_hyper_2_10_chunk."time" > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
                      Bulk Decompression: true
-                     ->  Seq Scan on _timescaledb_internal.compress_hyper_6_20_chunk (actual rows=1 loops=1)
-                           Output: compress_hyper_6_20_chunk."time", compress_hyper_6_20_chunk.device_id, compress_hyper_6_20_chunk.device_id_peer, compress_hyper_6_20_chunk.v0, compress_hyper_6_20_chunk.v1, compress_hyper_6_20_chunk.v2, compress_hyper_6_20_chunk.v3, compress_hyper_6_20_chunk._ts_meta_count, compress_hyper_6_20_chunk._ts_meta_sequence_num, compress_hyper_6_20_chunk._ts_meta_min_3, compress_hyper_6_20_chunk._ts_meta_max_3, compress_hyper_6_20_chunk._ts_meta_min_1, compress_hyper_6_20_chunk._ts_meta_max_1, compress_hyper_6_20_chunk._ts_meta_min_2, compress_hyper_6_20_chunk._ts_meta_max_2
-                           Filter: (compress_hyper_6_20_chunk._ts_meta_max_3 > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
+                     ->  Seq Scan on _timescaledb_internal.compress_hyper_6_24_chunk (actual rows=1 loops=1)
+                           Output: compress_hyper_6_24_chunk."time", compress_hyper_6_24_chunk.device_id, compress_hyper_6_24_chunk.device_id_peer, compress_hyper_6_24_chunk.v0, compress_hyper_6_24_chunk.v1, compress_hyper_6_24_chunk.v2, compress_hyper_6_24_chunk.v3, compress_hyper_6_24_chunk._ts_meta_count, compress_hyper_6_24_chunk._ts_meta_sequence_num, compress_hyper_6_24_chunk._ts_meta_min_3, compress_hyper_6_24_chunk._ts_meta_max_3, compress_hyper_6_24_chunk._ts_meta_min_1, compress_hyper_6_24_chunk._ts_meta_max_1, compress_hyper_6_24_chunk._ts_meta_min_2, compress_hyper_6_24_chunk._ts_meta_max_2
+                           Filter: (compress_hyper_6_24_chunk._ts_meta_max_3 > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
          ->  Sort (actual rows=1512 loops=1)
                Output: _hyper_2_11_chunk."time", _hyper_2_11_chunk.device_id, _hyper_2_11_chunk.device_id_peer, _hyper_2_11_chunk.v0, _hyper_2_11_chunk.v1, _hyper_2_11_chunk.v2, _hyper_2_11_chunk.v3
                Sort Key: _hyper_2_11_chunk.device_id, _hyper_2_11_chunk.device_id_peer, _hyper_2_11_chunk.v0, _hyper_2_11_chunk.v1 DESC, _hyper_2_11_chunk."time"
@@ -5609,9 +5609,9 @@ ORDER BY device_id,
                      Output: _hyper_2_11_chunk."time", _hyper_2_11_chunk.device_id, _hyper_2_11_chunk.device_id_peer, _hyper_2_11_chunk.v0, _hyper_2_11_chunk.v1, _hyper_2_11_chunk.v2, _hyper_2_11_chunk.v3
                      Filter: (_hyper_2_11_chunk."time" > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
                      Bulk Decompression: true
-                     ->  Seq Scan on _timescaledb_internal.compress_hyper_6_21_chunk (actual rows=3 loops=1)
-                           Output: compress_hyper_6_21_chunk."time", compress_hyper_6_21_chunk.device_id, compress_hyper_6_21_chunk.device_id_peer, compress_hyper_6_21_chunk.v0, compress_hyper_6_21_chunk.v1, compress_hyper_6_21_chunk.v2, compress_hyper_6_21_chunk.v3, compress_hyper_6_21_chunk._ts_meta_count, compress_hyper_6_21_chunk._ts_meta_sequence_num, compress_hyper_6_21_chunk._ts_meta_min_3, compress_hyper_6_21_chunk._ts_meta_max_3, compress_hyper_6_21_chunk._ts_meta_min_1, compress_hyper_6_21_chunk._ts_meta_max_1, compress_hyper_6_21_chunk._ts_meta_min_2, compress_hyper_6_21_chunk._ts_meta_max_2
-                           Filter: (compress_hyper_6_21_chunk._ts_meta_max_3 > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
+                     ->  Seq Scan on _timescaledb_internal.compress_hyper_6_25_chunk (actual rows=3 loops=1)
+                           Output: compress_hyper_6_25_chunk."time", compress_hyper_6_25_chunk.device_id, compress_hyper_6_25_chunk.device_id_peer, compress_hyper_6_25_chunk.v0, compress_hyper_6_25_chunk.v1, compress_hyper_6_25_chunk.v2, compress_hyper_6_25_chunk.v3, compress_hyper_6_25_chunk._ts_meta_count, compress_hyper_6_25_chunk._ts_meta_sequence_num, compress_hyper_6_25_chunk._ts_meta_min_3, compress_hyper_6_25_chunk._ts_meta_max_3, compress_hyper_6_25_chunk._ts_meta_min_1, compress_hyper_6_25_chunk._ts_meta_max_1, compress_hyper_6_25_chunk._ts_meta_min_2, compress_hyper_6_25_chunk._ts_meta_max_2
+                           Filter: (compress_hyper_6_25_chunk._ts_meta_max_3 > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
          ->  Index Scan using _hyper_2_12_chunk_metrics_space_device_id_device_id_peer_v0_v1_ on _timescaledb_internal._hyper_2_12_chunk (actual rows=504 loops=1)
                Output: _hyper_2_12_chunk."time", _hyper_2_12_chunk.device_id, _hyper_2_12_chunk.device_id_peer, _hyper_2_12_chunk.v0, _hyper_2_12_chunk.v1, _hyper_2_12_chunk.v2, _hyper_2_12_chunk.v3
                Index Cond: (_hyper_2_12_chunk."time" > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
@@ -5646,23 +5646,23 @@ ORDER BY device_id DESC,
          Filter: (_hyper_2_10_chunk."time" > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
          Bulk Decompression: true
          ->  Sort (actual rows=1 loops=1)
-               Output: compress_hyper_6_20_chunk."time", compress_hyper_6_20_chunk.device_id, compress_hyper_6_20_chunk.device_id_peer, compress_hyper_6_20_chunk.v0, compress_hyper_6_20_chunk.v1, compress_hyper_6_20_chunk.v2, compress_hyper_6_20_chunk.v3, compress_hyper_6_20_chunk._ts_meta_count, compress_hyper_6_20_chunk._ts_meta_sequence_num, compress_hyper_6_20_chunk._ts_meta_min_3, compress_hyper_6_20_chunk._ts_meta_max_3, compress_hyper_6_20_chunk._ts_meta_min_1, compress_hyper_6_20_chunk._ts_meta_max_1, compress_hyper_6_20_chunk._ts_meta_min_2, compress_hyper_6_20_chunk._ts_meta_max_2
-               Sort Key: compress_hyper_6_20_chunk.device_id DESC, compress_hyper_6_20_chunk.device_id_peer DESC, compress_hyper_6_20_chunk._ts_meta_sequence_num
+               Output: compress_hyper_6_24_chunk."time", compress_hyper_6_24_chunk.device_id, compress_hyper_6_24_chunk.device_id_peer, compress_hyper_6_24_chunk.v0, compress_hyper_6_24_chunk.v1, compress_hyper_6_24_chunk.v2, compress_hyper_6_24_chunk.v3, compress_hyper_6_24_chunk._ts_meta_count, compress_hyper_6_24_chunk._ts_meta_sequence_num, compress_hyper_6_24_chunk._ts_meta_min_3, compress_hyper_6_24_chunk._ts_meta_max_3, compress_hyper_6_24_chunk._ts_meta_min_1, compress_hyper_6_24_chunk._ts_meta_max_1, compress_hyper_6_24_chunk._ts_meta_min_2, compress_hyper_6_24_chunk._ts_meta_max_2
+               Sort Key: compress_hyper_6_24_chunk.device_id DESC, compress_hyper_6_24_chunk.device_id_peer DESC, compress_hyper_6_24_chunk._ts_meta_sequence_num
                Sort Method: quicksort 
-               ->  Seq Scan on _timescaledb_internal.compress_hyper_6_20_chunk (actual rows=1 loops=1)
-                     Output: compress_hyper_6_20_chunk."time", compress_hyper_6_20_chunk.device_id, compress_hyper_6_20_chunk.device_id_peer, compress_hyper_6_20_chunk.v0, compress_hyper_6_20_chunk.v1, compress_hyper_6_20_chunk.v2, compress_hyper_6_20_chunk.v3, compress_hyper_6_20_chunk._ts_meta_count, compress_hyper_6_20_chunk._ts_meta_sequence_num, compress_hyper_6_20_chunk._ts_meta_min_3, compress_hyper_6_20_chunk._ts_meta_max_3, compress_hyper_6_20_chunk._ts_meta_min_1, compress_hyper_6_20_chunk._ts_meta_max_1, compress_hyper_6_20_chunk._ts_meta_min_2, compress_hyper_6_20_chunk._ts_meta_max_2
-                     Filter: (compress_hyper_6_20_chunk._ts_meta_max_3 > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
+               ->  Seq Scan on _timescaledb_internal.compress_hyper_6_24_chunk (actual rows=1 loops=1)
+                     Output: compress_hyper_6_24_chunk."time", compress_hyper_6_24_chunk.device_id, compress_hyper_6_24_chunk.device_id_peer, compress_hyper_6_24_chunk.v0, compress_hyper_6_24_chunk.v1, compress_hyper_6_24_chunk.v2, compress_hyper_6_24_chunk.v3, compress_hyper_6_24_chunk._ts_meta_count, compress_hyper_6_24_chunk._ts_meta_sequence_num, compress_hyper_6_24_chunk._ts_meta_min_3, compress_hyper_6_24_chunk._ts_meta_max_3, compress_hyper_6_24_chunk._ts_meta_min_1, compress_hyper_6_24_chunk._ts_meta_max_1, compress_hyper_6_24_chunk._ts_meta_min_2, compress_hyper_6_24_chunk._ts_meta_max_2
+                     Filter: (compress_hyper_6_24_chunk._ts_meta_max_3 > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
    ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_11_chunk (actual rows=1512 loops=1)
          Output: _hyper_2_11_chunk."time", _hyper_2_11_chunk.device_id, _hyper_2_11_chunk.device_id_peer, _hyper_2_11_chunk.v0, _hyper_2_11_chunk.v1, _hyper_2_11_chunk.v2, _hyper_2_11_chunk.v3
          Filter: (_hyper_2_11_chunk."time" > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
          Bulk Decompression: true
          ->  Sort (actual rows=3 loops=1)
-               Output: compress_hyper_6_21_chunk."time", compress_hyper_6_21_chunk.device_id, compress_hyper_6_21_chunk.device_id_peer, compress_hyper_6_21_chunk.v0, compress_hyper_6_21_chunk.v1, compress_hyper_6_21_chunk.v2, compress_hyper_6_21_chunk.v3, compress_hyper_6_21_chunk._ts_meta_count, compress_hyper_6_21_chunk._ts_meta_sequence_num, compress_hyper_6_21_chunk._ts_meta_min_3, compress_hyper_6_21_chunk._ts_meta_max_3, compress_hyper_6_21_chunk._ts_meta_min_1, compress_hyper_6_21_chunk._ts_meta_max_1, compress_hyper_6_21_chunk._ts_meta_min_2, compress_hyper_6_21_chunk._ts_meta_max_2
-               Sort Key: compress_hyper_6_21_chunk.device_id DESC, compress_hyper_6_21_chunk.device_id_peer DESC, compress_hyper_6_21_chunk._ts_meta_sequence_num
+               Output: compress_hyper_6_25_chunk."time", compress_hyper_6_25_chunk.device_id, compress_hyper_6_25_chunk.device_id_peer, compress_hyper_6_25_chunk.v0, compress_hyper_6_25_chunk.v1, compress_hyper_6_25_chunk.v2, compress_hyper_6_25_chunk.v3, compress_hyper_6_25_chunk._ts_meta_count, compress_hyper_6_25_chunk._ts_meta_sequence_num, compress_hyper_6_25_chunk._ts_meta_min_3, compress_hyper_6_25_chunk._ts_meta_max_3, compress_hyper_6_25_chunk._ts_meta_min_1, compress_hyper_6_25_chunk._ts_meta_max_1, compress_hyper_6_25_chunk._ts_meta_min_2, compress_hyper_6_25_chunk._ts_meta_max_2
+               Sort Key: compress_hyper_6_25_chunk.device_id DESC, compress_hyper_6_25_chunk.device_id_peer DESC, compress_hyper_6_25_chunk._ts_meta_sequence_num
                Sort Method: quicksort 
-               ->  Seq Scan on _timescaledb_internal.compress_hyper_6_21_chunk (actual rows=3 loops=1)
-                     Output: compress_hyper_6_21_chunk."time", compress_hyper_6_21_chunk.device_id, compress_hyper_6_21_chunk.device_id_peer, compress_hyper_6_21_chunk.v0, compress_hyper_6_21_chunk.v1, compress_hyper_6_21_chunk.v2, compress_hyper_6_21_chunk.v3, compress_hyper_6_21_chunk._ts_meta_count, compress_hyper_6_21_chunk._ts_meta_sequence_num, compress_hyper_6_21_chunk._ts_meta_min_3, compress_hyper_6_21_chunk._ts_meta_max_3, compress_hyper_6_21_chunk._ts_meta_min_1, compress_hyper_6_21_chunk._ts_meta_max_1, compress_hyper_6_21_chunk._ts_meta_min_2, compress_hyper_6_21_chunk._ts_meta_max_2
-                     Filter: (compress_hyper_6_21_chunk._ts_meta_max_3 > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
+               ->  Seq Scan on _timescaledb_internal.compress_hyper_6_25_chunk (actual rows=3 loops=1)
+                     Output: compress_hyper_6_25_chunk."time", compress_hyper_6_25_chunk.device_id, compress_hyper_6_25_chunk.device_id_peer, compress_hyper_6_25_chunk.v0, compress_hyper_6_25_chunk.v1, compress_hyper_6_25_chunk.v2, compress_hyper_6_25_chunk.v3, compress_hyper_6_25_chunk._ts_meta_count, compress_hyper_6_25_chunk._ts_meta_sequence_num, compress_hyper_6_25_chunk._ts_meta_min_3, compress_hyper_6_25_chunk._ts_meta_max_3, compress_hyper_6_25_chunk._ts_meta_min_1, compress_hyper_6_25_chunk._ts_meta_max_1, compress_hyper_6_25_chunk._ts_meta_min_2, compress_hyper_6_25_chunk._ts_meta_max_2
+                     Filter: (compress_hyper_6_25_chunk._ts_meta_max_3 > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
    ->  Index Scan using _hyper_2_12_chunk_metrics_space_device_id_device_id_peer_v0_v_2 on _timescaledb_internal._hyper_2_12_chunk (actual rows=504 loops=1)
          Output: _hyper_2_12_chunk."time", _hyper_2_12_chunk.device_id, _hyper_2_12_chunk.device_id_peer, _hyper_2_12_chunk.v0, _hyper_2_12_chunk.v1, _hyper_2_12_chunk.v2, _hyper_2_12_chunk.v3
          Index Cond: (_hyper_2_12_chunk."time" > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
@@ -5701,16 +5701,16 @@ ORDER BY device_id DESC,
                Output: _hyper_2_10_chunk."time", _hyper_2_10_chunk.device_id, _hyper_2_10_chunk.device_id_peer, _hyper_2_10_chunk.v0, _hyper_2_10_chunk.v1, _hyper_2_10_chunk.v2, _hyper_2_10_chunk.v3
                Filter: (_hyper_2_10_chunk."time" > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
                Bulk Decompression: true
-               ->  Seq Scan on _timescaledb_internal.compress_hyper_6_20_chunk (actual rows=1 loops=1)
-                     Output: compress_hyper_6_20_chunk."time", compress_hyper_6_20_chunk.device_id, compress_hyper_6_20_chunk.device_id_peer, compress_hyper_6_20_chunk.v0, compress_hyper_6_20_chunk.v1, compress_hyper_6_20_chunk.v2, compress_hyper_6_20_chunk.v3, compress_hyper_6_20_chunk._ts_meta_count, compress_hyper_6_20_chunk._ts_meta_sequence_num, compress_hyper_6_20_chunk._ts_meta_min_3, compress_hyper_6_20_chunk._ts_meta_max_3, compress_hyper_6_20_chunk._ts_meta_min_1, compress_hyper_6_20_chunk._ts_meta_max_1, compress_hyper_6_20_chunk._ts_meta_min_2, compress_hyper_6_20_chunk._ts_meta_max_2
-                     Filter: (compress_hyper_6_20_chunk._ts_meta_max_3 > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
+               ->  Seq Scan on _timescaledb_internal.compress_hyper_6_24_chunk (actual rows=1 loops=1)
+                     Output: compress_hyper_6_24_chunk."time", compress_hyper_6_24_chunk.device_id, compress_hyper_6_24_chunk.device_id_peer, compress_hyper_6_24_chunk.v0, compress_hyper_6_24_chunk.v1, compress_hyper_6_24_chunk.v2, compress_hyper_6_24_chunk.v3, compress_hyper_6_24_chunk._ts_meta_count, compress_hyper_6_24_chunk._ts_meta_sequence_num, compress_hyper_6_24_chunk._ts_meta_min_3, compress_hyper_6_24_chunk._ts_meta_max_3, compress_hyper_6_24_chunk._ts_meta_min_1, compress_hyper_6_24_chunk._ts_meta_max_1, compress_hyper_6_24_chunk._ts_meta_min_2, compress_hyper_6_24_chunk._ts_meta_max_2
+                     Filter: (compress_hyper_6_24_chunk._ts_meta_max_3 > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
          ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_11_chunk (actual rows=1512 loops=1)
                Output: _hyper_2_11_chunk."time", _hyper_2_11_chunk.device_id, _hyper_2_11_chunk.device_id_peer, _hyper_2_11_chunk.v0, _hyper_2_11_chunk.v1, _hyper_2_11_chunk.v2, _hyper_2_11_chunk.v3
                Filter: (_hyper_2_11_chunk."time" > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
                Bulk Decompression: true
-               ->  Seq Scan on _timescaledb_internal.compress_hyper_6_21_chunk (actual rows=3 loops=1)
-                     Output: compress_hyper_6_21_chunk."time", compress_hyper_6_21_chunk.device_id, compress_hyper_6_21_chunk.device_id_peer, compress_hyper_6_21_chunk.v0, compress_hyper_6_21_chunk.v1, compress_hyper_6_21_chunk.v2, compress_hyper_6_21_chunk.v3, compress_hyper_6_21_chunk._ts_meta_count, compress_hyper_6_21_chunk._ts_meta_sequence_num, compress_hyper_6_21_chunk._ts_meta_min_3, compress_hyper_6_21_chunk._ts_meta_max_3, compress_hyper_6_21_chunk._ts_meta_min_1, compress_hyper_6_21_chunk._ts_meta_max_1, compress_hyper_6_21_chunk._ts_meta_min_2, compress_hyper_6_21_chunk._ts_meta_max_2
-                     Filter: (compress_hyper_6_21_chunk._ts_meta_max_3 > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
+               ->  Seq Scan on _timescaledb_internal.compress_hyper_6_25_chunk (actual rows=3 loops=1)
+                     Output: compress_hyper_6_25_chunk."time", compress_hyper_6_25_chunk.device_id, compress_hyper_6_25_chunk.device_id_peer, compress_hyper_6_25_chunk.v0, compress_hyper_6_25_chunk.v1, compress_hyper_6_25_chunk.v2, compress_hyper_6_25_chunk.v3, compress_hyper_6_25_chunk._ts_meta_count, compress_hyper_6_25_chunk._ts_meta_sequence_num, compress_hyper_6_25_chunk._ts_meta_min_3, compress_hyper_6_25_chunk._ts_meta_max_3, compress_hyper_6_25_chunk._ts_meta_min_1, compress_hyper_6_25_chunk._ts_meta_max_1, compress_hyper_6_25_chunk._ts_meta_min_2, compress_hyper_6_25_chunk._ts_meta_max_2
+                     Filter: (compress_hyper_6_25_chunk._ts_meta_max_3 > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
          ->  Seq Scan on _timescaledb_internal._hyper_2_12_chunk (actual rows=504 loops=1)
                Output: _hyper_2_12_chunk."time", _hyper_2_12_chunk.device_id, _hyper_2_12_chunk.device_id_peer, _hyper_2_12_chunk.v0, _hyper_2_12_chunk.v1, _hyper_2_12_chunk.v2, _hyper_2_12_chunk.v3
                Filter: (_hyper_2_12_chunk."time" > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
@@ -5753,7 +5753,7 @@ ORDER BY time,
                            Sort Method: quicksort 
                            ->  Custom Scan (DecompressChunk) on _hyper_2_10_chunk (actual rows=504 loops=1)
                                  Filter: ("time" > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
-                                 ->  Seq Scan on compress_hyper_6_20_chunk (actual rows=1 loops=1)
+                                 ->  Seq Scan on compress_hyper_6_24_chunk (actual rows=1 loops=1)
                                        Filter: (_ts_meta_max_3 > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
                ->  Sort (actual rows=1512 loops=1)
                      Sort Key: _hyper_2_11_chunk."time"
@@ -5763,7 +5763,7 @@ ORDER BY time,
                            Sort Method: quicksort 
                            ->  Custom Scan (DecompressChunk) on _hyper_2_11_chunk (actual rows=1512 loops=1)
                                  Filter: ("time" > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
-                                 ->  Seq Scan on compress_hyper_6_21_chunk (actual rows=3 loops=1)
+                                 ->  Seq Scan on compress_hyper_6_25_chunk (actual rows=3 loops=1)
                                        Filter: (_ts_meta_max_3 > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
                ->  Index Scan Backward using _hyper_2_12_chunk_metrics_space_time_idx on _hyper_2_12_chunk (actual rows=504 loops=1)
                      Index Cond: ("time" > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
@@ -5795,7 +5795,7 @@ ORDER BY time,
                            Sort Method: quicksort 
                            ->  Custom Scan (DecompressChunk) on _hyper_2_4_chunk (actual rows=0 loops=1)
                                  Filter: ("time" > ('2000-01-08'::cstring)::timestamp with time zone)
-                                 ->  Seq Scan on compress_hyper_6_17_chunk (actual rows=0 loops=1)
+                                 ->  Seq Scan on compress_hyper_6_18_chunk (actual rows=0 loops=1)
                                        Filter: (_ts_meta_max_3 > ('2000-01-08'::cstring)::timestamp with time zone)
                                        Rows Removed by Filter: 1
                ->  Sort (actual rows=0 loops=1)
@@ -5806,7 +5806,7 @@ ORDER BY time,
                            Sort Method: quicksort 
                            ->  Custom Scan (DecompressChunk) on _hyper_2_5_chunk (actual rows=0 loops=1)
                                  Filter: ("time" > ('2000-01-08'::cstring)::timestamp with time zone)
-                                 ->  Seq Scan on compress_hyper_6_18_chunk (actual rows=0 loops=1)
+                                 ->  Seq Scan on compress_hyper_6_19_chunk (actual rows=0 loops=1)
                                        Filter: (_ts_meta_max_3 > ('2000-01-08'::cstring)::timestamp with time zone)
                                        Rows Removed by Filter: 3
                ->  Sort (actual rows=0 loops=1)
@@ -5817,7 +5817,7 @@ ORDER BY time,
                            Sort Method: quicksort 
                            ->  Custom Scan (DecompressChunk) on _hyper_2_6_chunk (actual rows=0 loops=1)
                                  Filter: ("time" > ('2000-01-08'::cstring)::timestamp with time zone)
-                                 ->  Seq Scan on compress_hyper_6_19_chunk (actual rows=0 loops=1)
+                                 ->  Seq Scan on compress_hyper_6_20_chunk (actual rows=0 loops=1)
                                        Filter: (_ts_meta_max_3 > ('2000-01-08'::cstring)::timestamp with time zone)
                                        Rows Removed by Filter: 1
          ->  Merge Append (actual rows=1675 loops=1)
@@ -5838,7 +5838,7 @@ ORDER BY time,
                            Sort Method: quicksort 
                            ->  Custom Scan (DecompressChunk) on _hyper_2_10_chunk (actual rows=504 loops=1)
                                  Filter: ("time" > ('2000-01-08'::cstring)::timestamp with time zone)
-                                 ->  Seq Scan on compress_hyper_6_20_chunk (actual rows=1 loops=1)
+                                 ->  Seq Scan on compress_hyper_6_24_chunk (actual rows=1 loops=1)
                                        Filter: (_ts_meta_max_3 > ('2000-01-08'::cstring)::timestamp with time zone)
                ->  Sort (actual rows=1512 loops=1)
                      Sort Key: _hyper_2_11_chunk."time"
@@ -5848,7 +5848,7 @@ ORDER BY time,
                            Sort Method: quicksort 
                            ->  Custom Scan (DecompressChunk) on _hyper_2_11_chunk (actual rows=1512 loops=1)
                                  Filter: ("time" > ('2000-01-08'::cstring)::timestamp with time zone)
-                                 ->  Seq Scan on compress_hyper_6_21_chunk (actual rows=3 loops=1)
+                                 ->  Seq Scan on compress_hyper_6_25_chunk (actual rows=3 loops=1)
                                        Filter: (_ts_meta_max_3 > ('2000-01-08'::cstring)::timestamp with time zone)
                ->  Index Scan Backward using _hyper_2_12_chunk_metrics_space_time_idx on _hyper_2_12_chunk (actual rows=504 loops=1)
                      Index Cond: ("time" > ('2000-01-08'::cstring)::timestamp with time zone)
@@ -5863,18 +5863,18 @@ FROM :TEST_TABLE;
  Aggregate (actual rows=1 loops=1)
    ->  Append (actual rows=6840 loops=1)
          ->  Custom Scan (DecompressChunk) on _hyper_2_4_chunk (actual rows=360 loops=1)
-               ->  Seq Scan on compress_hyper_6_17_chunk (actual rows=1 loops=1)
+               ->  Seq Scan on compress_hyper_6_18_chunk (actual rows=1 loops=1)
          ->  Custom Scan (DecompressChunk) on _hyper_2_5_chunk (actual rows=1080 loops=1)
-               ->  Seq Scan on compress_hyper_6_18_chunk (actual rows=3 loops=1)
+               ->  Seq Scan on compress_hyper_6_19_chunk (actual rows=3 loops=1)
          ->  Custom Scan (DecompressChunk) on _hyper_2_6_chunk (actual rows=360 loops=1)
-               ->  Seq Scan on compress_hyper_6_19_chunk (actual rows=1 loops=1)
+               ->  Seq Scan on compress_hyper_6_20_chunk (actual rows=1 loops=1)
          ->  Seq Scan on _hyper_2_7_chunk (actual rows=504 loops=1)
          ->  Seq Scan on _hyper_2_8_chunk (actual rows=1512 loops=1)
          ->  Seq Scan on _hyper_2_9_chunk (actual rows=504 loops=1)
          ->  Custom Scan (DecompressChunk) on _hyper_2_10_chunk (actual rows=504 loops=1)
-               ->  Seq Scan on compress_hyper_6_20_chunk (actual rows=1 loops=1)
+               ->  Seq Scan on compress_hyper_6_24_chunk (actual rows=1 loops=1)
          ->  Custom Scan (DecompressChunk) on _hyper_2_11_chunk (actual rows=1512 loops=1)
-               ->  Seq Scan on compress_hyper_6_21_chunk (actual rows=3 loops=1)
+               ->  Seq Scan on compress_hyper_6_25_chunk (actual rows=3 loops=1)
          ->  Seq Scan on _hyper_2_12_chunk (actual rows=504 loops=1)
 (16 rows)
 
@@ -5894,18 +5894,18 @@ ORDER BY device_id;
          Batches: 1 
          ->  Append (actual rows=6840 loops=1)
                ->  Custom Scan (DecompressChunk) on _hyper_2_4_chunk (actual rows=360 loops=1)
-                     ->  Seq Scan on compress_hyper_6_17_chunk (actual rows=1 loops=1)
+                     ->  Seq Scan on compress_hyper_6_18_chunk (actual rows=1 loops=1)
                ->  Custom Scan (DecompressChunk) on _hyper_2_5_chunk (actual rows=1080 loops=1)
-                     ->  Seq Scan on compress_hyper_6_18_chunk (actual rows=3 loops=1)
+                     ->  Seq Scan on compress_hyper_6_19_chunk (actual rows=3 loops=1)
                ->  Custom Scan (DecompressChunk) on _hyper_2_6_chunk (actual rows=360 loops=1)
-                     ->  Seq Scan on compress_hyper_6_19_chunk (actual rows=1 loops=1)
+                     ->  Seq Scan on compress_hyper_6_20_chunk (actual rows=1 loops=1)
                ->  Seq Scan on _hyper_2_7_chunk (actual rows=504 loops=1)
                ->  Seq Scan on _hyper_2_8_chunk (actual rows=1512 loops=1)
                ->  Seq Scan on _hyper_2_9_chunk (actual rows=504 loops=1)
                ->  Custom Scan (DecompressChunk) on _hyper_2_10_chunk (actual rows=504 loops=1)
-                     ->  Seq Scan on compress_hyper_6_20_chunk (actual rows=1 loops=1)
+                     ->  Seq Scan on compress_hyper_6_24_chunk (actual rows=1 loops=1)
                ->  Custom Scan (DecompressChunk) on _hyper_2_11_chunk (actual rows=1512 loops=1)
-                     ->  Seq Scan on compress_hyper_6_21_chunk (actual rows=3 loops=1)
+                     ->  Seq Scan on compress_hyper_6_25_chunk (actual rows=3 loops=1)
                ->  Seq Scan on _hyper_2_12_chunk (actual rows=504 loops=1)
 (21 rows)
 
@@ -5926,18 +5926,18 @@ ORDER BY device_id;
                Batches: 1 
                ->  Append (actual rows=6840 loops=1)
                      ->  Custom Scan (DecompressChunk) on _hyper_2_4_chunk (actual rows=360 loops=1)
-                           ->  Seq Scan on compress_hyper_6_17_chunk (actual rows=1 loops=1)
+                           ->  Seq Scan on compress_hyper_6_18_chunk (actual rows=1 loops=1)
                      ->  Custom Scan (DecompressChunk) on _hyper_2_5_chunk (actual rows=1080 loops=1)
-                           ->  Seq Scan on compress_hyper_6_18_chunk (actual rows=3 loops=1)
+                           ->  Seq Scan on compress_hyper_6_19_chunk (actual rows=3 loops=1)
                      ->  Custom Scan (DecompressChunk) on _hyper_2_6_chunk (actual rows=360 loops=1)
-                           ->  Seq Scan on compress_hyper_6_19_chunk (actual rows=1 loops=1)
+                           ->  Seq Scan on compress_hyper_6_20_chunk (actual rows=1 loops=1)
                      ->  Seq Scan on _hyper_2_7_chunk (actual rows=504 loops=1)
                      ->  Seq Scan on _hyper_2_8_chunk (actual rows=1512 loops=1)
                      ->  Seq Scan on _hyper_2_9_chunk (actual rows=504 loops=1)
                      ->  Custom Scan (DecompressChunk) on _hyper_2_10_chunk (actual rows=504 loops=1)
-                           ->  Seq Scan on compress_hyper_6_20_chunk (actual rows=1 loops=1)
+                           ->  Seq Scan on compress_hyper_6_24_chunk (actual rows=1 loops=1)
                      ->  Custom Scan (DecompressChunk) on _hyper_2_11_chunk (actual rows=1512 loops=1)
-                           ->  Seq Scan on compress_hyper_6_21_chunk (actual rows=3 loops=1)
+                           ->  Seq Scan on compress_hyper_6_25_chunk (actual rows=3 loops=1)
                      ->  Seq Scan on _hyper_2_12_chunk (actual rows=504 loops=1)
 (22 rows)
 
@@ -5967,7 +5967,7 @@ ORDER BY v1;
                                  Sort Key: _hyper_2_4_chunk."time"
                                  Sort Method: quicksort 
                                  ->  Custom Scan (DecompressChunk) on _hyper_2_4_chunk (actual rows=360 loops=1)
-                                       ->  Seq Scan on compress_hyper_6_17_chunk (actual rows=1 loops=1)
+                                       ->  Seq Scan on compress_hyper_6_18_chunk (actual rows=1 loops=1)
                      ->  Sort (actual rows=1080 loops=1)
                            Sort Key: _hyper_2_5_chunk."time"
                            Sort Method: quicksort 
@@ -5975,7 +5975,7 @@ ORDER BY v1;
                                  Sort Key: _hyper_2_5_chunk."time"
                                  Sort Method: quicksort 
                                  ->  Custom Scan (DecompressChunk) on _hyper_2_5_chunk (actual rows=1080 loops=1)
-                                       ->  Seq Scan on compress_hyper_6_18_chunk (actual rows=3 loops=1)
+                                       ->  Seq Scan on compress_hyper_6_19_chunk (actual rows=3 loops=1)
                      ->  Sort (actual rows=360 loops=1)
                            Sort Key: _hyper_2_6_chunk."time"
                            Sort Method: quicksort 
@@ -5983,7 +5983,7 @@ ORDER BY v1;
                                  Sort Key: _hyper_2_6_chunk."time"
                                  Sort Method: quicksort 
                                  ->  Custom Scan (DecompressChunk) on _hyper_2_6_chunk (actual rows=360 loops=1)
-                                       ->  Seq Scan on compress_hyper_6_19_chunk (actual rows=1 loops=1)
+                                       ->  Seq Scan on compress_hyper_6_20_chunk (actual rows=1 loops=1)
                ->  Merge Append (actual rows=2520 loops=1)
                      Sort Key: _hyper_2_7_chunk."time"
                      ->  Index Scan Backward using _hyper_2_7_chunk_metrics_space_time_idx on _hyper_2_7_chunk (actual rows=504 loops=1)
@@ -5998,7 +5998,7 @@ ORDER BY v1;
                                  Sort Key: _hyper_2_10_chunk."time"
                                  Sort Method: quicksort 
                                  ->  Custom Scan (DecompressChunk) on _hyper_2_10_chunk (actual rows=504 loops=1)
-                                       ->  Seq Scan on compress_hyper_6_20_chunk (actual rows=1 loops=1)
+                                       ->  Seq Scan on compress_hyper_6_24_chunk (actual rows=1 loops=1)
                      ->  Sort (actual rows=1512 loops=1)
                            Sort Key: _hyper_2_11_chunk."time"
                            Sort Method: quicksort 
@@ -6006,7 +6006,7 @@ ORDER BY v1;
                                  Sort Key: _hyper_2_11_chunk."time"
                                  Sort Method: quicksort 
                                  ->  Custom Scan (DecompressChunk) on _hyper_2_11_chunk (actual rows=1512 loops=1)
-                                       ->  Seq Scan on compress_hyper_6_21_chunk (actual rows=3 loops=1)
+                                       ->  Seq Scan on compress_hyper_6_25_chunk (actual rows=3 loops=1)
                      ->  Index Scan Backward using _hyper_2_12_chunk_metrics_space_time_idx on _hyper_2_12_chunk (actual rows=504 loops=1)
 (56 rows)
 
@@ -6039,7 +6039,7 @@ ORDER BY q1.time;
                Sort Key: _hyper_2_4_chunk."time"
                Sort Method: quicksort 
                ->  Custom Scan (DecompressChunk) on _hyper_2_4_chunk (actual rows=360 loops=1)
-                     ->  Seq Scan on compress_hyper_6_17_chunk (actual rows=1 loops=1)
+                     ->  Seq Scan on compress_hyper_6_18_chunk (actual rows=1 loops=1)
                            Filter: (device_id = 1)
          ->  Index Scan Backward using _hyper_2_7_chunk_metrics_space_time_idx on _hyper_2_7_chunk (actual rows=504 loops=1)
                Filter: (device_id = 1)
@@ -6047,7 +6047,7 @@ ORDER BY q1.time;
                Sort Key: _hyper_2_10_chunk."time"
                Sort Method: quicksort 
                ->  Custom Scan (DecompressChunk) on _hyper_2_10_chunk (actual rows=504 loops=1)
-                     ->  Seq Scan on compress_hyper_6_20_chunk (actual rows=1 loops=1)
+                     ->  Seq Scan on compress_hyper_6_24_chunk (actual rows=1 loops=1)
                            Filter: (device_id = 1)
    ->  Materialize (actual rows=1368 loops=1)
          ->  Custom Scan (ChunkAppend) on metrics_space metrics_space_1 (actual rows=1368 loops=1)
@@ -6056,7 +6056,7 @@ ORDER BY q1.time;
                      Sort Key: _hyper_2_5_chunk."time"
                      Sort Method: quicksort 
                      ->  Custom Scan (DecompressChunk) on _hyper_2_5_chunk (actual rows=360 loops=1)
-                           ->  Seq Scan on compress_hyper_6_18_chunk (actual rows=1 loops=1)
+                           ->  Seq Scan on compress_hyper_6_19_chunk (actual rows=1 loops=1)
                                  Filter: (device_id = 2)
                                  Rows Removed by Filter: 2
                ->  Index Scan Backward using _hyper_2_8_chunk_metrics_space_device_id_time_idx on _hyper_2_8_chunk (actual rows=504 loops=1)
@@ -6065,7 +6065,7 @@ ORDER BY q1.time;
                      Sort Key: _hyper_2_11_chunk."time"
                      Sort Method: quicksort 
                      ->  Custom Scan (DecompressChunk) on _hyper_2_11_chunk (actual rows=504 loops=1)
-                           ->  Seq Scan on compress_hyper_6_21_chunk (actual rows=1 loops=1)
+                           ->  Seq Scan on compress_hyper_6_25_chunk (actual rows=1 loops=1)
                                  Filter: (device_id = 2)
                                  Rows Removed by Filter: 2
 (37 rows)
@@ -6081,12 +6081,12 @@ WHERE device_id = 1;
  Aggregate (actual rows=1 loops=1)
    ->  Append (actual rows=1368 loops=1)
          ->  Custom Scan (DecompressChunk) on _hyper_2_4_chunk (actual rows=360 loops=1)
-               ->  Seq Scan on compress_hyper_6_17_chunk (actual rows=1 loops=1)
+               ->  Seq Scan on compress_hyper_6_18_chunk (actual rows=1 loops=1)
                      Filter: (device_id = 1)
          ->  Seq Scan on _hyper_2_7_chunk (actual rows=504 loops=1)
                Filter: (device_id = 1)
          ->  Custom Scan (DecompressChunk) on _hyper_2_10_chunk (actual rows=504 loops=1)
-               ->  Seq Scan on compress_hyper_6_20_chunk (actual rows=1 loops=1)
+               ->  Seq Scan on compress_hyper_6_24_chunk (actual rows=1 loops=1)
                      Filter: (device_id = 1)
 (10 rows)
 
@@ -6150,9 +6150,9 @@ ORDER BY device_id,
          ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_4_chunk (actual rows=360 loops=1)
                Output: _hyper_2_4_chunk."time", _hyper_2_4_chunk.device_id
                Bulk Decompression: true
-               ->  Index Scan using compress_hyper_6_17_chunk_c_space_index_2 on _timescaledb_internal.compress_hyper_6_17_chunk (actual rows=1 loops=1)
-                     Output: compress_hyper_6_17_chunk."time", compress_hyper_6_17_chunk.device_id, compress_hyper_6_17_chunk.device_id_peer, compress_hyper_6_17_chunk.v0, compress_hyper_6_17_chunk.v1, compress_hyper_6_17_chunk.v2, compress_hyper_6_17_chunk.v3, compress_hyper_6_17_chunk._ts_meta_count, compress_hyper_6_17_chunk._ts_meta_sequence_num, compress_hyper_6_17_chunk._ts_meta_min_3, compress_hyper_6_17_chunk._ts_meta_max_3, compress_hyper_6_17_chunk._ts_meta_min_1, compress_hyper_6_17_chunk._ts_meta_max_1, compress_hyper_6_17_chunk._ts_meta_min_2, compress_hyper_6_17_chunk._ts_meta_max_2
-                     Index Cond: (compress_hyper_6_17_chunk.device_id = 1)
+               ->  Index Scan using compress_hyper_6_18_chunk_c_space_index_2 on _timescaledb_internal.compress_hyper_6_18_chunk (actual rows=1 loops=1)
+                     Output: compress_hyper_6_18_chunk."time", compress_hyper_6_18_chunk.device_id, compress_hyper_6_18_chunk.device_id_peer, compress_hyper_6_18_chunk.v0, compress_hyper_6_18_chunk.v1, compress_hyper_6_18_chunk.v2, compress_hyper_6_18_chunk.v3, compress_hyper_6_18_chunk._ts_meta_count, compress_hyper_6_18_chunk._ts_meta_sequence_num, compress_hyper_6_18_chunk._ts_meta_min_3, compress_hyper_6_18_chunk._ts_meta_max_3, compress_hyper_6_18_chunk._ts_meta_min_1, compress_hyper_6_18_chunk._ts_meta_max_1, compress_hyper_6_18_chunk._ts_meta_min_2, compress_hyper_6_18_chunk._ts_meta_max_2
+                     Index Cond: (compress_hyper_6_18_chunk.device_id = 1)
    ->  Index Scan Backward using _hyper_2_7_chunk_metrics_space_time_idx on _timescaledb_internal._hyper_2_7_chunk (actual rows=504 loops=1)
          Output: _hyper_2_7_chunk."time", _hyper_2_7_chunk.device_id
          Filter: (_hyper_2_7_chunk.device_id = 1)
@@ -6163,9 +6163,9 @@ ORDER BY device_id,
          ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_10_chunk (actual rows=504 loops=1)
                Output: _hyper_2_10_chunk."time", _hyper_2_10_chunk.device_id
                Bulk Decompression: true
-               ->  Index Scan using compress_hyper_6_20_chunk_c_space_index_2 on _timescaledb_internal.compress_hyper_6_20_chunk (actual rows=1 loops=1)
-                     Output: compress_hyper_6_20_chunk."time", compress_hyper_6_20_chunk.device_id, compress_hyper_6_20_chunk.device_id_peer, compress_hyper_6_20_chunk.v0, compress_hyper_6_20_chunk.v1, compress_hyper_6_20_chunk.v2, compress_hyper_6_20_chunk.v3, compress_hyper_6_20_chunk._ts_meta_count, compress_hyper_6_20_chunk._ts_meta_sequence_num, compress_hyper_6_20_chunk._ts_meta_min_3, compress_hyper_6_20_chunk._ts_meta_max_3, compress_hyper_6_20_chunk._ts_meta_min_1, compress_hyper_6_20_chunk._ts_meta_max_1, compress_hyper_6_20_chunk._ts_meta_min_2, compress_hyper_6_20_chunk._ts_meta_max_2
-                     Index Cond: (compress_hyper_6_20_chunk.device_id = 1)
+               ->  Index Scan using compress_hyper_6_24_chunk_c_space_index_2 on _timescaledb_internal.compress_hyper_6_24_chunk (actual rows=1 loops=1)
+                     Output: compress_hyper_6_24_chunk."time", compress_hyper_6_24_chunk.device_id, compress_hyper_6_24_chunk.device_id_peer, compress_hyper_6_24_chunk.v0, compress_hyper_6_24_chunk.v1, compress_hyper_6_24_chunk.v2, compress_hyper_6_24_chunk.v3, compress_hyper_6_24_chunk._ts_meta_count, compress_hyper_6_24_chunk._ts_meta_sequence_num, compress_hyper_6_24_chunk._ts_meta_min_3, compress_hyper_6_24_chunk._ts_meta_max_3, compress_hyper_6_24_chunk._ts_meta_min_1, compress_hyper_6_24_chunk._ts_meta_max_1, compress_hyper_6_24_chunk._ts_meta_min_2, compress_hyper_6_24_chunk._ts_meta_max_2
+                     Index Cond: (compress_hyper_6_24_chunk.device_id = 1)
 (25 rows)
 
 -- globs should not plan IndexOnlyScans
@@ -6186,9 +6186,9 @@ ORDER BY device_id,
          ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_4_chunk (actual rows=360 loops=1)
                Output: _hyper_2_4_chunk."time", _hyper_2_4_chunk.device_id, _hyper_2_4_chunk.device_id_peer, _hyper_2_4_chunk.v0, _hyper_2_4_chunk.v1, _hyper_2_4_chunk.v2, _hyper_2_4_chunk.v3
                Bulk Decompression: true
-               ->  Index Scan using compress_hyper_6_17_chunk_c_space_index_2 on _timescaledb_internal.compress_hyper_6_17_chunk (actual rows=1 loops=1)
-                     Output: compress_hyper_6_17_chunk."time", compress_hyper_6_17_chunk.device_id, compress_hyper_6_17_chunk.device_id_peer, compress_hyper_6_17_chunk.v0, compress_hyper_6_17_chunk.v1, compress_hyper_6_17_chunk.v2, compress_hyper_6_17_chunk.v3, compress_hyper_6_17_chunk._ts_meta_count, compress_hyper_6_17_chunk._ts_meta_sequence_num, compress_hyper_6_17_chunk._ts_meta_min_3, compress_hyper_6_17_chunk._ts_meta_max_3, compress_hyper_6_17_chunk._ts_meta_min_1, compress_hyper_6_17_chunk._ts_meta_max_1, compress_hyper_6_17_chunk._ts_meta_min_2, compress_hyper_6_17_chunk._ts_meta_max_2
-                     Index Cond: (compress_hyper_6_17_chunk.device_id = 1)
+               ->  Index Scan using compress_hyper_6_18_chunk_c_space_index_2 on _timescaledb_internal.compress_hyper_6_18_chunk (actual rows=1 loops=1)
+                     Output: compress_hyper_6_18_chunk."time", compress_hyper_6_18_chunk.device_id, compress_hyper_6_18_chunk.device_id_peer, compress_hyper_6_18_chunk.v0, compress_hyper_6_18_chunk.v1, compress_hyper_6_18_chunk.v2, compress_hyper_6_18_chunk.v3, compress_hyper_6_18_chunk._ts_meta_count, compress_hyper_6_18_chunk._ts_meta_sequence_num, compress_hyper_6_18_chunk._ts_meta_min_3, compress_hyper_6_18_chunk._ts_meta_max_3, compress_hyper_6_18_chunk._ts_meta_min_1, compress_hyper_6_18_chunk._ts_meta_max_1, compress_hyper_6_18_chunk._ts_meta_min_2, compress_hyper_6_18_chunk._ts_meta_max_2
+                     Index Cond: (compress_hyper_6_18_chunk.device_id = 1)
    ->  Index Scan Backward using _hyper_2_7_chunk_metrics_space_time_idx on _timescaledb_internal._hyper_2_7_chunk (actual rows=504 loops=1)
          Output: _hyper_2_7_chunk."time", _hyper_2_7_chunk.device_id, _hyper_2_7_chunk.device_id_peer, _hyper_2_7_chunk.v0, _hyper_2_7_chunk.v1, _hyper_2_7_chunk.v2, _hyper_2_7_chunk.v3
          Filter: (_hyper_2_7_chunk.device_id = 1)
@@ -6199,9 +6199,9 @@ ORDER BY device_id,
          ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_10_chunk (actual rows=504 loops=1)
                Output: _hyper_2_10_chunk."time", _hyper_2_10_chunk.device_id, _hyper_2_10_chunk.device_id_peer, _hyper_2_10_chunk.v0, _hyper_2_10_chunk.v1, _hyper_2_10_chunk.v2, _hyper_2_10_chunk.v3
                Bulk Decompression: true
-               ->  Index Scan using compress_hyper_6_20_chunk_c_space_index_2 on _timescaledb_internal.compress_hyper_6_20_chunk (actual rows=1 loops=1)
-                     Output: compress_hyper_6_20_chunk."time", compress_hyper_6_20_chunk.device_id, compress_hyper_6_20_chunk.device_id_peer, compress_hyper_6_20_chunk.v0, compress_hyper_6_20_chunk.v1, compress_hyper_6_20_chunk.v2, compress_hyper_6_20_chunk.v3, compress_hyper_6_20_chunk._ts_meta_count, compress_hyper_6_20_chunk._ts_meta_sequence_num, compress_hyper_6_20_chunk._ts_meta_min_3, compress_hyper_6_20_chunk._ts_meta_max_3, compress_hyper_6_20_chunk._ts_meta_min_1, compress_hyper_6_20_chunk._ts_meta_max_1, compress_hyper_6_20_chunk._ts_meta_min_2, compress_hyper_6_20_chunk._ts_meta_max_2
-                     Index Cond: (compress_hyper_6_20_chunk.device_id = 1)
+               ->  Index Scan using compress_hyper_6_24_chunk_c_space_index_2 on _timescaledb_internal.compress_hyper_6_24_chunk (actual rows=1 loops=1)
+                     Output: compress_hyper_6_24_chunk."time", compress_hyper_6_24_chunk.device_id, compress_hyper_6_24_chunk.device_id_peer, compress_hyper_6_24_chunk.v0, compress_hyper_6_24_chunk.v1, compress_hyper_6_24_chunk.v2, compress_hyper_6_24_chunk.v3, compress_hyper_6_24_chunk._ts_meta_count, compress_hyper_6_24_chunk._ts_meta_sequence_num, compress_hyper_6_24_chunk._ts_meta_min_3, compress_hyper_6_24_chunk._ts_meta_max_3, compress_hyper_6_24_chunk._ts_meta_min_1, compress_hyper_6_24_chunk._ts_meta_max_1, compress_hyper_6_24_chunk._ts_meta_min_2, compress_hyper_6_24_chunk._ts_meta_max_2
+                     Index Cond: (compress_hyper_6_24_chunk.device_id = 1)
 (25 rows)
 
 -- whole row reference should work
@@ -6222,9 +6222,9 @@ ORDER BY device_id,
          ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_4_chunk test_table_1 (actual rows=360 loops=1)
                Output: test_table_1.*, test_table_1.device_id, test_table_1."time"
                Bulk Decompression: true
-               ->  Index Scan using compress_hyper_6_17_chunk_c_space_index_2 on _timescaledb_internal.compress_hyper_6_17_chunk (actual rows=1 loops=1)
-                     Output: compress_hyper_6_17_chunk."time", compress_hyper_6_17_chunk.device_id, compress_hyper_6_17_chunk.device_id_peer, compress_hyper_6_17_chunk.v0, compress_hyper_6_17_chunk.v1, compress_hyper_6_17_chunk.v2, compress_hyper_6_17_chunk.v3, compress_hyper_6_17_chunk._ts_meta_count, compress_hyper_6_17_chunk._ts_meta_sequence_num, compress_hyper_6_17_chunk._ts_meta_min_3, compress_hyper_6_17_chunk._ts_meta_max_3, compress_hyper_6_17_chunk._ts_meta_min_1, compress_hyper_6_17_chunk._ts_meta_max_1, compress_hyper_6_17_chunk._ts_meta_min_2, compress_hyper_6_17_chunk._ts_meta_max_2
-                     Index Cond: (compress_hyper_6_17_chunk.device_id = 1)
+               ->  Index Scan using compress_hyper_6_18_chunk_c_space_index_2 on _timescaledb_internal.compress_hyper_6_18_chunk (actual rows=1 loops=1)
+                     Output: compress_hyper_6_18_chunk."time", compress_hyper_6_18_chunk.device_id, compress_hyper_6_18_chunk.device_id_peer, compress_hyper_6_18_chunk.v0, compress_hyper_6_18_chunk.v1, compress_hyper_6_18_chunk.v2, compress_hyper_6_18_chunk.v3, compress_hyper_6_18_chunk._ts_meta_count, compress_hyper_6_18_chunk._ts_meta_sequence_num, compress_hyper_6_18_chunk._ts_meta_min_3, compress_hyper_6_18_chunk._ts_meta_max_3, compress_hyper_6_18_chunk._ts_meta_min_1, compress_hyper_6_18_chunk._ts_meta_max_1, compress_hyper_6_18_chunk._ts_meta_min_2, compress_hyper_6_18_chunk._ts_meta_max_2
+                     Index Cond: (compress_hyper_6_18_chunk.device_id = 1)
    ->  Index Scan Backward using _hyper_2_7_chunk_metrics_space_time_idx on _timescaledb_internal._hyper_2_7_chunk test_table_2 (actual rows=504 loops=1)
          Output: test_table_2.*, test_table_2.device_id, test_table_2."time"
          Filter: (test_table_2.device_id = 1)
@@ -6235,9 +6235,9 @@ ORDER BY device_id,
          ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_10_chunk test_table_3 (actual rows=504 loops=1)
                Output: test_table_3.*, test_table_3.device_id, test_table_3."time"
                Bulk Decompression: true
-               ->  Index Scan using compress_hyper_6_20_chunk_c_space_index_2 on _timescaledb_internal.compress_hyper_6_20_chunk (actual rows=1 loops=1)
-                     Output: compress_hyper_6_20_chunk."time", compress_hyper_6_20_chunk.device_id, compress_hyper_6_20_chunk.device_id_peer, compress_hyper_6_20_chunk.v0, compress_hyper_6_20_chunk.v1, compress_hyper_6_20_chunk.v2, compress_hyper_6_20_chunk.v3, compress_hyper_6_20_chunk._ts_meta_count, compress_hyper_6_20_chunk._ts_meta_sequence_num, compress_hyper_6_20_chunk._ts_meta_min_3, compress_hyper_6_20_chunk._ts_meta_max_3, compress_hyper_6_20_chunk._ts_meta_min_1, compress_hyper_6_20_chunk._ts_meta_max_1, compress_hyper_6_20_chunk._ts_meta_min_2, compress_hyper_6_20_chunk._ts_meta_max_2
-                     Index Cond: (compress_hyper_6_20_chunk.device_id = 1)
+               ->  Index Scan using compress_hyper_6_24_chunk_c_space_index_2 on _timescaledb_internal.compress_hyper_6_24_chunk (actual rows=1 loops=1)
+                     Output: compress_hyper_6_24_chunk."time", compress_hyper_6_24_chunk.device_id, compress_hyper_6_24_chunk.device_id_peer, compress_hyper_6_24_chunk.v0, compress_hyper_6_24_chunk.v1, compress_hyper_6_24_chunk.v2, compress_hyper_6_24_chunk.v3, compress_hyper_6_24_chunk._ts_meta_count, compress_hyper_6_24_chunk._ts_meta_sequence_num, compress_hyper_6_24_chunk._ts_meta_min_3, compress_hyper_6_24_chunk._ts_meta_max_3, compress_hyper_6_24_chunk._ts_meta_min_1, compress_hyper_6_24_chunk._ts_meta_max_1, compress_hyper_6_24_chunk._ts_meta_min_2, compress_hyper_6_24_chunk._ts_meta_max_2
+                     Index Cond: (compress_hyper_6_24_chunk.device_id = 1)
 (25 rows)
 
 -- even when we select only a segmentby column, we still need count
@@ -6252,9 +6252,9 @@ ORDER BY device_id;
    ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_4_chunk (actual rows=360 loops=1)
          Output: _hyper_2_4_chunk.device_id
          Bulk Decompression: false
-         ->  Index Only Scan using compress_hyper_6_17_chunk_c_space_index_2 on _timescaledb_internal.compress_hyper_6_17_chunk (actual rows=1 loops=1)
-               Output: compress_hyper_6_17_chunk.device_id, compress_hyper_6_17_chunk._ts_meta_count
-               Index Cond: (compress_hyper_6_17_chunk.device_id = 1)
+         ->  Index Only Scan using compress_hyper_6_18_chunk_c_space_index_2 on _timescaledb_internal.compress_hyper_6_18_chunk (actual rows=1 loops=1)
+               Output: compress_hyper_6_18_chunk.device_id, compress_hyper_6_18_chunk._ts_meta_count
+               Index Cond: (compress_hyper_6_18_chunk.device_id = 1)
                Heap Fetches: 1
    ->  Index Only Scan using _hyper_2_7_chunk_metrics_space_device_id_device_id_peer_v0_v1_2 on _timescaledb_internal._hyper_2_7_chunk (actual rows=504 loops=1)
          Output: _hyper_2_7_chunk.device_id
@@ -6263,9 +6263,9 @@ ORDER BY device_id;
    ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_10_chunk (actual rows=504 loops=1)
          Output: _hyper_2_10_chunk.device_id
          Bulk Decompression: false
-         ->  Index Only Scan using compress_hyper_6_20_chunk_c_space_index_2 on _timescaledb_internal.compress_hyper_6_20_chunk (actual rows=1 loops=1)
-               Output: compress_hyper_6_20_chunk.device_id, compress_hyper_6_20_chunk._ts_meta_count
-               Index Cond: (compress_hyper_6_20_chunk.device_id = 1)
+         ->  Index Only Scan using compress_hyper_6_24_chunk_c_space_index_2 on _timescaledb_internal.compress_hyper_6_24_chunk (actual rows=1 loops=1)
+               Output: compress_hyper_6_24_chunk.device_id, compress_hyper_6_24_chunk._ts_meta_count
+               Index Cond: (compress_hyper_6_24_chunk.device_id = 1)
                Heap Fetches: 1
 (19 rows)
 
@@ -6280,18 +6280,18 @@ WHERE device_id = 1;
    ->  Append (actual rows=1368 loops=1)
          ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_4_chunk (actual rows=360 loops=1)
                Bulk Decompression: false
-               ->  Index Only Scan using compress_hyper_6_17_chunk_c_space_index_2 on _timescaledb_internal.compress_hyper_6_17_chunk (actual rows=1 loops=1)
-                     Output: compress_hyper_6_17_chunk.device_id, compress_hyper_6_17_chunk._ts_meta_count
-                     Index Cond: (compress_hyper_6_17_chunk.device_id = 1)
+               ->  Index Only Scan using compress_hyper_6_18_chunk_c_space_index_2 on _timescaledb_internal.compress_hyper_6_18_chunk (actual rows=1 loops=1)
+                     Output: compress_hyper_6_18_chunk.device_id, compress_hyper_6_18_chunk._ts_meta_count
+                     Index Cond: (compress_hyper_6_18_chunk.device_id = 1)
                      Heap Fetches: 1
          ->  Index Only Scan using _hyper_2_7_chunk_metrics_space_device_id_device_id_peer_v0_v1_2 on _timescaledb_internal._hyper_2_7_chunk (actual rows=504 loops=1)
                Index Cond: (_hyper_2_7_chunk.device_id = 1)
                Heap Fetches: 504
          ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_10_chunk (actual rows=504 loops=1)
                Bulk Decompression: false
-               ->  Index Only Scan using compress_hyper_6_20_chunk_c_space_index_2 on _timescaledb_internal.compress_hyper_6_20_chunk (actual rows=1 loops=1)
-                     Output: compress_hyper_6_20_chunk.device_id, compress_hyper_6_20_chunk._ts_meta_count
-                     Index Cond: (compress_hyper_6_20_chunk.device_id = 1)
+               ->  Index Only Scan using compress_hyper_6_24_chunk_c_space_index_2 on _timescaledb_internal.compress_hyper_6_24_chunk (actual rows=1 loops=1)
+                     Output: compress_hyper_6_24_chunk.device_id, compress_hyper_6_24_chunk._ts_meta_count
+                     Index Cond: (compress_hyper_6_24_chunk.device_id = 1)
                      Heap Fetches: 1
 (18 rows)
 
@@ -6308,20 +6308,20 @@ ORDER BY device_id;
    ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_4_chunk (actual rows=360 loops=1)
          Output: _hyper_2_4_chunk.device_id
          Bulk Decompression: false
-         ->  Index Only Scan using compress_hyper_6_17_chunk_c_space_index_2 on _timescaledb_internal.compress_hyper_6_17_chunk (actual rows=1 loops=1)
-               Output: compress_hyper_6_17_chunk.device_id, compress_hyper_6_17_chunk._ts_meta_count
+         ->  Index Only Scan using compress_hyper_6_18_chunk_c_space_index_2 on _timescaledb_internal.compress_hyper_6_18_chunk (actual rows=1 loops=1)
+               Output: compress_hyper_6_18_chunk.device_id, compress_hyper_6_18_chunk._ts_meta_count
                Heap Fetches: 1
    ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_5_chunk (actual rows=1080 loops=1)
          Output: _hyper_2_5_chunk.device_id
          Bulk Decompression: false
-         ->  Index Only Scan using compress_hyper_6_18_chunk_c_space_index_2 on _timescaledb_internal.compress_hyper_6_18_chunk (actual rows=3 loops=1)
-               Output: compress_hyper_6_18_chunk.device_id, compress_hyper_6_18_chunk._ts_meta_count
+         ->  Index Only Scan using compress_hyper_6_19_chunk_c_space_index_2 on _timescaledb_internal.compress_hyper_6_19_chunk (actual rows=3 loops=1)
+               Output: compress_hyper_6_19_chunk.device_id, compress_hyper_6_19_chunk._ts_meta_count
                Heap Fetches: 3
    ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_6_chunk (actual rows=360 loops=1)
          Output: _hyper_2_6_chunk.device_id
          Bulk Decompression: false
-         ->  Index Only Scan using compress_hyper_6_19_chunk_c_space_index_2 on _timescaledb_internal.compress_hyper_6_19_chunk (actual rows=1 loops=1)
-               Output: compress_hyper_6_19_chunk.device_id, compress_hyper_6_19_chunk._ts_meta_count
+         ->  Index Only Scan using compress_hyper_6_20_chunk_c_space_index_2 on _timescaledb_internal.compress_hyper_6_20_chunk (actual rows=1 loops=1)
+               Output: compress_hyper_6_20_chunk.device_id, compress_hyper_6_20_chunk._ts_meta_count
                Heap Fetches: 1
    ->  Index Only Scan using _hyper_2_7_chunk_tmp_idx on _timescaledb_internal._hyper_2_7_chunk (actual rows=504 loops=1)
          Output: _hyper_2_7_chunk.device_id
@@ -6335,14 +6335,14 @@ ORDER BY device_id;
    ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_10_chunk (actual rows=504 loops=1)
          Output: _hyper_2_10_chunk.device_id
          Bulk Decompression: false
-         ->  Index Only Scan using compress_hyper_6_20_chunk_c_space_index_2 on _timescaledb_internal.compress_hyper_6_20_chunk (actual rows=1 loops=1)
-               Output: compress_hyper_6_20_chunk.device_id, compress_hyper_6_20_chunk._ts_meta_count
+         ->  Index Only Scan using compress_hyper_6_24_chunk_c_space_index_2 on _timescaledb_internal.compress_hyper_6_24_chunk (actual rows=1 loops=1)
+               Output: compress_hyper_6_24_chunk.device_id, compress_hyper_6_24_chunk._ts_meta_count
                Heap Fetches: 1
    ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_11_chunk (actual rows=1512 loops=1)
          Output: _hyper_2_11_chunk.device_id
          Bulk Decompression: false
-         ->  Index Only Scan using compress_hyper_6_21_chunk_c_space_index_2 on _timescaledb_internal.compress_hyper_6_21_chunk (actual rows=3 loops=1)
-               Output: compress_hyper_6_21_chunk.device_id, compress_hyper_6_21_chunk._ts_meta_count
+         ->  Index Only Scan using compress_hyper_6_25_chunk_c_space_index_2 on _timescaledb_internal.compress_hyper_6_25_chunk (actual rows=3 loops=1)
+               Output: compress_hyper_6_25_chunk.device_id, compress_hyper_6_25_chunk._ts_meta_count
                Heap Fetches: 3
    ->  Index Only Scan using _hyper_2_12_chunk_tmp_idx on _timescaledb_internal._hyper_2_12_chunk (actual rows=504 loops=1)
          Output: _hyper_2_12_chunk.device_id
@@ -6368,9 +6368,9 @@ ORDER BY device_id_peer,
          ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_4_chunk (actual rows=0 loops=1)
                Output: _hyper_2_4_chunk."time", _hyper_2_4_chunk.device_id, _hyper_2_4_chunk.device_id_peer, _hyper_2_4_chunk.v0, _hyper_2_4_chunk.v1, _hyper_2_4_chunk.v2, _hyper_2_4_chunk.v3
                Bulk Decompression: true
-               ->  Index Scan using compress_hyper_6_17_chunk__compressed_hypertable_6_device_id_pe on _timescaledb_internal.compress_hyper_6_17_chunk (actual rows=0 loops=1)
-                     Output: compress_hyper_6_17_chunk."time", compress_hyper_6_17_chunk.device_id, compress_hyper_6_17_chunk.device_id_peer, compress_hyper_6_17_chunk.v0, compress_hyper_6_17_chunk.v1, compress_hyper_6_17_chunk.v2, compress_hyper_6_17_chunk.v3, compress_hyper_6_17_chunk._ts_meta_count, compress_hyper_6_17_chunk._ts_meta_sequence_num, compress_hyper_6_17_chunk._ts_meta_min_3, compress_hyper_6_17_chunk._ts_meta_max_3, compress_hyper_6_17_chunk._ts_meta_min_1, compress_hyper_6_17_chunk._ts_meta_max_1, compress_hyper_6_17_chunk._ts_meta_min_2, compress_hyper_6_17_chunk._ts_meta_max_2
-                     Index Cond: (compress_hyper_6_17_chunk.device_id_peer = 1)
+               ->  Index Scan using compress_hyper_6_18_chunk__compressed_hypertable_6_device_id_pe on _timescaledb_internal.compress_hyper_6_18_chunk (actual rows=0 loops=1)
+                     Output: compress_hyper_6_18_chunk."time", compress_hyper_6_18_chunk.device_id, compress_hyper_6_18_chunk.device_id_peer, compress_hyper_6_18_chunk.v0, compress_hyper_6_18_chunk.v1, compress_hyper_6_18_chunk.v2, compress_hyper_6_18_chunk.v3, compress_hyper_6_18_chunk._ts_meta_count, compress_hyper_6_18_chunk._ts_meta_sequence_num, compress_hyper_6_18_chunk._ts_meta_min_3, compress_hyper_6_18_chunk._ts_meta_max_3, compress_hyper_6_18_chunk._ts_meta_min_1, compress_hyper_6_18_chunk._ts_meta_max_1, compress_hyper_6_18_chunk._ts_meta_min_2, compress_hyper_6_18_chunk._ts_meta_max_2
+                     Index Cond: (compress_hyper_6_18_chunk.device_id_peer = 1)
    ->  Sort (actual rows=0 loops=1)
          Output: _hyper_2_5_chunk."time", _hyper_2_5_chunk.device_id, _hyper_2_5_chunk.device_id_peer, _hyper_2_5_chunk.v0, _hyper_2_5_chunk.v1, _hyper_2_5_chunk.v2, _hyper_2_5_chunk.v3
          Sort Key: _hyper_2_5_chunk."time"
@@ -6378,9 +6378,9 @@ ORDER BY device_id_peer,
          ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_5_chunk (actual rows=0 loops=1)
                Output: _hyper_2_5_chunk."time", _hyper_2_5_chunk.device_id, _hyper_2_5_chunk.device_id_peer, _hyper_2_5_chunk.v0, _hyper_2_5_chunk.v1, _hyper_2_5_chunk.v2, _hyper_2_5_chunk.v3
                Bulk Decompression: true
-               ->  Index Scan using compress_hyper_6_18_chunk__compressed_hypertable_6_device_id_pe on _timescaledb_internal.compress_hyper_6_18_chunk (actual rows=0 loops=1)
-                     Output: compress_hyper_6_18_chunk."time", compress_hyper_6_18_chunk.device_id, compress_hyper_6_18_chunk.device_id_peer, compress_hyper_6_18_chunk.v0, compress_hyper_6_18_chunk.v1, compress_hyper_6_18_chunk.v2, compress_hyper_6_18_chunk.v3, compress_hyper_6_18_chunk._ts_meta_count, compress_hyper_6_18_chunk._ts_meta_sequence_num, compress_hyper_6_18_chunk._ts_meta_min_3, compress_hyper_6_18_chunk._ts_meta_max_3, compress_hyper_6_18_chunk._ts_meta_min_1, compress_hyper_6_18_chunk._ts_meta_max_1, compress_hyper_6_18_chunk._ts_meta_min_2, compress_hyper_6_18_chunk._ts_meta_max_2
-                     Index Cond: (compress_hyper_6_18_chunk.device_id_peer = 1)
+               ->  Index Scan using compress_hyper_6_19_chunk__compressed_hypertable_6_device_id_pe on _timescaledb_internal.compress_hyper_6_19_chunk (actual rows=0 loops=1)
+                     Output: compress_hyper_6_19_chunk."time", compress_hyper_6_19_chunk.device_id, compress_hyper_6_19_chunk.device_id_peer, compress_hyper_6_19_chunk.v0, compress_hyper_6_19_chunk.v1, compress_hyper_6_19_chunk.v2, compress_hyper_6_19_chunk.v3, compress_hyper_6_19_chunk._ts_meta_count, compress_hyper_6_19_chunk._ts_meta_sequence_num, compress_hyper_6_19_chunk._ts_meta_min_3, compress_hyper_6_19_chunk._ts_meta_max_3, compress_hyper_6_19_chunk._ts_meta_min_1, compress_hyper_6_19_chunk._ts_meta_max_1, compress_hyper_6_19_chunk._ts_meta_min_2, compress_hyper_6_19_chunk._ts_meta_max_2
+                     Index Cond: (compress_hyper_6_19_chunk.device_id_peer = 1)
    ->  Sort (actual rows=0 loops=1)
          Output: _hyper_2_6_chunk."time", _hyper_2_6_chunk.device_id, _hyper_2_6_chunk.device_id_peer, _hyper_2_6_chunk.v0, _hyper_2_6_chunk.v1, _hyper_2_6_chunk.v2, _hyper_2_6_chunk.v3
          Sort Key: _hyper_2_6_chunk."time"
@@ -6388,9 +6388,9 @@ ORDER BY device_id_peer,
          ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_6_chunk (actual rows=0 loops=1)
                Output: _hyper_2_6_chunk."time", _hyper_2_6_chunk.device_id, _hyper_2_6_chunk.device_id_peer, _hyper_2_6_chunk.v0, _hyper_2_6_chunk.v1, _hyper_2_6_chunk.v2, _hyper_2_6_chunk.v3
                Bulk Decompression: true
-               ->  Index Scan using compress_hyper_6_19_chunk__compressed_hypertable_6_device_id_pe on _timescaledb_internal.compress_hyper_6_19_chunk (actual rows=0 loops=1)
-                     Output: compress_hyper_6_19_chunk."time", compress_hyper_6_19_chunk.device_id, compress_hyper_6_19_chunk.device_id_peer, compress_hyper_6_19_chunk.v0, compress_hyper_6_19_chunk.v1, compress_hyper_6_19_chunk.v2, compress_hyper_6_19_chunk.v3, compress_hyper_6_19_chunk._ts_meta_count, compress_hyper_6_19_chunk._ts_meta_sequence_num, compress_hyper_6_19_chunk._ts_meta_min_3, compress_hyper_6_19_chunk._ts_meta_max_3, compress_hyper_6_19_chunk._ts_meta_min_1, compress_hyper_6_19_chunk._ts_meta_max_1, compress_hyper_6_19_chunk._ts_meta_min_2, compress_hyper_6_19_chunk._ts_meta_max_2
-                     Index Cond: (compress_hyper_6_19_chunk.device_id_peer = 1)
+               ->  Index Scan using compress_hyper_6_20_chunk__compressed_hypertable_6_device_id_pe on _timescaledb_internal.compress_hyper_6_20_chunk (actual rows=0 loops=1)
+                     Output: compress_hyper_6_20_chunk."time", compress_hyper_6_20_chunk.device_id, compress_hyper_6_20_chunk.device_id_peer, compress_hyper_6_20_chunk.v0, compress_hyper_6_20_chunk.v1, compress_hyper_6_20_chunk.v2, compress_hyper_6_20_chunk.v3, compress_hyper_6_20_chunk._ts_meta_count, compress_hyper_6_20_chunk._ts_meta_sequence_num, compress_hyper_6_20_chunk._ts_meta_min_3, compress_hyper_6_20_chunk._ts_meta_max_3, compress_hyper_6_20_chunk._ts_meta_min_1, compress_hyper_6_20_chunk._ts_meta_max_1, compress_hyper_6_20_chunk._ts_meta_min_2, compress_hyper_6_20_chunk._ts_meta_max_2
+                     Index Cond: (compress_hyper_6_20_chunk.device_id_peer = 1)
    ->  Index Scan Backward using _hyper_2_7_chunk_metrics_space_time_idx on _timescaledb_internal._hyper_2_7_chunk (actual rows=0 loops=1)
          Output: _hyper_2_7_chunk."time", _hyper_2_7_chunk.device_id, _hyper_2_7_chunk.device_id_peer, _hyper_2_7_chunk.v0, _hyper_2_7_chunk.v1, _hyper_2_7_chunk.v2, _hyper_2_7_chunk.v3
          Filter: (_hyper_2_7_chunk.device_id_peer = 1)
@@ -6410,9 +6410,9 @@ ORDER BY device_id_peer,
          ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_10_chunk (actual rows=0 loops=1)
                Output: _hyper_2_10_chunk."time", _hyper_2_10_chunk.device_id, _hyper_2_10_chunk.device_id_peer, _hyper_2_10_chunk.v0, _hyper_2_10_chunk.v1, _hyper_2_10_chunk.v2, _hyper_2_10_chunk.v3
                Bulk Decompression: true
-               ->  Index Scan using compress_hyper_6_20_chunk__compressed_hypertable_6_device_id_pe on _timescaledb_internal.compress_hyper_6_20_chunk (actual rows=0 loops=1)
-                     Output: compress_hyper_6_20_chunk."time", compress_hyper_6_20_chunk.device_id, compress_hyper_6_20_chunk.device_id_peer, compress_hyper_6_20_chunk.v0, compress_hyper_6_20_chunk.v1, compress_hyper_6_20_chunk.v2, compress_hyper_6_20_chunk.v3, compress_hyper_6_20_chunk._ts_meta_count, compress_hyper_6_20_chunk._ts_meta_sequence_num, compress_hyper_6_20_chunk._ts_meta_min_3, compress_hyper_6_20_chunk._ts_meta_max_3, compress_hyper_6_20_chunk._ts_meta_min_1, compress_hyper_6_20_chunk._ts_meta_max_1, compress_hyper_6_20_chunk._ts_meta_min_2, compress_hyper_6_20_chunk._ts_meta_max_2
-                     Index Cond: (compress_hyper_6_20_chunk.device_id_peer = 1)
+               ->  Index Scan using compress_hyper_6_24_chunk__compressed_hypertable_6_device_id_pe on _timescaledb_internal.compress_hyper_6_24_chunk (actual rows=0 loops=1)
+                     Output: compress_hyper_6_24_chunk."time", compress_hyper_6_24_chunk.device_id, compress_hyper_6_24_chunk.device_id_peer, compress_hyper_6_24_chunk.v0, compress_hyper_6_24_chunk.v1, compress_hyper_6_24_chunk.v2, compress_hyper_6_24_chunk.v3, compress_hyper_6_24_chunk._ts_meta_count, compress_hyper_6_24_chunk._ts_meta_sequence_num, compress_hyper_6_24_chunk._ts_meta_min_3, compress_hyper_6_24_chunk._ts_meta_max_3, compress_hyper_6_24_chunk._ts_meta_min_1, compress_hyper_6_24_chunk._ts_meta_max_1, compress_hyper_6_24_chunk._ts_meta_min_2, compress_hyper_6_24_chunk._ts_meta_max_2
+                     Index Cond: (compress_hyper_6_24_chunk.device_id_peer = 1)
    ->  Sort (actual rows=0 loops=1)
          Output: _hyper_2_11_chunk."time", _hyper_2_11_chunk.device_id, _hyper_2_11_chunk.device_id_peer, _hyper_2_11_chunk.v0, _hyper_2_11_chunk.v1, _hyper_2_11_chunk.v2, _hyper_2_11_chunk.v3
          Sort Key: _hyper_2_11_chunk."time"
@@ -6420,9 +6420,9 @@ ORDER BY device_id_peer,
          ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_11_chunk (actual rows=0 loops=1)
                Output: _hyper_2_11_chunk."time", _hyper_2_11_chunk.device_id, _hyper_2_11_chunk.device_id_peer, _hyper_2_11_chunk.v0, _hyper_2_11_chunk.v1, _hyper_2_11_chunk.v2, _hyper_2_11_chunk.v3
                Bulk Decompression: true
-               ->  Index Scan using compress_hyper_6_21_chunk__compressed_hypertable_6_device_id_pe on _timescaledb_internal.compress_hyper_6_21_chunk (actual rows=0 loops=1)
-                     Output: compress_hyper_6_21_chunk."time", compress_hyper_6_21_chunk.device_id, compress_hyper_6_21_chunk.device_id_peer, compress_hyper_6_21_chunk.v0, compress_hyper_6_21_chunk.v1, compress_hyper_6_21_chunk.v2, compress_hyper_6_21_chunk.v3, compress_hyper_6_21_chunk._ts_meta_count, compress_hyper_6_21_chunk._ts_meta_sequence_num, compress_hyper_6_21_chunk._ts_meta_min_3, compress_hyper_6_21_chunk._ts_meta_max_3, compress_hyper_6_21_chunk._ts_meta_min_1, compress_hyper_6_21_chunk._ts_meta_max_1, compress_hyper_6_21_chunk._ts_meta_min_2, compress_hyper_6_21_chunk._ts_meta_max_2
-                     Index Cond: (compress_hyper_6_21_chunk.device_id_peer = 1)
+               ->  Index Scan using compress_hyper_6_25_chunk__compressed_hypertable_6_device_id_pe on _timescaledb_internal.compress_hyper_6_25_chunk (actual rows=0 loops=1)
+                     Output: compress_hyper_6_25_chunk."time", compress_hyper_6_25_chunk.device_id, compress_hyper_6_25_chunk.device_id_peer, compress_hyper_6_25_chunk.v0, compress_hyper_6_25_chunk.v1, compress_hyper_6_25_chunk.v2, compress_hyper_6_25_chunk.v3, compress_hyper_6_25_chunk._ts_meta_count, compress_hyper_6_25_chunk._ts_meta_sequence_num, compress_hyper_6_25_chunk._ts_meta_min_3, compress_hyper_6_25_chunk._ts_meta_max_3, compress_hyper_6_25_chunk._ts_meta_min_1, compress_hyper_6_25_chunk._ts_meta_max_1, compress_hyper_6_25_chunk._ts_meta_min_2, compress_hyper_6_25_chunk._ts_meta_max_2
+                     Index Cond: (compress_hyper_6_25_chunk.device_id_peer = 1)
    ->  Index Scan Backward using _hyper_2_12_chunk_metrics_space_time_idx on _timescaledb_internal._hyper_2_12_chunk (actual rows=0 loops=1)
          Output: _hyper_2_12_chunk."time", _hyper_2_12_chunk.device_id, _hyper_2_12_chunk.device_id_peer, _hyper_2_12_chunk.v0, _hyper_2_12_chunk.v1, _hyper_2_12_chunk.v2, _hyper_2_12_chunk.v3
          Filter: (_hyper_2_12_chunk.device_id_peer = 1)
@@ -6440,21 +6440,21 @@ ORDER BY device_id_peer;
    ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_4_chunk (actual rows=0 loops=1)
          Output: _hyper_2_4_chunk.device_id_peer
          Bulk Decompression: false
-         ->  Index Scan using compress_hyper_6_17_chunk__compressed_hypertable_6_device_id_pe on _timescaledb_internal.compress_hyper_6_17_chunk (actual rows=0 loops=1)
-               Output: compress_hyper_6_17_chunk."time", compress_hyper_6_17_chunk.device_id, compress_hyper_6_17_chunk.device_id_peer, compress_hyper_6_17_chunk.v0, compress_hyper_6_17_chunk.v1, compress_hyper_6_17_chunk.v2, compress_hyper_6_17_chunk.v3, compress_hyper_6_17_chunk._ts_meta_count, compress_hyper_6_17_chunk._ts_meta_sequence_num, compress_hyper_6_17_chunk._ts_meta_min_3, compress_hyper_6_17_chunk._ts_meta_max_3, compress_hyper_6_17_chunk._ts_meta_min_1, compress_hyper_6_17_chunk._ts_meta_max_1, compress_hyper_6_17_chunk._ts_meta_min_2, compress_hyper_6_17_chunk._ts_meta_max_2
-               Index Cond: (compress_hyper_6_17_chunk.device_id_peer = 1)
-   ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_5_chunk (actual rows=0 loops=1)
-         Output: _hyper_2_5_chunk.device_id_peer
-         Bulk Decompression: false
          ->  Index Scan using compress_hyper_6_18_chunk__compressed_hypertable_6_device_id_pe on _timescaledb_internal.compress_hyper_6_18_chunk (actual rows=0 loops=1)
                Output: compress_hyper_6_18_chunk."time", compress_hyper_6_18_chunk.device_id, compress_hyper_6_18_chunk.device_id_peer, compress_hyper_6_18_chunk.v0, compress_hyper_6_18_chunk.v1, compress_hyper_6_18_chunk.v2, compress_hyper_6_18_chunk.v3, compress_hyper_6_18_chunk._ts_meta_count, compress_hyper_6_18_chunk._ts_meta_sequence_num, compress_hyper_6_18_chunk._ts_meta_min_3, compress_hyper_6_18_chunk._ts_meta_max_3, compress_hyper_6_18_chunk._ts_meta_min_1, compress_hyper_6_18_chunk._ts_meta_max_1, compress_hyper_6_18_chunk._ts_meta_min_2, compress_hyper_6_18_chunk._ts_meta_max_2
                Index Cond: (compress_hyper_6_18_chunk.device_id_peer = 1)
-   ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_6_chunk (actual rows=0 loops=1)
-         Output: _hyper_2_6_chunk.device_id_peer
+   ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_5_chunk (actual rows=0 loops=1)
+         Output: _hyper_2_5_chunk.device_id_peer
          Bulk Decompression: false
          ->  Index Scan using compress_hyper_6_19_chunk__compressed_hypertable_6_device_id_pe on _timescaledb_internal.compress_hyper_6_19_chunk (actual rows=0 loops=1)
                Output: compress_hyper_6_19_chunk."time", compress_hyper_6_19_chunk.device_id, compress_hyper_6_19_chunk.device_id_peer, compress_hyper_6_19_chunk.v0, compress_hyper_6_19_chunk.v1, compress_hyper_6_19_chunk.v2, compress_hyper_6_19_chunk.v3, compress_hyper_6_19_chunk._ts_meta_count, compress_hyper_6_19_chunk._ts_meta_sequence_num, compress_hyper_6_19_chunk._ts_meta_min_3, compress_hyper_6_19_chunk._ts_meta_max_3, compress_hyper_6_19_chunk._ts_meta_min_1, compress_hyper_6_19_chunk._ts_meta_max_1, compress_hyper_6_19_chunk._ts_meta_min_2, compress_hyper_6_19_chunk._ts_meta_max_2
                Index Cond: (compress_hyper_6_19_chunk.device_id_peer = 1)
+   ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_6_chunk (actual rows=0 loops=1)
+         Output: _hyper_2_6_chunk.device_id_peer
+         Bulk Decompression: false
+         ->  Index Scan using compress_hyper_6_20_chunk__compressed_hypertable_6_device_id_pe on _timescaledb_internal.compress_hyper_6_20_chunk (actual rows=0 loops=1)
+               Output: compress_hyper_6_20_chunk."time", compress_hyper_6_20_chunk.device_id, compress_hyper_6_20_chunk.device_id_peer, compress_hyper_6_20_chunk.v0, compress_hyper_6_20_chunk.v1, compress_hyper_6_20_chunk.v2, compress_hyper_6_20_chunk.v3, compress_hyper_6_20_chunk._ts_meta_count, compress_hyper_6_20_chunk._ts_meta_sequence_num, compress_hyper_6_20_chunk._ts_meta_min_3, compress_hyper_6_20_chunk._ts_meta_max_3, compress_hyper_6_20_chunk._ts_meta_min_1, compress_hyper_6_20_chunk._ts_meta_max_1, compress_hyper_6_20_chunk._ts_meta_min_2, compress_hyper_6_20_chunk._ts_meta_max_2
+               Index Cond: (compress_hyper_6_20_chunk.device_id_peer = 1)
    ->  Index Only Scan using _hyper_2_7_chunk_metrics_space_device_id_device_id_peer_v0_v1_2 on _timescaledb_internal._hyper_2_7_chunk (actual rows=0 loops=1)
          Output: _hyper_2_7_chunk.device_id_peer
          Index Cond: (_hyper_2_7_chunk.device_id_peer = 1)
@@ -6470,15 +6470,15 @@ ORDER BY device_id_peer;
    ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_10_chunk (actual rows=0 loops=1)
          Output: _hyper_2_10_chunk.device_id_peer
          Bulk Decompression: false
-         ->  Index Scan using compress_hyper_6_20_chunk__compressed_hypertable_6_device_id_pe on _timescaledb_internal.compress_hyper_6_20_chunk (actual rows=0 loops=1)
-               Output: compress_hyper_6_20_chunk."time", compress_hyper_6_20_chunk.device_id, compress_hyper_6_20_chunk.device_id_peer, compress_hyper_6_20_chunk.v0, compress_hyper_6_20_chunk.v1, compress_hyper_6_20_chunk.v2, compress_hyper_6_20_chunk.v3, compress_hyper_6_20_chunk._ts_meta_count, compress_hyper_6_20_chunk._ts_meta_sequence_num, compress_hyper_6_20_chunk._ts_meta_min_3, compress_hyper_6_20_chunk._ts_meta_max_3, compress_hyper_6_20_chunk._ts_meta_min_1, compress_hyper_6_20_chunk._ts_meta_max_1, compress_hyper_6_20_chunk._ts_meta_min_2, compress_hyper_6_20_chunk._ts_meta_max_2
-               Index Cond: (compress_hyper_6_20_chunk.device_id_peer = 1)
+         ->  Index Scan using compress_hyper_6_24_chunk__compressed_hypertable_6_device_id_pe on _timescaledb_internal.compress_hyper_6_24_chunk (actual rows=0 loops=1)
+               Output: compress_hyper_6_24_chunk."time", compress_hyper_6_24_chunk.device_id, compress_hyper_6_24_chunk.device_id_peer, compress_hyper_6_24_chunk.v0, compress_hyper_6_24_chunk.v1, compress_hyper_6_24_chunk.v2, compress_hyper_6_24_chunk.v3, compress_hyper_6_24_chunk._ts_meta_count, compress_hyper_6_24_chunk._ts_meta_sequence_num, compress_hyper_6_24_chunk._ts_meta_min_3, compress_hyper_6_24_chunk._ts_meta_max_3, compress_hyper_6_24_chunk._ts_meta_min_1, compress_hyper_6_24_chunk._ts_meta_max_1, compress_hyper_6_24_chunk._ts_meta_min_2, compress_hyper_6_24_chunk._ts_meta_max_2
+               Index Cond: (compress_hyper_6_24_chunk.device_id_peer = 1)
    ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_11_chunk (actual rows=0 loops=1)
          Output: _hyper_2_11_chunk.device_id_peer
          Bulk Decompression: false
-         ->  Index Scan using compress_hyper_6_21_chunk__compressed_hypertable_6_device_id_pe on _timescaledb_internal.compress_hyper_6_21_chunk (actual rows=0 loops=1)
-               Output: compress_hyper_6_21_chunk."time", compress_hyper_6_21_chunk.device_id, compress_hyper_6_21_chunk.device_id_peer, compress_hyper_6_21_chunk.v0, compress_hyper_6_21_chunk.v1, compress_hyper_6_21_chunk.v2, compress_hyper_6_21_chunk.v3, compress_hyper_6_21_chunk._ts_meta_count, compress_hyper_6_21_chunk._ts_meta_sequence_num, compress_hyper_6_21_chunk._ts_meta_min_3, compress_hyper_6_21_chunk._ts_meta_max_3, compress_hyper_6_21_chunk._ts_meta_min_1, compress_hyper_6_21_chunk._ts_meta_max_1, compress_hyper_6_21_chunk._ts_meta_min_2, compress_hyper_6_21_chunk._ts_meta_max_2
-               Index Cond: (compress_hyper_6_21_chunk.device_id_peer = 1)
+         ->  Index Scan using compress_hyper_6_25_chunk__compressed_hypertable_6_device_id_pe on _timescaledb_internal.compress_hyper_6_25_chunk (actual rows=0 loops=1)
+               Output: compress_hyper_6_25_chunk."time", compress_hyper_6_25_chunk.device_id, compress_hyper_6_25_chunk.device_id_peer, compress_hyper_6_25_chunk.v0, compress_hyper_6_25_chunk.v1, compress_hyper_6_25_chunk.v2, compress_hyper_6_25_chunk.v3, compress_hyper_6_25_chunk._ts_meta_count, compress_hyper_6_25_chunk._ts_meta_sequence_num, compress_hyper_6_25_chunk._ts_meta_min_3, compress_hyper_6_25_chunk._ts_meta_max_3, compress_hyper_6_25_chunk._ts_meta_min_1, compress_hyper_6_25_chunk._ts_meta_max_1, compress_hyper_6_25_chunk._ts_meta_min_2, compress_hyper_6_25_chunk._ts_meta_max_2
+               Index Cond: (compress_hyper_6_25_chunk.device_id_peer = 1)
    ->  Index Only Scan using _hyper_2_12_chunk_metrics_space_device_id_device_id_peer_v0_v_2 on _timescaledb_internal._hyper_2_12_chunk (actual rows=0 loops=1)
          Output: _hyper_2_12_chunk.device_id_peer
          Index Cond: (_hyper_2_12_chunk.device_id_peer = 1)
@@ -6499,23 +6499,23 @@ WHERE device_id_peer IN (
    ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_4_chunk (actual rows=0 loops=1)
          Output: _hyper_2_4_chunk.device_id_peer
          Bulk Decompression: false
-         ->  Seq Scan on _timescaledb_internal.compress_hyper_6_17_chunk (actual rows=0 loops=1)
-               Output: compress_hyper_6_17_chunk."time", compress_hyper_6_17_chunk.device_id, compress_hyper_6_17_chunk.device_id_peer, compress_hyper_6_17_chunk.v0, compress_hyper_6_17_chunk.v1, compress_hyper_6_17_chunk.v2, compress_hyper_6_17_chunk.v3, compress_hyper_6_17_chunk._ts_meta_count, compress_hyper_6_17_chunk._ts_meta_sequence_num, compress_hyper_6_17_chunk._ts_meta_min_3, compress_hyper_6_17_chunk._ts_meta_max_3, compress_hyper_6_17_chunk._ts_meta_min_1, compress_hyper_6_17_chunk._ts_meta_max_1, compress_hyper_6_17_chunk._ts_meta_min_2, compress_hyper_6_17_chunk._ts_meta_max_2
-               Filter: (compress_hyper_6_17_chunk.device_id_peer = 1)
+         ->  Seq Scan on _timescaledb_internal.compress_hyper_6_18_chunk (actual rows=0 loops=1)
+               Output: compress_hyper_6_18_chunk."time", compress_hyper_6_18_chunk.device_id, compress_hyper_6_18_chunk.device_id_peer, compress_hyper_6_18_chunk.v0, compress_hyper_6_18_chunk.v1, compress_hyper_6_18_chunk.v2, compress_hyper_6_18_chunk.v3, compress_hyper_6_18_chunk._ts_meta_count, compress_hyper_6_18_chunk._ts_meta_sequence_num, compress_hyper_6_18_chunk._ts_meta_min_3, compress_hyper_6_18_chunk._ts_meta_max_3, compress_hyper_6_18_chunk._ts_meta_min_1, compress_hyper_6_18_chunk._ts_meta_max_1, compress_hyper_6_18_chunk._ts_meta_min_2, compress_hyper_6_18_chunk._ts_meta_max_2
+               Filter: (compress_hyper_6_18_chunk.device_id_peer = 1)
                Rows Removed by Filter: 1
    ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_5_chunk (actual rows=0 loops=1)
          Output: _hyper_2_5_chunk.device_id_peer
          Bulk Decompression: false
-         ->  Seq Scan on _timescaledb_internal.compress_hyper_6_18_chunk (actual rows=0 loops=1)
-               Output: compress_hyper_6_18_chunk."time", compress_hyper_6_18_chunk.device_id, compress_hyper_6_18_chunk.device_id_peer, compress_hyper_6_18_chunk.v0, compress_hyper_6_18_chunk.v1, compress_hyper_6_18_chunk.v2, compress_hyper_6_18_chunk.v3, compress_hyper_6_18_chunk._ts_meta_count, compress_hyper_6_18_chunk._ts_meta_sequence_num, compress_hyper_6_18_chunk._ts_meta_min_3, compress_hyper_6_18_chunk._ts_meta_max_3, compress_hyper_6_18_chunk._ts_meta_min_1, compress_hyper_6_18_chunk._ts_meta_max_1, compress_hyper_6_18_chunk._ts_meta_min_2, compress_hyper_6_18_chunk._ts_meta_max_2
-               Filter: (compress_hyper_6_18_chunk.device_id_peer = 1)
+         ->  Seq Scan on _timescaledb_internal.compress_hyper_6_19_chunk (actual rows=0 loops=1)
+               Output: compress_hyper_6_19_chunk."time", compress_hyper_6_19_chunk.device_id, compress_hyper_6_19_chunk.device_id_peer, compress_hyper_6_19_chunk.v0, compress_hyper_6_19_chunk.v1, compress_hyper_6_19_chunk.v2, compress_hyper_6_19_chunk.v3, compress_hyper_6_19_chunk._ts_meta_count, compress_hyper_6_19_chunk._ts_meta_sequence_num, compress_hyper_6_19_chunk._ts_meta_min_3, compress_hyper_6_19_chunk._ts_meta_max_3, compress_hyper_6_19_chunk._ts_meta_min_1, compress_hyper_6_19_chunk._ts_meta_max_1, compress_hyper_6_19_chunk._ts_meta_min_2, compress_hyper_6_19_chunk._ts_meta_max_2
+               Filter: (compress_hyper_6_19_chunk.device_id_peer = 1)
                Rows Removed by Filter: 3
    ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_6_chunk (actual rows=0 loops=1)
          Output: _hyper_2_6_chunk.device_id_peer
          Bulk Decompression: false
-         ->  Seq Scan on _timescaledb_internal.compress_hyper_6_19_chunk (actual rows=0 loops=1)
-               Output: compress_hyper_6_19_chunk."time", compress_hyper_6_19_chunk.device_id, compress_hyper_6_19_chunk.device_id_peer, compress_hyper_6_19_chunk.v0, compress_hyper_6_19_chunk.v1, compress_hyper_6_19_chunk.v2, compress_hyper_6_19_chunk.v3, compress_hyper_6_19_chunk._ts_meta_count, compress_hyper_6_19_chunk._ts_meta_sequence_num, compress_hyper_6_19_chunk._ts_meta_min_3, compress_hyper_6_19_chunk._ts_meta_max_3, compress_hyper_6_19_chunk._ts_meta_min_1, compress_hyper_6_19_chunk._ts_meta_max_1, compress_hyper_6_19_chunk._ts_meta_min_2, compress_hyper_6_19_chunk._ts_meta_max_2
-               Filter: (compress_hyper_6_19_chunk.device_id_peer = 1)
+         ->  Seq Scan on _timescaledb_internal.compress_hyper_6_20_chunk (actual rows=0 loops=1)
+               Output: compress_hyper_6_20_chunk."time", compress_hyper_6_20_chunk.device_id, compress_hyper_6_20_chunk.device_id_peer, compress_hyper_6_20_chunk.v0, compress_hyper_6_20_chunk.v1, compress_hyper_6_20_chunk.v2, compress_hyper_6_20_chunk.v3, compress_hyper_6_20_chunk._ts_meta_count, compress_hyper_6_20_chunk._ts_meta_sequence_num, compress_hyper_6_20_chunk._ts_meta_min_3, compress_hyper_6_20_chunk._ts_meta_max_3, compress_hyper_6_20_chunk._ts_meta_min_1, compress_hyper_6_20_chunk._ts_meta_max_1, compress_hyper_6_20_chunk._ts_meta_min_2, compress_hyper_6_20_chunk._ts_meta_max_2
+               Filter: (compress_hyper_6_20_chunk.device_id_peer = 1)
                Rows Removed by Filter: 1
    ->  Index Only Scan using _hyper_2_7_chunk_metrics_space_device_id_device_id_peer_v0_v1_2 on _timescaledb_internal._hyper_2_7_chunk (actual rows=0 loops=1)
          Output: _hyper_2_7_chunk.device_id_peer
@@ -6532,16 +6532,16 @@ WHERE device_id_peer IN (
    ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_10_chunk (actual rows=0 loops=1)
          Output: _hyper_2_10_chunk.device_id_peer
          Bulk Decompression: false
-         ->  Seq Scan on _timescaledb_internal.compress_hyper_6_20_chunk (actual rows=0 loops=1)
-               Output: compress_hyper_6_20_chunk."time", compress_hyper_6_20_chunk.device_id, compress_hyper_6_20_chunk.device_id_peer, compress_hyper_6_20_chunk.v0, compress_hyper_6_20_chunk.v1, compress_hyper_6_20_chunk.v2, compress_hyper_6_20_chunk.v3, compress_hyper_6_20_chunk._ts_meta_count, compress_hyper_6_20_chunk._ts_meta_sequence_num, compress_hyper_6_20_chunk._ts_meta_min_3, compress_hyper_6_20_chunk._ts_meta_max_3, compress_hyper_6_20_chunk._ts_meta_min_1, compress_hyper_6_20_chunk._ts_meta_max_1, compress_hyper_6_20_chunk._ts_meta_min_2, compress_hyper_6_20_chunk._ts_meta_max_2
-               Filter: (compress_hyper_6_20_chunk.device_id_peer = 1)
+         ->  Seq Scan on _timescaledb_internal.compress_hyper_6_24_chunk (actual rows=0 loops=1)
+               Output: compress_hyper_6_24_chunk."time", compress_hyper_6_24_chunk.device_id, compress_hyper_6_24_chunk.device_id_peer, compress_hyper_6_24_chunk.v0, compress_hyper_6_24_chunk.v1, compress_hyper_6_24_chunk.v2, compress_hyper_6_24_chunk.v3, compress_hyper_6_24_chunk._ts_meta_count, compress_hyper_6_24_chunk._ts_meta_sequence_num, compress_hyper_6_24_chunk._ts_meta_min_3, compress_hyper_6_24_chunk._ts_meta_max_3, compress_hyper_6_24_chunk._ts_meta_min_1, compress_hyper_6_24_chunk._ts_meta_max_1, compress_hyper_6_24_chunk._ts_meta_min_2, compress_hyper_6_24_chunk._ts_meta_max_2
+               Filter: (compress_hyper_6_24_chunk.device_id_peer = 1)
                Rows Removed by Filter: 1
    ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_11_chunk (actual rows=0 loops=1)
          Output: _hyper_2_11_chunk.device_id_peer
          Bulk Decompression: false
-         ->  Seq Scan on _timescaledb_internal.compress_hyper_6_21_chunk (actual rows=0 loops=1)
-               Output: compress_hyper_6_21_chunk."time", compress_hyper_6_21_chunk.device_id, compress_hyper_6_21_chunk.device_id_peer, compress_hyper_6_21_chunk.v0, compress_hyper_6_21_chunk.v1, compress_hyper_6_21_chunk.v2, compress_hyper_6_21_chunk.v3, compress_hyper_6_21_chunk._ts_meta_count, compress_hyper_6_21_chunk._ts_meta_sequence_num, compress_hyper_6_21_chunk._ts_meta_min_3, compress_hyper_6_21_chunk._ts_meta_max_3, compress_hyper_6_21_chunk._ts_meta_min_1, compress_hyper_6_21_chunk._ts_meta_max_1, compress_hyper_6_21_chunk._ts_meta_min_2, compress_hyper_6_21_chunk._ts_meta_max_2
-               Filter: (compress_hyper_6_21_chunk.device_id_peer = 1)
+         ->  Seq Scan on _timescaledb_internal.compress_hyper_6_25_chunk (actual rows=0 loops=1)
+               Output: compress_hyper_6_25_chunk."time", compress_hyper_6_25_chunk.device_id, compress_hyper_6_25_chunk.device_id_peer, compress_hyper_6_25_chunk.v0, compress_hyper_6_25_chunk.v1, compress_hyper_6_25_chunk.v2, compress_hyper_6_25_chunk.v3, compress_hyper_6_25_chunk._ts_meta_count, compress_hyper_6_25_chunk._ts_meta_sequence_num, compress_hyper_6_25_chunk._ts_meta_min_3, compress_hyper_6_25_chunk._ts_meta_max_3, compress_hyper_6_25_chunk._ts_meta_min_1, compress_hyper_6_25_chunk._ts_meta_max_1, compress_hyper_6_25_chunk._ts_meta_min_2, compress_hyper_6_25_chunk._ts_meta_max_2
+               Filter: (compress_hyper_6_25_chunk.device_id_peer = 1)
                Rows Removed by Filter: 3
    ->  Index Only Scan using _hyper_2_12_chunk_metrics_space_device_id_device_id_peer_v0_v_2 on _timescaledb_internal._hyper_2_12_chunk (actual rows=0 loops=1)
          Output: _hyper_2_12_chunk.device_id_peer
@@ -6566,18 +6566,18 @@ WHERE device_id_peer IN (
          ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_4_chunk (actual rows=360 loops=1)
                Output: _hyper_2_4_chunk.device_id_peer
                Bulk Decompression: false
-               ->  Seq Scan on _timescaledb_internal.compress_hyper_6_17_chunk (actual rows=1 loops=1)
-                     Output: compress_hyper_6_17_chunk."time", compress_hyper_6_17_chunk.device_id, compress_hyper_6_17_chunk.device_id_peer, compress_hyper_6_17_chunk.v0, compress_hyper_6_17_chunk.v1, compress_hyper_6_17_chunk.v2, compress_hyper_6_17_chunk.v3, compress_hyper_6_17_chunk._ts_meta_count, compress_hyper_6_17_chunk._ts_meta_sequence_num, compress_hyper_6_17_chunk._ts_meta_min_3, compress_hyper_6_17_chunk._ts_meta_max_3, compress_hyper_6_17_chunk._ts_meta_min_1, compress_hyper_6_17_chunk._ts_meta_max_1, compress_hyper_6_17_chunk._ts_meta_min_2, compress_hyper_6_17_chunk._ts_meta_max_2
+               ->  Seq Scan on _timescaledb_internal.compress_hyper_6_18_chunk (actual rows=1 loops=1)
+                     Output: compress_hyper_6_18_chunk."time", compress_hyper_6_18_chunk.device_id, compress_hyper_6_18_chunk.device_id_peer, compress_hyper_6_18_chunk.v0, compress_hyper_6_18_chunk.v1, compress_hyper_6_18_chunk.v2, compress_hyper_6_18_chunk.v3, compress_hyper_6_18_chunk._ts_meta_count, compress_hyper_6_18_chunk._ts_meta_sequence_num, compress_hyper_6_18_chunk._ts_meta_min_3, compress_hyper_6_18_chunk._ts_meta_max_3, compress_hyper_6_18_chunk._ts_meta_min_1, compress_hyper_6_18_chunk._ts_meta_max_1, compress_hyper_6_18_chunk._ts_meta_min_2, compress_hyper_6_18_chunk._ts_meta_max_2
          ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_5_chunk (actual rows=1080 loops=1)
                Output: _hyper_2_5_chunk.device_id_peer
                Bulk Decompression: false
-               ->  Seq Scan on _timescaledb_internal.compress_hyper_6_18_chunk (actual rows=3 loops=1)
-                     Output: compress_hyper_6_18_chunk."time", compress_hyper_6_18_chunk.device_id, compress_hyper_6_18_chunk.device_id_peer, compress_hyper_6_18_chunk.v0, compress_hyper_6_18_chunk.v1, compress_hyper_6_18_chunk.v2, compress_hyper_6_18_chunk.v3, compress_hyper_6_18_chunk._ts_meta_count, compress_hyper_6_18_chunk._ts_meta_sequence_num, compress_hyper_6_18_chunk._ts_meta_min_3, compress_hyper_6_18_chunk._ts_meta_max_3, compress_hyper_6_18_chunk._ts_meta_min_1, compress_hyper_6_18_chunk._ts_meta_max_1, compress_hyper_6_18_chunk._ts_meta_min_2, compress_hyper_6_18_chunk._ts_meta_max_2
+               ->  Seq Scan on _timescaledb_internal.compress_hyper_6_19_chunk (actual rows=3 loops=1)
+                     Output: compress_hyper_6_19_chunk."time", compress_hyper_6_19_chunk.device_id, compress_hyper_6_19_chunk.device_id_peer, compress_hyper_6_19_chunk.v0, compress_hyper_6_19_chunk.v1, compress_hyper_6_19_chunk.v2, compress_hyper_6_19_chunk.v3, compress_hyper_6_19_chunk._ts_meta_count, compress_hyper_6_19_chunk._ts_meta_sequence_num, compress_hyper_6_19_chunk._ts_meta_min_3, compress_hyper_6_19_chunk._ts_meta_max_3, compress_hyper_6_19_chunk._ts_meta_min_1, compress_hyper_6_19_chunk._ts_meta_max_1, compress_hyper_6_19_chunk._ts_meta_min_2, compress_hyper_6_19_chunk._ts_meta_max_2
          ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_6_chunk (actual rows=360 loops=1)
                Output: _hyper_2_6_chunk.device_id_peer
                Bulk Decompression: false
-               ->  Seq Scan on _timescaledb_internal.compress_hyper_6_19_chunk (actual rows=1 loops=1)
-                     Output: compress_hyper_6_19_chunk."time", compress_hyper_6_19_chunk.device_id, compress_hyper_6_19_chunk.device_id_peer, compress_hyper_6_19_chunk.v0, compress_hyper_6_19_chunk.v1, compress_hyper_6_19_chunk.v2, compress_hyper_6_19_chunk.v3, compress_hyper_6_19_chunk._ts_meta_count, compress_hyper_6_19_chunk._ts_meta_sequence_num, compress_hyper_6_19_chunk._ts_meta_min_3, compress_hyper_6_19_chunk._ts_meta_max_3, compress_hyper_6_19_chunk._ts_meta_min_1, compress_hyper_6_19_chunk._ts_meta_max_1, compress_hyper_6_19_chunk._ts_meta_min_2, compress_hyper_6_19_chunk._ts_meta_max_2
+               ->  Seq Scan on _timescaledb_internal.compress_hyper_6_20_chunk (actual rows=1 loops=1)
+                     Output: compress_hyper_6_20_chunk."time", compress_hyper_6_20_chunk.device_id, compress_hyper_6_20_chunk.device_id_peer, compress_hyper_6_20_chunk.v0, compress_hyper_6_20_chunk.v1, compress_hyper_6_20_chunk.v2, compress_hyper_6_20_chunk.v3, compress_hyper_6_20_chunk._ts_meta_count, compress_hyper_6_20_chunk._ts_meta_sequence_num, compress_hyper_6_20_chunk._ts_meta_min_3, compress_hyper_6_20_chunk._ts_meta_max_3, compress_hyper_6_20_chunk._ts_meta_min_1, compress_hyper_6_20_chunk._ts_meta_max_1, compress_hyper_6_20_chunk._ts_meta_min_2, compress_hyper_6_20_chunk._ts_meta_max_2
          ->  Seq Scan on _timescaledb_internal._hyper_2_7_chunk (actual rows=504 loops=1)
                Output: _hyper_2_7_chunk.device_id_peer
          ->  Seq Scan on _timescaledb_internal._hyper_2_8_chunk (actual rows=1512 loops=1)
@@ -6587,13 +6587,13 @@ WHERE device_id_peer IN (
          ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_10_chunk (actual rows=504 loops=1)
                Output: _hyper_2_10_chunk.device_id_peer
                Bulk Decompression: false
-               ->  Seq Scan on _timescaledb_internal.compress_hyper_6_20_chunk (actual rows=1 loops=1)
-                     Output: compress_hyper_6_20_chunk."time", compress_hyper_6_20_chunk.device_id, compress_hyper_6_20_chunk.device_id_peer, compress_hyper_6_20_chunk.v0, compress_hyper_6_20_chunk.v1, compress_hyper_6_20_chunk.v2, compress_hyper_6_20_chunk.v3, compress_hyper_6_20_chunk._ts_meta_count, compress_hyper_6_20_chunk._ts_meta_sequence_num, compress_hyper_6_20_chunk._ts_meta_min_3, compress_hyper_6_20_chunk._ts_meta_max_3, compress_hyper_6_20_chunk._ts_meta_min_1, compress_hyper_6_20_chunk._ts_meta_max_1, compress_hyper_6_20_chunk._ts_meta_min_2, compress_hyper_6_20_chunk._ts_meta_max_2
+               ->  Seq Scan on _timescaledb_internal.compress_hyper_6_24_chunk (actual rows=1 loops=1)
+                     Output: compress_hyper_6_24_chunk."time", compress_hyper_6_24_chunk.device_id, compress_hyper_6_24_chunk.device_id_peer, compress_hyper_6_24_chunk.v0, compress_hyper_6_24_chunk.v1, compress_hyper_6_24_chunk.v2, compress_hyper_6_24_chunk.v3, compress_hyper_6_24_chunk._ts_meta_count, compress_hyper_6_24_chunk._ts_meta_sequence_num, compress_hyper_6_24_chunk._ts_meta_min_3, compress_hyper_6_24_chunk._ts_meta_max_3, compress_hyper_6_24_chunk._ts_meta_min_1, compress_hyper_6_24_chunk._ts_meta_max_1, compress_hyper_6_24_chunk._ts_meta_min_2, compress_hyper_6_24_chunk._ts_meta_max_2
          ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_11_chunk (actual rows=1512 loops=1)
                Output: _hyper_2_11_chunk.device_id_peer
                Bulk Decompression: false
-               ->  Seq Scan on _timescaledb_internal.compress_hyper_6_21_chunk (actual rows=3 loops=1)
-                     Output: compress_hyper_6_21_chunk."time", compress_hyper_6_21_chunk.device_id, compress_hyper_6_21_chunk.device_id_peer, compress_hyper_6_21_chunk.v0, compress_hyper_6_21_chunk.v1, compress_hyper_6_21_chunk.v2, compress_hyper_6_21_chunk.v3, compress_hyper_6_21_chunk._ts_meta_count, compress_hyper_6_21_chunk._ts_meta_sequence_num, compress_hyper_6_21_chunk._ts_meta_min_3, compress_hyper_6_21_chunk._ts_meta_max_3, compress_hyper_6_21_chunk._ts_meta_min_1, compress_hyper_6_21_chunk._ts_meta_max_1, compress_hyper_6_21_chunk._ts_meta_min_2, compress_hyper_6_21_chunk._ts_meta_max_2
+               ->  Seq Scan on _timescaledb_internal.compress_hyper_6_25_chunk (actual rows=3 loops=1)
+                     Output: compress_hyper_6_25_chunk."time", compress_hyper_6_25_chunk.device_id, compress_hyper_6_25_chunk.device_id_peer, compress_hyper_6_25_chunk.v0, compress_hyper_6_25_chunk.v1, compress_hyper_6_25_chunk.v2, compress_hyper_6_25_chunk.v3, compress_hyper_6_25_chunk._ts_meta_count, compress_hyper_6_25_chunk._ts_meta_sequence_num, compress_hyper_6_25_chunk._ts_meta_min_3, compress_hyper_6_25_chunk._ts_meta_max_3, compress_hyper_6_25_chunk._ts_meta_min_1, compress_hyper_6_25_chunk._ts_meta_max_1, compress_hyper_6_25_chunk._ts_meta_min_2, compress_hyper_6_25_chunk._ts_meta_max_2
          ->  Seq Scan on _timescaledb_internal._hyper_2_12_chunk (actual rows=504 loops=1)
                Output: _hyper_2_12_chunk.device_id_peer
    ->  Materialize (actual rows=2 loops=6840)
@@ -6614,18 +6614,18 @@ WHERE device_id IN (
    ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_4_chunk (actual rows=360 loops=1)
          Output: _hyper_2_4_chunk.device_id_peer
          Bulk Decompression: false
-         ->  Seq Scan on _timescaledb_internal.compress_hyper_6_17_chunk (actual rows=1 loops=1)
-               Output: compress_hyper_6_17_chunk."time", compress_hyper_6_17_chunk.device_id, compress_hyper_6_17_chunk.device_id_peer, compress_hyper_6_17_chunk.v0, compress_hyper_6_17_chunk.v1, compress_hyper_6_17_chunk.v2, compress_hyper_6_17_chunk.v3, compress_hyper_6_17_chunk._ts_meta_count, compress_hyper_6_17_chunk._ts_meta_sequence_num, compress_hyper_6_17_chunk._ts_meta_min_3, compress_hyper_6_17_chunk._ts_meta_max_3, compress_hyper_6_17_chunk._ts_meta_min_1, compress_hyper_6_17_chunk._ts_meta_max_1, compress_hyper_6_17_chunk._ts_meta_min_2, compress_hyper_6_17_chunk._ts_meta_max_2
-               Filter: (compress_hyper_6_17_chunk.device_id = 1)
+         ->  Seq Scan on _timescaledb_internal.compress_hyper_6_18_chunk (actual rows=1 loops=1)
+               Output: compress_hyper_6_18_chunk."time", compress_hyper_6_18_chunk.device_id, compress_hyper_6_18_chunk.device_id_peer, compress_hyper_6_18_chunk.v0, compress_hyper_6_18_chunk.v1, compress_hyper_6_18_chunk.v2, compress_hyper_6_18_chunk.v3, compress_hyper_6_18_chunk._ts_meta_count, compress_hyper_6_18_chunk._ts_meta_sequence_num, compress_hyper_6_18_chunk._ts_meta_min_3, compress_hyper_6_18_chunk._ts_meta_max_3, compress_hyper_6_18_chunk._ts_meta_min_1, compress_hyper_6_18_chunk._ts_meta_max_1, compress_hyper_6_18_chunk._ts_meta_min_2, compress_hyper_6_18_chunk._ts_meta_max_2
+               Filter: (compress_hyper_6_18_chunk.device_id = 1)
    ->  Seq Scan on _timescaledb_internal._hyper_2_7_chunk (actual rows=504 loops=1)
          Output: _hyper_2_7_chunk.device_id_peer
          Filter: (_hyper_2_7_chunk.device_id = 1)
    ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_10_chunk (actual rows=504 loops=1)
          Output: _hyper_2_10_chunk.device_id_peer
          Bulk Decompression: false
-         ->  Seq Scan on _timescaledb_internal.compress_hyper_6_20_chunk (actual rows=1 loops=1)
-               Output: compress_hyper_6_20_chunk."time", compress_hyper_6_20_chunk.device_id, compress_hyper_6_20_chunk.device_id_peer, compress_hyper_6_20_chunk.v0, compress_hyper_6_20_chunk.v1, compress_hyper_6_20_chunk.v2, compress_hyper_6_20_chunk.v3, compress_hyper_6_20_chunk._ts_meta_count, compress_hyper_6_20_chunk._ts_meta_sequence_num, compress_hyper_6_20_chunk._ts_meta_min_3, compress_hyper_6_20_chunk._ts_meta_max_3, compress_hyper_6_20_chunk._ts_meta_min_1, compress_hyper_6_20_chunk._ts_meta_max_1, compress_hyper_6_20_chunk._ts_meta_min_2, compress_hyper_6_20_chunk._ts_meta_max_2
-               Filter: (compress_hyper_6_20_chunk.device_id = 1)
+         ->  Seq Scan on _timescaledb_internal.compress_hyper_6_24_chunk (actual rows=1 loops=1)
+               Output: compress_hyper_6_24_chunk."time", compress_hyper_6_24_chunk.device_id, compress_hyper_6_24_chunk.device_id_peer, compress_hyper_6_24_chunk.v0, compress_hyper_6_24_chunk.v1, compress_hyper_6_24_chunk.v2, compress_hyper_6_24_chunk.v3, compress_hyper_6_24_chunk._ts_meta_count, compress_hyper_6_24_chunk._ts_meta_sequence_num, compress_hyper_6_24_chunk._ts_meta_min_3, compress_hyper_6_24_chunk._ts_meta_max_3, compress_hyper_6_24_chunk._ts_meta_min_1, compress_hyper_6_24_chunk._ts_meta_max_1, compress_hyper_6_24_chunk._ts_meta_min_2, compress_hyper_6_24_chunk._ts_meta_max_2
+               Filter: (compress_hyper_6_24_chunk.device_id = 1)
 (16 rows)
 
 --with multiple values can get a semi-join or nested loop depending on seq_page_cost.
@@ -6644,18 +6644,18 @@ WHERE device_id IN (
          ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_4_chunk (actual rows=360 loops=1)
                Output: _hyper_2_4_chunk.device_id_peer, _hyper_2_4_chunk.device_id
                Bulk Decompression: false
-               ->  Seq Scan on _timescaledb_internal.compress_hyper_6_17_chunk (actual rows=1 loops=1)
-                     Output: compress_hyper_6_17_chunk."time", compress_hyper_6_17_chunk.device_id, compress_hyper_6_17_chunk.device_id_peer, compress_hyper_6_17_chunk.v0, compress_hyper_6_17_chunk.v1, compress_hyper_6_17_chunk.v2, compress_hyper_6_17_chunk.v3, compress_hyper_6_17_chunk._ts_meta_count, compress_hyper_6_17_chunk._ts_meta_sequence_num, compress_hyper_6_17_chunk._ts_meta_min_3, compress_hyper_6_17_chunk._ts_meta_max_3, compress_hyper_6_17_chunk._ts_meta_min_1, compress_hyper_6_17_chunk._ts_meta_max_1, compress_hyper_6_17_chunk._ts_meta_min_2, compress_hyper_6_17_chunk._ts_meta_max_2
+               ->  Seq Scan on _timescaledb_internal.compress_hyper_6_18_chunk (actual rows=1 loops=1)
+                     Output: compress_hyper_6_18_chunk."time", compress_hyper_6_18_chunk.device_id, compress_hyper_6_18_chunk.device_id_peer, compress_hyper_6_18_chunk.v0, compress_hyper_6_18_chunk.v1, compress_hyper_6_18_chunk.v2, compress_hyper_6_18_chunk.v3, compress_hyper_6_18_chunk._ts_meta_count, compress_hyper_6_18_chunk._ts_meta_sequence_num, compress_hyper_6_18_chunk._ts_meta_min_3, compress_hyper_6_18_chunk._ts_meta_max_3, compress_hyper_6_18_chunk._ts_meta_min_1, compress_hyper_6_18_chunk._ts_meta_max_1, compress_hyper_6_18_chunk._ts_meta_min_2, compress_hyper_6_18_chunk._ts_meta_max_2
          ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_5_chunk (actual rows=1080 loops=1)
                Output: _hyper_2_5_chunk.device_id_peer, _hyper_2_5_chunk.device_id
                Bulk Decompression: false
-               ->  Seq Scan on _timescaledb_internal.compress_hyper_6_18_chunk (actual rows=3 loops=1)
-                     Output: compress_hyper_6_18_chunk."time", compress_hyper_6_18_chunk.device_id, compress_hyper_6_18_chunk.device_id_peer, compress_hyper_6_18_chunk.v0, compress_hyper_6_18_chunk.v1, compress_hyper_6_18_chunk.v2, compress_hyper_6_18_chunk.v3, compress_hyper_6_18_chunk._ts_meta_count, compress_hyper_6_18_chunk._ts_meta_sequence_num, compress_hyper_6_18_chunk._ts_meta_min_3, compress_hyper_6_18_chunk._ts_meta_max_3, compress_hyper_6_18_chunk._ts_meta_min_1, compress_hyper_6_18_chunk._ts_meta_max_1, compress_hyper_6_18_chunk._ts_meta_min_2, compress_hyper_6_18_chunk._ts_meta_max_2
+               ->  Seq Scan on _timescaledb_internal.compress_hyper_6_19_chunk (actual rows=3 loops=1)
+                     Output: compress_hyper_6_19_chunk."time", compress_hyper_6_19_chunk.device_id, compress_hyper_6_19_chunk.device_id_peer, compress_hyper_6_19_chunk.v0, compress_hyper_6_19_chunk.v1, compress_hyper_6_19_chunk.v2, compress_hyper_6_19_chunk.v3, compress_hyper_6_19_chunk._ts_meta_count, compress_hyper_6_19_chunk._ts_meta_sequence_num, compress_hyper_6_19_chunk._ts_meta_min_3, compress_hyper_6_19_chunk._ts_meta_max_3, compress_hyper_6_19_chunk._ts_meta_min_1, compress_hyper_6_19_chunk._ts_meta_max_1, compress_hyper_6_19_chunk._ts_meta_min_2, compress_hyper_6_19_chunk._ts_meta_max_2
          ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_6_chunk (actual rows=360 loops=1)
                Output: _hyper_2_6_chunk.device_id_peer, _hyper_2_6_chunk.device_id
                Bulk Decompression: false
-               ->  Seq Scan on _timescaledb_internal.compress_hyper_6_19_chunk (actual rows=1 loops=1)
-                     Output: compress_hyper_6_19_chunk."time", compress_hyper_6_19_chunk.device_id, compress_hyper_6_19_chunk.device_id_peer, compress_hyper_6_19_chunk.v0, compress_hyper_6_19_chunk.v1, compress_hyper_6_19_chunk.v2, compress_hyper_6_19_chunk.v3, compress_hyper_6_19_chunk._ts_meta_count, compress_hyper_6_19_chunk._ts_meta_sequence_num, compress_hyper_6_19_chunk._ts_meta_min_3, compress_hyper_6_19_chunk._ts_meta_max_3, compress_hyper_6_19_chunk._ts_meta_min_1, compress_hyper_6_19_chunk._ts_meta_max_1, compress_hyper_6_19_chunk._ts_meta_min_2, compress_hyper_6_19_chunk._ts_meta_max_2
+               ->  Seq Scan on _timescaledb_internal.compress_hyper_6_20_chunk (actual rows=1 loops=1)
+                     Output: compress_hyper_6_20_chunk."time", compress_hyper_6_20_chunk.device_id, compress_hyper_6_20_chunk.device_id_peer, compress_hyper_6_20_chunk.v0, compress_hyper_6_20_chunk.v1, compress_hyper_6_20_chunk.v2, compress_hyper_6_20_chunk.v3, compress_hyper_6_20_chunk._ts_meta_count, compress_hyper_6_20_chunk._ts_meta_sequence_num, compress_hyper_6_20_chunk._ts_meta_min_3, compress_hyper_6_20_chunk._ts_meta_max_3, compress_hyper_6_20_chunk._ts_meta_min_1, compress_hyper_6_20_chunk._ts_meta_max_1, compress_hyper_6_20_chunk._ts_meta_min_2, compress_hyper_6_20_chunk._ts_meta_max_2
          ->  Seq Scan on _timescaledb_internal._hyper_2_7_chunk (actual rows=504 loops=1)
                Output: _hyper_2_7_chunk.device_id_peer, _hyper_2_7_chunk.device_id
          ->  Seq Scan on _timescaledb_internal._hyper_2_8_chunk (actual rows=1512 loops=1)
@@ -6665,13 +6665,13 @@ WHERE device_id IN (
          ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_10_chunk (actual rows=504 loops=1)
                Output: _hyper_2_10_chunk.device_id_peer, _hyper_2_10_chunk.device_id
                Bulk Decompression: false
-               ->  Seq Scan on _timescaledb_internal.compress_hyper_6_20_chunk (actual rows=1 loops=1)
-                     Output: compress_hyper_6_20_chunk."time", compress_hyper_6_20_chunk.device_id, compress_hyper_6_20_chunk.device_id_peer, compress_hyper_6_20_chunk.v0, compress_hyper_6_20_chunk.v1, compress_hyper_6_20_chunk.v2, compress_hyper_6_20_chunk.v3, compress_hyper_6_20_chunk._ts_meta_count, compress_hyper_6_20_chunk._ts_meta_sequence_num, compress_hyper_6_20_chunk._ts_meta_min_3, compress_hyper_6_20_chunk._ts_meta_max_3, compress_hyper_6_20_chunk._ts_meta_min_1, compress_hyper_6_20_chunk._ts_meta_max_1, compress_hyper_6_20_chunk._ts_meta_min_2, compress_hyper_6_20_chunk._ts_meta_max_2
+               ->  Seq Scan on _timescaledb_internal.compress_hyper_6_24_chunk (actual rows=1 loops=1)
+                     Output: compress_hyper_6_24_chunk."time", compress_hyper_6_24_chunk.device_id, compress_hyper_6_24_chunk.device_id_peer, compress_hyper_6_24_chunk.v0, compress_hyper_6_24_chunk.v1, compress_hyper_6_24_chunk.v2, compress_hyper_6_24_chunk.v3, compress_hyper_6_24_chunk._ts_meta_count, compress_hyper_6_24_chunk._ts_meta_sequence_num, compress_hyper_6_24_chunk._ts_meta_min_3, compress_hyper_6_24_chunk._ts_meta_max_3, compress_hyper_6_24_chunk._ts_meta_min_1, compress_hyper_6_24_chunk._ts_meta_max_1, compress_hyper_6_24_chunk._ts_meta_min_2, compress_hyper_6_24_chunk._ts_meta_max_2
          ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_11_chunk (actual rows=1512 loops=1)
                Output: _hyper_2_11_chunk.device_id_peer, _hyper_2_11_chunk.device_id
                Bulk Decompression: false
-               ->  Seq Scan on _timescaledb_internal.compress_hyper_6_21_chunk (actual rows=3 loops=1)
-                     Output: compress_hyper_6_21_chunk."time", compress_hyper_6_21_chunk.device_id, compress_hyper_6_21_chunk.device_id_peer, compress_hyper_6_21_chunk.v0, compress_hyper_6_21_chunk.v1, compress_hyper_6_21_chunk.v2, compress_hyper_6_21_chunk.v3, compress_hyper_6_21_chunk._ts_meta_count, compress_hyper_6_21_chunk._ts_meta_sequence_num, compress_hyper_6_21_chunk._ts_meta_min_3, compress_hyper_6_21_chunk._ts_meta_max_3, compress_hyper_6_21_chunk._ts_meta_min_1, compress_hyper_6_21_chunk._ts_meta_max_1, compress_hyper_6_21_chunk._ts_meta_min_2, compress_hyper_6_21_chunk._ts_meta_max_2
+               ->  Seq Scan on _timescaledb_internal.compress_hyper_6_25_chunk (actual rows=3 loops=1)
+                     Output: compress_hyper_6_25_chunk."time", compress_hyper_6_25_chunk.device_id, compress_hyper_6_25_chunk.device_id_peer, compress_hyper_6_25_chunk.v0, compress_hyper_6_25_chunk.v1, compress_hyper_6_25_chunk.v2, compress_hyper_6_25_chunk.v3, compress_hyper_6_25_chunk._ts_meta_count, compress_hyper_6_25_chunk._ts_meta_sequence_num, compress_hyper_6_25_chunk._ts_meta_min_3, compress_hyper_6_25_chunk._ts_meta_max_3, compress_hyper_6_25_chunk._ts_meta_min_1, compress_hyper_6_25_chunk._ts_meta_max_1, compress_hyper_6_25_chunk._ts_meta_min_2, compress_hyper_6_25_chunk._ts_meta_max_2
          ->  Seq Scan on _timescaledb_internal._hyper_2_12_chunk (actual rows=504 loops=1)
                Output: _hyper_2_12_chunk.device_id_peer, _hyper_2_12_chunk.device_id
    ->  Hash (actual rows=2 loops=1)
@@ -6703,19 +6703,19 @@ WHERE device_id IN (
    ->  Append
          ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_4_chunk
                Output: _hyper_2_4_chunk.device_id_peer, _hyper_2_4_chunk.device_id
-               ->  Index Scan using compress_hyper_6_17_chunk_c_space_index_2 on _timescaledb_internal.compress_hyper_6_17_chunk
-                     Output: compress_hyper_6_17_chunk."time", compress_hyper_6_17_chunk.device_id, compress_hyper_6_17_chunk.device_id_peer, compress_hyper_6_17_chunk.v0, compress_hyper_6_17_chunk.v1, compress_hyper_6_17_chunk.v2, compress_hyper_6_17_chunk.v3, compress_hyper_6_17_chunk._ts_meta_count, compress_hyper_6_17_chunk._ts_meta_sequence_num, compress_hyper_6_17_chunk._ts_meta_min_3, compress_hyper_6_17_chunk._ts_meta_max_3, compress_hyper_6_17_chunk._ts_meta_min_1, compress_hyper_6_17_chunk._ts_meta_max_1, compress_hyper_6_17_chunk._ts_meta_min_2, compress_hyper_6_17_chunk._ts_meta_max_2
-                     Index Cond: (compress_hyper_6_17_chunk.device_id = "*VALUES*".column1)
-         ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_5_chunk
-               Output: _hyper_2_5_chunk.device_id_peer, _hyper_2_5_chunk.device_id
                ->  Index Scan using compress_hyper_6_18_chunk_c_space_index_2 on _timescaledb_internal.compress_hyper_6_18_chunk
                      Output: compress_hyper_6_18_chunk."time", compress_hyper_6_18_chunk.device_id, compress_hyper_6_18_chunk.device_id_peer, compress_hyper_6_18_chunk.v0, compress_hyper_6_18_chunk.v1, compress_hyper_6_18_chunk.v2, compress_hyper_6_18_chunk.v3, compress_hyper_6_18_chunk._ts_meta_count, compress_hyper_6_18_chunk._ts_meta_sequence_num, compress_hyper_6_18_chunk._ts_meta_min_3, compress_hyper_6_18_chunk._ts_meta_max_3, compress_hyper_6_18_chunk._ts_meta_min_1, compress_hyper_6_18_chunk._ts_meta_max_1, compress_hyper_6_18_chunk._ts_meta_min_2, compress_hyper_6_18_chunk._ts_meta_max_2
                      Index Cond: (compress_hyper_6_18_chunk.device_id = "*VALUES*".column1)
-         ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_6_chunk
-               Output: _hyper_2_6_chunk.device_id_peer, _hyper_2_6_chunk.device_id
+         ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_5_chunk
+               Output: _hyper_2_5_chunk.device_id_peer, _hyper_2_5_chunk.device_id
                ->  Index Scan using compress_hyper_6_19_chunk_c_space_index_2 on _timescaledb_internal.compress_hyper_6_19_chunk
                      Output: compress_hyper_6_19_chunk."time", compress_hyper_6_19_chunk.device_id, compress_hyper_6_19_chunk.device_id_peer, compress_hyper_6_19_chunk.v0, compress_hyper_6_19_chunk.v1, compress_hyper_6_19_chunk.v2, compress_hyper_6_19_chunk.v3, compress_hyper_6_19_chunk._ts_meta_count, compress_hyper_6_19_chunk._ts_meta_sequence_num, compress_hyper_6_19_chunk._ts_meta_min_3, compress_hyper_6_19_chunk._ts_meta_max_3, compress_hyper_6_19_chunk._ts_meta_min_1, compress_hyper_6_19_chunk._ts_meta_max_1, compress_hyper_6_19_chunk._ts_meta_min_2, compress_hyper_6_19_chunk._ts_meta_max_2
                      Index Cond: (compress_hyper_6_19_chunk.device_id = "*VALUES*".column1)
+         ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_6_chunk
+               Output: _hyper_2_6_chunk.device_id_peer, _hyper_2_6_chunk.device_id
+               ->  Index Scan using compress_hyper_6_20_chunk_c_space_index_2 on _timescaledb_internal.compress_hyper_6_20_chunk
+                     Output: compress_hyper_6_20_chunk."time", compress_hyper_6_20_chunk.device_id, compress_hyper_6_20_chunk.device_id_peer, compress_hyper_6_20_chunk.v0, compress_hyper_6_20_chunk.v1, compress_hyper_6_20_chunk.v2, compress_hyper_6_20_chunk.v3, compress_hyper_6_20_chunk._ts_meta_count, compress_hyper_6_20_chunk._ts_meta_sequence_num, compress_hyper_6_20_chunk._ts_meta_min_3, compress_hyper_6_20_chunk._ts_meta_max_3, compress_hyper_6_20_chunk._ts_meta_min_1, compress_hyper_6_20_chunk._ts_meta_max_1, compress_hyper_6_20_chunk._ts_meta_min_2, compress_hyper_6_20_chunk._ts_meta_max_2
+                     Index Cond: (compress_hyper_6_20_chunk.device_id = "*VALUES*".column1)
          ->  Index Only Scan using _hyper_2_7_chunk_metrics_space_device_id_device_id_peer_v0_v1_2 on _timescaledb_internal._hyper_2_7_chunk
                Output: _hyper_2_7_chunk.device_id_peer, _hyper_2_7_chunk.device_id
                Index Cond: (_hyper_2_7_chunk.device_id = "*VALUES*".column1)
@@ -6727,14 +6727,14 @@ WHERE device_id IN (
                Index Cond: (_hyper_2_9_chunk.device_id = "*VALUES*".column1)
          ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_10_chunk
                Output: _hyper_2_10_chunk.device_id_peer, _hyper_2_10_chunk.device_id
-               ->  Index Scan using compress_hyper_6_20_chunk_c_space_index_2 on _timescaledb_internal.compress_hyper_6_20_chunk
-                     Output: compress_hyper_6_20_chunk."time", compress_hyper_6_20_chunk.device_id, compress_hyper_6_20_chunk.device_id_peer, compress_hyper_6_20_chunk.v0, compress_hyper_6_20_chunk.v1, compress_hyper_6_20_chunk.v2, compress_hyper_6_20_chunk.v3, compress_hyper_6_20_chunk._ts_meta_count, compress_hyper_6_20_chunk._ts_meta_sequence_num, compress_hyper_6_20_chunk._ts_meta_min_3, compress_hyper_6_20_chunk._ts_meta_max_3, compress_hyper_6_20_chunk._ts_meta_min_1, compress_hyper_6_20_chunk._ts_meta_max_1, compress_hyper_6_20_chunk._ts_meta_min_2, compress_hyper_6_20_chunk._ts_meta_max_2
-                     Index Cond: (compress_hyper_6_20_chunk.device_id = "*VALUES*".column1)
+               ->  Index Scan using compress_hyper_6_24_chunk_c_space_index_2 on _timescaledb_internal.compress_hyper_6_24_chunk
+                     Output: compress_hyper_6_24_chunk."time", compress_hyper_6_24_chunk.device_id, compress_hyper_6_24_chunk.device_id_peer, compress_hyper_6_24_chunk.v0, compress_hyper_6_24_chunk.v1, compress_hyper_6_24_chunk.v2, compress_hyper_6_24_chunk.v3, compress_hyper_6_24_chunk._ts_meta_count, compress_hyper_6_24_chunk._ts_meta_sequence_num, compress_hyper_6_24_chunk._ts_meta_min_3, compress_hyper_6_24_chunk._ts_meta_max_3, compress_hyper_6_24_chunk._ts_meta_min_1, compress_hyper_6_24_chunk._ts_meta_max_1, compress_hyper_6_24_chunk._ts_meta_min_2, compress_hyper_6_24_chunk._ts_meta_max_2
+                     Index Cond: (compress_hyper_6_24_chunk.device_id = "*VALUES*".column1)
          ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_11_chunk
                Output: _hyper_2_11_chunk.device_id_peer, _hyper_2_11_chunk.device_id
-               ->  Index Scan using compress_hyper_6_21_chunk_c_space_index_2 on _timescaledb_internal.compress_hyper_6_21_chunk
-                     Output: compress_hyper_6_21_chunk."time", compress_hyper_6_21_chunk.device_id, compress_hyper_6_21_chunk.device_id_peer, compress_hyper_6_21_chunk.v0, compress_hyper_6_21_chunk.v1, compress_hyper_6_21_chunk.v2, compress_hyper_6_21_chunk.v3, compress_hyper_6_21_chunk._ts_meta_count, compress_hyper_6_21_chunk._ts_meta_sequence_num, compress_hyper_6_21_chunk._ts_meta_min_3, compress_hyper_6_21_chunk._ts_meta_max_3, compress_hyper_6_21_chunk._ts_meta_min_1, compress_hyper_6_21_chunk._ts_meta_max_1, compress_hyper_6_21_chunk._ts_meta_min_2, compress_hyper_6_21_chunk._ts_meta_max_2
-                     Index Cond: (compress_hyper_6_21_chunk.device_id = "*VALUES*".column1)
+               ->  Index Scan using compress_hyper_6_25_chunk_c_space_index_2 on _timescaledb_internal.compress_hyper_6_25_chunk
+                     Output: compress_hyper_6_25_chunk."time", compress_hyper_6_25_chunk.device_id, compress_hyper_6_25_chunk.device_id_peer, compress_hyper_6_25_chunk.v0, compress_hyper_6_25_chunk.v1, compress_hyper_6_25_chunk.v2, compress_hyper_6_25_chunk.v3, compress_hyper_6_25_chunk._ts_meta_count, compress_hyper_6_25_chunk._ts_meta_sequence_num, compress_hyper_6_25_chunk._ts_meta_min_3, compress_hyper_6_25_chunk._ts_meta_max_3, compress_hyper_6_25_chunk._ts_meta_min_1, compress_hyper_6_25_chunk._ts_meta_max_1, compress_hyper_6_25_chunk._ts_meta_min_2, compress_hyper_6_25_chunk._ts_meta_max_2
+                     Index Cond: (compress_hyper_6_25_chunk.device_id = "*VALUES*".column1)
          ->  Index Only Scan using _hyper_2_12_chunk_metrics_space_device_id_device_id_peer_v0_v_2 on _timescaledb_internal._hyper_2_12_chunk
                Output: _hyper_2_12_chunk.device_id_peer, _hyper_2_12_chunk.device_id
                Index Cond: (_hyper_2_12_chunk.device_id = "*VALUES*".column1)
@@ -6752,18 +6752,18 @@ WHERE device_id IN (
    ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_4_chunk (actual rows=360 loops=1)
          Output: _hyper_2_4_chunk.device_id_peer
          Bulk Decompression: false
-         ->  Seq Scan on _timescaledb_internal.compress_hyper_6_17_chunk (actual rows=1 loops=1)
-               Output: compress_hyper_6_17_chunk."time", compress_hyper_6_17_chunk.device_id, compress_hyper_6_17_chunk.device_id_peer, compress_hyper_6_17_chunk.v0, compress_hyper_6_17_chunk.v1, compress_hyper_6_17_chunk.v2, compress_hyper_6_17_chunk.v3, compress_hyper_6_17_chunk._ts_meta_count, compress_hyper_6_17_chunk._ts_meta_sequence_num, compress_hyper_6_17_chunk._ts_meta_min_3, compress_hyper_6_17_chunk._ts_meta_max_3, compress_hyper_6_17_chunk._ts_meta_min_1, compress_hyper_6_17_chunk._ts_meta_max_1, compress_hyper_6_17_chunk._ts_meta_min_2, compress_hyper_6_17_chunk._ts_meta_max_2
-               Filter: (compress_hyper_6_17_chunk.device_id = 1)
+         ->  Seq Scan on _timescaledb_internal.compress_hyper_6_18_chunk (actual rows=1 loops=1)
+               Output: compress_hyper_6_18_chunk."time", compress_hyper_6_18_chunk.device_id, compress_hyper_6_18_chunk.device_id_peer, compress_hyper_6_18_chunk.v0, compress_hyper_6_18_chunk.v1, compress_hyper_6_18_chunk.v2, compress_hyper_6_18_chunk.v3, compress_hyper_6_18_chunk._ts_meta_count, compress_hyper_6_18_chunk._ts_meta_sequence_num, compress_hyper_6_18_chunk._ts_meta_min_3, compress_hyper_6_18_chunk._ts_meta_max_3, compress_hyper_6_18_chunk._ts_meta_min_1, compress_hyper_6_18_chunk._ts_meta_max_1, compress_hyper_6_18_chunk._ts_meta_min_2, compress_hyper_6_18_chunk._ts_meta_max_2
+               Filter: (compress_hyper_6_18_chunk.device_id = 1)
    ->  Seq Scan on _timescaledb_internal._hyper_2_7_chunk (actual rows=504 loops=1)
          Output: _hyper_2_7_chunk.device_id_peer
          Filter: (_hyper_2_7_chunk.device_id = 1)
    ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_10_chunk (actual rows=504 loops=1)
          Output: _hyper_2_10_chunk.device_id_peer
          Bulk Decompression: false
-         ->  Seq Scan on _timescaledb_internal.compress_hyper_6_20_chunk (actual rows=1 loops=1)
-               Output: compress_hyper_6_20_chunk."time", compress_hyper_6_20_chunk.device_id, compress_hyper_6_20_chunk.device_id_peer, compress_hyper_6_20_chunk.v0, compress_hyper_6_20_chunk.v1, compress_hyper_6_20_chunk.v2, compress_hyper_6_20_chunk.v3, compress_hyper_6_20_chunk._ts_meta_count, compress_hyper_6_20_chunk._ts_meta_sequence_num, compress_hyper_6_20_chunk._ts_meta_min_3, compress_hyper_6_20_chunk._ts_meta_max_3, compress_hyper_6_20_chunk._ts_meta_min_1, compress_hyper_6_20_chunk._ts_meta_max_1, compress_hyper_6_20_chunk._ts_meta_min_2, compress_hyper_6_20_chunk._ts_meta_max_2
-               Filter: (compress_hyper_6_20_chunk.device_id = 1)
+         ->  Seq Scan on _timescaledb_internal.compress_hyper_6_24_chunk (actual rows=1 loops=1)
+               Output: compress_hyper_6_24_chunk."time", compress_hyper_6_24_chunk.device_id, compress_hyper_6_24_chunk.device_id_peer, compress_hyper_6_24_chunk.v0, compress_hyper_6_24_chunk.v1, compress_hyper_6_24_chunk.v2, compress_hyper_6_24_chunk.v3, compress_hyper_6_24_chunk._ts_meta_count, compress_hyper_6_24_chunk._ts_meta_sequence_num, compress_hyper_6_24_chunk._ts_meta_min_3, compress_hyper_6_24_chunk._ts_meta_max_3, compress_hyper_6_24_chunk._ts_meta_min_1, compress_hyper_6_24_chunk._ts_meta_max_1, compress_hyper_6_24_chunk._ts_meta_min_2, compress_hyper_6_24_chunk._ts_meta_max_2
+               Filter: (compress_hyper_6_24_chunk.device_id = 1)
 (16 rows)
 
 :PREFIX_VERBOSE
@@ -6781,18 +6781,18 @@ WHERE device_id IN (
          ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_4_chunk (actual rows=360 loops=1)
                Output: _hyper_2_4_chunk.device_id_peer, _hyper_2_4_chunk.device_id
                Bulk Decompression: false
-               ->  Seq Scan on _timescaledb_internal.compress_hyper_6_17_chunk (actual rows=1 loops=1)
-                     Output: compress_hyper_6_17_chunk."time", compress_hyper_6_17_chunk.device_id, compress_hyper_6_17_chunk.device_id_peer, compress_hyper_6_17_chunk.v0, compress_hyper_6_17_chunk.v1, compress_hyper_6_17_chunk.v2, compress_hyper_6_17_chunk.v3, compress_hyper_6_17_chunk._ts_meta_count, compress_hyper_6_17_chunk._ts_meta_sequence_num, compress_hyper_6_17_chunk._ts_meta_min_3, compress_hyper_6_17_chunk._ts_meta_max_3, compress_hyper_6_17_chunk._ts_meta_min_1, compress_hyper_6_17_chunk._ts_meta_max_1, compress_hyper_6_17_chunk._ts_meta_min_2, compress_hyper_6_17_chunk._ts_meta_max_2
+               ->  Seq Scan on _timescaledb_internal.compress_hyper_6_18_chunk (actual rows=1 loops=1)
+                     Output: compress_hyper_6_18_chunk."time", compress_hyper_6_18_chunk.device_id, compress_hyper_6_18_chunk.device_id_peer, compress_hyper_6_18_chunk.v0, compress_hyper_6_18_chunk.v1, compress_hyper_6_18_chunk.v2, compress_hyper_6_18_chunk.v3, compress_hyper_6_18_chunk._ts_meta_count, compress_hyper_6_18_chunk._ts_meta_sequence_num, compress_hyper_6_18_chunk._ts_meta_min_3, compress_hyper_6_18_chunk._ts_meta_max_3, compress_hyper_6_18_chunk._ts_meta_min_1, compress_hyper_6_18_chunk._ts_meta_max_1, compress_hyper_6_18_chunk._ts_meta_min_2, compress_hyper_6_18_chunk._ts_meta_max_2
          ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_5_chunk (actual rows=1080 loops=1)
                Output: _hyper_2_5_chunk.device_id_peer, _hyper_2_5_chunk.device_id
                Bulk Decompression: false
-               ->  Seq Scan on _timescaledb_internal.compress_hyper_6_18_chunk (actual rows=3 loops=1)
-                     Output: compress_hyper_6_18_chunk."time", compress_hyper_6_18_chunk.device_id, compress_hyper_6_18_chunk.device_id_peer, compress_hyper_6_18_chunk.v0, compress_hyper_6_18_chunk.v1, compress_hyper_6_18_chunk.v2, compress_hyper_6_18_chunk.v3, compress_hyper_6_18_chunk._ts_meta_count, compress_hyper_6_18_chunk._ts_meta_sequence_num, compress_hyper_6_18_chunk._ts_meta_min_3, compress_hyper_6_18_chunk._ts_meta_max_3, compress_hyper_6_18_chunk._ts_meta_min_1, compress_hyper_6_18_chunk._ts_meta_max_1, compress_hyper_6_18_chunk._ts_meta_min_2, compress_hyper_6_18_chunk._ts_meta_max_2
+               ->  Seq Scan on _timescaledb_internal.compress_hyper_6_19_chunk (actual rows=3 loops=1)
+                     Output: compress_hyper_6_19_chunk."time", compress_hyper_6_19_chunk.device_id, compress_hyper_6_19_chunk.device_id_peer, compress_hyper_6_19_chunk.v0, compress_hyper_6_19_chunk.v1, compress_hyper_6_19_chunk.v2, compress_hyper_6_19_chunk.v3, compress_hyper_6_19_chunk._ts_meta_count, compress_hyper_6_19_chunk._ts_meta_sequence_num, compress_hyper_6_19_chunk._ts_meta_min_3, compress_hyper_6_19_chunk._ts_meta_max_3, compress_hyper_6_19_chunk._ts_meta_min_1, compress_hyper_6_19_chunk._ts_meta_max_1, compress_hyper_6_19_chunk._ts_meta_min_2, compress_hyper_6_19_chunk._ts_meta_max_2
          ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_6_chunk (actual rows=360 loops=1)
                Output: _hyper_2_6_chunk.device_id_peer, _hyper_2_6_chunk.device_id
                Bulk Decompression: false
-               ->  Seq Scan on _timescaledb_internal.compress_hyper_6_19_chunk (actual rows=1 loops=1)
-                     Output: compress_hyper_6_19_chunk."time", compress_hyper_6_19_chunk.device_id, compress_hyper_6_19_chunk.device_id_peer, compress_hyper_6_19_chunk.v0, compress_hyper_6_19_chunk.v1, compress_hyper_6_19_chunk.v2, compress_hyper_6_19_chunk.v3, compress_hyper_6_19_chunk._ts_meta_count, compress_hyper_6_19_chunk._ts_meta_sequence_num, compress_hyper_6_19_chunk._ts_meta_min_3, compress_hyper_6_19_chunk._ts_meta_max_3, compress_hyper_6_19_chunk._ts_meta_min_1, compress_hyper_6_19_chunk._ts_meta_max_1, compress_hyper_6_19_chunk._ts_meta_min_2, compress_hyper_6_19_chunk._ts_meta_max_2
+               ->  Seq Scan on _timescaledb_internal.compress_hyper_6_20_chunk (actual rows=1 loops=1)
+                     Output: compress_hyper_6_20_chunk."time", compress_hyper_6_20_chunk.device_id, compress_hyper_6_20_chunk.device_id_peer, compress_hyper_6_20_chunk.v0, compress_hyper_6_20_chunk.v1, compress_hyper_6_20_chunk.v2, compress_hyper_6_20_chunk.v3, compress_hyper_6_20_chunk._ts_meta_count, compress_hyper_6_20_chunk._ts_meta_sequence_num, compress_hyper_6_20_chunk._ts_meta_min_3, compress_hyper_6_20_chunk._ts_meta_max_3, compress_hyper_6_20_chunk._ts_meta_min_1, compress_hyper_6_20_chunk._ts_meta_max_1, compress_hyper_6_20_chunk._ts_meta_min_2, compress_hyper_6_20_chunk._ts_meta_max_2
          ->  Seq Scan on _timescaledb_internal._hyper_2_7_chunk (actual rows=504 loops=1)
                Output: _hyper_2_7_chunk.device_id_peer, _hyper_2_7_chunk.device_id
          ->  Seq Scan on _timescaledb_internal._hyper_2_8_chunk (actual rows=1512 loops=1)
@@ -6802,13 +6802,13 @@ WHERE device_id IN (
          ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_10_chunk (actual rows=504 loops=1)
                Output: _hyper_2_10_chunk.device_id_peer, _hyper_2_10_chunk.device_id
                Bulk Decompression: false
-               ->  Seq Scan on _timescaledb_internal.compress_hyper_6_20_chunk (actual rows=1 loops=1)
-                     Output: compress_hyper_6_20_chunk."time", compress_hyper_6_20_chunk.device_id, compress_hyper_6_20_chunk.device_id_peer, compress_hyper_6_20_chunk.v0, compress_hyper_6_20_chunk.v1, compress_hyper_6_20_chunk.v2, compress_hyper_6_20_chunk.v3, compress_hyper_6_20_chunk._ts_meta_count, compress_hyper_6_20_chunk._ts_meta_sequence_num, compress_hyper_6_20_chunk._ts_meta_min_3, compress_hyper_6_20_chunk._ts_meta_max_3, compress_hyper_6_20_chunk._ts_meta_min_1, compress_hyper_6_20_chunk._ts_meta_max_1, compress_hyper_6_20_chunk._ts_meta_min_2, compress_hyper_6_20_chunk._ts_meta_max_2
+               ->  Seq Scan on _timescaledb_internal.compress_hyper_6_24_chunk (actual rows=1 loops=1)
+                     Output: compress_hyper_6_24_chunk."time", compress_hyper_6_24_chunk.device_id, compress_hyper_6_24_chunk.device_id_peer, compress_hyper_6_24_chunk.v0, compress_hyper_6_24_chunk.v1, compress_hyper_6_24_chunk.v2, compress_hyper_6_24_chunk.v3, compress_hyper_6_24_chunk._ts_meta_count, compress_hyper_6_24_chunk._ts_meta_sequence_num, compress_hyper_6_24_chunk._ts_meta_min_3, compress_hyper_6_24_chunk._ts_meta_max_3, compress_hyper_6_24_chunk._ts_meta_min_1, compress_hyper_6_24_chunk._ts_meta_max_1, compress_hyper_6_24_chunk._ts_meta_min_2, compress_hyper_6_24_chunk._ts_meta_max_2
          ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_11_chunk (actual rows=1512 loops=1)
                Output: _hyper_2_11_chunk.device_id_peer, _hyper_2_11_chunk.device_id
                Bulk Decompression: false
-               ->  Seq Scan on _timescaledb_internal.compress_hyper_6_21_chunk (actual rows=3 loops=1)
-                     Output: compress_hyper_6_21_chunk."time", compress_hyper_6_21_chunk.device_id, compress_hyper_6_21_chunk.device_id_peer, compress_hyper_6_21_chunk.v0, compress_hyper_6_21_chunk.v1, compress_hyper_6_21_chunk.v2, compress_hyper_6_21_chunk.v3, compress_hyper_6_21_chunk._ts_meta_count, compress_hyper_6_21_chunk._ts_meta_sequence_num, compress_hyper_6_21_chunk._ts_meta_min_3, compress_hyper_6_21_chunk._ts_meta_max_3, compress_hyper_6_21_chunk._ts_meta_min_1, compress_hyper_6_21_chunk._ts_meta_max_1, compress_hyper_6_21_chunk._ts_meta_min_2, compress_hyper_6_21_chunk._ts_meta_max_2
+               ->  Seq Scan on _timescaledb_internal.compress_hyper_6_25_chunk (actual rows=3 loops=1)
+                     Output: compress_hyper_6_25_chunk."time", compress_hyper_6_25_chunk.device_id, compress_hyper_6_25_chunk.device_id_peer, compress_hyper_6_25_chunk.v0, compress_hyper_6_25_chunk.v1, compress_hyper_6_25_chunk.v2, compress_hyper_6_25_chunk.v3, compress_hyper_6_25_chunk._ts_meta_count, compress_hyper_6_25_chunk._ts_meta_sequence_num, compress_hyper_6_25_chunk._ts_meta_min_3, compress_hyper_6_25_chunk._ts_meta_max_3, compress_hyper_6_25_chunk._ts_meta_min_1, compress_hyper_6_25_chunk._ts_meta_max_1, compress_hyper_6_25_chunk._ts_meta_min_2, compress_hyper_6_25_chunk._ts_meta_max_2
          ->  Seq Scan on _timescaledb_internal._hyper_2_12_chunk (actual rows=504 loops=1)
                Output: _hyper_2_12_chunk.device_id_peer, _hyper_2_12_chunk.device_id
    ->  Hash (actual rows=2 loops=1)
@@ -6840,14 +6840,14 @@ LIMIT 10;
                Sort Key: _hyper_2_10_chunk."time" DESC
                Sort Method: top-N heapsort 
                ->  Custom Scan (DecompressChunk) on _hyper_2_10_chunk (actual rows=504 loops=1)
-                     ->  Seq Scan on compress_hyper_6_20_chunk (actual rows=1 loops=1)
+                     ->  Seq Scan on compress_hyper_6_24_chunk (actual rows=1 loops=1)
                            Filter: (device_id = 1)
          ->  Index Scan using _hyper_2_7_chunk_metrics_space_time_idx on _hyper_2_7_chunk (never executed)
                Filter: (device_id = 1)
          ->  Sort (never executed)
                Sort Key: _hyper_2_4_chunk."time" DESC
                ->  Custom Scan (DecompressChunk) on _hyper_2_4_chunk (never executed)
-                     ->  Seq Scan on compress_hyper_6_17_chunk (never executed)
+                     ->  Seq Scan on compress_hyper_6_18_chunk (never executed)
                            Filter: (device_id = 1)
 (16 rows)
 
@@ -6883,7 +6883,7 @@ FROM :TEST_TABLE m1
                                        Sort Key: m1_1."time"
                                        Sort Method: quicksort 
                                        ->  Custom Scan (DecompressChunk) on _hyper_2_4_chunk m1_1 (actual rows=360 loops=1)
-                                             ->  Seq Scan on compress_hyper_6_17_chunk (actual rows=1 loops=1)
+                                             ->  Seq Scan on compress_hyper_6_18_chunk (actual rows=1 loops=1)
                            ->  Sort (actual rows=7 loops=1)
                                  Sort Key: m1_2."time"
                                  Sort Method: quicksort 
@@ -6891,7 +6891,7 @@ FROM :TEST_TABLE m1
                                        Sort Key: m1_2."time"
                                        Sort Method: quicksort 
                                        ->  Custom Scan (DecompressChunk) on _hyper_2_5_chunk m1_2 (actual rows=1080 loops=1)
-                                             ->  Seq Scan on compress_hyper_6_18_chunk (actual rows=3 loops=1)
+                                             ->  Seq Scan on compress_hyper_6_19_chunk (actual rows=3 loops=1)
                            ->  Sort (actual rows=3 loops=1)
                                  Sort Key: m1_3."time"
                                  Sort Method: quicksort 
@@ -6899,7 +6899,7 @@ FROM :TEST_TABLE m1
                                        Sort Key: m1_3."time"
                                        Sort Method: quicksort 
                                        ->  Custom Scan (DecompressChunk) on _hyper_2_6_chunk m1_3 (actual rows=360 loops=1)
-                                             ->  Seq Scan on compress_hyper_6_19_chunk (actual rows=1 loops=1)
+                                             ->  Seq Scan on compress_hyper_6_20_chunk (actual rows=1 loops=1)
                      ->  Merge Append (never executed)
                            Sort Key: m1_4."time"
                            ->  Index Scan Backward using _hyper_2_7_chunk_metrics_space_time_idx on _hyper_2_7_chunk m1_4 (never executed)
@@ -6912,13 +6912,13 @@ FROM :TEST_TABLE m1
                                  ->  Sort (never executed)
                                        Sort Key: m1_7."time"
                                        ->  Custom Scan (DecompressChunk) on _hyper_2_10_chunk m1_7 (never executed)
-                                             ->  Seq Scan on compress_hyper_6_20_chunk (never executed)
+                                             ->  Seq Scan on compress_hyper_6_24_chunk (never executed)
                            ->  Sort (never executed)
                                  Sort Key: m1_8."time"
                                  ->  Sort (never executed)
                                        Sort Key: m1_8."time"
                                        ->  Custom Scan (DecompressChunk) on _hyper_2_11_chunk m1_8 (never executed)
-                                             ->  Seq Scan on compress_hyper_6_21_chunk (never executed)
+                                             ->  Seq Scan on compress_hyper_6_25_chunk (never executed)
                            ->  Index Scan Backward using _hyper_2_12_chunk_metrics_space_time_idx on _hyper_2_12_chunk m1_9 (never executed)
                ->  Materialize (actual rows=51 loops=1)
                      ->  Custom Scan (ChunkAppend) on metrics_space m2 (actual rows=11 loops=1)
@@ -6932,7 +6932,7 @@ FROM :TEST_TABLE m1
                                              Sort Key: m2_1."time"
                                              Sort Method: quicksort 
                                              ->  Custom Scan (DecompressChunk) on _hyper_2_4_chunk m2_1 (actual rows=360 loops=1)
-                                                   ->  Seq Scan on compress_hyper_6_17_chunk compress_hyper_6_17_chunk_1 (actual rows=1 loops=1)
+                                                   ->  Seq Scan on compress_hyper_6_18_chunk compress_hyper_6_18_chunk_1 (actual rows=1 loops=1)
                                  ->  Sort (actual rows=7 loops=1)
                                        Sort Key: m2_2."time"
                                        Sort Method: quicksort 
@@ -6940,7 +6940,7 @@ FROM :TEST_TABLE m1
                                              Sort Key: m2_2."time"
                                              Sort Method: quicksort 
                                              ->  Custom Scan (DecompressChunk) on _hyper_2_5_chunk m2_2 (actual rows=1080 loops=1)
-                                                   ->  Seq Scan on compress_hyper_6_18_chunk compress_hyper_6_18_chunk_1 (actual rows=3 loops=1)
+                                                   ->  Seq Scan on compress_hyper_6_19_chunk compress_hyper_6_19_chunk_1 (actual rows=3 loops=1)
                                  ->  Sort (actual rows=3 loops=1)
                                        Sort Key: m2_3."time"
                                        Sort Method: quicksort 
@@ -6948,7 +6948,7 @@ FROM :TEST_TABLE m1
                                              Sort Key: m2_3."time"
                                              Sort Method: quicksort 
                                              ->  Custom Scan (DecompressChunk) on _hyper_2_6_chunk m2_3 (actual rows=360 loops=1)
-                                                   ->  Seq Scan on compress_hyper_6_19_chunk compress_hyper_6_19_chunk_1 (actual rows=1 loops=1)
+                                                   ->  Seq Scan on compress_hyper_6_20_chunk compress_hyper_6_20_chunk_1 (actual rows=1 loops=1)
                            ->  Merge Append (never executed)
                                  Sort Key: m2_4."time"
                                  ->  Index Scan Backward using _hyper_2_7_chunk_metrics_space_time_idx on _hyper_2_7_chunk m2_4 (never executed)
@@ -6961,13 +6961,13 @@ FROM :TEST_TABLE m1
                                        ->  Sort (never executed)
                                              Sort Key: m2_7."time"
                                              ->  Custom Scan (DecompressChunk) on _hyper_2_10_chunk m2_7 (never executed)
-                                                   ->  Seq Scan on compress_hyper_6_20_chunk compress_hyper_6_20_chunk_1 (never executed)
+                                                   ->  Seq Scan on compress_hyper_6_24_chunk compress_hyper_6_24_chunk_1 (never executed)
                                  ->  Sort (never executed)
                                        Sort Key: m2_8."time"
                                        ->  Sort (never executed)
                                              Sort Key: m2_8."time"
                                              ->  Custom Scan (DecompressChunk) on _hyper_2_11_chunk m2_8 (never executed)
-                                                   ->  Seq Scan on compress_hyper_6_21_chunk compress_hyper_6_21_chunk_1 (never executed)
+                                                   ->  Seq Scan on compress_hyper_6_25_chunk compress_hyper_6_25_chunk_1 (never executed)
                                  ->  Index Scan Backward using _hyper_2_12_chunk_metrics_space_time_idx on _hyper_2_12_chunk m2_9 (never executed)
 (106 rows)
 
@@ -7005,7 +7005,7 @@ FROM :TEST_TABLE m1
                                              Sort Key: m1_1."time"
                                              Sort Method: quicksort 
                                              ->  Custom Scan (DecompressChunk) on _hyper_2_4_chunk m1_1 (actual rows=360 loops=1)
-                                                   ->  Seq Scan on compress_hyper_6_17_chunk (actual rows=1 loops=1)
+                                                   ->  Seq Scan on compress_hyper_6_18_chunk (actual rows=1 loops=1)
                                  ->  Sort (actual rows=7 loops=1)
                                        Sort Key: m1_2."time"
                                        Sort Method: quicksort 
@@ -7013,7 +7013,7 @@ FROM :TEST_TABLE m1
                                              Sort Key: m1_2."time"
                                              Sort Method: quicksort 
                                              ->  Custom Scan (DecompressChunk) on _hyper_2_5_chunk m1_2 (actual rows=1080 loops=1)
-                                                   ->  Seq Scan on compress_hyper_6_18_chunk (actual rows=3 loops=1)
+                                                   ->  Seq Scan on compress_hyper_6_19_chunk (actual rows=3 loops=1)
                                  ->  Sort (actual rows=3 loops=1)
                                        Sort Key: m1_3."time"
                                        Sort Method: quicksort 
@@ -7021,7 +7021,7 @@ FROM :TEST_TABLE m1
                                              Sort Key: m1_3."time"
                                              Sort Method: quicksort 
                                              ->  Custom Scan (DecompressChunk) on _hyper_2_6_chunk m1_3 (actual rows=360 loops=1)
-                                                   ->  Seq Scan on compress_hyper_6_19_chunk (actual rows=1 loops=1)
+                                                   ->  Seq Scan on compress_hyper_6_20_chunk (actual rows=1 loops=1)
                            ->  Merge Append (never executed)
                                  Sort Key: m1_4."time"
                                  ->  Index Scan Backward using _hyper_2_7_chunk_metrics_space_time_idx on _hyper_2_7_chunk m1_4 (never executed)
@@ -7034,13 +7034,13 @@ FROM :TEST_TABLE m1
                                        ->  Sort (never executed)
                                              Sort Key: m1_7."time"
                                              ->  Custom Scan (DecompressChunk) on _hyper_2_10_chunk m1_7 (never executed)
-                                                   ->  Seq Scan on compress_hyper_6_20_chunk (never executed)
+                                                   ->  Seq Scan on compress_hyper_6_24_chunk (never executed)
                                  ->  Sort (never executed)
                                        Sort Key: m1_8."time"
                                        ->  Sort (never executed)
                                              Sort Key: m1_8."time"
                                              ->  Custom Scan (DecompressChunk) on _hyper_2_11_chunk m1_8 (never executed)
-                                                   ->  Seq Scan on compress_hyper_6_21_chunk (never executed)
+                                                   ->  Seq Scan on compress_hyper_6_25_chunk (never executed)
                                  ->  Index Scan Backward using _hyper_2_12_chunk_metrics_space_time_idx on _hyper_2_12_chunk m1_9 (never executed)
                      ->  Materialize (actual rows=51 loops=1)
                            ->  Custom Scan (ChunkAppend) on metrics_space m2 (actual rows=11 loops=1)
@@ -7054,7 +7054,7 @@ FROM :TEST_TABLE m1
                                                    Sort Key: m2_1."time"
                                                    Sort Method: quicksort 
                                                    ->  Custom Scan (DecompressChunk) on _hyper_2_4_chunk m2_1 (actual rows=360 loops=1)
-                                                         ->  Seq Scan on compress_hyper_6_17_chunk compress_hyper_6_17_chunk_1 (actual rows=1 loops=1)
+                                                         ->  Seq Scan on compress_hyper_6_18_chunk compress_hyper_6_18_chunk_1 (actual rows=1 loops=1)
                                        ->  Sort (actual rows=7 loops=1)
                                              Sort Key: m2_2."time"
                                              Sort Method: quicksort 
@@ -7062,7 +7062,7 @@ FROM :TEST_TABLE m1
                                                    Sort Key: m2_2."time"
                                                    Sort Method: quicksort 
                                                    ->  Custom Scan (DecompressChunk) on _hyper_2_5_chunk m2_2 (actual rows=1080 loops=1)
-                                                         ->  Seq Scan on compress_hyper_6_18_chunk compress_hyper_6_18_chunk_1 (actual rows=3 loops=1)
+                                                         ->  Seq Scan on compress_hyper_6_19_chunk compress_hyper_6_19_chunk_1 (actual rows=3 loops=1)
                                        ->  Sort (actual rows=3 loops=1)
                                              Sort Key: m2_3."time"
                                              Sort Method: quicksort 
@@ -7070,7 +7070,7 @@ FROM :TEST_TABLE m1
                                                    Sort Key: m2_3."time"
                                                    Sort Method: quicksort 
                                                    ->  Custom Scan (DecompressChunk) on _hyper_2_6_chunk m2_3 (actual rows=360 loops=1)
-                                                         ->  Seq Scan on compress_hyper_6_19_chunk compress_hyper_6_19_chunk_1 (actual rows=1 loops=1)
+                                                         ->  Seq Scan on compress_hyper_6_20_chunk compress_hyper_6_20_chunk_1 (actual rows=1 loops=1)
                                  ->  Merge Append (never executed)
                                        Sort Key: m2_4."time"
                                        ->  Index Scan Backward using _hyper_2_7_chunk_metrics_space_time_idx on _hyper_2_7_chunk m2_4 (never executed)
@@ -7083,13 +7083,13 @@ FROM :TEST_TABLE m1
                                              ->  Sort (never executed)
                                                    Sort Key: m2_7."time"
                                                    ->  Custom Scan (DecompressChunk) on _hyper_2_10_chunk m2_7 (never executed)
-                                                         ->  Seq Scan on compress_hyper_6_20_chunk compress_hyper_6_20_chunk_1 (never executed)
+                                                         ->  Seq Scan on compress_hyper_6_24_chunk compress_hyper_6_24_chunk_1 (never executed)
                                        ->  Sort (never executed)
                                              Sort Key: m2_8."time"
                                              ->  Sort (never executed)
                                                    Sort Key: m2_8."time"
                                                    ->  Custom Scan (DecompressChunk) on _hyper_2_11_chunk m2_8 (never executed)
-                                                         ->  Seq Scan on compress_hyper_6_21_chunk compress_hyper_6_21_chunk_1 (never executed)
+                                                         ->  Seq Scan on compress_hyper_6_25_chunk compress_hyper_6_25_chunk_1 (never executed)
                                        ->  Index Scan Backward using _hyper_2_12_chunk_metrics_space_time_idx on _hyper_2_12_chunk m2_9 (never executed)
                ->  Materialize (actual rows=11 loops=1)
                      ->  Merge Append (actual rows=3 loops=1)
@@ -7098,7 +7098,7 @@ FROM :TEST_TABLE m1
                                  Sort Key: m3_1."time"
                                  Sort Method: quicksort 
                                  ->  Custom Scan (DecompressChunk) on _hyper_2_6_chunk m3_1 (actual rows=360 loops=1)
-                                       ->  Seq Scan on compress_hyper_6_19_chunk compress_hyper_6_19_chunk_2 (actual rows=1 loops=1)
+                                       ->  Seq Scan on compress_hyper_6_20_chunk compress_hyper_6_20_chunk_2 (actual rows=1 loops=1)
                                              Filter: (device_id = 3)
                            ->  Index Scan Backward using _hyper_2_9_chunk_metrics_space_time_idx on _hyper_2_9_chunk m3_2 (actual rows=1 loops=1)
                                  Filter: (device_id = 3)
@@ -7128,14 +7128,14 @@ FROM :TEST_TABLE m1
                      Sort Key: m1_1."time"
                      Sort Method: quicksort 
                      ->  Custom Scan (DecompressChunk) on _hyper_2_4_chunk m1_1 (actual rows=360 loops=1)
-                           ->  Seq Scan on compress_hyper_6_17_chunk (actual rows=1 loops=1)
+                           ->  Seq Scan on compress_hyper_6_18_chunk (actual rows=1 loops=1)
                                  Filter: (device_id = 1)
                ->  Index Scan Backward using _hyper_2_7_chunk_metrics_space_time_idx on _hyper_2_7_chunk m1_2 (never executed)
                      Filter: (device_id = 1)
                ->  Sort (never executed)
                      Sort Key: m1_3."time"
                      ->  Custom Scan (DecompressChunk) on _hyper_2_10_chunk m1_3 (never executed)
-                           ->  Seq Scan on compress_hyper_6_20_chunk (never executed)
+                           ->  Seq Scan on compress_hyper_6_24_chunk (never executed)
                                  Filter: (device_id = 1)
          ->  Materialize (actual rows=100 loops=1)
                ->  Custom Scan (ChunkAppend) on metrics_space m2 (actual rows=100 loops=1)
@@ -7144,7 +7144,7 @@ FROM :TEST_TABLE m1
                            Sort Key: m2_1."time"
                            Sort Method: quicksort 
                            ->  Custom Scan (DecompressChunk) on _hyper_2_5_chunk m2_1 (actual rows=360 loops=1)
-                                 ->  Seq Scan on compress_hyper_6_18_chunk (actual rows=1 loops=1)
+                                 ->  Seq Scan on compress_hyper_6_19_chunk (actual rows=1 loops=1)
                                        Filter: (device_id = 2)
                                        Rows Removed by Filter: 2
                      ->  Index Scan Backward using _hyper_2_8_chunk_metrics_space_device_id_time_idx on _hyper_2_8_chunk m2_2 (never executed)
@@ -7152,7 +7152,7 @@ FROM :TEST_TABLE m1
                      ->  Sort (never executed)
                            Sort Key: m2_3."time"
                            ->  Custom Scan (DecompressChunk) on _hyper_2_11_chunk m2_3 (never executed)
-                                 ->  Seq Scan on compress_hyper_6_21_chunk (never executed)
+                                 ->  Seq Scan on compress_hyper_6_25_chunk (never executed)
                                        Filter: (device_id = 2)
 (35 rows)
 
@@ -7186,7 +7186,7 @@ FROM metrics m1
                ->  Sort (never executed)
                      Sort Key: m1_3."time"
                      ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk m1_3 (never executed)
-                           ->  Seq Scan on compress_hyper_5_16_chunk (never executed)
+                           ->  Seq Scan on compress_hyper_5_17_chunk (never executed)
                                  Filter: (device_id = 1)
          ->  Materialize (actual rows=100 loops=1)
                ->  Custom Scan (ChunkAppend) on metrics_space m2 (actual rows=100 loops=1)
@@ -7195,7 +7195,7 @@ FROM metrics m1
                            Sort Key: m2_1."time"
                            Sort Method: quicksort 
                            ->  Custom Scan (DecompressChunk) on _hyper_2_5_chunk m2_1 (actual rows=360 loops=1)
-                                 ->  Seq Scan on compress_hyper_6_18_chunk (actual rows=1 loops=1)
+                                 ->  Seq Scan on compress_hyper_6_19_chunk (actual rows=1 loops=1)
                                        Filter: (device_id = 2)
                                        Rows Removed by Filter: 2
                      ->  Index Scan Backward using _hyper_2_8_chunk_metrics_space_device_id_time_idx on _hyper_2_8_chunk m2_2 (never executed)
@@ -7203,7 +7203,7 @@ FROM metrics m1
                      ->  Sort (never executed)
                            Sort Key: m2_3."time"
                            ->  Custom Scan (DecompressChunk) on _hyper_2_11_chunk m2_3 (never executed)
-                                 ->  Seq Scan on compress_hyper_6_21_chunk (never executed)
+                                 ->  Seq Scan on compress_hyper_6_25_chunk (never executed)
                                        Filter: (device_id = 2)
 (36 rows)
 
@@ -7238,7 +7238,7 @@ LIMIT 10;
                                        Sort Key: m1_1."time"
                                        Sort Method: quicksort 
                                        ->  Custom Scan (DecompressChunk) on _hyper_2_4_chunk m1_1 (actual rows=360 loops=1)
-                                             ->  Seq Scan on compress_hyper_6_17_chunk (actual rows=1 loops=1)
+                                             ->  Seq Scan on compress_hyper_6_18_chunk (actual rows=1 loops=1)
                            ->  Sort (actual rows=7 loops=1)
                                  Sort Key: m1_2."time"
                                  Sort Method: quicksort 
@@ -7246,7 +7246,7 @@ LIMIT 10;
                                        Sort Key: m1_2."time"
                                        Sort Method: quicksort 
                                        ->  Custom Scan (DecompressChunk) on _hyper_2_5_chunk m1_2 (actual rows=1080 loops=1)
-                                             ->  Seq Scan on compress_hyper_6_18_chunk (actual rows=3 loops=1)
+                                             ->  Seq Scan on compress_hyper_6_19_chunk (actual rows=3 loops=1)
                            ->  Sort (actual rows=3 loops=1)
                                  Sort Key: m1_3."time"
                                  Sort Method: quicksort 
@@ -7254,7 +7254,7 @@ LIMIT 10;
                                        Sort Key: m1_3."time"
                                        Sort Method: quicksort 
                                        ->  Custom Scan (DecompressChunk) on _hyper_2_6_chunk m1_3 (actual rows=360 loops=1)
-                                             ->  Seq Scan on compress_hyper_6_19_chunk (actual rows=1 loops=1)
+                                             ->  Seq Scan on compress_hyper_6_20_chunk (actual rows=1 loops=1)
                      ->  Merge Append (never executed)
                            Sort Key: m1_4."time"
                            ->  Index Scan Backward using _hyper_2_7_chunk_metrics_space_time_idx on _hyper_2_7_chunk m1_4 (never executed)
@@ -7267,13 +7267,13 @@ LIMIT 10;
                                  ->  Sort (never executed)
                                        Sort Key: m1_7."time"
                                        ->  Custom Scan (DecompressChunk) on _hyper_2_10_chunk m1_7 (never executed)
-                                             ->  Seq Scan on compress_hyper_6_20_chunk (never executed)
+                                             ->  Seq Scan on compress_hyper_6_24_chunk (never executed)
                            ->  Sort (never executed)
                                  Sort Key: m1_8."time"
                                  ->  Sort (never executed)
                                        Sort Key: m1_8."time"
                                        ->  Custom Scan (DecompressChunk) on _hyper_2_11_chunk m1_8 (never executed)
-                                             ->  Seq Scan on compress_hyper_6_21_chunk (never executed)
+                                             ->  Seq Scan on compress_hyper_6_25_chunk (never executed)
                            ->  Index Scan Backward using _hyper_2_12_chunk_metrics_space_time_idx on _hyper_2_12_chunk m1_9 (never executed)
                ->  Materialize (actual rows=51 loops=1)
                      ->  Custom Scan (ChunkAppend) on metrics_space m2 (actual rows=11 loops=1)
@@ -7287,7 +7287,7 @@ LIMIT 10;
                                              Sort Key: m2_1."time"
                                              Sort Method: quicksort 
                                              ->  Custom Scan (DecompressChunk) on _hyper_2_4_chunk m2_1 (actual rows=360 loops=1)
-                                                   ->  Seq Scan on compress_hyper_6_17_chunk compress_hyper_6_17_chunk_1 (actual rows=1 loops=1)
+                                                   ->  Seq Scan on compress_hyper_6_18_chunk compress_hyper_6_18_chunk_1 (actual rows=1 loops=1)
                                  ->  Sort (actual rows=7 loops=1)
                                        Sort Key: m2_2."time"
                                        Sort Method: quicksort 
@@ -7295,7 +7295,7 @@ LIMIT 10;
                                              Sort Key: m2_2."time"
                                              Sort Method: quicksort 
                                              ->  Custom Scan (DecompressChunk) on _hyper_2_5_chunk m2_2 (actual rows=1080 loops=1)
-                                                   ->  Seq Scan on compress_hyper_6_18_chunk compress_hyper_6_18_chunk_1 (actual rows=3 loops=1)
+                                                   ->  Seq Scan on compress_hyper_6_19_chunk compress_hyper_6_19_chunk_1 (actual rows=3 loops=1)
                                  ->  Sort (actual rows=3 loops=1)
                                        Sort Key: m2_3."time"
                                        Sort Method: quicksort 
@@ -7303,7 +7303,7 @@ LIMIT 10;
                                              Sort Key: m2_3."time"
                                              Sort Method: quicksort 
                                              ->  Custom Scan (DecompressChunk) on _hyper_2_6_chunk m2_3 (actual rows=360 loops=1)
-                                                   ->  Seq Scan on compress_hyper_6_19_chunk compress_hyper_6_19_chunk_1 (actual rows=1 loops=1)
+                                                   ->  Seq Scan on compress_hyper_6_20_chunk compress_hyper_6_20_chunk_1 (actual rows=1 loops=1)
                            ->  Merge Append (never executed)
                                  Sort Key: m2_4."time"
                                  ->  Index Scan Backward using _hyper_2_7_chunk_metrics_space_time_idx on _hyper_2_7_chunk m2_4 (never executed)
@@ -7316,13 +7316,13 @@ LIMIT 10;
                                        ->  Sort (never executed)
                                              Sort Key: m2_7."time"
                                              ->  Custom Scan (DecompressChunk) on _hyper_2_10_chunk m2_7 (never executed)
-                                                   ->  Seq Scan on compress_hyper_6_20_chunk compress_hyper_6_20_chunk_1 (never executed)
+                                                   ->  Seq Scan on compress_hyper_6_24_chunk compress_hyper_6_24_chunk_1 (never executed)
                                  ->  Sort (never executed)
                                        Sort Key: m2_8."time"
                                        ->  Sort (never executed)
                                              Sort Key: m2_8."time"
                                              ->  Custom Scan (DecompressChunk) on _hyper_2_11_chunk m2_8 (never executed)
-                                                   ->  Seq Scan on compress_hyper_6_21_chunk compress_hyper_6_21_chunk_1 (never executed)
+                                                   ->  Seq Scan on compress_hyper_6_25_chunk compress_hyper_6_25_chunk_1 (never executed)
                                  ->  Index Scan Backward using _hyper_2_12_chunk_metrics_space_time_idx on _hyper_2_12_chunk m2_9 (never executed)
 (106 rows)
 
@@ -7359,7 +7359,7 @@ LIMIT 100;
                                        Sort Key: m1_1."time"
                                        Sort Method: quicksort 
                                        ->  Custom Scan (DecompressChunk) on _hyper_2_4_chunk m1_1 (actual rows=360 loops=1)
-                                             ->  Seq Scan on compress_hyper_6_17_chunk (actual rows=1 loops=1)
+                                             ->  Seq Scan on compress_hyper_6_18_chunk (actual rows=1 loops=1)
                            ->  Sort (actual rows=61 loops=1)
                                  Sort Key: m1_2."time"
                                  Sort Method: quicksort 
@@ -7367,7 +7367,7 @@ LIMIT 100;
                                        Sort Key: m1_2."time"
                                        Sort Method: quicksort 
                                        ->  Custom Scan (DecompressChunk) on _hyper_2_5_chunk m1_2 (actual rows=1080 loops=1)
-                                             ->  Seq Scan on compress_hyper_6_18_chunk (actual rows=3 loops=1)
+                                             ->  Seq Scan on compress_hyper_6_19_chunk (actual rows=3 loops=1)
                            ->  Sort (actual rows=21 loops=1)
                                  Sort Key: m1_3."time"
                                  Sort Method: quicksort 
@@ -7375,7 +7375,7 @@ LIMIT 100;
                                        Sort Key: m1_3."time"
                                        Sort Method: quicksort 
                                        ->  Custom Scan (DecompressChunk) on _hyper_2_6_chunk m1_3 (actual rows=360 loops=1)
-                                             ->  Seq Scan on compress_hyper_6_19_chunk (actual rows=1 loops=1)
+                                             ->  Seq Scan on compress_hyper_6_20_chunk (actual rows=1 loops=1)
                      ->  Merge Append (never executed)
                            Sort Key: m1_4."time"
                            ->  Index Scan Backward using _hyper_2_7_chunk_metrics_space_time_idx on _hyper_2_7_chunk m1_4 (never executed)
@@ -7388,13 +7388,13 @@ LIMIT 100;
                                  ->  Sort (never executed)
                                        Sort Key: m1_7."time"
                                        ->  Custom Scan (DecompressChunk) on _hyper_2_10_chunk m1_7 (never executed)
-                                             ->  Seq Scan on compress_hyper_6_20_chunk (never executed)
+                                             ->  Seq Scan on compress_hyper_6_24_chunk (never executed)
                            ->  Sort (never executed)
                                  Sort Key: m1_8."time"
                                  ->  Sort (never executed)
                                        Sort Key: m1_8."time"
                                        ->  Custom Scan (DecompressChunk) on _hyper_2_11_chunk m1_8 (never executed)
-                                             ->  Seq Scan on compress_hyper_6_21_chunk (never executed)
+                                             ->  Seq Scan on compress_hyper_6_25_chunk (never executed)
                            ->  Index Scan Backward using _hyper_2_12_chunk_metrics_space_time_idx on _hyper_2_12_chunk m1_9 (never executed)
                ->  Materialize (actual rows=102 loops=1)
                      ->  Custom Scan (ChunkAppend) on metrics_space m2 (actual rows=22 loops=1)
@@ -7408,7 +7408,7 @@ LIMIT 100;
                                              Sort Key: m2_1."time"
                                              Sort Method: quicksort 
                                              ->  Custom Scan (DecompressChunk) on _hyper_2_4_chunk m2_1 (actual rows=0 loops=1)
-                                                   ->  Seq Scan on compress_hyper_6_17_chunk compress_hyper_6_17_chunk_1 (actual rows=0 loops=1)
+                                                   ->  Seq Scan on compress_hyper_6_18_chunk compress_hyper_6_18_chunk_1 (actual rows=0 loops=1)
                                                          Filter: (device_id = 2)
                                                          Rows Removed by Filter: 1
                                  ->  Sort (actual rows=22 loops=1)
@@ -7418,7 +7418,7 @@ LIMIT 100;
                                              Sort Key: m2_2."time"
                                              Sort Method: quicksort 
                                              ->  Custom Scan (DecompressChunk) on _hyper_2_5_chunk m2_2 (actual rows=360 loops=1)
-                                                   ->  Seq Scan on compress_hyper_6_18_chunk compress_hyper_6_18_chunk_1 (actual rows=1 loops=1)
+                                                   ->  Seq Scan on compress_hyper_6_19_chunk compress_hyper_6_19_chunk_1 (actual rows=1 loops=1)
                                                          Filter: (device_id = 2)
                                                          Rows Removed by Filter: 2
                                  ->  Sort (actual rows=0 loops=1)
@@ -7428,7 +7428,7 @@ LIMIT 100;
                                              Sort Key: m2_3."time"
                                              Sort Method: quicksort 
                                              ->  Custom Scan (DecompressChunk) on _hyper_2_6_chunk m2_3 (actual rows=0 loops=1)
-                                                   ->  Seq Scan on compress_hyper_6_19_chunk compress_hyper_6_19_chunk_1 (actual rows=0 loops=1)
+                                                   ->  Seq Scan on compress_hyper_6_20_chunk compress_hyper_6_20_chunk_1 (actual rows=0 loops=1)
                                                          Filter: (device_id = 2)
                                                          Rows Removed by Filter: 1
                            ->  Merge Append (never executed)
@@ -7446,14 +7446,14 @@ LIMIT 100;
                                        ->  Sort (never executed)
                                              Sort Key: m2_7."time"
                                              ->  Custom Scan (DecompressChunk) on _hyper_2_10_chunk m2_7 (never executed)
-                                                   ->  Seq Scan on compress_hyper_6_20_chunk compress_hyper_6_20_chunk_1 (never executed)
+                                                   ->  Seq Scan on compress_hyper_6_24_chunk compress_hyper_6_24_chunk_1 (never executed)
                                                          Filter: (device_id = 2)
                                  ->  Sort (never executed)
                                        Sort Key: m2_8."time"
                                        ->  Sort (never executed)
                                              Sort Key: m2_8."time"
                                              ->  Custom Scan (DecompressChunk) on _hyper_2_11_chunk m2_8 (never executed)
-                                                   ->  Seq Scan on compress_hyper_6_21_chunk compress_hyper_6_21_chunk_1 (never executed)
+                                                   ->  Seq Scan on compress_hyper_6_25_chunk compress_hyper_6_25_chunk_1 (never executed)
                                                          Filter: (device_id = 2)
                                  ->  Index Scan Backward using _hyper_2_12_chunk_metrics_space_time_idx on _hyper_2_12_chunk m2_9 (never executed)
                                        Filter: (device_id = 2)
@@ -7492,7 +7492,7 @@ LIMIT 100;
                      ->  Sort (never executed)
                            Sort Key: m1_3."time"
                            ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk m1_3 (never executed)
-                                 ->  Seq Scan on compress_hyper_5_16_chunk (never executed)
+                                 ->  Seq Scan on compress_hyper_5_17_chunk (never executed)
                ->  Materialize (actual rows=102 loops=1)
                      ->  Custom Scan (ChunkAppend) on metrics_space m2 (actual rows=22 loops=1)
                            Order: m2."time"
@@ -7505,7 +7505,7 @@ LIMIT 100;
                                              Sort Key: m2_1."time"
                                              Sort Method: quicksort 
                                              ->  Custom Scan (DecompressChunk) on _hyper_2_4_chunk m2_1 (actual rows=0 loops=1)
-                                                   ->  Seq Scan on compress_hyper_6_17_chunk (actual rows=0 loops=1)
+                                                   ->  Seq Scan on compress_hyper_6_18_chunk (actual rows=0 loops=1)
                                                          Filter: (device_id = 2)
                                                          Rows Removed by Filter: 1
                                  ->  Sort (actual rows=22 loops=1)
@@ -7515,7 +7515,7 @@ LIMIT 100;
                                              Sort Key: m2_2."time"
                                              Sort Method: quicksort 
                                              ->  Custom Scan (DecompressChunk) on _hyper_2_5_chunk m2_2 (actual rows=360 loops=1)
-                                                   ->  Seq Scan on compress_hyper_6_18_chunk (actual rows=1 loops=1)
+                                                   ->  Seq Scan on compress_hyper_6_19_chunk (actual rows=1 loops=1)
                                                          Filter: (device_id = 2)
                                                          Rows Removed by Filter: 2
                                  ->  Sort (actual rows=0 loops=1)
@@ -7525,7 +7525,7 @@ LIMIT 100;
                                              Sort Key: m2_3."time"
                                              Sort Method: quicksort 
                                              ->  Custom Scan (DecompressChunk) on _hyper_2_6_chunk m2_3 (actual rows=0 loops=1)
-                                                   ->  Seq Scan on compress_hyper_6_19_chunk (actual rows=0 loops=1)
+                                                   ->  Seq Scan on compress_hyper_6_20_chunk (actual rows=0 loops=1)
                                                          Filter: (device_id = 2)
                                                          Rows Removed by Filter: 1
                            ->  Merge Append (never executed)
@@ -7543,14 +7543,14 @@ LIMIT 100;
                                        ->  Sort (never executed)
                                              Sort Key: m2_7."time"
                                              ->  Custom Scan (DecompressChunk) on _hyper_2_10_chunk m2_7 (never executed)
-                                                   ->  Seq Scan on compress_hyper_6_20_chunk (never executed)
+                                                   ->  Seq Scan on compress_hyper_6_24_chunk (never executed)
                                                          Filter: (device_id = 2)
                                  ->  Sort (never executed)
                                        Sort Key: m2_8."time"
                                        ->  Sort (never executed)
                                              Sort Key: m2_8."time"
                                              ->  Custom Scan (DecompressChunk) on _hyper_2_11_chunk m2_8 (never executed)
-                                                   ->  Seq Scan on compress_hyper_6_21_chunk (never executed)
+                                                   ->  Seq Scan on compress_hyper_6_25_chunk (never executed)
                                                          Filter: (device_id = 2)
                                  ->  Index Scan Backward using _hyper_2_12_chunk_metrics_space_time_idx on _hyper_2_12_chunk m2_9 (never executed)
                                        Filter: (device_id = 2)
@@ -7587,7 +7587,7 @@ LIMIT 20;
                                        Sort Key: m1_1."time"
                                        Sort Method: quicksort 
                                        ->  Custom Scan (DecompressChunk) on _hyper_2_4_chunk m1_1 (actual rows=360 loops=1)
-                                             ->  Seq Scan on compress_hyper_6_17_chunk (actual rows=1 loops=1)
+                                             ->  Seq Scan on compress_hyper_6_18_chunk (actual rows=1 loops=1)
                            ->  Sort (actual rows=4 loops=1)
                                  Sort Key: m1_2."time"
                                  Sort Method: quicksort 
@@ -7595,7 +7595,7 @@ LIMIT 20;
                                        Sort Key: m1_2."time"
                                        Sort Method: quicksort 
                                        ->  Custom Scan (DecompressChunk) on _hyper_2_5_chunk m1_2 (actual rows=1080 loops=1)
-                                             ->  Seq Scan on compress_hyper_6_18_chunk (actual rows=3 loops=1)
+                                             ->  Seq Scan on compress_hyper_6_19_chunk (actual rows=3 loops=1)
                            ->  Sort (actual rows=2 loops=1)
                                  Sort Key: m1_3."time"
                                  Sort Method: quicksort 
@@ -7603,7 +7603,7 @@ LIMIT 20;
                                        Sort Key: m1_3."time"
                                        Sort Method: quicksort 
                                        ->  Custom Scan (DecompressChunk) on _hyper_2_6_chunk m1_3 (actual rows=360 loops=1)
-                                             ->  Seq Scan on compress_hyper_6_19_chunk (actual rows=1 loops=1)
+                                             ->  Seq Scan on compress_hyper_6_20_chunk (actual rows=1 loops=1)
                      ->  Merge Append (never executed)
                            Sort Key: m1_4."time"
                            ->  Index Scan Backward using _hyper_2_7_chunk_metrics_space_time_idx on _hyper_2_7_chunk m1_4 (never executed)
@@ -7616,13 +7616,13 @@ LIMIT 20;
                                  ->  Sort (never executed)
                                        Sort Key: m1_7."time"
                                        ->  Custom Scan (DecompressChunk) on _hyper_2_10_chunk m1_7 (never executed)
-                                             ->  Seq Scan on compress_hyper_6_20_chunk (never executed)
+                                             ->  Seq Scan on compress_hyper_6_24_chunk (never executed)
                            ->  Sort (never executed)
                                  Sort Key: m1_8."time"
                                  ->  Sort (never executed)
                                        Sort Key: m1_8."time"
                                        ->  Custom Scan (DecompressChunk) on _hyper_2_11_chunk m1_8 (never executed)
-                                             ->  Seq Scan on compress_hyper_6_21_chunk (never executed)
+                                             ->  Seq Scan on compress_hyper_6_25_chunk (never executed)
                            ->  Index Scan Backward using _hyper_2_12_chunk_metrics_space_time_idx on _hyper_2_12_chunk m1_9 (never executed)
                ->  Materialize (actual rows=26 loops=1)
                      ->  Custom Scan (ChunkAppend) on metrics_space m2 (actual rows=6 loops=1)
@@ -7636,7 +7636,7 @@ LIMIT 20;
                                              Sort Key: m2_1."time"
                                              Sort Method: quicksort 
                                              ->  Custom Scan (DecompressChunk) on _hyper_2_4_chunk m2_1 (actual rows=360 loops=1)
-                                                   ->  Seq Scan on compress_hyper_6_17_chunk compress_hyper_6_17_chunk_1 (actual rows=1 loops=1)
+                                                   ->  Seq Scan on compress_hyper_6_18_chunk compress_hyper_6_18_chunk_1 (actual rows=1 loops=1)
                                  ->  Sort (actual rows=4 loops=1)
                                        Sort Key: m2_2."time"
                                        Sort Method: quicksort 
@@ -7644,7 +7644,7 @@ LIMIT 20;
                                              Sort Key: m2_2."time"
                                              Sort Method: quicksort 
                                              ->  Custom Scan (DecompressChunk) on _hyper_2_5_chunk m2_2 (actual rows=1080 loops=1)
-                                                   ->  Seq Scan on compress_hyper_6_18_chunk compress_hyper_6_18_chunk_1 (actual rows=3 loops=1)
+                                                   ->  Seq Scan on compress_hyper_6_19_chunk compress_hyper_6_19_chunk_1 (actual rows=3 loops=1)
                                  ->  Sort (actual rows=2 loops=1)
                                        Sort Key: m2_3."time"
                                        Sort Method: quicksort 
@@ -7652,7 +7652,7 @@ LIMIT 20;
                                              Sort Key: m2_3."time"
                                              Sort Method: quicksort 
                                              ->  Custom Scan (DecompressChunk) on _hyper_2_6_chunk m2_3 (actual rows=360 loops=1)
-                                                   ->  Seq Scan on compress_hyper_6_19_chunk compress_hyper_6_19_chunk_1 (actual rows=1 loops=1)
+                                                   ->  Seq Scan on compress_hyper_6_20_chunk compress_hyper_6_20_chunk_1 (actual rows=1 loops=1)
                            ->  Merge Append (never executed)
                                  Sort Key: m2_4."time"
                                  ->  Index Scan Backward using _hyper_2_7_chunk_metrics_space_time_idx on _hyper_2_7_chunk m2_4 (never executed)
@@ -7665,13 +7665,13 @@ LIMIT 20;
                                        ->  Sort (never executed)
                                              Sort Key: m2_7."time"
                                              ->  Custom Scan (DecompressChunk) on _hyper_2_10_chunk m2_7 (never executed)
-                                                   ->  Seq Scan on compress_hyper_6_20_chunk compress_hyper_6_20_chunk_1 (never executed)
+                                                   ->  Seq Scan on compress_hyper_6_24_chunk compress_hyper_6_24_chunk_1 (never executed)
                                  ->  Sort (never executed)
                                        Sort Key: m2_8."time"
                                        ->  Sort (never executed)
                                              Sort Key: m2_8."time"
                                              ->  Custom Scan (DecompressChunk) on _hyper_2_11_chunk m2_8 (never executed)
-                                                   ->  Seq Scan on compress_hyper_6_21_chunk compress_hyper_6_21_chunk_1 (never executed)
+                                                   ->  Seq Scan on compress_hyper_6_25_chunk compress_hyper_6_25_chunk_1 (never executed)
                                  ->  Index Scan Backward using _hyper_2_12_chunk_metrics_space_time_idx on _hyper_2_12_chunk m2_9 (never executed)
 (104 rows)
 
@@ -7708,7 +7708,7 @@ LIMIT 10;
                                        Sort Key: m1_1."time"
                                        Sort Method: quicksort 
                                        ->  Custom Scan (DecompressChunk) on _hyper_2_4_chunk m1_1 (actual rows=360 loops=1)
-                                             ->  Seq Scan on compress_hyper_6_17_chunk (actual rows=1 loops=1)
+                                             ->  Seq Scan on compress_hyper_6_18_chunk (actual rows=1 loops=1)
                            ->  Sort (actual rows=4 loops=1)
                                  Sort Key: m1_2."time"
                                  Sort Method: quicksort 
@@ -7716,7 +7716,7 @@ LIMIT 10;
                                        Sort Key: m1_2."time"
                                        Sort Method: quicksort 
                                        ->  Custom Scan (DecompressChunk) on _hyper_2_5_chunk m1_2 (actual rows=1080 loops=1)
-                                             ->  Seq Scan on compress_hyper_6_18_chunk (actual rows=3 loops=1)
+                                             ->  Seq Scan on compress_hyper_6_19_chunk (actual rows=3 loops=1)
                            ->  Sort (actual rows=2 loops=1)
                                  Sort Key: m1_3."time"
                                  Sort Method: quicksort 
@@ -7724,7 +7724,7 @@ LIMIT 10;
                                        Sort Key: m1_3."time"
                                        Sort Method: quicksort 
                                        ->  Custom Scan (DecompressChunk) on _hyper_2_6_chunk m1_3 (actual rows=360 loops=1)
-                                             ->  Seq Scan on compress_hyper_6_19_chunk (actual rows=1 loops=1)
+                                             ->  Seq Scan on compress_hyper_6_20_chunk (actual rows=1 loops=1)
                      ->  Merge Append (never executed)
                            Sort Key: m1_4."time"
                            ->  Index Scan Backward using _hyper_2_7_chunk_metrics_space_time_idx on _hyper_2_7_chunk m1_4 (never executed)
@@ -7737,13 +7737,13 @@ LIMIT 10;
                                  ->  Sort (never executed)
                                        Sort Key: m1_7."time"
                                        ->  Custom Scan (DecompressChunk) on _hyper_2_10_chunk m1_7 (never executed)
-                                             ->  Seq Scan on compress_hyper_6_20_chunk (never executed)
+                                             ->  Seq Scan on compress_hyper_6_24_chunk (never executed)
                            ->  Sort (never executed)
                                  Sort Key: m1_8."time"
                                  ->  Sort (never executed)
                                        Sort Key: m1_8."time"
                                        ->  Custom Scan (DecompressChunk) on _hyper_2_11_chunk m1_8 (never executed)
-                                             ->  Seq Scan on compress_hyper_6_21_chunk (never executed)
+                                             ->  Seq Scan on compress_hyper_6_25_chunk (never executed)
                            ->  Index Scan Backward using _hyper_2_12_chunk_metrics_space_time_idx on _hyper_2_12_chunk m1_9 (never executed)
                ->  Materialize (actual rows=26 loops=1)
                      ->  Custom Scan (ChunkAppend) on metrics_space m2 (actual rows=6 loops=1)
@@ -7757,7 +7757,7 @@ LIMIT 10;
                                              Sort Key: m2_1."time"
                                              Sort Method: quicksort 
                                              ->  Custom Scan (DecompressChunk) on _hyper_2_4_chunk m2_1 (actual rows=360 loops=1)
-                                                   ->  Seq Scan on compress_hyper_6_17_chunk compress_hyper_6_17_chunk_1 (actual rows=1 loops=1)
+                                                   ->  Seq Scan on compress_hyper_6_18_chunk compress_hyper_6_18_chunk_1 (actual rows=1 loops=1)
                                  ->  Sort (actual rows=4 loops=1)
                                        Sort Key: m2_2."time"
                                        Sort Method: quicksort 
@@ -7765,7 +7765,7 @@ LIMIT 10;
                                              Sort Key: m2_2."time"
                                              Sort Method: quicksort 
                                              ->  Custom Scan (DecompressChunk) on _hyper_2_5_chunk m2_2 (actual rows=1080 loops=1)
-                                                   ->  Seq Scan on compress_hyper_6_18_chunk compress_hyper_6_18_chunk_1 (actual rows=3 loops=1)
+                                                   ->  Seq Scan on compress_hyper_6_19_chunk compress_hyper_6_19_chunk_1 (actual rows=3 loops=1)
                                  ->  Sort (actual rows=2 loops=1)
                                        Sort Key: m2_3."time"
                                        Sort Method: quicksort 
@@ -7773,7 +7773,7 @@ LIMIT 10;
                                              Sort Key: m2_3."time"
                                              Sort Method: quicksort 
                                              ->  Custom Scan (DecompressChunk) on _hyper_2_6_chunk m2_3 (actual rows=360 loops=1)
-                                                   ->  Seq Scan on compress_hyper_6_19_chunk compress_hyper_6_19_chunk_1 (actual rows=1 loops=1)
+                                                   ->  Seq Scan on compress_hyper_6_20_chunk compress_hyper_6_20_chunk_1 (actual rows=1 loops=1)
                            ->  Merge Append (never executed)
                                  Sort Key: m2_4."time"
                                  ->  Index Scan Backward using _hyper_2_7_chunk_metrics_space_time_idx on _hyper_2_7_chunk m2_4 (never executed)
@@ -7786,13 +7786,13 @@ LIMIT 10;
                                        ->  Sort (never executed)
                                              Sort Key: m2_7."time"
                                              ->  Custom Scan (DecompressChunk) on _hyper_2_10_chunk m2_7 (never executed)
-                                                   ->  Seq Scan on compress_hyper_6_20_chunk compress_hyper_6_20_chunk_1 (never executed)
+                                                   ->  Seq Scan on compress_hyper_6_24_chunk compress_hyper_6_24_chunk_1 (never executed)
                                  ->  Sort (never executed)
                                        Sort Key: m2_8."time"
                                        ->  Sort (never executed)
                                              Sort Key: m2_8."time"
                                              ->  Custom Scan (DecompressChunk) on _hyper_2_11_chunk m2_8 (never executed)
-                                                   ->  Seq Scan on compress_hyper_6_21_chunk compress_hyper_6_21_chunk_1 (never executed)
+                                                   ->  Seq Scan on compress_hyper_6_25_chunk compress_hyper_6_25_chunk_1 (never executed)
                                  ->  Index Scan Backward using _hyper_2_12_chunk_metrics_space_time_idx on _hyper_2_12_chunk m2_9 (never executed)
 (104 rows)
 
@@ -7814,15 +7814,15 @@ FROM generate_series('2000-01-01'::timestamptz, '2000-02-01'::timestamptz, '1d':
                ->  Custom Scan (DecompressChunk) on _hyper_2_4_chunk m1_1 (actual rows=1 loops=5)
                      Filter: ("time" = g."time")
                      Rows Removed by Filter: 168
-                     ->  Seq Scan on compress_hyper_6_17_chunk (actual rows=1 loops=5)
+                     ->  Seq Scan on compress_hyper_6_18_chunk (actual rows=1 loops=5)
                            Filter: ((_ts_meta_min_3 <= g."time") AND (_ts_meta_max_3 >= g."time"))
                ->  Custom Scan (DecompressChunk) on _hyper_2_5_chunk m1_2 (never executed)
                      Filter: ("time" = g."time")
-                     ->  Seq Scan on compress_hyper_6_18_chunk (never executed)
+                     ->  Seq Scan on compress_hyper_6_19_chunk (never executed)
                            Filter: ((_ts_meta_min_3 <= g."time") AND (_ts_meta_max_3 >= g."time"))
                ->  Custom Scan (DecompressChunk) on _hyper_2_6_chunk m1_3 (never executed)
                      Filter: ("time" = g."time")
-                     ->  Seq Scan on compress_hyper_6_19_chunk (never executed)
+                     ->  Seq Scan on compress_hyper_6_20_chunk (never executed)
                            Filter: ((_ts_meta_min_3 <= g."time") AND (_ts_meta_max_3 >= g."time"))
                ->  Index Only Scan using _hyper_2_7_chunk_metrics_space_time_idx on _hyper_2_7_chunk m1_4 (actual rows=1 loops=7)
                      Index Cond: ("time" = g."time")
@@ -7836,11 +7836,11 @@ FROM generate_series('2000-01-01'::timestamptz, '2000-02-01'::timestamptz, '1d':
                ->  Custom Scan (DecompressChunk) on _hyper_2_10_chunk m1_7 (actual rows=1 loops=7)
                      Filter: ("time" = g."time")
                      Rows Removed by Filter: 240
-                     ->  Seq Scan on compress_hyper_6_20_chunk (actual rows=1 loops=7)
+                     ->  Seq Scan on compress_hyper_6_24_chunk (actual rows=1 loops=7)
                            Filter: ((_ts_meta_min_3 <= g."time") AND (_ts_meta_max_3 >= g."time"))
                ->  Custom Scan (DecompressChunk) on _hyper_2_11_chunk m1_8 (never executed)
                      Filter: ("time" = g."time")
-                     ->  Seq Scan on compress_hyper_6_21_chunk (never executed)
+                     ->  Seq Scan on compress_hyper_6_25_chunk (never executed)
                            Filter: ((_ts_meta_min_3 <= g."time") AND (_ts_meta_max_3 >= g."time"))
                ->  Index Only Scan using _hyper_2_12_chunk_metrics_space_time_idx on _hyper_2_12_chunk m1_9 (never executed)
                      Index Cond: ("time" = g."time")
@@ -7868,7 +7868,7 @@ FROM generate_series('2000-01-01'::timestamptz, '2000-02-01'::timestamptz, '1d':
                ->  Custom Scan (DecompressChunk) on _hyper_2_4_chunk m1_1 (actual rows=1 loops=5)
                      Filter: ("time" = g."time")
                      Rows Removed by Filter: 168
-                     ->  Seq Scan on compress_hyper_6_17_chunk (actual rows=1 loops=5)
+                     ->  Seq Scan on compress_hyper_6_18_chunk (actual rows=1 loops=5)
                            Filter: ((_ts_meta_min_3 <= g."time") AND (_ts_meta_max_3 >= g."time") AND (device_id = 1))
                ->  Index Only Scan using _hyper_2_7_chunk_metrics_space_device_id_time_idx on _hyper_2_7_chunk m1_2 (actual rows=1 loops=7)
                      Index Cond: ((device_id = 1) AND ("time" = g."time"))
@@ -7876,7 +7876,7 @@ FROM generate_series('2000-01-01'::timestamptz, '2000-02-01'::timestamptz, '1d':
                ->  Custom Scan (DecompressChunk) on _hyper_2_10_chunk m1_3 (actual rows=1 loops=7)
                      Filter: ("time" = g."time")
                      Rows Removed by Filter: 240
-                     ->  Seq Scan on compress_hyper_6_20_chunk (actual rows=1 loops=7)
+                     ->  Seq Scan on compress_hyper_6_24_chunk (actual rows=1 loops=7)
                            Filter: ((_ts_meta_min_3 <= g."time") AND (_ts_meta_max_3 >= g."time") AND (device_id = 1))
 (18 rows)
 
@@ -7891,7 +7891,7 @@ FROM generate_series('2000-01-01'::timestamptz, '2000-02-01'::timestamptz, '1d':
                ->  Custom Scan (DecompressChunk) on _hyper_2_5_chunk m1_1 (actual rows=1 loops=5)
                      Filter: ("time" = g."time")
                      Rows Removed by Filter: 168
-                     ->  Seq Scan on compress_hyper_6_18_chunk (actual rows=1 loops=5)
+                     ->  Seq Scan on compress_hyper_6_19_chunk (actual rows=1 loops=5)
                            Filter: ((_ts_meta_min_3 <= g."time") AND (_ts_meta_max_3 >= g."time") AND (device_id = 2))
                ->  Index Only Scan using _hyper_2_8_chunk_metrics_space_device_id_time_idx on _hyper_2_8_chunk m1_2 (actual rows=1 loops=7)
                      Index Cond: ((device_id = 2) AND ("time" = g."time"))
@@ -7899,7 +7899,7 @@ FROM generate_series('2000-01-01'::timestamptz, '2000-02-01'::timestamptz, '1d':
                ->  Custom Scan (DecompressChunk) on _hyper_2_11_chunk m1_3 (actual rows=1 loops=7)
                      Filter: ("time" = g."time")
                      Rows Removed by Filter: 240
-                     ->  Seq Scan on compress_hyper_6_21_chunk (actual rows=1 loops=7)
+                     ->  Seq Scan on compress_hyper_6_25_chunk (actual rows=1 loops=7)
                            Filter: ((_ts_meta_min_3 <= g."time") AND (_ts_meta_max_3 >= g."time") AND (device_id = 2))
 (18 rows)
 
@@ -8064,18 +8064,18 @@ WHERE metrics.time > metrics_space.time
  Nested Loop (actual rows=0 loops=1)
    ->  Append (actual rows=6840 loops=1)
          ->  Custom Scan (DecompressChunk) on _hyper_2_4_chunk (actual rows=360 loops=1)
-               ->  Index Scan using compress_hyper_6_17_chunk_c_space_index_2 on compress_hyper_6_17_chunk (actual rows=1 loops=1)
+               ->  Index Scan using compress_hyper_6_18_chunk_c_space_index_2 on compress_hyper_6_18_chunk (actual rows=1 loops=1)
          ->  Custom Scan (DecompressChunk) on _hyper_2_5_chunk (actual rows=1080 loops=1)
-               ->  Index Scan using compress_hyper_6_18_chunk_c_space_index_2 on compress_hyper_6_18_chunk (actual rows=3 loops=1)
+               ->  Index Scan using compress_hyper_6_19_chunk_c_space_index_2 on compress_hyper_6_19_chunk (actual rows=3 loops=1)
          ->  Custom Scan (DecompressChunk) on _hyper_2_6_chunk (actual rows=360 loops=1)
-               ->  Index Scan using compress_hyper_6_19_chunk_c_space_index_2 on compress_hyper_6_19_chunk (actual rows=1 loops=1)
+               ->  Index Scan using compress_hyper_6_20_chunk_c_space_index_2 on compress_hyper_6_20_chunk (actual rows=1 loops=1)
          ->  Index Scan Backward using _hyper_2_7_chunk_metrics_space_device_id_device_id_peer_v0_v1_2 on _hyper_2_7_chunk (actual rows=504 loops=1)
          ->  Index Scan Backward using _hyper_2_8_chunk_metrics_space_device_id_device_id_peer_v0_v1_2 on _hyper_2_8_chunk (actual rows=1512 loops=1)
          ->  Index Scan Backward using _hyper_2_9_chunk_metrics_space_device_id_device_id_peer_v0_v1_2 on _hyper_2_9_chunk (actual rows=504 loops=1)
          ->  Custom Scan (DecompressChunk) on _hyper_2_10_chunk (actual rows=504 loops=1)
-               ->  Index Scan using compress_hyper_6_20_chunk_c_space_index_2 on compress_hyper_6_20_chunk (actual rows=1 loops=1)
+               ->  Index Scan using compress_hyper_6_24_chunk_c_space_index_2 on compress_hyper_6_24_chunk (actual rows=1 loops=1)
          ->  Custom Scan (DecompressChunk) on _hyper_2_11_chunk (actual rows=1512 loops=1)
-               ->  Index Scan using compress_hyper_6_21_chunk_c_space_index_2 on compress_hyper_6_21_chunk (actual rows=3 loops=1)
+               ->  Index Scan using compress_hyper_6_25_chunk_c_space_index_2 on compress_hyper_6_25_chunk (actual rows=3 loops=1)
          ->  Index Scan Backward using _hyper_2_12_chunk_metrics_space_device_id_device_id_peer_v0_v_2 on _hyper_2_12_chunk (actual rows=504 loops=1)
    ->  Append (actual rows=0 loops=6840)
          ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk (actual rows=0 loops=6840)
@@ -8089,7 +8089,7 @@ WHERE metrics.time > metrics_space.time
          ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk (actual rows=0 loops=6840)
                Filter: (("time" > _hyper_2_4_chunk."time") AND ("time" < _hyper_2_4_chunk."time"))
                Rows Removed by Filter: 504
-               ->  Index Scan using compress_hyper_5_16_chunk_c_index_2 on compress_hyper_5_16_chunk (actual rows=1 loops=6840)
+               ->  Index Scan using compress_hyper_5_17_chunk_c_index_2 on compress_hyper_5_17_chunk (actual rows=1 loops=6840)
                      Index Cond: (device_id = _hyper_2_4_chunk.device_id)
 (30 rows)
 
@@ -8126,9 +8126,9 @@ WHERE ht.table_name = 'metrics_ordered'
 ORDER BY c.id;
               compress_chunk              
 ------------------------------------------
- _timescaledb_internal._hyper_11_26_chunk
- _timescaledb_internal._hyper_11_27_chunk
- _timescaledb_internal._hyper_11_28_chunk
+ _timescaledb_internal._hyper_11_31_chunk
+ _timescaledb_internal._hyper_11_33_chunk
+ _timescaledb_internal._hyper_11_35_chunk
 (3 rows)
 
 -- reindexing compressed hypertable to update statistics
@@ -8152,19 +8152,19 @@ $$;
  Limit (actual rows=10 loops=1)
    ->  Custom Scan (ChunkAppend) on metrics_ordered (actual rows=10 loops=1)
          Order: metrics_ordered."time" DESC
-         ->  Custom Scan (DecompressChunk) on _hyper_11_28_chunk (actual rows=10 loops=1)
+         ->  Custom Scan (DecompressChunk) on _hyper_11_35_chunk (actual rows=10 loops=1)
                ->  Sort (actual rows=5 loops=1)
-                     Sort Key: compress_hyper_12_31_chunk._ts_meta_max_1 DESC
+                     Sort Key: compress_hyper_12_36_chunk._ts_meta_max_1 DESC
                      Sort Method: quicksort 
-                     ->  Seq Scan on compress_hyper_12_31_chunk (actual rows=5 loops=1)
-         ->  Custom Scan (DecompressChunk) on _hyper_11_27_chunk (never executed)
+                     ->  Seq Scan on compress_hyper_12_36_chunk (actual rows=5 loops=1)
+         ->  Custom Scan (DecompressChunk) on _hyper_11_33_chunk (never executed)
                ->  Sort (never executed)
-                     Sort Key: compress_hyper_12_30_chunk._ts_meta_max_1 DESC
-                     ->  Seq Scan on compress_hyper_12_30_chunk (never executed)
-         ->  Custom Scan (DecompressChunk) on _hyper_11_26_chunk (never executed)
+                     Sort Key: compress_hyper_12_34_chunk._ts_meta_max_1 DESC
+                     ->  Seq Scan on compress_hyper_12_34_chunk (never executed)
+         ->  Custom Scan (DecompressChunk) on _hyper_11_31_chunk (never executed)
                ->  Sort (never executed)
-                     Sort Key: compress_hyper_12_29_chunk._ts_meta_max_1 DESC
-                     ->  Seq Scan on compress_hyper_12_29_chunk (never executed)
+                     Sort Key: compress_hyper_12_32_chunk._ts_meta_max_1 DESC
+                     ->  Seq Scan on compress_hyper_12_32_chunk (never executed)
 (16 rows)
 
 -- should have ordered DecompressChunk path because segmentby columns have equality constraints
@@ -8174,25 +8174,25 @@ $$;
  Limit (actual rows=0 loops=1)
    ->  Custom Scan (ChunkAppend) on metrics_ordered (actual rows=0 loops=1)
          Order: metrics_ordered."time" DESC
-         ->  Custom Scan (DecompressChunk) on _hyper_11_28_chunk (actual rows=0 loops=1)
+         ->  Custom Scan (DecompressChunk) on _hyper_11_35_chunk (actual rows=0 loops=1)
                ->  Sort (actual rows=0 loops=1)
-                     Sort Key: compress_hyper_12_31_chunk._ts_meta_sequence_num
+                     Sort Key: compress_hyper_12_36_chunk._ts_meta_sequence_num
                      Sort Method: quicksort 
-                     ->  Seq Scan on compress_hyper_12_31_chunk (actual rows=0 loops=1)
+                     ->  Seq Scan on compress_hyper_12_36_chunk (actual rows=0 loops=1)
                            Filter: ((device_id = 1) AND (device_id_peer = 3))
                            Rows Removed by Filter: 5
-         ->  Custom Scan (DecompressChunk) on _hyper_11_27_chunk (actual rows=0 loops=1)
+         ->  Custom Scan (DecompressChunk) on _hyper_11_33_chunk (actual rows=0 loops=1)
                ->  Sort (actual rows=0 loops=1)
-                     Sort Key: compress_hyper_12_30_chunk._ts_meta_sequence_num
+                     Sort Key: compress_hyper_12_34_chunk._ts_meta_sequence_num
                      Sort Method: quicksort 
-                     ->  Seq Scan on compress_hyper_12_30_chunk (actual rows=0 loops=1)
+                     ->  Seq Scan on compress_hyper_12_34_chunk (actual rows=0 loops=1)
                            Filter: ((device_id = 1) AND (device_id_peer = 3))
                            Rows Removed by Filter: 5
-         ->  Custom Scan (DecompressChunk) on _hyper_11_26_chunk (actual rows=0 loops=1)
+         ->  Custom Scan (DecompressChunk) on _hyper_11_31_chunk (actual rows=0 loops=1)
                ->  Sort (actual rows=0 loops=1)
-                     Sort Key: compress_hyper_12_29_chunk._ts_meta_sequence_num
+                     Sort Key: compress_hyper_12_32_chunk._ts_meta_sequence_num
                      Sort Method: quicksort 
-                     ->  Seq Scan on compress_hyper_12_29_chunk (actual rows=0 loops=1)
+                     ->  Seq Scan on compress_hyper_12_32_chunk (actual rows=0 loops=1)
                            Filter: ((device_id = 1) AND (device_id_peer = 3))
                            Rows Removed by Filter: 5
 (24 rows)
@@ -8204,35 +8204,35 @@ $$;
    ->  Nested Loop (actual rows=0 loops=1)
          ->  Merge Append (actual rows=6840 loops=1)
                Sort Key: d_1.device_id
-               ->  Custom Scan (DecompressChunk) on _hyper_11_26_chunk d_1 (actual rows=1800 loops=1)
-                     ->  Index Scan using compress_hyper_12_29_chunk__compressed_hypertable_12_device_id_ on compress_hyper_12_29_chunk (actual rows=5 loops=1)
-               ->  Custom Scan (DecompressChunk) on _hyper_11_27_chunk d_2 (actual rows=2520 loops=1)
-                     ->  Index Scan using compress_hyper_12_30_chunk__compressed_hypertable_12_device_id_ on compress_hyper_12_30_chunk (actual rows=5 loops=1)
-               ->  Custom Scan (DecompressChunk) on _hyper_11_28_chunk d_3 (actual rows=2520 loops=1)
-                     ->  Index Scan using compress_hyper_12_31_chunk__compressed_hypertable_12_device_id_ on compress_hyper_12_31_chunk (actual rows=5 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_11_31_chunk d_1 (actual rows=1800 loops=1)
+                     ->  Index Scan using compress_hyper_12_32_chunk__compressed_hypertable_12_device_id_ on compress_hyper_12_32_chunk (actual rows=5 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_11_33_chunk d_2 (actual rows=2520 loops=1)
+                     ->  Index Scan using compress_hyper_12_34_chunk__compressed_hypertable_12_device_id_ on compress_hyper_12_34_chunk (actual rows=5 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_11_35_chunk d_3 (actual rows=2520 loops=1)
+                     ->  Index Scan using compress_hyper_12_36_chunk__compressed_hypertable_12_device_id_ on compress_hyper_12_36_chunk (actual rows=5 loops=1)
          ->  Limit (actual rows=0 loops=6840)
                ->  Custom Scan (ChunkAppend) on metrics_ordered m (actual rows=0 loops=6840)
                      Order: m."time" DESC
                      Hypertables excluded during runtime: 0
-                     ->  Custom Scan (DecompressChunk) on _hyper_11_28_chunk m_1 (actual rows=0 loops=6840)
+                     ->  Custom Scan (DecompressChunk) on _hyper_11_35_chunk m_1 (actual rows=0 loops=6840)
                            ->  Sort (actual rows=0 loops=6840)
-                                 Sort Key: compress_hyper_12_31_chunk_1._ts_meta_sequence_num
+                                 Sort Key: compress_hyper_12_36_chunk_1._ts_meta_sequence_num
                                  Sort Method: quicksort 
-                                 ->  Seq Scan on compress_hyper_12_31_chunk compress_hyper_12_31_chunk_1 (actual rows=0 loops=6840)
+                                 ->  Seq Scan on compress_hyper_12_36_chunk compress_hyper_12_36_chunk_1 (actual rows=0 loops=6840)
                                        Filter: ((device_id = d_1.device_id) AND (device_id_peer = 3))
                                        Rows Removed by Filter: 5
-                     ->  Custom Scan (DecompressChunk) on _hyper_11_27_chunk m_2 (actual rows=0 loops=6840)
+                     ->  Custom Scan (DecompressChunk) on _hyper_11_33_chunk m_2 (actual rows=0 loops=6840)
                            ->  Sort (actual rows=0 loops=6840)
-                                 Sort Key: compress_hyper_12_30_chunk_1._ts_meta_sequence_num
+                                 Sort Key: compress_hyper_12_34_chunk_1._ts_meta_sequence_num
                                  Sort Method: quicksort 
-                                 ->  Seq Scan on compress_hyper_12_30_chunk compress_hyper_12_30_chunk_1 (actual rows=0 loops=6840)
+                                 ->  Seq Scan on compress_hyper_12_34_chunk compress_hyper_12_34_chunk_1 (actual rows=0 loops=6840)
                                        Filter: ((device_id = d_1.device_id) AND (device_id_peer = 3))
                                        Rows Removed by Filter: 5
-                     ->  Custom Scan (DecompressChunk) on _hyper_11_26_chunk m_3 (actual rows=0 loops=6840)
+                     ->  Custom Scan (DecompressChunk) on _hyper_11_31_chunk m_3 (actual rows=0 loops=6840)
                            ->  Sort (actual rows=0 loops=6840)
-                                 Sort Key: compress_hyper_12_29_chunk_1._ts_meta_sequence_num
+                                 Sort Key: compress_hyper_12_32_chunk_1._ts_meta_sequence_num
                                  Sort Method: quicksort 
-                                 ->  Seq Scan on compress_hyper_12_29_chunk compress_hyper_12_29_chunk_1 (actual rows=0 loops=6840)
+                                 ->  Seq Scan on compress_hyper_12_32_chunk compress_hyper_12_32_chunk_1 (actual rows=0 loops=6840)
                                        Filter: ((device_id = d_1.device_id) AND (device_id_peer = 3))
                                        Rows Removed by Filter: 5
 (35 rows)
@@ -8312,7 +8312,7 @@ PREPARE tableoid_prep AS SELECT tableoid::regclass FROM :TEST_TABLE WHERE device
          ->  Sort (never executed)
                Sort Key: _hyper_1_3_chunk."time"
                ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk (never executed)
-                     ->  Seq Scan on compress_hyper_5_16_chunk (never executed)
+                     ->  Seq Scan on compress_hyper_5_17_chunk (never executed)
                            Filter: (device_id = 1)
 (17 rows)
 
@@ -8369,7 +8369,7 @@ INSERT into readings select g, 1, 1.3 from generate_series('2001-03-01 01:01:01'
 SELECT count(compress_chunk(chunk.schema_name|| '.' || chunk.table_name))
 FROM _timescaledb_catalog.chunk chunk
 INNER JOIN _timescaledb_catalog.hypertable hypertable ON (chunk.hypertable_id = hypertable.id)
-WHERE hypertable.table_name = 'readings' and chunk.compressed_chunk_id IS NULL;
+WHERE hypertable.table_name = 'readings' and chunk.status & 1 = 0;
  count 
 -------
    703
@@ -8379,1419 +8379,1419 @@ EXPLAIN (costs off) SELECT t.fleet as fleet, min(r.fuel_consumption) AS avg_fuel
 FROM tags t
 INNER JOIN LATERAL(SELECT tags_id, fuel_consumption FROM readings r WHERE r.tags_id = t.id ) r ON true
 GROUP BY fleet;
-                                  QUERY PLAN                                  
-------------------------------------------------------------------------------
+                                  QUERY PLAN                                   
+-------------------------------------------------------------------------------
  HashAggregate
    Group Key: t.fleet
    ->  Hash Join
          Hash Cond: (r_1.tags_id = t.id)
          ->  Append
-               ->  Custom Scan (DecompressChunk) on _hyper_13_32_chunk r_1
-                     ->  Seq Scan on compress_hyper_14_735_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_33_chunk r_2
+               ->  Custom Scan (DecompressChunk) on _hyper_13_37_chunk r_1
+                     ->  Seq Scan on compress_hyper_14_38_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_39_chunk r_2
+                     ->  Seq Scan on compress_hyper_14_40_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_41_chunk r_3
+                     ->  Seq Scan on compress_hyper_14_42_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_43_chunk r_4
+                     ->  Seq Scan on compress_hyper_14_44_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_45_chunk r_5
+                     ->  Seq Scan on compress_hyper_14_46_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_47_chunk r_6
+                     ->  Seq Scan on compress_hyper_14_48_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_49_chunk r_7
+                     ->  Seq Scan on compress_hyper_14_50_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_51_chunk r_8
+                     ->  Seq Scan on compress_hyper_14_52_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_53_chunk r_9
+                     ->  Seq Scan on compress_hyper_14_54_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_55_chunk r_10
+                     ->  Seq Scan on compress_hyper_14_56_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_57_chunk r_11
+                     ->  Seq Scan on compress_hyper_14_58_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_59_chunk r_12
+                     ->  Seq Scan on compress_hyper_14_60_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_61_chunk r_13
+                     ->  Seq Scan on compress_hyper_14_62_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_63_chunk r_14
+                     ->  Seq Scan on compress_hyper_14_64_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_65_chunk r_15
+                     ->  Seq Scan on compress_hyper_14_66_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_67_chunk r_16
+                     ->  Seq Scan on compress_hyper_14_68_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_69_chunk r_17
+                     ->  Seq Scan on compress_hyper_14_70_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_71_chunk r_18
+                     ->  Seq Scan on compress_hyper_14_72_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_73_chunk r_19
+                     ->  Seq Scan on compress_hyper_14_74_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_75_chunk r_20
+                     ->  Seq Scan on compress_hyper_14_76_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_77_chunk r_21
+                     ->  Seq Scan on compress_hyper_14_78_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_79_chunk r_22
+                     ->  Seq Scan on compress_hyper_14_80_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_81_chunk r_23
+                     ->  Seq Scan on compress_hyper_14_82_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_83_chunk r_24
+                     ->  Seq Scan on compress_hyper_14_84_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_85_chunk r_25
+                     ->  Seq Scan on compress_hyper_14_86_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_87_chunk r_26
+                     ->  Seq Scan on compress_hyper_14_88_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_89_chunk r_27
+                     ->  Seq Scan on compress_hyper_14_90_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_91_chunk r_28
+                     ->  Seq Scan on compress_hyper_14_92_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_93_chunk r_29
+                     ->  Seq Scan on compress_hyper_14_94_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_95_chunk r_30
+                     ->  Seq Scan on compress_hyper_14_96_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_97_chunk r_31
+                     ->  Seq Scan on compress_hyper_14_98_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_99_chunk r_32
+                     ->  Seq Scan on compress_hyper_14_100_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_101_chunk r_33
+                     ->  Seq Scan on compress_hyper_14_102_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_103_chunk r_34
+                     ->  Seq Scan on compress_hyper_14_104_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_105_chunk r_35
+                     ->  Seq Scan on compress_hyper_14_106_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_107_chunk r_36
+                     ->  Seq Scan on compress_hyper_14_108_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_109_chunk r_37
+                     ->  Seq Scan on compress_hyper_14_110_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_111_chunk r_38
+                     ->  Seq Scan on compress_hyper_14_112_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_113_chunk r_39
+                     ->  Seq Scan on compress_hyper_14_114_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_115_chunk r_40
+                     ->  Seq Scan on compress_hyper_14_116_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_117_chunk r_41
+                     ->  Seq Scan on compress_hyper_14_118_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_119_chunk r_42
+                     ->  Seq Scan on compress_hyper_14_120_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_121_chunk r_43
+                     ->  Seq Scan on compress_hyper_14_122_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_123_chunk r_44
+                     ->  Seq Scan on compress_hyper_14_124_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_125_chunk r_45
+                     ->  Seq Scan on compress_hyper_14_126_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_127_chunk r_46
+                     ->  Seq Scan on compress_hyper_14_128_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_129_chunk r_47
+                     ->  Seq Scan on compress_hyper_14_130_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_131_chunk r_48
+                     ->  Seq Scan on compress_hyper_14_132_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_133_chunk r_49
+                     ->  Seq Scan on compress_hyper_14_134_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_135_chunk r_50
+                     ->  Seq Scan on compress_hyper_14_136_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_137_chunk r_51
+                     ->  Seq Scan on compress_hyper_14_138_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_139_chunk r_52
+                     ->  Seq Scan on compress_hyper_14_140_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_141_chunk r_53
+                     ->  Seq Scan on compress_hyper_14_142_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_143_chunk r_54
+                     ->  Seq Scan on compress_hyper_14_144_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_145_chunk r_55
+                     ->  Seq Scan on compress_hyper_14_146_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_147_chunk r_56
+                     ->  Seq Scan on compress_hyper_14_148_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_149_chunk r_57
+                     ->  Seq Scan on compress_hyper_14_150_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_151_chunk r_58
+                     ->  Seq Scan on compress_hyper_14_152_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_153_chunk r_59
+                     ->  Seq Scan on compress_hyper_14_154_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_155_chunk r_60
+                     ->  Seq Scan on compress_hyper_14_156_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_157_chunk r_61
+                     ->  Seq Scan on compress_hyper_14_158_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_159_chunk r_62
+                     ->  Seq Scan on compress_hyper_14_160_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_161_chunk r_63
+                     ->  Seq Scan on compress_hyper_14_162_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_163_chunk r_64
+                     ->  Seq Scan on compress_hyper_14_164_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_165_chunk r_65
+                     ->  Seq Scan on compress_hyper_14_166_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_167_chunk r_66
+                     ->  Seq Scan on compress_hyper_14_168_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_169_chunk r_67
+                     ->  Seq Scan on compress_hyper_14_170_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_171_chunk r_68
+                     ->  Seq Scan on compress_hyper_14_172_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_173_chunk r_69
+                     ->  Seq Scan on compress_hyper_14_174_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_175_chunk r_70
+                     ->  Seq Scan on compress_hyper_14_176_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_177_chunk r_71
+                     ->  Seq Scan on compress_hyper_14_178_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_179_chunk r_72
+                     ->  Seq Scan on compress_hyper_14_180_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_181_chunk r_73
+                     ->  Seq Scan on compress_hyper_14_182_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_183_chunk r_74
+                     ->  Seq Scan on compress_hyper_14_184_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_185_chunk r_75
+                     ->  Seq Scan on compress_hyper_14_186_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_187_chunk r_76
+                     ->  Seq Scan on compress_hyper_14_188_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_189_chunk r_77
+                     ->  Seq Scan on compress_hyper_14_190_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_191_chunk r_78
+                     ->  Seq Scan on compress_hyper_14_192_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_193_chunk r_79
+                     ->  Seq Scan on compress_hyper_14_194_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_195_chunk r_80
+                     ->  Seq Scan on compress_hyper_14_196_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_197_chunk r_81
+                     ->  Seq Scan on compress_hyper_14_198_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_199_chunk r_82
+                     ->  Seq Scan on compress_hyper_14_200_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_201_chunk r_83
+                     ->  Seq Scan on compress_hyper_14_202_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_203_chunk r_84
+                     ->  Seq Scan on compress_hyper_14_204_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_205_chunk r_85
+                     ->  Seq Scan on compress_hyper_14_206_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_207_chunk r_86
+                     ->  Seq Scan on compress_hyper_14_208_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_209_chunk r_87
+                     ->  Seq Scan on compress_hyper_14_210_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_211_chunk r_88
+                     ->  Seq Scan on compress_hyper_14_212_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_213_chunk r_89
+                     ->  Seq Scan on compress_hyper_14_214_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_215_chunk r_90
+                     ->  Seq Scan on compress_hyper_14_216_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_217_chunk r_91
+                     ->  Seq Scan on compress_hyper_14_218_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_219_chunk r_92
+                     ->  Seq Scan on compress_hyper_14_220_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_221_chunk r_93
+                     ->  Seq Scan on compress_hyper_14_222_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_223_chunk r_94
+                     ->  Seq Scan on compress_hyper_14_224_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_225_chunk r_95
+                     ->  Seq Scan on compress_hyper_14_226_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_227_chunk r_96
+                     ->  Seq Scan on compress_hyper_14_228_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_229_chunk r_97
+                     ->  Seq Scan on compress_hyper_14_230_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_231_chunk r_98
+                     ->  Seq Scan on compress_hyper_14_232_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_233_chunk r_99
+                     ->  Seq Scan on compress_hyper_14_234_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_235_chunk r_100
+                     ->  Seq Scan on compress_hyper_14_236_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_237_chunk r_101
+                     ->  Seq Scan on compress_hyper_14_238_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_239_chunk r_102
+                     ->  Seq Scan on compress_hyper_14_240_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_241_chunk r_103
+                     ->  Seq Scan on compress_hyper_14_242_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_243_chunk r_104
+                     ->  Seq Scan on compress_hyper_14_244_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_245_chunk r_105
+                     ->  Seq Scan on compress_hyper_14_246_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_247_chunk r_106
+                     ->  Seq Scan on compress_hyper_14_248_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_249_chunk r_107
+                     ->  Seq Scan on compress_hyper_14_250_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_251_chunk r_108
+                     ->  Seq Scan on compress_hyper_14_252_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_253_chunk r_109
+                     ->  Seq Scan on compress_hyper_14_254_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_255_chunk r_110
+                     ->  Seq Scan on compress_hyper_14_256_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_257_chunk r_111
+                     ->  Seq Scan on compress_hyper_14_258_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_259_chunk r_112
+                     ->  Seq Scan on compress_hyper_14_260_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_261_chunk r_113
+                     ->  Seq Scan on compress_hyper_14_262_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_263_chunk r_114
+                     ->  Seq Scan on compress_hyper_14_264_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_265_chunk r_115
+                     ->  Seq Scan on compress_hyper_14_266_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_267_chunk r_116
+                     ->  Seq Scan on compress_hyper_14_268_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_269_chunk r_117
+                     ->  Seq Scan on compress_hyper_14_270_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_271_chunk r_118
+                     ->  Seq Scan on compress_hyper_14_272_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_273_chunk r_119
+                     ->  Seq Scan on compress_hyper_14_274_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_275_chunk r_120
+                     ->  Seq Scan on compress_hyper_14_276_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_277_chunk r_121
+                     ->  Seq Scan on compress_hyper_14_278_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_279_chunk r_122
+                     ->  Seq Scan on compress_hyper_14_280_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_281_chunk r_123
+                     ->  Seq Scan on compress_hyper_14_282_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_283_chunk r_124
+                     ->  Seq Scan on compress_hyper_14_284_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_285_chunk r_125
+                     ->  Seq Scan on compress_hyper_14_286_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_287_chunk r_126
+                     ->  Seq Scan on compress_hyper_14_288_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_289_chunk r_127
+                     ->  Seq Scan on compress_hyper_14_290_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_291_chunk r_128
+                     ->  Seq Scan on compress_hyper_14_292_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_293_chunk r_129
+                     ->  Seq Scan on compress_hyper_14_294_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_295_chunk r_130
+                     ->  Seq Scan on compress_hyper_14_296_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_297_chunk r_131
+                     ->  Seq Scan on compress_hyper_14_298_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_299_chunk r_132
+                     ->  Seq Scan on compress_hyper_14_300_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_301_chunk r_133
+                     ->  Seq Scan on compress_hyper_14_302_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_303_chunk r_134
+                     ->  Seq Scan on compress_hyper_14_304_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_305_chunk r_135
+                     ->  Seq Scan on compress_hyper_14_306_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_307_chunk r_136
+                     ->  Seq Scan on compress_hyper_14_308_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_309_chunk r_137
+                     ->  Seq Scan on compress_hyper_14_310_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_311_chunk r_138
+                     ->  Seq Scan on compress_hyper_14_312_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_313_chunk r_139
+                     ->  Seq Scan on compress_hyper_14_314_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_315_chunk r_140
+                     ->  Seq Scan on compress_hyper_14_316_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_317_chunk r_141
+                     ->  Seq Scan on compress_hyper_14_318_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_319_chunk r_142
+                     ->  Seq Scan on compress_hyper_14_320_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_321_chunk r_143
+                     ->  Seq Scan on compress_hyper_14_322_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_323_chunk r_144
+                     ->  Seq Scan on compress_hyper_14_324_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_325_chunk r_145
+                     ->  Seq Scan on compress_hyper_14_326_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_327_chunk r_146
+                     ->  Seq Scan on compress_hyper_14_328_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_329_chunk r_147
+                     ->  Seq Scan on compress_hyper_14_330_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_331_chunk r_148
+                     ->  Seq Scan on compress_hyper_14_332_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_333_chunk r_149
+                     ->  Seq Scan on compress_hyper_14_334_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_335_chunk r_150
+                     ->  Seq Scan on compress_hyper_14_336_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_337_chunk r_151
+                     ->  Seq Scan on compress_hyper_14_338_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_339_chunk r_152
+                     ->  Seq Scan on compress_hyper_14_340_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_341_chunk r_153
+                     ->  Seq Scan on compress_hyper_14_342_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_343_chunk r_154
+                     ->  Seq Scan on compress_hyper_14_344_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_345_chunk r_155
+                     ->  Seq Scan on compress_hyper_14_346_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_347_chunk r_156
+                     ->  Seq Scan on compress_hyper_14_348_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_349_chunk r_157
+                     ->  Seq Scan on compress_hyper_14_350_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_351_chunk r_158
+                     ->  Seq Scan on compress_hyper_14_352_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_353_chunk r_159
+                     ->  Seq Scan on compress_hyper_14_354_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_355_chunk r_160
+                     ->  Seq Scan on compress_hyper_14_356_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_357_chunk r_161
+                     ->  Seq Scan on compress_hyper_14_358_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_359_chunk r_162
+                     ->  Seq Scan on compress_hyper_14_360_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_361_chunk r_163
+                     ->  Seq Scan on compress_hyper_14_362_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_363_chunk r_164
+                     ->  Seq Scan on compress_hyper_14_364_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_365_chunk r_165
+                     ->  Seq Scan on compress_hyper_14_366_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_367_chunk r_166
+                     ->  Seq Scan on compress_hyper_14_368_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_369_chunk r_167
+                     ->  Seq Scan on compress_hyper_14_370_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_371_chunk r_168
+                     ->  Seq Scan on compress_hyper_14_372_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_373_chunk r_169
+                     ->  Seq Scan on compress_hyper_14_374_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_375_chunk r_170
+                     ->  Seq Scan on compress_hyper_14_376_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_377_chunk r_171
+                     ->  Seq Scan on compress_hyper_14_378_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_379_chunk r_172
+                     ->  Seq Scan on compress_hyper_14_380_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_381_chunk r_173
+                     ->  Seq Scan on compress_hyper_14_382_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_383_chunk r_174
+                     ->  Seq Scan on compress_hyper_14_384_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_385_chunk r_175
+                     ->  Seq Scan on compress_hyper_14_386_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_387_chunk r_176
+                     ->  Seq Scan on compress_hyper_14_388_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_389_chunk r_177
+                     ->  Seq Scan on compress_hyper_14_390_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_391_chunk r_178
+                     ->  Seq Scan on compress_hyper_14_392_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_393_chunk r_179
+                     ->  Seq Scan on compress_hyper_14_394_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_395_chunk r_180
+                     ->  Seq Scan on compress_hyper_14_396_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_397_chunk r_181
+                     ->  Seq Scan on compress_hyper_14_398_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_399_chunk r_182
+                     ->  Seq Scan on compress_hyper_14_400_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_401_chunk r_183
+                     ->  Seq Scan on compress_hyper_14_402_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_403_chunk r_184
+                     ->  Seq Scan on compress_hyper_14_404_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_405_chunk r_185
+                     ->  Seq Scan on compress_hyper_14_406_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_407_chunk r_186
+                     ->  Seq Scan on compress_hyper_14_408_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_409_chunk r_187
+                     ->  Seq Scan on compress_hyper_14_410_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_411_chunk r_188
+                     ->  Seq Scan on compress_hyper_14_412_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_413_chunk r_189
+                     ->  Seq Scan on compress_hyper_14_414_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_415_chunk r_190
+                     ->  Seq Scan on compress_hyper_14_416_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_417_chunk r_191
+                     ->  Seq Scan on compress_hyper_14_418_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_419_chunk r_192
+                     ->  Seq Scan on compress_hyper_14_420_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_421_chunk r_193
+                     ->  Seq Scan on compress_hyper_14_422_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_423_chunk r_194
+                     ->  Seq Scan on compress_hyper_14_424_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_425_chunk r_195
+                     ->  Seq Scan on compress_hyper_14_426_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_427_chunk r_196
+                     ->  Seq Scan on compress_hyper_14_428_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_429_chunk r_197
+                     ->  Seq Scan on compress_hyper_14_430_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_431_chunk r_198
+                     ->  Seq Scan on compress_hyper_14_432_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_433_chunk r_199
+                     ->  Seq Scan on compress_hyper_14_434_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_435_chunk r_200
+                     ->  Seq Scan on compress_hyper_14_436_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_437_chunk r_201
+                     ->  Seq Scan on compress_hyper_14_438_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_439_chunk r_202
+                     ->  Seq Scan on compress_hyper_14_440_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_441_chunk r_203
+                     ->  Seq Scan on compress_hyper_14_442_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_443_chunk r_204
+                     ->  Seq Scan on compress_hyper_14_444_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_445_chunk r_205
+                     ->  Seq Scan on compress_hyper_14_446_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_447_chunk r_206
+                     ->  Seq Scan on compress_hyper_14_448_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_449_chunk r_207
+                     ->  Seq Scan on compress_hyper_14_450_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_451_chunk r_208
+                     ->  Seq Scan on compress_hyper_14_452_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_453_chunk r_209
+                     ->  Seq Scan on compress_hyper_14_454_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_455_chunk r_210
+                     ->  Seq Scan on compress_hyper_14_456_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_457_chunk r_211
+                     ->  Seq Scan on compress_hyper_14_458_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_459_chunk r_212
+                     ->  Seq Scan on compress_hyper_14_460_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_461_chunk r_213
+                     ->  Seq Scan on compress_hyper_14_462_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_463_chunk r_214
+                     ->  Seq Scan on compress_hyper_14_464_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_465_chunk r_215
+                     ->  Seq Scan on compress_hyper_14_466_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_467_chunk r_216
+                     ->  Seq Scan on compress_hyper_14_468_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_469_chunk r_217
+                     ->  Seq Scan on compress_hyper_14_470_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_471_chunk r_218
+                     ->  Seq Scan on compress_hyper_14_472_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_473_chunk r_219
+                     ->  Seq Scan on compress_hyper_14_474_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_475_chunk r_220
+                     ->  Seq Scan on compress_hyper_14_476_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_477_chunk r_221
+                     ->  Seq Scan on compress_hyper_14_478_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_479_chunk r_222
+                     ->  Seq Scan on compress_hyper_14_480_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_481_chunk r_223
+                     ->  Seq Scan on compress_hyper_14_482_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_483_chunk r_224
+                     ->  Seq Scan on compress_hyper_14_484_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_485_chunk r_225
+                     ->  Seq Scan on compress_hyper_14_486_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_487_chunk r_226
+                     ->  Seq Scan on compress_hyper_14_488_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_489_chunk r_227
+                     ->  Seq Scan on compress_hyper_14_490_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_491_chunk r_228
+                     ->  Seq Scan on compress_hyper_14_492_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_493_chunk r_229
+                     ->  Seq Scan on compress_hyper_14_494_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_495_chunk r_230
+                     ->  Seq Scan on compress_hyper_14_496_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_497_chunk r_231
+                     ->  Seq Scan on compress_hyper_14_498_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_499_chunk r_232
+                     ->  Seq Scan on compress_hyper_14_500_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_501_chunk r_233
+                     ->  Seq Scan on compress_hyper_14_502_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_503_chunk r_234
+                     ->  Seq Scan on compress_hyper_14_504_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_505_chunk r_235
+                     ->  Seq Scan on compress_hyper_14_506_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_507_chunk r_236
+                     ->  Seq Scan on compress_hyper_14_508_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_509_chunk r_237
+                     ->  Seq Scan on compress_hyper_14_510_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_511_chunk r_238
+                     ->  Seq Scan on compress_hyper_14_512_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_513_chunk r_239
+                     ->  Seq Scan on compress_hyper_14_514_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_515_chunk r_240
+                     ->  Seq Scan on compress_hyper_14_516_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_517_chunk r_241
+                     ->  Seq Scan on compress_hyper_14_518_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_519_chunk r_242
+                     ->  Seq Scan on compress_hyper_14_520_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_521_chunk r_243
+                     ->  Seq Scan on compress_hyper_14_522_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_523_chunk r_244
+                     ->  Seq Scan on compress_hyper_14_524_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_525_chunk r_245
+                     ->  Seq Scan on compress_hyper_14_526_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_527_chunk r_246
+                     ->  Seq Scan on compress_hyper_14_528_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_529_chunk r_247
+                     ->  Seq Scan on compress_hyper_14_530_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_531_chunk r_248
+                     ->  Seq Scan on compress_hyper_14_532_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_533_chunk r_249
+                     ->  Seq Scan on compress_hyper_14_534_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_535_chunk r_250
+                     ->  Seq Scan on compress_hyper_14_536_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_537_chunk r_251
+                     ->  Seq Scan on compress_hyper_14_538_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_539_chunk r_252
+                     ->  Seq Scan on compress_hyper_14_540_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_541_chunk r_253
+                     ->  Seq Scan on compress_hyper_14_542_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_543_chunk r_254
+                     ->  Seq Scan on compress_hyper_14_544_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_545_chunk r_255
+                     ->  Seq Scan on compress_hyper_14_546_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_547_chunk r_256
+                     ->  Seq Scan on compress_hyper_14_548_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_549_chunk r_257
+                     ->  Seq Scan on compress_hyper_14_550_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_551_chunk r_258
+                     ->  Seq Scan on compress_hyper_14_552_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_553_chunk r_259
+                     ->  Seq Scan on compress_hyper_14_554_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_555_chunk r_260
+                     ->  Seq Scan on compress_hyper_14_556_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_557_chunk r_261
+                     ->  Seq Scan on compress_hyper_14_558_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_559_chunk r_262
+                     ->  Seq Scan on compress_hyper_14_560_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_561_chunk r_263
+                     ->  Seq Scan on compress_hyper_14_562_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_563_chunk r_264
+                     ->  Seq Scan on compress_hyper_14_564_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_565_chunk r_265
+                     ->  Seq Scan on compress_hyper_14_566_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_567_chunk r_266
+                     ->  Seq Scan on compress_hyper_14_568_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_569_chunk r_267
+                     ->  Seq Scan on compress_hyper_14_570_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_571_chunk r_268
+                     ->  Seq Scan on compress_hyper_14_572_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_573_chunk r_269
+                     ->  Seq Scan on compress_hyper_14_574_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_575_chunk r_270
+                     ->  Seq Scan on compress_hyper_14_576_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_577_chunk r_271
+                     ->  Seq Scan on compress_hyper_14_578_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_579_chunk r_272
+                     ->  Seq Scan on compress_hyper_14_580_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_581_chunk r_273
+                     ->  Seq Scan on compress_hyper_14_582_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_583_chunk r_274
+                     ->  Seq Scan on compress_hyper_14_584_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_585_chunk r_275
+                     ->  Seq Scan on compress_hyper_14_586_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_587_chunk r_276
+                     ->  Seq Scan on compress_hyper_14_588_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_589_chunk r_277
+                     ->  Seq Scan on compress_hyper_14_590_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_591_chunk r_278
+                     ->  Seq Scan on compress_hyper_14_592_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_593_chunk r_279
+                     ->  Seq Scan on compress_hyper_14_594_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_595_chunk r_280
+                     ->  Seq Scan on compress_hyper_14_596_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_597_chunk r_281
+                     ->  Seq Scan on compress_hyper_14_598_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_599_chunk r_282
+                     ->  Seq Scan on compress_hyper_14_600_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_601_chunk r_283
+                     ->  Seq Scan on compress_hyper_14_602_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_603_chunk r_284
+                     ->  Seq Scan on compress_hyper_14_604_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_605_chunk r_285
+                     ->  Seq Scan on compress_hyper_14_606_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_607_chunk r_286
+                     ->  Seq Scan on compress_hyper_14_608_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_609_chunk r_287
+                     ->  Seq Scan on compress_hyper_14_610_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_611_chunk r_288
+                     ->  Seq Scan on compress_hyper_14_612_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_613_chunk r_289
+                     ->  Seq Scan on compress_hyper_14_614_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_615_chunk r_290
+                     ->  Seq Scan on compress_hyper_14_616_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_617_chunk r_291
+                     ->  Seq Scan on compress_hyper_14_618_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_619_chunk r_292
+                     ->  Seq Scan on compress_hyper_14_620_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_621_chunk r_293
+                     ->  Seq Scan on compress_hyper_14_622_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_623_chunk r_294
+                     ->  Seq Scan on compress_hyper_14_624_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_625_chunk r_295
+                     ->  Seq Scan on compress_hyper_14_626_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_627_chunk r_296
+                     ->  Seq Scan on compress_hyper_14_628_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_629_chunk r_297
+                     ->  Seq Scan on compress_hyper_14_630_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_631_chunk r_298
+                     ->  Seq Scan on compress_hyper_14_632_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_633_chunk r_299
+                     ->  Seq Scan on compress_hyper_14_634_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_635_chunk r_300
+                     ->  Seq Scan on compress_hyper_14_636_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_637_chunk r_301
+                     ->  Seq Scan on compress_hyper_14_638_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_639_chunk r_302
+                     ->  Seq Scan on compress_hyper_14_640_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_641_chunk r_303
+                     ->  Seq Scan on compress_hyper_14_642_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_643_chunk r_304
+                     ->  Seq Scan on compress_hyper_14_644_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_645_chunk r_305
+                     ->  Seq Scan on compress_hyper_14_646_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_647_chunk r_306
+                     ->  Seq Scan on compress_hyper_14_648_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_649_chunk r_307
+                     ->  Seq Scan on compress_hyper_14_650_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_651_chunk r_308
+                     ->  Seq Scan on compress_hyper_14_652_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_653_chunk r_309
+                     ->  Seq Scan on compress_hyper_14_654_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_655_chunk r_310
+                     ->  Seq Scan on compress_hyper_14_656_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_657_chunk r_311
+                     ->  Seq Scan on compress_hyper_14_658_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_659_chunk r_312
+                     ->  Seq Scan on compress_hyper_14_660_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_661_chunk r_313
+                     ->  Seq Scan on compress_hyper_14_662_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_663_chunk r_314
+                     ->  Seq Scan on compress_hyper_14_664_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_665_chunk r_315
+                     ->  Seq Scan on compress_hyper_14_666_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_667_chunk r_316
+                     ->  Seq Scan on compress_hyper_14_668_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_669_chunk r_317
+                     ->  Seq Scan on compress_hyper_14_670_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_671_chunk r_318
+                     ->  Seq Scan on compress_hyper_14_672_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_673_chunk r_319
+                     ->  Seq Scan on compress_hyper_14_674_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_675_chunk r_320
+                     ->  Seq Scan on compress_hyper_14_676_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_677_chunk r_321
+                     ->  Seq Scan on compress_hyper_14_678_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_679_chunk r_322
+                     ->  Seq Scan on compress_hyper_14_680_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_681_chunk r_323
+                     ->  Seq Scan on compress_hyper_14_682_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_683_chunk r_324
+                     ->  Seq Scan on compress_hyper_14_684_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_685_chunk r_325
+                     ->  Seq Scan on compress_hyper_14_686_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_687_chunk r_326
+                     ->  Seq Scan on compress_hyper_14_688_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_689_chunk r_327
+                     ->  Seq Scan on compress_hyper_14_690_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_691_chunk r_328
+                     ->  Seq Scan on compress_hyper_14_692_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_693_chunk r_329
+                     ->  Seq Scan on compress_hyper_14_694_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_695_chunk r_330
+                     ->  Seq Scan on compress_hyper_14_696_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_697_chunk r_331
+                     ->  Seq Scan on compress_hyper_14_698_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_699_chunk r_332
+                     ->  Seq Scan on compress_hyper_14_700_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_701_chunk r_333
+                     ->  Seq Scan on compress_hyper_14_702_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_703_chunk r_334
+                     ->  Seq Scan on compress_hyper_14_704_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_705_chunk r_335
+                     ->  Seq Scan on compress_hyper_14_706_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_707_chunk r_336
+                     ->  Seq Scan on compress_hyper_14_708_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_709_chunk r_337
+                     ->  Seq Scan on compress_hyper_14_710_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_711_chunk r_338
+                     ->  Seq Scan on compress_hyper_14_712_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_713_chunk r_339
+                     ->  Seq Scan on compress_hyper_14_714_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_715_chunk r_340
+                     ->  Seq Scan on compress_hyper_14_716_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_717_chunk r_341
+                     ->  Seq Scan on compress_hyper_14_718_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_719_chunk r_342
+                     ->  Seq Scan on compress_hyper_14_720_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_721_chunk r_343
+                     ->  Seq Scan on compress_hyper_14_722_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_723_chunk r_344
+                     ->  Seq Scan on compress_hyper_14_724_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_725_chunk r_345
+                     ->  Seq Scan on compress_hyper_14_726_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_727_chunk r_346
+                     ->  Seq Scan on compress_hyper_14_728_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_729_chunk r_347
+                     ->  Seq Scan on compress_hyper_14_730_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_731_chunk r_348
+                     ->  Seq Scan on compress_hyper_14_732_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_733_chunk r_349
+                     ->  Seq Scan on compress_hyper_14_734_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_735_chunk r_350
                      ->  Seq Scan on compress_hyper_14_736_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_34_chunk r_3
-                     ->  Seq Scan on compress_hyper_14_737_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_35_chunk r_4
+               ->  Custom Scan (DecompressChunk) on _hyper_13_737_chunk r_351
                      ->  Seq Scan on compress_hyper_14_738_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_36_chunk r_5
-                     ->  Seq Scan on compress_hyper_14_739_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_37_chunk r_6
+               ->  Custom Scan (DecompressChunk) on _hyper_13_739_chunk r_352
                      ->  Seq Scan on compress_hyper_14_740_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_38_chunk r_7
-                     ->  Seq Scan on compress_hyper_14_741_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_39_chunk r_8
+               ->  Custom Scan (DecompressChunk) on _hyper_13_741_chunk r_353
                      ->  Seq Scan on compress_hyper_14_742_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_40_chunk r_9
-                     ->  Seq Scan on compress_hyper_14_743_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_41_chunk r_10
+               ->  Custom Scan (DecompressChunk) on _hyper_13_743_chunk r_354
                      ->  Seq Scan on compress_hyper_14_744_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_42_chunk r_11
-                     ->  Seq Scan on compress_hyper_14_745_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_43_chunk r_12
+               ->  Custom Scan (DecompressChunk) on _hyper_13_745_chunk r_355
                      ->  Seq Scan on compress_hyper_14_746_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_44_chunk r_13
-                     ->  Seq Scan on compress_hyper_14_747_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_45_chunk r_14
+               ->  Custom Scan (DecompressChunk) on _hyper_13_747_chunk r_356
                      ->  Seq Scan on compress_hyper_14_748_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_46_chunk r_15
-                     ->  Seq Scan on compress_hyper_14_749_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_47_chunk r_16
+               ->  Custom Scan (DecompressChunk) on _hyper_13_749_chunk r_357
                      ->  Seq Scan on compress_hyper_14_750_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_48_chunk r_17
-                     ->  Seq Scan on compress_hyper_14_751_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_49_chunk r_18
+               ->  Custom Scan (DecompressChunk) on _hyper_13_751_chunk r_358
                      ->  Seq Scan on compress_hyper_14_752_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_50_chunk r_19
-                     ->  Seq Scan on compress_hyper_14_753_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_51_chunk r_20
+               ->  Custom Scan (DecompressChunk) on _hyper_13_753_chunk r_359
                      ->  Seq Scan on compress_hyper_14_754_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_52_chunk r_21
-                     ->  Seq Scan on compress_hyper_14_755_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_53_chunk r_22
+               ->  Custom Scan (DecompressChunk) on _hyper_13_755_chunk r_360
                      ->  Seq Scan on compress_hyper_14_756_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_54_chunk r_23
-                     ->  Seq Scan on compress_hyper_14_757_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_55_chunk r_24
+               ->  Custom Scan (DecompressChunk) on _hyper_13_757_chunk r_361
                      ->  Seq Scan on compress_hyper_14_758_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_56_chunk r_25
-                     ->  Seq Scan on compress_hyper_14_759_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_57_chunk r_26
+               ->  Custom Scan (DecompressChunk) on _hyper_13_759_chunk r_362
                      ->  Seq Scan on compress_hyper_14_760_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_58_chunk r_27
-                     ->  Seq Scan on compress_hyper_14_761_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_59_chunk r_28
+               ->  Custom Scan (DecompressChunk) on _hyper_13_761_chunk r_363
                      ->  Seq Scan on compress_hyper_14_762_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_60_chunk r_29
-                     ->  Seq Scan on compress_hyper_14_763_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_61_chunk r_30
+               ->  Custom Scan (DecompressChunk) on _hyper_13_763_chunk r_364
                      ->  Seq Scan on compress_hyper_14_764_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_62_chunk r_31
-                     ->  Seq Scan on compress_hyper_14_765_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_63_chunk r_32
+               ->  Custom Scan (DecompressChunk) on _hyper_13_765_chunk r_365
                      ->  Seq Scan on compress_hyper_14_766_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_64_chunk r_33
-                     ->  Seq Scan on compress_hyper_14_767_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_65_chunk r_34
+               ->  Custom Scan (DecompressChunk) on _hyper_13_767_chunk r_366
                      ->  Seq Scan on compress_hyper_14_768_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_66_chunk r_35
-                     ->  Seq Scan on compress_hyper_14_769_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_67_chunk r_36
+               ->  Custom Scan (DecompressChunk) on _hyper_13_769_chunk r_367
                      ->  Seq Scan on compress_hyper_14_770_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_68_chunk r_37
-                     ->  Seq Scan on compress_hyper_14_771_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_69_chunk r_38
+               ->  Custom Scan (DecompressChunk) on _hyper_13_771_chunk r_368
                      ->  Seq Scan on compress_hyper_14_772_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_70_chunk r_39
-                     ->  Seq Scan on compress_hyper_14_773_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_71_chunk r_40
+               ->  Custom Scan (DecompressChunk) on _hyper_13_773_chunk r_369
                      ->  Seq Scan on compress_hyper_14_774_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_72_chunk r_41
-                     ->  Seq Scan on compress_hyper_14_775_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_73_chunk r_42
+               ->  Custom Scan (DecompressChunk) on _hyper_13_775_chunk r_370
                      ->  Seq Scan on compress_hyper_14_776_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_74_chunk r_43
-                     ->  Seq Scan on compress_hyper_14_777_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_75_chunk r_44
+               ->  Custom Scan (DecompressChunk) on _hyper_13_777_chunk r_371
                      ->  Seq Scan on compress_hyper_14_778_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_76_chunk r_45
-                     ->  Seq Scan on compress_hyper_14_779_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_77_chunk r_46
+               ->  Custom Scan (DecompressChunk) on _hyper_13_779_chunk r_372
                      ->  Seq Scan on compress_hyper_14_780_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_78_chunk r_47
-                     ->  Seq Scan on compress_hyper_14_781_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_79_chunk r_48
+               ->  Custom Scan (DecompressChunk) on _hyper_13_781_chunk r_373
                      ->  Seq Scan on compress_hyper_14_782_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_80_chunk r_49
-                     ->  Seq Scan on compress_hyper_14_783_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_81_chunk r_50
+               ->  Custom Scan (DecompressChunk) on _hyper_13_783_chunk r_374
                      ->  Seq Scan on compress_hyper_14_784_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_82_chunk r_51
-                     ->  Seq Scan on compress_hyper_14_785_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_83_chunk r_52
+               ->  Custom Scan (DecompressChunk) on _hyper_13_785_chunk r_375
                      ->  Seq Scan on compress_hyper_14_786_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_84_chunk r_53
-                     ->  Seq Scan on compress_hyper_14_787_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_85_chunk r_54
+               ->  Custom Scan (DecompressChunk) on _hyper_13_787_chunk r_376
                      ->  Seq Scan on compress_hyper_14_788_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_86_chunk r_55
-                     ->  Seq Scan on compress_hyper_14_789_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_87_chunk r_56
+               ->  Custom Scan (DecompressChunk) on _hyper_13_789_chunk r_377
                      ->  Seq Scan on compress_hyper_14_790_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_88_chunk r_57
-                     ->  Seq Scan on compress_hyper_14_791_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_89_chunk r_58
+               ->  Custom Scan (DecompressChunk) on _hyper_13_791_chunk r_378
                      ->  Seq Scan on compress_hyper_14_792_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_90_chunk r_59
-                     ->  Seq Scan on compress_hyper_14_793_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_91_chunk r_60
+               ->  Custom Scan (DecompressChunk) on _hyper_13_793_chunk r_379
                      ->  Seq Scan on compress_hyper_14_794_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_92_chunk r_61
-                     ->  Seq Scan on compress_hyper_14_795_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_93_chunk r_62
+               ->  Custom Scan (DecompressChunk) on _hyper_13_795_chunk r_380
                      ->  Seq Scan on compress_hyper_14_796_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_94_chunk r_63
-                     ->  Seq Scan on compress_hyper_14_797_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_95_chunk r_64
+               ->  Custom Scan (DecompressChunk) on _hyper_13_797_chunk r_381
                      ->  Seq Scan on compress_hyper_14_798_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_96_chunk r_65
-                     ->  Seq Scan on compress_hyper_14_799_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_97_chunk r_66
+               ->  Custom Scan (DecompressChunk) on _hyper_13_799_chunk r_382
                      ->  Seq Scan on compress_hyper_14_800_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_98_chunk r_67
-                     ->  Seq Scan on compress_hyper_14_801_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_99_chunk r_68
+               ->  Custom Scan (DecompressChunk) on _hyper_13_801_chunk r_383
                      ->  Seq Scan on compress_hyper_14_802_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_100_chunk r_69
-                     ->  Seq Scan on compress_hyper_14_803_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_101_chunk r_70
+               ->  Custom Scan (DecompressChunk) on _hyper_13_803_chunk r_384
                      ->  Seq Scan on compress_hyper_14_804_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_102_chunk r_71
-                     ->  Seq Scan on compress_hyper_14_805_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_103_chunk r_72
+               ->  Custom Scan (DecompressChunk) on _hyper_13_805_chunk r_385
                      ->  Seq Scan on compress_hyper_14_806_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_104_chunk r_73
-                     ->  Seq Scan on compress_hyper_14_807_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_105_chunk r_74
+               ->  Custom Scan (DecompressChunk) on _hyper_13_807_chunk r_386
                      ->  Seq Scan on compress_hyper_14_808_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_106_chunk r_75
-                     ->  Seq Scan on compress_hyper_14_809_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_107_chunk r_76
+               ->  Custom Scan (DecompressChunk) on _hyper_13_809_chunk r_387
                      ->  Seq Scan on compress_hyper_14_810_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_108_chunk r_77
-                     ->  Seq Scan on compress_hyper_14_811_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_109_chunk r_78
+               ->  Custom Scan (DecompressChunk) on _hyper_13_811_chunk r_388
                      ->  Seq Scan on compress_hyper_14_812_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_110_chunk r_79
-                     ->  Seq Scan on compress_hyper_14_813_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_111_chunk r_80
+               ->  Custom Scan (DecompressChunk) on _hyper_13_813_chunk r_389
                      ->  Seq Scan on compress_hyper_14_814_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_112_chunk r_81
-                     ->  Seq Scan on compress_hyper_14_815_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_113_chunk r_82
+               ->  Custom Scan (DecompressChunk) on _hyper_13_815_chunk r_390
                      ->  Seq Scan on compress_hyper_14_816_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_114_chunk r_83
-                     ->  Seq Scan on compress_hyper_14_817_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_115_chunk r_84
+               ->  Custom Scan (DecompressChunk) on _hyper_13_817_chunk r_391
                      ->  Seq Scan on compress_hyper_14_818_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_116_chunk r_85
-                     ->  Seq Scan on compress_hyper_14_819_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_117_chunk r_86
+               ->  Custom Scan (DecompressChunk) on _hyper_13_819_chunk r_392
                      ->  Seq Scan on compress_hyper_14_820_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_118_chunk r_87
-                     ->  Seq Scan on compress_hyper_14_821_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_119_chunk r_88
+               ->  Custom Scan (DecompressChunk) on _hyper_13_821_chunk r_393
                      ->  Seq Scan on compress_hyper_14_822_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_120_chunk r_89
-                     ->  Seq Scan on compress_hyper_14_823_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_121_chunk r_90
+               ->  Custom Scan (DecompressChunk) on _hyper_13_823_chunk r_394
                      ->  Seq Scan on compress_hyper_14_824_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_122_chunk r_91
-                     ->  Seq Scan on compress_hyper_14_825_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_123_chunk r_92
+               ->  Custom Scan (DecompressChunk) on _hyper_13_825_chunk r_395
                      ->  Seq Scan on compress_hyper_14_826_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_124_chunk r_93
-                     ->  Seq Scan on compress_hyper_14_827_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_125_chunk r_94
+               ->  Custom Scan (DecompressChunk) on _hyper_13_827_chunk r_396
                      ->  Seq Scan on compress_hyper_14_828_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_126_chunk r_95
-                     ->  Seq Scan on compress_hyper_14_829_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_127_chunk r_96
+               ->  Custom Scan (DecompressChunk) on _hyper_13_829_chunk r_397
                      ->  Seq Scan on compress_hyper_14_830_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_128_chunk r_97
-                     ->  Seq Scan on compress_hyper_14_831_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_129_chunk r_98
+               ->  Custom Scan (DecompressChunk) on _hyper_13_831_chunk r_398
                      ->  Seq Scan on compress_hyper_14_832_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_130_chunk r_99
-                     ->  Seq Scan on compress_hyper_14_833_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_131_chunk r_100
+               ->  Custom Scan (DecompressChunk) on _hyper_13_833_chunk r_399
                      ->  Seq Scan on compress_hyper_14_834_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_132_chunk r_101
-                     ->  Seq Scan on compress_hyper_14_835_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_133_chunk r_102
+               ->  Custom Scan (DecompressChunk) on _hyper_13_835_chunk r_400
                      ->  Seq Scan on compress_hyper_14_836_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_134_chunk r_103
-                     ->  Seq Scan on compress_hyper_14_837_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_135_chunk r_104
+               ->  Custom Scan (DecompressChunk) on _hyper_13_837_chunk r_401
                      ->  Seq Scan on compress_hyper_14_838_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_136_chunk r_105
-                     ->  Seq Scan on compress_hyper_14_839_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_137_chunk r_106
+               ->  Custom Scan (DecompressChunk) on _hyper_13_839_chunk r_402
                      ->  Seq Scan on compress_hyper_14_840_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_138_chunk r_107
-                     ->  Seq Scan on compress_hyper_14_841_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_139_chunk r_108
+               ->  Custom Scan (DecompressChunk) on _hyper_13_841_chunk r_403
                      ->  Seq Scan on compress_hyper_14_842_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_140_chunk r_109
-                     ->  Seq Scan on compress_hyper_14_843_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_141_chunk r_110
+               ->  Custom Scan (DecompressChunk) on _hyper_13_843_chunk r_404
                      ->  Seq Scan on compress_hyper_14_844_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_142_chunk r_111
-                     ->  Seq Scan on compress_hyper_14_845_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_143_chunk r_112
+               ->  Custom Scan (DecompressChunk) on _hyper_13_845_chunk r_405
                      ->  Seq Scan on compress_hyper_14_846_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_144_chunk r_113
-                     ->  Seq Scan on compress_hyper_14_847_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_145_chunk r_114
+               ->  Custom Scan (DecompressChunk) on _hyper_13_847_chunk r_406
                      ->  Seq Scan on compress_hyper_14_848_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_146_chunk r_115
-                     ->  Seq Scan on compress_hyper_14_849_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_147_chunk r_116
+               ->  Custom Scan (DecompressChunk) on _hyper_13_849_chunk r_407
                      ->  Seq Scan on compress_hyper_14_850_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_148_chunk r_117
-                     ->  Seq Scan on compress_hyper_14_851_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_149_chunk r_118
+               ->  Custom Scan (DecompressChunk) on _hyper_13_851_chunk r_408
                      ->  Seq Scan on compress_hyper_14_852_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_150_chunk r_119
-                     ->  Seq Scan on compress_hyper_14_853_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_151_chunk r_120
+               ->  Custom Scan (DecompressChunk) on _hyper_13_853_chunk r_409
                      ->  Seq Scan on compress_hyper_14_854_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_152_chunk r_121
-                     ->  Seq Scan on compress_hyper_14_855_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_153_chunk r_122
+               ->  Custom Scan (DecompressChunk) on _hyper_13_855_chunk r_410
                      ->  Seq Scan on compress_hyper_14_856_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_154_chunk r_123
-                     ->  Seq Scan on compress_hyper_14_857_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_155_chunk r_124
+               ->  Custom Scan (DecompressChunk) on _hyper_13_857_chunk r_411
                      ->  Seq Scan on compress_hyper_14_858_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_156_chunk r_125
-                     ->  Seq Scan on compress_hyper_14_859_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_157_chunk r_126
+               ->  Custom Scan (DecompressChunk) on _hyper_13_859_chunk r_412
                      ->  Seq Scan on compress_hyper_14_860_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_158_chunk r_127
-                     ->  Seq Scan on compress_hyper_14_861_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_159_chunk r_128
+               ->  Custom Scan (DecompressChunk) on _hyper_13_861_chunk r_413
                      ->  Seq Scan on compress_hyper_14_862_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_160_chunk r_129
-                     ->  Seq Scan on compress_hyper_14_863_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_161_chunk r_130
+               ->  Custom Scan (DecompressChunk) on _hyper_13_863_chunk r_414
                      ->  Seq Scan on compress_hyper_14_864_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_162_chunk r_131
-                     ->  Seq Scan on compress_hyper_14_865_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_163_chunk r_132
+               ->  Custom Scan (DecompressChunk) on _hyper_13_865_chunk r_415
                      ->  Seq Scan on compress_hyper_14_866_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_164_chunk r_133
-                     ->  Seq Scan on compress_hyper_14_867_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_165_chunk r_134
+               ->  Custom Scan (DecompressChunk) on _hyper_13_867_chunk r_416
                      ->  Seq Scan on compress_hyper_14_868_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_166_chunk r_135
-                     ->  Seq Scan on compress_hyper_14_869_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_167_chunk r_136
+               ->  Custom Scan (DecompressChunk) on _hyper_13_869_chunk r_417
                      ->  Seq Scan on compress_hyper_14_870_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_168_chunk r_137
-                     ->  Seq Scan on compress_hyper_14_871_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_169_chunk r_138
+               ->  Custom Scan (DecompressChunk) on _hyper_13_871_chunk r_418
                      ->  Seq Scan on compress_hyper_14_872_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_170_chunk r_139
-                     ->  Seq Scan on compress_hyper_14_873_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_171_chunk r_140
+               ->  Custom Scan (DecompressChunk) on _hyper_13_873_chunk r_419
                      ->  Seq Scan on compress_hyper_14_874_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_172_chunk r_141
-                     ->  Seq Scan on compress_hyper_14_875_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_173_chunk r_142
+               ->  Custom Scan (DecompressChunk) on _hyper_13_875_chunk r_420
                      ->  Seq Scan on compress_hyper_14_876_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_174_chunk r_143
-                     ->  Seq Scan on compress_hyper_14_877_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_175_chunk r_144
+               ->  Custom Scan (DecompressChunk) on _hyper_13_877_chunk r_421
                      ->  Seq Scan on compress_hyper_14_878_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_176_chunk r_145
-                     ->  Seq Scan on compress_hyper_14_879_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_177_chunk r_146
+               ->  Custom Scan (DecompressChunk) on _hyper_13_879_chunk r_422
                      ->  Seq Scan on compress_hyper_14_880_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_178_chunk r_147
-                     ->  Seq Scan on compress_hyper_14_881_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_179_chunk r_148
+               ->  Custom Scan (DecompressChunk) on _hyper_13_881_chunk r_423
                      ->  Seq Scan on compress_hyper_14_882_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_180_chunk r_149
-                     ->  Seq Scan on compress_hyper_14_883_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_181_chunk r_150
+               ->  Custom Scan (DecompressChunk) on _hyper_13_883_chunk r_424
                      ->  Seq Scan on compress_hyper_14_884_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_182_chunk r_151
-                     ->  Seq Scan on compress_hyper_14_885_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_183_chunk r_152
+               ->  Custom Scan (DecompressChunk) on _hyper_13_885_chunk r_425
                      ->  Seq Scan on compress_hyper_14_886_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_184_chunk r_153
-                     ->  Seq Scan on compress_hyper_14_887_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_185_chunk r_154
+               ->  Custom Scan (DecompressChunk) on _hyper_13_887_chunk r_426
                      ->  Seq Scan on compress_hyper_14_888_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_186_chunk r_155
-                     ->  Seq Scan on compress_hyper_14_889_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_187_chunk r_156
+               ->  Custom Scan (DecompressChunk) on _hyper_13_889_chunk r_427
                      ->  Seq Scan on compress_hyper_14_890_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_188_chunk r_157
-                     ->  Seq Scan on compress_hyper_14_891_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_189_chunk r_158
+               ->  Custom Scan (DecompressChunk) on _hyper_13_891_chunk r_428
                      ->  Seq Scan on compress_hyper_14_892_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_190_chunk r_159
-                     ->  Seq Scan on compress_hyper_14_893_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_191_chunk r_160
+               ->  Custom Scan (DecompressChunk) on _hyper_13_893_chunk r_429
                      ->  Seq Scan on compress_hyper_14_894_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_192_chunk r_161
-                     ->  Seq Scan on compress_hyper_14_895_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_193_chunk r_162
+               ->  Custom Scan (DecompressChunk) on _hyper_13_895_chunk r_430
                      ->  Seq Scan on compress_hyper_14_896_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_194_chunk r_163
-                     ->  Seq Scan on compress_hyper_14_897_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_195_chunk r_164
+               ->  Custom Scan (DecompressChunk) on _hyper_13_897_chunk r_431
                      ->  Seq Scan on compress_hyper_14_898_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_196_chunk r_165
-                     ->  Seq Scan on compress_hyper_14_899_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_197_chunk r_166
+               ->  Custom Scan (DecompressChunk) on _hyper_13_899_chunk r_432
                      ->  Seq Scan on compress_hyper_14_900_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_198_chunk r_167
-                     ->  Seq Scan on compress_hyper_14_901_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_199_chunk r_168
+               ->  Custom Scan (DecompressChunk) on _hyper_13_901_chunk r_433
                      ->  Seq Scan on compress_hyper_14_902_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_200_chunk r_169
-                     ->  Seq Scan on compress_hyper_14_903_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_201_chunk r_170
+               ->  Custom Scan (DecompressChunk) on _hyper_13_903_chunk r_434
                      ->  Seq Scan on compress_hyper_14_904_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_202_chunk r_171
-                     ->  Seq Scan on compress_hyper_14_905_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_203_chunk r_172
+               ->  Custom Scan (DecompressChunk) on _hyper_13_905_chunk r_435
                      ->  Seq Scan on compress_hyper_14_906_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_204_chunk r_173
-                     ->  Seq Scan on compress_hyper_14_907_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_205_chunk r_174
+               ->  Custom Scan (DecompressChunk) on _hyper_13_907_chunk r_436
                      ->  Seq Scan on compress_hyper_14_908_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_206_chunk r_175
-                     ->  Seq Scan on compress_hyper_14_909_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_207_chunk r_176
+               ->  Custom Scan (DecompressChunk) on _hyper_13_909_chunk r_437
                      ->  Seq Scan on compress_hyper_14_910_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_208_chunk r_177
-                     ->  Seq Scan on compress_hyper_14_911_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_209_chunk r_178
+               ->  Custom Scan (DecompressChunk) on _hyper_13_911_chunk r_438
                      ->  Seq Scan on compress_hyper_14_912_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_210_chunk r_179
-                     ->  Seq Scan on compress_hyper_14_913_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_211_chunk r_180
+               ->  Custom Scan (DecompressChunk) on _hyper_13_913_chunk r_439
                      ->  Seq Scan on compress_hyper_14_914_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_212_chunk r_181
-                     ->  Seq Scan on compress_hyper_14_915_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_213_chunk r_182
+               ->  Custom Scan (DecompressChunk) on _hyper_13_915_chunk r_440
                      ->  Seq Scan on compress_hyper_14_916_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_214_chunk r_183
-                     ->  Seq Scan on compress_hyper_14_917_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_215_chunk r_184
+               ->  Custom Scan (DecompressChunk) on _hyper_13_917_chunk r_441
                      ->  Seq Scan on compress_hyper_14_918_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_216_chunk r_185
-                     ->  Seq Scan on compress_hyper_14_919_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_217_chunk r_186
+               ->  Custom Scan (DecompressChunk) on _hyper_13_919_chunk r_442
                      ->  Seq Scan on compress_hyper_14_920_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_218_chunk r_187
-                     ->  Seq Scan on compress_hyper_14_921_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_219_chunk r_188
+               ->  Custom Scan (DecompressChunk) on _hyper_13_921_chunk r_443
                      ->  Seq Scan on compress_hyper_14_922_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_220_chunk r_189
-                     ->  Seq Scan on compress_hyper_14_923_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_221_chunk r_190
+               ->  Custom Scan (DecompressChunk) on _hyper_13_923_chunk r_444
                      ->  Seq Scan on compress_hyper_14_924_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_222_chunk r_191
-                     ->  Seq Scan on compress_hyper_14_925_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_223_chunk r_192
+               ->  Custom Scan (DecompressChunk) on _hyper_13_925_chunk r_445
                      ->  Seq Scan on compress_hyper_14_926_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_224_chunk r_193
-                     ->  Seq Scan on compress_hyper_14_927_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_225_chunk r_194
+               ->  Custom Scan (DecompressChunk) on _hyper_13_927_chunk r_446
                      ->  Seq Scan on compress_hyper_14_928_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_226_chunk r_195
-                     ->  Seq Scan on compress_hyper_14_929_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_227_chunk r_196
+               ->  Custom Scan (DecompressChunk) on _hyper_13_929_chunk r_447
                      ->  Seq Scan on compress_hyper_14_930_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_228_chunk r_197
-                     ->  Seq Scan on compress_hyper_14_931_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_229_chunk r_198
+               ->  Custom Scan (DecompressChunk) on _hyper_13_931_chunk r_448
                      ->  Seq Scan on compress_hyper_14_932_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_230_chunk r_199
-                     ->  Seq Scan on compress_hyper_14_933_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_231_chunk r_200
+               ->  Custom Scan (DecompressChunk) on _hyper_13_933_chunk r_449
                      ->  Seq Scan on compress_hyper_14_934_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_232_chunk r_201
-                     ->  Seq Scan on compress_hyper_14_935_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_233_chunk r_202
+               ->  Custom Scan (DecompressChunk) on _hyper_13_935_chunk r_450
                      ->  Seq Scan on compress_hyper_14_936_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_234_chunk r_203
-                     ->  Seq Scan on compress_hyper_14_937_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_235_chunk r_204
+               ->  Custom Scan (DecompressChunk) on _hyper_13_937_chunk r_451
                      ->  Seq Scan on compress_hyper_14_938_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_236_chunk r_205
-                     ->  Seq Scan on compress_hyper_14_939_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_237_chunk r_206
+               ->  Custom Scan (DecompressChunk) on _hyper_13_939_chunk r_452
                      ->  Seq Scan on compress_hyper_14_940_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_238_chunk r_207
-                     ->  Seq Scan on compress_hyper_14_941_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_239_chunk r_208
+               ->  Custom Scan (DecompressChunk) on _hyper_13_941_chunk r_453
                      ->  Seq Scan on compress_hyper_14_942_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_240_chunk r_209
-                     ->  Seq Scan on compress_hyper_14_943_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_241_chunk r_210
+               ->  Custom Scan (DecompressChunk) on _hyper_13_943_chunk r_454
                      ->  Seq Scan on compress_hyper_14_944_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_242_chunk r_211
-                     ->  Seq Scan on compress_hyper_14_945_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_243_chunk r_212
+               ->  Custom Scan (DecompressChunk) on _hyper_13_945_chunk r_455
                      ->  Seq Scan on compress_hyper_14_946_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_244_chunk r_213
-                     ->  Seq Scan on compress_hyper_14_947_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_245_chunk r_214
+               ->  Custom Scan (DecompressChunk) on _hyper_13_947_chunk r_456
                      ->  Seq Scan on compress_hyper_14_948_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_246_chunk r_215
-                     ->  Seq Scan on compress_hyper_14_949_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_247_chunk r_216
+               ->  Custom Scan (DecompressChunk) on _hyper_13_949_chunk r_457
                      ->  Seq Scan on compress_hyper_14_950_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_248_chunk r_217
-                     ->  Seq Scan on compress_hyper_14_951_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_249_chunk r_218
+               ->  Custom Scan (DecompressChunk) on _hyper_13_951_chunk r_458
                      ->  Seq Scan on compress_hyper_14_952_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_250_chunk r_219
-                     ->  Seq Scan on compress_hyper_14_953_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_251_chunk r_220
+               ->  Custom Scan (DecompressChunk) on _hyper_13_953_chunk r_459
                      ->  Seq Scan on compress_hyper_14_954_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_252_chunk r_221
-                     ->  Seq Scan on compress_hyper_14_955_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_253_chunk r_222
+               ->  Custom Scan (DecompressChunk) on _hyper_13_955_chunk r_460
                      ->  Seq Scan on compress_hyper_14_956_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_254_chunk r_223
-                     ->  Seq Scan on compress_hyper_14_957_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_255_chunk r_224
+               ->  Custom Scan (DecompressChunk) on _hyper_13_957_chunk r_461
                      ->  Seq Scan on compress_hyper_14_958_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_256_chunk r_225
-                     ->  Seq Scan on compress_hyper_14_959_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_257_chunk r_226
+               ->  Custom Scan (DecompressChunk) on _hyper_13_959_chunk r_462
                      ->  Seq Scan on compress_hyper_14_960_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_258_chunk r_227
-                     ->  Seq Scan on compress_hyper_14_961_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_259_chunk r_228
+               ->  Custom Scan (DecompressChunk) on _hyper_13_961_chunk r_463
                      ->  Seq Scan on compress_hyper_14_962_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_260_chunk r_229
-                     ->  Seq Scan on compress_hyper_14_963_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_261_chunk r_230
+               ->  Custom Scan (DecompressChunk) on _hyper_13_963_chunk r_464
                      ->  Seq Scan on compress_hyper_14_964_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_262_chunk r_231
-                     ->  Seq Scan on compress_hyper_14_965_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_263_chunk r_232
+               ->  Custom Scan (DecompressChunk) on _hyper_13_965_chunk r_465
                      ->  Seq Scan on compress_hyper_14_966_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_264_chunk r_233
-                     ->  Seq Scan on compress_hyper_14_967_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_265_chunk r_234
+               ->  Custom Scan (DecompressChunk) on _hyper_13_967_chunk r_466
                      ->  Seq Scan on compress_hyper_14_968_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_266_chunk r_235
-                     ->  Seq Scan on compress_hyper_14_969_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_267_chunk r_236
+               ->  Custom Scan (DecompressChunk) on _hyper_13_969_chunk r_467
                      ->  Seq Scan on compress_hyper_14_970_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_268_chunk r_237
-                     ->  Seq Scan on compress_hyper_14_971_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_269_chunk r_238
+               ->  Custom Scan (DecompressChunk) on _hyper_13_971_chunk r_468
                      ->  Seq Scan on compress_hyper_14_972_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_270_chunk r_239
-                     ->  Seq Scan on compress_hyper_14_973_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_271_chunk r_240
+               ->  Custom Scan (DecompressChunk) on _hyper_13_973_chunk r_469
                      ->  Seq Scan on compress_hyper_14_974_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_272_chunk r_241
-                     ->  Seq Scan on compress_hyper_14_975_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_273_chunk r_242
+               ->  Custom Scan (DecompressChunk) on _hyper_13_975_chunk r_470
                      ->  Seq Scan on compress_hyper_14_976_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_274_chunk r_243
-                     ->  Seq Scan on compress_hyper_14_977_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_275_chunk r_244
+               ->  Custom Scan (DecompressChunk) on _hyper_13_977_chunk r_471
                      ->  Seq Scan on compress_hyper_14_978_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_276_chunk r_245
-                     ->  Seq Scan on compress_hyper_14_979_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_277_chunk r_246
+               ->  Custom Scan (DecompressChunk) on _hyper_13_979_chunk r_472
                      ->  Seq Scan on compress_hyper_14_980_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_278_chunk r_247
-                     ->  Seq Scan on compress_hyper_14_981_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_279_chunk r_248
+               ->  Custom Scan (DecompressChunk) on _hyper_13_981_chunk r_473
                      ->  Seq Scan on compress_hyper_14_982_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_280_chunk r_249
-                     ->  Seq Scan on compress_hyper_14_983_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_281_chunk r_250
+               ->  Custom Scan (DecompressChunk) on _hyper_13_983_chunk r_474
                      ->  Seq Scan on compress_hyper_14_984_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_282_chunk r_251
-                     ->  Seq Scan on compress_hyper_14_985_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_283_chunk r_252
+               ->  Custom Scan (DecompressChunk) on _hyper_13_985_chunk r_475
                      ->  Seq Scan on compress_hyper_14_986_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_284_chunk r_253
-                     ->  Seq Scan on compress_hyper_14_987_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_285_chunk r_254
+               ->  Custom Scan (DecompressChunk) on _hyper_13_987_chunk r_476
                      ->  Seq Scan on compress_hyper_14_988_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_286_chunk r_255
-                     ->  Seq Scan on compress_hyper_14_989_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_287_chunk r_256
+               ->  Custom Scan (DecompressChunk) on _hyper_13_989_chunk r_477
                      ->  Seq Scan on compress_hyper_14_990_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_288_chunk r_257
-                     ->  Seq Scan on compress_hyper_14_991_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_289_chunk r_258
+               ->  Custom Scan (DecompressChunk) on _hyper_13_991_chunk r_478
                      ->  Seq Scan on compress_hyper_14_992_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_290_chunk r_259
-                     ->  Seq Scan on compress_hyper_14_993_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_291_chunk r_260
+               ->  Custom Scan (DecompressChunk) on _hyper_13_993_chunk r_479
                      ->  Seq Scan on compress_hyper_14_994_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_292_chunk r_261
-                     ->  Seq Scan on compress_hyper_14_995_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_293_chunk r_262
+               ->  Custom Scan (DecompressChunk) on _hyper_13_995_chunk r_480
                      ->  Seq Scan on compress_hyper_14_996_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_294_chunk r_263
-                     ->  Seq Scan on compress_hyper_14_997_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_295_chunk r_264
+               ->  Custom Scan (DecompressChunk) on _hyper_13_997_chunk r_481
                      ->  Seq Scan on compress_hyper_14_998_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_296_chunk r_265
-                     ->  Seq Scan on compress_hyper_14_999_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_297_chunk r_266
+               ->  Custom Scan (DecompressChunk) on _hyper_13_999_chunk r_482
                      ->  Seq Scan on compress_hyper_14_1000_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_298_chunk r_267
-                     ->  Seq Scan on compress_hyper_14_1001_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_299_chunk r_268
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1001_chunk r_483
                      ->  Seq Scan on compress_hyper_14_1002_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_300_chunk r_269
-                     ->  Seq Scan on compress_hyper_14_1003_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_301_chunk r_270
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1003_chunk r_484
                      ->  Seq Scan on compress_hyper_14_1004_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_302_chunk r_271
-                     ->  Seq Scan on compress_hyper_14_1005_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_303_chunk r_272
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1005_chunk r_485
                      ->  Seq Scan on compress_hyper_14_1006_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_304_chunk r_273
-                     ->  Seq Scan on compress_hyper_14_1007_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_305_chunk r_274
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1007_chunk r_486
                      ->  Seq Scan on compress_hyper_14_1008_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_306_chunk r_275
-                     ->  Seq Scan on compress_hyper_14_1009_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_307_chunk r_276
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1009_chunk r_487
                      ->  Seq Scan on compress_hyper_14_1010_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_308_chunk r_277
-                     ->  Seq Scan on compress_hyper_14_1011_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_309_chunk r_278
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1011_chunk r_488
                      ->  Seq Scan on compress_hyper_14_1012_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_310_chunk r_279
-                     ->  Seq Scan on compress_hyper_14_1013_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_311_chunk r_280
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1013_chunk r_489
                      ->  Seq Scan on compress_hyper_14_1014_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_312_chunk r_281
-                     ->  Seq Scan on compress_hyper_14_1015_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_313_chunk r_282
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1015_chunk r_490
                      ->  Seq Scan on compress_hyper_14_1016_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_314_chunk r_283
-                     ->  Seq Scan on compress_hyper_14_1017_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_315_chunk r_284
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1017_chunk r_491
                      ->  Seq Scan on compress_hyper_14_1018_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_316_chunk r_285
-                     ->  Seq Scan on compress_hyper_14_1019_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_317_chunk r_286
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1019_chunk r_492
                      ->  Seq Scan on compress_hyper_14_1020_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_318_chunk r_287
-                     ->  Seq Scan on compress_hyper_14_1021_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_319_chunk r_288
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1021_chunk r_493
                      ->  Seq Scan on compress_hyper_14_1022_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_320_chunk r_289
-                     ->  Seq Scan on compress_hyper_14_1023_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_321_chunk r_290
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1023_chunk r_494
                      ->  Seq Scan on compress_hyper_14_1024_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_322_chunk r_291
-                     ->  Seq Scan on compress_hyper_14_1025_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_323_chunk r_292
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1025_chunk r_495
                      ->  Seq Scan on compress_hyper_14_1026_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_324_chunk r_293
-                     ->  Seq Scan on compress_hyper_14_1027_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_325_chunk r_294
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1027_chunk r_496
                      ->  Seq Scan on compress_hyper_14_1028_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_326_chunk r_295
-                     ->  Seq Scan on compress_hyper_14_1029_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_327_chunk r_296
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1029_chunk r_497
                      ->  Seq Scan on compress_hyper_14_1030_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_328_chunk r_297
-                     ->  Seq Scan on compress_hyper_14_1031_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_329_chunk r_298
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1031_chunk r_498
                      ->  Seq Scan on compress_hyper_14_1032_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_330_chunk r_299
-                     ->  Seq Scan on compress_hyper_14_1033_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_331_chunk r_300
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1033_chunk r_499
                      ->  Seq Scan on compress_hyper_14_1034_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_332_chunk r_301
-                     ->  Seq Scan on compress_hyper_14_1035_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_333_chunk r_302
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1035_chunk r_500
                      ->  Seq Scan on compress_hyper_14_1036_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_334_chunk r_303
-                     ->  Seq Scan on compress_hyper_14_1037_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_335_chunk r_304
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1037_chunk r_501
                      ->  Seq Scan on compress_hyper_14_1038_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_336_chunk r_305
-                     ->  Seq Scan on compress_hyper_14_1039_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_337_chunk r_306
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1039_chunk r_502
                      ->  Seq Scan on compress_hyper_14_1040_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_338_chunk r_307
-                     ->  Seq Scan on compress_hyper_14_1041_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_339_chunk r_308
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1041_chunk r_503
                      ->  Seq Scan on compress_hyper_14_1042_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_340_chunk r_309
-                     ->  Seq Scan on compress_hyper_14_1043_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_341_chunk r_310
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1043_chunk r_504
                      ->  Seq Scan on compress_hyper_14_1044_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_342_chunk r_311
-                     ->  Seq Scan on compress_hyper_14_1045_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_343_chunk r_312
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1045_chunk r_505
                      ->  Seq Scan on compress_hyper_14_1046_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_344_chunk r_313
-                     ->  Seq Scan on compress_hyper_14_1047_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_345_chunk r_314
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1047_chunk r_506
                      ->  Seq Scan on compress_hyper_14_1048_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_346_chunk r_315
-                     ->  Seq Scan on compress_hyper_14_1049_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_347_chunk r_316
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1049_chunk r_507
                      ->  Seq Scan on compress_hyper_14_1050_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_348_chunk r_317
-                     ->  Seq Scan on compress_hyper_14_1051_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_349_chunk r_318
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1051_chunk r_508
                      ->  Seq Scan on compress_hyper_14_1052_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_350_chunk r_319
-                     ->  Seq Scan on compress_hyper_14_1053_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_351_chunk r_320
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1053_chunk r_509
                      ->  Seq Scan on compress_hyper_14_1054_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_352_chunk r_321
-                     ->  Seq Scan on compress_hyper_14_1055_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_353_chunk r_322
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1055_chunk r_510
                      ->  Seq Scan on compress_hyper_14_1056_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_354_chunk r_323
-                     ->  Seq Scan on compress_hyper_14_1057_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_355_chunk r_324
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1057_chunk r_511
                      ->  Seq Scan on compress_hyper_14_1058_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_356_chunk r_325
-                     ->  Seq Scan on compress_hyper_14_1059_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_357_chunk r_326
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1059_chunk r_512
                      ->  Seq Scan on compress_hyper_14_1060_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_358_chunk r_327
-                     ->  Seq Scan on compress_hyper_14_1061_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_359_chunk r_328
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1061_chunk r_513
                      ->  Seq Scan on compress_hyper_14_1062_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_360_chunk r_329
-                     ->  Seq Scan on compress_hyper_14_1063_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_361_chunk r_330
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1063_chunk r_514
                      ->  Seq Scan on compress_hyper_14_1064_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_362_chunk r_331
-                     ->  Seq Scan on compress_hyper_14_1065_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_363_chunk r_332
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1065_chunk r_515
                      ->  Seq Scan on compress_hyper_14_1066_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_364_chunk r_333
-                     ->  Seq Scan on compress_hyper_14_1067_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_365_chunk r_334
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1067_chunk r_516
                      ->  Seq Scan on compress_hyper_14_1068_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_366_chunk r_335
-                     ->  Seq Scan on compress_hyper_14_1069_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_367_chunk r_336
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1069_chunk r_517
                      ->  Seq Scan on compress_hyper_14_1070_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_368_chunk r_337
-                     ->  Seq Scan on compress_hyper_14_1071_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_369_chunk r_338
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1071_chunk r_518
                      ->  Seq Scan on compress_hyper_14_1072_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_370_chunk r_339
-                     ->  Seq Scan on compress_hyper_14_1073_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_371_chunk r_340
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1073_chunk r_519
                      ->  Seq Scan on compress_hyper_14_1074_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_372_chunk r_341
-                     ->  Seq Scan on compress_hyper_14_1075_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_373_chunk r_342
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1075_chunk r_520
                      ->  Seq Scan on compress_hyper_14_1076_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_374_chunk r_343
-                     ->  Seq Scan on compress_hyper_14_1077_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_375_chunk r_344
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1077_chunk r_521
                      ->  Seq Scan on compress_hyper_14_1078_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_376_chunk r_345
-                     ->  Seq Scan on compress_hyper_14_1079_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_377_chunk r_346
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1079_chunk r_522
                      ->  Seq Scan on compress_hyper_14_1080_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_378_chunk r_347
-                     ->  Seq Scan on compress_hyper_14_1081_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_379_chunk r_348
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1081_chunk r_523
                      ->  Seq Scan on compress_hyper_14_1082_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_380_chunk r_349
-                     ->  Seq Scan on compress_hyper_14_1083_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_381_chunk r_350
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1083_chunk r_524
                      ->  Seq Scan on compress_hyper_14_1084_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_382_chunk r_351
-                     ->  Seq Scan on compress_hyper_14_1085_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_383_chunk r_352
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1085_chunk r_525
                      ->  Seq Scan on compress_hyper_14_1086_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_384_chunk r_353
-                     ->  Seq Scan on compress_hyper_14_1087_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_385_chunk r_354
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1087_chunk r_526
                      ->  Seq Scan on compress_hyper_14_1088_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_386_chunk r_355
-                     ->  Seq Scan on compress_hyper_14_1089_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_387_chunk r_356
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1089_chunk r_527
                      ->  Seq Scan on compress_hyper_14_1090_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_388_chunk r_357
-                     ->  Seq Scan on compress_hyper_14_1091_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_389_chunk r_358
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1091_chunk r_528
                      ->  Seq Scan on compress_hyper_14_1092_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_390_chunk r_359
-                     ->  Seq Scan on compress_hyper_14_1093_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_391_chunk r_360
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1093_chunk r_529
                      ->  Seq Scan on compress_hyper_14_1094_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_392_chunk r_361
-                     ->  Seq Scan on compress_hyper_14_1095_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_393_chunk r_362
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1095_chunk r_530
                      ->  Seq Scan on compress_hyper_14_1096_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_394_chunk r_363
-                     ->  Seq Scan on compress_hyper_14_1097_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_395_chunk r_364
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1097_chunk r_531
                      ->  Seq Scan on compress_hyper_14_1098_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_396_chunk r_365
-                     ->  Seq Scan on compress_hyper_14_1099_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_397_chunk r_366
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1099_chunk r_532
                      ->  Seq Scan on compress_hyper_14_1100_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_398_chunk r_367
-                     ->  Seq Scan on compress_hyper_14_1101_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_399_chunk r_368
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1101_chunk r_533
                      ->  Seq Scan on compress_hyper_14_1102_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_400_chunk r_369
-                     ->  Seq Scan on compress_hyper_14_1103_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_401_chunk r_370
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1103_chunk r_534
                      ->  Seq Scan on compress_hyper_14_1104_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_402_chunk r_371
-                     ->  Seq Scan on compress_hyper_14_1105_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_403_chunk r_372
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1105_chunk r_535
                      ->  Seq Scan on compress_hyper_14_1106_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_404_chunk r_373
-                     ->  Seq Scan on compress_hyper_14_1107_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_405_chunk r_374
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1107_chunk r_536
                      ->  Seq Scan on compress_hyper_14_1108_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_406_chunk r_375
-                     ->  Seq Scan on compress_hyper_14_1109_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_407_chunk r_376
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1109_chunk r_537
                      ->  Seq Scan on compress_hyper_14_1110_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_408_chunk r_377
-                     ->  Seq Scan on compress_hyper_14_1111_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_409_chunk r_378
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1111_chunk r_538
                      ->  Seq Scan on compress_hyper_14_1112_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_410_chunk r_379
-                     ->  Seq Scan on compress_hyper_14_1113_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_411_chunk r_380
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1113_chunk r_539
                      ->  Seq Scan on compress_hyper_14_1114_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_412_chunk r_381
-                     ->  Seq Scan on compress_hyper_14_1115_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_413_chunk r_382
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1115_chunk r_540
                      ->  Seq Scan on compress_hyper_14_1116_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_414_chunk r_383
-                     ->  Seq Scan on compress_hyper_14_1117_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_415_chunk r_384
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1117_chunk r_541
                      ->  Seq Scan on compress_hyper_14_1118_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_416_chunk r_385
-                     ->  Seq Scan on compress_hyper_14_1119_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_417_chunk r_386
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1119_chunk r_542
                      ->  Seq Scan on compress_hyper_14_1120_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_418_chunk r_387
-                     ->  Seq Scan on compress_hyper_14_1121_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_419_chunk r_388
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1121_chunk r_543
                      ->  Seq Scan on compress_hyper_14_1122_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_420_chunk r_389
-                     ->  Seq Scan on compress_hyper_14_1123_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_421_chunk r_390
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1123_chunk r_544
                      ->  Seq Scan on compress_hyper_14_1124_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_422_chunk r_391
-                     ->  Seq Scan on compress_hyper_14_1125_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_423_chunk r_392
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1125_chunk r_545
                      ->  Seq Scan on compress_hyper_14_1126_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_424_chunk r_393
-                     ->  Seq Scan on compress_hyper_14_1127_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_425_chunk r_394
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1127_chunk r_546
                      ->  Seq Scan on compress_hyper_14_1128_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_426_chunk r_395
-                     ->  Seq Scan on compress_hyper_14_1129_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_427_chunk r_396
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1129_chunk r_547
                      ->  Seq Scan on compress_hyper_14_1130_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_428_chunk r_397
-                     ->  Seq Scan on compress_hyper_14_1131_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_429_chunk r_398
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1131_chunk r_548
                      ->  Seq Scan on compress_hyper_14_1132_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_430_chunk r_399
-                     ->  Seq Scan on compress_hyper_14_1133_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_431_chunk r_400
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1133_chunk r_549
                      ->  Seq Scan on compress_hyper_14_1134_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_432_chunk r_401
-                     ->  Seq Scan on compress_hyper_14_1135_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_433_chunk r_402
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1135_chunk r_550
                      ->  Seq Scan on compress_hyper_14_1136_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_434_chunk r_403
-                     ->  Seq Scan on compress_hyper_14_1137_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_435_chunk r_404
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1137_chunk r_551
                      ->  Seq Scan on compress_hyper_14_1138_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_436_chunk r_405
-                     ->  Seq Scan on compress_hyper_14_1139_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_437_chunk r_406
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1139_chunk r_552
                      ->  Seq Scan on compress_hyper_14_1140_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_438_chunk r_407
-                     ->  Seq Scan on compress_hyper_14_1141_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_439_chunk r_408
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1141_chunk r_553
                      ->  Seq Scan on compress_hyper_14_1142_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_440_chunk r_409
-                     ->  Seq Scan on compress_hyper_14_1143_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_441_chunk r_410
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1143_chunk r_554
                      ->  Seq Scan on compress_hyper_14_1144_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_442_chunk r_411
-                     ->  Seq Scan on compress_hyper_14_1145_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_443_chunk r_412
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1145_chunk r_555
                      ->  Seq Scan on compress_hyper_14_1146_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_444_chunk r_413
-                     ->  Seq Scan on compress_hyper_14_1147_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_445_chunk r_414
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1147_chunk r_556
                      ->  Seq Scan on compress_hyper_14_1148_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_446_chunk r_415
-                     ->  Seq Scan on compress_hyper_14_1149_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_447_chunk r_416
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1149_chunk r_557
                      ->  Seq Scan on compress_hyper_14_1150_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_448_chunk r_417
-                     ->  Seq Scan on compress_hyper_14_1151_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_449_chunk r_418
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1151_chunk r_558
                      ->  Seq Scan on compress_hyper_14_1152_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_450_chunk r_419
-                     ->  Seq Scan on compress_hyper_14_1153_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_451_chunk r_420
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1153_chunk r_559
                      ->  Seq Scan on compress_hyper_14_1154_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_452_chunk r_421
-                     ->  Seq Scan on compress_hyper_14_1155_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_453_chunk r_422
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1155_chunk r_560
                      ->  Seq Scan on compress_hyper_14_1156_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_454_chunk r_423
-                     ->  Seq Scan on compress_hyper_14_1157_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_455_chunk r_424
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1157_chunk r_561
                      ->  Seq Scan on compress_hyper_14_1158_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_456_chunk r_425
-                     ->  Seq Scan on compress_hyper_14_1159_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_457_chunk r_426
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1159_chunk r_562
                      ->  Seq Scan on compress_hyper_14_1160_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_458_chunk r_427
-                     ->  Seq Scan on compress_hyper_14_1161_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_459_chunk r_428
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1161_chunk r_563
                      ->  Seq Scan on compress_hyper_14_1162_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_460_chunk r_429
-                     ->  Seq Scan on compress_hyper_14_1163_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_461_chunk r_430
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1163_chunk r_564
                      ->  Seq Scan on compress_hyper_14_1164_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_462_chunk r_431
-                     ->  Seq Scan on compress_hyper_14_1165_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_463_chunk r_432
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1165_chunk r_565
                      ->  Seq Scan on compress_hyper_14_1166_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_464_chunk r_433
-                     ->  Seq Scan on compress_hyper_14_1167_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_465_chunk r_434
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1167_chunk r_566
                      ->  Seq Scan on compress_hyper_14_1168_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_466_chunk r_435
-                     ->  Seq Scan on compress_hyper_14_1169_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_467_chunk r_436
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1169_chunk r_567
                      ->  Seq Scan on compress_hyper_14_1170_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_468_chunk r_437
-                     ->  Seq Scan on compress_hyper_14_1171_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_469_chunk r_438
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1171_chunk r_568
                      ->  Seq Scan on compress_hyper_14_1172_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_470_chunk r_439
-                     ->  Seq Scan on compress_hyper_14_1173_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_471_chunk r_440
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1173_chunk r_569
                      ->  Seq Scan on compress_hyper_14_1174_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_472_chunk r_441
-                     ->  Seq Scan on compress_hyper_14_1175_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_473_chunk r_442
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1175_chunk r_570
                      ->  Seq Scan on compress_hyper_14_1176_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_474_chunk r_443
-                     ->  Seq Scan on compress_hyper_14_1177_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_475_chunk r_444
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1177_chunk r_571
                      ->  Seq Scan on compress_hyper_14_1178_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_476_chunk r_445
-                     ->  Seq Scan on compress_hyper_14_1179_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_477_chunk r_446
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1179_chunk r_572
                      ->  Seq Scan on compress_hyper_14_1180_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_478_chunk r_447
-                     ->  Seq Scan on compress_hyper_14_1181_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_479_chunk r_448
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1181_chunk r_573
                      ->  Seq Scan on compress_hyper_14_1182_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_480_chunk r_449
-                     ->  Seq Scan on compress_hyper_14_1183_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_481_chunk r_450
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1183_chunk r_574
                      ->  Seq Scan on compress_hyper_14_1184_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_482_chunk r_451
-                     ->  Seq Scan on compress_hyper_14_1185_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_483_chunk r_452
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1185_chunk r_575
                      ->  Seq Scan on compress_hyper_14_1186_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_484_chunk r_453
-                     ->  Seq Scan on compress_hyper_14_1187_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_485_chunk r_454
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1187_chunk r_576
                      ->  Seq Scan on compress_hyper_14_1188_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_486_chunk r_455
-                     ->  Seq Scan on compress_hyper_14_1189_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_487_chunk r_456
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1189_chunk r_577
                      ->  Seq Scan on compress_hyper_14_1190_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_488_chunk r_457
-                     ->  Seq Scan on compress_hyper_14_1191_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_489_chunk r_458
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1191_chunk r_578
                      ->  Seq Scan on compress_hyper_14_1192_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_490_chunk r_459
-                     ->  Seq Scan on compress_hyper_14_1193_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_491_chunk r_460
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1193_chunk r_579
                      ->  Seq Scan on compress_hyper_14_1194_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_492_chunk r_461
-                     ->  Seq Scan on compress_hyper_14_1195_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_493_chunk r_462
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1195_chunk r_580
                      ->  Seq Scan on compress_hyper_14_1196_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_494_chunk r_463
-                     ->  Seq Scan on compress_hyper_14_1197_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_495_chunk r_464
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1197_chunk r_581
                      ->  Seq Scan on compress_hyper_14_1198_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_496_chunk r_465
-                     ->  Seq Scan on compress_hyper_14_1199_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_497_chunk r_466
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1199_chunk r_582
                      ->  Seq Scan on compress_hyper_14_1200_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_498_chunk r_467
-                     ->  Seq Scan on compress_hyper_14_1201_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_499_chunk r_468
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1201_chunk r_583
                      ->  Seq Scan on compress_hyper_14_1202_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_500_chunk r_469
-                     ->  Seq Scan on compress_hyper_14_1203_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_501_chunk r_470
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1203_chunk r_584
                      ->  Seq Scan on compress_hyper_14_1204_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_502_chunk r_471
-                     ->  Seq Scan on compress_hyper_14_1205_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_503_chunk r_472
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1205_chunk r_585
                      ->  Seq Scan on compress_hyper_14_1206_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_504_chunk r_473
-                     ->  Seq Scan on compress_hyper_14_1207_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_505_chunk r_474
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1207_chunk r_586
                      ->  Seq Scan on compress_hyper_14_1208_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_506_chunk r_475
-                     ->  Seq Scan on compress_hyper_14_1209_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_507_chunk r_476
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1209_chunk r_587
                      ->  Seq Scan on compress_hyper_14_1210_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_508_chunk r_477
-                     ->  Seq Scan on compress_hyper_14_1211_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_509_chunk r_478
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1211_chunk r_588
                      ->  Seq Scan on compress_hyper_14_1212_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_510_chunk r_479
-                     ->  Seq Scan on compress_hyper_14_1213_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_511_chunk r_480
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1213_chunk r_589
                      ->  Seq Scan on compress_hyper_14_1214_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_512_chunk r_481
-                     ->  Seq Scan on compress_hyper_14_1215_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_513_chunk r_482
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1215_chunk r_590
                      ->  Seq Scan on compress_hyper_14_1216_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_514_chunk r_483
-                     ->  Seq Scan on compress_hyper_14_1217_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_515_chunk r_484
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1217_chunk r_591
                      ->  Seq Scan on compress_hyper_14_1218_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_516_chunk r_485
-                     ->  Seq Scan on compress_hyper_14_1219_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_517_chunk r_486
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1219_chunk r_592
                      ->  Seq Scan on compress_hyper_14_1220_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_518_chunk r_487
-                     ->  Seq Scan on compress_hyper_14_1221_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_519_chunk r_488
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1221_chunk r_593
                      ->  Seq Scan on compress_hyper_14_1222_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_520_chunk r_489
-                     ->  Seq Scan on compress_hyper_14_1223_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_521_chunk r_490
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1223_chunk r_594
                      ->  Seq Scan on compress_hyper_14_1224_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_522_chunk r_491
-                     ->  Seq Scan on compress_hyper_14_1225_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_523_chunk r_492
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1225_chunk r_595
                      ->  Seq Scan on compress_hyper_14_1226_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_524_chunk r_493
-                     ->  Seq Scan on compress_hyper_14_1227_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_525_chunk r_494
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1227_chunk r_596
                      ->  Seq Scan on compress_hyper_14_1228_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_526_chunk r_495
-                     ->  Seq Scan on compress_hyper_14_1229_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_527_chunk r_496
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1229_chunk r_597
                      ->  Seq Scan on compress_hyper_14_1230_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_528_chunk r_497
-                     ->  Seq Scan on compress_hyper_14_1231_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_529_chunk r_498
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1231_chunk r_598
                      ->  Seq Scan on compress_hyper_14_1232_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_530_chunk r_499
-                     ->  Seq Scan on compress_hyper_14_1233_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_531_chunk r_500
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1233_chunk r_599
                      ->  Seq Scan on compress_hyper_14_1234_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_532_chunk r_501
-                     ->  Seq Scan on compress_hyper_14_1235_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_533_chunk r_502
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1235_chunk r_600
                      ->  Seq Scan on compress_hyper_14_1236_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_534_chunk r_503
-                     ->  Seq Scan on compress_hyper_14_1237_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_535_chunk r_504
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1237_chunk r_601
                      ->  Seq Scan on compress_hyper_14_1238_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_536_chunk r_505
-                     ->  Seq Scan on compress_hyper_14_1239_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_537_chunk r_506
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1239_chunk r_602
                      ->  Seq Scan on compress_hyper_14_1240_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_538_chunk r_507
-                     ->  Seq Scan on compress_hyper_14_1241_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_539_chunk r_508
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1241_chunk r_603
                      ->  Seq Scan on compress_hyper_14_1242_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_540_chunk r_509
-                     ->  Seq Scan on compress_hyper_14_1243_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_541_chunk r_510
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1243_chunk r_604
                      ->  Seq Scan on compress_hyper_14_1244_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_542_chunk r_511
-                     ->  Seq Scan on compress_hyper_14_1245_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_543_chunk r_512
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1245_chunk r_605
                      ->  Seq Scan on compress_hyper_14_1246_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_544_chunk r_513
-                     ->  Seq Scan on compress_hyper_14_1247_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_545_chunk r_514
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1247_chunk r_606
                      ->  Seq Scan on compress_hyper_14_1248_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_546_chunk r_515
-                     ->  Seq Scan on compress_hyper_14_1249_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_547_chunk r_516
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1249_chunk r_607
                      ->  Seq Scan on compress_hyper_14_1250_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_548_chunk r_517
-                     ->  Seq Scan on compress_hyper_14_1251_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_549_chunk r_518
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1251_chunk r_608
                      ->  Seq Scan on compress_hyper_14_1252_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_550_chunk r_519
-                     ->  Seq Scan on compress_hyper_14_1253_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_551_chunk r_520
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1253_chunk r_609
                      ->  Seq Scan on compress_hyper_14_1254_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_552_chunk r_521
-                     ->  Seq Scan on compress_hyper_14_1255_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_553_chunk r_522
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1255_chunk r_610
                      ->  Seq Scan on compress_hyper_14_1256_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_554_chunk r_523
-                     ->  Seq Scan on compress_hyper_14_1257_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_555_chunk r_524
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1257_chunk r_611
                      ->  Seq Scan on compress_hyper_14_1258_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_556_chunk r_525
-                     ->  Seq Scan on compress_hyper_14_1259_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_557_chunk r_526
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1259_chunk r_612
                      ->  Seq Scan on compress_hyper_14_1260_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_558_chunk r_527
-                     ->  Seq Scan on compress_hyper_14_1261_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_559_chunk r_528
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1261_chunk r_613
                      ->  Seq Scan on compress_hyper_14_1262_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_560_chunk r_529
-                     ->  Seq Scan on compress_hyper_14_1263_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_561_chunk r_530
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1263_chunk r_614
                      ->  Seq Scan on compress_hyper_14_1264_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_562_chunk r_531
-                     ->  Seq Scan on compress_hyper_14_1265_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_563_chunk r_532
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1265_chunk r_615
                      ->  Seq Scan on compress_hyper_14_1266_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_564_chunk r_533
-                     ->  Seq Scan on compress_hyper_14_1267_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_565_chunk r_534
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1267_chunk r_616
                      ->  Seq Scan on compress_hyper_14_1268_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_566_chunk r_535
-                     ->  Seq Scan on compress_hyper_14_1269_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_567_chunk r_536
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1269_chunk r_617
                      ->  Seq Scan on compress_hyper_14_1270_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_568_chunk r_537
-                     ->  Seq Scan on compress_hyper_14_1271_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_569_chunk r_538
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1271_chunk r_618
                      ->  Seq Scan on compress_hyper_14_1272_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_570_chunk r_539
-                     ->  Seq Scan on compress_hyper_14_1273_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_571_chunk r_540
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1273_chunk r_619
                      ->  Seq Scan on compress_hyper_14_1274_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_572_chunk r_541
-                     ->  Seq Scan on compress_hyper_14_1275_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_573_chunk r_542
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1275_chunk r_620
                      ->  Seq Scan on compress_hyper_14_1276_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_574_chunk r_543
-                     ->  Seq Scan on compress_hyper_14_1277_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_575_chunk r_544
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1277_chunk r_621
                      ->  Seq Scan on compress_hyper_14_1278_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_576_chunk r_545
-                     ->  Seq Scan on compress_hyper_14_1279_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_577_chunk r_546
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1279_chunk r_622
                      ->  Seq Scan on compress_hyper_14_1280_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_578_chunk r_547
-                     ->  Seq Scan on compress_hyper_14_1281_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_579_chunk r_548
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1281_chunk r_623
                      ->  Seq Scan on compress_hyper_14_1282_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_580_chunk r_549
-                     ->  Seq Scan on compress_hyper_14_1283_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_581_chunk r_550
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1283_chunk r_624
                      ->  Seq Scan on compress_hyper_14_1284_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_582_chunk r_551
-                     ->  Seq Scan on compress_hyper_14_1285_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_583_chunk r_552
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1285_chunk r_625
                      ->  Seq Scan on compress_hyper_14_1286_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_584_chunk r_553
-                     ->  Seq Scan on compress_hyper_14_1287_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_585_chunk r_554
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1287_chunk r_626
                      ->  Seq Scan on compress_hyper_14_1288_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_586_chunk r_555
-                     ->  Seq Scan on compress_hyper_14_1289_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_587_chunk r_556
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1289_chunk r_627
                      ->  Seq Scan on compress_hyper_14_1290_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_588_chunk r_557
-                     ->  Seq Scan on compress_hyper_14_1291_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_589_chunk r_558
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1291_chunk r_628
                      ->  Seq Scan on compress_hyper_14_1292_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_590_chunk r_559
-                     ->  Seq Scan on compress_hyper_14_1293_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_591_chunk r_560
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1293_chunk r_629
                      ->  Seq Scan on compress_hyper_14_1294_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_592_chunk r_561
-                     ->  Seq Scan on compress_hyper_14_1295_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_593_chunk r_562
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1295_chunk r_630
                      ->  Seq Scan on compress_hyper_14_1296_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_594_chunk r_563
-                     ->  Seq Scan on compress_hyper_14_1297_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_595_chunk r_564
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1297_chunk r_631
                      ->  Seq Scan on compress_hyper_14_1298_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_596_chunk r_565
-                     ->  Seq Scan on compress_hyper_14_1299_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_597_chunk r_566
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1299_chunk r_632
                      ->  Seq Scan on compress_hyper_14_1300_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_598_chunk r_567
-                     ->  Seq Scan on compress_hyper_14_1301_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_599_chunk r_568
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1301_chunk r_633
                      ->  Seq Scan on compress_hyper_14_1302_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_600_chunk r_569
-                     ->  Seq Scan on compress_hyper_14_1303_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_601_chunk r_570
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1303_chunk r_634
                      ->  Seq Scan on compress_hyper_14_1304_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_602_chunk r_571
-                     ->  Seq Scan on compress_hyper_14_1305_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_603_chunk r_572
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1305_chunk r_635
                      ->  Seq Scan on compress_hyper_14_1306_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_604_chunk r_573
-                     ->  Seq Scan on compress_hyper_14_1307_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_605_chunk r_574
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1307_chunk r_636
                      ->  Seq Scan on compress_hyper_14_1308_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_606_chunk r_575
-                     ->  Seq Scan on compress_hyper_14_1309_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_607_chunk r_576
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1309_chunk r_637
                      ->  Seq Scan on compress_hyper_14_1310_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_608_chunk r_577
-                     ->  Seq Scan on compress_hyper_14_1311_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_609_chunk r_578
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1311_chunk r_638
                      ->  Seq Scan on compress_hyper_14_1312_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_610_chunk r_579
-                     ->  Seq Scan on compress_hyper_14_1313_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_611_chunk r_580
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1313_chunk r_639
                      ->  Seq Scan on compress_hyper_14_1314_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_612_chunk r_581
-                     ->  Seq Scan on compress_hyper_14_1315_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_613_chunk r_582
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1315_chunk r_640
                      ->  Seq Scan on compress_hyper_14_1316_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_614_chunk r_583
-                     ->  Seq Scan on compress_hyper_14_1317_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_615_chunk r_584
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1317_chunk r_641
                      ->  Seq Scan on compress_hyper_14_1318_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_616_chunk r_585
-                     ->  Seq Scan on compress_hyper_14_1319_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_617_chunk r_586
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1319_chunk r_642
                      ->  Seq Scan on compress_hyper_14_1320_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_618_chunk r_587
-                     ->  Seq Scan on compress_hyper_14_1321_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_619_chunk r_588
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1321_chunk r_643
                      ->  Seq Scan on compress_hyper_14_1322_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_620_chunk r_589
-                     ->  Seq Scan on compress_hyper_14_1323_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_621_chunk r_590
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1323_chunk r_644
                      ->  Seq Scan on compress_hyper_14_1324_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_622_chunk r_591
-                     ->  Seq Scan on compress_hyper_14_1325_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_623_chunk r_592
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1325_chunk r_645
                      ->  Seq Scan on compress_hyper_14_1326_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_624_chunk r_593
-                     ->  Seq Scan on compress_hyper_14_1327_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_625_chunk r_594
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1327_chunk r_646
                      ->  Seq Scan on compress_hyper_14_1328_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_626_chunk r_595
-                     ->  Seq Scan on compress_hyper_14_1329_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_627_chunk r_596
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1329_chunk r_647
                      ->  Seq Scan on compress_hyper_14_1330_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_628_chunk r_597
-                     ->  Seq Scan on compress_hyper_14_1331_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_629_chunk r_598
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1331_chunk r_648
                      ->  Seq Scan on compress_hyper_14_1332_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_630_chunk r_599
-                     ->  Seq Scan on compress_hyper_14_1333_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_631_chunk r_600
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1333_chunk r_649
                      ->  Seq Scan on compress_hyper_14_1334_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_632_chunk r_601
-                     ->  Seq Scan on compress_hyper_14_1335_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_633_chunk r_602
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1335_chunk r_650
                      ->  Seq Scan on compress_hyper_14_1336_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_634_chunk r_603
-                     ->  Seq Scan on compress_hyper_14_1337_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_635_chunk r_604
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1337_chunk r_651
                      ->  Seq Scan on compress_hyper_14_1338_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_636_chunk r_605
-                     ->  Seq Scan on compress_hyper_14_1339_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_637_chunk r_606
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1339_chunk r_652
                      ->  Seq Scan on compress_hyper_14_1340_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_638_chunk r_607
-                     ->  Seq Scan on compress_hyper_14_1341_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_639_chunk r_608
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1341_chunk r_653
                      ->  Seq Scan on compress_hyper_14_1342_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_640_chunk r_609
-                     ->  Seq Scan on compress_hyper_14_1343_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_641_chunk r_610
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1343_chunk r_654
                      ->  Seq Scan on compress_hyper_14_1344_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_642_chunk r_611
-                     ->  Seq Scan on compress_hyper_14_1345_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_643_chunk r_612
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1345_chunk r_655
                      ->  Seq Scan on compress_hyper_14_1346_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_644_chunk r_613
-                     ->  Seq Scan on compress_hyper_14_1347_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_645_chunk r_614
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1347_chunk r_656
                      ->  Seq Scan on compress_hyper_14_1348_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_646_chunk r_615
-                     ->  Seq Scan on compress_hyper_14_1349_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_647_chunk r_616
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1349_chunk r_657
                      ->  Seq Scan on compress_hyper_14_1350_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_648_chunk r_617
-                     ->  Seq Scan on compress_hyper_14_1351_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_649_chunk r_618
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1351_chunk r_658
                      ->  Seq Scan on compress_hyper_14_1352_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_650_chunk r_619
-                     ->  Seq Scan on compress_hyper_14_1353_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_651_chunk r_620
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1353_chunk r_659
                      ->  Seq Scan on compress_hyper_14_1354_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_652_chunk r_621
-                     ->  Seq Scan on compress_hyper_14_1355_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_653_chunk r_622
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1355_chunk r_660
                      ->  Seq Scan on compress_hyper_14_1356_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_654_chunk r_623
-                     ->  Seq Scan on compress_hyper_14_1357_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_655_chunk r_624
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1357_chunk r_661
                      ->  Seq Scan on compress_hyper_14_1358_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_656_chunk r_625
-                     ->  Seq Scan on compress_hyper_14_1359_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_657_chunk r_626
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1359_chunk r_662
                      ->  Seq Scan on compress_hyper_14_1360_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_658_chunk r_627
-                     ->  Seq Scan on compress_hyper_14_1361_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_659_chunk r_628
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1361_chunk r_663
                      ->  Seq Scan on compress_hyper_14_1362_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_660_chunk r_629
-                     ->  Seq Scan on compress_hyper_14_1363_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_661_chunk r_630
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1363_chunk r_664
                      ->  Seq Scan on compress_hyper_14_1364_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_662_chunk r_631
-                     ->  Seq Scan on compress_hyper_14_1365_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_663_chunk r_632
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1365_chunk r_665
                      ->  Seq Scan on compress_hyper_14_1366_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_664_chunk r_633
-                     ->  Seq Scan on compress_hyper_14_1367_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_665_chunk r_634
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1367_chunk r_666
                      ->  Seq Scan on compress_hyper_14_1368_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_666_chunk r_635
-                     ->  Seq Scan on compress_hyper_14_1369_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_667_chunk r_636
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1369_chunk r_667
                      ->  Seq Scan on compress_hyper_14_1370_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_668_chunk r_637
-                     ->  Seq Scan on compress_hyper_14_1371_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_669_chunk r_638
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1371_chunk r_668
                      ->  Seq Scan on compress_hyper_14_1372_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_670_chunk r_639
-                     ->  Seq Scan on compress_hyper_14_1373_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_671_chunk r_640
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1373_chunk r_669
                      ->  Seq Scan on compress_hyper_14_1374_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_672_chunk r_641
-                     ->  Seq Scan on compress_hyper_14_1375_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_673_chunk r_642
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1375_chunk r_670
                      ->  Seq Scan on compress_hyper_14_1376_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_674_chunk r_643
-                     ->  Seq Scan on compress_hyper_14_1377_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_675_chunk r_644
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1377_chunk r_671
                      ->  Seq Scan on compress_hyper_14_1378_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_676_chunk r_645
-                     ->  Seq Scan on compress_hyper_14_1379_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_677_chunk r_646
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1379_chunk r_672
                      ->  Seq Scan on compress_hyper_14_1380_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_678_chunk r_647
-                     ->  Seq Scan on compress_hyper_14_1381_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_679_chunk r_648
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1381_chunk r_673
                      ->  Seq Scan on compress_hyper_14_1382_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_680_chunk r_649
-                     ->  Seq Scan on compress_hyper_14_1383_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_681_chunk r_650
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1383_chunk r_674
                      ->  Seq Scan on compress_hyper_14_1384_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_682_chunk r_651
-                     ->  Seq Scan on compress_hyper_14_1385_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_683_chunk r_652
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1385_chunk r_675
                      ->  Seq Scan on compress_hyper_14_1386_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_684_chunk r_653
-                     ->  Seq Scan on compress_hyper_14_1387_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_685_chunk r_654
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1387_chunk r_676
                      ->  Seq Scan on compress_hyper_14_1388_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_686_chunk r_655
-                     ->  Seq Scan on compress_hyper_14_1389_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_687_chunk r_656
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1389_chunk r_677
                      ->  Seq Scan on compress_hyper_14_1390_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_688_chunk r_657
-                     ->  Seq Scan on compress_hyper_14_1391_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_689_chunk r_658
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1391_chunk r_678
                      ->  Seq Scan on compress_hyper_14_1392_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_690_chunk r_659
-                     ->  Seq Scan on compress_hyper_14_1393_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_691_chunk r_660
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1393_chunk r_679
                      ->  Seq Scan on compress_hyper_14_1394_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_692_chunk r_661
-                     ->  Seq Scan on compress_hyper_14_1395_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_693_chunk r_662
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1395_chunk r_680
                      ->  Seq Scan on compress_hyper_14_1396_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_694_chunk r_663
-                     ->  Seq Scan on compress_hyper_14_1397_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_695_chunk r_664
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1397_chunk r_681
                      ->  Seq Scan on compress_hyper_14_1398_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_696_chunk r_665
-                     ->  Seq Scan on compress_hyper_14_1399_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_697_chunk r_666
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1399_chunk r_682
                      ->  Seq Scan on compress_hyper_14_1400_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_698_chunk r_667
-                     ->  Seq Scan on compress_hyper_14_1401_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_699_chunk r_668
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1401_chunk r_683
                      ->  Seq Scan on compress_hyper_14_1402_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_700_chunk r_669
-                     ->  Seq Scan on compress_hyper_14_1403_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_701_chunk r_670
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1403_chunk r_684
                      ->  Seq Scan on compress_hyper_14_1404_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_702_chunk r_671
-                     ->  Seq Scan on compress_hyper_14_1405_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_703_chunk r_672
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1405_chunk r_685
                      ->  Seq Scan on compress_hyper_14_1406_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_704_chunk r_673
-                     ->  Seq Scan on compress_hyper_14_1407_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_705_chunk r_674
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1407_chunk r_686
                      ->  Seq Scan on compress_hyper_14_1408_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_706_chunk r_675
-                     ->  Seq Scan on compress_hyper_14_1409_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_707_chunk r_676
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1409_chunk r_687
                      ->  Seq Scan on compress_hyper_14_1410_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_708_chunk r_677
-                     ->  Seq Scan on compress_hyper_14_1411_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_709_chunk r_678
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1411_chunk r_688
                      ->  Seq Scan on compress_hyper_14_1412_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_710_chunk r_679
-                     ->  Seq Scan on compress_hyper_14_1413_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_711_chunk r_680
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1413_chunk r_689
                      ->  Seq Scan on compress_hyper_14_1414_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_712_chunk r_681
-                     ->  Seq Scan on compress_hyper_14_1415_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_713_chunk r_682
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1415_chunk r_690
                      ->  Seq Scan on compress_hyper_14_1416_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_714_chunk r_683
-                     ->  Seq Scan on compress_hyper_14_1417_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_715_chunk r_684
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1417_chunk r_691
                      ->  Seq Scan on compress_hyper_14_1418_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_716_chunk r_685
-                     ->  Seq Scan on compress_hyper_14_1419_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_717_chunk r_686
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1419_chunk r_692
                      ->  Seq Scan on compress_hyper_14_1420_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_718_chunk r_687
-                     ->  Seq Scan on compress_hyper_14_1421_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_719_chunk r_688
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1421_chunk r_693
                      ->  Seq Scan on compress_hyper_14_1422_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_720_chunk r_689
-                     ->  Seq Scan on compress_hyper_14_1423_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_721_chunk r_690
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1423_chunk r_694
                      ->  Seq Scan on compress_hyper_14_1424_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_722_chunk r_691
-                     ->  Seq Scan on compress_hyper_14_1425_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_723_chunk r_692
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1425_chunk r_695
                      ->  Seq Scan on compress_hyper_14_1426_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_724_chunk r_693
-                     ->  Seq Scan on compress_hyper_14_1427_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_725_chunk r_694
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1427_chunk r_696
                      ->  Seq Scan on compress_hyper_14_1428_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_726_chunk r_695
-                     ->  Seq Scan on compress_hyper_14_1429_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_727_chunk r_696
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1429_chunk r_697
                      ->  Seq Scan on compress_hyper_14_1430_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_728_chunk r_697
-                     ->  Seq Scan on compress_hyper_14_1431_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_729_chunk r_698
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1431_chunk r_698
                      ->  Seq Scan on compress_hyper_14_1432_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_730_chunk r_699
-                     ->  Seq Scan on compress_hyper_14_1433_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_731_chunk r_700
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1433_chunk r_699
                      ->  Seq Scan on compress_hyper_14_1434_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_732_chunk r_701
-                     ->  Seq Scan on compress_hyper_14_1435_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_733_chunk r_702
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1435_chunk r_700
                      ->  Seq Scan on compress_hyper_14_1436_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_734_chunk r_703
-                     ->  Seq Scan on compress_hyper_14_1437_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1437_chunk r_701
+                     ->  Seq Scan on compress_hyper_14_1438_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1439_chunk r_702
+                     ->  Seq Scan on compress_hyper_14_1440_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1441_chunk r_703
+                     ->  Seq Scan on compress_hyper_14_1442_chunk
          ->  Hash
                ->  Seq Scan on tags t
 (1413 rows)
@@ -9813,7 +9813,7 @@ EXPLAIN (costs off) SELECT * FROM metrics ORDER BY time, device_id;
                ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk
                      ->  Parallel Seq Scan on compress_hyper_5_15_chunk
                ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk
-                     ->  Parallel Seq Scan on compress_hyper_5_16_chunk
+                     ->  Parallel Seq Scan on compress_hyper_5_17_chunk
                ->  Parallel Seq Scan on _hyper_1_2_chunk
 (10 rows)
 
@@ -9831,7 +9831,7 @@ EXPLAIN (costs off) SELECT time_bucket('10 minutes', time) bucket, avg(v0) avg_v
                            ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk
                                  ->  Parallel Seq Scan on compress_hyper_5_15_chunk
                            ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk
-                                 ->  Parallel Seq Scan on compress_hyper_5_16_chunk
+                                 ->  Parallel Seq Scan on compress_hyper_5_17_chunk
                            ->  Parallel Seq Scan on _hyper_1_2_chunk
 (13 rows)
 
@@ -9844,15 +9844,15 @@ EXPLAIN (costs off) SELECT * FROM metrics_space ORDER BY time, device_id;
          Sort Key: _hyper_2_4_chunk."time", _hyper_2_4_chunk.device_id
          ->  Parallel Append
                ->  Custom Scan (DecompressChunk) on _hyper_2_4_chunk
-                     ->  Parallel Seq Scan on compress_hyper_6_17_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_2_6_chunk
-                     ->  Parallel Seq Scan on compress_hyper_6_19_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_2_10_chunk
-                     ->  Parallel Seq Scan on compress_hyper_6_20_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_2_5_chunk
                      ->  Parallel Seq Scan on compress_hyper_6_18_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_2_6_chunk
+                     ->  Parallel Seq Scan on compress_hyper_6_20_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_2_10_chunk
+                     ->  Parallel Seq Scan on compress_hyper_6_24_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_2_5_chunk
+                     ->  Parallel Seq Scan on compress_hyper_6_19_chunk
                ->  Custom Scan (DecompressChunk) on _hyper_2_11_chunk
-                     ->  Parallel Seq Scan on compress_hyper_6_21_chunk
+                     ->  Parallel Seq Scan on compress_hyper_6_25_chunk
                ->  Parallel Seq Scan on _hyper_2_8_chunk
                ->  Parallel Seq Scan on _hyper_2_7_chunk
                ->  Parallel Seq Scan on _hyper_2_9_chunk
@@ -9876,7 +9876,7 @@ EXPLAIN (costs off) SELECT * FROM metrics WHERE time > '2000-01-08' ORDER BY dev
                Index Cond: ("time" > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
    ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk
          Filter: ("time" > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
-         ->  Index Scan using compress_hyper_5_16_chunk_c_index_2 on compress_hyper_5_16_chunk
+         ->  Index Scan using compress_hyper_5_17_chunk_c_index_2 on compress_hyper_5_17_chunk
                Filter: (_ts_meta_max_3 > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
 (10 rows)
 
@@ -9893,11 +9893,11 @@ EXPLAIN (costs off) SELECT * FROM metrics_space WHERE time > '2000-01-08' ORDER 
          Index Cond: ("time" > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
    ->  Custom Scan (DecompressChunk) on _hyper_2_10_chunk
          Filter: ("time" > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
-         ->  Index Scan using compress_hyper_6_20_chunk_c_space_index_2 on compress_hyper_6_20_chunk
+         ->  Index Scan using compress_hyper_6_24_chunk_c_space_index_2 on compress_hyper_6_24_chunk
                Filter: (_ts_meta_max_3 > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
    ->  Custom Scan (DecompressChunk) on _hyper_2_11_chunk
          Filter: ("time" > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
-         ->  Index Scan using compress_hyper_6_21_chunk_c_space_index_2 on compress_hyper_6_21_chunk
+         ->  Index Scan using compress_hyper_6_25_chunk_c_space_index_2 on compress_hyper_6_25_chunk
                Filter: (_ts_meta_max_3 > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
    ->  Index Scan Backward using _hyper_2_12_chunk_metrics_space_device_id_device_id_peer_v0_v_2 on _hyper_2_12_chunk
          Index Cond: ("time" > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
@@ -9933,7 +9933,7 @@ $sql$;
          ->  Seq Scan on compress_hyper_5_15_chunk (actual rows=5 loops=1)
    ->  Seq Scan on _hyper_1_2_chunk (actual rows=2520 loops=1)
    ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk (actual rows=2520 loops=1)
-         ->  Seq Scan on compress_hyper_5_16_chunk (actual rows=5 loops=1)
+         ->  Seq Scan on compress_hyper_5_17_chunk (actual rows=5 loops=1)
 (6 rows)
 
 \c
@@ -9946,7 +9946,7 @@ $sql$;
          ->  Seq Scan on compress_hyper_5_15_chunk (actual rows=5 loops=1)
    ->  Seq Scan on _hyper_1_2_chunk (actual rows=2520 loops=1)
    ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk (actual rows=2520 loops=1)
-         ->  Seq Scan on compress_hyper_5_16_chunk (actual rows=5 loops=1)
+         ->  Seq Scan on compress_hyper_5_17_chunk (actual rows=5 loops=1)
 (6 rows)
 
 -- repro for core dump related to total_table_pages setting that get
@@ -10002,7 +10002,7 @@ FROM ( SELECT chunk_schema || '.' || chunk_name as chunk_table
        WHERE hypertable_name = 'motion_table' ORDER BY range_start limit 1 ) q;
                compress_chunk               
 --------------------------------------------
- _timescaledb_internal._hyper_15_1438_chunk
+ _timescaledb_internal._hyper_15_1443_chunk
 (1 row)
 
 --call to decompress chunk on 1 of the chunks

--- a/tsl/test/expected/transparent_decompression-15.out
+++ b/tsl/test/expected/transparent_decompression-15.out
@@ -254,9 +254,9 @@ LIMIT 5;
                ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_3_chunk (never executed)
                      Output: _hyper_1_3_chunk."time", _hyper_1_3_chunk.device_id, _hyper_1_3_chunk.device_id_peer, _hyper_1_3_chunk.v0, _hyper_1_3_chunk.v1, _hyper_1_3_chunk.v2, _hyper_1_3_chunk.v3
                      Bulk Decompression: true
-                     ->  Seq Scan on _timescaledb_internal.compress_hyper_5_16_chunk (never executed)
-                           Output: compress_hyper_5_16_chunk."time", compress_hyper_5_16_chunk.device_id, compress_hyper_5_16_chunk.device_id_peer, compress_hyper_5_16_chunk.v0, compress_hyper_5_16_chunk.v1, compress_hyper_5_16_chunk.v2, compress_hyper_5_16_chunk.v3, compress_hyper_5_16_chunk._ts_meta_count, compress_hyper_5_16_chunk._ts_meta_sequence_num, compress_hyper_5_16_chunk._ts_meta_min_3, compress_hyper_5_16_chunk._ts_meta_max_3, compress_hyper_5_16_chunk._ts_meta_min_1, compress_hyper_5_16_chunk._ts_meta_max_1, compress_hyper_5_16_chunk._ts_meta_min_2, compress_hyper_5_16_chunk._ts_meta_max_2
-                           Filter: (compress_hyper_5_16_chunk.device_id = 1)
+                     ->  Seq Scan on _timescaledb_internal.compress_hyper_5_17_chunk (never executed)
+                           Output: compress_hyper_5_17_chunk."time", compress_hyper_5_17_chunk.device_id, compress_hyper_5_17_chunk.device_id_peer, compress_hyper_5_17_chunk.v0, compress_hyper_5_17_chunk.v1, compress_hyper_5_17_chunk.v2, compress_hyper_5_17_chunk.v3, compress_hyper_5_17_chunk._ts_meta_count, compress_hyper_5_17_chunk._ts_meta_sequence_num, compress_hyper_5_17_chunk._ts_meta_min_3, compress_hyper_5_17_chunk._ts_meta_max_3, compress_hyper_5_17_chunk._ts_meta_min_1, compress_hyper_5_17_chunk._ts_meta_max_1, compress_hyper_5_17_chunk._ts_meta_min_2, compress_hyper_5_17_chunk._ts_meta_max_2
+                           Filter: (compress_hyper_5_17_chunk.device_id = 1)
 (30 rows)
 
 -- test RECORD by itself
@@ -283,7 +283,7 @@ ORDER BY time;
          Sort Key: _hyper_1_3_chunk."time"
          Sort Method: quicksort 
          ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk (actual rows=504 loops=1)
-               ->  Seq Scan on compress_hyper_5_16_chunk (actual rows=1 loops=1)
+               ->  Seq Scan on compress_hyper_5_17_chunk (actual rows=1 loops=1)
                      Filter: (device_id = 1)
                      Rows Removed by Filter: 4
 (19 rows)
@@ -323,7 +323,7 @@ ORDER BY time,
                      Sort Key: _hyper_1_3_chunk."time"
                      Sort Method: quicksort 
                      ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk (actual rows=1008 loops=1)
-                           ->  Seq Scan on compress_hyper_5_16_chunk (actual rows=2 loops=1)
+                           ->  Seq Scan on compress_hyper_5_17_chunk (actual rows=2 loops=1)
                                  Filter: (device_id = ANY ('{1,2}'::integer[]))
                                  Rows Removed by Filter: 3
 (24 rows)
@@ -339,7 +339,7 @@ FROM :TEST_TABLE;
          ->  Seq Scan on compress_hyper_5_15_chunk (actual rows=5 loops=1)
    ->  Seq Scan on _hyper_1_2_chunk (actual rows=2520 loops=1)
    ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk (actual rows=2520 loops=1)
-         ->  Seq Scan on compress_hyper_5_16_chunk (actual rows=5 loops=1)
+         ->  Seq Scan on compress_hyper_5_17_chunk (actual rows=5 loops=1)
 (6 rows)
 
 -- test empty resultset
@@ -358,7 +358,7 @@ WHERE device_id < 0;
          Filter: (device_id < 0)
          Rows Removed by Filter: 2520
    ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk (actual rows=0 loops=1)
-         ->  Seq Scan on compress_hyper_5_16_chunk (actual rows=0 loops=1)
+         ->  Seq Scan on compress_hyper_5_17_chunk (actual rows=0 loops=1)
                Filter: (device_id < 0)
                Rows Removed by Filter: 5
 (12 rows)
@@ -375,7 +375,7 @@ FROM :TEST_TABLE;
                ->  Seq Scan on compress_hyper_5_15_chunk (actual rows=5 loops=1)
          ->  Seq Scan on _hyper_1_2_chunk (actual rows=2520 loops=1)
          ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk (actual rows=2520 loops=1)
-               ->  Seq Scan on compress_hyper_5_16_chunk (actual rows=5 loops=1)
+               ->  Seq Scan on compress_hyper_5_17_chunk (actual rows=5 loops=1)
 (7 rows)
 
 -- test constraints not present in targetlist
@@ -398,7 +398,7 @@ ORDER BY v1;
                Filter: (device_id = 1)
                Rows Removed by Filter: 2016
          ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk (actual rows=504 loops=1)
-               ->  Seq Scan on compress_hyper_5_16_chunk (actual rows=1 loops=1)
+               ->  Seq Scan on compress_hyper_5_17_chunk (actual rows=1 loops=1)
                      Filter: (device_id = 1)
                      Rows Removed by Filter: 4
 (15 rows)
@@ -423,7 +423,7 @@ ORDER BY v1;
                Filter: (device_id = 1)
                Rows Removed by Filter: 2016
          ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk (actual rows=504 loops=1)
-               ->  Seq Scan on compress_hyper_5_16_chunk (actual rows=1 loops=1)
+               ->  Seq Scan on compress_hyper_5_17_chunk (actual rows=1 loops=1)
                      Filter: (device_id = 1)
                      Rows Removed by Filter: 4
 (15 rows)
@@ -444,7 +444,7 @@ WHERE device_id = 1;
          Filter: (device_id = 1)
          Rows Removed by Filter: 2016
    ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk (actual rows=504 loops=1)
-         ->  Seq Scan on compress_hyper_5_16_chunk (actual rows=1 loops=1)
+         ->  Seq Scan on compress_hyper_5_17_chunk (actual rows=1 loops=1)
                Filter: (device_id = 1)
                Rows Removed by Filter: 4
 (12 rows)
@@ -494,8 +494,8 @@ ORDER BY time,
                      Filter: (_hyper_1_3_chunk.v3 > '10'::double precision)
                      Rows Removed by Filter: 2520
                      Bulk Decompression: true
-                     ->  Seq Scan on _timescaledb_internal.compress_hyper_5_16_chunk (actual rows=5 loops=1)
-                           Output: compress_hyper_5_16_chunk."time", compress_hyper_5_16_chunk.device_id, compress_hyper_5_16_chunk.device_id_peer, compress_hyper_5_16_chunk.v0, compress_hyper_5_16_chunk.v1, compress_hyper_5_16_chunk.v2, compress_hyper_5_16_chunk.v3, compress_hyper_5_16_chunk._ts_meta_count, compress_hyper_5_16_chunk._ts_meta_sequence_num, compress_hyper_5_16_chunk._ts_meta_min_3, compress_hyper_5_16_chunk._ts_meta_max_3, compress_hyper_5_16_chunk._ts_meta_min_1, compress_hyper_5_16_chunk._ts_meta_max_1, compress_hyper_5_16_chunk._ts_meta_min_2, compress_hyper_5_16_chunk._ts_meta_max_2
+                     ->  Seq Scan on _timescaledb_internal.compress_hyper_5_17_chunk (actual rows=5 loops=1)
+                           Output: compress_hyper_5_17_chunk."time", compress_hyper_5_17_chunk.device_id, compress_hyper_5_17_chunk.device_id_peer, compress_hyper_5_17_chunk.v0, compress_hyper_5_17_chunk.v1, compress_hyper_5_17_chunk.v2, compress_hyper_5_17_chunk.v3, compress_hyper_5_17_chunk._ts_meta_count, compress_hyper_5_17_chunk._ts_meta_sequence_num, compress_hyper_5_17_chunk._ts_meta_min_3, compress_hyper_5_17_chunk._ts_meta_max_3, compress_hyper_5_17_chunk._ts_meta_min_1, compress_hyper_5_17_chunk._ts_meta_max_1, compress_hyper_5_17_chunk._ts_meta_min_2, compress_hyper_5_17_chunk._ts_meta_max_2
 (35 rows)
 
 -- device_id constraint should be pushed down
@@ -523,7 +523,7 @@ LIMIT 10;
          ->  Sort (never executed)
                Sort Key: _hyper_1_3_chunk."time"
                ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk (never executed)
-                     ->  Seq Scan on compress_hyper_5_16_chunk (never executed)
+                     ->  Seq Scan on compress_hyper_5_17_chunk (never executed)
                            Filter: (device_id = 1)
 (17 rows)
 
@@ -555,7 +555,7 @@ LIMIT 10;
                ->  Sort (never executed)
                      Sort Key: _hyper_1_3_chunk."time"
                      ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk (never executed)
-                           ->  Seq Scan on compress_hyper_5_16_chunk (never executed)
+                           ->  Seq Scan on compress_hyper_5_17_chunk (never executed)
                                  Filter: (device_id IS NOT NULL)
 (20 rows)
 
@@ -581,7 +581,7 @@ LIMIT 10;
                      Filter: (device_id IS NULL)
                      Rows Removed by Filter: 2520
                ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk (actual rows=0 loops=1)
-                     ->  Seq Scan on compress_hyper_5_16_chunk (actual rows=0 loops=1)
+                     ->  Seq Scan on compress_hyper_5_17_chunk (actual rows=0 loops=1)
                            Filter: (device_id IS NULL)
                            Rows Removed by Filter: 5
 (16 rows)
@@ -615,7 +615,7 @@ LIMIT 10;
                ->  Sort (never executed)
                      Sort Key: _hyper_1_3_chunk."time"
                      ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk (never executed)
-                           ->  Seq Scan on compress_hyper_5_16_chunk (never executed)
+                           ->  Seq Scan on compress_hyper_5_17_chunk (never executed)
                                  Filter: (device_id = ANY ('{1,2}'::integer[]))
 (21 rows)
 
@@ -644,7 +644,7 @@ LIMIT 10;
          ->  Sort (never executed)
                Sort Key: _hyper_1_3_chunk."time"
                ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk (never executed)
-                     ->  Seq Scan on compress_hyper_5_16_chunk (never executed)
+                     ->  Seq Scan on compress_hyper_5_17_chunk (never executed)
                            Filter: (device_id = 1)
 (17 rows)
 
@@ -679,7 +679,7 @@ LIMIT 10;
                      Sort Key: _hyper_1_3_chunk."time"
                      Sort Method: quicksort 
                      ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk (actual rows=0 loops=1)
-                           ->  Seq Scan on compress_hyper_5_16_chunk (actual rows=0 loops=1)
+                           ->  Seq Scan on compress_hyper_5_17_chunk (actual rows=0 loops=1)
                                  Filter: (device_id = device_id_peer)
                                  Rows Removed by Filter: 5
 (24 rows)
@@ -711,7 +711,7 @@ LIMIT 10;
                ->  Sort (never executed)
                      Sort Key: _hyper_1_3_chunk."time"
                      ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk (never executed)
-                           ->  Seq Scan on compress_hyper_5_16_chunk (never executed)
+                           ->  Seq Scan on compress_hyper_5_17_chunk (never executed)
                                  Filter: (device_id_peer < device_id)
 (20 rows)
 
@@ -740,7 +740,7 @@ LIMIT 10;
          ->  Sort (never executed)
                Sort Key: _hyper_1_3_chunk."time"
                ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk (never executed)
-                     ->  Seq Scan on compress_hyper_5_16_chunk (never executed)
+                     ->  Seq Scan on compress_hyper_5_17_chunk (never executed)
                            Filter: (device_id = 3)
 (17 rows)
 
@@ -772,7 +772,7 @@ LIMIT 10;
                Sort Key: _hyper_1_3_chunk."time"
                ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk (never executed)
                      Filter: (device_id = length("substring"(version(), 1, 3)))
-                     ->  Seq Scan on compress_hyper_5_16_chunk (never executed)
+                     ->  Seq Scan on compress_hyper_5_17_chunk (never executed)
 (18 rows)
 
 --
@@ -869,7 +869,7 @@ LIMIT 10;
                      Sort Key: _hyper_1_3_chunk."time"
                      ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk (never executed)
                            Filter: ("time" >= 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
-                           ->  Seq Scan on compress_hyper_5_16_chunk (never executed)
+                           ->  Seq Scan on compress_hyper_5_17_chunk (never executed)
                                  Filter: (_ts_meta_max_3 >= 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
 (23 rows)
 
@@ -903,7 +903,7 @@ LIMIT 10;
                      Sort Key: _hyper_1_3_chunk."time"
                      ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk (never executed)
                            Filter: ("time" > 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
-                           ->  Seq Scan on compress_hyper_5_16_chunk (never executed)
+                           ->  Seq Scan on compress_hyper_5_17_chunk (never executed)
                                  Filter: (_ts_meta_max_3 > 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
 (23 rows)
 
@@ -937,7 +937,7 @@ LIMIT 10;
                      Sort Key: _hyper_1_3_chunk."time"
                      ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk (never executed)
                            Filter: ('Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone < "time")
-                           ->  Seq Scan on compress_hyper_5_16_chunk (never executed)
+                           ->  Seq Scan on compress_hyper_5_17_chunk (never executed)
                                  Filter: (_ts_meta_max_3 > 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
 (23 rows)
 
@@ -973,7 +973,7 @@ LIMIT 10;
                      Sort Key: _hyper_1_3_chunk."time"
                      ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk (never executed)
                            Filter: (v0 < 1)
-                           ->  Seq Scan on compress_hyper_5_16_chunk (never executed)
+                           ->  Seq Scan on compress_hyper_5_17_chunk (never executed)
                                  Filter: (_ts_meta_min_1 < 1)
 (24 rows)
 
@@ -1007,7 +1007,7 @@ LIMIT 10;
                      Sort Key: _hyper_1_3_chunk."time"
                      ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk (never executed)
                            Filter: (v0 < device_id)
-                           ->  Seq Scan on compress_hyper_5_16_chunk (never executed)
+                           ->  Seq Scan on compress_hyper_5_17_chunk (never executed)
                                  Filter: (_ts_meta_min_1 < device_id)
 (23 rows)
 
@@ -1040,7 +1040,7 @@ LIMIT 10;
                      Sort Key: _hyper_1_3_chunk."time"
                      ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk (never executed)
                            Filter: (device_id < v0)
-                           ->  Seq Scan on compress_hyper_5_16_chunk (never executed)
+                           ->  Seq Scan on compress_hyper_5_17_chunk (never executed)
                                  Filter: (_ts_meta_max_1 > device_id)
 (22 rows)
 
@@ -1076,7 +1076,7 @@ LIMIT 10;
                      Sort Method: quicksort 
                      ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk (actual rows=0 loops=1)
                            Filter: (v1 = device_id)
-                           ->  Seq Scan on compress_hyper_5_16_chunk (actual rows=0 loops=1)
+                           ->  Seq Scan on compress_hyper_5_17_chunk (actual rows=0 loops=1)
                                  Filter: ((_ts_meta_min_2 <= device_id) AND (_ts_meta_max_2 >= device_id))
                                  Rows Removed by Filter: 5
 (26 rows)
@@ -1114,7 +1114,7 @@ LIMIT 10;
                      ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk (actual rows=0 loops=1)
                            Filter: (v0 = v1)
                            Rows Removed by Filter: 2520
-                           ->  Seq Scan on compress_hyper_5_16_chunk (actual rows=5 loops=1)
+                           ->  Seq Scan on compress_hyper_5_17_chunk (actual rows=5 loops=1)
 (24 rows)
 
 --pushdown of quals on order by and segment by cols anded together
@@ -1159,9 +1159,9 @@ LIMIT 10;
                      Output: _hyper_1_3_chunk."time", _hyper_1_3_chunk.device_id, _hyper_1_3_chunk.device_id_peer, _hyper_1_3_chunk.v0, _hyper_1_3_chunk.v1, _hyper_1_3_chunk.v2, _hyper_1_3_chunk.v3
                      Filter: (_hyper_1_3_chunk."time" > 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
                      Bulk Decompression: true
-                     ->  Seq Scan on _timescaledb_internal.compress_hyper_5_16_chunk (never executed)
-                           Output: compress_hyper_5_16_chunk."time", compress_hyper_5_16_chunk.device_id, compress_hyper_5_16_chunk.device_id_peer, compress_hyper_5_16_chunk.v0, compress_hyper_5_16_chunk.v1, compress_hyper_5_16_chunk.v2, compress_hyper_5_16_chunk.v3, compress_hyper_5_16_chunk._ts_meta_count, compress_hyper_5_16_chunk._ts_meta_sequence_num, compress_hyper_5_16_chunk._ts_meta_min_3, compress_hyper_5_16_chunk._ts_meta_max_3, compress_hyper_5_16_chunk._ts_meta_min_1, compress_hyper_5_16_chunk._ts_meta_max_1, compress_hyper_5_16_chunk._ts_meta_min_2, compress_hyper_5_16_chunk._ts_meta_max_2
-                           Filter: ((compress_hyper_5_16_chunk._ts_meta_max_3 > 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone) AND (compress_hyper_5_16_chunk.device_id = 1))
+                     ->  Seq Scan on _timescaledb_internal.compress_hyper_5_17_chunk (never executed)
+                           Output: compress_hyper_5_17_chunk."time", compress_hyper_5_17_chunk.device_id, compress_hyper_5_17_chunk.device_id_peer, compress_hyper_5_17_chunk.v0, compress_hyper_5_17_chunk.v1, compress_hyper_5_17_chunk.v2, compress_hyper_5_17_chunk.v3, compress_hyper_5_17_chunk._ts_meta_count, compress_hyper_5_17_chunk._ts_meta_sequence_num, compress_hyper_5_17_chunk._ts_meta_min_3, compress_hyper_5_17_chunk._ts_meta_max_3, compress_hyper_5_17_chunk._ts_meta_min_1, compress_hyper_5_17_chunk._ts_meta_max_1, compress_hyper_5_17_chunk._ts_meta_min_2, compress_hyper_5_17_chunk._ts_meta_max_2
+                           Filter: ((compress_hyper_5_17_chunk._ts_meta_max_3 > 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone) AND (compress_hyper_5_17_chunk.device_id = 1))
 (34 rows)
 
 --pushdown of quals on order by and segment by cols or together (not pushed down)
@@ -1195,7 +1195,7 @@ LIMIT 10;
                      Sort Key: _hyper_1_3_chunk."time"
                      ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk (never executed)
                            Filter: (("time" > 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone) OR (device_id = 1))
-                           ->  Seq Scan on compress_hyper_5_16_chunk (never executed)
+                           ->  Seq Scan on compress_hyper_5_17_chunk (never executed)
 (21 rows)
 
 --functions not yet optimized
@@ -1228,7 +1228,7 @@ LIMIT 10;
                      Sort Key: _hyper_1_3_chunk."time"
                      ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk (never executed)
                            Filter: ("time" < now())
-                           ->  Seq Scan on compress_hyper_5_16_chunk (never executed)
+                           ->  Seq Scan on compress_hyper_5_17_chunk (never executed)
 (21 rows)
 
 -- test sort optimization interaction
@@ -1246,7 +1246,7 @@ LIMIT 10;
                Sort Key: _hyper_1_3_chunk."time" DESC
                Sort Method: top-N heapsort 
                ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk (actual rows=2520 loops=1)
-                     ->  Seq Scan on compress_hyper_5_16_chunk (actual rows=5 loops=1)
+                     ->  Seq Scan on compress_hyper_5_17_chunk (actual rows=5 loops=1)
          ->  Index Only Scan using _hyper_1_2_chunk_metrics_time_idx on _hyper_1_2_chunk (never executed)
                Heap Fetches: 0
          ->  Sort (never executed)
@@ -1275,7 +1275,7 @@ LIMIT 10;
                      Sort Key: _hyper_1_3_chunk."time" DESC
                      Sort Method: quicksort 
                      ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk (actual rows=2520 loops=1)
-                           ->  Seq Scan on compress_hyper_5_16_chunk (actual rows=5 loops=1)
+                           ->  Seq Scan on compress_hyper_5_17_chunk (actual rows=5 loops=1)
                ->  Index Scan using _hyper_1_2_chunk_metrics_time_idx on _hyper_1_2_chunk (never executed)
                ->  Sort (never executed)
                      Sort Key: _hyper_1_1_chunk."time" DESC
@@ -1301,7 +1301,7 @@ LIMIT 10;
                      ->  Seq Scan on compress_hyper_5_15_chunk (actual rows=5 loops=1)
                ->  Seq Scan on _hyper_1_2_chunk (actual rows=2520 loops=1)
                ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk (actual rows=2520 loops=1)
-                     ->  Seq Scan on compress_hyper_5_16_chunk (actual rows=5 loops=1)
+                     ->  Seq Scan on compress_hyper_5_17_chunk (actual rows=5 loops=1)
 (10 rows)
 
 --
@@ -1337,9 +1337,9 @@ ORDER BY time,
                      Output: _hyper_1_3_chunk."time", _hyper_1_3_chunk.device_id, _hyper_1_3_chunk.device_id_peer, _hyper_1_3_chunk.v0, _hyper_1_3_chunk.v1, _hyper_1_3_chunk.v2, _hyper_1_3_chunk.v3
                      Filter: (_hyper_1_3_chunk."time" > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
                      Bulk Decompression: true
-                     ->  Seq Scan on _timescaledb_internal.compress_hyper_5_16_chunk (actual rows=5 loops=1)
-                           Output: compress_hyper_5_16_chunk."time", compress_hyper_5_16_chunk.device_id, compress_hyper_5_16_chunk.device_id_peer, compress_hyper_5_16_chunk.v0, compress_hyper_5_16_chunk.v1, compress_hyper_5_16_chunk.v2, compress_hyper_5_16_chunk.v3, compress_hyper_5_16_chunk._ts_meta_count, compress_hyper_5_16_chunk._ts_meta_sequence_num, compress_hyper_5_16_chunk._ts_meta_min_3, compress_hyper_5_16_chunk._ts_meta_max_3, compress_hyper_5_16_chunk._ts_meta_min_1, compress_hyper_5_16_chunk._ts_meta_max_1, compress_hyper_5_16_chunk._ts_meta_min_2, compress_hyper_5_16_chunk._ts_meta_max_2
-                           Filter: (compress_hyper_5_16_chunk._ts_meta_max_3 > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
+                     ->  Seq Scan on _timescaledb_internal.compress_hyper_5_17_chunk (actual rows=5 loops=1)
+                           Output: compress_hyper_5_17_chunk."time", compress_hyper_5_17_chunk.device_id, compress_hyper_5_17_chunk.device_id_peer, compress_hyper_5_17_chunk.v0, compress_hyper_5_17_chunk.v1, compress_hyper_5_17_chunk.v2, compress_hyper_5_17_chunk.v3, compress_hyper_5_17_chunk._ts_meta_count, compress_hyper_5_17_chunk._ts_meta_sequence_num, compress_hyper_5_17_chunk._ts_meta_min_3, compress_hyper_5_17_chunk._ts_meta_max_3, compress_hyper_5_17_chunk._ts_meta_min_1, compress_hyper_5_17_chunk._ts_meta_max_1, compress_hyper_5_17_chunk._ts_meta_min_2, compress_hyper_5_17_chunk._ts_meta_max_2
+                           Filter: (compress_hyper_5_17_chunk._ts_meta_max_3 > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
 (24 rows)
 
 -- should produce ordered path
@@ -1368,9 +1368,9 @@ ORDER BY device_id,
          Output: _hyper_1_3_chunk."time", _hyper_1_3_chunk.device_id, _hyper_1_3_chunk.device_id_peer, _hyper_1_3_chunk.v0, _hyper_1_3_chunk.v1, _hyper_1_3_chunk.v2, _hyper_1_3_chunk.v3
          Filter: (_hyper_1_3_chunk."time" > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
          Bulk Decompression: true
-         ->  Index Scan using compress_hyper_5_16_chunk__compressed_hypertable_5_device_id_de on _timescaledb_internal.compress_hyper_5_16_chunk (actual rows=5 loops=1)
-               Output: compress_hyper_5_16_chunk."time", compress_hyper_5_16_chunk.device_id, compress_hyper_5_16_chunk.device_id_peer, compress_hyper_5_16_chunk.v0, compress_hyper_5_16_chunk.v1, compress_hyper_5_16_chunk.v2, compress_hyper_5_16_chunk.v3, compress_hyper_5_16_chunk._ts_meta_count, compress_hyper_5_16_chunk._ts_meta_sequence_num, compress_hyper_5_16_chunk._ts_meta_min_3, compress_hyper_5_16_chunk._ts_meta_max_3, compress_hyper_5_16_chunk._ts_meta_min_1, compress_hyper_5_16_chunk._ts_meta_max_1, compress_hyper_5_16_chunk._ts_meta_min_2, compress_hyper_5_16_chunk._ts_meta_max_2
-               Filter: (compress_hyper_5_16_chunk._ts_meta_max_3 > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
+         ->  Index Scan using compress_hyper_5_17_chunk__compressed_hypertable_5_device_id_de on _timescaledb_internal.compress_hyper_5_17_chunk (actual rows=5 loops=1)
+               Output: compress_hyper_5_17_chunk."time", compress_hyper_5_17_chunk.device_id, compress_hyper_5_17_chunk.device_id_peer, compress_hyper_5_17_chunk.v0, compress_hyper_5_17_chunk.v1, compress_hyper_5_17_chunk.v2, compress_hyper_5_17_chunk.v3, compress_hyper_5_17_chunk._ts_meta_count, compress_hyper_5_17_chunk._ts_meta_sequence_num, compress_hyper_5_17_chunk._ts_meta_min_3, compress_hyper_5_17_chunk._ts_meta_max_3, compress_hyper_5_17_chunk._ts_meta_min_1, compress_hyper_5_17_chunk._ts_meta_max_1, compress_hyper_5_17_chunk._ts_meta_min_2, compress_hyper_5_17_chunk._ts_meta_max_2
+               Filter: (compress_hyper_5_17_chunk._ts_meta_max_3 > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
 (17 rows)
 
 -- test order by columns not in targetlist
@@ -1403,9 +1403,9 @@ LIMIT 100;
                Output: _hyper_1_3_chunk.device_id, _hyper_1_3_chunk.device_id_peer, _hyper_1_3_chunk.v0, _hyper_1_3_chunk.v1, _hyper_1_3_chunk."time"
                Filter: (_hyper_1_3_chunk."time" > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
                Bulk Decompression: true
-               ->  Index Scan using compress_hyper_5_16_chunk__compressed_hypertable_5_device_id_de on _timescaledb_internal.compress_hyper_5_16_chunk (actual rows=1 loops=1)
-                     Output: compress_hyper_5_16_chunk."time", compress_hyper_5_16_chunk.device_id, compress_hyper_5_16_chunk.device_id_peer, compress_hyper_5_16_chunk.v0, compress_hyper_5_16_chunk.v1, compress_hyper_5_16_chunk.v2, compress_hyper_5_16_chunk.v3, compress_hyper_5_16_chunk._ts_meta_count, compress_hyper_5_16_chunk._ts_meta_sequence_num, compress_hyper_5_16_chunk._ts_meta_min_3, compress_hyper_5_16_chunk._ts_meta_max_3, compress_hyper_5_16_chunk._ts_meta_min_1, compress_hyper_5_16_chunk._ts_meta_max_1, compress_hyper_5_16_chunk._ts_meta_min_2, compress_hyper_5_16_chunk._ts_meta_max_2
-                     Filter: (compress_hyper_5_16_chunk._ts_meta_max_3 > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
+               ->  Index Scan using compress_hyper_5_17_chunk__compressed_hypertable_5_device_id_de on _timescaledb_internal.compress_hyper_5_17_chunk (actual rows=1 loops=1)
+                     Output: compress_hyper_5_17_chunk."time", compress_hyper_5_17_chunk.device_id, compress_hyper_5_17_chunk.device_id_peer, compress_hyper_5_17_chunk.v0, compress_hyper_5_17_chunk.v1, compress_hyper_5_17_chunk.v2, compress_hyper_5_17_chunk.v3, compress_hyper_5_17_chunk._ts_meta_count, compress_hyper_5_17_chunk._ts_meta_sequence_num, compress_hyper_5_17_chunk._ts_meta_min_3, compress_hyper_5_17_chunk._ts_meta_max_3, compress_hyper_5_17_chunk._ts_meta_min_1, compress_hyper_5_17_chunk._ts_meta_max_1, compress_hyper_5_17_chunk._ts_meta_min_2, compress_hyper_5_17_chunk._ts_meta_max_2
+                     Filter: (compress_hyper_5_17_chunk._ts_meta_max_3 > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
 (19 rows)
 
 -- test ordering only by segmentby columns
@@ -1436,9 +1436,9 @@ LIMIT 100;
                Output: _hyper_1_3_chunk.device_id, _hyper_1_3_chunk.device_id_peer
                Filter: (_hyper_1_3_chunk."time" > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
                Bulk Decompression: true
-               ->  Index Scan using compress_hyper_5_16_chunk__compressed_hypertable_5_device_id_de on _timescaledb_internal.compress_hyper_5_16_chunk (actual rows=1 loops=1)
-                     Output: compress_hyper_5_16_chunk."time", compress_hyper_5_16_chunk.device_id, compress_hyper_5_16_chunk.device_id_peer, compress_hyper_5_16_chunk.v0, compress_hyper_5_16_chunk.v1, compress_hyper_5_16_chunk.v2, compress_hyper_5_16_chunk.v3, compress_hyper_5_16_chunk._ts_meta_count, compress_hyper_5_16_chunk._ts_meta_sequence_num, compress_hyper_5_16_chunk._ts_meta_min_3, compress_hyper_5_16_chunk._ts_meta_max_3, compress_hyper_5_16_chunk._ts_meta_min_1, compress_hyper_5_16_chunk._ts_meta_max_1, compress_hyper_5_16_chunk._ts_meta_min_2, compress_hyper_5_16_chunk._ts_meta_max_2
-                     Filter: (compress_hyper_5_16_chunk._ts_meta_max_3 > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
+               ->  Index Scan using compress_hyper_5_17_chunk__compressed_hypertable_5_device_id_de on _timescaledb_internal.compress_hyper_5_17_chunk (actual rows=1 loops=1)
+                     Output: compress_hyper_5_17_chunk."time", compress_hyper_5_17_chunk.device_id, compress_hyper_5_17_chunk.device_id_peer, compress_hyper_5_17_chunk.v0, compress_hyper_5_17_chunk.v1, compress_hyper_5_17_chunk.v2, compress_hyper_5_17_chunk.v3, compress_hyper_5_17_chunk._ts_meta_count, compress_hyper_5_17_chunk._ts_meta_sequence_num, compress_hyper_5_17_chunk._ts_meta_min_3, compress_hyper_5_17_chunk._ts_meta_max_3, compress_hyper_5_17_chunk._ts_meta_min_1, compress_hyper_5_17_chunk._ts_meta_max_1, compress_hyper_5_17_chunk._ts_meta_min_2, compress_hyper_5_17_chunk._ts_meta_max_2
+                     Filter: (compress_hyper_5_17_chunk._ts_meta_max_3 > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
 (19 rows)
 
 -- should produce ordered path
@@ -1468,9 +1468,9 @@ ORDER BY device_id,
          Output: _hyper_1_3_chunk.device_id, _hyper_1_3_chunk.device_id_peer, _hyper_1_3_chunk.v0
          Filter: (_hyper_1_3_chunk."time" > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
          Bulk Decompression: true
-         ->  Index Scan using compress_hyper_5_16_chunk__compressed_hypertable_5_device_id_de on _timescaledb_internal.compress_hyper_5_16_chunk (actual rows=5 loops=1)
-               Output: compress_hyper_5_16_chunk."time", compress_hyper_5_16_chunk.device_id, compress_hyper_5_16_chunk.device_id_peer, compress_hyper_5_16_chunk.v0, compress_hyper_5_16_chunk.v1, compress_hyper_5_16_chunk.v2, compress_hyper_5_16_chunk.v3, compress_hyper_5_16_chunk._ts_meta_count, compress_hyper_5_16_chunk._ts_meta_sequence_num, compress_hyper_5_16_chunk._ts_meta_min_3, compress_hyper_5_16_chunk._ts_meta_max_3, compress_hyper_5_16_chunk._ts_meta_min_1, compress_hyper_5_16_chunk._ts_meta_max_1, compress_hyper_5_16_chunk._ts_meta_min_2, compress_hyper_5_16_chunk._ts_meta_max_2
-               Filter: (compress_hyper_5_16_chunk._ts_meta_max_3 > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
+         ->  Index Scan using compress_hyper_5_17_chunk__compressed_hypertable_5_device_id_de on _timescaledb_internal.compress_hyper_5_17_chunk (actual rows=5 loops=1)
+               Output: compress_hyper_5_17_chunk."time", compress_hyper_5_17_chunk.device_id, compress_hyper_5_17_chunk.device_id_peer, compress_hyper_5_17_chunk.v0, compress_hyper_5_17_chunk.v1, compress_hyper_5_17_chunk.v2, compress_hyper_5_17_chunk.v3, compress_hyper_5_17_chunk._ts_meta_count, compress_hyper_5_17_chunk._ts_meta_sequence_num, compress_hyper_5_17_chunk._ts_meta_min_3, compress_hyper_5_17_chunk._ts_meta_max_3, compress_hyper_5_17_chunk._ts_meta_min_1, compress_hyper_5_17_chunk._ts_meta_max_1, compress_hyper_5_17_chunk._ts_meta_min_2, compress_hyper_5_17_chunk._ts_meta_max_2
+               Filter: (compress_hyper_5_17_chunk._ts_meta_max_3 > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
 (17 rows)
 
 -- should produce ordered path
@@ -1502,9 +1502,9 @@ ORDER BY device_id,
          Output: _hyper_1_3_chunk.device_id, _hyper_1_3_chunk.device_id_peer, _hyper_1_3_chunk.v0, _hyper_1_3_chunk.v1
          Filter: (_hyper_1_3_chunk."time" > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
          Bulk Decompression: true
-         ->  Index Scan using compress_hyper_5_16_chunk__compressed_hypertable_5_device_id_de on _timescaledb_internal.compress_hyper_5_16_chunk (actual rows=5 loops=1)
-               Output: compress_hyper_5_16_chunk."time", compress_hyper_5_16_chunk.device_id, compress_hyper_5_16_chunk.device_id_peer, compress_hyper_5_16_chunk.v0, compress_hyper_5_16_chunk.v1, compress_hyper_5_16_chunk.v2, compress_hyper_5_16_chunk.v3, compress_hyper_5_16_chunk._ts_meta_count, compress_hyper_5_16_chunk._ts_meta_sequence_num, compress_hyper_5_16_chunk._ts_meta_min_3, compress_hyper_5_16_chunk._ts_meta_max_3, compress_hyper_5_16_chunk._ts_meta_min_1, compress_hyper_5_16_chunk._ts_meta_max_1, compress_hyper_5_16_chunk._ts_meta_min_2, compress_hyper_5_16_chunk._ts_meta_max_2
-               Filter: (compress_hyper_5_16_chunk._ts_meta_max_3 > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
+         ->  Index Scan using compress_hyper_5_17_chunk__compressed_hypertable_5_device_id_de on _timescaledb_internal.compress_hyper_5_17_chunk (actual rows=5 loops=1)
+               Output: compress_hyper_5_17_chunk."time", compress_hyper_5_17_chunk.device_id, compress_hyper_5_17_chunk.device_id_peer, compress_hyper_5_17_chunk.v0, compress_hyper_5_17_chunk.v1, compress_hyper_5_17_chunk.v2, compress_hyper_5_17_chunk.v3, compress_hyper_5_17_chunk._ts_meta_count, compress_hyper_5_17_chunk._ts_meta_sequence_num, compress_hyper_5_17_chunk._ts_meta_min_3, compress_hyper_5_17_chunk._ts_meta_max_3, compress_hyper_5_17_chunk._ts_meta_min_1, compress_hyper_5_17_chunk._ts_meta_max_1, compress_hyper_5_17_chunk._ts_meta_min_2, compress_hyper_5_17_chunk._ts_meta_max_2
+               Filter: (compress_hyper_5_17_chunk._ts_meta_max_3 > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
 (17 rows)
 
 -- should not produce ordered path
@@ -1533,9 +1533,9 @@ ORDER BY device_id,
                Output: _hyper_1_3_chunk."time", _hyper_1_3_chunk.device_id, _hyper_1_3_chunk.device_id_peer, _hyper_1_3_chunk.v0, _hyper_1_3_chunk.v1, _hyper_1_3_chunk.v2, _hyper_1_3_chunk.v3
                Filter: (_hyper_1_3_chunk."time" > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
                Bulk Decompression: true
-               ->  Seq Scan on _timescaledb_internal.compress_hyper_5_16_chunk (actual rows=5 loops=1)
-                     Output: compress_hyper_5_16_chunk."time", compress_hyper_5_16_chunk.device_id, compress_hyper_5_16_chunk.device_id_peer, compress_hyper_5_16_chunk.v0, compress_hyper_5_16_chunk.v1, compress_hyper_5_16_chunk.v2, compress_hyper_5_16_chunk.v3, compress_hyper_5_16_chunk._ts_meta_count, compress_hyper_5_16_chunk._ts_meta_sequence_num, compress_hyper_5_16_chunk._ts_meta_min_3, compress_hyper_5_16_chunk._ts_meta_max_3, compress_hyper_5_16_chunk._ts_meta_min_1, compress_hyper_5_16_chunk._ts_meta_max_1, compress_hyper_5_16_chunk._ts_meta_min_2, compress_hyper_5_16_chunk._ts_meta_max_2
-                     Filter: (compress_hyper_5_16_chunk._ts_meta_max_3 > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
+               ->  Seq Scan on _timescaledb_internal.compress_hyper_5_17_chunk (actual rows=5 loops=1)
+                     Output: compress_hyper_5_17_chunk."time", compress_hyper_5_17_chunk.device_id, compress_hyper_5_17_chunk.device_id_peer, compress_hyper_5_17_chunk.v0, compress_hyper_5_17_chunk.v1, compress_hyper_5_17_chunk.v2, compress_hyper_5_17_chunk.v3, compress_hyper_5_17_chunk._ts_meta_count, compress_hyper_5_17_chunk._ts_meta_sequence_num, compress_hyper_5_17_chunk._ts_meta_min_3, compress_hyper_5_17_chunk._ts_meta_max_3, compress_hyper_5_17_chunk._ts_meta_min_1, compress_hyper_5_17_chunk._ts_meta_max_1, compress_hyper_5_17_chunk._ts_meta_min_2, compress_hyper_5_17_chunk._ts_meta_max_2
+                     Filter: (compress_hyper_5_17_chunk._ts_meta_max_3 > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
 (16 rows)
 
 -- should produce ordered path
@@ -1566,12 +1566,12 @@ ORDER BY device_id DESC,
          Filter: (_hyper_1_3_chunk."time" > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
          Bulk Decompression: true
          ->  Sort (actual rows=5 loops=1)
-               Output: compress_hyper_5_16_chunk."time", compress_hyper_5_16_chunk.device_id, compress_hyper_5_16_chunk.device_id_peer, compress_hyper_5_16_chunk.v0, compress_hyper_5_16_chunk.v1, compress_hyper_5_16_chunk.v2, compress_hyper_5_16_chunk.v3, compress_hyper_5_16_chunk._ts_meta_count, compress_hyper_5_16_chunk._ts_meta_sequence_num, compress_hyper_5_16_chunk._ts_meta_min_3, compress_hyper_5_16_chunk._ts_meta_max_3, compress_hyper_5_16_chunk._ts_meta_min_1, compress_hyper_5_16_chunk._ts_meta_max_1, compress_hyper_5_16_chunk._ts_meta_min_2, compress_hyper_5_16_chunk._ts_meta_max_2
-               Sort Key: compress_hyper_5_16_chunk.device_id DESC, compress_hyper_5_16_chunk.device_id_peer DESC, compress_hyper_5_16_chunk._ts_meta_sequence_num
+               Output: compress_hyper_5_17_chunk."time", compress_hyper_5_17_chunk.device_id, compress_hyper_5_17_chunk.device_id_peer, compress_hyper_5_17_chunk.v0, compress_hyper_5_17_chunk.v1, compress_hyper_5_17_chunk.v2, compress_hyper_5_17_chunk.v3, compress_hyper_5_17_chunk._ts_meta_count, compress_hyper_5_17_chunk._ts_meta_sequence_num, compress_hyper_5_17_chunk._ts_meta_min_3, compress_hyper_5_17_chunk._ts_meta_max_3, compress_hyper_5_17_chunk._ts_meta_min_1, compress_hyper_5_17_chunk._ts_meta_max_1, compress_hyper_5_17_chunk._ts_meta_min_2, compress_hyper_5_17_chunk._ts_meta_max_2
+               Sort Key: compress_hyper_5_17_chunk.device_id DESC, compress_hyper_5_17_chunk.device_id_peer DESC, compress_hyper_5_17_chunk._ts_meta_sequence_num
                Sort Method: quicksort 
-               ->  Seq Scan on _timescaledb_internal.compress_hyper_5_16_chunk (actual rows=5 loops=1)
-                     Output: compress_hyper_5_16_chunk."time", compress_hyper_5_16_chunk.device_id, compress_hyper_5_16_chunk.device_id_peer, compress_hyper_5_16_chunk.v0, compress_hyper_5_16_chunk.v1, compress_hyper_5_16_chunk.v2, compress_hyper_5_16_chunk.v3, compress_hyper_5_16_chunk._ts_meta_count, compress_hyper_5_16_chunk._ts_meta_sequence_num, compress_hyper_5_16_chunk._ts_meta_min_3, compress_hyper_5_16_chunk._ts_meta_max_3, compress_hyper_5_16_chunk._ts_meta_min_1, compress_hyper_5_16_chunk._ts_meta_max_1, compress_hyper_5_16_chunk._ts_meta_min_2, compress_hyper_5_16_chunk._ts_meta_max_2
-                     Filter: (compress_hyper_5_16_chunk._ts_meta_max_3 > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
+               ->  Seq Scan on _timescaledb_internal.compress_hyper_5_17_chunk (actual rows=5 loops=1)
+                     Output: compress_hyper_5_17_chunk."time", compress_hyper_5_17_chunk.device_id, compress_hyper_5_17_chunk.device_id_peer, compress_hyper_5_17_chunk.v0, compress_hyper_5_17_chunk.v1, compress_hyper_5_17_chunk.v2, compress_hyper_5_17_chunk.v3, compress_hyper_5_17_chunk._ts_meta_count, compress_hyper_5_17_chunk._ts_meta_sequence_num, compress_hyper_5_17_chunk._ts_meta_min_3, compress_hyper_5_17_chunk._ts_meta_max_3, compress_hyper_5_17_chunk._ts_meta_min_1, compress_hyper_5_17_chunk._ts_meta_max_1, compress_hyper_5_17_chunk._ts_meta_min_2, compress_hyper_5_17_chunk._ts_meta_max_2
+                     Filter: (compress_hyper_5_17_chunk._ts_meta_max_3 > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
 (21 rows)
 
 -- should not produce ordered path
@@ -1599,9 +1599,9 @@ ORDER BY device_id DESC,
                Output: _hyper_1_3_chunk."time", _hyper_1_3_chunk.device_id, _hyper_1_3_chunk.device_id_peer, _hyper_1_3_chunk.v0, _hyper_1_3_chunk.v1, _hyper_1_3_chunk.v2, _hyper_1_3_chunk.v3
                Filter: (_hyper_1_3_chunk."time" > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
                Bulk Decompression: true
-               ->  Seq Scan on _timescaledb_internal.compress_hyper_5_16_chunk (actual rows=5 loops=1)
-                     Output: compress_hyper_5_16_chunk."time", compress_hyper_5_16_chunk.device_id, compress_hyper_5_16_chunk.device_id_peer, compress_hyper_5_16_chunk.v0, compress_hyper_5_16_chunk.v1, compress_hyper_5_16_chunk.v2, compress_hyper_5_16_chunk.v3, compress_hyper_5_16_chunk._ts_meta_count, compress_hyper_5_16_chunk._ts_meta_sequence_num, compress_hyper_5_16_chunk._ts_meta_min_3, compress_hyper_5_16_chunk._ts_meta_max_3, compress_hyper_5_16_chunk._ts_meta_min_1, compress_hyper_5_16_chunk._ts_meta_max_1, compress_hyper_5_16_chunk._ts_meta_min_2, compress_hyper_5_16_chunk._ts_meta_max_2
-                     Filter: (compress_hyper_5_16_chunk._ts_meta_max_3 > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
+               ->  Seq Scan on _timescaledb_internal.compress_hyper_5_17_chunk (actual rows=5 loops=1)
+                     Output: compress_hyper_5_17_chunk."time", compress_hyper_5_17_chunk.device_id, compress_hyper_5_17_chunk.device_id_peer, compress_hyper_5_17_chunk.v0, compress_hyper_5_17_chunk.v1, compress_hyper_5_17_chunk.v2, compress_hyper_5_17_chunk.v3, compress_hyper_5_17_chunk._ts_meta_count, compress_hyper_5_17_chunk._ts_meta_sequence_num, compress_hyper_5_17_chunk._ts_meta_min_3, compress_hyper_5_17_chunk._ts_meta_max_3, compress_hyper_5_17_chunk._ts_meta_min_1, compress_hyper_5_17_chunk._ts_meta_max_1, compress_hyper_5_17_chunk._ts_meta_min_2, compress_hyper_5_17_chunk._ts_meta_max_2
+                     Filter: (compress_hyper_5_17_chunk._ts_meta_max_3 > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
 (16 rows)
 
 --
@@ -1630,7 +1630,7 @@ ORDER BY time,
                Sort Method: quicksort 
                ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk (actual rows=2520 loops=1)
                      Filter: ("time" > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
-                     ->  Seq Scan on compress_hyper_5_16_chunk (actual rows=5 loops=1)
+                     ->  Seq Scan on compress_hyper_5_17_chunk (actual rows=5 loops=1)
                            Filter: (_ts_meta_max_3 > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
 (15 rows)
 
@@ -1658,7 +1658,7 @@ ORDER BY time,
                Sort Method: quicksort 
                ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk (actual rows=2520 loops=1)
                      Filter: ("time" > ('2000-01-08'::cstring)::timestamp with time zone)
-                     ->  Seq Scan on compress_hyper_5_16_chunk (actual rows=5 loops=1)
+                     ->  Seq Scan on compress_hyper_5_17_chunk (actual rows=5 loops=1)
                            Filter: (_ts_meta_max_3 > ('2000-01-08'::cstring)::timestamp with time zone)
 (16 rows)
 
@@ -1674,7 +1674,7 @@ FROM :TEST_TABLE;
                ->  Seq Scan on compress_hyper_5_15_chunk (actual rows=5 loops=1)
          ->  Seq Scan on _hyper_1_2_chunk (actual rows=2520 loops=1)
          ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk (actual rows=2520 loops=1)
-               ->  Seq Scan on compress_hyper_5_16_chunk (actual rows=5 loops=1)
+               ->  Seq Scan on compress_hyper_5_17_chunk (actual rows=5 loops=1)
 (7 rows)
 
 -- test aggregate with GROUP BY
@@ -1696,7 +1696,7 @@ ORDER BY device_id;
                      ->  Seq Scan on compress_hyper_5_15_chunk (actual rows=5 loops=1)
                ->  Seq Scan on _hyper_1_2_chunk (actual rows=2520 loops=1)
                ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk (actual rows=2520 loops=1)
-                     ->  Seq Scan on compress_hyper_5_16_chunk (actual rows=5 loops=1)
+                     ->  Seq Scan on compress_hyper_5_17_chunk (actual rows=5 loops=1)
 (12 rows)
 
 -- test window functions with GROUP BY
@@ -1719,7 +1719,7 @@ ORDER BY device_id;
                            ->  Seq Scan on compress_hyper_5_15_chunk (actual rows=5 loops=1)
                      ->  Seq Scan on _hyper_1_2_chunk (actual rows=2520 loops=1)
                      ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk (actual rows=2520 loops=1)
-                           ->  Seq Scan on compress_hyper_5_16_chunk (actual rows=5 loops=1)
+                           ->  Seq Scan on compress_hyper_5_17_chunk (actual rows=5 loops=1)
 (13 rows)
 
 -- test CTE
@@ -1749,7 +1749,7 @@ ORDER BY v1;
                      Sort Key: _hyper_1_3_chunk."time"
                      Sort Method: quicksort 
                      ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk (actual rows=2520 loops=1)
-                           ->  Seq Scan on compress_hyper_5_16_chunk (actual rows=5 loops=1)
+                           ->  Seq Scan on compress_hyper_5_17_chunk (actual rows=5 loops=1)
 (17 rows)
 
 -- test CTE join
@@ -1791,7 +1791,7 @@ ORDER BY q1.time;
                Sort Key: _hyper_1_3_chunk."time"
                Sort Method: quicksort 
                ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk (actual rows=504 loops=1)
-                     ->  Seq Scan on compress_hyper_5_16_chunk (actual rows=1 loops=1)
+                     ->  Seq Scan on compress_hyper_5_17_chunk (actual rows=1 loops=1)
                            Filter: (device_id = 1)
                            Rows Removed by Filter: 4
    ->  Materialize (actual rows=1368 loops=1)
@@ -1811,7 +1811,7 @@ ORDER BY q1.time;
                      Sort Key: _hyper_1_3_chunk_1."time"
                      Sort Method: quicksort 
                      ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk _hyper_1_3_chunk_1 (actual rows=504 loops=1)
-                           ->  Seq Scan on compress_hyper_5_16_chunk compress_hyper_5_16_chunk_1 (actual rows=1 loops=1)
+                           ->  Seq Scan on compress_hyper_5_17_chunk compress_hyper_5_17_chunk_1 (actual rows=1 loops=1)
                                  Filter: (device_id = 2)
                                  Rows Removed by Filter: 4
 (41 rows)
@@ -1834,7 +1834,7 @@ WHERE device_id = 1;
                Filter: (device_id = 1)
                Rows Removed by Filter: 2016
          ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk (actual rows=504 loops=1)
-               ->  Seq Scan on compress_hyper_5_16_chunk (actual rows=1 loops=1)
+               ->  Seq Scan on compress_hyper_5_17_chunk (actual rows=1 loops=1)
                      Filter: (device_id = 1)
                      Rows Removed by Filter: 4
 (13 rows)
@@ -1913,9 +1913,9 @@ ORDER BY device_id,
          ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_3_chunk (actual rows=504 loops=1)
                Output: _hyper_1_3_chunk."time", _hyper_1_3_chunk.device_id
                Bulk Decompression: true
-               ->  Index Scan using compress_hyper_5_16_chunk_c_index_2 on _timescaledb_internal.compress_hyper_5_16_chunk (actual rows=1 loops=1)
-                     Output: compress_hyper_5_16_chunk."time", compress_hyper_5_16_chunk.device_id, compress_hyper_5_16_chunk.device_id_peer, compress_hyper_5_16_chunk.v0, compress_hyper_5_16_chunk.v1, compress_hyper_5_16_chunk.v2, compress_hyper_5_16_chunk.v3, compress_hyper_5_16_chunk._ts_meta_count, compress_hyper_5_16_chunk._ts_meta_sequence_num, compress_hyper_5_16_chunk._ts_meta_min_3, compress_hyper_5_16_chunk._ts_meta_max_3, compress_hyper_5_16_chunk._ts_meta_min_1, compress_hyper_5_16_chunk._ts_meta_max_1, compress_hyper_5_16_chunk._ts_meta_min_2, compress_hyper_5_16_chunk._ts_meta_max_2
-                     Index Cond: (compress_hyper_5_16_chunk.device_id = 1)
+               ->  Index Scan using compress_hyper_5_17_chunk_c_index_2 on _timescaledb_internal.compress_hyper_5_17_chunk (actual rows=1 loops=1)
+                     Output: compress_hyper_5_17_chunk."time", compress_hyper_5_17_chunk.device_id, compress_hyper_5_17_chunk.device_id_peer, compress_hyper_5_17_chunk.v0, compress_hyper_5_17_chunk.v1, compress_hyper_5_17_chunk.v2, compress_hyper_5_17_chunk.v3, compress_hyper_5_17_chunk._ts_meta_count, compress_hyper_5_17_chunk._ts_meta_sequence_num, compress_hyper_5_17_chunk._ts_meta_min_3, compress_hyper_5_17_chunk._ts_meta_max_3, compress_hyper_5_17_chunk._ts_meta_min_1, compress_hyper_5_17_chunk._ts_meta_max_1, compress_hyper_5_17_chunk._ts_meta_min_2, compress_hyper_5_17_chunk._ts_meta_max_2
+                     Index Cond: (compress_hyper_5_17_chunk.device_id = 1)
 (26 rows)
 
 -- globs should not plan IndexOnlyScans
@@ -1950,9 +1950,9 @@ ORDER BY device_id,
          ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_3_chunk (actual rows=504 loops=1)
                Output: _hyper_1_3_chunk."time", _hyper_1_3_chunk.device_id, _hyper_1_3_chunk.device_id_peer, _hyper_1_3_chunk.v0, _hyper_1_3_chunk.v1, _hyper_1_3_chunk.v2, _hyper_1_3_chunk.v3
                Bulk Decompression: true
-               ->  Index Scan using compress_hyper_5_16_chunk_c_index_2 on _timescaledb_internal.compress_hyper_5_16_chunk (actual rows=1 loops=1)
-                     Output: compress_hyper_5_16_chunk."time", compress_hyper_5_16_chunk.device_id, compress_hyper_5_16_chunk.device_id_peer, compress_hyper_5_16_chunk.v0, compress_hyper_5_16_chunk.v1, compress_hyper_5_16_chunk.v2, compress_hyper_5_16_chunk.v3, compress_hyper_5_16_chunk._ts_meta_count, compress_hyper_5_16_chunk._ts_meta_sequence_num, compress_hyper_5_16_chunk._ts_meta_min_3, compress_hyper_5_16_chunk._ts_meta_max_3, compress_hyper_5_16_chunk._ts_meta_min_1, compress_hyper_5_16_chunk._ts_meta_max_1, compress_hyper_5_16_chunk._ts_meta_min_2, compress_hyper_5_16_chunk._ts_meta_max_2
-                     Index Cond: (compress_hyper_5_16_chunk.device_id = 1)
+               ->  Index Scan using compress_hyper_5_17_chunk_c_index_2 on _timescaledb_internal.compress_hyper_5_17_chunk (actual rows=1 loops=1)
+                     Output: compress_hyper_5_17_chunk."time", compress_hyper_5_17_chunk.device_id, compress_hyper_5_17_chunk.device_id_peer, compress_hyper_5_17_chunk.v0, compress_hyper_5_17_chunk.v1, compress_hyper_5_17_chunk.v2, compress_hyper_5_17_chunk.v3, compress_hyper_5_17_chunk._ts_meta_count, compress_hyper_5_17_chunk._ts_meta_sequence_num, compress_hyper_5_17_chunk._ts_meta_min_3, compress_hyper_5_17_chunk._ts_meta_max_3, compress_hyper_5_17_chunk._ts_meta_min_1, compress_hyper_5_17_chunk._ts_meta_max_1, compress_hyper_5_17_chunk._ts_meta_min_2, compress_hyper_5_17_chunk._ts_meta_max_2
+                     Index Cond: (compress_hyper_5_17_chunk.device_id = 1)
 (26 rows)
 
 -- whole row reference should work
@@ -1987,9 +1987,9 @@ ORDER BY device_id,
          ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_3_chunk test_table_3 (actual rows=504 loops=1)
                Output: test_table_3.*, test_table_3.device_id, test_table_3."time"
                Bulk Decompression: true
-               ->  Index Scan using compress_hyper_5_16_chunk_c_index_2 on _timescaledb_internal.compress_hyper_5_16_chunk (actual rows=1 loops=1)
-                     Output: compress_hyper_5_16_chunk."time", compress_hyper_5_16_chunk.device_id, compress_hyper_5_16_chunk.device_id_peer, compress_hyper_5_16_chunk.v0, compress_hyper_5_16_chunk.v1, compress_hyper_5_16_chunk.v2, compress_hyper_5_16_chunk.v3, compress_hyper_5_16_chunk._ts_meta_count, compress_hyper_5_16_chunk._ts_meta_sequence_num, compress_hyper_5_16_chunk._ts_meta_min_3, compress_hyper_5_16_chunk._ts_meta_max_3, compress_hyper_5_16_chunk._ts_meta_min_1, compress_hyper_5_16_chunk._ts_meta_max_1, compress_hyper_5_16_chunk._ts_meta_min_2, compress_hyper_5_16_chunk._ts_meta_max_2
-                     Index Cond: (compress_hyper_5_16_chunk.device_id = 1)
+               ->  Index Scan using compress_hyper_5_17_chunk_c_index_2 on _timescaledb_internal.compress_hyper_5_17_chunk (actual rows=1 loops=1)
+                     Output: compress_hyper_5_17_chunk."time", compress_hyper_5_17_chunk.device_id, compress_hyper_5_17_chunk.device_id_peer, compress_hyper_5_17_chunk.v0, compress_hyper_5_17_chunk.v1, compress_hyper_5_17_chunk.v2, compress_hyper_5_17_chunk.v3, compress_hyper_5_17_chunk._ts_meta_count, compress_hyper_5_17_chunk._ts_meta_sequence_num, compress_hyper_5_17_chunk._ts_meta_min_3, compress_hyper_5_17_chunk._ts_meta_max_3, compress_hyper_5_17_chunk._ts_meta_min_1, compress_hyper_5_17_chunk._ts_meta_max_1, compress_hyper_5_17_chunk._ts_meta_min_2, compress_hyper_5_17_chunk._ts_meta_max_2
+                     Index Cond: (compress_hyper_5_17_chunk.device_id = 1)
 (26 rows)
 
 -- even when we select only a segmentby column, we still need count
@@ -2015,9 +2015,9 @@ ORDER BY device_id;
    ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_3_chunk (actual rows=504 loops=1)
          Output: _hyper_1_3_chunk.device_id
          Bulk Decompression: false
-         ->  Index Only Scan using compress_hyper_5_16_chunk_c_index_2 on _timescaledb_internal.compress_hyper_5_16_chunk (actual rows=1 loops=1)
-               Output: compress_hyper_5_16_chunk.device_id, compress_hyper_5_16_chunk._ts_meta_count
-               Index Cond: (compress_hyper_5_16_chunk.device_id = 1)
+         ->  Index Only Scan using compress_hyper_5_17_chunk_c_index_2 on _timescaledb_internal.compress_hyper_5_17_chunk (actual rows=1 loops=1)
+               Output: compress_hyper_5_17_chunk.device_id, compress_hyper_5_17_chunk._ts_meta_count
+               Index Cond: (compress_hyper_5_17_chunk.device_id = 1)
                Heap Fetches: 1
 (19 rows)
 
@@ -2041,9 +2041,9 @@ WHERE device_id = 1;
                Rows Removed by Filter: 2016
          ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_3_chunk (actual rows=504 loops=1)
                Bulk Decompression: false
-               ->  Index Only Scan using compress_hyper_5_16_chunk_c_index_2 on _timescaledb_internal.compress_hyper_5_16_chunk (actual rows=1 loops=1)
-                     Output: compress_hyper_5_16_chunk.device_id, compress_hyper_5_16_chunk._ts_meta_count
-                     Index Cond: (compress_hyper_5_16_chunk.device_id = 1)
+               ->  Index Only Scan using compress_hyper_5_17_chunk_c_index_2 on _timescaledb_internal.compress_hyper_5_17_chunk (actual rows=1 loops=1)
+                     Output: compress_hyper_5_17_chunk.device_id, compress_hyper_5_17_chunk._ts_meta_count
+                     Index Cond: (compress_hyper_5_17_chunk.device_id = 1)
                      Heap Fetches: 1
 (18 rows)
 
@@ -2069,8 +2069,8 @@ ORDER BY device_id;
    ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_3_chunk (actual rows=2520 loops=1)
          Output: _hyper_1_3_chunk.device_id
          Bulk Decompression: false
-         ->  Index Only Scan using compress_hyper_5_16_chunk_c_index_2 on _timescaledb_internal.compress_hyper_5_16_chunk (actual rows=5 loops=1)
-               Output: compress_hyper_5_16_chunk.device_id, compress_hyper_5_16_chunk._ts_meta_count
+         ->  Index Only Scan using compress_hyper_5_17_chunk_c_index_2 on _timescaledb_internal.compress_hyper_5_17_chunk (actual rows=5 loops=1)
+               Output: compress_hyper_5_17_chunk.device_id, compress_hyper_5_17_chunk._ts_meta_count
                Heap Fetches: 5
 (17 rows)
 
@@ -2102,9 +2102,9 @@ ORDER BY device_id_peer,
          ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_3_chunk (actual rows=0 loops=1)
                Output: _hyper_1_3_chunk."time", _hyper_1_3_chunk.device_id, _hyper_1_3_chunk.device_id_peer, _hyper_1_3_chunk.v0, _hyper_1_3_chunk.v1, _hyper_1_3_chunk.v2, _hyper_1_3_chunk.v3
                Bulk Decompression: true
-               ->  Index Scan using compress_hyper_5_16_chunk__compressed_hypertable_5_device_id_pe on _timescaledb_internal.compress_hyper_5_16_chunk (actual rows=0 loops=1)
-                     Output: compress_hyper_5_16_chunk."time", compress_hyper_5_16_chunk.device_id, compress_hyper_5_16_chunk.device_id_peer, compress_hyper_5_16_chunk.v0, compress_hyper_5_16_chunk.v1, compress_hyper_5_16_chunk.v2, compress_hyper_5_16_chunk.v3, compress_hyper_5_16_chunk._ts_meta_count, compress_hyper_5_16_chunk._ts_meta_sequence_num, compress_hyper_5_16_chunk._ts_meta_min_3, compress_hyper_5_16_chunk._ts_meta_max_3, compress_hyper_5_16_chunk._ts_meta_min_1, compress_hyper_5_16_chunk._ts_meta_max_1, compress_hyper_5_16_chunk._ts_meta_min_2, compress_hyper_5_16_chunk._ts_meta_max_2
-                     Index Cond: (compress_hyper_5_16_chunk.device_id_peer = 1)
+               ->  Index Scan using compress_hyper_5_17_chunk__compressed_hypertable_5_device_id_pe on _timescaledb_internal.compress_hyper_5_17_chunk (actual rows=0 loops=1)
+                     Output: compress_hyper_5_17_chunk."time", compress_hyper_5_17_chunk.device_id, compress_hyper_5_17_chunk.device_id_peer, compress_hyper_5_17_chunk.v0, compress_hyper_5_17_chunk.v1, compress_hyper_5_17_chunk.v2, compress_hyper_5_17_chunk.v3, compress_hyper_5_17_chunk._ts_meta_count, compress_hyper_5_17_chunk._ts_meta_sequence_num, compress_hyper_5_17_chunk._ts_meta_min_3, compress_hyper_5_17_chunk._ts_meta_max_3, compress_hyper_5_17_chunk._ts_meta_min_1, compress_hyper_5_17_chunk._ts_meta_max_1, compress_hyper_5_17_chunk._ts_meta_min_2, compress_hyper_5_17_chunk._ts_meta_max_2
+                     Index Cond: (compress_hyper_5_17_chunk.device_id_peer = 1)
 (21 rows)
 
 :PREFIX_VERBOSE
@@ -2128,9 +2128,9 @@ ORDER BY device_id_peer;
    ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_3_chunk (actual rows=0 loops=1)
          Output: _hyper_1_3_chunk.device_id_peer
          Bulk Decompression: false
-         ->  Index Scan using compress_hyper_5_16_chunk__compressed_hypertable_5_device_id_pe on _timescaledb_internal.compress_hyper_5_16_chunk (actual rows=0 loops=1)
-               Output: compress_hyper_5_16_chunk."time", compress_hyper_5_16_chunk.device_id, compress_hyper_5_16_chunk.device_id_peer, compress_hyper_5_16_chunk.v0, compress_hyper_5_16_chunk.v1, compress_hyper_5_16_chunk.v2, compress_hyper_5_16_chunk.v3, compress_hyper_5_16_chunk._ts_meta_count, compress_hyper_5_16_chunk._ts_meta_sequence_num, compress_hyper_5_16_chunk._ts_meta_min_3, compress_hyper_5_16_chunk._ts_meta_max_3, compress_hyper_5_16_chunk._ts_meta_min_1, compress_hyper_5_16_chunk._ts_meta_max_1, compress_hyper_5_16_chunk._ts_meta_min_2, compress_hyper_5_16_chunk._ts_meta_max_2
-               Index Cond: (compress_hyper_5_16_chunk.device_id_peer = 1)
+         ->  Index Scan using compress_hyper_5_17_chunk__compressed_hypertable_5_device_id_pe on _timescaledb_internal.compress_hyper_5_17_chunk (actual rows=0 loops=1)
+               Output: compress_hyper_5_17_chunk."time", compress_hyper_5_17_chunk.device_id, compress_hyper_5_17_chunk.device_id_peer, compress_hyper_5_17_chunk.v0, compress_hyper_5_17_chunk.v1, compress_hyper_5_17_chunk.v2, compress_hyper_5_17_chunk.v3, compress_hyper_5_17_chunk._ts_meta_count, compress_hyper_5_17_chunk._ts_meta_sequence_num, compress_hyper_5_17_chunk._ts_meta_min_3, compress_hyper_5_17_chunk._ts_meta_max_3, compress_hyper_5_17_chunk._ts_meta_min_1, compress_hyper_5_17_chunk._ts_meta_max_1, compress_hyper_5_17_chunk._ts_meta_min_2, compress_hyper_5_17_chunk._ts_meta_max_2
+               Index Cond: (compress_hyper_5_17_chunk.device_id_peer = 1)
 (17 rows)
 
 --ensure that we can get a nested loop
@@ -2158,9 +2158,9 @@ WHERE device_id_peer IN (
    ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_3_chunk (actual rows=0 loops=1)
          Output: _hyper_1_3_chunk.device_id_peer
          Bulk Decompression: false
-         ->  Seq Scan on _timescaledb_internal.compress_hyper_5_16_chunk (actual rows=0 loops=1)
-               Output: compress_hyper_5_16_chunk."time", compress_hyper_5_16_chunk.device_id, compress_hyper_5_16_chunk.device_id_peer, compress_hyper_5_16_chunk.v0, compress_hyper_5_16_chunk.v1, compress_hyper_5_16_chunk.v2, compress_hyper_5_16_chunk.v3, compress_hyper_5_16_chunk._ts_meta_count, compress_hyper_5_16_chunk._ts_meta_sequence_num, compress_hyper_5_16_chunk._ts_meta_min_3, compress_hyper_5_16_chunk._ts_meta_max_3, compress_hyper_5_16_chunk._ts_meta_min_1, compress_hyper_5_16_chunk._ts_meta_max_1, compress_hyper_5_16_chunk._ts_meta_min_2, compress_hyper_5_16_chunk._ts_meta_max_2
-               Filter: (compress_hyper_5_16_chunk.device_id_peer = 1)
+         ->  Seq Scan on _timescaledb_internal.compress_hyper_5_17_chunk (actual rows=0 loops=1)
+               Output: compress_hyper_5_17_chunk."time", compress_hyper_5_17_chunk.device_id, compress_hyper_5_17_chunk.device_id_peer, compress_hyper_5_17_chunk.v0, compress_hyper_5_17_chunk.v1, compress_hyper_5_17_chunk.v2, compress_hyper_5_17_chunk.v3, compress_hyper_5_17_chunk._ts_meta_count, compress_hyper_5_17_chunk._ts_meta_sequence_num, compress_hyper_5_17_chunk._ts_meta_min_3, compress_hyper_5_17_chunk._ts_meta_max_3, compress_hyper_5_17_chunk._ts_meta_min_1, compress_hyper_5_17_chunk._ts_meta_max_1, compress_hyper_5_17_chunk._ts_meta_min_2, compress_hyper_5_17_chunk._ts_meta_max_2
+               Filter: (compress_hyper_5_17_chunk.device_id_peer = 1)
                Rows Removed by Filter: 5
 (19 rows)
 
@@ -2197,9 +2197,9 @@ WHERE device_id_peer IN (
          ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_3_chunk (actual rows=0 loops=2)
                Output: _hyper_1_3_chunk.device_id_peer
                Bulk Decompression: false
-               ->  Index Scan using compress_hyper_5_16_chunk__compressed_hypertable_5_device_id_pe on _timescaledb_internal.compress_hyper_5_16_chunk (actual rows=0 loops=2)
-                     Output: compress_hyper_5_16_chunk."time", compress_hyper_5_16_chunk.device_id, compress_hyper_5_16_chunk.device_id_peer, compress_hyper_5_16_chunk.v0, compress_hyper_5_16_chunk.v1, compress_hyper_5_16_chunk.v2, compress_hyper_5_16_chunk.v3, compress_hyper_5_16_chunk._ts_meta_count, compress_hyper_5_16_chunk._ts_meta_sequence_num, compress_hyper_5_16_chunk._ts_meta_min_3, compress_hyper_5_16_chunk._ts_meta_max_3, compress_hyper_5_16_chunk._ts_meta_min_1, compress_hyper_5_16_chunk._ts_meta_max_1, compress_hyper_5_16_chunk._ts_meta_min_2, compress_hyper_5_16_chunk._ts_meta_max_2
-                     Index Cond: (compress_hyper_5_16_chunk.device_id_peer = "*VALUES*".column1)
+               ->  Index Scan using compress_hyper_5_17_chunk__compressed_hypertable_5_device_id_pe on _timescaledb_internal.compress_hyper_5_17_chunk (actual rows=0 loops=2)
+                     Output: compress_hyper_5_17_chunk."time", compress_hyper_5_17_chunk.device_id, compress_hyper_5_17_chunk.device_id_peer, compress_hyper_5_17_chunk.v0, compress_hyper_5_17_chunk.v1, compress_hyper_5_17_chunk.v2, compress_hyper_5_17_chunk.v3, compress_hyper_5_17_chunk._ts_meta_count, compress_hyper_5_17_chunk._ts_meta_sequence_num, compress_hyper_5_17_chunk._ts_meta_min_3, compress_hyper_5_17_chunk._ts_meta_max_3, compress_hyper_5_17_chunk._ts_meta_min_1, compress_hyper_5_17_chunk._ts_meta_max_1, compress_hyper_5_17_chunk._ts_meta_min_2, compress_hyper_5_17_chunk._ts_meta_max_2
+                     Index Cond: (compress_hyper_5_17_chunk.device_id_peer = "*VALUES*".column1)
 (27 rows)
 
 RESET enable_hashjoin;
@@ -2225,9 +2225,9 @@ WHERE device_id IN (
    ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_3_chunk (actual rows=504 loops=1)
          Output: _hyper_1_3_chunk.device_id_peer
          Bulk Decompression: false
-         ->  Seq Scan on _timescaledb_internal.compress_hyper_5_16_chunk (actual rows=1 loops=1)
-               Output: compress_hyper_5_16_chunk."time", compress_hyper_5_16_chunk.device_id, compress_hyper_5_16_chunk.device_id_peer, compress_hyper_5_16_chunk.v0, compress_hyper_5_16_chunk.v1, compress_hyper_5_16_chunk.v2, compress_hyper_5_16_chunk.v3, compress_hyper_5_16_chunk._ts_meta_count, compress_hyper_5_16_chunk._ts_meta_sequence_num, compress_hyper_5_16_chunk._ts_meta_min_3, compress_hyper_5_16_chunk._ts_meta_max_3, compress_hyper_5_16_chunk._ts_meta_min_1, compress_hyper_5_16_chunk._ts_meta_max_1, compress_hyper_5_16_chunk._ts_meta_min_2, compress_hyper_5_16_chunk._ts_meta_max_2
-               Filter: (compress_hyper_5_16_chunk.device_id = 1)
+         ->  Seq Scan on _timescaledb_internal.compress_hyper_5_17_chunk (actual rows=1 loops=1)
+               Output: compress_hyper_5_17_chunk."time", compress_hyper_5_17_chunk.device_id, compress_hyper_5_17_chunk.device_id_peer, compress_hyper_5_17_chunk.v0, compress_hyper_5_17_chunk.v1, compress_hyper_5_17_chunk.v2, compress_hyper_5_17_chunk.v3, compress_hyper_5_17_chunk._ts_meta_count, compress_hyper_5_17_chunk._ts_meta_sequence_num, compress_hyper_5_17_chunk._ts_meta_min_3, compress_hyper_5_17_chunk._ts_meta_max_3, compress_hyper_5_17_chunk._ts_meta_min_1, compress_hyper_5_17_chunk._ts_meta_max_1, compress_hyper_5_17_chunk._ts_meta_min_2, compress_hyper_5_17_chunk._ts_meta_max_2
+               Filter: (compress_hyper_5_17_chunk.device_id = 1)
                Rows Removed by Filter: 4
 (19 rows)
 
@@ -2264,9 +2264,9 @@ WHERE device_id IN (
          ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_3_chunk (actual rows=504 loops=2)
                Output: _hyper_1_3_chunk.device_id_peer, _hyper_1_3_chunk.device_id
                Bulk Decompression: false
-               ->  Index Scan using compress_hyper_5_16_chunk_c_index_2 on _timescaledb_internal.compress_hyper_5_16_chunk (actual rows=1 loops=2)
-                     Output: compress_hyper_5_16_chunk."time", compress_hyper_5_16_chunk.device_id, compress_hyper_5_16_chunk.device_id_peer, compress_hyper_5_16_chunk.v0, compress_hyper_5_16_chunk.v1, compress_hyper_5_16_chunk.v2, compress_hyper_5_16_chunk.v3, compress_hyper_5_16_chunk._ts_meta_count, compress_hyper_5_16_chunk._ts_meta_sequence_num, compress_hyper_5_16_chunk._ts_meta_min_3, compress_hyper_5_16_chunk._ts_meta_max_3, compress_hyper_5_16_chunk._ts_meta_min_1, compress_hyper_5_16_chunk._ts_meta_max_1, compress_hyper_5_16_chunk._ts_meta_min_2, compress_hyper_5_16_chunk._ts_meta_max_2
-                     Index Cond: (compress_hyper_5_16_chunk.device_id = "*VALUES*".column1)
+               ->  Index Scan using compress_hyper_5_17_chunk_c_index_2 on _timescaledb_internal.compress_hyper_5_17_chunk (actual rows=1 loops=2)
+                     Output: compress_hyper_5_17_chunk."time", compress_hyper_5_17_chunk.device_id, compress_hyper_5_17_chunk.device_id_peer, compress_hyper_5_17_chunk.v0, compress_hyper_5_17_chunk.v1, compress_hyper_5_17_chunk.v2, compress_hyper_5_17_chunk.v3, compress_hyper_5_17_chunk._ts_meta_count, compress_hyper_5_17_chunk._ts_meta_sequence_num, compress_hyper_5_17_chunk._ts_meta_min_3, compress_hyper_5_17_chunk._ts_meta_max_3, compress_hyper_5_17_chunk._ts_meta_min_1, compress_hyper_5_17_chunk._ts_meta_max_1, compress_hyper_5_17_chunk._ts_meta_min_2, compress_hyper_5_17_chunk._ts_meta_max_2
+                     Index Cond: (compress_hyper_5_17_chunk.device_id = "*VALUES*".column1)
 (27 rows)
 
 SET seq_page_cost = 100;
@@ -2291,8 +2291,8 @@ WHERE device_id IN (
                Output: _hyper_1_2_chunk.device_id_peer, _hyper_1_2_chunk.device_id
          ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_3_chunk
                Output: _hyper_1_3_chunk.device_id_peer, _hyper_1_3_chunk.device_id
-               ->  Index Scan using compress_hyper_5_16_chunk_c_index_2 on _timescaledb_internal.compress_hyper_5_16_chunk
-                     Output: compress_hyper_5_16_chunk."time", compress_hyper_5_16_chunk.device_id, compress_hyper_5_16_chunk.device_id_peer, compress_hyper_5_16_chunk.v0, compress_hyper_5_16_chunk.v1, compress_hyper_5_16_chunk.v2, compress_hyper_5_16_chunk.v3, compress_hyper_5_16_chunk._ts_meta_count, compress_hyper_5_16_chunk._ts_meta_sequence_num, compress_hyper_5_16_chunk._ts_meta_min_3, compress_hyper_5_16_chunk._ts_meta_max_3, compress_hyper_5_16_chunk._ts_meta_min_1, compress_hyper_5_16_chunk._ts_meta_max_1, compress_hyper_5_16_chunk._ts_meta_min_2, compress_hyper_5_16_chunk._ts_meta_max_2
+               ->  Index Scan using compress_hyper_5_17_chunk_c_index_2 on _timescaledb_internal.compress_hyper_5_17_chunk
+                     Output: compress_hyper_5_17_chunk."time", compress_hyper_5_17_chunk.device_id, compress_hyper_5_17_chunk.device_id_peer, compress_hyper_5_17_chunk.v0, compress_hyper_5_17_chunk.v1, compress_hyper_5_17_chunk.v2, compress_hyper_5_17_chunk.v3, compress_hyper_5_17_chunk._ts_meta_count, compress_hyper_5_17_chunk._ts_meta_sequence_num, compress_hyper_5_17_chunk._ts_meta_min_3, compress_hyper_5_17_chunk._ts_meta_max_3, compress_hyper_5_17_chunk._ts_meta_min_1, compress_hyper_5_17_chunk._ts_meta_max_1, compress_hyper_5_17_chunk._ts_meta_min_2, compress_hyper_5_17_chunk._ts_meta_max_2
    ->  Hash
          Output: "*VALUES*".column1
          ->  Values Scan on "*VALUES*"
@@ -2322,9 +2322,9 @@ WHERE device_id IN (
    ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_3_chunk (actual rows=504 loops=1)
          Output: _hyper_1_3_chunk.device_id_peer
          Bulk Decompression: false
-         ->  Seq Scan on _timescaledb_internal.compress_hyper_5_16_chunk (actual rows=1 loops=1)
-               Output: compress_hyper_5_16_chunk."time", compress_hyper_5_16_chunk.device_id, compress_hyper_5_16_chunk.device_id_peer, compress_hyper_5_16_chunk.v0, compress_hyper_5_16_chunk.v1, compress_hyper_5_16_chunk.v2, compress_hyper_5_16_chunk.v3, compress_hyper_5_16_chunk._ts_meta_count, compress_hyper_5_16_chunk._ts_meta_sequence_num, compress_hyper_5_16_chunk._ts_meta_min_3, compress_hyper_5_16_chunk._ts_meta_max_3, compress_hyper_5_16_chunk._ts_meta_min_1, compress_hyper_5_16_chunk._ts_meta_max_1, compress_hyper_5_16_chunk._ts_meta_min_2, compress_hyper_5_16_chunk._ts_meta_max_2
-               Filter: (compress_hyper_5_16_chunk.device_id = 1)
+         ->  Seq Scan on _timescaledb_internal.compress_hyper_5_17_chunk (actual rows=1 loops=1)
+               Output: compress_hyper_5_17_chunk."time", compress_hyper_5_17_chunk.device_id, compress_hyper_5_17_chunk.device_id_peer, compress_hyper_5_17_chunk.v0, compress_hyper_5_17_chunk.v1, compress_hyper_5_17_chunk.v2, compress_hyper_5_17_chunk.v3, compress_hyper_5_17_chunk._ts_meta_count, compress_hyper_5_17_chunk._ts_meta_sequence_num, compress_hyper_5_17_chunk._ts_meta_min_3, compress_hyper_5_17_chunk._ts_meta_max_3, compress_hyper_5_17_chunk._ts_meta_min_1, compress_hyper_5_17_chunk._ts_meta_max_1, compress_hyper_5_17_chunk._ts_meta_min_2, compress_hyper_5_17_chunk._ts_meta_max_2
+               Filter: (compress_hyper_5_17_chunk.device_id = 1)
                Rows Removed by Filter: 4
 (19 rows)
 
@@ -2360,9 +2360,9 @@ WHERE device_id IN (
          ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_3_chunk (actual rows=504 loops=2)
                Output: _hyper_1_3_chunk.device_id_peer, _hyper_1_3_chunk.device_id
                Bulk Decompression: false
-               ->  Index Scan using compress_hyper_5_16_chunk_c_index_2 on _timescaledb_internal.compress_hyper_5_16_chunk (actual rows=1 loops=2)
-                     Output: compress_hyper_5_16_chunk."time", compress_hyper_5_16_chunk.device_id, compress_hyper_5_16_chunk.device_id_peer, compress_hyper_5_16_chunk.v0, compress_hyper_5_16_chunk.v1, compress_hyper_5_16_chunk.v2, compress_hyper_5_16_chunk.v3, compress_hyper_5_16_chunk._ts_meta_count, compress_hyper_5_16_chunk._ts_meta_sequence_num, compress_hyper_5_16_chunk._ts_meta_min_3, compress_hyper_5_16_chunk._ts_meta_max_3, compress_hyper_5_16_chunk._ts_meta_min_1, compress_hyper_5_16_chunk._ts_meta_max_1, compress_hyper_5_16_chunk._ts_meta_min_2, compress_hyper_5_16_chunk._ts_meta_max_2
-                     Index Cond: (compress_hyper_5_16_chunk.device_id = "*VALUES*".column1)
+               ->  Index Scan using compress_hyper_5_17_chunk_c_index_2 on _timescaledb_internal.compress_hyper_5_17_chunk (actual rows=1 loops=2)
+                     Output: compress_hyper_5_17_chunk."time", compress_hyper_5_17_chunk.device_id, compress_hyper_5_17_chunk.device_id_peer, compress_hyper_5_17_chunk.v0, compress_hyper_5_17_chunk.v1, compress_hyper_5_17_chunk.v2, compress_hyper_5_17_chunk.v3, compress_hyper_5_17_chunk._ts_meta_count, compress_hyper_5_17_chunk._ts_meta_sequence_num, compress_hyper_5_17_chunk._ts_meta_min_3, compress_hyper_5_17_chunk._ts_meta_max_3, compress_hyper_5_17_chunk._ts_meta_min_1, compress_hyper_5_17_chunk._ts_meta_max_1, compress_hyper_5_17_chunk._ts_meta_min_2, compress_hyper_5_17_chunk._ts_meta_max_2
+                     Index Cond: (compress_hyper_5_17_chunk.device_id = "*VALUES*".column1)
 (27 rows)
 
 -- test view
@@ -2387,7 +2387,7 @@ LIMIT 10;
                Sort Key: _hyper_1_3_chunk."time" DESC
                Sort Method: top-N heapsort 
                ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk (actual rows=504 loops=1)
-                     ->  Seq Scan on compress_hyper_5_16_chunk (actual rows=1 loops=1)
+                     ->  Seq Scan on compress_hyper_5_17_chunk (actual rows=1 loops=1)
                            Filter: (device_id = 1)
                            Rows Removed by Filter: 4
          ->  Index Scan using _hyper_1_2_chunk_metrics_time_idx on _hyper_1_2_chunk (never executed)
@@ -2431,7 +2431,7 @@ FROM :TEST_TABLE m1
                      ->  Sort (never executed)
                            Sort Key: m1_3."time"
                            ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk m1_3 (never executed)
-                                 ->  Seq Scan on compress_hyper_5_16_chunk (never executed)
+                                 ->  Seq Scan on compress_hyper_5_17_chunk (never executed)
                ->  Materialize (actual rows=51 loops=1)
                      ->  Custom Scan (ChunkAppend) on metrics m2 (actual rows=11 loops=1)
                            Order: m2."time"
@@ -2444,7 +2444,7 @@ FROM :TEST_TABLE m1
                            ->  Sort (never executed)
                                  Sort Key: m2_3."time"
                                  ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk m2_3 (never executed)
-                                       ->  Seq Scan on compress_hyper_5_16_chunk compress_hyper_5_16_chunk_1 (never executed)
+                                       ->  Seq Scan on compress_hyper_5_17_chunk compress_hyper_5_17_chunk_1 (never executed)
 (34 rows)
 
 :PREFIX
@@ -2481,7 +2481,7 @@ FROM :TEST_TABLE m1
                            ->  Sort (never executed)
                                  Sort Key: m1_3."time"
                                  ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk m1_3 (never executed)
-                                       ->  Seq Scan on compress_hyper_5_16_chunk (never executed)
+                                       ->  Seq Scan on compress_hyper_5_17_chunk (never executed)
                      ->  Materialize (actual rows=51 loops=1)
                            ->  Custom Scan (ChunkAppend) on metrics m2 (actual rows=11 loops=1)
                                  Order: m2."time"
@@ -2494,7 +2494,7 @@ FROM :TEST_TABLE m1
                                  ->  Sort (never executed)
                                        Sort Key: m2_3."time"
                                        ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk m2_3 (never executed)
-                                             ->  Seq Scan on compress_hyper_5_16_chunk compress_hyper_5_16_chunk_1 (never executed)
+                                             ->  Seq Scan on compress_hyper_5_17_chunk compress_hyper_5_17_chunk_1 (never executed)
                ->  Materialize (actual rows=11 loops=1)
                      ->  Merge Append (actual rows=3 loops=1)
                            Sort Key: m3_1."time"
@@ -2512,7 +2512,7 @@ FROM :TEST_TABLE m1
                                  Sort Key: m3_3."time"
                                  Sort Method: quicksort 
                                  ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk m3_3 (actual rows=504 loops=1)
-                                       ->  Seq Scan on compress_hyper_5_16_chunk compress_hyper_5_16_chunk_2 (actual rows=1 loops=1)
+                                       ->  Seq Scan on compress_hyper_5_17_chunk compress_hyper_5_17_chunk_2 (actual rows=1 loops=1)
                                              Filter: (device_id = 3)
                                              Rows Removed by Filter: 4
 (56 rows)
@@ -2547,7 +2547,7 @@ FROM :TEST_TABLE m1
                ->  Sort (never executed)
                      Sort Key: m1_3."time"
                      ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk m1_3 (never executed)
-                           ->  Seq Scan on compress_hyper_5_16_chunk (never executed)
+                           ->  Seq Scan on compress_hyper_5_17_chunk (never executed)
                                  Filter: (device_id = 1)
          ->  Materialize (actual rows=100 loops=1)
                ->  Custom Scan (ChunkAppend) on metrics m2 (actual rows=100 loops=1)
@@ -2564,7 +2564,7 @@ FROM :TEST_TABLE m1
                      ->  Sort (never executed)
                            Sort Key: m2_3."time"
                            ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk m2_3 (never executed)
-                                 ->  Seq Scan on compress_hyper_5_16_chunk compress_hyper_5_16_chunk_1 (never executed)
+                                 ->  Seq Scan on compress_hyper_5_17_chunk compress_hyper_5_17_chunk_1 (never executed)
                                        Filter: (device_id = 2)
 (36 rows)
 
@@ -2598,7 +2598,7 @@ FROM metrics m1
                ->  Sort (never executed)
                      Sort Key: m1_3."time"
                      ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk m1_3 (never executed)
-                           ->  Seq Scan on compress_hyper_5_16_chunk (never executed)
+                           ->  Seq Scan on compress_hyper_5_17_chunk (never executed)
                                  Filter: (device_id = 1)
          ->  Materialize (actual rows=100 loops=1)
                ->  Custom Scan (ChunkAppend) on metrics_space m2 (actual rows=100 loops=1)
@@ -2607,7 +2607,7 @@ FROM metrics m1
                            Sort Key: m2_1."time"
                            Sort Method: quicksort 
                            ->  Custom Scan (DecompressChunk) on _hyper_2_5_chunk m2_1 (actual rows=360 loops=1)
-                                 ->  Seq Scan on compress_hyper_6_18_chunk (actual rows=1 loops=1)
+                                 ->  Seq Scan on compress_hyper_6_19_chunk (actual rows=1 loops=1)
                                        Filter: (device_id = 2)
                                        Rows Removed by Filter: 2
                      ->  Index Scan Backward using _hyper_2_8_chunk_metrics_space_device_id_time_idx on _hyper_2_8_chunk m2_2 (never executed)
@@ -2615,7 +2615,7 @@ FROM metrics m1
                      ->  Sort (never executed)
                            Sort Key: m2_3."time"
                            ->  Custom Scan (DecompressChunk) on _hyper_2_11_chunk m2_3 (never executed)
-                                 ->  Seq Scan on compress_hyper_6_21_chunk (never executed)
+                                 ->  Seq Scan on compress_hyper_6_25_chunk (never executed)
                                        Filter: (device_id = 2)
 (36 rows)
 
@@ -2650,7 +2650,7 @@ LIMIT 10;
                      ->  Sort (never executed)
                            Sort Key: m1_3."time"
                            ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk m1_3 (never executed)
-                                 ->  Seq Scan on compress_hyper_5_16_chunk (never executed)
+                                 ->  Seq Scan on compress_hyper_5_17_chunk (never executed)
                ->  Materialize (actual rows=51 loops=1)
                      ->  Custom Scan (ChunkAppend) on metrics m2 (actual rows=11 loops=1)
                            Order: m2."time"
@@ -2663,7 +2663,7 @@ LIMIT 10;
                            ->  Sort (never executed)
                                  Sort Key: m2_3."time"
                                  ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk m2_3 (never executed)
-                                       ->  Seq Scan on compress_hyper_5_16_chunk compress_hyper_5_16_chunk_1 (never executed)
+                                       ->  Seq Scan on compress_hyper_5_17_chunk compress_hyper_5_17_chunk_1 (never executed)
 (34 rows)
 
 :PREFIX
@@ -2699,7 +2699,7 @@ LIMIT 100;
                      ->  Sort (never executed)
                            Sort Key: m1_3."time"
                            ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk m1_3 (never executed)
-                                 ->  Seq Scan on compress_hyper_5_16_chunk (never executed)
+                                 ->  Seq Scan on compress_hyper_5_17_chunk (never executed)
                ->  Materialize (actual rows=102 loops=1)
                      ->  Custom Scan (ChunkAppend) on metrics m2 (actual rows=22 loops=1)
                            Order: m2."time"
@@ -2715,7 +2715,7 @@ LIMIT 100;
                            ->  Sort (never executed)
                                  Sort Key: m2_3."time"
                                  ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk m2_3 (never executed)
-                                       ->  Seq Scan on compress_hyper_5_16_chunk compress_hyper_5_16_chunk_1 (never executed)
+                                       ->  Seq Scan on compress_hyper_5_17_chunk compress_hyper_5_17_chunk_1 (never executed)
                                              Filter: (device_id = 2)
 (38 rows)
 
@@ -2752,7 +2752,7 @@ LIMIT 100;
                      ->  Sort (never executed)
                            Sort Key: m1_3."time"
                            ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk m1_3 (never executed)
-                                 ->  Seq Scan on compress_hyper_5_16_chunk (never executed)
+                                 ->  Seq Scan on compress_hyper_5_17_chunk (never executed)
                ->  Materialize (actual rows=102 loops=1)
                      ->  Custom Scan (ChunkAppend) on metrics_space m2 (actual rows=22 loops=1)
                            Order: m2."time"
@@ -2765,7 +2765,7 @@ LIMIT 100;
                                              Sort Key: m2_1."time"
                                              Sort Method: quicksort 
                                              ->  Custom Scan (DecompressChunk) on _hyper_2_4_chunk m2_1 (actual rows=0 loops=1)
-                                                   ->  Seq Scan on compress_hyper_6_17_chunk (actual rows=0 loops=1)
+                                                   ->  Seq Scan on compress_hyper_6_18_chunk (actual rows=0 loops=1)
                                                          Filter: (device_id = 2)
                                                          Rows Removed by Filter: 1
                                  ->  Sort (actual rows=22 loops=1)
@@ -2775,7 +2775,7 @@ LIMIT 100;
                                              Sort Key: m2_2."time"
                                              Sort Method: quicksort 
                                              ->  Custom Scan (DecompressChunk) on _hyper_2_5_chunk m2_2 (actual rows=360 loops=1)
-                                                   ->  Seq Scan on compress_hyper_6_18_chunk (actual rows=1 loops=1)
+                                                   ->  Seq Scan on compress_hyper_6_19_chunk (actual rows=1 loops=1)
                                                          Filter: (device_id = 2)
                                                          Rows Removed by Filter: 2
                                  ->  Sort (actual rows=0 loops=1)
@@ -2785,7 +2785,7 @@ LIMIT 100;
                                              Sort Key: m2_3."time"
                                              Sort Method: quicksort 
                                              ->  Custom Scan (DecompressChunk) on _hyper_2_6_chunk m2_3 (actual rows=0 loops=1)
-                                                   ->  Seq Scan on compress_hyper_6_19_chunk (actual rows=0 loops=1)
+                                                   ->  Seq Scan on compress_hyper_6_20_chunk (actual rows=0 loops=1)
                                                          Filter: (device_id = 2)
                                                          Rows Removed by Filter: 1
                            ->  Merge Append (never executed)
@@ -2803,14 +2803,14 @@ LIMIT 100;
                                        ->  Sort (never executed)
                                              Sort Key: m2_7."time"
                                              ->  Custom Scan (DecompressChunk) on _hyper_2_10_chunk m2_7 (never executed)
-                                                   ->  Seq Scan on compress_hyper_6_20_chunk (never executed)
+                                                   ->  Seq Scan on compress_hyper_6_24_chunk (never executed)
                                                          Filter: (device_id = 2)
                                  ->  Sort (never executed)
                                        Sort Key: m2_8."time"
                                        ->  Sort (never executed)
                                              Sort Key: m2_8."time"
                                              ->  Custom Scan (DecompressChunk) on _hyper_2_11_chunk m2_8 (never executed)
-                                                   ->  Seq Scan on compress_hyper_6_21_chunk (never executed)
+                                                   ->  Seq Scan on compress_hyper_6_25_chunk (never executed)
                                                          Filter: (device_id = 2)
                                  ->  Index Scan Backward using _hyper_2_12_chunk_metrics_space_time_idx on _hyper_2_12_chunk m2_9 (never executed)
                                        Filter: (device_id = 2)
@@ -2847,7 +2847,7 @@ LIMIT 20;
                      ->  Sort (never executed)
                            Sort Key: m1_3."time"
                            ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk m1_3 (never executed)
-                                 ->  Seq Scan on compress_hyper_5_16_chunk (never executed)
+                                 ->  Seq Scan on compress_hyper_5_17_chunk (never executed)
                ->  Materialize (actual rows=26 loops=1)
                      ->  Custom Scan (ChunkAppend) on metrics m2 (actual rows=6 loops=1)
                            Order: m2."time"
@@ -2860,7 +2860,7 @@ LIMIT 20;
                            ->  Sort (never executed)
                                  Sort Key: m2_3."time"
                                  ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk m2_3 (never executed)
-                                       ->  Seq Scan on compress_hyper_5_16_chunk compress_hyper_5_16_chunk_1 (never executed)
+                                       ->  Seq Scan on compress_hyper_5_17_chunk compress_hyper_5_17_chunk_1 (never executed)
 (32 rows)
 
 -- test self-join with sub-query
@@ -2896,7 +2896,7 @@ LIMIT 10;
                      ->  Sort (never executed)
                            Sort Key: m1_3."time"
                            ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk m1_3 (never executed)
-                                 ->  Seq Scan on compress_hyper_5_16_chunk (never executed)
+                                 ->  Seq Scan on compress_hyper_5_17_chunk (never executed)
                ->  Materialize (actual rows=26 loops=1)
                      ->  Custom Scan (ChunkAppend) on metrics m2 (actual rows=6 loops=1)
                            Order: m2."time"
@@ -2909,7 +2909,7 @@ LIMIT 10;
                            ->  Sort (never executed)
                                  Sort Key: m2_3."time"
                                  ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk m2_3 (never executed)
-                                       ->  Seq Scan on compress_hyper_5_16_chunk compress_hyper_5_16_chunk_1 (never executed)
+                                       ->  Seq Scan on compress_hyper_5_17_chunk compress_hyper_5_17_chunk_1 (never executed)
 (32 rows)
 
 :PREFIX
@@ -2938,7 +2938,7 @@ FROM generate_series('2000-01-01'::timestamptz, '2000-02-01'::timestamptz, '1d':
                ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk m1_3 (actual rows=1 loops=7)
                      Filter: ("time" = g."time")
                      Rows Removed by Filter: 240
-                     ->  Seq Scan on compress_hyper_5_16_chunk (actual rows=1 loops=7)
+                     ->  Seq Scan on compress_hyper_5_17_chunk (actual rows=1 loops=7)
                            Filter: ((_ts_meta_min_3 <= g."time") AND (_ts_meta_max_3 >= g."time"))
 (18 rows)
 
@@ -2971,7 +2971,7 @@ FROM generate_series('2000-01-01'::timestamptz, '2000-02-01'::timestamptz, '1d':
                ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk m1_3 (actual rows=1 loops=7)
                      Filter: ("time" = g."time")
                      Rows Removed by Filter: 240
-                     ->  Seq Scan on compress_hyper_5_16_chunk (actual rows=1 loops=7)
+                     ->  Seq Scan on compress_hyper_5_17_chunk (actual rows=1 loops=7)
                            Filter: ((_ts_meta_min_3 <= g."time") AND (_ts_meta_max_3 >= g."time") AND (device_id = 1))
 (18 rows)
 
@@ -2996,7 +2996,7 @@ FROM generate_series('2000-01-01'::timestamptz, '2000-02-01'::timestamptz, '1d':
                ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk m1_3 (actual rows=1 loops=7)
                      Filter: ("time" = g."time")
                      Rows Removed by Filter: 240
-                     ->  Seq Scan on compress_hyper_5_16_chunk (actual rows=1 loops=7)
+                     ->  Seq Scan on compress_hyper_5_17_chunk (actual rows=1 loops=7)
                            Filter: ((_ts_meta_min_3 <= g."time") AND (_ts_meta_max_3 >= g."time") AND (device_id = 2))
                            Rows Removed by Filter: 1
 (21 rows)
@@ -3162,18 +3162,18 @@ WHERE metrics.time > metrics_space.time
  Nested Loop (actual rows=0 loops=1)
    ->  Append (actual rows=6840 loops=1)
          ->  Custom Scan (DecompressChunk) on _hyper_2_4_chunk (actual rows=360 loops=1)
-               ->  Index Scan using compress_hyper_6_17_chunk_c_space_index_2 on compress_hyper_6_17_chunk (actual rows=1 loops=1)
+               ->  Index Scan using compress_hyper_6_18_chunk_c_space_index_2 on compress_hyper_6_18_chunk (actual rows=1 loops=1)
          ->  Custom Scan (DecompressChunk) on _hyper_2_5_chunk (actual rows=1080 loops=1)
-               ->  Index Scan using compress_hyper_6_18_chunk_c_space_index_2 on compress_hyper_6_18_chunk (actual rows=3 loops=1)
+               ->  Index Scan using compress_hyper_6_19_chunk_c_space_index_2 on compress_hyper_6_19_chunk (actual rows=3 loops=1)
          ->  Custom Scan (DecompressChunk) on _hyper_2_6_chunk (actual rows=360 loops=1)
-               ->  Index Scan using compress_hyper_6_19_chunk_c_space_index_2 on compress_hyper_6_19_chunk (actual rows=1 loops=1)
+               ->  Index Scan using compress_hyper_6_20_chunk_c_space_index_2 on compress_hyper_6_20_chunk (actual rows=1 loops=1)
          ->  Index Scan Backward using _hyper_2_7_chunk_metrics_space_device_id_device_id_peer_v0_v1_2 on _hyper_2_7_chunk (actual rows=504 loops=1)
          ->  Index Scan Backward using _hyper_2_8_chunk_metrics_space_device_id_device_id_peer_v0_v1_2 on _hyper_2_8_chunk (actual rows=1512 loops=1)
          ->  Index Scan Backward using _hyper_2_9_chunk_metrics_space_device_id_device_id_peer_v0_v1_2 on _hyper_2_9_chunk (actual rows=504 loops=1)
          ->  Custom Scan (DecompressChunk) on _hyper_2_10_chunk (actual rows=504 loops=1)
-               ->  Index Scan using compress_hyper_6_20_chunk_c_space_index_2 on compress_hyper_6_20_chunk (actual rows=1 loops=1)
+               ->  Index Scan using compress_hyper_6_24_chunk_c_space_index_2 on compress_hyper_6_24_chunk (actual rows=1 loops=1)
          ->  Custom Scan (DecompressChunk) on _hyper_2_11_chunk (actual rows=1512 loops=1)
-               ->  Index Scan using compress_hyper_6_21_chunk_c_space_index_2 on compress_hyper_6_21_chunk (actual rows=3 loops=1)
+               ->  Index Scan using compress_hyper_6_25_chunk_c_space_index_2 on compress_hyper_6_25_chunk (actual rows=3 loops=1)
          ->  Index Scan Backward using _hyper_2_12_chunk_metrics_space_device_id_device_id_peer_v0_v_2 on _hyper_2_12_chunk (actual rows=504 loops=1)
    ->  Append (actual rows=0 loops=6840)
          ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk (actual rows=0 loops=6840)
@@ -3187,7 +3187,7 @@ WHERE metrics.time > metrics_space.time
          ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk (actual rows=0 loops=6840)
                Filter: (("time" > _hyper_2_4_chunk."time") AND ("time" < _hyper_2_4_chunk."time"))
                Rows Removed by Filter: 504
-               ->  Index Scan using compress_hyper_5_16_chunk_c_index_2 on compress_hyper_5_16_chunk (actual rows=1 loops=6840)
+               ->  Index Scan using compress_hyper_5_17_chunk_c_index_2 on compress_hyper_5_17_chunk (actual rows=1 loops=6840)
                      Index Cond: (device_id = _hyper_2_4_chunk.device_id)
 (30 rows)
 
@@ -3225,9 +3225,9 @@ LIMIT 5;
                ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_4_chunk (actual rows=360 loops=1)
                      Output: _hyper_2_4_chunk."time", _hyper_2_4_chunk.device_id, _hyper_2_4_chunk.device_id_peer, _hyper_2_4_chunk.v0, _hyper_2_4_chunk.v1, _hyper_2_4_chunk.v2, _hyper_2_4_chunk.v3
                      Bulk Decompression: true
-                     ->  Seq Scan on _timescaledb_internal.compress_hyper_6_17_chunk (actual rows=1 loops=1)
-                           Output: compress_hyper_6_17_chunk."time", compress_hyper_6_17_chunk.device_id, compress_hyper_6_17_chunk.device_id_peer, compress_hyper_6_17_chunk.v0, compress_hyper_6_17_chunk.v1, compress_hyper_6_17_chunk.v2, compress_hyper_6_17_chunk.v3, compress_hyper_6_17_chunk._ts_meta_count, compress_hyper_6_17_chunk._ts_meta_sequence_num, compress_hyper_6_17_chunk._ts_meta_min_3, compress_hyper_6_17_chunk._ts_meta_max_3, compress_hyper_6_17_chunk._ts_meta_min_1, compress_hyper_6_17_chunk._ts_meta_max_1, compress_hyper_6_17_chunk._ts_meta_min_2, compress_hyper_6_17_chunk._ts_meta_max_2
-                           Filter: (compress_hyper_6_17_chunk.device_id = 1)
+                     ->  Seq Scan on _timescaledb_internal.compress_hyper_6_18_chunk (actual rows=1 loops=1)
+                           Output: compress_hyper_6_18_chunk."time", compress_hyper_6_18_chunk.device_id, compress_hyper_6_18_chunk.device_id_peer, compress_hyper_6_18_chunk.v0, compress_hyper_6_18_chunk.v1, compress_hyper_6_18_chunk.v2, compress_hyper_6_18_chunk.v3, compress_hyper_6_18_chunk._ts_meta_count, compress_hyper_6_18_chunk._ts_meta_sequence_num, compress_hyper_6_18_chunk._ts_meta_min_3, compress_hyper_6_18_chunk._ts_meta_max_3, compress_hyper_6_18_chunk._ts_meta_min_1, compress_hyper_6_18_chunk._ts_meta_max_1, compress_hyper_6_18_chunk._ts_meta_min_2, compress_hyper_6_18_chunk._ts_meta_max_2
+                           Filter: (compress_hyper_6_18_chunk.device_id = 1)
          ->  Index Scan Backward using _hyper_2_7_chunk_metrics_space_time_idx on _timescaledb_internal._hyper_2_7_chunk (never executed)
                Output: _hyper_2_7_chunk."time", _hyper_2_7_chunk.device_id, _hyper_2_7_chunk.device_id_peer, _hyper_2_7_chunk.v0, _hyper_2_7_chunk.v1, _hyper_2_7_chunk.v2, _hyper_2_7_chunk.v3
                Filter: (_hyper_2_7_chunk.device_id = 1)
@@ -3237,9 +3237,9 @@ LIMIT 5;
                ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_10_chunk (never executed)
                      Output: _hyper_2_10_chunk."time", _hyper_2_10_chunk.device_id, _hyper_2_10_chunk.device_id_peer, _hyper_2_10_chunk.v0, _hyper_2_10_chunk.v1, _hyper_2_10_chunk.v2, _hyper_2_10_chunk.v3
                      Bulk Decompression: true
-                     ->  Seq Scan on _timescaledb_internal.compress_hyper_6_20_chunk (never executed)
-                           Output: compress_hyper_6_20_chunk."time", compress_hyper_6_20_chunk.device_id, compress_hyper_6_20_chunk.device_id_peer, compress_hyper_6_20_chunk.v0, compress_hyper_6_20_chunk.v1, compress_hyper_6_20_chunk.v2, compress_hyper_6_20_chunk.v3, compress_hyper_6_20_chunk._ts_meta_count, compress_hyper_6_20_chunk._ts_meta_sequence_num, compress_hyper_6_20_chunk._ts_meta_min_3, compress_hyper_6_20_chunk._ts_meta_max_3, compress_hyper_6_20_chunk._ts_meta_min_1, compress_hyper_6_20_chunk._ts_meta_max_1, compress_hyper_6_20_chunk._ts_meta_min_2, compress_hyper_6_20_chunk._ts_meta_max_2
-                           Filter: (compress_hyper_6_20_chunk.device_id = 1)
+                     ->  Seq Scan on _timescaledb_internal.compress_hyper_6_24_chunk (never executed)
+                           Output: compress_hyper_6_24_chunk."time", compress_hyper_6_24_chunk.device_id, compress_hyper_6_24_chunk.device_id_peer, compress_hyper_6_24_chunk.v0, compress_hyper_6_24_chunk.v1, compress_hyper_6_24_chunk.v2, compress_hyper_6_24_chunk.v3, compress_hyper_6_24_chunk._ts_meta_count, compress_hyper_6_24_chunk._ts_meta_sequence_num, compress_hyper_6_24_chunk._ts_meta_min_3, compress_hyper_6_24_chunk._ts_meta_max_3, compress_hyper_6_24_chunk._ts_meta_min_1, compress_hyper_6_24_chunk._ts_meta_max_1, compress_hyper_6_24_chunk._ts_meta_min_2, compress_hyper_6_24_chunk._ts_meta_max_2
+                           Filter: (compress_hyper_6_24_chunk.device_id = 1)
 (29 rows)
 
 -- test RECORD by itself
@@ -3256,7 +3256,7 @@ ORDER BY time;
          Sort Key: _hyper_2_4_chunk."time"
          Sort Method: quicksort 
          ->  Custom Scan (DecompressChunk) on _hyper_2_4_chunk (actual rows=360 loops=1)
-               ->  Seq Scan on compress_hyper_6_17_chunk (actual rows=1 loops=1)
+               ->  Seq Scan on compress_hyper_6_18_chunk (actual rows=1 loops=1)
                      Filter: (device_id = 1)
    ->  Index Scan Backward using _hyper_2_7_chunk_metrics_space_time_idx on _hyper_2_7_chunk (actual rows=504 loops=1)
          Filter: (device_id = 1)
@@ -3264,7 +3264,7 @@ ORDER BY time;
          Sort Key: _hyper_2_10_chunk."time"
          Sort Method: quicksort 
          ->  Custom Scan (DecompressChunk) on _hyper_2_10_chunk (actual rows=504 loops=1)
-               ->  Seq Scan on compress_hyper_6_20_chunk (actual rows=1 loops=1)
+               ->  Seq Scan on compress_hyper_6_24_chunk (actual rows=1 loops=1)
                      Filter: (device_id = 1)
 (16 rows)
 
@@ -3298,7 +3298,7 @@ ORDER BY time,
                                  Sort Key: _hyper_2_4_chunk."time"
                                  Sort Method: quicksort 
                                  ->  Custom Scan (DecompressChunk) on _hyper_2_4_chunk (actual rows=360 loops=1)
-                                       ->  Seq Scan on compress_hyper_6_17_chunk (actual rows=1 loops=1)
+                                       ->  Seq Scan on compress_hyper_6_18_chunk (actual rows=1 loops=1)
                                              Filter: (device_id = ANY ('{1,2}'::integer[]))
                      ->  Sort (actual rows=360 loops=1)
                            Sort Key: _hyper_2_5_chunk."time"
@@ -3307,7 +3307,7 @@ ORDER BY time,
                                  Sort Key: _hyper_2_5_chunk."time"
                                  Sort Method: quicksort 
                                  ->  Custom Scan (DecompressChunk) on _hyper_2_5_chunk (actual rows=360 loops=1)
-                                       ->  Seq Scan on compress_hyper_6_18_chunk (actual rows=1 loops=1)
+                                       ->  Seq Scan on compress_hyper_6_19_chunk (actual rows=1 loops=1)
                                              Filter: (device_id = ANY ('{1,2}'::integer[]))
                                              Rows Removed by Filter: 2
                ->  Merge Append (actual rows=1008 loops=1)
@@ -3326,7 +3326,7 @@ ORDER BY time,
                                  Sort Key: _hyper_2_10_chunk."time"
                                  Sort Method: quicksort 
                                  ->  Custom Scan (DecompressChunk) on _hyper_2_10_chunk (actual rows=504 loops=1)
-                                       ->  Seq Scan on compress_hyper_6_20_chunk (actual rows=1 loops=1)
+                                       ->  Seq Scan on compress_hyper_6_24_chunk (actual rows=1 loops=1)
                                              Filter: (device_id = ANY ('{1,2}'::integer[]))
                      ->  Sort (actual rows=504 loops=1)
                            Sort Key: _hyper_2_11_chunk."time"
@@ -3335,7 +3335,7 @@ ORDER BY time,
                                  Sort Key: _hyper_2_11_chunk."time"
                                  Sort Method: quicksort 
                                  ->  Custom Scan (DecompressChunk) on _hyper_2_11_chunk (actual rows=504 loops=1)
-                                       ->  Seq Scan on compress_hyper_6_21_chunk (actual rows=1 loops=1)
+                                       ->  Seq Scan on compress_hyper_6_25_chunk (actual rows=1 loops=1)
                                              Filter: (device_id = ANY ('{1,2}'::integer[]))
                                              Rows Removed by Filter: 2
 (56 rows)
@@ -3348,18 +3348,18 @@ FROM :TEST_TABLE;
 -------------------------------------------------------------------------------------
  Append (actual rows=6840 loops=1)
    ->  Custom Scan (DecompressChunk) on _hyper_2_4_chunk (actual rows=360 loops=1)
-         ->  Seq Scan on compress_hyper_6_17_chunk (actual rows=1 loops=1)
+         ->  Seq Scan on compress_hyper_6_18_chunk (actual rows=1 loops=1)
    ->  Custom Scan (DecompressChunk) on _hyper_2_5_chunk (actual rows=1080 loops=1)
-         ->  Seq Scan on compress_hyper_6_18_chunk (actual rows=3 loops=1)
+         ->  Seq Scan on compress_hyper_6_19_chunk (actual rows=3 loops=1)
    ->  Custom Scan (DecompressChunk) on _hyper_2_6_chunk (actual rows=360 loops=1)
-         ->  Seq Scan on compress_hyper_6_19_chunk (actual rows=1 loops=1)
+         ->  Seq Scan on compress_hyper_6_20_chunk (actual rows=1 loops=1)
    ->  Seq Scan on _hyper_2_7_chunk (actual rows=504 loops=1)
    ->  Seq Scan on _hyper_2_8_chunk (actual rows=1512 loops=1)
    ->  Seq Scan on _hyper_2_9_chunk (actual rows=504 loops=1)
    ->  Custom Scan (DecompressChunk) on _hyper_2_10_chunk (actual rows=504 loops=1)
-         ->  Seq Scan on compress_hyper_6_20_chunk (actual rows=1 loops=1)
+         ->  Seq Scan on compress_hyper_6_24_chunk (actual rows=1 loops=1)
    ->  Custom Scan (DecompressChunk) on _hyper_2_11_chunk (actual rows=1512 loops=1)
-         ->  Seq Scan on compress_hyper_6_21_chunk (actual rows=3 loops=1)
+         ->  Seq Scan on compress_hyper_6_25_chunk (actual rows=3 loops=1)
    ->  Seq Scan on _hyper_2_12_chunk (actual rows=504 loops=1)
 (15 rows)
 
@@ -3372,15 +3372,15 @@ WHERE device_id < 0;
 -------------------------------------------------------------------------------------------------------------------------------------
  Append (actual rows=0 loops=1)
    ->  Custom Scan (DecompressChunk) on _hyper_2_4_chunk (actual rows=0 loops=1)
-         ->  Seq Scan on compress_hyper_6_17_chunk (actual rows=0 loops=1)
+         ->  Seq Scan on compress_hyper_6_18_chunk (actual rows=0 loops=1)
                Filter: (device_id < 0)
                Rows Removed by Filter: 1
    ->  Custom Scan (DecompressChunk) on _hyper_2_5_chunk (actual rows=0 loops=1)
-         ->  Seq Scan on compress_hyper_6_18_chunk (actual rows=0 loops=1)
+         ->  Seq Scan on compress_hyper_6_19_chunk (actual rows=0 loops=1)
                Filter: (device_id < 0)
                Rows Removed by Filter: 3
    ->  Custom Scan (DecompressChunk) on _hyper_2_6_chunk (actual rows=0 loops=1)
-         ->  Seq Scan on compress_hyper_6_19_chunk (actual rows=0 loops=1)
+         ->  Seq Scan on compress_hyper_6_20_chunk (actual rows=0 loops=1)
                Filter: (device_id < 0)
                Rows Removed by Filter: 1
    ->  Index Scan using _hyper_2_7_chunk_metrics_space_device_id_device_id_peer_v0_v1_2 on _hyper_2_7_chunk (actual rows=0 loops=1)
@@ -3390,11 +3390,11 @@ WHERE device_id < 0;
    ->  Index Scan using _hyper_2_9_chunk_metrics_space_device_id_device_id_peer_v0_v1_2 on _hyper_2_9_chunk (actual rows=0 loops=1)
          Index Cond: (device_id < 0)
    ->  Custom Scan (DecompressChunk) on _hyper_2_10_chunk (actual rows=0 loops=1)
-         ->  Seq Scan on compress_hyper_6_20_chunk (actual rows=0 loops=1)
+         ->  Seq Scan on compress_hyper_6_24_chunk (actual rows=0 loops=1)
                Filter: (device_id < 0)
                Rows Removed by Filter: 1
    ->  Custom Scan (DecompressChunk) on _hyper_2_11_chunk (actual rows=0 loops=1)
-         ->  Seq Scan on compress_hyper_6_21_chunk (actual rows=0 loops=1)
+         ->  Seq Scan on compress_hyper_6_25_chunk (actual rows=0 loops=1)
                Filter: (device_id < 0)
                Rows Removed by Filter: 3
    ->  Index Scan using _hyper_2_12_chunk_metrics_space_device_id_device_id_peer_v0_v_2 on _hyper_2_12_chunk (actual rows=0 loops=1)
@@ -3410,18 +3410,18 @@ FROM :TEST_TABLE;
  Result (actual rows=6840 loops=1)
    ->  Append (actual rows=6840 loops=1)
          ->  Custom Scan (DecompressChunk) on _hyper_2_4_chunk (actual rows=360 loops=1)
-               ->  Seq Scan on compress_hyper_6_17_chunk (actual rows=1 loops=1)
+               ->  Seq Scan on compress_hyper_6_18_chunk (actual rows=1 loops=1)
          ->  Custom Scan (DecompressChunk) on _hyper_2_5_chunk (actual rows=1080 loops=1)
-               ->  Seq Scan on compress_hyper_6_18_chunk (actual rows=3 loops=1)
+               ->  Seq Scan on compress_hyper_6_19_chunk (actual rows=3 loops=1)
          ->  Custom Scan (DecompressChunk) on _hyper_2_6_chunk (actual rows=360 loops=1)
-               ->  Seq Scan on compress_hyper_6_19_chunk (actual rows=1 loops=1)
+               ->  Seq Scan on compress_hyper_6_20_chunk (actual rows=1 loops=1)
          ->  Seq Scan on _hyper_2_7_chunk (actual rows=504 loops=1)
          ->  Seq Scan on _hyper_2_8_chunk (actual rows=1512 loops=1)
          ->  Seq Scan on _hyper_2_9_chunk (actual rows=504 loops=1)
          ->  Custom Scan (DecompressChunk) on _hyper_2_10_chunk (actual rows=504 loops=1)
-               ->  Seq Scan on compress_hyper_6_20_chunk (actual rows=1 loops=1)
+               ->  Seq Scan on compress_hyper_6_24_chunk (actual rows=1 loops=1)
          ->  Custom Scan (DecompressChunk) on _hyper_2_11_chunk (actual rows=1512 loops=1)
-               ->  Seq Scan on compress_hyper_6_21_chunk (actual rows=3 loops=1)
+               ->  Seq Scan on compress_hyper_6_25_chunk (actual rows=3 loops=1)
          ->  Seq Scan on _hyper_2_12_chunk (actual rows=504 loops=1)
 (16 rows)
 
@@ -3438,12 +3438,12 @@ ORDER BY v1;
    Sort Method: quicksort 
    ->  Append (actual rows=1368 loops=1)
          ->  Custom Scan (DecompressChunk) on _hyper_2_4_chunk (actual rows=360 loops=1)
-               ->  Seq Scan on compress_hyper_6_17_chunk (actual rows=1 loops=1)
+               ->  Seq Scan on compress_hyper_6_18_chunk (actual rows=1 loops=1)
                      Filter: (device_id = 1)
          ->  Seq Scan on _hyper_2_7_chunk (actual rows=504 loops=1)
                Filter: (device_id = 1)
          ->  Custom Scan (DecompressChunk) on _hyper_2_10_chunk (actual rows=504 loops=1)
-               ->  Seq Scan on compress_hyper_6_20_chunk (actual rows=1 loops=1)
+               ->  Seq Scan on compress_hyper_6_24_chunk (actual rows=1 loops=1)
                      Filter: (device_id = 1)
 (12 rows)
 
@@ -3460,12 +3460,12 @@ ORDER BY v1;
    Sort Method: quicksort 
    ->  Append (actual rows=1368 loops=1)
          ->  Custom Scan (DecompressChunk) on _hyper_2_4_chunk (actual rows=360 loops=1)
-               ->  Seq Scan on compress_hyper_6_17_chunk (actual rows=1 loops=1)
+               ->  Seq Scan on compress_hyper_6_18_chunk (actual rows=1 loops=1)
                      Filter: (device_id = 1)
          ->  Seq Scan on _hyper_2_7_chunk (actual rows=504 loops=1)
                Filter: (device_id = 1)
          ->  Custom Scan (DecompressChunk) on _hyper_2_10_chunk (actual rows=504 loops=1)
-               ->  Seq Scan on compress_hyper_6_20_chunk (actual rows=1 loops=1)
+               ->  Seq Scan on compress_hyper_6_24_chunk (actual rows=1 loops=1)
                      Filter: (device_id = 1)
 (12 rows)
 
@@ -3478,12 +3478,12 @@ WHERE device_id = 1;
 ------------------------------------------------------------------------------------
  Append (actual rows=1368 loops=1)
    ->  Custom Scan (DecompressChunk) on _hyper_2_4_chunk (actual rows=360 loops=1)
-         ->  Seq Scan on compress_hyper_6_17_chunk (actual rows=1 loops=1)
+         ->  Seq Scan on compress_hyper_6_18_chunk (actual rows=1 loops=1)
                Filter: (device_id = 1)
    ->  Seq Scan on _hyper_2_7_chunk (actual rows=504 loops=1)
          Filter: (device_id = 1)
    ->  Custom Scan (DecompressChunk) on _hyper_2_10_chunk (actual rows=504 loops=1)
-         ->  Seq Scan on compress_hyper_6_20_chunk (actual rows=1 loops=1)
+         ->  Seq Scan on compress_hyper_6_24_chunk (actual rows=1 loops=1)
                Filter: (device_id = 1)
 (9 rows)
 
@@ -3509,22 +3509,22 @@ ORDER BY time,
                Filter: (_hyper_2_4_chunk.v3 > '10'::double precision)
                Rows Removed by Filter: 360
                Bulk Decompression: true
-               ->  Seq Scan on _timescaledb_internal.compress_hyper_6_17_chunk (actual rows=1 loops=1)
-                     Output: compress_hyper_6_17_chunk."time", compress_hyper_6_17_chunk.device_id, compress_hyper_6_17_chunk.device_id_peer, compress_hyper_6_17_chunk.v0, compress_hyper_6_17_chunk.v1, compress_hyper_6_17_chunk.v2, compress_hyper_6_17_chunk.v3, compress_hyper_6_17_chunk._ts_meta_count, compress_hyper_6_17_chunk._ts_meta_sequence_num, compress_hyper_6_17_chunk._ts_meta_min_3, compress_hyper_6_17_chunk._ts_meta_max_3, compress_hyper_6_17_chunk._ts_meta_min_1, compress_hyper_6_17_chunk._ts_meta_max_1, compress_hyper_6_17_chunk._ts_meta_min_2, compress_hyper_6_17_chunk._ts_meta_max_2
+               ->  Seq Scan on _timescaledb_internal.compress_hyper_6_18_chunk (actual rows=1 loops=1)
+                     Output: compress_hyper_6_18_chunk."time", compress_hyper_6_18_chunk.device_id, compress_hyper_6_18_chunk.device_id_peer, compress_hyper_6_18_chunk.v0, compress_hyper_6_18_chunk.v1, compress_hyper_6_18_chunk.v2, compress_hyper_6_18_chunk.v3, compress_hyper_6_18_chunk._ts_meta_count, compress_hyper_6_18_chunk._ts_meta_sequence_num, compress_hyper_6_18_chunk._ts_meta_min_3, compress_hyper_6_18_chunk._ts_meta_max_3, compress_hyper_6_18_chunk._ts_meta_min_1, compress_hyper_6_18_chunk._ts_meta_max_1, compress_hyper_6_18_chunk._ts_meta_min_2, compress_hyper_6_18_chunk._ts_meta_max_2
          ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_5_chunk (actual rows=0 loops=1)
                Output: _hyper_2_5_chunk."time", _hyper_2_5_chunk.device_id, _hyper_2_5_chunk.device_id_peer, _hyper_2_5_chunk.v0, _hyper_2_5_chunk.v1, _hyper_2_5_chunk.v2, _hyper_2_5_chunk.v3
                Filter: (_hyper_2_5_chunk.v3 > '10'::double precision)
                Rows Removed by Filter: 1080
                Bulk Decompression: true
-               ->  Seq Scan on _timescaledb_internal.compress_hyper_6_18_chunk (actual rows=3 loops=1)
-                     Output: compress_hyper_6_18_chunk."time", compress_hyper_6_18_chunk.device_id, compress_hyper_6_18_chunk.device_id_peer, compress_hyper_6_18_chunk.v0, compress_hyper_6_18_chunk.v1, compress_hyper_6_18_chunk.v2, compress_hyper_6_18_chunk.v3, compress_hyper_6_18_chunk._ts_meta_count, compress_hyper_6_18_chunk._ts_meta_sequence_num, compress_hyper_6_18_chunk._ts_meta_min_3, compress_hyper_6_18_chunk._ts_meta_max_3, compress_hyper_6_18_chunk._ts_meta_min_1, compress_hyper_6_18_chunk._ts_meta_max_1, compress_hyper_6_18_chunk._ts_meta_min_2, compress_hyper_6_18_chunk._ts_meta_max_2
+               ->  Seq Scan on _timescaledb_internal.compress_hyper_6_19_chunk (actual rows=3 loops=1)
+                     Output: compress_hyper_6_19_chunk."time", compress_hyper_6_19_chunk.device_id, compress_hyper_6_19_chunk.device_id_peer, compress_hyper_6_19_chunk.v0, compress_hyper_6_19_chunk.v1, compress_hyper_6_19_chunk.v2, compress_hyper_6_19_chunk.v3, compress_hyper_6_19_chunk._ts_meta_count, compress_hyper_6_19_chunk._ts_meta_sequence_num, compress_hyper_6_19_chunk._ts_meta_min_3, compress_hyper_6_19_chunk._ts_meta_max_3, compress_hyper_6_19_chunk._ts_meta_min_1, compress_hyper_6_19_chunk._ts_meta_max_1, compress_hyper_6_19_chunk._ts_meta_min_2, compress_hyper_6_19_chunk._ts_meta_max_2
          ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_6_chunk (actual rows=0 loops=1)
                Output: _hyper_2_6_chunk."time", _hyper_2_6_chunk.device_id, _hyper_2_6_chunk.device_id_peer, _hyper_2_6_chunk.v0, _hyper_2_6_chunk.v1, _hyper_2_6_chunk.v2, _hyper_2_6_chunk.v3
                Filter: (_hyper_2_6_chunk.v3 > '10'::double precision)
                Rows Removed by Filter: 360
                Bulk Decompression: true
-               ->  Seq Scan on _timescaledb_internal.compress_hyper_6_19_chunk (actual rows=1 loops=1)
-                     Output: compress_hyper_6_19_chunk."time", compress_hyper_6_19_chunk.device_id, compress_hyper_6_19_chunk.device_id_peer, compress_hyper_6_19_chunk.v0, compress_hyper_6_19_chunk.v1, compress_hyper_6_19_chunk.v2, compress_hyper_6_19_chunk.v3, compress_hyper_6_19_chunk._ts_meta_count, compress_hyper_6_19_chunk._ts_meta_sequence_num, compress_hyper_6_19_chunk._ts_meta_min_3, compress_hyper_6_19_chunk._ts_meta_max_3, compress_hyper_6_19_chunk._ts_meta_min_1, compress_hyper_6_19_chunk._ts_meta_max_1, compress_hyper_6_19_chunk._ts_meta_min_2, compress_hyper_6_19_chunk._ts_meta_max_2
+               ->  Seq Scan on _timescaledb_internal.compress_hyper_6_20_chunk (actual rows=1 loops=1)
+                     Output: compress_hyper_6_20_chunk."time", compress_hyper_6_20_chunk.device_id, compress_hyper_6_20_chunk.device_id_peer, compress_hyper_6_20_chunk.v0, compress_hyper_6_20_chunk.v1, compress_hyper_6_20_chunk.v2, compress_hyper_6_20_chunk.v3, compress_hyper_6_20_chunk._ts_meta_count, compress_hyper_6_20_chunk._ts_meta_sequence_num, compress_hyper_6_20_chunk._ts_meta_min_3, compress_hyper_6_20_chunk._ts_meta_max_3, compress_hyper_6_20_chunk._ts_meta_min_1, compress_hyper_6_20_chunk._ts_meta_max_1, compress_hyper_6_20_chunk._ts_meta_min_2, compress_hyper_6_20_chunk._ts_meta_max_2
          ->  Seq Scan on _timescaledb_internal._hyper_2_7_chunk (actual rows=0 loops=1)
                Output: _hyper_2_7_chunk."time", _hyper_2_7_chunk.device_id, _hyper_2_7_chunk.device_id_peer, _hyper_2_7_chunk.v0, _hyper_2_7_chunk.v1, _hyper_2_7_chunk.v2, _hyper_2_7_chunk.v3
                Filter: (_hyper_2_7_chunk.v3 > '10'::double precision)
@@ -3542,15 +3542,15 @@ ORDER BY time,
                Filter: (_hyper_2_10_chunk.v3 > '10'::double precision)
                Rows Removed by Filter: 504
                Bulk Decompression: true
-               ->  Seq Scan on _timescaledb_internal.compress_hyper_6_20_chunk (actual rows=1 loops=1)
-                     Output: compress_hyper_6_20_chunk."time", compress_hyper_6_20_chunk.device_id, compress_hyper_6_20_chunk.device_id_peer, compress_hyper_6_20_chunk.v0, compress_hyper_6_20_chunk.v1, compress_hyper_6_20_chunk.v2, compress_hyper_6_20_chunk.v3, compress_hyper_6_20_chunk._ts_meta_count, compress_hyper_6_20_chunk._ts_meta_sequence_num, compress_hyper_6_20_chunk._ts_meta_min_3, compress_hyper_6_20_chunk._ts_meta_max_3, compress_hyper_6_20_chunk._ts_meta_min_1, compress_hyper_6_20_chunk._ts_meta_max_1, compress_hyper_6_20_chunk._ts_meta_min_2, compress_hyper_6_20_chunk._ts_meta_max_2
+               ->  Seq Scan on _timescaledb_internal.compress_hyper_6_24_chunk (actual rows=1 loops=1)
+                     Output: compress_hyper_6_24_chunk."time", compress_hyper_6_24_chunk.device_id, compress_hyper_6_24_chunk.device_id_peer, compress_hyper_6_24_chunk.v0, compress_hyper_6_24_chunk.v1, compress_hyper_6_24_chunk.v2, compress_hyper_6_24_chunk.v3, compress_hyper_6_24_chunk._ts_meta_count, compress_hyper_6_24_chunk._ts_meta_sequence_num, compress_hyper_6_24_chunk._ts_meta_min_3, compress_hyper_6_24_chunk._ts_meta_max_3, compress_hyper_6_24_chunk._ts_meta_min_1, compress_hyper_6_24_chunk._ts_meta_max_1, compress_hyper_6_24_chunk._ts_meta_min_2, compress_hyper_6_24_chunk._ts_meta_max_2
          ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_11_chunk (actual rows=0 loops=1)
                Output: _hyper_2_11_chunk."time", _hyper_2_11_chunk.device_id, _hyper_2_11_chunk.device_id_peer, _hyper_2_11_chunk.v0, _hyper_2_11_chunk.v1, _hyper_2_11_chunk.v2, _hyper_2_11_chunk.v3
                Filter: (_hyper_2_11_chunk.v3 > '10'::double precision)
                Rows Removed by Filter: 1512
                Bulk Decompression: true
-               ->  Seq Scan on _timescaledb_internal.compress_hyper_6_21_chunk (actual rows=3 loops=1)
-                     Output: compress_hyper_6_21_chunk."time", compress_hyper_6_21_chunk.device_id, compress_hyper_6_21_chunk.device_id_peer, compress_hyper_6_21_chunk.v0, compress_hyper_6_21_chunk.v1, compress_hyper_6_21_chunk.v2, compress_hyper_6_21_chunk.v3, compress_hyper_6_21_chunk._ts_meta_count, compress_hyper_6_21_chunk._ts_meta_sequence_num, compress_hyper_6_21_chunk._ts_meta_min_3, compress_hyper_6_21_chunk._ts_meta_max_3, compress_hyper_6_21_chunk._ts_meta_min_1, compress_hyper_6_21_chunk._ts_meta_max_1, compress_hyper_6_21_chunk._ts_meta_min_2, compress_hyper_6_21_chunk._ts_meta_max_2
+               ->  Seq Scan on _timescaledb_internal.compress_hyper_6_25_chunk (actual rows=3 loops=1)
+                     Output: compress_hyper_6_25_chunk."time", compress_hyper_6_25_chunk.device_id, compress_hyper_6_25_chunk.device_id_peer, compress_hyper_6_25_chunk.v0, compress_hyper_6_25_chunk.v1, compress_hyper_6_25_chunk.v2, compress_hyper_6_25_chunk.v3, compress_hyper_6_25_chunk._ts_meta_count, compress_hyper_6_25_chunk._ts_meta_sequence_num, compress_hyper_6_25_chunk._ts_meta_min_3, compress_hyper_6_25_chunk._ts_meta_max_3, compress_hyper_6_25_chunk._ts_meta_min_1, compress_hyper_6_25_chunk._ts_meta_max_1, compress_hyper_6_25_chunk._ts_meta_min_2, compress_hyper_6_25_chunk._ts_meta_max_2
          ->  Seq Scan on _timescaledb_internal._hyper_2_12_chunk (actual rows=0 loops=1)
                Output: _hyper_2_12_chunk."time", _hyper_2_12_chunk.device_id, _hyper_2_12_chunk.device_id_peer, _hyper_2_12_chunk.v0, _hyper_2_12_chunk.v1, _hyper_2_12_chunk.v2, _hyper_2_12_chunk.v3
                Filter: (_hyper_2_12_chunk.v3 > '10'::double precision)
@@ -3574,14 +3574,14 @@ LIMIT 10;
                Sort Key: _hyper_2_4_chunk."time"
                Sort Method: top-N heapsort 
                ->  Custom Scan (DecompressChunk) on _hyper_2_4_chunk (actual rows=360 loops=1)
-                     ->  Seq Scan on compress_hyper_6_17_chunk (actual rows=1 loops=1)
+                     ->  Seq Scan on compress_hyper_6_18_chunk (actual rows=1 loops=1)
                            Filter: (device_id = 1)
          ->  Index Scan Backward using _hyper_2_7_chunk_metrics_space_time_idx on _hyper_2_7_chunk (never executed)
                Filter: (device_id = 1)
          ->  Sort (never executed)
                Sort Key: _hyper_2_10_chunk."time"
                ->  Custom Scan (DecompressChunk) on _hyper_2_10_chunk (never executed)
-                     ->  Seq Scan on compress_hyper_6_20_chunk (never executed)
+                     ->  Seq Scan on compress_hyper_6_24_chunk (never executed)
                            Filter: (device_id = 1)
 (16 rows)
 
@@ -3611,7 +3611,7 @@ LIMIT 10;
                                  Sort Key: _hyper_2_4_chunk."time"
                                  Sort Method: quicksort 
                                  ->  Custom Scan (DecompressChunk) on _hyper_2_4_chunk (actual rows=360 loops=1)
-                                       ->  Seq Scan on compress_hyper_6_17_chunk (actual rows=1 loops=1)
+                                       ->  Seq Scan on compress_hyper_6_18_chunk (actual rows=1 loops=1)
                                              Filter: (device_id IS NOT NULL)
                      ->  Sort (actual rows=7 loops=1)
                            Sort Key: _hyper_2_5_chunk."time"
@@ -3620,7 +3620,7 @@ LIMIT 10;
                                  Sort Key: _hyper_2_5_chunk."time"
                                  Sort Method: quicksort 
                                  ->  Custom Scan (DecompressChunk) on _hyper_2_5_chunk (actual rows=1080 loops=1)
-                                       ->  Seq Scan on compress_hyper_6_18_chunk (actual rows=3 loops=1)
+                                       ->  Seq Scan on compress_hyper_6_19_chunk (actual rows=3 loops=1)
                                              Filter: (device_id IS NOT NULL)
                      ->  Sort (actual rows=3 loops=1)
                            Sort Key: _hyper_2_6_chunk."time"
@@ -3629,7 +3629,7 @@ LIMIT 10;
                                  Sort Key: _hyper_2_6_chunk."time"
                                  Sort Method: quicksort 
                                  ->  Custom Scan (DecompressChunk) on _hyper_2_6_chunk (actual rows=360 loops=1)
-                                       ->  Seq Scan on compress_hyper_6_19_chunk (actual rows=1 loops=1)
+                                       ->  Seq Scan on compress_hyper_6_20_chunk (actual rows=1 loops=1)
                                              Filter: (device_id IS NOT NULL)
                ->  Merge Append (never executed)
                      Sort Key: _hyper_2_7_chunk."time"
@@ -3646,14 +3646,14 @@ LIMIT 10;
                            ->  Sort (never executed)
                                  Sort Key: _hyper_2_10_chunk."time"
                                  ->  Custom Scan (DecompressChunk) on _hyper_2_10_chunk (never executed)
-                                       ->  Seq Scan on compress_hyper_6_20_chunk (never executed)
+                                       ->  Seq Scan on compress_hyper_6_24_chunk (never executed)
                                              Filter: (device_id IS NOT NULL)
                      ->  Sort (never executed)
                            Sort Key: _hyper_2_11_chunk."time"
                            ->  Sort (never executed)
                                  Sort Key: _hyper_2_11_chunk."time"
                                  ->  Custom Scan (DecompressChunk) on _hyper_2_11_chunk (never executed)
-                                       ->  Seq Scan on compress_hyper_6_21_chunk (never executed)
+                                       ->  Seq Scan on compress_hyper_6_25_chunk (never executed)
                                              Filter: (device_id IS NOT NULL)
                      ->  Index Scan Backward using _hyper_2_12_chunk_metrics_space_time_idx on _hyper_2_12_chunk (never executed)
                            Filter: (device_id IS NOT NULL)
@@ -3684,7 +3684,7 @@ LIMIT 10;
                                  Sort Key: _hyper_2_4_chunk."time"
                                  Sort Method: quicksort 
                                  ->  Custom Scan (DecompressChunk) on _hyper_2_4_chunk (actual rows=0 loops=1)
-                                       ->  Seq Scan on compress_hyper_6_17_chunk (actual rows=0 loops=1)
+                                       ->  Seq Scan on compress_hyper_6_18_chunk (actual rows=0 loops=1)
                                              Filter: (device_id IS NULL)
                                              Rows Removed by Filter: 1
                      ->  Sort (actual rows=0 loops=1)
@@ -3694,7 +3694,7 @@ LIMIT 10;
                                  Sort Key: _hyper_2_5_chunk."time"
                                  Sort Method: quicksort 
                                  ->  Custom Scan (DecompressChunk) on _hyper_2_5_chunk (actual rows=0 loops=1)
-                                       ->  Seq Scan on compress_hyper_6_18_chunk (actual rows=0 loops=1)
+                                       ->  Seq Scan on compress_hyper_6_19_chunk (actual rows=0 loops=1)
                                              Filter: (device_id IS NULL)
                                              Rows Removed by Filter: 3
                      ->  Sort (actual rows=0 loops=1)
@@ -3704,7 +3704,7 @@ LIMIT 10;
                                  Sort Key: _hyper_2_6_chunk."time"
                                  Sort Method: quicksort 
                                  ->  Custom Scan (DecompressChunk) on _hyper_2_6_chunk (actual rows=0 loops=1)
-                                       ->  Seq Scan on compress_hyper_6_19_chunk (actual rows=0 loops=1)
+                                       ->  Seq Scan on compress_hyper_6_20_chunk (actual rows=0 loops=1)
                                              Filter: (device_id IS NULL)
                                              Rows Removed by Filter: 1
                ->  Merge Append (actual rows=0 loops=1)
@@ -3727,7 +3727,7 @@ LIMIT 10;
                                  Sort Key: _hyper_2_10_chunk."time"
                                  Sort Method: quicksort 
                                  ->  Custom Scan (DecompressChunk) on _hyper_2_10_chunk (actual rows=0 loops=1)
-                                       ->  Seq Scan on compress_hyper_6_20_chunk (actual rows=0 loops=1)
+                                       ->  Seq Scan on compress_hyper_6_24_chunk (actual rows=0 loops=1)
                                              Filter: (device_id IS NULL)
                                              Rows Removed by Filter: 1
                      ->  Sort (actual rows=0 loops=1)
@@ -3737,7 +3737,7 @@ LIMIT 10;
                                  Sort Key: _hyper_2_11_chunk."time"
                                  Sort Method: quicksort 
                                  ->  Custom Scan (DecompressChunk) on _hyper_2_11_chunk (actual rows=0 loops=1)
-                                       ->  Seq Scan on compress_hyper_6_21_chunk (actual rows=0 loops=1)
+                                       ->  Seq Scan on compress_hyper_6_25_chunk (actual rows=0 loops=1)
                                              Filter: (device_id IS NULL)
                                              Rows Removed by Filter: 3
                      ->  Index Scan Backward using _hyper_2_12_chunk_metrics_space_time_idx on _hyper_2_12_chunk (actual rows=0 loops=1)
@@ -3771,7 +3771,7 @@ LIMIT 10;
                                  Sort Key: _hyper_2_4_chunk."time"
                                  Sort Method: quicksort 
                                  ->  Custom Scan (DecompressChunk) on _hyper_2_4_chunk (actual rows=360 loops=1)
-                                       ->  Seq Scan on compress_hyper_6_17_chunk (actual rows=1 loops=1)
+                                       ->  Seq Scan on compress_hyper_6_18_chunk (actual rows=1 loops=1)
                                              Filter: (device_id = ANY ('{1,2}'::integer[]))
                      ->  Sort (actual rows=6 loops=1)
                            Sort Key: _hyper_2_5_chunk."time"
@@ -3780,7 +3780,7 @@ LIMIT 10;
                                  Sort Key: _hyper_2_5_chunk."time"
                                  Sort Method: quicksort 
                                  ->  Custom Scan (DecompressChunk) on _hyper_2_5_chunk (actual rows=360 loops=1)
-                                       ->  Seq Scan on compress_hyper_6_18_chunk (actual rows=1 loops=1)
+                                       ->  Seq Scan on compress_hyper_6_19_chunk (actual rows=1 loops=1)
                                              Filter: (device_id = ANY ('{1,2}'::integer[]))
                                              Rows Removed by Filter: 2
                ->  Merge Append (never executed)
@@ -3796,14 +3796,14 @@ LIMIT 10;
                            ->  Sort (never executed)
                                  Sort Key: _hyper_2_10_chunk."time"
                                  ->  Custom Scan (DecompressChunk) on _hyper_2_10_chunk (never executed)
-                                       ->  Seq Scan on compress_hyper_6_20_chunk (never executed)
+                                       ->  Seq Scan on compress_hyper_6_24_chunk (never executed)
                                              Filter: (device_id = ANY ('{1,2}'::integer[]))
                      ->  Sort (never executed)
                            Sort Key: _hyper_2_11_chunk."time"
                            ->  Sort (never executed)
                                  Sort Key: _hyper_2_11_chunk."time"
                                  ->  Custom Scan (DecompressChunk) on _hyper_2_11_chunk (never executed)
-                                       ->  Seq Scan on compress_hyper_6_21_chunk (never executed)
+                                       ->  Seq Scan on compress_hyper_6_25_chunk (never executed)
                                              Filter: (device_id = ANY ('{1,2}'::integer[]))
 (50 rows)
 
@@ -3824,14 +3824,14 @@ LIMIT 10;
                Sort Key: _hyper_2_4_chunk."time"
                Sort Method: top-N heapsort 
                ->  Custom Scan (DecompressChunk) on _hyper_2_4_chunk (actual rows=360 loops=1)
-                     ->  Seq Scan on compress_hyper_6_17_chunk (actual rows=1 loops=1)
+                     ->  Seq Scan on compress_hyper_6_18_chunk (actual rows=1 loops=1)
                            Filter: (device_id = 1)
          ->  Index Scan Backward using _hyper_2_7_chunk_metrics_space_time_idx on _hyper_2_7_chunk (never executed)
                Filter: (device_id = 1)
          ->  Sort (never executed)
                Sort Key: _hyper_2_10_chunk."time"
                ->  Custom Scan (DecompressChunk) on _hyper_2_10_chunk (never executed)
-                     ->  Seq Scan on compress_hyper_6_20_chunk (never executed)
+                     ->  Seq Scan on compress_hyper_6_24_chunk (never executed)
                            Filter: (device_id = 1)
 (16 rows)
 
@@ -3861,7 +3861,7 @@ LIMIT 10;
                                  Sort Key: _hyper_2_4_chunk."time"
                                  Sort Method: quicksort 
                                  ->  Custom Scan (DecompressChunk) on _hyper_2_4_chunk (actual rows=0 loops=1)
-                                       ->  Seq Scan on compress_hyper_6_17_chunk (actual rows=0 loops=1)
+                                       ->  Seq Scan on compress_hyper_6_18_chunk (actual rows=0 loops=1)
                                              Filter: (device_id = device_id_peer)
                                              Rows Removed by Filter: 1
                      ->  Sort (actual rows=0 loops=1)
@@ -3871,7 +3871,7 @@ LIMIT 10;
                                  Sort Key: _hyper_2_5_chunk."time"
                                  Sort Method: quicksort 
                                  ->  Custom Scan (DecompressChunk) on _hyper_2_5_chunk (actual rows=0 loops=1)
-                                       ->  Seq Scan on compress_hyper_6_18_chunk (actual rows=0 loops=1)
+                                       ->  Seq Scan on compress_hyper_6_19_chunk (actual rows=0 loops=1)
                                              Filter: (device_id = device_id_peer)
                                              Rows Removed by Filter: 3
                      ->  Sort (actual rows=0 loops=1)
@@ -3881,7 +3881,7 @@ LIMIT 10;
                                  Sort Key: _hyper_2_6_chunk."time"
                                  Sort Method: quicksort 
                                  ->  Custom Scan (DecompressChunk) on _hyper_2_6_chunk (actual rows=0 loops=1)
-                                       ->  Seq Scan on compress_hyper_6_19_chunk (actual rows=0 loops=1)
+                                       ->  Seq Scan on compress_hyper_6_20_chunk (actual rows=0 loops=1)
                                              Filter: (device_id = device_id_peer)
                                              Rows Removed by Filter: 1
                ->  Merge Append (actual rows=0 loops=1)
@@ -3904,7 +3904,7 @@ LIMIT 10;
                                  Sort Key: _hyper_2_10_chunk."time"
                                  Sort Method: quicksort 
                                  ->  Custom Scan (DecompressChunk) on _hyper_2_10_chunk (actual rows=0 loops=1)
-                                       ->  Seq Scan on compress_hyper_6_20_chunk (actual rows=0 loops=1)
+                                       ->  Seq Scan on compress_hyper_6_24_chunk (actual rows=0 loops=1)
                                              Filter: (device_id = device_id_peer)
                                              Rows Removed by Filter: 1
                      ->  Sort (actual rows=0 loops=1)
@@ -3914,7 +3914,7 @@ LIMIT 10;
                                  Sort Key: _hyper_2_11_chunk."time"
                                  Sort Method: quicksort 
                                  ->  Custom Scan (DecompressChunk) on _hyper_2_11_chunk (actual rows=0 loops=1)
-                                       ->  Seq Scan on compress_hyper_6_21_chunk (actual rows=0 loops=1)
+                                       ->  Seq Scan on compress_hyper_6_25_chunk (actual rows=0 loops=1)
                                              Filter: (device_id = device_id_peer)
                                              Rows Removed by Filter: 3
                      ->  Index Scan Backward using _hyper_2_12_chunk_metrics_space_time_idx on _hyper_2_12_chunk (actual rows=0 loops=1)
@@ -3947,7 +3947,7 @@ LIMIT 10;
                                  Sort Key: _hyper_2_4_chunk."time"
                                  Sort Method: quicksort 
                                  ->  Custom Scan (DecompressChunk) on _hyper_2_4_chunk (actual rows=360 loops=1)
-                                       ->  Seq Scan on compress_hyper_6_17_chunk (actual rows=1 loops=1)
+                                       ->  Seq Scan on compress_hyper_6_18_chunk (actual rows=1 loops=1)
                                              Filter: (device_id_peer < device_id)
                      ->  Sort (actual rows=7 loops=1)
                            Sort Key: _hyper_2_5_chunk."time"
@@ -3956,7 +3956,7 @@ LIMIT 10;
                                  Sort Key: _hyper_2_5_chunk."time"
                                  Sort Method: quicksort 
                                  ->  Custom Scan (DecompressChunk) on _hyper_2_5_chunk (actual rows=1080 loops=1)
-                                       ->  Seq Scan on compress_hyper_6_18_chunk (actual rows=3 loops=1)
+                                       ->  Seq Scan on compress_hyper_6_19_chunk (actual rows=3 loops=1)
                                              Filter: (device_id_peer < device_id)
                      ->  Sort (actual rows=3 loops=1)
                            Sort Key: _hyper_2_6_chunk."time"
@@ -3965,7 +3965,7 @@ LIMIT 10;
                                  Sort Key: _hyper_2_6_chunk."time"
                                  Sort Method: quicksort 
                                  ->  Custom Scan (DecompressChunk) on _hyper_2_6_chunk (actual rows=360 loops=1)
-                                       ->  Seq Scan on compress_hyper_6_19_chunk (actual rows=1 loops=1)
+                                       ->  Seq Scan on compress_hyper_6_20_chunk (actual rows=1 loops=1)
                                              Filter: (device_id_peer < device_id)
                ->  Merge Append (never executed)
                      Sort Key: _hyper_2_7_chunk."time"
@@ -3982,14 +3982,14 @@ LIMIT 10;
                            ->  Sort (never executed)
                                  Sort Key: _hyper_2_10_chunk."time"
                                  ->  Custom Scan (DecompressChunk) on _hyper_2_10_chunk (never executed)
-                                       ->  Seq Scan on compress_hyper_6_20_chunk (never executed)
+                                       ->  Seq Scan on compress_hyper_6_24_chunk (never executed)
                                              Filter: (device_id_peer < device_id)
                      ->  Sort (never executed)
                            Sort Key: _hyper_2_11_chunk."time"
                            ->  Sort (never executed)
                                  Sort Key: _hyper_2_11_chunk."time"
                                  ->  Custom Scan (DecompressChunk) on _hyper_2_11_chunk (never executed)
-                                       ->  Seq Scan on compress_hyper_6_21_chunk (never executed)
+                                       ->  Seq Scan on compress_hyper_6_25_chunk (never executed)
                                              Filter: (device_id_peer < device_id)
                      ->  Index Scan Backward using _hyper_2_12_chunk_metrics_space_time_idx on _hyper_2_12_chunk (never executed)
                            Filter: (device_id_peer < device_id)
@@ -4012,7 +4012,7 @@ LIMIT 10;
                Sort Key: _hyper_2_6_chunk."time"
                Sort Method: top-N heapsort 
                ->  Custom Scan (DecompressChunk) on _hyper_2_6_chunk (actual rows=360 loops=1)
-                     ->  Seq Scan on compress_hyper_6_19_chunk (actual rows=1 loops=1)
+                     ->  Seq Scan on compress_hyper_6_20_chunk (actual rows=1 loops=1)
                            Filter: (device_id = 3)
          ->  Index Scan Backward using _hyper_2_9_chunk_metrics_space_time_idx on _hyper_2_9_chunk (never executed)
                Filter: (device_id = 3)
@@ -4045,7 +4045,7 @@ LIMIT 10;
                            ->  Custom Scan (DecompressChunk) on _hyper_2_4_chunk (actual rows=0 loops=1)
                                  Filter: (device_id = length("substring"(version(), 1, 3)))
                                  Rows Removed by Filter: 360
-                                 ->  Seq Scan on compress_hyper_6_17_chunk (actual rows=1 loops=1)
+                                 ->  Seq Scan on compress_hyper_6_18_chunk (actual rows=1 loops=1)
                ->  Sort (actual rows=0 loops=1)
                      Sort Key: _hyper_2_5_chunk."time"
                      Sort Method: quicksort 
@@ -4055,7 +4055,7 @@ LIMIT 10;
                            ->  Custom Scan (DecompressChunk) on _hyper_2_5_chunk (actual rows=0 loops=1)
                                  Filter: (device_id = length("substring"(version(), 1, 3)))
                                  Rows Removed by Filter: 1080
-                                 ->  Seq Scan on compress_hyper_6_18_chunk (actual rows=3 loops=1)
+                                 ->  Seq Scan on compress_hyper_6_19_chunk (actual rows=3 loops=1)
                ->  Sort (actual rows=10 loops=1)
                      Sort Key: _hyper_2_6_chunk."time"
                      Sort Method: top-N heapsort 
@@ -4064,7 +4064,7 @@ LIMIT 10;
                            Sort Method: quicksort 
                            ->  Custom Scan (DecompressChunk) on _hyper_2_6_chunk (actual rows=360 loops=1)
                                  Filter: (device_id = length("substring"(version(), 1, 3)))
-                                 ->  Seq Scan on compress_hyper_6_19_chunk (actual rows=1 loops=1)
+                                 ->  Seq Scan on compress_hyper_6_20_chunk (actual rows=1 loops=1)
          ->  Merge Append (never executed)
                Sort Key: _hyper_2_7_chunk."time"
                ->  Index Scan Backward using _hyper_2_7_chunk_metrics_space_device_id_time_idx on _hyper_2_7_chunk (never executed)
@@ -4081,14 +4081,14 @@ LIMIT 10;
                            Sort Key: _hyper_2_10_chunk."time"
                            ->  Custom Scan (DecompressChunk) on _hyper_2_10_chunk (never executed)
                                  Filter: (device_id = length("substring"(version(), 1, 3)))
-                                 ->  Seq Scan on compress_hyper_6_20_chunk (never executed)
+                                 ->  Seq Scan on compress_hyper_6_24_chunk (never executed)
                ->  Sort (never executed)
                      Sort Key: _hyper_2_11_chunk."time"
                      ->  Sort (never executed)
                            Sort Key: _hyper_2_11_chunk."time"
                            ->  Custom Scan (DecompressChunk) on _hyper_2_11_chunk (never executed)
                                  Filter: (device_id = length("substring"(version(), 1, 3)))
-                                 ->  Seq Scan on compress_hyper_6_21_chunk (never executed)
+                                 ->  Seq Scan on compress_hyper_6_25_chunk (never executed)
                ->  Index Scan Backward using _hyper_2_12_chunk_metrics_space_device_id_time_idx on _hyper_2_12_chunk (never executed)
                      Index Cond: (device_id = length("substring"(version(), 1, 3)))
 (60 rows)
@@ -4113,25 +4113,25 @@ LIMIT 10;
                Filter: ("time" = 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
                Rows Removed by Filter: 359
                ->  Sort (actual rows=1 loops=1)
-                     Sort Key: compress_hyper_6_17_chunk.device_id
+                     Sort Key: compress_hyper_6_18_chunk.device_id
                      Sort Method: quicksort 
-                     ->  Seq Scan on compress_hyper_6_17_chunk (actual rows=1 loops=1)
+                     ->  Seq Scan on compress_hyper_6_18_chunk (actual rows=1 loops=1)
                            Filter: ((_ts_meta_min_3 <= 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone) AND (_ts_meta_max_3 >= 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone))
          ->  Custom Scan (DecompressChunk) on _hyper_2_5_chunk (actual rows=3 loops=1)
                Filter: ("time" = 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
                Rows Removed by Filter: 1077
                ->  Sort (actual rows=3 loops=1)
-                     Sort Key: compress_hyper_6_18_chunk.device_id
+                     Sort Key: compress_hyper_6_19_chunk.device_id
                      Sort Method: quicksort 
-                     ->  Seq Scan on compress_hyper_6_18_chunk (actual rows=3 loops=1)
+                     ->  Seq Scan on compress_hyper_6_19_chunk (actual rows=3 loops=1)
                            Filter: ((_ts_meta_min_3 <= 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone) AND (_ts_meta_max_3 >= 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone))
          ->  Custom Scan (DecompressChunk) on _hyper_2_6_chunk (actual rows=1 loops=1)
                Filter: ("time" = 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
                Rows Removed by Filter: 359
                ->  Sort (actual rows=1 loops=1)
-                     Sort Key: compress_hyper_6_19_chunk.device_id
+                     Sort Key: compress_hyper_6_20_chunk.device_id
                      Sort Method: quicksort 
-                     ->  Seq Scan on compress_hyper_6_19_chunk (actual rows=1 loops=1)
+                     ->  Seq Scan on compress_hyper_6_20_chunk (actual rows=1 loops=1)
                            Filter: ((_ts_meta_min_3 <= 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone) AND (_ts_meta_max_3 >= 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone))
 (27 rows)
 
@@ -4152,17 +4152,17 @@ LIMIT 10;
                ->  Custom Scan (DecompressChunk) on _hyper_2_4_chunk (actual rows=3 loops=1)
                      Filter: ("time" < 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
                      Rows Removed by Filter: 357
-                     ->  Seq Scan on compress_hyper_6_17_chunk (actual rows=1 loops=1)
+                     ->  Seq Scan on compress_hyper_6_18_chunk (actual rows=1 loops=1)
                            Filter: (_ts_meta_min_3 < 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
                ->  Custom Scan (DecompressChunk) on _hyper_2_5_chunk (actual rows=9 loops=1)
                      Filter: ("time" < 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
                      Rows Removed by Filter: 1071
-                     ->  Seq Scan on compress_hyper_6_18_chunk (actual rows=3 loops=1)
+                     ->  Seq Scan on compress_hyper_6_19_chunk (actual rows=3 loops=1)
                            Filter: (_ts_meta_min_3 < 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
                ->  Custom Scan (DecompressChunk) on _hyper_2_6_chunk (actual rows=3 loops=1)
                      Filter: ("time" < 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
                      Rows Removed by Filter: 357
-                     ->  Seq Scan on compress_hyper_6_19_chunk (actual rows=1 loops=1)
+                     ->  Seq Scan on compress_hyper_6_20_chunk (actual rows=1 loops=1)
                            Filter: (_ts_meta_min_3 < 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
 (20 rows)
 
@@ -4183,17 +4183,17 @@ LIMIT 10;
                ->  Custom Scan (DecompressChunk) on _hyper_2_4_chunk (actual rows=4 loops=1)
                      Filter: ("time" <= 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
                      Rows Removed by Filter: 356
-                     ->  Seq Scan on compress_hyper_6_17_chunk (actual rows=1 loops=1)
+                     ->  Seq Scan on compress_hyper_6_18_chunk (actual rows=1 loops=1)
                            Filter: (_ts_meta_min_3 <= 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
                ->  Custom Scan (DecompressChunk) on _hyper_2_5_chunk (actual rows=12 loops=1)
                      Filter: ("time" <= 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
                      Rows Removed by Filter: 1068
-                     ->  Seq Scan on compress_hyper_6_18_chunk (actual rows=3 loops=1)
+                     ->  Seq Scan on compress_hyper_6_19_chunk (actual rows=3 loops=1)
                            Filter: (_ts_meta_min_3 <= 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
                ->  Custom Scan (DecompressChunk) on _hyper_2_6_chunk (actual rows=4 loops=1)
                      Filter: ("time" <= 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
                      Rows Removed by Filter: 356
-                     ->  Seq Scan on compress_hyper_6_19_chunk (actual rows=1 loops=1)
+                     ->  Seq Scan on compress_hyper_6_20_chunk (actual rows=1 loops=1)
                            Filter: (_ts_meta_min_3 <= 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
 (20 rows)
 
@@ -4224,7 +4224,7 @@ LIMIT 10;
                                  ->  Custom Scan (DecompressChunk) on _hyper_2_4_chunk (actual rows=357 loops=1)
                                        Filter: ("time" >= 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
                                        Rows Removed by Filter: 3
-                                       ->  Seq Scan on compress_hyper_6_17_chunk (actual rows=1 loops=1)
+                                       ->  Seq Scan on compress_hyper_6_18_chunk (actual rows=1 loops=1)
                                              Filter: (_ts_meta_max_3 >= 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
                      ->  Sort (actual rows=7 loops=1)
                            Sort Key: _hyper_2_5_chunk."time"
@@ -4235,7 +4235,7 @@ LIMIT 10;
                                  ->  Custom Scan (DecompressChunk) on _hyper_2_5_chunk (actual rows=1071 loops=1)
                                        Filter: ("time" >= 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
                                        Rows Removed by Filter: 9
-                                       ->  Seq Scan on compress_hyper_6_18_chunk (actual rows=3 loops=1)
+                                       ->  Seq Scan on compress_hyper_6_19_chunk (actual rows=3 loops=1)
                                              Filter: (_ts_meta_max_3 >= 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
                      ->  Sort (actual rows=3 loops=1)
                            Sort Key: _hyper_2_6_chunk."time"
@@ -4246,7 +4246,7 @@ LIMIT 10;
                                  ->  Custom Scan (DecompressChunk) on _hyper_2_6_chunk (actual rows=357 loops=1)
                                        Filter: ("time" >= 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
                                        Rows Removed by Filter: 3
-                                       ->  Seq Scan on compress_hyper_6_19_chunk (actual rows=1 loops=1)
+                                       ->  Seq Scan on compress_hyper_6_20_chunk (actual rows=1 loops=1)
                                              Filter: (_ts_meta_max_3 >= 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
                ->  Merge Append (never executed)
                      Sort Key: _hyper_2_7_chunk."time"
@@ -4264,7 +4264,7 @@ LIMIT 10;
                                  Sort Key: _hyper_2_10_chunk."time"
                                  ->  Custom Scan (DecompressChunk) on _hyper_2_10_chunk (never executed)
                                        Filter: ("time" >= 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
-                                       ->  Seq Scan on compress_hyper_6_20_chunk (never executed)
+                                       ->  Seq Scan on compress_hyper_6_24_chunk (never executed)
                                              Filter: (_ts_meta_max_3 >= 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
                      ->  Sort (never executed)
                            Sort Key: _hyper_2_11_chunk."time"
@@ -4272,7 +4272,7 @@ LIMIT 10;
                                  Sort Key: _hyper_2_11_chunk."time"
                                  ->  Custom Scan (DecompressChunk) on _hyper_2_11_chunk (never executed)
                                        Filter: ("time" >= 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
-                                       ->  Seq Scan on compress_hyper_6_21_chunk (never executed)
+                                       ->  Seq Scan on compress_hyper_6_25_chunk (never executed)
                                              Filter: (_ts_meta_max_3 >= 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
                      ->  Index Scan Backward using _hyper_2_12_chunk_metrics_space_time_idx on _hyper_2_12_chunk (never executed)
                            Index Cond: ("time" >= 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
@@ -4305,7 +4305,7 @@ LIMIT 10;
                                  ->  Custom Scan (DecompressChunk) on _hyper_2_4_chunk (actual rows=356 loops=1)
                                        Filter: ("time" > 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
                                        Rows Removed by Filter: 4
-                                       ->  Seq Scan on compress_hyper_6_17_chunk (actual rows=1 loops=1)
+                                       ->  Seq Scan on compress_hyper_6_18_chunk (actual rows=1 loops=1)
                                              Filter: (_ts_meta_max_3 > 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
                      ->  Sort (actual rows=7 loops=1)
                            Sort Key: _hyper_2_5_chunk."time"
@@ -4316,7 +4316,7 @@ LIMIT 10;
                                  ->  Custom Scan (DecompressChunk) on _hyper_2_5_chunk (actual rows=1068 loops=1)
                                        Filter: ("time" > 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
                                        Rows Removed by Filter: 12
-                                       ->  Seq Scan on compress_hyper_6_18_chunk (actual rows=3 loops=1)
+                                       ->  Seq Scan on compress_hyper_6_19_chunk (actual rows=3 loops=1)
                                              Filter: (_ts_meta_max_3 > 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
                      ->  Sort (actual rows=3 loops=1)
                            Sort Key: _hyper_2_6_chunk."time"
@@ -4327,7 +4327,7 @@ LIMIT 10;
                                  ->  Custom Scan (DecompressChunk) on _hyper_2_6_chunk (actual rows=356 loops=1)
                                        Filter: ("time" > 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
                                        Rows Removed by Filter: 4
-                                       ->  Seq Scan on compress_hyper_6_19_chunk (actual rows=1 loops=1)
+                                       ->  Seq Scan on compress_hyper_6_20_chunk (actual rows=1 loops=1)
                                              Filter: (_ts_meta_max_3 > 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
                ->  Merge Append (never executed)
                      Sort Key: _hyper_2_7_chunk."time"
@@ -4345,7 +4345,7 @@ LIMIT 10;
                                  Sort Key: _hyper_2_10_chunk."time"
                                  ->  Custom Scan (DecompressChunk) on _hyper_2_10_chunk (never executed)
                                        Filter: ("time" > 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
-                                       ->  Seq Scan on compress_hyper_6_20_chunk (never executed)
+                                       ->  Seq Scan on compress_hyper_6_24_chunk (never executed)
                                              Filter: (_ts_meta_max_3 > 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
                      ->  Sort (never executed)
                            Sort Key: _hyper_2_11_chunk."time"
@@ -4353,7 +4353,7 @@ LIMIT 10;
                                  Sort Key: _hyper_2_11_chunk."time"
                                  ->  Custom Scan (DecompressChunk) on _hyper_2_11_chunk (never executed)
                                        Filter: ("time" > 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
-                                       ->  Seq Scan on compress_hyper_6_21_chunk (never executed)
+                                       ->  Seq Scan on compress_hyper_6_25_chunk (never executed)
                                              Filter: (_ts_meta_max_3 > 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
                      ->  Index Scan Backward using _hyper_2_12_chunk_metrics_space_time_idx on _hyper_2_12_chunk (never executed)
                            Index Cond: ("time" > 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
@@ -4386,7 +4386,7 @@ LIMIT 10;
                                  ->  Custom Scan (DecompressChunk) on _hyper_2_4_chunk (actual rows=356 loops=1)
                                        Filter: ('Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone < "time")
                                        Rows Removed by Filter: 4
-                                       ->  Seq Scan on compress_hyper_6_17_chunk (actual rows=1 loops=1)
+                                       ->  Seq Scan on compress_hyper_6_18_chunk (actual rows=1 loops=1)
                                              Filter: (_ts_meta_max_3 > 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
                      ->  Sort (actual rows=7 loops=1)
                            Sort Key: _hyper_2_5_chunk."time"
@@ -4397,7 +4397,7 @@ LIMIT 10;
                                  ->  Custom Scan (DecompressChunk) on _hyper_2_5_chunk (actual rows=1068 loops=1)
                                        Filter: ('Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone < "time")
                                        Rows Removed by Filter: 12
-                                       ->  Seq Scan on compress_hyper_6_18_chunk (actual rows=3 loops=1)
+                                       ->  Seq Scan on compress_hyper_6_19_chunk (actual rows=3 loops=1)
                                              Filter: (_ts_meta_max_3 > 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
                      ->  Sort (actual rows=3 loops=1)
                            Sort Key: _hyper_2_6_chunk."time"
@@ -4408,7 +4408,7 @@ LIMIT 10;
                                  ->  Custom Scan (DecompressChunk) on _hyper_2_6_chunk (actual rows=356 loops=1)
                                        Filter: ('Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone < "time")
                                        Rows Removed by Filter: 4
-                                       ->  Seq Scan on compress_hyper_6_19_chunk (actual rows=1 loops=1)
+                                       ->  Seq Scan on compress_hyper_6_20_chunk (actual rows=1 loops=1)
                                              Filter: (_ts_meta_max_3 > 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
                ->  Merge Append (never executed)
                      Sort Key: _hyper_2_7_chunk."time"
@@ -4426,7 +4426,7 @@ LIMIT 10;
                                  Sort Key: _hyper_2_10_chunk."time"
                                  ->  Custom Scan (DecompressChunk) on _hyper_2_10_chunk (never executed)
                                        Filter: ('Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone < "time")
-                                       ->  Seq Scan on compress_hyper_6_20_chunk (never executed)
+                                       ->  Seq Scan on compress_hyper_6_24_chunk (never executed)
                                              Filter: (_ts_meta_max_3 > 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
                      ->  Sort (never executed)
                            Sort Key: _hyper_2_11_chunk."time"
@@ -4434,7 +4434,7 @@ LIMIT 10;
                                  Sort Key: _hyper_2_11_chunk."time"
                                  ->  Custom Scan (DecompressChunk) on _hyper_2_11_chunk (never executed)
                                        Filter: ('Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone < "time")
-                                       ->  Seq Scan on compress_hyper_6_21_chunk (never executed)
+                                       ->  Seq Scan on compress_hyper_6_25_chunk (never executed)
                                              Filter: (_ts_meta_max_3 > 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
                      ->  Index Scan Backward using _hyper_2_12_chunk_metrics_space_time_idx on _hyper_2_12_chunk (never executed)
                            Index Cond: ("time" > 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
@@ -4467,7 +4467,7 @@ LIMIT 10;
                                  Sort Method: quicksort 
                                  ->  Custom Scan (DecompressChunk) on _hyper_2_4_chunk (actual rows=0 loops=1)
                                        Filter: (v0 < 1)
-                                       ->  Seq Scan on compress_hyper_6_17_chunk (actual rows=0 loops=1)
+                                       ->  Seq Scan on compress_hyper_6_18_chunk (actual rows=0 loops=1)
                                              Filter: (_ts_meta_min_1 < 1)
                                              Rows Removed by Filter: 1
                      ->  Sort (actual rows=0 loops=1)
@@ -4478,7 +4478,7 @@ LIMIT 10;
                                  Sort Method: quicksort 
                                  ->  Custom Scan (DecompressChunk) on _hyper_2_5_chunk (actual rows=0 loops=1)
                                        Filter: (v0 < 1)
-                                       ->  Seq Scan on compress_hyper_6_18_chunk (actual rows=0 loops=1)
+                                       ->  Seq Scan on compress_hyper_6_19_chunk (actual rows=0 loops=1)
                                              Filter: (_ts_meta_min_1 < 1)
                                              Rows Removed by Filter: 3
                      ->  Sort (actual rows=0 loops=1)
@@ -4489,7 +4489,7 @@ LIMIT 10;
                                  Sort Method: quicksort 
                                  ->  Custom Scan (DecompressChunk) on _hyper_2_6_chunk (actual rows=0 loops=1)
                                        Filter: (v0 < 1)
-                                       ->  Seq Scan on compress_hyper_6_19_chunk (actual rows=0 loops=1)
+                                       ->  Seq Scan on compress_hyper_6_20_chunk (actual rows=0 loops=1)
                                              Filter: (_ts_meta_min_1 < 1)
                                              Rows Removed by Filter: 1
                ->  Merge Append (actual rows=0 loops=1)
@@ -4513,7 +4513,7 @@ LIMIT 10;
                                  Sort Method: quicksort 
                                  ->  Custom Scan (DecompressChunk) on _hyper_2_10_chunk (actual rows=0 loops=1)
                                        Filter: (v0 < 1)
-                                       ->  Seq Scan on compress_hyper_6_20_chunk (actual rows=0 loops=1)
+                                       ->  Seq Scan on compress_hyper_6_24_chunk (actual rows=0 loops=1)
                                              Filter: (_ts_meta_min_1 < 1)
                                              Rows Removed by Filter: 1
                      ->  Sort (actual rows=0 loops=1)
@@ -4524,7 +4524,7 @@ LIMIT 10;
                                  Sort Method: quicksort 
                                  ->  Custom Scan (DecompressChunk) on _hyper_2_11_chunk (actual rows=0 loops=1)
                                        Filter: (v0 < 1)
-                                       ->  Seq Scan on compress_hyper_6_21_chunk (actual rows=0 loops=1)
+                                       ->  Seq Scan on compress_hyper_6_25_chunk (actual rows=0 loops=1)
                                              Filter: (_ts_meta_min_1 < 1)
                                              Rows Removed by Filter: 3
                      ->  Index Scan Backward using _hyper_2_12_chunk_metrics_space_time_idx on _hyper_2_12_chunk (actual rows=0 loops=1)
@@ -4558,7 +4558,7 @@ LIMIT 10;
                                  Sort Method: quicksort 
                                  ->  Custom Scan (DecompressChunk) on _hyper_2_4_chunk (actual rows=0 loops=1)
                                        Filter: (v0 < device_id)
-                                       ->  Seq Scan on compress_hyper_6_17_chunk (actual rows=0 loops=1)
+                                       ->  Seq Scan on compress_hyper_6_18_chunk (actual rows=0 loops=1)
                                              Filter: (_ts_meta_min_1 < device_id)
                                              Rows Removed by Filter: 1
                      ->  Sort (actual rows=0 loops=1)
@@ -4569,7 +4569,7 @@ LIMIT 10;
                                  Sort Method: quicksort 
                                  ->  Custom Scan (DecompressChunk) on _hyper_2_5_chunk (actual rows=0 loops=1)
                                        Filter: (v0 < device_id)
-                                       ->  Seq Scan on compress_hyper_6_18_chunk (actual rows=0 loops=1)
+                                       ->  Seq Scan on compress_hyper_6_19_chunk (actual rows=0 loops=1)
                                              Filter: (_ts_meta_min_1 < device_id)
                                              Rows Removed by Filter: 3
                      ->  Sort (actual rows=0 loops=1)
@@ -4580,7 +4580,7 @@ LIMIT 10;
                                  Sort Method: quicksort 
                                  ->  Custom Scan (DecompressChunk) on _hyper_2_6_chunk (actual rows=0 loops=1)
                                        Filter: (v0 < device_id)
-                                       ->  Seq Scan on compress_hyper_6_19_chunk (actual rows=0 loops=1)
+                                       ->  Seq Scan on compress_hyper_6_20_chunk (actual rows=0 loops=1)
                                              Filter: (_ts_meta_min_1 < device_id)
                                              Rows Removed by Filter: 1
                ->  Merge Append (actual rows=0 loops=1)
@@ -4604,7 +4604,7 @@ LIMIT 10;
                                  Sort Method: quicksort 
                                  ->  Custom Scan (DecompressChunk) on _hyper_2_10_chunk (actual rows=0 loops=1)
                                        Filter: (v0 < device_id)
-                                       ->  Seq Scan on compress_hyper_6_20_chunk (actual rows=0 loops=1)
+                                       ->  Seq Scan on compress_hyper_6_24_chunk (actual rows=0 loops=1)
                                              Filter: (_ts_meta_min_1 < device_id)
                                              Rows Removed by Filter: 1
                      ->  Sort (actual rows=0 loops=1)
@@ -4615,7 +4615,7 @@ LIMIT 10;
                                  Sort Method: quicksort 
                                  ->  Custom Scan (DecompressChunk) on _hyper_2_11_chunk (actual rows=0 loops=1)
                                        Filter: (v0 < device_id)
-                                       ->  Seq Scan on compress_hyper_6_21_chunk (actual rows=0 loops=1)
+                                       ->  Seq Scan on compress_hyper_6_25_chunk (actual rows=0 loops=1)
                                              Filter: (_ts_meta_min_1 < device_id)
                                              Rows Removed by Filter: 3
                      ->  Index Scan Backward using _hyper_2_12_chunk_metrics_space_time_idx on _hyper_2_12_chunk (actual rows=0 loops=1)
@@ -4649,7 +4649,7 @@ LIMIT 10;
                                  Sort Method: quicksort 
                                  ->  Custom Scan (DecompressChunk) on _hyper_2_4_chunk (actual rows=360 loops=1)
                                        Filter: (device_id < v0)
-                                       ->  Seq Scan on compress_hyper_6_17_chunk (actual rows=1 loops=1)
+                                       ->  Seq Scan on compress_hyper_6_18_chunk (actual rows=1 loops=1)
                                              Filter: (_ts_meta_max_1 > device_id)
                      ->  Sort (actual rows=7 loops=1)
                            Sort Key: _hyper_2_5_chunk."time"
@@ -4659,7 +4659,7 @@ LIMIT 10;
                                  Sort Method: quicksort 
                                  ->  Custom Scan (DecompressChunk) on _hyper_2_5_chunk (actual rows=1080 loops=1)
                                        Filter: (device_id < v0)
-                                       ->  Seq Scan on compress_hyper_6_18_chunk (actual rows=3 loops=1)
+                                       ->  Seq Scan on compress_hyper_6_19_chunk (actual rows=3 loops=1)
                                              Filter: (_ts_meta_max_1 > device_id)
                      ->  Sort (actual rows=3 loops=1)
                            Sort Key: _hyper_2_6_chunk."time"
@@ -4669,7 +4669,7 @@ LIMIT 10;
                                  Sort Method: quicksort 
                                  ->  Custom Scan (DecompressChunk) on _hyper_2_6_chunk (actual rows=360 loops=1)
                                        Filter: (device_id < v0)
-                                       ->  Seq Scan on compress_hyper_6_19_chunk (actual rows=1 loops=1)
+                                       ->  Seq Scan on compress_hyper_6_20_chunk (actual rows=1 loops=1)
                                              Filter: (_ts_meta_max_1 > device_id)
                ->  Merge Append (never executed)
                      Sort Key: _hyper_2_7_chunk."time"
@@ -4687,7 +4687,7 @@ LIMIT 10;
                                  Sort Key: _hyper_2_10_chunk."time"
                                  ->  Custom Scan (DecompressChunk) on _hyper_2_10_chunk (never executed)
                                        Filter: (device_id < v0)
-                                       ->  Seq Scan on compress_hyper_6_20_chunk (never executed)
+                                       ->  Seq Scan on compress_hyper_6_24_chunk (never executed)
                                              Filter: (_ts_meta_max_1 > device_id)
                      ->  Sort (never executed)
                            Sort Key: _hyper_2_11_chunk."time"
@@ -4695,7 +4695,7 @@ LIMIT 10;
                                  Sort Key: _hyper_2_11_chunk."time"
                                  ->  Custom Scan (DecompressChunk) on _hyper_2_11_chunk (never executed)
                                        Filter: (device_id < v0)
-                                       ->  Seq Scan on compress_hyper_6_21_chunk (never executed)
+                                       ->  Seq Scan on compress_hyper_6_25_chunk (never executed)
                                              Filter: (_ts_meta_max_1 > device_id)
                      ->  Index Scan Backward using _hyper_2_12_chunk_metrics_space_time_idx on _hyper_2_12_chunk (never executed)
                            Filter: (device_id < v0)
@@ -4728,7 +4728,7 @@ LIMIT 10;
                                  ->  Custom Scan (DecompressChunk) on _hyper_2_4_chunk (actual rows=0 loops=1)
                                        Filter: (v1 = (device_id)::double precision)
                                        Rows Removed by Filter: 360
-                                       ->  Seq Scan on compress_hyper_6_17_chunk (actual rows=1 loops=1)
+                                       ->  Seq Scan on compress_hyper_6_18_chunk (actual rows=1 loops=1)
                      ->  Sort (actual rows=0 loops=1)
                            Sort Key: _hyper_2_5_chunk."time"
                            Sort Method: quicksort 
@@ -4738,7 +4738,7 @@ LIMIT 10;
                                  ->  Custom Scan (DecompressChunk) on _hyper_2_5_chunk (actual rows=0 loops=1)
                                        Filter: (v1 = (device_id)::double precision)
                                        Rows Removed by Filter: 1080
-                                       ->  Seq Scan on compress_hyper_6_18_chunk (actual rows=3 loops=1)
+                                       ->  Seq Scan on compress_hyper_6_19_chunk (actual rows=3 loops=1)
                      ->  Sort (actual rows=0 loops=1)
                            Sort Key: _hyper_2_6_chunk."time"
                            Sort Method: quicksort 
@@ -4748,7 +4748,7 @@ LIMIT 10;
                                  ->  Custom Scan (DecompressChunk) on _hyper_2_6_chunk (actual rows=0 loops=1)
                                        Filter: (v1 = (device_id)::double precision)
                                        Rows Removed by Filter: 360
-                                       ->  Seq Scan on compress_hyper_6_19_chunk (actual rows=1 loops=1)
+                                       ->  Seq Scan on compress_hyper_6_20_chunk (actual rows=1 loops=1)
                ->  Merge Append (actual rows=0 loops=1)
                      Sort Key: _hyper_2_7_chunk."time"
                      ->  Index Scan Backward using _hyper_2_7_chunk_metrics_space_time_idx on _hyper_2_7_chunk (actual rows=0 loops=1)
@@ -4771,7 +4771,7 @@ LIMIT 10;
                                  ->  Custom Scan (DecompressChunk) on _hyper_2_10_chunk (actual rows=0 loops=1)
                                        Filter: (v1 = (device_id)::double precision)
                                        Rows Removed by Filter: 504
-                                       ->  Seq Scan on compress_hyper_6_20_chunk (actual rows=1 loops=1)
+                                       ->  Seq Scan on compress_hyper_6_24_chunk (actual rows=1 loops=1)
                      ->  Sort (actual rows=0 loops=1)
                            Sort Key: _hyper_2_11_chunk."time"
                            Sort Method: quicksort 
@@ -4781,7 +4781,7 @@ LIMIT 10;
                                  ->  Custom Scan (DecompressChunk) on _hyper_2_11_chunk (actual rows=0 loops=1)
                                        Filter: (v1 = (device_id)::double precision)
                                        Rows Removed by Filter: 1512
-                                       ->  Seq Scan on compress_hyper_6_21_chunk (actual rows=3 loops=1)
+                                       ->  Seq Scan on compress_hyper_6_25_chunk (actual rows=3 loops=1)
                      ->  Index Scan Backward using _hyper_2_12_chunk_metrics_space_time_idx on _hyper_2_12_chunk (actual rows=0 loops=1)
                            Filter: (v1 = (device_id)::double precision)
                            Rows Removed by Filter: 504
@@ -4815,7 +4815,7 @@ LIMIT 10;
                                  ->  Custom Scan (DecompressChunk) on _hyper_2_4_chunk (actual rows=0 loops=1)
                                        Filter: ((v0)::double precision = v1)
                                        Rows Removed by Filter: 360
-                                       ->  Seq Scan on compress_hyper_6_17_chunk (actual rows=1 loops=1)
+                                       ->  Seq Scan on compress_hyper_6_18_chunk (actual rows=1 loops=1)
                      ->  Sort (actual rows=0 loops=1)
                            Sort Key: _hyper_2_5_chunk."time"
                            Sort Method: quicksort 
@@ -4825,7 +4825,7 @@ LIMIT 10;
                                  ->  Custom Scan (DecompressChunk) on _hyper_2_5_chunk (actual rows=0 loops=1)
                                        Filter: ((v0)::double precision = v1)
                                        Rows Removed by Filter: 1080
-                                       ->  Seq Scan on compress_hyper_6_18_chunk (actual rows=3 loops=1)
+                                       ->  Seq Scan on compress_hyper_6_19_chunk (actual rows=3 loops=1)
                      ->  Sort (actual rows=0 loops=1)
                            Sort Key: _hyper_2_6_chunk."time"
                            Sort Method: quicksort 
@@ -4835,7 +4835,7 @@ LIMIT 10;
                                  ->  Custom Scan (DecompressChunk) on _hyper_2_6_chunk (actual rows=0 loops=1)
                                        Filter: ((v0)::double precision = v1)
                                        Rows Removed by Filter: 360
-                                       ->  Seq Scan on compress_hyper_6_19_chunk (actual rows=1 loops=1)
+                                       ->  Seq Scan on compress_hyper_6_20_chunk (actual rows=1 loops=1)
                ->  Merge Append (actual rows=0 loops=1)
                      Sort Key: _hyper_2_7_chunk."time"
                      ->  Index Scan Backward using _hyper_2_7_chunk_metrics_space_time_idx on _hyper_2_7_chunk (actual rows=0 loops=1)
@@ -4858,7 +4858,7 @@ LIMIT 10;
                                  ->  Custom Scan (DecompressChunk) on _hyper_2_10_chunk (actual rows=0 loops=1)
                                        Filter: ((v0)::double precision = v1)
                                        Rows Removed by Filter: 504
-                                       ->  Seq Scan on compress_hyper_6_20_chunk (actual rows=1 loops=1)
+                                       ->  Seq Scan on compress_hyper_6_24_chunk (actual rows=1 loops=1)
                      ->  Sort (actual rows=0 loops=1)
                            Sort Key: _hyper_2_11_chunk."time"
                            Sort Method: quicksort 
@@ -4868,7 +4868,7 @@ LIMIT 10;
                                  ->  Custom Scan (DecompressChunk) on _hyper_2_11_chunk (actual rows=0 loops=1)
                                        Filter: ((v0)::double precision = v1)
                                        Rows Removed by Filter: 1512
-                                       ->  Seq Scan on compress_hyper_6_21_chunk (actual rows=3 loops=1)
+                                       ->  Seq Scan on compress_hyper_6_25_chunk (actual rows=3 loops=1)
                      ->  Index Scan Backward using _hyper_2_12_chunk_metrics_space_time_idx on _hyper_2_12_chunk (actual rows=0 loops=1)
                            Filter: ((v0)::double precision = v1)
                            Rows Removed by Filter: 504
@@ -4901,9 +4901,9 @@ LIMIT 10;
                      Filter: (_hyper_2_4_chunk."time" > 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
                      Rows Removed by Filter: 4
                      Bulk Decompression: true
-                     ->  Seq Scan on _timescaledb_internal.compress_hyper_6_17_chunk (actual rows=1 loops=1)
-                           Output: compress_hyper_6_17_chunk."time", compress_hyper_6_17_chunk.device_id, compress_hyper_6_17_chunk.device_id_peer, compress_hyper_6_17_chunk.v0, compress_hyper_6_17_chunk.v1, compress_hyper_6_17_chunk.v2, compress_hyper_6_17_chunk.v3, compress_hyper_6_17_chunk._ts_meta_count, compress_hyper_6_17_chunk._ts_meta_sequence_num, compress_hyper_6_17_chunk._ts_meta_min_3, compress_hyper_6_17_chunk._ts_meta_max_3, compress_hyper_6_17_chunk._ts_meta_min_1, compress_hyper_6_17_chunk._ts_meta_max_1, compress_hyper_6_17_chunk._ts_meta_min_2, compress_hyper_6_17_chunk._ts_meta_max_2
-                           Filter: ((compress_hyper_6_17_chunk._ts_meta_max_3 > 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone) AND (compress_hyper_6_17_chunk.device_id = 1))
+                     ->  Seq Scan on _timescaledb_internal.compress_hyper_6_18_chunk (actual rows=1 loops=1)
+                           Output: compress_hyper_6_18_chunk."time", compress_hyper_6_18_chunk.device_id, compress_hyper_6_18_chunk.device_id_peer, compress_hyper_6_18_chunk.v0, compress_hyper_6_18_chunk.v1, compress_hyper_6_18_chunk.v2, compress_hyper_6_18_chunk.v3, compress_hyper_6_18_chunk._ts_meta_count, compress_hyper_6_18_chunk._ts_meta_sequence_num, compress_hyper_6_18_chunk._ts_meta_min_3, compress_hyper_6_18_chunk._ts_meta_max_3, compress_hyper_6_18_chunk._ts_meta_min_1, compress_hyper_6_18_chunk._ts_meta_max_1, compress_hyper_6_18_chunk._ts_meta_min_2, compress_hyper_6_18_chunk._ts_meta_max_2
+                           Filter: ((compress_hyper_6_18_chunk._ts_meta_max_3 > 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone) AND (compress_hyper_6_18_chunk.device_id = 1))
          ->  Index Scan Backward using _hyper_2_7_chunk_metrics_space_time_idx on _timescaledb_internal._hyper_2_7_chunk (never executed)
                Output: _hyper_2_7_chunk."time", _hyper_2_7_chunk.device_id, _hyper_2_7_chunk.device_id_peer, _hyper_2_7_chunk.v0, _hyper_2_7_chunk.v1, _hyper_2_7_chunk.v2, _hyper_2_7_chunk.v3
                Index Cond: (_hyper_2_7_chunk."time" > 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
@@ -4915,9 +4915,9 @@ LIMIT 10;
                      Output: _hyper_2_10_chunk."time", _hyper_2_10_chunk.device_id, _hyper_2_10_chunk.device_id_peer, _hyper_2_10_chunk.v0, _hyper_2_10_chunk.v1, _hyper_2_10_chunk.v2, _hyper_2_10_chunk.v3
                      Filter: (_hyper_2_10_chunk."time" > 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
                      Bulk Decompression: true
-                     ->  Seq Scan on _timescaledb_internal.compress_hyper_6_20_chunk (never executed)
-                           Output: compress_hyper_6_20_chunk."time", compress_hyper_6_20_chunk.device_id, compress_hyper_6_20_chunk.device_id_peer, compress_hyper_6_20_chunk.v0, compress_hyper_6_20_chunk.v1, compress_hyper_6_20_chunk.v2, compress_hyper_6_20_chunk.v3, compress_hyper_6_20_chunk._ts_meta_count, compress_hyper_6_20_chunk._ts_meta_sequence_num, compress_hyper_6_20_chunk._ts_meta_min_3, compress_hyper_6_20_chunk._ts_meta_max_3, compress_hyper_6_20_chunk._ts_meta_min_1, compress_hyper_6_20_chunk._ts_meta_max_1, compress_hyper_6_20_chunk._ts_meta_min_2, compress_hyper_6_20_chunk._ts_meta_max_2
-                           Filter: ((compress_hyper_6_20_chunk._ts_meta_max_3 > 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone) AND (compress_hyper_6_20_chunk.device_id = 1))
+                     ->  Seq Scan on _timescaledb_internal.compress_hyper_6_24_chunk (never executed)
+                           Output: compress_hyper_6_24_chunk."time", compress_hyper_6_24_chunk.device_id, compress_hyper_6_24_chunk.device_id_peer, compress_hyper_6_24_chunk.v0, compress_hyper_6_24_chunk.v1, compress_hyper_6_24_chunk.v2, compress_hyper_6_24_chunk.v3, compress_hyper_6_24_chunk._ts_meta_count, compress_hyper_6_24_chunk._ts_meta_sequence_num, compress_hyper_6_24_chunk._ts_meta_min_3, compress_hyper_6_24_chunk._ts_meta_max_3, compress_hyper_6_24_chunk._ts_meta_min_1, compress_hyper_6_24_chunk._ts_meta_max_1, compress_hyper_6_24_chunk._ts_meta_min_2, compress_hyper_6_24_chunk._ts_meta_max_2
+                           Filter: ((compress_hyper_6_24_chunk._ts_meta_max_3 > 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone) AND (compress_hyper_6_24_chunk.device_id = 1))
 (33 rows)
 
 --pushdown of quals on order by and segment by cols or together (not pushed down)
@@ -4948,7 +4948,7 @@ LIMIT 10;
                                  Sort Method: quicksort 
                                  ->  Custom Scan (DecompressChunk) on _hyper_2_4_chunk (actual rows=360 loops=1)
                                        Filter: (("time" > 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone) OR (device_id = 1))
-                                       ->  Seq Scan on compress_hyper_6_17_chunk (actual rows=1 loops=1)
+                                       ->  Seq Scan on compress_hyper_6_18_chunk (actual rows=1 loops=1)
                      ->  Sort (actual rows=7 loops=1)
                            Sort Key: _hyper_2_5_chunk."time"
                            Sort Method: quicksort 
@@ -4958,7 +4958,7 @@ LIMIT 10;
                                  ->  Custom Scan (DecompressChunk) on _hyper_2_5_chunk (actual rows=1068 loops=1)
                                        Filter: (("time" > 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone) OR (device_id = 1))
                                        Rows Removed by Filter: 12
-                                       ->  Seq Scan on compress_hyper_6_18_chunk (actual rows=3 loops=1)
+                                       ->  Seq Scan on compress_hyper_6_19_chunk (actual rows=3 loops=1)
                      ->  Sort (actual rows=3 loops=1)
                            Sort Key: _hyper_2_6_chunk."time"
                            Sort Method: quicksort 
@@ -4968,7 +4968,7 @@ LIMIT 10;
                                  ->  Custom Scan (DecompressChunk) on _hyper_2_6_chunk (actual rows=356 loops=1)
                                        Filter: (("time" > 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone) OR (device_id = 1))
                                        Rows Removed by Filter: 4
-                                       ->  Seq Scan on compress_hyper_6_19_chunk (actual rows=1 loops=1)
+                                       ->  Seq Scan on compress_hyper_6_20_chunk (actual rows=1 loops=1)
                ->  Merge Append (never executed)
                      Sort Key: _hyper_2_7_chunk."time"
                      ->  Index Scan Backward using _hyper_2_7_chunk_metrics_space_time_idx on _hyper_2_7_chunk (never executed)
@@ -4985,14 +4985,14 @@ LIMIT 10;
                                  Sort Key: _hyper_2_10_chunk."time"
                                  ->  Custom Scan (DecompressChunk) on _hyper_2_10_chunk (never executed)
                                        Filter: (("time" > 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone) OR (device_id = 1))
-                                       ->  Seq Scan on compress_hyper_6_20_chunk (never executed)
+                                       ->  Seq Scan on compress_hyper_6_24_chunk (never executed)
                      ->  Sort (never executed)
                            Sort Key: _hyper_2_11_chunk."time"
                            ->  Sort (never executed)
                                  Sort Key: _hyper_2_11_chunk."time"
                                  ->  Custom Scan (DecompressChunk) on _hyper_2_11_chunk (never executed)
                                        Filter: (("time" > 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone) OR (device_id = 1))
-                                       ->  Seq Scan on compress_hyper_6_21_chunk (never executed)
+                                       ->  Seq Scan on compress_hyper_6_25_chunk (never executed)
                      ->  Index Scan Backward using _hyper_2_12_chunk_metrics_space_time_idx on _hyper_2_12_chunk (never executed)
                            Filter: (("time" > 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone) OR (device_id = 1))
 (64 rows)
@@ -5024,7 +5024,7 @@ LIMIT 10;
                                  Sort Method: quicksort 
                                  ->  Custom Scan (DecompressChunk) on _hyper_2_4_chunk (actual rows=360 loops=1)
                                        Filter: ("time" < now())
-                                       ->  Seq Scan on compress_hyper_6_17_chunk (actual rows=1 loops=1)
+                                       ->  Seq Scan on compress_hyper_6_18_chunk (actual rows=1 loops=1)
                      ->  Sort (actual rows=7 loops=1)
                            Sort Key: _hyper_2_5_chunk."time"
                            Sort Method: quicksort 
@@ -5033,7 +5033,7 @@ LIMIT 10;
                                  Sort Method: quicksort 
                                  ->  Custom Scan (DecompressChunk) on _hyper_2_5_chunk (actual rows=1080 loops=1)
                                        Filter: ("time" < now())
-                                       ->  Seq Scan on compress_hyper_6_18_chunk (actual rows=3 loops=1)
+                                       ->  Seq Scan on compress_hyper_6_19_chunk (actual rows=3 loops=1)
                      ->  Sort (actual rows=3 loops=1)
                            Sort Key: _hyper_2_6_chunk."time"
                            Sort Method: quicksort 
@@ -5042,7 +5042,7 @@ LIMIT 10;
                                  Sort Method: quicksort 
                                  ->  Custom Scan (DecompressChunk) on _hyper_2_6_chunk (actual rows=360 loops=1)
                                        Filter: ("time" < now())
-                                       ->  Seq Scan on compress_hyper_6_19_chunk (actual rows=1 loops=1)
+                                       ->  Seq Scan on compress_hyper_6_20_chunk (actual rows=1 loops=1)
                ->  Merge Append (never executed)
                      Sort Key: _hyper_2_7_chunk."time"
                      ->  Index Scan Backward using _hyper_2_7_chunk_metrics_space_time_idx on _hyper_2_7_chunk (never executed)
@@ -5059,14 +5059,14 @@ LIMIT 10;
                                  Sort Key: _hyper_2_10_chunk."time"
                                  ->  Custom Scan (DecompressChunk) on _hyper_2_10_chunk (never executed)
                                        Filter: ("time" < now())
-                                       ->  Seq Scan on compress_hyper_6_20_chunk (never executed)
+                                       ->  Seq Scan on compress_hyper_6_24_chunk (never executed)
                      ->  Sort (never executed)
                            Sort Key: _hyper_2_11_chunk."time"
                            ->  Sort (never executed)
                                  Sort Key: _hyper_2_11_chunk."time"
                                  ->  Custom Scan (DecompressChunk) on _hyper_2_11_chunk (never executed)
                                        Filter: ("time" < now())
-                                       ->  Seq Scan on compress_hyper_6_21_chunk (never executed)
+                                       ->  Seq Scan on compress_hyper_6_25_chunk (never executed)
                      ->  Index Scan Backward using _hyper_2_12_chunk_metrics_space_time_idx on _hyper_2_12_chunk (never executed)
                            Index Cond: ("time" < now())
 (62 rows)
@@ -5093,7 +5093,7 @@ LIMIT 10;
                            Sort Key: _hyper_2_11_chunk."time" DESC
                            Sort Method: quicksort 
                            ->  Custom Scan (DecompressChunk) on _hyper_2_11_chunk (actual rows=1512 loops=1)
-                                 ->  Seq Scan on compress_hyper_6_21_chunk (actual rows=3 loops=1)
+                                 ->  Seq Scan on compress_hyper_6_25_chunk (actual rows=3 loops=1)
                ->  Sort (actual rows=3 loops=1)
                      Sort Key: _hyper_2_10_chunk."time" DESC
                      Sort Method: top-N heapsort 
@@ -5101,7 +5101,7 @@ LIMIT 10;
                            Sort Key: _hyper_2_10_chunk."time" DESC
                            Sort Method: quicksort 
                            ->  Custom Scan (DecompressChunk) on _hyper_2_10_chunk (actual rows=504 loops=1)
-                                 ->  Seq Scan on compress_hyper_6_20_chunk (actual rows=1 loops=1)
+                                 ->  Seq Scan on compress_hyper_6_24_chunk (actual rows=1 loops=1)
          ->  Merge Append (never executed)
                Sort Key: _hyper_2_9_chunk."time" DESC
                ->  Index Only Scan using _hyper_2_9_chunk_metrics_space_time_idx on _hyper_2_9_chunk (never executed)
@@ -5117,19 +5117,19 @@ LIMIT 10;
                      ->  Sort (never executed)
                            Sort Key: _hyper_2_6_chunk."time" DESC
                            ->  Custom Scan (DecompressChunk) on _hyper_2_6_chunk (never executed)
-                                 ->  Seq Scan on compress_hyper_6_19_chunk (never executed)
+                                 ->  Seq Scan on compress_hyper_6_20_chunk (never executed)
                ->  Sort (never executed)
                      Sort Key: _hyper_2_5_chunk."time" DESC
                      ->  Sort (never executed)
                            Sort Key: _hyper_2_5_chunk."time" DESC
                            ->  Custom Scan (DecompressChunk) on _hyper_2_5_chunk (never executed)
-                                 ->  Seq Scan on compress_hyper_6_18_chunk (never executed)
+                                 ->  Seq Scan on compress_hyper_6_19_chunk (never executed)
                ->  Sort (never executed)
                      Sort Key: _hyper_2_4_chunk."time" DESC
                      ->  Sort (never executed)
                            Sort Key: _hyper_2_4_chunk."time" DESC
                            ->  Custom Scan (DecompressChunk) on _hyper_2_4_chunk (never executed)
-                                 ->  Seq Scan on compress_hyper_6_17_chunk (never executed)
+                                 ->  Seq Scan on compress_hyper_6_18_chunk (never executed)
 (51 rows)
 
 :PREFIX
@@ -5158,7 +5158,7 @@ LIMIT 10;
                                  Sort Key: _hyper_2_11_chunk."time" DESC
                                  Sort Method: quicksort 
                                  ->  Custom Scan (DecompressChunk) on _hyper_2_11_chunk (actual rows=1512 loops=1)
-                                       ->  Seq Scan on compress_hyper_6_21_chunk (actual rows=3 loops=1)
+                                       ->  Seq Scan on compress_hyper_6_25_chunk (actual rows=3 loops=1)
                      ->  Sort (actual rows=3 loops=1)
                            Sort Key: _hyper_2_10_chunk."time" DESC
                            Sort Method: quicksort 
@@ -5166,7 +5166,7 @@ LIMIT 10;
                                  Sort Key: _hyper_2_10_chunk."time" DESC
                                  Sort Method: quicksort 
                                  ->  Custom Scan (DecompressChunk) on _hyper_2_10_chunk (actual rows=504 loops=1)
-                                       ->  Seq Scan on compress_hyper_6_20_chunk (actual rows=1 loops=1)
+                                       ->  Seq Scan on compress_hyper_6_24_chunk (actual rows=1 loops=1)
                ->  Merge Append (never executed)
                      Sort Key: _hyper_2_9_chunk."time" DESC
                      ->  Index Scan using _hyper_2_9_chunk_metrics_space_time_idx on _hyper_2_9_chunk (never executed)
@@ -5179,19 +5179,19 @@ LIMIT 10;
                            ->  Sort (never executed)
                                  Sort Key: _hyper_2_6_chunk."time" DESC
                                  ->  Custom Scan (DecompressChunk) on _hyper_2_6_chunk (never executed)
-                                       ->  Seq Scan on compress_hyper_6_19_chunk (never executed)
+                                       ->  Seq Scan on compress_hyper_6_20_chunk (never executed)
                      ->  Sort (never executed)
                            Sort Key: _hyper_2_5_chunk."time" DESC
                            ->  Sort (never executed)
                                  Sort Key: _hyper_2_5_chunk."time" DESC
                                  ->  Custom Scan (DecompressChunk) on _hyper_2_5_chunk (never executed)
-                                       ->  Seq Scan on compress_hyper_6_18_chunk (never executed)
+                                       ->  Seq Scan on compress_hyper_6_19_chunk (never executed)
                      ->  Sort (never executed)
                            Sort Key: _hyper_2_4_chunk."time" DESC
                            ->  Sort (never executed)
                                  Sort Key: _hyper_2_4_chunk."time" DESC
                                  ->  Custom Scan (DecompressChunk) on _hyper_2_4_chunk (never executed)
-                                       ->  Seq Scan on compress_hyper_6_17_chunk (never executed)
+                                       ->  Seq Scan on compress_hyper_6_18_chunk (never executed)
 (51 rows)
 
 :PREFIX
@@ -5210,17 +5210,17 @@ LIMIT 10;
                Sort Key: _hyper_2_4_chunk.device_id, _hyper_2_4_chunk."time" DESC
                Sort Method: top-N heapsort 
                ->  Custom Scan (DecompressChunk) on _hyper_2_4_chunk (actual rows=360 loops=1)
-                     ->  Seq Scan on compress_hyper_6_17_chunk (actual rows=1 loops=1)
+                     ->  Seq Scan on compress_hyper_6_18_chunk (actual rows=1 loops=1)
          ->  Sort (actual rows=1 loops=1)
                Sort Key: _hyper_2_5_chunk.device_id, _hyper_2_5_chunk."time" DESC
                Sort Method: top-N heapsort 
                ->  Custom Scan (DecompressChunk) on _hyper_2_5_chunk (actual rows=1080 loops=1)
-                     ->  Seq Scan on compress_hyper_6_18_chunk (actual rows=3 loops=1)
+                     ->  Seq Scan on compress_hyper_6_19_chunk (actual rows=3 loops=1)
          ->  Sort (actual rows=1 loops=1)
                Sort Key: _hyper_2_6_chunk.device_id, _hyper_2_6_chunk."time" DESC
                Sort Method: top-N heapsort 
                ->  Custom Scan (DecompressChunk) on _hyper_2_6_chunk (actual rows=360 loops=1)
-                     ->  Seq Scan on compress_hyper_6_19_chunk (actual rows=1 loops=1)
+                     ->  Seq Scan on compress_hyper_6_20_chunk (actual rows=1 loops=1)
          ->  Index Only Scan using _hyper_2_7_chunk_metrics_space_device_id_time_idx on _hyper_2_7_chunk (actual rows=1 loops=1)
                Heap Fetches: 1
          ->  Index Only Scan using _hyper_2_8_chunk_metrics_space_device_id_time_idx on _hyper_2_8_chunk (actual rows=1 loops=1)
@@ -5231,12 +5231,12 @@ LIMIT 10;
                Sort Key: _hyper_2_10_chunk.device_id, _hyper_2_10_chunk."time" DESC
                Sort Method: top-N heapsort 
                ->  Custom Scan (DecompressChunk) on _hyper_2_10_chunk (actual rows=504 loops=1)
-                     ->  Seq Scan on compress_hyper_6_20_chunk (actual rows=1 loops=1)
+                     ->  Seq Scan on compress_hyper_6_24_chunk (actual rows=1 loops=1)
          ->  Sort (actual rows=1 loops=1)
                Sort Key: _hyper_2_11_chunk.device_id, _hyper_2_11_chunk."time" DESC
                Sort Method: top-N heapsort 
                ->  Custom Scan (DecompressChunk) on _hyper_2_11_chunk (actual rows=1512 loops=1)
-                     ->  Seq Scan on compress_hyper_6_21_chunk (actual rows=3 loops=1)
+                     ->  Seq Scan on compress_hyper_6_25_chunk (actual rows=3 loops=1)
          ->  Index Only Scan using _hyper_2_12_chunk_metrics_space_device_id_time_idx on _hyper_2_12_chunk (actual rows=1 loops=1)
                Heap Fetches: 1
 (36 rows)
@@ -5288,9 +5288,9 @@ ORDER BY time,
                                  Output: _hyper_2_10_chunk."time", _hyper_2_10_chunk.device_id, _hyper_2_10_chunk.device_id_peer, _hyper_2_10_chunk.v0, _hyper_2_10_chunk.v1, _hyper_2_10_chunk.v2, _hyper_2_10_chunk.v3
                                  Filter: (_hyper_2_10_chunk."time" > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
                                  Bulk Decompression: true
-                                 ->  Seq Scan on _timescaledb_internal.compress_hyper_6_20_chunk (actual rows=1 loops=1)
-                                       Output: compress_hyper_6_20_chunk."time", compress_hyper_6_20_chunk.device_id, compress_hyper_6_20_chunk.device_id_peer, compress_hyper_6_20_chunk.v0, compress_hyper_6_20_chunk.v1, compress_hyper_6_20_chunk.v2, compress_hyper_6_20_chunk.v3, compress_hyper_6_20_chunk._ts_meta_count, compress_hyper_6_20_chunk._ts_meta_sequence_num, compress_hyper_6_20_chunk._ts_meta_min_3, compress_hyper_6_20_chunk._ts_meta_max_3, compress_hyper_6_20_chunk._ts_meta_min_1, compress_hyper_6_20_chunk._ts_meta_max_1, compress_hyper_6_20_chunk._ts_meta_min_2, compress_hyper_6_20_chunk._ts_meta_max_2
-                                       Filter: (compress_hyper_6_20_chunk._ts_meta_max_3 > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
+                                 ->  Seq Scan on _timescaledb_internal.compress_hyper_6_24_chunk (actual rows=1 loops=1)
+                                       Output: compress_hyper_6_24_chunk."time", compress_hyper_6_24_chunk.device_id, compress_hyper_6_24_chunk.device_id_peer, compress_hyper_6_24_chunk.v0, compress_hyper_6_24_chunk.v1, compress_hyper_6_24_chunk.v2, compress_hyper_6_24_chunk.v3, compress_hyper_6_24_chunk._ts_meta_count, compress_hyper_6_24_chunk._ts_meta_sequence_num, compress_hyper_6_24_chunk._ts_meta_min_3, compress_hyper_6_24_chunk._ts_meta_max_3, compress_hyper_6_24_chunk._ts_meta_min_1, compress_hyper_6_24_chunk._ts_meta_max_1, compress_hyper_6_24_chunk._ts_meta_min_2, compress_hyper_6_24_chunk._ts_meta_max_2
+                                       Filter: (compress_hyper_6_24_chunk._ts_meta_max_3 > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
                ->  Sort (actual rows=1512 loops=1)
                      Output: _hyper_2_11_chunk."time", _hyper_2_11_chunk.device_id, _hyper_2_11_chunk.device_id_peer, _hyper_2_11_chunk.v0, _hyper_2_11_chunk.v1, _hyper_2_11_chunk.v2, _hyper_2_11_chunk.v3
                      Sort Key: _hyper_2_11_chunk."time"
@@ -5303,9 +5303,9 @@ ORDER BY time,
                                  Output: _hyper_2_11_chunk."time", _hyper_2_11_chunk.device_id, _hyper_2_11_chunk.device_id_peer, _hyper_2_11_chunk.v0, _hyper_2_11_chunk.v1, _hyper_2_11_chunk.v2, _hyper_2_11_chunk.v3
                                  Filter: (_hyper_2_11_chunk."time" > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
                                  Bulk Decompression: true
-                                 ->  Seq Scan on _timescaledb_internal.compress_hyper_6_21_chunk (actual rows=3 loops=1)
-                                       Output: compress_hyper_6_21_chunk."time", compress_hyper_6_21_chunk.device_id, compress_hyper_6_21_chunk.device_id_peer, compress_hyper_6_21_chunk.v0, compress_hyper_6_21_chunk.v1, compress_hyper_6_21_chunk.v2, compress_hyper_6_21_chunk.v3, compress_hyper_6_21_chunk._ts_meta_count, compress_hyper_6_21_chunk._ts_meta_sequence_num, compress_hyper_6_21_chunk._ts_meta_min_3, compress_hyper_6_21_chunk._ts_meta_max_3, compress_hyper_6_21_chunk._ts_meta_min_1, compress_hyper_6_21_chunk._ts_meta_max_1, compress_hyper_6_21_chunk._ts_meta_min_2, compress_hyper_6_21_chunk._ts_meta_max_2
-                                       Filter: (compress_hyper_6_21_chunk._ts_meta_max_3 > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
+                                 ->  Seq Scan on _timescaledb_internal.compress_hyper_6_25_chunk (actual rows=3 loops=1)
+                                       Output: compress_hyper_6_25_chunk."time", compress_hyper_6_25_chunk.device_id, compress_hyper_6_25_chunk.device_id_peer, compress_hyper_6_25_chunk.v0, compress_hyper_6_25_chunk.v1, compress_hyper_6_25_chunk.v2, compress_hyper_6_25_chunk.v3, compress_hyper_6_25_chunk._ts_meta_count, compress_hyper_6_25_chunk._ts_meta_sequence_num, compress_hyper_6_25_chunk._ts_meta_min_3, compress_hyper_6_25_chunk._ts_meta_max_3, compress_hyper_6_25_chunk._ts_meta_min_1, compress_hyper_6_25_chunk._ts_meta_max_1, compress_hyper_6_25_chunk._ts_meta_min_2, compress_hyper_6_25_chunk._ts_meta_max_2
+                                       Filter: (compress_hyper_6_25_chunk._ts_meta_max_3 > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
                ->  Index Scan Backward using _hyper_2_12_chunk_metrics_space_time_idx on _timescaledb_internal._hyper_2_12_chunk (actual rows=504 loops=1)
                      Output: _hyper_2_12_chunk."time", _hyper_2_12_chunk.device_id, _hyper_2_12_chunk.device_id_peer, _hyper_2_12_chunk.v0, _hyper_2_12_chunk.v1, _hyper_2_12_chunk.v2, _hyper_2_12_chunk.v3
                      Index Cond: (_hyper_2_12_chunk."time" > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
@@ -5338,16 +5338,16 @@ ORDER BY device_id,
          Output: _hyper_2_10_chunk."time", _hyper_2_10_chunk.device_id, _hyper_2_10_chunk.device_id_peer, _hyper_2_10_chunk.v0, _hyper_2_10_chunk.v1, _hyper_2_10_chunk.v2, _hyper_2_10_chunk.v3
          Filter: (_hyper_2_10_chunk."time" > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
          Bulk Decompression: true
-         ->  Index Scan using compress_hyper_6_20_chunk__compressed_hypertable_6_device_id_de on _timescaledb_internal.compress_hyper_6_20_chunk (actual rows=1 loops=1)
-               Output: compress_hyper_6_20_chunk."time", compress_hyper_6_20_chunk.device_id, compress_hyper_6_20_chunk.device_id_peer, compress_hyper_6_20_chunk.v0, compress_hyper_6_20_chunk.v1, compress_hyper_6_20_chunk.v2, compress_hyper_6_20_chunk.v3, compress_hyper_6_20_chunk._ts_meta_count, compress_hyper_6_20_chunk._ts_meta_sequence_num, compress_hyper_6_20_chunk._ts_meta_min_3, compress_hyper_6_20_chunk._ts_meta_max_3, compress_hyper_6_20_chunk._ts_meta_min_1, compress_hyper_6_20_chunk._ts_meta_max_1, compress_hyper_6_20_chunk._ts_meta_min_2, compress_hyper_6_20_chunk._ts_meta_max_2
-               Filter: (compress_hyper_6_20_chunk._ts_meta_max_3 > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
+         ->  Index Scan using compress_hyper_6_24_chunk__compressed_hypertable_6_device_id_de on _timescaledb_internal.compress_hyper_6_24_chunk (actual rows=1 loops=1)
+               Output: compress_hyper_6_24_chunk."time", compress_hyper_6_24_chunk.device_id, compress_hyper_6_24_chunk.device_id_peer, compress_hyper_6_24_chunk.v0, compress_hyper_6_24_chunk.v1, compress_hyper_6_24_chunk.v2, compress_hyper_6_24_chunk.v3, compress_hyper_6_24_chunk._ts_meta_count, compress_hyper_6_24_chunk._ts_meta_sequence_num, compress_hyper_6_24_chunk._ts_meta_min_3, compress_hyper_6_24_chunk._ts_meta_max_3, compress_hyper_6_24_chunk._ts_meta_min_1, compress_hyper_6_24_chunk._ts_meta_max_1, compress_hyper_6_24_chunk._ts_meta_min_2, compress_hyper_6_24_chunk._ts_meta_max_2
+               Filter: (compress_hyper_6_24_chunk._ts_meta_max_3 > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
    ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_11_chunk (actual rows=1512 loops=1)
          Output: _hyper_2_11_chunk."time", _hyper_2_11_chunk.device_id, _hyper_2_11_chunk.device_id_peer, _hyper_2_11_chunk.v0, _hyper_2_11_chunk.v1, _hyper_2_11_chunk.v2, _hyper_2_11_chunk.v3
          Filter: (_hyper_2_11_chunk."time" > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
          Bulk Decompression: true
-         ->  Index Scan using compress_hyper_6_21_chunk__compressed_hypertable_6_device_id_de on _timescaledb_internal.compress_hyper_6_21_chunk (actual rows=3 loops=1)
-               Output: compress_hyper_6_21_chunk."time", compress_hyper_6_21_chunk.device_id, compress_hyper_6_21_chunk.device_id_peer, compress_hyper_6_21_chunk.v0, compress_hyper_6_21_chunk.v1, compress_hyper_6_21_chunk.v2, compress_hyper_6_21_chunk.v3, compress_hyper_6_21_chunk._ts_meta_count, compress_hyper_6_21_chunk._ts_meta_sequence_num, compress_hyper_6_21_chunk._ts_meta_min_3, compress_hyper_6_21_chunk._ts_meta_max_3, compress_hyper_6_21_chunk._ts_meta_min_1, compress_hyper_6_21_chunk._ts_meta_max_1, compress_hyper_6_21_chunk._ts_meta_min_2, compress_hyper_6_21_chunk._ts_meta_max_2
-               Filter: (compress_hyper_6_21_chunk._ts_meta_max_3 > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
+         ->  Index Scan using compress_hyper_6_25_chunk__compressed_hypertable_6_device_id_de on _timescaledb_internal.compress_hyper_6_25_chunk (actual rows=3 loops=1)
+               Output: compress_hyper_6_25_chunk."time", compress_hyper_6_25_chunk.device_id, compress_hyper_6_25_chunk.device_id_peer, compress_hyper_6_25_chunk.v0, compress_hyper_6_25_chunk.v1, compress_hyper_6_25_chunk.v2, compress_hyper_6_25_chunk.v3, compress_hyper_6_25_chunk._ts_meta_count, compress_hyper_6_25_chunk._ts_meta_sequence_num, compress_hyper_6_25_chunk._ts_meta_min_3, compress_hyper_6_25_chunk._ts_meta_max_3, compress_hyper_6_25_chunk._ts_meta_min_1, compress_hyper_6_25_chunk._ts_meta_max_1, compress_hyper_6_25_chunk._ts_meta_min_2, compress_hyper_6_25_chunk._ts_meta_max_2
+               Filter: (compress_hyper_6_25_chunk._ts_meta_max_3 > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
    ->  Index Scan using _hyper_2_12_chunk_metrics_space_device_id_device_id_peer_v0_v1_ on _timescaledb_internal._hyper_2_12_chunk (actual rows=504 loops=1)
          Output: _hyper_2_12_chunk."time", _hyper_2_12_chunk.device_id, _hyper_2_12_chunk.device_id_peer, _hyper_2_12_chunk.v0, _hyper_2_12_chunk.v1, _hyper_2_12_chunk.v2, _hyper_2_12_chunk.v3
          Index Cond: (_hyper_2_12_chunk."time" > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
@@ -5388,23 +5388,23 @@ LIMIT 100;
                Filter: (_hyper_2_10_chunk."time" > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
                Bulk Decompression: true
                ->  Sort (actual rows=1 loops=1)
-                     Output: compress_hyper_6_20_chunk."time", compress_hyper_6_20_chunk.device_id, compress_hyper_6_20_chunk.device_id_peer, compress_hyper_6_20_chunk.v0, compress_hyper_6_20_chunk.v1, compress_hyper_6_20_chunk.v2, compress_hyper_6_20_chunk.v3, compress_hyper_6_20_chunk._ts_meta_count, compress_hyper_6_20_chunk._ts_meta_sequence_num, compress_hyper_6_20_chunk._ts_meta_min_3, compress_hyper_6_20_chunk._ts_meta_max_3, compress_hyper_6_20_chunk._ts_meta_min_1, compress_hyper_6_20_chunk._ts_meta_max_1, compress_hyper_6_20_chunk._ts_meta_min_2, compress_hyper_6_20_chunk._ts_meta_max_2
-                     Sort Key: compress_hyper_6_20_chunk.device_id, compress_hyper_6_20_chunk.device_id_peer, compress_hyper_6_20_chunk._ts_meta_sequence_num
+                     Output: compress_hyper_6_24_chunk."time", compress_hyper_6_24_chunk.device_id, compress_hyper_6_24_chunk.device_id_peer, compress_hyper_6_24_chunk.v0, compress_hyper_6_24_chunk.v1, compress_hyper_6_24_chunk.v2, compress_hyper_6_24_chunk.v3, compress_hyper_6_24_chunk._ts_meta_count, compress_hyper_6_24_chunk._ts_meta_sequence_num, compress_hyper_6_24_chunk._ts_meta_min_3, compress_hyper_6_24_chunk._ts_meta_max_3, compress_hyper_6_24_chunk._ts_meta_min_1, compress_hyper_6_24_chunk._ts_meta_max_1, compress_hyper_6_24_chunk._ts_meta_min_2, compress_hyper_6_24_chunk._ts_meta_max_2
+                     Sort Key: compress_hyper_6_24_chunk.device_id, compress_hyper_6_24_chunk.device_id_peer, compress_hyper_6_24_chunk._ts_meta_sequence_num
                      Sort Method: quicksort 
-                     ->  Seq Scan on _timescaledb_internal.compress_hyper_6_20_chunk (actual rows=1 loops=1)
-                           Output: compress_hyper_6_20_chunk."time", compress_hyper_6_20_chunk.device_id, compress_hyper_6_20_chunk.device_id_peer, compress_hyper_6_20_chunk.v0, compress_hyper_6_20_chunk.v1, compress_hyper_6_20_chunk.v2, compress_hyper_6_20_chunk.v3, compress_hyper_6_20_chunk._ts_meta_count, compress_hyper_6_20_chunk._ts_meta_sequence_num, compress_hyper_6_20_chunk._ts_meta_min_3, compress_hyper_6_20_chunk._ts_meta_max_3, compress_hyper_6_20_chunk._ts_meta_min_1, compress_hyper_6_20_chunk._ts_meta_max_1, compress_hyper_6_20_chunk._ts_meta_min_2, compress_hyper_6_20_chunk._ts_meta_max_2
-                           Filter: (compress_hyper_6_20_chunk._ts_meta_max_3 > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
+                     ->  Seq Scan on _timescaledb_internal.compress_hyper_6_24_chunk (actual rows=1 loops=1)
+                           Output: compress_hyper_6_24_chunk."time", compress_hyper_6_24_chunk.device_id, compress_hyper_6_24_chunk.device_id_peer, compress_hyper_6_24_chunk.v0, compress_hyper_6_24_chunk.v1, compress_hyper_6_24_chunk.v2, compress_hyper_6_24_chunk.v3, compress_hyper_6_24_chunk._ts_meta_count, compress_hyper_6_24_chunk._ts_meta_sequence_num, compress_hyper_6_24_chunk._ts_meta_min_3, compress_hyper_6_24_chunk._ts_meta_max_3, compress_hyper_6_24_chunk._ts_meta_min_1, compress_hyper_6_24_chunk._ts_meta_max_1, compress_hyper_6_24_chunk._ts_meta_min_2, compress_hyper_6_24_chunk._ts_meta_max_2
+                           Filter: (compress_hyper_6_24_chunk._ts_meta_max_3 > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
          ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_11_chunk (actual rows=1 loops=1)
                Output: _hyper_2_11_chunk.device_id, _hyper_2_11_chunk.device_id_peer, _hyper_2_11_chunk.v0, _hyper_2_11_chunk.v1, _hyper_2_11_chunk."time"
                Filter: (_hyper_2_11_chunk."time" > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
                Bulk Decompression: true
                ->  Sort (actual rows=1 loops=1)
-                     Output: compress_hyper_6_21_chunk."time", compress_hyper_6_21_chunk.device_id, compress_hyper_6_21_chunk.device_id_peer, compress_hyper_6_21_chunk.v0, compress_hyper_6_21_chunk.v1, compress_hyper_6_21_chunk.v2, compress_hyper_6_21_chunk.v3, compress_hyper_6_21_chunk._ts_meta_count, compress_hyper_6_21_chunk._ts_meta_sequence_num, compress_hyper_6_21_chunk._ts_meta_min_3, compress_hyper_6_21_chunk._ts_meta_max_3, compress_hyper_6_21_chunk._ts_meta_min_1, compress_hyper_6_21_chunk._ts_meta_max_1, compress_hyper_6_21_chunk._ts_meta_min_2, compress_hyper_6_21_chunk._ts_meta_max_2
-                     Sort Key: compress_hyper_6_21_chunk.device_id, compress_hyper_6_21_chunk.device_id_peer, compress_hyper_6_21_chunk._ts_meta_sequence_num
+                     Output: compress_hyper_6_25_chunk."time", compress_hyper_6_25_chunk.device_id, compress_hyper_6_25_chunk.device_id_peer, compress_hyper_6_25_chunk.v0, compress_hyper_6_25_chunk.v1, compress_hyper_6_25_chunk.v2, compress_hyper_6_25_chunk.v3, compress_hyper_6_25_chunk._ts_meta_count, compress_hyper_6_25_chunk._ts_meta_sequence_num, compress_hyper_6_25_chunk._ts_meta_min_3, compress_hyper_6_25_chunk._ts_meta_max_3, compress_hyper_6_25_chunk._ts_meta_min_1, compress_hyper_6_25_chunk._ts_meta_max_1, compress_hyper_6_25_chunk._ts_meta_min_2, compress_hyper_6_25_chunk._ts_meta_max_2
+                     Sort Key: compress_hyper_6_25_chunk.device_id, compress_hyper_6_25_chunk.device_id_peer, compress_hyper_6_25_chunk._ts_meta_sequence_num
                      Sort Method: quicksort 
-                     ->  Seq Scan on _timescaledb_internal.compress_hyper_6_21_chunk (actual rows=3 loops=1)
-                           Output: compress_hyper_6_21_chunk."time", compress_hyper_6_21_chunk.device_id, compress_hyper_6_21_chunk.device_id_peer, compress_hyper_6_21_chunk.v0, compress_hyper_6_21_chunk.v1, compress_hyper_6_21_chunk.v2, compress_hyper_6_21_chunk.v3, compress_hyper_6_21_chunk._ts_meta_count, compress_hyper_6_21_chunk._ts_meta_sequence_num, compress_hyper_6_21_chunk._ts_meta_min_3, compress_hyper_6_21_chunk._ts_meta_max_3, compress_hyper_6_21_chunk._ts_meta_min_1, compress_hyper_6_21_chunk._ts_meta_max_1, compress_hyper_6_21_chunk._ts_meta_min_2, compress_hyper_6_21_chunk._ts_meta_max_2
-                           Filter: (compress_hyper_6_21_chunk._ts_meta_max_3 > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
+                     ->  Seq Scan on _timescaledb_internal.compress_hyper_6_25_chunk (actual rows=3 loops=1)
+                           Output: compress_hyper_6_25_chunk."time", compress_hyper_6_25_chunk.device_id, compress_hyper_6_25_chunk.device_id_peer, compress_hyper_6_25_chunk.v0, compress_hyper_6_25_chunk.v1, compress_hyper_6_25_chunk.v2, compress_hyper_6_25_chunk.v3, compress_hyper_6_25_chunk._ts_meta_count, compress_hyper_6_25_chunk._ts_meta_sequence_num, compress_hyper_6_25_chunk._ts_meta_min_3, compress_hyper_6_25_chunk._ts_meta_max_3, compress_hyper_6_25_chunk._ts_meta_min_1, compress_hyper_6_25_chunk._ts_meta_max_1, compress_hyper_6_25_chunk._ts_meta_min_2, compress_hyper_6_25_chunk._ts_meta_max_2
+                           Filter: (compress_hyper_6_25_chunk._ts_meta_max_3 > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
          ->  Index Only Scan using _hyper_2_12_chunk_metrics_space_device_id_device_id_peer_v0_v1_ on _timescaledb_internal._hyper_2_12_chunk (actual rows=1 loops=1)
                Output: _hyper_2_12_chunk.device_id, _hyper_2_12_chunk.device_id_peer, _hyper_2_12_chunk.v0, _hyper_2_12_chunk.v1, _hyper_2_12_chunk."time"
                Index Cond: (_hyper_2_12_chunk."time" > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
@@ -5444,23 +5444,23 @@ LIMIT 100;
                Filter: (_hyper_2_10_chunk."time" > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
                Bulk Decompression: true
                ->  Sort (actual rows=1 loops=1)
-                     Output: compress_hyper_6_20_chunk."time", compress_hyper_6_20_chunk.device_id, compress_hyper_6_20_chunk.device_id_peer, compress_hyper_6_20_chunk.v0, compress_hyper_6_20_chunk.v1, compress_hyper_6_20_chunk.v2, compress_hyper_6_20_chunk.v3, compress_hyper_6_20_chunk._ts_meta_count, compress_hyper_6_20_chunk._ts_meta_sequence_num, compress_hyper_6_20_chunk._ts_meta_min_3, compress_hyper_6_20_chunk._ts_meta_max_3, compress_hyper_6_20_chunk._ts_meta_min_1, compress_hyper_6_20_chunk._ts_meta_max_1, compress_hyper_6_20_chunk._ts_meta_min_2, compress_hyper_6_20_chunk._ts_meta_max_2
-                     Sort Key: compress_hyper_6_20_chunk.device_id, compress_hyper_6_20_chunk.device_id_peer
+                     Output: compress_hyper_6_24_chunk."time", compress_hyper_6_24_chunk.device_id, compress_hyper_6_24_chunk.device_id_peer, compress_hyper_6_24_chunk.v0, compress_hyper_6_24_chunk.v1, compress_hyper_6_24_chunk.v2, compress_hyper_6_24_chunk.v3, compress_hyper_6_24_chunk._ts_meta_count, compress_hyper_6_24_chunk._ts_meta_sequence_num, compress_hyper_6_24_chunk._ts_meta_min_3, compress_hyper_6_24_chunk._ts_meta_max_3, compress_hyper_6_24_chunk._ts_meta_min_1, compress_hyper_6_24_chunk._ts_meta_max_1, compress_hyper_6_24_chunk._ts_meta_min_2, compress_hyper_6_24_chunk._ts_meta_max_2
+                     Sort Key: compress_hyper_6_24_chunk.device_id, compress_hyper_6_24_chunk.device_id_peer
                      Sort Method: quicksort 
-                     ->  Seq Scan on _timescaledb_internal.compress_hyper_6_20_chunk (actual rows=1 loops=1)
-                           Output: compress_hyper_6_20_chunk."time", compress_hyper_6_20_chunk.device_id, compress_hyper_6_20_chunk.device_id_peer, compress_hyper_6_20_chunk.v0, compress_hyper_6_20_chunk.v1, compress_hyper_6_20_chunk.v2, compress_hyper_6_20_chunk.v3, compress_hyper_6_20_chunk._ts_meta_count, compress_hyper_6_20_chunk._ts_meta_sequence_num, compress_hyper_6_20_chunk._ts_meta_min_3, compress_hyper_6_20_chunk._ts_meta_max_3, compress_hyper_6_20_chunk._ts_meta_min_1, compress_hyper_6_20_chunk._ts_meta_max_1, compress_hyper_6_20_chunk._ts_meta_min_2, compress_hyper_6_20_chunk._ts_meta_max_2
-                           Filter: (compress_hyper_6_20_chunk._ts_meta_max_3 > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
+                     ->  Seq Scan on _timescaledb_internal.compress_hyper_6_24_chunk (actual rows=1 loops=1)
+                           Output: compress_hyper_6_24_chunk."time", compress_hyper_6_24_chunk.device_id, compress_hyper_6_24_chunk.device_id_peer, compress_hyper_6_24_chunk.v0, compress_hyper_6_24_chunk.v1, compress_hyper_6_24_chunk.v2, compress_hyper_6_24_chunk.v3, compress_hyper_6_24_chunk._ts_meta_count, compress_hyper_6_24_chunk._ts_meta_sequence_num, compress_hyper_6_24_chunk._ts_meta_min_3, compress_hyper_6_24_chunk._ts_meta_max_3, compress_hyper_6_24_chunk._ts_meta_min_1, compress_hyper_6_24_chunk._ts_meta_max_1, compress_hyper_6_24_chunk._ts_meta_min_2, compress_hyper_6_24_chunk._ts_meta_max_2
+                           Filter: (compress_hyper_6_24_chunk._ts_meta_max_3 > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
          ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_11_chunk (actual rows=1 loops=1)
                Output: _hyper_2_11_chunk.device_id, _hyper_2_11_chunk.device_id_peer
                Filter: (_hyper_2_11_chunk."time" > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
                Bulk Decompression: true
                ->  Sort (actual rows=1 loops=1)
-                     Output: compress_hyper_6_21_chunk."time", compress_hyper_6_21_chunk.device_id, compress_hyper_6_21_chunk.device_id_peer, compress_hyper_6_21_chunk.v0, compress_hyper_6_21_chunk.v1, compress_hyper_6_21_chunk.v2, compress_hyper_6_21_chunk.v3, compress_hyper_6_21_chunk._ts_meta_count, compress_hyper_6_21_chunk._ts_meta_sequence_num, compress_hyper_6_21_chunk._ts_meta_min_3, compress_hyper_6_21_chunk._ts_meta_max_3, compress_hyper_6_21_chunk._ts_meta_min_1, compress_hyper_6_21_chunk._ts_meta_max_1, compress_hyper_6_21_chunk._ts_meta_min_2, compress_hyper_6_21_chunk._ts_meta_max_2
-                     Sort Key: compress_hyper_6_21_chunk.device_id, compress_hyper_6_21_chunk.device_id_peer
+                     Output: compress_hyper_6_25_chunk."time", compress_hyper_6_25_chunk.device_id, compress_hyper_6_25_chunk.device_id_peer, compress_hyper_6_25_chunk.v0, compress_hyper_6_25_chunk.v1, compress_hyper_6_25_chunk.v2, compress_hyper_6_25_chunk.v3, compress_hyper_6_25_chunk._ts_meta_count, compress_hyper_6_25_chunk._ts_meta_sequence_num, compress_hyper_6_25_chunk._ts_meta_min_3, compress_hyper_6_25_chunk._ts_meta_max_3, compress_hyper_6_25_chunk._ts_meta_min_1, compress_hyper_6_25_chunk._ts_meta_max_1, compress_hyper_6_25_chunk._ts_meta_min_2, compress_hyper_6_25_chunk._ts_meta_max_2
+                     Sort Key: compress_hyper_6_25_chunk.device_id, compress_hyper_6_25_chunk.device_id_peer
                      Sort Method: quicksort 
-                     ->  Seq Scan on _timescaledb_internal.compress_hyper_6_21_chunk (actual rows=3 loops=1)
-                           Output: compress_hyper_6_21_chunk."time", compress_hyper_6_21_chunk.device_id, compress_hyper_6_21_chunk.device_id_peer, compress_hyper_6_21_chunk.v0, compress_hyper_6_21_chunk.v1, compress_hyper_6_21_chunk.v2, compress_hyper_6_21_chunk.v3, compress_hyper_6_21_chunk._ts_meta_count, compress_hyper_6_21_chunk._ts_meta_sequence_num, compress_hyper_6_21_chunk._ts_meta_min_3, compress_hyper_6_21_chunk._ts_meta_max_3, compress_hyper_6_21_chunk._ts_meta_min_1, compress_hyper_6_21_chunk._ts_meta_max_1, compress_hyper_6_21_chunk._ts_meta_min_2, compress_hyper_6_21_chunk._ts_meta_max_2
-                           Filter: (compress_hyper_6_21_chunk._ts_meta_max_3 > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
+                     ->  Seq Scan on _timescaledb_internal.compress_hyper_6_25_chunk (actual rows=3 loops=1)
+                           Output: compress_hyper_6_25_chunk."time", compress_hyper_6_25_chunk.device_id, compress_hyper_6_25_chunk.device_id_peer, compress_hyper_6_25_chunk.v0, compress_hyper_6_25_chunk.v1, compress_hyper_6_25_chunk.v2, compress_hyper_6_25_chunk.v3, compress_hyper_6_25_chunk._ts_meta_count, compress_hyper_6_25_chunk._ts_meta_sequence_num, compress_hyper_6_25_chunk._ts_meta_min_3, compress_hyper_6_25_chunk._ts_meta_max_3, compress_hyper_6_25_chunk._ts_meta_min_1, compress_hyper_6_25_chunk._ts_meta_max_1, compress_hyper_6_25_chunk._ts_meta_min_2, compress_hyper_6_25_chunk._ts_meta_max_2
+                           Filter: (compress_hyper_6_25_chunk._ts_meta_max_3 > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
          ->  Index Only Scan Backward using _hyper_2_12_chunk_metrics_space_device_id_device_id_peer_v0_v_2 on _timescaledb_internal._hyper_2_12_chunk (actual rows=1 loops=1)
                Output: _hyper_2_12_chunk.device_id, _hyper_2_12_chunk.device_id_peer
                Index Cond: (_hyper_2_12_chunk."time" > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
@@ -5498,16 +5498,16 @@ ORDER BY device_id,
          Output: _hyper_2_10_chunk.device_id, _hyper_2_10_chunk.device_id_peer, _hyper_2_10_chunk.v0
          Filter: (_hyper_2_10_chunk."time" > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
          Bulk Decompression: true
-         ->  Index Scan using compress_hyper_6_20_chunk__compressed_hypertable_6_device_id_de on _timescaledb_internal.compress_hyper_6_20_chunk (actual rows=1 loops=1)
-               Output: compress_hyper_6_20_chunk."time", compress_hyper_6_20_chunk.device_id, compress_hyper_6_20_chunk.device_id_peer, compress_hyper_6_20_chunk.v0, compress_hyper_6_20_chunk.v1, compress_hyper_6_20_chunk.v2, compress_hyper_6_20_chunk.v3, compress_hyper_6_20_chunk._ts_meta_count, compress_hyper_6_20_chunk._ts_meta_sequence_num, compress_hyper_6_20_chunk._ts_meta_min_3, compress_hyper_6_20_chunk._ts_meta_max_3, compress_hyper_6_20_chunk._ts_meta_min_1, compress_hyper_6_20_chunk._ts_meta_max_1, compress_hyper_6_20_chunk._ts_meta_min_2, compress_hyper_6_20_chunk._ts_meta_max_2
-               Filter: (compress_hyper_6_20_chunk._ts_meta_max_3 > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
+         ->  Index Scan using compress_hyper_6_24_chunk__compressed_hypertable_6_device_id_de on _timescaledb_internal.compress_hyper_6_24_chunk (actual rows=1 loops=1)
+               Output: compress_hyper_6_24_chunk."time", compress_hyper_6_24_chunk.device_id, compress_hyper_6_24_chunk.device_id_peer, compress_hyper_6_24_chunk.v0, compress_hyper_6_24_chunk.v1, compress_hyper_6_24_chunk.v2, compress_hyper_6_24_chunk.v3, compress_hyper_6_24_chunk._ts_meta_count, compress_hyper_6_24_chunk._ts_meta_sequence_num, compress_hyper_6_24_chunk._ts_meta_min_3, compress_hyper_6_24_chunk._ts_meta_max_3, compress_hyper_6_24_chunk._ts_meta_min_1, compress_hyper_6_24_chunk._ts_meta_max_1, compress_hyper_6_24_chunk._ts_meta_min_2, compress_hyper_6_24_chunk._ts_meta_max_2
+               Filter: (compress_hyper_6_24_chunk._ts_meta_max_3 > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
    ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_11_chunk (actual rows=1512 loops=1)
          Output: _hyper_2_11_chunk.device_id, _hyper_2_11_chunk.device_id_peer, _hyper_2_11_chunk.v0
          Filter: (_hyper_2_11_chunk."time" > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
          Bulk Decompression: true
-         ->  Index Scan using compress_hyper_6_21_chunk__compressed_hypertable_6_device_id_de on _timescaledb_internal.compress_hyper_6_21_chunk (actual rows=3 loops=1)
-               Output: compress_hyper_6_21_chunk."time", compress_hyper_6_21_chunk.device_id, compress_hyper_6_21_chunk.device_id_peer, compress_hyper_6_21_chunk.v0, compress_hyper_6_21_chunk.v1, compress_hyper_6_21_chunk.v2, compress_hyper_6_21_chunk.v3, compress_hyper_6_21_chunk._ts_meta_count, compress_hyper_6_21_chunk._ts_meta_sequence_num, compress_hyper_6_21_chunk._ts_meta_min_3, compress_hyper_6_21_chunk._ts_meta_max_3, compress_hyper_6_21_chunk._ts_meta_min_1, compress_hyper_6_21_chunk._ts_meta_max_1, compress_hyper_6_21_chunk._ts_meta_min_2, compress_hyper_6_21_chunk._ts_meta_max_2
-               Filter: (compress_hyper_6_21_chunk._ts_meta_max_3 > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
+         ->  Index Scan using compress_hyper_6_25_chunk__compressed_hypertable_6_device_id_de on _timescaledb_internal.compress_hyper_6_25_chunk (actual rows=3 loops=1)
+               Output: compress_hyper_6_25_chunk."time", compress_hyper_6_25_chunk.device_id, compress_hyper_6_25_chunk.device_id_peer, compress_hyper_6_25_chunk.v0, compress_hyper_6_25_chunk.v1, compress_hyper_6_25_chunk.v2, compress_hyper_6_25_chunk.v3, compress_hyper_6_25_chunk._ts_meta_count, compress_hyper_6_25_chunk._ts_meta_sequence_num, compress_hyper_6_25_chunk._ts_meta_min_3, compress_hyper_6_25_chunk._ts_meta_max_3, compress_hyper_6_25_chunk._ts_meta_min_1, compress_hyper_6_25_chunk._ts_meta_max_1, compress_hyper_6_25_chunk._ts_meta_min_2, compress_hyper_6_25_chunk._ts_meta_max_2
+               Filter: (compress_hyper_6_25_chunk._ts_meta_max_3 > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
    ->  Index Only Scan using _hyper_2_12_chunk_metrics_space_device_id_device_id_peer_v0_v1_ on _timescaledb_internal._hyper_2_12_chunk (actual rows=504 loops=1)
          Output: _hyper_2_12_chunk.device_id, _hyper_2_12_chunk.device_id_peer, _hyper_2_12_chunk.v0
          Index Cond: (_hyper_2_12_chunk."time" > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
@@ -5547,16 +5547,16 @@ ORDER BY device_id,
          Output: _hyper_2_10_chunk.device_id, _hyper_2_10_chunk.device_id_peer, _hyper_2_10_chunk.v0, _hyper_2_10_chunk.v1
          Filter: (_hyper_2_10_chunk."time" > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
          Bulk Decompression: true
-         ->  Index Scan using compress_hyper_6_20_chunk__compressed_hypertable_6_device_id_de on _timescaledb_internal.compress_hyper_6_20_chunk (actual rows=1 loops=1)
-               Output: compress_hyper_6_20_chunk."time", compress_hyper_6_20_chunk.device_id, compress_hyper_6_20_chunk.device_id_peer, compress_hyper_6_20_chunk.v0, compress_hyper_6_20_chunk.v1, compress_hyper_6_20_chunk.v2, compress_hyper_6_20_chunk.v3, compress_hyper_6_20_chunk._ts_meta_count, compress_hyper_6_20_chunk._ts_meta_sequence_num, compress_hyper_6_20_chunk._ts_meta_min_3, compress_hyper_6_20_chunk._ts_meta_max_3, compress_hyper_6_20_chunk._ts_meta_min_1, compress_hyper_6_20_chunk._ts_meta_max_1, compress_hyper_6_20_chunk._ts_meta_min_2, compress_hyper_6_20_chunk._ts_meta_max_2
-               Filter: (compress_hyper_6_20_chunk._ts_meta_max_3 > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
+         ->  Index Scan using compress_hyper_6_24_chunk__compressed_hypertable_6_device_id_de on _timescaledb_internal.compress_hyper_6_24_chunk (actual rows=1 loops=1)
+               Output: compress_hyper_6_24_chunk."time", compress_hyper_6_24_chunk.device_id, compress_hyper_6_24_chunk.device_id_peer, compress_hyper_6_24_chunk.v0, compress_hyper_6_24_chunk.v1, compress_hyper_6_24_chunk.v2, compress_hyper_6_24_chunk.v3, compress_hyper_6_24_chunk._ts_meta_count, compress_hyper_6_24_chunk._ts_meta_sequence_num, compress_hyper_6_24_chunk._ts_meta_min_3, compress_hyper_6_24_chunk._ts_meta_max_3, compress_hyper_6_24_chunk._ts_meta_min_1, compress_hyper_6_24_chunk._ts_meta_max_1, compress_hyper_6_24_chunk._ts_meta_min_2, compress_hyper_6_24_chunk._ts_meta_max_2
+               Filter: (compress_hyper_6_24_chunk._ts_meta_max_3 > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
    ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_11_chunk (actual rows=1512 loops=1)
          Output: _hyper_2_11_chunk.device_id, _hyper_2_11_chunk.device_id_peer, _hyper_2_11_chunk.v0, _hyper_2_11_chunk.v1
          Filter: (_hyper_2_11_chunk."time" > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
          Bulk Decompression: true
-         ->  Index Scan using compress_hyper_6_21_chunk__compressed_hypertable_6_device_id_de on _timescaledb_internal.compress_hyper_6_21_chunk (actual rows=3 loops=1)
-               Output: compress_hyper_6_21_chunk."time", compress_hyper_6_21_chunk.device_id, compress_hyper_6_21_chunk.device_id_peer, compress_hyper_6_21_chunk.v0, compress_hyper_6_21_chunk.v1, compress_hyper_6_21_chunk.v2, compress_hyper_6_21_chunk.v3, compress_hyper_6_21_chunk._ts_meta_count, compress_hyper_6_21_chunk._ts_meta_sequence_num, compress_hyper_6_21_chunk._ts_meta_min_3, compress_hyper_6_21_chunk._ts_meta_max_3, compress_hyper_6_21_chunk._ts_meta_min_1, compress_hyper_6_21_chunk._ts_meta_max_1, compress_hyper_6_21_chunk._ts_meta_min_2, compress_hyper_6_21_chunk._ts_meta_max_2
-               Filter: (compress_hyper_6_21_chunk._ts_meta_max_3 > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
+         ->  Index Scan using compress_hyper_6_25_chunk__compressed_hypertable_6_device_id_de on _timescaledb_internal.compress_hyper_6_25_chunk (actual rows=3 loops=1)
+               Output: compress_hyper_6_25_chunk."time", compress_hyper_6_25_chunk.device_id, compress_hyper_6_25_chunk.device_id_peer, compress_hyper_6_25_chunk.v0, compress_hyper_6_25_chunk.v1, compress_hyper_6_25_chunk.v2, compress_hyper_6_25_chunk.v3, compress_hyper_6_25_chunk._ts_meta_count, compress_hyper_6_25_chunk._ts_meta_sequence_num, compress_hyper_6_25_chunk._ts_meta_min_3, compress_hyper_6_25_chunk._ts_meta_max_3, compress_hyper_6_25_chunk._ts_meta_min_1, compress_hyper_6_25_chunk._ts_meta_max_1, compress_hyper_6_25_chunk._ts_meta_min_2, compress_hyper_6_25_chunk._ts_meta_max_2
+               Filter: (compress_hyper_6_25_chunk._ts_meta_max_3 > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
    ->  Index Only Scan using _hyper_2_12_chunk_metrics_space_device_id_device_id_peer_v0_v1_ on _timescaledb_internal._hyper_2_12_chunk (actual rows=504 loops=1)
          Output: _hyper_2_12_chunk.device_id, _hyper_2_12_chunk.device_id_peer, _hyper_2_12_chunk.v0, _hyper_2_12_chunk.v1
          Index Cond: (_hyper_2_12_chunk."time" > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
@@ -5600,9 +5600,9 @@ ORDER BY device_id,
                      Output: _hyper_2_10_chunk."time", _hyper_2_10_chunk.device_id, _hyper_2_10_chunk.device_id_peer, _hyper_2_10_chunk.v0, _hyper_2_10_chunk.v1, _hyper_2_10_chunk.v2, _hyper_2_10_chunk.v3
                      Filter: (_hyper_2_10_chunk."time" > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
                      Bulk Decompression: true
-                     ->  Seq Scan on _timescaledb_internal.compress_hyper_6_20_chunk (actual rows=1 loops=1)
-                           Output: compress_hyper_6_20_chunk."time", compress_hyper_6_20_chunk.device_id, compress_hyper_6_20_chunk.device_id_peer, compress_hyper_6_20_chunk.v0, compress_hyper_6_20_chunk.v1, compress_hyper_6_20_chunk.v2, compress_hyper_6_20_chunk.v3, compress_hyper_6_20_chunk._ts_meta_count, compress_hyper_6_20_chunk._ts_meta_sequence_num, compress_hyper_6_20_chunk._ts_meta_min_3, compress_hyper_6_20_chunk._ts_meta_max_3, compress_hyper_6_20_chunk._ts_meta_min_1, compress_hyper_6_20_chunk._ts_meta_max_1, compress_hyper_6_20_chunk._ts_meta_min_2, compress_hyper_6_20_chunk._ts_meta_max_2
-                           Filter: (compress_hyper_6_20_chunk._ts_meta_max_3 > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
+                     ->  Seq Scan on _timescaledb_internal.compress_hyper_6_24_chunk (actual rows=1 loops=1)
+                           Output: compress_hyper_6_24_chunk."time", compress_hyper_6_24_chunk.device_id, compress_hyper_6_24_chunk.device_id_peer, compress_hyper_6_24_chunk.v0, compress_hyper_6_24_chunk.v1, compress_hyper_6_24_chunk.v2, compress_hyper_6_24_chunk.v3, compress_hyper_6_24_chunk._ts_meta_count, compress_hyper_6_24_chunk._ts_meta_sequence_num, compress_hyper_6_24_chunk._ts_meta_min_3, compress_hyper_6_24_chunk._ts_meta_max_3, compress_hyper_6_24_chunk._ts_meta_min_1, compress_hyper_6_24_chunk._ts_meta_max_1, compress_hyper_6_24_chunk._ts_meta_min_2, compress_hyper_6_24_chunk._ts_meta_max_2
+                           Filter: (compress_hyper_6_24_chunk._ts_meta_max_3 > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
          ->  Sort (actual rows=1512 loops=1)
                Output: _hyper_2_11_chunk."time", _hyper_2_11_chunk.device_id, _hyper_2_11_chunk.device_id_peer, _hyper_2_11_chunk.v0, _hyper_2_11_chunk.v1, _hyper_2_11_chunk.v2, _hyper_2_11_chunk.v3
                Sort Key: _hyper_2_11_chunk.device_id, _hyper_2_11_chunk.device_id_peer, _hyper_2_11_chunk.v0, _hyper_2_11_chunk.v1 DESC, _hyper_2_11_chunk."time"
@@ -5611,9 +5611,9 @@ ORDER BY device_id,
                      Output: _hyper_2_11_chunk."time", _hyper_2_11_chunk.device_id, _hyper_2_11_chunk.device_id_peer, _hyper_2_11_chunk.v0, _hyper_2_11_chunk.v1, _hyper_2_11_chunk.v2, _hyper_2_11_chunk.v3
                      Filter: (_hyper_2_11_chunk."time" > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
                      Bulk Decompression: true
-                     ->  Seq Scan on _timescaledb_internal.compress_hyper_6_21_chunk (actual rows=3 loops=1)
-                           Output: compress_hyper_6_21_chunk."time", compress_hyper_6_21_chunk.device_id, compress_hyper_6_21_chunk.device_id_peer, compress_hyper_6_21_chunk.v0, compress_hyper_6_21_chunk.v1, compress_hyper_6_21_chunk.v2, compress_hyper_6_21_chunk.v3, compress_hyper_6_21_chunk._ts_meta_count, compress_hyper_6_21_chunk._ts_meta_sequence_num, compress_hyper_6_21_chunk._ts_meta_min_3, compress_hyper_6_21_chunk._ts_meta_max_3, compress_hyper_6_21_chunk._ts_meta_min_1, compress_hyper_6_21_chunk._ts_meta_max_1, compress_hyper_6_21_chunk._ts_meta_min_2, compress_hyper_6_21_chunk._ts_meta_max_2
-                           Filter: (compress_hyper_6_21_chunk._ts_meta_max_3 > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
+                     ->  Seq Scan on _timescaledb_internal.compress_hyper_6_25_chunk (actual rows=3 loops=1)
+                           Output: compress_hyper_6_25_chunk."time", compress_hyper_6_25_chunk.device_id, compress_hyper_6_25_chunk.device_id_peer, compress_hyper_6_25_chunk.v0, compress_hyper_6_25_chunk.v1, compress_hyper_6_25_chunk.v2, compress_hyper_6_25_chunk.v3, compress_hyper_6_25_chunk._ts_meta_count, compress_hyper_6_25_chunk._ts_meta_sequence_num, compress_hyper_6_25_chunk._ts_meta_min_3, compress_hyper_6_25_chunk._ts_meta_max_3, compress_hyper_6_25_chunk._ts_meta_min_1, compress_hyper_6_25_chunk._ts_meta_max_1, compress_hyper_6_25_chunk._ts_meta_min_2, compress_hyper_6_25_chunk._ts_meta_max_2
+                           Filter: (compress_hyper_6_25_chunk._ts_meta_max_3 > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
          ->  Index Scan using _hyper_2_12_chunk_metrics_space_device_id_device_id_peer_v0_v1_ on _timescaledb_internal._hyper_2_12_chunk (actual rows=504 loops=1)
                Output: _hyper_2_12_chunk."time", _hyper_2_12_chunk.device_id, _hyper_2_12_chunk.device_id_peer, _hyper_2_12_chunk.v0, _hyper_2_12_chunk.v1, _hyper_2_12_chunk.v2, _hyper_2_12_chunk.v3
                Index Cond: (_hyper_2_12_chunk."time" > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
@@ -5648,23 +5648,23 @@ ORDER BY device_id DESC,
          Filter: (_hyper_2_10_chunk."time" > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
          Bulk Decompression: true
          ->  Sort (actual rows=1 loops=1)
-               Output: compress_hyper_6_20_chunk."time", compress_hyper_6_20_chunk.device_id, compress_hyper_6_20_chunk.device_id_peer, compress_hyper_6_20_chunk.v0, compress_hyper_6_20_chunk.v1, compress_hyper_6_20_chunk.v2, compress_hyper_6_20_chunk.v3, compress_hyper_6_20_chunk._ts_meta_count, compress_hyper_6_20_chunk._ts_meta_sequence_num, compress_hyper_6_20_chunk._ts_meta_min_3, compress_hyper_6_20_chunk._ts_meta_max_3, compress_hyper_6_20_chunk._ts_meta_min_1, compress_hyper_6_20_chunk._ts_meta_max_1, compress_hyper_6_20_chunk._ts_meta_min_2, compress_hyper_6_20_chunk._ts_meta_max_2
-               Sort Key: compress_hyper_6_20_chunk.device_id DESC, compress_hyper_6_20_chunk.device_id_peer DESC, compress_hyper_6_20_chunk._ts_meta_sequence_num
+               Output: compress_hyper_6_24_chunk."time", compress_hyper_6_24_chunk.device_id, compress_hyper_6_24_chunk.device_id_peer, compress_hyper_6_24_chunk.v0, compress_hyper_6_24_chunk.v1, compress_hyper_6_24_chunk.v2, compress_hyper_6_24_chunk.v3, compress_hyper_6_24_chunk._ts_meta_count, compress_hyper_6_24_chunk._ts_meta_sequence_num, compress_hyper_6_24_chunk._ts_meta_min_3, compress_hyper_6_24_chunk._ts_meta_max_3, compress_hyper_6_24_chunk._ts_meta_min_1, compress_hyper_6_24_chunk._ts_meta_max_1, compress_hyper_6_24_chunk._ts_meta_min_2, compress_hyper_6_24_chunk._ts_meta_max_2
+               Sort Key: compress_hyper_6_24_chunk.device_id DESC, compress_hyper_6_24_chunk.device_id_peer DESC, compress_hyper_6_24_chunk._ts_meta_sequence_num
                Sort Method: quicksort 
-               ->  Seq Scan on _timescaledb_internal.compress_hyper_6_20_chunk (actual rows=1 loops=1)
-                     Output: compress_hyper_6_20_chunk."time", compress_hyper_6_20_chunk.device_id, compress_hyper_6_20_chunk.device_id_peer, compress_hyper_6_20_chunk.v0, compress_hyper_6_20_chunk.v1, compress_hyper_6_20_chunk.v2, compress_hyper_6_20_chunk.v3, compress_hyper_6_20_chunk._ts_meta_count, compress_hyper_6_20_chunk._ts_meta_sequence_num, compress_hyper_6_20_chunk._ts_meta_min_3, compress_hyper_6_20_chunk._ts_meta_max_3, compress_hyper_6_20_chunk._ts_meta_min_1, compress_hyper_6_20_chunk._ts_meta_max_1, compress_hyper_6_20_chunk._ts_meta_min_2, compress_hyper_6_20_chunk._ts_meta_max_2
-                     Filter: (compress_hyper_6_20_chunk._ts_meta_max_3 > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
+               ->  Seq Scan on _timescaledb_internal.compress_hyper_6_24_chunk (actual rows=1 loops=1)
+                     Output: compress_hyper_6_24_chunk."time", compress_hyper_6_24_chunk.device_id, compress_hyper_6_24_chunk.device_id_peer, compress_hyper_6_24_chunk.v0, compress_hyper_6_24_chunk.v1, compress_hyper_6_24_chunk.v2, compress_hyper_6_24_chunk.v3, compress_hyper_6_24_chunk._ts_meta_count, compress_hyper_6_24_chunk._ts_meta_sequence_num, compress_hyper_6_24_chunk._ts_meta_min_3, compress_hyper_6_24_chunk._ts_meta_max_3, compress_hyper_6_24_chunk._ts_meta_min_1, compress_hyper_6_24_chunk._ts_meta_max_1, compress_hyper_6_24_chunk._ts_meta_min_2, compress_hyper_6_24_chunk._ts_meta_max_2
+                     Filter: (compress_hyper_6_24_chunk._ts_meta_max_3 > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
    ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_11_chunk (actual rows=1512 loops=1)
          Output: _hyper_2_11_chunk."time", _hyper_2_11_chunk.device_id, _hyper_2_11_chunk.device_id_peer, _hyper_2_11_chunk.v0, _hyper_2_11_chunk.v1, _hyper_2_11_chunk.v2, _hyper_2_11_chunk.v3
          Filter: (_hyper_2_11_chunk."time" > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
          Bulk Decompression: true
          ->  Sort (actual rows=3 loops=1)
-               Output: compress_hyper_6_21_chunk."time", compress_hyper_6_21_chunk.device_id, compress_hyper_6_21_chunk.device_id_peer, compress_hyper_6_21_chunk.v0, compress_hyper_6_21_chunk.v1, compress_hyper_6_21_chunk.v2, compress_hyper_6_21_chunk.v3, compress_hyper_6_21_chunk._ts_meta_count, compress_hyper_6_21_chunk._ts_meta_sequence_num, compress_hyper_6_21_chunk._ts_meta_min_3, compress_hyper_6_21_chunk._ts_meta_max_3, compress_hyper_6_21_chunk._ts_meta_min_1, compress_hyper_6_21_chunk._ts_meta_max_1, compress_hyper_6_21_chunk._ts_meta_min_2, compress_hyper_6_21_chunk._ts_meta_max_2
-               Sort Key: compress_hyper_6_21_chunk.device_id DESC, compress_hyper_6_21_chunk.device_id_peer DESC, compress_hyper_6_21_chunk._ts_meta_sequence_num
+               Output: compress_hyper_6_25_chunk."time", compress_hyper_6_25_chunk.device_id, compress_hyper_6_25_chunk.device_id_peer, compress_hyper_6_25_chunk.v0, compress_hyper_6_25_chunk.v1, compress_hyper_6_25_chunk.v2, compress_hyper_6_25_chunk.v3, compress_hyper_6_25_chunk._ts_meta_count, compress_hyper_6_25_chunk._ts_meta_sequence_num, compress_hyper_6_25_chunk._ts_meta_min_3, compress_hyper_6_25_chunk._ts_meta_max_3, compress_hyper_6_25_chunk._ts_meta_min_1, compress_hyper_6_25_chunk._ts_meta_max_1, compress_hyper_6_25_chunk._ts_meta_min_2, compress_hyper_6_25_chunk._ts_meta_max_2
+               Sort Key: compress_hyper_6_25_chunk.device_id DESC, compress_hyper_6_25_chunk.device_id_peer DESC, compress_hyper_6_25_chunk._ts_meta_sequence_num
                Sort Method: quicksort 
-               ->  Seq Scan on _timescaledb_internal.compress_hyper_6_21_chunk (actual rows=3 loops=1)
-                     Output: compress_hyper_6_21_chunk."time", compress_hyper_6_21_chunk.device_id, compress_hyper_6_21_chunk.device_id_peer, compress_hyper_6_21_chunk.v0, compress_hyper_6_21_chunk.v1, compress_hyper_6_21_chunk.v2, compress_hyper_6_21_chunk.v3, compress_hyper_6_21_chunk._ts_meta_count, compress_hyper_6_21_chunk._ts_meta_sequence_num, compress_hyper_6_21_chunk._ts_meta_min_3, compress_hyper_6_21_chunk._ts_meta_max_3, compress_hyper_6_21_chunk._ts_meta_min_1, compress_hyper_6_21_chunk._ts_meta_max_1, compress_hyper_6_21_chunk._ts_meta_min_2, compress_hyper_6_21_chunk._ts_meta_max_2
-                     Filter: (compress_hyper_6_21_chunk._ts_meta_max_3 > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
+               ->  Seq Scan on _timescaledb_internal.compress_hyper_6_25_chunk (actual rows=3 loops=1)
+                     Output: compress_hyper_6_25_chunk."time", compress_hyper_6_25_chunk.device_id, compress_hyper_6_25_chunk.device_id_peer, compress_hyper_6_25_chunk.v0, compress_hyper_6_25_chunk.v1, compress_hyper_6_25_chunk.v2, compress_hyper_6_25_chunk.v3, compress_hyper_6_25_chunk._ts_meta_count, compress_hyper_6_25_chunk._ts_meta_sequence_num, compress_hyper_6_25_chunk._ts_meta_min_3, compress_hyper_6_25_chunk._ts_meta_max_3, compress_hyper_6_25_chunk._ts_meta_min_1, compress_hyper_6_25_chunk._ts_meta_max_1, compress_hyper_6_25_chunk._ts_meta_min_2, compress_hyper_6_25_chunk._ts_meta_max_2
+                     Filter: (compress_hyper_6_25_chunk._ts_meta_max_3 > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
    ->  Index Scan using _hyper_2_12_chunk_metrics_space_device_id_device_id_peer_v0_v_2 on _timescaledb_internal._hyper_2_12_chunk (actual rows=504 loops=1)
          Output: _hyper_2_12_chunk."time", _hyper_2_12_chunk.device_id, _hyper_2_12_chunk.device_id_peer, _hyper_2_12_chunk.v0, _hyper_2_12_chunk.v1, _hyper_2_12_chunk.v2, _hyper_2_12_chunk.v3
          Index Cond: (_hyper_2_12_chunk."time" > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
@@ -5703,16 +5703,16 @@ ORDER BY device_id DESC,
                Output: _hyper_2_10_chunk."time", _hyper_2_10_chunk.device_id, _hyper_2_10_chunk.device_id_peer, _hyper_2_10_chunk.v0, _hyper_2_10_chunk.v1, _hyper_2_10_chunk.v2, _hyper_2_10_chunk.v3
                Filter: (_hyper_2_10_chunk."time" > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
                Bulk Decompression: true
-               ->  Seq Scan on _timescaledb_internal.compress_hyper_6_20_chunk (actual rows=1 loops=1)
-                     Output: compress_hyper_6_20_chunk."time", compress_hyper_6_20_chunk.device_id, compress_hyper_6_20_chunk.device_id_peer, compress_hyper_6_20_chunk.v0, compress_hyper_6_20_chunk.v1, compress_hyper_6_20_chunk.v2, compress_hyper_6_20_chunk.v3, compress_hyper_6_20_chunk._ts_meta_count, compress_hyper_6_20_chunk._ts_meta_sequence_num, compress_hyper_6_20_chunk._ts_meta_min_3, compress_hyper_6_20_chunk._ts_meta_max_3, compress_hyper_6_20_chunk._ts_meta_min_1, compress_hyper_6_20_chunk._ts_meta_max_1, compress_hyper_6_20_chunk._ts_meta_min_2, compress_hyper_6_20_chunk._ts_meta_max_2
-                     Filter: (compress_hyper_6_20_chunk._ts_meta_max_3 > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
+               ->  Seq Scan on _timescaledb_internal.compress_hyper_6_24_chunk (actual rows=1 loops=1)
+                     Output: compress_hyper_6_24_chunk."time", compress_hyper_6_24_chunk.device_id, compress_hyper_6_24_chunk.device_id_peer, compress_hyper_6_24_chunk.v0, compress_hyper_6_24_chunk.v1, compress_hyper_6_24_chunk.v2, compress_hyper_6_24_chunk.v3, compress_hyper_6_24_chunk._ts_meta_count, compress_hyper_6_24_chunk._ts_meta_sequence_num, compress_hyper_6_24_chunk._ts_meta_min_3, compress_hyper_6_24_chunk._ts_meta_max_3, compress_hyper_6_24_chunk._ts_meta_min_1, compress_hyper_6_24_chunk._ts_meta_max_1, compress_hyper_6_24_chunk._ts_meta_min_2, compress_hyper_6_24_chunk._ts_meta_max_2
+                     Filter: (compress_hyper_6_24_chunk._ts_meta_max_3 > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
          ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_11_chunk (actual rows=1512 loops=1)
                Output: _hyper_2_11_chunk."time", _hyper_2_11_chunk.device_id, _hyper_2_11_chunk.device_id_peer, _hyper_2_11_chunk.v0, _hyper_2_11_chunk.v1, _hyper_2_11_chunk.v2, _hyper_2_11_chunk.v3
                Filter: (_hyper_2_11_chunk."time" > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
                Bulk Decompression: true
-               ->  Seq Scan on _timescaledb_internal.compress_hyper_6_21_chunk (actual rows=3 loops=1)
-                     Output: compress_hyper_6_21_chunk."time", compress_hyper_6_21_chunk.device_id, compress_hyper_6_21_chunk.device_id_peer, compress_hyper_6_21_chunk.v0, compress_hyper_6_21_chunk.v1, compress_hyper_6_21_chunk.v2, compress_hyper_6_21_chunk.v3, compress_hyper_6_21_chunk._ts_meta_count, compress_hyper_6_21_chunk._ts_meta_sequence_num, compress_hyper_6_21_chunk._ts_meta_min_3, compress_hyper_6_21_chunk._ts_meta_max_3, compress_hyper_6_21_chunk._ts_meta_min_1, compress_hyper_6_21_chunk._ts_meta_max_1, compress_hyper_6_21_chunk._ts_meta_min_2, compress_hyper_6_21_chunk._ts_meta_max_2
-                     Filter: (compress_hyper_6_21_chunk._ts_meta_max_3 > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
+               ->  Seq Scan on _timescaledb_internal.compress_hyper_6_25_chunk (actual rows=3 loops=1)
+                     Output: compress_hyper_6_25_chunk."time", compress_hyper_6_25_chunk.device_id, compress_hyper_6_25_chunk.device_id_peer, compress_hyper_6_25_chunk.v0, compress_hyper_6_25_chunk.v1, compress_hyper_6_25_chunk.v2, compress_hyper_6_25_chunk.v3, compress_hyper_6_25_chunk._ts_meta_count, compress_hyper_6_25_chunk._ts_meta_sequence_num, compress_hyper_6_25_chunk._ts_meta_min_3, compress_hyper_6_25_chunk._ts_meta_max_3, compress_hyper_6_25_chunk._ts_meta_min_1, compress_hyper_6_25_chunk._ts_meta_max_1, compress_hyper_6_25_chunk._ts_meta_min_2, compress_hyper_6_25_chunk._ts_meta_max_2
+                     Filter: (compress_hyper_6_25_chunk._ts_meta_max_3 > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
          ->  Seq Scan on _timescaledb_internal._hyper_2_12_chunk (actual rows=504 loops=1)
                Output: _hyper_2_12_chunk."time", _hyper_2_12_chunk.device_id, _hyper_2_12_chunk.device_id_peer, _hyper_2_12_chunk.v0, _hyper_2_12_chunk.v1, _hyper_2_12_chunk.v2, _hyper_2_12_chunk.v3
                Filter: (_hyper_2_12_chunk."time" > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
@@ -5755,7 +5755,7 @@ ORDER BY time,
                            Sort Method: quicksort 
                            ->  Custom Scan (DecompressChunk) on _hyper_2_10_chunk (actual rows=504 loops=1)
                                  Filter: ("time" > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
-                                 ->  Seq Scan on compress_hyper_6_20_chunk (actual rows=1 loops=1)
+                                 ->  Seq Scan on compress_hyper_6_24_chunk (actual rows=1 loops=1)
                                        Filter: (_ts_meta_max_3 > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
                ->  Sort (actual rows=1512 loops=1)
                      Sort Key: _hyper_2_11_chunk."time"
@@ -5765,7 +5765,7 @@ ORDER BY time,
                            Sort Method: quicksort 
                            ->  Custom Scan (DecompressChunk) on _hyper_2_11_chunk (actual rows=1512 loops=1)
                                  Filter: ("time" > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
-                                 ->  Seq Scan on compress_hyper_6_21_chunk (actual rows=3 loops=1)
+                                 ->  Seq Scan on compress_hyper_6_25_chunk (actual rows=3 loops=1)
                                        Filter: (_ts_meta_max_3 > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
                ->  Index Scan Backward using _hyper_2_12_chunk_metrics_space_time_idx on _hyper_2_12_chunk (actual rows=504 loops=1)
                      Index Cond: ("time" > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
@@ -5797,7 +5797,7 @@ ORDER BY time,
                            Sort Method: quicksort 
                            ->  Custom Scan (DecompressChunk) on _hyper_2_4_chunk (actual rows=0 loops=1)
                                  Filter: ("time" > ('2000-01-08'::cstring)::timestamp with time zone)
-                                 ->  Seq Scan on compress_hyper_6_17_chunk (actual rows=0 loops=1)
+                                 ->  Seq Scan on compress_hyper_6_18_chunk (actual rows=0 loops=1)
                                        Filter: (_ts_meta_max_3 > ('2000-01-08'::cstring)::timestamp with time zone)
                                        Rows Removed by Filter: 1
                ->  Sort (actual rows=0 loops=1)
@@ -5808,7 +5808,7 @@ ORDER BY time,
                            Sort Method: quicksort 
                            ->  Custom Scan (DecompressChunk) on _hyper_2_5_chunk (actual rows=0 loops=1)
                                  Filter: ("time" > ('2000-01-08'::cstring)::timestamp with time zone)
-                                 ->  Seq Scan on compress_hyper_6_18_chunk (actual rows=0 loops=1)
+                                 ->  Seq Scan on compress_hyper_6_19_chunk (actual rows=0 loops=1)
                                        Filter: (_ts_meta_max_3 > ('2000-01-08'::cstring)::timestamp with time zone)
                                        Rows Removed by Filter: 3
                ->  Sort (actual rows=0 loops=1)
@@ -5819,7 +5819,7 @@ ORDER BY time,
                            Sort Method: quicksort 
                            ->  Custom Scan (DecompressChunk) on _hyper_2_6_chunk (actual rows=0 loops=1)
                                  Filter: ("time" > ('2000-01-08'::cstring)::timestamp with time zone)
-                                 ->  Seq Scan on compress_hyper_6_19_chunk (actual rows=0 loops=1)
+                                 ->  Seq Scan on compress_hyper_6_20_chunk (actual rows=0 loops=1)
                                        Filter: (_ts_meta_max_3 > ('2000-01-08'::cstring)::timestamp with time zone)
                                        Rows Removed by Filter: 1
          ->  Merge Append (actual rows=1675 loops=1)
@@ -5840,7 +5840,7 @@ ORDER BY time,
                            Sort Method: quicksort 
                            ->  Custom Scan (DecompressChunk) on _hyper_2_10_chunk (actual rows=504 loops=1)
                                  Filter: ("time" > ('2000-01-08'::cstring)::timestamp with time zone)
-                                 ->  Seq Scan on compress_hyper_6_20_chunk (actual rows=1 loops=1)
+                                 ->  Seq Scan on compress_hyper_6_24_chunk (actual rows=1 loops=1)
                                        Filter: (_ts_meta_max_3 > ('2000-01-08'::cstring)::timestamp with time zone)
                ->  Sort (actual rows=1512 loops=1)
                      Sort Key: _hyper_2_11_chunk."time"
@@ -5850,7 +5850,7 @@ ORDER BY time,
                            Sort Method: quicksort 
                            ->  Custom Scan (DecompressChunk) on _hyper_2_11_chunk (actual rows=1512 loops=1)
                                  Filter: ("time" > ('2000-01-08'::cstring)::timestamp with time zone)
-                                 ->  Seq Scan on compress_hyper_6_21_chunk (actual rows=3 loops=1)
+                                 ->  Seq Scan on compress_hyper_6_25_chunk (actual rows=3 loops=1)
                                        Filter: (_ts_meta_max_3 > ('2000-01-08'::cstring)::timestamp with time zone)
                ->  Index Scan Backward using _hyper_2_12_chunk_metrics_space_time_idx on _hyper_2_12_chunk (actual rows=504 loops=1)
                      Index Cond: ("time" > ('2000-01-08'::cstring)::timestamp with time zone)
@@ -5865,18 +5865,18 @@ FROM :TEST_TABLE;
  Aggregate (actual rows=1 loops=1)
    ->  Append (actual rows=6840 loops=1)
          ->  Custom Scan (DecompressChunk) on _hyper_2_4_chunk (actual rows=360 loops=1)
-               ->  Seq Scan on compress_hyper_6_17_chunk (actual rows=1 loops=1)
+               ->  Seq Scan on compress_hyper_6_18_chunk (actual rows=1 loops=1)
          ->  Custom Scan (DecompressChunk) on _hyper_2_5_chunk (actual rows=1080 loops=1)
-               ->  Seq Scan on compress_hyper_6_18_chunk (actual rows=3 loops=1)
+               ->  Seq Scan on compress_hyper_6_19_chunk (actual rows=3 loops=1)
          ->  Custom Scan (DecompressChunk) on _hyper_2_6_chunk (actual rows=360 loops=1)
-               ->  Seq Scan on compress_hyper_6_19_chunk (actual rows=1 loops=1)
+               ->  Seq Scan on compress_hyper_6_20_chunk (actual rows=1 loops=1)
          ->  Seq Scan on _hyper_2_7_chunk (actual rows=504 loops=1)
          ->  Seq Scan on _hyper_2_8_chunk (actual rows=1512 loops=1)
          ->  Seq Scan on _hyper_2_9_chunk (actual rows=504 loops=1)
          ->  Custom Scan (DecompressChunk) on _hyper_2_10_chunk (actual rows=504 loops=1)
-               ->  Seq Scan on compress_hyper_6_20_chunk (actual rows=1 loops=1)
+               ->  Seq Scan on compress_hyper_6_24_chunk (actual rows=1 loops=1)
          ->  Custom Scan (DecompressChunk) on _hyper_2_11_chunk (actual rows=1512 loops=1)
-               ->  Seq Scan on compress_hyper_6_21_chunk (actual rows=3 loops=1)
+               ->  Seq Scan on compress_hyper_6_25_chunk (actual rows=3 loops=1)
          ->  Seq Scan on _hyper_2_12_chunk (actual rows=504 loops=1)
 (16 rows)
 
@@ -5896,18 +5896,18 @@ ORDER BY device_id;
          Batches: 1 
          ->  Append (actual rows=6840 loops=1)
                ->  Custom Scan (DecompressChunk) on _hyper_2_4_chunk (actual rows=360 loops=1)
-                     ->  Seq Scan on compress_hyper_6_17_chunk (actual rows=1 loops=1)
+                     ->  Seq Scan on compress_hyper_6_18_chunk (actual rows=1 loops=1)
                ->  Custom Scan (DecompressChunk) on _hyper_2_5_chunk (actual rows=1080 loops=1)
-                     ->  Seq Scan on compress_hyper_6_18_chunk (actual rows=3 loops=1)
+                     ->  Seq Scan on compress_hyper_6_19_chunk (actual rows=3 loops=1)
                ->  Custom Scan (DecompressChunk) on _hyper_2_6_chunk (actual rows=360 loops=1)
-                     ->  Seq Scan on compress_hyper_6_19_chunk (actual rows=1 loops=1)
+                     ->  Seq Scan on compress_hyper_6_20_chunk (actual rows=1 loops=1)
                ->  Seq Scan on _hyper_2_7_chunk (actual rows=504 loops=1)
                ->  Seq Scan on _hyper_2_8_chunk (actual rows=1512 loops=1)
                ->  Seq Scan on _hyper_2_9_chunk (actual rows=504 loops=1)
                ->  Custom Scan (DecompressChunk) on _hyper_2_10_chunk (actual rows=504 loops=1)
-                     ->  Seq Scan on compress_hyper_6_20_chunk (actual rows=1 loops=1)
+                     ->  Seq Scan on compress_hyper_6_24_chunk (actual rows=1 loops=1)
                ->  Custom Scan (DecompressChunk) on _hyper_2_11_chunk (actual rows=1512 loops=1)
-                     ->  Seq Scan on compress_hyper_6_21_chunk (actual rows=3 loops=1)
+                     ->  Seq Scan on compress_hyper_6_25_chunk (actual rows=3 loops=1)
                ->  Seq Scan on _hyper_2_12_chunk (actual rows=504 loops=1)
 (21 rows)
 
@@ -5928,18 +5928,18 @@ ORDER BY device_id;
                Batches: 1 
                ->  Append (actual rows=6840 loops=1)
                      ->  Custom Scan (DecompressChunk) on _hyper_2_4_chunk (actual rows=360 loops=1)
-                           ->  Seq Scan on compress_hyper_6_17_chunk (actual rows=1 loops=1)
+                           ->  Seq Scan on compress_hyper_6_18_chunk (actual rows=1 loops=1)
                      ->  Custom Scan (DecompressChunk) on _hyper_2_5_chunk (actual rows=1080 loops=1)
-                           ->  Seq Scan on compress_hyper_6_18_chunk (actual rows=3 loops=1)
+                           ->  Seq Scan on compress_hyper_6_19_chunk (actual rows=3 loops=1)
                      ->  Custom Scan (DecompressChunk) on _hyper_2_6_chunk (actual rows=360 loops=1)
-                           ->  Seq Scan on compress_hyper_6_19_chunk (actual rows=1 loops=1)
+                           ->  Seq Scan on compress_hyper_6_20_chunk (actual rows=1 loops=1)
                      ->  Seq Scan on _hyper_2_7_chunk (actual rows=504 loops=1)
                      ->  Seq Scan on _hyper_2_8_chunk (actual rows=1512 loops=1)
                      ->  Seq Scan on _hyper_2_9_chunk (actual rows=504 loops=1)
                      ->  Custom Scan (DecompressChunk) on _hyper_2_10_chunk (actual rows=504 loops=1)
-                           ->  Seq Scan on compress_hyper_6_20_chunk (actual rows=1 loops=1)
+                           ->  Seq Scan on compress_hyper_6_24_chunk (actual rows=1 loops=1)
                      ->  Custom Scan (DecompressChunk) on _hyper_2_11_chunk (actual rows=1512 loops=1)
-                           ->  Seq Scan on compress_hyper_6_21_chunk (actual rows=3 loops=1)
+                           ->  Seq Scan on compress_hyper_6_25_chunk (actual rows=3 loops=1)
                      ->  Seq Scan on _hyper_2_12_chunk (actual rows=504 loops=1)
 (22 rows)
 
@@ -5969,7 +5969,7 @@ ORDER BY v1;
                                  Sort Key: _hyper_2_4_chunk."time"
                                  Sort Method: quicksort 
                                  ->  Custom Scan (DecompressChunk) on _hyper_2_4_chunk (actual rows=360 loops=1)
-                                       ->  Seq Scan on compress_hyper_6_17_chunk (actual rows=1 loops=1)
+                                       ->  Seq Scan on compress_hyper_6_18_chunk (actual rows=1 loops=1)
                      ->  Sort (actual rows=1080 loops=1)
                            Sort Key: _hyper_2_5_chunk."time"
                            Sort Method: quicksort 
@@ -5977,7 +5977,7 @@ ORDER BY v1;
                                  Sort Key: _hyper_2_5_chunk."time"
                                  Sort Method: quicksort 
                                  ->  Custom Scan (DecompressChunk) on _hyper_2_5_chunk (actual rows=1080 loops=1)
-                                       ->  Seq Scan on compress_hyper_6_18_chunk (actual rows=3 loops=1)
+                                       ->  Seq Scan on compress_hyper_6_19_chunk (actual rows=3 loops=1)
                      ->  Sort (actual rows=360 loops=1)
                            Sort Key: _hyper_2_6_chunk."time"
                            Sort Method: quicksort 
@@ -5985,7 +5985,7 @@ ORDER BY v1;
                                  Sort Key: _hyper_2_6_chunk."time"
                                  Sort Method: quicksort 
                                  ->  Custom Scan (DecompressChunk) on _hyper_2_6_chunk (actual rows=360 loops=1)
-                                       ->  Seq Scan on compress_hyper_6_19_chunk (actual rows=1 loops=1)
+                                       ->  Seq Scan on compress_hyper_6_20_chunk (actual rows=1 loops=1)
                ->  Merge Append (actual rows=2520 loops=1)
                      Sort Key: _hyper_2_7_chunk."time"
                      ->  Index Scan Backward using _hyper_2_7_chunk_metrics_space_time_idx on _hyper_2_7_chunk (actual rows=504 loops=1)
@@ -6000,7 +6000,7 @@ ORDER BY v1;
                                  Sort Key: _hyper_2_10_chunk."time"
                                  Sort Method: quicksort 
                                  ->  Custom Scan (DecompressChunk) on _hyper_2_10_chunk (actual rows=504 loops=1)
-                                       ->  Seq Scan on compress_hyper_6_20_chunk (actual rows=1 loops=1)
+                                       ->  Seq Scan on compress_hyper_6_24_chunk (actual rows=1 loops=1)
                      ->  Sort (actual rows=1512 loops=1)
                            Sort Key: _hyper_2_11_chunk."time"
                            Sort Method: quicksort 
@@ -6008,7 +6008,7 @@ ORDER BY v1;
                                  Sort Key: _hyper_2_11_chunk."time"
                                  Sort Method: quicksort 
                                  ->  Custom Scan (DecompressChunk) on _hyper_2_11_chunk (actual rows=1512 loops=1)
-                                       ->  Seq Scan on compress_hyper_6_21_chunk (actual rows=3 loops=1)
+                                       ->  Seq Scan on compress_hyper_6_25_chunk (actual rows=3 loops=1)
                      ->  Index Scan Backward using _hyper_2_12_chunk_metrics_space_time_idx on _hyper_2_12_chunk (actual rows=504 loops=1)
 (56 rows)
 
@@ -6041,7 +6041,7 @@ ORDER BY q1.time;
                Sort Key: _hyper_2_4_chunk."time"
                Sort Method: quicksort 
                ->  Custom Scan (DecompressChunk) on _hyper_2_4_chunk (actual rows=360 loops=1)
-                     ->  Seq Scan on compress_hyper_6_17_chunk (actual rows=1 loops=1)
+                     ->  Seq Scan on compress_hyper_6_18_chunk (actual rows=1 loops=1)
                            Filter: (device_id = 1)
          ->  Index Scan Backward using _hyper_2_7_chunk_metrics_space_time_idx on _hyper_2_7_chunk (actual rows=504 loops=1)
                Filter: (device_id = 1)
@@ -6049,7 +6049,7 @@ ORDER BY q1.time;
                Sort Key: _hyper_2_10_chunk."time"
                Sort Method: quicksort 
                ->  Custom Scan (DecompressChunk) on _hyper_2_10_chunk (actual rows=504 loops=1)
-                     ->  Seq Scan on compress_hyper_6_20_chunk (actual rows=1 loops=1)
+                     ->  Seq Scan on compress_hyper_6_24_chunk (actual rows=1 loops=1)
                            Filter: (device_id = 1)
    ->  Materialize (actual rows=1368 loops=1)
          ->  Custom Scan (ChunkAppend) on metrics_space metrics_space_1 (actual rows=1368 loops=1)
@@ -6058,7 +6058,7 @@ ORDER BY q1.time;
                      Sort Key: _hyper_2_5_chunk."time"
                      Sort Method: quicksort 
                      ->  Custom Scan (DecompressChunk) on _hyper_2_5_chunk (actual rows=360 loops=1)
-                           ->  Seq Scan on compress_hyper_6_18_chunk (actual rows=1 loops=1)
+                           ->  Seq Scan on compress_hyper_6_19_chunk (actual rows=1 loops=1)
                                  Filter: (device_id = 2)
                                  Rows Removed by Filter: 2
                ->  Index Scan Backward using _hyper_2_8_chunk_metrics_space_device_id_time_idx on _hyper_2_8_chunk (actual rows=504 loops=1)
@@ -6067,7 +6067,7 @@ ORDER BY q1.time;
                      Sort Key: _hyper_2_11_chunk."time"
                      Sort Method: quicksort 
                      ->  Custom Scan (DecompressChunk) on _hyper_2_11_chunk (actual rows=504 loops=1)
-                           ->  Seq Scan on compress_hyper_6_21_chunk (actual rows=1 loops=1)
+                           ->  Seq Scan on compress_hyper_6_25_chunk (actual rows=1 loops=1)
                                  Filter: (device_id = 2)
                                  Rows Removed by Filter: 2
 (37 rows)
@@ -6083,12 +6083,12 @@ WHERE device_id = 1;
  Aggregate (actual rows=1 loops=1)
    ->  Append (actual rows=1368 loops=1)
          ->  Custom Scan (DecompressChunk) on _hyper_2_4_chunk (actual rows=360 loops=1)
-               ->  Seq Scan on compress_hyper_6_17_chunk (actual rows=1 loops=1)
+               ->  Seq Scan on compress_hyper_6_18_chunk (actual rows=1 loops=1)
                      Filter: (device_id = 1)
          ->  Seq Scan on _hyper_2_7_chunk (actual rows=504 loops=1)
                Filter: (device_id = 1)
          ->  Custom Scan (DecompressChunk) on _hyper_2_10_chunk (actual rows=504 loops=1)
-               ->  Seq Scan on compress_hyper_6_20_chunk (actual rows=1 loops=1)
+               ->  Seq Scan on compress_hyper_6_24_chunk (actual rows=1 loops=1)
                      Filter: (device_id = 1)
 (10 rows)
 
@@ -6152,9 +6152,9 @@ ORDER BY device_id,
          ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_4_chunk (actual rows=360 loops=1)
                Output: _hyper_2_4_chunk."time", _hyper_2_4_chunk.device_id
                Bulk Decompression: true
-               ->  Index Scan using compress_hyper_6_17_chunk_c_space_index_2 on _timescaledb_internal.compress_hyper_6_17_chunk (actual rows=1 loops=1)
-                     Output: compress_hyper_6_17_chunk."time", compress_hyper_6_17_chunk.device_id, compress_hyper_6_17_chunk.device_id_peer, compress_hyper_6_17_chunk.v0, compress_hyper_6_17_chunk.v1, compress_hyper_6_17_chunk.v2, compress_hyper_6_17_chunk.v3, compress_hyper_6_17_chunk._ts_meta_count, compress_hyper_6_17_chunk._ts_meta_sequence_num, compress_hyper_6_17_chunk._ts_meta_min_3, compress_hyper_6_17_chunk._ts_meta_max_3, compress_hyper_6_17_chunk._ts_meta_min_1, compress_hyper_6_17_chunk._ts_meta_max_1, compress_hyper_6_17_chunk._ts_meta_min_2, compress_hyper_6_17_chunk._ts_meta_max_2
-                     Index Cond: (compress_hyper_6_17_chunk.device_id = 1)
+               ->  Index Scan using compress_hyper_6_18_chunk_c_space_index_2 on _timescaledb_internal.compress_hyper_6_18_chunk (actual rows=1 loops=1)
+                     Output: compress_hyper_6_18_chunk."time", compress_hyper_6_18_chunk.device_id, compress_hyper_6_18_chunk.device_id_peer, compress_hyper_6_18_chunk.v0, compress_hyper_6_18_chunk.v1, compress_hyper_6_18_chunk.v2, compress_hyper_6_18_chunk.v3, compress_hyper_6_18_chunk._ts_meta_count, compress_hyper_6_18_chunk._ts_meta_sequence_num, compress_hyper_6_18_chunk._ts_meta_min_3, compress_hyper_6_18_chunk._ts_meta_max_3, compress_hyper_6_18_chunk._ts_meta_min_1, compress_hyper_6_18_chunk._ts_meta_max_1, compress_hyper_6_18_chunk._ts_meta_min_2, compress_hyper_6_18_chunk._ts_meta_max_2
+                     Index Cond: (compress_hyper_6_18_chunk.device_id = 1)
    ->  Index Scan Backward using _hyper_2_7_chunk_metrics_space_time_idx on _timescaledb_internal._hyper_2_7_chunk (actual rows=504 loops=1)
          Output: _hyper_2_7_chunk."time", _hyper_2_7_chunk.device_id
          Filter: (_hyper_2_7_chunk.device_id = 1)
@@ -6165,9 +6165,9 @@ ORDER BY device_id,
          ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_10_chunk (actual rows=504 loops=1)
                Output: _hyper_2_10_chunk."time", _hyper_2_10_chunk.device_id
                Bulk Decompression: true
-               ->  Index Scan using compress_hyper_6_20_chunk_c_space_index_2 on _timescaledb_internal.compress_hyper_6_20_chunk (actual rows=1 loops=1)
-                     Output: compress_hyper_6_20_chunk."time", compress_hyper_6_20_chunk.device_id, compress_hyper_6_20_chunk.device_id_peer, compress_hyper_6_20_chunk.v0, compress_hyper_6_20_chunk.v1, compress_hyper_6_20_chunk.v2, compress_hyper_6_20_chunk.v3, compress_hyper_6_20_chunk._ts_meta_count, compress_hyper_6_20_chunk._ts_meta_sequence_num, compress_hyper_6_20_chunk._ts_meta_min_3, compress_hyper_6_20_chunk._ts_meta_max_3, compress_hyper_6_20_chunk._ts_meta_min_1, compress_hyper_6_20_chunk._ts_meta_max_1, compress_hyper_6_20_chunk._ts_meta_min_2, compress_hyper_6_20_chunk._ts_meta_max_2
-                     Index Cond: (compress_hyper_6_20_chunk.device_id = 1)
+               ->  Index Scan using compress_hyper_6_24_chunk_c_space_index_2 on _timescaledb_internal.compress_hyper_6_24_chunk (actual rows=1 loops=1)
+                     Output: compress_hyper_6_24_chunk."time", compress_hyper_6_24_chunk.device_id, compress_hyper_6_24_chunk.device_id_peer, compress_hyper_6_24_chunk.v0, compress_hyper_6_24_chunk.v1, compress_hyper_6_24_chunk.v2, compress_hyper_6_24_chunk.v3, compress_hyper_6_24_chunk._ts_meta_count, compress_hyper_6_24_chunk._ts_meta_sequence_num, compress_hyper_6_24_chunk._ts_meta_min_3, compress_hyper_6_24_chunk._ts_meta_max_3, compress_hyper_6_24_chunk._ts_meta_min_1, compress_hyper_6_24_chunk._ts_meta_max_1, compress_hyper_6_24_chunk._ts_meta_min_2, compress_hyper_6_24_chunk._ts_meta_max_2
+                     Index Cond: (compress_hyper_6_24_chunk.device_id = 1)
 (25 rows)
 
 -- globs should not plan IndexOnlyScans
@@ -6188,9 +6188,9 @@ ORDER BY device_id,
          ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_4_chunk (actual rows=360 loops=1)
                Output: _hyper_2_4_chunk."time", _hyper_2_4_chunk.device_id, _hyper_2_4_chunk.device_id_peer, _hyper_2_4_chunk.v0, _hyper_2_4_chunk.v1, _hyper_2_4_chunk.v2, _hyper_2_4_chunk.v3
                Bulk Decompression: true
-               ->  Index Scan using compress_hyper_6_17_chunk_c_space_index_2 on _timescaledb_internal.compress_hyper_6_17_chunk (actual rows=1 loops=1)
-                     Output: compress_hyper_6_17_chunk."time", compress_hyper_6_17_chunk.device_id, compress_hyper_6_17_chunk.device_id_peer, compress_hyper_6_17_chunk.v0, compress_hyper_6_17_chunk.v1, compress_hyper_6_17_chunk.v2, compress_hyper_6_17_chunk.v3, compress_hyper_6_17_chunk._ts_meta_count, compress_hyper_6_17_chunk._ts_meta_sequence_num, compress_hyper_6_17_chunk._ts_meta_min_3, compress_hyper_6_17_chunk._ts_meta_max_3, compress_hyper_6_17_chunk._ts_meta_min_1, compress_hyper_6_17_chunk._ts_meta_max_1, compress_hyper_6_17_chunk._ts_meta_min_2, compress_hyper_6_17_chunk._ts_meta_max_2
-                     Index Cond: (compress_hyper_6_17_chunk.device_id = 1)
+               ->  Index Scan using compress_hyper_6_18_chunk_c_space_index_2 on _timescaledb_internal.compress_hyper_6_18_chunk (actual rows=1 loops=1)
+                     Output: compress_hyper_6_18_chunk."time", compress_hyper_6_18_chunk.device_id, compress_hyper_6_18_chunk.device_id_peer, compress_hyper_6_18_chunk.v0, compress_hyper_6_18_chunk.v1, compress_hyper_6_18_chunk.v2, compress_hyper_6_18_chunk.v3, compress_hyper_6_18_chunk._ts_meta_count, compress_hyper_6_18_chunk._ts_meta_sequence_num, compress_hyper_6_18_chunk._ts_meta_min_3, compress_hyper_6_18_chunk._ts_meta_max_3, compress_hyper_6_18_chunk._ts_meta_min_1, compress_hyper_6_18_chunk._ts_meta_max_1, compress_hyper_6_18_chunk._ts_meta_min_2, compress_hyper_6_18_chunk._ts_meta_max_2
+                     Index Cond: (compress_hyper_6_18_chunk.device_id = 1)
    ->  Index Scan Backward using _hyper_2_7_chunk_metrics_space_time_idx on _timescaledb_internal._hyper_2_7_chunk (actual rows=504 loops=1)
          Output: _hyper_2_7_chunk."time", _hyper_2_7_chunk.device_id, _hyper_2_7_chunk.device_id_peer, _hyper_2_7_chunk.v0, _hyper_2_7_chunk.v1, _hyper_2_7_chunk.v2, _hyper_2_7_chunk.v3
          Filter: (_hyper_2_7_chunk.device_id = 1)
@@ -6201,9 +6201,9 @@ ORDER BY device_id,
          ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_10_chunk (actual rows=504 loops=1)
                Output: _hyper_2_10_chunk."time", _hyper_2_10_chunk.device_id, _hyper_2_10_chunk.device_id_peer, _hyper_2_10_chunk.v0, _hyper_2_10_chunk.v1, _hyper_2_10_chunk.v2, _hyper_2_10_chunk.v3
                Bulk Decompression: true
-               ->  Index Scan using compress_hyper_6_20_chunk_c_space_index_2 on _timescaledb_internal.compress_hyper_6_20_chunk (actual rows=1 loops=1)
-                     Output: compress_hyper_6_20_chunk."time", compress_hyper_6_20_chunk.device_id, compress_hyper_6_20_chunk.device_id_peer, compress_hyper_6_20_chunk.v0, compress_hyper_6_20_chunk.v1, compress_hyper_6_20_chunk.v2, compress_hyper_6_20_chunk.v3, compress_hyper_6_20_chunk._ts_meta_count, compress_hyper_6_20_chunk._ts_meta_sequence_num, compress_hyper_6_20_chunk._ts_meta_min_3, compress_hyper_6_20_chunk._ts_meta_max_3, compress_hyper_6_20_chunk._ts_meta_min_1, compress_hyper_6_20_chunk._ts_meta_max_1, compress_hyper_6_20_chunk._ts_meta_min_2, compress_hyper_6_20_chunk._ts_meta_max_2
-                     Index Cond: (compress_hyper_6_20_chunk.device_id = 1)
+               ->  Index Scan using compress_hyper_6_24_chunk_c_space_index_2 on _timescaledb_internal.compress_hyper_6_24_chunk (actual rows=1 loops=1)
+                     Output: compress_hyper_6_24_chunk."time", compress_hyper_6_24_chunk.device_id, compress_hyper_6_24_chunk.device_id_peer, compress_hyper_6_24_chunk.v0, compress_hyper_6_24_chunk.v1, compress_hyper_6_24_chunk.v2, compress_hyper_6_24_chunk.v3, compress_hyper_6_24_chunk._ts_meta_count, compress_hyper_6_24_chunk._ts_meta_sequence_num, compress_hyper_6_24_chunk._ts_meta_min_3, compress_hyper_6_24_chunk._ts_meta_max_3, compress_hyper_6_24_chunk._ts_meta_min_1, compress_hyper_6_24_chunk._ts_meta_max_1, compress_hyper_6_24_chunk._ts_meta_min_2, compress_hyper_6_24_chunk._ts_meta_max_2
+                     Index Cond: (compress_hyper_6_24_chunk.device_id = 1)
 (25 rows)
 
 -- whole row reference should work
@@ -6224,9 +6224,9 @@ ORDER BY device_id,
          ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_4_chunk test_table_1 (actual rows=360 loops=1)
                Output: test_table_1.*, test_table_1.device_id, test_table_1."time"
                Bulk Decompression: true
-               ->  Index Scan using compress_hyper_6_17_chunk_c_space_index_2 on _timescaledb_internal.compress_hyper_6_17_chunk (actual rows=1 loops=1)
-                     Output: compress_hyper_6_17_chunk."time", compress_hyper_6_17_chunk.device_id, compress_hyper_6_17_chunk.device_id_peer, compress_hyper_6_17_chunk.v0, compress_hyper_6_17_chunk.v1, compress_hyper_6_17_chunk.v2, compress_hyper_6_17_chunk.v3, compress_hyper_6_17_chunk._ts_meta_count, compress_hyper_6_17_chunk._ts_meta_sequence_num, compress_hyper_6_17_chunk._ts_meta_min_3, compress_hyper_6_17_chunk._ts_meta_max_3, compress_hyper_6_17_chunk._ts_meta_min_1, compress_hyper_6_17_chunk._ts_meta_max_1, compress_hyper_6_17_chunk._ts_meta_min_2, compress_hyper_6_17_chunk._ts_meta_max_2
-                     Index Cond: (compress_hyper_6_17_chunk.device_id = 1)
+               ->  Index Scan using compress_hyper_6_18_chunk_c_space_index_2 on _timescaledb_internal.compress_hyper_6_18_chunk (actual rows=1 loops=1)
+                     Output: compress_hyper_6_18_chunk."time", compress_hyper_6_18_chunk.device_id, compress_hyper_6_18_chunk.device_id_peer, compress_hyper_6_18_chunk.v0, compress_hyper_6_18_chunk.v1, compress_hyper_6_18_chunk.v2, compress_hyper_6_18_chunk.v3, compress_hyper_6_18_chunk._ts_meta_count, compress_hyper_6_18_chunk._ts_meta_sequence_num, compress_hyper_6_18_chunk._ts_meta_min_3, compress_hyper_6_18_chunk._ts_meta_max_3, compress_hyper_6_18_chunk._ts_meta_min_1, compress_hyper_6_18_chunk._ts_meta_max_1, compress_hyper_6_18_chunk._ts_meta_min_2, compress_hyper_6_18_chunk._ts_meta_max_2
+                     Index Cond: (compress_hyper_6_18_chunk.device_id = 1)
    ->  Index Scan Backward using _hyper_2_7_chunk_metrics_space_time_idx on _timescaledb_internal._hyper_2_7_chunk test_table_2 (actual rows=504 loops=1)
          Output: test_table_2.*, test_table_2.device_id, test_table_2."time"
          Filter: (test_table_2.device_id = 1)
@@ -6237,9 +6237,9 @@ ORDER BY device_id,
          ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_10_chunk test_table_3 (actual rows=504 loops=1)
                Output: test_table_3.*, test_table_3.device_id, test_table_3."time"
                Bulk Decompression: true
-               ->  Index Scan using compress_hyper_6_20_chunk_c_space_index_2 on _timescaledb_internal.compress_hyper_6_20_chunk (actual rows=1 loops=1)
-                     Output: compress_hyper_6_20_chunk."time", compress_hyper_6_20_chunk.device_id, compress_hyper_6_20_chunk.device_id_peer, compress_hyper_6_20_chunk.v0, compress_hyper_6_20_chunk.v1, compress_hyper_6_20_chunk.v2, compress_hyper_6_20_chunk.v3, compress_hyper_6_20_chunk._ts_meta_count, compress_hyper_6_20_chunk._ts_meta_sequence_num, compress_hyper_6_20_chunk._ts_meta_min_3, compress_hyper_6_20_chunk._ts_meta_max_3, compress_hyper_6_20_chunk._ts_meta_min_1, compress_hyper_6_20_chunk._ts_meta_max_1, compress_hyper_6_20_chunk._ts_meta_min_2, compress_hyper_6_20_chunk._ts_meta_max_2
-                     Index Cond: (compress_hyper_6_20_chunk.device_id = 1)
+               ->  Index Scan using compress_hyper_6_24_chunk_c_space_index_2 on _timescaledb_internal.compress_hyper_6_24_chunk (actual rows=1 loops=1)
+                     Output: compress_hyper_6_24_chunk."time", compress_hyper_6_24_chunk.device_id, compress_hyper_6_24_chunk.device_id_peer, compress_hyper_6_24_chunk.v0, compress_hyper_6_24_chunk.v1, compress_hyper_6_24_chunk.v2, compress_hyper_6_24_chunk.v3, compress_hyper_6_24_chunk._ts_meta_count, compress_hyper_6_24_chunk._ts_meta_sequence_num, compress_hyper_6_24_chunk._ts_meta_min_3, compress_hyper_6_24_chunk._ts_meta_max_3, compress_hyper_6_24_chunk._ts_meta_min_1, compress_hyper_6_24_chunk._ts_meta_max_1, compress_hyper_6_24_chunk._ts_meta_min_2, compress_hyper_6_24_chunk._ts_meta_max_2
+                     Index Cond: (compress_hyper_6_24_chunk.device_id = 1)
 (25 rows)
 
 -- even when we select only a segmentby column, we still need count
@@ -6254,9 +6254,9 @@ ORDER BY device_id;
    ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_4_chunk (actual rows=360 loops=1)
          Output: _hyper_2_4_chunk.device_id
          Bulk Decompression: false
-         ->  Index Only Scan using compress_hyper_6_17_chunk_c_space_index_2 on _timescaledb_internal.compress_hyper_6_17_chunk (actual rows=1 loops=1)
-               Output: compress_hyper_6_17_chunk.device_id, compress_hyper_6_17_chunk._ts_meta_count
-               Index Cond: (compress_hyper_6_17_chunk.device_id = 1)
+         ->  Index Only Scan using compress_hyper_6_18_chunk_c_space_index_2 on _timescaledb_internal.compress_hyper_6_18_chunk (actual rows=1 loops=1)
+               Output: compress_hyper_6_18_chunk.device_id, compress_hyper_6_18_chunk._ts_meta_count
+               Index Cond: (compress_hyper_6_18_chunk.device_id = 1)
                Heap Fetches: 1
    ->  Index Only Scan using _hyper_2_7_chunk_metrics_space_device_id_device_id_peer_v0_v1_2 on _timescaledb_internal._hyper_2_7_chunk (actual rows=504 loops=1)
          Output: _hyper_2_7_chunk.device_id
@@ -6265,9 +6265,9 @@ ORDER BY device_id;
    ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_10_chunk (actual rows=504 loops=1)
          Output: _hyper_2_10_chunk.device_id
          Bulk Decompression: false
-         ->  Index Only Scan using compress_hyper_6_20_chunk_c_space_index_2 on _timescaledb_internal.compress_hyper_6_20_chunk (actual rows=1 loops=1)
-               Output: compress_hyper_6_20_chunk.device_id, compress_hyper_6_20_chunk._ts_meta_count
-               Index Cond: (compress_hyper_6_20_chunk.device_id = 1)
+         ->  Index Only Scan using compress_hyper_6_24_chunk_c_space_index_2 on _timescaledb_internal.compress_hyper_6_24_chunk (actual rows=1 loops=1)
+               Output: compress_hyper_6_24_chunk.device_id, compress_hyper_6_24_chunk._ts_meta_count
+               Index Cond: (compress_hyper_6_24_chunk.device_id = 1)
                Heap Fetches: 1
 (19 rows)
 
@@ -6282,18 +6282,18 @@ WHERE device_id = 1;
    ->  Append (actual rows=1368 loops=1)
          ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_4_chunk (actual rows=360 loops=1)
                Bulk Decompression: false
-               ->  Index Only Scan using compress_hyper_6_17_chunk_c_space_index_2 on _timescaledb_internal.compress_hyper_6_17_chunk (actual rows=1 loops=1)
-                     Output: compress_hyper_6_17_chunk.device_id, compress_hyper_6_17_chunk._ts_meta_count
-                     Index Cond: (compress_hyper_6_17_chunk.device_id = 1)
+               ->  Index Only Scan using compress_hyper_6_18_chunk_c_space_index_2 on _timescaledb_internal.compress_hyper_6_18_chunk (actual rows=1 loops=1)
+                     Output: compress_hyper_6_18_chunk.device_id, compress_hyper_6_18_chunk._ts_meta_count
+                     Index Cond: (compress_hyper_6_18_chunk.device_id = 1)
                      Heap Fetches: 1
          ->  Index Only Scan using _hyper_2_7_chunk_metrics_space_device_id_device_id_peer_v0_v1_2 on _timescaledb_internal._hyper_2_7_chunk (actual rows=504 loops=1)
                Index Cond: (_hyper_2_7_chunk.device_id = 1)
                Heap Fetches: 504
          ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_10_chunk (actual rows=504 loops=1)
                Bulk Decompression: false
-               ->  Index Only Scan using compress_hyper_6_20_chunk_c_space_index_2 on _timescaledb_internal.compress_hyper_6_20_chunk (actual rows=1 loops=1)
-                     Output: compress_hyper_6_20_chunk.device_id, compress_hyper_6_20_chunk._ts_meta_count
-                     Index Cond: (compress_hyper_6_20_chunk.device_id = 1)
+               ->  Index Only Scan using compress_hyper_6_24_chunk_c_space_index_2 on _timescaledb_internal.compress_hyper_6_24_chunk (actual rows=1 loops=1)
+                     Output: compress_hyper_6_24_chunk.device_id, compress_hyper_6_24_chunk._ts_meta_count
+                     Index Cond: (compress_hyper_6_24_chunk.device_id = 1)
                      Heap Fetches: 1
 (18 rows)
 
@@ -6310,20 +6310,20 @@ ORDER BY device_id;
    ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_4_chunk (actual rows=360 loops=1)
          Output: _hyper_2_4_chunk.device_id
          Bulk Decompression: false
-         ->  Index Only Scan using compress_hyper_6_17_chunk_c_space_index_2 on _timescaledb_internal.compress_hyper_6_17_chunk (actual rows=1 loops=1)
-               Output: compress_hyper_6_17_chunk.device_id, compress_hyper_6_17_chunk._ts_meta_count
+         ->  Index Only Scan using compress_hyper_6_18_chunk_c_space_index_2 on _timescaledb_internal.compress_hyper_6_18_chunk (actual rows=1 loops=1)
+               Output: compress_hyper_6_18_chunk.device_id, compress_hyper_6_18_chunk._ts_meta_count
                Heap Fetches: 1
    ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_5_chunk (actual rows=1080 loops=1)
          Output: _hyper_2_5_chunk.device_id
          Bulk Decompression: false
-         ->  Index Only Scan using compress_hyper_6_18_chunk_c_space_index_2 on _timescaledb_internal.compress_hyper_6_18_chunk (actual rows=3 loops=1)
-               Output: compress_hyper_6_18_chunk.device_id, compress_hyper_6_18_chunk._ts_meta_count
+         ->  Index Only Scan using compress_hyper_6_19_chunk_c_space_index_2 on _timescaledb_internal.compress_hyper_6_19_chunk (actual rows=3 loops=1)
+               Output: compress_hyper_6_19_chunk.device_id, compress_hyper_6_19_chunk._ts_meta_count
                Heap Fetches: 3
    ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_6_chunk (actual rows=360 loops=1)
          Output: _hyper_2_6_chunk.device_id
          Bulk Decompression: false
-         ->  Index Only Scan using compress_hyper_6_19_chunk_c_space_index_2 on _timescaledb_internal.compress_hyper_6_19_chunk (actual rows=1 loops=1)
-               Output: compress_hyper_6_19_chunk.device_id, compress_hyper_6_19_chunk._ts_meta_count
+         ->  Index Only Scan using compress_hyper_6_20_chunk_c_space_index_2 on _timescaledb_internal.compress_hyper_6_20_chunk (actual rows=1 loops=1)
+               Output: compress_hyper_6_20_chunk.device_id, compress_hyper_6_20_chunk._ts_meta_count
                Heap Fetches: 1
    ->  Index Only Scan using _hyper_2_7_chunk_tmp_idx on _timescaledb_internal._hyper_2_7_chunk (actual rows=504 loops=1)
          Output: _hyper_2_7_chunk.device_id
@@ -6337,14 +6337,14 @@ ORDER BY device_id;
    ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_10_chunk (actual rows=504 loops=1)
          Output: _hyper_2_10_chunk.device_id
          Bulk Decompression: false
-         ->  Index Only Scan using compress_hyper_6_20_chunk_c_space_index_2 on _timescaledb_internal.compress_hyper_6_20_chunk (actual rows=1 loops=1)
-               Output: compress_hyper_6_20_chunk.device_id, compress_hyper_6_20_chunk._ts_meta_count
+         ->  Index Only Scan using compress_hyper_6_24_chunk_c_space_index_2 on _timescaledb_internal.compress_hyper_6_24_chunk (actual rows=1 loops=1)
+               Output: compress_hyper_6_24_chunk.device_id, compress_hyper_6_24_chunk._ts_meta_count
                Heap Fetches: 1
    ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_11_chunk (actual rows=1512 loops=1)
          Output: _hyper_2_11_chunk.device_id
          Bulk Decompression: false
-         ->  Index Only Scan using compress_hyper_6_21_chunk_c_space_index_2 on _timescaledb_internal.compress_hyper_6_21_chunk (actual rows=3 loops=1)
-               Output: compress_hyper_6_21_chunk.device_id, compress_hyper_6_21_chunk._ts_meta_count
+         ->  Index Only Scan using compress_hyper_6_25_chunk_c_space_index_2 on _timescaledb_internal.compress_hyper_6_25_chunk (actual rows=3 loops=1)
+               Output: compress_hyper_6_25_chunk.device_id, compress_hyper_6_25_chunk._ts_meta_count
                Heap Fetches: 3
    ->  Index Only Scan using _hyper_2_12_chunk_tmp_idx on _timescaledb_internal._hyper_2_12_chunk (actual rows=504 loops=1)
          Output: _hyper_2_12_chunk.device_id
@@ -6370,9 +6370,9 @@ ORDER BY device_id_peer,
          ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_4_chunk (actual rows=0 loops=1)
                Output: _hyper_2_4_chunk."time", _hyper_2_4_chunk.device_id, _hyper_2_4_chunk.device_id_peer, _hyper_2_4_chunk.v0, _hyper_2_4_chunk.v1, _hyper_2_4_chunk.v2, _hyper_2_4_chunk.v3
                Bulk Decompression: true
-               ->  Index Scan using compress_hyper_6_17_chunk__compressed_hypertable_6_device_id_pe on _timescaledb_internal.compress_hyper_6_17_chunk (actual rows=0 loops=1)
-                     Output: compress_hyper_6_17_chunk."time", compress_hyper_6_17_chunk.device_id, compress_hyper_6_17_chunk.device_id_peer, compress_hyper_6_17_chunk.v0, compress_hyper_6_17_chunk.v1, compress_hyper_6_17_chunk.v2, compress_hyper_6_17_chunk.v3, compress_hyper_6_17_chunk._ts_meta_count, compress_hyper_6_17_chunk._ts_meta_sequence_num, compress_hyper_6_17_chunk._ts_meta_min_3, compress_hyper_6_17_chunk._ts_meta_max_3, compress_hyper_6_17_chunk._ts_meta_min_1, compress_hyper_6_17_chunk._ts_meta_max_1, compress_hyper_6_17_chunk._ts_meta_min_2, compress_hyper_6_17_chunk._ts_meta_max_2
-                     Index Cond: (compress_hyper_6_17_chunk.device_id_peer = 1)
+               ->  Index Scan using compress_hyper_6_18_chunk__compressed_hypertable_6_device_id_pe on _timescaledb_internal.compress_hyper_6_18_chunk (actual rows=0 loops=1)
+                     Output: compress_hyper_6_18_chunk."time", compress_hyper_6_18_chunk.device_id, compress_hyper_6_18_chunk.device_id_peer, compress_hyper_6_18_chunk.v0, compress_hyper_6_18_chunk.v1, compress_hyper_6_18_chunk.v2, compress_hyper_6_18_chunk.v3, compress_hyper_6_18_chunk._ts_meta_count, compress_hyper_6_18_chunk._ts_meta_sequence_num, compress_hyper_6_18_chunk._ts_meta_min_3, compress_hyper_6_18_chunk._ts_meta_max_3, compress_hyper_6_18_chunk._ts_meta_min_1, compress_hyper_6_18_chunk._ts_meta_max_1, compress_hyper_6_18_chunk._ts_meta_min_2, compress_hyper_6_18_chunk._ts_meta_max_2
+                     Index Cond: (compress_hyper_6_18_chunk.device_id_peer = 1)
    ->  Sort (actual rows=0 loops=1)
          Output: _hyper_2_5_chunk."time", _hyper_2_5_chunk.device_id, _hyper_2_5_chunk.device_id_peer, _hyper_2_5_chunk.v0, _hyper_2_5_chunk.v1, _hyper_2_5_chunk.v2, _hyper_2_5_chunk.v3
          Sort Key: _hyper_2_5_chunk."time"
@@ -6380,9 +6380,9 @@ ORDER BY device_id_peer,
          ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_5_chunk (actual rows=0 loops=1)
                Output: _hyper_2_5_chunk."time", _hyper_2_5_chunk.device_id, _hyper_2_5_chunk.device_id_peer, _hyper_2_5_chunk.v0, _hyper_2_5_chunk.v1, _hyper_2_5_chunk.v2, _hyper_2_5_chunk.v3
                Bulk Decompression: true
-               ->  Index Scan using compress_hyper_6_18_chunk__compressed_hypertable_6_device_id_pe on _timescaledb_internal.compress_hyper_6_18_chunk (actual rows=0 loops=1)
-                     Output: compress_hyper_6_18_chunk."time", compress_hyper_6_18_chunk.device_id, compress_hyper_6_18_chunk.device_id_peer, compress_hyper_6_18_chunk.v0, compress_hyper_6_18_chunk.v1, compress_hyper_6_18_chunk.v2, compress_hyper_6_18_chunk.v3, compress_hyper_6_18_chunk._ts_meta_count, compress_hyper_6_18_chunk._ts_meta_sequence_num, compress_hyper_6_18_chunk._ts_meta_min_3, compress_hyper_6_18_chunk._ts_meta_max_3, compress_hyper_6_18_chunk._ts_meta_min_1, compress_hyper_6_18_chunk._ts_meta_max_1, compress_hyper_6_18_chunk._ts_meta_min_2, compress_hyper_6_18_chunk._ts_meta_max_2
-                     Index Cond: (compress_hyper_6_18_chunk.device_id_peer = 1)
+               ->  Index Scan using compress_hyper_6_19_chunk__compressed_hypertable_6_device_id_pe on _timescaledb_internal.compress_hyper_6_19_chunk (actual rows=0 loops=1)
+                     Output: compress_hyper_6_19_chunk."time", compress_hyper_6_19_chunk.device_id, compress_hyper_6_19_chunk.device_id_peer, compress_hyper_6_19_chunk.v0, compress_hyper_6_19_chunk.v1, compress_hyper_6_19_chunk.v2, compress_hyper_6_19_chunk.v3, compress_hyper_6_19_chunk._ts_meta_count, compress_hyper_6_19_chunk._ts_meta_sequence_num, compress_hyper_6_19_chunk._ts_meta_min_3, compress_hyper_6_19_chunk._ts_meta_max_3, compress_hyper_6_19_chunk._ts_meta_min_1, compress_hyper_6_19_chunk._ts_meta_max_1, compress_hyper_6_19_chunk._ts_meta_min_2, compress_hyper_6_19_chunk._ts_meta_max_2
+                     Index Cond: (compress_hyper_6_19_chunk.device_id_peer = 1)
    ->  Sort (actual rows=0 loops=1)
          Output: _hyper_2_6_chunk."time", _hyper_2_6_chunk.device_id, _hyper_2_6_chunk.device_id_peer, _hyper_2_6_chunk.v0, _hyper_2_6_chunk.v1, _hyper_2_6_chunk.v2, _hyper_2_6_chunk.v3
          Sort Key: _hyper_2_6_chunk."time"
@@ -6390,9 +6390,9 @@ ORDER BY device_id_peer,
          ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_6_chunk (actual rows=0 loops=1)
                Output: _hyper_2_6_chunk."time", _hyper_2_6_chunk.device_id, _hyper_2_6_chunk.device_id_peer, _hyper_2_6_chunk.v0, _hyper_2_6_chunk.v1, _hyper_2_6_chunk.v2, _hyper_2_6_chunk.v3
                Bulk Decompression: true
-               ->  Index Scan using compress_hyper_6_19_chunk__compressed_hypertable_6_device_id_pe on _timescaledb_internal.compress_hyper_6_19_chunk (actual rows=0 loops=1)
-                     Output: compress_hyper_6_19_chunk."time", compress_hyper_6_19_chunk.device_id, compress_hyper_6_19_chunk.device_id_peer, compress_hyper_6_19_chunk.v0, compress_hyper_6_19_chunk.v1, compress_hyper_6_19_chunk.v2, compress_hyper_6_19_chunk.v3, compress_hyper_6_19_chunk._ts_meta_count, compress_hyper_6_19_chunk._ts_meta_sequence_num, compress_hyper_6_19_chunk._ts_meta_min_3, compress_hyper_6_19_chunk._ts_meta_max_3, compress_hyper_6_19_chunk._ts_meta_min_1, compress_hyper_6_19_chunk._ts_meta_max_1, compress_hyper_6_19_chunk._ts_meta_min_2, compress_hyper_6_19_chunk._ts_meta_max_2
-                     Index Cond: (compress_hyper_6_19_chunk.device_id_peer = 1)
+               ->  Index Scan using compress_hyper_6_20_chunk__compressed_hypertable_6_device_id_pe on _timescaledb_internal.compress_hyper_6_20_chunk (actual rows=0 loops=1)
+                     Output: compress_hyper_6_20_chunk."time", compress_hyper_6_20_chunk.device_id, compress_hyper_6_20_chunk.device_id_peer, compress_hyper_6_20_chunk.v0, compress_hyper_6_20_chunk.v1, compress_hyper_6_20_chunk.v2, compress_hyper_6_20_chunk.v3, compress_hyper_6_20_chunk._ts_meta_count, compress_hyper_6_20_chunk._ts_meta_sequence_num, compress_hyper_6_20_chunk._ts_meta_min_3, compress_hyper_6_20_chunk._ts_meta_max_3, compress_hyper_6_20_chunk._ts_meta_min_1, compress_hyper_6_20_chunk._ts_meta_max_1, compress_hyper_6_20_chunk._ts_meta_min_2, compress_hyper_6_20_chunk._ts_meta_max_2
+                     Index Cond: (compress_hyper_6_20_chunk.device_id_peer = 1)
    ->  Index Scan Backward using _hyper_2_7_chunk_metrics_space_time_idx on _timescaledb_internal._hyper_2_7_chunk (actual rows=0 loops=1)
          Output: _hyper_2_7_chunk."time", _hyper_2_7_chunk.device_id, _hyper_2_7_chunk.device_id_peer, _hyper_2_7_chunk.v0, _hyper_2_7_chunk.v1, _hyper_2_7_chunk.v2, _hyper_2_7_chunk.v3
          Filter: (_hyper_2_7_chunk.device_id_peer = 1)
@@ -6412,9 +6412,9 @@ ORDER BY device_id_peer,
          ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_10_chunk (actual rows=0 loops=1)
                Output: _hyper_2_10_chunk."time", _hyper_2_10_chunk.device_id, _hyper_2_10_chunk.device_id_peer, _hyper_2_10_chunk.v0, _hyper_2_10_chunk.v1, _hyper_2_10_chunk.v2, _hyper_2_10_chunk.v3
                Bulk Decompression: true
-               ->  Index Scan using compress_hyper_6_20_chunk__compressed_hypertable_6_device_id_pe on _timescaledb_internal.compress_hyper_6_20_chunk (actual rows=0 loops=1)
-                     Output: compress_hyper_6_20_chunk."time", compress_hyper_6_20_chunk.device_id, compress_hyper_6_20_chunk.device_id_peer, compress_hyper_6_20_chunk.v0, compress_hyper_6_20_chunk.v1, compress_hyper_6_20_chunk.v2, compress_hyper_6_20_chunk.v3, compress_hyper_6_20_chunk._ts_meta_count, compress_hyper_6_20_chunk._ts_meta_sequence_num, compress_hyper_6_20_chunk._ts_meta_min_3, compress_hyper_6_20_chunk._ts_meta_max_3, compress_hyper_6_20_chunk._ts_meta_min_1, compress_hyper_6_20_chunk._ts_meta_max_1, compress_hyper_6_20_chunk._ts_meta_min_2, compress_hyper_6_20_chunk._ts_meta_max_2
-                     Index Cond: (compress_hyper_6_20_chunk.device_id_peer = 1)
+               ->  Index Scan using compress_hyper_6_24_chunk__compressed_hypertable_6_device_id_pe on _timescaledb_internal.compress_hyper_6_24_chunk (actual rows=0 loops=1)
+                     Output: compress_hyper_6_24_chunk."time", compress_hyper_6_24_chunk.device_id, compress_hyper_6_24_chunk.device_id_peer, compress_hyper_6_24_chunk.v0, compress_hyper_6_24_chunk.v1, compress_hyper_6_24_chunk.v2, compress_hyper_6_24_chunk.v3, compress_hyper_6_24_chunk._ts_meta_count, compress_hyper_6_24_chunk._ts_meta_sequence_num, compress_hyper_6_24_chunk._ts_meta_min_3, compress_hyper_6_24_chunk._ts_meta_max_3, compress_hyper_6_24_chunk._ts_meta_min_1, compress_hyper_6_24_chunk._ts_meta_max_1, compress_hyper_6_24_chunk._ts_meta_min_2, compress_hyper_6_24_chunk._ts_meta_max_2
+                     Index Cond: (compress_hyper_6_24_chunk.device_id_peer = 1)
    ->  Sort (actual rows=0 loops=1)
          Output: _hyper_2_11_chunk."time", _hyper_2_11_chunk.device_id, _hyper_2_11_chunk.device_id_peer, _hyper_2_11_chunk.v0, _hyper_2_11_chunk.v1, _hyper_2_11_chunk.v2, _hyper_2_11_chunk.v3
          Sort Key: _hyper_2_11_chunk."time"
@@ -6422,9 +6422,9 @@ ORDER BY device_id_peer,
          ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_11_chunk (actual rows=0 loops=1)
                Output: _hyper_2_11_chunk."time", _hyper_2_11_chunk.device_id, _hyper_2_11_chunk.device_id_peer, _hyper_2_11_chunk.v0, _hyper_2_11_chunk.v1, _hyper_2_11_chunk.v2, _hyper_2_11_chunk.v3
                Bulk Decompression: true
-               ->  Index Scan using compress_hyper_6_21_chunk__compressed_hypertable_6_device_id_pe on _timescaledb_internal.compress_hyper_6_21_chunk (actual rows=0 loops=1)
-                     Output: compress_hyper_6_21_chunk."time", compress_hyper_6_21_chunk.device_id, compress_hyper_6_21_chunk.device_id_peer, compress_hyper_6_21_chunk.v0, compress_hyper_6_21_chunk.v1, compress_hyper_6_21_chunk.v2, compress_hyper_6_21_chunk.v3, compress_hyper_6_21_chunk._ts_meta_count, compress_hyper_6_21_chunk._ts_meta_sequence_num, compress_hyper_6_21_chunk._ts_meta_min_3, compress_hyper_6_21_chunk._ts_meta_max_3, compress_hyper_6_21_chunk._ts_meta_min_1, compress_hyper_6_21_chunk._ts_meta_max_1, compress_hyper_6_21_chunk._ts_meta_min_2, compress_hyper_6_21_chunk._ts_meta_max_2
-                     Index Cond: (compress_hyper_6_21_chunk.device_id_peer = 1)
+               ->  Index Scan using compress_hyper_6_25_chunk__compressed_hypertable_6_device_id_pe on _timescaledb_internal.compress_hyper_6_25_chunk (actual rows=0 loops=1)
+                     Output: compress_hyper_6_25_chunk."time", compress_hyper_6_25_chunk.device_id, compress_hyper_6_25_chunk.device_id_peer, compress_hyper_6_25_chunk.v0, compress_hyper_6_25_chunk.v1, compress_hyper_6_25_chunk.v2, compress_hyper_6_25_chunk.v3, compress_hyper_6_25_chunk._ts_meta_count, compress_hyper_6_25_chunk._ts_meta_sequence_num, compress_hyper_6_25_chunk._ts_meta_min_3, compress_hyper_6_25_chunk._ts_meta_max_3, compress_hyper_6_25_chunk._ts_meta_min_1, compress_hyper_6_25_chunk._ts_meta_max_1, compress_hyper_6_25_chunk._ts_meta_min_2, compress_hyper_6_25_chunk._ts_meta_max_2
+                     Index Cond: (compress_hyper_6_25_chunk.device_id_peer = 1)
    ->  Index Scan Backward using _hyper_2_12_chunk_metrics_space_time_idx on _timescaledb_internal._hyper_2_12_chunk (actual rows=0 loops=1)
          Output: _hyper_2_12_chunk."time", _hyper_2_12_chunk.device_id, _hyper_2_12_chunk.device_id_peer, _hyper_2_12_chunk.v0, _hyper_2_12_chunk.v1, _hyper_2_12_chunk.v2, _hyper_2_12_chunk.v3
          Filter: (_hyper_2_12_chunk.device_id_peer = 1)
@@ -6442,21 +6442,21 @@ ORDER BY device_id_peer;
    ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_4_chunk (actual rows=0 loops=1)
          Output: _hyper_2_4_chunk.device_id_peer
          Bulk Decompression: false
-         ->  Index Scan using compress_hyper_6_17_chunk__compressed_hypertable_6_device_id_pe on _timescaledb_internal.compress_hyper_6_17_chunk (actual rows=0 loops=1)
-               Output: compress_hyper_6_17_chunk."time", compress_hyper_6_17_chunk.device_id, compress_hyper_6_17_chunk.device_id_peer, compress_hyper_6_17_chunk.v0, compress_hyper_6_17_chunk.v1, compress_hyper_6_17_chunk.v2, compress_hyper_6_17_chunk.v3, compress_hyper_6_17_chunk._ts_meta_count, compress_hyper_6_17_chunk._ts_meta_sequence_num, compress_hyper_6_17_chunk._ts_meta_min_3, compress_hyper_6_17_chunk._ts_meta_max_3, compress_hyper_6_17_chunk._ts_meta_min_1, compress_hyper_6_17_chunk._ts_meta_max_1, compress_hyper_6_17_chunk._ts_meta_min_2, compress_hyper_6_17_chunk._ts_meta_max_2
-               Index Cond: (compress_hyper_6_17_chunk.device_id_peer = 1)
-   ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_5_chunk (actual rows=0 loops=1)
-         Output: _hyper_2_5_chunk.device_id_peer
-         Bulk Decompression: false
          ->  Index Scan using compress_hyper_6_18_chunk__compressed_hypertable_6_device_id_pe on _timescaledb_internal.compress_hyper_6_18_chunk (actual rows=0 loops=1)
                Output: compress_hyper_6_18_chunk."time", compress_hyper_6_18_chunk.device_id, compress_hyper_6_18_chunk.device_id_peer, compress_hyper_6_18_chunk.v0, compress_hyper_6_18_chunk.v1, compress_hyper_6_18_chunk.v2, compress_hyper_6_18_chunk.v3, compress_hyper_6_18_chunk._ts_meta_count, compress_hyper_6_18_chunk._ts_meta_sequence_num, compress_hyper_6_18_chunk._ts_meta_min_3, compress_hyper_6_18_chunk._ts_meta_max_3, compress_hyper_6_18_chunk._ts_meta_min_1, compress_hyper_6_18_chunk._ts_meta_max_1, compress_hyper_6_18_chunk._ts_meta_min_2, compress_hyper_6_18_chunk._ts_meta_max_2
                Index Cond: (compress_hyper_6_18_chunk.device_id_peer = 1)
-   ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_6_chunk (actual rows=0 loops=1)
-         Output: _hyper_2_6_chunk.device_id_peer
+   ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_5_chunk (actual rows=0 loops=1)
+         Output: _hyper_2_5_chunk.device_id_peer
          Bulk Decompression: false
          ->  Index Scan using compress_hyper_6_19_chunk__compressed_hypertable_6_device_id_pe on _timescaledb_internal.compress_hyper_6_19_chunk (actual rows=0 loops=1)
                Output: compress_hyper_6_19_chunk."time", compress_hyper_6_19_chunk.device_id, compress_hyper_6_19_chunk.device_id_peer, compress_hyper_6_19_chunk.v0, compress_hyper_6_19_chunk.v1, compress_hyper_6_19_chunk.v2, compress_hyper_6_19_chunk.v3, compress_hyper_6_19_chunk._ts_meta_count, compress_hyper_6_19_chunk._ts_meta_sequence_num, compress_hyper_6_19_chunk._ts_meta_min_3, compress_hyper_6_19_chunk._ts_meta_max_3, compress_hyper_6_19_chunk._ts_meta_min_1, compress_hyper_6_19_chunk._ts_meta_max_1, compress_hyper_6_19_chunk._ts_meta_min_2, compress_hyper_6_19_chunk._ts_meta_max_2
                Index Cond: (compress_hyper_6_19_chunk.device_id_peer = 1)
+   ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_6_chunk (actual rows=0 loops=1)
+         Output: _hyper_2_6_chunk.device_id_peer
+         Bulk Decompression: false
+         ->  Index Scan using compress_hyper_6_20_chunk__compressed_hypertable_6_device_id_pe on _timescaledb_internal.compress_hyper_6_20_chunk (actual rows=0 loops=1)
+               Output: compress_hyper_6_20_chunk."time", compress_hyper_6_20_chunk.device_id, compress_hyper_6_20_chunk.device_id_peer, compress_hyper_6_20_chunk.v0, compress_hyper_6_20_chunk.v1, compress_hyper_6_20_chunk.v2, compress_hyper_6_20_chunk.v3, compress_hyper_6_20_chunk._ts_meta_count, compress_hyper_6_20_chunk._ts_meta_sequence_num, compress_hyper_6_20_chunk._ts_meta_min_3, compress_hyper_6_20_chunk._ts_meta_max_3, compress_hyper_6_20_chunk._ts_meta_min_1, compress_hyper_6_20_chunk._ts_meta_max_1, compress_hyper_6_20_chunk._ts_meta_min_2, compress_hyper_6_20_chunk._ts_meta_max_2
+               Index Cond: (compress_hyper_6_20_chunk.device_id_peer = 1)
    ->  Index Only Scan using _hyper_2_7_chunk_metrics_space_device_id_device_id_peer_v0_v1_2 on _timescaledb_internal._hyper_2_7_chunk (actual rows=0 loops=1)
          Output: _hyper_2_7_chunk.device_id_peer
          Index Cond: (_hyper_2_7_chunk.device_id_peer = 1)
@@ -6472,15 +6472,15 @@ ORDER BY device_id_peer;
    ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_10_chunk (actual rows=0 loops=1)
          Output: _hyper_2_10_chunk.device_id_peer
          Bulk Decompression: false
-         ->  Index Scan using compress_hyper_6_20_chunk__compressed_hypertable_6_device_id_pe on _timescaledb_internal.compress_hyper_6_20_chunk (actual rows=0 loops=1)
-               Output: compress_hyper_6_20_chunk."time", compress_hyper_6_20_chunk.device_id, compress_hyper_6_20_chunk.device_id_peer, compress_hyper_6_20_chunk.v0, compress_hyper_6_20_chunk.v1, compress_hyper_6_20_chunk.v2, compress_hyper_6_20_chunk.v3, compress_hyper_6_20_chunk._ts_meta_count, compress_hyper_6_20_chunk._ts_meta_sequence_num, compress_hyper_6_20_chunk._ts_meta_min_3, compress_hyper_6_20_chunk._ts_meta_max_3, compress_hyper_6_20_chunk._ts_meta_min_1, compress_hyper_6_20_chunk._ts_meta_max_1, compress_hyper_6_20_chunk._ts_meta_min_2, compress_hyper_6_20_chunk._ts_meta_max_2
-               Index Cond: (compress_hyper_6_20_chunk.device_id_peer = 1)
+         ->  Index Scan using compress_hyper_6_24_chunk__compressed_hypertable_6_device_id_pe on _timescaledb_internal.compress_hyper_6_24_chunk (actual rows=0 loops=1)
+               Output: compress_hyper_6_24_chunk."time", compress_hyper_6_24_chunk.device_id, compress_hyper_6_24_chunk.device_id_peer, compress_hyper_6_24_chunk.v0, compress_hyper_6_24_chunk.v1, compress_hyper_6_24_chunk.v2, compress_hyper_6_24_chunk.v3, compress_hyper_6_24_chunk._ts_meta_count, compress_hyper_6_24_chunk._ts_meta_sequence_num, compress_hyper_6_24_chunk._ts_meta_min_3, compress_hyper_6_24_chunk._ts_meta_max_3, compress_hyper_6_24_chunk._ts_meta_min_1, compress_hyper_6_24_chunk._ts_meta_max_1, compress_hyper_6_24_chunk._ts_meta_min_2, compress_hyper_6_24_chunk._ts_meta_max_2
+               Index Cond: (compress_hyper_6_24_chunk.device_id_peer = 1)
    ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_11_chunk (actual rows=0 loops=1)
          Output: _hyper_2_11_chunk.device_id_peer
          Bulk Decompression: false
-         ->  Index Scan using compress_hyper_6_21_chunk__compressed_hypertable_6_device_id_pe on _timescaledb_internal.compress_hyper_6_21_chunk (actual rows=0 loops=1)
-               Output: compress_hyper_6_21_chunk."time", compress_hyper_6_21_chunk.device_id, compress_hyper_6_21_chunk.device_id_peer, compress_hyper_6_21_chunk.v0, compress_hyper_6_21_chunk.v1, compress_hyper_6_21_chunk.v2, compress_hyper_6_21_chunk.v3, compress_hyper_6_21_chunk._ts_meta_count, compress_hyper_6_21_chunk._ts_meta_sequence_num, compress_hyper_6_21_chunk._ts_meta_min_3, compress_hyper_6_21_chunk._ts_meta_max_3, compress_hyper_6_21_chunk._ts_meta_min_1, compress_hyper_6_21_chunk._ts_meta_max_1, compress_hyper_6_21_chunk._ts_meta_min_2, compress_hyper_6_21_chunk._ts_meta_max_2
-               Index Cond: (compress_hyper_6_21_chunk.device_id_peer = 1)
+         ->  Index Scan using compress_hyper_6_25_chunk__compressed_hypertable_6_device_id_pe on _timescaledb_internal.compress_hyper_6_25_chunk (actual rows=0 loops=1)
+               Output: compress_hyper_6_25_chunk."time", compress_hyper_6_25_chunk.device_id, compress_hyper_6_25_chunk.device_id_peer, compress_hyper_6_25_chunk.v0, compress_hyper_6_25_chunk.v1, compress_hyper_6_25_chunk.v2, compress_hyper_6_25_chunk.v3, compress_hyper_6_25_chunk._ts_meta_count, compress_hyper_6_25_chunk._ts_meta_sequence_num, compress_hyper_6_25_chunk._ts_meta_min_3, compress_hyper_6_25_chunk._ts_meta_max_3, compress_hyper_6_25_chunk._ts_meta_min_1, compress_hyper_6_25_chunk._ts_meta_max_1, compress_hyper_6_25_chunk._ts_meta_min_2, compress_hyper_6_25_chunk._ts_meta_max_2
+               Index Cond: (compress_hyper_6_25_chunk.device_id_peer = 1)
    ->  Index Only Scan using _hyper_2_12_chunk_metrics_space_device_id_device_id_peer_v0_v_2 on _timescaledb_internal._hyper_2_12_chunk (actual rows=0 loops=1)
          Output: _hyper_2_12_chunk.device_id_peer
          Index Cond: (_hyper_2_12_chunk.device_id_peer = 1)
@@ -6501,23 +6501,23 @@ WHERE device_id_peer IN (
    ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_4_chunk (actual rows=0 loops=1)
          Output: _hyper_2_4_chunk.device_id_peer
          Bulk Decompression: false
-         ->  Seq Scan on _timescaledb_internal.compress_hyper_6_17_chunk (actual rows=0 loops=1)
-               Output: compress_hyper_6_17_chunk."time", compress_hyper_6_17_chunk.device_id, compress_hyper_6_17_chunk.device_id_peer, compress_hyper_6_17_chunk.v0, compress_hyper_6_17_chunk.v1, compress_hyper_6_17_chunk.v2, compress_hyper_6_17_chunk.v3, compress_hyper_6_17_chunk._ts_meta_count, compress_hyper_6_17_chunk._ts_meta_sequence_num, compress_hyper_6_17_chunk._ts_meta_min_3, compress_hyper_6_17_chunk._ts_meta_max_3, compress_hyper_6_17_chunk._ts_meta_min_1, compress_hyper_6_17_chunk._ts_meta_max_1, compress_hyper_6_17_chunk._ts_meta_min_2, compress_hyper_6_17_chunk._ts_meta_max_2
-               Filter: (compress_hyper_6_17_chunk.device_id_peer = 1)
+         ->  Seq Scan on _timescaledb_internal.compress_hyper_6_18_chunk (actual rows=0 loops=1)
+               Output: compress_hyper_6_18_chunk."time", compress_hyper_6_18_chunk.device_id, compress_hyper_6_18_chunk.device_id_peer, compress_hyper_6_18_chunk.v0, compress_hyper_6_18_chunk.v1, compress_hyper_6_18_chunk.v2, compress_hyper_6_18_chunk.v3, compress_hyper_6_18_chunk._ts_meta_count, compress_hyper_6_18_chunk._ts_meta_sequence_num, compress_hyper_6_18_chunk._ts_meta_min_3, compress_hyper_6_18_chunk._ts_meta_max_3, compress_hyper_6_18_chunk._ts_meta_min_1, compress_hyper_6_18_chunk._ts_meta_max_1, compress_hyper_6_18_chunk._ts_meta_min_2, compress_hyper_6_18_chunk._ts_meta_max_2
+               Filter: (compress_hyper_6_18_chunk.device_id_peer = 1)
                Rows Removed by Filter: 1
    ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_5_chunk (actual rows=0 loops=1)
          Output: _hyper_2_5_chunk.device_id_peer
          Bulk Decompression: false
-         ->  Seq Scan on _timescaledb_internal.compress_hyper_6_18_chunk (actual rows=0 loops=1)
-               Output: compress_hyper_6_18_chunk."time", compress_hyper_6_18_chunk.device_id, compress_hyper_6_18_chunk.device_id_peer, compress_hyper_6_18_chunk.v0, compress_hyper_6_18_chunk.v1, compress_hyper_6_18_chunk.v2, compress_hyper_6_18_chunk.v3, compress_hyper_6_18_chunk._ts_meta_count, compress_hyper_6_18_chunk._ts_meta_sequence_num, compress_hyper_6_18_chunk._ts_meta_min_3, compress_hyper_6_18_chunk._ts_meta_max_3, compress_hyper_6_18_chunk._ts_meta_min_1, compress_hyper_6_18_chunk._ts_meta_max_1, compress_hyper_6_18_chunk._ts_meta_min_2, compress_hyper_6_18_chunk._ts_meta_max_2
-               Filter: (compress_hyper_6_18_chunk.device_id_peer = 1)
+         ->  Seq Scan on _timescaledb_internal.compress_hyper_6_19_chunk (actual rows=0 loops=1)
+               Output: compress_hyper_6_19_chunk."time", compress_hyper_6_19_chunk.device_id, compress_hyper_6_19_chunk.device_id_peer, compress_hyper_6_19_chunk.v0, compress_hyper_6_19_chunk.v1, compress_hyper_6_19_chunk.v2, compress_hyper_6_19_chunk.v3, compress_hyper_6_19_chunk._ts_meta_count, compress_hyper_6_19_chunk._ts_meta_sequence_num, compress_hyper_6_19_chunk._ts_meta_min_3, compress_hyper_6_19_chunk._ts_meta_max_3, compress_hyper_6_19_chunk._ts_meta_min_1, compress_hyper_6_19_chunk._ts_meta_max_1, compress_hyper_6_19_chunk._ts_meta_min_2, compress_hyper_6_19_chunk._ts_meta_max_2
+               Filter: (compress_hyper_6_19_chunk.device_id_peer = 1)
                Rows Removed by Filter: 3
    ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_6_chunk (actual rows=0 loops=1)
          Output: _hyper_2_6_chunk.device_id_peer
          Bulk Decompression: false
-         ->  Seq Scan on _timescaledb_internal.compress_hyper_6_19_chunk (actual rows=0 loops=1)
-               Output: compress_hyper_6_19_chunk."time", compress_hyper_6_19_chunk.device_id, compress_hyper_6_19_chunk.device_id_peer, compress_hyper_6_19_chunk.v0, compress_hyper_6_19_chunk.v1, compress_hyper_6_19_chunk.v2, compress_hyper_6_19_chunk.v3, compress_hyper_6_19_chunk._ts_meta_count, compress_hyper_6_19_chunk._ts_meta_sequence_num, compress_hyper_6_19_chunk._ts_meta_min_3, compress_hyper_6_19_chunk._ts_meta_max_3, compress_hyper_6_19_chunk._ts_meta_min_1, compress_hyper_6_19_chunk._ts_meta_max_1, compress_hyper_6_19_chunk._ts_meta_min_2, compress_hyper_6_19_chunk._ts_meta_max_2
-               Filter: (compress_hyper_6_19_chunk.device_id_peer = 1)
+         ->  Seq Scan on _timescaledb_internal.compress_hyper_6_20_chunk (actual rows=0 loops=1)
+               Output: compress_hyper_6_20_chunk."time", compress_hyper_6_20_chunk.device_id, compress_hyper_6_20_chunk.device_id_peer, compress_hyper_6_20_chunk.v0, compress_hyper_6_20_chunk.v1, compress_hyper_6_20_chunk.v2, compress_hyper_6_20_chunk.v3, compress_hyper_6_20_chunk._ts_meta_count, compress_hyper_6_20_chunk._ts_meta_sequence_num, compress_hyper_6_20_chunk._ts_meta_min_3, compress_hyper_6_20_chunk._ts_meta_max_3, compress_hyper_6_20_chunk._ts_meta_min_1, compress_hyper_6_20_chunk._ts_meta_max_1, compress_hyper_6_20_chunk._ts_meta_min_2, compress_hyper_6_20_chunk._ts_meta_max_2
+               Filter: (compress_hyper_6_20_chunk.device_id_peer = 1)
                Rows Removed by Filter: 1
    ->  Index Only Scan using _hyper_2_7_chunk_metrics_space_device_id_device_id_peer_v0_v1_2 on _timescaledb_internal._hyper_2_7_chunk (actual rows=0 loops=1)
          Output: _hyper_2_7_chunk.device_id_peer
@@ -6534,16 +6534,16 @@ WHERE device_id_peer IN (
    ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_10_chunk (actual rows=0 loops=1)
          Output: _hyper_2_10_chunk.device_id_peer
          Bulk Decompression: false
-         ->  Seq Scan on _timescaledb_internal.compress_hyper_6_20_chunk (actual rows=0 loops=1)
-               Output: compress_hyper_6_20_chunk."time", compress_hyper_6_20_chunk.device_id, compress_hyper_6_20_chunk.device_id_peer, compress_hyper_6_20_chunk.v0, compress_hyper_6_20_chunk.v1, compress_hyper_6_20_chunk.v2, compress_hyper_6_20_chunk.v3, compress_hyper_6_20_chunk._ts_meta_count, compress_hyper_6_20_chunk._ts_meta_sequence_num, compress_hyper_6_20_chunk._ts_meta_min_3, compress_hyper_6_20_chunk._ts_meta_max_3, compress_hyper_6_20_chunk._ts_meta_min_1, compress_hyper_6_20_chunk._ts_meta_max_1, compress_hyper_6_20_chunk._ts_meta_min_2, compress_hyper_6_20_chunk._ts_meta_max_2
-               Filter: (compress_hyper_6_20_chunk.device_id_peer = 1)
+         ->  Seq Scan on _timescaledb_internal.compress_hyper_6_24_chunk (actual rows=0 loops=1)
+               Output: compress_hyper_6_24_chunk."time", compress_hyper_6_24_chunk.device_id, compress_hyper_6_24_chunk.device_id_peer, compress_hyper_6_24_chunk.v0, compress_hyper_6_24_chunk.v1, compress_hyper_6_24_chunk.v2, compress_hyper_6_24_chunk.v3, compress_hyper_6_24_chunk._ts_meta_count, compress_hyper_6_24_chunk._ts_meta_sequence_num, compress_hyper_6_24_chunk._ts_meta_min_3, compress_hyper_6_24_chunk._ts_meta_max_3, compress_hyper_6_24_chunk._ts_meta_min_1, compress_hyper_6_24_chunk._ts_meta_max_1, compress_hyper_6_24_chunk._ts_meta_min_2, compress_hyper_6_24_chunk._ts_meta_max_2
+               Filter: (compress_hyper_6_24_chunk.device_id_peer = 1)
                Rows Removed by Filter: 1
    ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_11_chunk (actual rows=0 loops=1)
          Output: _hyper_2_11_chunk.device_id_peer
          Bulk Decompression: false
-         ->  Seq Scan on _timescaledb_internal.compress_hyper_6_21_chunk (actual rows=0 loops=1)
-               Output: compress_hyper_6_21_chunk."time", compress_hyper_6_21_chunk.device_id, compress_hyper_6_21_chunk.device_id_peer, compress_hyper_6_21_chunk.v0, compress_hyper_6_21_chunk.v1, compress_hyper_6_21_chunk.v2, compress_hyper_6_21_chunk.v3, compress_hyper_6_21_chunk._ts_meta_count, compress_hyper_6_21_chunk._ts_meta_sequence_num, compress_hyper_6_21_chunk._ts_meta_min_3, compress_hyper_6_21_chunk._ts_meta_max_3, compress_hyper_6_21_chunk._ts_meta_min_1, compress_hyper_6_21_chunk._ts_meta_max_1, compress_hyper_6_21_chunk._ts_meta_min_2, compress_hyper_6_21_chunk._ts_meta_max_2
-               Filter: (compress_hyper_6_21_chunk.device_id_peer = 1)
+         ->  Seq Scan on _timescaledb_internal.compress_hyper_6_25_chunk (actual rows=0 loops=1)
+               Output: compress_hyper_6_25_chunk."time", compress_hyper_6_25_chunk.device_id, compress_hyper_6_25_chunk.device_id_peer, compress_hyper_6_25_chunk.v0, compress_hyper_6_25_chunk.v1, compress_hyper_6_25_chunk.v2, compress_hyper_6_25_chunk.v3, compress_hyper_6_25_chunk._ts_meta_count, compress_hyper_6_25_chunk._ts_meta_sequence_num, compress_hyper_6_25_chunk._ts_meta_min_3, compress_hyper_6_25_chunk._ts_meta_max_3, compress_hyper_6_25_chunk._ts_meta_min_1, compress_hyper_6_25_chunk._ts_meta_max_1, compress_hyper_6_25_chunk._ts_meta_min_2, compress_hyper_6_25_chunk._ts_meta_max_2
+               Filter: (compress_hyper_6_25_chunk.device_id_peer = 1)
                Rows Removed by Filter: 3
    ->  Index Only Scan using _hyper_2_12_chunk_metrics_space_device_id_device_id_peer_v0_v_2 on _timescaledb_internal._hyper_2_12_chunk (actual rows=0 loops=1)
          Output: _hyper_2_12_chunk.device_id_peer
@@ -6568,18 +6568,18 @@ WHERE device_id_peer IN (
          ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_4_chunk (actual rows=360 loops=1)
                Output: _hyper_2_4_chunk.device_id_peer
                Bulk Decompression: false
-               ->  Seq Scan on _timescaledb_internal.compress_hyper_6_17_chunk (actual rows=1 loops=1)
-                     Output: compress_hyper_6_17_chunk."time", compress_hyper_6_17_chunk.device_id, compress_hyper_6_17_chunk.device_id_peer, compress_hyper_6_17_chunk.v0, compress_hyper_6_17_chunk.v1, compress_hyper_6_17_chunk.v2, compress_hyper_6_17_chunk.v3, compress_hyper_6_17_chunk._ts_meta_count, compress_hyper_6_17_chunk._ts_meta_sequence_num, compress_hyper_6_17_chunk._ts_meta_min_3, compress_hyper_6_17_chunk._ts_meta_max_3, compress_hyper_6_17_chunk._ts_meta_min_1, compress_hyper_6_17_chunk._ts_meta_max_1, compress_hyper_6_17_chunk._ts_meta_min_2, compress_hyper_6_17_chunk._ts_meta_max_2
+               ->  Seq Scan on _timescaledb_internal.compress_hyper_6_18_chunk (actual rows=1 loops=1)
+                     Output: compress_hyper_6_18_chunk."time", compress_hyper_6_18_chunk.device_id, compress_hyper_6_18_chunk.device_id_peer, compress_hyper_6_18_chunk.v0, compress_hyper_6_18_chunk.v1, compress_hyper_6_18_chunk.v2, compress_hyper_6_18_chunk.v3, compress_hyper_6_18_chunk._ts_meta_count, compress_hyper_6_18_chunk._ts_meta_sequence_num, compress_hyper_6_18_chunk._ts_meta_min_3, compress_hyper_6_18_chunk._ts_meta_max_3, compress_hyper_6_18_chunk._ts_meta_min_1, compress_hyper_6_18_chunk._ts_meta_max_1, compress_hyper_6_18_chunk._ts_meta_min_2, compress_hyper_6_18_chunk._ts_meta_max_2
          ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_5_chunk (actual rows=1080 loops=1)
                Output: _hyper_2_5_chunk.device_id_peer
                Bulk Decompression: false
-               ->  Seq Scan on _timescaledb_internal.compress_hyper_6_18_chunk (actual rows=3 loops=1)
-                     Output: compress_hyper_6_18_chunk."time", compress_hyper_6_18_chunk.device_id, compress_hyper_6_18_chunk.device_id_peer, compress_hyper_6_18_chunk.v0, compress_hyper_6_18_chunk.v1, compress_hyper_6_18_chunk.v2, compress_hyper_6_18_chunk.v3, compress_hyper_6_18_chunk._ts_meta_count, compress_hyper_6_18_chunk._ts_meta_sequence_num, compress_hyper_6_18_chunk._ts_meta_min_3, compress_hyper_6_18_chunk._ts_meta_max_3, compress_hyper_6_18_chunk._ts_meta_min_1, compress_hyper_6_18_chunk._ts_meta_max_1, compress_hyper_6_18_chunk._ts_meta_min_2, compress_hyper_6_18_chunk._ts_meta_max_2
+               ->  Seq Scan on _timescaledb_internal.compress_hyper_6_19_chunk (actual rows=3 loops=1)
+                     Output: compress_hyper_6_19_chunk."time", compress_hyper_6_19_chunk.device_id, compress_hyper_6_19_chunk.device_id_peer, compress_hyper_6_19_chunk.v0, compress_hyper_6_19_chunk.v1, compress_hyper_6_19_chunk.v2, compress_hyper_6_19_chunk.v3, compress_hyper_6_19_chunk._ts_meta_count, compress_hyper_6_19_chunk._ts_meta_sequence_num, compress_hyper_6_19_chunk._ts_meta_min_3, compress_hyper_6_19_chunk._ts_meta_max_3, compress_hyper_6_19_chunk._ts_meta_min_1, compress_hyper_6_19_chunk._ts_meta_max_1, compress_hyper_6_19_chunk._ts_meta_min_2, compress_hyper_6_19_chunk._ts_meta_max_2
          ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_6_chunk (actual rows=360 loops=1)
                Output: _hyper_2_6_chunk.device_id_peer
                Bulk Decompression: false
-               ->  Seq Scan on _timescaledb_internal.compress_hyper_6_19_chunk (actual rows=1 loops=1)
-                     Output: compress_hyper_6_19_chunk."time", compress_hyper_6_19_chunk.device_id, compress_hyper_6_19_chunk.device_id_peer, compress_hyper_6_19_chunk.v0, compress_hyper_6_19_chunk.v1, compress_hyper_6_19_chunk.v2, compress_hyper_6_19_chunk.v3, compress_hyper_6_19_chunk._ts_meta_count, compress_hyper_6_19_chunk._ts_meta_sequence_num, compress_hyper_6_19_chunk._ts_meta_min_3, compress_hyper_6_19_chunk._ts_meta_max_3, compress_hyper_6_19_chunk._ts_meta_min_1, compress_hyper_6_19_chunk._ts_meta_max_1, compress_hyper_6_19_chunk._ts_meta_min_2, compress_hyper_6_19_chunk._ts_meta_max_2
+               ->  Seq Scan on _timescaledb_internal.compress_hyper_6_20_chunk (actual rows=1 loops=1)
+                     Output: compress_hyper_6_20_chunk."time", compress_hyper_6_20_chunk.device_id, compress_hyper_6_20_chunk.device_id_peer, compress_hyper_6_20_chunk.v0, compress_hyper_6_20_chunk.v1, compress_hyper_6_20_chunk.v2, compress_hyper_6_20_chunk.v3, compress_hyper_6_20_chunk._ts_meta_count, compress_hyper_6_20_chunk._ts_meta_sequence_num, compress_hyper_6_20_chunk._ts_meta_min_3, compress_hyper_6_20_chunk._ts_meta_max_3, compress_hyper_6_20_chunk._ts_meta_min_1, compress_hyper_6_20_chunk._ts_meta_max_1, compress_hyper_6_20_chunk._ts_meta_min_2, compress_hyper_6_20_chunk._ts_meta_max_2
          ->  Seq Scan on _timescaledb_internal._hyper_2_7_chunk (actual rows=504 loops=1)
                Output: _hyper_2_7_chunk.device_id_peer
          ->  Seq Scan on _timescaledb_internal._hyper_2_8_chunk (actual rows=1512 loops=1)
@@ -6589,13 +6589,13 @@ WHERE device_id_peer IN (
          ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_10_chunk (actual rows=504 loops=1)
                Output: _hyper_2_10_chunk.device_id_peer
                Bulk Decompression: false
-               ->  Seq Scan on _timescaledb_internal.compress_hyper_6_20_chunk (actual rows=1 loops=1)
-                     Output: compress_hyper_6_20_chunk."time", compress_hyper_6_20_chunk.device_id, compress_hyper_6_20_chunk.device_id_peer, compress_hyper_6_20_chunk.v0, compress_hyper_6_20_chunk.v1, compress_hyper_6_20_chunk.v2, compress_hyper_6_20_chunk.v3, compress_hyper_6_20_chunk._ts_meta_count, compress_hyper_6_20_chunk._ts_meta_sequence_num, compress_hyper_6_20_chunk._ts_meta_min_3, compress_hyper_6_20_chunk._ts_meta_max_3, compress_hyper_6_20_chunk._ts_meta_min_1, compress_hyper_6_20_chunk._ts_meta_max_1, compress_hyper_6_20_chunk._ts_meta_min_2, compress_hyper_6_20_chunk._ts_meta_max_2
+               ->  Seq Scan on _timescaledb_internal.compress_hyper_6_24_chunk (actual rows=1 loops=1)
+                     Output: compress_hyper_6_24_chunk."time", compress_hyper_6_24_chunk.device_id, compress_hyper_6_24_chunk.device_id_peer, compress_hyper_6_24_chunk.v0, compress_hyper_6_24_chunk.v1, compress_hyper_6_24_chunk.v2, compress_hyper_6_24_chunk.v3, compress_hyper_6_24_chunk._ts_meta_count, compress_hyper_6_24_chunk._ts_meta_sequence_num, compress_hyper_6_24_chunk._ts_meta_min_3, compress_hyper_6_24_chunk._ts_meta_max_3, compress_hyper_6_24_chunk._ts_meta_min_1, compress_hyper_6_24_chunk._ts_meta_max_1, compress_hyper_6_24_chunk._ts_meta_min_2, compress_hyper_6_24_chunk._ts_meta_max_2
          ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_11_chunk (actual rows=1512 loops=1)
                Output: _hyper_2_11_chunk.device_id_peer
                Bulk Decompression: false
-               ->  Seq Scan on _timescaledb_internal.compress_hyper_6_21_chunk (actual rows=3 loops=1)
-                     Output: compress_hyper_6_21_chunk."time", compress_hyper_6_21_chunk.device_id, compress_hyper_6_21_chunk.device_id_peer, compress_hyper_6_21_chunk.v0, compress_hyper_6_21_chunk.v1, compress_hyper_6_21_chunk.v2, compress_hyper_6_21_chunk.v3, compress_hyper_6_21_chunk._ts_meta_count, compress_hyper_6_21_chunk._ts_meta_sequence_num, compress_hyper_6_21_chunk._ts_meta_min_3, compress_hyper_6_21_chunk._ts_meta_max_3, compress_hyper_6_21_chunk._ts_meta_min_1, compress_hyper_6_21_chunk._ts_meta_max_1, compress_hyper_6_21_chunk._ts_meta_min_2, compress_hyper_6_21_chunk._ts_meta_max_2
+               ->  Seq Scan on _timescaledb_internal.compress_hyper_6_25_chunk (actual rows=3 loops=1)
+                     Output: compress_hyper_6_25_chunk."time", compress_hyper_6_25_chunk.device_id, compress_hyper_6_25_chunk.device_id_peer, compress_hyper_6_25_chunk.v0, compress_hyper_6_25_chunk.v1, compress_hyper_6_25_chunk.v2, compress_hyper_6_25_chunk.v3, compress_hyper_6_25_chunk._ts_meta_count, compress_hyper_6_25_chunk._ts_meta_sequence_num, compress_hyper_6_25_chunk._ts_meta_min_3, compress_hyper_6_25_chunk._ts_meta_max_3, compress_hyper_6_25_chunk._ts_meta_min_1, compress_hyper_6_25_chunk._ts_meta_max_1, compress_hyper_6_25_chunk._ts_meta_min_2, compress_hyper_6_25_chunk._ts_meta_max_2
          ->  Seq Scan on _timescaledb_internal._hyper_2_12_chunk (actual rows=504 loops=1)
                Output: _hyper_2_12_chunk.device_id_peer
    ->  Materialize (actual rows=2 loops=6840)
@@ -6616,18 +6616,18 @@ WHERE device_id IN (
    ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_4_chunk (actual rows=360 loops=1)
          Output: _hyper_2_4_chunk.device_id_peer
          Bulk Decompression: false
-         ->  Seq Scan on _timescaledb_internal.compress_hyper_6_17_chunk (actual rows=1 loops=1)
-               Output: compress_hyper_6_17_chunk."time", compress_hyper_6_17_chunk.device_id, compress_hyper_6_17_chunk.device_id_peer, compress_hyper_6_17_chunk.v0, compress_hyper_6_17_chunk.v1, compress_hyper_6_17_chunk.v2, compress_hyper_6_17_chunk.v3, compress_hyper_6_17_chunk._ts_meta_count, compress_hyper_6_17_chunk._ts_meta_sequence_num, compress_hyper_6_17_chunk._ts_meta_min_3, compress_hyper_6_17_chunk._ts_meta_max_3, compress_hyper_6_17_chunk._ts_meta_min_1, compress_hyper_6_17_chunk._ts_meta_max_1, compress_hyper_6_17_chunk._ts_meta_min_2, compress_hyper_6_17_chunk._ts_meta_max_2
-               Filter: (compress_hyper_6_17_chunk.device_id = 1)
+         ->  Seq Scan on _timescaledb_internal.compress_hyper_6_18_chunk (actual rows=1 loops=1)
+               Output: compress_hyper_6_18_chunk."time", compress_hyper_6_18_chunk.device_id, compress_hyper_6_18_chunk.device_id_peer, compress_hyper_6_18_chunk.v0, compress_hyper_6_18_chunk.v1, compress_hyper_6_18_chunk.v2, compress_hyper_6_18_chunk.v3, compress_hyper_6_18_chunk._ts_meta_count, compress_hyper_6_18_chunk._ts_meta_sequence_num, compress_hyper_6_18_chunk._ts_meta_min_3, compress_hyper_6_18_chunk._ts_meta_max_3, compress_hyper_6_18_chunk._ts_meta_min_1, compress_hyper_6_18_chunk._ts_meta_max_1, compress_hyper_6_18_chunk._ts_meta_min_2, compress_hyper_6_18_chunk._ts_meta_max_2
+               Filter: (compress_hyper_6_18_chunk.device_id = 1)
    ->  Seq Scan on _timescaledb_internal._hyper_2_7_chunk (actual rows=504 loops=1)
          Output: _hyper_2_7_chunk.device_id_peer
          Filter: (_hyper_2_7_chunk.device_id = 1)
    ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_10_chunk (actual rows=504 loops=1)
          Output: _hyper_2_10_chunk.device_id_peer
          Bulk Decompression: false
-         ->  Seq Scan on _timescaledb_internal.compress_hyper_6_20_chunk (actual rows=1 loops=1)
-               Output: compress_hyper_6_20_chunk."time", compress_hyper_6_20_chunk.device_id, compress_hyper_6_20_chunk.device_id_peer, compress_hyper_6_20_chunk.v0, compress_hyper_6_20_chunk.v1, compress_hyper_6_20_chunk.v2, compress_hyper_6_20_chunk.v3, compress_hyper_6_20_chunk._ts_meta_count, compress_hyper_6_20_chunk._ts_meta_sequence_num, compress_hyper_6_20_chunk._ts_meta_min_3, compress_hyper_6_20_chunk._ts_meta_max_3, compress_hyper_6_20_chunk._ts_meta_min_1, compress_hyper_6_20_chunk._ts_meta_max_1, compress_hyper_6_20_chunk._ts_meta_min_2, compress_hyper_6_20_chunk._ts_meta_max_2
-               Filter: (compress_hyper_6_20_chunk.device_id = 1)
+         ->  Seq Scan on _timescaledb_internal.compress_hyper_6_24_chunk (actual rows=1 loops=1)
+               Output: compress_hyper_6_24_chunk."time", compress_hyper_6_24_chunk.device_id, compress_hyper_6_24_chunk.device_id_peer, compress_hyper_6_24_chunk.v0, compress_hyper_6_24_chunk.v1, compress_hyper_6_24_chunk.v2, compress_hyper_6_24_chunk.v3, compress_hyper_6_24_chunk._ts_meta_count, compress_hyper_6_24_chunk._ts_meta_sequence_num, compress_hyper_6_24_chunk._ts_meta_min_3, compress_hyper_6_24_chunk._ts_meta_max_3, compress_hyper_6_24_chunk._ts_meta_min_1, compress_hyper_6_24_chunk._ts_meta_max_1, compress_hyper_6_24_chunk._ts_meta_min_2, compress_hyper_6_24_chunk._ts_meta_max_2
+               Filter: (compress_hyper_6_24_chunk.device_id = 1)
 (16 rows)
 
 --with multiple values can get a semi-join or nested loop depending on seq_page_cost.
@@ -6646,18 +6646,18 @@ WHERE device_id IN (
          ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_4_chunk (actual rows=360 loops=1)
                Output: _hyper_2_4_chunk.device_id_peer, _hyper_2_4_chunk.device_id
                Bulk Decompression: false
-               ->  Seq Scan on _timescaledb_internal.compress_hyper_6_17_chunk (actual rows=1 loops=1)
-                     Output: compress_hyper_6_17_chunk."time", compress_hyper_6_17_chunk.device_id, compress_hyper_6_17_chunk.device_id_peer, compress_hyper_6_17_chunk.v0, compress_hyper_6_17_chunk.v1, compress_hyper_6_17_chunk.v2, compress_hyper_6_17_chunk.v3, compress_hyper_6_17_chunk._ts_meta_count, compress_hyper_6_17_chunk._ts_meta_sequence_num, compress_hyper_6_17_chunk._ts_meta_min_3, compress_hyper_6_17_chunk._ts_meta_max_3, compress_hyper_6_17_chunk._ts_meta_min_1, compress_hyper_6_17_chunk._ts_meta_max_1, compress_hyper_6_17_chunk._ts_meta_min_2, compress_hyper_6_17_chunk._ts_meta_max_2
+               ->  Seq Scan on _timescaledb_internal.compress_hyper_6_18_chunk (actual rows=1 loops=1)
+                     Output: compress_hyper_6_18_chunk."time", compress_hyper_6_18_chunk.device_id, compress_hyper_6_18_chunk.device_id_peer, compress_hyper_6_18_chunk.v0, compress_hyper_6_18_chunk.v1, compress_hyper_6_18_chunk.v2, compress_hyper_6_18_chunk.v3, compress_hyper_6_18_chunk._ts_meta_count, compress_hyper_6_18_chunk._ts_meta_sequence_num, compress_hyper_6_18_chunk._ts_meta_min_3, compress_hyper_6_18_chunk._ts_meta_max_3, compress_hyper_6_18_chunk._ts_meta_min_1, compress_hyper_6_18_chunk._ts_meta_max_1, compress_hyper_6_18_chunk._ts_meta_min_2, compress_hyper_6_18_chunk._ts_meta_max_2
          ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_5_chunk (actual rows=1080 loops=1)
                Output: _hyper_2_5_chunk.device_id_peer, _hyper_2_5_chunk.device_id
                Bulk Decompression: false
-               ->  Seq Scan on _timescaledb_internal.compress_hyper_6_18_chunk (actual rows=3 loops=1)
-                     Output: compress_hyper_6_18_chunk."time", compress_hyper_6_18_chunk.device_id, compress_hyper_6_18_chunk.device_id_peer, compress_hyper_6_18_chunk.v0, compress_hyper_6_18_chunk.v1, compress_hyper_6_18_chunk.v2, compress_hyper_6_18_chunk.v3, compress_hyper_6_18_chunk._ts_meta_count, compress_hyper_6_18_chunk._ts_meta_sequence_num, compress_hyper_6_18_chunk._ts_meta_min_3, compress_hyper_6_18_chunk._ts_meta_max_3, compress_hyper_6_18_chunk._ts_meta_min_1, compress_hyper_6_18_chunk._ts_meta_max_1, compress_hyper_6_18_chunk._ts_meta_min_2, compress_hyper_6_18_chunk._ts_meta_max_2
+               ->  Seq Scan on _timescaledb_internal.compress_hyper_6_19_chunk (actual rows=3 loops=1)
+                     Output: compress_hyper_6_19_chunk."time", compress_hyper_6_19_chunk.device_id, compress_hyper_6_19_chunk.device_id_peer, compress_hyper_6_19_chunk.v0, compress_hyper_6_19_chunk.v1, compress_hyper_6_19_chunk.v2, compress_hyper_6_19_chunk.v3, compress_hyper_6_19_chunk._ts_meta_count, compress_hyper_6_19_chunk._ts_meta_sequence_num, compress_hyper_6_19_chunk._ts_meta_min_3, compress_hyper_6_19_chunk._ts_meta_max_3, compress_hyper_6_19_chunk._ts_meta_min_1, compress_hyper_6_19_chunk._ts_meta_max_1, compress_hyper_6_19_chunk._ts_meta_min_2, compress_hyper_6_19_chunk._ts_meta_max_2
          ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_6_chunk (actual rows=360 loops=1)
                Output: _hyper_2_6_chunk.device_id_peer, _hyper_2_6_chunk.device_id
                Bulk Decompression: false
-               ->  Seq Scan on _timescaledb_internal.compress_hyper_6_19_chunk (actual rows=1 loops=1)
-                     Output: compress_hyper_6_19_chunk."time", compress_hyper_6_19_chunk.device_id, compress_hyper_6_19_chunk.device_id_peer, compress_hyper_6_19_chunk.v0, compress_hyper_6_19_chunk.v1, compress_hyper_6_19_chunk.v2, compress_hyper_6_19_chunk.v3, compress_hyper_6_19_chunk._ts_meta_count, compress_hyper_6_19_chunk._ts_meta_sequence_num, compress_hyper_6_19_chunk._ts_meta_min_3, compress_hyper_6_19_chunk._ts_meta_max_3, compress_hyper_6_19_chunk._ts_meta_min_1, compress_hyper_6_19_chunk._ts_meta_max_1, compress_hyper_6_19_chunk._ts_meta_min_2, compress_hyper_6_19_chunk._ts_meta_max_2
+               ->  Seq Scan on _timescaledb_internal.compress_hyper_6_20_chunk (actual rows=1 loops=1)
+                     Output: compress_hyper_6_20_chunk."time", compress_hyper_6_20_chunk.device_id, compress_hyper_6_20_chunk.device_id_peer, compress_hyper_6_20_chunk.v0, compress_hyper_6_20_chunk.v1, compress_hyper_6_20_chunk.v2, compress_hyper_6_20_chunk.v3, compress_hyper_6_20_chunk._ts_meta_count, compress_hyper_6_20_chunk._ts_meta_sequence_num, compress_hyper_6_20_chunk._ts_meta_min_3, compress_hyper_6_20_chunk._ts_meta_max_3, compress_hyper_6_20_chunk._ts_meta_min_1, compress_hyper_6_20_chunk._ts_meta_max_1, compress_hyper_6_20_chunk._ts_meta_min_2, compress_hyper_6_20_chunk._ts_meta_max_2
          ->  Seq Scan on _timescaledb_internal._hyper_2_7_chunk (actual rows=504 loops=1)
                Output: _hyper_2_7_chunk.device_id_peer, _hyper_2_7_chunk.device_id
          ->  Seq Scan on _timescaledb_internal._hyper_2_8_chunk (actual rows=1512 loops=1)
@@ -6667,13 +6667,13 @@ WHERE device_id IN (
          ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_10_chunk (actual rows=504 loops=1)
                Output: _hyper_2_10_chunk.device_id_peer, _hyper_2_10_chunk.device_id
                Bulk Decompression: false
-               ->  Seq Scan on _timescaledb_internal.compress_hyper_6_20_chunk (actual rows=1 loops=1)
-                     Output: compress_hyper_6_20_chunk."time", compress_hyper_6_20_chunk.device_id, compress_hyper_6_20_chunk.device_id_peer, compress_hyper_6_20_chunk.v0, compress_hyper_6_20_chunk.v1, compress_hyper_6_20_chunk.v2, compress_hyper_6_20_chunk.v3, compress_hyper_6_20_chunk._ts_meta_count, compress_hyper_6_20_chunk._ts_meta_sequence_num, compress_hyper_6_20_chunk._ts_meta_min_3, compress_hyper_6_20_chunk._ts_meta_max_3, compress_hyper_6_20_chunk._ts_meta_min_1, compress_hyper_6_20_chunk._ts_meta_max_1, compress_hyper_6_20_chunk._ts_meta_min_2, compress_hyper_6_20_chunk._ts_meta_max_2
+               ->  Seq Scan on _timescaledb_internal.compress_hyper_6_24_chunk (actual rows=1 loops=1)
+                     Output: compress_hyper_6_24_chunk."time", compress_hyper_6_24_chunk.device_id, compress_hyper_6_24_chunk.device_id_peer, compress_hyper_6_24_chunk.v0, compress_hyper_6_24_chunk.v1, compress_hyper_6_24_chunk.v2, compress_hyper_6_24_chunk.v3, compress_hyper_6_24_chunk._ts_meta_count, compress_hyper_6_24_chunk._ts_meta_sequence_num, compress_hyper_6_24_chunk._ts_meta_min_3, compress_hyper_6_24_chunk._ts_meta_max_3, compress_hyper_6_24_chunk._ts_meta_min_1, compress_hyper_6_24_chunk._ts_meta_max_1, compress_hyper_6_24_chunk._ts_meta_min_2, compress_hyper_6_24_chunk._ts_meta_max_2
          ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_11_chunk (actual rows=1512 loops=1)
                Output: _hyper_2_11_chunk.device_id_peer, _hyper_2_11_chunk.device_id
                Bulk Decompression: false
-               ->  Seq Scan on _timescaledb_internal.compress_hyper_6_21_chunk (actual rows=3 loops=1)
-                     Output: compress_hyper_6_21_chunk."time", compress_hyper_6_21_chunk.device_id, compress_hyper_6_21_chunk.device_id_peer, compress_hyper_6_21_chunk.v0, compress_hyper_6_21_chunk.v1, compress_hyper_6_21_chunk.v2, compress_hyper_6_21_chunk.v3, compress_hyper_6_21_chunk._ts_meta_count, compress_hyper_6_21_chunk._ts_meta_sequence_num, compress_hyper_6_21_chunk._ts_meta_min_3, compress_hyper_6_21_chunk._ts_meta_max_3, compress_hyper_6_21_chunk._ts_meta_min_1, compress_hyper_6_21_chunk._ts_meta_max_1, compress_hyper_6_21_chunk._ts_meta_min_2, compress_hyper_6_21_chunk._ts_meta_max_2
+               ->  Seq Scan on _timescaledb_internal.compress_hyper_6_25_chunk (actual rows=3 loops=1)
+                     Output: compress_hyper_6_25_chunk."time", compress_hyper_6_25_chunk.device_id, compress_hyper_6_25_chunk.device_id_peer, compress_hyper_6_25_chunk.v0, compress_hyper_6_25_chunk.v1, compress_hyper_6_25_chunk.v2, compress_hyper_6_25_chunk.v3, compress_hyper_6_25_chunk._ts_meta_count, compress_hyper_6_25_chunk._ts_meta_sequence_num, compress_hyper_6_25_chunk._ts_meta_min_3, compress_hyper_6_25_chunk._ts_meta_max_3, compress_hyper_6_25_chunk._ts_meta_min_1, compress_hyper_6_25_chunk._ts_meta_max_1, compress_hyper_6_25_chunk._ts_meta_min_2, compress_hyper_6_25_chunk._ts_meta_max_2
          ->  Seq Scan on _timescaledb_internal._hyper_2_12_chunk (actual rows=504 loops=1)
                Output: _hyper_2_12_chunk.device_id_peer, _hyper_2_12_chunk.device_id
    ->  Hash (actual rows=2 loops=1)
@@ -6705,19 +6705,19 @@ WHERE device_id IN (
    ->  Append
          ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_4_chunk
                Output: _hyper_2_4_chunk.device_id_peer, _hyper_2_4_chunk.device_id
-               ->  Index Scan using compress_hyper_6_17_chunk_c_space_index_2 on _timescaledb_internal.compress_hyper_6_17_chunk
-                     Output: compress_hyper_6_17_chunk."time", compress_hyper_6_17_chunk.device_id, compress_hyper_6_17_chunk.device_id_peer, compress_hyper_6_17_chunk.v0, compress_hyper_6_17_chunk.v1, compress_hyper_6_17_chunk.v2, compress_hyper_6_17_chunk.v3, compress_hyper_6_17_chunk._ts_meta_count, compress_hyper_6_17_chunk._ts_meta_sequence_num, compress_hyper_6_17_chunk._ts_meta_min_3, compress_hyper_6_17_chunk._ts_meta_max_3, compress_hyper_6_17_chunk._ts_meta_min_1, compress_hyper_6_17_chunk._ts_meta_max_1, compress_hyper_6_17_chunk._ts_meta_min_2, compress_hyper_6_17_chunk._ts_meta_max_2
-                     Index Cond: (compress_hyper_6_17_chunk.device_id = "*VALUES*".column1)
-         ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_5_chunk
-               Output: _hyper_2_5_chunk.device_id_peer, _hyper_2_5_chunk.device_id
                ->  Index Scan using compress_hyper_6_18_chunk_c_space_index_2 on _timescaledb_internal.compress_hyper_6_18_chunk
                      Output: compress_hyper_6_18_chunk."time", compress_hyper_6_18_chunk.device_id, compress_hyper_6_18_chunk.device_id_peer, compress_hyper_6_18_chunk.v0, compress_hyper_6_18_chunk.v1, compress_hyper_6_18_chunk.v2, compress_hyper_6_18_chunk.v3, compress_hyper_6_18_chunk._ts_meta_count, compress_hyper_6_18_chunk._ts_meta_sequence_num, compress_hyper_6_18_chunk._ts_meta_min_3, compress_hyper_6_18_chunk._ts_meta_max_3, compress_hyper_6_18_chunk._ts_meta_min_1, compress_hyper_6_18_chunk._ts_meta_max_1, compress_hyper_6_18_chunk._ts_meta_min_2, compress_hyper_6_18_chunk._ts_meta_max_2
                      Index Cond: (compress_hyper_6_18_chunk.device_id = "*VALUES*".column1)
-         ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_6_chunk
-               Output: _hyper_2_6_chunk.device_id_peer, _hyper_2_6_chunk.device_id
+         ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_5_chunk
+               Output: _hyper_2_5_chunk.device_id_peer, _hyper_2_5_chunk.device_id
                ->  Index Scan using compress_hyper_6_19_chunk_c_space_index_2 on _timescaledb_internal.compress_hyper_6_19_chunk
                      Output: compress_hyper_6_19_chunk."time", compress_hyper_6_19_chunk.device_id, compress_hyper_6_19_chunk.device_id_peer, compress_hyper_6_19_chunk.v0, compress_hyper_6_19_chunk.v1, compress_hyper_6_19_chunk.v2, compress_hyper_6_19_chunk.v3, compress_hyper_6_19_chunk._ts_meta_count, compress_hyper_6_19_chunk._ts_meta_sequence_num, compress_hyper_6_19_chunk._ts_meta_min_3, compress_hyper_6_19_chunk._ts_meta_max_3, compress_hyper_6_19_chunk._ts_meta_min_1, compress_hyper_6_19_chunk._ts_meta_max_1, compress_hyper_6_19_chunk._ts_meta_min_2, compress_hyper_6_19_chunk._ts_meta_max_2
                      Index Cond: (compress_hyper_6_19_chunk.device_id = "*VALUES*".column1)
+         ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_6_chunk
+               Output: _hyper_2_6_chunk.device_id_peer, _hyper_2_6_chunk.device_id
+               ->  Index Scan using compress_hyper_6_20_chunk_c_space_index_2 on _timescaledb_internal.compress_hyper_6_20_chunk
+                     Output: compress_hyper_6_20_chunk."time", compress_hyper_6_20_chunk.device_id, compress_hyper_6_20_chunk.device_id_peer, compress_hyper_6_20_chunk.v0, compress_hyper_6_20_chunk.v1, compress_hyper_6_20_chunk.v2, compress_hyper_6_20_chunk.v3, compress_hyper_6_20_chunk._ts_meta_count, compress_hyper_6_20_chunk._ts_meta_sequence_num, compress_hyper_6_20_chunk._ts_meta_min_3, compress_hyper_6_20_chunk._ts_meta_max_3, compress_hyper_6_20_chunk._ts_meta_min_1, compress_hyper_6_20_chunk._ts_meta_max_1, compress_hyper_6_20_chunk._ts_meta_min_2, compress_hyper_6_20_chunk._ts_meta_max_2
+                     Index Cond: (compress_hyper_6_20_chunk.device_id = "*VALUES*".column1)
          ->  Index Only Scan using _hyper_2_7_chunk_metrics_space_device_id_device_id_peer_v0_v1_2 on _timescaledb_internal._hyper_2_7_chunk
                Output: _hyper_2_7_chunk.device_id_peer, _hyper_2_7_chunk.device_id
                Index Cond: (_hyper_2_7_chunk.device_id = "*VALUES*".column1)
@@ -6729,14 +6729,14 @@ WHERE device_id IN (
                Index Cond: (_hyper_2_9_chunk.device_id = "*VALUES*".column1)
          ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_10_chunk
                Output: _hyper_2_10_chunk.device_id_peer, _hyper_2_10_chunk.device_id
-               ->  Index Scan using compress_hyper_6_20_chunk_c_space_index_2 on _timescaledb_internal.compress_hyper_6_20_chunk
-                     Output: compress_hyper_6_20_chunk."time", compress_hyper_6_20_chunk.device_id, compress_hyper_6_20_chunk.device_id_peer, compress_hyper_6_20_chunk.v0, compress_hyper_6_20_chunk.v1, compress_hyper_6_20_chunk.v2, compress_hyper_6_20_chunk.v3, compress_hyper_6_20_chunk._ts_meta_count, compress_hyper_6_20_chunk._ts_meta_sequence_num, compress_hyper_6_20_chunk._ts_meta_min_3, compress_hyper_6_20_chunk._ts_meta_max_3, compress_hyper_6_20_chunk._ts_meta_min_1, compress_hyper_6_20_chunk._ts_meta_max_1, compress_hyper_6_20_chunk._ts_meta_min_2, compress_hyper_6_20_chunk._ts_meta_max_2
-                     Index Cond: (compress_hyper_6_20_chunk.device_id = "*VALUES*".column1)
+               ->  Index Scan using compress_hyper_6_24_chunk_c_space_index_2 on _timescaledb_internal.compress_hyper_6_24_chunk
+                     Output: compress_hyper_6_24_chunk."time", compress_hyper_6_24_chunk.device_id, compress_hyper_6_24_chunk.device_id_peer, compress_hyper_6_24_chunk.v0, compress_hyper_6_24_chunk.v1, compress_hyper_6_24_chunk.v2, compress_hyper_6_24_chunk.v3, compress_hyper_6_24_chunk._ts_meta_count, compress_hyper_6_24_chunk._ts_meta_sequence_num, compress_hyper_6_24_chunk._ts_meta_min_3, compress_hyper_6_24_chunk._ts_meta_max_3, compress_hyper_6_24_chunk._ts_meta_min_1, compress_hyper_6_24_chunk._ts_meta_max_1, compress_hyper_6_24_chunk._ts_meta_min_2, compress_hyper_6_24_chunk._ts_meta_max_2
+                     Index Cond: (compress_hyper_6_24_chunk.device_id = "*VALUES*".column1)
          ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_11_chunk
                Output: _hyper_2_11_chunk.device_id_peer, _hyper_2_11_chunk.device_id
-               ->  Index Scan using compress_hyper_6_21_chunk_c_space_index_2 on _timescaledb_internal.compress_hyper_6_21_chunk
-                     Output: compress_hyper_6_21_chunk."time", compress_hyper_6_21_chunk.device_id, compress_hyper_6_21_chunk.device_id_peer, compress_hyper_6_21_chunk.v0, compress_hyper_6_21_chunk.v1, compress_hyper_6_21_chunk.v2, compress_hyper_6_21_chunk.v3, compress_hyper_6_21_chunk._ts_meta_count, compress_hyper_6_21_chunk._ts_meta_sequence_num, compress_hyper_6_21_chunk._ts_meta_min_3, compress_hyper_6_21_chunk._ts_meta_max_3, compress_hyper_6_21_chunk._ts_meta_min_1, compress_hyper_6_21_chunk._ts_meta_max_1, compress_hyper_6_21_chunk._ts_meta_min_2, compress_hyper_6_21_chunk._ts_meta_max_2
-                     Index Cond: (compress_hyper_6_21_chunk.device_id = "*VALUES*".column1)
+               ->  Index Scan using compress_hyper_6_25_chunk_c_space_index_2 on _timescaledb_internal.compress_hyper_6_25_chunk
+                     Output: compress_hyper_6_25_chunk."time", compress_hyper_6_25_chunk.device_id, compress_hyper_6_25_chunk.device_id_peer, compress_hyper_6_25_chunk.v0, compress_hyper_6_25_chunk.v1, compress_hyper_6_25_chunk.v2, compress_hyper_6_25_chunk.v3, compress_hyper_6_25_chunk._ts_meta_count, compress_hyper_6_25_chunk._ts_meta_sequence_num, compress_hyper_6_25_chunk._ts_meta_min_3, compress_hyper_6_25_chunk._ts_meta_max_3, compress_hyper_6_25_chunk._ts_meta_min_1, compress_hyper_6_25_chunk._ts_meta_max_1, compress_hyper_6_25_chunk._ts_meta_min_2, compress_hyper_6_25_chunk._ts_meta_max_2
+                     Index Cond: (compress_hyper_6_25_chunk.device_id = "*VALUES*".column1)
          ->  Index Only Scan using _hyper_2_12_chunk_metrics_space_device_id_device_id_peer_v0_v_2 on _timescaledb_internal._hyper_2_12_chunk
                Output: _hyper_2_12_chunk.device_id_peer, _hyper_2_12_chunk.device_id
                Index Cond: (_hyper_2_12_chunk.device_id = "*VALUES*".column1)
@@ -6754,18 +6754,18 @@ WHERE device_id IN (
    ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_4_chunk (actual rows=360 loops=1)
          Output: _hyper_2_4_chunk.device_id_peer
          Bulk Decompression: false
-         ->  Seq Scan on _timescaledb_internal.compress_hyper_6_17_chunk (actual rows=1 loops=1)
-               Output: compress_hyper_6_17_chunk."time", compress_hyper_6_17_chunk.device_id, compress_hyper_6_17_chunk.device_id_peer, compress_hyper_6_17_chunk.v0, compress_hyper_6_17_chunk.v1, compress_hyper_6_17_chunk.v2, compress_hyper_6_17_chunk.v3, compress_hyper_6_17_chunk._ts_meta_count, compress_hyper_6_17_chunk._ts_meta_sequence_num, compress_hyper_6_17_chunk._ts_meta_min_3, compress_hyper_6_17_chunk._ts_meta_max_3, compress_hyper_6_17_chunk._ts_meta_min_1, compress_hyper_6_17_chunk._ts_meta_max_1, compress_hyper_6_17_chunk._ts_meta_min_2, compress_hyper_6_17_chunk._ts_meta_max_2
-               Filter: (compress_hyper_6_17_chunk.device_id = 1)
+         ->  Seq Scan on _timescaledb_internal.compress_hyper_6_18_chunk (actual rows=1 loops=1)
+               Output: compress_hyper_6_18_chunk."time", compress_hyper_6_18_chunk.device_id, compress_hyper_6_18_chunk.device_id_peer, compress_hyper_6_18_chunk.v0, compress_hyper_6_18_chunk.v1, compress_hyper_6_18_chunk.v2, compress_hyper_6_18_chunk.v3, compress_hyper_6_18_chunk._ts_meta_count, compress_hyper_6_18_chunk._ts_meta_sequence_num, compress_hyper_6_18_chunk._ts_meta_min_3, compress_hyper_6_18_chunk._ts_meta_max_3, compress_hyper_6_18_chunk._ts_meta_min_1, compress_hyper_6_18_chunk._ts_meta_max_1, compress_hyper_6_18_chunk._ts_meta_min_2, compress_hyper_6_18_chunk._ts_meta_max_2
+               Filter: (compress_hyper_6_18_chunk.device_id = 1)
    ->  Seq Scan on _timescaledb_internal._hyper_2_7_chunk (actual rows=504 loops=1)
          Output: _hyper_2_7_chunk.device_id_peer
          Filter: (_hyper_2_7_chunk.device_id = 1)
    ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_10_chunk (actual rows=504 loops=1)
          Output: _hyper_2_10_chunk.device_id_peer
          Bulk Decompression: false
-         ->  Seq Scan on _timescaledb_internal.compress_hyper_6_20_chunk (actual rows=1 loops=1)
-               Output: compress_hyper_6_20_chunk."time", compress_hyper_6_20_chunk.device_id, compress_hyper_6_20_chunk.device_id_peer, compress_hyper_6_20_chunk.v0, compress_hyper_6_20_chunk.v1, compress_hyper_6_20_chunk.v2, compress_hyper_6_20_chunk.v3, compress_hyper_6_20_chunk._ts_meta_count, compress_hyper_6_20_chunk._ts_meta_sequence_num, compress_hyper_6_20_chunk._ts_meta_min_3, compress_hyper_6_20_chunk._ts_meta_max_3, compress_hyper_6_20_chunk._ts_meta_min_1, compress_hyper_6_20_chunk._ts_meta_max_1, compress_hyper_6_20_chunk._ts_meta_min_2, compress_hyper_6_20_chunk._ts_meta_max_2
-               Filter: (compress_hyper_6_20_chunk.device_id = 1)
+         ->  Seq Scan on _timescaledb_internal.compress_hyper_6_24_chunk (actual rows=1 loops=1)
+               Output: compress_hyper_6_24_chunk."time", compress_hyper_6_24_chunk.device_id, compress_hyper_6_24_chunk.device_id_peer, compress_hyper_6_24_chunk.v0, compress_hyper_6_24_chunk.v1, compress_hyper_6_24_chunk.v2, compress_hyper_6_24_chunk.v3, compress_hyper_6_24_chunk._ts_meta_count, compress_hyper_6_24_chunk._ts_meta_sequence_num, compress_hyper_6_24_chunk._ts_meta_min_3, compress_hyper_6_24_chunk._ts_meta_max_3, compress_hyper_6_24_chunk._ts_meta_min_1, compress_hyper_6_24_chunk._ts_meta_max_1, compress_hyper_6_24_chunk._ts_meta_min_2, compress_hyper_6_24_chunk._ts_meta_max_2
+               Filter: (compress_hyper_6_24_chunk.device_id = 1)
 (16 rows)
 
 :PREFIX_VERBOSE
@@ -6783,18 +6783,18 @@ WHERE device_id IN (
          ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_4_chunk (actual rows=360 loops=1)
                Output: _hyper_2_4_chunk.device_id_peer, _hyper_2_4_chunk.device_id
                Bulk Decompression: false
-               ->  Seq Scan on _timescaledb_internal.compress_hyper_6_17_chunk (actual rows=1 loops=1)
-                     Output: compress_hyper_6_17_chunk."time", compress_hyper_6_17_chunk.device_id, compress_hyper_6_17_chunk.device_id_peer, compress_hyper_6_17_chunk.v0, compress_hyper_6_17_chunk.v1, compress_hyper_6_17_chunk.v2, compress_hyper_6_17_chunk.v3, compress_hyper_6_17_chunk._ts_meta_count, compress_hyper_6_17_chunk._ts_meta_sequence_num, compress_hyper_6_17_chunk._ts_meta_min_3, compress_hyper_6_17_chunk._ts_meta_max_3, compress_hyper_6_17_chunk._ts_meta_min_1, compress_hyper_6_17_chunk._ts_meta_max_1, compress_hyper_6_17_chunk._ts_meta_min_2, compress_hyper_6_17_chunk._ts_meta_max_2
+               ->  Seq Scan on _timescaledb_internal.compress_hyper_6_18_chunk (actual rows=1 loops=1)
+                     Output: compress_hyper_6_18_chunk."time", compress_hyper_6_18_chunk.device_id, compress_hyper_6_18_chunk.device_id_peer, compress_hyper_6_18_chunk.v0, compress_hyper_6_18_chunk.v1, compress_hyper_6_18_chunk.v2, compress_hyper_6_18_chunk.v3, compress_hyper_6_18_chunk._ts_meta_count, compress_hyper_6_18_chunk._ts_meta_sequence_num, compress_hyper_6_18_chunk._ts_meta_min_3, compress_hyper_6_18_chunk._ts_meta_max_3, compress_hyper_6_18_chunk._ts_meta_min_1, compress_hyper_6_18_chunk._ts_meta_max_1, compress_hyper_6_18_chunk._ts_meta_min_2, compress_hyper_6_18_chunk._ts_meta_max_2
          ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_5_chunk (actual rows=1080 loops=1)
                Output: _hyper_2_5_chunk.device_id_peer, _hyper_2_5_chunk.device_id
                Bulk Decompression: false
-               ->  Seq Scan on _timescaledb_internal.compress_hyper_6_18_chunk (actual rows=3 loops=1)
-                     Output: compress_hyper_6_18_chunk."time", compress_hyper_6_18_chunk.device_id, compress_hyper_6_18_chunk.device_id_peer, compress_hyper_6_18_chunk.v0, compress_hyper_6_18_chunk.v1, compress_hyper_6_18_chunk.v2, compress_hyper_6_18_chunk.v3, compress_hyper_6_18_chunk._ts_meta_count, compress_hyper_6_18_chunk._ts_meta_sequence_num, compress_hyper_6_18_chunk._ts_meta_min_3, compress_hyper_6_18_chunk._ts_meta_max_3, compress_hyper_6_18_chunk._ts_meta_min_1, compress_hyper_6_18_chunk._ts_meta_max_1, compress_hyper_6_18_chunk._ts_meta_min_2, compress_hyper_6_18_chunk._ts_meta_max_2
+               ->  Seq Scan on _timescaledb_internal.compress_hyper_6_19_chunk (actual rows=3 loops=1)
+                     Output: compress_hyper_6_19_chunk."time", compress_hyper_6_19_chunk.device_id, compress_hyper_6_19_chunk.device_id_peer, compress_hyper_6_19_chunk.v0, compress_hyper_6_19_chunk.v1, compress_hyper_6_19_chunk.v2, compress_hyper_6_19_chunk.v3, compress_hyper_6_19_chunk._ts_meta_count, compress_hyper_6_19_chunk._ts_meta_sequence_num, compress_hyper_6_19_chunk._ts_meta_min_3, compress_hyper_6_19_chunk._ts_meta_max_3, compress_hyper_6_19_chunk._ts_meta_min_1, compress_hyper_6_19_chunk._ts_meta_max_1, compress_hyper_6_19_chunk._ts_meta_min_2, compress_hyper_6_19_chunk._ts_meta_max_2
          ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_6_chunk (actual rows=360 loops=1)
                Output: _hyper_2_6_chunk.device_id_peer, _hyper_2_6_chunk.device_id
                Bulk Decompression: false
-               ->  Seq Scan on _timescaledb_internal.compress_hyper_6_19_chunk (actual rows=1 loops=1)
-                     Output: compress_hyper_6_19_chunk."time", compress_hyper_6_19_chunk.device_id, compress_hyper_6_19_chunk.device_id_peer, compress_hyper_6_19_chunk.v0, compress_hyper_6_19_chunk.v1, compress_hyper_6_19_chunk.v2, compress_hyper_6_19_chunk.v3, compress_hyper_6_19_chunk._ts_meta_count, compress_hyper_6_19_chunk._ts_meta_sequence_num, compress_hyper_6_19_chunk._ts_meta_min_3, compress_hyper_6_19_chunk._ts_meta_max_3, compress_hyper_6_19_chunk._ts_meta_min_1, compress_hyper_6_19_chunk._ts_meta_max_1, compress_hyper_6_19_chunk._ts_meta_min_2, compress_hyper_6_19_chunk._ts_meta_max_2
+               ->  Seq Scan on _timescaledb_internal.compress_hyper_6_20_chunk (actual rows=1 loops=1)
+                     Output: compress_hyper_6_20_chunk."time", compress_hyper_6_20_chunk.device_id, compress_hyper_6_20_chunk.device_id_peer, compress_hyper_6_20_chunk.v0, compress_hyper_6_20_chunk.v1, compress_hyper_6_20_chunk.v2, compress_hyper_6_20_chunk.v3, compress_hyper_6_20_chunk._ts_meta_count, compress_hyper_6_20_chunk._ts_meta_sequence_num, compress_hyper_6_20_chunk._ts_meta_min_3, compress_hyper_6_20_chunk._ts_meta_max_3, compress_hyper_6_20_chunk._ts_meta_min_1, compress_hyper_6_20_chunk._ts_meta_max_1, compress_hyper_6_20_chunk._ts_meta_min_2, compress_hyper_6_20_chunk._ts_meta_max_2
          ->  Seq Scan on _timescaledb_internal._hyper_2_7_chunk (actual rows=504 loops=1)
                Output: _hyper_2_7_chunk.device_id_peer, _hyper_2_7_chunk.device_id
          ->  Seq Scan on _timescaledb_internal._hyper_2_8_chunk (actual rows=1512 loops=1)
@@ -6804,13 +6804,13 @@ WHERE device_id IN (
          ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_10_chunk (actual rows=504 loops=1)
                Output: _hyper_2_10_chunk.device_id_peer, _hyper_2_10_chunk.device_id
                Bulk Decompression: false
-               ->  Seq Scan on _timescaledb_internal.compress_hyper_6_20_chunk (actual rows=1 loops=1)
-                     Output: compress_hyper_6_20_chunk."time", compress_hyper_6_20_chunk.device_id, compress_hyper_6_20_chunk.device_id_peer, compress_hyper_6_20_chunk.v0, compress_hyper_6_20_chunk.v1, compress_hyper_6_20_chunk.v2, compress_hyper_6_20_chunk.v3, compress_hyper_6_20_chunk._ts_meta_count, compress_hyper_6_20_chunk._ts_meta_sequence_num, compress_hyper_6_20_chunk._ts_meta_min_3, compress_hyper_6_20_chunk._ts_meta_max_3, compress_hyper_6_20_chunk._ts_meta_min_1, compress_hyper_6_20_chunk._ts_meta_max_1, compress_hyper_6_20_chunk._ts_meta_min_2, compress_hyper_6_20_chunk._ts_meta_max_2
+               ->  Seq Scan on _timescaledb_internal.compress_hyper_6_24_chunk (actual rows=1 loops=1)
+                     Output: compress_hyper_6_24_chunk."time", compress_hyper_6_24_chunk.device_id, compress_hyper_6_24_chunk.device_id_peer, compress_hyper_6_24_chunk.v0, compress_hyper_6_24_chunk.v1, compress_hyper_6_24_chunk.v2, compress_hyper_6_24_chunk.v3, compress_hyper_6_24_chunk._ts_meta_count, compress_hyper_6_24_chunk._ts_meta_sequence_num, compress_hyper_6_24_chunk._ts_meta_min_3, compress_hyper_6_24_chunk._ts_meta_max_3, compress_hyper_6_24_chunk._ts_meta_min_1, compress_hyper_6_24_chunk._ts_meta_max_1, compress_hyper_6_24_chunk._ts_meta_min_2, compress_hyper_6_24_chunk._ts_meta_max_2
          ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_11_chunk (actual rows=1512 loops=1)
                Output: _hyper_2_11_chunk.device_id_peer, _hyper_2_11_chunk.device_id
                Bulk Decompression: false
-               ->  Seq Scan on _timescaledb_internal.compress_hyper_6_21_chunk (actual rows=3 loops=1)
-                     Output: compress_hyper_6_21_chunk."time", compress_hyper_6_21_chunk.device_id, compress_hyper_6_21_chunk.device_id_peer, compress_hyper_6_21_chunk.v0, compress_hyper_6_21_chunk.v1, compress_hyper_6_21_chunk.v2, compress_hyper_6_21_chunk.v3, compress_hyper_6_21_chunk._ts_meta_count, compress_hyper_6_21_chunk._ts_meta_sequence_num, compress_hyper_6_21_chunk._ts_meta_min_3, compress_hyper_6_21_chunk._ts_meta_max_3, compress_hyper_6_21_chunk._ts_meta_min_1, compress_hyper_6_21_chunk._ts_meta_max_1, compress_hyper_6_21_chunk._ts_meta_min_2, compress_hyper_6_21_chunk._ts_meta_max_2
+               ->  Seq Scan on _timescaledb_internal.compress_hyper_6_25_chunk (actual rows=3 loops=1)
+                     Output: compress_hyper_6_25_chunk."time", compress_hyper_6_25_chunk.device_id, compress_hyper_6_25_chunk.device_id_peer, compress_hyper_6_25_chunk.v0, compress_hyper_6_25_chunk.v1, compress_hyper_6_25_chunk.v2, compress_hyper_6_25_chunk.v3, compress_hyper_6_25_chunk._ts_meta_count, compress_hyper_6_25_chunk._ts_meta_sequence_num, compress_hyper_6_25_chunk._ts_meta_min_3, compress_hyper_6_25_chunk._ts_meta_max_3, compress_hyper_6_25_chunk._ts_meta_min_1, compress_hyper_6_25_chunk._ts_meta_max_1, compress_hyper_6_25_chunk._ts_meta_min_2, compress_hyper_6_25_chunk._ts_meta_max_2
          ->  Seq Scan on _timescaledb_internal._hyper_2_12_chunk (actual rows=504 loops=1)
                Output: _hyper_2_12_chunk.device_id_peer, _hyper_2_12_chunk.device_id
    ->  Hash (actual rows=2 loops=1)
@@ -6842,14 +6842,14 @@ LIMIT 10;
                Sort Key: _hyper_2_10_chunk."time" DESC
                Sort Method: top-N heapsort 
                ->  Custom Scan (DecompressChunk) on _hyper_2_10_chunk (actual rows=504 loops=1)
-                     ->  Seq Scan on compress_hyper_6_20_chunk (actual rows=1 loops=1)
+                     ->  Seq Scan on compress_hyper_6_24_chunk (actual rows=1 loops=1)
                            Filter: (device_id = 1)
          ->  Index Scan using _hyper_2_7_chunk_metrics_space_time_idx on _hyper_2_7_chunk (never executed)
                Filter: (device_id = 1)
          ->  Sort (never executed)
                Sort Key: _hyper_2_4_chunk."time" DESC
                ->  Custom Scan (DecompressChunk) on _hyper_2_4_chunk (never executed)
-                     ->  Seq Scan on compress_hyper_6_17_chunk (never executed)
+                     ->  Seq Scan on compress_hyper_6_18_chunk (never executed)
                            Filter: (device_id = 1)
 (16 rows)
 
@@ -6885,7 +6885,7 @@ FROM :TEST_TABLE m1
                                        Sort Key: m1_1."time"
                                        Sort Method: quicksort 
                                        ->  Custom Scan (DecompressChunk) on _hyper_2_4_chunk m1_1 (actual rows=360 loops=1)
-                                             ->  Seq Scan on compress_hyper_6_17_chunk (actual rows=1 loops=1)
+                                             ->  Seq Scan on compress_hyper_6_18_chunk (actual rows=1 loops=1)
                            ->  Sort (actual rows=7 loops=1)
                                  Sort Key: m1_2."time"
                                  Sort Method: quicksort 
@@ -6893,7 +6893,7 @@ FROM :TEST_TABLE m1
                                        Sort Key: m1_2."time"
                                        Sort Method: quicksort 
                                        ->  Custom Scan (DecompressChunk) on _hyper_2_5_chunk m1_2 (actual rows=1080 loops=1)
-                                             ->  Seq Scan on compress_hyper_6_18_chunk (actual rows=3 loops=1)
+                                             ->  Seq Scan on compress_hyper_6_19_chunk (actual rows=3 loops=1)
                            ->  Sort (actual rows=3 loops=1)
                                  Sort Key: m1_3."time"
                                  Sort Method: quicksort 
@@ -6901,7 +6901,7 @@ FROM :TEST_TABLE m1
                                        Sort Key: m1_3."time"
                                        Sort Method: quicksort 
                                        ->  Custom Scan (DecompressChunk) on _hyper_2_6_chunk m1_3 (actual rows=360 loops=1)
-                                             ->  Seq Scan on compress_hyper_6_19_chunk (actual rows=1 loops=1)
+                                             ->  Seq Scan on compress_hyper_6_20_chunk (actual rows=1 loops=1)
                      ->  Merge Append (never executed)
                            Sort Key: m1_4."time"
                            ->  Index Scan Backward using _hyper_2_7_chunk_metrics_space_time_idx on _hyper_2_7_chunk m1_4 (never executed)
@@ -6914,13 +6914,13 @@ FROM :TEST_TABLE m1
                                  ->  Sort (never executed)
                                        Sort Key: m1_7."time"
                                        ->  Custom Scan (DecompressChunk) on _hyper_2_10_chunk m1_7 (never executed)
-                                             ->  Seq Scan on compress_hyper_6_20_chunk (never executed)
+                                             ->  Seq Scan on compress_hyper_6_24_chunk (never executed)
                            ->  Sort (never executed)
                                  Sort Key: m1_8."time"
                                  ->  Sort (never executed)
                                        Sort Key: m1_8."time"
                                        ->  Custom Scan (DecompressChunk) on _hyper_2_11_chunk m1_8 (never executed)
-                                             ->  Seq Scan on compress_hyper_6_21_chunk (never executed)
+                                             ->  Seq Scan on compress_hyper_6_25_chunk (never executed)
                            ->  Index Scan Backward using _hyper_2_12_chunk_metrics_space_time_idx on _hyper_2_12_chunk m1_9 (never executed)
                ->  Materialize (actual rows=51 loops=1)
                      ->  Custom Scan (ChunkAppend) on metrics_space m2 (actual rows=11 loops=1)
@@ -6934,7 +6934,7 @@ FROM :TEST_TABLE m1
                                              Sort Key: m2_1."time"
                                              Sort Method: quicksort 
                                              ->  Custom Scan (DecompressChunk) on _hyper_2_4_chunk m2_1 (actual rows=360 loops=1)
-                                                   ->  Seq Scan on compress_hyper_6_17_chunk compress_hyper_6_17_chunk_1 (actual rows=1 loops=1)
+                                                   ->  Seq Scan on compress_hyper_6_18_chunk compress_hyper_6_18_chunk_1 (actual rows=1 loops=1)
                                  ->  Sort (actual rows=7 loops=1)
                                        Sort Key: m2_2."time"
                                        Sort Method: quicksort 
@@ -6942,7 +6942,7 @@ FROM :TEST_TABLE m1
                                              Sort Key: m2_2."time"
                                              Sort Method: quicksort 
                                              ->  Custom Scan (DecompressChunk) on _hyper_2_5_chunk m2_2 (actual rows=1080 loops=1)
-                                                   ->  Seq Scan on compress_hyper_6_18_chunk compress_hyper_6_18_chunk_1 (actual rows=3 loops=1)
+                                                   ->  Seq Scan on compress_hyper_6_19_chunk compress_hyper_6_19_chunk_1 (actual rows=3 loops=1)
                                  ->  Sort (actual rows=3 loops=1)
                                        Sort Key: m2_3."time"
                                        Sort Method: quicksort 
@@ -6950,7 +6950,7 @@ FROM :TEST_TABLE m1
                                              Sort Key: m2_3."time"
                                              Sort Method: quicksort 
                                              ->  Custom Scan (DecompressChunk) on _hyper_2_6_chunk m2_3 (actual rows=360 loops=1)
-                                                   ->  Seq Scan on compress_hyper_6_19_chunk compress_hyper_6_19_chunk_1 (actual rows=1 loops=1)
+                                                   ->  Seq Scan on compress_hyper_6_20_chunk compress_hyper_6_20_chunk_1 (actual rows=1 loops=1)
                            ->  Merge Append (never executed)
                                  Sort Key: m2_4."time"
                                  ->  Index Scan Backward using _hyper_2_7_chunk_metrics_space_time_idx on _hyper_2_7_chunk m2_4 (never executed)
@@ -6963,13 +6963,13 @@ FROM :TEST_TABLE m1
                                        ->  Sort (never executed)
                                              Sort Key: m2_7."time"
                                              ->  Custom Scan (DecompressChunk) on _hyper_2_10_chunk m2_7 (never executed)
-                                                   ->  Seq Scan on compress_hyper_6_20_chunk compress_hyper_6_20_chunk_1 (never executed)
+                                                   ->  Seq Scan on compress_hyper_6_24_chunk compress_hyper_6_24_chunk_1 (never executed)
                                  ->  Sort (never executed)
                                        Sort Key: m2_8."time"
                                        ->  Sort (never executed)
                                              Sort Key: m2_8."time"
                                              ->  Custom Scan (DecompressChunk) on _hyper_2_11_chunk m2_8 (never executed)
-                                                   ->  Seq Scan on compress_hyper_6_21_chunk compress_hyper_6_21_chunk_1 (never executed)
+                                                   ->  Seq Scan on compress_hyper_6_25_chunk compress_hyper_6_25_chunk_1 (never executed)
                                  ->  Index Scan Backward using _hyper_2_12_chunk_metrics_space_time_idx on _hyper_2_12_chunk m2_9 (never executed)
 (106 rows)
 
@@ -7007,7 +7007,7 @@ FROM :TEST_TABLE m1
                                              Sort Key: m1_1."time"
                                              Sort Method: quicksort 
                                              ->  Custom Scan (DecompressChunk) on _hyper_2_4_chunk m1_1 (actual rows=360 loops=1)
-                                                   ->  Seq Scan on compress_hyper_6_17_chunk (actual rows=1 loops=1)
+                                                   ->  Seq Scan on compress_hyper_6_18_chunk (actual rows=1 loops=1)
                                  ->  Sort (actual rows=7 loops=1)
                                        Sort Key: m1_2."time"
                                        Sort Method: quicksort 
@@ -7015,7 +7015,7 @@ FROM :TEST_TABLE m1
                                              Sort Key: m1_2."time"
                                              Sort Method: quicksort 
                                              ->  Custom Scan (DecompressChunk) on _hyper_2_5_chunk m1_2 (actual rows=1080 loops=1)
-                                                   ->  Seq Scan on compress_hyper_6_18_chunk (actual rows=3 loops=1)
+                                                   ->  Seq Scan on compress_hyper_6_19_chunk (actual rows=3 loops=1)
                                  ->  Sort (actual rows=3 loops=1)
                                        Sort Key: m1_3."time"
                                        Sort Method: quicksort 
@@ -7023,7 +7023,7 @@ FROM :TEST_TABLE m1
                                              Sort Key: m1_3."time"
                                              Sort Method: quicksort 
                                              ->  Custom Scan (DecompressChunk) on _hyper_2_6_chunk m1_3 (actual rows=360 loops=1)
-                                                   ->  Seq Scan on compress_hyper_6_19_chunk (actual rows=1 loops=1)
+                                                   ->  Seq Scan on compress_hyper_6_20_chunk (actual rows=1 loops=1)
                            ->  Merge Append (never executed)
                                  Sort Key: m1_4."time"
                                  ->  Index Scan Backward using _hyper_2_7_chunk_metrics_space_time_idx on _hyper_2_7_chunk m1_4 (never executed)
@@ -7036,13 +7036,13 @@ FROM :TEST_TABLE m1
                                        ->  Sort (never executed)
                                              Sort Key: m1_7."time"
                                              ->  Custom Scan (DecompressChunk) on _hyper_2_10_chunk m1_7 (never executed)
-                                                   ->  Seq Scan on compress_hyper_6_20_chunk (never executed)
+                                                   ->  Seq Scan on compress_hyper_6_24_chunk (never executed)
                                  ->  Sort (never executed)
                                        Sort Key: m1_8."time"
                                        ->  Sort (never executed)
                                              Sort Key: m1_8."time"
                                              ->  Custom Scan (DecompressChunk) on _hyper_2_11_chunk m1_8 (never executed)
-                                                   ->  Seq Scan on compress_hyper_6_21_chunk (never executed)
+                                                   ->  Seq Scan on compress_hyper_6_25_chunk (never executed)
                                  ->  Index Scan Backward using _hyper_2_12_chunk_metrics_space_time_idx on _hyper_2_12_chunk m1_9 (never executed)
                      ->  Materialize (actual rows=51 loops=1)
                            ->  Custom Scan (ChunkAppend) on metrics_space m2 (actual rows=11 loops=1)
@@ -7056,7 +7056,7 @@ FROM :TEST_TABLE m1
                                                    Sort Key: m2_1."time"
                                                    Sort Method: quicksort 
                                                    ->  Custom Scan (DecompressChunk) on _hyper_2_4_chunk m2_1 (actual rows=360 loops=1)
-                                                         ->  Seq Scan on compress_hyper_6_17_chunk compress_hyper_6_17_chunk_1 (actual rows=1 loops=1)
+                                                         ->  Seq Scan on compress_hyper_6_18_chunk compress_hyper_6_18_chunk_1 (actual rows=1 loops=1)
                                        ->  Sort (actual rows=7 loops=1)
                                              Sort Key: m2_2."time"
                                              Sort Method: quicksort 
@@ -7064,7 +7064,7 @@ FROM :TEST_TABLE m1
                                                    Sort Key: m2_2."time"
                                                    Sort Method: quicksort 
                                                    ->  Custom Scan (DecompressChunk) on _hyper_2_5_chunk m2_2 (actual rows=1080 loops=1)
-                                                         ->  Seq Scan on compress_hyper_6_18_chunk compress_hyper_6_18_chunk_1 (actual rows=3 loops=1)
+                                                         ->  Seq Scan on compress_hyper_6_19_chunk compress_hyper_6_19_chunk_1 (actual rows=3 loops=1)
                                        ->  Sort (actual rows=3 loops=1)
                                              Sort Key: m2_3."time"
                                              Sort Method: quicksort 
@@ -7072,7 +7072,7 @@ FROM :TEST_TABLE m1
                                                    Sort Key: m2_3."time"
                                                    Sort Method: quicksort 
                                                    ->  Custom Scan (DecompressChunk) on _hyper_2_6_chunk m2_3 (actual rows=360 loops=1)
-                                                         ->  Seq Scan on compress_hyper_6_19_chunk compress_hyper_6_19_chunk_1 (actual rows=1 loops=1)
+                                                         ->  Seq Scan on compress_hyper_6_20_chunk compress_hyper_6_20_chunk_1 (actual rows=1 loops=1)
                                  ->  Merge Append (never executed)
                                        Sort Key: m2_4."time"
                                        ->  Index Scan Backward using _hyper_2_7_chunk_metrics_space_time_idx on _hyper_2_7_chunk m2_4 (never executed)
@@ -7085,13 +7085,13 @@ FROM :TEST_TABLE m1
                                              ->  Sort (never executed)
                                                    Sort Key: m2_7."time"
                                                    ->  Custom Scan (DecompressChunk) on _hyper_2_10_chunk m2_7 (never executed)
-                                                         ->  Seq Scan on compress_hyper_6_20_chunk compress_hyper_6_20_chunk_1 (never executed)
+                                                         ->  Seq Scan on compress_hyper_6_24_chunk compress_hyper_6_24_chunk_1 (never executed)
                                        ->  Sort (never executed)
                                              Sort Key: m2_8."time"
                                              ->  Sort (never executed)
                                                    Sort Key: m2_8."time"
                                                    ->  Custom Scan (DecompressChunk) on _hyper_2_11_chunk m2_8 (never executed)
-                                                         ->  Seq Scan on compress_hyper_6_21_chunk compress_hyper_6_21_chunk_1 (never executed)
+                                                         ->  Seq Scan on compress_hyper_6_25_chunk compress_hyper_6_25_chunk_1 (never executed)
                                        ->  Index Scan Backward using _hyper_2_12_chunk_metrics_space_time_idx on _hyper_2_12_chunk m2_9 (never executed)
                ->  Materialize (actual rows=11 loops=1)
                      ->  Merge Append (actual rows=3 loops=1)
@@ -7100,7 +7100,7 @@ FROM :TEST_TABLE m1
                                  Sort Key: m3_1."time"
                                  Sort Method: quicksort 
                                  ->  Custom Scan (DecompressChunk) on _hyper_2_6_chunk m3_1 (actual rows=360 loops=1)
-                                       ->  Seq Scan on compress_hyper_6_19_chunk compress_hyper_6_19_chunk_2 (actual rows=1 loops=1)
+                                       ->  Seq Scan on compress_hyper_6_20_chunk compress_hyper_6_20_chunk_2 (actual rows=1 loops=1)
                                              Filter: (device_id = 3)
                            ->  Index Scan Backward using _hyper_2_9_chunk_metrics_space_time_idx on _hyper_2_9_chunk m3_2 (actual rows=1 loops=1)
                                  Filter: (device_id = 3)
@@ -7130,14 +7130,14 @@ FROM :TEST_TABLE m1
                      Sort Key: m1_1."time"
                      Sort Method: quicksort 
                      ->  Custom Scan (DecompressChunk) on _hyper_2_4_chunk m1_1 (actual rows=360 loops=1)
-                           ->  Seq Scan on compress_hyper_6_17_chunk (actual rows=1 loops=1)
+                           ->  Seq Scan on compress_hyper_6_18_chunk (actual rows=1 loops=1)
                                  Filter: (device_id = 1)
                ->  Index Scan Backward using _hyper_2_7_chunk_metrics_space_time_idx on _hyper_2_7_chunk m1_2 (never executed)
                      Filter: (device_id = 1)
                ->  Sort (never executed)
                      Sort Key: m1_3."time"
                      ->  Custom Scan (DecompressChunk) on _hyper_2_10_chunk m1_3 (never executed)
-                           ->  Seq Scan on compress_hyper_6_20_chunk (never executed)
+                           ->  Seq Scan on compress_hyper_6_24_chunk (never executed)
                                  Filter: (device_id = 1)
          ->  Materialize (actual rows=100 loops=1)
                ->  Custom Scan (ChunkAppend) on metrics_space m2 (actual rows=100 loops=1)
@@ -7146,7 +7146,7 @@ FROM :TEST_TABLE m1
                            Sort Key: m2_1."time"
                            Sort Method: quicksort 
                            ->  Custom Scan (DecompressChunk) on _hyper_2_5_chunk m2_1 (actual rows=360 loops=1)
-                                 ->  Seq Scan on compress_hyper_6_18_chunk (actual rows=1 loops=1)
+                                 ->  Seq Scan on compress_hyper_6_19_chunk (actual rows=1 loops=1)
                                        Filter: (device_id = 2)
                                        Rows Removed by Filter: 2
                      ->  Index Scan Backward using _hyper_2_8_chunk_metrics_space_device_id_time_idx on _hyper_2_8_chunk m2_2 (never executed)
@@ -7154,7 +7154,7 @@ FROM :TEST_TABLE m1
                      ->  Sort (never executed)
                            Sort Key: m2_3."time"
                            ->  Custom Scan (DecompressChunk) on _hyper_2_11_chunk m2_3 (never executed)
-                                 ->  Seq Scan on compress_hyper_6_21_chunk (never executed)
+                                 ->  Seq Scan on compress_hyper_6_25_chunk (never executed)
                                        Filter: (device_id = 2)
 (35 rows)
 
@@ -7188,7 +7188,7 @@ FROM metrics m1
                ->  Sort (never executed)
                      Sort Key: m1_3."time"
                      ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk m1_3 (never executed)
-                           ->  Seq Scan on compress_hyper_5_16_chunk (never executed)
+                           ->  Seq Scan on compress_hyper_5_17_chunk (never executed)
                                  Filter: (device_id = 1)
          ->  Materialize (actual rows=100 loops=1)
                ->  Custom Scan (ChunkAppend) on metrics_space m2 (actual rows=100 loops=1)
@@ -7197,7 +7197,7 @@ FROM metrics m1
                            Sort Key: m2_1."time"
                            Sort Method: quicksort 
                            ->  Custom Scan (DecompressChunk) on _hyper_2_5_chunk m2_1 (actual rows=360 loops=1)
-                                 ->  Seq Scan on compress_hyper_6_18_chunk (actual rows=1 loops=1)
+                                 ->  Seq Scan on compress_hyper_6_19_chunk (actual rows=1 loops=1)
                                        Filter: (device_id = 2)
                                        Rows Removed by Filter: 2
                      ->  Index Scan Backward using _hyper_2_8_chunk_metrics_space_device_id_time_idx on _hyper_2_8_chunk m2_2 (never executed)
@@ -7205,7 +7205,7 @@ FROM metrics m1
                      ->  Sort (never executed)
                            Sort Key: m2_3."time"
                            ->  Custom Scan (DecompressChunk) on _hyper_2_11_chunk m2_3 (never executed)
-                                 ->  Seq Scan on compress_hyper_6_21_chunk (never executed)
+                                 ->  Seq Scan on compress_hyper_6_25_chunk (never executed)
                                        Filter: (device_id = 2)
 (36 rows)
 
@@ -7240,7 +7240,7 @@ LIMIT 10;
                                        Sort Key: m1_1."time"
                                        Sort Method: quicksort 
                                        ->  Custom Scan (DecompressChunk) on _hyper_2_4_chunk m1_1 (actual rows=360 loops=1)
-                                             ->  Seq Scan on compress_hyper_6_17_chunk (actual rows=1 loops=1)
+                                             ->  Seq Scan on compress_hyper_6_18_chunk (actual rows=1 loops=1)
                            ->  Sort (actual rows=7 loops=1)
                                  Sort Key: m1_2."time"
                                  Sort Method: quicksort 
@@ -7248,7 +7248,7 @@ LIMIT 10;
                                        Sort Key: m1_2."time"
                                        Sort Method: quicksort 
                                        ->  Custom Scan (DecompressChunk) on _hyper_2_5_chunk m1_2 (actual rows=1080 loops=1)
-                                             ->  Seq Scan on compress_hyper_6_18_chunk (actual rows=3 loops=1)
+                                             ->  Seq Scan on compress_hyper_6_19_chunk (actual rows=3 loops=1)
                            ->  Sort (actual rows=3 loops=1)
                                  Sort Key: m1_3."time"
                                  Sort Method: quicksort 
@@ -7256,7 +7256,7 @@ LIMIT 10;
                                        Sort Key: m1_3."time"
                                        Sort Method: quicksort 
                                        ->  Custom Scan (DecompressChunk) on _hyper_2_6_chunk m1_3 (actual rows=360 loops=1)
-                                             ->  Seq Scan on compress_hyper_6_19_chunk (actual rows=1 loops=1)
+                                             ->  Seq Scan on compress_hyper_6_20_chunk (actual rows=1 loops=1)
                      ->  Merge Append (never executed)
                            Sort Key: m1_4."time"
                            ->  Index Scan Backward using _hyper_2_7_chunk_metrics_space_time_idx on _hyper_2_7_chunk m1_4 (never executed)
@@ -7269,13 +7269,13 @@ LIMIT 10;
                                  ->  Sort (never executed)
                                        Sort Key: m1_7."time"
                                        ->  Custom Scan (DecompressChunk) on _hyper_2_10_chunk m1_7 (never executed)
-                                             ->  Seq Scan on compress_hyper_6_20_chunk (never executed)
+                                             ->  Seq Scan on compress_hyper_6_24_chunk (never executed)
                            ->  Sort (never executed)
                                  Sort Key: m1_8."time"
                                  ->  Sort (never executed)
                                        Sort Key: m1_8."time"
                                        ->  Custom Scan (DecompressChunk) on _hyper_2_11_chunk m1_8 (never executed)
-                                             ->  Seq Scan on compress_hyper_6_21_chunk (never executed)
+                                             ->  Seq Scan on compress_hyper_6_25_chunk (never executed)
                            ->  Index Scan Backward using _hyper_2_12_chunk_metrics_space_time_idx on _hyper_2_12_chunk m1_9 (never executed)
                ->  Materialize (actual rows=51 loops=1)
                      ->  Custom Scan (ChunkAppend) on metrics_space m2 (actual rows=11 loops=1)
@@ -7289,7 +7289,7 @@ LIMIT 10;
                                              Sort Key: m2_1."time"
                                              Sort Method: quicksort 
                                              ->  Custom Scan (DecompressChunk) on _hyper_2_4_chunk m2_1 (actual rows=360 loops=1)
-                                                   ->  Seq Scan on compress_hyper_6_17_chunk compress_hyper_6_17_chunk_1 (actual rows=1 loops=1)
+                                                   ->  Seq Scan on compress_hyper_6_18_chunk compress_hyper_6_18_chunk_1 (actual rows=1 loops=1)
                                  ->  Sort (actual rows=7 loops=1)
                                        Sort Key: m2_2."time"
                                        Sort Method: quicksort 
@@ -7297,7 +7297,7 @@ LIMIT 10;
                                              Sort Key: m2_2."time"
                                              Sort Method: quicksort 
                                              ->  Custom Scan (DecompressChunk) on _hyper_2_5_chunk m2_2 (actual rows=1080 loops=1)
-                                                   ->  Seq Scan on compress_hyper_6_18_chunk compress_hyper_6_18_chunk_1 (actual rows=3 loops=1)
+                                                   ->  Seq Scan on compress_hyper_6_19_chunk compress_hyper_6_19_chunk_1 (actual rows=3 loops=1)
                                  ->  Sort (actual rows=3 loops=1)
                                        Sort Key: m2_3."time"
                                        Sort Method: quicksort 
@@ -7305,7 +7305,7 @@ LIMIT 10;
                                              Sort Key: m2_3."time"
                                              Sort Method: quicksort 
                                              ->  Custom Scan (DecompressChunk) on _hyper_2_6_chunk m2_3 (actual rows=360 loops=1)
-                                                   ->  Seq Scan on compress_hyper_6_19_chunk compress_hyper_6_19_chunk_1 (actual rows=1 loops=1)
+                                                   ->  Seq Scan on compress_hyper_6_20_chunk compress_hyper_6_20_chunk_1 (actual rows=1 loops=1)
                            ->  Merge Append (never executed)
                                  Sort Key: m2_4."time"
                                  ->  Index Scan Backward using _hyper_2_7_chunk_metrics_space_time_idx on _hyper_2_7_chunk m2_4 (never executed)
@@ -7318,13 +7318,13 @@ LIMIT 10;
                                        ->  Sort (never executed)
                                              Sort Key: m2_7."time"
                                              ->  Custom Scan (DecompressChunk) on _hyper_2_10_chunk m2_7 (never executed)
-                                                   ->  Seq Scan on compress_hyper_6_20_chunk compress_hyper_6_20_chunk_1 (never executed)
+                                                   ->  Seq Scan on compress_hyper_6_24_chunk compress_hyper_6_24_chunk_1 (never executed)
                                  ->  Sort (never executed)
                                        Sort Key: m2_8."time"
                                        ->  Sort (never executed)
                                              Sort Key: m2_8."time"
                                              ->  Custom Scan (DecompressChunk) on _hyper_2_11_chunk m2_8 (never executed)
-                                                   ->  Seq Scan on compress_hyper_6_21_chunk compress_hyper_6_21_chunk_1 (never executed)
+                                                   ->  Seq Scan on compress_hyper_6_25_chunk compress_hyper_6_25_chunk_1 (never executed)
                                  ->  Index Scan Backward using _hyper_2_12_chunk_metrics_space_time_idx on _hyper_2_12_chunk m2_9 (never executed)
 (106 rows)
 
@@ -7361,7 +7361,7 @@ LIMIT 100;
                                        Sort Key: m1_1."time"
                                        Sort Method: quicksort 
                                        ->  Custom Scan (DecompressChunk) on _hyper_2_4_chunk m1_1 (actual rows=360 loops=1)
-                                             ->  Seq Scan on compress_hyper_6_17_chunk (actual rows=1 loops=1)
+                                             ->  Seq Scan on compress_hyper_6_18_chunk (actual rows=1 loops=1)
                            ->  Sort (actual rows=61 loops=1)
                                  Sort Key: m1_2."time"
                                  Sort Method: quicksort 
@@ -7369,7 +7369,7 @@ LIMIT 100;
                                        Sort Key: m1_2."time"
                                        Sort Method: quicksort 
                                        ->  Custom Scan (DecompressChunk) on _hyper_2_5_chunk m1_2 (actual rows=1080 loops=1)
-                                             ->  Seq Scan on compress_hyper_6_18_chunk (actual rows=3 loops=1)
+                                             ->  Seq Scan on compress_hyper_6_19_chunk (actual rows=3 loops=1)
                            ->  Sort (actual rows=21 loops=1)
                                  Sort Key: m1_3."time"
                                  Sort Method: quicksort 
@@ -7377,7 +7377,7 @@ LIMIT 100;
                                        Sort Key: m1_3."time"
                                        Sort Method: quicksort 
                                        ->  Custom Scan (DecompressChunk) on _hyper_2_6_chunk m1_3 (actual rows=360 loops=1)
-                                             ->  Seq Scan on compress_hyper_6_19_chunk (actual rows=1 loops=1)
+                                             ->  Seq Scan on compress_hyper_6_20_chunk (actual rows=1 loops=1)
                      ->  Merge Append (never executed)
                            Sort Key: m1_4."time"
                            ->  Index Scan Backward using _hyper_2_7_chunk_metrics_space_time_idx on _hyper_2_7_chunk m1_4 (never executed)
@@ -7390,13 +7390,13 @@ LIMIT 100;
                                  ->  Sort (never executed)
                                        Sort Key: m1_7."time"
                                        ->  Custom Scan (DecompressChunk) on _hyper_2_10_chunk m1_7 (never executed)
-                                             ->  Seq Scan on compress_hyper_6_20_chunk (never executed)
+                                             ->  Seq Scan on compress_hyper_6_24_chunk (never executed)
                            ->  Sort (never executed)
                                  Sort Key: m1_8."time"
                                  ->  Sort (never executed)
                                        Sort Key: m1_8."time"
                                        ->  Custom Scan (DecompressChunk) on _hyper_2_11_chunk m1_8 (never executed)
-                                             ->  Seq Scan on compress_hyper_6_21_chunk (never executed)
+                                             ->  Seq Scan on compress_hyper_6_25_chunk (never executed)
                            ->  Index Scan Backward using _hyper_2_12_chunk_metrics_space_time_idx on _hyper_2_12_chunk m1_9 (never executed)
                ->  Materialize (actual rows=102 loops=1)
                      ->  Custom Scan (ChunkAppend) on metrics_space m2 (actual rows=22 loops=1)
@@ -7410,7 +7410,7 @@ LIMIT 100;
                                              Sort Key: m2_1."time"
                                              Sort Method: quicksort 
                                              ->  Custom Scan (DecompressChunk) on _hyper_2_4_chunk m2_1 (actual rows=0 loops=1)
-                                                   ->  Seq Scan on compress_hyper_6_17_chunk compress_hyper_6_17_chunk_1 (actual rows=0 loops=1)
+                                                   ->  Seq Scan on compress_hyper_6_18_chunk compress_hyper_6_18_chunk_1 (actual rows=0 loops=1)
                                                          Filter: (device_id = 2)
                                                          Rows Removed by Filter: 1
                                  ->  Sort (actual rows=22 loops=1)
@@ -7420,7 +7420,7 @@ LIMIT 100;
                                              Sort Key: m2_2."time"
                                              Sort Method: quicksort 
                                              ->  Custom Scan (DecompressChunk) on _hyper_2_5_chunk m2_2 (actual rows=360 loops=1)
-                                                   ->  Seq Scan on compress_hyper_6_18_chunk compress_hyper_6_18_chunk_1 (actual rows=1 loops=1)
+                                                   ->  Seq Scan on compress_hyper_6_19_chunk compress_hyper_6_19_chunk_1 (actual rows=1 loops=1)
                                                          Filter: (device_id = 2)
                                                          Rows Removed by Filter: 2
                                  ->  Sort (actual rows=0 loops=1)
@@ -7430,7 +7430,7 @@ LIMIT 100;
                                              Sort Key: m2_3."time"
                                              Sort Method: quicksort 
                                              ->  Custom Scan (DecompressChunk) on _hyper_2_6_chunk m2_3 (actual rows=0 loops=1)
-                                                   ->  Seq Scan on compress_hyper_6_19_chunk compress_hyper_6_19_chunk_1 (actual rows=0 loops=1)
+                                                   ->  Seq Scan on compress_hyper_6_20_chunk compress_hyper_6_20_chunk_1 (actual rows=0 loops=1)
                                                          Filter: (device_id = 2)
                                                          Rows Removed by Filter: 1
                            ->  Merge Append (never executed)
@@ -7448,14 +7448,14 @@ LIMIT 100;
                                        ->  Sort (never executed)
                                              Sort Key: m2_7."time"
                                              ->  Custom Scan (DecompressChunk) on _hyper_2_10_chunk m2_7 (never executed)
-                                                   ->  Seq Scan on compress_hyper_6_20_chunk compress_hyper_6_20_chunk_1 (never executed)
+                                                   ->  Seq Scan on compress_hyper_6_24_chunk compress_hyper_6_24_chunk_1 (never executed)
                                                          Filter: (device_id = 2)
                                  ->  Sort (never executed)
                                        Sort Key: m2_8."time"
                                        ->  Sort (never executed)
                                              Sort Key: m2_8."time"
                                              ->  Custom Scan (DecompressChunk) on _hyper_2_11_chunk m2_8 (never executed)
-                                                   ->  Seq Scan on compress_hyper_6_21_chunk compress_hyper_6_21_chunk_1 (never executed)
+                                                   ->  Seq Scan on compress_hyper_6_25_chunk compress_hyper_6_25_chunk_1 (never executed)
                                                          Filter: (device_id = 2)
                                  ->  Index Scan Backward using _hyper_2_12_chunk_metrics_space_time_idx on _hyper_2_12_chunk m2_9 (never executed)
                                        Filter: (device_id = 2)
@@ -7494,7 +7494,7 @@ LIMIT 100;
                      ->  Sort (never executed)
                            Sort Key: m1_3."time"
                            ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk m1_3 (never executed)
-                                 ->  Seq Scan on compress_hyper_5_16_chunk (never executed)
+                                 ->  Seq Scan on compress_hyper_5_17_chunk (never executed)
                ->  Materialize (actual rows=102 loops=1)
                      ->  Custom Scan (ChunkAppend) on metrics_space m2 (actual rows=22 loops=1)
                            Order: m2."time"
@@ -7507,7 +7507,7 @@ LIMIT 100;
                                              Sort Key: m2_1."time"
                                              Sort Method: quicksort 
                                              ->  Custom Scan (DecompressChunk) on _hyper_2_4_chunk m2_1 (actual rows=0 loops=1)
-                                                   ->  Seq Scan on compress_hyper_6_17_chunk (actual rows=0 loops=1)
+                                                   ->  Seq Scan on compress_hyper_6_18_chunk (actual rows=0 loops=1)
                                                          Filter: (device_id = 2)
                                                          Rows Removed by Filter: 1
                                  ->  Sort (actual rows=22 loops=1)
@@ -7517,7 +7517,7 @@ LIMIT 100;
                                              Sort Key: m2_2."time"
                                              Sort Method: quicksort 
                                              ->  Custom Scan (DecompressChunk) on _hyper_2_5_chunk m2_2 (actual rows=360 loops=1)
-                                                   ->  Seq Scan on compress_hyper_6_18_chunk (actual rows=1 loops=1)
+                                                   ->  Seq Scan on compress_hyper_6_19_chunk (actual rows=1 loops=1)
                                                          Filter: (device_id = 2)
                                                          Rows Removed by Filter: 2
                                  ->  Sort (actual rows=0 loops=1)
@@ -7527,7 +7527,7 @@ LIMIT 100;
                                              Sort Key: m2_3."time"
                                              Sort Method: quicksort 
                                              ->  Custom Scan (DecompressChunk) on _hyper_2_6_chunk m2_3 (actual rows=0 loops=1)
-                                                   ->  Seq Scan on compress_hyper_6_19_chunk (actual rows=0 loops=1)
+                                                   ->  Seq Scan on compress_hyper_6_20_chunk (actual rows=0 loops=1)
                                                          Filter: (device_id = 2)
                                                          Rows Removed by Filter: 1
                            ->  Merge Append (never executed)
@@ -7545,14 +7545,14 @@ LIMIT 100;
                                        ->  Sort (never executed)
                                              Sort Key: m2_7."time"
                                              ->  Custom Scan (DecompressChunk) on _hyper_2_10_chunk m2_7 (never executed)
-                                                   ->  Seq Scan on compress_hyper_6_20_chunk (never executed)
+                                                   ->  Seq Scan on compress_hyper_6_24_chunk (never executed)
                                                          Filter: (device_id = 2)
                                  ->  Sort (never executed)
                                        Sort Key: m2_8."time"
                                        ->  Sort (never executed)
                                              Sort Key: m2_8."time"
                                              ->  Custom Scan (DecompressChunk) on _hyper_2_11_chunk m2_8 (never executed)
-                                                   ->  Seq Scan on compress_hyper_6_21_chunk (never executed)
+                                                   ->  Seq Scan on compress_hyper_6_25_chunk (never executed)
                                                          Filter: (device_id = 2)
                                  ->  Index Scan Backward using _hyper_2_12_chunk_metrics_space_time_idx on _hyper_2_12_chunk m2_9 (never executed)
                                        Filter: (device_id = 2)
@@ -7589,7 +7589,7 @@ LIMIT 20;
                                        Sort Key: m1_1."time"
                                        Sort Method: quicksort 
                                        ->  Custom Scan (DecompressChunk) on _hyper_2_4_chunk m1_1 (actual rows=360 loops=1)
-                                             ->  Seq Scan on compress_hyper_6_17_chunk (actual rows=1 loops=1)
+                                             ->  Seq Scan on compress_hyper_6_18_chunk (actual rows=1 loops=1)
                            ->  Sort (actual rows=4 loops=1)
                                  Sort Key: m1_2."time"
                                  Sort Method: quicksort 
@@ -7597,7 +7597,7 @@ LIMIT 20;
                                        Sort Key: m1_2."time"
                                        Sort Method: quicksort 
                                        ->  Custom Scan (DecompressChunk) on _hyper_2_5_chunk m1_2 (actual rows=1080 loops=1)
-                                             ->  Seq Scan on compress_hyper_6_18_chunk (actual rows=3 loops=1)
+                                             ->  Seq Scan on compress_hyper_6_19_chunk (actual rows=3 loops=1)
                            ->  Sort (actual rows=2 loops=1)
                                  Sort Key: m1_3."time"
                                  Sort Method: quicksort 
@@ -7605,7 +7605,7 @@ LIMIT 20;
                                        Sort Key: m1_3."time"
                                        Sort Method: quicksort 
                                        ->  Custom Scan (DecompressChunk) on _hyper_2_6_chunk m1_3 (actual rows=360 loops=1)
-                                             ->  Seq Scan on compress_hyper_6_19_chunk (actual rows=1 loops=1)
+                                             ->  Seq Scan on compress_hyper_6_20_chunk (actual rows=1 loops=1)
                      ->  Merge Append (never executed)
                            Sort Key: m1_4."time"
                            ->  Index Scan Backward using _hyper_2_7_chunk_metrics_space_time_idx on _hyper_2_7_chunk m1_4 (never executed)
@@ -7618,13 +7618,13 @@ LIMIT 20;
                                  ->  Sort (never executed)
                                        Sort Key: m1_7."time"
                                        ->  Custom Scan (DecompressChunk) on _hyper_2_10_chunk m1_7 (never executed)
-                                             ->  Seq Scan on compress_hyper_6_20_chunk (never executed)
+                                             ->  Seq Scan on compress_hyper_6_24_chunk (never executed)
                            ->  Sort (never executed)
                                  Sort Key: m1_8."time"
                                  ->  Sort (never executed)
                                        Sort Key: m1_8."time"
                                        ->  Custom Scan (DecompressChunk) on _hyper_2_11_chunk m1_8 (never executed)
-                                             ->  Seq Scan on compress_hyper_6_21_chunk (never executed)
+                                             ->  Seq Scan on compress_hyper_6_25_chunk (never executed)
                            ->  Index Scan Backward using _hyper_2_12_chunk_metrics_space_time_idx on _hyper_2_12_chunk m1_9 (never executed)
                ->  Materialize (actual rows=26 loops=1)
                      ->  Custom Scan (ChunkAppend) on metrics_space m2 (actual rows=6 loops=1)
@@ -7638,7 +7638,7 @@ LIMIT 20;
                                              Sort Key: m2_1."time"
                                              Sort Method: quicksort 
                                              ->  Custom Scan (DecompressChunk) on _hyper_2_4_chunk m2_1 (actual rows=360 loops=1)
-                                                   ->  Seq Scan on compress_hyper_6_17_chunk compress_hyper_6_17_chunk_1 (actual rows=1 loops=1)
+                                                   ->  Seq Scan on compress_hyper_6_18_chunk compress_hyper_6_18_chunk_1 (actual rows=1 loops=1)
                                  ->  Sort (actual rows=4 loops=1)
                                        Sort Key: m2_2."time"
                                        Sort Method: quicksort 
@@ -7646,7 +7646,7 @@ LIMIT 20;
                                              Sort Key: m2_2."time"
                                              Sort Method: quicksort 
                                              ->  Custom Scan (DecompressChunk) on _hyper_2_5_chunk m2_2 (actual rows=1080 loops=1)
-                                                   ->  Seq Scan on compress_hyper_6_18_chunk compress_hyper_6_18_chunk_1 (actual rows=3 loops=1)
+                                                   ->  Seq Scan on compress_hyper_6_19_chunk compress_hyper_6_19_chunk_1 (actual rows=3 loops=1)
                                  ->  Sort (actual rows=2 loops=1)
                                        Sort Key: m2_3."time"
                                        Sort Method: quicksort 
@@ -7654,7 +7654,7 @@ LIMIT 20;
                                              Sort Key: m2_3."time"
                                              Sort Method: quicksort 
                                              ->  Custom Scan (DecompressChunk) on _hyper_2_6_chunk m2_3 (actual rows=360 loops=1)
-                                                   ->  Seq Scan on compress_hyper_6_19_chunk compress_hyper_6_19_chunk_1 (actual rows=1 loops=1)
+                                                   ->  Seq Scan on compress_hyper_6_20_chunk compress_hyper_6_20_chunk_1 (actual rows=1 loops=1)
                            ->  Merge Append (never executed)
                                  Sort Key: m2_4."time"
                                  ->  Index Scan Backward using _hyper_2_7_chunk_metrics_space_time_idx on _hyper_2_7_chunk m2_4 (never executed)
@@ -7667,13 +7667,13 @@ LIMIT 20;
                                        ->  Sort (never executed)
                                              Sort Key: m2_7."time"
                                              ->  Custom Scan (DecompressChunk) on _hyper_2_10_chunk m2_7 (never executed)
-                                                   ->  Seq Scan on compress_hyper_6_20_chunk compress_hyper_6_20_chunk_1 (never executed)
+                                                   ->  Seq Scan on compress_hyper_6_24_chunk compress_hyper_6_24_chunk_1 (never executed)
                                  ->  Sort (never executed)
                                        Sort Key: m2_8."time"
                                        ->  Sort (never executed)
                                              Sort Key: m2_8."time"
                                              ->  Custom Scan (DecompressChunk) on _hyper_2_11_chunk m2_8 (never executed)
-                                                   ->  Seq Scan on compress_hyper_6_21_chunk compress_hyper_6_21_chunk_1 (never executed)
+                                                   ->  Seq Scan on compress_hyper_6_25_chunk compress_hyper_6_25_chunk_1 (never executed)
                                  ->  Index Scan Backward using _hyper_2_12_chunk_metrics_space_time_idx on _hyper_2_12_chunk m2_9 (never executed)
 (104 rows)
 
@@ -7710,7 +7710,7 @@ LIMIT 10;
                                        Sort Key: m1_1."time"
                                        Sort Method: quicksort 
                                        ->  Custom Scan (DecompressChunk) on _hyper_2_4_chunk m1_1 (actual rows=360 loops=1)
-                                             ->  Seq Scan on compress_hyper_6_17_chunk (actual rows=1 loops=1)
+                                             ->  Seq Scan on compress_hyper_6_18_chunk (actual rows=1 loops=1)
                            ->  Sort (actual rows=4 loops=1)
                                  Sort Key: m1_2."time"
                                  Sort Method: quicksort 
@@ -7718,7 +7718,7 @@ LIMIT 10;
                                        Sort Key: m1_2."time"
                                        Sort Method: quicksort 
                                        ->  Custom Scan (DecompressChunk) on _hyper_2_5_chunk m1_2 (actual rows=1080 loops=1)
-                                             ->  Seq Scan on compress_hyper_6_18_chunk (actual rows=3 loops=1)
+                                             ->  Seq Scan on compress_hyper_6_19_chunk (actual rows=3 loops=1)
                            ->  Sort (actual rows=2 loops=1)
                                  Sort Key: m1_3."time"
                                  Sort Method: quicksort 
@@ -7726,7 +7726,7 @@ LIMIT 10;
                                        Sort Key: m1_3."time"
                                        Sort Method: quicksort 
                                        ->  Custom Scan (DecompressChunk) on _hyper_2_6_chunk m1_3 (actual rows=360 loops=1)
-                                             ->  Seq Scan on compress_hyper_6_19_chunk (actual rows=1 loops=1)
+                                             ->  Seq Scan on compress_hyper_6_20_chunk (actual rows=1 loops=1)
                      ->  Merge Append (never executed)
                            Sort Key: m1_4."time"
                            ->  Index Scan Backward using _hyper_2_7_chunk_metrics_space_time_idx on _hyper_2_7_chunk m1_4 (never executed)
@@ -7739,13 +7739,13 @@ LIMIT 10;
                                  ->  Sort (never executed)
                                        Sort Key: m1_7."time"
                                        ->  Custom Scan (DecompressChunk) on _hyper_2_10_chunk m1_7 (never executed)
-                                             ->  Seq Scan on compress_hyper_6_20_chunk (never executed)
+                                             ->  Seq Scan on compress_hyper_6_24_chunk (never executed)
                            ->  Sort (never executed)
                                  Sort Key: m1_8."time"
                                  ->  Sort (never executed)
                                        Sort Key: m1_8."time"
                                        ->  Custom Scan (DecompressChunk) on _hyper_2_11_chunk m1_8 (never executed)
-                                             ->  Seq Scan on compress_hyper_6_21_chunk (never executed)
+                                             ->  Seq Scan on compress_hyper_6_25_chunk (never executed)
                            ->  Index Scan Backward using _hyper_2_12_chunk_metrics_space_time_idx on _hyper_2_12_chunk m1_9 (never executed)
                ->  Materialize (actual rows=26 loops=1)
                      ->  Custom Scan (ChunkAppend) on metrics_space m2 (actual rows=6 loops=1)
@@ -7759,7 +7759,7 @@ LIMIT 10;
                                              Sort Key: m2_1."time"
                                              Sort Method: quicksort 
                                              ->  Custom Scan (DecompressChunk) on _hyper_2_4_chunk m2_1 (actual rows=360 loops=1)
-                                                   ->  Seq Scan on compress_hyper_6_17_chunk compress_hyper_6_17_chunk_1 (actual rows=1 loops=1)
+                                                   ->  Seq Scan on compress_hyper_6_18_chunk compress_hyper_6_18_chunk_1 (actual rows=1 loops=1)
                                  ->  Sort (actual rows=4 loops=1)
                                        Sort Key: m2_2."time"
                                        Sort Method: quicksort 
@@ -7767,7 +7767,7 @@ LIMIT 10;
                                              Sort Key: m2_2."time"
                                              Sort Method: quicksort 
                                              ->  Custom Scan (DecompressChunk) on _hyper_2_5_chunk m2_2 (actual rows=1080 loops=1)
-                                                   ->  Seq Scan on compress_hyper_6_18_chunk compress_hyper_6_18_chunk_1 (actual rows=3 loops=1)
+                                                   ->  Seq Scan on compress_hyper_6_19_chunk compress_hyper_6_19_chunk_1 (actual rows=3 loops=1)
                                  ->  Sort (actual rows=2 loops=1)
                                        Sort Key: m2_3."time"
                                        Sort Method: quicksort 
@@ -7775,7 +7775,7 @@ LIMIT 10;
                                              Sort Key: m2_3."time"
                                              Sort Method: quicksort 
                                              ->  Custom Scan (DecompressChunk) on _hyper_2_6_chunk m2_3 (actual rows=360 loops=1)
-                                                   ->  Seq Scan on compress_hyper_6_19_chunk compress_hyper_6_19_chunk_1 (actual rows=1 loops=1)
+                                                   ->  Seq Scan on compress_hyper_6_20_chunk compress_hyper_6_20_chunk_1 (actual rows=1 loops=1)
                            ->  Merge Append (never executed)
                                  Sort Key: m2_4."time"
                                  ->  Index Scan Backward using _hyper_2_7_chunk_metrics_space_time_idx on _hyper_2_7_chunk m2_4 (never executed)
@@ -7788,13 +7788,13 @@ LIMIT 10;
                                        ->  Sort (never executed)
                                              Sort Key: m2_7."time"
                                              ->  Custom Scan (DecompressChunk) on _hyper_2_10_chunk m2_7 (never executed)
-                                                   ->  Seq Scan on compress_hyper_6_20_chunk compress_hyper_6_20_chunk_1 (never executed)
+                                                   ->  Seq Scan on compress_hyper_6_24_chunk compress_hyper_6_24_chunk_1 (never executed)
                                  ->  Sort (never executed)
                                        Sort Key: m2_8."time"
                                        ->  Sort (never executed)
                                              Sort Key: m2_8."time"
                                              ->  Custom Scan (DecompressChunk) on _hyper_2_11_chunk m2_8 (never executed)
-                                                   ->  Seq Scan on compress_hyper_6_21_chunk compress_hyper_6_21_chunk_1 (never executed)
+                                                   ->  Seq Scan on compress_hyper_6_25_chunk compress_hyper_6_25_chunk_1 (never executed)
                                  ->  Index Scan Backward using _hyper_2_12_chunk_metrics_space_time_idx on _hyper_2_12_chunk m2_9 (never executed)
 (104 rows)
 
@@ -7816,15 +7816,15 @@ FROM generate_series('2000-01-01'::timestamptz, '2000-02-01'::timestamptz, '1d':
                ->  Custom Scan (DecompressChunk) on _hyper_2_4_chunk m1_1 (actual rows=1 loops=5)
                      Filter: ("time" = g."time")
                      Rows Removed by Filter: 168
-                     ->  Seq Scan on compress_hyper_6_17_chunk (actual rows=1 loops=5)
+                     ->  Seq Scan on compress_hyper_6_18_chunk (actual rows=1 loops=5)
                            Filter: ((_ts_meta_min_3 <= g."time") AND (_ts_meta_max_3 >= g."time"))
                ->  Custom Scan (DecompressChunk) on _hyper_2_5_chunk m1_2 (never executed)
                      Filter: ("time" = g."time")
-                     ->  Seq Scan on compress_hyper_6_18_chunk (never executed)
+                     ->  Seq Scan on compress_hyper_6_19_chunk (never executed)
                            Filter: ((_ts_meta_min_3 <= g."time") AND (_ts_meta_max_3 >= g."time"))
                ->  Custom Scan (DecompressChunk) on _hyper_2_6_chunk m1_3 (never executed)
                      Filter: ("time" = g."time")
-                     ->  Seq Scan on compress_hyper_6_19_chunk (never executed)
+                     ->  Seq Scan on compress_hyper_6_20_chunk (never executed)
                            Filter: ((_ts_meta_min_3 <= g."time") AND (_ts_meta_max_3 >= g."time"))
                ->  Index Only Scan using _hyper_2_7_chunk_metrics_space_time_idx on _hyper_2_7_chunk m1_4 (actual rows=1 loops=7)
                      Index Cond: ("time" = g."time")
@@ -7838,11 +7838,11 @@ FROM generate_series('2000-01-01'::timestamptz, '2000-02-01'::timestamptz, '1d':
                ->  Custom Scan (DecompressChunk) on _hyper_2_10_chunk m1_7 (actual rows=1 loops=7)
                      Filter: ("time" = g."time")
                      Rows Removed by Filter: 240
-                     ->  Seq Scan on compress_hyper_6_20_chunk (actual rows=1 loops=7)
+                     ->  Seq Scan on compress_hyper_6_24_chunk (actual rows=1 loops=7)
                            Filter: ((_ts_meta_min_3 <= g."time") AND (_ts_meta_max_3 >= g."time"))
                ->  Custom Scan (DecompressChunk) on _hyper_2_11_chunk m1_8 (never executed)
                      Filter: ("time" = g."time")
-                     ->  Seq Scan on compress_hyper_6_21_chunk (never executed)
+                     ->  Seq Scan on compress_hyper_6_25_chunk (never executed)
                            Filter: ((_ts_meta_min_3 <= g."time") AND (_ts_meta_max_3 >= g."time"))
                ->  Index Only Scan using _hyper_2_12_chunk_metrics_space_time_idx on _hyper_2_12_chunk m1_9 (never executed)
                      Index Cond: ("time" = g."time")
@@ -7870,7 +7870,7 @@ FROM generate_series('2000-01-01'::timestamptz, '2000-02-01'::timestamptz, '1d':
                ->  Custom Scan (DecompressChunk) on _hyper_2_4_chunk m1_1 (actual rows=1 loops=5)
                      Filter: ("time" = g."time")
                      Rows Removed by Filter: 168
-                     ->  Seq Scan on compress_hyper_6_17_chunk (actual rows=1 loops=5)
+                     ->  Seq Scan on compress_hyper_6_18_chunk (actual rows=1 loops=5)
                            Filter: ((_ts_meta_min_3 <= g."time") AND (_ts_meta_max_3 >= g."time") AND (device_id = 1))
                ->  Index Only Scan using _hyper_2_7_chunk_metrics_space_device_id_time_idx on _hyper_2_7_chunk m1_2 (actual rows=1 loops=7)
                      Index Cond: ((device_id = 1) AND ("time" = g."time"))
@@ -7878,7 +7878,7 @@ FROM generate_series('2000-01-01'::timestamptz, '2000-02-01'::timestamptz, '1d':
                ->  Custom Scan (DecompressChunk) on _hyper_2_10_chunk m1_3 (actual rows=1 loops=7)
                      Filter: ("time" = g."time")
                      Rows Removed by Filter: 240
-                     ->  Seq Scan on compress_hyper_6_20_chunk (actual rows=1 loops=7)
+                     ->  Seq Scan on compress_hyper_6_24_chunk (actual rows=1 loops=7)
                            Filter: ((_ts_meta_min_3 <= g."time") AND (_ts_meta_max_3 >= g."time") AND (device_id = 1))
 (18 rows)
 
@@ -7893,7 +7893,7 @@ FROM generate_series('2000-01-01'::timestamptz, '2000-02-01'::timestamptz, '1d':
                ->  Custom Scan (DecompressChunk) on _hyper_2_5_chunk m1_1 (actual rows=1 loops=5)
                      Filter: ("time" = g."time")
                      Rows Removed by Filter: 168
-                     ->  Seq Scan on compress_hyper_6_18_chunk (actual rows=1 loops=5)
+                     ->  Seq Scan on compress_hyper_6_19_chunk (actual rows=1 loops=5)
                            Filter: ((_ts_meta_min_3 <= g."time") AND (_ts_meta_max_3 >= g."time") AND (device_id = 2))
                ->  Index Only Scan using _hyper_2_8_chunk_metrics_space_device_id_time_idx on _hyper_2_8_chunk m1_2 (actual rows=1 loops=7)
                      Index Cond: ((device_id = 2) AND ("time" = g."time"))
@@ -7901,7 +7901,7 @@ FROM generate_series('2000-01-01'::timestamptz, '2000-02-01'::timestamptz, '1d':
                ->  Custom Scan (DecompressChunk) on _hyper_2_11_chunk m1_3 (actual rows=1 loops=7)
                      Filter: ("time" = g."time")
                      Rows Removed by Filter: 240
-                     ->  Seq Scan on compress_hyper_6_21_chunk (actual rows=1 loops=7)
+                     ->  Seq Scan on compress_hyper_6_25_chunk (actual rows=1 loops=7)
                            Filter: ((_ts_meta_min_3 <= g."time") AND (_ts_meta_max_3 >= g."time") AND (device_id = 2))
 (18 rows)
 
@@ -8066,18 +8066,18 @@ WHERE metrics.time > metrics_space.time
  Nested Loop (actual rows=0 loops=1)
    ->  Append (actual rows=6840 loops=1)
          ->  Custom Scan (DecompressChunk) on _hyper_2_4_chunk (actual rows=360 loops=1)
-               ->  Index Scan using compress_hyper_6_17_chunk_c_space_index_2 on compress_hyper_6_17_chunk (actual rows=1 loops=1)
+               ->  Index Scan using compress_hyper_6_18_chunk_c_space_index_2 on compress_hyper_6_18_chunk (actual rows=1 loops=1)
          ->  Custom Scan (DecompressChunk) on _hyper_2_5_chunk (actual rows=1080 loops=1)
-               ->  Index Scan using compress_hyper_6_18_chunk_c_space_index_2 on compress_hyper_6_18_chunk (actual rows=3 loops=1)
+               ->  Index Scan using compress_hyper_6_19_chunk_c_space_index_2 on compress_hyper_6_19_chunk (actual rows=3 loops=1)
          ->  Custom Scan (DecompressChunk) on _hyper_2_6_chunk (actual rows=360 loops=1)
-               ->  Index Scan using compress_hyper_6_19_chunk_c_space_index_2 on compress_hyper_6_19_chunk (actual rows=1 loops=1)
+               ->  Index Scan using compress_hyper_6_20_chunk_c_space_index_2 on compress_hyper_6_20_chunk (actual rows=1 loops=1)
          ->  Index Scan Backward using _hyper_2_7_chunk_metrics_space_device_id_device_id_peer_v0_v1_2 on _hyper_2_7_chunk (actual rows=504 loops=1)
          ->  Index Scan Backward using _hyper_2_8_chunk_metrics_space_device_id_device_id_peer_v0_v1_2 on _hyper_2_8_chunk (actual rows=1512 loops=1)
          ->  Index Scan Backward using _hyper_2_9_chunk_metrics_space_device_id_device_id_peer_v0_v1_2 on _hyper_2_9_chunk (actual rows=504 loops=1)
          ->  Custom Scan (DecompressChunk) on _hyper_2_10_chunk (actual rows=504 loops=1)
-               ->  Index Scan using compress_hyper_6_20_chunk_c_space_index_2 on compress_hyper_6_20_chunk (actual rows=1 loops=1)
+               ->  Index Scan using compress_hyper_6_24_chunk_c_space_index_2 on compress_hyper_6_24_chunk (actual rows=1 loops=1)
          ->  Custom Scan (DecompressChunk) on _hyper_2_11_chunk (actual rows=1512 loops=1)
-               ->  Index Scan using compress_hyper_6_21_chunk_c_space_index_2 on compress_hyper_6_21_chunk (actual rows=3 loops=1)
+               ->  Index Scan using compress_hyper_6_25_chunk_c_space_index_2 on compress_hyper_6_25_chunk (actual rows=3 loops=1)
          ->  Index Scan Backward using _hyper_2_12_chunk_metrics_space_device_id_device_id_peer_v0_v_2 on _hyper_2_12_chunk (actual rows=504 loops=1)
    ->  Append (actual rows=0 loops=6840)
          ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk (actual rows=0 loops=6840)
@@ -8091,7 +8091,7 @@ WHERE metrics.time > metrics_space.time
          ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk (actual rows=0 loops=6840)
                Filter: (("time" > _hyper_2_4_chunk."time") AND ("time" < _hyper_2_4_chunk."time"))
                Rows Removed by Filter: 504
-               ->  Index Scan using compress_hyper_5_16_chunk_c_index_2 on compress_hyper_5_16_chunk (actual rows=1 loops=6840)
+               ->  Index Scan using compress_hyper_5_17_chunk_c_index_2 on compress_hyper_5_17_chunk (actual rows=1 loops=6840)
                      Index Cond: (device_id = _hyper_2_4_chunk.device_id)
 (30 rows)
 
@@ -8128,9 +8128,9 @@ WHERE ht.table_name = 'metrics_ordered'
 ORDER BY c.id;
               compress_chunk              
 ------------------------------------------
- _timescaledb_internal._hyper_11_26_chunk
- _timescaledb_internal._hyper_11_27_chunk
- _timescaledb_internal._hyper_11_28_chunk
+ _timescaledb_internal._hyper_11_31_chunk
+ _timescaledb_internal._hyper_11_33_chunk
+ _timescaledb_internal._hyper_11_35_chunk
 (3 rows)
 
 -- reindexing compressed hypertable to update statistics
@@ -8154,19 +8154,19 @@ $$;
  Limit (actual rows=10 loops=1)
    ->  Custom Scan (ChunkAppend) on metrics_ordered (actual rows=10 loops=1)
          Order: metrics_ordered."time" DESC
-         ->  Custom Scan (DecompressChunk) on _hyper_11_28_chunk (actual rows=10 loops=1)
+         ->  Custom Scan (DecompressChunk) on _hyper_11_35_chunk (actual rows=10 loops=1)
                ->  Sort (actual rows=5 loops=1)
-                     Sort Key: compress_hyper_12_31_chunk._ts_meta_max_1 DESC
+                     Sort Key: compress_hyper_12_36_chunk._ts_meta_max_1 DESC
                      Sort Method: quicksort 
-                     ->  Seq Scan on compress_hyper_12_31_chunk (actual rows=5 loops=1)
-         ->  Custom Scan (DecompressChunk) on _hyper_11_27_chunk (never executed)
+                     ->  Seq Scan on compress_hyper_12_36_chunk (actual rows=5 loops=1)
+         ->  Custom Scan (DecompressChunk) on _hyper_11_33_chunk (never executed)
                ->  Sort (never executed)
-                     Sort Key: compress_hyper_12_30_chunk._ts_meta_max_1 DESC
-                     ->  Seq Scan on compress_hyper_12_30_chunk (never executed)
-         ->  Custom Scan (DecompressChunk) on _hyper_11_26_chunk (never executed)
+                     Sort Key: compress_hyper_12_34_chunk._ts_meta_max_1 DESC
+                     ->  Seq Scan on compress_hyper_12_34_chunk (never executed)
+         ->  Custom Scan (DecompressChunk) on _hyper_11_31_chunk (never executed)
                ->  Sort (never executed)
-                     Sort Key: compress_hyper_12_29_chunk._ts_meta_max_1 DESC
-                     ->  Seq Scan on compress_hyper_12_29_chunk (never executed)
+                     Sort Key: compress_hyper_12_32_chunk._ts_meta_max_1 DESC
+                     ->  Seq Scan on compress_hyper_12_32_chunk (never executed)
 (16 rows)
 
 -- should have ordered DecompressChunk path because segmentby columns have equality constraints
@@ -8176,25 +8176,25 @@ $$;
  Limit (actual rows=0 loops=1)
    ->  Custom Scan (ChunkAppend) on metrics_ordered (actual rows=0 loops=1)
          Order: metrics_ordered."time" DESC
-         ->  Custom Scan (DecompressChunk) on _hyper_11_28_chunk (actual rows=0 loops=1)
+         ->  Custom Scan (DecompressChunk) on _hyper_11_35_chunk (actual rows=0 loops=1)
                ->  Sort (actual rows=0 loops=1)
-                     Sort Key: compress_hyper_12_31_chunk._ts_meta_sequence_num
+                     Sort Key: compress_hyper_12_36_chunk._ts_meta_sequence_num
                      Sort Method: quicksort 
-                     ->  Seq Scan on compress_hyper_12_31_chunk (actual rows=0 loops=1)
+                     ->  Seq Scan on compress_hyper_12_36_chunk (actual rows=0 loops=1)
                            Filter: ((device_id = 1) AND (device_id_peer = 3))
                            Rows Removed by Filter: 5
-         ->  Custom Scan (DecompressChunk) on _hyper_11_27_chunk (actual rows=0 loops=1)
+         ->  Custom Scan (DecompressChunk) on _hyper_11_33_chunk (actual rows=0 loops=1)
                ->  Sort (actual rows=0 loops=1)
-                     Sort Key: compress_hyper_12_30_chunk._ts_meta_sequence_num
+                     Sort Key: compress_hyper_12_34_chunk._ts_meta_sequence_num
                      Sort Method: quicksort 
-                     ->  Seq Scan on compress_hyper_12_30_chunk (actual rows=0 loops=1)
+                     ->  Seq Scan on compress_hyper_12_34_chunk (actual rows=0 loops=1)
                            Filter: ((device_id = 1) AND (device_id_peer = 3))
                            Rows Removed by Filter: 5
-         ->  Custom Scan (DecompressChunk) on _hyper_11_26_chunk (actual rows=0 loops=1)
+         ->  Custom Scan (DecompressChunk) on _hyper_11_31_chunk (actual rows=0 loops=1)
                ->  Sort (actual rows=0 loops=1)
-                     Sort Key: compress_hyper_12_29_chunk._ts_meta_sequence_num
+                     Sort Key: compress_hyper_12_32_chunk._ts_meta_sequence_num
                      Sort Method: quicksort 
-                     ->  Seq Scan on compress_hyper_12_29_chunk (actual rows=0 loops=1)
+                     ->  Seq Scan on compress_hyper_12_32_chunk (actual rows=0 loops=1)
                            Filter: ((device_id = 1) AND (device_id_peer = 3))
                            Rows Removed by Filter: 5
 (24 rows)
@@ -8206,35 +8206,35 @@ $$;
    ->  Nested Loop (actual rows=0 loops=1)
          ->  Merge Append (actual rows=6840 loops=1)
                Sort Key: d_1.device_id
-               ->  Custom Scan (DecompressChunk) on _hyper_11_26_chunk d_1 (actual rows=1800 loops=1)
-                     ->  Index Scan using compress_hyper_12_29_chunk__compressed_hypertable_12_device_id_ on compress_hyper_12_29_chunk (actual rows=5 loops=1)
-               ->  Custom Scan (DecompressChunk) on _hyper_11_27_chunk d_2 (actual rows=2520 loops=1)
-                     ->  Index Scan using compress_hyper_12_30_chunk__compressed_hypertable_12_device_id_ on compress_hyper_12_30_chunk (actual rows=5 loops=1)
-               ->  Custom Scan (DecompressChunk) on _hyper_11_28_chunk d_3 (actual rows=2520 loops=1)
-                     ->  Index Scan using compress_hyper_12_31_chunk__compressed_hypertable_12_device_id_ on compress_hyper_12_31_chunk (actual rows=5 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_11_31_chunk d_1 (actual rows=1800 loops=1)
+                     ->  Index Scan using compress_hyper_12_32_chunk__compressed_hypertable_12_device_id_ on compress_hyper_12_32_chunk (actual rows=5 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_11_33_chunk d_2 (actual rows=2520 loops=1)
+                     ->  Index Scan using compress_hyper_12_34_chunk__compressed_hypertable_12_device_id_ on compress_hyper_12_34_chunk (actual rows=5 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_11_35_chunk d_3 (actual rows=2520 loops=1)
+                     ->  Index Scan using compress_hyper_12_36_chunk__compressed_hypertable_12_device_id_ on compress_hyper_12_36_chunk (actual rows=5 loops=1)
          ->  Limit (actual rows=0 loops=6840)
                ->  Custom Scan (ChunkAppend) on metrics_ordered m (actual rows=0 loops=6840)
                      Order: m."time" DESC
                      Hypertables excluded during runtime: 0
-                     ->  Custom Scan (DecompressChunk) on _hyper_11_28_chunk m_1 (actual rows=0 loops=6840)
+                     ->  Custom Scan (DecompressChunk) on _hyper_11_35_chunk m_1 (actual rows=0 loops=6840)
                            ->  Sort (actual rows=0 loops=6840)
-                                 Sort Key: compress_hyper_12_31_chunk_1._ts_meta_sequence_num
+                                 Sort Key: compress_hyper_12_36_chunk_1._ts_meta_sequence_num
                                  Sort Method: quicksort 
-                                 ->  Seq Scan on compress_hyper_12_31_chunk compress_hyper_12_31_chunk_1 (actual rows=0 loops=6840)
+                                 ->  Seq Scan on compress_hyper_12_36_chunk compress_hyper_12_36_chunk_1 (actual rows=0 loops=6840)
                                        Filter: ((device_id = d_1.device_id) AND (device_id_peer = 3))
                                        Rows Removed by Filter: 5
-                     ->  Custom Scan (DecompressChunk) on _hyper_11_27_chunk m_2 (actual rows=0 loops=6840)
+                     ->  Custom Scan (DecompressChunk) on _hyper_11_33_chunk m_2 (actual rows=0 loops=6840)
                            ->  Sort (actual rows=0 loops=6840)
-                                 Sort Key: compress_hyper_12_30_chunk_1._ts_meta_sequence_num
+                                 Sort Key: compress_hyper_12_34_chunk_1._ts_meta_sequence_num
                                  Sort Method: quicksort 
-                                 ->  Seq Scan on compress_hyper_12_30_chunk compress_hyper_12_30_chunk_1 (actual rows=0 loops=6840)
+                                 ->  Seq Scan on compress_hyper_12_34_chunk compress_hyper_12_34_chunk_1 (actual rows=0 loops=6840)
                                        Filter: ((device_id = d_1.device_id) AND (device_id_peer = 3))
                                        Rows Removed by Filter: 5
-                     ->  Custom Scan (DecompressChunk) on _hyper_11_26_chunk m_3 (actual rows=0 loops=6840)
+                     ->  Custom Scan (DecompressChunk) on _hyper_11_31_chunk m_3 (actual rows=0 loops=6840)
                            ->  Sort (actual rows=0 loops=6840)
-                                 Sort Key: compress_hyper_12_29_chunk_1._ts_meta_sequence_num
+                                 Sort Key: compress_hyper_12_32_chunk_1._ts_meta_sequence_num
                                  Sort Method: quicksort 
-                                 ->  Seq Scan on compress_hyper_12_29_chunk compress_hyper_12_29_chunk_1 (actual rows=0 loops=6840)
+                                 ->  Seq Scan on compress_hyper_12_32_chunk compress_hyper_12_32_chunk_1 (actual rows=0 loops=6840)
                                        Filter: ((device_id = d_1.device_id) AND (device_id_peer = 3))
                                        Rows Removed by Filter: 5
 (35 rows)
@@ -8315,7 +8315,7 @@ PREPARE tableoid_prep AS SELECT tableoid::regclass FROM :TEST_TABLE WHERE device
                ->  Sort (never executed)
                      Sort Key: _hyper_1_3_chunk."time"
                      ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk (never executed)
-                           ->  Seq Scan on compress_hyper_5_16_chunk (never executed)
+                           ->  Seq Scan on compress_hyper_5_17_chunk (never executed)
                                  Filter: (device_id = 1)
 (18 rows)
 
@@ -8372,7 +8372,7 @@ INSERT into readings select g, 1, 1.3 from generate_series('2001-03-01 01:01:01'
 SELECT count(compress_chunk(chunk.schema_name|| '.' || chunk.table_name))
 FROM _timescaledb_catalog.chunk chunk
 INNER JOIN _timescaledb_catalog.hypertable hypertable ON (chunk.hypertable_id = hypertable.id)
-WHERE hypertable.table_name = 'readings' and chunk.compressed_chunk_id IS NULL;
+WHERE hypertable.table_name = 'readings' and chunk.status & 1 = 0;
  count 
 -------
    703
@@ -8382,1419 +8382,1419 @@ EXPLAIN (costs off) SELECT t.fleet as fleet, min(r.fuel_consumption) AS avg_fuel
 FROM tags t
 INNER JOIN LATERAL(SELECT tags_id, fuel_consumption FROM readings r WHERE r.tags_id = t.id ) r ON true
 GROUP BY fleet;
-                                  QUERY PLAN                                  
-------------------------------------------------------------------------------
+                                  QUERY PLAN                                   
+-------------------------------------------------------------------------------
  HashAggregate
    Group Key: t.fleet
    ->  Hash Join
          Hash Cond: (r_1.tags_id = t.id)
          ->  Append
-               ->  Custom Scan (DecompressChunk) on _hyper_13_32_chunk r_1
-                     ->  Seq Scan on compress_hyper_14_735_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_33_chunk r_2
+               ->  Custom Scan (DecompressChunk) on _hyper_13_37_chunk r_1
+                     ->  Seq Scan on compress_hyper_14_38_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_39_chunk r_2
+                     ->  Seq Scan on compress_hyper_14_40_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_41_chunk r_3
+                     ->  Seq Scan on compress_hyper_14_42_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_43_chunk r_4
+                     ->  Seq Scan on compress_hyper_14_44_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_45_chunk r_5
+                     ->  Seq Scan on compress_hyper_14_46_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_47_chunk r_6
+                     ->  Seq Scan on compress_hyper_14_48_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_49_chunk r_7
+                     ->  Seq Scan on compress_hyper_14_50_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_51_chunk r_8
+                     ->  Seq Scan on compress_hyper_14_52_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_53_chunk r_9
+                     ->  Seq Scan on compress_hyper_14_54_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_55_chunk r_10
+                     ->  Seq Scan on compress_hyper_14_56_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_57_chunk r_11
+                     ->  Seq Scan on compress_hyper_14_58_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_59_chunk r_12
+                     ->  Seq Scan on compress_hyper_14_60_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_61_chunk r_13
+                     ->  Seq Scan on compress_hyper_14_62_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_63_chunk r_14
+                     ->  Seq Scan on compress_hyper_14_64_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_65_chunk r_15
+                     ->  Seq Scan on compress_hyper_14_66_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_67_chunk r_16
+                     ->  Seq Scan on compress_hyper_14_68_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_69_chunk r_17
+                     ->  Seq Scan on compress_hyper_14_70_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_71_chunk r_18
+                     ->  Seq Scan on compress_hyper_14_72_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_73_chunk r_19
+                     ->  Seq Scan on compress_hyper_14_74_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_75_chunk r_20
+                     ->  Seq Scan on compress_hyper_14_76_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_77_chunk r_21
+                     ->  Seq Scan on compress_hyper_14_78_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_79_chunk r_22
+                     ->  Seq Scan on compress_hyper_14_80_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_81_chunk r_23
+                     ->  Seq Scan on compress_hyper_14_82_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_83_chunk r_24
+                     ->  Seq Scan on compress_hyper_14_84_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_85_chunk r_25
+                     ->  Seq Scan on compress_hyper_14_86_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_87_chunk r_26
+                     ->  Seq Scan on compress_hyper_14_88_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_89_chunk r_27
+                     ->  Seq Scan on compress_hyper_14_90_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_91_chunk r_28
+                     ->  Seq Scan on compress_hyper_14_92_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_93_chunk r_29
+                     ->  Seq Scan on compress_hyper_14_94_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_95_chunk r_30
+                     ->  Seq Scan on compress_hyper_14_96_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_97_chunk r_31
+                     ->  Seq Scan on compress_hyper_14_98_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_99_chunk r_32
+                     ->  Seq Scan on compress_hyper_14_100_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_101_chunk r_33
+                     ->  Seq Scan on compress_hyper_14_102_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_103_chunk r_34
+                     ->  Seq Scan on compress_hyper_14_104_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_105_chunk r_35
+                     ->  Seq Scan on compress_hyper_14_106_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_107_chunk r_36
+                     ->  Seq Scan on compress_hyper_14_108_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_109_chunk r_37
+                     ->  Seq Scan on compress_hyper_14_110_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_111_chunk r_38
+                     ->  Seq Scan on compress_hyper_14_112_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_113_chunk r_39
+                     ->  Seq Scan on compress_hyper_14_114_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_115_chunk r_40
+                     ->  Seq Scan on compress_hyper_14_116_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_117_chunk r_41
+                     ->  Seq Scan on compress_hyper_14_118_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_119_chunk r_42
+                     ->  Seq Scan on compress_hyper_14_120_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_121_chunk r_43
+                     ->  Seq Scan on compress_hyper_14_122_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_123_chunk r_44
+                     ->  Seq Scan on compress_hyper_14_124_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_125_chunk r_45
+                     ->  Seq Scan on compress_hyper_14_126_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_127_chunk r_46
+                     ->  Seq Scan on compress_hyper_14_128_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_129_chunk r_47
+                     ->  Seq Scan on compress_hyper_14_130_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_131_chunk r_48
+                     ->  Seq Scan on compress_hyper_14_132_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_133_chunk r_49
+                     ->  Seq Scan on compress_hyper_14_134_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_135_chunk r_50
+                     ->  Seq Scan on compress_hyper_14_136_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_137_chunk r_51
+                     ->  Seq Scan on compress_hyper_14_138_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_139_chunk r_52
+                     ->  Seq Scan on compress_hyper_14_140_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_141_chunk r_53
+                     ->  Seq Scan on compress_hyper_14_142_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_143_chunk r_54
+                     ->  Seq Scan on compress_hyper_14_144_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_145_chunk r_55
+                     ->  Seq Scan on compress_hyper_14_146_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_147_chunk r_56
+                     ->  Seq Scan on compress_hyper_14_148_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_149_chunk r_57
+                     ->  Seq Scan on compress_hyper_14_150_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_151_chunk r_58
+                     ->  Seq Scan on compress_hyper_14_152_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_153_chunk r_59
+                     ->  Seq Scan on compress_hyper_14_154_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_155_chunk r_60
+                     ->  Seq Scan on compress_hyper_14_156_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_157_chunk r_61
+                     ->  Seq Scan on compress_hyper_14_158_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_159_chunk r_62
+                     ->  Seq Scan on compress_hyper_14_160_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_161_chunk r_63
+                     ->  Seq Scan on compress_hyper_14_162_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_163_chunk r_64
+                     ->  Seq Scan on compress_hyper_14_164_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_165_chunk r_65
+                     ->  Seq Scan on compress_hyper_14_166_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_167_chunk r_66
+                     ->  Seq Scan on compress_hyper_14_168_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_169_chunk r_67
+                     ->  Seq Scan on compress_hyper_14_170_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_171_chunk r_68
+                     ->  Seq Scan on compress_hyper_14_172_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_173_chunk r_69
+                     ->  Seq Scan on compress_hyper_14_174_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_175_chunk r_70
+                     ->  Seq Scan on compress_hyper_14_176_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_177_chunk r_71
+                     ->  Seq Scan on compress_hyper_14_178_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_179_chunk r_72
+                     ->  Seq Scan on compress_hyper_14_180_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_181_chunk r_73
+                     ->  Seq Scan on compress_hyper_14_182_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_183_chunk r_74
+                     ->  Seq Scan on compress_hyper_14_184_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_185_chunk r_75
+                     ->  Seq Scan on compress_hyper_14_186_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_187_chunk r_76
+                     ->  Seq Scan on compress_hyper_14_188_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_189_chunk r_77
+                     ->  Seq Scan on compress_hyper_14_190_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_191_chunk r_78
+                     ->  Seq Scan on compress_hyper_14_192_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_193_chunk r_79
+                     ->  Seq Scan on compress_hyper_14_194_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_195_chunk r_80
+                     ->  Seq Scan on compress_hyper_14_196_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_197_chunk r_81
+                     ->  Seq Scan on compress_hyper_14_198_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_199_chunk r_82
+                     ->  Seq Scan on compress_hyper_14_200_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_201_chunk r_83
+                     ->  Seq Scan on compress_hyper_14_202_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_203_chunk r_84
+                     ->  Seq Scan on compress_hyper_14_204_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_205_chunk r_85
+                     ->  Seq Scan on compress_hyper_14_206_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_207_chunk r_86
+                     ->  Seq Scan on compress_hyper_14_208_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_209_chunk r_87
+                     ->  Seq Scan on compress_hyper_14_210_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_211_chunk r_88
+                     ->  Seq Scan on compress_hyper_14_212_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_213_chunk r_89
+                     ->  Seq Scan on compress_hyper_14_214_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_215_chunk r_90
+                     ->  Seq Scan on compress_hyper_14_216_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_217_chunk r_91
+                     ->  Seq Scan on compress_hyper_14_218_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_219_chunk r_92
+                     ->  Seq Scan on compress_hyper_14_220_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_221_chunk r_93
+                     ->  Seq Scan on compress_hyper_14_222_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_223_chunk r_94
+                     ->  Seq Scan on compress_hyper_14_224_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_225_chunk r_95
+                     ->  Seq Scan on compress_hyper_14_226_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_227_chunk r_96
+                     ->  Seq Scan on compress_hyper_14_228_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_229_chunk r_97
+                     ->  Seq Scan on compress_hyper_14_230_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_231_chunk r_98
+                     ->  Seq Scan on compress_hyper_14_232_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_233_chunk r_99
+                     ->  Seq Scan on compress_hyper_14_234_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_235_chunk r_100
+                     ->  Seq Scan on compress_hyper_14_236_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_237_chunk r_101
+                     ->  Seq Scan on compress_hyper_14_238_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_239_chunk r_102
+                     ->  Seq Scan on compress_hyper_14_240_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_241_chunk r_103
+                     ->  Seq Scan on compress_hyper_14_242_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_243_chunk r_104
+                     ->  Seq Scan on compress_hyper_14_244_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_245_chunk r_105
+                     ->  Seq Scan on compress_hyper_14_246_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_247_chunk r_106
+                     ->  Seq Scan on compress_hyper_14_248_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_249_chunk r_107
+                     ->  Seq Scan on compress_hyper_14_250_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_251_chunk r_108
+                     ->  Seq Scan on compress_hyper_14_252_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_253_chunk r_109
+                     ->  Seq Scan on compress_hyper_14_254_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_255_chunk r_110
+                     ->  Seq Scan on compress_hyper_14_256_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_257_chunk r_111
+                     ->  Seq Scan on compress_hyper_14_258_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_259_chunk r_112
+                     ->  Seq Scan on compress_hyper_14_260_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_261_chunk r_113
+                     ->  Seq Scan on compress_hyper_14_262_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_263_chunk r_114
+                     ->  Seq Scan on compress_hyper_14_264_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_265_chunk r_115
+                     ->  Seq Scan on compress_hyper_14_266_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_267_chunk r_116
+                     ->  Seq Scan on compress_hyper_14_268_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_269_chunk r_117
+                     ->  Seq Scan on compress_hyper_14_270_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_271_chunk r_118
+                     ->  Seq Scan on compress_hyper_14_272_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_273_chunk r_119
+                     ->  Seq Scan on compress_hyper_14_274_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_275_chunk r_120
+                     ->  Seq Scan on compress_hyper_14_276_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_277_chunk r_121
+                     ->  Seq Scan on compress_hyper_14_278_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_279_chunk r_122
+                     ->  Seq Scan on compress_hyper_14_280_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_281_chunk r_123
+                     ->  Seq Scan on compress_hyper_14_282_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_283_chunk r_124
+                     ->  Seq Scan on compress_hyper_14_284_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_285_chunk r_125
+                     ->  Seq Scan on compress_hyper_14_286_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_287_chunk r_126
+                     ->  Seq Scan on compress_hyper_14_288_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_289_chunk r_127
+                     ->  Seq Scan on compress_hyper_14_290_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_291_chunk r_128
+                     ->  Seq Scan on compress_hyper_14_292_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_293_chunk r_129
+                     ->  Seq Scan on compress_hyper_14_294_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_295_chunk r_130
+                     ->  Seq Scan on compress_hyper_14_296_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_297_chunk r_131
+                     ->  Seq Scan on compress_hyper_14_298_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_299_chunk r_132
+                     ->  Seq Scan on compress_hyper_14_300_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_301_chunk r_133
+                     ->  Seq Scan on compress_hyper_14_302_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_303_chunk r_134
+                     ->  Seq Scan on compress_hyper_14_304_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_305_chunk r_135
+                     ->  Seq Scan on compress_hyper_14_306_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_307_chunk r_136
+                     ->  Seq Scan on compress_hyper_14_308_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_309_chunk r_137
+                     ->  Seq Scan on compress_hyper_14_310_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_311_chunk r_138
+                     ->  Seq Scan on compress_hyper_14_312_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_313_chunk r_139
+                     ->  Seq Scan on compress_hyper_14_314_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_315_chunk r_140
+                     ->  Seq Scan on compress_hyper_14_316_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_317_chunk r_141
+                     ->  Seq Scan on compress_hyper_14_318_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_319_chunk r_142
+                     ->  Seq Scan on compress_hyper_14_320_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_321_chunk r_143
+                     ->  Seq Scan on compress_hyper_14_322_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_323_chunk r_144
+                     ->  Seq Scan on compress_hyper_14_324_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_325_chunk r_145
+                     ->  Seq Scan on compress_hyper_14_326_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_327_chunk r_146
+                     ->  Seq Scan on compress_hyper_14_328_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_329_chunk r_147
+                     ->  Seq Scan on compress_hyper_14_330_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_331_chunk r_148
+                     ->  Seq Scan on compress_hyper_14_332_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_333_chunk r_149
+                     ->  Seq Scan on compress_hyper_14_334_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_335_chunk r_150
+                     ->  Seq Scan on compress_hyper_14_336_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_337_chunk r_151
+                     ->  Seq Scan on compress_hyper_14_338_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_339_chunk r_152
+                     ->  Seq Scan on compress_hyper_14_340_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_341_chunk r_153
+                     ->  Seq Scan on compress_hyper_14_342_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_343_chunk r_154
+                     ->  Seq Scan on compress_hyper_14_344_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_345_chunk r_155
+                     ->  Seq Scan on compress_hyper_14_346_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_347_chunk r_156
+                     ->  Seq Scan on compress_hyper_14_348_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_349_chunk r_157
+                     ->  Seq Scan on compress_hyper_14_350_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_351_chunk r_158
+                     ->  Seq Scan on compress_hyper_14_352_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_353_chunk r_159
+                     ->  Seq Scan on compress_hyper_14_354_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_355_chunk r_160
+                     ->  Seq Scan on compress_hyper_14_356_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_357_chunk r_161
+                     ->  Seq Scan on compress_hyper_14_358_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_359_chunk r_162
+                     ->  Seq Scan on compress_hyper_14_360_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_361_chunk r_163
+                     ->  Seq Scan on compress_hyper_14_362_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_363_chunk r_164
+                     ->  Seq Scan on compress_hyper_14_364_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_365_chunk r_165
+                     ->  Seq Scan on compress_hyper_14_366_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_367_chunk r_166
+                     ->  Seq Scan on compress_hyper_14_368_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_369_chunk r_167
+                     ->  Seq Scan on compress_hyper_14_370_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_371_chunk r_168
+                     ->  Seq Scan on compress_hyper_14_372_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_373_chunk r_169
+                     ->  Seq Scan on compress_hyper_14_374_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_375_chunk r_170
+                     ->  Seq Scan on compress_hyper_14_376_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_377_chunk r_171
+                     ->  Seq Scan on compress_hyper_14_378_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_379_chunk r_172
+                     ->  Seq Scan on compress_hyper_14_380_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_381_chunk r_173
+                     ->  Seq Scan on compress_hyper_14_382_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_383_chunk r_174
+                     ->  Seq Scan on compress_hyper_14_384_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_385_chunk r_175
+                     ->  Seq Scan on compress_hyper_14_386_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_387_chunk r_176
+                     ->  Seq Scan on compress_hyper_14_388_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_389_chunk r_177
+                     ->  Seq Scan on compress_hyper_14_390_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_391_chunk r_178
+                     ->  Seq Scan on compress_hyper_14_392_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_393_chunk r_179
+                     ->  Seq Scan on compress_hyper_14_394_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_395_chunk r_180
+                     ->  Seq Scan on compress_hyper_14_396_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_397_chunk r_181
+                     ->  Seq Scan on compress_hyper_14_398_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_399_chunk r_182
+                     ->  Seq Scan on compress_hyper_14_400_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_401_chunk r_183
+                     ->  Seq Scan on compress_hyper_14_402_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_403_chunk r_184
+                     ->  Seq Scan on compress_hyper_14_404_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_405_chunk r_185
+                     ->  Seq Scan on compress_hyper_14_406_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_407_chunk r_186
+                     ->  Seq Scan on compress_hyper_14_408_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_409_chunk r_187
+                     ->  Seq Scan on compress_hyper_14_410_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_411_chunk r_188
+                     ->  Seq Scan on compress_hyper_14_412_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_413_chunk r_189
+                     ->  Seq Scan on compress_hyper_14_414_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_415_chunk r_190
+                     ->  Seq Scan on compress_hyper_14_416_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_417_chunk r_191
+                     ->  Seq Scan on compress_hyper_14_418_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_419_chunk r_192
+                     ->  Seq Scan on compress_hyper_14_420_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_421_chunk r_193
+                     ->  Seq Scan on compress_hyper_14_422_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_423_chunk r_194
+                     ->  Seq Scan on compress_hyper_14_424_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_425_chunk r_195
+                     ->  Seq Scan on compress_hyper_14_426_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_427_chunk r_196
+                     ->  Seq Scan on compress_hyper_14_428_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_429_chunk r_197
+                     ->  Seq Scan on compress_hyper_14_430_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_431_chunk r_198
+                     ->  Seq Scan on compress_hyper_14_432_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_433_chunk r_199
+                     ->  Seq Scan on compress_hyper_14_434_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_435_chunk r_200
+                     ->  Seq Scan on compress_hyper_14_436_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_437_chunk r_201
+                     ->  Seq Scan on compress_hyper_14_438_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_439_chunk r_202
+                     ->  Seq Scan on compress_hyper_14_440_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_441_chunk r_203
+                     ->  Seq Scan on compress_hyper_14_442_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_443_chunk r_204
+                     ->  Seq Scan on compress_hyper_14_444_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_445_chunk r_205
+                     ->  Seq Scan on compress_hyper_14_446_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_447_chunk r_206
+                     ->  Seq Scan on compress_hyper_14_448_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_449_chunk r_207
+                     ->  Seq Scan on compress_hyper_14_450_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_451_chunk r_208
+                     ->  Seq Scan on compress_hyper_14_452_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_453_chunk r_209
+                     ->  Seq Scan on compress_hyper_14_454_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_455_chunk r_210
+                     ->  Seq Scan on compress_hyper_14_456_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_457_chunk r_211
+                     ->  Seq Scan on compress_hyper_14_458_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_459_chunk r_212
+                     ->  Seq Scan on compress_hyper_14_460_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_461_chunk r_213
+                     ->  Seq Scan on compress_hyper_14_462_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_463_chunk r_214
+                     ->  Seq Scan on compress_hyper_14_464_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_465_chunk r_215
+                     ->  Seq Scan on compress_hyper_14_466_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_467_chunk r_216
+                     ->  Seq Scan on compress_hyper_14_468_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_469_chunk r_217
+                     ->  Seq Scan on compress_hyper_14_470_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_471_chunk r_218
+                     ->  Seq Scan on compress_hyper_14_472_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_473_chunk r_219
+                     ->  Seq Scan on compress_hyper_14_474_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_475_chunk r_220
+                     ->  Seq Scan on compress_hyper_14_476_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_477_chunk r_221
+                     ->  Seq Scan on compress_hyper_14_478_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_479_chunk r_222
+                     ->  Seq Scan on compress_hyper_14_480_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_481_chunk r_223
+                     ->  Seq Scan on compress_hyper_14_482_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_483_chunk r_224
+                     ->  Seq Scan on compress_hyper_14_484_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_485_chunk r_225
+                     ->  Seq Scan on compress_hyper_14_486_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_487_chunk r_226
+                     ->  Seq Scan on compress_hyper_14_488_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_489_chunk r_227
+                     ->  Seq Scan on compress_hyper_14_490_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_491_chunk r_228
+                     ->  Seq Scan on compress_hyper_14_492_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_493_chunk r_229
+                     ->  Seq Scan on compress_hyper_14_494_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_495_chunk r_230
+                     ->  Seq Scan on compress_hyper_14_496_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_497_chunk r_231
+                     ->  Seq Scan on compress_hyper_14_498_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_499_chunk r_232
+                     ->  Seq Scan on compress_hyper_14_500_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_501_chunk r_233
+                     ->  Seq Scan on compress_hyper_14_502_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_503_chunk r_234
+                     ->  Seq Scan on compress_hyper_14_504_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_505_chunk r_235
+                     ->  Seq Scan on compress_hyper_14_506_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_507_chunk r_236
+                     ->  Seq Scan on compress_hyper_14_508_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_509_chunk r_237
+                     ->  Seq Scan on compress_hyper_14_510_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_511_chunk r_238
+                     ->  Seq Scan on compress_hyper_14_512_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_513_chunk r_239
+                     ->  Seq Scan on compress_hyper_14_514_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_515_chunk r_240
+                     ->  Seq Scan on compress_hyper_14_516_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_517_chunk r_241
+                     ->  Seq Scan on compress_hyper_14_518_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_519_chunk r_242
+                     ->  Seq Scan on compress_hyper_14_520_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_521_chunk r_243
+                     ->  Seq Scan on compress_hyper_14_522_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_523_chunk r_244
+                     ->  Seq Scan on compress_hyper_14_524_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_525_chunk r_245
+                     ->  Seq Scan on compress_hyper_14_526_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_527_chunk r_246
+                     ->  Seq Scan on compress_hyper_14_528_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_529_chunk r_247
+                     ->  Seq Scan on compress_hyper_14_530_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_531_chunk r_248
+                     ->  Seq Scan on compress_hyper_14_532_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_533_chunk r_249
+                     ->  Seq Scan on compress_hyper_14_534_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_535_chunk r_250
+                     ->  Seq Scan on compress_hyper_14_536_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_537_chunk r_251
+                     ->  Seq Scan on compress_hyper_14_538_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_539_chunk r_252
+                     ->  Seq Scan on compress_hyper_14_540_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_541_chunk r_253
+                     ->  Seq Scan on compress_hyper_14_542_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_543_chunk r_254
+                     ->  Seq Scan on compress_hyper_14_544_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_545_chunk r_255
+                     ->  Seq Scan on compress_hyper_14_546_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_547_chunk r_256
+                     ->  Seq Scan on compress_hyper_14_548_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_549_chunk r_257
+                     ->  Seq Scan on compress_hyper_14_550_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_551_chunk r_258
+                     ->  Seq Scan on compress_hyper_14_552_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_553_chunk r_259
+                     ->  Seq Scan on compress_hyper_14_554_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_555_chunk r_260
+                     ->  Seq Scan on compress_hyper_14_556_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_557_chunk r_261
+                     ->  Seq Scan on compress_hyper_14_558_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_559_chunk r_262
+                     ->  Seq Scan on compress_hyper_14_560_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_561_chunk r_263
+                     ->  Seq Scan on compress_hyper_14_562_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_563_chunk r_264
+                     ->  Seq Scan on compress_hyper_14_564_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_565_chunk r_265
+                     ->  Seq Scan on compress_hyper_14_566_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_567_chunk r_266
+                     ->  Seq Scan on compress_hyper_14_568_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_569_chunk r_267
+                     ->  Seq Scan on compress_hyper_14_570_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_571_chunk r_268
+                     ->  Seq Scan on compress_hyper_14_572_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_573_chunk r_269
+                     ->  Seq Scan on compress_hyper_14_574_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_575_chunk r_270
+                     ->  Seq Scan on compress_hyper_14_576_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_577_chunk r_271
+                     ->  Seq Scan on compress_hyper_14_578_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_579_chunk r_272
+                     ->  Seq Scan on compress_hyper_14_580_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_581_chunk r_273
+                     ->  Seq Scan on compress_hyper_14_582_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_583_chunk r_274
+                     ->  Seq Scan on compress_hyper_14_584_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_585_chunk r_275
+                     ->  Seq Scan on compress_hyper_14_586_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_587_chunk r_276
+                     ->  Seq Scan on compress_hyper_14_588_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_589_chunk r_277
+                     ->  Seq Scan on compress_hyper_14_590_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_591_chunk r_278
+                     ->  Seq Scan on compress_hyper_14_592_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_593_chunk r_279
+                     ->  Seq Scan on compress_hyper_14_594_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_595_chunk r_280
+                     ->  Seq Scan on compress_hyper_14_596_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_597_chunk r_281
+                     ->  Seq Scan on compress_hyper_14_598_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_599_chunk r_282
+                     ->  Seq Scan on compress_hyper_14_600_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_601_chunk r_283
+                     ->  Seq Scan on compress_hyper_14_602_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_603_chunk r_284
+                     ->  Seq Scan on compress_hyper_14_604_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_605_chunk r_285
+                     ->  Seq Scan on compress_hyper_14_606_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_607_chunk r_286
+                     ->  Seq Scan on compress_hyper_14_608_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_609_chunk r_287
+                     ->  Seq Scan on compress_hyper_14_610_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_611_chunk r_288
+                     ->  Seq Scan on compress_hyper_14_612_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_613_chunk r_289
+                     ->  Seq Scan on compress_hyper_14_614_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_615_chunk r_290
+                     ->  Seq Scan on compress_hyper_14_616_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_617_chunk r_291
+                     ->  Seq Scan on compress_hyper_14_618_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_619_chunk r_292
+                     ->  Seq Scan on compress_hyper_14_620_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_621_chunk r_293
+                     ->  Seq Scan on compress_hyper_14_622_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_623_chunk r_294
+                     ->  Seq Scan on compress_hyper_14_624_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_625_chunk r_295
+                     ->  Seq Scan on compress_hyper_14_626_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_627_chunk r_296
+                     ->  Seq Scan on compress_hyper_14_628_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_629_chunk r_297
+                     ->  Seq Scan on compress_hyper_14_630_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_631_chunk r_298
+                     ->  Seq Scan on compress_hyper_14_632_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_633_chunk r_299
+                     ->  Seq Scan on compress_hyper_14_634_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_635_chunk r_300
+                     ->  Seq Scan on compress_hyper_14_636_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_637_chunk r_301
+                     ->  Seq Scan on compress_hyper_14_638_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_639_chunk r_302
+                     ->  Seq Scan on compress_hyper_14_640_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_641_chunk r_303
+                     ->  Seq Scan on compress_hyper_14_642_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_643_chunk r_304
+                     ->  Seq Scan on compress_hyper_14_644_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_645_chunk r_305
+                     ->  Seq Scan on compress_hyper_14_646_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_647_chunk r_306
+                     ->  Seq Scan on compress_hyper_14_648_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_649_chunk r_307
+                     ->  Seq Scan on compress_hyper_14_650_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_651_chunk r_308
+                     ->  Seq Scan on compress_hyper_14_652_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_653_chunk r_309
+                     ->  Seq Scan on compress_hyper_14_654_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_655_chunk r_310
+                     ->  Seq Scan on compress_hyper_14_656_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_657_chunk r_311
+                     ->  Seq Scan on compress_hyper_14_658_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_659_chunk r_312
+                     ->  Seq Scan on compress_hyper_14_660_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_661_chunk r_313
+                     ->  Seq Scan on compress_hyper_14_662_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_663_chunk r_314
+                     ->  Seq Scan on compress_hyper_14_664_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_665_chunk r_315
+                     ->  Seq Scan on compress_hyper_14_666_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_667_chunk r_316
+                     ->  Seq Scan on compress_hyper_14_668_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_669_chunk r_317
+                     ->  Seq Scan on compress_hyper_14_670_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_671_chunk r_318
+                     ->  Seq Scan on compress_hyper_14_672_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_673_chunk r_319
+                     ->  Seq Scan on compress_hyper_14_674_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_675_chunk r_320
+                     ->  Seq Scan on compress_hyper_14_676_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_677_chunk r_321
+                     ->  Seq Scan on compress_hyper_14_678_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_679_chunk r_322
+                     ->  Seq Scan on compress_hyper_14_680_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_681_chunk r_323
+                     ->  Seq Scan on compress_hyper_14_682_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_683_chunk r_324
+                     ->  Seq Scan on compress_hyper_14_684_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_685_chunk r_325
+                     ->  Seq Scan on compress_hyper_14_686_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_687_chunk r_326
+                     ->  Seq Scan on compress_hyper_14_688_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_689_chunk r_327
+                     ->  Seq Scan on compress_hyper_14_690_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_691_chunk r_328
+                     ->  Seq Scan on compress_hyper_14_692_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_693_chunk r_329
+                     ->  Seq Scan on compress_hyper_14_694_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_695_chunk r_330
+                     ->  Seq Scan on compress_hyper_14_696_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_697_chunk r_331
+                     ->  Seq Scan on compress_hyper_14_698_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_699_chunk r_332
+                     ->  Seq Scan on compress_hyper_14_700_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_701_chunk r_333
+                     ->  Seq Scan on compress_hyper_14_702_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_703_chunk r_334
+                     ->  Seq Scan on compress_hyper_14_704_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_705_chunk r_335
+                     ->  Seq Scan on compress_hyper_14_706_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_707_chunk r_336
+                     ->  Seq Scan on compress_hyper_14_708_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_709_chunk r_337
+                     ->  Seq Scan on compress_hyper_14_710_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_711_chunk r_338
+                     ->  Seq Scan on compress_hyper_14_712_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_713_chunk r_339
+                     ->  Seq Scan on compress_hyper_14_714_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_715_chunk r_340
+                     ->  Seq Scan on compress_hyper_14_716_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_717_chunk r_341
+                     ->  Seq Scan on compress_hyper_14_718_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_719_chunk r_342
+                     ->  Seq Scan on compress_hyper_14_720_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_721_chunk r_343
+                     ->  Seq Scan on compress_hyper_14_722_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_723_chunk r_344
+                     ->  Seq Scan on compress_hyper_14_724_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_725_chunk r_345
+                     ->  Seq Scan on compress_hyper_14_726_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_727_chunk r_346
+                     ->  Seq Scan on compress_hyper_14_728_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_729_chunk r_347
+                     ->  Seq Scan on compress_hyper_14_730_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_731_chunk r_348
+                     ->  Seq Scan on compress_hyper_14_732_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_733_chunk r_349
+                     ->  Seq Scan on compress_hyper_14_734_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_735_chunk r_350
                      ->  Seq Scan on compress_hyper_14_736_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_34_chunk r_3
-                     ->  Seq Scan on compress_hyper_14_737_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_35_chunk r_4
+               ->  Custom Scan (DecompressChunk) on _hyper_13_737_chunk r_351
                      ->  Seq Scan on compress_hyper_14_738_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_36_chunk r_5
-                     ->  Seq Scan on compress_hyper_14_739_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_37_chunk r_6
+               ->  Custom Scan (DecompressChunk) on _hyper_13_739_chunk r_352
                      ->  Seq Scan on compress_hyper_14_740_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_38_chunk r_7
-                     ->  Seq Scan on compress_hyper_14_741_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_39_chunk r_8
+               ->  Custom Scan (DecompressChunk) on _hyper_13_741_chunk r_353
                      ->  Seq Scan on compress_hyper_14_742_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_40_chunk r_9
-                     ->  Seq Scan on compress_hyper_14_743_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_41_chunk r_10
+               ->  Custom Scan (DecompressChunk) on _hyper_13_743_chunk r_354
                      ->  Seq Scan on compress_hyper_14_744_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_42_chunk r_11
-                     ->  Seq Scan on compress_hyper_14_745_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_43_chunk r_12
+               ->  Custom Scan (DecompressChunk) on _hyper_13_745_chunk r_355
                      ->  Seq Scan on compress_hyper_14_746_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_44_chunk r_13
-                     ->  Seq Scan on compress_hyper_14_747_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_45_chunk r_14
+               ->  Custom Scan (DecompressChunk) on _hyper_13_747_chunk r_356
                      ->  Seq Scan on compress_hyper_14_748_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_46_chunk r_15
-                     ->  Seq Scan on compress_hyper_14_749_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_47_chunk r_16
+               ->  Custom Scan (DecompressChunk) on _hyper_13_749_chunk r_357
                      ->  Seq Scan on compress_hyper_14_750_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_48_chunk r_17
-                     ->  Seq Scan on compress_hyper_14_751_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_49_chunk r_18
+               ->  Custom Scan (DecompressChunk) on _hyper_13_751_chunk r_358
                      ->  Seq Scan on compress_hyper_14_752_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_50_chunk r_19
-                     ->  Seq Scan on compress_hyper_14_753_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_51_chunk r_20
+               ->  Custom Scan (DecompressChunk) on _hyper_13_753_chunk r_359
                      ->  Seq Scan on compress_hyper_14_754_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_52_chunk r_21
-                     ->  Seq Scan on compress_hyper_14_755_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_53_chunk r_22
+               ->  Custom Scan (DecompressChunk) on _hyper_13_755_chunk r_360
                      ->  Seq Scan on compress_hyper_14_756_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_54_chunk r_23
-                     ->  Seq Scan on compress_hyper_14_757_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_55_chunk r_24
+               ->  Custom Scan (DecompressChunk) on _hyper_13_757_chunk r_361
                      ->  Seq Scan on compress_hyper_14_758_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_56_chunk r_25
-                     ->  Seq Scan on compress_hyper_14_759_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_57_chunk r_26
+               ->  Custom Scan (DecompressChunk) on _hyper_13_759_chunk r_362
                      ->  Seq Scan on compress_hyper_14_760_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_58_chunk r_27
-                     ->  Seq Scan on compress_hyper_14_761_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_59_chunk r_28
+               ->  Custom Scan (DecompressChunk) on _hyper_13_761_chunk r_363
                      ->  Seq Scan on compress_hyper_14_762_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_60_chunk r_29
-                     ->  Seq Scan on compress_hyper_14_763_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_61_chunk r_30
+               ->  Custom Scan (DecompressChunk) on _hyper_13_763_chunk r_364
                      ->  Seq Scan on compress_hyper_14_764_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_62_chunk r_31
-                     ->  Seq Scan on compress_hyper_14_765_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_63_chunk r_32
+               ->  Custom Scan (DecompressChunk) on _hyper_13_765_chunk r_365
                      ->  Seq Scan on compress_hyper_14_766_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_64_chunk r_33
-                     ->  Seq Scan on compress_hyper_14_767_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_65_chunk r_34
+               ->  Custom Scan (DecompressChunk) on _hyper_13_767_chunk r_366
                      ->  Seq Scan on compress_hyper_14_768_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_66_chunk r_35
-                     ->  Seq Scan on compress_hyper_14_769_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_67_chunk r_36
+               ->  Custom Scan (DecompressChunk) on _hyper_13_769_chunk r_367
                      ->  Seq Scan on compress_hyper_14_770_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_68_chunk r_37
-                     ->  Seq Scan on compress_hyper_14_771_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_69_chunk r_38
+               ->  Custom Scan (DecompressChunk) on _hyper_13_771_chunk r_368
                      ->  Seq Scan on compress_hyper_14_772_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_70_chunk r_39
-                     ->  Seq Scan on compress_hyper_14_773_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_71_chunk r_40
+               ->  Custom Scan (DecompressChunk) on _hyper_13_773_chunk r_369
                      ->  Seq Scan on compress_hyper_14_774_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_72_chunk r_41
-                     ->  Seq Scan on compress_hyper_14_775_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_73_chunk r_42
+               ->  Custom Scan (DecompressChunk) on _hyper_13_775_chunk r_370
                      ->  Seq Scan on compress_hyper_14_776_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_74_chunk r_43
-                     ->  Seq Scan on compress_hyper_14_777_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_75_chunk r_44
+               ->  Custom Scan (DecompressChunk) on _hyper_13_777_chunk r_371
                      ->  Seq Scan on compress_hyper_14_778_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_76_chunk r_45
-                     ->  Seq Scan on compress_hyper_14_779_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_77_chunk r_46
+               ->  Custom Scan (DecompressChunk) on _hyper_13_779_chunk r_372
                      ->  Seq Scan on compress_hyper_14_780_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_78_chunk r_47
-                     ->  Seq Scan on compress_hyper_14_781_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_79_chunk r_48
+               ->  Custom Scan (DecompressChunk) on _hyper_13_781_chunk r_373
                      ->  Seq Scan on compress_hyper_14_782_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_80_chunk r_49
-                     ->  Seq Scan on compress_hyper_14_783_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_81_chunk r_50
+               ->  Custom Scan (DecompressChunk) on _hyper_13_783_chunk r_374
                      ->  Seq Scan on compress_hyper_14_784_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_82_chunk r_51
-                     ->  Seq Scan on compress_hyper_14_785_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_83_chunk r_52
+               ->  Custom Scan (DecompressChunk) on _hyper_13_785_chunk r_375
                      ->  Seq Scan on compress_hyper_14_786_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_84_chunk r_53
-                     ->  Seq Scan on compress_hyper_14_787_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_85_chunk r_54
+               ->  Custom Scan (DecompressChunk) on _hyper_13_787_chunk r_376
                      ->  Seq Scan on compress_hyper_14_788_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_86_chunk r_55
-                     ->  Seq Scan on compress_hyper_14_789_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_87_chunk r_56
+               ->  Custom Scan (DecompressChunk) on _hyper_13_789_chunk r_377
                      ->  Seq Scan on compress_hyper_14_790_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_88_chunk r_57
-                     ->  Seq Scan on compress_hyper_14_791_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_89_chunk r_58
+               ->  Custom Scan (DecompressChunk) on _hyper_13_791_chunk r_378
                      ->  Seq Scan on compress_hyper_14_792_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_90_chunk r_59
-                     ->  Seq Scan on compress_hyper_14_793_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_91_chunk r_60
+               ->  Custom Scan (DecompressChunk) on _hyper_13_793_chunk r_379
                      ->  Seq Scan on compress_hyper_14_794_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_92_chunk r_61
-                     ->  Seq Scan on compress_hyper_14_795_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_93_chunk r_62
+               ->  Custom Scan (DecompressChunk) on _hyper_13_795_chunk r_380
                      ->  Seq Scan on compress_hyper_14_796_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_94_chunk r_63
-                     ->  Seq Scan on compress_hyper_14_797_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_95_chunk r_64
+               ->  Custom Scan (DecompressChunk) on _hyper_13_797_chunk r_381
                      ->  Seq Scan on compress_hyper_14_798_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_96_chunk r_65
-                     ->  Seq Scan on compress_hyper_14_799_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_97_chunk r_66
+               ->  Custom Scan (DecompressChunk) on _hyper_13_799_chunk r_382
                      ->  Seq Scan on compress_hyper_14_800_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_98_chunk r_67
-                     ->  Seq Scan on compress_hyper_14_801_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_99_chunk r_68
+               ->  Custom Scan (DecompressChunk) on _hyper_13_801_chunk r_383
                      ->  Seq Scan on compress_hyper_14_802_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_100_chunk r_69
-                     ->  Seq Scan on compress_hyper_14_803_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_101_chunk r_70
+               ->  Custom Scan (DecompressChunk) on _hyper_13_803_chunk r_384
                      ->  Seq Scan on compress_hyper_14_804_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_102_chunk r_71
-                     ->  Seq Scan on compress_hyper_14_805_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_103_chunk r_72
+               ->  Custom Scan (DecompressChunk) on _hyper_13_805_chunk r_385
                      ->  Seq Scan on compress_hyper_14_806_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_104_chunk r_73
-                     ->  Seq Scan on compress_hyper_14_807_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_105_chunk r_74
+               ->  Custom Scan (DecompressChunk) on _hyper_13_807_chunk r_386
                      ->  Seq Scan on compress_hyper_14_808_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_106_chunk r_75
-                     ->  Seq Scan on compress_hyper_14_809_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_107_chunk r_76
+               ->  Custom Scan (DecompressChunk) on _hyper_13_809_chunk r_387
                      ->  Seq Scan on compress_hyper_14_810_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_108_chunk r_77
-                     ->  Seq Scan on compress_hyper_14_811_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_109_chunk r_78
+               ->  Custom Scan (DecompressChunk) on _hyper_13_811_chunk r_388
                      ->  Seq Scan on compress_hyper_14_812_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_110_chunk r_79
-                     ->  Seq Scan on compress_hyper_14_813_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_111_chunk r_80
+               ->  Custom Scan (DecompressChunk) on _hyper_13_813_chunk r_389
                      ->  Seq Scan on compress_hyper_14_814_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_112_chunk r_81
-                     ->  Seq Scan on compress_hyper_14_815_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_113_chunk r_82
+               ->  Custom Scan (DecompressChunk) on _hyper_13_815_chunk r_390
                      ->  Seq Scan on compress_hyper_14_816_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_114_chunk r_83
-                     ->  Seq Scan on compress_hyper_14_817_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_115_chunk r_84
+               ->  Custom Scan (DecompressChunk) on _hyper_13_817_chunk r_391
                      ->  Seq Scan on compress_hyper_14_818_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_116_chunk r_85
-                     ->  Seq Scan on compress_hyper_14_819_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_117_chunk r_86
+               ->  Custom Scan (DecompressChunk) on _hyper_13_819_chunk r_392
                      ->  Seq Scan on compress_hyper_14_820_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_118_chunk r_87
-                     ->  Seq Scan on compress_hyper_14_821_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_119_chunk r_88
+               ->  Custom Scan (DecompressChunk) on _hyper_13_821_chunk r_393
                      ->  Seq Scan on compress_hyper_14_822_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_120_chunk r_89
-                     ->  Seq Scan on compress_hyper_14_823_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_121_chunk r_90
+               ->  Custom Scan (DecompressChunk) on _hyper_13_823_chunk r_394
                      ->  Seq Scan on compress_hyper_14_824_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_122_chunk r_91
-                     ->  Seq Scan on compress_hyper_14_825_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_123_chunk r_92
+               ->  Custom Scan (DecompressChunk) on _hyper_13_825_chunk r_395
                      ->  Seq Scan on compress_hyper_14_826_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_124_chunk r_93
-                     ->  Seq Scan on compress_hyper_14_827_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_125_chunk r_94
+               ->  Custom Scan (DecompressChunk) on _hyper_13_827_chunk r_396
                      ->  Seq Scan on compress_hyper_14_828_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_126_chunk r_95
-                     ->  Seq Scan on compress_hyper_14_829_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_127_chunk r_96
+               ->  Custom Scan (DecompressChunk) on _hyper_13_829_chunk r_397
                      ->  Seq Scan on compress_hyper_14_830_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_128_chunk r_97
-                     ->  Seq Scan on compress_hyper_14_831_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_129_chunk r_98
+               ->  Custom Scan (DecompressChunk) on _hyper_13_831_chunk r_398
                      ->  Seq Scan on compress_hyper_14_832_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_130_chunk r_99
-                     ->  Seq Scan on compress_hyper_14_833_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_131_chunk r_100
+               ->  Custom Scan (DecompressChunk) on _hyper_13_833_chunk r_399
                      ->  Seq Scan on compress_hyper_14_834_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_132_chunk r_101
-                     ->  Seq Scan on compress_hyper_14_835_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_133_chunk r_102
+               ->  Custom Scan (DecompressChunk) on _hyper_13_835_chunk r_400
                      ->  Seq Scan on compress_hyper_14_836_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_134_chunk r_103
-                     ->  Seq Scan on compress_hyper_14_837_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_135_chunk r_104
+               ->  Custom Scan (DecompressChunk) on _hyper_13_837_chunk r_401
                      ->  Seq Scan on compress_hyper_14_838_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_136_chunk r_105
-                     ->  Seq Scan on compress_hyper_14_839_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_137_chunk r_106
+               ->  Custom Scan (DecompressChunk) on _hyper_13_839_chunk r_402
                      ->  Seq Scan on compress_hyper_14_840_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_138_chunk r_107
-                     ->  Seq Scan on compress_hyper_14_841_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_139_chunk r_108
+               ->  Custom Scan (DecompressChunk) on _hyper_13_841_chunk r_403
                      ->  Seq Scan on compress_hyper_14_842_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_140_chunk r_109
-                     ->  Seq Scan on compress_hyper_14_843_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_141_chunk r_110
+               ->  Custom Scan (DecompressChunk) on _hyper_13_843_chunk r_404
                      ->  Seq Scan on compress_hyper_14_844_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_142_chunk r_111
-                     ->  Seq Scan on compress_hyper_14_845_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_143_chunk r_112
+               ->  Custom Scan (DecompressChunk) on _hyper_13_845_chunk r_405
                      ->  Seq Scan on compress_hyper_14_846_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_144_chunk r_113
-                     ->  Seq Scan on compress_hyper_14_847_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_145_chunk r_114
+               ->  Custom Scan (DecompressChunk) on _hyper_13_847_chunk r_406
                      ->  Seq Scan on compress_hyper_14_848_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_146_chunk r_115
-                     ->  Seq Scan on compress_hyper_14_849_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_147_chunk r_116
+               ->  Custom Scan (DecompressChunk) on _hyper_13_849_chunk r_407
                      ->  Seq Scan on compress_hyper_14_850_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_148_chunk r_117
-                     ->  Seq Scan on compress_hyper_14_851_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_149_chunk r_118
+               ->  Custom Scan (DecompressChunk) on _hyper_13_851_chunk r_408
                      ->  Seq Scan on compress_hyper_14_852_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_150_chunk r_119
-                     ->  Seq Scan on compress_hyper_14_853_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_151_chunk r_120
+               ->  Custom Scan (DecompressChunk) on _hyper_13_853_chunk r_409
                      ->  Seq Scan on compress_hyper_14_854_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_152_chunk r_121
-                     ->  Seq Scan on compress_hyper_14_855_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_153_chunk r_122
+               ->  Custom Scan (DecompressChunk) on _hyper_13_855_chunk r_410
                      ->  Seq Scan on compress_hyper_14_856_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_154_chunk r_123
-                     ->  Seq Scan on compress_hyper_14_857_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_155_chunk r_124
+               ->  Custom Scan (DecompressChunk) on _hyper_13_857_chunk r_411
                      ->  Seq Scan on compress_hyper_14_858_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_156_chunk r_125
-                     ->  Seq Scan on compress_hyper_14_859_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_157_chunk r_126
+               ->  Custom Scan (DecompressChunk) on _hyper_13_859_chunk r_412
                      ->  Seq Scan on compress_hyper_14_860_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_158_chunk r_127
-                     ->  Seq Scan on compress_hyper_14_861_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_159_chunk r_128
+               ->  Custom Scan (DecompressChunk) on _hyper_13_861_chunk r_413
                      ->  Seq Scan on compress_hyper_14_862_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_160_chunk r_129
-                     ->  Seq Scan on compress_hyper_14_863_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_161_chunk r_130
+               ->  Custom Scan (DecompressChunk) on _hyper_13_863_chunk r_414
                      ->  Seq Scan on compress_hyper_14_864_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_162_chunk r_131
-                     ->  Seq Scan on compress_hyper_14_865_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_163_chunk r_132
+               ->  Custom Scan (DecompressChunk) on _hyper_13_865_chunk r_415
                      ->  Seq Scan on compress_hyper_14_866_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_164_chunk r_133
-                     ->  Seq Scan on compress_hyper_14_867_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_165_chunk r_134
+               ->  Custom Scan (DecompressChunk) on _hyper_13_867_chunk r_416
                      ->  Seq Scan on compress_hyper_14_868_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_166_chunk r_135
-                     ->  Seq Scan on compress_hyper_14_869_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_167_chunk r_136
+               ->  Custom Scan (DecompressChunk) on _hyper_13_869_chunk r_417
                      ->  Seq Scan on compress_hyper_14_870_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_168_chunk r_137
-                     ->  Seq Scan on compress_hyper_14_871_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_169_chunk r_138
+               ->  Custom Scan (DecompressChunk) on _hyper_13_871_chunk r_418
                      ->  Seq Scan on compress_hyper_14_872_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_170_chunk r_139
-                     ->  Seq Scan on compress_hyper_14_873_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_171_chunk r_140
+               ->  Custom Scan (DecompressChunk) on _hyper_13_873_chunk r_419
                      ->  Seq Scan on compress_hyper_14_874_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_172_chunk r_141
-                     ->  Seq Scan on compress_hyper_14_875_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_173_chunk r_142
+               ->  Custom Scan (DecompressChunk) on _hyper_13_875_chunk r_420
                      ->  Seq Scan on compress_hyper_14_876_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_174_chunk r_143
-                     ->  Seq Scan on compress_hyper_14_877_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_175_chunk r_144
+               ->  Custom Scan (DecompressChunk) on _hyper_13_877_chunk r_421
                      ->  Seq Scan on compress_hyper_14_878_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_176_chunk r_145
-                     ->  Seq Scan on compress_hyper_14_879_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_177_chunk r_146
+               ->  Custom Scan (DecompressChunk) on _hyper_13_879_chunk r_422
                      ->  Seq Scan on compress_hyper_14_880_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_178_chunk r_147
-                     ->  Seq Scan on compress_hyper_14_881_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_179_chunk r_148
+               ->  Custom Scan (DecompressChunk) on _hyper_13_881_chunk r_423
                      ->  Seq Scan on compress_hyper_14_882_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_180_chunk r_149
-                     ->  Seq Scan on compress_hyper_14_883_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_181_chunk r_150
+               ->  Custom Scan (DecompressChunk) on _hyper_13_883_chunk r_424
                      ->  Seq Scan on compress_hyper_14_884_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_182_chunk r_151
-                     ->  Seq Scan on compress_hyper_14_885_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_183_chunk r_152
+               ->  Custom Scan (DecompressChunk) on _hyper_13_885_chunk r_425
                      ->  Seq Scan on compress_hyper_14_886_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_184_chunk r_153
-                     ->  Seq Scan on compress_hyper_14_887_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_185_chunk r_154
+               ->  Custom Scan (DecompressChunk) on _hyper_13_887_chunk r_426
                      ->  Seq Scan on compress_hyper_14_888_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_186_chunk r_155
-                     ->  Seq Scan on compress_hyper_14_889_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_187_chunk r_156
+               ->  Custom Scan (DecompressChunk) on _hyper_13_889_chunk r_427
                      ->  Seq Scan on compress_hyper_14_890_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_188_chunk r_157
-                     ->  Seq Scan on compress_hyper_14_891_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_189_chunk r_158
+               ->  Custom Scan (DecompressChunk) on _hyper_13_891_chunk r_428
                      ->  Seq Scan on compress_hyper_14_892_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_190_chunk r_159
-                     ->  Seq Scan on compress_hyper_14_893_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_191_chunk r_160
+               ->  Custom Scan (DecompressChunk) on _hyper_13_893_chunk r_429
                      ->  Seq Scan on compress_hyper_14_894_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_192_chunk r_161
-                     ->  Seq Scan on compress_hyper_14_895_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_193_chunk r_162
+               ->  Custom Scan (DecompressChunk) on _hyper_13_895_chunk r_430
                      ->  Seq Scan on compress_hyper_14_896_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_194_chunk r_163
-                     ->  Seq Scan on compress_hyper_14_897_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_195_chunk r_164
+               ->  Custom Scan (DecompressChunk) on _hyper_13_897_chunk r_431
                      ->  Seq Scan on compress_hyper_14_898_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_196_chunk r_165
-                     ->  Seq Scan on compress_hyper_14_899_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_197_chunk r_166
+               ->  Custom Scan (DecompressChunk) on _hyper_13_899_chunk r_432
                      ->  Seq Scan on compress_hyper_14_900_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_198_chunk r_167
-                     ->  Seq Scan on compress_hyper_14_901_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_199_chunk r_168
+               ->  Custom Scan (DecompressChunk) on _hyper_13_901_chunk r_433
                      ->  Seq Scan on compress_hyper_14_902_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_200_chunk r_169
-                     ->  Seq Scan on compress_hyper_14_903_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_201_chunk r_170
+               ->  Custom Scan (DecompressChunk) on _hyper_13_903_chunk r_434
                      ->  Seq Scan on compress_hyper_14_904_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_202_chunk r_171
-                     ->  Seq Scan on compress_hyper_14_905_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_203_chunk r_172
+               ->  Custom Scan (DecompressChunk) on _hyper_13_905_chunk r_435
                      ->  Seq Scan on compress_hyper_14_906_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_204_chunk r_173
-                     ->  Seq Scan on compress_hyper_14_907_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_205_chunk r_174
+               ->  Custom Scan (DecompressChunk) on _hyper_13_907_chunk r_436
                      ->  Seq Scan on compress_hyper_14_908_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_206_chunk r_175
-                     ->  Seq Scan on compress_hyper_14_909_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_207_chunk r_176
+               ->  Custom Scan (DecompressChunk) on _hyper_13_909_chunk r_437
                      ->  Seq Scan on compress_hyper_14_910_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_208_chunk r_177
-                     ->  Seq Scan on compress_hyper_14_911_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_209_chunk r_178
+               ->  Custom Scan (DecompressChunk) on _hyper_13_911_chunk r_438
                      ->  Seq Scan on compress_hyper_14_912_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_210_chunk r_179
-                     ->  Seq Scan on compress_hyper_14_913_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_211_chunk r_180
+               ->  Custom Scan (DecompressChunk) on _hyper_13_913_chunk r_439
                      ->  Seq Scan on compress_hyper_14_914_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_212_chunk r_181
-                     ->  Seq Scan on compress_hyper_14_915_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_213_chunk r_182
+               ->  Custom Scan (DecompressChunk) on _hyper_13_915_chunk r_440
                      ->  Seq Scan on compress_hyper_14_916_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_214_chunk r_183
-                     ->  Seq Scan on compress_hyper_14_917_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_215_chunk r_184
+               ->  Custom Scan (DecompressChunk) on _hyper_13_917_chunk r_441
                      ->  Seq Scan on compress_hyper_14_918_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_216_chunk r_185
-                     ->  Seq Scan on compress_hyper_14_919_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_217_chunk r_186
+               ->  Custom Scan (DecompressChunk) on _hyper_13_919_chunk r_442
                      ->  Seq Scan on compress_hyper_14_920_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_218_chunk r_187
-                     ->  Seq Scan on compress_hyper_14_921_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_219_chunk r_188
+               ->  Custom Scan (DecompressChunk) on _hyper_13_921_chunk r_443
                      ->  Seq Scan on compress_hyper_14_922_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_220_chunk r_189
-                     ->  Seq Scan on compress_hyper_14_923_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_221_chunk r_190
+               ->  Custom Scan (DecompressChunk) on _hyper_13_923_chunk r_444
                      ->  Seq Scan on compress_hyper_14_924_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_222_chunk r_191
-                     ->  Seq Scan on compress_hyper_14_925_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_223_chunk r_192
+               ->  Custom Scan (DecompressChunk) on _hyper_13_925_chunk r_445
                      ->  Seq Scan on compress_hyper_14_926_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_224_chunk r_193
-                     ->  Seq Scan on compress_hyper_14_927_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_225_chunk r_194
+               ->  Custom Scan (DecompressChunk) on _hyper_13_927_chunk r_446
                      ->  Seq Scan on compress_hyper_14_928_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_226_chunk r_195
-                     ->  Seq Scan on compress_hyper_14_929_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_227_chunk r_196
+               ->  Custom Scan (DecompressChunk) on _hyper_13_929_chunk r_447
                      ->  Seq Scan on compress_hyper_14_930_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_228_chunk r_197
-                     ->  Seq Scan on compress_hyper_14_931_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_229_chunk r_198
+               ->  Custom Scan (DecompressChunk) on _hyper_13_931_chunk r_448
                      ->  Seq Scan on compress_hyper_14_932_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_230_chunk r_199
-                     ->  Seq Scan on compress_hyper_14_933_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_231_chunk r_200
+               ->  Custom Scan (DecompressChunk) on _hyper_13_933_chunk r_449
                      ->  Seq Scan on compress_hyper_14_934_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_232_chunk r_201
-                     ->  Seq Scan on compress_hyper_14_935_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_233_chunk r_202
+               ->  Custom Scan (DecompressChunk) on _hyper_13_935_chunk r_450
                      ->  Seq Scan on compress_hyper_14_936_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_234_chunk r_203
-                     ->  Seq Scan on compress_hyper_14_937_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_235_chunk r_204
+               ->  Custom Scan (DecompressChunk) on _hyper_13_937_chunk r_451
                      ->  Seq Scan on compress_hyper_14_938_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_236_chunk r_205
-                     ->  Seq Scan on compress_hyper_14_939_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_237_chunk r_206
+               ->  Custom Scan (DecompressChunk) on _hyper_13_939_chunk r_452
                      ->  Seq Scan on compress_hyper_14_940_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_238_chunk r_207
-                     ->  Seq Scan on compress_hyper_14_941_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_239_chunk r_208
+               ->  Custom Scan (DecompressChunk) on _hyper_13_941_chunk r_453
                      ->  Seq Scan on compress_hyper_14_942_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_240_chunk r_209
-                     ->  Seq Scan on compress_hyper_14_943_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_241_chunk r_210
+               ->  Custom Scan (DecompressChunk) on _hyper_13_943_chunk r_454
                      ->  Seq Scan on compress_hyper_14_944_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_242_chunk r_211
-                     ->  Seq Scan on compress_hyper_14_945_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_243_chunk r_212
+               ->  Custom Scan (DecompressChunk) on _hyper_13_945_chunk r_455
                      ->  Seq Scan on compress_hyper_14_946_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_244_chunk r_213
-                     ->  Seq Scan on compress_hyper_14_947_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_245_chunk r_214
+               ->  Custom Scan (DecompressChunk) on _hyper_13_947_chunk r_456
                      ->  Seq Scan on compress_hyper_14_948_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_246_chunk r_215
-                     ->  Seq Scan on compress_hyper_14_949_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_247_chunk r_216
+               ->  Custom Scan (DecompressChunk) on _hyper_13_949_chunk r_457
                      ->  Seq Scan on compress_hyper_14_950_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_248_chunk r_217
-                     ->  Seq Scan on compress_hyper_14_951_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_249_chunk r_218
+               ->  Custom Scan (DecompressChunk) on _hyper_13_951_chunk r_458
                      ->  Seq Scan on compress_hyper_14_952_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_250_chunk r_219
-                     ->  Seq Scan on compress_hyper_14_953_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_251_chunk r_220
+               ->  Custom Scan (DecompressChunk) on _hyper_13_953_chunk r_459
                      ->  Seq Scan on compress_hyper_14_954_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_252_chunk r_221
-                     ->  Seq Scan on compress_hyper_14_955_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_253_chunk r_222
+               ->  Custom Scan (DecompressChunk) on _hyper_13_955_chunk r_460
                      ->  Seq Scan on compress_hyper_14_956_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_254_chunk r_223
-                     ->  Seq Scan on compress_hyper_14_957_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_255_chunk r_224
+               ->  Custom Scan (DecompressChunk) on _hyper_13_957_chunk r_461
                      ->  Seq Scan on compress_hyper_14_958_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_256_chunk r_225
-                     ->  Seq Scan on compress_hyper_14_959_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_257_chunk r_226
+               ->  Custom Scan (DecompressChunk) on _hyper_13_959_chunk r_462
                      ->  Seq Scan on compress_hyper_14_960_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_258_chunk r_227
-                     ->  Seq Scan on compress_hyper_14_961_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_259_chunk r_228
+               ->  Custom Scan (DecompressChunk) on _hyper_13_961_chunk r_463
                      ->  Seq Scan on compress_hyper_14_962_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_260_chunk r_229
-                     ->  Seq Scan on compress_hyper_14_963_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_261_chunk r_230
+               ->  Custom Scan (DecompressChunk) on _hyper_13_963_chunk r_464
                      ->  Seq Scan on compress_hyper_14_964_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_262_chunk r_231
-                     ->  Seq Scan on compress_hyper_14_965_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_263_chunk r_232
+               ->  Custom Scan (DecompressChunk) on _hyper_13_965_chunk r_465
                      ->  Seq Scan on compress_hyper_14_966_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_264_chunk r_233
-                     ->  Seq Scan on compress_hyper_14_967_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_265_chunk r_234
+               ->  Custom Scan (DecompressChunk) on _hyper_13_967_chunk r_466
                      ->  Seq Scan on compress_hyper_14_968_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_266_chunk r_235
-                     ->  Seq Scan on compress_hyper_14_969_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_267_chunk r_236
+               ->  Custom Scan (DecompressChunk) on _hyper_13_969_chunk r_467
                      ->  Seq Scan on compress_hyper_14_970_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_268_chunk r_237
-                     ->  Seq Scan on compress_hyper_14_971_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_269_chunk r_238
+               ->  Custom Scan (DecompressChunk) on _hyper_13_971_chunk r_468
                      ->  Seq Scan on compress_hyper_14_972_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_270_chunk r_239
-                     ->  Seq Scan on compress_hyper_14_973_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_271_chunk r_240
+               ->  Custom Scan (DecompressChunk) on _hyper_13_973_chunk r_469
                      ->  Seq Scan on compress_hyper_14_974_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_272_chunk r_241
-                     ->  Seq Scan on compress_hyper_14_975_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_273_chunk r_242
+               ->  Custom Scan (DecompressChunk) on _hyper_13_975_chunk r_470
                      ->  Seq Scan on compress_hyper_14_976_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_274_chunk r_243
-                     ->  Seq Scan on compress_hyper_14_977_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_275_chunk r_244
+               ->  Custom Scan (DecompressChunk) on _hyper_13_977_chunk r_471
                      ->  Seq Scan on compress_hyper_14_978_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_276_chunk r_245
-                     ->  Seq Scan on compress_hyper_14_979_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_277_chunk r_246
+               ->  Custom Scan (DecompressChunk) on _hyper_13_979_chunk r_472
                      ->  Seq Scan on compress_hyper_14_980_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_278_chunk r_247
-                     ->  Seq Scan on compress_hyper_14_981_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_279_chunk r_248
+               ->  Custom Scan (DecompressChunk) on _hyper_13_981_chunk r_473
                      ->  Seq Scan on compress_hyper_14_982_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_280_chunk r_249
-                     ->  Seq Scan on compress_hyper_14_983_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_281_chunk r_250
+               ->  Custom Scan (DecompressChunk) on _hyper_13_983_chunk r_474
                      ->  Seq Scan on compress_hyper_14_984_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_282_chunk r_251
-                     ->  Seq Scan on compress_hyper_14_985_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_283_chunk r_252
+               ->  Custom Scan (DecompressChunk) on _hyper_13_985_chunk r_475
                      ->  Seq Scan on compress_hyper_14_986_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_284_chunk r_253
-                     ->  Seq Scan on compress_hyper_14_987_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_285_chunk r_254
+               ->  Custom Scan (DecompressChunk) on _hyper_13_987_chunk r_476
                      ->  Seq Scan on compress_hyper_14_988_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_286_chunk r_255
-                     ->  Seq Scan on compress_hyper_14_989_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_287_chunk r_256
+               ->  Custom Scan (DecompressChunk) on _hyper_13_989_chunk r_477
                      ->  Seq Scan on compress_hyper_14_990_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_288_chunk r_257
-                     ->  Seq Scan on compress_hyper_14_991_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_289_chunk r_258
+               ->  Custom Scan (DecompressChunk) on _hyper_13_991_chunk r_478
                      ->  Seq Scan on compress_hyper_14_992_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_290_chunk r_259
-                     ->  Seq Scan on compress_hyper_14_993_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_291_chunk r_260
+               ->  Custom Scan (DecompressChunk) on _hyper_13_993_chunk r_479
                      ->  Seq Scan on compress_hyper_14_994_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_292_chunk r_261
-                     ->  Seq Scan on compress_hyper_14_995_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_293_chunk r_262
+               ->  Custom Scan (DecompressChunk) on _hyper_13_995_chunk r_480
                      ->  Seq Scan on compress_hyper_14_996_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_294_chunk r_263
-                     ->  Seq Scan on compress_hyper_14_997_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_295_chunk r_264
+               ->  Custom Scan (DecompressChunk) on _hyper_13_997_chunk r_481
                      ->  Seq Scan on compress_hyper_14_998_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_296_chunk r_265
-                     ->  Seq Scan on compress_hyper_14_999_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_297_chunk r_266
+               ->  Custom Scan (DecompressChunk) on _hyper_13_999_chunk r_482
                      ->  Seq Scan on compress_hyper_14_1000_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_298_chunk r_267
-                     ->  Seq Scan on compress_hyper_14_1001_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_299_chunk r_268
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1001_chunk r_483
                      ->  Seq Scan on compress_hyper_14_1002_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_300_chunk r_269
-                     ->  Seq Scan on compress_hyper_14_1003_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_301_chunk r_270
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1003_chunk r_484
                      ->  Seq Scan on compress_hyper_14_1004_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_302_chunk r_271
-                     ->  Seq Scan on compress_hyper_14_1005_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_303_chunk r_272
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1005_chunk r_485
                      ->  Seq Scan on compress_hyper_14_1006_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_304_chunk r_273
-                     ->  Seq Scan on compress_hyper_14_1007_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_305_chunk r_274
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1007_chunk r_486
                      ->  Seq Scan on compress_hyper_14_1008_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_306_chunk r_275
-                     ->  Seq Scan on compress_hyper_14_1009_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_307_chunk r_276
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1009_chunk r_487
                      ->  Seq Scan on compress_hyper_14_1010_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_308_chunk r_277
-                     ->  Seq Scan on compress_hyper_14_1011_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_309_chunk r_278
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1011_chunk r_488
                      ->  Seq Scan on compress_hyper_14_1012_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_310_chunk r_279
-                     ->  Seq Scan on compress_hyper_14_1013_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_311_chunk r_280
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1013_chunk r_489
                      ->  Seq Scan on compress_hyper_14_1014_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_312_chunk r_281
-                     ->  Seq Scan on compress_hyper_14_1015_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_313_chunk r_282
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1015_chunk r_490
                      ->  Seq Scan on compress_hyper_14_1016_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_314_chunk r_283
-                     ->  Seq Scan on compress_hyper_14_1017_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_315_chunk r_284
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1017_chunk r_491
                      ->  Seq Scan on compress_hyper_14_1018_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_316_chunk r_285
-                     ->  Seq Scan on compress_hyper_14_1019_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_317_chunk r_286
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1019_chunk r_492
                      ->  Seq Scan on compress_hyper_14_1020_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_318_chunk r_287
-                     ->  Seq Scan on compress_hyper_14_1021_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_319_chunk r_288
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1021_chunk r_493
                      ->  Seq Scan on compress_hyper_14_1022_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_320_chunk r_289
-                     ->  Seq Scan on compress_hyper_14_1023_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_321_chunk r_290
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1023_chunk r_494
                      ->  Seq Scan on compress_hyper_14_1024_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_322_chunk r_291
-                     ->  Seq Scan on compress_hyper_14_1025_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_323_chunk r_292
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1025_chunk r_495
                      ->  Seq Scan on compress_hyper_14_1026_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_324_chunk r_293
-                     ->  Seq Scan on compress_hyper_14_1027_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_325_chunk r_294
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1027_chunk r_496
                      ->  Seq Scan on compress_hyper_14_1028_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_326_chunk r_295
-                     ->  Seq Scan on compress_hyper_14_1029_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_327_chunk r_296
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1029_chunk r_497
                      ->  Seq Scan on compress_hyper_14_1030_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_328_chunk r_297
-                     ->  Seq Scan on compress_hyper_14_1031_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_329_chunk r_298
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1031_chunk r_498
                      ->  Seq Scan on compress_hyper_14_1032_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_330_chunk r_299
-                     ->  Seq Scan on compress_hyper_14_1033_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_331_chunk r_300
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1033_chunk r_499
                      ->  Seq Scan on compress_hyper_14_1034_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_332_chunk r_301
-                     ->  Seq Scan on compress_hyper_14_1035_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_333_chunk r_302
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1035_chunk r_500
                      ->  Seq Scan on compress_hyper_14_1036_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_334_chunk r_303
-                     ->  Seq Scan on compress_hyper_14_1037_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_335_chunk r_304
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1037_chunk r_501
                      ->  Seq Scan on compress_hyper_14_1038_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_336_chunk r_305
-                     ->  Seq Scan on compress_hyper_14_1039_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_337_chunk r_306
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1039_chunk r_502
                      ->  Seq Scan on compress_hyper_14_1040_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_338_chunk r_307
-                     ->  Seq Scan on compress_hyper_14_1041_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_339_chunk r_308
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1041_chunk r_503
                      ->  Seq Scan on compress_hyper_14_1042_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_340_chunk r_309
-                     ->  Seq Scan on compress_hyper_14_1043_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_341_chunk r_310
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1043_chunk r_504
                      ->  Seq Scan on compress_hyper_14_1044_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_342_chunk r_311
-                     ->  Seq Scan on compress_hyper_14_1045_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_343_chunk r_312
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1045_chunk r_505
                      ->  Seq Scan on compress_hyper_14_1046_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_344_chunk r_313
-                     ->  Seq Scan on compress_hyper_14_1047_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_345_chunk r_314
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1047_chunk r_506
                      ->  Seq Scan on compress_hyper_14_1048_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_346_chunk r_315
-                     ->  Seq Scan on compress_hyper_14_1049_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_347_chunk r_316
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1049_chunk r_507
                      ->  Seq Scan on compress_hyper_14_1050_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_348_chunk r_317
-                     ->  Seq Scan on compress_hyper_14_1051_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_349_chunk r_318
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1051_chunk r_508
                      ->  Seq Scan on compress_hyper_14_1052_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_350_chunk r_319
-                     ->  Seq Scan on compress_hyper_14_1053_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_351_chunk r_320
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1053_chunk r_509
                      ->  Seq Scan on compress_hyper_14_1054_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_352_chunk r_321
-                     ->  Seq Scan on compress_hyper_14_1055_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_353_chunk r_322
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1055_chunk r_510
                      ->  Seq Scan on compress_hyper_14_1056_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_354_chunk r_323
-                     ->  Seq Scan on compress_hyper_14_1057_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_355_chunk r_324
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1057_chunk r_511
                      ->  Seq Scan on compress_hyper_14_1058_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_356_chunk r_325
-                     ->  Seq Scan on compress_hyper_14_1059_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_357_chunk r_326
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1059_chunk r_512
                      ->  Seq Scan on compress_hyper_14_1060_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_358_chunk r_327
-                     ->  Seq Scan on compress_hyper_14_1061_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_359_chunk r_328
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1061_chunk r_513
                      ->  Seq Scan on compress_hyper_14_1062_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_360_chunk r_329
-                     ->  Seq Scan on compress_hyper_14_1063_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_361_chunk r_330
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1063_chunk r_514
                      ->  Seq Scan on compress_hyper_14_1064_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_362_chunk r_331
-                     ->  Seq Scan on compress_hyper_14_1065_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_363_chunk r_332
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1065_chunk r_515
                      ->  Seq Scan on compress_hyper_14_1066_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_364_chunk r_333
-                     ->  Seq Scan on compress_hyper_14_1067_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_365_chunk r_334
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1067_chunk r_516
                      ->  Seq Scan on compress_hyper_14_1068_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_366_chunk r_335
-                     ->  Seq Scan on compress_hyper_14_1069_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_367_chunk r_336
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1069_chunk r_517
                      ->  Seq Scan on compress_hyper_14_1070_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_368_chunk r_337
-                     ->  Seq Scan on compress_hyper_14_1071_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_369_chunk r_338
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1071_chunk r_518
                      ->  Seq Scan on compress_hyper_14_1072_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_370_chunk r_339
-                     ->  Seq Scan on compress_hyper_14_1073_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_371_chunk r_340
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1073_chunk r_519
                      ->  Seq Scan on compress_hyper_14_1074_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_372_chunk r_341
-                     ->  Seq Scan on compress_hyper_14_1075_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_373_chunk r_342
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1075_chunk r_520
                      ->  Seq Scan on compress_hyper_14_1076_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_374_chunk r_343
-                     ->  Seq Scan on compress_hyper_14_1077_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_375_chunk r_344
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1077_chunk r_521
                      ->  Seq Scan on compress_hyper_14_1078_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_376_chunk r_345
-                     ->  Seq Scan on compress_hyper_14_1079_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_377_chunk r_346
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1079_chunk r_522
                      ->  Seq Scan on compress_hyper_14_1080_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_378_chunk r_347
-                     ->  Seq Scan on compress_hyper_14_1081_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_379_chunk r_348
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1081_chunk r_523
                      ->  Seq Scan on compress_hyper_14_1082_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_380_chunk r_349
-                     ->  Seq Scan on compress_hyper_14_1083_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_381_chunk r_350
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1083_chunk r_524
                      ->  Seq Scan on compress_hyper_14_1084_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_382_chunk r_351
-                     ->  Seq Scan on compress_hyper_14_1085_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_383_chunk r_352
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1085_chunk r_525
                      ->  Seq Scan on compress_hyper_14_1086_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_384_chunk r_353
-                     ->  Seq Scan on compress_hyper_14_1087_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_385_chunk r_354
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1087_chunk r_526
                      ->  Seq Scan on compress_hyper_14_1088_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_386_chunk r_355
-                     ->  Seq Scan on compress_hyper_14_1089_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_387_chunk r_356
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1089_chunk r_527
                      ->  Seq Scan on compress_hyper_14_1090_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_388_chunk r_357
-                     ->  Seq Scan on compress_hyper_14_1091_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_389_chunk r_358
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1091_chunk r_528
                      ->  Seq Scan on compress_hyper_14_1092_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_390_chunk r_359
-                     ->  Seq Scan on compress_hyper_14_1093_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_391_chunk r_360
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1093_chunk r_529
                      ->  Seq Scan on compress_hyper_14_1094_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_392_chunk r_361
-                     ->  Seq Scan on compress_hyper_14_1095_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_393_chunk r_362
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1095_chunk r_530
                      ->  Seq Scan on compress_hyper_14_1096_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_394_chunk r_363
-                     ->  Seq Scan on compress_hyper_14_1097_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_395_chunk r_364
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1097_chunk r_531
                      ->  Seq Scan on compress_hyper_14_1098_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_396_chunk r_365
-                     ->  Seq Scan on compress_hyper_14_1099_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_397_chunk r_366
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1099_chunk r_532
                      ->  Seq Scan on compress_hyper_14_1100_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_398_chunk r_367
-                     ->  Seq Scan on compress_hyper_14_1101_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_399_chunk r_368
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1101_chunk r_533
                      ->  Seq Scan on compress_hyper_14_1102_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_400_chunk r_369
-                     ->  Seq Scan on compress_hyper_14_1103_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_401_chunk r_370
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1103_chunk r_534
                      ->  Seq Scan on compress_hyper_14_1104_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_402_chunk r_371
-                     ->  Seq Scan on compress_hyper_14_1105_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_403_chunk r_372
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1105_chunk r_535
                      ->  Seq Scan on compress_hyper_14_1106_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_404_chunk r_373
-                     ->  Seq Scan on compress_hyper_14_1107_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_405_chunk r_374
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1107_chunk r_536
                      ->  Seq Scan on compress_hyper_14_1108_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_406_chunk r_375
-                     ->  Seq Scan on compress_hyper_14_1109_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_407_chunk r_376
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1109_chunk r_537
                      ->  Seq Scan on compress_hyper_14_1110_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_408_chunk r_377
-                     ->  Seq Scan on compress_hyper_14_1111_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_409_chunk r_378
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1111_chunk r_538
                      ->  Seq Scan on compress_hyper_14_1112_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_410_chunk r_379
-                     ->  Seq Scan on compress_hyper_14_1113_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_411_chunk r_380
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1113_chunk r_539
                      ->  Seq Scan on compress_hyper_14_1114_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_412_chunk r_381
-                     ->  Seq Scan on compress_hyper_14_1115_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_413_chunk r_382
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1115_chunk r_540
                      ->  Seq Scan on compress_hyper_14_1116_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_414_chunk r_383
-                     ->  Seq Scan on compress_hyper_14_1117_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_415_chunk r_384
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1117_chunk r_541
                      ->  Seq Scan on compress_hyper_14_1118_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_416_chunk r_385
-                     ->  Seq Scan on compress_hyper_14_1119_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_417_chunk r_386
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1119_chunk r_542
                      ->  Seq Scan on compress_hyper_14_1120_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_418_chunk r_387
-                     ->  Seq Scan on compress_hyper_14_1121_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_419_chunk r_388
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1121_chunk r_543
                      ->  Seq Scan on compress_hyper_14_1122_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_420_chunk r_389
-                     ->  Seq Scan on compress_hyper_14_1123_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_421_chunk r_390
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1123_chunk r_544
                      ->  Seq Scan on compress_hyper_14_1124_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_422_chunk r_391
-                     ->  Seq Scan on compress_hyper_14_1125_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_423_chunk r_392
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1125_chunk r_545
                      ->  Seq Scan on compress_hyper_14_1126_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_424_chunk r_393
-                     ->  Seq Scan on compress_hyper_14_1127_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_425_chunk r_394
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1127_chunk r_546
                      ->  Seq Scan on compress_hyper_14_1128_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_426_chunk r_395
-                     ->  Seq Scan on compress_hyper_14_1129_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_427_chunk r_396
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1129_chunk r_547
                      ->  Seq Scan on compress_hyper_14_1130_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_428_chunk r_397
-                     ->  Seq Scan on compress_hyper_14_1131_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_429_chunk r_398
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1131_chunk r_548
                      ->  Seq Scan on compress_hyper_14_1132_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_430_chunk r_399
-                     ->  Seq Scan on compress_hyper_14_1133_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_431_chunk r_400
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1133_chunk r_549
                      ->  Seq Scan on compress_hyper_14_1134_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_432_chunk r_401
-                     ->  Seq Scan on compress_hyper_14_1135_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_433_chunk r_402
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1135_chunk r_550
                      ->  Seq Scan on compress_hyper_14_1136_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_434_chunk r_403
-                     ->  Seq Scan on compress_hyper_14_1137_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_435_chunk r_404
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1137_chunk r_551
                      ->  Seq Scan on compress_hyper_14_1138_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_436_chunk r_405
-                     ->  Seq Scan on compress_hyper_14_1139_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_437_chunk r_406
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1139_chunk r_552
                      ->  Seq Scan on compress_hyper_14_1140_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_438_chunk r_407
-                     ->  Seq Scan on compress_hyper_14_1141_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_439_chunk r_408
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1141_chunk r_553
                      ->  Seq Scan on compress_hyper_14_1142_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_440_chunk r_409
-                     ->  Seq Scan on compress_hyper_14_1143_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_441_chunk r_410
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1143_chunk r_554
                      ->  Seq Scan on compress_hyper_14_1144_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_442_chunk r_411
-                     ->  Seq Scan on compress_hyper_14_1145_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_443_chunk r_412
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1145_chunk r_555
                      ->  Seq Scan on compress_hyper_14_1146_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_444_chunk r_413
-                     ->  Seq Scan on compress_hyper_14_1147_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_445_chunk r_414
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1147_chunk r_556
                      ->  Seq Scan on compress_hyper_14_1148_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_446_chunk r_415
-                     ->  Seq Scan on compress_hyper_14_1149_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_447_chunk r_416
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1149_chunk r_557
                      ->  Seq Scan on compress_hyper_14_1150_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_448_chunk r_417
-                     ->  Seq Scan on compress_hyper_14_1151_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_449_chunk r_418
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1151_chunk r_558
                      ->  Seq Scan on compress_hyper_14_1152_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_450_chunk r_419
-                     ->  Seq Scan on compress_hyper_14_1153_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_451_chunk r_420
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1153_chunk r_559
                      ->  Seq Scan on compress_hyper_14_1154_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_452_chunk r_421
-                     ->  Seq Scan on compress_hyper_14_1155_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_453_chunk r_422
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1155_chunk r_560
                      ->  Seq Scan on compress_hyper_14_1156_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_454_chunk r_423
-                     ->  Seq Scan on compress_hyper_14_1157_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_455_chunk r_424
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1157_chunk r_561
                      ->  Seq Scan on compress_hyper_14_1158_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_456_chunk r_425
-                     ->  Seq Scan on compress_hyper_14_1159_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_457_chunk r_426
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1159_chunk r_562
                      ->  Seq Scan on compress_hyper_14_1160_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_458_chunk r_427
-                     ->  Seq Scan on compress_hyper_14_1161_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_459_chunk r_428
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1161_chunk r_563
                      ->  Seq Scan on compress_hyper_14_1162_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_460_chunk r_429
-                     ->  Seq Scan on compress_hyper_14_1163_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_461_chunk r_430
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1163_chunk r_564
                      ->  Seq Scan on compress_hyper_14_1164_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_462_chunk r_431
-                     ->  Seq Scan on compress_hyper_14_1165_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_463_chunk r_432
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1165_chunk r_565
                      ->  Seq Scan on compress_hyper_14_1166_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_464_chunk r_433
-                     ->  Seq Scan on compress_hyper_14_1167_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_465_chunk r_434
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1167_chunk r_566
                      ->  Seq Scan on compress_hyper_14_1168_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_466_chunk r_435
-                     ->  Seq Scan on compress_hyper_14_1169_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_467_chunk r_436
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1169_chunk r_567
                      ->  Seq Scan on compress_hyper_14_1170_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_468_chunk r_437
-                     ->  Seq Scan on compress_hyper_14_1171_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_469_chunk r_438
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1171_chunk r_568
                      ->  Seq Scan on compress_hyper_14_1172_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_470_chunk r_439
-                     ->  Seq Scan on compress_hyper_14_1173_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_471_chunk r_440
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1173_chunk r_569
                      ->  Seq Scan on compress_hyper_14_1174_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_472_chunk r_441
-                     ->  Seq Scan on compress_hyper_14_1175_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_473_chunk r_442
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1175_chunk r_570
                      ->  Seq Scan on compress_hyper_14_1176_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_474_chunk r_443
-                     ->  Seq Scan on compress_hyper_14_1177_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_475_chunk r_444
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1177_chunk r_571
                      ->  Seq Scan on compress_hyper_14_1178_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_476_chunk r_445
-                     ->  Seq Scan on compress_hyper_14_1179_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_477_chunk r_446
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1179_chunk r_572
                      ->  Seq Scan on compress_hyper_14_1180_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_478_chunk r_447
-                     ->  Seq Scan on compress_hyper_14_1181_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_479_chunk r_448
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1181_chunk r_573
                      ->  Seq Scan on compress_hyper_14_1182_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_480_chunk r_449
-                     ->  Seq Scan on compress_hyper_14_1183_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_481_chunk r_450
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1183_chunk r_574
                      ->  Seq Scan on compress_hyper_14_1184_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_482_chunk r_451
-                     ->  Seq Scan on compress_hyper_14_1185_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_483_chunk r_452
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1185_chunk r_575
                      ->  Seq Scan on compress_hyper_14_1186_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_484_chunk r_453
-                     ->  Seq Scan on compress_hyper_14_1187_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_485_chunk r_454
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1187_chunk r_576
                      ->  Seq Scan on compress_hyper_14_1188_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_486_chunk r_455
-                     ->  Seq Scan on compress_hyper_14_1189_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_487_chunk r_456
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1189_chunk r_577
                      ->  Seq Scan on compress_hyper_14_1190_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_488_chunk r_457
-                     ->  Seq Scan on compress_hyper_14_1191_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_489_chunk r_458
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1191_chunk r_578
                      ->  Seq Scan on compress_hyper_14_1192_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_490_chunk r_459
-                     ->  Seq Scan on compress_hyper_14_1193_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_491_chunk r_460
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1193_chunk r_579
                      ->  Seq Scan on compress_hyper_14_1194_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_492_chunk r_461
-                     ->  Seq Scan on compress_hyper_14_1195_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_493_chunk r_462
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1195_chunk r_580
                      ->  Seq Scan on compress_hyper_14_1196_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_494_chunk r_463
-                     ->  Seq Scan on compress_hyper_14_1197_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_495_chunk r_464
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1197_chunk r_581
                      ->  Seq Scan on compress_hyper_14_1198_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_496_chunk r_465
-                     ->  Seq Scan on compress_hyper_14_1199_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_497_chunk r_466
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1199_chunk r_582
                      ->  Seq Scan on compress_hyper_14_1200_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_498_chunk r_467
-                     ->  Seq Scan on compress_hyper_14_1201_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_499_chunk r_468
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1201_chunk r_583
                      ->  Seq Scan on compress_hyper_14_1202_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_500_chunk r_469
-                     ->  Seq Scan on compress_hyper_14_1203_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_501_chunk r_470
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1203_chunk r_584
                      ->  Seq Scan on compress_hyper_14_1204_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_502_chunk r_471
-                     ->  Seq Scan on compress_hyper_14_1205_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_503_chunk r_472
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1205_chunk r_585
                      ->  Seq Scan on compress_hyper_14_1206_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_504_chunk r_473
-                     ->  Seq Scan on compress_hyper_14_1207_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_505_chunk r_474
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1207_chunk r_586
                      ->  Seq Scan on compress_hyper_14_1208_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_506_chunk r_475
-                     ->  Seq Scan on compress_hyper_14_1209_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_507_chunk r_476
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1209_chunk r_587
                      ->  Seq Scan on compress_hyper_14_1210_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_508_chunk r_477
-                     ->  Seq Scan on compress_hyper_14_1211_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_509_chunk r_478
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1211_chunk r_588
                      ->  Seq Scan on compress_hyper_14_1212_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_510_chunk r_479
-                     ->  Seq Scan on compress_hyper_14_1213_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_511_chunk r_480
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1213_chunk r_589
                      ->  Seq Scan on compress_hyper_14_1214_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_512_chunk r_481
-                     ->  Seq Scan on compress_hyper_14_1215_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_513_chunk r_482
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1215_chunk r_590
                      ->  Seq Scan on compress_hyper_14_1216_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_514_chunk r_483
-                     ->  Seq Scan on compress_hyper_14_1217_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_515_chunk r_484
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1217_chunk r_591
                      ->  Seq Scan on compress_hyper_14_1218_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_516_chunk r_485
-                     ->  Seq Scan on compress_hyper_14_1219_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_517_chunk r_486
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1219_chunk r_592
                      ->  Seq Scan on compress_hyper_14_1220_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_518_chunk r_487
-                     ->  Seq Scan on compress_hyper_14_1221_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_519_chunk r_488
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1221_chunk r_593
                      ->  Seq Scan on compress_hyper_14_1222_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_520_chunk r_489
-                     ->  Seq Scan on compress_hyper_14_1223_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_521_chunk r_490
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1223_chunk r_594
                      ->  Seq Scan on compress_hyper_14_1224_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_522_chunk r_491
-                     ->  Seq Scan on compress_hyper_14_1225_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_523_chunk r_492
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1225_chunk r_595
                      ->  Seq Scan on compress_hyper_14_1226_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_524_chunk r_493
-                     ->  Seq Scan on compress_hyper_14_1227_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_525_chunk r_494
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1227_chunk r_596
                      ->  Seq Scan on compress_hyper_14_1228_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_526_chunk r_495
-                     ->  Seq Scan on compress_hyper_14_1229_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_527_chunk r_496
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1229_chunk r_597
                      ->  Seq Scan on compress_hyper_14_1230_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_528_chunk r_497
-                     ->  Seq Scan on compress_hyper_14_1231_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_529_chunk r_498
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1231_chunk r_598
                      ->  Seq Scan on compress_hyper_14_1232_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_530_chunk r_499
-                     ->  Seq Scan on compress_hyper_14_1233_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_531_chunk r_500
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1233_chunk r_599
                      ->  Seq Scan on compress_hyper_14_1234_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_532_chunk r_501
-                     ->  Seq Scan on compress_hyper_14_1235_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_533_chunk r_502
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1235_chunk r_600
                      ->  Seq Scan on compress_hyper_14_1236_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_534_chunk r_503
-                     ->  Seq Scan on compress_hyper_14_1237_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_535_chunk r_504
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1237_chunk r_601
                      ->  Seq Scan on compress_hyper_14_1238_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_536_chunk r_505
-                     ->  Seq Scan on compress_hyper_14_1239_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_537_chunk r_506
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1239_chunk r_602
                      ->  Seq Scan on compress_hyper_14_1240_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_538_chunk r_507
-                     ->  Seq Scan on compress_hyper_14_1241_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_539_chunk r_508
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1241_chunk r_603
                      ->  Seq Scan on compress_hyper_14_1242_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_540_chunk r_509
-                     ->  Seq Scan on compress_hyper_14_1243_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_541_chunk r_510
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1243_chunk r_604
                      ->  Seq Scan on compress_hyper_14_1244_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_542_chunk r_511
-                     ->  Seq Scan on compress_hyper_14_1245_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_543_chunk r_512
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1245_chunk r_605
                      ->  Seq Scan on compress_hyper_14_1246_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_544_chunk r_513
-                     ->  Seq Scan on compress_hyper_14_1247_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_545_chunk r_514
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1247_chunk r_606
                      ->  Seq Scan on compress_hyper_14_1248_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_546_chunk r_515
-                     ->  Seq Scan on compress_hyper_14_1249_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_547_chunk r_516
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1249_chunk r_607
                      ->  Seq Scan on compress_hyper_14_1250_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_548_chunk r_517
-                     ->  Seq Scan on compress_hyper_14_1251_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_549_chunk r_518
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1251_chunk r_608
                      ->  Seq Scan on compress_hyper_14_1252_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_550_chunk r_519
-                     ->  Seq Scan on compress_hyper_14_1253_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_551_chunk r_520
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1253_chunk r_609
                      ->  Seq Scan on compress_hyper_14_1254_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_552_chunk r_521
-                     ->  Seq Scan on compress_hyper_14_1255_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_553_chunk r_522
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1255_chunk r_610
                      ->  Seq Scan on compress_hyper_14_1256_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_554_chunk r_523
-                     ->  Seq Scan on compress_hyper_14_1257_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_555_chunk r_524
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1257_chunk r_611
                      ->  Seq Scan on compress_hyper_14_1258_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_556_chunk r_525
-                     ->  Seq Scan on compress_hyper_14_1259_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_557_chunk r_526
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1259_chunk r_612
                      ->  Seq Scan on compress_hyper_14_1260_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_558_chunk r_527
-                     ->  Seq Scan on compress_hyper_14_1261_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_559_chunk r_528
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1261_chunk r_613
                      ->  Seq Scan on compress_hyper_14_1262_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_560_chunk r_529
-                     ->  Seq Scan on compress_hyper_14_1263_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_561_chunk r_530
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1263_chunk r_614
                      ->  Seq Scan on compress_hyper_14_1264_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_562_chunk r_531
-                     ->  Seq Scan on compress_hyper_14_1265_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_563_chunk r_532
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1265_chunk r_615
                      ->  Seq Scan on compress_hyper_14_1266_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_564_chunk r_533
-                     ->  Seq Scan on compress_hyper_14_1267_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_565_chunk r_534
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1267_chunk r_616
                      ->  Seq Scan on compress_hyper_14_1268_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_566_chunk r_535
-                     ->  Seq Scan on compress_hyper_14_1269_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_567_chunk r_536
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1269_chunk r_617
                      ->  Seq Scan on compress_hyper_14_1270_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_568_chunk r_537
-                     ->  Seq Scan on compress_hyper_14_1271_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_569_chunk r_538
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1271_chunk r_618
                      ->  Seq Scan on compress_hyper_14_1272_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_570_chunk r_539
-                     ->  Seq Scan on compress_hyper_14_1273_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_571_chunk r_540
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1273_chunk r_619
                      ->  Seq Scan on compress_hyper_14_1274_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_572_chunk r_541
-                     ->  Seq Scan on compress_hyper_14_1275_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_573_chunk r_542
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1275_chunk r_620
                      ->  Seq Scan on compress_hyper_14_1276_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_574_chunk r_543
-                     ->  Seq Scan on compress_hyper_14_1277_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_575_chunk r_544
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1277_chunk r_621
                      ->  Seq Scan on compress_hyper_14_1278_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_576_chunk r_545
-                     ->  Seq Scan on compress_hyper_14_1279_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_577_chunk r_546
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1279_chunk r_622
                      ->  Seq Scan on compress_hyper_14_1280_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_578_chunk r_547
-                     ->  Seq Scan on compress_hyper_14_1281_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_579_chunk r_548
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1281_chunk r_623
                      ->  Seq Scan on compress_hyper_14_1282_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_580_chunk r_549
-                     ->  Seq Scan on compress_hyper_14_1283_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_581_chunk r_550
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1283_chunk r_624
                      ->  Seq Scan on compress_hyper_14_1284_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_582_chunk r_551
-                     ->  Seq Scan on compress_hyper_14_1285_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_583_chunk r_552
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1285_chunk r_625
                      ->  Seq Scan on compress_hyper_14_1286_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_584_chunk r_553
-                     ->  Seq Scan on compress_hyper_14_1287_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_585_chunk r_554
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1287_chunk r_626
                      ->  Seq Scan on compress_hyper_14_1288_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_586_chunk r_555
-                     ->  Seq Scan on compress_hyper_14_1289_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_587_chunk r_556
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1289_chunk r_627
                      ->  Seq Scan on compress_hyper_14_1290_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_588_chunk r_557
-                     ->  Seq Scan on compress_hyper_14_1291_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_589_chunk r_558
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1291_chunk r_628
                      ->  Seq Scan on compress_hyper_14_1292_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_590_chunk r_559
-                     ->  Seq Scan on compress_hyper_14_1293_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_591_chunk r_560
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1293_chunk r_629
                      ->  Seq Scan on compress_hyper_14_1294_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_592_chunk r_561
-                     ->  Seq Scan on compress_hyper_14_1295_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_593_chunk r_562
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1295_chunk r_630
                      ->  Seq Scan on compress_hyper_14_1296_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_594_chunk r_563
-                     ->  Seq Scan on compress_hyper_14_1297_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_595_chunk r_564
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1297_chunk r_631
                      ->  Seq Scan on compress_hyper_14_1298_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_596_chunk r_565
-                     ->  Seq Scan on compress_hyper_14_1299_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_597_chunk r_566
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1299_chunk r_632
                      ->  Seq Scan on compress_hyper_14_1300_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_598_chunk r_567
-                     ->  Seq Scan on compress_hyper_14_1301_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_599_chunk r_568
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1301_chunk r_633
                      ->  Seq Scan on compress_hyper_14_1302_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_600_chunk r_569
-                     ->  Seq Scan on compress_hyper_14_1303_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_601_chunk r_570
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1303_chunk r_634
                      ->  Seq Scan on compress_hyper_14_1304_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_602_chunk r_571
-                     ->  Seq Scan on compress_hyper_14_1305_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_603_chunk r_572
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1305_chunk r_635
                      ->  Seq Scan on compress_hyper_14_1306_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_604_chunk r_573
-                     ->  Seq Scan on compress_hyper_14_1307_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_605_chunk r_574
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1307_chunk r_636
                      ->  Seq Scan on compress_hyper_14_1308_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_606_chunk r_575
-                     ->  Seq Scan on compress_hyper_14_1309_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_607_chunk r_576
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1309_chunk r_637
                      ->  Seq Scan on compress_hyper_14_1310_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_608_chunk r_577
-                     ->  Seq Scan on compress_hyper_14_1311_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_609_chunk r_578
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1311_chunk r_638
                      ->  Seq Scan on compress_hyper_14_1312_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_610_chunk r_579
-                     ->  Seq Scan on compress_hyper_14_1313_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_611_chunk r_580
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1313_chunk r_639
                      ->  Seq Scan on compress_hyper_14_1314_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_612_chunk r_581
-                     ->  Seq Scan on compress_hyper_14_1315_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_613_chunk r_582
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1315_chunk r_640
                      ->  Seq Scan on compress_hyper_14_1316_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_614_chunk r_583
-                     ->  Seq Scan on compress_hyper_14_1317_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_615_chunk r_584
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1317_chunk r_641
                      ->  Seq Scan on compress_hyper_14_1318_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_616_chunk r_585
-                     ->  Seq Scan on compress_hyper_14_1319_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_617_chunk r_586
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1319_chunk r_642
                      ->  Seq Scan on compress_hyper_14_1320_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_618_chunk r_587
-                     ->  Seq Scan on compress_hyper_14_1321_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_619_chunk r_588
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1321_chunk r_643
                      ->  Seq Scan on compress_hyper_14_1322_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_620_chunk r_589
-                     ->  Seq Scan on compress_hyper_14_1323_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_621_chunk r_590
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1323_chunk r_644
                      ->  Seq Scan on compress_hyper_14_1324_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_622_chunk r_591
-                     ->  Seq Scan on compress_hyper_14_1325_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_623_chunk r_592
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1325_chunk r_645
                      ->  Seq Scan on compress_hyper_14_1326_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_624_chunk r_593
-                     ->  Seq Scan on compress_hyper_14_1327_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_625_chunk r_594
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1327_chunk r_646
                      ->  Seq Scan on compress_hyper_14_1328_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_626_chunk r_595
-                     ->  Seq Scan on compress_hyper_14_1329_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_627_chunk r_596
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1329_chunk r_647
                      ->  Seq Scan on compress_hyper_14_1330_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_628_chunk r_597
-                     ->  Seq Scan on compress_hyper_14_1331_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_629_chunk r_598
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1331_chunk r_648
                      ->  Seq Scan on compress_hyper_14_1332_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_630_chunk r_599
-                     ->  Seq Scan on compress_hyper_14_1333_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_631_chunk r_600
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1333_chunk r_649
                      ->  Seq Scan on compress_hyper_14_1334_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_632_chunk r_601
-                     ->  Seq Scan on compress_hyper_14_1335_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_633_chunk r_602
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1335_chunk r_650
                      ->  Seq Scan on compress_hyper_14_1336_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_634_chunk r_603
-                     ->  Seq Scan on compress_hyper_14_1337_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_635_chunk r_604
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1337_chunk r_651
                      ->  Seq Scan on compress_hyper_14_1338_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_636_chunk r_605
-                     ->  Seq Scan on compress_hyper_14_1339_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_637_chunk r_606
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1339_chunk r_652
                      ->  Seq Scan on compress_hyper_14_1340_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_638_chunk r_607
-                     ->  Seq Scan on compress_hyper_14_1341_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_639_chunk r_608
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1341_chunk r_653
                      ->  Seq Scan on compress_hyper_14_1342_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_640_chunk r_609
-                     ->  Seq Scan on compress_hyper_14_1343_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_641_chunk r_610
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1343_chunk r_654
                      ->  Seq Scan on compress_hyper_14_1344_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_642_chunk r_611
-                     ->  Seq Scan on compress_hyper_14_1345_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_643_chunk r_612
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1345_chunk r_655
                      ->  Seq Scan on compress_hyper_14_1346_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_644_chunk r_613
-                     ->  Seq Scan on compress_hyper_14_1347_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_645_chunk r_614
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1347_chunk r_656
                      ->  Seq Scan on compress_hyper_14_1348_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_646_chunk r_615
-                     ->  Seq Scan on compress_hyper_14_1349_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_647_chunk r_616
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1349_chunk r_657
                      ->  Seq Scan on compress_hyper_14_1350_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_648_chunk r_617
-                     ->  Seq Scan on compress_hyper_14_1351_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_649_chunk r_618
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1351_chunk r_658
                      ->  Seq Scan on compress_hyper_14_1352_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_650_chunk r_619
-                     ->  Seq Scan on compress_hyper_14_1353_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_651_chunk r_620
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1353_chunk r_659
                      ->  Seq Scan on compress_hyper_14_1354_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_652_chunk r_621
-                     ->  Seq Scan on compress_hyper_14_1355_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_653_chunk r_622
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1355_chunk r_660
                      ->  Seq Scan on compress_hyper_14_1356_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_654_chunk r_623
-                     ->  Seq Scan on compress_hyper_14_1357_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_655_chunk r_624
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1357_chunk r_661
                      ->  Seq Scan on compress_hyper_14_1358_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_656_chunk r_625
-                     ->  Seq Scan on compress_hyper_14_1359_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_657_chunk r_626
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1359_chunk r_662
                      ->  Seq Scan on compress_hyper_14_1360_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_658_chunk r_627
-                     ->  Seq Scan on compress_hyper_14_1361_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_659_chunk r_628
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1361_chunk r_663
                      ->  Seq Scan on compress_hyper_14_1362_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_660_chunk r_629
-                     ->  Seq Scan on compress_hyper_14_1363_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_661_chunk r_630
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1363_chunk r_664
                      ->  Seq Scan on compress_hyper_14_1364_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_662_chunk r_631
-                     ->  Seq Scan on compress_hyper_14_1365_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_663_chunk r_632
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1365_chunk r_665
                      ->  Seq Scan on compress_hyper_14_1366_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_664_chunk r_633
-                     ->  Seq Scan on compress_hyper_14_1367_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_665_chunk r_634
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1367_chunk r_666
                      ->  Seq Scan on compress_hyper_14_1368_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_666_chunk r_635
-                     ->  Seq Scan on compress_hyper_14_1369_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_667_chunk r_636
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1369_chunk r_667
                      ->  Seq Scan on compress_hyper_14_1370_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_668_chunk r_637
-                     ->  Seq Scan on compress_hyper_14_1371_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_669_chunk r_638
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1371_chunk r_668
                      ->  Seq Scan on compress_hyper_14_1372_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_670_chunk r_639
-                     ->  Seq Scan on compress_hyper_14_1373_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_671_chunk r_640
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1373_chunk r_669
                      ->  Seq Scan on compress_hyper_14_1374_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_672_chunk r_641
-                     ->  Seq Scan on compress_hyper_14_1375_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_673_chunk r_642
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1375_chunk r_670
                      ->  Seq Scan on compress_hyper_14_1376_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_674_chunk r_643
-                     ->  Seq Scan on compress_hyper_14_1377_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_675_chunk r_644
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1377_chunk r_671
                      ->  Seq Scan on compress_hyper_14_1378_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_676_chunk r_645
-                     ->  Seq Scan on compress_hyper_14_1379_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_677_chunk r_646
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1379_chunk r_672
                      ->  Seq Scan on compress_hyper_14_1380_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_678_chunk r_647
-                     ->  Seq Scan on compress_hyper_14_1381_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_679_chunk r_648
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1381_chunk r_673
                      ->  Seq Scan on compress_hyper_14_1382_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_680_chunk r_649
-                     ->  Seq Scan on compress_hyper_14_1383_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_681_chunk r_650
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1383_chunk r_674
                      ->  Seq Scan on compress_hyper_14_1384_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_682_chunk r_651
-                     ->  Seq Scan on compress_hyper_14_1385_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_683_chunk r_652
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1385_chunk r_675
                      ->  Seq Scan on compress_hyper_14_1386_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_684_chunk r_653
-                     ->  Seq Scan on compress_hyper_14_1387_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_685_chunk r_654
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1387_chunk r_676
                      ->  Seq Scan on compress_hyper_14_1388_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_686_chunk r_655
-                     ->  Seq Scan on compress_hyper_14_1389_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_687_chunk r_656
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1389_chunk r_677
                      ->  Seq Scan on compress_hyper_14_1390_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_688_chunk r_657
-                     ->  Seq Scan on compress_hyper_14_1391_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_689_chunk r_658
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1391_chunk r_678
                      ->  Seq Scan on compress_hyper_14_1392_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_690_chunk r_659
-                     ->  Seq Scan on compress_hyper_14_1393_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_691_chunk r_660
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1393_chunk r_679
                      ->  Seq Scan on compress_hyper_14_1394_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_692_chunk r_661
-                     ->  Seq Scan on compress_hyper_14_1395_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_693_chunk r_662
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1395_chunk r_680
                      ->  Seq Scan on compress_hyper_14_1396_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_694_chunk r_663
-                     ->  Seq Scan on compress_hyper_14_1397_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_695_chunk r_664
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1397_chunk r_681
                      ->  Seq Scan on compress_hyper_14_1398_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_696_chunk r_665
-                     ->  Seq Scan on compress_hyper_14_1399_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_697_chunk r_666
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1399_chunk r_682
                      ->  Seq Scan on compress_hyper_14_1400_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_698_chunk r_667
-                     ->  Seq Scan on compress_hyper_14_1401_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_699_chunk r_668
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1401_chunk r_683
                      ->  Seq Scan on compress_hyper_14_1402_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_700_chunk r_669
-                     ->  Seq Scan on compress_hyper_14_1403_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_701_chunk r_670
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1403_chunk r_684
                      ->  Seq Scan on compress_hyper_14_1404_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_702_chunk r_671
-                     ->  Seq Scan on compress_hyper_14_1405_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_703_chunk r_672
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1405_chunk r_685
                      ->  Seq Scan on compress_hyper_14_1406_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_704_chunk r_673
-                     ->  Seq Scan on compress_hyper_14_1407_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_705_chunk r_674
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1407_chunk r_686
                      ->  Seq Scan on compress_hyper_14_1408_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_706_chunk r_675
-                     ->  Seq Scan on compress_hyper_14_1409_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_707_chunk r_676
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1409_chunk r_687
                      ->  Seq Scan on compress_hyper_14_1410_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_708_chunk r_677
-                     ->  Seq Scan on compress_hyper_14_1411_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_709_chunk r_678
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1411_chunk r_688
                      ->  Seq Scan on compress_hyper_14_1412_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_710_chunk r_679
-                     ->  Seq Scan on compress_hyper_14_1413_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_711_chunk r_680
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1413_chunk r_689
                      ->  Seq Scan on compress_hyper_14_1414_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_712_chunk r_681
-                     ->  Seq Scan on compress_hyper_14_1415_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_713_chunk r_682
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1415_chunk r_690
                      ->  Seq Scan on compress_hyper_14_1416_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_714_chunk r_683
-                     ->  Seq Scan on compress_hyper_14_1417_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_715_chunk r_684
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1417_chunk r_691
                      ->  Seq Scan on compress_hyper_14_1418_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_716_chunk r_685
-                     ->  Seq Scan on compress_hyper_14_1419_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_717_chunk r_686
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1419_chunk r_692
                      ->  Seq Scan on compress_hyper_14_1420_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_718_chunk r_687
-                     ->  Seq Scan on compress_hyper_14_1421_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_719_chunk r_688
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1421_chunk r_693
                      ->  Seq Scan on compress_hyper_14_1422_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_720_chunk r_689
-                     ->  Seq Scan on compress_hyper_14_1423_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_721_chunk r_690
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1423_chunk r_694
                      ->  Seq Scan on compress_hyper_14_1424_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_722_chunk r_691
-                     ->  Seq Scan on compress_hyper_14_1425_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_723_chunk r_692
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1425_chunk r_695
                      ->  Seq Scan on compress_hyper_14_1426_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_724_chunk r_693
-                     ->  Seq Scan on compress_hyper_14_1427_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_725_chunk r_694
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1427_chunk r_696
                      ->  Seq Scan on compress_hyper_14_1428_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_726_chunk r_695
-                     ->  Seq Scan on compress_hyper_14_1429_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_727_chunk r_696
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1429_chunk r_697
                      ->  Seq Scan on compress_hyper_14_1430_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_728_chunk r_697
-                     ->  Seq Scan on compress_hyper_14_1431_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_729_chunk r_698
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1431_chunk r_698
                      ->  Seq Scan on compress_hyper_14_1432_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_730_chunk r_699
-                     ->  Seq Scan on compress_hyper_14_1433_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_731_chunk r_700
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1433_chunk r_699
                      ->  Seq Scan on compress_hyper_14_1434_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_732_chunk r_701
-                     ->  Seq Scan on compress_hyper_14_1435_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_733_chunk r_702
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1435_chunk r_700
                      ->  Seq Scan on compress_hyper_14_1436_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_13_734_chunk r_703
-                     ->  Seq Scan on compress_hyper_14_1437_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1437_chunk r_701
+                     ->  Seq Scan on compress_hyper_14_1438_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1439_chunk r_702
+                     ->  Seq Scan on compress_hyper_14_1440_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_13_1441_chunk r_703
+                     ->  Seq Scan on compress_hyper_14_1442_chunk
          ->  Hash
                ->  Seq Scan on tags t
 (1413 rows)
@@ -9816,7 +9816,7 @@ EXPLAIN (costs off) SELECT * FROM metrics ORDER BY time, device_id;
                ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk
                      ->  Parallel Seq Scan on compress_hyper_5_15_chunk
                ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk
-                     ->  Parallel Seq Scan on compress_hyper_5_16_chunk
+                     ->  Parallel Seq Scan on compress_hyper_5_17_chunk
                ->  Parallel Seq Scan on _hyper_1_2_chunk
 (10 rows)
 
@@ -9834,7 +9834,7 @@ EXPLAIN (costs off) SELECT time_bucket('10 minutes', time) bucket, avg(v0) avg_v
                            ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk
                                  ->  Parallel Seq Scan on compress_hyper_5_15_chunk
                            ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk
-                                 ->  Parallel Seq Scan on compress_hyper_5_16_chunk
+                                 ->  Parallel Seq Scan on compress_hyper_5_17_chunk
                            ->  Parallel Seq Scan on _hyper_1_2_chunk
 (13 rows)
 
@@ -9847,15 +9847,15 @@ EXPLAIN (costs off) SELECT * FROM metrics_space ORDER BY time, device_id;
          Sort Key: _hyper_2_4_chunk."time", _hyper_2_4_chunk.device_id
          ->  Parallel Append
                ->  Custom Scan (DecompressChunk) on _hyper_2_4_chunk
-                     ->  Parallel Seq Scan on compress_hyper_6_17_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_2_6_chunk
-                     ->  Parallel Seq Scan on compress_hyper_6_19_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_2_10_chunk
-                     ->  Parallel Seq Scan on compress_hyper_6_20_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_2_5_chunk
                      ->  Parallel Seq Scan on compress_hyper_6_18_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_2_6_chunk
+                     ->  Parallel Seq Scan on compress_hyper_6_20_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_2_10_chunk
+                     ->  Parallel Seq Scan on compress_hyper_6_24_chunk
+               ->  Custom Scan (DecompressChunk) on _hyper_2_5_chunk
+                     ->  Parallel Seq Scan on compress_hyper_6_19_chunk
                ->  Custom Scan (DecompressChunk) on _hyper_2_11_chunk
-                     ->  Parallel Seq Scan on compress_hyper_6_21_chunk
+                     ->  Parallel Seq Scan on compress_hyper_6_25_chunk
                ->  Parallel Seq Scan on _hyper_2_8_chunk
                ->  Parallel Seq Scan on _hyper_2_7_chunk
                ->  Parallel Seq Scan on _hyper_2_9_chunk
@@ -9879,7 +9879,7 @@ EXPLAIN (costs off) SELECT * FROM metrics WHERE time > '2000-01-08' ORDER BY dev
                Index Cond: ("time" > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
    ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk
          Filter: ("time" > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
-         ->  Index Scan using compress_hyper_5_16_chunk_c_index_2 on compress_hyper_5_16_chunk
+         ->  Index Scan using compress_hyper_5_17_chunk_c_index_2 on compress_hyper_5_17_chunk
                Filter: (_ts_meta_max_3 > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
 (10 rows)
 
@@ -9896,11 +9896,11 @@ EXPLAIN (costs off) SELECT * FROM metrics_space WHERE time > '2000-01-08' ORDER 
          Index Cond: ("time" > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
    ->  Custom Scan (DecompressChunk) on _hyper_2_10_chunk
          Filter: ("time" > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
-         ->  Index Scan using compress_hyper_6_20_chunk_c_space_index_2 on compress_hyper_6_20_chunk
+         ->  Index Scan using compress_hyper_6_24_chunk_c_space_index_2 on compress_hyper_6_24_chunk
                Filter: (_ts_meta_max_3 > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
    ->  Custom Scan (DecompressChunk) on _hyper_2_11_chunk
          Filter: ("time" > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
-         ->  Index Scan using compress_hyper_6_21_chunk_c_space_index_2 on compress_hyper_6_21_chunk
+         ->  Index Scan using compress_hyper_6_25_chunk_c_space_index_2 on compress_hyper_6_25_chunk
                Filter: (_ts_meta_max_3 > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
    ->  Index Scan Backward using _hyper_2_12_chunk_metrics_space_device_id_device_id_peer_v0_v_2 on _hyper_2_12_chunk
          Index Cond: ("time" > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
@@ -9936,7 +9936,7 @@ $sql$;
          ->  Seq Scan on compress_hyper_5_15_chunk (actual rows=5 loops=1)
    ->  Seq Scan on _hyper_1_2_chunk (actual rows=2520 loops=1)
    ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk (actual rows=2520 loops=1)
-         ->  Seq Scan on compress_hyper_5_16_chunk (actual rows=5 loops=1)
+         ->  Seq Scan on compress_hyper_5_17_chunk (actual rows=5 loops=1)
 (6 rows)
 
 \c
@@ -9949,7 +9949,7 @@ $sql$;
          ->  Seq Scan on compress_hyper_5_15_chunk (actual rows=5 loops=1)
    ->  Seq Scan on _hyper_1_2_chunk (actual rows=2520 loops=1)
    ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk (actual rows=2520 loops=1)
-         ->  Seq Scan on compress_hyper_5_16_chunk (actual rows=5 loops=1)
+         ->  Seq Scan on compress_hyper_5_17_chunk (actual rows=5 loops=1)
 (6 rows)
 
 -- repro for core dump related to total_table_pages setting that get
@@ -10005,7 +10005,7 @@ FROM ( SELECT chunk_schema || '.' || chunk_name as chunk_table
        WHERE hypertable_name = 'motion_table' ORDER BY range_start limit 1 ) q;
                compress_chunk               
 --------------------------------------------
- _timescaledb_internal._hyper_15_1438_chunk
+ _timescaledb_internal._hyper_15_1443_chunk
 (1 row)
 
 --call to decompress chunk on 1 of the chunks

--- a/tsl/test/expected/transparent_decompression_ordered_index-13.out
+++ b/tsl/test/expected/transparent_decompression_ordered_index-13.out
@@ -83,10 +83,10 @@ ORDER BY c.id;
              compress_chunk             
 ----------------------------------------
  _timescaledb_internal._hyper_1_1_chunk
- _timescaledb_internal._hyper_1_2_chunk
  _timescaledb_internal._hyper_1_3_chunk
- _timescaledb_internal._hyper_1_4_chunk
  _timescaledb_internal._hyper_1_5_chunk
+ _timescaledb_internal._hyper_1_7_chunk
+ _timescaledb_internal._hyper_1_9_chunk
 (5 rows)
 
 -- reindexing compressed hypertable to update statistics
@@ -236,28 +236,28 @@ ORDER BY 1,
    ->  Limit (actual rows=10 loops=1)
          ->  Custom Scan (ChunkAppend) on metrics_ordered_idx (actual rows=10 loops=1)
                Order: metrics_ordered_idx."time" DESC
-               ->  Custom Scan (DecompressChunk) on _hyper_1_5_chunk (actual rows=5 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_1_9_chunk (actual rows=5 loops=1)
                      ->  Sort (actual rows=5 loops=1)
                            Sort Key: compress_hyper_2_10_chunk._ts_meta_max_1 DESC
                            Sort Method: quicksort 
                            ->  Seq Scan on compress_hyper_2_10_chunk (actual rows=5 loops=1)
-               ->  Custom Scan (DecompressChunk) on _hyper_1_4_chunk (actual rows=5 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_1_7_chunk (actual rows=5 loops=1)
                      ->  Sort (actual rows=1 loops=1)
-                           Sort Key: compress_hyper_2_9_chunk._ts_meta_max_1 DESC
-                           Sort Method: quicksort 
-                           ->  Seq Scan on compress_hyper_2_9_chunk (actual rows=1 loops=1)
-               ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk (never executed)
-                     ->  Sort (never executed)
                            Sort Key: compress_hyper_2_8_chunk._ts_meta_max_1 DESC
-                           ->  Seq Scan on compress_hyper_2_8_chunk (never executed)
-               ->  Custom Scan (DecompressChunk) on _hyper_1_2_chunk (never executed)
-                     ->  Sort (never executed)
-                           Sort Key: compress_hyper_2_7_chunk._ts_meta_max_1 DESC
-                           ->  Seq Scan on compress_hyper_2_7_chunk (never executed)
-               ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk (never executed)
+                           Sort Method: quicksort 
+                           ->  Seq Scan on compress_hyper_2_8_chunk (actual rows=1 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_1_5_chunk (never executed)
                      ->  Sort (never executed)
                            Sort Key: compress_hyper_2_6_chunk._ts_meta_max_1 DESC
                            ->  Seq Scan on compress_hyper_2_6_chunk (never executed)
+               ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk (never executed)
+                     ->  Sort (never executed)
+                           Sort Key: compress_hyper_2_4_chunk._ts_meta_max_1 DESC
+                           ->  Seq Scan on compress_hyper_2_4_chunk (never executed)
+               ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk (never executed)
+                     ->  Sort (never executed)
+                           Sort Key: compress_hyper_2_2_chunk._ts_meta_max_1 DESC
+                           ->  Seq Scan on compress_hyper_2_2_chunk (never executed)
 (28 rows)
 
 -- should have ordered DecompressChunk path because segmentby columns have equality constraints
@@ -282,33 +282,33 @@ ORDER BY 1,
    ->  Limit (actual rows=10 loops=1)
          ->  Custom Scan (ChunkAppend) on metrics_ordered_idx (actual rows=10 loops=1)
                Order: metrics_ordered_idx."time" DESC
-               ->  Custom Scan (DecompressChunk) on _hyper_1_5_chunk (actual rows=0 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_1_9_chunk (actual rows=0 loops=1)
                      ->  Sort (actual rows=0 loops=1)
                            Sort Key: compress_hyper_2_10_chunk._ts_meta_sequence_num DESC
                            Sort Method: quicksort 
                            ->  Index Scan using compress_hyper_2_10_chunk__compressed_hypertable_2_device_id_de on compress_hyper_2_10_chunk (actual rows=0 loops=1)
                                  Index Cond: ((device_id = 3) AND (device_id_peer = 3))
-               ->  Custom Scan (DecompressChunk) on _hyper_1_4_chunk (actual rows=0 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_1_7_chunk (actual rows=0 loops=1)
                      ->  Sort (actual rows=0 loops=1)
-                           Sort Key: compress_hyper_2_9_chunk._ts_meta_sequence_num DESC
-                           Sort Method: quicksort 
-                           ->  Index Scan using compress_hyper_2_9_chunk__compressed_hypertable_2_device_id_dev on compress_hyper_2_9_chunk (actual rows=0 loops=1)
-                                 Index Cond: ((device_id = 3) AND (device_id_peer = 3))
-               ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk (actual rows=10 loops=1)
-                     ->  Sort (actual rows=1 loops=1)
                            Sort Key: compress_hyper_2_8_chunk._ts_meta_sequence_num DESC
                            Sort Method: quicksort 
-                           ->  Index Scan using compress_hyper_2_8_chunk__compressed_hypertable_2_device_id_dev on compress_hyper_2_8_chunk (actual rows=1 loops=1)
+                           ->  Index Scan using compress_hyper_2_8_chunk__compressed_hypertable_2_device_id_dev on compress_hyper_2_8_chunk (actual rows=0 loops=1)
                                  Index Cond: ((device_id = 3) AND (device_id_peer = 3))
-               ->  Custom Scan (DecompressChunk) on _hyper_1_2_chunk (never executed)
+               ->  Custom Scan (DecompressChunk) on _hyper_1_5_chunk (actual rows=10 loops=1)
+                     ->  Sort (actual rows=1 loops=1)
+                           Sort Key: compress_hyper_2_6_chunk._ts_meta_sequence_num DESC
+                           Sort Method: quicksort 
+                           ->  Index Scan using compress_hyper_2_6_chunk__compressed_hypertable_2_device_id_dev on compress_hyper_2_6_chunk (actual rows=1 loops=1)
+                                 Index Cond: ((device_id = 3) AND (device_id_peer = 3))
+               ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk (never executed)
                      ->  Sort (never executed)
-                           Sort Key: compress_hyper_2_7_chunk._ts_meta_sequence_num DESC
-                           ->  Index Scan using compress_hyper_2_7_chunk__compressed_hypertable_2_device_id_dev on compress_hyper_2_7_chunk (never executed)
+                           Sort Key: compress_hyper_2_4_chunk._ts_meta_sequence_num DESC
+                           ->  Index Scan using compress_hyper_2_4_chunk__compressed_hypertable_2_device_id_dev on compress_hyper_2_4_chunk (never executed)
                                  Index Cond: ((device_id = 3) AND (device_id_peer = 3))
                ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk (never executed)
                      ->  Sort (never executed)
-                           Sort Key: compress_hyper_2_6_chunk._ts_meta_sequence_num DESC
-                           ->  Index Scan using compress_hyper_2_6_chunk__compressed_hypertable_2_device_id_dev on compress_hyper_2_6_chunk (never executed)
+                           Sort Key: compress_hyper_2_2_chunk._ts_meta_sequence_num DESC
+                           ->  Index Scan using compress_hyper_2_2_chunk__compressed_hypertable_2_device_id_dev on compress_hyper_2_2_chunk (never executed)
                                  Index Cond: ((device_id = 3) AND (device_id_peer = 3))
 (34 rows)
 
@@ -335,20 +335,20 @@ WHERE extract(minute FROM d.time) = 0;
                      ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk d_1 (actual rows=120 loops=1)
                            Filter: (date_part('minute'::text, "time") = '0'::double precision)
                            Rows Removed by Filter: 360
-                           ->  Index Scan using compress_hyper_2_6_chunk__compressed_hypertable_2_device_id_dev on compress_hyper_2_6_chunk (actual rows=5 loops=1)
-                     ->  Custom Scan (DecompressChunk) on _hyper_1_2_chunk d_2 (actual rows=240 loops=1)
+                           ->  Index Scan using compress_hyper_2_2_chunk__compressed_hypertable_2_device_id_dev on compress_hyper_2_2_chunk (actual rows=5 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk d_2 (actual rows=240 loops=1)
                            Filter: (date_part('minute'::text, "time") = '0'::double precision)
                            Rows Removed by Filter: 720
-                           ->  Index Scan using compress_hyper_2_7_chunk__compressed_hypertable_2_device_id_dev on compress_hyper_2_7_chunk (actual rows=5 loops=1)
-                     ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk d_3 (actual rows=12 loops=1)
+                           ->  Index Scan using compress_hyper_2_4_chunk__compressed_hypertable_2_device_id_dev on compress_hyper_2_4_chunk (actual rows=5 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_1_5_chunk d_3 (actual rows=12 loops=1)
+                           Filter: (date_part('minute'::text, "time") = '0'::double precision)
+                           Rows Removed by Filter: 36
+                           ->  Index Scan using compress_hyper_2_6_chunk__compressed_hypertable_2_device_id_dev on compress_hyper_2_6_chunk (actual rows=1 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_1_7_chunk d_4 (actual rows=12 loops=1)
                            Filter: (date_part('minute'::text, "time") = '0'::double precision)
                            Rows Removed by Filter: 36
                            ->  Index Scan using compress_hyper_2_8_chunk__compressed_hypertable_2_device_id_dev on compress_hyper_2_8_chunk (actual rows=1 loops=1)
-                     ->  Custom Scan (DecompressChunk) on _hyper_1_4_chunk d_4 (actual rows=12 loops=1)
-                           Filter: (date_part('minute'::text, "time") = '0'::double precision)
-                           Rows Removed by Filter: 36
-                           ->  Index Scan using compress_hyper_2_9_chunk__compressed_hypertable_2_device_id_dev on compress_hyper_2_9_chunk (actual rows=1 loops=1)
-                     ->  Custom Scan (DecompressChunk) on _hyper_1_5_chunk d_5 (actual rows=5 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_1_9_chunk d_5 (actual rows=5 loops=1)
                            Filter: (date_part('minute'::text, "time") = '0'::double precision)
                            ->  Index Scan using compress_hyper_2_10_chunk__compressed_hypertable_2_device_id_de on compress_hyper_2_10_chunk (actual rows=5 loops=1)
          ->  Subquery Scan on m (actual rows=0 loops=389)
@@ -358,20 +358,20 @@ WHERE extract(minute FROM d.time) = 0;
                      ->  Custom Scan (ChunkAppend) on metrics_ordered_idx m_1 (actual rows=0 loops=389)
                            Order: m_1."time" DESC
                            Hypertables excluded during runtime: 0
-                           ->  Custom Scan (DecompressChunk) on _hyper_1_5_chunk m_2 (actual rows=0 loops=388)
+                           ->  Custom Scan (DecompressChunk) on _hyper_1_9_chunk m_2 (actual rows=0 loops=388)
                                  ->  Index Scan Backward using compress_hyper_2_10_chunk__compressed_hypertable_2_device_id_de on compress_hyper_2_10_chunk compress_hyper_2_10_chunk_1 (actual rows=0 loops=388)
                                        Index Cond: ((device_id = d.device_id) AND (device_id_peer = 3))
-                           ->  Custom Scan (DecompressChunk) on _hyper_1_4_chunk m_3 (actual rows=0 loops=388)
-                                 ->  Index Scan Backward using compress_hyper_2_9_chunk__compressed_hypertable_2_device_id_dev on compress_hyper_2_9_chunk compress_hyper_2_9_chunk_1 (actual rows=0 loops=388)
-                                       Index Cond: ((device_id = d.device_id) AND (device_id_peer = 3))
-                           ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk m_4 (actual rows=0 loops=388)
+                           ->  Custom Scan (DecompressChunk) on _hyper_1_7_chunk m_3 (actual rows=0 loops=388)
                                  ->  Index Scan Backward using compress_hyper_2_8_chunk__compressed_hypertable_2_device_id_dev on compress_hyper_2_8_chunk compress_hyper_2_8_chunk_1 (actual rows=0 loops=388)
                                        Index Cond: ((device_id = d.device_id) AND (device_id_peer = 3))
-                           ->  Custom Scan (DecompressChunk) on _hyper_1_2_chunk m_5 (actual rows=0 loops=304)
-                                 ->  Index Scan Backward using compress_hyper_2_7_chunk__compressed_hypertable_2_device_id_dev on compress_hyper_2_7_chunk compress_hyper_2_7_chunk_1 (actual rows=0 loops=304)
+                           ->  Custom Scan (DecompressChunk) on _hyper_1_5_chunk m_4 (actual rows=0 loops=388)
+                                 ->  Index Scan Backward using compress_hyper_2_6_chunk__compressed_hypertable_2_device_id_dev on compress_hyper_2_6_chunk compress_hyper_2_6_chunk_1 (actual rows=0 loops=388)
+                                       Index Cond: ((device_id = d.device_id) AND (device_id_peer = 3))
+                           ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk m_5 (actual rows=0 loops=304)
+                                 ->  Index Scan Backward using compress_hyper_2_4_chunk__compressed_hypertable_2_device_id_dev on compress_hyper_2_4_chunk compress_hyper_2_4_chunk_1 (actual rows=0 loops=304)
                                        Index Cond: ((device_id = d.device_id) AND (device_id_peer = 3))
                            ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk m_6 (actual rows=0 loops=304)
-                                 ->  Index Scan Backward using compress_hyper_2_6_chunk__compressed_hypertable_2_device_id_dev on compress_hyper_2_6_chunk compress_hyper_2_6_chunk_1 (actual rows=0 loops=304)
+                                 ->  Index Scan Backward using compress_hyper_2_2_chunk__compressed_hypertable_2_device_id_dev on compress_hyper_2_2_chunk compress_hyper_2_2_chunk_1 (actual rows=0 loops=304)
                                        Index Cond: ((device_id = d.device_id) AND (device_id_peer = 3))
 (48 rows)
 
@@ -396,20 +396,20 @@ WHERE extract(minute FROM d.time) = 0;
          ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk d_1 (actual rows=120 loops=1)
                Filter: (date_part('minute'::text, "time") = '0'::double precision)
                Rows Removed by Filter: 360
-               ->  Seq Scan on compress_hyper_2_6_chunk (actual rows=5 loops=1)
-         ->  Custom Scan (DecompressChunk) on _hyper_1_2_chunk d_2 (actual rows=240 loops=1)
+               ->  Seq Scan on compress_hyper_2_2_chunk (actual rows=5 loops=1)
+         ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk d_2 (actual rows=240 loops=1)
                Filter: (date_part('minute'::text, "time") = '0'::double precision)
                Rows Removed by Filter: 720
-               ->  Seq Scan on compress_hyper_2_7_chunk (actual rows=5 loops=1)
-         ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk d_3 (actual rows=12 loops=1)
+               ->  Seq Scan on compress_hyper_2_4_chunk (actual rows=5 loops=1)
+         ->  Custom Scan (DecompressChunk) on _hyper_1_5_chunk d_3 (actual rows=12 loops=1)
+               Filter: (date_part('minute'::text, "time") = '0'::double precision)
+               Rows Removed by Filter: 36
+               ->  Seq Scan on compress_hyper_2_6_chunk (actual rows=1 loops=1)
+         ->  Custom Scan (DecompressChunk) on _hyper_1_7_chunk d_4 (actual rows=12 loops=1)
                Filter: (date_part('minute'::text, "time") = '0'::double precision)
                Rows Removed by Filter: 36
                ->  Seq Scan on compress_hyper_2_8_chunk (actual rows=1 loops=1)
-         ->  Custom Scan (DecompressChunk) on _hyper_1_4_chunk d_4 (actual rows=12 loops=1)
-               Filter: (date_part('minute'::text, "time") = '0'::double precision)
-               Rows Removed by Filter: 36
-               ->  Seq Scan on compress_hyper_2_9_chunk (actual rows=1 loops=1)
-         ->  Custom Scan (DecompressChunk) on _hyper_1_5_chunk d_5 (actual rows=5 loops=1)
+         ->  Custom Scan (DecompressChunk) on _hyper_1_9_chunk d_5 (actual rows=5 loops=1)
                Filter: (date_part('minute'::text, "time") = '0'::double precision)
                ->  Seq Scan on compress_hyper_2_10_chunk (actual rows=5 loops=1)
    ->  Subquery Scan on m (actual rows=0 loops=389)
@@ -419,20 +419,20 @@ WHERE extract(minute FROM d.time) = 0;
                ->  Custom Scan (ChunkAppend) on metrics_ordered_idx m_1 (actual rows=0 loops=389)
                      Order: m_1."time" DESC
                      Hypertables excluded during runtime: 0
-                     ->  Custom Scan (DecompressChunk) on _hyper_1_5_chunk m_2 (actual rows=0 loops=388)
+                     ->  Custom Scan (DecompressChunk) on _hyper_1_9_chunk m_2 (actual rows=0 loops=388)
                            ->  Index Scan Backward using compress_hyper_2_10_chunk__compressed_hypertable_2_device_id_de on compress_hyper_2_10_chunk compress_hyper_2_10_chunk_1 (actual rows=0 loops=388)
                                  Index Cond: ((device_id = d.device_id) AND (device_id_peer = 3))
-                     ->  Custom Scan (DecompressChunk) on _hyper_1_4_chunk m_3 (actual rows=0 loops=388)
-                           ->  Index Scan Backward using compress_hyper_2_9_chunk__compressed_hypertable_2_device_id_dev on compress_hyper_2_9_chunk compress_hyper_2_9_chunk_1 (actual rows=0 loops=388)
-                                 Index Cond: ((device_id = d.device_id) AND (device_id_peer = 3))
-                     ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk m_4 (actual rows=0 loops=388)
+                     ->  Custom Scan (DecompressChunk) on _hyper_1_7_chunk m_3 (actual rows=0 loops=388)
                            ->  Index Scan Backward using compress_hyper_2_8_chunk__compressed_hypertable_2_device_id_dev on compress_hyper_2_8_chunk compress_hyper_2_8_chunk_1 (actual rows=0 loops=388)
                                  Index Cond: ((device_id = d.device_id) AND (device_id_peer = 3))
-                     ->  Custom Scan (DecompressChunk) on _hyper_1_2_chunk m_5 (actual rows=0 loops=304)
-                           ->  Index Scan Backward using compress_hyper_2_7_chunk__compressed_hypertable_2_device_id_dev on compress_hyper_2_7_chunk compress_hyper_2_7_chunk_1 (actual rows=0 loops=304)
+                     ->  Custom Scan (DecompressChunk) on _hyper_1_5_chunk m_4 (actual rows=0 loops=388)
+                           ->  Index Scan Backward using compress_hyper_2_6_chunk__compressed_hypertable_2_device_id_dev on compress_hyper_2_6_chunk compress_hyper_2_6_chunk_1 (actual rows=0 loops=388)
+                                 Index Cond: ((device_id = d.device_id) AND (device_id_peer = 3))
+                     ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk m_5 (actual rows=0 loops=304)
+                           ->  Index Scan Backward using compress_hyper_2_4_chunk__compressed_hypertable_2_device_id_dev on compress_hyper_2_4_chunk compress_hyper_2_4_chunk_1 (actual rows=0 loops=304)
                                  Index Cond: ((device_id = d.device_id) AND (device_id_peer = 3))
                      ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk m_6 (actual rows=0 loops=304)
-                           ->  Index Scan Backward using compress_hyper_2_6_chunk__compressed_hypertable_2_device_id_dev on compress_hyper_2_6_chunk compress_hyper_2_6_chunk_1 (actual rows=0 loops=304)
+                           ->  Index Scan Backward using compress_hyper_2_2_chunk__compressed_hypertable_2_device_id_dev on compress_hyper_2_2_chunk compress_hyper_2_2_chunk_1 (actual rows=0 loops=304)
                                  Index Cond: ((device_id = d.device_id) AND (device_id_peer = 3))
 (44 rows)
 
@@ -463,14 +463,14 @@ GROUP BY device_id;
          ->  Merge Append (actual rows=1541 loops=1)
                Sort Key: mt_1.device_id
                ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk mt_1 (actual rows=480 loops=1)
-                     ->  Index Scan using compress_hyper_2_6_chunk__compressed_hypertable_2_device_id_dev on compress_hyper_2_6_chunk (actual rows=5 loops=1)
-               ->  Custom Scan (DecompressChunk) on _hyper_1_2_chunk mt_2 (actual rows=960 loops=1)
-                     ->  Index Scan using compress_hyper_2_7_chunk__compressed_hypertable_2_device_id_dev on compress_hyper_2_7_chunk (actual rows=5 loops=1)
-               ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk mt_3 (actual rows=48 loops=1)
+                     ->  Index Scan using compress_hyper_2_2_chunk__compressed_hypertable_2_device_id_dev on compress_hyper_2_2_chunk (actual rows=5 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk mt_2 (actual rows=960 loops=1)
+                     ->  Index Scan using compress_hyper_2_4_chunk__compressed_hypertable_2_device_id_dev on compress_hyper_2_4_chunk (actual rows=5 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_1_5_chunk mt_3 (actual rows=48 loops=1)
+                     ->  Index Scan using compress_hyper_2_6_chunk__compressed_hypertable_2_device_id_dev on compress_hyper_2_6_chunk (actual rows=1 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_1_7_chunk mt_4 (actual rows=48 loops=1)
                      ->  Index Scan using compress_hyper_2_8_chunk__compressed_hypertable_2_device_id_dev on compress_hyper_2_8_chunk (actual rows=1 loops=1)
-               ->  Custom Scan (DecompressChunk) on _hyper_1_4_chunk mt_4 (actual rows=48 loops=1)
-                     ->  Index Scan using compress_hyper_2_9_chunk__compressed_hypertable_2_device_id_dev on compress_hyper_2_9_chunk (actual rows=1 loops=1)
-               ->  Custom Scan (DecompressChunk) on _hyper_1_5_chunk mt_5 (actual rows=5 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_1_9_chunk mt_5 (actual rows=5 loops=1)
                      ->  Index Scan using compress_hyper_2_10_chunk__compressed_hypertable_2_device_id_de on compress_hyper_2_10_chunk (actual rows=5 loops=1)
          ->  Materialize (actual rows=1 loops=1541)
                ->  Seq Scan on nodetime nd (actual rows=1 loops=1)
@@ -494,25 +494,25 @@ ORDER BY time;
          Order: mt."time"
          ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk mt_1 (actual rows=480 loops=1)
                ->  Sort (actual rows=5 loops=1)
+                     Sort Key: compress_hyper_2_2_chunk._ts_meta_min_1
+                     Sort Method: quicksort 
+                     ->  Index Scan using compress_hyper_2_2_chunk__compressed_hypertable_2_device_id_dev on compress_hyper_2_2_chunk (actual rows=5 loops=1)
+         ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk mt_2 (actual rows=960 loops=1)
+               ->  Sort (actual rows=5 loops=1)
+                     Sort Key: compress_hyper_2_4_chunk._ts_meta_min_1
+                     Sort Method: quicksort 
+                     ->  Index Scan using compress_hyper_2_4_chunk__compressed_hypertable_2_device_id_dev on compress_hyper_2_4_chunk (actual rows=5 loops=1)
+         ->  Custom Scan (DecompressChunk) on _hyper_1_5_chunk mt_3 (actual rows=48 loops=1)
+               ->  Sort (actual rows=1 loops=1)
                      Sort Key: compress_hyper_2_6_chunk._ts_meta_min_1
                      Sort Method: quicksort 
-                     ->  Index Scan using compress_hyper_2_6_chunk__compressed_hypertable_2_device_id_dev on compress_hyper_2_6_chunk (actual rows=5 loops=1)
-         ->  Custom Scan (DecompressChunk) on _hyper_1_2_chunk mt_2 (actual rows=960 loops=1)
-               ->  Sort (actual rows=5 loops=1)
-                     Sort Key: compress_hyper_2_7_chunk._ts_meta_min_1
-                     Sort Method: quicksort 
-                     ->  Index Scan using compress_hyper_2_7_chunk__compressed_hypertable_2_device_id_dev on compress_hyper_2_7_chunk (actual rows=5 loops=1)
-         ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk mt_3 (actual rows=48 loops=1)
+                     ->  Index Scan using compress_hyper_2_6_chunk__compressed_hypertable_2_device_id_dev on compress_hyper_2_6_chunk (actual rows=1 loops=1)
+         ->  Custom Scan (DecompressChunk) on _hyper_1_7_chunk mt_4 (actual rows=48 loops=1)
                ->  Sort (actual rows=1 loops=1)
                      Sort Key: compress_hyper_2_8_chunk._ts_meta_min_1
                      Sort Method: quicksort 
                      ->  Index Scan using compress_hyper_2_8_chunk__compressed_hypertable_2_device_id_dev on compress_hyper_2_8_chunk (actual rows=1 loops=1)
-         ->  Custom Scan (DecompressChunk) on _hyper_1_4_chunk mt_4 (actual rows=48 loops=1)
-               ->  Sort (actual rows=1 loops=1)
-                     Sort Key: compress_hyper_2_9_chunk._ts_meta_min_1
-                     Sort Method: quicksort 
-                     ->  Index Scan using compress_hyper_2_9_chunk__compressed_hypertable_2_device_id_dev on compress_hyper_2_9_chunk (actual rows=1 loops=1)
-         ->  Custom Scan (DecompressChunk) on _hyper_1_5_chunk mt_5 (actual rows=5 loops=1)
+         ->  Custom Scan (DecompressChunk) on _hyper_1_9_chunk mt_5 (actual rows=5 loops=1)
                ->  Sort (actual rows=5 loops=1)
                      Sort Key: compress_hyper_2_10_chunk._ts_meta_min_1
                      Sort Method: quicksort 
@@ -557,25 +557,25 @@ ORDER BY time;
                      Order: mt."time"
                      ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk mt_1 (actual rows=480 loops=1)
                            ->  Sort (actual rows=5 loops=1)
+                                 Sort Key: compress_hyper_2_2_chunk._ts_meta_min_1
+                                 Sort Method: quicksort 
+                                 ->  Seq Scan on compress_hyper_2_2_chunk (actual rows=5 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk mt_2 (actual rows=960 loops=1)
+                           ->  Sort (actual rows=5 loops=1)
+                                 Sort Key: compress_hyper_2_4_chunk._ts_meta_min_1
+                                 Sort Method: quicksort 
+                                 ->  Seq Scan on compress_hyper_2_4_chunk (actual rows=5 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_1_5_chunk mt_3 (actual rows=48 loops=1)
+                           ->  Sort (actual rows=1 loops=1)
                                  Sort Key: compress_hyper_2_6_chunk._ts_meta_min_1
                                  Sort Method: quicksort 
-                                 ->  Seq Scan on compress_hyper_2_6_chunk (actual rows=5 loops=1)
-                     ->  Custom Scan (DecompressChunk) on _hyper_1_2_chunk mt_2 (actual rows=960 loops=1)
-                           ->  Sort (actual rows=5 loops=1)
-                                 Sort Key: compress_hyper_2_7_chunk._ts_meta_min_1
-                                 Sort Method: quicksort 
-                                 ->  Seq Scan on compress_hyper_2_7_chunk (actual rows=5 loops=1)
-                     ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk mt_3 (actual rows=48 loops=1)
+                                 ->  Seq Scan on compress_hyper_2_6_chunk (actual rows=1 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_1_7_chunk mt_4 (actual rows=48 loops=1)
                            ->  Sort (actual rows=1 loops=1)
                                  Sort Key: compress_hyper_2_8_chunk._ts_meta_min_1
                                  Sort Method: quicksort 
                                  ->  Seq Scan on compress_hyper_2_8_chunk (actual rows=1 loops=1)
-                     ->  Custom Scan (DecompressChunk) on _hyper_1_4_chunk mt_4 (actual rows=48 loops=1)
-                           ->  Sort (actual rows=1 loops=1)
-                                 Sort Key: compress_hyper_2_9_chunk._ts_meta_min_1
-                                 Sort Method: quicksort 
-                                 ->  Seq Scan on compress_hyper_2_9_chunk (actual rows=1 loops=1)
-                     ->  Custom Scan (DecompressChunk) on _hyper_1_5_chunk mt_5 (actual rows=5 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_1_9_chunk mt_5 (actual rows=5 loops=1)
                            ->  Sort (actual rows=5 loops=1)
                                  Sort Key: compress_hyper_2_10_chunk._ts_meta_min_1
                                  Sort Method: quicksort 
@@ -604,14 +604,14 @@ ORDER BY time;
          Rows Removed by Join Filter: 289
          ->  Append (actual rows=1541 loops=1)
                ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk mt_1 (actual rows=480 loops=1)
-                     ->  Seq Scan on compress_hyper_2_6_chunk (actual rows=5 loops=1)
-               ->  Custom Scan (DecompressChunk) on _hyper_1_2_chunk mt_2 (actual rows=960 loops=1)
-                     ->  Seq Scan on compress_hyper_2_7_chunk (actual rows=5 loops=1)
-               ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk mt_3 (actual rows=48 loops=1)
+                     ->  Seq Scan on compress_hyper_2_2_chunk (actual rows=5 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk mt_2 (actual rows=960 loops=1)
+                     ->  Seq Scan on compress_hyper_2_4_chunk (actual rows=5 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_1_5_chunk mt_3 (actual rows=48 loops=1)
+                     ->  Seq Scan on compress_hyper_2_6_chunk (actual rows=1 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_1_7_chunk mt_4 (actual rows=48 loops=1)
                      ->  Seq Scan on compress_hyper_2_8_chunk (actual rows=1 loops=1)
-               ->  Custom Scan (DecompressChunk) on _hyper_1_4_chunk mt_4 (actual rows=48 loops=1)
-                     ->  Seq Scan on compress_hyper_2_9_chunk (actual rows=1 loops=1)
-               ->  Custom Scan (DecompressChunk) on _hyper_1_5_chunk mt_5 (actual rows=5 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_1_9_chunk mt_5 (actual rows=5 loops=1)
                      ->  Seq Scan on compress_hyper_2_10_chunk (actual rows=5 loops=1)
          ->  Hash (actual rows=1 loops=1)
                Buckets: 2048  Batches: 1 
@@ -641,10 +641,10 @@ WHERE met.time > '2000-01-19 19:00:00-05'
 ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Nested Loop (actual rows=2 loops=1)
    ->  Values Scan on "*VALUES*" (actual rows=2 loops=1)
-   ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk met (actual rows=1 loops=2)
+   ->  Custom Scan (DecompressChunk) on _hyper_1_5_chunk met (actual rows=1 loops=2)
          Filter: (("time" > 'Wed Jan 19 16:00:00 2000 PST'::timestamp with time zone) AND ("time" < 'Thu Jan 20 17:00:00 2000 PST'::timestamp with time zone) AND ("*VALUES*".column2 = v0))
          Rows Removed by Filter: 47
-         ->  Index Scan using compress_hyper_2_8_chunk__compressed_hypertable_2_device_id_dev on compress_hyper_2_8_chunk (actual rows=1 loops=2)
+         ->  Index Scan using compress_hyper_2_6_chunk__compressed_hypertable_2_device_id_dev on compress_hyper_2_6_chunk (actual rows=1 loops=2)
                Index Cond: (device_id = "*VALUES*".column1)
                Filter: ((_ts_meta_max_1 > 'Wed Jan 19 16:00:00 2000 PST'::timestamp with time zone) AND (_ts_meta_min_1 < 'Thu Jan 20 17:00:00 2000 PST'::timestamp with time zone))
 (8 rows)
@@ -664,10 +664,10 @@ WHERE met.time > '2000-01-19 19:00:00-05'
    ->  Values Scan on "*VALUES*" (actual rows=1 loops=1)
          Filter: ((column1 = 3) AND (column2 = 5))
          Rows Removed by Filter: 1
-   ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk met (actual rows=1 loops=1)
+   ->  Custom Scan (DecompressChunk) on _hyper_1_5_chunk met (actual rows=1 loops=1)
          Filter: (("time" > 'Wed Jan 19 16:00:00 2000 PST'::timestamp with time zone) AND ("time" < 'Thu Jan 20 17:00:00 2000 PST'::timestamp with time zone) AND (v0 = 5))
          Rows Removed by Filter: 47
-         ->  Index Scan using compress_hyper_2_8_chunk__compressed_hypertable_2_device_id_dev on compress_hyper_2_8_chunk (actual rows=1 loops=1)
+         ->  Index Scan using compress_hyper_2_6_chunk__compressed_hypertable_2_device_id_dev on compress_hyper_2_6_chunk (actual rows=1 loops=1)
                Index Cond: (device_id = 3)
                Filter: ((_ts_meta_max_1 > 'Wed Jan 19 16:00:00 2000 PST'::timestamp with time zone) AND (_ts_meta_min_1 < 'Thu Jan 20 17:00:00 2000 PST'::timestamp with time zone))
 (10 rows)
@@ -686,10 +686,10 @@ WHERE met.time = '2000-01-19 19:00:00-05'
    ->  Values Scan on "*VALUES*" (actual rows=1 loops=1)
          Filter: ((column1 = 3) AND (column2 = 5))
          Rows Removed by Filter: 1
-   ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk met (actual rows=0 loops=1)
+   ->  Custom Scan (DecompressChunk) on _hyper_1_5_chunk met (actual rows=0 loops=1)
          Filter: ((v0 = 5) AND ("time" = 'Wed Jan 19 16:00:00 2000 PST'::timestamp with time zone))
          Rows Removed by Filter: 48
-         ->  Index Scan using compress_hyper_2_8_chunk__compressed_hypertable_2_device_id_dev on compress_hyper_2_8_chunk (actual rows=1 loops=1)
+         ->  Index Scan using compress_hyper_2_6_chunk__compressed_hypertable_2_device_id_dev on compress_hyper_2_6_chunk (actual rows=1 loops=1)
                Index Cond: ((device_id = 3) AND (device_id_peer = 3))
                Filter: ((_ts_meta_min_1 <= 'Wed Jan 19 16:00:00 2000 PST'::timestamp with time zone) AND (_ts_meta_max_1 >= 'Wed Jan 19 16:00:00 2000 PST'::timestamp with time zone))
 (10 rows)
@@ -712,10 +712,10 @@ ON met.device_id = q.node and met.device_id_peer = q.device_id_peer
          Rows Removed by Join Filter: 1
          ->  Seq Scan on nodetime (actual rows=1 loops=1)
          ->  Values Scan on "*VALUES*" (actual rows=2 loops=1)
-   ->  Custom Scan (DecompressChunk) on _hyper_1_4_chunk met (actual rows=1 loops=1)
+   ->  Custom Scan (DecompressChunk) on _hyper_1_7_chunk met (actual rows=1 loops=1)
          Filter: ((v0 > 2) AND ("time" = 'Fri Jan 19 17:00:00 2018 PST'::timestamp with time zone) AND ("*VALUES*".column3 = v0))
          Rows Removed by Filter: 47
-         ->  Index Scan using compress_hyper_2_9_chunk__compressed_hypertable_2_device_id_dev on compress_hyper_2_9_chunk (actual rows=1 loops=1)
+         ->  Index Scan using compress_hyper_2_8_chunk__compressed_hypertable_2_device_id_dev on compress_hyper_2_8_chunk (actual rows=1 loops=1)
                Index Cond: ((device_id = "*VALUES*".column1) AND (device_id_peer = "*VALUES*".column2))
                Filter: ((_ts_meta_min_1 <= 'Fri Jan 19 17:00:00 2018 PST'::timestamp with time zone) AND (_ts_meta_max_1 >= 'Fri Jan 19 17:00:00 2018 PST'::timestamp with time zone))
 (13 rows)
@@ -740,10 +740,10 @@ WHERE met.time > '2000-01-19 19:00:00-05'
    ->  Values Scan on "*VALUES*" (actual rows=1 loops=1)
          Filter: ((column1 = 3) AND (column2 = 5))
          Rows Removed by Filter: 1
-   ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk met (actual rows=1 loops=1)
+   ->  Custom Scan (DecompressChunk) on _hyper_1_5_chunk met (actual rows=1 loops=1)
          Filter: (("time" > 'Wed Jan 19 16:00:00 2000 PST'::timestamp with time zone) AND ("time" < 'Thu Jan 20 17:00:00 2000 PST'::timestamp with time zone) AND (v0 = 5))
          Rows Removed by Filter: 47
-         ->  Seq Scan on compress_hyper_2_8_chunk (actual rows=1 loops=1)
+         ->  Seq Scan on compress_hyper_2_6_chunk (actual rows=1 loops=1)
                Filter: ((_ts_meta_max_1 > 'Wed Jan 19 16:00:00 2000 PST'::timestamp with time zone) AND (_ts_meta_min_1 < 'Thu Jan 20 17:00:00 2000 PST'::timestamp with time zone) AND (device_id = 3) AND (device_id_peer = 3))
 (9 rows)
 
@@ -783,15 +783,15 @@ ORDER BY 1,
                Hypertable: metrics_ordered_idx
                Chunks excluded during startup: 0
                ->  Merge Append (actual rows=10 loops=1)
-                     Sort Key: _hyper_1_4_chunk."time" DESC
-                     ->  Custom Scan (DecompressChunk) on _hyper_1_4_chunk (actual rows=5 loops=1)
+                     Sort Key: _hyper_1_7_chunk."time" DESC
+                     ->  Custom Scan (DecompressChunk) on _hyper_1_7_chunk (actual rows=5 loops=1)
                            Filter: (("time" > 'Tue Jan 01 00:00:00 2002 PST'::timestamp with time zone) AND ("time" < now()))
                            ->  Sort (actual rows=1 loops=1)
-                                 Sort Key: compress_hyper_2_9_chunk._ts_meta_max_1 DESC
+                                 Sort Key: compress_hyper_2_8_chunk._ts_meta_max_1 DESC
                                  Sort Method: quicksort 
-                                 ->  Seq Scan on compress_hyper_2_9_chunk (actual rows=1 loops=1)
+                                 ->  Seq Scan on compress_hyper_2_8_chunk (actual rows=1 loops=1)
                                        Filter: (_ts_meta_max_1 > 'Tue Jan 01 00:00:00 2002 PST'::timestamp with time zone)
-                     ->  Custom Scan (DecompressChunk) on _hyper_1_5_chunk (actual rows=5 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_1_9_chunk (actual rows=5 loops=1)
                            Filter: (("time" > 'Tue Jan 01 00:00:00 2002 PST'::timestamp with time zone) AND ("time" < now()))
                            ->  Sort (actual rows=5 loops=1)
                                  Sort Key: compress_hyper_2_10_chunk._ts_meta_max_1 DESC
@@ -826,15 +826,15 @@ ORDER BY 1,
                Hypertable: metrics_ordered_idx
                Chunks excluded during startup: 0
                ->  Merge Append (actual rows=10 loops=1)
-                     Sort Key: _hyper_1_4_chunk."time" DESC
-                     ->  Custom Scan (DecompressChunk) on _hyper_1_4_chunk (actual rows=9 loops=1)
+                     Sort Key: _hyper_1_7_chunk."time" DESC
+                     ->  Custom Scan (DecompressChunk) on _hyper_1_7_chunk (actual rows=9 loops=1)
                            Filter: (("time" > 'Tue Jan 01 00:00:00 2002 PST'::timestamp with time zone) AND ("time" < now()))
                            ->  Sort (actual rows=1 loops=1)
-                                 Sort Key: compress_hyper_2_9_chunk._ts_meta_sequence_num DESC
+                                 Sort Key: compress_hyper_2_8_chunk._ts_meta_sequence_num DESC
                                  Sort Method: quicksort 
-                                 ->  Seq Scan on compress_hyper_2_9_chunk (actual rows=1 loops=1)
+                                 ->  Seq Scan on compress_hyper_2_8_chunk (actual rows=1 loops=1)
                                        Filter: ((_ts_meta_max_1 > 'Tue Jan 01 00:00:00 2002 PST'::timestamp with time zone) AND (device_id = 4) AND (device_id_peer = 5))
-                     ->  Custom Scan (DecompressChunk) on _hyper_1_5_chunk (actual rows=1 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_1_9_chunk (actual rows=1 loops=1)
                            Filter: (("time" > 'Tue Jan 01 00:00:00 2002 PST'::timestamp with time zone) AND ("time" < now()))
                            ->  Sort (actual rows=1 loops=1)
                                  Sort Key: compress_hyper_2_10_chunk._ts_meta_sequence_num DESC
@@ -913,21 +913,21 @@ ORDER BY 1,
                            ->  Append (actual rows=1541 loops=1)
                                  ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk d_1 (actual rows=480 loops=1)
                                        Filter: ("time" > ('2000-01-01 0:00:00+0'::cstring)::timestamp with time zone)
-                                       ->  Seq Scan on compress_hyper_2_6_chunk (actual rows=5 loops=1)
+                                       ->  Seq Scan on compress_hyper_2_2_chunk (actual rows=5 loops=1)
                                              Filter: (_ts_meta_max_1 > ('2000-01-01 0:00:00+0'::cstring)::timestamp with time zone)
-                                 ->  Custom Scan (DecompressChunk) on _hyper_1_2_chunk d_2 (actual rows=960 loops=1)
+                                 ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk d_2 (actual rows=960 loops=1)
                                        Filter: ("time" > ('2000-01-01 0:00:00+0'::cstring)::timestamp with time zone)
-                                       ->  Seq Scan on compress_hyper_2_7_chunk (actual rows=5 loops=1)
+                                       ->  Seq Scan on compress_hyper_2_4_chunk (actual rows=5 loops=1)
                                              Filter: (_ts_meta_max_1 > ('2000-01-01 0:00:00+0'::cstring)::timestamp with time zone)
-                                 ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk d_3 (actual rows=48 loops=1)
+                                 ->  Custom Scan (DecompressChunk) on _hyper_1_5_chunk d_3 (actual rows=48 loops=1)
+                                       Filter: ("time" > ('2000-01-01 0:00:00+0'::cstring)::timestamp with time zone)
+                                       ->  Seq Scan on compress_hyper_2_6_chunk (actual rows=1 loops=1)
+                                             Filter: (_ts_meta_max_1 > ('2000-01-01 0:00:00+0'::cstring)::timestamp with time zone)
+                                 ->  Custom Scan (DecompressChunk) on _hyper_1_7_chunk d_4 (actual rows=48 loops=1)
                                        Filter: ("time" > ('2000-01-01 0:00:00+0'::cstring)::timestamp with time zone)
                                        ->  Seq Scan on compress_hyper_2_8_chunk (actual rows=1 loops=1)
                                              Filter: (_ts_meta_max_1 > ('2000-01-01 0:00:00+0'::cstring)::timestamp with time zone)
-                                 ->  Custom Scan (DecompressChunk) on _hyper_1_4_chunk d_4 (actual rows=48 loops=1)
-                                       Filter: ("time" > ('2000-01-01 0:00:00+0'::cstring)::timestamp with time zone)
-                                       ->  Seq Scan on compress_hyper_2_9_chunk (actual rows=1 loops=1)
-                                             Filter: (_ts_meta_max_1 > ('2000-01-01 0:00:00+0'::cstring)::timestamp with time zone)
-                                 ->  Custom Scan (DecompressChunk) on _hyper_1_5_chunk d_5 (actual rows=5 loops=1)
+                                 ->  Custom Scan (DecompressChunk) on _hyper_1_9_chunk d_5 (actual rows=5 loops=1)
                                        Filter: ("time" > ('2000-01-01 0:00:00+0'::cstring)::timestamp with time zone)
                                        ->  Seq Scan on compress_hyper_2_10_chunk (actual rows=5 loops=1)
                                              Filter: (_ts_meta_max_1 > ('2000-01-01 0:00:00+0'::cstring)::timestamp with time zone)
@@ -940,21 +940,21 @@ ORDER BY 1,
                            ->  Append (actual rows=1541 loops=1)
                                  ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk m_1 (actual rows=480 loops=1)
                                        Filter: ("time" > ('2000-01-01 0:00:00+0'::cstring)::timestamp with time zone)
-                                       ->  Seq Scan on compress_hyper_2_6_chunk compress_hyper_2_6_chunk_1 (actual rows=5 loops=1)
+                                       ->  Seq Scan on compress_hyper_2_2_chunk compress_hyper_2_2_chunk_1 (actual rows=5 loops=1)
                                              Filter: (_ts_meta_max_1 > ('2000-01-01 0:00:00+0'::cstring)::timestamp with time zone)
-                                 ->  Custom Scan (DecompressChunk) on _hyper_1_2_chunk m_2 (actual rows=960 loops=1)
+                                 ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk m_2 (actual rows=960 loops=1)
                                        Filter: ("time" > ('2000-01-01 0:00:00+0'::cstring)::timestamp with time zone)
-                                       ->  Seq Scan on compress_hyper_2_7_chunk compress_hyper_2_7_chunk_1 (actual rows=5 loops=1)
+                                       ->  Seq Scan on compress_hyper_2_4_chunk compress_hyper_2_4_chunk_1 (actual rows=5 loops=1)
                                              Filter: (_ts_meta_max_1 > ('2000-01-01 0:00:00+0'::cstring)::timestamp with time zone)
-                                 ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk m_3 (actual rows=48 loops=1)
+                                 ->  Custom Scan (DecompressChunk) on _hyper_1_5_chunk m_3 (actual rows=48 loops=1)
+                                       Filter: ("time" > ('2000-01-01 0:00:00+0'::cstring)::timestamp with time zone)
+                                       ->  Seq Scan on compress_hyper_2_6_chunk compress_hyper_2_6_chunk_1 (actual rows=1 loops=1)
+                                             Filter: (_ts_meta_max_1 > ('2000-01-01 0:00:00+0'::cstring)::timestamp with time zone)
+                                 ->  Custom Scan (DecompressChunk) on _hyper_1_7_chunk m_4 (actual rows=48 loops=1)
                                        Filter: ("time" > ('2000-01-01 0:00:00+0'::cstring)::timestamp with time zone)
                                        ->  Seq Scan on compress_hyper_2_8_chunk compress_hyper_2_8_chunk_1 (actual rows=1 loops=1)
                                              Filter: (_ts_meta_max_1 > ('2000-01-01 0:00:00+0'::cstring)::timestamp with time zone)
-                                 ->  Custom Scan (DecompressChunk) on _hyper_1_4_chunk m_4 (actual rows=48 loops=1)
-                                       Filter: ("time" > ('2000-01-01 0:00:00+0'::cstring)::timestamp with time zone)
-                                       ->  Seq Scan on compress_hyper_2_9_chunk compress_hyper_2_9_chunk_1 (actual rows=1 loops=1)
-                                             Filter: (_ts_meta_max_1 > ('2000-01-01 0:00:00+0'::cstring)::timestamp with time zone)
-                                 ->  Custom Scan (DecompressChunk) on _hyper_1_5_chunk m_5 (actual rows=5 loops=1)
+                                 ->  Custom Scan (DecompressChunk) on _hyper_1_9_chunk m_5 (actual rows=5 loops=1)
                                        Filter: ("time" > ('2000-01-01 0:00:00+0'::cstring)::timestamp with time zone)
                                        ->  Seq Scan on compress_hyper_2_10_chunk compress_hyper_2_10_chunk_1 (actual rows=5 loops=1)
                                              Filter: (_ts_meta_max_1 > ('2000-01-01 0:00:00+0'::cstring)::timestamp with time zone)
@@ -977,7 +977,7 @@ ORDER BY m.v0;
    Sort Method: quicksort 
    ->  Hash Join (actual rows=0 loops=1)
          Hash Cond: (m.device_id = d.device_id)
-         ->  Custom Scan (DecompressChunk) on _hyper_1_5_chunk m (actual rows=0 loops=1)
+         ->  Custom Scan (DecompressChunk) on _hyper_1_9_chunk m (actual rows=0 loops=1)
                Filter: (("time" > 'Tue Jan 01 00:00:00 2019 PST'::timestamp with time zone) AND ("time" < ('2000-01-01 0:00:00+0'::cstring)::timestamp with time zone))
                ->  Seq Scan on compress_hyper_2_10_chunk (actual rows=0 loops=1)
                      Filter: ((_ts_meta_max_1 > 'Tue Jan 01 00:00:00 2019 PST'::timestamp with time zone) AND (_ts_meta_min_1 < ('2000-01-01 0:00:00+0'::cstring)::timestamp with time zone))
@@ -1007,7 +1007,7 @@ ORDER BY m.v0;
          ->  Seq Scan on device_tbl d (actual rows=1 loops=1)
                Filter: (device_id = 8)
                Rows Removed by Filter: 6
-         ->  Custom Scan (DecompressChunk) on _hyper_1_5_chunk m (actual rows=0 loops=1)
+         ->  Custom Scan (DecompressChunk) on _hyper_1_9_chunk m (actual rows=0 loops=1)
                Filter: (("time" > 'Tue Jan 01 00:00:00 2019 PST'::timestamp with time zone) AND ("time" < ('2000-01-01 0:00:00+0'::cstring)::timestamp with time zone))
                ->  Seq Scan on compress_hyper_2_10_chunk (actual rows=0 loops=1)
                      Filter: ((_ts_meta_max_1 > 'Tue Jan 01 00:00:00 2019 PST'::timestamp with time zone) AND (device_id = 8) AND (_ts_meta_min_1 < ('2000-01-01 0:00:00+0'::cstring)::timestamp with time zone))
@@ -1034,22 +1034,22 @@ ORDER BY m.v0;
          Join Filter: ((m_1."time" > 'Tue Jan 01 00:00:00 2019 PST'::timestamp with time zone) AND (m_1."time" < ('2000-01-01 0:00:00+0'::cstring)::timestamp with time zone))
          ->  Append (actual rows=1 loops=1)
                ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk m_1 (actual rows=0 loops=1)
+                     ->  Seq Scan on compress_hyper_2_2_chunk (actual rows=0 loops=1)
+                           Filter: (device_id = 7)
+                           Rows Removed by Filter: 5
+               ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk m_2 (actual rows=0 loops=1)
+                     ->  Seq Scan on compress_hyper_2_4_chunk (actual rows=0 loops=1)
+                           Filter: (device_id = 7)
+                           Rows Removed by Filter: 5
+               ->  Custom Scan (DecompressChunk) on _hyper_1_5_chunk m_3 (actual rows=0 loops=1)
                      ->  Seq Scan on compress_hyper_2_6_chunk (actual rows=0 loops=1)
                            Filter: (device_id = 7)
-                           Rows Removed by Filter: 5
-               ->  Custom Scan (DecompressChunk) on _hyper_1_2_chunk m_2 (actual rows=0 loops=1)
-                     ->  Seq Scan on compress_hyper_2_7_chunk (actual rows=0 loops=1)
-                           Filter: (device_id = 7)
-                           Rows Removed by Filter: 5
-               ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk m_3 (actual rows=0 loops=1)
+                           Rows Removed by Filter: 1
+               ->  Custom Scan (DecompressChunk) on _hyper_1_7_chunk m_4 (actual rows=0 loops=1)
                      ->  Seq Scan on compress_hyper_2_8_chunk (actual rows=0 loops=1)
                            Filter: (device_id = 7)
                            Rows Removed by Filter: 1
-               ->  Custom Scan (DecompressChunk) on _hyper_1_4_chunk m_4 (actual rows=0 loops=1)
-                     ->  Seq Scan on compress_hyper_2_9_chunk (actual rows=0 loops=1)
-                           Filter: (device_id = 7)
-                           Rows Removed by Filter: 1
-               ->  Custom Scan (DecompressChunk) on _hyper_1_5_chunk m_5 (actual rows=1 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_1_9_chunk m_5 (actual rows=1 loops=1)
                      ->  Seq Scan on compress_hyper_2_10_chunk (actual rows=1 loops=1)
                            Filter: (device_id = 7)
                            Rows Removed by Filter: 4

--- a/tsl/test/expected/transparent_decompression_ordered_index-14.out
+++ b/tsl/test/expected/transparent_decompression_ordered_index-14.out
@@ -83,10 +83,10 @@ ORDER BY c.id;
              compress_chunk             
 ----------------------------------------
  _timescaledb_internal._hyper_1_1_chunk
- _timescaledb_internal._hyper_1_2_chunk
  _timescaledb_internal._hyper_1_3_chunk
- _timescaledb_internal._hyper_1_4_chunk
  _timescaledb_internal._hyper_1_5_chunk
+ _timescaledb_internal._hyper_1_7_chunk
+ _timescaledb_internal._hyper_1_9_chunk
 (5 rows)
 
 -- reindexing compressed hypertable to update statistics
@@ -236,28 +236,28 @@ ORDER BY 1,
    ->  Limit (actual rows=10 loops=1)
          ->  Custom Scan (ChunkAppend) on metrics_ordered_idx (actual rows=10 loops=1)
                Order: metrics_ordered_idx."time" DESC
-               ->  Custom Scan (DecompressChunk) on _hyper_1_5_chunk (actual rows=5 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_1_9_chunk (actual rows=5 loops=1)
                      ->  Sort (actual rows=5 loops=1)
                            Sort Key: compress_hyper_2_10_chunk._ts_meta_max_1 DESC
                            Sort Method: quicksort 
                            ->  Seq Scan on compress_hyper_2_10_chunk (actual rows=5 loops=1)
-               ->  Custom Scan (DecompressChunk) on _hyper_1_4_chunk (actual rows=5 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_1_7_chunk (actual rows=5 loops=1)
                      ->  Sort (actual rows=1 loops=1)
-                           Sort Key: compress_hyper_2_9_chunk._ts_meta_max_1 DESC
-                           Sort Method: quicksort 
-                           ->  Seq Scan on compress_hyper_2_9_chunk (actual rows=1 loops=1)
-               ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk (never executed)
-                     ->  Sort (never executed)
                            Sort Key: compress_hyper_2_8_chunk._ts_meta_max_1 DESC
-                           ->  Seq Scan on compress_hyper_2_8_chunk (never executed)
-               ->  Custom Scan (DecompressChunk) on _hyper_1_2_chunk (never executed)
-                     ->  Sort (never executed)
-                           Sort Key: compress_hyper_2_7_chunk._ts_meta_max_1 DESC
-                           ->  Seq Scan on compress_hyper_2_7_chunk (never executed)
-               ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk (never executed)
+                           Sort Method: quicksort 
+                           ->  Seq Scan on compress_hyper_2_8_chunk (actual rows=1 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_1_5_chunk (never executed)
                      ->  Sort (never executed)
                            Sort Key: compress_hyper_2_6_chunk._ts_meta_max_1 DESC
                            ->  Seq Scan on compress_hyper_2_6_chunk (never executed)
+               ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk (never executed)
+                     ->  Sort (never executed)
+                           Sort Key: compress_hyper_2_4_chunk._ts_meta_max_1 DESC
+                           ->  Seq Scan on compress_hyper_2_4_chunk (never executed)
+               ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk (never executed)
+                     ->  Sort (never executed)
+                           Sort Key: compress_hyper_2_2_chunk._ts_meta_max_1 DESC
+                           ->  Seq Scan on compress_hyper_2_2_chunk (never executed)
 (28 rows)
 
 -- should have ordered DecompressChunk path because segmentby columns have equality constraints
@@ -282,33 +282,33 @@ ORDER BY 1,
    ->  Limit (actual rows=10 loops=1)
          ->  Custom Scan (ChunkAppend) on metrics_ordered_idx (actual rows=10 loops=1)
                Order: metrics_ordered_idx."time" DESC
-               ->  Custom Scan (DecompressChunk) on _hyper_1_5_chunk (actual rows=0 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_1_9_chunk (actual rows=0 loops=1)
                      ->  Sort (actual rows=0 loops=1)
                            Sort Key: compress_hyper_2_10_chunk._ts_meta_sequence_num DESC
                            Sort Method: quicksort 
                            ->  Index Scan using compress_hyper_2_10_chunk__compressed_hypertable_2_device_id_de on compress_hyper_2_10_chunk (actual rows=0 loops=1)
                                  Index Cond: ((device_id = 3) AND (device_id_peer = 3))
-               ->  Custom Scan (DecompressChunk) on _hyper_1_4_chunk (actual rows=0 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_1_7_chunk (actual rows=0 loops=1)
                      ->  Sort (actual rows=0 loops=1)
-                           Sort Key: compress_hyper_2_9_chunk._ts_meta_sequence_num DESC
-                           Sort Method: quicksort 
-                           ->  Index Scan using compress_hyper_2_9_chunk__compressed_hypertable_2_device_id_dev on compress_hyper_2_9_chunk (actual rows=0 loops=1)
-                                 Index Cond: ((device_id = 3) AND (device_id_peer = 3))
-               ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk (actual rows=10 loops=1)
-                     ->  Sort (actual rows=1 loops=1)
                            Sort Key: compress_hyper_2_8_chunk._ts_meta_sequence_num DESC
                            Sort Method: quicksort 
-                           ->  Index Scan using compress_hyper_2_8_chunk__compressed_hypertable_2_device_id_dev on compress_hyper_2_8_chunk (actual rows=1 loops=1)
+                           ->  Index Scan using compress_hyper_2_8_chunk__compressed_hypertable_2_device_id_dev on compress_hyper_2_8_chunk (actual rows=0 loops=1)
                                  Index Cond: ((device_id = 3) AND (device_id_peer = 3))
-               ->  Custom Scan (DecompressChunk) on _hyper_1_2_chunk (never executed)
+               ->  Custom Scan (DecompressChunk) on _hyper_1_5_chunk (actual rows=10 loops=1)
+                     ->  Sort (actual rows=1 loops=1)
+                           Sort Key: compress_hyper_2_6_chunk._ts_meta_sequence_num DESC
+                           Sort Method: quicksort 
+                           ->  Index Scan using compress_hyper_2_6_chunk__compressed_hypertable_2_device_id_dev on compress_hyper_2_6_chunk (actual rows=1 loops=1)
+                                 Index Cond: ((device_id = 3) AND (device_id_peer = 3))
+               ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk (never executed)
                      ->  Sort (never executed)
-                           Sort Key: compress_hyper_2_7_chunk._ts_meta_sequence_num DESC
-                           ->  Index Scan using compress_hyper_2_7_chunk__compressed_hypertable_2_device_id_dev on compress_hyper_2_7_chunk (never executed)
+                           Sort Key: compress_hyper_2_4_chunk._ts_meta_sequence_num DESC
+                           ->  Index Scan using compress_hyper_2_4_chunk__compressed_hypertable_2_device_id_dev on compress_hyper_2_4_chunk (never executed)
                                  Index Cond: ((device_id = 3) AND (device_id_peer = 3))
                ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk (never executed)
                      ->  Sort (never executed)
-                           Sort Key: compress_hyper_2_6_chunk._ts_meta_sequence_num DESC
-                           ->  Index Scan using compress_hyper_2_6_chunk__compressed_hypertable_2_device_id_dev on compress_hyper_2_6_chunk (never executed)
+                           Sort Key: compress_hyper_2_2_chunk._ts_meta_sequence_num DESC
+                           ->  Index Scan using compress_hyper_2_2_chunk__compressed_hypertable_2_device_id_dev on compress_hyper_2_2_chunk (never executed)
                                  Index Cond: ((device_id = 3) AND (device_id_peer = 3))
 (34 rows)
 
@@ -335,20 +335,20 @@ WHERE extract(minute FROM d.time) = 0;
                      ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk d_1 (actual rows=120 loops=1)
                            Filter: (EXTRACT(minute FROM "time") = '0'::numeric)
                            Rows Removed by Filter: 360
-                           ->  Index Scan using compress_hyper_2_6_chunk__compressed_hypertable_2_device_id_dev on compress_hyper_2_6_chunk (actual rows=5 loops=1)
-                     ->  Custom Scan (DecompressChunk) on _hyper_1_2_chunk d_2 (actual rows=240 loops=1)
+                           ->  Index Scan using compress_hyper_2_2_chunk__compressed_hypertable_2_device_id_dev on compress_hyper_2_2_chunk (actual rows=5 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk d_2 (actual rows=240 loops=1)
                            Filter: (EXTRACT(minute FROM "time") = '0'::numeric)
                            Rows Removed by Filter: 720
-                           ->  Index Scan using compress_hyper_2_7_chunk__compressed_hypertable_2_device_id_dev on compress_hyper_2_7_chunk (actual rows=5 loops=1)
-                     ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk d_3 (actual rows=12 loops=1)
+                           ->  Index Scan using compress_hyper_2_4_chunk__compressed_hypertable_2_device_id_dev on compress_hyper_2_4_chunk (actual rows=5 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_1_5_chunk d_3 (actual rows=12 loops=1)
+                           Filter: (EXTRACT(minute FROM "time") = '0'::numeric)
+                           Rows Removed by Filter: 36
+                           ->  Index Scan using compress_hyper_2_6_chunk__compressed_hypertable_2_device_id_dev on compress_hyper_2_6_chunk (actual rows=1 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_1_7_chunk d_4 (actual rows=12 loops=1)
                            Filter: (EXTRACT(minute FROM "time") = '0'::numeric)
                            Rows Removed by Filter: 36
                            ->  Index Scan using compress_hyper_2_8_chunk__compressed_hypertable_2_device_id_dev on compress_hyper_2_8_chunk (actual rows=1 loops=1)
-                     ->  Custom Scan (DecompressChunk) on _hyper_1_4_chunk d_4 (actual rows=12 loops=1)
-                           Filter: (EXTRACT(minute FROM "time") = '0'::numeric)
-                           Rows Removed by Filter: 36
-                           ->  Index Scan using compress_hyper_2_9_chunk__compressed_hypertable_2_device_id_dev on compress_hyper_2_9_chunk (actual rows=1 loops=1)
-                     ->  Custom Scan (DecompressChunk) on _hyper_1_5_chunk d_5 (actual rows=5 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_1_9_chunk d_5 (actual rows=5 loops=1)
                            Filter: (EXTRACT(minute FROM "time") = '0'::numeric)
                            ->  Index Scan using compress_hyper_2_10_chunk__compressed_hypertable_2_device_id_de on compress_hyper_2_10_chunk (actual rows=5 loops=1)
          ->  Subquery Scan on m (actual rows=0 loops=389)
@@ -358,20 +358,20 @@ WHERE extract(minute FROM d.time) = 0;
                      ->  Custom Scan (ChunkAppend) on metrics_ordered_idx m_1 (actual rows=0 loops=389)
                            Order: m_1."time" DESC
                            Hypertables excluded during runtime: 0
-                           ->  Custom Scan (DecompressChunk) on _hyper_1_5_chunk m_2 (actual rows=0 loops=388)
+                           ->  Custom Scan (DecompressChunk) on _hyper_1_9_chunk m_2 (actual rows=0 loops=388)
                                  ->  Index Scan Backward using compress_hyper_2_10_chunk__compressed_hypertable_2_device_id_de on compress_hyper_2_10_chunk compress_hyper_2_10_chunk_1 (actual rows=0 loops=388)
                                        Index Cond: ((device_id = d.device_id) AND (device_id_peer = 3))
-                           ->  Custom Scan (DecompressChunk) on _hyper_1_4_chunk m_3 (actual rows=0 loops=388)
-                                 ->  Index Scan Backward using compress_hyper_2_9_chunk__compressed_hypertable_2_device_id_dev on compress_hyper_2_9_chunk compress_hyper_2_9_chunk_1 (actual rows=0 loops=388)
-                                       Index Cond: ((device_id = d.device_id) AND (device_id_peer = 3))
-                           ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk m_4 (actual rows=0 loops=388)
+                           ->  Custom Scan (DecompressChunk) on _hyper_1_7_chunk m_3 (actual rows=0 loops=388)
                                  ->  Index Scan Backward using compress_hyper_2_8_chunk__compressed_hypertable_2_device_id_dev on compress_hyper_2_8_chunk compress_hyper_2_8_chunk_1 (actual rows=0 loops=388)
                                        Index Cond: ((device_id = d.device_id) AND (device_id_peer = 3))
-                           ->  Custom Scan (DecompressChunk) on _hyper_1_2_chunk m_5 (actual rows=0 loops=304)
-                                 ->  Index Scan Backward using compress_hyper_2_7_chunk__compressed_hypertable_2_device_id_dev on compress_hyper_2_7_chunk compress_hyper_2_7_chunk_1 (actual rows=0 loops=304)
+                           ->  Custom Scan (DecompressChunk) on _hyper_1_5_chunk m_4 (actual rows=0 loops=388)
+                                 ->  Index Scan Backward using compress_hyper_2_6_chunk__compressed_hypertable_2_device_id_dev on compress_hyper_2_6_chunk compress_hyper_2_6_chunk_1 (actual rows=0 loops=388)
+                                       Index Cond: ((device_id = d.device_id) AND (device_id_peer = 3))
+                           ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk m_5 (actual rows=0 loops=304)
+                                 ->  Index Scan Backward using compress_hyper_2_4_chunk__compressed_hypertable_2_device_id_dev on compress_hyper_2_4_chunk compress_hyper_2_4_chunk_1 (actual rows=0 loops=304)
                                        Index Cond: ((device_id = d.device_id) AND (device_id_peer = 3))
                            ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk m_6 (actual rows=0 loops=304)
-                                 ->  Index Scan Backward using compress_hyper_2_6_chunk__compressed_hypertable_2_device_id_dev on compress_hyper_2_6_chunk compress_hyper_2_6_chunk_1 (actual rows=0 loops=304)
+                                 ->  Index Scan Backward using compress_hyper_2_2_chunk__compressed_hypertable_2_device_id_dev on compress_hyper_2_2_chunk compress_hyper_2_2_chunk_1 (actual rows=0 loops=304)
                                        Index Cond: ((device_id = d.device_id) AND (device_id_peer = 3))
 (48 rows)
 
@@ -396,20 +396,20 @@ WHERE extract(minute FROM d.time) = 0;
          ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk d_1 (actual rows=120 loops=1)
                Filter: (EXTRACT(minute FROM "time") = '0'::numeric)
                Rows Removed by Filter: 360
-               ->  Seq Scan on compress_hyper_2_6_chunk (actual rows=5 loops=1)
-         ->  Custom Scan (DecompressChunk) on _hyper_1_2_chunk d_2 (actual rows=240 loops=1)
+               ->  Seq Scan on compress_hyper_2_2_chunk (actual rows=5 loops=1)
+         ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk d_2 (actual rows=240 loops=1)
                Filter: (EXTRACT(minute FROM "time") = '0'::numeric)
                Rows Removed by Filter: 720
-               ->  Seq Scan on compress_hyper_2_7_chunk (actual rows=5 loops=1)
-         ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk d_3 (actual rows=12 loops=1)
+               ->  Seq Scan on compress_hyper_2_4_chunk (actual rows=5 loops=1)
+         ->  Custom Scan (DecompressChunk) on _hyper_1_5_chunk d_3 (actual rows=12 loops=1)
+               Filter: (EXTRACT(minute FROM "time") = '0'::numeric)
+               Rows Removed by Filter: 36
+               ->  Seq Scan on compress_hyper_2_6_chunk (actual rows=1 loops=1)
+         ->  Custom Scan (DecompressChunk) on _hyper_1_7_chunk d_4 (actual rows=12 loops=1)
                Filter: (EXTRACT(minute FROM "time") = '0'::numeric)
                Rows Removed by Filter: 36
                ->  Seq Scan on compress_hyper_2_8_chunk (actual rows=1 loops=1)
-         ->  Custom Scan (DecompressChunk) on _hyper_1_4_chunk d_4 (actual rows=12 loops=1)
-               Filter: (EXTRACT(minute FROM "time") = '0'::numeric)
-               Rows Removed by Filter: 36
-               ->  Seq Scan on compress_hyper_2_9_chunk (actual rows=1 loops=1)
-         ->  Custom Scan (DecompressChunk) on _hyper_1_5_chunk d_5 (actual rows=5 loops=1)
+         ->  Custom Scan (DecompressChunk) on _hyper_1_9_chunk d_5 (actual rows=5 loops=1)
                Filter: (EXTRACT(minute FROM "time") = '0'::numeric)
                ->  Seq Scan on compress_hyper_2_10_chunk (actual rows=5 loops=1)
    ->  Subquery Scan on m (actual rows=0 loops=389)
@@ -419,20 +419,20 @@ WHERE extract(minute FROM d.time) = 0;
                ->  Custom Scan (ChunkAppend) on metrics_ordered_idx m_1 (actual rows=0 loops=389)
                      Order: m_1."time" DESC
                      Hypertables excluded during runtime: 0
-                     ->  Custom Scan (DecompressChunk) on _hyper_1_5_chunk m_2 (actual rows=0 loops=388)
+                     ->  Custom Scan (DecompressChunk) on _hyper_1_9_chunk m_2 (actual rows=0 loops=388)
                            ->  Index Scan Backward using compress_hyper_2_10_chunk__compressed_hypertable_2_device_id_de on compress_hyper_2_10_chunk compress_hyper_2_10_chunk_1 (actual rows=0 loops=388)
                                  Index Cond: ((device_id = d.device_id) AND (device_id_peer = 3))
-                     ->  Custom Scan (DecompressChunk) on _hyper_1_4_chunk m_3 (actual rows=0 loops=388)
-                           ->  Index Scan Backward using compress_hyper_2_9_chunk__compressed_hypertable_2_device_id_dev on compress_hyper_2_9_chunk compress_hyper_2_9_chunk_1 (actual rows=0 loops=388)
-                                 Index Cond: ((device_id = d.device_id) AND (device_id_peer = 3))
-                     ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk m_4 (actual rows=0 loops=388)
+                     ->  Custom Scan (DecompressChunk) on _hyper_1_7_chunk m_3 (actual rows=0 loops=388)
                            ->  Index Scan Backward using compress_hyper_2_8_chunk__compressed_hypertable_2_device_id_dev on compress_hyper_2_8_chunk compress_hyper_2_8_chunk_1 (actual rows=0 loops=388)
                                  Index Cond: ((device_id = d.device_id) AND (device_id_peer = 3))
-                     ->  Custom Scan (DecompressChunk) on _hyper_1_2_chunk m_5 (actual rows=0 loops=304)
-                           ->  Index Scan Backward using compress_hyper_2_7_chunk__compressed_hypertable_2_device_id_dev on compress_hyper_2_7_chunk compress_hyper_2_7_chunk_1 (actual rows=0 loops=304)
+                     ->  Custom Scan (DecompressChunk) on _hyper_1_5_chunk m_4 (actual rows=0 loops=388)
+                           ->  Index Scan Backward using compress_hyper_2_6_chunk__compressed_hypertable_2_device_id_dev on compress_hyper_2_6_chunk compress_hyper_2_6_chunk_1 (actual rows=0 loops=388)
+                                 Index Cond: ((device_id = d.device_id) AND (device_id_peer = 3))
+                     ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk m_5 (actual rows=0 loops=304)
+                           ->  Index Scan Backward using compress_hyper_2_4_chunk__compressed_hypertable_2_device_id_dev on compress_hyper_2_4_chunk compress_hyper_2_4_chunk_1 (actual rows=0 loops=304)
                                  Index Cond: ((device_id = d.device_id) AND (device_id_peer = 3))
                      ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk m_6 (actual rows=0 loops=304)
-                           ->  Index Scan Backward using compress_hyper_2_6_chunk__compressed_hypertable_2_device_id_dev on compress_hyper_2_6_chunk compress_hyper_2_6_chunk_1 (actual rows=0 loops=304)
+                           ->  Index Scan Backward using compress_hyper_2_2_chunk__compressed_hypertable_2_device_id_dev on compress_hyper_2_2_chunk compress_hyper_2_2_chunk_1 (actual rows=0 loops=304)
                                  Index Cond: ((device_id = d.device_id) AND (device_id_peer = 3))
 (44 rows)
 
@@ -463,14 +463,14 @@ GROUP BY device_id;
          ->  Merge Append (actual rows=1541 loops=1)
                Sort Key: mt_1.device_id
                ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk mt_1 (actual rows=480 loops=1)
-                     ->  Index Scan using compress_hyper_2_6_chunk__compressed_hypertable_2_device_id_dev on compress_hyper_2_6_chunk (actual rows=5 loops=1)
-               ->  Custom Scan (DecompressChunk) on _hyper_1_2_chunk mt_2 (actual rows=960 loops=1)
-                     ->  Index Scan using compress_hyper_2_7_chunk__compressed_hypertable_2_device_id_dev on compress_hyper_2_7_chunk (actual rows=5 loops=1)
-               ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk mt_3 (actual rows=48 loops=1)
+                     ->  Index Scan using compress_hyper_2_2_chunk__compressed_hypertable_2_device_id_dev on compress_hyper_2_2_chunk (actual rows=5 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk mt_2 (actual rows=960 loops=1)
+                     ->  Index Scan using compress_hyper_2_4_chunk__compressed_hypertable_2_device_id_dev on compress_hyper_2_4_chunk (actual rows=5 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_1_5_chunk mt_3 (actual rows=48 loops=1)
+                     ->  Index Scan using compress_hyper_2_6_chunk__compressed_hypertable_2_device_id_dev on compress_hyper_2_6_chunk (actual rows=1 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_1_7_chunk mt_4 (actual rows=48 loops=1)
                      ->  Index Scan using compress_hyper_2_8_chunk__compressed_hypertable_2_device_id_dev on compress_hyper_2_8_chunk (actual rows=1 loops=1)
-               ->  Custom Scan (DecompressChunk) on _hyper_1_4_chunk mt_4 (actual rows=48 loops=1)
-                     ->  Index Scan using compress_hyper_2_9_chunk__compressed_hypertable_2_device_id_dev on compress_hyper_2_9_chunk (actual rows=1 loops=1)
-               ->  Custom Scan (DecompressChunk) on _hyper_1_5_chunk mt_5 (actual rows=5 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_1_9_chunk mt_5 (actual rows=5 loops=1)
                      ->  Index Scan using compress_hyper_2_10_chunk__compressed_hypertable_2_device_id_de on compress_hyper_2_10_chunk (actual rows=5 loops=1)
          ->  Materialize (actual rows=1 loops=1541)
                ->  Seq Scan on nodetime nd (actual rows=1 loops=1)
@@ -494,25 +494,25 @@ ORDER BY time;
          Order: mt."time"
          ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk mt_1 (actual rows=480 loops=1)
                ->  Sort (actual rows=5 loops=1)
+                     Sort Key: compress_hyper_2_2_chunk._ts_meta_min_1
+                     Sort Method: quicksort 
+                     ->  Index Scan using compress_hyper_2_2_chunk__compressed_hypertable_2_device_id_dev on compress_hyper_2_2_chunk (actual rows=5 loops=1)
+         ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk mt_2 (actual rows=960 loops=1)
+               ->  Sort (actual rows=5 loops=1)
+                     Sort Key: compress_hyper_2_4_chunk._ts_meta_min_1
+                     Sort Method: quicksort 
+                     ->  Index Scan using compress_hyper_2_4_chunk__compressed_hypertable_2_device_id_dev on compress_hyper_2_4_chunk (actual rows=5 loops=1)
+         ->  Custom Scan (DecompressChunk) on _hyper_1_5_chunk mt_3 (actual rows=48 loops=1)
+               ->  Sort (actual rows=1 loops=1)
                      Sort Key: compress_hyper_2_6_chunk._ts_meta_min_1
                      Sort Method: quicksort 
-                     ->  Index Scan using compress_hyper_2_6_chunk__compressed_hypertable_2_device_id_dev on compress_hyper_2_6_chunk (actual rows=5 loops=1)
-         ->  Custom Scan (DecompressChunk) on _hyper_1_2_chunk mt_2 (actual rows=960 loops=1)
-               ->  Sort (actual rows=5 loops=1)
-                     Sort Key: compress_hyper_2_7_chunk._ts_meta_min_1
-                     Sort Method: quicksort 
-                     ->  Index Scan using compress_hyper_2_7_chunk__compressed_hypertable_2_device_id_dev on compress_hyper_2_7_chunk (actual rows=5 loops=1)
-         ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk mt_3 (actual rows=48 loops=1)
+                     ->  Index Scan using compress_hyper_2_6_chunk__compressed_hypertable_2_device_id_dev on compress_hyper_2_6_chunk (actual rows=1 loops=1)
+         ->  Custom Scan (DecompressChunk) on _hyper_1_7_chunk mt_4 (actual rows=48 loops=1)
                ->  Sort (actual rows=1 loops=1)
                      Sort Key: compress_hyper_2_8_chunk._ts_meta_min_1
                      Sort Method: quicksort 
                      ->  Index Scan using compress_hyper_2_8_chunk__compressed_hypertable_2_device_id_dev on compress_hyper_2_8_chunk (actual rows=1 loops=1)
-         ->  Custom Scan (DecompressChunk) on _hyper_1_4_chunk mt_4 (actual rows=48 loops=1)
-               ->  Sort (actual rows=1 loops=1)
-                     Sort Key: compress_hyper_2_9_chunk._ts_meta_min_1
-                     Sort Method: quicksort 
-                     ->  Index Scan using compress_hyper_2_9_chunk__compressed_hypertable_2_device_id_dev on compress_hyper_2_9_chunk (actual rows=1 loops=1)
-         ->  Custom Scan (DecompressChunk) on _hyper_1_5_chunk mt_5 (actual rows=5 loops=1)
+         ->  Custom Scan (DecompressChunk) on _hyper_1_9_chunk mt_5 (actual rows=5 loops=1)
                ->  Sort (actual rows=5 loops=1)
                      Sort Key: compress_hyper_2_10_chunk._ts_meta_min_1
                      Sort Method: quicksort 
@@ -557,25 +557,25 @@ ORDER BY time;
                      Order: mt."time"
                      ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk mt_1 (actual rows=480 loops=1)
                            ->  Sort (actual rows=5 loops=1)
+                                 Sort Key: compress_hyper_2_2_chunk._ts_meta_min_1
+                                 Sort Method: quicksort 
+                                 ->  Seq Scan on compress_hyper_2_2_chunk (actual rows=5 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk mt_2 (actual rows=960 loops=1)
+                           ->  Sort (actual rows=5 loops=1)
+                                 Sort Key: compress_hyper_2_4_chunk._ts_meta_min_1
+                                 Sort Method: quicksort 
+                                 ->  Seq Scan on compress_hyper_2_4_chunk (actual rows=5 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_1_5_chunk mt_3 (actual rows=48 loops=1)
+                           ->  Sort (actual rows=1 loops=1)
                                  Sort Key: compress_hyper_2_6_chunk._ts_meta_min_1
                                  Sort Method: quicksort 
-                                 ->  Seq Scan on compress_hyper_2_6_chunk (actual rows=5 loops=1)
-                     ->  Custom Scan (DecompressChunk) on _hyper_1_2_chunk mt_2 (actual rows=960 loops=1)
-                           ->  Sort (actual rows=5 loops=1)
-                                 Sort Key: compress_hyper_2_7_chunk._ts_meta_min_1
-                                 Sort Method: quicksort 
-                                 ->  Seq Scan on compress_hyper_2_7_chunk (actual rows=5 loops=1)
-                     ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk mt_3 (actual rows=48 loops=1)
+                                 ->  Seq Scan on compress_hyper_2_6_chunk (actual rows=1 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_1_7_chunk mt_4 (actual rows=48 loops=1)
                            ->  Sort (actual rows=1 loops=1)
                                  Sort Key: compress_hyper_2_8_chunk._ts_meta_min_1
                                  Sort Method: quicksort 
                                  ->  Seq Scan on compress_hyper_2_8_chunk (actual rows=1 loops=1)
-                     ->  Custom Scan (DecompressChunk) on _hyper_1_4_chunk mt_4 (actual rows=48 loops=1)
-                           ->  Sort (actual rows=1 loops=1)
-                                 Sort Key: compress_hyper_2_9_chunk._ts_meta_min_1
-                                 Sort Method: quicksort 
-                                 ->  Seq Scan on compress_hyper_2_9_chunk (actual rows=1 loops=1)
-                     ->  Custom Scan (DecompressChunk) on _hyper_1_5_chunk mt_5 (actual rows=5 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_1_9_chunk mt_5 (actual rows=5 loops=1)
                            ->  Sort (actual rows=5 loops=1)
                                  Sort Key: compress_hyper_2_10_chunk._ts_meta_min_1
                                  Sort Method: quicksort 
@@ -604,14 +604,14 @@ ORDER BY time;
          Rows Removed by Join Filter: 289
          ->  Append (actual rows=1541 loops=1)
                ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk mt_1 (actual rows=480 loops=1)
-                     ->  Seq Scan on compress_hyper_2_6_chunk (actual rows=5 loops=1)
-               ->  Custom Scan (DecompressChunk) on _hyper_1_2_chunk mt_2 (actual rows=960 loops=1)
-                     ->  Seq Scan on compress_hyper_2_7_chunk (actual rows=5 loops=1)
-               ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk mt_3 (actual rows=48 loops=1)
+                     ->  Seq Scan on compress_hyper_2_2_chunk (actual rows=5 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk mt_2 (actual rows=960 loops=1)
+                     ->  Seq Scan on compress_hyper_2_4_chunk (actual rows=5 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_1_5_chunk mt_3 (actual rows=48 loops=1)
+                     ->  Seq Scan on compress_hyper_2_6_chunk (actual rows=1 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_1_7_chunk mt_4 (actual rows=48 loops=1)
                      ->  Seq Scan on compress_hyper_2_8_chunk (actual rows=1 loops=1)
-               ->  Custom Scan (DecompressChunk) on _hyper_1_4_chunk mt_4 (actual rows=48 loops=1)
-                     ->  Seq Scan on compress_hyper_2_9_chunk (actual rows=1 loops=1)
-               ->  Custom Scan (DecompressChunk) on _hyper_1_5_chunk mt_5 (actual rows=5 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_1_9_chunk mt_5 (actual rows=5 loops=1)
                      ->  Seq Scan on compress_hyper_2_10_chunk (actual rows=5 loops=1)
          ->  Hash (actual rows=1 loops=1)
                Buckets: 2048  Batches: 1 
@@ -641,10 +641,10 @@ WHERE met.time > '2000-01-19 19:00:00-05'
 ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Nested Loop (actual rows=2 loops=1)
    ->  Values Scan on "*VALUES*" (actual rows=2 loops=1)
-   ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk met (actual rows=1 loops=2)
+   ->  Custom Scan (DecompressChunk) on _hyper_1_5_chunk met (actual rows=1 loops=2)
          Filter: (("time" > 'Wed Jan 19 16:00:00 2000 PST'::timestamp with time zone) AND ("time" < 'Thu Jan 20 17:00:00 2000 PST'::timestamp with time zone) AND ("*VALUES*".column2 = v0))
          Rows Removed by Filter: 47
-         ->  Index Scan using compress_hyper_2_8_chunk__compressed_hypertable_2_device_id_dev on compress_hyper_2_8_chunk (actual rows=1 loops=2)
+         ->  Index Scan using compress_hyper_2_6_chunk__compressed_hypertable_2_device_id_dev on compress_hyper_2_6_chunk (actual rows=1 loops=2)
                Index Cond: (device_id = "*VALUES*".column1)
                Filter: ((_ts_meta_max_1 > 'Wed Jan 19 16:00:00 2000 PST'::timestamp with time zone) AND (_ts_meta_min_1 < 'Thu Jan 20 17:00:00 2000 PST'::timestamp with time zone))
 (8 rows)
@@ -664,10 +664,10 @@ WHERE met.time > '2000-01-19 19:00:00-05'
    ->  Values Scan on "*VALUES*" (actual rows=1 loops=1)
          Filter: ((column1 = 3) AND (column2 = 5))
          Rows Removed by Filter: 1
-   ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk met (actual rows=1 loops=1)
+   ->  Custom Scan (DecompressChunk) on _hyper_1_5_chunk met (actual rows=1 loops=1)
          Filter: (("time" > 'Wed Jan 19 16:00:00 2000 PST'::timestamp with time zone) AND ("time" < 'Thu Jan 20 17:00:00 2000 PST'::timestamp with time zone) AND (v0 = 5))
          Rows Removed by Filter: 47
-         ->  Index Scan using compress_hyper_2_8_chunk__compressed_hypertable_2_device_id_dev on compress_hyper_2_8_chunk (actual rows=1 loops=1)
+         ->  Index Scan using compress_hyper_2_6_chunk__compressed_hypertable_2_device_id_dev on compress_hyper_2_6_chunk (actual rows=1 loops=1)
                Index Cond: (device_id = 3)
                Filter: ((_ts_meta_max_1 > 'Wed Jan 19 16:00:00 2000 PST'::timestamp with time zone) AND (_ts_meta_min_1 < 'Thu Jan 20 17:00:00 2000 PST'::timestamp with time zone))
 (10 rows)
@@ -686,10 +686,10 @@ WHERE met.time = '2000-01-19 19:00:00-05'
    ->  Values Scan on "*VALUES*" (actual rows=1 loops=1)
          Filter: ((column1 = 3) AND (column2 = 5))
          Rows Removed by Filter: 1
-   ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk met (actual rows=0 loops=1)
+   ->  Custom Scan (DecompressChunk) on _hyper_1_5_chunk met (actual rows=0 loops=1)
          Filter: ((v0 = 5) AND ("time" = 'Wed Jan 19 16:00:00 2000 PST'::timestamp with time zone))
          Rows Removed by Filter: 48
-         ->  Index Scan using compress_hyper_2_8_chunk__compressed_hypertable_2_device_id_dev on compress_hyper_2_8_chunk (actual rows=1 loops=1)
+         ->  Index Scan using compress_hyper_2_6_chunk__compressed_hypertable_2_device_id_dev on compress_hyper_2_6_chunk (actual rows=1 loops=1)
                Index Cond: ((device_id = 3) AND (device_id_peer = 3))
                Filter: ((_ts_meta_min_1 <= 'Wed Jan 19 16:00:00 2000 PST'::timestamp with time zone) AND (_ts_meta_max_1 >= 'Wed Jan 19 16:00:00 2000 PST'::timestamp with time zone))
 (10 rows)
@@ -712,10 +712,10 @@ ON met.device_id = q.node and met.device_id_peer = q.device_id_peer
          Rows Removed by Join Filter: 1
          ->  Seq Scan on nodetime (actual rows=1 loops=1)
          ->  Values Scan on "*VALUES*" (actual rows=2 loops=1)
-   ->  Custom Scan (DecompressChunk) on _hyper_1_4_chunk met (actual rows=1 loops=1)
+   ->  Custom Scan (DecompressChunk) on _hyper_1_7_chunk met (actual rows=1 loops=1)
          Filter: ((v0 > 2) AND ("time" = 'Fri Jan 19 17:00:00 2018 PST'::timestamp with time zone) AND ("*VALUES*".column3 = v0))
          Rows Removed by Filter: 47
-         ->  Index Scan using compress_hyper_2_9_chunk__compressed_hypertable_2_device_id_dev on compress_hyper_2_9_chunk (actual rows=1 loops=1)
+         ->  Index Scan using compress_hyper_2_8_chunk__compressed_hypertable_2_device_id_dev on compress_hyper_2_8_chunk (actual rows=1 loops=1)
                Index Cond: ((device_id = "*VALUES*".column1) AND (device_id_peer = "*VALUES*".column2))
                Filter: ((_ts_meta_min_1 <= 'Fri Jan 19 17:00:00 2018 PST'::timestamp with time zone) AND (_ts_meta_max_1 >= 'Fri Jan 19 17:00:00 2018 PST'::timestamp with time zone))
 (13 rows)
@@ -740,10 +740,10 @@ WHERE met.time > '2000-01-19 19:00:00-05'
    ->  Values Scan on "*VALUES*" (actual rows=1 loops=1)
          Filter: ((column1 = 3) AND (column2 = 5))
          Rows Removed by Filter: 1
-   ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk met (actual rows=1 loops=1)
+   ->  Custom Scan (DecompressChunk) on _hyper_1_5_chunk met (actual rows=1 loops=1)
          Filter: (("time" > 'Wed Jan 19 16:00:00 2000 PST'::timestamp with time zone) AND ("time" < 'Thu Jan 20 17:00:00 2000 PST'::timestamp with time zone) AND (v0 = 5))
          Rows Removed by Filter: 47
-         ->  Seq Scan on compress_hyper_2_8_chunk (actual rows=1 loops=1)
+         ->  Seq Scan on compress_hyper_2_6_chunk (actual rows=1 loops=1)
                Filter: ((_ts_meta_max_1 > 'Wed Jan 19 16:00:00 2000 PST'::timestamp with time zone) AND (_ts_meta_min_1 < 'Thu Jan 20 17:00:00 2000 PST'::timestamp with time zone) AND (device_id = 3) AND (device_id_peer = 3))
 (9 rows)
 
@@ -783,15 +783,15 @@ ORDER BY 1,
                Hypertable: metrics_ordered_idx
                Chunks excluded during startup: 0
                ->  Merge Append (actual rows=10 loops=1)
-                     Sort Key: _hyper_1_4_chunk."time" DESC
-                     ->  Custom Scan (DecompressChunk) on _hyper_1_4_chunk (actual rows=5 loops=1)
+                     Sort Key: _hyper_1_7_chunk."time" DESC
+                     ->  Custom Scan (DecompressChunk) on _hyper_1_7_chunk (actual rows=5 loops=1)
                            Filter: (("time" > 'Tue Jan 01 00:00:00 2002 PST'::timestamp with time zone) AND ("time" < now()))
                            ->  Sort (actual rows=1 loops=1)
-                                 Sort Key: compress_hyper_2_9_chunk._ts_meta_max_1 DESC
+                                 Sort Key: compress_hyper_2_8_chunk._ts_meta_max_1 DESC
                                  Sort Method: quicksort 
-                                 ->  Seq Scan on compress_hyper_2_9_chunk (actual rows=1 loops=1)
+                                 ->  Seq Scan on compress_hyper_2_8_chunk (actual rows=1 loops=1)
                                        Filter: (_ts_meta_max_1 > 'Tue Jan 01 00:00:00 2002 PST'::timestamp with time zone)
-                     ->  Custom Scan (DecompressChunk) on _hyper_1_5_chunk (actual rows=5 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_1_9_chunk (actual rows=5 loops=1)
                            Filter: (("time" > 'Tue Jan 01 00:00:00 2002 PST'::timestamp with time zone) AND ("time" < now()))
                            ->  Sort (actual rows=5 loops=1)
                                  Sort Key: compress_hyper_2_10_chunk._ts_meta_max_1 DESC
@@ -826,15 +826,15 @@ ORDER BY 1,
                Hypertable: metrics_ordered_idx
                Chunks excluded during startup: 0
                ->  Merge Append (actual rows=10 loops=1)
-                     Sort Key: _hyper_1_4_chunk."time" DESC
-                     ->  Custom Scan (DecompressChunk) on _hyper_1_4_chunk (actual rows=9 loops=1)
+                     Sort Key: _hyper_1_7_chunk."time" DESC
+                     ->  Custom Scan (DecompressChunk) on _hyper_1_7_chunk (actual rows=9 loops=1)
                            Filter: (("time" > 'Tue Jan 01 00:00:00 2002 PST'::timestamp with time zone) AND ("time" < now()))
                            ->  Sort (actual rows=1 loops=1)
-                                 Sort Key: compress_hyper_2_9_chunk._ts_meta_sequence_num DESC
+                                 Sort Key: compress_hyper_2_8_chunk._ts_meta_sequence_num DESC
                                  Sort Method: quicksort 
-                                 ->  Seq Scan on compress_hyper_2_9_chunk (actual rows=1 loops=1)
+                                 ->  Seq Scan on compress_hyper_2_8_chunk (actual rows=1 loops=1)
                                        Filter: ((_ts_meta_max_1 > 'Tue Jan 01 00:00:00 2002 PST'::timestamp with time zone) AND (device_id = 4) AND (device_id_peer = 5))
-                     ->  Custom Scan (DecompressChunk) on _hyper_1_5_chunk (actual rows=1 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_1_9_chunk (actual rows=1 loops=1)
                            Filter: (("time" > 'Tue Jan 01 00:00:00 2002 PST'::timestamp with time zone) AND ("time" < now()))
                            ->  Sort (actual rows=1 loops=1)
                                  Sort Key: compress_hyper_2_10_chunk._ts_meta_sequence_num DESC
@@ -913,21 +913,21 @@ ORDER BY 1,
                            ->  Append (actual rows=1541 loops=1)
                                  ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk d_1 (actual rows=480 loops=1)
                                        Filter: ("time" > ('2000-01-01 0:00:00+0'::cstring)::timestamp with time zone)
-                                       ->  Seq Scan on compress_hyper_2_6_chunk (actual rows=5 loops=1)
+                                       ->  Seq Scan on compress_hyper_2_2_chunk (actual rows=5 loops=1)
                                              Filter: (_ts_meta_max_1 > ('2000-01-01 0:00:00+0'::cstring)::timestamp with time zone)
-                                 ->  Custom Scan (DecompressChunk) on _hyper_1_2_chunk d_2 (actual rows=960 loops=1)
+                                 ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk d_2 (actual rows=960 loops=1)
                                        Filter: ("time" > ('2000-01-01 0:00:00+0'::cstring)::timestamp with time zone)
-                                       ->  Seq Scan on compress_hyper_2_7_chunk (actual rows=5 loops=1)
+                                       ->  Seq Scan on compress_hyper_2_4_chunk (actual rows=5 loops=1)
                                              Filter: (_ts_meta_max_1 > ('2000-01-01 0:00:00+0'::cstring)::timestamp with time zone)
-                                 ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk d_3 (actual rows=48 loops=1)
+                                 ->  Custom Scan (DecompressChunk) on _hyper_1_5_chunk d_3 (actual rows=48 loops=1)
+                                       Filter: ("time" > ('2000-01-01 0:00:00+0'::cstring)::timestamp with time zone)
+                                       ->  Seq Scan on compress_hyper_2_6_chunk (actual rows=1 loops=1)
+                                             Filter: (_ts_meta_max_1 > ('2000-01-01 0:00:00+0'::cstring)::timestamp with time zone)
+                                 ->  Custom Scan (DecompressChunk) on _hyper_1_7_chunk d_4 (actual rows=48 loops=1)
                                        Filter: ("time" > ('2000-01-01 0:00:00+0'::cstring)::timestamp with time zone)
                                        ->  Seq Scan on compress_hyper_2_8_chunk (actual rows=1 loops=1)
                                              Filter: (_ts_meta_max_1 > ('2000-01-01 0:00:00+0'::cstring)::timestamp with time zone)
-                                 ->  Custom Scan (DecompressChunk) on _hyper_1_4_chunk d_4 (actual rows=48 loops=1)
-                                       Filter: ("time" > ('2000-01-01 0:00:00+0'::cstring)::timestamp with time zone)
-                                       ->  Seq Scan on compress_hyper_2_9_chunk (actual rows=1 loops=1)
-                                             Filter: (_ts_meta_max_1 > ('2000-01-01 0:00:00+0'::cstring)::timestamp with time zone)
-                                 ->  Custom Scan (DecompressChunk) on _hyper_1_5_chunk d_5 (actual rows=5 loops=1)
+                                 ->  Custom Scan (DecompressChunk) on _hyper_1_9_chunk d_5 (actual rows=5 loops=1)
                                        Filter: ("time" > ('2000-01-01 0:00:00+0'::cstring)::timestamp with time zone)
                                        ->  Seq Scan on compress_hyper_2_10_chunk (actual rows=5 loops=1)
                                              Filter: (_ts_meta_max_1 > ('2000-01-01 0:00:00+0'::cstring)::timestamp with time zone)
@@ -940,21 +940,21 @@ ORDER BY 1,
                            ->  Append (actual rows=1541 loops=1)
                                  ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk m_1 (actual rows=480 loops=1)
                                        Filter: ("time" > ('2000-01-01 0:00:00+0'::cstring)::timestamp with time zone)
-                                       ->  Seq Scan on compress_hyper_2_6_chunk compress_hyper_2_6_chunk_1 (actual rows=5 loops=1)
+                                       ->  Seq Scan on compress_hyper_2_2_chunk compress_hyper_2_2_chunk_1 (actual rows=5 loops=1)
                                              Filter: (_ts_meta_max_1 > ('2000-01-01 0:00:00+0'::cstring)::timestamp with time zone)
-                                 ->  Custom Scan (DecompressChunk) on _hyper_1_2_chunk m_2 (actual rows=960 loops=1)
+                                 ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk m_2 (actual rows=960 loops=1)
                                        Filter: ("time" > ('2000-01-01 0:00:00+0'::cstring)::timestamp with time zone)
-                                       ->  Seq Scan on compress_hyper_2_7_chunk compress_hyper_2_7_chunk_1 (actual rows=5 loops=1)
+                                       ->  Seq Scan on compress_hyper_2_4_chunk compress_hyper_2_4_chunk_1 (actual rows=5 loops=1)
                                              Filter: (_ts_meta_max_1 > ('2000-01-01 0:00:00+0'::cstring)::timestamp with time zone)
-                                 ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk m_3 (actual rows=48 loops=1)
+                                 ->  Custom Scan (DecompressChunk) on _hyper_1_5_chunk m_3 (actual rows=48 loops=1)
+                                       Filter: ("time" > ('2000-01-01 0:00:00+0'::cstring)::timestamp with time zone)
+                                       ->  Seq Scan on compress_hyper_2_6_chunk compress_hyper_2_6_chunk_1 (actual rows=1 loops=1)
+                                             Filter: (_ts_meta_max_1 > ('2000-01-01 0:00:00+0'::cstring)::timestamp with time zone)
+                                 ->  Custom Scan (DecompressChunk) on _hyper_1_7_chunk m_4 (actual rows=48 loops=1)
                                        Filter: ("time" > ('2000-01-01 0:00:00+0'::cstring)::timestamp with time zone)
                                        ->  Seq Scan on compress_hyper_2_8_chunk compress_hyper_2_8_chunk_1 (actual rows=1 loops=1)
                                              Filter: (_ts_meta_max_1 > ('2000-01-01 0:00:00+0'::cstring)::timestamp with time zone)
-                                 ->  Custom Scan (DecompressChunk) on _hyper_1_4_chunk m_4 (actual rows=48 loops=1)
-                                       Filter: ("time" > ('2000-01-01 0:00:00+0'::cstring)::timestamp with time zone)
-                                       ->  Seq Scan on compress_hyper_2_9_chunk compress_hyper_2_9_chunk_1 (actual rows=1 loops=1)
-                                             Filter: (_ts_meta_max_1 > ('2000-01-01 0:00:00+0'::cstring)::timestamp with time zone)
-                                 ->  Custom Scan (DecompressChunk) on _hyper_1_5_chunk m_5 (actual rows=5 loops=1)
+                                 ->  Custom Scan (DecompressChunk) on _hyper_1_9_chunk m_5 (actual rows=5 loops=1)
                                        Filter: ("time" > ('2000-01-01 0:00:00+0'::cstring)::timestamp with time zone)
                                        ->  Seq Scan on compress_hyper_2_10_chunk compress_hyper_2_10_chunk_1 (actual rows=5 loops=1)
                                              Filter: (_ts_meta_max_1 > ('2000-01-01 0:00:00+0'::cstring)::timestamp with time zone)
@@ -977,7 +977,7 @@ ORDER BY m.v0;
    Sort Method: quicksort 
    ->  Hash Join (actual rows=0 loops=1)
          Hash Cond: (m.device_id = d.device_id)
-         ->  Custom Scan (DecompressChunk) on _hyper_1_5_chunk m (actual rows=0 loops=1)
+         ->  Custom Scan (DecompressChunk) on _hyper_1_9_chunk m (actual rows=0 loops=1)
                Filter: (("time" > 'Tue Jan 01 00:00:00 2019 PST'::timestamp with time zone) AND ("time" < ('2000-01-01 0:00:00+0'::cstring)::timestamp with time zone))
                ->  Seq Scan on compress_hyper_2_10_chunk (actual rows=0 loops=1)
                      Filter: ((_ts_meta_max_1 > 'Tue Jan 01 00:00:00 2019 PST'::timestamp with time zone) AND (_ts_meta_min_1 < ('2000-01-01 0:00:00+0'::cstring)::timestamp with time zone))
@@ -1007,7 +1007,7 @@ ORDER BY m.v0;
          ->  Seq Scan on device_tbl d (actual rows=1 loops=1)
                Filter: (device_id = 8)
                Rows Removed by Filter: 6
-         ->  Custom Scan (DecompressChunk) on _hyper_1_5_chunk m (actual rows=0 loops=1)
+         ->  Custom Scan (DecompressChunk) on _hyper_1_9_chunk m (actual rows=0 loops=1)
                Filter: (("time" > 'Tue Jan 01 00:00:00 2019 PST'::timestamp with time zone) AND ("time" < ('2000-01-01 0:00:00+0'::cstring)::timestamp with time zone))
                ->  Seq Scan on compress_hyper_2_10_chunk (actual rows=0 loops=1)
                      Filter: ((_ts_meta_max_1 > 'Tue Jan 01 00:00:00 2019 PST'::timestamp with time zone) AND (device_id = 8) AND (_ts_meta_min_1 < ('2000-01-01 0:00:00+0'::cstring)::timestamp with time zone))
@@ -1034,22 +1034,22 @@ ORDER BY m.v0;
          Join Filter: ((m_1."time" > 'Tue Jan 01 00:00:00 2019 PST'::timestamp with time zone) AND (m_1."time" < ('2000-01-01 0:00:00+0'::cstring)::timestamp with time zone))
          ->  Append (actual rows=1 loops=1)
                ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk m_1 (actual rows=0 loops=1)
+                     ->  Seq Scan on compress_hyper_2_2_chunk (actual rows=0 loops=1)
+                           Filter: (device_id = 7)
+                           Rows Removed by Filter: 5
+               ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk m_2 (actual rows=0 loops=1)
+                     ->  Seq Scan on compress_hyper_2_4_chunk (actual rows=0 loops=1)
+                           Filter: (device_id = 7)
+                           Rows Removed by Filter: 5
+               ->  Custom Scan (DecompressChunk) on _hyper_1_5_chunk m_3 (actual rows=0 loops=1)
                      ->  Seq Scan on compress_hyper_2_6_chunk (actual rows=0 loops=1)
                            Filter: (device_id = 7)
-                           Rows Removed by Filter: 5
-               ->  Custom Scan (DecompressChunk) on _hyper_1_2_chunk m_2 (actual rows=0 loops=1)
-                     ->  Seq Scan on compress_hyper_2_7_chunk (actual rows=0 loops=1)
-                           Filter: (device_id = 7)
-                           Rows Removed by Filter: 5
-               ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk m_3 (actual rows=0 loops=1)
+                           Rows Removed by Filter: 1
+               ->  Custom Scan (DecompressChunk) on _hyper_1_7_chunk m_4 (actual rows=0 loops=1)
                      ->  Seq Scan on compress_hyper_2_8_chunk (actual rows=0 loops=1)
                            Filter: (device_id = 7)
                            Rows Removed by Filter: 1
-               ->  Custom Scan (DecompressChunk) on _hyper_1_4_chunk m_4 (actual rows=0 loops=1)
-                     ->  Seq Scan on compress_hyper_2_9_chunk (actual rows=0 loops=1)
-                           Filter: (device_id = 7)
-                           Rows Removed by Filter: 1
-               ->  Custom Scan (DecompressChunk) on _hyper_1_5_chunk m_5 (actual rows=1 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_1_9_chunk m_5 (actual rows=1 loops=1)
                      ->  Seq Scan on compress_hyper_2_10_chunk (actual rows=1 loops=1)
                            Filter: (device_id = 7)
                            Rows Removed by Filter: 4

--- a/tsl/test/expected/transparent_decompression_ordered_index-15.out
+++ b/tsl/test/expected/transparent_decompression_ordered_index-15.out
@@ -83,10 +83,10 @@ ORDER BY c.id;
              compress_chunk             
 ----------------------------------------
  _timescaledb_internal._hyper_1_1_chunk
- _timescaledb_internal._hyper_1_2_chunk
  _timescaledb_internal._hyper_1_3_chunk
- _timescaledb_internal._hyper_1_4_chunk
  _timescaledb_internal._hyper_1_5_chunk
+ _timescaledb_internal._hyper_1_7_chunk
+ _timescaledb_internal._hyper_1_9_chunk
 (5 rows)
 
 -- reindexing compressed hypertable to update statistics
@@ -237,28 +237,28 @@ ORDER BY 1,
    ->  Limit (actual rows=10 loops=1)
          ->  Custom Scan (ChunkAppend) on metrics_ordered_idx (actual rows=10 loops=1)
                Order: metrics_ordered_idx."time" DESC
-               ->  Custom Scan (DecompressChunk) on _hyper_1_5_chunk (actual rows=5 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_1_9_chunk (actual rows=5 loops=1)
                      ->  Sort (actual rows=5 loops=1)
                            Sort Key: compress_hyper_2_10_chunk._ts_meta_max_1 DESC
                            Sort Method: quicksort 
                            ->  Seq Scan on compress_hyper_2_10_chunk (actual rows=5 loops=1)
-               ->  Custom Scan (DecompressChunk) on _hyper_1_4_chunk (actual rows=5 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_1_7_chunk (actual rows=5 loops=1)
                      ->  Sort (actual rows=1 loops=1)
-                           Sort Key: compress_hyper_2_9_chunk._ts_meta_max_1 DESC
-                           Sort Method: quicksort 
-                           ->  Seq Scan on compress_hyper_2_9_chunk (actual rows=1 loops=1)
-               ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk (never executed)
-                     ->  Sort (never executed)
                            Sort Key: compress_hyper_2_8_chunk._ts_meta_max_1 DESC
-                           ->  Seq Scan on compress_hyper_2_8_chunk (never executed)
-               ->  Custom Scan (DecompressChunk) on _hyper_1_2_chunk (never executed)
-                     ->  Sort (never executed)
-                           Sort Key: compress_hyper_2_7_chunk._ts_meta_max_1 DESC
-                           ->  Seq Scan on compress_hyper_2_7_chunk (never executed)
-               ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk (never executed)
+                           Sort Method: quicksort 
+                           ->  Seq Scan on compress_hyper_2_8_chunk (actual rows=1 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_1_5_chunk (never executed)
                      ->  Sort (never executed)
                            Sort Key: compress_hyper_2_6_chunk._ts_meta_max_1 DESC
                            ->  Seq Scan on compress_hyper_2_6_chunk (never executed)
+               ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk (never executed)
+                     ->  Sort (never executed)
+                           Sort Key: compress_hyper_2_4_chunk._ts_meta_max_1 DESC
+                           ->  Seq Scan on compress_hyper_2_4_chunk (never executed)
+               ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk (never executed)
+                     ->  Sort (never executed)
+                           Sort Key: compress_hyper_2_2_chunk._ts_meta_max_1 DESC
+                           ->  Seq Scan on compress_hyper_2_2_chunk (never executed)
 (28 rows)
 
 -- should have ordered DecompressChunk path because segmentby columns have equality constraints
@@ -283,33 +283,33 @@ ORDER BY 1,
    ->  Limit (actual rows=10 loops=1)
          ->  Custom Scan (ChunkAppend) on metrics_ordered_idx (actual rows=10 loops=1)
                Order: metrics_ordered_idx."time" DESC
-               ->  Custom Scan (DecompressChunk) on _hyper_1_5_chunk (actual rows=0 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_1_9_chunk (actual rows=0 loops=1)
                      ->  Sort (actual rows=0 loops=1)
                            Sort Key: compress_hyper_2_10_chunk._ts_meta_sequence_num DESC
                            Sort Method: quicksort 
                            ->  Index Scan using compress_hyper_2_10_chunk__compressed_hypertable_2_device_id_de on compress_hyper_2_10_chunk (actual rows=0 loops=1)
                                  Index Cond: ((device_id = 3) AND (device_id_peer = 3))
-               ->  Custom Scan (DecompressChunk) on _hyper_1_4_chunk (actual rows=0 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_1_7_chunk (actual rows=0 loops=1)
                      ->  Sort (actual rows=0 loops=1)
-                           Sort Key: compress_hyper_2_9_chunk._ts_meta_sequence_num DESC
-                           Sort Method: quicksort 
-                           ->  Index Scan using compress_hyper_2_9_chunk__compressed_hypertable_2_device_id_dev on compress_hyper_2_9_chunk (actual rows=0 loops=1)
-                                 Index Cond: ((device_id = 3) AND (device_id_peer = 3))
-               ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk (actual rows=10 loops=1)
-                     ->  Sort (actual rows=1 loops=1)
                            Sort Key: compress_hyper_2_8_chunk._ts_meta_sequence_num DESC
                            Sort Method: quicksort 
-                           ->  Index Scan using compress_hyper_2_8_chunk__compressed_hypertable_2_device_id_dev on compress_hyper_2_8_chunk (actual rows=1 loops=1)
+                           ->  Index Scan using compress_hyper_2_8_chunk__compressed_hypertable_2_device_id_dev on compress_hyper_2_8_chunk (actual rows=0 loops=1)
                                  Index Cond: ((device_id = 3) AND (device_id_peer = 3))
-               ->  Custom Scan (DecompressChunk) on _hyper_1_2_chunk (never executed)
+               ->  Custom Scan (DecompressChunk) on _hyper_1_5_chunk (actual rows=10 loops=1)
+                     ->  Sort (actual rows=1 loops=1)
+                           Sort Key: compress_hyper_2_6_chunk._ts_meta_sequence_num DESC
+                           Sort Method: quicksort 
+                           ->  Index Scan using compress_hyper_2_6_chunk__compressed_hypertable_2_device_id_dev on compress_hyper_2_6_chunk (actual rows=1 loops=1)
+                                 Index Cond: ((device_id = 3) AND (device_id_peer = 3))
+               ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk (never executed)
                      ->  Sort (never executed)
-                           Sort Key: compress_hyper_2_7_chunk._ts_meta_sequence_num DESC
-                           ->  Index Scan using compress_hyper_2_7_chunk__compressed_hypertable_2_device_id_dev on compress_hyper_2_7_chunk (never executed)
+                           Sort Key: compress_hyper_2_4_chunk._ts_meta_sequence_num DESC
+                           ->  Index Scan using compress_hyper_2_4_chunk__compressed_hypertable_2_device_id_dev on compress_hyper_2_4_chunk (never executed)
                                  Index Cond: ((device_id = 3) AND (device_id_peer = 3))
                ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk (never executed)
                      ->  Sort (never executed)
-                           Sort Key: compress_hyper_2_6_chunk._ts_meta_sequence_num DESC
-                           ->  Index Scan using compress_hyper_2_6_chunk__compressed_hypertable_2_device_id_dev on compress_hyper_2_6_chunk (never executed)
+                           Sort Key: compress_hyper_2_2_chunk._ts_meta_sequence_num DESC
+                           ->  Index Scan using compress_hyper_2_2_chunk__compressed_hypertable_2_device_id_dev on compress_hyper_2_2_chunk (never executed)
                                  Index Cond: ((device_id = 3) AND (device_id_peer = 3))
 (34 rows)
 
@@ -336,20 +336,20 @@ WHERE extract(minute FROM d.time) = 0;
                      ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk d_1 (actual rows=120 loops=1)
                            Filter: (EXTRACT(minute FROM "time") = '0'::numeric)
                            Rows Removed by Filter: 360
-                           ->  Index Scan using compress_hyper_2_6_chunk__compressed_hypertable_2_device_id_dev on compress_hyper_2_6_chunk (actual rows=5 loops=1)
-                     ->  Custom Scan (DecompressChunk) on _hyper_1_2_chunk d_2 (actual rows=240 loops=1)
+                           ->  Index Scan using compress_hyper_2_2_chunk__compressed_hypertable_2_device_id_dev on compress_hyper_2_2_chunk (actual rows=5 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk d_2 (actual rows=240 loops=1)
                            Filter: (EXTRACT(minute FROM "time") = '0'::numeric)
                            Rows Removed by Filter: 720
-                           ->  Index Scan using compress_hyper_2_7_chunk__compressed_hypertable_2_device_id_dev on compress_hyper_2_7_chunk (actual rows=5 loops=1)
-                     ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk d_3 (actual rows=12 loops=1)
+                           ->  Index Scan using compress_hyper_2_4_chunk__compressed_hypertable_2_device_id_dev on compress_hyper_2_4_chunk (actual rows=5 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_1_5_chunk d_3 (actual rows=12 loops=1)
+                           Filter: (EXTRACT(minute FROM "time") = '0'::numeric)
+                           Rows Removed by Filter: 36
+                           ->  Index Scan using compress_hyper_2_6_chunk__compressed_hypertable_2_device_id_dev on compress_hyper_2_6_chunk (actual rows=1 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_1_7_chunk d_4 (actual rows=12 loops=1)
                            Filter: (EXTRACT(minute FROM "time") = '0'::numeric)
                            Rows Removed by Filter: 36
                            ->  Index Scan using compress_hyper_2_8_chunk__compressed_hypertable_2_device_id_dev on compress_hyper_2_8_chunk (actual rows=1 loops=1)
-                     ->  Custom Scan (DecompressChunk) on _hyper_1_4_chunk d_4 (actual rows=12 loops=1)
-                           Filter: (EXTRACT(minute FROM "time") = '0'::numeric)
-                           Rows Removed by Filter: 36
-                           ->  Index Scan using compress_hyper_2_9_chunk__compressed_hypertable_2_device_id_dev on compress_hyper_2_9_chunk (actual rows=1 loops=1)
-                     ->  Custom Scan (DecompressChunk) on _hyper_1_5_chunk d_5 (actual rows=5 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_1_9_chunk d_5 (actual rows=5 loops=1)
                            Filter: (EXTRACT(minute FROM "time") = '0'::numeric)
                            ->  Index Scan using compress_hyper_2_10_chunk__compressed_hypertable_2_device_id_de on compress_hyper_2_10_chunk (actual rows=5 loops=1)
          ->  Subquery Scan on m (actual rows=0 loops=389)
@@ -359,20 +359,20 @@ WHERE extract(minute FROM d.time) = 0;
                      ->  Custom Scan (ChunkAppend) on metrics_ordered_idx m_1 (actual rows=0 loops=389)
                            Order: m_1."time" DESC
                            Hypertables excluded during runtime: 0
-                           ->  Custom Scan (DecompressChunk) on _hyper_1_5_chunk m_2 (actual rows=0 loops=388)
+                           ->  Custom Scan (DecompressChunk) on _hyper_1_9_chunk m_2 (actual rows=0 loops=388)
                                  ->  Index Scan Backward using compress_hyper_2_10_chunk__compressed_hypertable_2_device_id_de on compress_hyper_2_10_chunk compress_hyper_2_10_chunk_1 (actual rows=0 loops=388)
                                        Index Cond: ((device_id = d.device_id) AND (device_id_peer = 3))
-                           ->  Custom Scan (DecompressChunk) on _hyper_1_4_chunk m_3 (actual rows=0 loops=388)
-                                 ->  Index Scan Backward using compress_hyper_2_9_chunk__compressed_hypertable_2_device_id_dev on compress_hyper_2_9_chunk compress_hyper_2_9_chunk_1 (actual rows=0 loops=388)
-                                       Index Cond: ((device_id = d.device_id) AND (device_id_peer = 3))
-                           ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk m_4 (actual rows=0 loops=388)
+                           ->  Custom Scan (DecompressChunk) on _hyper_1_7_chunk m_3 (actual rows=0 loops=388)
                                  ->  Index Scan Backward using compress_hyper_2_8_chunk__compressed_hypertable_2_device_id_dev on compress_hyper_2_8_chunk compress_hyper_2_8_chunk_1 (actual rows=0 loops=388)
                                        Index Cond: ((device_id = d.device_id) AND (device_id_peer = 3))
-                           ->  Custom Scan (DecompressChunk) on _hyper_1_2_chunk m_5 (actual rows=0 loops=304)
-                                 ->  Index Scan Backward using compress_hyper_2_7_chunk__compressed_hypertable_2_device_id_dev on compress_hyper_2_7_chunk compress_hyper_2_7_chunk_1 (actual rows=0 loops=304)
+                           ->  Custom Scan (DecompressChunk) on _hyper_1_5_chunk m_4 (actual rows=0 loops=388)
+                                 ->  Index Scan Backward using compress_hyper_2_6_chunk__compressed_hypertable_2_device_id_dev on compress_hyper_2_6_chunk compress_hyper_2_6_chunk_1 (actual rows=0 loops=388)
+                                       Index Cond: ((device_id = d.device_id) AND (device_id_peer = 3))
+                           ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk m_5 (actual rows=0 loops=304)
+                                 ->  Index Scan Backward using compress_hyper_2_4_chunk__compressed_hypertable_2_device_id_dev on compress_hyper_2_4_chunk compress_hyper_2_4_chunk_1 (actual rows=0 loops=304)
                                        Index Cond: ((device_id = d.device_id) AND (device_id_peer = 3))
                            ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk m_6 (actual rows=0 loops=304)
-                                 ->  Index Scan Backward using compress_hyper_2_6_chunk__compressed_hypertable_2_device_id_dev on compress_hyper_2_6_chunk compress_hyper_2_6_chunk_1 (actual rows=0 loops=304)
+                                 ->  Index Scan Backward using compress_hyper_2_2_chunk__compressed_hypertable_2_device_id_dev on compress_hyper_2_2_chunk compress_hyper_2_2_chunk_1 (actual rows=0 loops=304)
                                        Index Cond: ((device_id = d.device_id) AND (device_id_peer = 3))
 (48 rows)
 
@@ -397,20 +397,20 @@ WHERE extract(minute FROM d.time) = 0;
          ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk d_1 (actual rows=120 loops=1)
                Filter: (EXTRACT(minute FROM "time") = '0'::numeric)
                Rows Removed by Filter: 360
-               ->  Seq Scan on compress_hyper_2_6_chunk (actual rows=5 loops=1)
-         ->  Custom Scan (DecompressChunk) on _hyper_1_2_chunk d_2 (actual rows=240 loops=1)
+               ->  Seq Scan on compress_hyper_2_2_chunk (actual rows=5 loops=1)
+         ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk d_2 (actual rows=240 loops=1)
                Filter: (EXTRACT(minute FROM "time") = '0'::numeric)
                Rows Removed by Filter: 720
-               ->  Seq Scan on compress_hyper_2_7_chunk (actual rows=5 loops=1)
-         ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk d_3 (actual rows=12 loops=1)
+               ->  Seq Scan on compress_hyper_2_4_chunk (actual rows=5 loops=1)
+         ->  Custom Scan (DecompressChunk) on _hyper_1_5_chunk d_3 (actual rows=12 loops=1)
+               Filter: (EXTRACT(minute FROM "time") = '0'::numeric)
+               Rows Removed by Filter: 36
+               ->  Seq Scan on compress_hyper_2_6_chunk (actual rows=1 loops=1)
+         ->  Custom Scan (DecompressChunk) on _hyper_1_7_chunk d_4 (actual rows=12 loops=1)
                Filter: (EXTRACT(minute FROM "time") = '0'::numeric)
                Rows Removed by Filter: 36
                ->  Seq Scan on compress_hyper_2_8_chunk (actual rows=1 loops=1)
-         ->  Custom Scan (DecompressChunk) on _hyper_1_4_chunk d_4 (actual rows=12 loops=1)
-               Filter: (EXTRACT(minute FROM "time") = '0'::numeric)
-               Rows Removed by Filter: 36
-               ->  Seq Scan on compress_hyper_2_9_chunk (actual rows=1 loops=1)
-         ->  Custom Scan (DecompressChunk) on _hyper_1_5_chunk d_5 (actual rows=5 loops=1)
+         ->  Custom Scan (DecompressChunk) on _hyper_1_9_chunk d_5 (actual rows=5 loops=1)
                Filter: (EXTRACT(minute FROM "time") = '0'::numeric)
                ->  Seq Scan on compress_hyper_2_10_chunk (actual rows=5 loops=1)
    ->  Subquery Scan on m (actual rows=0 loops=389)
@@ -421,20 +421,20 @@ WHERE extract(minute FROM d.time) = 0;
                      ->  Custom Scan (ChunkAppend) on metrics_ordered_idx m_1 (actual rows=0 loops=389)
                            Order: m_1."time" DESC
                            Hypertables excluded during runtime: 0
-                           ->  Custom Scan (DecompressChunk) on _hyper_1_5_chunk m_2 (actual rows=0 loops=388)
+                           ->  Custom Scan (DecompressChunk) on _hyper_1_9_chunk m_2 (actual rows=0 loops=388)
                                  ->  Index Scan Backward using compress_hyper_2_10_chunk__compressed_hypertable_2_device_id_de on compress_hyper_2_10_chunk compress_hyper_2_10_chunk_1 (actual rows=0 loops=388)
                                        Index Cond: ((device_id = d.device_id) AND (device_id_peer = 3))
-                           ->  Custom Scan (DecompressChunk) on _hyper_1_4_chunk m_3 (actual rows=0 loops=388)
-                                 ->  Index Scan Backward using compress_hyper_2_9_chunk__compressed_hypertable_2_device_id_dev on compress_hyper_2_9_chunk compress_hyper_2_9_chunk_1 (actual rows=0 loops=388)
-                                       Index Cond: ((device_id = d.device_id) AND (device_id_peer = 3))
-                           ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk m_4 (actual rows=0 loops=388)
+                           ->  Custom Scan (DecompressChunk) on _hyper_1_7_chunk m_3 (actual rows=0 loops=388)
                                  ->  Index Scan Backward using compress_hyper_2_8_chunk__compressed_hypertable_2_device_id_dev on compress_hyper_2_8_chunk compress_hyper_2_8_chunk_1 (actual rows=0 loops=388)
                                        Index Cond: ((device_id = d.device_id) AND (device_id_peer = 3))
-                           ->  Custom Scan (DecompressChunk) on _hyper_1_2_chunk m_5 (actual rows=0 loops=304)
-                                 ->  Index Scan Backward using compress_hyper_2_7_chunk__compressed_hypertable_2_device_id_dev on compress_hyper_2_7_chunk compress_hyper_2_7_chunk_1 (actual rows=0 loops=304)
+                           ->  Custom Scan (DecompressChunk) on _hyper_1_5_chunk m_4 (actual rows=0 loops=388)
+                                 ->  Index Scan Backward using compress_hyper_2_6_chunk__compressed_hypertable_2_device_id_dev on compress_hyper_2_6_chunk compress_hyper_2_6_chunk_1 (actual rows=0 loops=388)
+                                       Index Cond: ((device_id = d.device_id) AND (device_id_peer = 3))
+                           ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk m_5 (actual rows=0 loops=304)
+                                 ->  Index Scan Backward using compress_hyper_2_4_chunk__compressed_hypertable_2_device_id_dev on compress_hyper_2_4_chunk compress_hyper_2_4_chunk_1 (actual rows=0 loops=304)
                                        Index Cond: ((device_id = d.device_id) AND (device_id_peer = 3))
                            ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk m_6 (actual rows=0 loops=304)
-                                 ->  Index Scan Backward using compress_hyper_2_6_chunk__compressed_hypertable_2_device_id_dev on compress_hyper_2_6_chunk compress_hyper_2_6_chunk_1 (actual rows=0 loops=304)
+                                 ->  Index Scan Backward using compress_hyper_2_2_chunk__compressed_hypertable_2_device_id_dev on compress_hyper_2_2_chunk compress_hyper_2_2_chunk_1 (actual rows=0 loops=304)
                                        Index Cond: ((device_id = d.device_id) AND (device_id_peer = 3))
 (45 rows)
 
@@ -465,14 +465,14 @@ GROUP BY device_id;
          ->  Merge Append (actual rows=1541 loops=1)
                Sort Key: mt_1.device_id
                ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk mt_1 (actual rows=480 loops=1)
-                     ->  Index Scan using compress_hyper_2_6_chunk__compressed_hypertable_2_device_id_dev on compress_hyper_2_6_chunk (actual rows=5 loops=1)
-               ->  Custom Scan (DecompressChunk) on _hyper_1_2_chunk mt_2 (actual rows=960 loops=1)
-                     ->  Index Scan using compress_hyper_2_7_chunk__compressed_hypertable_2_device_id_dev on compress_hyper_2_7_chunk (actual rows=5 loops=1)
-               ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk mt_3 (actual rows=48 loops=1)
+                     ->  Index Scan using compress_hyper_2_2_chunk__compressed_hypertable_2_device_id_dev on compress_hyper_2_2_chunk (actual rows=5 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk mt_2 (actual rows=960 loops=1)
+                     ->  Index Scan using compress_hyper_2_4_chunk__compressed_hypertable_2_device_id_dev on compress_hyper_2_4_chunk (actual rows=5 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_1_5_chunk mt_3 (actual rows=48 loops=1)
+                     ->  Index Scan using compress_hyper_2_6_chunk__compressed_hypertable_2_device_id_dev on compress_hyper_2_6_chunk (actual rows=1 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_1_7_chunk mt_4 (actual rows=48 loops=1)
                      ->  Index Scan using compress_hyper_2_8_chunk__compressed_hypertable_2_device_id_dev on compress_hyper_2_8_chunk (actual rows=1 loops=1)
-               ->  Custom Scan (DecompressChunk) on _hyper_1_4_chunk mt_4 (actual rows=48 loops=1)
-                     ->  Index Scan using compress_hyper_2_9_chunk__compressed_hypertable_2_device_id_dev on compress_hyper_2_9_chunk (actual rows=1 loops=1)
-               ->  Custom Scan (DecompressChunk) on _hyper_1_5_chunk mt_5 (actual rows=5 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_1_9_chunk mt_5 (actual rows=5 loops=1)
                      ->  Index Scan using compress_hyper_2_10_chunk__compressed_hypertable_2_device_id_de on compress_hyper_2_10_chunk (actual rows=5 loops=1)
          ->  Materialize (actual rows=1 loops=1541)
                ->  Seq Scan on nodetime nd (actual rows=1 loops=1)
@@ -496,25 +496,25 @@ ORDER BY time;
          Order: mt."time"
          ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk mt_1 (actual rows=480 loops=1)
                ->  Sort (actual rows=5 loops=1)
+                     Sort Key: compress_hyper_2_2_chunk._ts_meta_min_1
+                     Sort Method: quicksort 
+                     ->  Index Scan using compress_hyper_2_2_chunk__compressed_hypertable_2_device_id_dev on compress_hyper_2_2_chunk (actual rows=5 loops=1)
+         ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk mt_2 (actual rows=960 loops=1)
+               ->  Sort (actual rows=5 loops=1)
+                     Sort Key: compress_hyper_2_4_chunk._ts_meta_min_1
+                     Sort Method: quicksort 
+                     ->  Index Scan using compress_hyper_2_4_chunk__compressed_hypertable_2_device_id_dev on compress_hyper_2_4_chunk (actual rows=5 loops=1)
+         ->  Custom Scan (DecompressChunk) on _hyper_1_5_chunk mt_3 (actual rows=48 loops=1)
+               ->  Sort (actual rows=1 loops=1)
                      Sort Key: compress_hyper_2_6_chunk._ts_meta_min_1
                      Sort Method: quicksort 
-                     ->  Index Scan using compress_hyper_2_6_chunk__compressed_hypertable_2_device_id_dev on compress_hyper_2_6_chunk (actual rows=5 loops=1)
-         ->  Custom Scan (DecompressChunk) on _hyper_1_2_chunk mt_2 (actual rows=960 loops=1)
-               ->  Sort (actual rows=5 loops=1)
-                     Sort Key: compress_hyper_2_7_chunk._ts_meta_min_1
-                     Sort Method: quicksort 
-                     ->  Index Scan using compress_hyper_2_7_chunk__compressed_hypertable_2_device_id_dev on compress_hyper_2_7_chunk (actual rows=5 loops=1)
-         ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk mt_3 (actual rows=48 loops=1)
+                     ->  Index Scan using compress_hyper_2_6_chunk__compressed_hypertable_2_device_id_dev on compress_hyper_2_6_chunk (actual rows=1 loops=1)
+         ->  Custom Scan (DecompressChunk) on _hyper_1_7_chunk mt_4 (actual rows=48 loops=1)
                ->  Sort (actual rows=1 loops=1)
                      Sort Key: compress_hyper_2_8_chunk._ts_meta_min_1
                      Sort Method: quicksort 
                      ->  Index Scan using compress_hyper_2_8_chunk__compressed_hypertable_2_device_id_dev on compress_hyper_2_8_chunk (actual rows=1 loops=1)
-         ->  Custom Scan (DecompressChunk) on _hyper_1_4_chunk mt_4 (actual rows=48 loops=1)
-               ->  Sort (actual rows=1 loops=1)
-                     Sort Key: compress_hyper_2_9_chunk._ts_meta_min_1
-                     Sort Method: quicksort 
-                     ->  Index Scan using compress_hyper_2_9_chunk__compressed_hypertable_2_device_id_dev on compress_hyper_2_9_chunk (actual rows=1 loops=1)
-         ->  Custom Scan (DecompressChunk) on _hyper_1_5_chunk mt_5 (actual rows=5 loops=1)
+         ->  Custom Scan (DecompressChunk) on _hyper_1_9_chunk mt_5 (actual rows=5 loops=1)
                ->  Sort (actual rows=5 loops=1)
                      Sort Key: compress_hyper_2_10_chunk._ts_meta_min_1
                      Sort Method: quicksort 
@@ -559,25 +559,25 @@ ORDER BY time;
                      Order: mt."time"
                      ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk mt_1 (actual rows=480 loops=1)
                            ->  Sort (actual rows=5 loops=1)
+                                 Sort Key: compress_hyper_2_2_chunk._ts_meta_min_1
+                                 Sort Method: quicksort 
+                                 ->  Seq Scan on compress_hyper_2_2_chunk (actual rows=5 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk mt_2 (actual rows=960 loops=1)
+                           ->  Sort (actual rows=5 loops=1)
+                                 Sort Key: compress_hyper_2_4_chunk._ts_meta_min_1
+                                 Sort Method: quicksort 
+                                 ->  Seq Scan on compress_hyper_2_4_chunk (actual rows=5 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_1_5_chunk mt_3 (actual rows=48 loops=1)
+                           ->  Sort (actual rows=1 loops=1)
                                  Sort Key: compress_hyper_2_6_chunk._ts_meta_min_1
                                  Sort Method: quicksort 
-                                 ->  Seq Scan on compress_hyper_2_6_chunk (actual rows=5 loops=1)
-                     ->  Custom Scan (DecompressChunk) on _hyper_1_2_chunk mt_2 (actual rows=960 loops=1)
-                           ->  Sort (actual rows=5 loops=1)
-                                 Sort Key: compress_hyper_2_7_chunk._ts_meta_min_1
-                                 Sort Method: quicksort 
-                                 ->  Seq Scan on compress_hyper_2_7_chunk (actual rows=5 loops=1)
-                     ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk mt_3 (actual rows=48 loops=1)
+                                 ->  Seq Scan on compress_hyper_2_6_chunk (actual rows=1 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_1_7_chunk mt_4 (actual rows=48 loops=1)
                            ->  Sort (actual rows=1 loops=1)
                                  Sort Key: compress_hyper_2_8_chunk._ts_meta_min_1
                                  Sort Method: quicksort 
                                  ->  Seq Scan on compress_hyper_2_8_chunk (actual rows=1 loops=1)
-                     ->  Custom Scan (DecompressChunk) on _hyper_1_4_chunk mt_4 (actual rows=48 loops=1)
-                           ->  Sort (actual rows=1 loops=1)
-                                 Sort Key: compress_hyper_2_9_chunk._ts_meta_min_1
-                                 Sort Method: quicksort 
-                                 ->  Seq Scan on compress_hyper_2_9_chunk (actual rows=1 loops=1)
-                     ->  Custom Scan (DecompressChunk) on _hyper_1_5_chunk mt_5 (actual rows=5 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_1_9_chunk mt_5 (actual rows=5 loops=1)
                            ->  Sort (actual rows=5 loops=1)
                                  Sort Key: compress_hyper_2_10_chunk._ts_meta_min_1
                                  Sort Method: quicksort 
@@ -606,14 +606,14 @@ ORDER BY time;
          Rows Removed by Join Filter: 289
          ->  Append (actual rows=1541 loops=1)
                ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk mt_1 (actual rows=480 loops=1)
-                     ->  Seq Scan on compress_hyper_2_6_chunk (actual rows=5 loops=1)
-               ->  Custom Scan (DecompressChunk) on _hyper_1_2_chunk mt_2 (actual rows=960 loops=1)
-                     ->  Seq Scan on compress_hyper_2_7_chunk (actual rows=5 loops=1)
-               ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk mt_3 (actual rows=48 loops=1)
+                     ->  Seq Scan on compress_hyper_2_2_chunk (actual rows=5 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk mt_2 (actual rows=960 loops=1)
+                     ->  Seq Scan on compress_hyper_2_4_chunk (actual rows=5 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_1_5_chunk mt_3 (actual rows=48 loops=1)
+                     ->  Seq Scan on compress_hyper_2_6_chunk (actual rows=1 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_1_7_chunk mt_4 (actual rows=48 loops=1)
                      ->  Seq Scan on compress_hyper_2_8_chunk (actual rows=1 loops=1)
-               ->  Custom Scan (DecompressChunk) on _hyper_1_4_chunk mt_4 (actual rows=48 loops=1)
-                     ->  Seq Scan on compress_hyper_2_9_chunk (actual rows=1 loops=1)
-               ->  Custom Scan (DecompressChunk) on _hyper_1_5_chunk mt_5 (actual rows=5 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_1_9_chunk mt_5 (actual rows=5 loops=1)
                      ->  Seq Scan on compress_hyper_2_10_chunk (actual rows=5 loops=1)
          ->  Hash (actual rows=1 loops=1)
                Buckets: 2048  Batches: 1 
@@ -643,10 +643,10 @@ WHERE met.time > '2000-01-19 19:00:00-05'
 ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Nested Loop (actual rows=2 loops=1)
    ->  Values Scan on "*VALUES*" (actual rows=2 loops=1)
-   ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk met (actual rows=1 loops=2)
+   ->  Custom Scan (DecompressChunk) on _hyper_1_5_chunk met (actual rows=1 loops=2)
          Filter: (("time" > 'Wed Jan 19 16:00:00 2000 PST'::timestamp with time zone) AND ("time" < 'Thu Jan 20 17:00:00 2000 PST'::timestamp with time zone) AND ("*VALUES*".column2 = v0))
          Rows Removed by Filter: 47
-         ->  Index Scan using compress_hyper_2_8_chunk__compressed_hypertable_2_device_id_dev on compress_hyper_2_8_chunk (actual rows=1 loops=2)
+         ->  Index Scan using compress_hyper_2_6_chunk__compressed_hypertable_2_device_id_dev on compress_hyper_2_6_chunk (actual rows=1 loops=2)
                Index Cond: (device_id = "*VALUES*".column1)
                Filter: ((_ts_meta_max_1 > 'Wed Jan 19 16:00:00 2000 PST'::timestamp with time zone) AND (_ts_meta_min_1 < 'Thu Jan 20 17:00:00 2000 PST'::timestamp with time zone))
 (8 rows)
@@ -666,10 +666,10 @@ WHERE met.time > '2000-01-19 19:00:00-05'
    ->  Values Scan on "*VALUES*" (actual rows=1 loops=1)
          Filter: ((column1 = 3) AND (column2 = 5))
          Rows Removed by Filter: 1
-   ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk met (actual rows=1 loops=1)
+   ->  Custom Scan (DecompressChunk) on _hyper_1_5_chunk met (actual rows=1 loops=1)
          Filter: (("time" > 'Wed Jan 19 16:00:00 2000 PST'::timestamp with time zone) AND ("time" < 'Thu Jan 20 17:00:00 2000 PST'::timestamp with time zone) AND (v0 = 5))
          Rows Removed by Filter: 47
-         ->  Index Scan using compress_hyper_2_8_chunk__compressed_hypertable_2_device_id_dev on compress_hyper_2_8_chunk (actual rows=1 loops=1)
+         ->  Index Scan using compress_hyper_2_6_chunk__compressed_hypertable_2_device_id_dev on compress_hyper_2_6_chunk (actual rows=1 loops=1)
                Index Cond: (device_id = 3)
                Filter: ((_ts_meta_max_1 > 'Wed Jan 19 16:00:00 2000 PST'::timestamp with time zone) AND (_ts_meta_min_1 < 'Thu Jan 20 17:00:00 2000 PST'::timestamp with time zone))
 (10 rows)
@@ -688,10 +688,10 @@ WHERE met.time = '2000-01-19 19:00:00-05'
    ->  Values Scan on "*VALUES*" (actual rows=1 loops=1)
          Filter: ((column1 = 3) AND (column2 = 5))
          Rows Removed by Filter: 1
-   ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk met (actual rows=0 loops=1)
+   ->  Custom Scan (DecompressChunk) on _hyper_1_5_chunk met (actual rows=0 loops=1)
          Filter: ((v0 = 5) AND ("time" = 'Wed Jan 19 16:00:00 2000 PST'::timestamp with time zone))
          Rows Removed by Filter: 48
-         ->  Index Scan using compress_hyper_2_8_chunk__compressed_hypertable_2_device_id_dev on compress_hyper_2_8_chunk (actual rows=1 loops=1)
+         ->  Index Scan using compress_hyper_2_6_chunk__compressed_hypertable_2_device_id_dev on compress_hyper_2_6_chunk (actual rows=1 loops=1)
                Index Cond: ((device_id = 3) AND (device_id_peer = 3))
                Filter: ((_ts_meta_min_1 <= 'Wed Jan 19 16:00:00 2000 PST'::timestamp with time zone) AND (_ts_meta_max_1 >= 'Wed Jan 19 16:00:00 2000 PST'::timestamp with time zone))
 (10 rows)
@@ -714,10 +714,10 @@ ON met.device_id = q.node and met.device_id_peer = q.device_id_peer
          Rows Removed by Join Filter: 1
          ->  Seq Scan on nodetime (actual rows=1 loops=1)
          ->  Values Scan on "*VALUES*" (actual rows=2 loops=1)
-   ->  Custom Scan (DecompressChunk) on _hyper_1_4_chunk met (actual rows=1 loops=1)
+   ->  Custom Scan (DecompressChunk) on _hyper_1_7_chunk met (actual rows=1 loops=1)
          Filter: ((v0 > 2) AND ("time" = 'Fri Jan 19 17:00:00 2018 PST'::timestamp with time zone) AND ("*VALUES*".column3 = v0))
          Rows Removed by Filter: 47
-         ->  Index Scan using compress_hyper_2_9_chunk__compressed_hypertable_2_device_id_dev on compress_hyper_2_9_chunk (actual rows=1 loops=1)
+         ->  Index Scan using compress_hyper_2_8_chunk__compressed_hypertable_2_device_id_dev on compress_hyper_2_8_chunk (actual rows=1 loops=1)
                Index Cond: ((device_id = "*VALUES*".column1) AND (device_id_peer = "*VALUES*".column2))
                Filter: ((_ts_meta_min_1 <= 'Fri Jan 19 17:00:00 2018 PST'::timestamp with time zone) AND (_ts_meta_max_1 >= 'Fri Jan 19 17:00:00 2018 PST'::timestamp with time zone))
 (13 rows)
@@ -742,10 +742,10 @@ WHERE met.time > '2000-01-19 19:00:00-05'
    ->  Values Scan on "*VALUES*" (actual rows=1 loops=1)
          Filter: ((column1 = 3) AND (column2 = 5))
          Rows Removed by Filter: 1
-   ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk met (actual rows=1 loops=1)
+   ->  Custom Scan (DecompressChunk) on _hyper_1_5_chunk met (actual rows=1 loops=1)
          Filter: (("time" > 'Wed Jan 19 16:00:00 2000 PST'::timestamp with time zone) AND ("time" < 'Thu Jan 20 17:00:00 2000 PST'::timestamp with time zone) AND (v0 = 5))
          Rows Removed by Filter: 47
-         ->  Seq Scan on compress_hyper_2_8_chunk (actual rows=1 loops=1)
+         ->  Seq Scan on compress_hyper_2_6_chunk (actual rows=1 loops=1)
                Filter: ((_ts_meta_max_1 > 'Wed Jan 19 16:00:00 2000 PST'::timestamp with time zone) AND (_ts_meta_min_1 < 'Thu Jan 20 17:00:00 2000 PST'::timestamp with time zone) AND (device_id = 3) AND (device_id_peer = 3))
 (9 rows)
 
@@ -785,15 +785,15 @@ ORDER BY 1,
                Hypertable: metrics_ordered_idx
                Chunks excluded during startup: 0
                ->  Merge Append (actual rows=10 loops=1)
-                     Sort Key: _hyper_1_4_chunk."time" DESC
-                     ->  Custom Scan (DecompressChunk) on _hyper_1_4_chunk (actual rows=5 loops=1)
+                     Sort Key: _hyper_1_7_chunk."time" DESC
+                     ->  Custom Scan (DecompressChunk) on _hyper_1_7_chunk (actual rows=5 loops=1)
                            Filter: (("time" > 'Tue Jan 01 00:00:00 2002 PST'::timestamp with time zone) AND ("time" < now()))
                            ->  Sort (actual rows=1 loops=1)
-                                 Sort Key: compress_hyper_2_9_chunk._ts_meta_max_1 DESC
+                                 Sort Key: compress_hyper_2_8_chunk._ts_meta_max_1 DESC
                                  Sort Method: quicksort 
-                                 ->  Seq Scan on compress_hyper_2_9_chunk (actual rows=1 loops=1)
+                                 ->  Seq Scan on compress_hyper_2_8_chunk (actual rows=1 loops=1)
                                        Filter: (_ts_meta_max_1 > 'Tue Jan 01 00:00:00 2002 PST'::timestamp with time zone)
-                     ->  Custom Scan (DecompressChunk) on _hyper_1_5_chunk (actual rows=5 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_1_9_chunk (actual rows=5 loops=1)
                            Filter: (("time" > 'Tue Jan 01 00:00:00 2002 PST'::timestamp with time zone) AND ("time" < now()))
                            ->  Sort (actual rows=5 loops=1)
                                  Sort Key: compress_hyper_2_10_chunk._ts_meta_max_1 DESC
@@ -828,15 +828,15 @@ ORDER BY 1,
                Hypertable: metrics_ordered_idx
                Chunks excluded during startup: 0
                ->  Merge Append (actual rows=10 loops=1)
-                     Sort Key: _hyper_1_4_chunk."time" DESC
-                     ->  Custom Scan (DecompressChunk) on _hyper_1_4_chunk (actual rows=9 loops=1)
+                     Sort Key: _hyper_1_7_chunk."time" DESC
+                     ->  Custom Scan (DecompressChunk) on _hyper_1_7_chunk (actual rows=9 loops=1)
                            Filter: (("time" > 'Tue Jan 01 00:00:00 2002 PST'::timestamp with time zone) AND ("time" < now()))
                            ->  Sort (actual rows=1 loops=1)
-                                 Sort Key: compress_hyper_2_9_chunk._ts_meta_sequence_num DESC
+                                 Sort Key: compress_hyper_2_8_chunk._ts_meta_sequence_num DESC
                                  Sort Method: quicksort 
-                                 ->  Seq Scan on compress_hyper_2_9_chunk (actual rows=1 loops=1)
+                                 ->  Seq Scan on compress_hyper_2_8_chunk (actual rows=1 loops=1)
                                        Filter: ((_ts_meta_max_1 > 'Tue Jan 01 00:00:00 2002 PST'::timestamp with time zone) AND (device_id = 4) AND (device_id_peer = 5))
-                     ->  Custom Scan (DecompressChunk) on _hyper_1_5_chunk (actual rows=1 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_1_9_chunk (actual rows=1 loops=1)
                            Filter: (("time" > 'Tue Jan 01 00:00:00 2002 PST'::timestamp with time zone) AND ("time" < now()))
                            ->  Sort (actual rows=1 loops=1)
                                  Sort Key: compress_hyper_2_10_chunk._ts_meta_sequence_num DESC
@@ -915,21 +915,21 @@ ORDER BY 1,
                            ->  Append (actual rows=1541 loops=1)
                                  ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk d_1 (actual rows=480 loops=1)
                                        Filter: ("time" > ('2000-01-01 0:00:00+0'::cstring)::timestamp with time zone)
-                                       ->  Seq Scan on compress_hyper_2_6_chunk (actual rows=5 loops=1)
+                                       ->  Seq Scan on compress_hyper_2_2_chunk (actual rows=5 loops=1)
                                              Filter: (_ts_meta_max_1 > ('2000-01-01 0:00:00+0'::cstring)::timestamp with time zone)
-                                 ->  Custom Scan (DecompressChunk) on _hyper_1_2_chunk d_2 (actual rows=960 loops=1)
+                                 ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk d_2 (actual rows=960 loops=1)
                                        Filter: ("time" > ('2000-01-01 0:00:00+0'::cstring)::timestamp with time zone)
-                                       ->  Seq Scan on compress_hyper_2_7_chunk (actual rows=5 loops=1)
+                                       ->  Seq Scan on compress_hyper_2_4_chunk (actual rows=5 loops=1)
                                              Filter: (_ts_meta_max_1 > ('2000-01-01 0:00:00+0'::cstring)::timestamp with time zone)
-                                 ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk d_3 (actual rows=48 loops=1)
+                                 ->  Custom Scan (DecompressChunk) on _hyper_1_5_chunk d_3 (actual rows=48 loops=1)
+                                       Filter: ("time" > ('2000-01-01 0:00:00+0'::cstring)::timestamp with time zone)
+                                       ->  Seq Scan on compress_hyper_2_6_chunk (actual rows=1 loops=1)
+                                             Filter: (_ts_meta_max_1 > ('2000-01-01 0:00:00+0'::cstring)::timestamp with time zone)
+                                 ->  Custom Scan (DecompressChunk) on _hyper_1_7_chunk d_4 (actual rows=48 loops=1)
                                        Filter: ("time" > ('2000-01-01 0:00:00+0'::cstring)::timestamp with time zone)
                                        ->  Seq Scan on compress_hyper_2_8_chunk (actual rows=1 loops=1)
                                              Filter: (_ts_meta_max_1 > ('2000-01-01 0:00:00+0'::cstring)::timestamp with time zone)
-                                 ->  Custom Scan (DecompressChunk) on _hyper_1_4_chunk d_4 (actual rows=48 loops=1)
-                                       Filter: ("time" > ('2000-01-01 0:00:00+0'::cstring)::timestamp with time zone)
-                                       ->  Seq Scan on compress_hyper_2_9_chunk (actual rows=1 loops=1)
-                                             Filter: (_ts_meta_max_1 > ('2000-01-01 0:00:00+0'::cstring)::timestamp with time zone)
-                                 ->  Custom Scan (DecompressChunk) on _hyper_1_5_chunk d_5 (actual rows=5 loops=1)
+                                 ->  Custom Scan (DecompressChunk) on _hyper_1_9_chunk d_5 (actual rows=5 loops=1)
                                        Filter: ("time" > ('2000-01-01 0:00:00+0'::cstring)::timestamp with time zone)
                                        ->  Seq Scan on compress_hyper_2_10_chunk (actual rows=5 loops=1)
                                              Filter: (_ts_meta_max_1 > ('2000-01-01 0:00:00+0'::cstring)::timestamp with time zone)
@@ -942,21 +942,21 @@ ORDER BY 1,
                            ->  Append (actual rows=1541 loops=1)
                                  ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk m_1 (actual rows=480 loops=1)
                                        Filter: ("time" > ('2000-01-01 0:00:00+0'::cstring)::timestamp with time zone)
-                                       ->  Seq Scan on compress_hyper_2_6_chunk compress_hyper_2_6_chunk_1 (actual rows=5 loops=1)
+                                       ->  Seq Scan on compress_hyper_2_2_chunk compress_hyper_2_2_chunk_1 (actual rows=5 loops=1)
                                              Filter: (_ts_meta_max_1 > ('2000-01-01 0:00:00+0'::cstring)::timestamp with time zone)
-                                 ->  Custom Scan (DecompressChunk) on _hyper_1_2_chunk m_2 (actual rows=960 loops=1)
+                                 ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk m_2 (actual rows=960 loops=1)
                                        Filter: ("time" > ('2000-01-01 0:00:00+0'::cstring)::timestamp with time zone)
-                                       ->  Seq Scan on compress_hyper_2_7_chunk compress_hyper_2_7_chunk_1 (actual rows=5 loops=1)
+                                       ->  Seq Scan on compress_hyper_2_4_chunk compress_hyper_2_4_chunk_1 (actual rows=5 loops=1)
                                              Filter: (_ts_meta_max_1 > ('2000-01-01 0:00:00+0'::cstring)::timestamp with time zone)
-                                 ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk m_3 (actual rows=48 loops=1)
+                                 ->  Custom Scan (DecompressChunk) on _hyper_1_5_chunk m_3 (actual rows=48 loops=1)
+                                       Filter: ("time" > ('2000-01-01 0:00:00+0'::cstring)::timestamp with time zone)
+                                       ->  Seq Scan on compress_hyper_2_6_chunk compress_hyper_2_6_chunk_1 (actual rows=1 loops=1)
+                                             Filter: (_ts_meta_max_1 > ('2000-01-01 0:00:00+0'::cstring)::timestamp with time zone)
+                                 ->  Custom Scan (DecompressChunk) on _hyper_1_7_chunk m_4 (actual rows=48 loops=1)
                                        Filter: ("time" > ('2000-01-01 0:00:00+0'::cstring)::timestamp with time zone)
                                        ->  Seq Scan on compress_hyper_2_8_chunk compress_hyper_2_8_chunk_1 (actual rows=1 loops=1)
                                              Filter: (_ts_meta_max_1 > ('2000-01-01 0:00:00+0'::cstring)::timestamp with time zone)
-                                 ->  Custom Scan (DecompressChunk) on _hyper_1_4_chunk m_4 (actual rows=48 loops=1)
-                                       Filter: ("time" > ('2000-01-01 0:00:00+0'::cstring)::timestamp with time zone)
-                                       ->  Seq Scan on compress_hyper_2_9_chunk compress_hyper_2_9_chunk_1 (actual rows=1 loops=1)
-                                             Filter: (_ts_meta_max_1 > ('2000-01-01 0:00:00+0'::cstring)::timestamp with time zone)
-                                 ->  Custom Scan (DecompressChunk) on _hyper_1_5_chunk m_5 (actual rows=5 loops=1)
+                                 ->  Custom Scan (DecompressChunk) on _hyper_1_9_chunk m_5 (actual rows=5 loops=1)
                                        Filter: ("time" > ('2000-01-01 0:00:00+0'::cstring)::timestamp with time zone)
                                        ->  Seq Scan on compress_hyper_2_10_chunk compress_hyper_2_10_chunk_1 (actual rows=5 loops=1)
                                              Filter: (_ts_meta_max_1 > ('2000-01-01 0:00:00+0'::cstring)::timestamp with time zone)
@@ -979,7 +979,7 @@ ORDER BY m.v0;
    Sort Method: quicksort 
    ->  Hash Join (actual rows=0 loops=1)
          Hash Cond: (m.device_id = d.device_id)
-         ->  Custom Scan (DecompressChunk) on _hyper_1_5_chunk m (actual rows=0 loops=1)
+         ->  Custom Scan (DecompressChunk) on _hyper_1_9_chunk m (actual rows=0 loops=1)
                Filter: (("time" > 'Tue Jan 01 00:00:00 2019 PST'::timestamp with time zone) AND ("time" < ('2000-01-01 0:00:00+0'::cstring)::timestamp with time zone))
                ->  Seq Scan on compress_hyper_2_10_chunk (actual rows=0 loops=1)
                      Filter: ((_ts_meta_max_1 > 'Tue Jan 01 00:00:00 2019 PST'::timestamp with time zone) AND (_ts_meta_min_1 < ('2000-01-01 0:00:00+0'::cstring)::timestamp with time zone))
@@ -1009,7 +1009,7 @@ ORDER BY m.v0;
          ->  Seq Scan on device_tbl d (actual rows=1 loops=1)
                Filter: (device_id = 8)
                Rows Removed by Filter: 6
-         ->  Custom Scan (DecompressChunk) on _hyper_1_5_chunk m (actual rows=0 loops=1)
+         ->  Custom Scan (DecompressChunk) on _hyper_1_9_chunk m (actual rows=0 loops=1)
                Filter: (("time" > 'Tue Jan 01 00:00:00 2019 PST'::timestamp with time zone) AND ("time" < ('2000-01-01 0:00:00+0'::cstring)::timestamp with time zone))
                ->  Seq Scan on compress_hyper_2_10_chunk (actual rows=0 loops=1)
                      Filter: ((_ts_meta_max_1 > 'Tue Jan 01 00:00:00 2019 PST'::timestamp with time zone) AND (device_id = 8) AND (_ts_meta_min_1 < ('2000-01-01 0:00:00+0'::cstring)::timestamp with time zone))
@@ -1036,22 +1036,22 @@ ORDER BY m.v0;
          Join Filter: ((m_1."time" > 'Tue Jan 01 00:00:00 2019 PST'::timestamp with time zone) AND (m_1."time" < ('2000-01-01 0:00:00+0'::cstring)::timestamp with time zone))
          ->  Append (actual rows=1 loops=1)
                ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk m_1 (actual rows=0 loops=1)
+                     ->  Seq Scan on compress_hyper_2_2_chunk (actual rows=0 loops=1)
+                           Filter: (device_id = 7)
+                           Rows Removed by Filter: 5
+               ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk m_2 (actual rows=0 loops=1)
+                     ->  Seq Scan on compress_hyper_2_4_chunk (actual rows=0 loops=1)
+                           Filter: (device_id = 7)
+                           Rows Removed by Filter: 5
+               ->  Custom Scan (DecompressChunk) on _hyper_1_5_chunk m_3 (actual rows=0 loops=1)
                      ->  Seq Scan on compress_hyper_2_6_chunk (actual rows=0 loops=1)
                            Filter: (device_id = 7)
-                           Rows Removed by Filter: 5
-               ->  Custom Scan (DecompressChunk) on _hyper_1_2_chunk m_2 (actual rows=0 loops=1)
-                     ->  Seq Scan on compress_hyper_2_7_chunk (actual rows=0 loops=1)
-                           Filter: (device_id = 7)
-                           Rows Removed by Filter: 5
-               ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk m_3 (actual rows=0 loops=1)
+                           Rows Removed by Filter: 1
+               ->  Custom Scan (DecompressChunk) on _hyper_1_7_chunk m_4 (actual rows=0 loops=1)
                      ->  Seq Scan on compress_hyper_2_8_chunk (actual rows=0 loops=1)
                            Filter: (device_id = 7)
                            Rows Removed by Filter: 1
-               ->  Custom Scan (DecompressChunk) on _hyper_1_4_chunk m_4 (actual rows=0 loops=1)
-                     ->  Seq Scan on compress_hyper_2_9_chunk (actual rows=0 loops=1)
-                           Filter: (device_id = 7)
-                           Rows Removed by Filter: 1
-               ->  Custom Scan (DecompressChunk) on _hyper_1_5_chunk m_5 (actual rows=1 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_1_9_chunk m_5 (actual rows=1 loops=1)
                      ->  Seq Scan on compress_hyper_2_10_chunk (actual rows=1 loops=1)
                            Filter: (device_id = 7)
                            Rows Removed by Filter: 4

--- a/tsl/test/expected/transparent_decompression_queries.out
+++ b/tsl/test/expected/transparent_decompression_queries.out
@@ -87,8 +87,8 @@ EXPLAIN (analyze,costs off,timing off,summary off) SELECT
 FROM merge_sort
 WHERE time < now()
 GROUP BY 2, 3;
-                                                                          QUERY PLAN                                                                           
----------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                          QUERY PLAN                                                                          
+--------------------------------------------------------------------------------------------------------------------------------------------------------------
  GroupAggregate (actual rows=1 loops=1)
    Group Key: merge_sort.device_id, merge_sort.measure_id
    ->  Custom Scan (ConstraintAwareAppend) (actual rows=745 loops=1)
@@ -98,26 +98,26 @@ GROUP BY 2, 3;
                Sort Key: _hyper_3_5_chunk.device_id, _hyper_3_5_chunk.measure_id
                ->  Custom Scan (DecompressChunk) on _hyper_3_5_chunk (actual rows=120 loops=1)
                      Filter: ("time" < now())
-                     ->  Index Scan using compress_hyper_4_10_chunk__compressed_hypertable_4_device_id_me on compress_hyper_4_10_chunk (actual rows=1 loops=1)
-               ->  Sort (actual rows=168 loops=1)
-                     Sort Key: _hyper_3_6_chunk.device_id, _hyper_3_6_chunk.measure_id
-                     Sort Method: quicksort 
-                     ->  Seq Scan on _hyper_3_6_chunk (actual rows=168 loops=1)
-                           Filter: ("time" < now())
+                     ->  Index Scan using compress_hyper_4_6_chunk__compressed_hypertable_4_device_id_mea on compress_hyper_4_6_chunk (actual rows=1 loops=1)
                ->  Sort (actual rows=168 loops=1)
                      Sort Key: _hyper_3_7_chunk.device_id, _hyper_3_7_chunk.measure_id
                      Sort Method: quicksort 
                      ->  Seq Scan on _hyper_3_7_chunk (actual rows=168 loops=1)
                            Filter: ("time" < now())
                ->  Sort (actual rows=168 loops=1)
-                     Sort Key: _hyper_3_8_chunk.device_id, _hyper_3_8_chunk.measure_id
-                     Sort Method: quicksort 
-                     ->  Seq Scan on _hyper_3_8_chunk (actual rows=168 loops=1)
-                           Filter: ("time" < now())
-               ->  Sort (actual rows=121 loops=1)
                      Sort Key: _hyper_3_9_chunk.device_id, _hyper_3_9_chunk.measure_id
                      Sort Method: quicksort 
-                     ->  Seq Scan on _hyper_3_9_chunk (actual rows=121 loops=1)
+                     ->  Seq Scan on _hyper_3_9_chunk (actual rows=168 loops=1)
+                           Filter: ("time" < now())
+               ->  Sort (actual rows=168 loops=1)
+                     Sort Key: _hyper_3_11_chunk.device_id, _hyper_3_11_chunk.measure_id
+                     Sort Method: quicksort 
+                     ->  Seq Scan on _hyper_3_11_chunk (actual rows=168 loops=1)
+                           Filter: ("time" < now())
+               ->  Sort (actual rows=121 loops=1)
+                     Sort Key: _hyper_3_13_chunk.device_id, _hyper_3_13_chunk.measure_id
+                     Sort Method: quicksort 
+                     ->  Seq Scan on _hyper_3_13_chunk (actual rows=121 loops=1)
                            Filter: ("time" < now())
 (30 rows)
 
@@ -138,26 +138,26 @@ GROUP BY 2, 3;
          Hypertable: merge_sort
          Chunks excluded during startup: 1
          ->  Merge Append (actual rows=528 loops=1)
-               Sort Key: _hyper_3_6_chunk.device_id, _hyper_3_6_chunk.measure_id
+               Sort Key: _hyper_3_7_chunk.device_id, _hyper_3_7_chunk.measure_id
                ->  Sort (actual rows=71 loops=1)
-                     Sort Key: _hyper_3_6_chunk.device_id, _hyper_3_6_chunk.measure_id
-                     Sort Method: quicksort 
-                     ->  Index Scan using _hyper_3_6_chunk_merge_sort_time_idx on _hyper_3_6_chunk (actual rows=71 loops=1)
-                           Index Cond: ("time" > ('2000-01-10'::cstring)::timestamp without time zone)
-               ->  Sort (actual rows=168 loops=1)
                      Sort Key: _hyper_3_7_chunk.device_id, _hyper_3_7_chunk.measure_id
                      Sort Method: quicksort 
-                     ->  Seq Scan on _hyper_3_7_chunk (actual rows=168 loops=1)
-                           Filter: ("time" > ('2000-01-10'::cstring)::timestamp without time zone)
+                     ->  Index Scan using _hyper_3_7_chunk_merge_sort_time_idx on _hyper_3_7_chunk (actual rows=71 loops=1)
+                           Index Cond: ("time" > ('2000-01-10'::cstring)::timestamp without time zone)
                ->  Sort (actual rows=168 loops=1)
-                     Sort Key: _hyper_3_8_chunk.device_id, _hyper_3_8_chunk.measure_id
-                     Sort Method: quicksort 
-                     ->  Seq Scan on _hyper_3_8_chunk (actual rows=168 loops=1)
-                           Filter: ("time" > ('2000-01-10'::cstring)::timestamp without time zone)
-               ->  Sort (actual rows=121 loops=1)
                      Sort Key: _hyper_3_9_chunk.device_id, _hyper_3_9_chunk.measure_id
                      Sort Method: quicksort 
-                     ->  Seq Scan on _hyper_3_9_chunk (actual rows=121 loops=1)
+                     ->  Seq Scan on _hyper_3_9_chunk (actual rows=168 loops=1)
+                           Filter: ("time" > ('2000-01-10'::cstring)::timestamp without time zone)
+               ->  Sort (actual rows=168 loops=1)
+                     Sort Key: _hyper_3_11_chunk.device_id, _hyper_3_11_chunk.measure_id
+                     Sort Method: quicksort 
+                     ->  Seq Scan on _hyper_3_11_chunk (actual rows=168 loops=1)
+                           Filter: ("time" > ('2000-01-10'::cstring)::timestamp without time zone)
+               ->  Sort (actual rows=121 loops=1)
+                     Sort Key: _hyper_3_13_chunk.device_id, _hyper_3_13_chunk.measure_id
+                     Sort Method: quicksort 
+                     ->  Seq Scan on _hyper_3_13_chunk (actual rows=121 loops=1)
                            Filter: ("time" > ('2000-01-10'::cstring)::timestamp without time zone)
 (27 rows)
 
@@ -215,7 +215,7 @@ INSERT INTO pseudo SELECT '2000-01-01';
 SELECT compress_chunk(show_chunks('pseudo'));
              compress_chunk              
 -----------------------------------------
- _timescaledb_internal._hyper_5_11_chunk
+ _timescaledb_internal._hyper_5_15_chunk
 (1 row)
 
 SELECT * FROM pseudo WHERE now() IS NOT NULL;

--- a/tsl/test/isolation/expected/compression_conflicts_iso.out
+++ b/tsl/test/isolation/expected/compression_conflicts_iso.out
@@ -1,4 +1,4 @@
-Parsed test spec with 9 sessions
+Parsed test spec with 11 sessions
 
 starting permutation: LockChunk1 IB I1 C1 UnlockChunk Ic Cc SC1 S1 SChunkStat
 step LockChunk1: 
@@ -47,7 +47,7 @@ count(*)|count(*) only
 step S1: SELECT count(*) from ts_device_table;
 count
 -----
-   10
+   11
 (1 row)
 
 step SChunkStat: SELECT status from _timescaledb_catalog.chunk
@@ -105,7 +105,7 @@ count(*)|count(*) only
 step S1: SELECT count(*) from ts_device_table;
 count
 -----
-   10
+   11
 (1 row)
 
 step SChunkStat: SELECT status from _timescaledb_catalog.chunk
@@ -163,7 +163,7 @@ count(*)|count(*) only
 step S1: SELECT count(*) from ts_device_table;
 count
 -----
-   10
+   11
 (1 row)
 
 step SChunkStat: SELECT status from _timescaledb_catalog.chunk
@@ -221,7 +221,7 @@ count(*)|count(*) only
 step S1: SELECT count(*) from ts_device_table;
 count
 -----
-   10
+   11
 (1 row)
 
 step SU: SELECT * FROM ts_device_table WHERE value IN (98,99);
@@ -285,7 +285,7 @@ count(*)|count(*) only
 step S1: SELECT count(*) from ts_device_table;
 count
 -----
-   10
+   11
 (1 row)
 
 step SU: SELECT * FROM ts_device_table WHERE value IN (98,99);
@@ -349,7 +349,7 @@ count(*)|count(*) only
 step S1: SELECT count(*) from ts_device_table;
 count
 -----
-   10
+   11
 (1 row)
 
 step SU: SELECT * FROM ts_device_table WHERE value IN (98,99);
@@ -423,7 +423,8 @@ time|device|location|value
    7|     1|     100|   20
    8|     1|     100|   20
    9|     1|     100|   20
-(10 rows)
+ 100|     1|     100|   20
+(11 rows)
 
 step SChunkStat: SELECT status from _timescaledb_catalog.chunk
        WHERE id = ( select min(ch.id) FROM _timescaledb_catalog.hypertable ht, _timescaledb_catalog.chunk ch WHERE ch.hypertable_id = ht.id AND ht.table_name like 'ts_device_table');
@@ -490,7 +491,8 @@ time|device|location|value
    7|     1|     100|   20
    8|     1|     100|   20
    9|     1|     100|   20
-(10 rows)
+ 100|     1|     100|   20
+(11 rows)
 
 step SChunkStat: SELECT status from _timescaledb_catalog.chunk
        WHERE id = ( select min(ch.id) FROM _timescaledb_catalog.hypertable ht, _timescaledb_catalog.chunk ch WHERE ch.hypertable_id = ht.id AND ht.table_name like 'ts_device_table');
@@ -557,7 +559,8 @@ time|device|location|value
    7|     1|     100|   20
    8|     1|     100|   20
    9|     1|     100|   20
-(10 rows)
+ 100|     1|     100|   20
+(11 rows)
 
 step SChunkStat: SELECT status from _timescaledb_catalog.chunk
        WHERE id = ( select min(ch.id) FROM _timescaledb_catalog.hypertable ht, _timescaledb_catalog.chunk ch WHERE ch.hypertable_id = ht.id AND ht.table_name like 'ts_device_table');
@@ -624,7 +627,8 @@ time|device|location|value
    8|     1|     100|   20
    9|     1|     100|   20
    1|     1|     100|   98
-(10 rows)
+ 100|     1|     100|   20
+(11 rows)
 
 step SChunkStat: SELECT status from _timescaledb_catalog.chunk
        WHERE id = ( select min(ch.id) FROM _timescaledb_catalog.hypertable ht, _timescaledb_catalog.chunk ch WHERE ch.hypertable_id = ht.id AND ht.table_name like 'ts_device_table');
@@ -691,7 +695,8 @@ time|device|location|value
    8|     1|     100|   20
    9|     1|     100|   20
    1|     1|     100|   98
-(10 rows)
+ 100|     1|     100|   20
+(11 rows)
 
 step SChunkStat: SELECT status from _timescaledb_catalog.chunk
        WHERE id = ( select min(ch.id) FROM _timescaledb_catalog.hypertable ht, _timescaledb_catalog.chunk ch WHERE ch.hypertable_id = ht.id AND ht.table_name like 'ts_device_table');
@@ -758,7 +763,8 @@ time|device|location|value
    8|     1|     100|   20
    9|     1|     100|   20
    1|     1|     100|   98
-(10 rows)
+ 100|     1|     100|   20
+(11 rows)
 
 step SChunkStat: SELECT status from _timescaledb_catalog.chunk
        WHERE id = ( select min(ch.id) FROM _timescaledb_catalog.hypertable ht, _timescaledb_catalog.chunk ch WHERE ch.hypertable_id = ht.id AND ht.table_name like 'ts_device_table');
@@ -826,7 +832,8 @@ time|device|location|value
    7|     1|     100|   20
    8|     1|     100|   20
    9|     1|     100|   20
-(10 rows)
+ 100|     1|     100|   20
+(11 rows)
 
 
 starting permutation: C1 Cc LockChunkTuple IBRR I1 IN1 UnlockChunkTuple Ic INc SChunkStat SA
@@ -887,7 +894,8 @@ time|device|location|value
    7|     1|     100|   20
    8|     1|     100|   20
    9|     1|     100|   20
-(10 rows)
+ 100|     1|     100|   20
+(11 rows)
 
 
 starting permutation: C1 Cc LockChunkTuple IBS I1 IN1 UnlockChunkTuple Ic INc SChunkStat SA
@@ -948,7 +956,8 @@ time|device|location|value
    7|     1|     100|   20
    8|     1|     100|   20
    9|     1|     100|   20
-(10 rows)
+ 100|     1|     100|   20
+(11 rows)
 
 
 starting permutation: C1 Cc LockChunkTuple IB I1 INu1 UnlockChunkTuple Ic INc SChunkStat SU SA
@@ -1014,7 +1023,8 @@ time|device|location|value
    7|     1|     100|   20
    8|     1|     100|   20
    9|     1|     100|   20
-(10 rows)
+ 100|     1|     100|   20
+(11 rows)
 
 
 starting permutation: C1 Cc LockChunkTuple IBRR I1 INu1 UnlockChunkTuple Ic INc SChunkStat SA
@@ -1075,7 +1085,8 @@ time|device|location|value
    7|     1|     100|   20
    8|     1|     100|   20
    9|     1|     100|   20
-(10 rows)
+ 100|     1|     100|   20
+(11 rows)
 
 
 starting permutation: C1 Cc LockChunkTuple IBS I1 INu1 UnlockChunkTuple Ic INc SChunkStat SA
@@ -1136,7 +1147,8 @@ time|device|location|value
    7|     1|     100|   20
    8|     1|     100|   20
    9|     1|     100|   20
-(10 rows)
+ 100|     1|     100|   20
+(11 rows)
 
 
 starting permutation: C1 Cc LockChunkTuple IB Iu1 IN1 UnlockChunkTuple Ic INc SChunkStat SU SA
@@ -1203,7 +1215,8 @@ time|device|location|value
    8|     1|     100|   20
    9|     1|     100|   20
    1|     1|     100|   98
-(10 rows)
+ 100|     1|     100|   20
+(11 rows)
 
 
 starting permutation: C1 Cc LockChunkTuple IBRR Iu1 IN1 UnlockChunkTuple Ic INc SChunkStat SA
@@ -1264,7 +1277,8 @@ time|device|location|value
    8|     1|     100|   20
    9|     1|     100|   20
    1|     1|     100|   98
-(10 rows)
+ 100|     1|     100|   20
+(11 rows)
 
 
 starting permutation: C1 Cc LockChunkTuple IBS Iu1 IN1 UnlockChunkTuple Ic INc SChunkStat SA
@@ -1325,7 +1339,8 @@ time|device|location|value
    8|     1|     100|   20
    9|     1|     100|   20
    1|     1|     100|   98
-(10 rows)
+ 100|     1|     100|   20
+(11 rows)
 
 
 starting permutation: C1 Cc LockChunkTuple IB Iu1 INu1 UnlockChunkTuple Ic INc SChunkStat SU SA
@@ -1392,7 +1407,8 @@ time|device|location|value
    8|     1|     100|   20
    9|     1|     100|   20
    1|     1|     100|   98
-(10 rows)
+ 100|     1|     100|   20
+(11 rows)
 
 
 starting permutation: C1 Cc LockChunkTuple IBRR Iu1 INu1 UnlockChunkTuple Ic INc SChunkStat SA
@@ -1453,7 +1469,8 @@ time|device|location|value
    8|     1|     100|   20
    9|     1|     100|   20
    1|     1|     100|   98
-(10 rows)
+ 100|     1|     100|   20
+(11 rows)
 
 
 starting permutation: C1 Cc LockChunkTuple IBS Iu1 INu1 UnlockChunkTuple Ic INc SChunkStat SA
@@ -1514,7 +1531,8 @@ time|device|location|value
    8|     1|     100|   20
    9|     1|     100|   20
    1|     1|     100|   98
-(10 rows)
+ 100|     1|     100|   20
+(11 rows)
 
 
 starting permutation: CA1 CAc I1 SChunkStat LockChunk1 RC IB I1 UnlockChunk Ic SH SA SChunkStat
@@ -1528,7 +1546,8 @@ step CA1:
 compress
 --------
 t       
-(1 row)
+t       
+(2 rows)
 
 step CAc: COMMIT;
 step I1: 
@@ -1579,7 +1598,7 @@ step Ic: COMMIT;
 step SH: SELECT total_chunks, number_compressed_chunks from hypertable_compression_stats('ts_device_table');
 total_chunks|number_compressed_chunks
 ------------+------------------------
-           1|                       1
+           2|                       2
 (1 row)
 
 step SA: SELECT * FROM ts_device_table;
@@ -1595,7 +1614,8 @@ time|device|location|value
    7|     1|     100|   20
    8|     1|     100|   20
    9|     1|     100|   20
-(10 rows)
+ 100|     1|     100|   20
+(11 rows)
 
 step SChunkStat: SELECT status from _timescaledb_catalog.chunk
        WHERE id = ( select min(ch.id) FROM _timescaledb_catalog.hypertable ht, _timescaledb_catalog.chunk ch WHERE ch.hypertable_id = ht.id AND ht.table_name like 'ts_device_table');
@@ -1616,7 +1636,8 @@ step CA1:
 compress
 --------
 t       
-(1 row)
+t       
+(2 rows)
 
 step CAc: COMMIT;
 step I1: 
@@ -1667,7 +1688,7 @@ step Ic: COMMIT;
 step SH: SELECT total_chunks, number_compressed_chunks from hypertable_compression_stats('ts_device_table');
 total_chunks|number_compressed_chunks
 ------------+------------------------
-           1|                       1
+           2|                       2
 (1 row)
 
 step SA: SELECT * FROM ts_device_table;
@@ -1683,7 +1704,8 @@ time|device|location|value
    7|     1|     100|   20
    8|     1|     100|   20
    9|     1|     100|   20
-(10 rows)
+ 100|     1|     100|   20
+(11 rows)
 
 step SChunkStat: SELECT status from _timescaledb_catalog.chunk
        WHERE id = ( select min(ch.id) FROM _timescaledb_catalog.hypertable ht, _timescaledb_catalog.chunk ch WHERE ch.hypertable_id = ht.id AND ht.table_name like 'ts_device_table');
@@ -1704,7 +1726,8 @@ step CA1:
 compress
 --------
 t       
-(1 row)
+t       
+(2 rows)
 
 step CAc: COMMIT;
 step I1: 
@@ -1755,7 +1778,7 @@ step Ic: COMMIT;
 step SH: SELECT total_chunks, number_compressed_chunks from hypertable_compression_stats('ts_device_table');
 total_chunks|number_compressed_chunks
 ------------+------------------------
-           1|                       1
+           2|                       2
 (1 row)
 
 step SA: SELECT * FROM ts_device_table;
@@ -1771,7 +1794,8 @@ time|device|location|value
    7|     1|     100|   20
    8|     1|     100|   20
    9|     1|     100|   20
-(10 rows)
+ 100|     1|     100|   20
+(11 rows)
 
 step SChunkStat: SELECT status from _timescaledb_catalog.chunk
        WHERE id = ( select min(ch.id) FROM _timescaledb_catalog.hypertable ht, _timescaledb_catalog.chunk ch WHERE ch.hypertable_id = ht.id AND ht.table_name like 'ts_device_table');
@@ -1792,7 +1816,8 @@ step CA1:
 compress
 --------
 t       
-(1 row)
+t       
+(2 rows)
 
 step CAc: COMMIT;
 step I1: 
@@ -1843,7 +1868,7 @@ step Ic: COMMIT;
 step SH: SELECT total_chunks, number_compressed_chunks from hypertable_compression_stats('ts_device_table');
 total_chunks|number_compressed_chunks
 ------------+------------------------
-           1|                       1
+           2|                       2
 (1 row)
 
 step SA: SELECT * FROM ts_device_table;
@@ -1859,7 +1884,8 @@ time|device|location|value
    8|     1|     100|   20
    9|     1|     100|   20
    1|     1|     100|   98
-(10 rows)
+ 100|     1|     100|   20
+(11 rows)
 
 step SChunkStat: SELECT status from _timescaledb_catalog.chunk
        WHERE id = ( select min(ch.id) FROM _timescaledb_catalog.hypertable ht, _timescaledb_catalog.chunk ch WHERE ch.hypertable_id = ht.id AND ht.table_name like 'ts_device_table');
@@ -1880,7 +1906,8 @@ step CA1:
 compress
 --------
 t       
-(1 row)
+t       
+(2 rows)
 
 step CAc: COMMIT;
 step I1: 
@@ -1931,7 +1958,7 @@ step Ic: COMMIT;
 step SH: SELECT total_chunks, number_compressed_chunks from hypertable_compression_stats('ts_device_table');
 total_chunks|number_compressed_chunks
 ------------+------------------------
-           1|                       1
+           2|                       2
 (1 row)
 
 step SA: SELECT * FROM ts_device_table;
@@ -1947,7 +1974,8 @@ time|device|location|value
    8|     1|     100|   20
    9|     1|     100|   20
    1|     1|     100|   98
-(10 rows)
+ 100|     1|     100|   20
+(11 rows)
 
 step SChunkStat: SELECT status from _timescaledb_catalog.chunk
        WHERE id = ( select min(ch.id) FROM _timescaledb_catalog.hypertable ht, _timescaledb_catalog.chunk ch WHERE ch.hypertable_id = ht.id AND ht.table_name like 'ts_device_table');
@@ -1974,7 +2002,8 @@ step CA1:
 compress
 --------
 t       
-(1 row)
+t       
+(2 rows)
 
 step CAc: COMMIT;
 step I1: 
@@ -2025,7 +2054,7 @@ step Ic: COMMIT;
 step SH: SELECT total_chunks, number_compressed_chunks from hypertable_compression_stats('ts_device_table');
 total_chunks|number_compressed_chunks
 ------------+------------------------
-           1|                       1
+           2|                       2
 (1 row)
 
 step SA: SELECT * FROM ts_device_table;
@@ -2041,7 +2070,8 @@ time|device|location|value
    8|     1|     100|   20
    9|     1|     100|   20
    1|     1|     100|   98
-(10 rows)
+ 100|     1|     100|   20
+(11 rows)
 
 step SChunkStat: SELECT status from _timescaledb_catalog.chunk
        WHERE id = ( select min(ch.id) FROM _timescaledb_catalog.hypertable ht, _timescaledb_catalog.chunk ch WHERE ch.hypertable_id = ht.id AND ht.table_name like 'ts_device_table');
@@ -2068,7 +2098,8 @@ step CA1:
 compress
 --------
 t       
-(1 row)
+t       
+(2 rows)
 
 step CAc: COMMIT;
 step I1: 
@@ -2116,7 +2147,7 @@ step INc: COMMIT;
 step SH: SELECT total_chunks, number_compressed_chunks from hypertable_compression_stats('ts_device_table');
 total_chunks|number_compressed_chunks
 ------------+------------------------
-           1|                       1
+           2|                       2
 (1 row)
 
 step SA: SELECT * FROM ts_device_table;
@@ -2132,7 +2163,8 @@ time|device|location|value
    7|     1|     100|   20
    8|     1|     100|   20
    9|     1|     100|   20
-(10 rows)
+ 100|     1|     100|   20
+(11 rows)
 
 step SChunkStat: SELECT status from _timescaledb_catalog.chunk
        WHERE id = ( select min(ch.id) FROM _timescaledb_catalog.hypertable ht, _timescaledb_catalog.chunk ch WHERE ch.hypertable_id = ht.id AND ht.table_name like 'ts_device_table');
@@ -2153,7 +2185,8 @@ step CA1:
 compress
 --------
 t       
-(1 row)
+t       
+(2 rows)
 
 step CAc: COMMIT;
 step I1: 
@@ -2201,7 +2234,7 @@ step INc: COMMIT;
 step SH: SELECT total_chunks, number_compressed_chunks from hypertable_compression_stats('ts_device_table');
 total_chunks|number_compressed_chunks
 ------------+------------------------
-           1|                       1
+           2|                       2
 (1 row)
 
 step SA: SELECT * FROM ts_device_table;
@@ -2217,7 +2250,8 @@ time|device|location|value
    8|     1|     100|   20
    9|     1|     100|   20
    1|     1|     100|   99
-(10 rows)
+ 100|     1|     100|   20
+(11 rows)
 
 step SChunkStat: SELECT status from _timescaledb_catalog.chunk
        WHERE id = ( select min(ch.id) FROM _timescaledb_catalog.hypertable ht, _timescaledb_catalog.chunk ch WHERE ch.hypertable_id = ht.id AND ht.table_name like 'ts_device_table');
@@ -2244,7 +2278,8 @@ step CA1:
 compress
 --------
 t       
-(1 row)
+t       
+(2 rows)
 
 step CAc: COMMIT;
 step I1: 
@@ -2295,7 +2330,7 @@ step RC: <... completed>
 step SH: SELECT total_chunks, number_compressed_chunks from hypertable_compression_stats('ts_device_table');
 total_chunks|number_compressed_chunks
 ------------+------------------------
-           1|                       1
+           2|                       2
 (1 row)
 
 step SA: SELECT * FROM ts_device_table;
@@ -2311,7 +2346,8 @@ time|device|location|value
    7|     1|     100|   20
    8|     1|     100|   20
    9|     1|     100|   20
-(10 rows)
+ 100|     1|     100|   20
+(11 rows)
 
 step SChunkStat: SELECT status from _timescaledb_catalog.chunk
        WHERE id = ( select min(ch.id) FROM _timescaledb_catalog.hypertable ht, _timescaledb_catalog.chunk ch WHERE ch.hypertable_id = ht.id AND ht.table_name like 'ts_device_table');
@@ -2332,7 +2368,8 @@ step CA1:
 compress
 --------
 t       
-(1 row)
+t       
+(2 rows)
 
 step CAc: COMMIT;
 step I1: 
@@ -2383,7 +2420,7 @@ step RC: <... completed>
 step SH: SELECT total_chunks, number_compressed_chunks from hypertable_compression_stats('ts_device_table');
 total_chunks|number_compressed_chunks
 ------------+------------------------
-           1|                       1
+           2|                       2
 (1 row)
 
 step SA: SELECT * FROM ts_device_table;
@@ -2399,7 +2436,8 @@ time|device|location|value
    7|     1|     100|   20
    8|     1|     100|   20
    9|     1|     100|   20
-(10 rows)
+ 100|     1|     100|   20
+(11 rows)
 
 step SChunkStat: SELECT status from _timescaledb_catalog.chunk
        WHERE id = ( select min(ch.id) FROM _timescaledb_catalog.hypertable ht, _timescaledb_catalog.chunk ch WHERE ch.hypertable_id = ht.id AND ht.table_name like 'ts_device_table');
@@ -2420,7 +2458,8 @@ step CA1:
 compress
 --------
 t       
-(1 row)
+t       
+(2 rows)
 
 step CAc: COMMIT;
 step I1: 
@@ -2471,7 +2510,7 @@ step RC: <... completed>
 step SH: SELECT total_chunks, number_compressed_chunks from hypertable_compression_stats('ts_device_table');
 total_chunks|number_compressed_chunks
 ------------+------------------------
-           1|                       1
+           2|                       2
 (1 row)
 
 step SA: SELECT * FROM ts_device_table;
@@ -2487,7 +2526,8 @@ time|device|location|value
    7|     1|     100|   20
    8|     1|     100|   20
    9|     1|     100|   20
-(10 rows)
+ 100|     1|     100|   20
+(11 rows)
 
 step SChunkStat: SELECT status from _timescaledb_catalog.chunk
        WHERE id = ( select min(ch.id) FROM _timescaledb_catalog.hypertable ht, _timescaledb_catalog.chunk ch WHERE ch.hypertable_id = ht.id AND ht.table_name like 'ts_device_table');
@@ -2508,7 +2548,8 @@ step CA1:
 compress
 --------
 t       
-(1 row)
+t       
+(2 rows)
 
 step CAc: COMMIT;
 step I1: 
@@ -2559,7 +2600,7 @@ step RC: <... completed>
 step SH: SELECT total_chunks, number_compressed_chunks from hypertable_compression_stats('ts_device_table');
 total_chunks|number_compressed_chunks
 ------------+------------------------
-           1|                       1
+           2|                       2
 (1 row)
 
 step SA: SELECT * FROM ts_device_table;
@@ -2575,7 +2616,8 @@ time|device|location|value
    7|     1|     100|   20
    8|     1|     100|   20
    9|     1|     100|   20
-(10 rows)
+ 100|     1|     100|   20
+(11 rows)
 
 step SChunkStat: SELECT status from _timescaledb_catalog.chunk
        WHERE id = ( select min(ch.id) FROM _timescaledb_catalog.hypertable ht, _timescaledb_catalog.chunk ch WHERE ch.hypertable_id = ht.id AND ht.table_name like 'ts_device_table');
@@ -2602,7 +2644,8 @@ step CA1:
 compress
 --------
 t       
-(1 row)
+t       
+(2 rows)
 
 step CAc: COMMIT;
 step I1: 
@@ -2653,7 +2696,7 @@ step RC: <... completed>
 step SH: SELECT total_chunks, number_compressed_chunks from hypertable_compression_stats('ts_device_table');
 total_chunks|number_compressed_chunks
 ------------+------------------------
-           1|                       1
+           2|                       2
 (1 row)
 
 step SA: SELECT * FROM ts_device_table;
@@ -2669,7 +2712,8 @@ time|device|location|value
    7|     1|     100|   20
    8|     1|     100|   20
    9|     1|     100|   20
-(10 rows)
+ 100|     1|     100|   20
+(11 rows)
 
 step SChunkStat: SELECT status from _timescaledb_catalog.chunk
        WHERE id = ( select min(ch.id) FROM _timescaledb_catalog.hypertable ht, _timescaledb_catalog.chunk ch WHERE ch.hypertable_id = ht.id AND ht.table_name like 'ts_device_table');
@@ -2696,7 +2740,8 @@ step CA1:
 compress
 --------
 t       
-(1 row)
+t       
+(2 rows)
 
 step CAc: COMMIT;
 step I1: 
@@ -2747,7 +2792,7 @@ step RC: <... completed>
 step SH: SELECT total_chunks, number_compressed_chunks from hypertable_compression_stats('ts_device_table');
 total_chunks|number_compressed_chunks
 ------------+------------------------
-           1|                       1
+           2|                       2
 (1 row)
 
 step SA: SELECT * FROM ts_device_table;
@@ -2763,7 +2808,8 @@ time|device|location|value
    7|     1|     100|   20
    8|     1|     100|   20
    9|     1|     100|   20
-(10 rows)
+ 100|     1|     100|   20
+(11 rows)
 
 step SChunkStat: SELECT status from _timescaledb_catalog.chunk
        WHERE id = ( select min(ch.id) FROM _timescaledb_catalog.hypertable ht, _timescaledb_catalog.chunk ch WHERE ch.hypertable_id = ht.id AND ht.table_name like 'ts_device_table');
@@ -2790,7 +2836,8 @@ step CA1:
 compress
 --------
 t       
-(1 row)
+t       
+(2 rows)
 
 step CAc: COMMIT;
 step I1: 
@@ -2838,7 +2885,7 @@ step RC: <... completed>
 step SH: SELECT total_chunks, number_compressed_chunks from hypertable_compression_stats('ts_device_table');
 total_chunks|number_compressed_chunks
 ------------+------------------------
-           1|                       1
+           2|                       2
 (1 row)
 
 step SA: SELECT * FROM ts_device_table;
@@ -2854,7 +2901,8 @@ time|device|location|value
    7|     1|     100|   20
    8|     1|     100|   20
    9|     1|     100|   20
-(10 rows)
+ 100|     1|     100|   20
+(11 rows)
 
 step SChunkStat: SELECT status from _timescaledb_catalog.chunk
        WHERE id = ( select min(ch.id) FROM _timescaledb_catalog.hypertable ht, _timescaledb_catalog.chunk ch WHERE ch.hypertable_id = ht.id AND ht.table_name like 'ts_device_table');
@@ -2875,7 +2923,8 @@ step CA1:
 compress
 --------
 t       
-(1 row)
+t       
+(2 rows)
 
 step CAc: COMMIT;
 step I1: 
@@ -2923,7 +2972,7 @@ step RC: <... completed>
 step SH: SELECT total_chunks, number_compressed_chunks from hypertable_compression_stats('ts_device_table');
 total_chunks|number_compressed_chunks
 ------------+------------------------
-           1|                       1
+           2|                       2
 (1 row)
 
 step SA: SELECT * FROM ts_device_table;
@@ -2939,7 +2988,8 @@ time|device|location|value
    7|     1|     100|   20
    8|     1|     100|   20
    9|     1|     100|   20
-(10 rows)
+ 100|     1|     100|   20
+(11 rows)
 
 step SChunkStat: SELECT status from _timescaledb_catalog.chunk
        WHERE id = ( select min(ch.id) FROM _timescaledb_catalog.hypertable ht, _timescaledb_catalog.chunk ch WHERE ch.hypertable_id = ht.id AND ht.table_name like 'ts_device_table');
@@ -2953,4 +3003,56 @@ time|device|location|value
 ----+------+--------+-----
    1|     1|     100|   99
 (1 row)
+
+
+starting permutation: s1_compress_one s2_compress_one s2_commit s1_commit
+step s1_compress_one: 
+    BEGIN; 
+    SELECT compress_chunk(i.show_chunks) FROM (SELECT show_chunks('ts_device_table') ORDER BY 1 ASC LIMIT 1) i;
+
+compress_chunk                            
+------------------------------------------
+_timescaledb_internal._hyper_X_X_chunk
+(1 row)
+
+step s2_compress_one: 
+    BEGIN; 
+    SELECT compress_chunk(i.show_chunks) FROM (SELECT show_chunks('ts_device_table') ORDER BY 1 DESC LIMIT 1) i;
+
+compress_chunk                            
+------------------------------------------
+_timescaledb_internal._hyper_X_X_chunk
+(1 row)
+
+step s2_commit: 
+    COMMIT;
+
+step s1_commit: 
+    COMMIT;
+
+
+starting permutation: s2_compress_one s1_compress_one s2_commit s1_commit
+step s2_compress_one: 
+    BEGIN; 
+    SELECT compress_chunk(i.show_chunks) FROM (SELECT show_chunks('ts_device_table') ORDER BY 1 DESC LIMIT 1) i;
+
+compress_chunk                            
+------------------------------------------
+_timescaledb_internal._hyper_X_X_chunk
+(1 row)
+
+step s1_compress_one: 
+    BEGIN; 
+    SELECT compress_chunk(i.show_chunks) FROM (SELECT show_chunks('ts_device_table') ORDER BY 1 ASC LIMIT 1) i;
+
+compress_chunk                            
+------------------------------------------
+_timescaledb_internal._hyper_X_X_chunk
+(1 row)
+
+step s2_commit: 
+    COMMIT;
+
+step s1_commit: 
+    COMMIT;
 

--- a/tsl/test/isolation/expected/compression_merge_race.out
+++ b/tsl/test/isolation/expected/compression_merge_race.out
@@ -135,7 +135,7 @@ step s3_select_on_compressed_chunk:
       INNER JOIN _timescaledb_catalog.chunk c  
       ON h.id = c.hypertable_id 
       WHERE h.table_name = 'sensor_data' 
-      AND c.compressed_chunk_id IS NOT NULL;
+      AND c.status = 1;
       EXECUTE format('SELECT * 
         FROM _timescaledb_internal.compress_hyper_%s_%s_chunk 
         WHERE sensor_id = 40 

--- a/tsl/test/isolation/specs/compression_merge_race.spec
+++ b/tsl/test/isolation/specs/compression_merge_race.spec
@@ -136,7 +136,7 @@ step "s3_select_on_compressed_chunk" {
       INNER JOIN _timescaledb_catalog.chunk c  
       ON h.id = c.hypertable_id 
       WHERE h.table_name = 'sensor_data' 
-      AND c.compressed_chunk_id IS NOT NULL;
+      AND c.status = 1;
       EXECUTE format('SELECT * 
         FROM _timescaledb_internal.compress_hyper_%s_%s_chunk 
         WHERE sensor_id = 40 

--- a/tsl/test/shared/expected/compression_dml.out
+++ b/tsl/test/shared/expected/compression_dml.out
@@ -52,7 +52,7 @@ INSERT INTO metric_5m (time, series_id, value)
 -- manually compress all chunks
 SELECT count(compress_chunk(c.schema_name|| '.' || c.table_name))
     FROM _timescaledb_catalog.chunk c, _timescaledb_catalog.hypertable ht where
-    c.hypertable_id = ht.id and ht.table_name = 'metric_5m' and c.compressed_chunk_id IS NULL;
+    c.hypertable_id = ht.id and ht.table_name = 'metric_5m' and c.status & 1 = 0;
  count 
    289
 (1 row)
@@ -103,4 +103,4 @@ QUERY PLAN
 (4 rows)
 
 DROP TABLE mytab CASCADE;
-NOTICE:  drop cascades to table _timescaledb_internal.compress_hyper_X_X_chunk
+NOTICE:  drop cascades to 4 other objects

--- a/tsl/test/shared/expected/extension.out
+++ b/tsl/test/shared/expected/extension.out
@@ -59,6 +59,7 @@ ORDER BY pronamespace::regnamespace::text COLLATE "C", p.oid::regprocedure::text
  _timescaledb_functions.create_chunk_replica_table(regclass,name)
  _timescaledb_functions.create_chunk_table(regclass,jsonb,name,name)
  _timescaledb_functions.create_compressed_chunk(regclass,regclass,bigint,bigint,bigint,bigint,bigint,bigint,bigint,bigint)
+ _timescaledb_functions.create_compressed_chunks_for_hypertable(regclass)
  _timescaledb_functions.data_node_chunk_info(name,name,name)
  _timescaledb_functions.data_node_compressed_chunk_stats(name,name,name)
  _timescaledb_functions.data_node_hypertable_info(name,name,name)

--- a/tsl/test/shared/sql/compression_dml.sql
+++ b/tsl/test/shared/sql/compression_dml.sql
@@ -46,7 +46,7 @@ INSERT INTO metric_5m (time, series_id, value)
 -- manually compress all chunks
 SELECT count(compress_chunk(c.schema_name|| '.' || c.table_name))
     FROM _timescaledb_catalog.chunk c, _timescaledb_catalog.hypertable ht where
-    c.hypertable_id = ht.id and ht.table_name = 'metric_5m' and c.compressed_chunk_id IS NULL;
+    c.hypertable_id = ht.id and ht.table_name = 'metric_5m' and c.status & 1 = 0;
 
 -- populate into compressed hypertable, this should not crash
 INSERT INTO metric_5m (time, series_id, value)

--- a/tsl/test/shared/sql/include/shared_setup.sql
+++ b/tsl/test/shared/sql/include/shared_setup.sql
@@ -58,7 +58,7 @@ ANALYZE metrics_compressed;
 -- compress chunks
 ALTER TABLE metrics_compressed SET (timescaledb.compress, timescaledb.compress_orderby='time DESC', timescaledb.compress_segmentby='device_id');
 SELECT compress_chunk(c.schema_name|| '.' || c.table_name)
-FROM _timescaledb_catalog.chunk c, _timescaledb_catalog.hypertable ht where c.hypertable_id = ht.id and ht.table_name = 'metrics_compressed' and c.compressed_chunk_id IS NULL
+FROM _timescaledb_catalog.chunk c, _timescaledb_catalog.hypertable ht where c.hypertable_id = ht.id and ht.table_name = 'metrics_compressed' and c.status & 1 = 0
 ORDER BY c.table_name DESC;
 -- Reindexing compressed hypertable to update statistics
 -- this is for planner tests which depend on them
@@ -82,7 +82,7 @@ ANALYZE metrics_space_compressed;
 -- compress chunks
 ALTER TABLE metrics_space_compressed SET (timescaledb.compress, timescaledb.compress_orderby='time DESC', timescaledb.compress_segmentby='device_id');
 SELECT compress_chunk(c.schema_name|| '.' || c.table_name)
-FROM _timescaledb_catalog.chunk c, _timescaledb_catalog.hypertable ht where c.hypertable_id = ht.id and ht.table_name = 'metrics_space_compressed' and c.compressed_chunk_id IS NULL
+FROM _timescaledb_catalog.chunk c, _timescaledb_catalog.hypertable ht where c.hypertable_id = ht.id and ht.table_name = 'metrics_space_compressed' and c.status & 1 = 0
 ORDER BY c.table_name DESC;
 -- Reindexing compressed hypertable to update statistics
 -- this is for planner tests which depend on them

--- a/tsl/test/sql/CMakeLists.txt
+++ b/tsl/test/sql/CMakeLists.txt
@@ -51,6 +51,7 @@ if(CMAKE_BUILD_TYPE MATCHES Debug)
     chunk_merge.sql
     chunk_utils_compression.sql
     compression_algos.sql
+    compression_create_chunks.sql
     compression_ddl.sql
     compression_errors.sql
     compression_hypertable.sql

--- a/tsl/test/sql/chunk_merge.sql
+++ b/tsl/test/sql/chunk_merge.sql
@@ -29,16 +29,16 @@ SELECT * FROM _timescaledb_catalog.chunk;
 \set ON_ERROR_STOP 0
 
 -- Cannot merge chunks from different hypertables
-SELECT _timescaledb_internal.test_merge_chunks_on_dimension('_timescaledb_internal._hyper_1_1_chunk','_timescaledb_internal._hyper_3_7_chunk', 1);
+SELECT _timescaledb_internal.test_merge_chunks_on_dimension('_timescaledb_internal._hyper_1_1_chunk','_timescaledb_internal._hyper_3_13_chunk', 1);
 
 -- Cannot merge non-adjacent chunks
-SELECT _timescaledb_internal.test_merge_chunks_on_dimension('_timescaledb_internal._hyper_1_1_chunk','_timescaledb_internal._hyper_1_3_chunk', 1);
+SELECT _timescaledb_internal.test_merge_chunks_on_dimension('_timescaledb_internal._hyper_1_1_chunk','_timescaledb_internal._hyper_1_5_chunk', 1);
 
 -- Cannot merge same chunk to itself (its not adjacent to itself).
 SELECT _timescaledb_internal.test_merge_chunks_on_dimension('_timescaledb_internal._hyper_1_1_chunk','_timescaledb_internal._hyper_1_1_chunk', 1);
 
 -- Cannot merge chunks on with different partitioning schemas.
-SELECT _timescaledb_internal.test_merge_chunks_on_dimension('_timescaledb_internal._hyper_1_1_chunk','_timescaledb_internal._hyper_1_4_chunk', 1);
+SELECT _timescaledb_internal.test_merge_chunks_on_dimension('_timescaledb_internal._hyper_1_1_chunk','_timescaledb_internal._hyper_1_7_chunk', 1);
 
 -- Cannot merge chunks on with non-existant dimension slice.
 -- NOTE: we are merging the same chunk just so they have the exact same partitioning schema and we don't hit the previous test error.
@@ -48,17 +48,17 @@ SELECT _timescaledb_internal.test_merge_chunks_on_dimension('_timescaledb_intern
 \set ON_ERROR_STOP 1
 
 -- Merge on open (time) dimension.
-SELECT _timescaledb_internal.test_merge_chunks_on_dimension('_timescaledb_internal._hyper_1_5_chunk','_timescaledb_internal._hyper_1_6_chunk', 1);
+SELECT _timescaledb_internal.test_merge_chunks_on_dimension('_timescaledb_internal._hyper_1_9_chunk','_timescaledb_internal._hyper_1_11_chunk', 1);
 
 -- Merge on closed dimension.
-SELECT _timescaledb_internal.test_merge_chunks_on_dimension('_timescaledb_internal._hyper_1_1_chunk','_timescaledb_internal._hyper_1_4_chunk', 2);
+SELECT _timescaledb_internal.test_merge_chunks_on_dimension('_timescaledb_internal._hyper_1_1_chunk','_timescaledb_internal._hyper_1_7_chunk', 2);
 
 SELECT compress_chunk(i) FROM show_chunks('test1') i;
 
 \set ON_ERROR_STOP 0
 
 -- Cannot merge chunks internal compressed chunks, no dimensions on them.
-SELECT _timescaledb_internal.test_merge_chunks_on_dimension('_timescaledb_internal.compress_hyper_2_10_chunk','_timescaledb_internal.compress_hyper_2_11_chunk', 1);
+SELECT _timescaledb_internal.test_merge_chunks_on_dimension('_timescaledb_internal.compress_hyper_2_2_chunk','_timescaledb_internal.compress_hyper_2_4_chunk', 1);
 
 \set ON_ERROR_STOP 1
 

--- a/tsl/test/sql/compression.sql
+++ b/tsl/test/sql/compression.sql
@@ -151,7 +151,7 @@ FROM _timescaledb_catalog.chunk ch1, _timescaledb_catalog.hypertable ht where ch
 select tableoid::regclass, count(*) from conditions group by tableoid order by tableoid;
 
 select  compress_chunk(ch1.schema_name|| '.' || ch1.table_name)
-FROM _timescaledb_catalog.chunk ch1, _timescaledb_catalog.hypertable ht where ch1.hypertable_id = ht.id and ht.table_name like 'conditions' and ch1.compressed_chunk_id IS NULL;
+FROM _timescaledb_catalog.chunk ch1, _timescaledb_catalog.hypertable ht where ch1.hypertable_id = ht.id and ht.table_name like 'conditions' and ch1.status & 1 = 0;
 
 select tableoid::regclass, count(*) from conditions group by tableoid order by tableoid;
 
@@ -196,10 +196,8 @@ WHERE ch1.hypertable_id = ht.id and ht.table_name LIKE 'conditions'
 ORDER BY chunk;
 
 SELECT count(*), count(*) = :'ORIGINAL_CHUNK_COUNT' from :CHUNK_NAME;
---check that the compressed chunk is dropped
-\set ON_ERROR_STOP 0
+--check that the compressed chunk is empty
 SELECT count(*) from :COMPRESSED_CHUNK_NAME;
-\set ON_ERROR_STOP 1
 
 --size information is gone too
 select count(*)
@@ -209,7 +207,7 @@ where ch1.hypertable_id = ht.id and ht.table_name like 'conditions'
 and map.chunk_id = ch1.id;
 
 --make sure  compressed_chunk_id  is reset to NULL
-select ch1.compressed_chunk_id IS NULL
+select ch1.status & 1 = 0
 FROM _timescaledb_catalog.chunk ch1, _timescaledb_catalog.hypertable ht where ch1.hypertable_id = ht.id and ht.table_name like 'conditions';
 
 -- test plans get invalidated when chunks get compressed

--- a/tsl/test/sql/compression_create_chunks.sql
+++ b/tsl/test/sql/compression_create_chunks.sql
@@ -1,0 +1,42 @@
+-- This file and its contents are licensed under the Timescale License.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-TIMESCALE for a copy of the license.
+
+\c :TEST_DBNAME :ROLE_SUPERUSER
+
+CREATE TABLE conditions (
+    "time" TIMESTAMPTZ NOT NULL,
+    city TEXT NOT NULL,
+    temperature INTEGER NOT NULL,
+    device_id INTEGER NOT NULL
+);
+
+SELECT table_name FROM create_hypertable('conditions', 'time');
+
+INSERT INTO
+    conditions ("time", city, temperature, device_id)
+VALUES
+  ('2021-06-14 00:00:00-00', 'Moscow', 26,1),
+  ('2021-06-15 00:00:00-00', 'Berlin', 22,2),
+  ('2021-06-16 00:00:00-00', 'Stockholm', 24,3),
+  ('2021-06-17 00:00:00-00', 'London', 24,4),
+  ('2021-06-18 00:00:00-00', 'London', 27,4),
+  ('2021-06-19 00:00:00-00', 'Moscow', 28,4);
+
+ALTER TABLE conditions SET (timescaledb.compress);
+
+SELECT * FROM _timescaledb_catalog.chunk ORDER BY 1,2;
+
+UPDATE _timescaledb_catalog.chunk SET compressed_chunk_id = NULL WHERE id = 1;
+
+SELECT * FROM _timescaledb_catalog.chunk ORDER BY 1,2;
+
+SELECT _timescaledb_functions.create_compressed_chunks_for_hypertable('conditions');
+
+SELECT * FROM _timescaledb_catalog.chunk;
+SELECT * FROM _timescaledb_catalog.hypertable;
+
+\set ON_ERROR_STOP 0
+SELECT _timescaledb_functions.create_compressed_chunks_for_hypertable('_timescaledb_internal._compressed_hypertable_2');
+SELECT _timescaledb_functions.create_compressed_chunks_for_hypertable('nonexistant');
+\set ON_ERROR_STOP 1

--- a/tsl/test/sql/compression_errors.sql
+++ b/tsl/test/sql/compression_errors.sql
@@ -145,7 +145,7 @@ FROM _timescaledb_catalog.chunk ch1, _timescaledb_catalog.hypertable ht where ch
 
 --should succeed
 select decompress_chunk(ch1.schema_name|| '.' || ch1.table_name)
-FROM _timescaledb_catalog.chunk ch1, _timescaledb_catalog.hypertable ht where ch1.hypertable_id = ht.id and ht.table_name like 'foo' and ch1.compressed_chunk_id IS NOT NULL;
+FROM _timescaledb_catalog.chunk ch1, _timescaledb_catalog.hypertable ht where ch1.hypertable_id = ht.id and ht.table_name like 'foo' and ch1.status & 1 > 0;
 
 --should succeed
 ALTER TABLE foo set (timescaledb.compress, timescaledb.compress_orderby = 'a', timescaledb.compress_segmentby = 'b');

--- a/tsl/test/sql/compression_merge.sql
+++ b/tsl/test/sql/compression_merge.sql
@@ -112,8 +112,18 @@ SELECT
 
 SELECT compress_chunk(i) FROM show_chunks('test5') i LIMIT 4;
 
+SELECT cc.schema_name || '.' || cc.table_name AS "COMPRESSED_CHUNK_NAME"
+FROM _timescaledb_catalog.hypertable h
+INNER JOIN _timescaledb_catalog.chunk c
+ON h.id = c.hypertable_id
+INNER JOIN _timescaledb_catalog.chunk cc
+ON cc.id = c.compressed_chunk_id
+WHERE h.table_name = 'test5'
+AND c.status = 1
+LIMIT 1 \gset
+
 -- Make sure sequence numbers are correctly fetched from index.
-SELECT _ts_meta_sequence_num FROM _timescaledb_internal.compress_hyper_10_187_chunk where i = 1;
+SELECT _ts_meta_sequence_num FROM :COMPRESSED_CHUNK_NAME where i = 1;
 
 SELECT schemaname || '.' || indexname AS "INDEXNAME"
 FROM pg_indexes i
@@ -129,7 +139,7 @@ DROP INDEX :INDEXNAME;
 SELECT compress_chunk(i, true) FROM show_chunks('test5') i LIMIT 5;
 
 -- Make sure sequence numbers are correctly fetched from heap.
-SELECT _ts_meta_sequence_num FROM _timescaledb_internal.compress_hyper_10_187_chunk where i = 1;
+SELECT _ts_meta_sequence_num FROM :COMPRESSED_CHUNK_NAME where i = 1;
 
 SELECT 'test5' AS "HYPERTABLE_NAME" \gset
 \ir include/compression_test_merge.sql

--- a/tsl/test/sql/compression_permissions.sql
+++ b/tsl/test/sql/compression_permissions.sql
@@ -60,7 +60,7 @@ alter table conditions set (timescaledb.compress, timescaledb.compress_segmentby
 --- compress_chunks and decompress_chunks fail without correct perm --
 \c :TEST_DBNAME :ROLE_DEFAULT_PERM_USER_2
 select  compress_chunk(ch1.schema_name|| '.' || ch1.table_name)
-FROM _timescaledb_catalog.chunk ch1, _timescaledb_catalog.hypertable ht where ch1.hypertable_id = ht.id and ht.table_name like 'conditions' and ch1.compressed_chunk_id IS NULL;
+FROM _timescaledb_catalog.chunk ch1, _timescaledb_catalog.hypertable ht where ch1.hypertable_id = ht.id and ht.table_name like 'conditions' and ch1.status & 1 = 0;
 select decompress_chunk(ch1.schema_name|| '.' || ch1.table_name)
 FROM _timescaledb_catalog.chunk ch1, _timescaledb_catalog.hypertable ht where ch1.hypertable_id = ht.id and ht.table_name like 'conditions';
 select add_compression_policy('conditions', '1day'::interval);
@@ -77,7 +77,7 @@ select remove_compression_policy('conditions', true);
 GRANT SELECT on conditions to :ROLE_DEFAULT_PERM_USER_2;
 select count(*) from
 (select  compress_chunk(ch1.schema_name|| '.' || ch1.table_name)
-FROM _timescaledb_catalog.chunk ch1, _timescaledb_catalog.hypertable ht where ch1.hypertable_id = ht.id and ht.table_name like 'conditions' and ch1.compressed_chunk_id IS NULL ) as subq;
+FROM _timescaledb_catalog.chunk ch1, _timescaledb_catalog.hypertable ht where ch1.hypertable_id = ht.id and ht.table_name like 'conditions' and ch1.status & 1 = 0 ) as subq;
 \c :TEST_DBNAME :ROLE_DEFAULT_PERM_USER_2
 select count(*) from conditions;
 

--- a/tsl/test/sql/compression_update_delete.sql
+++ b/tsl/test/sql/compression_update_delete.sql
@@ -591,29 +591,17 @@ SELECT chunk_status,
 FROM compressed_chunk_info_view
 WHERE hypertable_name = 'sample_table' ORDER BY chunk_name;
 
--- get FIRST uncompressed chunk
-SELECT ch1.schema_name|| '.' || ch1.table_name AS "UNCOMPRESS_CHUNK_1"
-FROM _timescaledb_catalog.chunk ch1, _timescaledb_catalog.hypertable ht
-WHERE ch1.hypertable_id = ht.id AND ch1.table_name LIKE '_hyper_%'
-ORDER BY ch1.id LIMIT 1 \gset
+-- get FIRST chunk
+SELECT ch.schema_name || '.' || ch.table_name AS "UNCOMPRESS_CHUNK_1", ch1.schema_name || '.' || ch1.table_name AS "COMPRESS_CHUNK_1"
+FROM _timescaledb_catalog.chunk ch1, _timescaledb_catalog.chunk ch, _timescaledb_catalog.hypertable ht
+WHERE ch.hypertable_id = ht.id AND ht.table_name = 'sample_table' and ch.compressed_chunk_id = ch1.id
+ORDER BY ch.id LIMIT 1 \gset
 
--- get SECOND uncompressed chunk
-SELECT ch1.schema_name|| '.' || ch1.table_name AS "UNCOMPRESS_CHUNK_2"
-FROM _timescaledb_catalog.chunk ch1, _timescaledb_catalog.hypertable ht
-WHERE ch1.hypertable_id = ht.id AND ch1.table_name LIKE '_hyper_%'
-ORDER BY ch1.id DESC LIMIT 1 \gset
-
--- get FIRST compressed chunk
-SELECT ch1.schema_name|| '.' || ch1.table_name AS "COMPRESS_CHUNK_1"
-FROM _timescaledb_catalog.chunk ch1, _timescaledb_catalog.hypertable ht
-WHERE ch1.hypertable_id = ht.id AND ch1.table_name LIKE 'compress_%'
-ORDER BY ch1.id LIMIT 1 \gset
-
--- get SECOND compressed chunk
-SELECT ch1.schema_name|| '.' || ch1.table_name AS "COMPRESS_CHUNK_2"
-FROM _timescaledb_catalog.chunk ch1, _timescaledb_catalog.hypertable ht
-WHERE ch1.hypertable_id = ht.id AND ch1.table_name LIKE 'compress_%'
-ORDER BY ch1.id DESC LIMIT 1 \gset
+-- get SECOND chunk
+SELECT ch.schema_name || '.' || ch.table_name AS "UNCOMPRESS_CHUNK_2", ch1.schema_name || '.' || ch1.table_name AS "COMPRESS_CHUNK_2"
+FROM _timescaledb_catalog.chunk ch1, _timescaledb_catalog.chunk ch, _timescaledb_catalog.hypertable ht
+WHERE ch.hypertable_id = ht.id AND ht.table_name = 'sample_table' and ch.compressed_chunk_id = ch1.id
+ORDER BY ch.id DESC LIMIT 1 \gset
 
 -- ensure segment by column index position in compressed and uncompressed
 -- chunk is different

--- a/tsl/test/sql/dist_compression.sql
+++ b/tsl/test/sql/dist_compression.sql
@@ -185,7 +185,7 @@ FROM
 SELECT compress_chunk(chunk.schema_name|| '.' || chunk.table_name, true)
 FROM _timescaledb_catalog.chunk chunk
 INNER JOIN _timescaledb_catalog.hypertable hypertable ON (chunk.hypertable_id = hypertable.id)
-WHERE hypertable.table_name like 'compressed' and chunk.compressed_chunk_id IS NULL ORDER BY chunk.id
+WHERE hypertable.table_name like 'compressed' and chunk.status & 1 = 0 ORDER BY chunk.id
 )
 AS sub;
 

--- a/tsl/test/sql/dist_move_chunk.sql
+++ b/tsl/test/sql/dist_move_chunk.sql
@@ -169,7 +169,7 @@ FROM _timescaledb_catalog.chunk c1
 JOIN _timescaledb_catalog.chunk c2 ON (c1.compressed_chunk_id = c2.id)
 WHERE c1.table_name = '_dist_hyper_3_12_chunk';
 
-SELECT * FROM _timescaledb_internal.compress_hyper_3_6_chunk ORDER BY device, _ts_meta_min_1;
+SELECT * FROM _timescaledb_internal.compress_hyper_3_7_chunk ORDER BY device, _ts_meta_min_1;
 SELECT * FROM _timescaledb_internal._dist_hyper_3_12_chunk ORDER BY time;
 
 -- Get compressed chunk stat
@@ -192,7 +192,7 @@ JOIN _timescaledb_catalog.chunk c2 ON (c1.compressed_chunk_id = c2.id)
 WHERE c1.table_name = '_dist_hyper_3_12_chunk';
 
 -- Try to query hypertable member with compressed chunk
-SELECT * FROM _timescaledb_internal.compress_hyper_3_6_chunk ORDER BY device, _ts_meta_min_1;
+SELECT * FROM _timescaledb_internal.compress_hyper_3_7_chunk ORDER BY device, _ts_meta_min_1;
 SELECT * FROM _timescaledb_internal._dist_hyper_3_12_chunk ORDER BY time;
 
 -- Ensure that compressed chunk stats match stats from the source data node
@@ -207,7 +207,7 @@ JOIN _timescaledb_catalog.chunk c2 ON (c1.compressed_chunk_id = c2.id)
 WHERE c1.table_name = '_dist_hyper_3_12_chunk';
 
 \set ON_ERROR_STOP 0
-SELECT * FROM _timescaledb_internal.compress_hyper_3_6_chunk ORDER BY device, _ts_meta_min_1;
+SELECT * FROM _timescaledb_internal.compress_hyper_3_7_chunk ORDER BY device, _ts_meta_min_1;
 SELECT * FROM _timescaledb_internal._dist_hyper_3_12_chunk ORDER BY time;
 \set ON_ERROR_STOP 1
 
@@ -244,7 +244,7 @@ FROM _timescaledb_catalog.chunk c1
 JOIN _timescaledb_catalog.chunk c2 ON (c1.compressed_chunk_id = c2.id)
 WHERE c1.table_name = '_dist_hyper_3_12_chunk';
 
-SELECT * FROM _timescaledb_internal.compress_hyper_3_6_chunk ORDER BY device, _ts_meta_min_1;
+SELECT * FROM _timescaledb_internal.compress_hyper_3_7_chunk ORDER BY device, _ts_meta_min_1;
 SELECT * FROM _timescaledb_internal._dist_hyper_3_12_chunk ORDER BY time;
 SELECT * FROM _timescaledb_internal.compressed_chunk_stats WHERE chunk_name = '_dist_hyper_3_12_chunk';
 

--- a/tsl/test/sql/include/compression_alter.sql
+++ b/tsl/test/sql/include/compression_alter.sql
@@ -21,7 +21,7 @@ FROM
 SELECT compress_chunk(chunk.schema_name|| '.' || chunk.table_name)
 FROM _timescaledb_catalog.chunk chunk
 INNER JOIN _timescaledb_catalog.hypertable hypertable ON (chunk.hypertable_id = hypertable.id)
-WHERE hypertable.table_name like 'test1' and chunk.compressed_chunk_id IS NULL ORDER BY chunk.id
+WHERE hypertable.table_name like 'test1' and chunk.status & 1 = 0 ORDER BY chunk.id
 )
 AS sub;
 
@@ -42,7 +42,7 @@ FROM
 SELECT decompress_chunk(chunk.schema_name|| '.' || chunk.table_name)
 FROM _timescaledb_catalog.chunk chunk
 INNER JOIN _timescaledb_catalog.hypertable hypertable ON (chunk.hypertable_id = hypertable.id)
-WHERE hypertable.table_name like 'test1' and chunk.compressed_chunk_id IS NOT NULL ORDER BY chunk.id
+WHERE hypertable.table_name like 'test1' and chunk.status & 1 > 0 ORDER BY chunk.id
 LIMIT 1
 )
 AS sub;
@@ -63,7 +63,7 @@ FROM
 SELECT compress_chunk(chunk.schema_name|| '.' || chunk.table_name)
 FROM _timescaledb_catalog.chunk chunk
 INNER JOIN _timescaledb_catalog.hypertable hypertable ON (chunk.hypertable_id = hypertable.id)
-WHERE hypertable.table_name like 'test1' and chunk.compressed_chunk_id IS NULL ORDER BY chunk.id
+WHERE hypertable.table_name like 'test1' and chunk.status & 1 = 0 ORDER BY chunk.id
 )
 AS sub;
 SELECT count(*) from test1 where new_coli  = 100;
@@ -102,7 +102,7 @@ FROM
 SELECT compress_chunk(chunk.schema_name|| '.' || chunk.table_name)
 FROM _timescaledb_catalog.chunk chunk
 INNER JOIN _timescaledb_catalog.hypertable hypertable ON (chunk.hypertable_id = hypertable.id)
-WHERE hypertable.table_name = 'test1' and chunk.compressed_chunk_id IS NULL ORDER BY chunk.id
+WHERE hypertable.table_name = 'test1' and chunk.status & 1 = 0 ORDER BY chunk.id
 ) q;
 
 --check if all chunks have new column names

--- a/tsl/test/sql/include/compression_test_hypertable_segment_meta.sql
+++ b/tsl/test/sql/include/compression_test_hypertable_segment_meta.sql
@@ -10,7 +10,7 @@ SELECT 'NULL::'||:'TYPE' as "NULLTYPE" \gset
 SELECT count(compress_chunk(chunk.schema_name|| '.' || chunk.table_name)) as count_compressed
 FROM _timescaledb_catalog.chunk chunk
 INNER JOIN _timescaledb_catalog.hypertable hypertable ON (chunk.hypertable_id = hypertable.id)
-WHERE hypertable.table_name like :'HYPERTABLE_NAME' and chunk.compressed_chunk_id IS NULL;
+WHERE hypertable.table_name like :'HYPERTABLE_NAME' and chunk.status & 1 = 0;
 
 SELECT
     comp_hypertable.schema_name AS "COMP_SCHEMA_NAME",

--- a/tsl/test/sql/include/compression_test_merge.sql
+++ b/tsl/test/sql/include/compression_test_merge.sql
@@ -25,7 +25,7 @@ WHERE (original.*) IS DISTINCT FROM (compressed.*);
 SELECT count(decompress_chunk(chunk.schema_name|| '.' || chunk.table_name)) as count_decompressed
 FROM _timescaledb_catalog.chunk chunk
 INNER JOIN _timescaledb_catalog.hypertable hypertable ON (chunk.hypertable_id = hypertable.id)
-WHERE hypertable.table_name like :'HYPERTABLE_NAME' and chunk.compressed_chunk_id IS NOT NULL;
+WHERE hypertable.table_name like :'HYPERTABLE_NAME' and chunk.status & 1 > 0;
 
 
 --run data on data that's been compressed and decompressed, make sure it's the same.

--- a/tsl/test/sql/include/transparent_decompression_undiffed.sql
+++ b/tsl/test/sql/include/transparent_decompression_undiffed.sql
@@ -17,7 +17,7 @@ INSERT into readings select g, 1, 1.3 from generate_series('2001-03-01 01:01:01'
 SELECT count(compress_chunk(chunk.schema_name|| '.' || chunk.table_name))
 FROM _timescaledb_catalog.chunk chunk
 INNER JOIN _timescaledb_catalog.hypertable hypertable ON (chunk.hypertable_id = hypertable.id)
-WHERE hypertable.table_name = 'readings' and chunk.compressed_chunk_id IS NULL;
+WHERE hypertable.table_name = 'readings' and chunk.status & 1 = 0;
 
 EXPLAIN (costs off) SELECT t.fleet as fleet, min(r.fuel_consumption) AS avg_fuel_consumption
 FROM tags t

--- a/tsl/test/sql/merge_compress.sql
+++ b/tsl/test/sql/merge_compress.sql
@@ -29,7 +29,7 @@ INSERT INTO target (series_id, value, partition_column)
 -- compress chunks
 SELECT count(compress_chunk(c.schema_name|| '.' || c.table_name))
   FROM _timescaledb_catalog.chunk c, _timescaledb_catalog.hypertable ht where
-    c.hypertable_id = ht.id and ht.table_name = 'target' and c.compressed_chunk_id IS NULL;
+    c.hypertable_id = ht.id and ht.table_name = 'target' and c.status & 1 = 0;
 
 CREATE TABLE source (
         time TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP NOT NULL,


### PR DESCRIPTION
To avoid lock contention during compression operation, we are moving compressed chunk creation together with uncompressed chunk creation during insert time. Now compressed chunks live while the uncompressed chunk is alive, we don't remove them during decompression but rather truncate them. This moves lock contention over compressed hypertable to coincide with lock contention over uncompressed hypertable.