### PR TITLE
Make `set_chunk_time_interval` CAGGs aware

### DIFF
--- a/.unreleased/PR_5852
+++ b/.unreleased/PR_5852
@@ -1,0 +1,1 @@
+Implements: #5852 Make set_chunk_time_interval CAGGs aware

--- a/src/dimension.c
+++ b/src/dimension.c
@@ -1265,7 +1265,7 @@ ts_dimension_set_interval(PG_FUNCTION_ARGS)
 		ereport(ERROR,
 				(errcode(ERRCODE_INVALID_PARAMETER_VALUE), errmsg("hypertable cannot be NULL")));
 
-	ht = ts_hypertable_cache_get_entry(hcache, table_relid, CACHE_FLAG_NONE);
+	ht = ts_resolve_hypertable_from_table_or_cagg(hcache, table_relid, true);
 	ts_hypertable_permissions_check(table_relid, GetUserId());
 
 	if (PG_ARGISNULL(1))

--- a/src/hypertable.h
+++ b/src/hypertable.h
@@ -14,6 +14,7 @@
 #include "chunk_adaptive.h"
 #include "dimension.h"
 #include "export.h"
+#include "hypertable_cache.h"
 #include "scanner.h"
 #include "scan_iterator.h"
 #include "ts_catalog/tablespace.h"
@@ -109,6 +110,8 @@ extern TSDLLEXPORT Oid ts_hypertable_permissions_check(Oid hypertable_oid, Oid u
 
 extern TSDLLEXPORT void ts_hypertable_permissions_check_by_id(int32 hypertable_id);
 extern Hypertable *ts_hypertable_from_tupleinfo(const TupleInfo *ti);
+extern Hypertable *ts_resolve_hypertable_from_table_or_cagg(Cache *hcache, Oid relid,
+															bool allow_matht);
 extern int ts_hypertable_scan_with_memory_context(const char *schema, const char *table,
 												  tuple_found_func tuple_found, void *data,
 												  LOCKMODE lockmode, bool tuplock,

--- a/tsl/test/expected/cagg_ddl.out
+++ b/tsl/test/expected/cagg_ddl.out
@@ -2013,3 +2013,29 @@ SELECT * FROM transactions_montly ORDER BY bucket;
  Wed Oct 31 17:00:00 2018 PDT |  70 |  10 |  10
 (2 rows)
 
+-- Check set_chunk_time_interval on continuous aggregate
+CREATE MATERIALIZED VIEW cagg_set_chunk_time_interval
+WITH (timescaledb.continuous) AS
+SELECT time_bucket(INTERVAL '1 month', time) AS bucket,
+       SUM(fiat_value),
+       MAX(fiat_value),
+       MIN(fiat_value)
+FROM transactions
+GROUP BY 1
+WITH NO DATA;
+SELECT set_chunk_time_interval('cagg_set_chunk_time_interval', chunk_time_interval => interval '1 month');
+ set_chunk_time_interval 
+-------------------------
+ 
+(1 row)
+
+CALL refresh_continuous_aggregate('cagg_set_chunk_time_interval', NULL, NULL);
+SELECT _timescaledb_internal.to_interval(d.interval_length) = interval '1 month'
+FROM _timescaledb_catalog.dimension d
+         RIGHT JOIN _timescaledb_catalog.continuous_agg ca ON ca.user_view_name = 'cagg_set_chunk_time_interval'
+WHERE d.hypertable_id = ca.mat_hypertable_id;
+ ?column? 
+----------
+ t
+(1 row)
+

--- a/tsl/test/expected/cagg_ddl_dist_ht.out
+++ b/tsl/test/expected/cagg_ddl_dist_ht.out
@@ -2056,6 +2056,32 @@ SELECT * FROM transactions_montly ORDER BY bucket;
  Wed Oct 31 17:00:00 2018 PDT |  70 |  10 |  10
 (2 rows)
 
+-- Check set_chunk_time_interval on continuous aggregate
+CREATE MATERIALIZED VIEW cagg_set_chunk_time_interval
+WITH (timescaledb.continuous) AS
+SELECT time_bucket(INTERVAL '1 month', time) AS bucket,
+       SUM(fiat_value),
+       MAX(fiat_value),
+       MIN(fiat_value)
+FROM transactions
+GROUP BY 1
+WITH NO DATA;
+SELECT set_chunk_time_interval('cagg_set_chunk_time_interval', chunk_time_interval => interval '1 month');
+ set_chunk_time_interval 
+-------------------------
+ 
+(1 row)
+
+CALL refresh_continuous_aggregate('cagg_set_chunk_time_interval', NULL, NULL);
+SELECT _timescaledb_internal.to_interval(d.interval_length) = interval '1 month'
+FROM _timescaledb_catalog.dimension d
+         RIGHT JOIN _timescaledb_catalog.continuous_agg ca ON ca.user_view_name = 'cagg_set_chunk_time_interval'
+WHERE d.hypertable_id = ca.mat_hypertable_id;
+ ?column? 
+----------
+ t
+(1 row)
+
 -- cleanup
 \c :TEST_DBNAME :ROLE_CLUSTER_SUPERUSER;
 DROP DATABASE :DATA_NODE_1;

--- a/tsl/test/sql/include/cagg_ddl_common.sql
+++ b/tsl/test/sql/include/cagg_ddl_common.sql
@@ -1341,3 +1341,22 @@ SELECT * FROM transactions_montly ORDER BY bucket;
 -- Full refresh the CAGG
 CALL refresh_continuous_aggregate('transactions_montly', NULL, NULL);
 SELECT * FROM transactions_montly ORDER BY bucket;
+
+-- Check set_chunk_time_interval on continuous aggregate
+CREATE MATERIALIZED VIEW cagg_set_chunk_time_interval
+WITH (timescaledb.continuous) AS
+SELECT time_bucket(INTERVAL '1 month', time) AS bucket,
+       SUM(fiat_value),
+       MAX(fiat_value),
+       MIN(fiat_value)
+FROM transactions
+GROUP BY 1
+WITH NO DATA;
+
+SELECT set_chunk_time_interval('cagg_set_chunk_time_interval', chunk_time_interval => interval '1 month');
+CALL refresh_continuous_aggregate('cagg_set_chunk_time_interval', NULL, NULL);
+
+SELECT _timescaledb_internal.to_interval(d.interval_length) = interval '1 month'
+FROM _timescaledb_catalog.dimension d
+         RIGHT JOIN _timescaledb_catalog.continuous_agg ca ON ca.user_view_name = 'cagg_set_chunk_time_interval'
+WHERE d.hypertable_id = ca.mat_hypertable_id;


### PR DESCRIPTION
This patch adds support to pass continuous aggregate names to the `set_chunk_time_interval` function to align it with functions, such as `show_chunks`, `drop_chunks`, and others.

It reuses the previously existing function to find a hypertable or resolve a continuous aggregate to its underlying hypertable found in chunk.c. It, however, moves the function to hypertable.c and exports it from here. There is some discussion if this functionality should stay in chunk.c, though, it feels wrong in that file now that it is exported.