### PR TITLE
Warn if result of ts_set_flags_32 is not used

### DIFF
--- a/src/utils.h
+++ b/src/utils.h
@@ -169,7 +169,7 @@ ts_flags_are_set_32(uint32 bitmap, uint32 flags)
 	return (bitmap & flags) == flags;
 }
 
-static inline uint32
+static inline pg_nodiscard uint32
 ts_set_flags_32(uint32 bitmap, uint32 flags)
 {
 	return bitmap | flags;


### PR DESCRIPTION
The `ts_set_flags_32` function takes a bitmap and flags and returns an updated bitmap. However, if the returned value is not used, the function call has no effect. An unused result may indicate the improper use of this function.

This patch adds the qualifier `pg_nodiscard` to the function which triggers a warning if the returned value is not used.

Disable-check: force-changelog-file