### PR TITLE
Update debian/ubuntu versions

### DIFF
--- a/.github/workflows/apt-arm-packages.yaml
+++ b/.github/workflows/apt-arm-packages.yaml
@@ -16,9 +16,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # Debian images:  10 (buster), 11 (bullseye)
-        # Ubuntu images:  20.04 LTS (focal), 22.04 (jammy)
-        image: [ "debian:10-slim","debian:11-slim","ubuntu:focal", "ubuntu:jammy"]
+        image: [ "debian:10-slim", "debian:11-slim","debian:12-slim","ubuntu:20.04", "ubuntu:22.04", "ubuntu:23.04"]
         pg: [ 12, 13, 14, 15 ]
 
     steps:

--- a/.github/workflows/apt-packages.yaml
+++ b/.github/workflows/apt-packages.yaml
@@ -20,9 +20,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # Debian images:  10 (buster), 11 (bullseye)
-        # Ubuntu images:  18.04 LTS (bionic), 20.04 LTS (focal), 21.10 (impish), 22.04 (jammy), 22.10 (kinetic)
-        image: [ "debian:10-slim", "debian:11-slim", "ubuntu:focal", "ubuntu:jammy", "ubuntu:kinetic"]
+        image: [ "debian:10-slim", "debian:11-slim","debian:12-slim","ubuntu:20.04", "ubuntu:22.04", "ubuntu:23.04"]
         pg: [ 12, 13, 14, 15 ]
         license: [ "TSL", "Apache"]
         include:


### PR DESCRIPTION
Add: Debian 12, Ubuntu 23.04
Remove: Debian 10, Ubuntu 22.10
Change references to use version numbers instead of release names.

Disable-check: force-changelog-file