### PR TITLE
Rectify interval calculation

### DIFF
--- a/.unreleased/bugfix_5734
+++ b/.unreleased/bugfix_5734
@@ -1,0 +1,5 @@
+Implements: #5860 Rectifies interval calculation for Heirarchical CAggs
+
+Fixes: #5734
+
+Thanks: @lukaskirner

--- a/test/sql/updates/post.repair.hierarchical_cagg.sql
+++ b/test/sql/updates/post.repair.hierarchical_cagg.sql
@@ -1,0 +1,6 @@
+-- This file and its contents are licensed under the Apache License 2.0.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-APACHE for a copy of the license.
+
+SELECT count(*) FROM agg_test_monthly;
+

--- a/test/sql/updates/post.repair.sql
+++ b/test/sql/updates/post.repair.sql
@@ -20,6 +20,7 @@ WHERE extname = 'timescaledb' \gset
 
 \if :test_repair_cagg_joins
 --Check if the repaired cagg with joins work alright now
-\ir post.repair.cagg_joins.sql
+    \ir post.repair.cagg_joins.sql
+    \ir post.repair.hierarchical_cagg.sql
 \endif
 

--- a/test/sql/updates/setup.repair.hierarchical_cagg.sql
+++ b/test/sql/updates/setup.repair.hierarchical_cagg.sql
@@ -1,0 +1,46 @@
+-- This file and its contents are licensed under the Apache License 2.0.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-APACHE for a copy of the license.
+
+CREATE TABLE test (
+  timestamp TIMESTAMPTZ NOT NULL,
+  device_id TEXT NOT NULL,
+  value INT NOT NULL,
+
+  CONSTRAINT uk_test_timestamp_device_id UNIQUE (timestamp, device_id)
+);
+
+SELECT create_hypertable('test', 'timestamp');
+
+INSERT INTO test (timestamp, device_id, value) VALUES
+  ('2023-05-01 00:00:00+00', 'sensor0', 1),
+  ('2023-05-15 00:00:00+00', 'sensor0', 2),
+  ('2023-05-31 00:00:00+00', 'sensor0', 10);
+
+
+CREATE MATERIALIZED VIEW  agg_test_hourly WITH (timescaledb.continuous) AS
+    SELECT
+        time_bucket('1 hour'::interval, timestamp) AS hour_timestamp,
+        device_id,
+        SUM(value)
+    FROM test
+    GROUP BY hour_timestamp, device_id
+WITH DATA;
+
+CREATE MATERIALIZED VIEW agg_test_daily WITH (timescaledb.continuous) AS
+    SELECT
+        time_bucket('1 day'::interval, hour_timestamp) AS day_timestamp,
+        device_id,
+        SUM(sum)
+    FROM agg_test_hourly
+    GROUP BY day_timestamp, device_id
+WITH DATA;
+
+CREATE MATERIALIZED VIEW agg_test_monthly WITH (timescaledb.continuous) AS
+    SELECT
+        time_bucket('1 month'::interval, day_timestamp) AS month_timestamp,
+        device_id,
+        SUM(sum)
+    FROM agg_test_daily
+    GROUP BY month_timestamp, device_id
+WITH DATA;

--- a/test/sql/updates/setup.repair.sql
+++ b/test/sql/updates/setup.repair.sql
@@ -189,7 +189,7 @@ DROP VIEW slices;
 \endif
 
 \ir setup.repair.cagg.sql
-
 \if :has_cagg_joins
+     \ir setup.repair.hierarchical_cagg.sql
      \ir setup.repair.cagg_joins.sql
 \endif

--- a/tsl/src/continuous_aggs/common.c
+++ b/tsl/src/continuous_aggs/common.c
@@ -583,20 +583,23 @@ get_bucket_width(CAggTimebucketInfo bucket_info)
 		case INTERVALOID:
 		{
 			/*
+			 * Original interval should not be changed, hence create a local copy
+			 * for this check.
+			 */
+			Interval interval = *bucket_info.interval;
+
+			/*
 			 * epoch will treat year as 365.25 days. This leads to the unexpected
 			 * result that year is not multiple of day or month, which is perceived
 			 * as a bug. For that reason, we treat all months as 30 days regardless of year
 			 */
-			if (bucket_info.interval->month && !bucket_info.interval->day &&
-				!bucket_info.interval->time)
+			if (interval.month && !interval.day && !interval.time)
 			{
-				bucket_info.interval->day = bucket_info.interval->month * DAYS_PER_MONTH;
-				bucket_info.interval->month = 0;
+				interval.day = interval.month * DAYS_PER_MONTH;
+				interval.month = 0;
 			}
-
 			/* Convert Interval to int64 */
-			width =
-				ts_interval_value_to_internal(IntervalPGetDatum(bucket_info.interval), INTERVALOID);
+			width = ts_interval_value_to_internal(IntervalPGetDatum(&interval), INTERVALOID);
 			break;
 		}
 		default:

--- a/tsl/test/expected/cagg_on_cagg.out
+++ b/tsl/test/expected/cagg_on_cagg.out
@@ -6,6 +6,7 @@
 \set IS_TIME_DIMENSION_WITH_TIMEZONE_1ST FALSE
 \set IS_TIME_DIMENSION_WITH_TIMEZONE_2TH FALSE
 \set IS_JOIN FALSE
+\set INTERVAL_TEST FALSE
 -- ########################################################
 -- ## INTEGER data type tests
 -- ########################################################
@@ -868,6 +869,7 @@ psql:include/cagg_on_cagg_common.sql:200: ERROR:  relation "conditions_summary_1
 -- LICENSE-TIMESCALE for a copy of the license.
 \set CAGG_NAME_1ST_LEVEL conditions_summary_1
 \set CAGG_NAME_2TH_LEVEL conditions_summary_2
+\set CAGG_NAME_3TH_LEVEL conditions_summary_3
 --
 -- CAGG on hypertable (1st level)
 --
@@ -920,16 +922,40 @@ SELECT
 FROM :CAGG_NAME_1ST_LEVEL
 GROUP BY 1
 WITH NO DATA;
-psql:include/cagg_on_cagg_validations.sql:43: ERROR:  cannot create continuous aggregate with incompatible bucket width
+psql:include/cagg_on_cagg_validations.sql:44: ERROR:  cannot create continuous aggregate with incompatible bucket width
 DETAIL:  Time bucket width of "public.conditions_summary_2" [5] should be multiple of the time bucket width of "public.conditions_summary_1" [2].
 \d+ :CAGG_NAME_2TH_LEVEL
 \set ON_ERROR_STOP 1
 \set VERBOSITY terse
+-- Check for incorrect CAGGs
+\if :INTERVAL_TEST
+  INSERT INTO conditions ("time", temperature, device_id) VALUES ('2022-01-01 00:00:00-00', 10, 4);
+  INSERT INTO conditions ("time", temperature, device_id) VALUES ('2022-01-15 01:00:00-00', 20, 4);
+  INSERT INTO conditions ("time", temperature, device_id) VALUES ('2022-01-31 01:00:00-00', 30, 4);
+  CALL refresh_continuous_aggregate(:'CAGG_NAME_1ST_LEVEL', NULL, NULL);
+  CALL refresh_continuous_aggregate(:'CAGG_NAME_2TH_LEVEL', NULL, NULL);
+  CREATE MATERIALIZED VIEW :CAGG_NAME_3TH_LEVEL
+  WITH (timescaledb.continuous) AS
+  SELECT
+    \if :IS_TIME_DIMENSION_WITH_TIMEZONE_2TH
+      time_bucket(:BUCKET_WIDTH_3TH, "bucket", :'BUCKET_TZNAME_2TH') AS bucket
+    \else
+      time_bucket(:BUCKET_WIDTH_3TH, "bucket") AS bucket
+    \endif
+  FROM :CAGG_NAME_2TH_LEVEL
+  GROUP BY 1
+  WITH DATA;
+  \d+ :CAGG_NAME_3TH_LEVEL
+  --There should never be dulpicates in the output of the following query
+  SELECT * from :CAGG_NAME_3TH_LEVEL;
+  DROP MATERIALIZED VIEW IF EXISTS :CAGG_NAME_3TH_LEVEL;
+  DELETE FROM conditions WHERE device_id = 4;
+\endif
 --
 -- Cleanup
 --
 DROP MATERIALIZED VIEW IF EXISTS :CAGG_NAME_2TH_LEVEL;
-psql:include/cagg_on_cagg_validations.sql:53: NOTICE:  materialized view "conditions_summary_2" does not exist, skipping
+psql:include/cagg_on_cagg_validations.sql:86: NOTICE:  materialized view "conditions_summary_2" does not exist, skipping
 DROP MATERIALIZED VIEW IF EXISTS :CAGG_NAME_1ST_LEVEL;
 --
 -- Validation test for equal bucket sizes
@@ -943,6 +969,7 @@ DROP MATERIALIZED VIEW IF EXISTS :CAGG_NAME_1ST_LEVEL;
 -- LICENSE-TIMESCALE for a copy of the license.
 \set CAGG_NAME_1ST_LEVEL conditions_summary_1
 \set CAGG_NAME_2TH_LEVEL conditions_summary_2
+\set CAGG_NAME_3TH_LEVEL conditions_summary_3
 --
 -- CAGG on hypertable (1st level)
 --
@@ -1015,6 +1042,30 @@ UNION ALL
 
 \set ON_ERROR_STOP 1
 \set VERBOSITY terse
+-- Check for incorrect CAGGs
+\if :INTERVAL_TEST
+  INSERT INTO conditions ("time", temperature, device_id) VALUES ('2022-01-01 00:00:00-00', 10, 4);
+  INSERT INTO conditions ("time", temperature, device_id) VALUES ('2022-01-15 01:00:00-00', 20, 4);
+  INSERT INTO conditions ("time", temperature, device_id) VALUES ('2022-01-31 01:00:00-00', 30, 4);
+  CALL refresh_continuous_aggregate(:'CAGG_NAME_1ST_LEVEL', NULL, NULL);
+  CALL refresh_continuous_aggregate(:'CAGG_NAME_2TH_LEVEL', NULL, NULL);
+  CREATE MATERIALIZED VIEW :CAGG_NAME_3TH_LEVEL
+  WITH (timescaledb.continuous) AS
+  SELECT
+    \if :IS_TIME_DIMENSION_WITH_TIMEZONE_2TH
+      time_bucket(:BUCKET_WIDTH_3TH, "bucket", :'BUCKET_TZNAME_2TH') AS bucket
+    \else
+      time_bucket(:BUCKET_WIDTH_3TH, "bucket") AS bucket
+    \endif
+  FROM :CAGG_NAME_2TH_LEVEL
+  GROUP BY 1
+  WITH DATA;
+  \d+ :CAGG_NAME_3TH_LEVEL
+  --There should never be dulpicates in the output of the following query
+  SELECT * from :CAGG_NAME_3TH_LEVEL;
+  DROP MATERIALIZED VIEW IF EXISTS :CAGG_NAME_3TH_LEVEL;
+  DELETE FROM conditions WHERE device_id = 4;
+\endif
 --
 -- Cleanup
 --
@@ -1032,6 +1083,7 @@ DROP MATERIALIZED VIEW IF EXISTS :CAGG_NAME_1ST_LEVEL;
 -- LICENSE-TIMESCALE for a copy of the license.
 \set CAGG_NAME_1ST_LEVEL conditions_summary_1
 \set CAGG_NAME_2TH_LEVEL conditions_summary_2
+\set CAGG_NAME_3TH_LEVEL conditions_summary_3
 --
 -- CAGG on hypertable (1st level)
 --
@@ -1084,16 +1136,40 @@ SELECT
 FROM :CAGG_NAME_1ST_LEVEL
 GROUP BY 1
 WITH NO DATA;
-psql:include/cagg_on_cagg_validations.sql:43: ERROR:  cannot create continuous aggregate with incompatible bucket width
+psql:include/cagg_on_cagg_validations.sql:44: ERROR:  cannot create continuous aggregate with incompatible bucket width
 DETAIL:  Time bucket width of "public.conditions_summary_2" [2] should be greater or equal than the time bucket width of "public.conditions_summary_1" [4].
 \d+ :CAGG_NAME_2TH_LEVEL
 \set ON_ERROR_STOP 1
 \set VERBOSITY terse
+-- Check for incorrect CAGGs
+\if :INTERVAL_TEST
+  INSERT INTO conditions ("time", temperature, device_id) VALUES ('2022-01-01 00:00:00-00', 10, 4);
+  INSERT INTO conditions ("time", temperature, device_id) VALUES ('2022-01-15 01:00:00-00', 20, 4);
+  INSERT INTO conditions ("time", temperature, device_id) VALUES ('2022-01-31 01:00:00-00', 30, 4);
+  CALL refresh_continuous_aggregate(:'CAGG_NAME_1ST_LEVEL', NULL, NULL);
+  CALL refresh_continuous_aggregate(:'CAGG_NAME_2TH_LEVEL', NULL, NULL);
+  CREATE MATERIALIZED VIEW :CAGG_NAME_3TH_LEVEL
+  WITH (timescaledb.continuous) AS
+  SELECT
+    \if :IS_TIME_DIMENSION_WITH_TIMEZONE_2TH
+      time_bucket(:BUCKET_WIDTH_3TH, "bucket", :'BUCKET_TZNAME_2TH') AS bucket
+    \else
+      time_bucket(:BUCKET_WIDTH_3TH, "bucket") AS bucket
+    \endif
+  FROM :CAGG_NAME_2TH_LEVEL
+  GROUP BY 1
+  WITH DATA;
+  \d+ :CAGG_NAME_3TH_LEVEL
+  --There should never be dulpicates in the output of the following query
+  SELECT * from :CAGG_NAME_3TH_LEVEL;
+  DROP MATERIALIZED VIEW IF EXISTS :CAGG_NAME_3TH_LEVEL;
+  DELETE FROM conditions WHERE device_id = 4;
+\endif
 --
 -- Cleanup
 --
 DROP MATERIALIZED VIEW IF EXISTS :CAGG_NAME_2TH_LEVEL;
-psql:include/cagg_on_cagg_validations.sql:53: NOTICE:  materialized view "conditions_summary_2" does not exist, skipping
+psql:include/cagg_on_cagg_validations.sql:86: NOTICE:  materialized view "conditions_summary_2" does not exist, skipping
 DROP MATERIALIZED VIEW IF EXISTS :CAGG_NAME_1ST_LEVEL;
 -- ########################################################
 -- ## TIMESTAMP data type tests
@@ -1949,6 +2025,7 @@ psql:include/cagg_on_cagg_common.sql:200: ERROR:  relation "conditions_summary_1
 -- LICENSE-TIMESCALE for a copy of the license.
 \set CAGG_NAME_1ST_LEVEL conditions_summary_1
 \set CAGG_NAME_2TH_LEVEL conditions_summary_2
+\set CAGG_NAME_3TH_LEVEL conditions_summary_3
 --
 -- CAGG on hypertable (1st level)
 --
@@ -2001,17 +2078,41 @@ SELECT
 FROM :CAGG_NAME_1ST_LEVEL
 GROUP BY 1
 WITH NO DATA;
-psql:include/cagg_on_cagg_validations.sql:43: ERROR:  cannot create continuous aggregate with fixed-width bucket on top of one using variable-width bucket
+psql:include/cagg_on_cagg_validations.sql:44: ERROR:  cannot create continuous aggregate with fixed-width bucket on top of one using variable-width bucket
 DETAIL:  Continuous aggregate with a fixed time bucket width (e.g. 61 days) cannot be created on top of one using variable time bucket width (e.g. 1 month).
 The variance can lead to the fixed width one not being a multiple of the variable width one.
 \d+ :CAGG_NAME_2TH_LEVEL
 \set ON_ERROR_STOP 1
 \set VERBOSITY terse
+-- Check for incorrect CAGGs
+\if :INTERVAL_TEST
+  INSERT INTO conditions ("time", temperature, device_id) VALUES ('2022-01-01 00:00:00-00', 10, 4);
+  INSERT INTO conditions ("time", temperature, device_id) VALUES ('2022-01-15 01:00:00-00', 20, 4);
+  INSERT INTO conditions ("time", temperature, device_id) VALUES ('2022-01-31 01:00:00-00', 30, 4);
+  CALL refresh_continuous_aggregate(:'CAGG_NAME_1ST_LEVEL', NULL, NULL);
+  CALL refresh_continuous_aggregate(:'CAGG_NAME_2TH_LEVEL', NULL, NULL);
+  CREATE MATERIALIZED VIEW :CAGG_NAME_3TH_LEVEL
+  WITH (timescaledb.continuous) AS
+  SELECT
+    \if :IS_TIME_DIMENSION_WITH_TIMEZONE_2TH
+      time_bucket(:BUCKET_WIDTH_3TH, "bucket", :'BUCKET_TZNAME_2TH') AS bucket
+    \else
+      time_bucket(:BUCKET_WIDTH_3TH, "bucket") AS bucket
+    \endif
+  FROM :CAGG_NAME_2TH_LEVEL
+  GROUP BY 1
+  WITH DATA;
+  \d+ :CAGG_NAME_3TH_LEVEL
+  --There should never be dulpicates in the output of the following query
+  SELECT * from :CAGG_NAME_3TH_LEVEL;
+  DROP MATERIALIZED VIEW IF EXISTS :CAGG_NAME_3TH_LEVEL;
+  DELETE FROM conditions WHERE device_id = 4;
+\endif
 --
 -- Cleanup
 --
 DROP MATERIALIZED VIEW IF EXISTS :CAGG_NAME_2TH_LEVEL;
-psql:include/cagg_on_cagg_validations.sql:53: NOTICE:  materialized view "conditions_summary_2" does not exist, skipping
+psql:include/cagg_on_cagg_validations.sql:86: NOTICE:  materialized view "conditions_summary_2" does not exist, skipping
 DROP MATERIALIZED VIEW IF EXISTS :CAGG_NAME_1ST_LEVEL;
 --
 -- Validation test for non-multiple bucket sizes
@@ -2025,6 +2126,7 @@ DROP MATERIALIZED VIEW IF EXISTS :CAGG_NAME_1ST_LEVEL;
 -- LICENSE-TIMESCALE for a copy of the license.
 \set CAGG_NAME_1ST_LEVEL conditions_summary_1
 \set CAGG_NAME_2TH_LEVEL conditions_summary_2
+\set CAGG_NAME_3TH_LEVEL conditions_summary_3
 --
 -- CAGG on hypertable (1st level)
 --
@@ -2077,16 +2179,40 @@ SELECT
 FROM :CAGG_NAME_1ST_LEVEL
 GROUP BY 1
 WITH NO DATA;
-psql:include/cagg_on_cagg_validations.sql:43: ERROR:  cannot create continuous aggregate with incompatible bucket width
+psql:include/cagg_on_cagg_validations.sql:44: ERROR:  cannot create continuous aggregate with incompatible bucket width
 DETAIL:  Time bucket width of "public.conditions_summary_2" [@ 3 hours] should be multiple of the time bucket width of "public.conditions_summary_1" [@ 2 hours].
 \d+ :CAGG_NAME_2TH_LEVEL
 \set ON_ERROR_STOP 1
 \set VERBOSITY terse
+-- Check for incorrect CAGGs
+\if :INTERVAL_TEST
+  INSERT INTO conditions ("time", temperature, device_id) VALUES ('2022-01-01 00:00:00-00', 10, 4);
+  INSERT INTO conditions ("time", temperature, device_id) VALUES ('2022-01-15 01:00:00-00', 20, 4);
+  INSERT INTO conditions ("time", temperature, device_id) VALUES ('2022-01-31 01:00:00-00', 30, 4);
+  CALL refresh_continuous_aggregate(:'CAGG_NAME_1ST_LEVEL', NULL, NULL);
+  CALL refresh_continuous_aggregate(:'CAGG_NAME_2TH_LEVEL', NULL, NULL);
+  CREATE MATERIALIZED VIEW :CAGG_NAME_3TH_LEVEL
+  WITH (timescaledb.continuous) AS
+  SELECT
+    \if :IS_TIME_DIMENSION_WITH_TIMEZONE_2TH
+      time_bucket(:BUCKET_WIDTH_3TH, "bucket", :'BUCKET_TZNAME_2TH') AS bucket
+    \else
+      time_bucket(:BUCKET_WIDTH_3TH, "bucket") AS bucket
+    \endif
+  FROM :CAGG_NAME_2TH_LEVEL
+  GROUP BY 1
+  WITH DATA;
+  \d+ :CAGG_NAME_3TH_LEVEL
+  --There should never be dulpicates in the output of the following query
+  SELECT * from :CAGG_NAME_3TH_LEVEL;
+  DROP MATERIALIZED VIEW IF EXISTS :CAGG_NAME_3TH_LEVEL;
+  DELETE FROM conditions WHERE device_id = 4;
+\endif
 --
 -- Cleanup
 --
 DROP MATERIALIZED VIEW IF EXISTS :CAGG_NAME_2TH_LEVEL;
-psql:include/cagg_on_cagg_validations.sql:53: NOTICE:  materialized view "conditions_summary_2" does not exist, skipping
+psql:include/cagg_on_cagg_validations.sql:86: NOTICE:  materialized view "conditions_summary_2" does not exist, skipping
 DROP MATERIALIZED VIEW IF EXISTS :CAGG_NAME_1ST_LEVEL;
 --
 -- Validation test for equal bucket sizes
@@ -2100,6 +2226,7 @@ DROP MATERIALIZED VIEW IF EXISTS :CAGG_NAME_1ST_LEVEL;
 -- LICENSE-TIMESCALE for a copy of the license.
 \set CAGG_NAME_1ST_LEVEL conditions_summary_1
 \set CAGG_NAME_2TH_LEVEL conditions_summary_2
+\set CAGG_NAME_3TH_LEVEL conditions_summary_3
 --
 -- CAGG on hypertable (1st level)
 --
@@ -2172,6 +2299,30 @@ UNION ALL
 
 \set ON_ERROR_STOP 1
 \set VERBOSITY terse
+-- Check for incorrect CAGGs
+\if :INTERVAL_TEST
+  INSERT INTO conditions ("time", temperature, device_id) VALUES ('2022-01-01 00:00:00-00', 10, 4);
+  INSERT INTO conditions ("time", temperature, device_id) VALUES ('2022-01-15 01:00:00-00', 20, 4);
+  INSERT INTO conditions ("time", temperature, device_id) VALUES ('2022-01-31 01:00:00-00', 30, 4);
+  CALL refresh_continuous_aggregate(:'CAGG_NAME_1ST_LEVEL', NULL, NULL);
+  CALL refresh_continuous_aggregate(:'CAGG_NAME_2TH_LEVEL', NULL, NULL);
+  CREATE MATERIALIZED VIEW :CAGG_NAME_3TH_LEVEL
+  WITH (timescaledb.continuous) AS
+  SELECT
+    \if :IS_TIME_DIMENSION_WITH_TIMEZONE_2TH
+      time_bucket(:BUCKET_WIDTH_3TH, "bucket", :'BUCKET_TZNAME_2TH') AS bucket
+    \else
+      time_bucket(:BUCKET_WIDTH_3TH, "bucket") AS bucket
+    \endif
+  FROM :CAGG_NAME_2TH_LEVEL
+  GROUP BY 1
+  WITH DATA;
+  \d+ :CAGG_NAME_3TH_LEVEL
+  --There should never be dulpicates in the output of the following query
+  SELECT * from :CAGG_NAME_3TH_LEVEL;
+  DROP MATERIALIZED VIEW IF EXISTS :CAGG_NAME_3TH_LEVEL;
+  DELETE FROM conditions WHERE device_id = 4;
+\endif
 --
 -- Cleanup
 --
@@ -2189,6 +2340,7 @@ DROP MATERIALIZED VIEW IF EXISTS :CAGG_NAME_1ST_LEVEL;
 -- LICENSE-TIMESCALE for a copy of the license.
 \set CAGG_NAME_1ST_LEVEL conditions_summary_1
 \set CAGG_NAME_2TH_LEVEL conditions_summary_2
+\set CAGG_NAME_3TH_LEVEL conditions_summary_3
 --
 -- CAGG on hypertable (1st level)
 --
@@ -2241,16 +2393,40 @@ SELECT
 FROM :CAGG_NAME_1ST_LEVEL
 GROUP BY 1
 WITH NO DATA;
-psql:include/cagg_on_cagg_validations.sql:43: ERROR:  cannot create continuous aggregate with incompatible bucket width
+psql:include/cagg_on_cagg_validations.sql:44: ERROR:  cannot create continuous aggregate with incompatible bucket width
 DETAIL:  Time bucket width of "public.conditions_summary_2" [@ 1 hour] should be greater or equal than the time bucket width of "public.conditions_summary_1" [@ 2 hours].
 \d+ :CAGG_NAME_2TH_LEVEL
 \set ON_ERROR_STOP 1
 \set VERBOSITY terse
+-- Check for incorrect CAGGs
+\if :INTERVAL_TEST
+  INSERT INTO conditions ("time", temperature, device_id) VALUES ('2022-01-01 00:00:00-00', 10, 4);
+  INSERT INTO conditions ("time", temperature, device_id) VALUES ('2022-01-15 01:00:00-00', 20, 4);
+  INSERT INTO conditions ("time", temperature, device_id) VALUES ('2022-01-31 01:00:00-00', 30, 4);
+  CALL refresh_continuous_aggregate(:'CAGG_NAME_1ST_LEVEL', NULL, NULL);
+  CALL refresh_continuous_aggregate(:'CAGG_NAME_2TH_LEVEL', NULL, NULL);
+  CREATE MATERIALIZED VIEW :CAGG_NAME_3TH_LEVEL
+  WITH (timescaledb.continuous) AS
+  SELECT
+    \if :IS_TIME_DIMENSION_WITH_TIMEZONE_2TH
+      time_bucket(:BUCKET_WIDTH_3TH, "bucket", :'BUCKET_TZNAME_2TH') AS bucket
+    \else
+      time_bucket(:BUCKET_WIDTH_3TH, "bucket") AS bucket
+    \endif
+  FROM :CAGG_NAME_2TH_LEVEL
+  GROUP BY 1
+  WITH DATA;
+  \d+ :CAGG_NAME_3TH_LEVEL
+  --There should never be dulpicates in the output of the following query
+  SELECT * from :CAGG_NAME_3TH_LEVEL;
+  DROP MATERIALIZED VIEW IF EXISTS :CAGG_NAME_3TH_LEVEL;
+  DELETE FROM conditions WHERE device_id = 4;
+\endif
 --
 -- Cleanup
 --
 DROP MATERIALIZED VIEW IF EXISTS :CAGG_NAME_2TH_LEVEL;
-psql:include/cagg_on_cagg_validations.sql:53: NOTICE:  materialized view "conditions_summary_2" does not exist, skipping
+psql:include/cagg_on_cagg_validations.sql:86: NOTICE:  materialized view "conditions_summary_2" does not exist, skipping
 DROP MATERIALIZED VIEW IF EXISTS :CAGG_NAME_1ST_LEVEL;
 -- ########################################################
 -- ## TIMESTAMPTZ data type tests
@@ -3104,6 +3280,7 @@ psql:include/cagg_on_cagg_common.sql:200: ERROR:  relation "conditions_summary_1
 -- LICENSE-TIMESCALE for a copy of the license.
 \set CAGG_NAME_1ST_LEVEL conditions_summary_1
 \set CAGG_NAME_2TH_LEVEL conditions_summary_2
+\set CAGG_NAME_3TH_LEVEL conditions_summary_3
 --
 -- CAGG on hypertable (1st level)
 --
@@ -3156,17 +3333,41 @@ SELECT
 FROM :CAGG_NAME_1ST_LEVEL
 GROUP BY 1
 WITH NO DATA;
-psql:include/cagg_on_cagg_validations.sql:43: ERROR:  cannot create continuous aggregate with fixed-width bucket on top of one using variable-width bucket
+psql:include/cagg_on_cagg_validations.sql:44: ERROR:  cannot create continuous aggregate with fixed-width bucket on top of one using variable-width bucket
 DETAIL:  Continuous aggregate with a fixed time bucket width (e.g. 61 days) cannot be created on top of one using variable time bucket width (e.g. 1 month).
 The variance can lead to the fixed width one not being a multiple of the variable width one.
 \d+ :CAGG_NAME_2TH_LEVEL
 \set ON_ERROR_STOP 1
 \set VERBOSITY terse
+-- Check for incorrect CAGGs
+\if :INTERVAL_TEST
+  INSERT INTO conditions ("time", temperature, device_id) VALUES ('2022-01-01 00:00:00-00', 10, 4);
+  INSERT INTO conditions ("time", temperature, device_id) VALUES ('2022-01-15 01:00:00-00', 20, 4);
+  INSERT INTO conditions ("time", temperature, device_id) VALUES ('2022-01-31 01:00:00-00', 30, 4);
+  CALL refresh_continuous_aggregate(:'CAGG_NAME_1ST_LEVEL', NULL, NULL);
+  CALL refresh_continuous_aggregate(:'CAGG_NAME_2TH_LEVEL', NULL, NULL);
+  CREATE MATERIALIZED VIEW :CAGG_NAME_3TH_LEVEL
+  WITH (timescaledb.continuous) AS
+  SELECT
+    \if :IS_TIME_DIMENSION_WITH_TIMEZONE_2TH
+      time_bucket(:BUCKET_WIDTH_3TH, "bucket", :'BUCKET_TZNAME_2TH') AS bucket
+    \else
+      time_bucket(:BUCKET_WIDTH_3TH, "bucket") AS bucket
+    \endif
+  FROM :CAGG_NAME_2TH_LEVEL
+  GROUP BY 1
+  WITH DATA;
+  \d+ :CAGG_NAME_3TH_LEVEL
+  --There should never be dulpicates in the output of the following query
+  SELECT * from :CAGG_NAME_3TH_LEVEL;
+  DROP MATERIALIZED VIEW IF EXISTS :CAGG_NAME_3TH_LEVEL;
+  DELETE FROM conditions WHERE device_id = 4;
+\endif
 --
 -- Cleanup
 --
 DROP MATERIALIZED VIEW IF EXISTS :CAGG_NAME_2TH_LEVEL;
-psql:include/cagg_on_cagg_validations.sql:53: NOTICE:  materialized view "conditions_summary_2" does not exist, skipping
+psql:include/cagg_on_cagg_validations.sql:86: NOTICE:  materialized view "conditions_summary_2" does not exist, skipping
 DROP MATERIALIZED VIEW IF EXISTS :CAGG_NAME_1ST_LEVEL;
 --
 -- Validation test for non-multiple bucket sizes
@@ -3180,6 +3381,7 @@ DROP MATERIALIZED VIEW IF EXISTS :CAGG_NAME_1ST_LEVEL;
 -- LICENSE-TIMESCALE for a copy of the license.
 \set CAGG_NAME_1ST_LEVEL conditions_summary_1
 \set CAGG_NAME_2TH_LEVEL conditions_summary_2
+\set CAGG_NAME_3TH_LEVEL conditions_summary_3
 --
 -- CAGG on hypertable (1st level)
 --
@@ -3232,16 +3434,40 @@ SELECT
 FROM :CAGG_NAME_1ST_LEVEL
 GROUP BY 1
 WITH NO DATA;
-psql:include/cagg_on_cagg_validations.sql:43: ERROR:  cannot create continuous aggregate with incompatible bucket width
+psql:include/cagg_on_cagg_validations.sql:44: ERROR:  cannot create continuous aggregate with incompatible bucket width
 DETAIL:  Time bucket width of "public.conditions_summary_2" [@ 3 hours] should be multiple of the time bucket width of "public.conditions_summary_1" [@ 2 hours].
 \d+ :CAGG_NAME_2TH_LEVEL
 \set ON_ERROR_STOP 1
 \set VERBOSITY terse
+-- Check for incorrect CAGGs
+\if :INTERVAL_TEST
+  INSERT INTO conditions ("time", temperature, device_id) VALUES ('2022-01-01 00:00:00-00', 10, 4);
+  INSERT INTO conditions ("time", temperature, device_id) VALUES ('2022-01-15 01:00:00-00', 20, 4);
+  INSERT INTO conditions ("time", temperature, device_id) VALUES ('2022-01-31 01:00:00-00', 30, 4);
+  CALL refresh_continuous_aggregate(:'CAGG_NAME_1ST_LEVEL', NULL, NULL);
+  CALL refresh_continuous_aggregate(:'CAGG_NAME_2TH_LEVEL', NULL, NULL);
+  CREATE MATERIALIZED VIEW :CAGG_NAME_3TH_LEVEL
+  WITH (timescaledb.continuous) AS
+  SELECT
+    \if :IS_TIME_DIMENSION_WITH_TIMEZONE_2TH
+      time_bucket(:BUCKET_WIDTH_3TH, "bucket", :'BUCKET_TZNAME_2TH') AS bucket
+    \else
+      time_bucket(:BUCKET_WIDTH_3TH, "bucket") AS bucket
+    \endif
+  FROM :CAGG_NAME_2TH_LEVEL
+  GROUP BY 1
+  WITH DATA;
+  \d+ :CAGG_NAME_3TH_LEVEL
+  --There should never be dulpicates in the output of the following query
+  SELECT * from :CAGG_NAME_3TH_LEVEL;
+  DROP MATERIALIZED VIEW IF EXISTS :CAGG_NAME_3TH_LEVEL;
+  DELETE FROM conditions WHERE device_id = 4;
+\endif
 --
 -- Cleanup
 --
 DROP MATERIALIZED VIEW IF EXISTS :CAGG_NAME_2TH_LEVEL;
-psql:include/cagg_on_cagg_validations.sql:53: NOTICE:  materialized view "conditions_summary_2" does not exist, skipping
+psql:include/cagg_on_cagg_validations.sql:86: NOTICE:  materialized view "conditions_summary_2" does not exist, skipping
 DROP MATERIALIZED VIEW IF EXISTS :CAGG_NAME_1ST_LEVEL;
 --
 -- Validation test for equal bucket sizes
@@ -3255,6 +3481,7 @@ DROP MATERIALIZED VIEW IF EXISTS :CAGG_NAME_1ST_LEVEL;
 -- LICENSE-TIMESCALE for a copy of the license.
 \set CAGG_NAME_1ST_LEVEL conditions_summary_1
 \set CAGG_NAME_2TH_LEVEL conditions_summary_2
+\set CAGG_NAME_3TH_LEVEL conditions_summary_3
 --
 -- CAGG on hypertable (1st level)
 --
@@ -3327,6 +3554,30 @@ UNION ALL
 
 \set ON_ERROR_STOP 1
 \set VERBOSITY terse
+-- Check for incorrect CAGGs
+\if :INTERVAL_TEST
+  INSERT INTO conditions ("time", temperature, device_id) VALUES ('2022-01-01 00:00:00-00', 10, 4);
+  INSERT INTO conditions ("time", temperature, device_id) VALUES ('2022-01-15 01:00:00-00', 20, 4);
+  INSERT INTO conditions ("time", temperature, device_id) VALUES ('2022-01-31 01:00:00-00', 30, 4);
+  CALL refresh_continuous_aggregate(:'CAGG_NAME_1ST_LEVEL', NULL, NULL);
+  CALL refresh_continuous_aggregate(:'CAGG_NAME_2TH_LEVEL', NULL, NULL);
+  CREATE MATERIALIZED VIEW :CAGG_NAME_3TH_LEVEL
+  WITH (timescaledb.continuous) AS
+  SELECT
+    \if :IS_TIME_DIMENSION_WITH_TIMEZONE_2TH
+      time_bucket(:BUCKET_WIDTH_3TH, "bucket", :'BUCKET_TZNAME_2TH') AS bucket
+    \else
+      time_bucket(:BUCKET_WIDTH_3TH, "bucket") AS bucket
+    \endif
+  FROM :CAGG_NAME_2TH_LEVEL
+  GROUP BY 1
+  WITH DATA;
+  \d+ :CAGG_NAME_3TH_LEVEL
+  --There should never be dulpicates in the output of the following query
+  SELECT * from :CAGG_NAME_3TH_LEVEL;
+  DROP MATERIALIZED VIEW IF EXISTS :CAGG_NAME_3TH_LEVEL;
+  DELETE FROM conditions WHERE device_id = 4;
+\endif
 --
 -- Cleanup
 --
@@ -3344,6 +3595,7 @@ DROP MATERIALIZED VIEW IF EXISTS :CAGG_NAME_1ST_LEVEL;
 -- LICENSE-TIMESCALE for a copy of the license.
 \set CAGG_NAME_1ST_LEVEL conditions_summary_1
 \set CAGG_NAME_2TH_LEVEL conditions_summary_2
+\set CAGG_NAME_3TH_LEVEL conditions_summary_3
 --
 -- CAGG on hypertable (1st level)
 --
@@ -3396,16 +3648,40 @@ SELECT
 FROM :CAGG_NAME_1ST_LEVEL
 GROUP BY 1
 WITH NO DATA;
-psql:include/cagg_on_cagg_validations.sql:43: ERROR:  cannot create continuous aggregate with incompatible bucket width
+psql:include/cagg_on_cagg_validations.sql:44: ERROR:  cannot create continuous aggregate with incompatible bucket width
 DETAIL:  Time bucket width of "public.conditions_summary_2" [@ 1 hour] should be greater or equal than the time bucket width of "public.conditions_summary_1" [@ 2 hours].
 \d+ :CAGG_NAME_2TH_LEVEL
 \set ON_ERROR_STOP 1
 \set VERBOSITY terse
+-- Check for incorrect CAGGs
+\if :INTERVAL_TEST
+  INSERT INTO conditions ("time", temperature, device_id) VALUES ('2022-01-01 00:00:00-00', 10, 4);
+  INSERT INTO conditions ("time", temperature, device_id) VALUES ('2022-01-15 01:00:00-00', 20, 4);
+  INSERT INTO conditions ("time", temperature, device_id) VALUES ('2022-01-31 01:00:00-00', 30, 4);
+  CALL refresh_continuous_aggregate(:'CAGG_NAME_1ST_LEVEL', NULL, NULL);
+  CALL refresh_continuous_aggregate(:'CAGG_NAME_2TH_LEVEL', NULL, NULL);
+  CREATE MATERIALIZED VIEW :CAGG_NAME_3TH_LEVEL
+  WITH (timescaledb.continuous) AS
+  SELECT
+    \if :IS_TIME_DIMENSION_WITH_TIMEZONE_2TH
+      time_bucket(:BUCKET_WIDTH_3TH, "bucket", :'BUCKET_TZNAME_2TH') AS bucket
+    \else
+      time_bucket(:BUCKET_WIDTH_3TH, "bucket") AS bucket
+    \endif
+  FROM :CAGG_NAME_2TH_LEVEL
+  GROUP BY 1
+  WITH DATA;
+  \d+ :CAGG_NAME_3TH_LEVEL
+  --There should never be dulpicates in the output of the following query
+  SELECT * from :CAGG_NAME_3TH_LEVEL;
+  DROP MATERIALIZED VIEW IF EXISTS :CAGG_NAME_3TH_LEVEL;
+  DELETE FROM conditions WHERE device_id = 4;
+\endif
 --
 -- Cleanup
 --
 DROP MATERIALIZED VIEW IF EXISTS :CAGG_NAME_2TH_LEVEL;
-psql:include/cagg_on_cagg_validations.sql:53: NOTICE:  materialized view "conditions_summary_2" does not exist, skipping
+psql:include/cagg_on_cagg_validations.sql:86: NOTICE:  materialized view "conditions_summary_2" does not exist, skipping
 DROP MATERIALIZED VIEW IF EXISTS :CAGG_NAME_1ST_LEVEL;
 --
 -- Validations using time bucket with timezone (ref issue #5126)
@@ -3426,6 +3702,7 @@ DROP MATERIALIZED VIEW IF EXISTS :CAGG_NAME_1ST_LEVEL;
 -- LICENSE-TIMESCALE for a copy of the license.
 \set CAGG_NAME_1ST_LEVEL conditions_summary_1
 \set CAGG_NAME_2TH_LEVEL conditions_summary_2
+\set CAGG_NAME_3TH_LEVEL conditions_summary_3
 --
 -- CAGG on hypertable (1st level)
 --
@@ -3498,6 +3775,30 @@ UNION ALL
 
 \set ON_ERROR_STOP 1
 \set VERBOSITY terse
+-- Check for incorrect CAGGs
+\if :INTERVAL_TEST
+  INSERT INTO conditions ("time", temperature, device_id) VALUES ('2022-01-01 00:00:00-00', 10, 4);
+  INSERT INTO conditions ("time", temperature, device_id) VALUES ('2022-01-15 01:00:00-00', 20, 4);
+  INSERT INTO conditions ("time", temperature, device_id) VALUES ('2022-01-31 01:00:00-00', 30, 4);
+  CALL refresh_continuous_aggregate(:'CAGG_NAME_1ST_LEVEL', NULL, NULL);
+  CALL refresh_continuous_aggregate(:'CAGG_NAME_2TH_LEVEL', NULL, NULL);
+  CREATE MATERIALIZED VIEW :CAGG_NAME_3TH_LEVEL
+  WITH (timescaledb.continuous) AS
+  SELECT
+    \if :IS_TIME_DIMENSION_WITH_TIMEZONE_2TH
+      time_bucket(:BUCKET_WIDTH_3TH, "bucket", :'BUCKET_TZNAME_2TH') AS bucket
+    \else
+      time_bucket(:BUCKET_WIDTH_3TH, "bucket") AS bucket
+    \endif
+  FROM :CAGG_NAME_2TH_LEVEL
+  GROUP BY 1
+  WITH DATA;
+  \d+ :CAGG_NAME_3TH_LEVEL
+  --There should never be dulpicates in the output of the following query
+  SELECT * from :CAGG_NAME_3TH_LEVEL;
+  DROP MATERIALIZED VIEW IF EXISTS :CAGG_NAME_3TH_LEVEL;
+  DELETE FROM conditions WHERE device_id = 4;
+\endif
 --
 -- Cleanup
 --
@@ -3512,6 +3813,7 @@ DROP MATERIALIZED VIEW IF EXISTS :CAGG_NAME_1ST_LEVEL;
 -- LICENSE-TIMESCALE for a copy of the license.
 \set CAGG_NAME_1ST_LEVEL conditions_summary_1
 \set CAGG_NAME_2TH_LEVEL conditions_summary_2
+\set CAGG_NAME_3TH_LEVEL conditions_summary_3
 --
 -- CAGG on hypertable (1st level)
 --
@@ -3564,16 +3866,40 @@ SELECT
 FROM :CAGG_NAME_1ST_LEVEL
 GROUP BY 1
 WITH NO DATA;
-psql:include/cagg_on_cagg_validations.sql:43: ERROR:  cannot create continuous aggregate with incompatible bucket width
+psql:include/cagg_on_cagg_validations.sql:44: ERROR:  cannot create continuous aggregate with incompatible bucket width
 DETAIL:  Time bucket width of "public.conditions_summary_2" [@ 16 mins] should be multiple of the time bucket width of "public.conditions_summary_1" [@ 5 mins].
 \d+ :CAGG_NAME_2TH_LEVEL
 \set ON_ERROR_STOP 1
 \set VERBOSITY terse
+-- Check for incorrect CAGGs
+\if :INTERVAL_TEST
+  INSERT INTO conditions ("time", temperature, device_id) VALUES ('2022-01-01 00:00:00-00', 10, 4);
+  INSERT INTO conditions ("time", temperature, device_id) VALUES ('2022-01-15 01:00:00-00', 20, 4);
+  INSERT INTO conditions ("time", temperature, device_id) VALUES ('2022-01-31 01:00:00-00', 30, 4);
+  CALL refresh_continuous_aggregate(:'CAGG_NAME_1ST_LEVEL', NULL, NULL);
+  CALL refresh_continuous_aggregate(:'CAGG_NAME_2TH_LEVEL', NULL, NULL);
+  CREATE MATERIALIZED VIEW :CAGG_NAME_3TH_LEVEL
+  WITH (timescaledb.continuous) AS
+  SELECT
+    \if :IS_TIME_DIMENSION_WITH_TIMEZONE_2TH
+      time_bucket(:BUCKET_WIDTH_3TH, "bucket", :'BUCKET_TZNAME_2TH') AS bucket
+    \else
+      time_bucket(:BUCKET_WIDTH_3TH, "bucket") AS bucket
+    \endif
+  FROM :CAGG_NAME_2TH_LEVEL
+  GROUP BY 1
+  WITH DATA;
+  \d+ :CAGG_NAME_3TH_LEVEL
+  --There should never be dulpicates in the output of the following query
+  SELECT * from :CAGG_NAME_3TH_LEVEL;
+  DROP MATERIALIZED VIEW IF EXISTS :CAGG_NAME_3TH_LEVEL;
+  DELETE FROM conditions WHERE device_id = 4;
+\endif
 --
 -- Cleanup
 --
 DROP MATERIALIZED VIEW IF EXISTS :CAGG_NAME_2TH_LEVEL;
-psql:include/cagg_on_cagg_validations.sql:53: NOTICE:  materialized view "conditions_summary_2" does not exist, skipping
+psql:include/cagg_on_cagg_validations.sql:86: NOTICE:  materialized view "conditions_summary_2" does not exist, skipping
 DROP MATERIALIZED VIEW IF EXISTS :CAGG_NAME_1ST_LEVEL;
 --
 -- Variable bucket size with the same timezones
@@ -3589,6 +3915,7 @@ DROP MATERIALIZED VIEW IF EXISTS :CAGG_NAME_1ST_LEVEL;
 -- LICENSE-TIMESCALE for a copy of the license.
 \set CAGG_NAME_1ST_LEVEL conditions_summary_1
 \set CAGG_NAME_2TH_LEVEL conditions_summary_2
+\set CAGG_NAME_3TH_LEVEL conditions_summary_3
 --
 -- CAGG on hypertable (1st level)
 --
@@ -3661,25 +3988,47 @@ UNION ALL
 
 \set ON_ERROR_STOP 1
 \set VERBOSITY terse
+-- Check for incorrect CAGGs
+\if :INTERVAL_TEST
+  INSERT INTO conditions ("time", temperature, device_id) VALUES ('2022-01-01 00:00:00-00', 10, 4);
+  INSERT INTO conditions ("time", temperature, device_id) VALUES ('2022-01-15 01:00:00-00', 20, 4);
+  INSERT INTO conditions ("time", temperature, device_id) VALUES ('2022-01-31 01:00:00-00', 30, 4);
+  CALL refresh_continuous_aggregate(:'CAGG_NAME_1ST_LEVEL', NULL, NULL);
+  CALL refresh_continuous_aggregate(:'CAGG_NAME_2TH_LEVEL', NULL, NULL);
+  CREATE MATERIALIZED VIEW :CAGG_NAME_3TH_LEVEL
+  WITH (timescaledb.continuous) AS
+  SELECT
+    \if :IS_TIME_DIMENSION_WITH_TIMEZONE_2TH
+      time_bucket(:BUCKET_WIDTH_3TH, "bucket", :'BUCKET_TZNAME_2TH') AS bucket
+    \else
+      time_bucket(:BUCKET_WIDTH_3TH, "bucket") AS bucket
+    \endif
+  FROM :CAGG_NAME_2TH_LEVEL
+  GROUP BY 1
+  WITH DATA;
+  \d+ :CAGG_NAME_3TH_LEVEL
+  --There should never be dulpicates in the output of the following query
+  SELECT * from :CAGG_NAME_3TH_LEVEL;
+  DROP MATERIALIZED VIEW IF EXISTS :CAGG_NAME_3TH_LEVEL;
+  DELETE FROM conditions WHERE device_id = 4;
+\endif
 --
 -- Cleanup
 --
 DROP MATERIALIZED VIEW IF EXISTS :CAGG_NAME_2TH_LEVEL;
 DROP MATERIALIZED VIEW IF EXISTS :CAGG_NAME_1ST_LEVEL;
---
--- Variable bucket size with different timezones
---
-\set BUCKET_TZNAME_1ST 'US/Pacific'
-\set BUCKET_TZNAME_2TH 'UTC'
-\set BUCKET_WIDTH_1ST 'INTERVAL \'1 day\''
-\set BUCKET_WIDTH_2TH 'INTERVAL \'1 month\''
-\set WARNING_MESSAGE '-- SHOULD WORK'
+--#Bugfix 5734 #1
+\set INTERVAL_TEST TRUE
+\set BUCKET_WIDTH_1ST 'INTERVAL \'1 hour\''
+\set BUCKET_WIDTH_2TH 'INTERVAL \'1 day\''
+\set BUCKET_WIDTH_3TH 'INTERVAL \'1 month\''
 \ir include/cagg_on_cagg_validations.sql
 -- This file and its contents are licensed under the Timescale License.
 -- Please see the included NOTICE for copyright information and
 -- LICENSE-TIMESCALE for a copy of the license.
 \set CAGG_NAME_1ST_LEVEL conditions_summary_1
 \set CAGG_NAME_2TH_LEVEL conditions_summary_2
+\set CAGG_NAME_3TH_LEVEL conditions_summary_3
 --
 -- CAGG on hypertable (1st level)
 --
@@ -3707,11 +4056,11 @@ View definition:
    FROM _timescaledb_internal._materialized_hypertable_44
   WHERE _materialized_hypertable_44.bucket < COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(44)), '-infinity'::timestamp with time zone)
 UNION ALL
- SELECT time_bucket('@ 1 day'::interval, conditions."time", 'US/Pacific'::text) AS bucket,
+ SELECT time_bucket('@ 1 hour'::interval, conditions."time", 'UTC'::text) AS bucket,
     sum(conditions.temperature) AS temperature
    FROM conditions
   WHERE conditions."time" >= COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(44)), '-infinity'::timestamp with time zone)
-  GROUP BY (time_bucket('@ 1 day'::interval, conditions."time", 'US/Pacific'::text));
+  GROUP BY (time_bucket('@ 1 hour'::interval, conditions."time", 'UTC'::text));
 
 --
 -- CAGG on CAGG (2th level)
@@ -3744,19 +4093,320 @@ View definition:
    FROM _timescaledb_internal._materialized_hypertable_45
   WHERE _materialized_hypertable_45.bucket < COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(45)), '-infinity'::timestamp with time zone)
 UNION ALL
- SELECT time_bucket('@ 1 mon'::interval, conditions_summary_1.bucket, 'UTC'::text) AS bucket,
+ SELECT time_bucket('@ 1 day'::interval, conditions_summary_1.bucket, 'UTC'::text) AS bucket,
     sum(conditions_summary_1.temperature) AS temperature
    FROM conditions_summary_1
   WHERE conditions_summary_1.bucket >= COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(45)), '-infinity'::timestamp with time zone)
+  GROUP BY (time_bucket('@ 1 day'::interval, conditions_summary_1.bucket, 'UTC'::text));
+
+\set ON_ERROR_STOP 1
+\set VERBOSITY terse
+-- Check for incorrect CAGGs
+\if :INTERVAL_TEST
+  INSERT INTO conditions ("time", temperature, device_id) VALUES ('2022-01-01 00:00:00-00', 10, 4);
+  INSERT INTO conditions ("time", temperature, device_id) VALUES ('2022-01-15 01:00:00-00', 20, 4);
+  INSERT INTO conditions ("time", temperature, device_id) VALUES ('2022-01-31 01:00:00-00', 30, 4);
+  CALL refresh_continuous_aggregate(:'CAGG_NAME_1ST_LEVEL', NULL, NULL);
+  CALL refresh_continuous_aggregate(:'CAGG_NAME_2TH_LEVEL', NULL, NULL);
+  CREATE MATERIALIZED VIEW :CAGG_NAME_3TH_LEVEL
+  WITH (timescaledb.continuous) AS
+  SELECT
+    \if :IS_TIME_DIMENSION_WITH_TIMEZONE_2TH
+      time_bucket(:BUCKET_WIDTH_3TH, "bucket", :'BUCKET_TZNAME_2TH') AS bucket
+    \else
+      time_bucket(:BUCKET_WIDTH_3TH, "bucket") AS bucket
+    \endif
+  FROM :CAGG_NAME_2TH_LEVEL
+  GROUP BY 1
+  WITH DATA;
+psql:include/cagg_on_cagg_validations.sql:71: NOTICE:  refreshing continuous aggregate "conditions_summary_3"
+  \d+ :CAGG_NAME_3TH_LEVEL
+                             View "public.conditions_summary_3"
+ Column |           Type           | Collation | Nullable | Default | Storage | Description 
+--------+--------------------------+-----------+----------+---------+---------+-------------
+ bucket | timestamp with time zone |           |          |         | plain   | 
+View definition:
+ SELECT _materialized_hypertable_46.bucket
+   FROM _timescaledb_internal._materialized_hypertable_46
+  WHERE _materialized_hypertable_46.bucket < COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(46)), '-infinity'::timestamp with time zone)
+UNION ALL
+ SELECT time_bucket('@ 1 mon'::interval, conditions_summary_2.bucket, 'UTC'::text) AS bucket
+   FROM conditions_summary_2
+  WHERE conditions_summary_2.bucket >= COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(46)), '-infinity'::timestamp with time zone)
+  GROUP BY (time_bucket('@ 1 mon'::interval, conditions_summary_2.bucket, 'UTC'::text));
+
+  --There should never be dulpicates in the output of the following query
+  SELECT * from :CAGG_NAME_3TH_LEVEL;
+            bucket            
+------------------------------
+ Sat Jan 01 00:00:00 2022 UTC
+(1 row)
+
+  DROP MATERIALIZED VIEW IF EXISTS :CAGG_NAME_3TH_LEVEL;
+psql:include/cagg_on_cagg_validations.sql:79: NOTICE:  drop cascades to table _timescaledb_internal._hyper_46_31_chunk
+  DELETE FROM conditions WHERE device_id = 4;
+\endif
+--
+-- Cleanup
+--
+DROP MATERIALIZED VIEW IF EXISTS :CAGG_NAME_2TH_LEVEL;
+psql:include/cagg_on_cagg_validations.sql:86: NOTICE:  drop cascades to table _timescaledb_internal._hyper_45_30_chunk
+DROP MATERIALIZED VIEW IF EXISTS :CAGG_NAME_1ST_LEVEL;
+psql:include/cagg_on_cagg_validations.sql:87: NOTICE:  drop cascades to table _timescaledb_internal._hyper_44_29_chunk
+\set INTERVAL_TEST FALSE
+--
+-- Variable bucket size with different timezones
+--
+\set BUCKET_TZNAME_1ST 'US/Pacific'
+\set BUCKET_TZNAME_2TH 'UTC'
+\set BUCKET_WIDTH_1ST 'INTERVAL \'1 day\''
+\set BUCKET_WIDTH_2TH 'INTERVAL \'1 month\''
+\set WARNING_MESSAGE '-- SHOULD WORK'
+\ir include/cagg_on_cagg_validations.sql
+-- This file and its contents are licensed under the Timescale License.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-TIMESCALE for a copy of the license.
+\set CAGG_NAME_1ST_LEVEL conditions_summary_1
+\set CAGG_NAME_2TH_LEVEL conditions_summary_2
+\set CAGG_NAME_3TH_LEVEL conditions_summary_3
+--
+-- CAGG on hypertable (1st level)
+--
+CREATE MATERIALIZED VIEW :CAGG_NAME_1ST_LEVEL
+WITH (timescaledb.continuous) AS
+SELECT
+  \if :IS_TIME_DIMENSION_WITH_TIMEZONE_1ST
+    time_bucket(:BUCKET_WIDTH_1ST, "time", :'BUCKET_TZNAME_1ST') AS bucket,
+  \else
+    time_bucket(:BUCKET_WIDTH_1ST, "time") AS bucket,
+  \endif
+  SUM(temperature) AS temperature
+FROM conditions
+GROUP BY 1
+WITH NO DATA;
+\d+ :CAGG_NAME_1ST_LEVEL
+                               View "public.conditions_summary_1"
+   Column    |           Type           | Collation | Nullable | Default | Storage | Description 
+-------------+--------------------------+-----------+----------+---------+---------+-------------
+ bucket      | timestamp with time zone |           |          |         | plain   | 
+ temperature | numeric                  |           |          |         | main    | 
+View definition:
+ SELECT _materialized_hypertable_47.bucket,
+    _materialized_hypertable_47.temperature
+   FROM _timescaledb_internal._materialized_hypertable_47
+  WHERE _materialized_hypertable_47.bucket < COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(47)), '-infinity'::timestamp with time zone)
+UNION ALL
+ SELECT time_bucket('@ 1 day'::interval, conditions."time", 'US/Pacific'::text) AS bucket,
+    sum(conditions.temperature) AS temperature
+   FROM conditions
+  WHERE conditions."time" >= COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(47)), '-infinity'::timestamp with time zone)
+  GROUP BY (time_bucket('@ 1 day'::interval, conditions."time", 'US/Pacific'::text));
+
+--
+-- CAGG on CAGG (2th level)
+--
+\set VERBOSITY default
+\set ON_ERROR_STOP 0
+\echo :WARNING_MESSAGE
+-- SHOULD WORK
+CREATE MATERIALIZED VIEW :CAGG_NAME_2TH_LEVEL
+WITH (timescaledb.continuous) AS
+SELECT
+  \if :IS_TIME_DIMENSION_WITH_TIMEZONE_2TH
+    time_bucket(:BUCKET_WIDTH_2TH, "bucket", :'BUCKET_TZNAME_2TH') AS bucket,
+  \else
+    time_bucket(:BUCKET_WIDTH_2TH, "bucket") AS bucket,
+  \endif
+  SUM(temperature) AS temperature
+FROM :CAGG_NAME_1ST_LEVEL
+GROUP BY 1
+WITH NO DATA;
+\d+ :CAGG_NAME_2TH_LEVEL
+                               View "public.conditions_summary_2"
+   Column    |           Type           | Collation | Nullable | Default | Storage | Description 
+-------------+--------------------------+-----------+----------+---------+---------+-------------
+ bucket      | timestamp with time zone |           |          |         | plain   | 
+ temperature | numeric                  |           |          |         | main    | 
+View definition:
+ SELECT _materialized_hypertable_48.bucket,
+    _materialized_hypertable_48.temperature
+   FROM _timescaledb_internal._materialized_hypertable_48
+  WHERE _materialized_hypertable_48.bucket < COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(48)), '-infinity'::timestamp with time zone)
+UNION ALL
+ SELECT time_bucket('@ 1 mon'::interval, conditions_summary_1.bucket, 'UTC'::text) AS bucket,
+    sum(conditions_summary_1.temperature) AS temperature
+   FROM conditions_summary_1
+  WHERE conditions_summary_1.bucket >= COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(48)), '-infinity'::timestamp with time zone)
   GROUP BY (time_bucket('@ 1 mon'::interval, conditions_summary_1.bucket, 'UTC'::text));
 
 \set ON_ERROR_STOP 1
 \set VERBOSITY terse
+-- Check for incorrect CAGGs
+\if :INTERVAL_TEST
+  INSERT INTO conditions ("time", temperature, device_id) VALUES ('2022-01-01 00:00:00-00', 10, 4);
+  INSERT INTO conditions ("time", temperature, device_id) VALUES ('2022-01-15 01:00:00-00', 20, 4);
+  INSERT INTO conditions ("time", temperature, device_id) VALUES ('2022-01-31 01:00:00-00', 30, 4);
+  CALL refresh_continuous_aggregate(:'CAGG_NAME_1ST_LEVEL', NULL, NULL);
+  CALL refresh_continuous_aggregate(:'CAGG_NAME_2TH_LEVEL', NULL, NULL);
+  CREATE MATERIALIZED VIEW :CAGG_NAME_3TH_LEVEL
+  WITH (timescaledb.continuous) AS
+  SELECT
+    \if :IS_TIME_DIMENSION_WITH_TIMEZONE_2TH
+      time_bucket(:BUCKET_WIDTH_3TH, "bucket", :'BUCKET_TZNAME_2TH') AS bucket
+    \else
+      time_bucket(:BUCKET_WIDTH_3TH, "bucket") AS bucket
+    \endif
+  FROM :CAGG_NAME_2TH_LEVEL
+  GROUP BY 1
+  WITH DATA;
+  \d+ :CAGG_NAME_3TH_LEVEL
+  --There should never be dulpicates in the output of the following query
+  SELECT * from :CAGG_NAME_3TH_LEVEL;
+  DROP MATERIALIZED VIEW IF EXISTS :CAGG_NAME_3TH_LEVEL;
+  DELETE FROM conditions WHERE device_id = 4;
+\endif
 --
 -- Cleanup
 --
 DROP MATERIALIZED VIEW IF EXISTS :CAGG_NAME_2TH_LEVEL;
 DROP MATERIALIZED VIEW IF EXISTS :CAGG_NAME_1ST_LEVEL;
+--#Bugfix 5734 #2
+\set INTERVAL_TEST TRUE
+\set BUCKET_WIDTH_1ST 'INTERVAL \'1 hour\''
+\set BUCKET_WIDTH_2TH 'INTERVAL \'1 day\''
+\set BUCKET_WIDTH_3TH 'INTERVAL \'1 month\''
+\ir include/cagg_on_cagg_validations.sql
+-- This file and its contents are licensed under the Timescale License.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-TIMESCALE for a copy of the license.
+\set CAGG_NAME_1ST_LEVEL conditions_summary_1
+\set CAGG_NAME_2TH_LEVEL conditions_summary_2
+\set CAGG_NAME_3TH_LEVEL conditions_summary_3
+--
+-- CAGG on hypertable (1st level)
+--
+CREATE MATERIALIZED VIEW :CAGG_NAME_1ST_LEVEL
+WITH (timescaledb.continuous) AS
+SELECT
+  \if :IS_TIME_DIMENSION_WITH_TIMEZONE_1ST
+    time_bucket(:BUCKET_WIDTH_1ST, "time", :'BUCKET_TZNAME_1ST') AS bucket,
+  \else
+    time_bucket(:BUCKET_WIDTH_1ST, "time") AS bucket,
+  \endif
+  SUM(temperature) AS temperature
+FROM conditions
+GROUP BY 1
+WITH NO DATA;
+\d+ :CAGG_NAME_1ST_LEVEL
+                               View "public.conditions_summary_1"
+   Column    |           Type           | Collation | Nullable | Default | Storage | Description 
+-------------+--------------------------+-----------+----------+---------+---------+-------------
+ bucket      | timestamp with time zone |           |          |         | plain   | 
+ temperature | numeric                  |           |          |         | main    | 
+View definition:
+ SELECT _materialized_hypertable_49.bucket,
+    _materialized_hypertable_49.temperature
+   FROM _timescaledb_internal._materialized_hypertable_49
+  WHERE _materialized_hypertable_49.bucket < COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(49)), '-infinity'::timestamp with time zone)
+UNION ALL
+ SELECT time_bucket('@ 1 hour'::interval, conditions."time", 'US/Pacific'::text) AS bucket,
+    sum(conditions.temperature) AS temperature
+   FROM conditions
+  WHERE conditions."time" >= COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(49)), '-infinity'::timestamp with time zone)
+  GROUP BY (time_bucket('@ 1 hour'::interval, conditions."time", 'US/Pacific'::text));
+
+--
+-- CAGG on CAGG (2th level)
+--
+\set VERBOSITY default
+\set ON_ERROR_STOP 0
+\echo :WARNING_MESSAGE
+-- SHOULD WORK
+CREATE MATERIALIZED VIEW :CAGG_NAME_2TH_LEVEL
+WITH (timescaledb.continuous) AS
+SELECT
+  \if :IS_TIME_DIMENSION_WITH_TIMEZONE_2TH
+    time_bucket(:BUCKET_WIDTH_2TH, "bucket", :'BUCKET_TZNAME_2TH') AS bucket,
+  \else
+    time_bucket(:BUCKET_WIDTH_2TH, "bucket") AS bucket,
+  \endif
+  SUM(temperature) AS temperature
+FROM :CAGG_NAME_1ST_LEVEL
+GROUP BY 1
+WITH NO DATA;
+\d+ :CAGG_NAME_2TH_LEVEL
+                               View "public.conditions_summary_2"
+   Column    |           Type           | Collation | Nullable | Default | Storage | Description 
+-------------+--------------------------+-----------+----------+---------+---------+-------------
+ bucket      | timestamp with time zone |           |          |         | plain   | 
+ temperature | numeric                  |           |          |         | main    | 
+View definition:
+ SELECT _materialized_hypertable_50.bucket,
+    _materialized_hypertable_50.temperature
+   FROM _timescaledb_internal._materialized_hypertable_50
+  WHERE _materialized_hypertable_50.bucket < COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(50)), '-infinity'::timestamp with time zone)
+UNION ALL
+ SELECT time_bucket('@ 1 day'::interval, conditions_summary_1.bucket, 'UTC'::text) AS bucket,
+    sum(conditions_summary_1.temperature) AS temperature
+   FROM conditions_summary_1
+  WHERE conditions_summary_1.bucket >= COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(50)), '-infinity'::timestamp with time zone)
+  GROUP BY (time_bucket('@ 1 day'::interval, conditions_summary_1.bucket, 'UTC'::text));
+
+\set ON_ERROR_STOP 1
+\set VERBOSITY terse
+-- Check for incorrect CAGGs
+\if :INTERVAL_TEST
+  INSERT INTO conditions ("time", temperature, device_id) VALUES ('2022-01-01 00:00:00-00', 10, 4);
+  INSERT INTO conditions ("time", temperature, device_id) VALUES ('2022-01-15 01:00:00-00', 20, 4);
+  INSERT INTO conditions ("time", temperature, device_id) VALUES ('2022-01-31 01:00:00-00', 30, 4);
+  CALL refresh_continuous_aggregate(:'CAGG_NAME_1ST_LEVEL', NULL, NULL);
+  CALL refresh_continuous_aggregate(:'CAGG_NAME_2TH_LEVEL', NULL, NULL);
+  CREATE MATERIALIZED VIEW :CAGG_NAME_3TH_LEVEL
+  WITH (timescaledb.continuous) AS
+  SELECT
+    \if :IS_TIME_DIMENSION_WITH_TIMEZONE_2TH
+      time_bucket(:BUCKET_WIDTH_3TH, "bucket", :'BUCKET_TZNAME_2TH') AS bucket
+    \else
+      time_bucket(:BUCKET_WIDTH_3TH, "bucket") AS bucket
+    \endif
+  FROM :CAGG_NAME_2TH_LEVEL
+  GROUP BY 1
+  WITH DATA;
+psql:include/cagg_on_cagg_validations.sql:71: NOTICE:  refreshing continuous aggregate "conditions_summary_3"
+  \d+ :CAGG_NAME_3TH_LEVEL
+                             View "public.conditions_summary_3"
+ Column |           Type           | Collation | Nullable | Default | Storage | Description 
+--------+--------------------------+-----------+----------+---------+---------+-------------
+ bucket | timestamp with time zone |           |          |         | plain   | 
+View definition:
+ SELECT _materialized_hypertable_51.bucket
+   FROM _timescaledb_internal._materialized_hypertable_51
+  WHERE _materialized_hypertable_51.bucket < COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(51)), '-infinity'::timestamp with time zone)
+UNION ALL
+ SELECT time_bucket('@ 1 mon'::interval, conditions_summary_2.bucket, 'UTC'::text) AS bucket
+   FROM conditions_summary_2
+  WHERE conditions_summary_2.bucket >= COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(51)), '-infinity'::timestamp with time zone)
+  GROUP BY (time_bucket('@ 1 mon'::interval, conditions_summary_2.bucket, 'UTC'::text));
+
+  --There should never be dulpicates in the output of the following query
+  SELECT * from :CAGG_NAME_3TH_LEVEL;
+            bucket            
+------------------------------
+ Sat Jan 01 00:00:00 2022 UTC
+(1 row)
+
+  DROP MATERIALIZED VIEW IF EXISTS :CAGG_NAME_3TH_LEVEL;
+psql:include/cagg_on_cagg_validations.sql:79: NOTICE:  drop cascades to table _timescaledb_internal._hyper_51_34_chunk
+  DELETE FROM conditions WHERE device_id = 4;
+\endif
+--
+-- Cleanup
+--
+DROP MATERIALIZED VIEW IF EXISTS :CAGG_NAME_2TH_LEVEL;
+psql:include/cagg_on_cagg_validations.sql:86: NOTICE:  drop cascades to table _timescaledb_internal._hyper_50_33_chunk
+DROP MATERIALIZED VIEW IF EXISTS :CAGG_NAME_1ST_LEVEL;
+psql:include/cagg_on_cagg_validations.sql:87: NOTICE:  drop cascades to table _timescaledb_internal._hyper_49_32_chunk
+\set INTERVAL_TEST FALSE
 --
 -- TZ bucket on top of non-TZ bucket
 --
@@ -3772,274 +4422,7 @@ DROP MATERIALIZED VIEW IF EXISTS :CAGG_NAME_1ST_LEVEL;
 -- LICENSE-TIMESCALE for a copy of the license.
 \set CAGG_NAME_1ST_LEVEL conditions_summary_1
 \set CAGG_NAME_2TH_LEVEL conditions_summary_2
---
--- CAGG on hypertable (1st level)
---
-CREATE MATERIALIZED VIEW :CAGG_NAME_1ST_LEVEL
-WITH (timescaledb.continuous) AS
-SELECT
-  \if :IS_TIME_DIMENSION_WITH_TIMEZONE_1ST
-    time_bucket(:BUCKET_WIDTH_1ST, "time", :'BUCKET_TZNAME_1ST') AS bucket,
-  \else
-    time_bucket(:BUCKET_WIDTH_1ST, "time") AS bucket,
-  \endif
-  SUM(temperature) AS temperature
-FROM conditions
-GROUP BY 1
-WITH NO DATA;
-\d+ :CAGG_NAME_1ST_LEVEL
-                               View "public.conditions_summary_1"
-   Column    |           Type           | Collation | Nullable | Default | Storage | Description 
--------------+--------------------------+-----------+----------+---------+---------+-------------
- bucket      | timestamp with time zone |           |          |         | plain   | 
- temperature | numeric                  |           |          |         | main    | 
-View definition:
- SELECT _materialized_hypertable_46.bucket,
-    _materialized_hypertable_46.temperature
-   FROM _timescaledb_internal._materialized_hypertable_46
-  WHERE _materialized_hypertable_46.bucket < COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(46)), '-infinity'::timestamp with time zone)
-UNION ALL
- SELECT time_bucket('@ 1 day'::interval, conditions."time") AS bucket,
-    sum(conditions.temperature) AS temperature
-   FROM conditions
-  WHERE conditions."time" >= COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(46)), '-infinity'::timestamp with time zone)
-  GROUP BY (time_bucket('@ 1 day'::interval, conditions."time"));
-
---
--- CAGG on CAGG (2th level)
---
-\set VERBOSITY default
-\set ON_ERROR_STOP 0
-\echo :WARNING_MESSAGE
--- SHOULD WORK
-CREATE MATERIALIZED VIEW :CAGG_NAME_2TH_LEVEL
-WITH (timescaledb.continuous) AS
-SELECT
-  \if :IS_TIME_DIMENSION_WITH_TIMEZONE_2TH
-    time_bucket(:BUCKET_WIDTH_2TH, "bucket", :'BUCKET_TZNAME_2TH') AS bucket,
-  \else
-    time_bucket(:BUCKET_WIDTH_2TH, "bucket") AS bucket,
-  \endif
-  SUM(temperature) AS temperature
-FROM :CAGG_NAME_1ST_LEVEL
-GROUP BY 1
-WITH NO DATA;
-\d+ :CAGG_NAME_2TH_LEVEL
-                               View "public.conditions_summary_2"
-   Column    |           Type           | Collation | Nullable | Default | Storage | Description 
--------------+--------------------------+-----------+----------+---------+---------+-------------
- bucket      | timestamp with time zone |           |          |         | plain   | 
- temperature | numeric                  |           |          |         | main    | 
-View definition:
- SELECT _materialized_hypertable_47.bucket,
-    _materialized_hypertable_47.temperature
-   FROM _timescaledb_internal._materialized_hypertable_47
-  WHERE _materialized_hypertable_47.bucket < COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(47)), '-infinity'::timestamp with time zone)
-UNION ALL
- SELECT time_bucket('@ 1 mon'::interval, conditions_summary_1.bucket, 'UTC'::text) AS bucket,
-    sum(conditions_summary_1.temperature) AS temperature
-   FROM conditions_summary_1
-  WHERE conditions_summary_1.bucket >= COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(47)), '-infinity'::timestamp with time zone)
-  GROUP BY (time_bucket('@ 1 mon'::interval, conditions_summary_1.bucket, 'UTC'::text));
-
-\set ON_ERROR_STOP 1
-\set VERBOSITY terse
---
--- Cleanup
---
-DROP MATERIALIZED VIEW IF EXISTS :CAGG_NAME_2TH_LEVEL;
-DROP MATERIALIZED VIEW IF EXISTS :CAGG_NAME_1ST_LEVEL;
---
--- non-TZ bucket on top of TZ bucket
---
-\set IS_TIME_DIMENSION_WITH_TIMEZONE_1ST TRUE
-\set IS_TIME_DIMENSION_WITH_TIMEZONE_2TH FALSE
-\set BUCKET_TZNAME_1ST 'UTC'
-\set BUCKET_WIDTH_1ST 'INTERVAL \'1 day\''
-\set BUCKET_WIDTH_2TH 'INTERVAL \'1 month\''
-\set WARNING_MESSAGE '-- SHOULD WORK'
-\ir include/cagg_on_cagg_validations.sql
--- This file and its contents are licensed under the Timescale License.
--- Please see the included NOTICE for copyright information and
--- LICENSE-TIMESCALE for a copy of the license.
-\set CAGG_NAME_1ST_LEVEL conditions_summary_1
-\set CAGG_NAME_2TH_LEVEL conditions_summary_2
---
--- CAGG on hypertable (1st level)
---
-CREATE MATERIALIZED VIEW :CAGG_NAME_1ST_LEVEL
-WITH (timescaledb.continuous) AS
-SELECT
-  \if :IS_TIME_DIMENSION_WITH_TIMEZONE_1ST
-    time_bucket(:BUCKET_WIDTH_1ST, "time", :'BUCKET_TZNAME_1ST') AS bucket,
-  \else
-    time_bucket(:BUCKET_WIDTH_1ST, "time") AS bucket,
-  \endif
-  SUM(temperature) AS temperature
-FROM conditions
-GROUP BY 1
-WITH NO DATA;
-\d+ :CAGG_NAME_1ST_LEVEL
-                               View "public.conditions_summary_1"
-   Column    |           Type           | Collation | Nullable | Default | Storage | Description 
--------------+--------------------------+-----------+----------+---------+---------+-------------
- bucket      | timestamp with time zone |           |          |         | plain   | 
- temperature | numeric                  |           |          |         | main    | 
-View definition:
- SELECT _materialized_hypertable_48.bucket,
-    _materialized_hypertable_48.temperature
-   FROM _timescaledb_internal._materialized_hypertable_48
-  WHERE _materialized_hypertable_48.bucket < COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(48)), '-infinity'::timestamp with time zone)
-UNION ALL
- SELECT time_bucket('@ 1 day'::interval, conditions."time", 'UTC'::text) AS bucket,
-    sum(conditions.temperature) AS temperature
-   FROM conditions
-  WHERE conditions."time" >= COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(48)), '-infinity'::timestamp with time zone)
-  GROUP BY (time_bucket('@ 1 day'::interval, conditions."time", 'UTC'::text));
-
---
--- CAGG on CAGG (2th level)
---
-\set VERBOSITY default
-\set ON_ERROR_STOP 0
-\echo :WARNING_MESSAGE
--- SHOULD WORK
-CREATE MATERIALIZED VIEW :CAGG_NAME_2TH_LEVEL
-WITH (timescaledb.continuous) AS
-SELECT
-  \if :IS_TIME_DIMENSION_WITH_TIMEZONE_2TH
-    time_bucket(:BUCKET_WIDTH_2TH, "bucket", :'BUCKET_TZNAME_2TH') AS bucket,
-  \else
-    time_bucket(:BUCKET_WIDTH_2TH, "bucket") AS bucket,
-  \endif
-  SUM(temperature) AS temperature
-FROM :CAGG_NAME_1ST_LEVEL
-GROUP BY 1
-WITH NO DATA;
-\d+ :CAGG_NAME_2TH_LEVEL
-                               View "public.conditions_summary_2"
-   Column    |           Type           | Collation | Nullable | Default | Storage | Description 
--------------+--------------------------+-----------+----------+---------+---------+-------------
- bucket      | timestamp with time zone |           |          |         | plain   | 
- temperature | numeric                  |           |          |         | main    | 
-View definition:
- SELECT _materialized_hypertable_49.bucket,
-    _materialized_hypertable_49.temperature
-   FROM _timescaledb_internal._materialized_hypertable_49
-  WHERE _materialized_hypertable_49.bucket < COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(49)), '-infinity'::timestamp with time zone)
-UNION ALL
- SELECT time_bucket('@ 1 mon'::interval, conditions_summary_1.bucket) AS bucket,
-    sum(conditions_summary_1.temperature) AS temperature
-   FROM conditions_summary_1
-  WHERE conditions_summary_1.bucket >= COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(49)), '-infinity'::timestamp with time zone)
-  GROUP BY (time_bucket('@ 1 mon'::interval, conditions_summary_1.bucket));
-
-\set ON_ERROR_STOP 1
-\set VERBOSITY terse
---
--- Cleanup
---
-DROP MATERIALIZED VIEW IF EXISTS :CAGG_NAME_2TH_LEVEL;
-DROP MATERIALIZED VIEW IF EXISTS :CAGG_NAME_1ST_LEVEL;
--- test some intuitive intervals that should work but
--- were not working due to unix epochs
--- validation test for 1 year on top of one day
--- validation test for 1 year on top of 1 month
--- validation test for 1 year on top of 1 week
--- bug report 5231
-\set BUCKET_WIDTH_1ST 'INTERVAL \'1 day\''
-\set BUCKET_WIDTH_2TH 'INTERVAL \'1 year\''
-\ir include/cagg_on_cagg_validations.sql
--- This file and its contents are licensed under the Timescale License.
--- Please see the included NOTICE for copyright information and
--- LICENSE-TIMESCALE for a copy of the license.
-\set CAGG_NAME_1ST_LEVEL conditions_summary_1
-\set CAGG_NAME_2TH_LEVEL conditions_summary_2
---
--- CAGG on hypertable (1st level)
---
-CREATE MATERIALIZED VIEW :CAGG_NAME_1ST_LEVEL
-WITH (timescaledb.continuous) AS
-SELECT
-  \if :IS_TIME_DIMENSION_WITH_TIMEZONE_1ST
-    time_bucket(:BUCKET_WIDTH_1ST, "time", :'BUCKET_TZNAME_1ST') AS bucket,
-  \else
-    time_bucket(:BUCKET_WIDTH_1ST, "time") AS bucket,
-  \endif
-  SUM(temperature) AS temperature
-FROM conditions
-GROUP BY 1
-WITH NO DATA;
-\d+ :CAGG_NAME_1ST_LEVEL
-                               View "public.conditions_summary_1"
-   Column    |           Type           | Collation | Nullable | Default | Storage | Description 
--------------+--------------------------+-----------+----------+---------+---------+-------------
- bucket      | timestamp with time zone |           |          |         | plain   | 
- temperature | numeric                  |           |          |         | main    | 
-View definition:
- SELECT _materialized_hypertable_50.bucket,
-    _materialized_hypertable_50.temperature
-   FROM _timescaledb_internal._materialized_hypertable_50
-  WHERE _materialized_hypertable_50.bucket < COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(50)), '-infinity'::timestamp with time zone)
-UNION ALL
- SELECT time_bucket('@ 1 day'::interval, conditions."time", 'UTC'::text) AS bucket,
-    sum(conditions.temperature) AS temperature
-   FROM conditions
-  WHERE conditions."time" >= COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(50)), '-infinity'::timestamp with time zone)
-  GROUP BY (time_bucket('@ 1 day'::interval, conditions."time", 'UTC'::text));
-
---
--- CAGG on CAGG (2th level)
---
-\set VERBOSITY default
-\set ON_ERROR_STOP 0
-\echo :WARNING_MESSAGE
--- SHOULD WORK
-CREATE MATERIALIZED VIEW :CAGG_NAME_2TH_LEVEL
-WITH (timescaledb.continuous) AS
-SELECT
-  \if :IS_TIME_DIMENSION_WITH_TIMEZONE_2TH
-    time_bucket(:BUCKET_WIDTH_2TH, "bucket", :'BUCKET_TZNAME_2TH') AS bucket,
-  \else
-    time_bucket(:BUCKET_WIDTH_2TH, "bucket") AS bucket,
-  \endif
-  SUM(temperature) AS temperature
-FROM :CAGG_NAME_1ST_LEVEL
-GROUP BY 1
-WITH NO DATA;
-\d+ :CAGG_NAME_2TH_LEVEL
-                               View "public.conditions_summary_2"
-   Column    |           Type           | Collation | Nullable | Default | Storage | Description 
--------------+--------------------------+-----------+----------+---------+---------+-------------
- bucket      | timestamp with time zone |           |          |         | plain   | 
- temperature | numeric                  |           |          |         | main    | 
-View definition:
- SELECT _materialized_hypertable_51.bucket,
-    _materialized_hypertable_51.temperature
-   FROM _timescaledb_internal._materialized_hypertable_51
-  WHERE _materialized_hypertable_51.bucket < COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(51)), '-infinity'::timestamp with time zone)
-UNION ALL
- SELECT time_bucket('@ 1 year'::interval, conditions_summary_1.bucket) AS bucket,
-    sum(conditions_summary_1.temperature) AS temperature
-   FROM conditions_summary_1
-  WHERE conditions_summary_1.bucket >= COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(51)), '-infinity'::timestamp with time zone)
-  GROUP BY (time_bucket('@ 1 year'::interval, conditions_summary_1.bucket));
-
-\set ON_ERROR_STOP 1
-\set VERBOSITY terse
---
--- Cleanup
---
-DROP MATERIALIZED VIEW IF EXISTS :CAGG_NAME_2TH_LEVEL;
-DROP MATERIALIZED VIEW IF EXISTS :CAGG_NAME_1ST_LEVEL;
-\set BUCKET_WIDTH_1ST 'INTERVAL \'1 day\''
-\set BUCKET_WIDTH_2TH 'INTERVAL \'3 month\''
-\ir include/cagg_on_cagg_validations.sql
--- This file and its contents are licensed under the Timescale License.
--- Please see the included NOTICE for copyright information and
--- LICENSE-TIMESCALE for a copy of the license.
-\set CAGG_NAME_1ST_LEVEL conditions_summary_1
-\set CAGG_NAME_2TH_LEVEL conditions_summary_2
+\set CAGG_NAME_3TH_LEVEL conditions_summary_3
 --
 -- CAGG on hypertable (1st level)
 --
@@ -4067,11 +4450,11 @@ View definition:
    FROM _timescaledb_internal._materialized_hypertable_52
   WHERE _materialized_hypertable_52.bucket < COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(52)), '-infinity'::timestamp with time zone)
 UNION ALL
- SELECT time_bucket('@ 1 day'::interval, conditions."time", 'UTC'::text) AS bucket,
+ SELECT time_bucket('@ 1 day'::interval, conditions."time") AS bucket,
     sum(conditions.temperature) AS temperature
    FROM conditions
   WHERE conditions."time" >= COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(52)), '-infinity'::timestamp with time zone)
-  GROUP BY (time_bucket('@ 1 day'::interval, conditions."time", 'UTC'::text));
+  GROUP BY (time_bucket('@ 1 day'::interval, conditions."time"));
 
 --
 -- CAGG on CAGG (2th level)
@@ -4104,27 +4487,55 @@ View definition:
    FROM _timescaledb_internal._materialized_hypertable_53
   WHERE _materialized_hypertable_53.bucket < COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(53)), '-infinity'::timestamp with time zone)
 UNION ALL
- SELECT time_bucket('@ 3 mons'::interval, conditions_summary_1.bucket) AS bucket,
+ SELECT time_bucket('@ 1 mon'::interval, conditions_summary_1.bucket, 'UTC'::text) AS bucket,
     sum(conditions_summary_1.temperature) AS temperature
    FROM conditions_summary_1
   WHERE conditions_summary_1.bucket >= COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(53)), '-infinity'::timestamp with time zone)
-  GROUP BY (time_bucket('@ 3 mons'::interval, conditions_summary_1.bucket));
+  GROUP BY (time_bucket('@ 1 mon'::interval, conditions_summary_1.bucket, 'UTC'::text));
 
 \set ON_ERROR_STOP 1
 \set VERBOSITY terse
+-- Check for incorrect CAGGs
+\if :INTERVAL_TEST
+  INSERT INTO conditions ("time", temperature, device_id) VALUES ('2022-01-01 00:00:00-00', 10, 4);
+  INSERT INTO conditions ("time", temperature, device_id) VALUES ('2022-01-15 01:00:00-00', 20, 4);
+  INSERT INTO conditions ("time", temperature, device_id) VALUES ('2022-01-31 01:00:00-00', 30, 4);
+  CALL refresh_continuous_aggregate(:'CAGG_NAME_1ST_LEVEL', NULL, NULL);
+  CALL refresh_continuous_aggregate(:'CAGG_NAME_2TH_LEVEL', NULL, NULL);
+  CREATE MATERIALIZED VIEW :CAGG_NAME_3TH_LEVEL
+  WITH (timescaledb.continuous) AS
+  SELECT
+    \if :IS_TIME_DIMENSION_WITH_TIMEZONE_2TH
+      time_bucket(:BUCKET_WIDTH_3TH, "bucket", :'BUCKET_TZNAME_2TH') AS bucket
+    \else
+      time_bucket(:BUCKET_WIDTH_3TH, "bucket") AS bucket
+    \endif
+  FROM :CAGG_NAME_2TH_LEVEL
+  GROUP BY 1
+  WITH DATA;
+  \d+ :CAGG_NAME_3TH_LEVEL
+  --There should never be dulpicates in the output of the following query
+  SELECT * from :CAGG_NAME_3TH_LEVEL;
+  DROP MATERIALIZED VIEW IF EXISTS :CAGG_NAME_3TH_LEVEL;
+  DELETE FROM conditions WHERE device_id = 4;
+\endif
 --
 -- Cleanup
 --
 DROP MATERIALIZED VIEW IF EXISTS :CAGG_NAME_2TH_LEVEL;
 DROP MATERIALIZED VIEW IF EXISTS :CAGG_NAME_1ST_LEVEL;
-\set BUCKET_WIDTH_1ST 'INTERVAL \'1 month\''
-\set BUCKET_WIDTH_2TH 'INTERVAL \'1 year\''
+--#Bugfix 5734 #3
+\set INTERVAL_TEST TRUE
+\set BUCKET_WIDTH_1ST 'INTERVAL \'1 hour\''
+\set BUCKET_WIDTH_2TH 'INTERVAL \'1 day\''
+\set BUCKET_WIDTH_3TH 'INTERVAL \'1 month\''
 \ir include/cagg_on_cagg_validations.sql
 -- This file and its contents are licensed under the Timescale License.
 -- Please see the included NOTICE for copyright information and
 -- LICENSE-TIMESCALE for a copy of the license.
 \set CAGG_NAME_1ST_LEVEL conditions_summary_1
 \set CAGG_NAME_2TH_LEVEL conditions_summary_2
+\set CAGG_NAME_3TH_LEVEL conditions_summary_3
 --
 -- CAGG on hypertable (1st level)
 --
@@ -4152,11 +4563,11 @@ View definition:
    FROM _timescaledb_internal._materialized_hypertable_54
   WHERE _materialized_hypertable_54.bucket < COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(54)), '-infinity'::timestamp with time zone)
 UNION ALL
- SELECT time_bucket('@ 1 mon'::interval, conditions."time", 'UTC'::text) AS bucket,
+ SELECT time_bucket('@ 1 hour'::interval, conditions."time") AS bucket,
     sum(conditions.temperature) AS temperature
    FROM conditions
   WHERE conditions."time" >= COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(54)), '-infinity'::timestamp with time zone)
-  GROUP BY (time_bucket('@ 1 mon'::interval, conditions."time", 'UTC'::text));
+  GROUP BY (time_bucket('@ 1 hour'::interval, conditions."time"));
 
 --
 -- CAGG on CAGG (2th level)
@@ -4189,98 +4600,83 @@ View definition:
    FROM _timescaledb_internal._materialized_hypertable_55
   WHERE _materialized_hypertable_55.bucket < COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(55)), '-infinity'::timestamp with time zone)
 UNION ALL
- SELECT time_bucket('@ 1 year'::interval, conditions_summary_1.bucket) AS bucket,
+ SELECT time_bucket('@ 1 day'::interval, conditions_summary_1.bucket, 'UTC'::text) AS bucket,
     sum(conditions_summary_1.temperature) AS temperature
    FROM conditions_summary_1
   WHERE conditions_summary_1.bucket >= COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(55)), '-infinity'::timestamp with time zone)
-  GROUP BY (time_bucket('@ 1 year'::interval, conditions_summary_1.bucket));
+  GROUP BY (time_bucket('@ 1 day'::interval, conditions_summary_1.bucket, 'UTC'::text));
 
 \set ON_ERROR_STOP 1
 \set VERBOSITY terse
---
--- Cleanup
---
-DROP MATERIALIZED VIEW IF EXISTS :CAGG_NAME_2TH_LEVEL;
-DROP MATERIALIZED VIEW IF EXISTS :CAGG_NAME_1ST_LEVEL;
-\set BUCKET_WIDTH_1ST 'INTERVAL \'1 week\''
-\set BUCKET_WIDTH_2TH 'INTERVAL \'1 year\''
-\ir include/cagg_on_cagg_validations.sql
--- This file and its contents are licensed under the Timescale License.
--- Please see the included NOTICE for copyright information and
--- LICENSE-TIMESCALE for a copy of the license.
-\set CAGG_NAME_1ST_LEVEL conditions_summary_1
-\set CAGG_NAME_2TH_LEVEL conditions_summary_2
---
--- CAGG on hypertable (1st level)
---
-CREATE MATERIALIZED VIEW :CAGG_NAME_1ST_LEVEL
-WITH (timescaledb.continuous) AS
-SELECT
-  \if :IS_TIME_DIMENSION_WITH_TIMEZONE_1ST
-    time_bucket(:BUCKET_WIDTH_1ST, "time", :'BUCKET_TZNAME_1ST') AS bucket,
-  \else
-    time_bucket(:BUCKET_WIDTH_1ST, "time") AS bucket,
-  \endif
-  SUM(temperature) AS temperature
-FROM conditions
-GROUP BY 1
-WITH NO DATA;
-\d+ :CAGG_NAME_1ST_LEVEL
-                               View "public.conditions_summary_1"
-   Column    |           Type           | Collation | Nullable | Default | Storage | Description 
--------------+--------------------------+-----------+----------+---------+---------+-------------
- bucket      | timestamp with time zone |           |          |         | plain   | 
- temperature | numeric                  |           |          |         | main    | 
+-- Check for incorrect CAGGs
+\if :INTERVAL_TEST
+  INSERT INTO conditions ("time", temperature, device_id) VALUES ('2022-01-01 00:00:00-00', 10, 4);
+  INSERT INTO conditions ("time", temperature, device_id) VALUES ('2022-01-15 01:00:00-00', 20, 4);
+  INSERT INTO conditions ("time", temperature, device_id) VALUES ('2022-01-31 01:00:00-00', 30, 4);
+  CALL refresh_continuous_aggregate(:'CAGG_NAME_1ST_LEVEL', NULL, NULL);
+  CALL refresh_continuous_aggregate(:'CAGG_NAME_2TH_LEVEL', NULL, NULL);
+  CREATE MATERIALIZED VIEW :CAGG_NAME_3TH_LEVEL
+  WITH (timescaledb.continuous) AS
+  SELECT
+    \if :IS_TIME_DIMENSION_WITH_TIMEZONE_2TH
+      time_bucket(:BUCKET_WIDTH_3TH, "bucket", :'BUCKET_TZNAME_2TH') AS bucket
+    \else
+      time_bucket(:BUCKET_WIDTH_3TH, "bucket") AS bucket
+    \endif
+  FROM :CAGG_NAME_2TH_LEVEL
+  GROUP BY 1
+  WITH DATA;
+psql:include/cagg_on_cagg_validations.sql:71: NOTICE:  refreshing continuous aggregate "conditions_summary_3"
+  \d+ :CAGG_NAME_3TH_LEVEL
+                             View "public.conditions_summary_3"
+ Column |           Type           | Collation | Nullable | Default | Storage | Description 
+--------+--------------------------+-----------+----------+---------+---------+-------------
+ bucket | timestamp with time zone |           |          |         | plain   | 
 View definition:
- SELECT _materialized_hypertable_56.bucket,
-    _materialized_hypertable_56.temperature
+ SELECT _materialized_hypertable_56.bucket
    FROM _timescaledb_internal._materialized_hypertable_56
   WHERE _materialized_hypertable_56.bucket < COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(56)), '-infinity'::timestamp with time zone)
 UNION ALL
- SELECT time_bucket('@ 7 days'::interval, conditions."time", 'UTC'::text) AS bucket,
-    sum(conditions.temperature) AS temperature
-   FROM conditions
-  WHERE conditions."time" >= COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(56)), '-infinity'::timestamp with time zone)
-  GROUP BY (time_bucket('@ 7 days'::interval, conditions."time", 'UTC'::text));
+ SELECT time_bucket('@ 1 mon'::interval, conditions_summary_2.bucket, 'UTC'::text) AS bucket
+   FROM conditions_summary_2
+  WHERE conditions_summary_2.bucket >= COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(56)), '-infinity'::timestamp with time zone)
+  GROUP BY (time_bucket('@ 1 mon'::interval, conditions_summary_2.bucket, 'UTC'::text));
 
---
--- CAGG on CAGG (2th level)
---
-\set VERBOSITY default
-\set ON_ERROR_STOP 0
-\echo :WARNING_MESSAGE
--- SHOULD WORK
-CREATE MATERIALIZED VIEW :CAGG_NAME_2TH_LEVEL
-WITH (timescaledb.continuous) AS
-SELECT
-  \if :IS_TIME_DIMENSION_WITH_TIMEZONE_2TH
-    time_bucket(:BUCKET_WIDTH_2TH, "bucket", :'BUCKET_TZNAME_2TH') AS bucket,
-  \else
-    time_bucket(:BUCKET_WIDTH_2TH, "bucket") AS bucket,
-  \endif
-  SUM(temperature) AS temperature
-FROM :CAGG_NAME_1ST_LEVEL
-GROUP BY 1
-WITH NO DATA;
-psql:include/cagg_on_cagg_validations.sql:43: ERROR:  cannot create continuous aggregate with incompatible bucket width
-DETAIL:  Time bucket width of "public.conditions_summary_2" [@ 360 days] should be multiple of the time bucket width of "public.conditions_summary_1" [@ 7 days].
-\d+ :CAGG_NAME_2TH_LEVEL
-\set ON_ERROR_STOP 1
-\set VERBOSITY terse
+  --There should never be dulpicates in the output of the following query
+  SELECT * from :CAGG_NAME_3TH_LEVEL;
+            bucket            
+------------------------------
+ Sat Jan 01 00:00:00 2022 UTC
+(1 row)
+
+  DROP MATERIALIZED VIEW IF EXISTS :CAGG_NAME_3TH_LEVEL;
+psql:include/cagg_on_cagg_validations.sql:79: NOTICE:  drop cascades to table _timescaledb_internal._hyper_56_37_chunk
+  DELETE FROM conditions WHERE device_id = 4;
+\endif
 --
 -- Cleanup
 --
 DROP MATERIALIZED VIEW IF EXISTS :CAGG_NAME_2TH_LEVEL;
-psql:include/cagg_on_cagg_validations.sql:53: NOTICE:  materialized view "conditions_summary_2" does not exist, skipping
+psql:include/cagg_on_cagg_validations.sql:86: NOTICE:  drop cascades to table _timescaledb_internal._hyper_55_36_chunk
 DROP MATERIALIZED VIEW IF EXISTS :CAGG_NAME_1ST_LEVEL;
-\set BUCKET_WIDTH_1ST 'INTERVAL \'1 week\''
+psql:include/cagg_on_cagg_validations.sql:87: NOTICE:  drop cascades to table _timescaledb_internal._hyper_54_35_chunk
+\set INTERVAL_TEST FALSE
+--
+-- non-TZ bucket on top of TZ bucket
+--
+\set IS_TIME_DIMENSION_WITH_TIMEZONE_1ST TRUE
+\set IS_TIME_DIMENSION_WITH_TIMEZONE_2TH FALSE
+\set BUCKET_TZNAME_1ST 'UTC'
+\set BUCKET_WIDTH_1ST 'INTERVAL \'1 day\''
 \set BUCKET_WIDTH_2TH 'INTERVAL \'1 month\''
+\set WARNING_MESSAGE '-- SHOULD WORK'
 \ir include/cagg_on_cagg_validations.sql
 -- This file and its contents are licensed under the Timescale License.
 -- Please see the included NOTICE for copyright information and
 -- LICENSE-TIMESCALE for a copy of the license.
 \set CAGG_NAME_1ST_LEVEL conditions_summary_1
 \set CAGG_NAME_2TH_LEVEL conditions_summary_2
+\set CAGG_NAME_3TH_LEVEL conditions_summary_3
 --
 -- CAGG on hypertable (1st level)
 --
@@ -4308,11 +4704,11 @@ View definition:
    FROM _timescaledb_internal._materialized_hypertable_57
   WHERE _materialized_hypertable_57.bucket < COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(57)), '-infinity'::timestamp with time zone)
 UNION ALL
- SELECT time_bucket('@ 7 days'::interval, conditions."time", 'UTC'::text) AS bucket,
+ SELECT time_bucket('@ 1 day'::interval, conditions."time", 'UTC'::text) AS bucket,
     sum(conditions.temperature) AS temperature
    FROM conditions
   WHERE conditions."time" >= COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(57)), '-infinity'::timestamp with time zone)
-  GROUP BY (time_bucket('@ 7 days'::interval, conditions."time", 'UTC'::text));
+  GROUP BY (time_bucket('@ 1 day'::interval, conditions."time", 'UTC'::text));
 
 --
 -- CAGG on CAGG (2th level)
@@ -4333,29 +4729,70 @@ SELECT
 FROM :CAGG_NAME_1ST_LEVEL
 GROUP BY 1
 WITH NO DATA;
-psql:include/cagg_on_cagg_validations.sql:43: ERROR:  cannot create continuous aggregate with incompatible bucket width
-DETAIL:  Time bucket width of "public.conditions_summary_2" [@ 30 days] should be multiple of the time bucket width of "public.conditions_summary_1" [@ 7 days].
 \d+ :CAGG_NAME_2TH_LEVEL
+                               View "public.conditions_summary_2"
+   Column    |           Type           | Collation | Nullable | Default | Storage | Description 
+-------------+--------------------------+-----------+----------+---------+---------+-------------
+ bucket      | timestamp with time zone |           |          |         | plain   | 
+ temperature | numeric                  |           |          |         | main    | 
+View definition:
+ SELECT _materialized_hypertable_58.bucket,
+    _materialized_hypertable_58.temperature
+   FROM _timescaledb_internal._materialized_hypertable_58
+  WHERE _materialized_hypertable_58.bucket < COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(58)), '-infinity'::timestamp with time zone)
+UNION ALL
+ SELECT time_bucket('@ 1 mon'::interval, conditions_summary_1.bucket) AS bucket,
+    sum(conditions_summary_1.temperature) AS temperature
+   FROM conditions_summary_1
+  WHERE conditions_summary_1.bucket >= COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(58)), '-infinity'::timestamp with time zone)
+  GROUP BY (time_bucket('@ 1 mon'::interval, conditions_summary_1.bucket));
+
 \set ON_ERROR_STOP 1
 \set VERBOSITY terse
+-- Check for incorrect CAGGs
+\if :INTERVAL_TEST
+  INSERT INTO conditions ("time", temperature, device_id) VALUES ('2022-01-01 00:00:00-00', 10, 4);
+  INSERT INTO conditions ("time", temperature, device_id) VALUES ('2022-01-15 01:00:00-00', 20, 4);
+  INSERT INTO conditions ("time", temperature, device_id) VALUES ('2022-01-31 01:00:00-00', 30, 4);
+  CALL refresh_continuous_aggregate(:'CAGG_NAME_1ST_LEVEL', NULL, NULL);
+  CALL refresh_continuous_aggregate(:'CAGG_NAME_2TH_LEVEL', NULL, NULL);
+  CREATE MATERIALIZED VIEW :CAGG_NAME_3TH_LEVEL
+  WITH (timescaledb.continuous) AS
+  SELECT
+    \if :IS_TIME_DIMENSION_WITH_TIMEZONE_2TH
+      time_bucket(:BUCKET_WIDTH_3TH, "bucket", :'BUCKET_TZNAME_2TH') AS bucket
+    \else
+      time_bucket(:BUCKET_WIDTH_3TH, "bucket") AS bucket
+    \endif
+  FROM :CAGG_NAME_2TH_LEVEL
+  GROUP BY 1
+  WITH DATA;
+  \d+ :CAGG_NAME_3TH_LEVEL
+  --There should never be dulpicates in the output of the following query
+  SELECT * from :CAGG_NAME_3TH_LEVEL;
+  DROP MATERIALIZED VIEW IF EXISTS :CAGG_NAME_3TH_LEVEL;
+  DELETE FROM conditions WHERE device_id = 4;
+\endif
 --
 -- Cleanup
 --
 DROP MATERIALIZED VIEW IF EXISTS :CAGG_NAME_2TH_LEVEL;
-psql:include/cagg_on_cagg_validations.sql:53: NOTICE:  materialized view "conditions_summary_2" does not exist, skipping
 DROP MATERIALIZED VIEW IF EXISTS :CAGG_NAME_1ST_LEVEL;
--- bug report 5277
-\set IS_TIME_DIMENSION_WITH_TIMEZONE_1ST FALSE
-\set IS_TIME_DIMENSION_WITH_TIMEZONE_2TH FALSE
--- epoch plus cast to int would compute a bucket width of 0 for parent
-\set BUCKET_WIDTH_1ST 'INTERVAL \'146 ms\''
-\set BUCKET_WIDTH_2TH 'INTERVAL \'1168 ms\''
+-- test some intuitive intervals that should work but
+-- were not working due to unix epochs
+-- validation test for 1 year on top of one day
+-- validation test for 1 year on top of 1 month
+-- validation test for 1 year on top of 1 week
+-- bug report 5231
+\set BUCKET_WIDTH_1ST 'INTERVAL \'1 day\''
+\set BUCKET_WIDTH_2TH 'INTERVAL \'1 year\''
 \ir include/cagg_on_cagg_validations.sql
 -- This file and its contents are licensed under the Timescale License.
 -- Please see the included NOTICE for copyright information and
 -- LICENSE-TIMESCALE for a copy of the license.
 \set CAGG_NAME_1ST_LEVEL conditions_summary_1
 \set CAGG_NAME_2TH_LEVEL conditions_summary_2
+\set CAGG_NAME_3TH_LEVEL conditions_summary_3
 --
 -- CAGG on hypertable (1st level)
 --
@@ -4378,15 +4815,541 @@ WITH NO DATA;
  bucket      | timestamp with time zone |           |          |         | plain   | 
  temperature | numeric                  |           |          |         | main    | 
 View definition:
- SELECT _materialized_hypertable_58.bucket,
-    _materialized_hypertable_58.temperature
-   FROM _timescaledb_internal._materialized_hypertable_58
-  WHERE _materialized_hypertable_58.bucket < COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(58)), '-infinity'::timestamp with time zone)
+ SELECT _materialized_hypertable_59.bucket,
+    _materialized_hypertable_59.temperature
+   FROM _timescaledb_internal._materialized_hypertable_59
+  WHERE _materialized_hypertable_59.bucket < COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(59)), '-infinity'::timestamp with time zone)
+UNION ALL
+ SELECT time_bucket('@ 1 day'::interval, conditions."time", 'UTC'::text) AS bucket,
+    sum(conditions.temperature) AS temperature
+   FROM conditions
+  WHERE conditions."time" >= COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(59)), '-infinity'::timestamp with time zone)
+  GROUP BY (time_bucket('@ 1 day'::interval, conditions."time", 'UTC'::text));
+
+--
+-- CAGG on CAGG (2th level)
+--
+\set VERBOSITY default
+\set ON_ERROR_STOP 0
+\echo :WARNING_MESSAGE
+-- SHOULD WORK
+CREATE MATERIALIZED VIEW :CAGG_NAME_2TH_LEVEL
+WITH (timescaledb.continuous) AS
+SELECT
+  \if :IS_TIME_DIMENSION_WITH_TIMEZONE_2TH
+    time_bucket(:BUCKET_WIDTH_2TH, "bucket", :'BUCKET_TZNAME_2TH') AS bucket,
+  \else
+    time_bucket(:BUCKET_WIDTH_2TH, "bucket") AS bucket,
+  \endif
+  SUM(temperature) AS temperature
+FROM :CAGG_NAME_1ST_LEVEL
+GROUP BY 1
+WITH NO DATA;
+\d+ :CAGG_NAME_2TH_LEVEL
+                               View "public.conditions_summary_2"
+   Column    |           Type           | Collation | Nullable | Default | Storage | Description 
+-------------+--------------------------+-----------+----------+---------+---------+-------------
+ bucket      | timestamp with time zone |           |          |         | plain   | 
+ temperature | numeric                  |           |          |         | main    | 
+View definition:
+ SELECT _materialized_hypertable_60.bucket,
+    _materialized_hypertable_60.temperature
+   FROM _timescaledb_internal._materialized_hypertable_60
+  WHERE _materialized_hypertable_60.bucket < COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(60)), '-infinity'::timestamp with time zone)
+UNION ALL
+ SELECT time_bucket('@ 1 year'::interval, conditions_summary_1.bucket) AS bucket,
+    sum(conditions_summary_1.temperature) AS temperature
+   FROM conditions_summary_1
+  WHERE conditions_summary_1.bucket >= COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(60)), '-infinity'::timestamp with time zone)
+  GROUP BY (time_bucket('@ 1 year'::interval, conditions_summary_1.bucket));
+
+\set ON_ERROR_STOP 1
+\set VERBOSITY terse
+-- Check for incorrect CAGGs
+\if :INTERVAL_TEST
+  INSERT INTO conditions ("time", temperature, device_id) VALUES ('2022-01-01 00:00:00-00', 10, 4);
+  INSERT INTO conditions ("time", temperature, device_id) VALUES ('2022-01-15 01:00:00-00', 20, 4);
+  INSERT INTO conditions ("time", temperature, device_id) VALUES ('2022-01-31 01:00:00-00', 30, 4);
+  CALL refresh_continuous_aggregate(:'CAGG_NAME_1ST_LEVEL', NULL, NULL);
+  CALL refresh_continuous_aggregate(:'CAGG_NAME_2TH_LEVEL', NULL, NULL);
+  CREATE MATERIALIZED VIEW :CAGG_NAME_3TH_LEVEL
+  WITH (timescaledb.continuous) AS
+  SELECT
+    \if :IS_TIME_DIMENSION_WITH_TIMEZONE_2TH
+      time_bucket(:BUCKET_WIDTH_3TH, "bucket", :'BUCKET_TZNAME_2TH') AS bucket
+    \else
+      time_bucket(:BUCKET_WIDTH_3TH, "bucket") AS bucket
+    \endif
+  FROM :CAGG_NAME_2TH_LEVEL
+  GROUP BY 1
+  WITH DATA;
+  \d+ :CAGG_NAME_3TH_LEVEL
+  --There should never be dulpicates in the output of the following query
+  SELECT * from :CAGG_NAME_3TH_LEVEL;
+  DROP MATERIALIZED VIEW IF EXISTS :CAGG_NAME_3TH_LEVEL;
+  DELETE FROM conditions WHERE device_id = 4;
+\endif
+--
+-- Cleanup
+--
+DROP MATERIALIZED VIEW IF EXISTS :CAGG_NAME_2TH_LEVEL;
+DROP MATERIALIZED VIEW IF EXISTS :CAGG_NAME_1ST_LEVEL;
+\set BUCKET_WIDTH_1ST 'INTERVAL \'1 day\''
+\set BUCKET_WIDTH_2TH 'INTERVAL \'3 month\''
+\ir include/cagg_on_cagg_validations.sql
+-- This file and its contents are licensed under the Timescale License.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-TIMESCALE for a copy of the license.
+\set CAGG_NAME_1ST_LEVEL conditions_summary_1
+\set CAGG_NAME_2TH_LEVEL conditions_summary_2
+\set CAGG_NAME_3TH_LEVEL conditions_summary_3
+--
+-- CAGG on hypertable (1st level)
+--
+CREATE MATERIALIZED VIEW :CAGG_NAME_1ST_LEVEL
+WITH (timescaledb.continuous) AS
+SELECT
+  \if :IS_TIME_DIMENSION_WITH_TIMEZONE_1ST
+    time_bucket(:BUCKET_WIDTH_1ST, "time", :'BUCKET_TZNAME_1ST') AS bucket,
+  \else
+    time_bucket(:BUCKET_WIDTH_1ST, "time") AS bucket,
+  \endif
+  SUM(temperature) AS temperature
+FROM conditions
+GROUP BY 1
+WITH NO DATA;
+\d+ :CAGG_NAME_1ST_LEVEL
+                               View "public.conditions_summary_1"
+   Column    |           Type           | Collation | Nullable | Default | Storage | Description 
+-------------+--------------------------+-----------+----------+---------+---------+-------------
+ bucket      | timestamp with time zone |           |          |         | plain   | 
+ temperature | numeric                  |           |          |         | main    | 
+View definition:
+ SELECT _materialized_hypertable_61.bucket,
+    _materialized_hypertable_61.temperature
+   FROM _timescaledb_internal._materialized_hypertable_61
+  WHERE _materialized_hypertable_61.bucket < COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(61)), '-infinity'::timestamp with time zone)
+UNION ALL
+ SELECT time_bucket('@ 1 day'::interval, conditions."time", 'UTC'::text) AS bucket,
+    sum(conditions.temperature) AS temperature
+   FROM conditions
+  WHERE conditions."time" >= COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(61)), '-infinity'::timestamp with time zone)
+  GROUP BY (time_bucket('@ 1 day'::interval, conditions."time", 'UTC'::text));
+
+--
+-- CAGG on CAGG (2th level)
+--
+\set VERBOSITY default
+\set ON_ERROR_STOP 0
+\echo :WARNING_MESSAGE
+-- SHOULD WORK
+CREATE MATERIALIZED VIEW :CAGG_NAME_2TH_LEVEL
+WITH (timescaledb.continuous) AS
+SELECT
+  \if :IS_TIME_DIMENSION_WITH_TIMEZONE_2TH
+    time_bucket(:BUCKET_WIDTH_2TH, "bucket", :'BUCKET_TZNAME_2TH') AS bucket,
+  \else
+    time_bucket(:BUCKET_WIDTH_2TH, "bucket") AS bucket,
+  \endif
+  SUM(temperature) AS temperature
+FROM :CAGG_NAME_1ST_LEVEL
+GROUP BY 1
+WITH NO DATA;
+\d+ :CAGG_NAME_2TH_LEVEL
+                               View "public.conditions_summary_2"
+   Column    |           Type           | Collation | Nullable | Default | Storage | Description 
+-------------+--------------------------+-----------+----------+---------+---------+-------------
+ bucket      | timestamp with time zone |           |          |         | plain   | 
+ temperature | numeric                  |           |          |         | main    | 
+View definition:
+ SELECT _materialized_hypertable_62.bucket,
+    _materialized_hypertable_62.temperature
+   FROM _timescaledb_internal._materialized_hypertable_62
+  WHERE _materialized_hypertable_62.bucket < COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(62)), '-infinity'::timestamp with time zone)
+UNION ALL
+ SELECT time_bucket('@ 3 mons'::interval, conditions_summary_1.bucket) AS bucket,
+    sum(conditions_summary_1.temperature) AS temperature
+   FROM conditions_summary_1
+  WHERE conditions_summary_1.bucket >= COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(62)), '-infinity'::timestamp with time zone)
+  GROUP BY (time_bucket('@ 3 mons'::interval, conditions_summary_1.bucket));
+
+\set ON_ERROR_STOP 1
+\set VERBOSITY terse
+-- Check for incorrect CAGGs
+\if :INTERVAL_TEST
+  INSERT INTO conditions ("time", temperature, device_id) VALUES ('2022-01-01 00:00:00-00', 10, 4);
+  INSERT INTO conditions ("time", temperature, device_id) VALUES ('2022-01-15 01:00:00-00', 20, 4);
+  INSERT INTO conditions ("time", temperature, device_id) VALUES ('2022-01-31 01:00:00-00', 30, 4);
+  CALL refresh_continuous_aggregate(:'CAGG_NAME_1ST_LEVEL', NULL, NULL);
+  CALL refresh_continuous_aggregate(:'CAGG_NAME_2TH_LEVEL', NULL, NULL);
+  CREATE MATERIALIZED VIEW :CAGG_NAME_3TH_LEVEL
+  WITH (timescaledb.continuous) AS
+  SELECT
+    \if :IS_TIME_DIMENSION_WITH_TIMEZONE_2TH
+      time_bucket(:BUCKET_WIDTH_3TH, "bucket", :'BUCKET_TZNAME_2TH') AS bucket
+    \else
+      time_bucket(:BUCKET_WIDTH_3TH, "bucket") AS bucket
+    \endif
+  FROM :CAGG_NAME_2TH_LEVEL
+  GROUP BY 1
+  WITH DATA;
+  \d+ :CAGG_NAME_3TH_LEVEL
+  --There should never be dulpicates in the output of the following query
+  SELECT * from :CAGG_NAME_3TH_LEVEL;
+  DROP MATERIALIZED VIEW IF EXISTS :CAGG_NAME_3TH_LEVEL;
+  DELETE FROM conditions WHERE device_id = 4;
+\endif
+--
+-- Cleanup
+--
+DROP MATERIALIZED VIEW IF EXISTS :CAGG_NAME_2TH_LEVEL;
+DROP MATERIALIZED VIEW IF EXISTS :CAGG_NAME_1ST_LEVEL;
+\set BUCKET_WIDTH_1ST 'INTERVAL \'1 month\''
+\set BUCKET_WIDTH_2TH 'INTERVAL \'1 year\''
+\ir include/cagg_on_cagg_validations.sql
+-- This file and its contents are licensed under the Timescale License.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-TIMESCALE for a copy of the license.
+\set CAGG_NAME_1ST_LEVEL conditions_summary_1
+\set CAGG_NAME_2TH_LEVEL conditions_summary_2
+\set CAGG_NAME_3TH_LEVEL conditions_summary_3
+--
+-- CAGG on hypertable (1st level)
+--
+CREATE MATERIALIZED VIEW :CAGG_NAME_1ST_LEVEL
+WITH (timescaledb.continuous) AS
+SELECT
+  \if :IS_TIME_DIMENSION_WITH_TIMEZONE_1ST
+    time_bucket(:BUCKET_WIDTH_1ST, "time", :'BUCKET_TZNAME_1ST') AS bucket,
+  \else
+    time_bucket(:BUCKET_WIDTH_1ST, "time") AS bucket,
+  \endif
+  SUM(temperature) AS temperature
+FROM conditions
+GROUP BY 1
+WITH NO DATA;
+\d+ :CAGG_NAME_1ST_LEVEL
+                               View "public.conditions_summary_1"
+   Column    |           Type           | Collation | Nullable | Default | Storage | Description 
+-------------+--------------------------+-----------+----------+---------+---------+-------------
+ bucket      | timestamp with time zone |           |          |         | plain   | 
+ temperature | numeric                  |           |          |         | main    | 
+View definition:
+ SELECT _materialized_hypertable_63.bucket,
+    _materialized_hypertable_63.temperature
+   FROM _timescaledb_internal._materialized_hypertable_63
+  WHERE _materialized_hypertable_63.bucket < COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(63)), '-infinity'::timestamp with time zone)
+UNION ALL
+ SELECT time_bucket('@ 1 mon'::interval, conditions."time", 'UTC'::text) AS bucket,
+    sum(conditions.temperature) AS temperature
+   FROM conditions
+  WHERE conditions."time" >= COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(63)), '-infinity'::timestamp with time zone)
+  GROUP BY (time_bucket('@ 1 mon'::interval, conditions."time", 'UTC'::text));
+
+--
+-- CAGG on CAGG (2th level)
+--
+\set VERBOSITY default
+\set ON_ERROR_STOP 0
+\echo :WARNING_MESSAGE
+-- SHOULD WORK
+CREATE MATERIALIZED VIEW :CAGG_NAME_2TH_LEVEL
+WITH (timescaledb.continuous) AS
+SELECT
+  \if :IS_TIME_DIMENSION_WITH_TIMEZONE_2TH
+    time_bucket(:BUCKET_WIDTH_2TH, "bucket", :'BUCKET_TZNAME_2TH') AS bucket,
+  \else
+    time_bucket(:BUCKET_WIDTH_2TH, "bucket") AS bucket,
+  \endif
+  SUM(temperature) AS temperature
+FROM :CAGG_NAME_1ST_LEVEL
+GROUP BY 1
+WITH NO DATA;
+\d+ :CAGG_NAME_2TH_LEVEL
+                               View "public.conditions_summary_2"
+   Column    |           Type           | Collation | Nullable | Default | Storage | Description 
+-------------+--------------------------+-----------+----------+---------+---------+-------------
+ bucket      | timestamp with time zone |           |          |         | plain   | 
+ temperature | numeric                  |           |          |         | main    | 
+View definition:
+ SELECT _materialized_hypertable_64.bucket,
+    _materialized_hypertable_64.temperature
+   FROM _timescaledb_internal._materialized_hypertable_64
+  WHERE _materialized_hypertable_64.bucket < COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(64)), '-infinity'::timestamp with time zone)
+UNION ALL
+ SELECT time_bucket('@ 1 year'::interval, conditions_summary_1.bucket) AS bucket,
+    sum(conditions_summary_1.temperature) AS temperature
+   FROM conditions_summary_1
+  WHERE conditions_summary_1.bucket >= COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(64)), '-infinity'::timestamp with time zone)
+  GROUP BY (time_bucket('@ 1 year'::interval, conditions_summary_1.bucket));
+
+\set ON_ERROR_STOP 1
+\set VERBOSITY terse
+-- Check for incorrect CAGGs
+\if :INTERVAL_TEST
+  INSERT INTO conditions ("time", temperature, device_id) VALUES ('2022-01-01 00:00:00-00', 10, 4);
+  INSERT INTO conditions ("time", temperature, device_id) VALUES ('2022-01-15 01:00:00-00', 20, 4);
+  INSERT INTO conditions ("time", temperature, device_id) VALUES ('2022-01-31 01:00:00-00', 30, 4);
+  CALL refresh_continuous_aggregate(:'CAGG_NAME_1ST_LEVEL', NULL, NULL);
+  CALL refresh_continuous_aggregate(:'CAGG_NAME_2TH_LEVEL', NULL, NULL);
+  CREATE MATERIALIZED VIEW :CAGG_NAME_3TH_LEVEL
+  WITH (timescaledb.continuous) AS
+  SELECT
+    \if :IS_TIME_DIMENSION_WITH_TIMEZONE_2TH
+      time_bucket(:BUCKET_WIDTH_3TH, "bucket", :'BUCKET_TZNAME_2TH') AS bucket
+    \else
+      time_bucket(:BUCKET_WIDTH_3TH, "bucket") AS bucket
+    \endif
+  FROM :CAGG_NAME_2TH_LEVEL
+  GROUP BY 1
+  WITH DATA;
+  \d+ :CAGG_NAME_3TH_LEVEL
+  --There should never be dulpicates in the output of the following query
+  SELECT * from :CAGG_NAME_3TH_LEVEL;
+  DROP MATERIALIZED VIEW IF EXISTS :CAGG_NAME_3TH_LEVEL;
+  DELETE FROM conditions WHERE device_id = 4;
+\endif
+--
+-- Cleanup
+--
+DROP MATERIALIZED VIEW IF EXISTS :CAGG_NAME_2TH_LEVEL;
+DROP MATERIALIZED VIEW IF EXISTS :CAGG_NAME_1ST_LEVEL;
+\set BUCKET_WIDTH_1ST 'INTERVAL \'1 week\''
+\set BUCKET_WIDTH_2TH 'INTERVAL \'1 year\''
+\ir include/cagg_on_cagg_validations.sql
+-- This file and its contents are licensed under the Timescale License.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-TIMESCALE for a copy of the license.
+\set CAGG_NAME_1ST_LEVEL conditions_summary_1
+\set CAGG_NAME_2TH_LEVEL conditions_summary_2
+\set CAGG_NAME_3TH_LEVEL conditions_summary_3
+--
+-- CAGG on hypertable (1st level)
+--
+CREATE MATERIALIZED VIEW :CAGG_NAME_1ST_LEVEL
+WITH (timescaledb.continuous) AS
+SELECT
+  \if :IS_TIME_DIMENSION_WITH_TIMEZONE_1ST
+    time_bucket(:BUCKET_WIDTH_1ST, "time", :'BUCKET_TZNAME_1ST') AS bucket,
+  \else
+    time_bucket(:BUCKET_WIDTH_1ST, "time") AS bucket,
+  \endif
+  SUM(temperature) AS temperature
+FROM conditions
+GROUP BY 1
+WITH NO DATA;
+\d+ :CAGG_NAME_1ST_LEVEL
+                               View "public.conditions_summary_1"
+   Column    |           Type           | Collation | Nullable | Default | Storage | Description 
+-------------+--------------------------+-----------+----------+---------+---------+-------------
+ bucket      | timestamp with time zone |           |          |         | plain   | 
+ temperature | numeric                  |           |          |         | main    | 
+View definition:
+ SELECT _materialized_hypertable_65.bucket,
+    _materialized_hypertable_65.temperature
+   FROM _timescaledb_internal._materialized_hypertable_65
+  WHERE _materialized_hypertable_65.bucket < COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(65)), '-infinity'::timestamp with time zone)
+UNION ALL
+ SELECT time_bucket('@ 7 days'::interval, conditions."time", 'UTC'::text) AS bucket,
+    sum(conditions.temperature) AS temperature
+   FROM conditions
+  WHERE conditions."time" >= COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(65)), '-infinity'::timestamp with time zone)
+  GROUP BY (time_bucket('@ 7 days'::interval, conditions."time", 'UTC'::text));
+
+--
+-- CAGG on CAGG (2th level)
+--
+\set VERBOSITY default
+\set ON_ERROR_STOP 0
+\echo :WARNING_MESSAGE
+-- SHOULD WORK
+CREATE MATERIALIZED VIEW :CAGG_NAME_2TH_LEVEL
+WITH (timescaledb.continuous) AS
+SELECT
+  \if :IS_TIME_DIMENSION_WITH_TIMEZONE_2TH
+    time_bucket(:BUCKET_WIDTH_2TH, "bucket", :'BUCKET_TZNAME_2TH') AS bucket,
+  \else
+    time_bucket(:BUCKET_WIDTH_2TH, "bucket") AS bucket,
+  \endif
+  SUM(temperature) AS temperature
+FROM :CAGG_NAME_1ST_LEVEL
+GROUP BY 1
+WITH NO DATA;
+psql:include/cagg_on_cagg_validations.sql:44: ERROR:  cannot create continuous aggregate with incompatible bucket width
+DETAIL:  Time bucket width of "public.conditions_summary_2" [@ 1 year] should be multiple of the time bucket width of "public.conditions_summary_1" [@ 7 days].
+\d+ :CAGG_NAME_2TH_LEVEL
+\set ON_ERROR_STOP 1
+\set VERBOSITY terse
+-- Check for incorrect CAGGs
+\if :INTERVAL_TEST
+  INSERT INTO conditions ("time", temperature, device_id) VALUES ('2022-01-01 00:00:00-00', 10, 4);
+  INSERT INTO conditions ("time", temperature, device_id) VALUES ('2022-01-15 01:00:00-00', 20, 4);
+  INSERT INTO conditions ("time", temperature, device_id) VALUES ('2022-01-31 01:00:00-00', 30, 4);
+  CALL refresh_continuous_aggregate(:'CAGG_NAME_1ST_LEVEL', NULL, NULL);
+  CALL refresh_continuous_aggregate(:'CAGG_NAME_2TH_LEVEL', NULL, NULL);
+  CREATE MATERIALIZED VIEW :CAGG_NAME_3TH_LEVEL
+  WITH (timescaledb.continuous) AS
+  SELECT
+    \if :IS_TIME_DIMENSION_WITH_TIMEZONE_2TH
+      time_bucket(:BUCKET_WIDTH_3TH, "bucket", :'BUCKET_TZNAME_2TH') AS bucket
+    \else
+      time_bucket(:BUCKET_WIDTH_3TH, "bucket") AS bucket
+    \endif
+  FROM :CAGG_NAME_2TH_LEVEL
+  GROUP BY 1
+  WITH DATA;
+  \d+ :CAGG_NAME_3TH_LEVEL
+  --There should never be dulpicates in the output of the following query
+  SELECT * from :CAGG_NAME_3TH_LEVEL;
+  DROP MATERIALIZED VIEW IF EXISTS :CAGG_NAME_3TH_LEVEL;
+  DELETE FROM conditions WHERE device_id = 4;
+\endif
+--
+-- Cleanup
+--
+DROP MATERIALIZED VIEW IF EXISTS :CAGG_NAME_2TH_LEVEL;
+psql:include/cagg_on_cagg_validations.sql:86: NOTICE:  materialized view "conditions_summary_2" does not exist, skipping
+DROP MATERIALIZED VIEW IF EXISTS :CAGG_NAME_1ST_LEVEL;
+\set BUCKET_WIDTH_1ST 'INTERVAL \'1 week\''
+\set BUCKET_WIDTH_2TH 'INTERVAL \'1 month\''
+\ir include/cagg_on_cagg_validations.sql
+-- This file and its contents are licensed under the Timescale License.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-TIMESCALE for a copy of the license.
+\set CAGG_NAME_1ST_LEVEL conditions_summary_1
+\set CAGG_NAME_2TH_LEVEL conditions_summary_2
+\set CAGG_NAME_3TH_LEVEL conditions_summary_3
+--
+-- CAGG on hypertable (1st level)
+--
+CREATE MATERIALIZED VIEW :CAGG_NAME_1ST_LEVEL
+WITH (timescaledb.continuous) AS
+SELECT
+  \if :IS_TIME_DIMENSION_WITH_TIMEZONE_1ST
+    time_bucket(:BUCKET_WIDTH_1ST, "time", :'BUCKET_TZNAME_1ST') AS bucket,
+  \else
+    time_bucket(:BUCKET_WIDTH_1ST, "time") AS bucket,
+  \endif
+  SUM(temperature) AS temperature
+FROM conditions
+GROUP BY 1
+WITH NO DATA;
+\d+ :CAGG_NAME_1ST_LEVEL
+                               View "public.conditions_summary_1"
+   Column    |           Type           | Collation | Nullable | Default | Storage | Description 
+-------------+--------------------------+-----------+----------+---------+---------+-------------
+ bucket      | timestamp with time zone |           |          |         | plain   | 
+ temperature | numeric                  |           |          |         | main    | 
+View definition:
+ SELECT _materialized_hypertable_66.bucket,
+    _materialized_hypertable_66.temperature
+   FROM _timescaledb_internal._materialized_hypertable_66
+  WHERE _materialized_hypertable_66.bucket < COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(66)), '-infinity'::timestamp with time zone)
+UNION ALL
+ SELECT time_bucket('@ 7 days'::interval, conditions."time", 'UTC'::text) AS bucket,
+    sum(conditions.temperature) AS temperature
+   FROM conditions
+  WHERE conditions."time" >= COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(66)), '-infinity'::timestamp with time zone)
+  GROUP BY (time_bucket('@ 7 days'::interval, conditions."time", 'UTC'::text));
+
+--
+-- CAGG on CAGG (2th level)
+--
+\set VERBOSITY default
+\set ON_ERROR_STOP 0
+\echo :WARNING_MESSAGE
+-- SHOULD WORK
+CREATE MATERIALIZED VIEW :CAGG_NAME_2TH_LEVEL
+WITH (timescaledb.continuous) AS
+SELECT
+  \if :IS_TIME_DIMENSION_WITH_TIMEZONE_2TH
+    time_bucket(:BUCKET_WIDTH_2TH, "bucket", :'BUCKET_TZNAME_2TH') AS bucket,
+  \else
+    time_bucket(:BUCKET_WIDTH_2TH, "bucket") AS bucket,
+  \endif
+  SUM(temperature) AS temperature
+FROM :CAGG_NAME_1ST_LEVEL
+GROUP BY 1
+WITH NO DATA;
+psql:include/cagg_on_cagg_validations.sql:44: ERROR:  cannot create continuous aggregate with incompatible bucket width
+DETAIL:  Time bucket width of "public.conditions_summary_2" [@ 1 mon] should be multiple of the time bucket width of "public.conditions_summary_1" [@ 7 days].
+\d+ :CAGG_NAME_2TH_LEVEL
+\set ON_ERROR_STOP 1
+\set VERBOSITY terse
+-- Check for incorrect CAGGs
+\if :INTERVAL_TEST
+  INSERT INTO conditions ("time", temperature, device_id) VALUES ('2022-01-01 00:00:00-00', 10, 4);
+  INSERT INTO conditions ("time", temperature, device_id) VALUES ('2022-01-15 01:00:00-00', 20, 4);
+  INSERT INTO conditions ("time", temperature, device_id) VALUES ('2022-01-31 01:00:00-00', 30, 4);
+  CALL refresh_continuous_aggregate(:'CAGG_NAME_1ST_LEVEL', NULL, NULL);
+  CALL refresh_continuous_aggregate(:'CAGG_NAME_2TH_LEVEL', NULL, NULL);
+  CREATE MATERIALIZED VIEW :CAGG_NAME_3TH_LEVEL
+  WITH (timescaledb.continuous) AS
+  SELECT
+    \if :IS_TIME_DIMENSION_WITH_TIMEZONE_2TH
+      time_bucket(:BUCKET_WIDTH_3TH, "bucket", :'BUCKET_TZNAME_2TH') AS bucket
+    \else
+      time_bucket(:BUCKET_WIDTH_3TH, "bucket") AS bucket
+    \endif
+  FROM :CAGG_NAME_2TH_LEVEL
+  GROUP BY 1
+  WITH DATA;
+  \d+ :CAGG_NAME_3TH_LEVEL
+  --There should never be dulpicates in the output of the following query
+  SELECT * from :CAGG_NAME_3TH_LEVEL;
+  DROP MATERIALIZED VIEW IF EXISTS :CAGG_NAME_3TH_LEVEL;
+  DELETE FROM conditions WHERE device_id = 4;
+\endif
+--
+-- Cleanup
+--
+DROP MATERIALIZED VIEW IF EXISTS :CAGG_NAME_2TH_LEVEL;
+psql:include/cagg_on_cagg_validations.sql:86: NOTICE:  materialized view "conditions_summary_2" does not exist, skipping
+DROP MATERIALIZED VIEW IF EXISTS :CAGG_NAME_1ST_LEVEL;
+-- bug report 5277
+\set IS_TIME_DIMENSION_WITH_TIMEZONE_1ST FALSE
+\set IS_TIME_DIMENSION_WITH_TIMEZONE_2TH FALSE
+-- epoch plus cast to int would compute a bucket width of 0 for parent
+\set BUCKET_WIDTH_1ST 'INTERVAL \'146 ms\''
+\set BUCKET_WIDTH_2TH 'INTERVAL \'1168 ms\''
+\ir include/cagg_on_cagg_validations.sql
+-- This file and its contents are licensed under the Timescale License.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-TIMESCALE for a copy of the license.
+\set CAGG_NAME_1ST_LEVEL conditions_summary_1
+\set CAGG_NAME_2TH_LEVEL conditions_summary_2
+\set CAGG_NAME_3TH_LEVEL conditions_summary_3
+--
+-- CAGG on hypertable (1st level)
+--
+CREATE MATERIALIZED VIEW :CAGG_NAME_1ST_LEVEL
+WITH (timescaledb.continuous) AS
+SELECT
+  \if :IS_TIME_DIMENSION_WITH_TIMEZONE_1ST
+    time_bucket(:BUCKET_WIDTH_1ST, "time", :'BUCKET_TZNAME_1ST') AS bucket,
+  \else
+    time_bucket(:BUCKET_WIDTH_1ST, "time") AS bucket,
+  \endif
+  SUM(temperature) AS temperature
+FROM conditions
+GROUP BY 1
+WITH NO DATA;
+\d+ :CAGG_NAME_1ST_LEVEL
+                               View "public.conditions_summary_1"
+   Column    |           Type           | Collation | Nullable | Default | Storage | Description 
+-------------+--------------------------+-----------+----------+---------+---------+-------------
+ bucket      | timestamp with time zone |           |          |         | plain   | 
+ temperature | numeric                  |           |          |         | main    | 
+View definition:
+ SELECT _materialized_hypertable_67.bucket,
+    _materialized_hypertable_67.temperature
+   FROM _timescaledb_internal._materialized_hypertable_67
+  WHERE _materialized_hypertable_67.bucket < COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(67)), '-infinity'::timestamp with time zone)
 UNION ALL
  SELECT time_bucket('@ 0.146 secs'::interval, conditions."time") AS bucket,
     sum(conditions.temperature) AS temperature
    FROM conditions
-  WHERE conditions."time" >= COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(58)), '-infinity'::timestamp with time zone)
+  WHERE conditions."time" >= COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(67)), '-infinity'::timestamp with time zone)
   GROUP BY (time_bucket('@ 0.146 secs'::interval, conditions."time"));
 
 --
@@ -4415,19 +5378,43 @@ WITH NO DATA;
  bucket      | timestamp with time zone |           |          |         | plain   | 
  temperature | numeric                  |           |          |         | main    | 
 View definition:
- SELECT _materialized_hypertable_59.bucket,
-    _materialized_hypertable_59.temperature
-   FROM _timescaledb_internal._materialized_hypertable_59
-  WHERE _materialized_hypertable_59.bucket < COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(59)), '-infinity'::timestamp with time zone)
+ SELECT _materialized_hypertable_68.bucket,
+    _materialized_hypertable_68.temperature
+   FROM _timescaledb_internal._materialized_hypertable_68
+  WHERE _materialized_hypertable_68.bucket < COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(68)), '-infinity'::timestamp with time zone)
 UNION ALL
  SELECT time_bucket('@ 1.168 secs'::interval, conditions_summary_1.bucket) AS bucket,
     sum(conditions_summary_1.temperature) AS temperature
    FROM conditions_summary_1
-  WHERE conditions_summary_1.bucket >= COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(59)), '-infinity'::timestamp with time zone)
+  WHERE conditions_summary_1.bucket >= COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(68)), '-infinity'::timestamp with time zone)
   GROUP BY (time_bucket('@ 1.168 secs'::interval, conditions_summary_1.bucket));
 
 \set ON_ERROR_STOP 1
 \set VERBOSITY terse
+-- Check for incorrect CAGGs
+\if :INTERVAL_TEST
+  INSERT INTO conditions ("time", temperature, device_id) VALUES ('2022-01-01 00:00:00-00', 10, 4);
+  INSERT INTO conditions ("time", temperature, device_id) VALUES ('2022-01-15 01:00:00-00', 20, 4);
+  INSERT INTO conditions ("time", temperature, device_id) VALUES ('2022-01-31 01:00:00-00', 30, 4);
+  CALL refresh_continuous_aggregate(:'CAGG_NAME_1ST_LEVEL', NULL, NULL);
+  CALL refresh_continuous_aggregate(:'CAGG_NAME_2TH_LEVEL', NULL, NULL);
+  CREATE MATERIALIZED VIEW :CAGG_NAME_3TH_LEVEL
+  WITH (timescaledb.continuous) AS
+  SELECT
+    \if :IS_TIME_DIMENSION_WITH_TIMEZONE_2TH
+      time_bucket(:BUCKET_WIDTH_3TH, "bucket", :'BUCKET_TZNAME_2TH') AS bucket
+    \else
+      time_bucket(:BUCKET_WIDTH_3TH, "bucket") AS bucket
+    \endif
+  FROM :CAGG_NAME_2TH_LEVEL
+  GROUP BY 1
+  WITH DATA;
+  \d+ :CAGG_NAME_3TH_LEVEL
+  --There should never be dulpicates in the output of the following query
+  SELECT * from :CAGG_NAME_3TH_LEVEL;
+  DROP MATERIALIZED VIEW IF EXISTS :CAGG_NAME_3TH_LEVEL;
+  DELETE FROM conditions WHERE device_id = 4;
+\endif
 --
 -- Cleanup
 --
@@ -4441,6 +5428,7 @@ DROP MATERIALIZED VIEW IF EXISTS :CAGG_NAME_1ST_LEVEL;
 -- LICENSE-TIMESCALE for a copy of the license.
 \set CAGG_NAME_1ST_LEVEL conditions_summary_1
 \set CAGG_NAME_2TH_LEVEL conditions_summary_2
+\set CAGG_NAME_3TH_LEVEL conditions_summary_3
 --
 -- CAGG on hypertable (1st level)
 --
@@ -4463,15 +5451,15 @@ WITH NO DATA;
  bucket      | timestamp with time zone |           |          |         | plain   | 
  temperature | numeric                  |           |          |         | main    | 
 View definition:
- SELECT _materialized_hypertable_60.bucket,
-    _materialized_hypertable_60.temperature
-   FROM _timescaledb_internal._materialized_hypertable_60
-  WHERE _materialized_hypertable_60.bucket < COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(60)), '-infinity'::timestamp with time zone)
+ SELECT _materialized_hypertable_69.bucket,
+    _materialized_hypertable_69.temperature
+   FROM _timescaledb_internal._materialized_hypertable_69
+  WHERE _materialized_hypertable_69.bucket < COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(69)), '-infinity'::timestamp with time zone)
 UNION ALL
  SELECT time_bucket('@ 9.344 secs'::interval, conditions."time") AS bucket,
     sum(conditions.temperature) AS temperature
    FROM conditions
-  WHERE conditions."time" >= COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(60)), '-infinity'::timestamp with time zone)
+  WHERE conditions."time" >= COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(69)), '-infinity'::timestamp with time zone)
   GROUP BY (time_bucket('@ 9.344 secs'::interval, conditions."time"));
 
 --
@@ -4500,19 +5488,43 @@ WITH NO DATA;
  bucket      | timestamp with time zone |           |          |         | plain   | 
  temperature | numeric                  |           |          |         | main    | 
 View definition:
- SELECT _materialized_hypertable_61.bucket,
-    _materialized_hypertable_61.temperature
-   FROM _timescaledb_internal._materialized_hypertable_61
-  WHERE _materialized_hypertable_61.bucket < COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(61)), '-infinity'::timestamp with time zone)
+ SELECT _materialized_hypertable_70.bucket,
+    _materialized_hypertable_70.temperature
+   FROM _timescaledb_internal._materialized_hypertable_70
+  WHERE _materialized_hypertable_70.bucket < COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(70)), '-infinity'::timestamp with time zone)
 UNION ALL
  SELECT time_bucket('@ 1 min 14.752 secs'::interval, conditions_summary_1.bucket) AS bucket,
     sum(conditions_summary_1.temperature) AS temperature
    FROM conditions_summary_1
-  WHERE conditions_summary_1.bucket >= COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(61)), '-infinity'::timestamp with time zone)
+  WHERE conditions_summary_1.bucket >= COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(70)), '-infinity'::timestamp with time zone)
   GROUP BY (time_bucket('@ 1 min 14.752 secs'::interval, conditions_summary_1.bucket));
 
 \set ON_ERROR_STOP 1
 \set VERBOSITY terse
+-- Check for incorrect CAGGs
+\if :INTERVAL_TEST
+  INSERT INTO conditions ("time", temperature, device_id) VALUES ('2022-01-01 00:00:00-00', 10, 4);
+  INSERT INTO conditions ("time", temperature, device_id) VALUES ('2022-01-15 01:00:00-00', 20, 4);
+  INSERT INTO conditions ("time", temperature, device_id) VALUES ('2022-01-31 01:00:00-00', 30, 4);
+  CALL refresh_continuous_aggregate(:'CAGG_NAME_1ST_LEVEL', NULL, NULL);
+  CALL refresh_continuous_aggregate(:'CAGG_NAME_2TH_LEVEL', NULL, NULL);
+  CREATE MATERIALIZED VIEW :CAGG_NAME_3TH_LEVEL
+  WITH (timescaledb.continuous) AS
+  SELECT
+    \if :IS_TIME_DIMENSION_WITH_TIMEZONE_2TH
+      time_bucket(:BUCKET_WIDTH_3TH, "bucket", :'BUCKET_TZNAME_2TH') AS bucket
+    \else
+      time_bucket(:BUCKET_WIDTH_3TH, "bucket") AS bucket
+    \endif
+  FROM :CAGG_NAME_2TH_LEVEL
+  GROUP BY 1
+  WITH DATA;
+  \d+ :CAGG_NAME_3TH_LEVEL
+  --There should never be dulpicates in the output of the following query
+  SELECT * from :CAGG_NAME_3TH_LEVEL;
+  DROP MATERIALIZED VIEW IF EXISTS :CAGG_NAME_3TH_LEVEL;
+  DELETE FROM conditions WHERE device_id = 4;
+\endif
 --
 -- Cleanup
 --
@@ -4526,6 +5538,7 @@ DROP MATERIALIZED VIEW IF EXISTS :CAGG_NAME_1ST_LEVEL;
 -- LICENSE-TIMESCALE for a copy of the license.
 \set CAGG_NAME_1ST_LEVEL conditions_summary_1
 \set CAGG_NAME_2TH_LEVEL conditions_summary_2
+\set CAGG_NAME_3TH_LEVEL conditions_summary_3
 --
 -- CAGG on hypertable (1st level)
 --
@@ -4548,15 +5561,15 @@ WITH NO DATA;
  bucket      | timestamp with time zone |           |          |         | plain   | 
  temperature | numeric                  |           |          |         | main    | 
 View definition:
- SELECT _materialized_hypertable_62.bucket,
-    _materialized_hypertable_62.temperature
-   FROM _timescaledb_internal._materialized_hypertable_62
-  WHERE _materialized_hypertable_62.bucket < COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(62)), '-infinity'::timestamp with time zone)
+ SELECT _materialized_hypertable_71.bucket,
+    _materialized_hypertable_71.temperature
+   FROM _timescaledb_internal._materialized_hypertable_71
+  WHERE _materialized_hypertable_71.bucket < COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(71)), '-infinity'::timestamp with time zone)
 UNION ALL
  SELECT time_bucket('@ 1 min 14.752 secs'::interval, conditions."time") AS bucket,
     sum(conditions.temperature) AS temperature
    FROM conditions
-  WHERE conditions."time" >= COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(62)), '-infinity'::timestamp with time zone)
+  WHERE conditions."time" >= COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(71)), '-infinity'::timestamp with time zone)
   GROUP BY (time_bucket('@ 1 min 14.752 secs'::interval, conditions."time"));
 
 --
@@ -4585,19 +5598,43 @@ WITH NO DATA;
  bucket      | timestamp with time zone |           |          |         | plain   | 
  temperature | numeric                  |           |          |         | main    | 
 View definition:
- SELECT _materialized_hypertable_63.bucket,
-    _materialized_hypertable_63.temperature
-   FROM _timescaledb_internal._materialized_hypertable_63
-  WHERE _materialized_hypertable_63.bucket < COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(63)), '-infinity'::timestamp with time zone)
+ SELECT _materialized_hypertable_72.bucket,
+    _materialized_hypertable_72.temperature
+   FROM _timescaledb_internal._materialized_hypertable_72
+  WHERE _materialized_hypertable_72.bucket < COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(72)), '-infinity'::timestamp with time zone)
 UNION ALL
  SELECT time_bucket('@ 9 mins 58.016 secs'::interval, conditions_summary_1.bucket) AS bucket,
     sum(conditions_summary_1.temperature) AS temperature
    FROM conditions_summary_1
-  WHERE conditions_summary_1.bucket >= COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(63)), '-infinity'::timestamp with time zone)
+  WHERE conditions_summary_1.bucket >= COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(72)), '-infinity'::timestamp with time zone)
   GROUP BY (time_bucket('@ 9 mins 58.016 secs'::interval, conditions_summary_1.bucket));
 
 \set ON_ERROR_STOP 1
 \set VERBOSITY terse
+-- Check for incorrect CAGGs
+\if :INTERVAL_TEST
+  INSERT INTO conditions ("time", temperature, device_id) VALUES ('2022-01-01 00:00:00-00', 10, 4);
+  INSERT INTO conditions ("time", temperature, device_id) VALUES ('2022-01-15 01:00:00-00', 20, 4);
+  INSERT INTO conditions ("time", temperature, device_id) VALUES ('2022-01-31 01:00:00-00', 30, 4);
+  CALL refresh_continuous_aggregate(:'CAGG_NAME_1ST_LEVEL', NULL, NULL);
+  CALL refresh_continuous_aggregate(:'CAGG_NAME_2TH_LEVEL', NULL, NULL);
+  CREATE MATERIALIZED VIEW :CAGG_NAME_3TH_LEVEL
+  WITH (timescaledb.continuous) AS
+  SELECT
+    \if :IS_TIME_DIMENSION_WITH_TIMEZONE_2TH
+      time_bucket(:BUCKET_WIDTH_3TH, "bucket", :'BUCKET_TZNAME_2TH') AS bucket
+    \else
+      time_bucket(:BUCKET_WIDTH_3TH, "bucket") AS bucket
+    \endif
+  FROM :CAGG_NAME_2TH_LEVEL
+  GROUP BY 1
+  WITH DATA;
+  \d+ :CAGG_NAME_3TH_LEVEL
+  --There should never be dulpicates in the output of the following query
+  SELECT * from :CAGG_NAME_3TH_LEVEL;
+  DROP MATERIALIZED VIEW IF EXISTS :CAGG_NAME_3TH_LEVEL;
+  DELETE FROM conditions WHERE device_id = 4;
+\endif
 --
 -- Cleanup
 --
@@ -4612,6 +5649,7 @@ DROP MATERIALIZED VIEW IF EXISTS :CAGG_NAME_1ST_LEVEL;
 -- LICENSE-TIMESCALE for a copy of the license.
 \set CAGG_NAME_1ST_LEVEL conditions_summary_1
 \set CAGG_NAME_2TH_LEVEL conditions_summary_2
+\set CAGG_NAME_3TH_LEVEL conditions_summary_3
 --
 -- CAGG on hypertable (1st level)
 --
@@ -4634,15 +5672,15 @@ WITH NO DATA;
  bucket      | timestamp with time zone |           |          |         | plain   | 
  temperature | numeric                  |           |          |         | main    | 
 View definition:
- SELECT _materialized_hypertable_64.bucket,
-    _materialized_hypertable_64.temperature
-   FROM _timescaledb_internal._materialized_hypertable_64
-  WHERE _materialized_hypertable_64.bucket < COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(64)), '-infinity'::timestamp with time zone)
+ SELECT _materialized_hypertable_73.bucket,
+    _materialized_hypertable_73.temperature
+   FROM _timescaledb_internal._materialized_hypertable_73
+  WHERE _materialized_hypertable_73.bucket < COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(73)), '-infinity'::timestamp with time zone)
 UNION ALL
  SELECT time_bucket('@ 0.000146 secs'::interval, conditions."time") AS bucket,
     sum(conditions.temperature) AS temperature
    FROM conditions
-  WHERE conditions."time" >= COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(64)), '-infinity'::timestamp with time zone)
+  WHERE conditions."time" >= COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(73)), '-infinity'::timestamp with time zone)
   GROUP BY (time_bucket('@ 0.000146 secs'::interval, conditions."time"));
 
 --
@@ -4671,19 +5709,43 @@ WITH NO DATA;
  bucket      | timestamp with time zone |           |          |         | plain   | 
  temperature | numeric                  |           |          |         | main    | 
 View definition:
- SELECT _materialized_hypertable_65.bucket,
-    _materialized_hypertable_65.temperature
-   FROM _timescaledb_internal._materialized_hypertable_65
-  WHERE _materialized_hypertable_65.bucket < COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(65)), '-infinity'::timestamp with time zone)
+ SELECT _materialized_hypertable_74.bucket,
+    _materialized_hypertable_74.temperature
+   FROM _timescaledb_internal._materialized_hypertable_74
+  WHERE _materialized_hypertable_74.bucket < COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(74)), '-infinity'::timestamp with time zone)
 UNION ALL
  SELECT time_bucket('@ 0.001168 secs'::interval, conditions_summary_1.bucket) AS bucket,
     sum(conditions_summary_1.temperature) AS temperature
    FROM conditions_summary_1
-  WHERE conditions_summary_1.bucket >= COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(65)), '-infinity'::timestamp with time zone)
+  WHERE conditions_summary_1.bucket >= COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(74)), '-infinity'::timestamp with time zone)
   GROUP BY (time_bucket('@ 0.001168 secs'::interval, conditions_summary_1.bucket));
 
 \set ON_ERROR_STOP 1
 \set VERBOSITY terse
+-- Check for incorrect CAGGs
+\if :INTERVAL_TEST
+  INSERT INTO conditions ("time", temperature, device_id) VALUES ('2022-01-01 00:00:00-00', 10, 4);
+  INSERT INTO conditions ("time", temperature, device_id) VALUES ('2022-01-15 01:00:00-00', 20, 4);
+  INSERT INTO conditions ("time", temperature, device_id) VALUES ('2022-01-31 01:00:00-00', 30, 4);
+  CALL refresh_continuous_aggregate(:'CAGG_NAME_1ST_LEVEL', NULL, NULL);
+  CALL refresh_continuous_aggregate(:'CAGG_NAME_2TH_LEVEL', NULL, NULL);
+  CREATE MATERIALIZED VIEW :CAGG_NAME_3TH_LEVEL
+  WITH (timescaledb.continuous) AS
+  SELECT
+    \if :IS_TIME_DIMENSION_WITH_TIMEZONE_2TH
+      time_bucket(:BUCKET_WIDTH_3TH, "bucket", :'BUCKET_TZNAME_2TH') AS bucket
+    \else
+      time_bucket(:BUCKET_WIDTH_3TH, "bucket") AS bucket
+    \endif
+  FROM :CAGG_NAME_2TH_LEVEL
+  GROUP BY 1
+  WITH DATA;
+  \d+ :CAGG_NAME_3TH_LEVEL
+  --There should never be dulpicates in the output of the following query
+  SELECT * from :CAGG_NAME_3TH_LEVEL;
+  DROP MATERIALIZED VIEW IF EXISTS :CAGG_NAME_3TH_LEVEL;
+  DELETE FROM conditions WHERE device_id = 4;
+\endif
 --
 -- Cleanup
 --
@@ -4698,6 +5760,7 @@ DROP MATERIALIZED VIEW IF EXISTS :CAGG_NAME_1ST_LEVEL;
 -- LICENSE-TIMESCALE for a copy of the license.
 \set CAGG_NAME_1ST_LEVEL conditions_summary_1
 \set CAGG_NAME_2TH_LEVEL conditions_summary_2
+\set CAGG_NAME_3TH_LEVEL conditions_summary_3
 --
 -- CAGG on hypertable (1st level)
 --
@@ -4720,15 +5783,15 @@ WITH NO DATA;
  bucket      | timestamp with time zone |           |          |         | plain   | 
  temperature | numeric                  |           |          |         | main    | 
 View definition:
- SELECT _materialized_hypertable_66.bucket,
-    _materialized_hypertable_66.temperature
-   FROM _timescaledb_internal._materialized_hypertable_66
-  WHERE _materialized_hypertable_66.bucket < COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(66)), '-infinity'::timestamp with time zone)
+ SELECT _materialized_hypertable_75.bucket,
+    _materialized_hypertable_75.temperature
+   FROM _timescaledb_internal._materialized_hypertable_75
+  WHERE _materialized_hypertable_75.bucket < COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(75)), '-infinity'::timestamp with time zone)
 UNION ALL
  SELECT time_bucket('@ 0.000146 secs'::interval, conditions."time") AS bucket,
     sum(conditions.temperature) AS temperature
    FROM conditions
-  WHERE conditions."time" >= COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(66)), '-infinity'::timestamp with time zone)
+  WHERE conditions."time" >= COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(75)), '-infinity'::timestamp with time zone)
   GROUP BY (time_bucket('@ 0.000146 secs'::interval, conditions."time"));
 
 --
@@ -4750,14 +5813,38 @@ SELECT
 FROM :CAGG_NAME_1ST_LEVEL
 GROUP BY 1
 WITH NO DATA;
-psql:include/cagg_on_cagg_validations.sql:43: ERROR:  cannot create continuous aggregate with incompatible bucket width
+psql:include/cagg_on_cagg_validations.sql:44: ERROR:  cannot create continuous aggregate with incompatible bucket width
 DETAIL:  Time bucket width of "public.conditions_summary_2" [@ 0.00116 secs] should be multiple of the time bucket width of "public.conditions_summary_1" [@ 0.000146 secs].
 \d+ :CAGG_NAME_2TH_LEVEL
 \set ON_ERROR_STOP 1
 \set VERBOSITY terse
+-- Check for incorrect CAGGs
+\if :INTERVAL_TEST
+  INSERT INTO conditions ("time", temperature, device_id) VALUES ('2022-01-01 00:00:00-00', 10, 4);
+  INSERT INTO conditions ("time", temperature, device_id) VALUES ('2022-01-15 01:00:00-00', 20, 4);
+  INSERT INTO conditions ("time", temperature, device_id) VALUES ('2022-01-31 01:00:00-00', 30, 4);
+  CALL refresh_continuous_aggregate(:'CAGG_NAME_1ST_LEVEL', NULL, NULL);
+  CALL refresh_continuous_aggregate(:'CAGG_NAME_2TH_LEVEL', NULL, NULL);
+  CREATE MATERIALIZED VIEW :CAGG_NAME_3TH_LEVEL
+  WITH (timescaledb.continuous) AS
+  SELECT
+    \if :IS_TIME_DIMENSION_WITH_TIMEZONE_2TH
+      time_bucket(:BUCKET_WIDTH_3TH, "bucket", :'BUCKET_TZNAME_2TH') AS bucket
+    \else
+      time_bucket(:BUCKET_WIDTH_3TH, "bucket") AS bucket
+    \endif
+  FROM :CAGG_NAME_2TH_LEVEL
+  GROUP BY 1
+  WITH DATA;
+  \d+ :CAGG_NAME_3TH_LEVEL
+  --There should never be dulpicates in the output of the following query
+  SELECT * from :CAGG_NAME_3TH_LEVEL;
+  DROP MATERIALIZED VIEW IF EXISTS :CAGG_NAME_3TH_LEVEL;
+  DELETE FROM conditions WHERE device_id = 4;
+\endif
 --
 -- Cleanup
 --
 DROP MATERIALIZED VIEW IF EXISTS :CAGG_NAME_2TH_LEVEL;
-psql:include/cagg_on_cagg_validations.sql:53: NOTICE:  materialized view "conditions_summary_2" does not exist, skipping
+psql:include/cagg_on_cagg_validations.sql:86: NOTICE:  materialized view "conditions_summary_2" does not exist, skipping
 DROP MATERIALIZED VIEW IF EXISTS :CAGG_NAME_1ST_LEVEL;

--- a/tsl/test/expected/cagg_on_cagg_dist_ht.out
+++ b/tsl/test/expected/cagg_on_cagg_dist_ht.out
@@ -8,6 +8,7 @@
 \set DATA_NODE_1 :TEST_DBNAME _1
 \set DATA_NODE_2 :TEST_DBNAME _2
 \set DATA_NODE_3 :TEST_DBNAME _3
+\set INTERVAL_TEST FALSE
 \ir include/remote_exec.sql
 -- This file and its contents are licensed under the Timescale License.
 -- Please see the included NOTICE for copyright information and
@@ -46,6 +47,7 @@ GRANT CREATE ON SCHEMA public TO :ROLE_DEFAULT_PERM_USER;
 -- Current test variables
 \set IS_TIME_DIMENSION FALSE
 \set TIME_DIMENSION_DATATYPE INTEGER
+\set INTERVAL_TEST FALSE
 \set CAGG_NAME_1ST_LEVEL conditions_summary_1_1
 \set CAGG_NAME_2TH_LEVEL conditions_summary_2_5
 \set CAGG_NAME_3TH_LEVEL conditions_summary_3_10
@@ -902,6 +904,7 @@ psql:include/cagg_on_cagg_common.sql:200: ERROR:  relation "conditions_summary_1
 -- LICENSE-TIMESCALE for a copy of the license.
 \set CAGG_NAME_1ST_LEVEL conditions_summary_1
 \set CAGG_NAME_2TH_LEVEL conditions_summary_2
+\set CAGG_NAME_3TH_LEVEL conditions_summary_3
 --
 -- CAGG on hypertable (1st level)
 --
@@ -954,16 +957,40 @@ SELECT
 FROM :CAGG_NAME_1ST_LEVEL
 GROUP BY 1
 WITH NO DATA;
-psql:include/cagg_on_cagg_validations.sql:43: ERROR:  cannot create continuous aggregate with incompatible bucket width
+psql:include/cagg_on_cagg_validations.sql:44: ERROR:  cannot create continuous aggregate with incompatible bucket width
 DETAIL:  Time bucket width of "public.conditions_summary_2" [5] should be multiple of the time bucket width of "public.conditions_summary_1" [2].
 \d+ :CAGG_NAME_2TH_LEVEL
 \set ON_ERROR_STOP 1
 \set VERBOSITY terse
+-- Check for incorrect CAGGs
+\if :INTERVAL_TEST
+  INSERT INTO conditions ("time", temperature, device_id) VALUES ('2022-01-01 00:00:00-00', 10, 4);
+  INSERT INTO conditions ("time", temperature, device_id) VALUES ('2022-01-15 01:00:00-00', 20, 4);
+  INSERT INTO conditions ("time", temperature, device_id) VALUES ('2022-01-31 01:00:00-00', 30, 4);
+  CALL refresh_continuous_aggregate(:'CAGG_NAME_1ST_LEVEL', NULL, NULL);
+  CALL refresh_continuous_aggregate(:'CAGG_NAME_2TH_LEVEL', NULL, NULL);
+  CREATE MATERIALIZED VIEW :CAGG_NAME_3TH_LEVEL
+  WITH (timescaledb.continuous) AS
+  SELECT
+    \if :IS_TIME_DIMENSION_WITH_TIMEZONE_2TH
+      time_bucket(:BUCKET_WIDTH_3TH, "bucket", :'BUCKET_TZNAME_2TH') AS bucket
+    \else
+      time_bucket(:BUCKET_WIDTH_3TH, "bucket") AS bucket
+    \endif
+  FROM :CAGG_NAME_2TH_LEVEL
+  GROUP BY 1
+  WITH DATA;
+  \d+ :CAGG_NAME_3TH_LEVEL
+  --There should never be dulpicates in the output of the following query
+  SELECT * from :CAGG_NAME_3TH_LEVEL;
+  DROP MATERIALIZED VIEW IF EXISTS :CAGG_NAME_3TH_LEVEL;
+  DELETE FROM conditions WHERE device_id = 4;
+\endif
 --
 -- Cleanup
 --
 DROP MATERIALIZED VIEW IF EXISTS :CAGG_NAME_2TH_LEVEL;
-psql:include/cagg_on_cagg_validations.sql:53: NOTICE:  materialized view "conditions_summary_2" does not exist, skipping
+psql:include/cagg_on_cagg_validations.sql:86: NOTICE:  materialized view "conditions_summary_2" does not exist, skipping
 DROP MATERIALIZED VIEW IF EXISTS :CAGG_NAME_1ST_LEVEL;
 --
 -- Validation test for equal bucket sizes
@@ -977,6 +1004,7 @@ DROP MATERIALIZED VIEW IF EXISTS :CAGG_NAME_1ST_LEVEL;
 -- LICENSE-TIMESCALE for a copy of the license.
 \set CAGG_NAME_1ST_LEVEL conditions_summary_1
 \set CAGG_NAME_2TH_LEVEL conditions_summary_2
+\set CAGG_NAME_3TH_LEVEL conditions_summary_3
 --
 -- CAGG on hypertable (1st level)
 --
@@ -1049,6 +1077,30 @@ UNION ALL
 
 \set ON_ERROR_STOP 1
 \set VERBOSITY terse
+-- Check for incorrect CAGGs
+\if :INTERVAL_TEST
+  INSERT INTO conditions ("time", temperature, device_id) VALUES ('2022-01-01 00:00:00-00', 10, 4);
+  INSERT INTO conditions ("time", temperature, device_id) VALUES ('2022-01-15 01:00:00-00', 20, 4);
+  INSERT INTO conditions ("time", temperature, device_id) VALUES ('2022-01-31 01:00:00-00', 30, 4);
+  CALL refresh_continuous_aggregate(:'CAGG_NAME_1ST_LEVEL', NULL, NULL);
+  CALL refresh_continuous_aggregate(:'CAGG_NAME_2TH_LEVEL', NULL, NULL);
+  CREATE MATERIALIZED VIEW :CAGG_NAME_3TH_LEVEL
+  WITH (timescaledb.continuous) AS
+  SELECT
+    \if :IS_TIME_DIMENSION_WITH_TIMEZONE_2TH
+      time_bucket(:BUCKET_WIDTH_3TH, "bucket", :'BUCKET_TZNAME_2TH') AS bucket
+    \else
+      time_bucket(:BUCKET_WIDTH_3TH, "bucket") AS bucket
+    \endif
+  FROM :CAGG_NAME_2TH_LEVEL
+  GROUP BY 1
+  WITH DATA;
+  \d+ :CAGG_NAME_3TH_LEVEL
+  --There should never be dulpicates in the output of the following query
+  SELECT * from :CAGG_NAME_3TH_LEVEL;
+  DROP MATERIALIZED VIEW IF EXISTS :CAGG_NAME_3TH_LEVEL;
+  DELETE FROM conditions WHERE device_id = 4;
+\endif
 --
 -- Cleanup
 --
@@ -1066,6 +1118,7 @@ DROP MATERIALIZED VIEW IF EXISTS :CAGG_NAME_1ST_LEVEL;
 -- LICENSE-TIMESCALE for a copy of the license.
 \set CAGG_NAME_1ST_LEVEL conditions_summary_1
 \set CAGG_NAME_2TH_LEVEL conditions_summary_2
+\set CAGG_NAME_3TH_LEVEL conditions_summary_3
 --
 -- CAGG on hypertable (1st level)
 --
@@ -1118,16 +1171,40 @@ SELECT
 FROM :CAGG_NAME_1ST_LEVEL
 GROUP BY 1
 WITH NO DATA;
-psql:include/cagg_on_cagg_validations.sql:43: ERROR:  cannot create continuous aggregate with incompatible bucket width
+psql:include/cagg_on_cagg_validations.sql:44: ERROR:  cannot create continuous aggregate with incompatible bucket width
 DETAIL:  Time bucket width of "public.conditions_summary_2" [2] should be greater or equal than the time bucket width of "public.conditions_summary_1" [4].
 \d+ :CAGG_NAME_2TH_LEVEL
 \set ON_ERROR_STOP 1
 \set VERBOSITY terse
+-- Check for incorrect CAGGs
+\if :INTERVAL_TEST
+  INSERT INTO conditions ("time", temperature, device_id) VALUES ('2022-01-01 00:00:00-00', 10, 4);
+  INSERT INTO conditions ("time", temperature, device_id) VALUES ('2022-01-15 01:00:00-00', 20, 4);
+  INSERT INTO conditions ("time", temperature, device_id) VALUES ('2022-01-31 01:00:00-00', 30, 4);
+  CALL refresh_continuous_aggregate(:'CAGG_NAME_1ST_LEVEL', NULL, NULL);
+  CALL refresh_continuous_aggregate(:'CAGG_NAME_2TH_LEVEL', NULL, NULL);
+  CREATE MATERIALIZED VIEW :CAGG_NAME_3TH_LEVEL
+  WITH (timescaledb.continuous) AS
+  SELECT
+    \if :IS_TIME_DIMENSION_WITH_TIMEZONE_2TH
+      time_bucket(:BUCKET_WIDTH_3TH, "bucket", :'BUCKET_TZNAME_2TH') AS bucket
+    \else
+      time_bucket(:BUCKET_WIDTH_3TH, "bucket") AS bucket
+    \endif
+  FROM :CAGG_NAME_2TH_LEVEL
+  GROUP BY 1
+  WITH DATA;
+  \d+ :CAGG_NAME_3TH_LEVEL
+  --There should never be dulpicates in the output of the following query
+  SELECT * from :CAGG_NAME_3TH_LEVEL;
+  DROP MATERIALIZED VIEW IF EXISTS :CAGG_NAME_3TH_LEVEL;
+  DELETE FROM conditions WHERE device_id = 4;
+\endif
 --
 -- Cleanup
 --
 DROP MATERIALIZED VIEW IF EXISTS :CAGG_NAME_2TH_LEVEL;
-psql:include/cagg_on_cagg_validations.sql:53: NOTICE:  materialized view "conditions_summary_2" does not exist, skipping
+psql:include/cagg_on_cagg_validations.sql:86: NOTICE:  materialized view "conditions_summary_2" does not exist, skipping
 DROP MATERIALIZED VIEW IF EXISTS :CAGG_NAME_1ST_LEVEL;
 -- cleanup
 DROP TABLE conditions;
@@ -1986,6 +2063,7 @@ psql:include/cagg_on_cagg_common.sql:200: ERROR:  relation "conditions_summary_1
 -- LICENSE-TIMESCALE for a copy of the license.
 \set CAGG_NAME_1ST_LEVEL conditions_summary_1
 \set CAGG_NAME_2TH_LEVEL conditions_summary_2
+\set CAGG_NAME_3TH_LEVEL conditions_summary_3
 --
 -- CAGG on hypertable (1st level)
 --
@@ -2038,17 +2116,41 @@ SELECT
 FROM :CAGG_NAME_1ST_LEVEL
 GROUP BY 1
 WITH NO DATA;
-psql:include/cagg_on_cagg_validations.sql:43: ERROR:  cannot create continuous aggregate with fixed-width bucket on top of one using variable-width bucket
+psql:include/cagg_on_cagg_validations.sql:44: ERROR:  cannot create continuous aggregate with fixed-width bucket on top of one using variable-width bucket
 DETAIL:  Continuous aggregate with a fixed time bucket width (e.g. 61 days) cannot be created on top of one using variable time bucket width (e.g. 1 month).
 The variance can lead to the fixed width one not being a multiple of the variable width one.
 \d+ :CAGG_NAME_2TH_LEVEL
 \set ON_ERROR_STOP 1
 \set VERBOSITY terse
+-- Check for incorrect CAGGs
+\if :INTERVAL_TEST
+  INSERT INTO conditions ("time", temperature, device_id) VALUES ('2022-01-01 00:00:00-00', 10, 4);
+  INSERT INTO conditions ("time", temperature, device_id) VALUES ('2022-01-15 01:00:00-00', 20, 4);
+  INSERT INTO conditions ("time", temperature, device_id) VALUES ('2022-01-31 01:00:00-00', 30, 4);
+  CALL refresh_continuous_aggregate(:'CAGG_NAME_1ST_LEVEL', NULL, NULL);
+  CALL refresh_continuous_aggregate(:'CAGG_NAME_2TH_LEVEL', NULL, NULL);
+  CREATE MATERIALIZED VIEW :CAGG_NAME_3TH_LEVEL
+  WITH (timescaledb.continuous) AS
+  SELECT
+    \if :IS_TIME_DIMENSION_WITH_TIMEZONE_2TH
+      time_bucket(:BUCKET_WIDTH_3TH, "bucket", :'BUCKET_TZNAME_2TH') AS bucket
+    \else
+      time_bucket(:BUCKET_WIDTH_3TH, "bucket") AS bucket
+    \endif
+  FROM :CAGG_NAME_2TH_LEVEL
+  GROUP BY 1
+  WITH DATA;
+  \d+ :CAGG_NAME_3TH_LEVEL
+  --There should never be dulpicates in the output of the following query
+  SELECT * from :CAGG_NAME_3TH_LEVEL;
+  DROP MATERIALIZED VIEW IF EXISTS :CAGG_NAME_3TH_LEVEL;
+  DELETE FROM conditions WHERE device_id = 4;
+\endif
 --
 -- Cleanup
 --
 DROP MATERIALIZED VIEW IF EXISTS :CAGG_NAME_2TH_LEVEL;
-psql:include/cagg_on_cagg_validations.sql:53: NOTICE:  materialized view "conditions_summary_2" does not exist, skipping
+psql:include/cagg_on_cagg_validations.sql:86: NOTICE:  materialized view "conditions_summary_2" does not exist, skipping
 DROP MATERIALIZED VIEW IF EXISTS :CAGG_NAME_1ST_LEVEL;
 --
 -- Validation test for non-multiple bucket sizes
@@ -2062,6 +2164,7 @@ DROP MATERIALIZED VIEW IF EXISTS :CAGG_NAME_1ST_LEVEL;
 -- LICENSE-TIMESCALE for a copy of the license.
 \set CAGG_NAME_1ST_LEVEL conditions_summary_1
 \set CAGG_NAME_2TH_LEVEL conditions_summary_2
+\set CAGG_NAME_3TH_LEVEL conditions_summary_3
 --
 -- CAGG on hypertable (1st level)
 --
@@ -2114,16 +2217,40 @@ SELECT
 FROM :CAGG_NAME_1ST_LEVEL
 GROUP BY 1
 WITH NO DATA;
-psql:include/cagg_on_cagg_validations.sql:43: ERROR:  cannot create continuous aggregate with incompatible bucket width
+psql:include/cagg_on_cagg_validations.sql:44: ERROR:  cannot create continuous aggregate with incompatible bucket width
 DETAIL:  Time bucket width of "public.conditions_summary_2" [@ 3 hours] should be multiple of the time bucket width of "public.conditions_summary_1" [@ 2 hours].
 \d+ :CAGG_NAME_2TH_LEVEL
 \set ON_ERROR_STOP 1
 \set VERBOSITY terse
+-- Check for incorrect CAGGs
+\if :INTERVAL_TEST
+  INSERT INTO conditions ("time", temperature, device_id) VALUES ('2022-01-01 00:00:00-00', 10, 4);
+  INSERT INTO conditions ("time", temperature, device_id) VALUES ('2022-01-15 01:00:00-00', 20, 4);
+  INSERT INTO conditions ("time", temperature, device_id) VALUES ('2022-01-31 01:00:00-00', 30, 4);
+  CALL refresh_continuous_aggregate(:'CAGG_NAME_1ST_LEVEL', NULL, NULL);
+  CALL refresh_continuous_aggregate(:'CAGG_NAME_2TH_LEVEL', NULL, NULL);
+  CREATE MATERIALIZED VIEW :CAGG_NAME_3TH_LEVEL
+  WITH (timescaledb.continuous) AS
+  SELECT
+    \if :IS_TIME_DIMENSION_WITH_TIMEZONE_2TH
+      time_bucket(:BUCKET_WIDTH_3TH, "bucket", :'BUCKET_TZNAME_2TH') AS bucket
+    \else
+      time_bucket(:BUCKET_WIDTH_3TH, "bucket") AS bucket
+    \endif
+  FROM :CAGG_NAME_2TH_LEVEL
+  GROUP BY 1
+  WITH DATA;
+  \d+ :CAGG_NAME_3TH_LEVEL
+  --There should never be dulpicates in the output of the following query
+  SELECT * from :CAGG_NAME_3TH_LEVEL;
+  DROP MATERIALIZED VIEW IF EXISTS :CAGG_NAME_3TH_LEVEL;
+  DELETE FROM conditions WHERE device_id = 4;
+\endif
 --
 -- Cleanup
 --
 DROP MATERIALIZED VIEW IF EXISTS :CAGG_NAME_2TH_LEVEL;
-psql:include/cagg_on_cagg_validations.sql:53: NOTICE:  materialized view "conditions_summary_2" does not exist, skipping
+psql:include/cagg_on_cagg_validations.sql:86: NOTICE:  materialized view "conditions_summary_2" does not exist, skipping
 DROP MATERIALIZED VIEW IF EXISTS :CAGG_NAME_1ST_LEVEL;
 --
 -- Validation test for equal bucket sizes
@@ -2137,6 +2264,7 @@ DROP MATERIALIZED VIEW IF EXISTS :CAGG_NAME_1ST_LEVEL;
 -- LICENSE-TIMESCALE for a copy of the license.
 \set CAGG_NAME_1ST_LEVEL conditions_summary_1
 \set CAGG_NAME_2TH_LEVEL conditions_summary_2
+\set CAGG_NAME_3TH_LEVEL conditions_summary_3
 --
 -- CAGG on hypertable (1st level)
 --
@@ -2209,6 +2337,30 @@ UNION ALL
 
 \set ON_ERROR_STOP 1
 \set VERBOSITY terse
+-- Check for incorrect CAGGs
+\if :INTERVAL_TEST
+  INSERT INTO conditions ("time", temperature, device_id) VALUES ('2022-01-01 00:00:00-00', 10, 4);
+  INSERT INTO conditions ("time", temperature, device_id) VALUES ('2022-01-15 01:00:00-00', 20, 4);
+  INSERT INTO conditions ("time", temperature, device_id) VALUES ('2022-01-31 01:00:00-00', 30, 4);
+  CALL refresh_continuous_aggregate(:'CAGG_NAME_1ST_LEVEL', NULL, NULL);
+  CALL refresh_continuous_aggregate(:'CAGG_NAME_2TH_LEVEL', NULL, NULL);
+  CREATE MATERIALIZED VIEW :CAGG_NAME_3TH_LEVEL
+  WITH (timescaledb.continuous) AS
+  SELECT
+    \if :IS_TIME_DIMENSION_WITH_TIMEZONE_2TH
+      time_bucket(:BUCKET_WIDTH_3TH, "bucket", :'BUCKET_TZNAME_2TH') AS bucket
+    \else
+      time_bucket(:BUCKET_WIDTH_3TH, "bucket") AS bucket
+    \endif
+  FROM :CAGG_NAME_2TH_LEVEL
+  GROUP BY 1
+  WITH DATA;
+  \d+ :CAGG_NAME_3TH_LEVEL
+  --There should never be dulpicates in the output of the following query
+  SELECT * from :CAGG_NAME_3TH_LEVEL;
+  DROP MATERIALIZED VIEW IF EXISTS :CAGG_NAME_3TH_LEVEL;
+  DELETE FROM conditions WHERE device_id = 4;
+\endif
 --
 -- Cleanup
 --
@@ -2226,6 +2378,7 @@ DROP MATERIALIZED VIEW IF EXISTS :CAGG_NAME_1ST_LEVEL;
 -- LICENSE-TIMESCALE for a copy of the license.
 \set CAGG_NAME_1ST_LEVEL conditions_summary_1
 \set CAGG_NAME_2TH_LEVEL conditions_summary_2
+\set CAGG_NAME_3TH_LEVEL conditions_summary_3
 --
 -- CAGG on hypertable (1st level)
 --
@@ -2278,16 +2431,40 @@ SELECT
 FROM :CAGG_NAME_1ST_LEVEL
 GROUP BY 1
 WITH NO DATA;
-psql:include/cagg_on_cagg_validations.sql:43: ERROR:  cannot create continuous aggregate with incompatible bucket width
+psql:include/cagg_on_cagg_validations.sql:44: ERROR:  cannot create continuous aggregate with incompatible bucket width
 DETAIL:  Time bucket width of "public.conditions_summary_2" [@ 1 hour] should be greater or equal than the time bucket width of "public.conditions_summary_1" [@ 2 hours].
 \d+ :CAGG_NAME_2TH_LEVEL
 \set ON_ERROR_STOP 1
 \set VERBOSITY terse
+-- Check for incorrect CAGGs
+\if :INTERVAL_TEST
+  INSERT INTO conditions ("time", temperature, device_id) VALUES ('2022-01-01 00:00:00-00', 10, 4);
+  INSERT INTO conditions ("time", temperature, device_id) VALUES ('2022-01-15 01:00:00-00', 20, 4);
+  INSERT INTO conditions ("time", temperature, device_id) VALUES ('2022-01-31 01:00:00-00', 30, 4);
+  CALL refresh_continuous_aggregate(:'CAGG_NAME_1ST_LEVEL', NULL, NULL);
+  CALL refresh_continuous_aggregate(:'CAGG_NAME_2TH_LEVEL', NULL, NULL);
+  CREATE MATERIALIZED VIEW :CAGG_NAME_3TH_LEVEL
+  WITH (timescaledb.continuous) AS
+  SELECT
+    \if :IS_TIME_DIMENSION_WITH_TIMEZONE_2TH
+      time_bucket(:BUCKET_WIDTH_3TH, "bucket", :'BUCKET_TZNAME_2TH') AS bucket
+    \else
+      time_bucket(:BUCKET_WIDTH_3TH, "bucket") AS bucket
+    \endif
+  FROM :CAGG_NAME_2TH_LEVEL
+  GROUP BY 1
+  WITH DATA;
+  \d+ :CAGG_NAME_3TH_LEVEL
+  --There should never be dulpicates in the output of the following query
+  SELECT * from :CAGG_NAME_3TH_LEVEL;
+  DROP MATERIALIZED VIEW IF EXISTS :CAGG_NAME_3TH_LEVEL;
+  DELETE FROM conditions WHERE device_id = 4;
+\endif
 --
 -- Cleanup
 --
 DROP MATERIALIZED VIEW IF EXISTS :CAGG_NAME_2TH_LEVEL;
-psql:include/cagg_on_cagg_validations.sql:53: NOTICE:  materialized view "conditions_summary_2" does not exist, skipping
+psql:include/cagg_on_cagg_validations.sql:86: NOTICE:  materialized view "conditions_summary_2" does not exist, skipping
 DROP MATERIALIZED VIEW IF EXISTS :CAGG_NAME_1ST_LEVEL;
 -- ########################################################
 -- ## TIMESTAMPTZ data type tests
@@ -3141,6 +3318,7 @@ psql:include/cagg_on_cagg_common.sql:200: ERROR:  relation "conditions_summary_1
 -- LICENSE-TIMESCALE for a copy of the license.
 \set CAGG_NAME_1ST_LEVEL conditions_summary_1
 \set CAGG_NAME_2TH_LEVEL conditions_summary_2
+\set CAGG_NAME_3TH_LEVEL conditions_summary_3
 --
 -- CAGG on hypertable (1st level)
 --
@@ -3193,17 +3371,41 @@ SELECT
 FROM :CAGG_NAME_1ST_LEVEL
 GROUP BY 1
 WITH NO DATA;
-psql:include/cagg_on_cagg_validations.sql:43: ERROR:  cannot create continuous aggregate with fixed-width bucket on top of one using variable-width bucket
+psql:include/cagg_on_cagg_validations.sql:44: ERROR:  cannot create continuous aggregate with fixed-width bucket on top of one using variable-width bucket
 DETAIL:  Continuous aggregate with a fixed time bucket width (e.g. 61 days) cannot be created on top of one using variable time bucket width (e.g. 1 month).
 The variance can lead to the fixed width one not being a multiple of the variable width one.
 \d+ :CAGG_NAME_2TH_LEVEL
 \set ON_ERROR_STOP 1
 \set VERBOSITY terse
+-- Check for incorrect CAGGs
+\if :INTERVAL_TEST
+  INSERT INTO conditions ("time", temperature, device_id) VALUES ('2022-01-01 00:00:00-00', 10, 4);
+  INSERT INTO conditions ("time", temperature, device_id) VALUES ('2022-01-15 01:00:00-00', 20, 4);
+  INSERT INTO conditions ("time", temperature, device_id) VALUES ('2022-01-31 01:00:00-00', 30, 4);
+  CALL refresh_continuous_aggregate(:'CAGG_NAME_1ST_LEVEL', NULL, NULL);
+  CALL refresh_continuous_aggregate(:'CAGG_NAME_2TH_LEVEL', NULL, NULL);
+  CREATE MATERIALIZED VIEW :CAGG_NAME_3TH_LEVEL
+  WITH (timescaledb.continuous) AS
+  SELECT
+    \if :IS_TIME_DIMENSION_WITH_TIMEZONE_2TH
+      time_bucket(:BUCKET_WIDTH_3TH, "bucket", :'BUCKET_TZNAME_2TH') AS bucket
+    \else
+      time_bucket(:BUCKET_WIDTH_3TH, "bucket") AS bucket
+    \endif
+  FROM :CAGG_NAME_2TH_LEVEL
+  GROUP BY 1
+  WITH DATA;
+  \d+ :CAGG_NAME_3TH_LEVEL
+  --There should never be dulpicates in the output of the following query
+  SELECT * from :CAGG_NAME_3TH_LEVEL;
+  DROP MATERIALIZED VIEW IF EXISTS :CAGG_NAME_3TH_LEVEL;
+  DELETE FROM conditions WHERE device_id = 4;
+\endif
 --
 -- Cleanup
 --
 DROP MATERIALIZED VIEW IF EXISTS :CAGG_NAME_2TH_LEVEL;
-psql:include/cagg_on_cagg_validations.sql:53: NOTICE:  materialized view "conditions_summary_2" does not exist, skipping
+psql:include/cagg_on_cagg_validations.sql:86: NOTICE:  materialized view "conditions_summary_2" does not exist, skipping
 DROP MATERIALIZED VIEW IF EXISTS :CAGG_NAME_1ST_LEVEL;
 --
 -- Validation test for non-multiple bucket sizes
@@ -3217,6 +3419,7 @@ DROP MATERIALIZED VIEW IF EXISTS :CAGG_NAME_1ST_LEVEL;
 -- LICENSE-TIMESCALE for a copy of the license.
 \set CAGG_NAME_1ST_LEVEL conditions_summary_1
 \set CAGG_NAME_2TH_LEVEL conditions_summary_2
+\set CAGG_NAME_3TH_LEVEL conditions_summary_3
 --
 -- CAGG on hypertable (1st level)
 --
@@ -3269,16 +3472,40 @@ SELECT
 FROM :CAGG_NAME_1ST_LEVEL
 GROUP BY 1
 WITH NO DATA;
-psql:include/cagg_on_cagg_validations.sql:43: ERROR:  cannot create continuous aggregate with incompatible bucket width
+psql:include/cagg_on_cagg_validations.sql:44: ERROR:  cannot create continuous aggregate with incompatible bucket width
 DETAIL:  Time bucket width of "public.conditions_summary_2" [@ 3 hours] should be multiple of the time bucket width of "public.conditions_summary_1" [@ 2 hours].
 \d+ :CAGG_NAME_2TH_LEVEL
 \set ON_ERROR_STOP 1
 \set VERBOSITY terse
+-- Check for incorrect CAGGs
+\if :INTERVAL_TEST
+  INSERT INTO conditions ("time", temperature, device_id) VALUES ('2022-01-01 00:00:00-00', 10, 4);
+  INSERT INTO conditions ("time", temperature, device_id) VALUES ('2022-01-15 01:00:00-00', 20, 4);
+  INSERT INTO conditions ("time", temperature, device_id) VALUES ('2022-01-31 01:00:00-00', 30, 4);
+  CALL refresh_continuous_aggregate(:'CAGG_NAME_1ST_LEVEL', NULL, NULL);
+  CALL refresh_continuous_aggregate(:'CAGG_NAME_2TH_LEVEL', NULL, NULL);
+  CREATE MATERIALIZED VIEW :CAGG_NAME_3TH_LEVEL
+  WITH (timescaledb.continuous) AS
+  SELECT
+    \if :IS_TIME_DIMENSION_WITH_TIMEZONE_2TH
+      time_bucket(:BUCKET_WIDTH_3TH, "bucket", :'BUCKET_TZNAME_2TH') AS bucket
+    \else
+      time_bucket(:BUCKET_WIDTH_3TH, "bucket") AS bucket
+    \endif
+  FROM :CAGG_NAME_2TH_LEVEL
+  GROUP BY 1
+  WITH DATA;
+  \d+ :CAGG_NAME_3TH_LEVEL
+  --There should never be dulpicates in the output of the following query
+  SELECT * from :CAGG_NAME_3TH_LEVEL;
+  DROP MATERIALIZED VIEW IF EXISTS :CAGG_NAME_3TH_LEVEL;
+  DELETE FROM conditions WHERE device_id = 4;
+\endif
 --
 -- Cleanup
 --
 DROP MATERIALIZED VIEW IF EXISTS :CAGG_NAME_2TH_LEVEL;
-psql:include/cagg_on_cagg_validations.sql:53: NOTICE:  materialized view "conditions_summary_2" does not exist, skipping
+psql:include/cagg_on_cagg_validations.sql:86: NOTICE:  materialized view "conditions_summary_2" does not exist, skipping
 DROP MATERIALIZED VIEW IF EXISTS :CAGG_NAME_1ST_LEVEL;
 --
 -- Validation test for equal bucket sizes
@@ -3292,6 +3519,7 @@ DROP MATERIALIZED VIEW IF EXISTS :CAGG_NAME_1ST_LEVEL;
 -- LICENSE-TIMESCALE for a copy of the license.
 \set CAGG_NAME_1ST_LEVEL conditions_summary_1
 \set CAGG_NAME_2TH_LEVEL conditions_summary_2
+\set CAGG_NAME_3TH_LEVEL conditions_summary_3
 --
 -- CAGG on hypertable (1st level)
 --
@@ -3364,6 +3592,30 @@ UNION ALL
 
 \set ON_ERROR_STOP 1
 \set VERBOSITY terse
+-- Check for incorrect CAGGs
+\if :INTERVAL_TEST
+  INSERT INTO conditions ("time", temperature, device_id) VALUES ('2022-01-01 00:00:00-00', 10, 4);
+  INSERT INTO conditions ("time", temperature, device_id) VALUES ('2022-01-15 01:00:00-00', 20, 4);
+  INSERT INTO conditions ("time", temperature, device_id) VALUES ('2022-01-31 01:00:00-00', 30, 4);
+  CALL refresh_continuous_aggregate(:'CAGG_NAME_1ST_LEVEL', NULL, NULL);
+  CALL refresh_continuous_aggregate(:'CAGG_NAME_2TH_LEVEL', NULL, NULL);
+  CREATE MATERIALIZED VIEW :CAGG_NAME_3TH_LEVEL
+  WITH (timescaledb.continuous) AS
+  SELECT
+    \if :IS_TIME_DIMENSION_WITH_TIMEZONE_2TH
+      time_bucket(:BUCKET_WIDTH_3TH, "bucket", :'BUCKET_TZNAME_2TH') AS bucket
+    \else
+      time_bucket(:BUCKET_WIDTH_3TH, "bucket") AS bucket
+    \endif
+  FROM :CAGG_NAME_2TH_LEVEL
+  GROUP BY 1
+  WITH DATA;
+  \d+ :CAGG_NAME_3TH_LEVEL
+  --There should never be dulpicates in the output of the following query
+  SELECT * from :CAGG_NAME_3TH_LEVEL;
+  DROP MATERIALIZED VIEW IF EXISTS :CAGG_NAME_3TH_LEVEL;
+  DELETE FROM conditions WHERE device_id = 4;
+\endif
 --
 -- Cleanup
 --
@@ -3381,6 +3633,7 @@ DROP MATERIALIZED VIEW IF EXISTS :CAGG_NAME_1ST_LEVEL;
 -- LICENSE-TIMESCALE for a copy of the license.
 \set CAGG_NAME_1ST_LEVEL conditions_summary_1
 \set CAGG_NAME_2TH_LEVEL conditions_summary_2
+\set CAGG_NAME_3TH_LEVEL conditions_summary_3
 --
 -- CAGG on hypertable (1st level)
 --
@@ -3433,16 +3686,40 @@ SELECT
 FROM :CAGG_NAME_1ST_LEVEL
 GROUP BY 1
 WITH NO DATA;
-psql:include/cagg_on_cagg_validations.sql:43: ERROR:  cannot create continuous aggregate with incompatible bucket width
+psql:include/cagg_on_cagg_validations.sql:44: ERROR:  cannot create continuous aggregate with incompatible bucket width
 DETAIL:  Time bucket width of "public.conditions_summary_2" [@ 1 hour] should be greater or equal than the time bucket width of "public.conditions_summary_1" [@ 2 hours].
 \d+ :CAGG_NAME_2TH_LEVEL
 \set ON_ERROR_STOP 1
 \set VERBOSITY terse
+-- Check for incorrect CAGGs
+\if :INTERVAL_TEST
+  INSERT INTO conditions ("time", temperature, device_id) VALUES ('2022-01-01 00:00:00-00', 10, 4);
+  INSERT INTO conditions ("time", temperature, device_id) VALUES ('2022-01-15 01:00:00-00', 20, 4);
+  INSERT INTO conditions ("time", temperature, device_id) VALUES ('2022-01-31 01:00:00-00', 30, 4);
+  CALL refresh_continuous_aggregate(:'CAGG_NAME_1ST_LEVEL', NULL, NULL);
+  CALL refresh_continuous_aggregate(:'CAGG_NAME_2TH_LEVEL', NULL, NULL);
+  CREATE MATERIALIZED VIEW :CAGG_NAME_3TH_LEVEL
+  WITH (timescaledb.continuous) AS
+  SELECT
+    \if :IS_TIME_DIMENSION_WITH_TIMEZONE_2TH
+      time_bucket(:BUCKET_WIDTH_3TH, "bucket", :'BUCKET_TZNAME_2TH') AS bucket
+    \else
+      time_bucket(:BUCKET_WIDTH_3TH, "bucket") AS bucket
+    \endif
+  FROM :CAGG_NAME_2TH_LEVEL
+  GROUP BY 1
+  WITH DATA;
+  \d+ :CAGG_NAME_3TH_LEVEL
+  --There should never be dulpicates in the output of the following query
+  SELECT * from :CAGG_NAME_3TH_LEVEL;
+  DROP MATERIALIZED VIEW IF EXISTS :CAGG_NAME_3TH_LEVEL;
+  DELETE FROM conditions WHERE device_id = 4;
+\endif
 --
 -- Cleanup
 --
 DROP MATERIALIZED VIEW IF EXISTS :CAGG_NAME_2TH_LEVEL;
-psql:include/cagg_on_cagg_validations.sql:53: NOTICE:  materialized view "conditions_summary_2" does not exist, skipping
+psql:include/cagg_on_cagg_validations.sql:86: NOTICE:  materialized view "conditions_summary_2" does not exist, skipping
 DROP MATERIALIZED VIEW IF EXISTS :CAGG_NAME_1ST_LEVEL;
 --
 -- Validations using time bucket with timezone (ref issue #5126)
@@ -3463,6 +3740,7 @@ DROP MATERIALIZED VIEW IF EXISTS :CAGG_NAME_1ST_LEVEL;
 -- LICENSE-TIMESCALE for a copy of the license.
 \set CAGG_NAME_1ST_LEVEL conditions_summary_1
 \set CAGG_NAME_2TH_LEVEL conditions_summary_2
+\set CAGG_NAME_3TH_LEVEL conditions_summary_3
 --
 -- CAGG on hypertable (1st level)
 --
@@ -3535,6 +3813,30 @@ UNION ALL
 
 \set ON_ERROR_STOP 1
 \set VERBOSITY terse
+-- Check for incorrect CAGGs
+\if :INTERVAL_TEST
+  INSERT INTO conditions ("time", temperature, device_id) VALUES ('2022-01-01 00:00:00-00', 10, 4);
+  INSERT INTO conditions ("time", temperature, device_id) VALUES ('2022-01-15 01:00:00-00', 20, 4);
+  INSERT INTO conditions ("time", temperature, device_id) VALUES ('2022-01-31 01:00:00-00', 30, 4);
+  CALL refresh_continuous_aggregate(:'CAGG_NAME_1ST_LEVEL', NULL, NULL);
+  CALL refresh_continuous_aggregate(:'CAGG_NAME_2TH_LEVEL', NULL, NULL);
+  CREATE MATERIALIZED VIEW :CAGG_NAME_3TH_LEVEL
+  WITH (timescaledb.continuous) AS
+  SELECT
+    \if :IS_TIME_DIMENSION_WITH_TIMEZONE_2TH
+      time_bucket(:BUCKET_WIDTH_3TH, "bucket", :'BUCKET_TZNAME_2TH') AS bucket
+    \else
+      time_bucket(:BUCKET_WIDTH_3TH, "bucket") AS bucket
+    \endif
+  FROM :CAGG_NAME_2TH_LEVEL
+  GROUP BY 1
+  WITH DATA;
+  \d+ :CAGG_NAME_3TH_LEVEL
+  --There should never be dulpicates in the output of the following query
+  SELECT * from :CAGG_NAME_3TH_LEVEL;
+  DROP MATERIALIZED VIEW IF EXISTS :CAGG_NAME_3TH_LEVEL;
+  DELETE FROM conditions WHERE device_id = 4;
+\endif
 --
 -- Cleanup
 --
@@ -3549,6 +3851,7 @@ DROP MATERIALIZED VIEW IF EXISTS :CAGG_NAME_1ST_LEVEL;
 -- LICENSE-TIMESCALE for a copy of the license.
 \set CAGG_NAME_1ST_LEVEL conditions_summary_1
 \set CAGG_NAME_2TH_LEVEL conditions_summary_2
+\set CAGG_NAME_3TH_LEVEL conditions_summary_3
 --
 -- CAGG on hypertable (1st level)
 --
@@ -3601,16 +3904,40 @@ SELECT
 FROM :CAGG_NAME_1ST_LEVEL
 GROUP BY 1
 WITH NO DATA;
-psql:include/cagg_on_cagg_validations.sql:43: ERROR:  cannot create continuous aggregate with incompatible bucket width
+psql:include/cagg_on_cagg_validations.sql:44: ERROR:  cannot create continuous aggregate with incompatible bucket width
 DETAIL:  Time bucket width of "public.conditions_summary_2" [@ 16 mins] should be multiple of the time bucket width of "public.conditions_summary_1" [@ 5 mins].
 \d+ :CAGG_NAME_2TH_LEVEL
 \set ON_ERROR_STOP 1
 \set VERBOSITY terse
+-- Check for incorrect CAGGs
+\if :INTERVAL_TEST
+  INSERT INTO conditions ("time", temperature, device_id) VALUES ('2022-01-01 00:00:00-00', 10, 4);
+  INSERT INTO conditions ("time", temperature, device_id) VALUES ('2022-01-15 01:00:00-00', 20, 4);
+  INSERT INTO conditions ("time", temperature, device_id) VALUES ('2022-01-31 01:00:00-00', 30, 4);
+  CALL refresh_continuous_aggregate(:'CAGG_NAME_1ST_LEVEL', NULL, NULL);
+  CALL refresh_continuous_aggregate(:'CAGG_NAME_2TH_LEVEL', NULL, NULL);
+  CREATE MATERIALIZED VIEW :CAGG_NAME_3TH_LEVEL
+  WITH (timescaledb.continuous) AS
+  SELECT
+    \if :IS_TIME_DIMENSION_WITH_TIMEZONE_2TH
+      time_bucket(:BUCKET_WIDTH_3TH, "bucket", :'BUCKET_TZNAME_2TH') AS bucket
+    \else
+      time_bucket(:BUCKET_WIDTH_3TH, "bucket") AS bucket
+    \endif
+  FROM :CAGG_NAME_2TH_LEVEL
+  GROUP BY 1
+  WITH DATA;
+  \d+ :CAGG_NAME_3TH_LEVEL
+  --There should never be dulpicates in the output of the following query
+  SELECT * from :CAGG_NAME_3TH_LEVEL;
+  DROP MATERIALIZED VIEW IF EXISTS :CAGG_NAME_3TH_LEVEL;
+  DELETE FROM conditions WHERE device_id = 4;
+\endif
 --
 -- Cleanup
 --
 DROP MATERIALIZED VIEW IF EXISTS :CAGG_NAME_2TH_LEVEL;
-psql:include/cagg_on_cagg_validations.sql:53: NOTICE:  materialized view "conditions_summary_2" does not exist, skipping
+psql:include/cagg_on_cagg_validations.sql:86: NOTICE:  materialized view "conditions_summary_2" does not exist, skipping
 DROP MATERIALIZED VIEW IF EXISTS :CAGG_NAME_1ST_LEVEL;
 --
 -- Variable bucket size with the same timezones
@@ -3626,6 +3953,7 @@ DROP MATERIALIZED VIEW IF EXISTS :CAGG_NAME_1ST_LEVEL;
 -- LICENSE-TIMESCALE for a copy of the license.
 \set CAGG_NAME_1ST_LEVEL conditions_summary_1
 \set CAGG_NAME_2TH_LEVEL conditions_summary_2
+\set CAGG_NAME_3TH_LEVEL conditions_summary_3
 --
 -- CAGG on hypertable (1st level)
 --
@@ -3698,25 +4026,47 @@ UNION ALL
 
 \set ON_ERROR_STOP 1
 \set VERBOSITY terse
+-- Check for incorrect CAGGs
+\if :INTERVAL_TEST
+  INSERT INTO conditions ("time", temperature, device_id) VALUES ('2022-01-01 00:00:00-00', 10, 4);
+  INSERT INTO conditions ("time", temperature, device_id) VALUES ('2022-01-15 01:00:00-00', 20, 4);
+  INSERT INTO conditions ("time", temperature, device_id) VALUES ('2022-01-31 01:00:00-00', 30, 4);
+  CALL refresh_continuous_aggregate(:'CAGG_NAME_1ST_LEVEL', NULL, NULL);
+  CALL refresh_continuous_aggregate(:'CAGG_NAME_2TH_LEVEL', NULL, NULL);
+  CREATE MATERIALIZED VIEW :CAGG_NAME_3TH_LEVEL
+  WITH (timescaledb.continuous) AS
+  SELECT
+    \if :IS_TIME_DIMENSION_WITH_TIMEZONE_2TH
+      time_bucket(:BUCKET_WIDTH_3TH, "bucket", :'BUCKET_TZNAME_2TH') AS bucket
+    \else
+      time_bucket(:BUCKET_WIDTH_3TH, "bucket") AS bucket
+    \endif
+  FROM :CAGG_NAME_2TH_LEVEL
+  GROUP BY 1
+  WITH DATA;
+  \d+ :CAGG_NAME_3TH_LEVEL
+  --There should never be dulpicates in the output of the following query
+  SELECT * from :CAGG_NAME_3TH_LEVEL;
+  DROP MATERIALIZED VIEW IF EXISTS :CAGG_NAME_3TH_LEVEL;
+  DELETE FROM conditions WHERE device_id = 4;
+\endif
 --
 -- Cleanup
 --
 DROP MATERIALIZED VIEW IF EXISTS :CAGG_NAME_2TH_LEVEL;
 DROP MATERIALIZED VIEW IF EXISTS :CAGG_NAME_1ST_LEVEL;
---
--- Variable bucket size with different timezones
---
-\set BUCKET_TZNAME_1ST 'US/Pacific'
-\set BUCKET_TZNAME_2TH 'UTC'
-\set BUCKET_WIDTH_1ST 'INTERVAL \'1 day\''
-\set BUCKET_WIDTH_2TH 'INTERVAL \'1 month\''
-\set WARNING_MESSAGE '-- SHOULD WORK'
+--#Bugfix 5734 #1
+\set INTERVAL_TEST TRUE
+\set BUCKET_WIDTH_1ST 'INTERVAL \'1 hour\''
+\set BUCKET_WIDTH_2TH 'INTERVAL \'1 day\''
+\set BUCKET_WIDTH_3TH 'INTERVAL \'1 month\''
 \ir include/cagg_on_cagg_validations.sql
 -- This file and its contents are licensed under the Timescale License.
 -- Please see the included NOTICE for copyright information and
 -- LICENSE-TIMESCALE for a copy of the license.
 \set CAGG_NAME_1ST_LEVEL conditions_summary_1
 \set CAGG_NAME_2TH_LEVEL conditions_summary_2
+\set CAGG_NAME_3TH_LEVEL conditions_summary_3
 --
 -- CAGG on hypertable (1st level)
 --
@@ -3744,11 +4094,11 @@ View definition:
    FROM _timescaledb_internal._materialized_hypertable_44
   WHERE _materialized_hypertable_44.bucket < COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(44)), '-infinity'::timestamp with time zone)
 UNION ALL
- SELECT time_bucket('@ 1 day'::interval, conditions."time", 'US/Pacific'::text) AS bucket,
+ SELECT time_bucket('@ 1 hour'::interval, conditions."time", 'UTC'::text) AS bucket,
     sum(conditions.temperature) AS temperature
    FROM conditions
   WHERE conditions."time" >= COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(44)), '-infinity'::timestamp with time zone)
-  GROUP BY (time_bucket('@ 1 day'::interval, conditions."time", 'US/Pacific'::text));
+  GROUP BY (time_bucket('@ 1 hour'::interval, conditions."time", 'UTC'::text));
 
 --
 -- CAGG on CAGG (2th level)
@@ -3781,19 +4131,320 @@ View definition:
    FROM _timescaledb_internal._materialized_hypertable_45
   WHERE _materialized_hypertable_45.bucket < COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(45)), '-infinity'::timestamp with time zone)
 UNION ALL
- SELECT time_bucket('@ 1 mon'::interval, conditions_summary_1.bucket, 'UTC'::text) AS bucket,
+ SELECT time_bucket('@ 1 day'::interval, conditions_summary_1.bucket, 'UTC'::text) AS bucket,
     sum(conditions_summary_1.temperature) AS temperature
    FROM conditions_summary_1
   WHERE conditions_summary_1.bucket >= COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(45)), '-infinity'::timestamp with time zone)
+  GROUP BY (time_bucket('@ 1 day'::interval, conditions_summary_1.bucket, 'UTC'::text));
+
+\set ON_ERROR_STOP 1
+\set VERBOSITY terse
+-- Check for incorrect CAGGs
+\if :INTERVAL_TEST
+  INSERT INTO conditions ("time", temperature, device_id) VALUES ('2022-01-01 00:00:00-00', 10, 4);
+  INSERT INTO conditions ("time", temperature, device_id) VALUES ('2022-01-15 01:00:00-00', 20, 4);
+  INSERT INTO conditions ("time", temperature, device_id) VALUES ('2022-01-31 01:00:00-00', 30, 4);
+  CALL refresh_continuous_aggregate(:'CAGG_NAME_1ST_LEVEL', NULL, NULL);
+  CALL refresh_continuous_aggregate(:'CAGG_NAME_2TH_LEVEL', NULL, NULL);
+  CREATE MATERIALIZED VIEW :CAGG_NAME_3TH_LEVEL
+  WITH (timescaledb.continuous) AS
+  SELECT
+    \if :IS_TIME_DIMENSION_WITH_TIMEZONE_2TH
+      time_bucket(:BUCKET_WIDTH_3TH, "bucket", :'BUCKET_TZNAME_2TH') AS bucket
+    \else
+      time_bucket(:BUCKET_WIDTH_3TH, "bucket") AS bucket
+    \endif
+  FROM :CAGG_NAME_2TH_LEVEL
+  GROUP BY 1
+  WITH DATA;
+psql:include/cagg_on_cagg_validations.sql:71: NOTICE:  refreshing continuous aggregate "conditions_summary_3"
+  \d+ :CAGG_NAME_3TH_LEVEL
+                             View "public.conditions_summary_3"
+ Column |           Type           | Collation | Nullable | Default | Storage | Description 
+--------+--------------------------+-----------+----------+---------+---------+-------------
+ bucket | timestamp with time zone |           |          |         | plain   | 
+View definition:
+ SELECT _materialized_hypertable_46.bucket
+   FROM _timescaledb_internal._materialized_hypertable_46
+  WHERE _materialized_hypertable_46.bucket < COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(46)), '-infinity'::timestamp with time zone)
+UNION ALL
+ SELECT time_bucket('@ 1 mon'::interval, conditions_summary_2.bucket, 'UTC'::text) AS bucket
+   FROM conditions_summary_2
+  WHERE conditions_summary_2.bucket >= COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(46)), '-infinity'::timestamp with time zone)
+  GROUP BY (time_bucket('@ 1 mon'::interval, conditions_summary_2.bucket, 'UTC'::text));
+
+  --There should never be dulpicates in the output of the following query
+  SELECT * from :CAGG_NAME_3TH_LEVEL;
+            bucket            
+------------------------------
+ Sat Jan 01 00:00:00 2022 UTC
+(1 row)
+
+  DROP MATERIALIZED VIEW IF EXISTS :CAGG_NAME_3TH_LEVEL;
+psql:include/cagg_on_cagg_validations.sql:79: NOTICE:  drop cascades to table _timescaledb_internal._hyper_46_31_chunk
+  DELETE FROM conditions WHERE device_id = 4;
+\endif
+--
+-- Cleanup
+--
+DROP MATERIALIZED VIEW IF EXISTS :CAGG_NAME_2TH_LEVEL;
+psql:include/cagg_on_cagg_validations.sql:86: NOTICE:  drop cascades to table _timescaledb_internal._hyper_45_30_chunk
+DROP MATERIALIZED VIEW IF EXISTS :CAGG_NAME_1ST_LEVEL;
+psql:include/cagg_on_cagg_validations.sql:87: NOTICE:  drop cascades to table _timescaledb_internal._hyper_44_29_chunk
+\set INTERVAL_TEST FALSE
+--
+-- Variable bucket size with different timezones
+--
+\set BUCKET_TZNAME_1ST 'US/Pacific'
+\set BUCKET_TZNAME_2TH 'UTC'
+\set BUCKET_WIDTH_1ST 'INTERVAL \'1 day\''
+\set BUCKET_WIDTH_2TH 'INTERVAL \'1 month\''
+\set WARNING_MESSAGE '-- SHOULD WORK'
+\ir include/cagg_on_cagg_validations.sql
+-- This file and its contents are licensed under the Timescale License.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-TIMESCALE for a copy of the license.
+\set CAGG_NAME_1ST_LEVEL conditions_summary_1
+\set CAGG_NAME_2TH_LEVEL conditions_summary_2
+\set CAGG_NAME_3TH_LEVEL conditions_summary_3
+--
+-- CAGG on hypertable (1st level)
+--
+CREATE MATERIALIZED VIEW :CAGG_NAME_1ST_LEVEL
+WITH (timescaledb.continuous) AS
+SELECT
+  \if :IS_TIME_DIMENSION_WITH_TIMEZONE_1ST
+    time_bucket(:BUCKET_WIDTH_1ST, "time", :'BUCKET_TZNAME_1ST') AS bucket,
+  \else
+    time_bucket(:BUCKET_WIDTH_1ST, "time") AS bucket,
+  \endif
+  SUM(temperature) AS temperature
+FROM conditions
+GROUP BY 1
+WITH NO DATA;
+\d+ :CAGG_NAME_1ST_LEVEL
+                               View "public.conditions_summary_1"
+   Column    |           Type           | Collation | Nullable | Default | Storage | Description 
+-------------+--------------------------+-----------+----------+---------+---------+-------------
+ bucket      | timestamp with time zone |           |          |         | plain   | 
+ temperature | numeric                  |           |          |         | main    | 
+View definition:
+ SELECT _materialized_hypertable_47.bucket,
+    _materialized_hypertable_47.temperature
+   FROM _timescaledb_internal._materialized_hypertable_47
+  WHERE _materialized_hypertable_47.bucket < COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(47)), '-infinity'::timestamp with time zone)
+UNION ALL
+ SELECT time_bucket('@ 1 day'::interval, conditions."time", 'US/Pacific'::text) AS bucket,
+    sum(conditions.temperature) AS temperature
+   FROM conditions
+  WHERE conditions."time" >= COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(47)), '-infinity'::timestamp with time zone)
+  GROUP BY (time_bucket('@ 1 day'::interval, conditions."time", 'US/Pacific'::text));
+
+--
+-- CAGG on CAGG (2th level)
+--
+\set VERBOSITY default
+\set ON_ERROR_STOP 0
+\echo :WARNING_MESSAGE
+-- SHOULD WORK
+CREATE MATERIALIZED VIEW :CAGG_NAME_2TH_LEVEL
+WITH (timescaledb.continuous) AS
+SELECT
+  \if :IS_TIME_DIMENSION_WITH_TIMEZONE_2TH
+    time_bucket(:BUCKET_WIDTH_2TH, "bucket", :'BUCKET_TZNAME_2TH') AS bucket,
+  \else
+    time_bucket(:BUCKET_WIDTH_2TH, "bucket") AS bucket,
+  \endif
+  SUM(temperature) AS temperature
+FROM :CAGG_NAME_1ST_LEVEL
+GROUP BY 1
+WITH NO DATA;
+\d+ :CAGG_NAME_2TH_LEVEL
+                               View "public.conditions_summary_2"
+   Column    |           Type           | Collation | Nullable | Default | Storage | Description 
+-------------+--------------------------+-----------+----------+---------+---------+-------------
+ bucket      | timestamp with time zone |           |          |         | plain   | 
+ temperature | numeric                  |           |          |         | main    | 
+View definition:
+ SELECT _materialized_hypertable_48.bucket,
+    _materialized_hypertable_48.temperature
+   FROM _timescaledb_internal._materialized_hypertable_48
+  WHERE _materialized_hypertable_48.bucket < COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(48)), '-infinity'::timestamp with time zone)
+UNION ALL
+ SELECT time_bucket('@ 1 mon'::interval, conditions_summary_1.bucket, 'UTC'::text) AS bucket,
+    sum(conditions_summary_1.temperature) AS temperature
+   FROM conditions_summary_1
+  WHERE conditions_summary_1.bucket >= COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(48)), '-infinity'::timestamp with time zone)
   GROUP BY (time_bucket('@ 1 mon'::interval, conditions_summary_1.bucket, 'UTC'::text));
 
 \set ON_ERROR_STOP 1
 \set VERBOSITY terse
+-- Check for incorrect CAGGs
+\if :INTERVAL_TEST
+  INSERT INTO conditions ("time", temperature, device_id) VALUES ('2022-01-01 00:00:00-00', 10, 4);
+  INSERT INTO conditions ("time", temperature, device_id) VALUES ('2022-01-15 01:00:00-00', 20, 4);
+  INSERT INTO conditions ("time", temperature, device_id) VALUES ('2022-01-31 01:00:00-00', 30, 4);
+  CALL refresh_continuous_aggregate(:'CAGG_NAME_1ST_LEVEL', NULL, NULL);
+  CALL refresh_continuous_aggregate(:'CAGG_NAME_2TH_LEVEL', NULL, NULL);
+  CREATE MATERIALIZED VIEW :CAGG_NAME_3TH_LEVEL
+  WITH (timescaledb.continuous) AS
+  SELECT
+    \if :IS_TIME_DIMENSION_WITH_TIMEZONE_2TH
+      time_bucket(:BUCKET_WIDTH_3TH, "bucket", :'BUCKET_TZNAME_2TH') AS bucket
+    \else
+      time_bucket(:BUCKET_WIDTH_3TH, "bucket") AS bucket
+    \endif
+  FROM :CAGG_NAME_2TH_LEVEL
+  GROUP BY 1
+  WITH DATA;
+  \d+ :CAGG_NAME_3TH_LEVEL
+  --There should never be dulpicates in the output of the following query
+  SELECT * from :CAGG_NAME_3TH_LEVEL;
+  DROP MATERIALIZED VIEW IF EXISTS :CAGG_NAME_3TH_LEVEL;
+  DELETE FROM conditions WHERE device_id = 4;
+\endif
 --
 -- Cleanup
 --
 DROP MATERIALIZED VIEW IF EXISTS :CAGG_NAME_2TH_LEVEL;
 DROP MATERIALIZED VIEW IF EXISTS :CAGG_NAME_1ST_LEVEL;
+--#Bugfix 5734 #2
+\set INTERVAL_TEST TRUE
+\set BUCKET_WIDTH_1ST 'INTERVAL \'1 hour\''
+\set BUCKET_WIDTH_2TH 'INTERVAL \'1 day\''
+\set BUCKET_WIDTH_3TH 'INTERVAL \'1 month\''
+\ir include/cagg_on_cagg_validations.sql
+-- This file and its contents are licensed under the Timescale License.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-TIMESCALE for a copy of the license.
+\set CAGG_NAME_1ST_LEVEL conditions_summary_1
+\set CAGG_NAME_2TH_LEVEL conditions_summary_2
+\set CAGG_NAME_3TH_LEVEL conditions_summary_3
+--
+-- CAGG on hypertable (1st level)
+--
+CREATE MATERIALIZED VIEW :CAGG_NAME_1ST_LEVEL
+WITH (timescaledb.continuous) AS
+SELECT
+  \if :IS_TIME_DIMENSION_WITH_TIMEZONE_1ST
+    time_bucket(:BUCKET_WIDTH_1ST, "time", :'BUCKET_TZNAME_1ST') AS bucket,
+  \else
+    time_bucket(:BUCKET_WIDTH_1ST, "time") AS bucket,
+  \endif
+  SUM(temperature) AS temperature
+FROM conditions
+GROUP BY 1
+WITH NO DATA;
+\d+ :CAGG_NAME_1ST_LEVEL
+                               View "public.conditions_summary_1"
+   Column    |           Type           | Collation | Nullable | Default | Storage | Description 
+-------------+--------------------------+-----------+----------+---------+---------+-------------
+ bucket      | timestamp with time zone |           |          |         | plain   | 
+ temperature | numeric                  |           |          |         | main    | 
+View definition:
+ SELECT _materialized_hypertable_49.bucket,
+    _materialized_hypertable_49.temperature
+   FROM _timescaledb_internal._materialized_hypertable_49
+  WHERE _materialized_hypertable_49.bucket < COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(49)), '-infinity'::timestamp with time zone)
+UNION ALL
+ SELECT time_bucket('@ 1 hour'::interval, conditions."time", 'US/Pacific'::text) AS bucket,
+    sum(conditions.temperature) AS temperature
+   FROM conditions
+  WHERE conditions."time" >= COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(49)), '-infinity'::timestamp with time zone)
+  GROUP BY (time_bucket('@ 1 hour'::interval, conditions."time", 'US/Pacific'::text));
+
+--
+-- CAGG on CAGG (2th level)
+--
+\set VERBOSITY default
+\set ON_ERROR_STOP 0
+\echo :WARNING_MESSAGE
+-- SHOULD WORK
+CREATE MATERIALIZED VIEW :CAGG_NAME_2TH_LEVEL
+WITH (timescaledb.continuous) AS
+SELECT
+  \if :IS_TIME_DIMENSION_WITH_TIMEZONE_2TH
+    time_bucket(:BUCKET_WIDTH_2TH, "bucket", :'BUCKET_TZNAME_2TH') AS bucket,
+  \else
+    time_bucket(:BUCKET_WIDTH_2TH, "bucket") AS bucket,
+  \endif
+  SUM(temperature) AS temperature
+FROM :CAGG_NAME_1ST_LEVEL
+GROUP BY 1
+WITH NO DATA;
+\d+ :CAGG_NAME_2TH_LEVEL
+                               View "public.conditions_summary_2"
+   Column    |           Type           | Collation | Nullable | Default | Storage | Description 
+-------------+--------------------------+-----------+----------+---------+---------+-------------
+ bucket      | timestamp with time zone |           |          |         | plain   | 
+ temperature | numeric                  |           |          |         | main    | 
+View definition:
+ SELECT _materialized_hypertable_50.bucket,
+    _materialized_hypertable_50.temperature
+   FROM _timescaledb_internal._materialized_hypertable_50
+  WHERE _materialized_hypertable_50.bucket < COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(50)), '-infinity'::timestamp with time zone)
+UNION ALL
+ SELECT time_bucket('@ 1 day'::interval, conditions_summary_1.bucket, 'UTC'::text) AS bucket,
+    sum(conditions_summary_1.temperature) AS temperature
+   FROM conditions_summary_1
+  WHERE conditions_summary_1.bucket >= COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(50)), '-infinity'::timestamp with time zone)
+  GROUP BY (time_bucket('@ 1 day'::interval, conditions_summary_1.bucket, 'UTC'::text));
+
+\set ON_ERROR_STOP 1
+\set VERBOSITY terse
+-- Check for incorrect CAGGs
+\if :INTERVAL_TEST
+  INSERT INTO conditions ("time", temperature, device_id) VALUES ('2022-01-01 00:00:00-00', 10, 4);
+  INSERT INTO conditions ("time", temperature, device_id) VALUES ('2022-01-15 01:00:00-00', 20, 4);
+  INSERT INTO conditions ("time", temperature, device_id) VALUES ('2022-01-31 01:00:00-00', 30, 4);
+  CALL refresh_continuous_aggregate(:'CAGG_NAME_1ST_LEVEL', NULL, NULL);
+  CALL refresh_continuous_aggregate(:'CAGG_NAME_2TH_LEVEL', NULL, NULL);
+  CREATE MATERIALIZED VIEW :CAGG_NAME_3TH_LEVEL
+  WITH (timescaledb.continuous) AS
+  SELECT
+    \if :IS_TIME_DIMENSION_WITH_TIMEZONE_2TH
+      time_bucket(:BUCKET_WIDTH_3TH, "bucket", :'BUCKET_TZNAME_2TH') AS bucket
+    \else
+      time_bucket(:BUCKET_WIDTH_3TH, "bucket") AS bucket
+    \endif
+  FROM :CAGG_NAME_2TH_LEVEL
+  GROUP BY 1
+  WITH DATA;
+psql:include/cagg_on_cagg_validations.sql:71: NOTICE:  refreshing continuous aggregate "conditions_summary_3"
+  \d+ :CAGG_NAME_3TH_LEVEL
+                             View "public.conditions_summary_3"
+ Column |           Type           | Collation | Nullable | Default | Storage | Description 
+--------+--------------------------+-----------+----------+---------+---------+-------------
+ bucket | timestamp with time zone |           |          |         | plain   | 
+View definition:
+ SELECT _materialized_hypertable_51.bucket
+   FROM _timescaledb_internal._materialized_hypertable_51
+  WHERE _materialized_hypertable_51.bucket < COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(51)), '-infinity'::timestamp with time zone)
+UNION ALL
+ SELECT time_bucket('@ 1 mon'::interval, conditions_summary_2.bucket, 'UTC'::text) AS bucket
+   FROM conditions_summary_2
+  WHERE conditions_summary_2.bucket >= COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(51)), '-infinity'::timestamp with time zone)
+  GROUP BY (time_bucket('@ 1 mon'::interval, conditions_summary_2.bucket, 'UTC'::text));
+
+  --There should never be dulpicates in the output of the following query
+  SELECT * from :CAGG_NAME_3TH_LEVEL;
+            bucket            
+------------------------------
+ Sat Jan 01 00:00:00 2022 UTC
+(1 row)
+
+  DROP MATERIALIZED VIEW IF EXISTS :CAGG_NAME_3TH_LEVEL;
+psql:include/cagg_on_cagg_validations.sql:79: NOTICE:  drop cascades to table _timescaledb_internal._hyper_51_34_chunk
+  DELETE FROM conditions WHERE device_id = 4;
+\endif
+--
+-- Cleanup
+--
+DROP MATERIALIZED VIEW IF EXISTS :CAGG_NAME_2TH_LEVEL;
+psql:include/cagg_on_cagg_validations.sql:86: NOTICE:  drop cascades to table _timescaledb_internal._hyper_50_33_chunk
+DROP MATERIALIZED VIEW IF EXISTS :CAGG_NAME_1ST_LEVEL;
+psql:include/cagg_on_cagg_validations.sql:87: NOTICE:  drop cascades to table _timescaledb_internal._hyper_49_32_chunk
+\set INTERVAL_TEST FALSE
 --
 -- TZ bucket on top of non-TZ bucket
 --
@@ -3809,269 +4460,7 @@ DROP MATERIALIZED VIEW IF EXISTS :CAGG_NAME_1ST_LEVEL;
 -- LICENSE-TIMESCALE for a copy of the license.
 \set CAGG_NAME_1ST_LEVEL conditions_summary_1
 \set CAGG_NAME_2TH_LEVEL conditions_summary_2
---
--- CAGG on hypertable (1st level)
---
-CREATE MATERIALIZED VIEW :CAGG_NAME_1ST_LEVEL
-WITH (timescaledb.continuous) AS
-SELECT
-  \if :IS_TIME_DIMENSION_WITH_TIMEZONE_1ST
-    time_bucket(:BUCKET_WIDTH_1ST, "time", :'BUCKET_TZNAME_1ST') AS bucket,
-  \else
-    time_bucket(:BUCKET_WIDTH_1ST, "time") AS bucket,
-  \endif
-  SUM(temperature) AS temperature
-FROM conditions
-GROUP BY 1
-WITH NO DATA;
-\d+ :CAGG_NAME_1ST_LEVEL
-                               View "public.conditions_summary_1"
-   Column    |           Type           | Collation | Nullable | Default | Storage | Description 
--------------+--------------------------+-----------+----------+---------+---------+-------------
- bucket      | timestamp with time zone |           |          |         | plain   | 
- temperature | numeric                  |           |          |         | main    | 
-View definition:
- SELECT _materialized_hypertable_46.bucket,
-    _materialized_hypertable_46.temperature
-   FROM _timescaledb_internal._materialized_hypertable_46
-  WHERE _materialized_hypertable_46.bucket < COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(46)), '-infinity'::timestamp with time zone)
-UNION ALL
- SELECT time_bucket('@ 1 day'::interval, conditions."time") AS bucket,
-    sum(conditions.temperature) AS temperature
-   FROM conditions
-  WHERE conditions."time" >= COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(46)), '-infinity'::timestamp with time zone)
-  GROUP BY (time_bucket('@ 1 day'::interval, conditions."time"));
-
---
--- CAGG on CAGG (2th level)
---
-\set VERBOSITY default
-\set ON_ERROR_STOP 0
-\echo :WARNING_MESSAGE
--- SHOULD WORK
-CREATE MATERIALIZED VIEW :CAGG_NAME_2TH_LEVEL
-WITH (timescaledb.continuous) AS
-SELECT
-  \if :IS_TIME_DIMENSION_WITH_TIMEZONE_2TH
-    time_bucket(:BUCKET_WIDTH_2TH, "bucket", :'BUCKET_TZNAME_2TH') AS bucket,
-  \else
-    time_bucket(:BUCKET_WIDTH_2TH, "bucket") AS bucket,
-  \endif
-  SUM(temperature) AS temperature
-FROM :CAGG_NAME_1ST_LEVEL
-GROUP BY 1
-WITH NO DATA;
-\d+ :CAGG_NAME_2TH_LEVEL
-                               View "public.conditions_summary_2"
-   Column    |           Type           | Collation | Nullable | Default | Storage | Description 
--------------+--------------------------+-----------+----------+---------+---------+-------------
- bucket      | timestamp with time zone |           |          |         | plain   | 
- temperature | numeric                  |           |          |         | main    | 
-View definition:
- SELECT _materialized_hypertable_47.bucket,
-    _materialized_hypertable_47.temperature
-   FROM _timescaledb_internal._materialized_hypertable_47
-  WHERE _materialized_hypertable_47.bucket < COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(47)), '-infinity'::timestamp with time zone)
-UNION ALL
- SELECT time_bucket('@ 1 mon'::interval, conditions_summary_1.bucket, 'UTC'::text) AS bucket,
-    sum(conditions_summary_1.temperature) AS temperature
-   FROM conditions_summary_1
-  WHERE conditions_summary_1.bucket >= COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(47)), '-infinity'::timestamp with time zone)
-  GROUP BY (time_bucket('@ 1 mon'::interval, conditions_summary_1.bucket, 'UTC'::text));
-
-\set ON_ERROR_STOP 1
-\set VERBOSITY terse
---
--- Cleanup
---
-DROP MATERIALIZED VIEW IF EXISTS :CAGG_NAME_2TH_LEVEL;
-DROP MATERIALIZED VIEW IF EXISTS :CAGG_NAME_1ST_LEVEL;
---
--- non-TZ bucket on top of TZ bucket
---
-\set IS_TIME_DIMENSION_WITH_TIMEZONE_1ST TRUE
-\set IS_TIME_DIMENSION_WITH_TIMEZONE_2TH FALSE
-\set BUCKET_TZNAME_1ST 'UTC'
-\set BUCKET_WIDTH_1ST 'INTERVAL \'1 day\''
-\set BUCKET_WIDTH_2TH 'INTERVAL \'1 month\''
-\set WARNING_MESSAGE '-- SHOULD WORK'
-\ir include/cagg_on_cagg_validations.sql
--- This file and its contents are licensed under the Timescale License.
--- Please see the included NOTICE for copyright information and
--- LICENSE-TIMESCALE for a copy of the license.
-\set CAGG_NAME_1ST_LEVEL conditions_summary_1
-\set CAGG_NAME_2TH_LEVEL conditions_summary_2
---
--- CAGG on hypertable (1st level)
---
-CREATE MATERIALIZED VIEW :CAGG_NAME_1ST_LEVEL
-WITH (timescaledb.continuous) AS
-SELECT
-  \if :IS_TIME_DIMENSION_WITH_TIMEZONE_1ST
-    time_bucket(:BUCKET_WIDTH_1ST, "time", :'BUCKET_TZNAME_1ST') AS bucket,
-  \else
-    time_bucket(:BUCKET_WIDTH_1ST, "time") AS bucket,
-  \endif
-  SUM(temperature) AS temperature
-FROM conditions
-GROUP BY 1
-WITH NO DATA;
-\d+ :CAGG_NAME_1ST_LEVEL
-                               View "public.conditions_summary_1"
-   Column    |           Type           | Collation | Nullable | Default | Storage | Description 
--------------+--------------------------+-----------+----------+---------+---------+-------------
- bucket      | timestamp with time zone |           |          |         | plain   | 
- temperature | numeric                  |           |          |         | main    | 
-View definition:
- SELECT _materialized_hypertable_48.bucket,
-    _materialized_hypertable_48.temperature
-   FROM _timescaledb_internal._materialized_hypertable_48
-  WHERE _materialized_hypertable_48.bucket < COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(48)), '-infinity'::timestamp with time zone)
-UNION ALL
- SELECT time_bucket('@ 1 day'::interval, conditions."time", 'UTC'::text) AS bucket,
-    sum(conditions.temperature) AS temperature
-   FROM conditions
-  WHERE conditions."time" >= COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(48)), '-infinity'::timestamp with time zone)
-  GROUP BY (time_bucket('@ 1 day'::interval, conditions."time", 'UTC'::text));
-
---
--- CAGG on CAGG (2th level)
---
-\set VERBOSITY default
-\set ON_ERROR_STOP 0
-\echo :WARNING_MESSAGE
--- SHOULD WORK
-CREATE MATERIALIZED VIEW :CAGG_NAME_2TH_LEVEL
-WITH (timescaledb.continuous) AS
-SELECT
-  \if :IS_TIME_DIMENSION_WITH_TIMEZONE_2TH
-    time_bucket(:BUCKET_WIDTH_2TH, "bucket", :'BUCKET_TZNAME_2TH') AS bucket,
-  \else
-    time_bucket(:BUCKET_WIDTH_2TH, "bucket") AS bucket,
-  \endif
-  SUM(temperature) AS temperature
-FROM :CAGG_NAME_1ST_LEVEL
-GROUP BY 1
-WITH NO DATA;
-\d+ :CAGG_NAME_2TH_LEVEL
-                               View "public.conditions_summary_2"
-   Column    |           Type           | Collation | Nullable | Default | Storage | Description 
--------------+--------------------------+-----------+----------+---------+---------+-------------
- bucket      | timestamp with time zone |           |          |         | plain   | 
- temperature | numeric                  |           |          |         | main    | 
-View definition:
- SELECT _materialized_hypertable_49.bucket,
-    _materialized_hypertable_49.temperature
-   FROM _timescaledb_internal._materialized_hypertable_49
-  WHERE _materialized_hypertable_49.bucket < COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(49)), '-infinity'::timestamp with time zone)
-UNION ALL
- SELECT time_bucket('@ 1 mon'::interval, conditions_summary_1.bucket) AS bucket,
-    sum(conditions_summary_1.temperature) AS temperature
-   FROM conditions_summary_1
-  WHERE conditions_summary_1.bucket >= COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(49)), '-infinity'::timestamp with time zone)
-  GROUP BY (time_bucket('@ 1 mon'::interval, conditions_summary_1.bucket));
-
-\set ON_ERROR_STOP 1
-\set VERBOSITY terse
---
--- Cleanup
---
-DROP MATERIALIZED VIEW IF EXISTS :CAGG_NAME_2TH_LEVEL;
-DROP MATERIALIZED VIEW IF EXISTS :CAGG_NAME_1ST_LEVEL;
--- bug report 5231
-\set BUCKET_WIDTH_1ST 'INTERVAL \'1 day\''
-\set BUCKET_WIDTH_2TH 'INTERVAL \'1 year\''
-\ir include/cagg_on_cagg_validations.sql
--- This file and its contents are licensed under the Timescale License.
--- Please see the included NOTICE for copyright information and
--- LICENSE-TIMESCALE for a copy of the license.
-\set CAGG_NAME_1ST_LEVEL conditions_summary_1
-\set CAGG_NAME_2TH_LEVEL conditions_summary_2
---
--- CAGG on hypertable (1st level)
---
-CREATE MATERIALIZED VIEW :CAGG_NAME_1ST_LEVEL
-WITH (timescaledb.continuous) AS
-SELECT
-  \if :IS_TIME_DIMENSION_WITH_TIMEZONE_1ST
-    time_bucket(:BUCKET_WIDTH_1ST, "time", :'BUCKET_TZNAME_1ST') AS bucket,
-  \else
-    time_bucket(:BUCKET_WIDTH_1ST, "time") AS bucket,
-  \endif
-  SUM(temperature) AS temperature
-FROM conditions
-GROUP BY 1
-WITH NO DATA;
-\d+ :CAGG_NAME_1ST_LEVEL
-                               View "public.conditions_summary_1"
-   Column    |           Type           | Collation | Nullable | Default | Storage | Description 
--------------+--------------------------+-----------+----------+---------+---------+-------------
- bucket      | timestamp with time zone |           |          |         | plain   | 
- temperature | numeric                  |           |          |         | main    | 
-View definition:
- SELECT _materialized_hypertable_50.bucket,
-    _materialized_hypertable_50.temperature
-   FROM _timescaledb_internal._materialized_hypertable_50
-  WHERE _materialized_hypertable_50.bucket < COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(50)), '-infinity'::timestamp with time zone)
-UNION ALL
- SELECT time_bucket('@ 1 day'::interval, conditions."time", 'UTC'::text) AS bucket,
-    sum(conditions.temperature) AS temperature
-   FROM conditions
-  WHERE conditions."time" >= COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(50)), '-infinity'::timestamp with time zone)
-  GROUP BY (time_bucket('@ 1 day'::interval, conditions."time", 'UTC'::text));
-
---
--- CAGG on CAGG (2th level)
---
-\set VERBOSITY default
-\set ON_ERROR_STOP 0
-\echo :WARNING_MESSAGE
--- SHOULD WORK
-CREATE MATERIALIZED VIEW :CAGG_NAME_2TH_LEVEL
-WITH (timescaledb.continuous) AS
-SELECT
-  \if :IS_TIME_DIMENSION_WITH_TIMEZONE_2TH
-    time_bucket(:BUCKET_WIDTH_2TH, "bucket", :'BUCKET_TZNAME_2TH') AS bucket,
-  \else
-    time_bucket(:BUCKET_WIDTH_2TH, "bucket") AS bucket,
-  \endif
-  SUM(temperature) AS temperature
-FROM :CAGG_NAME_1ST_LEVEL
-GROUP BY 1
-WITH NO DATA;
-\d+ :CAGG_NAME_2TH_LEVEL
-                               View "public.conditions_summary_2"
-   Column    |           Type           | Collation | Nullable | Default | Storage | Description 
--------------+--------------------------+-----------+----------+---------+---------+-------------
- bucket      | timestamp with time zone |           |          |         | plain   | 
- temperature | numeric                  |           |          |         | main    | 
-View definition:
- SELECT _materialized_hypertable_51.bucket,
-    _materialized_hypertable_51.temperature
-   FROM _timescaledb_internal._materialized_hypertable_51
-  WHERE _materialized_hypertable_51.bucket < COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(51)), '-infinity'::timestamp with time zone)
-UNION ALL
- SELECT time_bucket('@ 1 year'::interval, conditions_summary_1.bucket) AS bucket,
-    sum(conditions_summary_1.temperature) AS temperature
-   FROM conditions_summary_1
-  WHERE conditions_summary_1.bucket >= COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(51)), '-infinity'::timestamp with time zone)
-  GROUP BY (time_bucket('@ 1 year'::interval, conditions_summary_1.bucket));
-
-\set ON_ERROR_STOP 1
-\set VERBOSITY terse
---
--- Cleanup
---
-DROP MATERIALIZED VIEW IF EXISTS :CAGG_NAME_2TH_LEVEL;
-DROP MATERIALIZED VIEW IF EXISTS :CAGG_NAME_1ST_LEVEL;
-\set BUCKET_WIDTH_1ST 'INTERVAL \'1 day\''
-\set BUCKET_WIDTH_2TH 'INTERVAL \'3 month\''
-\ir include/cagg_on_cagg_validations.sql
--- This file and its contents are licensed under the Timescale License.
--- Please see the included NOTICE for copyright information and
--- LICENSE-TIMESCALE for a copy of the license.
-\set CAGG_NAME_1ST_LEVEL conditions_summary_1
-\set CAGG_NAME_2TH_LEVEL conditions_summary_2
+\set CAGG_NAME_3TH_LEVEL conditions_summary_3
 --
 -- CAGG on hypertable (1st level)
 --
@@ -4099,11 +4488,11 @@ View definition:
    FROM _timescaledb_internal._materialized_hypertable_52
   WHERE _materialized_hypertable_52.bucket < COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(52)), '-infinity'::timestamp with time zone)
 UNION ALL
- SELECT time_bucket('@ 1 day'::interval, conditions."time", 'UTC'::text) AS bucket,
+ SELECT time_bucket('@ 1 day'::interval, conditions."time") AS bucket,
     sum(conditions.temperature) AS temperature
    FROM conditions
   WHERE conditions."time" >= COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(52)), '-infinity'::timestamp with time zone)
-  GROUP BY (time_bucket('@ 1 day'::interval, conditions."time", 'UTC'::text));
+  GROUP BY (time_bucket('@ 1 day'::interval, conditions."time"));
 
 --
 -- CAGG on CAGG (2th level)
@@ -4136,27 +4525,55 @@ View definition:
    FROM _timescaledb_internal._materialized_hypertable_53
   WHERE _materialized_hypertable_53.bucket < COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(53)), '-infinity'::timestamp with time zone)
 UNION ALL
- SELECT time_bucket('@ 3 mons'::interval, conditions_summary_1.bucket) AS bucket,
+ SELECT time_bucket('@ 1 mon'::interval, conditions_summary_1.bucket, 'UTC'::text) AS bucket,
     sum(conditions_summary_1.temperature) AS temperature
    FROM conditions_summary_1
   WHERE conditions_summary_1.bucket >= COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(53)), '-infinity'::timestamp with time zone)
-  GROUP BY (time_bucket('@ 3 mons'::interval, conditions_summary_1.bucket));
+  GROUP BY (time_bucket('@ 1 mon'::interval, conditions_summary_1.bucket, 'UTC'::text));
 
 \set ON_ERROR_STOP 1
 \set VERBOSITY terse
+-- Check for incorrect CAGGs
+\if :INTERVAL_TEST
+  INSERT INTO conditions ("time", temperature, device_id) VALUES ('2022-01-01 00:00:00-00', 10, 4);
+  INSERT INTO conditions ("time", temperature, device_id) VALUES ('2022-01-15 01:00:00-00', 20, 4);
+  INSERT INTO conditions ("time", temperature, device_id) VALUES ('2022-01-31 01:00:00-00', 30, 4);
+  CALL refresh_continuous_aggregate(:'CAGG_NAME_1ST_LEVEL', NULL, NULL);
+  CALL refresh_continuous_aggregate(:'CAGG_NAME_2TH_LEVEL', NULL, NULL);
+  CREATE MATERIALIZED VIEW :CAGG_NAME_3TH_LEVEL
+  WITH (timescaledb.continuous) AS
+  SELECT
+    \if :IS_TIME_DIMENSION_WITH_TIMEZONE_2TH
+      time_bucket(:BUCKET_WIDTH_3TH, "bucket", :'BUCKET_TZNAME_2TH') AS bucket
+    \else
+      time_bucket(:BUCKET_WIDTH_3TH, "bucket") AS bucket
+    \endif
+  FROM :CAGG_NAME_2TH_LEVEL
+  GROUP BY 1
+  WITH DATA;
+  \d+ :CAGG_NAME_3TH_LEVEL
+  --There should never be dulpicates in the output of the following query
+  SELECT * from :CAGG_NAME_3TH_LEVEL;
+  DROP MATERIALIZED VIEW IF EXISTS :CAGG_NAME_3TH_LEVEL;
+  DELETE FROM conditions WHERE device_id = 4;
+\endif
 --
 -- Cleanup
 --
 DROP MATERIALIZED VIEW IF EXISTS :CAGG_NAME_2TH_LEVEL;
 DROP MATERIALIZED VIEW IF EXISTS :CAGG_NAME_1ST_LEVEL;
-\set BUCKET_WIDTH_1ST 'INTERVAL \'1 month\''
-\set BUCKET_WIDTH_2TH 'INTERVAL \'1 year\''
+--#Bugfix 5734 #3
+\set INTERVAL_TEST TRUE
+\set BUCKET_WIDTH_1ST 'INTERVAL \'1 hour\''
+\set BUCKET_WIDTH_2TH 'INTERVAL \'1 day\''
+\set BUCKET_WIDTH_3TH 'INTERVAL \'1 month\''
 \ir include/cagg_on_cagg_validations.sql
 -- This file and its contents are licensed under the Timescale License.
 -- Please see the included NOTICE for copyright information and
 -- LICENSE-TIMESCALE for a copy of the license.
 \set CAGG_NAME_1ST_LEVEL conditions_summary_1
 \set CAGG_NAME_2TH_LEVEL conditions_summary_2
+\set CAGG_NAME_3TH_LEVEL conditions_summary_3
 --
 -- CAGG on hypertable (1st level)
 --
@@ -4184,11 +4601,11 @@ View definition:
    FROM _timescaledb_internal._materialized_hypertable_54
   WHERE _materialized_hypertable_54.bucket < COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(54)), '-infinity'::timestamp with time zone)
 UNION ALL
- SELECT time_bucket('@ 1 mon'::interval, conditions."time", 'UTC'::text) AS bucket,
+ SELECT time_bucket('@ 1 hour'::interval, conditions."time") AS bucket,
     sum(conditions.temperature) AS temperature
    FROM conditions
   WHERE conditions."time" >= COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(54)), '-infinity'::timestamp with time zone)
-  GROUP BY (time_bucket('@ 1 mon'::interval, conditions."time", 'UTC'::text));
+  GROUP BY (time_bucket('@ 1 hour'::interval, conditions."time"));
 
 --
 -- CAGG on CAGG (2th level)
@@ -4221,98 +4638,83 @@ View definition:
    FROM _timescaledb_internal._materialized_hypertable_55
   WHERE _materialized_hypertable_55.bucket < COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(55)), '-infinity'::timestamp with time zone)
 UNION ALL
- SELECT time_bucket('@ 1 year'::interval, conditions_summary_1.bucket) AS bucket,
+ SELECT time_bucket('@ 1 day'::interval, conditions_summary_1.bucket, 'UTC'::text) AS bucket,
     sum(conditions_summary_1.temperature) AS temperature
    FROM conditions_summary_1
   WHERE conditions_summary_1.bucket >= COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(55)), '-infinity'::timestamp with time zone)
-  GROUP BY (time_bucket('@ 1 year'::interval, conditions_summary_1.bucket));
+  GROUP BY (time_bucket('@ 1 day'::interval, conditions_summary_1.bucket, 'UTC'::text));
 
 \set ON_ERROR_STOP 1
 \set VERBOSITY terse
---
--- Cleanup
---
-DROP MATERIALIZED VIEW IF EXISTS :CAGG_NAME_2TH_LEVEL;
-DROP MATERIALIZED VIEW IF EXISTS :CAGG_NAME_1ST_LEVEL;
-\set BUCKET_WIDTH_1ST 'INTERVAL \'1 week\''
-\set BUCKET_WIDTH_2TH 'INTERVAL \'1 year\''
-\ir include/cagg_on_cagg_validations.sql
--- This file and its contents are licensed under the Timescale License.
--- Please see the included NOTICE for copyright information and
--- LICENSE-TIMESCALE for a copy of the license.
-\set CAGG_NAME_1ST_LEVEL conditions_summary_1
-\set CAGG_NAME_2TH_LEVEL conditions_summary_2
---
--- CAGG on hypertable (1st level)
---
-CREATE MATERIALIZED VIEW :CAGG_NAME_1ST_LEVEL
-WITH (timescaledb.continuous) AS
-SELECT
-  \if :IS_TIME_DIMENSION_WITH_TIMEZONE_1ST
-    time_bucket(:BUCKET_WIDTH_1ST, "time", :'BUCKET_TZNAME_1ST') AS bucket,
-  \else
-    time_bucket(:BUCKET_WIDTH_1ST, "time") AS bucket,
-  \endif
-  SUM(temperature) AS temperature
-FROM conditions
-GROUP BY 1
-WITH NO DATA;
-\d+ :CAGG_NAME_1ST_LEVEL
-                               View "public.conditions_summary_1"
-   Column    |           Type           | Collation | Nullable | Default | Storage | Description 
--------------+--------------------------+-----------+----------+---------+---------+-------------
- bucket      | timestamp with time zone |           |          |         | plain   | 
- temperature | numeric                  |           |          |         | main    | 
+-- Check for incorrect CAGGs
+\if :INTERVAL_TEST
+  INSERT INTO conditions ("time", temperature, device_id) VALUES ('2022-01-01 00:00:00-00', 10, 4);
+  INSERT INTO conditions ("time", temperature, device_id) VALUES ('2022-01-15 01:00:00-00', 20, 4);
+  INSERT INTO conditions ("time", temperature, device_id) VALUES ('2022-01-31 01:00:00-00', 30, 4);
+  CALL refresh_continuous_aggregate(:'CAGG_NAME_1ST_LEVEL', NULL, NULL);
+  CALL refresh_continuous_aggregate(:'CAGG_NAME_2TH_LEVEL', NULL, NULL);
+  CREATE MATERIALIZED VIEW :CAGG_NAME_3TH_LEVEL
+  WITH (timescaledb.continuous) AS
+  SELECT
+    \if :IS_TIME_DIMENSION_WITH_TIMEZONE_2TH
+      time_bucket(:BUCKET_WIDTH_3TH, "bucket", :'BUCKET_TZNAME_2TH') AS bucket
+    \else
+      time_bucket(:BUCKET_WIDTH_3TH, "bucket") AS bucket
+    \endif
+  FROM :CAGG_NAME_2TH_LEVEL
+  GROUP BY 1
+  WITH DATA;
+psql:include/cagg_on_cagg_validations.sql:71: NOTICE:  refreshing continuous aggregate "conditions_summary_3"
+  \d+ :CAGG_NAME_3TH_LEVEL
+                             View "public.conditions_summary_3"
+ Column |           Type           | Collation | Nullable | Default | Storage | Description 
+--------+--------------------------+-----------+----------+---------+---------+-------------
+ bucket | timestamp with time zone |           |          |         | plain   | 
 View definition:
- SELECT _materialized_hypertable_56.bucket,
-    _materialized_hypertable_56.temperature
+ SELECT _materialized_hypertable_56.bucket
    FROM _timescaledb_internal._materialized_hypertable_56
   WHERE _materialized_hypertable_56.bucket < COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(56)), '-infinity'::timestamp with time zone)
 UNION ALL
- SELECT time_bucket('@ 7 days'::interval, conditions."time", 'UTC'::text) AS bucket,
-    sum(conditions.temperature) AS temperature
-   FROM conditions
-  WHERE conditions."time" >= COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(56)), '-infinity'::timestamp with time zone)
-  GROUP BY (time_bucket('@ 7 days'::interval, conditions."time", 'UTC'::text));
+ SELECT time_bucket('@ 1 mon'::interval, conditions_summary_2.bucket, 'UTC'::text) AS bucket
+   FROM conditions_summary_2
+  WHERE conditions_summary_2.bucket >= COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(56)), '-infinity'::timestamp with time zone)
+  GROUP BY (time_bucket('@ 1 mon'::interval, conditions_summary_2.bucket, 'UTC'::text));
 
---
--- CAGG on CAGG (2th level)
---
-\set VERBOSITY default
-\set ON_ERROR_STOP 0
-\echo :WARNING_MESSAGE
--- SHOULD WORK
-CREATE MATERIALIZED VIEW :CAGG_NAME_2TH_LEVEL
-WITH (timescaledb.continuous) AS
-SELECT
-  \if :IS_TIME_DIMENSION_WITH_TIMEZONE_2TH
-    time_bucket(:BUCKET_WIDTH_2TH, "bucket", :'BUCKET_TZNAME_2TH') AS bucket,
-  \else
-    time_bucket(:BUCKET_WIDTH_2TH, "bucket") AS bucket,
-  \endif
-  SUM(temperature) AS temperature
-FROM :CAGG_NAME_1ST_LEVEL
-GROUP BY 1
-WITH NO DATA;
-psql:include/cagg_on_cagg_validations.sql:43: ERROR:  cannot create continuous aggregate with incompatible bucket width
-DETAIL:  Time bucket width of "public.conditions_summary_2" [@ 360 days] should be multiple of the time bucket width of "public.conditions_summary_1" [@ 7 days].
-\d+ :CAGG_NAME_2TH_LEVEL
-\set ON_ERROR_STOP 1
-\set VERBOSITY terse
+  --There should never be dulpicates in the output of the following query
+  SELECT * from :CAGG_NAME_3TH_LEVEL;
+            bucket            
+------------------------------
+ Sat Jan 01 00:00:00 2022 UTC
+(1 row)
+
+  DROP MATERIALIZED VIEW IF EXISTS :CAGG_NAME_3TH_LEVEL;
+psql:include/cagg_on_cagg_validations.sql:79: NOTICE:  drop cascades to table _timescaledb_internal._hyper_56_37_chunk
+  DELETE FROM conditions WHERE device_id = 4;
+\endif
 --
 -- Cleanup
 --
 DROP MATERIALIZED VIEW IF EXISTS :CAGG_NAME_2TH_LEVEL;
-psql:include/cagg_on_cagg_validations.sql:53: NOTICE:  materialized view "conditions_summary_2" does not exist, skipping
+psql:include/cagg_on_cagg_validations.sql:86: NOTICE:  drop cascades to table _timescaledb_internal._hyper_55_36_chunk
 DROP MATERIALIZED VIEW IF EXISTS :CAGG_NAME_1ST_LEVEL;
-\set BUCKET_WIDTH_1ST 'INTERVAL \'1 week\''
+psql:include/cagg_on_cagg_validations.sql:87: NOTICE:  drop cascades to table _timescaledb_internal._hyper_54_35_chunk
+\set INTERVAL_TEST FALSE
+--
+-- non-TZ bucket on top of TZ bucket
+--
+\set IS_TIME_DIMENSION_WITH_TIMEZONE_1ST TRUE
+\set IS_TIME_DIMENSION_WITH_TIMEZONE_2TH FALSE
+\set BUCKET_TZNAME_1ST 'UTC'
+\set BUCKET_WIDTH_1ST 'INTERVAL \'1 day\''
 \set BUCKET_WIDTH_2TH 'INTERVAL \'1 month\''
+\set WARNING_MESSAGE '-- SHOULD WORK'
 \ir include/cagg_on_cagg_validations.sql
 -- This file and its contents are licensed under the Timescale License.
 -- Please see the included NOTICE for copyright information and
 -- LICENSE-TIMESCALE for a copy of the license.
 \set CAGG_NAME_1ST_LEVEL conditions_summary_1
 \set CAGG_NAME_2TH_LEVEL conditions_summary_2
+\set CAGG_NAME_3TH_LEVEL conditions_summary_3
 --
 -- CAGG on hypertable (1st level)
 --
@@ -4340,11 +4742,11 @@ View definition:
    FROM _timescaledb_internal._materialized_hypertable_57
   WHERE _materialized_hypertable_57.bucket < COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(57)), '-infinity'::timestamp with time zone)
 UNION ALL
- SELECT time_bucket('@ 7 days'::interval, conditions."time", 'UTC'::text) AS bucket,
+ SELECT time_bucket('@ 1 day'::interval, conditions."time", 'UTC'::text) AS bucket,
     sum(conditions.temperature) AS temperature
    FROM conditions
   WHERE conditions."time" >= COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(57)), '-infinity'::timestamp with time zone)
-  GROUP BY (time_bucket('@ 7 days'::interval, conditions."time", 'UTC'::text));
+  GROUP BY (time_bucket('@ 1 day'::interval, conditions."time", 'UTC'::text));
 
 --
 -- CAGG on CAGG (2th level)
@@ -4365,29 +4767,66 @@ SELECT
 FROM :CAGG_NAME_1ST_LEVEL
 GROUP BY 1
 WITH NO DATA;
-psql:include/cagg_on_cagg_validations.sql:43: ERROR:  cannot create continuous aggregate with incompatible bucket width
-DETAIL:  Time bucket width of "public.conditions_summary_2" [@ 30 days] should be multiple of the time bucket width of "public.conditions_summary_1" [@ 7 days].
 \d+ :CAGG_NAME_2TH_LEVEL
+                               View "public.conditions_summary_2"
+   Column    |           Type           | Collation | Nullable | Default | Storage | Description 
+-------------+--------------------------+-----------+----------+---------+---------+-------------
+ bucket      | timestamp with time zone |           |          |         | plain   | 
+ temperature | numeric                  |           |          |         | main    | 
+View definition:
+ SELECT _materialized_hypertable_58.bucket,
+    _materialized_hypertable_58.temperature
+   FROM _timescaledb_internal._materialized_hypertable_58
+  WHERE _materialized_hypertable_58.bucket < COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(58)), '-infinity'::timestamp with time zone)
+UNION ALL
+ SELECT time_bucket('@ 1 mon'::interval, conditions_summary_1.bucket) AS bucket,
+    sum(conditions_summary_1.temperature) AS temperature
+   FROM conditions_summary_1
+  WHERE conditions_summary_1.bucket >= COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(58)), '-infinity'::timestamp with time zone)
+  GROUP BY (time_bucket('@ 1 mon'::interval, conditions_summary_1.bucket));
+
 \set ON_ERROR_STOP 1
 \set VERBOSITY terse
+-- Check for incorrect CAGGs
+\if :INTERVAL_TEST
+  INSERT INTO conditions ("time", temperature, device_id) VALUES ('2022-01-01 00:00:00-00', 10, 4);
+  INSERT INTO conditions ("time", temperature, device_id) VALUES ('2022-01-15 01:00:00-00', 20, 4);
+  INSERT INTO conditions ("time", temperature, device_id) VALUES ('2022-01-31 01:00:00-00', 30, 4);
+  CALL refresh_continuous_aggregate(:'CAGG_NAME_1ST_LEVEL', NULL, NULL);
+  CALL refresh_continuous_aggregate(:'CAGG_NAME_2TH_LEVEL', NULL, NULL);
+  CREATE MATERIALIZED VIEW :CAGG_NAME_3TH_LEVEL
+  WITH (timescaledb.continuous) AS
+  SELECT
+    \if :IS_TIME_DIMENSION_WITH_TIMEZONE_2TH
+      time_bucket(:BUCKET_WIDTH_3TH, "bucket", :'BUCKET_TZNAME_2TH') AS bucket
+    \else
+      time_bucket(:BUCKET_WIDTH_3TH, "bucket") AS bucket
+    \endif
+  FROM :CAGG_NAME_2TH_LEVEL
+  GROUP BY 1
+  WITH DATA;
+  \d+ :CAGG_NAME_3TH_LEVEL
+  --There should never be dulpicates in the output of the following query
+  SELECT * from :CAGG_NAME_3TH_LEVEL;
+  DROP MATERIALIZED VIEW IF EXISTS :CAGG_NAME_3TH_LEVEL;
+  DELETE FROM conditions WHERE device_id = 4;
+\endif
 --
 -- Cleanup
 --
 DROP MATERIALIZED VIEW IF EXISTS :CAGG_NAME_2TH_LEVEL;
-psql:include/cagg_on_cagg_validations.sql:53: NOTICE:  materialized view "conditions_summary_2" does not exist, skipping
 DROP MATERIALIZED VIEW IF EXISTS :CAGG_NAME_1ST_LEVEL;
--- bug report 5277
-\set IS_TIME_DIMENSION_WITH_TIMEZONE_1ST FALSE
-\set IS_TIME_DIMENSION_WITH_TIMEZONE_2TH FALSE
--- epoch plus cast to int would compute a bucket width of 0 for parent
-\set BUCKET_WIDTH_1ST 'INTERVAL \'146 ms\''
-\set BUCKET_WIDTH_2TH 'INTERVAL \'1168 ms\''
+\set INTERVAL_TEST FALSE
+-- bug report 5231
+\set BUCKET_WIDTH_1ST 'INTERVAL \'1 day\''
+\set BUCKET_WIDTH_2TH 'INTERVAL \'1 year\''
 \ir include/cagg_on_cagg_validations.sql
 -- This file and its contents are licensed under the Timescale License.
 -- Please see the included NOTICE for copyright information and
 -- LICENSE-TIMESCALE for a copy of the license.
 \set CAGG_NAME_1ST_LEVEL conditions_summary_1
 \set CAGG_NAME_2TH_LEVEL conditions_summary_2
+\set CAGG_NAME_3TH_LEVEL conditions_summary_3
 --
 -- CAGG on hypertable (1st level)
 --
@@ -4410,15 +4849,541 @@ WITH NO DATA;
  bucket      | timestamp with time zone |           |          |         | plain   | 
  temperature | numeric                  |           |          |         | main    | 
 View definition:
- SELECT _materialized_hypertable_58.bucket,
-    _materialized_hypertable_58.temperature
-   FROM _timescaledb_internal._materialized_hypertable_58
-  WHERE _materialized_hypertable_58.bucket < COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(58)), '-infinity'::timestamp with time zone)
+ SELECT _materialized_hypertable_59.bucket,
+    _materialized_hypertable_59.temperature
+   FROM _timescaledb_internal._materialized_hypertable_59
+  WHERE _materialized_hypertable_59.bucket < COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(59)), '-infinity'::timestamp with time zone)
+UNION ALL
+ SELECT time_bucket('@ 1 day'::interval, conditions."time", 'UTC'::text) AS bucket,
+    sum(conditions.temperature) AS temperature
+   FROM conditions
+  WHERE conditions."time" >= COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(59)), '-infinity'::timestamp with time zone)
+  GROUP BY (time_bucket('@ 1 day'::interval, conditions."time", 'UTC'::text));
+
+--
+-- CAGG on CAGG (2th level)
+--
+\set VERBOSITY default
+\set ON_ERROR_STOP 0
+\echo :WARNING_MESSAGE
+-- SHOULD WORK
+CREATE MATERIALIZED VIEW :CAGG_NAME_2TH_LEVEL
+WITH (timescaledb.continuous) AS
+SELECT
+  \if :IS_TIME_DIMENSION_WITH_TIMEZONE_2TH
+    time_bucket(:BUCKET_WIDTH_2TH, "bucket", :'BUCKET_TZNAME_2TH') AS bucket,
+  \else
+    time_bucket(:BUCKET_WIDTH_2TH, "bucket") AS bucket,
+  \endif
+  SUM(temperature) AS temperature
+FROM :CAGG_NAME_1ST_LEVEL
+GROUP BY 1
+WITH NO DATA;
+\d+ :CAGG_NAME_2TH_LEVEL
+                               View "public.conditions_summary_2"
+   Column    |           Type           | Collation | Nullable | Default | Storage | Description 
+-------------+--------------------------+-----------+----------+---------+---------+-------------
+ bucket      | timestamp with time zone |           |          |         | plain   | 
+ temperature | numeric                  |           |          |         | main    | 
+View definition:
+ SELECT _materialized_hypertable_60.bucket,
+    _materialized_hypertable_60.temperature
+   FROM _timescaledb_internal._materialized_hypertable_60
+  WHERE _materialized_hypertable_60.bucket < COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(60)), '-infinity'::timestamp with time zone)
+UNION ALL
+ SELECT time_bucket('@ 1 year'::interval, conditions_summary_1.bucket) AS bucket,
+    sum(conditions_summary_1.temperature) AS temperature
+   FROM conditions_summary_1
+  WHERE conditions_summary_1.bucket >= COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(60)), '-infinity'::timestamp with time zone)
+  GROUP BY (time_bucket('@ 1 year'::interval, conditions_summary_1.bucket));
+
+\set ON_ERROR_STOP 1
+\set VERBOSITY terse
+-- Check for incorrect CAGGs
+\if :INTERVAL_TEST
+  INSERT INTO conditions ("time", temperature, device_id) VALUES ('2022-01-01 00:00:00-00', 10, 4);
+  INSERT INTO conditions ("time", temperature, device_id) VALUES ('2022-01-15 01:00:00-00', 20, 4);
+  INSERT INTO conditions ("time", temperature, device_id) VALUES ('2022-01-31 01:00:00-00', 30, 4);
+  CALL refresh_continuous_aggregate(:'CAGG_NAME_1ST_LEVEL', NULL, NULL);
+  CALL refresh_continuous_aggregate(:'CAGG_NAME_2TH_LEVEL', NULL, NULL);
+  CREATE MATERIALIZED VIEW :CAGG_NAME_3TH_LEVEL
+  WITH (timescaledb.continuous) AS
+  SELECT
+    \if :IS_TIME_DIMENSION_WITH_TIMEZONE_2TH
+      time_bucket(:BUCKET_WIDTH_3TH, "bucket", :'BUCKET_TZNAME_2TH') AS bucket
+    \else
+      time_bucket(:BUCKET_WIDTH_3TH, "bucket") AS bucket
+    \endif
+  FROM :CAGG_NAME_2TH_LEVEL
+  GROUP BY 1
+  WITH DATA;
+  \d+ :CAGG_NAME_3TH_LEVEL
+  --There should never be dulpicates in the output of the following query
+  SELECT * from :CAGG_NAME_3TH_LEVEL;
+  DROP MATERIALIZED VIEW IF EXISTS :CAGG_NAME_3TH_LEVEL;
+  DELETE FROM conditions WHERE device_id = 4;
+\endif
+--
+-- Cleanup
+--
+DROP MATERIALIZED VIEW IF EXISTS :CAGG_NAME_2TH_LEVEL;
+DROP MATERIALIZED VIEW IF EXISTS :CAGG_NAME_1ST_LEVEL;
+\set BUCKET_WIDTH_1ST 'INTERVAL \'1 day\''
+\set BUCKET_WIDTH_2TH 'INTERVAL \'3 month\''
+\ir include/cagg_on_cagg_validations.sql
+-- This file and its contents are licensed under the Timescale License.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-TIMESCALE for a copy of the license.
+\set CAGG_NAME_1ST_LEVEL conditions_summary_1
+\set CAGG_NAME_2TH_LEVEL conditions_summary_2
+\set CAGG_NAME_3TH_LEVEL conditions_summary_3
+--
+-- CAGG on hypertable (1st level)
+--
+CREATE MATERIALIZED VIEW :CAGG_NAME_1ST_LEVEL
+WITH (timescaledb.continuous) AS
+SELECT
+  \if :IS_TIME_DIMENSION_WITH_TIMEZONE_1ST
+    time_bucket(:BUCKET_WIDTH_1ST, "time", :'BUCKET_TZNAME_1ST') AS bucket,
+  \else
+    time_bucket(:BUCKET_WIDTH_1ST, "time") AS bucket,
+  \endif
+  SUM(temperature) AS temperature
+FROM conditions
+GROUP BY 1
+WITH NO DATA;
+\d+ :CAGG_NAME_1ST_LEVEL
+                               View "public.conditions_summary_1"
+   Column    |           Type           | Collation | Nullable | Default | Storage | Description 
+-------------+--------------------------+-----------+----------+---------+---------+-------------
+ bucket      | timestamp with time zone |           |          |         | plain   | 
+ temperature | numeric                  |           |          |         | main    | 
+View definition:
+ SELECT _materialized_hypertable_61.bucket,
+    _materialized_hypertable_61.temperature
+   FROM _timescaledb_internal._materialized_hypertable_61
+  WHERE _materialized_hypertable_61.bucket < COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(61)), '-infinity'::timestamp with time zone)
+UNION ALL
+ SELECT time_bucket('@ 1 day'::interval, conditions."time", 'UTC'::text) AS bucket,
+    sum(conditions.temperature) AS temperature
+   FROM conditions
+  WHERE conditions."time" >= COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(61)), '-infinity'::timestamp with time zone)
+  GROUP BY (time_bucket('@ 1 day'::interval, conditions."time", 'UTC'::text));
+
+--
+-- CAGG on CAGG (2th level)
+--
+\set VERBOSITY default
+\set ON_ERROR_STOP 0
+\echo :WARNING_MESSAGE
+-- SHOULD WORK
+CREATE MATERIALIZED VIEW :CAGG_NAME_2TH_LEVEL
+WITH (timescaledb.continuous) AS
+SELECT
+  \if :IS_TIME_DIMENSION_WITH_TIMEZONE_2TH
+    time_bucket(:BUCKET_WIDTH_2TH, "bucket", :'BUCKET_TZNAME_2TH') AS bucket,
+  \else
+    time_bucket(:BUCKET_WIDTH_2TH, "bucket") AS bucket,
+  \endif
+  SUM(temperature) AS temperature
+FROM :CAGG_NAME_1ST_LEVEL
+GROUP BY 1
+WITH NO DATA;
+\d+ :CAGG_NAME_2TH_LEVEL
+                               View "public.conditions_summary_2"
+   Column    |           Type           | Collation | Nullable | Default | Storage | Description 
+-------------+--------------------------+-----------+----------+---------+---------+-------------
+ bucket      | timestamp with time zone |           |          |         | plain   | 
+ temperature | numeric                  |           |          |         | main    | 
+View definition:
+ SELECT _materialized_hypertable_62.bucket,
+    _materialized_hypertable_62.temperature
+   FROM _timescaledb_internal._materialized_hypertable_62
+  WHERE _materialized_hypertable_62.bucket < COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(62)), '-infinity'::timestamp with time zone)
+UNION ALL
+ SELECT time_bucket('@ 3 mons'::interval, conditions_summary_1.bucket) AS bucket,
+    sum(conditions_summary_1.temperature) AS temperature
+   FROM conditions_summary_1
+  WHERE conditions_summary_1.bucket >= COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(62)), '-infinity'::timestamp with time zone)
+  GROUP BY (time_bucket('@ 3 mons'::interval, conditions_summary_1.bucket));
+
+\set ON_ERROR_STOP 1
+\set VERBOSITY terse
+-- Check for incorrect CAGGs
+\if :INTERVAL_TEST
+  INSERT INTO conditions ("time", temperature, device_id) VALUES ('2022-01-01 00:00:00-00', 10, 4);
+  INSERT INTO conditions ("time", temperature, device_id) VALUES ('2022-01-15 01:00:00-00', 20, 4);
+  INSERT INTO conditions ("time", temperature, device_id) VALUES ('2022-01-31 01:00:00-00', 30, 4);
+  CALL refresh_continuous_aggregate(:'CAGG_NAME_1ST_LEVEL', NULL, NULL);
+  CALL refresh_continuous_aggregate(:'CAGG_NAME_2TH_LEVEL', NULL, NULL);
+  CREATE MATERIALIZED VIEW :CAGG_NAME_3TH_LEVEL
+  WITH (timescaledb.continuous) AS
+  SELECT
+    \if :IS_TIME_DIMENSION_WITH_TIMEZONE_2TH
+      time_bucket(:BUCKET_WIDTH_3TH, "bucket", :'BUCKET_TZNAME_2TH') AS bucket
+    \else
+      time_bucket(:BUCKET_WIDTH_3TH, "bucket") AS bucket
+    \endif
+  FROM :CAGG_NAME_2TH_LEVEL
+  GROUP BY 1
+  WITH DATA;
+  \d+ :CAGG_NAME_3TH_LEVEL
+  --There should never be dulpicates in the output of the following query
+  SELECT * from :CAGG_NAME_3TH_LEVEL;
+  DROP MATERIALIZED VIEW IF EXISTS :CAGG_NAME_3TH_LEVEL;
+  DELETE FROM conditions WHERE device_id = 4;
+\endif
+--
+-- Cleanup
+--
+DROP MATERIALIZED VIEW IF EXISTS :CAGG_NAME_2TH_LEVEL;
+DROP MATERIALIZED VIEW IF EXISTS :CAGG_NAME_1ST_LEVEL;
+\set BUCKET_WIDTH_1ST 'INTERVAL \'1 month\''
+\set BUCKET_WIDTH_2TH 'INTERVAL \'1 year\''
+\ir include/cagg_on_cagg_validations.sql
+-- This file and its contents are licensed under the Timescale License.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-TIMESCALE for a copy of the license.
+\set CAGG_NAME_1ST_LEVEL conditions_summary_1
+\set CAGG_NAME_2TH_LEVEL conditions_summary_2
+\set CAGG_NAME_3TH_LEVEL conditions_summary_3
+--
+-- CAGG on hypertable (1st level)
+--
+CREATE MATERIALIZED VIEW :CAGG_NAME_1ST_LEVEL
+WITH (timescaledb.continuous) AS
+SELECT
+  \if :IS_TIME_DIMENSION_WITH_TIMEZONE_1ST
+    time_bucket(:BUCKET_WIDTH_1ST, "time", :'BUCKET_TZNAME_1ST') AS bucket,
+  \else
+    time_bucket(:BUCKET_WIDTH_1ST, "time") AS bucket,
+  \endif
+  SUM(temperature) AS temperature
+FROM conditions
+GROUP BY 1
+WITH NO DATA;
+\d+ :CAGG_NAME_1ST_LEVEL
+                               View "public.conditions_summary_1"
+   Column    |           Type           | Collation | Nullable | Default | Storage | Description 
+-------------+--------------------------+-----------+----------+---------+---------+-------------
+ bucket      | timestamp with time zone |           |          |         | plain   | 
+ temperature | numeric                  |           |          |         | main    | 
+View definition:
+ SELECT _materialized_hypertable_63.bucket,
+    _materialized_hypertable_63.temperature
+   FROM _timescaledb_internal._materialized_hypertable_63
+  WHERE _materialized_hypertable_63.bucket < COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(63)), '-infinity'::timestamp with time zone)
+UNION ALL
+ SELECT time_bucket('@ 1 mon'::interval, conditions."time", 'UTC'::text) AS bucket,
+    sum(conditions.temperature) AS temperature
+   FROM conditions
+  WHERE conditions."time" >= COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(63)), '-infinity'::timestamp with time zone)
+  GROUP BY (time_bucket('@ 1 mon'::interval, conditions."time", 'UTC'::text));
+
+--
+-- CAGG on CAGG (2th level)
+--
+\set VERBOSITY default
+\set ON_ERROR_STOP 0
+\echo :WARNING_MESSAGE
+-- SHOULD WORK
+CREATE MATERIALIZED VIEW :CAGG_NAME_2TH_LEVEL
+WITH (timescaledb.continuous) AS
+SELECT
+  \if :IS_TIME_DIMENSION_WITH_TIMEZONE_2TH
+    time_bucket(:BUCKET_WIDTH_2TH, "bucket", :'BUCKET_TZNAME_2TH') AS bucket,
+  \else
+    time_bucket(:BUCKET_WIDTH_2TH, "bucket") AS bucket,
+  \endif
+  SUM(temperature) AS temperature
+FROM :CAGG_NAME_1ST_LEVEL
+GROUP BY 1
+WITH NO DATA;
+\d+ :CAGG_NAME_2TH_LEVEL
+                               View "public.conditions_summary_2"
+   Column    |           Type           | Collation | Nullable | Default | Storage | Description 
+-------------+--------------------------+-----------+----------+---------+---------+-------------
+ bucket      | timestamp with time zone |           |          |         | plain   | 
+ temperature | numeric                  |           |          |         | main    | 
+View definition:
+ SELECT _materialized_hypertable_64.bucket,
+    _materialized_hypertable_64.temperature
+   FROM _timescaledb_internal._materialized_hypertable_64
+  WHERE _materialized_hypertable_64.bucket < COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(64)), '-infinity'::timestamp with time zone)
+UNION ALL
+ SELECT time_bucket('@ 1 year'::interval, conditions_summary_1.bucket) AS bucket,
+    sum(conditions_summary_1.temperature) AS temperature
+   FROM conditions_summary_1
+  WHERE conditions_summary_1.bucket >= COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(64)), '-infinity'::timestamp with time zone)
+  GROUP BY (time_bucket('@ 1 year'::interval, conditions_summary_1.bucket));
+
+\set ON_ERROR_STOP 1
+\set VERBOSITY terse
+-- Check for incorrect CAGGs
+\if :INTERVAL_TEST
+  INSERT INTO conditions ("time", temperature, device_id) VALUES ('2022-01-01 00:00:00-00', 10, 4);
+  INSERT INTO conditions ("time", temperature, device_id) VALUES ('2022-01-15 01:00:00-00', 20, 4);
+  INSERT INTO conditions ("time", temperature, device_id) VALUES ('2022-01-31 01:00:00-00', 30, 4);
+  CALL refresh_continuous_aggregate(:'CAGG_NAME_1ST_LEVEL', NULL, NULL);
+  CALL refresh_continuous_aggregate(:'CAGG_NAME_2TH_LEVEL', NULL, NULL);
+  CREATE MATERIALIZED VIEW :CAGG_NAME_3TH_LEVEL
+  WITH (timescaledb.continuous) AS
+  SELECT
+    \if :IS_TIME_DIMENSION_WITH_TIMEZONE_2TH
+      time_bucket(:BUCKET_WIDTH_3TH, "bucket", :'BUCKET_TZNAME_2TH') AS bucket
+    \else
+      time_bucket(:BUCKET_WIDTH_3TH, "bucket") AS bucket
+    \endif
+  FROM :CAGG_NAME_2TH_LEVEL
+  GROUP BY 1
+  WITH DATA;
+  \d+ :CAGG_NAME_3TH_LEVEL
+  --There should never be dulpicates in the output of the following query
+  SELECT * from :CAGG_NAME_3TH_LEVEL;
+  DROP MATERIALIZED VIEW IF EXISTS :CAGG_NAME_3TH_LEVEL;
+  DELETE FROM conditions WHERE device_id = 4;
+\endif
+--
+-- Cleanup
+--
+DROP MATERIALIZED VIEW IF EXISTS :CAGG_NAME_2TH_LEVEL;
+DROP MATERIALIZED VIEW IF EXISTS :CAGG_NAME_1ST_LEVEL;
+\set BUCKET_WIDTH_1ST 'INTERVAL \'1 week\''
+\set BUCKET_WIDTH_2TH 'INTERVAL \'1 year\''
+\ir include/cagg_on_cagg_validations.sql
+-- This file and its contents are licensed under the Timescale License.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-TIMESCALE for a copy of the license.
+\set CAGG_NAME_1ST_LEVEL conditions_summary_1
+\set CAGG_NAME_2TH_LEVEL conditions_summary_2
+\set CAGG_NAME_3TH_LEVEL conditions_summary_3
+--
+-- CAGG on hypertable (1st level)
+--
+CREATE MATERIALIZED VIEW :CAGG_NAME_1ST_LEVEL
+WITH (timescaledb.continuous) AS
+SELECT
+  \if :IS_TIME_DIMENSION_WITH_TIMEZONE_1ST
+    time_bucket(:BUCKET_WIDTH_1ST, "time", :'BUCKET_TZNAME_1ST') AS bucket,
+  \else
+    time_bucket(:BUCKET_WIDTH_1ST, "time") AS bucket,
+  \endif
+  SUM(temperature) AS temperature
+FROM conditions
+GROUP BY 1
+WITH NO DATA;
+\d+ :CAGG_NAME_1ST_LEVEL
+                               View "public.conditions_summary_1"
+   Column    |           Type           | Collation | Nullable | Default | Storage | Description 
+-------------+--------------------------+-----------+----------+---------+---------+-------------
+ bucket      | timestamp with time zone |           |          |         | plain   | 
+ temperature | numeric                  |           |          |         | main    | 
+View definition:
+ SELECT _materialized_hypertable_65.bucket,
+    _materialized_hypertable_65.temperature
+   FROM _timescaledb_internal._materialized_hypertable_65
+  WHERE _materialized_hypertable_65.bucket < COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(65)), '-infinity'::timestamp with time zone)
+UNION ALL
+ SELECT time_bucket('@ 7 days'::interval, conditions."time", 'UTC'::text) AS bucket,
+    sum(conditions.temperature) AS temperature
+   FROM conditions
+  WHERE conditions."time" >= COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(65)), '-infinity'::timestamp with time zone)
+  GROUP BY (time_bucket('@ 7 days'::interval, conditions."time", 'UTC'::text));
+
+--
+-- CAGG on CAGG (2th level)
+--
+\set VERBOSITY default
+\set ON_ERROR_STOP 0
+\echo :WARNING_MESSAGE
+-- SHOULD WORK
+CREATE MATERIALIZED VIEW :CAGG_NAME_2TH_LEVEL
+WITH (timescaledb.continuous) AS
+SELECT
+  \if :IS_TIME_DIMENSION_WITH_TIMEZONE_2TH
+    time_bucket(:BUCKET_WIDTH_2TH, "bucket", :'BUCKET_TZNAME_2TH') AS bucket,
+  \else
+    time_bucket(:BUCKET_WIDTH_2TH, "bucket") AS bucket,
+  \endif
+  SUM(temperature) AS temperature
+FROM :CAGG_NAME_1ST_LEVEL
+GROUP BY 1
+WITH NO DATA;
+psql:include/cagg_on_cagg_validations.sql:44: ERROR:  cannot create continuous aggregate with incompatible bucket width
+DETAIL:  Time bucket width of "public.conditions_summary_2" [@ 1 year] should be multiple of the time bucket width of "public.conditions_summary_1" [@ 7 days].
+\d+ :CAGG_NAME_2TH_LEVEL
+\set ON_ERROR_STOP 1
+\set VERBOSITY terse
+-- Check for incorrect CAGGs
+\if :INTERVAL_TEST
+  INSERT INTO conditions ("time", temperature, device_id) VALUES ('2022-01-01 00:00:00-00', 10, 4);
+  INSERT INTO conditions ("time", temperature, device_id) VALUES ('2022-01-15 01:00:00-00', 20, 4);
+  INSERT INTO conditions ("time", temperature, device_id) VALUES ('2022-01-31 01:00:00-00', 30, 4);
+  CALL refresh_continuous_aggregate(:'CAGG_NAME_1ST_LEVEL', NULL, NULL);
+  CALL refresh_continuous_aggregate(:'CAGG_NAME_2TH_LEVEL', NULL, NULL);
+  CREATE MATERIALIZED VIEW :CAGG_NAME_3TH_LEVEL
+  WITH (timescaledb.continuous) AS
+  SELECT
+    \if :IS_TIME_DIMENSION_WITH_TIMEZONE_2TH
+      time_bucket(:BUCKET_WIDTH_3TH, "bucket", :'BUCKET_TZNAME_2TH') AS bucket
+    \else
+      time_bucket(:BUCKET_WIDTH_3TH, "bucket") AS bucket
+    \endif
+  FROM :CAGG_NAME_2TH_LEVEL
+  GROUP BY 1
+  WITH DATA;
+  \d+ :CAGG_NAME_3TH_LEVEL
+  --There should never be dulpicates in the output of the following query
+  SELECT * from :CAGG_NAME_3TH_LEVEL;
+  DROP MATERIALIZED VIEW IF EXISTS :CAGG_NAME_3TH_LEVEL;
+  DELETE FROM conditions WHERE device_id = 4;
+\endif
+--
+-- Cleanup
+--
+DROP MATERIALIZED VIEW IF EXISTS :CAGG_NAME_2TH_LEVEL;
+psql:include/cagg_on_cagg_validations.sql:86: NOTICE:  materialized view "conditions_summary_2" does not exist, skipping
+DROP MATERIALIZED VIEW IF EXISTS :CAGG_NAME_1ST_LEVEL;
+\set BUCKET_WIDTH_1ST 'INTERVAL \'1 week\''
+\set BUCKET_WIDTH_2TH 'INTERVAL \'1 month\''
+\ir include/cagg_on_cagg_validations.sql
+-- This file and its contents are licensed under the Timescale License.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-TIMESCALE for a copy of the license.
+\set CAGG_NAME_1ST_LEVEL conditions_summary_1
+\set CAGG_NAME_2TH_LEVEL conditions_summary_2
+\set CAGG_NAME_3TH_LEVEL conditions_summary_3
+--
+-- CAGG on hypertable (1st level)
+--
+CREATE MATERIALIZED VIEW :CAGG_NAME_1ST_LEVEL
+WITH (timescaledb.continuous) AS
+SELECT
+  \if :IS_TIME_DIMENSION_WITH_TIMEZONE_1ST
+    time_bucket(:BUCKET_WIDTH_1ST, "time", :'BUCKET_TZNAME_1ST') AS bucket,
+  \else
+    time_bucket(:BUCKET_WIDTH_1ST, "time") AS bucket,
+  \endif
+  SUM(temperature) AS temperature
+FROM conditions
+GROUP BY 1
+WITH NO DATA;
+\d+ :CAGG_NAME_1ST_LEVEL
+                               View "public.conditions_summary_1"
+   Column    |           Type           | Collation | Nullable | Default | Storage | Description 
+-------------+--------------------------+-----------+----------+---------+---------+-------------
+ bucket      | timestamp with time zone |           |          |         | plain   | 
+ temperature | numeric                  |           |          |         | main    | 
+View definition:
+ SELECT _materialized_hypertable_66.bucket,
+    _materialized_hypertable_66.temperature
+   FROM _timescaledb_internal._materialized_hypertable_66
+  WHERE _materialized_hypertable_66.bucket < COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(66)), '-infinity'::timestamp with time zone)
+UNION ALL
+ SELECT time_bucket('@ 7 days'::interval, conditions."time", 'UTC'::text) AS bucket,
+    sum(conditions.temperature) AS temperature
+   FROM conditions
+  WHERE conditions."time" >= COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(66)), '-infinity'::timestamp with time zone)
+  GROUP BY (time_bucket('@ 7 days'::interval, conditions."time", 'UTC'::text));
+
+--
+-- CAGG on CAGG (2th level)
+--
+\set VERBOSITY default
+\set ON_ERROR_STOP 0
+\echo :WARNING_MESSAGE
+-- SHOULD WORK
+CREATE MATERIALIZED VIEW :CAGG_NAME_2TH_LEVEL
+WITH (timescaledb.continuous) AS
+SELECT
+  \if :IS_TIME_DIMENSION_WITH_TIMEZONE_2TH
+    time_bucket(:BUCKET_WIDTH_2TH, "bucket", :'BUCKET_TZNAME_2TH') AS bucket,
+  \else
+    time_bucket(:BUCKET_WIDTH_2TH, "bucket") AS bucket,
+  \endif
+  SUM(temperature) AS temperature
+FROM :CAGG_NAME_1ST_LEVEL
+GROUP BY 1
+WITH NO DATA;
+psql:include/cagg_on_cagg_validations.sql:44: ERROR:  cannot create continuous aggregate with incompatible bucket width
+DETAIL:  Time bucket width of "public.conditions_summary_2" [@ 1 mon] should be multiple of the time bucket width of "public.conditions_summary_1" [@ 7 days].
+\d+ :CAGG_NAME_2TH_LEVEL
+\set ON_ERROR_STOP 1
+\set VERBOSITY terse
+-- Check for incorrect CAGGs
+\if :INTERVAL_TEST
+  INSERT INTO conditions ("time", temperature, device_id) VALUES ('2022-01-01 00:00:00-00', 10, 4);
+  INSERT INTO conditions ("time", temperature, device_id) VALUES ('2022-01-15 01:00:00-00', 20, 4);
+  INSERT INTO conditions ("time", temperature, device_id) VALUES ('2022-01-31 01:00:00-00', 30, 4);
+  CALL refresh_continuous_aggregate(:'CAGG_NAME_1ST_LEVEL', NULL, NULL);
+  CALL refresh_continuous_aggregate(:'CAGG_NAME_2TH_LEVEL', NULL, NULL);
+  CREATE MATERIALIZED VIEW :CAGG_NAME_3TH_LEVEL
+  WITH (timescaledb.continuous) AS
+  SELECT
+    \if :IS_TIME_DIMENSION_WITH_TIMEZONE_2TH
+      time_bucket(:BUCKET_WIDTH_3TH, "bucket", :'BUCKET_TZNAME_2TH') AS bucket
+    \else
+      time_bucket(:BUCKET_WIDTH_3TH, "bucket") AS bucket
+    \endif
+  FROM :CAGG_NAME_2TH_LEVEL
+  GROUP BY 1
+  WITH DATA;
+  \d+ :CAGG_NAME_3TH_LEVEL
+  --There should never be dulpicates in the output of the following query
+  SELECT * from :CAGG_NAME_3TH_LEVEL;
+  DROP MATERIALIZED VIEW IF EXISTS :CAGG_NAME_3TH_LEVEL;
+  DELETE FROM conditions WHERE device_id = 4;
+\endif
+--
+-- Cleanup
+--
+DROP MATERIALIZED VIEW IF EXISTS :CAGG_NAME_2TH_LEVEL;
+psql:include/cagg_on_cagg_validations.sql:86: NOTICE:  materialized view "conditions_summary_2" does not exist, skipping
+DROP MATERIALIZED VIEW IF EXISTS :CAGG_NAME_1ST_LEVEL;
+-- bug report 5277
+\set IS_TIME_DIMENSION_WITH_TIMEZONE_1ST FALSE
+\set IS_TIME_DIMENSION_WITH_TIMEZONE_2TH FALSE
+-- epoch plus cast to int would compute a bucket width of 0 for parent
+\set BUCKET_WIDTH_1ST 'INTERVAL \'146 ms\''
+\set BUCKET_WIDTH_2TH 'INTERVAL \'1168 ms\''
+\ir include/cagg_on_cagg_validations.sql
+-- This file and its contents are licensed under the Timescale License.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-TIMESCALE for a copy of the license.
+\set CAGG_NAME_1ST_LEVEL conditions_summary_1
+\set CAGG_NAME_2TH_LEVEL conditions_summary_2
+\set CAGG_NAME_3TH_LEVEL conditions_summary_3
+--
+-- CAGG on hypertable (1st level)
+--
+CREATE MATERIALIZED VIEW :CAGG_NAME_1ST_LEVEL
+WITH (timescaledb.continuous) AS
+SELECT
+  \if :IS_TIME_DIMENSION_WITH_TIMEZONE_1ST
+    time_bucket(:BUCKET_WIDTH_1ST, "time", :'BUCKET_TZNAME_1ST') AS bucket,
+  \else
+    time_bucket(:BUCKET_WIDTH_1ST, "time") AS bucket,
+  \endif
+  SUM(temperature) AS temperature
+FROM conditions
+GROUP BY 1
+WITH NO DATA;
+\d+ :CAGG_NAME_1ST_LEVEL
+                               View "public.conditions_summary_1"
+   Column    |           Type           | Collation | Nullable | Default | Storage | Description 
+-------------+--------------------------+-----------+----------+---------+---------+-------------
+ bucket      | timestamp with time zone |           |          |         | plain   | 
+ temperature | numeric                  |           |          |         | main    | 
+View definition:
+ SELECT _materialized_hypertable_67.bucket,
+    _materialized_hypertable_67.temperature
+   FROM _timescaledb_internal._materialized_hypertable_67
+  WHERE _materialized_hypertable_67.bucket < COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(67)), '-infinity'::timestamp with time zone)
 UNION ALL
  SELECT time_bucket('@ 0.146 secs'::interval, conditions."time") AS bucket,
     sum(conditions.temperature) AS temperature
    FROM conditions
-  WHERE conditions."time" >= COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(58)), '-infinity'::timestamp with time zone)
+  WHERE conditions."time" >= COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(67)), '-infinity'::timestamp with time zone)
   GROUP BY (time_bucket('@ 0.146 secs'::interval, conditions."time"));
 
 --
@@ -4447,19 +5412,43 @@ WITH NO DATA;
  bucket      | timestamp with time zone |           |          |         | plain   | 
  temperature | numeric                  |           |          |         | main    | 
 View definition:
- SELECT _materialized_hypertable_59.bucket,
-    _materialized_hypertable_59.temperature
-   FROM _timescaledb_internal._materialized_hypertable_59
-  WHERE _materialized_hypertable_59.bucket < COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(59)), '-infinity'::timestamp with time zone)
+ SELECT _materialized_hypertable_68.bucket,
+    _materialized_hypertable_68.temperature
+   FROM _timescaledb_internal._materialized_hypertable_68
+  WHERE _materialized_hypertable_68.bucket < COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(68)), '-infinity'::timestamp with time zone)
 UNION ALL
  SELECT time_bucket('@ 1.168 secs'::interval, conditions_summary_1.bucket) AS bucket,
     sum(conditions_summary_1.temperature) AS temperature
    FROM conditions_summary_1
-  WHERE conditions_summary_1.bucket >= COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(59)), '-infinity'::timestamp with time zone)
+  WHERE conditions_summary_1.bucket >= COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(68)), '-infinity'::timestamp with time zone)
   GROUP BY (time_bucket('@ 1.168 secs'::interval, conditions_summary_1.bucket));
 
 \set ON_ERROR_STOP 1
 \set VERBOSITY terse
+-- Check for incorrect CAGGs
+\if :INTERVAL_TEST
+  INSERT INTO conditions ("time", temperature, device_id) VALUES ('2022-01-01 00:00:00-00', 10, 4);
+  INSERT INTO conditions ("time", temperature, device_id) VALUES ('2022-01-15 01:00:00-00', 20, 4);
+  INSERT INTO conditions ("time", temperature, device_id) VALUES ('2022-01-31 01:00:00-00', 30, 4);
+  CALL refresh_continuous_aggregate(:'CAGG_NAME_1ST_LEVEL', NULL, NULL);
+  CALL refresh_continuous_aggregate(:'CAGG_NAME_2TH_LEVEL', NULL, NULL);
+  CREATE MATERIALIZED VIEW :CAGG_NAME_3TH_LEVEL
+  WITH (timescaledb.continuous) AS
+  SELECT
+    \if :IS_TIME_DIMENSION_WITH_TIMEZONE_2TH
+      time_bucket(:BUCKET_WIDTH_3TH, "bucket", :'BUCKET_TZNAME_2TH') AS bucket
+    \else
+      time_bucket(:BUCKET_WIDTH_3TH, "bucket") AS bucket
+    \endif
+  FROM :CAGG_NAME_2TH_LEVEL
+  GROUP BY 1
+  WITH DATA;
+  \d+ :CAGG_NAME_3TH_LEVEL
+  --There should never be dulpicates in the output of the following query
+  SELECT * from :CAGG_NAME_3TH_LEVEL;
+  DROP MATERIALIZED VIEW IF EXISTS :CAGG_NAME_3TH_LEVEL;
+  DELETE FROM conditions WHERE device_id = 4;
+\endif
 --
 -- Cleanup
 --
@@ -4473,6 +5462,7 @@ DROP MATERIALIZED VIEW IF EXISTS :CAGG_NAME_1ST_LEVEL;
 -- LICENSE-TIMESCALE for a copy of the license.
 \set CAGG_NAME_1ST_LEVEL conditions_summary_1
 \set CAGG_NAME_2TH_LEVEL conditions_summary_2
+\set CAGG_NAME_3TH_LEVEL conditions_summary_3
 --
 -- CAGG on hypertable (1st level)
 --
@@ -4495,15 +5485,15 @@ WITH NO DATA;
  bucket      | timestamp with time zone |           |          |         | plain   | 
  temperature | numeric                  |           |          |         | main    | 
 View definition:
- SELECT _materialized_hypertable_60.bucket,
-    _materialized_hypertable_60.temperature
-   FROM _timescaledb_internal._materialized_hypertable_60
-  WHERE _materialized_hypertable_60.bucket < COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(60)), '-infinity'::timestamp with time zone)
+ SELECT _materialized_hypertable_69.bucket,
+    _materialized_hypertable_69.temperature
+   FROM _timescaledb_internal._materialized_hypertable_69
+  WHERE _materialized_hypertable_69.bucket < COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(69)), '-infinity'::timestamp with time zone)
 UNION ALL
  SELECT time_bucket('@ 9.344 secs'::interval, conditions."time") AS bucket,
     sum(conditions.temperature) AS temperature
    FROM conditions
-  WHERE conditions."time" >= COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(60)), '-infinity'::timestamp with time zone)
+  WHERE conditions."time" >= COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(69)), '-infinity'::timestamp with time zone)
   GROUP BY (time_bucket('@ 9.344 secs'::interval, conditions."time"));
 
 --
@@ -4532,19 +5522,43 @@ WITH NO DATA;
  bucket      | timestamp with time zone |           |          |         | plain   | 
  temperature | numeric                  |           |          |         | main    | 
 View definition:
- SELECT _materialized_hypertable_61.bucket,
-    _materialized_hypertable_61.temperature
-   FROM _timescaledb_internal._materialized_hypertable_61
-  WHERE _materialized_hypertable_61.bucket < COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(61)), '-infinity'::timestamp with time zone)
+ SELECT _materialized_hypertable_70.bucket,
+    _materialized_hypertable_70.temperature
+   FROM _timescaledb_internal._materialized_hypertable_70
+  WHERE _materialized_hypertable_70.bucket < COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(70)), '-infinity'::timestamp with time zone)
 UNION ALL
  SELECT time_bucket('@ 1 min 14.752 secs'::interval, conditions_summary_1.bucket) AS bucket,
     sum(conditions_summary_1.temperature) AS temperature
    FROM conditions_summary_1
-  WHERE conditions_summary_1.bucket >= COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(61)), '-infinity'::timestamp with time zone)
+  WHERE conditions_summary_1.bucket >= COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(70)), '-infinity'::timestamp with time zone)
   GROUP BY (time_bucket('@ 1 min 14.752 secs'::interval, conditions_summary_1.bucket));
 
 \set ON_ERROR_STOP 1
 \set VERBOSITY terse
+-- Check for incorrect CAGGs
+\if :INTERVAL_TEST
+  INSERT INTO conditions ("time", temperature, device_id) VALUES ('2022-01-01 00:00:00-00', 10, 4);
+  INSERT INTO conditions ("time", temperature, device_id) VALUES ('2022-01-15 01:00:00-00', 20, 4);
+  INSERT INTO conditions ("time", temperature, device_id) VALUES ('2022-01-31 01:00:00-00', 30, 4);
+  CALL refresh_continuous_aggregate(:'CAGG_NAME_1ST_LEVEL', NULL, NULL);
+  CALL refresh_continuous_aggregate(:'CAGG_NAME_2TH_LEVEL', NULL, NULL);
+  CREATE MATERIALIZED VIEW :CAGG_NAME_3TH_LEVEL
+  WITH (timescaledb.continuous) AS
+  SELECT
+    \if :IS_TIME_DIMENSION_WITH_TIMEZONE_2TH
+      time_bucket(:BUCKET_WIDTH_3TH, "bucket", :'BUCKET_TZNAME_2TH') AS bucket
+    \else
+      time_bucket(:BUCKET_WIDTH_3TH, "bucket") AS bucket
+    \endif
+  FROM :CAGG_NAME_2TH_LEVEL
+  GROUP BY 1
+  WITH DATA;
+  \d+ :CAGG_NAME_3TH_LEVEL
+  --There should never be dulpicates in the output of the following query
+  SELECT * from :CAGG_NAME_3TH_LEVEL;
+  DROP MATERIALIZED VIEW IF EXISTS :CAGG_NAME_3TH_LEVEL;
+  DELETE FROM conditions WHERE device_id = 4;
+\endif
 --
 -- Cleanup
 --
@@ -4558,6 +5572,7 @@ DROP MATERIALIZED VIEW IF EXISTS :CAGG_NAME_1ST_LEVEL;
 -- LICENSE-TIMESCALE for a copy of the license.
 \set CAGG_NAME_1ST_LEVEL conditions_summary_1
 \set CAGG_NAME_2TH_LEVEL conditions_summary_2
+\set CAGG_NAME_3TH_LEVEL conditions_summary_3
 --
 -- CAGG on hypertable (1st level)
 --
@@ -4580,15 +5595,15 @@ WITH NO DATA;
  bucket      | timestamp with time zone |           |          |         | plain   | 
  temperature | numeric                  |           |          |         | main    | 
 View definition:
- SELECT _materialized_hypertable_62.bucket,
-    _materialized_hypertable_62.temperature
-   FROM _timescaledb_internal._materialized_hypertable_62
-  WHERE _materialized_hypertable_62.bucket < COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(62)), '-infinity'::timestamp with time zone)
+ SELECT _materialized_hypertable_71.bucket,
+    _materialized_hypertable_71.temperature
+   FROM _timescaledb_internal._materialized_hypertable_71
+  WHERE _materialized_hypertable_71.bucket < COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(71)), '-infinity'::timestamp with time zone)
 UNION ALL
  SELECT time_bucket('@ 1 min 14.752 secs'::interval, conditions."time") AS bucket,
     sum(conditions.temperature) AS temperature
    FROM conditions
-  WHERE conditions."time" >= COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(62)), '-infinity'::timestamp with time zone)
+  WHERE conditions."time" >= COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(71)), '-infinity'::timestamp with time zone)
   GROUP BY (time_bucket('@ 1 min 14.752 secs'::interval, conditions."time"));
 
 --
@@ -4617,19 +5632,43 @@ WITH NO DATA;
  bucket      | timestamp with time zone |           |          |         | plain   | 
  temperature | numeric                  |           |          |         | main    | 
 View definition:
- SELECT _materialized_hypertable_63.bucket,
-    _materialized_hypertable_63.temperature
-   FROM _timescaledb_internal._materialized_hypertable_63
-  WHERE _materialized_hypertable_63.bucket < COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(63)), '-infinity'::timestamp with time zone)
+ SELECT _materialized_hypertable_72.bucket,
+    _materialized_hypertable_72.temperature
+   FROM _timescaledb_internal._materialized_hypertable_72
+  WHERE _materialized_hypertable_72.bucket < COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(72)), '-infinity'::timestamp with time zone)
 UNION ALL
  SELECT time_bucket('@ 9 mins 58.016 secs'::interval, conditions_summary_1.bucket) AS bucket,
     sum(conditions_summary_1.temperature) AS temperature
    FROM conditions_summary_1
-  WHERE conditions_summary_1.bucket >= COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(63)), '-infinity'::timestamp with time zone)
+  WHERE conditions_summary_1.bucket >= COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(72)), '-infinity'::timestamp with time zone)
   GROUP BY (time_bucket('@ 9 mins 58.016 secs'::interval, conditions_summary_1.bucket));
 
 \set ON_ERROR_STOP 1
 \set VERBOSITY terse
+-- Check for incorrect CAGGs
+\if :INTERVAL_TEST
+  INSERT INTO conditions ("time", temperature, device_id) VALUES ('2022-01-01 00:00:00-00', 10, 4);
+  INSERT INTO conditions ("time", temperature, device_id) VALUES ('2022-01-15 01:00:00-00', 20, 4);
+  INSERT INTO conditions ("time", temperature, device_id) VALUES ('2022-01-31 01:00:00-00', 30, 4);
+  CALL refresh_continuous_aggregate(:'CAGG_NAME_1ST_LEVEL', NULL, NULL);
+  CALL refresh_continuous_aggregate(:'CAGG_NAME_2TH_LEVEL', NULL, NULL);
+  CREATE MATERIALIZED VIEW :CAGG_NAME_3TH_LEVEL
+  WITH (timescaledb.continuous) AS
+  SELECT
+    \if :IS_TIME_DIMENSION_WITH_TIMEZONE_2TH
+      time_bucket(:BUCKET_WIDTH_3TH, "bucket", :'BUCKET_TZNAME_2TH') AS bucket
+    \else
+      time_bucket(:BUCKET_WIDTH_3TH, "bucket") AS bucket
+    \endif
+  FROM :CAGG_NAME_2TH_LEVEL
+  GROUP BY 1
+  WITH DATA;
+  \d+ :CAGG_NAME_3TH_LEVEL
+  --There should never be dulpicates in the output of the following query
+  SELECT * from :CAGG_NAME_3TH_LEVEL;
+  DROP MATERIALIZED VIEW IF EXISTS :CAGG_NAME_3TH_LEVEL;
+  DELETE FROM conditions WHERE device_id = 4;
+\endif
 --
 -- Cleanup
 --
@@ -4644,6 +5683,7 @@ DROP MATERIALIZED VIEW IF EXISTS :CAGG_NAME_1ST_LEVEL;
 -- LICENSE-TIMESCALE for a copy of the license.
 \set CAGG_NAME_1ST_LEVEL conditions_summary_1
 \set CAGG_NAME_2TH_LEVEL conditions_summary_2
+\set CAGG_NAME_3TH_LEVEL conditions_summary_3
 --
 -- CAGG on hypertable (1st level)
 --
@@ -4666,15 +5706,15 @@ WITH NO DATA;
  bucket      | timestamp with time zone |           |          |         | plain   | 
  temperature | numeric                  |           |          |         | main    | 
 View definition:
- SELECT _materialized_hypertable_64.bucket,
-    _materialized_hypertable_64.temperature
-   FROM _timescaledb_internal._materialized_hypertable_64
-  WHERE _materialized_hypertable_64.bucket < COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(64)), '-infinity'::timestamp with time zone)
+ SELECT _materialized_hypertable_73.bucket,
+    _materialized_hypertable_73.temperature
+   FROM _timescaledb_internal._materialized_hypertable_73
+  WHERE _materialized_hypertable_73.bucket < COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(73)), '-infinity'::timestamp with time zone)
 UNION ALL
  SELECT time_bucket('@ 0.000146 secs'::interval, conditions."time") AS bucket,
     sum(conditions.temperature) AS temperature
    FROM conditions
-  WHERE conditions."time" >= COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(64)), '-infinity'::timestamp with time zone)
+  WHERE conditions."time" >= COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(73)), '-infinity'::timestamp with time zone)
   GROUP BY (time_bucket('@ 0.000146 secs'::interval, conditions."time"));
 
 --
@@ -4703,19 +5743,43 @@ WITH NO DATA;
  bucket      | timestamp with time zone |           |          |         | plain   | 
  temperature | numeric                  |           |          |         | main    | 
 View definition:
- SELECT _materialized_hypertable_65.bucket,
-    _materialized_hypertable_65.temperature
-   FROM _timescaledb_internal._materialized_hypertable_65
-  WHERE _materialized_hypertable_65.bucket < COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(65)), '-infinity'::timestamp with time zone)
+ SELECT _materialized_hypertable_74.bucket,
+    _materialized_hypertable_74.temperature
+   FROM _timescaledb_internal._materialized_hypertable_74
+  WHERE _materialized_hypertable_74.bucket < COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(74)), '-infinity'::timestamp with time zone)
 UNION ALL
  SELECT time_bucket('@ 0.001168 secs'::interval, conditions_summary_1.bucket) AS bucket,
     sum(conditions_summary_1.temperature) AS temperature
    FROM conditions_summary_1
-  WHERE conditions_summary_1.bucket >= COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(65)), '-infinity'::timestamp with time zone)
+  WHERE conditions_summary_1.bucket >= COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(74)), '-infinity'::timestamp with time zone)
   GROUP BY (time_bucket('@ 0.001168 secs'::interval, conditions_summary_1.bucket));
 
 \set ON_ERROR_STOP 1
 \set VERBOSITY terse
+-- Check for incorrect CAGGs
+\if :INTERVAL_TEST
+  INSERT INTO conditions ("time", temperature, device_id) VALUES ('2022-01-01 00:00:00-00', 10, 4);
+  INSERT INTO conditions ("time", temperature, device_id) VALUES ('2022-01-15 01:00:00-00', 20, 4);
+  INSERT INTO conditions ("time", temperature, device_id) VALUES ('2022-01-31 01:00:00-00', 30, 4);
+  CALL refresh_continuous_aggregate(:'CAGG_NAME_1ST_LEVEL', NULL, NULL);
+  CALL refresh_continuous_aggregate(:'CAGG_NAME_2TH_LEVEL', NULL, NULL);
+  CREATE MATERIALIZED VIEW :CAGG_NAME_3TH_LEVEL
+  WITH (timescaledb.continuous) AS
+  SELECT
+    \if :IS_TIME_DIMENSION_WITH_TIMEZONE_2TH
+      time_bucket(:BUCKET_WIDTH_3TH, "bucket", :'BUCKET_TZNAME_2TH') AS bucket
+    \else
+      time_bucket(:BUCKET_WIDTH_3TH, "bucket") AS bucket
+    \endif
+  FROM :CAGG_NAME_2TH_LEVEL
+  GROUP BY 1
+  WITH DATA;
+  \d+ :CAGG_NAME_3TH_LEVEL
+  --There should never be dulpicates in the output of the following query
+  SELECT * from :CAGG_NAME_3TH_LEVEL;
+  DROP MATERIALIZED VIEW IF EXISTS :CAGG_NAME_3TH_LEVEL;
+  DELETE FROM conditions WHERE device_id = 4;
+\endif
 --
 -- Cleanup
 --
@@ -4730,6 +5794,7 @@ DROP MATERIALIZED VIEW IF EXISTS :CAGG_NAME_1ST_LEVEL;
 -- LICENSE-TIMESCALE for a copy of the license.
 \set CAGG_NAME_1ST_LEVEL conditions_summary_1
 \set CAGG_NAME_2TH_LEVEL conditions_summary_2
+\set CAGG_NAME_3TH_LEVEL conditions_summary_3
 --
 -- CAGG on hypertable (1st level)
 --
@@ -4752,15 +5817,15 @@ WITH NO DATA;
  bucket      | timestamp with time zone |           |          |         | plain   | 
  temperature | numeric                  |           |          |         | main    | 
 View definition:
- SELECT _materialized_hypertable_66.bucket,
-    _materialized_hypertable_66.temperature
-   FROM _timescaledb_internal._materialized_hypertable_66
-  WHERE _materialized_hypertable_66.bucket < COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(66)), '-infinity'::timestamp with time zone)
+ SELECT _materialized_hypertable_75.bucket,
+    _materialized_hypertable_75.temperature
+   FROM _timescaledb_internal._materialized_hypertable_75
+  WHERE _materialized_hypertable_75.bucket < COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(75)), '-infinity'::timestamp with time zone)
 UNION ALL
  SELECT time_bucket('@ 0.000146 secs'::interval, conditions."time") AS bucket,
     sum(conditions.temperature) AS temperature
    FROM conditions
-  WHERE conditions."time" >= COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(66)), '-infinity'::timestamp with time zone)
+  WHERE conditions."time" >= COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(75)), '-infinity'::timestamp with time zone)
   GROUP BY (time_bucket('@ 0.000146 secs'::interval, conditions."time"));
 
 --
@@ -4782,16 +5847,40 @@ SELECT
 FROM :CAGG_NAME_1ST_LEVEL
 GROUP BY 1
 WITH NO DATA;
-psql:include/cagg_on_cagg_validations.sql:43: ERROR:  cannot create continuous aggregate with incompatible bucket width
+psql:include/cagg_on_cagg_validations.sql:44: ERROR:  cannot create continuous aggregate with incompatible bucket width
 DETAIL:  Time bucket width of "public.conditions_summary_2" [@ 0.00116 secs] should be multiple of the time bucket width of "public.conditions_summary_1" [@ 0.000146 secs].
 \d+ :CAGG_NAME_2TH_LEVEL
 \set ON_ERROR_STOP 1
 \set VERBOSITY terse
+-- Check for incorrect CAGGs
+\if :INTERVAL_TEST
+  INSERT INTO conditions ("time", temperature, device_id) VALUES ('2022-01-01 00:00:00-00', 10, 4);
+  INSERT INTO conditions ("time", temperature, device_id) VALUES ('2022-01-15 01:00:00-00', 20, 4);
+  INSERT INTO conditions ("time", temperature, device_id) VALUES ('2022-01-31 01:00:00-00', 30, 4);
+  CALL refresh_continuous_aggregate(:'CAGG_NAME_1ST_LEVEL', NULL, NULL);
+  CALL refresh_continuous_aggregate(:'CAGG_NAME_2TH_LEVEL', NULL, NULL);
+  CREATE MATERIALIZED VIEW :CAGG_NAME_3TH_LEVEL
+  WITH (timescaledb.continuous) AS
+  SELECT
+    \if :IS_TIME_DIMENSION_WITH_TIMEZONE_2TH
+      time_bucket(:BUCKET_WIDTH_3TH, "bucket", :'BUCKET_TZNAME_2TH') AS bucket
+    \else
+      time_bucket(:BUCKET_WIDTH_3TH, "bucket") AS bucket
+    \endif
+  FROM :CAGG_NAME_2TH_LEVEL
+  GROUP BY 1
+  WITH DATA;
+  \d+ :CAGG_NAME_3TH_LEVEL
+  --There should never be dulpicates in the output of the following query
+  SELECT * from :CAGG_NAME_3TH_LEVEL;
+  DROP MATERIALIZED VIEW IF EXISTS :CAGG_NAME_3TH_LEVEL;
+  DELETE FROM conditions WHERE device_id = 4;
+\endif
 --
 -- Cleanup
 --
 DROP MATERIALIZED VIEW IF EXISTS :CAGG_NAME_2TH_LEVEL;
-psql:include/cagg_on_cagg_validations.sql:53: NOTICE:  materialized view "conditions_summary_2" does not exist, skipping
+psql:include/cagg_on_cagg_validations.sql:86: NOTICE:  materialized view "conditions_summary_2" does not exist, skipping
 DROP MATERIALIZED VIEW IF EXISTS :CAGG_NAME_1ST_LEVEL;
 -- Cleanup
 \c :TEST_DBNAME :ROLE_CLUSTER_SUPERUSER;

--- a/tsl/test/expected/cagg_on_cagg_joins.out
+++ b/tsl/test/expected/cagg_on_cagg_joins.out
@@ -6,6 +6,7 @@
 \set IS_TIME_DIMENSION_WITH_TIMEZONE_1ST FALSE
 \set IS_TIME_DIMENSION_WITH_TIMEZONE_2TH FALSE
 \set IS_JOIN TRUE
+\set INTERVAL_TEST FALSE
 -- ########################################################
 -- ## INTEGER data type tests
 -- ########################################################
@@ -891,6 +892,7 @@ psql:include/cagg_on_cagg_common.sql:200: ERROR:  relation "conditions_summary_1
 -- LICENSE-TIMESCALE for a copy of the license.
 \set CAGG_NAME_1ST_LEVEL conditions_summary_1
 \set CAGG_NAME_2TH_LEVEL conditions_summary_2
+\set CAGG_NAME_3TH_LEVEL conditions_summary_3
 --
 -- CAGG on hypertable (1st level)
 --
@@ -943,16 +945,40 @@ SELECT
 FROM :CAGG_NAME_1ST_LEVEL
 GROUP BY 1
 WITH NO DATA;
-psql:include/cagg_on_cagg_validations.sql:43: ERROR:  cannot create continuous aggregate with incompatible bucket width
+psql:include/cagg_on_cagg_validations.sql:44: ERROR:  cannot create continuous aggregate with incompatible bucket width
 DETAIL:  Time bucket width of "public.conditions_summary_2" [5] should be multiple of the time bucket width of "public.conditions_summary_1" [2].
 \d+ :CAGG_NAME_2TH_LEVEL
 \set ON_ERROR_STOP 1
 \set VERBOSITY terse
+-- Check for incorrect CAGGs
+\if :INTERVAL_TEST
+  INSERT INTO conditions ("time", temperature, device_id) VALUES ('2022-01-01 00:00:00-00', 10, 4);
+  INSERT INTO conditions ("time", temperature, device_id) VALUES ('2022-01-15 01:00:00-00', 20, 4);
+  INSERT INTO conditions ("time", temperature, device_id) VALUES ('2022-01-31 01:00:00-00', 30, 4);
+  CALL refresh_continuous_aggregate(:'CAGG_NAME_1ST_LEVEL', NULL, NULL);
+  CALL refresh_continuous_aggregate(:'CAGG_NAME_2TH_LEVEL', NULL, NULL);
+  CREATE MATERIALIZED VIEW :CAGG_NAME_3TH_LEVEL
+  WITH (timescaledb.continuous) AS
+  SELECT
+    \if :IS_TIME_DIMENSION_WITH_TIMEZONE_2TH
+      time_bucket(:BUCKET_WIDTH_3TH, "bucket", :'BUCKET_TZNAME_2TH') AS bucket
+    \else
+      time_bucket(:BUCKET_WIDTH_3TH, "bucket") AS bucket
+    \endif
+  FROM :CAGG_NAME_2TH_LEVEL
+  GROUP BY 1
+  WITH DATA;
+  \d+ :CAGG_NAME_3TH_LEVEL
+  --There should never be dulpicates in the output of the following query
+  SELECT * from :CAGG_NAME_3TH_LEVEL;
+  DROP MATERIALIZED VIEW IF EXISTS :CAGG_NAME_3TH_LEVEL;
+  DELETE FROM conditions WHERE device_id = 4;
+\endif
 --
 -- Cleanup
 --
 DROP MATERIALIZED VIEW IF EXISTS :CAGG_NAME_2TH_LEVEL;
-psql:include/cagg_on_cagg_validations.sql:53: NOTICE:  materialized view "conditions_summary_2" does not exist, skipping
+psql:include/cagg_on_cagg_validations.sql:86: NOTICE:  materialized view "conditions_summary_2" does not exist, skipping
 DROP MATERIALIZED VIEW IF EXISTS :CAGG_NAME_1ST_LEVEL;
 --
 -- Validation test for equal bucket sizes
@@ -967,6 +993,7 @@ DROP MATERIALIZED VIEW IF EXISTS :CAGG_NAME_1ST_LEVEL;
 -- LICENSE-TIMESCALE for a copy of the license.
 \set CAGG_NAME_1ST_LEVEL conditions_summary_1
 \set CAGG_NAME_2TH_LEVEL conditions_summary_2
+\set CAGG_NAME_3TH_LEVEL conditions_summary_3
 --
 -- CAGG on hypertable (1st level)
 --
@@ -1039,6 +1066,30 @@ UNION ALL
 
 \set ON_ERROR_STOP 1
 \set VERBOSITY terse
+-- Check for incorrect CAGGs
+\if :INTERVAL_TEST
+  INSERT INTO conditions ("time", temperature, device_id) VALUES ('2022-01-01 00:00:00-00', 10, 4);
+  INSERT INTO conditions ("time", temperature, device_id) VALUES ('2022-01-15 01:00:00-00', 20, 4);
+  INSERT INTO conditions ("time", temperature, device_id) VALUES ('2022-01-31 01:00:00-00', 30, 4);
+  CALL refresh_continuous_aggregate(:'CAGG_NAME_1ST_LEVEL', NULL, NULL);
+  CALL refresh_continuous_aggregate(:'CAGG_NAME_2TH_LEVEL', NULL, NULL);
+  CREATE MATERIALIZED VIEW :CAGG_NAME_3TH_LEVEL
+  WITH (timescaledb.continuous) AS
+  SELECT
+    \if :IS_TIME_DIMENSION_WITH_TIMEZONE_2TH
+      time_bucket(:BUCKET_WIDTH_3TH, "bucket", :'BUCKET_TZNAME_2TH') AS bucket
+    \else
+      time_bucket(:BUCKET_WIDTH_3TH, "bucket") AS bucket
+    \endif
+  FROM :CAGG_NAME_2TH_LEVEL
+  GROUP BY 1
+  WITH DATA;
+  \d+ :CAGG_NAME_3TH_LEVEL
+  --There should never be dulpicates in the output of the following query
+  SELECT * from :CAGG_NAME_3TH_LEVEL;
+  DROP MATERIALIZED VIEW IF EXISTS :CAGG_NAME_3TH_LEVEL;
+  DELETE FROM conditions WHERE device_id = 4;
+\endif
 --
 -- Cleanup
 --
@@ -1057,6 +1108,7 @@ DROP MATERIALIZED VIEW IF EXISTS :CAGG_NAME_1ST_LEVEL;
 -- LICENSE-TIMESCALE for a copy of the license.
 \set CAGG_NAME_1ST_LEVEL conditions_summary_1
 \set CAGG_NAME_2TH_LEVEL conditions_summary_2
+\set CAGG_NAME_3TH_LEVEL conditions_summary_3
 --
 -- CAGG on hypertable (1st level)
 --
@@ -1109,16 +1161,40 @@ SELECT
 FROM :CAGG_NAME_1ST_LEVEL
 GROUP BY 1
 WITH NO DATA;
-psql:include/cagg_on_cagg_validations.sql:43: ERROR:  cannot create continuous aggregate with incompatible bucket width
+psql:include/cagg_on_cagg_validations.sql:44: ERROR:  cannot create continuous aggregate with incompatible bucket width
 DETAIL:  Time bucket width of "public.conditions_summary_2" [2] should be greater or equal than the time bucket width of "public.conditions_summary_1" [4].
 \d+ :CAGG_NAME_2TH_LEVEL
 \set ON_ERROR_STOP 1
 \set VERBOSITY terse
+-- Check for incorrect CAGGs
+\if :INTERVAL_TEST
+  INSERT INTO conditions ("time", temperature, device_id) VALUES ('2022-01-01 00:00:00-00', 10, 4);
+  INSERT INTO conditions ("time", temperature, device_id) VALUES ('2022-01-15 01:00:00-00', 20, 4);
+  INSERT INTO conditions ("time", temperature, device_id) VALUES ('2022-01-31 01:00:00-00', 30, 4);
+  CALL refresh_continuous_aggregate(:'CAGG_NAME_1ST_LEVEL', NULL, NULL);
+  CALL refresh_continuous_aggregate(:'CAGG_NAME_2TH_LEVEL', NULL, NULL);
+  CREATE MATERIALIZED VIEW :CAGG_NAME_3TH_LEVEL
+  WITH (timescaledb.continuous) AS
+  SELECT
+    \if :IS_TIME_DIMENSION_WITH_TIMEZONE_2TH
+      time_bucket(:BUCKET_WIDTH_3TH, "bucket", :'BUCKET_TZNAME_2TH') AS bucket
+    \else
+      time_bucket(:BUCKET_WIDTH_3TH, "bucket") AS bucket
+    \endif
+  FROM :CAGG_NAME_2TH_LEVEL
+  GROUP BY 1
+  WITH DATA;
+  \d+ :CAGG_NAME_3TH_LEVEL
+  --There should never be dulpicates in the output of the following query
+  SELECT * from :CAGG_NAME_3TH_LEVEL;
+  DROP MATERIALIZED VIEW IF EXISTS :CAGG_NAME_3TH_LEVEL;
+  DELETE FROM conditions WHERE device_id = 4;
+\endif
 --
 -- Cleanup
 --
 DROP MATERIALIZED VIEW IF EXISTS :CAGG_NAME_2TH_LEVEL;
-psql:include/cagg_on_cagg_validations.sql:53: NOTICE:  materialized view "conditions_summary_2" does not exist, skipping
+psql:include/cagg_on_cagg_validations.sql:86: NOTICE:  materialized view "conditions_summary_2" does not exist, skipping
 DROP MATERIALIZED VIEW IF EXISTS :CAGG_NAME_1ST_LEVEL;
 -- ########################################################
 -- ## TIMESTAMP data type tests
@@ -1996,6 +2072,7 @@ psql:include/cagg_on_cagg_common.sql:200: ERROR:  relation "conditions_summary_1
 -- LICENSE-TIMESCALE for a copy of the license.
 \set CAGG_NAME_1ST_LEVEL conditions_summary_1
 \set CAGG_NAME_2TH_LEVEL conditions_summary_2
+\set CAGG_NAME_3TH_LEVEL conditions_summary_3
 --
 -- CAGG on hypertable (1st level)
 --
@@ -2048,17 +2125,41 @@ SELECT
 FROM :CAGG_NAME_1ST_LEVEL
 GROUP BY 1
 WITH NO DATA;
-psql:include/cagg_on_cagg_validations.sql:43: ERROR:  cannot create continuous aggregate with fixed-width bucket on top of one using variable-width bucket
+psql:include/cagg_on_cagg_validations.sql:44: ERROR:  cannot create continuous aggregate with fixed-width bucket on top of one using variable-width bucket
 DETAIL:  Continuous aggregate with a fixed time bucket width (e.g. 61 days) cannot be created on top of one using variable time bucket width (e.g. 1 month).
 The variance can lead to the fixed width one not being a multiple of the variable width one.
 \d+ :CAGG_NAME_2TH_LEVEL
 \set ON_ERROR_STOP 1
 \set VERBOSITY terse
+-- Check for incorrect CAGGs
+\if :INTERVAL_TEST
+  INSERT INTO conditions ("time", temperature, device_id) VALUES ('2022-01-01 00:00:00-00', 10, 4);
+  INSERT INTO conditions ("time", temperature, device_id) VALUES ('2022-01-15 01:00:00-00', 20, 4);
+  INSERT INTO conditions ("time", temperature, device_id) VALUES ('2022-01-31 01:00:00-00', 30, 4);
+  CALL refresh_continuous_aggregate(:'CAGG_NAME_1ST_LEVEL', NULL, NULL);
+  CALL refresh_continuous_aggregate(:'CAGG_NAME_2TH_LEVEL', NULL, NULL);
+  CREATE MATERIALIZED VIEW :CAGG_NAME_3TH_LEVEL
+  WITH (timescaledb.continuous) AS
+  SELECT
+    \if :IS_TIME_DIMENSION_WITH_TIMEZONE_2TH
+      time_bucket(:BUCKET_WIDTH_3TH, "bucket", :'BUCKET_TZNAME_2TH') AS bucket
+    \else
+      time_bucket(:BUCKET_WIDTH_3TH, "bucket") AS bucket
+    \endif
+  FROM :CAGG_NAME_2TH_LEVEL
+  GROUP BY 1
+  WITH DATA;
+  \d+ :CAGG_NAME_3TH_LEVEL
+  --There should never be dulpicates in the output of the following query
+  SELECT * from :CAGG_NAME_3TH_LEVEL;
+  DROP MATERIALIZED VIEW IF EXISTS :CAGG_NAME_3TH_LEVEL;
+  DELETE FROM conditions WHERE device_id = 4;
+\endif
 --
 -- Cleanup
 --
 DROP MATERIALIZED VIEW IF EXISTS :CAGG_NAME_2TH_LEVEL;
-psql:include/cagg_on_cagg_validations.sql:53: NOTICE:  materialized view "conditions_summary_2" does not exist, skipping
+psql:include/cagg_on_cagg_validations.sql:86: NOTICE:  materialized view "conditions_summary_2" does not exist, skipping
 DROP MATERIALIZED VIEW IF EXISTS :CAGG_NAME_1ST_LEVEL;
 --
 -- Validation test for non-multiple bucket sizes
@@ -2073,6 +2174,7 @@ DROP MATERIALIZED VIEW IF EXISTS :CAGG_NAME_1ST_LEVEL;
 -- LICENSE-TIMESCALE for a copy of the license.
 \set CAGG_NAME_1ST_LEVEL conditions_summary_1
 \set CAGG_NAME_2TH_LEVEL conditions_summary_2
+\set CAGG_NAME_3TH_LEVEL conditions_summary_3
 --
 -- CAGG on hypertable (1st level)
 --
@@ -2125,16 +2227,40 @@ SELECT
 FROM :CAGG_NAME_1ST_LEVEL
 GROUP BY 1
 WITH NO DATA;
-psql:include/cagg_on_cagg_validations.sql:43: ERROR:  cannot create continuous aggregate with incompatible bucket width
+psql:include/cagg_on_cagg_validations.sql:44: ERROR:  cannot create continuous aggregate with incompatible bucket width
 DETAIL:  Time bucket width of "public.conditions_summary_2" [@ 3 hours] should be multiple of the time bucket width of "public.conditions_summary_1" [@ 2 hours].
 \d+ :CAGG_NAME_2TH_LEVEL
 \set ON_ERROR_STOP 1
 \set VERBOSITY terse
+-- Check for incorrect CAGGs
+\if :INTERVAL_TEST
+  INSERT INTO conditions ("time", temperature, device_id) VALUES ('2022-01-01 00:00:00-00', 10, 4);
+  INSERT INTO conditions ("time", temperature, device_id) VALUES ('2022-01-15 01:00:00-00', 20, 4);
+  INSERT INTO conditions ("time", temperature, device_id) VALUES ('2022-01-31 01:00:00-00', 30, 4);
+  CALL refresh_continuous_aggregate(:'CAGG_NAME_1ST_LEVEL', NULL, NULL);
+  CALL refresh_continuous_aggregate(:'CAGG_NAME_2TH_LEVEL', NULL, NULL);
+  CREATE MATERIALIZED VIEW :CAGG_NAME_3TH_LEVEL
+  WITH (timescaledb.continuous) AS
+  SELECT
+    \if :IS_TIME_DIMENSION_WITH_TIMEZONE_2TH
+      time_bucket(:BUCKET_WIDTH_3TH, "bucket", :'BUCKET_TZNAME_2TH') AS bucket
+    \else
+      time_bucket(:BUCKET_WIDTH_3TH, "bucket") AS bucket
+    \endif
+  FROM :CAGG_NAME_2TH_LEVEL
+  GROUP BY 1
+  WITH DATA;
+  \d+ :CAGG_NAME_3TH_LEVEL
+  --There should never be dulpicates in the output of the following query
+  SELECT * from :CAGG_NAME_3TH_LEVEL;
+  DROP MATERIALIZED VIEW IF EXISTS :CAGG_NAME_3TH_LEVEL;
+  DELETE FROM conditions WHERE device_id = 4;
+\endif
 --
 -- Cleanup
 --
 DROP MATERIALIZED VIEW IF EXISTS :CAGG_NAME_2TH_LEVEL;
-psql:include/cagg_on_cagg_validations.sql:53: NOTICE:  materialized view "conditions_summary_2" does not exist, skipping
+psql:include/cagg_on_cagg_validations.sql:86: NOTICE:  materialized view "conditions_summary_2" does not exist, skipping
 DROP MATERIALIZED VIEW IF EXISTS :CAGG_NAME_1ST_LEVEL;
 --
 -- Validation test for equal bucket sizes
@@ -2149,6 +2275,7 @@ DROP MATERIALIZED VIEW IF EXISTS :CAGG_NAME_1ST_LEVEL;
 -- LICENSE-TIMESCALE for a copy of the license.
 \set CAGG_NAME_1ST_LEVEL conditions_summary_1
 \set CAGG_NAME_2TH_LEVEL conditions_summary_2
+\set CAGG_NAME_3TH_LEVEL conditions_summary_3
 --
 -- CAGG on hypertable (1st level)
 --
@@ -2221,6 +2348,30 @@ UNION ALL
 
 \set ON_ERROR_STOP 1
 \set VERBOSITY terse
+-- Check for incorrect CAGGs
+\if :INTERVAL_TEST
+  INSERT INTO conditions ("time", temperature, device_id) VALUES ('2022-01-01 00:00:00-00', 10, 4);
+  INSERT INTO conditions ("time", temperature, device_id) VALUES ('2022-01-15 01:00:00-00', 20, 4);
+  INSERT INTO conditions ("time", temperature, device_id) VALUES ('2022-01-31 01:00:00-00', 30, 4);
+  CALL refresh_continuous_aggregate(:'CAGG_NAME_1ST_LEVEL', NULL, NULL);
+  CALL refresh_continuous_aggregate(:'CAGG_NAME_2TH_LEVEL', NULL, NULL);
+  CREATE MATERIALIZED VIEW :CAGG_NAME_3TH_LEVEL
+  WITH (timescaledb.continuous) AS
+  SELECT
+    \if :IS_TIME_DIMENSION_WITH_TIMEZONE_2TH
+      time_bucket(:BUCKET_WIDTH_3TH, "bucket", :'BUCKET_TZNAME_2TH') AS bucket
+    \else
+      time_bucket(:BUCKET_WIDTH_3TH, "bucket") AS bucket
+    \endif
+  FROM :CAGG_NAME_2TH_LEVEL
+  GROUP BY 1
+  WITH DATA;
+  \d+ :CAGG_NAME_3TH_LEVEL
+  --There should never be dulpicates in the output of the following query
+  SELECT * from :CAGG_NAME_3TH_LEVEL;
+  DROP MATERIALIZED VIEW IF EXISTS :CAGG_NAME_3TH_LEVEL;
+  DELETE FROM conditions WHERE device_id = 4;
+\endif
 --
 -- Cleanup
 --
@@ -2239,6 +2390,7 @@ DROP MATERIALIZED VIEW IF EXISTS :CAGG_NAME_1ST_LEVEL;
 -- LICENSE-TIMESCALE for a copy of the license.
 \set CAGG_NAME_1ST_LEVEL conditions_summary_1
 \set CAGG_NAME_2TH_LEVEL conditions_summary_2
+\set CAGG_NAME_3TH_LEVEL conditions_summary_3
 --
 -- CAGG on hypertable (1st level)
 --
@@ -2291,16 +2443,40 @@ SELECT
 FROM :CAGG_NAME_1ST_LEVEL
 GROUP BY 1
 WITH NO DATA;
-psql:include/cagg_on_cagg_validations.sql:43: ERROR:  cannot create continuous aggregate with incompatible bucket width
+psql:include/cagg_on_cagg_validations.sql:44: ERROR:  cannot create continuous aggregate with incompatible bucket width
 DETAIL:  Time bucket width of "public.conditions_summary_2" [@ 1 hour] should be greater or equal than the time bucket width of "public.conditions_summary_1" [@ 2 hours].
 \d+ :CAGG_NAME_2TH_LEVEL
 \set ON_ERROR_STOP 1
 \set VERBOSITY terse
+-- Check for incorrect CAGGs
+\if :INTERVAL_TEST
+  INSERT INTO conditions ("time", temperature, device_id) VALUES ('2022-01-01 00:00:00-00', 10, 4);
+  INSERT INTO conditions ("time", temperature, device_id) VALUES ('2022-01-15 01:00:00-00', 20, 4);
+  INSERT INTO conditions ("time", temperature, device_id) VALUES ('2022-01-31 01:00:00-00', 30, 4);
+  CALL refresh_continuous_aggregate(:'CAGG_NAME_1ST_LEVEL', NULL, NULL);
+  CALL refresh_continuous_aggregate(:'CAGG_NAME_2TH_LEVEL', NULL, NULL);
+  CREATE MATERIALIZED VIEW :CAGG_NAME_3TH_LEVEL
+  WITH (timescaledb.continuous) AS
+  SELECT
+    \if :IS_TIME_DIMENSION_WITH_TIMEZONE_2TH
+      time_bucket(:BUCKET_WIDTH_3TH, "bucket", :'BUCKET_TZNAME_2TH') AS bucket
+    \else
+      time_bucket(:BUCKET_WIDTH_3TH, "bucket") AS bucket
+    \endif
+  FROM :CAGG_NAME_2TH_LEVEL
+  GROUP BY 1
+  WITH DATA;
+  \d+ :CAGG_NAME_3TH_LEVEL
+  --There should never be dulpicates in the output of the following query
+  SELECT * from :CAGG_NAME_3TH_LEVEL;
+  DROP MATERIALIZED VIEW IF EXISTS :CAGG_NAME_3TH_LEVEL;
+  DELETE FROM conditions WHERE device_id = 4;
+\endif
 --
 -- Cleanup
 --
 DROP MATERIALIZED VIEW IF EXISTS :CAGG_NAME_2TH_LEVEL;
-psql:include/cagg_on_cagg_validations.sql:53: NOTICE:  materialized view "conditions_summary_2" does not exist, skipping
+psql:include/cagg_on_cagg_validations.sql:86: NOTICE:  materialized view "conditions_summary_2" does not exist, skipping
 DROP MATERIALIZED VIEW IF EXISTS :CAGG_NAME_1ST_LEVEL;
 -- ########################################################
 -- ## TIMESTAMPTZ data type tests
@@ -3177,6 +3353,7 @@ psql:include/cagg_on_cagg_common.sql:200: ERROR:  relation "conditions_summary_1
 -- LICENSE-TIMESCALE for a copy of the license.
 \set CAGG_NAME_1ST_LEVEL conditions_summary_1
 \set CAGG_NAME_2TH_LEVEL conditions_summary_2
+\set CAGG_NAME_3TH_LEVEL conditions_summary_3
 --
 -- CAGG on hypertable (1st level)
 --
@@ -3229,17 +3406,41 @@ SELECT
 FROM :CAGG_NAME_1ST_LEVEL
 GROUP BY 1
 WITH NO DATA;
-psql:include/cagg_on_cagg_validations.sql:43: ERROR:  cannot create continuous aggregate with fixed-width bucket on top of one using variable-width bucket
+psql:include/cagg_on_cagg_validations.sql:44: ERROR:  cannot create continuous aggregate with fixed-width bucket on top of one using variable-width bucket
 DETAIL:  Continuous aggregate with a fixed time bucket width (e.g. 61 days) cannot be created on top of one using variable time bucket width (e.g. 1 month).
 The variance can lead to the fixed width one not being a multiple of the variable width one.
 \d+ :CAGG_NAME_2TH_LEVEL
 \set ON_ERROR_STOP 1
 \set VERBOSITY terse
+-- Check for incorrect CAGGs
+\if :INTERVAL_TEST
+  INSERT INTO conditions ("time", temperature, device_id) VALUES ('2022-01-01 00:00:00-00', 10, 4);
+  INSERT INTO conditions ("time", temperature, device_id) VALUES ('2022-01-15 01:00:00-00', 20, 4);
+  INSERT INTO conditions ("time", temperature, device_id) VALUES ('2022-01-31 01:00:00-00', 30, 4);
+  CALL refresh_continuous_aggregate(:'CAGG_NAME_1ST_LEVEL', NULL, NULL);
+  CALL refresh_continuous_aggregate(:'CAGG_NAME_2TH_LEVEL', NULL, NULL);
+  CREATE MATERIALIZED VIEW :CAGG_NAME_3TH_LEVEL
+  WITH (timescaledb.continuous) AS
+  SELECT
+    \if :IS_TIME_DIMENSION_WITH_TIMEZONE_2TH
+      time_bucket(:BUCKET_WIDTH_3TH, "bucket", :'BUCKET_TZNAME_2TH') AS bucket
+    \else
+      time_bucket(:BUCKET_WIDTH_3TH, "bucket") AS bucket
+    \endif
+  FROM :CAGG_NAME_2TH_LEVEL
+  GROUP BY 1
+  WITH DATA;
+  \d+ :CAGG_NAME_3TH_LEVEL
+  --There should never be dulpicates in the output of the following query
+  SELECT * from :CAGG_NAME_3TH_LEVEL;
+  DROP MATERIALIZED VIEW IF EXISTS :CAGG_NAME_3TH_LEVEL;
+  DELETE FROM conditions WHERE device_id = 4;
+\endif
 --
 -- Cleanup
 --
 DROP MATERIALIZED VIEW IF EXISTS :CAGG_NAME_2TH_LEVEL;
-psql:include/cagg_on_cagg_validations.sql:53: NOTICE:  materialized view "conditions_summary_2" does not exist, skipping
+psql:include/cagg_on_cagg_validations.sql:86: NOTICE:  materialized view "conditions_summary_2" does not exist, skipping
 DROP MATERIALIZED VIEW IF EXISTS :CAGG_NAME_1ST_LEVEL;
 --
 -- Validation test for non-multiple bucket sizes
@@ -3254,6 +3455,7 @@ DROP MATERIALIZED VIEW IF EXISTS :CAGG_NAME_1ST_LEVEL;
 -- LICENSE-TIMESCALE for a copy of the license.
 \set CAGG_NAME_1ST_LEVEL conditions_summary_1
 \set CAGG_NAME_2TH_LEVEL conditions_summary_2
+\set CAGG_NAME_3TH_LEVEL conditions_summary_3
 --
 -- CAGG on hypertable (1st level)
 --
@@ -3306,16 +3508,40 @@ SELECT
 FROM :CAGG_NAME_1ST_LEVEL
 GROUP BY 1
 WITH NO DATA;
-psql:include/cagg_on_cagg_validations.sql:43: ERROR:  cannot create continuous aggregate with incompatible bucket width
+psql:include/cagg_on_cagg_validations.sql:44: ERROR:  cannot create continuous aggregate with incompatible bucket width
 DETAIL:  Time bucket width of "public.conditions_summary_2" [@ 3 hours] should be multiple of the time bucket width of "public.conditions_summary_1" [@ 2 hours].
 \d+ :CAGG_NAME_2TH_LEVEL
 \set ON_ERROR_STOP 1
 \set VERBOSITY terse
+-- Check for incorrect CAGGs
+\if :INTERVAL_TEST
+  INSERT INTO conditions ("time", temperature, device_id) VALUES ('2022-01-01 00:00:00-00', 10, 4);
+  INSERT INTO conditions ("time", temperature, device_id) VALUES ('2022-01-15 01:00:00-00', 20, 4);
+  INSERT INTO conditions ("time", temperature, device_id) VALUES ('2022-01-31 01:00:00-00', 30, 4);
+  CALL refresh_continuous_aggregate(:'CAGG_NAME_1ST_LEVEL', NULL, NULL);
+  CALL refresh_continuous_aggregate(:'CAGG_NAME_2TH_LEVEL', NULL, NULL);
+  CREATE MATERIALIZED VIEW :CAGG_NAME_3TH_LEVEL
+  WITH (timescaledb.continuous) AS
+  SELECT
+    \if :IS_TIME_DIMENSION_WITH_TIMEZONE_2TH
+      time_bucket(:BUCKET_WIDTH_3TH, "bucket", :'BUCKET_TZNAME_2TH') AS bucket
+    \else
+      time_bucket(:BUCKET_WIDTH_3TH, "bucket") AS bucket
+    \endif
+  FROM :CAGG_NAME_2TH_LEVEL
+  GROUP BY 1
+  WITH DATA;
+  \d+ :CAGG_NAME_3TH_LEVEL
+  --There should never be dulpicates in the output of the following query
+  SELECT * from :CAGG_NAME_3TH_LEVEL;
+  DROP MATERIALIZED VIEW IF EXISTS :CAGG_NAME_3TH_LEVEL;
+  DELETE FROM conditions WHERE device_id = 4;
+\endif
 --
 -- Cleanup
 --
 DROP MATERIALIZED VIEW IF EXISTS :CAGG_NAME_2TH_LEVEL;
-psql:include/cagg_on_cagg_validations.sql:53: NOTICE:  materialized view "conditions_summary_2" does not exist, skipping
+psql:include/cagg_on_cagg_validations.sql:86: NOTICE:  materialized view "conditions_summary_2" does not exist, skipping
 DROP MATERIALIZED VIEW IF EXISTS :CAGG_NAME_1ST_LEVEL;
 --
 -- Validation test for equal bucket sizes
@@ -3330,6 +3556,7 @@ DROP MATERIALIZED VIEW IF EXISTS :CAGG_NAME_1ST_LEVEL;
 -- LICENSE-TIMESCALE for a copy of the license.
 \set CAGG_NAME_1ST_LEVEL conditions_summary_1
 \set CAGG_NAME_2TH_LEVEL conditions_summary_2
+\set CAGG_NAME_3TH_LEVEL conditions_summary_3
 --
 -- CAGG on hypertable (1st level)
 --
@@ -3402,6 +3629,30 @@ UNION ALL
 
 \set ON_ERROR_STOP 1
 \set VERBOSITY terse
+-- Check for incorrect CAGGs
+\if :INTERVAL_TEST
+  INSERT INTO conditions ("time", temperature, device_id) VALUES ('2022-01-01 00:00:00-00', 10, 4);
+  INSERT INTO conditions ("time", temperature, device_id) VALUES ('2022-01-15 01:00:00-00', 20, 4);
+  INSERT INTO conditions ("time", temperature, device_id) VALUES ('2022-01-31 01:00:00-00', 30, 4);
+  CALL refresh_continuous_aggregate(:'CAGG_NAME_1ST_LEVEL', NULL, NULL);
+  CALL refresh_continuous_aggregate(:'CAGG_NAME_2TH_LEVEL', NULL, NULL);
+  CREATE MATERIALIZED VIEW :CAGG_NAME_3TH_LEVEL
+  WITH (timescaledb.continuous) AS
+  SELECT
+    \if :IS_TIME_DIMENSION_WITH_TIMEZONE_2TH
+      time_bucket(:BUCKET_WIDTH_3TH, "bucket", :'BUCKET_TZNAME_2TH') AS bucket
+    \else
+      time_bucket(:BUCKET_WIDTH_3TH, "bucket") AS bucket
+    \endif
+  FROM :CAGG_NAME_2TH_LEVEL
+  GROUP BY 1
+  WITH DATA;
+  \d+ :CAGG_NAME_3TH_LEVEL
+  --There should never be dulpicates in the output of the following query
+  SELECT * from :CAGG_NAME_3TH_LEVEL;
+  DROP MATERIALIZED VIEW IF EXISTS :CAGG_NAME_3TH_LEVEL;
+  DELETE FROM conditions WHERE device_id = 4;
+\endif
 --
 -- Cleanup
 --
@@ -3420,6 +3671,7 @@ DROP MATERIALIZED VIEW IF EXISTS :CAGG_NAME_1ST_LEVEL;
 -- LICENSE-TIMESCALE for a copy of the license.
 \set CAGG_NAME_1ST_LEVEL conditions_summary_1
 \set CAGG_NAME_2TH_LEVEL conditions_summary_2
+\set CAGG_NAME_3TH_LEVEL conditions_summary_3
 --
 -- CAGG on hypertable (1st level)
 --
@@ -3472,16 +3724,40 @@ SELECT
 FROM :CAGG_NAME_1ST_LEVEL
 GROUP BY 1
 WITH NO DATA;
-psql:include/cagg_on_cagg_validations.sql:43: ERROR:  cannot create continuous aggregate with incompatible bucket width
+psql:include/cagg_on_cagg_validations.sql:44: ERROR:  cannot create continuous aggregate with incompatible bucket width
 DETAIL:  Time bucket width of "public.conditions_summary_2" [@ 1 hour] should be greater or equal than the time bucket width of "public.conditions_summary_1" [@ 2 hours].
 \d+ :CAGG_NAME_2TH_LEVEL
 \set ON_ERROR_STOP 1
 \set VERBOSITY terse
+-- Check for incorrect CAGGs
+\if :INTERVAL_TEST
+  INSERT INTO conditions ("time", temperature, device_id) VALUES ('2022-01-01 00:00:00-00', 10, 4);
+  INSERT INTO conditions ("time", temperature, device_id) VALUES ('2022-01-15 01:00:00-00', 20, 4);
+  INSERT INTO conditions ("time", temperature, device_id) VALUES ('2022-01-31 01:00:00-00', 30, 4);
+  CALL refresh_continuous_aggregate(:'CAGG_NAME_1ST_LEVEL', NULL, NULL);
+  CALL refresh_continuous_aggregate(:'CAGG_NAME_2TH_LEVEL', NULL, NULL);
+  CREATE MATERIALIZED VIEW :CAGG_NAME_3TH_LEVEL
+  WITH (timescaledb.continuous) AS
+  SELECT
+    \if :IS_TIME_DIMENSION_WITH_TIMEZONE_2TH
+      time_bucket(:BUCKET_WIDTH_3TH, "bucket", :'BUCKET_TZNAME_2TH') AS bucket
+    \else
+      time_bucket(:BUCKET_WIDTH_3TH, "bucket") AS bucket
+    \endif
+  FROM :CAGG_NAME_2TH_LEVEL
+  GROUP BY 1
+  WITH DATA;
+  \d+ :CAGG_NAME_3TH_LEVEL
+  --There should never be dulpicates in the output of the following query
+  SELECT * from :CAGG_NAME_3TH_LEVEL;
+  DROP MATERIALIZED VIEW IF EXISTS :CAGG_NAME_3TH_LEVEL;
+  DELETE FROM conditions WHERE device_id = 4;
+\endif
 --
 -- Cleanup
 --
 DROP MATERIALIZED VIEW IF EXISTS :CAGG_NAME_2TH_LEVEL;
-psql:include/cagg_on_cagg_validations.sql:53: NOTICE:  materialized view "conditions_summary_2" does not exist, skipping
+psql:include/cagg_on_cagg_validations.sql:86: NOTICE:  materialized view "conditions_summary_2" does not exist, skipping
 DROP MATERIALIZED VIEW IF EXISTS :CAGG_NAME_1ST_LEVEL;
 --
 -- Validations using time bucket with timezone (ref issue #5126)
@@ -3503,6 +3779,7 @@ DROP MATERIALIZED VIEW IF EXISTS :CAGG_NAME_1ST_LEVEL;
 -- LICENSE-TIMESCALE for a copy of the license.
 \set CAGG_NAME_1ST_LEVEL conditions_summary_1
 \set CAGG_NAME_2TH_LEVEL conditions_summary_2
+\set CAGG_NAME_3TH_LEVEL conditions_summary_3
 --
 -- CAGG on hypertable (1st level)
 --
@@ -3575,6 +3852,30 @@ UNION ALL
 
 \set ON_ERROR_STOP 1
 \set VERBOSITY terse
+-- Check for incorrect CAGGs
+\if :INTERVAL_TEST
+  INSERT INTO conditions ("time", temperature, device_id) VALUES ('2022-01-01 00:00:00-00', 10, 4);
+  INSERT INTO conditions ("time", temperature, device_id) VALUES ('2022-01-15 01:00:00-00', 20, 4);
+  INSERT INTO conditions ("time", temperature, device_id) VALUES ('2022-01-31 01:00:00-00', 30, 4);
+  CALL refresh_continuous_aggregate(:'CAGG_NAME_1ST_LEVEL', NULL, NULL);
+  CALL refresh_continuous_aggregate(:'CAGG_NAME_2TH_LEVEL', NULL, NULL);
+  CREATE MATERIALIZED VIEW :CAGG_NAME_3TH_LEVEL
+  WITH (timescaledb.continuous) AS
+  SELECT
+    \if :IS_TIME_DIMENSION_WITH_TIMEZONE_2TH
+      time_bucket(:BUCKET_WIDTH_3TH, "bucket", :'BUCKET_TZNAME_2TH') AS bucket
+    \else
+      time_bucket(:BUCKET_WIDTH_3TH, "bucket") AS bucket
+    \endif
+  FROM :CAGG_NAME_2TH_LEVEL
+  GROUP BY 1
+  WITH DATA;
+  \d+ :CAGG_NAME_3TH_LEVEL
+  --There should never be dulpicates in the output of the following query
+  SELECT * from :CAGG_NAME_3TH_LEVEL;
+  DROP MATERIALIZED VIEW IF EXISTS :CAGG_NAME_3TH_LEVEL;
+  DELETE FROM conditions WHERE device_id = 4;
+\endif
 --
 -- Cleanup
 --
@@ -3589,6 +3890,7 @@ DROP MATERIALIZED VIEW IF EXISTS :CAGG_NAME_1ST_LEVEL;
 -- LICENSE-TIMESCALE for a copy of the license.
 \set CAGG_NAME_1ST_LEVEL conditions_summary_1
 \set CAGG_NAME_2TH_LEVEL conditions_summary_2
+\set CAGG_NAME_3TH_LEVEL conditions_summary_3
 --
 -- CAGG on hypertable (1st level)
 --
@@ -3641,16 +3943,40 @@ SELECT
 FROM :CAGG_NAME_1ST_LEVEL
 GROUP BY 1
 WITH NO DATA;
-psql:include/cagg_on_cagg_validations.sql:43: ERROR:  cannot create continuous aggregate with incompatible bucket width
+psql:include/cagg_on_cagg_validations.sql:44: ERROR:  cannot create continuous aggregate with incompatible bucket width
 DETAIL:  Time bucket width of "public.conditions_summary_2" [@ 16 mins] should be multiple of the time bucket width of "public.conditions_summary_1" [@ 5 mins].
 \d+ :CAGG_NAME_2TH_LEVEL
 \set ON_ERROR_STOP 1
 \set VERBOSITY terse
+-- Check for incorrect CAGGs
+\if :INTERVAL_TEST
+  INSERT INTO conditions ("time", temperature, device_id) VALUES ('2022-01-01 00:00:00-00', 10, 4);
+  INSERT INTO conditions ("time", temperature, device_id) VALUES ('2022-01-15 01:00:00-00', 20, 4);
+  INSERT INTO conditions ("time", temperature, device_id) VALUES ('2022-01-31 01:00:00-00', 30, 4);
+  CALL refresh_continuous_aggregate(:'CAGG_NAME_1ST_LEVEL', NULL, NULL);
+  CALL refresh_continuous_aggregate(:'CAGG_NAME_2TH_LEVEL', NULL, NULL);
+  CREATE MATERIALIZED VIEW :CAGG_NAME_3TH_LEVEL
+  WITH (timescaledb.continuous) AS
+  SELECT
+    \if :IS_TIME_DIMENSION_WITH_TIMEZONE_2TH
+      time_bucket(:BUCKET_WIDTH_3TH, "bucket", :'BUCKET_TZNAME_2TH') AS bucket
+    \else
+      time_bucket(:BUCKET_WIDTH_3TH, "bucket") AS bucket
+    \endif
+  FROM :CAGG_NAME_2TH_LEVEL
+  GROUP BY 1
+  WITH DATA;
+  \d+ :CAGG_NAME_3TH_LEVEL
+  --There should never be dulpicates in the output of the following query
+  SELECT * from :CAGG_NAME_3TH_LEVEL;
+  DROP MATERIALIZED VIEW IF EXISTS :CAGG_NAME_3TH_LEVEL;
+  DELETE FROM conditions WHERE device_id = 4;
+\endif
 --
 -- Cleanup
 --
 DROP MATERIALIZED VIEW IF EXISTS :CAGG_NAME_2TH_LEVEL;
-psql:include/cagg_on_cagg_validations.sql:53: NOTICE:  materialized view "conditions_summary_2" does not exist, skipping
+psql:include/cagg_on_cagg_validations.sql:86: NOTICE:  materialized view "conditions_summary_2" does not exist, skipping
 DROP MATERIALIZED VIEW IF EXISTS :CAGG_NAME_1ST_LEVEL;
 --
 -- Variable bucket size with the same timezones
@@ -3666,6 +3992,7 @@ DROP MATERIALIZED VIEW IF EXISTS :CAGG_NAME_1ST_LEVEL;
 -- LICENSE-TIMESCALE for a copy of the license.
 \set CAGG_NAME_1ST_LEVEL conditions_summary_1
 \set CAGG_NAME_2TH_LEVEL conditions_summary_2
+\set CAGG_NAME_3TH_LEVEL conditions_summary_3
 --
 -- CAGG on hypertable (1st level)
 --
@@ -3738,6 +4065,30 @@ UNION ALL
 
 \set ON_ERROR_STOP 1
 \set VERBOSITY terse
+-- Check for incorrect CAGGs
+\if :INTERVAL_TEST
+  INSERT INTO conditions ("time", temperature, device_id) VALUES ('2022-01-01 00:00:00-00', 10, 4);
+  INSERT INTO conditions ("time", temperature, device_id) VALUES ('2022-01-15 01:00:00-00', 20, 4);
+  INSERT INTO conditions ("time", temperature, device_id) VALUES ('2022-01-31 01:00:00-00', 30, 4);
+  CALL refresh_continuous_aggregate(:'CAGG_NAME_1ST_LEVEL', NULL, NULL);
+  CALL refresh_continuous_aggregate(:'CAGG_NAME_2TH_LEVEL', NULL, NULL);
+  CREATE MATERIALIZED VIEW :CAGG_NAME_3TH_LEVEL
+  WITH (timescaledb.continuous) AS
+  SELECT
+    \if :IS_TIME_DIMENSION_WITH_TIMEZONE_2TH
+      time_bucket(:BUCKET_WIDTH_3TH, "bucket", :'BUCKET_TZNAME_2TH') AS bucket
+    \else
+      time_bucket(:BUCKET_WIDTH_3TH, "bucket") AS bucket
+    \endif
+  FROM :CAGG_NAME_2TH_LEVEL
+  GROUP BY 1
+  WITH DATA;
+  \d+ :CAGG_NAME_3TH_LEVEL
+  --There should never be dulpicates in the output of the following query
+  SELECT * from :CAGG_NAME_3TH_LEVEL;
+  DROP MATERIALIZED VIEW IF EXISTS :CAGG_NAME_3TH_LEVEL;
+  DELETE FROM conditions WHERE device_id = 4;
+\endif
 --
 -- Cleanup
 --
@@ -3757,6 +4108,7 @@ DROP MATERIALIZED VIEW IF EXISTS :CAGG_NAME_1ST_LEVEL;
 -- LICENSE-TIMESCALE for a copy of the license.
 \set CAGG_NAME_1ST_LEVEL conditions_summary_1
 \set CAGG_NAME_2TH_LEVEL conditions_summary_2
+\set CAGG_NAME_3TH_LEVEL conditions_summary_3
 --
 -- CAGG on hypertable (1st level)
 --
@@ -3829,6 +4181,30 @@ UNION ALL
 
 \set ON_ERROR_STOP 1
 \set VERBOSITY terse
+-- Check for incorrect CAGGs
+\if :INTERVAL_TEST
+  INSERT INTO conditions ("time", temperature, device_id) VALUES ('2022-01-01 00:00:00-00', 10, 4);
+  INSERT INTO conditions ("time", temperature, device_id) VALUES ('2022-01-15 01:00:00-00', 20, 4);
+  INSERT INTO conditions ("time", temperature, device_id) VALUES ('2022-01-31 01:00:00-00', 30, 4);
+  CALL refresh_continuous_aggregate(:'CAGG_NAME_1ST_LEVEL', NULL, NULL);
+  CALL refresh_continuous_aggregate(:'CAGG_NAME_2TH_LEVEL', NULL, NULL);
+  CREATE MATERIALIZED VIEW :CAGG_NAME_3TH_LEVEL
+  WITH (timescaledb.continuous) AS
+  SELECT
+    \if :IS_TIME_DIMENSION_WITH_TIMEZONE_2TH
+      time_bucket(:BUCKET_WIDTH_3TH, "bucket", :'BUCKET_TZNAME_2TH') AS bucket
+    \else
+      time_bucket(:BUCKET_WIDTH_3TH, "bucket") AS bucket
+    \endif
+  FROM :CAGG_NAME_2TH_LEVEL
+  GROUP BY 1
+  WITH DATA;
+  \d+ :CAGG_NAME_3TH_LEVEL
+  --There should never be dulpicates in the output of the following query
+  SELECT * from :CAGG_NAME_3TH_LEVEL;
+  DROP MATERIALIZED VIEW IF EXISTS :CAGG_NAME_3TH_LEVEL;
+  DELETE FROM conditions WHERE device_id = 4;
+\endif
 --
 -- Cleanup
 --
@@ -3849,6 +4225,7 @@ DROP MATERIALIZED VIEW IF EXISTS :CAGG_NAME_1ST_LEVEL;
 -- LICENSE-TIMESCALE for a copy of the license.
 \set CAGG_NAME_1ST_LEVEL conditions_summary_1
 \set CAGG_NAME_2TH_LEVEL conditions_summary_2
+\set CAGG_NAME_3TH_LEVEL conditions_summary_3
 --
 -- CAGG on hypertable (1st level)
 --
@@ -3921,6 +4298,30 @@ UNION ALL
 
 \set ON_ERROR_STOP 1
 \set VERBOSITY terse
+-- Check for incorrect CAGGs
+\if :INTERVAL_TEST
+  INSERT INTO conditions ("time", temperature, device_id) VALUES ('2022-01-01 00:00:00-00', 10, 4);
+  INSERT INTO conditions ("time", temperature, device_id) VALUES ('2022-01-15 01:00:00-00', 20, 4);
+  INSERT INTO conditions ("time", temperature, device_id) VALUES ('2022-01-31 01:00:00-00', 30, 4);
+  CALL refresh_continuous_aggregate(:'CAGG_NAME_1ST_LEVEL', NULL, NULL);
+  CALL refresh_continuous_aggregate(:'CAGG_NAME_2TH_LEVEL', NULL, NULL);
+  CREATE MATERIALIZED VIEW :CAGG_NAME_3TH_LEVEL
+  WITH (timescaledb.continuous) AS
+  SELECT
+    \if :IS_TIME_DIMENSION_WITH_TIMEZONE_2TH
+      time_bucket(:BUCKET_WIDTH_3TH, "bucket", :'BUCKET_TZNAME_2TH') AS bucket
+    \else
+      time_bucket(:BUCKET_WIDTH_3TH, "bucket") AS bucket
+    \endif
+  FROM :CAGG_NAME_2TH_LEVEL
+  GROUP BY 1
+  WITH DATA;
+  \d+ :CAGG_NAME_3TH_LEVEL
+  --There should never be dulpicates in the output of the following query
+  SELECT * from :CAGG_NAME_3TH_LEVEL;
+  DROP MATERIALIZED VIEW IF EXISTS :CAGG_NAME_3TH_LEVEL;
+  DELETE FROM conditions WHERE device_id = 4;
+\endif
 --
 -- Cleanup
 --
@@ -3941,6 +4342,7 @@ DROP MATERIALIZED VIEW IF EXISTS :CAGG_NAME_1ST_LEVEL;
 -- LICENSE-TIMESCALE for a copy of the license.
 \set CAGG_NAME_1ST_LEVEL conditions_summary_1
 \set CAGG_NAME_2TH_LEVEL conditions_summary_2
+\set CAGG_NAME_3TH_LEVEL conditions_summary_3
 --
 -- CAGG on hypertable (1st level)
 --
@@ -4013,6 +4415,30 @@ UNION ALL
 
 \set ON_ERROR_STOP 1
 \set VERBOSITY terse
+-- Check for incorrect CAGGs
+\if :INTERVAL_TEST
+  INSERT INTO conditions ("time", temperature, device_id) VALUES ('2022-01-01 00:00:00-00', 10, 4);
+  INSERT INTO conditions ("time", temperature, device_id) VALUES ('2022-01-15 01:00:00-00', 20, 4);
+  INSERT INTO conditions ("time", temperature, device_id) VALUES ('2022-01-31 01:00:00-00', 30, 4);
+  CALL refresh_continuous_aggregate(:'CAGG_NAME_1ST_LEVEL', NULL, NULL);
+  CALL refresh_continuous_aggregate(:'CAGG_NAME_2TH_LEVEL', NULL, NULL);
+  CREATE MATERIALIZED VIEW :CAGG_NAME_3TH_LEVEL
+  WITH (timescaledb.continuous) AS
+  SELECT
+    \if :IS_TIME_DIMENSION_WITH_TIMEZONE_2TH
+      time_bucket(:BUCKET_WIDTH_3TH, "bucket", :'BUCKET_TZNAME_2TH') AS bucket
+    \else
+      time_bucket(:BUCKET_WIDTH_3TH, "bucket") AS bucket
+    \endif
+  FROM :CAGG_NAME_2TH_LEVEL
+  GROUP BY 1
+  WITH DATA;
+  \d+ :CAGG_NAME_3TH_LEVEL
+  --There should never be dulpicates in the output of the following query
+  SELECT * from :CAGG_NAME_3TH_LEVEL;
+  DROP MATERIALIZED VIEW IF EXISTS :CAGG_NAME_3TH_LEVEL;
+  DELETE FROM conditions WHERE device_id = 4;
+\endif
 --
 -- Cleanup
 --
@@ -4032,6 +4458,7 @@ DROP MATERIALIZED VIEW IF EXISTS :CAGG_NAME_1ST_LEVEL;
 -- LICENSE-TIMESCALE for a copy of the license.
 \set CAGG_NAME_1ST_LEVEL conditions_summary_1
 \set CAGG_NAME_2TH_LEVEL conditions_summary_2
+\set CAGG_NAME_3TH_LEVEL conditions_summary_3
 --
 -- CAGG on hypertable (1st level)
 --
@@ -4104,6 +4531,30 @@ UNION ALL
 
 \set ON_ERROR_STOP 1
 \set VERBOSITY terse
+-- Check for incorrect CAGGs
+\if :INTERVAL_TEST
+  INSERT INTO conditions ("time", temperature, device_id) VALUES ('2022-01-01 00:00:00-00', 10, 4);
+  INSERT INTO conditions ("time", temperature, device_id) VALUES ('2022-01-15 01:00:00-00', 20, 4);
+  INSERT INTO conditions ("time", temperature, device_id) VALUES ('2022-01-31 01:00:00-00', 30, 4);
+  CALL refresh_continuous_aggregate(:'CAGG_NAME_1ST_LEVEL', NULL, NULL);
+  CALL refresh_continuous_aggregate(:'CAGG_NAME_2TH_LEVEL', NULL, NULL);
+  CREATE MATERIALIZED VIEW :CAGG_NAME_3TH_LEVEL
+  WITH (timescaledb.continuous) AS
+  SELECT
+    \if :IS_TIME_DIMENSION_WITH_TIMEZONE_2TH
+      time_bucket(:BUCKET_WIDTH_3TH, "bucket", :'BUCKET_TZNAME_2TH') AS bucket
+    \else
+      time_bucket(:BUCKET_WIDTH_3TH, "bucket") AS bucket
+    \endif
+  FROM :CAGG_NAME_2TH_LEVEL
+  GROUP BY 1
+  WITH DATA;
+  \d+ :CAGG_NAME_3TH_LEVEL
+  --There should never be dulpicates in the output of the following query
+  SELECT * from :CAGG_NAME_3TH_LEVEL;
+  DROP MATERIALIZED VIEW IF EXISTS :CAGG_NAME_3TH_LEVEL;
+  DELETE FROM conditions WHERE device_id = 4;
+\endif
 --
 -- Cleanup
 --
@@ -4117,6 +4568,7 @@ DROP MATERIALIZED VIEW IF EXISTS :CAGG_NAME_1ST_LEVEL;
 -- LICENSE-TIMESCALE for a copy of the license.
 \set CAGG_NAME_1ST_LEVEL conditions_summary_1
 \set CAGG_NAME_2TH_LEVEL conditions_summary_2
+\set CAGG_NAME_3TH_LEVEL conditions_summary_3
 --
 -- CAGG on hypertable (1st level)
 --
@@ -4189,6 +4641,30 @@ UNION ALL
 
 \set ON_ERROR_STOP 1
 \set VERBOSITY terse
+-- Check for incorrect CAGGs
+\if :INTERVAL_TEST
+  INSERT INTO conditions ("time", temperature, device_id) VALUES ('2022-01-01 00:00:00-00', 10, 4);
+  INSERT INTO conditions ("time", temperature, device_id) VALUES ('2022-01-15 01:00:00-00', 20, 4);
+  INSERT INTO conditions ("time", temperature, device_id) VALUES ('2022-01-31 01:00:00-00', 30, 4);
+  CALL refresh_continuous_aggregate(:'CAGG_NAME_1ST_LEVEL', NULL, NULL);
+  CALL refresh_continuous_aggregate(:'CAGG_NAME_2TH_LEVEL', NULL, NULL);
+  CREATE MATERIALIZED VIEW :CAGG_NAME_3TH_LEVEL
+  WITH (timescaledb.continuous) AS
+  SELECT
+    \if :IS_TIME_DIMENSION_WITH_TIMEZONE_2TH
+      time_bucket(:BUCKET_WIDTH_3TH, "bucket", :'BUCKET_TZNAME_2TH') AS bucket
+    \else
+      time_bucket(:BUCKET_WIDTH_3TH, "bucket") AS bucket
+    \endif
+  FROM :CAGG_NAME_2TH_LEVEL
+  GROUP BY 1
+  WITH DATA;
+  \d+ :CAGG_NAME_3TH_LEVEL
+  --There should never be dulpicates in the output of the following query
+  SELECT * from :CAGG_NAME_3TH_LEVEL;
+  DROP MATERIALIZED VIEW IF EXISTS :CAGG_NAME_3TH_LEVEL;
+  DELETE FROM conditions WHERE device_id = 4;
+\endif
 --
 -- Cleanup
 --
@@ -4202,6 +4678,7 @@ DROP MATERIALIZED VIEW IF EXISTS :CAGG_NAME_1ST_LEVEL;
 -- LICENSE-TIMESCALE for a copy of the license.
 \set CAGG_NAME_1ST_LEVEL conditions_summary_1
 \set CAGG_NAME_2TH_LEVEL conditions_summary_2
+\set CAGG_NAME_3TH_LEVEL conditions_summary_3
 --
 -- CAGG on hypertable (1st level)
 --
@@ -4274,6 +4751,30 @@ UNION ALL
 
 \set ON_ERROR_STOP 1
 \set VERBOSITY terse
+-- Check for incorrect CAGGs
+\if :INTERVAL_TEST
+  INSERT INTO conditions ("time", temperature, device_id) VALUES ('2022-01-01 00:00:00-00', 10, 4);
+  INSERT INTO conditions ("time", temperature, device_id) VALUES ('2022-01-15 01:00:00-00', 20, 4);
+  INSERT INTO conditions ("time", temperature, device_id) VALUES ('2022-01-31 01:00:00-00', 30, 4);
+  CALL refresh_continuous_aggregate(:'CAGG_NAME_1ST_LEVEL', NULL, NULL);
+  CALL refresh_continuous_aggregate(:'CAGG_NAME_2TH_LEVEL', NULL, NULL);
+  CREATE MATERIALIZED VIEW :CAGG_NAME_3TH_LEVEL
+  WITH (timescaledb.continuous) AS
+  SELECT
+    \if :IS_TIME_DIMENSION_WITH_TIMEZONE_2TH
+      time_bucket(:BUCKET_WIDTH_3TH, "bucket", :'BUCKET_TZNAME_2TH') AS bucket
+    \else
+      time_bucket(:BUCKET_WIDTH_3TH, "bucket") AS bucket
+    \endif
+  FROM :CAGG_NAME_2TH_LEVEL
+  GROUP BY 1
+  WITH DATA;
+  \d+ :CAGG_NAME_3TH_LEVEL
+  --There should never be dulpicates in the output of the following query
+  SELECT * from :CAGG_NAME_3TH_LEVEL;
+  DROP MATERIALIZED VIEW IF EXISTS :CAGG_NAME_3TH_LEVEL;
+  DELETE FROM conditions WHERE device_id = 4;
+\endif
 --
 -- Cleanup
 --
@@ -4287,6 +4788,7 @@ DROP MATERIALIZED VIEW IF EXISTS :CAGG_NAME_1ST_LEVEL;
 -- LICENSE-TIMESCALE for a copy of the license.
 \set CAGG_NAME_1ST_LEVEL conditions_summary_1
 \set CAGG_NAME_2TH_LEVEL conditions_summary_2
+\set CAGG_NAME_3TH_LEVEL conditions_summary_3
 --
 -- CAGG on hypertable (1st level)
 --
@@ -4339,16 +4841,40 @@ SELECT
 FROM :CAGG_NAME_1ST_LEVEL
 GROUP BY 1
 WITH NO DATA;
-psql:include/cagg_on_cagg_validations.sql:43: ERROR:  cannot create continuous aggregate with incompatible bucket width
-DETAIL:  Time bucket width of "public.conditions_summary_2" [@ 360 days] should be multiple of the time bucket width of "public.conditions_summary_1" [@ 7 days].
+psql:include/cagg_on_cagg_validations.sql:44: ERROR:  cannot create continuous aggregate with incompatible bucket width
+DETAIL:  Time bucket width of "public.conditions_summary_2" [@ 1 year] should be multiple of the time bucket width of "public.conditions_summary_1" [@ 7 days].
 \d+ :CAGG_NAME_2TH_LEVEL
 \set ON_ERROR_STOP 1
 \set VERBOSITY terse
+-- Check for incorrect CAGGs
+\if :INTERVAL_TEST
+  INSERT INTO conditions ("time", temperature, device_id) VALUES ('2022-01-01 00:00:00-00', 10, 4);
+  INSERT INTO conditions ("time", temperature, device_id) VALUES ('2022-01-15 01:00:00-00', 20, 4);
+  INSERT INTO conditions ("time", temperature, device_id) VALUES ('2022-01-31 01:00:00-00', 30, 4);
+  CALL refresh_continuous_aggregate(:'CAGG_NAME_1ST_LEVEL', NULL, NULL);
+  CALL refresh_continuous_aggregate(:'CAGG_NAME_2TH_LEVEL', NULL, NULL);
+  CREATE MATERIALIZED VIEW :CAGG_NAME_3TH_LEVEL
+  WITH (timescaledb.continuous) AS
+  SELECT
+    \if :IS_TIME_DIMENSION_WITH_TIMEZONE_2TH
+      time_bucket(:BUCKET_WIDTH_3TH, "bucket", :'BUCKET_TZNAME_2TH') AS bucket
+    \else
+      time_bucket(:BUCKET_WIDTH_3TH, "bucket") AS bucket
+    \endif
+  FROM :CAGG_NAME_2TH_LEVEL
+  GROUP BY 1
+  WITH DATA;
+  \d+ :CAGG_NAME_3TH_LEVEL
+  --There should never be dulpicates in the output of the following query
+  SELECT * from :CAGG_NAME_3TH_LEVEL;
+  DROP MATERIALIZED VIEW IF EXISTS :CAGG_NAME_3TH_LEVEL;
+  DELETE FROM conditions WHERE device_id = 4;
+\endif
 --
 -- Cleanup
 --
 DROP MATERIALIZED VIEW IF EXISTS :CAGG_NAME_2TH_LEVEL;
-psql:include/cagg_on_cagg_validations.sql:53: NOTICE:  materialized view "conditions_summary_2" does not exist, skipping
+psql:include/cagg_on_cagg_validations.sql:86: NOTICE:  materialized view "conditions_summary_2" does not exist, skipping
 DROP MATERIALIZED VIEW IF EXISTS :CAGG_NAME_1ST_LEVEL;
 \set BUCKET_WIDTH_1ST 'INTERVAL \'1 week\''
 \set BUCKET_WIDTH_2TH 'INTERVAL \'1 month\''
@@ -4358,6 +4884,7 @@ DROP MATERIALIZED VIEW IF EXISTS :CAGG_NAME_1ST_LEVEL;
 -- LICENSE-TIMESCALE for a copy of the license.
 \set CAGG_NAME_1ST_LEVEL conditions_summary_1
 \set CAGG_NAME_2TH_LEVEL conditions_summary_2
+\set CAGG_NAME_3TH_LEVEL conditions_summary_3
 --
 -- CAGG on hypertable (1st level)
 --
@@ -4410,14 +4937,38 @@ SELECT
 FROM :CAGG_NAME_1ST_LEVEL
 GROUP BY 1
 WITH NO DATA;
-psql:include/cagg_on_cagg_validations.sql:43: ERROR:  cannot create continuous aggregate with incompatible bucket width
-DETAIL:  Time bucket width of "public.conditions_summary_2" [@ 30 days] should be multiple of the time bucket width of "public.conditions_summary_1" [@ 7 days].
+psql:include/cagg_on_cagg_validations.sql:44: ERROR:  cannot create continuous aggregate with incompatible bucket width
+DETAIL:  Time bucket width of "public.conditions_summary_2" [@ 1 mon] should be multiple of the time bucket width of "public.conditions_summary_1" [@ 7 days].
 \d+ :CAGG_NAME_2TH_LEVEL
 \set ON_ERROR_STOP 1
 \set VERBOSITY terse
+-- Check for incorrect CAGGs
+\if :INTERVAL_TEST
+  INSERT INTO conditions ("time", temperature, device_id) VALUES ('2022-01-01 00:00:00-00', 10, 4);
+  INSERT INTO conditions ("time", temperature, device_id) VALUES ('2022-01-15 01:00:00-00', 20, 4);
+  INSERT INTO conditions ("time", temperature, device_id) VALUES ('2022-01-31 01:00:00-00', 30, 4);
+  CALL refresh_continuous_aggregate(:'CAGG_NAME_1ST_LEVEL', NULL, NULL);
+  CALL refresh_continuous_aggregate(:'CAGG_NAME_2TH_LEVEL', NULL, NULL);
+  CREATE MATERIALIZED VIEW :CAGG_NAME_3TH_LEVEL
+  WITH (timescaledb.continuous) AS
+  SELECT
+    \if :IS_TIME_DIMENSION_WITH_TIMEZONE_2TH
+      time_bucket(:BUCKET_WIDTH_3TH, "bucket", :'BUCKET_TZNAME_2TH') AS bucket
+    \else
+      time_bucket(:BUCKET_WIDTH_3TH, "bucket") AS bucket
+    \endif
+  FROM :CAGG_NAME_2TH_LEVEL
+  GROUP BY 1
+  WITH DATA;
+  \d+ :CAGG_NAME_3TH_LEVEL
+  --There should never be dulpicates in the output of the following query
+  SELECT * from :CAGG_NAME_3TH_LEVEL;
+  DROP MATERIALIZED VIEW IF EXISTS :CAGG_NAME_3TH_LEVEL;
+  DELETE FROM conditions WHERE device_id = 4;
+\endif
 --
 -- Cleanup
 --
 DROP MATERIALIZED VIEW IF EXISTS :CAGG_NAME_2TH_LEVEL;
-psql:include/cagg_on_cagg_validations.sql:53: NOTICE:  materialized view "conditions_summary_2" does not exist, skipping
+psql:include/cagg_on_cagg_validations.sql:86: NOTICE:  materialized view "conditions_summary_2" does not exist, skipping
 DROP MATERIALIZED VIEW IF EXISTS :CAGG_NAME_1ST_LEVEL;

--- a/tsl/test/expected/cagg_on_cagg_joins_dist_ht.out
+++ b/tsl/test/expected/cagg_on_cagg_joins_dist_ht.out
@@ -8,6 +8,7 @@
 \set DATA_NODE_1 :TEST_DBNAME _1
 \set DATA_NODE_2 :TEST_DBNAME _2
 \set DATA_NODE_3 :TEST_DBNAME _3
+\set INTERVAL_TEST FALSE
 \ir include/remote_exec.sql
 -- This file and its contents are licensed under the Timescale License.
 -- Please see the included NOTICE for copyright information and
@@ -923,6 +924,7 @@ psql:include/cagg_on_cagg_common.sql:200: ERROR:  relation "conditions_summary_1
 -- LICENSE-TIMESCALE for a copy of the license.
 \set CAGG_NAME_1ST_LEVEL conditions_summary_1
 \set CAGG_NAME_2TH_LEVEL conditions_summary_2
+\set CAGG_NAME_3TH_LEVEL conditions_summary_3
 --
 -- CAGG on hypertable (1st level)
 --
@@ -975,16 +977,40 @@ SELECT
 FROM :CAGG_NAME_1ST_LEVEL
 GROUP BY 1
 WITH NO DATA;
-psql:include/cagg_on_cagg_validations.sql:43: ERROR:  cannot create continuous aggregate with incompatible bucket width
+psql:include/cagg_on_cagg_validations.sql:44: ERROR:  cannot create continuous aggregate with incompatible bucket width
 DETAIL:  Time bucket width of "public.conditions_summary_2" [5] should be multiple of the time bucket width of "public.conditions_summary_1" [2].
 \d+ :CAGG_NAME_2TH_LEVEL
 \set ON_ERROR_STOP 1
 \set VERBOSITY terse
+-- Check for incorrect CAGGs
+\if :INTERVAL_TEST
+  INSERT INTO conditions ("time", temperature, device_id) VALUES ('2022-01-01 00:00:00-00', 10, 4);
+  INSERT INTO conditions ("time", temperature, device_id) VALUES ('2022-01-15 01:00:00-00', 20, 4);
+  INSERT INTO conditions ("time", temperature, device_id) VALUES ('2022-01-31 01:00:00-00', 30, 4);
+  CALL refresh_continuous_aggregate(:'CAGG_NAME_1ST_LEVEL', NULL, NULL);
+  CALL refresh_continuous_aggregate(:'CAGG_NAME_2TH_LEVEL', NULL, NULL);
+  CREATE MATERIALIZED VIEW :CAGG_NAME_3TH_LEVEL
+  WITH (timescaledb.continuous) AS
+  SELECT
+    \if :IS_TIME_DIMENSION_WITH_TIMEZONE_2TH
+      time_bucket(:BUCKET_WIDTH_3TH, "bucket", :'BUCKET_TZNAME_2TH') AS bucket
+    \else
+      time_bucket(:BUCKET_WIDTH_3TH, "bucket") AS bucket
+    \endif
+  FROM :CAGG_NAME_2TH_LEVEL
+  GROUP BY 1
+  WITH DATA;
+  \d+ :CAGG_NAME_3TH_LEVEL
+  --There should never be dulpicates in the output of the following query
+  SELECT * from :CAGG_NAME_3TH_LEVEL;
+  DROP MATERIALIZED VIEW IF EXISTS :CAGG_NAME_3TH_LEVEL;
+  DELETE FROM conditions WHERE device_id = 4;
+\endif
 --
 -- Cleanup
 --
 DROP MATERIALIZED VIEW IF EXISTS :CAGG_NAME_2TH_LEVEL;
-psql:include/cagg_on_cagg_validations.sql:53: NOTICE:  materialized view "conditions_summary_2" does not exist, skipping
+psql:include/cagg_on_cagg_validations.sql:86: NOTICE:  materialized view "conditions_summary_2" does not exist, skipping
 DROP MATERIALIZED VIEW IF EXISTS :CAGG_NAME_1ST_LEVEL;
 --
 -- Validation test for equal bucket sizes
@@ -998,6 +1024,7 @@ DROP MATERIALIZED VIEW IF EXISTS :CAGG_NAME_1ST_LEVEL;
 -- LICENSE-TIMESCALE for a copy of the license.
 \set CAGG_NAME_1ST_LEVEL conditions_summary_1
 \set CAGG_NAME_2TH_LEVEL conditions_summary_2
+\set CAGG_NAME_3TH_LEVEL conditions_summary_3
 --
 -- CAGG on hypertable (1st level)
 --
@@ -1070,6 +1097,30 @@ UNION ALL
 
 \set ON_ERROR_STOP 1
 \set VERBOSITY terse
+-- Check for incorrect CAGGs
+\if :INTERVAL_TEST
+  INSERT INTO conditions ("time", temperature, device_id) VALUES ('2022-01-01 00:00:00-00', 10, 4);
+  INSERT INTO conditions ("time", temperature, device_id) VALUES ('2022-01-15 01:00:00-00', 20, 4);
+  INSERT INTO conditions ("time", temperature, device_id) VALUES ('2022-01-31 01:00:00-00', 30, 4);
+  CALL refresh_continuous_aggregate(:'CAGG_NAME_1ST_LEVEL', NULL, NULL);
+  CALL refresh_continuous_aggregate(:'CAGG_NAME_2TH_LEVEL', NULL, NULL);
+  CREATE MATERIALIZED VIEW :CAGG_NAME_3TH_LEVEL
+  WITH (timescaledb.continuous) AS
+  SELECT
+    \if :IS_TIME_DIMENSION_WITH_TIMEZONE_2TH
+      time_bucket(:BUCKET_WIDTH_3TH, "bucket", :'BUCKET_TZNAME_2TH') AS bucket
+    \else
+      time_bucket(:BUCKET_WIDTH_3TH, "bucket") AS bucket
+    \endif
+  FROM :CAGG_NAME_2TH_LEVEL
+  GROUP BY 1
+  WITH DATA;
+  \d+ :CAGG_NAME_3TH_LEVEL
+  --There should never be dulpicates in the output of the following query
+  SELECT * from :CAGG_NAME_3TH_LEVEL;
+  DROP MATERIALIZED VIEW IF EXISTS :CAGG_NAME_3TH_LEVEL;
+  DELETE FROM conditions WHERE device_id = 4;
+\endif
 --
 -- Cleanup
 --
@@ -1087,6 +1138,7 @@ DROP MATERIALIZED VIEW IF EXISTS :CAGG_NAME_1ST_LEVEL;
 -- LICENSE-TIMESCALE for a copy of the license.
 \set CAGG_NAME_1ST_LEVEL conditions_summary_1
 \set CAGG_NAME_2TH_LEVEL conditions_summary_2
+\set CAGG_NAME_3TH_LEVEL conditions_summary_3
 --
 -- CAGG on hypertable (1st level)
 --
@@ -1139,16 +1191,40 @@ SELECT
 FROM :CAGG_NAME_1ST_LEVEL
 GROUP BY 1
 WITH NO DATA;
-psql:include/cagg_on_cagg_validations.sql:43: ERROR:  cannot create continuous aggregate with incompatible bucket width
+psql:include/cagg_on_cagg_validations.sql:44: ERROR:  cannot create continuous aggregate with incompatible bucket width
 DETAIL:  Time bucket width of "public.conditions_summary_2" [2] should be greater or equal than the time bucket width of "public.conditions_summary_1" [4].
 \d+ :CAGG_NAME_2TH_LEVEL
 \set ON_ERROR_STOP 1
 \set VERBOSITY terse
+-- Check for incorrect CAGGs
+\if :INTERVAL_TEST
+  INSERT INTO conditions ("time", temperature, device_id) VALUES ('2022-01-01 00:00:00-00', 10, 4);
+  INSERT INTO conditions ("time", temperature, device_id) VALUES ('2022-01-15 01:00:00-00', 20, 4);
+  INSERT INTO conditions ("time", temperature, device_id) VALUES ('2022-01-31 01:00:00-00', 30, 4);
+  CALL refresh_continuous_aggregate(:'CAGG_NAME_1ST_LEVEL', NULL, NULL);
+  CALL refresh_continuous_aggregate(:'CAGG_NAME_2TH_LEVEL', NULL, NULL);
+  CREATE MATERIALIZED VIEW :CAGG_NAME_3TH_LEVEL
+  WITH (timescaledb.continuous) AS
+  SELECT
+    \if :IS_TIME_DIMENSION_WITH_TIMEZONE_2TH
+      time_bucket(:BUCKET_WIDTH_3TH, "bucket", :'BUCKET_TZNAME_2TH') AS bucket
+    \else
+      time_bucket(:BUCKET_WIDTH_3TH, "bucket") AS bucket
+    \endif
+  FROM :CAGG_NAME_2TH_LEVEL
+  GROUP BY 1
+  WITH DATA;
+  \d+ :CAGG_NAME_3TH_LEVEL
+  --There should never be dulpicates in the output of the following query
+  SELECT * from :CAGG_NAME_3TH_LEVEL;
+  DROP MATERIALIZED VIEW IF EXISTS :CAGG_NAME_3TH_LEVEL;
+  DELETE FROM conditions WHERE device_id = 4;
+\endif
 --
 -- Cleanup
 --
 DROP MATERIALIZED VIEW IF EXISTS :CAGG_NAME_2TH_LEVEL;
-psql:include/cagg_on_cagg_validations.sql:53: NOTICE:  materialized view "conditions_summary_2" does not exist, skipping
+psql:include/cagg_on_cagg_validations.sql:86: NOTICE:  materialized view "conditions_summary_2" does not exist, skipping
 DROP MATERIALIZED VIEW IF EXISTS :CAGG_NAME_1ST_LEVEL;
 -- cleanup
 DROP TABLE conditions;
@@ -2027,6 +2103,7 @@ psql:include/cagg_on_cagg_common.sql:200: ERROR:  relation "conditions_summary_1
 -- LICENSE-TIMESCALE for a copy of the license.
 \set CAGG_NAME_1ST_LEVEL conditions_summary_1
 \set CAGG_NAME_2TH_LEVEL conditions_summary_2
+\set CAGG_NAME_3TH_LEVEL conditions_summary_3
 --
 -- CAGG on hypertable (1st level)
 --
@@ -2079,17 +2156,41 @@ SELECT
 FROM :CAGG_NAME_1ST_LEVEL
 GROUP BY 1
 WITH NO DATA;
-psql:include/cagg_on_cagg_validations.sql:43: ERROR:  cannot create continuous aggregate with fixed-width bucket on top of one using variable-width bucket
+psql:include/cagg_on_cagg_validations.sql:44: ERROR:  cannot create continuous aggregate with fixed-width bucket on top of one using variable-width bucket
 DETAIL:  Continuous aggregate with a fixed time bucket width (e.g. 61 days) cannot be created on top of one using variable time bucket width (e.g. 1 month).
 The variance can lead to the fixed width one not being a multiple of the variable width one.
 \d+ :CAGG_NAME_2TH_LEVEL
 \set ON_ERROR_STOP 1
 \set VERBOSITY terse
+-- Check for incorrect CAGGs
+\if :INTERVAL_TEST
+  INSERT INTO conditions ("time", temperature, device_id) VALUES ('2022-01-01 00:00:00-00', 10, 4);
+  INSERT INTO conditions ("time", temperature, device_id) VALUES ('2022-01-15 01:00:00-00', 20, 4);
+  INSERT INTO conditions ("time", temperature, device_id) VALUES ('2022-01-31 01:00:00-00', 30, 4);
+  CALL refresh_continuous_aggregate(:'CAGG_NAME_1ST_LEVEL', NULL, NULL);
+  CALL refresh_continuous_aggregate(:'CAGG_NAME_2TH_LEVEL', NULL, NULL);
+  CREATE MATERIALIZED VIEW :CAGG_NAME_3TH_LEVEL
+  WITH (timescaledb.continuous) AS
+  SELECT
+    \if :IS_TIME_DIMENSION_WITH_TIMEZONE_2TH
+      time_bucket(:BUCKET_WIDTH_3TH, "bucket", :'BUCKET_TZNAME_2TH') AS bucket
+    \else
+      time_bucket(:BUCKET_WIDTH_3TH, "bucket") AS bucket
+    \endif
+  FROM :CAGG_NAME_2TH_LEVEL
+  GROUP BY 1
+  WITH DATA;
+  \d+ :CAGG_NAME_3TH_LEVEL
+  --There should never be dulpicates in the output of the following query
+  SELECT * from :CAGG_NAME_3TH_LEVEL;
+  DROP MATERIALIZED VIEW IF EXISTS :CAGG_NAME_3TH_LEVEL;
+  DELETE FROM conditions WHERE device_id = 4;
+\endif
 --
 -- Cleanup
 --
 DROP MATERIALIZED VIEW IF EXISTS :CAGG_NAME_2TH_LEVEL;
-psql:include/cagg_on_cagg_validations.sql:53: NOTICE:  materialized view "conditions_summary_2" does not exist, skipping
+psql:include/cagg_on_cagg_validations.sql:86: NOTICE:  materialized view "conditions_summary_2" does not exist, skipping
 DROP MATERIALIZED VIEW IF EXISTS :CAGG_NAME_1ST_LEVEL;
 --
 -- Validation test for non-multiple bucket sizes
@@ -2103,6 +2204,7 @@ DROP MATERIALIZED VIEW IF EXISTS :CAGG_NAME_1ST_LEVEL;
 -- LICENSE-TIMESCALE for a copy of the license.
 \set CAGG_NAME_1ST_LEVEL conditions_summary_1
 \set CAGG_NAME_2TH_LEVEL conditions_summary_2
+\set CAGG_NAME_3TH_LEVEL conditions_summary_3
 --
 -- CAGG on hypertable (1st level)
 --
@@ -2155,16 +2257,40 @@ SELECT
 FROM :CAGG_NAME_1ST_LEVEL
 GROUP BY 1
 WITH NO DATA;
-psql:include/cagg_on_cagg_validations.sql:43: ERROR:  cannot create continuous aggregate with incompatible bucket width
+psql:include/cagg_on_cagg_validations.sql:44: ERROR:  cannot create continuous aggregate with incompatible bucket width
 DETAIL:  Time bucket width of "public.conditions_summary_2" [@ 3 hours] should be multiple of the time bucket width of "public.conditions_summary_1" [@ 2 hours].
 \d+ :CAGG_NAME_2TH_LEVEL
 \set ON_ERROR_STOP 1
 \set VERBOSITY terse
+-- Check for incorrect CAGGs
+\if :INTERVAL_TEST
+  INSERT INTO conditions ("time", temperature, device_id) VALUES ('2022-01-01 00:00:00-00', 10, 4);
+  INSERT INTO conditions ("time", temperature, device_id) VALUES ('2022-01-15 01:00:00-00', 20, 4);
+  INSERT INTO conditions ("time", temperature, device_id) VALUES ('2022-01-31 01:00:00-00', 30, 4);
+  CALL refresh_continuous_aggregate(:'CAGG_NAME_1ST_LEVEL', NULL, NULL);
+  CALL refresh_continuous_aggregate(:'CAGG_NAME_2TH_LEVEL', NULL, NULL);
+  CREATE MATERIALIZED VIEW :CAGG_NAME_3TH_LEVEL
+  WITH (timescaledb.continuous) AS
+  SELECT
+    \if :IS_TIME_DIMENSION_WITH_TIMEZONE_2TH
+      time_bucket(:BUCKET_WIDTH_3TH, "bucket", :'BUCKET_TZNAME_2TH') AS bucket
+    \else
+      time_bucket(:BUCKET_WIDTH_3TH, "bucket") AS bucket
+    \endif
+  FROM :CAGG_NAME_2TH_LEVEL
+  GROUP BY 1
+  WITH DATA;
+  \d+ :CAGG_NAME_3TH_LEVEL
+  --There should never be dulpicates in the output of the following query
+  SELECT * from :CAGG_NAME_3TH_LEVEL;
+  DROP MATERIALIZED VIEW IF EXISTS :CAGG_NAME_3TH_LEVEL;
+  DELETE FROM conditions WHERE device_id = 4;
+\endif
 --
 -- Cleanup
 --
 DROP MATERIALIZED VIEW IF EXISTS :CAGG_NAME_2TH_LEVEL;
-psql:include/cagg_on_cagg_validations.sql:53: NOTICE:  materialized view "conditions_summary_2" does not exist, skipping
+psql:include/cagg_on_cagg_validations.sql:86: NOTICE:  materialized view "conditions_summary_2" does not exist, skipping
 DROP MATERIALIZED VIEW IF EXISTS :CAGG_NAME_1ST_LEVEL;
 --
 -- Validation test for equal bucket sizes
@@ -2178,6 +2304,7 @@ DROP MATERIALIZED VIEW IF EXISTS :CAGG_NAME_1ST_LEVEL;
 -- LICENSE-TIMESCALE for a copy of the license.
 \set CAGG_NAME_1ST_LEVEL conditions_summary_1
 \set CAGG_NAME_2TH_LEVEL conditions_summary_2
+\set CAGG_NAME_3TH_LEVEL conditions_summary_3
 --
 -- CAGG on hypertable (1st level)
 --
@@ -2250,6 +2377,30 @@ UNION ALL
 
 \set ON_ERROR_STOP 1
 \set VERBOSITY terse
+-- Check for incorrect CAGGs
+\if :INTERVAL_TEST
+  INSERT INTO conditions ("time", temperature, device_id) VALUES ('2022-01-01 00:00:00-00', 10, 4);
+  INSERT INTO conditions ("time", temperature, device_id) VALUES ('2022-01-15 01:00:00-00', 20, 4);
+  INSERT INTO conditions ("time", temperature, device_id) VALUES ('2022-01-31 01:00:00-00', 30, 4);
+  CALL refresh_continuous_aggregate(:'CAGG_NAME_1ST_LEVEL', NULL, NULL);
+  CALL refresh_continuous_aggregate(:'CAGG_NAME_2TH_LEVEL', NULL, NULL);
+  CREATE MATERIALIZED VIEW :CAGG_NAME_3TH_LEVEL
+  WITH (timescaledb.continuous) AS
+  SELECT
+    \if :IS_TIME_DIMENSION_WITH_TIMEZONE_2TH
+      time_bucket(:BUCKET_WIDTH_3TH, "bucket", :'BUCKET_TZNAME_2TH') AS bucket
+    \else
+      time_bucket(:BUCKET_WIDTH_3TH, "bucket") AS bucket
+    \endif
+  FROM :CAGG_NAME_2TH_LEVEL
+  GROUP BY 1
+  WITH DATA;
+  \d+ :CAGG_NAME_3TH_LEVEL
+  --There should never be dulpicates in the output of the following query
+  SELECT * from :CAGG_NAME_3TH_LEVEL;
+  DROP MATERIALIZED VIEW IF EXISTS :CAGG_NAME_3TH_LEVEL;
+  DELETE FROM conditions WHERE device_id = 4;
+\endif
 --
 -- Cleanup
 --
@@ -2267,6 +2418,7 @@ DROP MATERIALIZED VIEW IF EXISTS :CAGG_NAME_1ST_LEVEL;
 -- LICENSE-TIMESCALE for a copy of the license.
 \set CAGG_NAME_1ST_LEVEL conditions_summary_1
 \set CAGG_NAME_2TH_LEVEL conditions_summary_2
+\set CAGG_NAME_3TH_LEVEL conditions_summary_3
 --
 -- CAGG on hypertable (1st level)
 --
@@ -2319,16 +2471,40 @@ SELECT
 FROM :CAGG_NAME_1ST_LEVEL
 GROUP BY 1
 WITH NO DATA;
-psql:include/cagg_on_cagg_validations.sql:43: ERROR:  cannot create continuous aggregate with incompatible bucket width
+psql:include/cagg_on_cagg_validations.sql:44: ERROR:  cannot create continuous aggregate with incompatible bucket width
 DETAIL:  Time bucket width of "public.conditions_summary_2" [@ 1 hour] should be greater or equal than the time bucket width of "public.conditions_summary_1" [@ 2 hours].
 \d+ :CAGG_NAME_2TH_LEVEL
 \set ON_ERROR_STOP 1
 \set VERBOSITY terse
+-- Check for incorrect CAGGs
+\if :INTERVAL_TEST
+  INSERT INTO conditions ("time", temperature, device_id) VALUES ('2022-01-01 00:00:00-00', 10, 4);
+  INSERT INTO conditions ("time", temperature, device_id) VALUES ('2022-01-15 01:00:00-00', 20, 4);
+  INSERT INTO conditions ("time", temperature, device_id) VALUES ('2022-01-31 01:00:00-00', 30, 4);
+  CALL refresh_continuous_aggregate(:'CAGG_NAME_1ST_LEVEL', NULL, NULL);
+  CALL refresh_continuous_aggregate(:'CAGG_NAME_2TH_LEVEL', NULL, NULL);
+  CREATE MATERIALIZED VIEW :CAGG_NAME_3TH_LEVEL
+  WITH (timescaledb.continuous) AS
+  SELECT
+    \if :IS_TIME_DIMENSION_WITH_TIMEZONE_2TH
+      time_bucket(:BUCKET_WIDTH_3TH, "bucket", :'BUCKET_TZNAME_2TH') AS bucket
+    \else
+      time_bucket(:BUCKET_WIDTH_3TH, "bucket") AS bucket
+    \endif
+  FROM :CAGG_NAME_2TH_LEVEL
+  GROUP BY 1
+  WITH DATA;
+  \d+ :CAGG_NAME_3TH_LEVEL
+  --There should never be dulpicates in the output of the following query
+  SELECT * from :CAGG_NAME_3TH_LEVEL;
+  DROP MATERIALIZED VIEW IF EXISTS :CAGG_NAME_3TH_LEVEL;
+  DELETE FROM conditions WHERE device_id = 4;
+\endif
 --
 -- Cleanup
 --
 DROP MATERIALIZED VIEW IF EXISTS :CAGG_NAME_2TH_LEVEL;
-psql:include/cagg_on_cagg_validations.sql:53: NOTICE:  materialized view "conditions_summary_2" does not exist, skipping
+psql:include/cagg_on_cagg_validations.sql:86: NOTICE:  materialized view "conditions_summary_2" does not exist, skipping
 DROP MATERIALIZED VIEW IF EXISTS :CAGG_NAME_1ST_LEVEL;
 -- ########################################################
 -- ## TIMESTAMPTZ data type tests
@@ -3202,6 +3378,7 @@ psql:include/cagg_on_cagg_common.sql:200: ERROR:  relation "conditions_summary_1
 -- LICENSE-TIMESCALE for a copy of the license.
 \set CAGG_NAME_1ST_LEVEL conditions_summary_1
 \set CAGG_NAME_2TH_LEVEL conditions_summary_2
+\set CAGG_NAME_3TH_LEVEL conditions_summary_3
 --
 -- CAGG on hypertable (1st level)
 --
@@ -3254,17 +3431,41 @@ SELECT
 FROM :CAGG_NAME_1ST_LEVEL
 GROUP BY 1
 WITH NO DATA;
-psql:include/cagg_on_cagg_validations.sql:43: ERROR:  cannot create continuous aggregate with fixed-width bucket on top of one using variable-width bucket
+psql:include/cagg_on_cagg_validations.sql:44: ERROR:  cannot create continuous aggregate with fixed-width bucket on top of one using variable-width bucket
 DETAIL:  Continuous aggregate with a fixed time bucket width (e.g. 61 days) cannot be created on top of one using variable time bucket width (e.g. 1 month).
 The variance can lead to the fixed width one not being a multiple of the variable width one.
 \d+ :CAGG_NAME_2TH_LEVEL
 \set ON_ERROR_STOP 1
 \set VERBOSITY terse
+-- Check for incorrect CAGGs
+\if :INTERVAL_TEST
+  INSERT INTO conditions ("time", temperature, device_id) VALUES ('2022-01-01 00:00:00-00', 10, 4);
+  INSERT INTO conditions ("time", temperature, device_id) VALUES ('2022-01-15 01:00:00-00', 20, 4);
+  INSERT INTO conditions ("time", temperature, device_id) VALUES ('2022-01-31 01:00:00-00', 30, 4);
+  CALL refresh_continuous_aggregate(:'CAGG_NAME_1ST_LEVEL', NULL, NULL);
+  CALL refresh_continuous_aggregate(:'CAGG_NAME_2TH_LEVEL', NULL, NULL);
+  CREATE MATERIALIZED VIEW :CAGG_NAME_3TH_LEVEL
+  WITH (timescaledb.continuous) AS
+  SELECT
+    \if :IS_TIME_DIMENSION_WITH_TIMEZONE_2TH
+      time_bucket(:BUCKET_WIDTH_3TH, "bucket", :'BUCKET_TZNAME_2TH') AS bucket
+    \else
+      time_bucket(:BUCKET_WIDTH_3TH, "bucket") AS bucket
+    \endif
+  FROM :CAGG_NAME_2TH_LEVEL
+  GROUP BY 1
+  WITH DATA;
+  \d+ :CAGG_NAME_3TH_LEVEL
+  --There should never be dulpicates in the output of the following query
+  SELECT * from :CAGG_NAME_3TH_LEVEL;
+  DROP MATERIALIZED VIEW IF EXISTS :CAGG_NAME_3TH_LEVEL;
+  DELETE FROM conditions WHERE device_id = 4;
+\endif
 --
 -- Cleanup
 --
 DROP MATERIALIZED VIEW IF EXISTS :CAGG_NAME_2TH_LEVEL;
-psql:include/cagg_on_cagg_validations.sql:53: NOTICE:  materialized view "conditions_summary_2" does not exist, skipping
+psql:include/cagg_on_cagg_validations.sql:86: NOTICE:  materialized view "conditions_summary_2" does not exist, skipping
 DROP MATERIALIZED VIEW IF EXISTS :CAGG_NAME_1ST_LEVEL;
 --
 -- Validation test for non-multiple bucket sizes
@@ -3278,6 +3479,7 @@ DROP MATERIALIZED VIEW IF EXISTS :CAGG_NAME_1ST_LEVEL;
 -- LICENSE-TIMESCALE for a copy of the license.
 \set CAGG_NAME_1ST_LEVEL conditions_summary_1
 \set CAGG_NAME_2TH_LEVEL conditions_summary_2
+\set CAGG_NAME_3TH_LEVEL conditions_summary_3
 --
 -- CAGG on hypertable (1st level)
 --
@@ -3330,16 +3532,40 @@ SELECT
 FROM :CAGG_NAME_1ST_LEVEL
 GROUP BY 1
 WITH NO DATA;
-psql:include/cagg_on_cagg_validations.sql:43: ERROR:  cannot create continuous aggregate with incompatible bucket width
+psql:include/cagg_on_cagg_validations.sql:44: ERROR:  cannot create continuous aggregate with incompatible bucket width
 DETAIL:  Time bucket width of "public.conditions_summary_2" [@ 3 hours] should be multiple of the time bucket width of "public.conditions_summary_1" [@ 2 hours].
 \d+ :CAGG_NAME_2TH_LEVEL
 \set ON_ERROR_STOP 1
 \set VERBOSITY terse
+-- Check for incorrect CAGGs
+\if :INTERVAL_TEST
+  INSERT INTO conditions ("time", temperature, device_id) VALUES ('2022-01-01 00:00:00-00', 10, 4);
+  INSERT INTO conditions ("time", temperature, device_id) VALUES ('2022-01-15 01:00:00-00', 20, 4);
+  INSERT INTO conditions ("time", temperature, device_id) VALUES ('2022-01-31 01:00:00-00', 30, 4);
+  CALL refresh_continuous_aggregate(:'CAGG_NAME_1ST_LEVEL', NULL, NULL);
+  CALL refresh_continuous_aggregate(:'CAGG_NAME_2TH_LEVEL', NULL, NULL);
+  CREATE MATERIALIZED VIEW :CAGG_NAME_3TH_LEVEL
+  WITH (timescaledb.continuous) AS
+  SELECT
+    \if :IS_TIME_DIMENSION_WITH_TIMEZONE_2TH
+      time_bucket(:BUCKET_WIDTH_3TH, "bucket", :'BUCKET_TZNAME_2TH') AS bucket
+    \else
+      time_bucket(:BUCKET_WIDTH_3TH, "bucket") AS bucket
+    \endif
+  FROM :CAGG_NAME_2TH_LEVEL
+  GROUP BY 1
+  WITH DATA;
+  \d+ :CAGG_NAME_3TH_LEVEL
+  --There should never be dulpicates in the output of the following query
+  SELECT * from :CAGG_NAME_3TH_LEVEL;
+  DROP MATERIALIZED VIEW IF EXISTS :CAGG_NAME_3TH_LEVEL;
+  DELETE FROM conditions WHERE device_id = 4;
+\endif
 --
 -- Cleanup
 --
 DROP MATERIALIZED VIEW IF EXISTS :CAGG_NAME_2TH_LEVEL;
-psql:include/cagg_on_cagg_validations.sql:53: NOTICE:  materialized view "conditions_summary_2" does not exist, skipping
+psql:include/cagg_on_cagg_validations.sql:86: NOTICE:  materialized view "conditions_summary_2" does not exist, skipping
 DROP MATERIALIZED VIEW IF EXISTS :CAGG_NAME_1ST_LEVEL;
 --
 -- Validation test for equal bucket sizes
@@ -3353,6 +3579,7 @@ DROP MATERIALIZED VIEW IF EXISTS :CAGG_NAME_1ST_LEVEL;
 -- LICENSE-TIMESCALE for a copy of the license.
 \set CAGG_NAME_1ST_LEVEL conditions_summary_1
 \set CAGG_NAME_2TH_LEVEL conditions_summary_2
+\set CAGG_NAME_3TH_LEVEL conditions_summary_3
 --
 -- CAGG on hypertable (1st level)
 --
@@ -3425,6 +3652,30 @@ UNION ALL
 
 \set ON_ERROR_STOP 1
 \set VERBOSITY terse
+-- Check for incorrect CAGGs
+\if :INTERVAL_TEST
+  INSERT INTO conditions ("time", temperature, device_id) VALUES ('2022-01-01 00:00:00-00', 10, 4);
+  INSERT INTO conditions ("time", temperature, device_id) VALUES ('2022-01-15 01:00:00-00', 20, 4);
+  INSERT INTO conditions ("time", temperature, device_id) VALUES ('2022-01-31 01:00:00-00', 30, 4);
+  CALL refresh_continuous_aggregate(:'CAGG_NAME_1ST_LEVEL', NULL, NULL);
+  CALL refresh_continuous_aggregate(:'CAGG_NAME_2TH_LEVEL', NULL, NULL);
+  CREATE MATERIALIZED VIEW :CAGG_NAME_3TH_LEVEL
+  WITH (timescaledb.continuous) AS
+  SELECT
+    \if :IS_TIME_DIMENSION_WITH_TIMEZONE_2TH
+      time_bucket(:BUCKET_WIDTH_3TH, "bucket", :'BUCKET_TZNAME_2TH') AS bucket
+    \else
+      time_bucket(:BUCKET_WIDTH_3TH, "bucket") AS bucket
+    \endif
+  FROM :CAGG_NAME_2TH_LEVEL
+  GROUP BY 1
+  WITH DATA;
+  \d+ :CAGG_NAME_3TH_LEVEL
+  --There should never be dulpicates in the output of the following query
+  SELECT * from :CAGG_NAME_3TH_LEVEL;
+  DROP MATERIALIZED VIEW IF EXISTS :CAGG_NAME_3TH_LEVEL;
+  DELETE FROM conditions WHERE device_id = 4;
+\endif
 --
 -- Cleanup
 --
@@ -3442,6 +3693,7 @@ DROP MATERIALIZED VIEW IF EXISTS :CAGG_NAME_1ST_LEVEL;
 -- LICENSE-TIMESCALE for a copy of the license.
 \set CAGG_NAME_1ST_LEVEL conditions_summary_1
 \set CAGG_NAME_2TH_LEVEL conditions_summary_2
+\set CAGG_NAME_3TH_LEVEL conditions_summary_3
 --
 -- CAGG on hypertable (1st level)
 --
@@ -3494,16 +3746,40 @@ SELECT
 FROM :CAGG_NAME_1ST_LEVEL
 GROUP BY 1
 WITH NO DATA;
-psql:include/cagg_on_cagg_validations.sql:43: ERROR:  cannot create continuous aggregate with incompatible bucket width
+psql:include/cagg_on_cagg_validations.sql:44: ERROR:  cannot create continuous aggregate with incompatible bucket width
 DETAIL:  Time bucket width of "public.conditions_summary_2" [@ 1 hour] should be greater or equal than the time bucket width of "public.conditions_summary_1" [@ 2 hours].
 \d+ :CAGG_NAME_2TH_LEVEL
 \set ON_ERROR_STOP 1
 \set VERBOSITY terse
+-- Check for incorrect CAGGs
+\if :INTERVAL_TEST
+  INSERT INTO conditions ("time", temperature, device_id) VALUES ('2022-01-01 00:00:00-00', 10, 4);
+  INSERT INTO conditions ("time", temperature, device_id) VALUES ('2022-01-15 01:00:00-00', 20, 4);
+  INSERT INTO conditions ("time", temperature, device_id) VALUES ('2022-01-31 01:00:00-00', 30, 4);
+  CALL refresh_continuous_aggregate(:'CAGG_NAME_1ST_LEVEL', NULL, NULL);
+  CALL refresh_continuous_aggregate(:'CAGG_NAME_2TH_LEVEL', NULL, NULL);
+  CREATE MATERIALIZED VIEW :CAGG_NAME_3TH_LEVEL
+  WITH (timescaledb.continuous) AS
+  SELECT
+    \if :IS_TIME_DIMENSION_WITH_TIMEZONE_2TH
+      time_bucket(:BUCKET_WIDTH_3TH, "bucket", :'BUCKET_TZNAME_2TH') AS bucket
+    \else
+      time_bucket(:BUCKET_WIDTH_3TH, "bucket") AS bucket
+    \endif
+  FROM :CAGG_NAME_2TH_LEVEL
+  GROUP BY 1
+  WITH DATA;
+  \d+ :CAGG_NAME_3TH_LEVEL
+  --There should never be dulpicates in the output of the following query
+  SELECT * from :CAGG_NAME_3TH_LEVEL;
+  DROP MATERIALIZED VIEW IF EXISTS :CAGG_NAME_3TH_LEVEL;
+  DELETE FROM conditions WHERE device_id = 4;
+\endif
 --
 -- Cleanup
 --
 DROP MATERIALIZED VIEW IF EXISTS :CAGG_NAME_2TH_LEVEL;
-psql:include/cagg_on_cagg_validations.sql:53: NOTICE:  materialized view "conditions_summary_2" does not exist, skipping
+psql:include/cagg_on_cagg_validations.sql:86: NOTICE:  materialized view "conditions_summary_2" does not exist, skipping
 DROP MATERIALIZED VIEW IF EXISTS :CAGG_NAME_1ST_LEVEL;
 --
 -- Validations using time bucket with timezone (ref issue #5126)
@@ -3524,6 +3800,7 @@ DROP MATERIALIZED VIEW IF EXISTS :CAGG_NAME_1ST_LEVEL;
 -- LICENSE-TIMESCALE for a copy of the license.
 \set CAGG_NAME_1ST_LEVEL conditions_summary_1
 \set CAGG_NAME_2TH_LEVEL conditions_summary_2
+\set CAGG_NAME_3TH_LEVEL conditions_summary_3
 --
 -- CAGG on hypertable (1st level)
 --
@@ -3596,6 +3873,30 @@ UNION ALL
 
 \set ON_ERROR_STOP 1
 \set VERBOSITY terse
+-- Check for incorrect CAGGs
+\if :INTERVAL_TEST
+  INSERT INTO conditions ("time", temperature, device_id) VALUES ('2022-01-01 00:00:00-00', 10, 4);
+  INSERT INTO conditions ("time", temperature, device_id) VALUES ('2022-01-15 01:00:00-00', 20, 4);
+  INSERT INTO conditions ("time", temperature, device_id) VALUES ('2022-01-31 01:00:00-00', 30, 4);
+  CALL refresh_continuous_aggregate(:'CAGG_NAME_1ST_LEVEL', NULL, NULL);
+  CALL refresh_continuous_aggregate(:'CAGG_NAME_2TH_LEVEL', NULL, NULL);
+  CREATE MATERIALIZED VIEW :CAGG_NAME_3TH_LEVEL
+  WITH (timescaledb.continuous) AS
+  SELECT
+    \if :IS_TIME_DIMENSION_WITH_TIMEZONE_2TH
+      time_bucket(:BUCKET_WIDTH_3TH, "bucket", :'BUCKET_TZNAME_2TH') AS bucket
+    \else
+      time_bucket(:BUCKET_WIDTH_3TH, "bucket") AS bucket
+    \endif
+  FROM :CAGG_NAME_2TH_LEVEL
+  GROUP BY 1
+  WITH DATA;
+  \d+ :CAGG_NAME_3TH_LEVEL
+  --There should never be dulpicates in the output of the following query
+  SELECT * from :CAGG_NAME_3TH_LEVEL;
+  DROP MATERIALIZED VIEW IF EXISTS :CAGG_NAME_3TH_LEVEL;
+  DELETE FROM conditions WHERE device_id = 4;
+\endif
 --
 -- Cleanup
 --
@@ -3610,6 +3911,7 @@ DROP MATERIALIZED VIEW IF EXISTS :CAGG_NAME_1ST_LEVEL;
 -- LICENSE-TIMESCALE for a copy of the license.
 \set CAGG_NAME_1ST_LEVEL conditions_summary_1
 \set CAGG_NAME_2TH_LEVEL conditions_summary_2
+\set CAGG_NAME_3TH_LEVEL conditions_summary_3
 --
 -- CAGG on hypertable (1st level)
 --
@@ -3662,16 +3964,40 @@ SELECT
 FROM :CAGG_NAME_1ST_LEVEL
 GROUP BY 1
 WITH NO DATA;
-psql:include/cagg_on_cagg_validations.sql:43: ERROR:  cannot create continuous aggregate with incompatible bucket width
+psql:include/cagg_on_cagg_validations.sql:44: ERROR:  cannot create continuous aggregate with incompatible bucket width
 DETAIL:  Time bucket width of "public.conditions_summary_2" [@ 16 mins] should be multiple of the time bucket width of "public.conditions_summary_1" [@ 5 mins].
 \d+ :CAGG_NAME_2TH_LEVEL
 \set ON_ERROR_STOP 1
 \set VERBOSITY terse
+-- Check for incorrect CAGGs
+\if :INTERVAL_TEST
+  INSERT INTO conditions ("time", temperature, device_id) VALUES ('2022-01-01 00:00:00-00', 10, 4);
+  INSERT INTO conditions ("time", temperature, device_id) VALUES ('2022-01-15 01:00:00-00', 20, 4);
+  INSERT INTO conditions ("time", temperature, device_id) VALUES ('2022-01-31 01:00:00-00', 30, 4);
+  CALL refresh_continuous_aggregate(:'CAGG_NAME_1ST_LEVEL', NULL, NULL);
+  CALL refresh_continuous_aggregate(:'CAGG_NAME_2TH_LEVEL', NULL, NULL);
+  CREATE MATERIALIZED VIEW :CAGG_NAME_3TH_LEVEL
+  WITH (timescaledb.continuous) AS
+  SELECT
+    \if :IS_TIME_DIMENSION_WITH_TIMEZONE_2TH
+      time_bucket(:BUCKET_WIDTH_3TH, "bucket", :'BUCKET_TZNAME_2TH') AS bucket
+    \else
+      time_bucket(:BUCKET_WIDTH_3TH, "bucket") AS bucket
+    \endif
+  FROM :CAGG_NAME_2TH_LEVEL
+  GROUP BY 1
+  WITH DATA;
+  \d+ :CAGG_NAME_3TH_LEVEL
+  --There should never be dulpicates in the output of the following query
+  SELECT * from :CAGG_NAME_3TH_LEVEL;
+  DROP MATERIALIZED VIEW IF EXISTS :CAGG_NAME_3TH_LEVEL;
+  DELETE FROM conditions WHERE device_id = 4;
+\endif
 --
 -- Cleanup
 --
 DROP MATERIALIZED VIEW IF EXISTS :CAGG_NAME_2TH_LEVEL;
-psql:include/cagg_on_cagg_validations.sql:53: NOTICE:  materialized view "conditions_summary_2" does not exist, skipping
+psql:include/cagg_on_cagg_validations.sql:86: NOTICE:  materialized view "conditions_summary_2" does not exist, skipping
 DROP MATERIALIZED VIEW IF EXISTS :CAGG_NAME_1ST_LEVEL;
 --
 -- Variable bucket size with the same timezones
@@ -3687,6 +4013,7 @@ DROP MATERIALIZED VIEW IF EXISTS :CAGG_NAME_1ST_LEVEL;
 -- LICENSE-TIMESCALE for a copy of the license.
 \set CAGG_NAME_1ST_LEVEL conditions_summary_1
 \set CAGG_NAME_2TH_LEVEL conditions_summary_2
+\set CAGG_NAME_3TH_LEVEL conditions_summary_3
 --
 -- CAGG on hypertable (1st level)
 --
@@ -3759,6 +4086,30 @@ UNION ALL
 
 \set ON_ERROR_STOP 1
 \set VERBOSITY terse
+-- Check for incorrect CAGGs
+\if :INTERVAL_TEST
+  INSERT INTO conditions ("time", temperature, device_id) VALUES ('2022-01-01 00:00:00-00', 10, 4);
+  INSERT INTO conditions ("time", temperature, device_id) VALUES ('2022-01-15 01:00:00-00', 20, 4);
+  INSERT INTO conditions ("time", temperature, device_id) VALUES ('2022-01-31 01:00:00-00', 30, 4);
+  CALL refresh_continuous_aggregate(:'CAGG_NAME_1ST_LEVEL', NULL, NULL);
+  CALL refresh_continuous_aggregate(:'CAGG_NAME_2TH_LEVEL', NULL, NULL);
+  CREATE MATERIALIZED VIEW :CAGG_NAME_3TH_LEVEL
+  WITH (timescaledb.continuous) AS
+  SELECT
+    \if :IS_TIME_DIMENSION_WITH_TIMEZONE_2TH
+      time_bucket(:BUCKET_WIDTH_3TH, "bucket", :'BUCKET_TZNAME_2TH') AS bucket
+    \else
+      time_bucket(:BUCKET_WIDTH_3TH, "bucket") AS bucket
+    \endif
+  FROM :CAGG_NAME_2TH_LEVEL
+  GROUP BY 1
+  WITH DATA;
+  \d+ :CAGG_NAME_3TH_LEVEL
+  --There should never be dulpicates in the output of the following query
+  SELECT * from :CAGG_NAME_3TH_LEVEL;
+  DROP MATERIALIZED VIEW IF EXISTS :CAGG_NAME_3TH_LEVEL;
+  DELETE FROM conditions WHERE device_id = 4;
+\endif
 --
 -- Cleanup
 --
@@ -3778,6 +4129,7 @@ DROP MATERIALIZED VIEW IF EXISTS :CAGG_NAME_1ST_LEVEL;
 -- LICENSE-TIMESCALE for a copy of the license.
 \set CAGG_NAME_1ST_LEVEL conditions_summary_1
 \set CAGG_NAME_2TH_LEVEL conditions_summary_2
+\set CAGG_NAME_3TH_LEVEL conditions_summary_3
 --
 -- CAGG on hypertable (1st level)
 --
@@ -3850,6 +4202,30 @@ UNION ALL
 
 \set ON_ERROR_STOP 1
 \set VERBOSITY terse
+-- Check for incorrect CAGGs
+\if :INTERVAL_TEST
+  INSERT INTO conditions ("time", temperature, device_id) VALUES ('2022-01-01 00:00:00-00', 10, 4);
+  INSERT INTO conditions ("time", temperature, device_id) VALUES ('2022-01-15 01:00:00-00', 20, 4);
+  INSERT INTO conditions ("time", temperature, device_id) VALUES ('2022-01-31 01:00:00-00', 30, 4);
+  CALL refresh_continuous_aggregate(:'CAGG_NAME_1ST_LEVEL', NULL, NULL);
+  CALL refresh_continuous_aggregate(:'CAGG_NAME_2TH_LEVEL', NULL, NULL);
+  CREATE MATERIALIZED VIEW :CAGG_NAME_3TH_LEVEL
+  WITH (timescaledb.continuous) AS
+  SELECT
+    \if :IS_TIME_DIMENSION_WITH_TIMEZONE_2TH
+      time_bucket(:BUCKET_WIDTH_3TH, "bucket", :'BUCKET_TZNAME_2TH') AS bucket
+    \else
+      time_bucket(:BUCKET_WIDTH_3TH, "bucket") AS bucket
+    \endif
+  FROM :CAGG_NAME_2TH_LEVEL
+  GROUP BY 1
+  WITH DATA;
+  \d+ :CAGG_NAME_3TH_LEVEL
+  --There should never be dulpicates in the output of the following query
+  SELECT * from :CAGG_NAME_3TH_LEVEL;
+  DROP MATERIALIZED VIEW IF EXISTS :CAGG_NAME_3TH_LEVEL;
+  DELETE FROM conditions WHERE device_id = 4;
+\endif
 --
 -- Cleanup
 --
@@ -3870,6 +4246,7 @@ DROP MATERIALIZED VIEW IF EXISTS :CAGG_NAME_1ST_LEVEL;
 -- LICENSE-TIMESCALE for a copy of the license.
 \set CAGG_NAME_1ST_LEVEL conditions_summary_1
 \set CAGG_NAME_2TH_LEVEL conditions_summary_2
+\set CAGG_NAME_3TH_LEVEL conditions_summary_3
 --
 -- CAGG on hypertable (1st level)
 --
@@ -3942,6 +4319,30 @@ UNION ALL
 
 \set ON_ERROR_STOP 1
 \set VERBOSITY terse
+-- Check for incorrect CAGGs
+\if :INTERVAL_TEST
+  INSERT INTO conditions ("time", temperature, device_id) VALUES ('2022-01-01 00:00:00-00', 10, 4);
+  INSERT INTO conditions ("time", temperature, device_id) VALUES ('2022-01-15 01:00:00-00', 20, 4);
+  INSERT INTO conditions ("time", temperature, device_id) VALUES ('2022-01-31 01:00:00-00', 30, 4);
+  CALL refresh_continuous_aggregate(:'CAGG_NAME_1ST_LEVEL', NULL, NULL);
+  CALL refresh_continuous_aggregate(:'CAGG_NAME_2TH_LEVEL', NULL, NULL);
+  CREATE MATERIALIZED VIEW :CAGG_NAME_3TH_LEVEL
+  WITH (timescaledb.continuous) AS
+  SELECT
+    \if :IS_TIME_DIMENSION_WITH_TIMEZONE_2TH
+      time_bucket(:BUCKET_WIDTH_3TH, "bucket", :'BUCKET_TZNAME_2TH') AS bucket
+    \else
+      time_bucket(:BUCKET_WIDTH_3TH, "bucket") AS bucket
+    \endif
+  FROM :CAGG_NAME_2TH_LEVEL
+  GROUP BY 1
+  WITH DATA;
+  \d+ :CAGG_NAME_3TH_LEVEL
+  --There should never be dulpicates in the output of the following query
+  SELECT * from :CAGG_NAME_3TH_LEVEL;
+  DROP MATERIALIZED VIEW IF EXISTS :CAGG_NAME_3TH_LEVEL;
+  DELETE FROM conditions WHERE device_id = 4;
+\endif
 --
 -- Cleanup
 --
@@ -3962,6 +4363,7 @@ DROP MATERIALIZED VIEW IF EXISTS :CAGG_NAME_1ST_LEVEL;
 -- LICENSE-TIMESCALE for a copy of the license.
 \set CAGG_NAME_1ST_LEVEL conditions_summary_1
 \set CAGG_NAME_2TH_LEVEL conditions_summary_2
+\set CAGG_NAME_3TH_LEVEL conditions_summary_3
 --
 -- CAGG on hypertable (1st level)
 --
@@ -4034,6 +4436,30 @@ UNION ALL
 
 \set ON_ERROR_STOP 1
 \set VERBOSITY terse
+-- Check for incorrect CAGGs
+\if :INTERVAL_TEST
+  INSERT INTO conditions ("time", temperature, device_id) VALUES ('2022-01-01 00:00:00-00', 10, 4);
+  INSERT INTO conditions ("time", temperature, device_id) VALUES ('2022-01-15 01:00:00-00', 20, 4);
+  INSERT INTO conditions ("time", temperature, device_id) VALUES ('2022-01-31 01:00:00-00', 30, 4);
+  CALL refresh_continuous_aggregate(:'CAGG_NAME_1ST_LEVEL', NULL, NULL);
+  CALL refresh_continuous_aggregate(:'CAGG_NAME_2TH_LEVEL', NULL, NULL);
+  CREATE MATERIALIZED VIEW :CAGG_NAME_3TH_LEVEL
+  WITH (timescaledb.continuous) AS
+  SELECT
+    \if :IS_TIME_DIMENSION_WITH_TIMEZONE_2TH
+      time_bucket(:BUCKET_WIDTH_3TH, "bucket", :'BUCKET_TZNAME_2TH') AS bucket
+    \else
+      time_bucket(:BUCKET_WIDTH_3TH, "bucket") AS bucket
+    \endif
+  FROM :CAGG_NAME_2TH_LEVEL
+  GROUP BY 1
+  WITH DATA;
+  \d+ :CAGG_NAME_3TH_LEVEL
+  --There should never be dulpicates in the output of the following query
+  SELECT * from :CAGG_NAME_3TH_LEVEL;
+  DROP MATERIALIZED VIEW IF EXISTS :CAGG_NAME_3TH_LEVEL;
+  DELETE FROM conditions WHERE device_id = 4;
+\endif
 --
 -- Cleanup
 --
@@ -4048,6 +4474,7 @@ DROP MATERIALIZED VIEW IF EXISTS :CAGG_NAME_1ST_LEVEL;
 -- LICENSE-TIMESCALE for a copy of the license.
 \set CAGG_NAME_1ST_LEVEL conditions_summary_1
 \set CAGG_NAME_2TH_LEVEL conditions_summary_2
+\set CAGG_NAME_3TH_LEVEL conditions_summary_3
 --
 -- CAGG on hypertable (1st level)
 --
@@ -4120,6 +4547,30 @@ UNION ALL
 
 \set ON_ERROR_STOP 1
 \set VERBOSITY terse
+-- Check for incorrect CAGGs
+\if :INTERVAL_TEST
+  INSERT INTO conditions ("time", temperature, device_id) VALUES ('2022-01-01 00:00:00-00', 10, 4);
+  INSERT INTO conditions ("time", temperature, device_id) VALUES ('2022-01-15 01:00:00-00', 20, 4);
+  INSERT INTO conditions ("time", temperature, device_id) VALUES ('2022-01-31 01:00:00-00', 30, 4);
+  CALL refresh_continuous_aggregate(:'CAGG_NAME_1ST_LEVEL', NULL, NULL);
+  CALL refresh_continuous_aggregate(:'CAGG_NAME_2TH_LEVEL', NULL, NULL);
+  CREATE MATERIALIZED VIEW :CAGG_NAME_3TH_LEVEL
+  WITH (timescaledb.continuous) AS
+  SELECT
+    \if :IS_TIME_DIMENSION_WITH_TIMEZONE_2TH
+      time_bucket(:BUCKET_WIDTH_3TH, "bucket", :'BUCKET_TZNAME_2TH') AS bucket
+    \else
+      time_bucket(:BUCKET_WIDTH_3TH, "bucket") AS bucket
+    \endif
+  FROM :CAGG_NAME_2TH_LEVEL
+  GROUP BY 1
+  WITH DATA;
+  \d+ :CAGG_NAME_3TH_LEVEL
+  --There should never be dulpicates in the output of the following query
+  SELECT * from :CAGG_NAME_3TH_LEVEL;
+  DROP MATERIALIZED VIEW IF EXISTS :CAGG_NAME_3TH_LEVEL;
+  DELETE FROM conditions WHERE device_id = 4;
+\endif
 --
 -- Cleanup
 --
@@ -4133,6 +4584,7 @@ DROP MATERIALIZED VIEW IF EXISTS :CAGG_NAME_1ST_LEVEL;
 -- LICENSE-TIMESCALE for a copy of the license.
 \set CAGG_NAME_1ST_LEVEL conditions_summary_1
 \set CAGG_NAME_2TH_LEVEL conditions_summary_2
+\set CAGG_NAME_3TH_LEVEL conditions_summary_3
 --
 -- CAGG on hypertable (1st level)
 --
@@ -4205,6 +4657,30 @@ UNION ALL
 
 \set ON_ERROR_STOP 1
 \set VERBOSITY terse
+-- Check for incorrect CAGGs
+\if :INTERVAL_TEST
+  INSERT INTO conditions ("time", temperature, device_id) VALUES ('2022-01-01 00:00:00-00', 10, 4);
+  INSERT INTO conditions ("time", temperature, device_id) VALUES ('2022-01-15 01:00:00-00', 20, 4);
+  INSERT INTO conditions ("time", temperature, device_id) VALUES ('2022-01-31 01:00:00-00', 30, 4);
+  CALL refresh_continuous_aggregate(:'CAGG_NAME_1ST_LEVEL', NULL, NULL);
+  CALL refresh_continuous_aggregate(:'CAGG_NAME_2TH_LEVEL', NULL, NULL);
+  CREATE MATERIALIZED VIEW :CAGG_NAME_3TH_LEVEL
+  WITH (timescaledb.continuous) AS
+  SELECT
+    \if :IS_TIME_DIMENSION_WITH_TIMEZONE_2TH
+      time_bucket(:BUCKET_WIDTH_3TH, "bucket", :'BUCKET_TZNAME_2TH') AS bucket
+    \else
+      time_bucket(:BUCKET_WIDTH_3TH, "bucket") AS bucket
+    \endif
+  FROM :CAGG_NAME_2TH_LEVEL
+  GROUP BY 1
+  WITH DATA;
+  \d+ :CAGG_NAME_3TH_LEVEL
+  --There should never be dulpicates in the output of the following query
+  SELECT * from :CAGG_NAME_3TH_LEVEL;
+  DROP MATERIALIZED VIEW IF EXISTS :CAGG_NAME_3TH_LEVEL;
+  DELETE FROM conditions WHERE device_id = 4;
+\endif
 --
 -- Cleanup
 --
@@ -4218,6 +4694,7 @@ DROP MATERIALIZED VIEW IF EXISTS :CAGG_NAME_1ST_LEVEL;
 -- LICENSE-TIMESCALE for a copy of the license.
 \set CAGG_NAME_1ST_LEVEL conditions_summary_1
 \set CAGG_NAME_2TH_LEVEL conditions_summary_2
+\set CAGG_NAME_3TH_LEVEL conditions_summary_3
 --
 -- CAGG on hypertable (1st level)
 --
@@ -4290,6 +4767,30 @@ UNION ALL
 
 \set ON_ERROR_STOP 1
 \set VERBOSITY terse
+-- Check for incorrect CAGGs
+\if :INTERVAL_TEST
+  INSERT INTO conditions ("time", temperature, device_id) VALUES ('2022-01-01 00:00:00-00', 10, 4);
+  INSERT INTO conditions ("time", temperature, device_id) VALUES ('2022-01-15 01:00:00-00', 20, 4);
+  INSERT INTO conditions ("time", temperature, device_id) VALUES ('2022-01-31 01:00:00-00', 30, 4);
+  CALL refresh_continuous_aggregate(:'CAGG_NAME_1ST_LEVEL', NULL, NULL);
+  CALL refresh_continuous_aggregate(:'CAGG_NAME_2TH_LEVEL', NULL, NULL);
+  CREATE MATERIALIZED VIEW :CAGG_NAME_3TH_LEVEL
+  WITH (timescaledb.continuous) AS
+  SELECT
+    \if :IS_TIME_DIMENSION_WITH_TIMEZONE_2TH
+      time_bucket(:BUCKET_WIDTH_3TH, "bucket", :'BUCKET_TZNAME_2TH') AS bucket
+    \else
+      time_bucket(:BUCKET_WIDTH_3TH, "bucket") AS bucket
+    \endif
+  FROM :CAGG_NAME_2TH_LEVEL
+  GROUP BY 1
+  WITH DATA;
+  \d+ :CAGG_NAME_3TH_LEVEL
+  --There should never be dulpicates in the output of the following query
+  SELECT * from :CAGG_NAME_3TH_LEVEL;
+  DROP MATERIALIZED VIEW IF EXISTS :CAGG_NAME_3TH_LEVEL;
+  DELETE FROM conditions WHERE device_id = 4;
+\endif
 --
 -- Cleanup
 --
@@ -4303,6 +4804,7 @@ DROP MATERIALIZED VIEW IF EXISTS :CAGG_NAME_1ST_LEVEL;
 -- LICENSE-TIMESCALE for a copy of the license.
 \set CAGG_NAME_1ST_LEVEL conditions_summary_1
 \set CAGG_NAME_2TH_LEVEL conditions_summary_2
+\set CAGG_NAME_3TH_LEVEL conditions_summary_3
 --
 -- CAGG on hypertable (1st level)
 --
@@ -4355,16 +4857,40 @@ SELECT
 FROM :CAGG_NAME_1ST_LEVEL
 GROUP BY 1
 WITH NO DATA;
-psql:include/cagg_on_cagg_validations.sql:43: ERROR:  cannot create continuous aggregate with incompatible bucket width
-DETAIL:  Time bucket width of "public.conditions_summary_2" [@ 360 days] should be multiple of the time bucket width of "public.conditions_summary_1" [@ 7 days].
+psql:include/cagg_on_cagg_validations.sql:44: ERROR:  cannot create continuous aggregate with incompatible bucket width
+DETAIL:  Time bucket width of "public.conditions_summary_2" [@ 1 year] should be multiple of the time bucket width of "public.conditions_summary_1" [@ 7 days].
 \d+ :CAGG_NAME_2TH_LEVEL
 \set ON_ERROR_STOP 1
 \set VERBOSITY terse
+-- Check for incorrect CAGGs
+\if :INTERVAL_TEST
+  INSERT INTO conditions ("time", temperature, device_id) VALUES ('2022-01-01 00:00:00-00', 10, 4);
+  INSERT INTO conditions ("time", temperature, device_id) VALUES ('2022-01-15 01:00:00-00', 20, 4);
+  INSERT INTO conditions ("time", temperature, device_id) VALUES ('2022-01-31 01:00:00-00', 30, 4);
+  CALL refresh_continuous_aggregate(:'CAGG_NAME_1ST_LEVEL', NULL, NULL);
+  CALL refresh_continuous_aggregate(:'CAGG_NAME_2TH_LEVEL', NULL, NULL);
+  CREATE MATERIALIZED VIEW :CAGG_NAME_3TH_LEVEL
+  WITH (timescaledb.continuous) AS
+  SELECT
+    \if :IS_TIME_DIMENSION_WITH_TIMEZONE_2TH
+      time_bucket(:BUCKET_WIDTH_3TH, "bucket", :'BUCKET_TZNAME_2TH') AS bucket
+    \else
+      time_bucket(:BUCKET_WIDTH_3TH, "bucket") AS bucket
+    \endif
+  FROM :CAGG_NAME_2TH_LEVEL
+  GROUP BY 1
+  WITH DATA;
+  \d+ :CAGG_NAME_3TH_LEVEL
+  --There should never be dulpicates in the output of the following query
+  SELECT * from :CAGG_NAME_3TH_LEVEL;
+  DROP MATERIALIZED VIEW IF EXISTS :CAGG_NAME_3TH_LEVEL;
+  DELETE FROM conditions WHERE device_id = 4;
+\endif
 --
 -- Cleanup
 --
 DROP MATERIALIZED VIEW IF EXISTS :CAGG_NAME_2TH_LEVEL;
-psql:include/cagg_on_cagg_validations.sql:53: NOTICE:  materialized view "conditions_summary_2" does not exist, skipping
+psql:include/cagg_on_cagg_validations.sql:86: NOTICE:  materialized view "conditions_summary_2" does not exist, skipping
 DROP MATERIALIZED VIEW IF EXISTS :CAGG_NAME_1ST_LEVEL;
 \set BUCKET_WIDTH_1ST 'INTERVAL \'1 week\''
 \set BUCKET_WIDTH_2TH 'INTERVAL \'1 month\''
@@ -4374,6 +4900,7 @@ DROP MATERIALIZED VIEW IF EXISTS :CAGG_NAME_1ST_LEVEL;
 -- LICENSE-TIMESCALE for a copy of the license.
 \set CAGG_NAME_1ST_LEVEL conditions_summary_1
 \set CAGG_NAME_2TH_LEVEL conditions_summary_2
+\set CAGG_NAME_3TH_LEVEL conditions_summary_3
 --
 -- CAGG on hypertable (1st level)
 --
@@ -4426,16 +4953,40 @@ SELECT
 FROM :CAGG_NAME_1ST_LEVEL
 GROUP BY 1
 WITH NO DATA;
-psql:include/cagg_on_cagg_validations.sql:43: ERROR:  cannot create continuous aggregate with incompatible bucket width
-DETAIL:  Time bucket width of "public.conditions_summary_2" [@ 30 days] should be multiple of the time bucket width of "public.conditions_summary_1" [@ 7 days].
+psql:include/cagg_on_cagg_validations.sql:44: ERROR:  cannot create continuous aggregate with incompatible bucket width
+DETAIL:  Time bucket width of "public.conditions_summary_2" [@ 1 mon] should be multiple of the time bucket width of "public.conditions_summary_1" [@ 7 days].
 \d+ :CAGG_NAME_2TH_LEVEL
 \set ON_ERROR_STOP 1
 \set VERBOSITY terse
+-- Check for incorrect CAGGs
+\if :INTERVAL_TEST
+  INSERT INTO conditions ("time", temperature, device_id) VALUES ('2022-01-01 00:00:00-00', 10, 4);
+  INSERT INTO conditions ("time", temperature, device_id) VALUES ('2022-01-15 01:00:00-00', 20, 4);
+  INSERT INTO conditions ("time", temperature, device_id) VALUES ('2022-01-31 01:00:00-00', 30, 4);
+  CALL refresh_continuous_aggregate(:'CAGG_NAME_1ST_LEVEL', NULL, NULL);
+  CALL refresh_continuous_aggregate(:'CAGG_NAME_2TH_LEVEL', NULL, NULL);
+  CREATE MATERIALIZED VIEW :CAGG_NAME_3TH_LEVEL
+  WITH (timescaledb.continuous) AS
+  SELECT
+    \if :IS_TIME_DIMENSION_WITH_TIMEZONE_2TH
+      time_bucket(:BUCKET_WIDTH_3TH, "bucket", :'BUCKET_TZNAME_2TH') AS bucket
+    \else
+      time_bucket(:BUCKET_WIDTH_3TH, "bucket") AS bucket
+    \endif
+  FROM :CAGG_NAME_2TH_LEVEL
+  GROUP BY 1
+  WITH DATA;
+  \d+ :CAGG_NAME_3TH_LEVEL
+  --There should never be dulpicates in the output of the following query
+  SELECT * from :CAGG_NAME_3TH_LEVEL;
+  DROP MATERIALIZED VIEW IF EXISTS :CAGG_NAME_3TH_LEVEL;
+  DELETE FROM conditions WHERE device_id = 4;
+\endif
 --
 -- Cleanup
 --
 DROP MATERIALIZED VIEW IF EXISTS :CAGG_NAME_2TH_LEVEL;
-psql:include/cagg_on_cagg_validations.sql:53: NOTICE:  materialized view "conditions_summary_2" does not exist, skipping
+psql:include/cagg_on_cagg_validations.sql:86: NOTICE:  materialized view "conditions_summary_2" does not exist, skipping
 DROP MATERIALIZED VIEW IF EXISTS :CAGG_NAME_1ST_LEVEL;
 -- bug report 5277
 \set IS_TIME_DIMENSION_WITH_TIMEZONE_1ST FALSE
@@ -4449,6 +5000,7 @@ DROP MATERIALIZED VIEW IF EXISTS :CAGG_NAME_1ST_LEVEL;
 -- LICENSE-TIMESCALE for a copy of the license.
 \set CAGG_NAME_1ST_LEVEL conditions_summary_1
 \set CAGG_NAME_2TH_LEVEL conditions_summary_2
+\set CAGG_NAME_3TH_LEVEL conditions_summary_3
 --
 -- CAGG on hypertable (1st level)
 --
@@ -4521,6 +5073,30 @@ UNION ALL
 
 \set ON_ERROR_STOP 1
 \set VERBOSITY terse
+-- Check for incorrect CAGGs
+\if :INTERVAL_TEST
+  INSERT INTO conditions ("time", temperature, device_id) VALUES ('2022-01-01 00:00:00-00', 10, 4);
+  INSERT INTO conditions ("time", temperature, device_id) VALUES ('2022-01-15 01:00:00-00', 20, 4);
+  INSERT INTO conditions ("time", temperature, device_id) VALUES ('2022-01-31 01:00:00-00', 30, 4);
+  CALL refresh_continuous_aggregate(:'CAGG_NAME_1ST_LEVEL', NULL, NULL);
+  CALL refresh_continuous_aggregate(:'CAGG_NAME_2TH_LEVEL', NULL, NULL);
+  CREATE MATERIALIZED VIEW :CAGG_NAME_3TH_LEVEL
+  WITH (timescaledb.continuous) AS
+  SELECT
+    \if :IS_TIME_DIMENSION_WITH_TIMEZONE_2TH
+      time_bucket(:BUCKET_WIDTH_3TH, "bucket", :'BUCKET_TZNAME_2TH') AS bucket
+    \else
+      time_bucket(:BUCKET_WIDTH_3TH, "bucket") AS bucket
+    \endif
+  FROM :CAGG_NAME_2TH_LEVEL
+  GROUP BY 1
+  WITH DATA;
+  \d+ :CAGG_NAME_3TH_LEVEL
+  --There should never be dulpicates in the output of the following query
+  SELECT * from :CAGG_NAME_3TH_LEVEL;
+  DROP MATERIALIZED VIEW IF EXISTS :CAGG_NAME_3TH_LEVEL;
+  DELETE FROM conditions WHERE device_id = 4;
+\endif
 --
 -- Cleanup
 --
@@ -4534,6 +5110,7 @@ DROP MATERIALIZED VIEW IF EXISTS :CAGG_NAME_1ST_LEVEL;
 -- LICENSE-TIMESCALE for a copy of the license.
 \set CAGG_NAME_1ST_LEVEL conditions_summary_1
 \set CAGG_NAME_2TH_LEVEL conditions_summary_2
+\set CAGG_NAME_3TH_LEVEL conditions_summary_3
 --
 -- CAGG on hypertable (1st level)
 --
@@ -4606,6 +5183,30 @@ UNION ALL
 
 \set ON_ERROR_STOP 1
 \set VERBOSITY terse
+-- Check for incorrect CAGGs
+\if :INTERVAL_TEST
+  INSERT INTO conditions ("time", temperature, device_id) VALUES ('2022-01-01 00:00:00-00', 10, 4);
+  INSERT INTO conditions ("time", temperature, device_id) VALUES ('2022-01-15 01:00:00-00', 20, 4);
+  INSERT INTO conditions ("time", temperature, device_id) VALUES ('2022-01-31 01:00:00-00', 30, 4);
+  CALL refresh_continuous_aggregate(:'CAGG_NAME_1ST_LEVEL', NULL, NULL);
+  CALL refresh_continuous_aggregate(:'CAGG_NAME_2TH_LEVEL', NULL, NULL);
+  CREATE MATERIALIZED VIEW :CAGG_NAME_3TH_LEVEL
+  WITH (timescaledb.continuous) AS
+  SELECT
+    \if :IS_TIME_DIMENSION_WITH_TIMEZONE_2TH
+      time_bucket(:BUCKET_WIDTH_3TH, "bucket", :'BUCKET_TZNAME_2TH') AS bucket
+    \else
+      time_bucket(:BUCKET_WIDTH_3TH, "bucket") AS bucket
+    \endif
+  FROM :CAGG_NAME_2TH_LEVEL
+  GROUP BY 1
+  WITH DATA;
+  \d+ :CAGG_NAME_3TH_LEVEL
+  --There should never be dulpicates in the output of the following query
+  SELECT * from :CAGG_NAME_3TH_LEVEL;
+  DROP MATERIALIZED VIEW IF EXISTS :CAGG_NAME_3TH_LEVEL;
+  DELETE FROM conditions WHERE device_id = 4;
+\endif
 --
 -- Cleanup
 --
@@ -4619,6 +5220,7 @@ DROP MATERIALIZED VIEW IF EXISTS :CAGG_NAME_1ST_LEVEL;
 -- LICENSE-TIMESCALE for a copy of the license.
 \set CAGG_NAME_1ST_LEVEL conditions_summary_1
 \set CAGG_NAME_2TH_LEVEL conditions_summary_2
+\set CAGG_NAME_3TH_LEVEL conditions_summary_3
 --
 -- CAGG on hypertable (1st level)
 --
@@ -4691,6 +5293,30 @@ UNION ALL
 
 \set ON_ERROR_STOP 1
 \set VERBOSITY terse
+-- Check for incorrect CAGGs
+\if :INTERVAL_TEST
+  INSERT INTO conditions ("time", temperature, device_id) VALUES ('2022-01-01 00:00:00-00', 10, 4);
+  INSERT INTO conditions ("time", temperature, device_id) VALUES ('2022-01-15 01:00:00-00', 20, 4);
+  INSERT INTO conditions ("time", temperature, device_id) VALUES ('2022-01-31 01:00:00-00', 30, 4);
+  CALL refresh_continuous_aggregate(:'CAGG_NAME_1ST_LEVEL', NULL, NULL);
+  CALL refresh_continuous_aggregate(:'CAGG_NAME_2TH_LEVEL', NULL, NULL);
+  CREATE MATERIALIZED VIEW :CAGG_NAME_3TH_LEVEL
+  WITH (timescaledb.continuous) AS
+  SELECT
+    \if :IS_TIME_DIMENSION_WITH_TIMEZONE_2TH
+      time_bucket(:BUCKET_WIDTH_3TH, "bucket", :'BUCKET_TZNAME_2TH') AS bucket
+    \else
+      time_bucket(:BUCKET_WIDTH_3TH, "bucket") AS bucket
+    \endif
+  FROM :CAGG_NAME_2TH_LEVEL
+  GROUP BY 1
+  WITH DATA;
+  \d+ :CAGG_NAME_3TH_LEVEL
+  --There should never be dulpicates in the output of the following query
+  SELECT * from :CAGG_NAME_3TH_LEVEL;
+  DROP MATERIALIZED VIEW IF EXISTS :CAGG_NAME_3TH_LEVEL;
+  DELETE FROM conditions WHERE device_id = 4;
+\endif
 --
 -- Cleanup
 --
@@ -4705,6 +5331,7 @@ DROP MATERIALIZED VIEW IF EXISTS :CAGG_NAME_1ST_LEVEL;
 -- LICENSE-TIMESCALE for a copy of the license.
 \set CAGG_NAME_1ST_LEVEL conditions_summary_1
 \set CAGG_NAME_2TH_LEVEL conditions_summary_2
+\set CAGG_NAME_3TH_LEVEL conditions_summary_3
 --
 -- CAGG on hypertable (1st level)
 --
@@ -4777,6 +5404,30 @@ UNION ALL
 
 \set ON_ERROR_STOP 1
 \set VERBOSITY terse
+-- Check for incorrect CAGGs
+\if :INTERVAL_TEST
+  INSERT INTO conditions ("time", temperature, device_id) VALUES ('2022-01-01 00:00:00-00', 10, 4);
+  INSERT INTO conditions ("time", temperature, device_id) VALUES ('2022-01-15 01:00:00-00', 20, 4);
+  INSERT INTO conditions ("time", temperature, device_id) VALUES ('2022-01-31 01:00:00-00', 30, 4);
+  CALL refresh_continuous_aggregate(:'CAGG_NAME_1ST_LEVEL', NULL, NULL);
+  CALL refresh_continuous_aggregate(:'CAGG_NAME_2TH_LEVEL', NULL, NULL);
+  CREATE MATERIALIZED VIEW :CAGG_NAME_3TH_LEVEL
+  WITH (timescaledb.continuous) AS
+  SELECT
+    \if :IS_TIME_DIMENSION_WITH_TIMEZONE_2TH
+      time_bucket(:BUCKET_WIDTH_3TH, "bucket", :'BUCKET_TZNAME_2TH') AS bucket
+    \else
+      time_bucket(:BUCKET_WIDTH_3TH, "bucket") AS bucket
+    \endif
+  FROM :CAGG_NAME_2TH_LEVEL
+  GROUP BY 1
+  WITH DATA;
+  \d+ :CAGG_NAME_3TH_LEVEL
+  --There should never be dulpicates in the output of the following query
+  SELECT * from :CAGG_NAME_3TH_LEVEL;
+  DROP MATERIALIZED VIEW IF EXISTS :CAGG_NAME_3TH_LEVEL;
+  DELETE FROM conditions WHERE device_id = 4;
+\endif
 --
 -- Cleanup
 --
@@ -4791,6 +5442,7 @@ DROP MATERIALIZED VIEW IF EXISTS :CAGG_NAME_1ST_LEVEL;
 -- LICENSE-TIMESCALE for a copy of the license.
 \set CAGG_NAME_1ST_LEVEL conditions_summary_1
 \set CAGG_NAME_2TH_LEVEL conditions_summary_2
+\set CAGG_NAME_3TH_LEVEL conditions_summary_3
 --
 -- CAGG on hypertable (1st level)
 --
@@ -4843,16 +5495,40 @@ SELECT
 FROM :CAGG_NAME_1ST_LEVEL
 GROUP BY 1
 WITH NO DATA;
-psql:include/cagg_on_cagg_validations.sql:43: ERROR:  cannot create continuous aggregate with incompatible bucket width
+psql:include/cagg_on_cagg_validations.sql:44: ERROR:  cannot create continuous aggregate with incompatible bucket width
 DETAIL:  Time bucket width of "public.conditions_summary_2" [@ 0.00116 secs] should be multiple of the time bucket width of "public.conditions_summary_1" [@ 0.000146 secs].
 \d+ :CAGG_NAME_2TH_LEVEL
 \set ON_ERROR_STOP 1
 \set VERBOSITY terse
+-- Check for incorrect CAGGs
+\if :INTERVAL_TEST
+  INSERT INTO conditions ("time", temperature, device_id) VALUES ('2022-01-01 00:00:00-00', 10, 4);
+  INSERT INTO conditions ("time", temperature, device_id) VALUES ('2022-01-15 01:00:00-00', 20, 4);
+  INSERT INTO conditions ("time", temperature, device_id) VALUES ('2022-01-31 01:00:00-00', 30, 4);
+  CALL refresh_continuous_aggregate(:'CAGG_NAME_1ST_LEVEL', NULL, NULL);
+  CALL refresh_continuous_aggregate(:'CAGG_NAME_2TH_LEVEL', NULL, NULL);
+  CREATE MATERIALIZED VIEW :CAGG_NAME_3TH_LEVEL
+  WITH (timescaledb.continuous) AS
+  SELECT
+    \if :IS_TIME_DIMENSION_WITH_TIMEZONE_2TH
+      time_bucket(:BUCKET_WIDTH_3TH, "bucket", :'BUCKET_TZNAME_2TH') AS bucket
+    \else
+      time_bucket(:BUCKET_WIDTH_3TH, "bucket") AS bucket
+    \endif
+  FROM :CAGG_NAME_2TH_LEVEL
+  GROUP BY 1
+  WITH DATA;
+  \d+ :CAGG_NAME_3TH_LEVEL
+  --There should never be dulpicates in the output of the following query
+  SELECT * from :CAGG_NAME_3TH_LEVEL;
+  DROP MATERIALIZED VIEW IF EXISTS :CAGG_NAME_3TH_LEVEL;
+  DELETE FROM conditions WHERE device_id = 4;
+\endif
 --
 -- Cleanup
 --
 DROP MATERIALIZED VIEW IF EXISTS :CAGG_NAME_2TH_LEVEL;
-psql:include/cagg_on_cagg_validations.sql:53: NOTICE:  materialized view "conditions_summary_2" does not exist, skipping
+psql:include/cagg_on_cagg_validations.sql:86: NOTICE:  materialized view "conditions_summary_2" does not exist, skipping
 DROP MATERIALIZED VIEW IF EXISTS :CAGG_NAME_1ST_LEVEL;
 -- Cleanup
 \c :TEST_DBNAME :ROLE_CLUSTER_SUPERUSER;

--- a/tsl/test/sql/cagg_on_cagg.sql
+++ b/tsl/test/sql/cagg_on_cagg.sql
@@ -7,6 +7,7 @@
 \set IS_TIME_DIMENSION_WITH_TIMEZONE_1ST FALSE
 \set IS_TIME_DIMENSION_WITH_TIMEZONE_2TH FALSE
 \set IS_JOIN FALSE
+\set INTERVAL_TEST FALSE
 -- ########################################################
 -- ## INTEGER data type tests
 -- ########################################################
@@ -213,6 +214,14 @@ SET timezone TO 'UTC';
 \set WARNING_MESSAGE '-- SHOULD WORK'
 \ir include/cagg_on_cagg_validations.sql
 
+--#Bugfix 5734 #1
+\set INTERVAL_TEST TRUE
+\set BUCKET_WIDTH_1ST 'INTERVAL \'1 hour\''
+\set BUCKET_WIDTH_2TH 'INTERVAL \'1 day\''
+\set BUCKET_WIDTH_3TH 'INTERVAL \'1 month\''
+\ir include/cagg_on_cagg_validations.sql
+\set INTERVAL_TEST FALSE
+
 --
 -- Variable bucket size with different timezones
 --
@@ -222,6 +231,14 @@ SET timezone TO 'UTC';
 \set BUCKET_WIDTH_2TH 'INTERVAL \'1 month\''
 \set WARNING_MESSAGE '-- SHOULD WORK'
 \ir include/cagg_on_cagg_validations.sql
+
+--#Bugfix 5734 #2
+\set INTERVAL_TEST TRUE
+\set BUCKET_WIDTH_1ST 'INTERVAL \'1 hour\''
+\set BUCKET_WIDTH_2TH 'INTERVAL \'1 day\''
+\set BUCKET_WIDTH_3TH 'INTERVAL \'1 month\''
+\ir include/cagg_on_cagg_validations.sql
+\set INTERVAL_TEST FALSE
 
 --
 -- TZ bucket on top of non-TZ bucket
@@ -233,6 +250,14 @@ SET timezone TO 'UTC';
 \set BUCKET_WIDTH_2TH 'INTERVAL \'1 month\''
 \set WARNING_MESSAGE '-- SHOULD WORK'
 \ir include/cagg_on_cagg_validations.sql
+
+--#Bugfix 5734 #3
+\set INTERVAL_TEST TRUE
+\set BUCKET_WIDTH_1ST 'INTERVAL \'1 hour\''
+\set BUCKET_WIDTH_2TH 'INTERVAL \'1 day\''
+\set BUCKET_WIDTH_3TH 'INTERVAL \'1 month\''
+\ir include/cagg_on_cagg_validations.sql
+\set INTERVAL_TEST FALSE
 
 --
 -- non-TZ bucket on top of TZ bucket

--- a/tsl/test/sql/cagg_on_cagg_dist_ht.sql
+++ b/tsl/test/sql/cagg_on_cagg_dist_ht.sql
@@ -10,6 +10,7 @@
 \set DATA_NODE_1 :TEST_DBNAME _1
 \set DATA_NODE_2 :TEST_DBNAME _2
 \set DATA_NODE_3 :TEST_DBNAME _3
+\set INTERVAL_TEST FALSE
 
 \ir include/remote_exec.sql
 
@@ -33,6 +34,7 @@ GRANT CREATE ON SCHEMA public TO :ROLE_DEFAULT_PERM_USER;
 -- Current test variables
 \set IS_TIME_DIMENSION FALSE
 \set TIME_DIMENSION_DATATYPE INTEGER
+\set INTERVAL_TEST FALSE
 \set CAGG_NAME_1ST_LEVEL conditions_summary_1_1
 \set CAGG_NAME_2TH_LEVEL conditions_summary_2_5
 \set CAGG_NAME_3TH_LEVEL conditions_summary_3_10
@@ -234,6 +236,14 @@ SET timezone TO 'UTC';
 \set WARNING_MESSAGE '-- SHOULD WORK'
 \ir include/cagg_on_cagg_validations.sql
 
+--#Bugfix 5734 #1
+\set INTERVAL_TEST TRUE
+\set BUCKET_WIDTH_1ST 'INTERVAL \'1 hour\''
+\set BUCKET_WIDTH_2TH 'INTERVAL \'1 day\''
+\set BUCKET_WIDTH_3TH 'INTERVAL \'1 month\''
+\ir include/cagg_on_cagg_validations.sql
+\set INTERVAL_TEST FALSE
+
 --
 -- Variable bucket size with different timezones
 --
@@ -243,6 +253,14 @@ SET timezone TO 'UTC';
 \set BUCKET_WIDTH_2TH 'INTERVAL \'1 month\''
 \set WARNING_MESSAGE '-- SHOULD WORK'
 \ir include/cagg_on_cagg_validations.sql
+
+--#Bugfix 5734 #2
+\set INTERVAL_TEST TRUE
+\set BUCKET_WIDTH_1ST 'INTERVAL \'1 hour\''
+\set BUCKET_WIDTH_2TH 'INTERVAL \'1 day\''
+\set BUCKET_WIDTH_3TH 'INTERVAL \'1 month\''
+\ir include/cagg_on_cagg_validations.sql
+\set INTERVAL_TEST FALSE
 
 --
 -- TZ bucket on top of non-TZ bucket
@@ -255,6 +273,14 @@ SET timezone TO 'UTC';
 \set WARNING_MESSAGE '-- SHOULD WORK'
 \ir include/cagg_on_cagg_validations.sql
 
+--#Bugfix 5734 #3
+\set INTERVAL_TEST TRUE
+\set BUCKET_WIDTH_1ST 'INTERVAL \'1 hour\''
+\set BUCKET_WIDTH_2TH 'INTERVAL \'1 day\''
+\set BUCKET_WIDTH_3TH 'INTERVAL \'1 month\''
+\ir include/cagg_on_cagg_validations.sql
+\set INTERVAL_TEST FALSE
+
 --
 -- non-TZ bucket on top of TZ bucket
 --
@@ -265,6 +291,7 @@ SET timezone TO 'UTC';
 \set BUCKET_WIDTH_2TH 'INTERVAL \'1 month\''
 \set WARNING_MESSAGE '-- SHOULD WORK'
 \ir include/cagg_on_cagg_validations.sql
+\set INTERVAL_TEST FALSE
 
 -- bug report 5231
 \set BUCKET_WIDTH_1ST 'INTERVAL \'1 day\''

--- a/tsl/test/sql/cagg_on_cagg_joins.sql
+++ b/tsl/test/sql/cagg_on_cagg_joins.sql
@@ -7,6 +7,7 @@
 \set IS_TIME_DIMENSION_WITH_TIMEZONE_1ST FALSE
 \set IS_TIME_DIMENSION_WITH_TIMEZONE_2TH FALSE
 \set IS_JOIN TRUE
+\set INTERVAL_TEST FALSE
 -- ########################################################
 -- ## INTEGER data type tests
 -- ########################################################

--- a/tsl/test/sql/cagg_on_cagg_joins_dist_ht.sql
+++ b/tsl/test/sql/cagg_on_cagg_joins_dist_ht.sql
@@ -10,6 +10,7 @@
 \set DATA_NODE_1 :TEST_DBNAME _1
 \set DATA_NODE_2 :TEST_DBNAME _2
 \set DATA_NODE_3 :TEST_DBNAME _3
+\set INTERVAL_TEST FALSE
 
 \ir include/remote_exec.sql
 

--- a/tsl/test/sql/include/cagg_on_cagg_setup.sql
+++ b/tsl/test/sql/include/cagg_on_cagg_setup.sql
@@ -70,3 +70,4 @@ DROP TABLE IF EXISTS conditions CASCADE;
     INSERT INTO conditions ("time", temperature, device_id) VALUES (2,  5, 2);
     INSERT INTO conditions ("time", temperature, device_id) VALUES (5, 20, 3);
 \endif
+

--- a/tsl/test/sql/include/cagg_on_cagg_validations.sql
+++ b/tsl/test/sql/include/cagg_on_cagg_validations.sql
@@ -4,6 +4,7 @@
 
 \set CAGG_NAME_1ST_LEVEL conditions_summary_1
 \set CAGG_NAME_2TH_LEVEL conditions_summary_2
+\set CAGG_NAME_3TH_LEVEL conditions_summary_3
 
 --
 -- CAGG on hypertable (1st level)
@@ -46,6 +47,38 @@ WITH NO DATA;
 
 \set ON_ERROR_STOP 1
 \set VERBOSITY terse
+
+-- Check for incorrect CAGGs
+\if :INTERVAL_TEST
+
+  INSERT INTO conditions ("time", temperature, device_id) VALUES ('2022-01-01 00:00:00-00', 10, 4);
+  INSERT INTO conditions ("time", temperature, device_id) VALUES ('2022-01-15 01:00:00-00', 20, 4);
+  INSERT INTO conditions ("time", temperature, device_id) VALUES ('2022-01-31 01:00:00-00', 30, 4);
+
+  CALL refresh_continuous_aggregate(:'CAGG_NAME_1ST_LEVEL', NULL, NULL);
+  CALL refresh_continuous_aggregate(:'CAGG_NAME_2TH_LEVEL', NULL, NULL);
+
+  CREATE MATERIALIZED VIEW :CAGG_NAME_3TH_LEVEL
+  WITH (timescaledb.continuous) AS
+  SELECT
+    \if :IS_TIME_DIMENSION_WITH_TIMEZONE_2TH
+      time_bucket(:BUCKET_WIDTH_3TH, "bucket", :'BUCKET_TZNAME_2TH') AS bucket
+    \else
+      time_bucket(:BUCKET_WIDTH_3TH, "bucket") AS bucket
+    \endif
+  FROM :CAGG_NAME_2TH_LEVEL
+  GROUP BY 1
+  WITH DATA;
+
+  \d+ :CAGG_NAME_3TH_LEVEL
+
+  --There should never be dulpicates in the output of the following query
+
+  SELECT * from :CAGG_NAME_3TH_LEVEL;
+
+  DROP MATERIALIZED VIEW IF EXISTS :CAGG_NAME_3TH_LEVEL;
+  DELETE FROM conditions WHERE device_id = 4;
+\endif
 
 --
 -- Cleanup


### PR DESCRIPTION
For Hierarchical continuous aggregates with variable bucket size, the interval was wrongly manipulated in the process. It was introduced by commit 5b60343ac4 .

Now it is corrected by creating a copy of interval structure for validation purposes and keeping the original structure untouched.

Fixes #5734