### PR TITLE
Allow Replica Identity (Alter Table) on CAGGs

### DIFF
--- a/.unreleased/PR_5868
+++ b/.unreleased/PR_5868
@@ -1,0 +1,1 @@
+Implements: #5868 Allows ALTER TABLE ... REPLICA IDENTITY (FULL|INDEX) on materialized hypertables (continuoues aggregates)

--- a/src/process_utility.c
+++ b/src/process_utility.c
@@ -199,6 +199,7 @@ check_continuous_agg_alter_table_allowed(Hypertable *ht, AlterTableStmt *stmt)
 			case AT_AddIndex:
 			case AT_ReAddIndex:
 			case AT_SetRelOptions:
+			case AT_ReplicaIdentity:
 				/* allowed on materialization tables */
 				continue;
 			default:


### PR DESCRIPTION
This commit is a follow up of #5515, which added support for ALTER TABLE ... REPLICA IDENTITY (FULL | INDEX) on hypertables.

This commit allows the execution against materialized hypertables to enable update / delete operations on continuous aggregates when logical replication in enabled for them.