### PR TITLE
Improved parallel DecompressChunk worker selection

### DIFF
--- a/src/import/allpaths.c
+++ b/src/import/allpaths.c
@@ -90,7 +90,7 @@ set_tablesample_rel_pathlist(PlannerInfo *root, RelOptInfo *rel, RangeTblEntry *
 }
 
 /* copied from allpaths.c */
-void
+static void
 ts_create_plain_partial_paths(PlannerInfo *root, RelOptInfo *rel)
 {
 	int parallel_workers;

--- a/src/import/allpaths.h
+++ b/src/import/allpaths.h
@@ -11,7 +11,6 @@
 
 #include "export.h"
 
-extern TSDLLEXPORT void ts_create_plain_partial_paths(PlannerInfo *root, RelOptInfo *rel);
 extern void ts_set_rel_size(PlannerInfo *root, RelOptInfo *rel, Index rti, RangeTblEntry *rte);
 extern void ts_set_append_rel_pathlist(PlannerInfo *root, RelOptInfo *rel, Index rti,
 									   RangeTblEntry *rte);

--- a/test/sql/updates/post.compression.sql
+++ b/test/sql/updates/post.compression.sql
@@ -2,7 +2,7 @@
 -- Please see the included NOTICE for copyright information and
 -- LICENSE-APACHE for a copy of the license.
 
-SELECT * FROM compress ORDER BY time DESC, small_cardinality;
+SELECT * FROM compress ORDER BY time DESC, small_cardinality, large_cardinality, some_double, some_int, some_custom, some_bool;
 
 INSERT INTO compress
 SELECT g, 'QW', g::text, 2, 0, (100,4)::custom_type_for_compression, false
@@ -17,7 +17,7 @@ WHERE
   hypertable.table_name = 'compress'
   AND chunk.compressed_chunk_id IS NULL;
 
-SELECT * FROM compress ORDER BY time DESC, small_cardinality;
+SELECT * FROM compress ORDER BY time DESC, small_cardinality, large_cardinality, some_double, some_int, some_custom, some_bool;
 
 \x on
 WITH hypertables AS (

--- a/tsl/test/expected/compression.out
+++ b/tsl/test/expected/compression.out
@@ -1943,3 +1943,52 @@ SELECT count(*) FROM :chunk_name;
   1000
 (1 row)
 
+-- Test that parallel plans are chosen even if partial and small chunks are involved
+RESET min_parallel_index_scan_size;
+RESET min_parallel_table_scan_size;
+CREATE TABLE ht_metrics_partially_compressed(time timestamptz, device int, value float);
+SELECT create_hypertable('ht_metrics_partially_compressed','time',create_default_indexes:=false);
+NOTICE:  adding not-null constraint to column "time"
+               create_hypertable               
+-----------------------------------------------
+ (41,public,ht_metrics_partially_compressed,t)
+(1 row)
+
+ALTER TABLE ht_metrics_partially_compressed SET (timescaledb.compress, timescaledb.compress_segmentby='device');
+INSERT INTO ht_metrics_partially_compressed
+SELECT time, device, device * 0.1 FROM
+   generate_series('2020-01-01'::timestamptz,'2020-01-02'::timestamptz, INTERVAL '1 m') g(time),
+   LATERAL (SELECT generate_series(1,2) AS device) g2;
+SELECT compress_chunk(c) FROM show_chunks('ht_metrics_partially_compressed') c;
+              compress_chunk              
+------------------------------------------
+ _timescaledb_internal._hyper_41_75_chunk
+ _timescaledb_internal._hyper_41_76_chunk
+(2 rows)
+
+INSERT INTO ht_metrics_partially_compressed VALUES ('2020-01-01'::timestamptz, 1, 0.1);
+:explain
+SELECT * FROM ht_metrics_partially_compressed ORDER BY time DESC, device LIMIT 1;
+                                                                                                                                                            QUERY PLAN                                                                                                                                                             
+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Limit
+   Output: _hyper_41_75_chunk."time", _hyper_41_75_chunk.device, _hyper_41_75_chunk.value
+   ->  Gather Merge
+         Output: _hyper_41_75_chunk."time", _hyper_41_75_chunk.device, _hyper_41_75_chunk.value
+         Workers Planned: 2
+         ->  Sort
+               Output: _hyper_41_75_chunk."time", _hyper_41_75_chunk.device, _hyper_41_75_chunk.value
+               Sort Key: _hyper_41_75_chunk."time" DESC, _hyper_41_75_chunk.device
+               ->  Parallel Append
+                     ->  Parallel Seq Scan on _timescaledb_internal._hyper_41_75_chunk
+                           Output: _hyper_41_75_chunk."time", _hyper_41_75_chunk.device, _hyper_41_75_chunk.value
+                     ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_41_76_chunk
+                           Output: _hyper_41_76_chunk."time", _hyper_41_76_chunk.device, _hyper_41_76_chunk.value
+                           ->  Parallel Seq Scan on _timescaledb_internal.compress_hyper_42_78_chunk
+                                 Output: compress_hyper_42_78_chunk."time", compress_hyper_42_78_chunk.device, compress_hyper_42_78_chunk.value, compress_hyper_42_78_chunk._ts_meta_count, compress_hyper_42_78_chunk._ts_meta_sequence_num, compress_hyper_42_78_chunk._ts_meta_min_1, compress_hyper_42_78_chunk._ts_meta_max_1
+                     ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_41_75_chunk
+                           Output: _hyper_41_75_chunk."time", _hyper_41_75_chunk.device, _hyper_41_75_chunk.value
+                           ->  Parallel Seq Scan on _timescaledb_internal.compress_hyper_42_77_chunk
+                                 Output: compress_hyper_42_77_chunk."time", compress_hyper_42_77_chunk.device, compress_hyper_42_77_chunk.value, compress_hyper_42_77_chunk._ts_meta_count, compress_hyper_42_77_chunk._ts_meta_sequence_num, compress_hyper_42_77_chunk._ts_meta_min_1, compress_hyper_42_77_chunk._ts_meta_max_1
+(19 rows)
+


### PR DESCRIPTION
This PR improves the way the number of parallel workers for the DecompressChunk node are calculated. Since
1a93c2d482b50a43c105427ad99e6ecb58fcac7f, no partial paths for small chunks are generated, which could cause a fallback to a sequential plan and a performance regression. This patch ensures that a partial path is created again to get the 2.11.x behavior back.

---

Disable-check: force-changelog-file

---

### Benchmarks
Tsbench against the last commit before this PR: https://grafana.ops.savannah-dev.timescale.com/d/NdmLnOk4z/compare-benchmark-runs?orgId=1&var-branch=All&var-run1=2549&var-run2=2551&var-threshold=0.02

Tsbench against 2.11.1 (a version without the commit 1a93c2d482b50a43c105427ad99e6ecb58fcac7f): https://grafana.ops.savannah-dev.timescale.com/d/NdmLnOk4z/compare-benchmark-runs?orgId=1&var-branch=All&var-run1=2514&var-run2=2551&var-threshold=0.02

**Note:** Disabling parallel plans for some queries might be beneficial. For example, when `ht_chunk_compressed_2k` is processed. Using this table, we have a lot of small chunks, and we have a huge overhead by the parallel logic. Here, we see some regression compared to the last commit but almost the same execution times as for 2.11.1. 


### Planner regression

Another result from benchmarking: it seems we have some kind of planner regression introduced in ecc1b7b11a2aa9d483b14e240128632047af1b46. It is hidden on the tsbench dashboards due to some missing commits in tsbench and the fact this particular query becomes faster when it is executed sequentially. So, we have the planner regression which is compensated by the sequentially executed query. This should be addressed in a follow-up PR.

### Commit ecc1b7b11a2aa9d483b14e240128632047af1b46
```sql
tsbench=#  explain (verbose, analyze) SELECT * FROM ht_chunk_partially_compressed_2k WHERE device = 3 ORDER BY time, device DESC LIMIT 1;

 Planning Time: 1399.066 ms
 Execution Time: 674.978 ms
```

### Before (d6030a32d87b2b2a3caa8026faf007b8e6b532e5)
```sql
tsbench=#  explain (verbose, analyze) SELECT * FROM ht_chunk_partially_compressed_2k WHERE device = 3 ORDER BY time, device DESC LIMIT 1;

 Planning Time: 894.385 ms
 Execution Time: 717.762 ms
```

### Differential Flame Graphs

Differential Flame Graphs for the query and the commits d6030a32d87b2b2a3caa8026faf007b8e6b532e5 and ecc1b7b11a2aa9d483b14e240128632047af1b46

![diff](https://github.com/timescale/timescaledb/assets/5753622/db703559-67ce-4ccf-a060-9c3d56a85199)

### Tsbench run
https://grafana.ops.savannah-dev.timescale.com/d/NdmLnOk4z/compare-benchmark-runs?orgId=1&var-branch=main&var-run1=2620&var-run2=2621&var-threshold=0.02
