### PR TITLE
Store compression settings in HyperTable

### DIFF
--- a/src/hypertable.h
+++ b/src/hypertable.h
@@ -59,6 +59,8 @@ typedef struct Hypertable
 	 * use all available data nodes.
 	 */
 	List *data_nodes;
+	List *compression_keys;
+	bool compression_keys_loaded;
 } Hypertable;
 
 /* create_hypertable record attribute numbers */

--- a/src/nodes/chunk_dispatch/chunk_dispatch.c
+++ b/src/nodes/chunk_dispatch/chunk_dispatch.c
@@ -23,6 +23,7 @@
 #include "guc.h"
 #include "nodes/hypertable_modify.h"
 #include "ts_catalog/chunk_data_node.h"
+#include "ts_catalog/hypertable_compression.h"
 
 static Node *chunk_dispatch_state_create(CustomScan *cscan);
 
@@ -300,6 +301,7 @@ chunk_dispatch_begin(CustomScanState *node, EState *estate, int eflags)
 												 &hypertable_cache);
 	ps = ExecInitNode(state->subplan, estate, eflags);
 	state->hypertable_cache = hypertable_cache;
+	
 	ts_hypertable_compression_load(ht, ts_cache_memory_ctx(hypertable_cache));
 
 	state->dispatch = ts_chunk_dispatch_create(ht, estate, eflags);

--- a/src/nodes/chunk_dispatch/chunk_dispatch.c
+++ b/src/nodes/chunk_dispatch/chunk_dispatch.c
@@ -79,7 +79,6 @@ ts_chunk_dispatch_get_chunk_insert_state(ChunkDispatch *dispatch, Point *point,
 
 	cis = ts_subspace_store_get(dispatch->cache, point);
 
-
 	/*
 	 * The chunk search functions may leak memory, so switch to a temporary
 	 * memory context.
@@ -301,8 +300,8 @@ chunk_dispatch_begin(CustomScanState *node, EState *estate, int eflags)
 												 &hypertable_cache);
 	ps = ExecInitNode(state->subplan, estate, eflags);
 	state->hypertable_cache = hypertable_cache;
-	ts_hypertable_compression_load(ht,ts_cache_memory_ctx(hypertable_cache));
-	
+	ts_hypertable_compression_load(ht, ts_cache_memory_ctx(hypertable_cache));
+
 	state->dispatch = ts_chunk_dispatch_create(ht, estate, eflags);
 	state->dispatch->dispatch_state = state;
 	node->custom_ps = list_make1(ps);

--- a/src/nodes/chunk_dispatch/chunk_dispatch.c
+++ b/src/nodes/chunk_dispatch/chunk_dispatch.c
@@ -79,6 +79,7 @@ ts_chunk_dispatch_get_chunk_insert_state(ChunkDispatch *dispatch, Point *point,
 
 	cis = ts_subspace_store_get(dispatch->cache, point);
 
+
 	/*
 	 * The chunk search functions may leak memory, so switch to a temporary
 	 * memory context.
@@ -300,6 +301,8 @@ chunk_dispatch_begin(CustomScanState *node, EState *estate, int eflags)
 												 &hypertable_cache);
 	ps = ExecInitNode(state->subplan, estate, eflags);
 	state->hypertable_cache = hypertable_cache;
+	ts_hypertable_compression_load(ht,ts_cache_memory_ctx(hypertable_cache));
+	
 	state->dispatch = ts_chunk_dispatch_create(ht, estate, eflags);
 	state->dispatch->dispatch_state = state;
 	node->custom_ps = list_make1(ps);

--- a/src/nodes/chunk_dispatch/chunk_insert_state.c
+++ b/src/nodes/chunk_dispatch/chunk_insert_state.c
@@ -601,6 +601,8 @@ ts_chunk_insert_state_create(const Chunk *chunk, ChunkDispatch *dispatch)
 	CheckValidResultRel(relinfo, chunk_dispatch_get_cmd_type(dispatch));
 
 	state = palloc0(sizeof(ChunkInsertState));
+	
+	state->hypertable=dispatch->hypertable;
 	state->mctx = cis_context;
 	state->rel = rel;
 	state->result_relation_info = relinfo;

--- a/src/nodes/chunk_dispatch/chunk_insert_state.c
+++ b/src/nodes/chunk_dispatch/chunk_insert_state.c
@@ -601,8 +601,8 @@ ts_chunk_insert_state_create(const Chunk *chunk, ChunkDispatch *dispatch)
 	CheckValidResultRel(relinfo, chunk_dispatch_get_cmd_type(dispatch));
 
 	state = palloc0(sizeof(ChunkInsertState));
-	
-	state->hypertable=dispatch->hypertable;
+
+	state->hypertable = dispatch->hypertable;
 	state->mctx = cis_context;
 	state->rel = rel;
 	state->result_relation_info = relinfo;

--- a/src/nodes/chunk_dispatch/chunk_insert_state.h
+++ b/src/nodes/chunk_dispatch/chunk_insert_state.h
@@ -60,6 +60,7 @@ typedef struct ChunkInsertState
 	/* for tracking compressed chunks */
 	bool chunk_compressed;
 	bool chunk_partial;
+	Hypertable *hypertable;
 } ChunkInsertState;
 
 typedef struct ChunkDispatch ChunkDispatch;

--- a/src/ts_catalog/hypertable_compression.c
+++ b/src/ts_catalog/hypertable_compression.c
@@ -169,9 +169,9 @@ ts_hypertable_compression_get_by_pkey(int32 htid, const char *attname)
 }
 
 void
-ts_hypertable_compression_load(Hypertable*ht,MemoryContext mcxt)
+ts_hypertable_compression_load(Hypertable *ht, MemoryContext mcxt)
 {
-	int32 htid=ht->fd.id;
+	int32 htid = ht->fd.id;
 	ScanIterator iterator =
 		ts_scan_iterator_create(HYPERTABLE_COMPRESSION, AccessShareLock, CurrentMemoryContext);
 	iterator.ctx.index =
@@ -183,19 +183,19 @@ ts_hypertable_compression_load(Hypertable*ht,MemoryContext mcxt)
 								   Int32GetDatum(htid));
 
 	ts_scanner_start_scan(&iterator.ctx);
-	TupleInfo *ti=0;
-	List*li=0;
+	TupleInfo *ti = 0;
+	List *li = 0;
 	MemoryContext oldmctx = MemoryContextSwitchTo(mcxt);
 	while ((ti = ts_scanner_next(&iterator.ctx)))
 	{
 		FormData_hypertable_compression *colfd = NULL;
 		colfd = palloc0(sizeof(FormData_hypertable_compression));
 		hypertable_compression_fill_from_tuple(colfd, ti);
-		li=lappend(li,colfd)		;
+		li = lappend(li, colfd);
 	}
 	ts_scan_iterator_close(&iterator);
-	ht->compression_keys=li;
-	ht->compression_keys_loaded=true;
+	ht->compression_keys = li;
+	ht->compression_keys_loaded = true;
 	MemoryContextSwitchTo(oldmctx);
 }
 
@@ -204,15 +204,16 @@ ts_hypertable_compression_get_by_pkey2(Hypertable *ht, const char *attname)
 {
 	ListCell *lc;
 
-
-	if (!ht->compression_keys_loaded) {
-	elog(ERROR, "compression_keys not loaded");
-
+	if (!ht->compression_keys_loaded)
+	{
+		elog(ERROR, "compression_keys not loaded");
 	}
 
-	foreach(lc, ht->compression_keys) {
-		FormData_hypertable_compression *ent=lfirst(lc);
-		if(namestrcmp(&ent->attname,attname) == 0) {
+	foreach (lc, ht->compression_keys)
+	{
+		FormData_hypertable_compression *ent = lfirst(lc);
+		if (namestrcmp(&ent->attname, attname) == 0)
+		{
 			return ent;
 		}
 	}

--- a/src/ts_catalog/hypertable_compression.c
+++ b/src/ts_catalog/hypertable_compression.c
@@ -168,6 +168,57 @@ ts_hypertable_compression_get_by_pkey(int32 htid, const char *attname)
 	return colfd;
 }
 
+void
+ts_hypertable_compression_load(Hypertable*ht,MemoryContext mcxt)
+{
+	int32 htid=ht->fd.id;
+	ScanIterator iterator =
+		ts_scan_iterator_create(HYPERTABLE_COMPRESSION, AccessShareLock, CurrentMemoryContext);
+	iterator.ctx.index =
+		catalog_get_index(ts_catalog_get(), HYPERTABLE_COMPRESSION, HYPERTABLE_COMPRESSION_PKEY);
+	ts_scan_iterator_scan_key_init(&iterator,
+								   Anum_hypertable_compression_pkey_hypertable_id,
+								   BTEqualStrategyNumber,
+								   F_INT4EQ,
+								   Int32GetDatum(htid));
+
+	ts_scanner_start_scan(&iterator.ctx);
+	TupleInfo *ti=0;
+	List*li=0;
+	MemoryContext oldmctx = MemoryContextSwitchTo(mcxt);
+	while ((ti = ts_scanner_next(&iterator.ctx)))
+	{
+		FormData_hypertable_compression *colfd = NULL;
+		colfd = palloc0(sizeof(FormData_hypertable_compression));
+		hypertable_compression_fill_from_tuple(colfd, ti);
+		li=lappend(li,colfd)		;
+	}
+	ts_scan_iterator_close(&iterator);
+	ht->compression_keys=li;
+	ht->compression_keys_loaded=true;
+	MemoryContextSwitchTo(oldmctx);
+}
+
+TSDLLEXPORT FormData_hypertable_compression *
+ts_hypertable_compression_get_by_pkey2(Hypertable *ht, const char *attname)
+{
+	ListCell *lc;
+
+
+	if (!ht->compression_keys_loaded) {
+	elog(ERROR, "compression_keys not loaded");
+
+	}
+
+	foreach(lc, ht->compression_keys) {
+		FormData_hypertable_compression *ent=lfirst(lc);
+		if(namestrcmp(&ent->attname,attname) == 0) {
+			return ent;
+		}
+	}
+	return NULL;
+}
+
 TSDLLEXPORT bool
 ts_hypertable_compression_delete_by_hypertable_id(int32 htid)
 {

--- a/src/ts_catalog/hypertable_compression.h
+++ b/src/ts_catalog/hypertable_compression.h
@@ -14,12 +14,16 @@
 extern TSDLLEXPORT List *ts_hypertable_compression_get(int32 htid);
 extern TSDLLEXPORT FormData_hypertable_compression *
 ts_hypertable_compression_get_by_pkey(int32 htid, const char *attname);
+extern TSDLLEXPORT void ts_hypertable_compression_load(Hypertable *ht, MemoryContext mcxt);
+extern TSDLLEXPORT FormData_hypertable_compression *ts_hypertable_compression_get_by_pkey2(Hypertable *ht, const char *attname);
+
 extern TSDLLEXPORT void
 ts_hypertable_compression_fill_tuple_values(FormData_hypertable_compression *fd, Datum *values,
 											bool *nulls);
 
 extern TSDLLEXPORT bool ts_hypertable_compression_delete_by_hypertable_id(int32 htid);
 extern TSDLLEXPORT bool ts_hypertable_compression_delete_by_pkey(int32 htid, const char *attname);
+
 extern TSDLLEXPORT void ts_hypertable_compression_rename_column(int32 htid, char *old_column_name,
 																char *new_column_name);
 

--- a/src/ts_catalog/hypertable_compression.h
+++ b/src/ts_catalog/hypertable_compression.h
@@ -15,7 +15,8 @@ extern TSDLLEXPORT List *ts_hypertable_compression_get(int32 htid);
 extern TSDLLEXPORT FormData_hypertable_compression *
 ts_hypertable_compression_get_by_pkey(int32 htid, const char *attname);
 extern TSDLLEXPORT void ts_hypertable_compression_load(Hypertable *ht, MemoryContext mcxt);
-extern TSDLLEXPORT FormData_hypertable_compression *ts_hypertable_compression_get_by_pkey2(Hypertable *ht, const char *attname);
+extern TSDLLEXPORT FormData_hypertable_compression *
+ts_hypertable_compression_get_by_pkey2(Hypertable *ht, const char *attname);
 
 extern TSDLLEXPORT void
 ts_hypertable_compression_fill_tuple_values(FormData_hypertable_compression *fd, Datum *values,

--- a/tsl/src/compression/compression.c
+++ b/tsl/src/compression/compression.c
@@ -1815,9 +1815,8 @@ compression_get_toast_storage(CompressionAlgorithms algorithm)
  * columns of the uncompressed chunk.
  */
 static ScanKeyData *
-build_scankeys(Hypertable*ht, RowDecompressor decompressor,
-			   Bitmapset *key_columns, Bitmapset **null_columns, TupleTableSlot *slot,
-			   int *num_scankeys)
+build_scankeys(Hypertable *ht, RowDecompressor decompressor, Bitmapset *key_columns,
+			   Bitmapset **null_columns, TupleTableSlot *slot, int *num_scankeys)
 {
 	int key_index = 0;
 	ScanKeyData *scankeys = NULL;

--- a/tsl/src/compression/compression.c
+++ b/tsl/src/compression/compression.c
@@ -1815,7 +1815,7 @@ compression_get_toast_storage(CompressionAlgorithms algorithm)
  * columns of the uncompressed chunk.
  */
 static ScanKeyData *
-build_scankeys(int32 hypertable_id, Oid hypertable_relid, RowDecompressor decompressor,
+build_scankeys(Hypertable*ht, RowDecompressor decompressor,
 			   Bitmapset *key_columns, Bitmapset **null_columns, TupleTableSlot *slot,
 			   int *num_scankeys)
 {
@@ -1831,9 +1831,9 @@ build_scankeys(int32 hypertable_id, Oid hypertable_relid, RowDecompressor decomp
 			AttrNumber attno = i + FirstLowInvalidHeapAttributeNumber;
 			char *attname = get_attname(decompressor.out_rel->rd_id, attno, false);
 			FormData_hypertable_compression *fd =
-				ts_hypertable_compression_get_by_pkey(hypertable_id, attname);
+				ts_hypertable_compression_get_by_pkey2(ht, attname);
 			bool isnull;
-			AttrNumber ht_attno = get_attnum(hypertable_relid, attname);
+			AttrNumber ht_attno = get_attnum(ht->main_table_relid, attname);
 			Datum value = slot_getattr(slot, ht_attno, &isnull);
 			/*
 			 * There are 3 possible scenarios we have to consider
@@ -1971,6 +1971,8 @@ decompress_batches_for_insert(ChunkInsertState *cis, Chunk *chunk, TupleTableSlo
 				 errmsg("inserting into compressed chunk with unique constraints disabled"),
 				 errhint("Set timescaledb.enable_dml_decompression to TRUE.")));
 
+	// ts_hypertable_find_chunk_for_point
+	// cis->compressed_ht
 	Chunk *comp = ts_chunk_get_by_id(chunk->fd.compressed_chunk_id, true);
 	Relation in_rel = relation_open(comp->table_id, RowExclusiveLock);
 
@@ -1979,8 +1981,7 @@ decompress_batches_for_insert(ChunkInsertState *cis, Chunk *chunk, TupleTableSlo
 	Bitmapset *null_columns = NULL;
 
 	int num_scankeys;
-	ScanKeyData *scankeys = build_scankeys(chunk->fd.hypertable_id,
-										   chunk->hypertable_relid,
+	ScanKeyData *scankeys = build_scankeys(cis->hypertable,
 										   decompressor,
 										   key_columns,
 										   &null_columns,


### PR DESCRIPTION
   
   The ts_hypertable_compression_get_by_pkey method goes directly to catalog.
    But its only being used to build scankeys during compressed inserts; making
    the repeated catalog lookups unneccessary.

this change takes down the exec time for queries like [this](https://github.com/kgyrtkirk/timescaledb/blob/629245e62302e23e918bbdaa8dd1c2a40aa6dde8/_r.sql#L29) from 4.3ms to 3.7ms on my machine