### PR TITLE
Fixed two bugs in decompression sorted merge code

### DIFF
--- a/.unreleased/bugfix_5774
+++ b/.unreleased/bugfix_5774
@@ -1,0 +1,1 @@
+Fixes: #5774 Fixed two bugs in decompression sorted merge code 

--- a/tsl/src/nodes/decompress_chunk/exec.h
+++ b/tsl/src/nodes/decompress_chunk/exec.h
@@ -101,6 +101,18 @@ typedef struct DecompressChunkState
 	struct binaryheap *merge_heap; /* Binary heap of slot indices */
 	int n_sortkeys;				   /* Number of sort keys for heap compare function */
 	SortSupportData *sortkeys;	   /* Sort keys for binary heap compare function */
+
+	/*
+	 * Make non-refcounted copies of the tupdesc for reuse across all batch states
+	 * and avoid spending CPU in ResourceOwner when creating a big number of table
+	 * slots. This happens because each new slot pins its tuple descriptor using
+	 * PinTupleDesc, and for reference-counting tuples this involves adding a new
+	 * reference to ResourceOwner, which is not very efficient for a large number of
+	 * references.
+	 */
+	TupleDesc decompressed_slot_projected_tdesc;
+	TupleDesc decompressed_slot_scan_tdesc;
+	TupleDesc compressed_slot_tdesc;
 } DecompressChunkState;
 
 extern Node *decompress_chunk_state_create(CustomScan *cscan);

--- a/tsl/test/expected/compression_sorted_merge-12.out
+++ b/tsl/test/expected/compression_sorted_merge-12.out
@@ -1207,6 +1207,27 @@ CALL order_test('SELECT * FROM sensor_data ORDER BY time ASC NULLS FIRST LIMIT 1
 CALL order_test('SELECT * FROM test1 ORDER BY time DESC');
 CALL order_test('SELECT * FROM test1 ORDER BY time ASC NULLS LAST');
 ------
+-- Test window functions
+------
+CREATE TABLE insert_test(id INT);
+INSERT INTO insert_test SELECT time_bucket_gapfill(1,time,1,5) FROM (VALUES (1),(2)) v(time) GROUP BY 1 ORDER BY 1;
+SELECT * FROM insert_test AS ref_0
+WHERE EXISTS (
+    SELECT
+        sum(ref_0.id) OVER (partition by ref_0.id ORDER BY ref_0.id,ref_0.id,sample_0.time)
+    FROM
+        sensor_data AS sample_0
+    WHERE (1 > sample_0.temperature)
+);
+ id 
+----
+  1
+  2
+  3
+  4
+(4 rows)
+
+------
 -- Test enabling and disabling the optimization based on costs
 ------
 CREATE TABLE test_costs (

--- a/tsl/test/expected/compression_sorted_merge-13.out
+++ b/tsl/test/expected/compression_sorted_merge-13.out
@@ -1207,6 +1207,27 @@ CALL order_test('SELECT * FROM sensor_data ORDER BY time ASC NULLS FIRST LIMIT 1
 CALL order_test('SELECT * FROM test1 ORDER BY time DESC');
 CALL order_test('SELECT * FROM test1 ORDER BY time ASC NULLS LAST');
 ------
+-- Test window functions
+------
+CREATE TABLE insert_test(id INT);
+INSERT INTO insert_test SELECT time_bucket_gapfill(1,time,1,5) FROM (VALUES (1),(2)) v(time) GROUP BY 1 ORDER BY 1;
+SELECT * FROM insert_test AS ref_0
+WHERE EXISTS (
+    SELECT
+        sum(ref_0.id) OVER (partition by ref_0.id ORDER BY ref_0.id,ref_0.id,sample_0.time)
+    FROM
+        sensor_data AS sample_0
+    WHERE (1 > sample_0.temperature)
+);
+ id 
+----
+  1
+  2
+  3
+  4
+(4 rows)
+
+------
 -- Test enabling and disabling the optimization based on costs
 ------
 CREATE TABLE test_costs (

--- a/tsl/test/expected/compression_sorted_merge-14.out
+++ b/tsl/test/expected/compression_sorted_merge-14.out
@@ -1207,6 +1207,27 @@ CALL order_test('SELECT * FROM sensor_data ORDER BY time ASC NULLS FIRST LIMIT 1
 CALL order_test('SELECT * FROM test1 ORDER BY time DESC');
 CALL order_test('SELECT * FROM test1 ORDER BY time ASC NULLS LAST');
 ------
+-- Test window functions
+------
+CREATE TABLE insert_test(id INT);
+INSERT INTO insert_test SELECT time_bucket_gapfill(1,time,1,5) FROM (VALUES (1),(2)) v(time) GROUP BY 1 ORDER BY 1;
+SELECT * FROM insert_test AS ref_0
+WHERE EXISTS (
+    SELECT
+        sum(ref_0.id) OVER (partition by ref_0.id ORDER BY ref_0.id,ref_0.id,sample_0.time)
+    FROM
+        sensor_data AS sample_0
+    WHERE (1 > sample_0.temperature)
+);
+ id 
+----
+  1
+  2
+  3
+  4
+(4 rows)
+
+------
 -- Test enabling and disabling the optimization based on costs
 ------
 CREATE TABLE test_costs (

--- a/tsl/test/expected/compression_sorted_merge-15.out
+++ b/tsl/test/expected/compression_sorted_merge-15.out
@@ -1207,6 +1207,27 @@ CALL order_test('SELECT * FROM sensor_data ORDER BY time ASC NULLS FIRST LIMIT 1
 CALL order_test('SELECT * FROM test1 ORDER BY time DESC');
 CALL order_test('SELECT * FROM test1 ORDER BY time ASC NULLS LAST');
 ------
+-- Test window functions
+------
+CREATE TABLE insert_test(id INT);
+INSERT INTO insert_test SELECT time_bucket_gapfill(1,time,1,5) FROM (VALUES (1),(2)) v(time) GROUP BY 1 ORDER BY 1;
+SELECT * FROM insert_test AS ref_0
+WHERE EXISTS (
+    SELECT
+        sum(ref_0.id) OVER (partition by ref_0.id ORDER BY ref_0.id,ref_0.id,sample_0.time)
+    FROM
+        sensor_data AS sample_0
+    WHERE (1 > sample_0.temperature)
+);
+ id 
+----
+  1
+  2
+  3
+  4
+(4 rows)
+
+------
 -- Test enabling and disabling the optimization based on costs
 ------
 CREATE TABLE test_costs (

--- a/tsl/test/sql/compression_sorted_merge.sql.in
+++ b/tsl/test/sql/compression_sorted_merge.sql.in
@@ -405,6 +405,21 @@ CALL order_test('SELECT * FROM test1 ORDER BY time DESC');
 CALL order_test('SELECT * FROM test1 ORDER BY time ASC NULLS LAST');
 
 ------
+-- Test window functions
+------
+CREATE TABLE insert_test(id INT);
+INSERT INTO insert_test SELECT time_bucket_gapfill(1,time,1,5) FROM (VALUES (1),(2)) v(time) GROUP BY 1 ORDER BY 1;
+
+SELECT * FROM insert_test AS ref_0
+WHERE EXISTS (
+    SELECT
+        sum(ref_0.id) OVER (partition by ref_0.id ORDER BY ref_0.id,ref_0.id,sample_0.time)
+    FROM
+        sensor_data AS sample_0
+    WHERE (1 > sample_0.temperature)
+);
+
+------
 -- Test enabling and disabling the optimization based on costs
 ------
 


### PR DESCRIPTION
SQLSmith found two bugs in the compression sorted merge code.

* The unused_batch_states are not initialized properly. Therefore, non-existing unused batch states can be part of the BMS. This patch fixes the initialization.

* For performance reasons, We reuse the same TupleDesc across all TupleTableSlots. PostgreSQL sometimes uses TupleDesc data structures with active reference counting. The way we use the TupleDesc structures collides with the reference counting of PostgreSQL. This patch introduces a private TupleDesc copy without reference counting.