### PR TITLE
PG16 : New parameters added to DefineIndex and ExecInsertIndexTuples

### DIFF
--- a/src/compat/compat.h
+++ b/src/compat/compat.h
@@ -95,8 +95,19 @@
 									update,                                                        \
 									noDupErr,                                                      \
 									specConflict,                                                  \
-									arbiterIndexes)                                                \
+									arbiterIndexes,                                                \
+									onlySummarizing)                                               \
 	ExecInsertIndexTuples(slot, estate, noDupErr, specConflict, arbiterIndexes)
+#elif PG16_LT
+#define ExecInsertIndexTuplesCompat(rri,                                                           \
+									slot,                                                          \
+									estate,                                                        \
+									update,                                                        \
+									noDupErr,                                                      \
+									specConflict,                                                  \
+									arbiterIndexes,                                                \
+									onlySummarizing)                                               \
+	ExecInsertIndexTuples(rri, slot, estate, update, noDupErr, specConflict, arbiterIndexes)
 #else
 #define ExecInsertIndexTuplesCompat(rri,                                                           \
 									slot,                                                          \
@@ -104,8 +115,16 @@
 									update,                                                        \
 									noDupErr,                                                      \
 									specConflict,                                                  \
-									arbiterIndexes)                                                \
-	ExecInsertIndexTuples(rri, slot, estate, update, noDupErr, specConflict, arbiterIndexes)
+									arbiterIndexes,                                                \
+									onlySummarizing)                                               \
+	ExecInsertIndexTuples(rri,                                                                     \
+						  slot,                                                                    \
+						  estate,                                                                  \
+						  update,                                                                  \
+						  noDupErr,                                                                \
+						  specConflict,                                                            \
+						  arbiterIndexes,                                                          \
+						  onlySummarizing)
 #endif
 
 /* PG14 fixes a bug in miscomputation of relids set in pull_varnos. The bugfix

--- a/src/compat/compat.h
+++ b/src/compat/compat.h
@@ -827,4 +827,57 @@ RelationGetSmgr(Relation rel)
 #endif
 #endif
 
+/*
+ * PG16 adds a new parameter to DefineIndex, total_parts, that takes
+ * in the total number of direct and indirect partitions of the relation.
+ *
+ * https://github.com/postgres/postgres/commit/27f5c712
+ */
+#if PG16_LT
+#define DefineIndexCompat(relationId,                                                              \
+						  stmt,                                                                    \
+						  indexRelationId,                                                         \
+						  parentIndexId,                                                           \
+						  parentConstraintId,                                                      \
+						  total_parts,                                                             \
+						  is_alter_table,                                                          \
+						  check_rights,                                                            \
+						  check_not_in_use,                                                        \
+						  skip_build,                                                              \
+						  quiet)                                                                   \
+	DefineIndex(relationId,                                                                        \
+				stmt,                                                                              \
+				indexRelationId,                                                                   \
+				parentIndexId,                                                                     \
+				parentConstraintId,                                                                \
+				is_alter_table,                                                                    \
+				check_rights,                                                                      \
+				check_not_in_use,                                                                  \
+				skip_build,                                                                        \
+				quiet)
+#else
+#define DefineIndexCompat(relationId,                                                              \
+						  stmt,                                                                    \
+						  indexRelationId,                                                         \
+						  parentIndexId,                                                           \
+						  parentConstraintId,                                                      \
+						  total_parts,                                                             \
+						  is_alter_table,                                                          \
+						  check_rights,                                                            \
+						  check_not_in_use,                                                        \
+						  skip_build,                                                              \
+						  quiet)                                                                   \
+	DefineIndex(relationId,                                                                        \
+				stmt,                                                                              \
+				indexRelationId,                                                                   \
+				parentIndexId,                                                                     \
+				parentConstraintId,                                                                \
+				total_parts,                                                                       \
+				is_alter_table,                                                                    \
+				check_rights,                                                                      \
+				check_not_in_use,                                                                  \
+				skip_build,                                                                        \
+				quiet)
+#endif
+
 #endif /* TIMESCALEDB_COMPAT_H */

--- a/src/copy.c
+++ b/src/copy.c
@@ -385,7 +385,8 @@ TSCopyMultiInsertBufferFlush(TSCopyMultiInsertInfo *miinfo, TSCopyMultiInsertBuf
 														 false,
 														 false,
 														 NULL,
-														 NIL);
+														 NIL,
+														 false);
 
 			ExecARInsertTriggers(estate,
 								 resultRelInfo,
@@ -1091,7 +1092,8 @@ copyfrom(CopyChunkState *ccstate, List *range_table, Hypertable *ht, MemoryConte
 																 false,
 																 false,
 																 NULL,
-																 NIL);
+																 NIL,
+																 false);
 				/* AFTER ROW INSERT Triggers */
 				ExecARInsertTriggers(estate,
 									 resultRelInfo,

--- a/src/import/ht_hypertable_modify.c
+++ b/src/import/ht_hypertable_modify.c
@@ -193,9 +193,16 @@ ht_ExecUpdateEpilogue(ModifyTableContext * context, UpdateContext * updateCxt,
 	ModifyTableState *mtstate = context->mtstate;
 
 	/* insert index entries for tuple if necessary */
+
 	if (resultRelInfo->ri_NumIndices > 0 && updateCxt->updateIndexes)
-		recheckIndexes =
-			ExecInsertIndexTuples(resultRelInfo, slot, context->estate, true, false, NULL, NIL);
+		recheckIndexes = ExecInsertIndexTuplesCompat(resultRelInfo,
+													 slot,
+													 context->estate,
+													 true,
+													 false,
+													 NULL,
+													 NIL,
+													 false);
 
 	/* AFTER ROW UPDATE Triggers */
 	ExecARUpdateTriggersCompat(context->estate,

--- a/src/nodes/hypertable_modify.c
+++ b/src/nodes/hypertable_modify.c
@@ -1790,13 +1790,14 @@ ExecInsert(ModifyTableContext *context, ResultRelInfo *resultRelInfo, TupleTable
 										   specToken);
 
 			/* insert index entries for tuple */
-			recheckIndexes = ExecInsertIndexTuples(resultRelInfo,
-												   slot,
-												   estate,
-												   false,
-												   true,
-												   &specConflict,
-												   arbiterIndexes);
+			recheckIndexes = ExecInsertIndexTuplesCompat(resultRelInfo,
+														 slot,
+														 estate,
+														 false,
+														 true,
+														 &specConflict,
+														 arbiterIndexes,
+														 false);
 
 			/* adjust the tuple's state accordingly */
 			table_tuple_complete_speculative(resultRelationDesc, slot, specToken, !specConflict);
@@ -1830,8 +1831,14 @@ ExecInsert(ModifyTableContext *context, ResultRelInfo *resultRelInfo, TupleTable
 
 			/* insert index entries for tuple */
 			if (resultRelInfo->ri_NumIndices > 0)
-				recheckIndexes =
-					ExecInsertIndexTuples(resultRelInfo, slot, estate, false, false, NULL, NIL);
+				recheckIndexes = ExecInsertIndexTuplesCompat(resultRelInfo,
+															 slot,
+															 estate,
+															 false,
+															 false,
+															 NULL,
+															 NIL,
+															 false);
 		}
 	}
 

--- a/tsl/src/compression/compression.c
+++ b/tsl/src/compression/compression.c
@@ -2443,7 +2443,15 @@ fix_index_qual(Relation comp_chunk_rel, Relation index_rel, Var *var, List **pre
 			   char *column_name, Node *node, Oid opno)
 {
 	int i = 0;
+#if PG16_LT
 	Bitmapset *key_columns = RelationGetIndexAttrBitmap(comp_chunk_rel, INDEX_ATTR_BITMAP_ALL);
+#else
+	Bitmapset *key_columns =
+		RelationGetIndexAttrBitmap(comp_chunk_rel, INDEX_ATTR_BITMAP_HOT_BLOCKING);
+	key_columns =
+		bms_add_members(key_columns,
+						RelationGetIndexAttrBitmap(comp_chunk_rel, INDEX_ATTR_BITMAP_SUMMARIZED));
+#endif
 
 	for (i = 0; i < index_rel->rd_index->indnatts; i++)
 	{

--- a/tsl/src/compression/create.c
+++ b/tsl/src/compression/create.c
@@ -474,16 +474,17 @@ create_compressed_table_indexes(Oid compresstable_relid, CompressColInfo *compre
 	indexcols = lappend(indexcols, &sequence_num_elem);
 
 	stmt.indexParams = indexcols;
-	index_addr = DefineIndex(ht->main_table_relid,
-							 &stmt,
-							 InvalidOid, /* IndexRelationId */
-							 InvalidOid, /* parentIndexId */
-							 InvalidOid, /* parentConstraintId */
-							 false,		 /* is_alter_table */
-							 false,		 /* check_rights */
-							 false,		 /* check_not_in_use */
-							 false,		 /* skip_build */
-							 false);	 /* quiet */
+	index_addr = DefineIndexCompat(ht->main_table_relid,
+								   &stmt,
+								   InvalidOid, /* IndexRelationId */
+								   InvalidOid, /* parentIndexId */
+								   InvalidOid, /* parentConstraintId */
+								   -1,		   /* total_parts */
+								   false,	   /* is_alter_table */
+								   false,	   /* check_rights */
+								   false,	   /* check_not_in_use */
+								   false,	   /* skip_build */
+								   false);	   /* quiet */
 	index_tuple = SearchSysCache1(RELOID, ObjectIdGetDatum(index_addr.objectId));
 
 	if (!HeapTupleIsValid(index_tuple))

--- a/tsl/src/continuous_aggs/create.c
+++ b/tsl/src/continuous_aggs/create.c
@@ -411,16 +411,17 @@ mattablecolumninfo_add_mattable_index(MatTableColumnInfo *matcolinfo, Hypertable
 		char *grpcolname = (char *) lfirst(le);
 		IndexElem grpelem = { .type = T_IndexElem, .name = grpcolname };
 		stmt.indexParams = list_make2(&grpelem, &timeelem);
-		indxaddr = DefineIndex(ht->main_table_relid,
-							   &stmt,
-							   InvalidOid, /* indexRelationId */
-							   InvalidOid, /* parentIndexId */
-							   InvalidOid, /* parentConstraintId */
-							   false,	   /* is_alter_table */
-							   false,	   /* check_rights */
-							   false,	   /* check_not_in_use */
-							   false,	   /* skip_build */
-							   false);	   /* quiet */
+		indxaddr = DefineIndexCompat(ht->main_table_relid,
+									 &stmt,
+									 InvalidOid, /* indexRelationId */
+									 InvalidOid, /* parentIndexId */
+									 InvalidOid, /* parentConstraintId */
+									 -1,		 /* total_parts */
+									 false,		 /* is_alter_table */
+									 false,		 /* check_rights */
+									 false,		 /* check_not_in_use */
+									 false,		 /* skip_build */
+									 false);	 /* quiet */
 		indxtuple = SearchSysCache1(RELOID, ObjectIdGetDatum(indxaddr.objectId));
 
 		if (!HeapTupleIsValid(indxtuple))


### PR DESCRIPTION
[PG16: Handle DefineIndex's new parameter](https://github.com/lkshminarayanan/timescaledb/commit/26d4dc85a7f90d9be60672a92530fd6e9f99da9a) 

PG16 adds a new parameter to DefineIndex, total_parts, that takes in the
total number of direct and indirect partitions of the relation. Updated
all the callers to pass either the actual number if it is known or -1 if
it is unknown at that point.

https://github.com/postgres/postgres/commit/27f5c712

---

[PG16: ExecInsertIndexTuples requires additional parameter](https://github.com/lkshminarayanan/timescaledb/commit/7d673230d27c5239500e387a7ca51ddd8df0e984) 

PG16 adds a new boolean parameter to the ExecInsertIndexTuples function
to denote if the index is a BRIN index, which is then used to determine
if the index update can be skipped. The fix also removes the
INDEX_ATTR_BITMAP_ALL enum value.

Adapt these changes by updating the compat function to accomodate the
new parameter added to the ExecInsertIndexTuples function and using an
alternative for the removed INDEX_ATTR_BITMAP_ALL enum value.

https://github.com/postgres/postgres/commit/19d8e23

Disable-check: force-changelog-file
Disable-check: commit-count