### PR TITLE
PG16: Remove recursion-marker values in enum AlterTableType

### DIFF
--- a/src/process_utility.c
+++ b/src/process_utility.c
@@ -3422,7 +3422,9 @@ process_altertable_start_table(ProcessUtilityArgs *args)
 					process_altertable_drop_not_null(ht, cmd);
 				break;
 			case AT_AddColumn:
+#if PG16_LT
 			case AT_AddColumnRecurse:
+#endif
 			{
 				ColumnDef *col;
 				ListCell *constraint_lc;
@@ -3440,12 +3442,16 @@ process_altertable_start_table(ProcessUtilityArgs *args)
 				break;
 			}
 			case AT_DropColumn:
+#if PG16_LT
 			case AT_DropColumnRecurse:
+#endif
 				if (NULL != ht)
 					process_altertable_drop_column(ht, cmd);
 				break;
 			case AT_AddConstraint:
+#if PG16_LT
 			case AT_AddConstraintRecurse:
+#endif
 				Assert(IsA(cmd->def, Constraint));
 
 				if (NULL == ht)
@@ -3727,7 +3733,9 @@ process_altertable_end_subcmd(Hypertable *ht, Node *parsetree, ObjectAddress *ob
 		}
 		break;
 		case AT_AddConstraint:
+#if PG16_LT
 		case AT_AddConstraintRecurse:
+#endif
 		{
 			Constraint *stmt = (Constraint *) cmd->def;
 			const char *conname = stmt->conname;
@@ -3788,7 +3796,9 @@ process_altertable_end_subcmd(Hypertable *ht, Node *parsetree, ObjectAddress *ob
 			process_altertable_alter_constraint_end(ht, cmd);
 			break;
 		case AT_ValidateConstraint:
+#if PG16_LT
 		case AT_ValidateConstraintRecurse:
+#endif
 			process_altertable_validate_constraint_end(ht, cmd);
 			break;
 		case AT_DropCluster:
@@ -3850,11 +3860,15 @@ process_altertable_end_subcmd(Hypertable *ht, Node *parsetree, ObjectAddress *ob
 			 */
 			break;
 		case AT_AddColumn:
+#if PG16_LT
 		case AT_AddColumnRecurse:
+#endif
 			/* this is handled for compressed hypertables by tsl code */
 			break;
 		case AT_DropColumn:
+#if PG16_LT
 		case AT_DropColumnRecurse:
+#endif
 #if PG13_GE
 		case AT_DropExpression:
 #endif
@@ -3865,7 +3879,9 @@ process_altertable_end_subcmd(Hypertable *ht, Node *parsetree, ObjectAddress *ob
 			 */
 			break;
 		case AT_DropConstraint:
+#if PG16_LT
 		case AT_DropConstraintRecurse:
+#endif
 			/* drop constraints handled by process_ddl_sql_drop */
 			break;
 #if PG13_LT

--- a/tsl/src/process_utility.c
+++ b/tsl/src/process_utility.c
@@ -38,7 +38,9 @@ tsl_process_altertable_cmd(Hypertable *ht, const AlterTableCmd *cmd)
 	switch (cmd->subtype)
 	{
 		case AT_AddColumn:
+#if PG16_LT
 		case AT_AddColumnRecurse:
+#endif
 			if (TS_HYPERTABLE_HAS_COMPRESSION_TABLE(ht) ||
 				TS_HYPERTABLE_HAS_COMPRESSION_ENABLED(ht))
 			{
@@ -47,7 +49,9 @@ tsl_process_altertable_cmd(Hypertable *ht, const AlterTableCmd *cmd)
 			}
 			break;
 		case AT_DropColumn:
+#if PG16_LT
 		case AT_DropColumnRecurse:
+#endif
 			if (TS_HYPERTABLE_HAS_COMPRESSION_TABLE(ht) ||
 				TS_HYPERTABLE_HAS_COMPRESSION_ENABLED(ht))
 			{

--- a/tsl/src/remote/dist_ddl.c
+++ b/tsl/src/remote/dist_ddl.c
@@ -782,13 +782,15 @@ dist_ddl_process_alter_table(const ProcessUtilityArgs *args)
 		switch (cmd->subtype)
 		{
 			case AT_AddColumn:
-			case AT_AddColumnRecurse:
 			case AT_DropColumn:
-			case AT_DropColumnRecurse:
 			case AT_AddConstraint:
-			case AT_AddConstraintRecurse:
 			case AT_DropConstraint:
+#if PG16_LT
+			case AT_AddColumnRecurse:
+			case AT_DropColumnRecurse:
+			case AT_AddConstraintRecurse:
 			case AT_DropConstraintRecurse:
+#endif
 			case AT_SetNotNull:
 			case AT_DropNotNull:
 			case AT_AddIndex:


### PR DESCRIPTION
PG16 removed the recursion-marker values used to handle certain subcommands during an ALTER TABLE execution and provides an alternative flag. Removed the references to the recursion-marker values from timescaledb code.

postgres/postgres@840ff5f4

Disable-check: force-changelog-file