### PR TITLE
Fix broken CI after PG12 removal

### DIFF
--- a/.github/gh_matrix_builder.py
+++ b/.github/gh_matrix_builder.py
@@ -32,6 +32,7 @@ from ci_settings import (
     PG14_LATEST,
     PG15_EARLIEST,
     PG15_LATEST,
+    PG_LATEST,
 )
 
 # github event type which is either push, pull_request or schedule


### PR DESCRIPTION
The commit cdea343cc updated the gh_matrix_builder.py script but failed to import PG_LATEST variable into the script thus breaking the CI. Import that variable to fix the CI tests.

Disable-check: force-changelog-file