### PR TITLE
Check unique indexes when enabling compression

### DIFF
--- a/.unreleased/bugfix_5892
+++ b/.unreleased/bugfix_5892
@@ -1,0 +1,2 @@
+Implements: #5894 Check unique indexes when enabling compression
+Fixes: #5892

--- a/tsl/test/expected/compression.out
+++ b/tsl/test/expected/compression.out
@@ -1904,6 +1904,7 @@ NOTICE:  adding not-null constraint to column "time"
 
 INSERT INTO ts_device_table SELECT generate_series(0,999,1), 1, 100, 20;
 ALTER TABLE ts_device_table set(timescaledb.compress, timescaledb.compress_segmentby='location', timescaledb.compress_orderby='time');
+WARNING:  column "device" should be used for segmenting or ordering
 SELECT compress_chunk(i) AS chunk_name FROM show_chunks('ts_device_table') i \gset
 SELECT count(*) FROM ts_device_table;
  count 

--- a/tsl/test/expected/compression_errors.out
+++ b/tsl/test/expected/compression_errors.out
@@ -782,3 +782,42 @@ SELECT compress_chunk(show_chunks('readings'), TRUE);
 INSERT INTO readings("time", candy, battery_temperature)
     VALUES ('2022-11-11 11:11:11', 33, 0.3)
 ;
+-- Segmentby checks should be done for unique indexes without
+-- constraints, so create a table without constraints and add a unique
+-- index and try to create a table without using the right segmentby
+-- column.
+CREATE TABLE table_unique_index(
+       location smallint not null,
+       device_id smallint not null,
+       time timestamptz not null,
+       value float8 not null
+);
+CREATE UNIQUE index ON table_unique_index(location, device_id, time);
+SELECT table_name FROM create_hypertable('table_unique_index', 'time');
+     table_name     
+--------------------
+ table_unique_index
+(1 row)
+
+-- Will warn because the lack of segmentby/orderby compression options
+ALTER TABLE table_unique_index SET (timescaledb.compress);
+WARNING:  column "location" should be used for segmenting or ordering
+WARNING:  column "device_id" should be used for segmenting or ordering
+ALTER TABLE table_unique_index SET (timescaledb.compress = off);
+ALTER TABLE table_unique_index SET (timescaledb.compress, timescaledb.compress_segmentby = 'location');
+WARNING:  column "device_id" should be used for segmenting or ordering
+ALTER TABLE table_unique_index SET (timescaledb.compress = off);
+ALTER TABLE table_unique_index SET (timescaledb.compress, timescaledb.compress_orderby = 'device_id');
+WARNING:  column "location" should be used for segmenting or ordering
+ALTER TABLE table_unique_index SET (timescaledb.compress = off);
+-- Will enable compression without warnings
+ALTER TABLE table_unique_index SET (timescaledb.compress, timescaledb.compress_segmentby = 'location', timescaledb.compress_orderby = 'device_id');
+ALTER TABLE table_unique_index SET (timescaledb.compress = off);
+ALTER TABLE table_unique_index SET (timescaledb.compress, timescaledb.compress_segmentby = 'device_id,location');
+ALTER TABLE table_unique_index SET (timescaledb.compress = off);
+ALTER TABLE table_unique_index SET (timescaledb.compress, timescaledb.compress_orderby = 'device_id,location');
+ALTER TABLE table_unique_index SET (timescaledb.compress = off);
+ALTER TABLE table_unique_index SET (timescaledb.compress, timescaledb.compress_segmentby = 'time,location', timescaledb.compress_orderby = 'device_id');
+ALTER TABLE table_unique_index SET (timescaledb.compress = off);
+ALTER TABLE table_unique_index SET (timescaledb.compress, timescaledb.compress_segmentby = 'time,location,device_id');
+ALTER TABLE table_unique_index SET (timescaledb.compress = off);

--- a/tsl/test/sql/compression_errors.sql
+++ b/tsl/test/sql/compression_errors.sql
@@ -469,3 +469,35 @@ SELECT compress_chunk(show_chunks('readings'), TRUE);
 INSERT INTO readings("time", candy, battery_temperature)
     VALUES ('2022-11-11 11:11:11', 33, 0.3)
 ;
+
+-- Segmentby checks should be done for unique indexes without
+-- constraints, so create a table without constraints and add a unique
+-- index and try to create a table without using the right segmentby
+-- column.
+CREATE TABLE table_unique_index(
+       location smallint not null,
+       device_id smallint not null,
+       time timestamptz not null,
+       value float8 not null
+);
+CREATE UNIQUE index ON table_unique_index(location, device_id, time);
+SELECT table_name FROM create_hypertable('table_unique_index', 'time');
+-- Will warn because the lack of segmentby/orderby compression options
+ALTER TABLE table_unique_index SET (timescaledb.compress);
+ALTER TABLE table_unique_index SET (timescaledb.compress = off);
+ALTER TABLE table_unique_index SET (timescaledb.compress, timescaledb.compress_segmentby = 'location');
+ALTER TABLE table_unique_index SET (timescaledb.compress = off);
+ALTER TABLE table_unique_index SET (timescaledb.compress, timescaledb.compress_orderby = 'device_id');
+ALTER TABLE table_unique_index SET (timescaledb.compress = off);
+-- Will enable compression without warnings
+ALTER TABLE table_unique_index SET (timescaledb.compress, timescaledb.compress_segmentby = 'location', timescaledb.compress_orderby = 'device_id');
+ALTER TABLE table_unique_index SET (timescaledb.compress = off);
+ALTER TABLE table_unique_index SET (timescaledb.compress, timescaledb.compress_segmentby = 'device_id,location');
+ALTER TABLE table_unique_index SET (timescaledb.compress = off);
+ALTER TABLE table_unique_index SET (timescaledb.compress, timescaledb.compress_orderby = 'device_id,location');
+ALTER TABLE table_unique_index SET (timescaledb.compress = off);
+ALTER TABLE table_unique_index SET (timescaledb.compress, timescaledb.compress_segmentby = 'time,location', timescaledb.compress_orderby = 'device_id');
+ALTER TABLE table_unique_index SET (timescaledb.compress = off);
+ALTER TABLE table_unique_index SET (timescaledb.compress, timescaledb.compress_segmentby = 'time,location,device_id');
+ALTER TABLE table_unique_index SET (timescaledb.compress = off);
+


### PR DESCRIPTION
When enabling compression on a table, there is a check of unique constraints and primary key constraints, but no check if there is just a unique index. This means that it is possible to create a compressed table without getting a warning that you should include the columns in the index into the segmentby field, which can lead to suboptimal query times.

This commit adds a check for the unique index as well and ensure that a similar warning is printed as for a unique constraint.

Fixes #5892