### PR TITLE
Further code cleanup after PG12 removal

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -61,7 +61,6 @@ ForEachMacros:
   - foreach
   - forboth
   - for_each_cell
-  - for_each_cell_compat
   - for_both_cell
   - forthree
 IncludeBlocks:   Preserve # separate include blocks will not be merged

--- a/docs/BuildSource.md
+++ b/docs/BuildSource.md
@@ -9,7 +9,7 @@ See the Releases tab for the latest release.
 
 **Prerequisites**:
 
-- A standard PostgreSQL 14, 13.2+ or 12 installation with development
+- A standard PostgreSQL 13.2+, 14, or 15 installation with development
 environment (header files) (e.g., `postgresql-server-dev-13` package
 for Linux, Postgres.app for MacOS)
 - C compiler (e.g., gcc or clang)
@@ -42,7 +42,7 @@ See the Releases tab for the latest release.
 
 **Prerequisites**:
 
-- A standard [PostgreSQL 14, 13.2+ or 12 64-bit installation](https://www.enterprisedb.com/downloads/postgres-postgresql-downloads#windows)
+- A standard [PostgreSQL 13.2+, 14 or 15 64-bit installation](https://www.enterprisedb.com/downloads/postgres-postgresql-downloads#windows)
 - OpenSSL for Windows
 - Microsoft Visual Studio 2017 with CMake and Git components
 - OR Visual Studio 2015/2016 with [CMake](https://cmake.org/) version 3.4 or greater and Git

--- a/src/cache.c
+++ b/src/cache.c
@@ -113,9 +113,6 @@ static void
 remove_pin(Cache *cache, SubTransactionId subtxnid)
 {
 	ListCell *lc;
-#if PG13_LT
-	ListCell *prev = NULL;
-#endif
 
 	foreach (lc, pinned_caches)
 	{
@@ -123,14 +120,10 @@ remove_pin(Cache *cache, SubTransactionId subtxnid)
 
 		if (cp->cache == cache && cp->subtxnid == subtxnid)
 		{
-			pinned_caches = list_delete_cell_compat(pinned_caches, lc, prev);
+			pinned_caches = list_delete_cell(pinned_caches, lc);
 			pfree(cp);
 			return;
 		}
-
-#if PG13_LT
-		prev = lc;
-#endif
 	}
 
 	/* should never reach here: there should always be a pin to remove */

--- a/src/chunk.c
+++ b/src/chunk.c
@@ -1249,15 +1249,11 @@ chunk_add_inheritance(Chunk *chunk, const Hypertable *ht)
 								 0),
 	};
 	LOCKMODE lockmode = AlterTableGetLockLevel(alterstmt.cmds);
-#if PG13_GE
 	AlterTableUtilityContext atcontext = {
 		.relid = AlterTableLookupRelation(&alterstmt, lockmode),
 	};
 
 	AlterTable(&alterstmt, lockmode, &atcontext);
-#else
-	AlterTable(AlterTableLookupRelation(&alterstmt, lockmode), lockmode, &alterstmt);
-#endif
 }
 
 static Chunk *

--- a/src/chunk_index.c
+++ b/src/chunk_index.c
@@ -107,11 +107,7 @@ adjust_expr_attnos(Oid ht_relid, IndexInfo *ii, Relation chunkrel)
 		Var *var = lfirst_node(Var, lc);
 
 		var->varattno = ts_map_attno(ht_relid, chunkrel->rd_id, var->varattno);
-#if PG13_GE
 		var->varattnosyn = var->varattno;
-#else
-		var->varoattno = var->varattno;
-#endif
 	}
 }
 

--- a/src/hypertable_restrict_info.c
+++ b/src/hypertable_restrict_info.c
@@ -727,7 +727,7 @@ ts_hypertable_restrict_info_get_chunks(HypertableRestrictInfo *hri, Hypertable *
 	 * We don't care about the locking order here, because this code uses
 	 * AccessShareLock that doesn't conflict with itself.
 	 */
-	chunk_ids = list_sort_compat(chunk_ids, list_int_cmp_compat);
+	list_sort(chunk_ids, list_int_cmp_compat);
 
 	return ts_chunk_scan_by_chunk_ids(ht->space, chunk_ids, num_chunks);
 }

--- a/src/jsonb_utils.c
+++ b/src/jsonb_utils.c
@@ -12,11 +12,7 @@
 
 #include "compat/compat.h"
 
-#if PG13_LT
-#include <utils/jsonapi.h>
-#else
 #include <common/jsonapi.h>
-#endif
 
 #include "export.h"
 

--- a/src/loader/loader.c
+++ b/src/loader/loader.c
@@ -593,11 +593,7 @@ loader_process_utility_hook(PlannedStmt *pstmt, const char *query_string,
 #endif
 							ProcessUtilityContext context, ParamListInfo params,
 							QueryEnvironment *queryEnv, DestReceiver *dest,
-#if PG13_GE
 							QueryCompletion *completion_tag
-#else
-							char *completion_tag
-#endif
 
 )
 {

--- a/src/nodes/chunk_append/chunk_append.c
+++ b/src/nodes/chunk_append/chunk_append.c
@@ -344,7 +344,7 @@ ts_chunk_append_path_create(PlannerInfo *root, RelOptInfo *rel, Hypertable *ht, 
 						nmatches++;
 #endif
 						merge_childs = lappend(merge_childs, child);
-						flat = lnext_compat(children, flat);
+						flat = lnext(children, flat);
 						if (flat == NULL)
 							break;
 					}

--- a/src/nodes/chunk_append/exec.c
+++ b/src/nodes/chunk_append/exec.c
@@ -442,8 +442,8 @@ initialize_runtime_exclusion(ChunkAppendState *state)
 				state->runtime_number_exclusions_children++;
 		}
 
-		lc_clauses = lnext_compat(state->filtered_ri_clauses, lc_clauses);
-		lc_constraints = lnext_compat(state->filtered_constraints, lc_constraints);
+		lc_clauses = lnext(state->filtered_ri_clauses, lc_clauses);
+		lc_constraints = lnext(state->filtered_constraints, lc_constraints);
 	}
 }
 
@@ -1111,11 +1111,7 @@ show_sort_group_keys(ChunkAppendState *state, List *ancestors, ExplainState *es)
 	initStringInfo(&sortkeybuf);
 
 	/* Set up deparsing context */
-#if PG13_GE
 	context = set_deparse_context_plan(es->deparse_cxt, plan, ancestors);
-#else
-	context = set_deparse_context_planstate(es->deparse_cxt, (Node *) state, ancestors);
-#endif
 	useprefix = (list_length(es->rtable) > 1 || es->verbose);
 
 	for (keyno = 0; keyno < nkeys; keyno++)

--- a/src/nodes/chunk_dispatch/chunk_insert_state.c
+++ b/src/nodes/chunk_dispatch/chunk_insert_state.c
@@ -176,13 +176,12 @@ get_adjusted_projection_info_returning(ProjectionInfo *orig, List *returning_cla
 	/* map hypertable attnos -> chunk attnos */
 	if (map != NULL)
 		returning_clauses = castNode(List,
-									 map_variable_attnos_compat((Node *) returning_clauses,
-																varno,
-																0,
-																map->attrMap,
-																map->outdesc->natts,
-																rowtype,
-																&found_whole_row));
+									 map_variable_attnos((Node *) returning_clauses,
+														 varno,
+														 0,
+														 map->attrMap,
+														 rowtype,
+														 &found_whole_row));
 
 	return ExecBuildProjectionInfo(returning_clauses,
 								   orig->pi_exprContext,
@@ -204,23 +203,21 @@ translate_clause(List *inclause, TupleConversionMap *chunk_map, Index varno, Rel
 
 	/* map hypertable attnos -> chunk attnos for the "excluded" table */
 	clause = castNode(List,
-					  map_variable_attnos_compat((Node *) clause,
-												 INNER_VAR,
-												 0,
-												 chunk_map->attrMap,
-												 RelationGetDescr(hyper_rel)->natts,
-												 RelationGetForm(chunk_rel)->reltype,
-												 &found_whole_row));
+					  map_variable_attnos((Node *) clause,
+										  INNER_VAR,
+										  0,
+										  chunk_map->attrMap,
+										  RelationGetForm(chunk_rel)->reltype,
+										  &found_whole_row));
 
 	/* map hypertable attnos -> chunk attnos for the hypertable */
 	clause = castNode(List,
-					  map_variable_attnos_compat((Node *) clause,
-												 varno,
-												 0,
-												 chunk_map->attrMap,
-												 RelationGetDescr(hyper_rel)->natts,
-												 RelationGetForm(chunk_rel)->reltype,
-												 &found_whole_row));
+					  map_variable_attnos((Node *) clause,
+										  varno,
+										  0,
+										  chunk_map->attrMap,
+										  RelationGetForm(chunk_rel)->reltype,
+										  &found_whole_row));
 
 	return clause;
 }
@@ -245,11 +242,7 @@ adjust_hypertable_tlist(List *tlist, TupleConversionMap *map)
 {
 	List *new_tlist = NIL;
 	TupleDesc chunk_tupdesc = map->outdesc;
-#if PG13_GE
 	AttrNumber *attrMap = map->attrMap->attnums;
-#else
-	AttrNumber *attrMap = map->attrMap;
-#endif
 	AttrNumber chunk_attrno;
 
 	for (chunk_attrno = 1; chunk_attrno <= chunk_tupdesc->natts; chunk_attrno++)

--- a/src/planner/agg_bookend.c
+++ b/src/planner/agg_bookend.c
@@ -689,15 +689,14 @@ build_first_last_path(PlannerInfo *root, FirstLastAggInfo *fl_info, Oid eqop, Oi
 				AppendRelInfo *app = lfirst(next);
 				if (app->parent_reloid == rte->relid)
 				{
-					subroot->append_rel_list =
-						list_delete_cell_compat(subroot->append_rel_list, next, prev);
-					next = prev != NULL ? lnext_compat(subroot->append_rel_list, next) :
+					subroot->append_rel_list = list_delete_cell(subroot->append_rel_list, next);
+					next = prev != NULL ? lnext(subroot->append_rel_list, next) :
 										  list_head(subroot->append_rel_list);
 				}
 				else
 				{
 					prev = next;
-					next = lnext_compat(subroot->append_rel_list, next);
+					next = lnext(subroot->append_rel_list, next);
 				}
 			}
 		}

--- a/src/planner/expand_hypertable.c
+++ b/src/planner/expand_hypertable.c
@@ -627,8 +627,7 @@ process_quals(Node *quals, CollectQualCtx *ctx, bool is_outer_join)
 	ListCell *prev pg_attribute_unused() = NULL;
 	List *additional_quals = NIL;
 
-	for (lc = list_head((List *) quals); lc != NULL;
-		 prev = lc, lc = lnext_compat((List *) quals, lc))
+	for (lc = list_head((List *) quals); lc != NULL; prev = lc, lc = lnext((List *) quals, lc))
 	{
 		Expr *qual = lfirst(lc);
 		Relids relids = pull_varnos_compat(ctx->root, (Node *) qual);
@@ -701,9 +700,6 @@ process_quals(Node *quals, CollectQualCtx *ctx, bool is_outer_join)
 static List *
 remove_exclusion_fns(List *restrictinfo)
 {
-#if PG13_LT
-	ListCell *prev = NULL;
-#endif
 	ListCell *lc = list_head(restrictinfo);
 
 	while (lc != NULL)
@@ -722,13 +718,10 @@ remove_exclusion_fns(List *restrictinfo)
 						(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
 						 errmsg("first parameter for chunks_in function needs to be record")));
 
-			restrictinfo = list_delete_cell_compat((List *) restrictinfo, lc, prev);
+			restrictinfo = list_delete_cell(restrictinfo, lc);
 			return restrictinfo;
 		}
-#if PG13_LT
-		prev = lc;
-#endif
-		lc = lnext_compat(restrictinfo, lc);
+		lc = lnext(restrictinfo, lc);
 	}
 	return restrictinfo;
 }

--- a/src/planner/planner.c
+++ b/src/planner/planner.c
@@ -62,11 +62,7 @@
 #include "utils.h"
 
 #include "compat/compat.h"
-#if PG13_GE
 #include <common/hashfn.h>
-#else
-#include <utils/hashutils.h>
-#endif
 
 #ifdef USE_TELEMETRY
 #include "telemetry/functions.h"
@@ -436,12 +432,8 @@ preprocess_query(Node *node, PreprocessQueryContext *context)
 }
 
 static PlannedStmt *
-#if PG13_GE
 timescaledb_planner(Query *parse, const char *query_string, int cursor_opts,
 					ParamListInfo bound_params)
-#else
-timescaledb_planner(Query *parse, int cursor_opts, ParamListInfo bound_params)
-#endif
 {
 	PlannedStmt *stmt;
 	ListCell *lc;
@@ -568,19 +560,11 @@ timescaledb_planner(Query *parse, int cursor_opts, ParamListInfo bound_params)
 		}
 
 		if (prev_planner_hook != NULL)
-		/* Call any earlier hooks */
-#if PG13_GE
+			/* Call any earlier hooks */
 			stmt = (prev_planner_hook) (parse, query_string, cursor_opts, bound_params);
-#else
-			stmt = (prev_planner_hook) (parse, cursor_opts, bound_params);
-#endif
 		else
-		/* Call the standard planner */
-#if PG13_GE
+			/* Call the standard planner */
 			stmt = standard_planner(parse, query_string, cursor_opts, bound_params);
-#else
-			stmt = standard_planner(parse, cursor_opts, bound_params);
-#endif
 
 		if (ts_extension_is_loaded())
 		{

--- a/src/process_utility.c
+++ b/src/process_utility.c
@@ -674,13 +674,8 @@ process_copy(ProcessUtilityArgs *args)
 	/* Performs acl check in here inside `copy_security_check` */
 	timescaledb_DoCopy(stmt, args->query_string, &processed, ht);
 
-#if PG13_GE
 	args->completion_tag->commandTag = CMDTAG_COPY;
 	args->completion_tag->nprocessed = processed;
-#else
-	if (args->completion_tag)
-		snprintf(args->completion_tag, COMPLETION_TAG_BUFSIZE, "COPY " UINT64_FORMAT, processed);
-#endif
 
 	add_hypertable_to_process_args(args, ht);
 
@@ -3870,9 +3865,7 @@ process_altertable_end_subcmd(Hypertable *ht, Node *parsetree, ObjectAddress *ob
 #if PG16_LT
 		case AT_DropColumnRecurse:
 #endif
-#if PG13_GE
 		case AT_DropExpression:
-#endif
 
 			/*
 			 * adding and dropping columns handled in
@@ -3885,11 +3878,6 @@ process_altertable_end_subcmd(Hypertable *ht, Node *parsetree, ObjectAddress *ob
 #endif
 			/* drop constraints handled by process_ddl_sql_drop */
 			break;
-#if PG13_LT
-		case AT_ProcessedConstraint: /* internal command never hit in our
-									  * test code, so don't know how to
-									  * handle */
-#endif
 		case AT_ReAddComment:			   /* internal command never hit in our test
 											* code, so don't know how to handle */
 		case AT_AddColumnToView:		   /* only used with views */
@@ -4296,11 +4284,7 @@ process_ddl_command_start(ProcessUtilityArgs *args)
 		return DDL_CONTINUE;
 
 	if (check_read_only)
-#if PG13_GE
 		PreventCommandIfReadOnly(CreateCommandName(args->parsetree));
-#else
-		PreventCommandIfReadOnly(CreateCommandTag(args->parsetree));
-#endif
 
 	return handler(args);
 }
@@ -4496,12 +4480,7 @@ timescaledb_ddl_command_start(PlannedStmt *pstmt, const char *query_string,
 #endif
 							  ProcessUtilityContext context, ParamListInfo params,
 							  QueryEnvironment *queryEnv, DestReceiver *dest,
-#if PG13_GE
-							  QueryCompletion *completion_tag
-#else
-							  char *completion_tag
-#endif
-)
+							  QueryCompletion *completion_tag)
 {
 	ProcessUtilityArgs args = {
 		.query_string = query_string,

--- a/src/process_utility.h
+++ b/src/process_utility.h
@@ -24,11 +24,7 @@ typedef struct ProcessUtilityArgs
 	ParamListInfo params;
 	DestReceiver *dest;
 	List *hypertable_list;
-#if PG13_GE
 	QueryCompletion *completion_tag;
-#else
-	char *completion_tag;
-#endif
 #if PG14_GE
 	bool readonly_tree;
 #endif

--- a/test/src/bgw/test_job_refresh.c
+++ b/test/src/bgw/test_job_refresh.c
@@ -71,7 +71,7 @@ ts_test_job_refresh(PG_FUNCTION_ARGS)
 		memset(nulls, 0, sizeof(*nulls) * funcctx->tuple_desc->natts);
 		tuple = heap_form_tuple(funcctx->tuple_desc, values, nulls);
 
-		funcctx->user_fctx = lnext_compat(cur_scheduled_jobs, lc);
+		funcctx->user_fctx = lnext(cur_scheduled_jobs, lc);
 		SRF_RETURN_NEXT(funcctx, HeapTupleGetDatum(tuple));
 	}
 

--- a/test/src/loader/osm_init.c
+++ b/test/src/loader/osm_init.c
@@ -23,12 +23,7 @@ static void osm_process_utility_hook(PlannedStmt *pstmt, const char *queryString
 #endif
 									 ProcessUtilityContext context, ParamListInfo params,
 									 QueryEnvironment *queryEnv, DestReceiver *dest,
-#if PG13_GE
-									 QueryCompletion *qc
-#else
-									 char *qc
-#endif
-);
+									 QueryCompletion *qc);
 
 extern void PGDLLEXPORT _PG_init(void);
 void
@@ -53,13 +48,7 @@ osm_process_utility_hook(PlannedStmt *pstmt, const char *queryString,
 						 bool readOnlyTree,
 #endif
 						 ProcessUtilityContext context, ParamListInfo params,
-						 QueryEnvironment *queryEnv, DestReceiver *dest,
-#if PG13_GE
-						 QueryCompletion *qc
-#else
-						 char *qc
-#endif
-)
+						 QueryEnvironment *queryEnv, DestReceiver *dest, QueryCompletion *qc)
 {
 	if (nodeTag(pstmt->utilityStmt) == T_DropStmt)
 	{

--- a/test/src/test_utils.c
+++ b/test/src/test_utils.c
@@ -311,11 +311,5 @@ ts_debug_allocated_bytes(PG_FUNCTION_ARGS)
 		PG_RETURN_NULL();
 	}
 
-#if !PG13_GE
-	/* Don't have this function on PG 12. */
-	(void) context;
-	PG_RETURN_UINT64(1);
-#else
 	PG_RETURN_UINT64(MemoryContextMemAllocated(context, /* recurse = */ true));
-#endif
 }

--- a/tsl/src/bgw_policy/policies_v2.c
+++ b/tsl/src/bgw_policy/policies_v2.c
@@ -714,7 +714,7 @@ policies_show(PG_FUNCTION_ARGS)
 
 		JsonbValue *result = pushJsonbValue(&parse_state, WJB_END_OBJECT, NULL);
 
-		funcctx->user_fctx = lnext_compat(jobs, (ListCell *) funcctx->user_fctx);
+		funcctx->user_fctx = lnext(jobs, (ListCell *) funcctx->user_fctx);
 		SRF_RETURN_NEXT(funcctx, PointerGetDatum(JsonbValueToJsonb(result)));
 	}
 	PG_RETURN_NULL();

--- a/tsl/src/chunk.c
+++ b/tsl/src/chunk.c
@@ -583,7 +583,7 @@ chunk_id_list_create(ArrayType *array)
 	}
 	array_free_iterator(it);
 
-	(void) list_sort_compat(id_list, list_int_cmp_compat);
+	list_sort(id_list, list_int_cmp_compat);
 	return id_list;
 }
 
@@ -605,33 +605,33 @@ chunk_id_list_exclusive_right_merge_join(const List *an_list, const List *dn_lis
 			if (compare == 0)
 			{
 				/* l = r */
-				l = lnext_compat(an_list, l);
-				r = lnext_compat(dn_list, r);
+				l = lnext(an_list, l);
+				r = lnext(dn_list, r);
 			}
 			else if (compare < 0)
 			{
 				/* l < r */
 				/* chunk exists only on the access node */
-				l = lnext_compat(an_list, l);
+				l = lnext(an_list, l);
 			}
 			else
 			{
 				/* l > r */
 				/* chunk exists only on the data node */
 				result = lappend_int(result, lfirst_int(r));
-				r = lnext_compat(dn_list, r);
+				r = lnext(dn_list, r);
 			}
 		}
 		else if (l)
 		{
 			/* chunk exists only on the access node */
-			l = lnext_compat(an_list, l);
+			l = lnext(an_list, l);
 		}
 		else if (r)
 		{
 			/* chunk exists only on the data node */
 			result = lappend_int(result, lfirst_int(r));
-			r = lnext_compat(dn_list, r);
+			r = lnext(dn_list, r);
 		}
 		else
 		{

--- a/tsl/src/compression/compression.c
+++ b/tsl/src/compression/compression.c
@@ -1800,7 +1800,7 @@ tsl_compressed_data_in(PG_FUNCTION_ARGS)
 
 	decoded_len = pg_b64_dec_len(input_len);
 	decoded = palloc(decoded_len + 1);
-	decoded_len = pg_b64_decode_compat(input, input_len, decoded, decoded_len);
+	decoded_len = pg_b64_decode(input, input_len, decoded, decoded_len);
 
 	if (decoded_len < 0)
 		elog(ERROR, "could not decode base64-encoded compressed data");
@@ -1826,7 +1826,7 @@ tsl_compressed_data_out(PG_FUNCTION_ARGS)
 	const char *raw_data = VARDATA(bytes);
 	int encoded_len = pg_b64_enc_len(raw_len);
 	char *encoded = palloc(encoded_len + 1);
-	encoded_len = pg_b64_encode_compat(raw_data, raw_len, encoded, encoded_len);
+	encoded_len = pg_b64_encode(raw_data, raw_len, encoded, encoded_len);
 
 	if (encoded_len < 0)
 		elog(ERROR, "could not base64-encode compressed data");

--- a/tsl/src/continuous_aggs/common.c
+++ b/tsl/src/continuous_aggs/common.c
@@ -692,15 +692,6 @@ cagg_validate_query(const Query *query, const bool finalized, const char *cagg_s
 				if (IsA(jtnode, JoinExpr))
 				{
 					join = castNode(JoinExpr, jtnode);
-#if PG13_LT
-					if (join->usingClause != NULL)
-						ereport(ERROR,
-								(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
-								 errmsg("invalid continuous aggregate view"),
-								 errdetail(
-									 "Joins with USING clause in continuous aggregate definition"
-									 " work for Postgres versions 13 and above.")));
-#endif
 					jointype = join->jointype;
 					op = (OpExpr *) join->quals;
 					rte = list_nth(query->rtable, ((RangeTblRef *) join->larg)->rtindex - 1);

--- a/tsl/src/continuous_aggs/create.c
+++ b/tsl/src/continuous_aggs/create.c
@@ -630,7 +630,7 @@ fixup_userview_query_tlist(Query *userquery, List *tlist_aliases)
 			if (tle->resjunk)
 				continue;
 			tle->resname = pstrdup(strVal(lfirst(alist_item)));
-			alist_item = lnext_compat(tlist_aliases, alist_item);
+			alist_item = lnext(tlist_aliases, alist_item);
 			if (alist_item == NULL)
 				break; /* done assigning aliases */
 		}

--- a/tsl/src/continuous_aggs/finalize.c
+++ b/tsl/src/continuous_aggs/finalize.c
@@ -641,11 +641,9 @@ finalizequery_get_select_query(FinalizeQueryInfo *inp, List *matcollist,
 				RangeTblEntry *jrte = rt_fetch(join->rtindex, inp->final_userquery->rtable);
 				rte->joinaliasvars = jrte->joinaliasvars;
 				rte->jointype = jrte->jointype;
-#if PG13_GE
 				rte->joinleftcols = jrte->joinleftcols;
 				rte->joinrightcols = jrte->joinrightcols;
 				rte->joinmergedcols = jrte->joinmergedcols;
-#endif
 #if PG14_GE
 				rte->join_using_alias = jrte->join_using_alias;
 #endif

--- a/tsl/src/data_node.c
+++ b/tsl/src/data_node.c
@@ -1564,9 +1564,6 @@ append_data_node_option(List *new_options, List **current_options, const char *n
 	DefElem *elem;
 	ListCell *lc;
 	bool option_found = false;
-#if PG13_LT
-	ListCell *prev_lc = NULL;
-#endif
 
 	foreach (lc, *current_options)
 	{
@@ -1577,16 +1574,9 @@ append_data_node_option(List *new_options, List **current_options, const char *n
 			option_found = true;
 			/* Remove the option which is replaced so that the remaining
 			 * options can be merged later into an updated list */
-#if PG13_GE
 			*current_options = list_delete_cell(*current_options, lc);
-#else
-			*current_options = list_delete_cell(*current_options, lc, prev_lc);
-#endif
 			break;
 		}
-#if PG13_LT
-		prev_lc = lc;
-#endif
 	}
 
 	elem = makeDefElemExtended(NULL,

--- a/tsl/src/debug.c
+++ b/tsl/src/debug.c
@@ -169,7 +169,7 @@ append_func_expr(StringInfo buf, const Node *expr, const List *rtable)
 	foreach (l, e->args)
 	{
 		append_expr(buf, lfirst(l), rtable);
-		if (lnext_compat(e->args, l))
+		if (lnext(e->args, l))
 			appendStringInfoString(buf, ", ");
 	}
 	appendStringInfoChar(buf, ')');
@@ -218,7 +218,7 @@ append_restrict_clauses(StringInfo buf, PlannerInfo *root, List *clauses)
 		RestrictInfo *c = lfirst(cell);
 
 		append_expr(buf, (Node *) c->clause, root->parse->rtable);
-		if (lnext_compat(clauses, cell))
+		if (lnext(clauses, cell))
 			appendStringInfoString(buf, ", ");
 	}
 }
@@ -271,7 +271,7 @@ append_pathkeys(StringInfo buf, const List *pathkeys, const List *rtable)
 			append_expr(buf, (Node *) mem->em_expr, rtable);
 		}
 		appendStringInfoChar(buf, ')');
-		if (lnext_compat(pathkeys, i))
+		if (lnext(pathkeys, i))
 			appendStringInfoString(buf, ", ");
 	}
 	appendStringInfoChar(buf, ')');
@@ -515,9 +515,6 @@ tsl_debug_append_pruned_pathlist(StringInfo buf, PlannerInfo *root, RelOptInfo *
 	{
 		Path *p1 = (Path *) lfirst(lc1);
 		ListCell *lc2;
-#if PG13_LT
-		ListCell *prev = NULL;
-#endif
 
 		foreach (lc2, fdw_info->considered_paths)
 		{
@@ -525,14 +522,10 @@ tsl_debug_append_pruned_pathlist(StringInfo buf, PlannerInfo *root, RelOptInfo *
 
 			if (path_is_origin(p1, p2))
 			{
-				fdw_info->considered_paths =
-					list_delete_cell_compat(fdw_info->considered_paths, lc2, prev);
+				fdw_info->considered_paths = list_delete_cell(fdw_info->considered_paths, lc2);
 				fdw_utils_free_path(p2);
 				break;
 			}
-#if PG13_LT
-			prev = lc2;
-#endif
 		}
 	}
 

--- a/tsl/src/deparse.c
+++ b/tsl/src/deparse.c
@@ -964,7 +964,7 @@ deparse_grant_revoke_on_database(const GrantStmt *stmt, const char *dbname)
 			appendStringInfo(command,
 							 "%s%s ",
 							 priv->priv_name,
-							 lnext_compat(stmt->privileges, lc) != NULL ? "," : "");
+							 lnext(stmt->privileges, lc) != NULL ? "," : "");
 		}
 	}
 
@@ -1001,10 +1001,7 @@ deparse_grant_revoke_on_database(const GrantStmt *stmt, const char *dbname)
 				break;
 #endif
 		}
-		appendStringInfo(command,
-						 "%s%s ",
-						 role_name,
-						 lnext_compat(stmt->grantees, lc) != NULL ? "," : "");
+		appendStringInfo(command, "%s%s ", role_name, lnext(stmt->grantees, lc) != NULL ? "," : "");
 	}
 
 	if (stmt->grant_option)

--- a/tsl/src/fdw/deparse.c
+++ b/tsl/src/fdw/deparse.c
@@ -2636,7 +2636,7 @@ deparseSubscriptingRef(SubscriptingRef *node, deparse_expr_cxt *context)
 		{
 			deparseExpr(lfirst(lowlist_item), context);
 			appendStringInfoChar(buf, ':');
-			lowlist_item = lnext_compat(node->reflowerindexpr, lowlist_item);
+			lowlist_item = lnext(node->reflowerindexpr, lowlist_item);
 		}
 		deparseExpr(lfirst(uplist_item), context);
 		appendStringInfoChar(buf, ']');
@@ -2698,7 +2698,7 @@ deparseFuncExpr(FuncExpr *node, deparse_expr_cxt *context)
 	{
 		if (!first)
 			appendStringInfoString(buf, ", ");
-		if (use_variadic && lnext_compat(node->args, arg) == NULL)
+		if (use_variadic && lnext(node->args, arg) == NULL)
 			appendStringInfoString(buf, "VARIADIC ");
 		deparseExpr((Expr *) lfirst(arg), context);
 		first = false;
@@ -3026,7 +3026,7 @@ deparseAggref(Aggref *node, deparse_expr_cxt *context)
 				first = false;
 
 				/* Add VARIADIC */
-				if (use_variadic && lnext_compat(node->args, arg) == NULL)
+				if (use_variadic && lnext(node->args, arg) == NULL)
 					appendStringInfoString(buf, "VARIADIC ");
 
 				deparseExpr((Expr *) n, context);

--- a/tsl/src/fdw/modify_exec.c
+++ b/tsl/src/fdw/modify_exec.c
@@ -249,11 +249,7 @@ convert_attrs(TupleConversionMap *map, List *attrs)
 
 		for (i = 0; i < map->outdesc->natts; i++)
 		{
-#if PG13_GE
 			if (map->attrMap->attnums[i] == attnum)
-#else
-			if (map->attrMap[i] == attnum)
-#endif
 			{
 				new_attrs = lappend_int(new_attrs, AttrOffsetGetAttrNumber(i));
 				break;

--- a/tsl/src/nodes/async_append.c
+++ b/tsl/src/nodes/async_append.c
@@ -388,11 +388,9 @@ path_process(PlannerInfo *root, Path **path)
 		case T_SortPath:
 			path_process(root, &castNode(SortPath, subp)->subpath);
 			return;
-#if PG13_GE
 		case T_IncrementalSortPath:
 			path_process(root, &castNode(IncrementalSortPath, subp)->spath.subpath);
 			return;
-#endif
 		case T_UpperUniquePath:
 			path_process(root, &castNode(UpperUniquePath, subp)->subpath);
 			return;

--- a/tsl/src/nodes/gapfill/gapfill_plan.c
+++ b/tsl/src/nodes/gapfill/gapfill_plan.c
@@ -287,10 +287,10 @@ gapfill_build_pathtarget(PathTarget *pt_upper, PathTarget *pt_path, PathTarget *
 				/*
 				 * check arguments past first argument dont have Vars
 				 */
-				for (lc_arg = lnext_compat(context.call.window->args,
-										   list_head(context.call.window->args));
+				for (lc_arg =
+						 lnext(context.call.window->args, list_head(context.call.window->args));
 					 lc_arg != NULL;
-					 lc_arg = lnext_compat(context.call.window->args, lc_arg))
+					 lc_arg = lnext(context.call.window->args, lc_arg))
 				{
 					if (contain_var_clause(lfirst(lc_arg)))
 						ereport(ERROR,
@@ -547,10 +547,10 @@ gapfill_adjust_window_targetlist(PlannerInfo *root, RelOptInfo *input_rel, RelOp
 								/*
 								 * check arguments past first argument dont have Vars
 								 */
-								for (lc_arg = lnext_compat(context.call.window->args,
-														   list_head(context.call.window->args));
+								for (lc_arg = lnext(context.call.window->args,
+													list_head(context.call.window->args));
 									 lc_arg != NULL;
-									 lc_arg = lnext_compat(context.call.window->args, lc_arg))
+									 lc_arg = lnext(context.call.window->args, lc_arg))
 								{
 									if (contain_var_clause(lfirst(lc_arg)))
 										ereport(ERROR,

--- a/tsl/src/nodes/skip_scan/planner.c
+++ b/tsl/src/nodes/skip_scan/planner.c
@@ -458,13 +458,12 @@ get_distinct_var(PlannerInfo *root, IndexPath *index_path, SkipScanPath *skip_sc
 	/* attno mapping necessary */
 	if (map)
 	{
-		var = (Var *) map_variable_attnos_compat((Node *) var,
-												 var->varno,
-												 0,
-												 map->attrMap,
-												 map->outdesc->natts,
-												 InvalidOid,
-												 &found_wholerow);
+		var = (Var *) map_variable_attnos((Node *) var,
+										  var->varno,
+										  0,
+										  map->attrMap,
+										  InvalidOid,
+										  &found_wholerow);
 
 		free_conversion_map(map);
 

--- a/tsl/src/remote/connection_cache.c
+++ b/tsl/src/remote/connection_cache.c
@@ -397,9 +397,7 @@ static const char *conn_status_str[] = {
 	[CONNECTION_CHECK_WRITABLE] = "CHECK WRITABLE",
 	[CONNECTION_CONSUME] = "CONSUME",
 	[CONNECTION_GSS_STARTUP] = "GSS STARTUP",
-#if PG13_GE
 	[CONNECTION_CHECK_TARGET] = "CHECK TARGET",
-#endif
 };
 
 static const char *conn_txn_status_str[] = {

--- a/tsl/src/reorder.c
+++ b/tsl/src/reorder.c
@@ -60,11 +60,7 @@
 #include <utils/snapmgr.h>
 
 #include "compat/compat.h"
-#if PG13_LT
-#include <access/tuptoaster.h>
-#else
 #include <access/toast_internals.h>
-#endif
 
 #include "annotations.h"
 #include "chunk.h"

--- a/tsl/test/src/test_ddl_hook.c
+++ b/tsl/test/src/test_ddl_hook.c
@@ -80,11 +80,7 @@ test_ddl_command_end(EventTriggerData *command)
 	ListCell *cell;
 	Hypertable *ht;
 
-#if PG13_GE
 	elog(NOTICE, "test_ddl_command_end: %s", GetCommandTagName(command->tag));
-#else
-	elog(NOTICE, "test_ddl_command_end: %s", command->tag);
-#endif
 
 	if (tsl_delayed_execution_list == NIL)
 		return;


### PR DESCRIPTION
Removed PG12 specific code guarded by the PG13_LT and PG13_GE macros.

Disable-check: force-changelog-file