### PR TITLE
Bulk decompression: compute bitmap prefix sums

### DIFF
--- a/tsl/src/compression/gorilla.c
+++ b/tsl/src/compression/gorilla.c
@@ -882,6 +882,7 @@ unpack_leading_zeros_array(BitArray *bitarray, uint8 *restrict dest)
 }
 
 /* Bulk gorilla decompression, specialized for supported data types. */
+#include "simple8b_rle_prefix_sum.h"
 
 #define ELEMENT_TYPE uint8
 #include "simple8b_rle_decompress_all.h"

--- a/tsl/src/compression/gorilla_impl.c
+++ b/tsl/src/compression/gorilla_impl.c
@@ -40,22 +40,18 @@ FUNCTION_NAME(gorilla_decompress_all, ELEMENT_TYPE)(CompressedGorillaData *goril
 	CheckCompressedData(n_total >= n_notnull);
 
 	/* Unpack the basic compressed data parts. */
-	Simple8bRleBitmap tag0s = simple8brle_bitmap_prefixsums(gorilla_data->tag0s);
-	Simple8bRleBitmap tag1s = simple8brle_bitmap_prefixsums(gorilla_data->tag1s);
-
-	BitArray leading_zeros_bitarray = gorilla_data->leading_zeros;
-	BitArrayIterator leading_zeros_iterator;
-	bit_array_iterator_init(&leading_zeros_iterator, &leading_zeros_bitarray);
+	Simple8bRlePrefixSum tag1s;
+	simple8brle_prefix_sums(gorilla_data->tag1s, &tag1s);
 
 	uint8 all_leading_zeros[MAX_NUM_LEADING_ZEROS_PADDED_N64];
 	const uint16 leading_zeros_padded =
 		unpack_leading_zeros_array(&gorilla_data->leading_zeros, all_leading_zeros);
 
+	const uint16 num_bit_widths = gorilla_data->num_bits_used_per_xor->num_elements;
 	uint8 bit_widths[MAX_NUM_LEADING_ZEROS_PADDED_N64];
-	const uint16 num_bit_widths =
-		simple8brle_decompress_all_buf_uint8(gorilla_data->num_bits_used_per_xor,
-											 bit_widths,
-											 MAX_NUM_LEADING_ZEROS_PADDED_N64);
+	simple8brle_decompress_all_buf_uint8(gorilla_data->num_bits_used_per_xor,
+										 bit_widths,
+										 MAX_NUM_LEADING_ZEROS_PADDED_N64);
 
 	BitArray xors_bitarray = gorilla_data->xors;
 	BitArrayIterator xors_iterator;
@@ -69,14 +65,14 @@ FUNCTION_NAME(gorilla_decompress_all, ELEMENT_TYPE)(CompressedGorillaData *goril
 	 * 1a) Sanity check: the number of bit widths we have matches the
 	 * number of 1s in the tag1s array.
 	 */
-	CheckCompressedData(simple8brle_bitmap_num_ones(&tag1s) == num_bit_widths);
-	CheckCompressedData(simple8brle_bitmap_num_ones(&tag1s) <= leading_zeros_padded);
+	CheckCompressedData(simple8brle_prefix_sum_total(&tag1s) == num_bit_widths);
+	CheckCompressedData(simple8brle_prefix_sum_total(&tag1s) <= leading_zeros_padded);
 
 	/*
 	 * 1b) Sanity check: the first tag1 must be 1, so that we initialize the bit
 	 * widths.
 	 */
-	CheckCompressedData(simple8brle_bitmap_prefix_sum(&tag1s, 0) == 1);
+	CheckCompressedData(simple8brle_prefix_sum_get_at(&tag1s, 0) == 1);
 
 	/*
 	 * 1c) Sanity check: can't have more different elements than notnull elements.
@@ -93,9 +89,9 @@ FUNCTION_NAME(gorilla_decompress_all, ELEMENT_TYPE)(CompressedGorillaData *goril
 	ELEMENT_TYPE prev = 0;
 	for (uint16 i = 0; i < n_different; i++)
 	{
-		const uint8 current_xor_bits = bit_widths[simple8brle_bitmap_prefix_sum(&tag1s, i) - 1];
-		const uint8 current_leading_zeros =
-			all_leading_zeros[simple8brle_bitmap_prefix_sum(&tag1s, i) - 1];
+		const uint16 offset = simple8brle_prefix_sum_get_at(&tag1s, i) - 1;
+		const uint8 current_xor_bits = bit_widths[offset];
+		const uint8 current_leading_zeros = all_leading_zeros[offset];
 
 		/*
 		 * Truncate the shift here not to cause UB on the corrupt data.
@@ -109,25 +105,29 @@ FUNCTION_NAME(gorilla_decompress_all, ELEMENT_TYPE)(CompressedGorillaData *goril
 
 	/*
 	 * 2) Fill out the stretches of repeated elements, encoded with tag0 = 0.
-	 *
+	 */
+	Simple8bRlePrefixSum tag0s;
+	simple8brle_prefix_sums(gorilla_data->tag0s, &tag0s);
+
+	/*
 	 * 2a) Sanity check: number of different elements according to tag0s must be
 	 * the same as number of different elements according to tag1s, so that the
 	 * current_element doesn't underrun.
 	 */
-	CheckCompressedData(simple8brle_bitmap_num_ones(&tag0s) == n_different);
+	CheckCompressedData(simple8brle_prefix_sum_total(&tag0s) == n_different);
 
 	/*
 	 * 2b) Sanity check: tag0s[0] == 1 -- the first element of the sequence is
 	 * always "different from the previous one".
 	 */
-	CheckCompressedData(simple8brle_bitmap_prefix_sum(&tag0s, 0) == 1);
+	CheckCompressedData(simple8brle_prefix_sum_get_at(&tag0s, 0) == 1);
 
 	/*
 	 * 2b) Fill the repeated elements.
 	 */
 	for (int i = n_notnull - 1; i >= 0; i--)
 	{
-		decompressed_values[i] = decompressed_values[simple8brle_bitmap_prefix_sum(&tag0s, i) - 1];
+		decompressed_values[i] = decompressed_values[simple8brle_prefix_sum_get_at(&tag0s, i) - 1];
 	}
 
 	/*
@@ -149,7 +149,8 @@ FUNCTION_NAME(gorilla_decompress_all, ELEMENT_TYPE)(CompressedGorillaData *goril
 		 * We have decompressed the data with nulls skipped, reshuffle it
 		 * according to the nulls bitmap.
 		 */
-		Simple8bRleBitmap nulls = simple8brle_bitmap_decompress(gorilla_data->nulls);
+		Simple8bRleBitmap nulls;
+		simple8brle_bitmap_decompress(gorilla_data->nulls, &nulls);
 		CheckCompressedData(n_notnull + simple8brle_bitmap_num_ones(&nulls) == n_total);
 
 		int current_notnull_element = n_notnull - 1;

--- a/tsl/src/compression/simple8b_rle_bitmap.h
+++ b/tsl/src/compression/simple8b_rle_bitmap.h
@@ -15,11 +15,17 @@
 
 typedef struct Simple8bRleBitmap
 {
-	/* Either the bools or prefix sums, depending on the decompression method. */
-	void *data;
-
 	uint16 num_elements;
 	uint16 num_ones;
+
+	/*
+	 * Pad to next multiple of 64 bytes on the right, so that we can simplify the
+	 * decompression loop and the get() function. Note that for get() we need at
+	 * least one byte of padding, hence the next multiple.
+	 */
+#define BITMAP_NUM_ELEMENTS (((GLOBAL_MAX_ROWS_PER_COMPRESSION + 63) / 64 + 1) * 64)
+	bool data[BITMAP_NUM_ELEMENTS];
+#undef BITMAP_NUM_ELEMENTS
 } Simple8bRleBitmap;
 
 pg_attribute_always_inline static bool
@@ -28,14 +34,7 @@ simple8brle_bitmap_get_at(Simple8bRleBitmap *bitmap, uint16 i)
 	/* We have some padding on the right but we shouldn't overrun it. */
 	Assert(i < ((bitmap->num_elements + 63) / 64 + 1) * 64);
 
-	return ((bool *restrict) bitmap->data)[i];
-}
-
-pg_attribute_always_inline static uint16
-simple8brle_bitmap_prefix_sum(Simple8bRleBitmap *bitmap, uint16 i)
-{
-	Assert(i < ((bitmap->num_elements + 63) / 64 + 1) * 64);
-	return ((uint16 *restrict) bitmap->data)[i];
+	return bitmap->data[i];
 }
 
 pg_attribute_always_inline static uint16
@@ -44,161 +43,8 @@ simple8brle_bitmap_num_ones(Simple8bRleBitmap *bitmap)
 	return bitmap->num_ones;
 }
 
-/*
- * Calculate prefix sum of bits instead of bitmap itself, because it's more
- * useful for gorilla decompression. Can be unused by other users of this
- * header.
- */
-static Simple8bRleBitmap simple8brle_bitmap_prefixsums(Simple8bRleSerialized *compressed)
-	pg_attribute_unused();
-
-static Simple8bRleBitmap
-simple8brle_bitmap_prefixsums(Simple8bRleSerialized *compressed)
-{
-	CheckCompressedData(compressed->num_elements <= GLOBAL_MAX_ROWS_PER_COMPRESSION);
-	CheckCompressedData(compressed->num_blocks <= GLOBAL_MAX_ROWS_PER_COMPRESSION);
-
-	const uint16 num_elements = compressed->num_elements;
-
-	const uint16 num_selector_slots =
-		simple8brle_num_selector_slots_for_num_blocks(compressed->num_blocks);
-	const uint64 *compressed_data = compressed->slots + num_selector_slots;
-
-	/*
-	 * Pad to next multiple of 64 bytes on the right, so that we can simplify the
-	 * decompression loop and the get() function. Note that for get() we need at
-	 * least one byte of padding, hence the next multiple.
-	 */
-	const uint16 num_elements_padded = ((num_elements + 63) / 64 + 1) * 64;
-	const uint16 num_blocks = compressed->num_blocks;
-
-	uint16 *restrict prefix_sums = palloc(sizeof(uint16) * num_elements_padded);
-
-	uint16 current_prefix_sum = 0;
-	uint16 decompressed_index = 0;
-	for (uint16 block_index = 0; block_index < num_blocks; block_index++)
-	{
-		const uint16 selector_slot = block_index / SIMPLE8B_SELECTORS_PER_SELECTOR_SLOT;
-		const uint16 selector_pos_in_slot = block_index % SIMPLE8B_SELECTORS_PER_SELECTOR_SLOT;
-		const uint64 slot_value = compressed->slots[selector_slot];
-		const uint8 selector_shift = selector_pos_in_slot * SIMPLE8B_BITS_PER_SELECTOR;
-		const uint64 selector_mask = 0xFULL << selector_shift;
-		const uint8 selector_value = (slot_value & selector_mask) >> selector_shift;
-		Assert(selector_value < 16);
-
-		uint64 block_data = compressed_data[block_index];
-
-		if (simple8brle_selector_is_rle(selector_value))
-		{
-			/*
-			 * RLE block.
-			 */
-			const size_t n_block_values = simple8brle_rledata_repeatcount(block_data);
-			CheckCompressedData(n_block_values <= GLOBAL_MAX_ROWS_PER_COMPRESSION);
-
-			const bool repeated_value = simple8brle_rledata_value(block_data);
-
-			CheckCompressedData(decompressed_index + n_block_values <= num_elements);
-
-			if (repeated_value)
-			{
-				for (uint16 i = 0; i < n_block_values; i++)
-				{
-					prefix_sums[decompressed_index + i] = current_prefix_sum + i + 1;
-				}
-				current_prefix_sum += n_block_values;
-			}
-			else
-			{
-				for (uint16 i = 0; i < n_block_values; i++)
-				{
-					prefix_sums[decompressed_index + i] = current_prefix_sum;
-				}
-			}
-
-			decompressed_index += n_block_values;
-			Assert(decompressed_index <= num_elements);
-		}
-		else
-		{
-			/*
-			 * Bit-packed block. Since this is a bitmap, this block has 64 bits
-			 * packed. The last block might contain less than maximal possible
-			 * number of elements, but we have 64 bytes of padding on the right
-			 * so we don't care.
-			 */
-			CheckCompressedData(selector_value == 1);
-
-			Assert(SIMPLE8B_BIT_LENGTH[selector_value] == 1);
-			Assert(SIMPLE8B_NUM_ELEMENTS[selector_value] == 64);
-
-			/*
-			 * We should require at least one element from the block. Previous
-			 * blocks might have had incorrect lengths, so this is not an
-			 * assertion.
-			 */
-			CheckCompressedData(decompressed_index < num_elements);
-
-			/* Have to zero out the unused bits, so that the popcnt works properly. */
-			const int elements_this_block = Min(64, num_elements - decompressed_index);
-			Assert(elements_this_block <= 64);
-			Assert(elements_this_block > 0);
-			block_data &= (-1ULL) >> (64 - elements_this_block);
-
-			/*
-			 * The number of block elements should fit within padding. Previous
-			 * blocks might have had incorrect lengths, so this is not an
-			 * assertion.
-			 */
-			CheckCompressedData(decompressed_index + 64 < num_elements_padded);
-
-#ifdef HAVE__BUILTIN_POPCOUNT
-			for (uint16 i = 0; i < 64; i++)
-			{
-				const uint16 word_prefix_sum =
-					__builtin_popcountll(block_data & (-1ULL >> (63 - i)));
-				prefix_sums[decompressed_index + i] = current_prefix_sum + word_prefix_sum;
-			}
-			current_prefix_sum += __builtin_popcountll(block_data);
-#else
-			/*
-			 * Unfortunatly, we have to have this fallback for Windows.
-			 */
-			for (uint16 i = 0; i < 64; i++)
-			{
-				const bool this_bit = (block_data >> i) & 1;
-				current_prefix_sum += this_bit;
-				prefix_sums[decompressed_index + i] = current_prefix_sum;
-			}
-#endif
-			decompressed_index += 64;
-		}
-	}
-
-	/*
-	 * We might have unpacked more because we work in full blocks, but at least
-	 * we shouldn't have unpacked less.
-	 */
-	CheckCompressedData(decompressed_index >= num_elements);
-	Assert(decompressed_index <= num_elements_padded);
-
-	/*
-	 * Might happen if we have stray ones in the higher unused bits of the last
-	 * block.
-	 */
-	CheckCompressedData(current_prefix_sum <= num_elements);
-
-	Simple8bRleBitmap result = {
-		.data = prefix_sums,
-		.num_elements = num_elements,
-		.num_ones = current_prefix_sum,
-	};
-
-	return result;
-}
-
-static Simple8bRleBitmap
-simple8brle_bitmap_decompress(Simple8bRleSerialized *compressed)
+static void
+simple8brle_bitmap_decompress(Simple8bRleSerialized *compressed, Simple8bRleBitmap *result)
 {
 	CheckCompressedData(compressed->num_elements <= GLOBAL_MAX_ROWS_PER_COMPRESSION);
 	CheckCompressedData(compressed->num_blocks <= GLOBAL_MAX_ROWS_PER_COMPRESSION);
@@ -218,7 +64,7 @@ simple8brle_bitmap_decompress(Simple8bRleSerialized *compressed)
 	const uint16 num_elements_padded = ((num_elements + 63) / 64 + 1) * 64;
 	const uint16 num_blocks = compressed->num_blocks;
 
-	bool *restrict bitmap_bools_ = palloc(sizeof(bool) * num_elements_padded);
+	bool *restrict bitmap_bools_ = result->data;
 	uint16 decompressed_index = 0;
 	for (uint16 block_index = 0; block_index < num_blocks; block_index++)
 	{
@@ -334,21 +180,16 @@ simple8brle_bitmap_decompress(Simple8bRleSerialized *compressed)
 	 */
 	CheckCompressedData(num_ones <= num_elements);
 
-	Simple8bRleBitmap result = {
-		.num_elements = num_elements,
-		.data = bitmap_bools_,
-		.num_ones = num_ones,
-	};
+	result->num_elements = num_elements;
+	result->num_ones = num_ones;
 
 	/* Sanity check. */
 #ifdef USE_ASSERT_CHECKING
 	int num_ones_2 = 0;
 	for (int i = 0; i < num_elements; i++)
 	{
-		num_ones_2 += simple8brle_bitmap_get_at(&result, i);
+		num_ones_2 += simple8brle_bitmap_get_at(result, i);
 	}
 	Assert(num_ones_2 == num_ones);
 #endif
-
-	return result;
 }

--- a/tsl/src/compression/simple8b_rle_decompress_all.h
+++ b/tsl/src/compression/simple8b_rle_decompress_all.h
@@ -11,7 +11,7 @@
  * Specialization of bulk simple8brle decompression for a data type specified by
  * ELEMENT_TYPE macro.
  */
-static uint16
+static void
 FUNCTION_NAME(simple8brle_decompress_all_buf,
 			  ELEMENT_TYPE)(Simple8bRleSerialized *compressed,
 							ELEMENT_TYPE *restrict decompressed_values, uint16 n_buffer_elements)
@@ -134,8 +134,6 @@ FUNCTION_NAME(simple8brle_decompress_all_buf,
 	 */
 	CheckCompressedData(decompressed_index >= n_total_values);
 	Assert(decompressed_index <= n_buffer_elements);
-
-	return n_total_values;
 }
 
 /*
@@ -144,12 +142,11 @@ FUNCTION_NAME(simple8brle_decompress_all_buf,
  * element type we have.
  */
 static ELEMENT_TYPE *FUNCTION_NAME(simple8brle_decompress_all,
-								   ELEMENT_TYPE)(Simple8bRleSerialized *compressed, uint16 *n_)
+								   ELEMENT_TYPE)(Simple8bRleSerialized *compressed)
 	pg_attribute_unused();
 
 static ELEMENT_TYPE *
-FUNCTION_NAME(simple8brle_decompress_all, ELEMENT_TYPE)(Simple8bRleSerialized *compressed,
-														uint16 *n_)
+FUNCTION_NAME(simple8brle_decompress_all, ELEMENT_TYPE)(Simple8bRleSerialized *compressed)
 {
 	const uint16 n_total_values = compressed->num_elements;
 	Assert(n_total_values <= GLOBAL_MAX_ROWS_PER_COMPRESSION);
@@ -162,8 +159,8 @@ FUNCTION_NAME(simple8brle_decompress_all, ELEMENT_TYPE)(Simple8bRleSerialized *c
 
 	ELEMENT_TYPE *restrict decompressed_values = palloc(sizeof(ELEMENT_TYPE) * n_buffer_elements);
 
-	*n_ = FUNCTION_NAME(simple8brle_decompress_all_buf,
-						ELEMENT_TYPE)(compressed, decompressed_values, n_buffer_elements);
+	FUNCTION_NAME(simple8brle_decompress_all_buf, ELEMENT_TYPE)
+	(compressed, decompressed_values, n_buffer_elements);
 
 	return decompressed_values;
 }

--- a/tsl/src/compression/simple8b_rle_prefix_sum.h
+++ b/tsl/src/compression/simple8b_rle_prefix_sum.h
@@ -1,0 +1,180 @@
+
+/*
+ * This file and its contents are licensed under the Timescale License.
+ * Please see the included NOTICE for copyright information and
+ * LICENSE-TIMESCALE for a copy of the license.
+ */
+
+/*
+ * This file implements calculation of prefix sums of a Simple8bRLE-encoded
+ * bitmap. Used for gorilla decompression.
+ */
+
+#pragma once
+
+#include "compression/simple8b_rle.h"
+
+typedef struct Simple8bRlePrefixSum
+{
+	uint16 num_elements;
+	/*
+	 * Pad to next multiple of 64 bytes on the right, so that we can simplify the
+	 * decompression loop and the get() function. Note that for get() we need at
+	 * least one byte of padding, hence the next multiple.
+	 */
+#define BITMAP_NUM_ELEMENTS (((GLOBAL_MAX_ROWS_PER_COMPRESSION + 63) / 64 + 1) * 64)
+	uint16 data[BITMAP_NUM_ELEMENTS];
+#undef BITMAP_NUM_ELEMENTS
+} Simple8bRlePrefixSum;
+
+pg_attribute_always_inline static uint16
+simple8brle_prefix_sum_get_at(Simple8bRlePrefixSum *sums, uint16 i)
+{
+	Assert(i < ((sums->num_elements + 63) / 64 + 1) * 64);
+	return sums->data[i];
+}
+
+pg_attribute_always_inline static uint16
+simple8brle_prefix_sum_total(Simple8bRlePrefixSum *sums)
+{
+	return sums->data[sums->num_elements - 1];
+}
+
+static void
+simple8brle_prefix_sums(Simple8bRleSerialized *compressed, Simple8bRlePrefixSum *result)
+{
+	CheckCompressedData(compressed->num_elements <= GLOBAL_MAX_ROWS_PER_COMPRESSION);
+	CheckCompressedData(compressed->num_blocks <= GLOBAL_MAX_ROWS_PER_COMPRESSION);
+
+	const uint16 num_elements = compressed->num_elements;
+
+	const uint16 num_selector_slots =
+		simple8brle_num_selector_slots_for_num_blocks(compressed->num_blocks);
+	const uint64 *compressed_data = compressed->slots + num_selector_slots;
+
+	/*
+	 * Pad to next multiple of 64 bytes on the right, so that we can simplify the
+	 * decompression loop and the get() function. Note that for get() we need at
+	 * least one byte of padding, hence the next multiple.
+	 */
+	const uint16 num_elements_padded = ((num_elements + 63) / 64 + 1) * 64;
+	const uint16 num_blocks = compressed->num_blocks;
+
+	uint16 *restrict prefix_sums = result->data;
+
+	uint16 current_prefix_sum = 0;
+	uint16 decompressed_index = 0;
+	for (uint16 block_index = 0; block_index < num_blocks; block_index++)
+	{
+		const uint16 selector_slot = block_index / SIMPLE8B_SELECTORS_PER_SELECTOR_SLOT;
+		const uint16 selector_pos_in_slot = block_index % SIMPLE8B_SELECTORS_PER_SELECTOR_SLOT;
+		const uint64 slot_value = compressed->slots[selector_slot];
+		const uint8 selector_shift = selector_pos_in_slot * SIMPLE8B_BITS_PER_SELECTOR;
+		const uint64 selector_mask = 0xFULL << selector_shift;
+		const uint8 selector_value = (slot_value & selector_mask) >> selector_shift;
+		Assert(selector_value < 16);
+
+		uint64 block_data = compressed_data[block_index];
+
+		if (simple8brle_selector_is_rle(selector_value))
+		{
+			/*
+			 * RLE block.
+			 */
+			const size_t n_block_values = simple8brle_rledata_repeatcount(block_data);
+			CheckCompressedData(n_block_values <= GLOBAL_MAX_ROWS_PER_COMPRESSION);
+
+			const bool repeated_value = simple8brle_rledata_value(block_data);
+
+			CheckCompressedData(decompressed_index + n_block_values <= num_elements);
+
+			if (repeated_value)
+			{
+				for (uint16 i = 0; i < n_block_values; i++)
+				{
+					prefix_sums[decompressed_index + i] = current_prefix_sum + i + 1;
+				}
+				current_prefix_sum += n_block_values;
+			}
+			else
+			{
+				for (uint16 i = 0; i < n_block_values; i++)
+				{
+					prefix_sums[decompressed_index + i] = current_prefix_sum;
+				}
+			}
+
+			decompressed_index += n_block_values;
+			Assert(decompressed_index <= num_elements);
+		}
+		else
+		{
+			/*
+			 * Bit-packed block. Since this is a bitmap, this block has 64 bits
+			 * packed. The last block might contain less than maximal possible
+			 * number of elements, but we have 64 bytes of padding on the right
+			 * so we don't care.
+			 */
+			CheckCompressedData(selector_value == 1);
+
+			Assert(SIMPLE8B_BIT_LENGTH[selector_value] == 1);
+			Assert(SIMPLE8B_NUM_ELEMENTS[selector_value] == 64);
+
+			/*
+			 * We should require at least one element from the block. Previous
+			 * blocks might have had incorrect lengths, so this is not an
+			 * assertion.
+			 */
+			CheckCompressedData(decompressed_index < num_elements);
+
+			/* Have to zero out the unused bits, so that the popcnt works properly. */
+			const int elements_this_block = Min(64, num_elements - decompressed_index);
+			Assert(elements_this_block <= 64);
+			Assert(elements_this_block > 0);
+			block_data &= (-1ULL) >> (64 - elements_this_block);
+
+			/*
+			 * The number of block elements should fit within padding. Previous
+			 * blocks might have had incorrect lengths, so this is not an
+			 * assertion.
+			 */
+			CheckCompressedData(decompressed_index + 64 < num_elements_padded);
+
+#ifdef HAVE__BUILTIN_POPCOUNT
+			for (uint16 i = 0; i < 64; i++)
+			{
+				const uint16 word_prefix_sum =
+					__builtin_popcountll(block_data & (-1ULL >> (63 - i)));
+				prefix_sums[decompressed_index + i] = current_prefix_sum + word_prefix_sum;
+			}
+			current_prefix_sum += __builtin_popcountll(block_data);
+#else
+			/*
+			 * Unfortunatly, we have to have this fallback for Windows.
+			 */
+			for (uint16 i = 0; i < 64; i++)
+			{
+				const bool this_bit = (block_data >> i) & 1;
+				current_prefix_sum += this_bit;
+				prefix_sums[decompressed_index + i] = current_prefix_sum;
+			}
+#endif
+			decompressed_index += 64;
+		}
+	}
+
+	/*
+	 * We might have unpacked more because we work in full blocks, but at least
+	 * we shouldn't have unpacked less.
+	 */
+	CheckCompressedData(decompressed_index >= num_elements);
+	Assert(decompressed_index <= num_elements_padded);
+
+	/*
+	 * Might happen if we have stray ones in the higher unused bits of the last
+	 * block.
+	 */
+	CheckCompressedData(current_prefix_sum <= num_elements);
+
+	result->num_elements = num_elements;
+}


### PR DESCRIPTION
They are more useful for Gorilla decompression, and allow us to simplify the algorithms and get a small performance boost.