### PR TITLE
Fix crash in COPY from program returning error

### DIFF
--- a/.unreleased/bugfix_5918
+++ b/.unreleased/bugfix_5918
@@ -1,0 +1,3 @@
+Fixes: #5918 Fix crash in COPY from program returning error
+
+Thanks: @alexanderlaw

--- a/src/copy.c
+++ b/src/copy.c
@@ -1154,7 +1154,7 @@ copyfrom(CopyChunkState *ccstate, List *range_table, Hypertable *ht, MemoryConte
 		TSCopyMultiInsertInfoFlushAndCleanup(&multiInsertInfo);
 
 	/* Done, clean up */
-	if (errcallback.previous)
+	if (ccstate->cstate && callback)
 		error_context_stack = errcallback.previous;
 
 	FreeBulkInsertState(bistate);

--- a/test/expected/copy.out
+++ b/test/expected/copy.out
@@ -152,12 +152,15 @@ NOTICE:  adding not-null constraint to column "b"
 \set ON_ERROR_STOP 0
 COPY TEST (a,b) FROM STDIN (delimiter ',', null 'N');
 ERROR:  null value in column "a" of relation "_hyper_5_13_chunk" violates not-null constraint
+\c :TEST_DBNAME :ROLE_SUPERUSER
+SET client_min_messages TO NOTICE;
+-- Do a basic test of COPY with a wrong PROGRAM
+COPY hyper FROM PROGRAM 'error';
+ERROR:  program "error" failed
 \set ON_ERROR_STOP 1
 ----------------------------------------------------------------
 -- Testing COPY TO.
 ----------------------------------------------------------------
-\c :TEST_DBNAME :ROLE_SUPERUSER
-SET client_min_messages TO NOTICE;
 -- COPY TO using a hypertable will not copy any tuples, but should
 -- show a notice.
 COPY hyper TO STDOUT DELIMITER ',';

--- a/test/sql/copy.sql
+++ b/test/sql/copy.sql
@@ -94,14 +94,17 @@ SELECT create_hypertable('test', 'b');
 COPY TEST (a,b) FROM STDIN (delimiter ',', null 'N');
 N,'2020-01-01'
 \.
+
+\c :TEST_DBNAME :ROLE_SUPERUSER
+SET client_min_messages TO NOTICE;
+
+-- Do a basic test of COPY with a wrong PROGRAM
+COPY hyper FROM PROGRAM 'error';
 \set ON_ERROR_STOP 1
 
 ----------------------------------------------------------------
 -- Testing COPY TO.
 ----------------------------------------------------------------
-
-\c :TEST_DBNAME :ROLE_SUPERUSER
-SET client_min_messages TO NOTICE;
 
 -- COPY TO using a hypertable will not copy any tuples, but should
 -- show a notice.


### PR DESCRIPTION
Reset the errcallback appropriately so that the ereport in case of a PROGRAM returning error can work correctly.