### PR TITLE
PG16: ExecInsertIndexTuples requires additional parameter

### DIFF
--- a/src/compat/compat.h
+++ b/src/compat/compat.h
@@ -89,8 +89,19 @@
 									update,                                                        \
 									noDupErr,                                                      \
 									specConflict,                                                  \
-									arbiterIndexes)                                                \
+									arbiterIndexes,                                                \
+									onlySummarizing)                                               \
 	ExecInsertIndexTuples(slot, estate, noDupErr, specConflict, arbiterIndexes)
+#elif PG16_LT
+#define ExecInsertIndexTuplesCompat(rri,                                                           \
+									slot,                                                          \
+									estate,                                                        \
+									update,                                                        \
+									noDupErr,                                                      \
+									specConflict,                                                  \
+									arbiterIndexes,                                                \
+									onlySummarizing)                                               \
+	ExecInsertIndexTuples(rri, slot, estate, update, noDupErr, specConflict, arbiterIndexes)
 #else
 #define ExecInsertIndexTuplesCompat(rri,                                                           \
 									slot,                                                          \
@@ -98,8 +109,16 @@
 									update,                                                        \
 									noDupErr,                                                      \
 									specConflict,                                                  \
-									arbiterIndexes)                                                \
-	ExecInsertIndexTuples(rri, slot, estate, update, noDupErr, specConflict, arbiterIndexes)
+									arbiterIndexes,                                                \
+									onlySummarizing)                                               \
+	ExecInsertIndexTuples(rri,                                                                     \
+						  slot,                                                                    \
+						  estate,                                                                  \
+						  update,                                                                  \
+						  noDupErr,                                                                \
+						  specConflict,                                                            \
+						  arbiterIndexes,                                                          \
+						  onlySummarizing)
 #endif
 
 /* PG14 fixes a bug in miscomputation of relids set in pull_varnos. The bugfix

--- a/src/copy.c
+++ b/src/copy.c
@@ -385,7 +385,8 @@ TSCopyMultiInsertBufferFlush(TSCopyMultiInsertInfo *miinfo, TSCopyMultiInsertBuf
 														 false,
 														 false,
 														 NULL,
-														 NIL);
+														 NIL,
+														 false);
 
 			ExecARInsertTriggers(estate,
 								 resultRelInfo,
@@ -1091,7 +1092,8 @@ copyfrom(CopyChunkState *ccstate, List *range_table, Hypertable *ht, MemoryConte
 																 false,
 																 false,
 																 NULL,
-																 NIL);
+																 NIL,
+																 false);
 				/* AFTER ROW INSERT Triggers */
 				ExecARInsertTriggers(estate,
 									 resultRelInfo,

--- a/src/import/ht_hypertable_modify.c
+++ b/src/import/ht_hypertable_modify.c
@@ -193,9 +193,16 @@ ht_ExecUpdateEpilogue(ModifyTableContext * context, UpdateContext * updateCxt,
 	ModifyTableState *mtstate = context->mtstate;
 
 	/* insert index entries for tuple if necessary */
+
 	if (resultRelInfo->ri_NumIndices > 0 && updateCxt->updateIndexes)
-		recheckIndexes =
-			ExecInsertIndexTuples(resultRelInfo, slot, context->estate, true, false, NULL, NIL);
+		recheckIndexes = ExecInsertIndexTuplesCompat(resultRelInfo,
+													 slot,
+													 context->estate,
+													 true,
+													 false,
+													 NULL,
+													 NIL,
+													 false);
 
 	/* AFTER ROW UPDATE Triggers */
 	ExecARUpdateTriggersCompat(context->estate,

--- a/src/nodes/hypertable_modify.c
+++ b/src/nodes/hypertable_modify.c
@@ -1790,13 +1790,14 @@ ExecInsert(ModifyTableContext *context, ResultRelInfo *resultRelInfo, TupleTable
 										   specToken);
 
 			/* insert index entries for tuple */
-			recheckIndexes = ExecInsertIndexTuples(resultRelInfo,
-												   slot,
-												   estate,
-												   false,
-												   true,
-												   &specConflict,
-												   arbiterIndexes);
+			recheckIndexes = ExecInsertIndexTuplesCompat(resultRelInfo,
+														 slot,
+														 estate,
+														 false,
+														 true,
+														 &specConflict,
+														 arbiterIndexes,
+														 false);
 
 			/* adjust the tuple's state accordingly */
 			table_tuple_complete_speculative(resultRelationDesc, slot, specToken, !specConflict);
@@ -1830,8 +1831,14 @@ ExecInsert(ModifyTableContext *context, ResultRelInfo *resultRelInfo, TupleTable
 
 			/* insert index entries for tuple */
 			if (resultRelInfo->ri_NumIndices > 0)
-				recheckIndexes =
-					ExecInsertIndexTuples(resultRelInfo, slot, estate, false, false, NULL, NIL);
+				recheckIndexes = ExecInsertIndexTuplesCompat(resultRelInfo,
+															 slot,
+															 estate,
+															 false,
+															 false,
+															 NULL,
+															 NIL,
+															 false);
 		}
 	}
 

--- a/tsl/src/compression/compression.c
+++ b/tsl/src/compression/compression.c
@@ -2443,7 +2443,15 @@ fix_index_qual(Relation comp_chunk_rel, Relation index_rel, Var *var, List **pre
 			   char *column_name, Node *node, Oid opno)
 {
 	int i = 0;
+#if PG16_LT
 	Bitmapset *key_columns = RelationGetIndexAttrBitmap(comp_chunk_rel, INDEX_ATTR_BITMAP_ALL);
+#else
+	Bitmapset *key_columns =
+		RelationGetIndexAttrBitmap(comp_chunk_rel, INDEX_ATTR_BITMAP_HOT_BLOCKING);
+	key_columns =
+		bms_add_members(key_columns,
+						RelationGetIndexAttrBitmap(comp_chunk_rel, INDEX_ATTR_BITMAP_SUMMARIZED));
+#endif
 
 	for (i = 0; i < index_rel->rd_index->indnatts; i++)
 	{


### PR DESCRIPTION
PG16 adds a new boolean parameter to the ExecInsertIndexTuples function to denote if the index is a BRIN index, which is then used to determine if the index update can be skipped. The fix also removes the INDEX_ATTR_BITMAP_ALL enum value.

Adapt these changes by updating the compat function to accomodate the new parameter added to the ExecInsertIndexTuples function and using an alternative for the removed INDEX_ATTR_BITMAP_ALL enum value.

postgres/postgres@19d8e23

Disable-check: force-changelog-file