### PR TITLE
PG16 : update couple of redefined functions

### DIFF
--- a/src/import/planner.c
+++ b/src/import/planner.c
@@ -970,6 +970,7 @@ replace_nestloop_params_mutator(Node *node, PlannerInfo *root)
 		/* Upper-level PlaceHolderVars should be long gone at this point */
 		Assert(phv->phlevelsup == 0);
 
+#if PG16_LT
 		/*
 		 * Check whether we need to replace the PHV.  We use bms_overlap as a
 		 * cheap/quick test to see if the PHV might be evaluated in the outer
@@ -977,6 +978,10 @@ replace_nestloop_params_mutator(Node *node, PlannerInfo *root)
 		 */
 		if (!bms_overlap(phv->phrels, root->curOuterRels) ||
 			!bms_is_subset(find_placeholder_info(root, phv, false)->ph_eval_at, root->curOuterRels))
+#else
+		/* Check whether we need to replace the PHV */
+		if (!bms_is_subset(find_placeholder_info(root, phv)->ph_eval_at, root->curOuterRels))
+#endif
 		{
 			/*
 			 * We can't replace the whole PHV, but we might still need to

--- a/src/ts_catalog/catalog.c
+++ b/src/ts_catalog/catalog.c
@@ -473,7 +473,11 @@ ts_catalog_table_info_init(CatalogTableInfo *tables_info, int max_tables,
 		{
 			RangeVar *sequence;
 
+#if PG16_LT
 			sequence = makeRangeVarFromNameList(stringToQualifiedNameList(sequence_name));
+#else
+			sequence = makeRangeVarFromNameList(stringToQualifiedNameList(sequence_name, NULL));
+#endif
 			tables_info[i].serial_relid = RangeVarGetRelid(sequence, NoLock, false);
 		}
 		else

--- a/tsl/src/fdw/option.c
+++ b/tsl/src/fdw/option.c
@@ -320,7 +320,11 @@ option_extract_join_ref_table_list(const char *join_tables)
 	{
 		char *tablename = (char *) lfirst(lc);
 
+#if PG16_LT
 		RangeVar *rangevar = makeRangeVarFromNameList(stringToQualifiedNameList(tablename));
+#else
+		RangeVar *rangevar = makeRangeVarFromNameList(stringToQualifiedNameList(tablename, NULL));
+#endif
 
 		Oid relOid = RangeVarGetRelidExtended(rangevar,
 											  AccessShareLock,


### PR DESCRIPTION
[PG16: stringToQualifiedNameList requires escontext parameter](https://github.com/timescale/timescaledb/commit/599b4ea31186f1d7110fb9e9bcc24334be50f46f) 

https://github.com/postgres/postgres/commit/858e776c84f

---

[PG16: No need to pass create_new_ph flag to find_placeholder_info](https://github.com/timescale/timescaledb/commit/8fee6164824ed57ebeafc06c418db963d0b376b9) 

https://github.com/postgres/postgres/commit/b3ff6c742

Disable-check: force-changelog-file
Disable-check: commit-count