### PR TITLE
Adjust 1-step policy argument types

### DIFF
--- a/.unreleased/bugfix_5920
+++ b/.unreleased/bugfix_5920
@@ -1,0 +1,1 @@
+Fixes: #5933 Adjust 1-step policy argument types

--- a/tsl/src/bgw_policy/policies_v2.c
+++ b/tsl/src/bgw_policy/policies_v2.c
@@ -56,6 +56,20 @@ emit_error(const char *err)
 	ereport(ERROR, (errcode(ERRCODE_INVALID_PARAMETER_VALUE), errmsg("%s", err)));
 }
 
+static Oid
+adjust_unknown_policy_argytpe(Oid argtype, Oid partition_type)
+{
+	Oid expected_type = argtype;
+	if (argtype != UNKNOWNOID)
+		return expected_type;
+
+	if (IS_INTEGER_TYPE(partition_type))
+		expected_type = partition_type;
+	else
+		expected_type = INTERVALOID;
+	return expected_type;
+}
+
 static int64
 offset_to_int64(NullableDatum arg, Oid argtype, Oid partition_type, bool is_start)
 {
@@ -67,8 +81,13 @@ offset_to_int64(NullableDatum arg, Oid argtype, Oid partition_type, bool is_star
 			return ts_time_get_min(partition_type);
 	}
 	else
-		return interval_to_int64(arg.value, argtype);
+	{
+		Oid adjusted_argtype = adjust_unknown_policy_argytpe(argtype, partition_type);
+		/* now that we verified infinity or not, we can adjust the argtype */
+		return interval_to_int64(arg.value, adjusted_argtype);
+	}
 }
+
 /*
  * Check different conditions if the requested policy parameters
  * are compatible with each other and then create/update the
@@ -117,13 +136,19 @@ validate_and_create_policies(policies_info all_policies, bool if_exists)
 			refresh_total_interval != ts_time_get_max(all_policies.partition_type))
 			refresh_total_interval += refresh_interval;
 	}
-
+	/* compress_after, drop_after interval types might be unknown, adjust according to Cagg time
+	 * type */
 	if (all_policies.compress)
-		compress_after = interval_to_int64(all_policies.compress->compress_after,
-										   all_policies.compress->compress_after_type);
+		compress_after =
+			interval_to_int64(all_policies.compress->compress_after,
+							  adjust_unknown_policy_argytpe(all_policies.compress
+																->compress_after_type,
+															all_policies.partition_type));
 	if (all_policies.retention)
-		drop_after = interval_to_int64(all_policies.retention->drop_after,
-									   all_policies.retention->drop_after_type);
+		drop_after =
+			interval_to_int64(all_policies.retention->drop_after,
+							  adjust_unknown_policy_argytpe(all_policies.retention->drop_after_type,
+															all_policies.partition_type));
 
 	if (orig_ht_reten_job)
 	{

--- a/tsl/test/expected/cagg_policy.out
+++ b/tsl/test/expected/cagg_policy.out
@@ -1307,3 +1307,47 @@ SELECT timescaledb_experimental.add_policies('cagg');
  f
 (1 row)
 
+\set ON_ERROR_STOP 0
+-- untyped refresh_start/end
+-- errors out because the type is not integer
+SELECT timescaledb_experimental.add_policies('cagg', refresh_start_offset => '20 days');
+ERROR:  invalid input syntax for type integer: "20 days"
+-- untyped retention policy drop_after
+SELECT timescaledb_experimental.add_policies('cagg', refresh_end_offset => '20 days');
+ERROR:  invalid input syntax for type integer: "20 days"
+-- unspecified integer type
+SELECT timescaledb_experimental.add_policies('cagg', refresh_start_offset => 10, refresh_end_offset => 1);
+ add_policies 
+--------------
+ t
+(1 row)
+
+-- untyped compression policy compress_after
+ALTER MATERIALIZED VIEW cagg set (timescaledb.compress = true);
+NOTICE:  defaulting compress_orderby to a
+SELECT timescaledb_experimental.add_policies('cagg', compress_after => '20 days');
+ERROR:  unsupported compress_after argument type, expected type : integer
+SELECT timescaledb_experimental.add_policies('cagg', compress_after => 40);
+ add_policies 
+--------------
+ t
+(1 row)
+
+-- timestamptz type table
+create table tab (time timestamptz, a int, b int);
+select create_hypertable('tab', 'time');
+NOTICE:  adding not-null constraint to column "time"
+ create_hypertable 
+-------------------
+ (28,public,tab,t)
+(1 row)
+
+CREATE MATERIALIZED VIEW cagg_time WITH (timescaledb.continuous)
+AS SELECT time_bucket('7day', time), sum(b)
+FROM tab GROUP BY 1;
+NOTICE:  continuous aggregate "cagg_time" is already up-to-date
+ALTER MATERIALIZED VIEW cagg_time SET (timescaledb.compress);
+NOTICE:  defaulting compress_orderby to time_bucket
+SELECT timescaledb_experimental.add_policies('cagg_time', refresh_start_offset => '7 days', refresh_end_offset => '14 days', compress_after => '65 days', drop_after => '1 year');
+ERROR:  refresh and compression policies overlap
+\set ON_ERROR_STOP 1

--- a/tsl/test/sql/cagg_policy.sql
+++ b/tsl/test/sql/cagg_policy.sql
@@ -646,3 +646,31 @@ AS SELECT time_bucket(1, a), sum(b)
    FROM t GROUP BY time_bucket(1, a);
 
 SELECT timescaledb_experimental.add_policies('cagg');
+
+\set ON_ERROR_STOP 0
+
+-- untyped refresh_start/end
+-- errors out because the type is not integer
+SELECT timescaledb_experimental.add_policies('cagg', refresh_start_offset => '20 days');
+-- untyped retention policy drop_after
+SELECT timescaledb_experimental.add_policies('cagg', refresh_end_offset => '20 days');
+-- unspecified integer type
+SELECT timescaledb_experimental.add_policies('cagg', refresh_start_offset => 10, refresh_end_offset => 1);
+-- untyped compression policy compress_after
+ALTER MATERIALIZED VIEW cagg set (timescaledb.compress = true);
+SELECT timescaledb_experimental.add_policies('cagg', compress_after => '20 days');
+SELECT timescaledb_experimental.add_policies('cagg', compress_after => 40);
+-- timestamptz type table
+create table tab (time timestamptz, a int, b int);
+
+select create_hypertable('tab', 'time');
+
+CREATE MATERIALIZED VIEW cagg_time WITH (timescaledb.continuous)
+AS SELECT time_bucket('7day', time), sum(b)
+FROM tab GROUP BY 1;
+
+ALTER MATERIALIZED VIEW cagg_time SET (timescaledb.compress);
+
+SELECT timescaledb_experimental.add_policies('cagg_time', refresh_start_offset => '7 days', refresh_end_offset => '14 days', compress_after => '65 days', drop_after => '1 year');
+
+\set ON_ERROR_STOP 1


### PR DESCRIPTION
Previously, when argument types were not explicitly specified using casts, it was possible to get a server crash.
This is fixed by adjusting the argument types depending on the CAGG time dimension type.

Fixes #5920