### PR TITLE
Fix crash in 1-step integer policy creation

### DIFF
--- a/.unreleased/bugfix_5907
+++ b/.unreleased/bugfix_5907
@@ -1,0 +1,1 @@
+Fixes: #5912 Fix crash in 1-step integer policy creation

--- a/tsl/src/bgw_policy/policies_v2.c
+++ b/tsl/src/bgw_policy/policies_v2.c
@@ -129,9 +129,10 @@ validate_and_create_policies(policies_info all_policies, bool if_exists)
 	{
 		if (IS_INTEGER_TYPE(all_policies.partition_type))
 		{
+			bool found_drop_after = false;
 			drop_after_HT = ts_jsonb_get_int64_field(orig_ht_reten_job->fd.config,
 													 POL_RETENTION_CONF_KEY_DROP_AFTER,
-													 false);
+													 &found_drop_after);
 		}
 		else
 		{

--- a/tsl/test/expected/cagg_policy.out
+++ b/tsl/test/expected/cagg_policy.out
@@ -1275,3 +1275,35 @@ SELECT * FROM deals_best_weekly;
  Sun Apr 24 17:00:00 2022 PDT | 117.764705882353 |          6
 (1 row)
 
+-- github issue 5907: segfault when creating 1-step policies on cagg
+-- whose underlying hypertable has a retention policy setup
+CREATE TABLE t(a integer NOT NULL, b integer);
+SELECT create_hypertable('t', 'a', chunk_time_interval=> 10);
+ create_hypertable 
+-------------------
+ (25,public,t,t)
+(1 row)
+
+CREATE OR REPLACE FUNCTION unix_now() returns int LANGUAGE SQL IMMUTABLE as $$ SELECT extract(epoch from now())::INT $$;
+SELECT set_integer_now_func('t', 'unix_now');
+ set_integer_now_func 
+----------------------
+ 
+(1 row)
+
+SELECT add_retention_policy('t', 20);
+ add_retention_policy 
+----------------------
+                 1056
+(1 row)
+
+CREATE MATERIALIZED VIEW cagg(a, sumb) WITH (timescaledb.continuous)
+AS SELECT time_bucket(1, a), sum(b)
+   FROM t GROUP BY time_bucket(1, a);
+NOTICE:  continuous aggregate "cagg" is already up-to-date
+SELECT timescaledb_experimental.add_policies('cagg');
+ add_policies 
+--------------
+ f
+(1 row)
+


### PR DESCRIPTION
Previously when a retention policy existed on the underlying hypertable, we would get a segmentation fault when trying to add a Cagg refresh policy, due to passing a bool instead of pointer to bool argument to function `ts_jsonb_get_int64_field` in a particular code path. Fixed by passing the expected pointer type.

Fixes #5907

(cherry picked from commit bdba699220c7209e1fa52b14e4a522721b908578)