### PR TITLE
Backport to 2.11.x: #5923 Feature flags for TimescaleDB features

### DIFF
--- a/.unreleased/PR_5923
+++ b/.unreleased/PR_5923
@@ -1,0 +1,1 @@
+Implements: #5923 Feature flags for TimescaleDB features

--- a/src/guc.c
+++ b/src/guc.c
@@ -110,6 +110,68 @@ bool ts_shutdown_bgw = false;
 char *ts_current_timestamp_mock = NULL;
 #endif
 
+static bool ts_guc_enable_hypertable_create = true;
+static bool ts_guc_enable_hypertable_compression = true;
+static bool ts_guc_enable_cagg_create = true;
+static bool ts_guc_enable_policy_create = true;
+
+typedef struct
+{
+	const char *name;
+	const char *description;
+	bool *enable;
+} FeatureFlag;
+
+static FeatureFlag ts_feature_flags[] = {
+	[FEATURE_HYPERTABLE] = { "timescaledb.enable_hypertable_create",
+							 "Enable creation of hypertable",
+							 &ts_guc_enable_hypertable_create },
+
+	[FEATURE_HYPERTABLE_COMPRESSION] = { "timescaledb.enable_hypertable_compression",
+										 "Enable hypertable compression functions",
+										 &ts_guc_enable_hypertable_compression },
+
+	[FEATURE_CAGG] = { "timescaledb.enable_cagg_create",
+					   "Enable creation of continuous aggregate",
+					   &ts_guc_enable_cagg_create },
+
+	[FEATURE_POLICY] = { "timescaledb.enable_policy_create",
+						 "Enable creation of policies and user-defined actions",
+						 &ts_guc_enable_policy_create }
+};
+
+static void
+ts_feature_flag_add(FeatureFlagType type)
+{
+	FeatureFlag *flag = &ts_feature_flags[type];
+	int flag_context = PGC_SIGHUP;
+#ifdef TS_DEBUG
+	flag_context = PGC_USERSET;
+#endif
+	DefineCustomBoolVariable(flag->name,
+							 flag->description,
+							 NULL,
+							 flag->enable,
+							 true,
+							 flag_context,
+							 GUC_SUPERUSER_ONLY,
+							 NULL,
+							 NULL,
+							 NULL);
+}
+
+void
+ts_feature_flag_check(FeatureFlagType type)
+{
+	FeatureFlag *flag = &ts_feature_flags[type];
+	if (likely(*flag->enable))
+		return;
+	ereport(ERROR,
+			(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
+			 errmsg("this feature is disabled"),
+			 errdetail("Feature flag \"%s\" is off", flag->name)));
+}
+
 /*
  * We have to understand if we have finished initializing the GUCs, so that we
  * know when it's OK to check their values for mutual consistency.
@@ -648,6 +710,12 @@ _guc_init(void)
 							NULL,
 							NULL,
 							NULL);
+
+	/* register feature flags */
+	ts_feature_flag_add(FEATURE_HYPERTABLE);
+	ts_feature_flag_add(FEATURE_HYPERTABLE_COMPRESSION);
+	ts_feature_flag_add(FEATURE_CAGG);
+	ts_feature_flag_add(FEATURE_POLICY);
 
 	gucs_are_initialized = true;
 

--- a/src/guc.h
+++ b/src/guc.h
@@ -105,4 +105,14 @@ void _guc_init(void);
 void _guc_fini(void);
 extern TSDLLEXPORT void ts_assign_ssl_options_hook(void *fn);
 
+typedef enum
+{
+	FEATURE_HYPERTABLE,
+	FEATURE_HYPERTABLE_COMPRESSION,
+	FEATURE_CAGG,
+	FEATURE_POLICY
+} FeatureFlagType;
+
+extern TSDLLEXPORT void ts_feature_flag_check(FeatureFlagType);
+
 #endif /* TIMESCALEDB_GUC_H */

--- a/src/hypertable.c
+++ b/src/hypertable.c
@@ -1897,6 +1897,8 @@ ts_hypertable_create_internal(PG_FUNCTION_ARGS, bool is_dist_call)
 	uint32 flags = 0;
 	List *data_nodes = NIL;
 
+	ts_feature_flag_check(FEATURE_HYPERTABLE);
+
 	TS_PREVENT_FUNC_IF_READ_ONLY();
 
 	if (!OidIsValid(table_relid))

--- a/tsl/src/bgw_policy/compression_api.c
+++ b/tsl/src/bgw_policy/compression_api.c
@@ -15,6 +15,7 @@
 #include "hypertable_cache.h"
 #include "policy_utils.h"
 #include "utils.h"
+#include "guc.h"
 #include "jsonb_utils.h"
 #include "bgw/job.h"
 #include "bgw_policy/job.h"
@@ -128,6 +129,7 @@ policy_recompression_proc(PG_FUNCTION_ARGS)
 	if (PG_NARGS() != 2 || PG_ARGISNULL(0) || PG_ARGISNULL(1))
 		PG_RETURN_VOID();
 
+	ts_feature_flag_check(FEATURE_POLICY);
 	TS_PREVENT_FUNC_IF_READ_ONLY();
 
 	policy_recompression_execute(PG_GETARG_INT32(0), PG_GETARG_JSONB_P(1));
@@ -341,7 +343,10 @@ policy_compression_add(PG_FUNCTION_ARGS)
 	 * so we need to act like a strict function in those cases
 	 */
 	if (PG_ARGISNULL(0) || PG_ARGISNULL(1) || PG_ARGISNULL(2))
+	{
+		ts_feature_flag_check(FEATURE_POLICY);
 		PG_RETURN_NULL();
+	}
 
 	Oid user_rel_oid = PG_GETARG_OID(0);
 	Datum compress_after_datum = PG_GETARG_DATUM(1);
@@ -356,6 +361,7 @@ policy_compression_add(PG_FUNCTION_ARGS)
 	text *timezone = PG_ARGISNULL(5) ? NULL : PG_GETARG_TEXT_PP(5);
 	char *valid_timezone = NULL;
 
+	ts_feature_flag_check(FEATURE_POLICY);
 	TS_PREVENT_FUNC_IF_READ_ONLY();
 
 	/* if users pass in -infinity for initial_start, then use the current_timestamp instead */
@@ -454,6 +460,7 @@ policy_compression_remove(PG_FUNCTION_ARGS)
 	Oid user_rel_oid = PG_GETARG_OID(0);
 	bool if_exists = PG_GETARG_BOOL(1);
 
+	ts_feature_flag_check(FEATURE_POLICY);
 	TS_PREVENT_FUNC_IF_READ_ONLY();
 
 	return policy_compression_remove_internal(user_rel_oid, if_exists);

--- a/tsl/src/bgw_policy/continuous_aggregate_api.c
+++ b/tsl/src/bgw_policy/continuous_aggregate_api.c
@@ -24,6 +24,7 @@
 #include "time_utils.h"
 #include "policy_utils.h"
 #include "time_utils.h"
+#include "guc.h"
 #include "bgw_policy/policies_v2.h"
 #include "bgw/job_stat.h"
 #include "bgw/timer.h"
@@ -213,6 +214,7 @@ policy_refresh_cagg_proc(PG_FUNCTION_ARGS)
 	if (PG_NARGS() != 2 || PG_ARGISNULL(0) || PG_ARGISNULL(1))
 		PG_RETURN_VOID();
 
+	ts_feature_flag_check(FEATURE_POLICY);
 	TS_PREVENT_FUNC_IF_READ_ONLY();
 	policy_refresh_cagg_execute(PG_GETARG_INT32(0), PG_GETARG_JSONB_P(1));
 
@@ -652,6 +654,8 @@ policy_refresh_cagg_add(PG_FUNCTION_ARGS)
 	bool if_not_exists;
 	NullableDatum start_offset, end_offset;
 
+	ts_feature_flag_check(FEATURE_POLICY);
+
 	cagg_oid = PG_GETARG_OID(0);
 
 	if (PG_ARGISNULL(3))
@@ -750,6 +754,8 @@ policy_refresh_cagg_remove(PG_FUNCTION_ARGS)
 
 	/* For backward compatibility, we use IF_NOT_EXISTS when IF_EXISTS is not given */
 	if_exists = PG_ARGISNULL(2) ? if_not_exists : PG_GETARG_BOOL(2);
+
+	ts_feature_flag_check(FEATURE_POLICY);
 	(void) policy_refresh_cagg_remove_internal(cagg_oid, if_exists);
 	PG_RETURN_VOID();
 }

--- a/tsl/src/bgw_policy/policies_v2.c
+++ b/tsl/src/bgw_policy/policies_v2.c
@@ -17,6 +17,7 @@
 #include "hypertable_cache.h"
 #include "policy_utils.h"
 #include "utils.h"
+#include "guc.h"
 #include "jsonb_utils.h"
 #include "bgw/job.h"
 #include "bgw_policy/job.h"
@@ -241,6 +242,8 @@ policies_add(PG_FUNCTION_ARGS)
 	compression_policy comp;
 	retention_policy ret;
 
+	ts_feature_flag_check(FEATURE_POLICY);
+
 	rel_oid = PG_GETARG_OID(0);
 	if_not_exists = PG_GETARG_BOOL(1);
 
@@ -307,6 +310,8 @@ policies_remove(PG_FUNCTION_ARGS)
 	int i;
 	bool success = false;
 
+	ts_feature_flag_check(FEATURE_POLICY);
+
 	if (policy_array == NULL)
 		PG_RETURN_BOOL(false);
 
@@ -346,6 +351,8 @@ policies_remove_all(PG_FUNCTION_ARGS)
 	int failures = 0;
 	ContinuousAgg *cagg = ts_continuous_agg_find_by_relid(cagg_oid);
 
+	ts_feature_flag_check(FEATURE_POLICY);
+
 	if (!cagg)
 		ereport(ERROR,
 				(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
@@ -381,6 +388,8 @@ policies_alter(PG_FUNCTION_ARGS)
 	refresh_policy ref;
 	compression_policy comp;
 	retention_policy ret;
+
+	ts_feature_flag_check(FEATURE_POLICY);
 
 	cagg = ts_continuous_agg_find_by_relid(rel_oid);
 	if (!cagg)
@@ -612,6 +621,8 @@ policies_show(PG_FUNCTION_ARGS)
 	FuncCallContext *funcctx;
 	static List *jobs;
 	JsonbParseState *parse_state = NULL;
+
+	ts_feature_flag_check(FEATURE_POLICY);
 
 	cagg = ts_continuous_agg_find_by_relid(rel_oid);
 	if (!cagg)

--- a/tsl/src/bgw_policy/reorder_api.c
+++ b/tsl/src/bgw_policy/reorder_api.c
@@ -26,6 +26,7 @@
 #include "hypertable.h"
 #include "reorder.h"
 #include "utils.h"
+#include "guc.h"
 #include "bgw/job_stat.h"
 #include "bgw/timer.h"
 
@@ -129,6 +130,7 @@ policy_reorder_proc(PG_FUNCTION_ARGS)
 	if (PG_NARGS() != 2 || PG_ARGISNULL(0) || PG_ARGISNULL(1))
 		PG_RETURN_VOID();
 
+	ts_feature_flag_check(FEATURE_POLICY);
 	TS_PREVENT_FUNC_IF_READ_ONLY();
 
 	policy_reorder_execute(PG_GETARG_INT32(0), PG_GETARG_JSONB_P(1));
@@ -162,6 +164,7 @@ policy_reorder_add(PG_FUNCTION_ARGS)
 	text *timezone = PG_ARGISNULL(4) ? NULL : PG_GETARG_TEXT_PP(4);
 	char *valid_timezone = NULL;
 
+	ts_feature_flag_check(FEATURE_POLICY);
 	TS_PREVENT_FUNC_IF_READ_ONLY();
 
 	if (timezone != NULL)
@@ -303,6 +306,7 @@ policy_reorder_remove(PG_FUNCTION_ARGS)
 	Hypertable *ht;
 	Cache *hcache;
 
+	ts_feature_flag_check(FEATURE_POLICY);
 	TS_PREVENT_FUNC_IF_READ_ONLY();
 
 	ht = ts_hypertable_cache_get_cache_and_entry(hypertable_oid, CACHE_FLAG_NONE, &hcache);

--- a/tsl/src/bgw_policy/retention_api.c
+++ b/tsl/src/bgw_policy/retention_api.c
@@ -23,6 +23,7 @@
 #include "dimension.h"
 #include "policy_utils.h"
 #include "utils.h"
+#include "guc.h"
 #include "jsonb_utils.h"
 #include "bgw_policy/job.h"
 #include "bgw_policy/policies_v2.h"
@@ -35,6 +36,7 @@ policy_retention_proc(PG_FUNCTION_ARGS)
 	if (PG_NARGS() != 2 || PG_ARGISNULL(0) || PG_ARGISNULL(1))
 		PG_RETURN_VOID();
 
+	ts_feature_flag_check(FEATURE_POLICY);
 	TS_PREVENT_FUNC_IF_READ_ONLY();
 
 	policy_retention_execute(PG_GETARG_INT32(0), PG_GETARG_JSONB_P(1));
@@ -318,6 +320,7 @@ policy_retention_add(PG_FUNCTION_ARGS)
 	text *timezone = PG_ARGISNULL(5) ? NULL : PG_GETARG_TEXT_PP(5);
 	char *valid_timezone = NULL;
 
+	ts_feature_flag_check(FEATURE_POLICY);
 	TS_PREVENT_FUNC_IF_READ_ONLY();
 
 	Datum retval;
@@ -413,6 +416,7 @@ policy_retention_remove(PG_FUNCTION_ARGS)
 	Oid table_oid = PG_GETARG_OID(0);
 	bool if_exists = PG_GETARG_BOOL(1);
 
+	ts_feature_flag_check(FEATURE_POLICY);
 	TS_PREVENT_FUNC_IF_READ_ONLY();
 
 	return policy_retention_remove_internal(table_oid, if_exists);

--- a/tsl/src/compression/api.c
+++ b/tsl/src/compression/api.c
@@ -46,6 +46,7 @@
 #include "scanner.h"
 #include "scan_iterator.h"
 #include "utils.h"
+#include "guc.h"
 
 typedef struct CompressChunkCxt
 {
@@ -785,6 +786,7 @@ tsl_create_compressed_chunk(PG_FUNCTION_ARGS)
 	Assert(!PG_ARGISNULL(0));
 	Assert(!PG_ARGISNULL(1));
 
+	ts_feature_flag_check(FEATURE_HYPERTABLE_COMPRESSION);
 	TS_PREVENT_FUNC_IF_READ_ONLY();
 
 	chunk = ts_chunk_get_by_relid(chunk_relid, true);
@@ -833,6 +835,9 @@ tsl_compress_chunk(PG_FUNCTION_ARGS)
 {
 	Oid uncompressed_chunk_id = PG_ARGISNULL(0) ? InvalidOid : PG_GETARG_OID(0);
 	bool if_not_compressed = PG_ARGISNULL(1) ? false : PG_GETARG_BOOL(1);
+
+	ts_feature_flag_check(FEATURE_HYPERTABLE_COMPRESSION);
+
 	TS_PREVENT_FUNC_IF_READ_ONLY();
 	Chunk *chunk = ts_chunk_get_by_relid(uncompressed_chunk_id, true);
 
@@ -863,6 +868,9 @@ tsl_decompress_chunk(PG_FUNCTION_ARGS)
 {
 	Oid uncompressed_chunk_id = PG_ARGISNULL(0) ? InvalidOid : PG_GETARG_OID(0);
 	bool if_compressed = PG_ARGISNULL(1) ? false : PG_GETARG_BOOL(1);
+
+	ts_feature_flag_check(FEATURE_HYPERTABLE_COMPRESSION);
+
 	TS_PREVENT_FUNC_IF_READ_ONLY();
 	Chunk *uncompressed_chunk = ts_chunk_get_by_relid(uncompressed_chunk_id, true);
 
@@ -1013,6 +1021,7 @@ tsl_get_compressed_chunk_index_for_recompression(PG_FUNCTION_ARGS)
 	Oid uncompressed_chunk_id = PG_ARGISNULL(0) ? InvalidOid : PG_GETARG_OID(0);
 	Chunk *uncompressed_chunk = ts_chunk_get_by_relid(uncompressed_chunk_id, true);
 
+	ts_feature_flag_check(FEATURE_HYPERTABLE_COMPRESSION);
 	if (NULL == uncompressed_chunk)
 		elog(ERROR, "unknown chunk id %d", uncompressed_chunk_id);
 
@@ -1225,6 +1234,7 @@ tsl_recompress_chunk_segmentwise(PG_FUNCTION_ARGS)
 	Oid uncompressed_chunk_id = PG_ARGISNULL(0) ? InvalidOid : PG_GETARG_OID(0);
 	bool if_not_compressed = PG_ARGISNULL(1) ? false : PG_GETARG_BOOL(1);
 
+	ts_feature_flag_check(FEATURE_HYPERTABLE_COMPRESSION);
 	TS_PREVENT_FUNC_IF_READ_ONLY();
 	Chunk *uncompressed_chunk = ts_chunk_get_by_relid(uncompressed_chunk_id, true);
 

--- a/tsl/src/compression/create.c
+++ b/tsl/src/compression/create.c
@@ -44,6 +44,7 @@
 #include "custom_type_cache.h"
 #include "trigger.h"
 #include "utils.h"
+#include "guc.h"
 
 /* entrypoint
  * tsl_process_compress_table : is the entry point.
@@ -1097,6 +1098,8 @@ tsl_process_compress_table(AlterTableCmd *cmd, Hypertable *ht,
 	List *orderby_cols;
 	List *constraint_list = NIL;
 
+	ts_feature_flag_check(FEATURE_HYPERTABLE_COMPRESSION);
+
 	if (TS_HYPERTABLE_IS_INTERNAL_COMPRESSION_TABLE(ht))
 	{
 		ereport(ERROR,
@@ -1187,6 +1190,8 @@ tsl_process_compress_table_add_column(Hypertable *ht, ColumnDef *orig_def)
 	int32 orig_htid = ht->fd.id;
 	char *colname = orig_def->colname;
 
+	ts_feature_flag_check(FEATURE_HYPERTABLE_COMPRESSION);
+
 	FormData_hypertable_compression *ht_comp =
 		ts_hypertable_compression_get_by_pkey(orig_htid, colname);
 	/* don't add column if it already exists */
@@ -1222,6 +1227,8 @@ tsl_process_compress_table_drop_column(Hypertable *ht, char *name)
 	Assert(TS_HYPERTABLE_HAS_COMPRESSION_TABLE(ht) || TS_HYPERTABLE_HAS_COMPRESSION_ENABLED(ht));
 	FormData_hypertable_compression *ht_comp =
 		ts_hypertable_compression_get_by_pkey(ht->fd.id, name);
+
+	ts_feature_flag_check(FEATURE_HYPERTABLE_COMPRESSION);
 
 	/* With DROP COLUMN IF EXISTS we might end up being called
 	 * for non-existant columns. */

--- a/tsl/src/continuous_aggs/create.c
+++ b/tsl/src/continuous_aggs/create.c
@@ -81,6 +81,7 @@
 #include "remote/dist_commands.h"
 #include "deparse.h"
 #include "timezones.h"
+#include "guc.h"
 
 #define FINALFN "finalize_agg"
 #define PARTIALFN "partialize_agg"
@@ -2884,6 +2885,8 @@ tsl_process_continuous_agg_viewstmt(Node *node, const char *query_string, void *
 	Hypertable *mat_ht;
 	Oid relid;
 	char *schema_name;
+
+	ts_feature_flag_check(FEATURE_CAGG);
 
 	nspid = RangeVarGetCreationNamespace(stmt->into->rel);
 	relid = get_relname_relid(stmt->into->rel->relname, nspid);

--- a/tsl/src/continuous_aggs/refresh.c
+++ b/tsl/src/continuous_aggs/refresh.c
@@ -557,6 +557,8 @@ continuous_agg_refresh(PG_FUNCTION_ARGS)
 		.type = InvalidOid,
 	};
 
+	ts_feature_flag_check(FEATURE_CAGG);
+
 	cagg = get_cagg_by_relid(cagg_relid);
 	refresh_window.type = cagg->partition_type;
 

--- a/tsl/test/expected/feature_flags.out
+++ b/tsl/test/expected/feature_flags.out
@@ -1,0 +1,150 @@
+-- This file and its contents are licensed under the Timescale License.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-TIMESCALE for a copy of the license.
+\c :TEST_DBNAME :ROLE_SUPERUSER
+-- hypertable creation
+SHOW timescaledb.enable_hypertable_create;
+ timescaledb.enable_hypertable_create 
+--------------------------------------
+ on
+(1 row)
+
+SET timescaledb.enable_hypertable_create TO off;
+CREATE TABLE test(time timestamptz, device int);
+\set ON_ERROR_STOP 0
+SELECT * FROM create_hypertable('test', 'time');
+ERROR:  this feature is disabled
+\set ON_ERROR_STOP 1
+SET timescaledb.enable_hypertable_create TO on;
+SELECT * FROM create_hypertable('test', 'time');
+NOTICE:  adding not-null constraint to column "time"
+ hypertable_id | schema_name | table_name | created 
+---------------+-------------+------------+---------
+             1 | public      | test       | t
+(1 row)
+
+-- hypertable compression
+SHOW timescaledb.enable_hypertable_compression;
+ timescaledb.enable_hypertable_compression 
+-------------------------------------------
+ on
+(1 row)
+
+SET timescaledb.enable_hypertable_compression TO off;
+INSERT INTO test SELECT t, 0
+FROM generate_series('2018-03-02 1:00'::TIMESTAMPTZ, '2018-03-04 1:00', '1 hour') t;
+SELECT * FROM show_chunks('test');
+              show_chunks               
+----------------------------------------
+ _timescaledb_internal._hyper_1_1_chunk
+(1 row)
+
+-- compress_chunk
+\set ON_ERROR_STOP 0
+SELECT compress_chunk('_timescaledb_internal._hyper_1_1_chunk');
+ERROR:  this feature is disabled
+\set ON_ERROR_STOP 1
+SET timescaledb.enable_hypertable_compression TO on;
+-- ensure compression cannot be enabled
+\set ON_ERROR_STOP 0
+ALTER TABLE test
+SET (timescaledb.compress,
+     timescaledb.compress_orderby = 'time',
+     timescaledb.compress_segmentby = 'device');
+\set ON_ERROR_STOP 1
+SET timescaledb.enable_hypertable_compression TO on;
+ALTER TABLE test
+SET (timescaledb.compress,
+     timescaledb.compress_orderby = 'time',
+     timescaledb.compress_segmentby = 'device');
+SELECT compress_chunk('_timescaledb_internal._hyper_1_1_chunk');
+             compress_chunk             
+----------------------------------------
+ _timescaledb_internal._hyper_1_1_chunk
+(1 row)
+
+SET timescaledb.enable_hypertable_compression TO off;
+-- cannot alter compressed table
+\set ON_ERROR_STOP 0
+ALTER TABLE test ADD COLUMN col1 boolean DEFAULT false NOT NULL;
+ERROR:  this feature is disabled
+\set ON_ERROR_STOP 1
+SET timescaledb.enable_hypertable_compression TO on;
+ALTER TABLE test ADD COLUMN col1 boolean DEFAULT false NOT NULL;
+SET timescaledb.enable_hypertable_compression TO off;
+\set ON_ERROR_STOP 0
+ALTER TABLE test DROP COLUMN col1;
+ERROR:  this feature is disabled
+\set ON_ERROR_STOP 1
+-- cagg creation
+SHOW timescaledb.enable_cagg_create;
+ timescaledb.enable_cagg_create 
+--------------------------------
+ on
+(1 row)
+
+SET timescaledb.enable_cagg_create TO off;
+\set ON_ERROR_STOP 0
+CREATE MATERIALIZED VIEW contagg
+WITH (timescaledb.continuous) AS
+SELECT
+  time_bucket('1 hour', time) AS hour,
+  device
+FROM
+  test
+GROUP BY hour, device;
+ERROR:  this feature is disabled
+\set ON_ERROR_STOP 1
+SET timescaledb.enable_cagg_create TO on;
+CREATE MATERIALIZED VIEW contagg
+WITH (timescaledb.continuous) AS
+SELECT
+  time_bucket('1 hour', time) AS hour,
+  device
+FROM
+  test
+GROUP BY hour, device;
+NOTICE:  refreshing continuous aggregate "contagg"
+SET timescaledb.enable_cagg_create TO off;
+\set ON_ERROR_STOP 0
+CALL refresh_continuous_aggregate('contagg', NULL, NULL);
+ERROR:  this feature is disabled
+\set ON_ERROR_STOP 1
+SET timescaledb.enable_cagg_create TO on;
+-- policy creation
+SHOW timescaledb.enable_policy_create;
+ timescaledb.enable_policy_create 
+----------------------------------
+ on
+(1 row)
+
+SET timescaledb.enable_policy_create TO off;
+\set ON_ERROR_STOP 0
+select add_retention_policy('test', INTERVAL '4 months', true);
+ERROR:  this feature is disabled
+select remove_retention_policy('test');
+ERROR:  this feature is disabled
+select add_compression_policy('test', compress_after => NULL);
+ERROR:  this feature is disabled
+SELECT remove_compression_policy('test');
+ERROR:  this feature is disabled
+SELECT add_continuous_aggregate_policy('contagg', '1 day'::interval, 10 , '1 h'::interval);
+ERROR:  this feature is disabled
+SELECT remove_continuous_aggregate_policy('contagg');
+ERROR:  this feature is disabled
+CREATE INDEX idx ON test(device);
+SELECT add_reorder_policy('test', 'idx');
+ERROR:  this feature is disabled
+select remove_reorder_policy('test');
+ERROR:  this feature is disabled
+SELECT timescaledb_experimental.add_policies('test', refresh_start_offset => 1, refresh_end_offset => 10, compress_after => 11, drop_after => 20);
+ERROR:  this feature is disabled
+SELECT timescaledb_experimental.show_policies('test');
+ERROR:  this feature is disabled
+SELECT timescaledb_experimental.alter_policies('test',  refresh_start_offset => 11, compress_after=>13, drop_after => 25);
+ERROR:  this feature is disabled
+SELECT timescaledb_experimental.remove_all_policies('test');
+ERROR:  this feature is disabled
+SELECT timescaledb_experimental.remove_policies('test', false, 'policy_refresh_continuous_aggregate', 'policy_compression');
+ERROR:  this feature is disabled
+\set ON_ERROR_STOP 1

--- a/tsl/test/sql/CMakeLists.txt
+++ b/tsl/test/sql/CMakeLists.txt
@@ -105,7 +105,8 @@ if(CMAKE_BUILD_TYPE MATCHES Debug)
     tsl_tables.sql
     license_tsl.sql
     fixed_schedules.sql
-    recompress_chunk_segmentwise.sql)
+    recompress_chunk_segmentwise.sql
+    feature_flags.sql)
 endif(CMAKE_BUILD_TYPE MATCHES Debug)
 
 if((${PG_VERSION_MAJOR} GREATER_EQUAL "14"))

--- a/tsl/test/sql/feature_flags.sql
+++ b/tsl/test/sql/feature_flags.sql
@@ -1,0 +1,126 @@
+-- This file and its contents are licensed under the Timescale License.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-TIMESCALE for a copy of the license.
+
+\c :TEST_DBNAME :ROLE_SUPERUSER
+
+-- hypertable creation
+SHOW timescaledb.enable_hypertable_create;
+SET timescaledb.enable_hypertable_create TO off;
+
+CREATE TABLE test(time timestamptz, device int);
+\set ON_ERROR_STOP 0
+SELECT * FROM create_hypertable('test', 'time');
+\set ON_ERROR_STOP 1
+
+SET timescaledb.enable_hypertable_create TO on;
+SELECT * FROM create_hypertable('test', 'time');
+
+-- hypertable compression
+SHOW timescaledb.enable_hypertable_compression;
+SET timescaledb.enable_hypertable_compression TO off;
+
+INSERT INTO test SELECT t, 0
+FROM generate_series('2018-03-02 1:00'::TIMESTAMPTZ, '2018-03-04 1:00', '1 hour') t;
+SELECT * FROM show_chunks('test');
+
+-- compress_chunk
+\set ON_ERROR_STOP 0
+SELECT compress_chunk('_timescaledb_internal._hyper_1_1_chunk');
+\set ON_ERROR_STOP 1
+
+SET timescaledb.enable_hypertable_compression TO on;
+
+-- ensure compression cannot be enabled
+\set ON_ERROR_STOP 0
+ALTER TABLE test
+SET (timescaledb.compress,
+     timescaledb.compress_orderby = 'time',
+     timescaledb.compress_segmentby = 'device');
+\set ON_ERROR_STOP 1
+
+SET timescaledb.enable_hypertable_compression TO on;
+
+ALTER TABLE test
+SET (timescaledb.compress,
+     timescaledb.compress_orderby = 'time',
+     timescaledb.compress_segmentby = 'device');
+SELECT compress_chunk('_timescaledb_internal._hyper_1_1_chunk');
+
+SET timescaledb.enable_hypertable_compression TO off;
+
+-- cannot alter compressed table
+\set ON_ERROR_STOP 0
+ALTER TABLE test ADD COLUMN col1 boolean DEFAULT false NOT NULL;
+\set ON_ERROR_STOP 1
+
+SET timescaledb.enable_hypertable_compression TO on;
+ALTER TABLE test ADD COLUMN col1 boolean DEFAULT false NOT NULL;
+
+SET timescaledb.enable_hypertable_compression TO off;
+\set ON_ERROR_STOP 0
+ALTER TABLE test DROP COLUMN col1;
+\set ON_ERROR_STOP 1
+
+-- cagg creation
+SHOW timescaledb.enable_cagg_create;
+SET timescaledb.enable_cagg_create TO off;
+
+\set ON_ERROR_STOP 0
+
+CREATE MATERIALIZED VIEW contagg
+WITH (timescaledb.continuous) AS
+SELECT
+  time_bucket('1 hour', time) AS hour,
+  device
+FROM
+  test
+GROUP BY hour, device;
+
+\set ON_ERROR_STOP 1
+
+SET timescaledb.enable_cagg_create TO on;
+
+CREATE MATERIALIZED VIEW contagg
+WITH (timescaledb.continuous) AS
+SELECT
+  time_bucket('1 hour', time) AS hour,
+  device
+FROM
+  test
+GROUP BY hour, device;
+
+SET timescaledb.enable_cagg_create TO off;
+
+\set ON_ERROR_STOP 0
+CALL refresh_continuous_aggregate('contagg', NULL, NULL);
+\set ON_ERROR_STOP 1
+
+SET timescaledb.enable_cagg_create TO on;
+
+-- policy creation
+SHOW timescaledb.enable_policy_create;
+SET timescaledb.enable_policy_create TO off;
+
+\set ON_ERROR_STOP 0
+
+select add_retention_policy('test', INTERVAL '4 months', true);
+select remove_retention_policy('test');
+
+select add_compression_policy('test', compress_after => NULL);
+SELECT remove_compression_policy('test');
+
+SELECT add_continuous_aggregate_policy('contagg', '1 day'::interval, 10 , '1 h'::interval);
+SELECT remove_continuous_aggregate_policy('contagg');
+
+CREATE INDEX idx ON test(device);
+SELECT add_reorder_policy('test', 'idx');
+select remove_reorder_policy('test');
+
+SELECT timescaledb_experimental.add_policies('test', refresh_start_offset => 1, refresh_end_offset => 10, compress_after => 11, drop_after => 20);
+SELECT timescaledb_experimental.show_policies('test');
+SELECT timescaledb_experimental.alter_policies('test',  refresh_start_offset => 11, compress_after=>13, drop_after => 25);
+SELECT timescaledb_experimental.remove_all_policies('test');
+SELECT timescaledb_experimental.remove_policies('test', false, 'policy_refresh_continuous_aggregate', 'policy_compression');
+
+\set ON_ERROR_STOP 1


### PR DESCRIPTION
This PR adds several GUCs which allow to enable/disable major timescaledb features:

- enable_hypertable_create
- enable_hypertable_compression
- enable_cagg_create
- enable_policy_create

cherry-picked from https://github.com/timescale/timescaledb/commit/7aeed663b9c0f337b530fd6cad47704a51a9b2ec