### PR TITLE
Fix quoting owners in sql scripts.

### DIFF
--- a/.unreleased/PR_5906
+++ b/.unreleased/PR_5906
@@ -1,0 +1,3 @@
+Fixes: #5906 Fix quoting owners in sql scripts.
+
+Thanks: @mrksngl

--- a/sql/updates/2.10.1--2.10.2.sql
+++ b/sql/updates/2.10.1--2.10.2.sql
@@ -11,8 +11,8 @@ DROP VIEW IF EXISTS timescaledb_experimental.policies;
 
 ALTER TABLE _timescaledb_config.bgw_job
     ALTER COLUMN owner DROP DEFAULT,
-    ALTER COLUMN owner TYPE regrole USING owner::regrole,
-    ALTER COLUMN owner SET DEFAULT current_role::regrole;
+    ALTER COLUMN owner TYPE regrole USING pg_catalog.quote_ident(owner)::regrole,
+    ALTER COLUMN owner SET DEFAULT pg_catalog.quote_ident(current_role)::regrole;
 CREATE TABLE _timescaledb_config.bgw_job_tmp AS SELECT * FROM _timescaledb_config.bgw_job;
 
 ALTER EXTENSION timescaledb DROP TABLE _timescaledb_config.bgw_job;
@@ -40,7 +40,7 @@ CREATE TABLE _timescaledb_config.bgw_job (
   retry_period interval NOT NULL,
   proc_schema name NOT NULL,
   proc_name name NOT NULL,
-  owner regrole NOT NULL DEFAULT current_role::regrole,
+  owner regrole NOT NULL DEFAULT pg_catalog.quote_ident(current_role)::regrole,
   scheduled bool NOT NULL DEFAULT TRUE,
   fixed_schedule bool not null default true,
   initial_start timestamptz,

--- a/sql/updates/2.11.0--2.10.3.sql
+++ b/sql/updates/2.11.0--2.10.3.sql
@@ -198,7 +198,7 @@ END
 $BODY$ SET search_path TO pg_catalog, pg_temp;
 
 ALTER TABLE _timescaledb_config.bgw_job
-    ALTER COLUMN owner SET DEFAULT current_role::regrole;
+    ALTER COLUMN owner SET DEFAULT pg_catalog.quote_ident(current_role)::regrole;
 
 -- Rebuild the _timescaledb_catalog.continuous_agg_migrate_plan_step definition
 ALTER TABLE _timescaledb_catalog.continuous_agg_migrate_plan_step


### PR DESCRIPTION
When referring to a role from a string type, it must be properly quoted using pg_catalog.quote_ident before it can be casted to regrole. Fixed this, especially in update scripts.

(cherry picked from commit 5cf354e2469ee7e43248bed382a4b49fc7ccfecd)