### PR TITLE
Release 2.11.2

### DIFF
--- a/.unreleased/PR_5906
+++ b/.unreleased/PR_5906
@@ -1,3 +1,0 @@
-Fixes: #5906 Fix quoting owners in sql scripts.
-
-Thanks: @mrksngl

--- a/.unreleased/PR_5923
+++ b/.unreleased/PR_5923
@@ -1,1 +1,0 @@
-Implements: #5923 Feature flags for TimescaleDB features

--- a/.unreleased/bugfix_5774
+++ b/.unreleased/bugfix_5774
@@ -1,1 +1,0 @@
-Fixes: #5774 Fixed two bugs in decompression sorted merge code 

--- a/.unreleased/bugfix_5786
+++ b/.unreleased/bugfix_5786
@@ -1,1 +1,0 @@
-Fixes: #5786 Ensure pg_config --cppflags are passed

--- a/.unreleased/bugfix_5907
+++ b/.unreleased/bugfix_5907
@@ -1,1 +1,0 @@
-Fixes: #5912 Fix crash in 1-step integer policy creation

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,23 @@
 `psql` with the `-X` flag to prevent any `.psqlrc` commands from
 accidentally triggering the load of a previous DB version.**
 
+## 2.11.2 (2023-08-09)
+
+This release contains bug fixes since the 2.11.1 release.
+We recommend that you upgrade at the next available opportunity.
+
+**Features**
+* #5923 Feature flags for TimescaleDB features
+**Bugfixes**
+* #5680 Fix DISTINCT query with JOIN on multiple segmentby columns
+* #5774 Fixed two bugs in decompression sorted merge code 
+* #5786 Ensure pg_config --cppflags are passed
+* #5906 Fix quoting owners in sql scripts.
+* #5912 Fix crash in 1-step integer policy creation
+**Thanks**
+* @mrksngl for submitting a PR to fix extension upgrade scripts
+* @ericdevries for reporting an issue with DISTINCT queries using segmentby columns of compressed hypertable
+
 ## 2.11.1 (2023-06-29)
 
 This release contains bug fixes since the 2.11.0 release.
@@ -72,12 +89,10 @@ This release includes these noteworthy features:
 * #5642 Fix ALTER TABLE SET with normal tables
 * #5666 Reduce memory usage for distributed analyze
 * #5668 Fix subtransaction resource owner
-* #5680 Fix DISTINCT query with JOIN on multiple segmentby columns
 
 **Thanks**
 * @kovetskiy and @DZDomi for reporting peformance regression in Realtime Continuous Aggregates
 * @ollz272 for reporting an issue with interpolate error messages
-* @ericdevries for reporting an issue with DISTINCT queries using segmentby columns of compressed hypertable
 
 
 ## 2.10.3 (2023-04-26)

--- a/sql/CMakeLists.txt
+++ b/sql/CMakeLists.txt
@@ -36,7 +36,8 @@ set(MOD_FILES
     updates/2.10.1--2.10.2.sql
     updates/2.10.2--2.10.3.sql
     updates/2.10.3--2.11.0.sql
-    updates/2.11.0--2.11.1.sql)
+    updates/2.11.0--2.11.1.sql
+    updates/2.11.1--2.11.2.sql)
 
 # The downgrade file to generate a downgrade script for the current version, as
 # specified in version.config

--- a/version.config
+++ b/version.config
@@ -1,3 +1,3 @@
 version = 2.12.0-dev
-update_from_version = 2.11.1
+update_from_version = 2.11.2
 downgrade_to_version = 2.11.1


### PR DESCRIPTION
This release contains bug fixes since the 2.11.1 release.
We recommend that you upgrade at the next available opportunity.

**Features**
* https://github.com/timescale/timescaledb/pull/5909 CREATE INDEX ONLY ON hypertable creates index on chunks
* https://github.com/timescale/timescaledb/pull/5923 Feature flags for TimescaleDB features

**Bugfixes**
* https://github.com/timescale/timescaledb/pull/5680 Fix DISTINCT query with JOIN on multiple segmentby columns
* https://github.com/timescale/timescaledb/pull/5774 Fixed two bugs in decompression sorted merge code
* https://github.com/timescale/timescaledb/pull/5786 Ensure pg_config --cppflags are passed
* https://github.com/timescale/timescaledb/pull/5906 Fix quoting owners in sql scripts.
* https://github.com/timescale/timescaledb/pull/5912 Fix crash in 1-step integer policy creation

**Thanks**
* @mrksngl for submitting a PR to fix extension upgrade scripts
* @ericdevries for reporting an issue with DISTINCT queries using
segmentby columns of compressed hypertable