### PR TITLE
Revert "PG16: Use new function to check vacuum permission"

### DIFF
--- a/src/process_utility.c
+++ b/src/process_utility.c
@@ -822,18 +822,10 @@ ts_get_all_vacuum_rels(bool is_vacuumcmd)
 		relid = classform->oid;
 
 		/* check permissions of relation */
-#if PG16_LT
 		if (!vacuum_is_relation_owner(relid,
 									  classform,
 									  is_vacuumcmd ? VACOPT_VACUUM : VACOPT_ANALYZE))
 			continue;
-
-#else
-		if (!vacuum_is_permitted_for_relation(relid,
-											  classform,
-											  is_vacuumcmd ? VACOPT_VACUUM : VACOPT_ANALYZE))
-			continue;
-#endif
 
 		/*
 		 * We include partitioned tables here; depending on which operation is


### PR DESCRIPTION
This reverts commit 8b0ab4164 as the commit that introduced the new function has been reverted upstream.

postgres/postgres@95744599

Disable-check: force-changelog-file