### PR TITLE
Account for uncompressed rows in 'create_compressed_chunk'

### DIFF
--- a/.unreleased/bugfix_5951
+++ b/.unreleased/bugfix_5951
@@ -1,0 +1,4 @@
+Implements: #5951 _timescaledb_internal.create_compressed_chunk doesn't account for existing uncompressed rows
+
+Fixes: #5946
+

--- a/src/utils.h
+++ b/src/utils.h
@@ -215,6 +215,9 @@ extern TSDLLEXPORT void ts_copy_relation_acl(const Oid source_relid, const Oid t
 extern TSDLLEXPORT bool ts_data_node_is_available_by_server(const ForeignServer *server);
 extern TSDLLEXPORT bool ts_data_node_is_available(const char *node_name);
 
+extern TSDLLEXPORT bool ts_relation_has_tuples(Relation rel);
+extern TSDLLEXPORT bool ts_table_has_tuples(Oid table_relid, LOCKMODE lockmode);
+
 extern TSDLLEXPORT AttrNumber ts_map_attno(Oid src_rel, Oid dst_rel, AttrNumber attno);
 
 /*

--- a/tsl/test/expected/compression_create_compressed_table.out
+++ b/tsl/test/expected/compression_create_compressed_table.out
@@ -1,0 +1,69 @@
+-- This file and its contents are licensed under the Timescale License.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-TIMESCALE for a copy of the license.
+\c :TEST_DBNAME :ROLE_SUPERUSER
+-- create compressed hypertable
+CREATE TABLE "public"."metrics" (
+    "time" timestamp with time zone NOT NULL,
+    "device_id" "text",
+    "val" double precision
+);
+SELECT create_hypertable('public.metrics', 'time');
+  create_hypertable   
+----------------------
+ (1,public,metrics,t)
+(1 row)
+
+ALTER TABLE metrics SET (timescaledb.compress, timescaledb.compress_orderby = 'time', timescaledb.compress_segmentby = 'device_id');
+-- insert uncompressed row into hypertable
+INSERT INTO metrics (time, device_id, val)
+VALUES('2023-05-01T00:00:00Z'::timestamptz, 1, 1.0);
+SELECT count(*) FROM _timescaledb_internal._hyper_1_1_chunk;
+ count 
+-------
+     1
+(1 row)
+
+-- compress these rows, we do this to get compressed row data for the test
+SELECT compress_chunk('_timescaledb_internal._hyper_1_1_chunk');
+             compress_chunk             
+----------------------------------------
+ _timescaledb_internal._hyper_1_1_chunk
+(1 row)
+
+-- create custom compressed chunk table
+CREATE TABLE "_timescaledb_internal"."custom_compressed_chunk"() INHERITS ("_timescaledb_internal"."_compressed_hypertable_2");
+-- copy compressed row from compressed table into custom compressed chunk table
+INSERT INTO "_timescaledb_internal"."custom_compressed_chunk" SELECT * FROM "_timescaledb_internal"."compress_hyper_2_2_chunk";
+-- decompress the rows, moving them back to uncompressed space
+SELECT decompress_chunk('"_timescaledb_internal"."_hyper_1_1_chunk"');
+            decompress_chunk            
+----------------------------------------
+ _timescaledb_internal._hyper_1_1_chunk
+(1 row)
+
+-- attach compressed chunk to parent chunk
+SELECT _timescaledb_internal.create_compressed_chunk(
+    '"_timescaledb_internal"."_hyper_1_1_chunk"'::TEXT::REGCLASS,
+    '"_timescaledb_internal"."custom_compressed_chunk"'::TEXT::REGCLASS,
+    8192,
+    8192,
+    16384,
+    8192,
+    8192,
+    16384,
+    1,
+    1
+);
+        create_compressed_chunk         
+----------------------------------------
+ _timescaledb_internal._hyper_1_1_chunk
+(1 row)
+
+-- select total rows in chunk (should be 2)
+SELECT count(*) FROM "_timescaledb_internal"."_hyper_1_1_chunk";
+ count 
+-------
+     2
+(1 row)
+

--- a/tsl/test/sql/CMakeLists.txt
+++ b/tsl/test/sql/CMakeLists.txt
@@ -13,6 +13,7 @@ set(TEST_FILES
     cagg_refresh.sql
     cagg_watermark.sql
     compressed_collation.sql
+    compression_create_compressed_table.sql
     compression_bgw.sql
     compression_conflicts.sql
     compression_insert.sql

--- a/tsl/test/sql/compression_create_compressed_table.sql
+++ b/tsl/test/sql/compression_create_compressed_table.sql
@@ -1,0 +1,50 @@
+-- This file and its contents are licensed under the Timescale License.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-TIMESCALE for a copy of the license.
+
+\c :TEST_DBNAME :ROLE_SUPERUSER
+
+-- create compressed hypertable
+CREATE TABLE "public"."metrics" (
+    "time" timestamp with time zone NOT NULL,
+    "device_id" "text",
+    "val" double precision
+);
+SELECT create_hypertable('public.metrics', 'time');
+ALTER TABLE metrics SET (timescaledb.compress, timescaledb.compress_orderby = 'time', timescaledb.compress_segmentby = 'device_id');
+
+-- insert uncompressed row into hypertable
+INSERT INTO metrics (time, device_id, val)
+VALUES('2023-05-01T00:00:00Z'::timestamptz, 1, 1.0);
+
+SELECT count(*) FROM _timescaledb_internal._hyper_1_1_chunk;
+
+-- compress these rows, we do this to get compressed row data for the test
+SELECT compress_chunk('_timescaledb_internal._hyper_1_1_chunk');
+
+-- create custom compressed chunk table
+CREATE TABLE "_timescaledb_internal"."custom_compressed_chunk"() INHERITS ("_timescaledb_internal"."_compressed_hypertable_2");
+
+-- copy compressed row from compressed table into custom compressed chunk table
+INSERT INTO "_timescaledb_internal"."custom_compressed_chunk" SELECT * FROM "_timescaledb_internal"."compress_hyper_2_2_chunk";
+
+-- decompress the rows, moving them back to uncompressed space
+SELECT decompress_chunk('"_timescaledb_internal"."_hyper_1_1_chunk"');
+
+-- attach compressed chunk to parent chunk
+SELECT _timescaledb_internal.create_compressed_chunk(
+    '"_timescaledb_internal"."_hyper_1_1_chunk"'::TEXT::REGCLASS,
+    '"_timescaledb_internal"."custom_compressed_chunk"'::TEXT::REGCLASS,
+    8192,
+    8192,
+    16384,
+    8192,
+    8192,
+    16384,
+    1,
+    1
+);
+
+-- select total rows in chunk (should be 2)
+SELECT count(*) FROM "_timescaledb_internal"."_hyper_1_1_chunk";
+


### PR DESCRIPTION
`_timescaledb_internal.create_compressed_chunk` can be used to create a compressed chunk with existing compressed data. It did not account for the fact that the chunk can contain uncompressed data, in which case the chunk status must be set to partial.

Fixes #5946