### PR TITLE
Use cached Chunk struct when considering compressed paths

### DIFF
--- a/src/planner/expand_hypertable.c
+++ b/src/planner/expand_hypertable.c
@@ -1507,7 +1507,7 @@ ts_plan_expand_hypertable_chunks(Hypertable *ht, PlannerInfo *root, RelOptInfo *
 #endif
 		}
 
-		ts_get_private_reloptinfo(child_rel)->chunk = chunks[i];
+		ts_get_private_reloptinfo(child_rel)->cached_chunk_struct = chunks[i];
 		Assert(chunks[i]->table_id == root->simple_rte_array[child_rtindex]->relid);
 	}
 }

--- a/src/planner/planner.c
+++ b/src/planner/planner.c
@@ -1096,17 +1096,16 @@ apply_optimizations(PlannerInfo *root, TsRelType reltype, RelOptInfo *rel, Range
 		case TS_REL_CHUNK_STANDALONE:
 		case TS_REL_CHUNK_CHILD:
 			ts_sort_transform_optimization(root, rel);
+			/*
+			 * Since the sort optimization adds new paths to the rel it has
+			 * to happen before any optimizations that replace pathlist.
+			 */
+			if (ts_cm_functions->set_rel_pathlist_query != NULL)
+				ts_cm_functions->set_rel_pathlist_query(root, rel, rel->relid, rte, ht);
 			break;
 		default:
 			break;
 	}
-
-	/*
-	 * Since the sort optimization adds new paths to the rel it has
-	 * to happen before any optimizations that replace pathlist.
-	 */
-	if (ts_cm_functions->set_rel_pathlist_query != NULL)
-		ts_cm_functions->set_rel_pathlist_query(root, rel, rel->relid, rte, ht);
 
 	if (reltype == TS_REL_HYPERTABLE &&
 #if PG14_GE

--- a/src/planner/planner.h
+++ b/src/planner/planner.h
@@ -40,7 +40,7 @@ typedef struct TimescaleDBPrivate
 	TsFdwRelInfo *fdw_relation_info;
 
 	/* Cached chunk data for the chunk relinfo. */
-	Chunk *chunk;
+	Chunk *cached_chunk_struct;
 } TimescaleDBPrivate;
 
 extern TSDLLEXPORT bool ts_rte_is_hypertable(const RangeTblEntry *rte, bool *isdistributed);

--- a/tsl/src/fdw/data_node_chunk_assignment.c
+++ b/tsl/src/fdw/data_node_chunk_assignment.c
@@ -78,7 +78,7 @@ data_node_chunk_assignment_assign_chunk(DataNodeChunkAssignments *scas, RelOptIn
 	 */
 	Oid remote_chunk_relid = InvalidOid;
 	ListCell *lc;
-	foreach (lc, chunk_private->chunk->data_nodes)
+	foreach (lc, chunk_private->cached_chunk_struct->data_nodes)
 	{
 		ChunkDataNode *cdn = (ChunkDataNode *) lfirst(lc);
 		if (cdn->foreign_server_oid == chunkrel->serverid)
@@ -94,7 +94,7 @@ data_node_chunk_assignment_assign_chunk(DataNodeChunkAssignments *scas, RelOptIn
 	 */
 	old = MemoryContextSwitchTo(scas->mctx);
 	sca->chunk_relids = bms_add_member(sca->chunk_relids, chunkrel->relid);
-	sca->chunks = lappend(sca->chunks, chunk_private->chunk);
+	sca->chunks = lappend(sca->chunks, chunk_private->cached_chunk_struct);
 	sca->remote_chunk_ids = lappend_int(sca->remote_chunk_ids, remote_chunk_relid);
 	sca->pages += chunkrel->pages;
 	sca->rows += chunkrel->rows;

--- a/tsl/src/fdw/relinfo.c
+++ b/tsl/src/fdw/relinfo.c
@@ -300,10 +300,10 @@ estimate_chunk_size(PlannerInfo *root, RelOptInfo *chunk_rel)
 	 * exclusion, so we'll have to look up this info now.
 	 */
 	TimescaleDBPrivate *chunk_private = ts_get_private_reloptinfo(chunk_rel);
-	if (chunk_private->chunk == NULL)
+	if (chunk_private->cached_chunk_struct == NULL)
 	{
 		RangeTblEntry *chunk_rte = planner_rt_fetch(chunk_rel->relid, root);
-		chunk_private->chunk =
+		chunk_private->cached_chunk_struct =
 			ts_chunk_get_by_relid(chunk_rte->relid, true /* fail_if_not_found */);
 	}
 
@@ -319,7 +319,8 @@ estimate_chunk_size(PlannerInfo *root, RelOptInfo *chunk_rel)
 	Hypertable *ht = ts_hypertable_cache_get_entry(hcache, parent_rte->relid, CACHE_FLAG_NONE);
 	Hyperspace *hyperspace = ht->space;
 
-	const double fillfactor = estimate_chunk_fillfactor(chunk_private->chunk, hyperspace);
+	const double fillfactor =
+		estimate_chunk_fillfactor(chunk_private->cached_chunk_struct, hyperspace);
 
 	/* Can't have nonzero tuples in zero pages */
 	Assert(parent_private->average_chunk_pages != 0 || parent_private->average_chunk_tuples <= 0);


### PR DESCRIPTION
Full catalog lookups for a Chunk are expensive, avoiding them speeds up the planning.

Disable-check: force-changelog-file