### PR TITLE
PG16: Fix concurrent update issues with MERGE.

### DIFF
--- a/src/import/ht_hypertable_modify.h
+++ b/src/import/ht_hypertable_modify.h
@@ -72,15 +72,21 @@ typedef struct ModifyTableContext {
 /*
  * Context struct containing output data specific to UPDATE operations.
  */
-typedef struct UpdateContext {
-	bool		updated;	/* did UPDATE actually occur? */
-	bool		updateIndexes;	/* index update required? */
-	bool		crossPartUpdate;	/* was it a cross-partition
-						 * update? */
-}		UpdateContext;
+typedef struct UpdateContext
+{
+	bool updated; /* did UPDATE actually occur? */
+#if PG16_LT
+	bool updateIndexes; /* index update required? */
+#else
+	TU_UpdateIndexes updateIndexes; /* result codes */
+#endif
+
+	bool crossPartUpdate; /* was it a cross-partition
+						   * update? */
+} UpdateContext;
 
 bool		ht_ExecUpdatePrologue(ModifyTableContext * context, ResultRelInfo * resultRelInfo,
-	    ItemPointer tupleid, HeapTuple oldtuple, TupleTableSlot * slot);
+	    ItemPointer tupleid, HeapTuple oldtuple, TupleTableSlot * slot, TM_Result *result);
 void		ht_ExecUpdatePrepareSlot(ResultRelInfo * resultRelInfo, TupleTableSlot * slot, EState * estate);
 TM_Result	ht_ExecUpdateAct(ModifyTableContext * context, ResultRelInfo * resultRelInfo,
 	     ItemPointer tupleid, HeapTuple oldtuple, TupleTableSlot * slot,
@@ -90,7 +96,7 @@ void		ht_ExecUpdateEpilogue(ModifyTableContext * context, UpdateContext * update
 			      TupleTableSlot * slot, List * recheckIndexes);
 
 bool		ht_ExecDeletePrologue(ModifyTableContext * context, ResultRelInfo * resultRelInfo,
-  ItemPointer tupleid, HeapTuple oldtuple, TupleTableSlot * *epqreturnslot);
+  ItemPointer tupleid, HeapTuple oldtuple, TupleTableSlot * *epqreturnslot, TM_Result *result);
 TM_Result	ht_ExecDeleteAct(ModifyTableContext * context, ResultRelInfo * resultRelInfo,
 				 ItemPointer tupleid, bool changingPart);
 void		ht_ExecDeleteEpilogue(ModifyTableContext * context, ResultRelInfo * resultRelInfo,

--- a/src/nodes/hypertable_modify.c
+++ b/src/nodes/hypertable_modify.c
@@ -1998,7 +1998,7 @@ ExecUpdate(ModifyTableContext *context, ResultRelInfo *resultRelInfo, ItemPointe
 	 * Prepare for the update. This includes BEFORE ROW triggers, so we're
 	 * done if it says we are.
 	 */
-	if (!ht_ExecUpdatePrologue(context, resultRelInfo, tupleid, oldtuple, slot))
+	if (!ht_ExecUpdatePrologue(context, resultRelInfo, tupleid, oldtuple, slot, NULL))
 		return NULL;
 
 	/* INSTEAD OF ROW UPDATE Triggers */
@@ -2539,7 +2539,7 @@ ExecDelete(ModifyTableContext *context, ResultRelInfo *resultRelInfo, ItemPointe
 	 * Prepare for the delete.  This includes BEFORE ROW triggers, so we're
 	 * done if it says we are.
 	 */
-	if (!ht_ExecDeletePrologue(context, resultRelInfo, tupleid, oldtuple, epqreturnslot))
+	if (!ht_ExecDeletePrologue(context, resultRelInfo, tupleid, oldtuple, epqreturnslot, NULL))
 		return NULL;
 
 	/* INSTEAD OF ROW DELETE Triggers */


### PR DESCRIPTION
PG16 commit postgres/postgres@9321c79c fixes an issue with concurrent update issues in MERGE. This patch adapts that fix into the MERGE support for hypertables as well.

postgres/postgres@9321c79c

Disable-check: force-changelog-file