### PR TITLE
PG16 - Few more simple fixes

### DIFF
--- a/src/nodes/chunk_dispatch/chunk_insert_state.c
+++ b/src/nodes/chunk_dispatch/chunk_insert_state.c
@@ -348,8 +348,11 @@ setup_on_conflict_state(ChunkInsertState *state, ChunkDispatch *dispatch,
 	memcpy(onconfl, hyper_rri->ri_onConflict, sizeof(OnConflictSetState));
 	chunk_rri->ri_onConflict = onconfl;
 
-#if PG14_GE
+#if PG14_GE && PG16_LT
 	chunk_rri->ri_RootToPartitionMap = map;
+#elif PG16_GE
+	chunk_rri->ri_RootToChildMap = map;
+	chunk_rri->ri_RootToChildMapValid = true;
 #endif
 
 	Assert(mt->onConflictSet);

--- a/src/utils.c
+++ b/src/utils.c
@@ -1086,7 +1086,11 @@ ts_get_node_name(Node *node)
 		/*
 		 * plan nodes (plannodes.h)
 		 */
+#if PG16_LT
 		NODE_CASE(Plan);
+		NODE_CASE(Scan);
+		NODE_CASE(Join);
+#endif
 		NODE_CASE(Result);
 		NODE_CASE(ProjectSet);
 		NODE_CASE(ModifyTable);
@@ -1095,7 +1099,6 @@ ts_get_node_name(Node *node)
 		NODE_CASE(RecursiveUnion);
 		NODE_CASE(BitmapAnd);
 		NODE_CASE(BitmapOr);
-		NODE_CASE(Scan);
 		NODE_CASE(SeqScan);
 		NODE_CASE(SampleScan);
 		NODE_CASE(IndexScan);
@@ -1112,7 +1115,6 @@ ts_get_node_name(Node *node)
 		NODE_CASE(WorkTableScan);
 		NODE_CASE(ForeignScan);
 		NODE_CASE(CustomScan);
-		NODE_CASE(Join);
 		NODE_CASE(NestLoop);
 		NODE_CASE(MergeJoin);
 		NODE_CASE(HashJoin);

--- a/tsl/src/debug.c
+++ b/tsl/src/debug.c
@@ -64,7 +64,9 @@ static const char *reloptkind_name[] = {
 	[RELOPT_OTHER_JOINREL] = "OTHER_JOINREL",
 	[RELOPT_UPPER_REL] = "UPPER_REL",
 	[RELOPT_OTHER_UPPER_REL] = "OTHER_UPPER_REL",
+#if PG16_LT
 	[RELOPT_DEADREL] = "DEADREL",
+#endif
 };
 
 /* clang-format off */

--- a/tsl/src/debug.c
+++ b/tsl/src/debug.c
@@ -244,7 +244,7 @@ append_relids(StringInfo buf, PlannerInfo *root, Relids relids)
 }
 
 static void
-append_pathkeys(StringInfo buf, const List *pathkeys, const List *rtable)
+ts_append_pathkeys(StringInfo buf, const List *pathkeys, const List *rtable)
 {
 	const ListCell *i;
 
@@ -435,7 +435,7 @@ tsl_debug_append_path(StringInfo buf, PlannerInfo *root, Path *path, int indent)
 	if (path->pathkeys)
 	{
 		appendStringInfoString(buf, " with pathkeys: ");
-		append_pathkeys(buf, path->pathkeys, root->parse->rtable);
+		ts_append_pathkeys(buf, path->pathkeys, root->parse->rtable);
 	}
 
 	appendStringInfoString(buf, "\n");

--- a/tsl/src/nodes/decompress_chunk/decompress_chunk.c
+++ b/tsl/src/nodes/decompress_chunk/decompress_chunk.c
@@ -896,8 +896,15 @@ ts_decompress_chunk_generate_paths(PlannerInfo *root, RelOptInfo *chunk_rel, Hyp
 		 * freed if it's planned */
 		compressed_rel->partial_pathlist = NIL;
 	}
+#if PG16_LT
 	/* set reloptkind to RELOPT_DEADREL to prevent postgresql from replanning this relation */
 	compressed_rel->reloptkind = RELOPT_DEADREL;
+#else
+	/* remove the compressed_rel from the simple_rel_array to prevent it from being referenced again
+	 */
+	root->simple_rel_array[compressed_rel->relid] = NULL;
+	pfree(compressed_rel);
+#endif
 
 	/* We should never get in the situation with no viable paths. */
 	Ensure(chunk_rel->pathlist, "could not create decompression path");


### PR DESCRIPTION
[PG16: Rename ri_RootToPartitionMap to ri_RootToChildMap](https://github.com/timescale/timescaledb/commit/77992ba99e0d877e2935fb93afc1a11e79578268)

https://github.com/postgres/postgres/commit/fb958b5d

---

[PG16: Node tags T_Join, T_Plan and T_Scan have been removed](https://github.com/timescale/timescaledb/commit/d93a4dbfcde19178bfa156771339c49262f0354d) 

Node tags T_Join, T_Plan and T_Scan have been removed in PG16 as those
nodes are of abstract type and never directly instantiated.

https://github.com/postgres/postgres/commit/251154be
https://github.com/postgres/postgres/commit/8c73c11a

---

[PG16: When removing a relation from the query, drop its RelOptInfo.](https://github.com/timescale/timescaledb/commit/6939e6faa2acb88dcff49c11b40add8eb969c962) 

PG16 removes the notion of "dead relation" and instead recommends
deleting the relation's RelOptInfo from the planner's data structures
when it is no longer needed.

https://github.com/postgres/postgres/commit/e9a20e45

---

[PG16: Macro HeapKeyTest is now an inline function](https://github.com/timescale/timescaledb/commit/2706b72a0d75d84eec1df7677ffc3af74ba03d3d) 

https://github.com/postgres/postgres/commit/4eb3b112

---

[PG16: Rename append_pathkeys to append_pathkeys_custom](https://github.com/lkshminarayanan/timescaledb/commit/411b5190c47024ab39bdb3478b12871c50ff1354) 

Renamed append_pathkeys() to append_pathkeys_custom() to prevent
conflict with upstream changes

https://github.com/postgres/postgres/commit/1349d279

---

Disable-check: force-changelog-file
Disable-check: commit-count