### PR TITLE
Simplify compressed pathkey lookup

### DIFF
--- a/src/planner/planner.h
+++ b/src/planner/planner.h
@@ -41,6 +41,9 @@ typedef struct TimescaleDBPrivate
 
 	/* Cached chunk data for the chunk relinfo. */
 	Chunk *cached_chunk_struct;
+
+	/* Cached equivalence members for compressed chunks. List of (EC, EM) Lists. */
+	List *compressed_ec_em_pairs;
 } TimescaleDBPrivate;
 
 extern TSDLLEXPORT bool ts_rte_is_hypertable(const RangeTblEntry *rte, bool *isdistributed);

--- a/tsl/src/nodes/decompress_chunk/decompress_chunk.h
+++ b/tsl/src/nodes/decompress_chunk/decompress_chunk.h
@@ -29,8 +29,11 @@ typedef struct CompressionInfo
 
 	/* chunk attribute numbers that are segmentby columns */
 	Bitmapset *chunk_segmentby_attnos;
-	/* chunk attribute numbers that have equality constraint in baserestrictinfo */
-	Bitmapset *chunk_segmentby_ri;
+	/*
+	 * Chunk segmentby attribute numbers that are equated to a constant by a
+	 * baserestrictinfo.
+	 */
+	Bitmapset *chunk_const_segmentby;
 	/* compressed chunk attribute numbers for columns that are compressed */
 	Bitmapset *compressed_chunk_compressed_attnos;
 

--- a/tsl/test/expected/transparent_decompression-13.out
+++ b/tsl/test/expected/transparent_decompression-13.out
@@ -2462,64 +2462,64 @@ FROM :TEST_TABLE m1
     ORDER BY m1.time,
         m1.device_id
     LIMIT 10;
-                                                                   QUERY PLAN                                                                    
--------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                 QUERY PLAN                                                                 
+--------------------------------------------------------------------------------------------------------------------------------------------
  Limit (actual rows=10 loops=1)
    ->  Incremental Sort (actual rows=10 loops=1)
          Sort Key: m1."time", m1.device_id
          Presorted Key: m1."time"
          Full-sort Groups: 1  Sort Method: quicksort 
          ->  Merge Join (actual rows=11 loops=1)
-               Merge Cond: (m3_1."time" = m1."time")
-               ->  Merge Append (actual rows=3 loops=1)
-                     Sort Key: m3_1."time"
-                     ->  Sort (actual rows=3 loops=1)
-                           Sort Key: m3_1."time"
-                           Sort Method: quicksort 
-                           ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk m3_1 (actual rows=360 loops=1)
-                                 ->  Seq Scan on compress_hyper_5_15_chunk compress_hyper_5_15_chunk_2 (actual rows=1 loops=1)
-                                       Filter: (device_id = 3)
-                                       Rows Removed by Filter: 4
-                     ->  Index Scan Backward using _hyper_1_2_chunk_metrics_time_idx on _hyper_1_2_chunk m3_2 (actual rows=1 loops=1)
-                           Filter: (device_id = 3)
-                           Rows Removed by Filter: 2
-                     ->  Sort (actual rows=1 loops=1)
-                           Sort Key: m3_3."time"
-                           Sort Method: quicksort 
-                           ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk m3_3 (actual rows=504 loops=1)
-                                 ->  Seq Scan on compress_hyper_5_16_chunk compress_hyper_5_16_chunk_2 (actual rows=1 loops=1)
-                                       Filter: (device_id = 3)
-                                       Rows Removed by Filter: 4
-               ->  Materialize (actual rows=11 loops=1)
-                     ->  Merge Join (actual rows=11 loops=1)
-                           Merge Cond: (m1."time" = m2."time")
-                           Join Filter: (m1.device_id = m2.device_id)
-                           Rows Removed by Join Filter: 40
-                           ->  Custom Scan (ChunkAppend) on metrics m1 (actual rows=11 loops=1)
-                                 Order: m1."time"
+               Merge Cond: (m1."time" = m3_1."time")
+               ->  Merge Join (actual rows=11 loops=1)
+                     Merge Cond: (m1."time" = m2."time")
+                     Join Filter: (m1.device_id = m2.device_id)
+                     Rows Removed by Join Filter: 40
+                     ->  Custom Scan (ChunkAppend) on metrics m1 (actual rows=11 loops=1)
+                           Order: m1."time"
+                           ->  Sort (actual rows=11 loops=1)
+                                 Sort Key: m1_1."time"
+                                 Sort Method: quicksort 
+                                 ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk m1_1 (actual rows=1800 loops=1)
+                                       ->  Seq Scan on compress_hyper_5_15_chunk (actual rows=5 loops=1)
+                           ->  Index Scan Backward using _hyper_1_2_chunk_metrics_time_idx on _hyper_1_2_chunk m1_2 (never executed)
+                           ->  Sort (never executed)
+                                 Sort Key: m1_3."time"
+                                 ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk m1_3 (never executed)
+                                       ->  Seq Scan on compress_hyper_5_16_chunk (never executed)
+                     ->  Materialize (actual rows=51 loops=1)
+                           ->  Custom Scan (ChunkAppend) on metrics m2 (actual rows=11 loops=1)
+                                 Order: m2."time"
                                  ->  Sort (actual rows=11 loops=1)
-                                       Sort Key: m1_1."time"
+                                       Sort Key: m2_1."time"
                                        Sort Method: quicksort 
-                                       ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk m1_1 (actual rows=1800 loops=1)
-                                             ->  Seq Scan on compress_hyper_5_15_chunk (actual rows=5 loops=1)
-                                 ->  Index Scan Backward using _hyper_1_2_chunk_metrics_time_idx on _hyper_1_2_chunk m1_2 (never executed)
+                                       ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk m2_1 (actual rows=1800 loops=1)
+                                             ->  Seq Scan on compress_hyper_5_15_chunk compress_hyper_5_15_chunk_1 (actual rows=5 loops=1)
+                                 ->  Index Scan Backward using _hyper_1_2_chunk_metrics_time_idx on _hyper_1_2_chunk m2_2 (never executed)
                                  ->  Sort (never executed)
-                                       Sort Key: m1_3."time"
-                                       ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk m1_3 (never executed)
-                                             ->  Seq Scan on compress_hyper_5_16_chunk (never executed)
-                           ->  Materialize (actual rows=51 loops=1)
-                                 ->  Custom Scan (ChunkAppend) on metrics m2 (actual rows=11 loops=1)
-                                       Order: m2."time"
-                                       ->  Sort (actual rows=11 loops=1)
-                                             Sort Key: m2_1."time"
-                                             Sort Method: quicksort 
-                                             ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk m2_1 (actual rows=1800 loops=1)
-                                                   ->  Seq Scan on compress_hyper_5_15_chunk compress_hyper_5_15_chunk_1 (actual rows=5 loops=1)
-                                       ->  Index Scan Backward using _hyper_1_2_chunk_metrics_time_idx on _hyper_1_2_chunk m2_2 (never executed)
-                                       ->  Sort (never executed)
-                                             Sort Key: m2_3."time"
-                                             ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk m2_3 (never executed)
-                                                   ->  Seq Scan on compress_hyper_5_16_chunk compress_hyper_5_16_chunk_1 (never executed)
+                                       Sort Key: m2_3."time"
+                                       ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk m2_3 (never executed)
+                                             ->  Seq Scan on compress_hyper_5_16_chunk compress_hyper_5_16_chunk_1 (never executed)
+               ->  Materialize (actual rows=11 loops=1)
+                     ->  Merge Append (actual rows=3 loops=1)
+                           Sort Key: m3_1."time"
+                           ->  Sort (actual rows=3 loops=1)
+                                 Sort Key: m3_1."time"
+                                 Sort Method: quicksort 
+                                 ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk m3_1 (actual rows=360 loops=1)
+                                       ->  Seq Scan on compress_hyper_5_15_chunk compress_hyper_5_15_chunk_2 (actual rows=1 loops=1)
+                                             Filter: (device_id = 3)
+                                             Rows Removed by Filter: 4
+                           ->  Index Scan Backward using _hyper_1_2_chunk_metrics_time_idx on _hyper_1_2_chunk m3_2 (actual rows=1 loops=1)
+                                 Filter: (device_id = 3)
+                                 Rows Removed by Filter: 2
+                           ->  Sort (actual rows=1 loops=1)
+                                 Sort Key: m3_3."time"
+                                 Sort Method: quicksort 
+                                 ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk m3_3 (actual rows=504 loops=1)
+                                       ->  Seq Scan on compress_hyper_5_16_chunk compress_hyper_5_16_chunk_2 (actual rows=1 loops=1)
+                                             Filter: (device_id = 3)
+                                             Rows Removed by Filter: 4
 (56 rows)
 
 :PREFIX

--- a/tsl/test/expected/transparent_decompression-14.out
+++ b/tsl/test/expected/transparent_decompression-14.out
@@ -2462,64 +2462,64 @@ FROM :TEST_TABLE m1
     ORDER BY m1.time,
         m1.device_id
     LIMIT 10;
-                                                                   QUERY PLAN                                                                    
--------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                 QUERY PLAN                                                                 
+--------------------------------------------------------------------------------------------------------------------------------------------
  Limit (actual rows=10 loops=1)
    ->  Incremental Sort (actual rows=10 loops=1)
          Sort Key: m1."time", m1.device_id
          Presorted Key: m1."time"
          Full-sort Groups: 1  Sort Method: quicksort 
          ->  Merge Join (actual rows=11 loops=1)
-               Merge Cond: (m3_1."time" = m1."time")
-               ->  Merge Append (actual rows=3 loops=1)
-                     Sort Key: m3_1."time"
-                     ->  Sort (actual rows=3 loops=1)
-                           Sort Key: m3_1."time"
-                           Sort Method: quicksort 
-                           ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk m3_1 (actual rows=360 loops=1)
-                                 ->  Seq Scan on compress_hyper_5_15_chunk compress_hyper_5_15_chunk_2 (actual rows=1 loops=1)
-                                       Filter: (device_id = 3)
-                                       Rows Removed by Filter: 4
-                     ->  Index Scan Backward using _hyper_1_2_chunk_metrics_time_idx on _hyper_1_2_chunk m3_2 (actual rows=1 loops=1)
-                           Filter: (device_id = 3)
-                           Rows Removed by Filter: 2
-                     ->  Sort (actual rows=1 loops=1)
-                           Sort Key: m3_3."time"
-                           Sort Method: quicksort 
-                           ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk m3_3 (actual rows=504 loops=1)
-                                 ->  Seq Scan on compress_hyper_5_16_chunk compress_hyper_5_16_chunk_2 (actual rows=1 loops=1)
-                                       Filter: (device_id = 3)
-                                       Rows Removed by Filter: 4
-               ->  Materialize (actual rows=11 loops=1)
-                     ->  Merge Join (actual rows=11 loops=1)
-                           Merge Cond: (m1."time" = m2."time")
-                           Join Filter: (m1.device_id = m2.device_id)
-                           Rows Removed by Join Filter: 40
-                           ->  Custom Scan (ChunkAppend) on metrics m1 (actual rows=11 loops=1)
-                                 Order: m1."time"
+               Merge Cond: (m1."time" = m3_1."time")
+               ->  Merge Join (actual rows=11 loops=1)
+                     Merge Cond: (m1."time" = m2."time")
+                     Join Filter: (m1.device_id = m2.device_id)
+                     Rows Removed by Join Filter: 40
+                     ->  Custom Scan (ChunkAppend) on metrics m1 (actual rows=11 loops=1)
+                           Order: m1."time"
+                           ->  Sort (actual rows=11 loops=1)
+                                 Sort Key: m1_1."time"
+                                 Sort Method: quicksort 
+                                 ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk m1_1 (actual rows=1800 loops=1)
+                                       ->  Seq Scan on compress_hyper_5_15_chunk (actual rows=5 loops=1)
+                           ->  Index Scan Backward using _hyper_1_2_chunk_metrics_time_idx on _hyper_1_2_chunk m1_2 (never executed)
+                           ->  Sort (never executed)
+                                 Sort Key: m1_3."time"
+                                 ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk m1_3 (never executed)
+                                       ->  Seq Scan on compress_hyper_5_16_chunk (never executed)
+                     ->  Materialize (actual rows=51 loops=1)
+                           ->  Custom Scan (ChunkAppend) on metrics m2 (actual rows=11 loops=1)
+                                 Order: m2."time"
                                  ->  Sort (actual rows=11 loops=1)
-                                       Sort Key: m1_1."time"
+                                       Sort Key: m2_1."time"
                                        Sort Method: quicksort 
-                                       ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk m1_1 (actual rows=1800 loops=1)
-                                             ->  Seq Scan on compress_hyper_5_15_chunk (actual rows=5 loops=1)
-                                 ->  Index Scan Backward using _hyper_1_2_chunk_metrics_time_idx on _hyper_1_2_chunk m1_2 (never executed)
+                                       ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk m2_1 (actual rows=1800 loops=1)
+                                             ->  Seq Scan on compress_hyper_5_15_chunk compress_hyper_5_15_chunk_1 (actual rows=5 loops=1)
+                                 ->  Index Scan Backward using _hyper_1_2_chunk_metrics_time_idx on _hyper_1_2_chunk m2_2 (never executed)
                                  ->  Sort (never executed)
-                                       Sort Key: m1_3."time"
-                                       ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk m1_3 (never executed)
-                                             ->  Seq Scan on compress_hyper_5_16_chunk (never executed)
-                           ->  Materialize (actual rows=51 loops=1)
-                                 ->  Custom Scan (ChunkAppend) on metrics m2 (actual rows=11 loops=1)
-                                       Order: m2."time"
-                                       ->  Sort (actual rows=11 loops=1)
-                                             Sort Key: m2_1."time"
-                                             Sort Method: quicksort 
-                                             ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk m2_1 (actual rows=1800 loops=1)
-                                                   ->  Seq Scan on compress_hyper_5_15_chunk compress_hyper_5_15_chunk_1 (actual rows=5 loops=1)
-                                       ->  Index Scan Backward using _hyper_1_2_chunk_metrics_time_idx on _hyper_1_2_chunk m2_2 (never executed)
-                                       ->  Sort (never executed)
-                                             Sort Key: m2_3."time"
-                                             ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk m2_3 (never executed)
-                                                   ->  Seq Scan on compress_hyper_5_16_chunk compress_hyper_5_16_chunk_1 (never executed)
+                                       Sort Key: m2_3."time"
+                                       ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk m2_3 (never executed)
+                                             ->  Seq Scan on compress_hyper_5_16_chunk compress_hyper_5_16_chunk_1 (never executed)
+               ->  Materialize (actual rows=11 loops=1)
+                     ->  Merge Append (actual rows=3 loops=1)
+                           Sort Key: m3_1."time"
+                           ->  Sort (actual rows=3 loops=1)
+                                 Sort Key: m3_1."time"
+                                 Sort Method: quicksort 
+                                 ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk m3_1 (actual rows=360 loops=1)
+                                       ->  Seq Scan on compress_hyper_5_15_chunk compress_hyper_5_15_chunk_2 (actual rows=1 loops=1)
+                                             Filter: (device_id = 3)
+                                             Rows Removed by Filter: 4
+                           ->  Index Scan Backward using _hyper_1_2_chunk_metrics_time_idx on _hyper_1_2_chunk m3_2 (actual rows=1 loops=1)
+                                 Filter: (device_id = 3)
+                                 Rows Removed by Filter: 2
+                           ->  Sort (actual rows=1 loops=1)
+                                 Sort Key: m3_3."time"
+                                 Sort Method: quicksort 
+                                 ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk m3_3 (actual rows=504 loops=1)
+                                       ->  Seq Scan on compress_hyper_5_16_chunk compress_hyper_5_16_chunk_2 (actual rows=1 loops=1)
+                                             Filter: (device_id = 3)
+                                             Rows Removed by Filter: 4
 (56 rows)
 
 :PREFIX

--- a/tsl/test/expected/transparent_decompression-15.out
+++ b/tsl/test/expected/transparent_decompression-15.out
@@ -2463,64 +2463,64 @@ FROM :TEST_TABLE m1
     ORDER BY m1.time,
         m1.device_id
     LIMIT 10;
-                                                                   QUERY PLAN                                                                    
--------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                 QUERY PLAN                                                                 
+--------------------------------------------------------------------------------------------------------------------------------------------
  Limit (actual rows=10 loops=1)
    ->  Incremental Sort (actual rows=10 loops=1)
          Sort Key: m1."time", m1.device_id
          Presorted Key: m1."time"
          Full-sort Groups: 1  Sort Method: quicksort 
          ->  Merge Join (actual rows=11 loops=1)
-               Merge Cond: (m3_1."time" = m1."time")
-               ->  Merge Append (actual rows=3 loops=1)
-                     Sort Key: m3_1."time"
-                     ->  Sort (actual rows=3 loops=1)
-                           Sort Key: m3_1."time"
-                           Sort Method: quicksort 
-                           ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk m3_1 (actual rows=360 loops=1)
-                                 ->  Seq Scan on compress_hyper_5_15_chunk compress_hyper_5_15_chunk_2 (actual rows=1 loops=1)
-                                       Filter: (device_id = 3)
-                                       Rows Removed by Filter: 4
-                     ->  Index Scan Backward using _hyper_1_2_chunk_metrics_time_idx on _hyper_1_2_chunk m3_2 (actual rows=1 loops=1)
-                           Filter: (device_id = 3)
-                           Rows Removed by Filter: 2
-                     ->  Sort (actual rows=1 loops=1)
-                           Sort Key: m3_3."time"
-                           Sort Method: quicksort 
-                           ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk m3_3 (actual rows=504 loops=1)
-                                 ->  Seq Scan on compress_hyper_5_16_chunk compress_hyper_5_16_chunk_2 (actual rows=1 loops=1)
-                                       Filter: (device_id = 3)
-                                       Rows Removed by Filter: 4
-               ->  Materialize (actual rows=11 loops=1)
-                     ->  Merge Join (actual rows=11 loops=1)
-                           Merge Cond: (m1."time" = m2."time")
-                           Join Filter: (m1.device_id = m2.device_id)
-                           Rows Removed by Join Filter: 40
-                           ->  Custom Scan (ChunkAppend) on metrics m1 (actual rows=11 loops=1)
-                                 Order: m1."time"
+               Merge Cond: (m1."time" = m3_1."time")
+               ->  Merge Join (actual rows=11 loops=1)
+                     Merge Cond: (m1."time" = m2."time")
+                     Join Filter: (m1.device_id = m2.device_id)
+                     Rows Removed by Join Filter: 40
+                     ->  Custom Scan (ChunkAppend) on metrics m1 (actual rows=11 loops=1)
+                           Order: m1."time"
+                           ->  Sort (actual rows=11 loops=1)
+                                 Sort Key: m1_1."time"
+                                 Sort Method: quicksort 
+                                 ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk m1_1 (actual rows=1800 loops=1)
+                                       ->  Seq Scan on compress_hyper_5_15_chunk (actual rows=5 loops=1)
+                           ->  Index Scan Backward using _hyper_1_2_chunk_metrics_time_idx on _hyper_1_2_chunk m1_2 (never executed)
+                           ->  Sort (never executed)
+                                 Sort Key: m1_3."time"
+                                 ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk m1_3 (never executed)
+                                       ->  Seq Scan on compress_hyper_5_16_chunk (never executed)
+                     ->  Materialize (actual rows=51 loops=1)
+                           ->  Custom Scan (ChunkAppend) on metrics m2 (actual rows=11 loops=1)
+                                 Order: m2."time"
                                  ->  Sort (actual rows=11 loops=1)
-                                       Sort Key: m1_1."time"
+                                       Sort Key: m2_1."time"
                                        Sort Method: quicksort 
-                                       ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk m1_1 (actual rows=1800 loops=1)
-                                             ->  Seq Scan on compress_hyper_5_15_chunk (actual rows=5 loops=1)
-                                 ->  Index Scan Backward using _hyper_1_2_chunk_metrics_time_idx on _hyper_1_2_chunk m1_2 (never executed)
+                                       ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk m2_1 (actual rows=1800 loops=1)
+                                             ->  Seq Scan on compress_hyper_5_15_chunk compress_hyper_5_15_chunk_1 (actual rows=5 loops=1)
+                                 ->  Index Scan Backward using _hyper_1_2_chunk_metrics_time_idx on _hyper_1_2_chunk m2_2 (never executed)
                                  ->  Sort (never executed)
-                                       Sort Key: m1_3."time"
-                                       ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk m1_3 (never executed)
-                                             ->  Seq Scan on compress_hyper_5_16_chunk (never executed)
-                           ->  Materialize (actual rows=51 loops=1)
-                                 ->  Custom Scan (ChunkAppend) on metrics m2 (actual rows=11 loops=1)
-                                       Order: m2."time"
-                                       ->  Sort (actual rows=11 loops=1)
-                                             Sort Key: m2_1."time"
-                                             Sort Method: quicksort 
-                                             ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk m2_1 (actual rows=1800 loops=1)
-                                                   ->  Seq Scan on compress_hyper_5_15_chunk compress_hyper_5_15_chunk_1 (actual rows=5 loops=1)
-                                       ->  Index Scan Backward using _hyper_1_2_chunk_metrics_time_idx on _hyper_1_2_chunk m2_2 (never executed)
-                                       ->  Sort (never executed)
-                                             Sort Key: m2_3."time"
-                                             ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk m2_3 (never executed)
-                                                   ->  Seq Scan on compress_hyper_5_16_chunk compress_hyper_5_16_chunk_1 (never executed)
+                                       Sort Key: m2_3."time"
+                                       ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk m2_3 (never executed)
+                                             ->  Seq Scan on compress_hyper_5_16_chunk compress_hyper_5_16_chunk_1 (never executed)
+               ->  Materialize (actual rows=11 loops=1)
+                     ->  Merge Append (actual rows=3 loops=1)
+                           Sort Key: m3_1."time"
+                           ->  Sort (actual rows=3 loops=1)
+                                 Sort Key: m3_1."time"
+                                 Sort Method: quicksort 
+                                 ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk m3_1 (actual rows=360 loops=1)
+                                       ->  Seq Scan on compress_hyper_5_15_chunk compress_hyper_5_15_chunk_2 (actual rows=1 loops=1)
+                                             Filter: (device_id = 3)
+                                             Rows Removed by Filter: 4
+                           ->  Index Scan Backward using _hyper_1_2_chunk_metrics_time_idx on _hyper_1_2_chunk m3_2 (actual rows=1 loops=1)
+                                 Filter: (device_id = 3)
+                                 Rows Removed by Filter: 2
+                           ->  Sort (actual rows=1 loops=1)
+                                 Sort Key: m3_3."time"
+                                 Sort Method: quicksort 
+                                 ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk m3_3 (actual rows=504 loops=1)
+                                       ->  Seq Scan on compress_hyper_5_16_chunk compress_hyper_5_16_chunk_2 (actual rows=1 loops=1)
+                                             Filter: (device_id = 3)
+                                             Rows Removed by Filter: 4
 (56 rows)
 
 :PREFIX

--- a/tsl/test/expected/transparent_decompression_join_index.out
+++ b/tsl/test/expected/transparent_decompression_join_index.out
@@ -53,8 +53,8 @@ test inner join query_params q
     on q.a = test.a and q.b = test.b
 where test.time between '2020-01-01 00:00' and '2020-01-01 00:02'
 order by test.time;
-                                                                                                        QUERY PLAN                                                                                                         
----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                                            QUERY PLAN                                                                                                             
+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Sort
    Sort Key: _hyper_1_1_chunk."time"
    ->  Nested Loop
@@ -64,7 +64,7 @@ order by test.time;
                      ->  Seq Scan on test_copy
                            Filter: (((a)::text = ANY ('{lat,lon}'::text[])) AND (b = 1))
          ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk
-               Filter: (("time" >= 'Wed Jan 01 00:00:00 2020 PST'::timestamp with time zone) AND ("time" <= 'Wed Jan 01 00:02:00 2020 PST'::timestamp with time zone) AND ((test_copy.a)::text = a) AND (test_copy.b = b))
+               Filter: (("time" >= 'Wed Jan 01 00:00:00 2020 PST'::timestamp with time zone) AND ("time" <= 'Wed Jan 01 00:02:00 2020 PST'::timestamp with time zone) AND ((test_copy.a)::text = (a)::text) AND (test_copy.b = b))
                ->  Index Scan using compress_hyper_2_2_chunk__compressed_hypertable_2_a_b__ts_meta_ on compress_hyper_2_2_chunk
                      Index Cond: ((a = (test_copy.a)::text) AND (b = test_copy.b))
                      Filter: ((_ts_meta_max_1 >= 'Wed Jan 01 00:00:00 2020 PST'::timestamp with time zone) AND (_ts_meta_min_1 <= 'Wed Jan 01 00:02:00 2020 PST'::timestamp with time zone))

--- a/tsl/test/expected/transparent_decompression_ordered_index-13.out
+++ b/tsl/test/expected/transparent_decompression_ordered_index-13.out
@@ -637,18 +637,17 @@ FROM metrics_ordered_idx met join lookup
 ON met.device_id = lookup.did and met.v0 = lookup.version
 WHERE met.time > '2000-01-19 19:00:00-05'
       and met.time < '2000-01-20 20:00:00-05';
-                                                                                     QUERY PLAN                                                                                      
--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                                            QUERY PLAN                                                                                                            
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Nested Loop (actual rows=2 loops=1)
-   Join Filter: ((met.device_id = "*VALUES*".column1) AND (met.v0 = "*VALUES*".column2))
-   Rows Removed by Join Filter: 92
    ->  Values Scan on "*VALUES*" (actual rows=2 loops=1)
-   ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk met (actual rows=47 loops=2)
-         Filter: (("time" > 'Wed Jan 19 16:00:00 2000 PST'::timestamp with time zone) AND ("time" < 'Thu Jan 20 17:00:00 2000 PST'::timestamp with time zone))
-         Rows Removed by Filter: 1
+   ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk met (actual rows=1 loops=2)
+         Filter: (("time" > 'Wed Jan 19 16:00:00 2000 PST'::timestamp with time zone) AND ("time" < 'Thu Jan 20 17:00:00 2000 PST'::timestamp with time zone) AND ("*VALUES*".column1 = device_id) AND ("*VALUES*".column2 = v0))
+         Rows Removed by Filter: 47
          ->  Index Scan using compress_hyper_2_8_chunk__compressed_hypertable_2_device_id_dev on compress_hyper_2_8_chunk (actual rows=1 loops=2)
+               Index Cond: (device_id = "*VALUES*".column1)
                Filter: ((_ts_meta_max_1 > 'Wed Jan 19 16:00:00 2000 PST'::timestamp with time zone) AND (_ts_meta_min_1 < 'Thu Jan 20 17:00:00 2000 PST'::timestamp with time zone))
-(9 rows)
+(8 rows)
 
 --add filter to segment by (device_id) and compressed attr column (v0)
 :PREFIX
@@ -704,20 +703,20 @@ JOIN LATERAL
     WHERE  node = f1.device_id) q
 ON met.device_id = q.node and met.device_id_peer = q.device_id_peer
    and met.v0 = q.v0 and met.v0 > 2 and time = '2018-01-19 20:00:00-05';
-                                                                                      QUERY PLAN                                                                                       
----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                                   QUERY PLAN                                                                                                    
+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Nested Loop (actual rows=1 loops=1)
-   Join Filter: (("*VALUES*".column2 = met.device_id_peer) AND ("*VALUES*".column3 = met.v0))
+   Join Filter: (nodetime.node = met.device_id)
    ->  Nested Loop (actual rows=1 loops=1)
          Join Filter: (nodetime.node = "*VALUES*".column1)
          Rows Removed by Join Filter: 1
          ->  Seq Scan on nodetime (actual rows=1 loops=1)
          ->  Values Scan on "*VALUES*" (actual rows=2 loops=1)
    ->  Custom Scan (DecompressChunk) on _hyper_1_4_chunk met (actual rows=1 loops=1)
-         Filter: ((v0 > 2) AND ("time" = 'Fri Jan 19 17:00:00 2018 PST'::timestamp with time zone) AND (nodetime.node = device_id))
+         Filter: ((v0 > 2) AND ("time" = 'Fri Jan 19 17:00:00 2018 PST'::timestamp with time zone) AND ("*VALUES*".column1 = device_id) AND ("*VALUES*".column2 = device_id_peer) AND ("*VALUES*".column3 = v0))
          Rows Removed by Filter: 47
          ->  Index Scan using compress_hyper_2_9_chunk__compressed_hypertable_2_device_id_dev on compress_hyper_2_9_chunk (actual rows=1 loops=1)
-               Index Cond: (device_id = nodetime.node)
+               Index Cond: ((device_id = "*VALUES*".column1) AND (device_id_peer = "*VALUES*".column2))
                Filter: ((_ts_meta_min_1 <= 'Fri Jan 19 17:00:00 2018 PST'::timestamp with time zone) AND (_ts_meta_max_1 >= 'Fri Jan 19 17:00:00 2018 PST'::timestamp with time zone))
 (13 rows)
 

--- a/tsl/test/expected/transparent_decompression_ordered_index-14.out
+++ b/tsl/test/expected/transparent_decompression_ordered_index-14.out
@@ -637,18 +637,17 @@ FROM metrics_ordered_idx met join lookup
 ON met.device_id = lookup.did and met.v0 = lookup.version
 WHERE met.time > '2000-01-19 19:00:00-05'
       and met.time < '2000-01-20 20:00:00-05';
-                                                                                     QUERY PLAN                                                                                      
--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                                            QUERY PLAN                                                                                                            
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Nested Loop (actual rows=2 loops=1)
-   Join Filter: ((met.device_id = "*VALUES*".column1) AND (met.v0 = "*VALUES*".column2))
-   Rows Removed by Join Filter: 92
    ->  Values Scan on "*VALUES*" (actual rows=2 loops=1)
-   ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk met (actual rows=47 loops=2)
-         Filter: (("time" > 'Wed Jan 19 16:00:00 2000 PST'::timestamp with time zone) AND ("time" < 'Thu Jan 20 17:00:00 2000 PST'::timestamp with time zone))
-         Rows Removed by Filter: 1
+   ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk met (actual rows=1 loops=2)
+         Filter: (("time" > 'Wed Jan 19 16:00:00 2000 PST'::timestamp with time zone) AND ("time" < 'Thu Jan 20 17:00:00 2000 PST'::timestamp with time zone) AND ("*VALUES*".column1 = device_id) AND ("*VALUES*".column2 = v0))
+         Rows Removed by Filter: 47
          ->  Index Scan using compress_hyper_2_8_chunk__compressed_hypertable_2_device_id_dev on compress_hyper_2_8_chunk (actual rows=1 loops=2)
+               Index Cond: (device_id = "*VALUES*".column1)
                Filter: ((_ts_meta_max_1 > 'Wed Jan 19 16:00:00 2000 PST'::timestamp with time zone) AND (_ts_meta_min_1 < 'Thu Jan 20 17:00:00 2000 PST'::timestamp with time zone))
-(9 rows)
+(8 rows)
 
 --add filter to segment by (device_id) and compressed attr column (v0)
 :PREFIX
@@ -704,20 +703,20 @@ JOIN LATERAL
     WHERE  node = f1.device_id) q
 ON met.device_id = q.node and met.device_id_peer = q.device_id_peer
    and met.v0 = q.v0 and met.v0 > 2 and time = '2018-01-19 20:00:00-05';
-                                                                                      QUERY PLAN                                                                                       
----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                                   QUERY PLAN                                                                                                    
+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Nested Loop (actual rows=1 loops=1)
-   Join Filter: (("*VALUES*".column2 = met.device_id_peer) AND ("*VALUES*".column3 = met.v0))
+   Join Filter: (nodetime.node = met.device_id)
    ->  Nested Loop (actual rows=1 loops=1)
          Join Filter: (nodetime.node = "*VALUES*".column1)
          Rows Removed by Join Filter: 1
          ->  Seq Scan on nodetime (actual rows=1 loops=1)
          ->  Values Scan on "*VALUES*" (actual rows=2 loops=1)
    ->  Custom Scan (DecompressChunk) on _hyper_1_4_chunk met (actual rows=1 loops=1)
-         Filter: ((v0 > 2) AND ("time" = 'Fri Jan 19 17:00:00 2018 PST'::timestamp with time zone) AND (nodetime.node = device_id))
+         Filter: ((v0 > 2) AND ("time" = 'Fri Jan 19 17:00:00 2018 PST'::timestamp with time zone) AND ("*VALUES*".column1 = device_id) AND ("*VALUES*".column2 = device_id_peer) AND ("*VALUES*".column3 = v0))
          Rows Removed by Filter: 47
          ->  Index Scan using compress_hyper_2_9_chunk__compressed_hypertable_2_device_id_dev on compress_hyper_2_9_chunk (actual rows=1 loops=1)
-               Index Cond: (device_id = nodetime.node)
+               Index Cond: ((device_id = "*VALUES*".column1) AND (device_id_peer = "*VALUES*".column2))
                Filter: ((_ts_meta_min_1 <= 'Fri Jan 19 17:00:00 2018 PST'::timestamp with time zone) AND (_ts_meta_max_1 >= 'Fri Jan 19 17:00:00 2018 PST'::timestamp with time zone))
 (13 rows)
 

--- a/tsl/test/expected/transparent_decompression_ordered_index-15.out
+++ b/tsl/test/expected/transparent_decompression_ordered_index-15.out
@@ -639,18 +639,17 @@ FROM metrics_ordered_idx met join lookup
 ON met.device_id = lookup.did and met.v0 = lookup.version
 WHERE met.time > '2000-01-19 19:00:00-05'
       and met.time < '2000-01-20 20:00:00-05';
-                                                                                     QUERY PLAN                                                                                      
--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                                            QUERY PLAN                                                                                                            
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Nested Loop (actual rows=2 loops=1)
-   Join Filter: ((met.device_id = "*VALUES*".column1) AND (met.v0 = "*VALUES*".column2))
-   Rows Removed by Join Filter: 92
    ->  Values Scan on "*VALUES*" (actual rows=2 loops=1)
-   ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk met (actual rows=47 loops=2)
-         Filter: (("time" > 'Wed Jan 19 16:00:00 2000 PST'::timestamp with time zone) AND ("time" < 'Thu Jan 20 17:00:00 2000 PST'::timestamp with time zone))
-         Rows Removed by Filter: 1
+   ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk met (actual rows=1 loops=2)
+         Filter: (("time" > 'Wed Jan 19 16:00:00 2000 PST'::timestamp with time zone) AND ("time" < 'Thu Jan 20 17:00:00 2000 PST'::timestamp with time zone) AND ("*VALUES*".column1 = device_id) AND ("*VALUES*".column2 = v0))
+         Rows Removed by Filter: 47
          ->  Index Scan using compress_hyper_2_8_chunk__compressed_hypertable_2_device_id_dev on compress_hyper_2_8_chunk (actual rows=1 loops=2)
+               Index Cond: (device_id = "*VALUES*".column1)
                Filter: ((_ts_meta_max_1 > 'Wed Jan 19 16:00:00 2000 PST'::timestamp with time zone) AND (_ts_meta_min_1 < 'Thu Jan 20 17:00:00 2000 PST'::timestamp with time zone))
-(9 rows)
+(8 rows)
 
 --add filter to segment by (device_id) and compressed attr column (v0)
 :PREFIX
@@ -706,20 +705,20 @@ JOIN LATERAL
     WHERE  node = f1.device_id) q
 ON met.device_id = q.node and met.device_id_peer = q.device_id_peer
    and met.v0 = q.v0 and met.v0 > 2 and time = '2018-01-19 20:00:00-05';
-                                                                                      QUERY PLAN                                                                                       
----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                                   QUERY PLAN                                                                                                    
+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Nested Loop (actual rows=1 loops=1)
-   Join Filter: (("*VALUES*".column2 = met.device_id_peer) AND ("*VALUES*".column3 = met.v0))
+   Join Filter: (nodetime.node = met.device_id)
    ->  Nested Loop (actual rows=1 loops=1)
          Join Filter: (nodetime.node = "*VALUES*".column1)
          Rows Removed by Join Filter: 1
          ->  Seq Scan on nodetime (actual rows=1 loops=1)
          ->  Values Scan on "*VALUES*" (actual rows=2 loops=1)
    ->  Custom Scan (DecompressChunk) on _hyper_1_4_chunk met (actual rows=1 loops=1)
-         Filter: ((v0 > 2) AND ("time" = 'Fri Jan 19 17:00:00 2018 PST'::timestamp with time zone) AND (nodetime.node = device_id))
+         Filter: ((v0 > 2) AND ("time" = 'Fri Jan 19 17:00:00 2018 PST'::timestamp with time zone) AND ("*VALUES*".column1 = device_id) AND ("*VALUES*".column2 = device_id_peer) AND ("*VALUES*".column3 = v0))
          Rows Removed by Filter: 47
          ->  Index Scan using compress_hyper_2_9_chunk__compressed_hypertable_2_device_id_dev on compress_hyper_2_9_chunk (actual rows=1 loops=1)
-               Index Cond: (device_id = nodetime.node)
+               Index Cond: ((device_id = "*VALUES*".column1) AND (device_id_peer = "*VALUES*".column2))
                Filter: ((_ts_meta_min_1 <= 'Fri Jan 19 17:00:00 2018 PST'::timestamp with time zone) AND (_ts_meta_max_1 >= 'Fri Jan 19 17:00:00 2018 PST'::timestamp with time zone))
 (13 rows)
 

--- a/tsl/test/shared/expected/transparent_decompress_chunk-13.out
+++ b/tsl/test/shared/expected/transparent_decompress_chunk-13.out
@@ -684,7 +684,6 @@ FROM :TEST_TABLE m1
 QUERY PLAN
  Limit
    ->  Nested Loop
-         Join Filter: ((m1."time" = m2."time") AND (m1.device_id = m2.device_id))
          ->  Gather Merge
                Workers Planned: 1
                ->  Sort
@@ -692,8 +691,10 @@ QUERY PLAN
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk m1
                            ->  Parallel Seq Scan on compress_hyper_X_X_chunk
          ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk m2
-               ->  Seq Scan on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1
-(11 rows)
+               Filter: ((m1."time" = "time") AND (m1.device_id = device_id))
+               ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_4_device_id__t on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1
+                     Index Cond: (device_id = m1.device_id)
+(12 rows)
 
 :PREFIX_NO_VERBOSE
 SELECT *
@@ -708,21 +709,22 @@ FROM :TEST_TABLE m1
 QUERY PLAN
  Limit
    ->  Nested Loop
-         Join Filter: (m1."time" = m3."time")
          ->  Nested Loop
-               Join Filter: ((m1."time" = m2."time") AND (m1.device_id = m2.device_id))
+               Join Filter: (m1."time" = m3."time")
                ->  Gather Merge
                      Workers Planned: 1
                      ->  Sort
                            Sort Key: m1."time", m1.device_id
                            ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk m1
                                  ->  Parallel Seq Scan on compress_hyper_X_X_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk m2
-                     ->  Seq Scan on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1
-         ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk m3
-               ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_4_device_id__t on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_2
-                     Index Cond: (device_id = 3)
-(16 rows)
+               ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk m3
+                     ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_4_device_id__t on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_2
+                           Index Cond: (device_id = 3)
+         ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk m2
+               Filter: ((m1."time" = "time") AND (m1.device_id = device_id))
+               ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_4_device_id__t on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1
+                     Index Cond: (device_id = m1.device_id)
+(17 rows)
 
 RESET min_parallel_table_scan_size;
 :PREFIX_NO_VERBOSE

--- a/tsl/test/shared/expected/transparent_decompress_chunk-14.out
+++ b/tsl/test/shared/expected/transparent_decompress_chunk-14.out
@@ -684,7 +684,6 @@ FROM :TEST_TABLE m1
 QUERY PLAN
  Limit
    ->  Nested Loop
-         Join Filter: ((m1."time" = m2."time") AND (m1.device_id = m2.device_id))
          ->  Gather Merge
                Workers Planned: 1
                ->  Sort
@@ -692,8 +691,10 @@ QUERY PLAN
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk m1
                            ->  Parallel Seq Scan on compress_hyper_X_X_chunk
          ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk m2
-               ->  Seq Scan on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1
-(11 rows)
+               Filter: ((m1."time" = "time") AND (m1.device_id = device_id))
+               ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_4_device_id__t on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1
+                     Index Cond: (device_id = m1.device_id)
+(12 rows)
 
 :PREFIX_NO_VERBOSE
 SELECT *
@@ -708,21 +709,22 @@ FROM :TEST_TABLE m1
 QUERY PLAN
  Limit
    ->  Nested Loop
-         Join Filter: (m1."time" = m3."time")
          ->  Nested Loop
-               Join Filter: ((m1."time" = m2."time") AND (m1.device_id = m2.device_id))
+               Join Filter: (m1."time" = m3."time")
                ->  Gather Merge
                      Workers Planned: 1
                      ->  Sort
                            Sort Key: m1."time", m1.device_id
                            ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk m1
                                  ->  Parallel Seq Scan on compress_hyper_X_X_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk m2
-                     ->  Seq Scan on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1
-         ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk m3
-               ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_4_device_id__t on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_2
-                     Index Cond: (device_id = 3)
-(16 rows)
+               ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk m3
+                     ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_4_device_id__t on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_2
+                           Index Cond: (device_id = 3)
+         ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk m2
+               Filter: ((m1."time" = "time") AND (m1.device_id = device_id))
+               ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_4_device_id__t on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1
+                     Index Cond: (device_id = m1.device_id)
+(17 rows)
 
 RESET min_parallel_table_scan_size;
 :PREFIX_NO_VERBOSE

--- a/tsl/test/shared/expected/transparent_decompress_chunk-15.out
+++ b/tsl/test/shared/expected/transparent_decompress_chunk-15.out
@@ -686,7 +686,6 @@ FROM :TEST_TABLE m1
 QUERY PLAN
  Limit
    ->  Nested Loop
-         Join Filter: ((m1."time" = m2."time") AND (m1.device_id = m2.device_id))
          ->  Gather Merge
                Workers Planned: 1
                ->  Sort
@@ -694,8 +693,10 @@ QUERY PLAN
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk m1
                            ->  Parallel Seq Scan on compress_hyper_X_X_chunk
          ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk m2
-               ->  Seq Scan on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1
-(11 rows)
+               Filter: ((m1."time" = "time") AND (m1.device_id = device_id))
+               ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_4_device_id__t on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1
+                     Index Cond: (device_id = m1.device_id)
+(12 rows)
 
 :PREFIX_NO_VERBOSE
 SELECT *
@@ -710,21 +711,22 @@ FROM :TEST_TABLE m1
 QUERY PLAN
  Limit
    ->  Nested Loop
-         Join Filter: (m1."time" = m3."time")
          ->  Nested Loop
-               Join Filter: ((m1."time" = m2."time") AND (m1.device_id = m2.device_id))
+               Join Filter: (m1."time" = m3."time")
                ->  Gather Merge
                      Workers Planned: 1
                      ->  Sort
                            Sort Key: m1."time", m1.device_id
                            ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk m1
                                  ->  Parallel Seq Scan on compress_hyper_X_X_chunk
-               ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk m2
-                     ->  Seq Scan on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1
-         ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk m3
-               ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_4_device_id__t on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_2
-                     Index Cond: (device_id = 3)
-(16 rows)
+               ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk m3
+                     ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_4_device_id__t on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_2
+                           Index Cond: (device_id = 3)
+         ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk m2
+               Filter: ((m1."time" = "time") AND (m1.device_id = device_id))
+               ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_4_device_id__t on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1
+                     Index Cond: (device_id = m1.device_id)
+(17 rows)
 
 RESET min_parallel_table_scan_size;
 :PREFIX_NO_VERBOSE


### PR DESCRIPTION
When looking up a pathkey for compressed scan, we used to do a lot of work, including a quadratic lookup through all the equivalence members, to always arrive at the same canonical pathkey we started from. Just remove this useless code for a significant planning speedup.

This uncovers two bugs, fix them as well (see comments below).

Disable-check: force-changelog-file