### PR TITLE
Don't look up entire Chunk struct for compressed chunks

### DIFF
--- a/src/chunk.h
+++ b/src/chunk.h
@@ -164,10 +164,11 @@ extern TSDLLEXPORT Chunk *ts_chunk_get_by_id(int32 id, bool fail_if_not_found);
 extern TSDLLEXPORT Chunk *ts_chunk_get_by_relid(Oid relid, bool fail_if_not_found);
 extern TSDLLEXPORT void ts_chunk_free(Chunk *chunk);
 extern bool ts_chunk_exists(const char *schema_name, const char *table_name);
-extern TSDLLEXPORT int32 ts_chunk_get_hypertable_id_by_relid(Oid relid);
+extern TSDLLEXPORT int32 ts_chunk_get_hypertable_id_by_reloid(Oid relid);
 extern TSDLLEXPORT int32 ts_chunk_get_compressed_chunk_id(int32 chunk_id);
 extern bool ts_chunk_get_hypertable_id_and_status_by_relid(Oid relid, int32 *hypertable_id,
 														   int32 *chunk_status);
+extern TSDLLEXPORT FormData_chunk ts_chunk_get_formdata(int32 chunk_id);
 extern TSDLLEXPORT Oid ts_chunk_get_relid(int32 chunk_id, bool missing_ok);
 extern Oid ts_chunk_get_schema_id(int32 chunk_id, bool missing_ok);
 extern bool ts_chunk_get_id(const char *schema, const char *table, int32 *chunk_id,

--- a/src/planner/expand_hypertable.c
+++ b/src/planner/expand_hypertable.c
@@ -1363,7 +1363,7 @@ ts_plan_expand_hypertable_chunks(Hypertable *ht, PlannerInfo *root, RelOptInfo *
 		 * Add the information about chunks to the baserel info cache for
 		 * classify_relation().
 		 */
-		add_baserel_cache_entry_for_chunk(chunks[i]->table_id, ht);
+		ts_add_baserel_cache_entry_for_chunk(chunks[i]->table_id, ht);
 	}
 
 	/* nothing to do here if we have no chunks and no data nodes */

--- a/src/planner/planner.c
+++ b/src/planner/planner.c
@@ -152,7 +152,7 @@ static struct BaserelInfo_hash *ts_baserel_info = NULL;
  * chunk info at the plan time chunk exclusion.
  */
 void
-add_baserel_cache_entry_for_chunk(Oid chunk_reloid, Hypertable *hypertable)
+ts_add_baserel_cache_entry_for_chunk(Oid chunk_reloid, Hypertable *hypertable)
 {
 	Assert(hypertable != NULL);
 	Assert(ts_baserel_info != NULL);
@@ -165,6 +165,8 @@ add_baserel_cache_entry_for_chunk(Oid chunk_reloid, Hypertable *hypertable)
 		Assert(entry->ht != NULL);
 		return;
 	}
+
+	Assert(ts_chunk_get_hypertable_id_by_reloid(chunk_reloid) == hypertable->fd.id);
 
 	/* Fill the cache entry. */
 	entry->ht = hypertable;
@@ -695,7 +697,7 @@ get_or_add_baserel_from_cache(Oid chunk_reloid, Oid parent_reloid)
 
 #ifdef USE_ASSERT_CHECKING
 		/* Sanity check on the caller-specified hypertable reloid. */
-		int32 parent_hypertable_id = ts_chunk_get_hypertable_id_by_relid(chunk_reloid);
+		int32 parent_hypertable_id = ts_chunk_get_hypertable_id_by_reloid(chunk_reloid);
 		if (parent_hypertable_id != INVALID_HYPERTABLE_ID)
 		{
 			Assert(ts_hypertable_id_to_relid(parent_hypertable_id, false) == parent_reloid);
@@ -712,7 +714,7 @@ get_or_add_baserel_from_cache(Oid chunk_reloid, Oid parent_reloid)
 		/* Hypertable reloid not specified by the caller, look it up by
 		 * an expensive metadata scan.
 		 */
-		int32 hypertable_id = ts_chunk_get_hypertable_id_by_relid(chunk_reloid);
+		int32 hypertable_id = ts_chunk_get_hypertable_id_by_reloid(chunk_reloid);
 
 		if (hypertable_id != INVALID_HYPERTABLE_ID)
 		{

--- a/src/planner/planner.h
+++ b/src/planner/planner.h
@@ -98,7 +98,7 @@ typedef enum PartializeAggFixAggref
 	TS_FIX_AGGSPLIT_FINAL = 2
 } PartializeAggFixAggref;
 
-Hypertable *ts_planner_get_hypertable(const Oid relid, const unsigned int flags);
+extern TSDLLEXPORT Hypertable *ts_planner_get_hypertable(const Oid relid, const unsigned int flags);
 bool has_partialize_function(Node *node, PartializeAggFixAggref fix_aggref);
 bool ts_plan_process_partialize_agg(PlannerInfo *root, RelOptInfo *output_rel);
 
@@ -110,6 +110,7 @@ extern Node *ts_constify_now(PlannerInfo *root, List *rtable, Node *node);
 extern void ts_planner_constraint_cleanup(PlannerInfo *root, RelOptInfo *rel);
 extern Node *ts_add_space_constraints(PlannerInfo *root, List *rtable, Node *node);
 
-extern void add_baserel_cache_entry_for_chunk(Oid chunk_reloid, Hypertable *hypertable);
+extern TSDLLEXPORT void ts_add_baserel_cache_entry_for_chunk(Oid chunk_reloid,
+															 Hypertable *hypertable);
 
 #endif /* TIMESCALEDB_PLANNER_H */

--- a/tsl/src/fdw/modify_exec.c
+++ b/tsl/src/fdw/modify_exec.c
@@ -117,7 +117,7 @@ create_foreign_modify(EState *estate, Relation rel, CmdType operation, Oid check
 	Oid user_id = OidIsValid(check_as_user) ? check_as_user : GetUserId();
 	int i = 0;
 	int num_data_nodes, num_all_data_nodes;
-	int32 hypertable_id = ts_chunk_get_hypertable_id_by_relid(rel->rd_id);
+	int32 hypertable_id = ts_chunk_get_hypertable_id_by_reloid(rel->rd_id);
 	List *all_replicas = NIL, *avail_replicas = NIL;
 
 	if (hypertable_id == INVALID_HYPERTABLE_ID)

--- a/tsl/src/fdw/modify_plan.c
+++ b/tsl/src/fdw/modify_plan.c
@@ -67,7 +67,7 @@ get_chunk_data_nodes(Oid relid)
 	/* check that alteast one data node is available for this chunk */
 	if (chunk_data_nodes == NIL)
 	{
-		Hypertable *ht = ts_hypertable_get_by_id(ts_chunk_get_hypertable_id_by_relid(relid));
+		Hypertable *ht = ts_hypertable_get_by_id(ts_chunk_get_hypertable_id_by_reloid(relid));
 
 		ereport(ERROR,
 				(errcode(ERRCODE_TS_INSUFFICIENT_NUM_DATA_NODES),


### PR DESCRIPTION
It's not needed. Also add them to baserel cache.

Disable-check: force-changelog-file