### PR TITLE
Use cached Chunk when deciding to disable indexes

### DIFF
--- a/.github/workflows/linux-32bit-build-and-test.yaml
+++ b/.github/workflows/linux-32bit-build-and-test.yaml
@@ -162,17 +162,23 @@ jobs:
           for file in /tmp/core*
           do
             gdb /usr/lib/postgresql/${PG_MAJOR}/bin/postgres -c $file <<<"
-              set verbose on
-              set trace-commands on
-              show debug-file-directory
-              printf "'"'"query = '%s'\n\n"'"'", debug_query_string
-              frame function ExceptionalCondition
-              printf "'"'"condition = '%s'\n"'"'", conditionName
-              up 1
-              l
-              info args
-              info locals
-              bt full
+          set verbose on
+          set trace-commands on
+          show debug-file-directory
+          printf "'"'"query = '%s'\n\n"'"'", debug_query_string
+          bt full
+
+          # We try to find ExceptionalCondition frame to print the failed condition
+          # for searching in logs.
+          frame function ExceptionalCondition
+          printf "'"'"condition = '%s'\n"'"'", conditionName
+
+          # Hopefully now we should be around the failed assertion, print where
+          # we are.
+          up 1
+          list
+          info args
+          info locals
             " | tee -a stacktrace.log
           done
           echo "coredumps=true" >>$GITHUB_OUTPUT

--- a/.github/workflows/linux-build-and-test.yaml
+++ b/.github/workflows/linux-build-and-test.yaml
@@ -221,18 +221,24 @@ jobs:
     - name: Stack trace
       if: always() && steps.collectlogs.outputs.coredumps == 'true'
       run: |
-        sudo coredumpctl gdb <<<"
+        sudo coredumpctl debug --debugger=gdb --debugger-arguments='' <<<"
           set verbose on
           set trace-commands on
           show debug-file-directory
           printf "'"'"query = '%s'\n\n"'"'", debug_query_string
+          bt full
+
+          # We try to find ExceptionalCondition frame to print the failed condition
+          # for searching in logs.
           frame function ExceptionalCondition
           printf "'"'"condition = '%s'\n"'"'", conditionName
+
+          # Hopefully now we should be around the failed assertion, print where
+          # we are.
           up 1
-          l
+          list
           info args
           info locals
-          bt full
         " 2>&1 | tee stacktrace.log
         ./scripts/bundle_coredumps.sh
         grep -C40 "was terminated by signal" postgres.log > postgres-failure.log ||:

--- a/src/planner/expand_hypertable.c
+++ b/src/planner/expand_hypertable.c
@@ -1507,7 +1507,15 @@ ts_plan_expand_hypertable_chunks(Hypertable *ht, PlannerInfo *root, RelOptInfo *
 #endif
 		}
 
-		ts_get_private_reloptinfo(child_rel)->cached_chunk_struct = chunks[i];
+		/*
+		 * Can't touch fdw_private for OSM chunks, it might be managed by the
+		 * OSM extension, or, in the tests, by postgres_fdw.
+		 */
+		if (!IS_OSM_CHUNK(chunks[i]))
+		{
+			ts_get_private_reloptinfo(child_rel)->cached_chunk_struct = chunks[i];
+		}
+
 		Assert(chunks[i]->table_id == root->simple_rte_array[child_rtindex]->relid);
 	}
 }

--- a/src/planner/planner.h
+++ b/src/planner/planner.h
@@ -111,5 +111,6 @@ extern Node *ts_add_space_constraints(PlannerInfo *root, List *rtable, Node *nod
 
 extern TSDLLEXPORT void ts_add_baserel_cache_entry_for_chunk(Oid chunk_reloid,
 															 Hypertable *hypertable);
+TsRelType ts_classify_relation(const PlannerInfo *root, const RelOptInfo *rel, Hypertable **ht);
 
 #endif /* TIMESCALEDB_PLANNER_H */

--- a/tsl/src/planner.c
+++ b/tsl/src/planner.c
@@ -151,7 +151,9 @@ tsl_set_rel_pathlist_query(PlannerInfo *root, RelOptInfo *rel, Index rti, RangeT
 		}
 
 		if (fdw_private->cached_chunk_struct->fd.compressed_chunk_id != INVALID_CHUNK_ID)
+		{
 			ts_decompress_chunk_generate_paths(root, rel, ht, fdw_private->cached_chunk_struct);
+		}
 	}
 }
 


### PR DESCRIPTION
Move this decision to happen after the hypertable expansion, so that the cache is ready.

The benchmarks look pretty nice, 25% speedup on many `planning` queries, and 3x speedups on some first/last queries, although small in absolute magnitude: https://grafana.ops.savannah-dev.timescale.com/d/fasYic_4z/compare-akuzm?orgId=1&var-branch=All&var-run1=2696&var-run2=2698&var-threshold=0.05&var-use_historical_thresholds=false&chunkNotFound=


Disable-check: force-changelog-file