### PR TITLE
Pg16 few more fixes

### DIFF
--- a/src/guc.c
+++ b/src/guc.c
@@ -85,8 +85,10 @@ bool ts_guc_enable_async_append = true;
 TSDLLEXPORT bool ts_guc_enable_compression_indexscan = true;
 TSDLLEXPORT bool ts_guc_enable_bulk_decompression = true;
 TSDLLEXPORT bool ts_guc_enable_skip_scan = true;
-int ts_guc_max_open_chunks_per_insert; /* default is computed at runtime */
-int ts_guc_max_cached_chunks_per_hypertable = 100;
+/* default value of ts_guc_max_open_chunks_per_insert and ts_guc_max_cached_chunks_per_hypertable
+ * will be set as their respective boot-value when the GUC mechanism starts up */
+int ts_guc_max_open_chunks_per_insert;
+int ts_guc_max_cached_chunks_per_hypertable;
 #ifdef USE_TELEMETRY
 TelemetryLevel ts_guc_telemetry_level = TELEMETRY_DEFAULT;
 char *ts_telemetry_cloud = NULL;

--- a/tsl/src/remote/dist_txn.c
+++ b/tsl/src/remote/dist_txn.c
@@ -9,6 +9,7 @@
 #include <storage/lmgr.h>
 #include <utils/hsearch.h>
 #include <utils/builtins.h>
+#include <utils/guc.h>
 #include <utils/memutils.h>
 #include <utils/syscache.h>
 #include "dist_txn.h"

--- a/tsl/src/remote/txn.c
+++ b/tsl/src/remote/txn.c
@@ -8,6 +8,7 @@
 #include <access/xact.h>
 #include <storage/procarray.h>
 #include <utils/builtins.h>
+#include <utils/guc.h>
 #include <utils/snapmgr.h>
 #include <libpq-fe.h>
 #include <miscadmin.h>


### PR DESCRIPTION
[PG16: Replace float8in_internal_opt_error with float8in_internal](https://github.com/timescale/timescaledb/commit/f770db913b238671e49471a929d3286b5c5a2b6d) 

PG16 updated float8in_internal_opt_error() function to use soft error
reporting and renamed it to float8in_internal(). Updated the code to use
the new mechanism.

https://github.com/postgres/postgres/commit/ccff2d20e

---

[PG16: Include guc header to use GetConfigOptionByName](https://github.com/timescale/timescaledb/commit/af11870c762093253f7d30450c7b470f0796ecfa) 

https://github.com/postgres/postgres/commit/0a20ff54f5

---

[PG16: Align GUC variables initial value with boot values](https://github.com/timescale/timescaledb/commit/1a9098e5926f3cb6e52cd1fc148d5ed8fca9fbed) 

Any value hardcoded to a GUC variable will be overwritten by the
boot_value when the GUC mechanism starts up. PG16 makes this more clear
by checking that if a hardcoded value exists, it is same as the
boot_value. The server asserts in debug builds if values are not equal.

Commit https://github.com/timescale/timescaledb/commit/09636092714bbff8689d8d37c3965b99bee0db26 already fixes most of our code to align the hardcoded
and boot_values for various GUC variables. This patch updates only the
ts_guc_max_cached_chunks_per_hypertable initialisation which
had an initial value different from the boot_value.

https://github.com/postgres/postgres/commit/a73952b79

---

Disable-check: force-changelog-file
Disable-check: commit-count