### PR TITLE
PG16: Datum macros are now inline functions

### DIFF
--- a/src/compression_with_clause.c
+++ b/src/compression_with_clause.c
@@ -25,7 +25,7 @@ static const WithClauseDefinition compress_hypertable_with_clause_def[] = {
 		[CompressEnabled] = {
 			.arg_name = "compress",
 			.type_id = BOOLOID,
-			.default_val = BoolGetDatum(false),
+			.default_val = (Datum)false,
 		},
 		[CompressSegmentBy] = {
 			 .arg_name = "compress_segmentby",

--- a/src/process_utility.c
+++ b/src/process_utility.c
@@ -2612,7 +2612,7 @@ static const WithClauseDefinition index_with_clauses[] = {
 	[HypertableIndexFlagMultiTransaction] = {.arg_name = "transaction_per_chunk", .type_id = BOOLOID,},
 #ifdef DEBUG
 	[HypertableIndexFlagBarrierTable] = {.arg_name = "barrier_table", .type_id = REGCLASSOID,},
-	[HypertableIndexFlagMaxChunks] = {.arg_name = "max_chunks", .type_id = INT4OID, .default_val = Int32GetDatum(-1)},
+	[HypertableIndexFlagMaxChunks] = {.arg_name = "max_chunks", .type_id = INT4OID, .default_val = (Datum)-1},
 #endif
 };
 

--- a/src/ts_catalog/continuous_agg.c
+++ b/src/ts_catalog/continuous_agg.c
@@ -48,17 +48,17 @@ static const WithClauseDefinition continuous_aggregate_with_clause_def[] = {
 		[ContinuousEnabled] = {
 			.arg_name = "continuous",
 			.type_id = BOOLOID,
-			.default_val = BoolGetDatum(false),
+			.default_val = (Datum)false,
 		},
 		[ContinuousViewOptionCreateGroupIndex] = {
 			.arg_name = "create_group_indexes",
 			.type_id = BOOLOID,
-			.default_val = BoolGetDatum(true),
+			.default_val = (Datum)true,
 		},
 		[ContinuousViewOptionMaterializedOnly] = {
 			.arg_name = "materialized_only",
 			.type_id = BOOLOID,
-			.default_val = BoolGetDatum(false),
+			.default_val = (Datum)false,
 		},
 		[ContinuousViewOptionCompress] = {
 			.arg_name = "compress",
@@ -67,7 +67,7 @@ static const WithClauseDefinition continuous_aggregate_with_clause_def[] = {
 		[ContinuousViewOptionFinalized] = {
 			.arg_name = "finalized",
 			.type_id = BOOLOID,
-			.default_val = BoolGetDatum(true),
+			.default_val = (Datum)true,
 		},
 		[ContinuousViewOptionCompressSegmentBy] = {
 			 .arg_name = "compress_segmentby",

--- a/test/src/telemetry/test_telemetry.c
+++ b/test/src/telemetry/test_telemetry.c
@@ -128,7 +128,7 @@ ts_test_status(PG_FUNCTION_ARGS)
 	int port = 80;
 	int status = PG_GETARG_INT32(0);
 
-	PG_RETURN_JSONB_P(test_factory(CONNECTION_PLAIN, status, TEST_ENDPOINT, port));
+	PG_RETURN_JSONB_P((void *) test_factory(CONNECTION_PLAIN, status, TEST_ENDPOINT, port));
 }
 
 #ifdef TS_DEBUG
@@ -141,7 +141,7 @@ ts_test_status_mock(PG_FUNCTION_ARGS)
 
 	test_string = text_to_cstring(arg1);
 
-	PG_RETURN_JSONB_P(test_factory(CONNECTION_MOCK, 123, TEST_ENDPOINT, port));
+	PG_RETURN_JSONB_P((void *) test_factory(CONNECTION_MOCK, 123, TEST_ENDPOINT, port));
 }
 #endif
 
@@ -269,5 +269,5 @@ ts_test_telemetry(PG_FUNCTION_ARGS)
 
 	ts_http_response_state_destroy(rsp);
 
-	PG_RETURN_JSONB_P(json_body);
+	PG_RETURN_JSONB_P((void *) json_body);
 }

--- a/test/src/test_with_clause_parser.c
+++ b/test/src/test_with_clause_parser.c
@@ -186,7 +186,7 @@ static WithClauseDefinition test_args[] = {
 	[TestArgInt32] = { .arg_name = "int32", .type_id = INT4OID, },
 	[TestArgDefault] = { .arg_name = "default",
 						 .type_id = INT4OID,
-						 .default_val = Int32GetDatum(-100) },
+						 .default_val = (Datum)-100 },
 	[TestArgName] = { .arg_name = "name", .type_id = NAMEOID, },
 	[TestArgRegclass] = { .arg_name = "regclass",
 						  .type_id = REGCLASSOID },

--- a/tsl/test/src/test_compression.c
+++ b/tsl/test/src/test_compression.c
@@ -550,9 +550,11 @@ test_delta3(bool have_nulls, bool have_random)
 
 	/* Forward decompression. */
 	DecompressionIterator *iter =
-		delta_delta_decompression_iterator_from_datum_forward(PointerGetDatum(compressed), INT8OID);
-	ArrowArray *bulk_result =
-		delta_delta_decompress_all(PointerGetDatum(compressed), INT8OID, CurrentMemoryContext);
+		delta_delta_decompression_iterator_from_datum_forward(PointerGetDatum((void *) compressed),
+															  INT8OID);
+	ArrowArray *bulk_result = delta_delta_decompress_all(PointerGetDatum((void *) compressed),
+														 INT8OID,
+														 CurrentMemoryContext);
 	for (int i = 0; i < TEST_ELEMENTS; i++)
 	{
 		DecompressResult r = delta_delta_decompression_iterator_try_next_forward(iter);
@@ -575,7 +577,8 @@ test_delta3(bool have_nulls, bool have_random)
 
 	/* Reverse decompression. */
 	iter =
-		delta_delta_decompression_iterator_from_datum_reverse(PointerGetDatum(compressed), INT8OID);
+		delta_delta_decompression_iterator_from_datum_reverse(PointerGetDatum((void *) compressed),
+															  INT8OID);
 	for (int i = TEST_ELEMENTS - 1; i >= 0; i--)
 	{
 		DecompressResult r = delta_delta_decompression_iterator_try_next_reverse(iter);


### PR DESCRIPTION
PG16 converted the *GetDatum() and DatumGet*() macros to inline functions. This doesn't affect most of our code but a few places like struct object initialisations cannot use inline functions. This commit updates all the places affected by this change.

postgres/postgres@c8b2ef05

Disable-check: force-changelog-file