### PR TITLE
Place data in first/last function in correct mctx

### DIFF
--- a/.unreleased/bugfix_5990
+++ b/.unreleased/bugfix_5990
@@ -1,0 +1,1 @@
+Fixes: #5990 Place data in first/last function in correct mctx 

--- a/test/expected/agg_bookends.out
+++ b/test/expected/agg_bookends.out
@@ -1500,3 +1500,42 @@ ROLLBACK;
  (1 row)
  
             time           | gp | temp 
+-- Test partial aggregation
+CREATE TABLE partial_aggregation (time timestamptz NOT NULL, quantity numeric, longvalue text);
+SELECT schema_name, table_name, created FROM create_hypertable('partial_aggregation', 'time');
+ schema_name |     table_name      | created 
+-------------+---------------------+---------
+ public      | partial_aggregation | t
+(1 row)
+
+INSERT INTO partial_aggregation VALUES('2018-01-20T09:00:43', NULL, NULL);
+INSERT INTO partial_aggregation VALUES('2018-01-20T09:00:43', NULL, NULL);
+INSERT INTO partial_aggregation VALUES('2019-01-20T09:00:43', 1, 'Hello');
+INSERT INTO partial_aggregation VALUES('2019-01-20T09:00:43', 2, 'World');
+-- Use enable_partitionwise_aggregate to create partial aggregates per chunk
+SET enable_partitionwise_aggregate = ON;
+SELECT first(time, quantity) FROM partial_aggregation;
+            first             
+------------------------------
+ Sun Jan 20 09:00:43 2019 PST
+(1 row)
+
+SELECT last(time, quantity) FROM partial_aggregation;
+             last             
+------------------------------
+ Sun Jan 20 09:00:43 2019 PST
+(1 row)
+
+SELECT first(longvalue, quantity) FROM partial_aggregation;
+ first 
+-------
+ Hello
+(1 row)
+
+SELECT last(longvalue, quantity) FROM partial_aggregation;
+ last  
+-------
+ World
+(1 row)
+
+SET enable_partitionwise_aggregate = OFF;

--- a/test/sql/agg_bookends.sql
+++ b/test/sql/agg_bookends.sql
@@ -31,3 +31,21 @@ SET timescaledb.enable_optimizations TO true;
 \o
 
 :DIFF_CMD
+
+-- Test partial aggregation
+CREATE TABLE partial_aggregation (time timestamptz NOT NULL, quantity numeric, longvalue text);
+SELECT schema_name, table_name, created FROM create_hypertable('partial_aggregation', 'time');
+
+INSERT INTO partial_aggregation VALUES('2018-01-20T09:00:43', NULL, NULL);
+INSERT INTO partial_aggregation VALUES('2018-01-20T09:00:43', NULL, NULL);
+INSERT INTO partial_aggregation VALUES('2019-01-20T09:00:43', 1, 'Hello');
+INSERT INTO partial_aggregation VALUES('2019-01-20T09:00:43', 2, 'World');
+
+-- Use enable_partitionwise_aggregate to create partial aggregates per chunk
+SET enable_partitionwise_aggregate = ON;
+SELECT first(time, quantity) FROM partial_aggregation;
+SELECT last(time, quantity) FROM partial_aggregation;
+SELECT first(longvalue, quantity) FROM partial_aggregation;
+SELECT last(longvalue, quantity) FROM partial_aggregation;
+SET enable_partitionwise_aggregate = OFF;
+


### PR DESCRIPTION
So far, the `ts_bookend_deserializefunc()` function has allocated the deserialized data in the current memory context. This data could be removed before the aggregation is finished. This patch moves the data into the aggregation memory context.