### PR TITLE
Exclude PRs from bugs project board

### DIFF
--- a/.github/workflows/procedural.yaml
+++ b/.github/workflows/procedural.yaml
@@ -9,6 +9,10 @@ name: Add bugs to bugs project
 jobs:
   add-to-project:
     name: Add issue to project
+    # issue_comment is triggered when commenting on both issues and
+    # pull requests. To avoid adding pull requests to the bug board,
+    # filter out pull requests
+    if: ${{ !github.event.issue.pull_request }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/add-to-project@v0.4.0


### PR DESCRIPTION
An `issue_comment` event is triggered by comments on both issues and PRs. However, the bugs project workflow did not filter out pull requests when the `issue_comment` event happened, so pull requests were also added to the bugs project board.

Add a conditional that filters out pull requests so that only issues are added to the board.

Disable-check: force-changelog-file