### PR TITLE
Remove _timescaledb_internal.get_time_type

### DIFF
--- a/sql/partitioning.sql
+++ b/sql/partitioning.sql
@@ -11,6 +11,3 @@ CREATE OR REPLACE FUNCTION _timescaledb_internal.get_partition_hash(val anyeleme
     RETURNS int
     AS '@MODULE_PATHNAME@', 'ts_get_partition_hash' LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
-CREATE OR REPLACE FUNCTION _timescaledb_internal.get_time_type(hypertable_id INTEGER)
-    RETURNS OID
-    AS '@MODULE_PATHNAME@', 'ts_hypertable_get_time_type' LANGUAGE C STABLE STRICT;

--- a/sql/updates/latest-dev.sql
+++ b/sql/updates/latest-dev.sql
@@ -88,3 +88,6 @@ ALTER FUNCTION _timescaledb_internal.generate_uuid() SET SCHEMA _timescaledb_fun
 ALTER FUNCTION _timescaledb_internal.get_git_commit() SET SCHEMA _timescaledb_functions;
 ALTER FUNCTION _timescaledb_internal.get_os_info() SET SCHEMA _timescaledb_functions;
 ALTER FUNCTION _timescaledb_internal.tsl_loaded() SET SCHEMA _timescaledb_functions;
+
+DROP FUNCTION IF EXISTS _timescaledb_internal.get_time_type(integer);
+

--- a/src/hypertable.c
+++ b/src/hypertable.c
@@ -390,28 +390,6 @@ ts_hypertable_relid_to_id(Oid relid)
 	return result;
 }
 
-TS_FUNCTION_INFO_V1(ts_hypertable_get_time_type);
-Datum
-ts_hypertable_get_time_type(PG_FUNCTION_ARGS)
-{
-	int32 hypertable_id = PG_GETARG_INT32(0);
-	Cache *hcache = ts_hypertable_cache_pin();
-	Hypertable *ht = ts_hypertable_cache_get_entry_by_id(hcache, hypertable_id);
-	const Dimension *time_dimension;
-	Oid time_type;
-	if (ht == NULL)
-		PG_RETURN_NULL();
-	time_dimension = hyperspace_get_open_dimension(ht->space, 0);
-	if (time_dimension == NULL)
-		PG_RETURN_NULL();
-	/* This is deliberately column_type not partitioning_type, as that is how
-	 * the SQL function is defined
-	 */
-	time_type = time_dimension->fd.column_type;
-	ts_cache_release(hcache);
-	PG_RETURN_OID(time_type);
-}
-
 static bool
 hypertable_is_compressed_or_materialization(const Hypertable *ht)
 {

--- a/tsl/test/shared/expected/extension.out
+++ b/tsl/test/shared/expected/extension.out
@@ -113,7 +113,6 @@ ORDER BY pronamespace::regnamespace::text COLLATE "C", p.oid::regprocedure::text
  _timescaledb_internal.get_compressed_chunk_index_for_recompression(regclass)
  _timescaledb_internal.get_partition_for_key(anyelement)
  _timescaledb_internal.get_partition_hash(anyelement)
- _timescaledb_internal.get_time_type(integer)
  _timescaledb_internal.health()
  _timescaledb_internal.hypertable_constraint_add_table_fk_constraint(name,name,name,integer)
  _timescaledb_internal.hypertable_invalidation_log_delete(integer)


### PR DESCRIPTION
This function was used in an old version of a cagg informational view that was removed but the function itself was left in.

Disable-check: force-changelog-file
