### PR TITLE
Reread the catalog data after locking the chunk

### DIFF
--- a/.github/workflows/sanitizer-build-and-test.yaml
+++ b/.github/workflows/sanitizer-build-and-test.yaml
@@ -8,6 +8,7 @@ name: Sanitizer test
     branches:
       - main
       - prerelease_test
+      - trigger/sanitizer
   pull_request:
     paths: .github/workflows/sanitizer-build-and-test.yaml
 

--- a/src/planner/planner.c
+++ b/src/planner/planner.c
@@ -1320,10 +1320,6 @@ timescaledb_get_relation_info_hook(PlannerInfo *root, Oid relation_objectid, boo
 
 				if (chunk->fd.compressed_chunk_id != INVALID_CHUNK_ID)
 				{
-					Relation uncompressed_chunk = table_open(relation_objectid, NoLock);
-
-					ts_get_private_reloptinfo(rel)->compressed = true;
-
 					/* Planning indexes is expensive, and if this is a fully compressed chunk, we
 					 * know we'll never need to use indexes on the uncompressed version, since
 					 * all the data is in the compressed chunk anyway. Therefore, it is much
@@ -1334,7 +1330,6 @@ timescaledb_get_relation_info_hook(PlannerInfo *root, Oid relation_objectid, boo
 					 */
 					if (!ts_chunk_is_partial(chunk))
 						rel->indexlist = NIL;
-					table_close(uncompressed_chunk, NoLock);
 				}
 			}
 			break;

--- a/src/planner/planner.h
+++ b/src/planner/planner.h
@@ -33,7 +33,6 @@ typedef struct TimescaleDBPrivate
 	/* attno of the time dimension in the parent table if appends are ordered */
 	int order_attno;
 	List *nested_oids;
-	bool compressed;
 	List *chunk_oids;
 	List *serverids;
 	Relids server_relids;

--- a/test/isolation/expected/concurrent_query_and_drop_chunks.out
+++ b/test/isolation/expected/concurrent_query_and_drop_chunks.out
@@ -8,7 +8,7 @@ Fri Jan 03 10:30:00 2020 PST|     1|   1
 Sun Jan 03 10:30:00 2021 PST|     2|   2
 (2 rows)
 
-step s1_wp_enable: SELECT debug_waitpoint_enable('expanded_chunks');
+step s1_wp_enable: SELECT debug_waitpoint_enable('hypertable_expansion_before_lock_chunk');
 debug_waitpoint_enable
 ----------------------
                       
@@ -21,7 +21,7 @@ count
     1
 (1 row)
 
-step s1_wp_release: SELECT debug_waitpoint_release('expanded_chunks');
+step s1_wp_release: SELECT debug_waitpoint_release('hypertable_expansion_before_lock_chunk');
 debug_waitpoint_release
 -----------------------
                        

--- a/test/isolation/specs/concurrent_query_and_drop_chunks.spec
+++ b/test/isolation/specs/concurrent_query_and_drop_chunks.spec
@@ -19,9 +19,9 @@ teardown {
 # acqurired, the chunk should also be ignored.
 
 session "s1"
-step "s1_wp_enable"           { SELECT debug_waitpoint_enable('expanded_chunks'); }
-step "s1_wp_release"      { SELECT debug_waitpoint_release('expanded_chunks'); }
-step "s1_drop_chunks"	{ SELECT count(*) FROM drop_chunks('measurements', TIMESTAMPTZ '2020-03-01'); }
+step "s1_wp_enable" { SELECT debug_waitpoint_enable('hypertable_expansion_before_lock_chunk'); }
+step "s1_wp_release" { SELECT debug_waitpoint_release('hypertable_expansion_before_lock_chunk'); }
+step "s1_drop_chunks" { SELECT count(*) FROM drop_chunks('measurements', TIMESTAMPTZ '2020-03-01'); }
 
 session "s2"
 step "s2_show_num_chunks"  { SELECT count(*) FROM show_chunks('measurements') ORDER BY 1; }

--- a/tsl/src/planner.c
+++ b/tsl/src/planner.c
@@ -125,7 +125,7 @@ tsl_set_rel_pathlist_query(PlannerInfo *root, RelOptInfo *rel, Index rti, RangeT
 	if (ts_guc_enable_transparent_decompression && ht &&
 		(rel->reloptkind == RELOPT_OTHER_MEMBER_REL ||
 		 (rel->reloptkind == RELOPT_BASEREL && ts_rte_is_marked_for_expansion(rte))) &&
-		TS_HYPERTABLE_HAS_COMPRESSION_TABLE(ht) && fdw_private != NULL && fdw_private->compressed)
+		TS_HYPERTABLE_HAS_COMPRESSION_TABLE(ht))
 	{
 		if (fdw_private->cached_chunk_struct == NULL)
 		{

--- a/tsl/test/isolation/expected/concurrent_decompress_update.out
+++ b/tsl/test/isolation/expected/concurrent_decompress_update.out
@@ -1,0 +1,38 @@
+Parsed test spec with 2 sessions
+
+starting permutation: s2_explain_update s1_begin s1_decompress s2_explain_update s1_commit s2_explain_update
+compression_status
+------------------
+Compressed        
+(1 row)
+
+step s2_explain_update: 
+    UPDATE sensor_data SET cpu = cpu + 1 WHERE cpu = 0.1111111;
+
+step s1_begin: 
+  BEGIN;
+
+step s1_decompress: 
+   SELECT count(*) FROM (SELECT decompress_chunk(i, if_compressed => true) FROM show_chunks('sensor_data') i) i;
+   SELECT compression_status FROM chunk_compression_stats('sensor_data');
+
+count
+-----
+    1
+(1 row)
+
+compression_status
+------------------
+Uncompressed      
+(1 row)
+
+step s2_explain_update: 
+    UPDATE sensor_data SET cpu = cpu + 1 WHERE cpu = 0.1111111;
+ <waiting ...>
+step s1_commit: 
+  COMMIT;
+
+step s2_explain_update: <... completed>
+step s2_explain_update: 
+    UPDATE sensor_data SET cpu = cpu + 1 WHERE cpu = 0.1111111;
+

--- a/tsl/test/isolation/specs/CMakeLists.txt
+++ b/tsl/test/isolation/specs/CMakeLists.txt
@@ -18,6 +18,10 @@ list(
   cagg_concurrent_refresh_dist_ht.spec
   deadlock_drop_chunks_compress.spec)
 
+if(PG_VERSION VERSION_GREATER_EQUAL "14.0")
+  list(APPEND TEST_FILES concurrent_decompress_update.spec)
+endif()
+
 if(CMAKE_BUILD_TYPE MATCHES Debug)
   list(APPEND TEST_TEMPLATES_MODULE ${TEST_TEMPLATES_MODULE_DEBUG})
   list(

--- a/tsl/test/isolation/specs/concurrent_decompress_update.spec
+++ b/tsl/test/isolation/specs/concurrent_decompress_update.spec
@@ -67,10 +67,12 @@ step "s1_commit" {
 
 session "s2"
 
-step "s2_read_sensor_data" {
-   SELECT FROM sensor_data;
-   SELECT compression_status FROM chunk_compression_stats('sensor_data');
+step "s2_explain_update" {
+    UPDATE sensor_data SET cpu = cpu + 1 WHERE cpu = 0.1111111;
 }
 
-permutation "s2_read_sensor_data" "s1_begin" "s1_decompress" "s2_read_sensor_data" "s1_commit" "s2_read_sensor_data"
+# UPDATE/DELETE queries don't use TimescaleDB hypertable expansion, and use the
+# Postgres expansion code, which might have different locking behavior. Test it
+# as well.
+permutation "s2_explain_update" "s1_begin" "s1_decompress" "s2_explain_update" "s1_commit" "s2_explain_update"
 


### PR DESCRIPTION
The compression status can change, and this is prevented by locking, so to keep our data consistent, we should reread the chunk metadata after we have locked it. Currently we have some code in place that masks this inconsistency by rereading the metadata in another place. This code is removed.

Disable-check: force-changelog-file