### PR TITLE
Move scheduler functions to _timescaledb_functions schema

### DIFF
--- a/sql/bgw_scheduler.sql
+++ b/sql/bgw_scheduler.sql
@@ -2,17 +2,17 @@
 -- Please see the included NOTICE for copyright information and
 -- LICENSE-APACHE for a copy of the license.
 
-CREATE OR REPLACE FUNCTION _timescaledb_internal.restart_background_workers()
+CREATE OR REPLACE FUNCTION _timescaledb_functions.restart_background_workers()
 RETURNS BOOL
 AS '@LOADER_PATHNAME@', 'ts_bgw_db_workers_restart'
 LANGUAGE C VOLATILE;
 
-CREATE OR REPLACE FUNCTION _timescaledb_internal.stop_background_workers()
+CREATE OR REPLACE FUNCTION _timescaledb_functions.stop_background_workers()
 RETURNS BOOL
 AS '@LOADER_PATHNAME@', 'ts_bgw_db_workers_stop'
 LANGUAGE C VOLATILE;
 
-CREATE OR REPLACE FUNCTION _timescaledb_internal.start_background_workers()
+CREATE OR REPLACE FUNCTION _timescaledb_functions.start_background_workers()
 RETURNS BOOL
 AS '@LOADER_PATHNAME@', 'ts_bgw_db_workers_start'
 LANGUAGE C VOLATILE;

--- a/sql/bgw_startup.sql
+++ b/sql/bgw_startup.sql
@@ -2,4 +2,4 @@
 -- Please see the included NOTICE for copyright information and
 -- LICENSE-APACHE for a copy of the license.
 
-SELECT _timescaledb_internal.restart_background_workers();
+SELECT _timescaledb_functions.restart_background_workers();

--- a/sql/job_api.sql
+++ b/sql/job_api.sql
@@ -37,7 +37,7 @@ next_start TIMESTAMPTZ, check_config TEXT, fixed_schedule BOOL, initial_start TI
 AS '@MODULE_PATHNAME@', 'ts_job_alter'
 LANGUAGE C VOLATILE;
 
-CREATE OR REPLACE FUNCTION _timescaledb_internal.alter_job_set_hypertable_id(
+CREATE OR REPLACE FUNCTION _timescaledb_functions.alter_job_set_hypertable_id(
     job_id INTEGER,
     hypertable REGCLASS )
 RETURNS INTEGER AS '@MODULE_PATHNAME@', 'ts_job_alter_set_hypertable_id'

--- a/sql/restoring.sql
+++ b/sql/restoring.sql
@@ -10,7 +10,7 @@ BEGIN
     SELECT current_database() INTO db;
     EXECUTE format($$ALTER DATABASE %I SET timescaledb.restoring ='on'$$, db);
     SET SESSION timescaledb.restoring = 'on';
-    PERFORM _timescaledb_internal.stop_background_workers();
+    PERFORM _timescaledb_functions.stop_background_workers();
     --exported uuid may be included in the dump so backup the version
     UPDATE _timescaledb_catalog.metadata SET key='exported_uuid_bak' WHERE key='exported_uuid';
     RETURN true;
@@ -28,7 +28,7 @@ BEGIN
     EXECUTE format($$ALTER DATABASE %I RESET timescaledb.restoring $$, db);
     -- we cannot use reset here because the reset_val might not be off
     SET timescaledb.restoring TO off;
-    PERFORM _timescaledb_internal.restart_background_workers();
+    PERFORM _timescaledb_functions.restart_background_workers();
 
     --try to restore the backed up uuid, if the restore did not set one
     INSERT INTO _timescaledb_catalog.metadata

--- a/sql/updates/pre-update.sql
+++ b/sql/updates/pre-update.sql
@@ -26,12 +26,17 @@ DROP TRIGGER IF EXISTS "0_cache_inval" ON _timescaledb_catalog.chunk_constraint;
 DROP TRIGGER IF EXISTS "0_cache_inval" ON _timescaledb_catalog.dimension_slice;
 DROP TRIGGER IF EXISTS "0_cache_inval" ON _timescaledb_catalog.dimension;
 
-CREATE OR REPLACE FUNCTION _timescaledb_internal.restart_background_workers()
+-- Since we want to call the new version of restart_background_workers we
+-- create a function that points to that version. The proper restart_background_workers
+-- may either be in _timescaledb_internal or in _timescaledb_functions
+-- depending on the version we are upgrading from and we can't make
+-- the move in this location as the new schema might not have been set up.
+CREATE FUNCTION _timescaledb_internal._tmp_restart_background_workers()
 RETURNS BOOL
 AS '@LOADER_PATHNAME@', 'ts_bgw_db_workers_restart'
 LANGUAGE C VOLATILE;
-
-SELECT _timescaledb_internal.restart_background_workers();
+SELECT _timescaledb_internal._tmp_restart_background_workers();
+DROP FUNCTION _timescaledb_internal._tmp_restart_background_workers();
 
 -- Table for ACL and initprivs of tables.
 CREATE TABLE _timescaledb_internal.saved_privs(

--- a/sql/updates/reverse-dev.sql
+++ b/sql/updates/reverse-dev.sql
@@ -119,3 +119,11 @@ ALTER PROCEDURE _timescaledb_functions.cagg_migrate_execute_override_cagg(_times
 ALTER PROCEDURE _timescaledb_functions.cagg_migrate_execute_drop_old_cagg(_timescaledb_catalog.continuous_agg, _timescaledb_catalog.continuous_agg_migrate_plan_step) SET SCHEMA _timescaledb_internal;
 ALTER PROCEDURE _timescaledb_functions.cagg_migrate_execute_plan(_timescaledb_catalog.continuous_agg) SET SCHEMA _timescaledb_internal;
 
+-- pre-update of previous version will have created an additional copy of restart_background_workers
+-- since restart_background_workers was handled differently from other functions in previous versions
+DROP FUNCTION _timescaledb_internal.restart_background_workers();
+ALTER FUNCTION _timescaledb_functions.start_background_workers() SET SCHEMA _timescaledb_internal;
+ALTER FUNCTION _timescaledb_functions.stop_background_workers() SET SCHEMA _timescaledb_internal;
+ALTER FUNCTION _timescaledb_functions.restart_background_workers() SET SCHEMA _timescaledb_internal;
+ALTER FUNCTION _timescaledb_functions.alter_job_set_hypertable_id(integer,regclass) SET SCHEMA _timescaledb_internal;
+

--- a/test/expected/bgw_launcher.out
+++ b/test/expected/bgw_launcher.out
@@ -4,7 +4,7 @@
 \set TEST_DBNAME_2 :TEST_DBNAME _2
 \c :TEST_DBNAME :ROLE_SUPERUSER
 -- start bgw since they are stopped for tests by default
-SELECT _timescaledb_internal.start_background_workers();
+SELECT _timescaledb_functions.start_background_workers();
  start_background_workers 
 --------------------------
  t
@@ -107,7 +107,7 @@ WHERE application_name = 'TimescaleDB Background Worker Scheduler'
 AND datname = :'TEST_DBNAME_2' \gset
 -- We'll do this in a txn so that we can see that the worker locks on our txn before continuing
 BEGIN;
-SELECT _timescaledb_internal.restart_background_workers();
+SELECT _timescaledb_functions.restart_background_workers();
  restart_background_workers 
 ----------------------------
  t
@@ -146,7 +146,7 @@ AND datname = :'TEST_DBNAME_2';
 (1 row)
 
 -- Test stop
-SELECT _timescaledb_internal.stop_background_workers();
+SELECT _timescaledb_functions.stop_background_workers();
  stop_background_workers 
 -------------------------
  t
@@ -159,7 +159,7 @@ SELECT wait_worker_counts(1,0,0,0);
 (1 row)
 
 -- Make sure it doesn't break if we stop twice in a row
-SELECT _timescaledb_internal.stop_background_workers();
+SELECT _timescaledb_functions.stop_background_workers();
  stop_background_workers 
 -------------------------
  t
@@ -172,7 +172,7 @@ SELECT wait_worker_counts(1,0,0,0);
 (1 row)
 
 -- test start
-SELECT _timescaledb_internal.start_background_workers();
+SELECT _timescaledb_functions.start_background_workers();
  start_background_workers 
 --------------------------
  t
@@ -190,7 +190,7 @@ FROM pg_stat_activity
 WHERE application_name = 'TimescaleDB Background Worker Scheduler'
 AND datname = :'TEST_DBNAME_2' \gset
 -- Since we're doing idempotency tests, we're also going to exercise our queue and start 20 times
-SELECT _timescaledb_internal.start_background_workers() as start_background_workers, * FROM generate_series(1,20);
+SELECT _timescaledb_functions.start_background_workers() as start_background_workers, * FROM generate_series(1,20);
  start_background_workers | generate_series 
 --------------------------+-----------------
  t                        |               1
@@ -246,7 +246,7 @@ select wait_equals(:'orig_backend_start', :'TEST_DBNAME_2');
 (1 row)
 
 -- Make sure restart starts a worker even if it is stopped
-SELECT _timescaledb_internal.stop_background_workers();
+SELECT _timescaledb_functions.stop_background_workers();
  stop_background_workers 
 -------------------------
  t
@@ -258,7 +258,7 @@ SELECT wait_worker_counts(1,0,0,0);
  t
 (1 row)
 
-SELECT _timescaledb_internal.restart_background_workers();
+SELECT _timescaledb_functions.restart_background_workers();
  restart_background_workers 
 ----------------------------
  t
@@ -350,7 +350,7 @@ SELECT wait_worker_counts(1,0,0,0);
 
 -- Make sure a restart with restoring on first starts the background worker
 BEGIN;
-SELECT _timescaledb_internal.restart_background_workers();
+SELECT _timescaledb_functions.restart_background_workers();
  restart_background_workers 
 ----------------------------
  t

--- a/test/expected/pg_dump.out
+++ b/test/expected/pg_dump.out
@@ -321,7 +321,7 @@ SHOW timescaledb.restoring;
 
 -- timescaledb_post_restore restarts background worker so we have to stop them
 -- to make sure they dont interfere with this database being used as template below
-SELECT _timescaledb_internal.stop_background_workers();
+SELECT _timescaledb_functions.stop_background_workers();
  stop_background_workers 
 -------------------------
  t

--- a/test/sql/bgw_launcher.sql
+++ b/test/sql/bgw_launcher.sql
@@ -6,7 +6,7 @@
 \c :TEST_DBNAME :ROLE_SUPERUSER
 
 -- start bgw since they are stopped for tests by default
-SELECT _timescaledb_internal.start_background_workers();
+SELECT _timescaledb_functions.start_background_workers();
 
 CREATE DATABASE :TEST_DBNAME_2;
 
@@ -37,7 +37,7 @@ WHERE application_name = 'TimescaleDB Background Worker Scheduler'
 AND datname = :'TEST_DBNAME_2' \gset
 -- We'll do this in a txn so that we can see that the worker locks on our txn before continuing
 BEGIN;
-SELECT _timescaledb_internal.restart_background_workers();
+SELECT _timescaledb_functions.restart_background_workers();
 SELECT wait_worker_counts(1,0,1,0);
 
 SELECT (backend_start > :'orig_backend_start'::timestamptz) backend_start_changed,
@@ -54,15 +54,15 @@ WHERE application_name = 'TimescaleDB Background Worker Scheduler'
 AND datname = :'TEST_DBNAME_2';
 
 -- Test stop
-SELECT _timescaledb_internal.stop_background_workers();
+SELECT _timescaledb_functions.stop_background_workers();
 SELECT wait_worker_counts(1,0,0,0);
 
 -- Make sure it doesn't break if we stop twice in a row
-SELECT _timescaledb_internal.stop_background_workers();
+SELECT _timescaledb_functions.stop_background_workers();
 SELECT wait_worker_counts(1,0,0,0);
 
 -- test start
-SELECT _timescaledb_internal.start_background_workers();
+SELECT _timescaledb_functions.start_background_workers();
 SELECT wait_worker_counts(1,0,1,0);
 
 -- make sure start is idempotent
@@ -72,7 +72,7 @@ WHERE application_name = 'TimescaleDB Background Worker Scheduler'
 AND datname = :'TEST_DBNAME_2' \gset
 
 -- Since we're doing idempotency tests, we're also going to exercise our queue and start 20 times
-SELECT _timescaledb_internal.start_background_workers() as start_background_workers, * FROM generate_series(1,20);
+SELECT _timescaledb_functions.start_background_workers() as start_background_workers, * FROM generate_series(1,20);
 -- Here we're waiting to see if something shows up in pg_stat_activity,
 --  so we have to condition our loop in the opposite way. We'll only wait
 --  half a second in total as well so that tests don't take too long.
@@ -100,9 +100,9 @@ $BODY$;
 select wait_equals(:'orig_backend_start', :'TEST_DBNAME_2');
 
 -- Make sure restart starts a worker even if it is stopped
-SELECT _timescaledb_internal.stop_background_workers();
+SELECT _timescaledb_functions.stop_background_workers();
 SELECT wait_worker_counts(1,0,0,0);
-SELECT _timescaledb_internal.restart_background_workers();
+SELECT _timescaledb_functions.restart_background_workers();
 SELECT wait_worker_counts(1,0,1,0);
 
 -- Make sure drop extension statement restarts the worker and on rollback it keeps running
@@ -157,7 +157,7 @@ SELECT timescaledb_pre_restore();
 SELECT wait_worker_counts(1,0,0,0);
 -- Make sure a restart with restoring on first starts the background worker
 BEGIN;
-SELECT _timescaledb_internal.restart_background_workers();
+SELECT _timescaledb_functions.restart_background_workers();
 SELECT wait_worker_counts(1,0,1,0);
 COMMIT;
 -- Then the worker dies when it sees that restoring is on after the txn commits

--- a/test/sql/pg_dump.sql
+++ b/test/sql/pg_dump.sql
@@ -120,7 +120,7 @@ SELECT timescaledb_post_restore();
 SHOW timescaledb.restoring;
 -- timescaledb_post_restore restarts background worker so we have to stop them
 -- to make sure they dont interfere with this database being used as template below
-SELECT _timescaledb_internal.stop_background_workers();
+SELECT _timescaledb_functions.stop_background_workers();
 
 --should be same as count above
 SELECT count(*) = :num_dependent_objects as dependent_objects_match

--- a/test/sql/updates/pre.testing.sql
+++ b/test/sql/updates/pre.testing.sql
@@ -13,8 +13,13 @@ AS $$
 $$;
 
 CREATE OR REPLACE PROCEDURE _timescaledb_testing.stop_workers()
-LANGUAGE SQL
+LANGUAGE PLPGSQL
 AS $$
-   SELECT _timescaledb_internal.stop_background_workers();
+BEGIN
+   IF EXISTS (SELECT FROM pg_proc WHERE proname='stop_background_workers' AND pronamespace='_timescaledb_internal'::regnamespace)
+   THEN PERFORM _timescaledb_internal.stop_background_workers();
+   ELSE PERFORM _timescaledb_functions.stop_background_workers();
+   END IF;
+END
 $$;
 

--- a/test/sql/utils/testsupport.sql
+++ b/test/sql/utils/testsupport.sql
@@ -3,7 +3,7 @@
 -- LICENSE-APACHE for a copy of the license.
 
 
-SELECT _timescaledb_internal.stop_background_workers();
+SELECT _timescaledb_functions.stop_background_workers();
 
 CREATE SCHEMA IF NOT EXISTS test;
 GRANT USAGE ON SCHEMA test TO PUBLIC;

--- a/tsl/test/expected/bgw_custom.out
+++ b/tsl/test/expected/bgw_custom.out
@@ -344,7 +344,7 @@ SELECT add_job('custom_proc2', '1h', config := '{"type":"procedure"}'::jsonb, in
 SELECT add_job('custom_proc3', '1h', config := '{"type":"procedure"}'::jsonb, initial_start := now()) AS job_id_2 \gset
 \c :TEST_DBNAME :ROLE_SUPERUSER
 -- Start Background Workers
-SELECT _timescaledb_internal.start_background_workers();
+SELECT _timescaledb_functions.start_background_workers();
  start_background_workers 
 --------------------------
  t
@@ -538,7 +538,7 @@ SELECT count(*) FROM conditions_summary_daily;
 (1 row)
 
 -- TESTs for alter_job_set_hypertable_id API
-SELECT _timescaledb_internal.alter_job_set_hypertable_id( :job_id_5, NULL);
+SELECT _timescaledb_functions.alter_job_set_hypertable_id( :job_id_5, NULL);
  alter_job_set_hypertable_id 
 -----------------------------
                         1004
@@ -553,11 +553,11 @@ FROM _timescaledb_config.bgw_job WHERE id = :job_id_5;
 
 -- error case, try to associate with a PG relation
 \set ON_ERROR_STOP 0
-SELECT _timescaledb_internal.alter_job_set_hypertable_id( :job_id_5, 'custom_log');
+SELECT _timescaledb_functions.alter_job_set_hypertable_id( :job_id_5, 'custom_log');
 ERROR:  relation "custom_log" is not a hypertable or continuous aggregate
 \set ON_ERROR_STOP 1
 -- TEST associate the cagg with the job
-SELECT _timescaledb_internal.alter_job_set_hypertable_id( :job_id_5, 'conditions_summary_daily'::regclass);
+SELECT _timescaledb_functions.alter_job_set_hypertable_id( :job_id_5, 'conditions_summary_daily'::regclass);
  alter_job_set_hypertable_id 
 -----------------------------
                         1004
@@ -583,13 +583,13 @@ FROM _timescaledb_config.bgw_job WHERE id = :job_id_5;
 DROP TABLE conditions;
 DROP TABLE custom_log;
 -- Stop Background Workers
-SELECT _timescaledb_internal.stop_background_workers();
+SELECT _timescaledb_functions.stop_background_workers();
  stop_background_workers 
 -------------------------
  t
 (1 row)
 
-SELECT _timescaledb_internal.restart_background_workers();
+SELECT _timescaledb_functions.restart_background_workers();
  restart_background_workers 
 ----------------------------
  t
@@ -1031,7 +1031,7 @@ SELECT job_id, err_message
 (0 rows)
 
 -- cleanup
-SELECT _timescaledb_internal.stop_background_workers();
+SELECT _timescaledb_functions.stop_background_workers();
  stop_background_workers 
 -------------------------
  t

--- a/tsl/test/expected/bgw_db_scheduler.out
+++ b/tsl/test/expected/bgw_db_scheduler.out
@@ -1246,15 +1246,15 @@ SELECT * FROM sorted_bgw_log;
 -- Test updating jobs list
 TRUNCATE bgw_log;
 \set ON_ERROR_STOP 0
-SELECT _timescaledb_internal.stop_background_workers();
+SELECT _timescaledb_functions.stop_background_workers();
 ERROR:  must be superuser to stop background workers
-SELECT _timescaledb_internal.restart_background_workers();
+SELECT _timescaledb_functions.restart_background_workers();
 ERROR:  must be superuser to restart background workers
-SELECT _timescaledb_internal.start_background_workers();
+SELECT _timescaledb_functions.start_background_workers();
 ERROR:  must be superuser to start background workers
 \set ON_ERROR_STOP 1
 \c :TEST_DBNAME :ROLE_SUPERUSER
-SELECT _timescaledb_internal.stop_background_workers();
+SELECT _timescaledb_functions.stop_background_workers();
  stop_background_workers 
 -------------------------
  t
@@ -1663,7 +1663,7 @@ DELETE FROM _timescaledb_config.bgw_job WHERE id = :job_id;
 -- This should succeed
 DROP USER renamed_user;
 -- clean up jobs
-SELECT _timescaledb_internal.stop_background_workers();
+SELECT _timescaledb_functions.stop_background_workers();
  stop_background_workers 
 -------------------------
  t

--- a/tsl/test/expected/bgw_db_scheduler_fixed.out
+++ b/tsl/test/expected/bgw_db_scheduler_fixed.out
@@ -1244,15 +1244,15 @@ SELECT * FROM sorted_bgw_log;
 -- Test updating jobs list
 TRUNCATE bgw_log;
 \set ON_ERROR_STOP 0
-SELECT _timescaledb_internal.stop_background_workers();
+SELECT _timescaledb_functions.stop_background_workers();
 ERROR:  must be superuser to stop background workers
-SELECT _timescaledb_internal.restart_background_workers();
+SELECT _timescaledb_functions.restart_background_workers();
 ERROR:  must be superuser to restart background workers
-SELECT _timescaledb_internal.start_background_workers();
+SELECT _timescaledb_functions.start_background_workers();
 ERROR:  must be superuser to start background workers
 \set ON_ERROR_STOP 1
 \c :TEST_DBNAME :ROLE_SUPERUSER
-SELECT _timescaledb_internal.stop_background_workers();
+SELECT _timescaledb_functions.stop_background_workers();
  stop_background_workers 
 -------------------------
  t
@@ -1604,7 +1604,7 @@ SELECT * FROM _timescaledb_internal.bgw_job_stat;
 (1 row)
 
 -- clean up jobs
-SELECT _timescaledb_internal.stop_background_workers();
+SELECT _timescaledb_functions.stop_background_workers();
  stop_background_workers 
 -------------------------
  t

--- a/tsl/test/expected/cagg_dump.out
+++ b/tsl/test/expected/cagg_dump.out
@@ -151,7 +151,7 @@ SELECT timescaledb_post_restore();
  t
 (1 row)
 
-SELECT _timescaledb_internal.stop_background_workers();
+SELECT _timescaledb_functions.stop_background_workers();
  stop_background_workers 
 -------------------------
  t

--- a/tsl/test/expected/cagg_invalidation.out
+++ b/tsl/test/expected/cagg_invalidation.out
@@ -8,7 +8,7 @@
 -- LICENSE-TIMESCALE for a copy of the license.
 -- Disable background workers since we are testing manual refresh
 \c :TEST_DBNAME :ROLE_CLUSTER_SUPERUSER
-SELECT _timescaledb_internal.stop_background_workers();
+SELECT _timescaledb_functions.stop_background_workers();
  stop_background_workers 
 -------------------------
  t

--- a/tsl/test/expected/cagg_invalidation_dist_ht-13.out
+++ b/tsl/test/expected/cagg_invalidation_dist_ht-13.out
@@ -44,7 +44,7 @@ GRANT CREATE ON SCHEMA public TO :ROLE_DEFAULT_PERM_USER, :ROLE_DEFAULT_PERM_USE
 -- LICENSE-TIMESCALE for a copy of the license.
 -- Disable background workers since we are testing manual refresh
 \c :TEST_DBNAME :ROLE_CLUSTER_SUPERUSER
-SELECT _timescaledb_internal.stop_background_workers();
+SELECT _timescaledb_functions.stop_background_workers();
  stop_background_workers 
 -------------------------
  t

--- a/tsl/test/expected/cagg_invalidation_dist_ht-14.out
+++ b/tsl/test/expected/cagg_invalidation_dist_ht-14.out
@@ -44,7 +44,7 @@ GRANT CREATE ON SCHEMA public TO :ROLE_DEFAULT_PERM_USER, :ROLE_DEFAULT_PERM_USE
 -- LICENSE-TIMESCALE for a copy of the license.
 -- Disable background workers since we are testing manual refresh
 \c :TEST_DBNAME :ROLE_CLUSTER_SUPERUSER
-SELECT _timescaledb_internal.stop_background_workers();
+SELECT _timescaledb_functions.stop_background_workers();
  stop_background_workers 
 -------------------------
  t

--- a/tsl/test/expected/cagg_invalidation_dist_ht-15.out
+++ b/tsl/test/expected/cagg_invalidation_dist_ht-15.out
@@ -44,7 +44,7 @@ GRANT CREATE ON SCHEMA public TO :ROLE_DEFAULT_PERM_USER, :ROLE_DEFAULT_PERM_USE
 -- LICENSE-TIMESCALE for a copy of the license.
 -- Disable background workers since we are testing manual refresh
 \c :TEST_DBNAME :ROLE_CLUSTER_SUPERUSER
-SELECT _timescaledb_internal.stop_background_workers();
+SELECT _timescaledb_functions.stop_background_workers();
  stop_background_workers 
 -------------------------
  t

--- a/tsl/test/expected/cagg_policy.out
+++ b/tsl/test/expected/cagg_policy.out
@@ -610,7 +610,7 @@ $$
 $$;
  -- inject custom job
 SELECT add_job('custom_func','1h', config:='{"type":"function"}'::jsonb, initial_start => '2000-01-01 00:00:00+00'::timestamptz) AS job_id \gset
-SELECT _timescaledb_internal.alter_job_set_hypertable_id( :job_id, 'max_mat_view_date'::regclass);
+SELECT _timescaledb_functions.alter_job_set_hypertable_id( :job_id, 'max_mat_view_date'::regclass);
  alter_job_set_hypertable_id 
 -----------------------------
                         1027

--- a/tsl/test/expected/cagg_refresh.out
+++ b/tsl/test/expected/cagg_refresh.out
@@ -3,7 +3,7 @@
 -- LICENSE-TIMESCALE for a copy of the license.
 -- Disable background workers since we are testing manual refresh
 \c :TEST_DBNAME :ROLE_SUPERUSER
-SELECT _timescaledb_internal.stop_background_workers();
+SELECT _timescaledb_functions.stop_background_workers();
  stop_background_workers 
 -------------------------
  t

--- a/tsl/test/expected/cagg_union_view-13.out
+++ b/tsl/test/expected/cagg_union_view-13.out
@@ -3,7 +3,7 @@
 -- LICENSE-TIMESCALE for a copy of the license.
 -- disable background workers to make results reproducible
 \c :TEST_DBNAME :ROLE_SUPERUSER
-SELECT _timescaledb_internal.stop_background_workers();
+SELECT _timescaledb_functions.stop_background_workers();
  stop_background_workers 
 -------------------------
  t

--- a/tsl/test/expected/cagg_union_view-14.out
+++ b/tsl/test/expected/cagg_union_view-14.out
@@ -3,7 +3,7 @@
 -- LICENSE-TIMESCALE for a copy of the license.
 -- disable background workers to make results reproducible
 \c :TEST_DBNAME :ROLE_SUPERUSER
-SELECT _timescaledb_internal.stop_background_workers();
+SELECT _timescaledb_functions.stop_background_workers();
  stop_background_workers 
 -------------------------
  t

--- a/tsl/test/expected/cagg_union_view-15.out
+++ b/tsl/test/expected/cagg_union_view-15.out
@@ -3,7 +3,7 @@
 -- LICENSE-TIMESCALE for a copy of the license.
 -- disable background workers to make results reproducible
 \c :TEST_DBNAME :ROLE_SUPERUSER
-SELECT _timescaledb_internal.stop_background_workers();
+SELECT _timescaledb_functions.stop_background_workers();
  stop_background_workers 
 -------------------------
  t

--- a/tsl/test/expected/job_errors_permissions.out
+++ b/tsl/test/expected/job_errors_permissions.out
@@ -42,7 +42,7 @@ $$;
 -- to make sure custom_log is first updated by custom_proc_1
 select add_job('custom_proc2', '2 min', initial_start => now() + interval '5 seconds') as custom_proc2_id \gset
 SET ROLE :ROLE_SUPERUSER;
-SELECT _timescaledb_internal.start_background_workers();
+SELECT _timescaledb_functions.start_background_workers();
  start_background_workers 
 --------------------------
  t
@@ -106,7 +106,7 @@ FROM timescaledb_information.job_errors WHERE job_id >= 1000;
   22222 |             |              |            | job crash detected, see server logs
 (4 rows)
 
-SELECT _timescaledb_internal.stop_background_workers();
+SELECT _timescaledb_functions.stop_background_workers();
  stop_background_workers 
 -------------------------
  t

--- a/tsl/test/expected/scheduler_fixed.out
+++ b/tsl/test/expected/scheduler_fixed.out
@@ -53,7 +53,7 @@ select * from _timescaledb_internal.bgw_job_stat;
 select now() as initial_start \gset
 select add_job('job_5', schedule_interval => INTERVAL '15 seconds', initial_start => :'initial_start'::timestamptz) as short_job_fixed \gset
 select add_job('job_5', schedule_interval => INTERVAL '15 seconds', initial_start => :'initial_start'::timestamptz, fixed_schedule => false) as short_job_drifting \gset
-SELECT _timescaledb_internal.start_background_workers();
+SELECT _timescaledb_functions.start_background_workers();
  start_background_workers 
 --------------------------
  t

--- a/tsl/test/expected/troubleshooting_job_errors.out
+++ b/tsl/test/expected/troubleshooting_job_errors.out
@@ -75,7 +75,7 @@ select add_job('custom_proc2', '2 min', initial_start => now() + interval '5 sec
     1002
 (1 row)
 
-SELECT _timescaledb_internal.start_background_workers();
+SELECT _timescaledb_functions.start_background_workers();
  start_background_workers 
 --------------------------
  t

--- a/tsl/test/isolation/specs/cagg_concurrent_refresh.spec
+++ b/tsl/test/isolation/specs/cagg_concurrent_refresh.spec
@@ -14,7 +14,7 @@
 #
 setup
 {
-    SELECT _timescaledb_internal.stop_background_workers();
+    SELECT _timescaledb_functions.stop_background_workers();
 
     CREATE TABLE conditions(time int, temp float);
     SELECT create_hypertable('conditions', 'time', chunk_time_interval => 20);

--- a/tsl/test/isolation/specs/cagg_concurrent_refresh_dist_ht.spec
+++ b/tsl/test/isolation/specs/cagg_concurrent_refresh_dist_ht.spec
@@ -17,7 +17,7 @@ setup { SELECT node_name FROM add_data_node('data_node_3', host => 'localhost', 
 #
 setup
 {
-    SELECT _timescaledb_internal.stop_background_workers();
+    SELECT _timescaledb_functions.stop_background_workers();
     CREATE TABLE conditions(time int, temp float);
     SELECT create_distributed_hypertable('conditions', 'time', chunk_time_interval => 20, replication_factor => 2);
     INSERT INTO conditions

--- a/tsl/test/isolation/specs/cagg_insert.spec
+++ b/tsl/test/isolation/specs/cagg_insert.spec
@@ -4,7 +4,7 @@
 
 setup
 {
-    SELECT _timescaledb_internal.stop_background_workers();
+    SELECT _timescaledb_functions.stop_background_workers();
 
     CREATE TABLE ts_continuous_test_1(time INTEGER, location INTEGER);
     SELECT create_hypertable('ts_continuous_test_1', 'time', chunk_time_interval => 10);

--- a/tsl/test/isolation/specs/cagg_multi_dist_ht.spec
+++ b/tsl/test/isolation/specs/cagg_multi_dist_ht.spec
@@ -7,7 +7,7 @@ setup { SELECT node_name FROM add_data_node('data_node_2', host => 'localhost', 
 setup { SELECT node_name FROM add_data_node('data_node_3', host => 'localhost', database => 'cdrp_3', if_not_exists => true); }
 setup
 {
-    SELECT _timescaledb_internal.stop_background_workers();
+    SELECT _timescaledb_functions.stop_background_workers();
     CREATE TABLE ts_continuous_test(time INTEGER, val INTEGER);
     SELECT create_distributed_hypertable('ts_continuous_test', 'time', chunk_time_interval => 10, replication_factor => 2);
     CREATE OR REPLACE FUNCTION integer_now_test() returns INT LANGUAGE SQL STABLE as $$ SELECT coalesce(max(time), 0) FROM ts_continuous_test $$;

--- a/tsl/test/isolation/specs/cagg_multi_iso.spec
+++ b/tsl/test/isolation/specs/cagg_multi_iso.spec
@@ -4,7 +4,7 @@
 
 setup
 {
-    SELECT _timescaledb_internal.stop_background_workers();
+    SELECT _timescaledb_functions.stop_background_workers();
     CREATE TABLE ts_continuous_test(time INTEGER, val INTEGER);
     SELECT create_hypertable('ts_continuous_test', 'time', chunk_time_interval => 10);
     CREATE OR REPLACE FUNCTION integer_now_test() returns INT LANGUAGE SQL STABLE as $$ SELECT coalesce(max(time), 0) FROM ts_continuous_test $$;

--- a/tsl/test/shared/expected/extension.out
+++ b/tsl/test/shared/expected/extension.out
@@ -19,6 +19,7 @@ FROM pg_proc p
     e.oid = d.refobjid
 WHERE proname <> 'get_telemetry_report'
 ORDER BY pronamespace::regnamespace::text COLLATE "C", p.oid::regprocedure::text COLLATE "C";
+ _timescaledb_functions.alter_job_set_hypertable_id(integer,regclass)
  _timescaledb_functions.attach_osm_table_chunk(regclass,regclass)
  _timescaledb_functions.bookend_deserializefunc(bytea,internal)
  _timescaledb_functions.bookend_finalfunc(internal,anyelement,"any")
@@ -95,6 +96,7 @@ ORDER BY pronamespace::regnamespace::text COLLATE "C", p.oid::regprocedure::text
  _timescaledb_functions.range_value_to_pretty(bigint,regtype)
  _timescaledb_functions.relation_size(regclass)
  _timescaledb_functions.remote_txn_heal_data_node(oid)
+ _timescaledb_functions.restart_background_workers()
  _timescaledb_functions.rxid_in(cstring)
  _timescaledb_functions.rxid_out(rxid)
  _timescaledb_functions.set_chunk_default_data_node(regclass,name)
@@ -102,6 +104,8 @@ ORDER BY pronamespace::regnamespace::text COLLATE "C", p.oid::regprocedure::text
  _timescaledb_functions.set_peer_dist_id(uuid)
  _timescaledb_functions.show_chunk(regclass)
  _timescaledb_functions.show_connection_cache()
+ _timescaledb_functions.start_background_workers()
+ _timescaledb_functions.stop_background_workers()
  _timescaledb_functions.subtract_integer_from_now(regclass,bigint)
  _timescaledb_functions.time_to_internal(anyelement)
  _timescaledb_functions.to_date(bigint)
@@ -112,7 +116,6 @@ ORDER BY pronamespace::regnamespace::text COLLATE "C", p.oid::regprocedure::text
  _timescaledb_functions.tsl_loaded()
  _timescaledb_functions.unfreeze_chunk(regclass)
  _timescaledb_functions.validate_as_data_node()
- _timescaledb_internal.alter_job_set_hypertable_id(integer,regclass)
  _timescaledb_internal.cagg_watermark(integer)
  _timescaledb_internal.cagg_watermark_materialized(integer)
  _timescaledb_internal.chunk_constraint_add_table_constraint(_timescaledb_catalog.chunk_constraint)
@@ -141,9 +144,6 @@ ORDER BY pronamespace::regnamespace::text COLLATE "C", p.oid::regprocedure::text
  _timescaledb_internal.partialize_agg(anyelement)
  _timescaledb_internal.process_ddl_event()
  _timescaledb_internal.recompress_chunk_segmentwise(regclass,boolean)
- _timescaledb_internal.restart_background_workers()
- _timescaledb_internal.start_background_workers()
- _timescaledb_internal.stop_background_workers()
  _timescaledb_internal.wait_subscription_sync(name,name,integer,numeric)
  debug_waitpoint_enable(text)
  debug_waitpoint_id(text)

--- a/tsl/test/sql/bgw_custom.sql
+++ b/tsl/test/sql/bgw_custom.sql
@@ -206,7 +206,7 @@ SELECT add_job('custom_proc3', '1h', config := '{"type":"procedure"}'::jsonb, in
 
 \c :TEST_DBNAME :ROLE_SUPERUSER
 -- Start Background Workers
-SELECT _timescaledb_internal.start_background_workers();
+SELECT _timescaledb_functions.start_background_workers();
 
 -- Wait for jobs
 SELECT wait_for_job_to_run(:job_id_1, 1);
@@ -302,17 +302,17 @@ SELECT count(*) FROM conditions_summary_daily;
 
 -- TESTs for alter_job_set_hypertable_id API
 
-SELECT _timescaledb_internal.alter_job_set_hypertable_id( :job_id_5, NULL);
+SELECT _timescaledb_functions.alter_job_set_hypertable_id( :job_id_5, NULL);
 SELECT id, proc_name, hypertable_id
 FROM _timescaledb_config.bgw_job WHERE id = :job_id_5;
 
 -- error case, try to associate with a PG relation
 \set ON_ERROR_STOP 0
-SELECT _timescaledb_internal.alter_job_set_hypertable_id( :job_id_5, 'custom_log');
+SELECT _timescaledb_functions.alter_job_set_hypertable_id( :job_id_5, 'custom_log');
 \set ON_ERROR_STOP 1
 
 -- TEST associate the cagg with the job
-SELECT _timescaledb_internal.alter_job_set_hypertable_id( :job_id_5, 'conditions_summary_daily'::regclass);
+SELECT _timescaledb_functions.alter_job_set_hypertable_id( :job_id_5, 'conditions_summary_daily'::regclass);
 
 SELECT id, proc_name, hypertable_id
 FROM _timescaledb_config.bgw_job WHERE id = :job_id_5;
@@ -328,9 +328,9 @@ DROP TABLE conditions;
 DROP TABLE custom_log;
 
 -- Stop Background Workers
-SELECT _timescaledb_internal.stop_background_workers();
+SELECT _timescaledb_functions.stop_background_workers();
 
-SELECT _timescaledb_internal.restart_background_workers();
+SELECT _timescaledb_functions.restart_background_workers();
 
 \set ON_ERROR_STOP 0
 -- add test for custom jobs with custom check functions
@@ -683,7 +683,7 @@ SELECT job_id, err_message
   WHERE job_id IN (:job_id_1, :job_id_2, :job_id_3);
 
 -- cleanup
-SELECT _timescaledb_internal.stop_background_workers();
+SELECT _timescaledb_functions.stop_background_workers();
 CALL wait_for_job_status(:job_id_1, 'Scheduled');
 CALL wait_for_job_status(:job_id_2, 'Scheduled');
 CALL wait_for_job_status(:job_id_3, 'Scheduled');

--- a/tsl/test/sql/bgw_db_scheduler.sql
+++ b/tsl/test/sql/bgw_db_scheduler.sql
@@ -520,13 +520,13 @@ SELECT * FROM sorted_bgw_log;
 TRUNCATE bgw_log;
 
 \set ON_ERROR_STOP 0
-SELECT _timescaledb_internal.stop_background_workers();
-SELECT _timescaledb_internal.restart_background_workers();
-SELECT _timescaledb_internal.start_background_workers();
+SELECT _timescaledb_functions.stop_background_workers();
+SELECT _timescaledb_functions.restart_background_workers();
+SELECT _timescaledb_functions.start_background_workers();
 \set ON_ERROR_STOP 1
 
 \c :TEST_DBNAME :ROLE_SUPERUSER
-SELECT _timescaledb_internal.stop_background_workers();
+SELECT _timescaledb_functions.stop_background_workers();
 
 CREATE OR REPLACE FUNCTION ts_test_job_refresh() RETURNS TABLE(
 id INTEGER,
@@ -695,5 +695,5 @@ DELETE FROM _timescaledb_config.bgw_job WHERE id = :job_id;
 DROP USER renamed_user;
 
 -- clean up jobs
-SELECT _timescaledb_internal.stop_background_workers();
+SELECT _timescaledb_functions.stop_background_workers();
 

--- a/tsl/test/sql/bgw_db_scheduler_fixed.sql
+++ b/tsl/test/sql/bgw_db_scheduler_fixed.sql
@@ -531,13 +531,13 @@ SELECT * FROM sorted_bgw_log;
 TRUNCATE bgw_log;
 
 \set ON_ERROR_STOP 0
-SELECT _timescaledb_internal.stop_background_workers();
-SELECT _timescaledb_internal.restart_background_workers();
-SELECT _timescaledb_internal.start_background_workers();
+SELECT _timescaledb_functions.stop_background_workers();
+SELECT _timescaledb_functions.restart_background_workers();
+SELECT _timescaledb_functions.start_background_workers();
 \set ON_ERROR_STOP 1
 
 \c :TEST_DBNAME :ROLE_SUPERUSER
-SELECT _timescaledb_internal.stop_background_workers();
+SELECT _timescaledb_functions.stop_background_workers();
 
 CREATE OR REPLACE FUNCTION ts_test_job_refresh() RETURNS TABLE(
 id INTEGER,
@@ -677,7 +677,7 @@ SELECT * FROM sorted_bgw_log;
 SELECT * FROM _timescaledb_internal.bgw_job_stat;
 
 -- clean up jobs
-SELECT _timescaledb_internal.stop_background_workers();
+SELECT _timescaledb_functions.stop_background_workers();
 select delete_job(:job_id);
 -- test the new API with all its parameters: with timezone, without timezone
 TRUNCATE bgw_log;

--- a/tsl/test/sql/cagg_dump.sql
+++ b/tsl/test/sql/cagg_dump.sql
@@ -129,7 +129,7 @@ RESET client_min_messages;
 SELECT timescaledb_pre_restore();
 \! utils/pg_dump_aux_restore.sh dump/pg_dump.sql
 SELECT timescaledb_post_restore();
-SELECT _timescaledb_internal.stop_background_workers();
+SELECT _timescaledb_functions.stop_background_workers();
 
 \c :TEST_DBNAME :ROLE_DEFAULT_PERM_USER
 

--- a/tsl/test/sql/cagg_policy.sql
+++ b/tsl/test/sql/cagg_policy.sql
@@ -258,7 +258,7 @@ $$
 $$;
  -- inject custom job
 SELECT add_job('custom_func','1h', config:='{"type":"function"}'::jsonb, initial_start => '2000-01-01 00:00:00+00'::timestamptz) AS job_id \gset
-SELECT _timescaledb_internal.alter_job_set_hypertable_id( :job_id, 'max_mat_view_date'::regclass);
+SELECT _timescaledb_functions.alter_job_set_hypertable_id( :job_id, 'max_mat_view_date'::regclass);
 SELECT * FROM timescaledb_information.jobs WHERE job_id != 1 ORDER BY 1;
 SELECT timescaledb_experimental.remove_all_policies('max_mat_view_date', true); -- ignore custom job
 SELECT delete_job(:job_id);

--- a/tsl/test/sql/cagg_refresh.sql
+++ b/tsl/test/sql/cagg_refresh.sql
@@ -4,7 +4,7 @@
 
 -- Disable background workers since we are testing manual refresh
 \c :TEST_DBNAME :ROLE_SUPERUSER
-SELECT _timescaledb_internal.stop_background_workers();
+SELECT _timescaledb_functions.stop_background_workers();
 SET ROLE :ROLE_DEFAULT_PERM_USER;
 
 CREATE TABLE conditions (time timestamptz NOT NULL, device int, temp float);

--- a/tsl/test/sql/cagg_union_view.sql.in
+++ b/tsl/test/sql/cagg_union_view.sql.in
@@ -4,7 +4,7 @@
 
 -- disable background workers to make results reproducible
 \c :TEST_DBNAME :ROLE_SUPERUSER
-SELECT _timescaledb_internal.stop_background_workers();
+SELECT _timescaledb_functions.stop_background_workers();
 \c :TEST_DBNAME :ROLE_DEFAULT_PERM_USER
 
 \set PREFIX 'EXPLAIN (analyze, costs off, timing off, summary off)'

--- a/tsl/test/sql/include/cagg_invalidation_common.sql
+++ b/tsl/test/sql/include/cagg_invalidation_common.sql
@@ -4,7 +4,7 @@
 
 -- Disable background workers since we are testing manual refresh
 \c :TEST_DBNAME :ROLE_CLUSTER_SUPERUSER
-SELECT _timescaledb_internal.stop_background_workers();
+SELECT _timescaledb_functions.stop_background_workers();
 SET ROLE :ROLE_DEFAULT_PERM_USER;
 SET datestyle TO 'ISO, YMD';
 SET timezone TO 'UTC';

--- a/tsl/test/sql/job_errors_permissions.sql
+++ b/tsl/test/sql/job_errors_permissions.sql
@@ -48,7 +48,7 @@ $$;
 select add_job('custom_proc2', '2 min', initial_start => now() + interval '5 seconds') as custom_proc2_id \gset
 
 SET ROLE :ROLE_SUPERUSER;
-SELECT _timescaledb_internal.start_background_workers();
+SELECT _timescaledb_functions.start_background_workers();
 SELECT pg_sleep(20);
 
 \d timescaledb_information.job_errors
@@ -78,7 +78,7 @@ SET ROLE :ROLE_SUPERUSER;
 SELECT job_id, proc_schema, proc_name, sqlerrcode, err_message
 FROM timescaledb_information.job_errors WHERE job_id >= 1000;
 
-SELECT _timescaledb_internal.stop_background_workers();
+SELECT _timescaledb_functions.stop_background_workers();
 
 SELECT delete_job(:custom_proc2_id);
 SELECT delete_job(:custom_proc1_id);

--- a/tsl/test/sql/scheduler_fixed.sql
+++ b/tsl/test/sql/scheduler_fixed.sql
@@ -60,7 +60,7 @@ select now() as initial_start \gset
 select add_job('job_5', schedule_interval => INTERVAL '15 seconds', initial_start => :'initial_start'::timestamptz) as short_job_fixed \gset
 select add_job('job_5', schedule_interval => INTERVAL '15 seconds', initial_start => :'initial_start'::timestamptz, fixed_schedule => false) as short_job_drifting \gset
 
-SELECT _timescaledb_internal.start_background_workers();
+SELECT _timescaledb_functions.start_background_workers();
 
 select initial_start as initial_start_given from timescaledb_information.jobs where job_id = :short_job_fixed \gset
 

--- a/tsl/test/sql/troubleshooting_job_errors.sql
+++ b/tsl/test/sql/troubleshooting_job_errors.sql
@@ -71,7 +71,7 @@ select add_job('custom_proc1', '2 min', initial_start => now());
 -- to make sure custom_log is first updated by custom_proc_1
 select add_job('custom_proc2', '2 min', initial_start => now() + interval '5 seconds');
 
-SELECT _timescaledb_internal.start_background_workers();
+SELECT _timescaledb_functions.start_background_workers();
 -- enough time to for job_fail to fail
 select pg_sleep(10);
 select job_id, error_data->'proc_name' as proc_name, error_data->>'message' as err_message, error_data->>'sqlerrcode' as sqlerrcode


### PR DESCRIPTION
To increase schema security we do not want to mix our own internal objects with user objects. Since chunks are created in the _timescaledb_internal schema our internal functions should live in a different dedicated schema. This patch make the necessary adjustments for the following functions:

- restart_background_workers()
- stop_background_workers()
- start_background_workers()
- alter_job_set_hypertable_id(integer,regclass)

Disable-check: force-changelog-file
