### PR TITLE
Fix updates between 2.10.1 and 2.10.2

### DIFF
--- a/sql/updates/2.10.1--2.10.2.sql
+++ b/sql/updates/2.10.1--2.10.2.sql
@@ -1,4 +1,4 @@
-DROP FUNCTION _timescaledb_internal.ping_data_node(NAME);
+DROP FUNCTION IF EXISTS _timescaledb_internal.ping_data_node(NAME);
 
 CREATE OR REPLACE FUNCTION _timescaledb_internal.ping_data_node(node_name NAME, timeout INTERVAL = NULL) RETURNS BOOLEAN
 AS '@MODULE_PATHNAME@', 'ts_data_node_ping' LANGUAGE C VOLATILE;

--- a/sql/updates/2.10.2--2.10.1.sql
+++ b/sql/updates/2.10.2--2.10.1.sql
@@ -1,4 +1,4 @@
-DROP FUNCTION _timescaledb_internal.ping_data_node(NAME, INTERVAL);
+DROP FUNCTION IF EXISTS _timescaledb_internal.ping_data_node(NAME, INTERVAL);
 
 CREATE OR REPLACE FUNCTION _timescaledb_internal.ping_data_node(node_name NAME) RETURNS BOOLEAN
 AS '@MODULE_PATHNAME@', 'ts_data_node_ping' LANGUAGE C VOLATILE;


### PR DESCRIPTION
The upgrade and downgrade scripts between 2.10.1 and 2.10.2 use DROP FUNCTION without using IF EXISTS. This breaks the upgrade and downgrade paths for users upgrading from much lower versions (<2.0.0) since the function itself will not be available, throwing an error. A similar situation may occur in the future, if the API is deprecated in the future.

This should close #5789.