### PR TITLE
Fix incorrect row count in EXPLAIN ANALYZE INSERT .. ON CONFLICT output

### DIFF
--- a/.unreleased/bugfix_6015
+++ b/.unreleased/bugfix_6015
@@ -1,0 +1,1 @@
+Fixes: #6015 Correct row count in EXPLAIN ANALYZE INSERT .. ON CONFLICT output

--- a/src/nodes/hypertable_modify.c
+++ b/src/nodes/hypertable_modify.c
@@ -227,9 +227,18 @@ hypertable_modify_explain(CustomScanState *node, List *ancestors, ExplainState *
 	}
 #endif
 	/*
-	 * Since we hijack the ModifyTable node instrumentation on ModifyTable will
+	 * Since we hijack the ModifyTable node, instrumentation on ModifyTable will
 	 * be missing so we set it to instrumentation of HypertableModify node.
 	 */
+	if (mtstate->ps.instrument)
+	{
+		/*
+		 * INSERT .. ON CONFLICT statements record few metrics in the ModifyTable node.
+		 * So, copy them into HypertableModify node before replacing them.
+		 */
+		node->ss.ps.instrument->ntuples2 = mtstate->ps.instrument->ntuples2;
+		node->ss.ps.instrument->nfiltered1 = mtstate->ps.instrument->nfiltered1;
+	}
 	mtstate->ps.instrument = node->ss.ps.instrument;
 #endif
 

--- a/test/expected/upsert.out
+++ b/test/expected/upsert.out
@@ -29,6 +29,25 @@ SELECT * FROM upsert_test;
  Fri Jan 20 09:00:01 2017 | 23.8 | yellow
 (1 row)
 
+-- Test 'Tuples Inserted' and 'Conflicting Tuples' values in EXPLAIN ANALYZE
+EXPLAIN (VERBOSE, ANALYZE, COSTS FALSE, TIMING FALSE, SUMMARY FALSE)
+  INSERT INTO upsert_test VALUES
+    ('2017-01-20T09:00:01', 28.5, 'blue'),
+    ('2017-01-20T09:00:01', 21.9, 'red'),
+    ('2017-01-20T10:00:01', 2.4, 'pink') ON CONFLICT DO NOTHING;
+                                       QUERY PLAN                                       
+----------------------------------------------------------------------------------------
+ Custom Scan (HypertableModify) (actual rows=0 loops=1)
+   ->  Insert on public.upsert_test (actual rows=0 loops=1)
+         Conflict Resolution: NOTHING
+         Tuples Inserted: 1
+         Conflicting Tuples: 2
+         ->  Custom Scan (ChunkDispatch) (actual rows=3 loops=1)
+               Output: "*VALUES*".column1, "*VALUES*".column2, "*VALUES*".column3
+               ->  Values Scan on "*VALUES*" (actual rows=3 loops=1)
+                     Output: "*VALUES*".column1, "*VALUES*".column2, "*VALUES*".column3
+(9 rows)
+
 -- Test ON CONFLICT ON CONSTRAINT
 INSERT INTO upsert_test VALUES ('2017-01-20T09:00:01', 12.3, 'yellow') ON CONFLICT ON CONSTRAINT upsert_test_pkey
 DO UPDATE SET temp = 12.3 RETURNING time, temp, color;

--- a/test/sql/upsert.sql
+++ b/test/sql/upsert.sql
@@ -10,6 +10,13 @@ DO UPDATE SET temp = 23.8 RETURNING *;
 INSERT INTO upsert_test VALUES ('2017-01-20T09:00:01', 78.4, 'yellow') ON CONFLICT DO NOTHING;
 SELECT * FROM upsert_test;
 
+-- Test 'Tuples Inserted' and 'Conflicting Tuples' values in EXPLAIN ANALYZE
+EXPLAIN (VERBOSE, ANALYZE, COSTS FALSE, TIMING FALSE, SUMMARY FALSE)
+  INSERT INTO upsert_test VALUES
+    ('2017-01-20T09:00:01', 28.5, 'blue'),
+    ('2017-01-20T09:00:01', 21.9, 'red'),
+    ('2017-01-20T10:00:01', 2.4, 'pink') ON CONFLICT DO NOTHING;
+
 -- Test ON CONFLICT ON CONSTRAINT
 INSERT INTO upsert_test VALUES ('2017-01-20T09:00:01', 12.3, 'yellow') ON CONFLICT ON CONSTRAINT upsert_test_pkey
 DO UPDATE SET temp = 12.3 RETURNING time, temp, color;


### PR DESCRIPTION
INSERT ... ON CONFLICT statements record few metrics in the ModifyTable
node's instrument but they get overwritten by hypertable_modify_explain
causing wrong output in EXPLAIN ANALYZE statments. Fix it by saving the
metrics into HypertableModify node before replacing them.

Fixes https://github.com/timescale/timescaledb/issues/6014