### PR TITLE
Make up/downgrade test deterministic

### DIFF
--- a/test/sql/updates/post.continuous_aggs.v3.sql
+++ b/test/sql/updates/post.continuous_aggs.v3.sql
@@ -4,9 +4,9 @@
 
 \ir post.continuous_aggs.v2.sql
 
-SELECT "time", count(*) from rename_cols GROUP BY 1;
+SELECT "time", count(*) from rename_cols GROUP BY 1 ORDER BY 1;
 
 --verify compression can be enabled
 ALTER MATERIALIZED VIEW rename_cols SET ( timescaledb.compress='true');
 
-SELECT "time", count(*) from rename_cols GROUP BY 1;
+SELECT "time", count(*) from rename_cols GROUP BY 1 ORDER BY 1;


### PR DESCRIPTION
Two queries in post.continuous_aggs.v3.sql had no ORDER BY specification. Therefore, the query output was not deterministic. This patch adds the missing ORDER BY.

---

Disable-check: force-changelog-file