### PR TITLE
Add support for secondary dimensions

### DIFF
--- a/sql/ddl_api.sql
+++ b/sql/ddl_api.sql
@@ -123,7 +123,8 @@ CREATE OR REPLACE FUNCTION @extschema@.add_dimension(
     number_partitions       INTEGER = NULL,
     chunk_time_interval     ANYELEMENT = NULL::BIGINT,
     partitioning_func       REGPROC = NULL,
-    if_not_exists           BOOLEAN = FALSE
+    if_not_exists           BOOLEAN = FALSE,
+    secondary               BOOLEAN = FALSE
 ) RETURNS TABLE(dimension_id INT, schema_name NAME, table_name NAME, column_name NAME, created BOOL)
 AS '@MODULE_PATHNAME@', 'ts_dimension_add' LANGUAGE C VOLATILE;
 

--- a/sql/pre_install/tables.sql
+++ b/sql/pre_install/tables.sql
@@ -117,13 +117,14 @@ CREATE TABLE _timescaledb_catalog.dimension (
   compress_interval_length bigint NULL,
   integer_now_func_schema name NULL,
   integer_now_func name NULL,
+  secondary boolean NOT NULL,
   -- table constraints
   CONSTRAINT dimension_pkey PRIMARY KEY (id),
   CONSTRAINT dimension_hypertable_id_column_name_key UNIQUE (hypertable_id, column_name),
   CONSTRAINT dimension_check CHECK ((partitioning_func_schema IS NULL AND partitioning_func IS NULL) OR (partitioning_func_schema IS NOT NULL AND partitioning_func IS NOT NULL)),
   CONSTRAINT dimension_check1 CHECK ((num_slices IS NULL AND interval_length IS NOT NULL) OR (num_slices IS NOT NULL AND interval_length IS NULL)),
   CONSTRAINT dimension_check2 CHECK ((integer_now_func_schema IS NULL AND integer_now_func IS NULL) OR (integer_now_func_schema IS NOT NULL AND integer_now_func IS NOT NULL)),
-  CONSTRAINT dimension_interval_length_check CHECK (interval_length IS NULL OR interval_length > 0),
+  CONSTRAINT dimension_interval_length_check CHECK (interval_length IS NULL OR interval_length > 0 OR secondary IS true),
   CONSTRAINT dimension_compress_interval_length_check CHECK (compress_interval_length IS NULL OR compress_interval_length > 0),
   CONSTRAINT dimension_hypertable_id_fkey FOREIGN KEY (hypertable_id) REFERENCES _timescaledb_catalog.hypertable (id) ON DELETE CASCADE
 );

--- a/sql/updates/reverse-dev.sql
+++ b/sql/updates/reverse-dev.sql
@@ -142,6 +142,29 @@ next_start TIMESTAMPTZ, check_config TEXT)
 AS '@MODULE_PATHNAME@', 'ts_job_alter'
 LANGUAGE C VOLATILE;
 
+DROP FUNCTION IF EXISTS @extschema@.add_dimension(
+    REGCLASS,
+    NAME,
+    INTEGER,
+    ANYELEMENT,
+    REGPROC,
+    BOOLEAN,
+    BOOLEAN
+);
+
+CREATE OR REPLACE FUNCTION @extschema@.add_dimension(
+    hypertable              REGCLASS,
+    column_name             NAME,
+    number_partitions       INTEGER = NULL,
+    chunk_time_interval     ANYELEMENT = NULL::BIGINT,
+    partitioning_func       REGPROC = NULL,
+    if_not_exists           BOOLEAN = FALSE
+) RETURNS TABLE(dimension_id INT, schema_name NAME, table_name NAME, column_name NAME, created BOOL)
+AS '@MODULE_PATHNAME@', 'ts_dimension_add' LANGUAGE C VOLATILE;
+
+DELETE FROM _timescaledb_catalog.dimension WHERE secondary IS TRUE;
+ALTER TABLE _timescaledb_catalog.dimension DROP COLUMN secondary;
+
 ALTER FUNCTION _timescaledb_functions.insert_blocker() SET SCHEMA _timescaledb_internal;
 ALTER FUNCTION _timescaledb_functions.continuous_agg_invalidation_trigger() SET SCHEMA _timescaledb_internal;
 ALTER FUNCTION _timescaledb_functions.drop_dist_ht_invalidation_trigger(integer) SET SCHEMA _timescaledb_internal;

--- a/src/chunk_constraint.h
+++ b/src/chunk_constraint.h
@@ -12,9 +12,11 @@
 #include "ts_catalog/catalog.h"
 #include "hypertable.h"
 
+#define SEC_DIM_PREFIX "_$COS_" /* Constraint On Secondary dimension */
 typedef struct ChunkConstraint
 {
 	FormData_chunk_constraint fd;
+	bool secondary;
 } ChunkConstraint;
 
 typedef struct ChunkConstraints
@@ -28,7 +30,7 @@ typedef struct ChunkConstraints
 
 #define chunk_constraints_get(cc, i) &((cc)->constraints[i])
 
-#define is_dimension_constraint(cc) ((cc)->fd.dimension_slice_id > 0)
+#define is_dimension_constraint(cc) ((cc)->fd.dimension_slice_id > 0 && !(cc)->secondary)
 
 typedef struct Chunk Chunk;
 typedef struct DimensionSlice DimensionSlice;
@@ -49,7 +51,8 @@ extern int ts_chunk_constraint_scan_by_dimension_slice_id(int32 dimension_slice_
 extern ChunkConstraint *ts_chunk_constraints_add(ChunkConstraints *ccs, int32 chunk_id,
 												 int32 dimension_slice_id,
 												 const char *constraint_name,
-												 const char *hypertable_constraint_name);
+												 const char *hypertable_constraint_name,
+												 bool secondary);
 extern int ts_chunk_constraints_add_dimension_constraints(ChunkConstraints *ccs, int32 chunk_id,
 														  const Hypercube *cube);
 extern TSDLLEXPORT int ts_chunk_constraints_add_inheritable_constraints(ChunkConstraints *ccs,

--- a/src/dimension.c
+++ b/src/dimension.c
@@ -1613,12 +1613,18 @@ ts_dimension_add(PG_FUNCTION_ARGS)
 
 	info.ht = ts_hypertable_cache_get_cache_and_entry(info.table_relid, CACHE_FLAG_NONE, &hcache);
 
+	if (info.secondary)
+	{
+		info.interval_type = INT8OID;
+		info.interval_datum = DatumGetInt32(1);
+	}
+
 	if (info.num_slices_is_set && OidIsValid(info.interval_type))
 		ereport(ERROR,
 				(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
 				 errmsg("cannot specify both the number of partitions and an interval")));
 
-	if (!info.num_slices_is_set && !OidIsValid(info.interval_type) && !info.secondary)
+	if (!info.num_slices_is_set && !OidIsValid(info.interval_type))
 		ereport(ERROR,
 				(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
 				 errmsg("cannot omit both the number of partitions and the interval")));
@@ -1692,7 +1698,8 @@ ts_dimension_add(PG_FUNCTION_ARGS)
 															   chunk->fd.id,
 															   slice->fd.id,
 															   NULL,
-															   NULL);
+															   NULL,
+															   info.secondary);
 				ts_chunk_constraint_insert(cc);
 			}
 		}

--- a/src/dimension.h
+++ b/src/dimension.h
@@ -42,6 +42,7 @@ typedef struct Dimension
 #define IS_CLOSED_DIMENSION(d) ((d)->type == DIMENSION_TYPE_CLOSED)
 #define IS_VALID_OPEN_DIM_TYPE(type)                                                               \
 	(IS_INTEGER_TYPE(type) || IS_TIMESTAMP_TYPE(type) || ts_type_is_int8_binary_compatible(type))
+#define IS_SECONDARY_DIMENSION(d) ((d)->fd.secondary == true)
 
 /*
  * A hyperspace defines how to partition in a N-dimensional space.
@@ -100,6 +101,7 @@ typedef struct DimensionInfo
 	bool num_slices_is_set;
 	bool adaptive_chunking; /* True if adaptive chunking is enabled */
 	Hypertable *ht;
+	bool secondary; /* True if this is a secondary dimension entry */
 } DimensionInfo;
 
 #define DIMENSION_INFO_IS_SET(di)                                                                  \
@@ -107,6 +109,7 @@ typedef struct DimensionInfo
 
 extern Hyperspace *ts_dimension_scan(int32 hypertable_id, Oid main_table_relid, int16 num_dimension,
 									 MemoryContext mctx);
+extern void ts_secondary_dimension_assign(Hypertable *h, MemoryContext mctx);
 extern DimensionSlice *ts_dimension_calculate_default_slice(const Dimension *dim, int64 value);
 extern TSDLLEXPORT Point *ts_hyperspace_calculate_point(const Hyperspace *h, TupleTableSlot *slot);
 extern int ts_dimension_get_slice_ordinal(const Dimension *dim, const DimensionSlice *slice);

--- a/src/dimension_slice.h
+++ b/src/dimension_slice.h
@@ -77,6 +77,7 @@ extern bool ts_dimension_slice_cut(DimensionSlice *to_cut, const DimensionSlice 
 extern void ts_dimension_slice_free(DimensionSlice *slice);
 extern int ts_dimension_slice_insert_multi(DimensionSlice **slice, Size num_slices);
 extern void ts_dimension_slice_insert(DimensionSlice *slice);
+extern int ts_secondary_dimension_slices_constraints_insert(const Hypertable *ht, Chunk *chunk);
 extern int ts_dimension_slice_cmp(const DimensionSlice *left, const DimensionSlice *right);
 extern int ts_dimension_slice_cmp_coordinate(const DimensionSlice *slice, int64 coord);
 

--- a/src/hypertable.c
+++ b/src/hypertable.c
@@ -251,6 +251,8 @@ ts_hypertable_from_tupleinfo(const TupleInfo *ti)
 	h->main_table_relid =
 		ts_get_relation_relid(NameStr(h->fd.schema_name), NameStr(h->fd.table_name), true);
 	h->space = ts_dimension_scan(h->fd.id, h->main_table_relid, h->fd.num_dimensions, ti->mctx);
+	/* check and assign secondary dimensions */
+	ts_secondary_dimension_assign(h, ti->mctx);
 	h->chunk_cache =
 		ts_subspace_store_init(h->space, ti->mctx, ts_guc_max_cached_chunks_per_hypertable);
 	h->chunk_sizing_func = get_chunk_sizing_func_oid(&h->fd);

--- a/src/hypertable.c
+++ b/src/hypertable.c
@@ -1688,6 +1688,9 @@ ts_hypertable_check_partitioning(const Hypertable *ht, int32 id_of_updated_dimen
 
 	dim = ts_hyperspace_get_dimension_by_id(ht->space, id_of_updated_dimension);
 
+	if (!dim && ht->secondary_space)
+		dim = ts_hyperspace_get_dimension_by_id(ht->secondary_space, id_of_updated_dimension);
+
 	Assert(dim);
 
 	if (hypertable_is_distributed(ht))

--- a/src/hypertable.h
+++ b/src/hypertable.h
@@ -53,6 +53,7 @@ typedef struct Hypertable
 	Oid main_table_relid;
 	Oid chunk_sizing_func;
 	Hyperspace *space;
+	Hyperspace *secondary_space;
 	SubspaceStore *chunk_cache;
 	/*
 	 * Allows restricting the data nodes to use for the hypertable. Default is to

--- a/src/ts_catalog/catalog.h
+++ b/src/ts_catalog/catalog.h
@@ -246,6 +246,7 @@ enum Anum_dimension
 	Anum_dimension_compress_interval_length,
 	Anum_dimension_integer_now_func_schema,
 	Anum_dimension_integer_now_func,
+	Anum_dimension_secondary,
 	_Anum_dimension_max,
 };
 
@@ -267,6 +268,7 @@ typedef struct FormData_dimension
 	int64 compress_interval_length;
 	NameData integer_now_func_schema;
 	NameData integer_now_func;
+	bool secondary;
 } FormData_dimension;
 
 typedef FormData_dimension *Form_dimension;

--- a/test/expected/chunk_adaptive.out
+++ b/test/expected/chunk_adaptive.out
@@ -89,9 +89,9 @@ FROM _timescaledb_catalog.hypertable;
 -- Check that adaptive chunking sets a 1 day default chunk time
 -- interval => 86400000000 microseconds
 SELECT * FROM _timescaledb_catalog.dimension;
- id | hypertable_id | column_name |       column_type        | aligned | num_slices | partitioning_func_schema | partitioning_func | interval_length | compress_interval_length | integer_now_func_schema | integer_now_func 
-----+---------------+-------------+--------------------------+---------+------------+--------------------------+-------------------+-----------------+--------------------------+-------------------------+------------------
-  2 |             2 | time        | timestamp with time zone | t       |            |                          |                   |     86400000000 |                          |                         | 
+ id | hypertable_id | column_name |       column_type        | aligned | num_slices | partitioning_func_schema | partitioning_func | interval_length | compress_interval_length | integer_now_func_schema | integer_now_func | secondary 
+----+---------------+-------------+--------------------------+---------+------------+--------------------------+-------------------+-----------------+--------------------------+-------------------------+------------------+-----------
+  2 |             2 | time        | timestamp with time zone | t       |            |                          |                   |     86400000000 |                          |                         |                  | f
 (1 row)
 
 -- Change the target size

--- a/test/expected/create_chunks.out
+++ b/test/expected/create_chunks.out
@@ -82,10 +82,10 @@ SELECT set_chunk_time_interval('chunk_test', 5::bigint);
 (1 row)
 
 SELECT * FROM _timescaledb_catalog.dimension;
- id | hypertable_id | column_name | column_type | aligned | num_slices | partitioning_func_schema | partitioning_func  | interval_length | compress_interval_length | integer_now_func_schema | integer_now_func 
-----+---------------+-------------+-------------+---------+------------+--------------------------+--------------------+-----------------+--------------------------+-------------------------+------------------
-  2 |             1 | tag         | integer     | f       |          3 | _timescaledb_functions   | get_partition_hash |                 |                          |                         | 
-  1 |             1 | time        | integer     | t       |            |                          |                    |               5 |                          |                         | 
+ id | hypertable_id | column_name | column_type | aligned | num_slices | partitioning_func_schema | partitioning_func  | interval_length | compress_interval_length | integer_now_func_schema | integer_now_func | secondary 
+----+---------------+-------------+-------------+---------+------------+--------------------------+--------------------+-----------------+--------------------------+-------------------------+------------------+-----------
+  2 |             1 | tag         | integer     | f       |          3 | _timescaledb_functions   | get_partition_hash |                 |                          |                         |                  | f
+  1 |             1 | time        | integer     | t       |            |                          |                    |               5 |                          |                         |                  | f
 (2 rows)
 
 INSERT INTO chunk_test VALUES (7, 24.3, 79669, 1);

--- a/test/expected/create_hypertable.out
+++ b/test/expected/create_hypertable.out
@@ -92,13 +92,13 @@ select * from _timescaledb_catalog.hypertable where table_name = 'test_table';
 (1 row)
 
 select * from _timescaledb_catalog.dimension;
- id | hypertable_id | column_name | column_type | aligned | num_slices | partitioning_func_schema | partitioning_func  | interval_length | compress_interval_length | integer_now_func_schema | integer_now_func 
-----+---------------+-------------+-------------+---------+------------+--------------------------+--------------------+-----------------+--------------------------+-------------------------+------------------
-  1 |             1 | time        | bigint      | t       |            |                          |                    |   2592000000000 |                          |                         | 
-  2 |             1 | device_id   | text        | f       |          2 | _timescaledb_functions   | get_partition_hash |                 |                          |                         | 
-  3 |             2 | time        | bigint      | t       |            |                          |                    |   2592000000000 |                          |                         | 
-  4 |             2 | device_id   | text        | f       |          2 | _timescaledb_functions   | get_partition_hash |                 |                          |                         | 
-  5 |             2 | location    | text        | f       |          4 | _timescaledb_functions   | get_partition_hash |                 |                          |                         | 
+ id | hypertable_id | column_name | column_type | aligned | num_slices | partitioning_func_schema | partitioning_func  | interval_length | compress_interval_length | integer_now_func_schema | integer_now_func | secondary 
+----+---------------+-------------+-------------+---------+------------+--------------------------+--------------------+-----------------+--------------------------+-------------------------+------------------+-----------
+  1 |             1 | time        | bigint      | t       |            |                          |                    |   2592000000000 |                          |                         |                  | f
+  2 |             1 | device_id   | text        | f       |          2 | _timescaledb_functions   | get_partition_hash |                 |                          |                         |                  | f
+  3 |             2 | time        | bigint      | t       |            |                          |                    |   2592000000000 |                          |                         |                  | f
+  4 |             2 | device_id   | text        | f       |          2 | _timescaledb_functions   | get_partition_hash |                 |                          |                         |                  | f
+  5 |             2 | location    | text        | f       |          4 | _timescaledb_functions   | get_partition_hash |                 |                          |                         |                  | f
 (5 rows)
 
 --test that we can change the number of partitions and that 1 is allowed
@@ -109,9 +109,9 @@ SELECT set_number_partitions('test_schema.test_table', 1, 'location');
 (1 row)
 
 select * from _timescaledb_catalog.dimension WHERE column_name = 'location';
- id | hypertable_id | column_name | column_type | aligned | num_slices | partitioning_func_schema | partitioning_func  | interval_length | compress_interval_length | integer_now_func_schema | integer_now_func 
-----+---------------+-------------+-------------+---------+------------+--------------------------+--------------------+-----------------+--------------------------+-------------------------+------------------
-  5 |             2 | location    | text        | f       |          1 | _timescaledb_functions   | get_partition_hash |                 |                          |                         | 
+ id | hypertable_id | column_name | column_type | aligned | num_slices | partitioning_func_schema | partitioning_func  | interval_length | compress_interval_length | integer_now_func_schema | integer_now_func | secondary 
+----+---------------+-------------+-------------+---------+------------+--------------------------+--------------------+-----------------+--------------------------+-------------------------+------------------+-----------
+  5 |             2 | location    | text        | f       |          1 | _timescaledb_functions   | get_partition_hash |                 |                          |                         |                  | f
 (1 row)
 
 SELECT set_number_partitions('test_schema.test_table', 2, 'location');
@@ -121,9 +121,9 @@ SELECT set_number_partitions('test_schema.test_table', 2, 'location');
 (1 row)
 
 select * from _timescaledb_catalog.dimension WHERE column_name = 'location';
- id | hypertable_id | column_name | column_type | aligned | num_slices | partitioning_func_schema | partitioning_func  | interval_length | compress_interval_length | integer_now_func_schema | integer_now_func 
-----+---------------+-------------+-------------+---------+------------+--------------------------+--------------------+-----------------+--------------------------+-------------------------+------------------
-  5 |             2 | location    | text        | f       |          2 | _timescaledb_functions   | get_partition_hash |                 |                          |                         | 
+ id | hypertable_id | column_name | column_type | aligned | num_slices | partitioning_func_schema | partitioning_func  | interval_length | compress_interval_length | integer_now_func_schema | integer_now_func | secondary 
+----+---------------+-------------+-------------+---------+------------+--------------------------+--------------------+-----------------+--------------------------+-------------------------+------------------+-----------
+  5 |             2 | location    | text        | f       |          2 | _timescaledb_functions   | get_partition_hash |                 |                          |                         |                  | f
 (1 row)
 
 \set ON_ERROR_STOP 0
@@ -155,14 +155,14 @@ select * from _timescaledb_catalog.hypertable where table_name = 'test_table';
 (1 row)
 
 select * from _timescaledb_catalog.dimension;
- id | hypertable_id | column_name | column_type | aligned | num_slices | partitioning_func_schema | partitioning_func  | interval_length | compress_interval_length | integer_now_func_schema | integer_now_func 
-----+---------------+-------------+-------------+---------+------------+--------------------------+--------------------+-----------------+--------------------------+-------------------------+------------------
-  1 |             1 | time        | bigint      | t       |            |                          |                    |   2592000000000 |                          |                         | 
-  2 |             1 | device_id   | text        | f       |          2 | _timescaledb_functions   | get_partition_hash |                 |                          |                         | 
-  3 |             2 | time        | bigint      | t       |            |                          |                    |   2592000000000 |                          |                         | 
-  4 |             2 | device_id   | text        | f       |          2 | _timescaledb_functions   | get_partition_hash |                 |                          |                         | 
-  5 |             2 | location    | text        | f       |          2 | _timescaledb_functions   | get_partition_hash |                 |                          |                         | 
-  6 |             2 | id          | integer     | t       |            |                          |                    |            1000 |                          |                         | 
+ id | hypertable_id | column_name | column_type | aligned | num_slices | partitioning_func_schema | partitioning_func  | interval_length | compress_interval_length | integer_now_func_schema | integer_now_func | secondary 
+----+---------------+-------------+-------------+---------+------------+--------------------------+--------------------+-----------------+--------------------------+-------------------------+------------------+-----------
+  1 |             1 | time        | bigint      | t       |            |                          |                    |   2592000000000 |                          |                         |                  | f
+  2 |             1 | device_id   | text        | f       |          2 | _timescaledb_functions   | get_partition_hash |                 |                          |                         |                  | f
+  3 |             2 | time        | bigint      | t       |            |                          |                    |   2592000000000 |                          |                         |                  | f
+  4 |             2 | device_id   | text        | f       |          2 | _timescaledb_functions   | get_partition_hash |                 |                          |                         |                  | f
+  5 |             2 | location    | text        | f       |          2 | _timescaledb_functions   | get_partition_hash |                 |                          |                         |                  | f
+  6 |             2 | id          | integer     | t       |            |                          |                    |            1000 |                          |                         |                  | f
 (6 rows)
 
 -- Test add_dimension: can use interval types for TIMESTAMPTZ columns
@@ -757,9 +757,9 @@ select set_integer_now_func('test_table_int', 'dummy_now');
 (1 row)
 
 select * from _timescaledb_catalog.dimension WHERE hypertable_id = :TEST_TABLE_INT_HYPERTABLE_ID;
- id | hypertable_id | column_name | column_type | aligned | num_slices | partitioning_func_schema | partitioning_func | interval_length | compress_interval_length | integer_now_func_schema | integer_now_func 
-----+---------------+-------------+-------------+---------+------------+--------------------------+-------------------+-----------------+--------------------------+-------------------------+------------------
- 29 |            17 | time        | bigint      | t       |            |                          |                   |               1 |                          | public                  | dummy_now
+ id | hypertable_id | column_name | column_type | aligned | num_slices | partitioning_func_schema | partitioning_func | interval_length | compress_interval_length | integer_now_func_schema | integer_now_func | secondary 
+----+---------------+-------------+-------------+---------+------------+--------------------------+-------------------+-----------------+--------------------------+-------------------------+------------------+-----------
+ 29 |            17 | time        | bigint      | t       |            |                          |                   |               1 |                          | public                  | dummy_now        | f
 (1 row)
 
 \set ON_ERROR_STOP 0
@@ -782,9 +782,9 @@ select set_integer_now_func('test_table_int', 'my_user_schema.dummy_now4', repla
 \c :TEST_DBNAME :ROLE_SUPERUSER
 ALTER SCHEMA my_user_schema RENAME TO my_new_schema;
 select * from _timescaledb_catalog.dimension WHERE hypertable_id = :TEST_TABLE_INT_HYPERTABLE_ID;
- id | hypertable_id | column_name | column_type | aligned | num_slices | partitioning_func_schema | partitioning_func | interval_length | compress_interval_length | integer_now_func_schema | integer_now_func 
-----+---------------+-------------+-------------+---------+------------+--------------------------+-------------------+-----------------+--------------------------+-------------------------+------------------
- 29 |            17 | time        | bigint      | t       |            |                          |                   |               1 |                          | my_new_schema           | dummy_now4
+ id | hypertable_id | column_name | column_type | aligned | num_slices | partitioning_func_schema | partitioning_func | interval_length | compress_interval_length | integer_now_func_schema | integer_now_func | secondary 
+----+---------------+-------------+-------------+---------+------------+--------------------------+-------------------+-----------------+--------------------------+-------------------------+------------------+-----------
+ 29 |            17 | time        | bigint      | t       |            |                          |                   |               1 |                          | my_new_schema           | dummy_now4       | f
 (1 row)
 
 -- github issue #4650

--- a/test/expected/ddl-13.out
+++ b/test/expected/ddl-13.out
@@ -422,10 +422,10 @@ SELECT * FROM test.show_columnsp('_timescaledb_internal._hyper_9_%chunk');
 -- show the column name and type of the partitioning dimension in the
 -- metadata table
 SELECT * FROM _timescaledb_catalog.dimension WHERE hypertable_id = 9;
- id | hypertable_id | column_name |       column_type        | aligned | num_slices | partitioning_func_schema | partitioning_func  | interval_length | compress_interval_length | integer_now_func_schema | integer_now_func 
-----+---------------+-------------+--------------------------+---------+------------+--------------------------+--------------------+-----------------+--------------------------+-------------------------+------------------
- 15 |             9 | color       | character varying        | f       |          2 | _timescaledb_functions   | get_partition_hash |                 |                          |                         | 
- 14 |             9 | time        | timestamp with time zone | t       |            |                          |                    |   2628000000000 |                          |                         | 
+ id | hypertable_id | column_name |       column_type        | aligned | num_slices | partitioning_func_schema | partitioning_func  | interval_length | compress_interval_length | integer_now_func_schema | integer_now_func | secondary 
+----+---------------+-------------+--------------------------+---------+------------+--------------------------+--------------------+-----------------+--------------------------+-------------------------+------------------+-----------
+ 15 |             9 | color       | character varying        | f       |          2 | _timescaledb_functions   | get_partition_hash |                 |                          |                         |                  | f
+ 14 |             9 | time        | timestamp with time zone | t       |            |                          |                    |   2628000000000 |                          |                         |                  | f
 (2 rows)
 
 EXPLAIN (costs off)
@@ -476,10 +476,10 @@ SELECT * FROM test.show_columnsp('_timescaledb_internal._hyper_9_%chunk');
 
 -- show that the metadata has been updated
 SELECT * FROM _timescaledb_catalog.dimension WHERE hypertable_id = 9;
- id | hypertable_id | column_name |         column_type         | aligned | num_slices | partitioning_func_schema | partitioning_func  | interval_length | compress_interval_length | integer_now_func_schema | integer_now_func 
-----+---------------+-------------+-----------------------------+---------+------------+--------------------------+--------------------+-----------------+--------------------------+-------------------------+------------------
- 15 |             9 | colorname   | character varying           | f       |          2 | _timescaledb_functions   | get_partition_hash |                 |                          |                         | 
- 14 |             9 | time_us     | timestamp without time zone | t       |            |                          |                    |   2628000000000 |                          |                         | 
+ id | hypertable_id | column_name |         column_type         | aligned | num_slices | partitioning_func_schema | partitioning_func  | interval_length | compress_interval_length | integer_now_func_schema | integer_now_func | secondary 
+----+---------------+-------------+-----------------------------+---------+------------+--------------------------+--------------------+-----------------+--------------------------+-------------------------+------------------+-----------
+ 15 |             9 | colorname   | character varying           | f       |          2 | _timescaledb_functions   | get_partition_hash |                 |                          |                         |                  | f
+ 14 |             9 | time_us     | timestamp without time zone | t       |            |                          |                    |   2628000000000 |                          |                         |                  | f
 (2 rows)
 
 -- constraint exclusion should still work with updated column

--- a/test/expected/ddl-14.out
+++ b/test/expected/ddl-14.out
@@ -422,10 +422,10 @@ SELECT * FROM test.show_columnsp('_timescaledb_internal._hyper_9_%chunk');
 -- show the column name and type of the partitioning dimension in the
 -- metadata table
 SELECT * FROM _timescaledb_catalog.dimension WHERE hypertable_id = 9;
- id | hypertable_id | column_name |       column_type        | aligned | num_slices | partitioning_func_schema | partitioning_func  | interval_length | compress_interval_length | integer_now_func_schema | integer_now_func 
-----+---------------+-------------+--------------------------+---------+------------+--------------------------+--------------------+-----------------+--------------------------+-------------------------+------------------
- 15 |             9 | color       | character varying        | f       |          2 | _timescaledb_functions   | get_partition_hash |                 |                          |                         | 
- 14 |             9 | time        | timestamp with time zone | t       |            |                          |                    |   2628000000000 |                          |                         | 
+ id | hypertable_id | column_name |       column_type        | aligned | num_slices | partitioning_func_schema | partitioning_func  | interval_length | compress_interval_length | integer_now_func_schema | integer_now_func | secondary 
+----+---------------+-------------+--------------------------+---------+------------+--------------------------+--------------------+-----------------+--------------------------+-------------------------+------------------+-----------
+ 15 |             9 | color       | character varying        | f       |          2 | _timescaledb_functions   | get_partition_hash |                 |                          |                         |                  | f
+ 14 |             9 | time        | timestamp with time zone | t       |            |                          |                    |   2628000000000 |                          |                         |                  | f
 (2 rows)
 
 EXPLAIN (costs off)
@@ -476,10 +476,10 @@ SELECT * FROM test.show_columnsp('_timescaledb_internal._hyper_9_%chunk');
 
 -- show that the metadata has been updated
 SELECT * FROM _timescaledb_catalog.dimension WHERE hypertable_id = 9;
- id | hypertable_id | column_name |         column_type         | aligned | num_slices | partitioning_func_schema | partitioning_func  | interval_length | compress_interval_length | integer_now_func_schema | integer_now_func 
-----+---------------+-------------+-----------------------------+---------+------------+--------------------------+--------------------+-----------------+--------------------------+-------------------------+------------------
- 15 |             9 | colorname   | character varying           | f       |          2 | _timescaledb_functions   | get_partition_hash |                 |                          |                         | 
- 14 |             9 | time_us     | timestamp without time zone | t       |            |                          |                    |   2628000000000 |                          |                         | 
+ id | hypertable_id | column_name |         column_type         | aligned | num_slices | partitioning_func_schema | partitioning_func  | interval_length | compress_interval_length | integer_now_func_schema | integer_now_func | secondary 
+----+---------------+-------------+-----------------------------+---------+------------+--------------------------+--------------------+-----------------+--------------------------+-------------------------+------------------+-----------
+ 15 |             9 | colorname   | character varying           | f       |          2 | _timescaledb_functions   | get_partition_hash |                 |                          |                         |                  | f
+ 14 |             9 | time_us     | timestamp without time zone | t       |            |                          |                    |   2628000000000 |                          |                         |                  | f
 (2 rows)
 
 -- constraint exclusion should still work with updated column

--- a/test/expected/ddl-15.out
+++ b/test/expected/ddl-15.out
@@ -422,10 +422,10 @@ SELECT * FROM test.show_columnsp('_timescaledb_internal._hyper_9_%chunk');
 -- show the column name and type of the partitioning dimension in the
 -- metadata table
 SELECT * FROM _timescaledb_catalog.dimension WHERE hypertable_id = 9;
- id | hypertable_id | column_name |       column_type        | aligned | num_slices | partitioning_func_schema | partitioning_func  | interval_length | compress_interval_length | integer_now_func_schema | integer_now_func 
-----+---------------+-------------+--------------------------+---------+------------+--------------------------+--------------------+-----------------+--------------------------+-------------------------+------------------
- 15 |             9 | color       | character varying        | f       |          2 | _timescaledb_functions   | get_partition_hash |                 |                          |                         | 
- 14 |             9 | time        | timestamp with time zone | t       |            |                          |                    |   2628000000000 |                          |                         | 
+ id | hypertable_id | column_name |       column_type        | aligned | num_slices | partitioning_func_schema | partitioning_func  | interval_length | compress_interval_length | integer_now_func_schema | integer_now_func | secondary 
+----+---------------+-------------+--------------------------+---------+------------+--------------------------+--------------------+-----------------+--------------------------+-------------------------+------------------+-----------
+ 15 |             9 | color       | character varying        | f       |          2 | _timescaledb_functions   | get_partition_hash |                 |                          |                         |                  | f
+ 14 |             9 | time        | timestamp with time zone | t       |            |                          |                    |   2628000000000 |                          |                         |                  | f
 (2 rows)
 
 EXPLAIN (costs off)
@@ -476,10 +476,10 @@ SELECT * FROM test.show_columnsp('_timescaledb_internal._hyper_9_%chunk');
 
 -- show that the metadata has been updated
 SELECT * FROM _timescaledb_catalog.dimension WHERE hypertable_id = 9;
- id | hypertable_id | column_name |         column_type         | aligned | num_slices | partitioning_func_schema | partitioning_func  | interval_length | compress_interval_length | integer_now_func_schema | integer_now_func 
-----+---------------+-------------+-----------------------------+---------+------------+--------------------------+--------------------+-----------------+--------------------------+-------------------------+------------------
- 15 |             9 | colorname   | character varying           | f       |          2 | _timescaledb_functions   | get_partition_hash |                 |                          |                         | 
- 14 |             9 | time_us     | timestamp without time zone | t       |            |                          |                    |   2628000000000 |                          |                         | 
+ id | hypertable_id | column_name |         column_type         | aligned | num_slices | partitioning_func_schema | partitioning_func  | interval_length | compress_interval_length | integer_now_func_schema | integer_now_func | secondary 
+----+---------------+-------------+-----------------------------+---------+------------+--------------------------+--------------------+-----------------+--------------------------+-------------------------+------------------+-----------
+ 15 |             9 | colorname   | character varying           | f       |          2 | _timescaledb_functions   | get_partition_hash |                 |                          |                         |                  | f
+ 14 |             9 | time_us     | timestamp without time zone | t       |            |                          |                    |   2628000000000 |                          |                         |                  | f
 (2 rows)
 
 -- constraint exclusion should still work with updated column

--- a/test/expected/drop_hypertable.out
+++ b/test/expected/drop_hypertable.out
@@ -7,8 +7,8 @@ SELECT * from _timescaledb_catalog.hypertable;
 (0 rows)
 
 SELECT * from _timescaledb_catalog.dimension;
- id | hypertable_id | column_name | column_type | aligned | num_slices | partitioning_func_schema | partitioning_func | interval_length | compress_interval_length | integer_now_func_schema | integer_now_func 
-----+---------------+-------------+-------------+---------+------------+--------------------------+-------------------+-----------------+--------------------------+-------------------------+------------------
+ id | hypertable_id | column_name | column_type | aligned | num_slices | partitioning_func_schema | partitioning_func | interval_length | compress_interval_length | integer_now_func_schema | integer_now_func | secondary 
+----+---------------+-------------+-------------+---------+------------+--------------------------+-------------------+-----------------+--------------------------+-------------------------+------------------+-----------
 (0 rows)
 
 CREATE TABLE should_drop (time timestamp, temp float8);
@@ -82,9 +82,9 @@ SELECT * from _timescaledb_catalog.hypertable;
 (1 row)
 
 SELECT * from _timescaledb_catalog.dimension;
- id | hypertable_id | column_name |         column_type         | aligned | num_slices | partitioning_func_schema | partitioning_func | interval_length | compress_interval_length | integer_now_func_schema | integer_now_func 
-----+---------------+-------------+-----------------------------+---------+------------+--------------------------+-------------------+-----------------+--------------------------+-------------------------+------------------
-  1 |             1 | time        | timestamp without time zone | t       |            |                          |                   |    604800000000 |                          |                         | 
+ id | hypertable_id | column_name |         column_type         | aligned | num_slices | partitioning_func_schema | partitioning_func | interval_length | compress_interval_length | integer_now_func_schema | integer_now_func | secondary 
+----+---------------+-------------+-----------------------------+---------+------------+--------------------------+-------------------+-----------------+--------------------------+-------------------------+------------------+-----------
+  1 |             1 | time        | timestamp without time zone | t       |            |                          |                   |    604800000000 |                          |                         |                  | f
 (1 row)
 
 DROP TABLE should_drop;
@@ -105,8 +105,8 @@ SELECT * from _timescaledb_catalog.hypertable;
 (1 row)
 
 SELECT * from _timescaledb_catalog.dimension;
- id | hypertable_id | column_name |         column_type         | aligned | num_slices | partitioning_func_schema | partitioning_func | interval_length | compress_interval_length | integer_now_func_schema | integer_now_func 
-----+---------------+-------------+-----------------------------+---------+------------+--------------------------+-------------------+-----------------+--------------------------+-------------------------+------------------
-  4 |             4 | time        | timestamp without time zone | t       |            |                          |                   |    604800000000 |                          |                         | 
+ id | hypertable_id | column_name |         column_type         | aligned | num_slices | partitioning_func_schema | partitioning_func | interval_length | compress_interval_length | integer_now_func_schema | integer_now_func | secondary 
+----+---------------+-------------+-----------------------------+---------+------------+--------------------------+-------------------+-----------------+--------------------------+-------------------------+------------------+-----------
+  4 |             4 | time        | timestamp without time zone | t       |            |                          |                   |    604800000000 |                          |                         |                  | f
 (1 row)
 

--- a/test/expected/drop_owned.out
+++ b/test/expected/drop_owned.out
@@ -64,8 +64,8 @@ SELECT * FROM _timescaledb_catalog.chunk;
 (0 rows)
 
 SELECT * FROM _timescaledb_catalog.dimension;
- id | hypertable_id | column_name | column_type | aligned | num_slices | partitioning_func_schema | partitioning_func | interval_length | compress_interval_length | integer_now_func_schema | integer_now_func 
-----+---------------+-------------+-------------+---------+------------+--------------------------+-------------------+-----------------+--------------------------+-------------------------+------------------
+ id | hypertable_id | column_name | column_type | aligned | num_slices | partitioning_func_schema | partitioning_func | interval_length | compress_interval_length | integer_now_func_schema | integer_now_func | secondary 
+----+---------------+-------------+-------------+---------+------------+--------------------------+-------------------+-----------------+--------------------------+-------------------------+------------------+-----------
 (0 rows)
 
 SELECT * FROM _timescaledb_catalog.dimension_slice;

--- a/test/expected/drop_schema.out
+++ b/test/expected/drop_schema.out
@@ -96,8 +96,8 @@ SELECT * FROM _timescaledb_catalog.chunk;
 (0 rows)
 
 SELECT * FROM _timescaledb_catalog.dimension;
- id | hypertable_id | column_name | column_type | aligned | num_slices | partitioning_func_schema | partitioning_func | interval_length | compress_interval_length | integer_now_func_schema | integer_now_func 
-----+---------------+-------------+-------------+---------+------------+--------------------------+-------------------+-----------------+--------------------------+-------------------------+------------------
+ id | hypertable_id | column_name | column_type | aligned | num_slices | partitioning_func_schema | partitioning_func | interval_length | compress_interval_length | integer_now_func_schema | integer_now_func | secondary 
+----+---------------+-------------+-------------+---------+------------+--------------------------+-------------------+-----------------+--------------------------+-------------------------+------------------+-----------
 (0 rows)
 
 SELECT * FROM _timescaledb_catalog.dimension_slice;

--- a/test/expected/partition.out
+++ b/test/expected/partition.out
@@ -11,10 +11,10 @@ NOTICE:  adding not-null constraint to column "time"
 
 -- Show legacy partitioning function is used
 SELECT * FROM _timescaledb_catalog.dimension;
- id | hypertable_id | column_name |       column_type        | aligned | num_slices | partitioning_func_schema |   partitioning_func   | interval_length | compress_interval_length | integer_now_func_schema | integer_now_func 
-----+---------------+-------------+--------------------------+---------+------------+--------------------------+-----------------------+-----------------+--------------------------+-------------------------+------------------
-  1 |             1 | time        | timestamp with time zone | t       |            |                          |                       |    604800000000 |                          |                         | 
-  2 |             1 | device      | integer                  | f       |          2 | _timescaledb_functions   | get_partition_for_key |                 |                          |                         | 
+ id | hypertable_id | column_name |       column_type        | aligned | num_slices | partitioning_func_schema |   partitioning_func   | interval_length | compress_interval_length | integer_now_func_schema | integer_now_func | secondary 
+----+---------------+-------------+--------------------------+---------+------------+--------------------------+-----------------------+-----------------+--------------------------+-------------------------+------------------+-----------
+  1 |             1 | time        | timestamp with time zone | t       |            |                          |                       |    604800000000 |                          |                         |                  | f
+  2 |             1 | device      | integer                  | f       |          2 | _timescaledb_functions   | get_partition_for_key |                 |                          |                         |                  | f
 (2 rows)
 
 INSERT INTO part_legacy VALUES ('2017-03-22T09:18:23', 23.4, 1);
@@ -54,12 +54,12 @@ NOTICE:  adding not-null constraint to column "time"
 (1 row)
 
 SELECT * FROM _timescaledb_catalog.dimension;
- id | hypertable_id | column_name |       column_type        | aligned | num_slices | partitioning_func_schema |   partitioning_func   | interval_length | compress_interval_length | integer_now_func_schema | integer_now_func 
-----+---------------+-------------+--------------------------+---------+------------+--------------------------+-----------------------+-----------------+--------------------------+-------------------------+------------------
-  1 |             1 | time        | timestamp with time zone | t       |            |                          |                       |    604800000000 |                          |                         | 
-  2 |             1 | device      | integer                  | f       |          2 | _timescaledb_functions   | get_partition_for_key |                 |                          |                         | 
-  3 |             2 | time        | timestamp with time zone | t       |            |                          |                       |    604800000000 |                          |                         | 
-  4 |             2 | device      | integer                  | f       |          2 | _timescaledb_functions   | get_partition_hash    |                 |                          |                         | 
+ id | hypertable_id | column_name |       column_type        | aligned | num_slices | partitioning_func_schema |   partitioning_func   | interval_length | compress_interval_length | integer_now_func_schema | integer_now_func | secondary 
+----+---------------+-------------+--------------------------+---------+------------+--------------------------+-----------------------+-----------------+--------------------------+-------------------------+------------------+-----------
+  1 |             1 | time        | timestamp with time zone | t       |            |                          |                       |    604800000000 |                          |                         |                  | f
+  2 |             1 | device      | integer                  | f       |          2 | _timescaledb_functions   | get_partition_for_key |                 |                          |                         |                  | f
+  3 |             2 | time        | timestamp with time zone | t       |            |                          |                       |    604800000000 |                          |                         |                  | f
+  4 |             2 | device      | integer                  | f       |          2 | _timescaledb_functions   | get_partition_hash    |                 |                          |                         |                  | f
 (4 rows)
 
 INSERT INTO part_new VALUES ('2017-03-22T09:18:23', 23.4, 1);
@@ -133,17 +133,17 @@ SELECT add_dimension('part_add_dim', 'location', 2, partitioning_func => '_times
 (1 row)
 
 SELECT * FROM _timescaledb_catalog.dimension;
- id | hypertable_id | column_name |         column_type         | aligned | num_slices | partitioning_func_schema |   partitioning_func   | interval_length | compress_interval_length | integer_now_func_schema | integer_now_func 
-----+---------------+-------------+-----------------------------+---------+------------+--------------------------+-----------------------+-----------------+--------------------------+-------------------------+------------------
-  1 |             1 | time        | timestamp with time zone    | t       |            |                          |                       |    604800000000 |                          |                         | 
-  2 |             1 | device      | integer                     | f       |          2 | _timescaledb_functions   | get_partition_for_key |                 |                          |                         | 
-  3 |             2 | time        | timestamp with time zone    | t       |            |                          |                       |    604800000000 |                          |                         | 
-  4 |             2 | device      | integer                     | f       |          2 | _timescaledb_functions   | get_partition_hash    |                 |                          |                         | 
-  6 |             3 | temp        | double precision            | f       |          2 | _timescaledb_functions   | get_partition_hash    |                 |                          |                         | 
-  5 |             3 | time        | timestamp without time zone | t       |            |                          |                       |    604800000000 |                          |                         | 
-  7 |             4 | time        | timestamp with time zone    | t       |            |                          |                       |    604800000000 |                          |                         | 
-  8 |             4 | temp        | double precision            | f       |          2 | _timescaledb_functions   | get_partition_hash    |                 |                          |                         | 
-  9 |             4 | location    | integer                     | f       |          2 | _timescaledb_functions   | get_partition_for_key |                 |                          |                         | 
+ id | hypertable_id | column_name |         column_type         | aligned | num_slices | partitioning_func_schema |   partitioning_func   | interval_length | compress_interval_length | integer_now_func_schema | integer_now_func | secondary 
+----+---------------+-------------+-----------------------------+---------+------------+--------------------------+-----------------------+-----------------+--------------------------+-------------------------+------------------+-----------
+  1 |             1 | time        | timestamp with time zone    | t       |            |                          |                       |    604800000000 |                          |                         |                  | f
+  2 |             1 | device      | integer                     | f       |          2 | _timescaledb_functions   | get_partition_for_key |                 |                          |                         |                  | f
+  3 |             2 | time        | timestamp with time zone    | t       |            |                          |                       |    604800000000 |                          |                         |                  | f
+  4 |             2 | device      | integer                     | f       |          2 | _timescaledb_functions   | get_partition_hash    |                 |                          |                         |                  | f
+  6 |             3 | temp        | double precision            | f       |          2 | _timescaledb_functions   | get_partition_hash    |                 |                          |                         |                  | f
+  5 |             3 | time        | timestamp without time zone | t       |            |                          |                       |    604800000000 |                          |                         |                  | f
+  7 |             4 | time        | timestamp with time zone    | t       |            |                          |                       |    604800000000 |                          |                         |                  | f
+  8 |             4 | temp        | double precision            | f       |          2 | _timescaledb_functions   | get_partition_hash    |                 |                          |                         |                  | f
+  9 |             4 | location    | integer                     | f       |          2 | _timescaledb_functions   | get_partition_for_key |                 |                          |                         |                  | f
 (9 rows)
 
 -- Test that we support custom SQL-based partitioning functions and

--- a/tsl/test/expected/bgw_policy.out
+++ b/tsl/test/expected/bgw_policy.out
@@ -588,14 +588,14 @@ select remove_retention_policy('part_time_now_func');
 alter function dummy_now() rename to dummy_now_renamed;
 alter schema public rename to new_public;
 select * from  _timescaledb_catalog.dimension;
- id | hypertable_id | column_name |         column_type         | aligned | num_slices | partitioning_func_schema | partitioning_func  | interval_length | compress_interval_length | integer_now_func_schema | integer_now_func 
-----+---------------+-------------+-----------------------------+---------+------------+--------------------------+--------------------+-----------------+--------------------------+-------------------------+------------------
-  1 |             1 | time        | timestamp with time zone    | t       |            |                          |                    |    604800000000 |                          |                         | 
-  2 |             1 | chunk_id    | integer                     | f       |          2 | _timescaledb_functions   | get_partition_hash |                 |                          |                         | 
-  5 |             4 | time        | timestamp without time zone | t       |            |                          |                    |               1 |                          |                         | 
-  6 |             5 | time        | double precision            | t       |            | new_public               | time_partfunc      |               1 |                          | new_public              | dummy_now
-  3 |             2 | time        | bigint                      | t       |            |                          |                    |               1 |                          | new_public              | nowstamp
-  4 |             3 | time        | smallint                    | t       |            |                          |                    |               1 |                          | new_public              | overflow_now
+ id | hypertable_id | column_name |         column_type         | aligned | num_slices | partitioning_func_schema | partitioning_func  | interval_length | compress_interval_length | integer_now_func_schema | integer_now_func | secondary 
+----+---------------+-------------+-----------------------------+---------+------------+--------------------------+--------------------+-----------------+--------------------------+-------------------------+------------------+-----------
+  1 |             1 | time        | timestamp with time zone    | t       |            |                          |                    |    604800000000 |                          |                         |                  | f
+  2 |             1 | chunk_id    | integer                     | f       |          2 | _timescaledb_functions   | get_partition_hash |                 |                          |                         |                  | f
+  5 |             4 | time        | timestamp without time zone | t       |            |                          |                    |               1 |                          |                         |                  | f
+  6 |             5 | time        | double precision            | t       |            | new_public               | time_partfunc      |               1 |                          | new_public              | dummy_now        | f
+  3 |             2 | time        | bigint                      | t       |            |                          |                    |               1 |                          | new_public              | nowstamp         | f
+  4 |             3 | time        | smallint                    | t       |            |                          |                    |               1 |                          | new_public              | overflow_now     | f
 (6 rows)
 
 alter schema new_public rename to public;

--- a/tsl/test/expected/dist_hypertable-13.out
+++ b/tsl/test/expected/dist_hypertable-13.out
@@ -2210,13 +2210,13 @@ SELECT * FROM _timescaledb_catalog.hypertable;
 (3 rows)
 
 SELECT * FROM _timescaledb_catalog.dimension;
- id | hypertable_id |   column_name    |       column_type        | aligned | num_slices | partitioning_func_schema | partitioning_func  | interval_length | compress_interval_length | integer_now_func_schema | integer_now_func 
-----+---------------+------------------+--------------------------+---------+------------+--------------------------+--------------------+-----------------+--------------------------+-------------------------+------------------
-  1 |             1 | time             | timestamp with time zone | t       |            |                          |                    |    604800000000 |                          |                         | 
-  3 |             2 | time             | timestamp with time zone | t       |            |                          |                    |    604800000000 |                          |                         | 
-  2 |             1 | device           | integer                  | f       |          3 | _timescaledb_functions   | get_partition_hash |                 |                          |                         | 
-  5 |             4 | time Col %#^#@$# | timestamp with time zone | t       |            |                          |                    |    604800000000 |                          |                         | 
-  6 |             4 | __region         | text                     | f       |          4 | _timescaledb_functions   | get_partition_hash |                 |                          |                         | 
+ id | hypertable_id |   column_name    |       column_type        | aligned | num_slices | partitioning_func_schema | partitioning_func  | interval_length | compress_interval_length | integer_now_func_schema | integer_now_func | secondary 
+----+---------------+------------------+--------------------------+---------+------------+--------------------------+--------------------+-----------------+--------------------------+-------------------------+------------------+-----------
+  1 |             1 | time             | timestamp with time zone | t       |            |                          |                    |    604800000000 |                          |                         |                  | f
+  3 |             2 | time             | timestamp with time zone | t       |            |                          |                    |    604800000000 |                          |                         |                  | f
+  2 |             1 | device           | integer                  | f       |          3 | _timescaledb_functions   | get_partition_hash |                 |                          |                         |                  | f
+  5 |             4 | time Col %#^#@$# | timestamp with time zone | t       |            |                          |                    |    604800000000 |                          |                         |                  | f
+  6 |             4 | __region         | text                     | f       |          4 | _timescaledb_functions   | get_partition_hash |                 |                          |                         |                  | f
 (5 rows)
 
 SELECT * FROM test.show_triggers('"Table\\Schema"."Param_Table"');
@@ -2245,13 +2245,13 @@ id|schema_name  |table_name     |associated_schema_name|associated_table_prefix|
 NOTICE:  [db_dist_hypertable_1]: 
 SELECT * FROM _timescaledb_catalog.dimension
 NOTICE:  [db_dist_hypertable_1]:
-id|hypertable_id|column_name     |column_type             |aligned|num_slices|partitioning_func_schema|partitioning_func |interval_length|compress_interval_length|integer_now_func_schema|integer_now_func
---+-------------+----------------+------------------------+-------+----------+------------------------+------------------+---------------+------------------------+-----------------------+----------------
- 1|            1|time            |timestamp with time zone|t      |          |                        |                  |   604800000000|                        |                       |                
- 3|            2|time            |timestamp with time zone|t      |          |                        |                  |   604800000000|                        |                       |                
- 2|            1|device          |integer                 |f      |         3|_timescaledb_functions  |get_partition_hash|               |                        |                       |                
- 4|            3|time Col %#^#@$#|timestamp with time zone|t      |          |                        |                  |   604800000000|                        |                       |                
- 5|            3|__region        |text                    |f      |         4|_timescaledb_functions  |get_partition_hash|               |                        |                       |                
+id|hypertable_id|column_name     |column_type             |aligned|num_slices|partitioning_func_schema|partitioning_func |interval_length|compress_interval_length|integer_now_func_schema|integer_now_func|secondary
+--+-------------+----------------+------------------------+-------+----------+------------------------+------------------+---------------+------------------------+-----------------------+----------------+---------
+ 1|            1|time            |timestamp with time zone|t      |          |                        |                  |   604800000000|                        |                       |                |f        
+ 3|            2|time            |timestamp with time zone|t      |          |                        |                  |   604800000000|                        |                       |                |f        
+ 2|            1|device          |integer                 |f      |         3|_timescaledb_functions  |get_partition_hash|               |                        |                       |                |f        
+ 4|            3|time Col %#^#@$#|timestamp with time zone|t      |          |                        |                  |   604800000000|                        |                       |                |f        
+ 5|            3|__region        |text                    |f      |         4|_timescaledb_functions  |get_partition_hash|               |                        |                       |                |f        
 (5 rows)
 
 
@@ -2279,13 +2279,13 @@ id|schema_name  |table_name     |associated_schema_name|associated_table_prefix|
 NOTICE:  [db_dist_hypertable_2]: 
 SELECT * FROM _timescaledb_catalog.dimension
 NOTICE:  [db_dist_hypertable_2]:
-id|hypertable_id|column_name     |column_type             |aligned|num_slices|partitioning_func_schema|partitioning_func |interval_length|compress_interval_length|integer_now_func_schema|integer_now_func
---+-------------+----------------+------------------------+-------+----------+------------------------+------------------+---------------+------------------------+-----------------------+----------------
- 1|            1|time            |timestamp with time zone|t      |          |                        |                  |   604800000000|                        |                       |                
- 3|            2|time            |timestamp with time zone|t      |          |                        |                  |   604800000000|                        |                       |                
- 2|            1|device          |integer                 |f      |         3|_timescaledb_functions  |get_partition_hash|               |                        |                       |                
- 6|            4|time Col %#^#@$#|timestamp with time zone|t      |          |                        |                  |   604800000000|                        |                       |                
- 7|            4|__region        |text                    |f      |         4|_timescaledb_functions  |get_partition_hash|               |                        |                       |                
+id|hypertable_id|column_name     |column_type             |aligned|num_slices|partitioning_func_schema|partitioning_func |interval_length|compress_interval_length|integer_now_func_schema|integer_now_func|secondary
+--+-------------+----------------+------------------------+-------+----------+------------------------+------------------+---------------+------------------------+-----------------------+----------------+---------
+ 1|            1|time            |timestamp with time zone|t      |          |                        |                  |   604800000000|                        |                       |                |f        
+ 3|            2|time            |timestamp with time zone|t      |          |                        |                  |   604800000000|                        |                       |                |f        
+ 2|            1|device          |integer                 |f      |         3|_timescaledb_functions  |get_partition_hash|               |                        |                       |                |f        
+ 6|            4|time Col %#^#@$#|timestamp with time zone|t      |          |                        |                  |   604800000000|                        |                       |                |f        
+ 7|            4|__region        |text                    |f      |         4|_timescaledb_functions  |get_partition_hash|               |                        |                       |                |f        
 (5 rows)
 
 
@@ -2313,13 +2313,13 @@ id|schema_name  |table_name     |associated_schema_name|associated_table_prefix|
 NOTICE:  [db_dist_hypertable_3]: 
 SELECT * FROM _timescaledb_catalog.dimension
 NOTICE:  [db_dist_hypertable_3]:
-id|hypertable_id|column_name     |column_type             |aligned|num_slices|partitioning_func_schema|partitioning_func |interval_length|compress_interval_length|integer_now_func_schema|integer_now_func
---+-------------+----------------+------------------------+-------+----------+------------------------+------------------+---------------+------------------------+-----------------------+----------------
- 1|            1|time            |timestamp with time zone|t      |          |                        |                  |   604800000000|                        |                       |                
- 3|            2|time            |timestamp with time zone|t      |          |                        |                  |   604800000000|                        |                       |                
- 2|            1|device          |integer                 |f      |         3|_timescaledb_functions  |get_partition_hash|               |                        |                       |                
- 4|            3|time Col %#^#@$#|timestamp with time zone|t      |          |                        |                  |   604800000000|                        |                       |                
- 5|            3|__region        |text                    |f      |         4|_timescaledb_functions  |get_partition_hash|               |                        |                       |                
+id|hypertable_id|column_name     |column_type             |aligned|num_slices|partitioning_func_schema|partitioning_func |interval_length|compress_interval_length|integer_now_func_schema|integer_now_func|secondary
+--+-------------+----------------+------------------------+-------+----------+------------------------+------------------+---------------+------------------------+-----------------------+----------------+---------
+ 1|            1|time            |timestamp with time zone|t      |          |                        |                  |   604800000000|                        |                       |                |f        
+ 3|            2|time            |timestamp with time zone|t      |          |                        |                  |   604800000000|                        |                       |                |f        
+ 2|            1|device          |integer                 |f      |         3|_timescaledb_functions  |get_partition_hash|               |                        |                       |                |f        
+ 4|            3|time Col %#^#@$#|timestamp with time zone|t      |          |                        |                  |   604800000000|                        |                       |                |f        
+ 5|            3|__region        |text                    |f      |         4|_timescaledb_functions  |get_partition_hash|               |                        |                       |                |f        
 (5 rows)
 
 
@@ -2441,17 +2441,17 @@ SELECT * FROM dimented_table ORDER BY time;
 (1 row)
 
 SELECT * FROM _timescaledb_catalog.dimension;
- id | hypertable_id |   column_name    |       column_type        | aligned | num_slices | partitioning_func_schema |   partitioning_func   | interval_length | compress_interval_length | integer_now_func_schema | integer_now_func 
-----+---------------+------------------+--------------------------+---------+------------+--------------------------+-----------------------+-----------------+--------------------------+-------------------------+------------------
-  1 |             1 | time             | timestamp with time zone | t       |            |                          |                       |    604800000000 |                          |                         | 
-  3 |             2 | time             | timestamp with time zone | t       |            |                          |                       |    604800000000 |                          |                         | 
-  2 |             1 | device           | integer                  | f       |          3 | _timescaledb_functions   | get_partition_hash    |                 |                          |                         | 
-  5 |             4 | time Col %#^#@$# | timestamp with time zone | t       |            |                          |                       |    604800000000 |                          |                         | 
-  6 |             4 | __region         | text                     | f       |          2 | _timescaledb_functions   | get_partition_hash    |                 |                          |                         | 
-  7 |             5 | time             | timestamp with time zone | t       |            |                          |                       |    604800000000 |                          |                         | 
-  8 |             5 | column1          | integer                  | f       |          4 | _timescaledb_functions   | get_partition_hash    |                 |                          |                         | 
-  9 |             5 | column2          | timestamp with time zone | t       |            |                          |                       |    604800000000 |                          |                         | 
- 10 |             5 | column3          | integer                  | f       |          4 | _timescaledb_functions   | get_partition_for_key |                 |                          |                         | 
+ id | hypertable_id |   column_name    |       column_type        | aligned | num_slices | partitioning_func_schema |   partitioning_func   | interval_length | compress_interval_length | integer_now_func_schema | integer_now_func | secondary 
+----+---------------+------------------+--------------------------+---------+------------+--------------------------+-----------------------+-----------------+--------------------------+-------------------------+------------------+-----------
+  1 |             1 | time             | timestamp with time zone | t       |            |                          |                       |    604800000000 |                          |                         |                  | f
+  3 |             2 | time             | timestamp with time zone | t       |            |                          |                       |    604800000000 |                          |                         |                  | f
+  2 |             1 | device           | integer                  | f       |          3 | _timescaledb_functions   | get_partition_hash    |                 |                          |                         |                  | f
+  5 |             4 | time Col %#^#@$# | timestamp with time zone | t       |            |                          |                       |    604800000000 |                          |                         |                  | f
+  6 |             4 | __region         | text                     | f       |          2 | _timescaledb_functions   | get_partition_hash    |                 |                          |                         |                  | f
+  7 |             5 | time             | timestamp with time zone | t       |            |                          |                       |    604800000000 |                          |                         |                  | f
+  8 |             5 | column1          | integer                  | f       |          4 | _timescaledb_functions   | get_partition_hash    |                 |                          |                         |                  | f
+  9 |             5 | column2          | timestamp with time zone | t       |            |                          |                       |    604800000000 |                          |                         |                  | f
+ 10 |             5 | column3          | integer                  | f       |          4 | _timescaledb_functions   | get_partition_for_key |                 |                          |                         |                  | f
 (9 rows)
 
 SELECT * FROM attach_data_node(:'DATA_NODE_2', 'dimented_table');
@@ -2461,17 +2461,17 @@ SELECT * FROM attach_data_node(:'DATA_NODE_2', 'dimented_table');
 (1 row)
 
 SELECT * FROM _timescaledb_catalog.dimension;
- id | hypertable_id |   column_name    |       column_type        | aligned | num_slices | partitioning_func_schema |   partitioning_func   | interval_length | compress_interval_length | integer_now_func_schema | integer_now_func 
-----+---------------+------------------+--------------------------+---------+------------+--------------------------+-----------------------+-----------------+--------------------------+-------------------------+------------------
-  1 |             1 | time             | timestamp with time zone | t       |            |                          |                       |    604800000000 |                          |                         | 
-  3 |             2 | time             | timestamp with time zone | t       |            |                          |                       |    604800000000 |                          |                         | 
-  2 |             1 | device           | integer                  | f       |          3 | _timescaledb_functions   | get_partition_hash    |                 |                          |                         | 
-  5 |             4 | time Col %#^#@$# | timestamp with time zone | t       |            |                          |                       |    604800000000 |                          |                         | 
-  6 |             4 | __region         | text                     | f       |          2 | _timescaledb_functions   | get_partition_hash    |                 |                          |                         | 
-  7 |             5 | time             | timestamp with time zone | t       |            |                          |                       |    604800000000 |                          |                         | 
-  8 |             5 | column1          | integer                  | f       |          4 | _timescaledb_functions   | get_partition_hash    |                 |                          |                         | 
-  9 |             5 | column2          | timestamp with time zone | t       |            |                          |                       |    604800000000 |                          |                         | 
- 10 |             5 | column3          | integer                  | f       |          4 | _timescaledb_functions   | get_partition_for_key |                 |                          |                         | 
+ id | hypertable_id |   column_name    |       column_type        | aligned | num_slices | partitioning_func_schema |   partitioning_func   | interval_length | compress_interval_length | integer_now_func_schema | integer_now_func | secondary 
+----+---------------+------------------+--------------------------+---------+------------+--------------------------+-----------------------+-----------------+--------------------------+-------------------------+------------------+-----------
+  1 |             1 | time             | timestamp with time zone | t       |            |                          |                       |    604800000000 |                          |                         |                  | f
+  3 |             2 | time             | timestamp with time zone | t       |            |                          |                       |    604800000000 |                          |                         |                  | f
+  2 |             1 | device           | integer                  | f       |          3 | _timescaledb_functions   | get_partition_hash    |                 |                          |                         |                  | f
+  5 |             4 | time Col %#^#@$# | timestamp with time zone | t       |            |                          |                       |    604800000000 |                          |                         |                  | f
+  6 |             4 | __region         | text                     | f       |          2 | _timescaledb_functions   | get_partition_hash    |                 |                          |                         |                  | f
+  7 |             5 | time             | timestamp with time zone | t       |            |                          |                       |    604800000000 |                          |                         |                  | f
+  8 |             5 | column1          | integer                  | f       |          4 | _timescaledb_functions   | get_partition_hash    |                 |                          |                         |                  | f
+  9 |             5 | column2          | timestamp with time zone | t       |            |                          |                       |    604800000000 |                          |                         |                  | f
+ 10 |             5 | column3          | integer                  | f       |          4 | _timescaledb_functions   | get_partition_for_key |                 |                          |                         |                  | f
 (9 rows)
 
 -- ensure data node has new dimensions
@@ -2481,47 +2481,47 @@ $$);
 NOTICE:  [db_dist_hypertable_1]: 
 SELECT * FROM _timescaledb_catalog.dimension
 NOTICE:  [db_dist_hypertable_1]:
-id|hypertable_id|column_name     |column_type             |aligned|num_slices|partitioning_func_schema|partitioning_func    |interval_length|compress_interval_length|integer_now_func_schema|integer_now_func
---+-------------+----------------+------------------------+-------+----------+------------------------+---------------------+---------------+------------------------+-----------------------+----------------
- 1|            1|time            |timestamp with time zone|t      |          |                        |                     |   604800000000|                        |                       |                
- 3|            2|time            |timestamp with time zone|t      |          |                        |                     |   604800000000|                        |                       |                
- 2|            1|device          |integer                 |f      |         3|_timescaledb_functions  |get_partition_hash   |               |                        |                       |                
- 4|            3|time Col %#^#@$#|timestamp with time zone|t      |          |                        |                     |   604800000000|                        |                       |                
- 5|            3|__region        |text                    |f      |         4|_timescaledb_functions  |get_partition_hash   |               |                        |                       |                
- 6|            4|time            |timestamp with time zone|t      |          |                        |                     |   604800000000|                        |                       |                
- 7|            4|column1         |integer                 |f      |         4|_timescaledb_functions  |get_partition_hash   |               |                        |                       |                
- 8|            4|column2         |timestamp with time zone|t      |          |                        |                     |   604800000000|                        |                       |                
- 9|            4|column3         |integer                 |f      |         4|_timescaledb_functions  |get_partition_for_key|               |                        |                       |                
+id|hypertable_id|column_name     |column_type             |aligned|num_slices|partitioning_func_schema|partitioning_func    |interval_length|compress_interval_length|integer_now_func_schema|integer_now_func|secondary
+--+-------------+----------------+------------------------+-------+----------+------------------------+---------------------+---------------+------------------------+-----------------------+----------------+---------
+ 1|            1|time            |timestamp with time zone|t      |          |                        |                     |   604800000000|                        |                       |                |f        
+ 3|            2|time            |timestamp with time zone|t      |          |                        |                     |   604800000000|                        |                       |                |f        
+ 2|            1|device          |integer                 |f      |         3|_timescaledb_functions  |get_partition_hash   |               |                        |                       |                |f        
+ 4|            3|time Col %#^#@$#|timestamp with time zone|t      |          |                        |                     |   604800000000|                        |                       |                |f        
+ 5|            3|__region        |text                    |f      |         4|_timescaledb_functions  |get_partition_hash   |               |                        |                       |                |f        
+ 6|            4|time            |timestamp with time zone|t      |          |                        |                     |   604800000000|                        |                       |                |f        
+ 7|            4|column1         |integer                 |f      |         4|_timescaledb_functions  |get_partition_hash   |               |                        |                       |                |f        
+ 8|            4|column2         |timestamp with time zone|t      |          |                        |                     |   604800000000|                        |                       |                |f        
+ 9|            4|column3         |integer                 |f      |         4|_timescaledb_functions  |get_partition_for_key|               |                        |                       |                |f        
 (9 rows)
 
 
 NOTICE:  [db_dist_hypertable_2]: 
 SELECT * FROM _timescaledb_catalog.dimension
 NOTICE:  [db_dist_hypertable_2]:
-id|hypertable_id|column_name     |column_type             |aligned|num_slices|partitioning_func_schema|partitioning_func    |interval_length|compress_interval_length|integer_now_func_schema|integer_now_func
---+-------------+----------------+------------------------+-------+----------+------------------------+---------------------+---------------+------------------------+-----------------------+----------------
- 1|            1|time            |timestamp with time zone|t      |          |                        |                     |   604800000000|                        |                       |                
- 3|            2|time            |timestamp with time zone|t      |          |                        |                     |   604800000000|                        |                       |                
- 2|            1|device          |integer                 |f      |         3|_timescaledb_functions  |get_partition_hash   |               |                        |                       |                
- 6|            4|time Col %#^#@$#|timestamp with time zone|t      |          |                        |                     |   604800000000|                        |                       |                
- 7|            4|__region        |text                    |f      |         4|_timescaledb_functions  |get_partition_hash   |               |                        |                       |                
- 8|            5|time            |timestamp with time zone|t      |          |                        |                     |   604800000000|                        |                       |                
- 9|            5|column1         |integer                 |f      |         4|_timescaledb_functions  |get_partition_hash   |               |                        |                       |                
-10|            5|column2         |timestamp with time zone|t      |          |                        |                     |   604800000000|                        |                       |                
-11|            5|column3         |integer                 |f      |         4|_timescaledb_functions  |get_partition_for_key|               |                        |                       |                
+id|hypertable_id|column_name     |column_type             |aligned|num_slices|partitioning_func_schema|partitioning_func    |interval_length|compress_interval_length|integer_now_func_schema|integer_now_func|secondary
+--+-------------+----------------+------------------------+-------+----------+------------------------+---------------------+---------------+------------------------+-----------------------+----------------+---------
+ 1|            1|time            |timestamp with time zone|t      |          |                        |                     |   604800000000|                        |                       |                |f        
+ 3|            2|time            |timestamp with time zone|t      |          |                        |                     |   604800000000|                        |                       |                |f        
+ 2|            1|device          |integer                 |f      |         3|_timescaledb_functions  |get_partition_hash   |               |                        |                       |                |f        
+ 6|            4|time Col %#^#@$#|timestamp with time zone|t      |          |                        |                     |   604800000000|                        |                       |                |f        
+ 7|            4|__region        |text                    |f      |         4|_timescaledb_functions  |get_partition_hash   |               |                        |                       |                |f        
+ 8|            5|time            |timestamp with time zone|t      |          |                        |                     |   604800000000|                        |                       |                |f        
+ 9|            5|column1         |integer                 |f      |         4|_timescaledb_functions  |get_partition_hash   |               |                        |                       |                |f        
+10|            5|column2         |timestamp with time zone|t      |          |                        |                     |   604800000000|                        |                       |                |f        
+11|            5|column3         |integer                 |f      |         4|_timescaledb_functions  |get_partition_for_key|               |                        |                       |                |f        
 (9 rows)
 
 
 NOTICE:  [db_dist_hypertable_3]: 
 SELECT * FROM _timescaledb_catalog.dimension
 NOTICE:  [db_dist_hypertable_3]:
-id|hypertable_id|column_name     |column_type             |aligned|num_slices|partitioning_func_schema|partitioning_func |interval_length|compress_interval_length|integer_now_func_schema|integer_now_func
---+-------------+----------------+------------------------+-------+----------+------------------------+------------------+---------------+------------------------+-----------------------+----------------
- 1|            1|time            |timestamp with time zone|t      |          |                        |                  |   604800000000|                        |                       |                
- 3|            2|time            |timestamp with time zone|t      |          |                        |                  |   604800000000|                        |                       |                
- 2|            1|device          |integer                 |f      |         3|_timescaledb_functions  |get_partition_hash|               |                        |                       |                
- 4|            3|time Col %#^#@$#|timestamp with time zone|t      |          |                        |                  |   604800000000|                        |                       |                
- 5|            3|__region        |text                    |f      |         4|_timescaledb_functions  |get_partition_hash|               |                        |                       |                
+id|hypertable_id|column_name     |column_type             |aligned|num_slices|partitioning_func_schema|partitioning_func |interval_length|compress_interval_length|integer_now_func_schema|integer_now_func|secondary
+--+-------------+----------------+------------------------+-------+----------+------------------------+------------------+---------------+------------------------+-----------------------+----------------+---------
+ 1|            1|time            |timestamp with time zone|t      |          |                        |                  |   604800000000|                        |                       |                |f        
+ 3|            2|time            |timestamp with time zone|t      |          |                        |                  |   604800000000|                        |                       |                |f        
+ 2|            1|device          |integer                 |f      |         3|_timescaledb_functions  |get_partition_hash|               |                        |                       |                |f        
+ 4|            3|time Col %#^#@$#|timestamp with time zone|t      |          |                        |                  |   604800000000|                        |                       |                |f        
+ 5|            3|__region        |text                    |f      |         4|_timescaledb_functions  |get_partition_hash|               |                        |                       |                |f        
 (5 rows)
 
 
@@ -3491,9 +3491,9 @@ NOTICE:  [db_dist_hypertable_1]:
 SELECT d.* FROM _timescaledb_catalog.hypertable h, _timescaledb_catalog.dimension d
 WHERE h.id = d.hypertable_id AND h.table_name = 'disttable'
 NOTICE:  [db_dist_hypertable_1]:
-id|hypertable_id|column_name|column_type|aligned|num_slices|partitioning_func_schema|partitioning_func|interval_length|compress_interval_length|integer_now_func_schema|integer_now_func
---+-------------+-----------+-----------+-------+----------+------------------------+-----------------+---------------+------------------------+-----------------------+----------------
-20|           11|time       |bigint     |t      |          |                        |                 |        1000000|                        |                       |                
+id|hypertable_id|column_name|column_type|aligned|num_slices|partitioning_func_schema|partitioning_func|interval_length|compress_interval_length|integer_now_func_schema|integer_now_func|secondary
+--+-------------+-----------+-----------+-------+----------+------------------------+-----------------+---------------+------------------------+-----------------------+----------------+---------
+20|           11|time       |bigint     |t      |          |                        |                 |        1000000|                        |                       |                |f        
 (1 row)
 
 
@@ -3501,9 +3501,9 @@ NOTICE:  [db_dist_hypertable_2]:
 SELECT d.* FROM _timescaledb_catalog.hypertable h, _timescaledb_catalog.dimension d
 WHERE h.id = d.hypertable_id AND h.table_name = 'disttable'
 NOTICE:  [db_dist_hypertable_2]:
-id|hypertable_id|column_name|column_type|aligned|num_slices|partitioning_func_schema|partitioning_func|interval_length|compress_interval_length|integer_now_func_schema|integer_now_func
---+-------------+-----------+-----------+-------+----------+------------------------+-----------------+---------------+------------------------+-----------------------+----------------
-20|           11|time       |bigint     |t      |          |                        |                 |        1000000|                        |                       |                
+id|hypertable_id|column_name|column_type|aligned|num_slices|partitioning_func_schema|partitioning_func|interval_length|compress_interval_length|integer_now_func_schema|integer_now_func|secondary
+--+-------------+-----------+-----------+-------+----------+------------------------+-----------------+---------------+------------------------+-----------------------+----------------+---------
+20|           11|time       |bigint     |t      |          |                        |                 |        1000000|                        |                       |                |f        
 (1 row)
 
 
@@ -3511,9 +3511,9 @@ NOTICE:  [db_dist_hypertable_3]:
 SELECT d.* FROM _timescaledb_catalog.hypertable h, _timescaledb_catalog.dimension d
 WHERE h.id = d.hypertable_id AND h.table_name = 'disttable'
 NOTICE:  [db_dist_hypertable_3]:
-id|hypertable_id|column_name|column_type|aligned|num_slices|partitioning_func_schema|partitioning_func|interval_length|compress_interval_length|integer_now_func_schema|integer_now_func
---+-------------+-----------+-----------+-------+----------+------------------------+-----------------+---------------+------------------------+-----------------------+----------------
-14|            9|time       |bigint     |t      |          |                        |                 |        1000000|                        |                       |                
+id|hypertable_id|column_name|column_type|aligned|num_slices|partitioning_func_schema|partitioning_func|interval_length|compress_interval_length|integer_now_func_schema|integer_now_func|secondary
+--+-------------+-----------+-----------+-------+----------+------------------------+-----------------+---------------+------------------------+-----------------------+----------------+---------
+14|            9|time       |bigint     |t      |          |                        |                 |        1000000|                        |                       |                |f        
 (1 row)
 
 
@@ -3541,10 +3541,10 @@ NOTICE:  [db_dist_hypertable_1]:
 SELECT d.* FROM _timescaledb_catalog.hypertable h, _timescaledb_catalog.dimension d
 WHERE h.id = d.hypertable_id AND h.table_name = 'disttable'
 NOTICE:  [db_dist_hypertable_1]:
-id|hypertable_id|column_name|column_type|aligned|num_slices|partitioning_func_schema|partitioning_func |interval_length|compress_interval_length|integer_now_func_schema|integer_now_func
---+-------------+-----------+-----------+-------+----------+------------------------+------------------+---------------+------------------------+-----------------------+----------------
-21|           11|device     |integer    |f      |         1|_timescaledb_functions  |get_partition_hash|               |                        |                       |                
-20|           11|time       |bigint     |t      |          |                        |                  |        1000000|                        |                       |                
+id|hypertable_id|column_name|column_type|aligned|num_slices|partitioning_func_schema|partitioning_func |interval_length|compress_interval_length|integer_now_func_schema|integer_now_func|secondary
+--+-------------+-----------+-----------+-------+----------+------------------------+------------------+---------------+------------------------+-----------------------+----------------+---------
+21|           11|device     |integer    |f      |         1|_timescaledb_functions  |get_partition_hash|               |                        |                       |                |f        
+20|           11|time       |bigint     |t      |          |                        |                  |        1000000|                        |                       |                |f        
 (2 rows)
 
 
@@ -3552,10 +3552,10 @@ NOTICE:  [db_dist_hypertable_2]:
 SELECT d.* FROM _timescaledb_catalog.hypertable h, _timescaledb_catalog.dimension d
 WHERE h.id = d.hypertable_id AND h.table_name = 'disttable'
 NOTICE:  [db_dist_hypertable_2]:
-id|hypertable_id|column_name|column_type|aligned|num_slices|partitioning_func_schema|partitioning_func |interval_length|compress_interval_length|integer_now_func_schema|integer_now_func
---+-------------+-----------+-----------+-------+----------+------------------------+------------------+---------------+------------------------+-----------------------+----------------
-21|           11|device     |integer    |f      |         1|_timescaledb_functions  |get_partition_hash|               |                        |                       |                
-20|           11|time       |bigint     |t      |          |                        |                  |        1000000|                        |                       |                
+id|hypertable_id|column_name|column_type|aligned|num_slices|partitioning_func_schema|partitioning_func |interval_length|compress_interval_length|integer_now_func_schema|integer_now_func|secondary
+--+-------------+-----------+-----------+-------+----------+------------------------+------------------+---------------+------------------------+-----------------------+----------------+---------
+21|           11|device     |integer    |f      |         1|_timescaledb_functions  |get_partition_hash|               |                        |                       |                |f        
+20|           11|time       |bigint     |t      |          |                        |                  |        1000000|                        |                       |                |f        
 (2 rows)
 
 
@@ -3563,10 +3563,10 @@ NOTICE:  [db_dist_hypertable_3]:
 SELECT d.* FROM _timescaledb_catalog.hypertable h, _timescaledb_catalog.dimension d
 WHERE h.id = d.hypertable_id AND h.table_name = 'disttable'
 NOTICE:  [db_dist_hypertable_3]:
-id|hypertable_id|column_name|column_type|aligned|num_slices|partitioning_func_schema|partitioning_func |interval_length|compress_interval_length|integer_now_func_schema|integer_now_func
---+-------------+-----------+-----------+-------+----------+------------------------+------------------+---------------+------------------------+-----------------------+----------------
-15|            9|device     |integer    |f      |         1|_timescaledb_functions  |get_partition_hash|               |                        |                       |                
-14|            9|time       |bigint     |t      |          |                        |                  |        1000000|                        |                       |                
+id|hypertable_id|column_name|column_type|aligned|num_slices|partitioning_func_schema|partitioning_func |interval_length|compress_interval_length|integer_now_func_schema|integer_now_func|secondary
+--+-------------+-----------+-----------+-------+----------+------------------------+------------------+---------------+------------------------+-----------------------+----------------+---------
+15|            9|device     |integer    |f      |         1|_timescaledb_functions  |get_partition_hash|               |                        |                       |                |f        
+14|            9|time       |bigint     |t      |          |                        |                  |        1000000|                        |                       |                |f        
 (2 rows)
 
 
@@ -3607,10 +3607,10 @@ NOTICE:  [db_dist_hypertable_1]:
 SELECT d.* FROM _timescaledb_catalog.hypertable h, _timescaledb_catalog.dimension d
 WHERE h.id = d.hypertable_id AND h.table_name = 'disttable'
 NOTICE:  [db_dist_hypertable_1]:
-id|hypertable_id|column_name|column_type|aligned|num_slices|partitioning_func_schema|partitioning_func |interval_length|compress_interval_length|integer_now_func_schema|integer_now_func
---+-------------+-----------+-----------+-------+----------+------------------------+------------------+---------------+------------------------+-----------------------+----------------
-21|           11|device     |integer    |f      |         3|_timescaledb_functions  |get_partition_hash|               |                        |                       |                
-20|           11|time       |bigint     |t      |          |                        |                  |     2000000000|                        |public                 |dummy_now       
+id|hypertable_id|column_name|column_type|aligned|num_slices|partitioning_func_schema|partitioning_func |interval_length|compress_interval_length|integer_now_func_schema|integer_now_func|secondary
+--+-------------+-----------+-----------+-------+----------+------------------------+------------------+---------------+------------------------+-----------------------+----------------+---------
+21|           11|device     |integer    |f      |         3|_timescaledb_functions  |get_partition_hash|               |                        |                       |                |f        
+20|           11|time       |bigint     |t      |          |                        |                  |     2000000000|                        |public                 |dummy_now       |f        
 (2 rows)
 
 
@@ -3618,10 +3618,10 @@ NOTICE:  [db_dist_hypertable_2]:
 SELECT d.* FROM _timescaledb_catalog.hypertable h, _timescaledb_catalog.dimension d
 WHERE h.id = d.hypertable_id AND h.table_name = 'disttable'
 NOTICE:  [db_dist_hypertable_2]:
-id|hypertable_id|column_name|column_type|aligned|num_slices|partitioning_func_schema|partitioning_func |interval_length|compress_interval_length|integer_now_func_schema|integer_now_func
---+-------------+-----------+-----------+-------+----------+------------------------+------------------+---------------+------------------------+-----------------------+----------------
-21|           11|device     |integer    |f      |         3|_timescaledb_functions  |get_partition_hash|               |                        |                       |                
-20|           11|time       |bigint     |t      |          |                        |                  |     2000000000|                        |public                 |dummy_now       
+id|hypertable_id|column_name|column_type|aligned|num_slices|partitioning_func_schema|partitioning_func |interval_length|compress_interval_length|integer_now_func_schema|integer_now_func|secondary
+--+-------------+-----------+-----------+-------+----------+------------------------+------------------+---------------+------------------------+-----------------------+----------------+---------
+21|           11|device     |integer    |f      |         3|_timescaledb_functions  |get_partition_hash|               |                        |                       |                |f        
+20|           11|time       |bigint     |t      |          |                        |                  |     2000000000|                        |public                 |dummy_now       |f        
 (2 rows)
 
 
@@ -3629,10 +3629,10 @@ NOTICE:  [db_dist_hypertable_3]:
 SELECT d.* FROM _timescaledb_catalog.hypertable h, _timescaledb_catalog.dimension d
 WHERE h.id = d.hypertable_id AND h.table_name = 'disttable'
 NOTICE:  [db_dist_hypertable_3]:
-id|hypertable_id|column_name|column_type|aligned|num_slices|partitioning_func_schema|partitioning_func |interval_length|compress_interval_length|integer_now_func_schema|integer_now_func
---+-------------+-----------+-----------+-------+----------+------------------------+------------------+---------------+------------------------+-----------------------+----------------
-15|            9|device     |integer    |f      |         3|_timescaledb_functions  |get_partition_hash|               |                        |                       |                
-14|            9|time       |bigint     |t      |          |                        |                  |     2000000000|                        |public                 |dummy_now       
+id|hypertable_id|column_name|column_type|aligned|num_slices|partitioning_func_schema|partitioning_func |interval_length|compress_interval_length|integer_now_func_schema|integer_now_func|secondary
+--+-------------+-----------+-----------+-------+----------+------------------------+------------------+---------------+------------------------+-----------------------+----------------+---------
+15|            9|device     |integer    |f      |         3|_timescaledb_functions  |get_partition_hash|               |                        |                       |                |f        
+14|            9|time       |bigint     |t      |          |                        |                  |     2000000000|                        |public                 |dummy_now       |f        
 (2 rows)
 
 

--- a/tsl/test/expected/dist_hypertable-14.out
+++ b/tsl/test/expected/dist_hypertable-14.out
@@ -2214,13 +2214,13 @@ SELECT * FROM _timescaledb_catalog.hypertable;
 (3 rows)
 
 SELECT * FROM _timescaledb_catalog.dimension;
- id | hypertable_id |   column_name    |       column_type        | aligned | num_slices | partitioning_func_schema | partitioning_func  | interval_length | compress_interval_length | integer_now_func_schema | integer_now_func 
-----+---------------+------------------+--------------------------+---------+------------+--------------------------+--------------------+-----------------+--------------------------+-------------------------+------------------
-  1 |             1 | time             | timestamp with time zone | t       |            |                          |                    |    604800000000 |                          |                         | 
-  3 |             2 | time             | timestamp with time zone | t       |            |                          |                    |    604800000000 |                          |                         | 
-  2 |             1 | device           | integer                  | f       |          3 | _timescaledb_functions   | get_partition_hash |                 |                          |                         | 
-  5 |             4 | time Col %#^#@$# | timestamp with time zone | t       |            |                          |                    |    604800000000 |                          |                         | 
-  6 |             4 | __region         | text                     | f       |          4 | _timescaledb_functions   | get_partition_hash |                 |                          |                         | 
+ id | hypertable_id |   column_name    |       column_type        | aligned | num_slices | partitioning_func_schema | partitioning_func  | interval_length | compress_interval_length | integer_now_func_schema | integer_now_func | secondary 
+----+---------------+------------------+--------------------------+---------+------------+--------------------------+--------------------+-----------------+--------------------------+-------------------------+------------------+-----------
+  1 |             1 | time             | timestamp with time zone | t       |            |                          |                    |    604800000000 |                          |                         |                  | f
+  3 |             2 | time             | timestamp with time zone | t       |            |                          |                    |    604800000000 |                          |                         |                  | f
+  2 |             1 | device           | integer                  | f       |          3 | _timescaledb_functions   | get_partition_hash |                 |                          |                         |                  | f
+  5 |             4 | time Col %#^#@$# | timestamp with time zone | t       |            |                          |                    |    604800000000 |                          |                         |                  | f
+  6 |             4 | __region         | text                     | f       |          4 | _timescaledb_functions   | get_partition_hash |                 |                          |                         |                  | f
 (5 rows)
 
 SELECT * FROM test.show_triggers('"Table\\Schema"."Param_Table"');
@@ -2249,13 +2249,13 @@ id|schema_name  |table_name     |associated_schema_name|associated_table_prefix|
 NOTICE:  [db_dist_hypertable_1]: 
 SELECT * FROM _timescaledb_catalog.dimension
 NOTICE:  [db_dist_hypertable_1]:
-id|hypertable_id|column_name     |column_type             |aligned|num_slices|partitioning_func_schema|partitioning_func |interval_length|compress_interval_length|integer_now_func_schema|integer_now_func
---+-------------+----------------+------------------------+-------+----------+------------------------+------------------+---------------+------------------------+-----------------------+----------------
- 1|            1|time            |timestamp with time zone|t      |          |                        |                  |   604800000000|                        |                       |                
- 3|            2|time            |timestamp with time zone|t      |          |                        |                  |   604800000000|                        |                       |                
- 2|            1|device          |integer                 |f      |         3|_timescaledb_functions  |get_partition_hash|               |                        |                       |                
- 4|            3|time Col %#^#@$#|timestamp with time zone|t      |          |                        |                  |   604800000000|                        |                       |                
- 5|            3|__region        |text                    |f      |         4|_timescaledb_functions  |get_partition_hash|               |                        |                       |                
+id|hypertable_id|column_name     |column_type             |aligned|num_slices|partitioning_func_schema|partitioning_func |interval_length|compress_interval_length|integer_now_func_schema|integer_now_func|secondary
+--+-------------+----------------+------------------------+-------+----------+------------------------+------------------+---------------+------------------------+-----------------------+----------------+---------
+ 1|            1|time            |timestamp with time zone|t      |          |                        |                  |   604800000000|                        |                       |                |f        
+ 3|            2|time            |timestamp with time zone|t      |          |                        |                  |   604800000000|                        |                       |                |f        
+ 2|            1|device          |integer                 |f      |         3|_timescaledb_functions  |get_partition_hash|               |                        |                       |                |f        
+ 4|            3|time Col %#^#@$#|timestamp with time zone|t      |          |                        |                  |   604800000000|                        |                       |                |f        
+ 5|            3|__region        |text                    |f      |         4|_timescaledb_functions  |get_partition_hash|               |                        |                       |                |f        
 (5 rows)
 
 
@@ -2283,13 +2283,13 @@ id|schema_name  |table_name     |associated_schema_name|associated_table_prefix|
 NOTICE:  [db_dist_hypertable_2]: 
 SELECT * FROM _timescaledb_catalog.dimension
 NOTICE:  [db_dist_hypertable_2]:
-id|hypertable_id|column_name     |column_type             |aligned|num_slices|partitioning_func_schema|partitioning_func |interval_length|compress_interval_length|integer_now_func_schema|integer_now_func
---+-------------+----------------+------------------------+-------+----------+------------------------+------------------+---------------+------------------------+-----------------------+----------------
- 1|            1|time            |timestamp with time zone|t      |          |                        |                  |   604800000000|                        |                       |                
- 3|            2|time            |timestamp with time zone|t      |          |                        |                  |   604800000000|                        |                       |                
- 2|            1|device          |integer                 |f      |         3|_timescaledb_functions  |get_partition_hash|               |                        |                       |                
- 6|            4|time Col %#^#@$#|timestamp with time zone|t      |          |                        |                  |   604800000000|                        |                       |                
- 7|            4|__region        |text                    |f      |         4|_timescaledb_functions  |get_partition_hash|               |                        |                       |                
+id|hypertable_id|column_name     |column_type             |aligned|num_slices|partitioning_func_schema|partitioning_func |interval_length|compress_interval_length|integer_now_func_schema|integer_now_func|secondary
+--+-------------+----------------+------------------------+-------+----------+------------------------+------------------+---------------+------------------------+-----------------------+----------------+---------
+ 1|            1|time            |timestamp with time zone|t      |          |                        |                  |   604800000000|                        |                       |                |f        
+ 3|            2|time            |timestamp with time zone|t      |          |                        |                  |   604800000000|                        |                       |                |f        
+ 2|            1|device          |integer                 |f      |         3|_timescaledb_functions  |get_partition_hash|               |                        |                       |                |f        
+ 6|            4|time Col %#^#@$#|timestamp with time zone|t      |          |                        |                  |   604800000000|                        |                       |                |f        
+ 7|            4|__region        |text                    |f      |         4|_timescaledb_functions  |get_partition_hash|               |                        |                       |                |f        
 (5 rows)
 
 
@@ -2317,13 +2317,13 @@ id|schema_name  |table_name     |associated_schema_name|associated_table_prefix|
 NOTICE:  [db_dist_hypertable_3]: 
 SELECT * FROM _timescaledb_catalog.dimension
 NOTICE:  [db_dist_hypertable_3]:
-id|hypertable_id|column_name     |column_type             |aligned|num_slices|partitioning_func_schema|partitioning_func |interval_length|compress_interval_length|integer_now_func_schema|integer_now_func
---+-------------+----------------+------------------------+-------+----------+------------------------+------------------+---------------+------------------------+-----------------------+----------------
- 1|            1|time            |timestamp with time zone|t      |          |                        |                  |   604800000000|                        |                       |                
- 3|            2|time            |timestamp with time zone|t      |          |                        |                  |   604800000000|                        |                       |                
- 2|            1|device          |integer                 |f      |         3|_timescaledb_functions  |get_partition_hash|               |                        |                       |                
- 4|            3|time Col %#^#@$#|timestamp with time zone|t      |          |                        |                  |   604800000000|                        |                       |                
- 5|            3|__region        |text                    |f      |         4|_timescaledb_functions  |get_partition_hash|               |                        |                       |                
+id|hypertable_id|column_name     |column_type             |aligned|num_slices|partitioning_func_schema|partitioning_func |interval_length|compress_interval_length|integer_now_func_schema|integer_now_func|secondary
+--+-------------+----------------+------------------------+-------+----------+------------------------+------------------+---------------+------------------------+-----------------------+----------------+---------
+ 1|            1|time            |timestamp with time zone|t      |          |                        |                  |   604800000000|                        |                       |                |f        
+ 3|            2|time            |timestamp with time zone|t      |          |                        |                  |   604800000000|                        |                       |                |f        
+ 2|            1|device          |integer                 |f      |         3|_timescaledb_functions  |get_partition_hash|               |                        |                       |                |f        
+ 4|            3|time Col %#^#@$#|timestamp with time zone|t      |          |                        |                  |   604800000000|                        |                       |                |f        
+ 5|            3|__region        |text                    |f      |         4|_timescaledb_functions  |get_partition_hash|               |                        |                       |                |f        
 (5 rows)
 
 
@@ -2445,17 +2445,17 @@ SELECT * FROM dimented_table ORDER BY time;
 (1 row)
 
 SELECT * FROM _timescaledb_catalog.dimension;
- id | hypertable_id |   column_name    |       column_type        | aligned | num_slices | partitioning_func_schema |   partitioning_func   | interval_length | compress_interval_length | integer_now_func_schema | integer_now_func 
-----+---------------+------------------+--------------------------+---------+------------+--------------------------+-----------------------+-----------------+--------------------------+-------------------------+------------------
-  1 |             1 | time             | timestamp with time zone | t       |            |                          |                       |    604800000000 |                          |                         | 
-  3 |             2 | time             | timestamp with time zone | t       |            |                          |                       |    604800000000 |                          |                         | 
-  2 |             1 | device           | integer                  | f       |          3 | _timescaledb_functions   | get_partition_hash    |                 |                          |                         | 
-  5 |             4 | time Col %#^#@$# | timestamp with time zone | t       |            |                          |                       |    604800000000 |                          |                         | 
-  6 |             4 | __region         | text                     | f       |          2 | _timescaledb_functions   | get_partition_hash    |                 |                          |                         | 
-  7 |             5 | time             | timestamp with time zone | t       |            |                          |                       |    604800000000 |                          |                         | 
-  8 |             5 | column1          | integer                  | f       |          4 | _timescaledb_functions   | get_partition_hash    |                 |                          |                         | 
-  9 |             5 | column2          | timestamp with time zone | t       |            |                          |                       |    604800000000 |                          |                         | 
- 10 |             5 | column3          | integer                  | f       |          4 | _timescaledb_functions   | get_partition_for_key |                 |                          |                         | 
+ id | hypertable_id |   column_name    |       column_type        | aligned | num_slices | partitioning_func_schema |   partitioning_func   | interval_length | compress_interval_length | integer_now_func_schema | integer_now_func | secondary 
+----+---------------+------------------+--------------------------+---------+------------+--------------------------+-----------------------+-----------------+--------------------------+-------------------------+------------------+-----------
+  1 |             1 | time             | timestamp with time zone | t       |            |                          |                       |    604800000000 |                          |                         |                  | f
+  3 |             2 | time             | timestamp with time zone | t       |            |                          |                       |    604800000000 |                          |                         |                  | f
+  2 |             1 | device           | integer                  | f       |          3 | _timescaledb_functions   | get_partition_hash    |                 |                          |                         |                  | f
+  5 |             4 | time Col %#^#@$# | timestamp with time zone | t       |            |                          |                       |    604800000000 |                          |                         |                  | f
+  6 |             4 | __region         | text                     | f       |          2 | _timescaledb_functions   | get_partition_hash    |                 |                          |                         |                  | f
+  7 |             5 | time             | timestamp with time zone | t       |            |                          |                       |    604800000000 |                          |                         |                  | f
+  8 |             5 | column1          | integer                  | f       |          4 | _timescaledb_functions   | get_partition_hash    |                 |                          |                         |                  | f
+  9 |             5 | column2          | timestamp with time zone | t       |            |                          |                       |    604800000000 |                          |                         |                  | f
+ 10 |             5 | column3          | integer                  | f       |          4 | _timescaledb_functions   | get_partition_for_key |                 |                          |                         |                  | f
 (9 rows)
 
 SELECT * FROM attach_data_node(:'DATA_NODE_2', 'dimented_table');
@@ -2465,17 +2465,17 @@ SELECT * FROM attach_data_node(:'DATA_NODE_2', 'dimented_table');
 (1 row)
 
 SELECT * FROM _timescaledb_catalog.dimension;
- id | hypertable_id |   column_name    |       column_type        | aligned | num_slices | partitioning_func_schema |   partitioning_func   | interval_length | compress_interval_length | integer_now_func_schema | integer_now_func 
-----+---------------+------------------+--------------------------+---------+------------+--------------------------+-----------------------+-----------------+--------------------------+-------------------------+------------------
-  1 |             1 | time             | timestamp with time zone | t       |            |                          |                       |    604800000000 |                          |                         | 
-  3 |             2 | time             | timestamp with time zone | t       |            |                          |                       |    604800000000 |                          |                         | 
-  2 |             1 | device           | integer                  | f       |          3 | _timescaledb_functions   | get_partition_hash    |                 |                          |                         | 
-  5 |             4 | time Col %#^#@$# | timestamp with time zone | t       |            |                          |                       |    604800000000 |                          |                         | 
-  6 |             4 | __region         | text                     | f       |          2 | _timescaledb_functions   | get_partition_hash    |                 |                          |                         | 
-  7 |             5 | time             | timestamp with time zone | t       |            |                          |                       |    604800000000 |                          |                         | 
-  8 |             5 | column1          | integer                  | f       |          4 | _timescaledb_functions   | get_partition_hash    |                 |                          |                         | 
-  9 |             5 | column2          | timestamp with time zone | t       |            |                          |                       |    604800000000 |                          |                         | 
- 10 |             5 | column3          | integer                  | f       |          4 | _timescaledb_functions   | get_partition_for_key |                 |                          |                         | 
+ id | hypertable_id |   column_name    |       column_type        | aligned | num_slices | partitioning_func_schema |   partitioning_func   | interval_length | compress_interval_length | integer_now_func_schema | integer_now_func | secondary 
+----+---------------+------------------+--------------------------+---------+------------+--------------------------+-----------------------+-----------------+--------------------------+-------------------------+------------------+-----------
+  1 |             1 | time             | timestamp with time zone | t       |            |                          |                       |    604800000000 |                          |                         |                  | f
+  3 |             2 | time             | timestamp with time zone | t       |            |                          |                       |    604800000000 |                          |                         |                  | f
+  2 |             1 | device           | integer                  | f       |          3 | _timescaledb_functions   | get_partition_hash    |                 |                          |                         |                  | f
+  5 |             4 | time Col %#^#@$# | timestamp with time zone | t       |            |                          |                       |    604800000000 |                          |                         |                  | f
+  6 |             4 | __region         | text                     | f       |          2 | _timescaledb_functions   | get_partition_hash    |                 |                          |                         |                  | f
+  7 |             5 | time             | timestamp with time zone | t       |            |                          |                       |    604800000000 |                          |                         |                  | f
+  8 |             5 | column1          | integer                  | f       |          4 | _timescaledb_functions   | get_partition_hash    |                 |                          |                         |                  | f
+  9 |             5 | column2          | timestamp with time zone | t       |            |                          |                       |    604800000000 |                          |                         |                  | f
+ 10 |             5 | column3          | integer                  | f       |          4 | _timescaledb_functions   | get_partition_for_key |                 |                          |                         |                  | f
 (9 rows)
 
 -- ensure data node has new dimensions
@@ -2485,47 +2485,47 @@ $$);
 NOTICE:  [db_dist_hypertable_1]: 
 SELECT * FROM _timescaledb_catalog.dimension
 NOTICE:  [db_dist_hypertable_1]:
-id|hypertable_id|column_name     |column_type             |aligned|num_slices|partitioning_func_schema|partitioning_func    |interval_length|compress_interval_length|integer_now_func_schema|integer_now_func
---+-------------+----------------+------------------------+-------+----------+------------------------+---------------------+---------------+------------------------+-----------------------+----------------
- 1|            1|time            |timestamp with time zone|t      |          |                        |                     |   604800000000|                        |                       |                
- 3|            2|time            |timestamp with time zone|t      |          |                        |                     |   604800000000|                        |                       |                
- 2|            1|device          |integer                 |f      |         3|_timescaledb_functions  |get_partition_hash   |               |                        |                       |                
- 4|            3|time Col %#^#@$#|timestamp with time zone|t      |          |                        |                     |   604800000000|                        |                       |                
- 5|            3|__region        |text                    |f      |         4|_timescaledb_functions  |get_partition_hash   |               |                        |                       |                
- 6|            4|time            |timestamp with time zone|t      |          |                        |                     |   604800000000|                        |                       |                
- 7|            4|column1         |integer                 |f      |         4|_timescaledb_functions  |get_partition_hash   |               |                        |                       |                
- 8|            4|column2         |timestamp with time zone|t      |          |                        |                     |   604800000000|                        |                       |                
- 9|            4|column3         |integer                 |f      |         4|_timescaledb_functions  |get_partition_for_key|               |                        |                       |                
+id|hypertable_id|column_name     |column_type             |aligned|num_slices|partitioning_func_schema|partitioning_func    |interval_length|compress_interval_length|integer_now_func_schema|integer_now_func|secondary
+--+-------------+----------------+------------------------+-------+----------+------------------------+---------------------+---------------+------------------------+-----------------------+----------------+---------
+ 1|            1|time            |timestamp with time zone|t      |          |                        |                     |   604800000000|                        |                       |                |f        
+ 3|            2|time            |timestamp with time zone|t      |          |                        |                     |   604800000000|                        |                       |                |f        
+ 2|            1|device          |integer                 |f      |         3|_timescaledb_functions  |get_partition_hash   |               |                        |                       |                |f        
+ 4|            3|time Col %#^#@$#|timestamp with time zone|t      |          |                        |                     |   604800000000|                        |                       |                |f        
+ 5|            3|__region        |text                    |f      |         4|_timescaledb_functions  |get_partition_hash   |               |                        |                       |                |f        
+ 6|            4|time            |timestamp with time zone|t      |          |                        |                     |   604800000000|                        |                       |                |f        
+ 7|            4|column1         |integer                 |f      |         4|_timescaledb_functions  |get_partition_hash   |               |                        |                       |                |f        
+ 8|            4|column2         |timestamp with time zone|t      |          |                        |                     |   604800000000|                        |                       |                |f        
+ 9|            4|column3         |integer                 |f      |         4|_timescaledb_functions  |get_partition_for_key|               |                        |                       |                |f        
 (9 rows)
 
 
 NOTICE:  [db_dist_hypertable_2]: 
 SELECT * FROM _timescaledb_catalog.dimension
 NOTICE:  [db_dist_hypertable_2]:
-id|hypertable_id|column_name     |column_type             |aligned|num_slices|partitioning_func_schema|partitioning_func    |interval_length|compress_interval_length|integer_now_func_schema|integer_now_func
---+-------------+----------------+------------------------+-------+----------+------------------------+---------------------+---------------+------------------------+-----------------------+----------------
- 1|            1|time            |timestamp with time zone|t      |          |                        |                     |   604800000000|                        |                       |                
- 3|            2|time            |timestamp with time zone|t      |          |                        |                     |   604800000000|                        |                       |                
- 2|            1|device          |integer                 |f      |         3|_timescaledb_functions  |get_partition_hash   |               |                        |                       |                
- 6|            4|time Col %#^#@$#|timestamp with time zone|t      |          |                        |                     |   604800000000|                        |                       |                
- 7|            4|__region        |text                    |f      |         4|_timescaledb_functions  |get_partition_hash   |               |                        |                       |                
- 8|            5|time            |timestamp with time zone|t      |          |                        |                     |   604800000000|                        |                       |                
- 9|            5|column1         |integer                 |f      |         4|_timescaledb_functions  |get_partition_hash   |               |                        |                       |                
-10|            5|column2         |timestamp with time zone|t      |          |                        |                     |   604800000000|                        |                       |                
-11|            5|column3         |integer                 |f      |         4|_timescaledb_functions  |get_partition_for_key|               |                        |                       |                
+id|hypertable_id|column_name     |column_type             |aligned|num_slices|partitioning_func_schema|partitioning_func    |interval_length|compress_interval_length|integer_now_func_schema|integer_now_func|secondary
+--+-------------+----------------+------------------------+-------+----------+------------------------+---------------------+---------------+------------------------+-----------------------+----------------+---------
+ 1|            1|time            |timestamp with time zone|t      |          |                        |                     |   604800000000|                        |                       |                |f        
+ 3|            2|time            |timestamp with time zone|t      |          |                        |                     |   604800000000|                        |                       |                |f        
+ 2|            1|device          |integer                 |f      |         3|_timescaledb_functions  |get_partition_hash   |               |                        |                       |                |f        
+ 6|            4|time Col %#^#@$#|timestamp with time zone|t      |          |                        |                     |   604800000000|                        |                       |                |f        
+ 7|            4|__region        |text                    |f      |         4|_timescaledb_functions  |get_partition_hash   |               |                        |                       |                |f        
+ 8|            5|time            |timestamp with time zone|t      |          |                        |                     |   604800000000|                        |                       |                |f        
+ 9|            5|column1         |integer                 |f      |         4|_timescaledb_functions  |get_partition_hash   |               |                        |                       |                |f        
+10|            5|column2         |timestamp with time zone|t      |          |                        |                     |   604800000000|                        |                       |                |f        
+11|            5|column3         |integer                 |f      |         4|_timescaledb_functions  |get_partition_for_key|               |                        |                       |                |f        
 (9 rows)
 
 
 NOTICE:  [db_dist_hypertable_3]: 
 SELECT * FROM _timescaledb_catalog.dimension
 NOTICE:  [db_dist_hypertable_3]:
-id|hypertable_id|column_name     |column_type             |aligned|num_slices|partitioning_func_schema|partitioning_func |interval_length|compress_interval_length|integer_now_func_schema|integer_now_func
---+-------------+----------------+------------------------+-------+----------+------------------------+------------------+---------------+------------------------+-----------------------+----------------
- 1|            1|time            |timestamp with time zone|t      |          |                        |                  |   604800000000|                        |                       |                
- 3|            2|time            |timestamp with time zone|t      |          |                        |                  |   604800000000|                        |                       |                
- 2|            1|device          |integer                 |f      |         3|_timescaledb_functions  |get_partition_hash|               |                        |                       |                
- 4|            3|time Col %#^#@$#|timestamp with time zone|t      |          |                        |                  |   604800000000|                        |                       |                
- 5|            3|__region        |text                    |f      |         4|_timescaledb_functions  |get_partition_hash|               |                        |                       |                
+id|hypertable_id|column_name     |column_type             |aligned|num_slices|partitioning_func_schema|partitioning_func |interval_length|compress_interval_length|integer_now_func_schema|integer_now_func|secondary
+--+-------------+----------------+------------------------+-------+----------+------------------------+------------------+---------------+------------------------+-----------------------+----------------+---------
+ 1|            1|time            |timestamp with time zone|t      |          |                        |                  |   604800000000|                        |                       |                |f        
+ 3|            2|time            |timestamp with time zone|t      |          |                        |                  |   604800000000|                        |                       |                |f        
+ 2|            1|device          |integer                 |f      |         3|_timescaledb_functions  |get_partition_hash|               |                        |                       |                |f        
+ 4|            3|time Col %#^#@$#|timestamp with time zone|t      |          |                        |                  |   604800000000|                        |                       |                |f        
+ 5|            3|__region        |text                    |f      |         4|_timescaledb_functions  |get_partition_hash|               |                        |                       |                |f        
 (5 rows)
 
 
@@ -3498,9 +3498,9 @@ NOTICE:  [db_dist_hypertable_1]:
 SELECT d.* FROM _timescaledb_catalog.hypertable h, _timescaledb_catalog.dimension d
 WHERE h.id = d.hypertable_id AND h.table_name = 'disttable'
 NOTICE:  [db_dist_hypertable_1]:
-id|hypertable_id|column_name|column_type|aligned|num_slices|partitioning_func_schema|partitioning_func|interval_length|compress_interval_length|integer_now_func_schema|integer_now_func
---+-------------+-----------+-----------+-------+----------+------------------------+-----------------+---------------+------------------------+-----------------------+----------------
-20|           11|time       |bigint     |t      |          |                        |                 |        1000000|                        |                       |                
+id|hypertable_id|column_name|column_type|aligned|num_slices|partitioning_func_schema|partitioning_func|interval_length|compress_interval_length|integer_now_func_schema|integer_now_func|secondary
+--+-------------+-----------+-----------+-------+----------+------------------------+-----------------+---------------+------------------------+-----------------------+----------------+---------
+20|           11|time       |bigint     |t      |          |                        |                 |        1000000|                        |                       |                |f        
 (1 row)
 
 
@@ -3508,9 +3508,9 @@ NOTICE:  [db_dist_hypertable_2]:
 SELECT d.* FROM _timescaledb_catalog.hypertable h, _timescaledb_catalog.dimension d
 WHERE h.id = d.hypertable_id AND h.table_name = 'disttable'
 NOTICE:  [db_dist_hypertable_2]:
-id|hypertable_id|column_name|column_type|aligned|num_slices|partitioning_func_schema|partitioning_func|interval_length|compress_interval_length|integer_now_func_schema|integer_now_func
---+-------------+-----------+-----------+-------+----------+------------------------+-----------------+---------------+------------------------+-----------------------+----------------
-20|           11|time       |bigint     |t      |          |                        |                 |        1000000|                        |                       |                
+id|hypertable_id|column_name|column_type|aligned|num_slices|partitioning_func_schema|partitioning_func|interval_length|compress_interval_length|integer_now_func_schema|integer_now_func|secondary
+--+-------------+-----------+-----------+-------+----------+------------------------+-----------------+---------------+------------------------+-----------------------+----------------+---------
+20|           11|time       |bigint     |t      |          |                        |                 |        1000000|                        |                       |                |f        
 (1 row)
 
 
@@ -3518,9 +3518,9 @@ NOTICE:  [db_dist_hypertable_3]:
 SELECT d.* FROM _timescaledb_catalog.hypertable h, _timescaledb_catalog.dimension d
 WHERE h.id = d.hypertable_id AND h.table_name = 'disttable'
 NOTICE:  [db_dist_hypertable_3]:
-id|hypertable_id|column_name|column_type|aligned|num_slices|partitioning_func_schema|partitioning_func|interval_length|compress_interval_length|integer_now_func_schema|integer_now_func
---+-------------+-----------+-----------+-------+----------+------------------------+-----------------+---------------+------------------------+-----------------------+----------------
-14|            9|time       |bigint     |t      |          |                        |                 |        1000000|                        |                       |                
+id|hypertable_id|column_name|column_type|aligned|num_slices|partitioning_func_schema|partitioning_func|interval_length|compress_interval_length|integer_now_func_schema|integer_now_func|secondary
+--+-------------+-----------+-----------+-------+----------+------------------------+-----------------+---------------+------------------------+-----------------------+----------------+---------
+14|            9|time       |bigint     |t      |          |                        |                 |        1000000|                        |                       |                |f        
 (1 row)
 
 
@@ -3548,10 +3548,10 @@ NOTICE:  [db_dist_hypertable_1]:
 SELECT d.* FROM _timescaledb_catalog.hypertable h, _timescaledb_catalog.dimension d
 WHERE h.id = d.hypertable_id AND h.table_name = 'disttable'
 NOTICE:  [db_dist_hypertable_1]:
-id|hypertable_id|column_name|column_type|aligned|num_slices|partitioning_func_schema|partitioning_func |interval_length|compress_interval_length|integer_now_func_schema|integer_now_func
---+-------------+-----------+-----------+-------+----------+------------------------+------------------+---------------+------------------------+-----------------------+----------------
-21|           11|device     |integer    |f      |         1|_timescaledb_functions  |get_partition_hash|               |                        |                       |                
-20|           11|time       |bigint     |t      |          |                        |                  |        1000000|                        |                       |                
+id|hypertable_id|column_name|column_type|aligned|num_slices|partitioning_func_schema|partitioning_func |interval_length|compress_interval_length|integer_now_func_schema|integer_now_func|secondary
+--+-------------+-----------+-----------+-------+----------+------------------------+------------------+---------------+------------------------+-----------------------+----------------+---------
+21|           11|device     |integer    |f      |         1|_timescaledb_functions  |get_partition_hash|               |                        |                       |                |f        
+20|           11|time       |bigint     |t      |          |                        |                  |        1000000|                        |                       |                |f        
 (2 rows)
 
 
@@ -3559,10 +3559,10 @@ NOTICE:  [db_dist_hypertable_2]:
 SELECT d.* FROM _timescaledb_catalog.hypertable h, _timescaledb_catalog.dimension d
 WHERE h.id = d.hypertable_id AND h.table_name = 'disttable'
 NOTICE:  [db_dist_hypertable_2]:
-id|hypertable_id|column_name|column_type|aligned|num_slices|partitioning_func_schema|partitioning_func |interval_length|compress_interval_length|integer_now_func_schema|integer_now_func
---+-------------+-----------+-----------+-------+----------+------------------------+------------------+---------------+------------------------+-----------------------+----------------
-21|           11|device     |integer    |f      |         1|_timescaledb_functions  |get_partition_hash|               |                        |                       |                
-20|           11|time       |bigint     |t      |          |                        |                  |        1000000|                        |                       |                
+id|hypertable_id|column_name|column_type|aligned|num_slices|partitioning_func_schema|partitioning_func |interval_length|compress_interval_length|integer_now_func_schema|integer_now_func|secondary
+--+-------------+-----------+-----------+-------+----------+------------------------+------------------+---------------+------------------------+-----------------------+----------------+---------
+21|           11|device     |integer    |f      |         1|_timescaledb_functions  |get_partition_hash|               |                        |                       |                |f        
+20|           11|time       |bigint     |t      |          |                        |                  |        1000000|                        |                       |                |f        
 (2 rows)
 
 
@@ -3570,10 +3570,10 @@ NOTICE:  [db_dist_hypertable_3]:
 SELECT d.* FROM _timescaledb_catalog.hypertable h, _timescaledb_catalog.dimension d
 WHERE h.id = d.hypertable_id AND h.table_name = 'disttable'
 NOTICE:  [db_dist_hypertable_3]:
-id|hypertable_id|column_name|column_type|aligned|num_slices|partitioning_func_schema|partitioning_func |interval_length|compress_interval_length|integer_now_func_schema|integer_now_func
---+-------------+-----------+-----------+-------+----------+------------------------+------------------+---------------+------------------------+-----------------------+----------------
-15|            9|device     |integer    |f      |         1|_timescaledb_functions  |get_partition_hash|               |                        |                       |                
-14|            9|time       |bigint     |t      |          |                        |                  |        1000000|                        |                       |                
+id|hypertable_id|column_name|column_type|aligned|num_slices|partitioning_func_schema|partitioning_func |interval_length|compress_interval_length|integer_now_func_schema|integer_now_func|secondary
+--+-------------+-----------+-----------+-------+----------+------------------------+------------------+---------------+------------------------+-----------------------+----------------+---------
+15|            9|device     |integer    |f      |         1|_timescaledb_functions  |get_partition_hash|               |                        |                       |                |f        
+14|            9|time       |bigint     |t      |          |                        |                  |        1000000|                        |                       |                |f        
 (2 rows)
 
 
@@ -3614,10 +3614,10 @@ NOTICE:  [db_dist_hypertable_1]:
 SELECT d.* FROM _timescaledb_catalog.hypertable h, _timescaledb_catalog.dimension d
 WHERE h.id = d.hypertable_id AND h.table_name = 'disttable'
 NOTICE:  [db_dist_hypertable_1]:
-id|hypertable_id|column_name|column_type|aligned|num_slices|partitioning_func_schema|partitioning_func |interval_length|compress_interval_length|integer_now_func_schema|integer_now_func
---+-------------+-----------+-----------+-------+----------+------------------------+------------------+---------------+------------------------+-----------------------+----------------
-21|           11|device     |integer    |f      |         3|_timescaledb_functions  |get_partition_hash|               |                        |                       |                
-20|           11|time       |bigint     |t      |          |                        |                  |     2000000000|                        |public                 |dummy_now       
+id|hypertable_id|column_name|column_type|aligned|num_slices|partitioning_func_schema|partitioning_func |interval_length|compress_interval_length|integer_now_func_schema|integer_now_func|secondary
+--+-------------+-----------+-----------+-------+----------+------------------------+------------------+---------------+------------------------+-----------------------+----------------+---------
+21|           11|device     |integer    |f      |         3|_timescaledb_functions  |get_partition_hash|               |                        |                       |                |f        
+20|           11|time       |bigint     |t      |          |                        |                  |     2000000000|                        |public                 |dummy_now       |f        
 (2 rows)
 
 
@@ -3625,10 +3625,10 @@ NOTICE:  [db_dist_hypertable_2]:
 SELECT d.* FROM _timescaledb_catalog.hypertable h, _timescaledb_catalog.dimension d
 WHERE h.id = d.hypertable_id AND h.table_name = 'disttable'
 NOTICE:  [db_dist_hypertable_2]:
-id|hypertable_id|column_name|column_type|aligned|num_slices|partitioning_func_schema|partitioning_func |interval_length|compress_interval_length|integer_now_func_schema|integer_now_func
---+-------------+-----------+-----------+-------+----------+------------------------+------------------+---------------+------------------------+-----------------------+----------------
-21|           11|device     |integer    |f      |         3|_timescaledb_functions  |get_partition_hash|               |                        |                       |                
-20|           11|time       |bigint     |t      |          |                        |                  |     2000000000|                        |public                 |dummy_now       
+id|hypertable_id|column_name|column_type|aligned|num_slices|partitioning_func_schema|partitioning_func |interval_length|compress_interval_length|integer_now_func_schema|integer_now_func|secondary
+--+-------------+-----------+-----------+-------+----------+------------------------+------------------+---------------+------------------------+-----------------------+----------------+---------
+21|           11|device     |integer    |f      |         3|_timescaledb_functions  |get_partition_hash|               |                        |                       |                |f        
+20|           11|time       |bigint     |t      |          |                        |                  |     2000000000|                        |public                 |dummy_now       |f        
 (2 rows)
 
 
@@ -3636,10 +3636,10 @@ NOTICE:  [db_dist_hypertable_3]:
 SELECT d.* FROM _timescaledb_catalog.hypertable h, _timescaledb_catalog.dimension d
 WHERE h.id = d.hypertable_id AND h.table_name = 'disttable'
 NOTICE:  [db_dist_hypertable_3]:
-id|hypertable_id|column_name|column_type|aligned|num_slices|partitioning_func_schema|partitioning_func |interval_length|compress_interval_length|integer_now_func_schema|integer_now_func
---+-------------+-----------+-----------+-------+----------+------------------------+------------------+---------------+------------------------+-----------------------+----------------
-15|            9|device     |integer    |f      |         3|_timescaledb_functions  |get_partition_hash|               |                        |                       |                
-14|            9|time       |bigint     |t      |          |                        |                  |     2000000000|                        |public                 |dummy_now       
+id|hypertable_id|column_name|column_type|aligned|num_slices|partitioning_func_schema|partitioning_func |interval_length|compress_interval_length|integer_now_func_schema|integer_now_func|secondary
+--+-------------+-----------+-----------+-------+----------+------------------------+------------------+---------------+------------------------+-----------------------+----------------+---------
+15|            9|device     |integer    |f      |         3|_timescaledb_functions  |get_partition_hash|               |                        |                       |                |f        
+14|            9|time       |bigint     |t      |          |                        |                  |     2000000000|                        |public                 |dummy_now       |f        
 (2 rows)
 
 

--- a/tsl/test/expected/dist_hypertable-15.out
+++ b/tsl/test/expected/dist_hypertable-15.out
@@ -2220,13 +2220,13 @@ SELECT * FROM _timescaledb_catalog.hypertable;
 (3 rows)
 
 SELECT * FROM _timescaledb_catalog.dimension;
- id | hypertable_id |   column_name    |       column_type        | aligned | num_slices | partitioning_func_schema | partitioning_func  | interval_length | compress_interval_length | integer_now_func_schema | integer_now_func 
-----+---------------+------------------+--------------------------+---------+------------+--------------------------+--------------------+-----------------+--------------------------+-------------------------+------------------
-  1 |             1 | time             | timestamp with time zone | t       |            |                          |                    |    604800000000 |                          |                         | 
-  3 |             2 | time             | timestamp with time zone | t       |            |                          |                    |    604800000000 |                          |                         | 
-  2 |             1 | device           | integer                  | f       |          3 | _timescaledb_functions   | get_partition_hash |                 |                          |                         | 
-  5 |             4 | time Col %#^#@$# | timestamp with time zone | t       |            |                          |                    |    604800000000 |                          |                         | 
-  6 |             4 | __region         | text                     | f       |          4 | _timescaledb_functions   | get_partition_hash |                 |                          |                         | 
+ id | hypertable_id |   column_name    |       column_type        | aligned | num_slices | partitioning_func_schema | partitioning_func  | interval_length | compress_interval_length | integer_now_func_schema | integer_now_func | secondary 
+----+---------------+------------------+--------------------------+---------+------------+--------------------------+--------------------+-----------------+--------------------------+-------------------------+------------------+-----------
+  1 |             1 | time             | timestamp with time zone | t       |            |                          |                    |    604800000000 |                          |                         |                  | f
+  3 |             2 | time             | timestamp with time zone | t       |            |                          |                    |    604800000000 |                          |                         |                  | f
+  2 |             1 | device           | integer                  | f       |          3 | _timescaledb_functions   | get_partition_hash |                 |                          |                         |                  | f
+  5 |             4 | time Col %#^#@$# | timestamp with time zone | t       |            |                          |                    |    604800000000 |                          |                         |                  | f
+  6 |             4 | __region         | text                     | f       |          4 | _timescaledb_functions   | get_partition_hash |                 |                          |                         |                  | f
 (5 rows)
 
 SELECT * FROM test.show_triggers('"Table\\Schema"."Param_Table"');
@@ -2255,13 +2255,13 @@ id|schema_name  |table_name     |associated_schema_name|associated_table_prefix|
 NOTICE:  [db_dist_hypertable_1]: 
 SELECT * FROM _timescaledb_catalog.dimension
 NOTICE:  [db_dist_hypertable_1]:
-id|hypertable_id|column_name     |column_type             |aligned|num_slices|partitioning_func_schema|partitioning_func |interval_length|compress_interval_length|integer_now_func_schema|integer_now_func
---+-------------+----------------+------------------------+-------+----------+------------------------+------------------+---------------+------------------------+-----------------------+----------------
- 1|            1|time            |timestamp with time zone|t      |          |                        |                  |   604800000000|                        |                       |                
- 3|            2|time            |timestamp with time zone|t      |          |                        |                  |   604800000000|                        |                       |                
- 2|            1|device          |integer                 |f      |         3|_timescaledb_functions  |get_partition_hash|               |                        |                       |                
- 4|            3|time Col %#^#@$#|timestamp with time zone|t      |          |                        |                  |   604800000000|                        |                       |                
- 5|            3|__region        |text                    |f      |         4|_timescaledb_functions  |get_partition_hash|               |                        |                       |                
+id|hypertable_id|column_name     |column_type             |aligned|num_slices|partitioning_func_schema|partitioning_func |interval_length|compress_interval_length|integer_now_func_schema|integer_now_func|secondary
+--+-------------+----------------+------------------------+-------+----------+------------------------+------------------+---------------+------------------------+-----------------------+----------------+---------
+ 1|            1|time            |timestamp with time zone|t      |          |                        |                  |   604800000000|                        |                       |                |f        
+ 3|            2|time            |timestamp with time zone|t      |          |                        |                  |   604800000000|                        |                       |                |f        
+ 2|            1|device          |integer                 |f      |         3|_timescaledb_functions  |get_partition_hash|               |                        |                       |                |f        
+ 4|            3|time Col %#^#@$#|timestamp with time zone|t      |          |                        |                  |   604800000000|                        |                       |                |f        
+ 5|            3|__region        |text                    |f      |         4|_timescaledb_functions  |get_partition_hash|               |                        |                       |                |f        
 (5 rows)
 
 
@@ -2289,13 +2289,13 @@ id|schema_name  |table_name     |associated_schema_name|associated_table_prefix|
 NOTICE:  [db_dist_hypertable_2]: 
 SELECT * FROM _timescaledb_catalog.dimension
 NOTICE:  [db_dist_hypertable_2]:
-id|hypertable_id|column_name     |column_type             |aligned|num_slices|partitioning_func_schema|partitioning_func |interval_length|compress_interval_length|integer_now_func_schema|integer_now_func
---+-------------+----------------+------------------------+-------+----------+------------------------+------------------+---------------+------------------------+-----------------------+----------------
- 1|            1|time            |timestamp with time zone|t      |          |                        |                  |   604800000000|                        |                       |                
- 3|            2|time            |timestamp with time zone|t      |          |                        |                  |   604800000000|                        |                       |                
- 2|            1|device          |integer                 |f      |         3|_timescaledb_functions  |get_partition_hash|               |                        |                       |                
- 6|            4|time Col %#^#@$#|timestamp with time zone|t      |          |                        |                  |   604800000000|                        |                       |                
- 7|            4|__region        |text                    |f      |         4|_timescaledb_functions  |get_partition_hash|               |                        |                       |                
+id|hypertable_id|column_name     |column_type             |aligned|num_slices|partitioning_func_schema|partitioning_func |interval_length|compress_interval_length|integer_now_func_schema|integer_now_func|secondary
+--+-------------+----------------+------------------------+-------+----------+------------------------+------------------+---------------+------------------------+-----------------------+----------------+---------
+ 1|            1|time            |timestamp with time zone|t      |          |                        |                  |   604800000000|                        |                       |                |f        
+ 3|            2|time            |timestamp with time zone|t      |          |                        |                  |   604800000000|                        |                       |                |f        
+ 2|            1|device          |integer                 |f      |         3|_timescaledb_functions  |get_partition_hash|               |                        |                       |                |f        
+ 6|            4|time Col %#^#@$#|timestamp with time zone|t      |          |                        |                  |   604800000000|                        |                       |                |f        
+ 7|            4|__region        |text                    |f      |         4|_timescaledb_functions  |get_partition_hash|               |                        |                       |                |f        
 (5 rows)
 
 
@@ -2323,13 +2323,13 @@ id|schema_name  |table_name     |associated_schema_name|associated_table_prefix|
 NOTICE:  [db_dist_hypertable_3]: 
 SELECT * FROM _timescaledb_catalog.dimension
 NOTICE:  [db_dist_hypertable_3]:
-id|hypertable_id|column_name     |column_type             |aligned|num_slices|partitioning_func_schema|partitioning_func |interval_length|compress_interval_length|integer_now_func_schema|integer_now_func
---+-------------+----------------+------------------------+-------+----------+------------------------+------------------+---------------+------------------------+-----------------------+----------------
- 1|            1|time            |timestamp with time zone|t      |          |                        |                  |   604800000000|                        |                       |                
- 3|            2|time            |timestamp with time zone|t      |          |                        |                  |   604800000000|                        |                       |                
- 2|            1|device          |integer                 |f      |         3|_timescaledb_functions  |get_partition_hash|               |                        |                       |                
- 4|            3|time Col %#^#@$#|timestamp with time zone|t      |          |                        |                  |   604800000000|                        |                       |                
- 5|            3|__region        |text                    |f      |         4|_timescaledb_functions  |get_partition_hash|               |                        |                       |                
+id|hypertable_id|column_name     |column_type             |aligned|num_slices|partitioning_func_schema|partitioning_func |interval_length|compress_interval_length|integer_now_func_schema|integer_now_func|secondary
+--+-------------+----------------+------------------------+-------+----------+------------------------+------------------+---------------+------------------------+-----------------------+----------------+---------
+ 1|            1|time            |timestamp with time zone|t      |          |                        |                  |   604800000000|                        |                       |                |f        
+ 3|            2|time            |timestamp with time zone|t      |          |                        |                  |   604800000000|                        |                       |                |f        
+ 2|            1|device          |integer                 |f      |         3|_timescaledb_functions  |get_partition_hash|               |                        |                       |                |f        
+ 4|            3|time Col %#^#@$#|timestamp with time zone|t      |          |                        |                  |   604800000000|                        |                       |                |f        
+ 5|            3|__region        |text                    |f      |         4|_timescaledb_functions  |get_partition_hash|               |                        |                       |                |f        
 (5 rows)
 
 
@@ -2451,17 +2451,17 @@ SELECT * FROM dimented_table ORDER BY time;
 (1 row)
 
 SELECT * FROM _timescaledb_catalog.dimension;
- id | hypertable_id |   column_name    |       column_type        | aligned | num_slices | partitioning_func_schema |   partitioning_func   | interval_length | compress_interval_length | integer_now_func_schema | integer_now_func 
-----+---------------+------------------+--------------------------+---------+------------+--------------------------+-----------------------+-----------------+--------------------------+-------------------------+------------------
-  1 |             1 | time             | timestamp with time zone | t       |            |                          |                       |    604800000000 |                          |                         | 
-  3 |             2 | time             | timestamp with time zone | t       |            |                          |                       |    604800000000 |                          |                         | 
-  2 |             1 | device           | integer                  | f       |          3 | _timescaledb_functions   | get_partition_hash    |                 |                          |                         | 
-  5 |             4 | time Col %#^#@$# | timestamp with time zone | t       |            |                          |                       |    604800000000 |                          |                         | 
-  6 |             4 | __region         | text                     | f       |          2 | _timescaledb_functions   | get_partition_hash    |                 |                          |                         | 
-  7 |             5 | time             | timestamp with time zone | t       |            |                          |                       |    604800000000 |                          |                         | 
-  8 |             5 | column1          | integer                  | f       |          4 | _timescaledb_functions   | get_partition_hash    |                 |                          |                         | 
-  9 |             5 | column2          | timestamp with time zone | t       |            |                          |                       |    604800000000 |                          |                         | 
- 10 |             5 | column3          | integer                  | f       |          4 | _timescaledb_functions   | get_partition_for_key |                 |                          |                         | 
+ id | hypertable_id |   column_name    |       column_type        | aligned | num_slices | partitioning_func_schema |   partitioning_func   | interval_length | compress_interval_length | integer_now_func_schema | integer_now_func | secondary 
+----+---------------+------------------+--------------------------+---------+------------+--------------------------+-----------------------+-----------------+--------------------------+-------------------------+------------------+-----------
+  1 |             1 | time             | timestamp with time zone | t       |            |                          |                       |    604800000000 |                          |                         |                  | f
+  3 |             2 | time             | timestamp with time zone | t       |            |                          |                       |    604800000000 |                          |                         |                  | f
+  2 |             1 | device           | integer                  | f       |          3 | _timescaledb_functions   | get_partition_hash    |                 |                          |                         |                  | f
+  5 |             4 | time Col %#^#@$# | timestamp with time zone | t       |            |                          |                       |    604800000000 |                          |                         |                  | f
+  6 |             4 | __region         | text                     | f       |          2 | _timescaledb_functions   | get_partition_hash    |                 |                          |                         |                  | f
+  7 |             5 | time             | timestamp with time zone | t       |            |                          |                       |    604800000000 |                          |                         |                  | f
+  8 |             5 | column1          | integer                  | f       |          4 | _timescaledb_functions   | get_partition_hash    |                 |                          |                         |                  | f
+  9 |             5 | column2          | timestamp with time zone | t       |            |                          |                       |    604800000000 |                          |                         |                  | f
+ 10 |             5 | column3          | integer                  | f       |          4 | _timescaledb_functions   | get_partition_for_key |                 |                          |                         |                  | f
 (9 rows)
 
 SELECT * FROM attach_data_node(:'DATA_NODE_2', 'dimented_table');
@@ -2471,17 +2471,17 @@ SELECT * FROM attach_data_node(:'DATA_NODE_2', 'dimented_table');
 (1 row)
 
 SELECT * FROM _timescaledb_catalog.dimension;
- id | hypertable_id |   column_name    |       column_type        | aligned | num_slices | partitioning_func_schema |   partitioning_func   | interval_length | compress_interval_length | integer_now_func_schema | integer_now_func 
-----+---------------+------------------+--------------------------+---------+------------+--------------------------+-----------------------+-----------------+--------------------------+-------------------------+------------------
-  1 |             1 | time             | timestamp with time zone | t       |            |                          |                       |    604800000000 |                          |                         | 
-  3 |             2 | time             | timestamp with time zone | t       |            |                          |                       |    604800000000 |                          |                         | 
-  2 |             1 | device           | integer                  | f       |          3 | _timescaledb_functions   | get_partition_hash    |                 |                          |                         | 
-  5 |             4 | time Col %#^#@$# | timestamp with time zone | t       |            |                          |                       |    604800000000 |                          |                         | 
-  6 |             4 | __region         | text                     | f       |          2 | _timescaledb_functions   | get_partition_hash    |                 |                          |                         | 
-  7 |             5 | time             | timestamp with time zone | t       |            |                          |                       |    604800000000 |                          |                         | 
-  8 |             5 | column1          | integer                  | f       |          4 | _timescaledb_functions   | get_partition_hash    |                 |                          |                         | 
-  9 |             5 | column2          | timestamp with time zone | t       |            |                          |                       |    604800000000 |                          |                         | 
- 10 |             5 | column3          | integer                  | f       |          4 | _timescaledb_functions   | get_partition_for_key |                 |                          |                         | 
+ id | hypertable_id |   column_name    |       column_type        | aligned | num_slices | partitioning_func_schema |   partitioning_func   | interval_length | compress_interval_length | integer_now_func_schema | integer_now_func | secondary 
+----+---------------+------------------+--------------------------+---------+------------+--------------------------+-----------------------+-----------------+--------------------------+-------------------------+------------------+-----------
+  1 |             1 | time             | timestamp with time zone | t       |            |                          |                       |    604800000000 |                          |                         |                  | f
+  3 |             2 | time             | timestamp with time zone | t       |            |                          |                       |    604800000000 |                          |                         |                  | f
+  2 |             1 | device           | integer                  | f       |          3 | _timescaledb_functions   | get_partition_hash    |                 |                          |                         |                  | f
+  5 |             4 | time Col %#^#@$# | timestamp with time zone | t       |            |                          |                       |    604800000000 |                          |                         |                  | f
+  6 |             4 | __region         | text                     | f       |          2 | _timescaledb_functions   | get_partition_hash    |                 |                          |                         |                  | f
+  7 |             5 | time             | timestamp with time zone | t       |            |                          |                       |    604800000000 |                          |                         |                  | f
+  8 |             5 | column1          | integer                  | f       |          4 | _timescaledb_functions   | get_partition_hash    |                 |                          |                         |                  | f
+  9 |             5 | column2          | timestamp with time zone | t       |            |                          |                       |    604800000000 |                          |                         |                  | f
+ 10 |             5 | column3          | integer                  | f       |          4 | _timescaledb_functions   | get_partition_for_key |                 |                          |                         |                  | f
 (9 rows)
 
 -- ensure data node has new dimensions
@@ -2491,47 +2491,47 @@ $$);
 NOTICE:  [db_dist_hypertable_1]: 
 SELECT * FROM _timescaledb_catalog.dimension
 NOTICE:  [db_dist_hypertable_1]:
-id|hypertable_id|column_name     |column_type             |aligned|num_slices|partitioning_func_schema|partitioning_func    |interval_length|compress_interval_length|integer_now_func_schema|integer_now_func
---+-------------+----------------+------------------------+-------+----------+------------------------+---------------------+---------------+------------------------+-----------------------+----------------
- 1|            1|time            |timestamp with time zone|t      |          |                        |                     |   604800000000|                        |                       |                
- 3|            2|time            |timestamp with time zone|t      |          |                        |                     |   604800000000|                        |                       |                
- 2|            1|device          |integer                 |f      |         3|_timescaledb_functions  |get_partition_hash   |               |                        |                       |                
- 4|            3|time Col %#^#@$#|timestamp with time zone|t      |          |                        |                     |   604800000000|                        |                       |                
- 5|            3|__region        |text                    |f      |         4|_timescaledb_functions  |get_partition_hash   |               |                        |                       |                
- 6|            4|time            |timestamp with time zone|t      |          |                        |                     |   604800000000|                        |                       |                
- 7|            4|column1         |integer                 |f      |         4|_timescaledb_functions  |get_partition_hash   |               |                        |                       |                
- 8|            4|column2         |timestamp with time zone|t      |          |                        |                     |   604800000000|                        |                       |                
- 9|            4|column3         |integer                 |f      |         4|_timescaledb_functions  |get_partition_for_key|               |                        |                       |                
+id|hypertable_id|column_name     |column_type             |aligned|num_slices|partitioning_func_schema|partitioning_func    |interval_length|compress_interval_length|integer_now_func_schema|integer_now_func|secondary
+--+-------------+----------------+------------------------+-------+----------+------------------------+---------------------+---------------+------------------------+-----------------------+----------------+---------
+ 1|            1|time            |timestamp with time zone|t      |          |                        |                     |   604800000000|                        |                       |                |f        
+ 3|            2|time            |timestamp with time zone|t      |          |                        |                     |   604800000000|                        |                       |                |f        
+ 2|            1|device          |integer                 |f      |         3|_timescaledb_functions  |get_partition_hash   |               |                        |                       |                |f        
+ 4|            3|time Col %#^#@$#|timestamp with time zone|t      |          |                        |                     |   604800000000|                        |                       |                |f        
+ 5|            3|__region        |text                    |f      |         4|_timescaledb_functions  |get_partition_hash   |               |                        |                       |                |f        
+ 6|            4|time            |timestamp with time zone|t      |          |                        |                     |   604800000000|                        |                       |                |f        
+ 7|            4|column1         |integer                 |f      |         4|_timescaledb_functions  |get_partition_hash   |               |                        |                       |                |f        
+ 8|            4|column2         |timestamp with time zone|t      |          |                        |                     |   604800000000|                        |                       |                |f        
+ 9|            4|column3         |integer                 |f      |         4|_timescaledb_functions  |get_partition_for_key|               |                        |                       |                |f        
 (9 rows)
 
 
 NOTICE:  [db_dist_hypertable_2]: 
 SELECT * FROM _timescaledb_catalog.dimension
 NOTICE:  [db_dist_hypertable_2]:
-id|hypertable_id|column_name     |column_type             |aligned|num_slices|partitioning_func_schema|partitioning_func    |interval_length|compress_interval_length|integer_now_func_schema|integer_now_func
---+-------------+----------------+------------------------+-------+----------+------------------------+---------------------+---------------+------------------------+-----------------------+----------------
- 1|            1|time            |timestamp with time zone|t      |          |                        |                     |   604800000000|                        |                       |                
- 3|            2|time            |timestamp with time zone|t      |          |                        |                     |   604800000000|                        |                       |                
- 2|            1|device          |integer                 |f      |         3|_timescaledb_functions  |get_partition_hash   |               |                        |                       |                
- 6|            4|time Col %#^#@$#|timestamp with time zone|t      |          |                        |                     |   604800000000|                        |                       |                
- 7|            4|__region        |text                    |f      |         4|_timescaledb_functions  |get_partition_hash   |               |                        |                       |                
- 8|            5|time            |timestamp with time zone|t      |          |                        |                     |   604800000000|                        |                       |                
- 9|            5|column1         |integer                 |f      |         4|_timescaledb_functions  |get_partition_hash   |               |                        |                       |                
-10|            5|column2         |timestamp with time zone|t      |          |                        |                     |   604800000000|                        |                       |                
-11|            5|column3         |integer                 |f      |         4|_timescaledb_functions  |get_partition_for_key|               |                        |                       |                
+id|hypertable_id|column_name     |column_type             |aligned|num_slices|partitioning_func_schema|partitioning_func    |interval_length|compress_interval_length|integer_now_func_schema|integer_now_func|secondary
+--+-------------+----------------+------------------------+-------+----------+------------------------+---------------------+---------------+------------------------+-----------------------+----------------+---------
+ 1|            1|time            |timestamp with time zone|t      |          |                        |                     |   604800000000|                        |                       |                |f        
+ 3|            2|time            |timestamp with time zone|t      |          |                        |                     |   604800000000|                        |                       |                |f        
+ 2|            1|device          |integer                 |f      |         3|_timescaledb_functions  |get_partition_hash   |               |                        |                       |                |f        
+ 6|            4|time Col %#^#@$#|timestamp with time zone|t      |          |                        |                     |   604800000000|                        |                       |                |f        
+ 7|            4|__region        |text                    |f      |         4|_timescaledb_functions  |get_partition_hash   |               |                        |                       |                |f        
+ 8|            5|time            |timestamp with time zone|t      |          |                        |                     |   604800000000|                        |                       |                |f        
+ 9|            5|column1         |integer                 |f      |         4|_timescaledb_functions  |get_partition_hash   |               |                        |                       |                |f        
+10|            5|column2         |timestamp with time zone|t      |          |                        |                     |   604800000000|                        |                       |                |f        
+11|            5|column3         |integer                 |f      |         4|_timescaledb_functions  |get_partition_for_key|               |                        |                       |                |f        
 (9 rows)
 
 
 NOTICE:  [db_dist_hypertable_3]: 
 SELECT * FROM _timescaledb_catalog.dimension
 NOTICE:  [db_dist_hypertable_3]:
-id|hypertable_id|column_name     |column_type             |aligned|num_slices|partitioning_func_schema|partitioning_func |interval_length|compress_interval_length|integer_now_func_schema|integer_now_func
---+-------------+----------------+------------------------+-------+----------+------------------------+------------------+---------------+------------------------+-----------------------+----------------
- 1|            1|time            |timestamp with time zone|t      |          |                        |                  |   604800000000|                        |                       |                
- 3|            2|time            |timestamp with time zone|t      |          |                        |                  |   604800000000|                        |                       |                
- 2|            1|device          |integer                 |f      |         3|_timescaledb_functions  |get_partition_hash|               |                        |                       |                
- 4|            3|time Col %#^#@$#|timestamp with time zone|t      |          |                        |                  |   604800000000|                        |                       |                
- 5|            3|__region        |text                    |f      |         4|_timescaledb_functions  |get_partition_hash|               |                        |                       |                
+id|hypertable_id|column_name     |column_type             |aligned|num_slices|partitioning_func_schema|partitioning_func |interval_length|compress_interval_length|integer_now_func_schema|integer_now_func|secondary
+--+-------------+----------------+------------------------+-------+----------+------------------------+------------------+---------------+------------------------+-----------------------+----------------+---------
+ 1|            1|time            |timestamp with time zone|t      |          |                        |                  |   604800000000|                        |                       |                |f        
+ 3|            2|time            |timestamp with time zone|t      |          |                        |                  |   604800000000|                        |                       |                |f        
+ 2|            1|device          |integer                 |f      |         3|_timescaledb_functions  |get_partition_hash|               |                        |                       |                |f        
+ 4|            3|time Col %#^#@$#|timestamp with time zone|t      |          |                        |                  |   604800000000|                        |                       |                |f        
+ 5|            3|__region        |text                    |f      |         4|_timescaledb_functions  |get_partition_hash|               |                        |                       |                |f        
 (5 rows)
 
 
@@ -3504,9 +3504,9 @@ NOTICE:  [db_dist_hypertable_1]:
 SELECT d.* FROM _timescaledb_catalog.hypertable h, _timescaledb_catalog.dimension d
 WHERE h.id = d.hypertable_id AND h.table_name = 'disttable'
 NOTICE:  [db_dist_hypertable_1]:
-id|hypertable_id|column_name|column_type|aligned|num_slices|partitioning_func_schema|partitioning_func|interval_length|compress_interval_length|integer_now_func_schema|integer_now_func
---+-------------+-----------+-----------+-------+----------+------------------------+-----------------+---------------+------------------------+-----------------------+----------------
-20|           11|time       |bigint     |t      |          |                        |                 |        1000000|                        |                       |                
+id|hypertable_id|column_name|column_type|aligned|num_slices|partitioning_func_schema|partitioning_func|interval_length|compress_interval_length|integer_now_func_schema|integer_now_func|secondary
+--+-------------+-----------+-----------+-------+----------+------------------------+-----------------+---------------+------------------------+-----------------------+----------------+---------
+20|           11|time       |bigint     |t      |          |                        |                 |        1000000|                        |                       |                |f        
 (1 row)
 
 
@@ -3514,9 +3514,9 @@ NOTICE:  [db_dist_hypertable_2]:
 SELECT d.* FROM _timescaledb_catalog.hypertable h, _timescaledb_catalog.dimension d
 WHERE h.id = d.hypertable_id AND h.table_name = 'disttable'
 NOTICE:  [db_dist_hypertable_2]:
-id|hypertable_id|column_name|column_type|aligned|num_slices|partitioning_func_schema|partitioning_func|interval_length|compress_interval_length|integer_now_func_schema|integer_now_func
---+-------------+-----------+-----------+-------+----------+------------------------+-----------------+---------------+------------------------+-----------------------+----------------
-20|           11|time       |bigint     |t      |          |                        |                 |        1000000|                        |                       |                
+id|hypertable_id|column_name|column_type|aligned|num_slices|partitioning_func_schema|partitioning_func|interval_length|compress_interval_length|integer_now_func_schema|integer_now_func|secondary
+--+-------------+-----------+-----------+-------+----------+------------------------+-----------------+---------------+------------------------+-----------------------+----------------+---------
+20|           11|time       |bigint     |t      |          |                        |                 |        1000000|                        |                       |                |f        
 (1 row)
 
 
@@ -3524,9 +3524,9 @@ NOTICE:  [db_dist_hypertable_3]:
 SELECT d.* FROM _timescaledb_catalog.hypertable h, _timescaledb_catalog.dimension d
 WHERE h.id = d.hypertable_id AND h.table_name = 'disttable'
 NOTICE:  [db_dist_hypertable_3]:
-id|hypertable_id|column_name|column_type|aligned|num_slices|partitioning_func_schema|partitioning_func|interval_length|compress_interval_length|integer_now_func_schema|integer_now_func
---+-------------+-----------+-----------+-------+----------+------------------------+-----------------+---------------+------------------------+-----------------------+----------------
-14|            9|time       |bigint     |t      |          |                        |                 |        1000000|                        |                       |                
+id|hypertable_id|column_name|column_type|aligned|num_slices|partitioning_func_schema|partitioning_func|interval_length|compress_interval_length|integer_now_func_schema|integer_now_func|secondary
+--+-------------+-----------+-----------+-------+----------+------------------------+-----------------+---------------+------------------------+-----------------------+----------------+---------
+14|            9|time       |bigint     |t      |          |                        |                 |        1000000|                        |                       |                |f        
 (1 row)
 
 
@@ -3554,10 +3554,10 @@ NOTICE:  [db_dist_hypertable_1]:
 SELECT d.* FROM _timescaledb_catalog.hypertable h, _timescaledb_catalog.dimension d
 WHERE h.id = d.hypertable_id AND h.table_name = 'disttable'
 NOTICE:  [db_dist_hypertable_1]:
-id|hypertable_id|column_name|column_type|aligned|num_slices|partitioning_func_schema|partitioning_func |interval_length|compress_interval_length|integer_now_func_schema|integer_now_func
---+-------------+-----------+-----------+-------+----------+------------------------+------------------+---------------+------------------------+-----------------------+----------------
-21|           11|device     |integer    |f      |         1|_timescaledb_functions  |get_partition_hash|               |                        |                       |                
-20|           11|time       |bigint     |t      |          |                        |                  |        1000000|                        |                       |                
+id|hypertable_id|column_name|column_type|aligned|num_slices|partitioning_func_schema|partitioning_func |interval_length|compress_interval_length|integer_now_func_schema|integer_now_func|secondary
+--+-------------+-----------+-----------+-------+----------+------------------------+------------------+---------------+------------------------+-----------------------+----------------+---------
+21|           11|device     |integer    |f      |         1|_timescaledb_functions  |get_partition_hash|               |                        |                       |                |f        
+20|           11|time       |bigint     |t      |          |                        |                  |        1000000|                        |                       |                |f        
 (2 rows)
 
 
@@ -3565,10 +3565,10 @@ NOTICE:  [db_dist_hypertable_2]:
 SELECT d.* FROM _timescaledb_catalog.hypertable h, _timescaledb_catalog.dimension d
 WHERE h.id = d.hypertable_id AND h.table_name = 'disttable'
 NOTICE:  [db_dist_hypertable_2]:
-id|hypertable_id|column_name|column_type|aligned|num_slices|partitioning_func_schema|partitioning_func |interval_length|compress_interval_length|integer_now_func_schema|integer_now_func
---+-------------+-----------+-----------+-------+----------+------------------------+------------------+---------------+------------------------+-----------------------+----------------
-21|           11|device     |integer    |f      |         1|_timescaledb_functions  |get_partition_hash|               |                        |                       |                
-20|           11|time       |bigint     |t      |          |                        |                  |        1000000|                        |                       |                
+id|hypertable_id|column_name|column_type|aligned|num_slices|partitioning_func_schema|partitioning_func |interval_length|compress_interval_length|integer_now_func_schema|integer_now_func|secondary
+--+-------------+-----------+-----------+-------+----------+------------------------+------------------+---------------+------------------------+-----------------------+----------------+---------
+21|           11|device     |integer    |f      |         1|_timescaledb_functions  |get_partition_hash|               |                        |                       |                |f        
+20|           11|time       |bigint     |t      |          |                        |                  |        1000000|                        |                       |                |f        
 (2 rows)
 
 
@@ -3576,10 +3576,10 @@ NOTICE:  [db_dist_hypertable_3]:
 SELECT d.* FROM _timescaledb_catalog.hypertable h, _timescaledb_catalog.dimension d
 WHERE h.id = d.hypertable_id AND h.table_name = 'disttable'
 NOTICE:  [db_dist_hypertable_3]:
-id|hypertable_id|column_name|column_type|aligned|num_slices|partitioning_func_schema|partitioning_func |interval_length|compress_interval_length|integer_now_func_schema|integer_now_func
---+-------------+-----------+-----------+-------+----------+------------------------+------------------+---------------+------------------------+-----------------------+----------------
-15|            9|device     |integer    |f      |         1|_timescaledb_functions  |get_partition_hash|               |                        |                       |                
-14|            9|time       |bigint     |t      |          |                        |                  |        1000000|                        |                       |                
+id|hypertable_id|column_name|column_type|aligned|num_slices|partitioning_func_schema|partitioning_func |interval_length|compress_interval_length|integer_now_func_schema|integer_now_func|secondary
+--+-------------+-----------+-----------+-------+----------+------------------------+------------------+---------------+------------------------+-----------------------+----------------+---------
+15|            9|device     |integer    |f      |         1|_timescaledb_functions  |get_partition_hash|               |                        |                       |                |f        
+14|            9|time       |bigint     |t      |          |                        |                  |        1000000|                        |                       |                |f        
 (2 rows)
 
 
@@ -3620,10 +3620,10 @@ NOTICE:  [db_dist_hypertable_1]:
 SELECT d.* FROM _timescaledb_catalog.hypertable h, _timescaledb_catalog.dimension d
 WHERE h.id = d.hypertable_id AND h.table_name = 'disttable'
 NOTICE:  [db_dist_hypertable_1]:
-id|hypertable_id|column_name|column_type|aligned|num_slices|partitioning_func_schema|partitioning_func |interval_length|compress_interval_length|integer_now_func_schema|integer_now_func
---+-------------+-----------+-----------+-------+----------+------------------------+------------------+---------------+------------------------+-----------------------+----------------
-21|           11|device     |integer    |f      |         3|_timescaledb_functions  |get_partition_hash|               |                        |                       |                
-20|           11|time       |bigint     |t      |          |                        |                  |     2000000000|                        |public                 |dummy_now       
+id|hypertable_id|column_name|column_type|aligned|num_slices|partitioning_func_schema|partitioning_func |interval_length|compress_interval_length|integer_now_func_schema|integer_now_func|secondary
+--+-------------+-----------+-----------+-------+----------+------------------------+------------------+---------------+------------------------+-----------------------+----------------+---------
+21|           11|device     |integer    |f      |         3|_timescaledb_functions  |get_partition_hash|               |                        |                       |                |f        
+20|           11|time       |bigint     |t      |          |                        |                  |     2000000000|                        |public                 |dummy_now       |f        
 (2 rows)
 
 
@@ -3631,10 +3631,10 @@ NOTICE:  [db_dist_hypertable_2]:
 SELECT d.* FROM _timescaledb_catalog.hypertable h, _timescaledb_catalog.dimension d
 WHERE h.id = d.hypertable_id AND h.table_name = 'disttable'
 NOTICE:  [db_dist_hypertable_2]:
-id|hypertable_id|column_name|column_type|aligned|num_slices|partitioning_func_schema|partitioning_func |interval_length|compress_interval_length|integer_now_func_schema|integer_now_func
---+-------------+-----------+-----------+-------+----------+------------------------+------------------+---------------+------------------------+-----------------------+----------------
-21|           11|device     |integer    |f      |         3|_timescaledb_functions  |get_partition_hash|               |                        |                       |                
-20|           11|time       |bigint     |t      |          |                        |                  |     2000000000|                        |public                 |dummy_now       
+id|hypertable_id|column_name|column_type|aligned|num_slices|partitioning_func_schema|partitioning_func |interval_length|compress_interval_length|integer_now_func_schema|integer_now_func|secondary
+--+-------------+-----------+-----------+-------+----------+------------------------+------------------+---------------+------------------------+-----------------------+----------------+---------
+21|           11|device     |integer    |f      |         3|_timescaledb_functions  |get_partition_hash|               |                        |                       |                |f        
+20|           11|time       |bigint     |t      |          |                        |                  |     2000000000|                        |public                 |dummy_now       |f        
 (2 rows)
 
 
@@ -3642,10 +3642,10 @@ NOTICE:  [db_dist_hypertable_3]:
 SELECT d.* FROM _timescaledb_catalog.hypertable h, _timescaledb_catalog.dimension d
 WHERE h.id = d.hypertable_id AND h.table_name = 'disttable'
 NOTICE:  [db_dist_hypertable_3]:
-id|hypertable_id|column_name|column_type|aligned|num_slices|partitioning_func_schema|partitioning_func |interval_length|compress_interval_length|integer_now_func_schema|integer_now_func
---+-------------+-----------+-----------+-------+----------+------------------------+------------------+---------------+------------------------+-----------------------+----------------
-15|            9|device     |integer    |f      |         3|_timescaledb_functions  |get_partition_hash|               |                        |                       |                
-14|            9|time       |bigint     |t      |          |                        |                  |     2000000000|                        |public                 |dummy_now       
+id|hypertable_id|column_name|column_type|aligned|num_slices|partitioning_func_schema|partitioning_func |interval_length|compress_interval_length|integer_now_func_schema|integer_now_func|secondary
+--+-------------+-----------+-----------+-------+----------+------------------------+------------------+---------------+------------------------+-----------------------+----------------+---------
+15|            9|device     |integer    |f      |         3|_timescaledb_functions  |get_partition_hash|               |                        |                       |                |f        
+14|            9|time       |bigint     |t      |          |                        |                  |     2000000000|                        |public                 |dummy_now       |f        
 (2 rows)
 
 

--- a/tsl/test/expected/tsl_tables.out
+++ b/tsl/test/expected/tsl_tables.out
@@ -189,10 +189,10 @@ select remove_retention_policy('test_table');
 -- Test set_integer_now_func and add_retention_policy with
 -- hypertables that have integer time dimension
 select * from _timescaledb_catalog.dimension;
- id | hypertable_id | column_name |       column_type        | aligned | num_slices | partitioning_func_schema | partitioning_func | interval_length | compress_interval_length | integer_now_func_schema | integer_now_func 
-----+---------------+-------------+--------------------------+---------+------------+--------------------------+-------------------+-----------------+--------------------------+-------------------------+------------------
-  1 |             1 | time        | timestamp with time zone | t       |            |                          |                   |    604800000000 |                          |                         | 
-  2 |             2 | time        | bigint                   | t       |            |                          |                   |               1 |                          |                         | 
+ id | hypertable_id | column_name |       column_type        | aligned | num_slices | partitioning_func_schema | partitioning_func | interval_length | compress_interval_length | integer_now_func_schema | integer_now_func | secondary 
+----+---------------+-------------+--------------------------+---------+------------+--------------------------+-------------------+-----------------+--------------------------+-------------------------+------------------+-----------
+  1 |             1 | time        | timestamp with time zone | t       |            |                          |                   |    604800000000 |                          |                         |                  | f
+  2 |             2 | time        | bigint                   | t       |            |                          |                   |               1 |                          |                         |                  | f
 (2 rows)
 
 \c :TEST_DBNAME :ROLE_SUPERUSER
@@ -207,10 +207,10 @@ select set_integer_now_func('test_table_int', 'my_new_schema.dummy_now2');
 
 \c :TEST_DBNAME :ROLE_DEFAULT_PERM_USER
 select * from _timescaledb_catalog.dimension;
- id | hypertable_id | column_name |       column_type        | aligned | num_slices | partitioning_func_schema | partitioning_func | interval_length | compress_interval_length | integer_now_func_schema | integer_now_func 
-----+---------------+-------------+--------------------------+---------+------------+--------------------------+-------------------+-----------------+--------------------------+-------------------------+------------------
-  1 |             1 | time        | timestamp with time zone | t       |            |                          |                   |    604800000000 |                          |                         | 
-  2 |             2 | time        | bigint                   | t       |            |                          |                   |               1 |                          | my_new_schema           | dummy_now2
+ id | hypertable_id | column_name |       column_type        | aligned | num_slices | partitioning_func_schema | partitioning_func | interval_length | compress_interval_length | integer_now_func_schema | integer_now_func | secondary 
+----+---------------+-------------+--------------------------+---------+------------+--------------------------+-------------------+-----------------+--------------------------+-------------------------+------------------+-----------
+  1 |             1 | time        | timestamp with time zone | t       |            |                          |                   |    604800000000 |                          |                         |                  | f
+  2 |             2 | time        | bigint                   | t       |            |                          |                   |               1 |                          | my_new_schema           | dummy_now2       | f
 (2 rows)
 
 SELECT * FROM _timescaledb_config.bgw_job WHERE proc_name = 'policy_retention' ORDER BY id;

--- a/tsl/test/shared/expected/extension.out
+++ b/tsl/test/shared/expected/extension.out
@@ -259,7 +259,7 @@ ORDER BY pronamespace::regnamespace::text COLLATE "C", p.oid::regprocedure::text
  add_compression_policy(regclass,"any",boolean,interval,timestamp with time zone,text)
  add_continuous_aggregate_policy(regclass,"any","any",interval,boolean,timestamp with time zone,text)
  add_data_node(name,text,name,integer,boolean,boolean,text)
- add_dimension(regclass,name,integer,anyelement,regproc,boolean)
+ add_dimension(regclass,name,integer,anyelement,regproc,boolean,boolean)
  add_job(regproc,interval,jsonb,timestamp with time zone,boolean,regproc,boolean,text)
  add_reorder_policy(regclass,name,boolean,timestamp with time zone,text)
  add_retention_policy(regclass,"any",boolean,interval,timestamp with time zone,text)


### PR DESCRIPTION
Allow users to specify a specific column to be used as a secondary dimension using the add_dimension() API. A secondary dimension does not participate in partitioning of the data. Such a secondary dimension will be used for chunk pruning if the WHERE clause of a SQL query specifies ranges on such a column.

Disable-check: force-changelog-file

Disable-check: commit-count