### PR TITLE
Export is_decompress_chunk_path / is_gapfill_path

### DIFF
--- a/src/gapfill.c
+++ b/src/gapfill.c
@@ -10,6 +10,19 @@
 #include "cross_module_fn.h"
 #include "compat/compat.h"
 #include "export.h"
+#include "gapfill.h"
+
+bool
+ts_is_gapfill_path(Path *path)
+{
+	if (IsA(path, CustomPath))
+	{
+		CustomPath *cpath = castNode(CustomPath, path);
+		if (strcmp(cpath->methods->CustomName, GAPFILL_PATH_NAME) == 0)
+			return true;
+	}
+	return false;
+}
 
 /*
  * stub function to trigger locf and interpolate in gapfill node

--- a/src/gapfill.h
+++ b/src/gapfill.h
@@ -1,0 +1,13 @@
+/*
+ * This file and its contents are licensed under the Apache License 2.0.
+ * Please see the included NOTICE for copyright information and
+ * LICENSE-APACHE for a copy of the license.
+ */
+#ifndef TIMESCALEDB_GAPFILL_H
+#define TIMESCALEDB_GAPFILL_H
+
+#define GAPFILL_PATH_NAME "GapFill"
+
+extern bool ts_is_gapfill_path(Path *path);
+
+#endif

--- a/src/nodes/chunk_append/chunk_append.c
+++ b/src/nodes/chunk_append/chunk_append.c
@@ -68,6 +68,27 @@ create_group_subpath(PlannerInfo *root, RelOptInfo *rel, List *group, List *path
 	}
 }
 
+ChunkAppendPath *
+ts_chunk_append_path_copy(ChunkAppendPath *ca, List *subpaths)
+{
+	ListCell *lc;
+	double total_cost = 0, rows = 0;
+	ChunkAppendPath *new = palloc(sizeof(ChunkAppendPath));
+	memcpy(new, ca, sizeof(ChunkAppendPath));
+	new->cpath.custom_paths = subpaths;
+
+	foreach (lc, subpaths)
+	{
+		Path *child = lfirst(lc);
+		total_cost += child->total_cost;
+		rows += child->rows;
+	}
+	new->cpath.path.total_cost = total_cost;
+	new->cpath.path.rows = rows;
+
+	return new;
+}
+
 Path *
 ts_chunk_append_path_create(PlannerInfo *root, RelOptInfo *rel, Hypertable *ht, Path *subpath,
 							bool parallel_aware, bool ordered, List *nested_oids)

--- a/src/nodes/chunk_append/chunk_append.h
+++ b/src/nodes/chunk_append/chunk_append.h
@@ -22,6 +22,7 @@ typedef struct ChunkAppendPath
 	int first_partial_path;
 } ChunkAppendPath;
 
+extern TSDLLEXPORT ChunkAppendPath *ts_chunk_append_path_copy(ChunkAppendPath *ca, List *subpaths);
 extern Path *ts_chunk_append_path_create(PlannerInfo *root, RelOptInfo *rel, Hypertable *ht,
 										 Path *subpath, bool parallel_aware, bool ordered,
 										 List *nested_oids);


### PR DESCRIPTION
This patch adds the 'ts_' prefix to the function names of is_decompress_chunk_path and is_gapfill_path and makes them available for use by other parts of TimescaleDB.

Disable-check: force-changelog-file