### PR TITLE
Fix an invalid SPI result use after free

### DIFF
--- a/src/hypertable.c
+++ b/src/hypertable.c
@@ -2974,10 +2974,13 @@ ts_hypertable_get_open_dim_max_value(const Hypertable *ht, int dimension_index, 
 	if (isnull)
 		*isnull = max_isnull;
 
+	int64 max_value =
+		max_isnull ? ts_time_get_min(timetype) : ts_time_value_to_internal(maxdat, timetype);
+
 	if ((res = SPI_finish()) != SPI_OK_FINISH)
 		elog(ERROR, "SPI_finish failed: %s", SPI_result_code_string(res));
 
-	return max_isnull ? ts_time_get_min(timetype) : ts_time_value_to_internal(maxdat, timetype);
+	return max_value;
 }
 
 bool


### PR DESCRIPTION
This PR fixes the invalid use of an SPI result after SPI_finish is called and the result is freed.

Disable-check: force-changelog-file
