### PR TITLE
Fix non-deterministic cagg_insert isolation test

### DIFF
--- a/tsl/test/isolation/specs/cagg_insert.spec
+++ b/tsl/test/isolation/specs/cagg_insert.spec
@@ -123,7 +123,7 @@ step "LockMatInval" { BEGIN; LOCK TABLE _timescaledb_catalog.continuous_aggs_mat
 step "UnlockMatInval" { ROLLBACK; }
 
 #only one refresh
-permutation "LockInvalThrEx" "Refresh" "Refresh2" "Refresh3" "UnlockInvalThrEx"
+permutation "LockInvalThrEx" "Refresh" "Refresh2" (Refresh) "Refresh3" (Refresh, Refresh2) "UnlockInvalThrEx"
 
 #refresh and insert do not block each other once refresh is out of the
 #first transaction where it moves the invalidation threshold


### PR DESCRIPTION
One permutation of the cagg_insert isolation test contains an assumption about the execution order of three processes after a lock is released. However, this behavior is non-deterministic. This PR makes the assumption explicit and adds proper markers to the isolation test to make the output deterministic.

Disable-check: force-changelog-file