### PR TITLE
Fix server crash on UPDATE of compressed chunk

### DIFF
--- a/.unreleased/bugfix_6024
+++ b/.unreleased/bugfix_6024
@@ -1,0 +1,3 @@
+Fixes: #6035 UPDATE on compressed chunk crashes server
+
+Thanks: @alexanderlaw for reporting this issue on server crash

--- a/tsl/src/compression/compression.c
+++ b/tsl/src/compression/compression.c
@@ -2766,6 +2766,9 @@ fill_predicate_context(Chunk *ch, List *predicates, List **filters, List **index
 				else
 					continue;
 
+				/* ignore system-defined attributes */
+				if (var->varattno <= 0)
+					continue;
 				column_name = get_attname(ch->table_id, var->varattno, false);
 				FormData_hypertable_compression *fd =
 					ts_hypertable_compression_get_by_pkey(ch->fd.hypertable_id, column_name);
@@ -2847,6 +2850,9 @@ fill_predicate_context(Chunk *ch, List *predicates, List **filters, List **index
 				if (IsA(ntest->arg, Var))
 				{
 					var = (Var *) ntest->arg;
+					/* ignore system-defined attributes */
+					if (var->varattno <= 0)
+						continue;
 					column_name = get_attname(ch->table_id, var->varattno, false);
 					FormData_hypertable_compression *fd =
 						ts_hypertable_compression_get_by_pkey(ch->fd.hypertable_id, column_name);

--- a/tsl/test/expected/compression_update_delete.out
+++ b/tsl/test/expected/compression_update_delete.out
@@ -2534,3 +2534,24 @@ LOG:  statement: ROLLBACK;
 RESET client_min_messages;
 LOG:  statement: RESET client_min_messages;
 DROP TABLE tab1;
+--issue: #6024
+CREATE TABLE t(a integer, b integer);
+SELECT create_hypertable('t', 'a', chunk_time_interval=> 10);
+NOTICE:  adding not-null constraint to column "a"
+ create_hypertable 
+-------------------
+ (3,public,t,t)
+(1 row)
+
+INSERT INTO t values(1, 2);
+ALTER TABLE t SET (timescaledb.compress);
+SELECT compress_chunk(show_chunks('t'));
+             compress_chunk             
+----------------------------------------
+ _timescaledb_internal._hyper_3_3_chunk
+(1 row)
+
+-- should not crash
+UPDATE t SET b = 2 WHERE tableoid = 0;
+UPDATE t SET b = 2 WHERE tableoid is null;
+DROP TABLE t;

--- a/tsl/test/sql/compression_update_delete.sql
+++ b/tsl/test/sql/compression_update_delete.sql
@@ -1301,3 +1301,14 @@ ROLLBACK;
 
 RESET client_min_messages;
 DROP TABLE tab1;
+
+--issue: #6024
+CREATE TABLE t(a integer, b integer);
+SELECT create_hypertable('t', 'a', chunk_time_interval=> 10);
+INSERT INTO t values(1, 2);
+ALTER TABLE t SET (timescaledb.compress);
+SELECT compress_chunk(show_chunks('t'));
+-- should not crash
+UPDATE t SET b = 2 WHERE tableoid = 0;
+UPDATE t SET b = 2 WHERE tableoid is null;
+DROP TABLE t;


### PR DESCRIPTION
UPDATE query with system attributes in WHERE clause causes server to crash. This patch fixes this issue by checking for system attributes and handle cases only for segmentby attributes in fill_predicate_context().

Fixes #6024