### PR TITLE
Server crash when using duplicate segmentby column

### DIFF
--- a/.github/workflows/linux-32bit-build-and-test.yaml
+++ b/.github/workflows/linux-32bit-build-and-test.yaml
@@ -68,7 +68,7 @@ jobs:
         echo '/tmp/core.%h.%e.%t' > /proc/sys/kernel/core_pattern
         apt-get install -y gcc make cmake libssl-dev libkrb5-dev libipc-run-perl \
           libtest-most-perl sudo gdb git wget gawk lbzip2 flex bison lcov base-files \
-          locales clang-14 llvm-14 llvm-14-dev llvm-14-tools
+          locales clang-14 llvm-14 llvm-14-dev llvm-14-tools postgresql-client
 
     - name: Checkout TimescaleDB
       uses: actions/checkout@v3

--- a/.unreleased/bugfix_6044
+++ b/.unreleased/bugfix_6044
@@ -1,0 +1,1 @@
+Fixes: #6044 Server crash when using duplicate segmentby column

--- a/tsl/test/expected/compression_errors.out
+++ b/tsl/test/expected/compression_errors.out
@@ -195,6 +195,12 @@ HINT:  The option timescaledb.compress_segmentby must be a set of columns separa
 ALTER TABLE foo set (timescaledb.compress, timescaledb.compress_orderby = 'a, p');
 ERROR:  invalid ordering column type point
 DETAIL:  Could not identify a less-than operator for the type.
+ALTER TABLE foo set (timescaledb.compress, timescaledb.compress_segmentby = 'b, b');
+ERROR:  duplicate column name "b"
+HINT:  The timescaledb.compress_segmentby option must reference distinct column.
+ALTER TABLE foo set (timescaledb.compress, timescaledb.compress_orderby = 'b, b');
+ERROR:  duplicate column name "b"
+HINT:  The timescaledb.compress_orderby option must reference distinct column.
 --should succeed
 ALTER TABLE foo set (timescaledb.compress, timescaledb.compress_orderby = 'a, b');
 --ddl on ht with compression

--- a/tsl/test/sql/compression_errors.sql
+++ b/tsl/test/sql/compression_errors.sql
@@ -99,6 +99,8 @@ ALTER TABLE foo set (timescaledb.compress, timescaledb.compress_segmentby = 'ran
 ALTER TABLE foo set (timescaledb.compress, timescaledb.compress_segmentby = 'c LIMIT 1');
 ALTER TABLE foo set (timescaledb.compress, timescaledb.compress_segmentby = 'c + b');
 ALTER TABLE foo set (timescaledb.compress, timescaledb.compress_orderby = 'a, p');
+ALTER TABLE foo set (timescaledb.compress, timescaledb.compress_segmentby = 'b, b');
+ALTER TABLE foo set (timescaledb.compress, timescaledb.compress_orderby = 'b, b');
 
 --should succeed
 ALTER TABLE foo set (timescaledb.compress, timescaledb.compress_orderby = 'a, b');


### PR DESCRIPTION
The segmentby column info array is populated by using the column attribute number as an array index. This is done as part of validating and creating segment by column info in function `compresscolinfo_init`.

Since the column is duplicated the attribute number for both the segmentby column is same. When this attribute number is used as an index, only one of the array element is populated correctly with the detailed column info whareas the other element of the array ramins NULL. This segmentby column info is updated in catalog as part of processing compression options (ALTER TABLE ...).

When the chunk is being compressed this segmentby column information is being retrieved from the catalog to create the scan key in order to identify any existing index on the table that matches the segmentby column. Out of the two keys one key gets updated correctly whereas the second key contains NULL values. This results into a crash during index scan to identify any existing index on the table.

The proposed change avoid this crash by raising an error if user has specified duplicated columns as part of compress_segmentby option.