### PR TITLE
Fix segfault in set_integer_now_func

### DIFF
--- a/.unreleased/bugfix_6037
+++ b/.unreleased/bugfix_6037
@@ -1,0 +1,3 @@
+Fixes: #6045 Fix segfault in set_integer_now_func
+
+Thanks: @alexanderlaw for reporting this issue in set_integer_now_func

--- a/src/hypertable.c
+++ b/src/hypertable.c
@@ -2456,7 +2456,6 @@ integer_now_func_validate(Oid now_func_oid, Oid open_dim_type)
 	tuple = SearchSysCache1(PROCOID, ObjectIdGetDatum(now_func_oid));
 	if (!HeapTupleIsValid(tuple))
 	{
-		ReleaseSysCache(tuple);
 		ereport(ERROR,
 				(errcode(ERRCODE_NO_DATA_FOUND),
 				 errmsg("cache lookup failed for function %u", now_func_oid)));

--- a/test/expected/create_hypertable.out
+++ b/test/expected/create_hypertable.out
@@ -769,6 +769,9 @@ select set_integer_now_func('test_table_int', 'my_schema.dummy_now2', replace_if
 ERROR:  permission denied for schema my_schema at character 47
 select set_integer_now_func('test_table_int', 'dummy_now3', replace_if_exists => TRUE);
 ERROR:  permission denied for function dummy_now3
+-- test invalid oid as the integer_now_func
+select set_integer_now_func('test_table_int', 1, replace_if_exists => TRUE);
+ERROR:  cache lookup failed for function 1
 \set ON_ERROR_STOP
 select set_integer_now_func('test_table_int', 'my_user_schema.dummy_now4', replace_if_exists => TRUE);
  set_integer_now_func 

--- a/test/sql/create_hypertable.sql
+++ b/test/sql/create_hypertable.sql
@@ -419,6 +419,8 @@ select * from _timescaledb_catalog.dimension WHERE hypertable_id = :TEST_TABLE_I
 select set_integer_now_func('test_table_int', 'dummy_now');
 select set_integer_now_func('test_table_int', 'my_schema.dummy_now2', replace_if_exists => TRUE);
 select set_integer_now_func('test_table_int', 'dummy_now3', replace_if_exists => TRUE);
+-- test invalid oid as the integer_now_func
+select set_integer_now_func('test_table_int', 1, replace_if_exists => TRUE);
 \set ON_ERROR_STOP
 
 select set_integer_now_func('test_table_int', 'my_user_schema.dummy_now4', replace_if_exists => TRUE);


### PR DESCRIPTION
When an invalid function oid is passed to set_integer_now_func, it finds out that the function oid is invalid but before throwing the error, it calls ReleaseSysCache on an invalid tuple causing a segfault. Fixed that by removing the invalid call to ReleaseSysCache.

Fixes #6037