### PR TITLE
Vectorized aggregation execution for sum

### DIFF
--- a/.unreleased/feature_6050
+++ b/.unreleased/feature_6050
@@ -1,0 +1,1 @@
+Implements: #6050 Vectorized aggregation execution for sum() 

--- a/src/compat/compat.h
+++ b/src/compat/compat.h
@@ -417,10 +417,17 @@ get_reindex_options(ReindexStmt *stmt)
 #endif
 
 /*
- * define lfifth macro for convenience
+ * define some list macros for convenience
  */
 #define lfifth(l) lfirst(list_nth_cell(l, 4))
 #define lfifth_int(l) lfirst_int(list_nth_cell(l, 4))
+
+#define lsixth(l) lfirst(list_nth_cell(l, 5))
+#define lsixth_int(l) lfirst_int(list_nth_cell(l, 5))
+
+#define list_make6(x1, x2, x3, x4, x5, x6) lappend(list_make5(x1, x2, x3, x4, x5), x6)
+#define list_make6_oid(x1, x2, x3, x4, x5, x6) lappend_oid(list_make5_oid(x1, x2, x3, x4, x5), x6)
+#define list_make6_int(x1, x2, x3, x4, x5, x6) lappend_int(list_make5_int(x1, x2, x3, x4, x5), x6)
 
 /* PG14 adds estinfo parameter to estimate_num_groups for additional context
  * about the estimation
@@ -982,6 +989,10 @@ object_ownercheck(Oid classid, Oid objectid, Oid roleid)
 	}
 	return false;
 }
+#endif
+
+#if PG14_LT
+#define F_SUM_INT4 2108
 #endif
 
 #endif /* TIMESCALEDB_COMPAT_H */

--- a/src/cross_module_fn.c
+++ b/src/cross_module_fn.c
@@ -194,6 +194,13 @@ job_execute_default_fn(BgwJob *job)
 }
 
 static bool
+push_down_aggregation(PlannerInfo *root, AggPath *aggregation_path, Path *subpath)
+{
+	/* Don't skip adding the agg node on top of the path */
+	return false;
+}
+
+static bool
 process_compress_table_default(AlterTableCmd *cmd, Hypertable *ht,
 							   WithClauseResult *with_clause_options)
 {
@@ -474,6 +481,8 @@ TSDLLEXPORT CrossModuleFunctions ts_cm_functions_default = {
 	.policies_remove_all = error_no_default_fn_pg_community,
 	.policies_alter = error_no_default_fn_pg_community,
 	.policies_show = error_no_default_fn_pg_community,
+
+	.push_down_aggregation = push_down_aggregation,
 
 	.partialize_agg = error_no_default_fn_pg_community,
 	.finalize_agg_sfunc = error_no_default_fn_pg_community,

--- a/src/cross_module_fn.h
+++ b/src/cross_module_fn.h
@@ -99,6 +99,9 @@ typedef struct CrossModuleFunctions
 	void (*ddl_command_end)(EventTriggerData *command);
 	void (*sql_drop)(List *dropped_objects);
 
+	/* Vectorized queries */
+	bool (*push_down_aggregation)(PlannerInfo *root, AggPath *aggregation_path, Path *subpath);
+
 	/* Continuous Aggregates */
 	PGFunction partialize_agg;
 	PGFunction finalize_agg_sfunc;

--- a/src/guc.c
+++ b/src/guc.c
@@ -92,6 +92,7 @@ bool ts_guc_enable_per_data_node_queries = true;
 bool ts_guc_enable_parameterized_data_node_scan = true;
 bool ts_guc_enable_async_append = true;
 bool ts_guc_enable_chunkwise_aggregation = true;
+bool ts_guc_enable_vectorized_aggregation = true;
 TSDLLEXPORT bool ts_guc_enable_compression_indexscan = true;
 TSDLLEXPORT bool ts_guc_enable_bulk_decompression = true;
 TSDLLEXPORT int ts_guc_bgw_log_level = WARNING;
@@ -586,6 +587,17 @@ _guc_init(void)
 							 "Enable the pushdown of aggregations to the"
 							 " chunk level",
 							 &ts_guc_enable_chunkwise_aggregation,
+							 true,
+							 PGC_USERSET,
+							 0,
+							 NULL,
+							 NULL,
+							 NULL);
+
+	DefineCustomBoolVariable("timescaledb.vectorized_aggregation",
+							 "Enable vectorized aggregation",
+							 "Enable vectorized aggregation for compressed data",
+							 &ts_guc_enable_vectorized_aggregation,
 							 true,
 							 PGC_USERSET,
 							 0,

--- a/src/guc.h
+++ b/src/guc.h
@@ -36,6 +36,7 @@ extern TSDLLEXPORT bool ts_guc_enable_parameterized_data_node_scan;
 extern TSDLLEXPORT bool ts_guc_enable_async_append;
 extern TSDLLEXPORT bool ts_guc_enable_skip_scan;
 extern TSDLLEXPORT bool ts_guc_enable_chunkwise_aggregation;
+extern TSDLLEXPORT bool ts_guc_enable_vectorized_aggregation;
 extern bool ts_guc_restoring;
 extern int ts_guc_max_open_chunks_per_insert;
 extern int ts_guc_max_cached_chunks_per_hypertable;

--- a/src/planner/partialize.h
+++ b/src/planner/partialize.h
@@ -5,7 +5,9 @@
  */
 #ifndef TIMESCALEDB_PLAN_PARTIALIZE_H
 #define TIMESCALEDB_PLAN_PARTIALIZE_H
+
 #include <postgres.h>
+#include <nodes/pathnodes.h>
 #include <optimizer/planner.h>
 
 #include "chunk.h"

--- a/tsl/src/CMakeLists.txt
+++ b/tsl/src/CMakeLists.txt
@@ -8,6 +8,7 @@ set(SOURCES
     dist_backup.c
     hypertable.c
     init.c
+    partialize_agg.c
     partialize_finalize.c
     planner.c
     process_utility.c

--- a/tsl/src/init.c
+++ b/tsl/src/init.c
@@ -43,6 +43,7 @@
 #include "nodes/decompress_chunk/planner.h"
 #include "nodes/skip_scan/skip_scan.h"
 #include "nodes/gapfill/gapfill_functions.h"
+#include "partialize_agg.h"
 #include "partialize_finalize.h"
 #include "planner.h"
 #include "process_utility.h"
@@ -143,6 +144,9 @@ CrossModuleFunctions tsl_cm_functions = {
 	.policies_remove_all = policies_remove_all,
 	.policies_alter = policies_alter,
 	.policies_show = policies_show,
+
+	/* Vectorized queries */
+	.push_down_aggregation = apply_vectorized_agg_optimization,
 
 	/* Continuous Aggregates */
 	.partialize_agg = tsl_partialize_agg,

--- a/tsl/src/nodes/decompress_chunk/compressed_batch.c
+++ b/tsl/src/nodes/decompress_chunk/compressed_batch.c
@@ -207,6 +207,46 @@ apply_vector_quals(DecompressChunkState *chunk_state, DecompressBatchState *batc
 }
 
 /*
+ * Initialize the bulk decompression memory context
+ */
+void
+init_bulk_decompression_mctx(DecompressChunkState *chunk_state, MemoryContext parent_ctx)
+{
+	Assert(chunk_state != NULL);
+	Assert(parent_ctx != NULL);
+	Assert(chunk_state->bulk_decompression_context == NULL);
+
+	chunk_state->bulk_decompression_context = AllocSetContextCreate(parent_ctx,
+																	"bulk decompression",
+																	/* minContextSize = */ 0,
+																	/* initBlockSize = */ 64 * 1024,
+																	/* maxBlockSize = */ 64 * 1024);
+}
+
+/*
+ * Initialize the batch memory context
+ *
+ * We use custom size for the batch memory context page, calculated to
+ * fit the typical result of bulk decompression (if we use it).
+ * This allows us to save on expensive malloc/free calls, because the
+ * Postgres memory contexts reallocate all pages except the first one
+ * after each reset.
+ */
+void
+init_per_batch_mctx(DecompressChunkState *chunk_state, DecompressBatchState *batch_state)
+{
+	Assert(chunk_state != NULL);
+	Assert(batch_state != NULL);
+	Assert(batch_state->per_batch_context == NULL);
+
+	batch_state->per_batch_context = AllocSetContextCreate(CurrentMemoryContext,
+														   "DecompressChunk per_batch",
+														   0,
+														   chunk_state->batch_memory_context_bytes,
+														   chunk_state->batch_memory_context_bytes);
+}
+
+/*
  * Initialize the batch decompression state with the new compressed  tuple.
  */
 void
@@ -221,19 +261,9 @@ compressed_batch_set_compressed_tuple(DecompressChunkState *chunk_state,
 	 */
 	if (batch_state->per_batch_context == NULL)
 	{
-		/*
-		 * We use custom size for the batch memory context page, calculated to
-		 * fit the typical result of bulk decompression (if we use it).
-		 * This allows us to save on expensive malloc/free calls, because the
-		 * Postgres memory contexts reallocate all pages except the first one
-		 * after earch reset.
-		 */
-		batch_state->per_batch_context =
-			AllocSetContextCreate(CurrentMemoryContext,
-								  "DecompressChunk per_batch",
-								  0,
-								  chunk_state->batch_memory_context_bytes,
-								  chunk_state->batch_memory_context_bytes);
+		/* Init memory context */
+		init_per_batch_mctx(chunk_state, batch_state);
+		Assert(batch_state->per_batch_context != NULL);
 
 		Assert(batch_state->compressed_slot == NULL);
 
@@ -324,15 +354,9 @@ compressed_batch_set_compressed_tuple(DecompressChunkState *chunk_state,
 					column_description->bulk_decompression_supported)
 				{
 					if (chunk_state->bulk_decompression_context == NULL)
-					{
-						chunk_state->bulk_decompression_context =
-							AllocSetContextCreate(MemoryContextGetParent(
-													  batch_state->per_batch_context),
-												  "bulk decompression",
-												  /* minContextSize = */ 0,
-												  /* initBlockSize = */ 64 * 1024,
-												  /* maxBlockSize = */ 64 * 1024);
-					}
+						init_bulk_decompression_mctx(chunk_state,
+													 MemoryContextGetParent(
+														 batch_state->per_batch_context));
 
 					DecompressAllFunction decompress_all =
 						tsl_get_decompress_all_function(header->compression_algorithm);

--- a/tsl/src/nodes/decompress_chunk/compressed_batch.h
+++ b/tsl/src/nodes/decompress_chunk/compressed_batch.h
@@ -72,3 +72,9 @@ extern void compressed_batch_advance(DecompressChunkState *chunk_state,
 extern void compressed_batch_save_first_tuple(DecompressChunkState *chunk_state,
 											  DecompressBatchState *batch_state,
 											  TupleTableSlot *first_tuple_slot);
+
+extern void init_bulk_decompression_mctx(DecompressChunkState *chunk_state,
+										 MemoryContext parent_ctx);
+
+extern void init_per_batch_mctx(DecompressChunkState *chunk_state,
+								DecompressBatchState *batch_state);

--- a/tsl/src/nodes/decompress_chunk/decompress_chunk.h
+++ b/tsl/src/nodes/decompress_chunk/decompress_chunk.h
@@ -87,6 +87,11 @@ typedef struct DecompressChunkPath
 	 */
 	DecompressChunkColumnCompression *uncompressed_chunk_attno_to_compression_info;
 
+	/*
+	 * Are we able to execute a vectorized aggregation
+	 */
+	bool perform_vectorized_aggregation;
+
 	List *compressed_pathkeys;
 	bool needs_sequence_num;
 	bool reverse;

--- a/tsl/src/nodes/decompress_chunk/exec.c
+++ b/tsl/src/nodes/decompress_chunk/exec.c
@@ -147,14 +147,16 @@ decompress_chunk_state_create(CustomScan *cscan)
 	chunk_state->is_segmentby_column = lthird(cscan->custom_private);
 	chunk_state->bulk_decompression_column = lfourth(cscan->custom_private);
 	chunk_state->sortinfo = lfifth(cscan->custom_private);
+	chunk_state->custom_scan_tlist = cscan->custom_scan_tlist;
 
 	Assert(IsA(settings, IntList));
-	Assert(list_length(settings) == 5);
+	Assert(list_length(settings) == 6);
 	chunk_state->hypertable_id = linitial_int(settings);
 	chunk_state->chunk_relid = lsecond_int(settings);
 	chunk_state->reverse = lthird_int(settings);
 	chunk_state->batch_sorted_merge = lfourth_int(settings);
 	chunk_state->enable_bulk_decompression = lfifth_int(settings);
+	chunk_state->perform_vectorized_aggregation = lsixth_int(settings);
 
 	Assert(IsA(cscan->custom_exprs, List));
 	Assert(list_length(cscan->custom_exprs) == 1);
@@ -476,6 +478,247 @@ decompress_chunk_begin(CustomScanState *node, EState *estate, int eflags)
 }
 
 /*
+ * Perform a vectorized aggregation on int4 values
+ */
+static TupleTableSlot *
+perform_vectorized_sum_int4(DecompressChunkState *chunk_state, Aggref *aggref)
+{
+	Assert(chunk_state != NULL);
+	Assert(aggref != NULL);
+
+	/* Partial result is a int8 */
+	Assert(aggref->aggtranstype == INT8OID);
+
+	/* Two columns are decompressed, the column that needs to be aggregated and the count column */
+	Assert(chunk_state->num_total_columns == 2);
+
+	DecompressChunkColumnDescription *column_description = &chunk_state->template_columns[0];
+	Assert(chunk_state->template_columns[1].type == COUNT_COLUMN);
+
+	/* Get a free batch slot */
+	const int new_batch_index = batch_array_get_free_slot(chunk_state);
+
+	/* Nobody else should use batch states */
+	Assert(new_batch_index == 0);
+	DecompressBatchState *batch_state = batch_array_get_at(chunk_state, new_batch_index);
+
+	/* Init per batch memory context */
+	Assert(batch_state != NULL);
+	init_per_batch_mctx(chunk_state, batch_state);
+	Assert(batch_state->per_batch_context != NULL);
+
+	/* Init bulk decompression memory context */
+	init_bulk_decompression_mctx(chunk_state, CurrentMemoryContext);
+
+	/* Get a reference the the output TupleTableSlot */
+	TupleTableSlot *decompressed_scan_slot = chunk_state->csstate.ss.ss_ScanTupleSlot;
+	Assert(decompressed_scan_slot->tts_tupleDescriptor->natts == 1);
+
+	int64 result_sum = 0;
+
+	if (column_description->type == SEGMENTBY_COLUMN)
+	{
+		/*
+		 * To calculate the sum for a segment by value, we need to multiply the value of the segment
+		 * by column with the number of compressed tuples in this batch.
+		 */
+		DecompressChunkColumnDescription *column_description_count =
+			&chunk_state->template_columns[1];
+
+		while (true)
+		{
+			TupleTableSlot *compressed_slot =
+				ExecProcNode(linitial(chunk_state->csstate.custom_ps));
+
+			if (TupIsNull(compressed_slot))
+			{
+				/* All segment by values are processed. */
+				break;
+			}
+
+			bool isnull_value, isnull_elements;
+			Datum value = slot_getattr(compressed_slot,
+									   column_description->compressed_scan_attno,
+									   &isnull_value);
+
+			/* We have multiple compressed tuples for this segment by value. Get number of
+			 * compressed tuples */
+			Datum elements = slot_getattr(compressed_slot,
+										  column_description_count->compressed_scan_attno,
+										  &isnull_elements);
+
+			if (!isnull_value && !isnull_elements)
+			{
+				int32 intvalue = DatumGetInt32(value);
+				int32 amount = DatumGetInt32(elements);
+				int64 batch_sum = 0;
+
+				Assert(amount > 0);
+
+				/* We have at least one value */
+				decompressed_scan_slot->tts_isnull[0] = false;
+
+				/* Multiply the number of tuples with the actual value */
+				if (unlikely(pg_mul_s64_overflow(intvalue, amount, &batch_sum)))
+				{
+					ereport(ERROR,
+							(errcode(ERRCODE_NUMERIC_VALUE_OUT_OF_RANGE),
+							 errmsg("bigint out of range")));
+				}
+
+				/* Add the value to our sum */
+				if (unlikely(pg_add_s64_overflow(result_sum, batch_sum, ((int64 *) &result_sum))))
+					ereport(ERROR,
+							(errcode(ERRCODE_NUMERIC_VALUE_OUT_OF_RANGE),
+							 errmsg("bigint out of range")));
+			}
+		}
+	}
+	else if (column_description->type == COMPRESSED_COLUMN)
+	{
+		Assert(chunk_state->enable_bulk_decompression);
+		Assert(column_description->bulk_decompression_supported);
+
+		/* Due to the needed manipulation of the target list to emit partials (see
+		 * decompress_chunk_plan_create), PostgreSQL is not able to determine the type of the
+		 * compressed column automatically. So, correct the column type to the correct value. */
+		Assert(list_length(aggref->args) == 1);
+
+#ifdef USE_ASSERT_CHECKING
+		TargetEntry *tlentry = (TargetEntry *) linitial(aggref->args);
+		Assert(IsA(tlentry->expr, Var));
+		Var *input_var = castNode(Var, tlentry->expr);
+		Assert(input_var->vartype == INT4OID);
+#endif
+
+		column_description->typid = INT4OID;
+
+		while (true)
+		{
+			TupleTableSlot *compressed_slot =
+				ExecProcNode(linitial(chunk_state->csstate.custom_ps));
+			if (TupIsNull(compressed_slot))
+			{
+				/* All compressed batches are processed. */
+				break;
+			}
+
+			/* Decompress data */
+			bool isnull;
+			Datum value =
+				slot_getattr(compressed_slot, column_description->compressed_scan_attno, &isnull);
+
+			Ensure(isnull == false, "got unexpected NULL attribute value from compressed batch");
+
+			/* We have at least one value */
+			decompressed_scan_slot->tts_isnull[0] = false;
+
+			CompressedDataHeader *header = (CompressedDataHeader *) PG_DETOAST_DATUM(value);
+			ArrowArray *arrow = NULL;
+
+			DecompressAllFunction decompress_all =
+				tsl_get_decompress_all_function(header->compression_algorithm);
+			Assert(decompress_all != NULL);
+
+			MemoryContext context_before_decompression =
+				MemoryContextSwitchTo(chunk_state->bulk_decompression_context);
+
+			arrow = decompress_all(PointerGetDatum(header),
+								   column_description->typid,
+								   batch_state->per_batch_context);
+
+			Assert(arrow != NULL);
+
+			MemoryContextReset(chunk_state->bulk_decompression_context);
+			MemoryContextSwitchTo(context_before_decompression);
+
+			/* A compressed batch consists of 1000 tuples (see MAX_ROWS_PER_COMPRESSION). The
+			 * attribute value is a int32 with a max value of 2^32. Even if all tuples have the max
+			 * value, the max sum is = 1000 * 2^32 < 2^10 * 2^32 = 2^42. This is smaller than 2^64,
+			 * which is the max value of the int64 variable. The same is true for negative values).
+			 * Therefore, we don't need to check for overflows within the loop, which would slow
+			 * down the calculation. */
+			Assert(arrow->length <= MAX_ROWS_PER_COMPRESSION);
+			Assert(MAX_ROWS_PER_COMPRESSION <= 1024);
+
+			int64 batch_sum = 0;
+			for (int i = 0; i < arrow->length; i++)
+			{
+				const bool arrow_isnull = !arrow_row_is_valid(arrow->buffers[0], i);
+
+				if (likely(!arrow_isnull))
+				{
+					const int32 arrow_value = ((int32 *) arrow->buffers[1])[i];
+					batch_sum += arrow_value;
+				}
+			}
+
+			if (unlikely(pg_add_s64_overflow(result_sum, batch_sum, ((int64 *) &result_sum))))
+				ereport(ERROR,
+						(errcode(ERRCODE_NUMERIC_VALUE_OUT_OF_RANGE),
+						 errmsg("bigint out of range")));
+		}
+	}
+	else
+	{
+		elog(ERROR, "unsupported column type");
+	}
+
+	/* Use Int64GetDatum to store the result since a 64-bit value is not pass-by-value on 32-bit
+	 * systems */
+	decompressed_scan_slot->tts_values[0] = Int64GetDatum(result_sum);
+
+	ExecStoreVirtualTuple(decompressed_scan_slot);
+	return decompressed_scan_slot;
+}
+
+/*
+ * Directly execute an aggregation function on decompressed data and emit a partial aggregate
+ * result.
+ *
+ * Executing the aggregation directly in this node makes it possible to use the columnar data
+ * directly before it is converted into row-based tuples.
+ */
+static TupleTableSlot *
+perform_vectorized_aggregation(DecompressChunkState *chunk_state)
+{
+	Assert(list_length(chunk_state->custom_scan_tlist) == 1);
+
+	/* Checked by planner */
+	Assert(ts_guc_enable_vectorized_aggregation);
+	Assert(ts_guc_enable_bulk_decompression);
+
+	/* When using vectorized aggregates, only one result tuple is produced. So, if we have
+	 * already initialized a batch state, the aggregation was already performed.
+	 */
+	if (bms_num_members(chunk_state->unused_batch_states) != chunk_state->n_batch_states)
+	{
+		ExecClearTuple(chunk_state->csstate.ss.ss_ScanTupleSlot);
+		return chunk_state->csstate.ss.ss_ScanTupleSlot;
+	}
+
+	/* Determine which kind of vectorized aggregation we should perform */
+	TargetEntry *tlentry = (TargetEntry *) linitial(chunk_state->custom_scan_tlist);
+	Assert(IsA(tlentry->expr, Aggref));
+	Aggref *aggref = castNode(Aggref, tlentry->expr);
+
+	/* The aggregate should be a partial aggregate */
+	Assert(aggref->aggsplit == AGGSPLIT_INITIAL_SERIAL);
+
+	switch (aggref->aggfnoid)
+	{
+		case F_SUM_INT4:
+			return perform_vectorized_sum_int4(chunk_state, aggref);
+		default:
+			ereport(ERROR,
+					(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
+					 errmsg("vectorized aggregation for function %d is not supported",
+							aggref->aggfnoid)));
+			pg_unreachable();
+	}
+}
+
+/*
  * The exec function for the DecompressChunk node. It takes the explicit queue
  * functions pointer as an optimization, to allow these functions to be
  * inlined in the FIFO case. This is important because this is a part of a
@@ -485,6 +728,11 @@ pg_attribute_always_inline static TupleTableSlot *
 decompress_chunk_exec_impl(DecompressChunkState *chunk_state,
 						   const struct BatchQueueFunctions *queue)
 {
+	if (chunk_state->perform_vectorized_aggregation)
+	{
+		return perform_vectorized_aggregation(chunk_state);
+	}
+
 	queue->pop(chunk_state);
 	while (queue->needs_next_batch(chunk_state))
 	{
@@ -578,6 +826,13 @@ decompress_chunk_explain(CustomScanState *node, List *ancestors, ExplainState *e
 		if (es->analyze && (es->verbose || es->format != EXPLAIN_FORMAT_TEXT))
 		{
 			ExplainPropertyBool("Bulk Decompression", chunk_state->enable_bulk_decompression, es);
+		}
+
+		if (chunk_state->perform_vectorized_aggregation)
+		{
+			ExplainPropertyBool("Vectorized Aggregation",
+								chunk_state->perform_vectorized_aggregation,
+								es);
 		}
 	}
 }

--- a/tsl/src/nodes/decompress_chunk/exec.h
+++ b/tsl/src/nodes/decompress_chunk/exec.h
@@ -50,6 +50,7 @@ typedef struct DecompressChunkState
 	List *decompression_map;
 	List *is_segmentby_column;
 	List *bulk_decompression_column;
+	List *custom_scan_tlist;
 	int num_total_columns;
 	int num_compressed_columns;
 
@@ -82,6 +83,10 @@ typedef struct DecompressChunkState
 	TupleTableSlot *last_batch_first_tuple;
 
 	bool enable_bulk_decompression;
+
+	/* Perform calculation of the aggregate directly in the decompress chunk node and emit partials
+	 */
+	bool perform_vectorized_aggregation;
 
 	/*
 	 * Scratch space for bulk decompression which might need a lot of temporary

--- a/tsl/src/partialize_agg.c
+++ b/tsl/src/partialize_agg.c
@@ -1,0 +1,166 @@
+/*
+ * This file and its contents are licensed under the Timescale License.
+ * Please see the included NOTICE for copyright information and
+ * LICENSE-TIMESCALE for a copy of the license.
+ */
+
+#include <postgres.h>
+#include <catalog/pg_operator.h>
+#include <miscadmin.h>
+#include <nodes/bitmapset.h>
+#include <nodes/makefuncs.h>
+#include <nodes/nodeFuncs.h>
+#include <optimizer/cost.h>
+#include <optimizer/optimizer.h>
+#include <optimizer/pathnode.h>
+#include <optimizer/paths.h>
+#include <parser/parsetree.h>
+#include <utils/builtins.h>
+#include <utils/lsyscache.h>
+#include <utils/typcache.h>
+#include <utils/fmgroids.h>
+
+#include <planner.h>
+
+#include "compression/compression.h"
+#include "nodes/decompress_chunk/decompress_chunk.h"
+#include "partialize_agg.h"
+#include "utils.h"
+#include "debug_assert.h"
+
+#define is_restricted_path(path)                                                                   \
+	(list_length(path->parent->baserestrictinfo) > 0 || path->parent->joininfo != NULL)
+
+/*
+ * Are we able to optimize the path by applying vectorized aggregation?
+ */
+static bool
+is_vectorizable_agg_path(PlannerInfo *root, AggPath *agg_path, Path *path)
+{
+	Assert(agg_path->aggstrategy == AGG_SORTED || agg_path->aggstrategy == AGG_PLAIN ||
+		   agg_path->aggstrategy == AGG_HASHED);
+
+	/* Having is not supported at the moment */
+	if (root->hasHavingQual)
+		return false;
+
+	/* Only vectorizing within the decompress node is supported so far */
+	bool is_decompress_chunk = ts_is_decompress_chunk_path(path);
+	if (!is_decompress_chunk)
+		return false;
+
+	DecompressChunkPath *decompress_path = (DecompressChunkPath *) path;
+	Assert(decompress_path->custom_path.custom_paths != NIL);
+
+	Path *compressed_path = linitial(decompress_path->custom_path.custom_paths);
+
+	/* Hypertable compression info is already fetched from the catalog */
+	Assert(decompress_path->info != NULL);
+	Assert(decompress_path->info->hypertable_compression_info != NULL);
+
+	/* No filters are supported at the moment */
+	if (is_restricted_path(path) || is_restricted_path(compressed_path))
+		return false;
+
+	/* We currently handle only one agg function per node */
+	if (list_length(agg_path->path.pathtarget->exprs) != 1)
+		return false;
+
+	/* Only sum on int 4 is supported at the moment */
+	Node *expr_node = linitial(agg_path->path.pathtarget->exprs);
+	if (!IsA(expr_node, Aggref))
+		return false;
+
+	Aggref *aggref = castNode(Aggref, expr_node);
+
+	/* Filter expressions in the aggregate are not supported */
+	if (aggref->aggfilter != NULL)
+		return false;
+
+	if (aggref->aggfnoid != F_SUM_INT4)
+		return false;
+
+	/*
+	 * Check that the input columns of the aggregate can be processed by our vectorized
+	 * implementation. This is possible for (1) segment_by columns and (2) for columns which allow
+	 * bulk decompression.
+	 *
+	 * Bulk decompression is needed to produce the ArrowArray and perform the vectorized operations.
+	 * Bulk decompression should always be possible in the current implementation since we check for
+	 * the data type above. However, when we lift the restriction, the check becomes necessary.
+	 *
+	 * Note: decompress_path->bulk_decompression_column is not populated at this point. So, we have
+	 * to get this data from hypertable_compression_info.
+	 */
+	ListCell *lc;
+	foreach (lc, aggref->args)
+	{
+		Node *agg_arg = lfirst(lc);
+
+		if (!IsA(agg_arg, TargetEntry))
+			return false;
+
+		TargetEntry *target_entry = castNode(TargetEntry, agg_arg);
+
+		if (!IsA(target_entry->expr, Var))
+			continue;
+
+		Var *var = castNode(Var, target_entry->expr);
+
+		/* Agg input var is on the compressed relation */
+		Assert((Index) var->varno == path->parent->relid);
+		Assert((Index) var->varno == decompress_path->info->chunk_rel->relid);
+
+		char *column_name =
+			get_attname(decompress_path->info->chunk_rte->relid, var->varattno, false);
+
+		FormData_hypertable_compression *ci =
+			get_column_compressioninfo(decompress_path->info->hypertable_compression_info,
+									   column_name);
+		Assert(ci);
+
+		/* If this is a segment_by value, allow vectorization for sum */
+		if (ci->segmentby_column_index > 0)
+			continue;
+
+		bool bulk_decompression_possible = (tsl_get_decompress_all_function(ci->algo_id) != NULL);
+
+		if (!bulk_decompression_possible)
+			return false;
+	}
+
+	return true;
+}
+
+/*
+ * Check if we can perform the computation of the aggregate in a vectorized manner directly inside
+ * of the decompress chunk node. If this is possible, the decompress chunk node will emit partial
+ * aggregates directly, and there is no need for the PostgreSQL aggregation node on top.
+ */
+bool
+apply_vectorized_agg_optimization(PlannerInfo *root, AggPath *aggregation_path, Path *path)
+{
+	if (!ts_guc_enable_vectorized_aggregation || !ts_guc_enable_bulk_decompression)
+		return false;
+
+	Assert(path != NULL);
+	Assert(aggregation_path->aggsplit == AGGSPLIT_INITIAL_SERIAL);
+
+	if (is_vectorizable_agg_path(root, aggregation_path, path))
+	{
+		Assert(ts_is_decompress_chunk_path(path));
+		DecompressChunkPath *decompress_path = (DecompressChunkPath *) castNode(CustomPath, path);
+
+		/* Change the output of the path and let the decompress chunk node emit partial aggregates
+		 * directly */
+		decompress_path->perform_vectorized_aggregation = true;
+		decompress_path->custom_path.path.pathtarget = aggregation_path->path.pathtarget;
+
+		/* The decompress chunk node can perform the aggregation directly. No need for a dedicated
+		 * agg node on top. */
+		return true;
+	}
+
+	/* PostgreSQL should handle the aggregation. Regular agg node on top is required. */
+	return false;
+}

--- a/tsl/src/partialize_agg.h
+++ b/tsl/src/partialize_agg.h
@@ -1,0 +1,10 @@
+/*
+ * This file and its contents are licensed under the Timescale License.
+ * Please see the included NOTICE for copyright information and
+ * LICENSE-TIMESCALE for a copy of the license.
+ */
+
+#pragma once
+
+extern bool apply_vectorized_agg_optimization(PlannerInfo *root, AggPath *aggregation_path,
+											  Path *subpath);

--- a/tsl/test/expected/merge_append_partially_compressed-13.out
+++ b/tsl/test/expected/merge_append_partially_compressed-13.out
@@ -692,35 +692,31 @@ SELECT * FROM test1 ORDER BY time ASC NULLS FIRST, x3 DESC NULLS LAST, x4 ASC;
 
 :PREFIX
 SELECT x1, x2, max(time) FROM test1 GROUP BY x1, x2, time ORDER BY time limit 10;
-                                                     QUERY PLAN                                                      
----------------------------------------------------------------------------------------------------------------------
+                                                  QUERY PLAN                                                   
+---------------------------------------------------------------------------------------------------------------
  Limit (actual rows=5 loops=1)
-   ->  Sort (actual rows=5 loops=1)
-         Sort Key: test1."time"
-         Sort Method: quicksort 
-         ->  Finalize HashAggregate (actual rows=5 loops=1)
-               Group Key: test1."time", test1.x1, test1.x2
-               Batches: 1 
-               ->  Custom Scan (ChunkAppend) on test1 (actual rows=5 loops=1)
-                     Order: test1."time", test1.x1, test1.x2
-                     ->  Merge Append (actual rows=5 loops=1)
+   ->  Finalize GroupAggregate (actual rows=5 loops=1)
+         Group Key: test1."time", test1.x1, test1.x2
+         ->  Custom Scan (ChunkAppend) on test1 (actual rows=5 loops=1)
+               Order: test1."time", test1.x1, test1.x2
+               ->  Merge Append (actual rows=5 loops=1)
+                     Sort Key: _hyper_3_7_chunk."time", _hyper_3_7_chunk.x1, _hyper_3_7_chunk.x2
+                     ->  Sort (actual rows=4 loops=1)
                            Sort Key: _hyper_3_7_chunk."time", _hyper_3_7_chunk.x1, _hyper_3_7_chunk.x2
-                           ->  Sort (actual rows=4 loops=1)
-                                 Sort Key: _hyper_3_7_chunk."time", _hyper_3_7_chunk.x1, _hyper_3_7_chunk.x2
-                                 Sort Method: quicksort 
-                                 ->  Partial HashAggregate (actual rows=4 loops=1)
-                                       Group Key: _hyper_3_7_chunk."time", _hyper_3_7_chunk.x1, _hyper_3_7_chunk.x2
-                                       Batches: 1 
-                                       ->  Custom Scan (DecompressChunk) on _hyper_3_7_chunk (actual rows=4 loops=1)
-                                             ->  Seq Scan on compress_hyper_4_8_chunk (actual rows=3 loops=1)
-                           ->  Sort (actual rows=1 loops=1)
-                                 Sort Key: _hyper_3_7_chunk."time", _hyper_3_7_chunk.x1, _hyper_3_7_chunk.x2
-                                 Sort Method: quicksort 
-                                 ->  Partial HashAggregate (actual rows=1 loops=1)
-                                       Group Key: _hyper_3_7_chunk."time", _hyper_3_7_chunk.x1, _hyper_3_7_chunk.x2
-                                       Batches: 1 
-                                       ->  Seq Scan on _hyper_3_7_chunk (actual rows=1 loops=1)
-(26 rows)
+                           Sort Method: quicksort 
+                           ->  Partial HashAggregate (actual rows=4 loops=1)
+                                 Group Key: _hyper_3_7_chunk."time", _hyper_3_7_chunk.x1, _hyper_3_7_chunk.x2
+                                 Batches: 1 
+                                 ->  Custom Scan (DecompressChunk) on _hyper_3_7_chunk (actual rows=4 loops=1)
+                                       ->  Seq Scan on compress_hyper_4_8_chunk (actual rows=3 loops=1)
+                     ->  Sort (actual rows=1 loops=1)
+                           Sort Key: _hyper_3_7_chunk."time", _hyper_3_7_chunk.x1, _hyper_3_7_chunk.x2
+                           Sort Method: quicksort 
+                           ->  Partial HashAggregate (actual rows=1 loops=1)
+                                 Group Key: _hyper_3_7_chunk."time", _hyper_3_7_chunk.x1, _hyper_3_7_chunk.x2
+                                 Batches: 1 
+                                 ->  Seq Scan on _hyper_3_7_chunk (actual rows=1 loops=1)
+(22 rows)
 
 :PREFIX
 SELECT * FROM test1 ORDER BY x1, x2, x5, x4, time LIMIT 10;

--- a/tsl/test/expected/merge_append_partially_compressed-14.out
+++ b/tsl/test/expected/merge_append_partially_compressed-14.out
@@ -692,35 +692,31 @@ SELECT * FROM test1 ORDER BY time ASC NULLS FIRST, x3 DESC NULLS LAST, x4 ASC;
 
 :PREFIX
 SELECT x1, x2, max(time) FROM test1 GROUP BY x1, x2, time ORDER BY time limit 10;
-                                                     QUERY PLAN                                                      
----------------------------------------------------------------------------------------------------------------------
+                                                  QUERY PLAN                                                   
+---------------------------------------------------------------------------------------------------------------
  Limit (actual rows=5 loops=1)
-   ->  Sort (actual rows=5 loops=1)
-         Sort Key: test1."time"
-         Sort Method: quicksort 
-         ->  Finalize HashAggregate (actual rows=5 loops=1)
-               Group Key: test1."time", test1.x1, test1.x2
-               Batches: 1 
-               ->  Custom Scan (ChunkAppend) on test1 (actual rows=5 loops=1)
-                     Order: test1."time", test1.x1, test1.x2
-                     ->  Merge Append (actual rows=5 loops=1)
+   ->  Finalize GroupAggregate (actual rows=5 loops=1)
+         Group Key: test1."time", test1.x1, test1.x2
+         ->  Custom Scan (ChunkAppend) on test1 (actual rows=5 loops=1)
+               Order: test1."time", test1.x1, test1.x2
+               ->  Merge Append (actual rows=5 loops=1)
+                     Sort Key: _hyper_3_7_chunk."time", _hyper_3_7_chunk.x1, _hyper_3_7_chunk.x2
+                     ->  Sort (actual rows=4 loops=1)
                            Sort Key: _hyper_3_7_chunk."time", _hyper_3_7_chunk.x1, _hyper_3_7_chunk.x2
-                           ->  Sort (actual rows=4 loops=1)
-                                 Sort Key: _hyper_3_7_chunk."time", _hyper_3_7_chunk.x1, _hyper_3_7_chunk.x2
-                                 Sort Method: quicksort 
-                                 ->  Partial HashAggregate (actual rows=4 loops=1)
-                                       Group Key: _hyper_3_7_chunk."time", _hyper_3_7_chunk.x1, _hyper_3_7_chunk.x2
-                                       Batches: 1 
-                                       ->  Custom Scan (DecompressChunk) on _hyper_3_7_chunk (actual rows=4 loops=1)
-                                             ->  Seq Scan on compress_hyper_4_8_chunk (actual rows=3 loops=1)
-                           ->  Sort (actual rows=1 loops=1)
-                                 Sort Key: _hyper_3_7_chunk."time", _hyper_3_7_chunk.x1, _hyper_3_7_chunk.x2
-                                 Sort Method: quicksort 
-                                 ->  Partial HashAggregate (actual rows=1 loops=1)
-                                       Group Key: _hyper_3_7_chunk."time", _hyper_3_7_chunk.x1, _hyper_3_7_chunk.x2
-                                       Batches: 1 
-                                       ->  Seq Scan on _hyper_3_7_chunk (actual rows=1 loops=1)
-(26 rows)
+                           Sort Method: quicksort 
+                           ->  Partial HashAggregate (actual rows=4 loops=1)
+                                 Group Key: _hyper_3_7_chunk."time", _hyper_3_7_chunk.x1, _hyper_3_7_chunk.x2
+                                 Batches: 1 
+                                 ->  Custom Scan (DecompressChunk) on _hyper_3_7_chunk (actual rows=4 loops=1)
+                                       ->  Seq Scan on compress_hyper_4_8_chunk (actual rows=3 loops=1)
+                     ->  Sort (actual rows=1 loops=1)
+                           Sort Key: _hyper_3_7_chunk."time", _hyper_3_7_chunk.x1, _hyper_3_7_chunk.x2
+                           Sort Method: quicksort 
+                           ->  Partial HashAggregate (actual rows=1 loops=1)
+                                 Group Key: _hyper_3_7_chunk."time", _hyper_3_7_chunk.x1, _hyper_3_7_chunk.x2
+                                 Batches: 1 
+                                 ->  Seq Scan on _hyper_3_7_chunk (actual rows=1 loops=1)
+(22 rows)
 
 :PREFIX
 SELECT * FROM test1 ORDER BY x1, x2, x5, x4, time LIMIT 10;

--- a/tsl/test/expected/merge_append_partially_compressed-15.out
+++ b/tsl/test/expected/merge_append_partially_compressed-15.out
@@ -698,35 +698,31 @@ SELECT * FROM test1 ORDER BY time ASC NULLS FIRST, x3 DESC NULLS LAST, x4 ASC;
 
 :PREFIX
 SELECT x1, x2, max(time) FROM test1 GROUP BY x1, x2, time ORDER BY time limit 10;
-                                                     QUERY PLAN                                                      
----------------------------------------------------------------------------------------------------------------------
+                                                  QUERY PLAN                                                   
+---------------------------------------------------------------------------------------------------------------
  Limit (actual rows=5 loops=1)
-   ->  Sort (actual rows=5 loops=1)
-         Sort Key: test1."time"
-         Sort Method: quicksort 
-         ->  Finalize HashAggregate (actual rows=5 loops=1)
-               Group Key: test1."time", test1.x1, test1.x2
-               Batches: 1 
-               ->  Custom Scan (ChunkAppend) on test1 (actual rows=5 loops=1)
-                     Order: test1."time", test1.x1, test1.x2
-                     ->  Merge Append (actual rows=5 loops=1)
+   ->  Finalize GroupAggregate (actual rows=5 loops=1)
+         Group Key: test1."time", test1.x1, test1.x2
+         ->  Custom Scan (ChunkAppend) on test1 (actual rows=5 loops=1)
+               Order: test1."time", test1.x1, test1.x2
+               ->  Merge Append (actual rows=5 loops=1)
+                     Sort Key: _hyper_3_7_chunk."time", _hyper_3_7_chunk.x1, _hyper_3_7_chunk.x2
+                     ->  Sort (actual rows=4 loops=1)
                            Sort Key: _hyper_3_7_chunk."time", _hyper_3_7_chunk.x1, _hyper_3_7_chunk.x2
-                           ->  Sort (actual rows=4 loops=1)
-                                 Sort Key: _hyper_3_7_chunk."time", _hyper_3_7_chunk.x1, _hyper_3_7_chunk.x2
-                                 Sort Method: quicksort 
-                                 ->  Partial HashAggregate (actual rows=4 loops=1)
-                                       Group Key: _hyper_3_7_chunk."time", _hyper_3_7_chunk.x1, _hyper_3_7_chunk.x2
-                                       Batches: 1 
-                                       ->  Custom Scan (DecompressChunk) on _hyper_3_7_chunk (actual rows=4 loops=1)
-                                             ->  Seq Scan on compress_hyper_4_8_chunk (actual rows=3 loops=1)
-                           ->  Sort (actual rows=1 loops=1)
-                                 Sort Key: _hyper_3_7_chunk."time", _hyper_3_7_chunk.x1, _hyper_3_7_chunk.x2
-                                 Sort Method: quicksort 
-                                 ->  Partial HashAggregate (actual rows=1 loops=1)
-                                       Group Key: _hyper_3_7_chunk."time", _hyper_3_7_chunk.x1, _hyper_3_7_chunk.x2
-                                       Batches: 1 
-                                       ->  Seq Scan on _hyper_3_7_chunk (actual rows=1 loops=1)
-(26 rows)
+                           Sort Method: quicksort 
+                           ->  Partial HashAggregate (actual rows=4 loops=1)
+                                 Group Key: _hyper_3_7_chunk."time", _hyper_3_7_chunk.x1, _hyper_3_7_chunk.x2
+                                 Batches: 1 
+                                 ->  Custom Scan (DecompressChunk) on _hyper_3_7_chunk (actual rows=4 loops=1)
+                                       ->  Seq Scan on compress_hyper_4_8_chunk (actual rows=3 loops=1)
+                     ->  Sort (actual rows=1 loops=1)
+                           Sort Key: _hyper_3_7_chunk."time", _hyper_3_7_chunk.x1, _hyper_3_7_chunk.x2
+                           Sort Method: quicksort 
+                           ->  Partial HashAggregate (actual rows=1 loops=1)
+                                 Group Key: _hyper_3_7_chunk."time", _hyper_3_7_chunk.x1, _hyper_3_7_chunk.x2
+                                 Batches: 1 
+                                 ->  Seq Scan on _hyper_3_7_chunk (actual rows=1 loops=1)
+(22 rows)
 
 :PREFIX
 SELECT * FROM test1 ORDER BY x1, x2, x5, x4, time LIMIT 10;

--- a/tsl/test/expected/vectorized_aggregation.out
+++ b/tsl/test/expected/vectorized_aggregation.out
@@ -1,0 +1,2052 @@
+-- This file and its contents are licensed under the Timescale License.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-TIMESCALE for a copy of the license.
+\set EXPLAIN 'EXPLAIN (VERBOSE, COSTS OFF)'
+CREATE TABLE testtable (
+time timestamptz NOT NULL,
+segment_by_value integer,
+int_value integer,
+float_value double precision);
+SELECT FROM create_hypertable(relation=>'testtable', time_column_name=> 'time');
+--
+(1 row)
+
+ALTER TABLE testtable SET (timescaledb.compress, timescaledb.compress_segmentby='segment_by_value');
+INSERT INTO testtable
+SELECT time AS time,
+value AS segment_by_value,
+value AS int_value,
+value AS float_value
+FROM
+generate_series('1980-01-01 00:00:00-00', '1980-03-01 00:00:00-00', INTERVAL '1 day') AS g1(time),
+generate_series(-10, 100, 1) AS g2(value)
+ORDER BY time;
+-- Aggregation result without any vectorization
+SELECT sum(segment_by_value), sum(int_value), sum(float_value) FROM testtable;
+  sum   |  sum   |  sum   
+--------+--------+--------
+ 304695 | 304695 | 304695
+(1 row)
+
+---
+-- Tests with some chunks compressed
+---
+SELECT compress_chunk(ch) FROM show_chunks('testtable') ch LIMIT 3;
+             compress_chunk             
+----------------------------------------
+ _timescaledb_internal._hyper_1_1_chunk
+ _timescaledb_internal._hyper_1_2_chunk
+ _timescaledb_internal._hyper_1_3_chunk
+(3 rows)
+
+-- Vectorized aggregation possible
+SELECT sum(segment_by_value) FROM testtable;
+  sum   
+--------
+ 304695
+(1 row)
+
+:EXPLAIN
+SELECT sum(segment_by_value) FROM testtable;
+                                                                                                                                                                             QUERY PLAN                                                                                                                                                                              
+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Finalize Aggregate
+   Output: sum(_hyper_1_1_chunk.segment_by_value)
+   ->  Append
+         ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_1_chunk
+               Output: (PARTIAL sum(_hyper_1_1_chunk.segment_by_value))
+               Vectorized Aggregation: true
+               ->  Seq Scan on _timescaledb_internal.compress_hyper_2_11_chunk
+                     Output: compress_hyper_2_11_chunk."time", compress_hyper_2_11_chunk.segment_by_value, compress_hyper_2_11_chunk.int_value, compress_hyper_2_11_chunk.float_value, compress_hyper_2_11_chunk._ts_meta_count, compress_hyper_2_11_chunk._ts_meta_sequence_num, compress_hyper_2_11_chunk._ts_meta_min_1, compress_hyper_2_11_chunk._ts_meta_max_1
+         ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_2_chunk
+               Output: (PARTIAL sum(_hyper_1_2_chunk.segment_by_value))
+               Vectorized Aggregation: true
+               ->  Seq Scan on _timescaledb_internal.compress_hyper_2_12_chunk
+                     Output: compress_hyper_2_12_chunk."time", compress_hyper_2_12_chunk.segment_by_value, compress_hyper_2_12_chunk.int_value, compress_hyper_2_12_chunk.float_value, compress_hyper_2_12_chunk._ts_meta_count, compress_hyper_2_12_chunk._ts_meta_sequence_num, compress_hyper_2_12_chunk._ts_meta_min_1, compress_hyper_2_12_chunk._ts_meta_max_1
+         ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_3_chunk
+               Output: (PARTIAL sum(_hyper_1_3_chunk.segment_by_value))
+               Vectorized Aggregation: true
+               ->  Seq Scan on _timescaledb_internal.compress_hyper_2_13_chunk
+                     Output: compress_hyper_2_13_chunk."time", compress_hyper_2_13_chunk.segment_by_value, compress_hyper_2_13_chunk.int_value, compress_hyper_2_13_chunk.float_value, compress_hyper_2_13_chunk._ts_meta_count, compress_hyper_2_13_chunk._ts_meta_sequence_num, compress_hyper_2_13_chunk._ts_meta_min_1, compress_hyper_2_13_chunk._ts_meta_max_1
+         ->  Partial Aggregate
+               Output: PARTIAL sum(_hyper_1_4_chunk.segment_by_value)
+               ->  Seq Scan on _timescaledb_internal._hyper_1_4_chunk
+                     Output: _hyper_1_4_chunk.segment_by_value
+         ->  Partial Aggregate
+               Output: PARTIAL sum(_hyper_1_5_chunk.segment_by_value)
+               ->  Seq Scan on _timescaledb_internal._hyper_1_5_chunk
+                     Output: _hyper_1_5_chunk.segment_by_value
+         ->  Partial Aggregate
+               Output: PARTIAL sum(_hyper_1_6_chunk.segment_by_value)
+               ->  Seq Scan on _timescaledb_internal._hyper_1_6_chunk
+                     Output: _hyper_1_6_chunk.segment_by_value
+         ->  Partial Aggregate
+               Output: PARTIAL sum(_hyper_1_7_chunk.segment_by_value)
+               ->  Seq Scan on _timescaledb_internal._hyper_1_7_chunk
+                     Output: _hyper_1_7_chunk.segment_by_value
+         ->  Partial Aggregate
+               Output: PARTIAL sum(_hyper_1_8_chunk.segment_by_value)
+               ->  Seq Scan on _timescaledb_internal._hyper_1_8_chunk
+                     Output: _hyper_1_8_chunk.segment_by_value
+         ->  Partial Aggregate
+               Output: PARTIAL sum(_hyper_1_9_chunk.segment_by_value)
+               ->  Seq Scan on _timescaledb_internal._hyper_1_9_chunk
+                     Output: _hyper_1_9_chunk.segment_by_value
+         ->  Partial Aggregate
+               Output: PARTIAL sum(_hyper_1_10_chunk.segment_by_value)
+               ->  Seq Scan on _timescaledb_internal._hyper_1_10_chunk
+                     Output: _hyper_1_10_chunk.segment_by_value
+(46 rows)
+
+-- Vectorization not possible due to a used filter
+:EXPLAIN
+SELECT sum(segment_by_value) FROM testtable WHERE segment_by_value > 0;
+                                                                                                                                                                                QUERY PLAN                                                                                                                                                                                 
+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Finalize Aggregate
+   Output: sum(_hyper_1_1_chunk.segment_by_value)
+   ->  Append
+         ->  Partial Aggregate
+               Output: PARTIAL sum(_hyper_1_1_chunk.segment_by_value)
+               ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_1_chunk
+                     Output: _hyper_1_1_chunk.segment_by_value
+                     ->  Index Scan using compress_hyper_2_11_chunk__compressed_hypertable_2_segment_by_v on _timescaledb_internal.compress_hyper_2_11_chunk
+                           Output: compress_hyper_2_11_chunk."time", compress_hyper_2_11_chunk.segment_by_value, compress_hyper_2_11_chunk.int_value, compress_hyper_2_11_chunk.float_value, compress_hyper_2_11_chunk._ts_meta_count, compress_hyper_2_11_chunk._ts_meta_sequence_num, compress_hyper_2_11_chunk._ts_meta_min_1, compress_hyper_2_11_chunk._ts_meta_max_1
+                           Index Cond: (compress_hyper_2_11_chunk.segment_by_value > 0)
+         ->  Partial Aggregate
+               Output: PARTIAL sum(_hyper_1_2_chunk.segment_by_value)
+               ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_2_chunk
+                     Output: _hyper_1_2_chunk.segment_by_value
+                     ->  Index Scan using compress_hyper_2_12_chunk__compressed_hypertable_2_segment_by_v on _timescaledb_internal.compress_hyper_2_12_chunk
+                           Output: compress_hyper_2_12_chunk."time", compress_hyper_2_12_chunk.segment_by_value, compress_hyper_2_12_chunk.int_value, compress_hyper_2_12_chunk.float_value, compress_hyper_2_12_chunk._ts_meta_count, compress_hyper_2_12_chunk._ts_meta_sequence_num, compress_hyper_2_12_chunk._ts_meta_min_1, compress_hyper_2_12_chunk._ts_meta_max_1
+                           Index Cond: (compress_hyper_2_12_chunk.segment_by_value > 0)
+         ->  Partial Aggregate
+               Output: PARTIAL sum(_hyper_1_3_chunk.segment_by_value)
+               ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_3_chunk
+                     Output: _hyper_1_3_chunk.segment_by_value
+                     ->  Index Scan using compress_hyper_2_13_chunk__compressed_hypertable_2_segment_by_v on _timescaledb_internal.compress_hyper_2_13_chunk
+                           Output: compress_hyper_2_13_chunk."time", compress_hyper_2_13_chunk.segment_by_value, compress_hyper_2_13_chunk.int_value, compress_hyper_2_13_chunk.float_value, compress_hyper_2_13_chunk._ts_meta_count, compress_hyper_2_13_chunk._ts_meta_sequence_num, compress_hyper_2_13_chunk._ts_meta_min_1, compress_hyper_2_13_chunk._ts_meta_max_1
+                           Index Cond: (compress_hyper_2_13_chunk.segment_by_value > 0)
+         ->  Partial Aggregate
+               Output: PARTIAL sum(_hyper_1_4_chunk.segment_by_value)
+               ->  Seq Scan on _timescaledb_internal._hyper_1_4_chunk
+                     Output: _hyper_1_4_chunk.segment_by_value
+                     Filter: (_hyper_1_4_chunk.segment_by_value > 0)
+         ->  Partial Aggregate
+               Output: PARTIAL sum(_hyper_1_5_chunk.segment_by_value)
+               ->  Seq Scan on _timescaledb_internal._hyper_1_5_chunk
+                     Output: _hyper_1_5_chunk.segment_by_value
+                     Filter: (_hyper_1_5_chunk.segment_by_value > 0)
+         ->  Partial Aggregate
+               Output: PARTIAL sum(_hyper_1_6_chunk.segment_by_value)
+               ->  Seq Scan on _timescaledb_internal._hyper_1_6_chunk
+                     Output: _hyper_1_6_chunk.segment_by_value
+                     Filter: (_hyper_1_6_chunk.segment_by_value > 0)
+         ->  Partial Aggregate
+               Output: PARTIAL sum(_hyper_1_7_chunk.segment_by_value)
+               ->  Seq Scan on _timescaledb_internal._hyper_1_7_chunk
+                     Output: _hyper_1_7_chunk.segment_by_value
+                     Filter: (_hyper_1_7_chunk.segment_by_value > 0)
+         ->  Partial Aggregate
+               Output: PARTIAL sum(_hyper_1_8_chunk.segment_by_value)
+               ->  Seq Scan on _timescaledb_internal._hyper_1_8_chunk
+                     Output: _hyper_1_8_chunk.segment_by_value
+                     Filter: (_hyper_1_8_chunk.segment_by_value > 0)
+         ->  Partial Aggregate
+               Output: PARTIAL sum(_hyper_1_9_chunk.segment_by_value)
+               ->  Seq Scan on _timescaledb_internal._hyper_1_9_chunk
+                     Output: _hyper_1_9_chunk.segment_by_value
+                     Filter: (_hyper_1_9_chunk.segment_by_value > 0)
+         ->  Partial Aggregate
+               Output: PARTIAL sum(_hyper_1_10_chunk.segment_by_value)
+               ->  Seq Scan on _timescaledb_internal._hyper_1_10_chunk
+                     Output: _hyper_1_10_chunk.segment_by_value
+                     Filter: (_hyper_1_10_chunk.segment_by_value > 0)
+(59 rows)
+
+-- Vectorization not possible due grouping
+:EXPLAIN
+SELECT sum(segment_by_value) FROM testtable GROUP BY float_value;
+                                                                                                                                                                                      QUERY PLAN                                                                                                                                                                                       
+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Finalize GroupAggregate
+   Output: sum(_hyper_1_1_chunk.segment_by_value), _hyper_1_1_chunk.float_value
+   Group Key: _hyper_1_1_chunk.float_value
+   ->  Gather Merge
+         Output: _hyper_1_1_chunk.float_value, (PARTIAL sum(_hyper_1_1_chunk.segment_by_value))
+         Workers Planned: 2
+         ->  Sort
+               Output: _hyper_1_1_chunk.float_value, (PARTIAL sum(_hyper_1_1_chunk.segment_by_value))
+               Sort Key: _hyper_1_1_chunk.float_value
+               ->  Partial HashAggregate
+                     Output: _hyper_1_1_chunk.float_value, PARTIAL sum(_hyper_1_1_chunk.segment_by_value)
+                     Group Key: _hyper_1_1_chunk.float_value
+                     ->  Parallel Append
+                           ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_1_chunk
+                                 Output: _hyper_1_1_chunk.segment_by_value, _hyper_1_1_chunk.float_value
+                                 ->  Parallel Seq Scan on _timescaledb_internal.compress_hyper_2_11_chunk
+                                       Output: compress_hyper_2_11_chunk."time", compress_hyper_2_11_chunk.segment_by_value, compress_hyper_2_11_chunk.int_value, compress_hyper_2_11_chunk.float_value, compress_hyper_2_11_chunk._ts_meta_count, compress_hyper_2_11_chunk._ts_meta_sequence_num, compress_hyper_2_11_chunk._ts_meta_min_1, compress_hyper_2_11_chunk._ts_meta_max_1
+                           ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_2_chunk
+                                 Output: _hyper_1_2_chunk.segment_by_value, _hyper_1_2_chunk.float_value
+                                 ->  Parallel Seq Scan on _timescaledb_internal.compress_hyper_2_12_chunk
+                                       Output: compress_hyper_2_12_chunk."time", compress_hyper_2_12_chunk.segment_by_value, compress_hyper_2_12_chunk.int_value, compress_hyper_2_12_chunk.float_value, compress_hyper_2_12_chunk._ts_meta_count, compress_hyper_2_12_chunk._ts_meta_sequence_num, compress_hyper_2_12_chunk._ts_meta_min_1, compress_hyper_2_12_chunk._ts_meta_max_1
+                           ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_3_chunk
+                                 Output: _hyper_1_3_chunk.segment_by_value, _hyper_1_3_chunk.float_value
+                                 ->  Parallel Seq Scan on _timescaledb_internal.compress_hyper_2_13_chunk
+                                       Output: compress_hyper_2_13_chunk."time", compress_hyper_2_13_chunk.segment_by_value, compress_hyper_2_13_chunk.int_value, compress_hyper_2_13_chunk.float_value, compress_hyper_2_13_chunk._ts_meta_count, compress_hyper_2_13_chunk._ts_meta_sequence_num, compress_hyper_2_13_chunk._ts_meta_min_1, compress_hyper_2_13_chunk._ts_meta_max_1
+                           ->  Parallel Seq Scan on _timescaledb_internal._hyper_1_4_chunk
+                                 Output: _hyper_1_4_chunk.segment_by_value, _hyper_1_4_chunk.float_value
+                           ->  Parallel Seq Scan on _timescaledb_internal._hyper_1_5_chunk
+                                 Output: _hyper_1_5_chunk.segment_by_value, _hyper_1_5_chunk.float_value
+                           ->  Parallel Seq Scan on _timescaledb_internal._hyper_1_6_chunk
+                                 Output: _hyper_1_6_chunk.segment_by_value, _hyper_1_6_chunk.float_value
+                           ->  Parallel Seq Scan on _timescaledb_internal._hyper_1_7_chunk
+                                 Output: _hyper_1_7_chunk.segment_by_value, _hyper_1_7_chunk.float_value
+                           ->  Parallel Seq Scan on _timescaledb_internal._hyper_1_8_chunk
+                                 Output: _hyper_1_8_chunk.segment_by_value, _hyper_1_8_chunk.float_value
+                           ->  Parallel Seq Scan on _timescaledb_internal._hyper_1_9_chunk
+                                 Output: _hyper_1_9_chunk.segment_by_value, _hyper_1_9_chunk.float_value
+                           ->  Parallel Seq Scan on _timescaledb_internal._hyper_1_10_chunk
+                                 Output: _hyper_1_10_chunk.segment_by_value, _hyper_1_10_chunk.float_value
+(39 rows)
+
+:EXPLAIN
+SELECT sum(segment_by_value) FROM testtable GROUP BY int_value;
+                                                                                                                                                                                      QUERY PLAN                                                                                                                                                                                       
+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Finalize GroupAggregate
+   Output: sum(_hyper_1_1_chunk.segment_by_value), _hyper_1_1_chunk.int_value
+   Group Key: _hyper_1_1_chunk.int_value
+   ->  Gather Merge
+         Output: _hyper_1_1_chunk.int_value, (PARTIAL sum(_hyper_1_1_chunk.segment_by_value))
+         Workers Planned: 2
+         ->  Sort
+               Output: _hyper_1_1_chunk.int_value, (PARTIAL sum(_hyper_1_1_chunk.segment_by_value))
+               Sort Key: _hyper_1_1_chunk.int_value
+               ->  Partial HashAggregate
+                     Output: _hyper_1_1_chunk.int_value, PARTIAL sum(_hyper_1_1_chunk.segment_by_value)
+                     Group Key: _hyper_1_1_chunk.int_value
+                     ->  Parallel Append
+                           ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_1_chunk
+                                 Output: _hyper_1_1_chunk.segment_by_value, _hyper_1_1_chunk.int_value
+                                 ->  Parallel Seq Scan on _timescaledb_internal.compress_hyper_2_11_chunk
+                                       Output: compress_hyper_2_11_chunk."time", compress_hyper_2_11_chunk.segment_by_value, compress_hyper_2_11_chunk.int_value, compress_hyper_2_11_chunk.float_value, compress_hyper_2_11_chunk._ts_meta_count, compress_hyper_2_11_chunk._ts_meta_sequence_num, compress_hyper_2_11_chunk._ts_meta_min_1, compress_hyper_2_11_chunk._ts_meta_max_1
+                           ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_2_chunk
+                                 Output: _hyper_1_2_chunk.segment_by_value, _hyper_1_2_chunk.int_value
+                                 ->  Parallel Seq Scan on _timescaledb_internal.compress_hyper_2_12_chunk
+                                       Output: compress_hyper_2_12_chunk."time", compress_hyper_2_12_chunk.segment_by_value, compress_hyper_2_12_chunk.int_value, compress_hyper_2_12_chunk.float_value, compress_hyper_2_12_chunk._ts_meta_count, compress_hyper_2_12_chunk._ts_meta_sequence_num, compress_hyper_2_12_chunk._ts_meta_min_1, compress_hyper_2_12_chunk._ts_meta_max_1
+                           ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_3_chunk
+                                 Output: _hyper_1_3_chunk.segment_by_value, _hyper_1_3_chunk.int_value
+                                 ->  Parallel Seq Scan on _timescaledb_internal.compress_hyper_2_13_chunk
+                                       Output: compress_hyper_2_13_chunk."time", compress_hyper_2_13_chunk.segment_by_value, compress_hyper_2_13_chunk.int_value, compress_hyper_2_13_chunk.float_value, compress_hyper_2_13_chunk._ts_meta_count, compress_hyper_2_13_chunk._ts_meta_sequence_num, compress_hyper_2_13_chunk._ts_meta_min_1, compress_hyper_2_13_chunk._ts_meta_max_1
+                           ->  Parallel Seq Scan on _timescaledb_internal._hyper_1_4_chunk
+                                 Output: _hyper_1_4_chunk.segment_by_value, _hyper_1_4_chunk.int_value
+                           ->  Parallel Seq Scan on _timescaledb_internal._hyper_1_5_chunk
+                                 Output: _hyper_1_5_chunk.segment_by_value, _hyper_1_5_chunk.int_value
+                           ->  Parallel Seq Scan on _timescaledb_internal._hyper_1_6_chunk
+                                 Output: _hyper_1_6_chunk.segment_by_value, _hyper_1_6_chunk.int_value
+                           ->  Parallel Seq Scan on _timescaledb_internal._hyper_1_7_chunk
+                                 Output: _hyper_1_7_chunk.segment_by_value, _hyper_1_7_chunk.int_value
+                           ->  Parallel Seq Scan on _timescaledb_internal._hyper_1_8_chunk
+                                 Output: _hyper_1_8_chunk.segment_by_value, _hyper_1_8_chunk.int_value
+                           ->  Parallel Seq Scan on _timescaledb_internal._hyper_1_9_chunk
+                                 Output: _hyper_1_9_chunk.segment_by_value, _hyper_1_9_chunk.int_value
+                           ->  Parallel Seq Scan on _timescaledb_internal._hyper_1_10_chunk
+                                 Output: _hyper_1_10_chunk.segment_by_value, _hyper_1_10_chunk.int_value
+(39 rows)
+
+:EXPLAIN
+SELECT sum(int_value) FROM testtable GROUP BY segment_by_value;
+                                                                                                                                                                                      QUERY PLAN                                                                                                                                                                                       
+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Finalize GroupAggregate
+   Output: sum(_hyper_1_1_chunk.int_value), _hyper_1_1_chunk.segment_by_value
+   Group Key: _hyper_1_1_chunk.segment_by_value
+   ->  Gather Merge
+         Output: _hyper_1_1_chunk.segment_by_value, (PARTIAL sum(_hyper_1_1_chunk.int_value))
+         Workers Planned: 2
+         ->  Sort
+               Output: _hyper_1_1_chunk.segment_by_value, (PARTIAL sum(_hyper_1_1_chunk.int_value))
+               Sort Key: _hyper_1_1_chunk.segment_by_value
+               ->  Partial HashAggregate
+                     Output: _hyper_1_1_chunk.segment_by_value, PARTIAL sum(_hyper_1_1_chunk.int_value)
+                     Group Key: _hyper_1_1_chunk.segment_by_value
+                     ->  Parallel Append
+                           ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_1_chunk
+                                 Output: _hyper_1_1_chunk.int_value, _hyper_1_1_chunk.segment_by_value
+                                 ->  Parallel Seq Scan on _timescaledb_internal.compress_hyper_2_11_chunk
+                                       Output: compress_hyper_2_11_chunk."time", compress_hyper_2_11_chunk.segment_by_value, compress_hyper_2_11_chunk.int_value, compress_hyper_2_11_chunk.float_value, compress_hyper_2_11_chunk._ts_meta_count, compress_hyper_2_11_chunk._ts_meta_sequence_num, compress_hyper_2_11_chunk._ts_meta_min_1, compress_hyper_2_11_chunk._ts_meta_max_1
+                           ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_2_chunk
+                                 Output: _hyper_1_2_chunk.int_value, _hyper_1_2_chunk.segment_by_value
+                                 ->  Parallel Seq Scan on _timescaledb_internal.compress_hyper_2_12_chunk
+                                       Output: compress_hyper_2_12_chunk."time", compress_hyper_2_12_chunk.segment_by_value, compress_hyper_2_12_chunk.int_value, compress_hyper_2_12_chunk.float_value, compress_hyper_2_12_chunk._ts_meta_count, compress_hyper_2_12_chunk._ts_meta_sequence_num, compress_hyper_2_12_chunk._ts_meta_min_1, compress_hyper_2_12_chunk._ts_meta_max_1
+                           ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_3_chunk
+                                 Output: _hyper_1_3_chunk.int_value, _hyper_1_3_chunk.segment_by_value
+                                 ->  Parallel Seq Scan on _timescaledb_internal.compress_hyper_2_13_chunk
+                                       Output: compress_hyper_2_13_chunk."time", compress_hyper_2_13_chunk.segment_by_value, compress_hyper_2_13_chunk.int_value, compress_hyper_2_13_chunk.float_value, compress_hyper_2_13_chunk._ts_meta_count, compress_hyper_2_13_chunk._ts_meta_sequence_num, compress_hyper_2_13_chunk._ts_meta_min_1, compress_hyper_2_13_chunk._ts_meta_max_1
+                           ->  Parallel Seq Scan on _timescaledb_internal._hyper_1_4_chunk
+                                 Output: _hyper_1_4_chunk.int_value, _hyper_1_4_chunk.segment_by_value
+                           ->  Parallel Seq Scan on _timescaledb_internal._hyper_1_5_chunk
+                                 Output: _hyper_1_5_chunk.int_value, _hyper_1_5_chunk.segment_by_value
+                           ->  Parallel Seq Scan on _timescaledb_internal._hyper_1_6_chunk
+                                 Output: _hyper_1_6_chunk.int_value, _hyper_1_6_chunk.segment_by_value
+                           ->  Parallel Seq Scan on _timescaledb_internal._hyper_1_7_chunk
+                                 Output: _hyper_1_7_chunk.int_value, _hyper_1_7_chunk.segment_by_value
+                           ->  Parallel Seq Scan on _timescaledb_internal._hyper_1_8_chunk
+                                 Output: _hyper_1_8_chunk.int_value, _hyper_1_8_chunk.segment_by_value
+                           ->  Parallel Seq Scan on _timescaledb_internal._hyper_1_9_chunk
+                                 Output: _hyper_1_9_chunk.int_value, _hyper_1_9_chunk.segment_by_value
+                           ->  Parallel Seq Scan on _timescaledb_internal._hyper_1_10_chunk
+                                 Output: _hyper_1_10_chunk.int_value, _hyper_1_10_chunk.segment_by_value
+(39 rows)
+
+-- Vectorization not possible due to two variables and grouping
+:EXPLAIN
+SELECT sum(segment_by_value), segment_by_value FROM testtable GROUP BY segment_by_value;
+                                                                                                                                                                                   QUERY PLAN                                                                                                                                                                                    
+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Finalize HashAggregate
+   Output: sum(_hyper_1_1_chunk.segment_by_value), _hyper_1_1_chunk.segment_by_value
+   Group Key: _hyper_1_1_chunk.segment_by_value
+   ->  Gather
+         Output: _hyper_1_1_chunk.segment_by_value, (PARTIAL sum(_hyper_1_1_chunk.segment_by_value))
+         Workers Planned: 2
+         ->  Parallel Append
+               ->  Partial HashAggregate
+                     Output: _hyper_1_1_chunk.segment_by_value, PARTIAL sum(_hyper_1_1_chunk.segment_by_value)
+                     Group Key: _hyper_1_1_chunk.segment_by_value
+                     ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_1_chunk
+                           Output: _hyper_1_1_chunk.segment_by_value
+                           ->  Parallel Seq Scan on _timescaledb_internal.compress_hyper_2_11_chunk
+                                 Output: compress_hyper_2_11_chunk."time", compress_hyper_2_11_chunk.segment_by_value, compress_hyper_2_11_chunk.int_value, compress_hyper_2_11_chunk.float_value, compress_hyper_2_11_chunk._ts_meta_count, compress_hyper_2_11_chunk._ts_meta_sequence_num, compress_hyper_2_11_chunk._ts_meta_min_1, compress_hyper_2_11_chunk._ts_meta_max_1
+               ->  Partial HashAggregate
+                     Output: _hyper_1_2_chunk.segment_by_value, PARTIAL sum(_hyper_1_2_chunk.segment_by_value)
+                     Group Key: _hyper_1_2_chunk.segment_by_value
+                     ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_2_chunk
+                           Output: _hyper_1_2_chunk.segment_by_value
+                           ->  Parallel Seq Scan on _timescaledb_internal.compress_hyper_2_12_chunk
+                                 Output: compress_hyper_2_12_chunk."time", compress_hyper_2_12_chunk.segment_by_value, compress_hyper_2_12_chunk.int_value, compress_hyper_2_12_chunk.float_value, compress_hyper_2_12_chunk._ts_meta_count, compress_hyper_2_12_chunk._ts_meta_sequence_num, compress_hyper_2_12_chunk._ts_meta_min_1, compress_hyper_2_12_chunk._ts_meta_max_1
+               ->  Partial HashAggregate
+                     Output: _hyper_1_3_chunk.segment_by_value, PARTIAL sum(_hyper_1_3_chunk.segment_by_value)
+                     Group Key: _hyper_1_3_chunk.segment_by_value
+                     ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_3_chunk
+                           Output: _hyper_1_3_chunk.segment_by_value
+                           ->  Parallel Seq Scan on _timescaledb_internal.compress_hyper_2_13_chunk
+                                 Output: compress_hyper_2_13_chunk."time", compress_hyper_2_13_chunk.segment_by_value, compress_hyper_2_13_chunk.int_value, compress_hyper_2_13_chunk.float_value, compress_hyper_2_13_chunk._ts_meta_count, compress_hyper_2_13_chunk._ts_meta_sequence_num, compress_hyper_2_13_chunk._ts_meta_min_1, compress_hyper_2_13_chunk._ts_meta_max_1
+               ->  Partial HashAggregate
+                     Output: _hyper_1_4_chunk.segment_by_value, PARTIAL sum(_hyper_1_4_chunk.segment_by_value)
+                     Group Key: _hyper_1_4_chunk.segment_by_value
+                     ->  Parallel Seq Scan on _timescaledb_internal._hyper_1_4_chunk
+                           Output: _hyper_1_4_chunk.segment_by_value
+               ->  Partial HashAggregate
+                     Output: _hyper_1_5_chunk.segment_by_value, PARTIAL sum(_hyper_1_5_chunk.segment_by_value)
+                     Group Key: _hyper_1_5_chunk.segment_by_value
+                     ->  Parallel Seq Scan on _timescaledb_internal._hyper_1_5_chunk
+                           Output: _hyper_1_5_chunk.segment_by_value
+               ->  Partial HashAggregate
+                     Output: _hyper_1_6_chunk.segment_by_value, PARTIAL sum(_hyper_1_6_chunk.segment_by_value)
+                     Group Key: _hyper_1_6_chunk.segment_by_value
+                     ->  Parallel Seq Scan on _timescaledb_internal._hyper_1_6_chunk
+                           Output: _hyper_1_6_chunk.segment_by_value
+               ->  Partial HashAggregate
+                     Output: _hyper_1_7_chunk.segment_by_value, PARTIAL sum(_hyper_1_7_chunk.segment_by_value)
+                     Group Key: _hyper_1_7_chunk.segment_by_value
+                     ->  Parallel Seq Scan on _timescaledb_internal._hyper_1_7_chunk
+                           Output: _hyper_1_7_chunk.segment_by_value
+               ->  Partial HashAggregate
+                     Output: _hyper_1_8_chunk.segment_by_value, PARTIAL sum(_hyper_1_8_chunk.segment_by_value)
+                     Group Key: _hyper_1_8_chunk.segment_by_value
+                     ->  Parallel Seq Scan on _timescaledb_internal._hyper_1_8_chunk
+                           Output: _hyper_1_8_chunk.segment_by_value
+               ->  Partial HashAggregate
+                     Output: _hyper_1_9_chunk.segment_by_value, PARTIAL sum(_hyper_1_9_chunk.segment_by_value)
+                     Group Key: _hyper_1_9_chunk.segment_by_value
+                     ->  Parallel Seq Scan on _timescaledb_internal._hyper_1_9_chunk
+                           Output: _hyper_1_9_chunk.segment_by_value
+               ->  Partial HashAggregate
+                     Output: _hyper_1_10_chunk.segment_by_value, PARTIAL sum(_hyper_1_10_chunk.segment_by_value)
+                     Group Key: _hyper_1_10_chunk.segment_by_value
+                     ->  Parallel Seq Scan on _timescaledb_internal._hyper_1_10_chunk
+                           Output: _hyper_1_10_chunk.segment_by_value
+(63 rows)
+
+:EXPLAIN
+SELECT segment_by_value, sum(segment_by_value) FROM testtable GROUP BY segment_by_value;
+                                                                                                                                                                                   QUERY PLAN                                                                                                                                                                                    
+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Finalize HashAggregate
+   Output: _hyper_1_1_chunk.segment_by_value, sum(_hyper_1_1_chunk.segment_by_value)
+   Group Key: _hyper_1_1_chunk.segment_by_value
+   ->  Gather
+         Output: _hyper_1_1_chunk.segment_by_value, (PARTIAL sum(_hyper_1_1_chunk.segment_by_value))
+         Workers Planned: 2
+         ->  Parallel Append
+               ->  Partial HashAggregate
+                     Output: _hyper_1_1_chunk.segment_by_value, PARTIAL sum(_hyper_1_1_chunk.segment_by_value)
+                     Group Key: _hyper_1_1_chunk.segment_by_value
+                     ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_1_chunk
+                           Output: _hyper_1_1_chunk.segment_by_value
+                           ->  Parallel Seq Scan on _timescaledb_internal.compress_hyper_2_11_chunk
+                                 Output: compress_hyper_2_11_chunk."time", compress_hyper_2_11_chunk.segment_by_value, compress_hyper_2_11_chunk.int_value, compress_hyper_2_11_chunk.float_value, compress_hyper_2_11_chunk._ts_meta_count, compress_hyper_2_11_chunk._ts_meta_sequence_num, compress_hyper_2_11_chunk._ts_meta_min_1, compress_hyper_2_11_chunk._ts_meta_max_1
+               ->  Partial HashAggregate
+                     Output: _hyper_1_2_chunk.segment_by_value, PARTIAL sum(_hyper_1_2_chunk.segment_by_value)
+                     Group Key: _hyper_1_2_chunk.segment_by_value
+                     ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_2_chunk
+                           Output: _hyper_1_2_chunk.segment_by_value
+                           ->  Parallel Seq Scan on _timescaledb_internal.compress_hyper_2_12_chunk
+                                 Output: compress_hyper_2_12_chunk."time", compress_hyper_2_12_chunk.segment_by_value, compress_hyper_2_12_chunk.int_value, compress_hyper_2_12_chunk.float_value, compress_hyper_2_12_chunk._ts_meta_count, compress_hyper_2_12_chunk._ts_meta_sequence_num, compress_hyper_2_12_chunk._ts_meta_min_1, compress_hyper_2_12_chunk._ts_meta_max_1
+               ->  Partial HashAggregate
+                     Output: _hyper_1_3_chunk.segment_by_value, PARTIAL sum(_hyper_1_3_chunk.segment_by_value)
+                     Group Key: _hyper_1_3_chunk.segment_by_value
+                     ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_3_chunk
+                           Output: _hyper_1_3_chunk.segment_by_value
+                           ->  Parallel Seq Scan on _timescaledb_internal.compress_hyper_2_13_chunk
+                                 Output: compress_hyper_2_13_chunk."time", compress_hyper_2_13_chunk.segment_by_value, compress_hyper_2_13_chunk.int_value, compress_hyper_2_13_chunk.float_value, compress_hyper_2_13_chunk._ts_meta_count, compress_hyper_2_13_chunk._ts_meta_sequence_num, compress_hyper_2_13_chunk._ts_meta_min_1, compress_hyper_2_13_chunk._ts_meta_max_1
+               ->  Partial HashAggregate
+                     Output: _hyper_1_4_chunk.segment_by_value, PARTIAL sum(_hyper_1_4_chunk.segment_by_value)
+                     Group Key: _hyper_1_4_chunk.segment_by_value
+                     ->  Parallel Seq Scan on _timescaledb_internal._hyper_1_4_chunk
+                           Output: _hyper_1_4_chunk.segment_by_value
+               ->  Partial HashAggregate
+                     Output: _hyper_1_5_chunk.segment_by_value, PARTIAL sum(_hyper_1_5_chunk.segment_by_value)
+                     Group Key: _hyper_1_5_chunk.segment_by_value
+                     ->  Parallel Seq Scan on _timescaledb_internal._hyper_1_5_chunk
+                           Output: _hyper_1_5_chunk.segment_by_value
+               ->  Partial HashAggregate
+                     Output: _hyper_1_6_chunk.segment_by_value, PARTIAL sum(_hyper_1_6_chunk.segment_by_value)
+                     Group Key: _hyper_1_6_chunk.segment_by_value
+                     ->  Parallel Seq Scan on _timescaledb_internal._hyper_1_6_chunk
+                           Output: _hyper_1_6_chunk.segment_by_value
+               ->  Partial HashAggregate
+                     Output: _hyper_1_7_chunk.segment_by_value, PARTIAL sum(_hyper_1_7_chunk.segment_by_value)
+                     Group Key: _hyper_1_7_chunk.segment_by_value
+                     ->  Parallel Seq Scan on _timescaledb_internal._hyper_1_7_chunk
+                           Output: _hyper_1_7_chunk.segment_by_value
+               ->  Partial HashAggregate
+                     Output: _hyper_1_8_chunk.segment_by_value, PARTIAL sum(_hyper_1_8_chunk.segment_by_value)
+                     Group Key: _hyper_1_8_chunk.segment_by_value
+                     ->  Parallel Seq Scan on _timescaledb_internal._hyper_1_8_chunk
+                           Output: _hyper_1_8_chunk.segment_by_value
+               ->  Partial HashAggregate
+                     Output: _hyper_1_9_chunk.segment_by_value, PARTIAL sum(_hyper_1_9_chunk.segment_by_value)
+                     Group Key: _hyper_1_9_chunk.segment_by_value
+                     ->  Parallel Seq Scan on _timescaledb_internal._hyper_1_9_chunk
+                           Output: _hyper_1_9_chunk.segment_by_value
+               ->  Partial HashAggregate
+                     Output: _hyper_1_10_chunk.segment_by_value, PARTIAL sum(_hyper_1_10_chunk.segment_by_value)
+                     Group Key: _hyper_1_10_chunk.segment_by_value
+                     ->  Parallel Seq Scan on _timescaledb_internal._hyper_1_10_chunk
+                           Output: _hyper_1_10_chunk.segment_by_value
+(63 rows)
+
+-- Vectorized aggregation possible
+SELECT sum(int_value) FROM testtable;
+  sum   
+--------
+ 304695
+(1 row)
+
+:EXPLAIN
+SELECT sum(int_value) FROM testtable;
+                                                                                                                                                                             QUERY PLAN                                                                                                                                                                              
+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Finalize Aggregate
+   Output: sum(_hyper_1_1_chunk.int_value)
+   ->  Append
+         ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_1_chunk
+               Output: (PARTIAL sum(_hyper_1_1_chunk.int_value))
+               Vectorized Aggregation: true
+               ->  Seq Scan on _timescaledb_internal.compress_hyper_2_11_chunk
+                     Output: compress_hyper_2_11_chunk."time", compress_hyper_2_11_chunk.segment_by_value, compress_hyper_2_11_chunk.int_value, compress_hyper_2_11_chunk.float_value, compress_hyper_2_11_chunk._ts_meta_count, compress_hyper_2_11_chunk._ts_meta_sequence_num, compress_hyper_2_11_chunk._ts_meta_min_1, compress_hyper_2_11_chunk._ts_meta_max_1
+         ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_2_chunk
+               Output: (PARTIAL sum(_hyper_1_2_chunk.int_value))
+               Vectorized Aggregation: true
+               ->  Seq Scan on _timescaledb_internal.compress_hyper_2_12_chunk
+                     Output: compress_hyper_2_12_chunk."time", compress_hyper_2_12_chunk.segment_by_value, compress_hyper_2_12_chunk.int_value, compress_hyper_2_12_chunk.float_value, compress_hyper_2_12_chunk._ts_meta_count, compress_hyper_2_12_chunk._ts_meta_sequence_num, compress_hyper_2_12_chunk._ts_meta_min_1, compress_hyper_2_12_chunk._ts_meta_max_1
+         ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_3_chunk
+               Output: (PARTIAL sum(_hyper_1_3_chunk.int_value))
+               Vectorized Aggregation: true
+               ->  Seq Scan on _timescaledb_internal.compress_hyper_2_13_chunk
+                     Output: compress_hyper_2_13_chunk."time", compress_hyper_2_13_chunk.segment_by_value, compress_hyper_2_13_chunk.int_value, compress_hyper_2_13_chunk.float_value, compress_hyper_2_13_chunk._ts_meta_count, compress_hyper_2_13_chunk._ts_meta_sequence_num, compress_hyper_2_13_chunk._ts_meta_min_1, compress_hyper_2_13_chunk._ts_meta_max_1
+         ->  Partial Aggregate
+               Output: PARTIAL sum(_hyper_1_4_chunk.int_value)
+               ->  Seq Scan on _timescaledb_internal._hyper_1_4_chunk
+                     Output: _hyper_1_4_chunk.int_value
+         ->  Partial Aggregate
+               Output: PARTIAL sum(_hyper_1_5_chunk.int_value)
+               ->  Seq Scan on _timescaledb_internal._hyper_1_5_chunk
+                     Output: _hyper_1_5_chunk.int_value
+         ->  Partial Aggregate
+               Output: PARTIAL sum(_hyper_1_6_chunk.int_value)
+               ->  Seq Scan on _timescaledb_internal._hyper_1_6_chunk
+                     Output: _hyper_1_6_chunk.int_value
+         ->  Partial Aggregate
+               Output: PARTIAL sum(_hyper_1_7_chunk.int_value)
+               ->  Seq Scan on _timescaledb_internal._hyper_1_7_chunk
+                     Output: _hyper_1_7_chunk.int_value
+         ->  Partial Aggregate
+               Output: PARTIAL sum(_hyper_1_8_chunk.int_value)
+               ->  Seq Scan on _timescaledb_internal._hyper_1_8_chunk
+                     Output: _hyper_1_8_chunk.int_value
+         ->  Partial Aggregate
+               Output: PARTIAL sum(_hyper_1_9_chunk.int_value)
+               ->  Seq Scan on _timescaledb_internal._hyper_1_9_chunk
+                     Output: _hyper_1_9_chunk.int_value
+         ->  Partial Aggregate
+               Output: PARTIAL sum(_hyper_1_10_chunk.int_value)
+               ->  Seq Scan on _timescaledb_internal._hyper_1_10_chunk
+                     Output: _hyper_1_10_chunk.int_value
+(46 rows)
+
+-- Vectorized aggregation not possible
+SELECT sum(float_value) FROM testtable;
+  sum   
+--------
+ 304695
+(1 row)
+
+:EXPLAIN
+SELECT sum(float_value) FROM testtable;
+                                                                                                                                                                                   QUERY PLAN                                                                                                                                                                                    
+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Finalize Aggregate
+   Output: sum(_hyper_1_1_chunk.float_value)
+   ->  Gather
+         Output: (PARTIAL sum(_hyper_1_1_chunk.float_value))
+         Workers Planned: 2
+         ->  Parallel Append
+               ->  Partial Aggregate
+                     Output: PARTIAL sum(_hyper_1_1_chunk.float_value)
+                     ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_1_chunk
+                           Output: _hyper_1_1_chunk.float_value
+                           ->  Parallel Seq Scan on _timescaledb_internal.compress_hyper_2_11_chunk
+                                 Output: compress_hyper_2_11_chunk."time", compress_hyper_2_11_chunk.segment_by_value, compress_hyper_2_11_chunk.int_value, compress_hyper_2_11_chunk.float_value, compress_hyper_2_11_chunk._ts_meta_count, compress_hyper_2_11_chunk._ts_meta_sequence_num, compress_hyper_2_11_chunk._ts_meta_min_1, compress_hyper_2_11_chunk._ts_meta_max_1
+               ->  Partial Aggregate
+                     Output: PARTIAL sum(_hyper_1_2_chunk.float_value)
+                     ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_2_chunk
+                           Output: _hyper_1_2_chunk.float_value
+                           ->  Parallel Seq Scan on _timescaledb_internal.compress_hyper_2_12_chunk
+                                 Output: compress_hyper_2_12_chunk."time", compress_hyper_2_12_chunk.segment_by_value, compress_hyper_2_12_chunk.int_value, compress_hyper_2_12_chunk.float_value, compress_hyper_2_12_chunk._ts_meta_count, compress_hyper_2_12_chunk._ts_meta_sequence_num, compress_hyper_2_12_chunk._ts_meta_min_1, compress_hyper_2_12_chunk._ts_meta_max_1
+               ->  Partial Aggregate
+                     Output: PARTIAL sum(_hyper_1_3_chunk.float_value)
+                     ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_3_chunk
+                           Output: _hyper_1_3_chunk.float_value
+                           ->  Parallel Seq Scan on _timescaledb_internal.compress_hyper_2_13_chunk
+                                 Output: compress_hyper_2_13_chunk."time", compress_hyper_2_13_chunk.segment_by_value, compress_hyper_2_13_chunk.int_value, compress_hyper_2_13_chunk.float_value, compress_hyper_2_13_chunk._ts_meta_count, compress_hyper_2_13_chunk._ts_meta_sequence_num, compress_hyper_2_13_chunk._ts_meta_min_1, compress_hyper_2_13_chunk._ts_meta_max_1
+               ->  Partial Aggregate
+                     Output: PARTIAL sum(_hyper_1_4_chunk.float_value)
+                     ->  Parallel Seq Scan on _timescaledb_internal._hyper_1_4_chunk
+                           Output: _hyper_1_4_chunk.float_value
+               ->  Partial Aggregate
+                     Output: PARTIAL sum(_hyper_1_5_chunk.float_value)
+                     ->  Parallel Seq Scan on _timescaledb_internal._hyper_1_5_chunk
+                           Output: _hyper_1_5_chunk.float_value
+               ->  Partial Aggregate
+                     Output: PARTIAL sum(_hyper_1_6_chunk.float_value)
+                     ->  Parallel Seq Scan on _timescaledb_internal._hyper_1_6_chunk
+                           Output: _hyper_1_6_chunk.float_value
+               ->  Partial Aggregate
+                     Output: PARTIAL sum(_hyper_1_7_chunk.float_value)
+                     ->  Parallel Seq Scan on _timescaledb_internal._hyper_1_7_chunk
+                           Output: _hyper_1_7_chunk.float_value
+               ->  Partial Aggregate
+                     Output: PARTIAL sum(_hyper_1_8_chunk.float_value)
+                     ->  Parallel Seq Scan on _timescaledb_internal._hyper_1_8_chunk
+                           Output: _hyper_1_8_chunk.float_value
+               ->  Partial Aggregate
+                     Output: PARTIAL sum(_hyper_1_9_chunk.float_value)
+                     ->  Parallel Seq Scan on _timescaledb_internal._hyper_1_9_chunk
+                           Output: _hyper_1_9_chunk.float_value
+               ->  Partial Aggregate
+                     Output: PARTIAL sum(_hyper_1_10_chunk.float_value)
+                     ->  Parallel Seq Scan on _timescaledb_internal._hyper_1_10_chunk
+                           Output: _hyper_1_10_chunk.float_value
+(52 rows)
+
+---
+-- Tests with all chunks compressed
+---
+SELECT compress_chunk(ch, if_not_compressed => true) FROM show_chunks('testtable') ch;
+NOTICE:  chunk "_hyper_1_1_chunk" is already compressed
+NOTICE:  chunk "_hyper_1_2_chunk" is already compressed
+NOTICE:  chunk "_hyper_1_3_chunk" is already compressed
+             compress_chunk              
+-----------------------------------------
+ _timescaledb_internal._hyper_1_1_chunk
+ _timescaledb_internal._hyper_1_2_chunk
+ _timescaledb_internal._hyper_1_3_chunk
+ _timescaledb_internal._hyper_1_4_chunk
+ _timescaledb_internal._hyper_1_5_chunk
+ _timescaledb_internal._hyper_1_6_chunk
+ _timescaledb_internal._hyper_1_7_chunk
+ _timescaledb_internal._hyper_1_8_chunk
+ _timescaledb_internal._hyper_1_9_chunk
+ _timescaledb_internal._hyper_1_10_chunk
+(10 rows)
+
+-- Vectorized aggregation possible
+SELECT sum(segment_by_value) FROM testtable;
+  sum   
+--------
+ 304695
+(1 row)
+
+:EXPLAIN
+SELECT sum(segment_by_value) FROM testtable;
+                                                                                                                                                                             QUERY PLAN                                                                                                                                                                              
+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Finalize Aggregate
+   Output: sum(_hyper_1_1_chunk.segment_by_value)
+   ->  Append
+         ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_1_chunk
+               Output: (PARTIAL sum(_hyper_1_1_chunk.segment_by_value))
+               Vectorized Aggregation: true
+               ->  Seq Scan on _timescaledb_internal.compress_hyper_2_11_chunk
+                     Output: compress_hyper_2_11_chunk."time", compress_hyper_2_11_chunk.segment_by_value, compress_hyper_2_11_chunk.int_value, compress_hyper_2_11_chunk.float_value, compress_hyper_2_11_chunk._ts_meta_count, compress_hyper_2_11_chunk._ts_meta_sequence_num, compress_hyper_2_11_chunk._ts_meta_min_1, compress_hyper_2_11_chunk._ts_meta_max_1
+         ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_2_chunk
+               Output: (PARTIAL sum(_hyper_1_2_chunk.segment_by_value))
+               Vectorized Aggregation: true
+               ->  Seq Scan on _timescaledb_internal.compress_hyper_2_12_chunk
+                     Output: compress_hyper_2_12_chunk."time", compress_hyper_2_12_chunk.segment_by_value, compress_hyper_2_12_chunk.int_value, compress_hyper_2_12_chunk.float_value, compress_hyper_2_12_chunk._ts_meta_count, compress_hyper_2_12_chunk._ts_meta_sequence_num, compress_hyper_2_12_chunk._ts_meta_min_1, compress_hyper_2_12_chunk._ts_meta_max_1
+         ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_3_chunk
+               Output: (PARTIAL sum(_hyper_1_3_chunk.segment_by_value))
+               Vectorized Aggregation: true
+               ->  Seq Scan on _timescaledb_internal.compress_hyper_2_13_chunk
+                     Output: compress_hyper_2_13_chunk."time", compress_hyper_2_13_chunk.segment_by_value, compress_hyper_2_13_chunk.int_value, compress_hyper_2_13_chunk.float_value, compress_hyper_2_13_chunk._ts_meta_count, compress_hyper_2_13_chunk._ts_meta_sequence_num, compress_hyper_2_13_chunk._ts_meta_min_1, compress_hyper_2_13_chunk._ts_meta_max_1
+         ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_4_chunk
+               Output: (PARTIAL sum(_hyper_1_4_chunk.segment_by_value))
+               Vectorized Aggregation: true
+               ->  Seq Scan on _timescaledb_internal.compress_hyper_2_14_chunk
+                     Output: compress_hyper_2_14_chunk."time", compress_hyper_2_14_chunk.segment_by_value, compress_hyper_2_14_chunk.int_value, compress_hyper_2_14_chunk.float_value, compress_hyper_2_14_chunk._ts_meta_count, compress_hyper_2_14_chunk._ts_meta_sequence_num, compress_hyper_2_14_chunk._ts_meta_min_1, compress_hyper_2_14_chunk._ts_meta_max_1
+         ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_5_chunk
+               Output: (PARTIAL sum(_hyper_1_5_chunk.segment_by_value))
+               Vectorized Aggregation: true
+               ->  Seq Scan on _timescaledb_internal.compress_hyper_2_15_chunk
+                     Output: compress_hyper_2_15_chunk."time", compress_hyper_2_15_chunk.segment_by_value, compress_hyper_2_15_chunk.int_value, compress_hyper_2_15_chunk.float_value, compress_hyper_2_15_chunk._ts_meta_count, compress_hyper_2_15_chunk._ts_meta_sequence_num, compress_hyper_2_15_chunk._ts_meta_min_1, compress_hyper_2_15_chunk._ts_meta_max_1
+         ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_6_chunk
+               Output: (PARTIAL sum(_hyper_1_6_chunk.segment_by_value))
+               Vectorized Aggregation: true
+               ->  Seq Scan on _timescaledb_internal.compress_hyper_2_16_chunk
+                     Output: compress_hyper_2_16_chunk."time", compress_hyper_2_16_chunk.segment_by_value, compress_hyper_2_16_chunk.int_value, compress_hyper_2_16_chunk.float_value, compress_hyper_2_16_chunk._ts_meta_count, compress_hyper_2_16_chunk._ts_meta_sequence_num, compress_hyper_2_16_chunk._ts_meta_min_1, compress_hyper_2_16_chunk._ts_meta_max_1
+         ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_7_chunk
+               Output: (PARTIAL sum(_hyper_1_7_chunk.segment_by_value))
+               Vectorized Aggregation: true
+               ->  Seq Scan on _timescaledb_internal.compress_hyper_2_17_chunk
+                     Output: compress_hyper_2_17_chunk."time", compress_hyper_2_17_chunk.segment_by_value, compress_hyper_2_17_chunk.int_value, compress_hyper_2_17_chunk.float_value, compress_hyper_2_17_chunk._ts_meta_count, compress_hyper_2_17_chunk._ts_meta_sequence_num, compress_hyper_2_17_chunk._ts_meta_min_1, compress_hyper_2_17_chunk._ts_meta_max_1
+         ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_8_chunk
+               Output: (PARTIAL sum(_hyper_1_8_chunk.segment_by_value))
+               Vectorized Aggregation: true
+               ->  Seq Scan on _timescaledb_internal.compress_hyper_2_18_chunk
+                     Output: compress_hyper_2_18_chunk."time", compress_hyper_2_18_chunk.segment_by_value, compress_hyper_2_18_chunk.int_value, compress_hyper_2_18_chunk.float_value, compress_hyper_2_18_chunk._ts_meta_count, compress_hyper_2_18_chunk._ts_meta_sequence_num, compress_hyper_2_18_chunk._ts_meta_min_1, compress_hyper_2_18_chunk._ts_meta_max_1
+         ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_9_chunk
+               Output: (PARTIAL sum(_hyper_1_9_chunk.segment_by_value))
+               Vectorized Aggregation: true
+               ->  Seq Scan on _timescaledb_internal.compress_hyper_2_19_chunk
+                     Output: compress_hyper_2_19_chunk."time", compress_hyper_2_19_chunk.segment_by_value, compress_hyper_2_19_chunk.int_value, compress_hyper_2_19_chunk.float_value, compress_hyper_2_19_chunk._ts_meta_count, compress_hyper_2_19_chunk._ts_meta_sequence_num, compress_hyper_2_19_chunk._ts_meta_min_1, compress_hyper_2_19_chunk._ts_meta_max_1
+         ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_10_chunk
+               Output: (PARTIAL sum(_hyper_1_10_chunk.segment_by_value))
+               Vectorized Aggregation: true
+               ->  Seq Scan on _timescaledb_internal.compress_hyper_2_20_chunk
+                     Output: compress_hyper_2_20_chunk."time", compress_hyper_2_20_chunk.segment_by_value, compress_hyper_2_20_chunk.int_value, compress_hyper_2_20_chunk.float_value, compress_hyper_2_20_chunk._ts_meta_count, compress_hyper_2_20_chunk._ts_meta_sequence_num, compress_hyper_2_20_chunk._ts_meta_min_1, compress_hyper_2_20_chunk._ts_meta_max_1
+(53 rows)
+
+-- Vectorized aggregation possible
+SELECT sum(int_value) FROM testtable;
+  sum   
+--------
+ 304695
+(1 row)
+
+:EXPLAIN
+SELECT sum(int_value) FROM testtable;
+                                                                                                                                                                             QUERY PLAN                                                                                                                                                                              
+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Finalize Aggregate
+   Output: sum(_hyper_1_1_chunk.int_value)
+   ->  Append
+         ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_1_chunk
+               Output: (PARTIAL sum(_hyper_1_1_chunk.int_value))
+               Vectorized Aggregation: true
+               ->  Seq Scan on _timescaledb_internal.compress_hyper_2_11_chunk
+                     Output: compress_hyper_2_11_chunk."time", compress_hyper_2_11_chunk.segment_by_value, compress_hyper_2_11_chunk.int_value, compress_hyper_2_11_chunk.float_value, compress_hyper_2_11_chunk._ts_meta_count, compress_hyper_2_11_chunk._ts_meta_sequence_num, compress_hyper_2_11_chunk._ts_meta_min_1, compress_hyper_2_11_chunk._ts_meta_max_1
+         ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_2_chunk
+               Output: (PARTIAL sum(_hyper_1_2_chunk.int_value))
+               Vectorized Aggregation: true
+               ->  Seq Scan on _timescaledb_internal.compress_hyper_2_12_chunk
+                     Output: compress_hyper_2_12_chunk."time", compress_hyper_2_12_chunk.segment_by_value, compress_hyper_2_12_chunk.int_value, compress_hyper_2_12_chunk.float_value, compress_hyper_2_12_chunk._ts_meta_count, compress_hyper_2_12_chunk._ts_meta_sequence_num, compress_hyper_2_12_chunk._ts_meta_min_1, compress_hyper_2_12_chunk._ts_meta_max_1
+         ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_3_chunk
+               Output: (PARTIAL sum(_hyper_1_3_chunk.int_value))
+               Vectorized Aggregation: true
+               ->  Seq Scan on _timescaledb_internal.compress_hyper_2_13_chunk
+                     Output: compress_hyper_2_13_chunk."time", compress_hyper_2_13_chunk.segment_by_value, compress_hyper_2_13_chunk.int_value, compress_hyper_2_13_chunk.float_value, compress_hyper_2_13_chunk._ts_meta_count, compress_hyper_2_13_chunk._ts_meta_sequence_num, compress_hyper_2_13_chunk._ts_meta_min_1, compress_hyper_2_13_chunk._ts_meta_max_1
+         ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_4_chunk
+               Output: (PARTIAL sum(_hyper_1_4_chunk.int_value))
+               Vectorized Aggregation: true
+               ->  Seq Scan on _timescaledb_internal.compress_hyper_2_14_chunk
+                     Output: compress_hyper_2_14_chunk."time", compress_hyper_2_14_chunk.segment_by_value, compress_hyper_2_14_chunk.int_value, compress_hyper_2_14_chunk.float_value, compress_hyper_2_14_chunk._ts_meta_count, compress_hyper_2_14_chunk._ts_meta_sequence_num, compress_hyper_2_14_chunk._ts_meta_min_1, compress_hyper_2_14_chunk._ts_meta_max_1
+         ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_5_chunk
+               Output: (PARTIAL sum(_hyper_1_5_chunk.int_value))
+               Vectorized Aggregation: true
+               ->  Seq Scan on _timescaledb_internal.compress_hyper_2_15_chunk
+                     Output: compress_hyper_2_15_chunk."time", compress_hyper_2_15_chunk.segment_by_value, compress_hyper_2_15_chunk.int_value, compress_hyper_2_15_chunk.float_value, compress_hyper_2_15_chunk._ts_meta_count, compress_hyper_2_15_chunk._ts_meta_sequence_num, compress_hyper_2_15_chunk._ts_meta_min_1, compress_hyper_2_15_chunk._ts_meta_max_1
+         ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_6_chunk
+               Output: (PARTIAL sum(_hyper_1_6_chunk.int_value))
+               Vectorized Aggregation: true
+               ->  Seq Scan on _timescaledb_internal.compress_hyper_2_16_chunk
+                     Output: compress_hyper_2_16_chunk."time", compress_hyper_2_16_chunk.segment_by_value, compress_hyper_2_16_chunk.int_value, compress_hyper_2_16_chunk.float_value, compress_hyper_2_16_chunk._ts_meta_count, compress_hyper_2_16_chunk._ts_meta_sequence_num, compress_hyper_2_16_chunk._ts_meta_min_1, compress_hyper_2_16_chunk._ts_meta_max_1
+         ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_7_chunk
+               Output: (PARTIAL sum(_hyper_1_7_chunk.int_value))
+               Vectorized Aggregation: true
+               ->  Seq Scan on _timescaledb_internal.compress_hyper_2_17_chunk
+                     Output: compress_hyper_2_17_chunk."time", compress_hyper_2_17_chunk.segment_by_value, compress_hyper_2_17_chunk.int_value, compress_hyper_2_17_chunk.float_value, compress_hyper_2_17_chunk._ts_meta_count, compress_hyper_2_17_chunk._ts_meta_sequence_num, compress_hyper_2_17_chunk._ts_meta_min_1, compress_hyper_2_17_chunk._ts_meta_max_1
+         ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_8_chunk
+               Output: (PARTIAL sum(_hyper_1_8_chunk.int_value))
+               Vectorized Aggregation: true
+               ->  Seq Scan on _timescaledb_internal.compress_hyper_2_18_chunk
+                     Output: compress_hyper_2_18_chunk."time", compress_hyper_2_18_chunk.segment_by_value, compress_hyper_2_18_chunk.int_value, compress_hyper_2_18_chunk.float_value, compress_hyper_2_18_chunk._ts_meta_count, compress_hyper_2_18_chunk._ts_meta_sequence_num, compress_hyper_2_18_chunk._ts_meta_min_1, compress_hyper_2_18_chunk._ts_meta_max_1
+         ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_9_chunk
+               Output: (PARTIAL sum(_hyper_1_9_chunk.int_value))
+               Vectorized Aggregation: true
+               ->  Seq Scan on _timescaledb_internal.compress_hyper_2_19_chunk
+                     Output: compress_hyper_2_19_chunk."time", compress_hyper_2_19_chunk.segment_by_value, compress_hyper_2_19_chunk.int_value, compress_hyper_2_19_chunk.float_value, compress_hyper_2_19_chunk._ts_meta_count, compress_hyper_2_19_chunk._ts_meta_sequence_num, compress_hyper_2_19_chunk._ts_meta_min_1, compress_hyper_2_19_chunk._ts_meta_max_1
+         ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_10_chunk
+               Output: (PARTIAL sum(_hyper_1_10_chunk.int_value))
+               Vectorized Aggregation: true
+               ->  Seq Scan on _timescaledb_internal.compress_hyper_2_20_chunk
+                     Output: compress_hyper_2_20_chunk."time", compress_hyper_2_20_chunk.segment_by_value, compress_hyper_2_20_chunk.int_value, compress_hyper_2_20_chunk.float_value, compress_hyper_2_20_chunk._ts_meta_count, compress_hyper_2_20_chunk._ts_meta_sequence_num, compress_hyper_2_20_chunk._ts_meta_min_1, compress_hyper_2_20_chunk._ts_meta_max_1
+(53 rows)
+
+---
+-- Tests with some chunks are partially compressed
+---
+INSERT INTO testtable (time, segment_by_value, int_value, float_value)
+   VALUES ('1980-01-02 01:00:00-00', 0, 0, 0);
+-- Vectorized aggregation possible
+SELECT sum(segment_by_value) FROM testtable;
+  sum   
+--------
+ 304695
+(1 row)
+
+:EXPLAIN
+SELECT sum(segment_by_value) FROM testtable;
+                                                                                                                                                                             QUERY PLAN                                                                                                                                                                              
+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Finalize Aggregate
+   Output: sum(_hyper_1_1_chunk.segment_by_value)
+   ->  Append
+         ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_1_chunk
+               Output: (PARTIAL sum(_hyper_1_1_chunk.segment_by_value))
+               Vectorized Aggregation: true
+               ->  Seq Scan on _timescaledb_internal.compress_hyper_2_11_chunk
+                     Output: compress_hyper_2_11_chunk."time", compress_hyper_2_11_chunk.segment_by_value, compress_hyper_2_11_chunk.int_value, compress_hyper_2_11_chunk.float_value, compress_hyper_2_11_chunk._ts_meta_count, compress_hyper_2_11_chunk._ts_meta_sequence_num, compress_hyper_2_11_chunk._ts_meta_min_1, compress_hyper_2_11_chunk._ts_meta_max_1
+         ->  Partial Aggregate
+               Output: PARTIAL sum(_hyper_1_1_chunk.segment_by_value)
+               ->  Seq Scan on _timescaledb_internal._hyper_1_1_chunk
+                     Output: _hyper_1_1_chunk.segment_by_value
+         ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_2_chunk
+               Output: (PARTIAL sum(_hyper_1_2_chunk.segment_by_value))
+               Vectorized Aggregation: true
+               ->  Seq Scan on _timescaledb_internal.compress_hyper_2_12_chunk
+                     Output: compress_hyper_2_12_chunk."time", compress_hyper_2_12_chunk.segment_by_value, compress_hyper_2_12_chunk.int_value, compress_hyper_2_12_chunk.float_value, compress_hyper_2_12_chunk._ts_meta_count, compress_hyper_2_12_chunk._ts_meta_sequence_num, compress_hyper_2_12_chunk._ts_meta_min_1, compress_hyper_2_12_chunk._ts_meta_max_1
+         ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_3_chunk
+               Output: (PARTIAL sum(_hyper_1_3_chunk.segment_by_value))
+               Vectorized Aggregation: true
+               ->  Seq Scan on _timescaledb_internal.compress_hyper_2_13_chunk
+                     Output: compress_hyper_2_13_chunk."time", compress_hyper_2_13_chunk.segment_by_value, compress_hyper_2_13_chunk.int_value, compress_hyper_2_13_chunk.float_value, compress_hyper_2_13_chunk._ts_meta_count, compress_hyper_2_13_chunk._ts_meta_sequence_num, compress_hyper_2_13_chunk._ts_meta_min_1, compress_hyper_2_13_chunk._ts_meta_max_1
+         ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_4_chunk
+               Output: (PARTIAL sum(_hyper_1_4_chunk.segment_by_value))
+               Vectorized Aggregation: true
+               ->  Seq Scan on _timescaledb_internal.compress_hyper_2_14_chunk
+                     Output: compress_hyper_2_14_chunk."time", compress_hyper_2_14_chunk.segment_by_value, compress_hyper_2_14_chunk.int_value, compress_hyper_2_14_chunk.float_value, compress_hyper_2_14_chunk._ts_meta_count, compress_hyper_2_14_chunk._ts_meta_sequence_num, compress_hyper_2_14_chunk._ts_meta_min_1, compress_hyper_2_14_chunk._ts_meta_max_1
+         ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_5_chunk
+               Output: (PARTIAL sum(_hyper_1_5_chunk.segment_by_value))
+               Vectorized Aggregation: true
+               ->  Seq Scan on _timescaledb_internal.compress_hyper_2_15_chunk
+                     Output: compress_hyper_2_15_chunk."time", compress_hyper_2_15_chunk.segment_by_value, compress_hyper_2_15_chunk.int_value, compress_hyper_2_15_chunk.float_value, compress_hyper_2_15_chunk._ts_meta_count, compress_hyper_2_15_chunk._ts_meta_sequence_num, compress_hyper_2_15_chunk._ts_meta_min_1, compress_hyper_2_15_chunk._ts_meta_max_1
+         ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_6_chunk
+               Output: (PARTIAL sum(_hyper_1_6_chunk.segment_by_value))
+               Vectorized Aggregation: true
+               ->  Seq Scan on _timescaledb_internal.compress_hyper_2_16_chunk
+                     Output: compress_hyper_2_16_chunk."time", compress_hyper_2_16_chunk.segment_by_value, compress_hyper_2_16_chunk.int_value, compress_hyper_2_16_chunk.float_value, compress_hyper_2_16_chunk._ts_meta_count, compress_hyper_2_16_chunk._ts_meta_sequence_num, compress_hyper_2_16_chunk._ts_meta_min_1, compress_hyper_2_16_chunk._ts_meta_max_1
+         ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_7_chunk
+               Output: (PARTIAL sum(_hyper_1_7_chunk.segment_by_value))
+               Vectorized Aggregation: true
+               ->  Seq Scan on _timescaledb_internal.compress_hyper_2_17_chunk
+                     Output: compress_hyper_2_17_chunk."time", compress_hyper_2_17_chunk.segment_by_value, compress_hyper_2_17_chunk.int_value, compress_hyper_2_17_chunk.float_value, compress_hyper_2_17_chunk._ts_meta_count, compress_hyper_2_17_chunk._ts_meta_sequence_num, compress_hyper_2_17_chunk._ts_meta_min_1, compress_hyper_2_17_chunk._ts_meta_max_1
+         ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_8_chunk
+               Output: (PARTIAL sum(_hyper_1_8_chunk.segment_by_value))
+               Vectorized Aggregation: true
+               ->  Seq Scan on _timescaledb_internal.compress_hyper_2_18_chunk
+                     Output: compress_hyper_2_18_chunk."time", compress_hyper_2_18_chunk.segment_by_value, compress_hyper_2_18_chunk.int_value, compress_hyper_2_18_chunk.float_value, compress_hyper_2_18_chunk._ts_meta_count, compress_hyper_2_18_chunk._ts_meta_sequence_num, compress_hyper_2_18_chunk._ts_meta_min_1, compress_hyper_2_18_chunk._ts_meta_max_1
+         ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_9_chunk
+               Output: (PARTIAL sum(_hyper_1_9_chunk.segment_by_value))
+               Vectorized Aggregation: true
+               ->  Seq Scan on _timescaledb_internal.compress_hyper_2_19_chunk
+                     Output: compress_hyper_2_19_chunk."time", compress_hyper_2_19_chunk.segment_by_value, compress_hyper_2_19_chunk.int_value, compress_hyper_2_19_chunk.float_value, compress_hyper_2_19_chunk._ts_meta_count, compress_hyper_2_19_chunk._ts_meta_sequence_num, compress_hyper_2_19_chunk._ts_meta_min_1, compress_hyper_2_19_chunk._ts_meta_max_1
+         ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_10_chunk
+               Output: (PARTIAL sum(_hyper_1_10_chunk.segment_by_value))
+               Vectorized Aggregation: true
+               ->  Seq Scan on _timescaledb_internal.compress_hyper_2_20_chunk
+                     Output: compress_hyper_2_20_chunk."time", compress_hyper_2_20_chunk.segment_by_value, compress_hyper_2_20_chunk.int_value, compress_hyper_2_20_chunk.float_value, compress_hyper_2_20_chunk._ts_meta_count, compress_hyper_2_20_chunk._ts_meta_sequence_num, compress_hyper_2_20_chunk._ts_meta_min_1, compress_hyper_2_20_chunk._ts_meta_max_1
+(57 rows)
+
+-- Vectorized aggregation possible
+SELECT sum(int_value) FROM testtable;
+  sum   
+--------
+ 304695
+(1 row)
+
+:EXPLAIN
+SELECT sum(int_value) FROM testtable;
+                                                                                                                                                                             QUERY PLAN                                                                                                                                                                              
+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Finalize Aggregate
+   Output: sum(_hyper_1_1_chunk.int_value)
+   ->  Append
+         ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_1_chunk
+               Output: (PARTIAL sum(_hyper_1_1_chunk.int_value))
+               Vectorized Aggregation: true
+               ->  Seq Scan on _timescaledb_internal.compress_hyper_2_11_chunk
+                     Output: compress_hyper_2_11_chunk."time", compress_hyper_2_11_chunk.segment_by_value, compress_hyper_2_11_chunk.int_value, compress_hyper_2_11_chunk.float_value, compress_hyper_2_11_chunk._ts_meta_count, compress_hyper_2_11_chunk._ts_meta_sequence_num, compress_hyper_2_11_chunk._ts_meta_min_1, compress_hyper_2_11_chunk._ts_meta_max_1
+         ->  Partial Aggregate
+               Output: PARTIAL sum(_hyper_1_1_chunk.int_value)
+               ->  Seq Scan on _timescaledb_internal._hyper_1_1_chunk
+                     Output: _hyper_1_1_chunk.int_value
+         ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_2_chunk
+               Output: (PARTIAL sum(_hyper_1_2_chunk.int_value))
+               Vectorized Aggregation: true
+               ->  Seq Scan on _timescaledb_internal.compress_hyper_2_12_chunk
+                     Output: compress_hyper_2_12_chunk."time", compress_hyper_2_12_chunk.segment_by_value, compress_hyper_2_12_chunk.int_value, compress_hyper_2_12_chunk.float_value, compress_hyper_2_12_chunk._ts_meta_count, compress_hyper_2_12_chunk._ts_meta_sequence_num, compress_hyper_2_12_chunk._ts_meta_min_1, compress_hyper_2_12_chunk._ts_meta_max_1
+         ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_3_chunk
+               Output: (PARTIAL sum(_hyper_1_3_chunk.int_value))
+               Vectorized Aggregation: true
+               ->  Seq Scan on _timescaledb_internal.compress_hyper_2_13_chunk
+                     Output: compress_hyper_2_13_chunk."time", compress_hyper_2_13_chunk.segment_by_value, compress_hyper_2_13_chunk.int_value, compress_hyper_2_13_chunk.float_value, compress_hyper_2_13_chunk._ts_meta_count, compress_hyper_2_13_chunk._ts_meta_sequence_num, compress_hyper_2_13_chunk._ts_meta_min_1, compress_hyper_2_13_chunk._ts_meta_max_1
+         ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_4_chunk
+               Output: (PARTIAL sum(_hyper_1_4_chunk.int_value))
+               Vectorized Aggregation: true
+               ->  Seq Scan on _timescaledb_internal.compress_hyper_2_14_chunk
+                     Output: compress_hyper_2_14_chunk."time", compress_hyper_2_14_chunk.segment_by_value, compress_hyper_2_14_chunk.int_value, compress_hyper_2_14_chunk.float_value, compress_hyper_2_14_chunk._ts_meta_count, compress_hyper_2_14_chunk._ts_meta_sequence_num, compress_hyper_2_14_chunk._ts_meta_min_1, compress_hyper_2_14_chunk._ts_meta_max_1
+         ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_5_chunk
+               Output: (PARTIAL sum(_hyper_1_5_chunk.int_value))
+               Vectorized Aggregation: true
+               ->  Seq Scan on _timescaledb_internal.compress_hyper_2_15_chunk
+                     Output: compress_hyper_2_15_chunk."time", compress_hyper_2_15_chunk.segment_by_value, compress_hyper_2_15_chunk.int_value, compress_hyper_2_15_chunk.float_value, compress_hyper_2_15_chunk._ts_meta_count, compress_hyper_2_15_chunk._ts_meta_sequence_num, compress_hyper_2_15_chunk._ts_meta_min_1, compress_hyper_2_15_chunk._ts_meta_max_1
+         ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_6_chunk
+               Output: (PARTIAL sum(_hyper_1_6_chunk.int_value))
+               Vectorized Aggregation: true
+               ->  Seq Scan on _timescaledb_internal.compress_hyper_2_16_chunk
+                     Output: compress_hyper_2_16_chunk."time", compress_hyper_2_16_chunk.segment_by_value, compress_hyper_2_16_chunk.int_value, compress_hyper_2_16_chunk.float_value, compress_hyper_2_16_chunk._ts_meta_count, compress_hyper_2_16_chunk._ts_meta_sequence_num, compress_hyper_2_16_chunk._ts_meta_min_1, compress_hyper_2_16_chunk._ts_meta_max_1
+         ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_7_chunk
+               Output: (PARTIAL sum(_hyper_1_7_chunk.int_value))
+               Vectorized Aggregation: true
+               ->  Seq Scan on _timescaledb_internal.compress_hyper_2_17_chunk
+                     Output: compress_hyper_2_17_chunk."time", compress_hyper_2_17_chunk.segment_by_value, compress_hyper_2_17_chunk.int_value, compress_hyper_2_17_chunk.float_value, compress_hyper_2_17_chunk._ts_meta_count, compress_hyper_2_17_chunk._ts_meta_sequence_num, compress_hyper_2_17_chunk._ts_meta_min_1, compress_hyper_2_17_chunk._ts_meta_max_1
+         ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_8_chunk
+               Output: (PARTIAL sum(_hyper_1_8_chunk.int_value))
+               Vectorized Aggregation: true
+               ->  Seq Scan on _timescaledb_internal.compress_hyper_2_18_chunk
+                     Output: compress_hyper_2_18_chunk."time", compress_hyper_2_18_chunk.segment_by_value, compress_hyper_2_18_chunk.int_value, compress_hyper_2_18_chunk.float_value, compress_hyper_2_18_chunk._ts_meta_count, compress_hyper_2_18_chunk._ts_meta_sequence_num, compress_hyper_2_18_chunk._ts_meta_min_1, compress_hyper_2_18_chunk._ts_meta_max_1
+         ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_9_chunk
+               Output: (PARTIAL sum(_hyper_1_9_chunk.int_value))
+               Vectorized Aggregation: true
+               ->  Seq Scan on _timescaledb_internal.compress_hyper_2_19_chunk
+                     Output: compress_hyper_2_19_chunk."time", compress_hyper_2_19_chunk.segment_by_value, compress_hyper_2_19_chunk.int_value, compress_hyper_2_19_chunk.float_value, compress_hyper_2_19_chunk._ts_meta_count, compress_hyper_2_19_chunk._ts_meta_sequence_num, compress_hyper_2_19_chunk._ts_meta_min_1, compress_hyper_2_19_chunk._ts_meta_max_1
+         ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_10_chunk
+               Output: (PARTIAL sum(_hyper_1_10_chunk.int_value))
+               Vectorized Aggregation: true
+               ->  Seq Scan on _timescaledb_internal.compress_hyper_2_20_chunk
+                     Output: compress_hyper_2_20_chunk."time", compress_hyper_2_20_chunk.segment_by_value, compress_hyper_2_20_chunk.int_value, compress_hyper_2_20_chunk.float_value, compress_hyper_2_20_chunk._ts_meta_count, compress_hyper_2_20_chunk._ts_meta_sequence_num, compress_hyper_2_20_chunk._ts_meta_min_1, compress_hyper_2_20_chunk._ts_meta_max_1
+(57 rows)
+
+-- Vectorized aggregation NOT possible
+SET timescaledb.vectorized_aggregation = OFF;
+:EXPLAIN
+SELECT sum(int_value) FROM testtable;
+                                                                                                                                                                                   QUERY PLAN                                                                                                                                                                                    
+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Finalize Aggregate
+   Output: sum(_hyper_1_1_chunk.int_value)
+   ->  Gather
+         Output: (PARTIAL sum(_hyper_1_1_chunk.int_value))
+         Workers Planned: 2
+         ->  Parallel Append
+               ->  Partial Aggregate
+                     Output: PARTIAL sum(_hyper_1_1_chunk.int_value)
+                     ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_1_chunk
+                           Output: _hyper_1_1_chunk.int_value
+                           ->  Parallel Seq Scan on _timescaledb_internal.compress_hyper_2_11_chunk
+                                 Output: compress_hyper_2_11_chunk."time", compress_hyper_2_11_chunk.segment_by_value, compress_hyper_2_11_chunk.int_value, compress_hyper_2_11_chunk.float_value, compress_hyper_2_11_chunk._ts_meta_count, compress_hyper_2_11_chunk._ts_meta_sequence_num, compress_hyper_2_11_chunk._ts_meta_min_1, compress_hyper_2_11_chunk._ts_meta_max_1
+               ->  Partial Aggregate
+                     Output: PARTIAL sum(_hyper_1_2_chunk.int_value)
+                     ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_2_chunk
+                           Output: _hyper_1_2_chunk.int_value
+                           ->  Parallel Seq Scan on _timescaledb_internal.compress_hyper_2_12_chunk
+                                 Output: compress_hyper_2_12_chunk."time", compress_hyper_2_12_chunk.segment_by_value, compress_hyper_2_12_chunk.int_value, compress_hyper_2_12_chunk.float_value, compress_hyper_2_12_chunk._ts_meta_count, compress_hyper_2_12_chunk._ts_meta_sequence_num, compress_hyper_2_12_chunk._ts_meta_min_1, compress_hyper_2_12_chunk._ts_meta_max_1
+               ->  Partial Aggregate
+                     Output: PARTIAL sum(_hyper_1_3_chunk.int_value)
+                     ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_3_chunk
+                           Output: _hyper_1_3_chunk.int_value
+                           ->  Parallel Seq Scan on _timescaledb_internal.compress_hyper_2_13_chunk
+                                 Output: compress_hyper_2_13_chunk."time", compress_hyper_2_13_chunk.segment_by_value, compress_hyper_2_13_chunk.int_value, compress_hyper_2_13_chunk.float_value, compress_hyper_2_13_chunk._ts_meta_count, compress_hyper_2_13_chunk._ts_meta_sequence_num, compress_hyper_2_13_chunk._ts_meta_min_1, compress_hyper_2_13_chunk._ts_meta_max_1
+               ->  Partial Aggregate
+                     Output: PARTIAL sum(_hyper_1_4_chunk.int_value)
+                     ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_4_chunk
+                           Output: _hyper_1_4_chunk.int_value
+                           ->  Parallel Seq Scan on _timescaledb_internal.compress_hyper_2_14_chunk
+                                 Output: compress_hyper_2_14_chunk."time", compress_hyper_2_14_chunk.segment_by_value, compress_hyper_2_14_chunk.int_value, compress_hyper_2_14_chunk.float_value, compress_hyper_2_14_chunk._ts_meta_count, compress_hyper_2_14_chunk._ts_meta_sequence_num, compress_hyper_2_14_chunk._ts_meta_min_1, compress_hyper_2_14_chunk._ts_meta_max_1
+               ->  Partial Aggregate
+                     Output: PARTIAL sum(_hyper_1_5_chunk.int_value)
+                     ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_5_chunk
+                           Output: _hyper_1_5_chunk.int_value
+                           ->  Parallel Seq Scan on _timescaledb_internal.compress_hyper_2_15_chunk
+                                 Output: compress_hyper_2_15_chunk."time", compress_hyper_2_15_chunk.segment_by_value, compress_hyper_2_15_chunk.int_value, compress_hyper_2_15_chunk.float_value, compress_hyper_2_15_chunk._ts_meta_count, compress_hyper_2_15_chunk._ts_meta_sequence_num, compress_hyper_2_15_chunk._ts_meta_min_1, compress_hyper_2_15_chunk._ts_meta_max_1
+               ->  Partial Aggregate
+                     Output: PARTIAL sum(_hyper_1_6_chunk.int_value)
+                     ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_6_chunk
+                           Output: _hyper_1_6_chunk.int_value
+                           ->  Parallel Seq Scan on _timescaledb_internal.compress_hyper_2_16_chunk
+                                 Output: compress_hyper_2_16_chunk."time", compress_hyper_2_16_chunk.segment_by_value, compress_hyper_2_16_chunk.int_value, compress_hyper_2_16_chunk.float_value, compress_hyper_2_16_chunk._ts_meta_count, compress_hyper_2_16_chunk._ts_meta_sequence_num, compress_hyper_2_16_chunk._ts_meta_min_1, compress_hyper_2_16_chunk._ts_meta_max_1
+               ->  Partial Aggregate
+                     Output: PARTIAL sum(_hyper_1_7_chunk.int_value)
+                     ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_7_chunk
+                           Output: _hyper_1_7_chunk.int_value
+                           ->  Parallel Seq Scan on _timescaledb_internal.compress_hyper_2_17_chunk
+                                 Output: compress_hyper_2_17_chunk."time", compress_hyper_2_17_chunk.segment_by_value, compress_hyper_2_17_chunk.int_value, compress_hyper_2_17_chunk.float_value, compress_hyper_2_17_chunk._ts_meta_count, compress_hyper_2_17_chunk._ts_meta_sequence_num, compress_hyper_2_17_chunk._ts_meta_min_1, compress_hyper_2_17_chunk._ts_meta_max_1
+               ->  Partial Aggregate
+                     Output: PARTIAL sum(_hyper_1_8_chunk.int_value)
+                     ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_8_chunk
+                           Output: _hyper_1_8_chunk.int_value
+                           ->  Parallel Seq Scan on _timescaledb_internal.compress_hyper_2_18_chunk
+                                 Output: compress_hyper_2_18_chunk."time", compress_hyper_2_18_chunk.segment_by_value, compress_hyper_2_18_chunk.int_value, compress_hyper_2_18_chunk.float_value, compress_hyper_2_18_chunk._ts_meta_count, compress_hyper_2_18_chunk._ts_meta_sequence_num, compress_hyper_2_18_chunk._ts_meta_min_1, compress_hyper_2_18_chunk._ts_meta_max_1
+               ->  Partial Aggregate
+                     Output: PARTIAL sum(_hyper_1_9_chunk.int_value)
+                     ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_9_chunk
+                           Output: _hyper_1_9_chunk.int_value
+                           ->  Parallel Seq Scan on _timescaledb_internal.compress_hyper_2_19_chunk
+                                 Output: compress_hyper_2_19_chunk."time", compress_hyper_2_19_chunk.segment_by_value, compress_hyper_2_19_chunk.int_value, compress_hyper_2_19_chunk.float_value, compress_hyper_2_19_chunk._ts_meta_count, compress_hyper_2_19_chunk._ts_meta_sequence_num, compress_hyper_2_19_chunk._ts_meta_min_1, compress_hyper_2_19_chunk._ts_meta_max_1
+               ->  Partial Aggregate
+                     Output: PARTIAL sum(_hyper_1_10_chunk.int_value)
+                     ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_10_chunk
+                           Output: _hyper_1_10_chunk.int_value
+                           ->  Parallel Seq Scan on _timescaledb_internal.compress_hyper_2_20_chunk
+                                 Output: compress_hyper_2_20_chunk."time", compress_hyper_2_20_chunk.segment_by_value, compress_hyper_2_20_chunk.int_value, compress_hyper_2_20_chunk.float_value, compress_hyper_2_20_chunk._ts_meta_count, compress_hyper_2_20_chunk._ts_meta_sequence_num, compress_hyper_2_20_chunk._ts_meta_min_1, compress_hyper_2_20_chunk._ts_meta_max_1
+               ->  Partial Aggregate
+                     Output: PARTIAL sum(_hyper_1_1_chunk.int_value)
+                     ->  Parallel Seq Scan on _timescaledb_internal._hyper_1_1_chunk
+                           Output: _hyper_1_1_chunk.int_value
+(70 rows)
+
+RESET timescaledb.vectorized_aggregation;
+-- Vectorized aggregation NOT possible without bulk decompression
+SET timescaledb.enable_bulk_decompression = OFF;
+:EXPLAIN
+SELECT sum(int_value) FROM testtable;
+                                                                                                                                                                                   QUERY PLAN                                                                                                                                                                                    
+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Finalize Aggregate
+   Output: sum(_hyper_1_1_chunk.int_value)
+   ->  Gather
+         Output: (PARTIAL sum(_hyper_1_1_chunk.int_value))
+         Workers Planned: 2
+         ->  Parallel Append
+               ->  Partial Aggregate
+                     Output: PARTIAL sum(_hyper_1_1_chunk.int_value)
+                     ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_1_chunk
+                           Output: _hyper_1_1_chunk.int_value
+                           ->  Parallel Seq Scan on _timescaledb_internal.compress_hyper_2_11_chunk
+                                 Output: compress_hyper_2_11_chunk."time", compress_hyper_2_11_chunk.segment_by_value, compress_hyper_2_11_chunk.int_value, compress_hyper_2_11_chunk.float_value, compress_hyper_2_11_chunk._ts_meta_count, compress_hyper_2_11_chunk._ts_meta_sequence_num, compress_hyper_2_11_chunk._ts_meta_min_1, compress_hyper_2_11_chunk._ts_meta_max_1
+               ->  Partial Aggregate
+                     Output: PARTIAL sum(_hyper_1_2_chunk.int_value)
+                     ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_2_chunk
+                           Output: _hyper_1_2_chunk.int_value
+                           ->  Parallel Seq Scan on _timescaledb_internal.compress_hyper_2_12_chunk
+                                 Output: compress_hyper_2_12_chunk."time", compress_hyper_2_12_chunk.segment_by_value, compress_hyper_2_12_chunk.int_value, compress_hyper_2_12_chunk.float_value, compress_hyper_2_12_chunk._ts_meta_count, compress_hyper_2_12_chunk._ts_meta_sequence_num, compress_hyper_2_12_chunk._ts_meta_min_1, compress_hyper_2_12_chunk._ts_meta_max_1
+               ->  Partial Aggregate
+                     Output: PARTIAL sum(_hyper_1_3_chunk.int_value)
+                     ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_3_chunk
+                           Output: _hyper_1_3_chunk.int_value
+                           ->  Parallel Seq Scan on _timescaledb_internal.compress_hyper_2_13_chunk
+                                 Output: compress_hyper_2_13_chunk."time", compress_hyper_2_13_chunk.segment_by_value, compress_hyper_2_13_chunk.int_value, compress_hyper_2_13_chunk.float_value, compress_hyper_2_13_chunk._ts_meta_count, compress_hyper_2_13_chunk._ts_meta_sequence_num, compress_hyper_2_13_chunk._ts_meta_min_1, compress_hyper_2_13_chunk._ts_meta_max_1
+               ->  Partial Aggregate
+                     Output: PARTIAL sum(_hyper_1_4_chunk.int_value)
+                     ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_4_chunk
+                           Output: _hyper_1_4_chunk.int_value
+                           ->  Parallel Seq Scan on _timescaledb_internal.compress_hyper_2_14_chunk
+                                 Output: compress_hyper_2_14_chunk."time", compress_hyper_2_14_chunk.segment_by_value, compress_hyper_2_14_chunk.int_value, compress_hyper_2_14_chunk.float_value, compress_hyper_2_14_chunk._ts_meta_count, compress_hyper_2_14_chunk._ts_meta_sequence_num, compress_hyper_2_14_chunk._ts_meta_min_1, compress_hyper_2_14_chunk._ts_meta_max_1
+               ->  Partial Aggregate
+                     Output: PARTIAL sum(_hyper_1_5_chunk.int_value)
+                     ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_5_chunk
+                           Output: _hyper_1_5_chunk.int_value
+                           ->  Parallel Seq Scan on _timescaledb_internal.compress_hyper_2_15_chunk
+                                 Output: compress_hyper_2_15_chunk."time", compress_hyper_2_15_chunk.segment_by_value, compress_hyper_2_15_chunk.int_value, compress_hyper_2_15_chunk.float_value, compress_hyper_2_15_chunk._ts_meta_count, compress_hyper_2_15_chunk._ts_meta_sequence_num, compress_hyper_2_15_chunk._ts_meta_min_1, compress_hyper_2_15_chunk._ts_meta_max_1
+               ->  Partial Aggregate
+                     Output: PARTIAL sum(_hyper_1_6_chunk.int_value)
+                     ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_6_chunk
+                           Output: _hyper_1_6_chunk.int_value
+                           ->  Parallel Seq Scan on _timescaledb_internal.compress_hyper_2_16_chunk
+                                 Output: compress_hyper_2_16_chunk."time", compress_hyper_2_16_chunk.segment_by_value, compress_hyper_2_16_chunk.int_value, compress_hyper_2_16_chunk.float_value, compress_hyper_2_16_chunk._ts_meta_count, compress_hyper_2_16_chunk._ts_meta_sequence_num, compress_hyper_2_16_chunk._ts_meta_min_1, compress_hyper_2_16_chunk._ts_meta_max_1
+               ->  Partial Aggregate
+                     Output: PARTIAL sum(_hyper_1_7_chunk.int_value)
+                     ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_7_chunk
+                           Output: _hyper_1_7_chunk.int_value
+                           ->  Parallel Seq Scan on _timescaledb_internal.compress_hyper_2_17_chunk
+                                 Output: compress_hyper_2_17_chunk."time", compress_hyper_2_17_chunk.segment_by_value, compress_hyper_2_17_chunk.int_value, compress_hyper_2_17_chunk.float_value, compress_hyper_2_17_chunk._ts_meta_count, compress_hyper_2_17_chunk._ts_meta_sequence_num, compress_hyper_2_17_chunk._ts_meta_min_1, compress_hyper_2_17_chunk._ts_meta_max_1
+               ->  Partial Aggregate
+                     Output: PARTIAL sum(_hyper_1_8_chunk.int_value)
+                     ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_8_chunk
+                           Output: _hyper_1_8_chunk.int_value
+                           ->  Parallel Seq Scan on _timescaledb_internal.compress_hyper_2_18_chunk
+                                 Output: compress_hyper_2_18_chunk."time", compress_hyper_2_18_chunk.segment_by_value, compress_hyper_2_18_chunk.int_value, compress_hyper_2_18_chunk.float_value, compress_hyper_2_18_chunk._ts_meta_count, compress_hyper_2_18_chunk._ts_meta_sequence_num, compress_hyper_2_18_chunk._ts_meta_min_1, compress_hyper_2_18_chunk._ts_meta_max_1
+               ->  Partial Aggregate
+                     Output: PARTIAL sum(_hyper_1_9_chunk.int_value)
+                     ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_9_chunk
+                           Output: _hyper_1_9_chunk.int_value
+                           ->  Parallel Seq Scan on _timescaledb_internal.compress_hyper_2_19_chunk
+                                 Output: compress_hyper_2_19_chunk."time", compress_hyper_2_19_chunk.segment_by_value, compress_hyper_2_19_chunk.int_value, compress_hyper_2_19_chunk.float_value, compress_hyper_2_19_chunk._ts_meta_count, compress_hyper_2_19_chunk._ts_meta_sequence_num, compress_hyper_2_19_chunk._ts_meta_min_1, compress_hyper_2_19_chunk._ts_meta_max_1
+               ->  Partial Aggregate
+                     Output: PARTIAL sum(_hyper_1_10_chunk.int_value)
+                     ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_10_chunk
+                           Output: _hyper_1_10_chunk.int_value
+                           ->  Parallel Seq Scan on _timescaledb_internal.compress_hyper_2_20_chunk
+                                 Output: compress_hyper_2_20_chunk."time", compress_hyper_2_20_chunk.segment_by_value, compress_hyper_2_20_chunk.int_value, compress_hyper_2_20_chunk.float_value, compress_hyper_2_20_chunk._ts_meta_count, compress_hyper_2_20_chunk._ts_meta_sequence_num, compress_hyper_2_20_chunk._ts_meta_min_1, compress_hyper_2_20_chunk._ts_meta_max_1
+               ->  Partial Aggregate
+                     Output: PARTIAL sum(_hyper_1_1_chunk.int_value)
+                     ->  Parallel Seq Scan on _timescaledb_internal._hyper_1_1_chunk
+                           Output: _hyper_1_1_chunk.int_value
+(70 rows)
+
+RESET timescaledb.enable_bulk_decompression;
+-- Using the same sum function multiple times is supported by vectorization
+:EXPLAIN
+SELECT sum(int_value), sum(int_value) FROM testtable;
+                                                                                                                                                                             QUERY PLAN                                                                                                                                                                              
+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Finalize Aggregate
+   Output: sum(_hyper_1_1_chunk.int_value), sum(_hyper_1_1_chunk.int_value)
+   ->  Append
+         ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_1_chunk
+               Output: (PARTIAL sum(_hyper_1_1_chunk.int_value))
+               Vectorized Aggregation: true
+               ->  Seq Scan on _timescaledb_internal.compress_hyper_2_11_chunk
+                     Output: compress_hyper_2_11_chunk."time", compress_hyper_2_11_chunk.segment_by_value, compress_hyper_2_11_chunk.int_value, compress_hyper_2_11_chunk.float_value, compress_hyper_2_11_chunk._ts_meta_count, compress_hyper_2_11_chunk._ts_meta_sequence_num, compress_hyper_2_11_chunk._ts_meta_min_1, compress_hyper_2_11_chunk._ts_meta_max_1
+         ->  Partial Aggregate
+               Output: PARTIAL sum(_hyper_1_1_chunk.int_value)
+               ->  Seq Scan on _timescaledb_internal._hyper_1_1_chunk
+                     Output: _hyper_1_1_chunk.int_value
+         ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_2_chunk
+               Output: (PARTIAL sum(_hyper_1_2_chunk.int_value))
+               Vectorized Aggregation: true
+               ->  Seq Scan on _timescaledb_internal.compress_hyper_2_12_chunk
+                     Output: compress_hyper_2_12_chunk."time", compress_hyper_2_12_chunk.segment_by_value, compress_hyper_2_12_chunk.int_value, compress_hyper_2_12_chunk.float_value, compress_hyper_2_12_chunk._ts_meta_count, compress_hyper_2_12_chunk._ts_meta_sequence_num, compress_hyper_2_12_chunk._ts_meta_min_1, compress_hyper_2_12_chunk._ts_meta_max_1
+         ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_3_chunk
+               Output: (PARTIAL sum(_hyper_1_3_chunk.int_value))
+               Vectorized Aggregation: true
+               ->  Seq Scan on _timescaledb_internal.compress_hyper_2_13_chunk
+                     Output: compress_hyper_2_13_chunk."time", compress_hyper_2_13_chunk.segment_by_value, compress_hyper_2_13_chunk.int_value, compress_hyper_2_13_chunk.float_value, compress_hyper_2_13_chunk._ts_meta_count, compress_hyper_2_13_chunk._ts_meta_sequence_num, compress_hyper_2_13_chunk._ts_meta_min_1, compress_hyper_2_13_chunk._ts_meta_max_1
+         ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_4_chunk
+               Output: (PARTIAL sum(_hyper_1_4_chunk.int_value))
+               Vectorized Aggregation: true
+               ->  Seq Scan on _timescaledb_internal.compress_hyper_2_14_chunk
+                     Output: compress_hyper_2_14_chunk."time", compress_hyper_2_14_chunk.segment_by_value, compress_hyper_2_14_chunk.int_value, compress_hyper_2_14_chunk.float_value, compress_hyper_2_14_chunk._ts_meta_count, compress_hyper_2_14_chunk._ts_meta_sequence_num, compress_hyper_2_14_chunk._ts_meta_min_1, compress_hyper_2_14_chunk._ts_meta_max_1
+         ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_5_chunk
+               Output: (PARTIAL sum(_hyper_1_5_chunk.int_value))
+               Vectorized Aggregation: true
+               ->  Seq Scan on _timescaledb_internal.compress_hyper_2_15_chunk
+                     Output: compress_hyper_2_15_chunk."time", compress_hyper_2_15_chunk.segment_by_value, compress_hyper_2_15_chunk.int_value, compress_hyper_2_15_chunk.float_value, compress_hyper_2_15_chunk._ts_meta_count, compress_hyper_2_15_chunk._ts_meta_sequence_num, compress_hyper_2_15_chunk._ts_meta_min_1, compress_hyper_2_15_chunk._ts_meta_max_1
+         ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_6_chunk
+               Output: (PARTIAL sum(_hyper_1_6_chunk.int_value))
+               Vectorized Aggregation: true
+               ->  Seq Scan on _timescaledb_internal.compress_hyper_2_16_chunk
+                     Output: compress_hyper_2_16_chunk."time", compress_hyper_2_16_chunk.segment_by_value, compress_hyper_2_16_chunk.int_value, compress_hyper_2_16_chunk.float_value, compress_hyper_2_16_chunk._ts_meta_count, compress_hyper_2_16_chunk._ts_meta_sequence_num, compress_hyper_2_16_chunk._ts_meta_min_1, compress_hyper_2_16_chunk._ts_meta_max_1
+         ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_7_chunk
+               Output: (PARTIAL sum(_hyper_1_7_chunk.int_value))
+               Vectorized Aggregation: true
+               ->  Seq Scan on _timescaledb_internal.compress_hyper_2_17_chunk
+                     Output: compress_hyper_2_17_chunk."time", compress_hyper_2_17_chunk.segment_by_value, compress_hyper_2_17_chunk.int_value, compress_hyper_2_17_chunk.float_value, compress_hyper_2_17_chunk._ts_meta_count, compress_hyper_2_17_chunk._ts_meta_sequence_num, compress_hyper_2_17_chunk._ts_meta_min_1, compress_hyper_2_17_chunk._ts_meta_max_1
+         ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_8_chunk
+               Output: (PARTIAL sum(_hyper_1_8_chunk.int_value))
+               Vectorized Aggregation: true
+               ->  Seq Scan on _timescaledb_internal.compress_hyper_2_18_chunk
+                     Output: compress_hyper_2_18_chunk."time", compress_hyper_2_18_chunk.segment_by_value, compress_hyper_2_18_chunk.int_value, compress_hyper_2_18_chunk.float_value, compress_hyper_2_18_chunk._ts_meta_count, compress_hyper_2_18_chunk._ts_meta_sequence_num, compress_hyper_2_18_chunk._ts_meta_min_1, compress_hyper_2_18_chunk._ts_meta_max_1
+         ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_9_chunk
+               Output: (PARTIAL sum(_hyper_1_9_chunk.int_value))
+               Vectorized Aggregation: true
+               ->  Seq Scan on _timescaledb_internal.compress_hyper_2_19_chunk
+                     Output: compress_hyper_2_19_chunk."time", compress_hyper_2_19_chunk.segment_by_value, compress_hyper_2_19_chunk.int_value, compress_hyper_2_19_chunk.float_value, compress_hyper_2_19_chunk._ts_meta_count, compress_hyper_2_19_chunk._ts_meta_sequence_num, compress_hyper_2_19_chunk._ts_meta_min_1, compress_hyper_2_19_chunk._ts_meta_max_1
+         ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_10_chunk
+               Output: (PARTIAL sum(_hyper_1_10_chunk.int_value))
+               Vectorized Aggregation: true
+               ->  Seq Scan on _timescaledb_internal.compress_hyper_2_20_chunk
+                     Output: compress_hyper_2_20_chunk."time", compress_hyper_2_20_chunk.segment_by_value, compress_hyper_2_20_chunk.int_value, compress_hyper_2_20_chunk.float_value, compress_hyper_2_20_chunk._ts_meta_count, compress_hyper_2_20_chunk._ts_meta_sequence_num, compress_hyper_2_20_chunk._ts_meta_min_1, compress_hyper_2_20_chunk._ts_meta_max_1
+(57 rows)
+
+-- Using the same sum function multiple times is supported by vectorization
+:EXPLAIN
+SELECT sum(segment_by_value), sum(segment_by_value) FROM testtable;
+                                                                                                                                                                             QUERY PLAN                                                                                                                                                                              
+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Finalize Aggregate
+   Output: sum(_hyper_1_1_chunk.segment_by_value), sum(_hyper_1_1_chunk.segment_by_value)
+   ->  Append
+         ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_1_chunk
+               Output: (PARTIAL sum(_hyper_1_1_chunk.segment_by_value))
+               Vectorized Aggregation: true
+               ->  Seq Scan on _timescaledb_internal.compress_hyper_2_11_chunk
+                     Output: compress_hyper_2_11_chunk."time", compress_hyper_2_11_chunk.segment_by_value, compress_hyper_2_11_chunk.int_value, compress_hyper_2_11_chunk.float_value, compress_hyper_2_11_chunk._ts_meta_count, compress_hyper_2_11_chunk._ts_meta_sequence_num, compress_hyper_2_11_chunk._ts_meta_min_1, compress_hyper_2_11_chunk._ts_meta_max_1
+         ->  Partial Aggregate
+               Output: PARTIAL sum(_hyper_1_1_chunk.segment_by_value)
+               ->  Seq Scan on _timescaledb_internal._hyper_1_1_chunk
+                     Output: _hyper_1_1_chunk.segment_by_value
+         ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_2_chunk
+               Output: (PARTIAL sum(_hyper_1_2_chunk.segment_by_value))
+               Vectorized Aggregation: true
+               ->  Seq Scan on _timescaledb_internal.compress_hyper_2_12_chunk
+                     Output: compress_hyper_2_12_chunk."time", compress_hyper_2_12_chunk.segment_by_value, compress_hyper_2_12_chunk.int_value, compress_hyper_2_12_chunk.float_value, compress_hyper_2_12_chunk._ts_meta_count, compress_hyper_2_12_chunk._ts_meta_sequence_num, compress_hyper_2_12_chunk._ts_meta_min_1, compress_hyper_2_12_chunk._ts_meta_max_1
+         ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_3_chunk
+               Output: (PARTIAL sum(_hyper_1_3_chunk.segment_by_value))
+               Vectorized Aggregation: true
+               ->  Seq Scan on _timescaledb_internal.compress_hyper_2_13_chunk
+                     Output: compress_hyper_2_13_chunk."time", compress_hyper_2_13_chunk.segment_by_value, compress_hyper_2_13_chunk.int_value, compress_hyper_2_13_chunk.float_value, compress_hyper_2_13_chunk._ts_meta_count, compress_hyper_2_13_chunk._ts_meta_sequence_num, compress_hyper_2_13_chunk._ts_meta_min_1, compress_hyper_2_13_chunk._ts_meta_max_1
+         ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_4_chunk
+               Output: (PARTIAL sum(_hyper_1_4_chunk.segment_by_value))
+               Vectorized Aggregation: true
+               ->  Seq Scan on _timescaledb_internal.compress_hyper_2_14_chunk
+                     Output: compress_hyper_2_14_chunk."time", compress_hyper_2_14_chunk.segment_by_value, compress_hyper_2_14_chunk.int_value, compress_hyper_2_14_chunk.float_value, compress_hyper_2_14_chunk._ts_meta_count, compress_hyper_2_14_chunk._ts_meta_sequence_num, compress_hyper_2_14_chunk._ts_meta_min_1, compress_hyper_2_14_chunk._ts_meta_max_1
+         ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_5_chunk
+               Output: (PARTIAL sum(_hyper_1_5_chunk.segment_by_value))
+               Vectorized Aggregation: true
+               ->  Seq Scan on _timescaledb_internal.compress_hyper_2_15_chunk
+                     Output: compress_hyper_2_15_chunk."time", compress_hyper_2_15_chunk.segment_by_value, compress_hyper_2_15_chunk.int_value, compress_hyper_2_15_chunk.float_value, compress_hyper_2_15_chunk._ts_meta_count, compress_hyper_2_15_chunk._ts_meta_sequence_num, compress_hyper_2_15_chunk._ts_meta_min_1, compress_hyper_2_15_chunk._ts_meta_max_1
+         ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_6_chunk
+               Output: (PARTIAL sum(_hyper_1_6_chunk.segment_by_value))
+               Vectorized Aggregation: true
+               ->  Seq Scan on _timescaledb_internal.compress_hyper_2_16_chunk
+                     Output: compress_hyper_2_16_chunk."time", compress_hyper_2_16_chunk.segment_by_value, compress_hyper_2_16_chunk.int_value, compress_hyper_2_16_chunk.float_value, compress_hyper_2_16_chunk._ts_meta_count, compress_hyper_2_16_chunk._ts_meta_sequence_num, compress_hyper_2_16_chunk._ts_meta_min_1, compress_hyper_2_16_chunk._ts_meta_max_1
+         ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_7_chunk
+               Output: (PARTIAL sum(_hyper_1_7_chunk.segment_by_value))
+               Vectorized Aggregation: true
+               ->  Seq Scan on _timescaledb_internal.compress_hyper_2_17_chunk
+                     Output: compress_hyper_2_17_chunk."time", compress_hyper_2_17_chunk.segment_by_value, compress_hyper_2_17_chunk.int_value, compress_hyper_2_17_chunk.float_value, compress_hyper_2_17_chunk._ts_meta_count, compress_hyper_2_17_chunk._ts_meta_sequence_num, compress_hyper_2_17_chunk._ts_meta_min_1, compress_hyper_2_17_chunk._ts_meta_max_1
+         ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_8_chunk
+               Output: (PARTIAL sum(_hyper_1_8_chunk.segment_by_value))
+               Vectorized Aggregation: true
+               ->  Seq Scan on _timescaledb_internal.compress_hyper_2_18_chunk
+                     Output: compress_hyper_2_18_chunk."time", compress_hyper_2_18_chunk.segment_by_value, compress_hyper_2_18_chunk.int_value, compress_hyper_2_18_chunk.float_value, compress_hyper_2_18_chunk._ts_meta_count, compress_hyper_2_18_chunk._ts_meta_sequence_num, compress_hyper_2_18_chunk._ts_meta_min_1, compress_hyper_2_18_chunk._ts_meta_max_1
+         ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_9_chunk
+               Output: (PARTIAL sum(_hyper_1_9_chunk.segment_by_value))
+               Vectorized Aggregation: true
+               ->  Seq Scan on _timescaledb_internal.compress_hyper_2_19_chunk
+                     Output: compress_hyper_2_19_chunk."time", compress_hyper_2_19_chunk.segment_by_value, compress_hyper_2_19_chunk.int_value, compress_hyper_2_19_chunk.float_value, compress_hyper_2_19_chunk._ts_meta_count, compress_hyper_2_19_chunk._ts_meta_sequence_num, compress_hyper_2_19_chunk._ts_meta_min_1, compress_hyper_2_19_chunk._ts_meta_max_1
+         ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_10_chunk
+               Output: (PARTIAL sum(_hyper_1_10_chunk.segment_by_value))
+               Vectorized Aggregation: true
+               ->  Seq Scan on _timescaledb_internal.compress_hyper_2_20_chunk
+                     Output: compress_hyper_2_20_chunk."time", compress_hyper_2_20_chunk.segment_by_value, compress_hyper_2_20_chunk.int_value, compress_hyper_2_20_chunk.float_value, compress_hyper_2_20_chunk._ts_meta_count, compress_hyper_2_20_chunk._ts_meta_sequence_num, compress_hyper_2_20_chunk._ts_meta_min_1, compress_hyper_2_20_chunk._ts_meta_max_1
+(57 rows)
+
+-- Performing a sum on multiple columns is currently not supported by vectorization
+:EXPLAIN
+SELECT sum(int_value), sum(segment_by_value) FROM testtable;
+                                                                                                                                                                                   QUERY PLAN                                                                                                                                                                                    
+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Finalize Aggregate
+   Output: sum(_hyper_1_1_chunk.int_value), sum(_hyper_1_1_chunk.segment_by_value)
+   ->  Gather
+         Output: (PARTIAL sum(_hyper_1_1_chunk.int_value)), (PARTIAL sum(_hyper_1_1_chunk.segment_by_value))
+         Workers Planned: 2
+         ->  Parallel Append
+               ->  Partial Aggregate
+                     Output: PARTIAL sum(_hyper_1_1_chunk.int_value), PARTIAL sum(_hyper_1_1_chunk.segment_by_value)
+                     ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_1_chunk
+                           Output: _hyper_1_1_chunk.int_value, _hyper_1_1_chunk.segment_by_value
+                           ->  Parallel Seq Scan on _timescaledb_internal.compress_hyper_2_11_chunk
+                                 Output: compress_hyper_2_11_chunk."time", compress_hyper_2_11_chunk.segment_by_value, compress_hyper_2_11_chunk.int_value, compress_hyper_2_11_chunk.float_value, compress_hyper_2_11_chunk._ts_meta_count, compress_hyper_2_11_chunk._ts_meta_sequence_num, compress_hyper_2_11_chunk._ts_meta_min_1, compress_hyper_2_11_chunk._ts_meta_max_1
+               ->  Partial Aggregate
+                     Output: PARTIAL sum(_hyper_1_2_chunk.int_value), PARTIAL sum(_hyper_1_2_chunk.segment_by_value)
+                     ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_2_chunk
+                           Output: _hyper_1_2_chunk.int_value, _hyper_1_2_chunk.segment_by_value
+                           ->  Parallel Seq Scan on _timescaledb_internal.compress_hyper_2_12_chunk
+                                 Output: compress_hyper_2_12_chunk."time", compress_hyper_2_12_chunk.segment_by_value, compress_hyper_2_12_chunk.int_value, compress_hyper_2_12_chunk.float_value, compress_hyper_2_12_chunk._ts_meta_count, compress_hyper_2_12_chunk._ts_meta_sequence_num, compress_hyper_2_12_chunk._ts_meta_min_1, compress_hyper_2_12_chunk._ts_meta_max_1
+               ->  Partial Aggregate
+                     Output: PARTIAL sum(_hyper_1_3_chunk.int_value), PARTIAL sum(_hyper_1_3_chunk.segment_by_value)
+                     ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_3_chunk
+                           Output: _hyper_1_3_chunk.int_value, _hyper_1_3_chunk.segment_by_value
+                           ->  Parallel Seq Scan on _timescaledb_internal.compress_hyper_2_13_chunk
+                                 Output: compress_hyper_2_13_chunk."time", compress_hyper_2_13_chunk.segment_by_value, compress_hyper_2_13_chunk.int_value, compress_hyper_2_13_chunk.float_value, compress_hyper_2_13_chunk._ts_meta_count, compress_hyper_2_13_chunk._ts_meta_sequence_num, compress_hyper_2_13_chunk._ts_meta_min_1, compress_hyper_2_13_chunk._ts_meta_max_1
+               ->  Partial Aggregate
+                     Output: PARTIAL sum(_hyper_1_4_chunk.int_value), PARTIAL sum(_hyper_1_4_chunk.segment_by_value)
+                     ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_4_chunk
+                           Output: _hyper_1_4_chunk.int_value, _hyper_1_4_chunk.segment_by_value
+                           ->  Parallel Seq Scan on _timescaledb_internal.compress_hyper_2_14_chunk
+                                 Output: compress_hyper_2_14_chunk."time", compress_hyper_2_14_chunk.segment_by_value, compress_hyper_2_14_chunk.int_value, compress_hyper_2_14_chunk.float_value, compress_hyper_2_14_chunk._ts_meta_count, compress_hyper_2_14_chunk._ts_meta_sequence_num, compress_hyper_2_14_chunk._ts_meta_min_1, compress_hyper_2_14_chunk._ts_meta_max_1
+               ->  Partial Aggregate
+                     Output: PARTIAL sum(_hyper_1_5_chunk.int_value), PARTIAL sum(_hyper_1_5_chunk.segment_by_value)
+                     ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_5_chunk
+                           Output: _hyper_1_5_chunk.int_value, _hyper_1_5_chunk.segment_by_value
+                           ->  Parallel Seq Scan on _timescaledb_internal.compress_hyper_2_15_chunk
+                                 Output: compress_hyper_2_15_chunk."time", compress_hyper_2_15_chunk.segment_by_value, compress_hyper_2_15_chunk.int_value, compress_hyper_2_15_chunk.float_value, compress_hyper_2_15_chunk._ts_meta_count, compress_hyper_2_15_chunk._ts_meta_sequence_num, compress_hyper_2_15_chunk._ts_meta_min_1, compress_hyper_2_15_chunk._ts_meta_max_1
+               ->  Partial Aggregate
+                     Output: PARTIAL sum(_hyper_1_6_chunk.int_value), PARTIAL sum(_hyper_1_6_chunk.segment_by_value)
+                     ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_6_chunk
+                           Output: _hyper_1_6_chunk.int_value, _hyper_1_6_chunk.segment_by_value
+                           ->  Parallel Seq Scan on _timescaledb_internal.compress_hyper_2_16_chunk
+                                 Output: compress_hyper_2_16_chunk."time", compress_hyper_2_16_chunk.segment_by_value, compress_hyper_2_16_chunk.int_value, compress_hyper_2_16_chunk.float_value, compress_hyper_2_16_chunk._ts_meta_count, compress_hyper_2_16_chunk._ts_meta_sequence_num, compress_hyper_2_16_chunk._ts_meta_min_1, compress_hyper_2_16_chunk._ts_meta_max_1
+               ->  Partial Aggregate
+                     Output: PARTIAL sum(_hyper_1_7_chunk.int_value), PARTIAL sum(_hyper_1_7_chunk.segment_by_value)
+                     ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_7_chunk
+                           Output: _hyper_1_7_chunk.int_value, _hyper_1_7_chunk.segment_by_value
+                           ->  Parallel Seq Scan on _timescaledb_internal.compress_hyper_2_17_chunk
+                                 Output: compress_hyper_2_17_chunk."time", compress_hyper_2_17_chunk.segment_by_value, compress_hyper_2_17_chunk.int_value, compress_hyper_2_17_chunk.float_value, compress_hyper_2_17_chunk._ts_meta_count, compress_hyper_2_17_chunk._ts_meta_sequence_num, compress_hyper_2_17_chunk._ts_meta_min_1, compress_hyper_2_17_chunk._ts_meta_max_1
+               ->  Partial Aggregate
+                     Output: PARTIAL sum(_hyper_1_8_chunk.int_value), PARTIAL sum(_hyper_1_8_chunk.segment_by_value)
+                     ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_8_chunk
+                           Output: _hyper_1_8_chunk.int_value, _hyper_1_8_chunk.segment_by_value
+                           ->  Parallel Seq Scan on _timescaledb_internal.compress_hyper_2_18_chunk
+                                 Output: compress_hyper_2_18_chunk."time", compress_hyper_2_18_chunk.segment_by_value, compress_hyper_2_18_chunk.int_value, compress_hyper_2_18_chunk.float_value, compress_hyper_2_18_chunk._ts_meta_count, compress_hyper_2_18_chunk._ts_meta_sequence_num, compress_hyper_2_18_chunk._ts_meta_min_1, compress_hyper_2_18_chunk._ts_meta_max_1
+               ->  Partial Aggregate
+                     Output: PARTIAL sum(_hyper_1_9_chunk.int_value), PARTIAL sum(_hyper_1_9_chunk.segment_by_value)
+                     ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_9_chunk
+                           Output: _hyper_1_9_chunk.int_value, _hyper_1_9_chunk.segment_by_value
+                           ->  Parallel Seq Scan on _timescaledb_internal.compress_hyper_2_19_chunk
+                                 Output: compress_hyper_2_19_chunk."time", compress_hyper_2_19_chunk.segment_by_value, compress_hyper_2_19_chunk.int_value, compress_hyper_2_19_chunk.float_value, compress_hyper_2_19_chunk._ts_meta_count, compress_hyper_2_19_chunk._ts_meta_sequence_num, compress_hyper_2_19_chunk._ts_meta_min_1, compress_hyper_2_19_chunk._ts_meta_max_1
+               ->  Partial Aggregate
+                     Output: PARTIAL sum(_hyper_1_10_chunk.int_value), PARTIAL sum(_hyper_1_10_chunk.segment_by_value)
+                     ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_10_chunk
+                           Output: _hyper_1_10_chunk.int_value, _hyper_1_10_chunk.segment_by_value
+                           ->  Parallel Seq Scan on _timescaledb_internal.compress_hyper_2_20_chunk
+                                 Output: compress_hyper_2_20_chunk."time", compress_hyper_2_20_chunk.segment_by_value, compress_hyper_2_20_chunk.int_value, compress_hyper_2_20_chunk.float_value, compress_hyper_2_20_chunk._ts_meta_count, compress_hyper_2_20_chunk._ts_meta_sequence_num, compress_hyper_2_20_chunk._ts_meta_min_1, compress_hyper_2_20_chunk._ts_meta_max_1
+               ->  Partial Aggregate
+                     Output: PARTIAL sum(_hyper_1_1_chunk.int_value), PARTIAL sum(_hyper_1_1_chunk.segment_by_value)
+                     ->  Parallel Seq Scan on _timescaledb_internal._hyper_1_1_chunk
+                           Output: _hyper_1_1_chunk.int_value, _hyper_1_1_chunk.segment_by_value
+(70 rows)
+
+-- Using the sum function together with another non-vector capable aggregate is not supported
+:EXPLAIN
+SELECT sum(int_value), max(int_value) FROM testtable;
+                                                                                                                                                                                   QUERY PLAN                                                                                                                                                                                    
+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Finalize Aggregate
+   Output: sum(_hyper_1_1_chunk.int_value), max(_hyper_1_1_chunk.int_value)
+   ->  Gather
+         Output: (PARTIAL sum(_hyper_1_1_chunk.int_value)), (PARTIAL max(_hyper_1_1_chunk.int_value))
+         Workers Planned: 2
+         ->  Parallel Append
+               ->  Partial Aggregate
+                     Output: PARTIAL sum(_hyper_1_1_chunk.int_value), PARTIAL max(_hyper_1_1_chunk.int_value)
+                     ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_1_chunk
+                           Output: _hyper_1_1_chunk.int_value
+                           ->  Parallel Seq Scan on _timescaledb_internal.compress_hyper_2_11_chunk
+                                 Output: compress_hyper_2_11_chunk."time", compress_hyper_2_11_chunk.segment_by_value, compress_hyper_2_11_chunk.int_value, compress_hyper_2_11_chunk.float_value, compress_hyper_2_11_chunk._ts_meta_count, compress_hyper_2_11_chunk._ts_meta_sequence_num, compress_hyper_2_11_chunk._ts_meta_min_1, compress_hyper_2_11_chunk._ts_meta_max_1
+               ->  Partial Aggregate
+                     Output: PARTIAL sum(_hyper_1_2_chunk.int_value), PARTIAL max(_hyper_1_2_chunk.int_value)
+                     ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_2_chunk
+                           Output: _hyper_1_2_chunk.int_value
+                           ->  Parallel Seq Scan on _timescaledb_internal.compress_hyper_2_12_chunk
+                                 Output: compress_hyper_2_12_chunk."time", compress_hyper_2_12_chunk.segment_by_value, compress_hyper_2_12_chunk.int_value, compress_hyper_2_12_chunk.float_value, compress_hyper_2_12_chunk._ts_meta_count, compress_hyper_2_12_chunk._ts_meta_sequence_num, compress_hyper_2_12_chunk._ts_meta_min_1, compress_hyper_2_12_chunk._ts_meta_max_1
+               ->  Partial Aggregate
+                     Output: PARTIAL sum(_hyper_1_3_chunk.int_value), PARTIAL max(_hyper_1_3_chunk.int_value)
+                     ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_3_chunk
+                           Output: _hyper_1_3_chunk.int_value
+                           ->  Parallel Seq Scan on _timescaledb_internal.compress_hyper_2_13_chunk
+                                 Output: compress_hyper_2_13_chunk."time", compress_hyper_2_13_chunk.segment_by_value, compress_hyper_2_13_chunk.int_value, compress_hyper_2_13_chunk.float_value, compress_hyper_2_13_chunk._ts_meta_count, compress_hyper_2_13_chunk._ts_meta_sequence_num, compress_hyper_2_13_chunk._ts_meta_min_1, compress_hyper_2_13_chunk._ts_meta_max_1
+               ->  Partial Aggregate
+                     Output: PARTIAL sum(_hyper_1_4_chunk.int_value), PARTIAL max(_hyper_1_4_chunk.int_value)
+                     ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_4_chunk
+                           Output: _hyper_1_4_chunk.int_value
+                           ->  Parallel Seq Scan on _timescaledb_internal.compress_hyper_2_14_chunk
+                                 Output: compress_hyper_2_14_chunk."time", compress_hyper_2_14_chunk.segment_by_value, compress_hyper_2_14_chunk.int_value, compress_hyper_2_14_chunk.float_value, compress_hyper_2_14_chunk._ts_meta_count, compress_hyper_2_14_chunk._ts_meta_sequence_num, compress_hyper_2_14_chunk._ts_meta_min_1, compress_hyper_2_14_chunk._ts_meta_max_1
+               ->  Partial Aggregate
+                     Output: PARTIAL sum(_hyper_1_5_chunk.int_value), PARTIAL max(_hyper_1_5_chunk.int_value)
+                     ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_5_chunk
+                           Output: _hyper_1_5_chunk.int_value
+                           ->  Parallel Seq Scan on _timescaledb_internal.compress_hyper_2_15_chunk
+                                 Output: compress_hyper_2_15_chunk."time", compress_hyper_2_15_chunk.segment_by_value, compress_hyper_2_15_chunk.int_value, compress_hyper_2_15_chunk.float_value, compress_hyper_2_15_chunk._ts_meta_count, compress_hyper_2_15_chunk._ts_meta_sequence_num, compress_hyper_2_15_chunk._ts_meta_min_1, compress_hyper_2_15_chunk._ts_meta_max_1
+               ->  Partial Aggregate
+                     Output: PARTIAL sum(_hyper_1_6_chunk.int_value), PARTIAL max(_hyper_1_6_chunk.int_value)
+                     ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_6_chunk
+                           Output: _hyper_1_6_chunk.int_value
+                           ->  Parallel Seq Scan on _timescaledb_internal.compress_hyper_2_16_chunk
+                                 Output: compress_hyper_2_16_chunk."time", compress_hyper_2_16_chunk.segment_by_value, compress_hyper_2_16_chunk.int_value, compress_hyper_2_16_chunk.float_value, compress_hyper_2_16_chunk._ts_meta_count, compress_hyper_2_16_chunk._ts_meta_sequence_num, compress_hyper_2_16_chunk._ts_meta_min_1, compress_hyper_2_16_chunk._ts_meta_max_1
+               ->  Partial Aggregate
+                     Output: PARTIAL sum(_hyper_1_7_chunk.int_value), PARTIAL max(_hyper_1_7_chunk.int_value)
+                     ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_7_chunk
+                           Output: _hyper_1_7_chunk.int_value
+                           ->  Parallel Seq Scan on _timescaledb_internal.compress_hyper_2_17_chunk
+                                 Output: compress_hyper_2_17_chunk."time", compress_hyper_2_17_chunk.segment_by_value, compress_hyper_2_17_chunk.int_value, compress_hyper_2_17_chunk.float_value, compress_hyper_2_17_chunk._ts_meta_count, compress_hyper_2_17_chunk._ts_meta_sequence_num, compress_hyper_2_17_chunk._ts_meta_min_1, compress_hyper_2_17_chunk._ts_meta_max_1
+               ->  Partial Aggregate
+                     Output: PARTIAL sum(_hyper_1_8_chunk.int_value), PARTIAL max(_hyper_1_8_chunk.int_value)
+                     ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_8_chunk
+                           Output: _hyper_1_8_chunk.int_value
+                           ->  Parallel Seq Scan on _timescaledb_internal.compress_hyper_2_18_chunk
+                                 Output: compress_hyper_2_18_chunk."time", compress_hyper_2_18_chunk.segment_by_value, compress_hyper_2_18_chunk.int_value, compress_hyper_2_18_chunk.float_value, compress_hyper_2_18_chunk._ts_meta_count, compress_hyper_2_18_chunk._ts_meta_sequence_num, compress_hyper_2_18_chunk._ts_meta_min_1, compress_hyper_2_18_chunk._ts_meta_max_1
+               ->  Partial Aggregate
+                     Output: PARTIAL sum(_hyper_1_9_chunk.int_value), PARTIAL max(_hyper_1_9_chunk.int_value)
+                     ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_9_chunk
+                           Output: _hyper_1_9_chunk.int_value
+                           ->  Parallel Seq Scan on _timescaledb_internal.compress_hyper_2_19_chunk
+                                 Output: compress_hyper_2_19_chunk."time", compress_hyper_2_19_chunk.segment_by_value, compress_hyper_2_19_chunk.int_value, compress_hyper_2_19_chunk.float_value, compress_hyper_2_19_chunk._ts_meta_count, compress_hyper_2_19_chunk._ts_meta_sequence_num, compress_hyper_2_19_chunk._ts_meta_min_1, compress_hyper_2_19_chunk._ts_meta_max_1
+               ->  Partial Aggregate
+                     Output: PARTIAL sum(_hyper_1_10_chunk.int_value), PARTIAL max(_hyper_1_10_chunk.int_value)
+                     ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_10_chunk
+                           Output: _hyper_1_10_chunk.int_value
+                           ->  Parallel Seq Scan on _timescaledb_internal.compress_hyper_2_20_chunk
+                                 Output: compress_hyper_2_20_chunk."time", compress_hyper_2_20_chunk.segment_by_value, compress_hyper_2_20_chunk.int_value, compress_hyper_2_20_chunk.float_value, compress_hyper_2_20_chunk._ts_meta_count, compress_hyper_2_20_chunk._ts_meta_sequence_num, compress_hyper_2_20_chunk._ts_meta_min_1, compress_hyper_2_20_chunk._ts_meta_max_1
+               ->  Partial Aggregate
+                     Output: PARTIAL sum(_hyper_1_1_chunk.int_value), PARTIAL max(_hyper_1_1_chunk.int_value)
+                     ->  Parallel Seq Scan on _timescaledb_internal._hyper_1_1_chunk
+                           Output: _hyper_1_1_chunk.int_value
+(70 rows)
+
+-- Using the sum function together with another non-vector capable aggregate is not supported
+:EXPLAIN
+SELECT sum(segment_by_value), max(segment_by_value) FROM testtable;
+                                                                                                                                                                                   QUERY PLAN                                                                                                                                                                                    
+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Finalize Aggregate
+   Output: sum(_hyper_1_1_chunk.segment_by_value), max(_hyper_1_1_chunk.segment_by_value)
+   ->  Gather
+         Output: (PARTIAL sum(_hyper_1_1_chunk.segment_by_value)), (PARTIAL max(_hyper_1_1_chunk.segment_by_value))
+         Workers Planned: 2
+         ->  Parallel Append
+               ->  Partial Aggregate
+                     Output: PARTIAL sum(_hyper_1_1_chunk.segment_by_value), PARTIAL max(_hyper_1_1_chunk.segment_by_value)
+                     ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_1_chunk
+                           Output: _hyper_1_1_chunk.segment_by_value
+                           ->  Parallel Seq Scan on _timescaledb_internal.compress_hyper_2_11_chunk
+                                 Output: compress_hyper_2_11_chunk."time", compress_hyper_2_11_chunk.segment_by_value, compress_hyper_2_11_chunk.int_value, compress_hyper_2_11_chunk.float_value, compress_hyper_2_11_chunk._ts_meta_count, compress_hyper_2_11_chunk._ts_meta_sequence_num, compress_hyper_2_11_chunk._ts_meta_min_1, compress_hyper_2_11_chunk._ts_meta_max_1
+               ->  Partial Aggregate
+                     Output: PARTIAL sum(_hyper_1_2_chunk.segment_by_value), PARTIAL max(_hyper_1_2_chunk.segment_by_value)
+                     ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_2_chunk
+                           Output: _hyper_1_2_chunk.segment_by_value
+                           ->  Parallel Seq Scan on _timescaledb_internal.compress_hyper_2_12_chunk
+                                 Output: compress_hyper_2_12_chunk."time", compress_hyper_2_12_chunk.segment_by_value, compress_hyper_2_12_chunk.int_value, compress_hyper_2_12_chunk.float_value, compress_hyper_2_12_chunk._ts_meta_count, compress_hyper_2_12_chunk._ts_meta_sequence_num, compress_hyper_2_12_chunk._ts_meta_min_1, compress_hyper_2_12_chunk._ts_meta_max_1
+               ->  Partial Aggregate
+                     Output: PARTIAL sum(_hyper_1_3_chunk.segment_by_value), PARTIAL max(_hyper_1_3_chunk.segment_by_value)
+                     ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_3_chunk
+                           Output: _hyper_1_3_chunk.segment_by_value
+                           ->  Parallel Seq Scan on _timescaledb_internal.compress_hyper_2_13_chunk
+                                 Output: compress_hyper_2_13_chunk."time", compress_hyper_2_13_chunk.segment_by_value, compress_hyper_2_13_chunk.int_value, compress_hyper_2_13_chunk.float_value, compress_hyper_2_13_chunk._ts_meta_count, compress_hyper_2_13_chunk._ts_meta_sequence_num, compress_hyper_2_13_chunk._ts_meta_min_1, compress_hyper_2_13_chunk._ts_meta_max_1
+               ->  Partial Aggregate
+                     Output: PARTIAL sum(_hyper_1_4_chunk.segment_by_value), PARTIAL max(_hyper_1_4_chunk.segment_by_value)
+                     ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_4_chunk
+                           Output: _hyper_1_4_chunk.segment_by_value
+                           ->  Parallel Seq Scan on _timescaledb_internal.compress_hyper_2_14_chunk
+                                 Output: compress_hyper_2_14_chunk."time", compress_hyper_2_14_chunk.segment_by_value, compress_hyper_2_14_chunk.int_value, compress_hyper_2_14_chunk.float_value, compress_hyper_2_14_chunk._ts_meta_count, compress_hyper_2_14_chunk._ts_meta_sequence_num, compress_hyper_2_14_chunk._ts_meta_min_1, compress_hyper_2_14_chunk._ts_meta_max_1
+               ->  Partial Aggregate
+                     Output: PARTIAL sum(_hyper_1_5_chunk.segment_by_value), PARTIAL max(_hyper_1_5_chunk.segment_by_value)
+                     ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_5_chunk
+                           Output: _hyper_1_5_chunk.segment_by_value
+                           ->  Parallel Seq Scan on _timescaledb_internal.compress_hyper_2_15_chunk
+                                 Output: compress_hyper_2_15_chunk."time", compress_hyper_2_15_chunk.segment_by_value, compress_hyper_2_15_chunk.int_value, compress_hyper_2_15_chunk.float_value, compress_hyper_2_15_chunk._ts_meta_count, compress_hyper_2_15_chunk._ts_meta_sequence_num, compress_hyper_2_15_chunk._ts_meta_min_1, compress_hyper_2_15_chunk._ts_meta_max_1
+               ->  Partial Aggregate
+                     Output: PARTIAL sum(_hyper_1_6_chunk.segment_by_value), PARTIAL max(_hyper_1_6_chunk.segment_by_value)
+                     ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_6_chunk
+                           Output: _hyper_1_6_chunk.segment_by_value
+                           ->  Parallel Seq Scan on _timescaledb_internal.compress_hyper_2_16_chunk
+                                 Output: compress_hyper_2_16_chunk."time", compress_hyper_2_16_chunk.segment_by_value, compress_hyper_2_16_chunk.int_value, compress_hyper_2_16_chunk.float_value, compress_hyper_2_16_chunk._ts_meta_count, compress_hyper_2_16_chunk._ts_meta_sequence_num, compress_hyper_2_16_chunk._ts_meta_min_1, compress_hyper_2_16_chunk._ts_meta_max_1
+               ->  Partial Aggregate
+                     Output: PARTIAL sum(_hyper_1_7_chunk.segment_by_value), PARTIAL max(_hyper_1_7_chunk.segment_by_value)
+                     ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_7_chunk
+                           Output: _hyper_1_7_chunk.segment_by_value
+                           ->  Parallel Seq Scan on _timescaledb_internal.compress_hyper_2_17_chunk
+                                 Output: compress_hyper_2_17_chunk."time", compress_hyper_2_17_chunk.segment_by_value, compress_hyper_2_17_chunk.int_value, compress_hyper_2_17_chunk.float_value, compress_hyper_2_17_chunk._ts_meta_count, compress_hyper_2_17_chunk._ts_meta_sequence_num, compress_hyper_2_17_chunk._ts_meta_min_1, compress_hyper_2_17_chunk._ts_meta_max_1
+               ->  Partial Aggregate
+                     Output: PARTIAL sum(_hyper_1_8_chunk.segment_by_value), PARTIAL max(_hyper_1_8_chunk.segment_by_value)
+                     ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_8_chunk
+                           Output: _hyper_1_8_chunk.segment_by_value
+                           ->  Parallel Seq Scan on _timescaledb_internal.compress_hyper_2_18_chunk
+                                 Output: compress_hyper_2_18_chunk."time", compress_hyper_2_18_chunk.segment_by_value, compress_hyper_2_18_chunk.int_value, compress_hyper_2_18_chunk.float_value, compress_hyper_2_18_chunk._ts_meta_count, compress_hyper_2_18_chunk._ts_meta_sequence_num, compress_hyper_2_18_chunk._ts_meta_min_1, compress_hyper_2_18_chunk._ts_meta_max_1
+               ->  Partial Aggregate
+                     Output: PARTIAL sum(_hyper_1_9_chunk.segment_by_value), PARTIAL max(_hyper_1_9_chunk.segment_by_value)
+                     ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_9_chunk
+                           Output: _hyper_1_9_chunk.segment_by_value
+                           ->  Parallel Seq Scan on _timescaledb_internal.compress_hyper_2_19_chunk
+                                 Output: compress_hyper_2_19_chunk."time", compress_hyper_2_19_chunk.segment_by_value, compress_hyper_2_19_chunk.int_value, compress_hyper_2_19_chunk.float_value, compress_hyper_2_19_chunk._ts_meta_count, compress_hyper_2_19_chunk._ts_meta_sequence_num, compress_hyper_2_19_chunk._ts_meta_min_1, compress_hyper_2_19_chunk._ts_meta_max_1
+               ->  Partial Aggregate
+                     Output: PARTIAL sum(_hyper_1_10_chunk.segment_by_value), PARTIAL max(_hyper_1_10_chunk.segment_by_value)
+                     ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_10_chunk
+                           Output: _hyper_1_10_chunk.segment_by_value
+                           ->  Parallel Seq Scan on _timescaledb_internal.compress_hyper_2_20_chunk
+                                 Output: compress_hyper_2_20_chunk."time", compress_hyper_2_20_chunk.segment_by_value, compress_hyper_2_20_chunk.int_value, compress_hyper_2_20_chunk.float_value, compress_hyper_2_20_chunk._ts_meta_count, compress_hyper_2_20_chunk._ts_meta_sequence_num, compress_hyper_2_20_chunk._ts_meta_min_1, compress_hyper_2_20_chunk._ts_meta_max_1
+               ->  Partial Aggregate
+                     Output: PARTIAL sum(_hyper_1_1_chunk.segment_by_value), PARTIAL max(_hyper_1_1_chunk.segment_by_value)
+                     ->  Parallel Seq Scan on _timescaledb_internal._hyper_1_1_chunk
+                           Output: _hyper_1_1_chunk.segment_by_value
+(70 rows)
+
+---
+-- Tests with only negative values
+---
+TRUNCATE testtable;
+INSERT INTO testtable
+SELECT time AS time,
+value AS segment_by_value,
+value AS int_value,
+value AS float_value
+FROM
+generate_series('1980-01-01 00:00:00-00', '1980-03-01 00:00:00-00', INTERVAL '1 day') AS g1(time),
+generate_series(-10, 0, 1) AS g2(value)
+ORDER BY time;
+-- Aggregation result without any vectorization
+SELECT sum(segment_by_value), sum(int_value), sum(float_value) FROM testtable;
+  sum  |  sum  |  sum  
+-------+-------+-------
+ -3355 | -3355 | -3355
+(1 row)
+
+SELECT compress_chunk(ch) FROM show_chunks('testtable') ch;
+             compress_chunk              
+-----------------------------------------
+ _timescaledb_internal._hyper_1_21_chunk
+ _timescaledb_internal._hyper_1_22_chunk
+ _timescaledb_internal._hyper_1_23_chunk
+ _timescaledb_internal._hyper_1_24_chunk
+ _timescaledb_internal._hyper_1_25_chunk
+ _timescaledb_internal._hyper_1_26_chunk
+ _timescaledb_internal._hyper_1_27_chunk
+ _timescaledb_internal._hyper_1_28_chunk
+ _timescaledb_internal._hyper_1_29_chunk
+ _timescaledb_internal._hyper_1_30_chunk
+(10 rows)
+
+-- Aggregation with vectorization
+SELECT sum(segment_by_value) FROM testtable;
+  sum  
+-------
+ -3355
+(1 row)
+
+SELECT sum(int_value) FROM testtable;
+  sum  
+-------
+ -3355
+(1 row)
+
+---
+-- Tests with only positive values
+---
+TRUNCATE testtable;
+INSERT INTO testtable
+SELECT time AS time,
+value AS segment_by_value,
+value AS int_value,
+value AS float_value
+FROM
+generate_series('1980-01-01 00:00:00-00', '1980-03-01 00:00:00-00', INTERVAL '1 day') AS g1(time),
+generate_series(0, 10, 1) AS g2(value)
+ORDER BY time;
+-- Aggregation result without any vectorization
+SELECT sum(segment_by_value), sum(int_value), sum(float_value) FROM testtable;
+ sum  | sum  | sum  
+------+------+------
+ 3355 | 3355 | 3355
+(1 row)
+
+SELECT compress_chunk(ch) FROM show_chunks('testtable') ch;
+             compress_chunk              
+-----------------------------------------
+ _timescaledb_internal._hyper_1_41_chunk
+ _timescaledb_internal._hyper_1_42_chunk
+ _timescaledb_internal._hyper_1_43_chunk
+ _timescaledb_internal._hyper_1_44_chunk
+ _timescaledb_internal._hyper_1_45_chunk
+ _timescaledb_internal._hyper_1_46_chunk
+ _timescaledb_internal._hyper_1_47_chunk
+ _timescaledb_internal._hyper_1_48_chunk
+ _timescaledb_internal._hyper_1_49_chunk
+ _timescaledb_internal._hyper_1_50_chunk
+(10 rows)
+
+-- Aggregation with vectorization
+SELECT sum(segment_by_value) FROM testtable;
+ sum  
+------
+ 3355
+(1 row)
+
+SELECT sum(int_value) FROM testtable;
+ sum  
+------
+ 3355
+(1 row)
+
+---
+-- Tests with parallel plans
+---
+SET parallel_leader_participation = off;
+SET min_parallel_table_scan_size = 0;
+SET parallel_setup_cost = 0;
+SET parallel_tuple_cost = 0;
+:EXPLAIN
+SELECT sum(segment_by_value) FROM testtable;
+                                                                                                                                                                                QUERY PLAN                                                                                                                                                                                 
+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Finalize Aggregate
+   Output: sum(_hyper_1_41_chunk.segment_by_value)
+   ->  Gather
+         Output: (PARTIAL sum(_hyper_1_41_chunk.segment_by_value))
+         Workers Planned: 2
+         ->  Parallel Append
+               ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_41_chunk
+                     Output: (PARTIAL sum(_hyper_1_41_chunk.segment_by_value))
+                     Vectorized Aggregation: true
+                     ->  Parallel Seq Scan on _timescaledb_internal.compress_hyper_2_51_chunk
+                           Output: compress_hyper_2_51_chunk."time", compress_hyper_2_51_chunk.segment_by_value, compress_hyper_2_51_chunk.int_value, compress_hyper_2_51_chunk.float_value, compress_hyper_2_51_chunk._ts_meta_count, compress_hyper_2_51_chunk._ts_meta_sequence_num, compress_hyper_2_51_chunk._ts_meta_min_1, compress_hyper_2_51_chunk._ts_meta_max_1
+               ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_42_chunk
+                     Output: (PARTIAL sum(_hyper_1_42_chunk.segment_by_value))
+                     Vectorized Aggregation: true
+                     ->  Parallel Seq Scan on _timescaledb_internal.compress_hyper_2_52_chunk
+                           Output: compress_hyper_2_52_chunk."time", compress_hyper_2_52_chunk.segment_by_value, compress_hyper_2_52_chunk.int_value, compress_hyper_2_52_chunk.float_value, compress_hyper_2_52_chunk._ts_meta_count, compress_hyper_2_52_chunk._ts_meta_sequence_num, compress_hyper_2_52_chunk._ts_meta_min_1, compress_hyper_2_52_chunk._ts_meta_max_1
+               ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_43_chunk
+                     Output: (PARTIAL sum(_hyper_1_43_chunk.segment_by_value))
+                     Vectorized Aggregation: true
+                     ->  Parallel Seq Scan on _timescaledb_internal.compress_hyper_2_53_chunk
+                           Output: compress_hyper_2_53_chunk."time", compress_hyper_2_53_chunk.segment_by_value, compress_hyper_2_53_chunk.int_value, compress_hyper_2_53_chunk.float_value, compress_hyper_2_53_chunk._ts_meta_count, compress_hyper_2_53_chunk._ts_meta_sequence_num, compress_hyper_2_53_chunk._ts_meta_min_1, compress_hyper_2_53_chunk._ts_meta_max_1
+               ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_44_chunk
+                     Output: (PARTIAL sum(_hyper_1_44_chunk.segment_by_value))
+                     Vectorized Aggregation: true
+                     ->  Parallel Seq Scan on _timescaledb_internal.compress_hyper_2_54_chunk
+                           Output: compress_hyper_2_54_chunk."time", compress_hyper_2_54_chunk.segment_by_value, compress_hyper_2_54_chunk.int_value, compress_hyper_2_54_chunk.float_value, compress_hyper_2_54_chunk._ts_meta_count, compress_hyper_2_54_chunk._ts_meta_sequence_num, compress_hyper_2_54_chunk._ts_meta_min_1, compress_hyper_2_54_chunk._ts_meta_max_1
+               ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_45_chunk
+                     Output: (PARTIAL sum(_hyper_1_45_chunk.segment_by_value))
+                     Vectorized Aggregation: true
+                     ->  Parallel Seq Scan on _timescaledb_internal.compress_hyper_2_55_chunk
+                           Output: compress_hyper_2_55_chunk."time", compress_hyper_2_55_chunk.segment_by_value, compress_hyper_2_55_chunk.int_value, compress_hyper_2_55_chunk.float_value, compress_hyper_2_55_chunk._ts_meta_count, compress_hyper_2_55_chunk._ts_meta_sequence_num, compress_hyper_2_55_chunk._ts_meta_min_1, compress_hyper_2_55_chunk._ts_meta_max_1
+               ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_46_chunk
+                     Output: (PARTIAL sum(_hyper_1_46_chunk.segment_by_value))
+                     Vectorized Aggregation: true
+                     ->  Parallel Seq Scan on _timescaledb_internal.compress_hyper_2_56_chunk
+                           Output: compress_hyper_2_56_chunk."time", compress_hyper_2_56_chunk.segment_by_value, compress_hyper_2_56_chunk.int_value, compress_hyper_2_56_chunk.float_value, compress_hyper_2_56_chunk._ts_meta_count, compress_hyper_2_56_chunk._ts_meta_sequence_num, compress_hyper_2_56_chunk._ts_meta_min_1, compress_hyper_2_56_chunk._ts_meta_max_1
+               ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_47_chunk
+                     Output: (PARTIAL sum(_hyper_1_47_chunk.segment_by_value))
+                     Vectorized Aggregation: true
+                     ->  Parallel Seq Scan on _timescaledb_internal.compress_hyper_2_57_chunk
+                           Output: compress_hyper_2_57_chunk."time", compress_hyper_2_57_chunk.segment_by_value, compress_hyper_2_57_chunk.int_value, compress_hyper_2_57_chunk.float_value, compress_hyper_2_57_chunk._ts_meta_count, compress_hyper_2_57_chunk._ts_meta_sequence_num, compress_hyper_2_57_chunk._ts_meta_min_1, compress_hyper_2_57_chunk._ts_meta_max_1
+               ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_48_chunk
+                     Output: (PARTIAL sum(_hyper_1_48_chunk.segment_by_value))
+                     Vectorized Aggregation: true
+                     ->  Parallel Seq Scan on _timescaledb_internal.compress_hyper_2_58_chunk
+                           Output: compress_hyper_2_58_chunk."time", compress_hyper_2_58_chunk.segment_by_value, compress_hyper_2_58_chunk.int_value, compress_hyper_2_58_chunk.float_value, compress_hyper_2_58_chunk._ts_meta_count, compress_hyper_2_58_chunk._ts_meta_sequence_num, compress_hyper_2_58_chunk._ts_meta_min_1, compress_hyper_2_58_chunk._ts_meta_max_1
+               ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_49_chunk
+                     Output: (PARTIAL sum(_hyper_1_49_chunk.segment_by_value))
+                     Vectorized Aggregation: true
+                     ->  Parallel Seq Scan on _timescaledb_internal.compress_hyper_2_59_chunk
+                           Output: compress_hyper_2_59_chunk."time", compress_hyper_2_59_chunk.segment_by_value, compress_hyper_2_59_chunk.int_value, compress_hyper_2_59_chunk.float_value, compress_hyper_2_59_chunk._ts_meta_count, compress_hyper_2_59_chunk._ts_meta_sequence_num, compress_hyper_2_59_chunk._ts_meta_min_1, compress_hyper_2_59_chunk._ts_meta_max_1
+               ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_50_chunk
+                     Output: (PARTIAL sum(_hyper_1_50_chunk.segment_by_value))
+                     Vectorized Aggregation: true
+                     ->  Parallel Seq Scan on _timescaledb_internal.compress_hyper_2_60_chunk
+                           Output: compress_hyper_2_60_chunk."time", compress_hyper_2_60_chunk.segment_by_value, compress_hyper_2_60_chunk.int_value, compress_hyper_2_60_chunk.float_value, compress_hyper_2_60_chunk._ts_meta_count, compress_hyper_2_60_chunk._ts_meta_sequence_num, compress_hyper_2_60_chunk._ts_meta_min_1, compress_hyper_2_60_chunk._ts_meta_max_1
+(56 rows)
+
+SELECT sum(segment_by_value) FROM testtable;
+ sum  
+------
+ 3355
+(1 row)
+
+RESET parallel_leader_participation;
+RESET min_parallel_table_scan_size;
+RESET parallel_setup_cost;
+RESET parallel_tuple_cost;
+---
+-- Tests with only zero values
+---
+TRUNCATE testtable;
+INSERT INTO testtable
+SELECT time AS time,
+0 AS segment_by_value,
+0 AS int_value,
+0 AS float_value
+FROM
+generate_series('1980-01-01 00:00:00-00', '1980-03-01 00:00:00-00', INTERVAL '1 day') AS g1(time)
+ORDER BY time;
+-- Aggregation result without any vectorization
+SELECT sum(segment_by_value), sum(int_value), sum(float_value) FROM testtable;
+ sum | sum | sum 
+-----+-----+-----
+   0 |   0 |   0
+(1 row)
+
+SELECT compress_chunk(ch) FROM show_chunks('testtable') ch;
+             compress_chunk              
+-----------------------------------------
+ _timescaledb_internal._hyper_1_61_chunk
+ _timescaledb_internal._hyper_1_62_chunk
+ _timescaledb_internal._hyper_1_63_chunk
+ _timescaledb_internal._hyper_1_64_chunk
+ _timescaledb_internal._hyper_1_65_chunk
+ _timescaledb_internal._hyper_1_66_chunk
+ _timescaledb_internal._hyper_1_67_chunk
+ _timescaledb_internal._hyper_1_68_chunk
+ _timescaledb_internal._hyper_1_69_chunk
+ _timescaledb_internal._hyper_1_70_chunk
+(10 rows)
+
+-- Aggregation with vectorization
+SELECT sum(segment_by_value) FROM testtable;
+ sum 
+-----
+   0
+(1 row)
+
+SELECT sum(int_value) FROM testtable;
+ sum 
+-----
+   0
+(1 row)
+
+---
+-- Tests with null values
+---
+TRUNCATE testtable;
+INSERT INTO testtable
+SELECT time AS time,
+value AS segment_by_value,
+value AS int_value,
+value AS float_value
+FROM
+generate_series('1980-01-01 00:00:00-00', '1980-03-01 00:00:00-00', INTERVAL '1 day') AS g1(time),
+generate_series(0, 10, 1) AS g2(value)
+ORDER BY time;
+-- NULL values for compressed data
+INSERT INTO testtable
+SELECT time AS time,
+value AS segment_by_value,
+NULL AS int_value,
+NULL AS float_value
+FROM
+generate_series('1980-01-01 00:00:00-00', '1980-03-01 00:00:00-00', INTERVAL '1 day') AS g1(time),
+generate_series(0, 5, 1) AS g2(value)
+ORDER BY time;
+-- NULL values for segment_by
+INSERT INTO testtable
+SELECT time AS time,
+NULL AS segment_by_value,
+value AS int_value,
+value AS float_value
+FROM
+generate_series('1980-01-01 00:00:00-00', '1980-03-01 00:00:00-00', INTERVAL '1 day') AS g1(time),
+generate_series(0, 2, 1) AS g2(value)
+ORDER BY time;
+-- Aggregation result without any vectorization
+SELECT sum(segment_by_value), sum(int_value), sum(float_value) FROM testtable;
+ sum  | sum  | sum  
+------+------+------
+ 4270 | 3538 | 3538
+(1 row)
+
+SELECT compress_chunk(ch) FROM show_chunks('testtable') ch;
+             compress_chunk              
+-----------------------------------------
+ _timescaledb_internal._hyper_1_81_chunk
+ _timescaledb_internal._hyper_1_82_chunk
+ _timescaledb_internal._hyper_1_83_chunk
+ _timescaledb_internal._hyper_1_84_chunk
+ _timescaledb_internal._hyper_1_85_chunk
+ _timescaledb_internal._hyper_1_86_chunk
+ _timescaledb_internal._hyper_1_87_chunk
+ _timescaledb_internal._hyper_1_88_chunk
+ _timescaledb_internal._hyper_1_89_chunk
+ _timescaledb_internal._hyper_1_90_chunk
+(10 rows)
+
+-- Aggregation with vectorization
+:EXPLAIN
+SELECT sum(segment_by_value) FROM testtable;
+                                                                                                                                                                                 QUERY PLAN                                                                                                                                                                                  
+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Finalize Aggregate
+   Output: sum(_hyper_1_81_chunk.segment_by_value)
+   ->  Append
+         ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_81_chunk
+               Output: (PARTIAL sum(_hyper_1_81_chunk.segment_by_value))
+               Vectorized Aggregation: true
+               ->  Seq Scan on _timescaledb_internal.compress_hyper_2_91_chunk
+                     Output: compress_hyper_2_91_chunk."time", compress_hyper_2_91_chunk.segment_by_value, compress_hyper_2_91_chunk.int_value, compress_hyper_2_91_chunk.float_value, compress_hyper_2_91_chunk._ts_meta_count, compress_hyper_2_91_chunk._ts_meta_sequence_num, compress_hyper_2_91_chunk._ts_meta_min_1, compress_hyper_2_91_chunk._ts_meta_max_1
+         ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_82_chunk
+               Output: (PARTIAL sum(_hyper_1_82_chunk.segment_by_value))
+               Vectorized Aggregation: true
+               ->  Seq Scan on _timescaledb_internal.compress_hyper_2_92_chunk
+                     Output: compress_hyper_2_92_chunk."time", compress_hyper_2_92_chunk.segment_by_value, compress_hyper_2_92_chunk.int_value, compress_hyper_2_92_chunk.float_value, compress_hyper_2_92_chunk._ts_meta_count, compress_hyper_2_92_chunk._ts_meta_sequence_num, compress_hyper_2_92_chunk._ts_meta_min_1, compress_hyper_2_92_chunk._ts_meta_max_1
+         ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_83_chunk
+               Output: (PARTIAL sum(_hyper_1_83_chunk.segment_by_value))
+               Vectorized Aggregation: true
+               ->  Seq Scan on _timescaledb_internal.compress_hyper_2_93_chunk
+                     Output: compress_hyper_2_93_chunk."time", compress_hyper_2_93_chunk.segment_by_value, compress_hyper_2_93_chunk.int_value, compress_hyper_2_93_chunk.float_value, compress_hyper_2_93_chunk._ts_meta_count, compress_hyper_2_93_chunk._ts_meta_sequence_num, compress_hyper_2_93_chunk._ts_meta_min_1, compress_hyper_2_93_chunk._ts_meta_max_1
+         ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_84_chunk
+               Output: (PARTIAL sum(_hyper_1_84_chunk.segment_by_value))
+               Vectorized Aggregation: true
+               ->  Seq Scan on _timescaledb_internal.compress_hyper_2_94_chunk
+                     Output: compress_hyper_2_94_chunk."time", compress_hyper_2_94_chunk.segment_by_value, compress_hyper_2_94_chunk.int_value, compress_hyper_2_94_chunk.float_value, compress_hyper_2_94_chunk._ts_meta_count, compress_hyper_2_94_chunk._ts_meta_sequence_num, compress_hyper_2_94_chunk._ts_meta_min_1, compress_hyper_2_94_chunk._ts_meta_max_1
+         ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_85_chunk
+               Output: (PARTIAL sum(_hyper_1_85_chunk.segment_by_value))
+               Vectorized Aggregation: true
+               ->  Seq Scan on _timescaledb_internal.compress_hyper_2_95_chunk
+                     Output: compress_hyper_2_95_chunk."time", compress_hyper_2_95_chunk.segment_by_value, compress_hyper_2_95_chunk.int_value, compress_hyper_2_95_chunk.float_value, compress_hyper_2_95_chunk._ts_meta_count, compress_hyper_2_95_chunk._ts_meta_sequence_num, compress_hyper_2_95_chunk._ts_meta_min_1, compress_hyper_2_95_chunk._ts_meta_max_1
+         ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_86_chunk
+               Output: (PARTIAL sum(_hyper_1_86_chunk.segment_by_value))
+               Vectorized Aggregation: true
+               ->  Seq Scan on _timescaledb_internal.compress_hyper_2_96_chunk
+                     Output: compress_hyper_2_96_chunk."time", compress_hyper_2_96_chunk.segment_by_value, compress_hyper_2_96_chunk.int_value, compress_hyper_2_96_chunk.float_value, compress_hyper_2_96_chunk._ts_meta_count, compress_hyper_2_96_chunk._ts_meta_sequence_num, compress_hyper_2_96_chunk._ts_meta_min_1, compress_hyper_2_96_chunk._ts_meta_max_1
+         ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_87_chunk
+               Output: (PARTIAL sum(_hyper_1_87_chunk.segment_by_value))
+               Vectorized Aggregation: true
+               ->  Seq Scan on _timescaledb_internal.compress_hyper_2_97_chunk
+                     Output: compress_hyper_2_97_chunk."time", compress_hyper_2_97_chunk.segment_by_value, compress_hyper_2_97_chunk.int_value, compress_hyper_2_97_chunk.float_value, compress_hyper_2_97_chunk._ts_meta_count, compress_hyper_2_97_chunk._ts_meta_sequence_num, compress_hyper_2_97_chunk._ts_meta_min_1, compress_hyper_2_97_chunk._ts_meta_max_1
+         ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_88_chunk
+               Output: (PARTIAL sum(_hyper_1_88_chunk.segment_by_value))
+               Vectorized Aggregation: true
+               ->  Seq Scan on _timescaledb_internal.compress_hyper_2_98_chunk
+                     Output: compress_hyper_2_98_chunk."time", compress_hyper_2_98_chunk.segment_by_value, compress_hyper_2_98_chunk.int_value, compress_hyper_2_98_chunk.float_value, compress_hyper_2_98_chunk._ts_meta_count, compress_hyper_2_98_chunk._ts_meta_sequence_num, compress_hyper_2_98_chunk._ts_meta_min_1, compress_hyper_2_98_chunk._ts_meta_max_1
+         ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_89_chunk
+               Output: (PARTIAL sum(_hyper_1_89_chunk.segment_by_value))
+               Vectorized Aggregation: true
+               ->  Seq Scan on _timescaledb_internal.compress_hyper_2_99_chunk
+                     Output: compress_hyper_2_99_chunk."time", compress_hyper_2_99_chunk.segment_by_value, compress_hyper_2_99_chunk.int_value, compress_hyper_2_99_chunk.float_value, compress_hyper_2_99_chunk._ts_meta_count, compress_hyper_2_99_chunk._ts_meta_sequence_num, compress_hyper_2_99_chunk._ts_meta_min_1, compress_hyper_2_99_chunk._ts_meta_max_1
+         ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_90_chunk
+               Output: (PARTIAL sum(_hyper_1_90_chunk.segment_by_value))
+               Vectorized Aggregation: true
+               ->  Seq Scan on _timescaledb_internal.compress_hyper_2_100_chunk
+                     Output: compress_hyper_2_100_chunk."time", compress_hyper_2_100_chunk.segment_by_value, compress_hyper_2_100_chunk.int_value, compress_hyper_2_100_chunk.float_value, compress_hyper_2_100_chunk._ts_meta_count, compress_hyper_2_100_chunk._ts_meta_sequence_num, compress_hyper_2_100_chunk._ts_meta_min_1, compress_hyper_2_100_chunk._ts_meta_max_1
+(53 rows)
+
+:EXPLAIN
+SELECT sum(int_value) FROM testtable;
+                                                                                                                                                                                 QUERY PLAN                                                                                                                                                                                  
+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Finalize Aggregate
+   Output: sum(_hyper_1_81_chunk.int_value)
+   ->  Append
+         ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_81_chunk
+               Output: (PARTIAL sum(_hyper_1_81_chunk.int_value))
+               Vectorized Aggregation: true
+               ->  Seq Scan on _timescaledb_internal.compress_hyper_2_91_chunk
+                     Output: compress_hyper_2_91_chunk."time", compress_hyper_2_91_chunk.segment_by_value, compress_hyper_2_91_chunk.int_value, compress_hyper_2_91_chunk.float_value, compress_hyper_2_91_chunk._ts_meta_count, compress_hyper_2_91_chunk._ts_meta_sequence_num, compress_hyper_2_91_chunk._ts_meta_min_1, compress_hyper_2_91_chunk._ts_meta_max_1
+         ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_82_chunk
+               Output: (PARTIAL sum(_hyper_1_82_chunk.int_value))
+               Vectorized Aggregation: true
+               ->  Seq Scan on _timescaledb_internal.compress_hyper_2_92_chunk
+                     Output: compress_hyper_2_92_chunk."time", compress_hyper_2_92_chunk.segment_by_value, compress_hyper_2_92_chunk.int_value, compress_hyper_2_92_chunk.float_value, compress_hyper_2_92_chunk._ts_meta_count, compress_hyper_2_92_chunk._ts_meta_sequence_num, compress_hyper_2_92_chunk._ts_meta_min_1, compress_hyper_2_92_chunk._ts_meta_max_1
+         ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_83_chunk
+               Output: (PARTIAL sum(_hyper_1_83_chunk.int_value))
+               Vectorized Aggregation: true
+               ->  Seq Scan on _timescaledb_internal.compress_hyper_2_93_chunk
+                     Output: compress_hyper_2_93_chunk."time", compress_hyper_2_93_chunk.segment_by_value, compress_hyper_2_93_chunk.int_value, compress_hyper_2_93_chunk.float_value, compress_hyper_2_93_chunk._ts_meta_count, compress_hyper_2_93_chunk._ts_meta_sequence_num, compress_hyper_2_93_chunk._ts_meta_min_1, compress_hyper_2_93_chunk._ts_meta_max_1
+         ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_84_chunk
+               Output: (PARTIAL sum(_hyper_1_84_chunk.int_value))
+               Vectorized Aggregation: true
+               ->  Seq Scan on _timescaledb_internal.compress_hyper_2_94_chunk
+                     Output: compress_hyper_2_94_chunk."time", compress_hyper_2_94_chunk.segment_by_value, compress_hyper_2_94_chunk.int_value, compress_hyper_2_94_chunk.float_value, compress_hyper_2_94_chunk._ts_meta_count, compress_hyper_2_94_chunk._ts_meta_sequence_num, compress_hyper_2_94_chunk._ts_meta_min_1, compress_hyper_2_94_chunk._ts_meta_max_1
+         ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_85_chunk
+               Output: (PARTIAL sum(_hyper_1_85_chunk.int_value))
+               Vectorized Aggregation: true
+               ->  Seq Scan on _timescaledb_internal.compress_hyper_2_95_chunk
+                     Output: compress_hyper_2_95_chunk."time", compress_hyper_2_95_chunk.segment_by_value, compress_hyper_2_95_chunk.int_value, compress_hyper_2_95_chunk.float_value, compress_hyper_2_95_chunk._ts_meta_count, compress_hyper_2_95_chunk._ts_meta_sequence_num, compress_hyper_2_95_chunk._ts_meta_min_1, compress_hyper_2_95_chunk._ts_meta_max_1
+         ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_86_chunk
+               Output: (PARTIAL sum(_hyper_1_86_chunk.int_value))
+               Vectorized Aggregation: true
+               ->  Seq Scan on _timescaledb_internal.compress_hyper_2_96_chunk
+                     Output: compress_hyper_2_96_chunk."time", compress_hyper_2_96_chunk.segment_by_value, compress_hyper_2_96_chunk.int_value, compress_hyper_2_96_chunk.float_value, compress_hyper_2_96_chunk._ts_meta_count, compress_hyper_2_96_chunk._ts_meta_sequence_num, compress_hyper_2_96_chunk._ts_meta_min_1, compress_hyper_2_96_chunk._ts_meta_max_1
+         ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_87_chunk
+               Output: (PARTIAL sum(_hyper_1_87_chunk.int_value))
+               Vectorized Aggregation: true
+               ->  Seq Scan on _timescaledb_internal.compress_hyper_2_97_chunk
+                     Output: compress_hyper_2_97_chunk."time", compress_hyper_2_97_chunk.segment_by_value, compress_hyper_2_97_chunk.int_value, compress_hyper_2_97_chunk.float_value, compress_hyper_2_97_chunk._ts_meta_count, compress_hyper_2_97_chunk._ts_meta_sequence_num, compress_hyper_2_97_chunk._ts_meta_min_1, compress_hyper_2_97_chunk._ts_meta_max_1
+         ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_88_chunk
+               Output: (PARTIAL sum(_hyper_1_88_chunk.int_value))
+               Vectorized Aggregation: true
+               ->  Seq Scan on _timescaledb_internal.compress_hyper_2_98_chunk
+                     Output: compress_hyper_2_98_chunk."time", compress_hyper_2_98_chunk.segment_by_value, compress_hyper_2_98_chunk.int_value, compress_hyper_2_98_chunk.float_value, compress_hyper_2_98_chunk._ts_meta_count, compress_hyper_2_98_chunk._ts_meta_sequence_num, compress_hyper_2_98_chunk._ts_meta_min_1, compress_hyper_2_98_chunk._ts_meta_max_1
+         ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_89_chunk
+               Output: (PARTIAL sum(_hyper_1_89_chunk.int_value))
+               Vectorized Aggregation: true
+               ->  Seq Scan on _timescaledb_internal.compress_hyper_2_99_chunk
+                     Output: compress_hyper_2_99_chunk."time", compress_hyper_2_99_chunk.segment_by_value, compress_hyper_2_99_chunk.int_value, compress_hyper_2_99_chunk.float_value, compress_hyper_2_99_chunk._ts_meta_count, compress_hyper_2_99_chunk._ts_meta_sequence_num, compress_hyper_2_99_chunk._ts_meta_min_1, compress_hyper_2_99_chunk._ts_meta_max_1
+         ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_90_chunk
+               Output: (PARTIAL sum(_hyper_1_90_chunk.int_value))
+               Vectorized Aggregation: true
+               ->  Seq Scan on _timescaledb_internal.compress_hyper_2_100_chunk
+                     Output: compress_hyper_2_100_chunk."time", compress_hyper_2_100_chunk.segment_by_value, compress_hyper_2_100_chunk.int_value, compress_hyper_2_100_chunk.float_value, compress_hyper_2_100_chunk._ts_meta_count, compress_hyper_2_100_chunk._ts_meta_sequence_num, compress_hyper_2_100_chunk._ts_meta_min_1, compress_hyper_2_100_chunk._ts_meta_max_1
+(53 rows)
+
+SELECT sum(segment_by_value) FROM testtable;
+ sum  
+------
+ 4270
+(1 row)
+
+SELECT sum(int_value) FROM testtable;
+ sum  
+------
+ 3538
+(1 row)
+
+-- Aggregation filters are not supported at the moment
+:EXPLAIN
+SELECT sum(segment_by_value) FILTER (WHERE segment_by_value > 99999) FROM testtable;
+                                                                                                                                                                                       QUERY PLAN                                                                                                                                                                                        
+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Finalize Aggregate
+   Output: sum(_hyper_1_81_chunk.segment_by_value) FILTER (WHERE (_hyper_1_81_chunk.segment_by_value > 99999))
+   ->  Gather
+         Output: (PARTIAL sum(_hyper_1_81_chunk.segment_by_value) FILTER (WHERE (_hyper_1_81_chunk.segment_by_value > 99999)))
+         Workers Planned: 2
+         ->  Parallel Append
+               ->  Partial Aggregate
+                     Output: PARTIAL sum(_hyper_1_81_chunk.segment_by_value) FILTER (WHERE (_hyper_1_81_chunk.segment_by_value > 99999))
+                     ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_81_chunk
+                           Output: _hyper_1_81_chunk.segment_by_value
+                           ->  Parallel Seq Scan on _timescaledb_internal.compress_hyper_2_91_chunk
+                                 Output: compress_hyper_2_91_chunk."time", compress_hyper_2_91_chunk.segment_by_value, compress_hyper_2_91_chunk.int_value, compress_hyper_2_91_chunk.float_value, compress_hyper_2_91_chunk._ts_meta_count, compress_hyper_2_91_chunk._ts_meta_sequence_num, compress_hyper_2_91_chunk._ts_meta_min_1, compress_hyper_2_91_chunk._ts_meta_max_1
+               ->  Partial Aggregate
+                     Output: PARTIAL sum(_hyper_1_82_chunk.segment_by_value) FILTER (WHERE (_hyper_1_82_chunk.segment_by_value > 99999))
+                     ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_82_chunk
+                           Output: _hyper_1_82_chunk.segment_by_value
+                           ->  Parallel Seq Scan on _timescaledb_internal.compress_hyper_2_92_chunk
+                                 Output: compress_hyper_2_92_chunk."time", compress_hyper_2_92_chunk.segment_by_value, compress_hyper_2_92_chunk.int_value, compress_hyper_2_92_chunk.float_value, compress_hyper_2_92_chunk._ts_meta_count, compress_hyper_2_92_chunk._ts_meta_sequence_num, compress_hyper_2_92_chunk._ts_meta_min_1, compress_hyper_2_92_chunk._ts_meta_max_1
+               ->  Partial Aggregate
+                     Output: PARTIAL sum(_hyper_1_83_chunk.segment_by_value) FILTER (WHERE (_hyper_1_83_chunk.segment_by_value > 99999))
+                     ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_83_chunk
+                           Output: _hyper_1_83_chunk.segment_by_value
+                           ->  Parallel Seq Scan on _timescaledb_internal.compress_hyper_2_93_chunk
+                                 Output: compress_hyper_2_93_chunk."time", compress_hyper_2_93_chunk.segment_by_value, compress_hyper_2_93_chunk.int_value, compress_hyper_2_93_chunk.float_value, compress_hyper_2_93_chunk._ts_meta_count, compress_hyper_2_93_chunk._ts_meta_sequence_num, compress_hyper_2_93_chunk._ts_meta_min_1, compress_hyper_2_93_chunk._ts_meta_max_1
+               ->  Partial Aggregate
+                     Output: PARTIAL sum(_hyper_1_84_chunk.segment_by_value) FILTER (WHERE (_hyper_1_84_chunk.segment_by_value > 99999))
+                     ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_84_chunk
+                           Output: _hyper_1_84_chunk.segment_by_value
+                           ->  Parallel Seq Scan on _timescaledb_internal.compress_hyper_2_94_chunk
+                                 Output: compress_hyper_2_94_chunk."time", compress_hyper_2_94_chunk.segment_by_value, compress_hyper_2_94_chunk.int_value, compress_hyper_2_94_chunk.float_value, compress_hyper_2_94_chunk._ts_meta_count, compress_hyper_2_94_chunk._ts_meta_sequence_num, compress_hyper_2_94_chunk._ts_meta_min_1, compress_hyper_2_94_chunk._ts_meta_max_1
+               ->  Partial Aggregate
+                     Output: PARTIAL sum(_hyper_1_85_chunk.segment_by_value) FILTER (WHERE (_hyper_1_85_chunk.segment_by_value > 99999))
+                     ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_85_chunk
+                           Output: _hyper_1_85_chunk.segment_by_value
+                           ->  Parallel Seq Scan on _timescaledb_internal.compress_hyper_2_95_chunk
+                                 Output: compress_hyper_2_95_chunk."time", compress_hyper_2_95_chunk.segment_by_value, compress_hyper_2_95_chunk.int_value, compress_hyper_2_95_chunk.float_value, compress_hyper_2_95_chunk._ts_meta_count, compress_hyper_2_95_chunk._ts_meta_sequence_num, compress_hyper_2_95_chunk._ts_meta_min_1, compress_hyper_2_95_chunk._ts_meta_max_1
+               ->  Partial Aggregate
+                     Output: PARTIAL sum(_hyper_1_86_chunk.segment_by_value) FILTER (WHERE (_hyper_1_86_chunk.segment_by_value > 99999))
+                     ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_86_chunk
+                           Output: _hyper_1_86_chunk.segment_by_value
+                           ->  Parallel Seq Scan on _timescaledb_internal.compress_hyper_2_96_chunk
+                                 Output: compress_hyper_2_96_chunk."time", compress_hyper_2_96_chunk.segment_by_value, compress_hyper_2_96_chunk.int_value, compress_hyper_2_96_chunk.float_value, compress_hyper_2_96_chunk._ts_meta_count, compress_hyper_2_96_chunk._ts_meta_sequence_num, compress_hyper_2_96_chunk._ts_meta_min_1, compress_hyper_2_96_chunk._ts_meta_max_1
+               ->  Partial Aggregate
+                     Output: PARTIAL sum(_hyper_1_87_chunk.segment_by_value) FILTER (WHERE (_hyper_1_87_chunk.segment_by_value > 99999))
+                     ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_87_chunk
+                           Output: _hyper_1_87_chunk.segment_by_value
+                           ->  Parallel Seq Scan on _timescaledb_internal.compress_hyper_2_97_chunk
+                                 Output: compress_hyper_2_97_chunk."time", compress_hyper_2_97_chunk.segment_by_value, compress_hyper_2_97_chunk.int_value, compress_hyper_2_97_chunk.float_value, compress_hyper_2_97_chunk._ts_meta_count, compress_hyper_2_97_chunk._ts_meta_sequence_num, compress_hyper_2_97_chunk._ts_meta_min_1, compress_hyper_2_97_chunk._ts_meta_max_1
+               ->  Partial Aggregate
+                     Output: PARTIAL sum(_hyper_1_88_chunk.segment_by_value) FILTER (WHERE (_hyper_1_88_chunk.segment_by_value > 99999))
+                     ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_88_chunk
+                           Output: _hyper_1_88_chunk.segment_by_value
+                           ->  Parallel Seq Scan on _timescaledb_internal.compress_hyper_2_98_chunk
+                                 Output: compress_hyper_2_98_chunk."time", compress_hyper_2_98_chunk.segment_by_value, compress_hyper_2_98_chunk.int_value, compress_hyper_2_98_chunk.float_value, compress_hyper_2_98_chunk._ts_meta_count, compress_hyper_2_98_chunk._ts_meta_sequence_num, compress_hyper_2_98_chunk._ts_meta_min_1, compress_hyper_2_98_chunk._ts_meta_max_1
+               ->  Partial Aggregate
+                     Output: PARTIAL sum(_hyper_1_89_chunk.segment_by_value) FILTER (WHERE (_hyper_1_89_chunk.segment_by_value > 99999))
+                     ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_89_chunk
+                           Output: _hyper_1_89_chunk.segment_by_value
+                           ->  Parallel Seq Scan on _timescaledb_internal.compress_hyper_2_99_chunk
+                                 Output: compress_hyper_2_99_chunk."time", compress_hyper_2_99_chunk.segment_by_value, compress_hyper_2_99_chunk.int_value, compress_hyper_2_99_chunk.float_value, compress_hyper_2_99_chunk._ts_meta_count, compress_hyper_2_99_chunk._ts_meta_sequence_num, compress_hyper_2_99_chunk._ts_meta_min_1, compress_hyper_2_99_chunk._ts_meta_max_1
+               ->  Partial Aggregate
+                     Output: PARTIAL sum(_hyper_1_90_chunk.segment_by_value) FILTER (WHERE (_hyper_1_90_chunk.segment_by_value > 99999))
+                     ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_90_chunk
+                           Output: _hyper_1_90_chunk.segment_by_value
+                           ->  Parallel Seq Scan on _timescaledb_internal.compress_hyper_2_100_chunk
+                                 Output: compress_hyper_2_100_chunk."time", compress_hyper_2_100_chunk.segment_by_value, compress_hyper_2_100_chunk.int_value, compress_hyper_2_100_chunk.float_value, compress_hyper_2_100_chunk._ts_meta_count, compress_hyper_2_100_chunk._ts_meta_sequence_num, compress_hyper_2_100_chunk._ts_meta_min_1, compress_hyper_2_100_chunk._ts_meta_max_1
+(66 rows)
+
+SET timescaledb.vectorized_aggregation = OFF;
+SELECT sum(segment_by_value) FILTER (WHERE segment_by_value > 99999) FROM testtable;
+ sum 
+-----
+    
+(1 row)
+
+RESET timescaledb.vectorized_aggregation;
+SELECT sum(segment_by_value) FILTER (WHERE segment_by_value > 99999) FROM testtable;
+ sum 
+-----
+    
+(1 row)
+
+---
+-- Tests with multiple segment by values
+---
+CREATE TABLE testtable2 (
+time timestamptz NOT NULL,
+segment_by_value1 integer NOT NULL,
+segment_by_value2 integer NOT NULL,
+int_value integer NOT NULL,
+float_value double precision NOT NULL);
+SELECT FROM create_hypertable(relation=>'testtable2', time_column_name=> 'time');
+--
+(1 row)
+
+ALTER TABLE testtable2 SET (timescaledb.compress, timescaledb.compress_segmentby='segment_by_value1, segment_by_value2');
+INSERT INTO testtable2
+SELECT time AS time,
+value1 AS segment_by_value1,
+value2 AS segment_by_value2,
+value1 AS int_value,
+value1 AS float_value
+FROM
+generate_series('1980-01-01 00:00:00-00', '1980-03-01 00:00:00-00', INTERVAL '1 day') AS g1(time),
+generate_series(-10, 25, 1) AS g2(value1),
+generate_series(-30, 20, 1) AS g3(value2)
+ORDER BY time;
+-- Aggregation result without any vectorization
+SELECT sum(segment_by_value1), sum(segment_by_value2) FROM testtable2;
+  sum   |   sum   
+--------+---------
+ 839970 | -559980
+(1 row)
+
+SELECT compress_chunk(ch) FROM show_chunks('testtable2') ch;
+              compress_chunk              
+------------------------------------------
+ _timescaledb_internal._hyper_3_101_chunk
+ _timescaledb_internal._hyper_3_102_chunk
+ _timescaledb_internal._hyper_3_103_chunk
+ _timescaledb_internal._hyper_3_104_chunk
+ _timescaledb_internal._hyper_3_105_chunk
+ _timescaledb_internal._hyper_3_106_chunk
+ _timescaledb_internal._hyper_3_107_chunk
+ _timescaledb_internal._hyper_3_108_chunk
+ _timescaledb_internal._hyper_3_109_chunk
+ _timescaledb_internal._hyper_3_110_chunk
+(10 rows)
+
+:EXPLAIN
+SELECT sum(segment_by_value1) FROM testtable2;
+                                                                                                                                                                                                         QUERY PLAN                                                                                                                                                                                                         
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Finalize Aggregate
+   Output: sum(_hyper_3_101_chunk.segment_by_value1)
+   ->  Append
+         ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_3_101_chunk
+               Output: (PARTIAL sum(_hyper_3_101_chunk.segment_by_value1))
+               Vectorized Aggregation: true
+               ->  Seq Scan on _timescaledb_internal.compress_hyper_4_111_chunk
+                     Output: compress_hyper_4_111_chunk."time", compress_hyper_4_111_chunk.segment_by_value1, compress_hyper_4_111_chunk.segment_by_value2, compress_hyper_4_111_chunk.int_value, compress_hyper_4_111_chunk.float_value, compress_hyper_4_111_chunk._ts_meta_count, compress_hyper_4_111_chunk._ts_meta_sequence_num, compress_hyper_4_111_chunk._ts_meta_min_1, compress_hyper_4_111_chunk._ts_meta_max_1
+         ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_3_102_chunk
+               Output: (PARTIAL sum(_hyper_3_102_chunk.segment_by_value1))
+               Vectorized Aggregation: true
+               ->  Seq Scan on _timescaledb_internal.compress_hyper_4_112_chunk
+                     Output: compress_hyper_4_112_chunk."time", compress_hyper_4_112_chunk.segment_by_value1, compress_hyper_4_112_chunk.segment_by_value2, compress_hyper_4_112_chunk.int_value, compress_hyper_4_112_chunk.float_value, compress_hyper_4_112_chunk._ts_meta_count, compress_hyper_4_112_chunk._ts_meta_sequence_num, compress_hyper_4_112_chunk._ts_meta_min_1, compress_hyper_4_112_chunk._ts_meta_max_1
+         ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_3_103_chunk
+               Output: (PARTIAL sum(_hyper_3_103_chunk.segment_by_value1))
+               Vectorized Aggregation: true
+               ->  Seq Scan on _timescaledb_internal.compress_hyper_4_113_chunk
+                     Output: compress_hyper_4_113_chunk."time", compress_hyper_4_113_chunk.segment_by_value1, compress_hyper_4_113_chunk.segment_by_value2, compress_hyper_4_113_chunk.int_value, compress_hyper_4_113_chunk.float_value, compress_hyper_4_113_chunk._ts_meta_count, compress_hyper_4_113_chunk._ts_meta_sequence_num, compress_hyper_4_113_chunk._ts_meta_min_1, compress_hyper_4_113_chunk._ts_meta_max_1
+         ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_3_104_chunk
+               Output: (PARTIAL sum(_hyper_3_104_chunk.segment_by_value1))
+               Vectorized Aggregation: true
+               ->  Seq Scan on _timescaledb_internal.compress_hyper_4_114_chunk
+                     Output: compress_hyper_4_114_chunk."time", compress_hyper_4_114_chunk.segment_by_value1, compress_hyper_4_114_chunk.segment_by_value2, compress_hyper_4_114_chunk.int_value, compress_hyper_4_114_chunk.float_value, compress_hyper_4_114_chunk._ts_meta_count, compress_hyper_4_114_chunk._ts_meta_sequence_num, compress_hyper_4_114_chunk._ts_meta_min_1, compress_hyper_4_114_chunk._ts_meta_max_1
+         ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_3_105_chunk
+               Output: (PARTIAL sum(_hyper_3_105_chunk.segment_by_value1))
+               Vectorized Aggregation: true
+               ->  Seq Scan on _timescaledb_internal.compress_hyper_4_115_chunk
+                     Output: compress_hyper_4_115_chunk."time", compress_hyper_4_115_chunk.segment_by_value1, compress_hyper_4_115_chunk.segment_by_value2, compress_hyper_4_115_chunk.int_value, compress_hyper_4_115_chunk.float_value, compress_hyper_4_115_chunk._ts_meta_count, compress_hyper_4_115_chunk._ts_meta_sequence_num, compress_hyper_4_115_chunk._ts_meta_min_1, compress_hyper_4_115_chunk._ts_meta_max_1
+         ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_3_106_chunk
+               Output: (PARTIAL sum(_hyper_3_106_chunk.segment_by_value1))
+               Vectorized Aggregation: true
+               ->  Seq Scan on _timescaledb_internal.compress_hyper_4_116_chunk
+                     Output: compress_hyper_4_116_chunk."time", compress_hyper_4_116_chunk.segment_by_value1, compress_hyper_4_116_chunk.segment_by_value2, compress_hyper_4_116_chunk.int_value, compress_hyper_4_116_chunk.float_value, compress_hyper_4_116_chunk._ts_meta_count, compress_hyper_4_116_chunk._ts_meta_sequence_num, compress_hyper_4_116_chunk._ts_meta_min_1, compress_hyper_4_116_chunk._ts_meta_max_1
+         ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_3_107_chunk
+               Output: (PARTIAL sum(_hyper_3_107_chunk.segment_by_value1))
+               Vectorized Aggregation: true
+               ->  Seq Scan on _timescaledb_internal.compress_hyper_4_117_chunk
+                     Output: compress_hyper_4_117_chunk."time", compress_hyper_4_117_chunk.segment_by_value1, compress_hyper_4_117_chunk.segment_by_value2, compress_hyper_4_117_chunk.int_value, compress_hyper_4_117_chunk.float_value, compress_hyper_4_117_chunk._ts_meta_count, compress_hyper_4_117_chunk._ts_meta_sequence_num, compress_hyper_4_117_chunk._ts_meta_min_1, compress_hyper_4_117_chunk._ts_meta_max_1
+         ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_3_108_chunk
+               Output: (PARTIAL sum(_hyper_3_108_chunk.segment_by_value1))
+               Vectorized Aggregation: true
+               ->  Seq Scan on _timescaledb_internal.compress_hyper_4_118_chunk
+                     Output: compress_hyper_4_118_chunk."time", compress_hyper_4_118_chunk.segment_by_value1, compress_hyper_4_118_chunk.segment_by_value2, compress_hyper_4_118_chunk.int_value, compress_hyper_4_118_chunk.float_value, compress_hyper_4_118_chunk._ts_meta_count, compress_hyper_4_118_chunk._ts_meta_sequence_num, compress_hyper_4_118_chunk._ts_meta_min_1, compress_hyper_4_118_chunk._ts_meta_max_1
+         ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_3_109_chunk
+               Output: (PARTIAL sum(_hyper_3_109_chunk.segment_by_value1))
+               Vectorized Aggregation: true
+               ->  Seq Scan on _timescaledb_internal.compress_hyper_4_119_chunk
+                     Output: compress_hyper_4_119_chunk."time", compress_hyper_4_119_chunk.segment_by_value1, compress_hyper_4_119_chunk.segment_by_value2, compress_hyper_4_119_chunk.int_value, compress_hyper_4_119_chunk.float_value, compress_hyper_4_119_chunk._ts_meta_count, compress_hyper_4_119_chunk._ts_meta_sequence_num, compress_hyper_4_119_chunk._ts_meta_min_1, compress_hyper_4_119_chunk._ts_meta_max_1
+         ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_3_110_chunk
+               Output: (PARTIAL sum(_hyper_3_110_chunk.segment_by_value1))
+               Vectorized Aggregation: true
+               ->  Seq Scan on _timescaledb_internal.compress_hyper_4_120_chunk
+                     Output: compress_hyper_4_120_chunk."time", compress_hyper_4_120_chunk.segment_by_value1, compress_hyper_4_120_chunk.segment_by_value2, compress_hyper_4_120_chunk.int_value, compress_hyper_4_120_chunk.float_value, compress_hyper_4_120_chunk._ts_meta_count, compress_hyper_4_120_chunk._ts_meta_sequence_num, compress_hyper_4_120_chunk._ts_meta_min_1, compress_hyper_4_120_chunk._ts_meta_max_1
+(53 rows)
+
+SELECT sum(segment_by_value1) FROM testtable2;
+  sum   
+--------
+ 839970
+(1 row)
+
+:EXPLAIN
+SELECT sum(segment_by_value2) FROM testtable2;
+                                                                                                                                                                                                         QUERY PLAN                                                                                                                                                                                                         
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Finalize Aggregate
+   Output: sum(_hyper_3_101_chunk.segment_by_value2)
+   ->  Append
+         ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_3_101_chunk
+               Output: (PARTIAL sum(_hyper_3_101_chunk.segment_by_value2))
+               Vectorized Aggregation: true
+               ->  Seq Scan on _timescaledb_internal.compress_hyper_4_111_chunk
+                     Output: compress_hyper_4_111_chunk."time", compress_hyper_4_111_chunk.segment_by_value1, compress_hyper_4_111_chunk.segment_by_value2, compress_hyper_4_111_chunk.int_value, compress_hyper_4_111_chunk.float_value, compress_hyper_4_111_chunk._ts_meta_count, compress_hyper_4_111_chunk._ts_meta_sequence_num, compress_hyper_4_111_chunk._ts_meta_min_1, compress_hyper_4_111_chunk._ts_meta_max_1
+         ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_3_102_chunk
+               Output: (PARTIAL sum(_hyper_3_102_chunk.segment_by_value2))
+               Vectorized Aggregation: true
+               ->  Seq Scan on _timescaledb_internal.compress_hyper_4_112_chunk
+                     Output: compress_hyper_4_112_chunk."time", compress_hyper_4_112_chunk.segment_by_value1, compress_hyper_4_112_chunk.segment_by_value2, compress_hyper_4_112_chunk.int_value, compress_hyper_4_112_chunk.float_value, compress_hyper_4_112_chunk._ts_meta_count, compress_hyper_4_112_chunk._ts_meta_sequence_num, compress_hyper_4_112_chunk._ts_meta_min_1, compress_hyper_4_112_chunk._ts_meta_max_1
+         ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_3_103_chunk
+               Output: (PARTIAL sum(_hyper_3_103_chunk.segment_by_value2))
+               Vectorized Aggregation: true
+               ->  Seq Scan on _timescaledb_internal.compress_hyper_4_113_chunk
+                     Output: compress_hyper_4_113_chunk."time", compress_hyper_4_113_chunk.segment_by_value1, compress_hyper_4_113_chunk.segment_by_value2, compress_hyper_4_113_chunk.int_value, compress_hyper_4_113_chunk.float_value, compress_hyper_4_113_chunk._ts_meta_count, compress_hyper_4_113_chunk._ts_meta_sequence_num, compress_hyper_4_113_chunk._ts_meta_min_1, compress_hyper_4_113_chunk._ts_meta_max_1
+         ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_3_104_chunk
+               Output: (PARTIAL sum(_hyper_3_104_chunk.segment_by_value2))
+               Vectorized Aggregation: true
+               ->  Seq Scan on _timescaledb_internal.compress_hyper_4_114_chunk
+                     Output: compress_hyper_4_114_chunk."time", compress_hyper_4_114_chunk.segment_by_value1, compress_hyper_4_114_chunk.segment_by_value2, compress_hyper_4_114_chunk.int_value, compress_hyper_4_114_chunk.float_value, compress_hyper_4_114_chunk._ts_meta_count, compress_hyper_4_114_chunk._ts_meta_sequence_num, compress_hyper_4_114_chunk._ts_meta_min_1, compress_hyper_4_114_chunk._ts_meta_max_1
+         ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_3_105_chunk
+               Output: (PARTIAL sum(_hyper_3_105_chunk.segment_by_value2))
+               Vectorized Aggregation: true
+               ->  Seq Scan on _timescaledb_internal.compress_hyper_4_115_chunk
+                     Output: compress_hyper_4_115_chunk."time", compress_hyper_4_115_chunk.segment_by_value1, compress_hyper_4_115_chunk.segment_by_value2, compress_hyper_4_115_chunk.int_value, compress_hyper_4_115_chunk.float_value, compress_hyper_4_115_chunk._ts_meta_count, compress_hyper_4_115_chunk._ts_meta_sequence_num, compress_hyper_4_115_chunk._ts_meta_min_1, compress_hyper_4_115_chunk._ts_meta_max_1
+         ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_3_106_chunk
+               Output: (PARTIAL sum(_hyper_3_106_chunk.segment_by_value2))
+               Vectorized Aggregation: true
+               ->  Seq Scan on _timescaledb_internal.compress_hyper_4_116_chunk
+                     Output: compress_hyper_4_116_chunk."time", compress_hyper_4_116_chunk.segment_by_value1, compress_hyper_4_116_chunk.segment_by_value2, compress_hyper_4_116_chunk.int_value, compress_hyper_4_116_chunk.float_value, compress_hyper_4_116_chunk._ts_meta_count, compress_hyper_4_116_chunk._ts_meta_sequence_num, compress_hyper_4_116_chunk._ts_meta_min_1, compress_hyper_4_116_chunk._ts_meta_max_1
+         ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_3_107_chunk
+               Output: (PARTIAL sum(_hyper_3_107_chunk.segment_by_value2))
+               Vectorized Aggregation: true
+               ->  Seq Scan on _timescaledb_internal.compress_hyper_4_117_chunk
+                     Output: compress_hyper_4_117_chunk."time", compress_hyper_4_117_chunk.segment_by_value1, compress_hyper_4_117_chunk.segment_by_value2, compress_hyper_4_117_chunk.int_value, compress_hyper_4_117_chunk.float_value, compress_hyper_4_117_chunk._ts_meta_count, compress_hyper_4_117_chunk._ts_meta_sequence_num, compress_hyper_4_117_chunk._ts_meta_min_1, compress_hyper_4_117_chunk._ts_meta_max_1
+         ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_3_108_chunk
+               Output: (PARTIAL sum(_hyper_3_108_chunk.segment_by_value2))
+               Vectorized Aggregation: true
+               ->  Seq Scan on _timescaledb_internal.compress_hyper_4_118_chunk
+                     Output: compress_hyper_4_118_chunk."time", compress_hyper_4_118_chunk.segment_by_value1, compress_hyper_4_118_chunk.segment_by_value2, compress_hyper_4_118_chunk.int_value, compress_hyper_4_118_chunk.float_value, compress_hyper_4_118_chunk._ts_meta_count, compress_hyper_4_118_chunk._ts_meta_sequence_num, compress_hyper_4_118_chunk._ts_meta_min_1, compress_hyper_4_118_chunk._ts_meta_max_1
+         ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_3_109_chunk
+               Output: (PARTIAL sum(_hyper_3_109_chunk.segment_by_value2))
+               Vectorized Aggregation: true
+               ->  Seq Scan on _timescaledb_internal.compress_hyper_4_119_chunk
+                     Output: compress_hyper_4_119_chunk."time", compress_hyper_4_119_chunk.segment_by_value1, compress_hyper_4_119_chunk.segment_by_value2, compress_hyper_4_119_chunk.int_value, compress_hyper_4_119_chunk.float_value, compress_hyper_4_119_chunk._ts_meta_count, compress_hyper_4_119_chunk._ts_meta_sequence_num, compress_hyper_4_119_chunk._ts_meta_min_1, compress_hyper_4_119_chunk._ts_meta_max_1
+         ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_3_110_chunk
+               Output: (PARTIAL sum(_hyper_3_110_chunk.segment_by_value2))
+               Vectorized Aggregation: true
+               ->  Seq Scan on _timescaledb_internal.compress_hyper_4_120_chunk
+                     Output: compress_hyper_4_120_chunk."time", compress_hyper_4_120_chunk.segment_by_value1, compress_hyper_4_120_chunk.segment_by_value2, compress_hyper_4_120_chunk.int_value, compress_hyper_4_120_chunk.float_value, compress_hyper_4_120_chunk._ts_meta_count, compress_hyper_4_120_chunk._ts_meta_sequence_num, compress_hyper_4_120_chunk._ts_meta_min_1, compress_hyper_4_120_chunk._ts_meta_max_1
+(53 rows)
+
+SELECT sum(segment_by_value2) FROM testtable2;
+   sum   
+---------
+ -559980
+(1 row)
+

--- a/tsl/test/sql/CMakeLists.txt
+++ b/tsl/test/sql/CMakeLists.txt
@@ -26,7 +26,8 @@ set(TEST_FILES
     partialize_finalize.sql
     reorder.sql
     skip_scan.sql
-    size_utils_tsl.sql)
+    size_utils_tsl.sql
+    vectorized_aggregation.sql)
 
 if(ENABLE_MULTINODE_TESTS AND ${PG_VERSION_MAJOR} LESS "16")
   list(APPEND TEST_FILES dist_param.sql)

--- a/tsl/test/sql/vectorized_aggregation.sql
+++ b/tsl/test/sql/vectorized_aggregation.sql
@@ -1,0 +1,336 @@
+-- This file and its contents are licensed under the Timescale License.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-TIMESCALE for a copy of the license.
+
+\set EXPLAIN 'EXPLAIN (VERBOSE, COSTS OFF)'
+
+CREATE TABLE testtable (
+time timestamptz NOT NULL,
+segment_by_value integer,
+int_value integer,
+float_value double precision);
+
+SELECT FROM create_hypertable(relation=>'testtable', time_column_name=> 'time');
+
+ALTER TABLE testtable SET (timescaledb.compress, timescaledb.compress_segmentby='segment_by_value');
+
+INSERT INTO testtable
+SELECT time AS time,
+value AS segment_by_value,
+value AS int_value,
+value AS float_value
+FROM
+generate_series('1980-01-01 00:00:00-00', '1980-03-01 00:00:00-00', INTERVAL '1 day') AS g1(time),
+generate_series(-10, 100, 1) AS g2(value)
+ORDER BY time;
+
+-- Aggregation result without any vectorization
+SELECT sum(segment_by_value), sum(int_value), sum(float_value) FROM testtable;
+
+---
+-- Tests with some chunks compressed
+---
+SELECT compress_chunk(ch) FROM show_chunks('testtable') ch LIMIT 3;
+
+-- Vectorized aggregation possible
+SELECT sum(segment_by_value) FROM testtable;
+
+:EXPLAIN
+SELECT sum(segment_by_value) FROM testtable;
+
+-- Vectorization not possible due to a used filter
+:EXPLAIN
+SELECT sum(segment_by_value) FROM testtable WHERE segment_by_value > 0;
+
+-- Vectorization not possible due grouping
+:EXPLAIN
+SELECT sum(segment_by_value) FROM testtable GROUP BY float_value;
+
+:EXPLAIN
+SELECT sum(segment_by_value) FROM testtable GROUP BY int_value;
+
+:EXPLAIN
+SELECT sum(int_value) FROM testtable GROUP BY segment_by_value;
+
+-- Vectorization not possible due to two variables and grouping
+:EXPLAIN
+SELECT sum(segment_by_value), segment_by_value FROM testtable GROUP BY segment_by_value;
+
+:EXPLAIN
+SELECT segment_by_value, sum(segment_by_value) FROM testtable GROUP BY segment_by_value;
+
+-- Vectorized aggregation possible
+SELECT sum(int_value) FROM testtable;
+
+:EXPLAIN
+SELECT sum(int_value) FROM testtable;
+
+-- Vectorized aggregation not possible
+SELECT sum(float_value) FROM testtable;
+
+:EXPLAIN
+SELECT sum(float_value) FROM testtable;
+
+---
+-- Tests with all chunks compressed
+---
+SELECT compress_chunk(ch, if_not_compressed => true) FROM show_chunks('testtable') ch;
+
+-- Vectorized aggregation possible
+SELECT sum(segment_by_value) FROM testtable;
+
+:EXPLAIN
+SELECT sum(segment_by_value) FROM testtable;
+
+-- Vectorized aggregation possible
+SELECT sum(int_value) FROM testtable;
+
+:EXPLAIN
+SELECT sum(int_value) FROM testtable;
+
+---
+-- Tests with some chunks are partially compressed
+---
+INSERT INTO testtable (time, segment_by_value, int_value, float_value)
+   VALUES ('1980-01-02 01:00:00-00', 0, 0, 0);
+
+-- Vectorized aggregation possible
+SELECT sum(segment_by_value) FROM testtable;
+
+:EXPLAIN
+SELECT sum(segment_by_value) FROM testtable;
+
+-- Vectorized aggregation possible
+SELECT sum(int_value) FROM testtable;
+
+:EXPLAIN
+SELECT sum(int_value) FROM testtable;
+
+-- Vectorized aggregation NOT possible
+SET timescaledb.vectorized_aggregation = OFF;
+
+:EXPLAIN
+SELECT sum(int_value) FROM testtable;
+
+RESET timescaledb.vectorized_aggregation;
+
+-- Vectorized aggregation NOT possible without bulk decompression
+SET timescaledb.enable_bulk_decompression = OFF;
+
+:EXPLAIN
+SELECT sum(int_value) FROM testtable;
+
+RESET timescaledb.enable_bulk_decompression;
+
+-- Using the same sum function multiple times is supported by vectorization
+:EXPLAIN
+SELECT sum(int_value), sum(int_value) FROM testtable;
+
+-- Using the same sum function multiple times is supported by vectorization
+:EXPLAIN
+SELECT sum(segment_by_value), sum(segment_by_value) FROM testtable;
+
+-- Performing a sum on multiple columns is currently not supported by vectorization
+:EXPLAIN
+SELECT sum(int_value), sum(segment_by_value) FROM testtable;
+
+-- Using the sum function together with another non-vector capable aggregate is not supported
+:EXPLAIN
+SELECT sum(int_value), max(int_value) FROM testtable;
+
+-- Using the sum function together with another non-vector capable aggregate is not supported
+:EXPLAIN
+SELECT sum(segment_by_value), max(segment_by_value) FROM testtable;
+
+---
+-- Tests with only negative values
+---
+TRUNCATE testtable;
+
+INSERT INTO testtable
+SELECT time AS time,
+value AS segment_by_value,
+value AS int_value,
+value AS float_value
+FROM
+generate_series('1980-01-01 00:00:00-00', '1980-03-01 00:00:00-00', INTERVAL '1 day') AS g1(time),
+generate_series(-10, 0, 1) AS g2(value)
+ORDER BY time;
+
+-- Aggregation result without any vectorization
+SELECT sum(segment_by_value), sum(int_value), sum(float_value) FROM testtable;
+
+SELECT compress_chunk(ch) FROM show_chunks('testtable') ch;
+
+-- Aggregation with vectorization
+SELECT sum(segment_by_value) FROM testtable;
+SELECT sum(int_value) FROM testtable;
+
+---
+-- Tests with only positive values
+---
+TRUNCATE testtable;
+
+INSERT INTO testtable
+SELECT time AS time,
+value AS segment_by_value,
+value AS int_value,
+value AS float_value
+FROM
+generate_series('1980-01-01 00:00:00-00', '1980-03-01 00:00:00-00', INTERVAL '1 day') AS g1(time),
+generate_series(0, 10, 1) AS g2(value)
+ORDER BY time;
+
+-- Aggregation result without any vectorization
+SELECT sum(segment_by_value), sum(int_value), sum(float_value) FROM testtable;
+
+SELECT compress_chunk(ch) FROM show_chunks('testtable') ch;
+
+-- Aggregation with vectorization
+SELECT sum(segment_by_value) FROM testtable;
+SELECT sum(int_value) FROM testtable;
+
+---
+-- Tests with parallel plans
+---
+SET parallel_leader_participation = off;
+SET min_parallel_table_scan_size = 0;
+SET parallel_setup_cost = 0;
+SET parallel_tuple_cost = 0;
+
+:EXPLAIN
+SELECT sum(segment_by_value) FROM testtable;
+
+SELECT sum(segment_by_value) FROM testtable;
+
+RESET parallel_leader_participation;
+RESET min_parallel_table_scan_size;
+RESET parallel_setup_cost;
+RESET parallel_tuple_cost;
+
+---
+-- Tests with only zero values
+---
+TRUNCATE testtable;
+
+INSERT INTO testtable
+SELECT time AS time,
+0 AS segment_by_value,
+0 AS int_value,
+0 AS float_value
+FROM
+generate_series('1980-01-01 00:00:00-00', '1980-03-01 00:00:00-00', INTERVAL '1 day') AS g1(time)
+ORDER BY time;
+
+-- Aggregation result without any vectorization
+SELECT sum(segment_by_value), sum(int_value), sum(float_value) FROM testtable;
+
+SELECT compress_chunk(ch) FROM show_chunks('testtable') ch;
+
+-- Aggregation with vectorization
+SELECT sum(segment_by_value) FROM testtable;
+SELECT sum(int_value) FROM testtable;
+
+---
+-- Tests with null values
+---
+TRUNCATE testtable;
+
+INSERT INTO testtable
+SELECT time AS time,
+value AS segment_by_value,
+value AS int_value,
+value AS float_value
+FROM
+generate_series('1980-01-01 00:00:00-00', '1980-03-01 00:00:00-00', INTERVAL '1 day') AS g1(time),
+generate_series(0, 10, 1) AS g2(value)
+ORDER BY time;
+
+-- NULL values for compressed data
+INSERT INTO testtable
+SELECT time AS time,
+value AS segment_by_value,
+NULL AS int_value,
+NULL AS float_value
+FROM
+generate_series('1980-01-01 00:00:00-00', '1980-03-01 00:00:00-00', INTERVAL '1 day') AS g1(time),
+generate_series(0, 5, 1) AS g2(value)
+ORDER BY time;
+
+-- NULL values for segment_by
+INSERT INTO testtable
+SELECT time AS time,
+NULL AS segment_by_value,
+value AS int_value,
+value AS float_value
+FROM
+generate_series('1980-01-01 00:00:00-00', '1980-03-01 00:00:00-00', INTERVAL '1 day') AS g1(time),
+generate_series(0, 2, 1) AS g2(value)
+ORDER BY time;
+
+-- Aggregation result without any vectorization
+SELECT sum(segment_by_value), sum(int_value), sum(float_value) FROM testtable;
+
+SELECT compress_chunk(ch) FROM show_chunks('testtable') ch;
+
+-- Aggregation with vectorization
+:EXPLAIN
+SELECT sum(segment_by_value) FROM testtable;
+
+:EXPLAIN
+SELECT sum(int_value) FROM testtable;
+
+SELECT sum(segment_by_value) FROM testtable;
+
+SELECT sum(int_value) FROM testtable;
+
+-- Aggregation filters are not supported at the moment
+:EXPLAIN
+SELECT sum(segment_by_value) FILTER (WHERE segment_by_value > 99999) FROM testtable;
+
+SET timescaledb.vectorized_aggregation = OFF;
+SELECT sum(segment_by_value) FILTER (WHERE segment_by_value > 99999) FROM testtable;
+RESET timescaledb.vectorized_aggregation;
+
+SELECT sum(segment_by_value) FILTER (WHERE segment_by_value > 99999) FROM testtable;
+
+---
+-- Tests with multiple segment by values
+---
+CREATE TABLE testtable2 (
+time timestamptz NOT NULL,
+segment_by_value1 integer NOT NULL,
+segment_by_value2 integer NOT NULL,
+int_value integer NOT NULL,
+float_value double precision NOT NULL);
+
+SELECT FROM create_hypertable(relation=>'testtable2', time_column_name=> 'time');
+
+ALTER TABLE testtable2 SET (timescaledb.compress, timescaledb.compress_segmentby='segment_by_value1, segment_by_value2');
+
+INSERT INTO testtable2
+SELECT time AS time,
+value1 AS segment_by_value1,
+value2 AS segment_by_value2,
+value1 AS int_value,
+value1 AS float_value
+FROM
+generate_series('1980-01-01 00:00:00-00', '1980-03-01 00:00:00-00', INTERVAL '1 day') AS g1(time),
+generate_series(-10, 25, 1) AS g2(value1),
+generate_series(-30, 20, 1) AS g3(value2)
+ORDER BY time;
+
+-- Aggregation result without any vectorization
+SELECT sum(segment_by_value1), sum(segment_by_value2) FROM testtable2;
+
+SELECT compress_chunk(ch) FROM show_chunks('testtable2') ch;
+
+:EXPLAIN
+SELECT sum(segment_by_value1) FROM testtable2;
+
+SELECT sum(segment_by_value1) FROM testtable2;
+
+:EXPLAIN
+SELECT sum(segment_by_value2) FROM testtable2;
+
+SELECT sum(segment_by_value2) FROM testtable2;


### PR DESCRIPTION
This commit introduces a vectorized version of the sum() aggregate
function on compressed data. This optimization is enabled if (1) the
data is compressed, (2) no filters or grouping is applied, (3) the data
type is a 32-bit sum, and (4) the aggregation can be pushed down to
the chunk level.

---

Tsbench run: https://grafana.ops.savannah-dev.timescale.com/d/NdmLnOk4z/compare-benchmark-runs?orgId=1&var-branch=main&var-run1=2818&var-run2=2819&var-threshold=0.02