### PR TITLE
Function approximate_row_count returns 0 for caggs

### DIFF
--- a/.unreleased/bugfix_6053
+++ b/.unreleased/bugfix_6053
@@ -1,0 +1,1 @@
+Fixes: #6053 Function approximate_row_count returns 0 for caggs

--- a/tsl/test/expected/size_utils_tsl.out
+++ b/tsl/test/expected/size_utils_tsl.out
@@ -52,6 +52,12 @@ SELECT * FROM chunks_detailed_size('hypersize_cagg') ORDER BY node_name;
 --------------+------------+-------------+-------------+-------------+-------------+-----------
 (0 rows)
 
+SELECT * FROM approximate_row_count('hypersize_cagg');
+ approximate_row_count 
+-----------------------
+                     0
+(1 row)
+
 -- Test size functions on non-empty countinuous aggregate
 CALL refresh_continuous_aggregate('hypersize_cagg', NULL, NULL);
 SELECT * FROM hypertable_size('hypersize_cagg');
@@ -88,5 +94,12 @@ SELECT * FROM chunks_detailed_size(:'MAT_HYPERTABLE_NAME') ORDER BY node_name;
      chunk_schema      |    chunk_name    | table_bytes | index_bytes | toast_bytes | total_bytes | node_name 
 -----------------------+------------------+-------------+-------------+-------------+-------------+-----------
  _timescaledb_internal | _hyper_2_2_chunk |        8192 |       16384 |        8192 |       32768 | 
+(1 row)
+
+ANALYZE :MAT_HYPERTABLE_NAME;
+SELECT * FROM approximate_row_count('hypersize_cagg');
+ approximate_row_count 
+-----------------------
+                     1
 (1 row)
 

--- a/tsl/test/sql/size_utils_tsl.sql
+++ b/tsl/test/sql/size_utils_tsl.sql
@@ -21,6 +21,7 @@ SELECT * FROM chunks_detailed_size(:'MAT_HYPERTABLE_NAME') ORDER BY node_name;
 SELECT * FROM hypertable_size('hypersize_cagg');
 SELECT * FROM hypertable_detailed_size('hypersize_cagg') ORDER BY node_name;
 SELECT * FROM chunks_detailed_size('hypersize_cagg') ORDER BY node_name;
+SELECT * FROM approximate_row_count('hypersize_cagg');
 
 -- Test size functions on non-empty countinuous aggregate
 CALL refresh_continuous_aggregate('hypersize_cagg', NULL, NULL);
@@ -30,3 +31,5 @@ SELECT * FROM chunks_detailed_size('hypersize_cagg') ORDER BY node_name;
 SELECT * FROM hypertable_size(:'MAT_HYPERTABLE_NAME');
 SELECT * FROM hypertable_detailed_size(:'MAT_HYPERTABLE_NAME') ORDER BY node_name;
 SELECT * FROM chunks_detailed_size(:'MAT_HYPERTABLE_NAME') ORDER BY node_name;
+ANALYZE :MAT_HYPERTABLE_NAME;
+SELECT * FROM approximate_row_count('hypersize_cagg');


### PR DESCRIPTION
The approximate_row_count function is executed directly on the user view instead of corresponding materialized hypertable which returns 0 for caggs. The function is updated to fetch the details for materialized hypertable information corresponding to cagg and then get the approximate_row_count for the materialized hypertable.

Fixes #6051