### PR TITLE
Add metadata for chunk creation time

### DIFF
--- a/.unreleased/feature_6062
+++ b/.unreleased/feature_6062
@@ -1,0 +1,2 @@
+Implements: #6062 Add metadata for chunk creation time
+Thanks: @pdipesh02 for contributing to the implementation of this feature

--- a/scripts/test_repair_from_tag.sh
+++ b/scripts/test_repair_from_tag.sh
@@ -86,7 +86,7 @@ wait_for_pg() {
     for _ in {1..20}; do
         sleep 1
 
-        if docker_exec $1 "pg_isready -U postgres"; then
+        if docker_exec $1 "pg_isready -h localhost -U postgres"; then
             # this makes the test less flaky, although not
             # ideal. Apperently, pg_isready is not always a good
             # indication of whether the DB is actually ready to accept

--- a/sql/pre_install/tables.sql
+++ b/sql/pre_install/tables.sql
@@ -191,6 +191,7 @@ CREATE TABLE _timescaledb_catalog.chunk (
   dropped boolean NOT NULL DEFAULT FALSE,
   status integer NOT NULL DEFAULT 0,
   osm_chunk boolean NOT NULL DEFAULT FALSE,
+  creation_time timestamptz NOT NULL,
   -- table constraints
   CONSTRAINT chunk_pkey PRIMARY KEY (id),
   CONSTRAINT chunk_schema_name_table_name_key UNIQUE (schema_name, table_name),
@@ -206,6 +207,7 @@ CREATE INDEX chunk_compressed_chunk_id_idx ON _timescaledb_catalog.chunk (compre
 --Another option would be to use the status field to identify a OSM chunk. However bit
 --operations only work on varbit datatype and not integer datatype.
 CREATE INDEX chunk_osm_chunk_idx ON _timescaledb_catalog.chunk (osm_chunk, hypertable_id);
+CREATE INDEX chunk_hypertable_id_creation_time_idx ON _timescaledb_catalog.chunk(hypertable_id, creation_time);
 
 SELECT pg_catalog.pg_extension_config_dump('_timescaledb_catalog.chunk', '');
 SELECT pg_catalog.pg_extension_config_dump('_timescaledb_catalog.chunk_id_seq', '');

--- a/sql/updates/latest-dev.sql
+++ b/sql/updates/latest-dev.sql
@@ -1,4 +1,3 @@
-
 CREATE TYPE _timescaledb_internal.dimension_info;
 
 CREATE OR REPLACE FUNCTION _timescaledb_functions.dimension_info_in(cstring)
@@ -48,3 +47,135 @@ CREATE FUNCTION @extschema@.by_range(column_name NAME,
                                      partition_func regproc = NULL)
     RETURNS _timescaledb_internal.dimension_info LANGUAGE C
     AS '@MODULE_PATHNAME@', 'ts_range_dimension';
+
+--
+-- Rebuild the catalog table `_timescaledb_catalog.chunk` to
+-- add new column `creation_time`
+--
+CREATE TABLE _timescaledb_internal.chunk_tmp
+AS SELECT * from _timescaledb_catalog.chunk;
+
+CREATE TABLE _timescaledb_internal.tmp_chunk_seq_value AS
+SELECT last_value, is_called FROM _timescaledb_catalog.chunk_id_seq;
+
+--drop foreign keys on chunk table
+ALTER TABLE _timescaledb_catalog.chunk_constraint DROP CONSTRAINT
+chunk_constraint_chunk_id_fkey;
+ALTER TABLE _timescaledb_catalog.chunk_index DROP CONSTRAINT
+chunk_index_chunk_id_fkey;
+ALTER TABLE _timescaledb_catalog.chunk_data_node DROP CONSTRAINT
+chunk_data_node_chunk_id_fkey;
+ALTER TABLE _timescaledb_internal.bgw_policy_chunk_stats DROP CONSTRAINT
+bgw_policy_chunk_stats_chunk_id_fkey;
+ALTER TABLE _timescaledb_catalog.compression_chunk_size DROP CONSTRAINT
+compression_chunk_size_chunk_id_fkey;
+ALTER TABLE _timescaledb_catalog.compression_chunk_size DROP CONSTRAINT
+compression_chunk_size_compressed_chunk_id_fkey;
+ALTER TABLE _timescaledb_catalog.chunk_copy_operation DROP CONSTRAINT
+chunk_copy_operation_chunk_id_fkey;
+
+--drop dependent views
+DROP VIEW IF EXISTS timescaledb_information.hypertables;
+DROP VIEW IF EXISTS timescaledb_information.chunks;
+DROP VIEW IF EXISTS _timescaledb_internal.hypertable_chunk_local_size;
+DROP VIEW IF EXISTS _timescaledb_internal.compressed_chunk_stats;
+DROP VIEW IF EXISTS timescaledb_experimental.chunk_replication_status;
+
+ALTER EXTENSION timescaledb DROP TABLE _timescaledb_catalog.chunk;
+ALTER EXTENSION timescaledb DROP SEQUENCE _timescaledb_catalog.chunk_id_seq;
+DROP TABLE _timescaledb_catalog.chunk;
+
+CREATE SEQUENCE _timescaledb_catalog.chunk_id_seq MINVALUE 1;
+
+-- now create table without self referential foreign key
+CREATE TABLE _timescaledb_catalog.chunk (
+  id integer NOT NULL DEFAULT nextval('_timescaledb_catalog.chunk_id_seq'),
+  hypertable_id int NOT NULL,
+  schema_name name NOT NULL,
+  table_name name NOT NULL,
+  compressed_chunk_id integer ,
+  dropped boolean NOT NULL DEFAULT FALSE,
+  status integer NOT NULL DEFAULT 0,
+  osm_chunk boolean NOT NULL DEFAULT FALSE,
+  creation_time timestamptz,
+  -- table constraints
+  CONSTRAINT chunk_pkey PRIMARY KEY (id),
+  CONSTRAINT chunk_schema_name_table_name_key UNIQUE (schema_name, table_name)
+);
+
+INSERT INTO _timescaledb_catalog.chunk
+( id, hypertable_id, schema_name, table_name,
+  compressed_chunk_id, dropped, status, osm_chunk)
+SELECT id, hypertable_id, schema_name, table_name,
+  compressed_chunk_id, dropped, status, osm_chunk
+FROM _timescaledb_internal.chunk_tmp;
+
+-- update creation_time for chunks
+UPDATE
+    _timescaledb_catalog.chunk c
+SET
+    creation_time = (pg_catalog.pg_stat_file(pg_catalog.pg_relation_filepath(r.oid))).modification
+FROM
+    pg_class r, pg_namespace n
+WHERE
+    r.relnamespace = n.oid
+    AND r.relname = c.table_name
+    AND n.nspname = c.schema_name
+    AND r.relkind = 'r'
+    AND c.dropped IS FALSE;
+
+-- Make sure that there are no record with empty creation time
+UPDATE _timescaledb_catalog.chunk SET creation_time = now() WHERE creation_time IS NULL;
+
+--add indexes to the chunk table
+CREATE INDEX chunk_hypertable_id_idx ON _timescaledb_catalog.chunk (hypertable_id);
+CREATE INDEX chunk_compressed_chunk_id_idx ON _timescaledb_catalog.chunk (compressed_chunk_id);
+CREATE INDEX chunk_osm_chunk_idx ON _timescaledb_catalog.chunk (osm_chunk, hypertable_id);
+CREATE INDEX chunk_hypertable_id_creation_time_idx ON _timescaledb_catalog.chunk(hypertable_id, creation_time);
+
+ALTER SEQUENCE _timescaledb_catalog.chunk_id_seq OWNED BY _timescaledb_catalog.chunk.id;
+SELECT setval('_timescaledb_catalog.chunk_id_seq', last_value, is_called) FROM _timescaledb_internal.tmp_chunk_seq_value;
+
+-- add self referential foreign key
+ALTER TABLE _timescaledb_catalog.chunk ADD CONSTRAINT chunk_compressed_chunk_id_fkey FOREIGN KEY ( compressed_chunk_id )
+ REFERENCES _timescaledb_catalog.chunk( id );
+
+--add foreign key constraint
+ALTER TABLE _timescaledb_catalog.chunk
+      ADD CONSTRAINT chunk_hypertable_id_fkey
+      FOREIGN KEY (hypertable_id) REFERENCES _timescaledb_catalog.hypertable (id);
+
+SELECT pg_catalog.pg_extension_config_dump('_timescaledb_catalog.chunk', '');
+SELECT pg_catalog.pg_extension_config_dump('_timescaledb_catalog.chunk_id_seq', '');
+
+-- Add non-null constraint
+ALTER TABLE _timescaledb_catalog.chunk
+  ALTER COLUMN creation_time SET NOT NULL;
+
+--add the foreign key constraints
+ALTER TABLE _timescaledb_catalog.chunk_constraint ADD CONSTRAINT
+chunk_constraint_chunk_id_fkey FOREIGN KEY (chunk_id) REFERENCES _timescaledb_catalog.chunk(id);
+ALTER TABLE _timescaledb_catalog.chunk_index ADD CONSTRAINT
+chunk_index_chunk_id_fkey FOREIGN KEY (chunk_id)
+REFERENCES _timescaledb_catalog.chunk(id) ON DELETE CASCADE;
+ALTER TABLE _timescaledb_catalog.chunk_data_node ADD CONSTRAINT
+chunk_data_node_chunk_id_fkey FOREIGN KEY (chunk_id) REFERENCES _timescaledb_catalog.chunk(id);
+ALTER TABLE _timescaledb_internal.bgw_policy_chunk_stats ADD CONSTRAINT
+bgw_policy_chunk_stats_chunk_id_fkey FOREIGN KEY (chunk_id)
+REFERENCES _timescaledb_catalog.chunk(id) ON DELETE CASCADE;
+ALTER TABLE _timescaledb_catalog.compression_chunk_size ADD CONSTRAINT
+compression_chunk_size_chunk_id_fkey FOREIGN KEY (chunk_id)
+REFERENCES _timescaledb_catalog.chunk(id) ON DELETE CASCADE;
+ALTER TABLE _timescaledb_catalog.compression_chunk_size ADD CONSTRAINT
+compression_chunk_size_compressed_chunk_id_fkey FOREIGN KEY (compressed_chunk_id)
+REFERENCES _timescaledb_catalog.chunk(id) ON DELETE CASCADE;
+ALTER TABLE _timescaledb_catalog.chunk_copy_operation ADD CONSTRAINT
+chunk_copy_operation_chunk_id_fkey FOREIGN KEY (chunk_id) REFERENCES _timescaledb_catalog.chunk (id) ON DELETE CASCADE;
+
+--cleanup
+DROP TABLE _timescaledb_internal.chunk_tmp;
+DROP TABLE _timescaledb_internal.tmp_chunk_seq_value;
+
+GRANT SELECT ON _timescaledb_catalog.chunk_id_seq TO PUBLIC;
+GRANT SELECT ON _timescaledb_catalog.chunk TO PUBLIC;
+-- end recreate _timescaledb_catalog.chunk table --

--- a/sql/updates/reverse-dev.sql
+++ b/sql/updates/reverse-dev.sql
@@ -6,3 +6,121 @@ DROP FUNCTION IF EXISTS @extschema@.by_hash(name,integer,regproc);
 DROP FUNCTION IF EXISTS @extschema@.by_range(name,anyelement,regproc);
 
 DROP TYPE IF EXISTS _timescaledb_internal.dimension_info CASCADE;
+
+--
+-- Rebuild the catalog table `_timescaledb_catalog.chunk`
+--
+-- We need to recreate the catalog from scratch because when we drop a column
+-- Postgres marks `pg_attribute.attisdropped=TRUE` instead of removing it from
+-- the `pg_catalog.pg_attribute` table.
+--
+-- If we downgrade and upgrade the extension without rebuilding the catalog table it
+-- will mess up `pg_attribute.attnum` and we will end up with issues when trying
+-- to update data in those catalog tables.
+
+-- Recreate _timescaledb_catalog.chunk table --
+CREATE TABLE _timescaledb_internal.chunk_tmp
+AS SELECT * from _timescaledb_catalog.chunk;
+
+CREATE TABLE _timescaledb_internal.tmp_chunk_seq_value AS
+SELECT last_value, is_called FROM _timescaledb_catalog.chunk_id_seq;
+
+--drop foreign keys on chunk table
+ALTER TABLE _timescaledb_catalog.chunk_constraint DROP CONSTRAINT
+chunk_constraint_chunk_id_fkey;
+ALTER TABLE _timescaledb_catalog.chunk_index DROP CONSTRAINT
+chunk_index_chunk_id_fkey;
+ALTER TABLE _timescaledb_catalog.chunk_data_node DROP CONSTRAINT
+chunk_data_node_chunk_id_fkey;
+ALTER TABLE _timescaledb_internal.bgw_policy_chunk_stats DROP CONSTRAINT
+bgw_policy_chunk_stats_chunk_id_fkey;
+ALTER TABLE _timescaledb_catalog.compression_chunk_size DROP CONSTRAINT
+compression_chunk_size_chunk_id_fkey;
+ALTER TABLE _timescaledb_catalog.compression_chunk_size DROP CONSTRAINT
+compression_chunk_size_compressed_chunk_id_fkey;
+ALTER TABLE _timescaledb_catalog.chunk_copy_operation DROP CONSTRAINT
+chunk_copy_operation_chunk_id_fkey;
+
+--drop dependent views
+DROP VIEW IF EXISTS timescaledb_information.hypertables;
+DROP VIEW IF EXISTS timescaledb_information.chunks;
+DROP VIEW IF EXISTS _timescaledb_internal.hypertable_chunk_local_size;
+DROP VIEW IF EXISTS _timescaledb_internal.compressed_chunk_stats;
+DROP VIEW IF EXISTS timescaledb_experimental.chunk_replication_status;
+
+ALTER EXTENSION timescaledb DROP TABLE _timescaledb_catalog.chunk;
+ALTER EXTENSION timescaledb DROP SEQUENCE _timescaledb_catalog.chunk_id_seq;
+DROP TABLE _timescaledb_catalog.chunk;
+
+CREATE SEQUENCE _timescaledb_catalog.chunk_id_seq MINVALUE 1;
+
+-- now create table without self referential foreign key
+CREATE TABLE _timescaledb_catalog.chunk (
+  id integer NOT NULL DEFAULT nextval('_timescaledb_catalog.chunk_id_seq'),
+  hypertable_id int NOT NULL,
+  schema_name name NOT NULL,
+  table_name name NOT NULL,
+  compressed_chunk_id integer ,
+  dropped boolean NOT NULL DEFAULT FALSE,
+  status integer NOT NULL DEFAULT 0,
+  osm_chunk boolean NOT NULL DEFAULT FALSE,
+  -- table constraints
+  CONSTRAINT chunk_pkey PRIMARY KEY (id),
+  CONSTRAINT chunk_schema_name_table_name_key UNIQUE (schema_name, table_name)
+);
+
+INSERT INTO _timescaledb_catalog.chunk
+( id, hypertable_id, schema_name, table_name,
+  compressed_chunk_id, dropped, status, osm_chunk)
+SELECT id, hypertable_id, schema_name, table_name,
+  compressed_chunk_id, dropped, status, osm_chunk
+FROM _timescaledb_internal.chunk_tmp;
+
+--add indexes to the chunk table
+CREATE INDEX chunk_hypertable_id_idx ON _timescaledb_catalog.chunk (hypertable_id);
+CREATE INDEX chunk_compressed_chunk_id_idx ON _timescaledb_catalog.chunk (compressed_chunk_id);
+CREATE INDEX chunk_osm_chunk_idx ON _timescaledb_catalog.chunk (osm_chunk, hypertable_id);
+
+ALTER SEQUENCE _timescaledb_catalog.chunk_id_seq OWNED BY _timescaledb_catalog.chunk.id;
+SELECT setval('_timescaledb_catalog.chunk_id_seq', last_value, is_called) FROM _timescaledb_internal.tmp_chunk_seq_value;
+
+-- add self referential foreign key
+ALTER TABLE _timescaledb_catalog.chunk ADD CONSTRAINT chunk_compressed_chunk_id_fkey FOREIGN KEY ( compressed_chunk_id )
+ REFERENCES _timescaledb_catalog.chunk( id );
+
+--add foreign key constraint
+ALTER TABLE _timescaledb_catalog.chunk
+      ADD CONSTRAINT chunk_hypertable_id_fkey
+      FOREIGN KEY (hypertable_id) REFERENCES _timescaledb_catalog.hypertable (id);
+
+SELECT pg_catalog.pg_extension_config_dump('_timescaledb_catalog.chunk', '');
+SELECT pg_catalog.pg_extension_config_dump('_timescaledb_catalog.chunk_id_seq', '');
+
+--add the foreign key constraints
+ALTER TABLE _timescaledb_catalog.chunk_constraint ADD CONSTRAINT
+chunk_constraint_chunk_id_fkey FOREIGN KEY (chunk_id) REFERENCES _timescaledb_catalog.chunk(id);
+ALTER TABLE _timescaledb_catalog.chunk_index ADD CONSTRAINT
+chunk_index_chunk_id_fkey FOREIGN KEY (chunk_id)
+REFERENCES _timescaledb_catalog.chunk(id) ON DELETE CASCADE;
+ALTER TABLE _timescaledb_catalog.chunk_data_node ADD CONSTRAINT
+chunk_data_node_chunk_id_fkey FOREIGN KEY (chunk_id) REFERENCES _timescaledb_catalog.chunk(id);
+ALTER TABLE _timescaledb_internal.bgw_policy_chunk_stats ADD CONSTRAINT
+bgw_policy_chunk_stats_chunk_id_fkey FOREIGN KEY (chunk_id)
+REFERENCES _timescaledb_catalog.chunk(id) ON DELETE CASCADE;
+ALTER TABLE _timescaledb_catalog.compression_chunk_size ADD CONSTRAINT
+compression_chunk_size_chunk_id_fkey FOREIGN KEY (chunk_id)
+REFERENCES _timescaledb_catalog.chunk(id) ON DELETE CASCADE;
+ALTER TABLE _timescaledb_catalog.compression_chunk_size ADD CONSTRAINT
+compression_chunk_size_compressed_chunk_id_fkey FOREIGN KEY (compressed_chunk_id)
+REFERENCES _timescaledb_catalog.chunk(id) ON DELETE CASCADE;
+ALTER TABLE _timescaledb_catalog.chunk_copy_operation ADD CONSTRAINT
+chunk_copy_operation_chunk_id_fkey FOREIGN KEY (chunk_id) REFERENCES _timescaledb_catalog.chunk (id) ON DELETE CASCADE;
+
+--cleanup
+DROP TABLE _timescaledb_internal.chunk_tmp;
+DROP TABLE _timescaledb_internal.tmp_chunk_seq_value;
+
+GRANT SELECT ON _timescaledb_catalog.chunk_id_seq TO PUBLIC;
+GRANT SELECT ON _timescaledb_catalog.chunk TO PUBLIC;
+
+-- end recreate _timescaledb_catalog.chunk table --

--- a/sql/views.sql
+++ b/sql/views.sql
@@ -176,7 +176,8 @@ SELECT hypertable_schema,
   integer_range_end AS range_end_integer,
   is_compressed,
   chunk_table_space AS chunk_tablespace,
-  node_list AS data_nodes
+  node_list AS data_nodes,
+  creation_time AS chunk_creation_time
 FROM (
   SELECT ht.schema_name AS hypertable_schema,
     ht.table_name AS hypertable_name,
@@ -219,7 +220,8 @@ FROM (
     ELSE FALSE --remote chunk compression status uncertain
     END AS is_compressed,
     pgtab.spcname AS chunk_table_space,
-    chdn.node_list
+    chdn.node_list,
+	srcch.creation_time AS creation_time
   FROM _timescaledb_catalog.chunk srcch
     INNER JOIN _timescaledb_catalog.hypertable ht ON ht.id = srcch.hypertable_id
     INNER JOIN _timescaledb_catalog.chunk_constraint chcons ON srcch.id = chcons.chunk_id

--- a/src/chunk.c
+++ b/src/chunk.c
@@ -163,6 +163,7 @@ chunk_formdata_make_tuple(const FormData_chunk *fd, TupleDesc desc)
 	values[AttrNumberGetAttrOffset(Anum_chunk_dropped)] = BoolGetDatum(fd->dropped);
 	values[AttrNumberGetAttrOffset(Anum_chunk_status)] = Int32GetDatum(fd->status);
 	values[AttrNumberGetAttrOffset(Anum_chunk_osm_chunk)] = BoolGetDatum(fd->osm_chunk);
+	values[AttrNumberGetAttrOffset(Anum_chunk_creation_time)] = Int64GetDatum(fd->creation_time);
 
 	return heap_form_tuple(desc, values, nulls);
 }
@@ -185,6 +186,7 @@ ts_chunk_formdata_fill(FormData_chunk *fd, const TupleInfo *ti)
 	Assert(!nulls[AttrNumberGetAttrOffset(Anum_chunk_dropped)]);
 	Assert(!nulls[AttrNumberGetAttrOffset(Anum_chunk_status)]);
 	Assert(!nulls[AttrNumberGetAttrOffset(Anum_chunk_osm_chunk)]);
+	Assert(!nulls[AttrNumberGetAttrOffset(Anum_chunk_creation_time)]);
 
 	fd->id = DatumGetInt32(values[AttrNumberGetAttrOffset(Anum_chunk_id)]);
 	fd->hypertable_id = DatumGetInt32(values[AttrNumberGetAttrOffset(Anum_chunk_hypertable_id)]);
@@ -204,6 +206,7 @@ ts_chunk_formdata_fill(FormData_chunk *fd, const TupleInfo *ti)
 	fd->dropped = DatumGetBool(values[AttrNumberGetAttrOffset(Anum_chunk_dropped)]);
 	fd->status = DatumGetInt32(values[AttrNumberGetAttrOffset(Anum_chunk_status)]);
 	fd->osm_chunk = DatumGetBool(values[AttrNumberGetAttrOffset(Anum_chunk_osm_chunk)]);
+	fd->creation_time = DatumGetInt64(values[AttrNumberGetAttrOffset(Anum_chunk_creation_time)]);
 
 	if (should_free)
 		heap_freetuple(tuple);
@@ -973,6 +976,7 @@ chunk_create_object(const Hypertable *ht, Hypercube *cube, const char *schema_na
 	chunk->cube = cube;
 	chunk->hypertable_relid = ht->main_table_relid;
 	namestrcpy(&chunk->fd.schema_name, schema_name);
+	chunk->fd.creation_time = GetCurrentTimestamp();
 
 	if (NULL == table_name || table_name[0] == '\0')
 	{

--- a/src/ts_catalog/catalog.c
+++ b/src/ts_catalog/catalog.c
@@ -178,6 +178,7 @@ static const TableIndexDef catalog_table_index_definitions[_MAX_CATALOG_TABLES] 
 			[CHUNK_SCHEMA_NAME_INDEX] = "chunk_schema_name_table_name_key",
 			[CHUNK_COMPRESSED_CHUNK_ID_INDEX] = "chunk_compressed_chunk_id_idx",
 			[CHUNK_OSM_CHUNK_INDEX] = "chunk_osm_chunk_idx",
+			[CHUNK_HYPERTABLE_ID_CREATION_TIME_INDEX] = "chunk_hypertable_id_creation_time_idx",
 		},
 	},
 	[CHUNK_CONSTRAINT] = {

--- a/src/ts_catalog/catalog.h
+++ b/src/ts_catalog/catalog.h
@@ -415,6 +415,7 @@ enum Anum_chunk
 	Anum_chunk_dropped,
 	Anum_chunk_status,
 	Anum_chunk_osm_chunk,
+	Anum_chunk_creation_time,
 	_Anum_chunk_max,
 };
 
@@ -430,6 +431,7 @@ typedef struct FormData_chunk
 	bool dropped;
 	int32 status;
 	bool osm_chunk;
+	TimestampTz creation_time;
 } FormData_chunk;
 
 typedef FormData_chunk *Form_chunk;
@@ -441,6 +443,7 @@ enum
 	CHUNK_SCHEMA_NAME_INDEX,
 	CHUNK_COMPRESSED_CHUNK_ID_INDEX,
 	CHUNK_OSM_CHUNK_INDEX,
+	CHUNK_HYPERTABLE_ID_CREATION_TIME_INDEX,
 	_MAX_CHUNK_INDEX,
 };
 
@@ -469,6 +472,12 @@ enum Anum_chunk_osm_chunk_idx
 {
 	Anum_chunk_osm_chunk_idx_osm_chunk = 1,
 	Anum_chunk_osm_chunk_idx_hypertable_id,
+};
+
+enum Anum_chunk_hypertable_id_creation_time_idx
+{
+	Anum_chunk_hypertable_id_creation_time_idx_hypertable_id = 1,
+	Anum_chunk_hypertable_id_creation_time_idx_creation_time,
 };
 
 /************************************
@@ -1318,7 +1327,7 @@ typedef enum Anum_compression_chunk_size_pkey
  * The maximum number of indexes a catalog table can have.
  * This needs to be bumped in case of new catalog tables that have more indexes.
  */
-#define _MAX_TABLE_INDEXES 5
+#define _MAX_TABLE_INDEXES 6
 /************************************
  *
  * Remote txn table of 2pc commits

--- a/test/expected/alter.out
+++ b/test/expected/alter.out
@@ -186,7 +186,7 @@ SELECT relname, reloptions FROM pg_class WHERE relname IN ('_hyper_2_3_chunk','_
 
 -- Need superuser to ALTER chunks in _timescaledb_internal schema
 \c :TEST_DBNAME :ROLE_SUPERUSER
-SELECT * FROM _timescaledb_catalog.chunk WHERE id = 2;
+SELECT id, hypertable_id, schema_name, table_name, compressed_chunk_id, dropped, status, osm_chunk FROM _timescaledb_catalog.chunk WHERE id = 2;
  id | hypertable_id |      schema_name      |    table_name    | compressed_chunk_id | dropped | status | osm_chunk 
 ----+---------------+-----------------------+------------------+---------------------+---------+--------+-----------
   2 |             2 | _timescaledb_internal | _hyper_2_2_chunk |                     | f       |      0 | f
@@ -194,7 +194,7 @@ SELECT * FROM _timescaledb_catalog.chunk WHERE id = 2;
 
 -- Rename chunk
 ALTER TABLE _timescaledb_internal._hyper_2_2_chunk RENAME TO new_chunk_name;
-SELECT * FROM _timescaledb_catalog.chunk WHERE id = 2;
+SELECT id, hypertable_id, schema_name, table_name, compressed_chunk_id, dropped, status, osm_chunk FROM _timescaledb_catalog.chunk WHERE id = 2;
  id | hypertable_id |      schema_name      |   table_name   | compressed_chunk_id | dropped | status | osm_chunk 
 ----+---------------+-----------------------+----------------+---------------------+---------+--------+-----------
   2 |             2 | _timescaledb_internal | new_chunk_name |                     | f       |      0 | f
@@ -202,7 +202,7 @@ SELECT * FROM _timescaledb_catalog.chunk WHERE id = 2;
 
 -- Set schema
 ALTER TABLE _timescaledb_internal.new_chunk_name SET SCHEMA public;
-SELECT * FROM _timescaledb_catalog.chunk WHERE id = 2;
+SELECT id, hypertable_id, schema_name, table_name, compressed_chunk_id, dropped, status, osm_chunk FROM _timescaledb_catalog.chunk WHERE id = 2;
  id | hypertable_id | schema_name |   table_name   | compressed_chunk_id | dropped | status | osm_chunk 
 ----+---------------+-------------+----------------+---------------------+---------+--------+-----------
   2 |             2 | public      | new_chunk_name |                     | f       |      0 | f
@@ -680,7 +680,7 @@ SELECT * from _timescaledb_catalog.hypertable;
  12 | public      | my_table   | new_associated_schema  | _hyper_12               |              1 | _timescaledb_functions   | calculate_chunk_interval |                 0 |                 0 |                          |                    |      0
 (1 row)
 
-SELECT * from _timescaledb_catalog.chunk;
+SELECT id, hypertable_id, schema_name, table_name, compressed_chunk_id, dropped, status, osm_chunk from _timescaledb_catalog.chunk;
  id | hypertable_id |      schema_name      |     table_name     | compressed_chunk_id | dropped | status | osm_chunk 
 ----+---------------+-----------------------+--------------------+---------------------+---------+--------+-----------
  24 |            12 | new_associated_schema | _hyper_12_24_chunk |                     | f       |      0 | f

--- a/test/expected/create_hypertable.out
+++ b/test/expected/create_hypertable.out
@@ -18,6 +18,39 @@ ERROR:  hypertable "test_table" not found
  test_schema | test_table | table | default_perm_user
 (1 row)
 
+\d _timescaledb_catalog.chunk
+                                               Table "_timescaledb_catalog.chunk"
+       Column        |           Type           | Collation | Nullable |                        Default                         
+---------------------+--------------------------+-----------+----------+--------------------------------------------------------
+ id                  | integer                  |           | not null | nextval('_timescaledb_catalog.chunk_id_seq'::regclass)
+ hypertable_id       | integer                  |           | not null | 
+ schema_name         | name                     |           | not null | 
+ table_name          | name                     |           | not null | 
+ compressed_chunk_id | integer                  |           |          | 
+ dropped             | boolean                  |           | not null | false
+ status              | integer                  |           | not null | 0
+ osm_chunk           | boolean                  |           | not null | false
+ creation_time       | timestamp with time zone |           | not null | 
+Indexes:
+    "chunk_pkey" PRIMARY KEY, btree (id)
+    "chunk_compressed_chunk_id_idx" btree (compressed_chunk_id)
+    "chunk_hypertable_id_creation_time_idx" btree (hypertable_id, creation_time)
+    "chunk_hypertable_id_idx" btree (hypertable_id)
+    "chunk_osm_chunk_idx" btree (osm_chunk, hypertable_id)
+    "chunk_schema_name_table_name_key" UNIQUE CONSTRAINT, btree (schema_name, table_name)
+Foreign-key constraints:
+    "chunk_compressed_chunk_id_fkey" FOREIGN KEY (compressed_chunk_id) REFERENCES _timescaledb_catalog.chunk(id)
+    "chunk_hypertable_id_fkey" FOREIGN KEY (hypertable_id) REFERENCES _timescaledb_catalog.hypertable(id)
+Referenced by:
+    TABLE "_timescaledb_internal.bgw_policy_chunk_stats" CONSTRAINT "bgw_policy_chunk_stats_chunk_id_fkey" FOREIGN KEY (chunk_id) REFERENCES _timescaledb_catalog.chunk(id) ON DELETE CASCADE
+    TABLE "_timescaledb_catalog.chunk" CONSTRAINT "chunk_compressed_chunk_id_fkey" FOREIGN KEY (compressed_chunk_id) REFERENCES _timescaledb_catalog.chunk(id)
+    TABLE "_timescaledb_catalog.chunk_constraint" CONSTRAINT "chunk_constraint_chunk_id_fkey" FOREIGN KEY (chunk_id) REFERENCES _timescaledb_catalog.chunk(id)
+    TABLE "_timescaledb_catalog.chunk_copy_operation" CONSTRAINT "chunk_copy_operation_chunk_id_fkey" FOREIGN KEY (chunk_id) REFERENCES _timescaledb_catalog.chunk(id) ON DELETE CASCADE
+    TABLE "_timescaledb_catalog.chunk_data_node" CONSTRAINT "chunk_data_node_chunk_id_fkey" FOREIGN KEY (chunk_id) REFERENCES _timescaledb_catalog.chunk(id)
+    TABLE "_timescaledb_catalog.chunk_index" CONSTRAINT "chunk_index_chunk_id_fkey" FOREIGN KEY (chunk_id) REFERENCES _timescaledb_catalog.chunk(id) ON DELETE CASCADE
+    TABLE "_timescaledb_catalog.compression_chunk_size" CONSTRAINT "compression_chunk_size_chunk_id_fkey" FOREIGN KEY (chunk_id) REFERENCES _timescaledb_catalog.chunk(id) ON DELETE CASCADE
+    TABLE "_timescaledb_catalog.compression_chunk_size" CONSTRAINT "compression_chunk_size_compressed_chunk_id_fkey" FOREIGN KEY (compressed_chunk_id) REFERENCES _timescaledb_catalog.chunk(id) ON DELETE CASCADE
+
 create table test_schema.test_table_no_not_null(time BIGINT, device_id text);
 \set ON_ERROR_STOP 0
 -- Permission denied with unprivileged role
@@ -546,7 +579,7 @@ select * from _timescaledb_catalog.hypertable where table_name = 'test_migrate';
  10 | test_schema | test_migrate | _timescaledb_internal  | _hyper_10               |              1 | _timescaledb_functions   | calculate_chunk_interval |                 0 |                 0 |                          |                    |      0
 (1 row)
 
-select * from _timescaledb_catalog.chunk;
+select id, hypertable_id, schema_name, table_name, compressed_chunk_id, dropped, status, osm_chunk from _timescaledb_catalog.chunk;
  id | hypertable_id |      schema_name      |     table_name     | compressed_chunk_id | dropped | status | osm_chunk 
 ----+---------------+-----------------------+--------------------+---------------------+---------+--------+-----------
   1 |             1 | _timescaledb_internal | _hyper_1_1_chunk   |                     | f       |      0 | f

--- a/test/expected/drop_owned.out
+++ b/test/expected/drop_owned.out
@@ -31,7 +31,7 @@ SELECT * FROM _timescaledb_catalog.hypertable ORDER BY id;
   2 | hypertable_schema | superuser         | _timescaledb_internal  | _hyper_2                |              2 | _timescaledb_functions   | calculate_chunk_interval |                 0 |                 0 |                          |                    |      0
 (2 rows)
 
-SELECT * FROM _timescaledb_catalog.chunk;
+SELECT id, hypertable_id, schema_name, table_name, compressed_chunk_id, dropped, status, osm_chunk FROM _timescaledb_catalog.chunk;
  id | hypertable_id |      schema_name      |    table_name    | compressed_chunk_id | dropped | status | osm_chunk 
 ----+---------------+-----------------------+------------------+---------------------+---------+--------+-----------
   1 |             1 | _timescaledb_internal | _hyper_1_1_chunk |                     | f       |      0 | f
@@ -45,7 +45,7 @@ SELECT * FROM _timescaledb_catalog.hypertable ORDER BY id;
   2 | hypertable_schema | superuser  | _timescaledb_internal  | _hyper_2                |              2 | _timescaledb_functions   | calculate_chunk_interval |                 0 |                 0 |                          |                    |      0
 (1 row)
 
-SELECT * FROM _timescaledb_catalog.chunk;
+SELECT id, hypertable_id, schema_name, table_name, compressed_chunk_id, dropped, status, osm_chunk FROM _timescaledb_catalog.chunk;
  id | hypertable_id |      schema_name      |    table_name    | compressed_chunk_id | dropped | status | osm_chunk 
 ----+---------------+-----------------------+------------------+---------------------+---------+--------+-----------
   2 |             2 | _timescaledb_internal | _hyper_2_2_chunk |                     | f       |      0 | f
@@ -58,7 +58,7 @@ SELECT * FROM _timescaledb_catalog.hypertable GROUP BY id;
 ----+-------------+------------+------------------------+-------------------------+----------------+--------------------------+------------------------+-------------------+-------------------+--------------------------+--------------------+--------
 (0 rows)
 
-SELECT * FROM _timescaledb_catalog.chunk;
+SELECT id, hypertable_id, schema_name, table_name, compressed_chunk_id, dropped, status, osm_chunk FROM _timescaledb_catalog.chunk;
  id | hypertable_id | schema_name | table_name | compressed_chunk_id | dropped | status | osm_chunk 
 ----+---------------+-------------+------------+---------------------+---------+--------+-----------
 (0 rows)

--- a/test/expected/drop_schema.out
+++ b/test/expected/drop_schema.out
@@ -36,7 +36,7 @@ SELECT * FROM _timescaledb_catalog.hypertable ORDER BY id;
   2 | hypertable_schema | test2      | chunk_schema2          | _hyper_2                |              2 | _timescaledb_functions   | calculate_chunk_interval |                 0 |                 0 |                          |                    |      0
 (2 rows)
 
-SELECT * FROM _timescaledb_catalog.chunk;
+SELECT id, hypertable_id, schema_name, table_name, compressed_chunk_id, dropped, status, osm_chunk FROM _timescaledb_catalog.chunk;
  id | hypertable_id |  schema_name  |    table_name    | compressed_chunk_id | dropped | status | osm_chunk 
 ----+---------------+---------------+------------------+---------------------+---------+--------+-----------
   1 |             1 | chunk_schema1 | _hyper_1_1_chunk |                     | f       |      0 | f
@@ -59,7 +59,7 @@ SELECT * FROM _timescaledb_catalog.hypertable ORDER BY id;
   2 | hypertable_schema | test2      | chunk_schema2          | _hyper_2                |              2 | _timescaledb_functions   | calculate_chunk_interval |                 0 |                 0 |                          |                    |      0
 (2 rows)
 
-SELECT * FROM _timescaledb_catalog.chunk;
+SELECT id, hypertable_id, schema_name, table_name, compressed_chunk_id, dropped, status, osm_chunk FROM _timescaledb_catalog.chunk;
  id | hypertable_id |  schema_name  |    table_name    | compressed_chunk_id | dropped | status | osm_chunk 
 ----+---------------+---------------+------------------+---------------------+---------+--------+-----------
   2 |             2 | chunk_schema2 | _hyper_2_2_chunk |                     | f       |      0 | f
@@ -67,7 +67,7 @@ SELECT * FROM _timescaledb_catalog.chunk;
 
 --new chunk should be created in the internal associated schema
 INSERT INTO hypertable_schema.test1 VALUES ('2001-01-01 01:01:01', 23.3, 1);
-SELECT * FROM _timescaledb_catalog.chunk;
+SELECT id, hypertable_id, schema_name, table_name, compressed_chunk_id, dropped, status, osm_chunk FROM _timescaledb_catalog.chunk;
  id | hypertable_id |      schema_name      |    table_name    | compressed_chunk_id | dropped | status | osm_chunk 
 ----+---------------+-----------------------+------------------+---------------------+---------+--------+-----------
   2 |             2 | chunk_schema2         | _hyper_2_2_chunk |                     | f       |      0 | f
@@ -90,7 +90,7 @@ SELECT * FROM _timescaledb_catalog.hypertable GROUP BY id;
 ----+-------------+------------+------------------------+-------------------------+----------------+--------------------------+------------------------+-------------------+-------------------+--------------------------+--------------------+--------
 (0 rows)
 
-SELECT * FROM _timescaledb_catalog.chunk;
+SELECT id, hypertable_id, schema_name, table_name, compressed_chunk_id, dropped, status, osm_chunk FROM _timescaledb_catalog.chunk;
  id | hypertable_id | schema_name | table_name | compressed_chunk_id | dropped | status | osm_chunk 
 ----+---------------+-------------+------------+---------------------+---------+--------+-----------
 (0 rows)

--- a/test/expected/information_views.out
+++ b/test/expected/information_views.out
@@ -193,13 +193,58 @@ SELECT set_integer_now_func('test_table_int', 'table_int_now');
 (1 row)
 
 INSERT into test_table_int SELECT generate_series( 1, 20), 100;
- SELECT * FROM timescaledb_information.chunks WHERE hypertable_name = 'ht1' ORDER BY chunk_name;
+\d timescaledb_information.chunks
+                       View "timescaledb_information.chunks"
+         Column         |           Type           | Collation | Nullable | Default 
+------------------------+--------------------------+-----------+----------+---------
+ hypertable_schema      | name                     |           |          | 
+ hypertable_name        | name                     |           |          | 
+ chunk_schema           | name                     |           |          | 
+ chunk_name             | name                     |           |          | 
+ primary_dimension      | name                     |           |          | 
+ primary_dimension_type | regtype                  |           |          | 
+ range_start            | timestamp with time zone |           |          | 
+ range_end              | timestamp with time zone |           |          | 
+ range_start_integer    | bigint                   |           |          | 
+ range_end_integer      | bigint                   |           |          | 
+ is_compressed          | boolean                  |           |          | 
+ chunk_tablespace       | name                     |           |          | 
+ data_nodes             | name[]                   |           |          | 
+ chunk_creation_time    | timestamp with time zone |           |          | 
+
+SELECT hypertable_schema,
+       hypertable_name,
+       chunk_schema,
+       chunk_name,
+       primary_dimension,
+       primary_dimension_type,
+       range_start,
+       range_end,
+       range_start_integer,
+       range_end_integer,
+       is_compressed,
+       chunk_tablespace,
+       data_nodes
+FROM timescaledb_information.chunks WHERE hypertable_name = 'ht1' ORDER BY chunk_name;
  hypertable_schema | hypertable_name |     chunk_schema      |    chunk_name    | primary_dimension |  primary_dimension_type  |         range_start          |          range_end           | range_start_integer | range_end_integer | is_compressed | chunk_tablespace | data_nodes 
 -------------------+-----------------+-----------------------+------------------+-------------------+--------------------------+------------------------------+------------------------------+---------------------+-------------------+---------------+------------------+------------
  public            | ht1             | _timescaledb_internal | _hyper_1_1_chunk | time              | timestamp with time zone | Wed Dec 29 16:00:00 1999 PST | Wed Jan 05 16:00:00 2000 PST |                     |                   | f             |                  | 
 (1 row)
 
- SELECT * FROM timescaledb_information.chunks WHERE hypertable_name = 'test_table_int' ORDER BY chunk_name;
+SELECT hypertable_schema,
+       hypertable_name,
+       chunk_schema,
+       chunk_name,
+       primary_dimension,
+       primary_dimension_type,
+       range_start,
+       range_end,
+       range_start_integer,
+       range_end_integer,
+       is_compressed,
+       chunk_tablespace,
+       data_nodes
+FROM timescaledb_information.chunks WHERE hypertable_name = 'test_table_int' ORDER BY chunk_name;
  hypertable_schema | hypertable_name |     chunk_schema      |    chunk_name    | primary_dimension | primary_dimension_type | range_start | range_end | range_start_integer | range_end_integer | is_compressed | chunk_tablespace | data_nodes 
 -------------------+-----------------+-----------------------+------------------+-------------------+------------------------+-------------+-----------+---------------------+-------------------+---------------+------------------+------------
  public            | test_table_int  | _timescaledb_internal | _hyper_5_7_chunk | time              | bigint                 |             |           |                   0 |                10 | f             |                  | 

--- a/test/expected/insert.out
+++ b/test/expected/insert.out
@@ -156,7 +156,7 @@ SELECT * FROM test.show_indexesp('_timescaledb_internal._hyper%');
  _timescaledb_internal._hyper_1_4_chunk | _timescaledb_internal."_hyper_1_4_chunk_two_Partitions_timeCustom_idx"             | {timeCustom}             |      | f      | f       | f         | 
 (28 rows)
 
-SELECT * FROM _timescaledb_catalog.chunk;
+SELECT id, hypertable_id, schema_name, table_name, compressed_chunk_id, dropped, status, osm_chunk FROM _timescaledb_catalog.chunk;
  id | hypertable_id |      schema_name      |    table_name    | compressed_chunk_id | dropped | status | osm_chunk 
 ----+---------------+-----------------------+------------------+---------------------+---------+--------+-----------
   1 |             1 | _timescaledb_internal | _hyper_1_1_chunk |                     | f       |      0 | f

--- a/test/expected/insert_single.out
+++ b/test/expected/insert_single.out
@@ -245,7 +245,7 @@ SELECT * FROM "1dim_neg";
    20 | 21.2
 (7 rows)
 
-SELECT * FROM _timescaledb_catalog.chunk;
+SELECT id, hypertable_id, schema_name, table_name, compressed_chunk_id, dropped, status, osm_chunk FROM _timescaledb_catalog.chunk;
  id | hypertable_id |      schema_name      |    table_name     | compressed_chunk_id | dropped | status | osm_chunk 
 ----+---------------+-----------------------+-------------------+---------------------+---------+--------+-----------
   1 |             1 | one_Partition         | _hyper_1_1_chunk  |                     | f       |      0 | f

--- a/test/expected/tablespace.out
+++ b/test/expected/tablespace.out
@@ -152,35 +152,25 @@ replication_factor  |
 data_nodes          | 
 tablespaces         | {tablespace1,tablespace2}
 
-SELECT * FROM timescaledb_information.chunks ORDER BY chunk_name;
--[ RECORD 1 ]----------+-----------------------------
-hypertable_schema      | public
-hypertable_name        | tspace_2dim
-chunk_schema           | _timescaledb_internal
-chunk_name             | _hyper_1_1_chunk
-primary_dimension      | time
-primary_dimension_type | timestamp without time zone
-range_start            | Wed Jan 18 16:00:00 2017 PST
-range_end              | Wed Jan 25 16:00:00 2017 PST
-range_start_integer    | 
-range_end_integer      | 
-is_compressed          | f
-chunk_tablespace       | tablespace1
-data_nodes             | 
--[ RECORD 2 ]----------+-----------------------------
-hypertable_schema      | public
-hypertable_name        | tspace_2dim
-chunk_schema           | _timescaledb_internal
-chunk_name             | _hyper_1_2_chunk
-primary_dimension      | time
-primary_dimension_type | timestamp without time zone
-range_start            | Wed Jan 18 16:00:00 2017 PST
-range_end              | Wed Jan 25 16:00:00 2017 PST
-range_start_integer    | 
-range_end_integer      | 
-is_compressed          | f
-chunk_tablespace       | tablespace2
-data_nodes             | 
+SELECT hypertable_schema,
+       hypertable_name,
+       chunk_schema,
+       chunk_name,
+       chunk_tablespace
+FROM timescaledb_information.chunks
+ORDER BY chunk_name;
+-[ RECORD 1 ]-----+----------------------
+hypertable_schema | public
+hypertable_name   | tspace_2dim
+chunk_schema      | _timescaledb_internal
+chunk_name        | _hyper_1_1_chunk
+chunk_tablespace  | tablespace1
+-[ RECORD 2 ]-----+----------------------
+hypertable_schema | public
+hypertable_name   | tspace_2dim
+chunk_schema      | _timescaledb_internal
+chunk_name        | _hyper_1_2_chunk
+chunk_tablespace  | tablespace2
 
 \x
 --

--- a/test/expected/truncate.out
+++ b/test/expected/truncate.out
@@ -40,7 +40,7 @@ SELECT * FROM _timescaledb_catalog.hypertable;
   1 | public      | two_Partitions | _timescaledb_internal  | _hyper_1                |              2 | _timescaledb_functions   | calculate_chunk_interval |                 0 |                 0 |                          |                    |      0
 (1 row)
 
-SELECT * FROM _timescaledb_catalog.chunk;
+SELECT id, hypertable_id, schema_name, table_name, compressed_chunk_id, dropped, status, osm_chunk FROM _timescaledb_catalog.chunk;
  id | hypertable_id |      schema_name      |    table_name    | compressed_chunk_id | dropped | status | osm_chunk 
 ----+---------------+-----------------------+------------------+---------------------+---------+--------+-----------
   1 |             1 | _timescaledb_internal | _hyper_1_1_chunk |                     | f       |      0 | f
@@ -83,7 +83,7 @@ SELECT * FROM _timescaledb_catalog.hypertable;
   1 | public      | two_Partitions | _timescaledb_internal  | _hyper_1                |              2 | _timescaledb_functions   | calculate_chunk_interval |                 0 |                 0 |                          |                    |      0
 (1 row)
 
-SELECT * FROM _timescaledb_catalog.chunk;
+SELECT id, hypertable_id, schema_name, table_name, compressed_chunk_id, dropped, status, osm_chunk FROM _timescaledb_catalog.chunk;
  id | hypertable_id | schema_name | table_name | compressed_chunk_id | dropped | status | osm_chunk 
 ----+---------------+-------------+------------+---------------------+---------+--------+-----------
 (0 rows)
@@ -104,7 +104,7 @@ INSERT INTO public."two_Partitions"("timeCustom", device_id, series_0, series_1)
 (1257987600000000000, 'dev1', 1.5, 2),
 (1257894000000000000, 'dev2', 1.5, 1),
 (1257894002000000000, 'dev1', 2.5, 3);
-SELECT * FROM _timescaledb_catalog.chunk;
+SELECT id, hypertable_id, schema_name, table_name, compressed_chunk_id, dropped, status, osm_chunk FROM _timescaledb_catalog.chunk;
  id | hypertable_id |      schema_name      |    table_name    | compressed_chunk_id | dropped | status | osm_chunk 
 ----+---------------+-----------------------+------------------+---------------------+---------+--------+-----------
   5 |             1 | _timescaledb_internal | _hyper_1_5_chunk |                     | f       |      0 | f

--- a/test/sql/alter.sql
+++ b/test/sql/alter.sql
@@ -90,15 +90,15 @@ SELECT relname, reloptions FROM pg_class WHERE relname IN ('_hyper_2_3_chunk','_
 
 -- Need superuser to ALTER chunks in _timescaledb_internal schema
 \c :TEST_DBNAME :ROLE_SUPERUSER
-SELECT * FROM _timescaledb_catalog.chunk WHERE id = 2;
+SELECT id, hypertable_id, schema_name, table_name, compressed_chunk_id, dropped, status, osm_chunk FROM _timescaledb_catalog.chunk WHERE id = 2;
 
 -- Rename chunk
 ALTER TABLE _timescaledb_internal._hyper_2_2_chunk RENAME TO new_chunk_name;
-SELECT * FROM _timescaledb_catalog.chunk WHERE id = 2;
+SELECT id, hypertable_id, schema_name, table_name, compressed_chunk_id, dropped, status, osm_chunk FROM _timescaledb_catalog.chunk WHERE id = 2;
 
 -- Set schema
 ALTER TABLE _timescaledb_internal.new_chunk_name SET SCHEMA public;
-SELECT * FROM _timescaledb_catalog.chunk WHERE id = 2;
+SELECT id, hypertable_id, schema_name, table_name, compressed_chunk_id, dropped, status, osm_chunk FROM _timescaledb_catalog.chunk WHERE id = 2;
 
 -- Test that we cannot rename chunk columns
 \set ON_ERROR_STOP 0
@@ -375,7 +375,7 @@ ALTER SCHEMA my_associated_schema RENAME TO new_associated_schema;
 INSERT INTO my_table (date, quantity) VALUES ('2018-08-10T23:00:00+00:00', 20);
 -- Make sure the schema name is changed in both catalog tables
 SELECT * from _timescaledb_catalog.hypertable;
-SELECT * from _timescaledb_catalog.chunk;
+SELECT id, hypertable_id, schema_name, table_name, compressed_chunk_id, dropped, status, osm_chunk from _timescaledb_catalog.chunk;
 
 DROP TABLE my_table;
 

--- a/test/sql/create_hypertable.sql
+++ b/test/sql/create_hypertable.sql
@@ -15,6 +15,7 @@ SELECT * FROM _timescaledb_functions.get_create_command('test_table');
 \set ON_ERROR_STOP 1
 
 \dt "test_schema".*
+\d _timescaledb_catalog.chunk
 
 create table test_schema.test_table_no_not_null(time BIGINT, device_id text);
 
@@ -275,7 +276,7 @@ select create_hypertable('test_schema.test_migrate', 'time', migrate_data => tru
 
 --there should be two new chunks
 select * from _timescaledb_catalog.hypertable where table_name = 'test_migrate';
-select * from _timescaledb_catalog.chunk;
+select id, hypertable_id, schema_name, table_name, compressed_chunk_id, dropped, status, osm_chunk from _timescaledb_catalog.chunk;
 select * from test_schema.test_migrate;
 --main table should now be empty
 select * from only test_schema.test_migrate;

--- a/test/sql/drop_owned.sql
+++ b/test/sql/drop_owned.sql
@@ -18,18 +18,18 @@ SELECT create_hypertable('hypertable_schema.superuser', 'time', 'location', 2);
 INSERT INTO hypertable_schema.superuser VALUES ('2001-01-01 01:01:01', 23.3, 1);
 
 SELECT * FROM _timescaledb_catalog.hypertable ORDER BY id;
-SELECT * FROM _timescaledb_catalog.chunk;
+SELECT id, hypertable_id, schema_name, table_name, compressed_chunk_id, dropped, status, osm_chunk FROM _timescaledb_catalog.chunk;
 
 DROP OWNED BY :ROLE_DEFAULT_PERM_USER;
 
 SELECT * FROM _timescaledb_catalog.hypertable ORDER BY id;
-SELECT * FROM _timescaledb_catalog.chunk;
+SELECT id, hypertable_id, schema_name, table_name, compressed_chunk_id, dropped, status, osm_chunk FROM _timescaledb_catalog.chunk;
 
 DROP TABLE  hypertable_schema.superuser;
 
 --everything should be cleaned up
 SELECT * FROM _timescaledb_catalog.hypertable GROUP BY id;
-SELECT * FROM _timescaledb_catalog.chunk;
+SELECT id, hypertable_id, schema_name, table_name, compressed_chunk_id, dropped, status, osm_chunk FROM _timescaledb_catalog.chunk;
 SELECT * FROM _timescaledb_catalog.dimension;
 SELECT * FROM _timescaledb_catalog.dimension_slice;
 SELECT * FROM _timescaledb_catalog.chunk_index;

--- a/test/sql/drop_schema.sql
+++ b/test/sql/drop_schema.sql
@@ -22,7 +22,7 @@ INSERT INTO hypertable_schema.test1 VALUES ('2001-01-01 01:01:01', 23.3, 1);
 INSERT INTO hypertable_schema.test2 VALUES ('2001-01-01 01:01:01', 23.3, 1);
 
 SELECT * FROM _timescaledb_catalog.hypertable ORDER BY id;
-SELECT * FROM _timescaledb_catalog.chunk;
+SELECT id, hypertable_id, schema_name, table_name, compressed_chunk_id, dropped, status, osm_chunk FROM _timescaledb_catalog.chunk;
 
 RESET ROLE;
 --drop the associated schema. We drop the extra schema to show we can
@@ -33,11 +33,11 @@ SET ROLE :ROLE_DEFAULT_PERM_USER;
 --show that the metadata for the table using the dropped schema is
 --changed. The other table is not affected.
 SELECT * FROM _timescaledb_catalog.hypertable ORDER BY id;
-SELECT * FROM _timescaledb_catalog.chunk;
+SELECT id, hypertable_id, schema_name, table_name, compressed_chunk_id, dropped, status, osm_chunk FROM _timescaledb_catalog.chunk;
 
 --new chunk should be created in the internal associated schema
 INSERT INTO hypertable_schema.test1 VALUES ('2001-01-01 01:01:01', 23.3, 1);
-SELECT * FROM _timescaledb_catalog.chunk;
+SELECT id, hypertable_id, schema_name, table_name, compressed_chunk_id, dropped, status, osm_chunk FROM _timescaledb_catalog.chunk;
 
 RESET ROLE;
 --dropping the internal schema should not work
@@ -50,7 +50,7 @@ SET ROLE :ROLE_DEFAULT_PERM_USER;
 
 --everything should be cleaned up
 SELECT * FROM _timescaledb_catalog.hypertable GROUP BY id;
-SELECT * FROM _timescaledb_catalog.chunk;
+SELECT id, hypertable_id, schema_name, table_name, compressed_chunk_id, dropped, status, osm_chunk FROM _timescaledb_catalog.chunk;
 SELECT * FROM _timescaledb_catalog.dimension;
 SELECT * FROM _timescaledb_catalog.dimension_slice;
 SELECT * FROM _timescaledb_catalog.chunk_index;

--- a/test/sql/information_views.sql
+++ b/test/sql/information_views.sql
@@ -66,8 +66,36 @@ CREATE OR REPLACE function table_int_now() returns BIGINT LANGUAGE SQL IMMUTABLE
 SELECT set_integer_now_func('test_table_int', 'table_int_now');
 INSERT into test_table_int SELECT generate_series( 1, 20), 100;
 
- SELECT * FROM timescaledb_information.chunks WHERE hypertable_name = 'ht1' ORDER BY chunk_name;
- SELECT * FROM timescaledb_information.chunks WHERE hypertable_name = 'test_table_int' ORDER BY chunk_name;
+\d timescaledb_information.chunks
+SELECT hypertable_schema,
+       hypertable_name,
+       chunk_schema,
+       chunk_name,
+       primary_dimension,
+       primary_dimension_type,
+       range_start,
+       range_end,
+       range_start_integer,
+       range_end_integer,
+       is_compressed,
+       chunk_tablespace,
+       data_nodes
+FROM timescaledb_information.chunks WHERE hypertable_name = 'ht1' ORDER BY chunk_name;
+
+SELECT hypertable_schema,
+       hypertable_name,
+       chunk_schema,
+       chunk_name,
+       primary_dimension,
+       primary_dimension_type,
+       range_start,
+       range_end,
+       range_start_integer,
+       range_end_integer,
+       is_compressed,
+       chunk_tablespace,
+       data_nodes
+FROM timescaledb_information.chunks WHERE hypertable_name = 'test_table_int' ORDER BY chunk_name;
 
 \x
 SELECT * FROM timescaledb_information.dimensions ORDER BY hypertable_name, dimension_number;

--- a/test/sql/insert.sql
+++ b/test/sql/insert.sql
@@ -6,7 +6,7 @@
 
 SELECT * FROM test.show_columnsp('_timescaledb_internal.%_hyper%');
 SELECT * FROM test.show_indexesp('_timescaledb_internal._hyper%');
-SELECT * FROM _timescaledb_catalog.chunk;
+SELECT id, hypertable_id, schema_name, table_name, compressed_chunk_id, dropped, status, osm_chunk FROM _timescaledb_catalog.chunk;
 
 SELECT * FROM "two_Partitions" ORDER BY "timeCustom", device_id, series_0, series_1;
 SELECT * FROM ONLY "two_Partitions";

--- a/test/sql/insert_single.sql
+++ b/test/sql/insert_single.sql
@@ -55,7 +55,7 @@ INSERT INTO "1dim_neg" VALUES (19, 21.2);
 INSERT INTO "1dim_neg" VALUES (20, 21.2);
 SELECT * FROM "1dim_pre1970";
 SELECT * FROM "1dim_neg";
-SELECT * FROM _timescaledb_catalog.chunk;
+SELECT id, hypertable_id, schema_name, table_name, compressed_chunk_id, dropped, status, osm_chunk FROM _timescaledb_catalog.chunk;
 SELECT * FROM _timescaledb_catalog.dimension_slice;
 
 

--- a/test/sql/tablespace.sql
+++ b/test/sql/tablespace.sql
@@ -87,7 +87,13 @@ SELECT * FROM test.show_indexesp('_timescaledb_internal._hyper%_chunk');
 \x
 SELECT * FROM timescaledb_information.hypertables
 ORDER BY hypertable_schema, hypertable_name;
-SELECT * FROM timescaledb_information.chunks ORDER BY chunk_name;
+SELECT hypertable_schema,
+       hypertable_name,
+       chunk_schema,
+       chunk_name,
+       chunk_tablespace
+FROM timescaledb_information.chunks
+ORDER BY chunk_name;
 \x
 --
 SET ROLE :ROLE_DEFAULT_PERM_USER_2;

--- a/test/sql/truncate.sql
+++ b/test/sql/truncate.sql
@@ -7,7 +7,7 @@
 \o
 
 SELECT * FROM _timescaledb_catalog.hypertable;
-SELECT * FROM _timescaledb_catalog.chunk;
+SELECT id, hypertable_id, schema_name, table_name, compressed_chunk_id, dropped, status, osm_chunk FROM _timescaledb_catalog.chunk;
 SELECT * FROM test.show_subtables('"two_Partitions"');
 SELECT * FROM "two_Partitions";
 
@@ -15,7 +15,7 @@ SET client_min_messages = WARNING;
 TRUNCATE "two_Partitions";
 
 SELECT * FROM _timescaledb_catalog.hypertable;
-SELECT * FROM _timescaledb_catalog.chunk;
+SELECT id, hypertable_id, schema_name, table_name, compressed_chunk_id, dropped, status, osm_chunk FROM _timescaledb_catalog.chunk;
 
 -- should be empty
 SELECT * FROM test.show_subtables('"two_Partitions"');
@@ -27,7 +27,7 @@ INSERT INTO public."two_Partitions"("timeCustom", device_id, series_0, series_1)
 (1257894000000000000, 'dev2', 1.5, 1),
 (1257894002000000000, 'dev1', 2.5, 3);
 
-SELECT * FROM _timescaledb_catalog.chunk;
+SELECT id, hypertable_id, schema_name, table_name, compressed_chunk_id, dropped, status, osm_chunk FROM _timescaledb_catalog.chunk;
 
 CREATE VIEW dependent_view AS SELECT * FROM _timescaledb_internal._hyper_1_5_chunk;
 

--- a/test/sql/updates/post.catalog.sql
+++ b/test/sql/updates/post.catalog.sql
@@ -46,13 +46,13 @@ SELECT count(*)
 SELECT unnest(extconfig)::regclass::text AS obj FROM pg_extension WHERE extname='timescaledb' ORDER BY 1;
 
 -- Show dropped chunks
-SELECT *
+SELECT id, hypertable_id, schema_name, table_name, dropped
 FROM  _timescaledb_catalog.chunk c
 WHERE c.dropped
 ORDER BY c.id, c.hypertable_id;
 
 -- Show chunks that are not dropped and include owner in the output
-SELECT c.*, cl.relowner::regrole
+SELECT c.id, c.hypertable_id, c.schema_name, c.table_name, c.dropped, cl.relowner::regrole
 FROM  _timescaledb_catalog.chunk c
 INNER JOIN pg_class cl ON (cl.oid=format('%I.%I', schema_name, table_name)::regclass)
 WHERE NOT c.dropped

--- a/tsl/test/expected/cagg_ddl.out
+++ b/tsl/test/expected/cagg_ddl.out
@@ -622,7 +622,7 @@ SELECT * FROM drop_chunks_table ORDER BY time ASC limit 1;
 (1 row)
 
 --we see the chunks row with the dropped flags set;
-SELECT * FROM _timescaledb_catalog.chunk where dropped;
+SELECT id, hypertable_id, schema_name, table_name, compressed_chunk_id, dropped, status, osm_chunk FROM _timescaledb_catalog.chunk where dropped;
  id | hypertable_id |      schema_name      |     table_name     | compressed_chunk_id | dropped | status | osm_chunk 
 ----+---------------+-----------------------+--------------------+---------------------+---------+--------+-----------
  13 |            10 | _timescaledb_internal | _hyper_10_13_chunk |                     | t       |      0 | f

--- a/tsl/test/expected/cagg_ddl_dist_ht.out
+++ b/tsl/test/expected/cagg_ddl_dist_ht.out
@@ -659,7 +659,7 @@ SELECT * FROM drop_chunks_table ORDER BY time ASC limit 1;
 (1 row)
 
 --we see the chunks row with the dropped flags set;
-SELECT * FROM _timescaledb_catalog.chunk where dropped;
+SELECT id, hypertable_id, schema_name, table_name, compressed_chunk_id, dropped, status, osm_chunk FROM _timescaledb_catalog.chunk where dropped;
  id | hypertable_id |      schema_name      |       table_name        | compressed_chunk_id | dropped | status | osm_chunk 
 ----+---------------+-----------------------+-------------------------+---------------------+---------+--------+-----------
  13 |            10 | _timescaledb_internal | _dist_hyper_10_13_chunk |                     | t       |      0 | f

--- a/tsl/test/expected/chunk_merge.out
+++ b/tsl/test/expected/chunk_merge.out
@@ -35,7 +35,7 @@ NOTICE:  adding not-null constraint to column "Time"
 
 -- This creates chunks 7 - 9 on second hypertable.
 INSERT INTO test2 SELECT t, 1, 1.0 FROM generate_series('2018-03-02 1:00'::TIMESTAMPTZ, '2018-03-02 3:00', '1 minute') t;
-SELECT * FROM _timescaledb_catalog.chunk;
+SELECT id, hypertable_id, schema_name, table_name, compressed_chunk_id, dropped, status, osm_chunk FROM _timescaledb_catalog.chunk;
  id | hypertable_id |      schema_name      |    table_name    | compressed_chunk_id | dropped | status | osm_chunk 
 ----+---------------+-----------------------+------------------+---------------------+---------+--------+-----------
   1 |             1 | _timescaledb_internal | _hyper_1_1_chunk |                     | f       |      0 | f

--- a/tsl/test/expected/chunk_utils_internal.out
+++ b/tsl/test/expected/chunk_utils_internal.out
@@ -931,7 +931,8 @@ NOTICE:  hypertable_drop_chunks_hook
 (2 rows)
 
 SELECT id, table_name FROM _timescaledb_catalog.chunk
-where hypertable_id = (Select id from _timescaledb_catalog.hypertable where table_name = 'hyper_constr');
+where hypertable_id = (Select id from _timescaledb_catalog.hypertable where table_name = 'hyper_constr')
+ORDER BY id;
  id |     table_name     
 ----+--------------------
  13 | _hyper_7_13_chunk
@@ -1142,7 +1143,9 @@ ORDER BY 2,3;
 CREATE TABLE test_multicon(time timestamptz not null unique, a int);
 SELECT hypertable_id as htid FROM create_hypertable('test_multicon', 'time', chunk_time_interval => interval '1 day') \gset
 insert into test_multicon values ('2020-01-02 01:00'::timestamptz, 1);
-SELECT * FROM _timescaledb_catalog.chunk c, _timescaledb_catalog.chunk_constraint cc WHERE c.hypertable_id = :htid
+SELECT c.id, c.hypertable_id, c.schema_name, c.table_name, c.compressed_chunk_id, c.dropped, c.status, c.osm_chunk,
+cc.chunk_id, cc.dimension_slice_id, cc.constraint_name, cc.hypertable_constraint_name FROM
+_timescaledb_catalog.chunk c, _timescaledb_catalog.chunk_constraint cc WHERE c.hypertable_id = :htid
 AND c.id = cc.chunk_id;
  id | hypertable_id |      schema_name      |     table_name     | compressed_chunk_id | dropped | status | osm_chunk | chunk_id | dimension_slice_id |       constraint_name       | hypertable_constraint_name 
 ----+---------------+-----------------------+--------------------+---------------------+---------+--------+-----------+----------+--------------------+-----------------------------+----------------------------
@@ -1190,7 +1193,7 @@ SELECT _timescaledb_functions.hypertable_osm_range_update('test_multicon', NULL:
 
 SELECT cc.chunk_id, c.table_name, c.status, c.osm_chunk, cc.dimension_slice_id, ds.range_start, ds.range_end
 FROM _timescaledb_catalog.chunk c, _timescaledb_catalog.chunk_constraint cc, _timescaledb_catalog.dimension_slice ds
-WHERE c.hypertable_id = :htid AND cc.chunk_id = c.id AND ds.id = cc.dimension_slice_id;
+WHERE c.hypertable_id = :htid AND cc.chunk_id = c.id AND ds.id = cc.dimension_slice_id ORDER BY cc.chunk_id;
  chunk_id |     table_name     | status | osm_chunk | dimension_slice_id |     range_start     |      range_end      
 ----------+--------------------+--------+-----------+--------------------+---------------------+---------------------
        23 | _hyper_15_23_chunk |      0 | t         |                 23 | 9223372036854775806 | 9223372036854775807
@@ -1214,7 +1217,7 @@ SELECT _timescaledb_functions.attach_osm_table_chunk('test_chunkapp','test_chunk
 -- view range before update
 SELECT cc.chunk_id, c.table_name, c.status, c.osm_chunk, cc.dimension_slice_id, ds.range_start, ds.range_end
 FROM _timescaledb_catalog.chunk c, _timescaledb_catalog.chunk_constraint cc, _timescaledb_catalog.dimension_slice ds
-WHERE c.hypertable_id = :htid AND cc.chunk_id = c.id AND ds.id = cc.dimension_slice_id;
+WHERE c.hypertable_id = :htid AND cc.chunk_id = c.id AND ds.id = cc.dimension_slice_id ORDER BY cc.chunk_id;
  chunk_id |       table_name        | status | osm_chunk | dimension_slice_id |     range_start     |      range_end      
 ----------+-------------------------+--------+-----------+--------------------+---------------------+---------------------
        24 | _hyper_16_24_chunk      |      0 | f         |                 24 |    1577836800000000 |    1577923200000000
@@ -1237,7 +1240,7 @@ SELECT _timescaledb_functions.hypertable_osm_range_update('test_chunkapp', '2020
 -- view udpated range
 SELECT cc.chunk_id, c.table_name, c.status, c.osm_chunk, cc.dimension_slice_id, ds.range_start, ds.range_end
 FROM _timescaledb_catalog.chunk c, _timescaledb_catalog.chunk_constraint cc, _timescaledb_catalog.dimension_slice ds
-WHERE c.hypertable_id = :htid AND cc.chunk_id = c.id AND ds.id = cc.dimension_slice_id;
+WHERE c.hypertable_id = :htid AND cc.chunk_id = c.id AND ds.id = cc.dimension_slice_id ORDER BY cc.chunk_id;
  chunk_id |       table_name        | status | osm_chunk | dimension_slice_id |   range_start    |    range_end     
 ----------+-------------------------+--------+-----------+--------------------+------------------+------------------
        24 | _hyper_16_24_chunk      |      0 | f         |                 24 | 1577836800000000 | 1577923200000000
@@ -1309,7 +1312,7 @@ SELECT * FROM test_chunkapp ORDER BY 1;
 
 SELECT cc.chunk_id, c.table_name, c.status, c.osm_chunk, cc.dimension_slice_id, ds.range_start, ds.range_end
 FROM _timescaledb_catalog.chunk c, _timescaledb_catalog.chunk_constraint cc, _timescaledb_catalog.dimension_slice ds
-WHERE c.hypertable_id = :htid AND cc.chunk_id = c.id AND ds.id = cc.dimension_slice_id;
+WHERE c.hypertable_id = :htid AND cc.chunk_id = c.id AND ds.id = cc.dimension_slice_id ORDER BY cc.chunk_id;
  chunk_id |       table_name        | status | osm_chunk | dimension_slice_id |     range_start     |      range_end      
 ----------+-------------------------+--------+-----------+--------------------+---------------------+---------------------
        24 | _hyper_16_24_chunk      |      0 | f         |                 24 |    1577836800000000 |    1577923200000000

--- a/tsl/test/expected/compression_bgw.out
+++ b/tsl/test/expected/compression_bgw.out
@@ -72,7 +72,7 @@ from chunk_compression_stats('conditions') where compression_status like 'Compre
  _hyper_1_1_chunk | 32 kB        | 32 kB
 (1 row)
 
-SELECT * FROM _timescaledb_catalog.chunk ORDER BY id;
+SELECT id, hypertable_id, schema_name, table_name, compressed_chunk_id, dropped, status, osm_chunk FROM _timescaledb_catalog.chunk ORDER BY id;
  id | hypertable_id |      schema_name      |        table_name        | compressed_chunk_id | dropped | status | osm_chunk 
 ----+---------------+-----------------------+--------------------------+---------------------+---------+--------+-----------
   1 |             1 | _timescaledb_internal | _hyper_1_1_chunk         |                   4 | f       |      1 | f

--- a/tsl/test/expected/compression_hypertable.out
+++ b/tsl/test/expected/compression_hypertable.out
@@ -171,8 +171,8 @@ select * from _timescaledb_internal._hyper_1_10_chunk;
  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_10_chunk (actual rows=24 loops=1)
    Output: _hyper_1_10_chunk."Time", _hyper_1_10_chunk.i, _hyper_1_10_chunk.b, _hyper_1_10_chunk.t
    Bulk Decompression: true
-   ->  Seq Scan on _timescaledb_internal.compress_hyper_2_55_chunk (actual rows=1 loops=1)
-         Output: compress_hyper_2_55_chunk."Time", compress_hyper_2_55_chunk.i, compress_hyper_2_55_chunk.b, compress_hyper_2_55_chunk.t, compress_hyper_2_55_chunk._ts_meta_count, compress_hyper_2_55_chunk._ts_meta_sequence_num, compress_hyper_2_55_chunk._ts_meta_min_1, compress_hyper_2_55_chunk._ts_meta_max_1
+   ->  Seq Scan on _timescaledb_internal.compress_hyper_2_64_chunk (actual rows=1 loops=1)
+         Output: compress_hyper_2_64_chunk."Time", compress_hyper_2_64_chunk.i, compress_hyper_2_64_chunk.b, compress_hyper_2_64_chunk.t, compress_hyper_2_64_chunk._ts_meta_count, compress_hyper_2_64_chunk._ts_meta_sequence_num, compress_hyper_2_64_chunk._ts_meta_min_1, compress_hyper_2_64_chunk._ts_meta_max_1
 (5 rows)
 
 set timescaledb.enable_bulk_decompression to false;
@@ -183,8 +183,8 @@ select * from _timescaledb_internal._hyper_1_10_chunk;
  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_10_chunk (actual rows=24 loops=1)
    Output: _hyper_1_10_chunk."Time", _hyper_1_10_chunk.i, _hyper_1_10_chunk.b, _hyper_1_10_chunk.t
    Bulk Decompression: false
-   ->  Seq Scan on _timescaledb_internal.compress_hyper_2_55_chunk (actual rows=1 loops=1)
-         Output: compress_hyper_2_55_chunk."Time", compress_hyper_2_55_chunk.i, compress_hyper_2_55_chunk.b, compress_hyper_2_55_chunk.t, compress_hyper_2_55_chunk._ts_meta_count, compress_hyper_2_55_chunk._ts_meta_sequence_num, compress_hyper_2_55_chunk._ts_meta_min_1, compress_hyper_2_55_chunk._ts_meta_max_1
+   ->  Seq Scan on _timescaledb_internal.compress_hyper_2_64_chunk (actual rows=1 loops=1)
+         Output: compress_hyper_2_64_chunk."Time", compress_hyper_2_64_chunk.i, compress_hyper_2_64_chunk.b, compress_hyper_2_64_chunk.t, compress_hyper_2_64_chunk._ts_meta_count, compress_hyper_2_64_chunk._ts_meta_sequence_num, compress_hyper_2_64_chunk._ts_meta_min_1, compress_hyper_2_64_chunk._ts_meta_max_1
 (5 rows)
 
 reset timescaledb.enable_bulk_decompression;

--- a/tsl/test/expected/data_node.out
+++ b/tsl/test/expected/data_node.out
@@ -441,7 +441,7 @@ SELECT * FROM test.show_subtables('disttable');
  _timescaledb_internal._dist_hyper_3_4_chunk | 
 (3 rows)
 
-SELECT * FROM _timescaledb_catalog.chunk;
+SELECT id, hypertable_id, schema_name, table_name, compressed_chunk_id, dropped, status, osm_chunk FROM _timescaledb_catalog.chunk;
  id | hypertable_id |      schema_name      |      table_name       | compressed_chunk_id | dropped | status | osm_chunk 
 ----+---------------+-----------------------+-----------------------+---------------------+---------+--------+-----------
   2 |             3 | _timescaledb_internal | _dist_hyper_3_2_chunk |                     | f       |      0 | f
@@ -594,7 +594,7 @@ ORDER BY foreign_table_name;
  _dist_hyper_3_4_chunk | data_node_3
 (2 rows)
 
-SELECT * FROM _timescaledb_catalog.chunk;
+SELECT id, hypertable_id, schema_name, table_name, compressed_chunk_id, dropped, status, osm_chunk FROM _timescaledb_catalog.chunk;
  id | hypertable_id |      schema_name      |      table_name       | compressed_chunk_id | dropped | status | osm_chunk 
 ----+---------------+-----------------------+-----------------------+---------------------+---------+--------+-----------
   3 |             3 | _timescaledb_internal | _dist_hyper_3_3_chunk |                     | f       |      0 | f
@@ -644,7 +644,7 @@ SELECT * FROM _timescaledb_catalog.chunk_data_node;
 ----------+---------------+-----------
 (0 rows)
 
-SELECT * FROM _timescaledb_catalog.chunk;
+SELECT id, hypertable_id, schema_name, table_name, compressed_chunk_id, dropped, status, osm_chunk FROM _timescaledb_catalog.chunk;
  id | hypertable_id | schema_name | table_name | compressed_chunk_id | dropped | status | osm_chunk 
 ----+---------------+-------------+------------+---------------------+---------+--------+-----------
 (0 rows)
@@ -857,7 +857,7 @@ SELECT * FROM _timescaledb_catalog.chunk_data_node;
 ----------+---------------+-----------
 (0 rows)
 
-SELECT * FROM _timescaledb_catalog.chunk;
+SELECT id, hypertable_id, schema_name, table_name, compressed_chunk_id, dropped, status, osm_chunk FROM _timescaledb_catalog.chunk;
  id | hypertable_id | schema_name | table_name | compressed_chunk_id | dropped | status | osm_chunk 
 ----+---------------+-------------+------------+---------------------+---------+--------+-----------
 (0 rows)
@@ -926,7 +926,7 @@ SELECT * FROM test.show_subtables('disttable');
  _timescaledb_internal._dist_hyper_5_7_chunk | 
 (3 rows)
 
-SELECT * FROM _timescaledb_catalog.chunk;
+SELECT id, hypertable_id, schema_name, table_name, compressed_chunk_id, dropped, status, osm_chunk FROM _timescaledb_catalog.chunk;
  id | hypertable_id |      schema_name      |      table_name       | compressed_chunk_id | dropped | status | osm_chunk 
 ----+---------------+-----------------------+-----------------------+---------------------+---------+--------+-----------
   5 |             5 | _timescaledb_internal | _dist_hyper_5_5_chunk |                     | f       |      0 | f

--- a/tsl/test/expected/dist_compression.out
+++ b/tsl/test/expected/dist_compression.out
@@ -288,10 +288,10 @@ ORDER BY chunk_name, node_name;
 (6 rows)
 
 SELECT test.remote_exec(NULL, $$
-SELECT * FROM _timescaledb_catalog.chunk ORDER BY id;
+SELECT id, hypertable_id, schema_name, table_name, compressed_chunk_id, dropped, status, osm_chunk FROM _timescaledb_catalog.chunk ORDER BY id;
 $$);
 NOTICE:  [db_dist_compression_1]: 
-SELECT * FROM _timescaledb_catalog.chunk ORDER BY id
+SELECT id, hypertable_id, schema_name, table_name, compressed_chunk_id, dropped, status, osm_chunk FROM _timescaledb_catalog.chunk ORDER BY id
 NOTICE:  [db_dist_compression_1]:
 id|hypertable_id|schema_name          |table_name              |compressed_chunk_id|dropped|status|osm_chunk
 --+-------------+---------------------+------------------------+-------------------+-------+------+---------
@@ -303,7 +303,7 @@ id|hypertable_id|schema_name          |table_name              |compressed_chunk
 
 
 NOTICE:  [db_dist_compression_2]: 
-SELECT * FROM _timescaledb_catalog.chunk ORDER BY id
+SELECT id, hypertable_id, schema_name, table_name, compressed_chunk_id, dropped, status, osm_chunk FROM _timescaledb_catalog.chunk ORDER BY id
 NOTICE:  [db_dist_compression_2]:
 id|hypertable_id|schema_name          |table_name              |compressed_chunk_id|dropped|status|osm_chunk
 --+-------------+---------------------+------------------------+-------------------+-------+------+---------
@@ -315,7 +315,7 @@ id|hypertable_id|schema_name          |table_name              |compressed_chunk
 
 
 NOTICE:  [db_dist_compression_3]: 
-SELECT * FROM _timescaledb_catalog.chunk ORDER BY id
+SELECT id, hypertable_id, schema_name, table_name, compressed_chunk_id, dropped, status, osm_chunk FROM _timescaledb_catalog.chunk ORDER BY id
 NOTICE:  [db_dist_compression_3]:
 id|hypertable_id|schema_name          |table_name              |compressed_chunk_id|dropped|status|osm_chunk
 --+-------------+---------------------+------------------------+-------------------+-------+------+---------
@@ -381,7 +381,20 @@ replication_factor  | 2
 data_nodes          | {db_dist_compression_1,db_dist_compression_2,db_dist_compression_3}
 tablespaces         | 
 
-SELECT * from timescaledb_information.chunks
+SELECT hypertable_schema,
+       hypertable_name,
+       chunk_schema,
+       chunk_name,
+       primary_dimension,
+       primary_dimension_type,
+       range_start,
+       range_end,
+       range_start_integer,
+       range_end_integer,
+       is_compressed,
+       chunk_tablespace,
+       data_nodes
+FROM timescaledb_information.chunks
 ORDER BY hypertable_name, chunk_name;
 -[ RECORD 1 ]----------+----------------------------------------------
 hypertable_schema      | public
@@ -699,7 +712,7 @@ from chunk_compression_stats('conditions') where compression_status like 'Compre
  _dist_hyper_2_6_chunk | db_dist_compression_3 | 32 kB        | 32 kB
 (2 rows)
 
-SELECT * FROM _timescaledb_catalog.chunk ORDER BY id;
+SELECT id, hypertable_id, schema_name, table_name, compressed_chunk_id, dropped, status, osm_chunk FROM _timescaledb_catalog.chunk ORDER BY id;
  id | hypertable_id |      schema_name      |      table_name       | compressed_chunk_id | dropped | status | osm_chunk 
 ----+---------------+-----------------------+-----------------------+---------------------+---------+--------+-----------
   6 |             2 | _timescaledb_internal | _dist_hyper_2_6_chunk |                     | f       |      1 | f
@@ -1425,7 +1438,20 @@ ORDER BY chunk;
 (7 rows)
 
 -- make sure we have chunks on all data nodes
-select * from timescaledb_information.chunks where hypertable_name like 'metric';
+SELECT hypertable_schema,
+       hypertable_name,
+       chunk_schema,
+       chunk_name,
+       primary_dimension,
+       primary_dimension_type,
+       range_start,
+       range_end,
+       range_start_integer,
+       range_end_integer,
+       is_compressed,
+       chunk_tablespace,
+       data_nodes
+FROM timescaledb_information.chunks where hypertable_name like 'metric';
  hypertable_schema | hypertable_name |     chunk_schema      |       chunk_name        | primary_dimension |  primary_dimension_type  |         range_start          |          range_end           | range_start_integer | range_end_integer | is_compressed | chunk_tablespace |       data_nodes        
 -------------------+-----------------+-----------------------+-------------------------+-------------------+--------------------------+------------------------------+------------------------------+---------------------+-------------------+---------------+------------------+-------------------------
  public            | metric          | _timescaledb_internal | _dist_hyper_10_36_chunk | time              | timestamp with time zone | Wed Jun 30 17:00:00 2021 PDT | Wed Jul 07 17:00:00 2021 PDT |                     |                   | t             |                  | {db_dist_compression_2}

--- a/tsl/test/expected/dist_hypertable-13.out
+++ b/tsl/test/expected/dist_hypertable-13.out
@@ -1742,7 +1742,7 @@ SELECT * FROM disttable;
 (0 rows)
 
 -- Metadata and tables cleaned up
-SELECT * FROM _timescaledb_catalog.chunk;
+SELECT id, hypertable_id, schema_name, table_name, compressed_chunk_id, dropped, status, osm_chunk FROM _timescaledb_catalog.chunk;
  id | hypertable_id | schema_name | table_name | compressed_chunk_id | dropped | status | osm_chunk 
 ----+---------------+-------------+------------+---------------------+---------+--------+-----------
 (0 rows)
@@ -1754,12 +1754,12 @@ SELECT * FROM show_chunks('disttable');
 
 -- Also cleaned up remotely
 SELECT * FROM test.remote_exec(ARRAY[:'DATA_NODE_1', :'DATA_NODE_2', :'DATA_NODE_3'], $$
-SELECT * FROM _timescaledb_catalog.chunk;
+SELECT id, hypertable_id, schema_name, table_name, compressed_chunk_id, dropped, status, osm_chunk FROM _timescaledb_catalog.chunk;
 SELECT * FROM show_chunks('disttable');
 SELECT * FROM disttable;
 $$);
 NOTICE:  [db_dist_hypertable_1]: 
-SELECT * FROM _timescaledb_catalog.chunk
+SELECT id, hypertable_id, schema_name, table_name, compressed_chunk_id, dropped, status, osm_chunk FROM _timescaledb_catalog.chunk
 NOTICE:  [db_dist_hypertable_1]:
 id|hypertable_id|schema_name|table_name|compressed_chunk_id|dropped|status|osm_chunk
 --+-------------+-----------+----------+-------------------+-------+------+---------
@@ -1783,7 +1783,7 @@ time|device|temp|Color
 
 
 NOTICE:  [db_dist_hypertable_2]: 
-SELECT * FROM _timescaledb_catalog.chunk
+SELECT id, hypertable_id, schema_name, table_name, compressed_chunk_id, dropped, status, osm_chunk FROM _timescaledb_catalog.chunk
 NOTICE:  [db_dist_hypertable_2]:
 id|hypertable_id|schema_name|table_name|compressed_chunk_id|dropped|status|osm_chunk
 --+-------------+-----------+----------+-------------------+-------+------+---------
@@ -1807,7 +1807,7 @@ time|device|temp|Color
 
 
 NOTICE:  [db_dist_hypertable_3]: 
-SELECT * FROM _timescaledb_catalog.chunk
+SELECT id, hypertable_id, schema_name, table_name, compressed_chunk_id, dropped, status, osm_chunk FROM _timescaledb_catalog.chunk
 NOTICE:  [db_dist_hypertable_3]:
 id|hypertable_id|schema_name|table_name|compressed_chunk_id|dropped|status|osm_chunk
 --+-------------+-----------+----------+-------------------+-------+------+---------

--- a/tsl/test/expected/dist_hypertable-14.out
+++ b/tsl/test/expected/dist_hypertable-14.out
@@ -1746,7 +1746,7 @@ SELECT * FROM disttable;
 (0 rows)
 
 -- Metadata and tables cleaned up
-SELECT * FROM _timescaledb_catalog.chunk;
+SELECT id, hypertable_id, schema_name, table_name, compressed_chunk_id, dropped, status, osm_chunk FROM _timescaledb_catalog.chunk;
  id | hypertable_id | schema_name | table_name | compressed_chunk_id | dropped | status | osm_chunk 
 ----+---------------+-------------+------------+---------------------+---------+--------+-----------
 (0 rows)
@@ -1758,12 +1758,12 @@ SELECT * FROM show_chunks('disttable');
 
 -- Also cleaned up remotely
 SELECT * FROM test.remote_exec(ARRAY[:'DATA_NODE_1', :'DATA_NODE_2', :'DATA_NODE_3'], $$
-SELECT * FROM _timescaledb_catalog.chunk;
+SELECT id, hypertable_id, schema_name, table_name, compressed_chunk_id, dropped, status, osm_chunk FROM _timescaledb_catalog.chunk;
 SELECT * FROM show_chunks('disttable');
 SELECT * FROM disttable;
 $$);
 NOTICE:  [db_dist_hypertable_1]: 
-SELECT * FROM _timescaledb_catalog.chunk
+SELECT id, hypertable_id, schema_name, table_name, compressed_chunk_id, dropped, status, osm_chunk FROM _timescaledb_catalog.chunk
 NOTICE:  [db_dist_hypertable_1]:
 id|hypertable_id|schema_name|table_name|compressed_chunk_id|dropped|status|osm_chunk
 --+-------------+-----------+----------+-------------------+-------+------+---------
@@ -1787,7 +1787,7 @@ time|device|temp|Color
 
 
 NOTICE:  [db_dist_hypertable_2]: 
-SELECT * FROM _timescaledb_catalog.chunk
+SELECT id, hypertable_id, schema_name, table_name, compressed_chunk_id, dropped, status, osm_chunk FROM _timescaledb_catalog.chunk
 NOTICE:  [db_dist_hypertable_2]:
 id|hypertable_id|schema_name|table_name|compressed_chunk_id|dropped|status|osm_chunk
 --+-------------+-----------+----------+-------------------+-------+------+---------
@@ -1811,7 +1811,7 @@ time|device|temp|Color
 
 
 NOTICE:  [db_dist_hypertable_3]: 
-SELECT * FROM _timescaledb_catalog.chunk
+SELECT id, hypertable_id, schema_name, table_name, compressed_chunk_id, dropped, status, osm_chunk FROM _timescaledb_catalog.chunk
 NOTICE:  [db_dist_hypertable_3]:
 id|hypertable_id|schema_name|table_name|compressed_chunk_id|dropped|status|osm_chunk
 --+-------------+-----------+----------+-------------------+-------+------+---------

--- a/tsl/test/expected/dist_hypertable-15.out
+++ b/tsl/test/expected/dist_hypertable-15.out
@@ -1752,7 +1752,7 @@ SELECT * FROM disttable;
 (0 rows)
 
 -- Metadata and tables cleaned up
-SELECT * FROM _timescaledb_catalog.chunk;
+SELECT id, hypertable_id, schema_name, table_name, compressed_chunk_id, dropped, status, osm_chunk FROM _timescaledb_catalog.chunk;
  id | hypertable_id | schema_name | table_name | compressed_chunk_id | dropped | status | osm_chunk 
 ----+---------------+-------------+------------+---------------------+---------+--------+-----------
 (0 rows)
@@ -1764,12 +1764,12 @@ SELECT * FROM show_chunks('disttable');
 
 -- Also cleaned up remotely
 SELECT * FROM test.remote_exec(ARRAY[:'DATA_NODE_1', :'DATA_NODE_2', :'DATA_NODE_3'], $$
-SELECT * FROM _timescaledb_catalog.chunk;
+SELECT id, hypertable_id, schema_name, table_name, compressed_chunk_id, dropped, status, osm_chunk FROM _timescaledb_catalog.chunk;
 SELECT * FROM show_chunks('disttable');
 SELECT * FROM disttable;
 $$);
 NOTICE:  [db_dist_hypertable_1]: 
-SELECT * FROM _timescaledb_catalog.chunk
+SELECT id, hypertable_id, schema_name, table_name, compressed_chunk_id, dropped, status, osm_chunk FROM _timescaledb_catalog.chunk
 NOTICE:  [db_dist_hypertable_1]:
 id|hypertable_id|schema_name|table_name|compressed_chunk_id|dropped|status|osm_chunk
 --+-------------+-----------+----------+-------------------+-------+------+---------
@@ -1793,7 +1793,7 @@ time|device|temp|Color
 
 
 NOTICE:  [db_dist_hypertable_2]: 
-SELECT * FROM _timescaledb_catalog.chunk
+SELECT id, hypertable_id, schema_name, table_name, compressed_chunk_id, dropped, status, osm_chunk FROM _timescaledb_catalog.chunk
 NOTICE:  [db_dist_hypertable_2]:
 id|hypertable_id|schema_name|table_name|compressed_chunk_id|dropped|status|osm_chunk
 --+-------------+-----------+----------+-------------------+-------+------+---------
@@ -1817,7 +1817,7 @@ time|device|temp|Color
 
 
 NOTICE:  [db_dist_hypertable_3]: 
-SELECT * FROM _timescaledb_catalog.chunk
+SELECT id, hypertable_id, schema_name, table_name, compressed_chunk_id, dropped, status, osm_chunk FROM _timescaledb_catalog.chunk
 NOTICE:  [db_dist_hypertable_3]:
 id|hypertable_id|schema_name|table_name|compressed_chunk_id|dropped|status|osm_chunk
 --+-------------+-----------+----------+-------------------+-------+------+---------

--- a/tsl/test/expected/dist_views.out
+++ b/tsl/test/expected/dist_views.out
@@ -64,7 +64,20 @@ WHERE hypertable_name = 'dist_table';
  public            | dist_table      | test_role_1 |              3 |          3 | t                   | t              |                  2 | {db_dist_views_1,db_dist_views_2,db_dist_views_3} | 
 (1 row)
 
-SELECT * from timescaledb_information.chunks
+SELECT hypertable_schema,
+       hypertable_name,
+       chunk_schema,
+       chunk_name,
+       primary_dimension,
+       primary_dimension_type,
+       range_start,
+       range_end,
+       range_start_integer,
+       range_end_integer,
+       is_compressed,
+       chunk_tablespace,
+       data_nodes
+FROM timescaledb_information.chunks
 ORDER BY hypertable_name, chunk_name;
  hypertable_schema | hypertable_name |     chunk_schema      |      chunk_name       | primary_dimension |  primary_dimension_type  |         range_start          |          range_end           | range_start_integer | range_end_integer | is_compressed | chunk_tablespace |            data_nodes             
 -------------------+-----------------+-----------------------+-----------------------+-------------------+--------------------------+------------------------------+------------------------------+---------------------+-------------------+---------------+------------------+-----------------------------------

--- a/tsl/test/expected/remote_copy.out
+++ b/tsl/test/expected/remote_copy.out
@@ -131,7 +131,7 @@ SELECT * FROM "+ri(k33_')" ORDER BY 1;
  1203210 |     4.43244243242544 |                        |     0 | 
 (18 rows)
 
-SELECT * FROM _timescaledb_catalog.chunk ORDER BY 1;
+SELECT id, hypertable_id, schema_name, table_name, compressed_chunk_id, dropped, status, osm_chunk FROM _timescaledb_catalog.chunk ORDER BY 1;
  id | hypertable_id |      schema_name      |       table_name       | compressed_chunk_id | dropped | status | osm_chunk 
 ----+---------------+-----------------------+------------------------+---------------------+---------+--------+-----------
   1 |             1 | _timescaledb_internal | _dist_hyper_1_1_chunk  |                     | f       |      0 | f

--- a/tsl/test/sql/chunk_merge.sql
+++ b/tsl/test/sql/chunk_merge.sql
@@ -24,7 +24,7 @@ SELECT table_name FROM Create_hypertable('test2', 'Time', chunk_time_interval=> 
 -- This creates chunks 7 - 9 on second hypertable.
 INSERT INTO test2 SELECT t, 1, 1.0 FROM generate_series('2018-03-02 1:00'::TIMESTAMPTZ, '2018-03-02 3:00', '1 minute') t;
 
-SELECT * FROM _timescaledb_catalog.chunk;
+SELECT id, hypertable_id, schema_name, table_name, compressed_chunk_id, dropped, status, osm_chunk FROM _timescaledb_catalog.chunk;
 
 \set ON_ERROR_STOP 0
 

--- a/tsl/test/sql/compression_bgw.sql
+++ b/tsl/test/sql/compression_bgw.sql
@@ -51,7 +51,7 @@ CALL run_job(:compressjob_id);
 select chunk_name, pg_size_pretty(before_compression_total_bytes) before_total,
 pg_size_pretty( after_compression_total_bytes)  after_total
 from chunk_compression_stats('conditions') where compression_status like 'Compressed' order by chunk_name;
-SELECT * FROM _timescaledb_catalog.chunk ORDER BY id;
+SELECT id, hypertable_id, schema_name, table_name, compressed_chunk_id, dropped, status, osm_chunk FROM _timescaledb_catalog.chunk ORDER BY id;
 
 -- TEST 4 --
 --cannot set another policy

--- a/tsl/test/sql/data_node.sql
+++ b/tsl/test/sql/data_node.sql
@@ -252,7 +252,7 @@ INSERT INTO disttable VALUES
        ('2019-07-23 10:45', 8, 7.6);
 
 SELECT * FROM test.show_subtables('disttable');
-SELECT * FROM _timescaledb_catalog.chunk;
+SELECT id, hypertable_id, schema_name, table_name, compressed_chunk_id, dropped, status, osm_chunk FROM _timescaledb_catalog.chunk;
 SELECT * FROM _timescaledb_catalog.hypertable_data_node;
 SELECT * FROM _timescaledb_catalog.chunk_data_node;
 
@@ -312,7 +312,7 @@ SELECT * FROM test.show_subtables('disttable');
 SELECT foreign_table_name, foreign_server_name
 FROM information_schema.foreign_tables
 ORDER BY foreign_table_name;
-SELECT * FROM _timescaledb_catalog.chunk;
+SELECT id, hypertable_id, schema_name, table_name, compressed_chunk_id, dropped, status, osm_chunk FROM _timescaledb_catalog.chunk;
 SELECT * FROM _timescaledb_catalog.hypertable_data_node;
 SELECT * FROM _timescaledb_catalog.chunk_data_node;
 
@@ -329,7 +329,7 @@ SELECT * FROM delete_data_node('data_node_3', force => true);
 SELECT * FROM test.show_subtables('disttable');
 SELECT * FROM _timescaledb_catalog.hypertable_data_node;
 SELECT * FROM _timescaledb_catalog.chunk_data_node;
-SELECT * FROM _timescaledb_catalog.chunk;
+SELECT id, hypertable_id, schema_name, table_name, compressed_chunk_id, dropped, status, osm_chunk FROM _timescaledb_catalog.chunk;
 
 -- Attach data node should now succeed
 SET client_min_messages TO NOTICE;
@@ -434,7 +434,7 @@ SELECT node_name FROM timescaledb_information.data_nodes ORDER BY node_name;
 SELECT * FROM test.show_subtables('disttable');
 SELECT * FROM _timescaledb_catalog.hypertable_data_node;
 SELECT * FROM _timescaledb_catalog.chunk_data_node;
-SELECT * FROM _timescaledb_catalog.chunk;
+SELECT id, hypertable_id, schema_name, table_name, compressed_chunk_id, dropped, status, osm_chunk FROM _timescaledb_catalog.chunk;
 
 \set ON_ERROR_STOP 0
 -- No data nodes remain, so should fail
@@ -473,7 +473,7 @@ INSERT INTO disttable VALUES
        ('2019-07-23 10:45', 8, 7.6);
 
 SELECT * FROM test.show_subtables('disttable');
-SELECT * FROM _timescaledb_catalog.chunk;
+SELECT id, hypertable_id, schema_name, table_name, compressed_chunk_id, dropped, status, osm_chunk FROM _timescaledb_catalog.chunk;
 SELECT * FROM _timescaledb_catalog.hypertable_data_node;
 SELECT * FROM _timescaledb_catalog.chunk_data_node;
 SELECT * FROM hypertable_partitions;

--- a/tsl/test/sql/dist_compression.sql
+++ b/tsl/test/sql/dist_compression.sql
@@ -111,7 +111,7 @@ ORDER BY chunk;
 SELECT * from chunk_compression_stats('compressed')
 ORDER BY chunk_name, node_name;
 SELECT test.remote_exec(NULL, $$
-SELECT * FROM _timescaledb_catalog.chunk ORDER BY id;
+SELECT id, hypertable_id, schema_name, table_name, compressed_chunk_id, dropped, status, osm_chunk FROM _timescaledb_catalog.chunk ORDER BY id;
 $$);
 
 -- Decompress the chunks and replicas
@@ -132,7 +132,20 @@ LIMIT 1;
 \x
 SELECT * FROM timescaledb_information.hypertables
 WHERE hypertable_name = 'compressed';
-SELECT * from timescaledb_information.chunks
+SELECT hypertable_schema,
+       hypertable_name,
+       chunk_schema,
+       chunk_name,
+       primary_dimension,
+       primary_dimension_type,
+       range_start,
+       range_end,
+       range_start_integer,
+       range_end_integer,
+       is_compressed,
+       chunk_tablespace,
+       data_nodes
+FROM timescaledb_information.chunks
 ORDER BY hypertable_name, chunk_name;
 SELECT * from timescaledb_information.dimensions
 ORDER BY hypertable_name, dimension_number;
@@ -253,7 +266,7 @@ CALL run_job(:compressjob_id);
 select chunk_name, node_name, pg_size_pretty(before_compression_total_bytes) before_total,
 pg_size_pretty( after_compression_total_bytes)  after_total
 from chunk_compression_stats('conditions') where compression_status like 'Compressed' order by chunk_name;
-SELECT * FROM _timescaledb_catalog.chunk ORDER BY id;
+SELECT id, hypertable_id, schema_name, table_name, compressed_chunk_id, dropped, status, osm_chunk FROM _timescaledb_catalog.chunk ORDER BY id;
 
 -- TEST 4 --
 --cannot set another policy
@@ -635,7 +648,20 @@ FROM show_chunks('metric') AS chunk
 ORDER BY chunk;
 
 -- make sure we have chunks on all data nodes
-select * from timescaledb_information.chunks where hypertable_name like 'metric';
+SELECT hypertable_schema,
+       hypertable_name,
+       chunk_schema,
+       chunk_name,
+       primary_dimension,
+       primary_dimension_type,
+       range_start,
+       range_end,
+       range_start_integer,
+       range_end_integer,
+       is_compressed,
+       chunk_tablespace,
+       data_nodes
+FROM timescaledb_information.chunks where hypertable_name like 'metric';
 -- perform all combinations
 -- [IF NOT EXISTS] - []
 ALTER TABLE metric ADD COLUMN IF NOT EXISTS "medium" varchar;

--- a/tsl/test/sql/dist_hypertable.sql.in
+++ b/tsl/test/sql/dist_hypertable.sql.in
@@ -547,12 +547,12 @@ TRUNCATE disttable;
 SELECT * FROM disttable;
 
 -- Metadata and tables cleaned up
-SELECT * FROM _timescaledb_catalog.chunk;
+SELECT id, hypertable_id, schema_name, table_name, compressed_chunk_id, dropped, status, osm_chunk FROM _timescaledb_catalog.chunk;
 SELECT * FROM show_chunks('disttable');
 
 -- Also cleaned up remotely
 SELECT * FROM test.remote_exec(ARRAY[:'DATA_NODE_1', :'DATA_NODE_2', :'DATA_NODE_3'], $$
-SELECT * FROM _timescaledb_catalog.chunk;
+SELECT id, hypertable_id, schema_name, table_name, compressed_chunk_id, dropped, status, osm_chunk FROM _timescaledb_catalog.chunk;
 SELECT * FROM show_chunks('disttable');
 SELECT * FROM disttable;
 $$);

--- a/tsl/test/sql/dist_views.sql
+++ b/tsl/test/sql/dist_views.sql
@@ -38,7 +38,20 @@ LIMIT 1;
 
 SELECT * FROM timescaledb_information.hypertables
 WHERE hypertable_name = 'dist_table';
-SELECT * from timescaledb_information.chunks
+SELECT hypertable_schema,
+       hypertable_name,
+       chunk_schema,
+       chunk_name,
+       primary_dimension,
+       primary_dimension_type,
+       range_start,
+       range_end,
+       range_start_integer,
+       range_end_integer,
+       is_compressed,
+       chunk_tablespace,
+       data_nodes
+FROM timescaledb_information.chunks
 ORDER BY hypertable_name, chunk_name;
 SELECT * from timescaledb_information.dimensions
 ORDER BY hypertable_name, dimension_number;

--- a/tsl/test/sql/include/cagg_ddl_common.sql
+++ b/tsl/test/sql/include/cagg_ddl_common.sql
@@ -417,7 +417,7 @@ SELECT * FROM drop_chunks_view ORDER BY time_bucket DESC;
 --earliest datapoint now in table
 SELECT * FROM drop_chunks_table ORDER BY time ASC limit 1;
 --we see the chunks row with the dropped flags set;
-SELECT * FROM _timescaledb_catalog.chunk where dropped;
+SELECT id, hypertable_id, schema_name, table_name, compressed_chunk_id, dropped, status, osm_chunk FROM _timescaledb_catalog.chunk where dropped;
 --still see data in the view
 SELECT * FROM drop_chunks_view WHERE time_bucket < (integer_now_test2()-9) ORDER BY time_bucket DESC;
 --no data but covers dropped chunks

--- a/tsl/test/sql/remote_copy.sql
+++ b/tsl/test/sql/remote_copy.sql
@@ -148,7 +148,7 @@ COPY "+ri(k33_')" FROM STDIN (FORCE_NULL (flavor, "))_"), QUOTE '`', FREEZE, FOR
 \.
 
 SELECT * FROM "+ri(k33_')" ORDER BY 1;
-SELECT * FROM _timescaledb_catalog.chunk ORDER BY 1;
+SELECT id, hypertable_id, schema_name, table_name, compressed_chunk_id, dropped, status, osm_chunk FROM _timescaledb_catalog.chunk ORDER BY 1;
 SELECT * FROM _timescaledb_catalog.chunk_data_node ORDER BY 1, 3;
 SELECT * FROM _timescaledb_catalog.hypertable_data_node ORDER BY 3;
 select * from show_chunks('"+ri(k33_'')"') ORDER BY 1;


### PR DESCRIPTION
- Added creation_time attribute to timescaledb catalog table "chunk". Also, updated corresponding view timescaledb_information.chunks to include chunk_creation_time attribute.
- A newly created chunk is assigned the creation time during chunk creation to handle new partition range for give dimension (Time/ SERIAL/BIGSERIAL/INT/...).
- In case of an already existing chunk, the creation time is updated as part of running upgrade script. The current timestamp (now()) at the time of upgrade has been assigned as chunk creation time.
- Similarly, downgrade script is updated to drop the attribute creation_time from catalog table "chunk".
- All relevant queries/views/test output has been updated accordingly.