### PR TITLE
Improved bug board automatization

### DIFF
--- a/.github/workflows/procedural.yaml
+++ b/.github/workflows/procedural.yaml
@@ -40,8 +40,71 @@ jobs:
     name: Waiting for Engineering
     runs-on: ubuntu-latest
     if: github.event_name == 'issue_comment' && !github.event.issue.pull_request
-      && contains(github.event.issue.labels.*.name, 'waiting-for-author')
     steps:
+      - name: Install dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install jq
+      - name: Get board column of issue
+        id: extract_board_column
+        continue-on-error: true
+        run: |
+          # The following GraphQL query requests all issues from a project. It uses the repository
+          # to locate the issue and get the reference to the project. Then, a filter is applied
+          # (number: $project) to get the reference to the desired project (i.e., the bug board).
+          # Now, all issues from this project are requested. The reason for fetching all issues is
+          # because the current implementation of the GitHub GraphQL API for projects does not
+          # support server-side filters for issues and we can not restrict the query to our issue.
+          # Therefore, we fetch all issues and apply a filter on the client side in the next step.
+          gh api graphql --paginate -F issue=$ISSUE -F project=$PROJECT -F owner=$OWNER -F repo=$REPO -f query='
+            query board_column($issue: Int!, $project: Int!, $owner: String!, $repo: String!, $endCursor: String) {
+              repository(owner: $owner, name: $repo) {
+                issue(number: $issue) {
+                  projectV2(number: $project) {
+                    items(first: 100, after: $endCursor) {
+                      nodes {
+                        fieldValueByName(name: "Status") {
+                          ... on ProjectV2ItemFieldSingleSelectValue {
+                            name
+                          }
+                        }
+                        content {
+                          ... on Issue {
+                           id
+                           title
+                           number
+                           repository {
+                             name
+                             owner {
+                               login
+                              }
+                            }
+                          }
+                        }
+                      }
+                      pageInfo {
+                         hasNextPage
+                         endCursor
+                      }
+                    }
+                  }
+                }
+              }
+            }
+            ' > api_result
+            # Get board column for issue
+            board_column=$(jq -r ".data.repository.issue.projectV2.items.nodes[] |
+                select (.content.number == $ISSUE and .content.repository.name == \"$REPO\" and .content.repository.owner.login == \"$OWNER\") |
+                .fieldValueByName.name" api_result)
+            echo "Issue is in column: $board_column"
+            echo "issue_board_column=$board_column" >> "$GITHUB_OUTPUT"
+        env:
+          OWNER: timescale
+          REPO: ${{ github.event.repository.name }}
+          PROJECT: 55
+          ISSUE: ${{ github.event.issue.number }}
+          GITHUB_TOKEN: ${{ secrets.ORG_AUTOMATION_TOKEN }}
+
       - name: Check if organization member
         uses: tspascoal/get-user-teams-membership@v2
         id: checkUserMember
@@ -51,13 +114,15 @@ jobs:
          team: 'database-eng'
          GITHUB_TOKEN: ${{ secrets.ORG_AUTOMATION_TOKEN }}
       - name: Remove waiting-for-author label
-        if: ${{ steps.checkUserMember.outputs.isTeamMember == 'false' }}
+        if: ${{ steps.checkUserMember.outputs.isTeamMember == 'false'
+          && steps.extract_board_column.outputs.issue_board_column == 'Waiting for Author' }}
         uses: andymckay/labeler@3a4296e9dcdf9576b0456050db78cfd34853f260
         with:
           remove-labels: 'waiting-for-author, no-activity'
           repo-token: ${{ secrets.ORG_AUTOMATION_TOKEN }}
       - name: Move to waiting for engineering column
-        if: ${{ steps.checkUserMember.outputs.isTeamMember == 'false' }}
+        if: ${{ steps.checkUserMember.outputs.isTeamMember == 'false'
+          && steps.extract_board_column.outputs.issue_board_column == 'Waiting for Author' }}
         uses: leonsteinhaeuser/project-beta-automations@v2.0.0
         with:
           gh_token: ${{ secrets.ORG_AUTOMATION_TOKEN }}


### PR DESCRIPTION
In our bug board, issues were moved into the 'Waiting for Engineering' column when the author of an issue responded. The column move was made if the issue was tagged with the label 'waiting-for-author'. However, sometimes this label was not added to the waiting issues. As a result, the issue was not moved to the right column when the author responded.

This PR replaces the error-prone label check with a check in which column the issue is.

---
The workflow was tested in the timescaledb-tune repository with the issue https://github.com/timescale/timescaledb-tune/issues/126
Disable-check: force-changelog-file
