### PR TITLE
Fix missing cost initialization

### DIFF
--- a/src/planner/partialize.c
+++ b/src/planner/partialize.c
@@ -767,6 +767,10 @@ ts_pushdown_partial_agg(PlannerInfo *root, Hypertable *ht, RelOptInfo *input_rel
 	/* Calculate aggregation costs */
 	if (!extra_data->partial_costs_set)
 	{
+		/* Init costs */
+		MemSet(&extra_data->agg_partial_costs, 0, sizeof(AggClauseCosts));
+		MemSet(&extra_data->agg_final_costs, 0, sizeof(AggClauseCosts));
+
 		/* partial phase */
 		get_agg_clause_costs_compat(root,
 									(Node *) partial_grouping_target->exprs,


### PR DESCRIPTION
The Sanitizer build found a missing memory initialization of the aggregation costs. This PR adds the missing initialization.

---

Disable-check: force-changelog-file

Failing CI run: https://github.com/timescale/timescaledb/actions/runs/6192216103/job/16824687929
Fixed CI run: https://github.com/timescale/timescaledb/actions/runs/6197194660/job/16825298034