### PR TITLE
Updated reviewer list for pull-review bot

### DIFF
--- a/.pull-review
+++ b/.pull-review
@@ -42,16 +42,12 @@ reviewers:
   fabriziomello: {}
   konskov: {}
   erimatnor: {}
-  pmwkaa: {}
   nikkhils: {}
   akuzm: {}
-  RafiaSabih: {}
   gayyappan: {}
   jnidzwetzki: {}
   mahipv: {}
-  lkshminarayanan: {}
-  sb230132: {}
-  shhnwz: {}
+  antekresic: {}
 
 # list of users who will never be notified
 review_blacklist:


### PR DESCRIPTION
The pull-review bot requires that the chosen accounts be part of the organization. Updating the reviewer list to ensure the bot works.

---

Disable-check: force-changelog-file