### PR TITLE
Make CAggs materialized only by default

### DIFF
--- a/.unreleased/feature_6077
+++ b/.unreleased/feature_6077
@@ -1,0 +1,1 @@
+Implements: #6077 Make Continous Aggregates materialized only (non-realtime) by default

--- a/src/ts_catalog/continuous_agg.c
+++ b/src/ts_catalog/continuous_agg.c
@@ -58,7 +58,7 @@ static const WithClauseDefinition continuous_aggregate_with_clause_def[] = {
 		[ContinuousViewOptionMaterializedOnly] = {
 			.arg_name = "materialized_only",
 			.type_id = BOOLOID,
-			.default_val = (Datum)false,
+			.default_val = (Datum)true,
 		},
 		[ContinuousViewOptionCompress] = {
 			.arg_name = "compress",

--- a/tsl/test/expected/bgw_custom.out
+++ b/tsl/test/expected/bgw_custom.out
@@ -514,7 +514,7 @@ SELECT decompress_chunk(c) FROM show_chunks('conditions') c;
 
 -- TEST Continuous Aggregate job
 CREATE MATERIALIZED VIEW conditions_summary_daily
-WITH (timescaledb.continuous) AS
+WITH (timescaledb.continuous, timescaledb.materialized_only=false) AS
 SELECT location,
    time_bucket(INTERVAL '1 day', time) AS bucket,
    AVG(temperature),

--- a/tsl/test/expected/cagg_ddl.out
+++ b/tsl/test/expected/cagg_ddl.out
@@ -1097,39 +1097,39 @@ FROM (
 (3 rows)
 
 -- width expression for int2 hypertables
-CREATE MATERIALIZED VIEW width_expr WITH (timescaledb.continuous) AS
+CREATE MATERIALIZED VIEW width_expr WITH (timescaledb.continuous, timescaledb.materialized_only=false) AS
 SELECT time_bucket(1::smallint, time)
 FROM metrics_int2
 GROUP BY 1;
 psql:include/cagg_ddl_common.sql:750: NOTICE:  continuous aggregate "width_expr" is already up-to-date
 DROP MATERIALIZED VIEW width_expr;
-CREATE MATERIALIZED VIEW width_expr WITH (timescaledb.continuous) AS
+CREATE MATERIALIZED VIEW width_expr WITH (timescaledb.continuous, timescaledb.materialized_only=false) AS
 SELECT time_bucket(1::smallint + 2::smallint, time)
 FROM metrics_int2
 GROUP BY 1;
 psql:include/cagg_ddl_common.sql:757: NOTICE:  continuous aggregate "width_expr" is already up-to-date
 DROP MATERIALIZED VIEW width_expr;
 -- width expression for int4 hypertables
-CREATE MATERIALIZED VIEW width_expr WITH (timescaledb.continuous) AS
+CREATE MATERIALIZED VIEW width_expr WITH (timescaledb.continuous, timescaledb.materialized_only=false) AS
 SELECT time_bucket(1, time)
 FROM metrics_int4
 GROUP BY 1;
 psql:include/cagg_ddl_common.sql:765: NOTICE:  continuous aggregate "width_expr" is already up-to-date
 DROP MATERIALIZED VIEW width_expr;
-CREATE MATERIALIZED VIEW width_expr WITH (timescaledb.continuous) AS
+CREATE MATERIALIZED VIEW width_expr WITH (timescaledb.continuous, timescaledb.materialized_only=false) AS
 SELECT time_bucket(1 + 2, time)
 FROM metrics_int4
 GROUP BY 1;
 psql:include/cagg_ddl_common.sql:772: NOTICE:  continuous aggregate "width_expr" is already up-to-date
 DROP MATERIALIZED VIEW width_expr;
 -- width expression for int8 hypertables
-CREATE MATERIALIZED VIEW width_expr WITH (timescaledb.continuous) AS
+CREATE MATERIALIZED VIEW width_expr WITH (timescaledb.continuous, timescaledb.materialized_only=false) AS
 SELECT time_bucket(1, time)
 FROM metrics_int8
 GROUP BY 1;
 psql:include/cagg_ddl_common.sql:780: NOTICE:  continuous aggregate "width_expr" is already up-to-date
 DROP MATERIALIZED VIEW width_expr;
-CREATE MATERIALIZED VIEW width_expr WITH (timescaledb.continuous) AS
+CREATE MATERIALIZED VIEW width_expr WITH (timescaledb.continuous, timescaledb.materialized_only=false) AS
 SELECT time_bucket(1 + 2, time)
 FROM metrics_int8
 GROUP BY 1;
@@ -1137,17 +1137,17 @@ psql:include/cagg_ddl_common.sql:787: NOTICE:  continuous aggregate "width_expr"
 DROP MATERIALIZED VIEW width_expr;
 \set ON_ERROR_STOP 0
 -- non-immutable expresions should be rejected
-CREATE MATERIALIZED VIEW width_expr WITH (timescaledb.continuous) AS
+CREATE MATERIALIZED VIEW width_expr WITH (timescaledb.continuous, timescaledb.materialized_only=false) AS
 SELECT time_bucket(extract(year FROM now())::smallint, time)
 FROM metrics_int2
 GROUP BY 1;
 psql:include/cagg_ddl_common.sql:796: ERROR:  only immutable expressions allowed in time bucket function
-CREATE MATERIALIZED VIEW width_expr WITH (timescaledb.continuous) AS
+CREATE MATERIALIZED VIEW width_expr WITH (timescaledb.continuous, timescaledb.materialized_only=false) AS
 SELECT time_bucket(extract(year FROM now())::int, time)
 FROM metrics_int4
 GROUP BY 1;
 psql:include/cagg_ddl_common.sql:801: ERROR:  only immutable expressions allowed in time bucket function
-CREATE MATERIALIZED VIEW width_expr WITH (timescaledb.continuous) AS
+CREATE MATERIALIZED VIEW width_expr WITH (timescaledb.continuous, timescaledb.materialized_only=false) AS
 SELECT time_bucket(extract(year FROM now())::int, time)
 FROM metrics_int8
 GROUP BY 1;
@@ -1155,7 +1155,7 @@ psql:include/cagg_ddl_common.sql:806: ERROR:  only immutable expressions allowed
 \set ON_ERROR_STOP 1
 -- Test various ALTER MATERIALIZED VIEW statements.
 SET ROLE :ROLE_DEFAULT_PERM_USER;
-CREATE MATERIALIZED VIEW owner_check WITH (timescaledb.continuous) AS
+CREATE MATERIALIZED VIEW owner_check WITH (timescaledb.continuous, timescaledb.materialized_only=false) AS
 SELECT time_bucket(1 + 2, time)
 FROM metrics_int8
 GROUP BY 1
@@ -1293,7 +1293,7 @@ SELECT create_hypertable('test_schema.telemetry_raw', 'ts');
 
 \endif
 CREATE MATERIALIZED VIEW test_schema.telemetry_1s
-  WITH (timescaledb.continuous)
+  WITH (timescaledb.continuous, timescaledb.materialized_only=false)
     AS
 SELECT time_bucket(INTERVAL '1s', ts) AS ts_1s,
        avg(value)
@@ -1356,14 +1356,14 @@ SELECT create_hypertable('test_schema.telemetry_raw', 'ts');
 
 \endif
 CREATE MATERIALIZED VIEW test_schema.cagg1
-  WITH (timescaledb.continuous)
+  WITH (timescaledb.continuous, timescaledb.materialized_only=false)
     AS
 SELECT time_bucket(INTERVAL '1s', ts) AS ts_1s,
        avg(value)
   FROM test_schema.telemetry_raw
  GROUP BY ts_1s WITH NO DATA;
 CREATE MATERIALIZED VIEW test_schema.cagg2
-  WITH (timescaledb.continuous)
+  WITH (timescaledb.continuous, timescaledb.materialized_only=false)
     AS
 SELECT time_bucket(INTERVAL '1s', ts) AS ts_1s,
        avg(value)
@@ -1604,13 +1604,13 @@ SELECT table_name FROM create_hypertable('i3696','time');
 (1 row)
 
 \endif
-CREATE MATERIALIZED VIEW i3696_cagg1 WITH (timescaledb.continuous)
+CREATE MATERIALIZED VIEW i3696_cagg1 WITH (timescaledb.continuous, timescaledb.materialized_only=false)
 AS
  SELECT  search_query,count(search_query) as count, sum(cnt), time_bucket(INTERVAL '1 minute', time) AS bucket
  FROM i3696 GROUP BY cnt +cnt2 , bucket, search_query;
 psql:include/cagg_ddl_common.sql:1108: NOTICE:  continuous aggregate "i3696_cagg1" is already up-to-date
 ALTER MATERIALIZED VIEW i3696_cagg1 SET (timescaledb.materialized_only = 'true');
-CREATE MATERIALIZED VIEW i3696_cagg2 WITH (timescaledb.continuous)
+CREATE MATERIALIZED VIEW i3696_cagg2 WITH (timescaledb.continuous, timescaledb.materialized_only=false)
 AS
  SELECT  search_query,count(search_query) as count, sum(cnt), time_bucket(INTERVAL '1 minute', time) AS bucket
  FROM i3696 GROUP BY cnt + cnt2, bucket, search_query
@@ -1630,7 +1630,7 @@ SELECT create_hypertable('test_setting', 'time');
 (1 row)
 
 \endif
-CREATE MATERIALIZED VIEW test_setting_cagg with (timescaledb.continuous)
+CREATE MATERIALIZED VIEW test_setting_cagg with (timescaledb.continuous, timescaledb.materialized_only=false)
 AS SELECT time_bucket('1h',time), avg(val), count(*) FROM test_setting GROUP BY 1;
 psql:include/cagg_ddl_common.sql:1130: NOTICE:  continuous aggregate "test_setting_cagg" is already up-to-date
 INSERT INTO test_setting
@@ -1947,25 +1947,25 @@ SELECT * FROM cashflows;
 -- 4. test named bucket width
 -- named origin
 CREATE MATERIALIZED VIEW cagg_named_origin WITH
-(timescaledb.continuous) AS
+(timescaledb.continuous, timescaledb.materialized_only=false) AS
 SELECT time_bucket('1h', time, 'UTC', origin => '2001-01-03 01:23:45') AS bucket,
 avg(amount) as avg_amount
 FROM transactions GROUP BY 1 WITH NO DATA;
 -- named timezone
 CREATE MATERIALIZED VIEW cagg_named_tz_origin WITH
-(timescaledb.continuous) AS
+(timescaledb.continuous, timescaledb.materialized_only=false) AS
 SELECT time_bucket('1h', time, timezone => 'UTC', origin => '2001-01-03 01:23:45') AS bucket,
 avg(amount) as avg_amount
 FROM transactions GROUP BY 1 WITH NO DATA;
 -- named ts
 CREATE MATERIALIZED VIEW cagg_named_ts_tz_origin WITH
-(timescaledb.continuous) AS
+(timescaledb.continuous, timescaledb.materialized_only=false) AS
 SELECT time_bucket('1h', ts => time, timezone => 'UTC', origin => '2001-01-03 01:23:45') AS bucket,
 avg(amount) as avg_amount
 FROM transactions GROUP BY 1 WITH NO DATA;
 -- named bucket width
 CREATE MATERIALIZED VIEW cagg_named_all WITH
-(timescaledb.continuous) AS
+(timescaledb.continuous, timescaledb.materialized_only=false) AS
 SELECT time_bucket(bucket_width => '1h', ts => time, timezone => 'UTC', origin => '2001-01-03 01:23:45') AS bucket,
 avg(amount) as avg_amount
 FROM transactions GROUP BY 1 WITH NO DATA;
@@ -2015,7 +2015,7 @@ SELECT * FROM transactions_montly ORDER BY bucket;
 
 -- Check set_chunk_time_interval on continuous aggregate
 CREATE MATERIALIZED VIEW cagg_set_chunk_time_interval
-WITH (timescaledb.continuous) AS
+WITH (timescaledb.continuous, timescaledb.materialized_only=false) AS
 SELECT time_bucket(INTERVAL '1 month', time) AS bucket,
        SUM(fiat_value),
        MAX(fiat_value),
@@ -2038,4 +2038,122 @@ WHERE d.hypertable_id = ca.mat_hypertable_id;
 ----------
  t
 (1 row)
+
+-- Since #6077 CAggs are materialized only by default
+DROP TABLE conditions CASCADE;
+psql:include/cagg_ddl_common.sql:1365: NOTICE:  drop cascades to 3 other objects
+psql:include/cagg_ddl_common.sql:1365: NOTICE:  drop cascades to 2 other objects
+CREATE TABLE conditions (
+       time TIMESTAMPTZ NOT NULL,
+       location TEXT NOT NULL,
+       temperature DOUBLE PRECISION NULL
+);
+\if :IS_DISTRIBUTED
+SELECT create_distributed_hypertable('conditions', 'time', replication_factor => 2);
+\else
+SELECT create_hypertable('conditions', 'time');
+    create_hypertable     
+--------------------------
+ (54,public,conditions,t)
+(1 row)
+
+\endif
+INSERT INTO conditions VALUES ( '2018-01-01 09:20:00-08', 'SFO', 55);
+INSERT INTO conditions VALUES ( '2018-01-02 09:30:00-08', 'por', 100);
+INSERT INTO conditions VALUES ( '2018-01-02 09:20:00-08', 'SFO', 65);
+INSERT INTO conditions VALUES ( '2018-01-02 09:10:00-08', 'NYC', 65);
+INSERT INTO conditions VALUES ( '2018-11-01 09:20:00-08', 'NYC', 45);
+INSERT INTO conditions VALUES ( '2018-11-01 10:40:00-08', 'NYC', 55);
+INSERT INTO conditions VALUES ( '2018-11-01 11:50:00-08', 'NYC', 65);
+INSERT INTO conditions VALUES ( '2018-11-01 12:10:00-08', 'NYC', 75);
+INSERT INTO conditions VALUES ( '2018-11-01 13:10:00-08', 'NYC', 85);
+INSERT INTO conditions VALUES ( '2018-11-02 09:20:00-08', 'NYC', 10);
+INSERT INTO conditions VALUES ( '2018-11-02 10:30:00-08', 'NYC', 20);
+CREATE MATERIALIZED VIEW conditions_daily
+WITH (timescaledb.continuous) AS
+SELECT location,
+       time_bucket(INTERVAL '1 day', time) AS bucket,
+       AVG(temperature)
+  FROM conditions
+GROUP BY location, bucket
+WITH NO DATA;
+\d+ conditions_daily
+                                View "public.conditions_daily"
+  Column  |           Type           | Collation | Nullable | Default | Storage  | Description 
+----------+--------------------------+-----------+----------+---------+----------+-------------
+ location | text                     |           |          |         | extended | 
+ bucket   | timestamp with time zone |           |          |         | plain    | 
+ avg      | double precision         |           |          |         | plain    | 
+View definition:
+ SELECT _materialized_hypertable_55.location,
+    _materialized_hypertable_55.bucket,
+    _materialized_hypertable_55.avg
+   FROM _timescaledb_internal._materialized_hypertable_55;
+
+-- Should return NO ROWS
+SELECT * FROM conditions_daily ORDER BY bucket, avg;
+ location | bucket | avg 
+----------+--------+-----
+(0 rows)
+
+ALTER MATERIALIZED VIEW conditions_daily SET (timescaledb.materialized_only=false);
+\d+ conditions_daily
+                                View "public.conditions_daily"
+  Column  |           Type           | Collation | Nullable | Default | Storage  | Description 
+----------+--------------------------+-----------+----------+---------+----------+-------------
+ location | text                     |           |          |         | extended | 
+ bucket   | timestamp with time zone |           |          |         | plain    | 
+ avg      | double precision         |           |          |         | plain    | 
+View definition:
+ SELECT _materialized_hypertable_55.location,
+    _materialized_hypertable_55.bucket,
+    _materialized_hypertable_55.avg
+   FROM _timescaledb_internal._materialized_hypertable_55
+  WHERE _materialized_hypertable_55.bucket < COALESCE(_timescaledb_functions.to_timestamp(_timescaledb_functions.cagg_watermark(55)), '-infinity'::timestamp with time zone)
+UNION ALL
+ SELECT conditions.location,
+    time_bucket('@ 1 day'::interval, conditions."time") AS bucket,
+    avg(conditions.temperature) AS avg
+   FROM conditions
+  WHERE conditions."time" >= COALESCE(_timescaledb_functions.to_timestamp(_timescaledb_functions.cagg_watermark(55)), '-infinity'::timestamp with time zone)
+  GROUP BY conditions.location, (time_bucket('@ 1 day'::interval, conditions."time"));
+
+-- Should return ROWS because now it is realtime
+SELECT * FROM conditions_daily ORDER BY bucket, avg;
+ location |            bucket            | avg 
+----------+------------------------------+-----
+ SFO      | Sun Dec 31 16:00:00 2017 PST |  55
+ SFO      | Mon Jan 01 16:00:00 2018 PST |  65
+ NYC      | Mon Jan 01 16:00:00 2018 PST |  65
+ por      | Mon Jan 01 16:00:00 2018 PST | 100
+ NYC      | Wed Oct 31 17:00:00 2018 PDT |  65
+ NYC      | Thu Nov 01 17:00:00 2018 PDT |  15
+(6 rows)
+
+-- Should return ROWS because we refreshed it
+ALTER MATERIALIZED VIEW conditions_daily SET (timescaledb.materialized_only=true);
+\d+ conditions_daily
+                                View "public.conditions_daily"
+  Column  |           Type           | Collation | Nullable | Default | Storage  | Description 
+----------+--------------------------+-----------+----------+---------+----------+-------------
+ location | text                     |           |          |         | extended | 
+ bucket   | timestamp with time zone |           |          |         | plain    | 
+ avg      | double precision         |           |          |         | plain    | 
+View definition:
+ SELECT _materialized_hypertable_55.location,
+    _materialized_hypertable_55.bucket,
+    _materialized_hypertable_55.avg
+   FROM _timescaledb_internal._materialized_hypertable_55;
+
+CALL refresh_continuous_aggregate('conditions_daily', NULL, NULL);
+SELECT * FROM conditions_daily ORDER BY bucket, avg;
+ location |            bucket            | avg 
+----------+------------------------------+-----
+ SFO      | Sun Dec 31 16:00:00 2017 PST |  55
+ SFO      | Mon Jan 01 16:00:00 2018 PST |  65
+ NYC      | Mon Jan 01 16:00:00 2018 PST |  65
+ por      | Mon Jan 01 16:00:00 2018 PST | 100
+ NYC      | Wed Oct 31 17:00:00 2018 PDT |  65
+ NYC      | Thu Nov 01 17:00:00 2018 PDT |  15
+(6 rows)
 

--- a/tsl/test/expected/cagg_ddl_dist_ht.out
+++ b/tsl/test/expected/cagg_ddl_dist_ht.out
@@ -1140,39 +1140,39 @@ FROM (
 (3 rows)
 
 -- width expression for int2 hypertables
-CREATE MATERIALIZED VIEW width_expr WITH (timescaledb.continuous) AS
+CREATE MATERIALIZED VIEW width_expr WITH (timescaledb.continuous, timescaledb.materialized_only=false) AS
 SELECT time_bucket(1::smallint, time)
 FROM metrics_int2
 GROUP BY 1;
 psql:include/cagg_ddl_common.sql:750: NOTICE:  continuous aggregate "width_expr" is already up-to-date
 DROP MATERIALIZED VIEW width_expr;
-CREATE MATERIALIZED VIEW width_expr WITH (timescaledb.continuous) AS
+CREATE MATERIALIZED VIEW width_expr WITH (timescaledb.continuous, timescaledb.materialized_only=false) AS
 SELECT time_bucket(1::smallint + 2::smallint, time)
 FROM metrics_int2
 GROUP BY 1;
 psql:include/cagg_ddl_common.sql:757: NOTICE:  continuous aggregate "width_expr" is already up-to-date
 DROP MATERIALIZED VIEW width_expr;
 -- width expression for int4 hypertables
-CREATE MATERIALIZED VIEW width_expr WITH (timescaledb.continuous) AS
+CREATE MATERIALIZED VIEW width_expr WITH (timescaledb.continuous, timescaledb.materialized_only=false) AS
 SELECT time_bucket(1, time)
 FROM metrics_int4
 GROUP BY 1;
 psql:include/cagg_ddl_common.sql:765: NOTICE:  continuous aggregate "width_expr" is already up-to-date
 DROP MATERIALIZED VIEW width_expr;
-CREATE MATERIALIZED VIEW width_expr WITH (timescaledb.continuous) AS
+CREATE MATERIALIZED VIEW width_expr WITH (timescaledb.continuous, timescaledb.materialized_only=false) AS
 SELECT time_bucket(1 + 2, time)
 FROM metrics_int4
 GROUP BY 1;
 psql:include/cagg_ddl_common.sql:772: NOTICE:  continuous aggregate "width_expr" is already up-to-date
 DROP MATERIALIZED VIEW width_expr;
 -- width expression for int8 hypertables
-CREATE MATERIALIZED VIEW width_expr WITH (timescaledb.continuous) AS
+CREATE MATERIALIZED VIEW width_expr WITH (timescaledb.continuous, timescaledb.materialized_only=false) AS
 SELECT time_bucket(1, time)
 FROM metrics_int8
 GROUP BY 1;
 psql:include/cagg_ddl_common.sql:780: NOTICE:  continuous aggregate "width_expr" is already up-to-date
 DROP MATERIALIZED VIEW width_expr;
-CREATE MATERIALIZED VIEW width_expr WITH (timescaledb.continuous) AS
+CREATE MATERIALIZED VIEW width_expr WITH (timescaledb.continuous, timescaledb.materialized_only=false) AS
 SELECT time_bucket(1 + 2, time)
 FROM metrics_int8
 GROUP BY 1;
@@ -1180,17 +1180,17 @@ psql:include/cagg_ddl_common.sql:787: NOTICE:  continuous aggregate "width_expr"
 DROP MATERIALIZED VIEW width_expr;
 \set ON_ERROR_STOP 0
 -- non-immutable expresions should be rejected
-CREATE MATERIALIZED VIEW width_expr WITH (timescaledb.continuous) AS
+CREATE MATERIALIZED VIEW width_expr WITH (timescaledb.continuous, timescaledb.materialized_only=false) AS
 SELECT time_bucket(extract(year FROM now())::smallint, time)
 FROM metrics_int2
 GROUP BY 1;
 psql:include/cagg_ddl_common.sql:796: ERROR:  only immutable expressions allowed in time bucket function
-CREATE MATERIALIZED VIEW width_expr WITH (timescaledb.continuous) AS
+CREATE MATERIALIZED VIEW width_expr WITH (timescaledb.continuous, timescaledb.materialized_only=false) AS
 SELECT time_bucket(extract(year FROM now())::int, time)
 FROM metrics_int4
 GROUP BY 1;
 psql:include/cagg_ddl_common.sql:801: ERROR:  only immutable expressions allowed in time bucket function
-CREATE MATERIALIZED VIEW width_expr WITH (timescaledb.continuous) AS
+CREATE MATERIALIZED VIEW width_expr WITH (timescaledb.continuous, timescaledb.materialized_only=false) AS
 SELECT time_bucket(extract(year FROM now())::int, time)
 FROM metrics_int8
 GROUP BY 1;
@@ -1198,7 +1198,7 @@ psql:include/cagg_ddl_common.sql:806: ERROR:  only immutable expressions allowed
 \set ON_ERROR_STOP 1
 -- Test various ALTER MATERIALIZED VIEW statements.
 SET ROLE :ROLE_DEFAULT_PERM_USER;
-CREATE MATERIALIZED VIEW owner_check WITH (timescaledb.continuous) AS
+CREATE MATERIALIZED VIEW owner_check WITH (timescaledb.continuous, timescaledb.materialized_only=false) AS
 SELECT time_bucket(1 + 2, time)
 FROM metrics_int8
 GROUP BY 1
@@ -1336,7 +1336,7 @@ SELECT create_distributed_hypertable('test_schema.telemetry_raw', 'ts', replicat
 SELECT create_hypertable('test_schema.telemetry_raw', 'ts');
 \endif
 CREATE MATERIALIZED VIEW test_schema.telemetry_1s
-  WITH (timescaledb.continuous)
+  WITH (timescaledb.continuous, timescaledb.materialized_only=false)
     AS
 SELECT time_bucket(INTERVAL '1s', ts) AS ts_1s,
        avg(value)
@@ -1399,14 +1399,14 @@ SELECT create_distributed_hypertable('test_schema.telemetry_raw', 'ts', replicat
 SELECT create_hypertable('test_schema.telemetry_raw', 'ts');
 \endif
 CREATE MATERIALIZED VIEW test_schema.cagg1
-  WITH (timescaledb.continuous)
+  WITH (timescaledb.continuous, timescaledb.materialized_only=false)
     AS
 SELECT time_bucket(INTERVAL '1s', ts) AS ts_1s,
        avg(value)
   FROM test_schema.telemetry_raw
  GROUP BY ts_1s WITH NO DATA;
 CREATE MATERIALIZED VIEW test_schema.cagg2
-  WITH (timescaledb.continuous)
+  WITH (timescaledb.continuous, timescaledb.materialized_only=false)
     AS
 SELECT time_bucket(INTERVAL '1s', ts) AS ts_1s,
        avg(value)
@@ -1647,13 +1647,13 @@ SELECT create_distributed_hypertable('i3696', 'time', replication_factor => 2);
 \else
 SELECT table_name FROM create_hypertable('i3696','time');
 \endif
-CREATE MATERIALIZED VIEW i3696_cagg1 WITH (timescaledb.continuous)
+CREATE MATERIALIZED VIEW i3696_cagg1 WITH (timescaledb.continuous, timescaledb.materialized_only=false)
 AS
  SELECT  search_query,count(search_query) as count, sum(cnt), time_bucket(INTERVAL '1 minute', time) AS bucket
  FROM i3696 GROUP BY cnt +cnt2 , bucket, search_query;
 psql:include/cagg_ddl_common.sql:1108: NOTICE:  continuous aggregate "i3696_cagg1" is already up-to-date
 ALTER MATERIALIZED VIEW i3696_cagg1 SET (timescaledb.materialized_only = 'true');
-CREATE MATERIALIZED VIEW i3696_cagg2 WITH (timescaledb.continuous)
+CREATE MATERIALIZED VIEW i3696_cagg2 WITH (timescaledb.continuous, timescaledb.materialized_only=false)
 AS
  SELECT  search_query,count(search_query) as count, sum(cnt), time_bucket(INTERVAL '1 minute', time) AS bucket
  FROM i3696 GROUP BY cnt + cnt2, bucket, search_query
@@ -1673,7 +1673,7 @@ SELECT create_distributed_hypertable('test_setting', 'time', replication_factor 
 \else
 SELECT create_hypertable('test_setting', 'time');
 \endif
-CREATE MATERIALIZED VIEW test_setting_cagg with (timescaledb.continuous)
+CREATE MATERIALIZED VIEW test_setting_cagg with (timescaledb.continuous, timescaledb.materialized_only=false)
 AS SELECT time_bucket('1h',time), avg(val), count(*) FROM test_setting GROUP BY 1;
 psql:include/cagg_ddl_common.sql:1130: NOTICE:  continuous aggregate "test_setting_cagg" is already up-to-date
 INSERT INTO test_setting
@@ -1990,25 +1990,25 @@ SELECT * FROM cashflows;
 -- 4. test named bucket width
 -- named origin
 CREATE MATERIALIZED VIEW cagg_named_origin WITH
-(timescaledb.continuous) AS
+(timescaledb.continuous, timescaledb.materialized_only=false) AS
 SELECT time_bucket('1h', time, 'UTC', origin => '2001-01-03 01:23:45') AS bucket,
 avg(amount) as avg_amount
 FROM transactions GROUP BY 1 WITH NO DATA;
 -- named timezone
 CREATE MATERIALIZED VIEW cagg_named_tz_origin WITH
-(timescaledb.continuous) AS
+(timescaledb.continuous, timescaledb.materialized_only=false) AS
 SELECT time_bucket('1h', time, timezone => 'UTC', origin => '2001-01-03 01:23:45') AS bucket,
 avg(amount) as avg_amount
 FROM transactions GROUP BY 1 WITH NO DATA;
 -- named ts
 CREATE MATERIALIZED VIEW cagg_named_ts_tz_origin WITH
-(timescaledb.continuous) AS
+(timescaledb.continuous, timescaledb.materialized_only=false) AS
 SELECT time_bucket('1h', ts => time, timezone => 'UTC', origin => '2001-01-03 01:23:45') AS bucket,
 avg(amount) as avg_amount
 FROM transactions GROUP BY 1 WITH NO DATA;
 -- named bucket width
 CREATE MATERIALIZED VIEW cagg_named_all WITH
-(timescaledb.continuous) AS
+(timescaledb.continuous, timescaledb.materialized_only=false) AS
 SELECT time_bucket(bucket_width => '1h', ts => time, timezone => 'UTC', origin => '2001-01-03 01:23:45') AS bucket,
 avg(amount) as avg_amount
 FROM transactions GROUP BY 1 WITH NO DATA;
@@ -2058,7 +2058,7 @@ SELECT * FROM transactions_montly ORDER BY bucket;
 
 -- Check set_chunk_time_interval on continuous aggregate
 CREATE MATERIALIZED VIEW cagg_set_chunk_time_interval
-WITH (timescaledb.continuous) AS
+WITH (timescaledb.continuous, timescaledb.materialized_only=false) AS
 SELECT time_bucket(INTERVAL '1 month', time) AS bucket,
        SUM(fiat_value),
        MAX(fiat_value),
@@ -2081,6 +2081,124 @@ WHERE d.hypertable_id = ca.mat_hypertable_id;
 ----------
  t
 (1 row)
+
+-- Since #6077 CAggs are materialized only by default
+DROP TABLE conditions CASCADE;
+psql:include/cagg_ddl_common.sql:1365: NOTICE:  drop cascades to 3 other objects
+psql:include/cagg_ddl_common.sql:1365: NOTICE:  drop cascades to 2 other objects
+CREATE TABLE conditions (
+       time TIMESTAMPTZ NOT NULL,
+       location TEXT NOT NULL,
+       temperature DOUBLE PRECISION NULL
+);
+\if :IS_DISTRIBUTED
+SELECT create_distributed_hypertable('conditions', 'time', replication_factor => 2);
+ create_distributed_hypertable 
+-------------------------------
+ (54,public,conditions,t)
+(1 row)
+
+\else
+SELECT create_hypertable('conditions', 'time');
+\endif
+INSERT INTO conditions VALUES ( '2018-01-01 09:20:00-08', 'SFO', 55);
+INSERT INTO conditions VALUES ( '2018-01-02 09:30:00-08', 'por', 100);
+INSERT INTO conditions VALUES ( '2018-01-02 09:20:00-08', 'SFO', 65);
+INSERT INTO conditions VALUES ( '2018-01-02 09:10:00-08', 'NYC', 65);
+INSERT INTO conditions VALUES ( '2018-11-01 09:20:00-08', 'NYC', 45);
+INSERT INTO conditions VALUES ( '2018-11-01 10:40:00-08', 'NYC', 55);
+INSERT INTO conditions VALUES ( '2018-11-01 11:50:00-08', 'NYC', 65);
+INSERT INTO conditions VALUES ( '2018-11-01 12:10:00-08', 'NYC', 75);
+INSERT INTO conditions VALUES ( '2018-11-01 13:10:00-08', 'NYC', 85);
+INSERT INTO conditions VALUES ( '2018-11-02 09:20:00-08', 'NYC', 10);
+INSERT INTO conditions VALUES ( '2018-11-02 10:30:00-08', 'NYC', 20);
+CREATE MATERIALIZED VIEW conditions_daily
+WITH (timescaledb.continuous) AS
+SELECT location,
+       time_bucket(INTERVAL '1 day', time) AS bucket,
+       AVG(temperature)
+  FROM conditions
+GROUP BY location, bucket
+WITH NO DATA;
+\d+ conditions_daily
+                                View "public.conditions_daily"
+  Column  |           Type           | Collation | Nullable | Default | Storage  | Description 
+----------+--------------------------+-----------+----------+---------+----------+-------------
+ location | text                     |           |          |         | extended | 
+ bucket   | timestamp with time zone |           |          |         | plain    | 
+ avg      | double precision         |           |          |         | plain    | 
+View definition:
+ SELECT _materialized_hypertable_55.location,
+    _materialized_hypertable_55.bucket,
+    _materialized_hypertable_55.avg
+   FROM _timescaledb_internal._materialized_hypertable_55;
+
+-- Should return NO ROWS
+SELECT * FROM conditions_daily ORDER BY bucket, avg;
+ location | bucket | avg 
+----------+--------+-----
+(0 rows)
+
+ALTER MATERIALIZED VIEW conditions_daily SET (timescaledb.materialized_only=false);
+\d+ conditions_daily
+                                View "public.conditions_daily"
+  Column  |           Type           | Collation | Nullable | Default | Storage  | Description 
+----------+--------------------------+-----------+----------+---------+----------+-------------
+ location | text                     |           |          |         | extended | 
+ bucket   | timestamp with time zone |           |          |         | plain    | 
+ avg      | double precision         |           |          |         | plain    | 
+View definition:
+ SELECT _materialized_hypertable_55.location,
+    _materialized_hypertable_55.bucket,
+    _materialized_hypertable_55.avg
+   FROM _timescaledb_internal._materialized_hypertable_55
+  WHERE _materialized_hypertable_55.bucket < COALESCE(_timescaledb_functions.to_timestamp(_timescaledb_functions.cagg_watermark(55)), '-infinity'::timestamp with time zone)
+UNION ALL
+ SELECT conditions.location,
+    time_bucket('@ 1 day'::interval, conditions."time") AS bucket,
+    avg(conditions.temperature) AS avg
+   FROM conditions
+  WHERE conditions."time" >= COALESCE(_timescaledb_functions.to_timestamp(_timescaledb_functions.cagg_watermark(55)), '-infinity'::timestamp with time zone)
+  GROUP BY conditions.location, (time_bucket('@ 1 day'::interval, conditions."time"));
+
+-- Should return ROWS because now it is realtime
+SELECT * FROM conditions_daily ORDER BY bucket, avg;
+ location |            bucket            | avg 
+----------+------------------------------+-----
+ SFO      | Sun Dec 31 16:00:00 2017 PST |  55
+ NYC      | Mon Jan 01 16:00:00 2018 PST |  65
+ SFO      | Mon Jan 01 16:00:00 2018 PST |  65
+ por      | Mon Jan 01 16:00:00 2018 PST | 100
+ NYC      | Wed Oct 31 17:00:00 2018 PDT |  65
+ NYC      | Thu Nov 01 17:00:00 2018 PDT |  15
+(6 rows)
+
+-- Should return ROWS because we refreshed it
+ALTER MATERIALIZED VIEW conditions_daily SET (timescaledb.materialized_only=true);
+\d+ conditions_daily
+                                View "public.conditions_daily"
+  Column  |           Type           | Collation | Nullable | Default | Storage  | Description 
+----------+--------------------------+-----------+----------+---------+----------+-------------
+ location | text                     |           |          |         | extended | 
+ bucket   | timestamp with time zone |           |          |         | plain    | 
+ avg      | double precision         |           |          |         | plain    | 
+View definition:
+ SELECT _materialized_hypertable_55.location,
+    _materialized_hypertable_55.bucket,
+    _materialized_hypertable_55.avg
+   FROM _timescaledb_internal._materialized_hypertable_55;
+
+CALL refresh_continuous_aggregate('conditions_daily', NULL, NULL);
+SELECT * FROM conditions_daily ORDER BY bucket, avg;
+ location |            bucket            | avg 
+----------+------------------------------+-----
+ SFO      | Sun Dec 31 16:00:00 2017 PST |  55
+ SFO      | Mon Jan 01 16:00:00 2018 PST |  65
+ NYC      | Mon Jan 01 16:00:00 2018 PST |  65
+ por      | Mon Jan 01 16:00:00 2018 PST | 100
+ NYC      | Wed Oct 31 17:00:00 2018 PDT |  65
+ NYC      | Thu Nov 01 17:00:00 2018 PDT |  15
+(6 rows)
 
 -- cleanup
 \c :TEST_DBNAME :ROLE_CLUSTER_SUPERUSER;

--- a/tsl/test/expected/cagg_drop_chunks.out
+++ b/tsl/test/expected/cagg_drop_chunks.out
@@ -24,7 +24,7 @@ SELECT * FROM create_hypertable('records', 'time',
 (1 row)
 
 CREATE MATERIALIZED VIEW records_monthly
-    WITH (timescaledb.continuous)
+    WITH (timescaledb.continuous, timescaledb.materialized_only=false)
     AS
         SELECT time_bucket('1d', time) as bucket,
             clientId,

--- a/tsl/test/expected/cagg_errors.out
+++ b/tsl/test/expected/cagg_errors.out
@@ -19,38 +19,38 @@ select table_name from create_hypertable( 'conditions', 'timec');
  conditions
 (1 row)
 
-CREATE MATERIALIZED VIEW mat_m1 WITH ( timescaledb.continuous, timescaledb.myfill = 1)
+CREATE MATERIALIZED VIEW mat_m1 WITH (timescaledb.continuous, timescaledb.materialized_only=false, timescaledb.myfill = 1)
 as
 select location , min(temperature)
 from conditions
 group by time_bucket('1d', timec), location WITH NO DATA;
 ERROR:  unrecognized parameter "timescaledb.myfill"
 --valid PG option
-CREATE MATERIALIZED VIEW mat_m1 WITH ( timescaledb.continuous, check_option = LOCAL )
+CREATE MATERIALIZED VIEW mat_m1 WITH (timescaledb.continuous, timescaledb.materialized_only=false, check_option = LOCAL )
 as
 select * from conditions , mat_t1 WITH NO DATA;
 ERROR:  unsupported combination of storage parameters
 DETAIL:  A continuous aggregate does not support standard storage parameters.
 HINT:  Use only parameters with the "timescaledb." prefix when creating a continuous aggregate.
 --non-hypertable
-CREATE MATERIALIZED VIEW mat_m1 WITH ( timescaledb.continuous)
+CREATE MATERIALIZED VIEW mat_m1 WITH (timescaledb.continuous, timescaledb.materialized_only=false)
 as
 select a, count(*) from mat_t1
 group by a WITH NO DATA;
 ERROR:  table "mat_t1" is not a hypertable
 -- no group by
-CREATE MATERIALIZED VIEW mat_m1 WITH ( timescaledb.continuous)
+CREATE MATERIALIZED VIEW mat_m1 WITH (timescaledb.continuous, timescaledb.materialized_only=false)
 as
 select count(*) from conditions  WITH NO DATA;
 ERROR:  invalid continuous aggregate query
 HINT:  Include at least one aggregate function and a GROUP BY clause with time bucket.
 -- no time_bucket in group by
-CREATE MATERIALIZED VIEW mat_m1 WITH ( timescaledb.continuous)
+CREATE MATERIALIZED VIEW mat_m1 WITH (timescaledb.continuous, timescaledb.materialized_only=false)
 as
 select count(*) from conditions group by location WITH NO DATA;
 ERROR:  continuous aggregate view must include a valid time bucket function
 -- with valid query in a CTE
-CREATE MATERIALIZED VIEW mat_m1 WITH ( timescaledb.continuous)
+CREATE MATERIALIZED VIEW mat_m1 WITH (timescaledb.continuous, timescaledb.materialized_only=false)
 AS
 with m1 as (
 Select location, count(*) from conditions
@@ -59,41 +59,41 @@ select * from m1 WITH NO DATA;
 ERROR:  invalid continuous aggregate query
 DETAIL:  CTEs, subqueries and set-returning functions are not supported by continuous aggregates.
 --with DISTINCT ON
-CREATE MATERIALIZED VIEW mat_m1 WITH ( timescaledb.continuous)
+CREATE MATERIALIZED VIEW mat_m1 WITH (timescaledb.continuous, timescaledb.materialized_only=false)
 as
  select distinct on ( location ) count(*)  from conditions group by location, time_bucket('1week', timec)  WITH NO DATA;
 ERROR:  invalid continuous aggregate query
 DETAIL:  DISTINCT / DISTINCT ON queries are not supported by continuous aggregates.
 -- time_bucket on non partitioning column of hypertable
-CREATE MATERIALIZED VIEW mat_m1 WITH ( timescaledb.continuous)
+CREATE MATERIALIZED VIEW mat_m1 WITH (timescaledb.continuous, timescaledb.materialized_only=false)
 AS
 Select max(temperature)
 from conditions
  group by time_bucket('1week', timemeasure) , location WITH NO DATA;
 ERROR:  time bucket function must reference a hypertable dimension column
 --time_bucket on expression
-CREATE MATERIALIZED VIEW mat_m1 WITH ( timescaledb.continuous)
+CREATE MATERIALIZED VIEW mat_m1 WITH (timescaledb.continuous, timescaledb.materialized_only=false)
 AS
 Select max(temperature)
 from conditions
  group by time_bucket('1week', timec+ '10 minutes'::interval) , location WITH NO DATA;
 ERROR:  time bucket function must reference a hypertable dimension column
 --multiple time_bucket functions
-CREATE MATERIALIZED VIEW mat_m1 WITH ( timescaledb.continuous)
+CREATE MATERIALIZED VIEW mat_m1 WITH (timescaledb.continuous, timescaledb.materialized_only=false)
 AS
 Select max(temperature)
 from conditions
  group by time_bucket('1week', timec) , time_bucket('1month', timec), location WITH NO DATA;
 ERROR:  continuous aggregate view cannot contain multiple time bucket functions
 --time_bucket using additional args
-CREATE MATERIALIZED VIEW mat_m1 WITH ( timescaledb.continuous)
+CREATE MATERIALIZED VIEW mat_m1 WITH (timescaledb.continuous, timescaledb.materialized_only=false)
 AS
 Select max(temperature)
 from conditions
  group by time_bucket( INTERVAL '5 minutes', timec, INTERVAL '-2.5 minutes') , location WITH NO DATA;
 ERROR:  continuous aggregate view must include a valid time bucket function
 --time_bucket using non-const for first argument
-CREATE MATERIALIZED VIEW mat_m1 WITH ( timescaledb.continuous)
+CREATE MATERIALIZED VIEW mat_m1 WITH (timescaledb.continuous, timescaledb.materialized_only=false)
 AS
 Select max(temperature)
 from conditions
@@ -101,7 +101,7 @@ from conditions
 ERROR:  only immutable expressions allowed in time bucket function
 HINT:  Use an immutable expression as first argument to the time bucket function.
 --window function
-CREATE MATERIALIZED VIEW mat_m1 WITH ( timescaledb.continuous)
+CREATE MATERIALIZED VIEW mat_m1 WITH (timescaledb.continuous, timescaledb.materialized_only=false)
 AS
 Select avg(temperature) over( order by humidity)
 from conditions
@@ -109,7 +109,7 @@ from conditions
 ERROR:  invalid continuous aggregate query
 DETAIL:  Window functions are not supported by continuous aggregates.
 --aggregate without combine function but stable function
-CREATE MATERIALIZED VIEW mat_m1 WITH ( timescaledb.continuous)
+CREATE MATERIALIZED VIEW mat_m1 WITH (timescaledb.continuous, timescaledb.materialized_only=false)
 AS
 Select json_agg(location)
 from conditions
@@ -118,7 +118,7 @@ ERROR:  only immutable functions supported in continuous aggregate view
 HINT:  Make sure all functions in the continuous aggregate definition have IMMUTABLE volatility. Note that functions or expressions may be IMMUTABLE for one data type, but STABLE or VOLATILE for another.
 ;
 -- using subqueries
-CREATE MATERIALIZED VIEW mat_m1 WITH ( timescaledb.continuous)
+CREATE MATERIALIZED VIEW mat_m1 WITH (timescaledb.continuous, timescaledb.materialized_only=false)
 AS
 Select sum(humidity), avg(temperature::int4)
 from
@@ -126,7 +126,7 @@ from
 from conditions ) q
  group by time_bucket('1week', timec) , location  WITH NO DATA;
 ERROR:  invalid continuous aggregate view
-CREATE MATERIALIZED VIEW mat_m1 WITH ( timescaledb.continuous)
+CREATE MATERIALIZED VIEW mat_m1 WITH (timescaledb.continuous, timescaledb.materialized_only=false)
 AS
 select * from
 ( Select sum(humidity), avg(temperature::int4)
@@ -135,7 +135,7 @@ from conditions
 ERROR:  invalid continuous aggregate query
 HINT:  Include at least one aggregate function and a GROUP BY clause with time bucket.
 --using limit /limit offset
-CREATE MATERIALIZED VIEW mat_m1 WITH ( timescaledb.continuous)
+CREATE MATERIALIZED VIEW mat_m1 WITH (timescaledb.continuous, timescaledb.materialized_only=false)
 AS
 Select sum(humidity), avg(temperature::int4)
 from conditions
@@ -144,7 +144,7 @@ limit 10  WITH NO DATA;
 ERROR:  invalid continuous aggregate query
 DETAIL:  LIMIT and LIMIT OFFSET are not supported in queries defining continuous aggregates.
 HINT:  Use LIMIT and LIMIT OFFSET in SELECTS from the continuous aggregate view instead.
-CREATE MATERIALIZED VIEW mat_m1 WITH ( timescaledb.continuous)
+CREATE MATERIALIZED VIEW mat_m1 WITH (timescaledb.continuous, timescaledb.materialized_only=false)
 AS
 Select sum(humidity), avg(temperature::int4)
 from conditions
@@ -154,7 +154,7 @@ ERROR:  invalid continuous aggregate query
 DETAIL:  LIMIT and LIMIT OFFSET are not supported in queries defining continuous aggregates.
 HINT:  Use LIMIT and LIMIT OFFSET in SELECTS from the continuous aggregate view instead.
 --using FETCH
-CREATE MATERIALIZED VIEW mat_m1 WITH ( timescaledb.continuous)
+CREATE MATERIALIZED VIEW mat_m1 WITH (timescaledb.continuous, timescaledb.materialized_only=false)
 AS
 Select sum(humidity), avg(temperature::int4)
 from conditions
@@ -165,28 +165,28 @@ DETAIL:  LIMIT and LIMIT OFFSET are not supported in queries defining continuous
 HINT:  Use LIMIT and LIMIT OFFSET in SELECTS from the continuous aggregate view instead.
 --using locking clauses FOR clause
 --all should be disabled. we cannot guarntee locks on the hypertable
-CREATE MATERIALIZED VIEW mat_m1 WITH ( timescaledb.continuous)
+CREATE MATERIALIZED VIEW mat_m1 WITH (timescaledb.continuous, timescaledb.materialized_only=false)
 AS
 Select sum(humidity), avg(temperature::int4)
 from conditions
  group by time_bucket('1week', timec) , location
 FOR KEY SHARE WITH NO DATA;
 ERROR:  FOR KEY SHARE is not allowed with GROUP BY clause
-CREATE MATERIALIZED VIEW mat_m1 WITH ( timescaledb.continuous)
+CREATE MATERIALIZED VIEW mat_m1 WITH (timescaledb.continuous, timescaledb.materialized_only=false)
 AS
 Select sum(humidity), avg(temperature::int4)
 from conditions
  group by time_bucket('1week', timec) , location
 FOR SHARE WITH NO DATA;
 ERROR:  FOR SHARE is not allowed with GROUP BY clause
-CREATE MATERIALIZED VIEW mat_m1 WITH ( timescaledb.continuous)
+CREATE MATERIALIZED VIEW mat_m1 WITH (timescaledb.continuous, timescaledb.materialized_only=false)
 AS
 Select sum(humidity), avg(temperature::int4)
 from conditions
  group by time_bucket('1week', timec) , location
 FOR UPDATE WITH NO DATA;
 ERROR:  FOR UPDATE is not allowed with GROUP BY clause
-CREATE MATERIALIZED VIEW mat_m1 WITH ( timescaledb.continuous)
+CREATE MATERIALIZED VIEW mat_m1 WITH (timescaledb.continuous, timescaledb.materialized_only=false)
 AS
 Select sum(humidity), avg(temperature::int4)
 from conditions
@@ -194,7 +194,7 @@ from conditions
 FOR NO KEY UPDATE WITH NO DATA;
 ERROR:  FOR NO KEY UPDATE is not allowed with GROUP BY clause
 --tablesample clause
-CREATE MATERIALIZED VIEW mat_m1 WITH ( timescaledb.continuous)
+CREATE MATERIALIZED VIEW mat_m1 WITH (timescaledb.continuous, timescaledb.materialized_only=false)
 AS
 Select sum(humidity), avg(temperature::int4)
 from conditions tablesample bernoulli(0.2)
@@ -202,14 +202,14 @@ from conditions tablesample bernoulli(0.2)
  WITH NO DATA;
 ERROR:  invalid continuous aggregate view
 -- ONLY in from clause
-CREATE MATERIALIZED VIEW mat_m1 WITH ( timescaledb.continuous)
+CREATE MATERIALIZED VIEW mat_m1 WITH (timescaledb.continuous, timescaledb.materialized_only=false)
 AS
 Select sum(humidity), avg(temperature::int4)
 from ONLY conditions
  group by time_bucket('1week', timec) , location  WITH NO DATA;
 ERROR:  invalid continuous aggregate view
 --grouping sets and variants
-CREATE MATERIALIZED VIEW mat_m1 WITH ( timescaledb.continuous)
+CREATE MATERIALIZED VIEW mat_m1 WITH (timescaledb.continuous, timescaledb.materialized_only=false)
 AS
 Select sum(humidity), avg(temperature::int4)
 from conditions
@@ -217,7 +217,7 @@ from conditions
 ERROR:  invalid continuous aggregate query
 DETAIL:  GROUP BY GROUPING SETS, ROLLUP and CUBE are not supported by continuous aggregates
 HINT:  Define multiple continuous aggregates with different grouping levels.
-CREATE MATERIALIZED VIEW mat_m1 WITH ( timescaledb.continuous)
+CREATE MATERIALIZED VIEW mat_m1 WITH (timescaledb.continuous, timescaledb.materialized_only=false)
 AS
 Select sum(humidity), avg(temperature::int4)
 from conditions
@@ -228,21 +228,21 @@ HINT:  Define multiple continuous aggregates with different grouping levels.
 --NO immutable functions -- check all clauses
 CREATE FUNCTION test_stablefunc(int) RETURNS int LANGUAGE 'sql'
        STABLE AS 'SELECT $1 + 10';
-CREATE MATERIALIZED VIEW mat_m1 WITH ( timescaledb.continuous)
+CREATE MATERIALIZED VIEW mat_m1 WITH (timescaledb.continuous, timescaledb.materialized_only=false)
 AS
 Select sum(humidity), max(timec + INTERVAL '1h')
 from conditions
 group by time_bucket('1week', timec) , location   WITH NO DATA;
 ERROR:  only immutable functions supported in continuous aggregate view
 HINT:  Make sure all functions in the continuous aggregate definition have IMMUTABLE volatility. Note that functions or expressions may be IMMUTABLE for one data type, but STABLE or VOLATILE for another.
-CREATE MATERIALIZED VIEW mat_m1 WITH ( timescaledb.continuous)
+CREATE MATERIALIZED VIEW mat_m1 WITH (timescaledb.continuous, timescaledb.materialized_only=false)
 AS
 Select sum( test_stablefunc(humidity::int) ), min(location)
 from conditions
 group by time_bucket('1week', timec) WITH NO DATA;
 ERROR:  only immutable functions supported in continuous aggregate view
 HINT:  Make sure all functions in the continuous aggregate definition have IMMUTABLE volatility. Note that functions or expressions may be IMMUTABLE for one data type, but STABLE or VOLATILE for another.
-CREATE MATERIALIZED VIEW mat_m1 WITH ( timescaledb.continuous)
+CREATE MATERIALIZED VIEW mat_m1 WITH (timescaledb.continuous, timescaledb.materialized_only=false)
 AS
 Select sum( temperature ), min(location)
 from conditions
@@ -250,7 +250,7 @@ group by time_bucket('1week', timec), test_stablefunc(humidity::int) WITH NO DAT
 ERROR:  only immutable functions supported in continuous aggregate view
 HINT:  Make sure all functions in the continuous aggregate definition have IMMUTABLE volatility. Note that functions or expressions may be IMMUTABLE for one data type, but STABLE or VOLATILE for another.
 -- Should use CREATE MATERIALIZED VIEW to create continuous aggregates
-CREATE VIEW continuous_aggs_errors_tbl1 WITH (timescaledb.continuous) AS
+CREATE VIEW continuous_aggs_errors_tbl1 WITH (timescaledb.continuous, timescaledb.materialized_only=false) AS
 SELECT time_bucket('1 week', timec)
   FROM conditions
 GROUP BY time_bucket('1 week', timec);
@@ -275,7 +275,7 @@ SELECT set_integer_now_func('rowsec_tab', 'integer_now_test');
 
 alter table rowsec_tab ENABLE ROW LEVEL SECURITY;
 create policy rowsec_tab_allview ON rowsec_tab FOR SELECT USING(true);
-CREATE MATERIALIZED VIEW mat_m1 WITH ( timescaledb.continuous)
+CREATE MATERIALIZED VIEW mat_m1 WITH (timescaledb.continuous, timescaledb.materialized_only=false)
 AS
 Select sum( b), min(c)
 from rowsec_tab
@@ -299,7 +299,7 @@ select table_name from create_hypertable( 'conditions', 'timec');
 (1 row)
 
 create materialized view mat_with_test( timec, minl, sumt , sumh)
-WITH (timescaledb.continuous)
+WITH (timescaledb.continuous, timescaledb.materialized_only=false)
 as
 select time_bucket('1day', timec), min(location), sum(temperature),sum(humidity)
 from conditions
@@ -348,14 +348,14 @@ SELECT set_integer_now_func('conditions', 'integer_now_test_s');
 
 \set ON_ERROR_STOP 0
 create materialized view mat_with_test( timec, minl, sumt , sumh)
-WITH (timescaledb.continuous)
+WITH (timescaledb.continuous, timescaledb.materialized_only=false)
 as
 select time_bucket(100, timec), min(location), sum(temperature),sum(humidity)
 from conditions
 group by time_bucket(100, timec) WITH NO DATA;
 ERROR:  time bucket function must reference a hypertable dimension column
 create materialized view mat_with_test( timec, minl, sumt , sumh)
-WITH (timescaledb.continuous)
+WITH (timescaledb.continuous, timescaledb.materialized_only=false)
 as
 select time_bucket(100, timec), min(location), sum(temperature),sum(humidity)
 from conditions
@@ -363,7 +363,7 @@ group by time_bucket(100, timec) WITH NO DATA;
 ERROR:  time bucket function must reference a hypertable dimension column
 ALTER TABLE conditions ALTER timec type int;
 create materialized view mat_with_test( timec, minl, sumt , sumh)
-WITH (timescaledb.continuous)
+WITH (timescaledb.continuous, timescaledb.materialized_only=false)
 as
 select time_bucket(100, timec), min(location), sum(temperature),sum(humidity)
 from conditions
@@ -394,7 +394,7 @@ SELECT set_integer_now_func('conditions', 'integer_now_test_b');
 (1 row)
 
 create materialized view mat_with_test( timec, minl, sumt , sumh)
-WITH (timescaledb.continuous)
+WITH (timescaledb.continuous, timescaledb.materialized_only=false)
 as
 select time_bucket(BIGINT '100', timec), min(location), sum(temperature),sum(humidity)
 from conditions
@@ -414,7 +414,7 @@ NOTICE:  adding not-null constraint to column "time"
 \set VERBOSITY default
 \set ON_ERROR_STOP 0
 CREATE MATERIALIZED VIEW text_view
-    WITH (timescaledb.continuous)
+    WITH (timescaledb.continuous, timescaledb.materialized_only=false)
     AS SELECT time_bucket('5', text_part_func(time)), COUNT(time)
         FROM text_time
         GROUP BY 1 WITH NO DATA;
@@ -443,7 +443,7 @@ SELECT create_hypertable('measurements', 'time');
 INSERT INTO measurements VALUES ('2019-03-04 13:30', 1, 1.3);
 -- Add a continuous aggregate on the measurements table and a policy
 -- to be able to test error cases for the add_job function.
-CREATE MATERIALIZED VIEW measurements_summary WITH (timescaledb.continuous) AS
+CREATE MATERIALIZED VIEW measurements_summary WITH (timescaledb.continuous, timescaledb.materialized_only=false) AS
 SELECT time_bucket('1 day', time), COUNT(time)
   FROM measurements
 GROUP BY 1 WITH NO DATA;
@@ -523,18 +523,18 @@ select create_hypertable('i2980','time');
  (12,public,i2980,t)
 (1 row)
 
-create materialized view i2980_cagg with (timescaledb.continuous) AS SELECT time_bucket('1h',time), avg(7) FROM i2980 GROUP BY 1;
+create materialized view i2980_cagg with (timescaledb.continuous, timescaledb.materialized_only=false) AS SELECT time_bucket('1h',time), avg(7) FROM i2980 GROUP BY 1;
 NOTICE:  continuous aggregate "i2980_cagg" is already up-to-date
 select add_continuous_aggregate_policy('i2980_cagg',NULL,NULL,'4h') AS job_id \gset
 \set ON_ERROR_STOP 0
 select alter_job(:job_id,config:='{"end_offset": null, "start_offset": null, "mat_hypertable_id": 1000}');
 ERROR:  configuration materialization hypertable id 1000 not found
 --test creating continuous aggregate with compression enabled --
-CREATE MATERIALIZED VIEW  i2980_cagg2 with (timescaledb.continuous, timescaledb.compress)
+CREATE MATERIALIZED VIEW  i2980_cagg2 with (timescaledb.continuous, timescaledb.materialized_only=false, timescaledb.compress)
 AS SELECT time_bucket('1h',time), avg(7) FROM i2980 GROUP BY 1;
 ERROR:  cannot enable compression while creating a continuous aggregate
 --this one succeeds
-CREATE MATERIALIZED VIEW  i2980_cagg2 with (timescaledb.continuous)
+CREATE MATERIALIZED VIEW  i2980_cagg2 with (timescaledb.continuous, timescaledb.materialized_only=false)
 AS SELECT time_bucket('1h',time) as bucket, avg(7) FROM i2980 GROUP BY 1;
 NOTICE:  continuous aggregate "i2980_cagg2" is already up-to-date
 --now enable compression with invalid parameters
@@ -617,7 +617,7 @@ FROM
   _timescaledb_catalog.hypertable ht
   INNER JOIN _timescaledb_catalog.hypertable uncompress ON (ht.id = uncompress.compressed_hypertable_id
       AND uncompress.table_name = 'comp_ht_test') \gset
-CREATE MATERIALIZED VIEW cagg1 WITH(timescaledb.continuous) AS SELECT time_bucket('1h',_ts_meta_min_1) FROM :INTERNALTABLE GROUP BY 1;
+CREATE MATERIALIZED VIEW cagg1 WITH(timescaledb.continuous, timescaledb.materialized_only=false) AS SELECT time_bucket('1h',_ts_meta_min_1) FROM :INTERNALTABLE GROUP BY 1;
 ERROR:  hypertable is an internal compressed hypertable
 --TEST ht + cagg, do not enable compression on ht and try to compress chunk on ht.
 --Check error handling for this case
@@ -625,12 +625,12 @@ SELECT compress_chunk(ch) FROM show_chunks('i2980') ch;
 ERROR:  compression not enabled on "i2980"
 -- cagg on normal view should error out
 CREATE VIEW v1 AS SELECT now() AS time;
-CREATE MATERIALIZED VIEW cagg1 WITH (timescaledb.continuous) AS SELECT time_bucket('1h',time) FROM v1 GROUP BY 1;
+CREATE MATERIALIZED VIEW cagg1 WITH (timescaledb.continuous, timescaledb.materialized_only=false) AS SELECT time_bucket('1h',time) FROM v1 GROUP BY 1;
 ERROR:  invalid continuous aggregate query
 -- cagg on normal view should error out
 CREATE MATERIALIZED VIEW matv1 AS SELECT now() AS time;
-CREATE MATERIALIZED VIEW cagg1 WITH (timescaledb.continuous) AS SELECT time_bucket('1h',time) FROM matv1 GROUP BY 1;
+CREATE MATERIALIZED VIEW cagg1 WITH (timescaledb.continuous, timescaledb.materialized_only=false) AS SELECT time_bucket('1h',time) FROM matv1 GROUP BY 1;
 ERROR:  invalid continuous aggregate view
 -- No FROM clause in CAGG definition
-CREATE MATERIALIZED VIEW cagg1 with (timescaledb.continuous) AS SELECT 1 GROUP BY 1 WITH NO DATA;
+CREATE MATERIALIZED VIEW cagg1 with (timescaledb.continuous, timescaledb.materialized_only=false) AS SELECT 1 GROUP BY 1 WITH NO DATA;
 ERROR:  invalid continuous aggregate query

--- a/tsl/test/expected/cagg_errors_deprecated.out
+++ b/tsl/test/expected/cagg_errors_deprecated.out
@@ -19,38 +19,38 @@ select table_name from create_hypertable( 'conditions', 'timec');
  conditions
 (1 row)
 
-CREATE MATERIALIZED VIEW mat_m1 WITH (timescaledb.continuous, timescaledb.finalized = false, timescaledb.myfill = 1)
+CREATE MATERIALIZED VIEW mat_m1 WITH (timescaledb.continuous, timescaledb.materialized_only=false, timescaledb.finalized = false, timescaledb.myfill = 1)
 as
 select location , min(temperature)
 from conditions
 group by time_bucket('1d', timec), location WITH NO DATA;
 ERROR:  unrecognized parameter "timescaledb.myfill"
 --valid PG option
-CREATE MATERIALIZED VIEW mat_m1 WITH (timescaledb.continuous, timescaledb.finalized = false, check_option = LOCAL )
+CREATE MATERIALIZED VIEW mat_m1 WITH (timescaledb.continuous, timescaledb.materialized_only=false, timescaledb.finalized = false, check_option = LOCAL )
 as
 select * from conditions , mat_t1 WITH NO DATA;
 ERROR:  unsupported combination of storage parameters
 DETAIL:  A continuous aggregate does not support standard storage parameters.
 HINT:  Use only parameters with the "timescaledb." prefix when creating a continuous aggregate.
 --non-hypertable
-CREATE MATERIALIZED VIEW mat_m1 WITH (timescaledb.continuous, timescaledb.finalized = false)
+CREATE MATERIALIZED VIEW mat_m1 WITH (timescaledb.continuous, timescaledb.materialized_only=false, timescaledb.finalized = false)
 as
 select a, count(*) from mat_t1
 group by a WITH NO DATA;
 ERROR:  table "mat_t1" is not a hypertable
 -- no group by
-CREATE MATERIALIZED VIEW mat_m1 WITH (timescaledb.continuous, timescaledb.finalized = false)
+CREATE MATERIALIZED VIEW mat_m1 WITH (timescaledb.continuous, timescaledb.materialized_only=false, timescaledb.finalized = false)
 as
 select count(*) from conditions  WITH NO DATA;
 ERROR:  invalid continuous aggregate query
 HINT:  Include at least one aggregate function and a GROUP BY clause with time bucket.
 -- no time_bucket in group by
-CREATE MATERIALIZED VIEW mat_m1 WITH (timescaledb.continuous, timescaledb.finalized = false)
+CREATE MATERIALIZED VIEW mat_m1 WITH (timescaledb.continuous, timescaledb.materialized_only=false, timescaledb.finalized = false)
 as
 select count(*) from conditions group by location WITH NO DATA;
 ERROR:  continuous aggregate view must include a valid time bucket function
 -- with valid query in a CTE
-CREATE MATERIALIZED VIEW mat_m1 WITH (timescaledb.continuous, timescaledb.finalized = false)
+CREATE MATERIALIZED VIEW mat_m1 WITH (timescaledb.continuous, timescaledb.materialized_only=false, timescaledb.finalized = false)
 AS
 with m1 as (
 Select location, count(*) from conditions
@@ -59,27 +59,27 @@ select * from m1 WITH NO DATA;
 ERROR:  invalid continuous aggregate query
 DETAIL:  CTEs, subqueries and set-returning functions are not supported by continuous aggregates.
 --with DISTINCT ON
-CREATE MATERIALIZED VIEW mat_m1 WITH (timescaledb.continuous, timescaledb.finalized = false)
+CREATE MATERIALIZED VIEW mat_m1 WITH (timescaledb.continuous, timescaledb.materialized_only=false, timescaledb.finalized = false)
 as
  select distinct on ( location ) count(*)  from conditions group by location, time_bucket('1week', timec)  WITH NO DATA;
 ERROR:  invalid continuous aggregate query
 DETAIL:  DISTINCT / DISTINCT ON queries are not supported by continuous aggregates.
 --aggregate with DISTINCT
-CREATE MATERIALIZED VIEW mat_m1 WITH (timescaledb.continuous, timescaledb.finalized = false)
+CREATE MATERIALIZED VIEW mat_m1 WITH (timescaledb.continuous, timescaledb.materialized_only=false, timescaledb.finalized = false)
 AS
 Select time_bucket('1week', timec),
  count(location) , sum(distinct temperature) from conditions
  group by time_bucket('1week', timec) , location WITH NO DATA;
 ERROR:  aggregates with FILTER / DISTINCT / ORDER BY are not supported
 --aggregate with FILTER
-CREATE MATERIALIZED VIEW mat_m1 WITH (timescaledb.continuous, timescaledb.finalized = false)
+CREATE MATERIALIZED VIEW mat_m1 WITH (timescaledb.continuous, timescaledb.materialized_only=false, timescaledb.finalized = false)
 AS
 Select time_bucket('1week', timec),
  sum(temperature) filter ( where humidity > 20 ) from conditions
  group by time_bucket('1week', timec) , location WITH NO DATA;
 ERROR:  aggregates with FILTER / DISTINCT / ORDER BY are not supported
 -- aggregate with filter in having clause
-CREATE MATERIALIZED VIEW mat_m1 WITH (timescaledb.continuous, timescaledb.finalized = false)
+CREATE MATERIALIZED VIEW mat_m1 WITH (timescaledb.continuous, timescaledb.materialized_only=false, timescaledb.finalized = false)
 AS
 Select time_bucket('1week', timec), max(temperature)
 from conditions
@@ -87,35 +87,35 @@ from conditions
  having sum(temperature) filter ( where humidity > 20 ) > 50 WITH NO DATA;
 ERROR:  aggregates with FILTER / DISTINCT / ORDER BY are not supported
 -- time_bucket on non partitioning column of hypertable
-CREATE MATERIALIZED VIEW mat_m1 WITH (timescaledb.continuous, timescaledb.finalized = false)
+CREATE MATERIALIZED VIEW mat_m1 WITH (timescaledb.continuous, timescaledb.materialized_only=false, timescaledb.finalized = false)
 AS
 Select max(temperature)
 from conditions
  group by time_bucket('1week', timemeasure) , location WITH NO DATA;
 ERROR:  time bucket function must reference a hypertable dimension column
 --time_bucket on expression
-CREATE MATERIALIZED VIEW mat_m1 WITH (timescaledb.continuous, timescaledb.finalized = false)
+CREATE MATERIALIZED VIEW mat_m1 WITH (timescaledb.continuous, timescaledb.materialized_only=false, timescaledb.finalized = false)
 AS
 Select max(temperature)
 from conditions
  group by time_bucket('1week', timec+ '10 minutes'::interval) , location WITH NO DATA;
 ERROR:  time bucket function must reference a hypertable dimension column
 --multiple time_bucket functions
-CREATE MATERIALIZED VIEW mat_m1 WITH (timescaledb.continuous, timescaledb.finalized = false)
+CREATE MATERIALIZED VIEW mat_m1 WITH (timescaledb.continuous, timescaledb.materialized_only=false, timescaledb.finalized = false)
 AS
 Select max(temperature)
 from conditions
  group by time_bucket('1week', timec) , time_bucket('1month', timec), location WITH NO DATA;
 ERROR:  continuous aggregate view cannot contain multiple time bucket functions
 --time_bucket using additional args
-CREATE MATERIALIZED VIEW mat_m1 WITH (timescaledb.continuous, timescaledb.finalized = false)
+CREATE MATERIALIZED VIEW mat_m1 WITH (timescaledb.continuous, timescaledb.materialized_only=false, timescaledb.finalized = false)
 AS
 Select max(temperature)
 from conditions
  group by time_bucket( INTERVAL '5 minutes', timec, INTERVAL '-2.5 minutes') , location WITH NO DATA;
 ERROR:  continuous aggregate view must include a valid time bucket function
 --time_bucket using non-const for first argument
-CREATE MATERIALIZED VIEW mat_m1 WITH (timescaledb.continuous, timescaledb.finalized = false)
+CREATE MATERIALIZED VIEW mat_m1 WITH (timescaledb.continuous, timescaledb.materialized_only=false, timescaledb.finalized = false)
 AS
 Select max(temperature)
 from conditions
@@ -123,14 +123,14 @@ from conditions
 ERROR:  only immutable expressions allowed in time bucket function
 HINT:  Use an immutable expression as first argument to the time bucket function.
 -- ordered set aggr
-CREATE MATERIALIZED VIEW mat_m1 WITH (timescaledb.continuous, timescaledb.finalized = false)
+CREATE MATERIALIZED VIEW mat_m1 WITH (timescaledb.continuous, timescaledb.materialized_only=false, timescaledb.finalized = false)
 AS
 Select mode() within group( order by humidity)
 from conditions
  group by time_bucket('1week', timec)  WITH NO DATA;
 ERROR:  aggregates with FILTER / DISTINCT / ORDER BY are not supported
 --window function
-CREATE MATERIALIZED VIEW mat_m1 WITH (timescaledb.continuous, timescaledb.finalized = false)
+CREATE MATERIALIZED VIEW mat_m1 WITH (timescaledb.continuous, timescaledb.materialized_only=false, timescaledb.finalized = false)
 AS
 Select avg(temperature) over( order by humidity)
 from conditions
@@ -138,14 +138,14 @@ from conditions
 ERROR:  invalid continuous aggregate query
 DETAIL:  Window functions are not supported by continuous aggregates.
 --aggregate without combine function
-CREATE MATERIALIZED VIEW mat_m1 WITH (timescaledb.continuous, timescaledb.finalized = false)
+CREATE MATERIALIZED VIEW mat_m1 WITH (timescaledb.continuous, timescaledb.materialized_only=false, timescaledb.finalized = false)
 AS
 Select json_agg(location)
 from conditions
  group by time_bucket('1week', timec) , location WITH NO DATA;
 ERROR:  aggregates which are not parallelizable are not supported
 ;
-CREATE MATERIALIZED VIEW mat_m1 WITH (timescaledb.continuous, timescaledb.finalized = false)
+CREATE MATERIALIZED VIEW mat_m1 WITH (timescaledb.continuous, timescaledb.materialized_only=false, timescaledb.finalized = false)
 AS
 Select sum(humidity), avg(temperature), array_agg(location)
 from conditions
@@ -158,7 +158,7 @@ CREATE AGGREGATE newavg (
    finalfunc = int8_avg,
    initcond1 = '{0,0}'
 );
-CREATE MATERIALIZED VIEW mat_m1 WITH (timescaledb.continuous, timescaledb.finalized = false)
+CREATE MATERIALIZED VIEW mat_m1 WITH (timescaledb.continuous, timescaledb.materialized_only=false, timescaledb.finalized = false)
 AS
 Select sum(humidity), newavg(temperature::int4)
 from conditions
@@ -166,7 +166,7 @@ from conditions
 ERROR:  aggregates which are not parallelizable are not supported
 ;
 -- using subqueries
-CREATE MATERIALIZED VIEW mat_m1 WITH (timescaledb.continuous, timescaledb.finalized = false)
+CREATE MATERIALIZED VIEW mat_m1 WITH (timescaledb.continuous, timescaledb.materialized_only=false, timescaledb.finalized = false)
 AS
 Select sum(humidity), avg(temperature::int4)
 from
@@ -174,7 +174,7 @@ from
 from conditions ) q
  group by time_bucket('1week', timec) , location  WITH NO DATA;
 ERROR:  invalid continuous aggregate view
-CREATE MATERIALIZED VIEW mat_m1 WITH (timescaledb.continuous, timescaledb.finalized = false)
+CREATE MATERIALIZED VIEW mat_m1 WITH (timescaledb.continuous, timescaledb.materialized_only=false, timescaledb.finalized = false)
 AS
 select * from
 ( Select sum(humidity), avg(temperature::int4)
@@ -183,7 +183,7 @@ from conditions
 ERROR:  invalid continuous aggregate query
 HINT:  Include at least one aggregate function and a GROUP BY clause with time bucket.
 --using limit /limit offset
-CREATE MATERIALIZED VIEW mat_m1 WITH (timescaledb.continuous, timescaledb.finalized = false)
+CREATE MATERIALIZED VIEW mat_m1 WITH (timescaledb.continuous, timescaledb.materialized_only=false, timescaledb.finalized = false)
 AS
 Select sum(humidity), avg(temperature::int4)
 from conditions
@@ -192,7 +192,7 @@ limit 10  WITH NO DATA;
 ERROR:  invalid continuous aggregate query
 DETAIL:  LIMIT and LIMIT OFFSET are not supported in queries defining continuous aggregates.
 HINT:  Use LIMIT and LIMIT OFFSET in SELECTS from the continuous aggregate view instead.
-CREATE MATERIALIZED VIEW mat_m1 WITH (timescaledb.continuous, timescaledb.finalized = false)
+CREATE MATERIALIZED VIEW mat_m1 WITH (timescaledb.continuous, timescaledb.materialized_only=false, timescaledb.finalized = false)
 AS
 Select sum(humidity), avg(temperature::int4)
 from conditions
@@ -202,7 +202,7 @@ ERROR:  invalid continuous aggregate query
 DETAIL:  LIMIT and LIMIT OFFSET are not supported in queries defining continuous aggregates.
 HINT:  Use LIMIT and LIMIT OFFSET in SELECTS from the continuous aggregate view instead.
 --using ORDER BY in view defintion
-CREATE MATERIALIZED VIEW mat_m1 WITH (timescaledb.continuous, timescaledb.finalized = false)
+CREATE MATERIALIZED VIEW mat_m1 WITH (timescaledb.continuous, timescaledb.materialized_only=false, timescaledb.finalized = false)
 AS
 Select sum(humidity), avg(temperature::int4)
 from conditions
@@ -212,7 +212,7 @@ ERROR:  invalid continuous aggregate query
 DETAIL:  ORDER BY is not supported in queries defining continuous aggregates.
 HINT:  Use ORDER BY clauses in SELECTS from the continuous aggregate view instead.
 --using FETCH
-CREATE MATERIALIZED VIEW mat_m1 WITH (timescaledb.continuous, timescaledb.finalized = false)
+CREATE MATERIALIZED VIEW mat_m1 WITH (timescaledb.continuous, timescaledb.materialized_only=false, timescaledb.finalized = false)
 AS
 Select sum(humidity), avg(temperature::int4)
 from conditions
@@ -223,28 +223,28 @@ DETAIL:  LIMIT and LIMIT OFFSET are not supported in queries defining continuous
 HINT:  Use LIMIT and LIMIT OFFSET in SELECTS from the continuous aggregate view instead.
 --using locking clauses FOR clause
 --all should be disabled. we cannot guarntee locks on the hypertable
-CREATE MATERIALIZED VIEW mat_m1 WITH (timescaledb.continuous, timescaledb.finalized = false)
+CREATE MATERIALIZED VIEW mat_m1 WITH (timescaledb.continuous, timescaledb.materialized_only=false, timescaledb.finalized = false)
 AS
 Select sum(humidity), avg(temperature::int4)
 from conditions
  group by time_bucket('1week', timec) , location
 FOR KEY SHARE WITH NO DATA;
 ERROR:  FOR KEY SHARE is not allowed with GROUP BY clause
-CREATE MATERIALIZED VIEW mat_m1 WITH (timescaledb.continuous, timescaledb.finalized = false)
+CREATE MATERIALIZED VIEW mat_m1 WITH (timescaledb.continuous, timescaledb.materialized_only=false, timescaledb.finalized = false)
 AS
 Select sum(humidity), avg(temperature::int4)
 from conditions
  group by time_bucket('1week', timec) , location
 FOR SHARE WITH NO DATA;
 ERROR:  FOR SHARE is not allowed with GROUP BY clause
-CREATE MATERIALIZED VIEW mat_m1 WITH (timescaledb.continuous, timescaledb.finalized = false)
+CREATE MATERIALIZED VIEW mat_m1 WITH (timescaledb.continuous, timescaledb.materialized_only=false, timescaledb.finalized = false)
 AS
 Select sum(humidity), avg(temperature::int4)
 from conditions
  group by time_bucket('1week', timec) , location
 FOR UPDATE WITH NO DATA;
 ERROR:  FOR UPDATE is not allowed with GROUP BY clause
-CREATE MATERIALIZED VIEW mat_m1 WITH (timescaledb.continuous, timescaledb.finalized = false)
+CREATE MATERIALIZED VIEW mat_m1 WITH (timescaledb.continuous, timescaledb.materialized_only=false, timescaledb.finalized = false)
 AS
 Select sum(humidity), avg(temperature::int4)
 from conditions
@@ -252,7 +252,7 @@ from conditions
 FOR NO KEY UPDATE WITH NO DATA;
 ERROR:  FOR NO KEY UPDATE is not allowed with GROUP BY clause
 --tablesample clause
-CREATE MATERIALIZED VIEW mat_m1 WITH (timescaledb.continuous, timescaledb.finalized = false)
+CREATE MATERIALIZED VIEW mat_m1 WITH (timescaledb.continuous, timescaledb.materialized_only=false, timescaledb.finalized = false)
 AS
 Select sum(humidity), avg(temperature::int4)
 from conditions tablesample bernoulli(0.2)
@@ -260,14 +260,14 @@ from conditions tablesample bernoulli(0.2)
  WITH NO DATA;
 ERROR:  invalid continuous aggregate view
 -- ONLY in from clause
-CREATE MATERIALIZED VIEW mat_m1 WITH (timescaledb.continuous, timescaledb.finalized = false)
+CREATE MATERIALIZED VIEW mat_m1 WITH (timescaledb.continuous, timescaledb.materialized_only=false, timescaledb.finalized = false)
 AS
 Select sum(humidity), avg(temperature::int4)
 from ONLY conditions
  group by time_bucket('1week', timec) , location  WITH NO DATA;
 ERROR:  invalid continuous aggregate view
 --grouping sets and variants
-CREATE MATERIALIZED VIEW mat_m1 WITH (timescaledb.continuous, timescaledb.finalized = false)
+CREATE MATERIALIZED VIEW mat_m1 WITH (timescaledb.continuous, timescaledb.materialized_only=false, timescaledb.finalized = false)
 AS
 Select sum(humidity), avg(temperature::int4)
 from conditions
@@ -275,7 +275,7 @@ from conditions
 ERROR:  invalid continuous aggregate query
 DETAIL:  GROUP BY GROUPING SETS, ROLLUP and CUBE are not supported by continuous aggregates
 HINT:  Define multiple continuous aggregates with different grouping levels.
-CREATE MATERIALIZED VIEW mat_m1 WITH (timescaledb.continuous, timescaledb.finalized = false)
+CREATE MATERIALIZED VIEW mat_m1 WITH (timescaledb.continuous, timescaledb.materialized_only=false, timescaledb.finalized = false)
 AS
 Select sum(humidity), avg(temperature::int4)
 from conditions
@@ -286,14 +286,14 @@ HINT:  Define multiple continuous aggregates with different grouping levels.
 --NO immutable functions -- check all clauses
 CREATE FUNCTION test_stablefunc(int) RETURNS int LANGUAGE 'sql'
        STABLE AS 'SELECT $1 + 10';
-CREATE MATERIALIZED VIEW mat_m1 WITH (timescaledb.continuous, timescaledb.finalized = false)
+CREATE MATERIALIZED VIEW mat_m1 WITH (timescaledb.continuous, timescaledb.materialized_only=false, timescaledb.finalized = false)
 AS
 Select sum(humidity), max(timec + INTERVAL '1h')
 from conditions
 group by time_bucket('1week', timec) , location   WITH NO DATA;
 ERROR:  only immutable functions supported in continuous aggregate view
 HINT:  Make sure all functions in the continuous aggregate definition have IMMUTABLE volatility. Note that functions or expressions may be IMMUTABLE for one data type, but STABLE or VOLATILE for another.
-CREATE MATERIALIZED VIEW mat_m1 WITH (timescaledb.continuous, timescaledb.finalized = false)
+CREATE MATERIALIZED VIEW mat_m1 WITH (timescaledb.continuous, timescaledb.materialized_only=false, timescaledb.finalized = false)
 AS
 Select sum(humidity), min(location)
 from conditions
@@ -301,14 +301,14 @@ group by time_bucket('1week', timec)
 having  max(timec + INTERVAL '1h') > '2010-01-01 09:00:00-08' WITH NO DATA;
 ERROR:  only immutable functions supported in continuous aggregate view
 HINT:  Make sure all functions in the continuous aggregate definition have IMMUTABLE volatility. Note that functions or expressions may be IMMUTABLE for one data type, but STABLE or VOLATILE for another.
-CREATE MATERIALIZED VIEW mat_m1 WITH (timescaledb.continuous, timescaledb.finalized = false)
+CREATE MATERIALIZED VIEW mat_m1 WITH (timescaledb.continuous, timescaledb.materialized_only=false, timescaledb.finalized = false)
 AS
 Select sum( test_stablefunc(humidity::int) ), min(location)
 from conditions
 group by time_bucket('1week', timec) WITH NO DATA;
 ERROR:  only immutable functions supported in continuous aggregate view
 HINT:  Make sure all functions in the continuous aggregate definition have IMMUTABLE volatility. Note that functions or expressions may be IMMUTABLE for one data type, but STABLE or VOLATILE for another.
-CREATE MATERIALIZED VIEW mat_m1 WITH (timescaledb.continuous, timescaledb.finalized = false)
+CREATE MATERIALIZED VIEW mat_m1 WITH (timescaledb.continuous, timescaledb.materialized_only=false, timescaledb.finalized = false)
 AS
 Select sum( temperature ), min(location)
 from conditions
@@ -316,7 +316,7 @@ group by time_bucket('1week', timec), test_stablefunc(humidity::int) WITH NO DAT
 ERROR:  only immutable functions supported in continuous aggregate view
 HINT:  Make sure all functions in the continuous aggregate definition have IMMUTABLE volatility. Note that functions or expressions may be IMMUTABLE for one data type, but STABLE or VOLATILE for another.
 -- Should use CREATE MATERIALIZED VIEW to create continuous aggregates
-CREATE VIEW continuous_aggs_errors_tbl1 WITH (timescaledb.continuous, timescaledb.finalized = false) AS
+CREATE VIEW continuous_aggs_errors_tbl1 WITH (timescaledb.continuous, timescaledb.materialized_only=false, timescaledb.finalized = false) AS
 SELECT time_bucket('1 week', timec)
   FROM conditions
 GROUP BY time_bucket('1 week', timec);
@@ -341,20 +341,20 @@ SELECT set_integer_now_func('rowsec_tab', 'integer_now_test');
 
 alter table rowsec_tab ENABLE ROW LEVEL SECURITY;
 create policy rowsec_tab_allview ON rowsec_tab FOR SELECT USING(true);
-CREATE MATERIALIZED VIEW mat_m1 WITH (timescaledb.continuous, timescaledb.finalized = false)
+CREATE MATERIALIZED VIEW mat_m1 WITH (timescaledb.continuous, timescaledb.materialized_only=false, timescaledb.finalized = false)
 AS
 Select sum( b), min(c)
 from rowsec_tab
 group by time_bucket('1', a) WITH NO DATA;
 ERROR:  cannot create continuous aggregate on hypertable with row security
 -- cagg on cagg not allowed
-CREATE MATERIALIZED VIEW mat_m1 WITH (timescaledb.continuous, timescaledb.finalized = false)
+CREATE MATERIALIZED VIEW mat_m1 WITH (timescaledb.continuous, timescaledb.materialized_only=false, timescaledb.finalized = false)
 AS
 SELECT time_bucket('1 day', timec) AS bucket
   FROM conditions
 GROUP BY time_bucket('1 day', timec);
 NOTICE:  continuous aggregate "mat_m1" is already up-to-date
-CREATE MATERIALIZED VIEW mat_m2_on_mat_m1 WITH (timescaledb.continuous)
+CREATE MATERIALIZED VIEW mat_m2_on_mat_m1 WITH (timescaledb.continuous, timescaledb.materialized_only=false)
 AS
 SELECT time_bucket('1 week', bucket) AS bucket
   FROM mat_m1
@@ -383,7 +383,7 @@ select table_name from create_hypertable( 'conditions', 'timec');
 (1 row)
 
 create materialized view mat_with_test( timec, minl, sumt , sumh)
-WITH (timescaledb.continuous, timescaledb.finalized = false)
+WITH (timescaledb.continuous, timescaledb.materialized_only=false, timescaledb.finalized = false)
 as
 select time_bucket('1day', timec), min(location), sum(temperature),sum(humidity)
 from conditions
@@ -432,14 +432,14 @@ SELECT set_integer_now_func('conditions', 'integer_now_test_s');
 
 \set ON_ERROR_STOP 0
 create materialized view mat_with_test( timec, minl, sumt , sumh)
-WITH (timescaledb.continuous, timescaledb.finalized = false)
+WITH (timescaledb.continuous, timescaledb.materialized_only=false, timescaledb.finalized = false)
 as
 select time_bucket(100, timec), min(location), sum(temperature),sum(humidity)
 from conditions
 group by time_bucket(100, timec) WITH NO DATA;
 ERROR:  time bucket function must reference a hypertable dimension column
 create materialized view mat_with_test( timec, minl, sumt , sumh)
-WITH (timescaledb.continuous, timescaledb.finalized = false)
+WITH (timescaledb.continuous, timescaledb.materialized_only=false, timescaledb.finalized = false)
 as
 select time_bucket(100, timec), min(location), sum(temperature),sum(humidity)
 from conditions
@@ -447,7 +447,7 @@ group by time_bucket(100, timec) WITH NO DATA;
 ERROR:  time bucket function must reference a hypertable dimension column
 ALTER TABLE conditions ALTER timec type int;
 create materialized view mat_with_test( timec, minl, sumt , sumh)
-WITH (timescaledb.continuous, timescaledb.finalized = false)
+WITH (timescaledb.continuous, timescaledb.materialized_only=false, timescaledb.finalized = false)
 as
 select time_bucket(100, timec), min(location), sum(temperature),sum(humidity)
 from conditions
@@ -478,7 +478,7 @@ SELECT set_integer_now_func('conditions', 'integer_now_test_b');
 (1 row)
 
 create materialized view mat_with_test( timec, minl, sumt , sumh)
-WITH (timescaledb.continuous, timescaledb.finalized = false)
+WITH (timescaledb.continuous, timescaledb.materialized_only=false, timescaledb.finalized = false)
 as
 select time_bucket(BIGINT '100', timec), min(location), sum(temperature),sum(humidity)
 from conditions
@@ -498,7 +498,7 @@ NOTICE:  adding not-null constraint to column "time"
 \set VERBOSITY default
 \set ON_ERROR_STOP 0
 CREATE MATERIALIZED VIEW text_view
-    WITH (timescaledb.continuous, timescaledb.finalized = false)
+    WITH (timescaledb.continuous, timescaledb.materialized_only=false, timescaledb.finalized = false)
     AS SELECT time_bucket('5', text_part_func(time)), COUNT(time)
         FROM text_time
         GROUP BY 1 WITH NO DATA;
@@ -527,7 +527,7 @@ SELECT create_hypertable('measurements', 'time');
 INSERT INTO measurements VALUES ('2019-03-04 13:30', 1, 1.3);
 -- Add a continuous aggregate on the measurements table and a policy
 -- to be able to test error cases for the add_job function.
-CREATE MATERIALIZED VIEW measurements_summary WITH (timescaledb.continuous, timescaledb.finalized = false) AS
+CREATE MATERIALIZED VIEW measurements_summary WITH (timescaledb.continuous, timescaledb.materialized_only=false, timescaledb.finalized = false) AS
 SELECT time_bucket('1 day', time), COUNT(time)
   FROM measurements
 GROUP BY 1 WITH NO DATA;
@@ -607,18 +607,18 @@ select create_hypertable('i2980','time');
  (13,public,i2980,t)
 (1 row)
 
-create materialized view i2980_cagg with (timescaledb.continuous, timescaledb.finalized = false) AS SELECT time_bucket('1h',time), avg(7) FROM i2980 GROUP BY 1;
+create materialized view i2980_cagg with (timescaledb.continuous, timescaledb.materialized_only=false, timescaledb.finalized = false) AS SELECT time_bucket('1h',time), avg(7) FROM i2980 GROUP BY 1;
 NOTICE:  continuous aggregate "i2980_cagg" is already up-to-date
 select add_continuous_aggregate_policy('i2980_cagg',NULL,NULL,'4h') AS job_id \gset
 \set ON_ERROR_STOP 0
 select alter_job(:job_id,config:='{"end_offset": null, "start_offset": null, "mat_hypertable_id": 1000}');
 ERROR:  configuration materialization hypertable id 1000 not found
 --test creating continuous aggregate with compression enabled --
-CREATE MATERIALIZED VIEW  i2980_cagg2 with (timescaledb.continuous, timescaledb.compress, timescaledb.finalized = false)
+CREATE MATERIALIZED VIEW  i2980_cagg2 with (timescaledb.continuous, timescaledb.materialized_only=false, timescaledb.compress, timescaledb.finalized = false)
 AS SELECT time_bucket('1h',time), avg(7) FROM i2980 GROUP BY 1;
 ERROR:  cannot enable compression while creating a continuous aggregate
 --this one succeeds
-CREATE MATERIALIZED VIEW  i2980_cagg2 with (timescaledb.continuous, timescaledb.finalized = false)
+CREATE MATERIALIZED VIEW  i2980_cagg2 with (timescaledb.continuous, timescaledb.materialized_only=false, timescaledb.finalized = false)
 AS SELECT time_bucket('1h',time) as bucket, avg(7) FROM i2980 GROUP BY 1;
 NOTICE:  continuous aggregate "i2980_cagg2" is already up-to-date
 --now enable compression with invalid parameters
@@ -701,5 +701,5 @@ FROM
   _timescaledb_catalog.hypertable ht
   INNER JOIN _timescaledb_catalog.hypertable uncompress ON (ht.id = uncompress.compressed_hypertable_id
       AND uncompress.table_name = 'comp_ht_test') \gset
-CREATE MATERIALIZED VIEW cagg1 WITH(timescaledb.continuous, timescaledb.finalized = false) AS SELECT time_bucket('1h',_ts_meta_min_1) FROM :INTERNALTABLE GROUP BY 1;
+CREATE MATERIALIZED VIEW cagg1 WITH(timescaledb.continuous, timescaledb.materialized_only=false, timescaledb.finalized = false) AS SELECT time_bucket('1h',_ts_meta_min_1) FROM :INTERNALTABLE GROUP BY 1;
 ERROR:  hypertable is an internal compressed hypertable

--- a/tsl/test/expected/cagg_joins.out
+++ b/tsl/test/expected/cagg_joins.out
@@ -570,7 +570,7 @@ SELECT * FROM cagg ORDER BY bucket, name, thermo_id;
 
 -- Cagg with inner joins - realtime aggregate + JOIN clause
 CREATE MATERIALIZED VIEW cagg_join
-WITH (timescaledb.continuous) AS
+WITH (timescaledb.continuous, timescaledb.materialized_only = FALSE) AS
 SELECT time_bucket(INTERVAL '1 day', day) AS bucket,
    AVG(temperature),
    name
@@ -602,7 +602,7 @@ SELECT * FROM cagg_join ORDER BY bucket, name;
 
 -- Cagg with inner joins - realtime aggregate + USING clause
 CREATE MATERIALIZED VIEW cagg_using
-WITH (timescaledb.continuous) AS
+WITH (timescaledb.continuous, timescaledb.materialized_only = FALSE) AS
 SELECT time_bucket(INTERVAL '1 day', day) AS bucket,
    AVG(temperature),
    name
@@ -668,7 +668,7 @@ SELECT * FROM cagg_reorder ORDER BY bucket, name;
 
 -- Cagg with inner joins - realtime aggregate + JOIN clause
 CREATE MATERIALIZED VIEW cagg_reorder_join
-WITH (timescaledb.continuous) AS
+WITH (timescaledb.continuous, timescaledb.materialized_only = FALSE) AS
 SELECT time_bucket(INTERVAL '1 day', day) AS bucket,
    AVG(temperature),
    name
@@ -700,7 +700,7 @@ SELECT * FROM cagg_reorder_join;
 
 -- Cagg with inner joins - realtime aggregate + USING clause
 CREATE MATERIALIZED VIEW cagg_reorder_using
-WITH (timescaledb.continuous) AS
+WITH (timescaledb.continuous, timescaledb.materialized_only = FALSE) AS
 SELECT time_bucket(INTERVAL '1 day', day) AS bucket,
    AVG(temperature),
    name
@@ -966,7 +966,7 @@ ERROR:  old format of continuous aggregate is not supported with joins
 HINT:  Set timescaledb.finalized to TRUE.
 CREATE  TABLE mat_t1( a integer, b integer,c TEXT);
 --With LATERAL multiple tables old format
-CREATE MATERIALIZED VIEW mat_m1 WITH (timescaledb.continuous, timescaledb.finalized = false)
+CREATE MATERIALIZED VIEW mat_m1 WITH (timescaledb.continuous, timescaledb.materialized_only = FALSE, timescaledb.finalized = false)
 as
 select temperature, count(*) from conditions,
 LATERAL (Select * from mat_t1 where a = conditions.temperature) q
@@ -974,7 +974,7 @@ group by temperature WITH NO DATA;
 ERROR:  old format of continuous aggregate is not supported with joins
 HINT:  Set timescaledb.finalized to TRUE.
 --With LATERAL multiple tables in new format
-CREATE MATERIALIZED VIEW mat_m1 WITH (timescaledb.continuous)
+CREATE MATERIALIZED VIEW mat_m1 WITH (timescaledb.continuous, timescaledb.materialized_only = FALSE)
 as
 select temperature, count(*) from conditions,
 LATERAL (Select * from mat_t1 where a = conditions.temperature) q

--- a/tsl/test/expected/cagg_migrate.out
+++ b/tsl/test/expected/cagg_migrate.out
@@ -80,7 +80,7 @@ psql:include/cagg_migrate_common.sql:66: ERROR:  continuous aggregate "public.co
 \set ON_ERROR_STOP 1
 DROP TABLE conditions_summary_daily;
 CREATE MATERIALIZED VIEW conditions_summary_daily_new
-WITH (timescaledb.continuous) AS
+WITH (timescaledb.continuous, timescaledb.materialized_only=false) AS
 SELECT
 \if :IS_TIME_DIMENSION
     time_bucket(INTERVAL '1 day', "time") AS bucket,
@@ -103,7 +103,7 @@ psql:include/cagg_migrate_common.sql:91: ERROR:  continuous aggregate "public.co
 \set ON_ERROR_STOP 1
 -- older continuous aggregate to be migrated
 CREATE MATERIALIZED VIEW conditions_summary_daily
-WITH (timescaledb.continuous, timescaledb.finalized=false) AS
+WITH (timescaledb.continuous, timescaledb.materialized_only=false, timescaledb.finalized=false) AS
 SELECT
 \if :IS_TIME_DIMENSION
     time_bucket(INTERVAL '1 day', "time") AS bucket,
@@ -594,7 +594,7 @@ psql:include/cagg_migrate_common.sql:274: NOTICE:  drop cascades to 10 other obj
 GRANT ALL ON TABLE conditions TO :ROLE_DEFAULT_PERM_USER;
 SET ROLE :ROLE_DEFAULT_PERM_USER;
 CREATE MATERIALIZED VIEW conditions_summary_daily
-WITH (timescaledb.continuous, timescaledb.finalized=false) AS
+WITH (timescaledb.continuous, timescaledb.materialized_only=false, timescaledb.finalized=false) AS
 SELECT
 \if :IS_TIME_DIMENSION
     time_bucket(INTERVAL '1 day', "time") AS bucket,
@@ -784,7 +784,7 @@ psql:include/cagg_migrate_common.sql:66: ERROR:  continuous aggregate "public.co
 \set ON_ERROR_STOP 1
 DROP TABLE conditions_summary_daily;
 CREATE MATERIALIZED VIEW conditions_summary_daily_new
-WITH (timescaledb.continuous) AS
+WITH (timescaledb.continuous, timescaledb.materialized_only=false) AS
 SELECT
 \if :IS_TIME_DIMENSION
     time_bucket(INTERVAL '1 day', "time") AS bucket,
@@ -807,7 +807,7 @@ psql:include/cagg_migrate_common.sql:91: ERROR:  continuous aggregate "public.co
 \set ON_ERROR_STOP 1
 -- older continuous aggregate to be migrated
 CREATE MATERIALIZED VIEW conditions_summary_daily
-WITH (timescaledb.continuous, timescaledb.finalized=false) AS
+WITH (timescaledb.continuous, timescaledb.materialized_only=false, timescaledb.finalized=false) AS
 SELECT
 \if :IS_TIME_DIMENSION
     time_bucket(INTERVAL '1 day', "time") AS bucket,
@@ -1278,7 +1278,7 @@ psql:include/cagg_migrate_common.sql:274: NOTICE:  drop cascades to 6 other obje
 GRANT ALL ON TABLE conditions TO :ROLE_DEFAULT_PERM_USER;
 SET ROLE :ROLE_DEFAULT_PERM_USER;
 CREATE MATERIALIZED VIEW conditions_summary_daily
-WITH (timescaledb.continuous, timescaledb.finalized=false) AS
+WITH (timescaledb.continuous, timescaledb.materialized_only=false, timescaledb.finalized=false) AS
 SELECT
 \if :IS_TIME_DIMENSION
     time_bucket(INTERVAL '1 day', "time") AS bucket,
@@ -1463,7 +1463,7 @@ psql:include/cagg_migrate_common.sql:66: ERROR:  continuous aggregate "public.co
 \set ON_ERROR_STOP 1
 DROP TABLE conditions_summary_daily;
 CREATE MATERIALIZED VIEW conditions_summary_daily_new
-WITH (timescaledb.continuous) AS
+WITH (timescaledb.continuous, timescaledb.materialized_only=false) AS
 SELECT
 \if :IS_TIME_DIMENSION
     time_bucket(INTERVAL '1 day', "time") AS bucket,
@@ -1486,7 +1486,7 @@ psql:include/cagg_migrate_common.sql:91: ERROR:  continuous aggregate "public.co
 \set ON_ERROR_STOP 1
 -- older continuous aggregate to be migrated
 CREATE MATERIALIZED VIEW conditions_summary_daily
-WITH (timescaledb.continuous, timescaledb.finalized=false) AS
+WITH (timescaledb.continuous, timescaledb.materialized_only=false, timescaledb.finalized=false) AS
 SELECT
 \if :IS_TIME_DIMENSION
     time_bucket(INTERVAL '1 day', "time") AS bucket,
@@ -1957,7 +1957,7 @@ psql:include/cagg_migrate_common.sql:274: NOTICE:  drop cascades to 6 other obje
 GRANT ALL ON TABLE conditions TO :ROLE_DEFAULT_PERM_USER;
 SET ROLE :ROLE_DEFAULT_PERM_USER;
 CREATE MATERIALIZED VIEW conditions_summary_daily
-WITH (timescaledb.continuous, timescaledb.finalized=false) AS
+WITH (timescaledb.continuous, timescaledb.materialized_only=false, timescaledb.finalized=false) AS
 SELECT
 \if :IS_TIME_DIMENSION
     time_bucket(INTERVAL '1 day', "time") AS bucket,

--- a/tsl/test/expected/cagg_migrate_dist_ht.out
+++ b/tsl/test/expected/cagg_migrate_dist_ht.out
@@ -115,7 +115,7 @@ psql:include/cagg_migrate_common.sql:66: ERROR:  continuous aggregate "public.co
 \set ON_ERROR_STOP 1
 DROP TABLE conditions_summary_daily;
 CREATE MATERIALIZED VIEW conditions_summary_daily_new
-WITH (timescaledb.continuous) AS
+WITH (timescaledb.continuous, timescaledb.materialized_only=false) AS
 SELECT
 \if :IS_TIME_DIMENSION
     time_bucket(INTERVAL '1 day', "time") AS bucket,
@@ -138,7 +138,7 @@ psql:include/cagg_migrate_common.sql:91: ERROR:  continuous aggregate "public.co
 \set ON_ERROR_STOP 1
 -- older continuous aggregate to be migrated
 CREATE MATERIALIZED VIEW conditions_summary_daily
-WITH (timescaledb.continuous, timescaledb.finalized=false) AS
+WITH (timescaledb.continuous, timescaledb.materialized_only=false, timescaledb.finalized=false) AS
 SELECT
 \if :IS_TIME_DIMENSION
     time_bucket(INTERVAL '1 day', "time") AS bucket,
@@ -629,7 +629,7 @@ psql:include/cagg_migrate_common.sql:274: NOTICE:  drop cascades to 10 other obj
 GRANT ALL ON TABLE conditions TO :ROLE_DEFAULT_PERM_USER;
 SET ROLE :ROLE_DEFAULT_PERM_USER;
 CREATE MATERIALIZED VIEW conditions_summary_daily
-WITH (timescaledb.continuous, timescaledb.finalized=false) AS
+WITH (timescaledb.continuous, timescaledb.materialized_only=false, timescaledb.finalized=false) AS
 SELECT
 \if :IS_TIME_DIMENSION
     time_bucket(INTERVAL '1 day', "time") AS bucket,
@@ -819,7 +819,7 @@ psql:include/cagg_migrate_common.sql:66: ERROR:  continuous aggregate "public.co
 \set ON_ERROR_STOP 1
 DROP TABLE conditions_summary_daily;
 CREATE MATERIALIZED VIEW conditions_summary_daily_new
-WITH (timescaledb.continuous) AS
+WITH (timescaledb.continuous, timescaledb.materialized_only=false) AS
 SELECT
 \if :IS_TIME_DIMENSION
     time_bucket(INTERVAL '1 day', "time") AS bucket,
@@ -842,7 +842,7 @@ psql:include/cagg_migrate_common.sql:91: ERROR:  continuous aggregate "public.co
 \set ON_ERROR_STOP 1
 -- older continuous aggregate to be migrated
 CREATE MATERIALIZED VIEW conditions_summary_daily
-WITH (timescaledb.continuous, timescaledb.finalized=false) AS
+WITH (timescaledb.continuous, timescaledb.materialized_only=false, timescaledb.finalized=false) AS
 SELECT
 \if :IS_TIME_DIMENSION
     time_bucket(INTERVAL '1 day', "time") AS bucket,
@@ -1313,7 +1313,7 @@ psql:include/cagg_migrate_common.sql:274: NOTICE:  drop cascades to 6 other obje
 GRANT ALL ON TABLE conditions TO :ROLE_DEFAULT_PERM_USER;
 SET ROLE :ROLE_DEFAULT_PERM_USER;
 CREATE MATERIALIZED VIEW conditions_summary_daily
-WITH (timescaledb.continuous, timescaledb.finalized=false) AS
+WITH (timescaledb.continuous, timescaledb.materialized_only=false, timescaledb.finalized=false) AS
 SELECT
 \if :IS_TIME_DIMENSION
     time_bucket(INTERVAL '1 day', "time") AS bucket,
@@ -1498,7 +1498,7 @@ psql:include/cagg_migrate_common.sql:66: ERROR:  continuous aggregate "public.co
 \set ON_ERROR_STOP 1
 DROP TABLE conditions_summary_daily;
 CREATE MATERIALIZED VIEW conditions_summary_daily_new
-WITH (timescaledb.continuous) AS
+WITH (timescaledb.continuous, timescaledb.materialized_only=false) AS
 SELECT
 \if :IS_TIME_DIMENSION
     time_bucket(INTERVAL '1 day', "time") AS bucket,
@@ -1521,7 +1521,7 @@ psql:include/cagg_migrate_common.sql:91: ERROR:  continuous aggregate "public.co
 \set ON_ERROR_STOP 1
 -- older continuous aggregate to be migrated
 CREATE MATERIALIZED VIEW conditions_summary_daily
-WITH (timescaledb.continuous, timescaledb.finalized=false) AS
+WITH (timescaledb.continuous, timescaledb.materialized_only=false, timescaledb.finalized=false) AS
 SELECT
 \if :IS_TIME_DIMENSION
     time_bucket(INTERVAL '1 day', "time") AS bucket,
@@ -1992,7 +1992,7 @@ psql:include/cagg_migrate_common.sql:274: NOTICE:  drop cascades to 6 other obje
 GRANT ALL ON TABLE conditions TO :ROLE_DEFAULT_PERM_USER;
 SET ROLE :ROLE_DEFAULT_PERM_USER;
 CREATE MATERIALIZED VIEW conditions_summary_daily
-WITH (timescaledb.continuous, timescaledb.finalized=false) AS
+WITH (timescaledb.continuous, timescaledb.materialized_only=false, timescaledb.finalized=false) AS
 SELECT
 \if :IS_TIME_DIMENSION
     time_bucket(INTERVAL '1 day', "time") AS bucket,

--- a/tsl/test/expected/cagg_multi.out
+++ b/tsl/test/expected/cagg_multi.out
@@ -397,13 +397,13 @@ SELECT set_integer_now_func('foo', 'integer_now_foo');
 (1 row)
 
 CREATE MATERIALIZED VIEW mat_m1(a, countb)
-WITH (timescaledb.continuous)
+WITH (timescaledb.continuous, timescaledb.materialized_only=false)
 AS
 SELECT time_bucket(10, a), count(*)
 FROM foo
 GROUP BY time_bucket(10, a) WITH NO DATA;
 CREATE MATERIALIZED VIEW mat_m2(a, countb)
-WITH (timescaledb.continuous)
+WITH (timescaledb.continuous, timescaledb.materialized_only=false)
 AS
 SELECT time_bucket(5, a), count(*)
 FROM foo

--- a/tsl/test/expected/cagg_on_cagg.out
+++ b/tsl/test/expected/cagg_on_cagg.out
@@ -874,7 +874,7 @@ psql:include/cagg_on_cagg_common.sql:200: ERROR:  relation "conditions_summary_1
 -- CAGG on hypertable (1st level)
 --
 CREATE MATERIALIZED VIEW :CAGG_NAME_1ST_LEVEL
-WITH (timescaledb.continuous) AS
+WITH (timescaledb.continuous, timescaledb.materialized_only=false) AS
 SELECT
   \if :IS_TIME_DIMENSION_WITH_TIMEZONE_1ST
     time_bucket(:BUCKET_WIDTH_1ST, "time", :'BUCKET_TZNAME_1ST') AS bucket,
@@ -911,7 +911,7 @@ UNION ALL
 \echo :WARNING_MESSAGE
 -- SHOULD ERROR because non-multiple bucket sizes
 CREATE MATERIALIZED VIEW :CAGG_NAME_2TH_LEVEL
-WITH (timescaledb.continuous) AS
+WITH (timescaledb.continuous, timescaledb.materialized_only=false) AS
 SELECT
   \if :IS_TIME_DIMENSION_WITH_TIMEZONE_2TH
     time_bucket(:BUCKET_WIDTH_2TH, "bucket", :'BUCKET_TZNAME_2TH') AS bucket,
@@ -935,7 +935,7 @@ DETAIL:  Time bucket width of "public.conditions_summary_2" [5] should be multip
   CALL refresh_continuous_aggregate(:'CAGG_NAME_1ST_LEVEL', NULL, NULL);
   CALL refresh_continuous_aggregate(:'CAGG_NAME_2TH_LEVEL', NULL, NULL);
   CREATE MATERIALIZED VIEW :CAGG_NAME_3TH_LEVEL
-  WITH (timescaledb.continuous) AS
+  WITH (timescaledb.continuous, timescaledb.materialized_only=false) AS
   SELECT
     \if :IS_TIME_DIMENSION_WITH_TIMEZONE_2TH
       time_bucket(:BUCKET_WIDTH_3TH, "bucket", :'BUCKET_TZNAME_2TH') AS bucket
@@ -974,7 +974,7 @@ DROP MATERIALIZED VIEW IF EXISTS :CAGG_NAME_1ST_LEVEL;
 -- CAGG on hypertable (1st level)
 --
 CREATE MATERIALIZED VIEW :CAGG_NAME_1ST_LEVEL
-WITH (timescaledb.continuous) AS
+WITH (timescaledb.continuous, timescaledb.materialized_only=false) AS
 SELECT
   \if :IS_TIME_DIMENSION_WITH_TIMEZONE_1ST
     time_bucket(:BUCKET_WIDTH_1ST, "time", :'BUCKET_TZNAME_1ST') AS bucket,
@@ -1011,7 +1011,7 @@ UNION ALL
 \echo :WARNING_MESSAGE
 SHOULD WORK because new bucket should be greater than previous
 CREATE MATERIALIZED VIEW :CAGG_NAME_2TH_LEVEL
-WITH (timescaledb.continuous) AS
+WITH (timescaledb.continuous, timescaledb.materialized_only=false) AS
 SELECT
   \if :IS_TIME_DIMENSION_WITH_TIMEZONE_2TH
     time_bucket(:BUCKET_WIDTH_2TH, "bucket", :'BUCKET_TZNAME_2TH') AS bucket,
@@ -1050,7 +1050,7 @@ UNION ALL
   CALL refresh_continuous_aggregate(:'CAGG_NAME_1ST_LEVEL', NULL, NULL);
   CALL refresh_continuous_aggregate(:'CAGG_NAME_2TH_LEVEL', NULL, NULL);
   CREATE MATERIALIZED VIEW :CAGG_NAME_3TH_LEVEL
-  WITH (timescaledb.continuous) AS
+  WITH (timescaledb.continuous, timescaledb.materialized_only=false) AS
   SELECT
     \if :IS_TIME_DIMENSION_WITH_TIMEZONE_2TH
       time_bucket(:BUCKET_WIDTH_3TH, "bucket", :'BUCKET_TZNAME_2TH') AS bucket
@@ -1088,7 +1088,7 @@ DROP MATERIALIZED VIEW IF EXISTS :CAGG_NAME_1ST_LEVEL;
 -- CAGG on hypertable (1st level)
 --
 CREATE MATERIALIZED VIEW :CAGG_NAME_1ST_LEVEL
-WITH (timescaledb.continuous) AS
+WITH (timescaledb.continuous, timescaledb.materialized_only=false) AS
 SELECT
   \if :IS_TIME_DIMENSION_WITH_TIMEZONE_1ST
     time_bucket(:BUCKET_WIDTH_1ST, "time", :'BUCKET_TZNAME_1ST') AS bucket,
@@ -1125,7 +1125,7 @@ UNION ALL
 \echo :WARNING_MESSAGE
 -- SHOULD ERROR because new bucket should be greater than previous
 CREATE MATERIALIZED VIEW :CAGG_NAME_2TH_LEVEL
-WITH (timescaledb.continuous) AS
+WITH (timescaledb.continuous, timescaledb.materialized_only=false) AS
 SELECT
   \if :IS_TIME_DIMENSION_WITH_TIMEZONE_2TH
     time_bucket(:BUCKET_WIDTH_2TH, "bucket", :'BUCKET_TZNAME_2TH') AS bucket,
@@ -1149,7 +1149,7 @@ DETAIL:  Time bucket width of "public.conditions_summary_2" [2] should be greate
   CALL refresh_continuous_aggregate(:'CAGG_NAME_1ST_LEVEL', NULL, NULL);
   CALL refresh_continuous_aggregate(:'CAGG_NAME_2TH_LEVEL', NULL, NULL);
   CREATE MATERIALIZED VIEW :CAGG_NAME_3TH_LEVEL
-  WITH (timescaledb.continuous) AS
+  WITH (timescaledb.continuous, timescaledb.materialized_only=false) AS
   SELECT
     \if :IS_TIME_DIMENSION_WITH_TIMEZONE_2TH
       time_bucket(:BUCKET_WIDTH_3TH, "bucket", :'BUCKET_TZNAME_2TH') AS bucket
@@ -2030,7 +2030,7 @@ psql:include/cagg_on_cagg_common.sql:200: ERROR:  relation "conditions_summary_1
 -- CAGG on hypertable (1st level)
 --
 CREATE MATERIALIZED VIEW :CAGG_NAME_1ST_LEVEL
-WITH (timescaledb.continuous) AS
+WITH (timescaledb.continuous, timescaledb.materialized_only=false) AS
 SELECT
   \if :IS_TIME_DIMENSION_WITH_TIMEZONE_1ST
     time_bucket(:BUCKET_WIDTH_1ST, "time", :'BUCKET_TZNAME_1ST') AS bucket,
@@ -2067,7 +2067,7 @@ UNION ALL
 \echo :WARNING_MESSAGE
 -- SHOULD ERROR because is not allowed variable-size bucket on top of fixed-size bucket
 CREATE MATERIALIZED VIEW :CAGG_NAME_2TH_LEVEL
-WITH (timescaledb.continuous) AS
+WITH (timescaledb.continuous, timescaledb.materialized_only=false) AS
 SELECT
   \if :IS_TIME_DIMENSION_WITH_TIMEZONE_2TH
     time_bucket(:BUCKET_WIDTH_2TH, "bucket", :'BUCKET_TZNAME_2TH') AS bucket,
@@ -2092,7 +2092,7 @@ The variance can lead to the fixed width one not being a multiple of the variabl
   CALL refresh_continuous_aggregate(:'CAGG_NAME_1ST_LEVEL', NULL, NULL);
   CALL refresh_continuous_aggregate(:'CAGG_NAME_2TH_LEVEL', NULL, NULL);
   CREATE MATERIALIZED VIEW :CAGG_NAME_3TH_LEVEL
-  WITH (timescaledb.continuous) AS
+  WITH (timescaledb.continuous, timescaledb.materialized_only=false) AS
   SELECT
     \if :IS_TIME_DIMENSION_WITH_TIMEZONE_2TH
       time_bucket(:BUCKET_WIDTH_3TH, "bucket", :'BUCKET_TZNAME_2TH') AS bucket
@@ -2131,7 +2131,7 @@ DROP MATERIALIZED VIEW IF EXISTS :CAGG_NAME_1ST_LEVEL;
 -- CAGG on hypertable (1st level)
 --
 CREATE MATERIALIZED VIEW :CAGG_NAME_1ST_LEVEL
-WITH (timescaledb.continuous) AS
+WITH (timescaledb.continuous, timescaledb.materialized_only=false) AS
 SELECT
   \if :IS_TIME_DIMENSION_WITH_TIMEZONE_1ST
     time_bucket(:BUCKET_WIDTH_1ST, "time", :'BUCKET_TZNAME_1ST') AS bucket,
@@ -2168,7 +2168,7 @@ UNION ALL
 \echo :WARNING_MESSAGE
 -- SHOULD ERROR because non-multiple bucket sizes
 CREATE MATERIALIZED VIEW :CAGG_NAME_2TH_LEVEL
-WITH (timescaledb.continuous) AS
+WITH (timescaledb.continuous, timescaledb.materialized_only=false) AS
 SELECT
   \if :IS_TIME_DIMENSION_WITH_TIMEZONE_2TH
     time_bucket(:BUCKET_WIDTH_2TH, "bucket", :'BUCKET_TZNAME_2TH') AS bucket,
@@ -2192,7 +2192,7 @@ DETAIL:  Time bucket width of "public.conditions_summary_2" [@ 3 hours] should b
   CALL refresh_continuous_aggregate(:'CAGG_NAME_1ST_LEVEL', NULL, NULL);
   CALL refresh_continuous_aggregate(:'CAGG_NAME_2TH_LEVEL', NULL, NULL);
   CREATE MATERIALIZED VIEW :CAGG_NAME_3TH_LEVEL
-  WITH (timescaledb.continuous) AS
+  WITH (timescaledb.continuous, timescaledb.materialized_only=false) AS
   SELECT
     \if :IS_TIME_DIMENSION_WITH_TIMEZONE_2TH
       time_bucket(:BUCKET_WIDTH_3TH, "bucket", :'BUCKET_TZNAME_2TH') AS bucket
@@ -2231,7 +2231,7 @@ DROP MATERIALIZED VIEW IF EXISTS :CAGG_NAME_1ST_LEVEL;
 -- CAGG on hypertable (1st level)
 --
 CREATE MATERIALIZED VIEW :CAGG_NAME_1ST_LEVEL
-WITH (timescaledb.continuous) AS
+WITH (timescaledb.continuous, timescaledb.materialized_only=false) AS
 SELECT
   \if :IS_TIME_DIMENSION_WITH_TIMEZONE_1ST
     time_bucket(:BUCKET_WIDTH_1ST, "time", :'BUCKET_TZNAME_1ST') AS bucket,
@@ -2268,7 +2268,7 @@ UNION ALL
 \echo :WARNING_MESSAGE
 SHOULD WORK because new bucket should be greater than previous
 CREATE MATERIALIZED VIEW :CAGG_NAME_2TH_LEVEL
-WITH (timescaledb.continuous) AS
+WITH (timescaledb.continuous, timescaledb.materialized_only=false) AS
 SELECT
   \if :IS_TIME_DIMENSION_WITH_TIMEZONE_2TH
     time_bucket(:BUCKET_WIDTH_2TH, "bucket", :'BUCKET_TZNAME_2TH') AS bucket,
@@ -2307,7 +2307,7 @@ UNION ALL
   CALL refresh_continuous_aggregate(:'CAGG_NAME_1ST_LEVEL', NULL, NULL);
   CALL refresh_continuous_aggregate(:'CAGG_NAME_2TH_LEVEL', NULL, NULL);
   CREATE MATERIALIZED VIEW :CAGG_NAME_3TH_LEVEL
-  WITH (timescaledb.continuous) AS
+  WITH (timescaledb.continuous, timescaledb.materialized_only=false) AS
   SELECT
     \if :IS_TIME_DIMENSION_WITH_TIMEZONE_2TH
       time_bucket(:BUCKET_WIDTH_3TH, "bucket", :'BUCKET_TZNAME_2TH') AS bucket
@@ -2345,7 +2345,7 @@ DROP MATERIALIZED VIEW IF EXISTS :CAGG_NAME_1ST_LEVEL;
 -- CAGG on hypertable (1st level)
 --
 CREATE MATERIALIZED VIEW :CAGG_NAME_1ST_LEVEL
-WITH (timescaledb.continuous) AS
+WITH (timescaledb.continuous, timescaledb.materialized_only=false) AS
 SELECT
   \if :IS_TIME_DIMENSION_WITH_TIMEZONE_1ST
     time_bucket(:BUCKET_WIDTH_1ST, "time", :'BUCKET_TZNAME_1ST') AS bucket,
@@ -2382,7 +2382,7 @@ UNION ALL
 \echo :WARNING_MESSAGE
 -- SHOULD ERROR because new bucket should be greater than previous
 CREATE MATERIALIZED VIEW :CAGG_NAME_2TH_LEVEL
-WITH (timescaledb.continuous) AS
+WITH (timescaledb.continuous, timescaledb.materialized_only=false) AS
 SELECT
   \if :IS_TIME_DIMENSION_WITH_TIMEZONE_2TH
     time_bucket(:BUCKET_WIDTH_2TH, "bucket", :'BUCKET_TZNAME_2TH') AS bucket,
@@ -2406,7 +2406,7 @@ DETAIL:  Time bucket width of "public.conditions_summary_2" [@ 1 hour] should be
   CALL refresh_continuous_aggregate(:'CAGG_NAME_1ST_LEVEL', NULL, NULL);
   CALL refresh_continuous_aggregate(:'CAGG_NAME_2TH_LEVEL', NULL, NULL);
   CREATE MATERIALIZED VIEW :CAGG_NAME_3TH_LEVEL
-  WITH (timescaledb.continuous) AS
+  WITH (timescaledb.continuous, timescaledb.materialized_only=false) AS
   SELECT
     \if :IS_TIME_DIMENSION_WITH_TIMEZONE_2TH
       time_bucket(:BUCKET_WIDTH_3TH, "bucket", :'BUCKET_TZNAME_2TH') AS bucket
@@ -3285,7 +3285,7 @@ psql:include/cagg_on_cagg_common.sql:200: ERROR:  relation "conditions_summary_1
 -- CAGG on hypertable (1st level)
 --
 CREATE MATERIALIZED VIEW :CAGG_NAME_1ST_LEVEL
-WITH (timescaledb.continuous) AS
+WITH (timescaledb.continuous, timescaledb.materialized_only=false) AS
 SELECT
   \if :IS_TIME_DIMENSION_WITH_TIMEZONE_1ST
     time_bucket(:BUCKET_WIDTH_1ST, "time", :'BUCKET_TZNAME_1ST') AS bucket,
@@ -3322,7 +3322,7 @@ UNION ALL
 \echo :WARNING_MESSAGE
 -- SHOULD ERROR because is not allowed variable-size bucket on top of fixed-size bucket
 CREATE MATERIALIZED VIEW :CAGG_NAME_2TH_LEVEL
-WITH (timescaledb.continuous) AS
+WITH (timescaledb.continuous, timescaledb.materialized_only=false) AS
 SELECT
   \if :IS_TIME_DIMENSION_WITH_TIMEZONE_2TH
     time_bucket(:BUCKET_WIDTH_2TH, "bucket", :'BUCKET_TZNAME_2TH') AS bucket,
@@ -3347,7 +3347,7 @@ The variance can lead to the fixed width one not being a multiple of the variabl
   CALL refresh_continuous_aggregate(:'CAGG_NAME_1ST_LEVEL', NULL, NULL);
   CALL refresh_continuous_aggregate(:'CAGG_NAME_2TH_LEVEL', NULL, NULL);
   CREATE MATERIALIZED VIEW :CAGG_NAME_3TH_LEVEL
-  WITH (timescaledb.continuous) AS
+  WITH (timescaledb.continuous, timescaledb.materialized_only=false) AS
   SELECT
     \if :IS_TIME_DIMENSION_WITH_TIMEZONE_2TH
       time_bucket(:BUCKET_WIDTH_3TH, "bucket", :'BUCKET_TZNAME_2TH') AS bucket
@@ -3386,7 +3386,7 @@ DROP MATERIALIZED VIEW IF EXISTS :CAGG_NAME_1ST_LEVEL;
 -- CAGG on hypertable (1st level)
 --
 CREATE MATERIALIZED VIEW :CAGG_NAME_1ST_LEVEL
-WITH (timescaledb.continuous) AS
+WITH (timescaledb.continuous, timescaledb.materialized_only=false) AS
 SELECT
   \if :IS_TIME_DIMENSION_WITH_TIMEZONE_1ST
     time_bucket(:BUCKET_WIDTH_1ST, "time", :'BUCKET_TZNAME_1ST') AS bucket,
@@ -3423,7 +3423,7 @@ UNION ALL
 \echo :WARNING_MESSAGE
 -- SHOULD ERROR because non-multiple bucket sizes
 CREATE MATERIALIZED VIEW :CAGG_NAME_2TH_LEVEL
-WITH (timescaledb.continuous) AS
+WITH (timescaledb.continuous, timescaledb.materialized_only=false) AS
 SELECT
   \if :IS_TIME_DIMENSION_WITH_TIMEZONE_2TH
     time_bucket(:BUCKET_WIDTH_2TH, "bucket", :'BUCKET_TZNAME_2TH') AS bucket,
@@ -3447,7 +3447,7 @@ DETAIL:  Time bucket width of "public.conditions_summary_2" [@ 3 hours] should b
   CALL refresh_continuous_aggregate(:'CAGG_NAME_1ST_LEVEL', NULL, NULL);
   CALL refresh_continuous_aggregate(:'CAGG_NAME_2TH_LEVEL', NULL, NULL);
   CREATE MATERIALIZED VIEW :CAGG_NAME_3TH_LEVEL
-  WITH (timescaledb.continuous) AS
+  WITH (timescaledb.continuous, timescaledb.materialized_only=false) AS
   SELECT
     \if :IS_TIME_DIMENSION_WITH_TIMEZONE_2TH
       time_bucket(:BUCKET_WIDTH_3TH, "bucket", :'BUCKET_TZNAME_2TH') AS bucket
@@ -3486,7 +3486,7 @@ DROP MATERIALIZED VIEW IF EXISTS :CAGG_NAME_1ST_LEVEL;
 -- CAGG on hypertable (1st level)
 --
 CREATE MATERIALIZED VIEW :CAGG_NAME_1ST_LEVEL
-WITH (timescaledb.continuous) AS
+WITH (timescaledb.continuous, timescaledb.materialized_only=false) AS
 SELECT
   \if :IS_TIME_DIMENSION_WITH_TIMEZONE_1ST
     time_bucket(:BUCKET_WIDTH_1ST, "time", :'BUCKET_TZNAME_1ST') AS bucket,
@@ -3523,7 +3523,7 @@ UNION ALL
 \echo :WARNING_MESSAGE
 SHOULD WORK because new bucket should be greater than previous
 CREATE MATERIALIZED VIEW :CAGG_NAME_2TH_LEVEL
-WITH (timescaledb.continuous) AS
+WITH (timescaledb.continuous, timescaledb.materialized_only=false) AS
 SELECT
   \if :IS_TIME_DIMENSION_WITH_TIMEZONE_2TH
     time_bucket(:BUCKET_WIDTH_2TH, "bucket", :'BUCKET_TZNAME_2TH') AS bucket,
@@ -3562,7 +3562,7 @@ UNION ALL
   CALL refresh_continuous_aggregate(:'CAGG_NAME_1ST_LEVEL', NULL, NULL);
   CALL refresh_continuous_aggregate(:'CAGG_NAME_2TH_LEVEL', NULL, NULL);
   CREATE MATERIALIZED VIEW :CAGG_NAME_3TH_LEVEL
-  WITH (timescaledb.continuous) AS
+  WITH (timescaledb.continuous, timescaledb.materialized_only=false) AS
   SELECT
     \if :IS_TIME_DIMENSION_WITH_TIMEZONE_2TH
       time_bucket(:BUCKET_WIDTH_3TH, "bucket", :'BUCKET_TZNAME_2TH') AS bucket
@@ -3600,7 +3600,7 @@ DROP MATERIALIZED VIEW IF EXISTS :CAGG_NAME_1ST_LEVEL;
 -- CAGG on hypertable (1st level)
 --
 CREATE MATERIALIZED VIEW :CAGG_NAME_1ST_LEVEL
-WITH (timescaledb.continuous) AS
+WITH (timescaledb.continuous, timescaledb.materialized_only=false) AS
 SELECT
   \if :IS_TIME_DIMENSION_WITH_TIMEZONE_1ST
     time_bucket(:BUCKET_WIDTH_1ST, "time", :'BUCKET_TZNAME_1ST') AS bucket,
@@ -3637,7 +3637,7 @@ UNION ALL
 \echo :WARNING_MESSAGE
 -- SHOULD ERROR because new bucket should be greater than previous
 CREATE MATERIALIZED VIEW :CAGG_NAME_2TH_LEVEL
-WITH (timescaledb.continuous) AS
+WITH (timescaledb.continuous, timescaledb.materialized_only=false) AS
 SELECT
   \if :IS_TIME_DIMENSION_WITH_TIMEZONE_2TH
     time_bucket(:BUCKET_WIDTH_2TH, "bucket", :'BUCKET_TZNAME_2TH') AS bucket,
@@ -3661,7 +3661,7 @@ DETAIL:  Time bucket width of "public.conditions_summary_2" [@ 1 hour] should be
   CALL refresh_continuous_aggregate(:'CAGG_NAME_1ST_LEVEL', NULL, NULL);
   CALL refresh_continuous_aggregate(:'CAGG_NAME_2TH_LEVEL', NULL, NULL);
   CREATE MATERIALIZED VIEW :CAGG_NAME_3TH_LEVEL
-  WITH (timescaledb.continuous) AS
+  WITH (timescaledb.continuous, timescaledb.materialized_only=false) AS
   SELECT
     \if :IS_TIME_DIMENSION_WITH_TIMEZONE_2TH
       time_bucket(:BUCKET_WIDTH_3TH, "bucket", :'BUCKET_TZNAME_2TH') AS bucket
@@ -3707,7 +3707,7 @@ DROP MATERIALIZED VIEW IF EXISTS :CAGG_NAME_1ST_LEVEL;
 -- CAGG on hypertable (1st level)
 --
 CREATE MATERIALIZED VIEW :CAGG_NAME_1ST_LEVEL
-WITH (timescaledb.continuous) AS
+WITH (timescaledb.continuous, timescaledb.materialized_only=false) AS
 SELECT
   \if :IS_TIME_DIMENSION_WITH_TIMEZONE_1ST
     time_bucket(:BUCKET_WIDTH_1ST, "time", :'BUCKET_TZNAME_1ST') AS bucket,
@@ -3744,7 +3744,7 @@ UNION ALL
 \echo :WARNING_MESSAGE
 -- SHOULD WORK
 CREATE MATERIALIZED VIEW :CAGG_NAME_2TH_LEVEL
-WITH (timescaledb.continuous) AS
+WITH (timescaledb.continuous, timescaledb.materialized_only=false) AS
 SELECT
   \if :IS_TIME_DIMENSION_WITH_TIMEZONE_2TH
     time_bucket(:BUCKET_WIDTH_2TH, "bucket", :'BUCKET_TZNAME_2TH') AS bucket,
@@ -3783,7 +3783,7 @@ UNION ALL
   CALL refresh_continuous_aggregate(:'CAGG_NAME_1ST_LEVEL', NULL, NULL);
   CALL refresh_continuous_aggregate(:'CAGG_NAME_2TH_LEVEL', NULL, NULL);
   CREATE MATERIALIZED VIEW :CAGG_NAME_3TH_LEVEL
-  WITH (timescaledb.continuous) AS
+  WITH (timescaledb.continuous, timescaledb.materialized_only=false) AS
   SELECT
     \if :IS_TIME_DIMENSION_WITH_TIMEZONE_2TH
       time_bucket(:BUCKET_WIDTH_3TH, "bucket", :'BUCKET_TZNAME_2TH') AS bucket
@@ -3818,7 +3818,7 @@ DROP MATERIALIZED VIEW IF EXISTS :CAGG_NAME_1ST_LEVEL;
 -- CAGG on hypertable (1st level)
 --
 CREATE MATERIALIZED VIEW :CAGG_NAME_1ST_LEVEL
-WITH (timescaledb.continuous) AS
+WITH (timescaledb.continuous, timescaledb.materialized_only=false) AS
 SELECT
   \if :IS_TIME_DIMENSION_WITH_TIMEZONE_1ST
     time_bucket(:BUCKET_WIDTH_1ST, "time", :'BUCKET_TZNAME_1ST') AS bucket,
@@ -3855,7 +3855,7 @@ UNION ALL
 \echo :WARNING_MESSAGE
 -- SHOULD ERROR because non-multiple bucket sizes
 CREATE MATERIALIZED VIEW :CAGG_NAME_2TH_LEVEL
-WITH (timescaledb.continuous) AS
+WITH (timescaledb.continuous, timescaledb.materialized_only=false) AS
 SELECT
   \if :IS_TIME_DIMENSION_WITH_TIMEZONE_2TH
     time_bucket(:BUCKET_WIDTH_2TH, "bucket", :'BUCKET_TZNAME_2TH') AS bucket,
@@ -3879,7 +3879,7 @@ DETAIL:  Time bucket width of "public.conditions_summary_2" [@ 16 mins] should b
   CALL refresh_continuous_aggregate(:'CAGG_NAME_1ST_LEVEL', NULL, NULL);
   CALL refresh_continuous_aggregate(:'CAGG_NAME_2TH_LEVEL', NULL, NULL);
   CREATE MATERIALIZED VIEW :CAGG_NAME_3TH_LEVEL
-  WITH (timescaledb.continuous) AS
+  WITH (timescaledb.continuous, timescaledb.materialized_only=false) AS
   SELECT
     \if :IS_TIME_DIMENSION_WITH_TIMEZONE_2TH
       time_bucket(:BUCKET_WIDTH_3TH, "bucket", :'BUCKET_TZNAME_2TH') AS bucket
@@ -3920,7 +3920,7 @@ DROP MATERIALIZED VIEW IF EXISTS :CAGG_NAME_1ST_LEVEL;
 -- CAGG on hypertable (1st level)
 --
 CREATE MATERIALIZED VIEW :CAGG_NAME_1ST_LEVEL
-WITH (timescaledb.continuous) AS
+WITH (timescaledb.continuous, timescaledb.materialized_only=false) AS
 SELECT
   \if :IS_TIME_DIMENSION_WITH_TIMEZONE_1ST
     time_bucket(:BUCKET_WIDTH_1ST, "time", :'BUCKET_TZNAME_1ST') AS bucket,
@@ -3957,7 +3957,7 @@ UNION ALL
 \echo :WARNING_MESSAGE
 -- SHOULD WORK
 CREATE MATERIALIZED VIEW :CAGG_NAME_2TH_LEVEL
-WITH (timescaledb.continuous) AS
+WITH (timescaledb.continuous, timescaledb.materialized_only=false) AS
 SELECT
   \if :IS_TIME_DIMENSION_WITH_TIMEZONE_2TH
     time_bucket(:BUCKET_WIDTH_2TH, "bucket", :'BUCKET_TZNAME_2TH') AS bucket,
@@ -3996,7 +3996,7 @@ UNION ALL
   CALL refresh_continuous_aggregate(:'CAGG_NAME_1ST_LEVEL', NULL, NULL);
   CALL refresh_continuous_aggregate(:'CAGG_NAME_2TH_LEVEL', NULL, NULL);
   CREATE MATERIALIZED VIEW :CAGG_NAME_3TH_LEVEL
-  WITH (timescaledb.continuous) AS
+  WITH (timescaledb.continuous, timescaledb.materialized_only=false) AS
   SELECT
     \if :IS_TIME_DIMENSION_WITH_TIMEZONE_2TH
       time_bucket(:BUCKET_WIDTH_3TH, "bucket", :'BUCKET_TZNAME_2TH') AS bucket
@@ -4033,7 +4033,7 @@ DROP MATERIALIZED VIEW IF EXISTS :CAGG_NAME_1ST_LEVEL;
 -- CAGG on hypertable (1st level)
 --
 CREATE MATERIALIZED VIEW :CAGG_NAME_1ST_LEVEL
-WITH (timescaledb.continuous) AS
+WITH (timescaledb.continuous, timescaledb.materialized_only=false) AS
 SELECT
   \if :IS_TIME_DIMENSION_WITH_TIMEZONE_1ST
     time_bucket(:BUCKET_WIDTH_1ST, "time", :'BUCKET_TZNAME_1ST') AS bucket,
@@ -4070,7 +4070,7 @@ UNION ALL
 \echo :WARNING_MESSAGE
 -- SHOULD WORK
 CREATE MATERIALIZED VIEW :CAGG_NAME_2TH_LEVEL
-WITH (timescaledb.continuous) AS
+WITH (timescaledb.continuous, timescaledb.materialized_only=false) AS
 SELECT
   \if :IS_TIME_DIMENSION_WITH_TIMEZONE_2TH
     time_bucket(:BUCKET_WIDTH_2TH, "bucket", :'BUCKET_TZNAME_2TH') AS bucket,
@@ -4109,7 +4109,7 @@ UNION ALL
   CALL refresh_continuous_aggregate(:'CAGG_NAME_1ST_LEVEL', NULL, NULL);
   CALL refresh_continuous_aggregate(:'CAGG_NAME_2TH_LEVEL', NULL, NULL);
   CREATE MATERIALIZED VIEW :CAGG_NAME_3TH_LEVEL
-  WITH (timescaledb.continuous) AS
+  WITH (timescaledb.continuous, timescaledb.materialized_only=false) AS
   SELECT
     \if :IS_TIME_DIMENSION_WITH_TIMEZONE_2TH
       time_bucket(:BUCKET_WIDTH_3TH, "bucket", :'BUCKET_TZNAME_2TH') AS bucket
@@ -4173,7 +4173,7 @@ psql:include/cagg_on_cagg_validations.sql:87: NOTICE:  drop cascades to table _t
 -- CAGG on hypertable (1st level)
 --
 CREATE MATERIALIZED VIEW :CAGG_NAME_1ST_LEVEL
-WITH (timescaledb.continuous) AS
+WITH (timescaledb.continuous, timescaledb.materialized_only=false) AS
 SELECT
   \if :IS_TIME_DIMENSION_WITH_TIMEZONE_1ST
     time_bucket(:BUCKET_WIDTH_1ST, "time", :'BUCKET_TZNAME_1ST') AS bucket,
@@ -4210,7 +4210,7 @@ UNION ALL
 \echo :WARNING_MESSAGE
 -- SHOULD WORK
 CREATE MATERIALIZED VIEW :CAGG_NAME_2TH_LEVEL
-WITH (timescaledb.continuous) AS
+WITH (timescaledb.continuous, timescaledb.materialized_only=false) AS
 SELECT
   \if :IS_TIME_DIMENSION_WITH_TIMEZONE_2TH
     time_bucket(:BUCKET_WIDTH_2TH, "bucket", :'BUCKET_TZNAME_2TH') AS bucket,
@@ -4249,7 +4249,7 @@ UNION ALL
   CALL refresh_continuous_aggregate(:'CAGG_NAME_1ST_LEVEL', NULL, NULL);
   CALL refresh_continuous_aggregate(:'CAGG_NAME_2TH_LEVEL', NULL, NULL);
   CREATE MATERIALIZED VIEW :CAGG_NAME_3TH_LEVEL
-  WITH (timescaledb.continuous) AS
+  WITH (timescaledb.continuous, timescaledb.materialized_only=false) AS
   SELECT
     \if :IS_TIME_DIMENSION_WITH_TIMEZONE_2TH
       time_bucket(:BUCKET_WIDTH_3TH, "bucket", :'BUCKET_TZNAME_2TH') AS bucket
@@ -4286,7 +4286,7 @@ DROP MATERIALIZED VIEW IF EXISTS :CAGG_NAME_1ST_LEVEL;
 -- CAGG on hypertable (1st level)
 --
 CREATE MATERIALIZED VIEW :CAGG_NAME_1ST_LEVEL
-WITH (timescaledb.continuous) AS
+WITH (timescaledb.continuous, timescaledb.materialized_only=false) AS
 SELECT
   \if :IS_TIME_DIMENSION_WITH_TIMEZONE_1ST
     time_bucket(:BUCKET_WIDTH_1ST, "time", :'BUCKET_TZNAME_1ST') AS bucket,
@@ -4323,7 +4323,7 @@ UNION ALL
 \echo :WARNING_MESSAGE
 -- SHOULD WORK
 CREATE MATERIALIZED VIEW :CAGG_NAME_2TH_LEVEL
-WITH (timescaledb.continuous) AS
+WITH (timescaledb.continuous, timescaledb.materialized_only=false) AS
 SELECT
   \if :IS_TIME_DIMENSION_WITH_TIMEZONE_2TH
     time_bucket(:BUCKET_WIDTH_2TH, "bucket", :'BUCKET_TZNAME_2TH') AS bucket,
@@ -4362,7 +4362,7 @@ UNION ALL
   CALL refresh_continuous_aggregate(:'CAGG_NAME_1ST_LEVEL', NULL, NULL);
   CALL refresh_continuous_aggregate(:'CAGG_NAME_2TH_LEVEL', NULL, NULL);
   CREATE MATERIALIZED VIEW :CAGG_NAME_3TH_LEVEL
-  WITH (timescaledb.continuous) AS
+  WITH (timescaledb.continuous, timescaledb.materialized_only=false) AS
   SELECT
     \if :IS_TIME_DIMENSION_WITH_TIMEZONE_2TH
       time_bucket(:BUCKET_WIDTH_3TH, "bucket", :'BUCKET_TZNAME_2TH') AS bucket
@@ -4427,7 +4427,7 @@ psql:include/cagg_on_cagg_validations.sql:87: NOTICE:  drop cascades to table _t
 -- CAGG on hypertable (1st level)
 --
 CREATE MATERIALIZED VIEW :CAGG_NAME_1ST_LEVEL
-WITH (timescaledb.continuous) AS
+WITH (timescaledb.continuous, timescaledb.materialized_only=false) AS
 SELECT
   \if :IS_TIME_DIMENSION_WITH_TIMEZONE_1ST
     time_bucket(:BUCKET_WIDTH_1ST, "time", :'BUCKET_TZNAME_1ST') AS bucket,
@@ -4464,7 +4464,7 @@ UNION ALL
 \echo :WARNING_MESSAGE
 -- SHOULD WORK
 CREATE MATERIALIZED VIEW :CAGG_NAME_2TH_LEVEL
-WITH (timescaledb.continuous) AS
+WITH (timescaledb.continuous, timescaledb.materialized_only=false) AS
 SELECT
   \if :IS_TIME_DIMENSION_WITH_TIMEZONE_2TH
     time_bucket(:BUCKET_WIDTH_2TH, "bucket", :'BUCKET_TZNAME_2TH') AS bucket,
@@ -4503,7 +4503,7 @@ UNION ALL
   CALL refresh_continuous_aggregate(:'CAGG_NAME_1ST_LEVEL', NULL, NULL);
   CALL refresh_continuous_aggregate(:'CAGG_NAME_2TH_LEVEL', NULL, NULL);
   CREATE MATERIALIZED VIEW :CAGG_NAME_3TH_LEVEL
-  WITH (timescaledb.continuous) AS
+  WITH (timescaledb.continuous, timescaledb.materialized_only=false) AS
   SELECT
     \if :IS_TIME_DIMENSION_WITH_TIMEZONE_2TH
       time_bucket(:BUCKET_WIDTH_3TH, "bucket", :'BUCKET_TZNAME_2TH') AS bucket
@@ -4540,7 +4540,7 @@ DROP MATERIALIZED VIEW IF EXISTS :CAGG_NAME_1ST_LEVEL;
 -- CAGG on hypertable (1st level)
 --
 CREATE MATERIALIZED VIEW :CAGG_NAME_1ST_LEVEL
-WITH (timescaledb.continuous) AS
+WITH (timescaledb.continuous, timescaledb.materialized_only=false) AS
 SELECT
   \if :IS_TIME_DIMENSION_WITH_TIMEZONE_1ST
     time_bucket(:BUCKET_WIDTH_1ST, "time", :'BUCKET_TZNAME_1ST') AS bucket,
@@ -4577,7 +4577,7 @@ UNION ALL
 \echo :WARNING_MESSAGE
 -- SHOULD WORK
 CREATE MATERIALIZED VIEW :CAGG_NAME_2TH_LEVEL
-WITH (timescaledb.continuous) AS
+WITH (timescaledb.continuous, timescaledb.materialized_only=false) AS
 SELECT
   \if :IS_TIME_DIMENSION_WITH_TIMEZONE_2TH
     time_bucket(:BUCKET_WIDTH_2TH, "bucket", :'BUCKET_TZNAME_2TH') AS bucket,
@@ -4616,7 +4616,7 @@ UNION ALL
   CALL refresh_continuous_aggregate(:'CAGG_NAME_1ST_LEVEL', NULL, NULL);
   CALL refresh_continuous_aggregate(:'CAGG_NAME_2TH_LEVEL', NULL, NULL);
   CREATE MATERIALIZED VIEW :CAGG_NAME_3TH_LEVEL
-  WITH (timescaledb.continuous) AS
+  WITH (timescaledb.continuous, timescaledb.materialized_only=false) AS
   SELECT
     \if :IS_TIME_DIMENSION_WITH_TIMEZONE_2TH
       time_bucket(:BUCKET_WIDTH_3TH, "bucket", :'BUCKET_TZNAME_2TH') AS bucket
@@ -4681,7 +4681,7 @@ psql:include/cagg_on_cagg_validations.sql:87: NOTICE:  drop cascades to table _t
 -- CAGG on hypertable (1st level)
 --
 CREATE MATERIALIZED VIEW :CAGG_NAME_1ST_LEVEL
-WITH (timescaledb.continuous) AS
+WITH (timescaledb.continuous, timescaledb.materialized_only=false) AS
 SELECT
   \if :IS_TIME_DIMENSION_WITH_TIMEZONE_1ST
     time_bucket(:BUCKET_WIDTH_1ST, "time", :'BUCKET_TZNAME_1ST') AS bucket,
@@ -4718,7 +4718,7 @@ UNION ALL
 \echo :WARNING_MESSAGE
 -- SHOULD WORK
 CREATE MATERIALIZED VIEW :CAGG_NAME_2TH_LEVEL
-WITH (timescaledb.continuous) AS
+WITH (timescaledb.continuous, timescaledb.materialized_only=false) AS
 SELECT
   \if :IS_TIME_DIMENSION_WITH_TIMEZONE_2TH
     time_bucket(:BUCKET_WIDTH_2TH, "bucket", :'BUCKET_TZNAME_2TH') AS bucket,
@@ -4757,7 +4757,7 @@ UNION ALL
   CALL refresh_continuous_aggregate(:'CAGG_NAME_1ST_LEVEL', NULL, NULL);
   CALL refresh_continuous_aggregate(:'CAGG_NAME_2TH_LEVEL', NULL, NULL);
   CREATE MATERIALIZED VIEW :CAGG_NAME_3TH_LEVEL
-  WITH (timescaledb.continuous) AS
+  WITH (timescaledb.continuous, timescaledb.materialized_only=false) AS
   SELECT
     \if :IS_TIME_DIMENSION_WITH_TIMEZONE_2TH
       time_bucket(:BUCKET_WIDTH_3TH, "bucket", :'BUCKET_TZNAME_2TH') AS bucket
@@ -4797,7 +4797,7 @@ DROP MATERIALIZED VIEW IF EXISTS :CAGG_NAME_1ST_LEVEL;
 -- CAGG on hypertable (1st level)
 --
 CREATE MATERIALIZED VIEW :CAGG_NAME_1ST_LEVEL
-WITH (timescaledb.continuous) AS
+WITH (timescaledb.continuous, timescaledb.materialized_only=false) AS
 SELECT
   \if :IS_TIME_DIMENSION_WITH_TIMEZONE_1ST
     time_bucket(:BUCKET_WIDTH_1ST, "time", :'BUCKET_TZNAME_1ST') AS bucket,
@@ -4834,7 +4834,7 @@ UNION ALL
 \echo :WARNING_MESSAGE
 -- SHOULD WORK
 CREATE MATERIALIZED VIEW :CAGG_NAME_2TH_LEVEL
-WITH (timescaledb.continuous) AS
+WITH (timescaledb.continuous, timescaledb.materialized_only=false) AS
 SELECT
   \if :IS_TIME_DIMENSION_WITH_TIMEZONE_2TH
     time_bucket(:BUCKET_WIDTH_2TH, "bucket", :'BUCKET_TZNAME_2TH') AS bucket,
@@ -4873,7 +4873,7 @@ UNION ALL
   CALL refresh_continuous_aggregate(:'CAGG_NAME_1ST_LEVEL', NULL, NULL);
   CALL refresh_continuous_aggregate(:'CAGG_NAME_2TH_LEVEL', NULL, NULL);
   CREATE MATERIALIZED VIEW :CAGG_NAME_3TH_LEVEL
-  WITH (timescaledb.continuous) AS
+  WITH (timescaledb.continuous, timescaledb.materialized_only=false) AS
   SELECT
     \if :IS_TIME_DIMENSION_WITH_TIMEZONE_2TH
       time_bucket(:BUCKET_WIDTH_3TH, "bucket", :'BUCKET_TZNAME_2TH') AS bucket
@@ -4907,7 +4907,7 @@ DROP MATERIALIZED VIEW IF EXISTS :CAGG_NAME_1ST_LEVEL;
 -- CAGG on hypertable (1st level)
 --
 CREATE MATERIALIZED VIEW :CAGG_NAME_1ST_LEVEL
-WITH (timescaledb.continuous) AS
+WITH (timescaledb.continuous, timescaledb.materialized_only=false) AS
 SELECT
   \if :IS_TIME_DIMENSION_WITH_TIMEZONE_1ST
     time_bucket(:BUCKET_WIDTH_1ST, "time", :'BUCKET_TZNAME_1ST') AS bucket,
@@ -4944,7 +4944,7 @@ UNION ALL
 \echo :WARNING_MESSAGE
 -- SHOULD WORK
 CREATE MATERIALIZED VIEW :CAGG_NAME_2TH_LEVEL
-WITH (timescaledb.continuous) AS
+WITH (timescaledb.continuous, timescaledb.materialized_only=false) AS
 SELECT
   \if :IS_TIME_DIMENSION_WITH_TIMEZONE_2TH
     time_bucket(:BUCKET_WIDTH_2TH, "bucket", :'BUCKET_TZNAME_2TH') AS bucket,
@@ -4983,7 +4983,7 @@ UNION ALL
   CALL refresh_continuous_aggregate(:'CAGG_NAME_1ST_LEVEL', NULL, NULL);
   CALL refresh_continuous_aggregate(:'CAGG_NAME_2TH_LEVEL', NULL, NULL);
   CREATE MATERIALIZED VIEW :CAGG_NAME_3TH_LEVEL
-  WITH (timescaledb.continuous) AS
+  WITH (timescaledb.continuous, timescaledb.materialized_only=false) AS
   SELECT
     \if :IS_TIME_DIMENSION_WITH_TIMEZONE_2TH
       time_bucket(:BUCKET_WIDTH_3TH, "bucket", :'BUCKET_TZNAME_2TH') AS bucket
@@ -5017,7 +5017,7 @@ DROP MATERIALIZED VIEW IF EXISTS :CAGG_NAME_1ST_LEVEL;
 -- CAGG on hypertable (1st level)
 --
 CREATE MATERIALIZED VIEW :CAGG_NAME_1ST_LEVEL
-WITH (timescaledb.continuous) AS
+WITH (timescaledb.continuous, timescaledb.materialized_only=false) AS
 SELECT
   \if :IS_TIME_DIMENSION_WITH_TIMEZONE_1ST
     time_bucket(:BUCKET_WIDTH_1ST, "time", :'BUCKET_TZNAME_1ST') AS bucket,
@@ -5054,7 +5054,7 @@ UNION ALL
 \echo :WARNING_MESSAGE
 -- SHOULD WORK
 CREATE MATERIALIZED VIEW :CAGG_NAME_2TH_LEVEL
-WITH (timescaledb.continuous) AS
+WITH (timescaledb.continuous, timescaledb.materialized_only=false) AS
 SELECT
   \if :IS_TIME_DIMENSION_WITH_TIMEZONE_2TH
     time_bucket(:BUCKET_WIDTH_2TH, "bucket", :'BUCKET_TZNAME_2TH') AS bucket,
@@ -5093,7 +5093,7 @@ UNION ALL
   CALL refresh_continuous_aggregate(:'CAGG_NAME_1ST_LEVEL', NULL, NULL);
   CALL refresh_continuous_aggregate(:'CAGG_NAME_2TH_LEVEL', NULL, NULL);
   CREATE MATERIALIZED VIEW :CAGG_NAME_3TH_LEVEL
-  WITH (timescaledb.continuous) AS
+  WITH (timescaledb.continuous, timescaledb.materialized_only=false) AS
   SELECT
     \if :IS_TIME_DIMENSION_WITH_TIMEZONE_2TH
       time_bucket(:BUCKET_WIDTH_3TH, "bucket", :'BUCKET_TZNAME_2TH') AS bucket
@@ -5127,7 +5127,7 @@ DROP MATERIALIZED VIEW IF EXISTS :CAGG_NAME_1ST_LEVEL;
 -- CAGG on hypertable (1st level)
 --
 CREATE MATERIALIZED VIEW :CAGG_NAME_1ST_LEVEL
-WITH (timescaledb.continuous) AS
+WITH (timescaledb.continuous, timescaledb.materialized_only=false) AS
 SELECT
   \if :IS_TIME_DIMENSION_WITH_TIMEZONE_1ST
     time_bucket(:BUCKET_WIDTH_1ST, "time", :'BUCKET_TZNAME_1ST') AS bucket,
@@ -5164,7 +5164,7 @@ UNION ALL
 \echo :WARNING_MESSAGE
 -- SHOULD WORK
 CREATE MATERIALIZED VIEW :CAGG_NAME_2TH_LEVEL
-WITH (timescaledb.continuous) AS
+WITH (timescaledb.continuous, timescaledb.materialized_only=false) AS
 SELECT
   \if :IS_TIME_DIMENSION_WITH_TIMEZONE_2TH
     time_bucket(:BUCKET_WIDTH_2TH, "bucket", :'BUCKET_TZNAME_2TH') AS bucket,
@@ -5188,7 +5188,7 @@ DETAIL:  Time bucket width of "public.conditions_summary_2" [@ 1 year] should be
   CALL refresh_continuous_aggregate(:'CAGG_NAME_1ST_LEVEL', NULL, NULL);
   CALL refresh_continuous_aggregate(:'CAGG_NAME_2TH_LEVEL', NULL, NULL);
   CREATE MATERIALIZED VIEW :CAGG_NAME_3TH_LEVEL
-  WITH (timescaledb.continuous) AS
+  WITH (timescaledb.continuous, timescaledb.materialized_only=false) AS
   SELECT
     \if :IS_TIME_DIMENSION_WITH_TIMEZONE_2TH
       time_bucket(:BUCKET_WIDTH_3TH, "bucket", :'BUCKET_TZNAME_2TH') AS bucket
@@ -5223,7 +5223,7 @@ DROP MATERIALIZED VIEW IF EXISTS :CAGG_NAME_1ST_LEVEL;
 -- CAGG on hypertable (1st level)
 --
 CREATE MATERIALIZED VIEW :CAGG_NAME_1ST_LEVEL
-WITH (timescaledb.continuous) AS
+WITH (timescaledb.continuous, timescaledb.materialized_only=false) AS
 SELECT
   \if :IS_TIME_DIMENSION_WITH_TIMEZONE_1ST
     time_bucket(:BUCKET_WIDTH_1ST, "time", :'BUCKET_TZNAME_1ST') AS bucket,
@@ -5260,7 +5260,7 @@ UNION ALL
 \echo :WARNING_MESSAGE
 -- SHOULD WORK
 CREATE MATERIALIZED VIEW :CAGG_NAME_2TH_LEVEL
-WITH (timescaledb.continuous) AS
+WITH (timescaledb.continuous, timescaledb.materialized_only=false) AS
 SELECT
   \if :IS_TIME_DIMENSION_WITH_TIMEZONE_2TH
     time_bucket(:BUCKET_WIDTH_2TH, "bucket", :'BUCKET_TZNAME_2TH') AS bucket,
@@ -5284,7 +5284,7 @@ DETAIL:  Time bucket width of "public.conditions_summary_2" [@ 1 mon] should be 
   CALL refresh_continuous_aggregate(:'CAGG_NAME_1ST_LEVEL', NULL, NULL);
   CALL refresh_continuous_aggregate(:'CAGG_NAME_2TH_LEVEL', NULL, NULL);
   CREATE MATERIALIZED VIEW :CAGG_NAME_3TH_LEVEL
-  WITH (timescaledb.continuous) AS
+  WITH (timescaledb.continuous, timescaledb.materialized_only=false) AS
   SELECT
     \if :IS_TIME_DIMENSION_WITH_TIMEZONE_2TH
       time_bucket(:BUCKET_WIDTH_3TH, "bucket", :'BUCKET_TZNAME_2TH') AS bucket
@@ -5323,7 +5323,7 @@ DROP MATERIALIZED VIEW IF EXISTS :CAGG_NAME_1ST_LEVEL;
 -- CAGG on hypertable (1st level)
 --
 CREATE MATERIALIZED VIEW :CAGG_NAME_1ST_LEVEL
-WITH (timescaledb.continuous) AS
+WITH (timescaledb.continuous, timescaledb.materialized_only=false) AS
 SELECT
   \if :IS_TIME_DIMENSION_WITH_TIMEZONE_1ST
     time_bucket(:BUCKET_WIDTH_1ST, "time", :'BUCKET_TZNAME_1ST') AS bucket,
@@ -5360,7 +5360,7 @@ UNION ALL
 \echo :WARNING_MESSAGE
 -- SHOULD WORK
 CREATE MATERIALIZED VIEW :CAGG_NAME_2TH_LEVEL
-WITH (timescaledb.continuous) AS
+WITH (timescaledb.continuous, timescaledb.materialized_only=false) AS
 SELECT
   \if :IS_TIME_DIMENSION_WITH_TIMEZONE_2TH
     time_bucket(:BUCKET_WIDTH_2TH, "bucket", :'BUCKET_TZNAME_2TH') AS bucket,
@@ -5399,7 +5399,7 @@ UNION ALL
   CALL refresh_continuous_aggregate(:'CAGG_NAME_1ST_LEVEL', NULL, NULL);
   CALL refresh_continuous_aggregate(:'CAGG_NAME_2TH_LEVEL', NULL, NULL);
   CREATE MATERIALIZED VIEW :CAGG_NAME_3TH_LEVEL
-  WITH (timescaledb.continuous) AS
+  WITH (timescaledb.continuous, timescaledb.materialized_only=false) AS
   SELECT
     \if :IS_TIME_DIMENSION_WITH_TIMEZONE_2TH
       time_bucket(:BUCKET_WIDTH_3TH, "bucket", :'BUCKET_TZNAME_2TH') AS bucket
@@ -5433,7 +5433,7 @@ DROP MATERIALIZED VIEW IF EXISTS :CAGG_NAME_1ST_LEVEL;
 -- CAGG on hypertable (1st level)
 --
 CREATE MATERIALIZED VIEW :CAGG_NAME_1ST_LEVEL
-WITH (timescaledb.continuous) AS
+WITH (timescaledb.continuous, timescaledb.materialized_only=false) AS
 SELECT
   \if :IS_TIME_DIMENSION_WITH_TIMEZONE_1ST
     time_bucket(:BUCKET_WIDTH_1ST, "time", :'BUCKET_TZNAME_1ST') AS bucket,
@@ -5470,7 +5470,7 @@ UNION ALL
 \echo :WARNING_MESSAGE
 -- SHOULD WORK
 CREATE MATERIALIZED VIEW :CAGG_NAME_2TH_LEVEL
-WITH (timescaledb.continuous) AS
+WITH (timescaledb.continuous, timescaledb.materialized_only=false) AS
 SELECT
   \if :IS_TIME_DIMENSION_WITH_TIMEZONE_2TH
     time_bucket(:BUCKET_WIDTH_2TH, "bucket", :'BUCKET_TZNAME_2TH') AS bucket,
@@ -5509,7 +5509,7 @@ UNION ALL
   CALL refresh_continuous_aggregate(:'CAGG_NAME_1ST_LEVEL', NULL, NULL);
   CALL refresh_continuous_aggregate(:'CAGG_NAME_2TH_LEVEL', NULL, NULL);
   CREATE MATERIALIZED VIEW :CAGG_NAME_3TH_LEVEL
-  WITH (timescaledb.continuous) AS
+  WITH (timescaledb.continuous, timescaledb.materialized_only=false) AS
   SELECT
     \if :IS_TIME_DIMENSION_WITH_TIMEZONE_2TH
       time_bucket(:BUCKET_WIDTH_3TH, "bucket", :'BUCKET_TZNAME_2TH') AS bucket
@@ -5543,7 +5543,7 @@ DROP MATERIALIZED VIEW IF EXISTS :CAGG_NAME_1ST_LEVEL;
 -- CAGG on hypertable (1st level)
 --
 CREATE MATERIALIZED VIEW :CAGG_NAME_1ST_LEVEL
-WITH (timescaledb.continuous) AS
+WITH (timescaledb.continuous, timescaledb.materialized_only=false) AS
 SELECT
   \if :IS_TIME_DIMENSION_WITH_TIMEZONE_1ST
     time_bucket(:BUCKET_WIDTH_1ST, "time", :'BUCKET_TZNAME_1ST') AS bucket,
@@ -5580,7 +5580,7 @@ UNION ALL
 \echo :WARNING_MESSAGE
 -- SHOULD WORK
 CREATE MATERIALIZED VIEW :CAGG_NAME_2TH_LEVEL
-WITH (timescaledb.continuous) AS
+WITH (timescaledb.continuous, timescaledb.materialized_only=false) AS
 SELECT
   \if :IS_TIME_DIMENSION_WITH_TIMEZONE_2TH
     time_bucket(:BUCKET_WIDTH_2TH, "bucket", :'BUCKET_TZNAME_2TH') AS bucket,
@@ -5619,7 +5619,7 @@ UNION ALL
   CALL refresh_continuous_aggregate(:'CAGG_NAME_1ST_LEVEL', NULL, NULL);
   CALL refresh_continuous_aggregate(:'CAGG_NAME_2TH_LEVEL', NULL, NULL);
   CREATE MATERIALIZED VIEW :CAGG_NAME_3TH_LEVEL
-  WITH (timescaledb.continuous) AS
+  WITH (timescaledb.continuous, timescaledb.materialized_only=false) AS
   SELECT
     \if :IS_TIME_DIMENSION_WITH_TIMEZONE_2TH
       time_bucket(:BUCKET_WIDTH_3TH, "bucket", :'BUCKET_TZNAME_2TH') AS bucket
@@ -5654,7 +5654,7 @@ DROP MATERIALIZED VIEW IF EXISTS :CAGG_NAME_1ST_LEVEL;
 -- CAGG on hypertable (1st level)
 --
 CREATE MATERIALIZED VIEW :CAGG_NAME_1ST_LEVEL
-WITH (timescaledb.continuous) AS
+WITH (timescaledb.continuous, timescaledb.materialized_only=false) AS
 SELECT
   \if :IS_TIME_DIMENSION_WITH_TIMEZONE_1ST
     time_bucket(:BUCKET_WIDTH_1ST, "time", :'BUCKET_TZNAME_1ST') AS bucket,
@@ -5691,7 +5691,7 @@ UNION ALL
 \echo :WARNING_MESSAGE
 -- SHOULD WORK
 CREATE MATERIALIZED VIEW :CAGG_NAME_2TH_LEVEL
-WITH (timescaledb.continuous) AS
+WITH (timescaledb.continuous, timescaledb.materialized_only=false) AS
 SELECT
   \if :IS_TIME_DIMENSION_WITH_TIMEZONE_2TH
     time_bucket(:BUCKET_WIDTH_2TH, "bucket", :'BUCKET_TZNAME_2TH') AS bucket,
@@ -5730,7 +5730,7 @@ UNION ALL
   CALL refresh_continuous_aggregate(:'CAGG_NAME_1ST_LEVEL', NULL, NULL);
   CALL refresh_continuous_aggregate(:'CAGG_NAME_2TH_LEVEL', NULL, NULL);
   CREATE MATERIALIZED VIEW :CAGG_NAME_3TH_LEVEL
-  WITH (timescaledb.continuous) AS
+  WITH (timescaledb.continuous, timescaledb.materialized_only=false) AS
   SELECT
     \if :IS_TIME_DIMENSION_WITH_TIMEZONE_2TH
       time_bucket(:BUCKET_WIDTH_3TH, "bucket", :'BUCKET_TZNAME_2TH') AS bucket
@@ -5765,7 +5765,7 @@ DROP MATERIALIZED VIEW IF EXISTS :CAGG_NAME_1ST_LEVEL;
 -- CAGG on hypertable (1st level)
 --
 CREATE MATERIALIZED VIEW :CAGG_NAME_1ST_LEVEL
-WITH (timescaledb.continuous) AS
+WITH (timescaledb.continuous, timescaledb.materialized_only=false) AS
 SELECT
   \if :IS_TIME_DIMENSION_WITH_TIMEZONE_1ST
     time_bucket(:BUCKET_WIDTH_1ST, "time", :'BUCKET_TZNAME_1ST') AS bucket,
@@ -5802,7 +5802,7 @@ UNION ALL
 \echo :WARNING_MESSAGE
 -- SHOULD WORK
 CREATE MATERIALIZED VIEW :CAGG_NAME_2TH_LEVEL
-WITH (timescaledb.continuous) AS
+WITH (timescaledb.continuous, timescaledb.materialized_only=false) AS
 SELECT
   \if :IS_TIME_DIMENSION_WITH_TIMEZONE_2TH
     time_bucket(:BUCKET_WIDTH_2TH, "bucket", :'BUCKET_TZNAME_2TH') AS bucket,
@@ -5826,7 +5826,7 @@ DETAIL:  Time bucket width of "public.conditions_summary_2" [@ 0.00116 secs] sho
   CALL refresh_continuous_aggregate(:'CAGG_NAME_1ST_LEVEL', NULL, NULL);
   CALL refresh_continuous_aggregate(:'CAGG_NAME_2TH_LEVEL', NULL, NULL);
   CREATE MATERIALIZED VIEW :CAGG_NAME_3TH_LEVEL
-  WITH (timescaledb.continuous) AS
+  WITH (timescaledb.continuous, timescaledb.materialized_only=false) AS
   SELECT
     \if :IS_TIME_DIMENSION_WITH_TIMEZONE_2TH
       time_bucket(:BUCKET_WIDTH_3TH, "bucket", :'BUCKET_TZNAME_2TH') AS bucket

--- a/tsl/test/expected/cagg_on_cagg_dist_ht.out
+++ b/tsl/test/expected/cagg_on_cagg_dist_ht.out
@@ -909,7 +909,7 @@ psql:include/cagg_on_cagg_common.sql:200: ERROR:  relation "conditions_summary_1
 -- CAGG on hypertable (1st level)
 --
 CREATE MATERIALIZED VIEW :CAGG_NAME_1ST_LEVEL
-WITH (timescaledb.continuous) AS
+WITH (timescaledb.continuous, timescaledb.materialized_only=false) AS
 SELECT
   \if :IS_TIME_DIMENSION_WITH_TIMEZONE_1ST
     time_bucket(:BUCKET_WIDTH_1ST, "time", :'BUCKET_TZNAME_1ST') AS bucket,
@@ -946,7 +946,7 @@ UNION ALL
 \echo :WARNING_MESSAGE
 -- SHOULD ERROR because non-multiple bucket sizes
 CREATE MATERIALIZED VIEW :CAGG_NAME_2TH_LEVEL
-WITH (timescaledb.continuous) AS
+WITH (timescaledb.continuous, timescaledb.materialized_only=false) AS
 SELECT
   \if :IS_TIME_DIMENSION_WITH_TIMEZONE_2TH
     time_bucket(:BUCKET_WIDTH_2TH, "bucket", :'BUCKET_TZNAME_2TH') AS bucket,
@@ -970,7 +970,7 @@ DETAIL:  Time bucket width of "public.conditions_summary_2" [5] should be multip
   CALL refresh_continuous_aggregate(:'CAGG_NAME_1ST_LEVEL', NULL, NULL);
   CALL refresh_continuous_aggregate(:'CAGG_NAME_2TH_LEVEL', NULL, NULL);
   CREATE MATERIALIZED VIEW :CAGG_NAME_3TH_LEVEL
-  WITH (timescaledb.continuous) AS
+  WITH (timescaledb.continuous, timescaledb.materialized_only=false) AS
   SELECT
     \if :IS_TIME_DIMENSION_WITH_TIMEZONE_2TH
       time_bucket(:BUCKET_WIDTH_3TH, "bucket", :'BUCKET_TZNAME_2TH') AS bucket
@@ -1009,7 +1009,7 @@ DROP MATERIALIZED VIEW IF EXISTS :CAGG_NAME_1ST_LEVEL;
 -- CAGG on hypertable (1st level)
 --
 CREATE MATERIALIZED VIEW :CAGG_NAME_1ST_LEVEL
-WITH (timescaledb.continuous) AS
+WITH (timescaledb.continuous, timescaledb.materialized_only=false) AS
 SELECT
   \if :IS_TIME_DIMENSION_WITH_TIMEZONE_1ST
     time_bucket(:BUCKET_WIDTH_1ST, "time", :'BUCKET_TZNAME_1ST') AS bucket,
@@ -1046,7 +1046,7 @@ UNION ALL
 \echo :WARNING_MESSAGE
 SHOULD WORK because new bucket should be greater than previous
 CREATE MATERIALIZED VIEW :CAGG_NAME_2TH_LEVEL
-WITH (timescaledb.continuous) AS
+WITH (timescaledb.continuous, timescaledb.materialized_only=false) AS
 SELECT
   \if :IS_TIME_DIMENSION_WITH_TIMEZONE_2TH
     time_bucket(:BUCKET_WIDTH_2TH, "bucket", :'BUCKET_TZNAME_2TH') AS bucket,
@@ -1085,7 +1085,7 @@ UNION ALL
   CALL refresh_continuous_aggregate(:'CAGG_NAME_1ST_LEVEL', NULL, NULL);
   CALL refresh_continuous_aggregate(:'CAGG_NAME_2TH_LEVEL', NULL, NULL);
   CREATE MATERIALIZED VIEW :CAGG_NAME_3TH_LEVEL
-  WITH (timescaledb.continuous) AS
+  WITH (timescaledb.continuous, timescaledb.materialized_only=false) AS
   SELECT
     \if :IS_TIME_DIMENSION_WITH_TIMEZONE_2TH
       time_bucket(:BUCKET_WIDTH_3TH, "bucket", :'BUCKET_TZNAME_2TH') AS bucket
@@ -1123,7 +1123,7 @@ DROP MATERIALIZED VIEW IF EXISTS :CAGG_NAME_1ST_LEVEL;
 -- CAGG on hypertable (1st level)
 --
 CREATE MATERIALIZED VIEW :CAGG_NAME_1ST_LEVEL
-WITH (timescaledb.continuous) AS
+WITH (timescaledb.continuous, timescaledb.materialized_only=false) AS
 SELECT
   \if :IS_TIME_DIMENSION_WITH_TIMEZONE_1ST
     time_bucket(:BUCKET_WIDTH_1ST, "time", :'BUCKET_TZNAME_1ST') AS bucket,
@@ -1160,7 +1160,7 @@ UNION ALL
 \echo :WARNING_MESSAGE
 -- SHOULD ERROR because new bucket should be greater than previous
 CREATE MATERIALIZED VIEW :CAGG_NAME_2TH_LEVEL
-WITH (timescaledb.continuous) AS
+WITH (timescaledb.continuous, timescaledb.materialized_only=false) AS
 SELECT
   \if :IS_TIME_DIMENSION_WITH_TIMEZONE_2TH
     time_bucket(:BUCKET_WIDTH_2TH, "bucket", :'BUCKET_TZNAME_2TH') AS bucket,
@@ -1184,7 +1184,7 @@ DETAIL:  Time bucket width of "public.conditions_summary_2" [2] should be greate
   CALL refresh_continuous_aggregate(:'CAGG_NAME_1ST_LEVEL', NULL, NULL);
   CALL refresh_continuous_aggregate(:'CAGG_NAME_2TH_LEVEL', NULL, NULL);
   CREATE MATERIALIZED VIEW :CAGG_NAME_3TH_LEVEL
-  WITH (timescaledb.continuous) AS
+  WITH (timescaledb.continuous, timescaledb.materialized_only=false) AS
   SELECT
     \if :IS_TIME_DIMENSION_WITH_TIMEZONE_2TH
       time_bucket(:BUCKET_WIDTH_3TH, "bucket", :'BUCKET_TZNAME_2TH') AS bucket
@@ -2068,7 +2068,7 @@ psql:include/cagg_on_cagg_common.sql:200: ERROR:  relation "conditions_summary_1
 -- CAGG on hypertable (1st level)
 --
 CREATE MATERIALIZED VIEW :CAGG_NAME_1ST_LEVEL
-WITH (timescaledb.continuous) AS
+WITH (timescaledb.continuous, timescaledb.materialized_only=false) AS
 SELECT
   \if :IS_TIME_DIMENSION_WITH_TIMEZONE_1ST
     time_bucket(:BUCKET_WIDTH_1ST, "time", :'BUCKET_TZNAME_1ST') AS bucket,
@@ -2105,7 +2105,7 @@ UNION ALL
 \echo :WARNING_MESSAGE
 -- SHOULD ERROR because is not allowed variable-size bucket on top of fixed-size bucket
 CREATE MATERIALIZED VIEW :CAGG_NAME_2TH_LEVEL
-WITH (timescaledb.continuous) AS
+WITH (timescaledb.continuous, timescaledb.materialized_only=false) AS
 SELECT
   \if :IS_TIME_DIMENSION_WITH_TIMEZONE_2TH
     time_bucket(:BUCKET_WIDTH_2TH, "bucket", :'BUCKET_TZNAME_2TH') AS bucket,
@@ -2130,7 +2130,7 @@ The variance can lead to the fixed width one not being a multiple of the variabl
   CALL refresh_continuous_aggregate(:'CAGG_NAME_1ST_LEVEL', NULL, NULL);
   CALL refresh_continuous_aggregate(:'CAGG_NAME_2TH_LEVEL', NULL, NULL);
   CREATE MATERIALIZED VIEW :CAGG_NAME_3TH_LEVEL
-  WITH (timescaledb.continuous) AS
+  WITH (timescaledb.continuous, timescaledb.materialized_only=false) AS
   SELECT
     \if :IS_TIME_DIMENSION_WITH_TIMEZONE_2TH
       time_bucket(:BUCKET_WIDTH_3TH, "bucket", :'BUCKET_TZNAME_2TH') AS bucket
@@ -2169,7 +2169,7 @@ DROP MATERIALIZED VIEW IF EXISTS :CAGG_NAME_1ST_LEVEL;
 -- CAGG on hypertable (1st level)
 --
 CREATE MATERIALIZED VIEW :CAGG_NAME_1ST_LEVEL
-WITH (timescaledb.continuous) AS
+WITH (timescaledb.continuous, timescaledb.materialized_only=false) AS
 SELECT
   \if :IS_TIME_DIMENSION_WITH_TIMEZONE_1ST
     time_bucket(:BUCKET_WIDTH_1ST, "time", :'BUCKET_TZNAME_1ST') AS bucket,
@@ -2206,7 +2206,7 @@ UNION ALL
 \echo :WARNING_MESSAGE
 -- SHOULD ERROR because non-multiple bucket sizes
 CREATE MATERIALIZED VIEW :CAGG_NAME_2TH_LEVEL
-WITH (timescaledb.continuous) AS
+WITH (timescaledb.continuous, timescaledb.materialized_only=false) AS
 SELECT
   \if :IS_TIME_DIMENSION_WITH_TIMEZONE_2TH
     time_bucket(:BUCKET_WIDTH_2TH, "bucket", :'BUCKET_TZNAME_2TH') AS bucket,
@@ -2230,7 +2230,7 @@ DETAIL:  Time bucket width of "public.conditions_summary_2" [@ 3 hours] should b
   CALL refresh_continuous_aggregate(:'CAGG_NAME_1ST_LEVEL', NULL, NULL);
   CALL refresh_continuous_aggregate(:'CAGG_NAME_2TH_LEVEL', NULL, NULL);
   CREATE MATERIALIZED VIEW :CAGG_NAME_3TH_LEVEL
-  WITH (timescaledb.continuous) AS
+  WITH (timescaledb.continuous, timescaledb.materialized_only=false) AS
   SELECT
     \if :IS_TIME_DIMENSION_WITH_TIMEZONE_2TH
       time_bucket(:BUCKET_WIDTH_3TH, "bucket", :'BUCKET_TZNAME_2TH') AS bucket
@@ -2269,7 +2269,7 @@ DROP MATERIALIZED VIEW IF EXISTS :CAGG_NAME_1ST_LEVEL;
 -- CAGG on hypertable (1st level)
 --
 CREATE MATERIALIZED VIEW :CAGG_NAME_1ST_LEVEL
-WITH (timescaledb.continuous) AS
+WITH (timescaledb.continuous, timescaledb.materialized_only=false) AS
 SELECT
   \if :IS_TIME_DIMENSION_WITH_TIMEZONE_1ST
     time_bucket(:BUCKET_WIDTH_1ST, "time", :'BUCKET_TZNAME_1ST') AS bucket,
@@ -2306,7 +2306,7 @@ UNION ALL
 \echo :WARNING_MESSAGE
 SHOULD WORK because new bucket should be greater than previous
 CREATE MATERIALIZED VIEW :CAGG_NAME_2TH_LEVEL
-WITH (timescaledb.continuous) AS
+WITH (timescaledb.continuous, timescaledb.materialized_only=false) AS
 SELECT
   \if :IS_TIME_DIMENSION_WITH_TIMEZONE_2TH
     time_bucket(:BUCKET_WIDTH_2TH, "bucket", :'BUCKET_TZNAME_2TH') AS bucket,
@@ -2345,7 +2345,7 @@ UNION ALL
   CALL refresh_continuous_aggregate(:'CAGG_NAME_1ST_LEVEL', NULL, NULL);
   CALL refresh_continuous_aggregate(:'CAGG_NAME_2TH_LEVEL', NULL, NULL);
   CREATE MATERIALIZED VIEW :CAGG_NAME_3TH_LEVEL
-  WITH (timescaledb.continuous) AS
+  WITH (timescaledb.continuous, timescaledb.materialized_only=false) AS
   SELECT
     \if :IS_TIME_DIMENSION_WITH_TIMEZONE_2TH
       time_bucket(:BUCKET_WIDTH_3TH, "bucket", :'BUCKET_TZNAME_2TH') AS bucket
@@ -2383,7 +2383,7 @@ DROP MATERIALIZED VIEW IF EXISTS :CAGG_NAME_1ST_LEVEL;
 -- CAGG on hypertable (1st level)
 --
 CREATE MATERIALIZED VIEW :CAGG_NAME_1ST_LEVEL
-WITH (timescaledb.continuous) AS
+WITH (timescaledb.continuous, timescaledb.materialized_only=false) AS
 SELECT
   \if :IS_TIME_DIMENSION_WITH_TIMEZONE_1ST
     time_bucket(:BUCKET_WIDTH_1ST, "time", :'BUCKET_TZNAME_1ST') AS bucket,
@@ -2420,7 +2420,7 @@ UNION ALL
 \echo :WARNING_MESSAGE
 -- SHOULD ERROR because new bucket should be greater than previous
 CREATE MATERIALIZED VIEW :CAGG_NAME_2TH_LEVEL
-WITH (timescaledb.continuous) AS
+WITH (timescaledb.continuous, timescaledb.materialized_only=false) AS
 SELECT
   \if :IS_TIME_DIMENSION_WITH_TIMEZONE_2TH
     time_bucket(:BUCKET_WIDTH_2TH, "bucket", :'BUCKET_TZNAME_2TH') AS bucket,
@@ -2444,7 +2444,7 @@ DETAIL:  Time bucket width of "public.conditions_summary_2" [@ 1 hour] should be
   CALL refresh_continuous_aggregate(:'CAGG_NAME_1ST_LEVEL', NULL, NULL);
   CALL refresh_continuous_aggregate(:'CAGG_NAME_2TH_LEVEL', NULL, NULL);
   CREATE MATERIALIZED VIEW :CAGG_NAME_3TH_LEVEL
-  WITH (timescaledb.continuous) AS
+  WITH (timescaledb.continuous, timescaledb.materialized_only=false) AS
   SELECT
     \if :IS_TIME_DIMENSION_WITH_TIMEZONE_2TH
       time_bucket(:BUCKET_WIDTH_3TH, "bucket", :'BUCKET_TZNAME_2TH') AS bucket
@@ -3323,7 +3323,7 @@ psql:include/cagg_on_cagg_common.sql:200: ERROR:  relation "conditions_summary_1
 -- CAGG on hypertable (1st level)
 --
 CREATE MATERIALIZED VIEW :CAGG_NAME_1ST_LEVEL
-WITH (timescaledb.continuous) AS
+WITH (timescaledb.continuous, timescaledb.materialized_only=false) AS
 SELECT
   \if :IS_TIME_DIMENSION_WITH_TIMEZONE_1ST
     time_bucket(:BUCKET_WIDTH_1ST, "time", :'BUCKET_TZNAME_1ST') AS bucket,
@@ -3360,7 +3360,7 @@ UNION ALL
 \echo :WARNING_MESSAGE
 -- SHOULD ERROR because is not allowed variable-size bucket on top of fixed-size bucket
 CREATE MATERIALIZED VIEW :CAGG_NAME_2TH_LEVEL
-WITH (timescaledb.continuous) AS
+WITH (timescaledb.continuous, timescaledb.materialized_only=false) AS
 SELECT
   \if :IS_TIME_DIMENSION_WITH_TIMEZONE_2TH
     time_bucket(:BUCKET_WIDTH_2TH, "bucket", :'BUCKET_TZNAME_2TH') AS bucket,
@@ -3385,7 +3385,7 @@ The variance can lead to the fixed width one not being a multiple of the variabl
   CALL refresh_continuous_aggregate(:'CAGG_NAME_1ST_LEVEL', NULL, NULL);
   CALL refresh_continuous_aggregate(:'CAGG_NAME_2TH_LEVEL', NULL, NULL);
   CREATE MATERIALIZED VIEW :CAGG_NAME_3TH_LEVEL
-  WITH (timescaledb.continuous) AS
+  WITH (timescaledb.continuous, timescaledb.materialized_only=false) AS
   SELECT
     \if :IS_TIME_DIMENSION_WITH_TIMEZONE_2TH
       time_bucket(:BUCKET_WIDTH_3TH, "bucket", :'BUCKET_TZNAME_2TH') AS bucket
@@ -3424,7 +3424,7 @@ DROP MATERIALIZED VIEW IF EXISTS :CAGG_NAME_1ST_LEVEL;
 -- CAGG on hypertable (1st level)
 --
 CREATE MATERIALIZED VIEW :CAGG_NAME_1ST_LEVEL
-WITH (timescaledb.continuous) AS
+WITH (timescaledb.continuous, timescaledb.materialized_only=false) AS
 SELECT
   \if :IS_TIME_DIMENSION_WITH_TIMEZONE_1ST
     time_bucket(:BUCKET_WIDTH_1ST, "time", :'BUCKET_TZNAME_1ST') AS bucket,
@@ -3461,7 +3461,7 @@ UNION ALL
 \echo :WARNING_MESSAGE
 -- SHOULD ERROR because non-multiple bucket sizes
 CREATE MATERIALIZED VIEW :CAGG_NAME_2TH_LEVEL
-WITH (timescaledb.continuous) AS
+WITH (timescaledb.continuous, timescaledb.materialized_only=false) AS
 SELECT
   \if :IS_TIME_DIMENSION_WITH_TIMEZONE_2TH
     time_bucket(:BUCKET_WIDTH_2TH, "bucket", :'BUCKET_TZNAME_2TH') AS bucket,
@@ -3485,7 +3485,7 @@ DETAIL:  Time bucket width of "public.conditions_summary_2" [@ 3 hours] should b
   CALL refresh_continuous_aggregate(:'CAGG_NAME_1ST_LEVEL', NULL, NULL);
   CALL refresh_continuous_aggregate(:'CAGG_NAME_2TH_LEVEL', NULL, NULL);
   CREATE MATERIALIZED VIEW :CAGG_NAME_3TH_LEVEL
-  WITH (timescaledb.continuous) AS
+  WITH (timescaledb.continuous, timescaledb.materialized_only=false) AS
   SELECT
     \if :IS_TIME_DIMENSION_WITH_TIMEZONE_2TH
       time_bucket(:BUCKET_WIDTH_3TH, "bucket", :'BUCKET_TZNAME_2TH') AS bucket
@@ -3524,7 +3524,7 @@ DROP MATERIALIZED VIEW IF EXISTS :CAGG_NAME_1ST_LEVEL;
 -- CAGG on hypertable (1st level)
 --
 CREATE MATERIALIZED VIEW :CAGG_NAME_1ST_LEVEL
-WITH (timescaledb.continuous) AS
+WITH (timescaledb.continuous, timescaledb.materialized_only=false) AS
 SELECT
   \if :IS_TIME_DIMENSION_WITH_TIMEZONE_1ST
     time_bucket(:BUCKET_WIDTH_1ST, "time", :'BUCKET_TZNAME_1ST') AS bucket,
@@ -3561,7 +3561,7 @@ UNION ALL
 \echo :WARNING_MESSAGE
 SHOULD WORK because new bucket should be greater than previous
 CREATE MATERIALIZED VIEW :CAGG_NAME_2TH_LEVEL
-WITH (timescaledb.continuous) AS
+WITH (timescaledb.continuous, timescaledb.materialized_only=false) AS
 SELECT
   \if :IS_TIME_DIMENSION_WITH_TIMEZONE_2TH
     time_bucket(:BUCKET_WIDTH_2TH, "bucket", :'BUCKET_TZNAME_2TH') AS bucket,
@@ -3600,7 +3600,7 @@ UNION ALL
   CALL refresh_continuous_aggregate(:'CAGG_NAME_1ST_LEVEL', NULL, NULL);
   CALL refresh_continuous_aggregate(:'CAGG_NAME_2TH_LEVEL', NULL, NULL);
   CREATE MATERIALIZED VIEW :CAGG_NAME_3TH_LEVEL
-  WITH (timescaledb.continuous) AS
+  WITH (timescaledb.continuous, timescaledb.materialized_only=false) AS
   SELECT
     \if :IS_TIME_DIMENSION_WITH_TIMEZONE_2TH
       time_bucket(:BUCKET_WIDTH_3TH, "bucket", :'BUCKET_TZNAME_2TH') AS bucket
@@ -3638,7 +3638,7 @@ DROP MATERIALIZED VIEW IF EXISTS :CAGG_NAME_1ST_LEVEL;
 -- CAGG on hypertable (1st level)
 --
 CREATE MATERIALIZED VIEW :CAGG_NAME_1ST_LEVEL
-WITH (timescaledb.continuous) AS
+WITH (timescaledb.continuous, timescaledb.materialized_only=false) AS
 SELECT
   \if :IS_TIME_DIMENSION_WITH_TIMEZONE_1ST
     time_bucket(:BUCKET_WIDTH_1ST, "time", :'BUCKET_TZNAME_1ST') AS bucket,
@@ -3675,7 +3675,7 @@ UNION ALL
 \echo :WARNING_MESSAGE
 -- SHOULD ERROR because new bucket should be greater than previous
 CREATE MATERIALIZED VIEW :CAGG_NAME_2TH_LEVEL
-WITH (timescaledb.continuous) AS
+WITH (timescaledb.continuous, timescaledb.materialized_only=false) AS
 SELECT
   \if :IS_TIME_DIMENSION_WITH_TIMEZONE_2TH
     time_bucket(:BUCKET_WIDTH_2TH, "bucket", :'BUCKET_TZNAME_2TH') AS bucket,
@@ -3699,7 +3699,7 @@ DETAIL:  Time bucket width of "public.conditions_summary_2" [@ 1 hour] should be
   CALL refresh_continuous_aggregate(:'CAGG_NAME_1ST_LEVEL', NULL, NULL);
   CALL refresh_continuous_aggregate(:'CAGG_NAME_2TH_LEVEL', NULL, NULL);
   CREATE MATERIALIZED VIEW :CAGG_NAME_3TH_LEVEL
-  WITH (timescaledb.continuous) AS
+  WITH (timescaledb.continuous, timescaledb.materialized_only=false) AS
   SELECT
     \if :IS_TIME_DIMENSION_WITH_TIMEZONE_2TH
       time_bucket(:BUCKET_WIDTH_3TH, "bucket", :'BUCKET_TZNAME_2TH') AS bucket
@@ -3745,7 +3745,7 @@ DROP MATERIALIZED VIEW IF EXISTS :CAGG_NAME_1ST_LEVEL;
 -- CAGG on hypertable (1st level)
 --
 CREATE MATERIALIZED VIEW :CAGG_NAME_1ST_LEVEL
-WITH (timescaledb.continuous) AS
+WITH (timescaledb.continuous, timescaledb.materialized_only=false) AS
 SELECT
   \if :IS_TIME_DIMENSION_WITH_TIMEZONE_1ST
     time_bucket(:BUCKET_WIDTH_1ST, "time", :'BUCKET_TZNAME_1ST') AS bucket,
@@ -3782,7 +3782,7 @@ UNION ALL
 \echo :WARNING_MESSAGE
 -- SHOULD WORK
 CREATE MATERIALIZED VIEW :CAGG_NAME_2TH_LEVEL
-WITH (timescaledb.continuous) AS
+WITH (timescaledb.continuous, timescaledb.materialized_only=false) AS
 SELECT
   \if :IS_TIME_DIMENSION_WITH_TIMEZONE_2TH
     time_bucket(:BUCKET_WIDTH_2TH, "bucket", :'BUCKET_TZNAME_2TH') AS bucket,
@@ -3821,7 +3821,7 @@ UNION ALL
   CALL refresh_continuous_aggregate(:'CAGG_NAME_1ST_LEVEL', NULL, NULL);
   CALL refresh_continuous_aggregate(:'CAGG_NAME_2TH_LEVEL', NULL, NULL);
   CREATE MATERIALIZED VIEW :CAGG_NAME_3TH_LEVEL
-  WITH (timescaledb.continuous) AS
+  WITH (timescaledb.continuous, timescaledb.materialized_only=false) AS
   SELECT
     \if :IS_TIME_DIMENSION_WITH_TIMEZONE_2TH
       time_bucket(:BUCKET_WIDTH_3TH, "bucket", :'BUCKET_TZNAME_2TH') AS bucket
@@ -3856,7 +3856,7 @@ DROP MATERIALIZED VIEW IF EXISTS :CAGG_NAME_1ST_LEVEL;
 -- CAGG on hypertable (1st level)
 --
 CREATE MATERIALIZED VIEW :CAGG_NAME_1ST_LEVEL
-WITH (timescaledb.continuous) AS
+WITH (timescaledb.continuous, timescaledb.materialized_only=false) AS
 SELECT
   \if :IS_TIME_DIMENSION_WITH_TIMEZONE_1ST
     time_bucket(:BUCKET_WIDTH_1ST, "time", :'BUCKET_TZNAME_1ST') AS bucket,
@@ -3893,7 +3893,7 @@ UNION ALL
 \echo :WARNING_MESSAGE
 -- SHOULD ERROR because non-multiple bucket sizes
 CREATE MATERIALIZED VIEW :CAGG_NAME_2TH_LEVEL
-WITH (timescaledb.continuous) AS
+WITH (timescaledb.continuous, timescaledb.materialized_only=false) AS
 SELECT
   \if :IS_TIME_DIMENSION_WITH_TIMEZONE_2TH
     time_bucket(:BUCKET_WIDTH_2TH, "bucket", :'BUCKET_TZNAME_2TH') AS bucket,
@@ -3917,7 +3917,7 @@ DETAIL:  Time bucket width of "public.conditions_summary_2" [@ 16 mins] should b
   CALL refresh_continuous_aggregate(:'CAGG_NAME_1ST_LEVEL', NULL, NULL);
   CALL refresh_continuous_aggregate(:'CAGG_NAME_2TH_LEVEL', NULL, NULL);
   CREATE MATERIALIZED VIEW :CAGG_NAME_3TH_LEVEL
-  WITH (timescaledb.continuous) AS
+  WITH (timescaledb.continuous, timescaledb.materialized_only=false) AS
   SELECT
     \if :IS_TIME_DIMENSION_WITH_TIMEZONE_2TH
       time_bucket(:BUCKET_WIDTH_3TH, "bucket", :'BUCKET_TZNAME_2TH') AS bucket
@@ -3958,7 +3958,7 @@ DROP MATERIALIZED VIEW IF EXISTS :CAGG_NAME_1ST_LEVEL;
 -- CAGG on hypertable (1st level)
 --
 CREATE MATERIALIZED VIEW :CAGG_NAME_1ST_LEVEL
-WITH (timescaledb.continuous) AS
+WITH (timescaledb.continuous, timescaledb.materialized_only=false) AS
 SELECT
   \if :IS_TIME_DIMENSION_WITH_TIMEZONE_1ST
     time_bucket(:BUCKET_WIDTH_1ST, "time", :'BUCKET_TZNAME_1ST') AS bucket,
@@ -3995,7 +3995,7 @@ UNION ALL
 \echo :WARNING_MESSAGE
 -- SHOULD WORK
 CREATE MATERIALIZED VIEW :CAGG_NAME_2TH_LEVEL
-WITH (timescaledb.continuous) AS
+WITH (timescaledb.continuous, timescaledb.materialized_only=false) AS
 SELECT
   \if :IS_TIME_DIMENSION_WITH_TIMEZONE_2TH
     time_bucket(:BUCKET_WIDTH_2TH, "bucket", :'BUCKET_TZNAME_2TH') AS bucket,
@@ -4034,7 +4034,7 @@ UNION ALL
   CALL refresh_continuous_aggregate(:'CAGG_NAME_1ST_LEVEL', NULL, NULL);
   CALL refresh_continuous_aggregate(:'CAGG_NAME_2TH_LEVEL', NULL, NULL);
   CREATE MATERIALIZED VIEW :CAGG_NAME_3TH_LEVEL
-  WITH (timescaledb.continuous) AS
+  WITH (timescaledb.continuous, timescaledb.materialized_only=false) AS
   SELECT
     \if :IS_TIME_DIMENSION_WITH_TIMEZONE_2TH
       time_bucket(:BUCKET_WIDTH_3TH, "bucket", :'BUCKET_TZNAME_2TH') AS bucket
@@ -4071,7 +4071,7 @@ DROP MATERIALIZED VIEW IF EXISTS :CAGG_NAME_1ST_LEVEL;
 -- CAGG on hypertable (1st level)
 --
 CREATE MATERIALIZED VIEW :CAGG_NAME_1ST_LEVEL
-WITH (timescaledb.continuous) AS
+WITH (timescaledb.continuous, timescaledb.materialized_only=false) AS
 SELECT
   \if :IS_TIME_DIMENSION_WITH_TIMEZONE_1ST
     time_bucket(:BUCKET_WIDTH_1ST, "time", :'BUCKET_TZNAME_1ST') AS bucket,
@@ -4108,7 +4108,7 @@ UNION ALL
 \echo :WARNING_MESSAGE
 -- SHOULD WORK
 CREATE MATERIALIZED VIEW :CAGG_NAME_2TH_LEVEL
-WITH (timescaledb.continuous) AS
+WITH (timescaledb.continuous, timescaledb.materialized_only=false) AS
 SELECT
   \if :IS_TIME_DIMENSION_WITH_TIMEZONE_2TH
     time_bucket(:BUCKET_WIDTH_2TH, "bucket", :'BUCKET_TZNAME_2TH') AS bucket,
@@ -4147,7 +4147,7 @@ UNION ALL
   CALL refresh_continuous_aggregate(:'CAGG_NAME_1ST_LEVEL', NULL, NULL);
   CALL refresh_continuous_aggregate(:'CAGG_NAME_2TH_LEVEL', NULL, NULL);
   CREATE MATERIALIZED VIEW :CAGG_NAME_3TH_LEVEL
-  WITH (timescaledb.continuous) AS
+  WITH (timescaledb.continuous, timescaledb.materialized_only=false) AS
   SELECT
     \if :IS_TIME_DIMENSION_WITH_TIMEZONE_2TH
       time_bucket(:BUCKET_WIDTH_3TH, "bucket", :'BUCKET_TZNAME_2TH') AS bucket
@@ -4211,7 +4211,7 @@ psql:include/cagg_on_cagg_validations.sql:87: NOTICE:  drop cascades to table _t
 -- CAGG on hypertable (1st level)
 --
 CREATE MATERIALIZED VIEW :CAGG_NAME_1ST_LEVEL
-WITH (timescaledb.continuous) AS
+WITH (timescaledb.continuous, timescaledb.materialized_only=false) AS
 SELECT
   \if :IS_TIME_DIMENSION_WITH_TIMEZONE_1ST
     time_bucket(:BUCKET_WIDTH_1ST, "time", :'BUCKET_TZNAME_1ST') AS bucket,
@@ -4248,7 +4248,7 @@ UNION ALL
 \echo :WARNING_MESSAGE
 -- SHOULD WORK
 CREATE MATERIALIZED VIEW :CAGG_NAME_2TH_LEVEL
-WITH (timescaledb.continuous) AS
+WITH (timescaledb.continuous, timescaledb.materialized_only=false) AS
 SELECT
   \if :IS_TIME_DIMENSION_WITH_TIMEZONE_2TH
     time_bucket(:BUCKET_WIDTH_2TH, "bucket", :'BUCKET_TZNAME_2TH') AS bucket,
@@ -4287,7 +4287,7 @@ UNION ALL
   CALL refresh_continuous_aggregate(:'CAGG_NAME_1ST_LEVEL', NULL, NULL);
   CALL refresh_continuous_aggregate(:'CAGG_NAME_2TH_LEVEL', NULL, NULL);
   CREATE MATERIALIZED VIEW :CAGG_NAME_3TH_LEVEL
-  WITH (timescaledb.continuous) AS
+  WITH (timescaledb.continuous, timescaledb.materialized_only=false) AS
   SELECT
     \if :IS_TIME_DIMENSION_WITH_TIMEZONE_2TH
       time_bucket(:BUCKET_WIDTH_3TH, "bucket", :'BUCKET_TZNAME_2TH') AS bucket
@@ -4324,7 +4324,7 @@ DROP MATERIALIZED VIEW IF EXISTS :CAGG_NAME_1ST_LEVEL;
 -- CAGG on hypertable (1st level)
 --
 CREATE MATERIALIZED VIEW :CAGG_NAME_1ST_LEVEL
-WITH (timescaledb.continuous) AS
+WITH (timescaledb.continuous, timescaledb.materialized_only=false) AS
 SELECT
   \if :IS_TIME_DIMENSION_WITH_TIMEZONE_1ST
     time_bucket(:BUCKET_WIDTH_1ST, "time", :'BUCKET_TZNAME_1ST') AS bucket,
@@ -4361,7 +4361,7 @@ UNION ALL
 \echo :WARNING_MESSAGE
 -- SHOULD WORK
 CREATE MATERIALIZED VIEW :CAGG_NAME_2TH_LEVEL
-WITH (timescaledb.continuous) AS
+WITH (timescaledb.continuous, timescaledb.materialized_only=false) AS
 SELECT
   \if :IS_TIME_DIMENSION_WITH_TIMEZONE_2TH
     time_bucket(:BUCKET_WIDTH_2TH, "bucket", :'BUCKET_TZNAME_2TH') AS bucket,
@@ -4400,7 +4400,7 @@ UNION ALL
   CALL refresh_continuous_aggregate(:'CAGG_NAME_1ST_LEVEL', NULL, NULL);
   CALL refresh_continuous_aggregate(:'CAGG_NAME_2TH_LEVEL', NULL, NULL);
   CREATE MATERIALIZED VIEW :CAGG_NAME_3TH_LEVEL
-  WITH (timescaledb.continuous) AS
+  WITH (timescaledb.continuous, timescaledb.materialized_only=false) AS
   SELECT
     \if :IS_TIME_DIMENSION_WITH_TIMEZONE_2TH
       time_bucket(:BUCKET_WIDTH_3TH, "bucket", :'BUCKET_TZNAME_2TH') AS bucket
@@ -4465,7 +4465,7 @@ psql:include/cagg_on_cagg_validations.sql:87: NOTICE:  drop cascades to table _t
 -- CAGG on hypertable (1st level)
 --
 CREATE MATERIALIZED VIEW :CAGG_NAME_1ST_LEVEL
-WITH (timescaledb.continuous) AS
+WITH (timescaledb.continuous, timescaledb.materialized_only=false) AS
 SELECT
   \if :IS_TIME_DIMENSION_WITH_TIMEZONE_1ST
     time_bucket(:BUCKET_WIDTH_1ST, "time", :'BUCKET_TZNAME_1ST') AS bucket,
@@ -4502,7 +4502,7 @@ UNION ALL
 \echo :WARNING_MESSAGE
 -- SHOULD WORK
 CREATE MATERIALIZED VIEW :CAGG_NAME_2TH_LEVEL
-WITH (timescaledb.continuous) AS
+WITH (timescaledb.continuous, timescaledb.materialized_only=false) AS
 SELECT
   \if :IS_TIME_DIMENSION_WITH_TIMEZONE_2TH
     time_bucket(:BUCKET_WIDTH_2TH, "bucket", :'BUCKET_TZNAME_2TH') AS bucket,
@@ -4541,7 +4541,7 @@ UNION ALL
   CALL refresh_continuous_aggregate(:'CAGG_NAME_1ST_LEVEL', NULL, NULL);
   CALL refresh_continuous_aggregate(:'CAGG_NAME_2TH_LEVEL', NULL, NULL);
   CREATE MATERIALIZED VIEW :CAGG_NAME_3TH_LEVEL
-  WITH (timescaledb.continuous) AS
+  WITH (timescaledb.continuous, timescaledb.materialized_only=false) AS
   SELECT
     \if :IS_TIME_DIMENSION_WITH_TIMEZONE_2TH
       time_bucket(:BUCKET_WIDTH_3TH, "bucket", :'BUCKET_TZNAME_2TH') AS bucket
@@ -4578,7 +4578,7 @@ DROP MATERIALIZED VIEW IF EXISTS :CAGG_NAME_1ST_LEVEL;
 -- CAGG on hypertable (1st level)
 --
 CREATE MATERIALIZED VIEW :CAGG_NAME_1ST_LEVEL
-WITH (timescaledb.continuous) AS
+WITH (timescaledb.continuous, timescaledb.materialized_only=false) AS
 SELECT
   \if :IS_TIME_DIMENSION_WITH_TIMEZONE_1ST
     time_bucket(:BUCKET_WIDTH_1ST, "time", :'BUCKET_TZNAME_1ST') AS bucket,
@@ -4615,7 +4615,7 @@ UNION ALL
 \echo :WARNING_MESSAGE
 -- SHOULD WORK
 CREATE MATERIALIZED VIEW :CAGG_NAME_2TH_LEVEL
-WITH (timescaledb.continuous) AS
+WITH (timescaledb.continuous, timescaledb.materialized_only=false) AS
 SELECT
   \if :IS_TIME_DIMENSION_WITH_TIMEZONE_2TH
     time_bucket(:BUCKET_WIDTH_2TH, "bucket", :'BUCKET_TZNAME_2TH') AS bucket,
@@ -4654,7 +4654,7 @@ UNION ALL
   CALL refresh_continuous_aggregate(:'CAGG_NAME_1ST_LEVEL', NULL, NULL);
   CALL refresh_continuous_aggregate(:'CAGG_NAME_2TH_LEVEL', NULL, NULL);
   CREATE MATERIALIZED VIEW :CAGG_NAME_3TH_LEVEL
-  WITH (timescaledb.continuous) AS
+  WITH (timescaledb.continuous, timescaledb.materialized_only=false) AS
   SELECT
     \if :IS_TIME_DIMENSION_WITH_TIMEZONE_2TH
       time_bucket(:BUCKET_WIDTH_3TH, "bucket", :'BUCKET_TZNAME_2TH') AS bucket
@@ -4719,7 +4719,7 @@ psql:include/cagg_on_cagg_validations.sql:87: NOTICE:  drop cascades to table _t
 -- CAGG on hypertable (1st level)
 --
 CREATE MATERIALIZED VIEW :CAGG_NAME_1ST_LEVEL
-WITH (timescaledb.continuous) AS
+WITH (timescaledb.continuous, timescaledb.materialized_only=false) AS
 SELECT
   \if :IS_TIME_DIMENSION_WITH_TIMEZONE_1ST
     time_bucket(:BUCKET_WIDTH_1ST, "time", :'BUCKET_TZNAME_1ST') AS bucket,
@@ -4756,7 +4756,7 @@ UNION ALL
 \echo :WARNING_MESSAGE
 -- SHOULD WORK
 CREATE MATERIALIZED VIEW :CAGG_NAME_2TH_LEVEL
-WITH (timescaledb.continuous) AS
+WITH (timescaledb.continuous, timescaledb.materialized_only=false) AS
 SELECT
   \if :IS_TIME_DIMENSION_WITH_TIMEZONE_2TH
     time_bucket(:BUCKET_WIDTH_2TH, "bucket", :'BUCKET_TZNAME_2TH') AS bucket,
@@ -4795,7 +4795,7 @@ UNION ALL
   CALL refresh_continuous_aggregate(:'CAGG_NAME_1ST_LEVEL', NULL, NULL);
   CALL refresh_continuous_aggregate(:'CAGG_NAME_2TH_LEVEL', NULL, NULL);
   CREATE MATERIALIZED VIEW :CAGG_NAME_3TH_LEVEL
-  WITH (timescaledb.continuous) AS
+  WITH (timescaledb.continuous, timescaledb.materialized_only=false) AS
   SELECT
     \if :IS_TIME_DIMENSION_WITH_TIMEZONE_2TH
       time_bucket(:BUCKET_WIDTH_3TH, "bucket", :'BUCKET_TZNAME_2TH') AS bucket
@@ -4831,7 +4831,7 @@ DROP MATERIALIZED VIEW IF EXISTS :CAGG_NAME_1ST_LEVEL;
 -- CAGG on hypertable (1st level)
 --
 CREATE MATERIALIZED VIEW :CAGG_NAME_1ST_LEVEL
-WITH (timescaledb.continuous) AS
+WITH (timescaledb.continuous, timescaledb.materialized_only=false) AS
 SELECT
   \if :IS_TIME_DIMENSION_WITH_TIMEZONE_1ST
     time_bucket(:BUCKET_WIDTH_1ST, "time", :'BUCKET_TZNAME_1ST') AS bucket,
@@ -4868,7 +4868,7 @@ UNION ALL
 \echo :WARNING_MESSAGE
 -- SHOULD WORK
 CREATE MATERIALIZED VIEW :CAGG_NAME_2TH_LEVEL
-WITH (timescaledb.continuous) AS
+WITH (timescaledb.continuous, timescaledb.materialized_only=false) AS
 SELECT
   \if :IS_TIME_DIMENSION_WITH_TIMEZONE_2TH
     time_bucket(:BUCKET_WIDTH_2TH, "bucket", :'BUCKET_TZNAME_2TH') AS bucket,
@@ -4907,7 +4907,7 @@ UNION ALL
   CALL refresh_continuous_aggregate(:'CAGG_NAME_1ST_LEVEL', NULL, NULL);
   CALL refresh_continuous_aggregate(:'CAGG_NAME_2TH_LEVEL', NULL, NULL);
   CREATE MATERIALIZED VIEW :CAGG_NAME_3TH_LEVEL
-  WITH (timescaledb.continuous) AS
+  WITH (timescaledb.continuous, timescaledb.materialized_only=false) AS
   SELECT
     \if :IS_TIME_DIMENSION_WITH_TIMEZONE_2TH
       time_bucket(:BUCKET_WIDTH_3TH, "bucket", :'BUCKET_TZNAME_2TH') AS bucket
@@ -4941,7 +4941,7 @@ DROP MATERIALIZED VIEW IF EXISTS :CAGG_NAME_1ST_LEVEL;
 -- CAGG on hypertable (1st level)
 --
 CREATE MATERIALIZED VIEW :CAGG_NAME_1ST_LEVEL
-WITH (timescaledb.continuous) AS
+WITH (timescaledb.continuous, timescaledb.materialized_only=false) AS
 SELECT
   \if :IS_TIME_DIMENSION_WITH_TIMEZONE_1ST
     time_bucket(:BUCKET_WIDTH_1ST, "time", :'BUCKET_TZNAME_1ST') AS bucket,
@@ -4978,7 +4978,7 @@ UNION ALL
 \echo :WARNING_MESSAGE
 -- SHOULD WORK
 CREATE MATERIALIZED VIEW :CAGG_NAME_2TH_LEVEL
-WITH (timescaledb.continuous) AS
+WITH (timescaledb.continuous, timescaledb.materialized_only=false) AS
 SELECT
   \if :IS_TIME_DIMENSION_WITH_TIMEZONE_2TH
     time_bucket(:BUCKET_WIDTH_2TH, "bucket", :'BUCKET_TZNAME_2TH') AS bucket,
@@ -5017,7 +5017,7 @@ UNION ALL
   CALL refresh_continuous_aggregate(:'CAGG_NAME_1ST_LEVEL', NULL, NULL);
   CALL refresh_continuous_aggregate(:'CAGG_NAME_2TH_LEVEL', NULL, NULL);
   CREATE MATERIALIZED VIEW :CAGG_NAME_3TH_LEVEL
-  WITH (timescaledb.continuous) AS
+  WITH (timescaledb.continuous, timescaledb.materialized_only=false) AS
   SELECT
     \if :IS_TIME_DIMENSION_WITH_TIMEZONE_2TH
       time_bucket(:BUCKET_WIDTH_3TH, "bucket", :'BUCKET_TZNAME_2TH') AS bucket
@@ -5051,7 +5051,7 @@ DROP MATERIALIZED VIEW IF EXISTS :CAGG_NAME_1ST_LEVEL;
 -- CAGG on hypertable (1st level)
 --
 CREATE MATERIALIZED VIEW :CAGG_NAME_1ST_LEVEL
-WITH (timescaledb.continuous) AS
+WITH (timescaledb.continuous, timescaledb.materialized_only=false) AS
 SELECT
   \if :IS_TIME_DIMENSION_WITH_TIMEZONE_1ST
     time_bucket(:BUCKET_WIDTH_1ST, "time", :'BUCKET_TZNAME_1ST') AS bucket,
@@ -5088,7 +5088,7 @@ UNION ALL
 \echo :WARNING_MESSAGE
 -- SHOULD WORK
 CREATE MATERIALIZED VIEW :CAGG_NAME_2TH_LEVEL
-WITH (timescaledb.continuous) AS
+WITH (timescaledb.continuous, timescaledb.materialized_only=false) AS
 SELECT
   \if :IS_TIME_DIMENSION_WITH_TIMEZONE_2TH
     time_bucket(:BUCKET_WIDTH_2TH, "bucket", :'BUCKET_TZNAME_2TH') AS bucket,
@@ -5127,7 +5127,7 @@ UNION ALL
   CALL refresh_continuous_aggregate(:'CAGG_NAME_1ST_LEVEL', NULL, NULL);
   CALL refresh_continuous_aggregate(:'CAGG_NAME_2TH_LEVEL', NULL, NULL);
   CREATE MATERIALIZED VIEW :CAGG_NAME_3TH_LEVEL
-  WITH (timescaledb.continuous) AS
+  WITH (timescaledb.continuous, timescaledb.materialized_only=false) AS
   SELECT
     \if :IS_TIME_DIMENSION_WITH_TIMEZONE_2TH
       time_bucket(:BUCKET_WIDTH_3TH, "bucket", :'BUCKET_TZNAME_2TH') AS bucket
@@ -5161,7 +5161,7 @@ DROP MATERIALIZED VIEW IF EXISTS :CAGG_NAME_1ST_LEVEL;
 -- CAGG on hypertable (1st level)
 --
 CREATE MATERIALIZED VIEW :CAGG_NAME_1ST_LEVEL
-WITH (timescaledb.continuous) AS
+WITH (timescaledb.continuous, timescaledb.materialized_only=false) AS
 SELECT
   \if :IS_TIME_DIMENSION_WITH_TIMEZONE_1ST
     time_bucket(:BUCKET_WIDTH_1ST, "time", :'BUCKET_TZNAME_1ST') AS bucket,
@@ -5198,7 +5198,7 @@ UNION ALL
 \echo :WARNING_MESSAGE
 -- SHOULD WORK
 CREATE MATERIALIZED VIEW :CAGG_NAME_2TH_LEVEL
-WITH (timescaledb.continuous) AS
+WITH (timescaledb.continuous, timescaledb.materialized_only=false) AS
 SELECT
   \if :IS_TIME_DIMENSION_WITH_TIMEZONE_2TH
     time_bucket(:BUCKET_WIDTH_2TH, "bucket", :'BUCKET_TZNAME_2TH') AS bucket,
@@ -5222,7 +5222,7 @@ DETAIL:  Time bucket width of "public.conditions_summary_2" [@ 1 year] should be
   CALL refresh_continuous_aggregate(:'CAGG_NAME_1ST_LEVEL', NULL, NULL);
   CALL refresh_continuous_aggregate(:'CAGG_NAME_2TH_LEVEL', NULL, NULL);
   CREATE MATERIALIZED VIEW :CAGG_NAME_3TH_LEVEL
-  WITH (timescaledb.continuous) AS
+  WITH (timescaledb.continuous, timescaledb.materialized_only=false) AS
   SELECT
     \if :IS_TIME_DIMENSION_WITH_TIMEZONE_2TH
       time_bucket(:BUCKET_WIDTH_3TH, "bucket", :'BUCKET_TZNAME_2TH') AS bucket
@@ -5257,7 +5257,7 @@ DROP MATERIALIZED VIEW IF EXISTS :CAGG_NAME_1ST_LEVEL;
 -- CAGG on hypertable (1st level)
 --
 CREATE MATERIALIZED VIEW :CAGG_NAME_1ST_LEVEL
-WITH (timescaledb.continuous) AS
+WITH (timescaledb.continuous, timescaledb.materialized_only=false) AS
 SELECT
   \if :IS_TIME_DIMENSION_WITH_TIMEZONE_1ST
     time_bucket(:BUCKET_WIDTH_1ST, "time", :'BUCKET_TZNAME_1ST') AS bucket,
@@ -5294,7 +5294,7 @@ UNION ALL
 \echo :WARNING_MESSAGE
 -- SHOULD WORK
 CREATE MATERIALIZED VIEW :CAGG_NAME_2TH_LEVEL
-WITH (timescaledb.continuous) AS
+WITH (timescaledb.continuous, timescaledb.materialized_only=false) AS
 SELECT
   \if :IS_TIME_DIMENSION_WITH_TIMEZONE_2TH
     time_bucket(:BUCKET_WIDTH_2TH, "bucket", :'BUCKET_TZNAME_2TH') AS bucket,
@@ -5318,7 +5318,7 @@ DETAIL:  Time bucket width of "public.conditions_summary_2" [@ 1 mon] should be 
   CALL refresh_continuous_aggregate(:'CAGG_NAME_1ST_LEVEL', NULL, NULL);
   CALL refresh_continuous_aggregate(:'CAGG_NAME_2TH_LEVEL', NULL, NULL);
   CREATE MATERIALIZED VIEW :CAGG_NAME_3TH_LEVEL
-  WITH (timescaledb.continuous) AS
+  WITH (timescaledb.continuous, timescaledb.materialized_only=false) AS
   SELECT
     \if :IS_TIME_DIMENSION_WITH_TIMEZONE_2TH
       time_bucket(:BUCKET_WIDTH_3TH, "bucket", :'BUCKET_TZNAME_2TH') AS bucket
@@ -5357,7 +5357,7 @@ DROP MATERIALIZED VIEW IF EXISTS :CAGG_NAME_1ST_LEVEL;
 -- CAGG on hypertable (1st level)
 --
 CREATE MATERIALIZED VIEW :CAGG_NAME_1ST_LEVEL
-WITH (timescaledb.continuous) AS
+WITH (timescaledb.continuous, timescaledb.materialized_only=false) AS
 SELECT
   \if :IS_TIME_DIMENSION_WITH_TIMEZONE_1ST
     time_bucket(:BUCKET_WIDTH_1ST, "time", :'BUCKET_TZNAME_1ST') AS bucket,
@@ -5394,7 +5394,7 @@ UNION ALL
 \echo :WARNING_MESSAGE
 -- SHOULD WORK
 CREATE MATERIALIZED VIEW :CAGG_NAME_2TH_LEVEL
-WITH (timescaledb.continuous) AS
+WITH (timescaledb.continuous, timescaledb.materialized_only=false) AS
 SELECT
   \if :IS_TIME_DIMENSION_WITH_TIMEZONE_2TH
     time_bucket(:BUCKET_WIDTH_2TH, "bucket", :'BUCKET_TZNAME_2TH') AS bucket,
@@ -5433,7 +5433,7 @@ UNION ALL
   CALL refresh_continuous_aggregate(:'CAGG_NAME_1ST_LEVEL', NULL, NULL);
   CALL refresh_continuous_aggregate(:'CAGG_NAME_2TH_LEVEL', NULL, NULL);
   CREATE MATERIALIZED VIEW :CAGG_NAME_3TH_LEVEL
-  WITH (timescaledb.continuous) AS
+  WITH (timescaledb.continuous, timescaledb.materialized_only=false) AS
   SELECT
     \if :IS_TIME_DIMENSION_WITH_TIMEZONE_2TH
       time_bucket(:BUCKET_WIDTH_3TH, "bucket", :'BUCKET_TZNAME_2TH') AS bucket
@@ -5467,7 +5467,7 @@ DROP MATERIALIZED VIEW IF EXISTS :CAGG_NAME_1ST_LEVEL;
 -- CAGG on hypertable (1st level)
 --
 CREATE MATERIALIZED VIEW :CAGG_NAME_1ST_LEVEL
-WITH (timescaledb.continuous) AS
+WITH (timescaledb.continuous, timescaledb.materialized_only=false) AS
 SELECT
   \if :IS_TIME_DIMENSION_WITH_TIMEZONE_1ST
     time_bucket(:BUCKET_WIDTH_1ST, "time", :'BUCKET_TZNAME_1ST') AS bucket,
@@ -5504,7 +5504,7 @@ UNION ALL
 \echo :WARNING_MESSAGE
 -- SHOULD WORK
 CREATE MATERIALIZED VIEW :CAGG_NAME_2TH_LEVEL
-WITH (timescaledb.continuous) AS
+WITH (timescaledb.continuous, timescaledb.materialized_only=false) AS
 SELECT
   \if :IS_TIME_DIMENSION_WITH_TIMEZONE_2TH
     time_bucket(:BUCKET_WIDTH_2TH, "bucket", :'BUCKET_TZNAME_2TH') AS bucket,
@@ -5543,7 +5543,7 @@ UNION ALL
   CALL refresh_continuous_aggregate(:'CAGG_NAME_1ST_LEVEL', NULL, NULL);
   CALL refresh_continuous_aggregate(:'CAGG_NAME_2TH_LEVEL', NULL, NULL);
   CREATE MATERIALIZED VIEW :CAGG_NAME_3TH_LEVEL
-  WITH (timescaledb.continuous) AS
+  WITH (timescaledb.continuous, timescaledb.materialized_only=false) AS
   SELECT
     \if :IS_TIME_DIMENSION_WITH_TIMEZONE_2TH
       time_bucket(:BUCKET_WIDTH_3TH, "bucket", :'BUCKET_TZNAME_2TH') AS bucket
@@ -5577,7 +5577,7 @@ DROP MATERIALIZED VIEW IF EXISTS :CAGG_NAME_1ST_LEVEL;
 -- CAGG on hypertable (1st level)
 --
 CREATE MATERIALIZED VIEW :CAGG_NAME_1ST_LEVEL
-WITH (timescaledb.continuous) AS
+WITH (timescaledb.continuous, timescaledb.materialized_only=false) AS
 SELECT
   \if :IS_TIME_DIMENSION_WITH_TIMEZONE_1ST
     time_bucket(:BUCKET_WIDTH_1ST, "time", :'BUCKET_TZNAME_1ST') AS bucket,
@@ -5614,7 +5614,7 @@ UNION ALL
 \echo :WARNING_MESSAGE
 -- SHOULD WORK
 CREATE MATERIALIZED VIEW :CAGG_NAME_2TH_LEVEL
-WITH (timescaledb.continuous) AS
+WITH (timescaledb.continuous, timescaledb.materialized_only=false) AS
 SELECT
   \if :IS_TIME_DIMENSION_WITH_TIMEZONE_2TH
     time_bucket(:BUCKET_WIDTH_2TH, "bucket", :'BUCKET_TZNAME_2TH') AS bucket,
@@ -5653,7 +5653,7 @@ UNION ALL
   CALL refresh_continuous_aggregate(:'CAGG_NAME_1ST_LEVEL', NULL, NULL);
   CALL refresh_continuous_aggregate(:'CAGG_NAME_2TH_LEVEL', NULL, NULL);
   CREATE MATERIALIZED VIEW :CAGG_NAME_3TH_LEVEL
-  WITH (timescaledb.continuous) AS
+  WITH (timescaledb.continuous, timescaledb.materialized_only=false) AS
   SELECT
     \if :IS_TIME_DIMENSION_WITH_TIMEZONE_2TH
       time_bucket(:BUCKET_WIDTH_3TH, "bucket", :'BUCKET_TZNAME_2TH') AS bucket
@@ -5688,7 +5688,7 @@ DROP MATERIALIZED VIEW IF EXISTS :CAGG_NAME_1ST_LEVEL;
 -- CAGG on hypertable (1st level)
 --
 CREATE MATERIALIZED VIEW :CAGG_NAME_1ST_LEVEL
-WITH (timescaledb.continuous) AS
+WITH (timescaledb.continuous, timescaledb.materialized_only=false) AS
 SELECT
   \if :IS_TIME_DIMENSION_WITH_TIMEZONE_1ST
     time_bucket(:BUCKET_WIDTH_1ST, "time", :'BUCKET_TZNAME_1ST') AS bucket,
@@ -5725,7 +5725,7 @@ UNION ALL
 \echo :WARNING_MESSAGE
 -- SHOULD WORK
 CREATE MATERIALIZED VIEW :CAGG_NAME_2TH_LEVEL
-WITH (timescaledb.continuous) AS
+WITH (timescaledb.continuous, timescaledb.materialized_only=false) AS
 SELECT
   \if :IS_TIME_DIMENSION_WITH_TIMEZONE_2TH
     time_bucket(:BUCKET_WIDTH_2TH, "bucket", :'BUCKET_TZNAME_2TH') AS bucket,
@@ -5764,7 +5764,7 @@ UNION ALL
   CALL refresh_continuous_aggregate(:'CAGG_NAME_1ST_LEVEL', NULL, NULL);
   CALL refresh_continuous_aggregate(:'CAGG_NAME_2TH_LEVEL', NULL, NULL);
   CREATE MATERIALIZED VIEW :CAGG_NAME_3TH_LEVEL
-  WITH (timescaledb.continuous) AS
+  WITH (timescaledb.continuous, timescaledb.materialized_only=false) AS
   SELECT
     \if :IS_TIME_DIMENSION_WITH_TIMEZONE_2TH
       time_bucket(:BUCKET_WIDTH_3TH, "bucket", :'BUCKET_TZNAME_2TH') AS bucket
@@ -5799,7 +5799,7 @@ DROP MATERIALIZED VIEW IF EXISTS :CAGG_NAME_1ST_LEVEL;
 -- CAGG on hypertable (1st level)
 --
 CREATE MATERIALIZED VIEW :CAGG_NAME_1ST_LEVEL
-WITH (timescaledb.continuous) AS
+WITH (timescaledb.continuous, timescaledb.materialized_only=false) AS
 SELECT
   \if :IS_TIME_DIMENSION_WITH_TIMEZONE_1ST
     time_bucket(:BUCKET_WIDTH_1ST, "time", :'BUCKET_TZNAME_1ST') AS bucket,
@@ -5836,7 +5836,7 @@ UNION ALL
 \echo :WARNING_MESSAGE
 -- SHOULD WORK
 CREATE MATERIALIZED VIEW :CAGG_NAME_2TH_LEVEL
-WITH (timescaledb.continuous) AS
+WITH (timescaledb.continuous, timescaledb.materialized_only=false) AS
 SELECT
   \if :IS_TIME_DIMENSION_WITH_TIMEZONE_2TH
     time_bucket(:BUCKET_WIDTH_2TH, "bucket", :'BUCKET_TZNAME_2TH') AS bucket,
@@ -5860,7 +5860,7 @@ DETAIL:  Time bucket width of "public.conditions_summary_2" [@ 0.00116 secs] sho
   CALL refresh_continuous_aggregate(:'CAGG_NAME_1ST_LEVEL', NULL, NULL);
   CALL refresh_continuous_aggregate(:'CAGG_NAME_2TH_LEVEL', NULL, NULL);
   CREATE MATERIALIZED VIEW :CAGG_NAME_3TH_LEVEL
-  WITH (timescaledb.continuous) AS
+  WITH (timescaledb.continuous, timescaledb.materialized_only=false) AS
   SELECT
     \if :IS_TIME_DIMENSION_WITH_TIMEZONE_2TH
       time_bucket(:BUCKET_WIDTH_3TH, "bucket", :'BUCKET_TZNAME_2TH') AS bucket

--- a/tsl/test/expected/cagg_on_cagg_joins.out
+++ b/tsl/test/expected/cagg_on_cagg_joins.out
@@ -897,7 +897,7 @@ psql:include/cagg_on_cagg_common.sql:200: ERROR:  relation "conditions_summary_1
 -- CAGG on hypertable (1st level)
 --
 CREATE MATERIALIZED VIEW :CAGG_NAME_1ST_LEVEL
-WITH (timescaledb.continuous) AS
+WITH (timescaledb.continuous, timescaledb.materialized_only=false) AS
 SELECT
   \if :IS_TIME_DIMENSION_WITH_TIMEZONE_1ST
     time_bucket(:BUCKET_WIDTH_1ST, "time", :'BUCKET_TZNAME_1ST') AS bucket,
@@ -934,7 +934,7 @@ UNION ALL
 \echo :WARNING_MESSAGE
 -- SHOULD ERROR because non-multiple bucket sizes
 CREATE MATERIALIZED VIEW :CAGG_NAME_2TH_LEVEL
-WITH (timescaledb.continuous) AS
+WITH (timescaledb.continuous, timescaledb.materialized_only=false) AS
 SELECT
   \if :IS_TIME_DIMENSION_WITH_TIMEZONE_2TH
     time_bucket(:BUCKET_WIDTH_2TH, "bucket", :'BUCKET_TZNAME_2TH') AS bucket,
@@ -958,7 +958,7 @@ DETAIL:  Time bucket width of "public.conditions_summary_2" [5] should be multip
   CALL refresh_continuous_aggregate(:'CAGG_NAME_1ST_LEVEL', NULL, NULL);
   CALL refresh_continuous_aggregate(:'CAGG_NAME_2TH_LEVEL', NULL, NULL);
   CREATE MATERIALIZED VIEW :CAGG_NAME_3TH_LEVEL
-  WITH (timescaledb.continuous) AS
+  WITH (timescaledb.continuous, timescaledb.materialized_only=false) AS
   SELECT
     \if :IS_TIME_DIMENSION_WITH_TIMEZONE_2TH
       time_bucket(:BUCKET_WIDTH_3TH, "bucket", :'BUCKET_TZNAME_2TH') AS bucket
@@ -998,7 +998,7 @@ DROP MATERIALIZED VIEW IF EXISTS :CAGG_NAME_1ST_LEVEL;
 -- CAGG on hypertable (1st level)
 --
 CREATE MATERIALIZED VIEW :CAGG_NAME_1ST_LEVEL
-WITH (timescaledb.continuous) AS
+WITH (timescaledb.continuous, timescaledb.materialized_only=false) AS
 SELECT
   \if :IS_TIME_DIMENSION_WITH_TIMEZONE_1ST
     time_bucket(:BUCKET_WIDTH_1ST, "time", :'BUCKET_TZNAME_1ST') AS bucket,
@@ -1035,7 +1035,7 @@ UNION ALL
 \echo :WARNING_MESSAGE
 SHOULD WORK because new bucket should be greater than previous
 CREATE MATERIALIZED VIEW :CAGG_NAME_2TH_LEVEL
-WITH (timescaledb.continuous) AS
+WITH (timescaledb.continuous, timescaledb.materialized_only=false) AS
 SELECT
   \if :IS_TIME_DIMENSION_WITH_TIMEZONE_2TH
     time_bucket(:BUCKET_WIDTH_2TH, "bucket", :'BUCKET_TZNAME_2TH') AS bucket,
@@ -1074,7 +1074,7 @@ UNION ALL
   CALL refresh_continuous_aggregate(:'CAGG_NAME_1ST_LEVEL', NULL, NULL);
   CALL refresh_continuous_aggregate(:'CAGG_NAME_2TH_LEVEL', NULL, NULL);
   CREATE MATERIALIZED VIEW :CAGG_NAME_3TH_LEVEL
-  WITH (timescaledb.continuous) AS
+  WITH (timescaledb.continuous, timescaledb.materialized_only=false) AS
   SELECT
     \if :IS_TIME_DIMENSION_WITH_TIMEZONE_2TH
       time_bucket(:BUCKET_WIDTH_3TH, "bucket", :'BUCKET_TZNAME_2TH') AS bucket
@@ -1113,7 +1113,7 @@ DROP MATERIALIZED VIEW IF EXISTS :CAGG_NAME_1ST_LEVEL;
 -- CAGG on hypertable (1st level)
 --
 CREATE MATERIALIZED VIEW :CAGG_NAME_1ST_LEVEL
-WITH (timescaledb.continuous) AS
+WITH (timescaledb.continuous, timescaledb.materialized_only=false) AS
 SELECT
   \if :IS_TIME_DIMENSION_WITH_TIMEZONE_1ST
     time_bucket(:BUCKET_WIDTH_1ST, "time", :'BUCKET_TZNAME_1ST') AS bucket,
@@ -1150,7 +1150,7 @@ UNION ALL
 \echo :WARNING_MESSAGE
 -- SHOULD ERROR because new bucket should be greater than previous
 CREATE MATERIALIZED VIEW :CAGG_NAME_2TH_LEVEL
-WITH (timescaledb.continuous) AS
+WITH (timescaledb.continuous, timescaledb.materialized_only=false) AS
 SELECT
   \if :IS_TIME_DIMENSION_WITH_TIMEZONE_2TH
     time_bucket(:BUCKET_WIDTH_2TH, "bucket", :'BUCKET_TZNAME_2TH') AS bucket,
@@ -1174,7 +1174,7 @@ DETAIL:  Time bucket width of "public.conditions_summary_2" [2] should be greate
   CALL refresh_continuous_aggregate(:'CAGG_NAME_1ST_LEVEL', NULL, NULL);
   CALL refresh_continuous_aggregate(:'CAGG_NAME_2TH_LEVEL', NULL, NULL);
   CREATE MATERIALIZED VIEW :CAGG_NAME_3TH_LEVEL
-  WITH (timescaledb.continuous) AS
+  WITH (timescaledb.continuous, timescaledb.materialized_only=false) AS
   SELECT
     \if :IS_TIME_DIMENSION_WITH_TIMEZONE_2TH
       time_bucket(:BUCKET_WIDTH_3TH, "bucket", :'BUCKET_TZNAME_2TH') AS bucket
@@ -2077,7 +2077,7 @@ psql:include/cagg_on_cagg_common.sql:200: ERROR:  relation "conditions_summary_1
 -- CAGG on hypertable (1st level)
 --
 CREATE MATERIALIZED VIEW :CAGG_NAME_1ST_LEVEL
-WITH (timescaledb.continuous) AS
+WITH (timescaledb.continuous, timescaledb.materialized_only=false) AS
 SELECT
   \if :IS_TIME_DIMENSION_WITH_TIMEZONE_1ST
     time_bucket(:BUCKET_WIDTH_1ST, "time", :'BUCKET_TZNAME_1ST') AS bucket,
@@ -2114,7 +2114,7 @@ UNION ALL
 \echo :WARNING_MESSAGE
 -- SHOULD ERROR because is not allowed variable-size bucket on top of fixed-size bucket
 CREATE MATERIALIZED VIEW :CAGG_NAME_2TH_LEVEL
-WITH (timescaledb.continuous) AS
+WITH (timescaledb.continuous, timescaledb.materialized_only=false) AS
 SELECT
   \if :IS_TIME_DIMENSION_WITH_TIMEZONE_2TH
     time_bucket(:BUCKET_WIDTH_2TH, "bucket", :'BUCKET_TZNAME_2TH') AS bucket,
@@ -2139,7 +2139,7 @@ The variance can lead to the fixed width one not being a multiple of the variabl
   CALL refresh_continuous_aggregate(:'CAGG_NAME_1ST_LEVEL', NULL, NULL);
   CALL refresh_continuous_aggregate(:'CAGG_NAME_2TH_LEVEL', NULL, NULL);
   CREATE MATERIALIZED VIEW :CAGG_NAME_3TH_LEVEL
-  WITH (timescaledb.continuous) AS
+  WITH (timescaledb.continuous, timescaledb.materialized_only=false) AS
   SELECT
     \if :IS_TIME_DIMENSION_WITH_TIMEZONE_2TH
       time_bucket(:BUCKET_WIDTH_3TH, "bucket", :'BUCKET_TZNAME_2TH') AS bucket
@@ -2179,7 +2179,7 @@ DROP MATERIALIZED VIEW IF EXISTS :CAGG_NAME_1ST_LEVEL;
 -- CAGG on hypertable (1st level)
 --
 CREATE MATERIALIZED VIEW :CAGG_NAME_1ST_LEVEL
-WITH (timescaledb.continuous) AS
+WITH (timescaledb.continuous, timescaledb.materialized_only=false) AS
 SELECT
   \if :IS_TIME_DIMENSION_WITH_TIMEZONE_1ST
     time_bucket(:BUCKET_WIDTH_1ST, "time", :'BUCKET_TZNAME_1ST') AS bucket,
@@ -2216,7 +2216,7 @@ UNION ALL
 \echo :WARNING_MESSAGE
 -- SHOULD ERROR because non-multiple bucket sizes
 CREATE MATERIALIZED VIEW :CAGG_NAME_2TH_LEVEL
-WITH (timescaledb.continuous) AS
+WITH (timescaledb.continuous, timescaledb.materialized_only=false) AS
 SELECT
   \if :IS_TIME_DIMENSION_WITH_TIMEZONE_2TH
     time_bucket(:BUCKET_WIDTH_2TH, "bucket", :'BUCKET_TZNAME_2TH') AS bucket,
@@ -2240,7 +2240,7 @@ DETAIL:  Time bucket width of "public.conditions_summary_2" [@ 3 hours] should b
   CALL refresh_continuous_aggregate(:'CAGG_NAME_1ST_LEVEL', NULL, NULL);
   CALL refresh_continuous_aggregate(:'CAGG_NAME_2TH_LEVEL', NULL, NULL);
   CREATE MATERIALIZED VIEW :CAGG_NAME_3TH_LEVEL
-  WITH (timescaledb.continuous) AS
+  WITH (timescaledb.continuous, timescaledb.materialized_only=false) AS
   SELECT
     \if :IS_TIME_DIMENSION_WITH_TIMEZONE_2TH
       time_bucket(:BUCKET_WIDTH_3TH, "bucket", :'BUCKET_TZNAME_2TH') AS bucket
@@ -2280,7 +2280,7 @@ DROP MATERIALIZED VIEW IF EXISTS :CAGG_NAME_1ST_LEVEL;
 -- CAGG on hypertable (1st level)
 --
 CREATE MATERIALIZED VIEW :CAGG_NAME_1ST_LEVEL
-WITH (timescaledb.continuous) AS
+WITH (timescaledb.continuous, timescaledb.materialized_only=false) AS
 SELECT
   \if :IS_TIME_DIMENSION_WITH_TIMEZONE_1ST
     time_bucket(:BUCKET_WIDTH_1ST, "time", :'BUCKET_TZNAME_1ST') AS bucket,
@@ -2317,7 +2317,7 @@ UNION ALL
 \echo :WARNING_MESSAGE
 SHOULD WORK because new bucket should be greater than previous
 CREATE MATERIALIZED VIEW :CAGG_NAME_2TH_LEVEL
-WITH (timescaledb.continuous) AS
+WITH (timescaledb.continuous, timescaledb.materialized_only=false) AS
 SELECT
   \if :IS_TIME_DIMENSION_WITH_TIMEZONE_2TH
     time_bucket(:BUCKET_WIDTH_2TH, "bucket", :'BUCKET_TZNAME_2TH') AS bucket,
@@ -2356,7 +2356,7 @@ UNION ALL
   CALL refresh_continuous_aggregate(:'CAGG_NAME_1ST_LEVEL', NULL, NULL);
   CALL refresh_continuous_aggregate(:'CAGG_NAME_2TH_LEVEL', NULL, NULL);
   CREATE MATERIALIZED VIEW :CAGG_NAME_3TH_LEVEL
-  WITH (timescaledb.continuous) AS
+  WITH (timescaledb.continuous, timescaledb.materialized_only=false) AS
   SELECT
     \if :IS_TIME_DIMENSION_WITH_TIMEZONE_2TH
       time_bucket(:BUCKET_WIDTH_3TH, "bucket", :'BUCKET_TZNAME_2TH') AS bucket
@@ -2395,7 +2395,7 @@ DROP MATERIALIZED VIEW IF EXISTS :CAGG_NAME_1ST_LEVEL;
 -- CAGG on hypertable (1st level)
 --
 CREATE MATERIALIZED VIEW :CAGG_NAME_1ST_LEVEL
-WITH (timescaledb.continuous) AS
+WITH (timescaledb.continuous, timescaledb.materialized_only=false) AS
 SELECT
   \if :IS_TIME_DIMENSION_WITH_TIMEZONE_1ST
     time_bucket(:BUCKET_WIDTH_1ST, "time", :'BUCKET_TZNAME_1ST') AS bucket,
@@ -2432,7 +2432,7 @@ UNION ALL
 \echo :WARNING_MESSAGE
 -- SHOULD ERROR because new bucket should be greater than previous
 CREATE MATERIALIZED VIEW :CAGG_NAME_2TH_LEVEL
-WITH (timescaledb.continuous) AS
+WITH (timescaledb.continuous, timescaledb.materialized_only=false) AS
 SELECT
   \if :IS_TIME_DIMENSION_WITH_TIMEZONE_2TH
     time_bucket(:BUCKET_WIDTH_2TH, "bucket", :'BUCKET_TZNAME_2TH') AS bucket,
@@ -2456,7 +2456,7 @@ DETAIL:  Time bucket width of "public.conditions_summary_2" [@ 1 hour] should be
   CALL refresh_continuous_aggregate(:'CAGG_NAME_1ST_LEVEL', NULL, NULL);
   CALL refresh_continuous_aggregate(:'CAGG_NAME_2TH_LEVEL', NULL, NULL);
   CREATE MATERIALIZED VIEW :CAGG_NAME_3TH_LEVEL
-  WITH (timescaledb.continuous) AS
+  WITH (timescaledb.continuous, timescaledb.materialized_only=false) AS
   SELECT
     \if :IS_TIME_DIMENSION_WITH_TIMEZONE_2TH
       time_bucket(:BUCKET_WIDTH_3TH, "bucket", :'BUCKET_TZNAME_2TH') AS bucket
@@ -3358,7 +3358,7 @@ psql:include/cagg_on_cagg_common.sql:200: ERROR:  relation "conditions_summary_1
 -- CAGG on hypertable (1st level)
 --
 CREATE MATERIALIZED VIEW :CAGG_NAME_1ST_LEVEL
-WITH (timescaledb.continuous) AS
+WITH (timescaledb.continuous, timescaledb.materialized_only=false) AS
 SELECT
   \if :IS_TIME_DIMENSION_WITH_TIMEZONE_1ST
     time_bucket(:BUCKET_WIDTH_1ST, "time", :'BUCKET_TZNAME_1ST') AS bucket,
@@ -3395,7 +3395,7 @@ UNION ALL
 \echo :WARNING_MESSAGE
 -- SHOULD ERROR because is not allowed variable-size bucket on top of fixed-size bucket
 CREATE MATERIALIZED VIEW :CAGG_NAME_2TH_LEVEL
-WITH (timescaledb.continuous) AS
+WITH (timescaledb.continuous, timescaledb.materialized_only=false) AS
 SELECT
   \if :IS_TIME_DIMENSION_WITH_TIMEZONE_2TH
     time_bucket(:BUCKET_WIDTH_2TH, "bucket", :'BUCKET_TZNAME_2TH') AS bucket,
@@ -3420,7 +3420,7 @@ The variance can lead to the fixed width one not being a multiple of the variabl
   CALL refresh_continuous_aggregate(:'CAGG_NAME_1ST_LEVEL', NULL, NULL);
   CALL refresh_continuous_aggregate(:'CAGG_NAME_2TH_LEVEL', NULL, NULL);
   CREATE MATERIALIZED VIEW :CAGG_NAME_3TH_LEVEL
-  WITH (timescaledb.continuous) AS
+  WITH (timescaledb.continuous, timescaledb.materialized_only=false) AS
   SELECT
     \if :IS_TIME_DIMENSION_WITH_TIMEZONE_2TH
       time_bucket(:BUCKET_WIDTH_3TH, "bucket", :'BUCKET_TZNAME_2TH') AS bucket
@@ -3460,7 +3460,7 @@ DROP MATERIALIZED VIEW IF EXISTS :CAGG_NAME_1ST_LEVEL;
 -- CAGG on hypertable (1st level)
 --
 CREATE MATERIALIZED VIEW :CAGG_NAME_1ST_LEVEL
-WITH (timescaledb.continuous) AS
+WITH (timescaledb.continuous, timescaledb.materialized_only=false) AS
 SELECT
   \if :IS_TIME_DIMENSION_WITH_TIMEZONE_1ST
     time_bucket(:BUCKET_WIDTH_1ST, "time", :'BUCKET_TZNAME_1ST') AS bucket,
@@ -3497,7 +3497,7 @@ UNION ALL
 \echo :WARNING_MESSAGE
 -- SHOULD ERROR because non-multiple bucket sizes
 CREATE MATERIALIZED VIEW :CAGG_NAME_2TH_LEVEL
-WITH (timescaledb.continuous) AS
+WITH (timescaledb.continuous, timescaledb.materialized_only=false) AS
 SELECT
   \if :IS_TIME_DIMENSION_WITH_TIMEZONE_2TH
     time_bucket(:BUCKET_WIDTH_2TH, "bucket", :'BUCKET_TZNAME_2TH') AS bucket,
@@ -3521,7 +3521,7 @@ DETAIL:  Time bucket width of "public.conditions_summary_2" [@ 3 hours] should b
   CALL refresh_continuous_aggregate(:'CAGG_NAME_1ST_LEVEL', NULL, NULL);
   CALL refresh_continuous_aggregate(:'CAGG_NAME_2TH_LEVEL', NULL, NULL);
   CREATE MATERIALIZED VIEW :CAGG_NAME_3TH_LEVEL
-  WITH (timescaledb.continuous) AS
+  WITH (timescaledb.continuous, timescaledb.materialized_only=false) AS
   SELECT
     \if :IS_TIME_DIMENSION_WITH_TIMEZONE_2TH
       time_bucket(:BUCKET_WIDTH_3TH, "bucket", :'BUCKET_TZNAME_2TH') AS bucket
@@ -3561,7 +3561,7 @@ DROP MATERIALIZED VIEW IF EXISTS :CAGG_NAME_1ST_LEVEL;
 -- CAGG on hypertable (1st level)
 --
 CREATE MATERIALIZED VIEW :CAGG_NAME_1ST_LEVEL
-WITH (timescaledb.continuous) AS
+WITH (timescaledb.continuous, timescaledb.materialized_only=false) AS
 SELECT
   \if :IS_TIME_DIMENSION_WITH_TIMEZONE_1ST
     time_bucket(:BUCKET_WIDTH_1ST, "time", :'BUCKET_TZNAME_1ST') AS bucket,
@@ -3598,7 +3598,7 @@ UNION ALL
 \echo :WARNING_MESSAGE
 SHOULD WORK because new bucket should be greater than previous
 CREATE MATERIALIZED VIEW :CAGG_NAME_2TH_LEVEL
-WITH (timescaledb.continuous) AS
+WITH (timescaledb.continuous, timescaledb.materialized_only=false) AS
 SELECT
   \if :IS_TIME_DIMENSION_WITH_TIMEZONE_2TH
     time_bucket(:BUCKET_WIDTH_2TH, "bucket", :'BUCKET_TZNAME_2TH') AS bucket,
@@ -3637,7 +3637,7 @@ UNION ALL
   CALL refresh_continuous_aggregate(:'CAGG_NAME_1ST_LEVEL', NULL, NULL);
   CALL refresh_continuous_aggregate(:'CAGG_NAME_2TH_LEVEL', NULL, NULL);
   CREATE MATERIALIZED VIEW :CAGG_NAME_3TH_LEVEL
-  WITH (timescaledb.continuous) AS
+  WITH (timescaledb.continuous, timescaledb.materialized_only=false) AS
   SELECT
     \if :IS_TIME_DIMENSION_WITH_TIMEZONE_2TH
       time_bucket(:BUCKET_WIDTH_3TH, "bucket", :'BUCKET_TZNAME_2TH') AS bucket
@@ -3676,7 +3676,7 @@ DROP MATERIALIZED VIEW IF EXISTS :CAGG_NAME_1ST_LEVEL;
 -- CAGG on hypertable (1st level)
 --
 CREATE MATERIALIZED VIEW :CAGG_NAME_1ST_LEVEL
-WITH (timescaledb.continuous) AS
+WITH (timescaledb.continuous, timescaledb.materialized_only=false) AS
 SELECT
   \if :IS_TIME_DIMENSION_WITH_TIMEZONE_1ST
     time_bucket(:BUCKET_WIDTH_1ST, "time", :'BUCKET_TZNAME_1ST') AS bucket,
@@ -3713,7 +3713,7 @@ UNION ALL
 \echo :WARNING_MESSAGE
 -- SHOULD ERROR because new bucket should be greater than previous
 CREATE MATERIALIZED VIEW :CAGG_NAME_2TH_LEVEL
-WITH (timescaledb.continuous) AS
+WITH (timescaledb.continuous, timescaledb.materialized_only=false) AS
 SELECT
   \if :IS_TIME_DIMENSION_WITH_TIMEZONE_2TH
     time_bucket(:BUCKET_WIDTH_2TH, "bucket", :'BUCKET_TZNAME_2TH') AS bucket,
@@ -3737,7 +3737,7 @@ DETAIL:  Time bucket width of "public.conditions_summary_2" [@ 1 hour] should be
   CALL refresh_continuous_aggregate(:'CAGG_NAME_1ST_LEVEL', NULL, NULL);
   CALL refresh_continuous_aggregate(:'CAGG_NAME_2TH_LEVEL', NULL, NULL);
   CREATE MATERIALIZED VIEW :CAGG_NAME_3TH_LEVEL
-  WITH (timescaledb.continuous) AS
+  WITH (timescaledb.continuous, timescaledb.materialized_only=false) AS
   SELECT
     \if :IS_TIME_DIMENSION_WITH_TIMEZONE_2TH
       time_bucket(:BUCKET_WIDTH_3TH, "bucket", :'BUCKET_TZNAME_2TH') AS bucket
@@ -3784,7 +3784,7 @@ DROP MATERIALIZED VIEW IF EXISTS :CAGG_NAME_1ST_LEVEL;
 -- CAGG on hypertable (1st level)
 --
 CREATE MATERIALIZED VIEW :CAGG_NAME_1ST_LEVEL
-WITH (timescaledb.continuous) AS
+WITH (timescaledb.continuous, timescaledb.materialized_only=false) AS
 SELECT
   \if :IS_TIME_DIMENSION_WITH_TIMEZONE_1ST
     time_bucket(:BUCKET_WIDTH_1ST, "time", :'BUCKET_TZNAME_1ST') AS bucket,
@@ -3821,7 +3821,7 @@ UNION ALL
 \echo :WARNING_MESSAGE
 -- SHOULD WORK
 CREATE MATERIALIZED VIEW :CAGG_NAME_2TH_LEVEL
-WITH (timescaledb.continuous) AS
+WITH (timescaledb.continuous, timescaledb.materialized_only=false) AS
 SELECT
   \if :IS_TIME_DIMENSION_WITH_TIMEZONE_2TH
     time_bucket(:BUCKET_WIDTH_2TH, "bucket", :'BUCKET_TZNAME_2TH') AS bucket,
@@ -3860,7 +3860,7 @@ UNION ALL
   CALL refresh_continuous_aggregate(:'CAGG_NAME_1ST_LEVEL', NULL, NULL);
   CALL refresh_continuous_aggregate(:'CAGG_NAME_2TH_LEVEL', NULL, NULL);
   CREATE MATERIALIZED VIEW :CAGG_NAME_3TH_LEVEL
-  WITH (timescaledb.continuous) AS
+  WITH (timescaledb.continuous, timescaledb.materialized_only=false) AS
   SELECT
     \if :IS_TIME_DIMENSION_WITH_TIMEZONE_2TH
       time_bucket(:BUCKET_WIDTH_3TH, "bucket", :'BUCKET_TZNAME_2TH') AS bucket
@@ -3895,7 +3895,7 @@ DROP MATERIALIZED VIEW IF EXISTS :CAGG_NAME_1ST_LEVEL;
 -- CAGG on hypertable (1st level)
 --
 CREATE MATERIALIZED VIEW :CAGG_NAME_1ST_LEVEL
-WITH (timescaledb.continuous) AS
+WITH (timescaledb.continuous, timescaledb.materialized_only=false) AS
 SELECT
   \if :IS_TIME_DIMENSION_WITH_TIMEZONE_1ST
     time_bucket(:BUCKET_WIDTH_1ST, "time", :'BUCKET_TZNAME_1ST') AS bucket,
@@ -3932,7 +3932,7 @@ UNION ALL
 \echo :WARNING_MESSAGE
 -- SHOULD ERROR because non-multiple bucket sizes
 CREATE MATERIALIZED VIEW :CAGG_NAME_2TH_LEVEL
-WITH (timescaledb.continuous) AS
+WITH (timescaledb.continuous, timescaledb.materialized_only=false) AS
 SELECT
   \if :IS_TIME_DIMENSION_WITH_TIMEZONE_2TH
     time_bucket(:BUCKET_WIDTH_2TH, "bucket", :'BUCKET_TZNAME_2TH') AS bucket,
@@ -3956,7 +3956,7 @@ DETAIL:  Time bucket width of "public.conditions_summary_2" [@ 16 mins] should b
   CALL refresh_continuous_aggregate(:'CAGG_NAME_1ST_LEVEL', NULL, NULL);
   CALL refresh_continuous_aggregate(:'CAGG_NAME_2TH_LEVEL', NULL, NULL);
   CREATE MATERIALIZED VIEW :CAGG_NAME_3TH_LEVEL
-  WITH (timescaledb.continuous) AS
+  WITH (timescaledb.continuous, timescaledb.materialized_only=false) AS
   SELECT
     \if :IS_TIME_DIMENSION_WITH_TIMEZONE_2TH
       time_bucket(:BUCKET_WIDTH_3TH, "bucket", :'BUCKET_TZNAME_2TH') AS bucket
@@ -3997,7 +3997,7 @@ DROP MATERIALIZED VIEW IF EXISTS :CAGG_NAME_1ST_LEVEL;
 -- CAGG on hypertable (1st level)
 --
 CREATE MATERIALIZED VIEW :CAGG_NAME_1ST_LEVEL
-WITH (timescaledb.continuous) AS
+WITH (timescaledb.continuous, timescaledb.materialized_only=false) AS
 SELECT
   \if :IS_TIME_DIMENSION_WITH_TIMEZONE_1ST
     time_bucket(:BUCKET_WIDTH_1ST, "time", :'BUCKET_TZNAME_1ST') AS bucket,
@@ -4034,7 +4034,7 @@ UNION ALL
 \echo :WARNING_MESSAGE
 -- SHOULD WORK
 CREATE MATERIALIZED VIEW :CAGG_NAME_2TH_LEVEL
-WITH (timescaledb.continuous) AS
+WITH (timescaledb.continuous, timescaledb.materialized_only=false) AS
 SELECT
   \if :IS_TIME_DIMENSION_WITH_TIMEZONE_2TH
     time_bucket(:BUCKET_WIDTH_2TH, "bucket", :'BUCKET_TZNAME_2TH') AS bucket,
@@ -4073,7 +4073,7 @@ UNION ALL
   CALL refresh_continuous_aggregate(:'CAGG_NAME_1ST_LEVEL', NULL, NULL);
   CALL refresh_continuous_aggregate(:'CAGG_NAME_2TH_LEVEL', NULL, NULL);
   CREATE MATERIALIZED VIEW :CAGG_NAME_3TH_LEVEL
-  WITH (timescaledb.continuous) AS
+  WITH (timescaledb.continuous, timescaledb.materialized_only=false) AS
   SELECT
     \if :IS_TIME_DIMENSION_WITH_TIMEZONE_2TH
       time_bucket(:BUCKET_WIDTH_3TH, "bucket", :'BUCKET_TZNAME_2TH') AS bucket
@@ -4113,7 +4113,7 @@ DROP MATERIALIZED VIEW IF EXISTS :CAGG_NAME_1ST_LEVEL;
 -- CAGG on hypertable (1st level)
 --
 CREATE MATERIALIZED VIEW :CAGG_NAME_1ST_LEVEL
-WITH (timescaledb.continuous) AS
+WITH (timescaledb.continuous, timescaledb.materialized_only=false) AS
 SELECT
   \if :IS_TIME_DIMENSION_WITH_TIMEZONE_1ST
     time_bucket(:BUCKET_WIDTH_1ST, "time", :'BUCKET_TZNAME_1ST') AS bucket,
@@ -4150,7 +4150,7 @@ UNION ALL
 \echo :WARNING_MESSAGE
 -- SHOULD WORK
 CREATE MATERIALIZED VIEW :CAGG_NAME_2TH_LEVEL
-WITH (timescaledb.continuous) AS
+WITH (timescaledb.continuous, timescaledb.materialized_only=false) AS
 SELECT
   \if :IS_TIME_DIMENSION_WITH_TIMEZONE_2TH
     time_bucket(:BUCKET_WIDTH_2TH, "bucket", :'BUCKET_TZNAME_2TH') AS bucket,
@@ -4189,7 +4189,7 @@ UNION ALL
   CALL refresh_continuous_aggregate(:'CAGG_NAME_1ST_LEVEL', NULL, NULL);
   CALL refresh_continuous_aggregate(:'CAGG_NAME_2TH_LEVEL', NULL, NULL);
   CREATE MATERIALIZED VIEW :CAGG_NAME_3TH_LEVEL
-  WITH (timescaledb.continuous) AS
+  WITH (timescaledb.continuous, timescaledb.materialized_only=false) AS
   SELECT
     \if :IS_TIME_DIMENSION_WITH_TIMEZONE_2TH
       time_bucket(:BUCKET_WIDTH_3TH, "bucket", :'BUCKET_TZNAME_2TH') AS bucket
@@ -4230,7 +4230,7 @@ DROP MATERIALIZED VIEW IF EXISTS :CAGG_NAME_1ST_LEVEL;
 -- CAGG on hypertable (1st level)
 --
 CREATE MATERIALIZED VIEW :CAGG_NAME_1ST_LEVEL
-WITH (timescaledb.continuous) AS
+WITH (timescaledb.continuous, timescaledb.materialized_only=false) AS
 SELECT
   \if :IS_TIME_DIMENSION_WITH_TIMEZONE_1ST
     time_bucket(:BUCKET_WIDTH_1ST, "time", :'BUCKET_TZNAME_1ST') AS bucket,
@@ -4267,7 +4267,7 @@ UNION ALL
 \echo :WARNING_MESSAGE
 -- SHOULD WORK
 CREATE MATERIALIZED VIEW :CAGG_NAME_2TH_LEVEL
-WITH (timescaledb.continuous) AS
+WITH (timescaledb.continuous, timescaledb.materialized_only=false) AS
 SELECT
   \if :IS_TIME_DIMENSION_WITH_TIMEZONE_2TH
     time_bucket(:BUCKET_WIDTH_2TH, "bucket", :'BUCKET_TZNAME_2TH') AS bucket,
@@ -4306,7 +4306,7 @@ UNION ALL
   CALL refresh_continuous_aggregate(:'CAGG_NAME_1ST_LEVEL', NULL, NULL);
   CALL refresh_continuous_aggregate(:'CAGG_NAME_2TH_LEVEL', NULL, NULL);
   CREATE MATERIALIZED VIEW :CAGG_NAME_3TH_LEVEL
-  WITH (timescaledb.continuous) AS
+  WITH (timescaledb.continuous, timescaledb.materialized_only=false) AS
   SELECT
     \if :IS_TIME_DIMENSION_WITH_TIMEZONE_2TH
       time_bucket(:BUCKET_WIDTH_3TH, "bucket", :'BUCKET_TZNAME_2TH') AS bucket
@@ -4347,7 +4347,7 @@ DROP MATERIALIZED VIEW IF EXISTS :CAGG_NAME_1ST_LEVEL;
 -- CAGG on hypertable (1st level)
 --
 CREATE MATERIALIZED VIEW :CAGG_NAME_1ST_LEVEL
-WITH (timescaledb.continuous) AS
+WITH (timescaledb.continuous, timescaledb.materialized_only=false) AS
 SELECT
   \if :IS_TIME_DIMENSION_WITH_TIMEZONE_1ST
     time_bucket(:BUCKET_WIDTH_1ST, "time", :'BUCKET_TZNAME_1ST') AS bucket,
@@ -4384,7 +4384,7 @@ UNION ALL
 \echo :WARNING_MESSAGE
 -- SHOULD WORK
 CREATE MATERIALIZED VIEW :CAGG_NAME_2TH_LEVEL
-WITH (timescaledb.continuous) AS
+WITH (timescaledb.continuous, timescaledb.materialized_only=false) AS
 SELECT
   \if :IS_TIME_DIMENSION_WITH_TIMEZONE_2TH
     time_bucket(:BUCKET_WIDTH_2TH, "bucket", :'BUCKET_TZNAME_2TH') AS bucket,
@@ -4423,7 +4423,7 @@ UNION ALL
   CALL refresh_continuous_aggregate(:'CAGG_NAME_1ST_LEVEL', NULL, NULL);
   CALL refresh_continuous_aggregate(:'CAGG_NAME_2TH_LEVEL', NULL, NULL);
   CREATE MATERIALIZED VIEW :CAGG_NAME_3TH_LEVEL
-  WITH (timescaledb.continuous) AS
+  WITH (timescaledb.continuous, timescaledb.materialized_only=false) AS
   SELECT
     \if :IS_TIME_DIMENSION_WITH_TIMEZONE_2TH
       time_bucket(:BUCKET_WIDTH_3TH, "bucket", :'BUCKET_TZNAME_2TH') AS bucket
@@ -4463,7 +4463,7 @@ DROP MATERIALIZED VIEW IF EXISTS :CAGG_NAME_1ST_LEVEL;
 -- CAGG on hypertable (1st level)
 --
 CREATE MATERIALIZED VIEW :CAGG_NAME_1ST_LEVEL
-WITH (timescaledb.continuous) AS
+WITH (timescaledb.continuous, timescaledb.materialized_only=false) AS
 SELECT
   \if :IS_TIME_DIMENSION_WITH_TIMEZONE_1ST
     time_bucket(:BUCKET_WIDTH_1ST, "time", :'BUCKET_TZNAME_1ST') AS bucket,
@@ -4500,7 +4500,7 @@ UNION ALL
 \echo :WARNING_MESSAGE
 -- SHOULD WORK
 CREATE MATERIALIZED VIEW :CAGG_NAME_2TH_LEVEL
-WITH (timescaledb.continuous) AS
+WITH (timescaledb.continuous, timescaledb.materialized_only=false) AS
 SELECT
   \if :IS_TIME_DIMENSION_WITH_TIMEZONE_2TH
     time_bucket(:BUCKET_WIDTH_2TH, "bucket", :'BUCKET_TZNAME_2TH') AS bucket,
@@ -4539,7 +4539,7 @@ UNION ALL
   CALL refresh_continuous_aggregate(:'CAGG_NAME_1ST_LEVEL', NULL, NULL);
   CALL refresh_continuous_aggregate(:'CAGG_NAME_2TH_LEVEL', NULL, NULL);
   CREATE MATERIALIZED VIEW :CAGG_NAME_3TH_LEVEL
-  WITH (timescaledb.continuous) AS
+  WITH (timescaledb.continuous, timescaledb.materialized_only=false) AS
   SELECT
     \if :IS_TIME_DIMENSION_WITH_TIMEZONE_2TH
       time_bucket(:BUCKET_WIDTH_3TH, "bucket", :'BUCKET_TZNAME_2TH') AS bucket
@@ -4573,7 +4573,7 @@ DROP MATERIALIZED VIEW IF EXISTS :CAGG_NAME_1ST_LEVEL;
 -- CAGG on hypertable (1st level)
 --
 CREATE MATERIALIZED VIEW :CAGG_NAME_1ST_LEVEL
-WITH (timescaledb.continuous) AS
+WITH (timescaledb.continuous, timescaledb.materialized_only=false) AS
 SELECT
   \if :IS_TIME_DIMENSION_WITH_TIMEZONE_1ST
     time_bucket(:BUCKET_WIDTH_1ST, "time", :'BUCKET_TZNAME_1ST') AS bucket,
@@ -4610,7 +4610,7 @@ UNION ALL
 \echo :WARNING_MESSAGE
 -- SHOULD WORK
 CREATE MATERIALIZED VIEW :CAGG_NAME_2TH_LEVEL
-WITH (timescaledb.continuous) AS
+WITH (timescaledb.continuous, timescaledb.materialized_only=false) AS
 SELECT
   \if :IS_TIME_DIMENSION_WITH_TIMEZONE_2TH
     time_bucket(:BUCKET_WIDTH_2TH, "bucket", :'BUCKET_TZNAME_2TH') AS bucket,
@@ -4649,7 +4649,7 @@ UNION ALL
   CALL refresh_continuous_aggregate(:'CAGG_NAME_1ST_LEVEL', NULL, NULL);
   CALL refresh_continuous_aggregate(:'CAGG_NAME_2TH_LEVEL', NULL, NULL);
   CREATE MATERIALIZED VIEW :CAGG_NAME_3TH_LEVEL
-  WITH (timescaledb.continuous) AS
+  WITH (timescaledb.continuous, timescaledb.materialized_only=false) AS
   SELECT
     \if :IS_TIME_DIMENSION_WITH_TIMEZONE_2TH
       time_bucket(:BUCKET_WIDTH_3TH, "bucket", :'BUCKET_TZNAME_2TH') AS bucket
@@ -4683,7 +4683,7 @@ DROP MATERIALIZED VIEW IF EXISTS :CAGG_NAME_1ST_LEVEL;
 -- CAGG on hypertable (1st level)
 --
 CREATE MATERIALIZED VIEW :CAGG_NAME_1ST_LEVEL
-WITH (timescaledb.continuous) AS
+WITH (timescaledb.continuous, timescaledb.materialized_only=false) AS
 SELECT
   \if :IS_TIME_DIMENSION_WITH_TIMEZONE_1ST
     time_bucket(:BUCKET_WIDTH_1ST, "time", :'BUCKET_TZNAME_1ST') AS bucket,
@@ -4720,7 +4720,7 @@ UNION ALL
 \echo :WARNING_MESSAGE
 -- SHOULD WORK
 CREATE MATERIALIZED VIEW :CAGG_NAME_2TH_LEVEL
-WITH (timescaledb.continuous) AS
+WITH (timescaledb.continuous, timescaledb.materialized_only=false) AS
 SELECT
   \if :IS_TIME_DIMENSION_WITH_TIMEZONE_2TH
     time_bucket(:BUCKET_WIDTH_2TH, "bucket", :'BUCKET_TZNAME_2TH') AS bucket,
@@ -4759,7 +4759,7 @@ UNION ALL
   CALL refresh_continuous_aggregate(:'CAGG_NAME_1ST_LEVEL', NULL, NULL);
   CALL refresh_continuous_aggregate(:'CAGG_NAME_2TH_LEVEL', NULL, NULL);
   CREATE MATERIALIZED VIEW :CAGG_NAME_3TH_LEVEL
-  WITH (timescaledb.continuous) AS
+  WITH (timescaledb.continuous, timescaledb.materialized_only=false) AS
   SELECT
     \if :IS_TIME_DIMENSION_WITH_TIMEZONE_2TH
       time_bucket(:BUCKET_WIDTH_3TH, "bucket", :'BUCKET_TZNAME_2TH') AS bucket
@@ -4793,7 +4793,7 @@ DROP MATERIALIZED VIEW IF EXISTS :CAGG_NAME_1ST_LEVEL;
 -- CAGG on hypertable (1st level)
 --
 CREATE MATERIALIZED VIEW :CAGG_NAME_1ST_LEVEL
-WITH (timescaledb.continuous) AS
+WITH (timescaledb.continuous, timescaledb.materialized_only=false) AS
 SELECT
   \if :IS_TIME_DIMENSION_WITH_TIMEZONE_1ST
     time_bucket(:BUCKET_WIDTH_1ST, "time", :'BUCKET_TZNAME_1ST') AS bucket,
@@ -4830,7 +4830,7 @@ UNION ALL
 \echo :WARNING_MESSAGE
 -- SHOULD WORK
 CREATE MATERIALIZED VIEW :CAGG_NAME_2TH_LEVEL
-WITH (timescaledb.continuous) AS
+WITH (timescaledb.continuous, timescaledb.materialized_only=false) AS
 SELECT
   \if :IS_TIME_DIMENSION_WITH_TIMEZONE_2TH
     time_bucket(:BUCKET_WIDTH_2TH, "bucket", :'BUCKET_TZNAME_2TH') AS bucket,
@@ -4854,7 +4854,7 @@ DETAIL:  Time bucket width of "public.conditions_summary_2" [@ 1 year] should be
   CALL refresh_continuous_aggregate(:'CAGG_NAME_1ST_LEVEL', NULL, NULL);
   CALL refresh_continuous_aggregate(:'CAGG_NAME_2TH_LEVEL', NULL, NULL);
   CREATE MATERIALIZED VIEW :CAGG_NAME_3TH_LEVEL
-  WITH (timescaledb.continuous) AS
+  WITH (timescaledb.continuous, timescaledb.materialized_only=false) AS
   SELECT
     \if :IS_TIME_DIMENSION_WITH_TIMEZONE_2TH
       time_bucket(:BUCKET_WIDTH_3TH, "bucket", :'BUCKET_TZNAME_2TH') AS bucket
@@ -4889,7 +4889,7 @@ DROP MATERIALIZED VIEW IF EXISTS :CAGG_NAME_1ST_LEVEL;
 -- CAGG on hypertable (1st level)
 --
 CREATE MATERIALIZED VIEW :CAGG_NAME_1ST_LEVEL
-WITH (timescaledb.continuous) AS
+WITH (timescaledb.continuous, timescaledb.materialized_only=false) AS
 SELECT
   \if :IS_TIME_DIMENSION_WITH_TIMEZONE_1ST
     time_bucket(:BUCKET_WIDTH_1ST, "time", :'BUCKET_TZNAME_1ST') AS bucket,
@@ -4926,7 +4926,7 @@ UNION ALL
 \echo :WARNING_MESSAGE
 -- SHOULD WORK
 CREATE MATERIALIZED VIEW :CAGG_NAME_2TH_LEVEL
-WITH (timescaledb.continuous) AS
+WITH (timescaledb.continuous, timescaledb.materialized_only=false) AS
 SELECT
   \if :IS_TIME_DIMENSION_WITH_TIMEZONE_2TH
     time_bucket(:BUCKET_WIDTH_2TH, "bucket", :'BUCKET_TZNAME_2TH') AS bucket,
@@ -4950,7 +4950,7 @@ DETAIL:  Time bucket width of "public.conditions_summary_2" [@ 1 mon] should be 
   CALL refresh_continuous_aggregate(:'CAGG_NAME_1ST_LEVEL', NULL, NULL);
   CALL refresh_continuous_aggregate(:'CAGG_NAME_2TH_LEVEL', NULL, NULL);
   CREATE MATERIALIZED VIEW :CAGG_NAME_3TH_LEVEL
-  WITH (timescaledb.continuous) AS
+  WITH (timescaledb.continuous, timescaledb.materialized_only=false) AS
   SELECT
     \if :IS_TIME_DIMENSION_WITH_TIMEZONE_2TH
       time_bucket(:BUCKET_WIDTH_3TH, "bucket", :'BUCKET_TZNAME_2TH') AS bucket

--- a/tsl/test/expected/cagg_on_cagg_joins_dist_ht.out
+++ b/tsl/test/expected/cagg_on_cagg_joins_dist_ht.out
@@ -929,7 +929,7 @@ psql:include/cagg_on_cagg_common.sql:200: ERROR:  relation "conditions_summary_1
 -- CAGG on hypertable (1st level)
 --
 CREATE MATERIALIZED VIEW :CAGG_NAME_1ST_LEVEL
-WITH (timescaledb.continuous) AS
+WITH (timescaledb.continuous, timescaledb.materialized_only=false) AS
 SELECT
   \if :IS_TIME_DIMENSION_WITH_TIMEZONE_1ST
     time_bucket(:BUCKET_WIDTH_1ST, "time", :'BUCKET_TZNAME_1ST') AS bucket,
@@ -966,7 +966,7 @@ UNION ALL
 \echo :WARNING_MESSAGE
 -- SHOULD ERROR because non-multiple bucket sizes
 CREATE MATERIALIZED VIEW :CAGG_NAME_2TH_LEVEL
-WITH (timescaledb.continuous) AS
+WITH (timescaledb.continuous, timescaledb.materialized_only=false) AS
 SELECT
   \if :IS_TIME_DIMENSION_WITH_TIMEZONE_2TH
     time_bucket(:BUCKET_WIDTH_2TH, "bucket", :'BUCKET_TZNAME_2TH') AS bucket,
@@ -990,7 +990,7 @@ DETAIL:  Time bucket width of "public.conditions_summary_2" [5] should be multip
   CALL refresh_continuous_aggregate(:'CAGG_NAME_1ST_LEVEL', NULL, NULL);
   CALL refresh_continuous_aggregate(:'CAGG_NAME_2TH_LEVEL', NULL, NULL);
   CREATE MATERIALIZED VIEW :CAGG_NAME_3TH_LEVEL
-  WITH (timescaledb.continuous) AS
+  WITH (timescaledb.continuous, timescaledb.materialized_only=false) AS
   SELECT
     \if :IS_TIME_DIMENSION_WITH_TIMEZONE_2TH
       time_bucket(:BUCKET_WIDTH_3TH, "bucket", :'BUCKET_TZNAME_2TH') AS bucket
@@ -1029,7 +1029,7 @@ DROP MATERIALIZED VIEW IF EXISTS :CAGG_NAME_1ST_LEVEL;
 -- CAGG on hypertable (1st level)
 --
 CREATE MATERIALIZED VIEW :CAGG_NAME_1ST_LEVEL
-WITH (timescaledb.continuous) AS
+WITH (timescaledb.continuous, timescaledb.materialized_only=false) AS
 SELECT
   \if :IS_TIME_DIMENSION_WITH_TIMEZONE_1ST
     time_bucket(:BUCKET_WIDTH_1ST, "time", :'BUCKET_TZNAME_1ST') AS bucket,
@@ -1066,7 +1066,7 @@ UNION ALL
 \echo :WARNING_MESSAGE
 SHOULD WORK because new bucket should be greater than previous
 CREATE MATERIALIZED VIEW :CAGG_NAME_2TH_LEVEL
-WITH (timescaledb.continuous) AS
+WITH (timescaledb.continuous, timescaledb.materialized_only=false) AS
 SELECT
   \if :IS_TIME_DIMENSION_WITH_TIMEZONE_2TH
     time_bucket(:BUCKET_WIDTH_2TH, "bucket", :'BUCKET_TZNAME_2TH') AS bucket,
@@ -1105,7 +1105,7 @@ UNION ALL
   CALL refresh_continuous_aggregate(:'CAGG_NAME_1ST_LEVEL', NULL, NULL);
   CALL refresh_continuous_aggregate(:'CAGG_NAME_2TH_LEVEL', NULL, NULL);
   CREATE MATERIALIZED VIEW :CAGG_NAME_3TH_LEVEL
-  WITH (timescaledb.continuous) AS
+  WITH (timescaledb.continuous, timescaledb.materialized_only=false) AS
   SELECT
     \if :IS_TIME_DIMENSION_WITH_TIMEZONE_2TH
       time_bucket(:BUCKET_WIDTH_3TH, "bucket", :'BUCKET_TZNAME_2TH') AS bucket
@@ -1143,7 +1143,7 @@ DROP MATERIALIZED VIEW IF EXISTS :CAGG_NAME_1ST_LEVEL;
 -- CAGG on hypertable (1st level)
 --
 CREATE MATERIALIZED VIEW :CAGG_NAME_1ST_LEVEL
-WITH (timescaledb.continuous) AS
+WITH (timescaledb.continuous, timescaledb.materialized_only=false) AS
 SELECT
   \if :IS_TIME_DIMENSION_WITH_TIMEZONE_1ST
     time_bucket(:BUCKET_WIDTH_1ST, "time", :'BUCKET_TZNAME_1ST') AS bucket,
@@ -1180,7 +1180,7 @@ UNION ALL
 \echo :WARNING_MESSAGE
 -- SHOULD ERROR because new bucket should be greater than previous
 CREATE MATERIALIZED VIEW :CAGG_NAME_2TH_LEVEL
-WITH (timescaledb.continuous) AS
+WITH (timescaledb.continuous, timescaledb.materialized_only=false) AS
 SELECT
   \if :IS_TIME_DIMENSION_WITH_TIMEZONE_2TH
     time_bucket(:BUCKET_WIDTH_2TH, "bucket", :'BUCKET_TZNAME_2TH') AS bucket,
@@ -1204,7 +1204,7 @@ DETAIL:  Time bucket width of "public.conditions_summary_2" [2] should be greate
   CALL refresh_continuous_aggregate(:'CAGG_NAME_1ST_LEVEL', NULL, NULL);
   CALL refresh_continuous_aggregate(:'CAGG_NAME_2TH_LEVEL', NULL, NULL);
   CREATE MATERIALIZED VIEW :CAGG_NAME_3TH_LEVEL
-  WITH (timescaledb.continuous) AS
+  WITH (timescaledb.continuous, timescaledb.materialized_only=false) AS
   SELECT
     \if :IS_TIME_DIMENSION_WITH_TIMEZONE_2TH
       time_bucket(:BUCKET_WIDTH_3TH, "bucket", :'BUCKET_TZNAME_2TH') AS bucket
@@ -2108,7 +2108,7 @@ psql:include/cagg_on_cagg_common.sql:200: ERROR:  relation "conditions_summary_1
 -- CAGG on hypertable (1st level)
 --
 CREATE MATERIALIZED VIEW :CAGG_NAME_1ST_LEVEL
-WITH (timescaledb.continuous) AS
+WITH (timescaledb.continuous, timescaledb.materialized_only=false) AS
 SELECT
   \if :IS_TIME_DIMENSION_WITH_TIMEZONE_1ST
     time_bucket(:BUCKET_WIDTH_1ST, "time", :'BUCKET_TZNAME_1ST') AS bucket,
@@ -2145,7 +2145,7 @@ UNION ALL
 \echo :WARNING_MESSAGE
 -- SHOULD ERROR because is not allowed variable-size bucket on top of fixed-size bucket
 CREATE MATERIALIZED VIEW :CAGG_NAME_2TH_LEVEL
-WITH (timescaledb.continuous) AS
+WITH (timescaledb.continuous, timescaledb.materialized_only=false) AS
 SELECT
   \if :IS_TIME_DIMENSION_WITH_TIMEZONE_2TH
     time_bucket(:BUCKET_WIDTH_2TH, "bucket", :'BUCKET_TZNAME_2TH') AS bucket,
@@ -2170,7 +2170,7 @@ The variance can lead to the fixed width one not being a multiple of the variabl
   CALL refresh_continuous_aggregate(:'CAGG_NAME_1ST_LEVEL', NULL, NULL);
   CALL refresh_continuous_aggregate(:'CAGG_NAME_2TH_LEVEL', NULL, NULL);
   CREATE MATERIALIZED VIEW :CAGG_NAME_3TH_LEVEL
-  WITH (timescaledb.continuous) AS
+  WITH (timescaledb.continuous, timescaledb.materialized_only=false) AS
   SELECT
     \if :IS_TIME_DIMENSION_WITH_TIMEZONE_2TH
       time_bucket(:BUCKET_WIDTH_3TH, "bucket", :'BUCKET_TZNAME_2TH') AS bucket
@@ -2209,7 +2209,7 @@ DROP MATERIALIZED VIEW IF EXISTS :CAGG_NAME_1ST_LEVEL;
 -- CAGG on hypertable (1st level)
 --
 CREATE MATERIALIZED VIEW :CAGG_NAME_1ST_LEVEL
-WITH (timescaledb.continuous) AS
+WITH (timescaledb.continuous, timescaledb.materialized_only=false) AS
 SELECT
   \if :IS_TIME_DIMENSION_WITH_TIMEZONE_1ST
     time_bucket(:BUCKET_WIDTH_1ST, "time", :'BUCKET_TZNAME_1ST') AS bucket,
@@ -2246,7 +2246,7 @@ UNION ALL
 \echo :WARNING_MESSAGE
 -- SHOULD ERROR because non-multiple bucket sizes
 CREATE MATERIALIZED VIEW :CAGG_NAME_2TH_LEVEL
-WITH (timescaledb.continuous) AS
+WITH (timescaledb.continuous, timescaledb.materialized_only=false) AS
 SELECT
   \if :IS_TIME_DIMENSION_WITH_TIMEZONE_2TH
     time_bucket(:BUCKET_WIDTH_2TH, "bucket", :'BUCKET_TZNAME_2TH') AS bucket,
@@ -2270,7 +2270,7 @@ DETAIL:  Time bucket width of "public.conditions_summary_2" [@ 3 hours] should b
   CALL refresh_continuous_aggregate(:'CAGG_NAME_1ST_LEVEL', NULL, NULL);
   CALL refresh_continuous_aggregate(:'CAGG_NAME_2TH_LEVEL', NULL, NULL);
   CREATE MATERIALIZED VIEW :CAGG_NAME_3TH_LEVEL
-  WITH (timescaledb.continuous) AS
+  WITH (timescaledb.continuous, timescaledb.materialized_only=false) AS
   SELECT
     \if :IS_TIME_DIMENSION_WITH_TIMEZONE_2TH
       time_bucket(:BUCKET_WIDTH_3TH, "bucket", :'BUCKET_TZNAME_2TH') AS bucket
@@ -2309,7 +2309,7 @@ DROP MATERIALIZED VIEW IF EXISTS :CAGG_NAME_1ST_LEVEL;
 -- CAGG on hypertable (1st level)
 --
 CREATE MATERIALIZED VIEW :CAGG_NAME_1ST_LEVEL
-WITH (timescaledb.continuous) AS
+WITH (timescaledb.continuous, timescaledb.materialized_only=false) AS
 SELECT
   \if :IS_TIME_DIMENSION_WITH_TIMEZONE_1ST
     time_bucket(:BUCKET_WIDTH_1ST, "time", :'BUCKET_TZNAME_1ST') AS bucket,
@@ -2346,7 +2346,7 @@ UNION ALL
 \echo :WARNING_MESSAGE
 SHOULD WORK because new bucket should be greater than previous
 CREATE MATERIALIZED VIEW :CAGG_NAME_2TH_LEVEL
-WITH (timescaledb.continuous) AS
+WITH (timescaledb.continuous, timescaledb.materialized_only=false) AS
 SELECT
   \if :IS_TIME_DIMENSION_WITH_TIMEZONE_2TH
     time_bucket(:BUCKET_WIDTH_2TH, "bucket", :'BUCKET_TZNAME_2TH') AS bucket,
@@ -2385,7 +2385,7 @@ UNION ALL
   CALL refresh_continuous_aggregate(:'CAGG_NAME_1ST_LEVEL', NULL, NULL);
   CALL refresh_continuous_aggregate(:'CAGG_NAME_2TH_LEVEL', NULL, NULL);
   CREATE MATERIALIZED VIEW :CAGG_NAME_3TH_LEVEL
-  WITH (timescaledb.continuous) AS
+  WITH (timescaledb.continuous, timescaledb.materialized_only=false) AS
   SELECT
     \if :IS_TIME_DIMENSION_WITH_TIMEZONE_2TH
       time_bucket(:BUCKET_WIDTH_3TH, "bucket", :'BUCKET_TZNAME_2TH') AS bucket
@@ -2423,7 +2423,7 @@ DROP MATERIALIZED VIEW IF EXISTS :CAGG_NAME_1ST_LEVEL;
 -- CAGG on hypertable (1st level)
 --
 CREATE MATERIALIZED VIEW :CAGG_NAME_1ST_LEVEL
-WITH (timescaledb.continuous) AS
+WITH (timescaledb.continuous, timescaledb.materialized_only=false) AS
 SELECT
   \if :IS_TIME_DIMENSION_WITH_TIMEZONE_1ST
     time_bucket(:BUCKET_WIDTH_1ST, "time", :'BUCKET_TZNAME_1ST') AS bucket,
@@ -2460,7 +2460,7 @@ UNION ALL
 \echo :WARNING_MESSAGE
 -- SHOULD ERROR because new bucket should be greater than previous
 CREATE MATERIALIZED VIEW :CAGG_NAME_2TH_LEVEL
-WITH (timescaledb.continuous) AS
+WITH (timescaledb.continuous, timescaledb.materialized_only=false) AS
 SELECT
   \if :IS_TIME_DIMENSION_WITH_TIMEZONE_2TH
     time_bucket(:BUCKET_WIDTH_2TH, "bucket", :'BUCKET_TZNAME_2TH') AS bucket,
@@ -2484,7 +2484,7 @@ DETAIL:  Time bucket width of "public.conditions_summary_2" [@ 1 hour] should be
   CALL refresh_continuous_aggregate(:'CAGG_NAME_1ST_LEVEL', NULL, NULL);
   CALL refresh_continuous_aggregate(:'CAGG_NAME_2TH_LEVEL', NULL, NULL);
   CREATE MATERIALIZED VIEW :CAGG_NAME_3TH_LEVEL
-  WITH (timescaledb.continuous) AS
+  WITH (timescaledb.continuous, timescaledb.materialized_only=false) AS
   SELECT
     \if :IS_TIME_DIMENSION_WITH_TIMEZONE_2TH
       time_bucket(:BUCKET_WIDTH_3TH, "bucket", :'BUCKET_TZNAME_2TH') AS bucket
@@ -3383,7 +3383,7 @@ psql:include/cagg_on_cagg_common.sql:200: ERROR:  relation "conditions_summary_1
 -- CAGG on hypertable (1st level)
 --
 CREATE MATERIALIZED VIEW :CAGG_NAME_1ST_LEVEL
-WITH (timescaledb.continuous) AS
+WITH (timescaledb.continuous, timescaledb.materialized_only=false) AS
 SELECT
   \if :IS_TIME_DIMENSION_WITH_TIMEZONE_1ST
     time_bucket(:BUCKET_WIDTH_1ST, "time", :'BUCKET_TZNAME_1ST') AS bucket,
@@ -3420,7 +3420,7 @@ UNION ALL
 \echo :WARNING_MESSAGE
 -- SHOULD ERROR because is not allowed variable-size bucket on top of fixed-size bucket
 CREATE MATERIALIZED VIEW :CAGG_NAME_2TH_LEVEL
-WITH (timescaledb.continuous) AS
+WITH (timescaledb.continuous, timescaledb.materialized_only=false) AS
 SELECT
   \if :IS_TIME_DIMENSION_WITH_TIMEZONE_2TH
     time_bucket(:BUCKET_WIDTH_2TH, "bucket", :'BUCKET_TZNAME_2TH') AS bucket,
@@ -3445,7 +3445,7 @@ The variance can lead to the fixed width one not being a multiple of the variabl
   CALL refresh_continuous_aggregate(:'CAGG_NAME_1ST_LEVEL', NULL, NULL);
   CALL refresh_continuous_aggregate(:'CAGG_NAME_2TH_LEVEL', NULL, NULL);
   CREATE MATERIALIZED VIEW :CAGG_NAME_3TH_LEVEL
-  WITH (timescaledb.continuous) AS
+  WITH (timescaledb.continuous, timescaledb.materialized_only=false) AS
   SELECT
     \if :IS_TIME_DIMENSION_WITH_TIMEZONE_2TH
       time_bucket(:BUCKET_WIDTH_3TH, "bucket", :'BUCKET_TZNAME_2TH') AS bucket
@@ -3484,7 +3484,7 @@ DROP MATERIALIZED VIEW IF EXISTS :CAGG_NAME_1ST_LEVEL;
 -- CAGG on hypertable (1st level)
 --
 CREATE MATERIALIZED VIEW :CAGG_NAME_1ST_LEVEL
-WITH (timescaledb.continuous) AS
+WITH (timescaledb.continuous, timescaledb.materialized_only=false) AS
 SELECT
   \if :IS_TIME_DIMENSION_WITH_TIMEZONE_1ST
     time_bucket(:BUCKET_WIDTH_1ST, "time", :'BUCKET_TZNAME_1ST') AS bucket,
@@ -3521,7 +3521,7 @@ UNION ALL
 \echo :WARNING_MESSAGE
 -- SHOULD ERROR because non-multiple bucket sizes
 CREATE MATERIALIZED VIEW :CAGG_NAME_2TH_LEVEL
-WITH (timescaledb.continuous) AS
+WITH (timescaledb.continuous, timescaledb.materialized_only=false) AS
 SELECT
   \if :IS_TIME_DIMENSION_WITH_TIMEZONE_2TH
     time_bucket(:BUCKET_WIDTH_2TH, "bucket", :'BUCKET_TZNAME_2TH') AS bucket,
@@ -3545,7 +3545,7 @@ DETAIL:  Time bucket width of "public.conditions_summary_2" [@ 3 hours] should b
   CALL refresh_continuous_aggregate(:'CAGG_NAME_1ST_LEVEL', NULL, NULL);
   CALL refresh_continuous_aggregate(:'CAGG_NAME_2TH_LEVEL', NULL, NULL);
   CREATE MATERIALIZED VIEW :CAGG_NAME_3TH_LEVEL
-  WITH (timescaledb.continuous) AS
+  WITH (timescaledb.continuous, timescaledb.materialized_only=false) AS
   SELECT
     \if :IS_TIME_DIMENSION_WITH_TIMEZONE_2TH
       time_bucket(:BUCKET_WIDTH_3TH, "bucket", :'BUCKET_TZNAME_2TH') AS bucket
@@ -3584,7 +3584,7 @@ DROP MATERIALIZED VIEW IF EXISTS :CAGG_NAME_1ST_LEVEL;
 -- CAGG on hypertable (1st level)
 --
 CREATE MATERIALIZED VIEW :CAGG_NAME_1ST_LEVEL
-WITH (timescaledb.continuous) AS
+WITH (timescaledb.continuous, timescaledb.materialized_only=false) AS
 SELECT
   \if :IS_TIME_DIMENSION_WITH_TIMEZONE_1ST
     time_bucket(:BUCKET_WIDTH_1ST, "time", :'BUCKET_TZNAME_1ST') AS bucket,
@@ -3621,7 +3621,7 @@ UNION ALL
 \echo :WARNING_MESSAGE
 SHOULD WORK because new bucket should be greater than previous
 CREATE MATERIALIZED VIEW :CAGG_NAME_2TH_LEVEL
-WITH (timescaledb.continuous) AS
+WITH (timescaledb.continuous, timescaledb.materialized_only=false) AS
 SELECT
   \if :IS_TIME_DIMENSION_WITH_TIMEZONE_2TH
     time_bucket(:BUCKET_WIDTH_2TH, "bucket", :'BUCKET_TZNAME_2TH') AS bucket,
@@ -3660,7 +3660,7 @@ UNION ALL
   CALL refresh_continuous_aggregate(:'CAGG_NAME_1ST_LEVEL', NULL, NULL);
   CALL refresh_continuous_aggregate(:'CAGG_NAME_2TH_LEVEL', NULL, NULL);
   CREATE MATERIALIZED VIEW :CAGG_NAME_3TH_LEVEL
-  WITH (timescaledb.continuous) AS
+  WITH (timescaledb.continuous, timescaledb.materialized_only=false) AS
   SELECT
     \if :IS_TIME_DIMENSION_WITH_TIMEZONE_2TH
       time_bucket(:BUCKET_WIDTH_3TH, "bucket", :'BUCKET_TZNAME_2TH') AS bucket
@@ -3698,7 +3698,7 @@ DROP MATERIALIZED VIEW IF EXISTS :CAGG_NAME_1ST_LEVEL;
 -- CAGG on hypertable (1st level)
 --
 CREATE MATERIALIZED VIEW :CAGG_NAME_1ST_LEVEL
-WITH (timescaledb.continuous) AS
+WITH (timescaledb.continuous, timescaledb.materialized_only=false) AS
 SELECT
   \if :IS_TIME_DIMENSION_WITH_TIMEZONE_1ST
     time_bucket(:BUCKET_WIDTH_1ST, "time", :'BUCKET_TZNAME_1ST') AS bucket,
@@ -3735,7 +3735,7 @@ UNION ALL
 \echo :WARNING_MESSAGE
 -- SHOULD ERROR because new bucket should be greater than previous
 CREATE MATERIALIZED VIEW :CAGG_NAME_2TH_LEVEL
-WITH (timescaledb.continuous) AS
+WITH (timescaledb.continuous, timescaledb.materialized_only=false) AS
 SELECT
   \if :IS_TIME_DIMENSION_WITH_TIMEZONE_2TH
     time_bucket(:BUCKET_WIDTH_2TH, "bucket", :'BUCKET_TZNAME_2TH') AS bucket,
@@ -3759,7 +3759,7 @@ DETAIL:  Time bucket width of "public.conditions_summary_2" [@ 1 hour] should be
   CALL refresh_continuous_aggregate(:'CAGG_NAME_1ST_LEVEL', NULL, NULL);
   CALL refresh_continuous_aggregate(:'CAGG_NAME_2TH_LEVEL', NULL, NULL);
   CREATE MATERIALIZED VIEW :CAGG_NAME_3TH_LEVEL
-  WITH (timescaledb.continuous) AS
+  WITH (timescaledb.continuous, timescaledb.materialized_only=false) AS
   SELECT
     \if :IS_TIME_DIMENSION_WITH_TIMEZONE_2TH
       time_bucket(:BUCKET_WIDTH_3TH, "bucket", :'BUCKET_TZNAME_2TH') AS bucket
@@ -3805,7 +3805,7 @@ DROP MATERIALIZED VIEW IF EXISTS :CAGG_NAME_1ST_LEVEL;
 -- CAGG on hypertable (1st level)
 --
 CREATE MATERIALIZED VIEW :CAGG_NAME_1ST_LEVEL
-WITH (timescaledb.continuous) AS
+WITH (timescaledb.continuous, timescaledb.materialized_only=false) AS
 SELECT
   \if :IS_TIME_DIMENSION_WITH_TIMEZONE_1ST
     time_bucket(:BUCKET_WIDTH_1ST, "time", :'BUCKET_TZNAME_1ST') AS bucket,
@@ -3842,7 +3842,7 @@ UNION ALL
 \echo :WARNING_MESSAGE
 -- SHOULD WORK
 CREATE MATERIALIZED VIEW :CAGG_NAME_2TH_LEVEL
-WITH (timescaledb.continuous) AS
+WITH (timescaledb.continuous, timescaledb.materialized_only=false) AS
 SELECT
   \if :IS_TIME_DIMENSION_WITH_TIMEZONE_2TH
     time_bucket(:BUCKET_WIDTH_2TH, "bucket", :'BUCKET_TZNAME_2TH') AS bucket,
@@ -3881,7 +3881,7 @@ UNION ALL
   CALL refresh_continuous_aggregate(:'CAGG_NAME_1ST_LEVEL', NULL, NULL);
   CALL refresh_continuous_aggregate(:'CAGG_NAME_2TH_LEVEL', NULL, NULL);
   CREATE MATERIALIZED VIEW :CAGG_NAME_3TH_LEVEL
-  WITH (timescaledb.continuous) AS
+  WITH (timescaledb.continuous, timescaledb.materialized_only=false) AS
   SELECT
     \if :IS_TIME_DIMENSION_WITH_TIMEZONE_2TH
       time_bucket(:BUCKET_WIDTH_3TH, "bucket", :'BUCKET_TZNAME_2TH') AS bucket
@@ -3916,7 +3916,7 @@ DROP MATERIALIZED VIEW IF EXISTS :CAGG_NAME_1ST_LEVEL;
 -- CAGG on hypertable (1st level)
 --
 CREATE MATERIALIZED VIEW :CAGG_NAME_1ST_LEVEL
-WITH (timescaledb.continuous) AS
+WITH (timescaledb.continuous, timescaledb.materialized_only=false) AS
 SELECT
   \if :IS_TIME_DIMENSION_WITH_TIMEZONE_1ST
     time_bucket(:BUCKET_WIDTH_1ST, "time", :'BUCKET_TZNAME_1ST') AS bucket,
@@ -3953,7 +3953,7 @@ UNION ALL
 \echo :WARNING_MESSAGE
 -- SHOULD ERROR because non-multiple bucket sizes
 CREATE MATERIALIZED VIEW :CAGG_NAME_2TH_LEVEL
-WITH (timescaledb.continuous) AS
+WITH (timescaledb.continuous, timescaledb.materialized_only=false) AS
 SELECT
   \if :IS_TIME_DIMENSION_WITH_TIMEZONE_2TH
     time_bucket(:BUCKET_WIDTH_2TH, "bucket", :'BUCKET_TZNAME_2TH') AS bucket,
@@ -3977,7 +3977,7 @@ DETAIL:  Time bucket width of "public.conditions_summary_2" [@ 16 mins] should b
   CALL refresh_continuous_aggregate(:'CAGG_NAME_1ST_LEVEL', NULL, NULL);
   CALL refresh_continuous_aggregate(:'CAGG_NAME_2TH_LEVEL', NULL, NULL);
   CREATE MATERIALIZED VIEW :CAGG_NAME_3TH_LEVEL
-  WITH (timescaledb.continuous) AS
+  WITH (timescaledb.continuous, timescaledb.materialized_only=false) AS
   SELECT
     \if :IS_TIME_DIMENSION_WITH_TIMEZONE_2TH
       time_bucket(:BUCKET_WIDTH_3TH, "bucket", :'BUCKET_TZNAME_2TH') AS bucket
@@ -4018,7 +4018,7 @@ DROP MATERIALIZED VIEW IF EXISTS :CAGG_NAME_1ST_LEVEL;
 -- CAGG on hypertable (1st level)
 --
 CREATE MATERIALIZED VIEW :CAGG_NAME_1ST_LEVEL
-WITH (timescaledb.continuous) AS
+WITH (timescaledb.continuous, timescaledb.materialized_only=false) AS
 SELECT
   \if :IS_TIME_DIMENSION_WITH_TIMEZONE_1ST
     time_bucket(:BUCKET_WIDTH_1ST, "time", :'BUCKET_TZNAME_1ST') AS bucket,
@@ -4055,7 +4055,7 @@ UNION ALL
 \echo :WARNING_MESSAGE
 -- SHOULD WORK
 CREATE MATERIALIZED VIEW :CAGG_NAME_2TH_LEVEL
-WITH (timescaledb.continuous) AS
+WITH (timescaledb.continuous, timescaledb.materialized_only=false) AS
 SELECT
   \if :IS_TIME_DIMENSION_WITH_TIMEZONE_2TH
     time_bucket(:BUCKET_WIDTH_2TH, "bucket", :'BUCKET_TZNAME_2TH') AS bucket,
@@ -4094,7 +4094,7 @@ UNION ALL
   CALL refresh_continuous_aggregate(:'CAGG_NAME_1ST_LEVEL', NULL, NULL);
   CALL refresh_continuous_aggregate(:'CAGG_NAME_2TH_LEVEL', NULL, NULL);
   CREATE MATERIALIZED VIEW :CAGG_NAME_3TH_LEVEL
-  WITH (timescaledb.continuous) AS
+  WITH (timescaledb.continuous, timescaledb.materialized_only=false) AS
   SELECT
     \if :IS_TIME_DIMENSION_WITH_TIMEZONE_2TH
       time_bucket(:BUCKET_WIDTH_3TH, "bucket", :'BUCKET_TZNAME_2TH') AS bucket
@@ -4134,7 +4134,7 @@ DROP MATERIALIZED VIEW IF EXISTS :CAGG_NAME_1ST_LEVEL;
 -- CAGG on hypertable (1st level)
 --
 CREATE MATERIALIZED VIEW :CAGG_NAME_1ST_LEVEL
-WITH (timescaledb.continuous) AS
+WITH (timescaledb.continuous, timescaledb.materialized_only=false) AS
 SELECT
   \if :IS_TIME_DIMENSION_WITH_TIMEZONE_1ST
     time_bucket(:BUCKET_WIDTH_1ST, "time", :'BUCKET_TZNAME_1ST') AS bucket,
@@ -4171,7 +4171,7 @@ UNION ALL
 \echo :WARNING_MESSAGE
 -- SHOULD WORK
 CREATE MATERIALIZED VIEW :CAGG_NAME_2TH_LEVEL
-WITH (timescaledb.continuous) AS
+WITH (timescaledb.continuous, timescaledb.materialized_only=false) AS
 SELECT
   \if :IS_TIME_DIMENSION_WITH_TIMEZONE_2TH
     time_bucket(:BUCKET_WIDTH_2TH, "bucket", :'BUCKET_TZNAME_2TH') AS bucket,
@@ -4210,7 +4210,7 @@ UNION ALL
   CALL refresh_continuous_aggregate(:'CAGG_NAME_1ST_LEVEL', NULL, NULL);
   CALL refresh_continuous_aggregate(:'CAGG_NAME_2TH_LEVEL', NULL, NULL);
   CREATE MATERIALIZED VIEW :CAGG_NAME_3TH_LEVEL
-  WITH (timescaledb.continuous) AS
+  WITH (timescaledb.continuous, timescaledb.materialized_only=false) AS
   SELECT
     \if :IS_TIME_DIMENSION_WITH_TIMEZONE_2TH
       time_bucket(:BUCKET_WIDTH_3TH, "bucket", :'BUCKET_TZNAME_2TH') AS bucket
@@ -4251,7 +4251,7 @@ DROP MATERIALIZED VIEW IF EXISTS :CAGG_NAME_1ST_LEVEL;
 -- CAGG on hypertable (1st level)
 --
 CREATE MATERIALIZED VIEW :CAGG_NAME_1ST_LEVEL
-WITH (timescaledb.continuous) AS
+WITH (timescaledb.continuous, timescaledb.materialized_only=false) AS
 SELECT
   \if :IS_TIME_DIMENSION_WITH_TIMEZONE_1ST
     time_bucket(:BUCKET_WIDTH_1ST, "time", :'BUCKET_TZNAME_1ST') AS bucket,
@@ -4288,7 +4288,7 @@ UNION ALL
 \echo :WARNING_MESSAGE
 -- SHOULD WORK
 CREATE MATERIALIZED VIEW :CAGG_NAME_2TH_LEVEL
-WITH (timescaledb.continuous) AS
+WITH (timescaledb.continuous, timescaledb.materialized_only=false) AS
 SELECT
   \if :IS_TIME_DIMENSION_WITH_TIMEZONE_2TH
     time_bucket(:BUCKET_WIDTH_2TH, "bucket", :'BUCKET_TZNAME_2TH') AS bucket,
@@ -4327,7 +4327,7 @@ UNION ALL
   CALL refresh_continuous_aggregate(:'CAGG_NAME_1ST_LEVEL', NULL, NULL);
   CALL refresh_continuous_aggregate(:'CAGG_NAME_2TH_LEVEL', NULL, NULL);
   CREATE MATERIALIZED VIEW :CAGG_NAME_3TH_LEVEL
-  WITH (timescaledb.continuous) AS
+  WITH (timescaledb.continuous, timescaledb.materialized_only=false) AS
   SELECT
     \if :IS_TIME_DIMENSION_WITH_TIMEZONE_2TH
       time_bucket(:BUCKET_WIDTH_3TH, "bucket", :'BUCKET_TZNAME_2TH') AS bucket
@@ -4368,7 +4368,7 @@ DROP MATERIALIZED VIEW IF EXISTS :CAGG_NAME_1ST_LEVEL;
 -- CAGG on hypertable (1st level)
 --
 CREATE MATERIALIZED VIEW :CAGG_NAME_1ST_LEVEL
-WITH (timescaledb.continuous) AS
+WITH (timescaledb.continuous, timescaledb.materialized_only=false) AS
 SELECT
   \if :IS_TIME_DIMENSION_WITH_TIMEZONE_1ST
     time_bucket(:BUCKET_WIDTH_1ST, "time", :'BUCKET_TZNAME_1ST') AS bucket,
@@ -4405,7 +4405,7 @@ UNION ALL
 \echo :WARNING_MESSAGE
 -- SHOULD WORK
 CREATE MATERIALIZED VIEW :CAGG_NAME_2TH_LEVEL
-WITH (timescaledb.continuous) AS
+WITH (timescaledb.continuous, timescaledb.materialized_only=false) AS
 SELECT
   \if :IS_TIME_DIMENSION_WITH_TIMEZONE_2TH
     time_bucket(:BUCKET_WIDTH_2TH, "bucket", :'BUCKET_TZNAME_2TH') AS bucket,
@@ -4444,7 +4444,7 @@ UNION ALL
   CALL refresh_continuous_aggregate(:'CAGG_NAME_1ST_LEVEL', NULL, NULL);
   CALL refresh_continuous_aggregate(:'CAGG_NAME_2TH_LEVEL', NULL, NULL);
   CREATE MATERIALIZED VIEW :CAGG_NAME_3TH_LEVEL
-  WITH (timescaledb.continuous) AS
+  WITH (timescaledb.continuous, timescaledb.materialized_only=false) AS
   SELECT
     \if :IS_TIME_DIMENSION_WITH_TIMEZONE_2TH
       time_bucket(:BUCKET_WIDTH_3TH, "bucket", :'BUCKET_TZNAME_2TH') AS bucket
@@ -4479,7 +4479,7 @@ DROP MATERIALIZED VIEW IF EXISTS :CAGG_NAME_1ST_LEVEL;
 -- CAGG on hypertable (1st level)
 --
 CREATE MATERIALIZED VIEW :CAGG_NAME_1ST_LEVEL
-WITH (timescaledb.continuous) AS
+WITH (timescaledb.continuous, timescaledb.materialized_only=false) AS
 SELECT
   \if :IS_TIME_DIMENSION_WITH_TIMEZONE_1ST
     time_bucket(:BUCKET_WIDTH_1ST, "time", :'BUCKET_TZNAME_1ST') AS bucket,
@@ -4516,7 +4516,7 @@ UNION ALL
 \echo :WARNING_MESSAGE
 -- SHOULD WORK
 CREATE MATERIALIZED VIEW :CAGG_NAME_2TH_LEVEL
-WITH (timescaledb.continuous) AS
+WITH (timescaledb.continuous, timescaledb.materialized_only=false) AS
 SELECT
   \if :IS_TIME_DIMENSION_WITH_TIMEZONE_2TH
     time_bucket(:BUCKET_WIDTH_2TH, "bucket", :'BUCKET_TZNAME_2TH') AS bucket,
@@ -4555,7 +4555,7 @@ UNION ALL
   CALL refresh_continuous_aggregate(:'CAGG_NAME_1ST_LEVEL', NULL, NULL);
   CALL refresh_continuous_aggregate(:'CAGG_NAME_2TH_LEVEL', NULL, NULL);
   CREATE MATERIALIZED VIEW :CAGG_NAME_3TH_LEVEL
-  WITH (timescaledb.continuous) AS
+  WITH (timescaledb.continuous, timescaledb.materialized_only=false) AS
   SELECT
     \if :IS_TIME_DIMENSION_WITH_TIMEZONE_2TH
       time_bucket(:BUCKET_WIDTH_3TH, "bucket", :'BUCKET_TZNAME_2TH') AS bucket
@@ -4589,7 +4589,7 @@ DROP MATERIALIZED VIEW IF EXISTS :CAGG_NAME_1ST_LEVEL;
 -- CAGG on hypertable (1st level)
 --
 CREATE MATERIALIZED VIEW :CAGG_NAME_1ST_LEVEL
-WITH (timescaledb.continuous) AS
+WITH (timescaledb.continuous, timescaledb.materialized_only=false) AS
 SELECT
   \if :IS_TIME_DIMENSION_WITH_TIMEZONE_1ST
     time_bucket(:BUCKET_WIDTH_1ST, "time", :'BUCKET_TZNAME_1ST') AS bucket,
@@ -4626,7 +4626,7 @@ UNION ALL
 \echo :WARNING_MESSAGE
 -- SHOULD WORK
 CREATE MATERIALIZED VIEW :CAGG_NAME_2TH_LEVEL
-WITH (timescaledb.continuous) AS
+WITH (timescaledb.continuous, timescaledb.materialized_only=false) AS
 SELECT
   \if :IS_TIME_DIMENSION_WITH_TIMEZONE_2TH
     time_bucket(:BUCKET_WIDTH_2TH, "bucket", :'BUCKET_TZNAME_2TH') AS bucket,
@@ -4665,7 +4665,7 @@ UNION ALL
   CALL refresh_continuous_aggregate(:'CAGG_NAME_1ST_LEVEL', NULL, NULL);
   CALL refresh_continuous_aggregate(:'CAGG_NAME_2TH_LEVEL', NULL, NULL);
   CREATE MATERIALIZED VIEW :CAGG_NAME_3TH_LEVEL
-  WITH (timescaledb.continuous) AS
+  WITH (timescaledb.continuous, timescaledb.materialized_only=false) AS
   SELECT
     \if :IS_TIME_DIMENSION_WITH_TIMEZONE_2TH
       time_bucket(:BUCKET_WIDTH_3TH, "bucket", :'BUCKET_TZNAME_2TH') AS bucket
@@ -4699,7 +4699,7 @@ DROP MATERIALIZED VIEW IF EXISTS :CAGG_NAME_1ST_LEVEL;
 -- CAGG on hypertable (1st level)
 --
 CREATE MATERIALIZED VIEW :CAGG_NAME_1ST_LEVEL
-WITH (timescaledb.continuous) AS
+WITH (timescaledb.continuous, timescaledb.materialized_only=false) AS
 SELECT
   \if :IS_TIME_DIMENSION_WITH_TIMEZONE_1ST
     time_bucket(:BUCKET_WIDTH_1ST, "time", :'BUCKET_TZNAME_1ST') AS bucket,
@@ -4736,7 +4736,7 @@ UNION ALL
 \echo :WARNING_MESSAGE
 -- SHOULD WORK
 CREATE MATERIALIZED VIEW :CAGG_NAME_2TH_LEVEL
-WITH (timescaledb.continuous) AS
+WITH (timescaledb.continuous, timescaledb.materialized_only=false) AS
 SELECT
   \if :IS_TIME_DIMENSION_WITH_TIMEZONE_2TH
     time_bucket(:BUCKET_WIDTH_2TH, "bucket", :'BUCKET_TZNAME_2TH') AS bucket,
@@ -4775,7 +4775,7 @@ UNION ALL
   CALL refresh_continuous_aggregate(:'CAGG_NAME_1ST_LEVEL', NULL, NULL);
   CALL refresh_continuous_aggregate(:'CAGG_NAME_2TH_LEVEL', NULL, NULL);
   CREATE MATERIALIZED VIEW :CAGG_NAME_3TH_LEVEL
-  WITH (timescaledb.continuous) AS
+  WITH (timescaledb.continuous, timescaledb.materialized_only=false) AS
   SELECT
     \if :IS_TIME_DIMENSION_WITH_TIMEZONE_2TH
       time_bucket(:BUCKET_WIDTH_3TH, "bucket", :'BUCKET_TZNAME_2TH') AS bucket
@@ -4809,7 +4809,7 @@ DROP MATERIALIZED VIEW IF EXISTS :CAGG_NAME_1ST_LEVEL;
 -- CAGG on hypertable (1st level)
 --
 CREATE MATERIALIZED VIEW :CAGG_NAME_1ST_LEVEL
-WITH (timescaledb.continuous) AS
+WITH (timescaledb.continuous, timescaledb.materialized_only=false) AS
 SELECT
   \if :IS_TIME_DIMENSION_WITH_TIMEZONE_1ST
     time_bucket(:BUCKET_WIDTH_1ST, "time", :'BUCKET_TZNAME_1ST') AS bucket,
@@ -4846,7 +4846,7 @@ UNION ALL
 \echo :WARNING_MESSAGE
 -- SHOULD WORK
 CREATE MATERIALIZED VIEW :CAGG_NAME_2TH_LEVEL
-WITH (timescaledb.continuous) AS
+WITH (timescaledb.continuous, timescaledb.materialized_only=false) AS
 SELECT
   \if :IS_TIME_DIMENSION_WITH_TIMEZONE_2TH
     time_bucket(:BUCKET_WIDTH_2TH, "bucket", :'BUCKET_TZNAME_2TH') AS bucket,
@@ -4870,7 +4870,7 @@ DETAIL:  Time bucket width of "public.conditions_summary_2" [@ 1 year] should be
   CALL refresh_continuous_aggregate(:'CAGG_NAME_1ST_LEVEL', NULL, NULL);
   CALL refresh_continuous_aggregate(:'CAGG_NAME_2TH_LEVEL', NULL, NULL);
   CREATE MATERIALIZED VIEW :CAGG_NAME_3TH_LEVEL
-  WITH (timescaledb.continuous) AS
+  WITH (timescaledb.continuous, timescaledb.materialized_only=false) AS
   SELECT
     \if :IS_TIME_DIMENSION_WITH_TIMEZONE_2TH
       time_bucket(:BUCKET_WIDTH_3TH, "bucket", :'BUCKET_TZNAME_2TH') AS bucket
@@ -4905,7 +4905,7 @@ DROP MATERIALIZED VIEW IF EXISTS :CAGG_NAME_1ST_LEVEL;
 -- CAGG on hypertable (1st level)
 --
 CREATE MATERIALIZED VIEW :CAGG_NAME_1ST_LEVEL
-WITH (timescaledb.continuous) AS
+WITH (timescaledb.continuous, timescaledb.materialized_only=false) AS
 SELECT
   \if :IS_TIME_DIMENSION_WITH_TIMEZONE_1ST
     time_bucket(:BUCKET_WIDTH_1ST, "time", :'BUCKET_TZNAME_1ST') AS bucket,
@@ -4942,7 +4942,7 @@ UNION ALL
 \echo :WARNING_MESSAGE
 -- SHOULD WORK
 CREATE MATERIALIZED VIEW :CAGG_NAME_2TH_LEVEL
-WITH (timescaledb.continuous) AS
+WITH (timescaledb.continuous, timescaledb.materialized_only=false) AS
 SELECT
   \if :IS_TIME_DIMENSION_WITH_TIMEZONE_2TH
     time_bucket(:BUCKET_WIDTH_2TH, "bucket", :'BUCKET_TZNAME_2TH') AS bucket,
@@ -4966,7 +4966,7 @@ DETAIL:  Time bucket width of "public.conditions_summary_2" [@ 1 mon] should be 
   CALL refresh_continuous_aggregate(:'CAGG_NAME_1ST_LEVEL', NULL, NULL);
   CALL refresh_continuous_aggregate(:'CAGG_NAME_2TH_LEVEL', NULL, NULL);
   CREATE MATERIALIZED VIEW :CAGG_NAME_3TH_LEVEL
-  WITH (timescaledb.continuous) AS
+  WITH (timescaledb.continuous, timescaledb.materialized_only=false) AS
   SELECT
     \if :IS_TIME_DIMENSION_WITH_TIMEZONE_2TH
       time_bucket(:BUCKET_WIDTH_3TH, "bucket", :'BUCKET_TZNAME_2TH') AS bucket
@@ -5005,7 +5005,7 @@ DROP MATERIALIZED VIEW IF EXISTS :CAGG_NAME_1ST_LEVEL;
 -- CAGG on hypertable (1st level)
 --
 CREATE MATERIALIZED VIEW :CAGG_NAME_1ST_LEVEL
-WITH (timescaledb.continuous) AS
+WITH (timescaledb.continuous, timescaledb.materialized_only=false) AS
 SELECT
   \if :IS_TIME_DIMENSION_WITH_TIMEZONE_1ST
     time_bucket(:BUCKET_WIDTH_1ST, "time", :'BUCKET_TZNAME_1ST') AS bucket,
@@ -5042,7 +5042,7 @@ UNION ALL
 \echo :WARNING_MESSAGE
 -- SHOULD WORK
 CREATE MATERIALIZED VIEW :CAGG_NAME_2TH_LEVEL
-WITH (timescaledb.continuous) AS
+WITH (timescaledb.continuous, timescaledb.materialized_only=false) AS
 SELECT
   \if :IS_TIME_DIMENSION_WITH_TIMEZONE_2TH
     time_bucket(:BUCKET_WIDTH_2TH, "bucket", :'BUCKET_TZNAME_2TH') AS bucket,
@@ -5081,7 +5081,7 @@ UNION ALL
   CALL refresh_continuous_aggregate(:'CAGG_NAME_1ST_LEVEL', NULL, NULL);
   CALL refresh_continuous_aggregate(:'CAGG_NAME_2TH_LEVEL', NULL, NULL);
   CREATE MATERIALIZED VIEW :CAGG_NAME_3TH_LEVEL
-  WITH (timescaledb.continuous) AS
+  WITH (timescaledb.continuous, timescaledb.materialized_only=false) AS
   SELECT
     \if :IS_TIME_DIMENSION_WITH_TIMEZONE_2TH
       time_bucket(:BUCKET_WIDTH_3TH, "bucket", :'BUCKET_TZNAME_2TH') AS bucket
@@ -5115,7 +5115,7 @@ DROP MATERIALIZED VIEW IF EXISTS :CAGG_NAME_1ST_LEVEL;
 -- CAGG on hypertable (1st level)
 --
 CREATE MATERIALIZED VIEW :CAGG_NAME_1ST_LEVEL
-WITH (timescaledb.continuous) AS
+WITH (timescaledb.continuous, timescaledb.materialized_only=false) AS
 SELECT
   \if :IS_TIME_DIMENSION_WITH_TIMEZONE_1ST
     time_bucket(:BUCKET_WIDTH_1ST, "time", :'BUCKET_TZNAME_1ST') AS bucket,
@@ -5152,7 +5152,7 @@ UNION ALL
 \echo :WARNING_MESSAGE
 -- SHOULD WORK
 CREATE MATERIALIZED VIEW :CAGG_NAME_2TH_LEVEL
-WITH (timescaledb.continuous) AS
+WITH (timescaledb.continuous, timescaledb.materialized_only=false) AS
 SELECT
   \if :IS_TIME_DIMENSION_WITH_TIMEZONE_2TH
     time_bucket(:BUCKET_WIDTH_2TH, "bucket", :'BUCKET_TZNAME_2TH') AS bucket,
@@ -5191,7 +5191,7 @@ UNION ALL
   CALL refresh_continuous_aggregate(:'CAGG_NAME_1ST_LEVEL', NULL, NULL);
   CALL refresh_continuous_aggregate(:'CAGG_NAME_2TH_LEVEL', NULL, NULL);
   CREATE MATERIALIZED VIEW :CAGG_NAME_3TH_LEVEL
-  WITH (timescaledb.continuous) AS
+  WITH (timescaledb.continuous, timescaledb.materialized_only=false) AS
   SELECT
     \if :IS_TIME_DIMENSION_WITH_TIMEZONE_2TH
       time_bucket(:BUCKET_WIDTH_3TH, "bucket", :'BUCKET_TZNAME_2TH') AS bucket
@@ -5225,7 +5225,7 @@ DROP MATERIALIZED VIEW IF EXISTS :CAGG_NAME_1ST_LEVEL;
 -- CAGG on hypertable (1st level)
 --
 CREATE MATERIALIZED VIEW :CAGG_NAME_1ST_LEVEL
-WITH (timescaledb.continuous) AS
+WITH (timescaledb.continuous, timescaledb.materialized_only=false) AS
 SELECT
   \if :IS_TIME_DIMENSION_WITH_TIMEZONE_1ST
     time_bucket(:BUCKET_WIDTH_1ST, "time", :'BUCKET_TZNAME_1ST') AS bucket,
@@ -5262,7 +5262,7 @@ UNION ALL
 \echo :WARNING_MESSAGE
 -- SHOULD WORK
 CREATE MATERIALIZED VIEW :CAGG_NAME_2TH_LEVEL
-WITH (timescaledb.continuous) AS
+WITH (timescaledb.continuous, timescaledb.materialized_only=false) AS
 SELECT
   \if :IS_TIME_DIMENSION_WITH_TIMEZONE_2TH
     time_bucket(:BUCKET_WIDTH_2TH, "bucket", :'BUCKET_TZNAME_2TH') AS bucket,
@@ -5301,7 +5301,7 @@ UNION ALL
   CALL refresh_continuous_aggregate(:'CAGG_NAME_1ST_LEVEL', NULL, NULL);
   CALL refresh_continuous_aggregate(:'CAGG_NAME_2TH_LEVEL', NULL, NULL);
   CREATE MATERIALIZED VIEW :CAGG_NAME_3TH_LEVEL
-  WITH (timescaledb.continuous) AS
+  WITH (timescaledb.continuous, timescaledb.materialized_only=false) AS
   SELECT
     \if :IS_TIME_DIMENSION_WITH_TIMEZONE_2TH
       time_bucket(:BUCKET_WIDTH_3TH, "bucket", :'BUCKET_TZNAME_2TH') AS bucket
@@ -5336,7 +5336,7 @@ DROP MATERIALIZED VIEW IF EXISTS :CAGG_NAME_1ST_LEVEL;
 -- CAGG on hypertable (1st level)
 --
 CREATE MATERIALIZED VIEW :CAGG_NAME_1ST_LEVEL
-WITH (timescaledb.continuous) AS
+WITH (timescaledb.continuous, timescaledb.materialized_only=false) AS
 SELECT
   \if :IS_TIME_DIMENSION_WITH_TIMEZONE_1ST
     time_bucket(:BUCKET_WIDTH_1ST, "time", :'BUCKET_TZNAME_1ST') AS bucket,
@@ -5373,7 +5373,7 @@ UNION ALL
 \echo :WARNING_MESSAGE
 -- SHOULD WORK
 CREATE MATERIALIZED VIEW :CAGG_NAME_2TH_LEVEL
-WITH (timescaledb.continuous) AS
+WITH (timescaledb.continuous, timescaledb.materialized_only=false) AS
 SELECT
   \if :IS_TIME_DIMENSION_WITH_TIMEZONE_2TH
     time_bucket(:BUCKET_WIDTH_2TH, "bucket", :'BUCKET_TZNAME_2TH') AS bucket,
@@ -5412,7 +5412,7 @@ UNION ALL
   CALL refresh_continuous_aggregate(:'CAGG_NAME_1ST_LEVEL', NULL, NULL);
   CALL refresh_continuous_aggregate(:'CAGG_NAME_2TH_LEVEL', NULL, NULL);
   CREATE MATERIALIZED VIEW :CAGG_NAME_3TH_LEVEL
-  WITH (timescaledb.continuous) AS
+  WITH (timescaledb.continuous, timescaledb.materialized_only=false) AS
   SELECT
     \if :IS_TIME_DIMENSION_WITH_TIMEZONE_2TH
       time_bucket(:BUCKET_WIDTH_3TH, "bucket", :'BUCKET_TZNAME_2TH') AS bucket
@@ -5447,7 +5447,7 @@ DROP MATERIALIZED VIEW IF EXISTS :CAGG_NAME_1ST_LEVEL;
 -- CAGG on hypertable (1st level)
 --
 CREATE MATERIALIZED VIEW :CAGG_NAME_1ST_LEVEL
-WITH (timescaledb.continuous) AS
+WITH (timescaledb.continuous, timescaledb.materialized_only=false) AS
 SELECT
   \if :IS_TIME_DIMENSION_WITH_TIMEZONE_1ST
     time_bucket(:BUCKET_WIDTH_1ST, "time", :'BUCKET_TZNAME_1ST') AS bucket,
@@ -5484,7 +5484,7 @@ UNION ALL
 \echo :WARNING_MESSAGE
 -- SHOULD WORK
 CREATE MATERIALIZED VIEW :CAGG_NAME_2TH_LEVEL
-WITH (timescaledb.continuous) AS
+WITH (timescaledb.continuous, timescaledb.materialized_only=false) AS
 SELECT
   \if :IS_TIME_DIMENSION_WITH_TIMEZONE_2TH
     time_bucket(:BUCKET_WIDTH_2TH, "bucket", :'BUCKET_TZNAME_2TH') AS bucket,
@@ -5508,7 +5508,7 @@ DETAIL:  Time bucket width of "public.conditions_summary_2" [@ 0.00116 secs] sho
   CALL refresh_continuous_aggregate(:'CAGG_NAME_1ST_LEVEL', NULL, NULL);
   CALL refresh_continuous_aggregate(:'CAGG_NAME_2TH_LEVEL', NULL, NULL);
   CREATE MATERIALIZED VIEW :CAGG_NAME_3TH_LEVEL
-  WITH (timescaledb.continuous) AS
+  WITH (timescaledb.continuous, timescaledb.materialized_only=false) AS
   SELECT
     \if :IS_TIME_DIMENSION_WITH_TIMEZONE_2TH
       time_bucket(:BUCKET_WIDTH_3TH, "bucket", :'BUCKET_TZNAME_2TH') AS bucket

--- a/tsl/test/expected/cagg_permissions.out
+++ b/tsl/test/expected/cagg_permissions.out
@@ -50,7 +50,7 @@ SELECT set_integer_now_func('conditions', 'integer_now_test1');
 (1 row)
 
 CREATE MATERIALIZED VIEW mat_refresh_test
-WITH (timescaledb.continuous)
+WITH (timescaledb.continuous, timescaledb.materialized_only=false)
 as
 select location, max(humidity)
 from conditions
@@ -298,7 +298,7 @@ SELECT create_hypertable('test_default_privileges.devices', 'time');
 (1 row)
 
 CREATE MATERIALIZED VIEW test_default_privileges.devices_summary
-WITH (timescaledb.continuous)
+WITH (timescaledb.continuous, timescaledb.materialized_only=false)
 AS
 SELECT time_bucket('1 day', time) AS bucket, device, MAX(temp)
 FROM test_default_privileges.devices

--- a/tsl/test/expected/cagg_query-13.out
+++ b/tsl/test/expected/cagg_query-13.out
@@ -42,7 +42,7 @@ insert into location_tab values( 1, 'SFO');
 insert into location_tab values( 2, 'NYC');
 insert into location_tab values( 3, 'por');
 create materialized view mat_m1( location, timec, minl, sumt , sumh)
-WITH (timescaledb.continuous)
+WITH (timescaledb.continuous, timescaledb.materialized_only=false)
 as
 select location, time_bucket('1day', timec), min(location), sum(temperature),sum(humidity)
 from conditions
@@ -58,7 +58,7 @@ FROM ( select max(timec)as timeval from conditions ) as q;
 CALL refresh_continuous_aggregate('mat_m1', NULL, NULL);
 --test first/last
 create materialized view mat_m2(location, timec, firsth, lasth, maxtemp, mintemp)
-WITH (timescaledb.continuous)
+WITH (timescaledb.continuous, timescaledb.materialized_only=false)
 as
 select location, time_bucket('1day', timec), first(humidity, timec), last(humidity, timec), max(temperature), min(temperature)
 from conditions

--- a/tsl/test/expected/cagg_query-14.out
+++ b/tsl/test/expected/cagg_query-14.out
@@ -42,7 +42,7 @@ insert into location_tab values( 1, 'SFO');
 insert into location_tab values( 2, 'NYC');
 insert into location_tab values( 3, 'por');
 create materialized view mat_m1( location, timec, minl, sumt , sumh)
-WITH (timescaledb.continuous)
+WITH (timescaledb.continuous, timescaledb.materialized_only=false)
 as
 select location, time_bucket('1day', timec), min(location), sum(temperature),sum(humidity)
 from conditions
@@ -58,7 +58,7 @@ FROM ( select max(timec)as timeval from conditions ) as q;
 CALL refresh_continuous_aggregate('mat_m1', NULL, NULL);
 --test first/last
 create materialized view mat_m2(location, timec, firsth, lasth, maxtemp, mintemp)
-WITH (timescaledb.continuous)
+WITH (timescaledb.continuous, timescaledb.materialized_only=false)
 as
 select location, time_bucket('1day', timec), first(humidity, timec), last(humidity, timec), max(temperature), min(temperature)
 from conditions

--- a/tsl/test/expected/cagg_query-15.out
+++ b/tsl/test/expected/cagg_query-15.out
@@ -42,7 +42,7 @@ insert into location_tab values( 1, 'SFO');
 insert into location_tab values( 2, 'NYC');
 insert into location_tab values( 3, 'por');
 create materialized view mat_m1( location, timec, minl, sumt , sumh)
-WITH (timescaledb.continuous)
+WITH (timescaledb.continuous, timescaledb.materialized_only=false)
 as
 select location, time_bucket('1day', timec), min(location), sum(temperature),sum(humidity)
 from conditions
@@ -58,7 +58,7 @@ FROM ( select max(timec)as timeval from conditions ) as q;
 CALL refresh_continuous_aggregate('mat_m1', NULL, NULL);
 --test first/last
 create materialized view mat_m2(location, timec, firsth, lasth, maxtemp, mintemp)
-WITH (timescaledb.continuous)
+WITH (timescaledb.continuous, timescaledb.materialized_only=false)
 as
 select location, time_bucket('1day', timec), first(humidity, timec), last(humidity, timec), max(temperature), min(temperature)
 from conditions

--- a/tsl/test/expected/cagg_repair.out
+++ b/tsl/test/expected/cagg_repair.out
@@ -274,7 +274,7 @@ SELECT * FROM conditions_summary ORDER BY bucket, device_name;
 
 -- Tests without join
 CREATE MATERIALIZED VIEW conditions_summary_nojoin
-WITH (timescaledb.continuous) AS
+WITH (timescaledb.continuous, timescaledb.materialized_only=false) AS
 SELECT
     time_bucket(INTERVAL '1 week', "time") AS bucket,
     MIN(temperature),
@@ -313,7 +313,7 @@ UNION ALL
 
 -- Tests with old cagg format
 CREATE MATERIALIZED VIEW conditions_summary_old_format
-WITH (timescaledb.continuous, timescaledb.finalized=false) AS
+WITH (timescaledb.continuous, timescaledb.materialized_only=false, timescaledb.finalized=false) AS
 SELECT
     time_bucket(INTERVAL '1 week', "time") AS bucket,
     MIN(temperature),

--- a/tsl/test/expected/cagg_union_view-13.out
+++ b/tsl/test/expected/cagg_union_view-13.out
@@ -25,7 +25,7 @@ INSERT INTO metrics(time, device_id, value) SELECT '2000-01-01'::timestamptz, de
 --
 -- check default view for new continuous aggregate
 CREATE MATERIALIZED VIEW metrics_summary
-  WITH (timescaledb.continuous)
+  WITH (timescaledb.continuous, timescaledb.materialized_only=false)
 AS
   SELECT time_bucket('1d',time), avg(value) FROM metrics GROUP BY 1 WITH NO DATA;
 ALTER TABLE metrics DROP COLUMN f2;
@@ -338,7 +338,7 @@ SELECT set_integer_now_func('boundary_test','boundary_test_int_now');
 (1 row)
 
 CREATE MATERIALIZED VIEW boundary_view
-  WITH (timescaledb.continuous)
+  WITH (timescaledb.continuous, timescaledb.materialized_only=false)
 AS
   SELECT time_bucket(10,time), avg(value) FROM boundary_test GROUP BY 1 WITH NO DATA;
 INSERT INTO boundary_test SELECT i, i*10 FROM generate_series(10,40,10) AS g(i);
@@ -453,7 +453,7 @@ SELECT set_integer_now_func('ht_intdata', 'integer_now_ht_intdata');
 (1 row)
 
 CREATE MATERIALIZED VIEW mat_m1(a, countb, sumbc, spreadcb, avgc)
-WITH (timescaledb.continuous)
+WITH (timescaledb.continuous, timescaledb.materialized_only=false)
 AS
 SELECT time_bucket(1, a), count(*), sum(b+c), max(c)-min(b), avg(c)::int
 FROM ht_intdata
@@ -530,7 +530,7 @@ DROP MATERIALIZED VIEW mat_m1;
 NOTICE:  drop cascades to table _timescaledb_internal._hyper_8_12_chunk
 --- TEST union view with multiple WHERE and HAVING clauses
 CREATE MATERIALIZED VIEW mat_m1
-WITH (timescaledb.continuous)
+WITH (timescaledb.continuous, timescaledb.materialized_only=false)
 AS
 SELECT time_bucket(5, a), sum(b+c)
 FROM ht_intdata
@@ -695,37 +695,37 @@ SELECT set_integer_now_func('bigint_table', 'bigint_now');
 (1 row)
 
 CREATE MATERIALIZED VIEW smallint_agg
-WITH (timescaledb.continuous)
+WITH (timescaledb.continuous, timescaledb.materialized_only=false)
 AS
 SELECT time_bucket(SMALLINT '10', time) AS bucket, avg(value)
 FROM smallint_table
 GROUP BY 1 WITH NO DATA;
 CREATE MATERIALIZED VIEW int_agg
-WITH (timescaledb.continuous)
+WITH (timescaledb.continuous, timescaledb.materialized_only=false)
 AS
 SELECT time_bucket(5, time) AS bucket, avg(value)
 FROM int_table
 GROUP BY 1 WITH NO DATA;
 CREATE MATERIALIZED VIEW bigint_agg
-WITH (timescaledb.continuous)
+WITH (timescaledb.continuous, timescaledb.materialized_only=false)
 AS
 SELECT time_bucket(BIGINT '10', time) AS bucket, avg(value)
 FROM bigint_table
 GROUP BY 1 WITH NO DATA;
 CREATE MATERIALIZED VIEW date_agg
-WITH (timescaledb.continuous)
+WITH (timescaledb.continuous, timescaledb.materialized_only=false)
 AS
 SELECT time_bucket('2 days', time) AS bucket, avg(value)
 FROM date_table
 GROUP BY 1 WITH NO DATA;
 CREATE MATERIALIZED VIEW timestamp_agg
-WITH (timescaledb.continuous)
+WITH (timescaledb.continuous, timescaledb.materialized_only=false)
 AS
 SELECT time_bucket('2 days', time) AS bucket, avg(value)
 FROM timestamp_table
 GROUP BY 1 WITH NO DATA;
 CREATE MATERIALIZED VIEW timestamptz_agg
-WITH (timescaledb.continuous)
+WITH (timescaledb.continuous, timescaledb.materialized_only=false)
 AS
 SELECT time_bucket('2 days', time) AS bucket, avg(value)
 FROM timestamptz_table

--- a/tsl/test/expected/cagg_union_view-14.out
+++ b/tsl/test/expected/cagg_union_view-14.out
@@ -25,7 +25,7 @@ INSERT INTO metrics(time, device_id, value) SELECT '2000-01-01'::timestamptz, de
 --
 -- check default view for new continuous aggregate
 CREATE MATERIALIZED VIEW metrics_summary
-  WITH (timescaledb.continuous)
+  WITH (timescaledb.continuous, timescaledb.materialized_only=false)
 AS
   SELECT time_bucket('1d',time), avg(value) FROM metrics GROUP BY 1 WITH NO DATA;
 ALTER TABLE metrics DROP COLUMN f2;
@@ -338,7 +338,7 @@ SELECT set_integer_now_func('boundary_test','boundary_test_int_now');
 (1 row)
 
 CREATE MATERIALIZED VIEW boundary_view
-  WITH (timescaledb.continuous)
+  WITH (timescaledb.continuous, timescaledb.materialized_only=false)
 AS
   SELECT time_bucket(10,time), avg(value) FROM boundary_test GROUP BY 1 WITH NO DATA;
 INSERT INTO boundary_test SELECT i, i*10 FROM generate_series(10,40,10) AS g(i);
@@ -453,7 +453,7 @@ SELECT set_integer_now_func('ht_intdata', 'integer_now_ht_intdata');
 (1 row)
 
 CREATE MATERIALIZED VIEW mat_m1(a, countb, sumbc, spreadcb, avgc)
-WITH (timescaledb.continuous)
+WITH (timescaledb.continuous, timescaledb.materialized_only=false)
 AS
 SELECT time_bucket(1, a), count(*), sum(b+c), max(c)-min(b), avg(c)::int
 FROM ht_intdata
@@ -530,7 +530,7 @@ DROP MATERIALIZED VIEW mat_m1;
 NOTICE:  drop cascades to table _timescaledb_internal._hyper_8_12_chunk
 --- TEST union view with multiple WHERE and HAVING clauses
 CREATE MATERIALIZED VIEW mat_m1
-WITH (timescaledb.continuous)
+WITH (timescaledb.continuous, timescaledb.materialized_only=false)
 AS
 SELECT time_bucket(5, a), sum(b+c)
 FROM ht_intdata
@@ -695,37 +695,37 @@ SELECT set_integer_now_func('bigint_table', 'bigint_now');
 (1 row)
 
 CREATE MATERIALIZED VIEW smallint_agg
-WITH (timescaledb.continuous)
+WITH (timescaledb.continuous, timescaledb.materialized_only=false)
 AS
 SELECT time_bucket(SMALLINT '10', time) AS bucket, avg(value)
 FROM smallint_table
 GROUP BY 1 WITH NO DATA;
 CREATE MATERIALIZED VIEW int_agg
-WITH (timescaledb.continuous)
+WITH (timescaledb.continuous, timescaledb.materialized_only=false)
 AS
 SELECT time_bucket(5, time) AS bucket, avg(value)
 FROM int_table
 GROUP BY 1 WITH NO DATA;
 CREATE MATERIALIZED VIEW bigint_agg
-WITH (timescaledb.continuous)
+WITH (timescaledb.continuous, timescaledb.materialized_only=false)
 AS
 SELECT time_bucket(BIGINT '10', time) AS bucket, avg(value)
 FROM bigint_table
 GROUP BY 1 WITH NO DATA;
 CREATE MATERIALIZED VIEW date_agg
-WITH (timescaledb.continuous)
+WITH (timescaledb.continuous, timescaledb.materialized_only=false)
 AS
 SELECT time_bucket('2 days', time) AS bucket, avg(value)
 FROM date_table
 GROUP BY 1 WITH NO DATA;
 CREATE MATERIALIZED VIEW timestamp_agg
-WITH (timescaledb.continuous)
+WITH (timescaledb.continuous, timescaledb.materialized_only=false)
 AS
 SELECT time_bucket('2 days', time) AS bucket, avg(value)
 FROM timestamp_table
 GROUP BY 1 WITH NO DATA;
 CREATE MATERIALIZED VIEW timestamptz_agg
-WITH (timescaledb.continuous)
+WITH (timescaledb.continuous, timescaledb.materialized_only=false)
 AS
 SELECT time_bucket('2 days', time) AS bucket, avg(value)
 FROM timestamptz_table

--- a/tsl/test/expected/cagg_union_view-15.out
+++ b/tsl/test/expected/cagg_union_view-15.out
@@ -25,7 +25,7 @@ INSERT INTO metrics(time, device_id, value) SELECT '2000-01-01'::timestamptz, de
 --
 -- check default view for new continuous aggregate
 CREATE MATERIALIZED VIEW metrics_summary
-  WITH (timescaledb.continuous)
+  WITH (timescaledb.continuous, timescaledb.materialized_only=false)
 AS
   SELECT time_bucket('1d',time), avg(value) FROM metrics GROUP BY 1 WITH NO DATA;
 ALTER TABLE metrics DROP COLUMN f2;
@@ -338,7 +338,7 @@ SELECT set_integer_now_func('boundary_test','boundary_test_int_now');
 (1 row)
 
 CREATE MATERIALIZED VIEW boundary_view
-  WITH (timescaledb.continuous)
+  WITH (timescaledb.continuous, timescaledb.materialized_only=false)
 AS
   SELECT time_bucket(10,time), avg(value) FROM boundary_test GROUP BY 1 WITH NO DATA;
 INSERT INTO boundary_test SELECT i, i*10 FROM generate_series(10,40,10) AS g(i);
@@ -455,7 +455,7 @@ SELECT set_integer_now_func('ht_intdata', 'integer_now_ht_intdata');
 (1 row)
 
 CREATE MATERIALIZED VIEW mat_m1(a, countb, sumbc, spreadcb, avgc)
-WITH (timescaledb.continuous)
+WITH (timescaledb.continuous, timescaledb.materialized_only=false)
 AS
 SELECT time_bucket(1, a), count(*), sum(b+c), max(c)-min(b), avg(c)::int
 FROM ht_intdata
@@ -532,7 +532,7 @@ DROP MATERIALIZED VIEW mat_m1;
 NOTICE:  drop cascades to table _timescaledb_internal._hyper_8_12_chunk
 --- TEST union view with multiple WHERE and HAVING clauses
 CREATE MATERIALIZED VIEW mat_m1
-WITH (timescaledb.continuous)
+WITH (timescaledb.continuous, timescaledb.materialized_only=false)
 AS
 SELECT time_bucket(5, a), sum(b+c)
 FROM ht_intdata
@@ -698,37 +698,37 @@ SELECT set_integer_now_func('bigint_table', 'bigint_now');
 (1 row)
 
 CREATE MATERIALIZED VIEW smallint_agg
-WITH (timescaledb.continuous)
+WITH (timescaledb.continuous, timescaledb.materialized_only=false)
 AS
 SELECT time_bucket(SMALLINT '10', time) AS bucket, avg(value)
 FROM smallint_table
 GROUP BY 1 WITH NO DATA;
 CREATE MATERIALIZED VIEW int_agg
-WITH (timescaledb.continuous)
+WITH (timescaledb.continuous, timescaledb.materialized_only=false)
 AS
 SELECT time_bucket(5, time) AS bucket, avg(value)
 FROM int_table
 GROUP BY 1 WITH NO DATA;
 CREATE MATERIALIZED VIEW bigint_agg
-WITH (timescaledb.continuous)
+WITH (timescaledb.continuous, timescaledb.materialized_only=false)
 AS
 SELECT time_bucket(BIGINT '10', time) AS bucket, avg(value)
 FROM bigint_table
 GROUP BY 1 WITH NO DATA;
 CREATE MATERIALIZED VIEW date_agg
-WITH (timescaledb.continuous)
+WITH (timescaledb.continuous, timescaledb.materialized_only=false)
 AS
 SELECT time_bucket('2 days', time) AS bucket, avg(value)
 FROM date_table
 GROUP BY 1 WITH NO DATA;
 CREATE MATERIALIZED VIEW timestamp_agg
-WITH (timescaledb.continuous)
+WITH (timescaledb.continuous, timescaledb.materialized_only=false)
 AS
 SELECT time_bucket('2 days', time) AS bucket, avg(value)
 FROM timestamp_table
 GROUP BY 1 WITH NO DATA;
 CREATE MATERIALIZED VIEW timestamptz_agg
-WITH (timescaledb.continuous)
+WITH (timescaledb.continuous, timescaledb.materialized_only=false)
 AS
 SELECT time_bucket('2 days', time) AS bucket, avg(value)
 FROM timestamptz_table

--- a/tsl/test/expected/cagg_watermark.out
+++ b/tsl/test/expected/cagg_watermark.out
@@ -227,7 +227,7 @@ SELECT set_integer_now_func('ca_inval_test', 'integer_now_test2');
 (1 row)
 
 CREATE MATERIALIZED VIEW cit_view
-    WITH ( timescaledb.continuous)
+    WITH (timescaledb.continuous, timescaledb.materialized_only=false)
     AS SELECT time_bucket('5', time), COUNT(time)
         FROM ca_inval_test
         GROUP BY 1 WITH NO DATA;
@@ -326,7 +326,7 @@ SELECT set_integer_now_func('ts_continuous_test', 'integer_now_test3');
 INSERT INTO ts_continuous_test SELECT i, i FROM
     (SELECT generate_series(0, 29) AS i) AS i;
 CREATE MATERIALIZED VIEW continuous_view
-    WITH ( timescaledb.continuous)
+    WITH (timescaledb.continuous, timescaledb.materialized_only=false)
     AS SELECT time_bucket('5', time), COUNT(location)
         FROM ts_continuous_test
         GROUP BY 1 WITH NO DATA;

--- a/tsl/test/expected/chunk_utils_internal.out
+++ b/tsl/test/expected/chunk_utils_internal.out
@@ -381,7 +381,7 @@ SELECT set_integer_now_func('test1.hyper1', 'hyper_dummy_now');
  
 (1 row)
 
-CREATE MATERIALIZED VIEW hyper1_cagg WITH (timescaledb.continuous)
+CREATE MATERIALIZED VIEW hyper1_cagg WITH (timescaledb.continuous, timescaledb.materialized_only=false)
 AS SELECT time_bucket( 5, "time") as bucket, count(*)
 FROM test1.hyper1 GROUP BY 1;
 NOTICE:  refreshing continuous aggregate "hyper1_cagg"

--- a/tsl/test/expected/continuous_aggs-13.out
+++ b/tsl/test/expected/continuous_aggs-13.out
@@ -1175,7 +1175,7 @@ SELECT * FROM mat_refresh_test order by 1,2 ;
 (4 rows)
 
 -- test for bug when group by is not in project list
-CREATE MATERIALIZED VIEW conditions_grpby_view with (timescaledb.continuous) as
+CREATE MATERIALIZED VIEW conditions_grpby_view with (timescaledb.continuous, timescaledb.materialized_only=false) as
 select time_bucket(100, timec),  sum(humidity)
 from conditions
 group by time_bucket(100, timec), location;
@@ -1189,7 +1189,7 @@ select * from conditions_grpby_view order by 1, 2;
          200 |  75
 (4 rows)
 
-CREATE MATERIALIZED VIEW conditions_grpby_view2 with (timescaledb.continuous) as
+CREATE MATERIALIZED VIEW conditions_grpby_view2 with (timescaledb.continuous, timescaledb.materialized_only=false) as
 select time_bucket(100, timec), sum(humidity)
 from conditions
 group by time_bucket(100, timec), location
@@ -1238,7 +1238,7 @@ SELECT
   'yellow',
   '{foo,bar,baz}',
   '{1,2.5,3}';
-CREATE MATERIALIZED VIEW mat_types WITH (timescaledb.continuous) AS
+CREATE MATERIALIZED VIEW mat_types WITH (timescaledb.continuous, timescaledb.materialized_only=false) AS
 SELECT
   time_bucket('1d', time),
   min(status) AS status,
@@ -1405,7 +1405,7 @@ NOTICE:  adding not-null constraint to column "time"
 
 insert into raw_data select '2000-01-01','Q1';
 --having has exprs that appear in select
-CREATE MATERIALIZED VIEW search_query_count_1m WITH (timescaledb.continuous)
+CREATE MATERIALIZED VIEW search_query_count_1m WITH (timescaledb.continuous, timescaledb.materialized_only=false)
 AS
  SELECT  search_query,count(search_query) as count,
          time_bucket(INTERVAL '1 minute', time) AS bucket
@@ -1414,7 +1414,7 @@ AS
  GROUP BY search_query, bucket HAVING count(search_query) > 3 OR sum(cnt) > 1;
 NOTICE:  refreshing continuous aggregate "search_query_count_1m"
 --having has aggregates + grp by columns that appear in select
-CREATE MATERIALIZED VIEW search_query_count_2 WITH (timescaledb.continuous)
+CREATE MATERIALIZED VIEW search_query_count_2 WITH (timescaledb.continuous, timescaledb.materialized_only=false)
 AS
  SELECT  search_query,count(search_query) as count, sum(cnt),
          time_bucket(INTERVAL '1 minute', time) AS bucket
@@ -1425,7 +1425,7 @@ HAVING count(search_query) > 3 OR sum(cnt) > 1 OR
        ( sum(cnt) + count(cnt)) > 1
        AND search_query = 'Q1';
 NOTICE:  refreshing continuous aggregate "search_query_count_2"
-CREATE MATERIALIZED VIEW search_query_count_3 WITH (timescaledb.continuous)
+CREATE MATERIALIZED VIEW search_query_count_3 WITH (timescaledb.continuous, timescaledb.materialized_only=false)
 AS
  SELECT  search_query,count(search_query) as count, sum(cnt),
          time_bucket(INTERVAL '1 minute', time) AS bucket
@@ -1639,7 +1639,7 @@ SELECT create_hypertable('test_morecols', 'time', chunk_time_interval=> '7 days'
 
 INSERT INTO test_morecols
 SELECT generate_series('2018-12-01 00:00'::timestamp, '2018-12-31 00:00'::timestamp, '1 day'), 55, 75, 40, 70, NULL, 100, 200, 200;
-CREATE MATERIALIZED VIEW test_morecols_cagg with (timescaledb.continuous)
+CREATE MATERIALIZED VIEW test_morecols_cagg with (timescaledb.continuous, timescaledb.materialized_only=false)
 AS SELECT time_bucket('30 days',time), avg(val1),  count(val2)
  FROM test_morecols GROUP BY 1;
 NOTICE:  refreshing continuous aggregate "test_morecols_cagg"
@@ -1701,7 +1701,7 @@ SELECT time, device_id, device_id, device_id + 2, device_id + 0.5, NULL
 FROM generate_series('2000-01-13 0:00:00+0'::timestamptz,'2000-01-19 23:55:00+0','8h') gtime(time),
      generate_series(1,5,1) gdevice(device_id);
 ANALYZE issue3248;
-CREATE materialized view issue3248_cagg WITH (timescaledb.continuous)
+CREATE materialized view issue3248_cagg WITH (timescaledb.continuous, timescaledb.materialized_only=false)
 AS SELECT time_bucket('1h',time), device_id, min(v0), max(v1), avg(v2)
 FROM issue3248 GROUP BY 1,2;
 NOTICE:  refreshing continuous aggregate "issue3248_cagg"
@@ -1728,7 +1728,7 @@ insert into test_group_idx
 select t, round(random()*10), random()*5
 from generate_series('2020-01-01', '2020-02-25', INTERVAL '12 hours') t;
 create materialized view cagg_index_true
-with (timescaledb.continuous, timescaledb.create_group_indexes=true) as
+with (timescaledb.continuous, timescaledb.materialized_only=false, timescaledb.create_group_indexes=true) as
 select
 	time_bucket('1 day', "time") as bucket,
 	sum(value),
@@ -1737,7 +1737,7 @@ from test_group_idx
 group by bucket, symbol;
 NOTICE:  refreshing continuous aggregate "cagg_index_true"
 create materialized view cagg_index_false
-with (timescaledb.continuous, timescaledb.create_group_indexes=false) as
+with (timescaledb.continuous, timescaledb.materialized_only=false, timescaledb.create_group_indexes=false) as
 select
 	time_bucket('1 day', "time") as bucket,
 	sum(value),
@@ -1746,7 +1746,7 @@ from test_group_idx
 group by bucket, symbol;
 NOTICE:  refreshing continuous aggregate "cagg_index_false"
 create materialized view cagg_index_default
-with (timescaledb.continuous) as
+with (timescaledb.continuous, timescaledb.materialized_only=false) as
 select
 	time_bucket('1 day', "time") as bucket,
 	sum(value),
@@ -1838,7 +1838,7 @@ VALUES
   ('2018-11-02 09:00:00-08', 'NYC', 35, 15),
   ('2018-11-03 09:00:00-08', 'NYC', 35, 25);
 -- aggregate with DISTINCT
-CREATE MATERIALIZED VIEW mat_m1 WITH (timescaledb.continuous)
+CREATE MATERIALIZED VIEW mat_m1 WITH (timescaledb.continuous, timescaledb.materialized_only=false)
 AS
 SELECT
   time_bucket('1week', timec),
@@ -1860,7 +1860,7 @@ SELECT * FROM mat_m1 ORDER BY 1, 2, 3;
 -- aggregate with FILTER
 DROP MATERIALIZED VIEW mat_m1;
 NOTICE:  drop cascades to 2 other objects
-CREATE MATERIALIZED VIEW mat_m1 WITH (timescaledb.continuous)
+CREATE MATERIALIZED VIEW mat_m1 WITH (timescaledb.continuous, timescaledb.materialized_only=false)
 AS
 SELECT
   time_bucket('1week', timec),
@@ -1881,7 +1881,7 @@ SELECT * FROM mat_m1 ORDER BY 1, 2;
 -- aggregate with filter in having clause
 DROP MATERIALIZED VIEW mat_m1;
 NOTICE:  drop cascades to 2 other objects
-CREATE MATERIALIZED VIEW mat_m1 WITH (timescaledb.continuous)
+CREATE MATERIALIZED VIEW mat_m1 WITH (timescaledb.continuous, timescaledb.materialized_only=false)
 AS
 SELECT
   time_bucket('1week', timec),
@@ -1902,7 +1902,7 @@ SELECT * FROM mat_m1 ORDER BY 1, 2;
 -- ordered set aggr
 DROP MATERIALIZED VIEW mat_m1;
 NOTICE:  drop cascades to table _timescaledb_internal._hyper_55_116_chunk
-CREATE MATERIALIZED VIEW mat_m1 WITH (timescaledb.continuous)
+CREATE MATERIALIZED VIEW mat_m1 WITH (timescaledb.continuous, timescaledb.materialized_only=false)
 AS
 SELECT
   time_bucket('1week', timec),
@@ -1921,7 +1921,7 @@ SELECT * FROM mat_m1 ORDER BY 1;
 -- hypothetical-set aggr
 DROP MATERIALIZED VIEW mat_m1;
 NOTICE:  drop cascades to 2 other objects
-CREATE MATERIALIZED VIEW mat_m1 WITH (timescaledb.continuous)
+CREATE MATERIALIZED VIEW mat_m1 WITH (timescaledb.continuous, timescaledb.materialized_only=false)
 AS
 SELECT
   time_bucket('1week', timec),
@@ -1949,7 +1949,7 @@ CREATE AGGREGATE newavg (
   finalfunc = int8_avg,
   initcond1 = '{0,0}'
 );
-CREATE MATERIALIZED VIEW mat_m1 WITH (timescaledb.continuous)
+CREATE MATERIALIZED VIEW mat_m1 WITH (timescaledb.continuous, timescaledb.materialized_only=false)
 AS
 SELECT
   SUM(humidity),
@@ -1970,7 +1970,7 @@ SELECT * FROM mat_m1 ORDER BY 1, 2;
 -- ORDER BY in the view definition
 DROP MATERIALIZED VIEW mat_m1;
 NOTICE:  drop cascades to 2 other objects
-CREATE MATERIALIZED VIEW mat_m1 WITH (timescaledb.continuous)
+CREATE MATERIALIZED VIEW mat_m1 WITH (timescaledb.continuous, timescaledb.materialized_only=false)
 AS
 SELECT
   time_bucket('1week', timec),
@@ -2300,7 +2300,7 @@ SELECT table_name FROM create_hypertable('conditions', 'timec');
 
 INSERT INTO conditions
 SELECT t, 10 FROM generate_series('2023-01-01 00:00-03'::timestamptz, '2023-12-31 23:59-03'::timestamptz, '1 hour'::interval) AS t;
-CREATE MATERIALIZED VIEW conditions_daily WITH (timescaledb.continuous)
+CREATE MATERIALIZED VIEW conditions_daily WITH (timescaledb.continuous, timescaledb.materialized_only=false)
 AS
 SELECT
   time_bucket('1 day', timec),

--- a/tsl/test/expected/continuous_aggs-14.out
+++ b/tsl/test/expected/continuous_aggs-14.out
@@ -1175,7 +1175,7 @@ SELECT * FROM mat_refresh_test order by 1,2 ;
 (4 rows)
 
 -- test for bug when group by is not in project list
-CREATE MATERIALIZED VIEW conditions_grpby_view with (timescaledb.continuous) as
+CREATE MATERIALIZED VIEW conditions_grpby_view with (timescaledb.continuous, timescaledb.materialized_only=false) as
 select time_bucket(100, timec),  sum(humidity)
 from conditions
 group by time_bucket(100, timec), location;
@@ -1189,7 +1189,7 @@ select * from conditions_grpby_view order by 1, 2;
          200 |  75
 (4 rows)
 
-CREATE MATERIALIZED VIEW conditions_grpby_view2 with (timescaledb.continuous) as
+CREATE MATERIALIZED VIEW conditions_grpby_view2 with (timescaledb.continuous, timescaledb.materialized_only=false) as
 select time_bucket(100, timec), sum(humidity)
 from conditions
 group by time_bucket(100, timec), location
@@ -1238,7 +1238,7 @@ SELECT
   'yellow',
   '{foo,bar,baz}',
   '{1,2.5,3}';
-CREATE MATERIALIZED VIEW mat_types WITH (timescaledb.continuous) AS
+CREATE MATERIALIZED VIEW mat_types WITH (timescaledb.continuous, timescaledb.materialized_only=false) AS
 SELECT
   time_bucket('1d', time),
   min(status) AS status,
@@ -1405,7 +1405,7 @@ NOTICE:  adding not-null constraint to column "time"
 
 insert into raw_data select '2000-01-01','Q1';
 --having has exprs that appear in select
-CREATE MATERIALIZED VIEW search_query_count_1m WITH (timescaledb.continuous)
+CREATE MATERIALIZED VIEW search_query_count_1m WITH (timescaledb.continuous, timescaledb.materialized_only=false)
 AS
  SELECT  search_query,count(search_query) as count,
          time_bucket(INTERVAL '1 minute', time) AS bucket
@@ -1414,7 +1414,7 @@ AS
  GROUP BY search_query, bucket HAVING count(search_query) > 3 OR sum(cnt) > 1;
 NOTICE:  refreshing continuous aggregate "search_query_count_1m"
 --having has aggregates + grp by columns that appear in select
-CREATE MATERIALIZED VIEW search_query_count_2 WITH (timescaledb.continuous)
+CREATE MATERIALIZED VIEW search_query_count_2 WITH (timescaledb.continuous, timescaledb.materialized_only=false)
 AS
  SELECT  search_query,count(search_query) as count, sum(cnt),
          time_bucket(INTERVAL '1 minute', time) AS bucket
@@ -1425,7 +1425,7 @@ HAVING count(search_query) > 3 OR sum(cnt) > 1 OR
        ( sum(cnt) + count(cnt)) > 1
        AND search_query = 'Q1';
 NOTICE:  refreshing continuous aggregate "search_query_count_2"
-CREATE MATERIALIZED VIEW search_query_count_3 WITH (timescaledb.continuous)
+CREATE MATERIALIZED VIEW search_query_count_3 WITH (timescaledb.continuous, timescaledb.materialized_only=false)
 AS
  SELECT  search_query,count(search_query) as count, sum(cnt),
          time_bucket(INTERVAL '1 minute', time) AS bucket
@@ -1638,7 +1638,7 @@ SELECT create_hypertable('test_morecols', 'time', chunk_time_interval=> '7 days'
 
 INSERT INTO test_morecols
 SELECT generate_series('2018-12-01 00:00'::timestamp, '2018-12-31 00:00'::timestamp, '1 day'), 55, 75, 40, 70, NULL, 100, 200, 200;
-CREATE MATERIALIZED VIEW test_morecols_cagg with (timescaledb.continuous)
+CREATE MATERIALIZED VIEW test_morecols_cagg with (timescaledb.continuous, timescaledb.materialized_only=false)
 AS SELECT time_bucket('30 days',time), avg(val1),  count(val2)
  FROM test_morecols GROUP BY 1;
 NOTICE:  refreshing continuous aggregate "test_morecols_cagg"
@@ -1700,7 +1700,7 @@ SELECT time, device_id, device_id, device_id + 2, device_id + 0.5, NULL
 FROM generate_series('2000-01-13 0:00:00+0'::timestamptz,'2000-01-19 23:55:00+0','8h') gtime(time),
      generate_series(1,5,1) gdevice(device_id);
 ANALYZE issue3248;
-CREATE materialized view issue3248_cagg WITH (timescaledb.continuous)
+CREATE materialized view issue3248_cagg WITH (timescaledb.continuous, timescaledb.materialized_only=false)
 AS SELECT time_bucket('1h',time), device_id, min(v0), max(v1), avg(v2)
 FROM issue3248 GROUP BY 1,2;
 NOTICE:  refreshing continuous aggregate "issue3248_cagg"
@@ -1727,7 +1727,7 @@ insert into test_group_idx
 select t, round(random()*10), random()*5
 from generate_series('2020-01-01', '2020-02-25', INTERVAL '12 hours') t;
 create materialized view cagg_index_true
-with (timescaledb.continuous, timescaledb.create_group_indexes=true) as
+with (timescaledb.continuous, timescaledb.materialized_only=false, timescaledb.create_group_indexes=true) as
 select
 	time_bucket('1 day', "time") as bucket,
 	sum(value),
@@ -1736,7 +1736,7 @@ from test_group_idx
 group by bucket, symbol;
 NOTICE:  refreshing continuous aggregate "cagg_index_true"
 create materialized view cagg_index_false
-with (timescaledb.continuous, timescaledb.create_group_indexes=false) as
+with (timescaledb.continuous, timescaledb.materialized_only=false, timescaledb.create_group_indexes=false) as
 select
 	time_bucket('1 day', "time") as bucket,
 	sum(value),
@@ -1745,7 +1745,7 @@ from test_group_idx
 group by bucket, symbol;
 NOTICE:  refreshing continuous aggregate "cagg_index_false"
 create materialized view cagg_index_default
-with (timescaledb.continuous) as
+with (timescaledb.continuous, timescaledb.materialized_only=false) as
 select
 	time_bucket('1 day', "time") as bucket,
 	sum(value),
@@ -1837,7 +1837,7 @@ VALUES
   ('2018-11-02 09:00:00-08', 'NYC', 35, 15),
   ('2018-11-03 09:00:00-08', 'NYC', 35, 25);
 -- aggregate with DISTINCT
-CREATE MATERIALIZED VIEW mat_m1 WITH (timescaledb.continuous)
+CREATE MATERIALIZED VIEW mat_m1 WITH (timescaledb.continuous, timescaledb.materialized_only=false)
 AS
 SELECT
   time_bucket('1week', timec),
@@ -1859,7 +1859,7 @@ SELECT * FROM mat_m1 ORDER BY 1, 2, 3;
 -- aggregate with FILTER
 DROP MATERIALIZED VIEW mat_m1;
 NOTICE:  drop cascades to 2 other objects
-CREATE MATERIALIZED VIEW mat_m1 WITH (timescaledb.continuous)
+CREATE MATERIALIZED VIEW mat_m1 WITH (timescaledb.continuous, timescaledb.materialized_only=false)
 AS
 SELECT
   time_bucket('1week', timec),
@@ -1880,7 +1880,7 @@ SELECT * FROM mat_m1 ORDER BY 1, 2;
 -- aggregate with filter in having clause
 DROP MATERIALIZED VIEW mat_m1;
 NOTICE:  drop cascades to 2 other objects
-CREATE MATERIALIZED VIEW mat_m1 WITH (timescaledb.continuous)
+CREATE MATERIALIZED VIEW mat_m1 WITH (timescaledb.continuous, timescaledb.materialized_only=false)
 AS
 SELECT
   time_bucket('1week', timec),
@@ -1901,7 +1901,7 @@ SELECT * FROM mat_m1 ORDER BY 1, 2;
 -- ordered set aggr
 DROP MATERIALIZED VIEW mat_m1;
 NOTICE:  drop cascades to table _timescaledb_internal._hyper_55_116_chunk
-CREATE MATERIALIZED VIEW mat_m1 WITH (timescaledb.continuous)
+CREATE MATERIALIZED VIEW mat_m1 WITH (timescaledb.continuous, timescaledb.materialized_only=false)
 AS
 SELECT
   time_bucket('1week', timec),
@@ -1920,7 +1920,7 @@ SELECT * FROM mat_m1 ORDER BY 1;
 -- hypothetical-set aggr
 DROP MATERIALIZED VIEW mat_m1;
 NOTICE:  drop cascades to 2 other objects
-CREATE MATERIALIZED VIEW mat_m1 WITH (timescaledb.continuous)
+CREATE MATERIALIZED VIEW mat_m1 WITH (timescaledb.continuous, timescaledb.materialized_only=false)
 AS
 SELECT
   time_bucket('1week', timec),
@@ -1948,7 +1948,7 @@ CREATE AGGREGATE newavg (
   finalfunc = int8_avg,
   initcond1 = '{0,0}'
 );
-CREATE MATERIALIZED VIEW mat_m1 WITH (timescaledb.continuous)
+CREATE MATERIALIZED VIEW mat_m1 WITH (timescaledb.continuous, timescaledb.materialized_only=false)
 AS
 SELECT
   SUM(humidity),
@@ -1969,7 +1969,7 @@ SELECT * FROM mat_m1 ORDER BY 1, 2;
 -- ORDER BY in the view definition
 DROP MATERIALIZED VIEW mat_m1;
 NOTICE:  drop cascades to 2 other objects
-CREATE MATERIALIZED VIEW mat_m1 WITH (timescaledb.continuous)
+CREATE MATERIALIZED VIEW mat_m1 WITH (timescaledb.continuous, timescaledb.materialized_only=false)
 AS
 SELECT
   time_bucket('1week', timec),
@@ -2299,7 +2299,7 @@ SELECT table_name FROM create_hypertable('conditions', 'timec');
 
 INSERT INTO conditions
 SELECT t, 10 FROM generate_series('2023-01-01 00:00-03'::timestamptz, '2023-12-31 23:59-03'::timestamptz, '1 hour'::interval) AS t;
-CREATE MATERIALIZED VIEW conditions_daily WITH (timescaledb.continuous)
+CREATE MATERIALIZED VIEW conditions_daily WITH (timescaledb.continuous, timescaledb.materialized_only=false)
 AS
 SELECT
   time_bucket('1 day', timec),

--- a/tsl/test/expected/continuous_aggs-15.out
+++ b/tsl/test/expected/continuous_aggs-15.out
@@ -1175,7 +1175,7 @@ SELECT * FROM mat_refresh_test order by 1,2 ;
 (4 rows)
 
 -- test for bug when group by is not in project list
-CREATE MATERIALIZED VIEW conditions_grpby_view with (timescaledb.continuous) as
+CREATE MATERIALIZED VIEW conditions_grpby_view with (timescaledb.continuous, timescaledb.materialized_only=false) as
 select time_bucket(100, timec),  sum(humidity)
 from conditions
 group by time_bucket(100, timec), location;
@@ -1189,7 +1189,7 @@ select * from conditions_grpby_view order by 1, 2;
          200 |  75
 (4 rows)
 
-CREATE MATERIALIZED VIEW conditions_grpby_view2 with (timescaledb.continuous) as
+CREATE MATERIALIZED VIEW conditions_grpby_view2 with (timescaledb.continuous, timescaledb.materialized_only=false) as
 select time_bucket(100, timec), sum(humidity)
 from conditions
 group by time_bucket(100, timec), location
@@ -1238,7 +1238,7 @@ SELECT
   'yellow',
   '{foo,bar,baz}',
   '{1,2.5,3}';
-CREATE MATERIALIZED VIEW mat_types WITH (timescaledb.continuous) AS
+CREATE MATERIALIZED VIEW mat_types WITH (timescaledb.continuous, timescaledb.materialized_only=false) AS
 SELECT
   time_bucket('1d', time),
   min(status) AS status,
@@ -1405,7 +1405,7 @@ NOTICE:  adding not-null constraint to column "time"
 
 insert into raw_data select '2000-01-01','Q1';
 --having has exprs that appear in select
-CREATE MATERIALIZED VIEW search_query_count_1m WITH (timescaledb.continuous)
+CREATE MATERIALIZED VIEW search_query_count_1m WITH (timescaledb.continuous, timescaledb.materialized_only=false)
 AS
  SELECT  search_query,count(search_query) as count,
          time_bucket(INTERVAL '1 minute', time) AS bucket
@@ -1414,7 +1414,7 @@ AS
  GROUP BY search_query, bucket HAVING count(search_query) > 3 OR sum(cnt) > 1;
 NOTICE:  refreshing continuous aggregate "search_query_count_1m"
 --having has aggregates + grp by columns that appear in select
-CREATE MATERIALIZED VIEW search_query_count_2 WITH (timescaledb.continuous)
+CREATE MATERIALIZED VIEW search_query_count_2 WITH (timescaledb.continuous, timescaledb.materialized_only=false)
 AS
  SELECT  search_query,count(search_query) as count, sum(cnt),
          time_bucket(INTERVAL '1 minute', time) AS bucket
@@ -1425,7 +1425,7 @@ HAVING count(search_query) > 3 OR sum(cnt) > 1 OR
        ( sum(cnt) + count(cnt)) > 1
        AND search_query = 'Q1';
 NOTICE:  refreshing continuous aggregate "search_query_count_2"
-CREATE MATERIALIZED VIEW search_query_count_3 WITH (timescaledb.continuous)
+CREATE MATERIALIZED VIEW search_query_count_3 WITH (timescaledb.continuous, timescaledb.materialized_only=false)
 AS
  SELECT  search_query,count(search_query) as count, sum(cnt),
          time_bucket(INTERVAL '1 minute', time) AS bucket
@@ -1638,7 +1638,7 @@ SELECT create_hypertable('test_morecols', 'time', chunk_time_interval=> '7 days'
 
 INSERT INTO test_morecols
 SELECT generate_series('2018-12-01 00:00'::timestamp, '2018-12-31 00:00'::timestamp, '1 day'), 55, 75, 40, 70, NULL, 100, 200, 200;
-CREATE MATERIALIZED VIEW test_morecols_cagg with (timescaledb.continuous)
+CREATE MATERIALIZED VIEW test_morecols_cagg with (timescaledb.continuous, timescaledb.materialized_only=false)
 AS SELECT time_bucket('30 days',time), avg(val1),  count(val2)
  FROM test_morecols GROUP BY 1;
 NOTICE:  refreshing continuous aggregate "test_morecols_cagg"
@@ -1700,7 +1700,7 @@ SELECT time, device_id, device_id, device_id + 2, device_id + 0.5, NULL
 FROM generate_series('2000-01-13 0:00:00+0'::timestamptz,'2000-01-19 23:55:00+0','8h') gtime(time),
      generate_series(1,5,1) gdevice(device_id);
 ANALYZE issue3248;
-CREATE materialized view issue3248_cagg WITH (timescaledb.continuous)
+CREATE materialized view issue3248_cagg WITH (timescaledb.continuous, timescaledb.materialized_only=false)
 AS SELECT time_bucket('1h',time), device_id, min(v0), max(v1), avg(v2)
 FROM issue3248 GROUP BY 1,2;
 NOTICE:  refreshing continuous aggregate "issue3248_cagg"
@@ -1727,7 +1727,7 @@ insert into test_group_idx
 select t, round(random()*10), random()*5
 from generate_series('2020-01-01', '2020-02-25', INTERVAL '12 hours') t;
 create materialized view cagg_index_true
-with (timescaledb.continuous, timescaledb.create_group_indexes=true) as
+with (timescaledb.continuous, timescaledb.materialized_only=false, timescaledb.create_group_indexes=true) as
 select
 	time_bucket('1 day', "time") as bucket,
 	sum(value),
@@ -1736,7 +1736,7 @@ from test_group_idx
 group by bucket, symbol;
 NOTICE:  refreshing continuous aggregate "cagg_index_true"
 create materialized view cagg_index_false
-with (timescaledb.continuous, timescaledb.create_group_indexes=false) as
+with (timescaledb.continuous, timescaledb.materialized_only=false, timescaledb.create_group_indexes=false) as
 select
 	time_bucket('1 day', "time") as bucket,
 	sum(value),
@@ -1745,7 +1745,7 @@ from test_group_idx
 group by bucket, symbol;
 NOTICE:  refreshing continuous aggregate "cagg_index_false"
 create materialized view cagg_index_default
-with (timescaledb.continuous) as
+with (timescaledb.continuous, timescaledb.materialized_only=false) as
 select
 	time_bucket('1 day', "time") as bucket,
 	sum(value),
@@ -1837,7 +1837,7 @@ VALUES
   ('2018-11-02 09:00:00-08', 'NYC', 35, 15),
   ('2018-11-03 09:00:00-08', 'NYC', 35, 25);
 -- aggregate with DISTINCT
-CREATE MATERIALIZED VIEW mat_m1 WITH (timescaledb.continuous)
+CREATE MATERIALIZED VIEW mat_m1 WITH (timescaledb.continuous, timescaledb.materialized_only=false)
 AS
 SELECT
   time_bucket('1week', timec),
@@ -1859,7 +1859,7 @@ SELECT * FROM mat_m1 ORDER BY 1, 2, 3;
 -- aggregate with FILTER
 DROP MATERIALIZED VIEW mat_m1;
 NOTICE:  drop cascades to 2 other objects
-CREATE MATERIALIZED VIEW mat_m1 WITH (timescaledb.continuous)
+CREATE MATERIALIZED VIEW mat_m1 WITH (timescaledb.continuous, timescaledb.materialized_only=false)
 AS
 SELECT
   time_bucket('1week', timec),
@@ -1880,7 +1880,7 @@ SELECT * FROM mat_m1 ORDER BY 1, 2;
 -- aggregate with filter in having clause
 DROP MATERIALIZED VIEW mat_m1;
 NOTICE:  drop cascades to 2 other objects
-CREATE MATERIALIZED VIEW mat_m1 WITH (timescaledb.continuous)
+CREATE MATERIALIZED VIEW mat_m1 WITH (timescaledb.continuous, timescaledb.materialized_only=false)
 AS
 SELECT
   time_bucket('1week', timec),
@@ -1901,7 +1901,7 @@ SELECT * FROM mat_m1 ORDER BY 1, 2;
 -- ordered set aggr
 DROP MATERIALIZED VIEW mat_m1;
 NOTICE:  drop cascades to table _timescaledb_internal._hyper_55_116_chunk
-CREATE MATERIALIZED VIEW mat_m1 WITH (timescaledb.continuous)
+CREATE MATERIALIZED VIEW mat_m1 WITH (timescaledb.continuous, timescaledb.materialized_only=false)
 AS
 SELECT
   time_bucket('1week', timec),
@@ -1920,7 +1920,7 @@ SELECT * FROM mat_m1 ORDER BY 1;
 -- hypothetical-set aggr
 DROP MATERIALIZED VIEW mat_m1;
 NOTICE:  drop cascades to 2 other objects
-CREATE MATERIALIZED VIEW mat_m1 WITH (timescaledb.continuous)
+CREATE MATERIALIZED VIEW mat_m1 WITH (timescaledb.continuous, timescaledb.materialized_only=false)
 AS
 SELECT
   time_bucket('1week', timec),
@@ -1948,7 +1948,7 @@ CREATE AGGREGATE newavg (
   finalfunc = int8_avg,
   initcond1 = '{0,0}'
 );
-CREATE MATERIALIZED VIEW mat_m1 WITH (timescaledb.continuous)
+CREATE MATERIALIZED VIEW mat_m1 WITH (timescaledb.continuous, timescaledb.materialized_only=false)
 AS
 SELECT
   SUM(humidity),
@@ -1969,7 +1969,7 @@ SELECT * FROM mat_m1 ORDER BY 1, 2;
 -- ORDER BY in the view definition
 DROP MATERIALIZED VIEW mat_m1;
 NOTICE:  drop cascades to 2 other objects
-CREATE MATERIALIZED VIEW mat_m1 WITH (timescaledb.continuous)
+CREATE MATERIALIZED VIEW mat_m1 WITH (timescaledb.continuous, timescaledb.materialized_only=false)
 AS
 SELECT
   time_bucket('1week', timec),
@@ -2301,7 +2301,7 @@ SELECT table_name FROM create_hypertable('conditions', 'timec');
 
 INSERT INTO conditions
 SELECT t, 10 FROM generate_series('2023-01-01 00:00-03'::timestamptz, '2023-12-31 23:59-03'::timestamptz, '1 hour'::interval) AS t;
-CREATE MATERIALIZED VIEW conditions_daily WITH (timescaledb.continuous)
+CREATE MATERIALIZED VIEW conditions_daily WITH (timescaledb.continuous, timescaledb.materialized_only=false)
 AS
 SELECT
   time_bucket('1 day', timec),

--- a/tsl/test/expected/continuous_aggs_deprecated-13.out
+++ b/tsl/test/expected/continuous_aggs_deprecated-13.out
@@ -1202,7 +1202,7 @@ SELECT * FROM mat_refresh_test order by 1,2 ;
 (4 rows)
 
 -- test for bug when group by is not in project list
-CREATE MATERIALIZED VIEW conditions_grpby_view with (timescaledb.continuous, timescaledb.finalized=false) as
+CREATE MATERIALIZED VIEW conditions_grpby_view with (timescaledb.continuous, timescaledb.materialized_only=false, timescaledb.finalized=false) as
 select time_bucket(100, timec),  sum(humidity)
 from conditions
 group by time_bucket(100, timec), location;
@@ -1216,7 +1216,7 @@ select * from conditions_grpby_view order by 1, 2;
          200 |  75
 (4 rows)
 
-CREATE MATERIALIZED VIEW conditions_grpby_view2 with (timescaledb.continuous, timescaledb.finalized=false) as
+CREATE MATERIALIZED VIEW conditions_grpby_view2 with (timescaledb.continuous, timescaledb.materialized_only=false, timescaledb.finalized=false) as
 select time_bucket(100, timec), sum(humidity)
 from conditions
 group by time_bucket(100, timec), location
@@ -1265,7 +1265,7 @@ SELECT
   'yellow',
   '{foo,bar,baz}',
   '{1,2.5,3}';
-CREATE MATERIALIZED VIEW mat_types WITH (timescaledb.continuous, timescaledb.finalized=false) AS
+CREATE MATERIALIZED VIEW mat_types WITH (timescaledb.continuous, timescaledb.materialized_only=false, timescaledb.finalized=false) AS
 SELECT
   time_bucket('1d', time),
   min(status) AS status,
@@ -1432,7 +1432,7 @@ NOTICE:  adding not-null constraint to column "time"
 
 insert into raw_data select '2000-01-01','Q1';
 --having has exprs that appear in select
-CREATE MATERIALIZED VIEW search_query_count_1m WITH (timescaledb.continuous, timescaledb.finalized=false)
+CREATE MATERIALIZED VIEW search_query_count_1m WITH (timescaledb.continuous, timescaledb.materialized_only=false, timescaledb.finalized=false)
 AS
  SELECT  search_query,count(search_query) as count,
          time_bucket(INTERVAL '1 minute', time) AS bucket
@@ -1441,7 +1441,7 @@ AS
  GROUP BY search_query, bucket HAVING count(search_query) > 3 OR sum(cnt) > 1;
 NOTICE:  refreshing continuous aggregate "search_query_count_1m"
 --having has aggregates + grp by columns that appear in select
-CREATE MATERIALIZED VIEW search_query_count_2 WITH (timescaledb.continuous, timescaledb.finalized=false)
+CREATE MATERIALIZED VIEW search_query_count_2 WITH (timescaledb.continuous, timescaledb.materialized_only=false, timescaledb.finalized=false)
 AS
  SELECT  search_query,count(search_query) as count, sum(cnt),
          time_bucket(INTERVAL '1 minute', time) AS bucket
@@ -1452,7 +1452,7 @@ HAVING count(search_query) > 3 OR sum(cnt) > 1 OR
        ( sum(cnt) + count(cnt)) > 1
        AND search_query = 'Q1';
 NOTICE:  refreshing continuous aggregate "search_query_count_2"
-CREATE MATERIALIZED VIEW search_query_count_3 WITH (timescaledb.continuous, timescaledb.finalized=false)
+CREATE MATERIALIZED VIEW search_query_count_3 WITH (timescaledb.continuous, timescaledb.materialized_only=false, timescaledb.finalized=false)
 AS
  SELECT  search_query,count(search_query) as count, sum(cnt),
          time_bucket(INTERVAL '1 minute', time) AS bucket
@@ -1672,7 +1672,7 @@ SELECT create_hypertable('test_morecols', 'time', chunk_time_interval=> '7 days'
 
 INSERT INTO test_morecols
 SELECT generate_series('2018-12-01 00:00'::timestamp, '2018-12-31 00:00'::timestamp, '1 day'), 55, 75, 40, 70, NULL, 100, 200, 200;
-CREATE MATERIALIZED VIEW test_morecols_cagg with (timescaledb.continuous, timescaledb.finalized=false)
+CREATE MATERIALIZED VIEW test_morecols_cagg with (timescaledb.continuous, timescaledb.materialized_only=false, timescaledb.finalized=false)
 AS SELECT time_bucket('30 days',time), avg(val1),  count(val2)
  FROM test_morecols GROUP BY 1;
 NOTICE:  refreshing continuous aggregate "test_morecols_cagg"
@@ -1734,7 +1734,7 @@ SELECT time, device_id, device_id, device_id + 2, device_id + 0.5, NULL
 FROM generate_series('2000-01-13 0:00:00+0'::timestamptz,'2000-01-19 23:55:00+0','8h') gtime(time),
      generate_series(1,5,1) gdevice(device_id);
 ANALYZE issue3248;
-CREATE materialized view issue3248_cagg WITH (timescaledb.continuous, timescaledb.finalized=false)
+CREATE materialized view issue3248_cagg WITH (timescaledb.continuous, timescaledb.materialized_only=false, timescaledb.finalized=false)
 AS SELECT time_bucket('1h',time), device_id, min(v0), max(v1), avg(v2)
 FROM issue3248 GROUP BY 1,2;
 NOTICE:  refreshing continuous aggregate "issue3248_cagg"
@@ -1761,7 +1761,7 @@ insert into test_group_idx
 select t, round(random()*10), random()*5
 from generate_series('2020-01-01', '2020-02-25', INTERVAL '12 hours') t;
 create materialized view cagg_index_true
-with (timescaledb.continuous, timescaledb.create_group_indexes=true, timescaledb.finalized=false) as
+with (timescaledb.continuous, timescaledb.materialized_only=false, timescaledb.create_group_indexes=true, timescaledb.finalized=false) as
 select
 	time_bucket('1 day', "time") as bucket,
 	sum(value),
@@ -1770,7 +1770,7 @@ from test_group_idx
 group by bucket, symbol;
 NOTICE:  refreshing continuous aggregate "cagg_index_true"
 create materialized view cagg_index_false
-with (timescaledb.continuous, timescaledb.create_group_indexes=false, timescaledb.finalized=false) as
+with (timescaledb.continuous, timescaledb.materialized_only=false, timescaledb.create_group_indexes=false, timescaledb.finalized=false) as
 select
 	time_bucket('1 day', "time") as bucket,
 	sum(value),
@@ -1779,7 +1779,7 @@ from test_group_idx
 group by bucket, symbol;
 NOTICE:  refreshing continuous aggregate "cagg_index_false"
 create materialized view cagg_index_default
-with (timescaledb.continuous, timescaledb.finalized=false) as
+with (timescaledb.continuous, timescaledb.materialized_only=false, timescaledb.finalized=false) as
 select
 	time_bucket('1 day', "time") as bucket,
 	sum(value),

--- a/tsl/test/expected/continuous_aggs_deprecated-14.out
+++ b/tsl/test/expected/continuous_aggs_deprecated-14.out
@@ -1202,7 +1202,7 @@ SELECT * FROM mat_refresh_test order by 1,2 ;
 (4 rows)
 
 -- test for bug when group by is not in project list
-CREATE MATERIALIZED VIEW conditions_grpby_view with (timescaledb.continuous, timescaledb.finalized=false) as
+CREATE MATERIALIZED VIEW conditions_grpby_view with (timescaledb.continuous, timescaledb.materialized_only=false, timescaledb.finalized=false) as
 select time_bucket(100, timec),  sum(humidity)
 from conditions
 group by time_bucket(100, timec), location;
@@ -1216,7 +1216,7 @@ select * from conditions_grpby_view order by 1, 2;
          200 |  75
 (4 rows)
 
-CREATE MATERIALIZED VIEW conditions_grpby_view2 with (timescaledb.continuous, timescaledb.finalized=false) as
+CREATE MATERIALIZED VIEW conditions_grpby_view2 with (timescaledb.continuous, timescaledb.materialized_only=false, timescaledb.finalized=false) as
 select time_bucket(100, timec), sum(humidity)
 from conditions
 group by time_bucket(100, timec), location
@@ -1265,7 +1265,7 @@ SELECT
   'yellow',
   '{foo,bar,baz}',
   '{1,2.5,3}';
-CREATE MATERIALIZED VIEW mat_types WITH (timescaledb.continuous, timescaledb.finalized=false) AS
+CREATE MATERIALIZED VIEW mat_types WITH (timescaledb.continuous, timescaledb.materialized_only=false, timescaledb.finalized=false) AS
 SELECT
   time_bucket('1d', time),
   min(status) AS status,
@@ -1432,7 +1432,7 @@ NOTICE:  adding not-null constraint to column "time"
 
 insert into raw_data select '2000-01-01','Q1';
 --having has exprs that appear in select
-CREATE MATERIALIZED VIEW search_query_count_1m WITH (timescaledb.continuous, timescaledb.finalized=false)
+CREATE MATERIALIZED VIEW search_query_count_1m WITH (timescaledb.continuous, timescaledb.materialized_only=false, timescaledb.finalized=false)
 AS
  SELECT  search_query,count(search_query) as count,
          time_bucket(INTERVAL '1 minute', time) AS bucket
@@ -1441,7 +1441,7 @@ AS
  GROUP BY search_query, bucket HAVING count(search_query) > 3 OR sum(cnt) > 1;
 NOTICE:  refreshing continuous aggregate "search_query_count_1m"
 --having has aggregates + grp by columns that appear in select
-CREATE MATERIALIZED VIEW search_query_count_2 WITH (timescaledb.continuous, timescaledb.finalized=false)
+CREATE MATERIALIZED VIEW search_query_count_2 WITH (timescaledb.continuous, timescaledb.materialized_only=false, timescaledb.finalized=false)
 AS
  SELECT  search_query,count(search_query) as count, sum(cnt),
          time_bucket(INTERVAL '1 minute', time) AS bucket
@@ -1452,7 +1452,7 @@ HAVING count(search_query) > 3 OR sum(cnt) > 1 OR
        ( sum(cnt) + count(cnt)) > 1
        AND search_query = 'Q1';
 NOTICE:  refreshing continuous aggregate "search_query_count_2"
-CREATE MATERIALIZED VIEW search_query_count_3 WITH (timescaledb.continuous, timescaledb.finalized=false)
+CREATE MATERIALIZED VIEW search_query_count_3 WITH (timescaledb.continuous, timescaledb.materialized_only=false, timescaledb.finalized=false)
 AS
  SELECT  search_query,count(search_query) as count, sum(cnt),
          time_bucket(INTERVAL '1 minute', time) AS bucket
@@ -1670,7 +1670,7 @@ SELECT create_hypertable('test_morecols', 'time', chunk_time_interval=> '7 days'
 
 INSERT INTO test_morecols
 SELECT generate_series('2018-12-01 00:00'::timestamp, '2018-12-31 00:00'::timestamp, '1 day'), 55, 75, 40, 70, NULL, 100, 200, 200;
-CREATE MATERIALIZED VIEW test_morecols_cagg with (timescaledb.continuous, timescaledb.finalized=false)
+CREATE MATERIALIZED VIEW test_morecols_cagg with (timescaledb.continuous, timescaledb.materialized_only=false, timescaledb.finalized=false)
 AS SELECT time_bucket('30 days',time), avg(val1),  count(val2)
  FROM test_morecols GROUP BY 1;
 NOTICE:  refreshing continuous aggregate "test_morecols_cagg"
@@ -1732,7 +1732,7 @@ SELECT time, device_id, device_id, device_id + 2, device_id + 0.5, NULL
 FROM generate_series('2000-01-13 0:00:00+0'::timestamptz,'2000-01-19 23:55:00+0','8h') gtime(time),
      generate_series(1,5,1) gdevice(device_id);
 ANALYZE issue3248;
-CREATE materialized view issue3248_cagg WITH (timescaledb.continuous, timescaledb.finalized=false)
+CREATE materialized view issue3248_cagg WITH (timescaledb.continuous, timescaledb.materialized_only=false, timescaledb.finalized=false)
 AS SELECT time_bucket('1h',time), device_id, min(v0), max(v1), avg(v2)
 FROM issue3248 GROUP BY 1,2;
 NOTICE:  refreshing continuous aggregate "issue3248_cagg"
@@ -1759,7 +1759,7 @@ insert into test_group_idx
 select t, round(random()*10), random()*5
 from generate_series('2020-01-01', '2020-02-25', INTERVAL '12 hours') t;
 create materialized view cagg_index_true
-with (timescaledb.continuous, timescaledb.create_group_indexes=true, timescaledb.finalized=false) as
+with (timescaledb.continuous, timescaledb.materialized_only=false, timescaledb.create_group_indexes=true, timescaledb.finalized=false) as
 select
 	time_bucket('1 day', "time") as bucket,
 	sum(value),
@@ -1768,7 +1768,7 @@ from test_group_idx
 group by bucket, symbol;
 NOTICE:  refreshing continuous aggregate "cagg_index_true"
 create materialized view cagg_index_false
-with (timescaledb.continuous, timescaledb.create_group_indexes=false, timescaledb.finalized=false) as
+with (timescaledb.continuous, timescaledb.materialized_only=false, timescaledb.create_group_indexes=false, timescaledb.finalized=false) as
 select
 	time_bucket('1 day', "time") as bucket,
 	sum(value),
@@ -1777,7 +1777,7 @@ from test_group_idx
 group by bucket, symbol;
 NOTICE:  refreshing continuous aggregate "cagg_index_false"
 create materialized view cagg_index_default
-with (timescaledb.continuous, timescaledb.finalized=false) as
+with (timescaledb.continuous, timescaledb.materialized_only=false, timescaledb.finalized=false) as
 select
 	time_bucket('1 day', "time") as bucket,
 	sum(value),

--- a/tsl/test/expected/continuous_aggs_deprecated-15.out
+++ b/tsl/test/expected/continuous_aggs_deprecated-15.out
@@ -1202,7 +1202,7 @@ SELECT * FROM mat_refresh_test order by 1,2 ;
 (4 rows)
 
 -- test for bug when group by is not in project list
-CREATE MATERIALIZED VIEW conditions_grpby_view with (timescaledb.continuous, timescaledb.finalized=false) as
+CREATE MATERIALIZED VIEW conditions_grpby_view with (timescaledb.continuous, timescaledb.materialized_only=false, timescaledb.finalized=false) as
 select time_bucket(100, timec),  sum(humidity)
 from conditions
 group by time_bucket(100, timec), location;
@@ -1216,7 +1216,7 @@ select * from conditions_grpby_view order by 1, 2;
          200 |  75
 (4 rows)
 
-CREATE MATERIALIZED VIEW conditions_grpby_view2 with (timescaledb.continuous, timescaledb.finalized=false) as
+CREATE MATERIALIZED VIEW conditions_grpby_view2 with (timescaledb.continuous, timescaledb.materialized_only=false, timescaledb.finalized=false) as
 select time_bucket(100, timec), sum(humidity)
 from conditions
 group by time_bucket(100, timec), location
@@ -1265,7 +1265,7 @@ SELECT
   'yellow',
   '{foo,bar,baz}',
   '{1,2.5,3}';
-CREATE MATERIALIZED VIEW mat_types WITH (timescaledb.continuous, timescaledb.finalized=false) AS
+CREATE MATERIALIZED VIEW mat_types WITH (timescaledb.continuous, timescaledb.materialized_only=false, timescaledb.finalized=false) AS
 SELECT
   time_bucket('1d', time),
   min(status) AS status,
@@ -1432,7 +1432,7 @@ NOTICE:  adding not-null constraint to column "time"
 
 insert into raw_data select '2000-01-01','Q1';
 --having has exprs that appear in select
-CREATE MATERIALIZED VIEW search_query_count_1m WITH (timescaledb.continuous, timescaledb.finalized=false)
+CREATE MATERIALIZED VIEW search_query_count_1m WITH (timescaledb.continuous, timescaledb.materialized_only=false, timescaledb.finalized=false)
 AS
  SELECT  search_query,count(search_query) as count,
          time_bucket(INTERVAL '1 minute', time) AS bucket
@@ -1441,7 +1441,7 @@ AS
  GROUP BY search_query, bucket HAVING count(search_query) > 3 OR sum(cnt) > 1;
 NOTICE:  refreshing continuous aggregate "search_query_count_1m"
 --having has aggregates + grp by columns that appear in select
-CREATE MATERIALIZED VIEW search_query_count_2 WITH (timescaledb.continuous, timescaledb.finalized=false)
+CREATE MATERIALIZED VIEW search_query_count_2 WITH (timescaledb.continuous, timescaledb.materialized_only=false, timescaledb.finalized=false)
 AS
  SELECT  search_query,count(search_query) as count, sum(cnt),
          time_bucket(INTERVAL '1 minute', time) AS bucket
@@ -1452,7 +1452,7 @@ HAVING count(search_query) > 3 OR sum(cnt) > 1 OR
        ( sum(cnt) + count(cnt)) > 1
        AND search_query = 'Q1';
 NOTICE:  refreshing continuous aggregate "search_query_count_2"
-CREATE MATERIALIZED VIEW search_query_count_3 WITH (timescaledb.continuous, timescaledb.finalized=false)
+CREATE MATERIALIZED VIEW search_query_count_3 WITH (timescaledb.continuous, timescaledb.materialized_only=false, timescaledb.finalized=false)
 AS
  SELECT  search_query,count(search_query) as count, sum(cnt),
          time_bucket(INTERVAL '1 minute', time) AS bucket
@@ -1670,7 +1670,7 @@ SELECT create_hypertable('test_morecols', 'time', chunk_time_interval=> '7 days'
 
 INSERT INTO test_morecols
 SELECT generate_series('2018-12-01 00:00'::timestamp, '2018-12-31 00:00'::timestamp, '1 day'), 55, 75, 40, 70, NULL, 100, 200, 200;
-CREATE MATERIALIZED VIEW test_morecols_cagg with (timescaledb.continuous, timescaledb.finalized=false)
+CREATE MATERIALIZED VIEW test_morecols_cagg with (timescaledb.continuous, timescaledb.materialized_only=false, timescaledb.finalized=false)
 AS SELECT time_bucket('30 days',time), avg(val1),  count(val2)
  FROM test_morecols GROUP BY 1;
 NOTICE:  refreshing continuous aggregate "test_morecols_cagg"
@@ -1732,7 +1732,7 @@ SELECT time, device_id, device_id, device_id + 2, device_id + 0.5, NULL
 FROM generate_series('2000-01-13 0:00:00+0'::timestamptz,'2000-01-19 23:55:00+0','8h') gtime(time),
      generate_series(1,5,1) gdevice(device_id);
 ANALYZE issue3248;
-CREATE materialized view issue3248_cagg WITH (timescaledb.continuous, timescaledb.finalized=false)
+CREATE materialized view issue3248_cagg WITH (timescaledb.continuous, timescaledb.materialized_only=false, timescaledb.finalized=false)
 AS SELECT time_bucket('1h',time), device_id, min(v0), max(v1), avg(v2)
 FROM issue3248 GROUP BY 1,2;
 NOTICE:  refreshing continuous aggregate "issue3248_cagg"
@@ -1759,7 +1759,7 @@ insert into test_group_idx
 select t, round(random()*10), random()*5
 from generate_series('2020-01-01', '2020-02-25', INTERVAL '12 hours') t;
 create materialized view cagg_index_true
-with (timescaledb.continuous, timescaledb.create_group_indexes=true, timescaledb.finalized=false) as
+with (timescaledb.continuous, timescaledb.materialized_only=false, timescaledb.create_group_indexes=true, timescaledb.finalized=false) as
 select
 	time_bucket('1 day', "time") as bucket,
 	sum(value),
@@ -1768,7 +1768,7 @@ from test_group_idx
 group by bucket, symbol;
 NOTICE:  refreshing continuous aggregate "cagg_index_true"
 create materialized view cagg_index_false
-with (timescaledb.continuous, timescaledb.create_group_indexes=false, timescaledb.finalized=false) as
+with (timescaledb.continuous, timescaledb.materialized_only=false, timescaledb.create_group_indexes=false, timescaledb.finalized=false) as
 select
 	time_bucket('1 day', "time") as bucket,
 	sum(value),
@@ -1777,7 +1777,7 @@ from test_group_idx
 group by bucket, symbol;
 NOTICE:  refreshing continuous aggregate "cagg_index_false"
 create materialized view cagg_index_default
-with (timescaledb.continuous, timescaledb.finalized=false) as
+with (timescaledb.continuous, timescaledb.materialized_only=false, timescaledb.finalized=false) as
 select
 	time_bucket('1 day', "time") as bucket,
 	sum(value),

--- a/tsl/test/expected/exp_cagg_monthly.out
+++ b/tsl/test/expected/exp_cagg_monthly.out
@@ -431,7 +431,7 @@ WHERE hypertable_id = :ht_id;
 DROP MATERIALIZED VIEW conditions_summary;
 NOTICE:  drop cascades to 4 other objects
 CREATE MATERIALIZED VIEW conditions_summary
-WITH (timescaledb.continuous) AS
+WITH (timescaledb.continuous, timescaledb.materialized_only=false) AS
 SELECT city,
    timescaledb_experimental.time_bucket_ng('1 month', day) AS bucket,
    MIN(temperature),
@@ -687,7 +687,7 @@ INSERT INTO conditions_large(day, temperature)
 SELECT ts, date_part('month', ts)*100 + date_part('day', ts)
 FROM generate_series('2010-01-01' :: date, '2020-01-01' :: date - interval '1 day', '1 day') as ts;
 CREATE MATERIALIZED VIEW conditions_large_2m
-WITH (timescaledb.continuous) AS
+WITH (timescaledb.continuous, timescaledb.materialized_only=false) AS
 SELECT
    timescaledb_experimental.time_bucket_ng('2 months', day) AS bucket,
    MIN(temperature),
@@ -761,7 +761,7 @@ SELECT * FROM conditions_large_2m ORDER BY bucket;
 (60 rows)
 
 CREATE MATERIALIZED VIEW conditions_large_3m
-WITH (timescaledb.continuous) AS
+WITH (timescaledb.continuous, timescaledb.materialized_only=false) AS
 SELECT
    timescaledb_experimental.time_bucket_ng('3 months', day) AS bucket,
    MIN(temperature),
@@ -815,7 +815,7 @@ SELECT * FROM conditions_large_3m ORDER BY bucket;
 (40 rows)
 
 CREATE MATERIALIZED VIEW conditions_large_4m
-WITH (timescaledb.continuous) AS
+WITH (timescaledb.continuous, timescaledb.materialized_only=false) AS
 SELECT
    timescaledb_experimental.time_bucket_ng('4 months', day) AS bucket,
    MIN(temperature),
@@ -859,7 +859,7 @@ SELECT * FROM conditions_large_4m ORDER BY bucket;
 (30 rows)
 
 CREATE MATERIALIZED VIEW conditions_large_5m
-WITH (timescaledb.continuous) AS
+WITH (timescaledb.continuous, timescaledb.materialized_only=false) AS
 SELECT
    timescaledb_experimental.time_bucket_ng('5 months', day) AS bucket,
    MIN(temperature),
@@ -897,7 +897,7 @@ SELECT * FROM conditions_large_5m ORDER BY bucket;
 (24 rows)
 
 CREATE MATERIALIZED VIEW conditions_large_6m
-WITH (timescaledb.continuous) AS
+WITH (timescaledb.continuous, timescaledb.materialized_only=false) AS
 SELECT
    timescaledb_experimental.time_bucket_ng('6 months', day) AS bucket,
    MIN(temperature),
@@ -931,7 +931,7 @@ SELECT * FROM conditions_large_6m ORDER BY bucket;
 (20 rows)
 
 CREATE MATERIALIZED VIEW conditions_large_1y
-WITH (timescaledb.continuous) AS
+WITH (timescaledb.continuous, timescaledb.materialized_only=false) AS
 SELECT
    timescaledb_experimental.time_bucket_ng('1 year', day) AS bucket,
    MIN(temperature),
@@ -955,7 +955,7 @@ SELECT * FROM conditions_large_1y ORDER BY bucket;
 (10 rows)
 
 CREATE MATERIALIZED VIEW conditions_large_1y1m
-WITH (timescaledb.continuous) AS
+WITH (timescaledb.continuous, timescaledb.materialized_only=false) AS
 SELECT
    timescaledb_experimental.time_bucket_ng('1 year 1 month', day) AS bucket,
    MIN(temperature),
@@ -1061,7 +1061,7 @@ INSERT INTO conditions_dist(day, temperature)
 SELECT ts, date_part('month', ts)*100 + date_part('day', ts)
 FROM generate_series('2010-01-01' :: date, '2010-03-01' :: date - interval '1 day', '1 day') as ts;
 CREATE MATERIALIZED VIEW conditions_dist_1m
-WITH (timescaledb.continuous) AS
+WITH (timescaledb.continuous, timescaledb.materialized_only=false) AS
 SELECT
    timescaledb_experimental.time_bucket_ng('1 month', day) AS bucket,
    MIN(temperature),

--- a/tsl/test/expected/exp_cagg_next_gen.out
+++ b/tsl/test/expected/exp_cagg_next_gen.out
@@ -32,7 +32,7 @@ INSERT INTO conditions (day, city, temperature) VALUES
   ('2021-06-26', 'Moscow', 32),
   ('2021-06-27', 'Moscow', 31);
 CREATE MATERIALIZED VIEW conditions_summary_weekly
-WITH (timescaledb.continuous) AS
+WITH (timescaledb.continuous, timescaledb.materialized_only=false) AS
 SELECT city,
        timescaledb_experimental.time_bucket_ng('7 days', day) AS bucket,
        MIN(temperature),
@@ -85,7 +85,7 @@ INSERT INTO conditions (tstamp, city, temperature) VALUES
   ('2021-06-14 12:32:10', 'Moscow', 32),
   ('2021-06-14 12:32:20', 'Moscow', 31);
 CREATE MATERIALIZED VIEW conditions_summary_30sec
-WITH (timescaledb.continuous) AS
+WITH (timescaledb.continuous, timescaledb.materialized_only=false) AS
 SELECT city,
        timescaledb_experimental.time_bucket_ng('30 seconds', tstamp) AS bucket,
        MIN(temperature),
@@ -94,7 +94,7 @@ FROM conditions
 GROUP BY city, bucket;
 NOTICE:  refreshing continuous aggregate "conditions_summary_30sec"
 CREATE MATERIALIZED VIEW conditions_summary_1min
-WITH (timescaledb.continuous) AS
+WITH (timescaledb.continuous, timescaledb.materialized_only=false) AS
 SELECT city,
        timescaledb_experimental.time_bucket_ng('1 minute', tstamp) AS bucket,
        MIN(temperature),
@@ -103,7 +103,7 @@ FROM conditions
 GROUP BY city, bucket;
 NOTICE:  refreshing continuous aggregate "conditions_summary_1min"
 CREATE MATERIALIZED VIEW conditions_summary_1hour
-WITH (timescaledb.continuous) AS
+WITH (timescaledb.continuous, timescaledb.materialized_only=false) AS
 SELECT city,
        timescaledb_experimental.time_bucket_ng('1 hour', tstamp) AS bucket,
        MIN(temperature),

--- a/tsl/test/expected/exp_cagg_origin.out
+++ b/tsl/test/expected/exp_cagg_origin.out
@@ -274,7 +274,7 @@ WHERE hypertable_id = :ht_id;
 
 -- Create a real-time aggregate with custom origin - June 2000
 CREATE MATERIALIZED VIEW conditions_summary_rt
-WITH (timescaledb.continuous) AS
+WITH (timescaledb.continuous, timescaledb.materialized_only=false) AS
 SELECT city,
    timescaledb_experimental.time_bucket_ng('1 month', day, '2000-06-01' :: date) AS bucket,
    MIN(temperature),
@@ -500,7 +500,7 @@ INSERT INTO conditions_dist(day, temperature)
 SELECT ts, date_part('month', ts)*100 + date_part('day', ts)
 FROM generate_series('2010-01-01' :: date, '2010-03-01' :: date - interval '1 day', '1 day') as ts;
 CREATE MATERIALIZED VIEW conditions_dist_1m
-WITH (timescaledb.continuous) AS
+WITH (timescaledb.continuous, timescaledb.materialized_only=false) AS
 SELECT
    timescaledb_experimental.time_bucket_ng('1 month', day, '2010-01-01') AS bucket,
    MIN(temperature),
@@ -787,7 +787,7 @@ WARNING:  column type "timestamp without time zone" used for "tstamp" does not f
 (1 row)
 
 CREATE MATERIALIZED VIEW conditions_summary_timestamp
-WITH (timescaledb.continuous) AS
+WITH (timescaledb.continuous, timescaledb.materialized_only=false) AS
 SELECT city,
    timescaledb_experimental.time_bucket_ng('12 hours', tstamp, '2000-06-01 12:00:00') AS bucket,
    MIN(temperature),
@@ -944,7 +944,7 @@ GROUP BY city, bucket;
 ERROR:  invalid interval specified
 \set ON_ERROR_STOP 1
 CREATE MATERIALIZED VIEW conditions_summary_timestamptz
-WITH (timescaledb.continuous) AS
+WITH (timescaledb.continuous, timescaledb.materialized_only=false) AS
 SELECT city,
    timescaledb_experimental.time_bucket_ng('12 hours', tstamp, '2020-06-01 12:00:00 MSK', 'Europe/Moscow') AS bucket,
    MIN(temperature),

--- a/tsl/test/expected/exp_cagg_timezone.out
+++ b/tsl/test/expected/exp_cagg_timezone.out
@@ -394,7 +394,7 @@ DROP MATERIALIZED VIEW conditions_summary_1w;
 NOTICE:  drop cascades to 2 other objects
 -- Create a real-time aggregate
 CREATE MATERIALIZED VIEW conditions_summary_tz
-WITH (timescaledb.continuous) AS
+WITH (timescaledb.continuous, timescaledb.materialized_only=false) AS
 SELECT city,
    timescaledb_experimental.time_bucket_ng('1 month', day, 'MSK') AS bucket,
    MIN(temperature),
@@ -578,7 +578,7 @@ SELECT create_hypertable(
 
 -- Create a real-time aggregate on top of empty HT
 CREATE MATERIALIZED VIEW conditions2_summary
-WITH (timescaledb.continuous) AS
+WITH (timescaledb.continuous, timescaledb.materialized_only=false) AS
 SELECT city,
    timescaledb_experimental.time_bucket_ng('7 days', day, 'MSK') AS bucket,
    MIN(temperature),
@@ -684,7 +684,7 @@ INSERT INTO conditions_dist(day, temperature)
 SELECT ts, date_part('month', ts)*100 + date_part('day', ts)
 FROM generate_series('2010-01-01 00:00:00 MSK' :: timestamptz, '2010-03-01 00:00:00 MSK' :: timestamptz - interval '1 day', '1 day') as ts;
 CREATE MATERIALIZED VIEW conditions_dist_1m
-WITH (timescaledb.continuous) AS
+WITH (timescaledb.continuous, timescaledb.materialized_only=false) AS
 SELECT
    timescaledb_experimental.time_bucket_ng('1 month', day, 'MSK') AS bucket,
    MIN(temperature),

--- a/tsl/test/expected/information_view_chunk_count.out
+++ b/tsl/test/expected/information_view_chunk_count.out
@@ -19,7 +19,7 @@ FROM
        generate_series('2018-03-02 1:00'::TIMESTAMPTZ, '2018-03-28 1:00', '1 hour') AS g1(time),
        generate_series(1, 100, 1 ) AS g2(sensor_id)
 ORDER BY time;
-CREATE materialized VIEW sensor_data_v WITH(timescaledb.continuous) AS
+CREATE materialized VIEW sensor_data_v WITH(timescaledb.continuous, timescaledb.materialized_only=false) AS
 SELECT sensor_id, time_bucket(INTERVAL '1 day', time) AS bucket,
 AVG(temperature) FROM sensor_data
 GROUP BY sensor_id, bucket;

--- a/tsl/test/expected/jit-13.out
+++ b/tsl/test/expected/jit-13.out
@@ -49,7 +49,7 @@ SELECT table_name FROM create_hypertable('jit_test_contagg', 'observation_time')
 (1 row)
 
 CREATE MATERIALIZED VIEW jit_device_summary
-WITH (timescaledb.continuous)
+WITH (timescaledb.continuous, timescaledb.materialized_only=false)
 AS
 SELECT
   time_bucket('1 hour', observation_time) as bucket,

--- a/tsl/test/expected/jit-14.out
+++ b/tsl/test/expected/jit-14.out
@@ -49,7 +49,7 @@ SELECT table_name FROM create_hypertable('jit_test_contagg', 'observation_time')
 (1 row)
 
 CREATE MATERIALIZED VIEW jit_device_summary
-WITH (timescaledb.continuous)
+WITH (timescaledb.continuous, timescaledb.materialized_only=false)
 AS
 SELECT
   time_bucket('1 hour', observation_time) as bucket,

--- a/tsl/test/expected/jit-15.out
+++ b/tsl/test/expected/jit-15.out
@@ -49,7 +49,7 @@ SELECT table_name FROM create_hypertable('jit_test_contagg', 'observation_time')
 (1 row)
 
 CREATE MATERIALIZED VIEW jit_device_summary
-WITH (timescaledb.continuous)
+WITH (timescaledb.continuous, timescaledb.materialized_only=false)
 AS
 SELECT
   time_bucket('1 hour', observation_time) as bucket,

--- a/tsl/test/expected/telemetry_stats-13.out
+++ b/tsl/test/expected/telemetry_stats-13.out
@@ -61,7 +61,7 @@ SELECT table_name FROM create_hypertable('hyper', 'time');
 (1 row)
 
 CREATE MATERIALIZED VIEW contagg
-WITH (timescaledb.continuous) AS
+WITH (timescaledb.continuous, timescaledb.materialized_only=false) AS
 SELECT
   time_bucket('1 hour', time) AS hour,
   device,
@@ -71,7 +71,7 @@ FROM
 GROUP BY hour, device;
 NOTICE:  continuous aggregate "contagg" is already up-to-date
 CREATE MATERIALIZED VIEW contagg_old
-WITH (timescaledb.continuous, timescaledb.finalized=false) AS
+WITH (timescaledb.continuous, timescaledb.materialized_only=false, timescaledb.finalized=false) AS
 SELECT
   time_bucket('1 hour', time) AS hour,
   device,
@@ -911,7 +911,7 @@ FROM relations;
 
 -- Create a continuous aggregate on the distributed hypertable
 CREATE MATERIALIZED VIEW distcontagg
-WITH (timescaledb.continuous) AS
+WITH (timescaledb.continuous, timescaledb.materialized_only=false) AS
 SELECT
   time_bucket('1 hour', time) AS hour,
   device,
@@ -921,7 +921,7 @@ FROM
 GROUP BY hour, device;
 NOTICE:  refreshing continuous aggregate "distcontagg"
 CREATE MATERIALIZED VIEW distcontagg_old
-WITH (timescaledb.continuous, timescaledb.finalized=false) AS
+WITH (timescaledb.continuous, timescaledb.materialized_only=false, timescaledb.finalized=false) AS
 SELECT
   time_bucket('1 hour', time) AS hour,
   device,

--- a/tsl/test/expected/telemetry_stats-14.out
+++ b/tsl/test/expected/telemetry_stats-14.out
@@ -61,7 +61,7 @@ SELECT table_name FROM create_hypertable('hyper', 'time');
 (1 row)
 
 CREATE MATERIALIZED VIEW contagg
-WITH (timescaledb.continuous) AS
+WITH (timescaledb.continuous, timescaledb.materialized_only=false) AS
 SELECT
   time_bucket('1 hour', time) AS hour,
   device,
@@ -71,7 +71,7 @@ FROM
 GROUP BY hour, device;
 NOTICE:  continuous aggregate "contagg" is already up-to-date
 CREATE MATERIALIZED VIEW contagg_old
-WITH (timescaledb.continuous, timescaledb.finalized=false) AS
+WITH (timescaledb.continuous, timescaledb.materialized_only=false, timescaledb.finalized=false) AS
 SELECT
   time_bucket('1 hour', time) AS hour,
   device,
@@ -911,7 +911,7 @@ FROM relations;
 
 -- Create a continuous aggregate on the distributed hypertable
 CREATE MATERIALIZED VIEW distcontagg
-WITH (timescaledb.continuous) AS
+WITH (timescaledb.continuous, timescaledb.materialized_only=false) AS
 SELECT
   time_bucket('1 hour', time) AS hour,
   device,
@@ -921,7 +921,7 @@ FROM
 GROUP BY hour, device;
 NOTICE:  refreshing continuous aggregate "distcontagg"
 CREATE MATERIALIZED VIEW distcontagg_old
-WITH (timescaledb.continuous, timescaledb.finalized=false) AS
+WITH (timescaledb.continuous, timescaledb.materialized_only=false, timescaledb.finalized=false) AS
 SELECT
   time_bucket('1 hour', time) AS hour,
   device,

--- a/tsl/test/expected/telemetry_stats-15.out
+++ b/tsl/test/expected/telemetry_stats-15.out
@@ -61,7 +61,7 @@ SELECT table_name FROM create_hypertable('hyper', 'time');
 (1 row)
 
 CREATE MATERIALIZED VIEW contagg
-WITH (timescaledb.continuous) AS
+WITH (timescaledb.continuous, timescaledb.materialized_only=false) AS
 SELECT
   time_bucket('1 hour', time) AS hour,
   device,
@@ -71,7 +71,7 @@ FROM
 GROUP BY hour, device;
 NOTICE:  continuous aggregate "contagg" is already up-to-date
 CREATE MATERIALIZED VIEW contagg_old
-WITH (timescaledb.continuous, timescaledb.finalized=false) AS
+WITH (timescaledb.continuous, timescaledb.materialized_only=false, timescaledb.finalized=false) AS
 SELECT
   time_bucket('1 hour', time) AS hour,
   device,
@@ -911,7 +911,7 @@ FROM relations;
 
 -- Create a continuous aggregate on the distributed hypertable
 CREATE MATERIALIZED VIEW distcontagg
-WITH (timescaledb.continuous) AS
+WITH (timescaledb.continuous, timescaledb.materialized_only=false) AS
 SELECT
   time_bucket('1 hour', time) AS hour,
   device,
@@ -921,7 +921,7 @@ FROM
 GROUP BY hour, device;
 NOTICE:  refreshing continuous aggregate "distcontagg"
 CREATE MATERIALIZED VIEW distcontagg_old
-WITH (timescaledb.continuous, timescaledb.finalized=false) AS
+WITH (timescaledb.continuous, timescaledb.materialized_only=false, timescaledb.finalized=false) AS
 SELECT
   time_bucket('1 hour', time) AS hour,
   device,

--- a/tsl/test/shared/expected/cagg_compression.out
+++ b/tsl/test/shared/expected/cagg_compression.out
@@ -25,7 +25,7 @@ UNION
 SELECT * FROM extra_devices;
 -- Compressed CAgg + Compressed Hypertable
 CREATE MATERIALIZED VIEW metrics_compressed_summary
-WITH (timescaledb.continuous) AS
+WITH (timescaledb.continuous, timescaledb.materialized_only=false) AS
 SELECT
 	device_id,
 	time_bucket(INTERVAL '1 week', time) AS bucket,
@@ -87,7 +87,7 @@ WHERE
 
 -- Compressed CAgg + Uncompressed Hypertable
 CREATE MATERIALIZED VIEW metrics_summary
-WITH (timescaledb.continuous) AS
+WITH (timescaledb.continuous, timescaledb.materialized_only=false) AS
 SELECT
 	device_id,
 	time_bucket(INTERVAL '1 week', time) AS bucket,
@@ -346,7 +346,7 @@ NOTICE:  adding not-null constraint to column "time"
  comp_rename
 (1 row)
 
-CREATE MATERIALIZED VIEW comp_rename_cagg WITH (timescaledb.continuous) AS
+CREATE MATERIALIZED VIEW comp_rename_cagg WITH (timescaledb.continuous, timescaledb.materialized_only=false) AS
 SELECT time_bucket('1 week', time) AS bucket FROM comp_rename GROUP BY 1;
 NOTICE:  continuous aggregate "comp_rename_cagg" is already up-to-date
 ALTER MATERIALIZED VIEW comp_rename_cagg RENAME COLUMN bucket to "time";

--- a/tsl/test/shared/sql/cagg_compression.sql
+++ b/tsl/test/shared/sql/cagg_compression.sql
@@ -100,7 +100,7 @@ DROP TABLE extra_devices;
 CREATE TABLE comp_rename(time timestamptz);
 SELECT table_name FROM create_hypertable('comp_rename', 'time');
 
-CREATE MATERIALIZED VIEW comp_rename_cagg WITH (timescaledb.continuous) AS
+CREATE MATERIALIZED VIEW comp_rename_cagg WITH (timescaledb.continuous, timescaledb.materialized_only=false) AS
 SELECT time_bucket('1 week', time) AS bucket FROM comp_rename GROUP BY 1;
 
 ALTER MATERIALIZED VIEW comp_rename_cagg RENAME COLUMN bucket to "time";

--- a/tsl/test/shared/sql/include/cagg_compression_setup.sql
+++ b/tsl/test/shared/sql/include/cagg_compression_setup.sql
@@ -15,7 +15,7 @@ SELECT * FROM extra_devices;
 
 -- Compressed CAgg + Compressed Hypertable
 CREATE MATERIALIZED VIEW metrics_compressed_summary
-WITH (timescaledb.continuous) AS
+WITH (timescaledb.continuous, timescaledb.materialized_only=false) AS
 SELECT
 	device_id,
 	time_bucket(INTERVAL '1 week', time) AS bucket,
@@ -67,7 +67,7 @@ WHERE
 
 -- Compressed CAgg + Uncompressed Hypertable
 CREATE MATERIALIZED VIEW metrics_summary
-WITH (timescaledb.continuous) AS
+WITH (timescaledb.continuous, timescaledb.materialized_only=false) AS
 SELECT
 	device_id,
 	time_bucket(INTERVAL '1 week', time) AS bucket,

--- a/tsl/test/sql/bgw_custom.sql
+++ b/tsl/test/sql/bgw_custom.sql
@@ -285,7 +285,7 @@ SELECT decompress_chunk(c) FROM show_chunks('conditions') c;
 
 -- TEST Continuous Aggregate job
 CREATE MATERIALIZED VIEW conditions_summary_daily
-WITH (timescaledb.continuous) AS
+WITH (timescaledb.continuous, timescaledb.materialized_only=false) AS
 SELECT location,
    time_bucket(INTERVAL '1 day', time) AS bucket,
    AVG(temperature),

--- a/tsl/test/sql/cagg_drop_chunks.sql
+++ b/tsl/test/sql/cagg_drop_chunks.sql
@@ -24,7 +24,7 @@ SELECT * FROM create_hypertable('records', 'time',
        chunk_time_interval => INTERVAL '1h');
 
 CREATE MATERIALIZED VIEW records_monthly
-    WITH (timescaledb.continuous)
+    WITH (timescaledb.continuous, timescaledb.materialized_only=false)
     AS
         SELECT time_bucket('1d', time) as bucket,
             clientId,

--- a/tsl/test/sql/cagg_errors.sql
+++ b/tsl/test/sql/cagg_errors.sql
@@ -18,37 +18,37 @@ CREATE TABLE conditions (
     );
 select table_name from create_hypertable( 'conditions', 'timec');
 
-CREATE MATERIALIZED VIEW mat_m1 WITH ( timescaledb.continuous, timescaledb.myfill = 1)
+CREATE MATERIALIZED VIEW mat_m1 WITH (timescaledb.continuous, timescaledb.materialized_only=false, timescaledb.myfill = 1)
 as
 select location , min(temperature)
 from conditions
 group by time_bucket('1d', timec), location WITH NO DATA;
 
 --valid PG option
-CREATE MATERIALIZED VIEW mat_m1 WITH ( timescaledb.continuous, check_option = LOCAL )
+CREATE MATERIALIZED VIEW mat_m1 WITH (timescaledb.continuous, timescaledb.materialized_only=false, check_option = LOCAL )
 as
 select * from conditions , mat_t1 WITH NO DATA;
 
 
 --non-hypertable
-CREATE MATERIALIZED VIEW mat_m1 WITH ( timescaledb.continuous)
+CREATE MATERIALIZED VIEW mat_m1 WITH (timescaledb.continuous, timescaledb.materialized_only=false)
 as
 select a, count(*) from mat_t1
 group by a WITH NO DATA;
 
 
 -- no group by
-CREATE MATERIALIZED VIEW mat_m1 WITH ( timescaledb.continuous)
+CREATE MATERIALIZED VIEW mat_m1 WITH (timescaledb.continuous, timescaledb.materialized_only=false)
 as
 select count(*) from conditions  WITH NO DATA;
 
 -- no time_bucket in group by
-CREATE MATERIALIZED VIEW mat_m1 WITH ( timescaledb.continuous)
+CREATE MATERIALIZED VIEW mat_m1 WITH (timescaledb.continuous, timescaledb.materialized_only=false)
 as
 select count(*) from conditions group by location WITH NO DATA;
 
 -- with valid query in a CTE
-CREATE MATERIALIZED VIEW mat_m1 WITH ( timescaledb.continuous)
+CREATE MATERIALIZED VIEW mat_m1 WITH (timescaledb.continuous, timescaledb.materialized_only=false)
 AS
 with m1 as (
 Select location, count(*) from conditions
@@ -56,54 +56,54 @@ Select location, count(*) from conditions
 select * from m1 WITH NO DATA;
 
 --with DISTINCT ON
-CREATE MATERIALIZED VIEW mat_m1 WITH ( timescaledb.continuous)
+CREATE MATERIALIZED VIEW mat_m1 WITH (timescaledb.continuous, timescaledb.materialized_only=false)
 as
  select distinct on ( location ) count(*)  from conditions group by location, time_bucket('1week', timec)  WITH NO DATA;
 
 -- time_bucket on non partitioning column of hypertable
-CREATE MATERIALIZED VIEW mat_m1 WITH ( timescaledb.continuous)
+CREATE MATERIALIZED VIEW mat_m1 WITH (timescaledb.continuous, timescaledb.materialized_only=false)
 AS
 Select max(temperature)
 from conditions
  group by time_bucket('1week', timemeasure) , location WITH NO DATA;
 
 --time_bucket on expression
-CREATE MATERIALIZED VIEW mat_m1 WITH ( timescaledb.continuous)
+CREATE MATERIALIZED VIEW mat_m1 WITH (timescaledb.continuous, timescaledb.materialized_only=false)
 AS
 Select max(temperature)
 from conditions
  group by time_bucket('1week', timec+ '10 minutes'::interval) , location WITH NO DATA;
 
 --multiple time_bucket functions
-CREATE MATERIALIZED VIEW mat_m1 WITH ( timescaledb.continuous)
+CREATE MATERIALIZED VIEW mat_m1 WITH (timescaledb.continuous, timescaledb.materialized_only=false)
 AS
 Select max(temperature)
 from conditions
  group by time_bucket('1week', timec) , time_bucket('1month', timec), location WITH NO DATA;
 
 --time_bucket using additional args
-CREATE MATERIALIZED VIEW mat_m1 WITH ( timescaledb.continuous)
+CREATE MATERIALIZED VIEW mat_m1 WITH (timescaledb.continuous, timescaledb.materialized_only=false)
 AS
 Select max(temperature)
 from conditions
  group by time_bucket( INTERVAL '5 minutes', timec, INTERVAL '-2.5 minutes') , location WITH NO DATA;
 
 --time_bucket using non-const for first argument
-CREATE MATERIALIZED VIEW mat_m1 WITH ( timescaledb.continuous)
+CREATE MATERIALIZED VIEW mat_m1 WITH (timescaledb.continuous, timescaledb.materialized_only=false)
 AS
 Select max(temperature)
 from conditions
  group by time_bucket( timeinterval, timec) , location WITH NO DATA;
 
 --window function
-CREATE MATERIALIZED VIEW mat_m1 WITH ( timescaledb.continuous)
+CREATE MATERIALIZED VIEW mat_m1 WITH (timescaledb.continuous, timescaledb.materialized_only=false)
 AS
 Select avg(temperature) over( order by humidity)
 from conditions
  WITH NO DATA;
 
 --aggregate without combine function but stable function
-CREATE MATERIALIZED VIEW mat_m1 WITH ( timescaledb.continuous)
+CREATE MATERIALIZED VIEW mat_m1 WITH (timescaledb.continuous, timescaledb.materialized_only=false)
 AS
 Select json_agg(location)
 from conditions
@@ -111,7 +111,7 @@ from conditions
 ;
 
 -- using subqueries
-CREATE MATERIALIZED VIEW mat_m1 WITH ( timescaledb.continuous)
+CREATE MATERIALIZED VIEW mat_m1 WITH (timescaledb.continuous, timescaledb.materialized_only=false)
 AS
 Select sum(humidity), avg(temperature::int4)
 from
@@ -119,7 +119,7 @@ from
 from conditions ) q
  group by time_bucket('1week', timec) , location  WITH NO DATA;
 
-CREATE MATERIALIZED VIEW mat_m1 WITH ( timescaledb.continuous)
+CREATE MATERIALIZED VIEW mat_m1 WITH (timescaledb.continuous, timescaledb.materialized_only=false)
 AS
 select * from
 ( Select sum(humidity), avg(temperature::int4)
@@ -127,14 +127,14 @@ from conditions
  group by time_bucket('1week', timec) , location )  q WITH NO DATA;
 
 --using limit /limit offset
-CREATE MATERIALIZED VIEW mat_m1 WITH ( timescaledb.continuous)
+CREATE MATERIALIZED VIEW mat_m1 WITH (timescaledb.continuous, timescaledb.materialized_only=false)
 AS
 Select sum(humidity), avg(temperature::int4)
 from conditions
  group by time_bucket('1week', timec) , location
 limit 10  WITH NO DATA;
 
-CREATE MATERIALIZED VIEW mat_m1 WITH ( timescaledb.continuous)
+CREATE MATERIALIZED VIEW mat_m1 WITH (timescaledb.continuous, timescaledb.materialized_only=false)
 AS
 Select sum(humidity), avg(temperature::int4)
 from conditions
@@ -142,7 +142,7 @@ from conditions
 offset 10 WITH NO DATA;
 
 --using FETCH
-CREATE MATERIALIZED VIEW mat_m1 WITH ( timescaledb.continuous)
+CREATE MATERIALIZED VIEW mat_m1 WITH (timescaledb.continuous, timescaledb.materialized_only=false)
 AS
 Select sum(humidity), avg(temperature::int4)
 from conditions
@@ -151,14 +151,14 @@ fetch first 10 rows only WITH NO DATA;
 
 --using locking clauses FOR clause
 --all should be disabled. we cannot guarntee locks on the hypertable
-CREATE MATERIALIZED VIEW mat_m1 WITH ( timescaledb.continuous)
+CREATE MATERIALIZED VIEW mat_m1 WITH (timescaledb.continuous, timescaledb.materialized_only=false)
 AS
 Select sum(humidity), avg(temperature::int4)
 from conditions
  group by time_bucket('1week', timec) , location
 FOR KEY SHARE WITH NO DATA;
 
-CREATE MATERIALIZED VIEW mat_m1 WITH ( timescaledb.continuous)
+CREATE MATERIALIZED VIEW mat_m1 WITH (timescaledb.continuous, timescaledb.materialized_only=false)
 AS
 Select sum(humidity), avg(temperature::int4)
 from conditions
@@ -166,14 +166,14 @@ from conditions
 FOR SHARE WITH NO DATA;
 
 
-CREATE MATERIALIZED VIEW mat_m1 WITH ( timescaledb.continuous)
+CREATE MATERIALIZED VIEW mat_m1 WITH (timescaledb.continuous, timescaledb.materialized_only=false)
 AS
 Select sum(humidity), avg(temperature::int4)
 from conditions
  group by time_bucket('1week', timec) , location
 FOR UPDATE WITH NO DATA;
 
-CREATE MATERIALIZED VIEW mat_m1 WITH ( timescaledb.continuous)
+CREATE MATERIALIZED VIEW mat_m1 WITH (timescaledb.continuous, timescaledb.materialized_only=false)
 AS
 Select sum(humidity), avg(temperature::int4)
 from conditions
@@ -181,7 +181,7 @@ from conditions
 FOR NO KEY UPDATE WITH NO DATA;
 
 --tablesample clause
-CREATE MATERIALIZED VIEW mat_m1 WITH ( timescaledb.continuous)
+CREATE MATERIALIZED VIEW mat_m1 WITH (timescaledb.continuous, timescaledb.materialized_only=false)
 AS
 Select sum(humidity), avg(temperature::int4)
 from conditions tablesample bernoulli(0.2)
@@ -189,20 +189,20 @@ from conditions tablesample bernoulli(0.2)
  WITH NO DATA;
 
 -- ONLY in from clause
-CREATE MATERIALIZED VIEW mat_m1 WITH ( timescaledb.continuous)
+CREATE MATERIALIZED VIEW mat_m1 WITH (timescaledb.continuous, timescaledb.materialized_only=false)
 AS
 Select sum(humidity), avg(temperature::int4)
 from ONLY conditions
  group by time_bucket('1week', timec) , location  WITH NO DATA;
 
 --grouping sets and variants
-CREATE MATERIALIZED VIEW mat_m1 WITH ( timescaledb.continuous)
+CREATE MATERIALIZED VIEW mat_m1 WITH (timescaledb.continuous, timescaledb.materialized_only=false)
 AS
 Select sum(humidity), avg(temperature::int4)
 from conditions
  group by grouping sets(time_bucket('1week', timec) , location )  WITH NO DATA;
 
-CREATE MATERIALIZED VIEW mat_m1 WITH ( timescaledb.continuous)
+CREATE MATERIALIZED VIEW mat_m1 WITH (timescaledb.continuous, timescaledb.materialized_only=false)
 AS
 Select sum(humidity), avg(temperature::int4)
 from conditions
@@ -212,26 +212,26 @@ group by rollup(time_bucket('1week', timec) , location )  WITH NO DATA;
 CREATE FUNCTION test_stablefunc(int) RETURNS int LANGUAGE 'sql'
        STABLE AS 'SELECT $1 + 10';
 
-CREATE MATERIALIZED VIEW mat_m1 WITH ( timescaledb.continuous)
+CREATE MATERIALIZED VIEW mat_m1 WITH (timescaledb.continuous, timescaledb.materialized_only=false)
 AS
 Select sum(humidity), max(timec + INTERVAL '1h')
 from conditions
 group by time_bucket('1week', timec) , location   WITH NO DATA;
 
-CREATE MATERIALIZED VIEW mat_m1 WITH ( timescaledb.continuous)
+CREATE MATERIALIZED VIEW mat_m1 WITH (timescaledb.continuous, timescaledb.materialized_only=false)
 AS
 Select sum( test_stablefunc(humidity::int) ), min(location)
 from conditions
 group by time_bucket('1week', timec) WITH NO DATA;
 
-CREATE MATERIALIZED VIEW mat_m1 WITH ( timescaledb.continuous)
+CREATE MATERIALIZED VIEW mat_m1 WITH (timescaledb.continuous, timescaledb.materialized_only=false)
 AS
 Select sum( temperature ), min(location)
 from conditions
 group by time_bucket('1week', timec), test_stablefunc(humidity::int) WITH NO DATA;
 
 -- Should use CREATE MATERIALIZED VIEW to create continuous aggregates
-CREATE VIEW continuous_aggs_errors_tbl1 WITH (timescaledb.continuous) AS
+CREATE VIEW continuous_aggs_errors_tbl1 WITH (timescaledb.continuous, timescaledb.materialized_only=false) AS
 SELECT time_bucket('1 week', timec)
   FROM conditions
 GROUP BY time_bucket('1 week', timec);
@@ -244,7 +244,7 @@ SELECT set_integer_now_func('rowsec_tab', 'integer_now_test');
 alter table rowsec_tab ENABLE ROW LEVEL SECURITY;
 create policy rowsec_tab_allview ON rowsec_tab FOR SELECT USING(true);
 
-CREATE MATERIALIZED VIEW mat_m1 WITH ( timescaledb.continuous)
+CREATE MATERIALIZED VIEW mat_m1 WITH (timescaledb.continuous, timescaledb.materialized_only=false)
 AS
 Select sum( b), min(c)
 from rowsec_tab
@@ -266,7 +266,7 @@ CREATE TABLE conditions (
 select table_name from create_hypertable( 'conditions', 'timec');
 
 create materialized view mat_with_test( timec, minl, sumt , sumh)
-WITH (timescaledb.continuous)
+WITH (timescaledb.continuous, timescaledb.materialized_only=false)
 as
 select time_bucket('1day', timec), min(location), sum(temperature),sum(humidity)
 from conditions
@@ -307,14 +307,14 @@ SELECT set_integer_now_func('conditions', 'integer_now_test_s');
 
 \set ON_ERROR_STOP 0
 create materialized view mat_with_test( timec, minl, sumt , sumh)
-WITH (timescaledb.continuous)
+WITH (timescaledb.continuous, timescaledb.materialized_only=false)
 as
 select time_bucket(100, timec), min(location), sum(temperature),sum(humidity)
 from conditions
 group by time_bucket(100, timec) WITH NO DATA;
 
 create materialized view mat_with_test( timec, minl, sumt , sumh)
-WITH (timescaledb.continuous)
+WITH (timescaledb.continuous, timescaledb.materialized_only=false)
 as
 select time_bucket(100, timec), min(location), sum(temperature),sum(humidity)
 from conditions
@@ -323,7 +323,7 @@ group by time_bucket(100, timec) WITH NO DATA;
 ALTER TABLE conditions ALTER timec type int;
 
 create materialized view mat_with_test( timec, minl, sumt , sumh)
-WITH (timescaledb.continuous)
+WITH (timescaledb.continuous, timescaledb.materialized_only=false)
 as
 select time_bucket(100, timec), min(location), sum(temperature),sum(humidity)
 from conditions
@@ -347,7 +347,7 @@ CREATE OR REPLACE FUNCTION integer_now_test_b() returns bigint LANGUAGE SQL STAB
 SELECT set_integer_now_func('conditions', 'integer_now_test_b');
 
 create materialized view mat_with_test( timec, minl, sumt , sumh)
-WITH (timescaledb.continuous)
+WITH (timescaledb.continuous, timescaledb.materialized_only=false)
 as
 select time_bucket(BIGINT '100', timec), min(location), sum(temperature),sum(humidity)
 from conditions
@@ -364,7 +364,7 @@ CREATE TABLE text_time(time TEXT);
 \set VERBOSITY default
 \set ON_ERROR_STOP 0
 CREATE MATERIALIZED VIEW text_view
-    WITH (timescaledb.continuous)
+    WITH (timescaledb.continuous, timescaledb.materialized_only=false)
     AS SELECT time_bucket('5', text_part_func(time)), COUNT(time)
         FROM text_time
         GROUP BY 1 WITH NO DATA;
@@ -391,7 +391,7 @@ INSERT INTO measurements VALUES ('2019-03-04 13:30', 1, 1.3);
 
 -- Add a continuous aggregate on the measurements table and a policy
 -- to be able to test error cases for the add_job function.
-CREATE MATERIALIZED VIEW measurements_summary WITH (timescaledb.continuous) AS
+CREATE MATERIALIZED VIEW measurements_summary WITH (timescaledb.continuous, timescaledb.materialized_only=false) AS
 SELECT time_bucket('1 day', time), COUNT(time)
   FROM measurements
 GROUP BY 1 WITH NO DATA;
@@ -445,17 +445,17 @@ DROP TABLE conditions CASCADE;
 -- test handling of invalid mat_hypertable_id
 create table i2980(time timestamptz not null);
 select create_hypertable('i2980','time');
-create materialized view i2980_cagg with (timescaledb.continuous) AS SELECT time_bucket('1h',time), avg(7) FROM i2980 GROUP BY 1;
+create materialized view i2980_cagg with (timescaledb.continuous, timescaledb.materialized_only=false) AS SELECT time_bucket('1h',time), avg(7) FROM i2980 GROUP BY 1;
 select add_continuous_aggregate_policy('i2980_cagg',NULL,NULL,'4h') AS job_id \gset
 \set ON_ERROR_STOP 0
 select alter_job(:job_id,config:='{"end_offset": null, "start_offset": null, "mat_hypertable_id": 1000}');
 
 --test creating continuous aggregate with compression enabled --
-CREATE MATERIALIZED VIEW  i2980_cagg2 with (timescaledb.continuous, timescaledb.compress)
+CREATE MATERIALIZED VIEW  i2980_cagg2 with (timescaledb.continuous, timescaledb.materialized_only=false, timescaledb.compress)
 AS SELECT time_bucket('1h',time), avg(7) FROM i2980 GROUP BY 1;
 
 --this one succeeds
-CREATE MATERIALIZED VIEW  i2980_cagg2 with (timescaledb.continuous)
+CREATE MATERIALIZED VIEW  i2980_cagg2 with (timescaledb.continuous, timescaledb.materialized_only=false)
 AS SELECT time_bucket('1h',time) as bucket, avg(7) FROM i2980 GROUP BY 1;
 
 --now enable compression with invalid parameters
@@ -509,7 +509,7 @@ FROM
   INNER JOIN _timescaledb_catalog.hypertable uncompress ON (ht.id = uncompress.compressed_hypertable_id
       AND uncompress.table_name = 'comp_ht_test') \gset
 
-CREATE MATERIALIZED VIEW cagg1 WITH(timescaledb.continuous) AS SELECT time_bucket('1h',_ts_meta_min_1) FROM :INTERNALTABLE GROUP BY 1;
+CREATE MATERIALIZED VIEW cagg1 WITH(timescaledb.continuous, timescaledb.materialized_only=false) AS SELECT time_bucket('1h',_ts_meta_min_1) FROM :INTERNALTABLE GROUP BY 1;
 
 --TEST ht + cagg, do not enable compression on ht and try to compress chunk on ht.
 --Check error handling for this case
@@ -517,11 +517,11 @@ SELECT compress_chunk(ch) FROM show_chunks('i2980') ch;
 
 -- cagg on normal view should error out
 CREATE VIEW v1 AS SELECT now() AS time;
-CREATE MATERIALIZED VIEW cagg1 WITH (timescaledb.continuous) AS SELECT time_bucket('1h',time) FROM v1 GROUP BY 1;
+CREATE MATERIALIZED VIEW cagg1 WITH (timescaledb.continuous, timescaledb.materialized_only=false) AS SELECT time_bucket('1h',time) FROM v1 GROUP BY 1;
 
 -- cagg on normal view should error out
 CREATE MATERIALIZED VIEW matv1 AS SELECT now() AS time;
-CREATE MATERIALIZED VIEW cagg1 WITH (timescaledb.continuous) AS SELECT time_bucket('1h',time) FROM matv1 GROUP BY 1;
+CREATE MATERIALIZED VIEW cagg1 WITH (timescaledb.continuous, timescaledb.materialized_only=false) AS SELECT time_bucket('1h',time) FROM matv1 GROUP BY 1;
 
 -- No FROM clause in CAGG definition
-CREATE MATERIALIZED VIEW cagg1 with (timescaledb.continuous) AS SELECT 1 GROUP BY 1 WITH NO DATA;
+CREATE MATERIALIZED VIEW cagg1 with (timescaledb.continuous, timescaledb.materialized_only=false) AS SELECT 1 GROUP BY 1 WITH NO DATA;

--- a/tsl/test/sql/cagg_errors_deprecated.sql
+++ b/tsl/test/sql/cagg_errors_deprecated.sql
@@ -18,35 +18,35 @@ CREATE TABLE conditions (
     );
 select table_name from create_hypertable( 'conditions', 'timec');
 
-CREATE MATERIALIZED VIEW mat_m1 WITH (timescaledb.continuous, timescaledb.finalized = false, timescaledb.myfill = 1)
+CREATE MATERIALIZED VIEW mat_m1 WITH (timescaledb.continuous, timescaledb.materialized_only=false, timescaledb.finalized = false, timescaledb.myfill = 1)
 as
 select location , min(temperature)
 from conditions
 group by time_bucket('1d', timec), location WITH NO DATA;
 
 --valid PG option
-CREATE MATERIALIZED VIEW mat_m1 WITH (timescaledb.continuous, timescaledb.finalized = false, check_option = LOCAL )
+CREATE MATERIALIZED VIEW mat_m1 WITH (timescaledb.continuous, timescaledb.materialized_only=false, timescaledb.finalized = false, check_option = LOCAL )
 as
 select * from conditions , mat_t1 WITH NO DATA;
 
 --non-hypertable
-CREATE MATERIALIZED VIEW mat_m1 WITH (timescaledb.continuous, timescaledb.finalized = false)
+CREATE MATERIALIZED VIEW mat_m1 WITH (timescaledb.continuous, timescaledb.materialized_only=false, timescaledb.finalized = false)
 as
 select a, count(*) from mat_t1
 group by a WITH NO DATA;
 
 -- no group by
-CREATE MATERIALIZED VIEW mat_m1 WITH (timescaledb.continuous, timescaledb.finalized = false)
+CREATE MATERIALIZED VIEW mat_m1 WITH (timescaledb.continuous, timescaledb.materialized_only=false, timescaledb.finalized = false)
 as
 select count(*) from conditions  WITH NO DATA;
 
 -- no time_bucket in group by
-CREATE MATERIALIZED VIEW mat_m1 WITH (timescaledb.continuous, timescaledb.finalized = false)
+CREATE MATERIALIZED VIEW mat_m1 WITH (timescaledb.continuous, timescaledb.materialized_only=false, timescaledb.finalized = false)
 as
 select count(*) from conditions group by location WITH NO DATA;
 
 -- with valid query in a CTE
-CREATE MATERIALIZED VIEW mat_m1 WITH (timescaledb.continuous, timescaledb.finalized = false)
+CREATE MATERIALIZED VIEW mat_m1 WITH (timescaledb.continuous, timescaledb.materialized_only=false, timescaledb.finalized = false)
 AS
 with m1 as (
 Select location, count(*) from conditions
@@ -54,26 +54,26 @@ Select location, count(*) from conditions
 select * from m1 WITH NO DATA;
 
 --with DISTINCT ON
-CREATE MATERIALIZED VIEW mat_m1 WITH (timescaledb.continuous, timescaledb.finalized = false)
+CREATE MATERIALIZED VIEW mat_m1 WITH (timescaledb.continuous, timescaledb.materialized_only=false, timescaledb.finalized = false)
 as
  select distinct on ( location ) count(*)  from conditions group by location, time_bucket('1week', timec)  WITH NO DATA;
 
 --aggregate with DISTINCT
-CREATE MATERIALIZED VIEW mat_m1 WITH (timescaledb.continuous, timescaledb.finalized = false)
+CREATE MATERIALIZED VIEW mat_m1 WITH (timescaledb.continuous, timescaledb.materialized_only=false, timescaledb.finalized = false)
 AS
 Select time_bucket('1week', timec),
  count(location) , sum(distinct temperature) from conditions
  group by time_bucket('1week', timec) , location WITH NO DATA;
 
 --aggregate with FILTER
-CREATE MATERIALIZED VIEW mat_m1 WITH (timescaledb.continuous, timescaledb.finalized = false)
+CREATE MATERIALIZED VIEW mat_m1 WITH (timescaledb.continuous, timescaledb.materialized_only=false, timescaledb.finalized = false)
 AS
 Select time_bucket('1week', timec),
  sum(temperature) filter ( where humidity > 20 ) from conditions
  group by time_bucket('1week', timec) , location WITH NO DATA;
 
 -- aggregate with filter in having clause
-CREATE MATERIALIZED VIEW mat_m1 WITH (timescaledb.continuous, timescaledb.finalized = false)
+CREATE MATERIALIZED VIEW mat_m1 WITH (timescaledb.continuous, timescaledb.materialized_only=false, timescaledb.finalized = false)
 AS
 Select time_bucket('1week', timec), max(temperature)
 from conditions
@@ -81,63 +81,63 @@ from conditions
  having sum(temperature) filter ( where humidity > 20 ) > 50 WITH NO DATA;
 
 -- time_bucket on non partitioning column of hypertable
-CREATE MATERIALIZED VIEW mat_m1 WITH (timescaledb.continuous, timescaledb.finalized = false)
+CREATE MATERIALIZED VIEW mat_m1 WITH (timescaledb.continuous, timescaledb.materialized_only=false, timescaledb.finalized = false)
 AS
 Select max(temperature)
 from conditions
  group by time_bucket('1week', timemeasure) , location WITH NO DATA;
 
 --time_bucket on expression
-CREATE MATERIALIZED VIEW mat_m1 WITH (timescaledb.continuous, timescaledb.finalized = false)
+CREATE MATERIALIZED VIEW mat_m1 WITH (timescaledb.continuous, timescaledb.materialized_only=false, timescaledb.finalized = false)
 AS
 Select max(temperature)
 from conditions
  group by time_bucket('1week', timec+ '10 minutes'::interval) , location WITH NO DATA;
 
 --multiple time_bucket functions
-CREATE MATERIALIZED VIEW mat_m1 WITH (timescaledb.continuous, timescaledb.finalized = false)
+CREATE MATERIALIZED VIEW mat_m1 WITH (timescaledb.continuous, timescaledb.materialized_only=false, timescaledb.finalized = false)
 AS
 Select max(temperature)
 from conditions
  group by time_bucket('1week', timec) , time_bucket('1month', timec), location WITH NO DATA;
 
 --time_bucket using additional args
-CREATE MATERIALIZED VIEW mat_m1 WITH (timescaledb.continuous, timescaledb.finalized = false)
+CREATE MATERIALIZED VIEW mat_m1 WITH (timescaledb.continuous, timescaledb.materialized_only=false, timescaledb.finalized = false)
 AS
 Select max(temperature)
 from conditions
  group by time_bucket( INTERVAL '5 minutes', timec, INTERVAL '-2.5 minutes') , location WITH NO DATA;
 
 --time_bucket using non-const for first argument
-CREATE MATERIALIZED VIEW mat_m1 WITH (timescaledb.continuous, timescaledb.finalized = false)
+CREATE MATERIALIZED VIEW mat_m1 WITH (timescaledb.continuous, timescaledb.materialized_only=false, timescaledb.finalized = false)
 AS
 Select max(temperature)
 from conditions
  group by time_bucket( timeinterval, timec) , location WITH NO DATA;
 
 -- ordered set aggr
-CREATE MATERIALIZED VIEW mat_m1 WITH (timescaledb.continuous, timescaledb.finalized = false)
+CREATE MATERIALIZED VIEW mat_m1 WITH (timescaledb.continuous, timescaledb.materialized_only=false, timescaledb.finalized = false)
 AS
 Select mode() within group( order by humidity)
 from conditions
  group by time_bucket('1week', timec)  WITH NO DATA;
 
 --window function
-CREATE MATERIALIZED VIEW mat_m1 WITH (timescaledb.continuous, timescaledb.finalized = false)
+CREATE MATERIALIZED VIEW mat_m1 WITH (timescaledb.continuous, timescaledb.materialized_only=false, timescaledb.finalized = false)
 AS
 Select avg(temperature) over( order by humidity)
 from conditions
  WITH NO DATA;
 
 --aggregate without combine function
-CREATE MATERIALIZED VIEW mat_m1 WITH (timescaledb.continuous, timescaledb.finalized = false)
+CREATE MATERIALIZED VIEW mat_m1 WITH (timescaledb.continuous, timescaledb.materialized_only=false, timescaledb.finalized = false)
 AS
 Select json_agg(location)
 from conditions
  group by time_bucket('1week', timec) , location WITH NO DATA;
 ;
 
-CREATE MATERIALIZED VIEW mat_m1 WITH (timescaledb.continuous, timescaledb.finalized = false)
+CREATE MATERIALIZED VIEW mat_m1 WITH (timescaledb.continuous, timescaledb.materialized_only=false, timescaledb.finalized = false)
 AS
 Select sum(humidity), avg(temperature), array_agg(location)
 from conditions
@@ -150,7 +150,7 @@ CREATE AGGREGATE newavg (
    finalfunc = int8_avg,
    initcond1 = '{0,0}'
 );
-CREATE MATERIALIZED VIEW mat_m1 WITH (timescaledb.continuous, timescaledb.finalized = false)
+CREATE MATERIALIZED VIEW mat_m1 WITH (timescaledb.continuous, timescaledb.materialized_only=false, timescaledb.finalized = false)
 AS
 Select sum(humidity), newavg(temperature::int4)
 from conditions
@@ -158,7 +158,7 @@ from conditions
 ;
 
 -- using subqueries
-CREATE MATERIALIZED VIEW mat_m1 WITH (timescaledb.continuous, timescaledb.finalized = false)
+CREATE MATERIALIZED VIEW mat_m1 WITH (timescaledb.continuous, timescaledb.materialized_only=false, timescaledb.finalized = false)
 AS
 Select sum(humidity), avg(temperature::int4)
 from
@@ -166,7 +166,7 @@ from
 from conditions ) q
  group by time_bucket('1week', timec) , location  WITH NO DATA;
 
-CREATE MATERIALIZED VIEW mat_m1 WITH (timescaledb.continuous, timescaledb.finalized = false)
+CREATE MATERIALIZED VIEW mat_m1 WITH (timescaledb.continuous, timescaledb.materialized_only=false, timescaledb.finalized = false)
 AS
 select * from
 ( Select sum(humidity), avg(temperature::int4)
@@ -174,14 +174,14 @@ from conditions
  group by time_bucket('1week', timec) , location )  q WITH NO DATA;
 
 --using limit /limit offset
-CREATE MATERIALIZED VIEW mat_m1 WITH (timescaledb.continuous, timescaledb.finalized = false)
+CREATE MATERIALIZED VIEW mat_m1 WITH (timescaledb.continuous, timescaledb.materialized_only=false, timescaledb.finalized = false)
 AS
 Select sum(humidity), avg(temperature::int4)
 from conditions
  group by time_bucket('1week', timec) , location
 limit 10  WITH NO DATA;
 
-CREATE MATERIALIZED VIEW mat_m1 WITH (timescaledb.continuous, timescaledb.finalized = false)
+CREATE MATERIALIZED VIEW mat_m1 WITH (timescaledb.continuous, timescaledb.materialized_only=false, timescaledb.finalized = false)
 AS
 Select sum(humidity), avg(temperature::int4)
 from conditions
@@ -189,7 +189,7 @@ from conditions
 offset 10 WITH NO DATA;
 
 --using ORDER BY in view defintion
-CREATE MATERIALIZED VIEW mat_m1 WITH (timescaledb.continuous, timescaledb.finalized = false)
+CREATE MATERIALIZED VIEW mat_m1 WITH (timescaledb.continuous, timescaledb.materialized_only=false, timescaledb.finalized = false)
 AS
 Select sum(humidity), avg(temperature::int4)
 from conditions
@@ -197,7 +197,7 @@ from conditions
 ORDER BY 1 WITH NO DATA;
 
 --using FETCH
-CREATE MATERIALIZED VIEW mat_m1 WITH (timescaledb.continuous, timescaledb.finalized = false)
+CREATE MATERIALIZED VIEW mat_m1 WITH (timescaledb.continuous, timescaledb.materialized_only=false, timescaledb.finalized = false)
 AS
 Select sum(humidity), avg(temperature::int4)
 from conditions
@@ -206,14 +206,14 @@ fetch first 10 rows only WITH NO DATA;
 
 --using locking clauses FOR clause
 --all should be disabled. we cannot guarntee locks on the hypertable
-CREATE MATERIALIZED VIEW mat_m1 WITH (timescaledb.continuous, timescaledb.finalized = false)
+CREATE MATERIALIZED VIEW mat_m1 WITH (timescaledb.continuous, timescaledb.materialized_only=false, timescaledb.finalized = false)
 AS
 Select sum(humidity), avg(temperature::int4)
 from conditions
  group by time_bucket('1week', timec) , location
 FOR KEY SHARE WITH NO DATA;
 
-CREATE MATERIALIZED VIEW mat_m1 WITH (timescaledb.continuous, timescaledb.finalized = false)
+CREATE MATERIALIZED VIEW mat_m1 WITH (timescaledb.continuous, timescaledb.materialized_only=false, timescaledb.finalized = false)
 AS
 Select sum(humidity), avg(temperature::int4)
 from conditions
@@ -221,14 +221,14 @@ from conditions
 FOR SHARE WITH NO DATA;
 
 
-CREATE MATERIALIZED VIEW mat_m1 WITH (timescaledb.continuous, timescaledb.finalized = false)
+CREATE MATERIALIZED VIEW mat_m1 WITH (timescaledb.continuous, timescaledb.materialized_only=false, timescaledb.finalized = false)
 AS
 Select sum(humidity), avg(temperature::int4)
 from conditions
  group by time_bucket('1week', timec) , location
 FOR UPDATE WITH NO DATA;
 
-CREATE MATERIALIZED VIEW mat_m1 WITH (timescaledb.continuous, timescaledb.finalized = false)
+CREATE MATERIALIZED VIEW mat_m1 WITH (timescaledb.continuous, timescaledb.materialized_only=false, timescaledb.finalized = false)
 AS
 Select sum(humidity), avg(temperature::int4)
 from conditions
@@ -236,7 +236,7 @@ from conditions
 FOR NO KEY UPDATE WITH NO DATA;
 
 --tablesample clause
-CREATE MATERIALIZED VIEW mat_m1 WITH (timescaledb.continuous, timescaledb.finalized = false)
+CREATE MATERIALIZED VIEW mat_m1 WITH (timescaledb.continuous, timescaledb.materialized_only=false, timescaledb.finalized = false)
 AS
 Select sum(humidity), avg(temperature::int4)
 from conditions tablesample bernoulli(0.2)
@@ -244,20 +244,20 @@ from conditions tablesample bernoulli(0.2)
  WITH NO DATA;
 
 -- ONLY in from clause
-CREATE MATERIALIZED VIEW mat_m1 WITH (timescaledb.continuous, timescaledb.finalized = false)
+CREATE MATERIALIZED VIEW mat_m1 WITH (timescaledb.continuous, timescaledb.materialized_only=false, timescaledb.finalized = false)
 AS
 Select sum(humidity), avg(temperature::int4)
 from ONLY conditions
  group by time_bucket('1week', timec) , location  WITH NO DATA;
 
 --grouping sets and variants
-CREATE MATERIALIZED VIEW mat_m1 WITH (timescaledb.continuous, timescaledb.finalized = false)
+CREATE MATERIALIZED VIEW mat_m1 WITH (timescaledb.continuous, timescaledb.materialized_only=false, timescaledb.finalized = false)
 AS
 Select sum(humidity), avg(temperature::int4)
 from conditions
  group by grouping sets(time_bucket('1week', timec) , location )  WITH NO DATA;
 
-CREATE MATERIALIZED VIEW mat_m1 WITH (timescaledb.continuous, timescaledb.finalized = false)
+CREATE MATERIALIZED VIEW mat_m1 WITH (timescaledb.continuous, timescaledb.materialized_only=false, timescaledb.finalized = false)
 AS
 Select sum(humidity), avg(temperature::int4)
 from conditions
@@ -267,33 +267,33 @@ group by rollup(time_bucket('1week', timec) , location )  WITH NO DATA;
 CREATE FUNCTION test_stablefunc(int) RETURNS int LANGUAGE 'sql'
        STABLE AS 'SELECT $1 + 10';
 
-CREATE MATERIALIZED VIEW mat_m1 WITH (timescaledb.continuous, timescaledb.finalized = false)
+CREATE MATERIALIZED VIEW mat_m1 WITH (timescaledb.continuous, timescaledb.materialized_only=false, timescaledb.finalized = false)
 AS
 Select sum(humidity), max(timec + INTERVAL '1h')
 from conditions
 group by time_bucket('1week', timec) , location   WITH NO DATA;
 
-CREATE MATERIALIZED VIEW mat_m1 WITH (timescaledb.continuous, timescaledb.finalized = false)
+CREATE MATERIALIZED VIEW mat_m1 WITH (timescaledb.continuous, timescaledb.materialized_only=false, timescaledb.finalized = false)
 AS
 Select sum(humidity), min(location)
 from conditions
 group by time_bucket('1week', timec)
 having  max(timec + INTERVAL '1h') > '2010-01-01 09:00:00-08' WITH NO DATA;
 
-CREATE MATERIALIZED VIEW mat_m1 WITH (timescaledb.continuous, timescaledb.finalized = false)
+CREATE MATERIALIZED VIEW mat_m1 WITH (timescaledb.continuous, timescaledb.materialized_only=false, timescaledb.finalized = false)
 AS
 Select sum( test_stablefunc(humidity::int) ), min(location)
 from conditions
 group by time_bucket('1week', timec) WITH NO DATA;
 
-CREATE MATERIALIZED VIEW mat_m1 WITH (timescaledb.continuous, timescaledb.finalized = false)
+CREATE MATERIALIZED VIEW mat_m1 WITH (timescaledb.continuous, timescaledb.materialized_only=false, timescaledb.finalized = false)
 AS
 Select sum( temperature ), min(location)
 from conditions
 group by time_bucket('1week', timec), test_stablefunc(humidity::int) WITH NO DATA;
 
 -- Should use CREATE MATERIALIZED VIEW to create continuous aggregates
-CREATE VIEW continuous_aggs_errors_tbl1 WITH (timescaledb.continuous, timescaledb.finalized = false) AS
+CREATE VIEW continuous_aggs_errors_tbl1 WITH (timescaledb.continuous, timescaledb.materialized_only=false, timescaledb.finalized = false) AS
 SELECT time_bucket('1 week', timec)
   FROM conditions
 GROUP BY time_bucket('1 week', timec);
@@ -306,20 +306,20 @@ SELECT set_integer_now_func('rowsec_tab', 'integer_now_test');
 alter table rowsec_tab ENABLE ROW LEVEL SECURITY;
 create policy rowsec_tab_allview ON rowsec_tab FOR SELECT USING(true);
 
-CREATE MATERIALIZED VIEW mat_m1 WITH (timescaledb.continuous, timescaledb.finalized = false)
+CREATE MATERIALIZED VIEW mat_m1 WITH (timescaledb.continuous, timescaledb.materialized_only=false, timescaledb.finalized = false)
 AS
 Select sum( b), min(c)
 from rowsec_tab
 group by time_bucket('1', a) WITH NO DATA;
 
 -- cagg on cagg not allowed
-CREATE MATERIALIZED VIEW mat_m1 WITH (timescaledb.continuous, timescaledb.finalized = false)
+CREATE MATERIALIZED VIEW mat_m1 WITH (timescaledb.continuous, timescaledb.materialized_only=false, timescaledb.finalized = false)
 AS
 SELECT time_bucket('1 day', timec) AS bucket
   FROM conditions
 GROUP BY time_bucket('1 day', timec);
 
-CREATE MATERIALIZED VIEW mat_m2_on_mat_m1 WITH (timescaledb.continuous)
+CREATE MATERIALIZED VIEW mat_m2_on_mat_m1 WITH (timescaledb.continuous, timescaledb.materialized_only=false)
 AS
 SELECT time_bucket('1 week', bucket) AS bucket
   FROM mat_m1
@@ -341,7 +341,7 @@ CREATE TABLE conditions (
 select table_name from create_hypertable( 'conditions', 'timec');
 
 create materialized view mat_with_test( timec, minl, sumt , sumh)
-WITH (timescaledb.continuous, timescaledb.finalized = false)
+WITH (timescaledb.continuous, timescaledb.materialized_only=false, timescaledb.finalized = false)
 as
 select time_bucket('1day', timec), min(location), sum(temperature),sum(humidity)
 from conditions
@@ -382,14 +382,14 @@ SELECT set_integer_now_func('conditions', 'integer_now_test_s');
 
 \set ON_ERROR_STOP 0
 create materialized view mat_with_test( timec, minl, sumt , sumh)
-WITH (timescaledb.continuous, timescaledb.finalized = false)
+WITH (timescaledb.continuous, timescaledb.materialized_only=false, timescaledb.finalized = false)
 as
 select time_bucket(100, timec), min(location), sum(temperature),sum(humidity)
 from conditions
 group by time_bucket(100, timec) WITH NO DATA;
 
 create materialized view mat_with_test( timec, minl, sumt , sumh)
-WITH (timescaledb.continuous, timescaledb.finalized = false)
+WITH (timescaledb.continuous, timescaledb.materialized_only=false, timescaledb.finalized = false)
 as
 select time_bucket(100, timec), min(location), sum(temperature),sum(humidity)
 from conditions
@@ -398,7 +398,7 @@ group by time_bucket(100, timec) WITH NO DATA;
 ALTER TABLE conditions ALTER timec type int;
 
 create materialized view mat_with_test( timec, minl, sumt , sumh)
-WITH (timescaledb.continuous, timescaledb.finalized = false)
+WITH (timescaledb.continuous, timescaledb.materialized_only=false, timescaledb.finalized = false)
 as
 select time_bucket(100, timec), min(location), sum(temperature),sum(humidity)
 from conditions
@@ -422,7 +422,7 @@ CREATE OR REPLACE FUNCTION integer_now_test_b() returns bigint LANGUAGE SQL STAB
 SELECT set_integer_now_func('conditions', 'integer_now_test_b');
 
 create materialized view mat_with_test( timec, minl, sumt , sumh)
-WITH (timescaledb.continuous, timescaledb.finalized = false)
+WITH (timescaledb.continuous, timescaledb.materialized_only=false, timescaledb.finalized = false)
 as
 select time_bucket(BIGINT '100', timec), min(location), sum(temperature),sum(humidity)
 from conditions
@@ -439,7 +439,7 @@ CREATE TABLE text_time(time TEXT);
 \set VERBOSITY default
 \set ON_ERROR_STOP 0
 CREATE MATERIALIZED VIEW text_view
-    WITH (timescaledb.continuous, timescaledb.finalized = false)
+    WITH (timescaledb.continuous, timescaledb.materialized_only=false, timescaledb.finalized = false)
     AS SELECT time_bucket('5', text_part_func(time)), COUNT(time)
         FROM text_time
         GROUP BY 1 WITH NO DATA;
@@ -466,7 +466,7 @@ INSERT INTO measurements VALUES ('2019-03-04 13:30', 1, 1.3);
 
 -- Add a continuous aggregate on the measurements table and a policy
 -- to be able to test error cases for the add_job function.
-CREATE MATERIALIZED VIEW measurements_summary WITH (timescaledb.continuous, timescaledb.finalized = false) AS
+CREATE MATERIALIZED VIEW measurements_summary WITH (timescaledb.continuous, timescaledb.materialized_only=false, timescaledb.finalized = false) AS
 SELECT time_bucket('1 day', time), COUNT(time)
   FROM measurements
 GROUP BY 1 WITH NO DATA;
@@ -520,17 +520,17 @@ DROP TABLE conditions CASCADE;
 -- test handling of invalid mat_hypertable_id
 create table i2980(time timestamptz not null);
 select create_hypertable('i2980','time');
-create materialized view i2980_cagg with (timescaledb.continuous, timescaledb.finalized = false) AS SELECT time_bucket('1h',time), avg(7) FROM i2980 GROUP BY 1;
+create materialized view i2980_cagg with (timescaledb.continuous, timescaledb.materialized_only=false, timescaledb.finalized = false) AS SELECT time_bucket('1h',time), avg(7) FROM i2980 GROUP BY 1;
 select add_continuous_aggregate_policy('i2980_cagg',NULL,NULL,'4h') AS job_id \gset
 \set ON_ERROR_STOP 0
 select alter_job(:job_id,config:='{"end_offset": null, "start_offset": null, "mat_hypertable_id": 1000}');
 
 --test creating continuous aggregate with compression enabled --
-CREATE MATERIALIZED VIEW  i2980_cagg2 with (timescaledb.continuous, timescaledb.compress, timescaledb.finalized = false)
+CREATE MATERIALIZED VIEW  i2980_cagg2 with (timescaledb.continuous, timescaledb.materialized_only=false, timescaledb.compress, timescaledb.finalized = false)
 AS SELECT time_bucket('1h',time), avg(7) FROM i2980 GROUP BY 1;
 
 --this one succeeds
-CREATE MATERIALIZED VIEW  i2980_cagg2 with (timescaledb.continuous, timescaledb.finalized = false)
+CREATE MATERIALIZED VIEW  i2980_cagg2 with (timescaledb.continuous, timescaledb.materialized_only=false, timescaledb.finalized = false)
 AS SELECT time_bucket('1h',time) as bucket, avg(7) FROM i2980 GROUP BY 1;
 
 --now enable compression with invalid parameters
@@ -584,4 +584,4 @@ FROM
   INNER JOIN _timescaledb_catalog.hypertable uncompress ON (ht.id = uncompress.compressed_hypertable_id
       AND uncompress.table_name = 'comp_ht_test') \gset
 
-CREATE MATERIALIZED VIEW cagg1 WITH(timescaledb.continuous, timescaledb.finalized = false) AS SELECT time_bucket('1h',_ts_meta_min_1) FROM :INTERNALTABLE GROUP BY 1;
+CREATE MATERIALIZED VIEW cagg1 WITH(timescaledb.continuous, timescaledb.materialized_only=false, timescaledb.finalized = false) AS SELECT time_bucket('1h',_ts_meta_min_1) FROM :INTERNALTABLE GROUP BY 1;

--- a/tsl/test/sql/cagg_joins.sql
+++ b/tsl/test/sql/cagg_joins.sql
@@ -185,7 +185,7 @@ SELECT * FROM cagg ORDER BY bucket, name, thermo_id;
 -- Cagg with inner joins - realtime aggregate + JOIN clause
 
 CREATE MATERIALIZED VIEW cagg_join
-WITH (timescaledb.continuous) AS
+WITH (timescaledb.continuous, timescaledb.materialized_only = FALSE) AS
 SELECT time_bucket(INTERVAL '1 day', day) AS bucket,
    AVG(temperature),
    name
@@ -198,7 +198,7 @@ SELECT * FROM cagg_join ORDER BY bucket, name;
 -- Cagg with inner joins - realtime aggregate + USING clause
 
 CREATE MATERIALIZED VIEW cagg_using
-WITH (timescaledb.continuous) AS
+WITH (timescaledb.continuous, timescaledb.materialized_only = FALSE) AS
 SELECT time_bucket(INTERVAL '1 day', day) AS bucket,
    AVG(temperature),
    name
@@ -226,7 +226,7 @@ SELECT * FROM cagg_reorder ORDER BY bucket, name;
 -- Cagg with inner joins - realtime aggregate + JOIN clause
 
 CREATE MATERIALIZED VIEW cagg_reorder_join
-WITH (timescaledb.continuous) AS
+WITH (timescaledb.continuous, timescaledb.materialized_only = FALSE) AS
 SELECT time_bucket(INTERVAL '1 day', day) AS bucket,
    AVG(temperature),
    name
@@ -239,7 +239,7 @@ SELECT * FROM cagg_reorder_join;
 -- Cagg with inner joins - realtime aggregate + USING clause
 
 CREATE MATERIALIZED VIEW cagg_reorder_using
-WITH (timescaledb.continuous) AS
+WITH (timescaledb.continuous, timescaledb.materialized_only = FALSE) AS
 SELECT time_bucket(INTERVAL '1 day', day) AS bucket,
    AVG(temperature),
    name
@@ -408,14 +408,14 @@ GROUP BY name, bucket, devices.device_id;
 CREATE  TABLE mat_t1( a integer, b integer,c TEXT);
 
 --With LATERAL multiple tables old format
-CREATE MATERIALIZED VIEW mat_m1 WITH (timescaledb.continuous, timescaledb.finalized = false)
+CREATE MATERIALIZED VIEW mat_m1 WITH (timescaledb.continuous, timescaledb.materialized_only = FALSE, timescaledb.finalized = false)
 as
 select temperature, count(*) from conditions,
 LATERAL (Select * from mat_t1 where a = conditions.temperature) q
 group by temperature WITH NO DATA;
 
 --With LATERAL multiple tables in new format
-CREATE MATERIALIZED VIEW mat_m1 WITH (timescaledb.continuous)
+CREATE MATERIALIZED VIEW mat_m1 WITH (timescaledb.continuous, timescaledb.materialized_only = FALSE)
 as
 select temperature, count(*) from conditions,
 LATERAL (Select * from mat_t1 where a = conditions.temperature) q

--- a/tsl/test/sql/cagg_multi.sql
+++ b/tsl/test/sql/cagg_multi.sql
@@ -175,14 +175,14 @@ CREATE OR REPLACE FUNCTION integer_now_foo() returns int LANGUAGE SQL STABLE as 
 SELECT set_integer_now_func('foo', 'integer_now_foo');
 
 CREATE MATERIALIZED VIEW mat_m1(a, countb)
-WITH (timescaledb.continuous)
+WITH (timescaledb.continuous, timescaledb.materialized_only=false)
 AS
 SELECT time_bucket(10, a), count(*)
 FROM foo
 GROUP BY time_bucket(10, a) WITH NO DATA;
 
 CREATE MATERIALIZED VIEW mat_m2(a, countb)
-WITH (timescaledb.continuous)
+WITH (timescaledb.continuous, timescaledb.materialized_only=false)
 AS
 SELECT time_bucket(5, a), count(*)
 FROM foo

--- a/tsl/test/sql/cagg_permissions.sql
+++ b/tsl/test/sql/cagg_permissions.sql
@@ -48,7 +48,7 @@ SELECT set_integer_now_func('conditions', 'integer_now_test1');
 
 
 CREATE MATERIALIZED VIEW mat_refresh_test
-WITH (timescaledb.continuous)
+WITH (timescaledb.continuous, timescaledb.materialized_only=false)
 as
 select location, max(humidity)
 from conditions
@@ -252,7 +252,7 @@ CREATE TABLE test_default_privileges.devices (
 SELECT create_hypertable('test_default_privileges.devices', 'time');
 
 CREATE MATERIALIZED VIEW test_default_privileges.devices_summary
-WITH (timescaledb.continuous)
+WITH (timescaledb.continuous, timescaledb.materialized_only=false)
 AS
 SELECT time_bucket('1 day', time) AS bucket, device, MAX(temp)
 FROM test_default_privileges.devices

--- a/tsl/test/sql/cagg_query.sql.in
+++ b/tsl/test/sql/cagg_query.sql.in
@@ -46,7 +46,7 @@ insert into location_tab values( 2, 'NYC');
 insert into location_tab values( 3, 'por');
 
 create materialized view mat_m1( location, timec, minl, sumt , sumh)
-WITH (timescaledb.continuous)
+WITH (timescaledb.continuous, timescaledb.materialized_only=false)
 as
 select location, time_bucket('1day', timec), min(location), sum(temperature),sum(humidity)
 from conditions
@@ -59,7 +59,7 @@ CALL refresh_continuous_aggregate('mat_m1', NULL, NULL);
 
 --test first/last
 create materialized view mat_m2(location, timec, firsth, lasth, maxtemp, mintemp)
-WITH (timescaledb.continuous)
+WITH (timescaledb.continuous, timescaledb.materialized_only=false)
 as
 select location, time_bucket('1day', timec), first(humidity, timec), last(humidity, timec), max(temperature), min(temperature)
 from conditions

--- a/tsl/test/sql/cagg_repair.sql
+++ b/tsl/test/sql/cagg_repair.sql
@@ -94,7 +94,7 @@ SELECT * FROM conditions_summary ORDER BY bucket, device_name;
 
 -- Tests without join
 CREATE MATERIALIZED VIEW conditions_summary_nojoin
-WITH (timescaledb.continuous) AS
+WITH (timescaledb.continuous, timescaledb.materialized_only=false) AS
 SELECT
     time_bucket(INTERVAL '1 week', "time") AS bucket,
     MIN(temperature),
@@ -111,7 +111,7 @@ CALL _timescaledb_internal.cagg_try_repair('conditions_summary_nojoin', TRUE);
 
 -- Tests with old cagg format
 CREATE MATERIALIZED VIEW conditions_summary_old_format
-WITH (timescaledb.continuous, timescaledb.finalized=false) AS
+WITH (timescaledb.continuous, timescaledb.materialized_only=false, timescaledb.finalized=false) AS
 SELECT
     time_bucket(INTERVAL '1 week', "time") AS bucket,
     MIN(temperature),

--- a/tsl/test/sql/cagg_union_view.sql.in
+++ b/tsl/test/sql/cagg_union_view.sql.in
@@ -21,7 +21,7 @@ INSERT INTO metrics(time, device_id, value) SELECT '2000-01-01'::timestamptz, de
 
 -- check default view for new continuous aggregate
 CREATE MATERIALIZED VIEW metrics_summary
-  WITH (timescaledb.continuous)
+  WITH (timescaledb.continuous, timescaledb.materialized_only=false)
 AS
   SELECT time_bucket('1d',time), avg(value) FROM metrics GROUP BY 1 WITH NO DATA;
 
@@ -150,7 +150,7 @@ SELECT create_hypertable('boundary_test','time',chunk_time_interval:=10);
 SELECT set_integer_now_func('boundary_test','boundary_test_int_now');
 
 CREATE MATERIALIZED VIEW boundary_view
-  WITH (timescaledb.continuous)
+  WITH (timescaledb.continuous, timescaledb.materialized_only=false)
 AS
   SELECT time_bucket(10,time), avg(value) FROM boundary_test GROUP BY 1 WITH NO DATA;
 
@@ -207,7 +207,7 @@ SELECT set_integer_now_func('ht_intdata', 'integer_now_ht_intdata');
 
 
 CREATE MATERIALIZED VIEW mat_m1(a, countb, sumbc, spreadcb, avgc)
-WITH (timescaledb.continuous)
+WITH (timescaledb.continuous, timescaledb.materialized_only=false)
 AS
 SELECT time_bucket(1, a), count(*), sum(b+c), max(c)-min(b), avg(c)::int
 FROM ht_intdata
@@ -252,7 +252,7 @@ DROP MATERIALIZED VIEW mat_m1;
 
 --- TEST union view with multiple WHERE and HAVING clauses
 CREATE MATERIALIZED VIEW mat_m1
-WITH (timescaledb.continuous)
+WITH (timescaledb.continuous, timescaledb.materialized_only=false)
 AS
 SELECT time_bucket(5, a), sum(b+c)
 FROM ht_intdata
@@ -329,42 +329,42 @@ SELECT set_integer_now_func('int_table', 'int_now');
 SELECT set_integer_now_func('bigint_table', 'bigint_now');
 
 CREATE MATERIALIZED VIEW smallint_agg
-WITH (timescaledb.continuous)
+WITH (timescaledb.continuous, timescaledb.materialized_only=false)
 AS
 SELECT time_bucket(SMALLINT '10', time) AS bucket, avg(value)
 FROM smallint_table
 GROUP BY 1 WITH NO DATA;
 
 CREATE MATERIALIZED VIEW int_agg
-WITH (timescaledb.continuous)
+WITH (timescaledb.continuous, timescaledb.materialized_only=false)
 AS
 SELECT time_bucket(5, time) AS bucket, avg(value)
 FROM int_table
 GROUP BY 1 WITH NO DATA;
 
 CREATE MATERIALIZED VIEW bigint_agg
-WITH (timescaledb.continuous)
+WITH (timescaledb.continuous, timescaledb.materialized_only=false)
 AS
 SELECT time_bucket(BIGINT '10', time) AS bucket, avg(value)
 FROM bigint_table
 GROUP BY 1 WITH NO DATA;
 
 CREATE MATERIALIZED VIEW date_agg
-WITH (timescaledb.continuous)
+WITH (timescaledb.continuous, timescaledb.materialized_only=false)
 AS
 SELECT time_bucket('2 days', time) AS bucket, avg(value)
 FROM date_table
 GROUP BY 1 WITH NO DATA;
 
 CREATE MATERIALIZED VIEW timestamp_agg
-WITH (timescaledb.continuous)
+WITH (timescaledb.continuous, timescaledb.materialized_only=false)
 AS
 SELECT time_bucket('2 days', time) AS bucket, avg(value)
 FROM timestamp_table
 GROUP BY 1 WITH NO DATA;
 
 CREATE MATERIALIZED VIEW timestamptz_agg
-WITH (timescaledb.continuous)
+WITH (timescaledb.continuous, timescaledb.materialized_only=false)
 AS
 SELECT time_bucket('2 days', time) AS bucket, avg(value)
 FROM timestamptz_table

--- a/tsl/test/sql/cagg_watermark.sql
+++ b/tsl/test/sql/cagg_watermark.sql
@@ -109,7 +109,7 @@ CREATE OR REPLACE FUNCTION integer_now_test2() returns int LANGUAGE SQL STABLE a
 SELECT set_integer_now_func('ca_inval_test', 'integer_now_test2');
 
 CREATE MATERIALIZED VIEW cit_view
-    WITH ( timescaledb.continuous)
+    WITH (timescaledb.continuous, timescaledb.materialized_only=false)
     AS SELECT time_bucket('5', time), COUNT(time)
         FROM ca_inval_test
         GROUP BY 1 WITH NO DATA;
@@ -167,7 +167,7 @@ SELECT set_integer_now_func('ts_continuous_test', 'integer_now_test3');
 INSERT INTO ts_continuous_test SELECT i, i FROM
     (SELECT generate_series(0, 29) AS i) AS i;
 CREATE MATERIALIZED VIEW continuous_view
-    WITH ( timescaledb.continuous)
+    WITH (timescaledb.continuous, timescaledb.materialized_only=false)
     AS SELECT time_bucket('5', time), COUNT(location)
         FROM ts_continuous_test
         GROUP BY 1 WITH NO DATA;

--- a/tsl/test/sql/chunk_utils_internal.sql
+++ b/tsl/test/sql/chunk_utils_internal.sql
@@ -238,7 +238,7 @@ CREATE OR REPLACE FUNCTION hyper_dummy_now() RETURNS BIGINT
 LANGUAGE SQL IMMUTABLE AS  'SELECT 100::BIGINT';
 SELECT set_integer_now_func('test1.hyper1', 'hyper_dummy_now');
 
-CREATE MATERIALIZED VIEW hyper1_cagg WITH (timescaledb.continuous)
+CREATE MATERIALIZED VIEW hyper1_cagg WITH (timescaledb.continuous, timescaledb.materialized_only=false)
 AS SELECT time_bucket( 5, "time") as bucket, count(*)
 FROM test1.hyper1 GROUP BY 1;
 SELECT * FROM hyper1_cagg ORDER BY 1;

--- a/tsl/test/sql/continuous_aggs.sql.in
+++ b/tsl/test/sql/continuous_aggs.sql.in
@@ -879,13 +879,13 @@ CALL refresh_continuous_aggregate('mat_refresh_test', NULL, NULL);
 SELECT * FROM mat_refresh_test order by 1,2 ;
 
 -- test for bug when group by is not in project list
-CREATE MATERIALIZED VIEW conditions_grpby_view with (timescaledb.continuous) as
+CREATE MATERIALIZED VIEW conditions_grpby_view with (timescaledb.continuous, timescaledb.materialized_only=false) as
 select time_bucket(100, timec),  sum(humidity)
 from conditions
 group by time_bucket(100, timec), location;
 select * from conditions_grpby_view order by 1, 2;
 
-CREATE MATERIALIZED VIEW conditions_grpby_view2 with (timescaledb.continuous) as
+CREATE MATERIALIZED VIEW conditions_grpby_view2 with (timescaledb.continuous, timescaledb.materialized_only=false) as
 select time_bucket(100, timec), sum(humidity)
 from conditions
 group by time_bucket(100, timec), location
@@ -922,7 +922,7 @@ SELECT
   '{foo,bar,baz}',
   '{1,2.5,3}';
 
-CREATE MATERIALIZED VIEW mat_types WITH (timescaledb.continuous) AS
+CREATE MATERIALIZED VIEW mat_types WITH (timescaledb.continuous, timescaledb.materialized_only=false) AS
 SELECT
   time_bucket('1d', time),
   min(status) AS status,
@@ -1035,7 +1035,7 @@ select create_hypertable('raw_data','time', chunk_time_interval=>'15 days'::inte
 insert into raw_data select '2000-01-01','Q1';
 
 --having has exprs that appear in select
-CREATE MATERIALIZED VIEW search_query_count_1m WITH (timescaledb.continuous)
+CREATE MATERIALIZED VIEW search_query_count_1m WITH (timescaledb.continuous, timescaledb.materialized_only=false)
 AS
  SELECT  search_query,count(search_query) as count,
          time_bucket(INTERVAL '1 minute', time) AS bucket
@@ -1044,7 +1044,7 @@ AS
  GROUP BY search_query, bucket HAVING count(search_query) > 3 OR sum(cnt) > 1;
 
 --having has aggregates + grp by columns that appear in select
-CREATE MATERIALIZED VIEW search_query_count_2 WITH (timescaledb.continuous)
+CREATE MATERIALIZED VIEW search_query_count_2 WITH (timescaledb.continuous, timescaledb.materialized_only=false)
 AS
  SELECT  search_query,count(search_query) as count, sum(cnt),
          time_bucket(INTERVAL '1 minute', time) AS bucket
@@ -1055,7 +1055,7 @@ HAVING count(search_query) > 3 OR sum(cnt) > 1 OR
        ( sum(cnt) + count(cnt)) > 1
        AND search_query = 'Q1';
 
-CREATE MATERIALIZED VIEW search_query_count_3 WITH (timescaledb.continuous)
+CREATE MATERIALIZED VIEW search_query_count_3 WITH (timescaledb.continuous, timescaledb.materialized_only=false)
 AS
  SELECT  search_query,count(search_query) as count, sum(cnt),
          time_bucket(INTERVAL '1 minute', time) AS bucket
@@ -1176,7 +1176,7 @@ SELECT create_hypertable('test_morecols', 'time', chunk_time_interval=> '7 days'
 INSERT INTO test_morecols
 SELECT generate_series('2018-12-01 00:00'::timestamp, '2018-12-31 00:00'::timestamp, '1 day'), 55, 75, 40, 70, NULL, 100, 200, 200;
 
-CREATE MATERIALIZED VIEW test_morecols_cagg with (timescaledb.continuous)
+CREATE MATERIALIZED VIEW test_morecols_cagg with (timescaledb.continuous, timescaledb.materialized_only=false)
 AS SELECT time_bucket('30 days',time), avg(val1),  count(val2)
  FROM test_morecols GROUP BY 1;
 
@@ -1219,7 +1219,7 @@ FROM generate_series('2000-01-13 0:00:00+0'::timestamptz,'2000-01-19 23:55:00+0'
      generate_series(1,5,1) gdevice(device_id);
 ANALYZE issue3248;
 
-CREATE materialized view issue3248_cagg WITH (timescaledb.continuous)
+CREATE materialized view issue3248_cagg WITH (timescaledb.continuous, timescaledb.materialized_only=false)
 AS SELECT time_bucket('1h',time), device_id, min(v0), max(v1), avg(v2)
 FROM issue3248 GROUP BY 1,2;
 
@@ -1241,7 +1241,7 @@ select t, round(random()*10), random()*5
 from generate_series('2020-01-01', '2020-02-25', INTERVAL '12 hours') t;
 
 create materialized view cagg_index_true
-with (timescaledb.continuous, timescaledb.create_group_indexes=true) as
+with (timescaledb.continuous, timescaledb.materialized_only=false, timescaledb.create_group_indexes=true) as
 select
 	time_bucket('1 day', "time") as bucket,
 	sum(value),
@@ -1250,7 +1250,7 @@ from test_group_idx
 group by bucket, symbol;
 
 create materialized view cagg_index_false
-with (timescaledb.continuous, timescaledb.create_group_indexes=false) as
+with (timescaledb.continuous, timescaledb.materialized_only=false, timescaledb.create_group_indexes=false) as
 select
 	time_bucket('1 day', "time") as bucket,
 	sum(value),
@@ -1259,7 +1259,7 @@ from test_group_idx
 group by bucket, symbol;
 
 create materialized view cagg_index_default
-with (timescaledb.continuous) as
+with (timescaledb.continuous, timescaledb.materialized_only=false) as
 select
 	time_bucket('1 day', "time") as bucket,
 	sum(value),
@@ -1311,7 +1311,7 @@ VALUES
   ('2018-11-03 09:00:00-08', 'NYC', 35, 25);
 
 -- aggregate with DISTINCT
-CREATE MATERIALIZED VIEW mat_m1 WITH (timescaledb.continuous)
+CREATE MATERIALIZED VIEW mat_m1 WITH (timescaledb.continuous, timescaledb.materialized_only=false)
 AS
 SELECT
   time_bucket('1week', timec),
@@ -1324,7 +1324,7 @@ SELECT * FROM mat_m1 ORDER BY 1, 2, 3;
 
 -- aggregate with FILTER
 DROP MATERIALIZED VIEW mat_m1;
-CREATE MATERIALIZED VIEW mat_m1 WITH (timescaledb.continuous)
+CREATE MATERIALIZED VIEW mat_m1 WITH (timescaledb.continuous, timescaledb.materialized_only=false)
 AS
 SELECT
   time_bucket('1week', timec),
@@ -1336,7 +1336,7 @@ SELECT * FROM mat_m1 ORDER BY 1, 2;
 
 -- aggregate with filter in having clause
 DROP MATERIALIZED VIEW mat_m1;
-CREATE MATERIALIZED VIEW mat_m1 WITH (timescaledb.continuous)
+CREATE MATERIALIZED VIEW mat_m1 WITH (timescaledb.continuous, timescaledb.materialized_only=false)
 AS
 SELECT
   time_bucket('1week', timec),
@@ -1349,7 +1349,7 @@ SELECT * FROM mat_m1 ORDER BY 1, 2;
 
 -- ordered set aggr
 DROP MATERIALIZED VIEW mat_m1;
-CREATE MATERIALIZED VIEW mat_m1 WITH (timescaledb.continuous)
+CREATE MATERIALIZED VIEW mat_m1 WITH (timescaledb.continuous, timescaledb.materialized_only=false)
 AS
 SELECT
   time_bucket('1week', timec),
@@ -1361,7 +1361,7 @@ SELECT * FROM mat_m1 ORDER BY 1;
 
 -- hypothetical-set aggr
 DROP MATERIALIZED VIEW mat_m1;
-CREATE MATERIALIZED VIEW mat_m1 WITH (timescaledb.continuous)
+CREATE MATERIALIZED VIEW mat_m1 WITH (timescaledb.continuous, timescaledb.materialized_only=false)
 AS
 SELECT
   time_bucket('1week', timec),
@@ -1383,7 +1383,7 @@ CREATE AGGREGATE newavg (
   initcond1 = '{0,0}'
 );
 
-CREATE MATERIALIZED VIEW mat_m1 WITH (timescaledb.continuous)
+CREATE MATERIALIZED VIEW mat_m1 WITH (timescaledb.continuous, timescaledb.materialized_only=false)
 AS
 SELECT
   SUM(humidity),
@@ -1395,7 +1395,7 @@ SELECT * FROM mat_m1 ORDER BY 1, 2;
 
 -- ORDER BY in the view definition
 DROP MATERIALIZED VIEW mat_m1;
-CREATE MATERIALIZED VIEW mat_m1 WITH (timescaledb.continuous)
+CREATE MATERIALIZED VIEW mat_m1 WITH (timescaledb.continuous, timescaledb.materialized_only=false)
 AS
 SELECT
   time_bucket('1week', timec),
@@ -1530,7 +1530,7 @@ SELECT table_name FROM create_hypertable('conditions', 'timec');
 INSERT INTO conditions
 SELECT t, 10 FROM generate_series('2023-01-01 00:00-03'::timestamptz, '2023-12-31 23:59-03'::timestamptz, '1 hour'::interval) AS t;
 
-CREATE MATERIALIZED VIEW conditions_daily WITH (timescaledb.continuous)
+CREATE MATERIALIZED VIEW conditions_daily WITH (timescaledb.continuous, timescaledb.materialized_only=false)
 AS
 SELECT
   time_bucket('1 day', timec),

--- a/tsl/test/sql/continuous_aggs_deprecated.sql.in
+++ b/tsl/test/sql/continuous_aggs_deprecated.sql.in
@@ -883,13 +883,13 @@ CALL refresh_continuous_aggregate('mat_refresh_test', NULL, NULL);
 SELECT * FROM mat_refresh_test order by 1,2 ;
 
 -- test for bug when group by is not in project list
-CREATE MATERIALIZED VIEW conditions_grpby_view with (timescaledb.continuous, timescaledb.finalized=false) as
+CREATE MATERIALIZED VIEW conditions_grpby_view with (timescaledb.continuous, timescaledb.materialized_only=false, timescaledb.finalized=false) as
 select time_bucket(100, timec),  sum(humidity)
 from conditions
 group by time_bucket(100, timec), location;
 select * from conditions_grpby_view order by 1, 2;
 
-CREATE MATERIALIZED VIEW conditions_grpby_view2 with (timescaledb.continuous, timescaledb.finalized=false) as
+CREATE MATERIALIZED VIEW conditions_grpby_view2 with (timescaledb.continuous, timescaledb.materialized_only=false, timescaledb.finalized=false) as
 select time_bucket(100, timec), sum(humidity)
 from conditions
 group by time_bucket(100, timec), location
@@ -926,7 +926,7 @@ SELECT
   '{foo,bar,baz}',
   '{1,2.5,3}';
 
-CREATE MATERIALIZED VIEW mat_types WITH (timescaledb.continuous, timescaledb.finalized=false) AS
+CREATE MATERIALIZED VIEW mat_types WITH (timescaledb.continuous, timescaledb.materialized_only=false, timescaledb.finalized=false) AS
 SELECT
   time_bucket('1d', time),
   min(status) AS status,
@@ -1039,7 +1039,7 @@ select create_hypertable('raw_data','time', chunk_time_interval=>'15 days'::inte
 insert into raw_data select '2000-01-01','Q1';
 
 --having has exprs that appear in select
-CREATE MATERIALIZED VIEW search_query_count_1m WITH (timescaledb.continuous, timescaledb.finalized=false)
+CREATE MATERIALIZED VIEW search_query_count_1m WITH (timescaledb.continuous, timescaledb.materialized_only=false, timescaledb.finalized=false)
 AS
  SELECT  search_query,count(search_query) as count,
          time_bucket(INTERVAL '1 minute', time) AS bucket
@@ -1048,7 +1048,7 @@ AS
  GROUP BY search_query, bucket HAVING count(search_query) > 3 OR sum(cnt) > 1;
 
 --having has aggregates + grp by columns that appear in select
-CREATE MATERIALIZED VIEW search_query_count_2 WITH (timescaledb.continuous, timescaledb.finalized=false)
+CREATE MATERIALIZED VIEW search_query_count_2 WITH (timescaledb.continuous, timescaledb.materialized_only=false, timescaledb.finalized=false)
 AS
  SELECT  search_query,count(search_query) as count, sum(cnt),
          time_bucket(INTERVAL '1 minute', time) AS bucket
@@ -1059,7 +1059,7 @@ HAVING count(search_query) > 3 OR sum(cnt) > 1 OR
        ( sum(cnt) + count(cnt)) > 1
        AND search_query = 'Q1';
 
-CREATE MATERIALIZED VIEW search_query_count_3 WITH (timescaledb.continuous, timescaledb.finalized=false)
+CREATE MATERIALIZED VIEW search_query_count_3 WITH (timescaledb.continuous, timescaledb.materialized_only=false, timescaledb.finalized=false)
 AS
  SELECT  search_query,count(search_query) as count, sum(cnt),
          time_bucket(INTERVAL '1 minute', time) AS bucket
@@ -1178,7 +1178,7 @@ SELECT create_hypertable('test_morecols', 'time', chunk_time_interval=> '7 days'
 INSERT INTO test_morecols
 SELECT generate_series('2018-12-01 00:00'::timestamp, '2018-12-31 00:00'::timestamp, '1 day'), 55, 75, 40, 70, NULL, 100, 200, 200;
 
-CREATE MATERIALIZED VIEW test_morecols_cagg with (timescaledb.continuous, timescaledb.finalized=false)
+CREATE MATERIALIZED VIEW test_morecols_cagg with (timescaledb.continuous, timescaledb.materialized_only=false, timescaledb.finalized=false)
 AS SELECT time_bucket('30 days',time), avg(val1),  count(val2)
  FROM test_morecols GROUP BY 1;
 
@@ -1221,7 +1221,7 @@ FROM generate_series('2000-01-13 0:00:00+0'::timestamptz,'2000-01-19 23:55:00+0'
      generate_series(1,5,1) gdevice(device_id);
 ANALYZE issue3248;
 
-CREATE materialized view issue3248_cagg WITH (timescaledb.continuous, timescaledb.finalized=false)
+CREATE materialized view issue3248_cagg WITH (timescaledb.continuous, timescaledb.materialized_only=false, timescaledb.finalized=false)
 AS SELECT time_bucket('1h',time), device_id, min(v0), max(v1), avg(v2)
 FROM issue3248 GROUP BY 1,2;
 
@@ -1243,7 +1243,7 @@ select t, round(random()*10), random()*5
 from generate_series('2020-01-01', '2020-02-25', INTERVAL '12 hours') t;
 
 create materialized view cagg_index_true
-with (timescaledb.continuous, timescaledb.create_group_indexes=true, timescaledb.finalized=false) as
+with (timescaledb.continuous, timescaledb.materialized_only=false, timescaledb.create_group_indexes=true, timescaledb.finalized=false) as
 select
 	time_bucket('1 day', "time") as bucket,
 	sum(value),
@@ -1252,7 +1252,7 @@ from test_group_idx
 group by bucket, symbol;
 
 create materialized view cagg_index_false
-with (timescaledb.continuous, timescaledb.create_group_indexes=false, timescaledb.finalized=false) as
+with (timescaledb.continuous, timescaledb.materialized_only=false, timescaledb.create_group_indexes=false, timescaledb.finalized=false) as
 select
 	time_bucket('1 day', "time") as bucket,
 	sum(value),
@@ -1261,7 +1261,7 @@ from test_group_idx
 group by bucket, symbol;
 
 create materialized view cagg_index_default
-with (timescaledb.continuous, timescaledb.finalized=false) as
+with (timescaledb.continuous, timescaledb.materialized_only=false, timescaledb.finalized=false) as
 select
 	time_bucket('1 day', "time") as bucket,
 	sum(value),

--- a/tsl/test/sql/exp_cagg_monthly.sql
+++ b/tsl/test/sql/exp_cagg_monthly.sql
@@ -224,7 +224,7 @@ WHERE hypertable_id = :ht_id;
 -- Create a real-time aggregate
 DROP MATERIALIZED VIEW conditions_summary;
 CREATE MATERIALIZED VIEW conditions_summary
-WITH (timescaledb.continuous) AS
+WITH (timescaledb.continuous, timescaledb.materialized_only=false) AS
 SELECT city,
    timescaledb_experimental.time_bucket_ng('1 month', day) AS bucket,
    MIN(temperature),
@@ -306,7 +306,7 @@ SELECT ts, date_part('month', ts)*100 + date_part('day', ts)
 FROM generate_series('2010-01-01' :: date, '2020-01-01' :: date - interval '1 day', '1 day') as ts;
 
 CREATE MATERIALIZED VIEW conditions_large_2m
-WITH (timescaledb.continuous) AS
+WITH (timescaledb.continuous, timescaledb.materialized_only=false) AS
 SELECT
    timescaledb_experimental.time_bucket_ng('2 months', day) AS bucket,
    MIN(temperature),
@@ -317,7 +317,7 @@ GROUP BY bucket;
 SELECT * FROM conditions_large_2m ORDER BY bucket;
 
 CREATE MATERIALIZED VIEW conditions_large_3m
-WITH (timescaledb.continuous) AS
+WITH (timescaledb.continuous, timescaledb.materialized_only=false) AS
 SELECT
    timescaledb_experimental.time_bucket_ng('3 months', day) AS bucket,
    MIN(temperature),
@@ -328,7 +328,7 @@ GROUP BY bucket;
 SELECT * FROM conditions_large_3m ORDER BY bucket;
 
 CREATE MATERIALIZED VIEW conditions_large_4m
-WITH (timescaledb.continuous) AS
+WITH (timescaledb.continuous, timescaledb.materialized_only=false) AS
 SELECT
    timescaledb_experimental.time_bucket_ng('4 months', day) AS bucket,
    MIN(temperature),
@@ -339,7 +339,7 @@ GROUP BY bucket;
 SELECT * FROM conditions_large_4m ORDER BY bucket;
 
 CREATE MATERIALIZED VIEW conditions_large_5m
-WITH (timescaledb.continuous) AS
+WITH (timescaledb.continuous, timescaledb.materialized_only=false) AS
 SELECT
    timescaledb_experimental.time_bucket_ng('5 months', day) AS bucket,
    MIN(temperature),
@@ -350,7 +350,7 @@ GROUP BY bucket;
 SELECT * FROM conditions_large_5m ORDER BY bucket;
 
 CREATE MATERIALIZED VIEW conditions_large_6m
-WITH (timescaledb.continuous) AS
+WITH (timescaledb.continuous, timescaledb.materialized_only=false) AS
 SELECT
    timescaledb_experimental.time_bucket_ng('6 months', day) AS bucket,
    MIN(temperature),
@@ -361,7 +361,7 @@ GROUP BY bucket;
 SELECT * FROM conditions_large_6m ORDER BY bucket;
 
 CREATE MATERIALIZED VIEW conditions_large_1y
-WITH (timescaledb.continuous) AS
+WITH (timescaledb.continuous, timescaledb.materialized_only=false) AS
 SELECT
    timescaledb_experimental.time_bucket_ng('1 year', day) AS bucket,
    MIN(temperature),
@@ -372,7 +372,7 @@ GROUP BY bucket;
 SELECT * FROM conditions_large_1y ORDER BY bucket;
 
 CREATE MATERIALIZED VIEW conditions_large_1y1m
-WITH (timescaledb.continuous) AS
+WITH (timescaledb.continuous, timescaledb.materialized_only=false) AS
 SELECT
    timescaledb_experimental.time_bucket_ng('1 year 1 month', day) AS bucket,
    MIN(temperature),
@@ -435,7 +435,7 @@ SELECT ts, date_part('month', ts)*100 + date_part('day', ts)
 FROM generate_series('2010-01-01' :: date, '2010-03-01' :: date - interval '1 day', '1 day') as ts;
 
 CREATE MATERIALIZED VIEW conditions_dist_1m
-WITH (timescaledb.continuous) AS
+WITH (timescaledb.continuous, timescaledb.materialized_only=false) AS
 SELECT
    timescaledb_experimental.time_bucket_ng('1 month', day) AS bucket,
    MIN(temperature),

--- a/tsl/test/sql/exp_cagg_next_gen.sql
+++ b/tsl/test/sql/exp_cagg_next_gen.sql
@@ -32,7 +32,7 @@ INSERT INTO conditions (day, city, temperature) VALUES
   ('2021-06-27', 'Moscow', 31);
 
 CREATE MATERIALIZED VIEW conditions_summary_weekly
-WITH (timescaledb.continuous) AS
+WITH (timescaledb.continuous, timescaledb.materialized_only=false) AS
 SELECT city,
        timescaledb_experimental.time_bucket_ng('7 days', day) AS bucket,
        MIN(temperature),
@@ -75,7 +75,7 @@ INSERT INTO conditions (tstamp, city, temperature) VALUES
   ('2021-06-14 12:32:20', 'Moscow', 31);
 
 CREATE MATERIALIZED VIEW conditions_summary_30sec
-WITH (timescaledb.continuous) AS
+WITH (timescaledb.continuous, timescaledb.materialized_only=false) AS
 SELECT city,
        timescaledb_experimental.time_bucket_ng('30 seconds', tstamp) AS bucket,
        MIN(temperature),
@@ -84,7 +84,7 @@ FROM conditions
 GROUP BY city, bucket;
 
 CREATE MATERIALIZED VIEW conditions_summary_1min
-WITH (timescaledb.continuous) AS
+WITH (timescaledb.continuous, timescaledb.materialized_only=false) AS
 SELECT city,
        timescaledb_experimental.time_bucket_ng('1 minute', tstamp) AS bucket,
        MIN(temperature),
@@ -93,7 +93,7 @@ FROM conditions
 GROUP BY city, bucket;
 
 CREATE MATERIALIZED VIEW conditions_summary_1hour
-WITH (timescaledb.continuous) AS
+WITH (timescaledb.continuous, timescaledb.materialized_only=false) AS
 SELECT city,
        timescaledb_experimental.time_bucket_ng('1 hour', tstamp) AS bucket,
        MIN(temperature),

--- a/tsl/test/sql/exp_cagg_origin.sql
+++ b/tsl/test/sql/exp_cagg_origin.sql
@@ -186,7 +186,7 @@ WHERE hypertable_id = :ht_id;
 
 -- Create a real-time aggregate with custom origin - June 2000
 CREATE MATERIALIZED VIEW conditions_summary_rt
-WITH (timescaledb.continuous) AS
+WITH (timescaledb.continuous, timescaledb.materialized_only=false) AS
 SELECT city,
    timescaledb_experimental.time_bucket_ng('1 month', day, '2000-06-01' :: date) AS bucket,
    MIN(temperature),
@@ -282,7 +282,7 @@ SELECT ts, date_part('month', ts)*100 + date_part('day', ts)
 FROM generate_series('2010-01-01' :: date, '2010-03-01' :: date - interval '1 day', '1 day') as ts;
 
 CREATE MATERIALIZED VIEW conditions_dist_1m
-WITH (timescaledb.continuous) AS
+WITH (timescaledb.continuous, timescaledb.materialized_only=false) AS
 SELECT
    timescaledb_experimental.time_bucket_ng('1 month', day, '2010-01-01') AS bucket,
    MIN(temperature),
@@ -479,7 +479,7 @@ SELECT create_hypertable(
 );
 
 CREATE MATERIALIZED VIEW conditions_summary_timestamp
-WITH (timescaledb.continuous) AS
+WITH (timescaledb.continuous, timescaledb.materialized_only=false) AS
 SELECT city,
    timescaledb_experimental.time_bucket_ng('12 hours', tstamp, '2000-06-01 12:00:00') AS bucket,
    MIN(temperature),
@@ -593,7 +593,7 @@ GROUP BY city, bucket;
 \set ON_ERROR_STOP 1
 
 CREATE MATERIALIZED VIEW conditions_summary_timestamptz
-WITH (timescaledb.continuous) AS
+WITH (timescaledb.continuous, timescaledb.materialized_only=false) AS
 SELECT city,
    timescaledb_experimental.time_bucket_ng('12 hours', tstamp, '2020-06-01 12:00:00 MSK', 'Europe/Moscow') AS bucket,
    MIN(temperature),

--- a/tsl/test/sql/exp_cagg_timezone.sql
+++ b/tsl/test/sql/exp_cagg_timezone.sql
@@ -282,7 +282,7 @@ DROP MATERIALIZED VIEW conditions_summary_1w;
 
 -- Create a real-time aggregate
 CREATE MATERIALIZED VIEW conditions_summary_tz
-WITH (timescaledb.continuous) AS
+WITH (timescaledb.continuous, timescaledb.materialized_only=false) AS
 SELECT city,
    timescaledb_experimental.time_bucket_ng('1 month', day, 'MSK') AS bucket,
    MIN(temperature),
@@ -362,7 +362,7 @@ SELECT create_hypertable(
 
 -- Create a real-time aggregate on top of empty HT
 CREATE MATERIALIZED VIEW conditions2_summary
-WITH (timescaledb.continuous) AS
+WITH (timescaledb.continuous, timescaledb.materialized_only=false) AS
 SELECT city,
    timescaledb_experimental.time_bucket_ng('7 days', day, 'MSK') AS bucket,
    MIN(temperature),
@@ -443,7 +443,7 @@ SELECT ts, date_part('month', ts)*100 + date_part('day', ts)
 FROM generate_series('2010-01-01 00:00:00 MSK' :: timestamptz, '2010-03-01 00:00:00 MSK' :: timestamptz - interval '1 day', '1 day') as ts;
 
 CREATE MATERIALIZED VIEW conditions_dist_1m
-WITH (timescaledb.continuous) AS
+WITH (timescaledb.continuous, timescaledb.materialized_only=false) AS
 SELECT
    timescaledb_experimental.time_bucket_ng('1 month', day, 'MSK') AS bucket,
    MIN(temperature),

--- a/tsl/test/sql/include/cagg_ddl_common.sql
+++ b/tsl/test/sql/include/cagg_ddl_common.sql
@@ -744,14 +744,14 @@ FROM (
     ('int8')) v (dt);
 
 -- width expression for int2 hypertables
-CREATE MATERIALIZED VIEW width_expr WITH (timescaledb.continuous) AS
+CREATE MATERIALIZED VIEW width_expr WITH (timescaledb.continuous, timescaledb.materialized_only=false) AS
 SELECT time_bucket(1::smallint, time)
 FROM metrics_int2
 GROUP BY 1;
 
 DROP MATERIALIZED VIEW width_expr;
 
-CREATE MATERIALIZED VIEW width_expr WITH (timescaledb.continuous) AS
+CREATE MATERIALIZED VIEW width_expr WITH (timescaledb.continuous, timescaledb.materialized_only=false) AS
 SELECT time_bucket(1::smallint + 2::smallint, time)
 FROM metrics_int2
 GROUP BY 1;
@@ -759,14 +759,14 @@ GROUP BY 1;
 DROP MATERIALIZED VIEW width_expr;
 
 -- width expression for int4 hypertables
-CREATE MATERIALIZED VIEW width_expr WITH (timescaledb.continuous) AS
+CREATE MATERIALIZED VIEW width_expr WITH (timescaledb.continuous, timescaledb.materialized_only=false) AS
 SELECT time_bucket(1, time)
 FROM metrics_int4
 GROUP BY 1;
 
 DROP MATERIALIZED VIEW width_expr;
 
-CREATE MATERIALIZED VIEW width_expr WITH (timescaledb.continuous) AS
+CREATE MATERIALIZED VIEW width_expr WITH (timescaledb.continuous, timescaledb.materialized_only=false) AS
 SELECT time_bucket(1 + 2, time)
 FROM metrics_int4
 GROUP BY 1;
@@ -774,14 +774,14 @@ GROUP BY 1;
 DROP MATERIALIZED VIEW width_expr;
 
 -- width expression for int8 hypertables
-CREATE MATERIALIZED VIEW width_expr WITH (timescaledb.continuous) AS
+CREATE MATERIALIZED VIEW width_expr WITH (timescaledb.continuous, timescaledb.materialized_only=false) AS
 SELECT time_bucket(1, time)
 FROM metrics_int8
 GROUP BY 1;
 
 DROP MATERIALIZED VIEW width_expr;
 
-CREATE MATERIALIZED VIEW width_expr WITH (timescaledb.continuous) AS
+CREATE MATERIALIZED VIEW width_expr WITH (timescaledb.continuous, timescaledb.materialized_only=false) AS
 SELECT time_bucket(1 + 2, time)
 FROM metrics_int8
 GROUP BY 1;
@@ -790,17 +790,17 @@ DROP MATERIALIZED VIEW width_expr;
 
 \set ON_ERROR_STOP 0
 -- non-immutable expresions should be rejected
-CREATE MATERIALIZED VIEW width_expr WITH (timescaledb.continuous) AS
+CREATE MATERIALIZED VIEW width_expr WITH (timescaledb.continuous, timescaledb.materialized_only=false) AS
 SELECT time_bucket(extract(year FROM now())::smallint, time)
 FROM metrics_int2
 GROUP BY 1;
 
-CREATE MATERIALIZED VIEW width_expr WITH (timescaledb.continuous) AS
+CREATE MATERIALIZED VIEW width_expr WITH (timescaledb.continuous, timescaledb.materialized_only=false) AS
 SELECT time_bucket(extract(year FROM now())::int, time)
 FROM metrics_int4
 GROUP BY 1;
 
-CREATE MATERIALIZED VIEW width_expr WITH (timescaledb.continuous) AS
+CREATE MATERIALIZED VIEW width_expr WITH (timescaledb.continuous, timescaledb.materialized_only=false) AS
 SELECT time_bucket(extract(year FROM now())::int, time)
 FROM metrics_int8
 GROUP BY 1;
@@ -810,7 +810,7 @@ GROUP BY 1;
 
 SET ROLE :ROLE_DEFAULT_PERM_USER;
 
-CREATE MATERIALIZED VIEW owner_check WITH (timescaledb.continuous) AS
+CREATE MATERIALIZED VIEW owner_check WITH (timescaledb.continuous, timescaledb.materialized_only=false) AS
 SELECT time_bucket(1 + 2, time)
 FROM metrics_int8
 GROUP BY 1
@@ -921,7 +921,7 @@ SELECT create_hypertable('test_schema.telemetry_raw', 'ts');
 \endif
 
 CREATE MATERIALIZED VIEW test_schema.telemetry_1s
-  WITH (timescaledb.continuous)
+  WITH (timescaledb.continuous, timescaledb.materialized_only=false)
     AS
 SELECT time_bucket(INTERVAL '1s', ts) AS ts_1s,
        avg(value)
@@ -960,7 +960,7 @@ SELECT create_hypertable('test_schema.telemetry_raw', 'ts');
 \endif
 
 CREATE MATERIALIZED VIEW test_schema.cagg1
-  WITH (timescaledb.continuous)
+  WITH (timescaledb.continuous, timescaledb.materialized_only=false)
     AS
 SELECT time_bucket(INTERVAL '1s', ts) AS ts_1s,
        avg(value)
@@ -968,7 +968,7 @@ SELECT time_bucket(INTERVAL '1s', ts) AS ts_1s,
  GROUP BY ts_1s WITH NO DATA;
 
 CREATE MATERIALIZED VIEW test_schema.cagg2
-  WITH (timescaledb.continuous)
+  WITH (timescaledb.continuous, timescaledb.materialized_only=false)
     AS
 SELECT time_bucket(INTERVAL '1s', ts) AS ts_1s,
        avg(value)
@@ -1102,14 +1102,14 @@ SELECT create_distributed_hypertable('i3696', 'time', replication_factor => 2);
 SELECT table_name FROM create_hypertable('i3696','time');
 \endif
 
-CREATE MATERIALIZED VIEW i3696_cagg1 WITH (timescaledb.continuous)
+CREATE MATERIALIZED VIEW i3696_cagg1 WITH (timescaledb.continuous, timescaledb.materialized_only=false)
 AS
  SELECT  search_query,count(search_query) as count, sum(cnt), time_bucket(INTERVAL '1 minute', time) AS bucket
  FROM i3696 GROUP BY cnt +cnt2 , bucket, search_query;
 
 ALTER MATERIALIZED VIEW i3696_cagg1 SET (timescaledb.materialized_only = 'true');
 
-CREATE MATERIALIZED VIEW i3696_cagg2 WITH (timescaledb.continuous)
+CREATE MATERIALIZED VIEW i3696_cagg2 WITH (timescaledb.continuous, timescaledb.materialized_only=false)
 AS
  SELECT  search_query,count(search_query) as count, sum(cnt), time_bucket(INTERVAL '1 minute', time) AS bucket
  FROM i3696 GROUP BY cnt + cnt2, bucket, search_query
@@ -1126,7 +1126,7 @@ SELECT create_distributed_hypertable('test_setting', 'time', replication_factor 
 SELECT create_hypertable('test_setting', 'time');
 \endif
 
-CREATE MATERIALIZED VIEW test_setting_cagg with (timescaledb.continuous)
+CREATE MATERIALIZED VIEW test_setting_cagg with (timescaledb.continuous, timescaledb.materialized_only=false)
 AS SELECT time_bucket('1h',time), avg(val), count(*) FROM test_setting GROUP BY 1;
 
 INSERT INTO test_setting
@@ -1291,25 +1291,25 @@ SELECT * FROM cashflows;
 -- 4. test named bucket width
 -- named origin
 CREATE MATERIALIZED VIEW cagg_named_origin WITH
-(timescaledb.continuous) AS
+(timescaledb.continuous, timescaledb.materialized_only=false) AS
 SELECT time_bucket('1h', time, 'UTC', origin => '2001-01-03 01:23:45') AS bucket,
 avg(amount) as avg_amount
 FROM transactions GROUP BY 1 WITH NO DATA;
 -- named timezone
 CREATE MATERIALIZED VIEW cagg_named_tz_origin WITH
-(timescaledb.continuous) AS
+(timescaledb.continuous, timescaledb.materialized_only=false) AS
 SELECT time_bucket('1h', time, timezone => 'UTC', origin => '2001-01-03 01:23:45') AS bucket,
 avg(amount) as avg_amount
 FROM transactions GROUP BY 1 WITH NO DATA;
 -- named ts
 CREATE MATERIALIZED VIEW cagg_named_ts_tz_origin WITH
-(timescaledb.continuous) AS
+(timescaledb.continuous, timescaledb.materialized_only=false) AS
 SELECT time_bucket('1h', ts => time, timezone => 'UTC', origin => '2001-01-03 01:23:45') AS bucket,
 avg(amount) as avg_amount
 FROM transactions GROUP BY 1 WITH NO DATA;
 -- named bucket width
 CREATE MATERIALIZED VIEW cagg_named_all WITH
-(timescaledb.continuous) AS
+(timescaledb.continuous, timescaledb.materialized_only=false) AS
 SELECT time_bucket(bucket_width => '1h', ts => time, timezone => 'UTC', origin => '2001-01-03 01:23:45') AS bucket,
 avg(amount) as avg_amount
 FROM transactions GROUP BY 1 WITH NO DATA;
@@ -1344,7 +1344,7 @@ SELECT * FROM transactions_montly ORDER BY bucket;
 
 -- Check set_chunk_time_interval on continuous aggregate
 CREATE MATERIALIZED VIEW cagg_set_chunk_time_interval
-WITH (timescaledb.continuous) AS
+WITH (timescaledb.continuous, timescaledb.materialized_only=false) AS
 SELECT time_bucket(INTERVAL '1 month', time) AS bucket,
        SUM(fiat_value),
        MAX(fiat_value),
@@ -1360,3 +1360,56 @@ SELECT _timescaledb_functions.to_interval(d.interval_length) = interval '1 month
 FROM _timescaledb_catalog.dimension d
          RIGHT JOIN _timescaledb_catalog.continuous_agg ca ON ca.user_view_name = 'cagg_set_chunk_time_interval'
 WHERE d.hypertable_id = ca.mat_hypertable_id;
+
+-- Since #6077 CAggs are materialized only by default
+DROP TABLE conditions CASCADE;
+CREATE TABLE conditions (
+       time TIMESTAMPTZ NOT NULL,
+       location TEXT NOT NULL,
+       temperature DOUBLE PRECISION NULL
+);
+
+\if :IS_DISTRIBUTED
+SELECT create_distributed_hypertable('conditions', 'time', replication_factor => 2);
+\else
+SELECT create_hypertable('conditions', 'time');
+\endif
+
+INSERT INTO conditions VALUES ( '2018-01-01 09:20:00-08', 'SFO', 55);
+INSERT INTO conditions VALUES ( '2018-01-02 09:30:00-08', 'por', 100);
+INSERT INTO conditions VALUES ( '2018-01-02 09:20:00-08', 'SFO', 65);
+INSERT INTO conditions VALUES ( '2018-01-02 09:10:00-08', 'NYC', 65);
+INSERT INTO conditions VALUES ( '2018-11-01 09:20:00-08', 'NYC', 45);
+INSERT INTO conditions VALUES ( '2018-11-01 10:40:00-08', 'NYC', 55);
+INSERT INTO conditions VALUES ( '2018-11-01 11:50:00-08', 'NYC', 65);
+INSERT INTO conditions VALUES ( '2018-11-01 12:10:00-08', 'NYC', 75);
+INSERT INTO conditions VALUES ( '2018-11-01 13:10:00-08', 'NYC', 85);
+INSERT INTO conditions VALUES ( '2018-11-02 09:20:00-08', 'NYC', 10);
+INSERT INTO conditions VALUES ( '2018-11-02 10:30:00-08', 'NYC', 20);
+
+CREATE MATERIALIZED VIEW conditions_daily
+WITH (timescaledb.continuous) AS
+SELECT location,
+       time_bucket(INTERVAL '1 day', time) AS bucket,
+       AVG(temperature)
+  FROM conditions
+GROUP BY location, bucket
+WITH NO DATA;
+
+\d+ conditions_daily
+
+-- Should return NO ROWS
+SELECT * FROM conditions_daily ORDER BY bucket, avg;
+
+ALTER MATERIALIZED VIEW conditions_daily SET (timescaledb.materialized_only=false);
+
+\d+ conditions_daily
+
+-- Should return ROWS because now it is realtime
+SELECT * FROM conditions_daily ORDER BY bucket, avg;
+
+-- Should return ROWS because we refreshed it
+ALTER MATERIALIZED VIEW conditions_daily SET (timescaledb.materialized_only=true);
+\d+ conditions_daily
+CALL refresh_continuous_aggregate('conditions_daily', NULL, NULL);
+SELECT * FROM conditions_daily ORDER BY bucket, avg;

--- a/tsl/test/sql/include/cagg_migrate_common.sql
+++ b/tsl/test/sql/include/cagg_migrate_common.sql
@@ -69,7 +69,7 @@ CALL cagg_migrate('conditions_summary_daily');
 DROP TABLE conditions_summary_daily;
 
 CREATE MATERIALIZED VIEW conditions_summary_daily_new
-WITH (timescaledb.continuous) AS
+WITH (timescaledb.continuous, timescaledb.materialized_only=false) AS
 SELECT
 \if :IS_TIME_DIMENSION
     time_bucket(INTERVAL '1 day', "time") AS bucket,
@@ -93,7 +93,7 @@ CALL cagg_migrate('conditions_summary_daily_new');
 
 -- older continuous aggregate to be migrated
 CREATE MATERIALIZED VIEW conditions_summary_daily
-WITH (timescaledb.continuous, timescaledb.finalized=false) AS
+WITH (timescaledb.continuous, timescaledb.materialized_only=false, timescaledb.finalized=false) AS
 SELECT
 \if :IS_TIME_DIMENSION
     time_bucket(INTERVAL '1 day', "time") AS bucket,
@@ -276,7 +276,7 @@ GRANT ALL ON TABLE conditions TO :ROLE_DEFAULT_PERM_USER;
 SET ROLE :ROLE_DEFAULT_PERM_USER;
 
 CREATE MATERIALIZED VIEW conditions_summary_daily
-WITH (timescaledb.continuous, timescaledb.finalized=false) AS
+WITH (timescaledb.continuous, timescaledb.materialized_only=false, timescaledb.finalized=false) AS
 SELECT
 \if :IS_TIME_DIMENSION
     time_bucket(INTERVAL '1 day', "time") AS bucket,

--- a/tsl/test/sql/include/cagg_on_cagg_validations.sql
+++ b/tsl/test/sql/include/cagg_on_cagg_validations.sql
@@ -10,7 +10,7 @@
 -- CAGG on hypertable (1st level)
 --
 CREATE MATERIALIZED VIEW :CAGG_NAME_1ST_LEVEL
-WITH (timescaledb.continuous) AS
+WITH (timescaledb.continuous, timescaledb.materialized_only=false) AS
 SELECT
   \if :IS_TIME_DIMENSION_WITH_TIMEZONE_1ST
     time_bucket(:BUCKET_WIDTH_1ST, "time", :'BUCKET_TZNAME_1ST') AS bucket,
@@ -31,7 +31,7 @@ WITH NO DATA;
 \set ON_ERROR_STOP 0
 \echo :WARNING_MESSAGE
 CREATE MATERIALIZED VIEW :CAGG_NAME_2TH_LEVEL
-WITH (timescaledb.continuous) AS
+WITH (timescaledb.continuous, timescaledb.materialized_only=false) AS
 SELECT
   \if :IS_TIME_DIMENSION_WITH_TIMEZONE_2TH
     time_bucket(:BUCKET_WIDTH_2TH, "bucket", :'BUCKET_TZNAME_2TH') AS bucket,
@@ -59,7 +59,7 @@ WITH NO DATA;
   CALL refresh_continuous_aggregate(:'CAGG_NAME_2TH_LEVEL', NULL, NULL);
 
   CREATE MATERIALIZED VIEW :CAGG_NAME_3TH_LEVEL
-  WITH (timescaledb.continuous) AS
+  WITH (timescaledb.continuous, timescaledb.materialized_only=false) AS
   SELECT
     \if :IS_TIME_DIMENSION_WITH_TIMEZONE_2TH
       time_bucket(:BUCKET_WIDTH_3TH, "bucket", :'BUCKET_TZNAME_2TH') AS bucket

--- a/tsl/test/sql/include/jit_load.sql
+++ b/tsl/test/sql/include/jit_load.sql
@@ -18,7 +18,7 @@ CREATE TABLE jit_test_contagg (
 SELECT table_name FROM create_hypertable('jit_test_contagg', 'observation_time');
 
 CREATE MATERIALIZED VIEW jit_device_summary
-WITH (timescaledb.continuous)
+WITH (timescaledb.continuous, timescaledb.materialized_only=false)
 AS
 SELECT
   time_bucket('1 hour', observation_time) as bucket,

--- a/tsl/test/sql/information_view_chunk_count.sql
+++ b/tsl/test/sql/information_view_chunk_count.sql
@@ -20,7 +20,7 @@ FROM
        generate_series(1, 100, 1 ) AS g2(sensor_id)
 ORDER BY time;
 
-CREATE materialized VIEW sensor_data_v WITH(timescaledb.continuous) AS
+CREATE materialized VIEW sensor_data_v WITH(timescaledb.continuous, timescaledb.materialized_only=false) AS
 SELECT sensor_id, time_bucket(INTERVAL '1 day', time) AS bucket,
 AVG(temperature) FROM sensor_data
 GROUP BY sensor_id, bucket;

--- a/tsl/test/sql/telemetry_stats.sql.in
+++ b/tsl/test/sql/telemetry_stats.sql.in
@@ -47,7 +47,7 @@ CREATE TABLE hyper (LIKE normal);
 SELECT table_name FROM create_hypertable('hyper', 'time');
 
 CREATE MATERIALIZED VIEW contagg
-WITH (timescaledb.continuous) AS
+WITH (timescaledb.continuous, timescaledb.materialized_only=false) AS
 SELECT
   time_bucket('1 hour', time) AS hour,
   device,
@@ -57,7 +57,7 @@ FROM
 GROUP BY hour, device;
 
 CREATE MATERIALIZED VIEW contagg_old
-WITH (timescaledb.continuous, timescaledb.finalized=false) AS
+WITH (timescaledb.continuous, timescaledb.materialized_only=false, timescaledb.finalized=false) AS
 SELECT
   time_bucket('1 hour', time) AS hour,
   device,
@@ -218,7 +218,7 @@ FROM relations;
 
 -- Create a continuous aggregate on the distributed hypertable
 CREATE MATERIALIZED VIEW distcontagg
-WITH (timescaledb.continuous) AS
+WITH (timescaledb.continuous, timescaledb.materialized_only=false) AS
 SELECT
   time_bucket('1 hour', time) AS hour,
   device,
@@ -228,7 +228,7 @@ FROM
 GROUP BY hour, device;
 
 CREATE MATERIALIZED VIEW distcontagg_old
-WITH (timescaledb.continuous, timescaledb.finalized=false) AS
+WITH (timescaledb.continuous, timescaledb.materialized_only=false, timescaledb.finalized=false) AS
 SELECT
   time_bucket('1 hour', time) AS hour,
   device,


### PR DESCRIPTION
Historically creating a Continuous Aggregate make it realtime by default
but it confuse users specially when using `WITH NO DATA` option. Also is
well known that realtime Continuous Aggregates can potentially lead to
issues with Hierarchical and Data Tiering.

Improved the UX by making Continuous Aggregates non-realtime by default.