### PR TITLE
Fix flaky compression_update_delete test

### DIFF
--- a/test/runner.sh
+++ b/test/runner.sh
@@ -139,4 +139,5 @@ ${PSQL} -U ${TEST_PGUSER} \
                -e 's! Memory: [0-9]\{1,\}kB!!' \
                -e 's! Memory Usage: [0-9]\{1,\}kB!!' \
                -e 's! Average  Peak Memory: [0-9]\{1,\}kB!!' | \
-          grep -v 'DEBUG:  rehashing catalog cache id'
+          grep -v 'DEBUG:  rehashing catalog cache id' | \
+          grep -v 'DEBUG:  compacted fsync request queue from'

--- a/test/runner_shared.sh
+++ b/test/runner_shared.sh
@@ -87,4 +87,5 @@ ${PSQL} -U ${TEST_PGUSER} \
                -e 's! Memory: [0-9]\{1,\}kB!!' \
                -e 's! Memory Usage: [0-9]\{1,\}kB!!' \
                -e 's! Average  Peak Memory: [0-9]\{1,\}kB!!' | \
-          grep -v 'DEBUG:  rehashing catalog cache id'
+          grep -v 'DEBUG:  rehashing catalog cache id' | \
+          grep -v 'DEBUG:  compacted fsync request queue from'


### PR DESCRIPTION
The compression_update_delete test (and further tests) sets the log level to DEBUG1. Especially on Windows, the additional log message 'DEBUG:  compacted fsync request queue from XXX entries to XXX entries' causes the test to be flaky. This patch removes this log message from the test output.

Fixes: #4723

---
Disable-check: force-changelog-file
Link to failed CI run: https://github.com/timescale/timescaledb/actions/runs/6215855526/job/16869164441