### PR TITLE
Fix build failure in PG15 memory test

### DIFF
--- a/.github/workflows/memory-tests.yaml
+++ b/.github/workflows/memory-tests.yaml
@@ -5,6 +5,7 @@ name: Memory tests
       - main
       - prerelease_test
       - memory_test
+      - trigger/memory_test
 jobs:
   memory_leak:
     name: Memory leak on insert PG${{ matrix.pg }}
@@ -28,6 +29,7 @@ jobs:
 
     - name: Build TimescaleDB
       run: |
+        PATH="/usr/lib/postgresql/${{ matrix.pg }}/bin:$PATH"
         ./bootstrap -DCMAKE_BUILD_TYPE=Release
         make -C build
         sudo make -C build install


### PR DESCRIPTION
This PR ensures the path to the PostgreSQL installation is set in the memory test workflow before TimescaleDB is compiled. 

---
Failed CI run: https://github.com/timescale/timescaledb/actions/runs/6234012065/job/16920380918
Fixed CI run: https://github.com/timescale/timescaledb/actions/runs/6234178259/job/16920879363
Disable-check: force-changelog-file
