### PR TITLE
Support for multiple BGW in scheduler mock

### DIFF
--- a/src/bgw/scheduler.c
+++ b/src/bgw/scheduler.c
@@ -399,7 +399,7 @@ scheduled_ts_bgw_job_start(ScheduledBgwJob *sjob,
 
 	Assert(sjob->handle != NULL);
 	if (bgw_register != NULL)
-		bgw_register(sjob->handle);
+		bgw_register(sjob->handle, scheduler_mctx);
 
 	status = WaitForBackgroundWorkerStartup(sjob->handle, &pid);
 	switch (status)

--- a/src/bgw/scheduler.h
+++ b/src/bgw/scheduler.h
@@ -16,7 +16,8 @@
 typedef struct ScheduledBgwJob ScheduledBgwJob;
 
 /* callback used in testing */
-typedef void (*register_background_worker_callback_type)(BackgroundWorkerHandle *);
+typedef void (*register_background_worker_callback_type)(BackgroundWorkerHandle *,
+														 MemoryContext scheduler_ctx);
 
 /* Exposed for testing */
 extern List *ts_update_scheduled_jobs_list(List *cur_jobs_list, MemoryContext mctx);

--- a/test/src/bgw/scheduler_mock.c
+++ b/test/src/bgw/scheduler_mock.c
@@ -220,19 +220,17 @@ ts_bgw_db_scheduler_test_run_and_wait_for_scheduler_finish(PG_FUNCTION_ARGS)
 	pid_t pid;
 
 	worker_handle = start_test_scheduler(PG_GETARG_INT32(0), GetUserId());
+	TestAssertTrue(worker_handle != NULL);
 
-	if (worker_handle != NULL)
-	{
-		BgwHandleStatus status = WaitForBackgroundWorkerStartup(worker_handle, &pid);
-		TestAssertTrue(BGWH_STARTED == status);
-		if (status != BGWH_STARTED)
-			elog(ERROR, "bgw not started");
+	BgwHandleStatus status = WaitForBackgroundWorkerStartup(worker_handle, &pid);
+	TestAssertTrue(BGWH_STARTED == status);
+	if (status != BGWH_STARTED)
+		elog(ERROR, "bgw not started");
 
-		status = WaitForBackgroundWorkerShutdown(worker_handle);
-		TestAssertTrue(BGWH_STOPPED == status);
-		if (status != BGWH_STOPPED)
-			elog(ERROR, "bgw not stopped");
-	}
+	status = WaitForBackgroundWorkerShutdown(worker_handle);
+	TestAssertTrue(BGWH_STOPPED == status);
+	if (status != BGWH_STOPPED)
+		elog(ERROR, "bgw not stopped");
 
 	PG_RETURN_VOID();
 }

--- a/test/src/bgw/timer_mock.h
+++ b/test/src/bgw/timer_mock.h
@@ -11,7 +11,8 @@
 
 #include "bgw/timer.h"
 
-extern void ts_timer_mock_register_bgw_handle(BackgroundWorkerHandle *handle);
+extern void ts_timer_mock_register_bgw_handle(BackgroundWorkerHandle *handle,
+											  MemoryContext scheduler_mctx);
 
 extern const Timer ts_mock_timer;
 

--- a/tsl/test/expected/bgw_reorder_drop_chunks.out
+++ b/tsl/test/expected/bgw_reorder_drop_chunks.out
@@ -372,7 +372,7 @@ SELECT ts_bgw_params_reset_time();
 
 \c :TEST_DBNAME :ROLE_DEFAULT_PERM_USER
 -----------------------------------
--- test drop chunnks policy runs --
+-- test drop chunks policy runs --
 -----------------------------------
 CREATE TABLE test_drop_chunks_table(time timestamptz, drop_order int);
 SELECT create_hypertable('test_drop_chunks_table', 'time', chunk_time_interval => INTERVAL '1 week');
@@ -647,14 +647,6 @@ SELECT alter_job(id,config:=jsonb_set(config,'{verbose_log}', 'true'))
  (1003,"@ 1 day","@ 5 mins",-1,"@ 5 mins",t,"{""drop_after"": ""@ 4 mons"", ""verbose_log"": true, ""hypertable_id"": 4}",-infinity,_timescaledb_functions.policy_retention_check,f,,)
 (1 row)
 
-CALL run_job(:drop_chunks_date_job_id);
-SELECT ts_bgw_db_scheduler_test_run_and_wait_for_scheduler_finish(1000);
- ts_bgw_db_scheduler_test_run_and_wait_for_scheduler_finish 
-------------------------------------------------------------
- 
-(1 row)
-
-CALL run_job(:drop_chunks_tsntz_job_id);
 SELECT ts_bgw_db_scheduler_test_run_and_wait_for_scheduler_finish(1000);
  ts_bgw_db_scheduler_test_run_and_wait_for_scheduler_finish 
 ------------------------------------------------------------
@@ -671,8 +663,7 @@ SELECT * FROM sorted_bgw_log;
       1 |         0 | Retention Policy [1002] | job 1002 (Retention Policy [1002]) exiting with success: execution time (RANDOM) ms
       0 |         0 | Retention Policy [1003] | applying retention policy to hypertable "test_drop_chunks_table_tsntz": dropping...
       1 |         0 | Retention Policy [1003] | job 1003 (Retention Policy [1003]) exiting with success: execution time (RANDOM) ms
-      0 |   1000000 | DB Scheduler            | [TESTING] Wait until 2000000, started at 1000000
-(8 rows)
+(7 rows)
 
 -- test the schedule_interval parameter for policies
 CREATE TABLE test_schedint(time timestamptz, a int, b int);

--- a/tsl/test/sql/bgw_reorder_drop_chunks.sql
+++ b/tsl/test/sql/bgw_reorder_drop_chunks.sql
@@ -198,7 +198,7 @@ SELECT ts_bgw_params_reset_time();
 \c :TEST_DBNAME :ROLE_DEFAULT_PERM_USER
 
 -----------------------------------
--- test drop chunnks policy runs --
+-- test drop chunks policy runs --
 -----------------------------------
 
 
@@ -327,10 +327,6 @@ SELECT alter_job(id,config:=jsonb_set(config,'{verbose_log}', 'true'))
 SELECT alter_job(id,config:=jsonb_set(config,'{verbose_log}', 'true'))
  FROM _timescaledb_config.bgw_job WHERE id = :drop_chunks_tsntz_job_id;
 
-CALL run_job(:drop_chunks_date_job_id);
-SELECT ts_bgw_db_scheduler_test_run_and_wait_for_scheduler_finish(1000);
-
-CALL run_job(:drop_chunks_tsntz_job_id);
 SELECT ts_bgw_db_scheduler_test_run_and_wait_for_scheduler_finish(1000);
 
 SELECT * FROM sorted_bgw_log;


### PR DESCRIPTION
The current version of the BGW scheduler mock does not support multiple background workers. If a second worker was registered, the reference to the previously registered worker gets lost. So, the implementation of the mock scheduler only waits for the latest registered worker before updating the mocked current time, which causes a race condition. If the previous workers are still active and logging messages after this point, the messages are logged with the updated mocked time. This leads to a non-deterministic behavior and test failures. For example:

```
  msg_no | mock_time |    application_name     |    msg
---------+-----------+-------------------------+----------------------
-      1 |         0 | Retention Policy [1002] | job 1002 [...]
[...]
+      1 |   1000000 | Retention Policy [1002] | job 1002 [...]
```

---
Disable-check: force-changelog-file