### PR TITLE
Fix ignored workflow logic

### DIFF
--- a/.github/workflows/linux-32bit-build-and-test-ignored.yaml
+++ b/.github/workflows/linux-32bit-build-and-test-ignored.yaml
@@ -5,13 +5,15 @@ name: Regression Linux i386
 "on":
   push:
     branches:
-      - prerelease_test
+      - main
     paths:
+      - '!**'
       - '**.md'
       - 'LICENSE*'
       - NOTICE
   pull_request:
     paths:
+      - '!**'
       - '**.md'
       - 'LICENSE*'
       - NOTICE

--- a/.github/workflows/linux-build-and-test-ignored.yaml
+++ b/.github/workflows/linux-build-and-test-ignored.yaml
@@ -5,13 +5,15 @@ name: Regression
 "on":
   push:
     branches:
-      - prerelease_test
+      - main
     paths:
+      - '!**'
       - '**.md'
       - 'LICENSE*'
       - NOTICE
   pull_request:
     paths:
+      - '!**'
       - '**.md'
       - 'LICENSE*'
       - NOTICE

--- a/.github/workflows/linux-build-and-test.yaml
+++ b/.github/workflows/linux-build-and-test.yaml
@@ -39,7 +39,7 @@ jobs:
         else
           .github/gh_matrix_builder.py ${{ github.event_name }}
         fi
-    
+
   regress:
     # Change the JOB_NAME variable below when changing the name.
     name: PG${{ matrix.pg }}${{ matrix.snapshot }} ${{ matrix.name }} ${{ matrix.os }}

--- a/.github/workflows/shellcheck-ignored.yaml
+++ b/.github/workflows/shellcheck-ignored.yaml
@@ -3,13 +3,13 @@
 # executed because some files were ignored.
 name: Shellcheck
 "on":
-  pull_request:
+  push:
+    branches:
+      - main
     paths-ignore:
       - '**.sh'
       - .github/workflows/shellcheck.yaml
-  push:
-    branches:
-      - prerelease_test
+  pull_request:
     paths-ignore:
       - '**.sh'
       - .github/workflows/shellcheck.yaml

--- a/.github/workflows/windows-build-and-test-ignored.yaml
+++ b/.github/workflows/windows-build-and-test-ignored.yaml
@@ -5,8 +5,9 @@ name: Regression Windows
 "on":
   push:
     branches:
-      - prerelease_test
+      - main
     paths:
+      - '!**'
       - '**.md'
       - CHANGELOG
       - 'LICENSE*'
@@ -14,6 +15,7 @@ name: Regression Windows
       - 'bootstrap*'
   pull_request:
     paths:
+      - '!**'
       - '**.md'
       - CHANGELOG
       - 'LICENSE*'


### PR DESCRIPTION
The paths filter in github workflows will trigger when at least
one of the pathes match unless everything else has been explicitly
excluded. For the ignored workflows we want it to only trigger
when only those files explicitly specified are changed and nothing
else.

Disable-check: force-changelog-file
