### PR TITLE
Remove outdated URL from install message

### DIFF
--- a/sql/notice.sql
+++ b/sql/notice.sql
@@ -30,8 +30,7 @@ BEGIN
     E'For more information on TimescaleDB, please visit the following links:\n\n'
     ||
     E' 1. Getting started: https://docs.timescale.com/timescaledb/latest/getting-started\n' ||
-    E' 2. API reference documentation: https://docs.timescale.com/api/latest\n' ||
-    E' 3. How TimescaleDB is designed: https://docs.timescale.com/timescaledb/latest/overview/core-concepts\n',
+    E' 2. API reference documentation: https://docs.timescale.com/api/latest\n',
     telemetry_string;
 END;
 $$;


### PR DESCRIPTION
With the current version of our docs, the first and third URL in our extension installation message pointed to the same page. This PR removes one of the duplicates.

---
Disable-check: force-changelog-file

```
test4=# create extension timescaledb;
WARNING:  
WELCOME TO
 _____ _                               _     ____________  
|_   _(_)                             | |    |  _  \ ___ \ 
  | |  _ _ __ ___   ___  ___  ___ __ _| | ___| | | | |_/ / 
  | | | |  _ ` _ \ / _ \/ __|/ __/ _` | |/ _ \ | | | ___ \ 
  | | | | | | | | |  __/\__ \ (_| (_| | |  __/ |/ /| |_/ /
  |_| |_|_| |_| |_|\___||___/\___\__,_|_|\___|___/ \____/
               Running version 2.12.0-dev
For more information on TimescaleDB, please visit the following links:

 1. Getting started: https://docs.timescale.com/timescaledb/latest/getting-started
 2. API reference documentation: https://docs.timescale.com/api/latest

Note: Please enable telemetry to help us improve our product by running: ALTER DATABASE "test4" SET timescaledb.telemetry_level = 'basic';

CREATE EXTENSION
```