### PR TITLE
Make sure BGW are stopped in test teardown

### DIFF
--- a/test/expected/bgw_launcher.out
+++ b/test/expected/bgw_launcher.out
@@ -595,6 +595,18 @@ SELECT wait_for_bgw_scheduler(:'TEST_DBNAME');
 
 ALTER DATABASE :TEST_DBNAME SET TABLESPACE tablespace1;
 WARNING:  you may need to manually restart any running background workers after this command
--- clean up additional database
+-- tear down test and clean up additional database
 \c :TEST_DBNAME :ROLE_SUPERUSER
-DROP DATABASE :TEST_DBNAME_2;
+SELECT _timescaledb_functions.stop_background_workers();
+ stop_background_workers 
+-------------------------
+ t
+(1 row)
+
+SELECT pg_terminate_backend(pid) FROM pg_stat_activity WHERE application_name = 'TimescaleDB Background Worker Launcher';
+ pg_terminate_backend 
+----------------------
+ t
+(1 row)
+
+DROP DATABASE :TEST_DBNAME_2 WITH (force);

--- a/test/sql/bgw_launcher.sql
+++ b/test/sql/bgw_launcher.sql
@@ -256,7 +256,9 @@ CREATE TABLESPACE tablespace1 OWNER :ROLE_DEFAULT_PERM_USER LOCATION :TEST_TABLE
 SELECT wait_for_bgw_scheduler(:'TEST_DBNAME');
 ALTER DATABASE :TEST_DBNAME SET TABLESPACE tablespace1;
 
--- clean up additional database
+-- tear down test and clean up additional database
 \c :TEST_DBNAME :ROLE_SUPERUSER
-DROP DATABASE :TEST_DBNAME_2;
+SELECT _timescaledb_functions.stop_background_workers();
+SELECT pg_terminate_backend(pid) FROM pg_stat_activity WHERE application_name = 'TimescaleDB Background Worker Launcher';
+DROP DATABASE :TEST_DBNAME_2 WITH (force);
 


### PR DESCRIPTION
This patch stops the background worker in the bgw_launcher test teardown before the database is dropped. The current version of the test is flaky because sometimes the database cannot be dropped due to BGW activity.

---

Disable-check: force-changelog-file
Link to failing CI run: https://github.com/timescale/timescaledb/actions/runs/6238257502/job/16933717932
