### PR TITLE
Fix race condition in bgw_db_scheduler

### DIFF
--- a/tsl/test/expected/bgw_db_scheduler.out
+++ b/tsl/test/expected/bgw_db_scheduler.out
@@ -276,6 +276,13 @@ SELECT application_name FROM pg_stat_activity WHERE application_name LIKE 'User-
 ------------------
 (0 rows)
 
+-- wait for scheduler finish
+SELECT ts_bgw_db_scheduler_test_wait_for_scheduler_finish();
+ ts_bgw_db_scheduler_test_wait_for_scheduler_finish 
+----------------------------------------------------
+ 
+(1 row)
+
 --
 -- Test running a normal job
 --

--- a/tsl/test/sql/bgw_db_scheduler.sql
+++ b/tsl/test/sql/bgw_db_scheduler.sql
@@ -185,6 +185,9 @@ SELECT delete_job(:job_id);
 RESET client_min_messages;
 SELECT application_name FROM pg_stat_activity WHERE application_name LIKE 'User-Defined Action%';
 
+-- wait for scheduler finish
+SELECT ts_bgw_db_scheduler_test_wait_for_scheduler_finish();
+
 --
 -- Test running a normal job
 --


### PR DESCRIPTION
The regression test bgw_db_scheduler tests if the BGW scheduler starts a background job after it is created. However, this only happens if the previous instance of the BGW scheduler is no longer active. If the old BGW scheduler instance is still running, it will pick up the job and prevent it from starting in the current test.

---
Disable-check: force-changelog-file
Link to failed CI run: https://github.com/timescale/timescaledb/actions/runs/6249241189/job/16965466092?pr=6100 (attempt 1)