### PR TITLE
Run scheduled windows test

### DIFF
--- a/.github/workflows/windows-build-and-test.yaml
+++ b/.github/workflows/windows-build-and-test.yaml
@@ -1,10 +1,14 @@
 # Test building the extension on Windows
 name: Regression Windows
 "on":
+  schedule:
+    # run daily 0:00 on main branch
+    - cron: '0 0 * * *'
   push:
     branches:
       - main
       - prerelease_test
+      - trigger/windows_tests
     paths-ignore:
       - '**.md'
       - 'LICENSE*'


### PR DESCRIPTION
Our nightly windows tests have not been running for several months, causing the status badge in our readme to remain in a failing state without ever turning green. This pull request enables the daily scheduled windows tests once again.

---
Previous CI runs: https://github.com/timescale/timescaledb/actions?query=workflow%3A%22Regression+Windows%22+branch%3Amain+event%3Aschedule
Disable-check: force-changelog-file