### PR TITLE
Fix error in osmcallback hook

### DIFF
--- a/.unreleased/PR_6106
+++ b/.unreleased/PR_6106
@@ -1,0 +1,1 @@
+Fixes: #6106 incorrect pointer usage in OSM hook callback

--- a/src/osm_callbacks.c
+++ b/src/osm_callbacks.c
@@ -61,7 +61,7 @@ ts_get_osm_hypertable_drop_hook()
 	{
 		OsmCallbacks *ptr_old = ts_get_osm_callbacks_old();
 		if (ptr_old)
-			return ptr->hypertable_drop_hook;
+			return ptr_old->hypertable_drop_hook;
 	}
 	return NULL;
 }


### PR DESCRIPTION
The callback hook should use the old pointer instead of the new. This causes a segfault when ptr is NULL.