### PR TITLE
Ensure database is unused in bgw_launcher test

### DIFF
--- a/test/expected/bgw_launcher.out
+++ b/test/expected/bgw_launcher.out
@@ -587,15 +587,14 @@ SET client_min_messages TO error;
 DROP TABLESPACE IF EXISTS tablespace1;
 RESET client_min_messages;
 CREATE TABLESPACE tablespace1 OWNER :ROLE_DEFAULT_PERM_USER LOCATION :TEST_TABLESPACE1_PATH;
+-- Stop background worker before we change the tablespace of the database (otherwise, the database might be used)
 SELECT wait_for_bgw_scheduler(:'TEST_DBNAME');
  wait_for_bgw_scheduler 
 ------------------------
  BGW Scheduler found.
 (1 row)
 
-ALTER DATABASE :TEST_DBNAME SET TABLESPACE tablespace1;
-WARNING:  you may need to manually restart any running background workers after this command
--- tear down test and clean up additional database
+-- Connect to TEST_DBNAME (_timescaledb_functions.stop_background_workers() is not available in TEST_DBNAME_2)
 \c :TEST_DBNAME :ROLE_SUPERUSER
 SELECT _timescaledb_functions.stop_background_workers();
  stop_background_workers 
@@ -609,4 +608,10 @@ SELECT pg_terminate_backend(pid) FROM pg_stat_activity WHERE application_name = 
  t
 (1 row)
 
+\c :TEST_DBNAME_2 :ROLE_SUPERUSER
+-- Change tablespace
+ALTER DATABASE :TEST_DBNAME SET TABLESPACE tablespace1;
+WARNING:  you may need to manually restart any running background workers after this command
+-- tear down test and clean up additional database
+\c :TEST_DBNAME :ROLE_SUPERUSER
 DROP DATABASE :TEST_DBNAME_2 WITH (force);


### PR DESCRIPTION
The bgw_launcher test changes the tablespace for a database. However, this requires that the database is used and no BGW are accessing the database. This PR ensures that the background workers are stopped before the tablespace is changed.

---
Disable-check: force-changelog-file
Failing CI run: https://github.com/timescale/timescaledb/actions/runs/6268372126/job/17023181691