### PR TITLE
Make compression_bgw executable multiple times

### DIFF
--- a/tsl/test/expected/compression_bgw.out
+++ b/tsl/test/expected/compression_bgw.out
@@ -272,6 +272,7 @@ ALTER TABLE test_table_nologin set (timescaledb.compress);
 SELECT add_compression_policy('test_table_nologin', 2::int);
 ERROR:  permission denied to start background process as role "nologin_role"
 \set ON_ERROR_STOP 1
+DROP TABLE test_table_nologin;
 RESET ROLE;
 REVOKE NOLOGIN_ROLE FROM :ROLE_DEFAULT_PERM_USER;
 \c :TEST_DBNAME :ROLE_DEFAULT_PERM_USER
@@ -651,3 +652,7 @@ SELECT delete_job(:JOB_RECOMPRESS);
  
 (1 row)
 
+-- Teardown test
+\c :TEST_DBNAME :ROLE_SUPERUSER
+REVOKE CREATE ON SCHEMA public FROM NOLOGIN_ROLE;
+DROP ROLE NOLOGIN_ROLE;

--- a/tsl/test/sql/compression_bgw.sql
+++ b/tsl/test/sql/compression_bgw.sql
@@ -159,6 +159,7 @@ ALTER TABLE test_table_nologin set (timescaledb.compress);
 \set ON_ERROR_STOP 0
 SELECT add_compression_policy('test_table_nologin', 2::int);
 \set ON_ERROR_STOP 1
+DROP TABLE test_table_nologin;
 RESET ROLE;
 REVOKE NOLOGIN_ROLE FROM :ROLE_DEFAULT_PERM_USER;
 
@@ -217,3 +218,8 @@ SELECT count(*) FROM timescaledb_information.chunks
 WHERE hypertable_name = 'conditions' and is_compressed = true;
 
 \i include/recompress_basic.sql
+
+-- Teardown test
+\c :TEST_DBNAME :ROLE_SUPERUSER
+REVOKE CREATE ON SCHEMA public FROM NOLOGIN_ROLE;
+DROP ROLE NOLOGIN_ROLE;


### PR DESCRIPTION
The test compression_bgw cannot be executed multiple times because a role was created and not properly deleted. This PR adds the needed teardown step to the test.

-- 
Disable-check: force-changelog-file
Link to failed CI run: https://github.com/timescale/timescaledb/actions/runs/6262456556/job/17004671724?pr=6102
Fixed CI run: https://github.com/timescale/timescaledb/actions/runs/6273903911/job/17038280449?pr=6110
