### PR TITLE
Fix planner distributed table count

### DIFF
--- a/.unreleased/pr_6113
+++ b/.unreleased/pr_6113
@@ -1,0 +1,3 @@
+Fixes: #6113 Fix planner distributed table count
+
+Thanks: @symbx for reporting a crash when selecting from empty hypertables

--- a/src/planner/planner.c
+++ b/src/planner/planner.c
@@ -388,19 +388,18 @@ preprocess_query(Node *node, PreprocessQueryContext *context)
 							query->rowMarks == NIL && rte->inh)
 							rte_mark_for_expansion(rte);
 
+						if (hypertable_is_distributed(ht))
+						{
+							context->num_distributed_tables++;
+						}
+
 						if (TS_HYPERTABLE_HAS_COMPRESSION_TABLE(ht))
 						{
 							int compr_htid = ht->fd.compressed_hypertable_id;
 
 							/* Also warm the cache with the compressed
 							 * companion hypertable */
-							ht = ts_hypertable_cache_get_entry_by_id(hcache, compr_htid);
-							Assert(ht != NULL);
-						}
-
-						if (hypertable_is_distributed(ht))
-						{
-							context->num_distributed_tables++;
+							ts_hypertable_cache_get_entry_by_id(hcache, compr_htid);
 						}
 					}
 					else


### PR DESCRIPTION
The check for a distributed hypertable was done after ht had been changed to the compressed hypertable potentially leading to miscount or even segfault when the cache lookup for the compressed hypertable returned NULL.

Fixes #5966 
