### PR TITLE
Fix bgw_custom test flakiness

### DIFF
--- a/tsl/test/expected/bgw_custom.out
+++ b/tsl/test/expected/bgw_custom.out
@@ -913,15 +913,6 @@ INSERT INTO sensor_data
 		time;
 -- enable compression
 ALTER TABLE sensor_data SET (timescaledb.compress, timescaledb.compress_orderby = 'time DESC');
--- add new compression policy job
-SELECT add_compression_policy('sensor_data', INTERVAL '1' minute) AS compressjob_id \gset
--- set recompress to true
-SELECT alter_job(id,config:=jsonb_set(config,'{recompress}', 'true')) FROM _timescaledb_config.bgw_job WHERE id = :compressjob_id;
-                                                                                        alter_job                                                                                        
------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
- (1014,"@ 12 hours","@ 0",-1,"@ 1 hour",t,"{""recompress"": true, ""hypertable_id"": 4, ""compress_after"": ""@ 1 min""}",-infinity,_timescaledb_functions.policy_compression_check,f,,)
-(1 row)
-
 -- create new chunks
 INSERT INTO sensor_data
 	SELECT
@@ -940,6 +931,15 @@ SELECT chunk_name AS new_uncompressed_chunk_name
   WHERE hypertable_name = 'sensor_data' AND NOT is_compressed LIMIT 1 \gset
 -- change compression status so that this chunk is skipped when policy is run
 update _timescaledb_catalog.chunk set status=3 where table_name = :'new_uncompressed_chunk_name';
+-- add new compression policy job
+SELECT add_compression_policy('sensor_data', INTERVAL '1' minute) AS compressjob_id \gset
+-- set recompress to true
+SELECT alter_job(id,config:=jsonb_set(config,'{recompress}', 'true')) FROM _timescaledb_config.bgw_job WHERE id = :compressjob_id;
+                                                                                        alter_job                                                                                        
+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ (1014,"@ 12 hours","@ 0",-1,"@ 1 hour",t,"{""recompress"": true, ""hypertable_id"": 4, ""compress_after"": ""@ 1 min""}",-infinity,_timescaledb_functions.policy_compression_check,f,,)
+(1 row)
+
 -- verify that there are other uncompressed new chunks that need to be compressed
 SELECT count(*) > 1
   FROM timescaledb_information.chunks


### PR DESCRIPTION
One of the test cases changes chunk status in order to fail the background job in order to ensure jobs continue to be scheduled even after such a scenario. The problem lies in the race condition between compression policy and the status update which both update the catalog and that causes random test failures. The solution is to add the compression policy after updating the status, eliminating the possibility of race condition.

Failed CI run: https://github.com/timescale/timescaledb/actions/runs/6292122261/job/17081217268
Disable-check: force-changelog-file