### PR TITLE
Adjust APT package test

### DIFF
--- a/.github/workflows/apt-arm-packages.yaml
+++ b/.github/workflows/apt-arm-packages.yaml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        image: [ "debian:10-slim","debian:11-slim","ubuntu:20.04", "ubuntu:22.04"]
+        image: [ "debian:10-slim","debian:11-slim","debian:12-slim","ubuntu:20.04","ubuntu:22.04"]
         pg: [ 13, 14, 15 ]
 
     steps:

--- a/.github/workflows/apt-packages.yaml
+++ b/.github/workflows/apt-packages.yaml
@@ -20,7 +20,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        image: [ "debian:10-slim", "debian:11-slim", "debian:12-slim", "ubuntu:20.04", "ubuntu:22.04" ]
+        image: [ "debian:10-slim", "debian:11-slim", "debian:12-slim", "ubuntu:20.04", "ubuntu:22.04", "ubuntu:23.04" ]
         pg: [ 13, 14, 15 ]
         license: [ "TSL", "Apache"]
         include:
@@ -81,6 +81,7 @@ jobs:
         fi
 
     - name: Test Downgrade
+      if: matrix.image != 'ubuntu:23.04'
       run: |
         # Since this runs nightly on main we have to get the previous version
         # from the last released version and not current branch.


### PR DESCRIPTION
We now build APT packages for Debian 10,11,12 and Ubuntu packages for 20.04 and 22.04 for both amd64 and arm64.
We also build Ubuntu packages for 23.04 for amd64 but not for arm64 because pgdg packages for postgres is not available for arm64 on Ubuntu 23.04.

Disable-check: force-changelog-file
