### PR TITLE
Fix bgw_custom flakiness by stopping bgws

### DIFF
--- a/tsl/test/expected/bgw_custom.out
+++ b/tsl/test/expected/bgw_custom.out
@@ -972,7 +972,19 @@ SELECT count(*) = 0
 (1 row)
 
 -- cleanup
+SELECT _timescaledb_functions.stop_background_workers();
+ stop_background_workers 
+-------------------------
+ t
+(1 row)
+
 DROP TABLE sensor_data;
+SELECT _timescaledb_functions.restart_background_workers();
+ restart_background_workers 
+----------------------------
+ t
+(1 row)
+
 -- Github issue #5537
 -- Proc that waits until the given job enters the expected state
 CREATE OR REPLACE PROCEDURE wait_for_job_status(job_param_id INTEGER, expected_status TEXT, spins INTEGER=:TEST_SPINWAIT_ITERS)

--- a/tsl/test/sql/bgw_custom.sql
+++ b/tsl/test/sql/bgw_custom.sql
@@ -629,7 +629,9 @@ SELECT count(*) = 0
   WHERE hypertable_name = 'sensor_data' AND NOT is_compressed;
 
 -- cleanup
+SELECT _timescaledb_functions.stop_background_workers();
 DROP TABLE sensor_data;
+SELECT _timescaledb_functions.restart_background_workers();
 
 -- Github issue #5537
 -- Proc that waits until the given job enters the expected state


### PR DESCRIPTION
When dropping a table, we get notices if that causes to cancel background jobs and thus fail tests. By stopping the workers before dropping the table, we should reduce this flakiness.

Flaky CI runs:
https://github.com/timescale/timescaledb/actions/runs/6350907791/job/17251315853
https://github.com/timescale/timescaledb/actions/runs/6350907791/job/17251315717

Disable-check: force-changelog-file
