### PR TITLE
Fix segfaults in generic hypertable api

### DIFF
--- a/src/dimension.c
+++ b/src/dimension.c
@@ -31,6 +31,7 @@
 #include "time_utils.h"
 #include "utils.h"
 #include "errors.h"
+#include "error_utils.h"
 #include "debug_point.h"
 
 /* add_dimension record attribute numbers */
@@ -1835,7 +1836,8 @@ ts_range_dimension(PG_FUNCTION_ARGS)
 Datum
 ts_dimension_add_general(PG_FUNCTION_ARGS)
 {
-	DimensionInfo *info = (DimensionInfo *) PG_GETARG_POINTER(1);
+	DimensionInfo *info = NULL;
+	GETARG_NOTNULL_POINTER(info, 1, "dimension", DimensionInfo);
 	info->table_relid = PG_GETARG_OID(0);
 	if (PG_GETARG_BOOL(2))
 		info->if_not_exists = true;

--- a/src/error_utils.h
+++ b/src/error_utils.h
@@ -15,6 +15,15 @@
 					 errmsg("%s cannot be NULL", name)));                                          \
 	}
 
+#define GETARG_NOTNULL_POINTER(var, arg, name, type)                                               \
+	{                                                                                              \
+		if (PG_ARGISNULL(arg))                                                                     \
+			ereport(ERROR,                                                                         \
+					(errcode(ERRCODE_INVALID_PARAMETER_VALUE),                                     \
+					 errmsg("%s cannot be NULL", name)));                                          \
+		var = (type *) PG_GETARG_POINTER(arg);                                                     \
+	}
+
 #define GETARG_NOTNULL_NULLABLE(var, arg, name, type)                                              \
 	{                                                                                              \
 		if (PG_ARGISNULL(arg))                                                                     \

--- a/src/hypertable.c
+++ b/src/hypertable.c
@@ -67,6 +67,7 @@
 #include "scan_iterator.h"
 #include "debug_assert.h"
 #include "osm_callbacks.h"
+#include "error_utils.h"
 
 Oid
 ts_rel_get_owner(Oid relid)
@@ -2135,7 +2136,8 @@ Datum
 ts_hypertable_create_general(PG_FUNCTION_ARGS)
 {
 	Oid table_relid = PG_ARGISNULL(0) ? InvalidOid : PG_GETARG_OID(0);
-	DimensionInfo *dim_info = (DimensionInfo *) PG_GETARG_POINTER(1);
+	DimensionInfo *dim_info = NULL;
+	GETARG_NOTNULL_POINTER(dim_info, 1, "dimension", DimensionInfo);
 	bool create_default_indexes = PG_ARGISNULL(2) ? false : PG_GETARG_BOOL(2);
 	bool if_not_exists = PG_ARGISNULL(3) ? false : PG_GETARG_BOOL(3);
 	bool migrate_data = PG_ARGISNULL(4) ? false : PG_GETARG_BOOL(4);

--- a/tsl/test/expected/hypertable_generalization.out
+++ b/tsl/test/expected/hypertable_generalization.out
@@ -11,6 +11,14 @@ BEGIN
 	RETURN retval;
 END
 $BODY$;
+-- test null handling
+\set ON_ERROR_STOP 0
+CREATE TABLE n();
+SELECT create_hypertable('n',NULL::_timescaledb_internal.dimension_info);
+ERROR:  dimension cannot be NULL
+SELECT add_dimension('n',NULL::_timescaledb_internal.dimension_info);
+ERROR:  dimension cannot be NULL
+\set ON_ERROR_STOP 1
 SELECT by_range('id');
     by_range     
 -----------------

--- a/tsl/test/sql/hypertable_generalization.sql
+++ b/tsl/test/sql/hypertable_generalization.sql
@@ -13,6 +13,13 @@ BEGIN
 END
 $BODY$;
 
+-- test null handling
+\set ON_ERROR_STOP 0
+CREATE TABLE n();
+SELECT create_hypertable('n',NULL::_timescaledb_internal.dimension_info);
+SELECT add_dimension('n',NULL::_timescaledb_internal.dimension_info);
+\set ON_ERROR_STOP 1
+
 SELECT by_range('id');
 SELECT by_range('id', partition_func => 'part_func');
 SELECT by_range('id', '1 week'::interval);


### PR DESCRIPTION
This patch fixes segfaults in create_hypertable and add_dimension when passing NULL parameters.

Disable-check: force-changelog-file
