### PR TITLE
PG16: adjust tests to use debug_parallel_query

### DIFF
--- a/test/expected/loader-tsl.out
+++ b/test/expected/loader-tsl.out
@@ -536,8 +536,13 @@ INSERT INTO test SELECT x, x+0.1 FROM generate_series(1,100) AS x;
 WARNING:  mock post_analyze_hook "mock-2"
 DISCARD ALL;
 WARNING:  mock post_analyze_hook "mock-2"
-SET force_parallel_mode = 'on';
+SELECT set_config(CASE WHEN current_setting('server_version_num')::int < 160000 THEN 'force_parallel_mode' ELSE 'debug_parallel_query' END,'on', false);
 WARNING:  mock post_analyze_hook "mock-2"
+ set_config 
+------------
+ on
+(1 row)
+
 SET max_parallel_workers_per_gather = 1;
 WARNING:  mock post_analyze_hook "mock-2"
 SELECT count(*) FROM test;

--- a/test/expected/parallel-13.out
+++ b/test/expected/parallel-13.out
@@ -21,7 +21,12 @@ ANALYZE test;
 ALTER TABLE :CHUNK1 SET (parallel_workers=2);
 ALTER TABLE :CHUNK2 SET (parallel_workers=2);
 SET work_mem TO '50MB';
-SET force_parallel_mode = 'on';
+SELECT set_config(CASE WHEN current_setting('server_version_num')::int < 160000 THEN 'force_parallel_mode' ELSE 'debug_parallel_query' END,'on', false);
+ set_config 
+------------
+ on
+(1 row)
+
 SET max_parallel_workers_per_gather = 4;
 SET parallel_setup_cost TO 0;
 EXPLAIN (costs off) SELECT first(i, j) FROM "test";
@@ -498,7 +503,12 @@ SELECT * FROM sensor_data AS s1 JOIN sensor_data AS s2 ON (TRUE) WHERE s1.time >
 RESET parallel_leader_participation;
 -- Ensure the same query result is produced by a sequencial query
 SET max_parallel_workers_per_gather TO 0;
-SET force_parallel_mode = 'off';
+SELECT set_config(CASE WHEN current_setting('server_version_num')::int < 160000 THEN 'force_parallel_mode' ELSE 'debug_parallel_query' END,'off', false);
+ set_config 
+------------
+ off
+(1 row)
+
 SELECT * FROM sensor_data AS s1 JOIN sensor_data AS s2 ON (TRUE) WHERE s1.time > '2020-01-01 00:00:30'::text::timestamptz AND s2.time > '2020-01-01 00:00:30' AND s2.time < '2021-01-01 00:00:30' AND s1.sensor_id > 50 ORDER BY s2.time, s1.time, s1.sensor_id, s2.sensor_id;
              time             | sensor_id |             time             | sensor_id 
 ------------------------------+-----------+------------------------------+-----------
@@ -522,7 +532,12 @@ RESET min_parallel_index_scan_size;
 RESET enable_hashjoin;
 RESET enable_nestloop;
 RESET parallel_tuple_cost;
-SET force_parallel_mode = 'on';
+SELECT set_config(CASE WHEN current_setting('server_version_num')::int < 160000 THEN 'force_parallel_mode' ELSE 'debug_parallel_query' END,'on', false);
+ set_config 
+------------
+ on
+(1 row)
+
 -- test worker assignment
 -- first chunk should have 1 worker and second chunk should have 2
 SET max_parallel_workers_per_gather TO 2;

--- a/test/expected/parallel-14.out
+++ b/test/expected/parallel-14.out
@@ -21,7 +21,12 @@ ANALYZE test;
 ALTER TABLE :CHUNK1 SET (parallel_workers=2);
 ALTER TABLE :CHUNK2 SET (parallel_workers=2);
 SET work_mem TO '50MB';
-SET force_parallel_mode = 'on';
+SELECT set_config(CASE WHEN current_setting('server_version_num')::int < 160000 THEN 'force_parallel_mode' ELSE 'debug_parallel_query' END,'on', false);
+ set_config 
+------------
+ on
+(1 row)
+
 SET max_parallel_workers_per_gather = 4;
 SET parallel_setup_cost TO 0;
 EXPLAIN (costs off) SELECT first(i, j) FROM "test";
@@ -498,7 +503,12 @@ SELECT * FROM sensor_data AS s1 JOIN sensor_data AS s2 ON (TRUE) WHERE s1.time >
 RESET parallel_leader_participation;
 -- Ensure the same query result is produced by a sequencial query
 SET max_parallel_workers_per_gather TO 0;
-SET force_parallel_mode = 'off';
+SELECT set_config(CASE WHEN current_setting('server_version_num')::int < 160000 THEN 'force_parallel_mode' ELSE 'debug_parallel_query' END,'off', false);
+ set_config 
+------------
+ off
+(1 row)
+
 SELECT * FROM sensor_data AS s1 JOIN sensor_data AS s2 ON (TRUE) WHERE s1.time > '2020-01-01 00:00:30'::text::timestamptz AND s2.time > '2020-01-01 00:00:30' AND s2.time < '2021-01-01 00:00:30' AND s1.sensor_id > 50 ORDER BY s2.time, s1.time, s1.sensor_id, s2.sensor_id;
              time             | sensor_id |             time             | sensor_id 
 ------------------------------+-----------+------------------------------+-----------
@@ -522,7 +532,12 @@ RESET min_parallel_index_scan_size;
 RESET enable_hashjoin;
 RESET enable_nestloop;
 RESET parallel_tuple_cost;
-SET force_parallel_mode = 'on';
+SELECT set_config(CASE WHEN current_setting('server_version_num')::int < 160000 THEN 'force_parallel_mode' ELSE 'debug_parallel_query' END,'on', false);
+ set_config 
+------------
+ on
+(1 row)
+
 -- test worker assignment
 -- first chunk should have 1 worker and second chunk should have 2
 SET max_parallel_workers_per_gather TO 2;

--- a/test/expected/parallel-15.out
+++ b/test/expected/parallel-15.out
@@ -21,7 +21,12 @@ ANALYZE test;
 ALTER TABLE :CHUNK1 SET (parallel_workers=2);
 ALTER TABLE :CHUNK2 SET (parallel_workers=2);
 SET work_mem TO '50MB';
-SET force_parallel_mode = 'on';
+SELECT set_config(CASE WHEN current_setting('server_version_num')::int < 160000 THEN 'force_parallel_mode' ELSE 'debug_parallel_query' END,'on', false);
+ set_config 
+------------
+ on
+(1 row)
+
 SET max_parallel_workers_per_gather = 4;
 SET parallel_setup_cost TO 0;
 EXPLAIN (costs off) SELECT first(i, j) FROM "test";
@@ -499,7 +504,12 @@ SELECT * FROM sensor_data AS s1 JOIN sensor_data AS s2 ON (TRUE) WHERE s1.time >
 RESET parallel_leader_participation;
 -- Ensure the same query result is produced by a sequencial query
 SET max_parallel_workers_per_gather TO 0;
-SET force_parallel_mode = 'off';
+SELECT set_config(CASE WHEN current_setting('server_version_num')::int < 160000 THEN 'force_parallel_mode' ELSE 'debug_parallel_query' END,'off', false);
+ set_config 
+------------
+ off
+(1 row)
+
 SELECT * FROM sensor_data AS s1 JOIN sensor_data AS s2 ON (TRUE) WHERE s1.time > '2020-01-01 00:00:30'::text::timestamptz AND s2.time > '2020-01-01 00:00:30' AND s2.time < '2021-01-01 00:00:30' AND s1.sensor_id > 50 ORDER BY s2.time, s1.time, s1.sensor_id, s2.sensor_id;
              time             | sensor_id |             time             | sensor_id 
 ------------------------------+-----------+------------------------------+-----------
@@ -523,7 +533,12 @@ RESET min_parallel_index_scan_size;
 RESET enable_hashjoin;
 RESET enable_nestloop;
 RESET parallel_tuple_cost;
-SET force_parallel_mode = 'on';
+SELECT set_config(CASE WHEN current_setting('server_version_num')::int < 160000 THEN 'force_parallel_mode' ELSE 'debug_parallel_query' END,'on', false);
+ set_config 
+------------
+ on
+(1 row)
+
 -- test worker assignment
 -- first chunk should have 1 worker and second chunk should have 2
 SET max_parallel_workers_per_gather TO 2;

--- a/test/sql/loader.sql.in
+++ b/test/sql/loader.sql.in
@@ -204,7 +204,7 @@ CREATE TABLE test (i int, j double precision);
 INSERT INTO test SELECT x, x+0.1 FROM generate_series(1,100) AS x;
 
 DISCARD ALL;
-SET force_parallel_mode = 'on';
+SELECT set_config(CASE WHEN current_setting('server_version_num')::int < 160000 THEN 'force_parallel_mode' ELSE 'debug_parallel_query' END,'on', false);
 SET max_parallel_workers_per_gather = 1;
 SELECT count(*) FROM test;
 

--- a/test/sql/parallel.sql.in
+++ b/test/sql/parallel.sql.in
@@ -20,7 +20,7 @@ ALTER TABLE :CHUNK1 SET (parallel_workers=2);
 ALTER TABLE :CHUNK2 SET (parallel_workers=2);
 
 SET work_mem TO '50MB';
-SET force_parallel_mode = 'on';
+SELECT set_config(CASE WHEN current_setting('server_version_num')::int < 160000 THEN 'force_parallel_mode' ELSE 'debug_parallel_query' END,'on', false);
 SET max_parallel_workers_per_gather = 4;
 SET parallel_setup_cost TO 0;
 
@@ -126,7 +126,7 @@ RESET parallel_leader_participation;
 
 -- Ensure the same query result is produced by a sequencial query
 SET max_parallel_workers_per_gather TO 0;
-SET force_parallel_mode = 'off';
+SELECT set_config(CASE WHEN current_setting('server_version_num')::int < 160000 THEN 'force_parallel_mode' ELSE 'debug_parallel_query' END,'off', false);
 SELECT * FROM sensor_data AS s1 JOIN sensor_data AS s2 ON (TRUE) WHERE s1.time > '2020-01-01 00:00:30'::text::timestamptz AND s2.time > '2020-01-01 00:00:30' AND s2.time < '2021-01-01 00:00:30' AND s1.sensor_id > 50 ORDER BY s2.time, s1.time, s1.sensor_id, s2.sensor_id;
 
 RESET enable_material;
@@ -135,7 +135,7 @@ RESET min_parallel_index_scan_size;
 RESET enable_hashjoin;
 RESET enable_nestloop;
 RESET parallel_tuple_cost;
-SET force_parallel_mode = 'on';
+SELECT set_config(CASE WHEN current_setting('server_version_num')::int < 160000 THEN 'force_parallel_mode' ELSE 'debug_parallel_query' END,'on', false);
 
 -- test worker assignment
 -- first chunk should have 1 worker and second chunk should have 2

--- a/tsl/test/expected/agg_partials_pushdown.out
+++ b/tsl/test/expected/agg_partials_pushdown.out
@@ -281,7 +281,12 @@ SELECT timeCustom t, min(series_0) FROM PUBLIC.testtable2 GROUP BY t ORDER BY t 
 (32 rows)
 
 -- Force parallel query
-SET force_parallel_mode = 'on';
+SELECT set_config(CASE WHEN current_setting('server_version_num')::int < 160000 THEN 'force_parallel_mode' ELSE 'debug_parallel_query' END,'on', false);
+ set_config 
+------------
+ on
+(1 row)
+
 SET parallel_setup_cost = 0;
 SET parallel_tuple_cost = 0;
 SELECT timeCustom t, min(series_0) FROM PUBLIC.testtable2 GROUP BY t ORDER BY t DESC NULLS LAST limit 2;

--- a/tsl/test/expected/continuous_aggs-13.out
+++ b/tsl/test/expected/continuous_aggs-13.out
@@ -2309,7 +2309,12 @@ FROM conditions
 GROUP BY 1
 ORDER BY 2 DESC;
 NOTICE:  refreshing continuous aggregate "conditions_daily"
-SET force_parallel_mode = 'on';
+SELECT set_config(CASE WHEN current_setting('server_version_num')::int < 160000 THEN 'force_parallel_mode' ELSE 'debug_parallel_query' END,'on', false);
+ set_config 
+------------
+ on
+(1 row)
+
 SET max_parallel_workers_per_gather = 4;
 SET parallel_setup_cost = 0;
 SET parallel_tuple_cost = 0;

--- a/tsl/test/expected/continuous_aggs-14.out
+++ b/tsl/test/expected/continuous_aggs-14.out
@@ -2308,7 +2308,12 @@ FROM conditions
 GROUP BY 1
 ORDER BY 2 DESC;
 NOTICE:  refreshing continuous aggregate "conditions_daily"
-SET force_parallel_mode = 'on';
+SELECT set_config(CASE WHEN current_setting('server_version_num')::int < 160000 THEN 'force_parallel_mode' ELSE 'debug_parallel_query' END,'on', false);
+ set_config 
+------------
+ on
+(1 row)
+
 SET max_parallel_workers_per_gather = 4;
 SET parallel_setup_cost = 0;
 SET parallel_tuple_cost = 0;

--- a/tsl/test/expected/continuous_aggs-15.out
+++ b/tsl/test/expected/continuous_aggs-15.out
@@ -2310,7 +2310,12 @@ FROM conditions
 GROUP BY 1
 ORDER BY 2 DESC;
 NOTICE:  refreshing continuous aggregate "conditions_daily"
-SET force_parallel_mode = 'on';
+SELECT set_config(CASE WHEN current_setting('server_version_num')::int < 160000 THEN 'force_parallel_mode' ELSE 'debug_parallel_query' END,'on', false);
+ set_config 
+------------
+ on
+(1 row)
+
 SET max_parallel_workers_per_gather = 4;
 SET parallel_setup_cost = 0;
 SET parallel_tuple_cost = 0;

--- a/tsl/test/expected/partialize_finalize.out
+++ b/tsl/test/expected/partialize_finalize.out
@@ -408,7 +408,12 @@ CREATE OR REPLACE FUNCTION mix(x INTEGER) RETURNS INTEGER AS $$ SELECT (((hashin
 INSERT INTO issue4922 (time, value)
 SELECT '2022-01-01 00:00:00-03'::timestamptz + interval '1 year' * mix(x), mix(x)
 FROM generate_series(1, 100000) x(x);
-SET force_parallel_mode = 'on';
+SELECT set_config(CASE WHEN current_setting('server_version_num')::int < 160000 THEN 'force_parallel_mode' ELSE 'debug_parallel_query' END,'on', false);
+ set_config 
+------------
+ on
+(1 row)
+
 SET parallel_setup_cost = 0;
 -- Materialize partials from execution of parallel query plan
 EXPLAIN (VERBOSE, COSTS OFF)

--- a/tsl/test/expected/plan_skip_scan-13.out
+++ b/tsl/test/expected/plan_skip_scan-13.out
@@ -1275,7 +1275,12 @@ UNION SELECT b.* FROM
 (6 rows)
 
 -- parallel query
-SET force_parallel_mode TO true;
+SELECT set_config(CASE WHEN current_setting('server_version_num')::int < 160000 THEN 'force_parallel_mode' ELSE 'debug_parallel_query' END,'on', false);
+ set_config 
+------------
+ on
+(1 row)
+
 :PREFIX SELECT DISTINCT dev FROM :TABLE ORDER BY dev;
                                         QUERY PLAN                                         
 -------------------------------------------------------------------------------------------
@@ -1286,7 +1291,12 @@ SET force_parallel_mode TO true;
                Heap Fetches: 12
 (5 rows)
 
-RESET force_parallel_mode;
+SELECT set_config(CASE WHEN current_setting('server_version_num')::int < 160000 THEN 'force_parallel_mode' ELSE 'debug_parallel_query' END,'off', false);
+ set_config 
+------------
+ off
+(1 row)
+
 TRUNCATE skip_scan_insert;
 -- table with only nulls
 :PREFIX SELECT DISTINCT ON (time) time FROM skip_scan_nulls;
@@ -3710,7 +3720,12 @@ UNION SELECT b.* FROM
 (14 rows)
 
 -- parallel query
-SET force_parallel_mode TO true;
+SELECT set_config(CASE WHEN current_setting('server_version_num')::int < 160000 THEN 'force_parallel_mode' ELSE 'debug_parallel_query' END,'on', false);
+ set_config 
+------------
+ on
+(1 row)
+
 :PREFIX SELECT DISTINCT dev FROM :TABLE ORDER BY dev;
                                                          QUERY PLAN                                                         
 ----------------------------------------------------------------------------------------------------------------------------
@@ -3735,7 +3750,12 @@ SET force_parallel_mode TO true;
                      Heap Fetches: 11
 (19 rows)
 
-RESET force_parallel_mode;
+SELECT set_config(CASE WHEN current_setting('server_version_num')::int < 160000 THEN 'force_parallel_mode' ELSE 'debug_parallel_query' END,'off', false);
+ set_config 
+------------
+ off
+(1 row)
+
 TRUNCATE skip_scan_insert;
 -- table with only nulls
 :PREFIX SELECT DISTINCT ON (time) time FROM skip_scan_nulls;

--- a/tsl/test/expected/plan_skip_scan-14.out
+++ b/tsl/test/expected/plan_skip_scan-14.out
@@ -1274,7 +1274,12 @@ UNION SELECT b.* FROM
 (6 rows)
 
 -- parallel query
-SET force_parallel_mode TO true;
+SELECT set_config(CASE WHEN current_setting('server_version_num')::int < 160000 THEN 'force_parallel_mode' ELSE 'debug_parallel_query' END,'on', false);
+ set_config 
+------------
+ on
+(1 row)
+
 :PREFIX SELECT DISTINCT dev FROM :TABLE ORDER BY dev;
                                         QUERY PLAN                                         
 -------------------------------------------------------------------------------------------
@@ -1285,7 +1290,12 @@ SET force_parallel_mode TO true;
                Heap Fetches: 12
 (5 rows)
 
-RESET force_parallel_mode;
+SELECT set_config(CASE WHEN current_setting('server_version_num')::int < 160000 THEN 'force_parallel_mode' ELSE 'debug_parallel_query' END,'off', false);
+ set_config 
+------------
+ off
+(1 row)
+
 TRUNCATE skip_scan_insert;
 -- table with only nulls
 :PREFIX SELECT DISTINCT ON (time) time FROM skip_scan_nulls;
@@ -3708,7 +3718,12 @@ UNION SELECT b.* FROM
 (14 rows)
 
 -- parallel query
-SET force_parallel_mode TO true;
+SELECT set_config(CASE WHEN current_setting('server_version_num')::int < 160000 THEN 'force_parallel_mode' ELSE 'debug_parallel_query' END,'on', false);
+ set_config 
+------------
+ on
+(1 row)
+
 :PREFIX SELECT DISTINCT dev FROM :TABLE ORDER BY dev;
                                                          QUERY PLAN                                                         
 ----------------------------------------------------------------------------------------------------------------------------
@@ -3733,7 +3748,12 @@ SET force_parallel_mode TO true;
                      Heap Fetches: 11
 (19 rows)
 
-RESET force_parallel_mode;
+SELECT set_config(CASE WHEN current_setting('server_version_num')::int < 160000 THEN 'force_parallel_mode' ELSE 'debug_parallel_query' END,'off', false);
+ set_config 
+------------
+ off
+(1 row)
+
 TRUNCATE skip_scan_insert;
 -- table with only nulls
 :PREFIX SELECT DISTINCT ON (time) time FROM skip_scan_nulls;

--- a/tsl/test/expected/plan_skip_scan-15.out
+++ b/tsl/test/expected/plan_skip_scan-15.out
@@ -1274,7 +1274,12 @@ UNION SELECT b.* FROM
 (6 rows)
 
 -- parallel query
-SET force_parallel_mode TO true;
+SELECT set_config(CASE WHEN current_setting('server_version_num')::int < 160000 THEN 'force_parallel_mode' ELSE 'debug_parallel_query' END,'on', false);
+ set_config 
+------------
+ on
+(1 row)
+
 :PREFIX SELECT DISTINCT dev FROM :TABLE ORDER BY dev;
                                         QUERY PLAN                                         
 -------------------------------------------------------------------------------------------
@@ -1285,7 +1290,12 @@ SET force_parallel_mode TO true;
                Heap Fetches: 12
 (5 rows)
 
-RESET force_parallel_mode;
+SELECT set_config(CASE WHEN current_setting('server_version_num')::int < 160000 THEN 'force_parallel_mode' ELSE 'debug_parallel_query' END,'off', false);
+ set_config 
+------------
+ off
+(1 row)
+
 TRUNCATE skip_scan_insert;
 -- table with only nulls
 :PREFIX SELECT DISTINCT ON (time) time FROM skip_scan_nulls;
@@ -3708,7 +3718,12 @@ UNION SELECT b.* FROM
 (14 rows)
 
 -- parallel query
-SET force_parallel_mode TO true;
+SELECT set_config(CASE WHEN current_setting('server_version_num')::int < 160000 THEN 'force_parallel_mode' ELSE 'debug_parallel_query' END,'on', false);
+ set_config 
+------------
+ on
+(1 row)
+
 :PREFIX SELECT DISTINCT dev FROM :TABLE ORDER BY dev;
                                                          QUERY PLAN                                                         
 ----------------------------------------------------------------------------------------------------------------------------
@@ -3733,7 +3748,12 @@ SET force_parallel_mode TO true;
                      Heap Fetches: 11
 (19 rows)
 
-RESET force_parallel_mode;
+SELECT set_config(CASE WHEN current_setting('server_version_num')::int < 160000 THEN 'force_parallel_mode' ELSE 'debug_parallel_query' END,'off', false);
+ set_config 
+------------
+ off
+(1 row)
+
 TRUNCATE skip_scan_insert;
 -- table with only nulls
 :PREFIX SELECT DISTINCT ON (time) time FROM skip_scan_nulls;

--- a/tsl/test/expected/skip_scan.out
+++ b/tsl/test/expected/skip_scan.out
@@ -249,9 +249,9 @@ UNION SELECT b.* FROM
 -- SkipScan into INSERT
 :PREFIX INSERT INTO skip_scan_insert(time, dev, val, query) SELECT time, dev, val, 'q10_1' FROM (SELECT DISTINCT ON (dev) * FROM :TABLE) a;
 -- parallel query
-SET force_parallel_mode TO true;
+SELECT set_config(CASE WHEN current_setting('server_version_num')::int < 160000 THEN 'force_parallel_mode' ELSE 'debug_parallel_query' END,'on', false);
 :PREFIX SELECT DISTINCT dev FROM :TABLE ORDER BY dev;
-RESET force_parallel_mode;
+SELECT set_config(CASE WHEN current_setting('server_version_num')::int < 160000 THEN 'force_parallel_mode' ELSE 'debug_parallel_query' END,'off', false);
 TRUNCATE skip_scan_insert;
 -- table with only nulls
 :PREFIX SELECT DISTINCT ON (time) time FROM skip_scan_nulls;
@@ -453,9 +453,9 @@ UNION SELECT b.* FROM
 -- SkipScan into INSERT
 :PREFIX INSERT INTO skip_scan_insert(time, dev, val, query) SELECT time, dev, val, 'q10_1' FROM (SELECT DISTINCT ON (dev) * FROM :TABLE) a;
 -- parallel query
-SET force_parallel_mode TO true;
+SELECT set_config(CASE WHEN current_setting('server_version_num')::int < 160000 THEN 'force_parallel_mode' ELSE 'debug_parallel_query' END,'on', false);
 :PREFIX SELECT DISTINCT dev FROM :TABLE ORDER BY dev;
-RESET force_parallel_mode;
+SELECT set_config(CASE WHEN current_setting('server_version_num')::int < 160000 THEN 'force_parallel_mode' ELSE 'debug_parallel_query' END,'off', false);
 TRUNCATE skip_scan_insert;
 -- table with only nulls
 :PREFIX SELECT DISTINCT ON (time) time FROM skip_scan_nulls;
@@ -672,9 +672,9 @@ UNION SELECT b.* FROM
 -- SkipScan into INSERT
 :PREFIX INSERT INTO skip_scan_insert(time, dev, val, query) SELECT time, dev, val, 'q10_1' FROM (SELECT DISTINCT ON (dev) * FROM :TABLE) a;
 -- parallel query
-SET force_parallel_mode TO true;
+SELECT set_config(CASE WHEN current_setting('server_version_num')::int < 160000 THEN 'force_parallel_mode' ELSE 'debug_parallel_query' END,'on', false);
 :PREFIX SELECT DISTINCT dev FROM :TABLE ORDER BY dev;
-RESET force_parallel_mode;
+SELECT set_config(CASE WHEN current_setting('server_version_num')::int < 160000 THEN 'force_parallel_mode' ELSE 'debug_parallel_query' END,'off', false);
 TRUNCATE skip_scan_insert;
 -- table with only nulls
 :PREFIX SELECT DISTINCT ON (time) time FROM skip_scan_nulls;
@@ -876,9 +876,9 @@ UNION SELECT b.* FROM
 -- SkipScan into INSERT
 :PREFIX INSERT INTO skip_scan_insert(time, dev, val, query) SELECT time, dev, val, 'q10_1' FROM (SELECT DISTINCT ON (dev) * FROM :TABLE) a;
 -- parallel query
-SET force_parallel_mode TO true;
+SELECT set_config(CASE WHEN current_setting('server_version_num')::int < 160000 THEN 'force_parallel_mode' ELSE 'debug_parallel_query' END,'on', false);
 :PREFIX SELECT DISTINCT dev FROM :TABLE ORDER BY dev;
-RESET force_parallel_mode;
+SELECT set_config(CASE WHEN current_setting('server_version_num')::int < 160000 THEN 'force_parallel_mode' ELSE 'debug_parallel_query' END,'off', false);
 TRUNCATE skip_scan_insert;
 -- table with only nulls
 :PREFIX SELECT DISTINCT ON (time) time FROM skip_scan_nulls;

--- a/tsl/test/sql/agg_partials_pushdown.sql
+++ b/tsl/test/sql/agg_partials_pushdown.sql
@@ -86,7 +86,7 @@ SELECT timeCustom t, min(series_0) FROM PUBLIC.testtable2 GROUP BY t ORDER BY t 
 SELECT timeCustom t, min(series_0) FROM PUBLIC.testtable2 GROUP BY t ORDER BY t DESC NULLS LAST limit 2;
 
 -- Force parallel query
-SET force_parallel_mode = 'on';
+SELECT set_config(CASE WHEN current_setting('server_version_num')::int < 160000 THEN 'force_parallel_mode' ELSE 'debug_parallel_query' END,'on', false);
 SET parallel_setup_cost = 0;
 SET parallel_tuple_cost = 0;
 

--- a/tsl/test/sql/continuous_aggs.sql.in
+++ b/tsl/test/sql/continuous_aggs.sql.in
@@ -1539,7 +1539,7 @@ FROM conditions
 GROUP BY 1
 ORDER BY 2 DESC;
 
-SET force_parallel_mode = 'on';
+SELECT set_config(CASE WHEN current_setting('server_version_num')::int < 160000 THEN 'force_parallel_mode' ELSE 'debug_parallel_query' END,'on', false);
 SET max_parallel_workers_per_gather = 4;
 SET parallel_setup_cost = 0;
 SET parallel_tuple_cost = 0;

--- a/tsl/test/sql/include/skip_scan_query.sql
+++ b/tsl/test/sql/include/skip_scan_query.sql
@@ -227,9 +227,9 @@ UNION SELECT b.* FROM
 :PREFIX INSERT INTO skip_scan_insert(time, dev, val, query) SELECT time, dev, val, 'q10_1' FROM (SELECT DISTINCT ON (dev) * FROM :TABLE) a;
 
 -- parallel query
-SET force_parallel_mode TO true;
+SELECT set_config(CASE WHEN current_setting('server_version_num')::int < 160000 THEN 'force_parallel_mode' ELSE 'debug_parallel_query' END,'on', false);
 :PREFIX SELECT DISTINCT dev FROM :TABLE ORDER BY dev;
-RESET force_parallel_mode;
+SELECT set_config(CASE WHEN current_setting('server_version_num')::int < 160000 THEN 'force_parallel_mode' ELSE 'debug_parallel_query' END,'off', false);
 
 TRUNCATE skip_scan_insert;
 

--- a/tsl/test/sql/partialize_finalize.sql
+++ b/tsl/test/sql/partialize_finalize.sql
@@ -313,7 +313,7 @@ INSERT INTO issue4922 (time, value)
 SELECT '2022-01-01 00:00:00-03'::timestamptz + interval '1 year' * mix(x), mix(x)
 FROM generate_series(1, 100000) x(x);
 
-SET force_parallel_mode = 'on';
+SELECT set_config(CASE WHEN current_setting('server_version_num')::int < 160000 THEN 'force_parallel_mode' ELSE 'debug_parallel_query' END,'on', false);
 SET parallel_setup_cost = 0;
 
 -- Materialize partials from execution of parallel query plan

--- a/tsl/test/t/008_mvcc_cagg.pl
+++ b/tsl/test/t/008_mvcc_cagg.pl
@@ -92,7 +92,7 @@ for (my $iteration = 0; $iteration < 10; $iteration++)
 	{
 		# Encourage the use of parallel workers
 		my $sql = q{
-           SET force_parallel_mode = 1;
+           SELECT set_config(CASE WHEN current_setting('server_version_num')::int < 160000 THEN 'force_parallel_mode' ELSE 'debug_parallel_query' END,'on', false);
            SET enable_bitmapscan = 0;
            SET parallel_setup_cost = 0;
            SET parallel_tuple_cost = 0;


### PR DESCRIPTION
PG16 renamed force_parallel_mode to debug_parallel_query.

https://github.com/postgres/postgres/commit/5352ca22e

Disable-check: force-changelog-file
