### PR TITLE
Modify interpolate() call in gapfill test

### DIFF
--- a/tsl/test/shared/expected/gapfill.out
+++ b/tsl/test/shared/expected/gapfill.out
@@ -926,7 +926,7 @@ SELECT locf(NULL::int);
      
 (1 row)
 
-SELECT interpolate(NULL);
+SELECT interpolate(NULL::bigint);
  interpolate 
             
 (1 row)

--- a/tsl/test/shared/sql/gapfill.sql
+++ b/tsl/test/shared/sql/gapfill.sql
@@ -195,7 +195,7 @@ SELECT locf(1);
 SELECT interpolate(1);
 -- test locf and interpolate call with NULL input
 SELECT locf(NULL::int);
-SELECT interpolate(NULL);
+SELECT interpolate(NULL::bigint);
 
 \set ON_ERROR_STOP 0
 -- test time_bucket_gapfill not top level function call


### PR DESCRIPTION
To work fine on dev-cloud tests, in presence of other extensions.

Disable-check: force-changelog-file