### PR TITLE
PG16 Fix transparent decompression

### DIFF
--- a/tsl/src/nodes/decompress_chunk/decompress_chunk.c
+++ b/tsl/src/nodes/decompress_chunk/decompress_chunk.c
@@ -901,15 +901,9 @@ ts_decompress_chunk_generate_paths(PlannerInfo *root, RelOptInfo *chunk_rel, Hyp
 		 * freed if it's planned */
 		compressed_rel->partial_pathlist = NIL;
 	}
-#if PG16_LT
-	/* set reloptkind to RELOPT_DEADREL to prevent postgresql from replanning this relation */
-	compressed_rel->reloptkind = RELOPT_DEADREL;
-#else
-	/* remove the compressed_rel from the simple_rel_array to prevent it from being referenced again
-	 */
+	/* Remove the compressed_rel from the simple_rel_array to prevent it from
+	 * being referenced again. */
 	root->simple_rel_array[compressed_rel->relid] = NULL;
-	pfree(compressed_rel);
-#endif
 
 	/* We should never get in the situation with no viable paths. */
 	Ensure(chunk_rel->pathlist, "could not create decompression path");


### PR DESCRIPTION
The initial commit to adjust RELOPT_DEADREL for PG16 also freed
the RelOptInfo but even though we dont want them to be referenced
again since they are internal we must not free them because the
lower plan nodes still reference them leading to segfaults in the
executor when trying to access those reloptinfo. With this change
most of the compression tests pass on PG16.
This patch also gets rid of RELOPT_DEADREL for earlier PG versions
and always removes the entry from simple_rel_array.

Disable-check: force-changelog-file

