### PR TITLE
Release 2.12.1

### DIFF
--- a/.unreleased/PR_6117
+++ b/.unreleased/PR_6117
@@ -1,1 +1,0 @@
-Fixes: #6117 Avoid decompressing batches using an empty slot

--- a/.unreleased/pr_6113
+++ b/.unreleased/pr_6113
@@ -1,3 +1,0 @@
-Fixes: #6113 Fix planner distributed table count
-
-Thanks: @symbx for reporting a crash when selecting from empty hypertables

--- a/.unreleased/pr_6142
+++ b/.unreleased/pr_6142
@@ -1,1 +1,0 @@
-Fixes: #6142 do not throw an error when deprecation GUC cannot be read

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,19 @@
 `psql` with the `-X` flag to prevent any `.psqlrc` commands from
 accidentally triggering the load of a previous DB version.**
 
+## 2.12.1 (2023-10-11)
+
+This release contains bug fixes since the 2.12.0 release.
+We recommend that you upgrade at the next available opportunity.
+
+**Bugfixes**
+* #6113 Fix planner distributed table count
+* #6117 Avoid decompressing batches using an empty slot
+* #6123 Fix concurrency errors in OSM API
+* #6142 do not throw an error when deprecation GUC cannot be read
+**Thanks**
+* @symbx for reporting a crash when selecting from empty hypertables
+
 ## 2.12.0 (2023-09-27)
 
 This release contains performance improvements for compressed hypertables

--- a/sql/CMakeLists.txt
+++ b/sql/CMakeLists.txt
@@ -38,7 +38,8 @@ set(MOD_FILES
     updates/2.10.3--2.11.0.sql
     updates/2.11.0--2.11.1.sql
     updates/2.11.1--2.11.2.sql
-    updates/2.11.2--2.12.0.sql)
+    updates/2.11.2--2.12.0.sql
+    updates/2.12.0--2.12.1.sql)
 
 # The downgrade file to generate a downgrade script for the current version, as
 # specified in version.config

--- a/version.config
+++ b/version.config
@@ -1,3 +1,3 @@
 version = 2.13.0-dev
-update_from_version = 2.12.0
+update_from_version = 2.12.1
 downgrade_to_version = 2.12.0


### PR DESCRIPTION
This release contains bug fixes since the 2.12.0 release.
We recommend that you upgrade at the next available opportunity.

**Bugfixes**
* https://github.com/timescale/timescaledb/pull/6113 Fix planner distributed table count
* https://github.com/timescale/timescaledb/pull/6117 Avoid decompressing batches using an empty slot
* https://github.com/timescale/timescaledb/pull/6123 Fix concurrency errors in OSM API
* https://github.com/timescale/timescaledb/pull/6142 do not throw an error when deprecation GUC cannot be read

**Thanks**
* @symbx for reporting a crash when selecting from empty hypertables