### PR TITLE
Improve arg handling in continuous_agg_trigfn

### DIFF
--- a/tsl/src/continuous_aggs/insert.c
+++ b/tsl/src/continuous_aggs/insert.c
@@ -218,7 +218,8 @@ continuous_agg_trigfn(PG_FUNCTION_ARGS)
 	char *hypertable_id_str, *parent_hypertable_id_str;
 	int32 hypertable_id, parent_hypertable_id = 0;
 	bool is_distributed_hypertable_trigger = false;
-	if (trigdata->tg_trigger->tgnargs < 0)
+
+	if (trigdata == NULL || trigdata->tg_trigger == NULL || trigdata->tg_trigger->tgnargs < 0)
 		elog(ERROR, "must supply hypertable id");
 
 	hypertable_id_str = trigdata->tg_trigger->tgargs[0];

--- a/tsl/test/expected/cagg_usage.out
+++ b/tsl/test/expected/cagg_usage.out
@@ -409,6 +409,9 @@ SELECT relname FROM pg_class WHERE oid = :mat_table;
 ----------------------------------------------------------------
 -- Cleanup
 DROP TABLE whatever;
+-- Check that continuous_agg_invalidation_trigger() handles no arguments properly
+SELECT _timescaledb_functions.continuous_agg_invalidation_trigger();
+ERROR:  must supply hypertable id
 -- END OF BASIC USAGE TESTS --
 CREATE TABLE metrics(time timestamptz, device TEXT, value float);
 SELECT table_name FROM create_hypertable('metrics','time');

--- a/tsl/test/sql/cagg_usage.sql
+++ b/tsl/test/sql/cagg_usage.sql
@@ -267,6 +267,9 @@ SELECT relname FROM pg_class WHERE oid = :mat_table;
 -- Cleanup
 DROP TABLE whatever;
 
+-- Check that continuous_agg_invalidation_trigger() handles no arguments properly
+SELECT _timescaledb_functions.continuous_agg_invalidation_trigger();
+
 -- END OF BASIC USAGE TESTS --
 
 CREATE TABLE metrics(time timestamptz, device TEXT, value float);


### PR DESCRIPTION
When `continuous_agg_invalidation_trigger` is called without any argument, fcinfo->context in continuous_agg_trigfn is NULL and it should not be dereferenced.

---
Disable-check: force-changelog-file