### PR TITLE
Handle non existing ht in cache_inval_entry_init

### DIFF
--- a/tsl/src/continuous_aggs/insert.c
+++ b/tsl/src/continuous_aggs/insert.c
@@ -155,6 +155,13 @@ cache_inval_entry_init(ContinuousAggsCacheInvalEntry *cache_entry, int32 hyperta
 	/* NOTE: we can remove the id=>relid scan, if it becomes an issue, by getting the
 	 * hypertable_relid directly from the Chunk*/
 	Hypertable *ht = ts_hypertable_cache_get_entry_by_id(ht_cache, hypertable_id);
+	if (ht == NULL)
+	{
+		ereport(ERROR,
+				(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
+				 errmsg("unable to determine relid for hypertable %d", hypertable_id)));
+	}
+
 	cache_entry->hypertable_id = hypertable_id;
 	cache_entry->entry_id = entry_id;
 	cache_entry->hypertable_relid = ht->main_table_relid;

--- a/tsl/test/expected/cagg_usage.out
+++ b/tsl/test/expected/cagg_usage.out
@@ -412,6 +412,20 @@ DROP TABLE whatever;
 -- Check that continuous_agg_invalidation_trigger() handles no arguments properly
 SELECT _timescaledb_functions.continuous_agg_invalidation_trigger();
 ERROR:  must supply hypertable id
+-- Check that continuous_agg_invalidation_trigger() not crashes when an invalid ht id is used
+CREATE TABLE sensor_data (
+time timestamptz NOT NULL,
+sensor_id integer NOT NULL,
+cpu double precision NULL,
+temperature double precision NULL);
+SELECT FROM create_hypertable('sensor_data','time');
+--
+(1 row)
+
+CREATE TRIGGER ts_cagg_invalidation_trigger AFTER INSERT OR DELETE OR UPDATE ON sensor_data FOR EACH ROW EXECUTE FUNCTION _timescaledb_functions.continuous_agg_invalidation_trigger(999999);
+INSERT INTO sensor_data values('1980-01-01 00:00:00-00', 1, 1, 1);
+ERROR:  unable to determine relid for hypertable 999999
+DROP TABLE sensor_data;
 -- END OF BASIC USAGE TESTS --
 CREATE TABLE metrics(time timestamptz, device TEXT, value float);
 SELECT table_name FROM create_hypertable('metrics','time');

--- a/tsl/test/sql/cagg_usage.sql
+++ b/tsl/test/sql/cagg_usage.sql
@@ -270,6 +270,18 @@ DROP TABLE whatever;
 -- Check that continuous_agg_invalidation_trigger() handles no arguments properly
 SELECT _timescaledb_functions.continuous_agg_invalidation_trigger();
 
+-- Check that continuous_agg_invalidation_trigger() not crashes when an invalid ht id is used
+CREATE TABLE sensor_data (
+time timestamptz NOT NULL,
+sensor_id integer NOT NULL,
+cpu double precision NULL,
+temperature double precision NULL);
+
+SELECT FROM create_hypertable('sensor_data','time');
+CREATE TRIGGER ts_cagg_invalidation_trigger AFTER INSERT OR DELETE OR UPDATE ON sensor_data FOR EACH ROW EXECUTE FUNCTION _timescaledb_functions.continuous_agg_invalidation_trigger(999999);
+INSERT INTO sensor_data values('1980-01-01 00:00:00-00', 1, 1, 1);
+DROP TABLE sensor_data;
+
 -- END OF BASIC USAGE TESTS --
 
 CREATE TABLE metrics(time timestamptz, device TEXT, value float);


### PR DESCRIPTION
When the `continuous_agg_invalidation` trigger is called with an invalid hypertable id (e.g., caused by a user that modifies the trigger), the hypertable lookup returns NULL. This case was not handled properly so far. This patch adds proper checks to the function.

---
Disable-check: force-changelog-file