### PR TITLE
Reduce loops in scheduled sqlsmith runs

### DIFF
--- a/.github/workflows/sqlsmith.yaml
+++ b/.github/workflows/sqlsmith.yaml
@@ -86,7 +86,7 @@ jobs:
       run: |
         set -o pipefail
         if [ "${{ github.event_name }}" == "schedule" ]; then
-          LOOPS=50
+          LOOPS=40
         else
           LOOPS=10
         fi


### PR DESCRIPTION
The scheduled sqlsmith seems to run into timeout quite often so reduce the number of loops a bit.

Disable-check: force-changelog-file
