### PR TITLE
Show batches/tuples decompressed during DML operations in EXPLAIN output

### DIFF
--- a/.unreleased/pr_6178
+++ b/.unreleased/pr_6178
@@ -1,0 +1,1 @@
+Implements: #6178 Show batches/tuples decompressed during DML operations in EXPLAIN output

--- a/src/cross_module_fn.h
+++ b/src/cross_module_fn.h
@@ -35,6 +35,7 @@ typedef struct Hypertable Hypertable;
 typedef struct Chunk Chunk;
 typedef struct ChunkInsertState ChunkInsertState;
 typedef struct CopyChunkState CopyChunkState;
+typedef struct HypertableModifyState HypertableModifyState;
 
 typedef struct CrossModuleFunctions
 {
@@ -139,7 +140,7 @@ typedef struct CrossModuleFunctions
 	PGFunction decompress_chunk;
 	void (*decompress_batches_for_insert)(ChunkInsertState *state, Chunk *chunk,
 										  TupleTableSlot *slot);
-	bool (*decompress_target_segments)(ModifyTableState *ps);
+	bool (*decompress_target_segments)(HypertableModifyState *ht_state);
 	/* The compression functions below are not installed in SQL as part of create extension;
 	 *  They are installed and tested during testing scripts. They are exposed in cross-module
 	 *  functions because they may be very useful for debugging customer problems if the sql

--- a/src/nodes/chunk_dispatch/chunk_dispatch.h
+++ b/src/nodes/chunk_dispatch/chunk_dispatch.h
@@ -27,7 +27,7 @@
 typedef struct ChunkDispatch
 {
 	/* Link to the executor state for INSERTs. This is not set for COPY path. */
-	const struct ChunkDispatchState *dispatch_state;
+	struct ChunkDispatchState *dispatch_state;
 	Hypertable *hypertable;
 	SubspaceStore *cache;
 	EState *estate;
@@ -74,6 +74,8 @@ typedef struct ChunkDispatchState
 	ResultRelInfo *rri;
 	/* flag to represent dropped attributes */
 	bool is_dropped_attr_exists;
+	int64 batches_decompressed;
+	int64 tuples_decompressed;
 } ChunkDispatchState;
 
 extern TSDLLEXPORT bool ts_is_chunk_dispatch_state(PlanState *state);

--- a/src/nodes/chunk_dispatch/chunk_insert_state.c
+++ b/src/nodes/chunk_dispatch/chunk_insert_state.c
@@ -595,6 +595,7 @@ ts_chunk_insert_state_create(const Chunk *chunk, ChunkDispatch *dispatch)
 	CheckValidResultRel(relinfo, chunk_dispatch_get_cmd_type(dispatch));
 
 	state = palloc0(sizeof(ChunkInsertState));
+	state->cds = dispatch->dispatch_state;
 	state->mctx = cis_context;
 	state->rel = rel;
 	state->result_relation_info = relinfo;

--- a/src/nodes/chunk_dispatch/chunk_insert_state.h
+++ b/src/nodes/chunk_dispatch/chunk_insert_state.h
@@ -15,6 +15,7 @@
 #include "cross_module_fn.h"
 
 typedef struct TSCopyMultiInsertBuffer TSCopyMultiInsertBuffer;
+typedef struct ChunkDispatchState ChunkDispatchState;
 
 typedef struct ChunkInsertState
 {
@@ -22,6 +23,7 @@ typedef struct ChunkInsertState
 	ResultRelInfo *result_relation_info;
 	/* Per-chunk arbiter indexes for ON CONFLICT handling */
 	List *arbiter_indexes;
+	ChunkDispatchState *cds;
 
 	/* When the tuple descriptors for the main hypertable (root) and a chunk
 	 * differs, it is necessary to convert tuples to chunk format before

--- a/src/nodes/hypertable_modify.h
+++ b/src/nodes/hypertable_modify.h
@@ -30,6 +30,8 @@ typedef struct HypertableModifyState
 	bool comp_chunks_processed;
 	Snapshot snapshot;
 	FdwRoutine *fdwroutine;
+	int64 tuples_decompressed;
+	int64 batches_decompressed;
 } HypertableModifyState;
 
 extern void ts_hypertable_modify_fixup_tlist(Plan *plan);

--- a/tsl/src/compression/compression.h
+++ b/tsl/src/compression/compression.h
@@ -150,6 +150,8 @@ typedef struct RowDecompressor
 	bool *decompressed_is_nulls;
 
 	MemoryContext per_compressed_row_ctx;
+	int64 batches_decompressed;
+	int64 tuples_decompressed;
 } RowDecompressor;
 
 /*
@@ -323,7 +325,8 @@ typedef struct ChunkInsertState ChunkInsertState;
 extern void decompress_batches_for_insert(ChunkInsertState *cis, Chunk *chunk,
 										  TupleTableSlot *slot);
 #if PG14_GE
-extern bool decompress_target_segments(ModifyTableState *ps);
+typedef struct HypertableModifyState HypertableModifyState;
+extern bool decompress_target_segments(HypertableModifyState *ht_state);
 #endif
 /* CompressSingleRowState methods */
 struct CompressSingleRowState;

--- a/tsl/test/shared/expected/decompress_tracking.out
+++ b/tsl/test/shared/expected/decompress_tracking.out
@@ -1,0 +1,100 @@
+-- This file and its contents are licensed under the Timescale License.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-TIMESCALE for a copy of the license.
+\set EXPLAIN 'EXPLAIN (costs off,timing off,summary off)'
+\set EXPLAIN_ANALYZE 'EXPLAIN (analyze,costs off,timing off,summary off)'
+CREATE TABLE decompress_tracking(time timestamptz not null, device text, value float, primary key(time, device));
+SELECT table_name FROM create_hypertable('decompress_tracking','time');
+     table_name      
+ decompress_tracking
+(1 row)
+
+ALTER TABLE decompress_tracking SET (timescaledb.compress, timescaledb.compress_segmentby='device');
+INSERT INTO decompress_tracking SELECT '2020-01-01'::timestamptz + format('%s hour', g)::interval, 'd1', random() FROM generate_series(1,10) g;
+INSERT INTO decompress_tracking SELECT '2020-01-01'::timestamptz + format('%s hour', g)::interval, 'd2', random() FROM generate_series(1,20) g;
+INSERT INTO decompress_tracking SELECT '2020-01-01'::timestamptz + format('%s hour', g)::interval, 'd3', random() FROM generate_series(1,30) g;
+SELECT count(compress_chunk(ch)) FROM show_chunks('decompress_tracking') ch;
+ count 
+     2
+(1 row)
+
+-- no tracking without analyze
+:EXPLAIN UPDATE decompress_tracking SET value = value + 3;
+QUERY PLAN
+ Custom Scan (HypertableModify)
+   ->  Update on decompress_tracking
+         Update on _hyper_X_X_chunk decompress_tracking_1
+         Update on _hyper_X_X_chunk decompress_tracking_2
+         ->  Result
+               ->  Append
+                     ->  Seq Scan on _hyper_X_X_chunk decompress_tracking_1
+                     ->  Seq Scan on _hyper_X_X_chunk decompress_tracking_2
+(8 rows)
+
+BEGIN; :EXPLAIN_ANALYZE UPDATE decompress_tracking SET value = value + 3; ROLLBACK;
+QUERY PLAN
+ Custom Scan (HypertableModify) (actual rows=0 loops=1)
+   Batches decompressed: 5
+   Tuples decompressed: 60
+   ->  Update on decompress_tracking (actual rows=0 loops=1)
+         Update on _hyper_X_X_chunk decompress_tracking_1
+         Update on _hyper_X_X_chunk decompress_tracking_2
+         ->  Result (actual rows=60 loops=1)
+               ->  Append (actual rows=60 loops=1)
+                     ->  Seq Scan on _hyper_X_X_chunk decompress_tracking_1 (actual rows=40 loops=1)
+                     ->  Seq Scan on _hyper_X_X_chunk decompress_tracking_2 (actual rows=20 loops=1)
+(10 rows)
+
+BEGIN; :EXPLAIN_ANALYZE DELETE FROM decompress_tracking; ROLLBACK;
+QUERY PLAN
+ Custom Scan (HypertableModify) (actual rows=0 loops=1)
+   Batches decompressed: 5
+   Tuples decompressed: 60
+   ->  Delete on decompress_tracking (actual rows=0 loops=1)
+         Delete on _hyper_X_X_chunk decompress_tracking_1
+         Delete on _hyper_X_X_chunk decompress_tracking_2
+         ->  Append (actual rows=60 loops=1)
+               ->  Seq Scan on _hyper_X_X_chunk decompress_tracking_1 (actual rows=40 loops=1)
+               ->  Seq Scan on _hyper_X_X_chunk decompress_tracking_2 (actual rows=20 loops=1)
+(9 rows)
+
+BEGIN; :EXPLAIN_ANALYZE INSERT INTO decompress_tracking SELECT '2020-01-01 1:30','d1',random(); ROLLBACK;
+QUERY PLAN
+ Custom Scan (HypertableModify) (actual rows=0 loops=1)
+   Batches decompressed: 1
+   Tuples decompressed: 10
+   ->  Insert on decompress_tracking (actual rows=0 loops=1)
+         ->  Custom Scan (ChunkDispatch) (actual rows=1 loops=1)
+               ->  Subquery Scan on "*SELECT*" (actual rows=1 loops=1)
+                     ->  Result (actual rows=1 loops=1)
+(7 rows)
+
+BEGIN; :EXPLAIN_ANALYZE INSERT INTO decompress_tracking SELECT '2020-01-01','d2',random(); ROLLBACK;
+QUERY PLAN
+ Custom Scan (HypertableModify) (actual rows=0 loops=1)
+   ->  Insert on decompress_tracking (actual rows=0 loops=1)
+         ->  Custom Scan (ChunkDispatch) (actual rows=1 loops=1)
+               ->  Subquery Scan on "*SELECT*" (actual rows=1 loops=1)
+                     ->  Result (actual rows=1 loops=1)
+(5 rows)
+
+BEGIN; :EXPLAIN_ANALYZE INSERT INTO decompress_tracking SELECT '2020-01-01','d4',random(); ROLLBACK;
+QUERY PLAN
+ Custom Scan (HypertableModify) (actual rows=0 loops=1)
+   ->  Insert on decompress_tracking (actual rows=0 loops=1)
+         ->  Custom Scan (ChunkDispatch) (actual rows=1 loops=1)
+               ->  Subquery Scan on "*SELECT*" (actual rows=1 loops=1)
+                     ->  Result (actual rows=1 loops=1)
+(5 rows)
+
+BEGIN; :EXPLAIN_ANALYZE INSERT INTO decompress_tracking (VALUES ('2020-01-01 1:30','d1',random()),('2020-01-01 1:30','d2',random())); ROLLBACK;
+QUERY PLAN
+ Custom Scan (HypertableModify) (actual rows=0 loops=1)
+   Batches decompressed: 2
+   Tuples decompressed: 25
+   ->  Insert on decompress_tracking (actual rows=0 loops=1)
+         ->  Custom Scan (ChunkDispatch) (actual rows=2 loops=1)
+               ->  Values Scan on "*VALUES*" (actual rows=2 loops=1)
+(6 rows)
+
+DROP TABLE decompress_tracking;

--- a/tsl/test/shared/sql/CMakeLists.txt
+++ b/tsl/test/shared/sql/CMakeLists.txt
@@ -22,7 +22,8 @@ if(ENABLE_MULTINODE_TESTS)
 endif()
 
 if((${PG_VERSION_MAJOR} GREATER_EQUAL "14"))
-  list(APPEND TEST_FILES_SHARED compression_dml.sql memoize.sql)
+  list(APPEND TEST_FILES_SHARED compression_dml.sql decompress_tracking.sql
+       memoize.sql)
 endif()
 
 # this test was changing the contents of tables in shared_setup.sql thus causing

--- a/tsl/test/shared/sql/decompress_tracking.sql
+++ b/tsl/test/shared/sql/decompress_tracking.sql
@@ -1,0 +1,28 @@
+-- This file and its contents are licensed under the Timescale License.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-TIMESCALE for a copy of the license.
+
+\set EXPLAIN 'EXPLAIN (costs off,timing off,summary off)'
+\set EXPLAIN_ANALYZE 'EXPLAIN (analyze,costs off,timing off,summary off)'
+
+CREATE TABLE decompress_tracking(time timestamptz not null, device text, value float, primary key(time, device));
+SELECT table_name FROM create_hypertable('decompress_tracking','time');
+ALTER TABLE decompress_tracking SET (timescaledb.compress, timescaledb.compress_segmentby='device');
+
+INSERT INTO decompress_tracking SELECT '2020-01-01'::timestamptz + format('%s hour', g)::interval, 'd1', random() FROM generate_series(1,10) g;
+INSERT INTO decompress_tracking SELECT '2020-01-01'::timestamptz + format('%s hour', g)::interval, 'd2', random() FROM generate_series(1,20) g;
+INSERT INTO decompress_tracking SELECT '2020-01-01'::timestamptz + format('%s hour', g)::interval, 'd3', random() FROM generate_series(1,30) g;
+
+SELECT count(compress_chunk(ch)) FROM show_chunks('decompress_tracking') ch;
+
+-- no tracking without analyze
+:EXPLAIN UPDATE decompress_tracking SET value = value + 3;
+
+BEGIN; :EXPLAIN_ANALYZE UPDATE decompress_tracking SET value = value + 3; ROLLBACK;
+BEGIN; :EXPLAIN_ANALYZE DELETE FROM decompress_tracking; ROLLBACK;
+BEGIN; :EXPLAIN_ANALYZE INSERT INTO decompress_tracking SELECT '2020-01-01 1:30','d1',random(); ROLLBACK;
+BEGIN; :EXPLAIN_ANALYZE INSERT INTO decompress_tracking SELECT '2020-01-01','d2',random(); ROLLBACK;
+BEGIN; :EXPLAIN_ANALYZE INSERT INTO decompress_tracking SELECT '2020-01-01','d4',random(); ROLLBACK;
+BEGIN; :EXPLAIN_ANALYZE INSERT INTO decompress_tracking (VALUES ('2020-01-01 1:30','d1',random()),('2020-01-01 1:30','d2',random())); ROLLBACK;
+
+DROP TABLE decompress_tracking;


### PR DESCRIPTION
This patch adds tracking number of batches and tuples that needed to be decompressed as part of DML operations on compressed hypertables.

These will be visible in EXPLAIN ANALYZE output like so:

QUERY PLAN
 Custom Scan (HypertableModify) (actual rows=0 loops=1)
   Batches decompressed: 2
   Tuples decompressed: 25
   ->  Insert on decompress_tracking (actual rows=0 loops=1)
         ->  Custom Scan (ChunkDispatch) (actual rows=2 loops=1)
               ->  Values Scan on "*VALUES*" (actual rows=2 loops=1)
(6 rows)