### PR TITLE
Add CI check for unecessary template tests

### DIFF
--- a/.github/workflows/code_style.yaml
+++ b/.github/workflows/code_style.yaml
@@ -100,7 +100,7 @@ jobs:
           git diff --exit-code
 
   misc_checks:
-    name: Check license, update scripts, git hooks and missing gitignore entries
+    name: Check license, update scripts, git hooks, missing gitignore entries and unecessary template tests
     runs-on: ubuntu-22.04
     strategy:
       fail-fast: false
@@ -124,3 +124,7 @@ jobs:
     - name: Check for missing gitignore entries for template test files
       if: always()
       run: ./scripts/check_missing_gitignore_for_template_tests.sh
+    - name: Check for unecessary template test files
+      if: always()
+      run: ./scripts/check_unecessary_template_tests.sh
+

--- a/scripts/check_unecessary_template_tests.sh
+++ b/scripts/check_unecessary_template_tests.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+ERROR=0
+
+for FILE in $(git ls-files test/sql/*.sql.in tsl/test/sql/*.sql.in)
+do
+  DIRNAME=$(dirname "${FILE}" | sed 's/sql/expected/g')
+  TESTNAME=$(basename "${FILE}" .sql.in)
+
+  if diff --from-file ${DIRNAME}/${TESTNAME}-*.out > /dev/null 2>&1; then
+      echo "ERROR: all template output test files are equal: \"${DIRNAME}/${TESTNAME}-*.out\""
+      echo "HINT: Please turn template test file \"${FILE}\" into a regular test file"
+      ERROR=1
+  fi
+done
+
+exit ${ERROR}


### PR DESCRIPTION
When the regression tests output differs between PG versions we create a template test (aka *.sql.in) and add several different output files for each supported version.

Over time we support new PG version and deprecate older ones, for example nowadays we're working on PG16 support and removed PG12 so we need to check if we still need template files.

Disable-check: force-changelog-file
