### PR TITLE
Post-release fixes for 2.12.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 `psql` with the `-X` flag to prevent any `.psqlrc` commands from
 accidentally triggering the load of a previous DB version.**
 
-## 2.12.1 (2023-10-11)
+## 2.12.1 (2023-10-12)
 
 This release contains bug fixes since the 2.12.0 release.
 We recommend that you upgrade at the next available opportunity.

--- a/scripts/test_updates_pg13.sh
+++ b/scripts/test_updates_pg13.sh
@@ -16,4 +16,4 @@ run_tests "$@" -v8 \
 
 # Also run repair tests for >=2.10.x versions due to PR #5441
 run_tests "$@" -r -v8 \
-          2.10.0-pg13 2.10.1-pg13 2.10.2-pg13 2.10.3-pg13 2.11.0-pg13 2.11.1-pg13 2.11.2-pg13 2.12.0-pg13
+          2.10.0-pg13 2.10.1-pg13 2.10.2-pg13 2.10.3-pg13 2.11.0-pg13 2.11.1-pg13 2.11.2-pg13 2.12.0-pg13 2.12.1-pg13

--- a/scripts/test_updates_pg14.sh
+++ b/scripts/test_updates_pg14.sh
@@ -15,5 +15,5 @@ run_tests "$@" -v8 \
 
 # Also run repair tests for >=2.10.x versions due to PR #5441
 run_tests "$@" -r -v8 \
-          2.10.0-pg14 2.10.1-pg14 2.10.2-pg14 2.10.3-pg14 2.11.0-pg14 2.11.1-pg14 2.11.2-pg14 2.12.0-pg14
+          2.10.0-pg14 2.10.1-pg14 2.10.2-pg14 2.10.3-pg14 2.11.0-pg14 2.11.1-pg14 2.11.2-pg14 2.12.0-pg14 2.12.1-pg14
 

--- a/scripts/test_updates_pg15.sh
+++ b/scripts/test_updates_pg15.sh
@@ -12,4 +12,4 @@ run_tests "$@" -v8 \
 
 # Also run repair tests for >=2.10.x versions due to PR #5441
 run_tests "$@" -r -v8 \
-          2.10.0-pg15 2.10.1-pg15 2.10.2-pg15 2.10.3-pg15 2.11.0-pg15 2.11.1-pg15 2.11.2-pg15 2.12.0-pg15
+          2.10.0-pg15 2.10.1-pg15 2.10.2-pg15 2.10.3-pg15 2.11.0-pg15 2.11.1-pg15 2.11.2-pg15 2.12.0-pg15 2.12.1-pg15

--- a/sql/CMakeLists.txt
+++ b/sql/CMakeLists.txt
@@ -73,7 +73,8 @@ set(OLD_REV_FILES
     2.11.0--2.10.3.sql
     2.11.1--2.11.0.sql
     2.11.2--2.11.1.sql
-    2.12.0--2.11.2.sql)
+    2.12.0--2.11.2.sql
+    2.12.1--2.12.0.sql)
 
 set(MODULE_PATHNAME "$libdir/timescaledb-${PROJECT_VERSION_MOD}")
 set(LOADER_PATHNAME "$libdir/timescaledb")

--- a/version.config
+++ b/version.config
@@ -1,3 +1,3 @@
 version = 2.13.0-dev
 update_from_version = 2.12.1
-downgrade_to_version = 2.12.0
+downgrade_to_version = 2.12.1


### PR DESCRIPTION
Bumping the previous version and adding tests for 2.12.1. Also adjust tagging date in changelog.