### PR TITLE
Remove canceled bgw jobs from test output

### DIFF
--- a/test/runner.sh
+++ b/test/runner.sh
@@ -140,4 +140,5 @@ ${PSQL} -U ${TEST_PGUSER} \
                -e 's! Memory Usage: [0-9]\{1,\}kB!!' \
                -e 's! Average  Peak Memory: [0-9]\{1,\}kB!!' | \
           grep -v 'DEBUG:  rehashing catalog cache id' | \
-          grep -v 'DEBUG:  compacted fsync request queue from'
+          grep -v 'DEBUG:  compacted fsync request queue from' | \
+          grep -v 'NOTICE:  cancelling the background worker for job'

--- a/test/runner_shared.sh
+++ b/test/runner_shared.sh
@@ -88,4 +88,5 @@ ${PSQL} -U ${TEST_PGUSER} \
                -e 's! Memory Usage: [0-9]\{1,\}kB!!' \
                -e 's! Average  Peak Memory: [0-9]\{1,\}kB!!' | \
           grep -v 'DEBUG:  rehashing catalog cache id' | \
-          grep -v 'DEBUG:  compacted fsync request queue from'
+          grep -v 'DEBUG:  compacted fsync request queue from' | \
+          grep -v 'NOTICE:  cancelling the background worker for job'


### PR DESCRIPTION
When a background worker is canceled by 'select delete_job()' the following log message is printed:

NOTICE:  cancelling the background worker for job

However, this log message is not deterministic and breaks our CI checks. So, this patch removes the log message from the test output to make the regression checks more deterministic.

---

Disable-check: force-changelog-file
Link to failed CI run: https://github.com/timescale/timescaledb/actions/runs/6532360279/job/17735391567