### PR TITLE
stable expressions as constant in vectorized filters

### DIFF
--- a/tsl/src/nodes/decompress_chunk/compressed_batch.c
+++ b/tsl/src/nodes/decompress_chunk/compressed_batch.c
@@ -81,7 +81,7 @@ make_single_value_arrow(Oid pgtype, Datum datum, bool isnull)
 static void
 apply_vector_quals(DecompressChunkState *chunk_state, DecompressBatchState *batch_state)
 {
-	if (!chunk_state->vectorized_quals)
+	if (!chunk_state->vectorized_quals_constified)
 	{
 		return;
 	}
@@ -98,7 +98,7 @@ apply_vector_quals(DecompressChunkState *chunk_state, DecompressBatchState *batc
 	 * Compute the quals.
 	 */
 	ListCell *lc;
-	foreach (lc, chunk_state->vectorized_quals)
+	foreach (lc, chunk_state->vectorized_quals_constified)
 	{
 		/* For now we only support "Var ? Const" predicates. */
 		OpExpr *oe = castNode(OpExpr, lfirst(lc));

--- a/tsl/src/nodes/decompress_chunk/exec.h
+++ b/tsl/src/nodes/decompress_chunk/exec.h
@@ -97,9 +97,14 @@ typedef struct DecompressChunkState
 	/*
 	 * For some predicates, we have more efficient implementation that work on
 	 * the entire compressed batch in one go. They go to this list, and the rest
-	 * goes into the usual ss.ps.qual.
+	 * goes into the usual ss.ps.qual. Note that we constify stable functions
+	 * in these predicates at execution time, but have to keep the original
+	 * version for EXPLAIN. We also need special handling for quals that
+	 * evaluate to constant false, hence the flag.
 	 */
-	List *vectorized_quals;
+	List *vectorized_quals_original;
+	List *vectorized_quals_constified;
+	bool have_constant_false_vectorized_qual;
 
 	/*
 	 * Make non-refcounted copies of the tupdesc for reuse across all batch states

--- a/tsl/src/nodes/decompress_chunk/planner.c
+++ b/tsl/src/nodes/decompress_chunk/planner.c
@@ -377,27 +377,89 @@ find_attr_pos_in_tlist(List *targetlist, AttrNumber pos)
 }
 
 static bool
-qual_is_vectorizable(DecompressChunkPath *path, Node *qual)
+contains_volatile_functions_checker(Oid func_id, void *context)
+{
+	return (func_volatile(func_id) == PROVOLATILE_VOLATILE);
+}
+
+static bool
+is_not_runtime_constant_walker(Node *node, void *context)
+{
+	if (node == NULL)
+	{
+		return false;
+	}
+
+	switch (nodeTag(node))
+	{
+		case T_Var:
+		case T_PlaceHolderVar:
+		case T_Param:
+			/*
+			 * We might want to support these nodes to have vectorizable
+			 * join clauses (T_Var), join clauses referencing a variable that is
+			 * above outer join (T_PlaceHolderVar) or initplan parameters and
+			 * prepared statement parameters (T_Param). We don't support them at
+			 * the moment.
+			 */
+			return true;
+		default:
+			if (check_functions_in_node(node,
+										contains_volatile_functions_checker,
+										/* context = */ NULL))
+			{
+				return true;
+			}
+			return expression_tree_walker(node,
+										  is_not_runtime_constant_walker,
+										  /* context = */ NULL);
+	}
+}
+
+/*
+ * Check if the given node is a run-time constant, i.e. it doesn't contain
+ * volatile functions or variables or parameters. This means we can evaluate
+ * it at run time, allowing us to apply the vectorized comparison operators
+ * that have the form "Var op Const". This applies for example to filter
+ * expressions like `time > now() - interval '1 hour'`.
+ * Note that we do the same evaluation when doing run time chunk exclusion, but
+ * there is no good way to pass the evaluated clauses to the underlying nodes
+ * like this DecompressChunk node.
+ */
+static bool
+is_not_runtime_constant(Node *node)
+{
+	bool result = is_not_runtime_constant_walker(node, /* context = */ NULL);
+	return result;
+}
+
+/*
+ * Try to check if the current qual is vectorizable, and if needed make a
+ * commuted copy. If not, return NULL.
+ */
+static Node *
+make_vectorized_qual(DecompressChunkPath *path, Node *qual)
 {
 	/* Only simple "Var op Const" binary predicates for now. */
 	if (!IsA(qual, OpExpr))
 	{
-		return false;
+		return NULL;
 	}
 
 	OpExpr *o = castNode(OpExpr, qual);
 
 	if (list_length(o->args) != 2)
 	{
-		return false;
+		return NULL;
 	}
 
-	if (IsA(lsecond(o->args), Var) && IsA(linitial(o->args), Const))
+	if (IsA(lsecond(o->args), Var))
 	{
 		/* Try to commute the operator if the constant is on the right. */
 		Oid commutator_opno = get_commutator(o->opno);
 		if (OidIsValid(commutator_opno))
 		{
+			o = (OpExpr *) copyObject(o);
 			o->opno = commutator_opno;
 			/*
 			 * opfuncid is a cache, we can set it to InvalidOid like the
@@ -408,9 +470,14 @@ qual_is_vectorizable(DecompressChunkPath *path, Node *qual)
 		}
 	}
 
-	if (!IsA(linitial(o->args), Var) || !IsA(lsecond(o->args), Const))
+	/*
+	 * We can vectorize the operation where the left side is a Var and the right
+	 * side is a constant or can be evaluated to a constant at run time (e.g.
+	 * contains stable functions).
+	 */
+	if (!IsA(linitial(o->args), Var) || is_not_runtime_constant(lsecond(o->args)))
 	{
-		return false;
+		return NULL;
 	}
 
 	Var *var = castNode(Var, linitial(o->args));
@@ -424,16 +491,16 @@ qual_is_vectorizable(DecompressChunkPath *path, Node *qual)
 			 .bulk_decompression_possible)
 	{
 		/* This column doesn't support bulk decompression. */
-		return false;
+		return NULL;
 	}
 
 	Oid opcode = get_opcode(o->opno);
 	if (get_vector_const_predicate(opcode))
 	{
-		return true;
+		return (Node *) o;
 	}
 
-	return false;
+	return NULL;
 }
 
 /*
@@ -441,15 +508,22 @@ qual_is_vectorizable(DecompressChunkPath *path, Node *qual)
  * list.
  */
 static void
-find_vectorized_quals(DecompressChunkPath *path, List *qual, List **vectorized,
+find_vectorized_quals(DecompressChunkPath *path, List *qual_list, List **vectorized,
 					  List **nonvectorized)
 {
 	ListCell *lc;
-	foreach (lc, qual)
+	foreach (lc, qual_list)
 	{
-		Node *node = lfirst(lc);
-		List **dest = qual_is_vectorizable(path, node) ? vectorized : nonvectorized;
-		*dest = lappend(*dest, node);
+		Node *source_qual = lfirst(lc);
+		Node *vectorized_qual = make_vectorized_qual(path, source_qual);
+		if (vectorized_qual)
+		{
+			*vectorized = lappend(*vectorized, vectorized_qual);
+		}
+		else
+		{
+			*nonvectorized = lappend(*nonvectorized, source_qual);
+		}
 	}
 }
 

--- a/tsl/test/expected/agg_partials_pushdown.out
+++ b/tsl/test/expected/agg_partials_pushdown.out
@@ -127,8 +127,7 @@ SELECT count(*), sum(v0), sum(v1), sum(v2), sum(v3) FROM testtable WHERE time >=
                Output: PARTIAL count(*), PARTIAL sum(_hyper_1_1_chunk.v0), PARTIAL sum(_hyper_1_1_chunk.v1), PARTIAL sum(_hyper_1_1_chunk.v2), PARTIAL sum(_hyper_1_1_chunk.v3)
                ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_1_chunk (actual rows=25 loops=1)
                      Output: _hyper_1_1_chunk.v0, _hyper_1_1_chunk.v1, _hyper_1_1_chunk.v2, _hyper_1_1_chunk.v3
-                     Filter: (_hyper_1_1_chunk."time" >= ('2000-01-01 00:00:00+0'::cstring)::timestamp with time zone)
-                     Vectorized Filter: (_hyper_1_1_chunk."time" <= 'Mon Jan 31 16:00:00 2000 PST'::timestamp with time zone)
+                     Vectorized Filter: ((_hyper_1_1_chunk."time" <= 'Mon Jan 31 16:00:00 2000 PST'::timestamp with time zone) AND (_hyper_1_1_chunk."time" >= ('2000-01-01 00:00:00+0'::cstring)::timestamp with time zone))
                      Bulk Decompression: true
                      ->  Seq Scan on _timescaledb_internal.compress_hyper_2_3_chunk (actual rows=5 loops=1)
                            Output: compress_hyper_2_3_chunk.filter_1, compress_hyper_2_3_chunk.filler_2, compress_hyper_2_3_chunk.filler_3, compress_hyper_2_3_chunk."time", compress_hyper_2_3_chunk.device_id, compress_hyper_2_3_chunk.v0, compress_hyper_2_3_chunk.v1, compress_hyper_2_3_chunk.v2, compress_hyper_2_3_chunk.v3, compress_hyper_2_3_chunk._ts_meta_count, compress_hyper_2_3_chunk._ts_meta_sequence_num, compress_hyper_2_3_chunk._ts_meta_min_1, compress_hyper_2_3_chunk._ts_meta_max_1
@@ -142,8 +141,7 @@ SELECT count(*), sum(v0), sum(v1), sum(v2), sum(v3) FROM testtable WHERE time >=
                Output: PARTIAL count(*), PARTIAL sum(_hyper_1_2_chunk.v0), PARTIAL sum(_hyper_1_2_chunk.v1), PARTIAL sum(_hyper_1_2_chunk.v2), PARTIAL sum(_hyper_1_2_chunk.v3)
                ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_2_chunk (actual rows=25 loops=1)
                      Output: _hyper_1_2_chunk.v0, _hyper_1_2_chunk.v1, _hyper_1_2_chunk.v2, _hyper_1_2_chunk.v3
-                     Filter: (_hyper_1_2_chunk."time" >= ('2000-01-01 00:00:00+0'::cstring)::timestamp with time zone)
-                     Vectorized Filter: (_hyper_1_2_chunk."time" <= 'Mon Jan 31 16:00:00 2000 PST'::timestamp with time zone)
+                     Vectorized Filter: ((_hyper_1_2_chunk."time" <= 'Mon Jan 31 16:00:00 2000 PST'::timestamp with time zone) AND (_hyper_1_2_chunk."time" >= ('2000-01-01 00:00:00+0'::cstring)::timestamp with time zone))
                      Bulk Decompression: true
                      ->  Seq Scan on _timescaledb_internal.compress_hyper_2_4_chunk (actual rows=5 loops=1)
                            Output: compress_hyper_2_4_chunk.filter_1, compress_hyper_2_4_chunk.filler_2, compress_hyper_2_4_chunk.filler_3, compress_hyper_2_4_chunk."time", compress_hyper_2_4_chunk.device_id, compress_hyper_2_4_chunk.v0, compress_hyper_2_4_chunk.v1, compress_hyper_2_4_chunk.v2, compress_hyper_2_4_chunk.v3, compress_hyper_2_4_chunk._ts_meta_count, compress_hyper_2_4_chunk._ts_meta_sequence_num, compress_hyper_2_4_chunk._ts_meta_min_1, compress_hyper_2_4_chunk._ts_meta_max_1
@@ -153,7 +151,7 @@ SELECT count(*), sum(v0), sum(v1), sum(v2), sum(v3) FROM testtable WHERE time >=
                ->  Seq Scan on _timescaledb_internal._hyper_1_2_chunk (actual rows=25 loops=1)
                      Output: _hyper_1_2_chunk.v0, _hyper_1_2_chunk.v1, _hyper_1_2_chunk.v2, _hyper_1_2_chunk.v3
                      Filter: ((_hyper_1_2_chunk."time" <= 'Mon Jan 31 16:00:00 2000 PST'::timestamp with time zone) AND (_hyper_1_2_chunk."time" >= ('2000-01-01 00:00:00+0'::cstring)::timestamp with time zone))
-(37 rows)
+(35 rows)
 
 -- Force plain / sorted aggregation
 SET enable_hashagg = OFF;
@@ -178,8 +176,7 @@ SELECT count(*), sum(v0), sum(v1), sum(v2), sum(v3) FROM testtable WHERE time >=
                Output: PARTIAL count(*), PARTIAL sum(_hyper_1_1_chunk.v0), PARTIAL sum(_hyper_1_1_chunk.v1), PARTIAL sum(_hyper_1_1_chunk.v2), PARTIAL sum(_hyper_1_1_chunk.v3)
                ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_1_chunk (actual rows=25 loops=1)
                      Output: _hyper_1_1_chunk.v0, _hyper_1_1_chunk.v1, _hyper_1_1_chunk.v2, _hyper_1_1_chunk.v3
-                     Filter: (_hyper_1_1_chunk."time" >= ('2000-01-01 00:00:00+0'::cstring)::timestamp with time zone)
-                     Vectorized Filter: (_hyper_1_1_chunk."time" <= 'Mon Jan 31 16:00:00 2000 PST'::timestamp with time zone)
+                     Vectorized Filter: ((_hyper_1_1_chunk."time" <= 'Mon Jan 31 16:00:00 2000 PST'::timestamp with time zone) AND (_hyper_1_1_chunk."time" >= ('2000-01-01 00:00:00+0'::cstring)::timestamp with time zone))
                      Bulk Decompression: true
                      ->  Seq Scan on _timescaledb_internal.compress_hyper_2_3_chunk (actual rows=5 loops=1)
                            Output: compress_hyper_2_3_chunk.filter_1, compress_hyper_2_3_chunk.filler_2, compress_hyper_2_3_chunk.filler_3, compress_hyper_2_3_chunk."time", compress_hyper_2_3_chunk.device_id, compress_hyper_2_3_chunk.v0, compress_hyper_2_3_chunk.v1, compress_hyper_2_3_chunk.v2, compress_hyper_2_3_chunk.v3, compress_hyper_2_3_chunk._ts_meta_count, compress_hyper_2_3_chunk._ts_meta_sequence_num, compress_hyper_2_3_chunk._ts_meta_min_1, compress_hyper_2_3_chunk._ts_meta_max_1
@@ -193,8 +190,7 @@ SELECT count(*), sum(v0), sum(v1), sum(v2), sum(v3) FROM testtable WHERE time >=
                Output: PARTIAL count(*), PARTIAL sum(_hyper_1_2_chunk.v0), PARTIAL sum(_hyper_1_2_chunk.v1), PARTIAL sum(_hyper_1_2_chunk.v2), PARTIAL sum(_hyper_1_2_chunk.v3)
                ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_2_chunk (actual rows=25 loops=1)
                      Output: _hyper_1_2_chunk.v0, _hyper_1_2_chunk.v1, _hyper_1_2_chunk.v2, _hyper_1_2_chunk.v3
-                     Filter: (_hyper_1_2_chunk."time" >= ('2000-01-01 00:00:00+0'::cstring)::timestamp with time zone)
-                     Vectorized Filter: (_hyper_1_2_chunk."time" <= 'Mon Jan 31 16:00:00 2000 PST'::timestamp with time zone)
+                     Vectorized Filter: ((_hyper_1_2_chunk."time" <= 'Mon Jan 31 16:00:00 2000 PST'::timestamp with time zone) AND (_hyper_1_2_chunk."time" >= ('2000-01-01 00:00:00+0'::cstring)::timestamp with time zone))
                      Bulk Decompression: true
                      ->  Seq Scan on _timescaledb_internal.compress_hyper_2_4_chunk (actual rows=5 loops=1)
                            Output: compress_hyper_2_4_chunk.filter_1, compress_hyper_2_4_chunk.filler_2, compress_hyper_2_4_chunk.filler_3, compress_hyper_2_4_chunk."time", compress_hyper_2_4_chunk.device_id, compress_hyper_2_4_chunk.v0, compress_hyper_2_4_chunk.v1, compress_hyper_2_4_chunk.v2, compress_hyper_2_4_chunk.v3, compress_hyper_2_4_chunk._ts_meta_count, compress_hyper_2_4_chunk._ts_meta_sequence_num, compress_hyper_2_4_chunk._ts_meta_min_1, compress_hyper_2_4_chunk._ts_meta_max_1
@@ -204,7 +200,7 @@ SELECT count(*), sum(v0), sum(v1), sum(v2), sum(v3) FROM testtable WHERE time >=
                ->  Seq Scan on _timescaledb_internal._hyper_1_2_chunk (actual rows=25 loops=1)
                      Output: _hyper_1_2_chunk.v0, _hyper_1_2_chunk.v1, _hyper_1_2_chunk.v2, _hyper_1_2_chunk.v3
                      Filter: ((_hyper_1_2_chunk."time" <= 'Mon Jan 31 16:00:00 2000 PST'::timestamp with time zone) AND (_hyper_1_2_chunk."time" >= ('2000-01-01 00:00:00+0'::cstring)::timestamp with time zone))
-(37 rows)
+(35 rows)
 
 RESET enable_hashagg;
 -- Check Append Node under ChunkAppend

--- a/tsl/test/expected/decompress_vector_qual.out
+++ b/tsl/test/expected/decompress_vector_qual.out
@@ -198,6 +198,53 @@ select count(*) from vectorqual where metric4 is not null;
      2
 (1 row)
 
+-- Vectorized filters also work if we have only stable functions on the right
+-- side that can be evaluated to a constant at run time.
+set timescaledb.debug_require_vector_qual to 'only';
+select count(*) from vectorqual where ts > '2021-01-01 00:00:00'::timestamptz::timestamp;
+ count 
+-------
+     3
+(1 row)
+
+select count(*) from vectorqual where ts > '2021-01-01 00:00:00'::timestamp - interval '1 day';
+ count 
+-------
+     4
+(1 row)
+
+-- Expression that evaluates to Null.
+select count(*) from vectorqual where ts > case when '2021-01-01'::timestamp < '2022-01-01'::timestamptz then null else '2021-01-01 00:00:00'::timestamp end;
+ count 
+-------
+     0
+(1 row)
+
+-- This filter is not vectorized because the 'timestamp > timestamptz'
+-- operator is stable, not immutable, because it uses the current session
+-- timezone. We could transform it to something like
+-- 'timestamp > timestamptz::timestamp' to allow our stable function evaluation
+-- to handle this case, but we don't do it at the moment.
+set timescaledb.debug_require_vector_qual to 'forbid';
+select count(*) from vectorqual where ts > '2021-01-01 00:00:00'::timestamptz;
+ count 
+-------
+     3
+(1 row)
+
+-- Can't vectorize comparison with a volatile function.
+select count(*) from vectorqual where metric3 > random()::int - 100;
+ count 
+-------
+     5
+(1 row)
+
+select count(*) from vectorqual where ts > case when random() < 10 then null else '2021-01-01 00:00:00'::timestamp end;
+ count 
+-------
+     0
+(1 row)
+
 -- Test that the vectorized quals are disabled by disabling the bulk decompression.
 set timescaledb.enable_bulk_decompression to off;
 set timescaledb.debug_require_vector_qual to 'forbid';

--- a/tsl/test/expected/transparent_decompression-13.out
+++ b/tsl/test/expected/transparent_decompression-13.out
@@ -1200,7 +1200,7 @@ LIMIT 10;
                Sort Key: _hyper_1_1_chunk."time", _hyper_1_1_chunk.device_id
                Sort Method: top-N heapsort 
                ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk (actual rows=1800 loops=1)
-                     Filter: ("time" < now())
+                     Vectorized Filter: ("time" < now())
                      ->  Seq Scan on compress_hyper_5_15_chunk (actual rows=5 loops=1)
          ->  Sort (never executed)
                Sort Key: _hyper_1_2_chunk."time", _hyper_1_2_chunk.device_id
@@ -1209,7 +1209,7 @@ LIMIT 10;
          ->  Sort (never executed)
                Sort Key: _hyper_1_3_chunk."time", _hyper_1_3_chunk.device_id
                ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk (never executed)
-                     Filter: ("time" < now())
+                     Vectorized Filter: ("time" < now())
                      ->  Seq Scan on compress_hyper_5_16_chunk (never executed)
 (19 rows)
 
@@ -1643,7 +1643,7 @@ ORDER BY time,
          Sort Key: _hyper_1_3_chunk."time", _hyper_1_3_chunk.device_id
          Sort Method: quicksort 
          ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk (actual rows=2520 loops=1)
-               Filter: ("time" > ('2000-01-08'::cstring)::timestamp with time zone)
+               Vectorized Filter: ("time" > ('2000-01-08'::cstring)::timestamp with time zone)
                ->  Seq Scan on compress_hyper_5_16_chunk (actual rows=5 loops=1)
                      Filter: (_ts_meta_max_3 > ('2000-01-08'::cstring)::timestamp with time zone)
 (15 rows)
@@ -5067,19 +5067,19 @@ LIMIT 10;
                      Sort Key: _hyper_2_4_chunk."time", _hyper_2_4_chunk.device_id
                      Sort Method: top-N heapsort 
                      ->  Custom Scan (DecompressChunk) on _hyper_2_4_chunk (actual rows=360 loops=1)
-                           Filter: ("time" < now())
+                           Vectorized Filter: ("time" < now())
                            ->  Seq Scan on compress_hyper_6_17_chunk (actual rows=1 loops=1)
                ->  Sort (actual rows=6 loops=1)
                      Sort Key: _hyper_2_5_chunk."time", _hyper_2_5_chunk.device_id
                      Sort Method: top-N heapsort 
                      ->  Custom Scan (DecompressChunk) on _hyper_2_5_chunk (actual rows=1080 loops=1)
-                           Filter: ("time" < now())
+                           Vectorized Filter: ("time" < now())
                            ->  Seq Scan on compress_hyper_6_18_chunk (actual rows=3 loops=1)
                ->  Sort (actual rows=3 loops=1)
                      Sort Key: _hyper_2_6_chunk."time", _hyper_2_6_chunk.device_id
                      Sort Method: top-N heapsort 
                      ->  Custom Scan (DecompressChunk) on _hyper_2_6_chunk (actual rows=360 loops=1)
-                           Filter: ("time" < now())
+                           Vectorized Filter: ("time" < now())
                            ->  Seq Scan on compress_hyper_6_19_chunk (actual rows=1 loops=1)
          ->  Merge Append (never executed)
                Sort Key: _hyper_2_7_chunk."time", _hyper_2_7_chunk.device_id
@@ -5106,12 +5106,12 @@ LIMIT 10;
                ->  Sort (never executed)
                      Sort Key: _hyper_2_10_chunk."time", _hyper_2_10_chunk.device_id
                      ->  Custom Scan (DecompressChunk) on _hyper_2_10_chunk (never executed)
-                           Filter: ("time" < now())
+                           Vectorized Filter: ("time" < now())
                            ->  Seq Scan on compress_hyper_6_20_chunk (never executed)
                ->  Sort (never executed)
                      Sort Key: _hyper_2_11_chunk."time", _hyper_2_11_chunk.device_id
                      ->  Custom Scan (DecompressChunk) on _hyper_2_11_chunk (never executed)
-                           Filter: ("time" < now())
+                           Vectorized Filter: ("time" < now())
                            ->  Seq Scan on compress_hyper_6_21_chunk (never executed)
                ->  Sort (never executed)
                      Sort Key: _hyper_2_12_chunk."time", _hyper_2_12_chunk.device_id
@@ -5771,7 +5771,7 @@ ORDER BY time,
                Sort Key: _hyper_2_4_chunk."time", _hyper_2_4_chunk.device_id
                Sort Method: quicksort 
                ->  Custom Scan (DecompressChunk) on _hyper_2_4_chunk (actual rows=0 loops=1)
-                     Filter: ("time" > ('2000-01-08'::cstring)::timestamp with time zone)
+                     Vectorized Filter: ("time" > ('2000-01-08'::cstring)::timestamp with time zone)
                      ->  Seq Scan on compress_hyper_6_17_chunk (actual rows=0 loops=1)
                            Filter: (_ts_meta_max_3 > ('2000-01-08'::cstring)::timestamp with time zone)
                            Rows Removed by Filter: 1
@@ -5779,7 +5779,7 @@ ORDER BY time,
                Sort Key: _hyper_2_5_chunk."time", _hyper_2_5_chunk.device_id
                Sort Method: quicksort 
                ->  Custom Scan (DecompressChunk) on _hyper_2_5_chunk (actual rows=0 loops=1)
-                     Filter: ("time" > ('2000-01-08'::cstring)::timestamp with time zone)
+                     Vectorized Filter: ("time" > ('2000-01-08'::cstring)::timestamp with time zone)
                      ->  Seq Scan on compress_hyper_6_18_chunk (actual rows=0 loops=1)
                            Filter: (_ts_meta_max_3 > ('2000-01-08'::cstring)::timestamp with time zone)
                            Rows Removed by Filter: 3
@@ -5787,7 +5787,7 @@ ORDER BY time,
                Sort Key: _hyper_2_6_chunk."time", _hyper_2_6_chunk.device_id
                Sort Method: quicksort 
                ->  Custom Scan (DecompressChunk) on _hyper_2_6_chunk (actual rows=0 loops=1)
-                     Filter: ("time" > ('2000-01-08'::cstring)::timestamp with time zone)
+                     Vectorized Filter: ("time" > ('2000-01-08'::cstring)::timestamp with time zone)
                      ->  Seq Scan on compress_hyper_6_19_chunk (actual rows=0 loops=1)
                            Filter: (_ts_meta_max_3 > ('2000-01-08'::cstring)::timestamp with time zone)
                            Rows Removed by Filter: 1
@@ -5825,14 +5825,14 @@ ORDER BY time,
                Sort Key: _hyper_2_10_chunk."time", _hyper_2_10_chunk.device_id
                Sort Method: quicksort 
                ->  Custom Scan (DecompressChunk) on _hyper_2_10_chunk (actual rows=504 loops=1)
-                     Filter: ("time" > ('2000-01-08'::cstring)::timestamp with time zone)
+                     Vectorized Filter: ("time" > ('2000-01-08'::cstring)::timestamp with time zone)
                      ->  Seq Scan on compress_hyper_6_20_chunk (actual rows=1 loops=1)
                            Filter: (_ts_meta_max_3 > ('2000-01-08'::cstring)::timestamp with time zone)
          ->  Sort (actual rows=1512 loops=1)
                Sort Key: _hyper_2_11_chunk."time", _hyper_2_11_chunk.device_id
                Sort Method: quicksort 
                ->  Custom Scan (DecompressChunk) on _hyper_2_11_chunk (actual rows=1512 loops=1)
-                     Filter: ("time" > ('2000-01-08'::cstring)::timestamp with time zone)
+                     Vectorized Filter: ("time" > ('2000-01-08'::cstring)::timestamp with time zone)
                      ->  Seq Scan on compress_hyper_6_21_chunk (actual rows=3 loops=1)
                            Filter: (_ts_meta_max_3 > ('2000-01-08'::cstring)::timestamp with time zone)
          ->  Sort (actual rows=504 loops=1)

--- a/tsl/test/expected/transparent_decompression-14.out
+++ b/tsl/test/expected/transparent_decompression-14.out
@@ -1200,7 +1200,7 @@ LIMIT 10;
                Sort Key: _hyper_1_1_chunk."time", _hyper_1_1_chunk.device_id
                Sort Method: top-N heapsort 
                ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk (actual rows=1800 loops=1)
-                     Filter: ("time" < now())
+                     Vectorized Filter: ("time" < now())
                      ->  Seq Scan on compress_hyper_5_15_chunk (actual rows=5 loops=1)
          ->  Sort (never executed)
                Sort Key: _hyper_1_2_chunk."time", _hyper_1_2_chunk.device_id
@@ -1209,7 +1209,7 @@ LIMIT 10;
          ->  Sort (never executed)
                Sort Key: _hyper_1_3_chunk."time", _hyper_1_3_chunk.device_id
                ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk (never executed)
-                     Filter: ("time" < now())
+                     Vectorized Filter: ("time" < now())
                      ->  Seq Scan on compress_hyper_5_16_chunk (never executed)
 (19 rows)
 
@@ -1643,7 +1643,7 @@ ORDER BY time,
          Sort Key: _hyper_1_3_chunk."time", _hyper_1_3_chunk.device_id
          Sort Method: quicksort 
          ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk (actual rows=2520 loops=1)
-               Filter: ("time" > ('2000-01-08'::cstring)::timestamp with time zone)
+               Vectorized Filter: ("time" > ('2000-01-08'::cstring)::timestamp with time zone)
                ->  Seq Scan on compress_hyper_5_16_chunk (actual rows=5 loops=1)
                      Filter: (_ts_meta_max_3 > ('2000-01-08'::cstring)::timestamp with time zone)
 (15 rows)
@@ -5067,19 +5067,19 @@ LIMIT 10;
                      Sort Key: _hyper_2_4_chunk."time", _hyper_2_4_chunk.device_id
                      Sort Method: top-N heapsort 
                      ->  Custom Scan (DecompressChunk) on _hyper_2_4_chunk (actual rows=360 loops=1)
-                           Filter: ("time" < now())
+                           Vectorized Filter: ("time" < now())
                            ->  Seq Scan on compress_hyper_6_17_chunk (actual rows=1 loops=1)
                ->  Sort (actual rows=6 loops=1)
                      Sort Key: _hyper_2_5_chunk."time", _hyper_2_5_chunk.device_id
                      Sort Method: top-N heapsort 
                      ->  Custom Scan (DecompressChunk) on _hyper_2_5_chunk (actual rows=1080 loops=1)
-                           Filter: ("time" < now())
+                           Vectorized Filter: ("time" < now())
                            ->  Seq Scan on compress_hyper_6_18_chunk (actual rows=3 loops=1)
                ->  Sort (actual rows=3 loops=1)
                      Sort Key: _hyper_2_6_chunk."time", _hyper_2_6_chunk.device_id
                      Sort Method: top-N heapsort 
                      ->  Custom Scan (DecompressChunk) on _hyper_2_6_chunk (actual rows=360 loops=1)
-                           Filter: ("time" < now())
+                           Vectorized Filter: ("time" < now())
                            ->  Seq Scan on compress_hyper_6_19_chunk (actual rows=1 loops=1)
          ->  Merge Append (never executed)
                Sort Key: _hyper_2_7_chunk."time", _hyper_2_7_chunk.device_id
@@ -5106,12 +5106,12 @@ LIMIT 10;
                ->  Sort (never executed)
                      Sort Key: _hyper_2_10_chunk."time", _hyper_2_10_chunk.device_id
                      ->  Custom Scan (DecompressChunk) on _hyper_2_10_chunk (never executed)
-                           Filter: ("time" < now())
+                           Vectorized Filter: ("time" < now())
                            ->  Seq Scan on compress_hyper_6_20_chunk (never executed)
                ->  Sort (never executed)
                      Sort Key: _hyper_2_11_chunk."time", _hyper_2_11_chunk.device_id
                      ->  Custom Scan (DecompressChunk) on _hyper_2_11_chunk (never executed)
-                           Filter: ("time" < now())
+                           Vectorized Filter: ("time" < now())
                            ->  Seq Scan on compress_hyper_6_21_chunk (never executed)
                ->  Sort (never executed)
                      Sort Key: _hyper_2_12_chunk."time", _hyper_2_12_chunk.device_id
@@ -5771,7 +5771,7 @@ ORDER BY time,
                Sort Key: _hyper_2_4_chunk."time", _hyper_2_4_chunk.device_id
                Sort Method: quicksort 
                ->  Custom Scan (DecompressChunk) on _hyper_2_4_chunk (actual rows=0 loops=1)
-                     Filter: ("time" > ('2000-01-08'::cstring)::timestamp with time zone)
+                     Vectorized Filter: ("time" > ('2000-01-08'::cstring)::timestamp with time zone)
                      ->  Seq Scan on compress_hyper_6_17_chunk (actual rows=0 loops=1)
                            Filter: (_ts_meta_max_3 > ('2000-01-08'::cstring)::timestamp with time zone)
                            Rows Removed by Filter: 1
@@ -5779,7 +5779,7 @@ ORDER BY time,
                Sort Key: _hyper_2_5_chunk."time", _hyper_2_5_chunk.device_id
                Sort Method: quicksort 
                ->  Custom Scan (DecompressChunk) on _hyper_2_5_chunk (actual rows=0 loops=1)
-                     Filter: ("time" > ('2000-01-08'::cstring)::timestamp with time zone)
+                     Vectorized Filter: ("time" > ('2000-01-08'::cstring)::timestamp with time zone)
                      ->  Seq Scan on compress_hyper_6_18_chunk (actual rows=0 loops=1)
                            Filter: (_ts_meta_max_3 > ('2000-01-08'::cstring)::timestamp with time zone)
                            Rows Removed by Filter: 3
@@ -5787,7 +5787,7 @@ ORDER BY time,
                Sort Key: _hyper_2_6_chunk."time", _hyper_2_6_chunk.device_id
                Sort Method: quicksort 
                ->  Custom Scan (DecompressChunk) on _hyper_2_6_chunk (actual rows=0 loops=1)
-                     Filter: ("time" > ('2000-01-08'::cstring)::timestamp with time zone)
+                     Vectorized Filter: ("time" > ('2000-01-08'::cstring)::timestamp with time zone)
                      ->  Seq Scan on compress_hyper_6_19_chunk (actual rows=0 loops=1)
                            Filter: (_ts_meta_max_3 > ('2000-01-08'::cstring)::timestamp with time zone)
                            Rows Removed by Filter: 1
@@ -5825,14 +5825,14 @@ ORDER BY time,
                Sort Key: _hyper_2_10_chunk."time", _hyper_2_10_chunk.device_id
                Sort Method: quicksort 
                ->  Custom Scan (DecompressChunk) on _hyper_2_10_chunk (actual rows=504 loops=1)
-                     Filter: ("time" > ('2000-01-08'::cstring)::timestamp with time zone)
+                     Vectorized Filter: ("time" > ('2000-01-08'::cstring)::timestamp with time zone)
                      ->  Seq Scan on compress_hyper_6_20_chunk (actual rows=1 loops=1)
                            Filter: (_ts_meta_max_3 > ('2000-01-08'::cstring)::timestamp with time zone)
          ->  Sort (actual rows=1512 loops=1)
                Sort Key: _hyper_2_11_chunk."time", _hyper_2_11_chunk.device_id
                Sort Method: quicksort 
                ->  Custom Scan (DecompressChunk) on _hyper_2_11_chunk (actual rows=1512 loops=1)
-                     Filter: ("time" > ('2000-01-08'::cstring)::timestamp with time zone)
+                     Vectorized Filter: ("time" > ('2000-01-08'::cstring)::timestamp with time zone)
                      ->  Seq Scan on compress_hyper_6_21_chunk (actual rows=3 loops=1)
                            Filter: (_ts_meta_max_3 > ('2000-01-08'::cstring)::timestamp with time zone)
          ->  Sort (actual rows=504 loops=1)

--- a/tsl/test/expected/transparent_decompression-15.out
+++ b/tsl/test/expected/transparent_decompression-15.out
@@ -1201,7 +1201,7 @@ LIMIT 10;
                Sort Key: _hyper_1_1_chunk."time", _hyper_1_1_chunk.device_id
                Sort Method: top-N heapsort 
                ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk (actual rows=1800 loops=1)
-                     Filter: ("time" < now())
+                     Vectorized Filter: ("time" < now())
                      ->  Seq Scan on compress_hyper_5_15_chunk (actual rows=5 loops=1)
          ->  Sort (never executed)
                Sort Key: _hyper_1_2_chunk."time", _hyper_1_2_chunk.device_id
@@ -1210,7 +1210,7 @@ LIMIT 10;
          ->  Sort (never executed)
                Sort Key: _hyper_1_3_chunk."time", _hyper_1_3_chunk.device_id
                ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk (never executed)
-                     Filter: ("time" < now())
+                     Vectorized Filter: ("time" < now())
                      ->  Seq Scan on compress_hyper_5_16_chunk (never executed)
 (19 rows)
 
@@ -1644,7 +1644,7 @@ ORDER BY time,
          Sort Key: _hyper_1_3_chunk."time", _hyper_1_3_chunk.device_id
          Sort Method: quicksort 
          ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk (actual rows=2520 loops=1)
-               Filter: ("time" > ('2000-01-08'::cstring)::timestamp with time zone)
+               Vectorized Filter: ("time" > ('2000-01-08'::cstring)::timestamp with time zone)
                ->  Seq Scan on compress_hyper_5_16_chunk (actual rows=5 loops=1)
                      Filter: (_ts_meta_max_3 > ('2000-01-08'::cstring)::timestamp with time zone)
 (15 rows)
@@ -5041,19 +5041,19 @@ LIMIT 10;
                      Sort Key: _hyper_2_4_chunk."time", _hyper_2_4_chunk.device_id
                      Sort Method: top-N heapsort 
                      ->  Custom Scan (DecompressChunk) on _hyper_2_4_chunk (actual rows=360 loops=1)
-                           Filter: ("time" < now())
+                           Vectorized Filter: ("time" < now())
                            ->  Seq Scan on compress_hyper_6_17_chunk (actual rows=1 loops=1)
                ->  Sort (actual rows=6 loops=1)
                      Sort Key: _hyper_2_5_chunk."time", _hyper_2_5_chunk.device_id
                      Sort Method: top-N heapsort 
                      ->  Custom Scan (DecompressChunk) on _hyper_2_5_chunk (actual rows=1080 loops=1)
-                           Filter: ("time" < now())
+                           Vectorized Filter: ("time" < now())
                            ->  Seq Scan on compress_hyper_6_18_chunk (actual rows=3 loops=1)
                ->  Sort (actual rows=3 loops=1)
                      Sort Key: _hyper_2_6_chunk."time", _hyper_2_6_chunk.device_id
                      Sort Method: top-N heapsort 
                      ->  Custom Scan (DecompressChunk) on _hyper_2_6_chunk (actual rows=360 loops=1)
-                           Filter: ("time" < now())
+                           Vectorized Filter: ("time" < now())
                            ->  Seq Scan on compress_hyper_6_19_chunk (actual rows=1 loops=1)
          ->  Merge Append (never executed)
                Sort Key: _hyper_2_7_chunk."time", _hyper_2_7_chunk.device_id
@@ -5080,12 +5080,12 @@ LIMIT 10;
                ->  Sort (never executed)
                      Sort Key: _hyper_2_10_chunk."time", _hyper_2_10_chunk.device_id
                      ->  Custom Scan (DecompressChunk) on _hyper_2_10_chunk (never executed)
-                           Filter: ("time" < now())
+                           Vectorized Filter: ("time" < now())
                            ->  Seq Scan on compress_hyper_6_20_chunk (never executed)
                ->  Sort (never executed)
                      Sort Key: _hyper_2_11_chunk."time", _hyper_2_11_chunk.device_id
                      ->  Custom Scan (DecompressChunk) on _hyper_2_11_chunk (never executed)
-                           Filter: ("time" < now())
+                           Vectorized Filter: ("time" < now())
                            ->  Seq Scan on compress_hyper_6_21_chunk (never executed)
                ->  Sort (never executed)
                      Sort Key: _hyper_2_12_chunk."time", _hyper_2_12_chunk.device_id
@@ -5745,7 +5745,7 @@ ORDER BY time,
                Sort Key: _hyper_2_4_chunk."time", _hyper_2_4_chunk.device_id
                Sort Method: quicksort 
                ->  Custom Scan (DecompressChunk) on _hyper_2_4_chunk (actual rows=0 loops=1)
-                     Filter: ("time" > ('2000-01-08'::cstring)::timestamp with time zone)
+                     Vectorized Filter: ("time" > ('2000-01-08'::cstring)::timestamp with time zone)
                      ->  Seq Scan on compress_hyper_6_17_chunk (actual rows=0 loops=1)
                            Filter: (_ts_meta_max_3 > ('2000-01-08'::cstring)::timestamp with time zone)
                            Rows Removed by Filter: 1
@@ -5753,7 +5753,7 @@ ORDER BY time,
                Sort Key: _hyper_2_5_chunk."time", _hyper_2_5_chunk.device_id
                Sort Method: quicksort 
                ->  Custom Scan (DecompressChunk) on _hyper_2_5_chunk (actual rows=0 loops=1)
-                     Filter: ("time" > ('2000-01-08'::cstring)::timestamp with time zone)
+                     Vectorized Filter: ("time" > ('2000-01-08'::cstring)::timestamp with time zone)
                      ->  Seq Scan on compress_hyper_6_18_chunk (actual rows=0 loops=1)
                            Filter: (_ts_meta_max_3 > ('2000-01-08'::cstring)::timestamp with time zone)
                            Rows Removed by Filter: 3
@@ -5761,7 +5761,7 @@ ORDER BY time,
                Sort Key: _hyper_2_6_chunk."time", _hyper_2_6_chunk.device_id
                Sort Method: quicksort 
                ->  Custom Scan (DecompressChunk) on _hyper_2_6_chunk (actual rows=0 loops=1)
-                     Filter: ("time" > ('2000-01-08'::cstring)::timestamp with time zone)
+                     Vectorized Filter: ("time" > ('2000-01-08'::cstring)::timestamp with time zone)
                      ->  Seq Scan on compress_hyper_6_19_chunk (actual rows=0 loops=1)
                            Filter: (_ts_meta_max_3 > ('2000-01-08'::cstring)::timestamp with time zone)
                            Rows Removed by Filter: 1
@@ -5799,14 +5799,14 @@ ORDER BY time,
                Sort Key: _hyper_2_10_chunk."time", _hyper_2_10_chunk.device_id
                Sort Method: quicksort 
                ->  Custom Scan (DecompressChunk) on _hyper_2_10_chunk (actual rows=504 loops=1)
-                     Filter: ("time" > ('2000-01-08'::cstring)::timestamp with time zone)
+                     Vectorized Filter: ("time" > ('2000-01-08'::cstring)::timestamp with time zone)
                      ->  Seq Scan on compress_hyper_6_20_chunk (actual rows=1 loops=1)
                            Filter: (_ts_meta_max_3 > ('2000-01-08'::cstring)::timestamp with time zone)
          ->  Sort (actual rows=1512 loops=1)
                Sort Key: _hyper_2_11_chunk."time", _hyper_2_11_chunk.device_id
                Sort Method: quicksort 
                ->  Custom Scan (DecompressChunk) on _hyper_2_11_chunk (actual rows=1512 loops=1)
-                     Filter: ("time" > ('2000-01-08'::cstring)::timestamp with time zone)
+                     Vectorized Filter: ("time" > ('2000-01-08'::cstring)::timestamp with time zone)
                      ->  Seq Scan on compress_hyper_6_21_chunk (actual rows=3 loops=1)
                            Filter: (_ts_meta_max_3 > ('2000-01-08'::cstring)::timestamp with time zone)
          ->  Sort (actual rows=504 loops=1)

--- a/tsl/test/expected/transparent_decompression_ordered_index-13.out
+++ b/tsl/test/expected/transparent_decompression_ordered_index-13.out
@@ -830,23 +830,21 @@ ORDER BY 1,
                ->  Merge Append (actual rows=10 loops=1)
                      Sort Key: _hyper_1_4_chunk."time" DESC
                      ->  Custom Scan (DecompressChunk) on _hyper_1_4_chunk (actual rows=9 loops=1)
-                           Filter: ("time" < now())
-                           Vectorized Filter: ("time" > 'Tue Jan 01 00:00:00 2002 PST'::timestamp with time zone)
+                           Vectorized Filter: (("time" > 'Tue Jan 01 00:00:00 2002 PST'::timestamp with time zone) AND ("time" < now()))
                            ->  Sort (actual rows=1 loops=1)
                                  Sort Key: compress_hyper_2_9_chunk._ts_meta_sequence_num DESC
                                  Sort Method: quicksort 
                                  ->  Seq Scan on compress_hyper_2_9_chunk (actual rows=1 loops=1)
                                        Filter: ((_ts_meta_max_1 > 'Tue Jan 01 00:00:00 2002 PST'::timestamp with time zone) AND (device_id = 4) AND (device_id_peer = 5))
                      ->  Custom Scan (DecompressChunk) on _hyper_1_5_chunk (actual rows=1 loops=1)
-                           Filter: ("time" < now())
-                           Vectorized Filter: ("time" > 'Tue Jan 01 00:00:00 2002 PST'::timestamp with time zone)
+                           Vectorized Filter: (("time" > 'Tue Jan 01 00:00:00 2002 PST'::timestamp with time zone) AND ("time" < now()))
                            ->  Sort (actual rows=1 loops=1)
                                  Sort Key: compress_hyper_2_10_chunk._ts_meta_sequence_num DESC
                                  Sort Method: quicksort 
                                  ->  Seq Scan on compress_hyper_2_10_chunk (actual rows=1 loops=1)
                                        Filter: ((_ts_meta_max_1 > 'Tue Jan 01 00:00:00 2002 PST'::timestamp with time zone) AND (device_id = 4) AND (device_id_peer = 5))
                                        Rows Removed by Filter: 4
-(26 rows)
+(24 rows)
 
 :PREFIX
 SELECT m.device_id,
@@ -916,23 +914,23 @@ ORDER BY 1,
                            Chunks excluded during startup: 0
                            ->  Append (actual rows=1541 loops=1)
                                  ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk d_1 (actual rows=480 loops=1)
-                                       Filter: ("time" > ('2000-01-01 0:00:00+0'::cstring)::timestamp with time zone)
+                                       Vectorized Filter: ("time" > ('2000-01-01 0:00:00+0'::cstring)::timestamp with time zone)
                                        ->  Seq Scan on compress_hyper_2_6_chunk (actual rows=5 loops=1)
                                              Filter: (_ts_meta_max_1 > ('2000-01-01 0:00:00+0'::cstring)::timestamp with time zone)
                                  ->  Custom Scan (DecompressChunk) on _hyper_1_2_chunk d_2 (actual rows=960 loops=1)
-                                       Filter: ("time" > ('2000-01-01 0:00:00+0'::cstring)::timestamp with time zone)
+                                       Vectorized Filter: ("time" > ('2000-01-01 0:00:00+0'::cstring)::timestamp with time zone)
                                        ->  Seq Scan on compress_hyper_2_7_chunk (actual rows=5 loops=1)
                                              Filter: (_ts_meta_max_1 > ('2000-01-01 0:00:00+0'::cstring)::timestamp with time zone)
                                  ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk d_3 (actual rows=48 loops=1)
-                                       Filter: ("time" > ('2000-01-01 0:00:00+0'::cstring)::timestamp with time zone)
+                                       Vectorized Filter: ("time" > ('2000-01-01 0:00:00+0'::cstring)::timestamp with time zone)
                                        ->  Seq Scan on compress_hyper_2_8_chunk (actual rows=1 loops=1)
                                              Filter: (_ts_meta_max_1 > ('2000-01-01 0:00:00+0'::cstring)::timestamp with time zone)
                                  ->  Custom Scan (DecompressChunk) on _hyper_1_4_chunk d_4 (actual rows=48 loops=1)
-                                       Filter: ("time" > ('2000-01-01 0:00:00+0'::cstring)::timestamp with time zone)
+                                       Vectorized Filter: ("time" > ('2000-01-01 0:00:00+0'::cstring)::timestamp with time zone)
                                        ->  Seq Scan on compress_hyper_2_9_chunk (actual rows=1 loops=1)
                                              Filter: (_ts_meta_max_1 > ('2000-01-01 0:00:00+0'::cstring)::timestamp with time zone)
                                  ->  Custom Scan (DecompressChunk) on _hyper_1_5_chunk d_5 (actual rows=5 loops=1)
-                                       Filter: ("time" > ('2000-01-01 0:00:00+0'::cstring)::timestamp with time zone)
+                                       Vectorized Filter: ("time" > ('2000-01-01 0:00:00+0'::cstring)::timestamp with time zone)
                                        ->  Seq Scan on compress_hyper_2_10_chunk (actual rows=5 loops=1)
                                              Filter: (_ts_meta_max_1 > ('2000-01-01 0:00:00+0'::cstring)::timestamp with time zone)
                ->  Sort (actual rows=7317 loops=1)
@@ -943,23 +941,23 @@ ORDER BY 1,
                            Chunks excluded during startup: 0
                            ->  Append (actual rows=1541 loops=1)
                                  ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk m_1 (actual rows=480 loops=1)
-                                       Filter: ("time" > ('2000-01-01 0:00:00+0'::cstring)::timestamp with time zone)
+                                       Vectorized Filter: ("time" > ('2000-01-01 0:00:00+0'::cstring)::timestamp with time zone)
                                        ->  Seq Scan on compress_hyper_2_6_chunk compress_hyper_2_6_chunk_1 (actual rows=5 loops=1)
                                              Filter: (_ts_meta_max_1 > ('2000-01-01 0:00:00+0'::cstring)::timestamp with time zone)
                                  ->  Custom Scan (DecompressChunk) on _hyper_1_2_chunk m_2 (actual rows=960 loops=1)
-                                       Filter: ("time" > ('2000-01-01 0:00:00+0'::cstring)::timestamp with time zone)
+                                       Vectorized Filter: ("time" > ('2000-01-01 0:00:00+0'::cstring)::timestamp with time zone)
                                        ->  Seq Scan on compress_hyper_2_7_chunk compress_hyper_2_7_chunk_1 (actual rows=5 loops=1)
                                              Filter: (_ts_meta_max_1 > ('2000-01-01 0:00:00+0'::cstring)::timestamp with time zone)
                                  ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk m_3 (actual rows=48 loops=1)
-                                       Filter: ("time" > ('2000-01-01 0:00:00+0'::cstring)::timestamp with time zone)
+                                       Vectorized Filter: ("time" > ('2000-01-01 0:00:00+0'::cstring)::timestamp with time zone)
                                        ->  Seq Scan on compress_hyper_2_8_chunk compress_hyper_2_8_chunk_1 (actual rows=1 loops=1)
                                              Filter: (_ts_meta_max_1 > ('2000-01-01 0:00:00+0'::cstring)::timestamp with time zone)
                                  ->  Custom Scan (DecompressChunk) on _hyper_1_4_chunk m_4 (actual rows=48 loops=1)
-                                       Filter: ("time" > ('2000-01-01 0:00:00+0'::cstring)::timestamp with time zone)
+                                       Vectorized Filter: ("time" > ('2000-01-01 0:00:00+0'::cstring)::timestamp with time zone)
                                        ->  Seq Scan on compress_hyper_2_9_chunk compress_hyper_2_9_chunk_1 (actual rows=1 loops=1)
                                              Filter: (_ts_meta_max_1 > ('2000-01-01 0:00:00+0'::cstring)::timestamp with time zone)
                                  ->  Custom Scan (DecompressChunk) on _hyper_1_5_chunk m_5 (actual rows=5 loops=1)
-                                       Filter: ("time" > ('2000-01-01 0:00:00+0'::cstring)::timestamp with time zone)
+                                       Vectorized Filter: ("time" > ('2000-01-01 0:00:00+0'::cstring)::timestamp with time zone)
                                        ->  Seq Scan on compress_hyper_2_10_chunk compress_hyper_2_10_chunk_1 (actual rows=5 loops=1)
                                              Filter: (_ts_meta_max_1 > ('2000-01-01 0:00:00+0'::cstring)::timestamp with time zone)
 (62 rows)
@@ -982,15 +980,14 @@ ORDER BY m.v0;
    ->  Hash Join (actual rows=0 loops=1)
          Hash Cond: (m.device_id = d.device_id)
          ->  Custom Scan (DecompressChunk) on _hyper_1_5_chunk m (actual rows=0 loops=1)
-               Filter: ("time" < ('2000-01-01 0:00:00+0'::cstring)::timestamp with time zone)
-               Vectorized Filter: ("time" > 'Tue Jan 01 00:00:00 2019 PST'::timestamp with time zone)
+               Vectorized Filter: (("time" > 'Tue Jan 01 00:00:00 2019 PST'::timestamp with time zone) AND ("time" < ('2000-01-01 0:00:00+0'::cstring)::timestamp with time zone))
                ->  Seq Scan on compress_hyper_2_10_chunk (actual rows=0 loops=1)
                      Filter: ((_ts_meta_max_1 > 'Tue Jan 01 00:00:00 2019 PST'::timestamp with time zone) AND (_ts_meta_min_1 < ('2000-01-01 0:00:00+0'::cstring)::timestamp with time zone))
                      Rows Removed by Filter: 5
          ->  Hash (actual rows=7 loops=1)
                Buckets: 1024  Batches: 1 
                ->  Seq Scan on device_tbl d (actual rows=7 loops=1)
-(14 rows)
+(13 rows)
 
 -- no matches in metrics_ordered_idx but one row in device_tbl
 :PREFIX
@@ -1013,12 +1010,11 @@ ORDER BY m.v0;
                Filter: (device_id = 8)
                Rows Removed by Filter: 6
          ->  Custom Scan (DecompressChunk) on _hyper_1_5_chunk m (actual rows=0 loops=1)
-               Filter: ("time" < ('2000-01-01 0:00:00+0'::cstring)::timestamp with time zone)
-               Vectorized Filter: ("time" > 'Tue Jan 01 00:00:00 2019 PST'::timestamp with time zone)
+               Vectorized Filter: (("time" > 'Tue Jan 01 00:00:00 2019 PST'::timestamp with time zone) AND ("time" < ('2000-01-01 0:00:00+0'::cstring)::timestamp with time zone))
                ->  Seq Scan on compress_hyper_2_10_chunk (actual rows=0 loops=1)
                      Filter: ((_ts_meta_max_1 > 'Tue Jan 01 00:00:00 2019 PST'::timestamp with time zone) AND (device_id = 8) AND (_ts_meta_min_1 < ('2000-01-01 0:00:00+0'::cstring)::timestamp with time zone))
                      Rows Removed by Filter: 5
-(14 rows)
+(13 rows)
 
 -- no matches in device_tbl but 1 row in metrics_ordered_idx
 :PREFIX

--- a/tsl/test/expected/transparent_decompression_ordered_index-14.out
+++ b/tsl/test/expected/transparent_decompression_ordered_index-14.out
@@ -830,23 +830,21 @@ ORDER BY 1,
                ->  Merge Append (actual rows=10 loops=1)
                      Sort Key: _hyper_1_4_chunk."time" DESC
                      ->  Custom Scan (DecompressChunk) on _hyper_1_4_chunk (actual rows=9 loops=1)
-                           Filter: ("time" < now())
-                           Vectorized Filter: ("time" > 'Tue Jan 01 00:00:00 2002 PST'::timestamp with time zone)
+                           Vectorized Filter: (("time" > 'Tue Jan 01 00:00:00 2002 PST'::timestamp with time zone) AND ("time" < now()))
                            ->  Sort (actual rows=1 loops=1)
                                  Sort Key: compress_hyper_2_9_chunk._ts_meta_sequence_num DESC
                                  Sort Method: quicksort 
                                  ->  Seq Scan on compress_hyper_2_9_chunk (actual rows=1 loops=1)
                                        Filter: ((_ts_meta_max_1 > 'Tue Jan 01 00:00:00 2002 PST'::timestamp with time zone) AND (device_id = 4) AND (device_id_peer = 5))
                      ->  Custom Scan (DecompressChunk) on _hyper_1_5_chunk (actual rows=1 loops=1)
-                           Filter: ("time" < now())
-                           Vectorized Filter: ("time" > 'Tue Jan 01 00:00:00 2002 PST'::timestamp with time zone)
+                           Vectorized Filter: (("time" > 'Tue Jan 01 00:00:00 2002 PST'::timestamp with time zone) AND ("time" < now()))
                            ->  Sort (actual rows=1 loops=1)
                                  Sort Key: compress_hyper_2_10_chunk._ts_meta_sequence_num DESC
                                  Sort Method: quicksort 
                                  ->  Seq Scan on compress_hyper_2_10_chunk (actual rows=1 loops=1)
                                        Filter: ((_ts_meta_max_1 > 'Tue Jan 01 00:00:00 2002 PST'::timestamp with time zone) AND (device_id = 4) AND (device_id_peer = 5))
                                        Rows Removed by Filter: 4
-(26 rows)
+(24 rows)
 
 :PREFIX
 SELECT m.device_id,
@@ -916,23 +914,23 @@ ORDER BY 1,
                            Chunks excluded during startup: 0
                            ->  Append (actual rows=1541 loops=1)
                                  ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk d_1 (actual rows=480 loops=1)
-                                       Filter: ("time" > ('2000-01-01 0:00:00+0'::cstring)::timestamp with time zone)
+                                       Vectorized Filter: ("time" > ('2000-01-01 0:00:00+0'::cstring)::timestamp with time zone)
                                        ->  Seq Scan on compress_hyper_2_6_chunk (actual rows=5 loops=1)
                                              Filter: (_ts_meta_max_1 > ('2000-01-01 0:00:00+0'::cstring)::timestamp with time zone)
                                  ->  Custom Scan (DecompressChunk) on _hyper_1_2_chunk d_2 (actual rows=960 loops=1)
-                                       Filter: ("time" > ('2000-01-01 0:00:00+0'::cstring)::timestamp with time zone)
+                                       Vectorized Filter: ("time" > ('2000-01-01 0:00:00+0'::cstring)::timestamp with time zone)
                                        ->  Seq Scan on compress_hyper_2_7_chunk (actual rows=5 loops=1)
                                              Filter: (_ts_meta_max_1 > ('2000-01-01 0:00:00+0'::cstring)::timestamp with time zone)
                                  ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk d_3 (actual rows=48 loops=1)
-                                       Filter: ("time" > ('2000-01-01 0:00:00+0'::cstring)::timestamp with time zone)
+                                       Vectorized Filter: ("time" > ('2000-01-01 0:00:00+0'::cstring)::timestamp with time zone)
                                        ->  Seq Scan on compress_hyper_2_8_chunk (actual rows=1 loops=1)
                                              Filter: (_ts_meta_max_1 > ('2000-01-01 0:00:00+0'::cstring)::timestamp with time zone)
                                  ->  Custom Scan (DecompressChunk) on _hyper_1_4_chunk d_4 (actual rows=48 loops=1)
-                                       Filter: ("time" > ('2000-01-01 0:00:00+0'::cstring)::timestamp with time zone)
+                                       Vectorized Filter: ("time" > ('2000-01-01 0:00:00+0'::cstring)::timestamp with time zone)
                                        ->  Seq Scan on compress_hyper_2_9_chunk (actual rows=1 loops=1)
                                              Filter: (_ts_meta_max_1 > ('2000-01-01 0:00:00+0'::cstring)::timestamp with time zone)
                                  ->  Custom Scan (DecompressChunk) on _hyper_1_5_chunk d_5 (actual rows=5 loops=1)
-                                       Filter: ("time" > ('2000-01-01 0:00:00+0'::cstring)::timestamp with time zone)
+                                       Vectorized Filter: ("time" > ('2000-01-01 0:00:00+0'::cstring)::timestamp with time zone)
                                        ->  Seq Scan on compress_hyper_2_10_chunk (actual rows=5 loops=1)
                                              Filter: (_ts_meta_max_1 > ('2000-01-01 0:00:00+0'::cstring)::timestamp with time zone)
                ->  Sort (actual rows=7317 loops=1)
@@ -943,23 +941,23 @@ ORDER BY 1,
                            Chunks excluded during startup: 0
                            ->  Append (actual rows=1541 loops=1)
                                  ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk m_1 (actual rows=480 loops=1)
-                                       Filter: ("time" > ('2000-01-01 0:00:00+0'::cstring)::timestamp with time zone)
+                                       Vectorized Filter: ("time" > ('2000-01-01 0:00:00+0'::cstring)::timestamp with time zone)
                                        ->  Seq Scan on compress_hyper_2_6_chunk compress_hyper_2_6_chunk_1 (actual rows=5 loops=1)
                                              Filter: (_ts_meta_max_1 > ('2000-01-01 0:00:00+0'::cstring)::timestamp with time zone)
                                  ->  Custom Scan (DecompressChunk) on _hyper_1_2_chunk m_2 (actual rows=960 loops=1)
-                                       Filter: ("time" > ('2000-01-01 0:00:00+0'::cstring)::timestamp with time zone)
+                                       Vectorized Filter: ("time" > ('2000-01-01 0:00:00+0'::cstring)::timestamp with time zone)
                                        ->  Seq Scan on compress_hyper_2_7_chunk compress_hyper_2_7_chunk_1 (actual rows=5 loops=1)
                                              Filter: (_ts_meta_max_1 > ('2000-01-01 0:00:00+0'::cstring)::timestamp with time zone)
                                  ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk m_3 (actual rows=48 loops=1)
-                                       Filter: ("time" > ('2000-01-01 0:00:00+0'::cstring)::timestamp with time zone)
+                                       Vectorized Filter: ("time" > ('2000-01-01 0:00:00+0'::cstring)::timestamp with time zone)
                                        ->  Seq Scan on compress_hyper_2_8_chunk compress_hyper_2_8_chunk_1 (actual rows=1 loops=1)
                                              Filter: (_ts_meta_max_1 > ('2000-01-01 0:00:00+0'::cstring)::timestamp with time zone)
                                  ->  Custom Scan (DecompressChunk) on _hyper_1_4_chunk m_4 (actual rows=48 loops=1)
-                                       Filter: ("time" > ('2000-01-01 0:00:00+0'::cstring)::timestamp with time zone)
+                                       Vectorized Filter: ("time" > ('2000-01-01 0:00:00+0'::cstring)::timestamp with time zone)
                                        ->  Seq Scan on compress_hyper_2_9_chunk compress_hyper_2_9_chunk_1 (actual rows=1 loops=1)
                                              Filter: (_ts_meta_max_1 > ('2000-01-01 0:00:00+0'::cstring)::timestamp with time zone)
                                  ->  Custom Scan (DecompressChunk) on _hyper_1_5_chunk m_5 (actual rows=5 loops=1)
-                                       Filter: ("time" > ('2000-01-01 0:00:00+0'::cstring)::timestamp with time zone)
+                                       Vectorized Filter: ("time" > ('2000-01-01 0:00:00+0'::cstring)::timestamp with time zone)
                                        ->  Seq Scan on compress_hyper_2_10_chunk compress_hyper_2_10_chunk_1 (actual rows=5 loops=1)
                                              Filter: (_ts_meta_max_1 > ('2000-01-01 0:00:00+0'::cstring)::timestamp with time zone)
 (62 rows)
@@ -982,15 +980,14 @@ ORDER BY m.v0;
    ->  Hash Join (actual rows=0 loops=1)
          Hash Cond: (m.device_id = d.device_id)
          ->  Custom Scan (DecompressChunk) on _hyper_1_5_chunk m (actual rows=0 loops=1)
-               Filter: ("time" < ('2000-01-01 0:00:00+0'::cstring)::timestamp with time zone)
-               Vectorized Filter: ("time" > 'Tue Jan 01 00:00:00 2019 PST'::timestamp with time zone)
+               Vectorized Filter: (("time" > 'Tue Jan 01 00:00:00 2019 PST'::timestamp with time zone) AND ("time" < ('2000-01-01 0:00:00+0'::cstring)::timestamp with time zone))
                ->  Seq Scan on compress_hyper_2_10_chunk (actual rows=0 loops=1)
                      Filter: ((_ts_meta_max_1 > 'Tue Jan 01 00:00:00 2019 PST'::timestamp with time zone) AND (_ts_meta_min_1 < ('2000-01-01 0:00:00+0'::cstring)::timestamp with time zone))
                      Rows Removed by Filter: 5
          ->  Hash (actual rows=7 loops=1)
                Buckets: 1024  Batches: 1 
                ->  Seq Scan on device_tbl d (actual rows=7 loops=1)
-(14 rows)
+(13 rows)
 
 -- no matches in metrics_ordered_idx but one row in device_tbl
 :PREFIX
@@ -1013,12 +1010,11 @@ ORDER BY m.v0;
                Filter: (device_id = 8)
                Rows Removed by Filter: 6
          ->  Custom Scan (DecompressChunk) on _hyper_1_5_chunk m (actual rows=0 loops=1)
-               Filter: ("time" < ('2000-01-01 0:00:00+0'::cstring)::timestamp with time zone)
-               Vectorized Filter: ("time" > 'Tue Jan 01 00:00:00 2019 PST'::timestamp with time zone)
+               Vectorized Filter: (("time" > 'Tue Jan 01 00:00:00 2019 PST'::timestamp with time zone) AND ("time" < ('2000-01-01 0:00:00+0'::cstring)::timestamp with time zone))
                ->  Seq Scan on compress_hyper_2_10_chunk (actual rows=0 loops=1)
                      Filter: ((_ts_meta_max_1 > 'Tue Jan 01 00:00:00 2019 PST'::timestamp with time zone) AND (device_id = 8) AND (_ts_meta_min_1 < ('2000-01-01 0:00:00+0'::cstring)::timestamp with time zone))
                      Rows Removed by Filter: 5
-(14 rows)
+(13 rows)
 
 -- no matches in device_tbl but 1 row in metrics_ordered_idx
 :PREFIX

--- a/tsl/test/expected/transparent_decompression_ordered_index-15.out
+++ b/tsl/test/expected/transparent_decompression_ordered_index-15.out
@@ -832,23 +832,21 @@ ORDER BY 1,
                ->  Merge Append (actual rows=10 loops=1)
                      Sort Key: _hyper_1_4_chunk."time" DESC
                      ->  Custom Scan (DecompressChunk) on _hyper_1_4_chunk (actual rows=9 loops=1)
-                           Filter: ("time" < now())
-                           Vectorized Filter: ("time" > 'Tue Jan 01 00:00:00 2002 PST'::timestamp with time zone)
+                           Vectorized Filter: (("time" > 'Tue Jan 01 00:00:00 2002 PST'::timestamp with time zone) AND ("time" < now()))
                            ->  Sort (actual rows=1 loops=1)
                                  Sort Key: compress_hyper_2_9_chunk._ts_meta_sequence_num DESC
                                  Sort Method: quicksort 
                                  ->  Seq Scan on compress_hyper_2_9_chunk (actual rows=1 loops=1)
                                        Filter: ((_ts_meta_max_1 > 'Tue Jan 01 00:00:00 2002 PST'::timestamp with time zone) AND (device_id = 4) AND (device_id_peer = 5))
                      ->  Custom Scan (DecompressChunk) on _hyper_1_5_chunk (actual rows=1 loops=1)
-                           Filter: ("time" < now())
-                           Vectorized Filter: ("time" > 'Tue Jan 01 00:00:00 2002 PST'::timestamp with time zone)
+                           Vectorized Filter: (("time" > 'Tue Jan 01 00:00:00 2002 PST'::timestamp with time zone) AND ("time" < now()))
                            ->  Sort (actual rows=1 loops=1)
                                  Sort Key: compress_hyper_2_10_chunk._ts_meta_sequence_num DESC
                                  Sort Method: quicksort 
                                  ->  Seq Scan on compress_hyper_2_10_chunk (actual rows=1 loops=1)
                                        Filter: ((_ts_meta_max_1 > 'Tue Jan 01 00:00:00 2002 PST'::timestamp with time zone) AND (device_id = 4) AND (device_id_peer = 5))
                                        Rows Removed by Filter: 4
-(26 rows)
+(24 rows)
 
 :PREFIX
 SELECT m.device_id,
@@ -918,23 +916,23 @@ ORDER BY 1,
                            Chunks excluded during startup: 0
                            ->  Append (actual rows=1541 loops=1)
                                  ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk d_1 (actual rows=480 loops=1)
-                                       Filter: ("time" > ('2000-01-01 0:00:00+0'::cstring)::timestamp with time zone)
+                                       Vectorized Filter: ("time" > ('2000-01-01 0:00:00+0'::cstring)::timestamp with time zone)
                                        ->  Seq Scan on compress_hyper_2_6_chunk (actual rows=5 loops=1)
                                              Filter: (_ts_meta_max_1 > ('2000-01-01 0:00:00+0'::cstring)::timestamp with time zone)
                                  ->  Custom Scan (DecompressChunk) on _hyper_1_2_chunk d_2 (actual rows=960 loops=1)
-                                       Filter: ("time" > ('2000-01-01 0:00:00+0'::cstring)::timestamp with time zone)
+                                       Vectorized Filter: ("time" > ('2000-01-01 0:00:00+0'::cstring)::timestamp with time zone)
                                        ->  Seq Scan on compress_hyper_2_7_chunk (actual rows=5 loops=1)
                                              Filter: (_ts_meta_max_1 > ('2000-01-01 0:00:00+0'::cstring)::timestamp with time zone)
                                  ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk d_3 (actual rows=48 loops=1)
-                                       Filter: ("time" > ('2000-01-01 0:00:00+0'::cstring)::timestamp with time zone)
+                                       Vectorized Filter: ("time" > ('2000-01-01 0:00:00+0'::cstring)::timestamp with time zone)
                                        ->  Seq Scan on compress_hyper_2_8_chunk (actual rows=1 loops=1)
                                              Filter: (_ts_meta_max_1 > ('2000-01-01 0:00:00+0'::cstring)::timestamp with time zone)
                                  ->  Custom Scan (DecompressChunk) on _hyper_1_4_chunk d_4 (actual rows=48 loops=1)
-                                       Filter: ("time" > ('2000-01-01 0:00:00+0'::cstring)::timestamp with time zone)
+                                       Vectorized Filter: ("time" > ('2000-01-01 0:00:00+0'::cstring)::timestamp with time zone)
                                        ->  Seq Scan on compress_hyper_2_9_chunk (actual rows=1 loops=1)
                                              Filter: (_ts_meta_max_1 > ('2000-01-01 0:00:00+0'::cstring)::timestamp with time zone)
                                  ->  Custom Scan (DecompressChunk) on _hyper_1_5_chunk d_5 (actual rows=5 loops=1)
-                                       Filter: ("time" > ('2000-01-01 0:00:00+0'::cstring)::timestamp with time zone)
+                                       Vectorized Filter: ("time" > ('2000-01-01 0:00:00+0'::cstring)::timestamp with time zone)
                                        ->  Seq Scan on compress_hyper_2_10_chunk (actual rows=5 loops=1)
                                              Filter: (_ts_meta_max_1 > ('2000-01-01 0:00:00+0'::cstring)::timestamp with time zone)
                ->  Sort (actual rows=7317 loops=1)
@@ -945,23 +943,23 @@ ORDER BY 1,
                            Chunks excluded during startup: 0
                            ->  Append (actual rows=1541 loops=1)
                                  ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk m_1 (actual rows=480 loops=1)
-                                       Filter: ("time" > ('2000-01-01 0:00:00+0'::cstring)::timestamp with time zone)
+                                       Vectorized Filter: ("time" > ('2000-01-01 0:00:00+0'::cstring)::timestamp with time zone)
                                        ->  Seq Scan on compress_hyper_2_6_chunk compress_hyper_2_6_chunk_1 (actual rows=5 loops=1)
                                              Filter: (_ts_meta_max_1 > ('2000-01-01 0:00:00+0'::cstring)::timestamp with time zone)
                                  ->  Custom Scan (DecompressChunk) on _hyper_1_2_chunk m_2 (actual rows=960 loops=1)
-                                       Filter: ("time" > ('2000-01-01 0:00:00+0'::cstring)::timestamp with time zone)
+                                       Vectorized Filter: ("time" > ('2000-01-01 0:00:00+0'::cstring)::timestamp with time zone)
                                        ->  Seq Scan on compress_hyper_2_7_chunk compress_hyper_2_7_chunk_1 (actual rows=5 loops=1)
                                              Filter: (_ts_meta_max_1 > ('2000-01-01 0:00:00+0'::cstring)::timestamp with time zone)
                                  ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk m_3 (actual rows=48 loops=1)
-                                       Filter: ("time" > ('2000-01-01 0:00:00+0'::cstring)::timestamp with time zone)
+                                       Vectorized Filter: ("time" > ('2000-01-01 0:00:00+0'::cstring)::timestamp with time zone)
                                        ->  Seq Scan on compress_hyper_2_8_chunk compress_hyper_2_8_chunk_1 (actual rows=1 loops=1)
                                              Filter: (_ts_meta_max_1 > ('2000-01-01 0:00:00+0'::cstring)::timestamp with time zone)
                                  ->  Custom Scan (DecompressChunk) on _hyper_1_4_chunk m_4 (actual rows=48 loops=1)
-                                       Filter: ("time" > ('2000-01-01 0:00:00+0'::cstring)::timestamp with time zone)
+                                       Vectorized Filter: ("time" > ('2000-01-01 0:00:00+0'::cstring)::timestamp with time zone)
                                        ->  Seq Scan on compress_hyper_2_9_chunk compress_hyper_2_9_chunk_1 (actual rows=1 loops=1)
                                              Filter: (_ts_meta_max_1 > ('2000-01-01 0:00:00+0'::cstring)::timestamp with time zone)
                                  ->  Custom Scan (DecompressChunk) on _hyper_1_5_chunk m_5 (actual rows=5 loops=1)
-                                       Filter: ("time" > ('2000-01-01 0:00:00+0'::cstring)::timestamp with time zone)
+                                       Vectorized Filter: ("time" > ('2000-01-01 0:00:00+0'::cstring)::timestamp with time zone)
                                        ->  Seq Scan on compress_hyper_2_10_chunk compress_hyper_2_10_chunk_1 (actual rows=5 loops=1)
                                              Filter: (_ts_meta_max_1 > ('2000-01-01 0:00:00+0'::cstring)::timestamp with time zone)
 (62 rows)
@@ -984,15 +982,14 @@ ORDER BY m.v0;
    ->  Hash Join (actual rows=0 loops=1)
          Hash Cond: (m.device_id = d.device_id)
          ->  Custom Scan (DecompressChunk) on _hyper_1_5_chunk m (actual rows=0 loops=1)
-               Filter: ("time" < ('2000-01-01 0:00:00+0'::cstring)::timestamp with time zone)
-               Vectorized Filter: ("time" > 'Tue Jan 01 00:00:00 2019 PST'::timestamp with time zone)
+               Vectorized Filter: (("time" > 'Tue Jan 01 00:00:00 2019 PST'::timestamp with time zone) AND ("time" < ('2000-01-01 0:00:00+0'::cstring)::timestamp with time zone))
                ->  Seq Scan on compress_hyper_2_10_chunk (actual rows=0 loops=1)
                      Filter: ((_ts_meta_max_1 > 'Tue Jan 01 00:00:00 2019 PST'::timestamp with time zone) AND (_ts_meta_min_1 < ('2000-01-01 0:00:00+0'::cstring)::timestamp with time zone))
                      Rows Removed by Filter: 5
          ->  Hash (actual rows=7 loops=1)
                Buckets: 1024  Batches: 1 
                ->  Seq Scan on device_tbl d (actual rows=7 loops=1)
-(14 rows)
+(13 rows)
 
 -- no matches in metrics_ordered_idx but one row in device_tbl
 :PREFIX
@@ -1015,12 +1012,11 @@ ORDER BY m.v0;
                Filter: (device_id = 8)
                Rows Removed by Filter: 6
          ->  Custom Scan (DecompressChunk) on _hyper_1_5_chunk m (actual rows=0 loops=1)
-               Filter: ("time" < ('2000-01-01 0:00:00+0'::cstring)::timestamp with time zone)
-               Vectorized Filter: ("time" > 'Tue Jan 01 00:00:00 2019 PST'::timestamp with time zone)
+               Vectorized Filter: (("time" > 'Tue Jan 01 00:00:00 2019 PST'::timestamp with time zone) AND ("time" < ('2000-01-01 0:00:00+0'::cstring)::timestamp with time zone))
                ->  Seq Scan on compress_hyper_2_10_chunk (actual rows=0 loops=1)
                      Filter: ((_ts_meta_max_1 > 'Tue Jan 01 00:00:00 2019 PST'::timestamp with time zone) AND (device_id = 8) AND (_ts_meta_min_1 < ('2000-01-01 0:00:00+0'::cstring)::timestamp with time zone))
                      Rows Removed by Filter: 5
-(14 rows)
+(13 rows)
 
 -- no matches in device_tbl but 1 row in metrics_ordered_idx
 :PREFIX

--- a/tsl/test/shared/expected/constify_timestamptz_op_interval.out
+++ b/tsl/test/shared/expected/constify_timestamptz_op_interval.out
@@ -122,7 +122,7 @@ FROM metrics_compressed
 WHERE time < '2000-01-01'::timestamptz - '6h'::interval;
 QUERY PLAN
  Custom Scan (DecompressChunk) on _hyper_X_X_chunk
-   Filter: ("time" < ('Sat Jan 01 00:00:00 2000 PST'::timestamp with time zone - '@ 6 hours'::interval))
+   Vectorized Filter: ("time" < ('Sat Jan 01 00:00:00 2000 PST'::timestamp with time zone - '@ 6 hours'::interval))
    ->  Seq Scan on compress_hyper_X_X_chunk
          Filter: (_ts_meta_min_1 < ('Sat Jan 01 00:00:00 2000 PST'::timestamp with time zone - '@ 6 hours'::interval))
 (4 rows)
@@ -135,7 +135,7 @@ WHERE time < '2000-01-01'::timestamptz - '6h'::interval
     AND device_id = 1;
 QUERY PLAN
  Custom Scan (DecompressChunk) on _hyper_X_X_chunk
-   Filter: ("time" < ('Sat Jan 01 00:00:00 2000 PST'::timestamp with time zone - '@ 6 hours'::interval))
+   Vectorized Filter: ("time" < ('Sat Jan 01 00:00:00 2000 PST'::timestamp with time zone - '@ 6 hours'::interval))
    ->  Seq Scan on compress_hyper_X_X_chunk
          Filter: ((device_id = 1) AND (_ts_meta_min_1 < ('Sat Jan 01 00:00:00 2000 PST'::timestamp with time zone - '@ 6 hours'::interval)))
 (4 rows)

--- a/tsl/test/shared/expected/constraint_exclusion_prepared.out
+++ b/tsl/test/shared/expected/constraint_exclusion_prepared.out
@@ -1482,15 +1482,15 @@ QUERY PLAN
          Order: metrics_compressed."time"
          Chunks excluded during startup: 0
          ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=100 loops=1)
-               Filter: ("time" < now())
+               Vectorized Filter: ("time" < now())
                ->  Index Scan Backward using compress_hyper_X_X_chunk__compressed_hypertable_4_device_id__t on compress_hyper_X_X_chunk (actual rows=1 loops=1)
                      Index Cond: (device_id = 1)
          ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (never executed)
-               Filter: ("time" < now())
+               Vectorized Filter: ("time" < now())
                ->  Index Scan Backward using compress_hyper_X_X_chunk__compressed_hypertable_4_device_id__t on compress_hyper_X_X_chunk (never executed)
                      Index Cond: (device_id = 1)
          ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (never executed)
-               Filter: ("time" < now())
+               Vectorized Filter: ("time" < now())
                ->  Index Scan Backward using compress_hyper_X_X_chunk__compressed_hypertable_4_device_id__t on compress_hyper_X_X_chunk (never executed)
                      Index Cond: (device_id = 1)
 (16 rows)
@@ -1502,15 +1502,15 @@ QUERY PLAN
          Order: metrics_compressed."time"
          Chunks excluded during startup: 0
          ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=100 loops=1)
-               Filter: ("time" < now())
+               Vectorized Filter: ("time" < now())
                ->  Index Scan Backward using compress_hyper_X_X_chunk__compressed_hypertable_4_device_id__t on compress_hyper_X_X_chunk (actual rows=1 loops=1)
                      Index Cond: (device_id = 1)
          ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (never executed)
-               Filter: ("time" < now())
+               Vectorized Filter: ("time" < now())
                ->  Index Scan Backward using compress_hyper_X_X_chunk__compressed_hypertable_4_device_id__t on compress_hyper_X_X_chunk (never executed)
                      Index Cond: (device_id = 1)
          ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (never executed)
-               Filter: ("time" < now())
+               Vectorized Filter: ("time" < now())
                ->  Index Scan Backward using compress_hyper_X_X_chunk__compressed_hypertable_4_device_id__t on compress_hyper_X_X_chunk (never executed)
                      Index Cond: (device_id = 1)
 (16 rows)
@@ -1522,15 +1522,15 @@ QUERY PLAN
          Order: metrics_compressed."time"
          Chunks excluded during startup: 0
          ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=100 loops=1)
-               Filter: ("time" < now())
+               Vectorized Filter: ("time" < now())
                ->  Index Scan Backward using compress_hyper_X_X_chunk__compressed_hypertable_4_device_id__t on compress_hyper_X_X_chunk (actual rows=1 loops=1)
                      Index Cond: (device_id = 1)
          ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (never executed)
-               Filter: ("time" < now())
+               Vectorized Filter: ("time" < now())
                ->  Index Scan Backward using compress_hyper_X_X_chunk__compressed_hypertable_4_device_id__t on compress_hyper_X_X_chunk (never executed)
                      Index Cond: (device_id = 1)
          ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (never executed)
-               Filter: ("time" < now())
+               Vectorized Filter: ("time" < now())
                ->  Index Scan Backward using compress_hyper_X_X_chunk__compressed_hypertable_4_device_id__t on compress_hyper_X_X_chunk (never executed)
                      Index Cond: (device_id = 1)
 (16 rows)
@@ -1542,15 +1542,15 @@ QUERY PLAN
          Order: metrics_compressed."time"
          Chunks excluded during startup: 0
          ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=100 loops=1)
-               Filter: ("time" < now())
+               Vectorized Filter: ("time" < now())
                ->  Index Scan Backward using compress_hyper_X_X_chunk__compressed_hypertable_4_device_id__t on compress_hyper_X_X_chunk (actual rows=1 loops=1)
                      Index Cond: (device_id = 1)
          ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (never executed)
-               Filter: ("time" < now())
+               Vectorized Filter: ("time" < now())
                ->  Index Scan Backward using compress_hyper_X_X_chunk__compressed_hypertable_4_device_id__t on compress_hyper_X_X_chunk (never executed)
                      Index Cond: (device_id = 1)
          ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (never executed)
-               Filter: ("time" < now())
+               Vectorized Filter: ("time" < now())
                ->  Index Scan Backward using compress_hyper_X_X_chunk__compressed_hypertable_4_device_id__t on compress_hyper_X_X_chunk (never executed)
                      Index Cond: (device_id = 1)
 (16 rows)
@@ -1562,15 +1562,15 @@ QUERY PLAN
          Order: metrics_compressed."time"
          Chunks excluded during startup: 0
          ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=100 loops=1)
-               Filter: ("time" < now())
+               Vectorized Filter: ("time" < now())
                ->  Index Scan Backward using compress_hyper_X_X_chunk__compressed_hypertable_4_device_id__t on compress_hyper_X_X_chunk (actual rows=1 loops=1)
                      Index Cond: (device_id = 1)
          ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (never executed)
-               Filter: ("time" < now())
+               Vectorized Filter: ("time" < now())
                ->  Index Scan Backward using compress_hyper_X_X_chunk__compressed_hypertable_4_device_id__t on compress_hyper_X_X_chunk (never executed)
                      Index Cond: (device_id = 1)
          ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (never executed)
-               Filter: ("time" < now())
+               Vectorized Filter: ("time" < now())
                ->  Index Scan Backward using compress_hyper_X_X_chunk__compressed_hypertable_4_device_id__t on compress_hyper_X_X_chunk (never executed)
                      Index Cond: (device_id = 1)
 (16 rows)
@@ -1591,12 +1591,12 @@ QUERY PLAN
          Order: metrics_compressed."time"
          Chunks excluded during startup: 1
          ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=100 loops=1)
-               Filter: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
+               Vectorized Filter: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
                ->  Index Scan Backward using compress_hyper_X_X_chunk__compressed_hypertable_4_device_id__t on compress_hyper_X_X_chunk (actual rows=1 loops=1)
                      Index Cond: (device_id = 1)
                      Filter: (_ts_meta_min_1 < ('2000-01-10'::cstring)::timestamp with time zone)
          ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (never executed)
-               Filter: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
+               Vectorized Filter: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
                ->  Index Scan Backward using compress_hyper_X_X_chunk__compressed_hypertable_4_device_id__t on compress_hyper_X_X_chunk (never executed)
                      Index Cond: (device_id = 1)
                      Filter: (_ts_meta_min_1 < ('2000-01-10'::cstring)::timestamp with time zone)
@@ -1609,12 +1609,12 @@ QUERY PLAN
          Order: metrics_compressed."time"
          Chunks excluded during startup: 1
          ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=100 loops=1)
-               Filter: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
+               Vectorized Filter: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
                ->  Index Scan Backward using compress_hyper_X_X_chunk__compressed_hypertable_4_device_id__t on compress_hyper_X_X_chunk (actual rows=1 loops=1)
                      Index Cond: (device_id = 1)
                      Filter: (_ts_meta_min_1 < ('2000-01-10'::cstring)::timestamp with time zone)
          ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (never executed)
-               Filter: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
+               Vectorized Filter: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
                ->  Index Scan Backward using compress_hyper_X_X_chunk__compressed_hypertable_4_device_id__t on compress_hyper_X_X_chunk (never executed)
                      Index Cond: (device_id = 1)
                      Filter: (_ts_meta_min_1 < ('2000-01-10'::cstring)::timestamp with time zone)
@@ -1627,12 +1627,12 @@ QUERY PLAN
          Order: metrics_compressed."time"
          Chunks excluded during startup: 1
          ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=100 loops=1)
-               Filter: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
+               Vectorized Filter: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
                ->  Index Scan Backward using compress_hyper_X_X_chunk__compressed_hypertable_4_device_id__t on compress_hyper_X_X_chunk (actual rows=1 loops=1)
                      Index Cond: (device_id = 1)
                      Filter: (_ts_meta_min_1 < ('2000-01-10'::cstring)::timestamp with time zone)
          ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (never executed)
-               Filter: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
+               Vectorized Filter: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
                ->  Index Scan Backward using compress_hyper_X_X_chunk__compressed_hypertable_4_device_id__t on compress_hyper_X_X_chunk (never executed)
                      Index Cond: (device_id = 1)
                      Filter: (_ts_meta_min_1 < ('2000-01-10'::cstring)::timestamp with time zone)
@@ -1645,12 +1645,12 @@ QUERY PLAN
          Order: metrics_compressed."time"
          Chunks excluded during startup: 1
          ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=100 loops=1)
-               Filter: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
+               Vectorized Filter: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
                ->  Index Scan Backward using compress_hyper_X_X_chunk__compressed_hypertable_4_device_id__t on compress_hyper_X_X_chunk (actual rows=1 loops=1)
                      Index Cond: (device_id = 1)
                      Filter: (_ts_meta_min_1 < ('2000-01-10'::cstring)::timestamp with time zone)
          ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (never executed)
-               Filter: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
+               Vectorized Filter: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
                ->  Index Scan Backward using compress_hyper_X_X_chunk__compressed_hypertable_4_device_id__t on compress_hyper_X_X_chunk (never executed)
                      Index Cond: (device_id = 1)
                      Filter: (_ts_meta_min_1 < ('2000-01-10'::cstring)::timestamp with time zone)
@@ -1663,12 +1663,12 @@ QUERY PLAN
          Order: metrics_compressed."time"
          Chunks excluded during startup: 1
          ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=100 loops=1)
-               Filter: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
+               Vectorized Filter: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
                ->  Index Scan Backward using compress_hyper_X_X_chunk__compressed_hypertable_4_device_id__t on compress_hyper_X_X_chunk (actual rows=1 loops=1)
                      Index Cond: (device_id = 1)
                      Filter: (_ts_meta_min_1 < ('2000-01-10'::cstring)::timestamp with time zone)
          ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (never executed)
-               Filter: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
+               Vectorized Filter: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
                ->  Index Scan Backward using compress_hyper_X_X_chunk__compressed_hypertable_4_device_id__t on compress_hyper_X_X_chunk (never executed)
                      Index Cond: (device_id = 1)
                      Filter: (_ts_meta_min_1 < ('2000-01-10'::cstring)::timestamp with time zone)
@@ -1880,13 +1880,13 @@ QUERY PLAN
                Sort Key: _hyper_X_X_chunk."time"
                Sort Method: top-N heapsort 
                ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=17990 loops=1)
-                     Filter: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
+                     Vectorized Filter: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
                      ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=20 loops=1)
                            Filter: (_ts_meta_min_1 < ('2000-01-10'::cstring)::timestamp with time zone)
          ->  Sort (never executed)
                Sort Key: _hyper_X_X_chunk."time"
                ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (never executed)
-                     Filter: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
+                     Vectorized Filter: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
                      ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
                            Filter: (_ts_meta_min_1 < ('2000-01-10'::cstring)::timestamp with time zone)
 (17 rows)
@@ -1901,13 +1901,13 @@ QUERY PLAN
                Sort Key: _hyper_X_X_chunk."time"
                Sort Method: top-N heapsort 
                ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=17990 loops=1)
-                     Filter: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
+                     Vectorized Filter: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
                      ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=20 loops=1)
                            Filter: (_ts_meta_min_1 < ('2000-01-10'::cstring)::timestamp with time zone)
          ->  Sort (never executed)
                Sort Key: _hyper_X_X_chunk."time"
                ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (never executed)
-                     Filter: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
+                     Vectorized Filter: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
                      ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
                            Filter: (_ts_meta_min_1 < ('2000-01-10'::cstring)::timestamp with time zone)
 (17 rows)
@@ -1922,13 +1922,13 @@ QUERY PLAN
                Sort Key: _hyper_X_X_chunk."time"
                Sort Method: top-N heapsort 
                ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=17990 loops=1)
-                     Filter: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
+                     Vectorized Filter: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
                      ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=20 loops=1)
                            Filter: (_ts_meta_min_1 < ('2000-01-10'::cstring)::timestamp with time zone)
          ->  Sort (never executed)
                Sort Key: _hyper_X_X_chunk."time"
                ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (never executed)
-                     Filter: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
+                     Vectorized Filter: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
                      ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
                            Filter: (_ts_meta_min_1 < ('2000-01-10'::cstring)::timestamp with time zone)
 (17 rows)
@@ -1943,13 +1943,13 @@ QUERY PLAN
                Sort Key: _hyper_X_X_chunk."time"
                Sort Method: top-N heapsort 
                ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=17990 loops=1)
-                     Filter: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
+                     Vectorized Filter: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
                      ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=20 loops=1)
                            Filter: (_ts_meta_min_1 < ('2000-01-10'::cstring)::timestamp with time zone)
          ->  Sort (never executed)
                Sort Key: _hyper_X_X_chunk."time"
                ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (never executed)
-                     Filter: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
+                     Vectorized Filter: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
                      ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
                            Filter: (_ts_meta_min_1 < ('2000-01-10'::cstring)::timestamp with time zone)
 (17 rows)
@@ -1964,13 +1964,13 @@ QUERY PLAN
                Sort Key: _hyper_X_X_chunk."time"
                Sort Method: top-N heapsort 
                ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=17990 loops=1)
-                     Filter: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
+                     Vectorized Filter: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
                      ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=20 loops=1)
                            Filter: (_ts_meta_min_1 < ('2000-01-10'::cstring)::timestamp with time zone)
          ->  Sort (never executed)
                Sort Key: _hyper_X_X_chunk."time"
                ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (never executed)
-                     Filter: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
+                     Vectorized Filter: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
                      ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
                            Filter: (_ts_meta_min_1 < ('2000-01-10'::cstring)::timestamp with time zone)
 (17 rows)
@@ -1998,14 +1998,14 @@ QUERY PLAN
          ->  Merge Append (actual rows=100 loops=1)
                Sort Key: _hyper_X_X_chunk.device_id, _hyper_X_X_chunk."time"
                ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=100 loops=1)
-                     Filter: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
+                     Vectorized Filter: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
                      ->  Sort (actual rows=1 loops=1)
                            Sort Key: compress_hyper_X_X_chunk.device_id, compress_hyper_X_X_chunk._ts_meta_sequence_num DESC
                            Sort Method: quicksort 
                            ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=20 loops=1)
                                  Filter: (_ts_meta_min_1 < ('2000-01-10'::cstring)::timestamp with time zone)
                ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=1 loops=1)
-                     Filter: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
+                     Vectorized Filter: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
                      ->  Sort (actual rows=1 loops=1)
                            Sort Key: compress_hyper_X_X_chunk.device_id, compress_hyper_X_X_chunk._ts_meta_sequence_num DESC
                            Sort Method: quicksort 
@@ -2023,14 +2023,14 @@ QUERY PLAN
          ->  Merge Append (actual rows=100 loops=1)
                Sort Key: _hyper_X_X_chunk.device_id, _hyper_X_X_chunk."time"
                ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=100 loops=1)
-                     Filter: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
+                     Vectorized Filter: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
                      ->  Sort (actual rows=1 loops=1)
                            Sort Key: compress_hyper_X_X_chunk.device_id, compress_hyper_X_X_chunk._ts_meta_sequence_num DESC
                            Sort Method: quicksort 
                            ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=20 loops=1)
                                  Filter: (_ts_meta_min_1 < ('2000-01-10'::cstring)::timestamp with time zone)
                ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=1 loops=1)
-                     Filter: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
+                     Vectorized Filter: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
                      ->  Sort (actual rows=1 loops=1)
                            Sort Key: compress_hyper_X_X_chunk.device_id, compress_hyper_X_X_chunk._ts_meta_sequence_num DESC
                            Sort Method: quicksort 
@@ -2048,14 +2048,14 @@ QUERY PLAN
          ->  Merge Append (actual rows=100 loops=1)
                Sort Key: _hyper_X_X_chunk.device_id, _hyper_X_X_chunk."time"
                ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=100 loops=1)
-                     Filter: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
+                     Vectorized Filter: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
                      ->  Sort (actual rows=1 loops=1)
                            Sort Key: compress_hyper_X_X_chunk.device_id, compress_hyper_X_X_chunk._ts_meta_sequence_num DESC
                            Sort Method: quicksort 
                            ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=20 loops=1)
                                  Filter: (_ts_meta_min_1 < ('2000-01-10'::cstring)::timestamp with time zone)
                ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=1 loops=1)
-                     Filter: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
+                     Vectorized Filter: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
                      ->  Sort (actual rows=1 loops=1)
                            Sort Key: compress_hyper_X_X_chunk.device_id, compress_hyper_X_X_chunk._ts_meta_sequence_num DESC
                            Sort Method: quicksort 
@@ -2073,14 +2073,14 @@ QUERY PLAN
          ->  Merge Append (actual rows=100 loops=1)
                Sort Key: _hyper_X_X_chunk.device_id, _hyper_X_X_chunk."time"
                ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=100 loops=1)
-                     Filter: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
+                     Vectorized Filter: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
                      ->  Sort (actual rows=1 loops=1)
                            Sort Key: compress_hyper_X_X_chunk.device_id, compress_hyper_X_X_chunk._ts_meta_sequence_num DESC
                            Sort Method: quicksort 
                            ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=20 loops=1)
                                  Filter: (_ts_meta_min_1 < ('2000-01-10'::cstring)::timestamp with time zone)
                ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=1 loops=1)
-                     Filter: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
+                     Vectorized Filter: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
                      ->  Sort (actual rows=1 loops=1)
                            Sort Key: compress_hyper_X_X_chunk.device_id, compress_hyper_X_X_chunk._ts_meta_sequence_num DESC
                            Sort Method: quicksort 
@@ -2098,14 +2098,14 @@ QUERY PLAN
          ->  Merge Append (actual rows=100 loops=1)
                Sort Key: _hyper_X_X_chunk.device_id, _hyper_X_X_chunk."time"
                ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=100 loops=1)
-                     Filter: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
+                     Vectorized Filter: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
                      ->  Sort (actual rows=1 loops=1)
                            Sort Key: compress_hyper_X_X_chunk.device_id, compress_hyper_X_X_chunk._ts_meta_sequence_num DESC
                            Sort Method: quicksort 
                            ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=20 loops=1)
                                  Filter: (_ts_meta_min_1 < ('2000-01-10'::cstring)::timestamp with time zone)
                ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=1 loops=1)
-                     Filter: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
+                     Vectorized Filter: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
                      ->  Sort (actual rows=1 loops=1)
                            Sort Key: compress_hyper_X_X_chunk.device_id, compress_hyper_X_X_chunk._ts_meta_sequence_num DESC
                            Sort Method: quicksort 
@@ -2200,20 +2200,20 @@ QUERY PLAN
          Order: metrics_space_compressed."time"
          Chunks excluded during startup: 0
          ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=100 loops=1)
-               Filter: ("time" < now())
+               Vectorized Filter: ("time" < now())
                ->  Sort (actual rows=1 loops=1)
                      Sort Key: compress_hyper_X_X_chunk._ts_meta_sequence_num DESC
                      Sort Method: quicksort 
                      ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=4 loops=1)
                            Filter: (device_id = 1)
          ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (never executed)
-               Filter: ("time" < now())
+               Vectorized Filter: ("time" < now())
                ->  Sort (never executed)
                      Sort Key: compress_hyper_X_X_chunk._ts_meta_sequence_num DESC
                      ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
                            Filter: (device_id = 1)
          ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (never executed)
-               Filter: ("time" < now())
+               Vectorized Filter: ("time" < now())
                ->  Sort (never executed)
                      Sort Key: compress_hyper_X_X_chunk._ts_meta_sequence_num DESC
                      ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
@@ -2227,20 +2227,20 @@ QUERY PLAN
          Order: metrics_space_compressed."time"
          Chunks excluded during startup: 0
          ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=100 loops=1)
-               Filter: ("time" < now())
+               Vectorized Filter: ("time" < now())
                ->  Sort (actual rows=1 loops=1)
                      Sort Key: compress_hyper_X_X_chunk._ts_meta_sequence_num DESC
                      Sort Method: quicksort 
                      ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=4 loops=1)
                            Filter: (device_id = 1)
          ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (never executed)
-               Filter: ("time" < now())
+               Vectorized Filter: ("time" < now())
                ->  Sort (never executed)
                      Sort Key: compress_hyper_X_X_chunk._ts_meta_sequence_num DESC
                      ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
                            Filter: (device_id = 1)
          ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (never executed)
-               Filter: ("time" < now())
+               Vectorized Filter: ("time" < now())
                ->  Sort (never executed)
                      Sort Key: compress_hyper_X_X_chunk._ts_meta_sequence_num DESC
                      ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
@@ -2254,20 +2254,20 @@ QUERY PLAN
          Order: metrics_space_compressed."time"
          Chunks excluded during startup: 0
          ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=100 loops=1)
-               Filter: ("time" < now())
+               Vectorized Filter: ("time" < now())
                ->  Sort (actual rows=1 loops=1)
                      Sort Key: compress_hyper_X_X_chunk._ts_meta_sequence_num DESC
                      Sort Method: quicksort 
                      ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=4 loops=1)
                            Filter: (device_id = 1)
          ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (never executed)
-               Filter: ("time" < now())
+               Vectorized Filter: ("time" < now())
                ->  Sort (never executed)
                      Sort Key: compress_hyper_X_X_chunk._ts_meta_sequence_num DESC
                      ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
                            Filter: (device_id = 1)
          ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (never executed)
-               Filter: ("time" < now())
+               Vectorized Filter: ("time" < now())
                ->  Sort (never executed)
                      Sort Key: compress_hyper_X_X_chunk._ts_meta_sequence_num DESC
                      ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
@@ -2281,20 +2281,20 @@ QUERY PLAN
          Order: metrics_space_compressed."time"
          Chunks excluded during startup: 0
          ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=100 loops=1)
-               Filter: ("time" < now())
+               Vectorized Filter: ("time" < now())
                ->  Sort (actual rows=1 loops=1)
                      Sort Key: compress_hyper_X_X_chunk._ts_meta_sequence_num DESC
                      Sort Method: quicksort 
                      ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=4 loops=1)
                            Filter: (device_id = 1)
          ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (never executed)
-               Filter: ("time" < now())
+               Vectorized Filter: ("time" < now())
                ->  Sort (never executed)
                      Sort Key: compress_hyper_X_X_chunk._ts_meta_sequence_num DESC
                      ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
                            Filter: (device_id = 1)
          ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (never executed)
-               Filter: ("time" < now())
+               Vectorized Filter: ("time" < now())
                ->  Sort (never executed)
                      Sort Key: compress_hyper_X_X_chunk._ts_meta_sequence_num DESC
                      ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
@@ -2308,20 +2308,20 @@ QUERY PLAN
          Order: metrics_space_compressed."time"
          Chunks excluded during startup: 0
          ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=100 loops=1)
-               Filter: ("time" < now())
+               Vectorized Filter: ("time" < now())
                ->  Sort (actual rows=1 loops=1)
                      Sort Key: compress_hyper_X_X_chunk._ts_meta_sequence_num DESC
                      Sort Method: quicksort 
                      ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=4 loops=1)
                            Filter: (device_id = 1)
          ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (never executed)
-               Filter: ("time" < now())
+               Vectorized Filter: ("time" < now())
                ->  Sort (never executed)
                      Sort Key: compress_hyper_X_X_chunk._ts_meta_sequence_num DESC
                      ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
                            Filter: (device_id = 1)
          ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (never executed)
-               Filter: ("time" < now())
+               Vectorized Filter: ("time" < now())
                ->  Sort (never executed)
                      Sort Key: compress_hyper_X_X_chunk._ts_meta_sequence_num DESC
                      ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
@@ -2344,14 +2344,14 @@ QUERY PLAN
          Order: metrics_space_compressed."time"
          Chunks excluded during startup: 1
          ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=100 loops=1)
-               Filter: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
+               Vectorized Filter: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
                ->  Sort (actual rows=1 loops=1)
                      Sort Key: compress_hyper_X_X_chunk._ts_meta_sequence_num DESC
                      Sort Method: quicksort 
                      ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=4 loops=1)
                            Filter: ((device_id = 1) AND (_ts_meta_min_1 < ('2000-01-10'::cstring)::timestamp with time zone))
          ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (never executed)
-               Filter: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
+               Vectorized Filter: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
                ->  Sort (never executed)
                      Sort Key: compress_hyper_X_X_chunk._ts_meta_sequence_num DESC
                      ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
@@ -2365,14 +2365,14 @@ QUERY PLAN
          Order: metrics_space_compressed."time"
          Chunks excluded during startup: 1
          ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=100 loops=1)
-               Filter: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
+               Vectorized Filter: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
                ->  Sort (actual rows=1 loops=1)
                      Sort Key: compress_hyper_X_X_chunk._ts_meta_sequence_num DESC
                      Sort Method: quicksort 
                      ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=4 loops=1)
                            Filter: ((device_id = 1) AND (_ts_meta_min_1 < ('2000-01-10'::cstring)::timestamp with time zone))
          ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (never executed)
-               Filter: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
+               Vectorized Filter: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
                ->  Sort (never executed)
                      Sort Key: compress_hyper_X_X_chunk._ts_meta_sequence_num DESC
                      ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
@@ -2386,14 +2386,14 @@ QUERY PLAN
          Order: metrics_space_compressed."time"
          Chunks excluded during startup: 1
          ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=100 loops=1)
-               Filter: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
+               Vectorized Filter: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
                ->  Sort (actual rows=1 loops=1)
                      Sort Key: compress_hyper_X_X_chunk._ts_meta_sequence_num DESC
                      Sort Method: quicksort 
                      ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=4 loops=1)
                            Filter: ((device_id = 1) AND (_ts_meta_min_1 < ('2000-01-10'::cstring)::timestamp with time zone))
          ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (never executed)
-               Filter: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
+               Vectorized Filter: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
                ->  Sort (never executed)
                      Sort Key: compress_hyper_X_X_chunk._ts_meta_sequence_num DESC
                      ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
@@ -2407,14 +2407,14 @@ QUERY PLAN
          Order: metrics_space_compressed."time"
          Chunks excluded during startup: 1
          ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=100 loops=1)
-               Filter: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
+               Vectorized Filter: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
                ->  Sort (actual rows=1 loops=1)
                      Sort Key: compress_hyper_X_X_chunk._ts_meta_sequence_num DESC
                      Sort Method: quicksort 
                      ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=4 loops=1)
                            Filter: ((device_id = 1) AND (_ts_meta_min_1 < ('2000-01-10'::cstring)::timestamp with time zone))
          ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (never executed)
-               Filter: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
+               Vectorized Filter: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
                ->  Sort (never executed)
                      Sort Key: compress_hyper_X_X_chunk._ts_meta_sequence_num DESC
                      ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
@@ -2428,14 +2428,14 @@ QUERY PLAN
          Order: metrics_space_compressed."time"
          Chunks excluded during startup: 1
          ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=100 loops=1)
-               Filter: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
+               Vectorized Filter: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
                ->  Sort (actual rows=1 loops=1)
                      Sort Key: compress_hyper_X_X_chunk._ts_meta_sequence_num DESC
                      Sort Method: quicksort 
                      ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=4 loops=1)
                            Filter: ((device_id = 1) AND (_ts_meta_min_1 < ('2000-01-10'::cstring)::timestamp with time zone))
          ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (never executed)
-               Filter: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
+               Vectorized Filter: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
                ->  Sort (never executed)
                      Sort Key: compress_hyper_X_X_chunk._ts_meta_sequence_num DESC
                      ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
@@ -2769,21 +2769,21 @@ QUERY PLAN
                      Sort Key: _hyper_X_X_chunk."time"
                      Sort Method: top-N heapsort 
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=3598 loops=1)
-                           Filter: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
+                           Vectorized Filter: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
                            ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=4 loops=1)
                                  Filter: (_ts_meta_min_1 < ('2000-01-10'::cstring)::timestamp with time zone)
                ->  Sort (actual rows=60 loops=1)
                      Sort Key: _hyper_X_X_chunk."time"
                      Sort Method: top-N heapsort 
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=10794 loops=1)
-                           Filter: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
+                           Vectorized Filter: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
                            ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=12 loops=1)
                                  Filter: (_ts_meta_min_1 < ('2000-01-10'::cstring)::timestamp with time zone)
                ->  Sort (actual rows=21 loops=1)
                      Sort Key: _hyper_X_X_chunk."time"
                      Sort Method: top-N heapsort 
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=3598 loops=1)
-                           Filter: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
+                           Vectorized Filter: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
                            ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=4 loops=1)
                                  Filter: (_ts_meta_min_1 < ('2000-01-10'::cstring)::timestamp with time zone)
          ->  Merge Append (never executed)
@@ -2791,19 +2791,19 @@ QUERY PLAN
                ->  Sort (never executed)
                      Sort Key: _hyper_X_X_chunk."time"
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (never executed)
-                           Filter: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
+                           Vectorized Filter: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
                            ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
                                  Filter: (_ts_meta_min_1 < ('2000-01-10'::cstring)::timestamp with time zone)
                ->  Sort (never executed)
                      Sort Key: _hyper_X_X_chunk."time"
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (never executed)
-                           Filter: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
+                           Vectorized Filter: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
                            ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
                                  Filter: (_ts_meta_min_1 < ('2000-01-10'::cstring)::timestamp with time zone)
                ->  Sort (never executed)
                      Sort Key: _hyper_X_X_chunk."time"
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (never executed)
-                           Filter: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
+                           Vectorized Filter: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
                            ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
                                  Filter: (_ts_meta_min_1 < ('2000-01-10'::cstring)::timestamp with time zone)
          ->  Merge Append (never executed)
@@ -2811,19 +2811,19 @@ QUERY PLAN
                ->  Sort (never executed)
                      Sort Key: _hyper_X_X_chunk."time"
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (never executed)
-                           Filter: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
+                           Vectorized Filter: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
                            ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
                                  Filter: (_ts_meta_min_1 < ('2000-01-10'::cstring)::timestamp with time zone)
                ->  Sort (never executed)
                      Sort Key: _hyper_X_X_chunk."time"
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (never executed)
-                           Filter: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
+                           Vectorized Filter: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
                            ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
                                  Filter: (_ts_meta_min_1 < ('2000-01-10'::cstring)::timestamp with time zone)
                ->  Sort (never executed)
                      Sort Key: _hyper_X_X_chunk."time"
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (never executed)
-                           Filter: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
+                           Vectorized Filter: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
                            ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
                                  Filter: (_ts_meta_min_1 < ('2000-01-10'::cstring)::timestamp with time zone)
 (66 rows)
@@ -2839,21 +2839,21 @@ QUERY PLAN
                      Sort Key: _hyper_X_X_chunk."time"
                      Sort Method: top-N heapsort 
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=3598 loops=1)
-                           Filter: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
+                           Vectorized Filter: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
                            ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=4 loops=1)
                                  Filter: (_ts_meta_min_1 < ('2000-01-10'::cstring)::timestamp with time zone)
                ->  Sort (actual rows=60 loops=1)
                      Sort Key: _hyper_X_X_chunk."time"
                      Sort Method: top-N heapsort 
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=10794 loops=1)
-                           Filter: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
+                           Vectorized Filter: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
                            ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=12 loops=1)
                                  Filter: (_ts_meta_min_1 < ('2000-01-10'::cstring)::timestamp with time zone)
                ->  Sort (actual rows=21 loops=1)
                      Sort Key: _hyper_X_X_chunk."time"
                      Sort Method: top-N heapsort 
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=3598 loops=1)
-                           Filter: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
+                           Vectorized Filter: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
                            ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=4 loops=1)
                                  Filter: (_ts_meta_min_1 < ('2000-01-10'::cstring)::timestamp with time zone)
          ->  Merge Append (never executed)
@@ -2861,19 +2861,19 @@ QUERY PLAN
                ->  Sort (never executed)
                      Sort Key: _hyper_X_X_chunk."time"
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (never executed)
-                           Filter: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
+                           Vectorized Filter: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
                            ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
                                  Filter: (_ts_meta_min_1 < ('2000-01-10'::cstring)::timestamp with time zone)
                ->  Sort (never executed)
                      Sort Key: _hyper_X_X_chunk."time"
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (never executed)
-                           Filter: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
+                           Vectorized Filter: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
                            ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
                                  Filter: (_ts_meta_min_1 < ('2000-01-10'::cstring)::timestamp with time zone)
                ->  Sort (never executed)
                      Sort Key: _hyper_X_X_chunk."time"
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (never executed)
-                           Filter: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
+                           Vectorized Filter: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
                            ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
                                  Filter: (_ts_meta_min_1 < ('2000-01-10'::cstring)::timestamp with time zone)
          ->  Merge Append (never executed)
@@ -2881,19 +2881,19 @@ QUERY PLAN
                ->  Sort (never executed)
                      Sort Key: _hyper_X_X_chunk."time"
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (never executed)
-                           Filter: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
+                           Vectorized Filter: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
                            ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
                                  Filter: (_ts_meta_min_1 < ('2000-01-10'::cstring)::timestamp with time zone)
                ->  Sort (never executed)
                      Sort Key: _hyper_X_X_chunk."time"
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (never executed)
-                           Filter: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
+                           Vectorized Filter: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
                            ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
                                  Filter: (_ts_meta_min_1 < ('2000-01-10'::cstring)::timestamp with time zone)
                ->  Sort (never executed)
                      Sort Key: _hyper_X_X_chunk."time"
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (never executed)
-                           Filter: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
+                           Vectorized Filter: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
                            ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
                                  Filter: (_ts_meta_min_1 < ('2000-01-10'::cstring)::timestamp with time zone)
 (66 rows)
@@ -2909,21 +2909,21 @@ QUERY PLAN
                      Sort Key: _hyper_X_X_chunk."time"
                      Sort Method: top-N heapsort 
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=3598 loops=1)
-                           Filter: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
+                           Vectorized Filter: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
                            ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=4 loops=1)
                                  Filter: (_ts_meta_min_1 < ('2000-01-10'::cstring)::timestamp with time zone)
                ->  Sort (actual rows=60 loops=1)
                      Sort Key: _hyper_X_X_chunk."time"
                      Sort Method: top-N heapsort 
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=10794 loops=1)
-                           Filter: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
+                           Vectorized Filter: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
                            ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=12 loops=1)
                                  Filter: (_ts_meta_min_1 < ('2000-01-10'::cstring)::timestamp with time zone)
                ->  Sort (actual rows=21 loops=1)
                      Sort Key: _hyper_X_X_chunk."time"
                      Sort Method: top-N heapsort 
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=3598 loops=1)
-                           Filter: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
+                           Vectorized Filter: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
                            ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=4 loops=1)
                                  Filter: (_ts_meta_min_1 < ('2000-01-10'::cstring)::timestamp with time zone)
          ->  Merge Append (never executed)
@@ -2931,19 +2931,19 @@ QUERY PLAN
                ->  Sort (never executed)
                      Sort Key: _hyper_X_X_chunk."time"
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (never executed)
-                           Filter: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
+                           Vectorized Filter: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
                            ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
                                  Filter: (_ts_meta_min_1 < ('2000-01-10'::cstring)::timestamp with time zone)
                ->  Sort (never executed)
                      Sort Key: _hyper_X_X_chunk."time"
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (never executed)
-                           Filter: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
+                           Vectorized Filter: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
                            ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
                                  Filter: (_ts_meta_min_1 < ('2000-01-10'::cstring)::timestamp with time zone)
                ->  Sort (never executed)
                      Sort Key: _hyper_X_X_chunk."time"
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (never executed)
-                           Filter: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
+                           Vectorized Filter: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
                            ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
                                  Filter: (_ts_meta_min_1 < ('2000-01-10'::cstring)::timestamp with time zone)
          ->  Merge Append (never executed)
@@ -2951,19 +2951,19 @@ QUERY PLAN
                ->  Sort (never executed)
                      Sort Key: _hyper_X_X_chunk."time"
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (never executed)
-                           Filter: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
+                           Vectorized Filter: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
                            ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
                                  Filter: (_ts_meta_min_1 < ('2000-01-10'::cstring)::timestamp with time zone)
                ->  Sort (never executed)
                      Sort Key: _hyper_X_X_chunk."time"
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (never executed)
-                           Filter: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
+                           Vectorized Filter: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
                            ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
                                  Filter: (_ts_meta_min_1 < ('2000-01-10'::cstring)::timestamp with time zone)
                ->  Sort (never executed)
                      Sort Key: _hyper_X_X_chunk."time"
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (never executed)
-                           Filter: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
+                           Vectorized Filter: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
                            ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
                                  Filter: (_ts_meta_min_1 < ('2000-01-10'::cstring)::timestamp with time zone)
 (66 rows)
@@ -2979,21 +2979,21 @@ QUERY PLAN
                      Sort Key: _hyper_X_X_chunk."time"
                      Sort Method: top-N heapsort 
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=3598 loops=1)
-                           Filter: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
+                           Vectorized Filter: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
                            ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=4 loops=1)
                                  Filter: (_ts_meta_min_1 < ('2000-01-10'::cstring)::timestamp with time zone)
                ->  Sort (actual rows=60 loops=1)
                      Sort Key: _hyper_X_X_chunk."time"
                      Sort Method: top-N heapsort 
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=10794 loops=1)
-                           Filter: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
+                           Vectorized Filter: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
                            ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=12 loops=1)
                                  Filter: (_ts_meta_min_1 < ('2000-01-10'::cstring)::timestamp with time zone)
                ->  Sort (actual rows=21 loops=1)
                      Sort Key: _hyper_X_X_chunk."time"
                      Sort Method: top-N heapsort 
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=3598 loops=1)
-                           Filter: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
+                           Vectorized Filter: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
                            ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=4 loops=1)
                                  Filter: (_ts_meta_min_1 < ('2000-01-10'::cstring)::timestamp with time zone)
          ->  Merge Append (never executed)
@@ -3001,19 +3001,19 @@ QUERY PLAN
                ->  Sort (never executed)
                      Sort Key: _hyper_X_X_chunk."time"
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (never executed)
-                           Filter: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
+                           Vectorized Filter: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
                            ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
                                  Filter: (_ts_meta_min_1 < ('2000-01-10'::cstring)::timestamp with time zone)
                ->  Sort (never executed)
                      Sort Key: _hyper_X_X_chunk."time"
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (never executed)
-                           Filter: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
+                           Vectorized Filter: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
                            ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
                                  Filter: (_ts_meta_min_1 < ('2000-01-10'::cstring)::timestamp with time zone)
                ->  Sort (never executed)
                      Sort Key: _hyper_X_X_chunk."time"
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (never executed)
-                           Filter: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
+                           Vectorized Filter: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
                            ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
                                  Filter: (_ts_meta_min_1 < ('2000-01-10'::cstring)::timestamp with time zone)
          ->  Merge Append (never executed)
@@ -3021,19 +3021,19 @@ QUERY PLAN
                ->  Sort (never executed)
                      Sort Key: _hyper_X_X_chunk."time"
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (never executed)
-                           Filter: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
+                           Vectorized Filter: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
                            ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
                                  Filter: (_ts_meta_min_1 < ('2000-01-10'::cstring)::timestamp with time zone)
                ->  Sort (never executed)
                      Sort Key: _hyper_X_X_chunk."time"
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (never executed)
-                           Filter: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
+                           Vectorized Filter: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
                            ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
                                  Filter: (_ts_meta_min_1 < ('2000-01-10'::cstring)::timestamp with time zone)
                ->  Sort (never executed)
                      Sort Key: _hyper_X_X_chunk."time"
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (never executed)
-                           Filter: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
+                           Vectorized Filter: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
                            ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
                                  Filter: (_ts_meta_min_1 < ('2000-01-10'::cstring)::timestamp with time zone)
 (66 rows)
@@ -3049,21 +3049,21 @@ QUERY PLAN
                      Sort Key: _hyper_X_X_chunk."time"
                      Sort Method: top-N heapsort 
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=3598 loops=1)
-                           Filter: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
+                           Vectorized Filter: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
                            ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=4 loops=1)
                                  Filter: (_ts_meta_min_1 < ('2000-01-10'::cstring)::timestamp with time zone)
                ->  Sort (actual rows=60 loops=1)
                      Sort Key: _hyper_X_X_chunk."time"
                      Sort Method: top-N heapsort 
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=10794 loops=1)
-                           Filter: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
+                           Vectorized Filter: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
                            ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=12 loops=1)
                                  Filter: (_ts_meta_min_1 < ('2000-01-10'::cstring)::timestamp with time zone)
                ->  Sort (actual rows=21 loops=1)
                      Sort Key: _hyper_X_X_chunk."time"
                      Sort Method: top-N heapsort 
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=3598 loops=1)
-                           Filter: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
+                           Vectorized Filter: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
                            ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=4 loops=1)
                                  Filter: (_ts_meta_min_1 < ('2000-01-10'::cstring)::timestamp with time zone)
          ->  Merge Append (never executed)
@@ -3071,19 +3071,19 @@ QUERY PLAN
                ->  Sort (never executed)
                      Sort Key: _hyper_X_X_chunk."time"
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (never executed)
-                           Filter: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
+                           Vectorized Filter: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
                            ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
                                  Filter: (_ts_meta_min_1 < ('2000-01-10'::cstring)::timestamp with time zone)
                ->  Sort (never executed)
                      Sort Key: _hyper_X_X_chunk."time"
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (never executed)
-                           Filter: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
+                           Vectorized Filter: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
                            ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
                                  Filter: (_ts_meta_min_1 < ('2000-01-10'::cstring)::timestamp with time zone)
                ->  Sort (never executed)
                      Sort Key: _hyper_X_X_chunk."time"
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (never executed)
-                           Filter: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
+                           Vectorized Filter: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
                            ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
                                  Filter: (_ts_meta_min_1 < ('2000-01-10'::cstring)::timestamp with time zone)
          ->  Merge Append (never executed)
@@ -3091,19 +3091,19 @@ QUERY PLAN
                ->  Sort (never executed)
                      Sort Key: _hyper_X_X_chunk."time"
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (never executed)
-                           Filter: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
+                           Vectorized Filter: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
                            ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
                                  Filter: (_ts_meta_min_1 < ('2000-01-10'::cstring)::timestamp with time zone)
                ->  Sort (never executed)
                      Sort Key: _hyper_X_X_chunk."time"
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (never executed)
-                           Filter: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
+                           Vectorized Filter: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
                            ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
                                  Filter: (_ts_meta_min_1 < ('2000-01-10'::cstring)::timestamp with time zone)
                ->  Sort (never executed)
                      Sort Key: _hyper_X_X_chunk."time"
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (never executed)
-                           Filter: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
+                           Vectorized Filter: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
                            ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
                                  Filter: (_ts_meta_min_1 < ('2000-01-10'::cstring)::timestamp with time zone)
 (66 rows)
@@ -3131,28 +3131,28 @@ QUERY PLAN
          ->  Merge Append (actual rows=100 loops=1)
                Sort Key: _hyper_X_X_chunk.device_id, _hyper_X_X_chunk."time"
                ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=100 loops=1)
-                     Filter: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
+                     Vectorized Filter: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
                      ->  Sort (actual rows=1 loops=1)
                            Sort Key: compress_hyper_X_X_chunk.device_id, compress_hyper_X_X_chunk._ts_meta_sequence_num DESC
                            Sort Method: quicksort 
                            ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=4 loops=1)
                                  Filter: (_ts_meta_min_1 < ('2000-01-10'::cstring)::timestamp with time zone)
                ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=1 loops=1)
-                     Filter: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
+                     Vectorized Filter: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
                      ->  Sort (actual rows=1 loops=1)
                            Sort Key: compress_hyper_X_X_chunk.device_id, compress_hyper_X_X_chunk._ts_meta_sequence_num DESC
                            Sort Method: quicksort 
                            ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=12 loops=1)
                                  Filter: (_ts_meta_min_1 < ('2000-01-10'::cstring)::timestamp with time zone)
                ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=1 loops=1)
-                     Filter: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
+                     Vectorized Filter: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
                      ->  Sort (actual rows=1 loops=1)
                            Sort Key: compress_hyper_X_X_chunk.device_id, compress_hyper_X_X_chunk._ts_meta_sequence_num DESC
                            Sort Method: quicksort 
                            ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=4 loops=1)
                                  Filter: (_ts_meta_min_1 < ('2000-01-10'::cstring)::timestamp with time zone)
                ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=1 loops=1)
-                     Filter: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
+                     Vectorized Filter: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
                      ->  Sort (actual rows=1 loops=1)
                            Sort Key: compress_hyper_X_X_chunk.device_id, compress_hyper_X_X_chunk._ts_meta_sequence_num DESC
                            Sort Method: quicksort 
@@ -3160,7 +3160,7 @@ QUERY PLAN
                                  Filter: (_ts_meta_min_1 < ('2000-01-10'::cstring)::timestamp with time zone)
                                  Rows Removed by Filter: 1
                ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=1 loops=1)
-                     Filter: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
+                     Vectorized Filter: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
                      ->  Sort (actual rows=1 loops=1)
                            Sort Key: compress_hyper_X_X_chunk.device_id, compress_hyper_X_X_chunk._ts_meta_sequence_num DESC
                            Sort Method: quicksort 
@@ -3168,7 +3168,7 @@ QUERY PLAN
                                  Filter: (_ts_meta_min_1 < ('2000-01-10'::cstring)::timestamp with time zone)
                                  Rows Removed by Filter: 3
                ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=1 loops=1)
-                     Filter: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
+                     Vectorized Filter: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
                      ->  Sort (actual rows=1 loops=1)
                            Sort Key: compress_hyper_X_X_chunk.device_id, compress_hyper_X_X_chunk._ts_meta_sequence_num DESC
                            Sort Method: quicksort 
@@ -3186,28 +3186,28 @@ QUERY PLAN
          ->  Merge Append (actual rows=100 loops=1)
                Sort Key: _hyper_X_X_chunk.device_id, _hyper_X_X_chunk."time"
                ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=100 loops=1)
-                     Filter: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
+                     Vectorized Filter: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
                      ->  Sort (actual rows=1 loops=1)
                            Sort Key: compress_hyper_X_X_chunk.device_id, compress_hyper_X_X_chunk._ts_meta_sequence_num DESC
                            Sort Method: quicksort 
                            ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=4 loops=1)
                                  Filter: (_ts_meta_min_1 < ('2000-01-10'::cstring)::timestamp with time zone)
                ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=1 loops=1)
-                     Filter: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
+                     Vectorized Filter: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
                      ->  Sort (actual rows=1 loops=1)
                            Sort Key: compress_hyper_X_X_chunk.device_id, compress_hyper_X_X_chunk._ts_meta_sequence_num DESC
                            Sort Method: quicksort 
                            ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=12 loops=1)
                                  Filter: (_ts_meta_min_1 < ('2000-01-10'::cstring)::timestamp with time zone)
                ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=1 loops=1)
-                     Filter: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
+                     Vectorized Filter: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
                      ->  Sort (actual rows=1 loops=1)
                            Sort Key: compress_hyper_X_X_chunk.device_id, compress_hyper_X_X_chunk._ts_meta_sequence_num DESC
                            Sort Method: quicksort 
                            ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=4 loops=1)
                                  Filter: (_ts_meta_min_1 < ('2000-01-10'::cstring)::timestamp with time zone)
                ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=1 loops=1)
-                     Filter: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
+                     Vectorized Filter: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
                      ->  Sort (actual rows=1 loops=1)
                            Sort Key: compress_hyper_X_X_chunk.device_id, compress_hyper_X_X_chunk._ts_meta_sequence_num DESC
                            Sort Method: quicksort 
@@ -3215,7 +3215,7 @@ QUERY PLAN
                                  Filter: (_ts_meta_min_1 < ('2000-01-10'::cstring)::timestamp with time zone)
                                  Rows Removed by Filter: 1
                ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=1 loops=1)
-                     Filter: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
+                     Vectorized Filter: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
                      ->  Sort (actual rows=1 loops=1)
                            Sort Key: compress_hyper_X_X_chunk.device_id, compress_hyper_X_X_chunk._ts_meta_sequence_num DESC
                            Sort Method: quicksort 
@@ -3223,7 +3223,7 @@ QUERY PLAN
                                  Filter: (_ts_meta_min_1 < ('2000-01-10'::cstring)::timestamp with time zone)
                                  Rows Removed by Filter: 3
                ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=1 loops=1)
-                     Filter: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
+                     Vectorized Filter: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
                      ->  Sort (actual rows=1 loops=1)
                            Sort Key: compress_hyper_X_X_chunk.device_id, compress_hyper_X_X_chunk._ts_meta_sequence_num DESC
                            Sort Method: quicksort 
@@ -3241,28 +3241,28 @@ QUERY PLAN
          ->  Merge Append (actual rows=100 loops=1)
                Sort Key: _hyper_X_X_chunk.device_id, _hyper_X_X_chunk."time"
                ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=100 loops=1)
-                     Filter: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
+                     Vectorized Filter: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
                      ->  Sort (actual rows=1 loops=1)
                            Sort Key: compress_hyper_X_X_chunk.device_id, compress_hyper_X_X_chunk._ts_meta_sequence_num DESC
                            Sort Method: quicksort 
                            ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=4 loops=1)
                                  Filter: (_ts_meta_min_1 < ('2000-01-10'::cstring)::timestamp with time zone)
                ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=1 loops=1)
-                     Filter: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
+                     Vectorized Filter: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
                      ->  Sort (actual rows=1 loops=1)
                            Sort Key: compress_hyper_X_X_chunk.device_id, compress_hyper_X_X_chunk._ts_meta_sequence_num DESC
                            Sort Method: quicksort 
                            ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=12 loops=1)
                                  Filter: (_ts_meta_min_1 < ('2000-01-10'::cstring)::timestamp with time zone)
                ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=1 loops=1)
-                     Filter: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
+                     Vectorized Filter: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
                      ->  Sort (actual rows=1 loops=1)
                            Sort Key: compress_hyper_X_X_chunk.device_id, compress_hyper_X_X_chunk._ts_meta_sequence_num DESC
                            Sort Method: quicksort 
                            ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=4 loops=1)
                                  Filter: (_ts_meta_min_1 < ('2000-01-10'::cstring)::timestamp with time zone)
                ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=1 loops=1)
-                     Filter: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
+                     Vectorized Filter: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
                      ->  Sort (actual rows=1 loops=1)
                            Sort Key: compress_hyper_X_X_chunk.device_id, compress_hyper_X_X_chunk._ts_meta_sequence_num DESC
                            Sort Method: quicksort 
@@ -3270,7 +3270,7 @@ QUERY PLAN
                                  Filter: (_ts_meta_min_1 < ('2000-01-10'::cstring)::timestamp with time zone)
                                  Rows Removed by Filter: 1
                ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=1 loops=1)
-                     Filter: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
+                     Vectorized Filter: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
                      ->  Sort (actual rows=1 loops=1)
                            Sort Key: compress_hyper_X_X_chunk.device_id, compress_hyper_X_X_chunk._ts_meta_sequence_num DESC
                            Sort Method: quicksort 
@@ -3278,7 +3278,7 @@ QUERY PLAN
                                  Filter: (_ts_meta_min_1 < ('2000-01-10'::cstring)::timestamp with time zone)
                                  Rows Removed by Filter: 3
                ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=1 loops=1)
-                     Filter: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
+                     Vectorized Filter: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
                      ->  Sort (actual rows=1 loops=1)
                            Sort Key: compress_hyper_X_X_chunk.device_id, compress_hyper_X_X_chunk._ts_meta_sequence_num DESC
                            Sort Method: quicksort 
@@ -3296,28 +3296,28 @@ QUERY PLAN
          ->  Merge Append (actual rows=100 loops=1)
                Sort Key: _hyper_X_X_chunk.device_id, _hyper_X_X_chunk."time"
                ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=100 loops=1)
-                     Filter: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
+                     Vectorized Filter: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
                      ->  Sort (actual rows=1 loops=1)
                            Sort Key: compress_hyper_X_X_chunk.device_id, compress_hyper_X_X_chunk._ts_meta_sequence_num DESC
                            Sort Method: quicksort 
                            ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=4 loops=1)
                                  Filter: (_ts_meta_min_1 < ('2000-01-10'::cstring)::timestamp with time zone)
                ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=1 loops=1)
-                     Filter: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
+                     Vectorized Filter: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
                      ->  Sort (actual rows=1 loops=1)
                            Sort Key: compress_hyper_X_X_chunk.device_id, compress_hyper_X_X_chunk._ts_meta_sequence_num DESC
                            Sort Method: quicksort 
                            ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=12 loops=1)
                                  Filter: (_ts_meta_min_1 < ('2000-01-10'::cstring)::timestamp with time zone)
                ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=1 loops=1)
-                     Filter: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
+                     Vectorized Filter: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
                      ->  Sort (actual rows=1 loops=1)
                            Sort Key: compress_hyper_X_X_chunk.device_id, compress_hyper_X_X_chunk._ts_meta_sequence_num DESC
                            Sort Method: quicksort 
                            ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=4 loops=1)
                                  Filter: (_ts_meta_min_1 < ('2000-01-10'::cstring)::timestamp with time zone)
                ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=1 loops=1)
-                     Filter: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
+                     Vectorized Filter: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
                      ->  Sort (actual rows=1 loops=1)
                            Sort Key: compress_hyper_X_X_chunk.device_id, compress_hyper_X_X_chunk._ts_meta_sequence_num DESC
                            Sort Method: quicksort 
@@ -3325,7 +3325,7 @@ QUERY PLAN
                                  Filter: (_ts_meta_min_1 < ('2000-01-10'::cstring)::timestamp with time zone)
                                  Rows Removed by Filter: 1
                ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=1 loops=1)
-                     Filter: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
+                     Vectorized Filter: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
                      ->  Sort (actual rows=1 loops=1)
                            Sort Key: compress_hyper_X_X_chunk.device_id, compress_hyper_X_X_chunk._ts_meta_sequence_num DESC
                            Sort Method: quicksort 
@@ -3333,7 +3333,7 @@ QUERY PLAN
                                  Filter: (_ts_meta_min_1 < ('2000-01-10'::cstring)::timestamp with time zone)
                                  Rows Removed by Filter: 3
                ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=1 loops=1)
-                     Filter: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
+                     Vectorized Filter: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
                      ->  Sort (actual rows=1 loops=1)
                            Sort Key: compress_hyper_X_X_chunk.device_id, compress_hyper_X_X_chunk._ts_meta_sequence_num DESC
                            Sort Method: quicksort 
@@ -3351,28 +3351,28 @@ QUERY PLAN
          ->  Merge Append (actual rows=100 loops=1)
                Sort Key: _hyper_X_X_chunk.device_id, _hyper_X_X_chunk."time"
                ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=100 loops=1)
-                     Filter: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
+                     Vectorized Filter: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
                      ->  Sort (actual rows=1 loops=1)
                            Sort Key: compress_hyper_X_X_chunk.device_id, compress_hyper_X_X_chunk._ts_meta_sequence_num DESC
                            Sort Method: quicksort 
                            ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=4 loops=1)
                                  Filter: (_ts_meta_min_1 < ('2000-01-10'::cstring)::timestamp with time zone)
                ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=1 loops=1)
-                     Filter: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
+                     Vectorized Filter: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
                      ->  Sort (actual rows=1 loops=1)
                            Sort Key: compress_hyper_X_X_chunk.device_id, compress_hyper_X_X_chunk._ts_meta_sequence_num DESC
                            Sort Method: quicksort 
                            ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=12 loops=1)
                                  Filter: (_ts_meta_min_1 < ('2000-01-10'::cstring)::timestamp with time zone)
                ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=1 loops=1)
-                     Filter: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
+                     Vectorized Filter: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
                      ->  Sort (actual rows=1 loops=1)
                            Sort Key: compress_hyper_X_X_chunk.device_id, compress_hyper_X_X_chunk._ts_meta_sequence_num DESC
                            Sort Method: quicksort 
                            ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=4 loops=1)
                                  Filter: (_ts_meta_min_1 < ('2000-01-10'::cstring)::timestamp with time zone)
                ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=1 loops=1)
-                     Filter: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
+                     Vectorized Filter: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
                      ->  Sort (actual rows=1 loops=1)
                            Sort Key: compress_hyper_X_X_chunk.device_id, compress_hyper_X_X_chunk._ts_meta_sequence_num DESC
                            Sort Method: quicksort 
@@ -3380,7 +3380,7 @@ QUERY PLAN
                                  Filter: (_ts_meta_min_1 < ('2000-01-10'::cstring)::timestamp with time zone)
                                  Rows Removed by Filter: 1
                ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=1 loops=1)
-                     Filter: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
+                     Vectorized Filter: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
                      ->  Sort (actual rows=1 loops=1)
                            Sort Key: compress_hyper_X_X_chunk.device_id, compress_hyper_X_X_chunk._ts_meta_sequence_num DESC
                            Sort Method: quicksort 
@@ -3388,7 +3388,7 @@ QUERY PLAN
                                  Filter: (_ts_meta_min_1 < ('2000-01-10'::cstring)::timestamp with time zone)
                                  Rows Removed by Filter: 3
                ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=1 loops=1)
-                     Filter: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
+                     Vectorized Filter: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
                      ->  Sort (actual rows=1 loops=1)
                            Sort Key: compress_hyper_X_X_chunk.device_id, compress_hyper_X_X_chunk._ts_meta_sequence_num DESC
                            Sort Method: quicksort 

--- a/tsl/test/shared/expected/ordered_append-13.out
+++ b/tsl/test/shared/expected/ordered_append-13.out
@@ -2469,7 +2469,7 @@ QUERY PLAN
                Sort Key: _hyper_X_X_chunk."time"
                Sort Method: top-N heapsort 
                ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=16785 loops=1)
-                     Filter: ("time" > ('2000-01-08'::cstring)::timestamp with time zone)
+                     Vectorized Filter: ("time" > ('2000-01-08'::cstring)::timestamp with time zone)
                      Rows Removed by Filter: 3215
                      ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=20 loops=1)
                            Filter: (_ts_meta_max_1 > ('2000-01-08'::cstring)::timestamp with time zone)
@@ -2477,7 +2477,7 @@ QUERY PLAN
          ->  Sort (never executed)
                Sort Key: _hyper_X_X_chunk."time"
                ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (never executed)
-                     Filter: ("time" > ('2000-01-08'::cstring)::timestamp with time zone)
+                     Vectorized Filter: ("time" > ('2000-01-08'::cstring)::timestamp with time zone)
                      ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
                            Filter: (_ts_meta_max_1 > ('2000-01-08'::cstring)::timestamp with time zone)
 (19 rows)
@@ -2497,13 +2497,13 @@ QUERY PLAN
                Sort Key: _hyper_X_X_chunk."time"
                Sort Method: top-N heapsort 
                ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=17990 loops=1)
-                     Filter: ("time" < ('2000-01-08'::cstring)::timestamp with time zone)
+                     Vectorized Filter: ("time" < ('2000-01-08'::cstring)::timestamp with time zone)
                      ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=20 loops=1)
                            Filter: (_ts_meta_min_1 < ('2000-01-08'::cstring)::timestamp with time zone)
          ->  Sort (never executed)
                Sort Key: _hyper_X_X_chunk."time"
                ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (never executed)
-                     Filter: ("time" < ('2000-01-08'::cstring)::timestamp with time zone)
+                     Vectorized Filter: ("time" < ('2000-01-08'::cstring)::timestamp with time zone)
                      ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
                            Filter: (_ts_meta_min_1 < ('2000-01-08'::cstring)::timestamp with time zone)
 (17 rows)
@@ -2525,13 +2525,12 @@ QUERY PLAN
                Sort Key: _hyper_X_X_chunk."time"
                Sort Method: top-N heapsort 
                ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=7195 loops=1)
-                     Filter: ("time" > ('2000-01-08'::cstring)::timestamp with time zone)
+                     Vectorized Filter: (("time" < 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone) AND ("time" > ('2000-01-08'::cstring)::timestamp with time zone))
                      Rows Removed by Filter: 7805
-                     Vectorized Filter: ("time" < 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone)
                      ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=15 loops=1)
                            Filter: ((_ts_meta_min_1 < 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone) AND (_ts_meta_max_1 > ('2000-01-08'::cstring)::timestamp with time zone))
                            Rows Removed by Filter: 15
-(14 rows)
+(13 rows)
 
 :PREFIX
 SELECT time
@@ -2549,13 +2548,12 @@ QUERY PLAN
                Sort Key: _hyper_X_X_chunk."time"
                Sort Method: top-N heapsort 
                ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=3595 loops=1)
-                     Filter: ("time" < ('2000-01-08'::cstring)::timestamp with time zone)
+                     Vectorized Filter: (("time" > 'Fri Jan 07 00:00:00 2000 PST'::timestamp with time zone) AND ("time" < ('2000-01-08'::cstring)::timestamp with time zone))
                      Rows Removed by Filter: 6405
-                     Vectorized Filter: ("time" > 'Fri Jan 07 00:00:00 2000 PST'::timestamp with time zone)
                      ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=10 loops=1)
                            Filter: ((_ts_meta_max_1 > 'Fri Jan 07 00:00:00 2000 PST'::timestamp with time zone) AND (_ts_meta_min_1 < ('2000-01-08'::cstring)::timestamp with time zone))
                            Rows Removed by Filter: 20
-(14 rows)
+(13 rows)
 
 -- Disable hash aggregation to get a deterministic test output
 SET enable_hashagg = OFF;
@@ -2837,17 +2835,17 @@ QUERY PLAN
                Sort Key: _hyper_X_X_chunk."time" DESC
                Sort Method: top-N heapsort 
                ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=25190 loops=1)
-                     Filter: ("time" < (now() + '@ 1 mon'::interval))
+                     Vectorized Filter: ("time" < (now() + '@ 1 mon'::interval))
                      ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=30 loops=1)
          ->  Sort (never executed)
                Sort Key: _hyper_X_X_chunk."time" DESC
                ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (never executed)
-                     Filter: ("time" < (now() + '@ 1 mon'::interval))
+                     Vectorized Filter: ("time" < (now() + '@ 1 mon'::interval))
                      ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
          ->  Sort (never executed)
                Sort Key: _hyper_X_X_chunk."time" DESC
                ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (never executed)
-                     Filter: ("time" < (now() + '@ 1 mon'::interval))
+                     Vectorized Filter: ("time" < (now() + '@ 1 mon'::interval))
                      ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
 (20 rows)
 
@@ -2870,17 +2868,17 @@ QUERY PLAN
                Sort Key: _hyper_X_X_chunk."time" DESC
                Sort Method: top-N heapsort 
                ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=25190 loops=1)
-                     Filter: ("time" < now())
+                     Vectorized Filter: ("time" < now())
                      ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=30 loops=1)
          ->  Sort (never executed)
                Sort Key: _hyper_X_X_chunk."time" DESC
                ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (never executed)
-                     Filter: ("time" < now())
+                     Vectorized Filter: ("time" < now())
                      ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
          ->  Sort (never executed)
                Sort Key: _hyper_X_X_chunk."time" DESC
                ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (never executed)
-                     Filter: ("time" < now())
+                     Vectorized Filter: ("time" < now())
                      ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
 (20 rows)
 
@@ -3761,7 +3759,7 @@ QUERY PLAN
                      Sort Key: _hyper_X_X_chunk."time"
                      Sort Method: quicksort 
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=0 loops=1)
-                           Filter: ("time" > ('2000-01-08'::cstring)::timestamp with time zone)
+                           Vectorized Filter: ("time" > ('2000-01-08'::cstring)::timestamp with time zone)
                            ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=0 loops=1)
                                  Filter: (_ts_meta_max_1 > ('2000-01-08'::cstring)::timestamp with time zone)
                                  Rows Removed by Filter: 4
@@ -3769,7 +3767,7 @@ QUERY PLAN
                      Sort Key: _hyper_X_X_chunk."time"
                      Sort Method: quicksort 
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=0 loops=1)
-                           Filter: ("time" > ('2000-01-08'::cstring)::timestamp with time zone)
+                           Vectorized Filter: ("time" > ('2000-01-08'::cstring)::timestamp with time zone)
                            ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=0 loops=1)
                                  Filter: (_ts_meta_max_1 > ('2000-01-08'::cstring)::timestamp with time zone)
                                  Rows Removed by Filter: 12
@@ -3777,7 +3775,7 @@ QUERY PLAN
                      Sort Key: _hyper_X_X_chunk."time"
                      Sort Method: quicksort 
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=0 loops=1)
-                           Filter: ("time" > ('2000-01-08'::cstring)::timestamp with time zone)
+                           Vectorized Filter: ("time" > ('2000-01-08'::cstring)::timestamp with time zone)
                            ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=0 loops=1)
                                  Filter: (_ts_meta_max_1 > ('2000-01-08'::cstring)::timestamp with time zone)
                                  Rows Removed by Filter: 4
@@ -3787,7 +3785,7 @@ QUERY PLAN
                      Sort Key: _hyper_X_X_chunk."time"
                      Sort Method: top-N heapsort 
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=3357 loops=1)
-                           Filter: ("time" > ('2000-01-08'::cstring)::timestamp with time zone)
+                           Vectorized Filter: ("time" > ('2000-01-08'::cstring)::timestamp with time zone)
                            Rows Removed by Filter: 643
                            ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=4 loops=1)
                                  Filter: (_ts_meta_max_1 > ('2000-01-08'::cstring)::timestamp with time zone)
@@ -3796,7 +3794,7 @@ QUERY PLAN
                      Sort Key: _hyper_X_X_chunk."time"
                      Sort Method: top-N heapsort 
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=10071 loops=1)
-                           Filter: ("time" > ('2000-01-08'::cstring)::timestamp with time zone)
+                           Vectorized Filter: ("time" > ('2000-01-08'::cstring)::timestamp with time zone)
                            Rows Removed by Filter: 1929
                            ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=12 loops=1)
                                  Filter: (_ts_meta_max_1 > ('2000-01-08'::cstring)::timestamp with time zone)
@@ -3805,7 +3803,7 @@ QUERY PLAN
                      Sort Key: _hyper_X_X_chunk."time"
                      Sort Method: top-N heapsort 
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=3357 loops=1)
-                           Filter: ("time" > ('2000-01-08'::cstring)::timestamp with time zone)
+                           Vectorized Filter: ("time" > ('2000-01-08'::cstring)::timestamp with time zone)
                            Rows Removed by Filter: 643
                            ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=4 loops=1)
                                  Filter: (_ts_meta_max_1 > ('2000-01-08'::cstring)::timestamp with time zone)
@@ -3815,19 +3813,19 @@ QUERY PLAN
                ->  Sort (never executed)
                      Sort Key: _hyper_X_X_chunk."time"
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (never executed)
-                           Filter: ("time" > ('2000-01-08'::cstring)::timestamp with time zone)
+                           Vectorized Filter: ("time" > ('2000-01-08'::cstring)::timestamp with time zone)
                            ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
                                  Filter: (_ts_meta_max_1 > ('2000-01-08'::cstring)::timestamp with time zone)
                ->  Sort (never executed)
                      Sort Key: _hyper_X_X_chunk."time"
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (never executed)
-                           Filter: ("time" > ('2000-01-08'::cstring)::timestamp with time zone)
+                           Vectorized Filter: ("time" > ('2000-01-08'::cstring)::timestamp with time zone)
                            ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
                                  Filter: (_ts_meta_max_1 > ('2000-01-08'::cstring)::timestamp with time zone)
                ->  Sort (never executed)
                      Sort Key: _hyper_X_X_chunk."time"
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (never executed)
-                           Filter: ("time" > ('2000-01-08'::cstring)::timestamp with time zone)
+                           Vectorized Filter: ("time" > ('2000-01-08'::cstring)::timestamp with time zone)
                            ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
                                  Filter: (_ts_meta_max_1 > ('2000-01-08'::cstring)::timestamp with time zone)
 (78 rows)
@@ -3848,21 +3846,21 @@ QUERY PLAN
                      Sort Key: _hyper_X_X_chunk."time"
                      Sort Method: top-N heapsort 
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=3598 loops=1)
-                           Filter: ("time" < ('2000-01-08'::cstring)::timestamp with time zone)
+                           Vectorized Filter: ("time" < ('2000-01-08'::cstring)::timestamp with time zone)
                            ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=4 loops=1)
                                  Filter: (_ts_meta_min_1 < ('2000-01-08'::cstring)::timestamp with time zone)
                ->  Sort (actual rows=1 loops=1)
                      Sort Key: _hyper_X_X_chunk."time"
                      Sort Method: top-N heapsort 
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=10794 loops=1)
-                           Filter: ("time" < ('2000-01-08'::cstring)::timestamp with time zone)
+                           Vectorized Filter: ("time" < ('2000-01-08'::cstring)::timestamp with time zone)
                            ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=12 loops=1)
                                  Filter: (_ts_meta_min_1 < ('2000-01-08'::cstring)::timestamp with time zone)
                ->  Sort (actual rows=1 loops=1)
                      Sort Key: _hyper_X_X_chunk."time"
                      Sort Method: top-N heapsort 
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=3598 loops=1)
-                           Filter: ("time" < ('2000-01-08'::cstring)::timestamp with time zone)
+                           Vectorized Filter: ("time" < ('2000-01-08'::cstring)::timestamp with time zone)
                            ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=4 loops=1)
                                  Filter: (_ts_meta_min_1 < ('2000-01-08'::cstring)::timestamp with time zone)
          ->  Merge Append (never executed)
@@ -3870,19 +3868,19 @@ QUERY PLAN
                ->  Sort (never executed)
                      Sort Key: _hyper_X_X_chunk."time"
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (never executed)
-                           Filter: ("time" < ('2000-01-08'::cstring)::timestamp with time zone)
+                           Vectorized Filter: ("time" < ('2000-01-08'::cstring)::timestamp with time zone)
                            ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
                                  Filter: (_ts_meta_min_1 < ('2000-01-08'::cstring)::timestamp with time zone)
                ->  Sort (never executed)
                      Sort Key: _hyper_X_X_chunk."time"
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (never executed)
-                           Filter: ("time" < ('2000-01-08'::cstring)::timestamp with time zone)
+                           Vectorized Filter: ("time" < ('2000-01-08'::cstring)::timestamp with time zone)
                            ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
                                  Filter: (_ts_meta_min_1 < ('2000-01-08'::cstring)::timestamp with time zone)
                ->  Sort (never executed)
                      Sort Key: _hyper_X_X_chunk."time"
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (never executed)
-                           Filter: ("time" < ('2000-01-08'::cstring)::timestamp with time zone)
+                           Vectorized Filter: ("time" < ('2000-01-08'::cstring)::timestamp with time zone)
                            ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
                                  Filter: (_ts_meta_min_1 < ('2000-01-08'::cstring)::timestamp with time zone)
          ->  Merge Append (never executed)
@@ -3890,19 +3888,19 @@ QUERY PLAN
                ->  Sort (never executed)
                      Sort Key: _hyper_X_X_chunk."time"
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (never executed)
-                           Filter: ("time" < ('2000-01-08'::cstring)::timestamp with time zone)
+                           Vectorized Filter: ("time" < ('2000-01-08'::cstring)::timestamp with time zone)
                            ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
                                  Filter: (_ts_meta_min_1 < ('2000-01-08'::cstring)::timestamp with time zone)
                ->  Sort (never executed)
                      Sort Key: _hyper_X_X_chunk."time"
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (never executed)
-                           Filter: ("time" < ('2000-01-08'::cstring)::timestamp with time zone)
+                           Vectorized Filter: ("time" < ('2000-01-08'::cstring)::timestamp with time zone)
                            ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
                                  Filter: (_ts_meta_min_1 < ('2000-01-08'::cstring)::timestamp with time zone)
                ->  Sort (never executed)
                      Sort Key: _hyper_X_X_chunk."time"
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (never executed)
-                           Filter: ("time" < ('2000-01-08'::cstring)::timestamp with time zone)
+                           Vectorized Filter: ("time" < ('2000-01-08'::cstring)::timestamp with time zone)
                            ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
                                  Filter: (_ts_meta_min_1 < ('2000-01-08'::cstring)::timestamp with time zone)
 (66 rows)
@@ -3925,8 +3923,7 @@ QUERY PLAN
                      Sort Key: _hyper_X_X_chunk."time"
                      Sort Method: quicksort 
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=0 loops=1)
-                           Filter: ("time" > ('2000-01-08'::cstring)::timestamp with time zone)
-                           Vectorized Filter: ("time" < 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone)
+                           Vectorized Filter: (("time" < 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone) AND ("time" > ('2000-01-08'::cstring)::timestamp with time zone))
                            ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=0 loops=1)
                                  Filter: ((_ts_meta_min_1 < 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone) AND (_ts_meta_max_1 > ('2000-01-08'::cstring)::timestamp with time zone))
                                  Rows Removed by Filter: 4
@@ -3934,8 +3931,7 @@ QUERY PLAN
                      Sort Key: _hyper_X_X_chunk."time"
                      Sort Method: quicksort 
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=0 loops=1)
-                           Filter: ("time" > ('2000-01-08'::cstring)::timestamp with time zone)
-                           Vectorized Filter: ("time" < 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone)
+                           Vectorized Filter: (("time" < 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone) AND ("time" > ('2000-01-08'::cstring)::timestamp with time zone))
                            ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=0 loops=1)
                                  Filter: ((_ts_meta_min_1 < 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone) AND (_ts_meta_max_1 > ('2000-01-08'::cstring)::timestamp with time zone))
                                  Rows Removed by Filter: 12
@@ -3943,8 +3939,7 @@ QUERY PLAN
                      Sort Key: _hyper_X_X_chunk."time"
                      Sort Method: quicksort 
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=0 loops=1)
-                           Filter: ("time" > ('2000-01-08'::cstring)::timestamp with time zone)
-                           Vectorized Filter: ("time" < 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone)
+                           Vectorized Filter: (("time" < 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone) AND ("time" > ('2000-01-08'::cstring)::timestamp with time zone))
                            ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=0 loops=1)
                                  Filter: ((_ts_meta_min_1 < 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone) AND (_ts_meta_max_1 > ('2000-01-08'::cstring)::timestamp with time zone))
                                  Rows Removed by Filter: 4
@@ -3954,9 +3949,8 @@ QUERY PLAN
                      Sort Key: _hyper_X_X_chunk."time"
                      Sort Method: top-N heapsort 
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=1439 loops=1)
-                           Filter: ("time" > ('2000-01-08'::cstring)::timestamp with time zone)
+                           Vectorized Filter: (("time" < 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone) AND ("time" > ('2000-01-08'::cstring)::timestamp with time zone))
                            Rows Removed by Filter: 1561
-                           Vectorized Filter: ("time" < 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone)
                            ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=3 loops=1)
                                  Filter: ((_ts_meta_min_1 < 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone) AND (_ts_meta_max_1 > ('2000-01-08'::cstring)::timestamp with time zone))
                                  Rows Removed by Filter: 3
@@ -3964,9 +3958,8 @@ QUERY PLAN
                      Sort Key: _hyper_X_X_chunk."time"
                      Sort Method: top-N heapsort 
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=4317 loops=1)
-                           Filter: ("time" > ('2000-01-08'::cstring)::timestamp with time zone)
+                           Vectorized Filter: (("time" < 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone) AND ("time" > ('2000-01-08'::cstring)::timestamp with time zone))
                            Rows Removed by Filter: 4683
-                           Vectorized Filter: ("time" < 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone)
                            ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=9 loops=1)
                                  Filter: ((_ts_meta_min_1 < 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone) AND (_ts_meta_max_1 > ('2000-01-08'::cstring)::timestamp with time zone))
                                  Rows Removed by Filter: 9
@@ -3974,13 +3967,12 @@ QUERY PLAN
                      Sort Key: _hyper_X_X_chunk."time"
                      Sort Method: top-N heapsort 
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=1439 loops=1)
-                           Filter: ("time" > ('2000-01-08'::cstring)::timestamp with time zone)
+                           Vectorized Filter: (("time" < 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone) AND ("time" > ('2000-01-08'::cstring)::timestamp with time zone))
                            Rows Removed by Filter: 1561
-                           Vectorized Filter: ("time" < 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone)
                            ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=3 loops=1)
                                  Filter: ((_ts_meta_min_1 < 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone) AND (_ts_meta_max_1 > ('2000-01-08'::cstring)::timestamp with time zone))
                                  Rows Removed by Filter: 3
-(64 rows)
+(58 rows)
 
 :PREFIX
 SELECT time
@@ -3999,9 +3991,8 @@ QUERY PLAN
                      Sort Key: _hyper_X_X_chunk."time"
                      Sort Method: top-N heapsort 
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=719 loops=1)
-                           Filter: ("time" < ('2000-01-08'::cstring)::timestamp with time zone)
+                           Vectorized Filter: (("time" > 'Fri Jan 07 00:00:00 2000 PST'::timestamp with time zone) AND ("time" < ('2000-01-08'::cstring)::timestamp with time zone))
                            Rows Removed by Filter: 1281
-                           Vectorized Filter: ("time" > 'Fri Jan 07 00:00:00 2000 PST'::timestamp with time zone)
                            ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=2 loops=1)
                                  Filter: ((_ts_meta_max_1 > 'Fri Jan 07 00:00:00 2000 PST'::timestamp with time zone) AND (_ts_meta_min_1 < ('2000-01-08'::cstring)::timestamp with time zone))
                                  Rows Removed by Filter: 4
@@ -4009,9 +4000,8 @@ QUERY PLAN
                      Sort Key: _hyper_X_X_chunk."time"
                      Sort Method: top-N heapsort 
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=2157 loops=1)
-                           Filter: ("time" < ('2000-01-08'::cstring)::timestamp with time zone)
+                           Vectorized Filter: (("time" > 'Fri Jan 07 00:00:00 2000 PST'::timestamp with time zone) AND ("time" < ('2000-01-08'::cstring)::timestamp with time zone))
                            Rows Removed by Filter: 3843
-                           Vectorized Filter: ("time" > 'Fri Jan 07 00:00:00 2000 PST'::timestamp with time zone)
                            ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=6 loops=1)
                                  Filter: ((_ts_meta_max_1 > 'Fri Jan 07 00:00:00 2000 PST'::timestamp with time zone) AND (_ts_meta_min_1 < ('2000-01-08'::cstring)::timestamp with time zone))
                                  Rows Removed by Filter: 12
@@ -4019,9 +4009,8 @@ QUERY PLAN
                      Sort Key: _hyper_X_X_chunk."time"
                      Sort Method: top-N heapsort 
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=719 loops=1)
-                           Filter: ("time" < ('2000-01-08'::cstring)::timestamp with time zone)
+                           Vectorized Filter: (("time" > 'Fri Jan 07 00:00:00 2000 PST'::timestamp with time zone) AND ("time" < ('2000-01-08'::cstring)::timestamp with time zone))
                            Rows Removed by Filter: 1281
-                           Vectorized Filter: ("time" > 'Fri Jan 07 00:00:00 2000 PST'::timestamp with time zone)
                            ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=2 loops=1)
                                  Filter: ((_ts_meta_max_1 > 'Fri Jan 07 00:00:00 2000 PST'::timestamp with time zone) AND (_ts_meta_min_1 < ('2000-01-08'::cstring)::timestamp with time zone))
                                  Rows Removed by Filter: 4
@@ -4030,25 +4019,22 @@ QUERY PLAN
                ->  Sort (never executed)
                      Sort Key: _hyper_X_X_chunk."time"
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (never executed)
-                           Filter: ("time" < ('2000-01-08'::cstring)::timestamp with time zone)
-                           Vectorized Filter: ("time" > 'Fri Jan 07 00:00:00 2000 PST'::timestamp with time zone)
+                           Vectorized Filter: (("time" > 'Fri Jan 07 00:00:00 2000 PST'::timestamp with time zone) AND ("time" < ('2000-01-08'::cstring)::timestamp with time zone))
                            ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
                                  Filter: ((_ts_meta_max_1 > 'Fri Jan 07 00:00:00 2000 PST'::timestamp with time zone) AND (_ts_meta_min_1 < ('2000-01-08'::cstring)::timestamp with time zone))
                ->  Sort (never executed)
                      Sort Key: _hyper_X_X_chunk."time"
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (never executed)
-                           Filter: ("time" < ('2000-01-08'::cstring)::timestamp with time zone)
-                           Vectorized Filter: ("time" > 'Fri Jan 07 00:00:00 2000 PST'::timestamp with time zone)
+                           Vectorized Filter: (("time" > 'Fri Jan 07 00:00:00 2000 PST'::timestamp with time zone) AND ("time" < ('2000-01-08'::cstring)::timestamp with time zone))
                            ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
                                  Filter: ((_ts_meta_max_1 > 'Fri Jan 07 00:00:00 2000 PST'::timestamp with time zone) AND (_ts_meta_min_1 < ('2000-01-08'::cstring)::timestamp with time zone))
                ->  Sort (never executed)
                      Sort Key: _hyper_X_X_chunk."time"
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (never executed)
-                           Filter: ("time" < ('2000-01-08'::cstring)::timestamp with time zone)
-                           Vectorized Filter: ("time" > 'Fri Jan 07 00:00:00 2000 PST'::timestamp with time zone)
+                           Vectorized Filter: (("time" > 'Fri Jan 07 00:00:00 2000 PST'::timestamp with time zone) AND ("time" < ('2000-01-08'::cstring)::timestamp with time zone))
                            ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
                                  Filter: ((_ts_meta_max_1 > 'Fri Jan 07 00:00:00 2000 PST'::timestamp with time zone) AND (_ts_meta_min_1 < ('2000-01-08'::cstring)::timestamp with time zone))
-(58 rows)
+(52 rows)
 
 -- Disable hash aggregation to get a deterministic test output
 SET enable_hashagg = OFF;
@@ -4569,53 +4555,53 @@ QUERY PLAN
                      Sort Key: _hyper_X_X_chunk."time" DESC
                      Sort Method: top-N heapsort 
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=5038 loops=1)
-                           Filter: ("time" < (now() + '@ 1 mon'::interval))
+                           Vectorized Filter: ("time" < (now() + '@ 1 mon'::interval))
                            ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=6 loops=1)
                ->  Sort (actual rows=1 loops=1)
                      Sort Key: _hyper_X_X_chunk."time" DESC
                      Sort Method: top-N heapsort 
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=15114 loops=1)
-                           Filter: ("time" < (now() + '@ 1 mon'::interval))
+                           Vectorized Filter: ("time" < (now() + '@ 1 mon'::interval))
                            ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=18 loops=1)
                ->  Sort (actual rows=1 loops=1)
                      Sort Key: _hyper_X_X_chunk."time" DESC
                      Sort Method: top-N heapsort 
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=5038 loops=1)
-                           Filter: ("time" < (now() + '@ 1 mon'::interval))
+                           Vectorized Filter: ("time" < (now() + '@ 1 mon'::interval))
                            ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=6 loops=1)
          ->  Merge Append (never executed)
                Sort Key: _hyper_X_X_chunk."time" DESC
                ->  Sort (never executed)
                      Sort Key: _hyper_X_X_chunk."time" DESC
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (never executed)
-                           Filter: ("time" < (now() + '@ 1 mon'::interval))
+                           Vectorized Filter: ("time" < (now() + '@ 1 mon'::interval))
                            ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
                ->  Sort (never executed)
                      Sort Key: _hyper_X_X_chunk."time" DESC
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (never executed)
-                           Filter: ("time" < (now() + '@ 1 mon'::interval))
+                           Vectorized Filter: ("time" < (now() + '@ 1 mon'::interval))
                            ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
                ->  Sort (never executed)
                      Sort Key: _hyper_X_X_chunk."time" DESC
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (never executed)
-                           Filter: ("time" < (now() + '@ 1 mon'::interval))
+                           Vectorized Filter: ("time" < (now() + '@ 1 mon'::interval))
                            ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
          ->  Merge Append (never executed)
                Sort Key: _hyper_X_X_chunk."time" DESC
                ->  Sort (never executed)
                      Sort Key: _hyper_X_X_chunk."time" DESC
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (never executed)
-                           Filter: ("time" < (now() + '@ 1 mon'::interval))
+                           Vectorized Filter: ("time" < (now() + '@ 1 mon'::interval))
                            ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
                ->  Sort (never executed)
                      Sort Key: _hyper_X_X_chunk."time" DESC
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (never executed)
-                           Filter: ("time" < (now() + '@ 1 mon'::interval))
+                           Vectorized Filter: ("time" < (now() + '@ 1 mon'::interval))
                            ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
                ->  Sort (never executed)
                      Sort Key: _hyper_X_X_chunk."time" DESC
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (never executed)
-                           Filter: ("time" < (now() + '@ 1 mon'::interval))
+                           Vectorized Filter: ("time" < (now() + '@ 1 mon'::interval))
                            ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
 (57 rows)
 
@@ -4639,53 +4625,53 @@ QUERY PLAN
                      Sort Key: _hyper_X_X_chunk."time" DESC
                      Sort Method: top-N heapsort 
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=5038 loops=1)
-                           Filter: ("time" < now())
+                           Vectorized Filter: ("time" < now())
                            ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=6 loops=1)
                ->  Sort (actual rows=60 loops=1)
                      Sort Key: _hyper_X_X_chunk."time" DESC
                      Sort Method: top-N heapsort 
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=15114 loops=1)
-                           Filter: ("time" < now())
+                           Vectorized Filter: ("time" < now())
                            ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=18 loops=1)
                ->  Sort (actual rows=21 loops=1)
                      Sort Key: _hyper_X_X_chunk."time" DESC
                      Sort Method: top-N heapsort 
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=5038 loops=1)
-                           Filter: ("time" < now())
+                           Vectorized Filter: ("time" < now())
                            ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=6 loops=1)
          ->  Merge Append (never executed)
                Sort Key: _hyper_X_X_chunk."time" DESC
                ->  Sort (never executed)
                      Sort Key: _hyper_X_X_chunk."time" DESC
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (never executed)
-                           Filter: ("time" < now())
+                           Vectorized Filter: ("time" < now())
                            ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
                ->  Sort (never executed)
                      Sort Key: _hyper_X_X_chunk."time" DESC
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (never executed)
-                           Filter: ("time" < now())
+                           Vectorized Filter: ("time" < now())
                            ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
                ->  Sort (never executed)
                      Sort Key: _hyper_X_X_chunk."time" DESC
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (never executed)
-                           Filter: ("time" < now())
+                           Vectorized Filter: ("time" < now())
                            ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
          ->  Merge Append (never executed)
                Sort Key: _hyper_X_X_chunk."time" DESC
                ->  Sort (never executed)
                      Sort Key: _hyper_X_X_chunk."time" DESC
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (never executed)
-                           Filter: ("time" < now())
+                           Vectorized Filter: ("time" < now())
                            ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
                ->  Sort (never executed)
                      Sort Key: _hyper_X_X_chunk."time" DESC
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (never executed)
-                           Filter: ("time" < now())
+                           Vectorized Filter: ("time" < now())
                            ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
                ->  Sort (never executed)
                      Sort Key: _hyper_X_X_chunk."time" DESC
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (never executed)
-                           Filter: ("time" < now())
+                           Vectorized Filter: ("time" < now())
                            ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
 (57 rows)
 

--- a/tsl/test/shared/expected/ordered_append-14.out
+++ b/tsl/test/shared/expected/ordered_append-14.out
@@ -2469,7 +2469,7 @@ QUERY PLAN
                Sort Key: _hyper_X_X_chunk."time"
                Sort Method: top-N heapsort 
                ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=16785 loops=1)
-                     Filter: ("time" > ('2000-01-08'::cstring)::timestamp with time zone)
+                     Vectorized Filter: ("time" > ('2000-01-08'::cstring)::timestamp with time zone)
                      Rows Removed by Filter: 3215
                      ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=20 loops=1)
                            Filter: (_ts_meta_max_1 > ('2000-01-08'::cstring)::timestamp with time zone)
@@ -2477,7 +2477,7 @@ QUERY PLAN
          ->  Sort (never executed)
                Sort Key: _hyper_X_X_chunk."time"
                ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (never executed)
-                     Filter: ("time" > ('2000-01-08'::cstring)::timestamp with time zone)
+                     Vectorized Filter: ("time" > ('2000-01-08'::cstring)::timestamp with time zone)
                      ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
                            Filter: (_ts_meta_max_1 > ('2000-01-08'::cstring)::timestamp with time zone)
 (19 rows)
@@ -2497,13 +2497,13 @@ QUERY PLAN
                Sort Key: _hyper_X_X_chunk."time"
                Sort Method: top-N heapsort 
                ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=17990 loops=1)
-                     Filter: ("time" < ('2000-01-08'::cstring)::timestamp with time zone)
+                     Vectorized Filter: ("time" < ('2000-01-08'::cstring)::timestamp with time zone)
                      ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=20 loops=1)
                            Filter: (_ts_meta_min_1 < ('2000-01-08'::cstring)::timestamp with time zone)
          ->  Sort (never executed)
                Sort Key: _hyper_X_X_chunk."time"
                ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (never executed)
-                     Filter: ("time" < ('2000-01-08'::cstring)::timestamp with time zone)
+                     Vectorized Filter: ("time" < ('2000-01-08'::cstring)::timestamp with time zone)
                      ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
                            Filter: (_ts_meta_min_1 < ('2000-01-08'::cstring)::timestamp with time zone)
 (17 rows)
@@ -2525,13 +2525,12 @@ QUERY PLAN
                Sort Key: _hyper_X_X_chunk."time"
                Sort Method: top-N heapsort 
                ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=7195 loops=1)
-                     Filter: ("time" > ('2000-01-08'::cstring)::timestamp with time zone)
+                     Vectorized Filter: (("time" < 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone) AND ("time" > ('2000-01-08'::cstring)::timestamp with time zone))
                      Rows Removed by Filter: 7805
-                     Vectorized Filter: ("time" < 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone)
                      ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=15 loops=1)
                            Filter: ((_ts_meta_min_1 < 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone) AND (_ts_meta_max_1 > ('2000-01-08'::cstring)::timestamp with time zone))
                            Rows Removed by Filter: 15
-(14 rows)
+(13 rows)
 
 :PREFIX
 SELECT time
@@ -2549,13 +2548,12 @@ QUERY PLAN
                Sort Key: _hyper_X_X_chunk."time"
                Sort Method: top-N heapsort 
                ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=3595 loops=1)
-                     Filter: ("time" < ('2000-01-08'::cstring)::timestamp with time zone)
+                     Vectorized Filter: (("time" > 'Fri Jan 07 00:00:00 2000 PST'::timestamp with time zone) AND ("time" < ('2000-01-08'::cstring)::timestamp with time zone))
                      Rows Removed by Filter: 6405
-                     Vectorized Filter: ("time" > 'Fri Jan 07 00:00:00 2000 PST'::timestamp with time zone)
                      ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=10 loops=1)
                            Filter: ((_ts_meta_max_1 > 'Fri Jan 07 00:00:00 2000 PST'::timestamp with time zone) AND (_ts_meta_min_1 < ('2000-01-08'::cstring)::timestamp with time zone))
                            Rows Removed by Filter: 20
-(14 rows)
+(13 rows)
 
 -- Disable hash aggregation to get a deterministic test output
 SET enable_hashagg = OFF;
@@ -2837,17 +2835,17 @@ QUERY PLAN
                Sort Key: _hyper_X_X_chunk."time" DESC
                Sort Method: top-N heapsort 
                ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=25190 loops=1)
-                     Filter: ("time" < (now() + '@ 1 mon'::interval))
+                     Vectorized Filter: ("time" < (now() + '@ 1 mon'::interval))
                      ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=30 loops=1)
          ->  Sort (never executed)
                Sort Key: _hyper_X_X_chunk."time" DESC
                ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (never executed)
-                     Filter: ("time" < (now() + '@ 1 mon'::interval))
+                     Vectorized Filter: ("time" < (now() + '@ 1 mon'::interval))
                      ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
          ->  Sort (never executed)
                Sort Key: _hyper_X_X_chunk."time" DESC
                ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (never executed)
-                     Filter: ("time" < (now() + '@ 1 mon'::interval))
+                     Vectorized Filter: ("time" < (now() + '@ 1 mon'::interval))
                      ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
 (20 rows)
 
@@ -2870,17 +2868,17 @@ QUERY PLAN
                Sort Key: _hyper_X_X_chunk."time" DESC
                Sort Method: top-N heapsort 
                ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=25190 loops=1)
-                     Filter: ("time" < now())
+                     Vectorized Filter: ("time" < now())
                      ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=30 loops=1)
          ->  Sort (never executed)
                Sort Key: _hyper_X_X_chunk."time" DESC
                ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (never executed)
-                     Filter: ("time" < now())
+                     Vectorized Filter: ("time" < now())
                      ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
          ->  Sort (never executed)
                Sort Key: _hyper_X_X_chunk."time" DESC
                ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (never executed)
-                     Filter: ("time" < now())
+                     Vectorized Filter: ("time" < now())
                      ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
 (20 rows)
 
@@ -3761,7 +3759,7 @@ QUERY PLAN
                      Sort Key: _hyper_X_X_chunk."time"
                      Sort Method: quicksort 
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=0 loops=1)
-                           Filter: ("time" > ('2000-01-08'::cstring)::timestamp with time zone)
+                           Vectorized Filter: ("time" > ('2000-01-08'::cstring)::timestamp with time zone)
                            ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=0 loops=1)
                                  Filter: (_ts_meta_max_1 > ('2000-01-08'::cstring)::timestamp with time zone)
                                  Rows Removed by Filter: 4
@@ -3769,7 +3767,7 @@ QUERY PLAN
                      Sort Key: _hyper_X_X_chunk."time"
                      Sort Method: quicksort 
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=0 loops=1)
-                           Filter: ("time" > ('2000-01-08'::cstring)::timestamp with time zone)
+                           Vectorized Filter: ("time" > ('2000-01-08'::cstring)::timestamp with time zone)
                            ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=0 loops=1)
                                  Filter: (_ts_meta_max_1 > ('2000-01-08'::cstring)::timestamp with time zone)
                                  Rows Removed by Filter: 12
@@ -3777,7 +3775,7 @@ QUERY PLAN
                      Sort Key: _hyper_X_X_chunk."time"
                      Sort Method: quicksort 
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=0 loops=1)
-                           Filter: ("time" > ('2000-01-08'::cstring)::timestamp with time zone)
+                           Vectorized Filter: ("time" > ('2000-01-08'::cstring)::timestamp with time zone)
                            ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=0 loops=1)
                                  Filter: (_ts_meta_max_1 > ('2000-01-08'::cstring)::timestamp with time zone)
                                  Rows Removed by Filter: 4
@@ -3787,7 +3785,7 @@ QUERY PLAN
                      Sort Key: _hyper_X_X_chunk."time"
                      Sort Method: top-N heapsort 
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=3357 loops=1)
-                           Filter: ("time" > ('2000-01-08'::cstring)::timestamp with time zone)
+                           Vectorized Filter: ("time" > ('2000-01-08'::cstring)::timestamp with time zone)
                            Rows Removed by Filter: 643
                            ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=4 loops=1)
                                  Filter: (_ts_meta_max_1 > ('2000-01-08'::cstring)::timestamp with time zone)
@@ -3796,7 +3794,7 @@ QUERY PLAN
                      Sort Key: _hyper_X_X_chunk."time"
                      Sort Method: top-N heapsort 
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=10071 loops=1)
-                           Filter: ("time" > ('2000-01-08'::cstring)::timestamp with time zone)
+                           Vectorized Filter: ("time" > ('2000-01-08'::cstring)::timestamp with time zone)
                            Rows Removed by Filter: 1929
                            ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=12 loops=1)
                                  Filter: (_ts_meta_max_1 > ('2000-01-08'::cstring)::timestamp with time zone)
@@ -3805,7 +3803,7 @@ QUERY PLAN
                      Sort Key: _hyper_X_X_chunk."time"
                      Sort Method: top-N heapsort 
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=3357 loops=1)
-                           Filter: ("time" > ('2000-01-08'::cstring)::timestamp with time zone)
+                           Vectorized Filter: ("time" > ('2000-01-08'::cstring)::timestamp with time zone)
                            Rows Removed by Filter: 643
                            ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=4 loops=1)
                                  Filter: (_ts_meta_max_1 > ('2000-01-08'::cstring)::timestamp with time zone)
@@ -3815,19 +3813,19 @@ QUERY PLAN
                ->  Sort (never executed)
                      Sort Key: _hyper_X_X_chunk."time"
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (never executed)
-                           Filter: ("time" > ('2000-01-08'::cstring)::timestamp with time zone)
+                           Vectorized Filter: ("time" > ('2000-01-08'::cstring)::timestamp with time zone)
                            ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
                                  Filter: (_ts_meta_max_1 > ('2000-01-08'::cstring)::timestamp with time zone)
                ->  Sort (never executed)
                      Sort Key: _hyper_X_X_chunk."time"
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (never executed)
-                           Filter: ("time" > ('2000-01-08'::cstring)::timestamp with time zone)
+                           Vectorized Filter: ("time" > ('2000-01-08'::cstring)::timestamp with time zone)
                            ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
                                  Filter: (_ts_meta_max_1 > ('2000-01-08'::cstring)::timestamp with time zone)
                ->  Sort (never executed)
                      Sort Key: _hyper_X_X_chunk."time"
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (never executed)
-                           Filter: ("time" > ('2000-01-08'::cstring)::timestamp with time zone)
+                           Vectorized Filter: ("time" > ('2000-01-08'::cstring)::timestamp with time zone)
                            ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
                                  Filter: (_ts_meta_max_1 > ('2000-01-08'::cstring)::timestamp with time zone)
 (78 rows)
@@ -3848,21 +3846,21 @@ QUERY PLAN
                      Sort Key: _hyper_X_X_chunk."time"
                      Sort Method: top-N heapsort 
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=3598 loops=1)
-                           Filter: ("time" < ('2000-01-08'::cstring)::timestamp with time zone)
+                           Vectorized Filter: ("time" < ('2000-01-08'::cstring)::timestamp with time zone)
                            ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=4 loops=1)
                                  Filter: (_ts_meta_min_1 < ('2000-01-08'::cstring)::timestamp with time zone)
                ->  Sort (actual rows=1 loops=1)
                      Sort Key: _hyper_X_X_chunk."time"
                      Sort Method: top-N heapsort 
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=10794 loops=1)
-                           Filter: ("time" < ('2000-01-08'::cstring)::timestamp with time zone)
+                           Vectorized Filter: ("time" < ('2000-01-08'::cstring)::timestamp with time zone)
                            ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=12 loops=1)
                                  Filter: (_ts_meta_min_1 < ('2000-01-08'::cstring)::timestamp with time zone)
                ->  Sort (actual rows=1 loops=1)
                      Sort Key: _hyper_X_X_chunk."time"
                      Sort Method: top-N heapsort 
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=3598 loops=1)
-                           Filter: ("time" < ('2000-01-08'::cstring)::timestamp with time zone)
+                           Vectorized Filter: ("time" < ('2000-01-08'::cstring)::timestamp with time zone)
                            ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=4 loops=1)
                                  Filter: (_ts_meta_min_1 < ('2000-01-08'::cstring)::timestamp with time zone)
          ->  Merge Append (never executed)
@@ -3870,19 +3868,19 @@ QUERY PLAN
                ->  Sort (never executed)
                      Sort Key: _hyper_X_X_chunk."time"
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (never executed)
-                           Filter: ("time" < ('2000-01-08'::cstring)::timestamp with time zone)
+                           Vectorized Filter: ("time" < ('2000-01-08'::cstring)::timestamp with time zone)
                            ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
                                  Filter: (_ts_meta_min_1 < ('2000-01-08'::cstring)::timestamp with time zone)
                ->  Sort (never executed)
                      Sort Key: _hyper_X_X_chunk."time"
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (never executed)
-                           Filter: ("time" < ('2000-01-08'::cstring)::timestamp with time zone)
+                           Vectorized Filter: ("time" < ('2000-01-08'::cstring)::timestamp with time zone)
                            ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
                                  Filter: (_ts_meta_min_1 < ('2000-01-08'::cstring)::timestamp with time zone)
                ->  Sort (never executed)
                      Sort Key: _hyper_X_X_chunk."time"
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (never executed)
-                           Filter: ("time" < ('2000-01-08'::cstring)::timestamp with time zone)
+                           Vectorized Filter: ("time" < ('2000-01-08'::cstring)::timestamp with time zone)
                            ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
                                  Filter: (_ts_meta_min_1 < ('2000-01-08'::cstring)::timestamp with time zone)
          ->  Merge Append (never executed)
@@ -3890,19 +3888,19 @@ QUERY PLAN
                ->  Sort (never executed)
                      Sort Key: _hyper_X_X_chunk."time"
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (never executed)
-                           Filter: ("time" < ('2000-01-08'::cstring)::timestamp with time zone)
+                           Vectorized Filter: ("time" < ('2000-01-08'::cstring)::timestamp with time zone)
                            ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
                                  Filter: (_ts_meta_min_1 < ('2000-01-08'::cstring)::timestamp with time zone)
                ->  Sort (never executed)
                      Sort Key: _hyper_X_X_chunk."time"
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (never executed)
-                           Filter: ("time" < ('2000-01-08'::cstring)::timestamp with time zone)
+                           Vectorized Filter: ("time" < ('2000-01-08'::cstring)::timestamp with time zone)
                            ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
                                  Filter: (_ts_meta_min_1 < ('2000-01-08'::cstring)::timestamp with time zone)
                ->  Sort (never executed)
                      Sort Key: _hyper_X_X_chunk."time"
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (never executed)
-                           Filter: ("time" < ('2000-01-08'::cstring)::timestamp with time zone)
+                           Vectorized Filter: ("time" < ('2000-01-08'::cstring)::timestamp with time zone)
                            ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
                                  Filter: (_ts_meta_min_1 < ('2000-01-08'::cstring)::timestamp with time zone)
 (66 rows)
@@ -3925,8 +3923,7 @@ QUERY PLAN
                      Sort Key: _hyper_X_X_chunk."time"
                      Sort Method: quicksort 
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=0 loops=1)
-                           Filter: ("time" > ('2000-01-08'::cstring)::timestamp with time zone)
-                           Vectorized Filter: ("time" < 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone)
+                           Vectorized Filter: (("time" < 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone) AND ("time" > ('2000-01-08'::cstring)::timestamp with time zone))
                            ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=0 loops=1)
                                  Filter: ((_ts_meta_min_1 < 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone) AND (_ts_meta_max_1 > ('2000-01-08'::cstring)::timestamp with time zone))
                                  Rows Removed by Filter: 4
@@ -3934,8 +3931,7 @@ QUERY PLAN
                      Sort Key: _hyper_X_X_chunk."time"
                      Sort Method: quicksort 
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=0 loops=1)
-                           Filter: ("time" > ('2000-01-08'::cstring)::timestamp with time zone)
-                           Vectorized Filter: ("time" < 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone)
+                           Vectorized Filter: (("time" < 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone) AND ("time" > ('2000-01-08'::cstring)::timestamp with time zone))
                            ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=0 loops=1)
                                  Filter: ((_ts_meta_min_1 < 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone) AND (_ts_meta_max_1 > ('2000-01-08'::cstring)::timestamp with time zone))
                                  Rows Removed by Filter: 12
@@ -3943,8 +3939,7 @@ QUERY PLAN
                      Sort Key: _hyper_X_X_chunk."time"
                      Sort Method: quicksort 
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=0 loops=1)
-                           Filter: ("time" > ('2000-01-08'::cstring)::timestamp with time zone)
-                           Vectorized Filter: ("time" < 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone)
+                           Vectorized Filter: (("time" < 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone) AND ("time" > ('2000-01-08'::cstring)::timestamp with time zone))
                            ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=0 loops=1)
                                  Filter: ((_ts_meta_min_1 < 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone) AND (_ts_meta_max_1 > ('2000-01-08'::cstring)::timestamp with time zone))
                                  Rows Removed by Filter: 4
@@ -3954,9 +3949,8 @@ QUERY PLAN
                      Sort Key: _hyper_X_X_chunk."time"
                      Sort Method: top-N heapsort 
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=1439 loops=1)
-                           Filter: ("time" > ('2000-01-08'::cstring)::timestamp with time zone)
+                           Vectorized Filter: (("time" < 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone) AND ("time" > ('2000-01-08'::cstring)::timestamp with time zone))
                            Rows Removed by Filter: 1561
-                           Vectorized Filter: ("time" < 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone)
                            ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=3 loops=1)
                                  Filter: ((_ts_meta_min_1 < 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone) AND (_ts_meta_max_1 > ('2000-01-08'::cstring)::timestamp with time zone))
                                  Rows Removed by Filter: 3
@@ -3964,9 +3958,8 @@ QUERY PLAN
                      Sort Key: _hyper_X_X_chunk."time"
                      Sort Method: top-N heapsort 
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=4317 loops=1)
-                           Filter: ("time" > ('2000-01-08'::cstring)::timestamp with time zone)
+                           Vectorized Filter: (("time" < 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone) AND ("time" > ('2000-01-08'::cstring)::timestamp with time zone))
                            Rows Removed by Filter: 4683
-                           Vectorized Filter: ("time" < 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone)
                            ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=9 loops=1)
                                  Filter: ((_ts_meta_min_1 < 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone) AND (_ts_meta_max_1 > ('2000-01-08'::cstring)::timestamp with time zone))
                                  Rows Removed by Filter: 9
@@ -3974,13 +3967,12 @@ QUERY PLAN
                      Sort Key: _hyper_X_X_chunk."time"
                      Sort Method: top-N heapsort 
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=1439 loops=1)
-                           Filter: ("time" > ('2000-01-08'::cstring)::timestamp with time zone)
+                           Vectorized Filter: (("time" < 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone) AND ("time" > ('2000-01-08'::cstring)::timestamp with time zone))
                            Rows Removed by Filter: 1561
-                           Vectorized Filter: ("time" < 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone)
                            ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=3 loops=1)
                                  Filter: ((_ts_meta_min_1 < 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone) AND (_ts_meta_max_1 > ('2000-01-08'::cstring)::timestamp with time zone))
                                  Rows Removed by Filter: 3
-(64 rows)
+(58 rows)
 
 :PREFIX
 SELECT time
@@ -3999,9 +3991,8 @@ QUERY PLAN
                      Sort Key: _hyper_X_X_chunk."time"
                      Sort Method: top-N heapsort 
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=719 loops=1)
-                           Filter: ("time" < ('2000-01-08'::cstring)::timestamp with time zone)
+                           Vectorized Filter: (("time" > 'Fri Jan 07 00:00:00 2000 PST'::timestamp with time zone) AND ("time" < ('2000-01-08'::cstring)::timestamp with time zone))
                            Rows Removed by Filter: 1281
-                           Vectorized Filter: ("time" > 'Fri Jan 07 00:00:00 2000 PST'::timestamp with time zone)
                            ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=2 loops=1)
                                  Filter: ((_ts_meta_max_1 > 'Fri Jan 07 00:00:00 2000 PST'::timestamp with time zone) AND (_ts_meta_min_1 < ('2000-01-08'::cstring)::timestamp with time zone))
                                  Rows Removed by Filter: 4
@@ -4009,9 +4000,8 @@ QUERY PLAN
                      Sort Key: _hyper_X_X_chunk."time"
                      Sort Method: top-N heapsort 
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=2157 loops=1)
-                           Filter: ("time" < ('2000-01-08'::cstring)::timestamp with time zone)
+                           Vectorized Filter: (("time" > 'Fri Jan 07 00:00:00 2000 PST'::timestamp with time zone) AND ("time" < ('2000-01-08'::cstring)::timestamp with time zone))
                            Rows Removed by Filter: 3843
-                           Vectorized Filter: ("time" > 'Fri Jan 07 00:00:00 2000 PST'::timestamp with time zone)
                            ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=6 loops=1)
                                  Filter: ((_ts_meta_max_1 > 'Fri Jan 07 00:00:00 2000 PST'::timestamp with time zone) AND (_ts_meta_min_1 < ('2000-01-08'::cstring)::timestamp with time zone))
                                  Rows Removed by Filter: 12
@@ -4019,9 +4009,8 @@ QUERY PLAN
                      Sort Key: _hyper_X_X_chunk."time"
                      Sort Method: top-N heapsort 
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=719 loops=1)
-                           Filter: ("time" < ('2000-01-08'::cstring)::timestamp with time zone)
+                           Vectorized Filter: (("time" > 'Fri Jan 07 00:00:00 2000 PST'::timestamp with time zone) AND ("time" < ('2000-01-08'::cstring)::timestamp with time zone))
                            Rows Removed by Filter: 1281
-                           Vectorized Filter: ("time" > 'Fri Jan 07 00:00:00 2000 PST'::timestamp with time zone)
                            ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=2 loops=1)
                                  Filter: ((_ts_meta_max_1 > 'Fri Jan 07 00:00:00 2000 PST'::timestamp with time zone) AND (_ts_meta_min_1 < ('2000-01-08'::cstring)::timestamp with time zone))
                                  Rows Removed by Filter: 4
@@ -4030,25 +4019,22 @@ QUERY PLAN
                ->  Sort (never executed)
                      Sort Key: _hyper_X_X_chunk."time"
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (never executed)
-                           Filter: ("time" < ('2000-01-08'::cstring)::timestamp with time zone)
-                           Vectorized Filter: ("time" > 'Fri Jan 07 00:00:00 2000 PST'::timestamp with time zone)
+                           Vectorized Filter: (("time" > 'Fri Jan 07 00:00:00 2000 PST'::timestamp with time zone) AND ("time" < ('2000-01-08'::cstring)::timestamp with time zone))
                            ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
                                  Filter: ((_ts_meta_max_1 > 'Fri Jan 07 00:00:00 2000 PST'::timestamp with time zone) AND (_ts_meta_min_1 < ('2000-01-08'::cstring)::timestamp with time zone))
                ->  Sort (never executed)
                      Sort Key: _hyper_X_X_chunk."time"
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (never executed)
-                           Filter: ("time" < ('2000-01-08'::cstring)::timestamp with time zone)
-                           Vectorized Filter: ("time" > 'Fri Jan 07 00:00:00 2000 PST'::timestamp with time zone)
+                           Vectorized Filter: (("time" > 'Fri Jan 07 00:00:00 2000 PST'::timestamp with time zone) AND ("time" < ('2000-01-08'::cstring)::timestamp with time zone))
                            ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
                                  Filter: ((_ts_meta_max_1 > 'Fri Jan 07 00:00:00 2000 PST'::timestamp with time zone) AND (_ts_meta_min_1 < ('2000-01-08'::cstring)::timestamp with time zone))
                ->  Sort (never executed)
                      Sort Key: _hyper_X_X_chunk."time"
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (never executed)
-                           Filter: ("time" < ('2000-01-08'::cstring)::timestamp with time zone)
-                           Vectorized Filter: ("time" > 'Fri Jan 07 00:00:00 2000 PST'::timestamp with time zone)
+                           Vectorized Filter: (("time" > 'Fri Jan 07 00:00:00 2000 PST'::timestamp with time zone) AND ("time" < ('2000-01-08'::cstring)::timestamp with time zone))
                            ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
                                  Filter: ((_ts_meta_max_1 > 'Fri Jan 07 00:00:00 2000 PST'::timestamp with time zone) AND (_ts_meta_min_1 < ('2000-01-08'::cstring)::timestamp with time zone))
-(58 rows)
+(52 rows)
 
 -- Disable hash aggregation to get a deterministic test output
 SET enable_hashagg = OFF;
@@ -4569,53 +4555,53 @@ QUERY PLAN
                      Sort Key: _hyper_X_X_chunk."time" DESC
                      Sort Method: top-N heapsort 
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=5038 loops=1)
-                           Filter: ("time" < (now() + '@ 1 mon'::interval))
+                           Vectorized Filter: ("time" < (now() + '@ 1 mon'::interval))
                            ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=6 loops=1)
                ->  Sort (actual rows=1 loops=1)
                      Sort Key: _hyper_X_X_chunk."time" DESC
                      Sort Method: top-N heapsort 
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=15114 loops=1)
-                           Filter: ("time" < (now() + '@ 1 mon'::interval))
+                           Vectorized Filter: ("time" < (now() + '@ 1 mon'::interval))
                            ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=18 loops=1)
                ->  Sort (actual rows=1 loops=1)
                      Sort Key: _hyper_X_X_chunk."time" DESC
                      Sort Method: top-N heapsort 
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=5038 loops=1)
-                           Filter: ("time" < (now() + '@ 1 mon'::interval))
+                           Vectorized Filter: ("time" < (now() + '@ 1 mon'::interval))
                            ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=6 loops=1)
          ->  Merge Append (never executed)
                Sort Key: _hyper_X_X_chunk."time" DESC
                ->  Sort (never executed)
                      Sort Key: _hyper_X_X_chunk."time" DESC
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (never executed)
-                           Filter: ("time" < (now() + '@ 1 mon'::interval))
+                           Vectorized Filter: ("time" < (now() + '@ 1 mon'::interval))
                            ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
                ->  Sort (never executed)
                      Sort Key: _hyper_X_X_chunk."time" DESC
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (never executed)
-                           Filter: ("time" < (now() + '@ 1 mon'::interval))
+                           Vectorized Filter: ("time" < (now() + '@ 1 mon'::interval))
                            ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
                ->  Sort (never executed)
                      Sort Key: _hyper_X_X_chunk."time" DESC
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (never executed)
-                           Filter: ("time" < (now() + '@ 1 mon'::interval))
+                           Vectorized Filter: ("time" < (now() + '@ 1 mon'::interval))
                            ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
          ->  Merge Append (never executed)
                Sort Key: _hyper_X_X_chunk."time" DESC
                ->  Sort (never executed)
                      Sort Key: _hyper_X_X_chunk."time" DESC
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (never executed)
-                           Filter: ("time" < (now() + '@ 1 mon'::interval))
+                           Vectorized Filter: ("time" < (now() + '@ 1 mon'::interval))
                            ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
                ->  Sort (never executed)
                      Sort Key: _hyper_X_X_chunk."time" DESC
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (never executed)
-                           Filter: ("time" < (now() + '@ 1 mon'::interval))
+                           Vectorized Filter: ("time" < (now() + '@ 1 mon'::interval))
                            ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
                ->  Sort (never executed)
                      Sort Key: _hyper_X_X_chunk."time" DESC
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (never executed)
-                           Filter: ("time" < (now() + '@ 1 mon'::interval))
+                           Vectorized Filter: ("time" < (now() + '@ 1 mon'::interval))
                            ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
 (57 rows)
 
@@ -4639,53 +4625,53 @@ QUERY PLAN
                      Sort Key: _hyper_X_X_chunk."time" DESC
                      Sort Method: top-N heapsort 
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=5038 loops=1)
-                           Filter: ("time" < now())
+                           Vectorized Filter: ("time" < now())
                            ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=6 loops=1)
                ->  Sort (actual rows=60 loops=1)
                      Sort Key: _hyper_X_X_chunk."time" DESC
                      Sort Method: top-N heapsort 
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=15114 loops=1)
-                           Filter: ("time" < now())
+                           Vectorized Filter: ("time" < now())
                            ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=18 loops=1)
                ->  Sort (actual rows=21 loops=1)
                      Sort Key: _hyper_X_X_chunk."time" DESC
                      Sort Method: top-N heapsort 
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=5038 loops=1)
-                           Filter: ("time" < now())
+                           Vectorized Filter: ("time" < now())
                            ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=6 loops=1)
          ->  Merge Append (never executed)
                Sort Key: _hyper_X_X_chunk."time" DESC
                ->  Sort (never executed)
                      Sort Key: _hyper_X_X_chunk."time" DESC
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (never executed)
-                           Filter: ("time" < now())
+                           Vectorized Filter: ("time" < now())
                            ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
                ->  Sort (never executed)
                      Sort Key: _hyper_X_X_chunk."time" DESC
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (never executed)
-                           Filter: ("time" < now())
+                           Vectorized Filter: ("time" < now())
                            ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
                ->  Sort (never executed)
                      Sort Key: _hyper_X_X_chunk."time" DESC
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (never executed)
-                           Filter: ("time" < now())
+                           Vectorized Filter: ("time" < now())
                            ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
          ->  Merge Append (never executed)
                Sort Key: _hyper_X_X_chunk."time" DESC
                ->  Sort (never executed)
                      Sort Key: _hyper_X_X_chunk."time" DESC
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (never executed)
-                           Filter: ("time" < now())
+                           Vectorized Filter: ("time" < now())
                            ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
                ->  Sort (never executed)
                      Sort Key: _hyper_X_X_chunk."time" DESC
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (never executed)
-                           Filter: ("time" < now())
+                           Vectorized Filter: ("time" < now())
                            ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
                ->  Sort (never executed)
                      Sort Key: _hyper_X_X_chunk."time" DESC
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (never executed)
-                           Filter: ("time" < now())
+                           Vectorized Filter: ("time" < now())
                            ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
 (57 rows)
 

--- a/tsl/test/shared/expected/ordered_append-15.out
+++ b/tsl/test/shared/expected/ordered_append-15.out
@@ -2490,7 +2490,7 @@ QUERY PLAN
                Sort Key: _hyper_X_X_chunk."time"
                Sort Method: top-N heapsort 
                ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=16785 loops=1)
-                     Filter: ("time" > ('2000-01-08'::cstring)::timestamp with time zone)
+                     Vectorized Filter: ("time" > ('2000-01-08'::cstring)::timestamp with time zone)
                      Rows Removed by Filter: 3215
                      ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=20 loops=1)
                            Filter: (_ts_meta_max_1 > ('2000-01-08'::cstring)::timestamp with time zone)
@@ -2498,7 +2498,7 @@ QUERY PLAN
          ->  Sort (never executed)
                Sort Key: _hyper_X_X_chunk."time"
                ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (never executed)
-                     Filter: ("time" > ('2000-01-08'::cstring)::timestamp with time zone)
+                     Vectorized Filter: ("time" > ('2000-01-08'::cstring)::timestamp with time zone)
                      ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
                            Filter: (_ts_meta_max_1 > ('2000-01-08'::cstring)::timestamp with time zone)
 (19 rows)
@@ -2518,13 +2518,13 @@ QUERY PLAN
                Sort Key: _hyper_X_X_chunk."time"
                Sort Method: top-N heapsort 
                ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=17990 loops=1)
-                     Filter: ("time" < ('2000-01-08'::cstring)::timestamp with time zone)
+                     Vectorized Filter: ("time" < ('2000-01-08'::cstring)::timestamp with time zone)
                      ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=20 loops=1)
                            Filter: (_ts_meta_min_1 < ('2000-01-08'::cstring)::timestamp with time zone)
          ->  Sort (never executed)
                Sort Key: _hyper_X_X_chunk."time"
                ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (never executed)
-                     Filter: ("time" < ('2000-01-08'::cstring)::timestamp with time zone)
+                     Vectorized Filter: ("time" < ('2000-01-08'::cstring)::timestamp with time zone)
                      ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
                            Filter: (_ts_meta_min_1 < ('2000-01-08'::cstring)::timestamp with time zone)
 (17 rows)
@@ -2546,13 +2546,12 @@ QUERY PLAN
                Sort Key: _hyper_X_X_chunk."time"
                Sort Method: top-N heapsort 
                ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=7195 loops=1)
-                     Filter: ("time" > ('2000-01-08'::cstring)::timestamp with time zone)
+                     Vectorized Filter: (("time" < 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone) AND ("time" > ('2000-01-08'::cstring)::timestamp with time zone))
                      Rows Removed by Filter: 7805
-                     Vectorized Filter: ("time" < 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone)
                      ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=15 loops=1)
                            Filter: ((_ts_meta_min_1 < 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone) AND (_ts_meta_max_1 > ('2000-01-08'::cstring)::timestamp with time zone))
                            Rows Removed by Filter: 15
-(14 rows)
+(13 rows)
 
 :PREFIX
 SELECT time
@@ -2570,13 +2569,12 @@ QUERY PLAN
                Sort Key: _hyper_X_X_chunk."time"
                Sort Method: top-N heapsort 
                ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=3595 loops=1)
-                     Filter: ("time" < ('2000-01-08'::cstring)::timestamp with time zone)
+                     Vectorized Filter: (("time" > 'Fri Jan 07 00:00:00 2000 PST'::timestamp with time zone) AND ("time" < ('2000-01-08'::cstring)::timestamp with time zone))
                      Rows Removed by Filter: 6405
-                     Vectorized Filter: ("time" > 'Fri Jan 07 00:00:00 2000 PST'::timestamp with time zone)
                      ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=10 loops=1)
                            Filter: ((_ts_meta_max_1 > 'Fri Jan 07 00:00:00 2000 PST'::timestamp with time zone) AND (_ts_meta_min_1 < ('2000-01-08'::cstring)::timestamp with time zone))
                            Rows Removed by Filter: 20
-(14 rows)
+(13 rows)
 
 -- Disable hash aggregation to get a deterministic test output
 SET enable_hashagg = OFF;
@@ -2861,17 +2859,17 @@ QUERY PLAN
                Sort Key: _hyper_X_X_chunk."time" DESC
                Sort Method: top-N heapsort 
                ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=25190 loops=1)
-                     Filter: ("time" < (now() + '@ 1 mon'::interval))
+                     Vectorized Filter: ("time" < (now() + '@ 1 mon'::interval))
                      ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=30 loops=1)
          ->  Sort (never executed)
                Sort Key: _hyper_X_X_chunk."time" DESC
                ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (never executed)
-                     Filter: ("time" < (now() + '@ 1 mon'::interval))
+                     Vectorized Filter: ("time" < (now() + '@ 1 mon'::interval))
                      ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
          ->  Sort (never executed)
                Sort Key: _hyper_X_X_chunk."time" DESC
                ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (never executed)
-                     Filter: ("time" < (now() + '@ 1 mon'::interval))
+                     Vectorized Filter: ("time" < (now() + '@ 1 mon'::interval))
                      ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
 (20 rows)
 
@@ -2894,17 +2892,17 @@ QUERY PLAN
                Sort Key: _hyper_X_X_chunk."time" DESC
                Sort Method: top-N heapsort 
                ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=25190 loops=1)
-                     Filter: ("time" < now())
+                     Vectorized Filter: ("time" < now())
                      ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=30 loops=1)
          ->  Sort (never executed)
                Sort Key: _hyper_X_X_chunk."time" DESC
                ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (never executed)
-                     Filter: ("time" < now())
+                     Vectorized Filter: ("time" < now())
                      ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
          ->  Sort (never executed)
                Sort Key: _hyper_X_X_chunk."time" DESC
                ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (never executed)
-                     Filter: ("time" < now())
+                     Vectorized Filter: ("time" < now())
                      ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
 (20 rows)
 
@@ -3788,7 +3786,7 @@ QUERY PLAN
                      Sort Key: _hyper_X_X_chunk."time"
                      Sort Method: quicksort 
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=0 loops=1)
-                           Filter: ("time" > ('2000-01-08'::cstring)::timestamp with time zone)
+                           Vectorized Filter: ("time" > ('2000-01-08'::cstring)::timestamp with time zone)
                            ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=0 loops=1)
                                  Filter: (_ts_meta_max_1 > ('2000-01-08'::cstring)::timestamp with time zone)
                                  Rows Removed by Filter: 4
@@ -3796,7 +3794,7 @@ QUERY PLAN
                      Sort Key: _hyper_X_X_chunk."time"
                      Sort Method: quicksort 
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=0 loops=1)
-                           Filter: ("time" > ('2000-01-08'::cstring)::timestamp with time zone)
+                           Vectorized Filter: ("time" > ('2000-01-08'::cstring)::timestamp with time zone)
                            ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=0 loops=1)
                                  Filter: (_ts_meta_max_1 > ('2000-01-08'::cstring)::timestamp with time zone)
                                  Rows Removed by Filter: 12
@@ -3804,7 +3802,7 @@ QUERY PLAN
                      Sort Key: _hyper_X_X_chunk."time"
                      Sort Method: quicksort 
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=0 loops=1)
-                           Filter: ("time" > ('2000-01-08'::cstring)::timestamp with time zone)
+                           Vectorized Filter: ("time" > ('2000-01-08'::cstring)::timestamp with time zone)
                            ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=0 loops=1)
                                  Filter: (_ts_meta_max_1 > ('2000-01-08'::cstring)::timestamp with time zone)
                                  Rows Removed by Filter: 4
@@ -3814,7 +3812,7 @@ QUERY PLAN
                      Sort Key: _hyper_X_X_chunk."time"
                      Sort Method: top-N heapsort 
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=3357 loops=1)
-                           Filter: ("time" > ('2000-01-08'::cstring)::timestamp with time zone)
+                           Vectorized Filter: ("time" > ('2000-01-08'::cstring)::timestamp with time zone)
                            Rows Removed by Filter: 643
                            ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=4 loops=1)
                                  Filter: (_ts_meta_max_1 > ('2000-01-08'::cstring)::timestamp with time zone)
@@ -3823,7 +3821,7 @@ QUERY PLAN
                      Sort Key: _hyper_X_X_chunk."time"
                      Sort Method: top-N heapsort 
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=10071 loops=1)
-                           Filter: ("time" > ('2000-01-08'::cstring)::timestamp with time zone)
+                           Vectorized Filter: ("time" > ('2000-01-08'::cstring)::timestamp with time zone)
                            Rows Removed by Filter: 1929
                            ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=12 loops=1)
                                  Filter: (_ts_meta_max_1 > ('2000-01-08'::cstring)::timestamp with time zone)
@@ -3832,7 +3830,7 @@ QUERY PLAN
                      Sort Key: _hyper_X_X_chunk."time"
                      Sort Method: top-N heapsort 
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=3357 loops=1)
-                           Filter: ("time" > ('2000-01-08'::cstring)::timestamp with time zone)
+                           Vectorized Filter: ("time" > ('2000-01-08'::cstring)::timestamp with time zone)
                            Rows Removed by Filter: 643
                            ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=4 loops=1)
                                  Filter: (_ts_meta_max_1 > ('2000-01-08'::cstring)::timestamp with time zone)
@@ -3842,19 +3840,19 @@ QUERY PLAN
                ->  Sort (never executed)
                      Sort Key: _hyper_X_X_chunk."time"
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (never executed)
-                           Filter: ("time" > ('2000-01-08'::cstring)::timestamp with time zone)
+                           Vectorized Filter: ("time" > ('2000-01-08'::cstring)::timestamp with time zone)
                            ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
                                  Filter: (_ts_meta_max_1 > ('2000-01-08'::cstring)::timestamp with time zone)
                ->  Sort (never executed)
                      Sort Key: _hyper_X_X_chunk."time"
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (never executed)
-                           Filter: ("time" > ('2000-01-08'::cstring)::timestamp with time zone)
+                           Vectorized Filter: ("time" > ('2000-01-08'::cstring)::timestamp with time zone)
                            ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
                                  Filter: (_ts_meta_max_1 > ('2000-01-08'::cstring)::timestamp with time zone)
                ->  Sort (never executed)
                      Sort Key: _hyper_X_X_chunk."time"
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (never executed)
-                           Filter: ("time" > ('2000-01-08'::cstring)::timestamp with time zone)
+                           Vectorized Filter: ("time" > ('2000-01-08'::cstring)::timestamp with time zone)
                            ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
                                  Filter: (_ts_meta_max_1 > ('2000-01-08'::cstring)::timestamp with time zone)
 (78 rows)
@@ -3875,21 +3873,21 @@ QUERY PLAN
                      Sort Key: _hyper_X_X_chunk."time"
                      Sort Method: top-N heapsort 
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=3598 loops=1)
-                           Filter: ("time" < ('2000-01-08'::cstring)::timestamp with time zone)
+                           Vectorized Filter: ("time" < ('2000-01-08'::cstring)::timestamp with time zone)
                            ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=4 loops=1)
                                  Filter: (_ts_meta_min_1 < ('2000-01-08'::cstring)::timestamp with time zone)
                ->  Sort (actual rows=1 loops=1)
                      Sort Key: _hyper_X_X_chunk."time"
                      Sort Method: top-N heapsort 
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=10794 loops=1)
-                           Filter: ("time" < ('2000-01-08'::cstring)::timestamp with time zone)
+                           Vectorized Filter: ("time" < ('2000-01-08'::cstring)::timestamp with time zone)
                            ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=12 loops=1)
                                  Filter: (_ts_meta_min_1 < ('2000-01-08'::cstring)::timestamp with time zone)
                ->  Sort (actual rows=1 loops=1)
                      Sort Key: _hyper_X_X_chunk."time"
                      Sort Method: top-N heapsort 
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=3598 loops=1)
-                           Filter: ("time" < ('2000-01-08'::cstring)::timestamp with time zone)
+                           Vectorized Filter: ("time" < ('2000-01-08'::cstring)::timestamp with time zone)
                            ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=4 loops=1)
                                  Filter: (_ts_meta_min_1 < ('2000-01-08'::cstring)::timestamp with time zone)
          ->  Merge Append (never executed)
@@ -3897,19 +3895,19 @@ QUERY PLAN
                ->  Sort (never executed)
                      Sort Key: _hyper_X_X_chunk."time"
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (never executed)
-                           Filter: ("time" < ('2000-01-08'::cstring)::timestamp with time zone)
+                           Vectorized Filter: ("time" < ('2000-01-08'::cstring)::timestamp with time zone)
                            ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
                                  Filter: (_ts_meta_min_1 < ('2000-01-08'::cstring)::timestamp with time zone)
                ->  Sort (never executed)
                      Sort Key: _hyper_X_X_chunk."time"
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (never executed)
-                           Filter: ("time" < ('2000-01-08'::cstring)::timestamp with time zone)
+                           Vectorized Filter: ("time" < ('2000-01-08'::cstring)::timestamp with time zone)
                            ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
                                  Filter: (_ts_meta_min_1 < ('2000-01-08'::cstring)::timestamp with time zone)
                ->  Sort (never executed)
                      Sort Key: _hyper_X_X_chunk."time"
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (never executed)
-                           Filter: ("time" < ('2000-01-08'::cstring)::timestamp with time zone)
+                           Vectorized Filter: ("time" < ('2000-01-08'::cstring)::timestamp with time zone)
                            ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
                                  Filter: (_ts_meta_min_1 < ('2000-01-08'::cstring)::timestamp with time zone)
          ->  Merge Append (never executed)
@@ -3917,19 +3915,19 @@ QUERY PLAN
                ->  Sort (never executed)
                      Sort Key: _hyper_X_X_chunk."time"
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (never executed)
-                           Filter: ("time" < ('2000-01-08'::cstring)::timestamp with time zone)
+                           Vectorized Filter: ("time" < ('2000-01-08'::cstring)::timestamp with time zone)
                            ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
                                  Filter: (_ts_meta_min_1 < ('2000-01-08'::cstring)::timestamp with time zone)
                ->  Sort (never executed)
                      Sort Key: _hyper_X_X_chunk."time"
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (never executed)
-                           Filter: ("time" < ('2000-01-08'::cstring)::timestamp with time zone)
+                           Vectorized Filter: ("time" < ('2000-01-08'::cstring)::timestamp with time zone)
                            ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
                                  Filter: (_ts_meta_min_1 < ('2000-01-08'::cstring)::timestamp with time zone)
                ->  Sort (never executed)
                      Sort Key: _hyper_X_X_chunk."time"
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (never executed)
-                           Filter: ("time" < ('2000-01-08'::cstring)::timestamp with time zone)
+                           Vectorized Filter: ("time" < ('2000-01-08'::cstring)::timestamp with time zone)
                            ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
                                  Filter: (_ts_meta_min_1 < ('2000-01-08'::cstring)::timestamp with time zone)
 (66 rows)
@@ -3952,8 +3950,7 @@ QUERY PLAN
                      Sort Key: _hyper_X_X_chunk."time"
                      Sort Method: quicksort 
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=0 loops=1)
-                           Filter: ("time" > ('2000-01-08'::cstring)::timestamp with time zone)
-                           Vectorized Filter: ("time" < 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone)
+                           Vectorized Filter: (("time" < 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone) AND ("time" > ('2000-01-08'::cstring)::timestamp with time zone))
                            ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=0 loops=1)
                                  Filter: ((_ts_meta_min_1 < 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone) AND (_ts_meta_max_1 > ('2000-01-08'::cstring)::timestamp with time zone))
                                  Rows Removed by Filter: 4
@@ -3961,8 +3958,7 @@ QUERY PLAN
                      Sort Key: _hyper_X_X_chunk."time"
                      Sort Method: quicksort 
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=0 loops=1)
-                           Filter: ("time" > ('2000-01-08'::cstring)::timestamp with time zone)
-                           Vectorized Filter: ("time" < 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone)
+                           Vectorized Filter: (("time" < 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone) AND ("time" > ('2000-01-08'::cstring)::timestamp with time zone))
                            ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=0 loops=1)
                                  Filter: ((_ts_meta_min_1 < 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone) AND (_ts_meta_max_1 > ('2000-01-08'::cstring)::timestamp with time zone))
                                  Rows Removed by Filter: 12
@@ -3970,8 +3966,7 @@ QUERY PLAN
                      Sort Key: _hyper_X_X_chunk."time"
                      Sort Method: quicksort 
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=0 loops=1)
-                           Filter: ("time" > ('2000-01-08'::cstring)::timestamp with time zone)
-                           Vectorized Filter: ("time" < 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone)
+                           Vectorized Filter: (("time" < 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone) AND ("time" > ('2000-01-08'::cstring)::timestamp with time zone))
                            ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=0 loops=1)
                                  Filter: ((_ts_meta_min_1 < 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone) AND (_ts_meta_max_1 > ('2000-01-08'::cstring)::timestamp with time zone))
                                  Rows Removed by Filter: 4
@@ -3981,9 +3976,8 @@ QUERY PLAN
                      Sort Key: _hyper_X_X_chunk."time"
                      Sort Method: top-N heapsort 
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=1439 loops=1)
-                           Filter: ("time" > ('2000-01-08'::cstring)::timestamp with time zone)
+                           Vectorized Filter: (("time" < 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone) AND ("time" > ('2000-01-08'::cstring)::timestamp with time zone))
                            Rows Removed by Filter: 1561
-                           Vectorized Filter: ("time" < 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone)
                            ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=3 loops=1)
                                  Filter: ((_ts_meta_min_1 < 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone) AND (_ts_meta_max_1 > ('2000-01-08'::cstring)::timestamp with time zone))
                                  Rows Removed by Filter: 3
@@ -3991,9 +3985,8 @@ QUERY PLAN
                      Sort Key: _hyper_X_X_chunk."time"
                      Sort Method: top-N heapsort 
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=4317 loops=1)
-                           Filter: ("time" > ('2000-01-08'::cstring)::timestamp with time zone)
+                           Vectorized Filter: (("time" < 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone) AND ("time" > ('2000-01-08'::cstring)::timestamp with time zone))
                            Rows Removed by Filter: 4683
-                           Vectorized Filter: ("time" < 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone)
                            ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=9 loops=1)
                                  Filter: ((_ts_meta_min_1 < 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone) AND (_ts_meta_max_1 > ('2000-01-08'::cstring)::timestamp with time zone))
                                  Rows Removed by Filter: 9
@@ -4001,13 +3994,12 @@ QUERY PLAN
                      Sort Key: _hyper_X_X_chunk."time"
                      Sort Method: top-N heapsort 
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=1439 loops=1)
-                           Filter: ("time" > ('2000-01-08'::cstring)::timestamp with time zone)
+                           Vectorized Filter: (("time" < 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone) AND ("time" > ('2000-01-08'::cstring)::timestamp with time zone))
                            Rows Removed by Filter: 1561
-                           Vectorized Filter: ("time" < 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone)
                            ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=3 loops=1)
                                  Filter: ((_ts_meta_min_1 < 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone) AND (_ts_meta_max_1 > ('2000-01-08'::cstring)::timestamp with time zone))
                                  Rows Removed by Filter: 3
-(64 rows)
+(58 rows)
 
 :PREFIX
 SELECT time
@@ -4026,9 +4018,8 @@ QUERY PLAN
                      Sort Key: _hyper_X_X_chunk."time"
                      Sort Method: top-N heapsort 
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=719 loops=1)
-                           Filter: ("time" < ('2000-01-08'::cstring)::timestamp with time zone)
+                           Vectorized Filter: (("time" > 'Fri Jan 07 00:00:00 2000 PST'::timestamp with time zone) AND ("time" < ('2000-01-08'::cstring)::timestamp with time zone))
                            Rows Removed by Filter: 1281
-                           Vectorized Filter: ("time" > 'Fri Jan 07 00:00:00 2000 PST'::timestamp with time zone)
                            ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=2 loops=1)
                                  Filter: ((_ts_meta_max_1 > 'Fri Jan 07 00:00:00 2000 PST'::timestamp with time zone) AND (_ts_meta_min_1 < ('2000-01-08'::cstring)::timestamp with time zone))
                                  Rows Removed by Filter: 4
@@ -4036,9 +4027,8 @@ QUERY PLAN
                      Sort Key: _hyper_X_X_chunk."time"
                      Sort Method: top-N heapsort 
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=2157 loops=1)
-                           Filter: ("time" < ('2000-01-08'::cstring)::timestamp with time zone)
+                           Vectorized Filter: (("time" > 'Fri Jan 07 00:00:00 2000 PST'::timestamp with time zone) AND ("time" < ('2000-01-08'::cstring)::timestamp with time zone))
                            Rows Removed by Filter: 3843
-                           Vectorized Filter: ("time" > 'Fri Jan 07 00:00:00 2000 PST'::timestamp with time zone)
                            ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=6 loops=1)
                                  Filter: ((_ts_meta_max_1 > 'Fri Jan 07 00:00:00 2000 PST'::timestamp with time zone) AND (_ts_meta_min_1 < ('2000-01-08'::cstring)::timestamp with time zone))
                                  Rows Removed by Filter: 12
@@ -4046,9 +4036,8 @@ QUERY PLAN
                      Sort Key: _hyper_X_X_chunk."time"
                      Sort Method: top-N heapsort 
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=719 loops=1)
-                           Filter: ("time" < ('2000-01-08'::cstring)::timestamp with time zone)
+                           Vectorized Filter: (("time" > 'Fri Jan 07 00:00:00 2000 PST'::timestamp with time zone) AND ("time" < ('2000-01-08'::cstring)::timestamp with time zone))
                            Rows Removed by Filter: 1281
-                           Vectorized Filter: ("time" > 'Fri Jan 07 00:00:00 2000 PST'::timestamp with time zone)
                            ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=2 loops=1)
                                  Filter: ((_ts_meta_max_1 > 'Fri Jan 07 00:00:00 2000 PST'::timestamp with time zone) AND (_ts_meta_min_1 < ('2000-01-08'::cstring)::timestamp with time zone))
                                  Rows Removed by Filter: 4
@@ -4057,25 +4046,22 @@ QUERY PLAN
                ->  Sort (never executed)
                      Sort Key: _hyper_X_X_chunk."time"
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (never executed)
-                           Filter: ("time" < ('2000-01-08'::cstring)::timestamp with time zone)
-                           Vectorized Filter: ("time" > 'Fri Jan 07 00:00:00 2000 PST'::timestamp with time zone)
+                           Vectorized Filter: (("time" > 'Fri Jan 07 00:00:00 2000 PST'::timestamp with time zone) AND ("time" < ('2000-01-08'::cstring)::timestamp with time zone))
                            ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
                                  Filter: ((_ts_meta_max_1 > 'Fri Jan 07 00:00:00 2000 PST'::timestamp with time zone) AND (_ts_meta_min_1 < ('2000-01-08'::cstring)::timestamp with time zone))
                ->  Sort (never executed)
                      Sort Key: _hyper_X_X_chunk."time"
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (never executed)
-                           Filter: ("time" < ('2000-01-08'::cstring)::timestamp with time zone)
-                           Vectorized Filter: ("time" > 'Fri Jan 07 00:00:00 2000 PST'::timestamp with time zone)
+                           Vectorized Filter: (("time" > 'Fri Jan 07 00:00:00 2000 PST'::timestamp with time zone) AND ("time" < ('2000-01-08'::cstring)::timestamp with time zone))
                            ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
                                  Filter: ((_ts_meta_max_1 > 'Fri Jan 07 00:00:00 2000 PST'::timestamp with time zone) AND (_ts_meta_min_1 < ('2000-01-08'::cstring)::timestamp with time zone))
                ->  Sort (never executed)
                      Sort Key: _hyper_X_X_chunk."time"
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (never executed)
-                           Filter: ("time" < ('2000-01-08'::cstring)::timestamp with time zone)
-                           Vectorized Filter: ("time" > 'Fri Jan 07 00:00:00 2000 PST'::timestamp with time zone)
+                           Vectorized Filter: (("time" > 'Fri Jan 07 00:00:00 2000 PST'::timestamp with time zone) AND ("time" < ('2000-01-08'::cstring)::timestamp with time zone))
                            ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
                                  Filter: ((_ts_meta_max_1 > 'Fri Jan 07 00:00:00 2000 PST'::timestamp with time zone) AND (_ts_meta_min_1 < ('2000-01-08'::cstring)::timestamp with time zone))
-(58 rows)
+(52 rows)
 
 -- Disable hash aggregation to get a deterministic test output
 SET enable_hashagg = OFF;
@@ -4599,53 +4585,53 @@ QUERY PLAN
                      Sort Key: _hyper_X_X_chunk."time" DESC
                      Sort Method: top-N heapsort 
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=5038 loops=1)
-                           Filter: ("time" < (now() + '@ 1 mon'::interval))
+                           Vectorized Filter: ("time" < (now() + '@ 1 mon'::interval))
                            ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=6 loops=1)
                ->  Sort (actual rows=1 loops=1)
                      Sort Key: _hyper_X_X_chunk."time" DESC
                      Sort Method: top-N heapsort 
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=15114 loops=1)
-                           Filter: ("time" < (now() + '@ 1 mon'::interval))
+                           Vectorized Filter: ("time" < (now() + '@ 1 mon'::interval))
                            ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=18 loops=1)
                ->  Sort (actual rows=1 loops=1)
                      Sort Key: _hyper_X_X_chunk."time" DESC
                      Sort Method: top-N heapsort 
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=5038 loops=1)
-                           Filter: ("time" < (now() + '@ 1 mon'::interval))
+                           Vectorized Filter: ("time" < (now() + '@ 1 mon'::interval))
                            ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=6 loops=1)
          ->  Merge Append (never executed)
                Sort Key: _hyper_X_X_chunk."time" DESC
                ->  Sort (never executed)
                      Sort Key: _hyper_X_X_chunk."time" DESC
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (never executed)
-                           Filter: ("time" < (now() + '@ 1 mon'::interval))
+                           Vectorized Filter: ("time" < (now() + '@ 1 mon'::interval))
                            ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
                ->  Sort (never executed)
                      Sort Key: _hyper_X_X_chunk."time" DESC
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (never executed)
-                           Filter: ("time" < (now() + '@ 1 mon'::interval))
+                           Vectorized Filter: ("time" < (now() + '@ 1 mon'::interval))
                            ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
                ->  Sort (never executed)
                      Sort Key: _hyper_X_X_chunk."time" DESC
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (never executed)
-                           Filter: ("time" < (now() + '@ 1 mon'::interval))
+                           Vectorized Filter: ("time" < (now() + '@ 1 mon'::interval))
                            ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
          ->  Merge Append (never executed)
                Sort Key: _hyper_X_X_chunk."time" DESC
                ->  Sort (never executed)
                      Sort Key: _hyper_X_X_chunk."time" DESC
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (never executed)
-                           Filter: ("time" < (now() + '@ 1 mon'::interval))
+                           Vectorized Filter: ("time" < (now() + '@ 1 mon'::interval))
                            ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
                ->  Sort (never executed)
                      Sort Key: _hyper_X_X_chunk."time" DESC
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (never executed)
-                           Filter: ("time" < (now() + '@ 1 mon'::interval))
+                           Vectorized Filter: ("time" < (now() + '@ 1 mon'::interval))
                            ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
                ->  Sort (never executed)
                      Sort Key: _hyper_X_X_chunk."time" DESC
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (never executed)
-                           Filter: ("time" < (now() + '@ 1 mon'::interval))
+                           Vectorized Filter: ("time" < (now() + '@ 1 mon'::interval))
                            ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
 (57 rows)
 
@@ -4669,53 +4655,53 @@ QUERY PLAN
                      Sort Key: _hyper_X_X_chunk."time" DESC
                      Sort Method: top-N heapsort 
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=5038 loops=1)
-                           Filter: ("time" < now())
+                           Vectorized Filter: ("time" < now())
                            ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=6 loops=1)
                ->  Sort (actual rows=60 loops=1)
                      Sort Key: _hyper_X_X_chunk."time" DESC
                      Sort Method: top-N heapsort 
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=15114 loops=1)
-                           Filter: ("time" < now())
+                           Vectorized Filter: ("time" < now())
                            ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=18 loops=1)
                ->  Sort (actual rows=21 loops=1)
                      Sort Key: _hyper_X_X_chunk."time" DESC
                      Sort Method: top-N heapsort 
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=5038 loops=1)
-                           Filter: ("time" < now())
+                           Vectorized Filter: ("time" < now())
                            ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=6 loops=1)
          ->  Merge Append (never executed)
                Sort Key: _hyper_X_X_chunk."time" DESC
                ->  Sort (never executed)
                      Sort Key: _hyper_X_X_chunk."time" DESC
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (never executed)
-                           Filter: ("time" < now())
+                           Vectorized Filter: ("time" < now())
                            ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
                ->  Sort (never executed)
                      Sort Key: _hyper_X_X_chunk."time" DESC
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (never executed)
-                           Filter: ("time" < now())
+                           Vectorized Filter: ("time" < now())
                            ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
                ->  Sort (never executed)
                      Sort Key: _hyper_X_X_chunk."time" DESC
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (never executed)
-                           Filter: ("time" < now())
+                           Vectorized Filter: ("time" < now())
                            ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
          ->  Merge Append (never executed)
                Sort Key: _hyper_X_X_chunk."time" DESC
                ->  Sort (never executed)
                      Sort Key: _hyper_X_X_chunk."time" DESC
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (never executed)
-                           Filter: ("time" < now())
+                           Vectorized Filter: ("time" < now())
                            ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
                ->  Sort (never executed)
                      Sort Key: _hyper_X_X_chunk."time" DESC
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (never executed)
-                           Filter: ("time" < now())
+                           Vectorized Filter: ("time" < now())
                            ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
                ->  Sort (never executed)
                      Sort Key: _hyper_X_X_chunk."time" DESC
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (never executed)
-                           Filter: ("time" < now())
+                           Vectorized Filter: ("time" < now())
                            ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
 (57 rows)
 

--- a/tsl/test/shared/expected/ordered_append_join-13.out
+++ b/tsl/test/shared/expected/ordered_append_join-13.out
@@ -2074,25 +2074,28 @@ QUERY PLAN
                ->  Sort (never executed)
                      Sort Key: o_1."time" DESC
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o_1 (never executed)
-                           Filter: (("time" >= g."time") AND ("time" < (g."time" + '@ 1 day'::interval)) AND ("time" < now()))
+                           Filter: (("time" >= g."time") AND ("time" < (g."time" + '@ 1 day'::interval)))
+                           Vectorized Filter: ("time" < now())
                            ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
                                  Filter: ((_ts_meta_max_1 >= g."time") AND (_ts_meta_min_1 < (g."time" + '@ 1 day'::interval)))
                ->  Sort (never executed)
                      Sort Key: o_2."time" DESC
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o_2 (never executed)
-                           Filter: (("time" >= g."time") AND ("time" < (g."time" + '@ 1 day'::interval)) AND ("time" < now()))
+                           Filter: (("time" >= g."time") AND ("time" < (g."time" + '@ 1 day'::interval)))
+                           Vectorized Filter: ("time" < now())
                            ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
                                  Filter: ((_ts_meta_max_1 >= g."time") AND (_ts_meta_min_1 < (g."time" + '@ 1 day'::interval)))
                ->  Sort (actual rows=1 loops=3)
                      Sort Key: o_3."time" DESC
                      Sort Method: top-N heapsort 
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o_3 (actual rows=3600 loops=3)
-                           Filter: (("time" >= g."time") AND ("time" < (g."time" + '@ 1 day'::interval)) AND ("time" < now()))
+                           Filter: (("time" >= g."time") AND ("time" < (g."time" + '@ 1 day'::interval)))
                            Rows Removed by Filter: 4063
+                           Vectorized Filter: ("time" < now())
                            ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=8 loops=3)
                                  Filter: ((_ts_meta_max_1 >= g."time") AND (_ts_meta_min_1 < (g."time" + '@ 1 day'::interval)))
                                  Rows Removed by Filter: 12
-(28 rows)
+(31 rows)
 
 -- test startup and runtime exclusion together
 -- all chunks should be filtered
@@ -3196,7 +3199,8 @@ QUERY PLAN
                            Sort Key: o_1."time" DESC
                            Sort Method: quicksort 
                            ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o_1 (actual rows=0 loops=3)
-                                 Filter: (("time" >= g."time") AND ("time" < (g."time" + '@ 1 day'::interval)) AND ("time" < now()))
+                                 Filter: (("time" >= g."time") AND ("time" < (g."time" + '@ 1 day'::interval)))
+                                 Vectorized Filter: ("time" < now())
                                  ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=0 loops=3)
                                        Filter: ((_ts_meta_max_1 >= g."time") AND (_ts_meta_min_1 < (g."time" + '@ 1 day'::interval)))
                                        Rows Removed by Filter: 6
@@ -3204,7 +3208,8 @@ QUERY PLAN
                            Sort Key: o_2."time" DESC
                            Sort Method: quicksort 
                            ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o_2 (actual rows=0 loops=3)
-                                 Filter: (("time" >= g."time") AND ("time" < (g."time" + '@ 1 day'::interval)) AND ("time" < now()))
+                                 Filter: (("time" >= g."time") AND ("time" < (g."time" + '@ 1 day'::interval)))
+                                 Vectorized Filter: ("time" < now())
                                  ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=0 loops=3)
                                        Filter: ((_ts_meta_max_1 >= g."time") AND (_ts_meta_min_1 < (g."time" + '@ 1 day'::interval)))
                                        Rows Removed by Filter: 18
@@ -3212,7 +3217,8 @@ QUERY PLAN
                            Sort Key: o_3."time" DESC
                            Sort Method: quicksort 
                            ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o_3 (actual rows=0 loops=3)
-                                 Filter: (("time" >= g."time") AND ("time" < (g."time" + '@ 1 day'::interval)) AND ("time" < now()))
+                                 Filter: (("time" >= g."time") AND ("time" < (g."time" + '@ 1 day'::interval)))
+                                 Vectorized Filter: ("time" < now())
                                  ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=0 loops=3)
                                        Filter: ((_ts_meta_max_1 >= g."time") AND (_ts_meta_min_1 < (g."time" + '@ 1 day'::interval)))
                                        Rows Removed by Filter: 6
@@ -3222,7 +3228,8 @@ QUERY PLAN
                            Sort Key: o_4."time" DESC
                            Sort Method: quicksort 
                            ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o_4 (actual rows=0 loops=3)
-                                 Filter: (("time" >= g."time") AND ("time" < (g."time" + '@ 1 day'::interval)) AND ("time" < now()))
+                                 Filter: (("time" >= g."time") AND ("time" < (g."time" + '@ 1 day'::interval)))
+                                 Vectorized Filter: ("time" < now())
                                  ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=0 loops=3)
                                        Filter: ((_ts_meta_max_1 >= g."time") AND (_ts_meta_min_1 < (g."time" + '@ 1 day'::interval)))
                                        Rows Removed by Filter: 6
@@ -3230,7 +3237,8 @@ QUERY PLAN
                            Sort Key: o_5."time" DESC
                            Sort Method: quicksort 
                            ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o_5 (actual rows=0 loops=3)
-                                 Filter: (("time" >= g."time") AND ("time" < (g."time" + '@ 1 day'::interval)) AND ("time" < now()))
+                                 Filter: (("time" >= g."time") AND ("time" < (g."time" + '@ 1 day'::interval)))
+                                 Vectorized Filter: ("time" < now())
                                  ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=0 loops=3)
                                        Filter: ((_ts_meta_max_1 >= g."time") AND (_ts_meta_min_1 < (g."time" + '@ 1 day'::interval)))
                                        Rows Removed by Filter: 18
@@ -3238,7 +3246,8 @@ QUERY PLAN
                            Sort Key: o_6."time" DESC
                            Sort Method: quicksort 
                            ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o_6 (actual rows=0 loops=3)
-                                 Filter: (("time" >= g."time") AND ("time" < (g."time" + '@ 1 day'::interval)) AND ("time" < now()))
+                                 Filter: (("time" >= g."time") AND ("time" < (g."time" + '@ 1 day'::interval)))
+                                 Vectorized Filter: ("time" < now())
                                  ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=0 loops=3)
                                        Filter: ((_ts_meta_max_1 >= g."time") AND (_ts_meta_min_1 < (g."time" + '@ 1 day'::interval)))
                                        Rows Removed by Filter: 6
@@ -3248,8 +3257,9 @@ QUERY PLAN
                            Sort Key: o_7."time" DESC
                            Sort Method: top-N heapsort 
                            ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o_7 (actual rows=720 loops=3)
-                                 Filter: (("time" >= g."time") AND ("time" < (g."time" + '@ 1 day'::interval)) AND ("time" < now()))
+                                 Filter: (("time" >= g."time") AND ("time" < (g."time" + '@ 1 day'::interval)))
                                  Rows Removed by Filter: 813
+                                 Vectorized Filter: ("time" < now())
                                  ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=2 loops=3)
                                        Filter: ((_ts_meta_max_1 >= g."time") AND (_ts_meta_min_1 < (g."time" + '@ 1 day'::interval)))
                                        Rows Removed by Filter: 2
@@ -3257,8 +3267,9 @@ QUERY PLAN
                            Sort Key: o_8."time" DESC
                            Sort Method: top-N heapsort 
                            ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o_8 (actual rows=2160 loops=3)
-                                 Filter: (("time" >= g."time") AND ("time" < (g."time" + '@ 1 day'::interval)) AND ("time" < now()))
+                                 Filter: (("time" >= g."time") AND ("time" < (g."time" + '@ 1 day'::interval)))
                                  Rows Removed by Filter: 2438
+                                 Vectorized Filter: ("time" < now())
                                  ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=5 loops=3)
                                        Filter: ((_ts_meta_max_1 >= g."time") AND (_ts_meta_min_1 < (g."time" + '@ 1 day'::interval)))
                                        Rows Removed by Filter: 7
@@ -3266,12 +3277,13 @@ QUERY PLAN
                            Sort Key: o_9."time" DESC
                            Sort Method: top-N heapsort 
                            ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o_9 (actual rows=720 loops=3)
-                                 Filter: (("time" >= g."time") AND ("time" < (g."time" + '@ 1 day'::interval)) AND ("time" < now()))
+                                 Filter: (("time" >= g."time") AND ("time" < (g."time" + '@ 1 day'::interval)))
                                  Rows Removed by Filter: 813
+                                 Vectorized Filter: ("time" < now())
                                  ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=2 loops=3)
                                        Filter: ((_ts_meta_max_1 >= g."time") AND (_ts_meta_min_1 < (g."time" + '@ 1 day'::interval)))
                                        Rows Removed by Filter: 2
-(86 rows)
+(95 rows)
 
 -- test startup and runtime exclusion together
 -- all chunks should be filtered
@@ -3299,7 +3311,8 @@ QUERY PLAN
                            Sort Key: o_1."time" DESC
                            Sort Method: quicksort 
                            ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o_1 (actual rows=0 loops=3)
-                                 Filter: (("time" >= g."time") AND ("time" < (g."time" + '@ 1 day'::interval)) AND ("time" > now()))
+                                 Filter: (("time" >= g."time") AND ("time" < (g."time" + '@ 1 day'::interval)))
+                                 Vectorized Filter: ("time" > now())
                                  ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=0 loops=3)
                                        Filter: ((_ts_meta_max_1 >= g."time") AND (_ts_meta_min_1 < (g."time" + '@ 1 day'::interval)))
                                        Rows Removed by Filter: 6
@@ -3307,7 +3320,8 @@ QUERY PLAN
                            Sort Key: o_2."time" DESC
                            Sort Method: quicksort 
                            ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o_2 (actual rows=0 loops=3)
-                                 Filter: (("time" >= g."time") AND ("time" < (g."time" + '@ 1 day'::interval)) AND ("time" > now()))
+                                 Filter: (("time" >= g."time") AND ("time" < (g."time" + '@ 1 day'::interval)))
+                                 Vectorized Filter: ("time" > now())
                                  ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=0 loops=3)
                                        Filter: ((_ts_meta_max_1 >= g."time") AND (_ts_meta_min_1 < (g."time" + '@ 1 day'::interval)))
                                        Rows Removed by Filter: 18
@@ -3315,7 +3329,8 @@ QUERY PLAN
                            Sort Key: o_3."time" DESC
                            Sort Method: quicksort 
                            ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o_3 (actual rows=0 loops=3)
-                                 Filter: (("time" >= g."time") AND ("time" < (g."time" + '@ 1 day'::interval)) AND ("time" > now()))
+                                 Filter: (("time" >= g."time") AND ("time" < (g."time" + '@ 1 day'::interval)))
+                                 Vectorized Filter: ("time" > now())
                                  ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=0 loops=3)
                                        Filter: ((_ts_meta_max_1 >= g."time") AND (_ts_meta_min_1 < (g."time" + '@ 1 day'::interval)))
                                        Rows Removed by Filter: 6
@@ -3325,7 +3340,8 @@ QUERY PLAN
                            Sort Key: o_4."time" DESC
                            Sort Method: quicksort 
                            ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o_4 (actual rows=0 loops=3)
-                                 Filter: (("time" >= g."time") AND ("time" < (g."time" + '@ 1 day'::interval)) AND ("time" > now()))
+                                 Filter: (("time" >= g."time") AND ("time" < (g."time" + '@ 1 day'::interval)))
+                                 Vectorized Filter: ("time" > now())
                                  ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=0 loops=3)
                                        Filter: ((_ts_meta_max_1 >= g."time") AND (_ts_meta_min_1 < (g."time" + '@ 1 day'::interval)))
                                        Rows Removed by Filter: 6
@@ -3333,7 +3349,8 @@ QUERY PLAN
                            Sort Key: o_5."time" DESC
                            Sort Method: quicksort 
                            ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o_5 (actual rows=0 loops=3)
-                                 Filter: (("time" >= g."time") AND ("time" < (g."time" + '@ 1 day'::interval)) AND ("time" > now()))
+                                 Filter: (("time" >= g."time") AND ("time" < (g."time" + '@ 1 day'::interval)))
+                                 Vectorized Filter: ("time" > now())
                                  ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=0 loops=3)
                                        Filter: ((_ts_meta_max_1 >= g."time") AND (_ts_meta_min_1 < (g."time" + '@ 1 day'::interval)))
                                        Rows Removed by Filter: 18
@@ -3341,7 +3358,8 @@ QUERY PLAN
                            Sort Key: o_6."time" DESC
                            Sort Method: quicksort 
                            ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o_6 (actual rows=0 loops=3)
-                                 Filter: (("time" >= g."time") AND ("time" < (g."time" + '@ 1 day'::interval)) AND ("time" > now()))
+                                 Filter: (("time" >= g."time") AND ("time" < (g."time" + '@ 1 day'::interval)))
+                                 Vectorized Filter: ("time" > now())
                                  ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=0 loops=3)
                                        Filter: ((_ts_meta_max_1 >= g."time") AND (_ts_meta_min_1 < (g."time" + '@ 1 day'::interval)))
                                        Rows Removed by Filter: 6
@@ -3351,8 +3369,9 @@ QUERY PLAN
                            Sort Key: o_7."time" DESC
                            Sort Method: quicksort 
                            ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o_7 (actual rows=0 loops=3)
-                                 Filter: (("time" >= g."time") AND ("time" < (g."time" + '@ 1 day'::interval)) AND ("time" > now()))
+                                 Filter: (("time" >= g."time") AND ("time" < (g."time" + '@ 1 day'::interval)))
                                  Rows Removed by Filter: 1533
+                                 Vectorized Filter: ("time" > now())
                                  ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=2 loops=3)
                                        Filter: ((_ts_meta_max_1 >= g."time") AND (_ts_meta_min_1 < (g."time" + '@ 1 day'::interval)))
                                        Rows Removed by Filter: 2
@@ -3360,8 +3379,9 @@ QUERY PLAN
                            Sort Key: o_8."time" DESC
                            Sort Method: quicksort 
                            ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o_8 (actual rows=0 loops=3)
-                                 Filter: (("time" >= g."time") AND ("time" < (g."time" + '@ 1 day'::interval)) AND ("time" > now()))
+                                 Filter: (("time" >= g."time") AND ("time" < (g."time" + '@ 1 day'::interval)))
                                  Rows Removed by Filter: 4598
+                                 Vectorized Filter: ("time" > now())
                                  ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=5 loops=3)
                                        Filter: ((_ts_meta_max_1 >= g."time") AND (_ts_meta_min_1 < (g."time" + '@ 1 day'::interval)))
                                        Rows Removed by Filter: 7
@@ -3369,12 +3389,13 @@ QUERY PLAN
                            Sort Key: o_9."time" DESC
                            Sort Method: quicksort 
                            ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o_9 (actual rows=0 loops=3)
-                                 Filter: (("time" >= g."time") AND ("time" < (g."time" + '@ 1 day'::interval)) AND ("time" > now()))
+                                 Filter: (("time" >= g."time") AND ("time" < (g."time" + '@ 1 day'::interval)))
                                  Rows Removed by Filter: 1533
+                                 Vectorized Filter: ("time" > now())
                                  ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=2 loops=3)
                                        Filter: ((_ts_meta_max_1 >= g."time") AND (_ts_meta_min_1 < (g."time" + '@ 1 day'::interval)))
                                        Rows Removed by Filter: 2
-(86 rows)
+(95 rows)
 
 -- test JOIN
 -- no exclusion on joined table because quals are not propagated yet

--- a/tsl/test/shared/expected/ordered_append_join-14.out
+++ b/tsl/test/shared/expected/ordered_append_join-14.out
@@ -2074,25 +2074,28 @@ QUERY PLAN
                ->  Sort (never executed)
                      Sort Key: o_1."time" DESC
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o_1 (never executed)
-                           Filter: (("time" >= g."time") AND ("time" < (g."time" + '@ 1 day'::interval)) AND ("time" < now()))
+                           Filter: (("time" >= g."time") AND ("time" < (g."time" + '@ 1 day'::interval)))
+                           Vectorized Filter: ("time" < now())
                            ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
                                  Filter: ((_ts_meta_max_1 >= g."time") AND (_ts_meta_min_1 < (g."time" + '@ 1 day'::interval)))
                ->  Sort (never executed)
                      Sort Key: o_2."time" DESC
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o_2 (never executed)
-                           Filter: (("time" >= g."time") AND ("time" < (g."time" + '@ 1 day'::interval)) AND ("time" < now()))
+                           Filter: (("time" >= g."time") AND ("time" < (g."time" + '@ 1 day'::interval)))
+                           Vectorized Filter: ("time" < now())
                            ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
                                  Filter: ((_ts_meta_max_1 >= g."time") AND (_ts_meta_min_1 < (g."time" + '@ 1 day'::interval)))
                ->  Sort (actual rows=1 loops=3)
                      Sort Key: o_3."time" DESC
                      Sort Method: top-N heapsort 
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o_3 (actual rows=3600 loops=3)
-                           Filter: (("time" >= g."time") AND ("time" < (g."time" + '@ 1 day'::interval)) AND ("time" < now()))
+                           Filter: (("time" >= g."time") AND ("time" < (g."time" + '@ 1 day'::interval)))
                            Rows Removed by Filter: 4063
+                           Vectorized Filter: ("time" < now())
                            ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=8 loops=3)
                                  Filter: ((_ts_meta_max_1 >= g."time") AND (_ts_meta_min_1 < (g."time" + '@ 1 day'::interval)))
                                  Rows Removed by Filter: 12
-(28 rows)
+(31 rows)
 
 -- test startup and runtime exclusion together
 -- all chunks should be filtered
@@ -3196,7 +3199,8 @@ QUERY PLAN
                            Sort Key: o_1."time" DESC
                            Sort Method: quicksort 
                            ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o_1 (actual rows=0 loops=3)
-                                 Filter: (("time" >= g."time") AND ("time" < (g."time" + '@ 1 day'::interval)) AND ("time" < now()))
+                                 Filter: (("time" >= g."time") AND ("time" < (g."time" + '@ 1 day'::interval)))
+                                 Vectorized Filter: ("time" < now())
                                  ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=0 loops=3)
                                        Filter: ((_ts_meta_max_1 >= g."time") AND (_ts_meta_min_1 < (g."time" + '@ 1 day'::interval)))
                                        Rows Removed by Filter: 6
@@ -3204,7 +3208,8 @@ QUERY PLAN
                            Sort Key: o_2."time" DESC
                            Sort Method: quicksort 
                            ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o_2 (actual rows=0 loops=3)
-                                 Filter: (("time" >= g."time") AND ("time" < (g."time" + '@ 1 day'::interval)) AND ("time" < now()))
+                                 Filter: (("time" >= g."time") AND ("time" < (g."time" + '@ 1 day'::interval)))
+                                 Vectorized Filter: ("time" < now())
                                  ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=0 loops=3)
                                        Filter: ((_ts_meta_max_1 >= g."time") AND (_ts_meta_min_1 < (g."time" + '@ 1 day'::interval)))
                                        Rows Removed by Filter: 18
@@ -3212,7 +3217,8 @@ QUERY PLAN
                            Sort Key: o_3."time" DESC
                            Sort Method: quicksort 
                            ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o_3 (actual rows=0 loops=3)
-                                 Filter: (("time" >= g."time") AND ("time" < (g."time" + '@ 1 day'::interval)) AND ("time" < now()))
+                                 Filter: (("time" >= g."time") AND ("time" < (g."time" + '@ 1 day'::interval)))
+                                 Vectorized Filter: ("time" < now())
                                  ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=0 loops=3)
                                        Filter: ((_ts_meta_max_1 >= g."time") AND (_ts_meta_min_1 < (g."time" + '@ 1 day'::interval)))
                                        Rows Removed by Filter: 6
@@ -3222,7 +3228,8 @@ QUERY PLAN
                            Sort Key: o_4."time" DESC
                            Sort Method: quicksort 
                            ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o_4 (actual rows=0 loops=3)
-                                 Filter: (("time" >= g."time") AND ("time" < (g."time" + '@ 1 day'::interval)) AND ("time" < now()))
+                                 Filter: (("time" >= g."time") AND ("time" < (g."time" + '@ 1 day'::interval)))
+                                 Vectorized Filter: ("time" < now())
                                  ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=0 loops=3)
                                        Filter: ((_ts_meta_max_1 >= g."time") AND (_ts_meta_min_1 < (g."time" + '@ 1 day'::interval)))
                                        Rows Removed by Filter: 6
@@ -3230,7 +3237,8 @@ QUERY PLAN
                            Sort Key: o_5."time" DESC
                            Sort Method: quicksort 
                            ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o_5 (actual rows=0 loops=3)
-                                 Filter: (("time" >= g."time") AND ("time" < (g."time" + '@ 1 day'::interval)) AND ("time" < now()))
+                                 Filter: (("time" >= g."time") AND ("time" < (g."time" + '@ 1 day'::interval)))
+                                 Vectorized Filter: ("time" < now())
                                  ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=0 loops=3)
                                        Filter: ((_ts_meta_max_1 >= g."time") AND (_ts_meta_min_1 < (g."time" + '@ 1 day'::interval)))
                                        Rows Removed by Filter: 18
@@ -3238,7 +3246,8 @@ QUERY PLAN
                            Sort Key: o_6."time" DESC
                            Sort Method: quicksort 
                            ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o_6 (actual rows=0 loops=3)
-                                 Filter: (("time" >= g."time") AND ("time" < (g."time" + '@ 1 day'::interval)) AND ("time" < now()))
+                                 Filter: (("time" >= g."time") AND ("time" < (g."time" + '@ 1 day'::interval)))
+                                 Vectorized Filter: ("time" < now())
                                  ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=0 loops=3)
                                        Filter: ((_ts_meta_max_1 >= g."time") AND (_ts_meta_min_1 < (g."time" + '@ 1 day'::interval)))
                                        Rows Removed by Filter: 6
@@ -3248,8 +3257,9 @@ QUERY PLAN
                            Sort Key: o_7."time" DESC
                            Sort Method: top-N heapsort 
                            ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o_7 (actual rows=720 loops=3)
-                                 Filter: (("time" >= g."time") AND ("time" < (g."time" + '@ 1 day'::interval)) AND ("time" < now()))
+                                 Filter: (("time" >= g."time") AND ("time" < (g."time" + '@ 1 day'::interval)))
                                  Rows Removed by Filter: 813
+                                 Vectorized Filter: ("time" < now())
                                  ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=2 loops=3)
                                        Filter: ((_ts_meta_max_1 >= g."time") AND (_ts_meta_min_1 < (g."time" + '@ 1 day'::interval)))
                                        Rows Removed by Filter: 2
@@ -3257,8 +3267,9 @@ QUERY PLAN
                            Sort Key: o_8."time" DESC
                            Sort Method: top-N heapsort 
                            ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o_8 (actual rows=2160 loops=3)
-                                 Filter: (("time" >= g."time") AND ("time" < (g."time" + '@ 1 day'::interval)) AND ("time" < now()))
+                                 Filter: (("time" >= g."time") AND ("time" < (g."time" + '@ 1 day'::interval)))
                                  Rows Removed by Filter: 2438
+                                 Vectorized Filter: ("time" < now())
                                  ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=5 loops=3)
                                        Filter: ((_ts_meta_max_1 >= g."time") AND (_ts_meta_min_1 < (g."time" + '@ 1 day'::interval)))
                                        Rows Removed by Filter: 7
@@ -3266,12 +3277,13 @@ QUERY PLAN
                            Sort Key: o_9."time" DESC
                            Sort Method: top-N heapsort 
                            ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o_9 (actual rows=720 loops=3)
-                                 Filter: (("time" >= g."time") AND ("time" < (g."time" + '@ 1 day'::interval)) AND ("time" < now()))
+                                 Filter: (("time" >= g."time") AND ("time" < (g."time" + '@ 1 day'::interval)))
                                  Rows Removed by Filter: 813
+                                 Vectorized Filter: ("time" < now())
                                  ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=2 loops=3)
                                        Filter: ((_ts_meta_max_1 >= g."time") AND (_ts_meta_min_1 < (g."time" + '@ 1 day'::interval)))
                                        Rows Removed by Filter: 2
-(86 rows)
+(95 rows)
 
 -- test startup and runtime exclusion together
 -- all chunks should be filtered
@@ -3299,7 +3311,8 @@ QUERY PLAN
                            Sort Key: o_1."time" DESC
                            Sort Method: quicksort 
                            ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o_1 (actual rows=0 loops=3)
-                                 Filter: (("time" >= g."time") AND ("time" < (g."time" + '@ 1 day'::interval)) AND ("time" > now()))
+                                 Filter: (("time" >= g."time") AND ("time" < (g."time" + '@ 1 day'::interval)))
+                                 Vectorized Filter: ("time" > now())
                                  ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=0 loops=3)
                                        Filter: ((_ts_meta_max_1 >= g."time") AND (_ts_meta_min_1 < (g."time" + '@ 1 day'::interval)))
                                        Rows Removed by Filter: 6
@@ -3307,7 +3320,8 @@ QUERY PLAN
                            Sort Key: o_2."time" DESC
                            Sort Method: quicksort 
                            ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o_2 (actual rows=0 loops=3)
-                                 Filter: (("time" >= g."time") AND ("time" < (g."time" + '@ 1 day'::interval)) AND ("time" > now()))
+                                 Filter: (("time" >= g."time") AND ("time" < (g."time" + '@ 1 day'::interval)))
+                                 Vectorized Filter: ("time" > now())
                                  ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=0 loops=3)
                                        Filter: ((_ts_meta_max_1 >= g."time") AND (_ts_meta_min_1 < (g."time" + '@ 1 day'::interval)))
                                        Rows Removed by Filter: 18
@@ -3315,7 +3329,8 @@ QUERY PLAN
                            Sort Key: o_3."time" DESC
                            Sort Method: quicksort 
                            ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o_3 (actual rows=0 loops=3)
-                                 Filter: (("time" >= g."time") AND ("time" < (g."time" + '@ 1 day'::interval)) AND ("time" > now()))
+                                 Filter: (("time" >= g."time") AND ("time" < (g."time" + '@ 1 day'::interval)))
+                                 Vectorized Filter: ("time" > now())
                                  ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=0 loops=3)
                                        Filter: ((_ts_meta_max_1 >= g."time") AND (_ts_meta_min_1 < (g."time" + '@ 1 day'::interval)))
                                        Rows Removed by Filter: 6
@@ -3325,7 +3340,8 @@ QUERY PLAN
                            Sort Key: o_4."time" DESC
                            Sort Method: quicksort 
                            ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o_4 (actual rows=0 loops=3)
-                                 Filter: (("time" >= g."time") AND ("time" < (g."time" + '@ 1 day'::interval)) AND ("time" > now()))
+                                 Filter: (("time" >= g."time") AND ("time" < (g."time" + '@ 1 day'::interval)))
+                                 Vectorized Filter: ("time" > now())
                                  ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=0 loops=3)
                                        Filter: ((_ts_meta_max_1 >= g."time") AND (_ts_meta_min_1 < (g."time" + '@ 1 day'::interval)))
                                        Rows Removed by Filter: 6
@@ -3333,7 +3349,8 @@ QUERY PLAN
                            Sort Key: o_5."time" DESC
                            Sort Method: quicksort 
                            ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o_5 (actual rows=0 loops=3)
-                                 Filter: (("time" >= g."time") AND ("time" < (g."time" + '@ 1 day'::interval)) AND ("time" > now()))
+                                 Filter: (("time" >= g."time") AND ("time" < (g."time" + '@ 1 day'::interval)))
+                                 Vectorized Filter: ("time" > now())
                                  ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=0 loops=3)
                                        Filter: ((_ts_meta_max_1 >= g."time") AND (_ts_meta_min_1 < (g."time" + '@ 1 day'::interval)))
                                        Rows Removed by Filter: 18
@@ -3341,7 +3358,8 @@ QUERY PLAN
                            Sort Key: o_6."time" DESC
                            Sort Method: quicksort 
                            ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o_6 (actual rows=0 loops=3)
-                                 Filter: (("time" >= g."time") AND ("time" < (g."time" + '@ 1 day'::interval)) AND ("time" > now()))
+                                 Filter: (("time" >= g."time") AND ("time" < (g."time" + '@ 1 day'::interval)))
+                                 Vectorized Filter: ("time" > now())
                                  ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=0 loops=3)
                                        Filter: ((_ts_meta_max_1 >= g."time") AND (_ts_meta_min_1 < (g."time" + '@ 1 day'::interval)))
                                        Rows Removed by Filter: 6
@@ -3351,8 +3369,9 @@ QUERY PLAN
                            Sort Key: o_7."time" DESC
                            Sort Method: quicksort 
                            ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o_7 (actual rows=0 loops=3)
-                                 Filter: (("time" >= g."time") AND ("time" < (g."time" + '@ 1 day'::interval)) AND ("time" > now()))
+                                 Filter: (("time" >= g."time") AND ("time" < (g."time" + '@ 1 day'::interval)))
                                  Rows Removed by Filter: 1533
+                                 Vectorized Filter: ("time" > now())
                                  ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=2 loops=3)
                                        Filter: ((_ts_meta_max_1 >= g."time") AND (_ts_meta_min_1 < (g."time" + '@ 1 day'::interval)))
                                        Rows Removed by Filter: 2
@@ -3360,8 +3379,9 @@ QUERY PLAN
                            Sort Key: o_8."time" DESC
                            Sort Method: quicksort 
                            ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o_8 (actual rows=0 loops=3)
-                                 Filter: (("time" >= g."time") AND ("time" < (g."time" + '@ 1 day'::interval)) AND ("time" > now()))
+                                 Filter: (("time" >= g."time") AND ("time" < (g."time" + '@ 1 day'::interval)))
                                  Rows Removed by Filter: 4598
+                                 Vectorized Filter: ("time" > now())
                                  ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=5 loops=3)
                                        Filter: ((_ts_meta_max_1 >= g."time") AND (_ts_meta_min_1 < (g."time" + '@ 1 day'::interval)))
                                        Rows Removed by Filter: 7
@@ -3369,12 +3389,13 @@ QUERY PLAN
                            Sort Key: o_9."time" DESC
                            Sort Method: quicksort 
                            ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o_9 (actual rows=0 loops=3)
-                                 Filter: (("time" >= g."time") AND ("time" < (g."time" + '@ 1 day'::interval)) AND ("time" > now()))
+                                 Filter: (("time" >= g."time") AND ("time" < (g."time" + '@ 1 day'::interval)))
                                  Rows Removed by Filter: 1533
+                                 Vectorized Filter: ("time" > now())
                                  ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=2 loops=3)
                                        Filter: ((_ts_meta_max_1 >= g."time") AND (_ts_meta_min_1 < (g."time" + '@ 1 day'::interval)))
                                        Rows Removed by Filter: 2
-(86 rows)
+(95 rows)
 
 -- test JOIN
 -- no exclusion on joined table because quals are not propagated yet

--- a/tsl/test/shared/expected/ordered_append_join-15.out
+++ b/tsl/test/shared/expected/ordered_append_join-15.out
@@ -2090,25 +2090,28 @@ QUERY PLAN
                      ->  Sort (never executed)
                            Sort Key: o_1."time" DESC
                            ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o_1 (never executed)
-                                 Filter: (("time" >= g."time") AND ("time" < (g."time" + '@ 1 day'::interval)) AND ("time" < now()))
+                                 Filter: (("time" >= g."time") AND ("time" < (g."time" + '@ 1 day'::interval)))
+                                 Vectorized Filter: ("time" < now())
                                  ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
                                        Filter: ((_ts_meta_max_1 >= g."time") AND (_ts_meta_min_1 < (g."time" + '@ 1 day'::interval)))
                      ->  Sort (never executed)
                            Sort Key: o_2."time" DESC
                            ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o_2 (never executed)
-                                 Filter: (("time" >= g."time") AND ("time" < (g."time" + '@ 1 day'::interval)) AND ("time" < now()))
+                                 Filter: (("time" >= g."time") AND ("time" < (g."time" + '@ 1 day'::interval)))
+                                 Vectorized Filter: ("time" < now())
                                  ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
                                        Filter: ((_ts_meta_max_1 >= g."time") AND (_ts_meta_min_1 < (g."time" + '@ 1 day'::interval)))
                      ->  Sort (actual rows=1 loops=3)
                            Sort Key: o_3."time" DESC
                            Sort Method: top-N heapsort 
                            ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o_3 (actual rows=3600 loops=3)
-                                 Filter: (("time" >= g."time") AND ("time" < (g."time" + '@ 1 day'::interval)) AND ("time" < now()))
+                                 Filter: (("time" >= g."time") AND ("time" < (g."time" + '@ 1 day'::interval)))
                                  Rows Removed by Filter: 4063
+                                 Vectorized Filter: ("time" < now())
                                  ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=8 loops=3)
                                        Filter: ((_ts_meta_max_1 >= g."time") AND (_ts_meta_min_1 < (g."time" + '@ 1 day'::interval)))
                                        Rows Removed by Filter: 12
-(29 rows)
+(32 rows)
 
 -- test startup and runtime exclusion together
 -- all chunks should be filtered
@@ -3218,7 +3221,8 @@ QUERY PLAN
                                  Sort Key: o_1."time" DESC
                                  Sort Method: quicksort 
                                  ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o_1 (actual rows=0 loops=3)
-                                       Filter: (("time" >= g."time") AND ("time" < (g."time" + '@ 1 day'::interval)) AND ("time" < now()))
+                                       Filter: (("time" >= g."time") AND ("time" < (g."time" + '@ 1 day'::interval)))
+                                       Vectorized Filter: ("time" < now())
                                        ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=0 loops=3)
                                              Filter: ((_ts_meta_max_1 >= g."time") AND (_ts_meta_min_1 < (g."time" + '@ 1 day'::interval)))
                                              Rows Removed by Filter: 6
@@ -3226,7 +3230,8 @@ QUERY PLAN
                                  Sort Key: o_2."time" DESC
                                  Sort Method: quicksort 
                                  ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o_2 (actual rows=0 loops=3)
-                                       Filter: (("time" >= g."time") AND ("time" < (g."time" + '@ 1 day'::interval)) AND ("time" < now()))
+                                       Filter: (("time" >= g."time") AND ("time" < (g."time" + '@ 1 day'::interval)))
+                                       Vectorized Filter: ("time" < now())
                                        ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=0 loops=3)
                                              Filter: ((_ts_meta_max_1 >= g."time") AND (_ts_meta_min_1 < (g."time" + '@ 1 day'::interval)))
                                              Rows Removed by Filter: 18
@@ -3234,7 +3239,8 @@ QUERY PLAN
                                  Sort Key: o_3."time" DESC
                                  Sort Method: quicksort 
                                  ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o_3 (actual rows=0 loops=3)
-                                       Filter: (("time" >= g."time") AND ("time" < (g."time" + '@ 1 day'::interval)) AND ("time" < now()))
+                                       Filter: (("time" >= g."time") AND ("time" < (g."time" + '@ 1 day'::interval)))
+                                       Vectorized Filter: ("time" < now())
                                        ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=0 loops=3)
                                              Filter: ((_ts_meta_max_1 >= g."time") AND (_ts_meta_min_1 < (g."time" + '@ 1 day'::interval)))
                                              Rows Removed by Filter: 6
@@ -3244,7 +3250,8 @@ QUERY PLAN
                                  Sort Key: o_4."time" DESC
                                  Sort Method: quicksort 
                                  ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o_4 (actual rows=0 loops=3)
-                                       Filter: (("time" >= g."time") AND ("time" < (g."time" + '@ 1 day'::interval)) AND ("time" < now()))
+                                       Filter: (("time" >= g."time") AND ("time" < (g."time" + '@ 1 day'::interval)))
+                                       Vectorized Filter: ("time" < now())
                                        ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=0 loops=3)
                                              Filter: ((_ts_meta_max_1 >= g."time") AND (_ts_meta_min_1 < (g."time" + '@ 1 day'::interval)))
                                              Rows Removed by Filter: 6
@@ -3252,7 +3259,8 @@ QUERY PLAN
                                  Sort Key: o_5."time" DESC
                                  Sort Method: quicksort 
                                  ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o_5 (actual rows=0 loops=3)
-                                       Filter: (("time" >= g."time") AND ("time" < (g."time" + '@ 1 day'::interval)) AND ("time" < now()))
+                                       Filter: (("time" >= g."time") AND ("time" < (g."time" + '@ 1 day'::interval)))
+                                       Vectorized Filter: ("time" < now())
                                        ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=0 loops=3)
                                              Filter: ((_ts_meta_max_1 >= g."time") AND (_ts_meta_min_1 < (g."time" + '@ 1 day'::interval)))
                                              Rows Removed by Filter: 18
@@ -3260,7 +3268,8 @@ QUERY PLAN
                                  Sort Key: o_6."time" DESC
                                  Sort Method: quicksort 
                                  ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o_6 (actual rows=0 loops=3)
-                                       Filter: (("time" >= g."time") AND ("time" < (g."time" + '@ 1 day'::interval)) AND ("time" < now()))
+                                       Filter: (("time" >= g."time") AND ("time" < (g."time" + '@ 1 day'::interval)))
+                                       Vectorized Filter: ("time" < now())
                                        ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=0 loops=3)
                                              Filter: ((_ts_meta_max_1 >= g."time") AND (_ts_meta_min_1 < (g."time" + '@ 1 day'::interval)))
                                              Rows Removed by Filter: 6
@@ -3270,8 +3279,9 @@ QUERY PLAN
                                  Sort Key: o_7."time" DESC
                                  Sort Method: top-N heapsort 
                                  ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o_7 (actual rows=720 loops=3)
-                                       Filter: (("time" >= g."time") AND ("time" < (g."time" + '@ 1 day'::interval)) AND ("time" < now()))
+                                       Filter: (("time" >= g."time") AND ("time" < (g."time" + '@ 1 day'::interval)))
                                        Rows Removed by Filter: 813
+                                       Vectorized Filter: ("time" < now())
                                        ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=2 loops=3)
                                              Filter: ((_ts_meta_max_1 >= g."time") AND (_ts_meta_min_1 < (g."time" + '@ 1 day'::interval)))
                                              Rows Removed by Filter: 2
@@ -3279,8 +3289,9 @@ QUERY PLAN
                                  Sort Key: o_8."time" DESC
                                  Sort Method: top-N heapsort 
                                  ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o_8 (actual rows=2160 loops=3)
-                                       Filter: (("time" >= g."time") AND ("time" < (g."time" + '@ 1 day'::interval)) AND ("time" < now()))
+                                       Filter: (("time" >= g."time") AND ("time" < (g."time" + '@ 1 day'::interval)))
                                        Rows Removed by Filter: 2438
+                                       Vectorized Filter: ("time" < now())
                                        ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=5 loops=3)
                                              Filter: ((_ts_meta_max_1 >= g."time") AND (_ts_meta_min_1 < (g."time" + '@ 1 day'::interval)))
                                              Rows Removed by Filter: 7
@@ -3288,12 +3299,13 @@ QUERY PLAN
                                  Sort Key: o_9."time" DESC
                                  Sort Method: top-N heapsort 
                                  ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o_9 (actual rows=720 loops=3)
-                                       Filter: (("time" >= g."time") AND ("time" < (g."time" + '@ 1 day'::interval)) AND ("time" < now()))
+                                       Filter: (("time" >= g."time") AND ("time" < (g."time" + '@ 1 day'::interval)))
                                        Rows Removed by Filter: 813
+                                       Vectorized Filter: ("time" < now())
                                        ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=2 loops=3)
                                              Filter: ((_ts_meta_max_1 >= g."time") AND (_ts_meta_min_1 < (g."time" + '@ 1 day'::interval)))
                                              Rows Removed by Filter: 2
-(87 rows)
+(96 rows)
 
 -- test startup and runtime exclusion together
 -- all chunks should be filtered
@@ -3322,7 +3334,8 @@ QUERY PLAN
                                  Sort Key: o_1."time" DESC
                                  Sort Method: quicksort 
                                  ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o_1 (actual rows=0 loops=3)
-                                       Filter: (("time" >= g."time") AND ("time" < (g."time" + '@ 1 day'::interval)) AND ("time" > now()))
+                                       Filter: (("time" >= g."time") AND ("time" < (g."time" + '@ 1 day'::interval)))
+                                       Vectorized Filter: ("time" > now())
                                        ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=0 loops=3)
                                              Filter: ((_ts_meta_max_1 >= g."time") AND (_ts_meta_min_1 < (g."time" + '@ 1 day'::interval)))
                                              Rows Removed by Filter: 6
@@ -3330,7 +3343,8 @@ QUERY PLAN
                                  Sort Key: o_2."time" DESC
                                  Sort Method: quicksort 
                                  ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o_2 (actual rows=0 loops=3)
-                                       Filter: (("time" >= g."time") AND ("time" < (g."time" + '@ 1 day'::interval)) AND ("time" > now()))
+                                       Filter: (("time" >= g."time") AND ("time" < (g."time" + '@ 1 day'::interval)))
+                                       Vectorized Filter: ("time" > now())
                                        ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=0 loops=3)
                                              Filter: ((_ts_meta_max_1 >= g."time") AND (_ts_meta_min_1 < (g."time" + '@ 1 day'::interval)))
                                              Rows Removed by Filter: 18
@@ -3338,7 +3352,8 @@ QUERY PLAN
                                  Sort Key: o_3."time" DESC
                                  Sort Method: quicksort 
                                  ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o_3 (actual rows=0 loops=3)
-                                       Filter: (("time" >= g."time") AND ("time" < (g."time" + '@ 1 day'::interval)) AND ("time" > now()))
+                                       Filter: (("time" >= g."time") AND ("time" < (g."time" + '@ 1 day'::interval)))
+                                       Vectorized Filter: ("time" > now())
                                        ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=0 loops=3)
                                              Filter: ((_ts_meta_max_1 >= g."time") AND (_ts_meta_min_1 < (g."time" + '@ 1 day'::interval)))
                                              Rows Removed by Filter: 6
@@ -3348,7 +3363,8 @@ QUERY PLAN
                                  Sort Key: o_4."time" DESC
                                  Sort Method: quicksort 
                                  ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o_4 (actual rows=0 loops=3)
-                                       Filter: (("time" >= g."time") AND ("time" < (g."time" + '@ 1 day'::interval)) AND ("time" > now()))
+                                       Filter: (("time" >= g."time") AND ("time" < (g."time" + '@ 1 day'::interval)))
+                                       Vectorized Filter: ("time" > now())
                                        ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=0 loops=3)
                                              Filter: ((_ts_meta_max_1 >= g."time") AND (_ts_meta_min_1 < (g."time" + '@ 1 day'::interval)))
                                              Rows Removed by Filter: 6
@@ -3356,7 +3372,8 @@ QUERY PLAN
                                  Sort Key: o_5."time" DESC
                                  Sort Method: quicksort 
                                  ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o_5 (actual rows=0 loops=3)
-                                       Filter: (("time" >= g."time") AND ("time" < (g."time" + '@ 1 day'::interval)) AND ("time" > now()))
+                                       Filter: (("time" >= g."time") AND ("time" < (g."time" + '@ 1 day'::interval)))
+                                       Vectorized Filter: ("time" > now())
                                        ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=0 loops=3)
                                              Filter: ((_ts_meta_max_1 >= g."time") AND (_ts_meta_min_1 < (g."time" + '@ 1 day'::interval)))
                                              Rows Removed by Filter: 18
@@ -3364,7 +3381,8 @@ QUERY PLAN
                                  Sort Key: o_6."time" DESC
                                  Sort Method: quicksort 
                                  ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o_6 (actual rows=0 loops=3)
-                                       Filter: (("time" >= g."time") AND ("time" < (g."time" + '@ 1 day'::interval)) AND ("time" > now()))
+                                       Filter: (("time" >= g."time") AND ("time" < (g."time" + '@ 1 day'::interval)))
+                                       Vectorized Filter: ("time" > now())
                                        ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=0 loops=3)
                                              Filter: ((_ts_meta_max_1 >= g."time") AND (_ts_meta_min_1 < (g."time" + '@ 1 day'::interval)))
                                              Rows Removed by Filter: 6
@@ -3374,8 +3392,9 @@ QUERY PLAN
                                  Sort Key: o_7."time" DESC
                                  Sort Method: quicksort 
                                  ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o_7 (actual rows=0 loops=3)
-                                       Filter: (("time" >= g."time") AND ("time" < (g."time" + '@ 1 day'::interval)) AND ("time" > now()))
+                                       Filter: (("time" >= g."time") AND ("time" < (g."time" + '@ 1 day'::interval)))
                                        Rows Removed by Filter: 1533
+                                       Vectorized Filter: ("time" > now())
                                        ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=2 loops=3)
                                              Filter: ((_ts_meta_max_1 >= g."time") AND (_ts_meta_min_1 < (g."time" + '@ 1 day'::interval)))
                                              Rows Removed by Filter: 2
@@ -3383,8 +3402,9 @@ QUERY PLAN
                                  Sort Key: o_8."time" DESC
                                  Sort Method: quicksort 
                                  ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o_8 (actual rows=0 loops=3)
-                                       Filter: (("time" >= g."time") AND ("time" < (g."time" + '@ 1 day'::interval)) AND ("time" > now()))
+                                       Filter: (("time" >= g."time") AND ("time" < (g."time" + '@ 1 day'::interval)))
                                        Rows Removed by Filter: 4598
+                                       Vectorized Filter: ("time" > now())
                                        ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=5 loops=3)
                                              Filter: ((_ts_meta_max_1 >= g."time") AND (_ts_meta_min_1 < (g."time" + '@ 1 day'::interval)))
                                              Rows Removed by Filter: 7
@@ -3392,12 +3412,13 @@ QUERY PLAN
                                  Sort Key: o_9."time" DESC
                                  Sort Method: quicksort 
                                  ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o_9 (actual rows=0 loops=3)
-                                       Filter: (("time" >= g."time") AND ("time" < (g."time" + '@ 1 day'::interval)) AND ("time" > now()))
+                                       Filter: (("time" >= g."time") AND ("time" < (g."time" + '@ 1 day'::interval)))
                                        Rows Removed by Filter: 1533
+                                       Vectorized Filter: ("time" > now())
                                        ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=2 loops=3)
                                              Filter: ((_ts_meta_max_1 >= g."time") AND (_ts_meta_min_1 < (g."time" + '@ 1 day'::interval)))
                                              Rows Removed by Filter: 2
-(87 rows)
+(96 rows)
 
 -- test JOIN
 -- no exclusion on joined table because quals are not propagated yet

--- a/tsl/test/shared/expected/transparent_decompress_chunk-13.out
+++ b/tsl/test/shared/expected/transparent_decompress_chunk-13.out
@@ -408,7 +408,7 @@ QUERY PLAN
          Sort Key: _hyper_X_X_chunk."time", _hyper_X_X_chunk.device_id
          Sort Method: top-N heapsort 
          ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=17990 loops=1)
-               Filter: ("time" < now())
+               Vectorized Filter: ("time" < now())
                ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=20 loops=1)
 (7 rows)
 

--- a/tsl/test/shared/expected/transparent_decompress_chunk-14.out
+++ b/tsl/test/shared/expected/transparent_decompress_chunk-14.out
@@ -408,7 +408,7 @@ QUERY PLAN
          Sort Key: _hyper_X_X_chunk."time", _hyper_X_X_chunk.device_id
          Sort Method: top-N heapsort 
          ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=17990 loops=1)
-               Filter: ("time" < now())
+               Vectorized Filter: ("time" < now())
                ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=20 loops=1)
 (7 rows)
 

--- a/tsl/test/shared/expected/transparent_decompress_chunk-15.out
+++ b/tsl/test/shared/expected/transparent_decompress_chunk-15.out
@@ -410,7 +410,7 @@ QUERY PLAN
          Sort Key: _hyper_X_X_chunk."time", _hyper_X_X_chunk.device_id
          Sort Method: top-N heapsort 
          ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=17990 loops=1)
-               Filter: ("time" < now())
+               Vectorized Filter: ("time" < now())
                ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=20 loops=1)
 (7 rows)
 

--- a/tsl/test/sql/decompress_vector_qual.sql
+++ b/tsl/test/sql/decompress_vector_qual.sql
@@ -73,6 +73,27 @@ select count(*) from vectorqual where metric4 is null;
 select count(*) from vectorqual where metric4 is not null;
 
 
+-- Vectorized filters also work if we have only stable functions on the right
+-- side that can be evaluated to a constant at run time.
+set timescaledb.debug_require_vector_qual to 'only';
+select count(*) from vectorqual where ts > '2021-01-01 00:00:00'::timestamptz::timestamp;
+select count(*) from vectorqual where ts > '2021-01-01 00:00:00'::timestamp - interval '1 day';
+-- Expression that evaluates to Null.
+select count(*) from vectorqual where ts > case when '2021-01-01'::timestamp < '2022-01-01'::timestamptz then null else '2021-01-01 00:00:00'::timestamp end;
+
+-- This filter is not vectorized because the 'timestamp > timestamptz'
+-- operator is stable, not immutable, because it uses the current session
+-- timezone. We could transform it to something like
+-- 'timestamp > timestamptz::timestamp' to allow our stable function evaluation
+-- to handle this case, but we don't do it at the moment.
+set timescaledb.debug_require_vector_qual to 'forbid';
+select count(*) from vectorqual where ts > '2021-01-01 00:00:00'::timestamptz;
+
+-- Can't vectorize comparison with a volatile function.
+select count(*) from vectorqual where metric3 > random()::int - 100;
+select count(*) from vectorqual where ts > case when random() < 10 then null else '2021-01-01 00:00:00'::timestamp end;
+
+
 -- Test that the vectorized quals are disabled by disabling the bulk decompression.
 set timescaledb.enable_bulk_decompression to off;
 set timescaledb.debug_require_vector_qual to 'forbid';


### PR DESCRIPTION
This means vectorizing very common filters such as `ts > now() - interval '1 day'`.

The only query with stable expressions we have in tsbench shows a 130% improvement:
https://grafana.ops.savannah-dev.timescale.com/d/fasYic_4z/compare-akuzm?orgId=1&var-branch=All&var-run1=2853&var-run2=2855&var-threshold=0.05&var-use_historical_thresholds=false

Disable-check: force-changelog-file