### PR TITLE
vectorized comparisons for Date

### DIFF
--- a/tsl/src/nodes/decompress_chunk/pred_vector_const_arithmetic_all.c
+++ b/tsl/src/nodes/decompress_chunk/pred_vector_const_arithmetic_all.c
@@ -84,3 +84,11 @@
 #define PG_PREDICATE(X) F_FLOAT4##X
 
 #include "pred_vector_const_arithmetic_type_pair.c"
+
+/* date functions. */
+#define VECTOR_CTYPE DateADT
+#define CONST_CTYPE DateADT
+#define CONST_CONVERSION(X) DatumGetDateADT(X)
+#define PG_PREDICATE(X) F_DATE_##X
+
+#include "pred_vector_const_arithmetic_type_pair.c"

--- a/tsl/src/nodes/decompress_chunk/vector_predicates.c
+++ b/tsl/src/nodes/decompress_chunk/vector_predicates.c
@@ -10,6 +10,7 @@
 
 #include <postgres.h>
 
+#include <utils/date.h>
 #include <utils/fmgroids.h>
 
 #include "compat/compat.h"

--- a/tsl/test/expected/decompress_vector_qual.out
+++ b/tsl/test/expected/decompress_vector_qual.out
@@ -217,3 +217,54 @@ set timescaledb.debug_require_vector_qual to 'only';
 select count(*) from vectorqual where metric4 is null;
 ERROR:  debug: encountered non-vector quals when they are disabled
 \set ON_ERROR_STOP 1
+-- Date columns
+create table date_table(ts date);
+select create_hypertable('date_table', 'ts');
+NOTICE:  adding not-null constraint to column "ts"
+    create_hypertable    
+-------------------------
+ (3,public,date_table,t)
+(1 row)
+
+alter table date_table set (timescaledb.compress);
+insert into date_table values ('2021-01-01'), ('2021-01-02'),
+    ('2021-01-03');
+select count(compress_chunk(x, true)) from show_chunks('date_table') x;
+ count 
+-------
+     1
+(1 row)
+
+set timescaledb.debug_require_vector_qual to 'only';
+select * from date_table where ts >  '2021-01-02';
+     ts     
+------------
+ 01-03-2021
+(1 row)
+
+select * from date_table where ts >= '2021-01-02';
+     ts     
+------------
+ 01-03-2021
+ 01-02-2021
+(2 rows)
+
+select * from date_table where ts =  '2021-01-02';
+     ts     
+------------
+ 01-02-2021
+(1 row)
+
+select * from date_table where ts <= '2021-01-02';
+     ts     
+------------
+ 01-02-2021
+ 01-01-2021
+(2 rows)
+
+select * from date_table where ts <  '2021-01-02';
+     ts     
+------------
+ 01-01-2021
+(1 row)
+

--- a/tsl/test/sql/decompress_vector_qual.sql
+++ b/tsl/test/sql/decompress_vector_qual.sql
@@ -87,3 +87,19 @@ select count(*) from vectorqual where metric4 > 4;
 set timescaledb.debug_require_vector_qual to 'only';
 select count(*) from vectorqual where metric4 is null;
 \set ON_ERROR_STOP 1
+
+
+-- Date columns
+create table date_table(ts date);
+select create_hypertable('date_table', 'ts');
+alter table date_table set (timescaledb.compress);
+insert into date_table values ('2021-01-01'), ('2021-01-02'),
+    ('2021-01-03');
+select count(compress_chunk(x, true)) from show_chunks('date_table') x;
+
+set timescaledb.debug_require_vector_qual to 'only';
+select * from date_table where ts >  '2021-01-02';
+select * from date_table where ts >= '2021-01-02';
+select * from date_table where ts =  '2021-01-02';
+select * from date_table where ts <= '2021-01-02';
+select * from date_table where ts <  '2021-01-02';


### PR DESCRIPTION
Implement the vectorized comparison operators for Date type, using our existing vector functions for arithmetic comparison.


Disable-check: force-changelog-file