### PR TITLE
PG16: Fix ts_bgw_log_level bootval

### DIFF
--- a/src/guc.c
+++ b/src/guc.c
@@ -727,7 +727,7 @@ _guc_init(void)
 							 "Log level for the scheduler and workers of the background worker "
 							 "subsystem. Requires configuration reload to change.",
 							 /* valueAddr= */ &ts_guc_bgw_log_level,
-							 /* bootValue= */ log_min_messages,
+							 /* bootValue= */ WARNING,
 							 /* options= */ loglevel_options,
 							 /* context= */ PGC_SIGHUP,
 							 0,


### PR DESCRIPTION
When defining a GUC Postgres do a cross-check between the initial value of the C declaration associated to a GUC and its actual boot value in assert-enabled builds.

Previous PR #6206 didn't fixed it entirely and this happen just on PG16.

postgres/postgres@a73952b7

Disable-check: force-changelog-file
