### PR TITLE
Release 2.12.2

### DIFF
--- a/.unreleased/PR_6155
+++ b/.unreleased/PR_6155
@@ -1,1 +1,0 @@
-Fixes: #6155 Align gapfill bucket generation with time_bucket

--- a/.unreleased/pr_6210
+++ b/.unreleased/pr_6210
@@ -1,1 +1,0 @@
-Fixes: #6210 Fix EXPLAIN ANALYZE for compressed DML

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@
 `psql` with the `-X` flag to prevent any `.psqlrc` commands from
 accidentally triggering the load of a previous DB version.**
 
+## 2.12.2 (2023-10-19)
+
+This release contains bug fixes since the 2.12.1 release.
+We recommend that you upgrade at the next available opportunity.
+
+**Bugfixes**
+* #6155 Align gapfill bucket generation with time_bucket
+* #6181 Ensure fixed_schedule field is populated
+* #6210 Fix EXPLAIN ANALYZE for compressed DML
+
 ## 2.12.1 (2023-10-12)
 
 This release contains bug fixes since the 2.12.0 release.

--- a/sql/CMakeLists.txt
+++ b/sql/CMakeLists.txt
@@ -39,7 +39,8 @@ set(MOD_FILES
     updates/2.11.0--2.11.1.sql
     updates/2.11.1--2.11.2.sql
     updates/2.11.2--2.12.0.sql
-    updates/2.12.0--2.12.1.sql)
+    updates/2.12.0--2.12.1.sql
+    updates/2.12.1--2.12.2.sql)
 
 # The downgrade file to generate a downgrade script for the current version, as
 # specified in version.config

--- a/version.config
+++ b/version.config
@@ -1,3 +1,3 @@
 version = 2.13.0-dev
-update_from_version = 2.12.1
+update_from_version = 2.12.2
 downgrade_to_version = 2.12.1


### PR DESCRIPTION
This release contains bug fixes since the 2.12.1 release.
We recommend that you upgrade at the next available opportunity.

**Bugfixes**
* https://github.com/timescale/timescaledb/pull/6155 Align gapfill bucket generation with time_bucket
* https://github.com/timescale/timescaledb/pull/6181 Ensure fixed_schedule field is populated
* https://github.com/timescale/timescaledb/pull/6210 Fix EXPLAIN ANALYZE for compressed DML

Disable-check: force-changelog-file
