### PR TITLE
Backport to 2.12.x: #6155: Align gapfill bucket generation with time_bucket

### DIFF
--- a/.unreleased/PR_6155
+++ b/.unreleased/PR_6155
@@ -1,0 +1,1 @@
+Fixes: #6155 Align gapfill bucket generation with time_bucket

--- a/tsl/src/nodes/gapfill/gapfill_internal.h
+++ b/tsl/src/nodes/gapfill/gapfill_internal.h
@@ -104,6 +104,8 @@ typedef struct GapFillState
 	Interval *gapfill_interval;
 
 	int64 next_timestamp;
+	/* interval offset for next_timestamp from gapfill_start */
+	Interval *next_offset;
 	int64 subslot_time; /* time of tuple in subslot */
 
 	int time_index;			 /* position of time column */

--- a/tsl/test/shared/expected/gapfill.out
+++ b/tsl/test/shared/expected/gapfill.out
@@ -3283,11 +3283,11 @@ SELECT time_bucket_gapfill('2 month'::interval, ts, 'Europe/Berlin', '2000-01-01
      time_bucket_gapfill      
  Fri Dec 31 15:00:00 1999 PST
  Tue Feb 29 15:00:00 2000 PST
- Sat Apr 29 15:00:00 2000 PDT
- Thu Jun 29 15:00:00 2000 PDT
- Tue Aug 29 15:00:00 2000 PDT
- Sun Oct 29 15:00:00 2000 PST
- Fri Dec 29 15:00:00 2000 PST
+ Sun Apr 30 15:00:00 2000 PDT
+ Fri Jun 30 15:00:00 2000 PDT
+ Thu Aug 31 15:00:00 2000 PDT
+ Tue Oct 31 15:00:00 2000 PST
+ Sun Dec 31 15:00:00 2000 PST
 (7 rows)
 
 SELECT time_bucket_gapfill('2 month'::interval, ts, current_setting('timezone'), '2000-01-01','2001-01-01') FROM (VALUES ('2000-03-01'::timestamptz)) v(ts) GROUP BY 1;
@@ -3304,11 +3304,11 @@ SELECT time_bucket_gapfill('2 month'::interval, ts, 'UTC', '2000-01-01','2001-01
      time_bucket_gapfill      
  Fri Dec 31 16:00:00 1999 PST
  Tue Feb 29 16:00:00 2000 PST
- Sat Apr 29 16:00:00 2000 PDT
- Thu Jun 29 16:00:00 2000 PDT
- Tue Aug 29 16:00:00 2000 PDT
- Sun Oct 29 16:00:00 2000 PST
- Fri Dec 29 16:00:00 2000 PST
+ Sun Apr 30 16:00:00 2000 PDT
+ Fri Jun 30 16:00:00 2000 PDT
+ Thu Aug 31 16:00:00 2000 PDT
+ Tue Oct 31 16:00:00 2000 PST
+ Sun Dec 31 16:00:00 2000 PST
 (7 rows)
 
 SET timezone TO 'Europe/Berlin';
@@ -3330,7 +3330,7 @@ FROM (
     SELECT ARRAY[1,2,3,4]::int[] as int_arr, x as ts, x+500000 as value
     FROM generate_series(1, 10, 100) as x
     ) t
-GROUP BY 1, 2
+GROUP BY 1, 2;
  ts |  int_arr  |  locf  
 ----+-----------+--------
   0 | {1,2,3,4} | 500001
@@ -3355,3 +3355,30 @@ GROUP BY 1, 2
  95 | {1,2,3,4} | 500001
 (20 rows)
 
+-- Test gapfill is aligned with non-gapfill time_bucket
+-- when using different timezones and month bucketing
+CREATE TABLE month_timezone(time timestamptz NOT NULL, value float);
+SELECT table_name FROM create_hypertable('month_timezone','time');
+   table_name   
+ month_timezone
+(1 row)
+
+INSERT INTO month_timezone VALUES ('2023-03-01 14:05:00+01', 3.123), ('2023-04-01 14:05:00+01',4.123), ('2023-05-01 14:05:00+01', 5.123);
+SELECT
+  time_bucket_gapfill('1 month'::interval, time, 'Europe/Berlin', '2023-01-01', '2023-07-01') AS time,
+  sum(value)
+FROM
+  month_timezone
+GROUP BY 1;
+             time             |  sum  
+------------------------------+-------
+ Sat Dec 31 15:00:00 2022 PST |      
+ Tue Jan 31 15:00:00 2023 PST |      
+ Tue Feb 28 15:00:00 2023 PST | 3.123
+ Fri Mar 31 15:00:00 2023 PDT | 4.123
+ Sun Apr 30 15:00:00 2023 PDT | 5.123
+ Wed May 31 15:00:00 2023 PDT |      
+ Fri Jun 30 15:00:00 2023 PDT |      
+(7 rows)
+
+DROP TABLE month_timezone;

--- a/tsl/test/shared/sql/gapfill.sql
+++ b/tsl/test/shared/sql/gapfill.sql
@@ -1512,4 +1512,20 @@ FROM (
     SELECT ARRAY[1,2,3,4]::int[] as int_arr, x as ts, x+500000 as value
     FROM generate_series(1, 10, 100) as x
     ) t
-GROUP BY 1, 2
+GROUP BY 1, 2;
+
+-- Test gapfill is aligned with non-gapfill time_bucket
+-- when using different timezones and month bucketing
+CREATE TABLE month_timezone(time timestamptz NOT NULL, value float);
+SELECT table_name FROM create_hypertable('month_timezone','time');
+
+INSERT INTO month_timezone VALUES ('2023-03-01 14:05:00+01', 3.123), ('2023-04-01 14:05:00+01',4.123), ('2023-05-01 14:05:00+01', 5.123);
+
+SELECT
+  time_bucket_gapfill('1 month'::interval, time, 'Europe/Berlin', '2023-01-01', '2023-07-01') AS time,
+  sum(value)
+FROM
+  month_timezone
+GROUP BY 1;
+
+DROP TABLE month_timezone;


### PR DESCRIPTION
In certain scenarios, when generating buckets with monthly buckets and different timezones, gapfill
would create timestamps which don't align with
time_bucket and thus potentially generating multiple rows for an individual month. Instead of relying on previous timestamp to generate the next one, now
we generate them always from the start point
which will make us align with time_bucket buckets.

Disable-check: force-changelog-file