### PR TITLE
Support for segment_by filters on vector aggs

### DIFF
--- a/tsl/src/nodes/decompress_chunk/exec.c
+++ b/tsl/src/nodes/decompress_chunk/exec.c
@@ -514,6 +514,12 @@ perform_vectorized_sum_int4(DecompressChunkState *chunk_state, Aggref *aggref)
 	TupleTableSlot *decompressed_scan_slot = chunk_state->csstate.ss.ss_ScanTupleSlot;
 	Assert(decompressed_scan_slot->tts_tupleDescriptor->natts == 1);
 
+	/* Set all attributes of the result tuple to NULL. So, we return NULL if no data is processed
+	 * by our implementation. In addition, the call marks the slot as beeing used (i.e., no
+	 * ExecStoreVirtualTuple call is required). */
+	ExecStoreAllNullTuple(decompressed_scan_slot);
+	Assert(!TupIsNull(decompressed_scan_slot));
+
 	int64 result_sum = 0;
 
 	if (column_description->type == SEGMENTBY_COLUMN)
@@ -668,7 +674,6 @@ perform_vectorized_sum_int4(DecompressChunkState *chunk_state, Aggref *aggref)
 	 * systems */
 	decompressed_scan_slot->tts_values[0] = Int64GetDatum(result_sum);
 
-	ExecStoreVirtualTuple(decompressed_scan_slot);
 	return decompressed_scan_slot;
 }
 

--- a/tsl/test/expected/compression_qualpushdown.out
+++ b/tsl/test/expected/compression_qualpushdown.out
@@ -289,24 +289,22 @@ SELECT compress_chunk(i) FROM show_chunks('deleteme') i;
 (1 row)
 
 EXPLAIN (costs off) SELECT sum(data) FROM deleteme WHERE segment::text like '%4%';
-                          QUERY PLAN                           
----------------------------------------------------------------
+                       QUERY PLAN                        
+---------------------------------------------------------
  Finalize Aggregate
-   ->  Partial Aggregate
-         ->  Custom Scan (DecompressChunk) on _hyper_7_8_chunk
-               ->  Seq Scan on compress_hyper_8_9_chunk
-                     Filter: ((segment)::text ~~ '%4%'::text)
-(5 rows)
+   ->  Custom Scan (DecompressChunk) on _hyper_7_8_chunk
+         ->  Seq Scan on compress_hyper_8_9_chunk
+               Filter: ((segment)::text ~~ '%4%'::text)
+(4 rows)
 
 EXPLAIN (costs off) SELECT sum(data) FROM deleteme WHERE '4' = segment::text;
-                          QUERY PLAN                           
----------------------------------------------------------------
+                       QUERY PLAN                        
+---------------------------------------------------------
  Finalize Aggregate
-   ->  Partial Aggregate
-         ->  Custom Scan (DecompressChunk) on _hyper_7_8_chunk
-               ->  Seq Scan on compress_hyper_8_9_chunk
-                     Filter: ('4'::text = (segment)::text)
-(5 rows)
+   ->  Custom Scan (DecompressChunk) on _hyper_7_8_chunk
+         ->  Seq Scan on compress_hyper_8_9_chunk
+               Filter: ('4'::text = (segment)::text)
+(4 rows)
 
 CREATE TABLE deleteme_with_bytea(time bigint NOT NULL, bdata bytea);
 SELECT create_hypertable('deleteme_with_bytea', 'time', chunk_time_interval => 1000000);

--- a/tsl/test/expected/vectorized_aggregation.out
+++ b/tsl/test/expected/vectorized_aggregation.out
@@ -98,35 +98,32 @@ SELECT sum(segment_by_value) FROM testtable;
                      Output: _hyper_1_10_chunk.segment_by_value
 (46 rows)
 
--- Vectorization not possible due to a used filter
+-- Vectorization possible - filter on segment_by
 :EXPLAIN
 SELECT sum(segment_by_value) FROM testtable WHERE segment_by_value > 0;
-                                                                                                                                                                                QUERY PLAN                                                                                                                                                                                 
----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                                                                                                             QUERY PLAN                                                                                                                                                                              
+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Finalize Aggregate
    Output: sum(_hyper_1_1_chunk.segment_by_value)
    ->  Append
-         ->  Partial Aggregate
-               Output: PARTIAL sum(_hyper_1_1_chunk.segment_by_value)
-               ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_1_chunk
-                     Output: _hyper_1_1_chunk.segment_by_value
-                     ->  Index Scan using compress_hyper_2_11_chunk__compressed_hypertable_2_segment_by_v on _timescaledb_internal.compress_hyper_2_11_chunk
-                           Output: compress_hyper_2_11_chunk."time", compress_hyper_2_11_chunk.segment_by_value, compress_hyper_2_11_chunk.int_value, compress_hyper_2_11_chunk.float_value, compress_hyper_2_11_chunk._ts_meta_count, compress_hyper_2_11_chunk._ts_meta_sequence_num, compress_hyper_2_11_chunk._ts_meta_min_1, compress_hyper_2_11_chunk._ts_meta_max_1
-                           Index Cond: (compress_hyper_2_11_chunk.segment_by_value > 0)
-         ->  Partial Aggregate
-               Output: PARTIAL sum(_hyper_1_2_chunk.segment_by_value)
-               ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_2_chunk
-                     Output: _hyper_1_2_chunk.segment_by_value
-                     ->  Index Scan using compress_hyper_2_12_chunk__compressed_hypertable_2_segment_by_v on _timescaledb_internal.compress_hyper_2_12_chunk
-                           Output: compress_hyper_2_12_chunk."time", compress_hyper_2_12_chunk.segment_by_value, compress_hyper_2_12_chunk.int_value, compress_hyper_2_12_chunk.float_value, compress_hyper_2_12_chunk._ts_meta_count, compress_hyper_2_12_chunk._ts_meta_sequence_num, compress_hyper_2_12_chunk._ts_meta_min_1, compress_hyper_2_12_chunk._ts_meta_max_1
-                           Index Cond: (compress_hyper_2_12_chunk.segment_by_value > 0)
-         ->  Partial Aggregate
-               Output: PARTIAL sum(_hyper_1_3_chunk.segment_by_value)
-               ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_3_chunk
-                     Output: _hyper_1_3_chunk.segment_by_value
-                     ->  Index Scan using compress_hyper_2_13_chunk__compressed_hypertable_2_segment_by_v on _timescaledb_internal.compress_hyper_2_13_chunk
-                           Output: compress_hyper_2_13_chunk."time", compress_hyper_2_13_chunk.segment_by_value, compress_hyper_2_13_chunk.int_value, compress_hyper_2_13_chunk.float_value, compress_hyper_2_13_chunk._ts_meta_count, compress_hyper_2_13_chunk._ts_meta_sequence_num, compress_hyper_2_13_chunk._ts_meta_min_1, compress_hyper_2_13_chunk._ts_meta_max_1
-                           Index Cond: (compress_hyper_2_13_chunk.segment_by_value > 0)
+         ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_1_chunk
+               Output: (PARTIAL sum(_hyper_1_1_chunk.segment_by_value))
+               Vectorized Aggregation: true
+               ->  Index Scan using compress_hyper_2_11_chunk__compressed_hypertable_2_segment_by_v on _timescaledb_internal.compress_hyper_2_11_chunk
+                     Output: compress_hyper_2_11_chunk."time", compress_hyper_2_11_chunk.segment_by_value, compress_hyper_2_11_chunk.int_value, compress_hyper_2_11_chunk.float_value, compress_hyper_2_11_chunk._ts_meta_count, compress_hyper_2_11_chunk._ts_meta_sequence_num, compress_hyper_2_11_chunk._ts_meta_min_1, compress_hyper_2_11_chunk._ts_meta_max_1
+                     Index Cond: (compress_hyper_2_11_chunk.segment_by_value > 0)
+         ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_2_chunk
+               Output: (PARTIAL sum(_hyper_1_2_chunk.segment_by_value))
+               Vectorized Aggregation: true
+               ->  Index Scan using compress_hyper_2_12_chunk__compressed_hypertable_2_segment_by_v on _timescaledb_internal.compress_hyper_2_12_chunk
+                     Output: compress_hyper_2_12_chunk."time", compress_hyper_2_12_chunk.segment_by_value, compress_hyper_2_12_chunk.int_value, compress_hyper_2_12_chunk.float_value, compress_hyper_2_12_chunk._ts_meta_count, compress_hyper_2_12_chunk._ts_meta_sequence_num, compress_hyper_2_12_chunk._ts_meta_min_1, compress_hyper_2_12_chunk._ts_meta_max_1
+                     Index Cond: (compress_hyper_2_12_chunk.segment_by_value > 0)
+         ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_3_chunk
+               Output: (PARTIAL sum(_hyper_1_3_chunk.segment_by_value))
+               Vectorized Aggregation: true
+               ->  Index Scan using compress_hyper_2_13_chunk__compressed_hypertable_2_segment_by_v on _timescaledb_internal.compress_hyper_2_13_chunk
+                     Output: compress_hyper_2_13_chunk."time", compress_hyper_2_13_chunk.segment_by_value, compress_hyper_2_13_chunk.int_value, compress_hyper_2_13_chunk.float_value, compress_hyper_2_13_chunk._ts_meta_count, compress_hyper_2_13_chunk._ts_meta_sequence_num, compress_hyper_2_13_chunk._ts_meta_min_1, compress_hyper_2_13_chunk._ts_meta_max_1
+                     Index Cond: (compress_hyper_2_13_chunk.segment_by_value > 0)
          ->  Partial Aggregate
                Output: PARTIAL sum(_hyper_1_4_chunk.segment_by_value)
                ->  Seq Scan on _timescaledb_internal._hyper_1_4_chunk
@@ -162,7 +159,212 @@ SELECT sum(segment_by_value) FROM testtable WHERE segment_by_value > 0;
                ->  Seq Scan on _timescaledb_internal._hyper_1_10_chunk
                      Output: _hyper_1_10_chunk.segment_by_value
                      Filter: (_hyper_1_10_chunk.segment_by_value > 0)
-(59 rows)
+(56 rows)
+
+-- Vectorization not possible due to a used filter
+:EXPLAIN
+SELECT sum(segment_by_value) FROM testtable WHERE segment_by_value > 0 AND int_value > 0;
+                                                                                                                                                                                QUERY PLAN                                                                                                                                                                                 
+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Finalize Aggregate
+   Output: sum(_hyper_1_1_chunk.segment_by_value)
+   ->  Append
+         ->  Partial Aggregate
+               Output: PARTIAL sum(_hyper_1_1_chunk.segment_by_value)
+               ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_1_chunk
+                     Output: _hyper_1_1_chunk.segment_by_value
+                     Vectorized Filter: (_hyper_1_1_chunk.int_value > 0)
+                     ->  Index Scan using compress_hyper_2_11_chunk__compressed_hypertable_2_segment_by_v on _timescaledb_internal.compress_hyper_2_11_chunk
+                           Output: compress_hyper_2_11_chunk."time", compress_hyper_2_11_chunk.segment_by_value, compress_hyper_2_11_chunk.int_value, compress_hyper_2_11_chunk.float_value, compress_hyper_2_11_chunk._ts_meta_count, compress_hyper_2_11_chunk._ts_meta_sequence_num, compress_hyper_2_11_chunk._ts_meta_min_1, compress_hyper_2_11_chunk._ts_meta_max_1
+                           Index Cond: (compress_hyper_2_11_chunk.segment_by_value > 0)
+         ->  Partial Aggregate
+               Output: PARTIAL sum(_hyper_1_2_chunk.segment_by_value)
+               ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_2_chunk
+                     Output: _hyper_1_2_chunk.segment_by_value
+                     Vectorized Filter: (_hyper_1_2_chunk.int_value > 0)
+                     ->  Index Scan using compress_hyper_2_12_chunk__compressed_hypertable_2_segment_by_v on _timescaledb_internal.compress_hyper_2_12_chunk
+                           Output: compress_hyper_2_12_chunk."time", compress_hyper_2_12_chunk.segment_by_value, compress_hyper_2_12_chunk.int_value, compress_hyper_2_12_chunk.float_value, compress_hyper_2_12_chunk._ts_meta_count, compress_hyper_2_12_chunk._ts_meta_sequence_num, compress_hyper_2_12_chunk._ts_meta_min_1, compress_hyper_2_12_chunk._ts_meta_max_1
+                           Index Cond: (compress_hyper_2_12_chunk.segment_by_value > 0)
+         ->  Partial Aggregate
+               Output: PARTIAL sum(_hyper_1_3_chunk.segment_by_value)
+               ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_3_chunk
+                     Output: _hyper_1_3_chunk.segment_by_value
+                     Vectorized Filter: (_hyper_1_3_chunk.int_value > 0)
+                     ->  Index Scan using compress_hyper_2_13_chunk__compressed_hypertable_2_segment_by_v on _timescaledb_internal.compress_hyper_2_13_chunk
+                           Output: compress_hyper_2_13_chunk."time", compress_hyper_2_13_chunk.segment_by_value, compress_hyper_2_13_chunk.int_value, compress_hyper_2_13_chunk.float_value, compress_hyper_2_13_chunk._ts_meta_count, compress_hyper_2_13_chunk._ts_meta_sequence_num, compress_hyper_2_13_chunk._ts_meta_min_1, compress_hyper_2_13_chunk._ts_meta_max_1
+                           Index Cond: (compress_hyper_2_13_chunk.segment_by_value > 0)
+         ->  Partial Aggregate
+               Output: PARTIAL sum(_hyper_1_4_chunk.segment_by_value)
+               ->  Seq Scan on _timescaledb_internal._hyper_1_4_chunk
+                     Output: _hyper_1_4_chunk.segment_by_value
+                     Filter: ((_hyper_1_4_chunk.segment_by_value > 0) AND (_hyper_1_4_chunk.int_value > 0))
+         ->  Partial Aggregate
+               Output: PARTIAL sum(_hyper_1_5_chunk.segment_by_value)
+               ->  Seq Scan on _timescaledb_internal._hyper_1_5_chunk
+                     Output: _hyper_1_5_chunk.segment_by_value
+                     Filter: ((_hyper_1_5_chunk.segment_by_value > 0) AND (_hyper_1_5_chunk.int_value > 0))
+         ->  Partial Aggregate
+               Output: PARTIAL sum(_hyper_1_6_chunk.segment_by_value)
+               ->  Seq Scan on _timescaledb_internal._hyper_1_6_chunk
+                     Output: _hyper_1_6_chunk.segment_by_value
+                     Filter: ((_hyper_1_6_chunk.segment_by_value > 0) AND (_hyper_1_6_chunk.int_value > 0))
+         ->  Partial Aggregate
+               Output: PARTIAL sum(_hyper_1_7_chunk.segment_by_value)
+               ->  Seq Scan on _timescaledb_internal._hyper_1_7_chunk
+                     Output: _hyper_1_7_chunk.segment_by_value
+                     Filter: ((_hyper_1_7_chunk.segment_by_value > 0) AND (_hyper_1_7_chunk.int_value > 0))
+         ->  Partial Aggregate
+               Output: PARTIAL sum(_hyper_1_8_chunk.segment_by_value)
+               ->  Seq Scan on _timescaledb_internal._hyper_1_8_chunk
+                     Output: _hyper_1_8_chunk.segment_by_value
+                     Filter: ((_hyper_1_8_chunk.segment_by_value > 0) AND (_hyper_1_8_chunk.int_value > 0))
+         ->  Partial Aggregate
+               Output: PARTIAL sum(_hyper_1_9_chunk.segment_by_value)
+               ->  Seq Scan on _timescaledb_internal._hyper_1_9_chunk
+                     Output: _hyper_1_9_chunk.segment_by_value
+                     Filter: ((_hyper_1_9_chunk.segment_by_value > 0) AND (_hyper_1_9_chunk.int_value > 0))
+         ->  Partial Aggregate
+               Output: PARTIAL sum(_hyper_1_10_chunk.segment_by_value)
+               ->  Seq Scan on _timescaledb_internal._hyper_1_10_chunk
+                     Output: _hyper_1_10_chunk.segment_by_value
+                     Filter: ((_hyper_1_10_chunk.segment_by_value > 0) AND (_hyper_1_10_chunk.int_value > 0))
+(62 rows)
+
+:EXPLAIN
+SELECT sum(segment_by_value) FROM testtable WHERE int_value > 0;
+                                                                                                                                                                                   QUERY PLAN                                                                                                                                                                                    
+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Finalize Aggregate
+   Output: sum(_hyper_1_1_chunk.segment_by_value)
+   ->  Gather
+         Output: (PARTIAL sum(_hyper_1_1_chunk.segment_by_value))
+         Workers Planned: 2
+         ->  Parallel Append
+               ->  Partial Aggregate
+                     Output: PARTIAL sum(_hyper_1_1_chunk.segment_by_value)
+                     ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_1_chunk
+                           Output: _hyper_1_1_chunk.segment_by_value
+                           Vectorized Filter: (_hyper_1_1_chunk.int_value > 0)
+                           ->  Parallel Seq Scan on _timescaledb_internal.compress_hyper_2_11_chunk
+                                 Output: compress_hyper_2_11_chunk."time", compress_hyper_2_11_chunk.segment_by_value, compress_hyper_2_11_chunk.int_value, compress_hyper_2_11_chunk.float_value, compress_hyper_2_11_chunk._ts_meta_count, compress_hyper_2_11_chunk._ts_meta_sequence_num, compress_hyper_2_11_chunk._ts_meta_min_1, compress_hyper_2_11_chunk._ts_meta_max_1
+               ->  Partial Aggregate
+                     Output: PARTIAL sum(_hyper_1_2_chunk.segment_by_value)
+                     ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_2_chunk
+                           Output: _hyper_1_2_chunk.segment_by_value
+                           Vectorized Filter: (_hyper_1_2_chunk.int_value > 0)
+                           ->  Parallel Seq Scan on _timescaledb_internal.compress_hyper_2_12_chunk
+                                 Output: compress_hyper_2_12_chunk."time", compress_hyper_2_12_chunk.segment_by_value, compress_hyper_2_12_chunk.int_value, compress_hyper_2_12_chunk.float_value, compress_hyper_2_12_chunk._ts_meta_count, compress_hyper_2_12_chunk._ts_meta_sequence_num, compress_hyper_2_12_chunk._ts_meta_min_1, compress_hyper_2_12_chunk._ts_meta_max_1
+               ->  Partial Aggregate
+                     Output: PARTIAL sum(_hyper_1_3_chunk.segment_by_value)
+                     ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_3_chunk
+                           Output: _hyper_1_3_chunk.segment_by_value
+                           Vectorized Filter: (_hyper_1_3_chunk.int_value > 0)
+                           ->  Parallel Seq Scan on _timescaledb_internal.compress_hyper_2_13_chunk
+                                 Output: compress_hyper_2_13_chunk."time", compress_hyper_2_13_chunk.segment_by_value, compress_hyper_2_13_chunk.int_value, compress_hyper_2_13_chunk.float_value, compress_hyper_2_13_chunk._ts_meta_count, compress_hyper_2_13_chunk._ts_meta_sequence_num, compress_hyper_2_13_chunk._ts_meta_min_1, compress_hyper_2_13_chunk._ts_meta_max_1
+               ->  Partial Aggregate
+                     Output: PARTIAL sum(_hyper_1_4_chunk.segment_by_value)
+                     ->  Parallel Seq Scan on _timescaledb_internal._hyper_1_4_chunk
+                           Output: _hyper_1_4_chunk.segment_by_value
+                           Filter: (_hyper_1_4_chunk.int_value > 0)
+               ->  Partial Aggregate
+                     Output: PARTIAL sum(_hyper_1_5_chunk.segment_by_value)
+                     ->  Parallel Seq Scan on _timescaledb_internal._hyper_1_5_chunk
+                           Output: _hyper_1_5_chunk.segment_by_value
+                           Filter: (_hyper_1_5_chunk.int_value > 0)
+               ->  Partial Aggregate
+                     Output: PARTIAL sum(_hyper_1_6_chunk.segment_by_value)
+                     ->  Parallel Seq Scan on _timescaledb_internal._hyper_1_6_chunk
+                           Output: _hyper_1_6_chunk.segment_by_value
+                           Filter: (_hyper_1_6_chunk.int_value > 0)
+               ->  Partial Aggregate
+                     Output: PARTIAL sum(_hyper_1_7_chunk.segment_by_value)
+                     ->  Parallel Seq Scan on _timescaledb_internal._hyper_1_7_chunk
+                           Output: _hyper_1_7_chunk.segment_by_value
+                           Filter: (_hyper_1_7_chunk.int_value > 0)
+               ->  Partial Aggregate
+                     Output: PARTIAL sum(_hyper_1_8_chunk.segment_by_value)
+                     ->  Parallel Seq Scan on _timescaledb_internal._hyper_1_8_chunk
+                           Output: _hyper_1_8_chunk.segment_by_value
+                           Filter: (_hyper_1_8_chunk.int_value > 0)
+               ->  Partial Aggregate
+                     Output: PARTIAL sum(_hyper_1_9_chunk.segment_by_value)
+                     ->  Parallel Seq Scan on _timescaledb_internal._hyper_1_9_chunk
+                           Output: _hyper_1_9_chunk.segment_by_value
+                           Filter: (_hyper_1_9_chunk.int_value > 0)
+               ->  Partial Aggregate
+                     Output: PARTIAL sum(_hyper_1_10_chunk.segment_by_value)
+                     ->  Parallel Seq Scan on _timescaledb_internal._hyper_1_10_chunk
+                           Output: _hyper_1_10_chunk.segment_by_value
+                           Filter: (_hyper_1_10_chunk.int_value > 0)
+(62 rows)
+
+:EXPLAIN
+SELECT sum(segment_by_value) FROM testtable WHERE float_value > 0;
+                                                                                                                                                                                   QUERY PLAN                                                                                                                                                                                    
+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Finalize Aggregate
+   Output: sum(_hyper_1_1_chunk.segment_by_value)
+   ->  Gather
+         Output: (PARTIAL sum(_hyper_1_1_chunk.segment_by_value))
+         Workers Planned: 2
+         ->  Parallel Append
+               ->  Partial Aggregate
+                     Output: PARTIAL sum(_hyper_1_1_chunk.segment_by_value)
+                     ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_1_chunk
+                           Output: _hyper_1_1_chunk.segment_by_value
+                           Vectorized Filter: (_hyper_1_1_chunk.float_value > '0'::double precision)
+                           ->  Parallel Seq Scan on _timescaledb_internal.compress_hyper_2_11_chunk
+                                 Output: compress_hyper_2_11_chunk."time", compress_hyper_2_11_chunk.segment_by_value, compress_hyper_2_11_chunk.int_value, compress_hyper_2_11_chunk.float_value, compress_hyper_2_11_chunk._ts_meta_count, compress_hyper_2_11_chunk._ts_meta_sequence_num, compress_hyper_2_11_chunk._ts_meta_min_1, compress_hyper_2_11_chunk._ts_meta_max_1
+               ->  Partial Aggregate
+                     Output: PARTIAL sum(_hyper_1_2_chunk.segment_by_value)
+                     ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_2_chunk
+                           Output: _hyper_1_2_chunk.segment_by_value
+                           Vectorized Filter: (_hyper_1_2_chunk.float_value > '0'::double precision)
+                           ->  Parallel Seq Scan on _timescaledb_internal.compress_hyper_2_12_chunk
+                                 Output: compress_hyper_2_12_chunk."time", compress_hyper_2_12_chunk.segment_by_value, compress_hyper_2_12_chunk.int_value, compress_hyper_2_12_chunk.float_value, compress_hyper_2_12_chunk._ts_meta_count, compress_hyper_2_12_chunk._ts_meta_sequence_num, compress_hyper_2_12_chunk._ts_meta_min_1, compress_hyper_2_12_chunk._ts_meta_max_1
+               ->  Partial Aggregate
+                     Output: PARTIAL sum(_hyper_1_3_chunk.segment_by_value)
+                     ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_3_chunk
+                           Output: _hyper_1_3_chunk.segment_by_value
+                           Vectorized Filter: (_hyper_1_3_chunk.float_value > '0'::double precision)
+                           ->  Parallel Seq Scan on _timescaledb_internal.compress_hyper_2_13_chunk
+                                 Output: compress_hyper_2_13_chunk."time", compress_hyper_2_13_chunk.segment_by_value, compress_hyper_2_13_chunk.int_value, compress_hyper_2_13_chunk.float_value, compress_hyper_2_13_chunk._ts_meta_count, compress_hyper_2_13_chunk._ts_meta_sequence_num, compress_hyper_2_13_chunk._ts_meta_min_1, compress_hyper_2_13_chunk._ts_meta_max_1
+               ->  Partial Aggregate
+                     Output: PARTIAL sum(_hyper_1_4_chunk.segment_by_value)
+                     ->  Parallel Seq Scan on _timescaledb_internal._hyper_1_4_chunk
+                           Output: _hyper_1_4_chunk.segment_by_value
+                           Filter: (_hyper_1_4_chunk.float_value > '0'::double precision)
+               ->  Partial Aggregate
+                     Output: PARTIAL sum(_hyper_1_5_chunk.segment_by_value)
+                     ->  Parallel Seq Scan on _timescaledb_internal._hyper_1_5_chunk
+                           Output: _hyper_1_5_chunk.segment_by_value
+                           Filter: (_hyper_1_5_chunk.float_value > '0'::double precision)
+               ->  Partial Aggregate
+                     Output: PARTIAL sum(_hyper_1_6_chunk.segment_by_value)
+                     ->  Parallel Seq Scan on _timescaledb_internal._hyper_1_6_chunk
+                           Output: _hyper_1_6_chunk.segment_by_value
+                           Filter: (_hyper_1_6_chunk.float_value > '0'::double precision)
+               ->  Partial Aggregate
+                     Output: PARTIAL sum(_hyper_1_7_chunk.segment_by_value)
+                     ->  Parallel Seq Scan on _timescaledb_internal._hyper_1_7_chunk
+                           Output: _hyper_1_7_chunk.segment_by_value
+                           Filter: (_hyper_1_7_chunk.float_value > '0'::double precision)
+               ->  Partial Aggregate
+                     Output: PARTIAL sum(_hyper_1_8_chunk.segment_by_value)
+                     ->  Parallel Seq Scan on _timescaledb_internal._hyper_1_8_chunk
+                           Output: _hyper_1_8_chunk.segment_by_value
+                           Filter: (_hyper_1_8_chunk.float_value > '0'::double precision)
+               ->  Partial Aggregate
+                     Output: PARTIAL sum(_hyper_1_9_chunk.segment_by_value)
+                     ->  Parallel Seq Scan on _timescaledb_internal._hyper_1_9_chunk
+                           Output: _hyper_1_9_chunk.segment_by_value
+                           Filter: (_hyper_1_9_chunk.float_value > '0'::double precision)
+               ->  Partial Aggregate
+                     Output: PARTIAL sum(_hyper_1_10_chunk.segment_by_value)
+                     ->  Parallel Seq Scan on _timescaledb_internal._hyper_1_10_chunk
+                           Output: _hyper_1_10_chunk.segment_by_value
+                           Filter: (_hyper_1_10_chunk.float_value > '0'::double precision)
+(62 rows)
 
 -- Vectorization not possible due grouping
 :EXPLAIN
@@ -1474,6 +1676,104 @@ SELECT sum(int_value) FROM testtable;
  3355
 (1 row)
 
+-- Vectorization possible - filter on segment_by
+:EXPLAIN
+SELECT sum(int_value) FROM testtable WHERE segment_by_value > 5;
+                                                                                                                                                                             QUERY PLAN                                                                                                                                                                              
+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Finalize Aggregate
+   Output: sum(_hyper_1_41_chunk.int_value)
+   ->  Append
+         ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_41_chunk
+               Output: (PARTIAL sum(_hyper_1_41_chunk.int_value))
+               Vectorized Aggregation: true
+               ->  Index Scan using compress_hyper_2_51_chunk__compressed_hypertable_2_segment_by_v on _timescaledb_internal.compress_hyper_2_51_chunk
+                     Output: compress_hyper_2_51_chunk."time", compress_hyper_2_51_chunk.segment_by_value, compress_hyper_2_51_chunk.int_value, compress_hyper_2_51_chunk.float_value, compress_hyper_2_51_chunk._ts_meta_count, compress_hyper_2_51_chunk._ts_meta_sequence_num, compress_hyper_2_51_chunk._ts_meta_min_1, compress_hyper_2_51_chunk._ts_meta_max_1
+                     Index Cond: (compress_hyper_2_51_chunk.segment_by_value > 5)
+         ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_42_chunk
+               Output: (PARTIAL sum(_hyper_1_42_chunk.int_value))
+               Vectorized Aggregation: true
+               ->  Index Scan using compress_hyper_2_52_chunk__compressed_hypertable_2_segment_by_v on _timescaledb_internal.compress_hyper_2_52_chunk
+                     Output: compress_hyper_2_52_chunk."time", compress_hyper_2_52_chunk.segment_by_value, compress_hyper_2_52_chunk.int_value, compress_hyper_2_52_chunk.float_value, compress_hyper_2_52_chunk._ts_meta_count, compress_hyper_2_52_chunk._ts_meta_sequence_num, compress_hyper_2_52_chunk._ts_meta_min_1, compress_hyper_2_52_chunk._ts_meta_max_1
+                     Index Cond: (compress_hyper_2_52_chunk.segment_by_value > 5)
+         ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_43_chunk
+               Output: (PARTIAL sum(_hyper_1_43_chunk.int_value))
+               Vectorized Aggregation: true
+               ->  Index Scan using compress_hyper_2_53_chunk__compressed_hypertable_2_segment_by_v on _timescaledb_internal.compress_hyper_2_53_chunk
+                     Output: compress_hyper_2_53_chunk."time", compress_hyper_2_53_chunk.segment_by_value, compress_hyper_2_53_chunk.int_value, compress_hyper_2_53_chunk.float_value, compress_hyper_2_53_chunk._ts_meta_count, compress_hyper_2_53_chunk._ts_meta_sequence_num, compress_hyper_2_53_chunk._ts_meta_min_1, compress_hyper_2_53_chunk._ts_meta_max_1
+                     Index Cond: (compress_hyper_2_53_chunk.segment_by_value > 5)
+         ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_44_chunk
+               Output: (PARTIAL sum(_hyper_1_44_chunk.int_value))
+               Vectorized Aggregation: true
+               ->  Index Scan using compress_hyper_2_54_chunk__compressed_hypertable_2_segment_by_v on _timescaledb_internal.compress_hyper_2_54_chunk
+                     Output: compress_hyper_2_54_chunk."time", compress_hyper_2_54_chunk.segment_by_value, compress_hyper_2_54_chunk.int_value, compress_hyper_2_54_chunk.float_value, compress_hyper_2_54_chunk._ts_meta_count, compress_hyper_2_54_chunk._ts_meta_sequence_num, compress_hyper_2_54_chunk._ts_meta_min_1, compress_hyper_2_54_chunk._ts_meta_max_1
+                     Index Cond: (compress_hyper_2_54_chunk.segment_by_value > 5)
+         ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_45_chunk
+               Output: (PARTIAL sum(_hyper_1_45_chunk.int_value))
+               Vectorized Aggregation: true
+               ->  Index Scan using compress_hyper_2_55_chunk__compressed_hypertable_2_segment_by_v on _timescaledb_internal.compress_hyper_2_55_chunk
+                     Output: compress_hyper_2_55_chunk."time", compress_hyper_2_55_chunk.segment_by_value, compress_hyper_2_55_chunk.int_value, compress_hyper_2_55_chunk.float_value, compress_hyper_2_55_chunk._ts_meta_count, compress_hyper_2_55_chunk._ts_meta_sequence_num, compress_hyper_2_55_chunk._ts_meta_min_1, compress_hyper_2_55_chunk._ts_meta_max_1
+                     Index Cond: (compress_hyper_2_55_chunk.segment_by_value > 5)
+         ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_46_chunk
+               Output: (PARTIAL sum(_hyper_1_46_chunk.int_value))
+               Vectorized Aggregation: true
+               ->  Index Scan using compress_hyper_2_56_chunk__compressed_hypertable_2_segment_by_v on _timescaledb_internal.compress_hyper_2_56_chunk
+                     Output: compress_hyper_2_56_chunk."time", compress_hyper_2_56_chunk.segment_by_value, compress_hyper_2_56_chunk.int_value, compress_hyper_2_56_chunk.float_value, compress_hyper_2_56_chunk._ts_meta_count, compress_hyper_2_56_chunk._ts_meta_sequence_num, compress_hyper_2_56_chunk._ts_meta_min_1, compress_hyper_2_56_chunk._ts_meta_max_1
+                     Index Cond: (compress_hyper_2_56_chunk.segment_by_value > 5)
+         ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_47_chunk
+               Output: (PARTIAL sum(_hyper_1_47_chunk.int_value))
+               Vectorized Aggregation: true
+               ->  Index Scan using compress_hyper_2_57_chunk__compressed_hypertable_2_segment_by_v on _timescaledb_internal.compress_hyper_2_57_chunk
+                     Output: compress_hyper_2_57_chunk."time", compress_hyper_2_57_chunk.segment_by_value, compress_hyper_2_57_chunk.int_value, compress_hyper_2_57_chunk.float_value, compress_hyper_2_57_chunk._ts_meta_count, compress_hyper_2_57_chunk._ts_meta_sequence_num, compress_hyper_2_57_chunk._ts_meta_min_1, compress_hyper_2_57_chunk._ts_meta_max_1
+                     Index Cond: (compress_hyper_2_57_chunk.segment_by_value > 5)
+         ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_48_chunk
+               Output: (PARTIAL sum(_hyper_1_48_chunk.int_value))
+               Vectorized Aggregation: true
+               ->  Index Scan using compress_hyper_2_58_chunk__compressed_hypertable_2_segment_by_v on _timescaledb_internal.compress_hyper_2_58_chunk
+                     Output: compress_hyper_2_58_chunk."time", compress_hyper_2_58_chunk.segment_by_value, compress_hyper_2_58_chunk.int_value, compress_hyper_2_58_chunk.float_value, compress_hyper_2_58_chunk._ts_meta_count, compress_hyper_2_58_chunk._ts_meta_sequence_num, compress_hyper_2_58_chunk._ts_meta_min_1, compress_hyper_2_58_chunk._ts_meta_max_1
+                     Index Cond: (compress_hyper_2_58_chunk.segment_by_value > 5)
+         ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_49_chunk
+               Output: (PARTIAL sum(_hyper_1_49_chunk.int_value))
+               Vectorized Aggregation: true
+               ->  Index Scan using compress_hyper_2_59_chunk__compressed_hypertable_2_segment_by_v on _timescaledb_internal.compress_hyper_2_59_chunk
+                     Output: compress_hyper_2_59_chunk."time", compress_hyper_2_59_chunk.segment_by_value, compress_hyper_2_59_chunk.int_value, compress_hyper_2_59_chunk.float_value, compress_hyper_2_59_chunk._ts_meta_count, compress_hyper_2_59_chunk._ts_meta_sequence_num, compress_hyper_2_59_chunk._ts_meta_min_1, compress_hyper_2_59_chunk._ts_meta_max_1
+                     Index Cond: (compress_hyper_2_59_chunk.segment_by_value > 5)
+         ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_50_chunk
+               Output: (PARTIAL sum(_hyper_1_50_chunk.int_value))
+               Vectorized Aggregation: true
+               ->  Index Scan using compress_hyper_2_60_chunk__compressed_hypertable_2_segment_by_v on _timescaledb_internal.compress_hyper_2_60_chunk
+                     Output: compress_hyper_2_60_chunk."time", compress_hyper_2_60_chunk.segment_by_value, compress_hyper_2_60_chunk.int_value, compress_hyper_2_60_chunk.float_value, compress_hyper_2_60_chunk._ts_meta_count, compress_hyper_2_60_chunk._ts_meta_sequence_num, compress_hyper_2_60_chunk._ts_meta_min_1, compress_hyper_2_60_chunk._ts_meta_max_1
+                     Index Cond: (compress_hyper_2_60_chunk.segment_by_value > 5)
+(63 rows)
+
+SELECT sum(int_value) FROM testtable WHERE segment_by_value > 5;
+ sum  
+------
+ 2440
+(1 row)
+
+SET timescaledb.vectorized_aggregation = OFF;
+SELECT sum(int_value) FROM testtable WHERE segment_by_value > 5;
+ sum  
+------
+ 2440
+(1 row)
+
+RESET timescaledb.vectorized_aggregation;
+SELECT sum(int_value) FROM testtable WHERE segment_by_value > 10;
+ sum 
+-----
+    
+(1 row)
+
+SET timescaledb.vectorized_aggregation = OFF;
+SELECT sum(int_value) FROM testtable WHERE segment_by_value > 10;
+ sum 
+-----
+    
+(1 row)
+
+RESET timescaledb.vectorized_aggregation;
 ---
 -- Tests with parallel plans
 ---
@@ -2050,3 +2350,304 @@ SELECT sum(segment_by_value2) FROM testtable2;
  -559980
 (1 row)
 
+-- Vectorization possible - filter on segment_by
+:EXPLAIN
+SELECT sum(segment_by_value1) FROM testtable2 WHERE segment_by_value1 > 0;
+                                                                                                                                                                                                         QUERY PLAN                                                                                                                                                                                                         
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Finalize Aggregate
+   Output: sum(_hyper_3_101_chunk.segment_by_value1)
+   ->  Append
+         ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_3_101_chunk
+               Output: (PARTIAL sum(_hyper_3_101_chunk.segment_by_value1))
+               Vectorized Aggregation: true
+               ->  Index Scan using compress_hyper_4_111_chunk__compressed_hypertable_4_segment_by_ on _timescaledb_internal.compress_hyper_4_111_chunk
+                     Output: compress_hyper_4_111_chunk."time", compress_hyper_4_111_chunk.segment_by_value1, compress_hyper_4_111_chunk.segment_by_value2, compress_hyper_4_111_chunk.int_value, compress_hyper_4_111_chunk.float_value, compress_hyper_4_111_chunk._ts_meta_count, compress_hyper_4_111_chunk._ts_meta_sequence_num, compress_hyper_4_111_chunk._ts_meta_min_1, compress_hyper_4_111_chunk._ts_meta_max_1
+                     Index Cond: (compress_hyper_4_111_chunk.segment_by_value1 > 0)
+         ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_3_102_chunk
+               Output: (PARTIAL sum(_hyper_3_102_chunk.segment_by_value1))
+               Vectorized Aggregation: true
+               ->  Index Scan using compress_hyper_4_112_chunk__compressed_hypertable_4_segment_by_ on _timescaledb_internal.compress_hyper_4_112_chunk
+                     Output: compress_hyper_4_112_chunk."time", compress_hyper_4_112_chunk.segment_by_value1, compress_hyper_4_112_chunk.segment_by_value2, compress_hyper_4_112_chunk.int_value, compress_hyper_4_112_chunk.float_value, compress_hyper_4_112_chunk._ts_meta_count, compress_hyper_4_112_chunk._ts_meta_sequence_num, compress_hyper_4_112_chunk._ts_meta_min_1, compress_hyper_4_112_chunk._ts_meta_max_1
+                     Index Cond: (compress_hyper_4_112_chunk.segment_by_value1 > 0)
+         ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_3_103_chunk
+               Output: (PARTIAL sum(_hyper_3_103_chunk.segment_by_value1))
+               Vectorized Aggregation: true
+               ->  Index Scan using compress_hyper_4_113_chunk__compressed_hypertable_4_segment_by_ on _timescaledb_internal.compress_hyper_4_113_chunk
+                     Output: compress_hyper_4_113_chunk."time", compress_hyper_4_113_chunk.segment_by_value1, compress_hyper_4_113_chunk.segment_by_value2, compress_hyper_4_113_chunk.int_value, compress_hyper_4_113_chunk.float_value, compress_hyper_4_113_chunk._ts_meta_count, compress_hyper_4_113_chunk._ts_meta_sequence_num, compress_hyper_4_113_chunk._ts_meta_min_1, compress_hyper_4_113_chunk._ts_meta_max_1
+                     Index Cond: (compress_hyper_4_113_chunk.segment_by_value1 > 0)
+         ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_3_104_chunk
+               Output: (PARTIAL sum(_hyper_3_104_chunk.segment_by_value1))
+               Vectorized Aggregation: true
+               ->  Index Scan using compress_hyper_4_114_chunk__compressed_hypertable_4_segment_by_ on _timescaledb_internal.compress_hyper_4_114_chunk
+                     Output: compress_hyper_4_114_chunk."time", compress_hyper_4_114_chunk.segment_by_value1, compress_hyper_4_114_chunk.segment_by_value2, compress_hyper_4_114_chunk.int_value, compress_hyper_4_114_chunk.float_value, compress_hyper_4_114_chunk._ts_meta_count, compress_hyper_4_114_chunk._ts_meta_sequence_num, compress_hyper_4_114_chunk._ts_meta_min_1, compress_hyper_4_114_chunk._ts_meta_max_1
+                     Index Cond: (compress_hyper_4_114_chunk.segment_by_value1 > 0)
+         ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_3_105_chunk
+               Output: (PARTIAL sum(_hyper_3_105_chunk.segment_by_value1))
+               Vectorized Aggregation: true
+               ->  Index Scan using compress_hyper_4_115_chunk__compressed_hypertable_4_segment_by_ on _timescaledb_internal.compress_hyper_4_115_chunk
+                     Output: compress_hyper_4_115_chunk."time", compress_hyper_4_115_chunk.segment_by_value1, compress_hyper_4_115_chunk.segment_by_value2, compress_hyper_4_115_chunk.int_value, compress_hyper_4_115_chunk.float_value, compress_hyper_4_115_chunk._ts_meta_count, compress_hyper_4_115_chunk._ts_meta_sequence_num, compress_hyper_4_115_chunk._ts_meta_min_1, compress_hyper_4_115_chunk._ts_meta_max_1
+                     Index Cond: (compress_hyper_4_115_chunk.segment_by_value1 > 0)
+         ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_3_106_chunk
+               Output: (PARTIAL sum(_hyper_3_106_chunk.segment_by_value1))
+               Vectorized Aggregation: true
+               ->  Index Scan using compress_hyper_4_116_chunk__compressed_hypertable_4_segment_by_ on _timescaledb_internal.compress_hyper_4_116_chunk
+                     Output: compress_hyper_4_116_chunk."time", compress_hyper_4_116_chunk.segment_by_value1, compress_hyper_4_116_chunk.segment_by_value2, compress_hyper_4_116_chunk.int_value, compress_hyper_4_116_chunk.float_value, compress_hyper_4_116_chunk._ts_meta_count, compress_hyper_4_116_chunk._ts_meta_sequence_num, compress_hyper_4_116_chunk._ts_meta_min_1, compress_hyper_4_116_chunk._ts_meta_max_1
+                     Index Cond: (compress_hyper_4_116_chunk.segment_by_value1 > 0)
+         ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_3_107_chunk
+               Output: (PARTIAL sum(_hyper_3_107_chunk.segment_by_value1))
+               Vectorized Aggregation: true
+               ->  Index Scan using compress_hyper_4_117_chunk__compressed_hypertable_4_segment_by_ on _timescaledb_internal.compress_hyper_4_117_chunk
+                     Output: compress_hyper_4_117_chunk."time", compress_hyper_4_117_chunk.segment_by_value1, compress_hyper_4_117_chunk.segment_by_value2, compress_hyper_4_117_chunk.int_value, compress_hyper_4_117_chunk.float_value, compress_hyper_4_117_chunk._ts_meta_count, compress_hyper_4_117_chunk._ts_meta_sequence_num, compress_hyper_4_117_chunk._ts_meta_min_1, compress_hyper_4_117_chunk._ts_meta_max_1
+                     Index Cond: (compress_hyper_4_117_chunk.segment_by_value1 > 0)
+         ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_3_108_chunk
+               Output: (PARTIAL sum(_hyper_3_108_chunk.segment_by_value1))
+               Vectorized Aggregation: true
+               ->  Index Scan using compress_hyper_4_118_chunk__compressed_hypertable_4_segment_by_ on _timescaledb_internal.compress_hyper_4_118_chunk
+                     Output: compress_hyper_4_118_chunk."time", compress_hyper_4_118_chunk.segment_by_value1, compress_hyper_4_118_chunk.segment_by_value2, compress_hyper_4_118_chunk.int_value, compress_hyper_4_118_chunk.float_value, compress_hyper_4_118_chunk._ts_meta_count, compress_hyper_4_118_chunk._ts_meta_sequence_num, compress_hyper_4_118_chunk._ts_meta_min_1, compress_hyper_4_118_chunk._ts_meta_max_1
+                     Index Cond: (compress_hyper_4_118_chunk.segment_by_value1 > 0)
+         ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_3_109_chunk
+               Output: (PARTIAL sum(_hyper_3_109_chunk.segment_by_value1))
+               Vectorized Aggregation: true
+               ->  Index Scan using compress_hyper_4_119_chunk__compressed_hypertable_4_segment_by_ on _timescaledb_internal.compress_hyper_4_119_chunk
+                     Output: compress_hyper_4_119_chunk."time", compress_hyper_4_119_chunk.segment_by_value1, compress_hyper_4_119_chunk.segment_by_value2, compress_hyper_4_119_chunk.int_value, compress_hyper_4_119_chunk.float_value, compress_hyper_4_119_chunk._ts_meta_count, compress_hyper_4_119_chunk._ts_meta_sequence_num, compress_hyper_4_119_chunk._ts_meta_min_1, compress_hyper_4_119_chunk._ts_meta_max_1
+                     Index Cond: (compress_hyper_4_119_chunk.segment_by_value1 > 0)
+         ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_3_110_chunk
+               Output: (PARTIAL sum(_hyper_3_110_chunk.segment_by_value1))
+               Vectorized Aggregation: true
+               ->  Index Scan using compress_hyper_4_120_chunk__compressed_hypertable_4_segment_by_ on _timescaledb_internal.compress_hyper_4_120_chunk
+                     Output: compress_hyper_4_120_chunk."time", compress_hyper_4_120_chunk.segment_by_value1, compress_hyper_4_120_chunk.segment_by_value2, compress_hyper_4_120_chunk.int_value, compress_hyper_4_120_chunk.float_value, compress_hyper_4_120_chunk._ts_meta_count, compress_hyper_4_120_chunk._ts_meta_sequence_num, compress_hyper_4_120_chunk._ts_meta_min_1, compress_hyper_4_120_chunk._ts_meta_max_1
+                     Index Cond: (compress_hyper_4_120_chunk.segment_by_value1 > 0)
+(63 rows)
+
+:EXPLAIN
+SELECT sum(segment_by_value1) FROM testtable2 WHERE segment_by_value1 > 0 AND segment_by_value2 > 0;
+                                                                                                                                                                                                         QUERY PLAN                                                                                                                                                                                                         
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Finalize Aggregate
+   Output: sum(_hyper_3_101_chunk.segment_by_value1)
+   ->  Append
+         ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_3_101_chunk
+               Output: (PARTIAL sum(_hyper_3_101_chunk.segment_by_value1))
+               Vectorized Aggregation: true
+               ->  Index Scan using compress_hyper_4_111_chunk__compressed_hypertable_4_segment_by_ on _timescaledb_internal.compress_hyper_4_111_chunk
+                     Output: compress_hyper_4_111_chunk."time", compress_hyper_4_111_chunk.segment_by_value1, compress_hyper_4_111_chunk.segment_by_value2, compress_hyper_4_111_chunk.int_value, compress_hyper_4_111_chunk.float_value, compress_hyper_4_111_chunk._ts_meta_count, compress_hyper_4_111_chunk._ts_meta_sequence_num, compress_hyper_4_111_chunk._ts_meta_min_1, compress_hyper_4_111_chunk._ts_meta_max_1
+                     Index Cond: ((compress_hyper_4_111_chunk.segment_by_value1 > 0) AND (compress_hyper_4_111_chunk.segment_by_value2 > 0))
+         ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_3_102_chunk
+               Output: (PARTIAL sum(_hyper_3_102_chunk.segment_by_value1))
+               Vectorized Aggregation: true
+               ->  Index Scan using compress_hyper_4_112_chunk__compressed_hypertable_4_segment_by_ on _timescaledb_internal.compress_hyper_4_112_chunk
+                     Output: compress_hyper_4_112_chunk."time", compress_hyper_4_112_chunk.segment_by_value1, compress_hyper_4_112_chunk.segment_by_value2, compress_hyper_4_112_chunk.int_value, compress_hyper_4_112_chunk.float_value, compress_hyper_4_112_chunk._ts_meta_count, compress_hyper_4_112_chunk._ts_meta_sequence_num, compress_hyper_4_112_chunk._ts_meta_min_1, compress_hyper_4_112_chunk._ts_meta_max_1
+                     Index Cond: ((compress_hyper_4_112_chunk.segment_by_value1 > 0) AND (compress_hyper_4_112_chunk.segment_by_value2 > 0))
+         ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_3_103_chunk
+               Output: (PARTIAL sum(_hyper_3_103_chunk.segment_by_value1))
+               Vectorized Aggregation: true
+               ->  Index Scan using compress_hyper_4_113_chunk__compressed_hypertable_4_segment_by_ on _timescaledb_internal.compress_hyper_4_113_chunk
+                     Output: compress_hyper_4_113_chunk."time", compress_hyper_4_113_chunk.segment_by_value1, compress_hyper_4_113_chunk.segment_by_value2, compress_hyper_4_113_chunk.int_value, compress_hyper_4_113_chunk.float_value, compress_hyper_4_113_chunk._ts_meta_count, compress_hyper_4_113_chunk._ts_meta_sequence_num, compress_hyper_4_113_chunk._ts_meta_min_1, compress_hyper_4_113_chunk._ts_meta_max_1
+                     Index Cond: ((compress_hyper_4_113_chunk.segment_by_value1 > 0) AND (compress_hyper_4_113_chunk.segment_by_value2 > 0))
+         ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_3_104_chunk
+               Output: (PARTIAL sum(_hyper_3_104_chunk.segment_by_value1))
+               Vectorized Aggregation: true
+               ->  Index Scan using compress_hyper_4_114_chunk__compressed_hypertable_4_segment_by_ on _timescaledb_internal.compress_hyper_4_114_chunk
+                     Output: compress_hyper_4_114_chunk."time", compress_hyper_4_114_chunk.segment_by_value1, compress_hyper_4_114_chunk.segment_by_value2, compress_hyper_4_114_chunk.int_value, compress_hyper_4_114_chunk.float_value, compress_hyper_4_114_chunk._ts_meta_count, compress_hyper_4_114_chunk._ts_meta_sequence_num, compress_hyper_4_114_chunk._ts_meta_min_1, compress_hyper_4_114_chunk._ts_meta_max_1
+                     Index Cond: ((compress_hyper_4_114_chunk.segment_by_value1 > 0) AND (compress_hyper_4_114_chunk.segment_by_value2 > 0))
+         ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_3_105_chunk
+               Output: (PARTIAL sum(_hyper_3_105_chunk.segment_by_value1))
+               Vectorized Aggregation: true
+               ->  Index Scan using compress_hyper_4_115_chunk__compressed_hypertable_4_segment_by_ on _timescaledb_internal.compress_hyper_4_115_chunk
+                     Output: compress_hyper_4_115_chunk."time", compress_hyper_4_115_chunk.segment_by_value1, compress_hyper_4_115_chunk.segment_by_value2, compress_hyper_4_115_chunk.int_value, compress_hyper_4_115_chunk.float_value, compress_hyper_4_115_chunk._ts_meta_count, compress_hyper_4_115_chunk._ts_meta_sequence_num, compress_hyper_4_115_chunk._ts_meta_min_1, compress_hyper_4_115_chunk._ts_meta_max_1
+                     Index Cond: ((compress_hyper_4_115_chunk.segment_by_value1 > 0) AND (compress_hyper_4_115_chunk.segment_by_value2 > 0))
+         ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_3_106_chunk
+               Output: (PARTIAL sum(_hyper_3_106_chunk.segment_by_value1))
+               Vectorized Aggregation: true
+               ->  Index Scan using compress_hyper_4_116_chunk__compressed_hypertable_4_segment_by_ on _timescaledb_internal.compress_hyper_4_116_chunk
+                     Output: compress_hyper_4_116_chunk."time", compress_hyper_4_116_chunk.segment_by_value1, compress_hyper_4_116_chunk.segment_by_value2, compress_hyper_4_116_chunk.int_value, compress_hyper_4_116_chunk.float_value, compress_hyper_4_116_chunk._ts_meta_count, compress_hyper_4_116_chunk._ts_meta_sequence_num, compress_hyper_4_116_chunk._ts_meta_min_1, compress_hyper_4_116_chunk._ts_meta_max_1
+                     Index Cond: ((compress_hyper_4_116_chunk.segment_by_value1 > 0) AND (compress_hyper_4_116_chunk.segment_by_value2 > 0))
+         ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_3_107_chunk
+               Output: (PARTIAL sum(_hyper_3_107_chunk.segment_by_value1))
+               Vectorized Aggregation: true
+               ->  Index Scan using compress_hyper_4_117_chunk__compressed_hypertable_4_segment_by_ on _timescaledb_internal.compress_hyper_4_117_chunk
+                     Output: compress_hyper_4_117_chunk."time", compress_hyper_4_117_chunk.segment_by_value1, compress_hyper_4_117_chunk.segment_by_value2, compress_hyper_4_117_chunk.int_value, compress_hyper_4_117_chunk.float_value, compress_hyper_4_117_chunk._ts_meta_count, compress_hyper_4_117_chunk._ts_meta_sequence_num, compress_hyper_4_117_chunk._ts_meta_min_1, compress_hyper_4_117_chunk._ts_meta_max_1
+                     Index Cond: ((compress_hyper_4_117_chunk.segment_by_value1 > 0) AND (compress_hyper_4_117_chunk.segment_by_value2 > 0))
+         ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_3_108_chunk
+               Output: (PARTIAL sum(_hyper_3_108_chunk.segment_by_value1))
+               Vectorized Aggregation: true
+               ->  Index Scan using compress_hyper_4_118_chunk__compressed_hypertable_4_segment_by_ on _timescaledb_internal.compress_hyper_4_118_chunk
+                     Output: compress_hyper_4_118_chunk."time", compress_hyper_4_118_chunk.segment_by_value1, compress_hyper_4_118_chunk.segment_by_value2, compress_hyper_4_118_chunk.int_value, compress_hyper_4_118_chunk.float_value, compress_hyper_4_118_chunk._ts_meta_count, compress_hyper_4_118_chunk._ts_meta_sequence_num, compress_hyper_4_118_chunk._ts_meta_min_1, compress_hyper_4_118_chunk._ts_meta_max_1
+                     Index Cond: ((compress_hyper_4_118_chunk.segment_by_value1 > 0) AND (compress_hyper_4_118_chunk.segment_by_value2 > 0))
+         ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_3_109_chunk
+               Output: (PARTIAL sum(_hyper_3_109_chunk.segment_by_value1))
+               Vectorized Aggregation: true
+               ->  Index Scan using compress_hyper_4_119_chunk__compressed_hypertable_4_segment_by_ on _timescaledb_internal.compress_hyper_4_119_chunk
+                     Output: compress_hyper_4_119_chunk."time", compress_hyper_4_119_chunk.segment_by_value1, compress_hyper_4_119_chunk.segment_by_value2, compress_hyper_4_119_chunk.int_value, compress_hyper_4_119_chunk.float_value, compress_hyper_4_119_chunk._ts_meta_count, compress_hyper_4_119_chunk._ts_meta_sequence_num, compress_hyper_4_119_chunk._ts_meta_min_1, compress_hyper_4_119_chunk._ts_meta_max_1
+                     Index Cond: ((compress_hyper_4_119_chunk.segment_by_value1 > 0) AND (compress_hyper_4_119_chunk.segment_by_value2 > 0))
+         ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_3_110_chunk
+               Output: (PARTIAL sum(_hyper_3_110_chunk.segment_by_value1))
+               Vectorized Aggregation: true
+               ->  Index Scan using compress_hyper_4_120_chunk__compressed_hypertable_4_segment_by_ on _timescaledb_internal.compress_hyper_4_120_chunk
+                     Output: compress_hyper_4_120_chunk."time", compress_hyper_4_120_chunk.segment_by_value1, compress_hyper_4_120_chunk.segment_by_value2, compress_hyper_4_120_chunk.int_value, compress_hyper_4_120_chunk.float_value, compress_hyper_4_120_chunk._ts_meta_count, compress_hyper_4_120_chunk._ts_meta_sequence_num, compress_hyper_4_120_chunk._ts_meta_min_1, compress_hyper_4_120_chunk._ts_meta_max_1
+                     Index Cond: ((compress_hyper_4_120_chunk.segment_by_value1 > 0) AND (compress_hyper_4_120_chunk.segment_by_value2 > 0))
+(63 rows)
+
+:EXPLAIN
+SELECT sum(segment_by_value1) FROM testtable2 WHERE segment_by_value1 > 0 AND segment_by_value2 > 0 AND 2>1;
+                                                                                                                                                                                                         QUERY PLAN                                                                                                                                                                                                         
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Finalize Aggregate
+   Output: sum(_hyper_3_101_chunk.segment_by_value1)
+   ->  Append
+         ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_3_101_chunk
+               Output: (PARTIAL sum(_hyper_3_101_chunk.segment_by_value1))
+               Vectorized Aggregation: true
+               ->  Index Scan using compress_hyper_4_111_chunk__compressed_hypertable_4_segment_by_ on _timescaledb_internal.compress_hyper_4_111_chunk
+                     Output: compress_hyper_4_111_chunk."time", compress_hyper_4_111_chunk.segment_by_value1, compress_hyper_4_111_chunk.segment_by_value2, compress_hyper_4_111_chunk.int_value, compress_hyper_4_111_chunk.float_value, compress_hyper_4_111_chunk._ts_meta_count, compress_hyper_4_111_chunk._ts_meta_sequence_num, compress_hyper_4_111_chunk._ts_meta_min_1, compress_hyper_4_111_chunk._ts_meta_max_1
+                     Index Cond: ((compress_hyper_4_111_chunk.segment_by_value1 > 0) AND (compress_hyper_4_111_chunk.segment_by_value2 > 0))
+         ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_3_102_chunk
+               Output: (PARTIAL sum(_hyper_3_102_chunk.segment_by_value1))
+               Vectorized Aggregation: true
+               ->  Index Scan using compress_hyper_4_112_chunk__compressed_hypertable_4_segment_by_ on _timescaledb_internal.compress_hyper_4_112_chunk
+                     Output: compress_hyper_4_112_chunk."time", compress_hyper_4_112_chunk.segment_by_value1, compress_hyper_4_112_chunk.segment_by_value2, compress_hyper_4_112_chunk.int_value, compress_hyper_4_112_chunk.float_value, compress_hyper_4_112_chunk._ts_meta_count, compress_hyper_4_112_chunk._ts_meta_sequence_num, compress_hyper_4_112_chunk._ts_meta_min_1, compress_hyper_4_112_chunk._ts_meta_max_1
+                     Index Cond: ((compress_hyper_4_112_chunk.segment_by_value1 > 0) AND (compress_hyper_4_112_chunk.segment_by_value2 > 0))
+         ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_3_103_chunk
+               Output: (PARTIAL sum(_hyper_3_103_chunk.segment_by_value1))
+               Vectorized Aggregation: true
+               ->  Index Scan using compress_hyper_4_113_chunk__compressed_hypertable_4_segment_by_ on _timescaledb_internal.compress_hyper_4_113_chunk
+                     Output: compress_hyper_4_113_chunk."time", compress_hyper_4_113_chunk.segment_by_value1, compress_hyper_4_113_chunk.segment_by_value2, compress_hyper_4_113_chunk.int_value, compress_hyper_4_113_chunk.float_value, compress_hyper_4_113_chunk._ts_meta_count, compress_hyper_4_113_chunk._ts_meta_sequence_num, compress_hyper_4_113_chunk._ts_meta_min_1, compress_hyper_4_113_chunk._ts_meta_max_1
+                     Index Cond: ((compress_hyper_4_113_chunk.segment_by_value1 > 0) AND (compress_hyper_4_113_chunk.segment_by_value2 > 0))
+         ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_3_104_chunk
+               Output: (PARTIAL sum(_hyper_3_104_chunk.segment_by_value1))
+               Vectorized Aggregation: true
+               ->  Index Scan using compress_hyper_4_114_chunk__compressed_hypertable_4_segment_by_ on _timescaledb_internal.compress_hyper_4_114_chunk
+                     Output: compress_hyper_4_114_chunk."time", compress_hyper_4_114_chunk.segment_by_value1, compress_hyper_4_114_chunk.segment_by_value2, compress_hyper_4_114_chunk.int_value, compress_hyper_4_114_chunk.float_value, compress_hyper_4_114_chunk._ts_meta_count, compress_hyper_4_114_chunk._ts_meta_sequence_num, compress_hyper_4_114_chunk._ts_meta_min_1, compress_hyper_4_114_chunk._ts_meta_max_1
+                     Index Cond: ((compress_hyper_4_114_chunk.segment_by_value1 > 0) AND (compress_hyper_4_114_chunk.segment_by_value2 > 0))
+         ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_3_105_chunk
+               Output: (PARTIAL sum(_hyper_3_105_chunk.segment_by_value1))
+               Vectorized Aggregation: true
+               ->  Index Scan using compress_hyper_4_115_chunk__compressed_hypertable_4_segment_by_ on _timescaledb_internal.compress_hyper_4_115_chunk
+                     Output: compress_hyper_4_115_chunk."time", compress_hyper_4_115_chunk.segment_by_value1, compress_hyper_4_115_chunk.segment_by_value2, compress_hyper_4_115_chunk.int_value, compress_hyper_4_115_chunk.float_value, compress_hyper_4_115_chunk._ts_meta_count, compress_hyper_4_115_chunk._ts_meta_sequence_num, compress_hyper_4_115_chunk._ts_meta_min_1, compress_hyper_4_115_chunk._ts_meta_max_1
+                     Index Cond: ((compress_hyper_4_115_chunk.segment_by_value1 > 0) AND (compress_hyper_4_115_chunk.segment_by_value2 > 0))
+         ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_3_106_chunk
+               Output: (PARTIAL sum(_hyper_3_106_chunk.segment_by_value1))
+               Vectorized Aggregation: true
+               ->  Index Scan using compress_hyper_4_116_chunk__compressed_hypertable_4_segment_by_ on _timescaledb_internal.compress_hyper_4_116_chunk
+                     Output: compress_hyper_4_116_chunk."time", compress_hyper_4_116_chunk.segment_by_value1, compress_hyper_4_116_chunk.segment_by_value2, compress_hyper_4_116_chunk.int_value, compress_hyper_4_116_chunk.float_value, compress_hyper_4_116_chunk._ts_meta_count, compress_hyper_4_116_chunk._ts_meta_sequence_num, compress_hyper_4_116_chunk._ts_meta_min_1, compress_hyper_4_116_chunk._ts_meta_max_1
+                     Index Cond: ((compress_hyper_4_116_chunk.segment_by_value1 > 0) AND (compress_hyper_4_116_chunk.segment_by_value2 > 0))
+         ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_3_107_chunk
+               Output: (PARTIAL sum(_hyper_3_107_chunk.segment_by_value1))
+               Vectorized Aggregation: true
+               ->  Index Scan using compress_hyper_4_117_chunk__compressed_hypertable_4_segment_by_ on _timescaledb_internal.compress_hyper_4_117_chunk
+                     Output: compress_hyper_4_117_chunk."time", compress_hyper_4_117_chunk.segment_by_value1, compress_hyper_4_117_chunk.segment_by_value2, compress_hyper_4_117_chunk.int_value, compress_hyper_4_117_chunk.float_value, compress_hyper_4_117_chunk._ts_meta_count, compress_hyper_4_117_chunk._ts_meta_sequence_num, compress_hyper_4_117_chunk._ts_meta_min_1, compress_hyper_4_117_chunk._ts_meta_max_1
+                     Index Cond: ((compress_hyper_4_117_chunk.segment_by_value1 > 0) AND (compress_hyper_4_117_chunk.segment_by_value2 > 0))
+         ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_3_108_chunk
+               Output: (PARTIAL sum(_hyper_3_108_chunk.segment_by_value1))
+               Vectorized Aggregation: true
+               ->  Index Scan using compress_hyper_4_118_chunk__compressed_hypertable_4_segment_by_ on _timescaledb_internal.compress_hyper_4_118_chunk
+                     Output: compress_hyper_4_118_chunk."time", compress_hyper_4_118_chunk.segment_by_value1, compress_hyper_4_118_chunk.segment_by_value2, compress_hyper_4_118_chunk.int_value, compress_hyper_4_118_chunk.float_value, compress_hyper_4_118_chunk._ts_meta_count, compress_hyper_4_118_chunk._ts_meta_sequence_num, compress_hyper_4_118_chunk._ts_meta_min_1, compress_hyper_4_118_chunk._ts_meta_max_1
+                     Index Cond: ((compress_hyper_4_118_chunk.segment_by_value1 > 0) AND (compress_hyper_4_118_chunk.segment_by_value2 > 0))
+         ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_3_109_chunk
+               Output: (PARTIAL sum(_hyper_3_109_chunk.segment_by_value1))
+               Vectorized Aggregation: true
+               ->  Index Scan using compress_hyper_4_119_chunk__compressed_hypertable_4_segment_by_ on _timescaledb_internal.compress_hyper_4_119_chunk
+                     Output: compress_hyper_4_119_chunk."time", compress_hyper_4_119_chunk.segment_by_value1, compress_hyper_4_119_chunk.segment_by_value2, compress_hyper_4_119_chunk.int_value, compress_hyper_4_119_chunk.float_value, compress_hyper_4_119_chunk._ts_meta_count, compress_hyper_4_119_chunk._ts_meta_sequence_num, compress_hyper_4_119_chunk._ts_meta_min_1, compress_hyper_4_119_chunk._ts_meta_max_1
+                     Index Cond: ((compress_hyper_4_119_chunk.segment_by_value1 > 0) AND (compress_hyper_4_119_chunk.segment_by_value2 > 0))
+         ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_3_110_chunk
+               Output: (PARTIAL sum(_hyper_3_110_chunk.segment_by_value1))
+               Vectorized Aggregation: true
+               ->  Index Scan using compress_hyper_4_120_chunk__compressed_hypertable_4_segment_by_ on _timescaledb_internal.compress_hyper_4_120_chunk
+                     Output: compress_hyper_4_120_chunk."time", compress_hyper_4_120_chunk.segment_by_value1, compress_hyper_4_120_chunk.segment_by_value2, compress_hyper_4_120_chunk.int_value, compress_hyper_4_120_chunk.float_value, compress_hyper_4_120_chunk._ts_meta_count, compress_hyper_4_120_chunk._ts_meta_sequence_num, compress_hyper_4_120_chunk._ts_meta_min_1, compress_hyper_4_120_chunk._ts_meta_max_1
+                     Index Cond: ((compress_hyper_4_120_chunk.segment_by_value1 > 0) AND (compress_hyper_4_120_chunk.segment_by_value2 > 0))
+(63 rows)
+
+-- Vectorization not possible filter on segment_by and compressed value
+-- Disable parallel worker to get deterministic query plans on i386
+SET max_parallel_workers_per_gather = 0;
+:EXPLAIN
+SELECT sum(segment_by_value1) FROM testtable2 WHERE segment_by_value1 > 1000 AND int_value > 1000;
+                                                                                                                                                                                                            QUERY PLAN                                                                                                                                                                                                            
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Finalize Aggregate
+   Output: sum(_hyper_3_101_chunk.segment_by_value1)
+   ->  Append
+         ->  Partial Aggregate
+               Output: PARTIAL sum(_hyper_3_101_chunk.segment_by_value1)
+               ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_3_101_chunk
+                     Output: _hyper_3_101_chunk.segment_by_value1
+                     Vectorized Filter: (_hyper_3_101_chunk.int_value > 1000)
+                     ->  Index Scan using compress_hyper_4_111_chunk__compressed_hypertable_4_segment_by_ on _timescaledb_internal.compress_hyper_4_111_chunk
+                           Output: compress_hyper_4_111_chunk."time", compress_hyper_4_111_chunk.segment_by_value1, compress_hyper_4_111_chunk.segment_by_value2, compress_hyper_4_111_chunk.int_value, compress_hyper_4_111_chunk.float_value, compress_hyper_4_111_chunk._ts_meta_count, compress_hyper_4_111_chunk._ts_meta_sequence_num, compress_hyper_4_111_chunk._ts_meta_min_1, compress_hyper_4_111_chunk._ts_meta_max_1
+                           Index Cond: (compress_hyper_4_111_chunk.segment_by_value1 > 1000)
+         ->  Partial Aggregate
+               Output: PARTIAL sum(_hyper_3_102_chunk.segment_by_value1)
+               ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_3_102_chunk
+                     Output: _hyper_3_102_chunk.segment_by_value1
+                     Vectorized Filter: (_hyper_3_102_chunk.int_value > 1000)
+                     ->  Index Scan using compress_hyper_4_112_chunk__compressed_hypertable_4_segment_by_ on _timescaledb_internal.compress_hyper_4_112_chunk
+                           Output: compress_hyper_4_112_chunk."time", compress_hyper_4_112_chunk.segment_by_value1, compress_hyper_4_112_chunk.segment_by_value2, compress_hyper_4_112_chunk.int_value, compress_hyper_4_112_chunk.float_value, compress_hyper_4_112_chunk._ts_meta_count, compress_hyper_4_112_chunk._ts_meta_sequence_num, compress_hyper_4_112_chunk._ts_meta_min_1, compress_hyper_4_112_chunk._ts_meta_max_1
+                           Index Cond: (compress_hyper_4_112_chunk.segment_by_value1 > 1000)
+         ->  Partial Aggregate
+               Output: PARTIAL sum(_hyper_3_103_chunk.segment_by_value1)
+               ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_3_103_chunk
+                     Output: _hyper_3_103_chunk.segment_by_value1
+                     Vectorized Filter: (_hyper_3_103_chunk.int_value > 1000)
+                     ->  Index Scan using compress_hyper_4_113_chunk__compressed_hypertable_4_segment_by_ on _timescaledb_internal.compress_hyper_4_113_chunk
+                           Output: compress_hyper_4_113_chunk."time", compress_hyper_4_113_chunk.segment_by_value1, compress_hyper_4_113_chunk.segment_by_value2, compress_hyper_4_113_chunk.int_value, compress_hyper_4_113_chunk.float_value, compress_hyper_4_113_chunk._ts_meta_count, compress_hyper_4_113_chunk._ts_meta_sequence_num, compress_hyper_4_113_chunk._ts_meta_min_1, compress_hyper_4_113_chunk._ts_meta_max_1
+                           Index Cond: (compress_hyper_4_113_chunk.segment_by_value1 > 1000)
+         ->  Partial Aggregate
+               Output: PARTIAL sum(_hyper_3_104_chunk.segment_by_value1)
+               ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_3_104_chunk
+                     Output: _hyper_3_104_chunk.segment_by_value1
+                     Vectorized Filter: (_hyper_3_104_chunk.int_value > 1000)
+                     ->  Index Scan using compress_hyper_4_114_chunk__compressed_hypertable_4_segment_by_ on _timescaledb_internal.compress_hyper_4_114_chunk
+                           Output: compress_hyper_4_114_chunk."time", compress_hyper_4_114_chunk.segment_by_value1, compress_hyper_4_114_chunk.segment_by_value2, compress_hyper_4_114_chunk.int_value, compress_hyper_4_114_chunk.float_value, compress_hyper_4_114_chunk._ts_meta_count, compress_hyper_4_114_chunk._ts_meta_sequence_num, compress_hyper_4_114_chunk._ts_meta_min_1, compress_hyper_4_114_chunk._ts_meta_max_1
+                           Index Cond: (compress_hyper_4_114_chunk.segment_by_value1 > 1000)
+         ->  Partial Aggregate
+               Output: PARTIAL sum(_hyper_3_105_chunk.segment_by_value1)
+               ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_3_105_chunk
+                     Output: _hyper_3_105_chunk.segment_by_value1
+                     Vectorized Filter: (_hyper_3_105_chunk.int_value > 1000)
+                     ->  Index Scan using compress_hyper_4_115_chunk__compressed_hypertable_4_segment_by_ on _timescaledb_internal.compress_hyper_4_115_chunk
+                           Output: compress_hyper_4_115_chunk."time", compress_hyper_4_115_chunk.segment_by_value1, compress_hyper_4_115_chunk.segment_by_value2, compress_hyper_4_115_chunk.int_value, compress_hyper_4_115_chunk.float_value, compress_hyper_4_115_chunk._ts_meta_count, compress_hyper_4_115_chunk._ts_meta_sequence_num, compress_hyper_4_115_chunk._ts_meta_min_1, compress_hyper_4_115_chunk._ts_meta_max_1
+                           Index Cond: (compress_hyper_4_115_chunk.segment_by_value1 > 1000)
+         ->  Partial Aggregate
+               Output: PARTIAL sum(_hyper_3_106_chunk.segment_by_value1)
+               ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_3_106_chunk
+                     Output: _hyper_3_106_chunk.segment_by_value1
+                     Vectorized Filter: (_hyper_3_106_chunk.int_value > 1000)
+                     ->  Index Scan using compress_hyper_4_116_chunk__compressed_hypertable_4_segment_by_ on _timescaledb_internal.compress_hyper_4_116_chunk
+                           Output: compress_hyper_4_116_chunk."time", compress_hyper_4_116_chunk.segment_by_value1, compress_hyper_4_116_chunk.segment_by_value2, compress_hyper_4_116_chunk.int_value, compress_hyper_4_116_chunk.float_value, compress_hyper_4_116_chunk._ts_meta_count, compress_hyper_4_116_chunk._ts_meta_sequence_num, compress_hyper_4_116_chunk._ts_meta_min_1, compress_hyper_4_116_chunk._ts_meta_max_1
+                           Index Cond: (compress_hyper_4_116_chunk.segment_by_value1 > 1000)
+         ->  Partial Aggregate
+               Output: PARTIAL sum(_hyper_3_107_chunk.segment_by_value1)
+               ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_3_107_chunk
+                     Output: _hyper_3_107_chunk.segment_by_value1
+                     Vectorized Filter: (_hyper_3_107_chunk.int_value > 1000)
+                     ->  Index Scan using compress_hyper_4_117_chunk__compressed_hypertable_4_segment_by_ on _timescaledb_internal.compress_hyper_4_117_chunk
+                           Output: compress_hyper_4_117_chunk."time", compress_hyper_4_117_chunk.segment_by_value1, compress_hyper_4_117_chunk.segment_by_value2, compress_hyper_4_117_chunk.int_value, compress_hyper_4_117_chunk.float_value, compress_hyper_4_117_chunk._ts_meta_count, compress_hyper_4_117_chunk._ts_meta_sequence_num, compress_hyper_4_117_chunk._ts_meta_min_1, compress_hyper_4_117_chunk._ts_meta_max_1
+                           Index Cond: (compress_hyper_4_117_chunk.segment_by_value1 > 1000)
+         ->  Partial Aggregate
+               Output: PARTIAL sum(_hyper_3_108_chunk.segment_by_value1)
+               ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_3_108_chunk
+                     Output: _hyper_3_108_chunk.segment_by_value1
+                     Vectorized Filter: (_hyper_3_108_chunk.int_value > 1000)
+                     ->  Index Scan using compress_hyper_4_118_chunk__compressed_hypertable_4_segment_by_ on _timescaledb_internal.compress_hyper_4_118_chunk
+                           Output: compress_hyper_4_118_chunk."time", compress_hyper_4_118_chunk.segment_by_value1, compress_hyper_4_118_chunk.segment_by_value2, compress_hyper_4_118_chunk.int_value, compress_hyper_4_118_chunk.float_value, compress_hyper_4_118_chunk._ts_meta_count, compress_hyper_4_118_chunk._ts_meta_sequence_num, compress_hyper_4_118_chunk._ts_meta_min_1, compress_hyper_4_118_chunk._ts_meta_max_1
+                           Index Cond: (compress_hyper_4_118_chunk.segment_by_value1 > 1000)
+         ->  Partial Aggregate
+               Output: PARTIAL sum(_hyper_3_109_chunk.segment_by_value1)
+               ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_3_109_chunk
+                     Output: _hyper_3_109_chunk.segment_by_value1
+                     Vectorized Filter: (_hyper_3_109_chunk.int_value > 1000)
+                     ->  Index Scan using compress_hyper_4_119_chunk__compressed_hypertable_4_segment_by_ on _timescaledb_internal.compress_hyper_4_119_chunk
+                           Output: compress_hyper_4_119_chunk."time", compress_hyper_4_119_chunk.segment_by_value1, compress_hyper_4_119_chunk.segment_by_value2, compress_hyper_4_119_chunk.int_value, compress_hyper_4_119_chunk.float_value, compress_hyper_4_119_chunk._ts_meta_count, compress_hyper_4_119_chunk._ts_meta_sequence_num, compress_hyper_4_119_chunk._ts_meta_min_1, compress_hyper_4_119_chunk._ts_meta_max_1
+                           Index Cond: (compress_hyper_4_119_chunk.segment_by_value1 > 1000)
+         ->  Partial Aggregate
+               Output: PARTIAL sum(_hyper_3_110_chunk.segment_by_value1)
+               ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_3_110_chunk
+                     Output: _hyper_3_110_chunk.segment_by_value1
+                     Vectorized Filter: (_hyper_3_110_chunk.int_value > 1000)
+                     ->  Index Scan using compress_hyper_4_120_chunk__compressed_hypertable_4_segment_by_ on _timescaledb_internal.compress_hyper_4_120_chunk
+                           Output: compress_hyper_4_120_chunk."time", compress_hyper_4_120_chunk.segment_by_value1, compress_hyper_4_120_chunk.segment_by_value2, compress_hyper_4_120_chunk.int_value, compress_hyper_4_120_chunk.float_value, compress_hyper_4_120_chunk._ts_meta_count, compress_hyper_4_120_chunk._ts_meta_sequence_num, compress_hyper_4_120_chunk._ts_meta_min_1, compress_hyper_4_120_chunk._ts_meta_max_1
+                           Index Cond: (compress_hyper_4_120_chunk.segment_by_value1 > 1000)
+(83 rows)
+
+RESET max_parallel_workers_per_gather;

--- a/tsl/test/sql/vectorized_aggregation.sql
+++ b/tsl/test/sql/vectorized_aggregation.sql
@@ -38,9 +38,19 @@ SELECT sum(segment_by_value) FROM testtable;
 :EXPLAIN
 SELECT sum(segment_by_value) FROM testtable;
 
--- Vectorization not possible due to a used filter
+-- Vectorization possible - filter on segment_by
 :EXPLAIN
 SELECT sum(segment_by_value) FROM testtable WHERE segment_by_value > 0;
+
+-- Vectorization not possible due to a used filter
+:EXPLAIN
+SELECT sum(segment_by_value) FROM testtable WHERE segment_by_value > 0 AND int_value > 0;
+
+:EXPLAIN
+SELECT sum(segment_by_value) FROM testtable WHERE int_value > 0;
+
+:EXPLAIN
+SELECT sum(segment_by_value) FROM testtable WHERE float_value > 0;
 
 -- Vectorization not possible due grouping
 :EXPLAIN
@@ -190,6 +200,22 @@ SELECT compress_chunk(ch) FROM show_chunks('testtable') ch;
 SELECT sum(segment_by_value) FROM testtable;
 SELECT sum(int_value) FROM testtable;
 
+-- Vectorization possible - filter on segment_by
+:EXPLAIN
+SELECT sum(int_value) FROM testtable WHERE segment_by_value > 5;
+
+SELECT sum(int_value) FROM testtable WHERE segment_by_value > 5;
+
+SET timescaledb.vectorized_aggregation = OFF;
+SELECT sum(int_value) FROM testtable WHERE segment_by_value > 5;
+RESET timescaledb.vectorized_aggregation;
+
+SELECT sum(int_value) FROM testtable WHERE segment_by_value > 10;
+
+SET timescaledb.vectorized_aggregation = OFF;
+SELECT sum(int_value) FROM testtable WHERE segment_by_value > 10;
+RESET timescaledb.vectorized_aggregation;
+
 ---
 -- Tests with parallel plans
 ---
@@ -334,3 +360,24 @@ SELECT sum(segment_by_value1) FROM testtable2;
 SELECT sum(segment_by_value2) FROM testtable2;
 
 SELECT sum(segment_by_value2) FROM testtable2;
+
+
+-- Vectorization possible - filter on segment_by
+:EXPLAIN
+SELECT sum(segment_by_value1) FROM testtable2 WHERE segment_by_value1 > 0;
+
+:EXPLAIN
+SELECT sum(segment_by_value1) FROM testtable2 WHERE segment_by_value1 > 0 AND segment_by_value2 > 0;
+
+:EXPLAIN
+SELECT sum(segment_by_value1) FROM testtable2 WHERE segment_by_value1 > 0 AND segment_by_value2 > 0 AND 2>1;
+
+-- Vectorization not possible filter on segment_by and compressed value
+
+-- Disable parallel worker to get deterministic query plans on i386
+SET max_parallel_workers_per_gather = 0;
+
+:EXPLAIN
+SELECT sum(segment_by_value1) FROM testtable2 WHERE segment_by_value1 > 1000 AND int_value > 1000;
+
+RESET max_parallel_workers_per_gather;


### PR DESCRIPTION
This patch adds support for vectorized aggregation queries with filters
on the segment_by value of compressed data.

---
Should be merged after: https://github.com/timescale/timescaledb/pull/6050
Disable-check: force-changelog-file