### PR TITLE
Fix EXPLAIN for compressed DML

### DIFF
--- a/.unreleased/pr_6210
+++ b/.unreleased/pr_6210
@@ -1,0 +1,1 @@
+Fixes: #6210 Fix EXPLAIN ANALYZE for compressed DML

--- a/tsl/src/compression/compression.c
+++ b/tsl/src/compression/compression.c
@@ -2751,9 +2751,7 @@ fill_predicate_context(Chunk *ch, List *predicates, List **filters, List **index
 	ListCell *lc;
 	foreach (lc, predicates)
 	{
-		Node *node = lfirst(lc);
-		if (node == NULL)
-			continue;
+		Node *node = copyObject(lfirst(lc));
 
 		Var *var;
 		char *column_name;
@@ -3346,7 +3344,6 @@ decompress_chunk_walker(PlanState *ps, List *relids)
 		case T_TidScanState:
 		case T_TidRangeScanState:
 		{
-			/* We copy so we can always just free the predicates */
 			predicates = list_copy(ps->plan->qual);
 			needs_decompression = true;
 			break;


### PR DESCRIPTION
EXPLAIN ANALYZE for compressed DML would error out with `bogus varno` error because we would modify the original expressions of the plan that were still referenced in nodes instead of adjusting copies and using those copies in our internal scans.