### PR TITLE
Install PG15 in homebrew test

### DIFF
--- a/.github/workflows/homebrew.yaml
+++ b/.github/workflows/homebrew.yaml
@@ -26,6 +26,8 @@ jobs:
 
     - name: Setup
       run: |
+        brew install postgresql@15
+        echo "/usr/local/opt/postgresql@15/bin" >> $GITHUB_PATH
         brew tap timescale/tap
         brew info timescaledb
 
@@ -34,7 +36,7 @@ jobs:
         brew install timescaledb ${{ matrix.install_options }}
         timescaledb-tune --quiet --yes
         timescaledb_move.sh
-        brew services start postgresql
+        brew services start postgresql@15
 
     # checkout code to get version information
     - uses: actions/checkout@v3


### PR DESCRIPTION
The homebrew tap for timescaledb has been switched to PG15 but
the default postgres in the macos github environment is PG14 so
we have to explicitly install PG15.

Disable-check: force-changelog-file
