### PR TITLE
PG16: Fix JOIN behaviour

### DIFF
--- a/src/planner/planner.c
+++ b/src/planner/planner.c
@@ -1019,7 +1019,7 @@ reenable_inheritance(PlannerInfo *root, RelOptInfo *rel, Index rti, RangeTblEntr
 	{
 		RangeTblEntry *in_rte = root->simple_rte_array[i];
 
-		if (rte_should_expand(in_rte))
+		if (rte_should_expand(in_rte) && root->simple_rel_array[i])
 		{
 			RelOptInfo *in_rel = root->simple_rel_array[i];
 			Hypertable *ht = ts_planner_get_hypertable(in_rte->relid, CACHE_FLAG_NOCREATE);

--- a/test/sql/include/join_query.sql
+++ b/test/sql/include/join_query.sql
@@ -992,7 +992,7 @@ select * from tenk1 a join tenk1 b on
 select * from tenk1 t1 left join
   (tenk1 t2 join tenk1 t3 on t2.thousand = t3.unique2)
   on t1.hundred = t2.hundred and t1.ten = t3.ten
-where t1.unique1 = 1;
+where t1.unique1 = 1 ORDER BY t1,t2,t3;
 
 :PREFIX
 select * from tenk1 t1 left join


### PR DESCRIPTION
PG16 will remove RelOptInfo entries from root->simple_rel_array when it considers them not needed in analyzejoins.c to prevent reprocessing them. Due to this a relation may be present in root->simple_rte_array but have no corresponding entry in root->simple_rel_array. This patch adds a check for this case.

https://github.com/postgres/postgres/commit/e9a20e45

Disable-check: force-changelog-file
