### PR TITLE
Fix flaky upgrade test

### DIFF
--- a/test/sql/updates/post.continuous_aggs.sql
+++ b/test/sql/updates/post.continuous_aggs.sql
@@ -2,6 +2,17 @@
 -- Please see the included NOTICE for copyright information and
 -- LICENSE-APACHE for a copy of the license.
 
+SELECT
+	extversion < '2.0.0' AS has_refresh_mat_view
+  FROM pg_extension
+ WHERE extname = 'timescaledb' \gset
+
+\if :has_refresh_mat_view
+REFRESH MATERIALIZED VIEW mat_before;
+\else
+CALL refresh_continuous_aggregate('mat_before',NULL,NULL);
+\endif
+
 \x on
 SELECT * FROM mat_before ORDER BY bucket, location;
 \x off

--- a/test/sql/updates/post.continuous_aggs.v3.sql
+++ b/test/sql/updates/post.continuous_aggs.v3.sql
@@ -4,6 +4,18 @@
 
 \ir post.continuous_aggs.v2.sql
 
+-- Ensure CAgg is refreshed
+SELECT
+	extversion < '2.0.0' AS has_refresh_mat_view
+  FROM pg_extension
+ WHERE extname = 'timescaledb' \gset
+
+\if :has_refresh_mat_view
+REFRESH MATERIALIZED VIEW rename_cols;
+\else
+CALL refresh_continuous_aggregate('rename_cols',NULL,NULL);
+\endif
+
 SELECT "time", count(*) from rename_cols GROUP BY 1 ORDER BY 1;
 
 --verify compression can be enabled

--- a/test/sql/updates/setup.catalog.sql
+++ b/test/sql/updates/setup.catalog.sql
@@ -2,7 +2,7 @@
 -- Please see the included NOTICE for copyright information and
 -- LICENSE-APACHE for a copy of the license.
 
--- Catalog tables are occationally rewritten as part of updates, so
+-- Catalog tables are occasionally rewritten as part of updates, so
 -- this is to test that privileges are maintained over updates of the
 -- extension. We could verify that other properties (e.g., comments)
 -- are maintained here as well, but this is not something we use right

--- a/test/sql/updates/setup.continuous_aggs.sql
+++ b/test/sql/updates/setup.continuous_aggs.sql
@@ -89,7 +89,6 @@ SELECT generate_series('2018-11-01 00:00'::timestamp, '2018-12-15 00:00'::timest
 \else
       GROUP BY bucket, location
       HAVING min(location) >= 'NYC' and avg(temperature) > 2 WITH NO DATA;
-	SELECT add_continuous_aggregate_policy('mat_before', NULL, '-30 days'::interval, '336 h');
     ALTER MATERIALIZED VIEW mat_before SET (timescaledb.materialized_only=true);
 \endif
 

--- a/test/sql/updates/setup.continuous_aggs.v2.sql
+++ b/test/sql/updates/setup.continuous_aggs.v2.sql
@@ -78,7 +78,6 @@ SELECT generate_series('2018-11-01 00:00'::timestamp, '2018-12-15 00:00'::timest
 \else
     GROUP BY bucket, location
     WITH NO DATA;
-    SELECT add_continuous_aggregate_policy('rename_cols', NULL, '14 days'::interval, '336 h');
 \endif
 
 \if :has_refresh_mat_view
@@ -141,7 +140,6 @@ SELECT generate_series('2018-11-01 00:00'::timestamp, '2018-12-15 00:00'::timest
 \else
       GROUP BY bucket, location
       HAVING min(location) >= 'NYC' and avg(temperature) > 2 WITH NO DATA;
-    SELECT add_continuous_aggregate_policy('mat_before', NULL, '-30 days'::interval, '336 h');
 
     ALTER MATERIALIZED VIEW rename_cols RENAME COLUMN bucket TO "time";
 \endif
@@ -218,7 +216,6 @@ CREATE SCHEMA cagg;
 \else
       GROUP BY bucket, location
       HAVING min(location) >= 'NYC' and avg(temperature) > 2 WITH NO DATA;
-    SELECT add_continuous_aggregate_policy('cagg.realtime_mat', NULL, '-30 days'::interval, '336 h');
 \endif
 \if :WITH_SUPERUSER
 GRANT SELECT ON cagg.realtime_mat TO cagg_user;


### PR DESCRIPTION
The upgrade test utilizes several CAggs and defines refresh policies.
However, the test results are not deterministic due to the unpredictable
timing of the refreshes. This causes the test to be flaky. This pull
request explicitly adds explicit refreshes to the upgrade test to ensure
that the test results are deterministic.

---
Link to failed CI run: https://github.com/timescale/timescaledb/actions/runs/6644016971/job/18057621681?pr=6229
Link to fixed CI run: https://github.com/timescale/timescaledb/actions/runs/6646121959/job/18058928349
Disable-check: force-changelog-file

