### PR TITLE
Use "dylib" uniformly on MacOSX

### DIFF
--- a/src/build-defs.cmake
+++ b/src/build-defs.cmake
@@ -12,6 +12,9 @@ if(UNIX)
 endif()
 
 if(APPLE)
+  if((${PG_VERSION_MAJOR} GREATER_EQUAL "16"))
+    set(CMAKE_SHARED_MODULE_SUFFIX ".dylib")
+  endif()
   set(CMAKE_SHARED_LINKER_FLAGS
       "${CMAKE_SHARED_LINKER_FLAGS} -multiply_defined suppress")
   set(CMAKE_MODULE_LINKER_FLAGS

--- a/tsl/src/build-defs.cmake
+++ b/tsl/src/build-defs.cmake
@@ -10,6 +10,9 @@ if(UNIX)
 endif()
 
 if(APPLE)
+  if((${PG_VERSION_MAJOR} GREATER_EQUAL "16"))
+    set(CMAKE_SHARED_MODULE_SUFFIX ".dylib")
+  endif()
   set(CMAKE_SHARED_LINKER_FLAGS
       "${CMAKE_SHARED_LINKER_FLAGS} -multiply_defined suppress")
   set(CMAKE_MODULE_LINKER_FLAGS


### PR DESCRIPTION
Till PG15, shared libraries with ".so" suffix used to be loaded properly on MacOSX. That has changed with PG16. Change it so that shared libraries will uniformly use the ".dylib" suffix on MacOSX

Disable-check: force-changelog-file