### PR TITLE
PG16: Handle new vacuum option ONLY_DATABASE_STATS

### DIFF
--- a/src/process_utility.c
+++ b/src/process_utility.c
@@ -870,6 +870,22 @@ process_vacuum(ProcessUtilityArgs *args)
 
 	is_vacuumcmd = stmt->is_vacuumcmd;
 
+#if PG16_GE
+	if (is_vacuumcmd)
+	{
+		/* Look for new option ONLY_DATABASE_STATS */
+		foreach (lc, stmt->options)
+		{
+			DefElem *opt = (DefElem *) lfirst(lc);
+
+			/* if "only_database_stats" is defined then don't execute our custom code and return to
+			 * the postgres execution for the proper validations */
+			if (strcmp(opt->defname, "only_database_stats") == 0)
+				return DDL_CONTINUE;
+		}
+	}
+#endif
+
 	if (stmt->rels == NIL)
 		vacuum_rels = ts_get_all_vacuum_rels(is_vacuumcmd);
 	else


### PR DESCRIPTION
In order to properly process hypertables, chunks and compressed chunks we run our own code when a VACUUM is executed.

PG16 introduced a new option named ONLY_DATABASE_STATS that only update the database-wide statistics and when this option is specified no other option may be enabled. Internally we build the list of all underlying relations for hypertables in order to properly execute this utility command leading to the following error:

```sql
test=# VACUUM (ONLY_DATABASE_STATS);
ERROR:  0A000: ONLY_DATABASE_STATS cannot be specified with a list of tables LOCATION:  ExecVacuum, vacuum.c:369
```

Fixed it by properly handling the ONLY_DATABASE_STATS to don't execute our modified vacuum code and instead the regular Postgres.

The error was catched up when running the `pginstallcheck` regression tests.

postgres/postgres@a46a7011

Disable-check: force-changelog-file
