### PR TITLE
Further reduce sqlsmith loops in nightly runs

### DIFF
--- a/.github/workflows/sqlsmith.yaml
+++ b/.github/workflows/sqlsmith.yaml
@@ -86,7 +86,7 @@ jobs:
       run: |
         set -o pipefail
         if [ "${{ github.event_name }}" == "schedule" ]; then
-          LOOPS=40
+          LOOPS=20
         else
           LOOPS=10
         fi


### PR DESCRIPTION
In the nightly CI runs the sqlsmith job seems to fail quite often with `GitHub Actions 3 lost communication with the server.`. This can happen when the runner process is starved for CPU/Memory. To reduce the likelyhood this patch reduces the number of loops for sqlsmith during nightly CI runs further.

Disable-check: force-changelog-file
