### PR TITLE
PG16: Refactored ownercheck functions

### DIFF
--- a/src/process_utility.c
+++ b/src/process_utility.c
@@ -3952,7 +3952,7 @@ process_altertable_end_table(Node *parsetree, CollectedCommand *cmd)
 
 	Assert(IsA(stmt, AlterTableStmt));
 
-	relid = AlterTableLookupRelation(stmt, NoLock);
+	relid = RangeVarGetRelid(stmt->relation, NoLock, true);
 
 	if (!OidIsValid(relid))
 		return;


### PR DESCRIPTION
In our code we have an Event Trigger on `ddl_command_end` to process some DDL commands, and specially the `ALTER TABLE` we execute some code to properly deal with hypertables, chunks and compressed chunks.

The problem is when we start to process our code at `ddl_command_end` event we get the related `relid` by calling the `AlterTableLookupRelation` that perform the proper acl checking. But this is a bit wrong because in case of a `ALTER TABLE ... OWNER TO ...` at this point (aka `ddl_command_end`) the ownership of the relation was already processed and with this PG16 refactoring it now is visible for the `object_ownercheck` leading to a misbehavior.

Due to our intention is just the get the `relid` related to the AlterTableCmd just fixed it by replacing the `AlterTableLookupRelation` for the `RangeVarGetRelid` because at this point all the proper aclcheck was already done.

postgres/postgres@afbfc029

Disable-check: force-changelog-file
