### PR TITLE
Fix exception detail passing in compression_policy_execute

### DIFF
--- a/.unreleased/pr_6254
+++ b/.unreleased/pr_6254
@@ -1,0 +1,3 @@
+Fixes: #6254 Fix exception detail passing in compression_policy_execute
+
+Thanks: @fetchezar for reporting an issue with compression policy error messages

--- a/sql/policy_internal.sql
+++ b/sql/policy_internal.sql
@@ -111,6 +111,9 @@ BEGIN
       BEGIN
         PERFORM @extschema@.decompress_chunk(chunk_rec.oid, if_compressed => true);
       EXCEPTION WHEN OTHERS THEN
+        GET STACKED DIAGNOSTICS
+            _message = MESSAGE_TEXT,
+            _detail = PG_EXCEPTION_DETAIL;
         RAISE WARNING 'decompressing chunk "%" failed when compression policy is executed', chunk_rec.oid::regclass::text
             USING DETAIL = format('Message: (%s), Detail: (%s).', _message, _detail),
                   ERRCODE = sqlstate;
@@ -122,6 +125,9 @@ BEGIN
       BEGIN
         PERFORM @extschema@.compress_chunk(chunk_rec.oid);
       EXCEPTION WHEN OTHERS THEN
+        GET STACKED DIAGNOSTICS
+            _message = MESSAGE_TEXT,
+            _detail = PG_EXCEPTION_DETAIL;
         RAISE WARNING 'compressing chunk "%" failed when compression policy is executed', chunk_rec.oid::regclass::text
             USING DETAIL = format('Message: (%s), Detail: (%s).', _message, _detail),
                   ERRCODE = sqlstate;


### PR DESCRIPTION
In 2 instances of the exception handling _message and _detail were not properly set in compression_policy_execute leading to empty message and detail being reported.