### PR TITLE
PG16: Fix join recursion

### DIFF
--- a/tsl/src/nodes/decompress_chunk/decompress_chunk.c
+++ b/tsl/src/nodes/decompress_chunk/decompress_chunk.c
@@ -290,12 +290,14 @@ build_compressioninfo(PlannerInfo *root, Hypertable *ht, RelOptInfo *chunk_rel)
 	{
 		appinfo = ts_get_appendrelinfo(root, chunk_rel->relid, false);
 		info->ht_rte = planner_rt_fetch(appinfo->parent_relid, root);
+		info->ht_rel = root->simple_rel_array[appinfo->parent_relid];
 	}
 	else
 	{
 		Assert(chunk_rel->reloptkind == RELOPT_BASEREL);
 		info->single_chunk = true;
 		info->ht_rte = info->chunk_rte;
+		info->ht_rel = info->chunk_rel;
 	}
 
 	info->hypertable_id = ht->fd.id;

--- a/tsl/src/nodes/decompress_chunk/decompress_chunk.c
+++ b/tsl/src/nodes/decompress_chunk/decompress_chunk.c
@@ -1416,10 +1416,26 @@ create_var_for_compressed_equivalence_member(Var *var, const EMCreationContext *
 	return NULL;
 }
 
+#if PG16_GE
+static EquivalenceMember *
+find_em_for_relid(EquivalenceClass *ec, Index relid)
+{
+	ListCell *lc;
+
+	foreach (lc, ec->ec_members)
+	{
+		EquivalenceMember *em = lfirst_node(EquivalenceMember, lc);
+		if (bms_is_member(relid, em->em_relids) && bms_num_members(em->em_relids) == 1)
+			return em;
+	}
+	return NULL;
+}
+#endif
+
 /* This function is inspired by the Postgres add_child_rel_equivalences. */
 static bool
-add_segmentby_to_equivalence_class(EquivalenceClass *cur_ec, CompressionInfo *info,
-								   EMCreationContext *context)
+add_segmentby_to_equivalence_class(PlannerInfo *root, EquivalenceClass *cur_ec,
+								   CompressionInfo *info, EMCreationContext *context)
 {
 	Relids uncompressed_chunk_relids = info->chunk_rel->relids;
 	ListCell *lc;
@@ -1528,6 +1544,25 @@ add_segmentby_to_equivalence_class(EquivalenceClass *cur_ec, CompressionInfo *in
 			compressed_fdw_private->compressed_ec_em_pairs =
 				lappend(compressed_fdw_private->compressed_ec_em_pairs, list_make2(cur_ec, em));
 
+#if PG16_GE
+			EquivalenceMember *ht_em = find_em_for_relid(cur_ec, info->ht_rel->relid);
+
+			if (ht_em && ht_em->em_jdomain)
+			{
+				int i = -1;
+				while ((i = bms_next_member(ht_em->em_jdomain->jd_relids, i)) >= 0)
+				{
+					RestrictInfo *d = make_simple_restrictinfo_compat(root, em->em_expr);
+					d->parent_ec = cur_ec;
+					d->left_em = find_em_for_relid(cur_ec, i);
+					if (!d->left_em)
+						continue;
+					d->right_em = em;
+					cur_ec->ec_derives = lappend(cur_ec->ec_derives, d);
+				}
+			}
+#endif
+
 			return true;
 		}
 	}
@@ -1572,7 +1607,7 @@ compressed_rel_setup_equivalence_classes(PlannerInfo *root, CompressionInfo *inf
 		if (bms_overlap(cur_ec->ec_relids, info->compressed_rel->relids))
 			continue;
 
-		bool em_added = add_segmentby_to_equivalence_class(cur_ec, info, &context);
+		bool em_added = add_segmentby_to_equivalence_class(root, cur_ec, info, &context);
 		/* Record this EC index for the compressed rel */
 		if (em_added)
 			info->compressed_rel->eclass_indexes =

--- a/tsl/src/nodes/decompress_chunk/decompress_chunk.h
+++ b/tsl/src/nodes/decompress_chunk/decompress_chunk.h
@@ -17,6 +17,7 @@ typedef struct CompressionInfo
 {
 	RelOptInfo *chunk_rel;
 	RelOptInfo *compressed_rel;
+	RelOptInfo *ht_rel;
 	RangeTblEntry *chunk_rte;
 	RangeTblEntry *compressed_rte;
 	RangeTblEntry *ht_rte;

--- a/tsl/test/expected/merge_append_partially_compressed-16.out
+++ b/tsl/test/expected/merge_append_partially_compressed-16.out
@@ -698,35 +698,31 @@ SELECT * FROM test1 ORDER BY time ASC NULLS FIRST, x3 DESC NULLS LAST, x4 ASC;
 
 :PREFIX
 SELECT x1, x2, max(time) FROM test1 GROUP BY x1, x2, time ORDER BY time limit 10;
-                                                     QUERY PLAN                                                      
----------------------------------------------------------------------------------------------------------------------
+                                                  QUERY PLAN                                                   
+---------------------------------------------------------------------------------------------------------------
  Limit (actual rows=5 loops=1)
-   ->  Sort (actual rows=5 loops=1)
-         Sort Key: test1."time"
-         Sort Method: quicksort 
-         ->  Finalize HashAggregate (actual rows=5 loops=1)
-               Group Key: test1.x1, test1.x2, test1."time"
-               Batches: 1 
-               ->  Custom Scan (ChunkAppend) on test1 (actual rows=5 loops=1)
-                     Order: test1."time", test1.x1, test1.x2
-                     ->  Merge Append (actual rows=5 loops=1)
+   ->  Finalize GroupAggregate (actual rows=5 loops=1)
+         Group Key: test1.x1, test1.x2, test1."time"
+         ->  Custom Scan (ChunkAppend) on test1 (actual rows=5 loops=1)
+               Order: test1."time", test1.x1, test1.x2
+               ->  Merge Append (actual rows=5 loops=1)
+                     Sort Key: _hyper_3_7_chunk."time", _hyper_3_7_chunk.x1, _hyper_3_7_chunk.x2
+                     ->  Sort (actual rows=4 loops=1)
                            Sort Key: _hyper_3_7_chunk."time", _hyper_3_7_chunk.x1, _hyper_3_7_chunk.x2
-                           ->  Sort (actual rows=4 loops=1)
-                                 Sort Key: _hyper_3_7_chunk."time", _hyper_3_7_chunk.x1, _hyper_3_7_chunk.x2
-                                 Sort Method: quicksort 
-                                 ->  Partial HashAggregate (actual rows=4 loops=1)
-                                       Group Key: _hyper_3_7_chunk.x1, _hyper_3_7_chunk.x2, _hyper_3_7_chunk."time"
-                                       Batches: 1 
-                                       ->  Custom Scan (DecompressChunk) on _hyper_3_7_chunk (actual rows=4 loops=1)
-                                             ->  Seq Scan on compress_hyper_4_8_chunk (actual rows=3 loops=1)
-                           ->  Sort (actual rows=1 loops=1)
-                                 Sort Key: _hyper_3_7_chunk."time", _hyper_3_7_chunk.x1, _hyper_3_7_chunk.x2
-                                 Sort Method: quicksort 
-                                 ->  Partial HashAggregate (actual rows=1 loops=1)
-                                       Group Key: _hyper_3_7_chunk.x1, _hyper_3_7_chunk.x2, _hyper_3_7_chunk."time"
-                                       Batches: 1 
-                                       ->  Seq Scan on _hyper_3_7_chunk (actual rows=1 loops=1)
-(26 rows)
+                           Sort Method: quicksort 
+                           ->  Partial HashAggregate (actual rows=4 loops=1)
+                                 Group Key: _hyper_3_7_chunk.x1, _hyper_3_7_chunk.x2, _hyper_3_7_chunk."time"
+                                 Batches: 1 
+                                 ->  Custom Scan (DecompressChunk) on _hyper_3_7_chunk (actual rows=4 loops=1)
+                                       ->  Seq Scan on compress_hyper_4_8_chunk (actual rows=3 loops=1)
+                     ->  Sort (actual rows=1 loops=1)
+                           Sort Key: _hyper_3_7_chunk."time", _hyper_3_7_chunk.x1, _hyper_3_7_chunk.x2
+                           Sort Method: quicksort 
+                           ->  Partial HashAggregate (actual rows=1 loops=1)
+                                 Group Key: _hyper_3_7_chunk.x1, _hyper_3_7_chunk.x2, _hyper_3_7_chunk."time"
+                                 Batches: 1 
+                                 ->  Seq Scan on _hyper_3_7_chunk (actual rows=1 loops=1)
+(22 rows)
 
 :PREFIX
 SELECT * FROM test1 ORDER BY x1, x2, x5, x4, time LIMIT 10;

--- a/tsl/test/expected/transparent_decompression-16.out
+++ b/tsl/test/expected/transparent_decompression-16.out
@@ -300,33 +300,32 @@ FROM :TEST_TABLE
 WHERE device_id IN (1, 2)
 ORDER BY time,
     device_id;
-                                                          QUERY PLAN                                                          
-------------------------------------------------------------------------------------------------------------------------------
- Incremental Sort (actual rows=2736 loops=1)
-   Sort Key: metrics."time", metrics.device_id
-   Presorted Key: metrics."time"
-   Full-sort Groups: 86  Sort Method: quicksort 
-   ->  Result (actual rows=2736 loops=1)
-         ->  Custom Scan (ChunkAppend) on metrics (actual rows=2736 loops=1)
-               Order: metrics."time"
-               ->  Sort (actual rows=720 loops=1)
-                     Sort Key: _hyper_1_1_chunk."time"
-                     Sort Method: quicksort 
-                     ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk (actual rows=720 loops=1)
-                           ->  Seq Scan on compress_hyper_5_15_chunk (actual rows=2 loops=1)
-                                 Filter: (device_id = ANY ('{1,2}'::integer[]))
-                                 Rows Removed by Filter: 3
-               ->  Index Scan Backward using _hyper_1_2_chunk_metrics_time_idx on _hyper_1_2_chunk (actual rows=1008 loops=1)
+                                           QUERY PLAN                                           
+------------------------------------------------------------------------------------------------
+ Result (actual rows=2736 loops=1)
+   ->  Custom Scan (ChunkAppend) on metrics (actual rows=2736 loops=1)
+         Order: metrics."time", metrics.device_id
+         ->  Sort (actual rows=720 loops=1)
+               Sort Key: _hyper_1_1_chunk."time", _hyper_1_1_chunk.device_id
+               Sort Method: quicksort 
+               ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk (actual rows=720 loops=1)
+                     ->  Seq Scan on compress_hyper_5_15_chunk (actual rows=2 loops=1)
+                           Filter: (device_id = ANY ('{1,2}'::integer[]))
+                           Rows Removed by Filter: 3
+         ->  Sort (actual rows=1008 loops=1)
+               Sort Key: _hyper_1_2_chunk."time", _hyper_1_2_chunk.device_id
+               Sort Method: quicksort 
+               ->  Seq Scan on _hyper_1_2_chunk (actual rows=1008 loops=1)
                      Filter: (device_id = ANY ('{1,2}'::integer[]))
                      Rows Removed by Filter: 1512
-               ->  Sort (actual rows=1008 loops=1)
-                     Sort Key: _hyper_1_3_chunk."time"
-                     Sort Method: quicksort 
-                     ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk (actual rows=1008 loops=1)
-                           ->  Seq Scan on compress_hyper_5_16_chunk (actual rows=2 loops=1)
-                                 Filter: (device_id = ANY ('{1,2}'::integer[]))
-                                 Rows Removed by Filter: 3
-(24 rows)
+         ->  Sort (actual rows=1008 loops=1)
+               Sort Key: _hyper_1_3_chunk."time", _hyper_1_3_chunk.device_id
+               Sort Method: quicksort 
+               ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk (actual rows=1008 loops=1)
+                     ->  Seq Scan on compress_hyper_5_16_chunk (actual rows=2 loops=1)
+                           Filter: (device_id = ANY ('{1,2}'::integer[]))
+                           Rows Removed by Filter: 3
+(23 rows)
 
 -- test empty targetlist
 :PREFIX
@@ -459,43 +458,43 @@ FROM :TEST_TABLE
 WHERE v3 > 10.0
 ORDER BY time,
     device_id;
-                                                                                                                                                                                                                                                                                                            QUERY PLAN                                                                                                                                                                                                                                                                                                            
-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
- Sort (actual rows=0 loops=1)
+                                                                                                                                                                                                                                                                                                         QUERY PLAN                                                                                                                                                                                                                                                                                                         
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Custom Scan (ChunkAppend) on public.metrics (actual rows=0 loops=1)
    Output: metrics."time", metrics.device_id, metrics.device_id_peer, metrics.v0, metrics.v1, metrics.v2, metrics.v3
-   Sort Key: metrics."time", metrics.device_id
-   Sort Method: quicksort 
-   ->  Custom Scan (ChunkAppend) on public.metrics (actual rows=0 loops=1)
-         Output: metrics."time", metrics.device_id, metrics.device_id_peer, metrics.v0, metrics.v1, metrics.v2, metrics.v3
-         Order: metrics."time"
-         Startup Exclusion: false
-         Runtime Exclusion: false
-         ->  Sort (actual rows=0 loops=1)
+   Order: metrics."time", metrics.device_id
+   Startup Exclusion: false
+   Runtime Exclusion: false
+   ->  Sort (actual rows=0 loops=1)
+         Output: _hyper_1_1_chunk."time", _hyper_1_1_chunk.device_id, _hyper_1_1_chunk.device_id_peer, _hyper_1_1_chunk.v0, _hyper_1_1_chunk.v1, _hyper_1_1_chunk.v2, _hyper_1_1_chunk.v3
+         Sort Key: _hyper_1_1_chunk."time", _hyper_1_1_chunk.device_id
+         Sort Method: quicksort 
+         ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_1_chunk (actual rows=0 loops=1)
                Output: _hyper_1_1_chunk."time", _hyper_1_1_chunk.device_id, _hyper_1_1_chunk.device_id_peer, _hyper_1_1_chunk.v0, _hyper_1_1_chunk.v1, _hyper_1_1_chunk.v2, _hyper_1_1_chunk.v3
-               Sort Key: _hyper_1_1_chunk."time"
-               Sort Method: quicksort 
-               ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_1_chunk (actual rows=0 loops=1)
-                     Output: _hyper_1_1_chunk."time", _hyper_1_1_chunk.device_id, _hyper_1_1_chunk.device_id_peer, _hyper_1_1_chunk.v0, _hyper_1_1_chunk.v1, _hyper_1_1_chunk.v2, _hyper_1_1_chunk.v3
-                     Vectorized Filter: (_hyper_1_1_chunk.v3 > '10'::double precision)
-                     Rows Removed by Filter: 1800
-                     Bulk Decompression: true
-                     ->  Seq Scan on _timescaledb_internal.compress_hyper_5_15_chunk (actual rows=5 loops=1)
-                           Output: compress_hyper_5_15_chunk."time", compress_hyper_5_15_chunk.device_id, compress_hyper_5_15_chunk.device_id_peer, compress_hyper_5_15_chunk.v0, compress_hyper_5_15_chunk.v1, compress_hyper_5_15_chunk.v2, compress_hyper_5_15_chunk.v3, compress_hyper_5_15_chunk._ts_meta_count, compress_hyper_5_15_chunk._ts_meta_sequence_num, compress_hyper_5_15_chunk._ts_meta_min_3, compress_hyper_5_15_chunk._ts_meta_max_3, compress_hyper_5_15_chunk._ts_meta_min_1, compress_hyper_5_15_chunk._ts_meta_max_1, compress_hyper_5_15_chunk._ts_meta_min_2, compress_hyper_5_15_chunk._ts_meta_max_2
-         ->  Index Scan Backward using _hyper_1_2_chunk_metrics_time_idx on _timescaledb_internal._hyper_1_2_chunk (actual rows=0 loops=1)
+               Vectorized Filter: (_hyper_1_1_chunk.v3 > '10'::double precision)
+               Rows Removed by Filter: 1800
+               Bulk Decompression: true
+               ->  Seq Scan on _timescaledb_internal.compress_hyper_5_15_chunk (actual rows=5 loops=1)
+                     Output: compress_hyper_5_15_chunk."time", compress_hyper_5_15_chunk.device_id, compress_hyper_5_15_chunk.device_id_peer, compress_hyper_5_15_chunk.v0, compress_hyper_5_15_chunk.v1, compress_hyper_5_15_chunk.v2, compress_hyper_5_15_chunk.v3, compress_hyper_5_15_chunk._ts_meta_count, compress_hyper_5_15_chunk._ts_meta_sequence_num, compress_hyper_5_15_chunk._ts_meta_min_3, compress_hyper_5_15_chunk._ts_meta_max_3, compress_hyper_5_15_chunk._ts_meta_min_1, compress_hyper_5_15_chunk._ts_meta_max_1, compress_hyper_5_15_chunk._ts_meta_min_2, compress_hyper_5_15_chunk._ts_meta_max_2
+   ->  Sort (actual rows=0 loops=1)
+         Output: _hyper_1_2_chunk."time", _hyper_1_2_chunk.device_id, _hyper_1_2_chunk.device_id_peer, _hyper_1_2_chunk.v0, _hyper_1_2_chunk.v1, _hyper_1_2_chunk.v2, _hyper_1_2_chunk.v3
+         Sort Key: _hyper_1_2_chunk."time", _hyper_1_2_chunk.device_id
+         Sort Method: quicksort 
+         ->  Seq Scan on _timescaledb_internal._hyper_1_2_chunk (actual rows=0 loops=1)
                Output: _hyper_1_2_chunk."time", _hyper_1_2_chunk.device_id, _hyper_1_2_chunk.device_id_peer, _hyper_1_2_chunk.v0, _hyper_1_2_chunk.v1, _hyper_1_2_chunk.v2, _hyper_1_2_chunk.v3
                Filter: (_hyper_1_2_chunk.v3 > '10'::double precision)
                Rows Removed by Filter: 2520
-         ->  Sort (actual rows=0 loops=1)
+   ->  Sort (actual rows=0 loops=1)
+         Output: _hyper_1_3_chunk."time", _hyper_1_3_chunk.device_id, _hyper_1_3_chunk.device_id_peer, _hyper_1_3_chunk.v0, _hyper_1_3_chunk.v1, _hyper_1_3_chunk.v2, _hyper_1_3_chunk.v3
+         Sort Key: _hyper_1_3_chunk."time", _hyper_1_3_chunk.device_id
+         Sort Method: quicksort 
+         ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_3_chunk (actual rows=0 loops=1)
                Output: _hyper_1_3_chunk."time", _hyper_1_3_chunk.device_id, _hyper_1_3_chunk.device_id_peer, _hyper_1_3_chunk.v0, _hyper_1_3_chunk.v1, _hyper_1_3_chunk.v2, _hyper_1_3_chunk.v3
-               Sort Key: _hyper_1_3_chunk."time"
-               Sort Method: quicksort 
-               ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_3_chunk (actual rows=0 loops=1)
-                     Output: _hyper_1_3_chunk."time", _hyper_1_3_chunk.device_id, _hyper_1_3_chunk.device_id_peer, _hyper_1_3_chunk.v0, _hyper_1_3_chunk.v1, _hyper_1_3_chunk.v2, _hyper_1_3_chunk.v3
-                     Vectorized Filter: (_hyper_1_3_chunk.v3 > '10'::double precision)
-                     Rows Removed by Filter: 2520
-                     Bulk Decompression: true
-                     ->  Seq Scan on _timescaledb_internal.compress_hyper_5_16_chunk (actual rows=5 loops=1)
-                           Output: compress_hyper_5_16_chunk."time", compress_hyper_5_16_chunk.device_id, compress_hyper_5_16_chunk.device_id_peer, compress_hyper_5_16_chunk.v0, compress_hyper_5_16_chunk.v1, compress_hyper_5_16_chunk.v2, compress_hyper_5_16_chunk.v3, compress_hyper_5_16_chunk._ts_meta_count, compress_hyper_5_16_chunk._ts_meta_sequence_num, compress_hyper_5_16_chunk._ts_meta_min_3, compress_hyper_5_16_chunk._ts_meta_max_3, compress_hyper_5_16_chunk._ts_meta_min_1, compress_hyper_5_16_chunk._ts_meta_max_1, compress_hyper_5_16_chunk._ts_meta_min_2, compress_hyper_5_16_chunk._ts_meta_max_2
+               Vectorized Filter: (_hyper_1_3_chunk.v3 > '10'::double precision)
+               Rows Removed by Filter: 2520
+               Bulk Decompression: true
+               ->  Seq Scan on _timescaledb_internal.compress_hyper_5_16_chunk (actual rows=5 loops=1)
+                     Output: compress_hyper_5_16_chunk."time", compress_hyper_5_16_chunk.device_id, compress_hyper_5_16_chunk.device_id_peer, compress_hyper_5_16_chunk.v0, compress_hyper_5_16_chunk.v1, compress_hyper_5_16_chunk.v2, compress_hyper_5_16_chunk.v3, compress_hyper_5_16_chunk._ts_meta_count, compress_hyper_5_16_chunk._ts_meta_sequence_num, compress_hyper_5_16_chunk._ts_meta_min_3, compress_hyper_5_16_chunk._ts_meta_max_3, compress_hyper_5_16_chunk._ts_meta_min_1, compress_hyper_5_16_chunk._ts_meta_max_1, compress_hyper_5_16_chunk._ts_meta_min_2, compress_hyper_5_16_chunk._ts_meta_max_2
 (35 rows)
 
 -- device_id constraint should be pushed down
@@ -535,29 +534,27 @@ WHERE device_id IS NOT NULL
 ORDER BY time,
     device_id
 LIMIT 10;
-                                                     QUERY PLAN                                                     
---------------------------------------------------------------------------------------------------------------------
+                                           QUERY PLAN                                           
+------------------------------------------------------------------------------------------------
  Limit (actual rows=10 loops=1)
-   ->  Incremental Sort (actual rows=10 loops=1)
-         Sort Key: metrics."time", metrics.device_id
-         Presorted Key: metrics."time"
-         Full-sort Groups: 1  Sort Method: quicksort 
-         ->  Custom Scan (ChunkAppend) on metrics (actual rows=11 loops=1)
-               Order: metrics."time"
-               ->  Sort (actual rows=11 loops=1)
-                     Sort Key: _hyper_1_1_chunk."time"
-                     Sort Method: quicksort 
-                     ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk (actual rows=1800 loops=1)
-                           ->  Seq Scan on compress_hyper_5_15_chunk (actual rows=5 loops=1)
-                                 Filter: (device_id IS NOT NULL)
-               ->  Index Scan Backward using _hyper_1_2_chunk_metrics_time_idx on _hyper_1_2_chunk (never executed)
+   ->  Custom Scan (ChunkAppend) on metrics (actual rows=10 loops=1)
+         Order: metrics."time", metrics.device_id
+         ->  Sort (actual rows=10 loops=1)
+               Sort Key: _hyper_1_1_chunk."time", _hyper_1_1_chunk.device_id
+               Sort Method: top-N heapsort 
+               ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk (actual rows=1800 loops=1)
+                     ->  Seq Scan on compress_hyper_5_15_chunk (actual rows=5 loops=1)
+                           Filter: (device_id IS NOT NULL)
+         ->  Sort (never executed)
+               Sort Key: _hyper_1_2_chunk."time", _hyper_1_2_chunk.device_id
+               ->  Seq Scan on _hyper_1_2_chunk (never executed)
                      Filter: (device_id IS NOT NULL)
-               ->  Sort (never executed)
-                     Sort Key: _hyper_1_3_chunk."time"
-                     ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk (never executed)
-                           ->  Seq Scan on compress_hyper_5_16_chunk (never executed)
-                                 Filter: (device_id IS NOT NULL)
-(20 rows)
+         ->  Sort (never executed)
+               Sort Key: _hyper_1_3_chunk."time", _hyper_1_3_chunk.device_id
+               ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk (never executed)
+                     ->  Seq Scan on compress_hyper_5_16_chunk (never executed)
+                           Filter: (device_id IS NOT NULL)
+(18 rows)
 
 :PREFIX
 SELECT *
@@ -569,22 +566,29 @@ LIMIT 10;
                                          QUERY PLAN                                          
 ---------------------------------------------------------------------------------------------
  Limit (actual rows=0 loops=1)
-   ->  Sort (actual rows=0 loops=1)
-         Sort Key: _hyper_1_1_chunk."time", _hyper_1_1_chunk.device_id
-         Sort Method: quicksort 
-         ->  Append (actual rows=0 loops=1)
+   ->  Custom Scan (ChunkAppend) on metrics (actual rows=0 loops=1)
+         Order: metrics."time", metrics.device_id
+         ->  Sort (actual rows=0 loops=1)
+               Sort Key: _hyper_1_1_chunk."time", _hyper_1_1_chunk.device_id
+               Sort Method: quicksort 
                ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk (actual rows=0 loops=1)
                      ->  Seq Scan on compress_hyper_5_15_chunk (actual rows=0 loops=1)
                            Filter: (device_id IS NULL)
                            Rows Removed by Filter: 5
+         ->  Sort (actual rows=0 loops=1)
+               Sort Key: _hyper_1_2_chunk."time", _hyper_1_2_chunk.device_id
+               Sort Method: quicksort 
                ->  Seq Scan on _hyper_1_2_chunk (actual rows=0 loops=1)
                      Filter: (device_id IS NULL)
                      Rows Removed by Filter: 2520
+         ->  Sort (actual rows=0 loops=1)
+               Sort Key: _hyper_1_3_chunk."time", _hyper_1_3_chunk.device_id
+               Sort Method: quicksort 
                ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk (actual rows=0 loops=1)
                      ->  Seq Scan on compress_hyper_5_16_chunk (actual rows=0 loops=1)
                            Filter: (device_id IS NULL)
                            Rows Removed by Filter: 5
-(16 rows)
+(23 rows)
 
 -- test IN (Const,Const)
 :PREFIX
@@ -594,30 +598,28 @@ WHERE device_id IN (1, 2)
 ORDER BY time,
     device_id
 LIMIT 10;
-                                                     QUERY PLAN                                                     
---------------------------------------------------------------------------------------------------------------------
+                                          QUERY PLAN                                           
+-----------------------------------------------------------------------------------------------
  Limit (actual rows=10 loops=1)
-   ->  Incremental Sort (actual rows=10 loops=1)
-         Sort Key: metrics."time", metrics.device_id
-         Presorted Key: metrics."time"
-         Full-sort Groups: 1  Sort Method: quicksort 
-         ->  Custom Scan (ChunkAppend) on metrics (actual rows=11 loops=1)
-               Order: metrics."time"
-               ->  Sort (actual rows=11 loops=1)
-                     Sort Key: _hyper_1_1_chunk."time"
-                     Sort Method: quicksort 
-                     ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk (actual rows=720 loops=1)
-                           ->  Seq Scan on compress_hyper_5_15_chunk (actual rows=2 loops=1)
-                                 Filter: (device_id = ANY ('{1,2}'::integer[]))
-                                 Rows Removed by Filter: 3
-               ->  Index Scan Backward using _hyper_1_2_chunk_metrics_time_idx on _hyper_1_2_chunk (never executed)
+   ->  Custom Scan (ChunkAppend) on metrics (actual rows=10 loops=1)
+         Order: metrics."time", metrics.device_id
+         ->  Sort (actual rows=10 loops=1)
+               Sort Key: _hyper_1_1_chunk."time", _hyper_1_1_chunk.device_id
+               Sort Method: top-N heapsort 
+               ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk (actual rows=720 loops=1)
+                     ->  Seq Scan on compress_hyper_5_15_chunk (actual rows=2 loops=1)
+                           Filter: (device_id = ANY ('{1,2}'::integer[]))
+                           Rows Removed by Filter: 3
+         ->  Sort (never executed)
+               Sort Key: _hyper_1_2_chunk."time", _hyper_1_2_chunk.device_id
+               ->  Seq Scan on _hyper_1_2_chunk (never executed)
                      Filter: (device_id = ANY ('{1,2}'::integer[]))
-               ->  Sort (never executed)
-                     Sort Key: _hyper_1_3_chunk."time"
-                     ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk (never executed)
-                           ->  Seq Scan on compress_hyper_5_16_chunk (never executed)
-                                 Filter: (device_id = ANY ('{1,2}'::integer[]))
-(21 rows)
+         ->  Sort (never executed)
+               Sort Key: _hyper_1_3_chunk."time", _hyper_1_3_chunk.device_id
+               ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk (never executed)
+                     ->  Seq Scan on compress_hyper_5_16_chunk (never executed)
+                           Filter: (device_id = ANY ('{1,2}'::integer[]))
+(19 rows)
 
 -- test cast pushdown
 :PREFIX
@@ -656,33 +658,32 @@ WHERE device_id = device_id_peer
 ORDER BY time,
     device_id
 LIMIT 10;
-                                                        QUERY PLAN                                                         
----------------------------------------------------------------------------------------------------------------------------
+                                         QUERY PLAN                                          
+---------------------------------------------------------------------------------------------
  Limit (actual rows=0 loops=1)
-   ->  Incremental Sort (actual rows=0 loops=1)
-         Sort Key: metrics."time", metrics.device_id
-         Presorted Key: metrics."time"
-         Full-sort Groups: 1  Sort Method: quicksort 
-         ->  Custom Scan (ChunkAppend) on metrics (actual rows=0 loops=1)
-               Order: metrics."time"
-               ->  Sort (actual rows=0 loops=1)
-                     Sort Key: _hyper_1_1_chunk."time"
-                     Sort Method: quicksort 
-                     ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk (actual rows=0 loops=1)
-                           ->  Seq Scan on compress_hyper_5_15_chunk (actual rows=0 loops=1)
-                                 Filter: (device_id = device_id_peer)
-                                 Rows Removed by Filter: 5
-               ->  Index Scan Backward using _hyper_1_2_chunk_metrics_time_idx on _hyper_1_2_chunk (actual rows=0 loops=1)
+   ->  Custom Scan (ChunkAppend) on metrics (actual rows=0 loops=1)
+         Order: metrics."time", metrics.device_id
+         ->  Sort (actual rows=0 loops=1)
+               Sort Key: _hyper_1_1_chunk."time", _hyper_1_1_chunk.device_id
+               Sort Method: quicksort 
+               ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk (actual rows=0 loops=1)
+                     ->  Seq Scan on compress_hyper_5_15_chunk (actual rows=0 loops=1)
+                           Filter: (device_id = device_id_peer)
+                           Rows Removed by Filter: 5
+         ->  Sort (actual rows=0 loops=1)
+               Sort Key: _hyper_1_2_chunk."time", _hyper_1_2_chunk.device_id
+               Sort Method: quicksort 
+               ->  Seq Scan on _hyper_1_2_chunk (actual rows=0 loops=1)
                      Filter: (device_id = device_id_peer)
                      Rows Removed by Filter: 2520
-               ->  Sort (actual rows=0 loops=1)
-                     Sort Key: _hyper_1_3_chunk."time"
-                     Sort Method: quicksort 
-                     ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk (actual rows=0 loops=1)
-                           ->  Seq Scan on compress_hyper_5_16_chunk (actual rows=0 loops=1)
-                                 Filter: (device_id = device_id_peer)
-                                 Rows Removed by Filter: 5
-(24 rows)
+         ->  Sort (actual rows=0 loops=1)
+               Sort Key: _hyper_1_3_chunk."time", _hyper_1_3_chunk.device_id
+               Sort Method: quicksort 
+               ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk (actual rows=0 loops=1)
+                     ->  Seq Scan on compress_hyper_5_16_chunk (actual rows=0 loops=1)
+                           Filter: (device_id = device_id_peer)
+                           Rows Removed by Filter: 5
+(23 rows)
 
 :PREFIX
 SELECT *
@@ -691,29 +692,27 @@ WHERE device_id_peer < device_id
 ORDER BY time,
     device_id
 LIMIT 10;
-                                                     QUERY PLAN                                                     
---------------------------------------------------------------------------------------------------------------------
+                                           QUERY PLAN                                           
+------------------------------------------------------------------------------------------------
  Limit (actual rows=10 loops=1)
-   ->  Incremental Sort (actual rows=10 loops=1)
-         Sort Key: metrics."time", metrics.device_id
-         Presorted Key: metrics."time"
-         Full-sort Groups: 1  Sort Method: quicksort 
-         ->  Custom Scan (ChunkAppend) on metrics (actual rows=11 loops=1)
-               Order: metrics."time"
-               ->  Sort (actual rows=11 loops=1)
-                     Sort Key: _hyper_1_1_chunk."time"
-                     Sort Method: quicksort 
-                     ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk (actual rows=1800 loops=1)
-                           ->  Seq Scan on compress_hyper_5_15_chunk (actual rows=5 loops=1)
-                                 Filter: (device_id_peer < device_id)
-               ->  Index Scan Backward using _hyper_1_2_chunk_metrics_time_idx on _hyper_1_2_chunk (never executed)
+   ->  Custom Scan (ChunkAppend) on metrics (actual rows=10 loops=1)
+         Order: metrics."time", metrics.device_id
+         ->  Sort (actual rows=10 loops=1)
+               Sort Key: _hyper_1_1_chunk."time", _hyper_1_1_chunk.device_id
+               Sort Method: top-N heapsort 
+               ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk (actual rows=1800 loops=1)
+                     ->  Seq Scan on compress_hyper_5_15_chunk (actual rows=5 loops=1)
+                           Filter: (device_id_peer < device_id)
+         ->  Sort (never executed)
+               Sort Key: _hyper_1_2_chunk."time", _hyper_1_2_chunk.device_id
+               ->  Seq Scan on _hyper_1_2_chunk (never executed)
                      Filter: (device_id_peer < device_id)
-               ->  Sort (never executed)
-                     Sort Key: _hyper_1_3_chunk."time"
-                     ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk (never executed)
-                           ->  Seq Scan on compress_hyper_5_16_chunk (never executed)
-                                 Filter: (device_id_peer < device_id)
-(20 rows)
+         ->  Sort (never executed)
+               Sort Key: _hyper_1_3_chunk."time", _hyper_1_3_chunk.device_id
+               ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk (never executed)
+                     ->  Seq Scan on compress_hyper_5_16_chunk (never executed)
+                           Filter: (device_id_peer < device_id)
+(18 rows)
 
 -- test expressions
 :PREFIX
@@ -846,32 +845,30 @@ WHERE time >= '2000-01-01 1:00:00+0'
 ORDER BY time,
     device_id
 LIMIT 10;
-                                                      QUERY PLAN                                                      
-----------------------------------------------------------------------------------------------------------------------
+                                                   QUERY PLAN                                                   
+----------------------------------------------------------------------------------------------------------------
  Limit (actual rows=10 loops=1)
-   ->  Incremental Sort (actual rows=10 loops=1)
-         Sort Key: metrics."time", metrics.device_id
-         Presorted Key: metrics."time"
-         Full-sort Groups: 1  Sort Method: quicksort 
-         ->  Custom Scan (ChunkAppend) on metrics (actual rows=11 loops=1)
-               Order: metrics."time"
-               ->  Sort (actual rows=11 loops=1)
-                     Sort Key: _hyper_1_1_chunk."time"
-                     Sort Method: quicksort 
-                     ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk (actual rows=1785 loops=1)
-                           Vectorized Filter: ("time" >= 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
-                           Rows Removed by Filter: 15
-                           ->  Seq Scan on compress_hyper_5_15_chunk (actual rows=5 loops=1)
-                                 Filter: (_ts_meta_max_3 >= 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
-               ->  Index Scan Backward using _hyper_1_2_chunk_metrics_time_idx on _hyper_1_2_chunk (never executed)
-                     Index Cond: ("time" >= 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
-               ->  Sort (never executed)
-                     Sort Key: _hyper_1_3_chunk."time"
-                     ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk (never executed)
-                           Vectorized Filter: ("time" >= 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
-                           ->  Seq Scan on compress_hyper_5_16_chunk (never executed)
-                                 Filter: (_ts_meta_max_3 >= 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
-(23 rows)
+   ->  Custom Scan (ChunkAppend) on metrics (actual rows=10 loops=1)
+         Order: metrics."time", metrics.device_id
+         ->  Sort (actual rows=10 loops=1)
+               Sort Key: _hyper_1_1_chunk."time", _hyper_1_1_chunk.device_id
+               Sort Method: top-N heapsort 
+               ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk (actual rows=1785 loops=1)
+                     Vectorized Filter: ("time" >= 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
+                     Rows Removed by Filter: 15
+                     ->  Seq Scan on compress_hyper_5_15_chunk (actual rows=5 loops=1)
+                           Filter: (_ts_meta_max_3 >= 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
+         ->  Sort (never executed)
+               Sort Key: _hyper_1_2_chunk."time", _hyper_1_2_chunk.device_id
+               ->  Seq Scan on _hyper_1_2_chunk (never executed)
+                     Filter: ("time" >= 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
+         ->  Sort (never executed)
+               Sort Key: _hyper_1_3_chunk."time", _hyper_1_3_chunk.device_id
+               ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk (never executed)
+                     Vectorized Filter: ("time" >= 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
+                     ->  Seq Scan on compress_hyper_5_16_chunk (never executed)
+                           Filter: (_ts_meta_max_3 >= 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
+(21 rows)
 
 :PREFIX
 SELECT *
@@ -880,32 +877,30 @@ WHERE time > '2000-01-01 1:00:00+0'
 ORDER BY time,
     device_id
 LIMIT 10;
-                                                     QUERY PLAN                                                      
----------------------------------------------------------------------------------------------------------------------
+                                                  QUERY PLAN                                                   
+---------------------------------------------------------------------------------------------------------------
  Limit (actual rows=10 loops=1)
-   ->  Incremental Sort (actual rows=10 loops=1)
-         Sort Key: metrics."time", metrics.device_id
-         Presorted Key: metrics."time"
-         Full-sort Groups: 1  Sort Method: quicksort 
-         ->  Custom Scan (ChunkAppend) on metrics (actual rows=11 loops=1)
-               Order: metrics."time"
-               ->  Sort (actual rows=11 loops=1)
-                     Sort Key: _hyper_1_1_chunk."time"
-                     Sort Method: quicksort 
-                     ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk (actual rows=1780 loops=1)
-                           Vectorized Filter: ("time" > 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
-                           Rows Removed by Filter: 20
-                           ->  Seq Scan on compress_hyper_5_15_chunk (actual rows=5 loops=1)
-                                 Filter: (_ts_meta_max_3 > 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
-               ->  Index Scan Backward using _hyper_1_2_chunk_metrics_time_idx on _hyper_1_2_chunk (never executed)
-                     Index Cond: ("time" > 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
-               ->  Sort (never executed)
-                     Sort Key: _hyper_1_3_chunk."time"
-                     ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk (never executed)
-                           Vectorized Filter: ("time" > 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
-                           ->  Seq Scan on compress_hyper_5_16_chunk (never executed)
-                                 Filter: (_ts_meta_max_3 > 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
-(23 rows)
+   ->  Custom Scan (ChunkAppend) on metrics (actual rows=10 loops=1)
+         Order: metrics."time", metrics.device_id
+         ->  Sort (actual rows=10 loops=1)
+               Sort Key: _hyper_1_1_chunk."time", _hyper_1_1_chunk.device_id
+               Sort Method: top-N heapsort 
+               ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk (actual rows=1780 loops=1)
+                     Vectorized Filter: ("time" > 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
+                     Rows Removed by Filter: 20
+                     ->  Seq Scan on compress_hyper_5_15_chunk (actual rows=5 loops=1)
+                           Filter: (_ts_meta_max_3 > 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
+         ->  Sort (never executed)
+               Sort Key: _hyper_1_2_chunk."time", _hyper_1_2_chunk.device_id
+               ->  Seq Scan on _hyper_1_2_chunk (never executed)
+                     Filter: ("time" > 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
+         ->  Sort (never executed)
+               Sort Key: _hyper_1_3_chunk."time", _hyper_1_3_chunk.device_id
+               ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk (never executed)
+                     Vectorized Filter: ("time" > 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
+                     ->  Seq Scan on compress_hyper_5_16_chunk (never executed)
+                           Filter: (_ts_meta_max_3 > 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
+(21 rows)
 
 :PREFIX
 SELECT *
@@ -914,32 +909,30 @@ WHERE '2000-01-01 1:00:00+0' < time
 ORDER BY time,
     device_id
 LIMIT 10;
-                                                     QUERY PLAN                                                      
----------------------------------------------------------------------------------------------------------------------
+                                                  QUERY PLAN                                                   
+---------------------------------------------------------------------------------------------------------------
  Limit (actual rows=10 loops=1)
-   ->  Incremental Sort (actual rows=10 loops=1)
-         Sort Key: metrics."time", metrics.device_id
-         Presorted Key: metrics."time"
-         Full-sort Groups: 1  Sort Method: quicksort 
-         ->  Custom Scan (ChunkAppend) on metrics (actual rows=11 loops=1)
-               Order: metrics."time"
-               ->  Sort (actual rows=11 loops=1)
-                     Sort Key: _hyper_1_1_chunk."time"
-                     Sort Method: quicksort 
-                     ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk (actual rows=1780 loops=1)
-                           Vectorized Filter: ("time" > 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
-                           Rows Removed by Filter: 20
-                           ->  Seq Scan on compress_hyper_5_15_chunk (actual rows=5 loops=1)
-                                 Filter: (_ts_meta_max_3 > 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
-               ->  Index Scan Backward using _hyper_1_2_chunk_metrics_time_idx on _hyper_1_2_chunk (never executed)
-                     Index Cond: ("time" > 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
-               ->  Sort (never executed)
-                     Sort Key: _hyper_1_3_chunk."time"
-                     ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk (never executed)
-                           Vectorized Filter: ("time" > 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
-                           ->  Seq Scan on compress_hyper_5_16_chunk (never executed)
-                                 Filter: (_ts_meta_max_3 > 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
-(23 rows)
+   ->  Custom Scan (ChunkAppend) on metrics (actual rows=10 loops=1)
+         Order: metrics."time", metrics.device_id
+         ->  Sort (actual rows=10 loops=1)
+               Sort Key: _hyper_1_1_chunk."time", _hyper_1_1_chunk.device_id
+               Sort Method: top-N heapsort 
+               ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk (actual rows=1780 loops=1)
+                     Vectorized Filter: ("time" > 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
+                     Rows Removed by Filter: 20
+                     ->  Seq Scan on compress_hyper_5_15_chunk (actual rows=5 loops=1)
+                           Filter: (_ts_meta_max_3 > 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
+         ->  Sort (never executed)
+               Sort Key: _hyper_1_2_chunk."time", _hyper_1_2_chunk.device_id
+               ->  Seq Scan on _hyper_1_2_chunk (never executed)
+                     Filter: ('Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone < "time")
+         ->  Sort (never executed)
+               Sort Key: _hyper_1_3_chunk."time", _hyper_1_3_chunk.device_id
+               ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk (never executed)
+                     Vectorized Filter: ("time" > 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
+                     ->  Seq Scan on compress_hyper_5_16_chunk (never executed)
+                           Filter: (_ts_meta_max_3 > 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
+(21 rows)
 
 --pushdowns between order by and segment by columns
 :PREFIX
@@ -949,33 +942,32 @@ WHERE v0 < 1
 ORDER BY time,
     device_id
 LIMIT 10;
-                                                         QUERY PLAN                                                         
-----------------------------------------------------------------------------------------------------------------------------
+                                         QUERY PLAN                                          
+---------------------------------------------------------------------------------------------
  Limit (actual rows=10 loops=1)
-   ->  Incremental Sort (actual rows=10 loops=1)
-         Sort Key: metrics."time", metrics.device_id
-         Presorted Key: metrics."time"
-         Full-sort Groups: 1  Sort Method: quicksort 
-         ->  Custom Scan (ChunkAppend) on metrics (actual rows=11 loops=1)
-               Order: metrics."time"
-               ->  Sort (actual rows=0 loops=1)
-                     Sort Key: _hyper_1_1_chunk."time"
-                     Sort Method: quicksort 
-                     ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk (actual rows=0 loops=1)
-                           Vectorized Filter: (v0 < 1)
-                           ->  Seq Scan on compress_hyper_5_15_chunk (actual rows=0 loops=1)
-                                 Filter: (_ts_meta_min_1 < 1)
-                                 Rows Removed by Filter: 5
-               ->  Index Scan Backward using _hyper_1_2_chunk_metrics_time_idx on _hyper_1_2_chunk (actual rows=11 loops=1)
+   ->  Custom Scan (ChunkAppend) on metrics (actual rows=10 loops=1)
+         Order: metrics."time", metrics.device_id
+         ->  Sort (actual rows=0 loops=1)
+               Sort Key: _hyper_1_1_chunk."time", _hyper_1_1_chunk.device_id
+               Sort Method: quicksort 
+               ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk (actual rows=0 loops=1)
+                     Vectorized Filter: (v0 < 1)
+                     ->  Seq Scan on compress_hyper_5_15_chunk (actual rows=0 loops=1)
+                           Filter: (_ts_meta_min_1 < 1)
+                           Rows Removed by Filter: 5
+         ->  Sort (actual rows=10 loops=1)
+               Sort Key: _hyper_1_2_chunk."time", _hyper_1_2_chunk.device_id
+               Sort Method: top-N heapsort 
+               ->  Seq Scan on _hyper_1_2_chunk (actual rows=504 loops=1)
                      Filter: (v0 < 1)
-                     Rows Removed by Filter: 44
-               ->  Sort (never executed)
-                     Sort Key: _hyper_1_3_chunk."time"
-                     ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk (never executed)
-                           Vectorized Filter: (v0 < 1)
-                           ->  Seq Scan on compress_hyper_5_16_chunk (never executed)
-                                 Filter: (_ts_meta_min_1 < 1)
-(24 rows)
+                     Rows Removed by Filter: 2016
+         ->  Sort (never executed)
+               Sort Key: _hyper_1_3_chunk."time", _hyper_1_3_chunk.device_id
+               ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk (never executed)
+                     Vectorized Filter: (v0 < 1)
+                     ->  Seq Scan on compress_hyper_5_16_chunk (never executed)
+                           Filter: (_ts_meta_min_1 < 1)
+(23 rows)
 
 :PREFIX
 SELECT *
@@ -984,32 +976,31 @@ WHERE v0 < device_id
 ORDER BY time,
     device_id
 LIMIT 10;
-                                                         QUERY PLAN                                                         
-----------------------------------------------------------------------------------------------------------------------------
+                                         QUERY PLAN                                          
+---------------------------------------------------------------------------------------------
  Limit (actual rows=10 loops=1)
-   ->  Incremental Sort (actual rows=10 loops=1)
-         Sort Key: metrics."time", metrics.device_id
-         Presorted Key: metrics."time"
-         Full-sort Groups: 1  Sort Method: quicksort 
-         ->  Custom Scan (ChunkAppend) on metrics (actual rows=11 loops=1)
-               Order: metrics."time"
-               ->  Sort (actual rows=0 loops=1)
-                     Sort Key: _hyper_1_1_chunk."time"
-                     Sort Method: quicksort 
-                     ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk (actual rows=0 loops=1)
-                           Filter: (v0 < device_id)
-                           ->  Seq Scan on compress_hyper_5_15_chunk (actual rows=0 loops=1)
-                                 Filter: (_ts_meta_min_1 < device_id)
-                                 Rows Removed by Filter: 5
-               ->  Index Scan Backward using _hyper_1_2_chunk_metrics_time_idx on _hyper_1_2_chunk (actual rows=11 loops=1)
+   ->  Custom Scan (ChunkAppend) on metrics (actual rows=10 loops=1)
+         Order: metrics."time", metrics.device_id
+         ->  Sort (actual rows=0 loops=1)
+               Sort Key: _hyper_1_1_chunk."time", _hyper_1_1_chunk.device_id
+               Sort Method: quicksort 
+               ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk (actual rows=0 loops=1)
                      Filter: (v0 < device_id)
-               ->  Sort (never executed)
-                     Sort Key: _hyper_1_3_chunk."time"
-                     ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk (never executed)
-                           Filter: (v0 < device_id)
-                           ->  Seq Scan on compress_hyper_5_16_chunk (never executed)
-                                 Filter: (_ts_meta_min_1 < device_id)
-(23 rows)
+                     ->  Seq Scan on compress_hyper_5_15_chunk (actual rows=0 loops=1)
+                           Filter: (_ts_meta_min_1 < device_id)
+                           Rows Removed by Filter: 5
+         ->  Sort (actual rows=10 loops=1)
+               Sort Key: _hyper_1_2_chunk."time", _hyper_1_2_chunk.device_id
+               Sort Method: top-N heapsort 
+               ->  Seq Scan on _hyper_1_2_chunk (actual rows=2520 loops=1)
+                     Filter: (v0 < device_id)
+         ->  Sort (never executed)
+               Sort Key: _hyper_1_3_chunk."time", _hyper_1_3_chunk.device_id
+               ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk (never executed)
+                     Filter: (v0 < device_id)
+                     ->  Seq Scan on compress_hyper_5_16_chunk (never executed)
+                           Filter: (_ts_meta_min_1 < device_id)
+(22 rows)
 
 :PREFIX
 SELECT *
@@ -1018,31 +1009,29 @@ WHERE device_id < v0
 ORDER BY time,
     device_id
 LIMIT 10;
-                                                     QUERY PLAN                                                     
---------------------------------------------------------------------------------------------------------------------
+                                           QUERY PLAN                                           
+------------------------------------------------------------------------------------------------
  Limit (actual rows=10 loops=1)
-   ->  Incremental Sort (actual rows=10 loops=1)
-         Sort Key: metrics."time", metrics.device_id
-         Presorted Key: metrics."time"
-         Full-sort Groups: 1  Sort Method: quicksort 
-         ->  Custom Scan (ChunkAppend) on metrics (actual rows=11 loops=1)
-               Order: metrics."time"
-               ->  Sort (actual rows=11 loops=1)
-                     Sort Key: _hyper_1_1_chunk."time"
-                     Sort Method: quicksort 
-                     ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk (actual rows=1800 loops=1)
-                           Filter: (device_id < v0)
-                           ->  Seq Scan on compress_hyper_5_15_chunk (actual rows=5 loops=1)
-                                 Filter: (_ts_meta_max_1 > device_id)
-               ->  Index Scan Backward using _hyper_1_2_chunk_metrics_time_idx on _hyper_1_2_chunk (never executed)
+   ->  Custom Scan (ChunkAppend) on metrics (actual rows=10 loops=1)
+         Order: metrics."time", metrics.device_id
+         ->  Sort (actual rows=10 loops=1)
+               Sort Key: _hyper_1_1_chunk."time", _hyper_1_1_chunk.device_id
+               Sort Method: top-N heapsort 
+               ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk (actual rows=1800 loops=1)
                      Filter: (device_id < v0)
-               ->  Sort (never executed)
-                     Sort Key: _hyper_1_3_chunk."time"
-                     ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk (never executed)
-                           Filter: (device_id < v0)
-                           ->  Seq Scan on compress_hyper_5_16_chunk (never executed)
-                                 Filter: (_ts_meta_max_1 > device_id)
-(22 rows)
+                     ->  Seq Scan on compress_hyper_5_15_chunk (actual rows=5 loops=1)
+                           Filter: (_ts_meta_max_1 > device_id)
+         ->  Sort (never executed)
+               Sort Key: _hyper_1_2_chunk."time", _hyper_1_2_chunk.device_id
+               ->  Seq Scan on _hyper_1_2_chunk (never executed)
+                     Filter: (device_id < v0)
+         ->  Sort (never executed)
+               Sort Key: _hyper_1_3_chunk."time", _hyper_1_3_chunk.device_id
+               ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk (never executed)
+                     Filter: (device_id < v0)
+                     ->  Seq Scan on compress_hyper_5_16_chunk (never executed)
+                           Filter: (_ts_meta_max_1 > device_id)
+(20 rows)
 
 :PREFIX
 SELECT *
@@ -1051,35 +1040,34 @@ WHERE v1 = device_id
 ORDER BY time,
     device_id
 LIMIT 10;
-                                                        QUERY PLAN                                                         
----------------------------------------------------------------------------------------------------------------------------
+                                             QUERY PLAN                                              
+-----------------------------------------------------------------------------------------------------
  Limit (actual rows=0 loops=1)
-   ->  Incremental Sort (actual rows=0 loops=1)
-         Sort Key: metrics."time", metrics.device_id
-         Presorted Key: metrics."time"
-         Full-sort Groups: 1  Sort Method: quicksort 
-         ->  Custom Scan (ChunkAppend) on metrics (actual rows=0 loops=1)
-               Order: metrics."time"
-               ->  Sort (actual rows=0 loops=1)
-                     Sort Key: _hyper_1_1_chunk."time"
-                     Sort Method: quicksort 
-                     ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk (actual rows=0 loops=1)
-                           Filter: (v1 = device_id)
-                           ->  Seq Scan on compress_hyper_5_15_chunk (actual rows=0 loops=1)
-                                 Filter: ((_ts_meta_min_2 <= device_id) AND (_ts_meta_max_2 >= device_id))
-                                 Rows Removed by Filter: 5
-               ->  Index Scan Backward using _hyper_1_2_chunk_metrics_time_idx on _hyper_1_2_chunk (actual rows=0 loops=1)
+   ->  Custom Scan (ChunkAppend) on metrics (actual rows=0 loops=1)
+         Order: metrics."time", metrics.device_id
+         ->  Sort (actual rows=0 loops=1)
+               Sort Key: _hyper_1_1_chunk."time", _hyper_1_1_chunk.device_id
+               Sort Method: quicksort 
+               ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk (actual rows=0 loops=1)
+                     Filter: (v1 = device_id)
+                     ->  Seq Scan on compress_hyper_5_15_chunk (actual rows=0 loops=1)
+                           Filter: ((_ts_meta_min_2 <= device_id) AND (_ts_meta_max_2 >= device_id))
+                           Rows Removed by Filter: 5
+         ->  Sort (actual rows=0 loops=1)
+               Sort Key: _hyper_1_2_chunk."time", _hyper_1_2_chunk.device_id
+               Sort Method: quicksort 
+               ->  Seq Scan on _hyper_1_2_chunk (actual rows=0 loops=1)
                      Filter: (v1 = device_id)
                      Rows Removed by Filter: 2520
-               ->  Sort (actual rows=0 loops=1)
-                     Sort Key: _hyper_1_3_chunk."time"
-                     Sort Method: quicksort 
-                     ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk (actual rows=0 loops=1)
-                           Filter: (v1 = device_id)
-                           ->  Seq Scan on compress_hyper_5_16_chunk (actual rows=0 loops=1)
-                                 Filter: ((_ts_meta_min_2 <= device_id) AND (_ts_meta_max_2 >= device_id))
-                                 Rows Removed by Filter: 5
-(26 rows)
+         ->  Sort (actual rows=0 loops=1)
+               Sort Key: _hyper_1_3_chunk."time", _hyper_1_3_chunk.device_id
+               Sort Method: quicksort 
+               ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk (actual rows=0 loops=1)
+                     Filter: (v1 = device_id)
+                     ->  Seq Scan on compress_hyper_5_16_chunk (actual rows=0 loops=1)
+                           Filter: ((_ts_meta_min_2 <= device_id) AND (_ts_meta_max_2 >= device_id))
+                           Rows Removed by Filter: 5
+(25 rows)
 
 --pushdown between two order by column (not pushed down)
 :PREFIX
@@ -1089,33 +1077,32 @@ WHERE v0 = v1
 ORDER BY time,
     device_id
 LIMIT 10;
-                                                        QUERY PLAN                                                         
----------------------------------------------------------------------------------------------------------------------------
+                                         QUERY PLAN                                          
+---------------------------------------------------------------------------------------------
  Limit (actual rows=0 loops=1)
-   ->  Incremental Sort (actual rows=0 loops=1)
-         Sort Key: metrics."time", metrics.device_id
-         Presorted Key: metrics."time"
-         Full-sort Groups: 1  Sort Method: quicksort 
-         ->  Custom Scan (ChunkAppend) on metrics (actual rows=0 loops=1)
-               Order: metrics."time"
-               ->  Sort (actual rows=0 loops=1)
-                     Sort Key: _hyper_1_1_chunk."time"
-                     Sort Method: quicksort 
-                     ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk (actual rows=0 loops=1)
-                           Filter: (v0 = v1)
-                           Rows Removed by Filter: 1800
-                           ->  Seq Scan on compress_hyper_5_15_chunk (actual rows=5 loops=1)
-               ->  Index Scan Backward using _hyper_1_2_chunk_metrics_time_idx on _hyper_1_2_chunk (actual rows=0 loops=1)
+   ->  Custom Scan (ChunkAppend) on metrics (actual rows=0 loops=1)
+         Order: metrics."time", metrics.device_id
+         ->  Sort (actual rows=0 loops=1)
+               Sort Key: _hyper_1_1_chunk."time", _hyper_1_1_chunk.device_id
+               Sort Method: quicksort 
+               ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk (actual rows=0 loops=1)
+                     Filter: (v0 = v1)
+                     Rows Removed by Filter: 1800
+                     ->  Seq Scan on compress_hyper_5_15_chunk (actual rows=5 loops=1)
+         ->  Sort (actual rows=0 loops=1)
+               Sort Key: _hyper_1_2_chunk."time", _hyper_1_2_chunk.device_id
+               Sort Method: quicksort 
+               ->  Seq Scan on _hyper_1_2_chunk (actual rows=0 loops=1)
                      Filter: (v0 = v1)
                      Rows Removed by Filter: 2520
-               ->  Sort (actual rows=0 loops=1)
-                     Sort Key: _hyper_1_3_chunk."time"
-                     Sort Method: quicksort 
-                     ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk (actual rows=0 loops=1)
-                           Filter: (v0 = v1)
-                           Rows Removed by Filter: 2520
-                           ->  Seq Scan on compress_hyper_5_16_chunk (actual rows=5 loops=1)
-(24 rows)
+         ->  Sort (actual rows=0 loops=1)
+               Sort Key: _hyper_1_3_chunk."time", _hyper_1_3_chunk.device_id
+               Sort Method: quicksort 
+               ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk (actual rows=0 loops=1)
+                     Filter: (v0 = v1)
+                     Rows Removed by Filter: 2520
+                     ->  Seq Scan on compress_hyper_5_16_chunk (actual rows=5 loops=1)
+(23 rows)
 
 --pushdown of quals on order by and segment by cols anded together
 :PREFIX_VERBOSE
@@ -1173,30 +1160,28 @@ WHERE time > '2000-01-01 1:00:00+0'
 ORDER BY time,
     device_id
 LIMIT 10;
-                                                         QUERY PLAN                                                         
-----------------------------------------------------------------------------------------------------------------------------
+                                                      QUERY PLAN                                                      
+----------------------------------------------------------------------------------------------------------------------
  Limit (actual rows=10 loops=1)
-   ->  Incremental Sort (actual rows=10 loops=1)
-         Sort Key: metrics."time", metrics.device_id
-         Presorted Key: metrics."time"
-         Full-sort Groups: 1  Sort Method: quicksort 
-         ->  Custom Scan (ChunkAppend) on metrics (actual rows=15 loops=1)
-               Order: metrics."time"
-               ->  Sort (actual rows=15 loops=1)
-                     Sort Key: _hyper_1_1_chunk."time"
-                     Sort Method: quicksort 
-                     ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk (actual rows=1784 loops=1)
-                           Filter: (("time" > 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone) OR (device_id = 1))
-                           Rows Removed by Filter: 16
-                           ->  Seq Scan on compress_hyper_5_15_chunk (actual rows=5 loops=1)
-               ->  Index Scan Backward using _hyper_1_2_chunk_metrics_time_idx on _hyper_1_2_chunk (never executed)
+   ->  Custom Scan (ChunkAppend) on metrics (actual rows=10 loops=1)
+         Order: metrics."time", metrics.device_id
+         ->  Sort (actual rows=10 loops=1)
+               Sort Key: _hyper_1_1_chunk."time", _hyper_1_1_chunk.device_id
+               Sort Method: top-N heapsort 
+               ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk (actual rows=1784 loops=1)
                      Filter: (("time" > 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone) OR (device_id = 1))
-               ->  Sort (never executed)
-                     Sort Key: _hyper_1_3_chunk."time"
-                     ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk (never executed)
-                           Filter: (("time" > 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone) OR (device_id = 1))
-                           ->  Seq Scan on compress_hyper_5_16_chunk (never executed)
-(21 rows)
+                     Rows Removed by Filter: 16
+                     ->  Seq Scan on compress_hyper_5_15_chunk (actual rows=5 loops=1)
+         ->  Sort (never executed)
+               Sort Key: _hyper_1_2_chunk."time", _hyper_1_2_chunk.device_id
+               ->  Seq Scan on _hyper_1_2_chunk (never executed)
+                     Filter: (("time" > 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone) OR (device_id = 1))
+         ->  Sort (never executed)
+               Sort Key: _hyper_1_3_chunk."time", _hyper_1_3_chunk.device_id
+               ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk (never executed)
+                     Filter: (("time" > 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone) OR (device_id = 1))
+                     ->  Seq Scan on compress_hyper_5_16_chunk (never executed)
+(19 rows)
 
 --functions not yet optimized
 :PREFIX
@@ -1206,30 +1191,28 @@ WHERE time < now()
 ORDER BY time,
     device_id
 LIMIT 10;
-                                                     QUERY PLAN                                                     
---------------------------------------------------------------------------------------------------------------------
+                                           QUERY PLAN                                           
+------------------------------------------------------------------------------------------------
  Limit (actual rows=10 loops=1)
-   ->  Incremental Sort (actual rows=10 loops=1)
-         Sort Key: metrics."time", metrics.device_id
-         Presorted Key: metrics."time"
-         Full-sort Groups: 1  Sort Method: quicksort 
-         ->  Custom Scan (ChunkAppend) on metrics (actual rows=11 loops=1)
-               Order: metrics."time"
-               Chunks excluded during startup: 0
-               ->  Sort (actual rows=11 loops=1)
-                     Sort Key: _hyper_1_1_chunk."time"
-                     Sort Method: quicksort 
-                     ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk (actual rows=1800 loops=1)
-                           Filter: ("time" < now())
-                           ->  Seq Scan on compress_hyper_5_15_chunk (actual rows=5 loops=1)
-               ->  Index Scan Backward using _hyper_1_2_chunk_metrics_time_idx on _hyper_1_2_chunk (never executed)
-                     Index Cond: ("time" < now())
-               ->  Sort (never executed)
-                     Sort Key: _hyper_1_3_chunk."time"
-                     ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk (never executed)
-                           Filter: ("time" < now())
-                           ->  Seq Scan on compress_hyper_5_16_chunk (never executed)
-(21 rows)
+   ->  Custom Scan (ChunkAppend) on metrics (actual rows=10 loops=1)
+         Order: metrics."time", metrics.device_id
+         Chunks excluded during startup: 0
+         ->  Sort (actual rows=10 loops=1)
+               Sort Key: _hyper_1_1_chunk."time", _hyper_1_1_chunk.device_id
+               Sort Method: top-N heapsort 
+               ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk (actual rows=1800 loops=1)
+                     Filter: ("time" < now())
+                     ->  Seq Scan on compress_hyper_5_15_chunk (actual rows=5 loops=1)
+         ->  Sort (never executed)
+               Sort Key: _hyper_1_2_chunk."time", _hyper_1_2_chunk.device_id
+               ->  Seq Scan on _hyper_1_2_chunk (never executed)
+                     Filter: ("time" < now())
+         ->  Sort (never executed)
+               Sort Key: _hyper_1_3_chunk."time", _hyper_1_3_chunk.device_id
+               ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk (never executed)
+                     Filter: ("time" < now())
+                     ->  Seq Scan on compress_hyper_5_16_chunk (never executed)
+(19 rows)
 
 -- test sort optimization interaction
 :PREFIX
@@ -1262,26 +1245,24 @@ FROM :TEST_TABLE
 ORDER BY time DESC,
     device_id
 LIMIT 10;
-                                                QUERY PLAN                                                 
------------------------------------------------------------------------------------------------------------
+                                           QUERY PLAN                                           
+------------------------------------------------------------------------------------------------
  Limit (actual rows=10 loops=1)
-   ->  Incremental Sort (actual rows=10 loops=1)
-         Sort Key: metrics."time" DESC, metrics.device_id
-         Presorted Key: metrics."time"
-         Full-sort Groups: 1  Sort Method: quicksort 
-         ->  Custom Scan (ChunkAppend) on metrics (actual rows=11 loops=1)
-               Order: metrics."time" DESC
-               ->  Sort (actual rows=11 loops=1)
-                     Sort Key: _hyper_1_3_chunk."time" DESC
-                     Sort Method: quicksort 
-                     ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk (actual rows=2520 loops=1)
-                           ->  Seq Scan on compress_hyper_5_16_chunk (actual rows=5 loops=1)
-               ->  Index Scan using _hyper_1_2_chunk_metrics_time_idx on _hyper_1_2_chunk (never executed)
-               ->  Sort (never executed)
-                     Sort Key: _hyper_1_1_chunk."time" DESC
-                     ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk (never executed)
-                           ->  Seq Scan on compress_hyper_5_15_chunk (never executed)
-(17 rows)
+   ->  Custom Scan (ChunkAppend) on metrics (actual rows=10 loops=1)
+         Order: metrics."time" DESC, metrics.device_id
+         ->  Sort (actual rows=10 loops=1)
+               Sort Key: _hyper_1_3_chunk."time" DESC, _hyper_1_3_chunk.device_id
+               Sort Method: top-N heapsort 
+               ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk (actual rows=2520 loops=1)
+                     ->  Seq Scan on compress_hyper_5_16_chunk (actual rows=5 loops=1)
+         ->  Sort (never executed)
+               Sort Key: _hyper_1_2_chunk."time" DESC, _hyper_1_2_chunk.device_id
+               ->  Seq Scan on _hyper_1_2_chunk (never executed)
+         ->  Sort (never executed)
+               Sort Key: _hyper_1_1_chunk."time" DESC, _hyper_1_1_chunk.device_id
+               ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk (never executed)
+                     ->  Seq Scan on compress_hyper_5_15_chunk (never executed)
+(15 rows)
 
 :PREFIX
 SELECT time,
@@ -1293,16 +1274,23 @@ LIMIT 10;
                                            QUERY PLAN                                           
 ------------------------------------------------------------------------------------------------
  Limit (actual rows=10 loops=1)
-   ->  Sort (actual rows=10 loops=1)
+   ->  Merge Append (actual rows=10 loops=1)
          Sort Key: _hyper_1_1_chunk.device_id, _hyper_1_1_chunk."time" DESC
-         Sort Method: top-N heapsort 
-         ->  Append (actual rows=6840 loops=1)
+         ->  Sort (actual rows=1 loops=1)
+               Sort Key: _hyper_1_1_chunk.device_id, _hyper_1_1_chunk."time" DESC
+               Sort Method: top-N heapsort 
                ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk (actual rows=1800 loops=1)
                      ->  Seq Scan on compress_hyper_5_15_chunk (actual rows=5 loops=1)
+         ->  Sort (actual rows=1 loops=1)
+               Sort Key: _hyper_1_2_chunk.device_id, _hyper_1_2_chunk."time" DESC
+               Sort Method: top-N heapsort 
                ->  Seq Scan on _hyper_1_2_chunk (actual rows=2520 loops=1)
+         ->  Sort (actual rows=10 loops=1)
+               Sort Key: _hyper_1_3_chunk.device_id, _hyper_1_3_chunk."time" DESC
+               Sort Method: top-N heapsort 
                ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk (actual rows=2520 loops=1)
                      ->  Seq Scan on compress_hyper_5_16_chunk (actual rows=5 loops=1)
-(10 rows)
+(17 rows)
 
 --
 -- test ordered path
@@ -1314,32 +1302,32 @@ FROM :TEST_TABLE
 WHERE time > '2000-01-08'
 ORDER BY time,
     device_id;
-                                                                                                                                                                                                                                                                                                            QUERY PLAN                                                                                                                                                                                                                                                                                                            
-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
- Incremental Sort (actual rows=4195 loops=1)
+                                                                                                                                                                                                                                                                                                         QUERY PLAN                                                                                                                                                                                                                                                                                                         
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Custom Scan (ChunkAppend) on public.metrics (actual rows=4195 loops=1)
    Output: metrics."time", metrics.device_id, metrics.device_id_peer, metrics.v0, metrics.v1, metrics.v2, metrics.v3
-   Sort Key: metrics."time", metrics.device_id
-   Presorted Key: metrics."time"
-   Full-sort Groups: 120  Sort Method: quicksort 
-   ->  Custom Scan (ChunkAppend) on public.metrics (actual rows=4195 loops=1)
-         Output: metrics."time", metrics.device_id, metrics.device_id_peer, metrics.v0, metrics.v1, metrics.v2, metrics.v3
-         Order: metrics."time"
-         Startup Exclusion: false
-         Runtime Exclusion: false
-         ->  Index Scan Backward using _hyper_1_2_chunk_metrics_time_idx on _timescaledb_internal._hyper_1_2_chunk (actual rows=1675 loops=1)
+   Order: metrics."time", metrics.device_id
+   Startup Exclusion: false
+   Runtime Exclusion: false
+   ->  Sort (actual rows=1675 loops=1)
+         Output: _hyper_1_2_chunk."time", _hyper_1_2_chunk.device_id, _hyper_1_2_chunk.device_id_peer, _hyper_1_2_chunk.v0, _hyper_1_2_chunk.v1, _hyper_1_2_chunk.v2, _hyper_1_2_chunk.v3
+         Sort Key: _hyper_1_2_chunk."time", _hyper_1_2_chunk.device_id
+         Sort Method: quicksort 
+         ->  Seq Scan on _timescaledb_internal._hyper_1_2_chunk (actual rows=1675 loops=1)
                Output: _hyper_1_2_chunk."time", _hyper_1_2_chunk.device_id, _hyper_1_2_chunk.device_id_peer, _hyper_1_2_chunk.v0, _hyper_1_2_chunk.v1, _hyper_1_2_chunk.v2, _hyper_1_2_chunk.v3
-               Index Cond: (_hyper_1_2_chunk."time" > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
-         ->  Sort (actual rows=2520 loops=1)
+               Filter: (_hyper_1_2_chunk."time" > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
+               Rows Removed by Filter: 845
+   ->  Sort (actual rows=2520 loops=1)
+         Output: _hyper_1_3_chunk."time", _hyper_1_3_chunk.device_id, _hyper_1_3_chunk.device_id_peer, _hyper_1_3_chunk.v0, _hyper_1_3_chunk.v1, _hyper_1_3_chunk.v2, _hyper_1_3_chunk.v3
+         Sort Key: _hyper_1_3_chunk."time", _hyper_1_3_chunk.device_id
+         Sort Method: quicksort 
+         ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_3_chunk (actual rows=2520 loops=1)
                Output: _hyper_1_3_chunk."time", _hyper_1_3_chunk.device_id, _hyper_1_3_chunk.device_id_peer, _hyper_1_3_chunk.v0, _hyper_1_3_chunk.v1, _hyper_1_3_chunk.v2, _hyper_1_3_chunk.v3
-               Sort Key: _hyper_1_3_chunk."time"
-               Sort Method: quicksort 
-               ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_3_chunk (actual rows=2520 loops=1)
-                     Output: _hyper_1_3_chunk."time", _hyper_1_3_chunk.device_id, _hyper_1_3_chunk.device_id_peer, _hyper_1_3_chunk.v0, _hyper_1_3_chunk.v1, _hyper_1_3_chunk.v2, _hyper_1_3_chunk.v3
-                     Vectorized Filter: (_hyper_1_3_chunk."time" > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
-                     Bulk Decompression: true
-                     ->  Seq Scan on _timescaledb_internal.compress_hyper_5_16_chunk (actual rows=5 loops=1)
-                           Output: compress_hyper_5_16_chunk."time", compress_hyper_5_16_chunk.device_id, compress_hyper_5_16_chunk.device_id_peer, compress_hyper_5_16_chunk.v0, compress_hyper_5_16_chunk.v1, compress_hyper_5_16_chunk.v2, compress_hyper_5_16_chunk.v3, compress_hyper_5_16_chunk._ts_meta_count, compress_hyper_5_16_chunk._ts_meta_sequence_num, compress_hyper_5_16_chunk._ts_meta_min_3, compress_hyper_5_16_chunk._ts_meta_max_3, compress_hyper_5_16_chunk._ts_meta_min_1, compress_hyper_5_16_chunk._ts_meta_max_1, compress_hyper_5_16_chunk._ts_meta_min_2, compress_hyper_5_16_chunk._ts_meta_max_2
-                           Filter: (compress_hyper_5_16_chunk._ts_meta_max_3 > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
+               Vectorized Filter: (_hyper_1_3_chunk."time" > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
+               Bulk Decompression: true
+               ->  Seq Scan on _timescaledb_internal.compress_hyper_5_16_chunk (actual rows=5 loops=1)
+                     Output: compress_hyper_5_16_chunk."time", compress_hyper_5_16_chunk.device_id, compress_hyper_5_16_chunk.device_id_peer, compress_hyper_5_16_chunk.v0, compress_hyper_5_16_chunk.v1, compress_hyper_5_16_chunk.v2, compress_hyper_5_16_chunk.v3, compress_hyper_5_16_chunk._ts_meta_count, compress_hyper_5_16_chunk._ts_meta_sequence_num, compress_hyper_5_16_chunk._ts_meta_min_3, compress_hyper_5_16_chunk._ts_meta_max_3, compress_hyper_5_16_chunk._ts_meta_min_1, compress_hyper_5_16_chunk._ts_meta_max_1, compress_hyper_5_16_chunk._ts_meta_min_2, compress_hyper_5_16_chunk._ts_meta_max_2
+                     Filter: (compress_hyper_5_16_chunk._ts_meta_max_3 > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
 (24 rows)
 
 -- should produce ordered path
@@ -1615,23 +1603,23 @@ FROM :TEST_TABLE
 WHERE time > '2000-01-08'
 ORDER BY time,
     device_id;
-                                                       QUERY PLAN                                                       
-------------------------------------------------------------------------------------------------------------------------
- Incremental Sort (actual rows=4195 loops=1)
-   Sort Key: metrics."time", metrics.device_id
-   Presorted Key: metrics."time"
-   Full-sort Groups: 120  Sort Method: quicksort 
-   ->  Custom Scan (ChunkAppend) on metrics (actual rows=4195 loops=1)
-         Order: metrics."time"
-         ->  Index Scan Backward using _hyper_1_2_chunk_metrics_time_idx on _hyper_1_2_chunk (actual rows=1675 loops=1)
-               Index Cond: ("time" > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
-         ->  Sort (actual rows=2520 loops=1)
-               Sort Key: _hyper_1_3_chunk."time"
-               Sort Method: quicksort 
-               ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk (actual rows=2520 loops=1)
-                     Vectorized Filter: ("time" > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
-                     ->  Seq Scan on compress_hyper_5_16_chunk (actual rows=5 loops=1)
-                           Filter: (_ts_meta_max_3 > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
+                                               QUERY PLAN                                                
+---------------------------------------------------------------------------------------------------------
+ Custom Scan (ChunkAppend) on metrics (actual rows=4195 loops=1)
+   Order: metrics."time", metrics.device_id
+   ->  Sort (actual rows=1675 loops=1)
+         Sort Key: _hyper_1_2_chunk."time", _hyper_1_2_chunk.device_id
+         Sort Method: quicksort 
+         ->  Seq Scan on _hyper_1_2_chunk (actual rows=1675 loops=1)
+               Filter: ("time" > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
+               Rows Removed by Filter: 845
+   ->  Sort (actual rows=2520 loops=1)
+         Sort Key: _hyper_1_3_chunk."time", _hyper_1_3_chunk.device_id
+         Sort Method: quicksort 
+         ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk (actual rows=2520 loops=1)
+               Vectorized Filter: ("time" > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
+               ->  Seq Scan on compress_hyper_5_16_chunk (actual rows=5 loops=1)
+                     Filter: (_ts_meta_max_3 > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
 (15 rows)
 
 -- test runtime exclusion
@@ -1644,23 +1632,22 @@ ORDER BY time,
     device_id;
                                                        QUERY PLAN                                                       
 ------------------------------------------------------------------------------------------------------------------------
- Incremental Sort (actual rows=4195 loops=1)
-   Sort Key: metrics."time", metrics.device_id
-   Presorted Key: metrics."time"
-   Full-sort Groups: 120  Sort Method: quicksort 
-   ->  Custom Scan (ChunkAppend) on metrics (actual rows=4195 loops=1)
-         Order: metrics."time"
-         Chunks excluded during startup: 1
+ Custom Scan (ChunkAppend) on metrics (actual rows=4195 loops=1)
+   Order: metrics."time", metrics.device_id
+   Chunks excluded during startup: 1
+   ->  Sort (actual rows=1675 loops=1)
+         Sort Key: _hyper_1_2_chunk."time", _hyper_1_2_chunk.device_id
+         Sort Method: quicksort 
          ->  Index Scan Backward using _hyper_1_2_chunk_metrics_time_idx on _hyper_1_2_chunk (actual rows=1675 loops=1)
                Index Cond: ("time" > ('2000-01-08'::cstring)::timestamp with time zone)
-         ->  Sort (actual rows=2520 loops=1)
-               Sort Key: _hyper_1_3_chunk."time"
-               Sort Method: quicksort 
-               ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk (actual rows=2520 loops=1)
-                     Filter: ("time" > ('2000-01-08'::cstring)::timestamp with time zone)
-                     ->  Seq Scan on compress_hyper_5_16_chunk (actual rows=5 loops=1)
-                           Filter: (_ts_meta_max_3 > ('2000-01-08'::cstring)::timestamp with time zone)
-(16 rows)
+   ->  Sort (actual rows=2520 loops=1)
+         Sort Key: _hyper_1_3_chunk."time", _hyper_1_3_chunk.device_id
+         Sort Method: quicksort 
+         ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk (actual rows=2520 loops=1)
+               Filter: ("time" > ('2000-01-08'::cstring)::timestamp with time zone)
+               ->  Seq Scan on compress_hyper_5_16_chunk (actual rows=5 loops=1)
+                     Filter: (_ts_meta_max_3 > ('2000-01-08'::cstring)::timestamp with time zone)
+(15 rows)
 
 -- test aggregate
 :PREFIX
@@ -2216,34 +2203,28 @@ WHERE device_id_peer IN (
             (2));
                                                                                                                                                                                                                                                                                                          QUERY PLAN                                                                                                                                                                                                                                                                                                         
 ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
- Nested Loop (actual rows=0 loops=1)
+ Nested Loop Semi Join (actual rows=0 loops=1)
    Output: _hyper_1_1_chunk.device_id_peer
-   ->  Unique (actual rows=2 loops=1)
-         Output: "*VALUES*".column1
-         ->  Sort (actual rows=2 loops=1)
-               Output: "*VALUES*".column1
-               Sort Key: "*VALUES*".column1
-               Sort Method: quicksort 
-               ->  Values Scan on "*VALUES*" (actual rows=2 loops=1)
-                     Output: "*VALUES*".column1
-   ->  Append (actual rows=0 loops=2)
-         ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_1_chunk (actual rows=0 loops=2)
+   Join Filter: (_hyper_1_1_chunk.device_id_peer = "*VALUES*".column1)
+   Rows Removed by Join Filter: 13680
+   ->  Append (actual rows=6840 loops=1)
+         ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_1_chunk (actual rows=1800 loops=1)
                Output: _hyper_1_1_chunk.device_id_peer
                Bulk Decompression: false
-               ->  Index Scan using compress_hyper_5_15_chunk__compressed_hypertable_5_device_id_pe on _timescaledb_internal.compress_hyper_5_15_chunk (actual rows=0 loops=2)
+               ->  Seq Scan on _timescaledb_internal.compress_hyper_5_15_chunk (actual rows=5 loops=1)
                      Output: compress_hyper_5_15_chunk."time", compress_hyper_5_15_chunk.device_id, compress_hyper_5_15_chunk.device_id_peer, compress_hyper_5_15_chunk.v0, compress_hyper_5_15_chunk.v1, compress_hyper_5_15_chunk.v2, compress_hyper_5_15_chunk.v3, compress_hyper_5_15_chunk._ts_meta_count, compress_hyper_5_15_chunk._ts_meta_sequence_num, compress_hyper_5_15_chunk._ts_meta_min_3, compress_hyper_5_15_chunk._ts_meta_max_3, compress_hyper_5_15_chunk._ts_meta_min_1, compress_hyper_5_15_chunk._ts_meta_max_1, compress_hyper_5_15_chunk._ts_meta_min_2, compress_hyper_5_15_chunk._ts_meta_max_2
-                     Index Cond: (compress_hyper_5_15_chunk.device_id_peer = "*VALUES*".column1)
-         ->  Seq Scan on _timescaledb_internal._hyper_1_2_chunk (actual rows=0 loops=2)
+         ->  Seq Scan on _timescaledb_internal._hyper_1_2_chunk (actual rows=2520 loops=1)
                Output: _hyper_1_2_chunk.device_id_peer
-               Filter: ("*VALUES*".column1 = _hyper_1_2_chunk.device_id_peer)
-               Rows Removed by Filter: 2520
-         ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_3_chunk (actual rows=0 loops=2)
+         ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_3_chunk (actual rows=2520 loops=1)
                Output: _hyper_1_3_chunk.device_id_peer
                Bulk Decompression: false
-               ->  Index Scan using compress_hyper_5_16_chunk__compressed_hypertable_5_device_id_pe on _timescaledb_internal.compress_hyper_5_16_chunk (actual rows=0 loops=2)
+               ->  Seq Scan on _timescaledb_internal.compress_hyper_5_16_chunk (actual rows=5 loops=1)
                      Output: compress_hyper_5_16_chunk."time", compress_hyper_5_16_chunk.device_id, compress_hyper_5_16_chunk.device_id_peer, compress_hyper_5_16_chunk.v0, compress_hyper_5_16_chunk.v1, compress_hyper_5_16_chunk.v2, compress_hyper_5_16_chunk.v3, compress_hyper_5_16_chunk._ts_meta_count, compress_hyper_5_16_chunk._ts_meta_sequence_num, compress_hyper_5_16_chunk._ts_meta_min_3, compress_hyper_5_16_chunk._ts_meta_max_3, compress_hyper_5_16_chunk._ts_meta_min_1, compress_hyper_5_16_chunk._ts_meta_max_1, compress_hyper_5_16_chunk._ts_meta_min_2, compress_hyper_5_16_chunk._ts_meta_max_2
-                     Index Cond: (compress_hyper_5_16_chunk.device_id_peer = "*VALUES*".column1)
-(27 rows)
+   ->  Materialize (actual rows=2 loops=6840)
+         Output: "*VALUES*".column1
+         ->  Values Scan on "*VALUES*" (actual rows=2 loops=1)
+               Output: "*VALUES*".column1
+(21 rows)
 
 RESET enable_hashjoin;
 :PREFIX_VERBOSE
@@ -2283,34 +2264,28 @@ WHERE device_id IN (
             (2));
                                                                                                                                                                                                                                                                                                          QUERY PLAN                                                                                                                                                                                                                                                                                                         
 ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
- Nested Loop (actual rows=2736 loops=1)
+ Hash Semi Join (actual rows=2736 loops=1)
    Output: _hyper_1_1_chunk.device_id_peer
-   ->  Unique (actual rows=2 loops=1)
-         Output: "*VALUES*".column1
-         ->  Sort (actual rows=2 loops=1)
-               Output: "*VALUES*".column1
-               Sort Key: "*VALUES*".column1
-               Sort Method: quicksort 
-               ->  Values Scan on "*VALUES*" (actual rows=2 loops=1)
-                     Output: "*VALUES*".column1
-   ->  Append (actual rows=1368 loops=2)
-         ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_1_chunk (actual rows=360 loops=2)
+   Hash Cond: (_hyper_1_1_chunk.device_id = "*VALUES*".column1)
+   ->  Append (actual rows=6840 loops=1)
+         ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_1_chunk (actual rows=1800 loops=1)
                Output: _hyper_1_1_chunk.device_id_peer, _hyper_1_1_chunk.device_id
                Bulk Decompression: false
-               ->  Index Scan using compress_hyper_5_15_chunk_c_index_2 on _timescaledb_internal.compress_hyper_5_15_chunk (actual rows=1 loops=2)
+               ->  Seq Scan on _timescaledb_internal.compress_hyper_5_15_chunk (actual rows=5 loops=1)
                      Output: compress_hyper_5_15_chunk."time", compress_hyper_5_15_chunk.device_id, compress_hyper_5_15_chunk.device_id_peer, compress_hyper_5_15_chunk.v0, compress_hyper_5_15_chunk.v1, compress_hyper_5_15_chunk.v2, compress_hyper_5_15_chunk.v3, compress_hyper_5_15_chunk._ts_meta_count, compress_hyper_5_15_chunk._ts_meta_sequence_num, compress_hyper_5_15_chunk._ts_meta_min_3, compress_hyper_5_15_chunk._ts_meta_max_3, compress_hyper_5_15_chunk._ts_meta_min_1, compress_hyper_5_15_chunk._ts_meta_max_1, compress_hyper_5_15_chunk._ts_meta_min_2, compress_hyper_5_15_chunk._ts_meta_max_2
-                     Index Cond: (compress_hyper_5_15_chunk.device_id = "*VALUES*".column1)
-         ->  Seq Scan on _timescaledb_internal._hyper_1_2_chunk (actual rows=504 loops=2)
+         ->  Seq Scan on _timescaledb_internal._hyper_1_2_chunk (actual rows=2520 loops=1)
                Output: _hyper_1_2_chunk.device_id_peer, _hyper_1_2_chunk.device_id
-               Filter: ("*VALUES*".column1 = _hyper_1_2_chunk.device_id)
-               Rows Removed by Filter: 2016
-         ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_3_chunk (actual rows=504 loops=2)
+         ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_3_chunk (actual rows=2520 loops=1)
                Output: _hyper_1_3_chunk.device_id_peer, _hyper_1_3_chunk.device_id
                Bulk Decompression: false
-               ->  Index Scan using compress_hyper_5_16_chunk_c_index_2 on _timescaledb_internal.compress_hyper_5_16_chunk (actual rows=1 loops=2)
+               ->  Seq Scan on _timescaledb_internal.compress_hyper_5_16_chunk (actual rows=5 loops=1)
                      Output: compress_hyper_5_16_chunk."time", compress_hyper_5_16_chunk.device_id, compress_hyper_5_16_chunk.device_id_peer, compress_hyper_5_16_chunk.v0, compress_hyper_5_16_chunk.v1, compress_hyper_5_16_chunk.v2, compress_hyper_5_16_chunk.v3, compress_hyper_5_16_chunk._ts_meta_count, compress_hyper_5_16_chunk._ts_meta_sequence_num, compress_hyper_5_16_chunk._ts_meta_min_3, compress_hyper_5_16_chunk._ts_meta_max_3, compress_hyper_5_16_chunk._ts_meta_min_1, compress_hyper_5_16_chunk._ts_meta_max_1, compress_hyper_5_16_chunk._ts_meta_min_2, compress_hyper_5_16_chunk._ts_meta_max_2
-                     Index Cond: (compress_hyper_5_16_chunk.device_id = "*VALUES*".column1)
-(27 rows)
+   ->  Hash (actual rows=2 loops=1)
+         Output: "*VALUES*".column1
+         Buckets: 1024  Batches: 1 
+         ->  Values Scan on "*VALUES*" (actual rows=2 loops=1)
+               Output: "*VALUES*".column1
+(21 rows)
 
 SET seq_page_cost = 100;
 -- loop/row counts of this query is different on windows so we run it without analyze
@@ -2379,34 +2354,28 @@ WHERE device_id IN (
             (2));
                                                                                                                                                                                                                                                                                                          QUERY PLAN                                                                                                                                                                                                                                                                                                         
 ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
- Nested Loop (actual rows=2736 loops=1)
+ Hash Semi Join (actual rows=2736 loops=1)
    Output: _hyper_1_1_chunk.device_id_peer
-   ->  Unique (actual rows=2 loops=1)
-         Output: "*VALUES*".column1
-         ->  Sort (actual rows=2 loops=1)
-               Output: "*VALUES*".column1
-               Sort Key: "*VALUES*".column1
-               Sort Method: quicksort 
-               ->  Values Scan on "*VALUES*" (actual rows=2 loops=1)
-                     Output: "*VALUES*".column1
-   ->  Append (actual rows=1368 loops=2)
-         ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_1_chunk (actual rows=360 loops=2)
+   Hash Cond: (_hyper_1_1_chunk.device_id = "*VALUES*".column1)
+   ->  Append (actual rows=6840 loops=1)
+         ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_1_chunk (actual rows=1800 loops=1)
                Output: _hyper_1_1_chunk.device_id_peer, _hyper_1_1_chunk.device_id
                Bulk Decompression: false
-               ->  Index Scan using compress_hyper_5_15_chunk_c_index_2 on _timescaledb_internal.compress_hyper_5_15_chunk (actual rows=1 loops=2)
+               ->  Seq Scan on _timescaledb_internal.compress_hyper_5_15_chunk (actual rows=5 loops=1)
                      Output: compress_hyper_5_15_chunk."time", compress_hyper_5_15_chunk.device_id, compress_hyper_5_15_chunk.device_id_peer, compress_hyper_5_15_chunk.v0, compress_hyper_5_15_chunk.v1, compress_hyper_5_15_chunk.v2, compress_hyper_5_15_chunk.v3, compress_hyper_5_15_chunk._ts_meta_count, compress_hyper_5_15_chunk._ts_meta_sequence_num, compress_hyper_5_15_chunk._ts_meta_min_3, compress_hyper_5_15_chunk._ts_meta_max_3, compress_hyper_5_15_chunk._ts_meta_min_1, compress_hyper_5_15_chunk._ts_meta_max_1, compress_hyper_5_15_chunk._ts_meta_min_2, compress_hyper_5_15_chunk._ts_meta_max_2
-                     Index Cond: (compress_hyper_5_15_chunk.device_id = "*VALUES*".column1)
-         ->  Seq Scan on _timescaledb_internal._hyper_1_2_chunk (actual rows=504 loops=2)
+         ->  Seq Scan on _timescaledb_internal._hyper_1_2_chunk (actual rows=2520 loops=1)
                Output: _hyper_1_2_chunk.device_id_peer, _hyper_1_2_chunk.device_id
-               Filter: ("*VALUES*".column1 = _hyper_1_2_chunk.device_id)
-               Rows Removed by Filter: 2016
-         ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_3_chunk (actual rows=504 loops=2)
+         ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_3_chunk (actual rows=2520 loops=1)
                Output: _hyper_1_3_chunk.device_id_peer, _hyper_1_3_chunk.device_id
                Bulk Decompression: false
-               ->  Index Scan using compress_hyper_5_16_chunk_c_index_2 on _timescaledb_internal.compress_hyper_5_16_chunk (actual rows=1 loops=2)
+               ->  Seq Scan on _timescaledb_internal.compress_hyper_5_16_chunk (actual rows=5 loops=1)
                      Output: compress_hyper_5_16_chunk."time", compress_hyper_5_16_chunk.device_id, compress_hyper_5_16_chunk.device_id_peer, compress_hyper_5_16_chunk.v0, compress_hyper_5_16_chunk.v1, compress_hyper_5_16_chunk.v2, compress_hyper_5_16_chunk.v3, compress_hyper_5_16_chunk._ts_meta_count, compress_hyper_5_16_chunk._ts_meta_sequence_num, compress_hyper_5_16_chunk._ts_meta_min_3, compress_hyper_5_16_chunk._ts_meta_max_3, compress_hyper_5_16_chunk._ts_meta_min_1, compress_hyper_5_16_chunk._ts_meta_max_1, compress_hyper_5_16_chunk._ts_meta_min_2, compress_hyper_5_16_chunk._ts_meta_max_2
-                     Index Cond: (compress_hyper_5_16_chunk.device_id = "*VALUES*".column1)
-(27 rows)
+   ->  Hash (actual rows=2 loops=1)
+         Output: "*VALUES*".column1
+         Buckets: 1024  Batches: 1 
+         ->  Values Scan on "*VALUES*" (actual rows=2 loops=1)
+               Output: "*VALUES*".column1
+(21 rows)
 
 -- test view
 CREATE OR REPLACE VIEW compressed_view AS
@@ -2452,43 +2421,41 @@ FROM :TEST_TABLE m1
     ORDER BY m1.time,
         m1.device_id
     LIMIT 10;
-                                                             QUERY PLAN                                                              
--------------------------------------------------------------------------------------------------------------------------------------
+                                                          QUERY PLAN                                                           
+-------------------------------------------------------------------------------------------------------------------------------
  Limit (actual rows=10 loops=1)
-   ->  Incremental Sort (actual rows=10 loops=1)
-         Sort Key: m1."time", m1.device_id
-         Presorted Key: m1."time"
-         Full-sort Groups: 1  Sort Method: quicksort 
-         ->  Merge Join (actual rows=11 loops=1)
-               Merge Cond: (m1."time" = m2."time")
-               Join Filter: (m1.device_id = m2.device_id)
-               Rows Removed by Join Filter: 40
-               ->  Custom Scan (ChunkAppend) on metrics m1 (actual rows=11 loops=1)
-                     Order: m1."time"
-                     ->  Sort (actual rows=11 loops=1)
-                           Sort Key: m1_1."time"
+   ->  Merge Join (actual rows=10 loops=1)
+         Merge Cond: ((m1."time" = m2."time") AND (m1.device_id = m2.device_id))
+         ->  Custom Scan (ChunkAppend) on metrics m1 (actual rows=10 loops=1)
+               Order: m1."time", m1.device_id
+               ->  Sort (actual rows=10 loops=1)
+                     Sort Key: m1_1."time", m1_1.device_id
+                     Sort Method: quicksort 
+                     ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk m1_1 (actual rows=1800 loops=1)
+                           ->  Seq Scan on compress_hyper_5_15_chunk (actual rows=5 loops=1)
+               ->  Sort (never executed)
+                     Sort Key: m1_2."time", m1_2.device_id
+                     ->  Seq Scan on _hyper_1_2_chunk m1_2 (never executed)
+               ->  Sort (never executed)
+                     Sort Key: m1_3."time", m1_3.device_id
+                     ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk m1_3 (never executed)
+                           ->  Seq Scan on compress_hyper_5_16_chunk (never executed)
+         ->  Materialize (actual rows=10 loops=1)
+               ->  Custom Scan (ChunkAppend) on metrics m2 (actual rows=10 loops=1)
+                     Order: m2."time", m2.device_id
+                     ->  Sort (actual rows=10 loops=1)
+                           Sort Key: m2_1."time", m2_1.device_id
                            Sort Method: quicksort 
-                           ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk m1_1 (actual rows=1800 loops=1)
-                                 ->  Seq Scan on compress_hyper_5_15_chunk (actual rows=5 loops=1)
-                     ->  Index Scan Backward using _hyper_1_2_chunk_metrics_time_idx on _hyper_1_2_chunk m1_2 (never executed)
+                           ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk m2_1 (actual rows=1800 loops=1)
+                                 ->  Seq Scan on compress_hyper_5_15_chunk compress_hyper_5_15_chunk_1 (actual rows=5 loops=1)
                      ->  Sort (never executed)
-                           Sort Key: m1_3."time"
-                           ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk m1_3 (never executed)
-                                 ->  Seq Scan on compress_hyper_5_16_chunk (never executed)
-               ->  Materialize (actual rows=51 loops=1)
-                     ->  Custom Scan (ChunkAppend) on metrics m2 (actual rows=11 loops=1)
-                           Order: m2."time"
-                           ->  Sort (actual rows=11 loops=1)
-                                 Sort Key: m2_1."time"
-                                 Sort Method: quicksort 
-                                 ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk m2_1 (actual rows=1800 loops=1)
-                                       ->  Seq Scan on compress_hyper_5_15_chunk compress_hyper_5_15_chunk_1 (actual rows=5 loops=1)
-                           ->  Index Scan Backward using _hyper_1_2_chunk_metrics_time_idx on _hyper_1_2_chunk m2_2 (never executed)
-                           ->  Sort (never executed)
-                                 Sort Key: m2_3."time"
-                                 ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk m2_3 (never executed)
-                                       ->  Seq Scan on compress_hyper_5_16_chunk compress_hyper_5_16_chunk_1 (never executed)
-(34 rows)
+                           Sort Key: m2_2."time", m2_2.device_id
+                           ->  Seq Scan on _hyper_1_2_chunk m2_2 (never executed)
+                     ->  Sort (never executed)
+                           Sort Key: m2_3."time", m2_3.device_id
+                           ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk m2_3 (never executed)
+                                 ->  Seq Scan on compress_hyper_5_16_chunk compress_hyper_5_16_chunk_1 (never executed)
+(32 rows)
 
 :PREFIX
 SELECT *
@@ -2503,42 +2470,28 @@ FROM :TEST_TABLE m1
                                                                  QUERY PLAN                                                                 
 --------------------------------------------------------------------------------------------------------------------------------------------
  Limit (actual rows=10 loops=1)
-   ->  Incremental Sort (actual rows=10 loops=1)
-         Sort Key: m1."time", m1.device_id
-         Presorted Key: m1."time"
-         Full-sort Groups: 1  Sort Method: quicksort 
-         ->  Merge Join (actual rows=11 loops=1)
-               Merge Cond: (m1."time" = m3_1."time")
-               ->  Merge Join (actual rows=11 loops=1)
-                     Merge Cond: (m1."time" = m2."time")
-                     Join Filter: (m1.device_id = m2.device_id)
-                     Rows Removed by Join Filter: 40
-                     ->  Custom Scan (ChunkAppend) on metrics m1 (actual rows=11 loops=1)
-                           Order: m1."time"
-                           ->  Sort (actual rows=11 loops=1)
-                                 Sort Key: m1_1."time"
-                                 Sort Method: quicksort 
-                                 ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk m1_1 (actual rows=1800 loops=1)
-                                       ->  Seq Scan on compress_hyper_5_15_chunk (actual rows=5 loops=1)
-                           ->  Index Scan Backward using _hyper_1_2_chunk_metrics_time_idx on _hyper_1_2_chunk m1_2 (never executed)
-                           ->  Sort (never executed)
-                                 Sort Key: m1_3."time"
-                                 ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk m1_3 (never executed)
-                                       ->  Seq Scan on compress_hyper_5_16_chunk (never executed)
-                     ->  Materialize (actual rows=51 loops=1)
-                           ->  Custom Scan (ChunkAppend) on metrics m2 (actual rows=11 loops=1)
-                                 Order: m2."time"
-                                 ->  Sort (actual rows=11 loops=1)
-                                       Sort Key: m2_1."time"
-                                       Sort Method: quicksort 
-                                       ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk m2_1 (actual rows=1800 loops=1)
-                                             ->  Seq Scan on compress_hyper_5_15_chunk compress_hyper_5_15_chunk_1 (actual rows=5 loops=1)
-                                 ->  Index Scan Backward using _hyper_1_2_chunk_metrics_time_idx on _hyper_1_2_chunk m2_2 (never executed)
-                                 ->  Sort (never executed)
-                                       Sort Key: m2_3."time"
-                                       ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk m2_3 (never executed)
-                                             ->  Seq Scan on compress_hyper_5_16_chunk compress_hyper_5_16_chunk_1 (never executed)
-               ->  Materialize (actual rows=11 loops=1)
+   ->  Merge Join (actual rows=10 loops=1)
+         Merge Cond: (m2."time" = m1_1."time")
+         Join Filter: (m2.device_id = m1_1.device_id)
+         Rows Removed by Join Filter: 40
+         ->  Custom Scan (ChunkAppend) on metrics m2 (actual rows=10 loops=1)
+               Order: m2."time", m2.device_id
+               ->  Sort (actual rows=10 loops=1)
+                     Sort Key: m2_1."time", m2_1.device_id
+                     Sort Method: quicksort 
+                     ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk m2_1 (actual rows=1800 loops=1)
+                           ->  Seq Scan on compress_hyper_5_15_chunk compress_hyper_5_15_chunk_1 (actual rows=5 loops=1)
+               ->  Sort (never executed)
+                     Sort Key: m2_2."time", m2_2.device_id
+                     ->  Seq Scan on _hyper_1_2_chunk m2_2 (never executed)
+               ->  Sort (never executed)
+                     Sort Key: m2_3."time", m2_3.device_id
+                     ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk m2_3 (never executed)
+                           ->  Seq Scan on compress_hyper_5_16_chunk compress_hyper_5_16_chunk_1 (never executed)
+         ->  Materialize (actual rows=50 loops=1)
+               ->  Nested Loop (actual rows=11 loops=1)
+                     Join Filter: (m1_1."time" = m3_1."time")
+                     Rows Removed by Join Filter: 13672
                      ->  Merge Append (actual rows=3 loops=1)
                            Sort Key: m3_1."time"
                            ->  Sort (actual rows=3 loops=1)
@@ -2558,7 +2511,14 @@ FROM :TEST_TABLE m1
                                        ->  Seq Scan on compress_hyper_5_16_chunk compress_hyper_5_16_chunk_2 (actual rows=1 loops=1)
                                              Filter: (device_id = 3)
                                              Rows Removed by Filter: 4
-(56 rows)
+                     ->  Materialize (actual rows=4561 loops=3)
+                           ->  Append (actual rows=6840 loops=1)
+                                 ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk m1_1 (actual rows=1800 loops=1)
+                                       ->  Seq Scan on compress_hyper_5_15_chunk (actual rows=5 loops=1)
+                                 ->  Seq Scan on _hyper_1_2_chunk m1_2 (actual rows=2520 loops=1)
+                                 ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk m1_3 (actual rows=2520 loops=1)
+                                       ->  Seq Scan on compress_hyper_5_16_chunk (actual rows=5 loops=1)
+(49 rows)
 
 :PREFIX
 SELECT *
@@ -2671,43 +2631,41 @@ FROM :TEST_TABLE m1
 ORDER BY m1.time,
     m1.device_id
 LIMIT 10;
-                                                             QUERY PLAN                                                              
--------------------------------------------------------------------------------------------------------------------------------------
+                                                          QUERY PLAN                                                           
+-------------------------------------------------------------------------------------------------------------------------------
  Limit (actual rows=10 loops=1)
-   ->  Incremental Sort (actual rows=10 loops=1)
-         Sort Key: m1."time", m1.device_id
-         Presorted Key: m1."time"
-         Full-sort Groups: 1  Sort Method: quicksort 
-         ->  Merge Left Join (actual rows=11 loops=1)
-               Merge Cond: (m1."time" = m2."time")
-               Join Filter: (m1.device_id = m2.device_id)
-               Rows Removed by Join Filter: 40
-               ->  Custom Scan (ChunkAppend) on metrics m1 (actual rows=11 loops=1)
-                     Order: m1."time"
+   ->  Merge Left Join (actual rows=10 loops=1)
+         Merge Cond: (m1."time" = m2."time")
+         Join Filter: (m1.device_id = m2.device_id)
+         Rows Removed by Join Filter: 37
+         ->  Custom Scan (ChunkAppend) on metrics m1 (actual rows=10 loops=1)
+               Order: m1."time", m1.device_id
+               ->  Sort (actual rows=10 loops=1)
+                     Sort Key: m1_1."time", m1_1.device_id
+                     Sort Method: quicksort 
+                     ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk m1_1 (actual rows=1800 loops=1)
+                           ->  Seq Scan on compress_hyper_5_15_chunk (actual rows=5 loops=1)
+               ->  Sort (never executed)
+                     Sort Key: m1_2."time", m1_2.device_id
+                     ->  Seq Scan on _hyper_1_2_chunk m1_2 (never executed)
+               ->  Sort (never executed)
+                     Sort Key: m1_3."time", m1_3.device_id
+                     ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk m1_3 (never executed)
+                           ->  Seq Scan on compress_hyper_5_16_chunk (never executed)
+         ->  Materialize (actual rows=47 loops=1)
+               ->  Custom Scan (ChunkAppend) on metrics m2 (actual rows=11 loops=1)
+                     Order: m2."time"
                      ->  Sort (actual rows=11 loops=1)
-                           Sort Key: m1_1."time"
+                           Sort Key: m2_1."time"
                            Sort Method: quicksort 
-                           ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk m1_1 (actual rows=1800 loops=1)
-                                 ->  Seq Scan on compress_hyper_5_15_chunk (actual rows=5 loops=1)
-                     ->  Index Scan Backward using _hyper_1_2_chunk_metrics_time_idx on _hyper_1_2_chunk m1_2 (never executed)
+                           ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk m2_1 (actual rows=1800 loops=1)
+                                 ->  Seq Scan on compress_hyper_5_15_chunk compress_hyper_5_15_chunk_1 (actual rows=5 loops=1)
+                     ->  Index Scan Backward using _hyper_1_2_chunk_metrics_time_idx on _hyper_1_2_chunk m2_2 (never executed)
                      ->  Sort (never executed)
-                           Sort Key: m1_3."time"
-                           ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk m1_3 (never executed)
-                                 ->  Seq Scan on compress_hyper_5_16_chunk (never executed)
-               ->  Materialize (actual rows=51 loops=1)
-                     ->  Custom Scan (ChunkAppend) on metrics m2 (actual rows=11 loops=1)
-                           Order: m2."time"
-                           ->  Sort (actual rows=11 loops=1)
-                                 Sort Key: m2_1."time"
-                                 Sort Method: quicksort 
-                                 ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk m2_1 (actual rows=1800 loops=1)
-                                       ->  Seq Scan on compress_hyper_5_15_chunk compress_hyper_5_15_chunk_1 (actual rows=5 loops=1)
-                           ->  Index Scan Backward using _hyper_1_2_chunk_metrics_time_idx on _hyper_1_2_chunk m2_2 (never executed)
-                           ->  Sort (never executed)
-                                 Sort Key: m2_3."time"
-                                 ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk m2_3 (never executed)
-                                       ->  Seq Scan on compress_hyper_5_16_chunk compress_hyper_5_16_chunk_1 (never executed)
-(34 rows)
+                           Sort Key: m2_3."time"
+                           ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk m2_3 (never executed)
+                                 ->  Seq Scan on compress_hyper_5_16_chunk compress_hyper_5_16_chunk_1 (never executed)
+(32 rows)
 
 :PREFIX
 SELECT *
@@ -2725,28 +2683,30 @@ LIMIT 100;
  Limit (actual rows=100 loops=1)
    ->  Incremental Sort (actual rows=100 loops=1)
          Sort Key: m1."time", m1.device_id, m2."time", m2.device_id
-         Presorted Key: m1."time"
-         Full-sort Groups: 3  Sort Method: quicksort 
+         Presorted Key: m1."time", m1.device_id
+         Full-sort Groups: 4  Sort Method: quicksort 
          ->  Merge Left Join (actual rows=101 loops=1)
                Merge Cond: (m1."time" = m2."time")
                Join Filter: (m1.device_id = 1)
-               Rows Removed by Join Filter: 81
+               Rows Removed by Join Filter: 80
                ->  Custom Scan (ChunkAppend) on metrics m1 (actual rows=101 loops=1)
-                     Order: m1."time"
+                     Order: m1."time", m1.device_id
                      ->  Sort (actual rows=101 loops=1)
-                           Sort Key: m1_1."time"
+                           Sort Key: m1_1."time", m1_1.device_id
                            Sort Method: quicksort 
                            ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk m1_1 (actual rows=1800 loops=1)
                                  ->  Seq Scan on compress_hyper_5_15_chunk (actual rows=5 loops=1)
-                     ->  Index Scan Backward using _hyper_1_2_chunk_metrics_time_idx on _hyper_1_2_chunk m1_2 (never executed)
                      ->  Sort (never executed)
-                           Sort Key: m1_3."time"
+                           Sort Key: m1_2."time", m1_2.device_id
+                           ->  Seq Scan on _hyper_1_2_chunk m1_2 (never executed)
+                     ->  Sort (never executed)
+                           Sort Key: m1_3."time", m1_3.device_id
                            ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk m1_3 (never executed)
                                  ->  Seq Scan on compress_hyper_5_16_chunk (never executed)
-               ->  Materialize (actual rows=102 loops=1)
-                     ->  Custom Scan (ChunkAppend) on metrics m2 (actual rows=22 loops=1)
+               ->  Materialize (actual rows=101 loops=1)
+                     ->  Custom Scan (ChunkAppend) on metrics m2 (actual rows=21 loops=1)
                            Order: m2."time"
-                           ->  Sort (actual rows=22 loops=1)
+                           ->  Sort (actual rows=21 loops=1)
                                  Sort Key: m2_1."time"
                                  Sort Method: quicksort 
                                  ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk m2_1 (actual rows=360 loops=1)
@@ -2760,7 +2720,7 @@ LIMIT 100;
                                  ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk m2_3 (never executed)
                                        ->  Seq Scan on compress_hyper_5_16_chunk compress_hyper_5_16_chunk_1 (never executed)
                                              Filter: (device_id = 2)
-(38 rows)
+(40 rows)
 
 :PREFIX
 SELECT *
@@ -2773,33 +2733,35 @@ ORDER BY m1.time,
     m2.time,
     m2.device_id
 LIMIT 100;
-                                                                    QUERY PLAN                                                                     
----------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                         QUERY PLAN                                                                          
+-------------------------------------------------------------------------------------------------------------------------------------------------------------
  Limit (actual rows=100 loops=1)
    ->  Incremental Sort (actual rows=100 loops=1)
          Sort Key: m1."time", m1.device_id, m2."time", m2.device_id
-         Presorted Key: m1."time"
-         Full-sort Groups: 3  Sort Method: quicksort 
+         Presorted Key: m1."time", m1.device_id
+         Full-sort Groups: 4  Sort Method: quicksort 
          ->  Merge Left Join (actual rows=101 loops=1)
                Merge Cond: (m1."time" = m2."time")
                Join Filter: (m1.device_id = 1)
-               Rows Removed by Join Filter: 81
+               Rows Removed by Join Filter: 80
                ->  Custom Scan (ChunkAppend) on metrics m1 (actual rows=101 loops=1)
-                     Order: m1."time"
+                     Order: m1."time", m1.device_id
                      ->  Sort (actual rows=101 loops=1)
-                           Sort Key: m1_1."time"
+                           Sort Key: m1_1."time", m1_1.device_id
                            Sort Method: quicksort 
                            ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk m1_1 (actual rows=1800 loops=1)
                                  ->  Seq Scan on compress_hyper_5_15_chunk (actual rows=5 loops=1)
-                     ->  Index Scan Backward using _hyper_1_2_chunk_metrics_time_idx on _hyper_1_2_chunk m1_2 (never executed)
                      ->  Sort (never executed)
-                           Sort Key: m1_3."time"
+                           Sort Key: m1_2."time", m1_2.device_id
+                           ->  Seq Scan on _hyper_1_2_chunk m1_2 (never executed)
+                     ->  Sort (never executed)
+                           Sort Key: m1_3."time", m1_3.device_id
                            ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk m1_3 (never executed)
                                  ->  Seq Scan on compress_hyper_5_16_chunk (never executed)
-               ->  Materialize (actual rows=102 loops=1)
-                     ->  Custom Scan (ChunkAppend) on metrics_space m2 (actual rows=22 loops=1)
+               ->  Materialize (actual rows=101 loops=1)
+                     ->  Custom Scan (ChunkAppend) on metrics_space m2 (actual rows=21 loops=1)
                            Order: m2."time"
-                           ->  Merge Append (actual rows=22 loops=1)
+                           ->  Merge Append (actual rows=21 loops=1)
                                  Sort Key: m2_1."time"
                                  ->  Sort (actual rows=0 loops=1)
                                        Sort Key: m2_1."time"
@@ -2811,7 +2773,7 @@ LIMIT 100;
                                                    ->  Seq Scan on compress_hyper_6_17_chunk (actual rows=0 loops=1)
                                                          Filter: (device_id = 2)
                                                          Rows Removed by Filter: 1
-                                 ->  Sort (actual rows=22 loops=1)
+                                 ->  Sort (actual rows=21 loops=1)
                                        Sort Key: m2_2."time"
                                        Sort Method: quicksort 
                                        ->  Sort (actual rows=360 loops=1)
@@ -2833,12 +2795,12 @@ LIMIT 100;
                                                          Rows Removed by Filter: 1
                            ->  Merge Append (never executed)
                                  Sort Key: m2_4."time"
-                                 ->  Index Scan Backward using _hyper_2_7_chunk_metrics_space_time_idx on _hyper_2_7_chunk m2_4 (never executed)
-                                       Filter: (device_id = 2)
-                                 ->  Index Scan Backward using _hyper_2_8_chunk_metrics_space_time_idx on _hyper_2_8_chunk m2_5 (never executed)
-                                       Filter: (device_id = 2)
-                                 ->  Index Scan Backward using _hyper_2_9_chunk_metrics_space_time_idx on _hyper_2_9_chunk m2_6 (never executed)
-                                       Filter: (device_id = 2)
+                                 ->  Index Scan Backward using _hyper_2_7_chunk_metrics_space_device_id_time_idx on _hyper_2_7_chunk m2_4 (never executed)
+                                       Index Cond: (device_id = 2)
+                                 ->  Index Scan Backward using _hyper_2_8_chunk_metrics_space_device_id_time_idx on _hyper_2_8_chunk m2_5 (never executed)
+                                       Index Cond: (device_id = 2)
+                                 ->  Index Scan Backward using _hyper_2_9_chunk_metrics_space_device_id_time_idx on _hyper_2_9_chunk m2_6 (never executed)
+                                       Index Cond: (device_id = 2)
                            ->  Merge Append (never executed)
                                  Sort Key: m2_7."time"
                                  ->  Sort (never executed)
@@ -2855,9 +2817,9 @@ LIMIT 100;
                                              ->  Custom Scan (DecompressChunk) on _hyper_2_11_chunk m2_8 (never executed)
                                                    ->  Seq Scan on compress_hyper_6_21_chunk (never executed)
                                                          Filter: (device_id = 2)
-                                 ->  Index Scan Backward using _hyper_2_12_chunk_metrics_space_time_idx on _hyper_2_12_chunk m2_9 (never executed)
-                                       Filter: (device_id = 2)
-(82 rows)
+                                 ->  Index Scan Backward using _hyper_2_12_chunk_metrics_space_device_id_time_idx on _hyper_2_12_chunk m2_9 (never executed)
+                                       Index Cond: (device_id = 2)
+(84 rows)
 
 -- test implicit self-join
 :PREFIX
@@ -2875,23 +2837,25 @@ LIMIT 20;
  Limit (actual rows=20 loops=1)
    ->  Incremental Sort (actual rows=20 loops=1)
          Sort Key: m1."time", m1.device_id, m2.device_id
-         Presorted Key: m1."time"
+         Presorted Key: m1."time", m1.device_id
          Full-sort Groups: 1  Sort Method: quicksort 
-         ->  Merge Join (actual rows=26 loops=1)
+         ->  Merge Join (actual rows=21 loops=1)
                Merge Cond: (m1."time" = m2."time")
-               ->  Custom Scan (ChunkAppend) on metrics m1 (actual rows=6 loops=1)
-                     Order: m1."time"
-                     ->  Sort (actual rows=6 loops=1)
-                           Sort Key: m1_1."time"
+               ->  Custom Scan (ChunkAppend) on metrics m1 (actual rows=5 loops=1)
+                     Order: m1."time", m1.device_id
+                     ->  Sort (actual rows=5 loops=1)
+                           Sort Key: m1_1."time", m1_1.device_id
                            Sort Method: quicksort 
                            ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk m1_1 (actual rows=1800 loops=1)
                                  ->  Seq Scan on compress_hyper_5_15_chunk (actual rows=5 loops=1)
-                     ->  Index Scan Backward using _hyper_1_2_chunk_metrics_time_idx on _hyper_1_2_chunk m1_2 (never executed)
                      ->  Sort (never executed)
-                           Sort Key: m1_3."time"
+                           Sort Key: m1_2."time", m1_2.device_id
+                           ->  Seq Scan on _hyper_1_2_chunk m1_2 (never executed)
+                     ->  Sort (never executed)
+                           Sort Key: m1_3."time", m1_3.device_id
                            ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk m1_3 (never executed)
                                  ->  Seq Scan on compress_hyper_5_16_chunk (never executed)
-               ->  Materialize (actual rows=26 loops=1)
+               ->  Materialize (actual rows=21 loops=1)
                      ->  Custom Scan (ChunkAppend) on metrics m2 (actual rows=6 loops=1)
                            Order: m2."time"
                            ->  Sort (actual rows=6 loops=1)
@@ -2904,7 +2868,7 @@ LIMIT 20;
                                  Sort Key: m2_3."time"
                                  ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk m2_3 (never executed)
                                        ->  Seq Scan on compress_hyper_5_16_chunk compress_hyper_5_16_chunk_1 (never executed)
-(32 rows)
+(34 rows)
 
 -- test self-join with sub-query
 :PREFIX
@@ -2924,23 +2888,25 @@ LIMIT 10;
  Limit (actual rows=10 loops=1)
    ->  Incremental Sort (actual rows=10 loops=1)
          Sort Key: m1."time", m1.device_id, m2.device_id
-         Presorted Key: m1."time"
-         Full-sort Groups: 1  Sort Method: top-N heapsort 
-         ->  Merge Join (actual rows=26 loops=1)
+         Presorted Key: m1."time", m1.device_id
+         Full-sort Groups: 1  Sort Method: quicksort 
+         ->  Merge Join (actual rows=11 loops=1)
                Merge Cond: (m1."time" = m2."time")
-               ->  Custom Scan (ChunkAppend) on metrics m1 (actual rows=6 loops=1)
-                     Order: m1."time"
-                     ->  Sort (actual rows=6 loops=1)
-                           Sort Key: m1_1."time"
+               ->  Custom Scan (ChunkAppend) on metrics m1 (actual rows=3 loops=1)
+                     Order: m1."time", m1.device_id
+                     ->  Sort (actual rows=3 loops=1)
+                           Sort Key: m1_1."time", m1_1.device_id
                            Sort Method: quicksort 
                            ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk m1_1 (actual rows=1800 loops=1)
                                  ->  Seq Scan on compress_hyper_5_15_chunk (actual rows=5 loops=1)
-                     ->  Index Scan Backward using _hyper_1_2_chunk_metrics_time_idx on _hyper_1_2_chunk m1_2 (never executed)
                      ->  Sort (never executed)
-                           Sort Key: m1_3."time"
+                           Sort Key: m1_2."time", m1_2.device_id
+                           ->  Seq Scan on _hyper_1_2_chunk m1_2 (never executed)
+                     ->  Sort (never executed)
+                           Sort Key: m1_3."time", m1_3.device_id
                            ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk m1_3 (never executed)
                                  ->  Seq Scan on compress_hyper_5_16_chunk (never executed)
-               ->  Materialize (actual rows=26 loops=1)
+               ->  Materialize (actual rows=11 loops=1)
                      ->  Custom Scan (ChunkAppend) on metrics m2 (actual rows=6 loops=1)
                            Order: m2."time"
                            ->  Sort (actual rows=6 loops=1)
@@ -2953,7 +2919,7 @@ LIMIT 10;
                                  Sort Key: m2_3."time"
                                  ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk m2_3 (never executed)
                                        ->  Seq Scan on compress_hyper_5_16_chunk compress_hyper_5_16_chunk_1 (never executed)
-(32 rows)
+(34 rows)
 
 :PREFIX
 SELECT *
@@ -3200,39 +3166,34 @@ FROM metrics,
 WHERE metrics.time > metrics_space.time
     AND metrics.device_id = metrics_space.device_id
     AND metrics.time < metrics_space.time;
-                                                                      QUERY PLAN                                                                      
-------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                         QUERY PLAN                                                                                         
+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Nested Loop (actual rows=0 loops=1)
+   Join Filter: ((_hyper_1_1_chunk."time" > _hyper_2_4_chunk."time") AND (_hyper_1_1_chunk."time" < _hyper_2_4_chunk."time") AND (_hyper_2_4_chunk.device_id = _hyper_1_1_chunk.device_id))
+   Rows Removed by Join Filter: 46785600
    ->  Append (actual rows=6840 loops=1)
-         ->  Custom Scan (DecompressChunk) on _hyper_2_4_chunk (actual rows=360 loops=1)
-               ->  Index Scan using compress_hyper_6_17_chunk_c_space_index_2 on compress_hyper_6_17_chunk (actual rows=1 loops=1)
-         ->  Custom Scan (DecompressChunk) on _hyper_2_5_chunk (actual rows=1080 loops=1)
-               ->  Index Scan using compress_hyper_6_18_chunk_c_space_index_2 on compress_hyper_6_18_chunk (actual rows=3 loops=1)
-         ->  Custom Scan (DecompressChunk) on _hyper_2_6_chunk (actual rows=360 loops=1)
-               ->  Index Scan using compress_hyper_6_19_chunk_c_space_index_2 on compress_hyper_6_19_chunk (actual rows=1 loops=1)
-         ->  Index Scan Backward using _hyper_2_7_chunk_metrics_space_device_id_device_id_peer_v0_v1_2 on _hyper_2_7_chunk (actual rows=504 loops=1)
-         ->  Index Scan Backward using _hyper_2_8_chunk_metrics_space_device_id_device_id_peer_v0_v1_2 on _hyper_2_8_chunk (actual rows=1512 loops=1)
-         ->  Index Scan Backward using _hyper_2_9_chunk_metrics_space_device_id_device_id_peer_v0_v1_2 on _hyper_2_9_chunk (actual rows=504 loops=1)
-         ->  Custom Scan (DecompressChunk) on _hyper_2_10_chunk (actual rows=504 loops=1)
-               ->  Index Scan using compress_hyper_6_20_chunk_c_space_index_2 on compress_hyper_6_20_chunk (actual rows=1 loops=1)
-         ->  Custom Scan (DecompressChunk) on _hyper_2_11_chunk (actual rows=1512 loops=1)
-               ->  Index Scan using compress_hyper_6_21_chunk_c_space_index_2 on compress_hyper_6_21_chunk (actual rows=3 loops=1)
-         ->  Index Scan Backward using _hyper_2_12_chunk_metrics_space_device_id_device_id_peer_v0_v_2 on _hyper_2_12_chunk (actual rows=504 loops=1)
-   ->  Append (actual rows=0 loops=6840)
-         ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk (actual rows=0 loops=6840)
-               Filter: (("time" > _hyper_2_4_chunk."time") AND ("time" < _hyper_2_4_chunk."time"))
-               Rows Removed by Filter: 360
-               ->  Index Scan using compress_hyper_5_15_chunk_c_index_2 on compress_hyper_5_15_chunk (actual rows=1 loops=6840)
-                     Index Cond: (device_id = _hyper_2_4_chunk.device_id)
-         ->  Index Scan using _hyper_1_2_chunk_metrics_time_idx on _hyper_1_2_chunk (actual rows=0 loops=6840)
-               Index Cond: (("time" > _hyper_2_4_chunk."time") AND ("time" < _hyper_2_4_chunk."time"))
-               Filter: (_hyper_2_4_chunk.device_id = device_id)
-         ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk (actual rows=0 loops=6840)
-               Filter: (("time" > _hyper_2_4_chunk."time") AND ("time" < _hyper_2_4_chunk."time"))
-               Rows Removed by Filter: 504
-               ->  Index Scan using compress_hyper_5_16_chunk_c_index_2 on compress_hyper_5_16_chunk (actual rows=1 loops=6840)
-                     Index Cond: (device_id = _hyper_2_4_chunk.device_id)
-(30 rows)
+         ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk (actual rows=1800 loops=1)
+               ->  Index Scan using compress_hyper_5_15_chunk_c_index_2 on compress_hyper_5_15_chunk (actual rows=5 loops=1)
+         ->  Seq Scan on _hyper_1_2_chunk (actual rows=2520 loops=1)
+         ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk (actual rows=2520 loops=1)
+               ->  Index Scan using compress_hyper_5_16_chunk_c_index_2 on compress_hyper_5_16_chunk (actual rows=5 loops=1)
+   ->  Materialize (actual rows=6840 loops=6840)
+         ->  Append (actual rows=6840 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_2_4_chunk (actual rows=360 loops=1)
+                     ->  Index Scan using compress_hyper_6_17_chunk_c_space_index_2 on compress_hyper_6_17_chunk (actual rows=1 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_2_5_chunk (actual rows=1080 loops=1)
+                     ->  Index Scan using compress_hyper_6_18_chunk_c_space_index_2 on compress_hyper_6_18_chunk (actual rows=3 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_2_6_chunk (actual rows=360 loops=1)
+                     ->  Index Scan using compress_hyper_6_19_chunk_c_space_index_2 on compress_hyper_6_19_chunk (actual rows=1 loops=1)
+               ->  Index Scan Backward using _hyper_2_7_chunk_metrics_space_device_id_device_id_peer_v0_v1_2 on _hyper_2_7_chunk (actual rows=504 loops=1)
+               ->  Index Scan Backward using _hyper_2_8_chunk_metrics_space_device_id_device_id_peer_v0_v1_2 on _hyper_2_8_chunk (actual rows=1512 loops=1)
+               ->  Index Scan Backward using _hyper_2_9_chunk_metrics_space_device_id_device_id_peer_v0_v1_2 on _hyper_2_9_chunk (actual rows=504 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_2_10_chunk (actual rows=504 loops=1)
+                     ->  Index Scan using compress_hyper_6_20_chunk_c_space_index_2 on compress_hyper_6_20_chunk (actual rows=1 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_2_11_chunk (actual rows=1512 loops=1)
+                     ->  Index Scan using compress_hyper_6_21_chunk_c_space_index_2 on compress_hyper_6_21_chunk (actual rows=3 loops=1)
+               ->  Index Scan Backward using _hyper_2_12_chunk_metrics_space_device_id_device_id_peer_v0_v_2 on _hyper_2_12_chunk (actual rows=504 loops=1)
+(25 rows)
 
 SET enable_seqscan = TRUE;
 SET enable_bitmapscan = TRUE;
@@ -3323,65 +3284,32 @@ FROM :TEST_TABLE
 WHERE device_id IN (1, 2)
 ORDER BY time,
     device_id;
-                                                               QUERY PLAN                                                                
------------------------------------------------------------------------------------------------------------------------------------------
- Incremental Sort (actual rows=2736 loops=1)
-   Sort Key: metrics_space."time", metrics_space.device_id
-   Presorted Key: metrics_space."time"
-   Full-sort Groups: 86  Sort Method: quicksort 
+                                                                    QUERY PLAN                                                                    
+--------------------------------------------------------------------------------------------------------------------------------------------------
+ Sort (actual rows=2736 loops=1)
+   Sort Key: _hyper_2_4_chunk."time", _hyper_2_4_chunk.device_id
+   Sort Method: quicksort 
    ->  Result (actual rows=2736 loops=1)
-         ->  Custom Scan (ChunkAppend) on metrics_space (actual rows=2736 loops=1)
-               Order: metrics_space."time"
-               ->  Merge Append (actual rows=720 loops=1)
-                     Sort Key: _hyper_2_4_chunk."time"
-                     ->  Sort (actual rows=360 loops=1)
-                           Sort Key: _hyper_2_4_chunk."time"
-                           Sort Method: quicksort 
-                           ->  Sort (actual rows=360 loops=1)
-                                 Sort Key: _hyper_2_4_chunk."time"
-                                 Sort Method: quicksort 
-                                 ->  Custom Scan (DecompressChunk) on _hyper_2_4_chunk (actual rows=360 loops=1)
-                                       ->  Seq Scan on compress_hyper_6_17_chunk (actual rows=1 loops=1)
-                                             Filter: (device_id = ANY ('{1,2}'::integer[]))
-                     ->  Sort (actual rows=360 loops=1)
-                           Sort Key: _hyper_2_5_chunk."time"
-                           Sort Method: quicksort 
-                           ->  Sort (actual rows=360 loops=1)
-                                 Sort Key: _hyper_2_5_chunk."time"
-                                 Sort Method: quicksort 
-                                 ->  Custom Scan (DecompressChunk) on _hyper_2_5_chunk (actual rows=360 loops=1)
-                                       ->  Seq Scan on compress_hyper_6_18_chunk (actual rows=1 loops=1)
-                                             Filter: (device_id = ANY ('{1,2}'::integer[]))
-                                             Rows Removed by Filter: 2
-               ->  Merge Append (actual rows=1008 loops=1)
-                     Sort Key: _hyper_2_7_chunk."time"
-                     ->  Index Scan Backward using _hyper_2_7_chunk_metrics_space_time_idx on _hyper_2_7_chunk (actual rows=504 loops=1)
+         ->  Append (actual rows=2736 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_2_4_chunk (actual rows=360 loops=1)
+                     ->  Seq Scan on compress_hyper_6_17_chunk (actual rows=1 loops=1)
                            Filter: (device_id = ANY ('{1,2}'::integer[]))
-                     ->  Index Scan Backward using _hyper_2_8_chunk_metrics_space_time_idx on _hyper_2_8_chunk (actual rows=504 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_2_5_chunk (actual rows=360 loops=1)
+                     ->  Seq Scan on compress_hyper_6_18_chunk (actual rows=1 loops=1)
                            Filter: (device_id = ANY ('{1,2}'::integer[]))
-                           Rows Removed by Filter: 1008
-               ->  Merge Append (actual rows=1008 loops=1)
-                     Sort Key: _hyper_2_10_chunk."time"
-                     ->  Sort (actual rows=504 loops=1)
-                           Sort Key: _hyper_2_10_chunk."time"
-                           Sort Method: quicksort 
-                           ->  Sort (actual rows=504 loops=1)
-                                 Sort Key: _hyper_2_10_chunk."time"
-                                 Sort Method: quicksort 
-                                 ->  Custom Scan (DecompressChunk) on _hyper_2_10_chunk (actual rows=504 loops=1)
-                                       ->  Seq Scan on compress_hyper_6_20_chunk (actual rows=1 loops=1)
-                                             Filter: (device_id = ANY ('{1,2}'::integer[]))
-                     ->  Sort (actual rows=504 loops=1)
-                           Sort Key: _hyper_2_11_chunk."time"
-                           Sort Method: quicksort 
-                           ->  Sort (actual rows=504 loops=1)
-                                 Sort Key: _hyper_2_11_chunk."time"
-                                 Sort Method: quicksort 
-                                 ->  Custom Scan (DecompressChunk) on _hyper_2_11_chunk (actual rows=504 loops=1)
-                                       ->  Seq Scan on compress_hyper_6_21_chunk (actual rows=1 loops=1)
-                                             Filter: (device_id = ANY ('{1,2}'::integer[]))
-                                             Rows Removed by Filter: 2
-(56 rows)
+                           Rows Removed by Filter: 2
+               ->  Seq Scan on _hyper_2_7_chunk (actual rows=504 loops=1)
+                     Filter: (device_id = ANY ('{1,2}'::integer[]))
+               ->  Index Scan using _hyper_2_8_chunk_metrics_space_device_id_device_id_peer_v0_v1_2 on _hyper_2_8_chunk (actual rows=504 loops=1)
+                     Index Cond: (device_id = ANY ('{1,2}'::integer[]))
+               ->  Custom Scan (DecompressChunk) on _hyper_2_10_chunk (actual rows=504 loops=1)
+                     ->  Seq Scan on compress_hyper_6_20_chunk (actual rows=1 loops=1)
+                           Filter: (device_id = ANY ('{1,2}'::integer[]))
+               ->  Custom Scan (DecompressChunk) on _hyper_2_11_chunk (actual rows=504 loops=1)
+                     ->  Seq Scan on compress_hyper_6_21_chunk (actual rows=1 loops=1)
+                           Filter: (device_id = ANY ('{1,2}'::integer[]))
+                           Rows Removed by Filter: 2
+(23 rows)
 
 -- test empty targetlist
 :PREFIX
@@ -3476,19 +3404,26 @@ WHERE device_id = 1
 ORDER BY v1;
                                         QUERY PLAN                                        
 ------------------------------------------------------------------------------------------
- Sort (actual rows=1368 loops=1)
+ Merge Append (actual rows=1368 loops=1)
    Sort Key: _hyper_2_4_chunk.v1
-   Sort Method: quicksort 
-   ->  Append (actual rows=1368 loops=1)
+   ->  Sort (actual rows=360 loops=1)
+         Sort Key: _hyper_2_4_chunk.v1
+         Sort Method: quicksort 
          ->  Custom Scan (DecompressChunk) on _hyper_2_4_chunk (actual rows=360 loops=1)
                ->  Seq Scan on compress_hyper_6_17_chunk (actual rows=1 loops=1)
                      Filter: (device_id = 1)
+   ->  Sort (actual rows=504 loops=1)
+         Sort Key: _hyper_2_7_chunk.v1
+         Sort Method: quicksort 
          ->  Seq Scan on _hyper_2_7_chunk (actual rows=504 loops=1)
                Filter: (device_id = 1)
+   ->  Sort (actual rows=504 loops=1)
+         Sort Key: _hyper_2_10_chunk.v1
+         Sort Method: quicksort 
          ->  Custom Scan (DecompressChunk) on _hyper_2_10_chunk (actual rows=504 loops=1)
                ->  Seq Scan on compress_hyper_6_20_chunk (actual rows=1 loops=1)
                      Filter: (device_id = 1)
-(12 rows)
+(19 rows)
 
 -- test order not present in targetlist
 :PREFIX
@@ -3498,19 +3433,26 @@ WHERE device_id = 1
 ORDER BY v1;
                                         QUERY PLAN                                        
 ------------------------------------------------------------------------------------------
- Sort (actual rows=1368 loops=1)
+ Merge Append (actual rows=1368 loops=1)
    Sort Key: _hyper_2_4_chunk.v1
-   Sort Method: quicksort 
-   ->  Append (actual rows=1368 loops=1)
+   ->  Sort (actual rows=360 loops=1)
+         Sort Key: _hyper_2_4_chunk.v1
+         Sort Method: quicksort 
          ->  Custom Scan (DecompressChunk) on _hyper_2_4_chunk (actual rows=360 loops=1)
                ->  Seq Scan on compress_hyper_6_17_chunk (actual rows=1 loops=1)
                      Filter: (device_id = 1)
+   ->  Sort (actual rows=504 loops=1)
+         Sort Key: _hyper_2_7_chunk.v1
+         Sort Method: quicksort 
          ->  Seq Scan on _hyper_2_7_chunk (actual rows=504 loops=1)
                Filter: (device_id = 1)
+   ->  Sort (actual rows=504 loops=1)
+         Sort Key: _hyper_2_10_chunk.v1
+         Sort Method: quicksort 
          ->  Custom Scan (DecompressChunk) on _hyper_2_10_chunk (actual rows=504 loops=1)
                ->  Seq Scan on compress_hyper_6_20_chunk (actual rows=1 loops=1)
                      Filter: (device_id = 1)
-(12 rows)
+(19 rows)
 
 -- test column with all NULL
 :PREFIX
@@ -3636,71 +3578,70 @@ WHERE device_id IS NOT NULL
 ORDER BY time,
     device_id
 LIMIT 10;
-                                                            QUERY PLAN                                                            
-----------------------------------------------------------------------------------------------------------------------------------
+                                              QUERY PLAN                                              
+------------------------------------------------------------------------------------------------------
  Limit (actual rows=10 loops=1)
-   ->  Incremental Sort (actual rows=10 loops=1)
-         Sort Key: metrics_space."time", metrics_space.device_id
-         Presorted Key: metrics_space."time"
-         Full-sort Groups: 1  Sort Method: quicksort 
-         ->  Custom Scan (ChunkAppend) on metrics_space (actual rows=11 loops=1)
-               Order: metrics_space."time"
-               ->  Merge Append (actual rows=11 loops=1)
-                     Sort Key: _hyper_2_4_chunk."time"
-                     ->  Sort (actual rows=3 loops=1)
-                           Sort Key: _hyper_2_4_chunk."time"
-                           Sort Method: quicksort 
-                           ->  Sort (actual rows=360 loops=1)
-                                 Sort Key: _hyper_2_4_chunk."time"
-                                 Sort Method: quicksort 
-                                 ->  Custom Scan (DecompressChunk) on _hyper_2_4_chunk (actual rows=360 loops=1)
-                                       ->  Seq Scan on compress_hyper_6_17_chunk (actual rows=1 loops=1)
-                                             Filter: (device_id IS NOT NULL)
-                     ->  Sort (actual rows=7 loops=1)
-                           Sort Key: _hyper_2_5_chunk."time"
-                           Sort Method: quicksort 
-                           ->  Sort (actual rows=1080 loops=1)
-                                 Sort Key: _hyper_2_5_chunk."time"
-                                 Sort Method: quicksort 
-                                 ->  Custom Scan (DecompressChunk) on _hyper_2_5_chunk (actual rows=1080 loops=1)
-                                       ->  Seq Scan on compress_hyper_6_18_chunk (actual rows=3 loops=1)
-                                             Filter: (device_id IS NOT NULL)
-                     ->  Sort (actual rows=3 loops=1)
-                           Sort Key: _hyper_2_6_chunk."time"
-                           Sort Method: quicksort 
-                           ->  Sort (actual rows=360 loops=1)
-                                 Sort Key: _hyper_2_6_chunk."time"
-                                 Sort Method: quicksort 
-                                 ->  Custom Scan (DecompressChunk) on _hyper_2_6_chunk (actual rows=360 loops=1)
-                                       ->  Seq Scan on compress_hyper_6_19_chunk (actual rows=1 loops=1)
-                                             Filter: (device_id IS NOT NULL)
-               ->  Merge Append (never executed)
-                     Sort Key: _hyper_2_7_chunk."time"
-                     ->  Index Scan Backward using _hyper_2_7_chunk_metrics_space_time_idx on _hyper_2_7_chunk (never executed)
-                           Filter: (device_id IS NOT NULL)
-                     ->  Index Scan Backward using _hyper_2_8_chunk_metrics_space_time_idx on _hyper_2_8_chunk (never executed)
-                           Filter: (device_id IS NOT NULL)
-                     ->  Index Scan Backward using _hyper_2_9_chunk_metrics_space_time_idx on _hyper_2_9_chunk (never executed)
-                           Filter: (device_id IS NOT NULL)
-               ->  Merge Append (never executed)
-                     Sort Key: _hyper_2_10_chunk."time"
+   ->  Custom Scan (ChunkAppend) on metrics_space (actual rows=10 loops=1)
+         Order: metrics_space."time", metrics_space.device_id
+         ->  Merge Append (actual rows=10 loops=1)
+               Sort Key: _hyper_2_4_chunk."time", _hyper_2_4_chunk.device_id
+               ->  Sort (actual rows=3 loops=1)
+                     Sort Key: _hyper_2_4_chunk."time", _hyper_2_4_chunk.device_id
+                     Sort Method: top-N heapsort 
+                     ->  Custom Scan (DecompressChunk) on _hyper_2_4_chunk (actual rows=360 loops=1)
+                           ->  Seq Scan on compress_hyper_6_17_chunk (actual rows=1 loops=1)
+                                 Filter: (device_id IS NOT NULL)
+               ->  Sort (actual rows=6 loops=1)
+                     Sort Key: _hyper_2_5_chunk."time", _hyper_2_5_chunk.device_id
+                     Sort Method: top-N heapsort 
+                     ->  Custom Scan (DecompressChunk) on _hyper_2_5_chunk (actual rows=1080 loops=1)
+                           ->  Seq Scan on compress_hyper_6_18_chunk (actual rows=3 loops=1)
+                                 Filter: (device_id IS NOT NULL)
+               ->  Sort (actual rows=3 loops=1)
+                     Sort Key: _hyper_2_6_chunk."time", _hyper_2_6_chunk.device_id
+                     Sort Method: top-N heapsort 
+                     ->  Custom Scan (DecompressChunk) on _hyper_2_6_chunk (actual rows=360 loops=1)
+                           ->  Seq Scan on compress_hyper_6_19_chunk (actual rows=1 loops=1)
+                                 Filter: (device_id IS NOT NULL)
+         ->  Merge Append (never executed)
+               Sort Key: _hyper_2_7_chunk."time", _hyper_2_7_chunk.device_id
+               ->  Sort (never executed)
+                     Sort Key: _hyper_2_7_chunk."time", _hyper_2_7_chunk.device_id
                      ->  Sort (never executed)
-                           Sort Key: _hyper_2_10_chunk."time"
-                           ->  Sort (never executed)
-                                 Sort Key: _hyper_2_10_chunk."time"
-                                 ->  Custom Scan (DecompressChunk) on _hyper_2_10_chunk (never executed)
-                                       ->  Seq Scan on compress_hyper_6_20_chunk (never executed)
-                                             Filter: (device_id IS NOT NULL)
+                           Sort Key: _hyper_2_7_chunk."time", _hyper_2_7_chunk.device_id
+                           ->  Seq Scan on _hyper_2_7_chunk (never executed)
+                                 Filter: (device_id IS NOT NULL)
+               ->  Sort (never executed)
+                     Sort Key: _hyper_2_8_chunk."time", _hyper_2_8_chunk.device_id
                      ->  Sort (never executed)
-                           Sort Key: _hyper_2_11_chunk."time"
-                           ->  Sort (never executed)
-                                 Sort Key: _hyper_2_11_chunk."time"
-                                 ->  Custom Scan (DecompressChunk) on _hyper_2_11_chunk (never executed)
-                                       ->  Seq Scan on compress_hyper_6_21_chunk (never executed)
-                                             Filter: (device_id IS NOT NULL)
-                     ->  Index Scan Backward using _hyper_2_12_chunk_metrics_space_time_idx on _hyper_2_12_chunk (never executed)
-                           Filter: (device_id IS NOT NULL)
-(62 rows)
+                           Sort Key: _hyper_2_8_chunk."time", _hyper_2_8_chunk.device_id
+                           ->  Seq Scan on _hyper_2_8_chunk (never executed)
+                                 Filter: (device_id IS NOT NULL)
+               ->  Sort (never executed)
+                     Sort Key: _hyper_2_9_chunk."time", _hyper_2_9_chunk.device_id
+                     ->  Sort (never executed)
+                           Sort Key: _hyper_2_9_chunk."time", _hyper_2_9_chunk.device_id
+                           ->  Seq Scan on _hyper_2_9_chunk (never executed)
+                                 Filter: (device_id IS NOT NULL)
+         ->  Merge Append (never executed)
+               Sort Key: _hyper_2_10_chunk."time", _hyper_2_10_chunk.device_id
+               ->  Sort (never executed)
+                     Sort Key: _hyper_2_10_chunk."time", _hyper_2_10_chunk.device_id
+                     ->  Custom Scan (DecompressChunk) on _hyper_2_10_chunk (never executed)
+                           ->  Seq Scan on compress_hyper_6_20_chunk (never executed)
+                                 Filter: (device_id IS NOT NULL)
+               ->  Sort (never executed)
+                     Sort Key: _hyper_2_11_chunk."time", _hyper_2_11_chunk.device_id
+                     ->  Custom Scan (DecompressChunk) on _hyper_2_11_chunk (never executed)
+                           ->  Seq Scan on compress_hyper_6_21_chunk (never executed)
+                                 Filter: (device_id IS NOT NULL)
+               ->  Sort (never executed)
+                     Sort Key: _hyper_2_12_chunk."time", _hyper_2_12_chunk.device_id
+                     ->  Sort (never executed)
+                           Sort Key: _hyper_2_12_chunk."time", _hyper_2_12_chunk.device_id
+                           ->  Seq Scan on _hyper_2_12_chunk (never executed)
+                                 Filter: (device_id IS NOT NULL)
+(61 rows)
 
 :PREFIX
 SELECT *
@@ -3709,84 +3650,85 @@ WHERE device_id IS NULL
 ORDER BY time,
     device_id
 LIMIT 10;
-                                                               QUERY PLAN                                                                
------------------------------------------------------------------------------------------------------------------------------------------
+                                                                         QUERY PLAN                                                                          
+-------------------------------------------------------------------------------------------------------------------------------------------------------------
  Limit (actual rows=0 loops=1)
-   ->  Incremental Sort (actual rows=0 loops=1)
-         Sort Key: metrics_space."time", metrics_space.device_id
-         Presorted Key: metrics_space."time"
-         Full-sort Groups: 1  Sort Method: quicksort 
-         ->  Custom Scan (ChunkAppend) on metrics_space (actual rows=0 loops=1)
-               Order: metrics_space."time"
-               ->  Merge Append (actual rows=0 loops=1)
-                     Sort Key: _hyper_2_4_chunk."time"
+   ->  Custom Scan (ChunkAppend) on metrics_space (actual rows=0 loops=1)
+         Order: metrics_space."time", metrics_space.device_id
+         ->  Merge Append (actual rows=0 loops=1)
+               Sort Key: _hyper_2_4_chunk."time", _hyper_2_4_chunk.device_id
+               ->  Sort (actual rows=0 loops=1)
+                     Sort Key: _hyper_2_4_chunk."time", _hyper_2_4_chunk.device_id
+                     Sort Method: quicksort 
+                     ->  Custom Scan (DecompressChunk) on _hyper_2_4_chunk (actual rows=0 loops=1)
+                           ->  Seq Scan on compress_hyper_6_17_chunk (actual rows=0 loops=1)
+                                 Filter: (device_id IS NULL)
+                                 Rows Removed by Filter: 1
+               ->  Sort (actual rows=0 loops=1)
+                     Sort Key: _hyper_2_5_chunk."time", _hyper_2_5_chunk.device_id
+                     Sort Method: quicksort 
+                     ->  Custom Scan (DecompressChunk) on _hyper_2_5_chunk (actual rows=0 loops=1)
+                           ->  Seq Scan on compress_hyper_6_18_chunk (actual rows=0 loops=1)
+                                 Filter: (device_id IS NULL)
+                                 Rows Removed by Filter: 3
+               ->  Sort (actual rows=0 loops=1)
+                     Sort Key: _hyper_2_6_chunk."time", _hyper_2_6_chunk.device_id
+                     Sort Method: quicksort 
+                     ->  Custom Scan (DecompressChunk) on _hyper_2_6_chunk (actual rows=0 loops=1)
+                           ->  Seq Scan on compress_hyper_6_19_chunk (actual rows=0 loops=1)
+                                 Filter: (device_id IS NULL)
+                                 Rows Removed by Filter: 1
+         ->  Merge Append (actual rows=0 loops=1)
+               Sort Key: _hyper_2_7_chunk."time", _hyper_2_7_chunk.device_id
+               ->  Sort (actual rows=0 loops=1)
+                     Sort Key: _hyper_2_7_chunk."time", _hyper_2_7_chunk.device_id
+                     Sort Method: quicksort 
                      ->  Sort (actual rows=0 loops=1)
-                           Sort Key: _hyper_2_4_chunk."time"
+                           Sort Key: _hyper_2_7_chunk."time", _hyper_2_7_chunk.device_id
                            Sort Method: quicksort 
-                           ->  Sort (actual rows=0 loops=1)
-                                 Sort Key: _hyper_2_4_chunk."time"
-                                 Sort Method: quicksort 
-                                 ->  Custom Scan (DecompressChunk) on _hyper_2_4_chunk (actual rows=0 loops=1)
-                                       ->  Seq Scan on compress_hyper_6_17_chunk (actual rows=0 loops=1)
-                                             Filter: (device_id IS NULL)
-                                             Rows Removed by Filter: 1
+                           ->  Index Scan using _hyper_2_7_chunk_metrics_space_device_id_device_id_peer_v0_v1_2 on _hyper_2_7_chunk (actual rows=0 loops=1)
+                                 Index Cond: (device_id IS NULL)
+               ->  Sort (actual rows=0 loops=1)
+                     Sort Key: _hyper_2_8_chunk."time", _hyper_2_8_chunk.device_id
+                     Sort Method: quicksort 
                      ->  Sort (actual rows=0 loops=1)
-                           Sort Key: _hyper_2_5_chunk."time"
+                           Sort Key: _hyper_2_8_chunk."time", _hyper_2_8_chunk.device_id
                            Sort Method: quicksort 
-                           ->  Sort (actual rows=0 loops=1)
-                                 Sort Key: _hyper_2_5_chunk."time"
-                                 Sort Method: quicksort 
-                                 ->  Custom Scan (DecompressChunk) on _hyper_2_5_chunk (actual rows=0 loops=1)
-                                       ->  Seq Scan on compress_hyper_6_18_chunk (actual rows=0 loops=1)
-                                             Filter: (device_id IS NULL)
-                                             Rows Removed by Filter: 3
+                           ->  Index Scan using _hyper_2_8_chunk_metrics_space_device_id_device_id_peer_v0_v1_2 on _hyper_2_8_chunk (actual rows=0 loops=1)
+                                 Index Cond: (device_id IS NULL)
+               ->  Sort (actual rows=0 loops=1)
+                     Sort Key: _hyper_2_9_chunk."time", _hyper_2_9_chunk.device_id
+                     Sort Method: quicksort 
                      ->  Sort (actual rows=0 loops=1)
-                           Sort Key: _hyper_2_6_chunk."time"
+                           Sort Key: _hyper_2_9_chunk."time", _hyper_2_9_chunk.device_id
                            Sort Method: quicksort 
-                           ->  Sort (actual rows=0 loops=1)
-                                 Sort Key: _hyper_2_6_chunk."time"
-                                 Sort Method: quicksort 
-                                 ->  Custom Scan (DecompressChunk) on _hyper_2_6_chunk (actual rows=0 loops=1)
-                                       ->  Seq Scan on compress_hyper_6_19_chunk (actual rows=0 loops=1)
-                                             Filter: (device_id IS NULL)
-                                             Rows Removed by Filter: 1
-               ->  Merge Append (actual rows=0 loops=1)
-                     Sort Key: _hyper_2_7_chunk."time"
-                     ->  Index Scan Backward using _hyper_2_7_chunk_metrics_space_time_idx on _hyper_2_7_chunk (actual rows=0 loops=1)
-                           Filter: (device_id IS NULL)
-                           Rows Removed by Filter: 504
-                     ->  Index Scan Backward using _hyper_2_8_chunk_metrics_space_time_idx on _hyper_2_8_chunk (actual rows=0 loops=1)
-                           Filter: (device_id IS NULL)
-                           Rows Removed by Filter: 1512
-                     ->  Index Scan Backward using _hyper_2_9_chunk_metrics_space_time_idx on _hyper_2_9_chunk (actual rows=0 loops=1)
-                           Filter: (device_id IS NULL)
-                           Rows Removed by Filter: 504
-               ->  Merge Append (actual rows=0 loops=1)
-                     Sort Key: _hyper_2_10_chunk."time"
+                           ->  Index Scan using _hyper_2_9_chunk_metrics_space_device_id_device_id_peer_v0_v1_2 on _hyper_2_9_chunk (actual rows=0 loops=1)
+                                 Index Cond: (device_id IS NULL)
+         ->  Merge Append (actual rows=0 loops=1)
+               Sort Key: _hyper_2_10_chunk."time", _hyper_2_10_chunk.device_id
+               ->  Sort (actual rows=0 loops=1)
+                     Sort Key: _hyper_2_10_chunk."time", _hyper_2_10_chunk.device_id
+                     Sort Method: quicksort 
+                     ->  Custom Scan (DecompressChunk) on _hyper_2_10_chunk (actual rows=0 loops=1)
+                           ->  Seq Scan on compress_hyper_6_20_chunk (actual rows=0 loops=1)
+                                 Filter: (device_id IS NULL)
+                                 Rows Removed by Filter: 1
+               ->  Sort (actual rows=0 loops=1)
+                     Sort Key: _hyper_2_11_chunk."time", _hyper_2_11_chunk.device_id
+                     Sort Method: quicksort 
+                     ->  Custom Scan (DecompressChunk) on _hyper_2_11_chunk (actual rows=0 loops=1)
+                           ->  Seq Scan on compress_hyper_6_21_chunk (actual rows=0 loops=1)
+                                 Filter: (device_id IS NULL)
+                                 Rows Removed by Filter: 3
+               ->  Sort (actual rows=0 loops=1)
+                     Sort Key: _hyper_2_12_chunk."time", _hyper_2_12_chunk.device_id
+                     Sort Method: quicksort 
                      ->  Sort (actual rows=0 loops=1)
-                           Sort Key: _hyper_2_10_chunk."time"
+                           Sort Key: _hyper_2_12_chunk."time", _hyper_2_12_chunk.device_id
                            Sort Method: quicksort 
-                           ->  Sort (actual rows=0 loops=1)
-                                 Sort Key: _hyper_2_10_chunk."time"
-                                 Sort Method: quicksort 
-                                 ->  Custom Scan (DecompressChunk) on _hyper_2_10_chunk (actual rows=0 loops=1)
-                                       ->  Seq Scan on compress_hyper_6_20_chunk (actual rows=0 loops=1)
-                                             Filter: (device_id IS NULL)
-                                             Rows Removed by Filter: 1
-                     ->  Sort (actual rows=0 loops=1)
-                           Sort Key: _hyper_2_11_chunk."time"
-                           Sort Method: quicksort 
-                           ->  Sort (actual rows=0 loops=1)
-                                 Sort Key: _hyper_2_11_chunk."time"
-                                 Sort Method: quicksort 
-                                 ->  Custom Scan (DecompressChunk) on _hyper_2_11_chunk (actual rows=0 loops=1)
-                                       ->  Seq Scan on compress_hyper_6_21_chunk (actual rows=0 loops=1)
-                                             Filter: (device_id IS NULL)
-                                             Rows Removed by Filter: 3
-                     ->  Index Scan Backward using _hyper_2_12_chunk_metrics_space_time_idx on _hyper_2_12_chunk (actual rows=0 loops=1)
-                           Filter: (device_id IS NULL)
-                           Rows Removed by Filter: 504
-(75 rows)
+                           ->  Index Scan using _hyper_2_12_chunk_metrics_space_device_id_device_id_peer_v0_v_2 on _hyper_2_12_chunk (actual rows=0 loops=1)
+                                 Index Cond: (device_id IS NULL)
+(76 rows)
 
 -- test IN (Const,Const)
 :PREFIX
@@ -3796,59 +3738,53 @@ WHERE device_id IN (1, 2)
 ORDER BY time,
     device_id
 LIMIT 10;
-                                                           QUERY PLAN                                                           
---------------------------------------------------------------------------------------------------------------------------------
+                                                                     QUERY PLAN                                                                      
+-----------------------------------------------------------------------------------------------------------------------------------------------------
  Limit (actual rows=10 loops=1)
-   ->  Incremental Sort (actual rows=10 loops=1)
-         Sort Key: metrics_space."time", metrics_space.device_id
-         Presorted Key: metrics_space."time"
-         Full-sort Groups: 1  Sort Method: quicksort 
-         ->  Custom Scan (ChunkAppend) on metrics_space (actual rows=11 loops=1)
-               Order: metrics_space."time"
-               ->  Merge Append (actual rows=11 loops=1)
-                     Sort Key: _hyper_2_4_chunk."time"
-                     ->  Sort (actual rows=6 loops=1)
-                           Sort Key: _hyper_2_4_chunk."time"
-                           Sort Method: quicksort 
-                           ->  Sort (actual rows=360 loops=1)
-                                 Sort Key: _hyper_2_4_chunk."time"
-                                 Sort Method: quicksort 
-                                 ->  Custom Scan (DecompressChunk) on _hyper_2_4_chunk (actual rows=360 loops=1)
-                                       ->  Seq Scan on compress_hyper_6_17_chunk (actual rows=1 loops=1)
-                                             Filter: (device_id = ANY ('{1,2}'::integer[]))
-                     ->  Sort (actual rows=6 loops=1)
-                           Sort Key: _hyper_2_5_chunk."time"
-                           Sort Method: quicksort 
-                           ->  Sort (actual rows=360 loops=1)
-                                 Sort Key: _hyper_2_5_chunk."time"
-                                 Sort Method: quicksort 
-                                 ->  Custom Scan (DecompressChunk) on _hyper_2_5_chunk (actual rows=360 loops=1)
-                                       ->  Seq Scan on compress_hyper_6_18_chunk (actual rows=1 loops=1)
-                                             Filter: (device_id = ANY ('{1,2}'::integer[]))
-                                             Rows Removed by Filter: 2
-               ->  Merge Append (never executed)
-                     Sort Key: _hyper_2_7_chunk."time"
-                     ->  Index Scan Backward using _hyper_2_7_chunk_metrics_space_time_idx on _hyper_2_7_chunk (never executed)
-                           Filter: (device_id = ANY ('{1,2}'::integer[]))
-                     ->  Index Scan Backward using _hyper_2_8_chunk_metrics_space_time_idx on _hyper_2_8_chunk (never executed)
-                           Filter: (device_id = ANY ('{1,2}'::integer[]))
-               ->  Merge Append (never executed)
-                     Sort Key: _hyper_2_10_chunk."time"
+   ->  Custom Scan (ChunkAppend) on metrics_space (actual rows=10 loops=1)
+         Order: metrics_space."time", metrics_space.device_id
+         ->  Merge Append (actual rows=10 loops=1)
+               Sort Key: _hyper_2_4_chunk."time", _hyper_2_4_chunk.device_id
+               ->  Sort (actual rows=6 loops=1)
+                     Sort Key: _hyper_2_4_chunk."time", _hyper_2_4_chunk.device_id
+                     Sort Method: top-N heapsort 
+                     ->  Custom Scan (DecompressChunk) on _hyper_2_4_chunk (actual rows=360 loops=1)
+                           ->  Seq Scan on compress_hyper_6_17_chunk (actual rows=1 loops=1)
+                                 Filter: (device_id = ANY ('{1,2}'::integer[]))
+               ->  Sort (actual rows=5 loops=1)
+                     Sort Key: _hyper_2_5_chunk."time", _hyper_2_5_chunk.device_id
+                     Sort Method: top-N heapsort 
+                     ->  Custom Scan (DecompressChunk) on _hyper_2_5_chunk (actual rows=360 loops=1)
+                           ->  Seq Scan on compress_hyper_6_18_chunk (actual rows=1 loops=1)
+                                 Filter: (device_id = ANY ('{1,2}'::integer[]))
+                                 Rows Removed by Filter: 2
+         ->  Merge Append (never executed)
+               Sort Key: _hyper_2_7_chunk."time", _hyper_2_7_chunk.device_id
+               ->  Sort (never executed)
+                     Sort Key: _hyper_2_7_chunk."time", _hyper_2_7_chunk.device_id
                      ->  Sort (never executed)
-                           Sort Key: _hyper_2_10_chunk."time"
-                           ->  Sort (never executed)
-                                 Sort Key: _hyper_2_10_chunk."time"
-                                 ->  Custom Scan (DecompressChunk) on _hyper_2_10_chunk (never executed)
-                                       ->  Seq Scan on compress_hyper_6_20_chunk (never executed)
-                                             Filter: (device_id = ANY ('{1,2}'::integer[]))
+                           Sort Key: _hyper_2_7_chunk."time", _hyper_2_7_chunk.device_id
+                           ->  Seq Scan on _hyper_2_7_chunk (never executed)
+                                 Filter: (device_id = ANY ('{1,2}'::integer[]))
+               ->  Sort (never executed)
+                     Sort Key: _hyper_2_8_chunk."time", _hyper_2_8_chunk.device_id
                      ->  Sort (never executed)
-                           Sort Key: _hyper_2_11_chunk."time"
-                           ->  Sort (never executed)
-                                 Sort Key: _hyper_2_11_chunk."time"
-                                 ->  Custom Scan (DecompressChunk) on _hyper_2_11_chunk (never executed)
-                                       ->  Seq Scan on compress_hyper_6_21_chunk (never executed)
-                                             Filter: (device_id = ANY ('{1,2}'::integer[]))
-(50 rows)
+                           Sort Key: _hyper_2_8_chunk."time", _hyper_2_8_chunk.device_id
+                           ->  Index Scan using _hyper_2_8_chunk_metrics_space_device_id_device_id_peer_v0_v1_2 on _hyper_2_8_chunk (never executed)
+                                 Index Cond: (device_id = ANY ('{1,2}'::integer[]))
+         ->  Merge Append (never executed)
+               Sort Key: _hyper_2_10_chunk."time", _hyper_2_10_chunk.device_id
+               ->  Sort (never executed)
+                     Sort Key: _hyper_2_10_chunk."time", _hyper_2_10_chunk.device_id
+                     ->  Custom Scan (DecompressChunk) on _hyper_2_10_chunk (never executed)
+                           ->  Seq Scan on compress_hyper_6_20_chunk (never executed)
+                                 Filter: (device_id = ANY ('{1,2}'::integer[]))
+               ->  Sort (never executed)
+                     Sort Key: _hyper_2_11_chunk."time", _hyper_2_11_chunk.device_id
+                     ->  Custom Scan (DecompressChunk) on _hyper_2_11_chunk (never executed)
+                           ->  Seq Scan on compress_hyper_6_21_chunk (never executed)
+                                 Filter: (device_id = ANY ('{1,2}'::integer[]))
+(44 rows)
 
 -- test cast pushdown
 :PREFIX
@@ -3886,84 +3822,89 @@ WHERE device_id = device_id_peer
 ORDER BY time,
     device_id
 LIMIT 10;
-                                                               QUERY PLAN                                                                
------------------------------------------------------------------------------------------------------------------------------------------
+                                             QUERY PLAN                                             
+----------------------------------------------------------------------------------------------------
  Limit (actual rows=0 loops=1)
-   ->  Incremental Sort (actual rows=0 loops=1)
-         Sort Key: metrics_space."time", metrics_space.device_id
-         Presorted Key: metrics_space."time"
-         Full-sort Groups: 1  Sort Method: quicksort 
-         ->  Custom Scan (ChunkAppend) on metrics_space (actual rows=0 loops=1)
-               Order: metrics_space."time"
-               ->  Merge Append (actual rows=0 loops=1)
-                     Sort Key: _hyper_2_4_chunk."time"
+   ->  Custom Scan (ChunkAppend) on metrics_space (actual rows=0 loops=1)
+         Order: metrics_space."time", metrics_space.device_id
+         ->  Merge Append (actual rows=0 loops=1)
+               Sort Key: _hyper_2_4_chunk."time", _hyper_2_4_chunk.device_id
+               ->  Sort (actual rows=0 loops=1)
+                     Sort Key: _hyper_2_4_chunk."time", _hyper_2_4_chunk.device_id
+                     Sort Method: quicksort 
+                     ->  Custom Scan (DecompressChunk) on _hyper_2_4_chunk (actual rows=0 loops=1)
+                           ->  Seq Scan on compress_hyper_6_17_chunk (actual rows=0 loops=1)
+                                 Filter: (device_id = device_id_peer)
+                                 Rows Removed by Filter: 1
+               ->  Sort (actual rows=0 loops=1)
+                     Sort Key: _hyper_2_5_chunk."time", _hyper_2_5_chunk.device_id
+                     Sort Method: quicksort 
+                     ->  Custom Scan (DecompressChunk) on _hyper_2_5_chunk (actual rows=0 loops=1)
+                           ->  Seq Scan on compress_hyper_6_18_chunk (actual rows=0 loops=1)
+                                 Filter: (device_id = device_id_peer)
+                                 Rows Removed by Filter: 3
+               ->  Sort (actual rows=0 loops=1)
+                     Sort Key: _hyper_2_6_chunk."time", _hyper_2_6_chunk.device_id
+                     Sort Method: quicksort 
+                     ->  Custom Scan (DecompressChunk) on _hyper_2_6_chunk (actual rows=0 loops=1)
+                           ->  Seq Scan on compress_hyper_6_19_chunk (actual rows=0 loops=1)
+                                 Filter: (device_id = device_id_peer)
+                                 Rows Removed by Filter: 1
+         ->  Merge Append (actual rows=0 loops=1)
+               Sort Key: _hyper_2_7_chunk."time", _hyper_2_7_chunk.device_id
+               ->  Sort (actual rows=0 loops=1)
+                     Sort Key: _hyper_2_7_chunk."time", _hyper_2_7_chunk.device_id
+                     Sort Method: quicksort 
                      ->  Sort (actual rows=0 loops=1)
-                           Sort Key: _hyper_2_4_chunk."time"
+                           Sort Key: _hyper_2_7_chunk."time", _hyper_2_7_chunk.device_id
                            Sort Method: quicksort 
-                           ->  Sort (actual rows=0 loops=1)
-                                 Sort Key: _hyper_2_4_chunk."time"
-                                 Sort Method: quicksort 
-                                 ->  Custom Scan (DecompressChunk) on _hyper_2_4_chunk (actual rows=0 loops=1)
-                                       ->  Seq Scan on compress_hyper_6_17_chunk (actual rows=0 loops=1)
-                                             Filter: (device_id = device_id_peer)
-                                             Rows Removed by Filter: 1
+                           ->  Seq Scan on _hyper_2_7_chunk (actual rows=0 loops=1)
+                                 Filter: (device_id = device_id_peer)
+                                 Rows Removed by Filter: 504
+               ->  Sort (actual rows=0 loops=1)
+                     Sort Key: _hyper_2_8_chunk."time", _hyper_2_8_chunk.device_id
+                     Sort Method: quicksort 
                      ->  Sort (actual rows=0 loops=1)
-                           Sort Key: _hyper_2_5_chunk."time"
+                           Sort Key: _hyper_2_8_chunk."time", _hyper_2_8_chunk.device_id
                            Sort Method: quicksort 
-                           ->  Sort (actual rows=0 loops=1)
-                                 Sort Key: _hyper_2_5_chunk."time"
-                                 Sort Method: quicksort 
-                                 ->  Custom Scan (DecompressChunk) on _hyper_2_5_chunk (actual rows=0 loops=1)
-                                       ->  Seq Scan on compress_hyper_6_18_chunk (actual rows=0 loops=1)
-                                             Filter: (device_id = device_id_peer)
-                                             Rows Removed by Filter: 3
+                           ->  Seq Scan on _hyper_2_8_chunk (actual rows=0 loops=1)
+                                 Filter: (device_id = device_id_peer)
+                                 Rows Removed by Filter: 1512
+               ->  Sort (actual rows=0 loops=1)
+                     Sort Key: _hyper_2_9_chunk."time", _hyper_2_9_chunk.device_id
+                     Sort Method: quicksort 
                      ->  Sort (actual rows=0 loops=1)
-                           Sort Key: _hyper_2_6_chunk."time"
+                           Sort Key: _hyper_2_9_chunk."time", _hyper_2_9_chunk.device_id
                            Sort Method: quicksort 
-                           ->  Sort (actual rows=0 loops=1)
-                                 Sort Key: _hyper_2_6_chunk."time"
-                                 Sort Method: quicksort 
-                                 ->  Custom Scan (DecompressChunk) on _hyper_2_6_chunk (actual rows=0 loops=1)
-                                       ->  Seq Scan on compress_hyper_6_19_chunk (actual rows=0 loops=1)
-                                             Filter: (device_id = device_id_peer)
-                                             Rows Removed by Filter: 1
-               ->  Merge Append (actual rows=0 loops=1)
-                     Sort Key: _hyper_2_7_chunk."time"
-                     ->  Index Scan Backward using _hyper_2_7_chunk_metrics_space_time_idx on _hyper_2_7_chunk (actual rows=0 loops=1)
-                           Filter: (device_id = device_id_peer)
-                           Rows Removed by Filter: 504
-                     ->  Index Scan Backward using _hyper_2_8_chunk_metrics_space_time_idx on _hyper_2_8_chunk (actual rows=0 loops=1)
-                           Filter: (device_id = device_id_peer)
-                           Rows Removed by Filter: 1512
-                     ->  Index Scan Backward using _hyper_2_9_chunk_metrics_space_time_idx on _hyper_2_9_chunk (actual rows=0 loops=1)
-                           Filter: (device_id = device_id_peer)
-                           Rows Removed by Filter: 504
-               ->  Merge Append (actual rows=0 loops=1)
-                     Sort Key: _hyper_2_10_chunk."time"
+                           ->  Seq Scan on _hyper_2_9_chunk (actual rows=0 loops=1)
+                                 Filter: (device_id = device_id_peer)
+                                 Rows Removed by Filter: 504
+         ->  Merge Append (actual rows=0 loops=1)
+               Sort Key: _hyper_2_10_chunk."time", _hyper_2_10_chunk.device_id
+               ->  Sort (actual rows=0 loops=1)
+                     Sort Key: _hyper_2_10_chunk."time", _hyper_2_10_chunk.device_id
+                     Sort Method: quicksort 
+                     ->  Custom Scan (DecompressChunk) on _hyper_2_10_chunk (actual rows=0 loops=1)
+                           ->  Seq Scan on compress_hyper_6_20_chunk (actual rows=0 loops=1)
+                                 Filter: (device_id = device_id_peer)
+                                 Rows Removed by Filter: 1
+               ->  Sort (actual rows=0 loops=1)
+                     Sort Key: _hyper_2_11_chunk."time", _hyper_2_11_chunk.device_id
+                     Sort Method: quicksort 
+                     ->  Custom Scan (DecompressChunk) on _hyper_2_11_chunk (actual rows=0 loops=1)
+                           ->  Seq Scan on compress_hyper_6_21_chunk (actual rows=0 loops=1)
+                                 Filter: (device_id = device_id_peer)
+                                 Rows Removed by Filter: 3
+               ->  Sort (actual rows=0 loops=1)
+                     Sort Key: _hyper_2_12_chunk."time", _hyper_2_12_chunk.device_id
+                     Sort Method: quicksort 
                      ->  Sort (actual rows=0 loops=1)
-                           Sort Key: _hyper_2_10_chunk."time"
+                           Sort Key: _hyper_2_12_chunk."time", _hyper_2_12_chunk.device_id
                            Sort Method: quicksort 
-                           ->  Sort (actual rows=0 loops=1)
-                                 Sort Key: _hyper_2_10_chunk."time"
-                                 Sort Method: quicksort 
-                                 ->  Custom Scan (DecompressChunk) on _hyper_2_10_chunk (actual rows=0 loops=1)
-                                       ->  Seq Scan on compress_hyper_6_20_chunk (actual rows=0 loops=1)
-                                             Filter: (device_id = device_id_peer)
-                                             Rows Removed by Filter: 1
-                     ->  Sort (actual rows=0 loops=1)
-                           Sort Key: _hyper_2_11_chunk."time"
-                           Sort Method: quicksort 
-                           ->  Sort (actual rows=0 loops=1)
-                                 Sort Key: _hyper_2_11_chunk."time"
-                                 Sort Method: quicksort 
-                                 ->  Custom Scan (DecompressChunk) on _hyper_2_11_chunk (actual rows=0 loops=1)
-                                       ->  Seq Scan on compress_hyper_6_21_chunk (actual rows=0 loops=1)
-                                             Filter: (device_id = device_id_peer)
-                                             Rows Removed by Filter: 3
-                     ->  Index Scan Backward using _hyper_2_12_chunk_metrics_space_time_idx on _hyper_2_12_chunk (actual rows=0 loops=1)
-                           Filter: (device_id = device_id_peer)
-                           Rows Removed by Filter: 504
-(75 rows)
+                           ->  Seq Scan on _hyper_2_12_chunk (actual rows=0 loops=1)
+                                 Filter: (device_id = device_id_peer)
+                                 Rows Removed by Filter: 504
+(80 rows)
 
 :PREFIX
 SELECT *
@@ -3972,71 +3913,70 @@ WHERE device_id_peer < device_id
 ORDER BY time,
     device_id
 LIMIT 10;
-                                                            QUERY PLAN                                                            
-----------------------------------------------------------------------------------------------------------------------------------
+                                              QUERY PLAN                                              
+------------------------------------------------------------------------------------------------------
  Limit (actual rows=10 loops=1)
-   ->  Incremental Sort (actual rows=10 loops=1)
-         Sort Key: metrics_space."time", metrics_space.device_id
-         Presorted Key: metrics_space."time"
-         Full-sort Groups: 1  Sort Method: quicksort 
-         ->  Custom Scan (ChunkAppend) on metrics_space (actual rows=11 loops=1)
-               Order: metrics_space."time"
-               ->  Merge Append (actual rows=11 loops=1)
-                     Sort Key: _hyper_2_4_chunk."time"
-                     ->  Sort (actual rows=3 loops=1)
-                           Sort Key: _hyper_2_4_chunk."time"
-                           Sort Method: quicksort 
-                           ->  Sort (actual rows=360 loops=1)
-                                 Sort Key: _hyper_2_4_chunk."time"
-                                 Sort Method: quicksort 
-                                 ->  Custom Scan (DecompressChunk) on _hyper_2_4_chunk (actual rows=360 loops=1)
-                                       ->  Seq Scan on compress_hyper_6_17_chunk (actual rows=1 loops=1)
-                                             Filter: (device_id_peer < device_id)
-                     ->  Sort (actual rows=7 loops=1)
-                           Sort Key: _hyper_2_5_chunk."time"
-                           Sort Method: quicksort 
-                           ->  Sort (actual rows=1080 loops=1)
-                                 Sort Key: _hyper_2_5_chunk."time"
-                                 Sort Method: quicksort 
-                                 ->  Custom Scan (DecompressChunk) on _hyper_2_5_chunk (actual rows=1080 loops=1)
-                                       ->  Seq Scan on compress_hyper_6_18_chunk (actual rows=3 loops=1)
-                                             Filter: (device_id_peer < device_id)
-                     ->  Sort (actual rows=3 loops=1)
-                           Sort Key: _hyper_2_6_chunk."time"
-                           Sort Method: quicksort 
-                           ->  Sort (actual rows=360 loops=1)
-                                 Sort Key: _hyper_2_6_chunk."time"
-                                 Sort Method: quicksort 
-                                 ->  Custom Scan (DecompressChunk) on _hyper_2_6_chunk (actual rows=360 loops=1)
-                                       ->  Seq Scan on compress_hyper_6_19_chunk (actual rows=1 loops=1)
-                                             Filter: (device_id_peer < device_id)
-               ->  Merge Append (never executed)
-                     Sort Key: _hyper_2_7_chunk."time"
-                     ->  Index Scan Backward using _hyper_2_7_chunk_metrics_space_time_idx on _hyper_2_7_chunk (never executed)
-                           Filter: (device_id_peer < device_id)
-                     ->  Index Scan Backward using _hyper_2_8_chunk_metrics_space_time_idx on _hyper_2_8_chunk (never executed)
-                           Filter: (device_id_peer < device_id)
-                     ->  Index Scan Backward using _hyper_2_9_chunk_metrics_space_time_idx on _hyper_2_9_chunk (never executed)
-                           Filter: (device_id_peer < device_id)
-               ->  Merge Append (never executed)
-                     Sort Key: _hyper_2_10_chunk."time"
+   ->  Custom Scan (ChunkAppend) on metrics_space (actual rows=10 loops=1)
+         Order: metrics_space."time", metrics_space.device_id
+         ->  Merge Append (actual rows=10 loops=1)
+               Sort Key: _hyper_2_4_chunk."time", _hyper_2_4_chunk.device_id
+               ->  Sort (actual rows=3 loops=1)
+                     Sort Key: _hyper_2_4_chunk."time", _hyper_2_4_chunk.device_id
+                     Sort Method: top-N heapsort 
+                     ->  Custom Scan (DecompressChunk) on _hyper_2_4_chunk (actual rows=360 loops=1)
+                           ->  Seq Scan on compress_hyper_6_17_chunk (actual rows=1 loops=1)
+                                 Filter: (device_id_peer < device_id)
+               ->  Sort (actual rows=6 loops=1)
+                     Sort Key: _hyper_2_5_chunk."time", _hyper_2_5_chunk.device_id
+                     Sort Method: top-N heapsort 
+                     ->  Custom Scan (DecompressChunk) on _hyper_2_5_chunk (actual rows=1080 loops=1)
+                           ->  Seq Scan on compress_hyper_6_18_chunk (actual rows=3 loops=1)
+                                 Filter: (device_id_peer < device_id)
+               ->  Sort (actual rows=3 loops=1)
+                     Sort Key: _hyper_2_6_chunk."time", _hyper_2_6_chunk.device_id
+                     Sort Method: top-N heapsort 
+                     ->  Custom Scan (DecompressChunk) on _hyper_2_6_chunk (actual rows=360 loops=1)
+                           ->  Seq Scan on compress_hyper_6_19_chunk (actual rows=1 loops=1)
+                                 Filter: (device_id_peer < device_id)
+         ->  Merge Append (never executed)
+               Sort Key: _hyper_2_7_chunk."time", _hyper_2_7_chunk.device_id
+               ->  Sort (never executed)
+                     Sort Key: _hyper_2_7_chunk."time", _hyper_2_7_chunk.device_id
                      ->  Sort (never executed)
-                           Sort Key: _hyper_2_10_chunk."time"
-                           ->  Sort (never executed)
-                                 Sort Key: _hyper_2_10_chunk."time"
-                                 ->  Custom Scan (DecompressChunk) on _hyper_2_10_chunk (never executed)
-                                       ->  Seq Scan on compress_hyper_6_20_chunk (never executed)
-                                             Filter: (device_id_peer < device_id)
+                           Sort Key: _hyper_2_7_chunk."time", _hyper_2_7_chunk.device_id
+                           ->  Seq Scan on _hyper_2_7_chunk (never executed)
+                                 Filter: (device_id_peer < device_id)
+               ->  Sort (never executed)
+                     Sort Key: _hyper_2_8_chunk."time", _hyper_2_8_chunk.device_id
                      ->  Sort (never executed)
-                           Sort Key: _hyper_2_11_chunk."time"
-                           ->  Sort (never executed)
-                                 Sort Key: _hyper_2_11_chunk."time"
-                                 ->  Custom Scan (DecompressChunk) on _hyper_2_11_chunk (never executed)
-                                       ->  Seq Scan on compress_hyper_6_21_chunk (never executed)
-                                             Filter: (device_id_peer < device_id)
-                     ->  Index Scan Backward using _hyper_2_12_chunk_metrics_space_time_idx on _hyper_2_12_chunk (never executed)
-                           Filter: (device_id_peer < device_id)
-(62 rows)
+                           Sort Key: _hyper_2_8_chunk."time", _hyper_2_8_chunk.device_id
+                           ->  Seq Scan on _hyper_2_8_chunk (never executed)
+                                 Filter: (device_id_peer < device_id)
+               ->  Sort (never executed)
+                     Sort Key: _hyper_2_9_chunk."time", _hyper_2_9_chunk.device_id
+                     ->  Sort (never executed)
+                           Sort Key: _hyper_2_9_chunk."time", _hyper_2_9_chunk.device_id
+                           ->  Seq Scan on _hyper_2_9_chunk (never executed)
+                                 Filter: (device_id_peer < device_id)
+         ->  Merge Append (never executed)
+               Sort Key: _hyper_2_10_chunk."time", _hyper_2_10_chunk.device_id
+               ->  Sort (never executed)
+                     Sort Key: _hyper_2_10_chunk."time", _hyper_2_10_chunk.device_id
+                     ->  Custom Scan (DecompressChunk) on _hyper_2_10_chunk (never executed)
+                           ->  Seq Scan on compress_hyper_6_20_chunk (never executed)
+                                 Filter: (device_id_peer < device_id)
+               ->  Sort (never executed)
+                     Sort Key: _hyper_2_11_chunk."time", _hyper_2_11_chunk.device_id
+                     ->  Custom Scan (DecompressChunk) on _hyper_2_11_chunk (never executed)
+                           ->  Seq Scan on compress_hyper_6_21_chunk (never executed)
+                                 Filter: (device_id_peer < device_id)
+               ->  Sort (never executed)
+                     Sort Key: _hyper_2_12_chunk."time", _hyper_2_12_chunk.device_id
+                     ->  Sort (never executed)
+                           Sort Key: _hyper_2_12_chunk."time", _hyper_2_12_chunk.device_id
+                           ->  Seq Scan on _hyper_2_12_chunk (never executed)
+                                 Filter: (device_id_peer < device_id)
+(61 rows)
 
 -- test expressions
 :PREFIX
@@ -4082,32 +4022,23 @@ LIMIT 10;
                ->  Sort (actual rows=0 loops=1)
                      Sort Key: _hyper_2_4_chunk."time"
                      Sort Method: quicksort 
-                     ->  Sort (actual rows=0 loops=1)
-                           Sort Key: _hyper_2_4_chunk."time"
-                           Sort Method: quicksort 
-                           ->  Custom Scan (DecompressChunk) on _hyper_2_4_chunk (actual rows=0 loops=1)
-                                 Filter: (device_id = length("substring"(version(), 1, 3)))
-                                 Rows Removed by Filter: 360
-                                 ->  Seq Scan on compress_hyper_6_17_chunk (actual rows=1 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_2_4_chunk (actual rows=0 loops=1)
+                           Filter: (device_id = length("substring"(version(), 1, 3)))
+                           Rows Removed by Filter: 360
+                           ->  Seq Scan on compress_hyper_6_17_chunk (actual rows=1 loops=1)
                ->  Sort (actual rows=0 loops=1)
                      Sort Key: _hyper_2_5_chunk."time"
                      Sort Method: quicksort 
-                     ->  Sort (actual rows=0 loops=1)
-                           Sort Key: _hyper_2_5_chunk."time"
-                           Sort Method: quicksort 
-                           ->  Custom Scan (DecompressChunk) on _hyper_2_5_chunk (actual rows=0 loops=1)
-                                 Filter: (device_id = length("substring"(version(), 1, 3)))
-                                 Rows Removed by Filter: 1080
-                                 ->  Seq Scan on compress_hyper_6_18_chunk (actual rows=3 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_2_5_chunk (actual rows=0 loops=1)
+                           Filter: (device_id = length("substring"(version(), 1, 3)))
+                           Rows Removed by Filter: 1080
+                           ->  Seq Scan on compress_hyper_6_18_chunk (actual rows=3 loops=1)
                ->  Sort (actual rows=10 loops=1)
                      Sort Key: _hyper_2_6_chunk."time"
                      Sort Method: top-N heapsort 
-                     ->  Sort (actual rows=360 loops=1)
-                           Sort Key: _hyper_2_6_chunk."time"
-                           Sort Method: quicksort 
-                           ->  Custom Scan (DecompressChunk) on _hyper_2_6_chunk (actual rows=360 loops=1)
-                                 Filter: (device_id = length("substring"(version(), 1, 3)))
-                                 ->  Seq Scan on compress_hyper_6_19_chunk (actual rows=1 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_2_6_chunk (actual rows=360 loops=1)
+                           Filter: (device_id = length("substring"(version(), 1, 3)))
+                           ->  Seq Scan on compress_hyper_6_19_chunk (actual rows=1 loops=1)
          ->  Merge Append (never executed)
                Sort Key: _hyper_2_7_chunk."time"
                ->  Index Scan Backward using _hyper_2_7_chunk_metrics_space_device_id_time_idx on _hyper_2_7_chunk (never executed)
@@ -4120,21 +4051,17 @@ LIMIT 10;
                Sort Key: _hyper_2_10_chunk."time"
                ->  Sort (never executed)
                      Sort Key: _hyper_2_10_chunk."time"
-                     ->  Sort (never executed)
-                           Sort Key: _hyper_2_10_chunk."time"
-                           ->  Custom Scan (DecompressChunk) on _hyper_2_10_chunk (never executed)
-                                 Filter: (device_id = length("substring"(version(), 1, 3)))
-                                 ->  Seq Scan on compress_hyper_6_20_chunk (never executed)
+                     ->  Custom Scan (DecompressChunk) on _hyper_2_10_chunk (never executed)
+                           Filter: (device_id = length("substring"(version(), 1, 3)))
+                           ->  Seq Scan on compress_hyper_6_20_chunk (never executed)
                ->  Sort (never executed)
                      Sort Key: _hyper_2_11_chunk."time"
-                     ->  Sort (never executed)
-                           Sort Key: _hyper_2_11_chunk."time"
-                           ->  Custom Scan (DecompressChunk) on _hyper_2_11_chunk (never executed)
-                                 Filter: (device_id = length("substring"(version(), 1, 3)))
-                                 ->  Seq Scan on compress_hyper_6_21_chunk (never executed)
+                     ->  Custom Scan (DecompressChunk) on _hyper_2_11_chunk (never executed)
+                           Filter: (device_id = length("substring"(version(), 1, 3)))
+                           ->  Seq Scan on compress_hyper_6_21_chunk (never executed)
                ->  Index Scan Backward using _hyper_2_12_chunk_metrics_space_device_id_time_idx on _hyper_2_12_chunk (never executed)
                      Index Cond: (device_id = length("substring"(version(), 1, 3)))
-(60 rows)
+(47 rows)
 
 --
 -- test segment meta pushdown
@@ -4185,29 +4112,38 @@ WHERE time < '2000-01-01 1:00:00+0'
 ORDER BY time,
     device_id
 LIMIT 10;
-                                                  QUERY PLAN                                                   
----------------------------------------------------------------------------------------------------------------
+                                                     QUERY PLAN                                                      
+---------------------------------------------------------------------------------------------------------------------
  Limit (actual rows=10 loops=1)
-   ->  Sort (actual rows=10 loops=1)
-         Sort Key: _hyper_2_4_chunk."time", _hyper_2_4_chunk.device_id
-         Sort Method: quicksort 
-         ->  Append (actual rows=15 loops=1)
-               ->  Custom Scan (DecompressChunk) on _hyper_2_4_chunk (actual rows=3 loops=1)
-                     Vectorized Filter: ("time" < 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
-                     Rows Removed by Filter: 357
-                     ->  Seq Scan on compress_hyper_6_17_chunk (actual rows=1 loops=1)
-                           Filter: (_ts_meta_min_3 < 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
-               ->  Custom Scan (DecompressChunk) on _hyper_2_5_chunk (actual rows=9 loops=1)
-                     Vectorized Filter: ("time" < 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
-                     Rows Removed by Filter: 1071
-                     ->  Seq Scan on compress_hyper_6_18_chunk (actual rows=3 loops=1)
-                           Filter: (_ts_meta_min_3 < 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
-               ->  Custom Scan (DecompressChunk) on _hyper_2_6_chunk (actual rows=3 loops=1)
-                     Vectorized Filter: ("time" < 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
-                     Rows Removed by Filter: 357
-                     ->  Seq Scan on compress_hyper_6_19_chunk (actual rows=1 loops=1)
-                           Filter: (_ts_meta_min_3 < 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
-(20 rows)
+   ->  Custom Scan (ChunkAppend) on metrics_space (actual rows=10 loops=1)
+         Order: metrics_space."time", metrics_space.device_id
+         ->  Merge Append (actual rows=10 loops=1)
+               Sort Key: _hyper_2_4_chunk."time", _hyper_2_4_chunk.device_id
+               ->  Sort (actual rows=3 loops=1)
+                     Sort Key: _hyper_2_4_chunk."time", _hyper_2_4_chunk.device_id
+                     Sort Method: quicksort 
+                     ->  Custom Scan (DecompressChunk) on _hyper_2_4_chunk (actual rows=3 loops=1)
+                           Vectorized Filter: ("time" < 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
+                           Rows Removed by Filter: 357
+                           ->  Seq Scan on compress_hyper_6_17_chunk (actual rows=1 loops=1)
+                                 Filter: (_ts_meta_min_3 < 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
+               ->  Sort (actual rows=6 loops=1)
+                     Sort Key: _hyper_2_5_chunk."time", _hyper_2_5_chunk.device_id
+                     Sort Method: quicksort 
+                     ->  Custom Scan (DecompressChunk) on _hyper_2_5_chunk (actual rows=9 loops=1)
+                           Vectorized Filter: ("time" < 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
+                           Rows Removed by Filter: 1071
+                           ->  Seq Scan on compress_hyper_6_18_chunk (actual rows=3 loops=1)
+                                 Filter: (_ts_meta_min_3 < 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
+               ->  Sort (actual rows=3 loops=1)
+                     Sort Key: _hyper_2_6_chunk."time", _hyper_2_6_chunk.device_id
+                     Sort Method: quicksort 
+                     ->  Custom Scan (DecompressChunk) on _hyper_2_6_chunk (actual rows=3 loops=1)
+                           Vectorized Filter: ("time" < 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
+                           Rows Removed by Filter: 357
+                           ->  Seq Scan on compress_hyper_6_19_chunk (actual rows=1 loops=1)
+                                 Filter: (_ts_meta_min_3 < 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
+(29 rows)
 
 :PREFIX
 SELECT *
@@ -4216,29 +4152,38 @@ WHERE time <= '2000-01-01 1:00:00+0'
 ORDER BY time,
     device_id
 LIMIT 10;
-                                                   QUERY PLAN                                                   
-----------------------------------------------------------------------------------------------------------------
+                                                      QUERY PLAN                                                      
+----------------------------------------------------------------------------------------------------------------------
  Limit (actual rows=10 loops=1)
-   ->  Sort (actual rows=10 loops=1)
-         Sort Key: _hyper_2_4_chunk."time", _hyper_2_4_chunk.device_id
-         Sort Method: quicksort 
-         ->  Append (actual rows=20 loops=1)
-               ->  Custom Scan (DecompressChunk) on _hyper_2_4_chunk (actual rows=4 loops=1)
-                     Vectorized Filter: ("time" <= 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
-                     Rows Removed by Filter: 356
-                     ->  Seq Scan on compress_hyper_6_17_chunk (actual rows=1 loops=1)
-                           Filter: (_ts_meta_min_3 <= 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
-               ->  Custom Scan (DecompressChunk) on _hyper_2_5_chunk (actual rows=12 loops=1)
-                     Vectorized Filter: ("time" <= 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
-                     Rows Removed by Filter: 1068
-                     ->  Seq Scan on compress_hyper_6_18_chunk (actual rows=3 loops=1)
-                           Filter: (_ts_meta_min_3 <= 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
-               ->  Custom Scan (DecompressChunk) on _hyper_2_6_chunk (actual rows=4 loops=1)
-                     Vectorized Filter: ("time" <= 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
-                     Rows Removed by Filter: 356
-                     ->  Seq Scan on compress_hyper_6_19_chunk (actual rows=1 loops=1)
-                           Filter: (_ts_meta_min_3 <= 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
-(20 rows)
+   ->  Custom Scan (ChunkAppend) on metrics_space (actual rows=10 loops=1)
+         Order: metrics_space."time", metrics_space.device_id
+         ->  Merge Append (actual rows=10 loops=1)
+               Sort Key: _hyper_2_4_chunk."time", _hyper_2_4_chunk.device_id
+               ->  Sort (actual rows=3 loops=1)
+                     Sort Key: _hyper_2_4_chunk."time", _hyper_2_4_chunk.device_id
+                     Sort Method: quicksort 
+                     ->  Custom Scan (DecompressChunk) on _hyper_2_4_chunk (actual rows=4 loops=1)
+                           Vectorized Filter: ("time" <= 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
+                           Rows Removed by Filter: 356
+                           ->  Seq Scan on compress_hyper_6_17_chunk (actual rows=1 loops=1)
+                                 Filter: (_ts_meta_min_3 <= 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
+               ->  Sort (actual rows=6 loops=1)
+                     Sort Key: _hyper_2_5_chunk."time", _hyper_2_5_chunk.device_id
+                     Sort Method: quicksort 
+                     ->  Custom Scan (DecompressChunk) on _hyper_2_5_chunk (actual rows=12 loops=1)
+                           Vectorized Filter: ("time" <= 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
+                           Rows Removed by Filter: 1068
+                           ->  Seq Scan on compress_hyper_6_18_chunk (actual rows=3 loops=1)
+                                 Filter: (_ts_meta_min_3 <= 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
+               ->  Sort (actual rows=3 loops=1)
+                     Sort Key: _hyper_2_6_chunk."time", _hyper_2_6_chunk.device_id
+                     Sort Method: quicksort 
+                     ->  Custom Scan (DecompressChunk) on _hyper_2_6_chunk (actual rows=4 loops=1)
+                           Vectorized Filter: ("time" <= 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
+                           Rows Removed by Filter: 356
+                           ->  Seq Scan on compress_hyper_6_19_chunk (actual rows=1 loops=1)
+                                 Filter: (_ts_meta_min_3 <= 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
+(29 rows)
 
 :PREFIX
 SELECT *
@@ -4247,79 +4192,78 @@ WHERE time >= '2000-01-01 1:00:00+0'
 ORDER BY time,
     device_id
 LIMIT 10;
-                                                            QUERY PLAN                                                            
-----------------------------------------------------------------------------------------------------------------------------------
+                                                      QUERY PLAN                                                      
+----------------------------------------------------------------------------------------------------------------------
  Limit (actual rows=10 loops=1)
-   ->  Incremental Sort (actual rows=10 loops=1)
-         Sort Key: metrics_space."time", metrics_space.device_id
-         Presorted Key: metrics_space."time"
-         Full-sort Groups: 1  Sort Method: quicksort 
-         ->  Custom Scan (ChunkAppend) on metrics_space (actual rows=11 loops=1)
-               Order: metrics_space."time"
-               ->  Merge Append (actual rows=11 loops=1)
-                     Sort Key: _hyper_2_4_chunk."time"
-                     ->  Sort (actual rows=3 loops=1)
-                           Sort Key: _hyper_2_4_chunk."time"
-                           Sort Method: quicksort 
-                           ->  Sort (actual rows=357 loops=1)
-                                 Sort Key: _hyper_2_4_chunk."time"
-                                 Sort Method: quicksort 
-                                 ->  Custom Scan (DecompressChunk) on _hyper_2_4_chunk (actual rows=357 loops=1)
-                                       Vectorized Filter: ("time" >= 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
-                                       Rows Removed by Filter: 3
-                                       ->  Seq Scan on compress_hyper_6_17_chunk (actual rows=1 loops=1)
-                                             Filter: (_ts_meta_max_3 >= 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
-                     ->  Sort (actual rows=7 loops=1)
-                           Sort Key: _hyper_2_5_chunk."time"
-                           Sort Method: quicksort 
-                           ->  Sort (actual rows=1071 loops=1)
-                                 Sort Key: _hyper_2_5_chunk."time"
-                                 Sort Method: quicksort 
-                                 ->  Custom Scan (DecompressChunk) on _hyper_2_5_chunk (actual rows=1071 loops=1)
-                                       Vectorized Filter: ("time" >= 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
-                                       Rows Removed by Filter: 9
-                                       ->  Seq Scan on compress_hyper_6_18_chunk (actual rows=3 loops=1)
-                                             Filter: (_ts_meta_max_3 >= 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
-                     ->  Sort (actual rows=3 loops=1)
-                           Sort Key: _hyper_2_6_chunk."time"
-                           Sort Method: quicksort 
-                           ->  Sort (actual rows=357 loops=1)
-                                 Sort Key: _hyper_2_6_chunk."time"
-                                 Sort Method: quicksort 
-                                 ->  Custom Scan (DecompressChunk) on _hyper_2_6_chunk (actual rows=357 loops=1)
-                                       Vectorized Filter: ("time" >= 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
-                                       Rows Removed by Filter: 3
-                                       ->  Seq Scan on compress_hyper_6_19_chunk (actual rows=1 loops=1)
-                                             Filter: (_ts_meta_max_3 >= 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
-               ->  Merge Append (never executed)
-                     Sort Key: _hyper_2_7_chunk."time"
-                     ->  Index Scan Backward using _hyper_2_7_chunk_metrics_space_time_idx on _hyper_2_7_chunk (never executed)
-                           Index Cond: ("time" >= 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
-                     ->  Index Scan Backward using _hyper_2_8_chunk_metrics_space_time_idx on _hyper_2_8_chunk (never executed)
-                           Index Cond: ("time" >= 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
-                     ->  Index Scan Backward using _hyper_2_9_chunk_metrics_space_time_idx on _hyper_2_9_chunk (never executed)
-                           Index Cond: ("time" >= 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
-               ->  Merge Append (never executed)
-                     Sort Key: _hyper_2_10_chunk."time"
+   ->  Custom Scan (ChunkAppend) on metrics_space (actual rows=10 loops=1)
+         Order: metrics_space."time", metrics_space.device_id
+         ->  Merge Append (actual rows=10 loops=1)
+               Sort Key: _hyper_2_4_chunk."time", _hyper_2_4_chunk.device_id
+               ->  Sort (actual rows=3 loops=1)
+                     Sort Key: _hyper_2_4_chunk."time", _hyper_2_4_chunk.device_id
+                     Sort Method: top-N heapsort 
+                     ->  Custom Scan (DecompressChunk) on _hyper_2_4_chunk (actual rows=357 loops=1)
+                           Vectorized Filter: ("time" >= 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
+                           Rows Removed by Filter: 3
+                           ->  Seq Scan on compress_hyper_6_17_chunk (actual rows=1 loops=1)
+                                 Filter: (_ts_meta_max_3 >= 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
+               ->  Sort (actual rows=6 loops=1)
+                     Sort Key: _hyper_2_5_chunk."time", _hyper_2_5_chunk.device_id
+                     Sort Method: top-N heapsort 
+                     ->  Custom Scan (DecompressChunk) on _hyper_2_5_chunk (actual rows=1071 loops=1)
+                           Vectorized Filter: ("time" >= 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
+                           Rows Removed by Filter: 9
+                           ->  Seq Scan on compress_hyper_6_18_chunk (actual rows=3 loops=1)
+                                 Filter: (_ts_meta_max_3 >= 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
+               ->  Sort (actual rows=3 loops=1)
+                     Sort Key: _hyper_2_6_chunk."time", _hyper_2_6_chunk.device_id
+                     Sort Method: top-N heapsort 
+                     ->  Custom Scan (DecompressChunk) on _hyper_2_6_chunk (actual rows=357 loops=1)
+                           Vectorized Filter: ("time" >= 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
+                           Rows Removed by Filter: 3
+                           ->  Seq Scan on compress_hyper_6_19_chunk (actual rows=1 loops=1)
+                                 Filter: (_ts_meta_max_3 >= 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
+         ->  Merge Append (never executed)
+               Sort Key: _hyper_2_7_chunk."time", _hyper_2_7_chunk.device_id
+               ->  Sort (never executed)
+                     Sort Key: _hyper_2_7_chunk."time", _hyper_2_7_chunk.device_id
                      ->  Sort (never executed)
-                           Sort Key: _hyper_2_10_chunk."time"
-                           ->  Sort (never executed)
-                                 Sort Key: _hyper_2_10_chunk."time"
-                                 ->  Custom Scan (DecompressChunk) on _hyper_2_10_chunk (never executed)
-                                       Vectorized Filter: ("time" >= 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
-                                       ->  Seq Scan on compress_hyper_6_20_chunk (never executed)
-                                             Filter: (_ts_meta_max_3 >= 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
+                           Sort Key: _hyper_2_7_chunk."time", _hyper_2_7_chunk.device_id
+                           ->  Seq Scan on _hyper_2_7_chunk (never executed)
+                                 Filter: ("time" >= 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
+               ->  Sort (never executed)
+                     Sort Key: _hyper_2_8_chunk."time", _hyper_2_8_chunk.device_id
                      ->  Sort (never executed)
-                           Sort Key: _hyper_2_11_chunk."time"
-                           ->  Sort (never executed)
-                                 Sort Key: _hyper_2_11_chunk."time"
-                                 ->  Custom Scan (DecompressChunk) on _hyper_2_11_chunk (never executed)
-                                       Vectorized Filter: ("time" >= 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
-                                       ->  Seq Scan on compress_hyper_6_21_chunk (never executed)
-                                             Filter: (_ts_meta_max_3 >= 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
-                     ->  Index Scan Backward using _hyper_2_12_chunk_metrics_space_time_idx on _hyper_2_12_chunk (never executed)
-                           Index Cond: ("time" >= 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
-(70 rows)
+                           Sort Key: _hyper_2_8_chunk."time", _hyper_2_8_chunk.device_id
+                           ->  Seq Scan on _hyper_2_8_chunk (never executed)
+                                 Filter: ("time" >= 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
+               ->  Sort (never executed)
+                     Sort Key: _hyper_2_9_chunk."time", _hyper_2_9_chunk.device_id
+                     ->  Sort (never executed)
+                           Sort Key: _hyper_2_9_chunk."time", _hyper_2_9_chunk.device_id
+                           ->  Seq Scan on _hyper_2_9_chunk (never executed)
+                                 Filter: ("time" >= 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
+         ->  Merge Append (never executed)
+               Sort Key: _hyper_2_10_chunk."time", _hyper_2_10_chunk.device_id
+               ->  Sort (never executed)
+                     Sort Key: _hyper_2_10_chunk."time", _hyper_2_10_chunk.device_id
+                     ->  Custom Scan (DecompressChunk) on _hyper_2_10_chunk (never executed)
+                           Vectorized Filter: ("time" >= 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
+                           ->  Seq Scan on compress_hyper_6_20_chunk (never executed)
+                                 Filter: (_ts_meta_max_3 >= 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
+               ->  Sort (never executed)
+                     Sort Key: _hyper_2_11_chunk."time", _hyper_2_11_chunk.device_id
+                     ->  Custom Scan (DecompressChunk) on _hyper_2_11_chunk (never executed)
+                           Vectorized Filter: ("time" >= 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
+                           ->  Seq Scan on compress_hyper_6_21_chunk (never executed)
+                                 Filter: (_ts_meta_max_3 >= 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
+               ->  Sort (never executed)
+                     Sort Key: _hyper_2_12_chunk."time", _hyper_2_12_chunk.device_id
+                     ->  Sort (never executed)
+                           Sort Key: _hyper_2_12_chunk."time", _hyper_2_12_chunk.device_id
+                           ->  Seq Scan on _hyper_2_12_chunk (never executed)
+                                 Filter: ("time" >= 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
+(69 rows)
 
 :PREFIX
 SELECT *
@@ -4328,79 +4272,78 @@ WHERE time > '2000-01-01 1:00:00+0'
 ORDER BY time,
     device_id
 LIMIT 10;
-                                                            QUERY PLAN                                                            
-----------------------------------------------------------------------------------------------------------------------------------
+                                                     QUERY PLAN                                                      
+---------------------------------------------------------------------------------------------------------------------
  Limit (actual rows=10 loops=1)
-   ->  Incremental Sort (actual rows=10 loops=1)
-         Sort Key: metrics_space."time", metrics_space.device_id
-         Presorted Key: metrics_space."time"
-         Full-sort Groups: 1  Sort Method: quicksort 
-         ->  Custom Scan (ChunkAppend) on metrics_space (actual rows=11 loops=1)
-               Order: metrics_space."time"
-               ->  Merge Append (actual rows=11 loops=1)
-                     Sort Key: _hyper_2_4_chunk."time"
-                     ->  Sort (actual rows=3 loops=1)
-                           Sort Key: _hyper_2_4_chunk."time"
-                           Sort Method: quicksort 
-                           ->  Sort (actual rows=356 loops=1)
-                                 Sort Key: _hyper_2_4_chunk."time"
-                                 Sort Method: quicksort 
-                                 ->  Custom Scan (DecompressChunk) on _hyper_2_4_chunk (actual rows=356 loops=1)
-                                       Vectorized Filter: ("time" > 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
-                                       Rows Removed by Filter: 4
-                                       ->  Seq Scan on compress_hyper_6_17_chunk (actual rows=1 loops=1)
-                                             Filter: (_ts_meta_max_3 > 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
-                     ->  Sort (actual rows=7 loops=1)
-                           Sort Key: _hyper_2_5_chunk."time"
-                           Sort Method: quicksort 
-                           ->  Sort (actual rows=1068 loops=1)
-                                 Sort Key: _hyper_2_5_chunk."time"
-                                 Sort Method: quicksort 
-                                 ->  Custom Scan (DecompressChunk) on _hyper_2_5_chunk (actual rows=1068 loops=1)
-                                       Vectorized Filter: ("time" > 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
-                                       Rows Removed by Filter: 12
-                                       ->  Seq Scan on compress_hyper_6_18_chunk (actual rows=3 loops=1)
-                                             Filter: (_ts_meta_max_3 > 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
-                     ->  Sort (actual rows=3 loops=1)
-                           Sort Key: _hyper_2_6_chunk."time"
-                           Sort Method: quicksort 
-                           ->  Sort (actual rows=356 loops=1)
-                                 Sort Key: _hyper_2_6_chunk."time"
-                                 Sort Method: quicksort 
-                                 ->  Custom Scan (DecompressChunk) on _hyper_2_6_chunk (actual rows=356 loops=1)
-                                       Vectorized Filter: ("time" > 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
-                                       Rows Removed by Filter: 4
-                                       ->  Seq Scan on compress_hyper_6_19_chunk (actual rows=1 loops=1)
-                                             Filter: (_ts_meta_max_3 > 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
-               ->  Merge Append (never executed)
-                     Sort Key: _hyper_2_7_chunk."time"
-                     ->  Index Scan Backward using _hyper_2_7_chunk_metrics_space_time_idx on _hyper_2_7_chunk (never executed)
-                           Index Cond: ("time" > 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
-                     ->  Index Scan Backward using _hyper_2_8_chunk_metrics_space_time_idx on _hyper_2_8_chunk (never executed)
-                           Index Cond: ("time" > 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
-                     ->  Index Scan Backward using _hyper_2_9_chunk_metrics_space_time_idx on _hyper_2_9_chunk (never executed)
-                           Index Cond: ("time" > 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
-               ->  Merge Append (never executed)
-                     Sort Key: _hyper_2_10_chunk."time"
+   ->  Custom Scan (ChunkAppend) on metrics_space (actual rows=10 loops=1)
+         Order: metrics_space."time", metrics_space.device_id
+         ->  Merge Append (actual rows=10 loops=1)
+               Sort Key: _hyper_2_4_chunk."time", _hyper_2_4_chunk.device_id
+               ->  Sort (actual rows=3 loops=1)
+                     Sort Key: _hyper_2_4_chunk."time", _hyper_2_4_chunk.device_id
+                     Sort Method: top-N heapsort 
+                     ->  Custom Scan (DecompressChunk) on _hyper_2_4_chunk (actual rows=356 loops=1)
+                           Vectorized Filter: ("time" > 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
+                           Rows Removed by Filter: 4
+                           ->  Seq Scan on compress_hyper_6_17_chunk (actual rows=1 loops=1)
+                                 Filter: (_ts_meta_max_3 > 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
+               ->  Sort (actual rows=6 loops=1)
+                     Sort Key: _hyper_2_5_chunk."time", _hyper_2_5_chunk.device_id
+                     Sort Method: top-N heapsort 
+                     ->  Custom Scan (DecompressChunk) on _hyper_2_5_chunk (actual rows=1068 loops=1)
+                           Vectorized Filter: ("time" > 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
+                           Rows Removed by Filter: 12
+                           ->  Seq Scan on compress_hyper_6_18_chunk (actual rows=3 loops=1)
+                                 Filter: (_ts_meta_max_3 > 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
+               ->  Sort (actual rows=3 loops=1)
+                     Sort Key: _hyper_2_6_chunk."time", _hyper_2_6_chunk.device_id
+                     Sort Method: top-N heapsort 
+                     ->  Custom Scan (DecompressChunk) on _hyper_2_6_chunk (actual rows=356 loops=1)
+                           Vectorized Filter: ("time" > 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
+                           Rows Removed by Filter: 4
+                           ->  Seq Scan on compress_hyper_6_19_chunk (actual rows=1 loops=1)
+                                 Filter: (_ts_meta_max_3 > 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
+         ->  Merge Append (never executed)
+               Sort Key: _hyper_2_7_chunk."time", _hyper_2_7_chunk.device_id
+               ->  Sort (never executed)
+                     Sort Key: _hyper_2_7_chunk."time", _hyper_2_7_chunk.device_id
                      ->  Sort (never executed)
-                           Sort Key: _hyper_2_10_chunk."time"
-                           ->  Sort (never executed)
-                                 Sort Key: _hyper_2_10_chunk."time"
-                                 ->  Custom Scan (DecompressChunk) on _hyper_2_10_chunk (never executed)
-                                       Vectorized Filter: ("time" > 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
-                                       ->  Seq Scan on compress_hyper_6_20_chunk (never executed)
-                                             Filter: (_ts_meta_max_3 > 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
+                           Sort Key: _hyper_2_7_chunk."time", _hyper_2_7_chunk.device_id
+                           ->  Seq Scan on _hyper_2_7_chunk (never executed)
+                                 Filter: ("time" > 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
+               ->  Sort (never executed)
+                     Sort Key: _hyper_2_8_chunk."time", _hyper_2_8_chunk.device_id
                      ->  Sort (never executed)
-                           Sort Key: _hyper_2_11_chunk."time"
-                           ->  Sort (never executed)
-                                 Sort Key: _hyper_2_11_chunk."time"
-                                 ->  Custom Scan (DecompressChunk) on _hyper_2_11_chunk (never executed)
-                                       Vectorized Filter: ("time" > 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
-                                       ->  Seq Scan on compress_hyper_6_21_chunk (never executed)
-                                             Filter: (_ts_meta_max_3 > 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
-                     ->  Index Scan Backward using _hyper_2_12_chunk_metrics_space_time_idx on _hyper_2_12_chunk (never executed)
-                           Index Cond: ("time" > 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
-(70 rows)
+                           Sort Key: _hyper_2_8_chunk."time", _hyper_2_8_chunk.device_id
+                           ->  Seq Scan on _hyper_2_8_chunk (never executed)
+                                 Filter: ("time" > 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
+               ->  Sort (never executed)
+                     Sort Key: _hyper_2_9_chunk."time", _hyper_2_9_chunk.device_id
+                     ->  Sort (never executed)
+                           Sort Key: _hyper_2_9_chunk."time", _hyper_2_9_chunk.device_id
+                           ->  Seq Scan on _hyper_2_9_chunk (never executed)
+                                 Filter: ("time" > 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
+         ->  Merge Append (never executed)
+               Sort Key: _hyper_2_10_chunk."time", _hyper_2_10_chunk.device_id
+               ->  Sort (never executed)
+                     Sort Key: _hyper_2_10_chunk."time", _hyper_2_10_chunk.device_id
+                     ->  Custom Scan (DecompressChunk) on _hyper_2_10_chunk (never executed)
+                           Vectorized Filter: ("time" > 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
+                           ->  Seq Scan on compress_hyper_6_20_chunk (never executed)
+                                 Filter: (_ts_meta_max_3 > 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
+               ->  Sort (never executed)
+                     Sort Key: _hyper_2_11_chunk."time", _hyper_2_11_chunk.device_id
+                     ->  Custom Scan (DecompressChunk) on _hyper_2_11_chunk (never executed)
+                           Vectorized Filter: ("time" > 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
+                           ->  Seq Scan on compress_hyper_6_21_chunk (never executed)
+                                 Filter: (_ts_meta_max_3 > 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
+               ->  Sort (never executed)
+                     Sort Key: _hyper_2_12_chunk."time", _hyper_2_12_chunk.device_id
+                     ->  Sort (never executed)
+                           Sort Key: _hyper_2_12_chunk."time", _hyper_2_12_chunk.device_id
+                           ->  Seq Scan on _hyper_2_12_chunk (never executed)
+                                 Filter: ("time" > 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
+(69 rows)
 
 :PREFIX
 SELECT *
@@ -4409,79 +4352,78 @@ WHERE '2000-01-01 1:00:00+0' < time
 ORDER BY time,
     device_id
 LIMIT 10;
-                                                            QUERY PLAN                                                            
-----------------------------------------------------------------------------------------------------------------------------------
+                                                     QUERY PLAN                                                      
+---------------------------------------------------------------------------------------------------------------------
  Limit (actual rows=10 loops=1)
-   ->  Incremental Sort (actual rows=10 loops=1)
-         Sort Key: metrics_space."time", metrics_space.device_id
-         Presorted Key: metrics_space."time"
-         Full-sort Groups: 1  Sort Method: quicksort 
-         ->  Custom Scan (ChunkAppend) on metrics_space (actual rows=11 loops=1)
-               Order: metrics_space."time"
-               ->  Merge Append (actual rows=11 loops=1)
-                     Sort Key: _hyper_2_4_chunk."time"
-                     ->  Sort (actual rows=3 loops=1)
-                           Sort Key: _hyper_2_4_chunk."time"
-                           Sort Method: quicksort 
-                           ->  Sort (actual rows=356 loops=1)
-                                 Sort Key: _hyper_2_4_chunk."time"
-                                 Sort Method: quicksort 
-                                 ->  Custom Scan (DecompressChunk) on _hyper_2_4_chunk (actual rows=356 loops=1)
-                                       Vectorized Filter: ("time" > 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
-                                       Rows Removed by Filter: 4
-                                       ->  Seq Scan on compress_hyper_6_17_chunk (actual rows=1 loops=1)
-                                             Filter: (_ts_meta_max_3 > 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
-                     ->  Sort (actual rows=7 loops=1)
-                           Sort Key: _hyper_2_5_chunk."time"
-                           Sort Method: quicksort 
-                           ->  Sort (actual rows=1068 loops=1)
-                                 Sort Key: _hyper_2_5_chunk."time"
-                                 Sort Method: quicksort 
-                                 ->  Custom Scan (DecompressChunk) on _hyper_2_5_chunk (actual rows=1068 loops=1)
-                                       Vectorized Filter: ("time" > 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
-                                       Rows Removed by Filter: 12
-                                       ->  Seq Scan on compress_hyper_6_18_chunk (actual rows=3 loops=1)
-                                             Filter: (_ts_meta_max_3 > 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
-                     ->  Sort (actual rows=3 loops=1)
-                           Sort Key: _hyper_2_6_chunk."time"
-                           Sort Method: quicksort 
-                           ->  Sort (actual rows=356 loops=1)
-                                 Sort Key: _hyper_2_6_chunk."time"
-                                 Sort Method: quicksort 
-                                 ->  Custom Scan (DecompressChunk) on _hyper_2_6_chunk (actual rows=356 loops=1)
-                                       Vectorized Filter: ("time" > 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
-                                       Rows Removed by Filter: 4
-                                       ->  Seq Scan on compress_hyper_6_19_chunk (actual rows=1 loops=1)
-                                             Filter: (_ts_meta_max_3 > 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
-               ->  Merge Append (never executed)
-                     Sort Key: _hyper_2_7_chunk."time"
-                     ->  Index Scan Backward using _hyper_2_7_chunk_metrics_space_time_idx on _hyper_2_7_chunk (never executed)
-                           Index Cond: ("time" > 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
-                     ->  Index Scan Backward using _hyper_2_8_chunk_metrics_space_time_idx on _hyper_2_8_chunk (never executed)
-                           Index Cond: ("time" > 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
-                     ->  Index Scan Backward using _hyper_2_9_chunk_metrics_space_time_idx on _hyper_2_9_chunk (never executed)
-                           Index Cond: ("time" > 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
-               ->  Merge Append (never executed)
-                     Sort Key: _hyper_2_10_chunk."time"
+   ->  Custom Scan (ChunkAppend) on metrics_space (actual rows=10 loops=1)
+         Order: metrics_space."time", metrics_space.device_id
+         ->  Merge Append (actual rows=10 loops=1)
+               Sort Key: _hyper_2_4_chunk."time", _hyper_2_4_chunk.device_id
+               ->  Sort (actual rows=3 loops=1)
+                     Sort Key: _hyper_2_4_chunk."time", _hyper_2_4_chunk.device_id
+                     Sort Method: top-N heapsort 
+                     ->  Custom Scan (DecompressChunk) on _hyper_2_4_chunk (actual rows=356 loops=1)
+                           Vectorized Filter: ("time" > 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
+                           Rows Removed by Filter: 4
+                           ->  Seq Scan on compress_hyper_6_17_chunk (actual rows=1 loops=1)
+                                 Filter: (_ts_meta_max_3 > 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
+               ->  Sort (actual rows=6 loops=1)
+                     Sort Key: _hyper_2_5_chunk."time", _hyper_2_5_chunk.device_id
+                     Sort Method: top-N heapsort 
+                     ->  Custom Scan (DecompressChunk) on _hyper_2_5_chunk (actual rows=1068 loops=1)
+                           Vectorized Filter: ("time" > 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
+                           Rows Removed by Filter: 12
+                           ->  Seq Scan on compress_hyper_6_18_chunk (actual rows=3 loops=1)
+                                 Filter: (_ts_meta_max_3 > 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
+               ->  Sort (actual rows=3 loops=1)
+                     Sort Key: _hyper_2_6_chunk."time", _hyper_2_6_chunk.device_id
+                     Sort Method: top-N heapsort 
+                     ->  Custom Scan (DecompressChunk) on _hyper_2_6_chunk (actual rows=356 loops=1)
+                           Vectorized Filter: ("time" > 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
+                           Rows Removed by Filter: 4
+                           ->  Seq Scan on compress_hyper_6_19_chunk (actual rows=1 loops=1)
+                                 Filter: (_ts_meta_max_3 > 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
+         ->  Merge Append (never executed)
+               Sort Key: _hyper_2_7_chunk."time", _hyper_2_7_chunk.device_id
+               ->  Sort (never executed)
+                     Sort Key: _hyper_2_7_chunk."time", _hyper_2_7_chunk.device_id
                      ->  Sort (never executed)
-                           Sort Key: _hyper_2_10_chunk."time"
-                           ->  Sort (never executed)
-                                 Sort Key: _hyper_2_10_chunk."time"
-                                 ->  Custom Scan (DecompressChunk) on _hyper_2_10_chunk (never executed)
-                                       Vectorized Filter: ("time" > 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
-                                       ->  Seq Scan on compress_hyper_6_20_chunk (never executed)
-                                             Filter: (_ts_meta_max_3 > 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
+                           Sort Key: _hyper_2_7_chunk."time", _hyper_2_7_chunk.device_id
+                           ->  Seq Scan on _hyper_2_7_chunk (never executed)
+                                 Filter: ('Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone < "time")
+               ->  Sort (never executed)
+                     Sort Key: _hyper_2_8_chunk."time", _hyper_2_8_chunk.device_id
                      ->  Sort (never executed)
-                           Sort Key: _hyper_2_11_chunk."time"
-                           ->  Sort (never executed)
-                                 Sort Key: _hyper_2_11_chunk."time"
-                                 ->  Custom Scan (DecompressChunk) on _hyper_2_11_chunk (never executed)
-                                       Vectorized Filter: ("time" > 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
-                                       ->  Seq Scan on compress_hyper_6_21_chunk (never executed)
-                                             Filter: (_ts_meta_max_3 > 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
-                     ->  Index Scan Backward using _hyper_2_12_chunk_metrics_space_time_idx on _hyper_2_12_chunk (never executed)
-                           Index Cond: ("time" > 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
-(70 rows)
+                           Sort Key: _hyper_2_8_chunk."time", _hyper_2_8_chunk.device_id
+                           ->  Seq Scan on _hyper_2_8_chunk (never executed)
+                                 Filter: ('Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone < "time")
+               ->  Sort (never executed)
+                     Sort Key: _hyper_2_9_chunk."time", _hyper_2_9_chunk.device_id
+                     ->  Sort (never executed)
+                           Sort Key: _hyper_2_9_chunk."time", _hyper_2_9_chunk.device_id
+                           ->  Seq Scan on _hyper_2_9_chunk (never executed)
+                                 Filter: ('Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone < "time")
+         ->  Merge Append (never executed)
+               Sort Key: _hyper_2_10_chunk."time", _hyper_2_10_chunk.device_id
+               ->  Sort (never executed)
+                     Sort Key: _hyper_2_10_chunk."time", _hyper_2_10_chunk.device_id
+                     ->  Custom Scan (DecompressChunk) on _hyper_2_10_chunk (never executed)
+                           Vectorized Filter: ("time" > 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
+                           ->  Seq Scan on compress_hyper_6_20_chunk (never executed)
+                                 Filter: (_ts_meta_max_3 > 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
+               ->  Sort (never executed)
+                     Sort Key: _hyper_2_11_chunk."time", _hyper_2_11_chunk.device_id
+                     ->  Custom Scan (DecompressChunk) on _hyper_2_11_chunk (never executed)
+                           Vectorized Filter: ("time" > 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
+                           ->  Seq Scan on compress_hyper_6_21_chunk (never executed)
+                                 Filter: (_ts_meta_max_3 > 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
+               ->  Sort (never executed)
+                     Sort Key: _hyper_2_12_chunk."time", _hyper_2_12_chunk.device_id
+                     ->  Sort (never executed)
+                           Sort Key: _hyper_2_12_chunk."time", _hyper_2_12_chunk.device_id
+                           ->  Seq Scan on _hyper_2_12_chunk (never executed)
+                                 Filter: ('Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone < "time")
+(69 rows)
 
 --pushdowns between order by and segment by columns
 :PREFIX
@@ -4491,89 +4433,90 @@ WHERE v0 < 1
 ORDER BY time,
     device_id
 LIMIT 10;
-                                                               QUERY PLAN                                                                
------------------------------------------------------------------------------------------------------------------------------------------
+                                                                         QUERY PLAN                                                                          
+-------------------------------------------------------------------------------------------------------------------------------------------------------------
  Limit (actual rows=0 loops=1)
-   ->  Incremental Sort (actual rows=0 loops=1)
-         Sort Key: metrics_space."time", metrics_space.device_id
-         Presorted Key: metrics_space."time"
-         Full-sort Groups: 1  Sort Method: quicksort 
-         ->  Custom Scan (ChunkAppend) on metrics_space (actual rows=0 loops=1)
-               Order: metrics_space."time"
-               ->  Merge Append (actual rows=0 loops=1)
-                     Sort Key: _hyper_2_4_chunk."time"
+   ->  Custom Scan (ChunkAppend) on metrics_space (actual rows=0 loops=1)
+         Order: metrics_space."time", metrics_space.device_id
+         ->  Merge Append (actual rows=0 loops=1)
+               Sort Key: _hyper_2_4_chunk."time", _hyper_2_4_chunk.device_id
+               ->  Sort (actual rows=0 loops=1)
+                     Sort Key: _hyper_2_4_chunk."time", _hyper_2_4_chunk.device_id
+                     Sort Method: quicksort 
+                     ->  Custom Scan (DecompressChunk) on _hyper_2_4_chunk (actual rows=0 loops=1)
+                           Vectorized Filter: (v0 < 1)
+                           ->  Seq Scan on compress_hyper_6_17_chunk (actual rows=0 loops=1)
+                                 Filter: (_ts_meta_min_1 < 1)
+                                 Rows Removed by Filter: 1
+               ->  Sort (actual rows=0 loops=1)
+                     Sort Key: _hyper_2_5_chunk."time", _hyper_2_5_chunk.device_id
+                     Sort Method: quicksort 
+                     ->  Custom Scan (DecompressChunk) on _hyper_2_5_chunk (actual rows=0 loops=1)
+                           Vectorized Filter: (v0 < 1)
+                           ->  Seq Scan on compress_hyper_6_18_chunk (actual rows=0 loops=1)
+                                 Filter: (_ts_meta_min_1 < 1)
+                                 Rows Removed by Filter: 3
+               ->  Sort (actual rows=0 loops=1)
+                     Sort Key: _hyper_2_6_chunk."time", _hyper_2_6_chunk.device_id
+                     Sort Method: quicksort 
+                     ->  Custom Scan (DecompressChunk) on _hyper_2_6_chunk (actual rows=0 loops=1)
+                           Vectorized Filter: (v0 < 1)
+                           ->  Seq Scan on compress_hyper_6_19_chunk (actual rows=0 loops=1)
+                                 Filter: (_ts_meta_min_1 < 1)
+                                 Rows Removed by Filter: 1
+         ->  Merge Append (actual rows=0 loops=1)
+               Sort Key: _hyper_2_7_chunk."time", _hyper_2_7_chunk.device_id
+               ->  Sort (actual rows=0 loops=1)
+                     Sort Key: _hyper_2_7_chunk."time", _hyper_2_7_chunk.device_id
+                     Sort Method: quicksort 
                      ->  Sort (actual rows=0 loops=1)
-                           Sort Key: _hyper_2_4_chunk."time"
+                           Sort Key: _hyper_2_7_chunk."time", _hyper_2_7_chunk.device_id
                            Sort Method: quicksort 
-                           ->  Sort (actual rows=0 loops=1)
-                                 Sort Key: _hyper_2_4_chunk."time"
-                                 Sort Method: quicksort 
-                                 ->  Custom Scan (DecompressChunk) on _hyper_2_4_chunk (actual rows=0 loops=1)
-                                       Vectorized Filter: (v0 < 1)
-                                       ->  Seq Scan on compress_hyper_6_17_chunk (actual rows=0 loops=1)
-                                             Filter: (_ts_meta_min_1 < 1)
-                                             Rows Removed by Filter: 1
+                           ->  Index Scan using _hyper_2_7_chunk_metrics_space_device_id_device_id_peer_v0_v1_2 on _hyper_2_7_chunk (actual rows=0 loops=1)
+                                 Index Cond: (v0 < 1)
+               ->  Sort (actual rows=0 loops=1)
+                     Sort Key: _hyper_2_8_chunk."time", _hyper_2_8_chunk.device_id
+                     Sort Method: quicksort 
                      ->  Sort (actual rows=0 loops=1)
-                           Sort Key: _hyper_2_5_chunk."time"
+                           Sort Key: _hyper_2_8_chunk."time", _hyper_2_8_chunk.device_id
                            Sort Method: quicksort 
-                           ->  Sort (actual rows=0 loops=1)
-                                 Sort Key: _hyper_2_5_chunk."time"
-                                 Sort Method: quicksort 
-                                 ->  Custom Scan (DecompressChunk) on _hyper_2_5_chunk (actual rows=0 loops=1)
-                                       Vectorized Filter: (v0 < 1)
-                                       ->  Seq Scan on compress_hyper_6_18_chunk (actual rows=0 loops=1)
-                                             Filter: (_ts_meta_min_1 < 1)
-                                             Rows Removed by Filter: 3
+                           ->  Index Scan using _hyper_2_8_chunk_metrics_space_device_id_device_id_peer_v0_v1_2 on _hyper_2_8_chunk (actual rows=0 loops=1)
+                                 Index Cond: (v0 < 1)
+               ->  Sort (actual rows=0 loops=1)
+                     Sort Key: _hyper_2_9_chunk."time", _hyper_2_9_chunk.device_id
+                     Sort Method: quicksort 
                      ->  Sort (actual rows=0 loops=1)
-                           Sort Key: _hyper_2_6_chunk."time"
+                           Sort Key: _hyper_2_9_chunk."time", _hyper_2_9_chunk.device_id
                            Sort Method: quicksort 
-                           ->  Sort (actual rows=0 loops=1)
-                                 Sort Key: _hyper_2_6_chunk."time"
-                                 Sort Method: quicksort 
-                                 ->  Custom Scan (DecompressChunk) on _hyper_2_6_chunk (actual rows=0 loops=1)
-                                       Vectorized Filter: (v0 < 1)
-                                       ->  Seq Scan on compress_hyper_6_19_chunk (actual rows=0 loops=1)
-                                             Filter: (_ts_meta_min_1 < 1)
-                                             Rows Removed by Filter: 1
-               ->  Merge Append (actual rows=0 loops=1)
-                     Sort Key: _hyper_2_7_chunk."time"
-                     ->  Index Scan Backward using _hyper_2_7_chunk_metrics_space_time_idx on _hyper_2_7_chunk (actual rows=0 loops=1)
-                           Filter: (v0 < 1)
-                           Rows Removed by Filter: 504
-                     ->  Index Scan Backward using _hyper_2_8_chunk_metrics_space_time_idx on _hyper_2_8_chunk (actual rows=0 loops=1)
-                           Filter: (v0 < 1)
-                           Rows Removed by Filter: 1512
-                     ->  Index Scan Backward using _hyper_2_9_chunk_metrics_space_time_idx on _hyper_2_9_chunk (actual rows=0 loops=1)
-                           Filter: (v0 < 1)
-                           Rows Removed by Filter: 504
-               ->  Merge Append (actual rows=0 loops=1)
-                     Sort Key: _hyper_2_10_chunk."time"
+                           ->  Index Scan using _hyper_2_9_chunk_metrics_space_device_id_device_id_peer_v0_v1_2 on _hyper_2_9_chunk (actual rows=0 loops=1)
+                                 Index Cond: (v0 < 1)
+         ->  Merge Append (actual rows=0 loops=1)
+               Sort Key: _hyper_2_10_chunk."time", _hyper_2_10_chunk.device_id
+               ->  Sort (actual rows=0 loops=1)
+                     Sort Key: _hyper_2_10_chunk."time", _hyper_2_10_chunk.device_id
+                     Sort Method: quicksort 
+                     ->  Custom Scan (DecompressChunk) on _hyper_2_10_chunk (actual rows=0 loops=1)
+                           Vectorized Filter: (v0 < 1)
+                           ->  Seq Scan on compress_hyper_6_20_chunk (actual rows=0 loops=1)
+                                 Filter: (_ts_meta_min_1 < 1)
+                                 Rows Removed by Filter: 1
+               ->  Sort (actual rows=0 loops=1)
+                     Sort Key: _hyper_2_11_chunk."time", _hyper_2_11_chunk.device_id
+                     Sort Method: quicksort 
+                     ->  Custom Scan (DecompressChunk) on _hyper_2_11_chunk (actual rows=0 loops=1)
+                           Vectorized Filter: (v0 < 1)
+                           ->  Seq Scan on compress_hyper_6_21_chunk (actual rows=0 loops=1)
+                                 Filter: (_ts_meta_min_1 < 1)
+                                 Rows Removed by Filter: 3
+               ->  Sort (actual rows=0 loops=1)
+                     Sort Key: _hyper_2_12_chunk."time", _hyper_2_12_chunk.device_id
+                     Sort Method: quicksort 
                      ->  Sort (actual rows=0 loops=1)
-                           Sort Key: _hyper_2_10_chunk."time"
+                           Sort Key: _hyper_2_12_chunk."time", _hyper_2_12_chunk.device_id
                            Sort Method: quicksort 
-                           ->  Sort (actual rows=0 loops=1)
-                                 Sort Key: _hyper_2_10_chunk."time"
-                                 Sort Method: quicksort 
-                                 ->  Custom Scan (DecompressChunk) on _hyper_2_10_chunk (actual rows=0 loops=1)
-                                       Vectorized Filter: (v0 < 1)
-                                       ->  Seq Scan on compress_hyper_6_20_chunk (actual rows=0 loops=1)
-                                             Filter: (_ts_meta_min_1 < 1)
-                                             Rows Removed by Filter: 1
-                     ->  Sort (actual rows=0 loops=1)
-                           Sort Key: _hyper_2_11_chunk."time"
-                           Sort Method: quicksort 
-                           ->  Sort (actual rows=0 loops=1)
-                                 Sort Key: _hyper_2_11_chunk."time"
-                                 Sort Method: quicksort 
-                                 ->  Custom Scan (DecompressChunk) on _hyper_2_11_chunk (actual rows=0 loops=1)
-                                       Vectorized Filter: (v0 < 1)
-                                       ->  Seq Scan on compress_hyper_6_21_chunk (actual rows=0 loops=1)
-                                             Filter: (_ts_meta_min_1 < 1)
-                                             Rows Removed by Filter: 3
-                     ->  Index Scan Backward using _hyper_2_12_chunk_metrics_space_time_idx on _hyper_2_12_chunk (actual rows=0 loops=1)
-                           Filter: (v0 < 1)
-                           Rows Removed by Filter: 504
-(80 rows)
+                           ->  Index Scan using _hyper_2_12_chunk_metrics_space_device_id_device_id_peer_v0_v_2 on _hyper_2_12_chunk (actual rows=0 loops=1)
+                                 Index Cond: (v0 < 1)
+(81 rows)
 
 :PREFIX
 SELECT *
@@ -4582,89 +4525,94 @@ WHERE v0 < device_id
 ORDER BY time,
     device_id
 LIMIT 10;
-                                                               QUERY PLAN                                                                
------------------------------------------------------------------------------------------------------------------------------------------
+                                             QUERY PLAN                                             
+----------------------------------------------------------------------------------------------------
  Limit (actual rows=0 loops=1)
-   ->  Incremental Sort (actual rows=0 loops=1)
-         Sort Key: metrics_space."time", metrics_space.device_id
-         Presorted Key: metrics_space."time"
-         Full-sort Groups: 1  Sort Method: quicksort 
-         ->  Custom Scan (ChunkAppend) on metrics_space (actual rows=0 loops=1)
-               Order: metrics_space."time"
-               ->  Merge Append (actual rows=0 loops=1)
-                     Sort Key: _hyper_2_4_chunk."time"
-                     ->  Sort (actual rows=0 loops=1)
-                           Sort Key: _hyper_2_4_chunk."time"
-                           Sort Method: quicksort 
-                           ->  Sort (actual rows=0 loops=1)
-                                 Sort Key: _hyper_2_4_chunk."time"
-                                 Sort Method: quicksort 
-                                 ->  Custom Scan (DecompressChunk) on _hyper_2_4_chunk (actual rows=0 loops=1)
-                                       Filter: (v0 < device_id)
-                                       ->  Seq Scan on compress_hyper_6_17_chunk (actual rows=0 loops=1)
-                                             Filter: (_ts_meta_min_1 < device_id)
-                                             Rows Removed by Filter: 1
-                     ->  Sort (actual rows=0 loops=1)
-                           Sort Key: _hyper_2_5_chunk."time"
-                           Sort Method: quicksort 
-                           ->  Sort (actual rows=0 loops=1)
-                                 Sort Key: _hyper_2_5_chunk."time"
-                                 Sort Method: quicksort 
-                                 ->  Custom Scan (DecompressChunk) on _hyper_2_5_chunk (actual rows=0 loops=1)
-                                       Filter: (v0 < device_id)
-                                       ->  Seq Scan on compress_hyper_6_18_chunk (actual rows=0 loops=1)
-                                             Filter: (_ts_meta_min_1 < device_id)
-                                             Rows Removed by Filter: 3
-                     ->  Sort (actual rows=0 loops=1)
-                           Sort Key: _hyper_2_6_chunk."time"
-                           Sort Method: quicksort 
-                           ->  Sort (actual rows=0 loops=1)
-                                 Sort Key: _hyper_2_6_chunk."time"
-                                 Sort Method: quicksort 
-                                 ->  Custom Scan (DecompressChunk) on _hyper_2_6_chunk (actual rows=0 loops=1)
-                                       Filter: (v0 < device_id)
-                                       ->  Seq Scan on compress_hyper_6_19_chunk (actual rows=0 loops=1)
-                                             Filter: (_ts_meta_min_1 < device_id)
-                                             Rows Removed by Filter: 1
-               ->  Merge Append (actual rows=0 loops=1)
-                     Sort Key: _hyper_2_7_chunk."time"
-                     ->  Index Scan Backward using _hyper_2_7_chunk_metrics_space_time_idx on _hyper_2_7_chunk (actual rows=0 loops=1)
+   ->  Custom Scan (ChunkAppend) on metrics_space (actual rows=0 loops=1)
+         Order: metrics_space."time", metrics_space.device_id
+         ->  Merge Append (actual rows=0 loops=1)
+               Sort Key: _hyper_2_4_chunk."time", _hyper_2_4_chunk.device_id
+               ->  Sort (actual rows=0 loops=1)
+                     Sort Key: _hyper_2_4_chunk."time", _hyper_2_4_chunk.device_id
+                     Sort Method: quicksort 
+                     ->  Custom Scan (DecompressChunk) on _hyper_2_4_chunk (actual rows=0 loops=1)
                            Filter: (v0 < device_id)
-                           Rows Removed by Filter: 504
-                     ->  Index Scan Backward using _hyper_2_8_chunk_metrics_space_time_idx on _hyper_2_8_chunk (actual rows=0 loops=1)
+                           ->  Seq Scan on compress_hyper_6_17_chunk (actual rows=0 loops=1)
+                                 Filter: (_ts_meta_min_1 < device_id)
+                                 Rows Removed by Filter: 1
+               ->  Sort (actual rows=0 loops=1)
+                     Sort Key: _hyper_2_5_chunk."time", _hyper_2_5_chunk.device_id
+                     Sort Method: quicksort 
+                     ->  Custom Scan (DecompressChunk) on _hyper_2_5_chunk (actual rows=0 loops=1)
                            Filter: (v0 < device_id)
-                           Rows Removed by Filter: 1512
-                     ->  Index Scan Backward using _hyper_2_9_chunk_metrics_space_time_idx on _hyper_2_9_chunk (actual rows=0 loops=1)
+                           ->  Seq Scan on compress_hyper_6_18_chunk (actual rows=0 loops=1)
+                                 Filter: (_ts_meta_min_1 < device_id)
+                                 Rows Removed by Filter: 3
+               ->  Sort (actual rows=0 loops=1)
+                     Sort Key: _hyper_2_6_chunk."time", _hyper_2_6_chunk.device_id
+                     Sort Method: quicksort 
+                     ->  Custom Scan (DecompressChunk) on _hyper_2_6_chunk (actual rows=0 loops=1)
                            Filter: (v0 < device_id)
-                           Rows Removed by Filter: 504
-               ->  Merge Append (actual rows=0 loops=1)
-                     Sort Key: _hyper_2_10_chunk."time"
+                           ->  Seq Scan on compress_hyper_6_19_chunk (actual rows=0 loops=1)
+                                 Filter: (_ts_meta_min_1 < device_id)
+                                 Rows Removed by Filter: 1
+         ->  Merge Append (actual rows=0 loops=1)
+               Sort Key: _hyper_2_7_chunk."time", _hyper_2_7_chunk.device_id
+               ->  Sort (actual rows=0 loops=1)
+                     Sort Key: _hyper_2_7_chunk."time", _hyper_2_7_chunk.device_id
+                     Sort Method: quicksort 
                      ->  Sort (actual rows=0 loops=1)
-                           Sort Key: _hyper_2_10_chunk."time"
+                           Sort Key: _hyper_2_7_chunk."time", _hyper_2_7_chunk.device_id
                            Sort Method: quicksort 
-                           ->  Sort (actual rows=0 loops=1)
-                                 Sort Key: _hyper_2_10_chunk."time"
-                                 Sort Method: quicksort 
-                                 ->  Custom Scan (DecompressChunk) on _hyper_2_10_chunk (actual rows=0 loops=1)
-                                       Filter: (v0 < device_id)
-                                       ->  Seq Scan on compress_hyper_6_20_chunk (actual rows=0 loops=1)
-                                             Filter: (_ts_meta_min_1 < device_id)
-                                             Rows Removed by Filter: 1
+                           ->  Seq Scan on _hyper_2_7_chunk (actual rows=0 loops=1)
+                                 Filter: (v0 < device_id)
+                                 Rows Removed by Filter: 504
+               ->  Sort (actual rows=0 loops=1)
+                     Sort Key: _hyper_2_8_chunk."time", _hyper_2_8_chunk.device_id
+                     Sort Method: quicksort 
                      ->  Sort (actual rows=0 loops=1)
-                           Sort Key: _hyper_2_11_chunk."time"
+                           Sort Key: _hyper_2_8_chunk."time", _hyper_2_8_chunk.device_id
                            Sort Method: quicksort 
-                           ->  Sort (actual rows=0 loops=1)
-                                 Sort Key: _hyper_2_11_chunk."time"
-                                 Sort Method: quicksort 
-                                 ->  Custom Scan (DecompressChunk) on _hyper_2_11_chunk (actual rows=0 loops=1)
-                                       Filter: (v0 < device_id)
-                                       ->  Seq Scan on compress_hyper_6_21_chunk (actual rows=0 loops=1)
-                                             Filter: (_ts_meta_min_1 < device_id)
-                                             Rows Removed by Filter: 3
-                     ->  Index Scan Backward using _hyper_2_12_chunk_metrics_space_time_idx on _hyper_2_12_chunk (actual rows=0 loops=1)
+                           ->  Seq Scan on _hyper_2_8_chunk (actual rows=0 loops=1)
+                                 Filter: (v0 < device_id)
+                                 Rows Removed by Filter: 1512
+               ->  Sort (actual rows=0 loops=1)
+                     Sort Key: _hyper_2_9_chunk."time", _hyper_2_9_chunk.device_id
+                     Sort Method: quicksort 
+                     ->  Sort (actual rows=0 loops=1)
+                           Sort Key: _hyper_2_9_chunk."time", _hyper_2_9_chunk.device_id
+                           Sort Method: quicksort 
+                           ->  Seq Scan on _hyper_2_9_chunk (actual rows=0 loops=1)
+                                 Filter: (v0 < device_id)
+                                 Rows Removed by Filter: 504
+         ->  Merge Append (actual rows=0 loops=1)
+               Sort Key: _hyper_2_10_chunk."time", _hyper_2_10_chunk.device_id
+               ->  Sort (actual rows=0 loops=1)
+                     Sort Key: _hyper_2_10_chunk."time", _hyper_2_10_chunk.device_id
+                     Sort Method: quicksort 
+                     ->  Custom Scan (DecompressChunk) on _hyper_2_10_chunk (actual rows=0 loops=1)
                            Filter: (v0 < device_id)
-                           Rows Removed by Filter: 504
-(80 rows)
+                           ->  Seq Scan on compress_hyper_6_20_chunk (actual rows=0 loops=1)
+                                 Filter: (_ts_meta_min_1 < device_id)
+                                 Rows Removed by Filter: 1
+               ->  Sort (actual rows=0 loops=1)
+                     Sort Key: _hyper_2_11_chunk."time", _hyper_2_11_chunk.device_id
+                     Sort Method: quicksort 
+                     ->  Custom Scan (DecompressChunk) on _hyper_2_11_chunk (actual rows=0 loops=1)
+                           Filter: (v0 < device_id)
+                           ->  Seq Scan on compress_hyper_6_21_chunk (actual rows=0 loops=1)
+                                 Filter: (_ts_meta_min_1 < device_id)
+                                 Rows Removed by Filter: 3
+               ->  Sort (actual rows=0 loops=1)
+                     Sort Key: _hyper_2_12_chunk."time", _hyper_2_12_chunk.device_id
+                     Sort Method: quicksort 
+                     ->  Sort (actual rows=0 loops=1)
+                           Sort Key: _hyper_2_12_chunk."time", _hyper_2_12_chunk.device_id
+                           Sort Method: quicksort 
+                           ->  Seq Scan on _hyper_2_12_chunk (actual rows=0 loops=1)
+                                 Filter: (v0 < device_id)
+                                 Rows Removed by Filter: 504
+(85 rows)
 
 :PREFIX
 SELECT *
@@ -4673,76 +4621,75 @@ WHERE device_id < v0
 ORDER BY time,
     device_id
 LIMIT 10;
-                                                            QUERY PLAN                                                            
-----------------------------------------------------------------------------------------------------------------------------------
+                                              QUERY PLAN                                              
+------------------------------------------------------------------------------------------------------
  Limit (actual rows=10 loops=1)
-   ->  Incremental Sort (actual rows=10 loops=1)
-         Sort Key: metrics_space."time", metrics_space.device_id
-         Presorted Key: metrics_space."time"
-         Full-sort Groups: 1  Sort Method: quicksort 
-         ->  Custom Scan (ChunkAppend) on metrics_space (actual rows=11 loops=1)
-               Order: metrics_space."time"
-               ->  Merge Append (actual rows=11 loops=1)
-                     Sort Key: _hyper_2_4_chunk."time"
-                     ->  Sort (actual rows=3 loops=1)
-                           Sort Key: _hyper_2_4_chunk."time"
-                           Sort Method: quicksort 
-                           ->  Sort (actual rows=360 loops=1)
-                                 Sort Key: _hyper_2_4_chunk."time"
-                                 Sort Method: quicksort 
-                                 ->  Custom Scan (DecompressChunk) on _hyper_2_4_chunk (actual rows=360 loops=1)
-                                       Filter: (device_id < v0)
-                                       ->  Seq Scan on compress_hyper_6_17_chunk (actual rows=1 loops=1)
-                                             Filter: (_ts_meta_max_1 > device_id)
-                     ->  Sort (actual rows=7 loops=1)
-                           Sort Key: _hyper_2_5_chunk."time"
-                           Sort Method: quicksort 
-                           ->  Sort (actual rows=1080 loops=1)
-                                 Sort Key: _hyper_2_5_chunk."time"
-                                 Sort Method: quicksort 
-                                 ->  Custom Scan (DecompressChunk) on _hyper_2_5_chunk (actual rows=1080 loops=1)
-                                       Filter: (device_id < v0)
-                                       ->  Seq Scan on compress_hyper_6_18_chunk (actual rows=3 loops=1)
-                                             Filter: (_ts_meta_max_1 > device_id)
-                     ->  Sort (actual rows=3 loops=1)
-                           Sort Key: _hyper_2_6_chunk."time"
-                           Sort Method: quicksort 
-                           ->  Sort (actual rows=360 loops=1)
-                                 Sort Key: _hyper_2_6_chunk."time"
-                                 Sort Method: quicksort 
-                                 ->  Custom Scan (DecompressChunk) on _hyper_2_6_chunk (actual rows=360 loops=1)
-                                       Filter: (device_id < v0)
-                                       ->  Seq Scan on compress_hyper_6_19_chunk (actual rows=1 loops=1)
-                                             Filter: (_ts_meta_max_1 > device_id)
-               ->  Merge Append (never executed)
-                     Sort Key: _hyper_2_7_chunk."time"
-                     ->  Index Scan Backward using _hyper_2_7_chunk_metrics_space_time_idx on _hyper_2_7_chunk (never executed)
+   ->  Custom Scan (ChunkAppend) on metrics_space (actual rows=10 loops=1)
+         Order: metrics_space."time", metrics_space.device_id
+         ->  Merge Append (actual rows=10 loops=1)
+               Sort Key: _hyper_2_4_chunk."time", _hyper_2_4_chunk.device_id
+               ->  Sort (actual rows=3 loops=1)
+                     Sort Key: _hyper_2_4_chunk."time", _hyper_2_4_chunk.device_id
+                     Sort Method: top-N heapsort 
+                     ->  Custom Scan (DecompressChunk) on _hyper_2_4_chunk (actual rows=360 loops=1)
                            Filter: (device_id < v0)
-                     ->  Index Scan Backward using _hyper_2_8_chunk_metrics_space_time_idx on _hyper_2_8_chunk (never executed)
+                           ->  Seq Scan on compress_hyper_6_17_chunk (actual rows=1 loops=1)
+                                 Filter: (_ts_meta_max_1 > device_id)
+               ->  Sort (actual rows=6 loops=1)
+                     Sort Key: _hyper_2_5_chunk."time", _hyper_2_5_chunk.device_id
+                     Sort Method: top-N heapsort 
+                     ->  Custom Scan (DecompressChunk) on _hyper_2_5_chunk (actual rows=1080 loops=1)
                            Filter: (device_id < v0)
-                     ->  Index Scan Backward using _hyper_2_9_chunk_metrics_space_time_idx on _hyper_2_9_chunk (never executed)
+                           ->  Seq Scan on compress_hyper_6_18_chunk (actual rows=3 loops=1)
+                                 Filter: (_ts_meta_max_1 > device_id)
+               ->  Sort (actual rows=3 loops=1)
+                     Sort Key: _hyper_2_6_chunk."time", _hyper_2_6_chunk.device_id
+                     Sort Method: top-N heapsort 
+                     ->  Custom Scan (DecompressChunk) on _hyper_2_6_chunk (actual rows=360 loops=1)
                            Filter: (device_id < v0)
-               ->  Merge Append (never executed)
-                     Sort Key: _hyper_2_10_chunk."time"
+                           ->  Seq Scan on compress_hyper_6_19_chunk (actual rows=1 loops=1)
+                                 Filter: (_ts_meta_max_1 > device_id)
+         ->  Merge Append (never executed)
+               Sort Key: _hyper_2_7_chunk."time", _hyper_2_7_chunk.device_id
+               ->  Sort (never executed)
+                     Sort Key: _hyper_2_7_chunk."time", _hyper_2_7_chunk.device_id
                      ->  Sort (never executed)
-                           Sort Key: _hyper_2_10_chunk."time"
-                           ->  Sort (never executed)
-                                 Sort Key: _hyper_2_10_chunk."time"
-                                 ->  Custom Scan (DecompressChunk) on _hyper_2_10_chunk (never executed)
-                                       Filter: (device_id < v0)
-                                       ->  Seq Scan on compress_hyper_6_20_chunk (never executed)
-                                             Filter: (_ts_meta_max_1 > device_id)
+                           Sort Key: _hyper_2_7_chunk."time", _hyper_2_7_chunk.device_id
+                           ->  Seq Scan on _hyper_2_7_chunk (never executed)
+                                 Filter: (device_id < v0)
+               ->  Sort (never executed)
+                     Sort Key: _hyper_2_8_chunk."time", _hyper_2_8_chunk.device_id
                      ->  Sort (never executed)
-                           Sort Key: _hyper_2_11_chunk."time"
-                           ->  Sort (never executed)
-                                 Sort Key: _hyper_2_11_chunk."time"
-                                 ->  Custom Scan (DecompressChunk) on _hyper_2_11_chunk (never executed)
-                                       Filter: (device_id < v0)
-                                       ->  Seq Scan on compress_hyper_6_21_chunk (never executed)
-                                             Filter: (_ts_meta_max_1 > device_id)
-                     ->  Index Scan Backward using _hyper_2_12_chunk_metrics_space_time_idx on _hyper_2_12_chunk (never executed)
+                           Sort Key: _hyper_2_8_chunk."time", _hyper_2_8_chunk.device_id
+                           ->  Seq Scan on _hyper_2_8_chunk (never executed)
+                                 Filter: (device_id < v0)
+               ->  Sort (never executed)
+                     Sort Key: _hyper_2_9_chunk."time", _hyper_2_9_chunk.device_id
+                     ->  Sort (never executed)
+                           Sort Key: _hyper_2_9_chunk."time", _hyper_2_9_chunk.device_id
+                           ->  Seq Scan on _hyper_2_9_chunk (never executed)
+                                 Filter: (device_id < v0)
+         ->  Merge Append (never executed)
+               Sort Key: _hyper_2_10_chunk."time", _hyper_2_10_chunk.device_id
+               ->  Sort (never executed)
+                     Sort Key: _hyper_2_10_chunk."time", _hyper_2_10_chunk.device_id
+                     ->  Custom Scan (DecompressChunk) on _hyper_2_10_chunk (never executed)
                            Filter: (device_id < v0)
-(67 rows)
+                           ->  Seq Scan on compress_hyper_6_20_chunk (never executed)
+                                 Filter: (_ts_meta_max_1 > device_id)
+               ->  Sort (never executed)
+                     Sort Key: _hyper_2_11_chunk."time", _hyper_2_11_chunk.device_id
+                     ->  Custom Scan (DecompressChunk) on _hyper_2_11_chunk (never executed)
+                           Filter: (device_id < v0)
+                           ->  Seq Scan on compress_hyper_6_21_chunk (never executed)
+                                 Filter: (_ts_meta_max_1 > device_id)
+               ->  Sort (never executed)
+                     Sort Key: _hyper_2_12_chunk."time", _hyper_2_12_chunk.device_id
+                     ->  Sort (never executed)
+                           Sort Key: _hyper_2_12_chunk."time", _hyper_2_12_chunk.device_id
+                           ->  Seq Scan on _hyper_2_12_chunk (never executed)
+                                 Filter: (device_id < v0)
+(66 rows)
 
 :PREFIX
 SELECT *
@@ -4751,84 +4698,89 @@ WHERE v1 = device_id
 ORDER BY time,
     device_id
 LIMIT 10;
-                                                               QUERY PLAN                                                                
------------------------------------------------------------------------------------------------------------------------------------------
+                                             QUERY PLAN                                             
+----------------------------------------------------------------------------------------------------
  Limit (actual rows=0 loops=1)
-   ->  Incremental Sort (actual rows=0 loops=1)
-         Sort Key: metrics_space."time", metrics_space.device_id
-         Presorted Key: metrics_space."time"
-         Full-sort Groups: 1  Sort Method: quicksort 
-         ->  Custom Scan (ChunkAppend) on metrics_space (actual rows=0 loops=1)
-               Order: metrics_space."time"
-               ->  Merge Append (actual rows=0 loops=1)
-                     Sort Key: _hyper_2_4_chunk."time"
+   ->  Custom Scan (ChunkAppend) on metrics_space (actual rows=0 loops=1)
+         Order: metrics_space."time", metrics_space.device_id
+         ->  Merge Append (actual rows=0 loops=1)
+               Sort Key: _hyper_2_4_chunk."time", _hyper_2_4_chunk.device_id
+               ->  Sort (actual rows=0 loops=1)
+                     Sort Key: _hyper_2_4_chunk."time", _hyper_2_4_chunk.device_id
+                     Sort Method: quicksort 
+                     ->  Custom Scan (DecompressChunk) on _hyper_2_4_chunk (actual rows=0 loops=1)
+                           Filter: (v1 = (device_id)::double precision)
+                           Rows Removed by Filter: 360
+                           ->  Seq Scan on compress_hyper_6_17_chunk (actual rows=1 loops=1)
+               ->  Sort (actual rows=0 loops=1)
+                     Sort Key: _hyper_2_5_chunk."time", _hyper_2_5_chunk.device_id
+                     Sort Method: quicksort 
+                     ->  Custom Scan (DecompressChunk) on _hyper_2_5_chunk (actual rows=0 loops=1)
+                           Filter: (v1 = (device_id)::double precision)
+                           Rows Removed by Filter: 1080
+                           ->  Seq Scan on compress_hyper_6_18_chunk (actual rows=3 loops=1)
+               ->  Sort (actual rows=0 loops=1)
+                     Sort Key: _hyper_2_6_chunk."time", _hyper_2_6_chunk.device_id
+                     Sort Method: quicksort 
+                     ->  Custom Scan (DecompressChunk) on _hyper_2_6_chunk (actual rows=0 loops=1)
+                           Filter: (v1 = (device_id)::double precision)
+                           Rows Removed by Filter: 360
+                           ->  Seq Scan on compress_hyper_6_19_chunk (actual rows=1 loops=1)
+         ->  Merge Append (actual rows=0 loops=1)
+               Sort Key: _hyper_2_7_chunk."time", _hyper_2_7_chunk.device_id
+               ->  Sort (actual rows=0 loops=1)
+                     Sort Key: _hyper_2_7_chunk."time", _hyper_2_7_chunk.device_id
+                     Sort Method: quicksort 
                      ->  Sort (actual rows=0 loops=1)
-                           Sort Key: _hyper_2_4_chunk."time"
+                           Sort Key: _hyper_2_7_chunk."time", _hyper_2_7_chunk.device_id
                            Sort Method: quicksort 
-                           ->  Sort (actual rows=0 loops=1)
-                                 Sort Key: _hyper_2_4_chunk."time"
-                                 Sort Method: quicksort 
-                                 ->  Custom Scan (DecompressChunk) on _hyper_2_4_chunk (actual rows=0 loops=1)
-                                       Filter: (v1 = (device_id)::double precision)
-                                       Rows Removed by Filter: 360
-                                       ->  Seq Scan on compress_hyper_6_17_chunk (actual rows=1 loops=1)
+                           ->  Seq Scan on _hyper_2_7_chunk (actual rows=0 loops=1)
+                                 Filter: (v1 = (device_id)::double precision)
+                                 Rows Removed by Filter: 504
+               ->  Sort (actual rows=0 loops=1)
+                     Sort Key: _hyper_2_8_chunk."time", _hyper_2_8_chunk.device_id
+                     Sort Method: quicksort 
                      ->  Sort (actual rows=0 loops=1)
-                           Sort Key: _hyper_2_5_chunk."time"
+                           Sort Key: _hyper_2_8_chunk."time", _hyper_2_8_chunk.device_id
                            Sort Method: quicksort 
-                           ->  Sort (actual rows=0 loops=1)
-                                 Sort Key: _hyper_2_5_chunk."time"
-                                 Sort Method: quicksort 
-                                 ->  Custom Scan (DecompressChunk) on _hyper_2_5_chunk (actual rows=0 loops=1)
-                                       Filter: (v1 = (device_id)::double precision)
-                                       Rows Removed by Filter: 1080
-                                       ->  Seq Scan on compress_hyper_6_18_chunk (actual rows=3 loops=1)
+                           ->  Seq Scan on _hyper_2_8_chunk (actual rows=0 loops=1)
+                                 Filter: (v1 = (device_id)::double precision)
+                                 Rows Removed by Filter: 1512
+               ->  Sort (actual rows=0 loops=1)
+                     Sort Key: _hyper_2_9_chunk."time", _hyper_2_9_chunk.device_id
+                     Sort Method: quicksort 
                      ->  Sort (actual rows=0 loops=1)
-                           Sort Key: _hyper_2_6_chunk."time"
+                           Sort Key: _hyper_2_9_chunk."time", _hyper_2_9_chunk.device_id
                            Sort Method: quicksort 
-                           ->  Sort (actual rows=0 loops=1)
-                                 Sort Key: _hyper_2_6_chunk."time"
-                                 Sort Method: quicksort 
-                                 ->  Custom Scan (DecompressChunk) on _hyper_2_6_chunk (actual rows=0 loops=1)
-                                       Filter: (v1 = (device_id)::double precision)
-                                       Rows Removed by Filter: 360
-                                       ->  Seq Scan on compress_hyper_6_19_chunk (actual rows=1 loops=1)
-               ->  Merge Append (actual rows=0 loops=1)
-                     Sort Key: _hyper_2_7_chunk."time"
-                     ->  Index Scan Backward using _hyper_2_7_chunk_metrics_space_time_idx on _hyper_2_7_chunk (actual rows=0 loops=1)
+                           ->  Seq Scan on _hyper_2_9_chunk (actual rows=0 loops=1)
+                                 Filter: (v1 = (device_id)::double precision)
+                                 Rows Removed by Filter: 504
+         ->  Merge Append (actual rows=0 loops=1)
+               Sort Key: _hyper_2_10_chunk."time", _hyper_2_10_chunk.device_id
+               ->  Sort (actual rows=0 loops=1)
+                     Sort Key: _hyper_2_10_chunk."time", _hyper_2_10_chunk.device_id
+                     Sort Method: quicksort 
+                     ->  Custom Scan (DecompressChunk) on _hyper_2_10_chunk (actual rows=0 loops=1)
                            Filter: (v1 = (device_id)::double precision)
                            Rows Removed by Filter: 504
-                     ->  Index Scan Backward using _hyper_2_8_chunk_metrics_space_time_idx on _hyper_2_8_chunk (actual rows=0 loops=1)
+                           ->  Seq Scan on compress_hyper_6_20_chunk (actual rows=1 loops=1)
+               ->  Sort (actual rows=0 loops=1)
+                     Sort Key: _hyper_2_11_chunk."time", _hyper_2_11_chunk.device_id
+                     Sort Method: quicksort 
+                     ->  Custom Scan (DecompressChunk) on _hyper_2_11_chunk (actual rows=0 loops=1)
                            Filter: (v1 = (device_id)::double precision)
                            Rows Removed by Filter: 1512
-                     ->  Index Scan Backward using _hyper_2_9_chunk_metrics_space_time_idx on _hyper_2_9_chunk (actual rows=0 loops=1)
-                           Filter: (v1 = (device_id)::double precision)
-                           Rows Removed by Filter: 504
-               ->  Merge Append (actual rows=0 loops=1)
-                     Sort Key: _hyper_2_10_chunk."time"
+                           ->  Seq Scan on compress_hyper_6_21_chunk (actual rows=3 loops=1)
+               ->  Sort (actual rows=0 loops=1)
+                     Sort Key: _hyper_2_12_chunk."time", _hyper_2_12_chunk.device_id
+                     Sort Method: quicksort 
                      ->  Sort (actual rows=0 loops=1)
-                           Sort Key: _hyper_2_10_chunk."time"
+                           Sort Key: _hyper_2_12_chunk."time", _hyper_2_12_chunk.device_id
                            Sort Method: quicksort 
-                           ->  Sort (actual rows=0 loops=1)
-                                 Sort Key: _hyper_2_10_chunk."time"
-                                 Sort Method: quicksort 
-                                 ->  Custom Scan (DecompressChunk) on _hyper_2_10_chunk (actual rows=0 loops=1)
-                                       Filter: (v1 = (device_id)::double precision)
-                                       Rows Removed by Filter: 504
-                                       ->  Seq Scan on compress_hyper_6_20_chunk (actual rows=1 loops=1)
-                     ->  Sort (actual rows=0 loops=1)
-                           Sort Key: _hyper_2_11_chunk."time"
-                           Sort Method: quicksort 
-                           ->  Sort (actual rows=0 loops=1)
-                                 Sort Key: _hyper_2_11_chunk."time"
-                                 Sort Method: quicksort 
-                                 ->  Custom Scan (DecompressChunk) on _hyper_2_11_chunk (actual rows=0 loops=1)
-                                       Filter: (v1 = (device_id)::double precision)
-                                       Rows Removed by Filter: 1512
-                                       ->  Seq Scan on compress_hyper_6_21_chunk (actual rows=3 loops=1)
-                     ->  Index Scan Backward using _hyper_2_12_chunk_metrics_space_time_idx on _hyper_2_12_chunk (actual rows=0 loops=1)
-                           Filter: (v1 = (device_id)::double precision)
-                           Rows Removed by Filter: 504
-(75 rows)
+                           ->  Seq Scan on _hyper_2_12_chunk (actual rows=0 loops=1)
+                                 Filter: (v1 = (device_id)::double precision)
+                                 Rows Removed by Filter: 504
+(80 rows)
 
 --pushdown between two order by column (not pushed down)
 :PREFIX
@@ -4838,84 +4790,89 @@ WHERE v0 = v1
 ORDER BY time,
     device_id
 LIMIT 10;
-                                                               QUERY PLAN                                                                
------------------------------------------------------------------------------------------------------------------------------------------
+                                             QUERY PLAN                                             
+----------------------------------------------------------------------------------------------------
  Limit (actual rows=0 loops=1)
-   ->  Incremental Sort (actual rows=0 loops=1)
-         Sort Key: metrics_space."time", metrics_space.device_id
-         Presorted Key: metrics_space."time"
-         Full-sort Groups: 1  Sort Method: quicksort 
-         ->  Custom Scan (ChunkAppend) on metrics_space (actual rows=0 loops=1)
-               Order: metrics_space."time"
-               ->  Merge Append (actual rows=0 loops=1)
-                     Sort Key: _hyper_2_4_chunk."time"
+   ->  Custom Scan (ChunkAppend) on metrics_space (actual rows=0 loops=1)
+         Order: metrics_space."time", metrics_space.device_id
+         ->  Merge Append (actual rows=0 loops=1)
+               Sort Key: _hyper_2_4_chunk."time", _hyper_2_4_chunk.device_id
+               ->  Sort (actual rows=0 loops=1)
+                     Sort Key: _hyper_2_4_chunk."time", _hyper_2_4_chunk.device_id
+                     Sort Method: quicksort 
+                     ->  Custom Scan (DecompressChunk) on _hyper_2_4_chunk (actual rows=0 loops=1)
+                           Filter: ((v0)::double precision = v1)
+                           Rows Removed by Filter: 360
+                           ->  Seq Scan on compress_hyper_6_17_chunk (actual rows=1 loops=1)
+               ->  Sort (actual rows=0 loops=1)
+                     Sort Key: _hyper_2_5_chunk."time", _hyper_2_5_chunk.device_id
+                     Sort Method: quicksort 
+                     ->  Custom Scan (DecompressChunk) on _hyper_2_5_chunk (actual rows=0 loops=1)
+                           Filter: ((v0)::double precision = v1)
+                           Rows Removed by Filter: 1080
+                           ->  Seq Scan on compress_hyper_6_18_chunk (actual rows=3 loops=1)
+               ->  Sort (actual rows=0 loops=1)
+                     Sort Key: _hyper_2_6_chunk."time", _hyper_2_6_chunk.device_id
+                     Sort Method: quicksort 
+                     ->  Custom Scan (DecompressChunk) on _hyper_2_6_chunk (actual rows=0 loops=1)
+                           Filter: ((v0)::double precision = v1)
+                           Rows Removed by Filter: 360
+                           ->  Seq Scan on compress_hyper_6_19_chunk (actual rows=1 loops=1)
+         ->  Merge Append (actual rows=0 loops=1)
+               Sort Key: _hyper_2_7_chunk."time", _hyper_2_7_chunk.device_id
+               ->  Sort (actual rows=0 loops=1)
+                     Sort Key: _hyper_2_7_chunk."time", _hyper_2_7_chunk.device_id
+                     Sort Method: quicksort 
                      ->  Sort (actual rows=0 loops=1)
-                           Sort Key: _hyper_2_4_chunk."time"
+                           Sort Key: _hyper_2_7_chunk."time", _hyper_2_7_chunk.device_id
                            Sort Method: quicksort 
-                           ->  Sort (actual rows=0 loops=1)
-                                 Sort Key: _hyper_2_4_chunk."time"
-                                 Sort Method: quicksort 
-                                 ->  Custom Scan (DecompressChunk) on _hyper_2_4_chunk (actual rows=0 loops=1)
-                                       Filter: ((v0)::double precision = v1)
-                                       Rows Removed by Filter: 360
-                                       ->  Seq Scan on compress_hyper_6_17_chunk (actual rows=1 loops=1)
+                           ->  Seq Scan on _hyper_2_7_chunk (actual rows=0 loops=1)
+                                 Filter: ((v0)::double precision = v1)
+                                 Rows Removed by Filter: 504
+               ->  Sort (actual rows=0 loops=1)
+                     Sort Key: _hyper_2_8_chunk."time", _hyper_2_8_chunk.device_id
+                     Sort Method: quicksort 
                      ->  Sort (actual rows=0 loops=1)
-                           Sort Key: _hyper_2_5_chunk."time"
+                           Sort Key: _hyper_2_8_chunk."time", _hyper_2_8_chunk.device_id
                            Sort Method: quicksort 
-                           ->  Sort (actual rows=0 loops=1)
-                                 Sort Key: _hyper_2_5_chunk."time"
-                                 Sort Method: quicksort 
-                                 ->  Custom Scan (DecompressChunk) on _hyper_2_5_chunk (actual rows=0 loops=1)
-                                       Filter: ((v0)::double precision = v1)
-                                       Rows Removed by Filter: 1080
-                                       ->  Seq Scan on compress_hyper_6_18_chunk (actual rows=3 loops=1)
+                           ->  Seq Scan on _hyper_2_8_chunk (actual rows=0 loops=1)
+                                 Filter: ((v0)::double precision = v1)
+                                 Rows Removed by Filter: 1512
+               ->  Sort (actual rows=0 loops=1)
+                     Sort Key: _hyper_2_9_chunk."time", _hyper_2_9_chunk.device_id
+                     Sort Method: quicksort 
                      ->  Sort (actual rows=0 loops=1)
-                           Sort Key: _hyper_2_6_chunk."time"
+                           Sort Key: _hyper_2_9_chunk."time", _hyper_2_9_chunk.device_id
                            Sort Method: quicksort 
-                           ->  Sort (actual rows=0 loops=1)
-                                 Sort Key: _hyper_2_6_chunk."time"
-                                 Sort Method: quicksort 
-                                 ->  Custom Scan (DecompressChunk) on _hyper_2_6_chunk (actual rows=0 loops=1)
-                                       Filter: ((v0)::double precision = v1)
-                                       Rows Removed by Filter: 360
-                                       ->  Seq Scan on compress_hyper_6_19_chunk (actual rows=1 loops=1)
-               ->  Merge Append (actual rows=0 loops=1)
-                     Sort Key: _hyper_2_7_chunk."time"
-                     ->  Index Scan Backward using _hyper_2_7_chunk_metrics_space_time_idx on _hyper_2_7_chunk (actual rows=0 loops=1)
+                           ->  Seq Scan on _hyper_2_9_chunk (actual rows=0 loops=1)
+                                 Filter: ((v0)::double precision = v1)
+                                 Rows Removed by Filter: 504
+         ->  Merge Append (actual rows=0 loops=1)
+               Sort Key: _hyper_2_10_chunk."time", _hyper_2_10_chunk.device_id
+               ->  Sort (actual rows=0 loops=1)
+                     Sort Key: _hyper_2_10_chunk."time", _hyper_2_10_chunk.device_id
+                     Sort Method: quicksort 
+                     ->  Custom Scan (DecompressChunk) on _hyper_2_10_chunk (actual rows=0 loops=1)
                            Filter: ((v0)::double precision = v1)
                            Rows Removed by Filter: 504
-                     ->  Index Scan Backward using _hyper_2_8_chunk_metrics_space_time_idx on _hyper_2_8_chunk (actual rows=0 loops=1)
+                           ->  Seq Scan on compress_hyper_6_20_chunk (actual rows=1 loops=1)
+               ->  Sort (actual rows=0 loops=1)
+                     Sort Key: _hyper_2_11_chunk."time", _hyper_2_11_chunk.device_id
+                     Sort Method: quicksort 
+                     ->  Custom Scan (DecompressChunk) on _hyper_2_11_chunk (actual rows=0 loops=1)
                            Filter: ((v0)::double precision = v1)
                            Rows Removed by Filter: 1512
-                     ->  Index Scan Backward using _hyper_2_9_chunk_metrics_space_time_idx on _hyper_2_9_chunk (actual rows=0 loops=1)
-                           Filter: ((v0)::double precision = v1)
-                           Rows Removed by Filter: 504
-               ->  Merge Append (actual rows=0 loops=1)
-                     Sort Key: _hyper_2_10_chunk."time"
+                           ->  Seq Scan on compress_hyper_6_21_chunk (actual rows=3 loops=1)
+               ->  Sort (actual rows=0 loops=1)
+                     Sort Key: _hyper_2_12_chunk."time", _hyper_2_12_chunk.device_id
+                     Sort Method: quicksort 
                      ->  Sort (actual rows=0 loops=1)
-                           Sort Key: _hyper_2_10_chunk."time"
+                           Sort Key: _hyper_2_12_chunk."time", _hyper_2_12_chunk.device_id
                            Sort Method: quicksort 
-                           ->  Sort (actual rows=0 loops=1)
-                                 Sort Key: _hyper_2_10_chunk."time"
-                                 Sort Method: quicksort 
-                                 ->  Custom Scan (DecompressChunk) on _hyper_2_10_chunk (actual rows=0 loops=1)
-                                       Filter: ((v0)::double precision = v1)
-                                       Rows Removed by Filter: 504
-                                       ->  Seq Scan on compress_hyper_6_20_chunk (actual rows=1 loops=1)
-                     ->  Sort (actual rows=0 loops=1)
-                           Sort Key: _hyper_2_11_chunk."time"
-                           Sort Method: quicksort 
-                           ->  Sort (actual rows=0 loops=1)
-                                 Sort Key: _hyper_2_11_chunk."time"
-                                 Sort Method: quicksort 
-                                 ->  Custom Scan (DecompressChunk) on _hyper_2_11_chunk (actual rows=0 loops=1)
-                                       Filter: ((v0)::double precision = v1)
-                                       Rows Removed by Filter: 1512
-                                       ->  Seq Scan on compress_hyper_6_21_chunk (actual rows=3 loops=1)
-                     ->  Index Scan Backward using _hyper_2_12_chunk_metrics_space_time_idx on _hyper_2_12_chunk (actual rows=0 loops=1)
-                           Filter: ((v0)::double precision = v1)
-                           Rows Removed by Filter: 504
-(75 rows)
+                           ->  Seq Scan on _hyper_2_12_chunk (actual rows=0 loops=1)
+                                 Filter: ((v0)::double precision = v1)
+                                 Rows Removed by Filter: 504
+(80 rows)
 
 --pushdown of quals on order by and segment by cols anded together
 :PREFIX_VERBOSE
@@ -4972,73 +4929,72 @@ WHERE time > '2000-01-01 1:00:00+0'
 ORDER BY time,
     device_id
 LIMIT 10;
-                                                               QUERY PLAN                                                               
-----------------------------------------------------------------------------------------------------------------------------------------
+                                                            QUERY PLAN                                                            
+----------------------------------------------------------------------------------------------------------------------------------
  Limit (actual rows=10 loops=1)
-   ->  Incremental Sort (actual rows=10 loops=1)
-         Sort Key: metrics_space."time", metrics_space.device_id
-         Presorted Key: metrics_space."time"
-         Full-sort Groups: 1  Sort Method: quicksort 
-         ->  Custom Scan (ChunkAppend) on metrics_space (actual rows=15 loops=1)
-               Order: metrics_space."time"
-               ->  Merge Append (actual rows=15 loops=1)
-                     Sort Key: _hyper_2_4_chunk."time"
-                     ->  Sort (actual rows=7 loops=1)
-                           Sort Key: _hyper_2_4_chunk."time"
-                           Sort Method: quicksort 
-                           ->  Sort (actual rows=360 loops=1)
-                                 Sort Key: _hyper_2_4_chunk."time"
-                                 Sort Method: quicksort 
-                                 ->  Custom Scan (DecompressChunk) on _hyper_2_4_chunk (actual rows=360 loops=1)
-                                       Filter: (("time" > 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone) OR (device_id = 1))
-                                       ->  Seq Scan on compress_hyper_6_17_chunk (actual rows=1 loops=1)
-                     ->  Sort (actual rows=7 loops=1)
-                           Sort Key: _hyper_2_5_chunk."time"
-                           Sort Method: quicksort 
-                           ->  Sort (actual rows=1068 loops=1)
-                                 Sort Key: _hyper_2_5_chunk."time"
-                                 Sort Method: quicksort 
-                                 ->  Custom Scan (DecompressChunk) on _hyper_2_5_chunk (actual rows=1068 loops=1)
-                                       Filter: (("time" > 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone) OR (device_id = 1))
-                                       Rows Removed by Filter: 12
-                                       ->  Seq Scan on compress_hyper_6_18_chunk (actual rows=3 loops=1)
-                     ->  Sort (actual rows=3 loops=1)
-                           Sort Key: _hyper_2_6_chunk."time"
-                           Sort Method: quicksort 
-                           ->  Sort (actual rows=356 loops=1)
-                                 Sort Key: _hyper_2_6_chunk."time"
-                                 Sort Method: quicksort 
-                                 ->  Custom Scan (DecompressChunk) on _hyper_2_6_chunk (actual rows=356 loops=1)
-                                       Filter: (("time" > 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone) OR (device_id = 1))
-                                       Rows Removed by Filter: 4
-                                       ->  Seq Scan on compress_hyper_6_19_chunk (actual rows=1 loops=1)
-               ->  Merge Append (never executed)
-                     Sort Key: _hyper_2_7_chunk."time"
-                     ->  Index Scan Backward using _hyper_2_7_chunk_metrics_space_time_idx on _hyper_2_7_chunk (never executed)
+   ->  Custom Scan (ChunkAppend) on metrics_space (actual rows=10 loops=1)
+         Order: metrics_space."time", metrics_space.device_id
+         ->  Merge Append (actual rows=10 loops=1)
+               Sort Key: _hyper_2_4_chunk."time", _hyper_2_4_chunk.device_id
+               ->  Sort (actual rows=6 loops=1)
+                     Sort Key: _hyper_2_4_chunk."time", _hyper_2_4_chunk.device_id
+                     Sort Method: top-N heapsort 
+                     ->  Custom Scan (DecompressChunk) on _hyper_2_4_chunk (actual rows=360 loops=1)
                            Filter: (("time" > 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone) OR (device_id = 1))
-                     ->  Index Scan Backward using _hyper_2_8_chunk_metrics_space_time_idx on _hyper_2_8_chunk (never executed)
+                           ->  Seq Scan on compress_hyper_6_17_chunk (actual rows=1 loops=1)
+               ->  Sort (actual rows=4 loops=1)
+                     Sort Key: _hyper_2_5_chunk."time", _hyper_2_5_chunk.device_id
+                     Sort Method: top-N heapsort 
+                     ->  Custom Scan (DecompressChunk) on _hyper_2_5_chunk (actual rows=1068 loops=1)
                            Filter: (("time" > 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone) OR (device_id = 1))
-                     ->  Index Scan Backward using _hyper_2_9_chunk_metrics_space_time_idx on _hyper_2_9_chunk (never executed)
+                           Rows Removed by Filter: 12
+                           ->  Seq Scan on compress_hyper_6_18_chunk (actual rows=3 loops=1)
+               ->  Sort (actual rows=2 loops=1)
+                     Sort Key: _hyper_2_6_chunk."time", _hyper_2_6_chunk.device_id
+                     Sort Method: top-N heapsort 
+                     ->  Custom Scan (DecompressChunk) on _hyper_2_6_chunk (actual rows=356 loops=1)
                            Filter: (("time" > 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone) OR (device_id = 1))
-               ->  Merge Append (never executed)
-                     Sort Key: _hyper_2_10_chunk."time"
+                           Rows Removed by Filter: 4
+                           ->  Seq Scan on compress_hyper_6_19_chunk (actual rows=1 loops=1)
+         ->  Merge Append (never executed)
+               Sort Key: _hyper_2_7_chunk."time", _hyper_2_7_chunk.device_id
+               ->  Sort (never executed)
+                     Sort Key: _hyper_2_7_chunk."time", _hyper_2_7_chunk.device_id
                      ->  Sort (never executed)
-                           Sort Key: _hyper_2_10_chunk."time"
-                           ->  Sort (never executed)
-                                 Sort Key: _hyper_2_10_chunk."time"
-                                 ->  Custom Scan (DecompressChunk) on _hyper_2_10_chunk (never executed)
-                                       Filter: (("time" > 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone) OR (device_id = 1))
-                                       ->  Seq Scan on compress_hyper_6_20_chunk (never executed)
+                           Sort Key: _hyper_2_7_chunk."time", _hyper_2_7_chunk.device_id
+                           ->  Seq Scan on _hyper_2_7_chunk (never executed)
+                                 Filter: (("time" > 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone) OR (device_id = 1))
+               ->  Sort (never executed)
+                     Sort Key: _hyper_2_8_chunk."time", _hyper_2_8_chunk.device_id
                      ->  Sort (never executed)
-                           Sort Key: _hyper_2_11_chunk."time"
-                           ->  Sort (never executed)
-                                 Sort Key: _hyper_2_11_chunk."time"
-                                 ->  Custom Scan (DecompressChunk) on _hyper_2_11_chunk (never executed)
-                                       Filter: (("time" > 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone) OR (device_id = 1))
-                                       ->  Seq Scan on compress_hyper_6_21_chunk (never executed)
-                     ->  Index Scan Backward using _hyper_2_12_chunk_metrics_space_time_idx on _hyper_2_12_chunk (never executed)
+                           Sort Key: _hyper_2_8_chunk."time", _hyper_2_8_chunk.device_id
+                           ->  Seq Scan on _hyper_2_8_chunk (never executed)
+                                 Filter: (("time" > 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone) OR (device_id = 1))
+               ->  Sort (never executed)
+                     Sort Key: _hyper_2_9_chunk."time", _hyper_2_9_chunk.device_id
+                     ->  Sort (never executed)
+                           Sort Key: _hyper_2_9_chunk."time", _hyper_2_9_chunk.device_id
+                           ->  Seq Scan on _hyper_2_9_chunk (never executed)
+                                 Filter: (("time" > 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone) OR (device_id = 1))
+         ->  Merge Append (never executed)
+               Sort Key: _hyper_2_10_chunk."time", _hyper_2_10_chunk.device_id
+               ->  Sort (never executed)
+                     Sort Key: _hyper_2_10_chunk."time", _hyper_2_10_chunk.device_id
+                     ->  Custom Scan (DecompressChunk) on _hyper_2_10_chunk (never executed)
                            Filter: (("time" > 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone) OR (device_id = 1))
-(64 rows)
+                           ->  Seq Scan on compress_hyper_6_20_chunk (never executed)
+               ->  Sort (never executed)
+                     Sort Key: _hyper_2_11_chunk."time", _hyper_2_11_chunk.device_id
+                     ->  Custom Scan (DecompressChunk) on _hyper_2_11_chunk (never executed)
+                           Filter: (("time" > 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone) OR (device_id = 1))
+                           ->  Seq Scan on compress_hyper_6_21_chunk (never executed)
+               ->  Sort (never executed)
+                     Sort Key: _hyper_2_12_chunk."time", _hyper_2_12_chunk.device_id
+                     ->  Sort (never executed)
+                           Sort Key: _hyper_2_12_chunk."time", _hyper_2_12_chunk.device_id
+                           ->  Seq Scan on _hyper_2_12_chunk (never executed)
+                                 Filter: (("time" > 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone) OR (device_id = 1))
+(63 rows)
 
 --functions not yet optimized
 :PREFIX
@@ -5048,71 +5004,70 @@ WHERE time < now()
 ORDER BY time,
     device_id
 LIMIT 10;
-                                                            QUERY PLAN                                                            
-----------------------------------------------------------------------------------------------------------------------------------
+                                              QUERY PLAN                                              
+------------------------------------------------------------------------------------------------------
  Limit (actual rows=10 loops=1)
-   ->  Incremental Sort (actual rows=10 loops=1)
-         Sort Key: metrics_space."time", metrics_space.device_id
-         Presorted Key: metrics_space."time"
-         Full-sort Groups: 1  Sort Method: quicksort 
-         ->  Custom Scan (ChunkAppend) on metrics_space (actual rows=11 loops=1)
-               Order: metrics_space."time"
-               ->  Merge Append (actual rows=11 loops=1)
-                     Sort Key: _hyper_2_4_chunk."time"
-                     ->  Sort (actual rows=3 loops=1)
-                           Sort Key: _hyper_2_4_chunk."time"
-                           Sort Method: quicksort 
-                           ->  Sort (actual rows=360 loops=1)
-                                 Sort Key: _hyper_2_4_chunk."time"
-                                 Sort Method: quicksort 
-                                 ->  Custom Scan (DecompressChunk) on _hyper_2_4_chunk (actual rows=360 loops=1)
-                                       Filter: ("time" < now())
-                                       ->  Seq Scan on compress_hyper_6_17_chunk (actual rows=1 loops=1)
-                     ->  Sort (actual rows=7 loops=1)
-                           Sort Key: _hyper_2_5_chunk."time"
-                           Sort Method: quicksort 
-                           ->  Sort (actual rows=1080 loops=1)
-                                 Sort Key: _hyper_2_5_chunk."time"
-                                 Sort Method: quicksort 
-                                 ->  Custom Scan (DecompressChunk) on _hyper_2_5_chunk (actual rows=1080 loops=1)
-                                       Filter: ("time" < now())
-                                       ->  Seq Scan on compress_hyper_6_18_chunk (actual rows=3 loops=1)
-                     ->  Sort (actual rows=3 loops=1)
-                           Sort Key: _hyper_2_6_chunk."time"
-                           Sort Method: quicksort 
-                           ->  Sort (actual rows=360 loops=1)
-                                 Sort Key: _hyper_2_6_chunk."time"
-                                 Sort Method: quicksort 
-                                 ->  Custom Scan (DecompressChunk) on _hyper_2_6_chunk (actual rows=360 loops=1)
-                                       Filter: ("time" < now())
-                                       ->  Seq Scan on compress_hyper_6_19_chunk (actual rows=1 loops=1)
-               ->  Merge Append (never executed)
-                     Sort Key: _hyper_2_7_chunk."time"
-                     ->  Index Scan Backward using _hyper_2_7_chunk_metrics_space_time_idx on _hyper_2_7_chunk (never executed)
-                           Index Cond: ("time" < now())
-                     ->  Index Scan Backward using _hyper_2_8_chunk_metrics_space_time_idx on _hyper_2_8_chunk (never executed)
-                           Index Cond: ("time" < now())
-                     ->  Index Scan Backward using _hyper_2_9_chunk_metrics_space_time_idx on _hyper_2_9_chunk (never executed)
-                           Index Cond: ("time" < now())
-               ->  Merge Append (never executed)
-                     Sort Key: _hyper_2_10_chunk."time"
+   ->  Custom Scan (ChunkAppend) on metrics_space (actual rows=10 loops=1)
+         Order: metrics_space."time", metrics_space.device_id
+         ->  Merge Append (actual rows=10 loops=1)
+               Sort Key: _hyper_2_4_chunk."time", _hyper_2_4_chunk.device_id
+               ->  Sort (actual rows=3 loops=1)
+                     Sort Key: _hyper_2_4_chunk."time", _hyper_2_4_chunk.device_id
+                     Sort Method: top-N heapsort 
+                     ->  Custom Scan (DecompressChunk) on _hyper_2_4_chunk (actual rows=360 loops=1)
+                           Filter: ("time" < now())
+                           ->  Seq Scan on compress_hyper_6_17_chunk (actual rows=1 loops=1)
+               ->  Sort (actual rows=6 loops=1)
+                     Sort Key: _hyper_2_5_chunk."time", _hyper_2_5_chunk.device_id
+                     Sort Method: top-N heapsort 
+                     ->  Custom Scan (DecompressChunk) on _hyper_2_5_chunk (actual rows=1080 loops=1)
+                           Filter: ("time" < now())
+                           ->  Seq Scan on compress_hyper_6_18_chunk (actual rows=3 loops=1)
+               ->  Sort (actual rows=3 loops=1)
+                     Sort Key: _hyper_2_6_chunk."time", _hyper_2_6_chunk.device_id
+                     Sort Method: top-N heapsort 
+                     ->  Custom Scan (DecompressChunk) on _hyper_2_6_chunk (actual rows=360 loops=1)
+                           Filter: ("time" < now())
+                           ->  Seq Scan on compress_hyper_6_19_chunk (actual rows=1 loops=1)
+         ->  Merge Append (never executed)
+               Sort Key: _hyper_2_7_chunk."time", _hyper_2_7_chunk.device_id
+               ->  Sort (never executed)
+                     Sort Key: _hyper_2_7_chunk."time", _hyper_2_7_chunk.device_id
                      ->  Sort (never executed)
-                           Sort Key: _hyper_2_10_chunk."time"
-                           ->  Sort (never executed)
-                                 Sort Key: _hyper_2_10_chunk."time"
-                                 ->  Custom Scan (DecompressChunk) on _hyper_2_10_chunk (never executed)
-                                       Filter: ("time" < now())
-                                       ->  Seq Scan on compress_hyper_6_20_chunk (never executed)
+                           Sort Key: _hyper_2_7_chunk."time", _hyper_2_7_chunk.device_id
+                           ->  Seq Scan on _hyper_2_7_chunk (never executed)
+                                 Filter: ("time" < now())
+               ->  Sort (never executed)
+                     Sort Key: _hyper_2_8_chunk."time", _hyper_2_8_chunk.device_id
                      ->  Sort (never executed)
-                           Sort Key: _hyper_2_11_chunk."time"
-                           ->  Sort (never executed)
-                                 Sort Key: _hyper_2_11_chunk."time"
-                                 ->  Custom Scan (DecompressChunk) on _hyper_2_11_chunk (never executed)
-                                       Filter: ("time" < now())
-                                       ->  Seq Scan on compress_hyper_6_21_chunk (never executed)
-                     ->  Index Scan Backward using _hyper_2_12_chunk_metrics_space_time_idx on _hyper_2_12_chunk (never executed)
-                           Index Cond: ("time" < now())
-(62 rows)
+                           Sort Key: _hyper_2_8_chunk."time", _hyper_2_8_chunk.device_id
+                           ->  Seq Scan on _hyper_2_8_chunk (never executed)
+                                 Filter: ("time" < now())
+               ->  Sort (never executed)
+                     Sort Key: _hyper_2_9_chunk."time", _hyper_2_9_chunk.device_id
+                     ->  Sort (never executed)
+                           Sort Key: _hyper_2_9_chunk."time", _hyper_2_9_chunk.device_id
+                           ->  Seq Scan on _hyper_2_9_chunk (never executed)
+                                 Filter: ("time" < now())
+         ->  Merge Append (never executed)
+               Sort Key: _hyper_2_10_chunk."time", _hyper_2_10_chunk.device_id
+               ->  Sort (never executed)
+                     Sort Key: _hyper_2_10_chunk."time", _hyper_2_10_chunk.device_id
+                     ->  Custom Scan (DecompressChunk) on _hyper_2_10_chunk (never executed)
+                           Filter: ("time" < now())
+                           ->  Seq Scan on compress_hyper_6_20_chunk (never executed)
+               ->  Sort (never executed)
+                     Sort Key: _hyper_2_11_chunk."time", _hyper_2_11_chunk.device_id
+                     ->  Custom Scan (DecompressChunk) on _hyper_2_11_chunk (never executed)
+                           Filter: ("time" < now())
+                           ->  Seq Scan on compress_hyper_6_21_chunk (never executed)
+               ->  Sort (never executed)
+                     Sort Key: _hyper_2_12_chunk."time", _hyper_2_12_chunk.device_id
+                     ->  Sort (never executed)
+                           Sort Key: _hyper_2_12_chunk."time", _hyper_2_12_chunk.device_id
+                           ->  Seq Scan on _hyper_2_12_chunk (never executed)
+                                 Filter: ("time" < now())
+(61 rows)
 
 -- test sort optimization interaction
 :PREFIX
@@ -5132,19 +5087,13 @@ LIMIT 10;
                ->  Sort (actual rows=6 loops=1)
                      Sort Key: _hyper_2_11_chunk."time" DESC
                      Sort Method: top-N heapsort 
-                     ->  Sort (actual rows=1512 loops=1)
-                           Sort Key: _hyper_2_11_chunk."time" DESC
-                           Sort Method: quicksort 
-                           ->  Custom Scan (DecompressChunk) on _hyper_2_11_chunk (actual rows=1512 loops=1)
-                                 ->  Seq Scan on compress_hyper_6_21_chunk (actual rows=3 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_2_11_chunk (actual rows=1512 loops=1)
+                           ->  Seq Scan on compress_hyper_6_21_chunk (actual rows=3 loops=1)
                ->  Sort (actual rows=3 loops=1)
                      Sort Key: _hyper_2_10_chunk."time" DESC
                      Sort Method: top-N heapsort 
-                     ->  Sort (actual rows=504 loops=1)
-                           Sort Key: _hyper_2_10_chunk."time" DESC
-                           Sort Method: quicksort 
-                           ->  Custom Scan (DecompressChunk) on _hyper_2_10_chunk (actual rows=504 loops=1)
-                                 ->  Seq Scan on compress_hyper_6_20_chunk (actual rows=1 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_2_10_chunk (actual rows=504 loops=1)
+                           ->  Seq Scan on compress_hyper_6_20_chunk (actual rows=1 loops=1)
          ->  Merge Append (never executed)
                Sort Key: _hyper_2_9_chunk."time" DESC
                ->  Index Only Scan using _hyper_2_9_chunk_metrics_space_time_idx on _hyper_2_9_chunk (never executed)
@@ -5157,23 +5106,17 @@ LIMIT 10;
                Sort Key: _hyper_2_6_chunk."time" DESC
                ->  Sort (never executed)
                      Sort Key: _hyper_2_6_chunk."time" DESC
-                     ->  Sort (never executed)
-                           Sort Key: _hyper_2_6_chunk."time" DESC
-                           ->  Custom Scan (DecompressChunk) on _hyper_2_6_chunk (never executed)
-                                 ->  Seq Scan on compress_hyper_6_19_chunk (never executed)
+                     ->  Custom Scan (DecompressChunk) on _hyper_2_6_chunk (never executed)
+                           ->  Seq Scan on compress_hyper_6_19_chunk (never executed)
                ->  Sort (never executed)
                      Sort Key: _hyper_2_5_chunk."time" DESC
-                     ->  Sort (never executed)
-                           Sort Key: _hyper_2_5_chunk."time" DESC
-                           ->  Custom Scan (DecompressChunk) on _hyper_2_5_chunk (never executed)
-                                 ->  Seq Scan on compress_hyper_6_18_chunk (never executed)
+                     ->  Custom Scan (DecompressChunk) on _hyper_2_5_chunk (never executed)
+                           ->  Seq Scan on compress_hyper_6_18_chunk (never executed)
                ->  Sort (never executed)
                      Sort Key: _hyper_2_4_chunk."time" DESC
-                     ->  Sort (never executed)
-                           Sort Key: _hyper_2_4_chunk."time" DESC
-                           ->  Custom Scan (DecompressChunk) on _hyper_2_4_chunk (never executed)
-                                 ->  Seq Scan on compress_hyper_6_17_chunk (never executed)
-(51 rows)
+                     ->  Custom Scan (DecompressChunk) on _hyper_2_4_chunk (never executed)
+                           ->  Seq Scan on compress_hyper_6_17_chunk (never executed)
+(39 rows)
 
 :PREFIX
 SELECT time,
@@ -5195,21 +5138,15 @@ LIMIT 10;
                      Sort Key: _hyper_2_12_chunk."time" DESC
                      ->  Index Scan using _hyper_2_12_chunk_metrics_space_time_idx on _hyper_2_12_chunk (actual rows=3 loops=1)
                      ->  Sort (actual rows=7 loops=1)
-                           Sort Key: _hyper_2_11_chunk."time" DESC
+                           Sort Key: _hyper_2_11_chunk."time" DESC, _hyper_2_11_chunk.device_id
                            Sort Method: quicksort 
-                           ->  Sort (actual rows=1512 loops=1)
-                                 Sort Key: _hyper_2_11_chunk."time" DESC
-                                 Sort Method: quicksort 
-                                 ->  Custom Scan (DecompressChunk) on _hyper_2_11_chunk (actual rows=1512 loops=1)
-                                       ->  Seq Scan on compress_hyper_6_21_chunk (actual rows=3 loops=1)
+                           ->  Custom Scan (DecompressChunk) on _hyper_2_11_chunk (actual rows=1512 loops=1)
+                                 ->  Seq Scan on compress_hyper_6_21_chunk (actual rows=3 loops=1)
                      ->  Sort (actual rows=3 loops=1)
-                           Sort Key: _hyper_2_10_chunk."time" DESC
+                           Sort Key: _hyper_2_10_chunk."time" DESC, _hyper_2_10_chunk.device_id
                            Sort Method: quicksort 
-                           ->  Sort (actual rows=504 loops=1)
-                                 Sort Key: _hyper_2_10_chunk."time" DESC
-                                 Sort Method: quicksort 
-                                 ->  Custom Scan (DecompressChunk) on _hyper_2_10_chunk (actual rows=504 loops=1)
-                                       ->  Seq Scan on compress_hyper_6_20_chunk (actual rows=1 loops=1)
+                           ->  Custom Scan (DecompressChunk) on _hyper_2_10_chunk (actual rows=504 loops=1)
+                                 ->  Seq Scan on compress_hyper_6_20_chunk (actual rows=1 loops=1)
                ->  Merge Append (never executed)
                      Sort Key: _hyper_2_9_chunk."time" DESC
                      ->  Index Scan using _hyper_2_9_chunk_metrics_space_time_idx on _hyper_2_9_chunk (never executed)
@@ -5218,24 +5155,18 @@ LIMIT 10;
                ->  Merge Append (never executed)
                      Sort Key: _hyper_2_6_chunk."time" DESC
                      ->  Sort (never executed)
-                           Sort Key: _hyper_2_6_chunk."time" DESC
-                           ->  Sort (never executed)
-                                 Sort Key: _hyper_2_6_chunk."time" DESC
-                                 ->  Custom Scan (DecompressChunk) on _hyper_2_6_chunk (never executed)
-                                       ->  Seq Scan on compress_hyper_6_19_chunk (never executed)
+                           Sort Key: _hyper_2_6_chunk."time" DESC, _hyper_2_6_chunk.device_id
+                           ->  Custom Scan (DecompressChunk) on _hyper_2_6_chunk (never executed)
+                                 ->  Seq Scan on compress_hyper_6_19_chunk (never executed)
                      ->  Sort (never executed)
-                           Sort Key: _hyper_2_5_chunk."time" DESC
-                           ->  Sort (never executed)
-                                 Sort Key: _hyper_2_5_chunk."time" DESC
-                                 ->  Custom Scan (DecompressChunk) on _hyper_2_5_chunk (never executed)
-                                       ->  Seq Scan on compress_hyper_6_18_chunk (never executed)
+                           Sort Key: _hyper_2_5_chunk."time" DESC, _hyper_2_5_chunk.device_id
+                           ->  Custom Scan (DecompressChunk) on _hyper_2_5_chunk (never executed)
+                                 ->  Seq Scan on compress_hyper_6_18_chunk (never executed)
                      ->  Sort (never executed)
-                           Sort Key: _hyper_2_4_chunk."time" DESC
-                           ->  Sort (never executed)
-                                 Sort Key: _hyper_2_4_chunk."time" DESC
-                                 ->  Custom Scan (DecompressChunk) on _hyper_2_4_chunk (never executed)
-                                       ->  Seq Scan on compress_hyper_6_17_chunk (never executed)
-(51 rows)
+                           Sort Key: _hyper_2_4_chunk."time" DESC, _hyper_2_4_chunk.device_id
+                           ->  Custom Scan (DecompressChunk) on _hyper_2_4_chunk (never executed)
+                                 ->  Seq Scan on compress_hyper_6_17_chunk (never executed)
+(39 rows)
 
 :PREFIX
 SELECT time,
@@ -5294,65 +5225,43 @@ FROM :TEST_TABLE
 WHERE time > '2000-01-08'
 ORDER BY time,
     device_id;
-                                                                                                                                                                                                                                                                                                                  QUERY PLAN                                                                                                                                                                                                                                                                                                                  
-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
- Incremental Sort (actual rows=4195 loops=1)
-   Output: metrics_space."time", metrics_space.device_id, metrics_space.device_id_peer, metrics_space.v0, metrics_space.v1, metrics_space.v2, metrics_space.v3
-   Sort Key: metrics_space."time", metrics_space.device_id
-   Presorted Key: metrics_space."time"
-   Full-sort Groups: 120  Sort Method: quicksort 
-   ->  Custom Scan (ChunkAppend) on public.metrics_space (actual rows=4195 loops=1)
-         Output: metrics_space."time", metrics_space.device_id, metrics_space.device_id_peer, metrics_space.v0, metrics_space.v1, metrics_space.v2, metrics_space.v3
-         Order: metrics_space."time"
-         Startup Exclusion: false
-         Runtime Exclusion: false
-         ->  Merge Append (actual rows=1675 loops=1)
-               Sort Key: _hyper_2_7_chunk."time"
-               ->  Index Scan Backward using _hyper_2_7_chunk_metrics_space_time_idx on _timescaledb_internal._hyper_2_7_chunk (actual rows=335 loops=1)
-                     Output: _hyper_2_7_chunk."time", _hyper_2_7_chunk.device_id, _hyper_2_7_chunk.device_id_peer, _hyper_2_7_chunk.v0, _hyper_2_7_chunk.v1, _hyper_2_7_chunk.v2, _hyper_2_7_chunk.v3
-                     Index Cond: (_hyper_2_7_chunk."time" > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
-               ->  Index Scan Backward using _hyper_2_8_chunk_metrics_space_time_idx on _timescaledb_internal._hyper_2_8_chunk (actual rows=1005 loops=1)
-                     Output: _hyper_2_8_chunk."time", _hyper_2_8_chunk.device_id, _hyper_2_8_chunk.device_id_peer, _hyper_2_8_chunk.v0, _hyper_2_8_chunk.v1, _hyper_2_8_chunk.v2, _hyper_2_8_chunk.v3
-                     Index Cond: (_hyper_2_8_chunk."time" > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
-               ->  Index Scan Backward using _hyper_2_9_chunk_metrics_space_time_idx on _timescaledb_internal._hyper_2_9_chunk (actual rows=335 loops=1)
-                     Output: _hyper_2_9_chunk."time", _hyper_2_9_chunk.device_id, _hyper_2_9_chunk.device_id_peer, _hyper_2_9_chunk.v0, _hyper_2_9_chunk.v1, _hyper_2_9_chunk.v2, _hyper_2_9_chunk.v3
-                     Index Cond: (_hyper_2_9_chunk."time" > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
-         ->  Merge Append (actual rows=2520 loops=1)
-               Sort Key: _hyper_2_10_chunk."time"
-               ->  Sort (actual rows=504 loops=1)
-                     Output: _hyper_2_10_chunk."time", _hyper_2_10_chunk.device_id, _hyper_2_10_chunk.device_id_peer, _hyper_2_10_chunk.v0, _hyper_2_10_chunk.v1, _hyper_2_10_chunk.v2, _hyper_2_10_chunk.v3
-                     Sort Key: _hyper_2_10_chunk."time"
-                     Sort Method: quicksort 
-                     ->  Sort (actual rows=504 loops=1)
-                           Output: _hyper_2_10_chunk."time", _hyper_2_10_chunk.device_id, _hyper_2_10_chunk.device_id_peer, _hyper_2_10_chunk.v0, _hyper_2_10_chunk.v1, _hyper_2_10_chunk.v2, _hyper_2_10_chunk.v3
-                           Sort Key: _hyper_2_10_chunk."time"
-                           Sort Method: quicksort 
-                           ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_10_chunk (actual rows=504 loops=1)
-                                 Output: _hyper_2_10_chunk."time", _hyper_2_10_chunk.device_id, _hyper_2_10_chunk.device_id_peer, _hyper_2_10_chunk.v0, _hyper_2_10_chunk.v1, _hyper_2_10_chunk.v2, _hyper_2_10_chunk.v3
-                                 Vectorized Filter: (_hyper_2_10_chunk."time" > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
-                                 Bulk Decompression: true
-                                 ->  Seq Scan on _timescaledb_internal.compress_hyper_6_20_chunk (actual rows=1 loops=1)
-                                       Output: compress_hyper_6_20_chunk."time", compress_hyper_6_20_chunk.device_id, compress_hyper_6_20_chunk.device_id_peer, compress_hyper_6_20_chunk.v0, compress_hyper_6_20_chunk.v1, compress_hyper_6_20_chunk.v2, compress_hyper_6_20_chunk.v3, compress_hyper_6_20_chunk._ts_meta_count, compress_hyper_6_20_chunk._ts_meta_sequence_num, compress_hyper_6_20_chunk._ts_meta_min_3, compress_hyper_6_20_chunk._ts_meta_max_3, compress_hyper_6_20_chunk._ts_meta_min_1, compress_hyper_6_20_chunk._ts_meta_max_1, compress_hyper_6_20_chunk._ts_meta_min_2, compress_hyper_6_20_chunk._ts_meta_max_2
-                                       Filter: (compress_hyper_6_20_chunk._ts_meta_max_3 > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
-               ->  Sort (actual rows=1512 loops=1)
-                     Output: _hyper_2_11_chunk."time", _hyper_2_11_chunk.device_id, _hyper_2_11_chunk.device_id_peer, _hyper_2_11_chunk.v0, _hyper_2_11_chunk.v1, _hyper_2_11_chunk.v2, _hyper_2_11_chunk.v3
-                     Sort Key: _hyper_2_11_chunk."time"
-                     Sort Method: quicksort 
-                     ->  Sort (actual rows=1512 loops=1)
-                           Output: _hyper_2_11_chunk."time", _hyper_2_11_chunk.device_id, _hyper_2_11_chunk.device_id_peer, _hyper_2_11_chunk.v0, _hyper_2_11_chunk.v1, _hyper_2_11_chunk.v2, _hyper_2_11_chunk.v3
-                           Sort Key: _hyper_2_11_chunk."time"
-                           Sort Method: quicksort 
-                           ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_11_chunk (actual rows=1512 loops=1)
-                                 Output: _hyper_2_11_chunk."time", _hyper_2_11_chunk.device_id, _hyper_2_11_chunk.device_id_peer, _hyper_2_11_chunk.v0, _hyper_2_11_chunk.v1, _hyper_2_11_chunk.v2, _hyper_2_11_chunk.v3
-                                 Vectorized Filter: (_hyper_2_11_chunk."time" > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
-                                 Bulk Decompression: true
-                                 ->  Seq Scan on _timescaledb_internal.compress_hyper_6_21_chunk (actual rows=3 loops=1)
-                                       Output: compress_hyper_6_21_chunk."time", compress_hyper_6_21_chunk.device_id, compress_hyper_6_21_chunk.device_id_peer, compress_hyper_6_21_chunk.v0, compress_hyper_6_21_chunk.v1, compress_hyper_6_21_chunk.v2, compress_hyper_6_21_chunk.v3, compress_hyper_6_21_chunk._ts_meta_count, compress_hyper_6_21_chunk._ts_meta_sequence_num, compress_hyper_6_21_chunk._ts_meta_min_3, compress_hyper_6_21_chunk._ts_meta_max_3, compress_hyper_6_21_chunk._ts_meta_min_1, compress_hyper_6_21_chunk._ts_meta_max_1, compress_hyper_6_21_chunk._ts_meta_min_2, compress_hyper_6_21_chunk._ts_meta_max_2
-                                       Filter: (compress_hyper_6_21_chunk._ts_meta_max_3 > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
-               ->  Index Scan Backward using _hyper_2_12_chunk_metrics_space_time_idx on _timescaledb_internal._hyper_2_12_chunk (actual rows=504 loops=1)
-                     Output: _hyper_2_12_chunk."time", _hyper_2_12_chunk.device_id, _hyper_2_12_chunk.device_id_peer, _hyper_2_12_chunk.v0, _hyper_2_12_chunk.v1, _hyper_2_12_chunk.v2, _hyper_2_12_chunk.v3
-                     Index Cond: (_hyper_2_12_chunk."time" > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
-(56 rows)
+                                                                                                                                                                                                                                                                                                         QUERY PLAN                                                                                                                                                                                                                                                                                                         
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Sort (actual rows=4195 loops=1)
+   Output: _hyper_2_7_chunk."time", _hyper_2_7_chunk.device_id, _hyper_2_7_chunk.device_id_peer, _hyper_2_7_chunk.v0, _hyper_2_7_chunk.v1, _hyper_2_7_chunk.v2, _hyper_2_7_chunk.v3
+   Sort Key: _hyper_2_7_chunk."time", _hyper_2_7_chunk.device_id
+   Sort Method: quicksort 
+   ->  Append (actual rows=4195 loops=1)
+         ->  Seq Scan on _timescaledb_internal._hyper_2_7_chunk (actual rows=335 loops=1)
+               Output: _hyper_2_7_chunk."time", _hyper_2_7_chunk.device_id, _hyper_2_7_chunk.device_id_peer, _hyper_2_7_chunk.v0, _hyper_2_7_chunk.v1, _hyper_2_7_chunk.v2, _hyper_2_7_chunk.v3
+               Filter: (_hyper_2_7_chunk."time" > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
+               Rows Removed by Filter: 169
+         ->  Seq Scan on _timescaledb_internal._hyper_2_8_chunk (actual rows=1005 loops=1)
+               Output: _hyper_2_8_chunk."time", _hyper_2_8_chunk.device_id, _hyper_2_8_chunk.device_id_peer, _hyper_2_8_chunk.v0, _hyper_2_8_chunk.v1, _hyper_2_8_chunk.v2, _hyper_2_8_chunk.v3
+               Filter: (_hyper_2_8_chunk."time" > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
+               Rows Removed by Filter: 507
+         ->  Seq Scan on _timescaledb_internal._hyper_2_9_chunk (actual rows=335 loops=1)
+               Output: _hyper_2_9_chunk."time", _hyper_2_9_chunk.device_id, _hyper_2_9_chunk.device_id_peer, _hyper_2_9_chunk.v0, _hyper_2_9_chunk.v1, _hyper_2_9_chunk.v2, _hyper_2_9_chunk.v3
+               Filter: (_hyper_2_9_chunk."time" > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
+               Rows Removed by Filter: 169
+         ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_10_chunk (actual rows=504 loops=1)
+               Output: _hyper_2_10_chunk."time", _hyper_2_10_chunk.device_id, _hyper_2_10_chunk.device_id_peer, _hyper_2_10_chunk.v0, _hyper_2_10_chunk.v1, _hyper_2_10_chunk.v2, _hyper_2_10_chunk.v3
+               Vectorized Filter: (_hyper_2_10_chunk."time" > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
+               Bulk Decompression: true
+               ->  Seq Scan on _timescaledb_internal.compress_hyper_6_20_chunk (actual rows=1 loops=1)
+                     Output: compress_hyper_6_20_chunk."time", compress_hyper_6_20_chunk.device_id, compress_hyper_6_20_chunk.device_id_peer, compress_hyper_6_20_chunk.v0, compress_hyper_6_20_chunk.v1, compress_hyper_6_20_chunk.v2, compress_hyper_6_20_chunk.v3, compress_hyper_6_20_chunk._ts_meta_count, compress_hyper_6_20_chunk._ts_meta_sequence_num, compress_hyper_6_20_chunk._ts_meta_min_3, compress_hyper_6_20_chunk._ts_meta_max_3, compress_hyper_6_20_chunk._ts_meta_min_1, compress_hyper_6_20_chunk._ts_meta_max_1, compress_hyper_6_20_chunk._ts_meta_min_2, compress_hyper_6_20_chunk._ts_meta_max_2
+                     Filter: (compress_hyper_6_20_chunk._ts_meta_max_3 > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
+         ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_11_chunk (actual rows=1512 loops=1)
+               Output: _hyper_2_11_chunk."time", _hyper_2_11_chunk.device_id, _hyper_2_11_chunk.device_id_peer, _hyper_2_11_chunk.v0, _hyper_2_11_chunk.v1, _hyper_2_11_chunk.v2, _hyper_2_11_chunk.v3
+               Vectorized Filter: (_hyper_2_11_chunk."time" > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
+               Bulk Decompression: true
+               ->  Seq Scan on _timescaledb_internal.compress_hyper_6_21_chunk (actual rows=3 loops=1)
+                     Output: compress_hyper_6_21_chunk."time", compress_hyper_6_21_chunk.device_id, compress_hyper_6_21_chunk.device_id_peer, compress_hyper_6_21_chunk.v0, compress_hyper_6_21_chunk.v1, compress_hyper_6_21_chunk.v2, compress_hyper_6_21_chunk.v3, compress_hyper_6_21_chunk._ts_meta_count, compress_hyper_6_21_chunk._ts_meta_sequence_num, compress_hyper_6_21_chunk._ts_meta_min_3, compress_hyper_6_21_chunk._ts_meta_max_3, compress_hyper_6_21_chunk._ts_meta_min_1, compress_hyper_6_21_chunk._ts_meta_max_1, compress_hyper_6_21_chunk._ts_meta_min_2, compress_hyper_6_21_chunk._ts_meta_max_2
+                     Filter: (compress_hyper_6_21_chunk._ts_meta_max_3 > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
+         ->  Seq Scan on _timescaledb_internal._hyper_2_12_chunk (actual rows=504 loops=1)
+               Output: _hyper_2_12_chunk."time", _hyper_2_12_chunk.device_id, _hyper_2_12_chunk.device_id_peer, _hyper_2_12_chunk.v0, _hyper_2_12_chunk.v1, _hyper_2_12_chunk.v2, _hyper_2_12_chunk.v3
+               Filter: (_hyper_2_12_chunk."time" > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
+(34 rows)
 
 -- should produce ordered path
 :PREFIX_VERBOSE
@@ -5617,50 +5526,43 @@ ORDER BY device_id,
     v1 DESC,
     time,
     v3;
-                                                                                                                                                                                                                                                                                                            QUERY PLAN                                                                                                                                                                                                                                                                                                            
-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
- Incremental Sort (actual rows=4195 loops=1)
+                                                                                                                                                                                                                                                                                                         QUERY PLAN                                                                                                                                                                                                                                                                                                         
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Sort (actual rows=4195 loops=1)
    Output: _hyper_2_7_chunk."time", _hyper_2_7_chunk.device_id, _hyper_2_7_chunk.device_id_peer, _hyper_2_7_chunk.v0, _hyper_2_7_chunk.v1, _hyper_2_7_chunk.v2, _hyper_2_7_chunk.v3
    Sort Key: _hyper_2_7_chunk.device_id, _hyper_2_7_chunk.device_id_peer, _hyper_2_7_chunk.v0, _hyper_2_7_chunk.v1 DESC, _hyper_2_7_chunk."time", _hyper_2_7_chunk.v3
-   Presorted Key: _hyper_2_7_chunk.device_id, _hyper_2_7_chunk.device_id_peer, _hyper_2_7_chunk.v0, _hyper_2_7_chunk.v1, _hyper_2_7_chunk."time"
-   Full-sort Groups: 132  Sort Method: quicksort 
-   ->  Merge Append (actual rows=4195 loops=1)
-         Sort Key: _hyper_2_7_chunk.device_id, _hyper_2_7_chunk.device_id_peer, _hyper_2_7_chunk.v0, _hyper_2_7_chunk.v1 DESC, _hyper_2_7_chunk."time"
-         ->  Index Scan using _hyper_2_7_chunk_metrics_space_device_id_device_id_peer_v0_v1_t on _timescaledb_internal._hyper_2_7_chunk (actual rows=335 loops=1)
+   Sort Method: quicksort 
+   ->  Append (actual rows=4195 loops=1)
+         ->  Seq Scan on _timescaledb_internal._hyper_2_7_chunk (actual rows=335 loops=1)
                Output: _hyper_2_7_chunk."time", _hyper_2_7_chunk.device_id, _hyper_2_7_chunk.device_id_peer, _hyper_2_7_chunk.v0, _hyper_2_7_chunk.v1, _hyper_2_7_chunk.v2, _hyper_2_7_chunk.v3
-               Index Cond: (_hyper_2_7_chunk."time" > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
-         ->  Index Scan using _hyper_2_8_chunk_metrics_space_device_id_device_id_peer_v0_v1_t on _timescaledb_internal._hyper_2_8_chunk (actual rows=1005 loops=1)
+               Filter: (_hyper_2_7_chunk."time" > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
+               Rows Removed by Filter: 169
+         ->  Seq Scan on _timescaledb_internal._hyper_2_8_chunk (actual rows=1005 loops=1)
                Output: _hyper_2_8_chunk."time", _hyper_2_8_chunk.device_id, _hyper_2_8_chunk.device_id_peer, _hyper_2_8_chunk.v0, _hyper_2_8_chunk.v1, _hyper_2_8_chunk.v2, _hyper_2_8_chunk.v3
-               Index Cond: (_hyper_2_8_chunk."time" > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
-         ->  Index Scan using _hyper_2_9_chunk_metrics_space_device_id_device_id_peer_v0_v1_t on _timescaledb_internal._hyper_2_9_chunk (actual rows=335 loops=1)
+               Filter: (_hyper_2_8_chunk."time" > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
+               Rows Removed by Filter: 507
+         ->  Seq Scan on _timescaledb_internal._hyper_2_9_chunk (actual rows=335 loops=1)
                Output: _hyper_2_9_chunk."time", _hyper_2_9_chunk.device_id, _hyper_2_9_chunk.device_id_peer, _hyper_2_9_chunk.v0, _hyper_2_9_chunk.v1, _hyper_2_9_chunk.v2, _hyper_2_9_chunk.v3
-               Index Cond: (_hyper_2_9_chunk."time" > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
-         ->  Sort (actual rows=504 loops=1)
+               Filter: (_hyper_2_9_chunk."time" > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
+               Rows Removed by Filter: 169
+         ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_10_chunk (actual rows=504 loops=1)
                Output: _hyper_2_10_chunk."time", _hyper_2_10_chunk.device_id, _hyper_2_10_chunk.device_id_peer, _hyper_2_10_chunk.v0, _hyper_2_10_chunk.v1, _hyper_2_10_chunk.v2, _hyper_2_10_chunk.v3
-               Sort Key: _hyper_2_10_chunk.device_id, _hyper_2_10_chunk.device_id_peer, _hyper_2_10_chunk.v0, _hyper_2_10_chunk.v1 DESC, _hyper_2_10_chunk."time"
-               Sort Method: quicksort 
-               ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_10_chunk (actual rows=504 loops=1)
-                     Output: _hyper_2_10_chunk."time", _hyper_2_10_chunk.device_id, _hyper_2_10_chunk.device_id_peer, _hyper_2_10_chunk.v0, _hyper_2_10_chunk.v1, _hyper_2_10_chunk.v2, _hyper_2_10_chunk.v3
-                     Vectorized Filter: (_hyper_2_10_chunk."time" > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
-                     Bulk Decompression: true
-                     ->  Seq Scan on _timescaledb_internal.compress_hyper_6_20_chunk (actual rows=1 loops=1)
-                           Output: compress_hyper_6_20_chunk."time", compress_hyper_6_20_chunk.device_id, compress_hyper_6_20_chunk.device_id_peer, compress_hyper_6_20_chunk.v0, compress_hyper_6_20_chunk.v1, compress_hyper_6_20_chunk.v2, compress_hyper_6_20_chunk.v3, compress_hyper_6_20_chunk._ts_meta_count, compress_hyper_6_20_chunk._ts_meta_sequence_num, compress_hyper_6_20_chunk._ts_meta_min_3, compress_hyper_6_20_chunk._ts_meta_max_3, compress_hyper_6_20_chunk._ts_meta_min_1, compress_hyper_6_20_chunk._ts_meta_max_1, compress_hyper_6_20_chunk._ts_meta_min_2, compress_hyper_6_20_chunk._ts_meta_max_2
-                           Filter: (compress_hyper_6_20_chunk._ts_meta_max_3 > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
-         ->  Sort (actual rows=1512 loops=1)
+               Vectorized Filter: (_hyper_2_10_chunk."time" > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
+               Bulk Decompression: true
+               ->  Seq Scan on _timescaledb_internal.compress_hyper_6_20_chunk (actual rows=1 loops=1)
+                     Output: compress_hyper_6_20_chunk."time", compress_hyper_6_20_chunk.device_id, compress_hyper_6_20_chunk.device_id_peer, compress_hyper_6_20_chunk.v0, compress_hyper_6_20_chunk.v1, compress_hyper_6_20_chunk.v2, compress_hyper_6_20_chunk.v3, compress_hyper_6_20_chunk._ts_meta_count, compress_hyper_6_20_chunk._ts_meta_sequence_num, compress_hyper_6_20_chunk._ts_meta_min_3, compress_hyper_6_20_chunk._ts_meta_max_3, compress_hyper_6_20_chunk._ts_meta_min_1, compress_hyper_6_20_chunk._ts_meta_max_1, compress_hyper_6_20_chunk._ts_meta_min_2, compress_hyper_6_20_chunk._ts_meta_max_2
+                     Filter: (compress_hyper_6_20_chunk._ts_meta_max_3 > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
+         ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_11_chunk (actual rows=1512 loops=1)
                Output: _hyper_2_11_chunk."time", _hyper_2_11_chunk.device_id, _hyper_2_11_chunk.device_id_peer, _hyper_2_11_chunk.v0, _hyper_2_11_chunk.v1, _hyper_2_11_chunk.v2, _hyper_2_11_chunk.v3
-               Sort Key: _hyper_2_11_chunk.device_id, _hyper_2_11_chunk.device_id_peer, _hyper_2_11_chunk.v0, _hyper_2_11_chunk.v1 DESC, _hyper_2_11_chunk."time"
-               Sort Method: quicksort 
-               ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_11_chunk (actual rows=1512 loops=1)
-                     Output: _hyper_2_11_chunk."time", _hyper_2_11_chunk.device_id, _hyper_2_11_chunk.device_id_peer, _hyper_2_11_chunk.v0, _hyper_2_11_chunk.v1, _hyper_2_11_chunk.v2, _hyper_2_11_chunk.v3
-                     Vectorized Filter: (_hyper_2_11_chunk."time" > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
-                     Bulk Decompression: true
-                     ->  Seq Scan on _timescaledb_internal.compress_hyper_6_21_chunk (actual rows=3 loops=1)
-                           Output: compress_hyper_6_21_chunk."time", compress_hyper_6_21_chunk.device_id, compress_hyper_6_21_chunk.device_id_peer, compress_hyper_6_21_chunk.v0, compress_hyper_6_21_chunk.v1, compress_hyper_6_21_chunk.v2, compress_hyper_6_21_chunk.v3, compress_hyper_6_21_chunk._ts_meta_count, compress_hyper_6_21_chunk._ts_meta_sequence_num, compress_hyper_6_21_chunk._ts_meta_min_3, compress_hyper_6_21_chunk._ts_meta_max_3, compress_hyper_6_21_chunk._ts_meta_min_1, compress_hyper_6_21_chunk._ts_meta_max_1, compress_hyper_6_21_chunk._ts_meta_min_2, compress_hyper_6_21_chunk._ts_meta_max_2
-                           Filter: (compress_hyper_6_21_chunk._ts_meta_max_3 > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
-         ->  Index Scan using _hyper_2_12_chunk_metrics_space_device_id_device_id_peer_v0_v1_ on _timescaledb_internal._hyper_2_12_chunk (actual rows=504 loops=1)
+               Vectorized Filter: (_hyper_2_11_chunk."time" > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
+               Bulk Decompression: true
+               ->  Seq Scan on _timescaledb_internal.compress_hyper_6_21_chunk (actual rows=3 loops=1)
+                     Output: compress_hyper_6_21_chunk."time", compress_hyper_6_21_chunk.device_id, compress_hyper_6_21_chunk.device_id_peer, compress_hyper_6_21_chunk.v0, compress_hyper_6_21_chunk.v1, compress_hyper_6_21_chunk.v2, compress_hyper_6_21_chunk.v3, compress_hyper_6_21_chunk._ts_meta_count, compress_hyper_6_21_chunk._ts_meta_sequence_num, compress_hyper_6_21_chunk._ts_meta_min_3, compress_hyper_6_21_chunk._ts_meta_max_3, compress_hyper_6_21_chunk._ts_meta_min_1, compress_hyper_6_21_chunk._ts_meta_max_1, compress_hyper_6_21_chunk._ts_meta_min_2, compress_hyper_6_21_chunk._ts_meta_max_2
+                     Filter: (compress_hyper_6_21_chunk._ts_meta_max_3 > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
+         ->  Seq Scan on _timescaledb_internal._hyper_2_12_chunk (actual rows=504 loops=1)
                Output: _hyper_2_12_chunk."time", _hyper_2_12_chunk.device_id, _hyper_2_12_chunk.device_id_peer, _hyper_2_12_chunk.v0, _hyper_2_12_chunk.v1, _hyper_2_12_chunk.v2, _hyper_2_12_chunk.v3
-               Index Cond: (_hyper_2_12_chunk."time" > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
-(41 rows)
+               Filter: (_hyper_2_12_chunk."time" > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
+(34 rows)
 
 -- should produce ordered path
 -- ASC/DESC for segmentby columns can be pushed down
@@ -5772,47 +5674,32 @@ FROM :TEST_TABLE
 WHERE time > '2000-01-08'
 ORDER BY time,
     device_id;
-                                                             QUERY PLAN                                                              
--------------------------------------------------------------------------------------------------------------------------------------
- Incremental Sort (actual rows=4195 loops=1)
-   Sort Key: metrics_space."time", metrics_space.device_id
-   Presorted Key: metrics_space."time"
-   Full-sort Groups: 120  Sort Method: quicksort 
-   ->  Custom Scan (ChunkAppend) on metrics_space (actual rows=4195 loops=1)
-         Order: metrics_space."time"
-         ->  Merge Append (actual rows=1675 loops=1)
-               Sort Key: _hyper_2_7_chunk."time"
-               ->  Index Scan Backward using _hyper_2_7_chunk_metrics_space_time_idx on _hyper_2_7_chunk (actual rows=335 loops=1)
-                     Index Cond: ("time" > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
-               ->  Index Scan Backward using _hyper_2_8_chunk_metrics_space_time_idx on _hyper_2_8_chunk (actual rows=1005 loops=1)
-                     Index Cond: ("time" > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
-               ->  Index Scan Backward using _hyper_2_9_chunk_metrics_space_time_idx on _hyper_2_9_chunk (actual rows=335 loops=1)
-                     Index Cond: ("time" > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
-         ->  Merge Append (actual rows=2520 loops=1)
-               Sort Key: _hyper_2_10_chunk."time"
-               ->  Sort (actual rows=504 loops=1)
-                     Sort Key: _hyper_2_10_chunk."time"
-                     Sort Method: quicksort 
-                     ->  Sort (actual rows=504 loops=1)
-                           Sort Key: _hyper_2_10_chunk."time"
-                           Sort Method: quicksort 
-                           ->  Custom Scan (DecompressChunk) on _hyper_2_10_chunk (actual rows=504 loops=1)
-                                 Vectorized Filter: ("time" > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
-                                 ->  Seq Scan on compress_hyper_6_20_chunk (actual rows=1 loops=1)
-                                       Filter: (_ts_meta_max_3 > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
-               ->  Sort (actual rows=1512 loops=1)
-                     Sort Key: _hyper_2_11_chunk."time"
-                     Sort Method: quicksort 
-                     ->  Sort (actual rows=1512 loops=1)
-                           Sort Key: _hyper_2_11_chunk."time"
-                           Sort Method: quicksort 
-                           ->  Custom Scan (DecompressChunk) on _hyper_2_11_chunk (actual rows=1512 loops=1)
-                                 Vectorized Filter: ("time" > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
-                                 ->  Seq Scan on compress_hyper_6_21_chunk (actual rows=3 loops=1)
-                                       Filter: (_ts_meta_max_3 > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
-               ->  Index Scan Backward using _hyper_2_12_chunk_metrics_space_time_idx on _hyper_2_12_chunk (actual rows=504 loops=1)
-                     Index Cond: ("time" > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
-(38 rows)
+                                               QUERY PLAN                                                
+---------------------------------------------------------------------------------------------------------
+ Sort (actual rows=4195 loops=1)
+   Sort Key: _hyper_2_7_chunk."time", _hyper_2_7_chunk.device_id
+   Sort Method: quicksort 
+   ->  Append (actual rows=4195 loops=1)
+         ->  Seq Scan on _hyper_2_7_chunk (actual rows=335 loops=1)
+               Filter: ("time" > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
+               Rows Removed by Filter: 169
+         ->  Seq Scan on _hyper_2_8_chunk (actual rows=1005 loops=1)
+               Filter: ("time" > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
+               Rows Removed by Filter: 507
+         ->  Seq Scan on _hyper_2_9_chunk (actual rows=335 loops=1)
+               Filter: ("time" > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
+               Rows Removed by Filter: 169
+         ->  Custom Scan (DecompressChunk) on _hyper_2_10_chunk (actual rows=504 loops=1)
+               Vectorized Filter: ("time" > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
+               ->  Seq Scan on compress_hyper_6_20_chunk (actual rows=1 loops=1)
+                     Filter: (_ts_meta_max_3 > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
+         ->  Custom Scan (DecompressChunk) on _hyper_2_11_chunk (actual rows=1512 loops=1)
+               Vectorized Filter: ("time" > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
+               ->  Seq Scan on compress_hyper_6_21_chunk (actual rows=3 loops=1)
+                     Filter: (_ts_meta_max_3 > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
+         ->  Seq Scan on _hyper_2_12_chunk (actual rows=504 loops=1)
+               Filter: ("time" > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
+(23 rows)
 
 -- test runtime exclusion
 -- first chunk should be excluded
@@ -5822,82 +5709,89 @@ FROM :TEST_TABLE
 WHERE time > '2000-01-08'::text::timestamptz
 ORDER BY time,
     device_id;
-                                                             QUERY PLAN                                                              
--------------------------------------------------------------------------------------------------------------------------------------
- Incremental Sort (actual rows=4195 loops=1)
-   Sort Key: metrics_space."time", metrics_space.device_id
-   Presorted Key: metrics_space."time"
-   Full-sort Groups: 120  Sort Method: quicksort 
-   ->  Custom Scan (ChunkAppend) on metrics_space (actual rows=4195 loops=1)
-         Order: metrics_space."time"
-         ->  Merge Append (actual rows=0 loops=1)
-               Sort Key: _hyper_2_4_chunk."time"
-               ->  Sort (actual rows=0 loops=1)
-                     Sort Key: _hyper_2_4_chunk."time"
+                                                                QUERY PLAN                                                                
+------------------------------------------------------------------------------------------------------------------------------------------
+ Custom Scan (ChunkAppend) on metrics_space (actual rows=4195 loops=1)
+   Order: metrics_space."time", metrics_space.device_id
+   ->  Merge Append (actual rows=0 loops=1)
+         Sort Key: _hyper_2_4_chunk."time", _hyper_2_4_chunk.device_id
+         ->  Sort (actual rows=0 loops=1)
+               Sort Key: _hyper_2_4_chunk."time", _hyper_2_4_chunk.device_id
+               Sort Method: quicksort 
+               ->  Custom Scan (DecompressChunk) on _hyper_2_4_chunk (actual rows=0 loops=1)
+                     Filter: ("time" > ('2000-01-08'::cstring)::timestamp with time zone)
+                     ->  Seq Scan on compress_hyper_6_17_chunk (actual rows=0 loops=1)
+                           Filter: (_ts_meta_max_3 > ('2000-01-08'::cstring)::timestamp with time zone)
+                           Rows Removed by Filter: 1
+         ->  Sort (actual rows=0 loops=1)
+               Sort Key: _hyper_2_5_chunk."time", _hyper_2_5_chunk.device_id
+               Sort Method: quicksort 
+               ->  Custom Scan (DecompressChunk) on _hyper_2_5_chunk (actual rows=0 loops=1)
+                     Filter: ("time" > ('2000-01-08'::cstring)::timestamp with time zone)
+                     ->  Seq Scan on compress_hyper_6_18_chunk (actual rows=0 loops=1)
+                           Filter: (_ts_meta_max_3 > ('2000-01-08'::cstring)::timestamp with time zone)
+                           Rows Removed by Filter: 3
+         ->  Sort (actual rows=0 loops=1)
+               Sort Key: _hyper_2_6_chunk."time", _hyper_2_6_chunk.device_id
+               Sort Method: quicksort 
+               ->  Custom Scan (DecompressChunk) on _hyper_2_6_chunk (actual rows=0 loops=1)
+                     Filter: ("time" > ('2000-01-08'::cstring)::timestamp with time zone)
+                     ->  Seq Scan on compress_hyper_6_19_chunk (actual rows=0 loops=1)
+                           Filter: (_ts_meta_max_3 > ('2000-01-08'::cstring)::timestamp with time zone)
+                           Rows Removed by Filter: 1
+   ->  Merge Append (actual rows=1675 loops=1)
+         Sort Key: _hyper_2_7_chunk."time", _hyper_2_7_chunk.device_id
+         ->  Sort (actual rows=335 loops=1)
+               Sort Key: _hyper_2_7_chunk."time", _hyper_2_7_chunk.device_id
+               Sort Method: quicksort 
+               ->  Sort (actual rows=335 loops=1)
+                     Sort Key: _hyper_2_7_chunk."time", _hyper_2_7_chunk.device_id
                      Sort Method: quicksort 
-                     ->  Sort (actual rows=0 loops=1)
-                           Sort Key: _hyper_2_4_chunk."time"
-                           Sort Method: quicksort 
-                           ->  Custom Scan (DecompressChunk) on _hyper_2_4_chunk (actual rows=0 loops=1)
-                                 Filter: ("time" > ('2000-01-08'::cstring)::timestamp with time zone)
-                                 ->  Seq Scan on compress_hyper_6_17_chunk (actual rows=0 loops=1)
-                                       Filter: (_ts_meta_max_3 > ('2000-01-08'::cstring)::timestamp with time zone)
-                                       Rows Removed by Filter: 1
-               ->  Sort (actual rows=0 loops=1)
-                     Sort Key: _hyper_2_5_chunk."time"
+                     ->  Seq Scan on _hyper_2_7_chunk (actual rows=335 loops=1)
+                           Filter: ("time" > ('2000-01-08'::cstring)::timestamp with time zone)
+                           Rows Removed by Filter: 169
+         ->  Sort (actual rows=1005 loops=1)
+               Sort Key: _hyper_2_8_chunk."time", _hyper_2_8_chunk.device_id
+               Sort Method: quicksort 
+               ->  Sort (actual rows=1005 loops=1)
+                     Sort Key: _hyper_2_8_chunk."time", _hyper_2_8_chunk.device_id
                      Sort Method: quicksort 
-                     ->  Sort (actual rows=0 loops=1)
-                           Sort Key: _hyper_2_5_chunk."time"
-                           Sort Method: quicksort 
-                           ->  Custom Scan (DecompressChunk) on _hyper_2_5_chunk (actual rows=0 loops=1)
-                                 Filter: ("time" > ('2000-01-08'::cstring)::timestamp with time zone)
-                                 ->  Seq Scan on compress_hyper_6_18_chunk (actual rows=0 loops=1)
-                                       Filter: (_ts_meta_max_3 > ('2000-01-08'::cstring)::timestamp with time zone)
-                                       Rows Removed by Filter: 3
-               ->  Sort (actual rows=0 loops=1)
-                     Sort Key: _hyper_2_6_chunk."time"
+                     ->  Index Scan Backward using _hyper_2_8_chunk_metrics_space_time_idx on _hyper_2_8_chunk (actual rows=1005 loops=1)
+                           Index Cond: ("time" > ('2000-01-08'::cstring)::timestamp with time zone)
+         ->  Sort (actual rows=335 loops=1)
+               Sort Key: _hyper_2_9_chunk."time", _hyper_2_9_chunk.device_id
+               Sort Method: quicksort 
+               ->  Sort (actual rows=335 loops=1)
+                     Sort Key: _hyper_2_9_chunk."time", _hyper_2_9_chunk.device_id
                      Sort Method: quicksort 
-                     ->  Sort (actual rows=0 loops=1)
-                           Sort Key: _hyper_2_6_chunk."time"
-                           Sort Method: quicksort 
-                           ->  Custom Scan (DecompressChunk) on _hyper_2_6_chunk (actual rows=0 loops=1)
-                                 Filter: ("time" > ('2000-01-08'::cstring)::timestamp with time zone)
-                                 ->  Seq Scan on compress_hyper_6_19_chunk (actual rows=0 loops=1)
-                                       Filter: (_ts_meta_max_3 > ('2000-01-08'::cstring)::timestamp with time zone)
-                                       Rows Removed by Filter: 1
-         ->  Merge Append (actual rows=1675 loops=1)
-               Sort Key: _hyper_2_7_chunk."time"
-               ->  Index Scan Backward using _hyper_2_7_chunk_metrics_space_time_idx on _hyper_2_7_chunk (actual rows=335 loops=1)
-                     Index Cond: ("time" > ('2000-01-08'::cstring)::timestamp with time zone)
-               ->  Index Scan Backward using _hyper_2_8_chunk_metrics_space_time_idx on _hyper_2_8_chunk (actual rows=1005 loops=1)
-                     Index Cond: ("time" > ('2000-01-08'::cstring)::timestamp with time zone)
-               ->  Index Scan Backward using _hyper_2_9_chunk_metrics_space_time_idx on _hyper_2_9_chunk (actual rows=335 loops=1)
-                     Index Cond: ("time" > ('2000-01-08'::cstring)::timestamp with time zone)
-         ->  Merge Append (actual rows=2520 loops=1)
-               Sort Key: _hyper_2_10_chunk."time"
+                     ->  Seq Scan on _hyper_2_9_chunk (actual rows=335 loops=1)
+                           Filter: ("time" > ('2000-01-08'::cstring)::timestamp with time zone)
+                           Rows Removed by Filter: 169
+   ->  Merge Append (actual rows=2520 loops=1)
+         Sort Key: _hyper_2_10_chunk."time", _hyper_2_10_chunk.device_id
+         ->  Sort (actual rows=504 loops=1)
+               Sort Key: _hyper_2_10_chunk."time", _hyper_2_10_chunk.device_id
+               Sort Method: quicksort 
+               ->  Custom Scan (DecompressChunk) on _hyper_2_10_chunk (actual rows=504 loops=1)
+                     Filter: ("time" > ('2000-01-08'::cstring)::timestamp with time zone)
+                     ->  Seq Scan on compress_hyper_6_20_chunk (actual rows=1 loops=1)
+                           Filter: (_ts_meta_max_3 > ('2000-01-08'::cstring)::timestamp with time zone)
+         ->  Sort (actual rows=1512 loops=1)
+               Sort Key: _hyper_2_11_chunk."time", _hyper_2_11_chunk.device_id
+               Sort Method: quicksort 
+               ->  Custom Scan (DecompressChunk) on _hyper_2_11_chunk (actual rows=1512 loops=1)
+                     Filter: ("time" > ('2000-01-08'::cstring)::timestamp with time zone)
+                     ->  Seq Scan on compress_hyper_6_21_chunk (actual rows=3 loops=1)
+                           Filter: (_ts_meta_max_3 > ('2000-01-08'::cstring)::timestamp with time zone)
+         ->  Sort (actual rows=504 loops=1)
+               Sort Key: _hyper_2_12_chunk."time", _hyper_2_12_chunk.device_id
+               Sort Method: quicksort 
                ->  Sort (actual rows=504 loops=1)
-                     Sort Key: _hyper_2_10_chunk."time"
+                     Sort Key: _hyper_2_12_chunk."time", _hyper_2_12_chunk.device_id
                      Sort Method: quicksort 
-                     ->  Sort (actual rows=504 loops=1)
-                           Sort Key: _hyper_2_10_chunk."time"
-                           Sort Method: quicksort 
-                           ->  Custom Scan (DecompressChunk) on _hyper_2_10_chunk (actual rows=504 loops=1)
-                                 Filter: ("time" > ('2000-01-08'::cstring)::timestamp with time zone)
-                                 ->  Seq Scan on compress_hyper_6_20_chunk (actual rows=1 loops=1)
-                                       Filter: (_ts_meta_max_3 > ('2000-01-08'::cstring)::timestamp with time zone)
-               ->  Sort (actual rows=1512 loops=1)
-                     Sort Key: _hyper_2_11_chunk."time"
-                     Sort Method: quicksort 
-                     ->  Sort (actual rows=1512 loops=1)
-                           Sort Key: _hyper_2_11_chunk."time"
-                           Sort Method: quicksort 
-                           ->  Custom Scan (DecompressChunk) on _hyper_2_11_chunk (actual rows=1512 loops=1)
-                                 Filter: ("time" > ('2000-01-08'::cstring)::timestamp with time zone)
-                                 ->  Seq Scan on compress_hyper_6_21_chunk (actual rows=3 loops=1)
-                                       Filter: (_ts_meta_max_3 > ('2000-01-08'::cstring)::timestamp with time zone)
-               ->  Index Scan Backward using _hyper_2_12_chunk_metrics_space_time_idx on _hyper_2_12_chunk (actual rows=504 loops=1)
-                     Index Cond: ("time" > ('2000-01-08'::cstring)::timestamp with time zone)
-(73 rows)
+                     ->  Seq Scan on _hyper_2_12_chunk (actual rows=504 loops=1)
+                           Filter: ("time" > ('2000-01-08'::cstring)::timestamp with time zone)
+(80 rows)
 
 -- test aggregate
 :PREFIX
@@ -6108,27 +6002,18 @@ ORDER BY v1;
                      ->  Sort (actual rows=360 loops=1)
                            Sort Key: _hyper_2_4_chunk."time"
                            Sort Method: quicksort 
-                           ->  Sort (actual rows=360 loops=1)
-                                 Sort Key: _hyper_2_4_chunk."time"
-                                 Sort Method: quicksort 
-                                 ->  Custom Scan (DecompressChunk) on _hyper_2_4_chunk (actual rows=360 loops=1)
-                                       ->  Seq Scan on compress_hyper_6_17_chunk (actual rows=1 loops=1)
+                           ->  Custom Scan (DecompressChunk) on _hyper_2_4_chunk (actual rows=360 loops=1)
+                                 ->  Seq Scan on compress_hyper_6_17_chunk (actual rows=1 loops=1)
                      ->  Sort (actual rows=1080 loops=1)
                            Sort Key: _hyper_2_5_chunk."time"
                            Sort Method: quicksort 
-                           ->  Sort (actual rows=1080 loops=1)
-                                 Sort Key: _hyper_2_5_chunk."time"
-                                 Sort Method: quicksort 
-                                 ->  Custom Scan (DecompressChunk) on _hyper_2_5_chunk (actual rows=1080 loops=1)
-                                       ->  Seq Scan on compress_hyper_6_18_chunk (actual rows=3 loops=1)
+                           ->  Custom Scan (DecompressChunk) on _hyper_2_5_chunk (actual rows=1080 loops=1)
+                                 ->  Seq Scan on compress_hyper_6_18_chunk (actual rows=3 loops=1)
                      ->  Sort (actual rows=360 loops=1)
                            Sort Key: _hyper_2_6_chunk."time"
                            Sort Method: quicksort 
-                           ->  Sort (actual rows=360 loops=1)
-                                 Sort Key: _hyper_2_6_chunk."time"
-                                 Sort Method: quicksort 
-                                 ->  Custom Scan (DecompressChunk) on _hyper_2_6_chunk (actual rows=360 loops=1)
-                                       ->  Seq Scan on compress_hyper_6_19_chunk (actual rows=1 loops=1)
+                           ->  Custom Scan (DecompressChunk) on _hyper_2_6_chunk (actual rows=360 loops=1)
+                                 ->  Seq Scan on compress_hyper_6_19_chunk (actual rows=1 loops=1)
                ->  Merge Append (actual rows=2520 loops=1)
                      Sort Key: _hyper_2_7_chunk."time"
                      ->  Index Scan Backward using _hyper_2_7_chunk_metrics_space_time_idx on _hyper_2_7_chunk (actual rows=504 loops=1)
@@ -6139,21 +6024,15 @@ ORDER BY v1;
                      ->  Sort (actual rows=504 loops=1)
                            Sort Key: _hyper_2_10_chunk."time"
                            Sort Method: quicksort 
-                           ->  Sort (actual rows=504 loops=1)
-                                 Sort Key: _hyper_2_10_chunk."time"
-                                 Sort Method: quicksort 
-                                 ->  Custom Scan (DecompressChunk) on _hyper_2_10_chunk (actual rows=504 loops=1)
-                                       ->  Seq Scan on compress_hyper_6_20_chunk (actual rows=1 loops=1)
+                           ->  Custom Scan (DecompressChunk) on _hyper_2_10_chunk (actual rows=504 loops=1)
+                                 ->  Seq Scan on compress_hyper_6_20_chunk (actual rows=1 loops=1)
                      ->  Sort (actual rows=1512 loops=1)
                            Sort Key: _hyper_2_11_chunk."time"
                            Sort Method: quicksort 
-                           ->  Sort (actual rows=1512 loops=1)
-                                 Sort Key: _hyper_2_11_chunk."time"
-                                 Sort Method: quicksort 
-                                 ->  Custom Scan (DecompressChunk) on _hyper_2_11_chunk (actual rows=1512 loops=1)
-                                       ->  Seq Scan on compress_hyper_6_21_chunk (actual rows=3 loops=1)
+                           ->  Custom Scan (DecompressChunk) on _hyper_2_11_chunk (actual rows=1512 loops=1)
+                                 ->  Seq Scan on compress_hyper_6_21_chunk (actual rows=3 loops=1)
                      ->  Index Scan Backward using _hyper_2_12_chunk_metrics_space_time_idx on _hyper_2_12_chunk (actual rows=504 loops=1)
-(56 rows)
+(41 rows)
 
 -- test CTE join
 :PREFIX WITH q1 AS (
@@ -6845,54 +6724,43 @@ WHERE device_id IN (
             (2));
                                                                                                                                                                                                                                                                                                          QUERY PLAN                                                                                                                                                                                                                                                                                                         
 ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
- Nested Loop
+ Hash Semi Join
    Output: _hyper_2_4_chunk.device_id_peer
-   ->  Unique
-         Output: "*VALUES*".column1
-         ->  Sort
-               Output: "*VALUES*".column1
-               Sort Key: "*VALUES*".column1
-               ->  Values Scan on "*VALUES*"
-                     Output: "*VALUES*".column1
+   Hash Cond: (_hyper_2_4_chunk.device_id = "*VALUES*".column1)
    ->  Append
          ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_4_chunk
                Output: _hyper_2_4_chunk.device_id_peer, _hyper_2_4_chunk.device_id
                ->  Index Scan using compress_hyper_6_17_chunk_c_space_index_2 on _timescaledb_internal.compress_hyper_6_17_chunk
                      Output: compress_hyper_6_17_chunk."time", compress_hyper_6_17_chunk.device_id, compress_hyper_6_17_chunk.device_id_peer, compress_hyper_6_17_chunk.v0, compress_hyper_6_17_chunk.v1, compress_hyper_6_17_chunk.v2, compress_hyper_6_17_chunk.v3, compress_hyper_6_17_chunk._ts_meta_count, compress_hyper_6_17_chunk._ts_meta_sequence_num, compress_hyper_6_17_chunk._ts_meta_min_3, compress_hyper_6_17_chunk._ts_meta_max_3, compress_hyper_6_17_chunk._ts_meta_min_1, compress_hyper_6_17_chunk._ts_meta_max_1, compress_hyper_6_17_chunk._ts_meta_min_2, compress_hyper_6_17_chunk._ts_meta_max_2
-                     Index Cond: (compress_hyper_6_17_chunk.device_id = "*VALUES*".column1)
          ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_5_chunk
                Output: _hyper_2_5_chunk.device_id_peer, _hyper_2_5_chunk.device_id
                ->  Index Scan using compress_hyper_6_18_chunk_c_space_index_2 on _timescaledb_internal.compress_hyper_6_18_chunk
                      Output: compress_hyper_6_18_chunk."time", compress_hyper_6_18_chunk.device_id, compress_hyper_6_18_chunk.device_id_peer, compress_hyper_6_18_chunk.v0, compress_hyper_6_18_chunk.v1, compress_hyper_6_18_chunk.v2, compress_hyper_6_18_chunk.v3, compress_hyper_6_18_chunk._ts_meta_count, compress_hyper_6_18_chunk._ts_meta_sequence_num, compress_hyper_6_18_chunk._ts_meta_min_3, compress_hyper_6_18_chunk._ts_meta_max_3, compress_hyper_6_18_chunk._ts_meta_min_1, compress_hyper_6_18_chunk._ts_meta_max_1, compress_hyper_6_18_chunk._ts_meta_min_2, compress_hyper_6_18_chunk._ts_meta_max_2
-                     Index Cond: (compress_hyper_6_18_chunk.device_id = "*VALUES*".column1)
          ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_6_chunk
                Output: _hyper_2_6_chunk.device_id_peer, _hyper_2_6_chunk.device_id
                ->  Index Scan using compress_hyper_6_19_chunk_c_space_index_2 on _timescaledb_internal.compress_hyper_6_19_chunk
                      Output: compress_hyper_6_19_chunk."time", compress_hyper_6_19_chunk.device_id, compress_hyper_6_19_chunk.device_id_peer, compress_hyper_6_19_chunk.v0, compress_hyper_6_19_chunk.v1, compress_hyper_6_19_chunk.v2, compress_hyper_6_19_chunk.v3, compress_hyper_6_19_chunk._ts_meta_count, compress_hyper_6_19_chunk._ts_meta_sequence_num, compress_hyper_6_19_chunk._ts_meta_min_3, compress_hyper_6_19_chunk._ts_meta_max_3, compress_hyper_6_19_chunk._ts_meta_min_1, compress_hyper_6_19_chunk._ts_meta_max_1, compress_hyper_6_19_chunk._ts_meta_min_2, compress_hyper_6_19_chunk._ts_meta_max_2
-                     Index Cond: (compress_hyper_6_19_chunk.device_id = "*VALUES*".column1)
-         ->  Index Only Scan using _hyper_2_7_chunk_metrics_space_device_id_device_id_peer_v0_v1_2 on _timescaledb_internal._hyper_2_7_chunk
+         ->  Index Only Scan Backward using _hyper_2_7_chunk_metrics_space_device_id_device_id_peer_v0_v1_2 on _timescaledb_internal._hyper_2_7_chunk
                Output: _hyper_2_7_chunk.device_id_peer, _hyper_2_7_chunk.device_id
-               Index Cond: (_hyper_2_7_chunk.device_id = "*VALUES*".column1)
-         ->  Index Only Scan using _hyper_2_8_chunk_metrics_space_device_id_device_id_peer_v0_v1_2 on _timescaledb_internal._hyper_2_8_chunk
+         ->  Index Only Scan Backward using _hyper_2_8_chunk_metrics_space_device_id_device_id_peer_v0_v1_2 on _timescaledb_internal._hyper_2_8_chunk
                Output: _hyper_2_8_chunk.device_id_peer, _hyper_2_8_chunk.device_id
-               Index Cond: (_hyper_2_8_chunk.device_id = "*VALUES*".column1)
-         ->  Index Only Scan using _hyper_2_9_chunk_metrics_space_device_id_device_id_peer_v0_v1_2 on _timescaledb_internal._hyper_2_9_chunk
+         ->  Index Only Scan Backward using _hyper_2_9_chunk_metrics_space_device_id_device_id_peer_v0_v1_2 on _timescaledb_internal._hyper_2_9_chunk
                Output: _hyper_2_9_chunk.device_id_peer, _hyper_2_9_chunk.device_id
-               Index Cond: (_hyper_2_9_chunk.device_id = "*VALUES*".column1)
          ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_10_chunk
                Output: _hyper_2_10_chunk.device_id_peer, _hyper_2_10_chunk.device_id
                ->  Index Scan using compress_hyper_6_20_chunk_c_space_index_2 on _timescaledb_internal.compress_hyper_6_20_chunk
                      Output: compress_hyper_6_20_chunk."time", compress_hyper_6_20_chunk.device_id, compress_hyper_6_20_chunk.device_id_peer, compress_hyper_6_20_chunk.v0, compress_hyper_6_20_chunk.v1, compress_hyper_6_20_chunk.v2, compress_hyper_6_20_chunk.v3, compress_hyper_6_20_chunk._ts_meta_count, compress_hyper_6_20_chunk._ts_meta_sequence_num, compress_hyper_6_20_chunk._ts_meta_min_3, compress_hyper_6_20_chunk._ts_meta_max_3, compress_hyper_6_20_chunk._ts_meta_min_1, compress_hyper_6_20_chunk._ts_meta_max_1, compress_hyper_6_20_chunk._ts_meta_min_2, compress_hyper_6_20_chunk._ts_meta_max_2
-                     Index Cond: (compress_hyper_6_20_chunk.device_id = "*VALUES*".column1)
          ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_11_chunk
                Output: _hyper_2_11_chunk.device_id_peer, _hyper_2_11_chunk.device_id
                ->  Index Scan using compress_hyper_6_21_chunk_c_space_index_2 on _timescaledb_internal.compress_hyper_6_21_chunk
                      Output: compress_hyper_6_21_chunk."time", compress_hyper_6_21_chunk.device_id, compress_hyper_6_21_chunk.device_id_peer, compress_hyper_6_21_chunk.v0, compress_hyper_6_21_chunk.v1, compress_hyper_6_21_chunk.v2, compress_hyper_6_21_chunk.v3, compress_hyper_6_21_chunk._ts_meta_count, compress_hyper_6_21_chunk._ts_meta_sequence_num, compress_hyper_6_21_chunk._ts_meta_min_3, compress_hyper_6_21_chunk._ts_meta_max_3, compress_hyper_6_21_chunk._ts_meta_min_1, compress_hyper_6_21_chunk._ts_meta_max_1, compress_hyper_6_21_chunk._ts_meta_min_2, compress_hyper_6_21_chunk._ts_meta_max_2
-                     Index Cond: (compress_hyper_6_21_chunk.device_id = "*VALUES*".column1)
-         ->  Index Only Scan using _hyper_2_12_chunk_metrics_space_device_id_device_id_peer_v0_v_2 on _timescaledb_internal._hyper_2_12_chunk
+         ->  Index Only Scan Backward using _hyper_2_12_chunk_metrics_space_device_id_device_id_peer_v0_v_2 on _timescaledb_internal._hyper_2_12_chunk
                Output: _hyper_2_12_chunk.device_id_peer, _hyper_2_12_chunk.device_id
-               Index Cond: (_hyper_2_12_chunk.device_id = "*VALUES*".column1)
-(47 rows)
+   ->  Hash
+         Output: "*VALUES*".column1
+         ->  Values Scan on "*VALUES*"
+               Output: "*VALUES*".column1
+(36 rows)
 
 RESET seq_page_cost;
 :PREFIX_VERBOSE
@@ -7015,114 +6883,114 @@ FROM :TEST_TABLE m1
     ORDER BY m1.time,
         m1.device_id
     LIMIT 10;
-                                                                    QUERY PLAN                                                                     
----------------------------------------------------------------------------------------------------------------------------------------------------
+                                                             QUERY PLAN                                                              
+-------------------------------------------------------------------------------------------------------------------------------------
  Limit (actual rows=10 loops=1)
-   ->  Incremental Sort (actual rows=10 loops=1)
-         Sort Key: m1."time", m1.device_id
-         Presorted Key: m1."time"
-         Full-sort Groups: 1  Sort Method: quicksort 
-         ->  Merge Join (actual rows=11 loops=1)
-               Merge Cond: (m1."time" = m2."time")
-               Join Filter: (m1.device_id = m2.device_id)
-               Rows Removed by Join Filter: 40
-               ->  Custom Scan (ChunkAppend) on metrics_space m1 (actual rows=11 loops=1)
-                     Order: m1."time"
-                     ->  Merge Append (actual rows=11 loops=1)
-                           Sort Key: m1_1."time"
-                           ->  Sort (actual rows=3 loops=1)
-                                 Sort Key: m1_1."time"
-                                 Sort Method: quicksort 
-                                 ->  Sort (actual rows=360 loops=1)
-                                       Sort Key: m1_1."time"
-                                       Sort Method: quicksort 
-                                       ->  Custom Scan (DecompressChunk) on _hyper_2_4_chunk m1_1 (actual rows=360 loops=1)
-                                             ->  Seq Scan on compress_hyper_6_17_chunk (actual rows=1 loops=1)
-                           ->  Sort (actual rows=7 loops=1)
-                                 Sort Key: m1_2."time"
-                                 Sort Method: quicksort 
-                                 ->  Sort (actual rows=1080 loops=1)
-                                       Sort Key: m1_2."time"
-                                       Sort Method: quicksort 
-                                       ->  Custom Scan (DecompressChunk) on _hyper_2_5_chunk m1_2 (actual rows=1080 loops=1)
-                                             ->  Seq Scan on compress_hyper_6_18_chunk (actual rows=3 loops=1)
-                           ->  Sort (actual rows=3 loops=1)
-                                 Sort Key: m1_3."time"
-                                 Sort Method: quicksort 
-                                 ->  Sort (actual rows=360 loops=1)
-                                       Sort Key: m1_3."time"
-                                       Sort Method: quicksort 
-                                       ->  Custom Scan (DecompressChunk) on _hyper_2_6_chunk m1_3 (actual rows=360 loops=1)
-                                             ->  Seq Scan on compress_hyper_6_19_chunk (actual rows=1 loops=1)
-                     ->  Merge Append (never executed)
-                           Sort Key: m1_4."time"
-                           ->  Index Scan Backward using _hyper_2_7_chunk_metrics_space_time_idx on _hyper_2_7_chunk m1_4 (never executed)
-                           ->  Index Scan Backward using _hyper_2_8_chunk_metrics_space_time_idx on _hyper_2_8_chunk m1_5 (never executed)
-                           ->  Index Scan Backward using _hyper_2_9_chunk_metrics_space_time_idx on _hyper_2_9_chunk m1_6 (never executed)
-                     ->  Merge Append (never executed)
-                           Sort Key: m1_7."time"
+   ->  Merge Join (actual rows=10 loops=1)
+         Merge Cond: ((m1."time" = m2."time") AND (m1.device_id = m2.device_id))
+         ->  Custom Scan (ChunkAppend) on metrics_space m1 (actual rows=10 loops=1)
+               Order: m1."time", m1.device_id
+               ->  Merge Append (actual rows=10 loops=1)
+                     Sort Key: m1_1."time", m1_1.device_id
+                     ->  Sort (actual rows=3 loops=1)
+                           Sort Key: m1_1."time", m1_1.device_id
+                           Sort Method: quicksort 
+                           ->  Custom Scan (DecompressChunk) on _hyper_2_4_chunk m1_1 (actual rows=360 loops=1)
+                                 ->  Seq Scan on compress_hyper_6_17_chunk (actual rows=1 loops=1)
+                     ->  Sort (actual rows=6 loops=1)
+                           Sort Key: m1_2."time", m1_2.device_id
+                           Sort Method: quicksort 
+                           ->  Custom Scan (DecompressChunk) on _hyper_2_5_chunk m1_2 (actual rows=1080 loops=1)
+                                 ->  Seq Scan on compress_hyper_6_18_chunk (actual rows=3 loops=1)
+                     ->  Sort (actual rows=3 loops=1)
+                           Sort Key: m1_3."time", m1_3.device_id
+                           Sort Method: quicksort 
+                           ->  Custom Scan (DecompressChunk) on _hyper_2_6_chunk m1_3 (actual rows=360 loops=1)
+                                 ->  Seq Scan on compress_hyper_6_19_chunk (actual rows=1 loops=1)
+               ->  Merge Append (never executed)
+                     Sort Key: m1_4."time", m1_4.device_id
+                     ->  Sort (never executed)
+                           Sort Key: m1_4."time", m1_4.device_id
                            ->  Sort (never executed)
-                                 Sort Key: m1_7."time"
-                                 ->  Sort (never executed)
-                                       Sort Key: m1_7."time"
-                                       ->  Custom Scan (DecompressChunk) on _hyper_2_10_chunk m1_7 (never executed)
-                                             ->  Seq Scan on compress_hyper_6_20_chunk (never executed)
+                                 Sort Key: m1_4."time", m1_4.device_id
+                                 ->  Seq Scan on _hyper_2_7_chunk m1_4 (never executed)
+                     ->  Sort (never executed)
+                           Sort Key: m1_5."time", m1_5.device_id
                            ->  Sort (never executed)
-                                 Sort Key: m1_8."time"
+                                 Sort Key: m1_5."time", m1_5.device_id
+                                 ->  Seq Scan on _hyper_2_8_chunk m1_5 (never executed)
+                     ->  Sort (never executed)
+                           Sort Key: m1_6."time", m1_6.device_id
+                           ->  Sort (never executed)
+                                 Sort Key: m1_6."time", m1_6.device_id
+                                 ->  Seq Scan on _hyper_2_9_chunk m1_6 (never executed)
+               ->  Merge Append (never executed)
+                     Sort Key: m1_7."time", m1_7.device_id
+                     ->  Sort (never executed)
+                           Sort Key: m1_7."time", m1_7.device_id
+                           ->  Custom Scan (DecompressChunk) on _hyper_2_10_chunk m1_7 (never executed)
+                                 ->  Seq Scan on compress_hyper_6_20_chunk (never executed)
+                     ->  Sort (never executed)
+                           Sort Key: m1_8."time", m1_8.device_id
+                           ->  Custom Scan (DecompressChunk) on _hyper_2_11_chunk m1_8 (never executed)
+                                 ->  Seq Scan on compress_hyper_6_21_chunk (never executed)
+                     ->  Sort (never executed)
+                           Sort Key: m1_9."time", m1_9.device_id
+                           ->  Sort (never executed)
+                                 Sort Key: m1_9."time", m1_9.device_id
+                                 ->  Seq Scan on _hyper_2_12_chunk m1_9 (never executed)
+         ->  Materialize (actual rows=10 loops=1)
+               ->  Custom Scan (ChunkAppend) on metrics_space m2 (actual rows=10 loops=1)
+                     Order: m2."time", m2.device_id
+                     ->  Merge Append (actual rows=10 loops=1)
+                           Sort Key: m2_1."time", m2_1.device_id
+                           ->  Sort (actual rows=3 loops=1)
+                                 Sort Key: m2_1."time", m2_1.device_id
+                                 Sort Method: quicksort 
+                                 ->  Custom Scan (DecompressChunk) on _hyper_2_4_chunk m2_1 (actual rows=360 loops=1)
+                                       ->  Seq Scan on compress_hyper_6_17_chunk compress_hyper_6_17_chunk_1 (actual rows=1 loops=1)
+                           ->  Sort (actual rows=6 loops=1)
+                                 Sort Key: m2_2."time", m2_2.device_id
+                                 Sort Method: quicksort 
+                                 ->  Custom Scan (DecompressChunk) on _hyper_2_5_chunk m2_2 (actual rows=1080 loops=1)
+                                       ->  Seq Scan on compress_hyper_6_18_chunk compress_hyper_6_18_chunk_1 (actual rows=3 loops=1)
+                           ->  Sort (actual rows=3 loops=1)
+                                 Sort Key: m2_3."time", m2_3.device_id
+                                 Sort Method: quicksort 
+                                 ->  Custom Scan (DecompressChunk) on _hyper_2_6_chunk m2_3 (actual rows=360 loops=1)
+                                       ->  Seq Scan on compress_hyper_6_19_chunk compress_hyper_6_19_chunk_1 (actual rows=1 loops=1)
+                     ->  Merge Append (never executed)
+                           Sort Key: m2_4."time", m2_4.device_id
+                           ->  Sort (never executed)
+                                 Sort Key: m2_4."time", m2_4.device_id
                                  ->  Sort (never executed)
-                                       Sort Key: m1_8."time"
-                                       ->  Custom Scan (DecompressChunk) on _hyper_2_11_chunk m1_8 (never executed)
-                                             ->  Seq Scan on compress_hyper_6_21_chunk (never executed)
-                           ->  Index Scan Backward using _hyper_2_12_chunk_metrics_space_time_idx on _hyper_2_12_chunk m1_9 (never executed)
-               ->  Materialize (actual rows=51 loops=1)
-                     ->  Custom Scan (ChunkAppend) on metrics_space m2 (actual rows=11 loops=1)
-                           Order: m2."time"
-                           ->  Merge Append (actual rows=11 loops=1)
-                                 Sort Key: m2_1."time"
-                                 ->  Sort (actual rows=3 loops=1)
-                                       Sort Key: m2_1."time"
-                                       Sort Method: quicksort 
-                                       ->  Sort (actual rows=360 loops=1)
-                                             Sort Key: m2_1."time"
-                                             Sort Method: quicksort 
-                                             ->  Custom Scan (DecompressChunk) on _hyper_2_4_chunk m2_1 (actual rows=360 loops=1)
-                                                   ->  Seq Scan on compress_hyper_6_17_chunk compress_hyper_6_17_chunk_1 (actual rows=1 loops=1)
-                                 ->  Sort (actual rows=7 loops=1)
-                                       Sort Key: m2_2."time"
-                                       Sort Method: quicksort 
-                                       ->  Sort (actual rows=1080 loops=1)
-                                             Sort Key: m2_2."time"
-                                             Sort Method: quicksort 
-                                             ->  Custom Scan (DecompressChunk) on _hyper_2_5_chunk m2_2 (actual rows=1080 loops=1)
-                                                   ->  Seq Scan on compress_hyper_6_18_chunk compress_hyper_6_18_chunk_1 (actual rows=3 loops=1)
-                                 ->  Sort (actual rows=3 loops=1)
-                                       Sort Key: m2_3."time"
-                                       Sort Method: quicksort 
-                                       ->  Sort (actual rows=360 loops=1)
-                                             Sort Key: m2_3."time"
-                                             Sort Method: quicksort 
-                                             ->  Custom Scan (DecompressChunk) on _hyper_2_6_chunk m2_3 (actual rows=360 loops=1)
-                                                   ->  Seq Scan on compress_hyper_6_19_chunk compress_hyper_6_19_chunk_1 (actual rows=1 loops=1)
-                           ->  Merge Append (never executed)
-                                 Sort Key: m2_4."time"
-                                 ->  Index Scan Backward using _hyper_2_7_chunk_metrics_space_time_idx on _hyper_2_7_chunk m2_4 (never executed)
-                                 ->  Index Scan Backward using _hyper_2_8_chunk_metrics_space_time_idx on _hyper_2_8_chunk m2_5 (never executed)
-                                 ->  Index Scan Backward using _hyper_2_9_chunk_metrics_space_time_idx on _hyper_2_9_chunk m2_6 (never executed)
-                           ->  Merge Append (never executed)
-                                 Sort Key: m2_7."time"
+                                       Sort Key: m2_4."time", m2_4.device_id
+                                       ->  Seq Scan on _hyper_2_7_chunk m2_4 (never executed)
+                           ->  Sort (never executed)
+                                 Sort Key: m2_5."time", m2_5.device_id
                                  ->  Sort (never executed)
-                                       Sort Key: m2_7."time"
-                                       ->  Sort (never executed)
-                                             Sort Key: m2_7."time"
-                                             ->  Custom Scan (DecompressChunk) on _hyper_2_10_chunk m2_7 (never executed)
-                                                   ->  Seq Scan on compress_hyper_6_20_chunk compress_hyper_6_20_chunk_1 (never executed)
+                                       Sort Key: m2_5."time", m2_5.device_id
+                                       ->  Seq Scan on _hyper_2_8_chunk m2_5 (never executed)
+                           ->  Sort (never executed)
+                                 Sort Key: m2_6."time", m2_6.device_id
                                  ->  Sort (never executed)
-                                       Sort Key: m2_8."time"
-                                       ->  Sort (never executed)
-                                             Sort Key: m2_8."time"
-                                             ->  Custom Scan (DecompressChunk) on _hyper_2_11_chunk m2_8 (never executed)
-                                                   ->  Seq Scan on compress_hyper_6_21_chunk compress_hyper_6_21_chunk_1 (never executed)
-                                 ->  Index Scan Backward using _hyper_2_12_chunk_metrics_space_time_idx on _hyper_2_12_chunk m2_9 (never executed)
+                                       Sort Key: m2_6."time", m2_6.device_id
+                                       ->  Seq Scan on _hyper_2_9_chunk m2_6 (never executed)
+                     ->  Merge Append (never executed)
+                           Sort Key: m2_7."time", m2_7.device_id
+                           ->  Sort (never executed)
+                                 Sort Key: m2_7."time", m2_7.device_id
+                                 ->  Custom Scan (DecompressChunk) on _hyper_2_10_chunk m2_7 (never executed)
+                                       ->  Seq Scan on compress_hyper_6_20_chunk compress_hyper_6_20_chunk_1 (never executed)
+                           ->  Sort (never executed)
+                                 Sort Key: m2_8."time", m2_8.device_id
+                                 ->  Custom Scan (DecompressChunk) on _hyper_2_11_chunk m2_8 (never executed)
+                                       ->  Seq Scan on compress_hyper_6_21_chunk compress_hyper_6_21_chunk_1 (never executed)
+                           ->  Sort (never executed)
+                                 Sort Key: m2_9."time", m2_9.device_id
+                                 ->  Sort (never executed)
+                                       Sort Key: m2_9."time", m2_9.device_id
+                                       ->  Seq Scan on _hyper_2_12_chunk m2_9 (never executed)
 (106 rows)
 
 :PREFIX
@@ -7135,117 +7003,68 @@ FROM :TEST_TABLE m1
     ORDER BY m1.time,
         m1.device_id
     LIMIT 10;
-                                                                       QUERY PLAN                                                                        
----------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                     QUERY PLAN                                                                     
+----------------------------------------------------------------------------------------------------------------------------------------------------
  Limit (actual rows=10 loops=1)
-   ->  Incremental Sort (actual rows=10 loops=1)
-         Sort Key: m1."time", m1.device_id
-         Presorted Key: m1."time"
-         Full-sort Groups: 1  Sort Method: quicksort 
-         ->  Merge Join (actual rows=11 loops=1)
-               Merge Cond: (m1."time" = m3_1."time")
-               ->  Merge Join (actual rows=11 loops=1)
-                     Merge Cond: (m1."time" = m2."time")
-                     Join Filter: (m1.device_id = m2.device_id)
-                     Rows Removed by Join Filter: 40
-                     ->  Custom Scan (ChunkAppend) on metrics_space m1 (actual rows=11 loops=1)
-                           Order: m1."time"
-                           ->  Merge Append (actual rows=11 loops=1)
-                                 Sort Key: m1_1."time"
-                                 ->  Sort (actual rows=3 loops=1)
-                                       Sort Key: m1_1."time"
-                                       Sort Method: quicksort 
-                                       ->  Sort (actual rows=360 loops=1)
-                                             Sort Key: m1_1."time"
-                                             Sort Method: quicksort 
-                                             ->  Custom Scan (DecompressChunk) on _hyper_2_4_chunk m1_1 (actual rows=360 loops=1)
-                                                   ->  Seq Scan on compress_hyper_6_17_chunk (actual rows=1 loops=1)
-                                 ->  Sort (actual rows=7 loops=1)
-                                       Sort Key: m1_2."time"
-                                       Sort Method: quicksort 
-                                       ->  Sort (actual rows=1080 loops=1)
-                                             Sort Key: m1_2."time"
-                                             Sort Method: quicksort 
-                                             ->  Custom Scan (DecompressChunk) on _hyper_2_5_chunk m1_2 (actual rows=1080 loops=1)
-                                                   ->  Seq Scan on compress_hyper_6_18_chunk (actual rows=3 loops=1)
-                                 ->  Sort (actual rows=3 loops=1)
-                                       Sort Key: m1_3."time"
-                                       Sort Method: quicksort 
-                                       ->  Sort (actual rows=360 loops=1)
-                                             Sort Key: m1_3."time"
-                                             Sort Method: quicksort 
-                                             ->  Custom Scan (DecompressChunk) on _hyper_2_6_chunk m1_3 (actual rows=360 loops=1)
-                                                   ->  Seq Scan on compress_hyper_6_19_chunk (actual rows=1 loops=1)
-                           ->  Merge Append (never executed)
-                                 Sort Key: m1_4."time"
-                                 ->  Index Scan Backward using _hyper_2_7_chunk_metrics_space_time_idx on _hyper_2_7_chunk m1_4 (never executed)
-                                 ->  Index Scan Backward using _hyper_2_8_chunk_metrics_space_time_idx on _hyper_2_8_chunk m1_5 (never executed)
-                                 ->  Index Scan Backward using _hyper_2_9_chunk_metrics_space_time_idx on _hyper_2_9_chunk m1_6 (never executed)
-                           ->  Merge Append (never executed)
-                                 Sort Key: m1_7."time"
-                                 ->  Sort (never executed)
-                                       Sort Key: m1_7."time"
-                                       ->  Sort (never executed)
-                                             Sort Key: m1_7."time"
-                                             ->  Custom Scan (DecompressChunk) on _hyper_2_10_chunk m1_7 (never executed)
-                                                   ->  Seq Scan on compress_hyper_6_20_chunk (never executed)
-                                 ->  Sort (never executed)
-                                       Sort Key: m1_8."time"
-                                       ->  Sort (never executed)
-                                             Sort Key: m1_8."time"
-                                             ->  Custom Scan (DecompressChunk) on _hyper_2_11_chunk m1_8 (never executed)
-                                                   ->  Seq Scan on compress_hyper_6_21_chunk (never executed)
-                                 ->  Index Scan Backward using _hyper_2_12_chunk_metrics_space_time_idx on _hyper_2_12_chunk m1_9 (never executed)
-                     ->  Materialize (actual rows=51 loops=1)
-                           ->  Custom Scan (ChunkAppend) on metrics_space m2 (actual rows=11 loops=1)
-                                 Order: m2."time"
-                                 ->  Merge Append (actual rows=11 loops=1)
-                                       Sort Key: m2_1."time"
-                                       ->  Sort (actual rows=3 loops=1)
-                                             Sort Key: m2_1."time"
-                                             Sort Method: quicksort 
-                                             ->  Sort (actual rows=360 loops=1)
-                                                   Sort Key: m2_1."time"
-                                                   Sort Method: quicksort 
-                                                   ->  Custom Scan (DecompressChunk) on _hyper_2_4_chunk m2_1 (actual rows=360 loops=1)
-                                                         ->  Seq Scan on compress_hyper_6_17_chunk compress_hyper_6_17_chunk_1 (actual rows=1 loops=1)
-                                       ->  Sort (actual rows=7 loops=1)
-                                             Sort Key: m2_2."time"
-                                             Sort Method: quicksort 
-                                             ->  Sort (actual rows=1080 loops=1)
-                                                   Sort Key: m2_2."time"
-                                                   Sort Method: quicksort 
-                                                   ->  Custom Scan (DecompressChunk) on _hyper_2_5_chunk m2_2 (actual rows=1080 loops=1)
-                                                         ->  Seq Scan on compress_hyper_6_18_chunk compress_hyper_6_18_chunk_1 (actual rows=3 loops=1)
-                                       ->  Sort (actual rows=3 loops=1)
-                                             Sort Key: m2_3."time"
-                                             Sort Method: quicksort 
-                                             ->  Sort (actual rows=360 loops=1)
-                                                   Sort Key: m2_3."time"
-                                                   Sort Method: quicksort 
-                                                   ->  Custom Scan (DecompressChunk) on _hyper_2_6_chunk m2_3 (actual rows=360 loops=1)
-                                                         ->  Seq Scan on compress_hyper_6_19_chunk compress_hyper_6_19_chunk_1 (actual rows=1 loops=1)
-                                 ->  Merge Append (never executed)
-                                       Sort Key: m2_4."time"
-                                       ->  Index Scan Backward using _hyper_2_7_chunk_metrics_space_time_idx on _hyper_2_7_chunk m2_4 (never executed)
-                                       ->  Index Scan Backward using _hyper_2_8_chunk_metrics_space_time_idx on _hyper_2_8_chunk m2_5 (never executed)
-                                       ->  Index Scan Backward using _hyper_2_9_chunk_metrics_space_time_idx on _hyper_2_9_chunk m2_6 (never executed)
-                                 ->  Merge Append (never executed)
-                                       Sort Key: m2_7."time"
-                                       ->  Sort (never executed)
-                                             Sort Key: m2_7."time"
-                                             ->  Sort (never executed)
-                                                   Sort Key: m2_7."time"
-                                                   ->  Custom Scan (DecompressChunk) on _hyper_2_10_chunk m2_7 (never executed)
-                                                         ->  Seq Scan on compress_hyper_6_20_chunk compress_hyper_6_20_chunk_1 (never executed)
-                                       ->  Sort (never executed)
-                                             Sort Key: m2_8."time"
-                                             ->  Sort (never executed)
-                                                   Sort Key: m2_8."time"
-                                                   ->  Custom Scan (DecompressChunk) on _hyper_2_11_chunk m2_8 (never executed)
-                                                         ->  Seq Scan on compress_hyper_6_21_chunk compress_hyper_6_21_chunk_1 (never executed)
-                                       ->  Index Scan Backward using _hyper_2_12_chunk_metrics_space_time_idx on _hyper_2_12_chunk m2_9 (never executed)
-               ->  Materialize (actual rows=11 loops=1)
+   ->  Merge Join (actual rows=10 loops=1)
+         Merge Cond: (m2."time" = m1_1."time")
+         Join Filter: (m1_1.device_id = m2.device_id)
+         Rows Removed by Join Filter: 39
+         ->  Custom Scan (ChunkAppend) on metrics_space m2 (actual rows=10 loops=1)
+               Order: m2."time", m2.device_id
+               ->  Merge Append (actual rows=10 loops=1)
+                     Sort Key: m2_1."time", m2_1.device_id
+                     ->  Sort (actual rows=3 loops=1)
+                           Sort Key: m2_1."time", m2_1.device_id
+                           Sort Method: quicksort 
+                           ->  Custom Scan (DecompressChunk) on _hyper_2_4_chunk m2_1 (actual rows=360 loops=1)
+                                 ->  Seq Scan on compress_hyper_6_17_chunk compress_hyper_6_17_chunk_1 (actual rows=1 loops=1)
+                     ->  Sort (actual rows=6 loops=1)
+                           Sort Key: m2_2."time", m2_2.device_id
+                           Sort Method: quicksort 
+                           ->  Custom Scan (DecompressChunk) on _hyper_2_5_chunk m2_2 (actual rows=1080 loops=1)
+                                 ->  Seq Scan on compress_hyper_6_18_chunk compress_hyper_6_18_chunk_1 (actual rows=3 loops=1)
+                     ->  Sort (actual rows=3 loops=1)
+                           Sort Key: m2_3."time", m2_3.device_id
+                           Sort Method: quicksort 
+                           ->  Custom Scan (DecompressChunk) on _hyper_2_6_chunk m2_3 (actual rows=360 loops=1)
+                                 ->  Seq Scan on compress_hyper_6_19_chunk compress_hyper_6_19_chunk_1 (actual rows=1 loops=1)
+               ->  Merge Append (never executed)
+                     Sort Key: m2_4."time", m2_4.device_id
+                     ->  Sort (never executed)
+                           Sort Key: m2_4."time", m2_4.device_id
+                           ->  Sort (never executed)
+                                 Sort Key: m2_4."time", m2_4.device_id
+                                 ->  Seq Scan on _hyper_2_7_chunk m2_4 (never executed)
+                     ->  Sort (never executed)
+                           Sort Key: m2_5."time", m2_5.device_id
+                           ->  Sort (never executed)
+                                 Sort Key: m2_5."time", m2_5.device_id
+                                 ->  Seq Scan on _hyper_2_8_chunk m2_5 (never executed)
+                     ->  Sort (never executed)
+                           Sort Key: m2_6."time", m2_6.device_id
+                           ->  Sort (never executed)
+                                 Sort Key: m2_6."time", m2_6.device_id
+                                 ->  Seq Scan on _hyper_2_9_chunk m2_6 (never executed)
+               ->  Merge Append (never executed)
+                     Sort Key: m2_7."time", m2_7.device_id
+                     ->  Sort (never executed)
+                           Sort Key: m2_7."time", m2_7.device_id
+                           ->  Custom Scan (DecompressChunk) on _hyper_2_10_chunk m2_7 (never executed)
+                                 ->  Seq Scan on compress_hyper_6_20_chunk compress_hyper_6_20_chunk_1 (never executed)
+                     ->  Sort (never executed)
+                           Sort Key: m2_8."time", m2_8.device_id
+                           ->  Custom Scan (DecompressChunk) on _hyper_2_11_chunk m2_8 (never executed)
+                                 ->  Seq Scan on compress_hyper_6_21_chunk compress_hyper_6_21_chunk_1 (never executed)
+                     ->  Sort (never executed)
+                           Sort Key: m2_9."time", m2_9.device_id
+                           ->  Sort (never executed)
+                                 Sort Key: m2_9."time", m2_9.device_id
+                                 ->  Seq Scan on _hyper_2_12_chunk m2_9 (never executed)
+         ->  Materialize (actual rows=49 loops=1)
+               ->  Nested Loop (actual rows=11 loops=1)
+                     Join Filter: (m1_1."time" = m3_1."time")
+                     Rows Removed by Join Filter: 13672
                      ->  Merge Append (actual rows=3 loops=1)
                            Sort Key: m3_1."time"
                            ->  Sort (actual rows=3 loops=1)
@@ -7258,7 +7077,23 @@ FROM :TEST_TABLE m1
                                  Filter: (device_id = 3)
                            ->  Index Scan Backward using _hyper_2_12_chunk_metrics_space_time_idx on _hyper_2_12_chunk m3_3 (actual rows=1 loops=1)
                                  Filter: (device_id = 3)
-(121 rows)
+                     ->  Materialize (actual rows=4561 loops=3)
+                           ->  Append (actual rows=6840 loops=1)
+                                 ->  Custom Scan (DecompressChunk) on _hyper_2_4_chunk m1_1 (actual rows=360 loops=1)
+                                       ->  Seq Scan on compress_hyper_6_17_chunk (actual rows=1 loops=1)
+                                 ->  Custom Scan (DecompressChunk) on _hyper_2_5_chunk m1_2 (actual rows=1080 loops=1)
+                                       ->  Seq Scan on compress_hyper_6_18_chunk (actual rows=3 loops=1)
+                                 ->  Custom Scan (DecompressChunk) on _hyper_2_6_chunk m1_3 (actual rows=360 loops=1)
+                                       ->  Seq Scan on compress_hyper_6_19_chunk (actual rows=1 loops=1)
+                                 ->  Seq Scan on _hyper_2_7_chunk m1_4 (actual rows=504 loops=1)
+                                 ->  Seq Scan on _hyper_2_8_chunk m1_5 (actual rows=1512 loops=1)
+                                 ->  Seq Scan on _hyper_2_9_chunk m1_6 (actual rows=504 loops=1)
+                                 ->  Custom Scan (DecompressChunk) on _hyper_2_10_chunk m1_7 (actual rows=504 loops=1)
+                                       ->  Seq Scan on compress_hyper_6_20_chunk (actual rows=1 loops=1)
+                                 ->  Custom Scan (DecompressChunk) on _hyper_2_11_chunk m1_8 (actual rows=1512 loops=1)
+                                       ->  Seq Scan on compress_hyper_6_21_chunk (actual rows=3 loops=1)
+                                 ->  Seq Scan on _hyper_2_12_chunk m1_9 (actual rows=504 loops=1)
+(88 rows)
 
 :PREFIX
 SELECT *
@@ -7370,115 +7205,114 @@ FROM :TEST_TABLE m1
 ORDER BY m1.time,
     m1.device_id
 LIMIT 10;
-                                                                    QUERY PLAN                                                                     
----------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                 QUERY PLAN                                                                  
+---------------------------------------------------------------------------------------------------------------------------------------------
  Limit (actual rows=10 loops=1)
-   ->  Incremental Sort (actual rows=10 loops=1)
-         Sort Key: m1."time", m1.device_id
-         Presorted Key: m1."time"
-         Full-sort Groups: 1  Sort Method: quicksort 
-         ->  Merge Left Join (actual rows=11 loops=1)
-               Merge Cond: (m1."time" = m2."time")
-               Join Filter: (m1.device_id = m2.device_id)
-               Rows Removed by Join Filter: 40
-               ->  Custom Scan (ChunkAppend) on metrics_space m1 (actual rows=11 loops=1)
-                     Order: m1."time"
+   ->  Merge Left Join (actual rows=10 loops=1)
+         Merge Cond: (m1."time" = m2."time")
+         Join Filter: (m1.device_id = m2.device_id)
+         Rows Removed by Join Filter: 40
+         ->  Custom Scan (ChunkAppend) on metrics_space m1 (actual rows=10 loops=1)
+               Order: m1."time", m1.device_id
+               ->  Merge Append (actual rows=10 loops=1)
+                     Sort Key: m1_1."time", m1_1.device_id
+                     ->  Sort (actual rows=3 loops=1)
+                           Sort Key: m1_1."time", m1_1.device_id
+                           Sort Method: quicksort 
+                           ->  Custom Scan (DecompressChunk) on _hyper_2_4_chunk m1_1 (actual rows=360 loops=1)
+                                 ->  Seq Scan on compress_hyper_6_17_chunk (actual rows=1 loops=1)
+                     ->  Sort (actual rows=6 loops=1)
+                           Sort Key: m1_2."time", m1_2.device_id
+                           Sort Method: quicksort 
+                           ->  Custom Scan (DecompressChunk) on _hyper_2_5_chunk m1_2 (actual rows=1080 loops=1)
+                                 ->  Seq Scan on compress_hyper_6_18_chunk (actual rows=3 loops=1)
+                     ->  Sort (actual rows=3 loops=1)
+                           Sort Key: m1_3."time", m1_3.device_id
+                           Sort Method: quicksort 
+                           ->  Custom Scan (DecompressChunk) on _hyper_2_6_chunk m1_3 (actual rows=360 loops=1)
+                                 ->  Seq Scan on compress_hyper_6_19_chunk (actual rows=1 loops=1)
+               ->  Merge Append (never executed)
+                     Sort Key: m1_4."time", m1_4.device_id
+                     ->  Sort (never executed)
+                           Sort Key: m1_4."time", m1_4.device_id
+                           ->  Sort (never executed)
+                                 Sort Key: m1_4."time", m1_4.device_id
+                                 ->  Seq Scan on _hyper_2_7_chunk m1_4 (never executed)
+                     ->  Sort (never executed)
+                           Sort Key: m1_5."time", m1_5.device_id
+                           ->  Sort (never executed)
+                                 Sort Key: m1_5."time", m1_5.device_id
+                                 ->  Seq Scan on _hyper_2_8_chunk m1_5 (never executed)
+                     ->  Sort (never executed)
+                           Sort Key: m1_6."time", m1_6.device_id
+                           ->  Sort (never executed)
+                                 Sort Key: m1_6."time", m1_6.device_id
+                                 ->  Seq Scan on _hyper_2_9_chunk m1_6 (never executed)
+               ->  Merge Append (never executed)
+                     Sort Key: m1_7."time", m1_7.device_id
+                     ->  Sort (never executed)
+                           Sort Key: m1_7."time", m1_7.device_id
+                           ->  Custom Scan (DecompressChunk) on _hyper_2_10_chunk m1_7 (never executed)
+                                 ->  Seq Scan on compress_hyper_6_20_chunk (never executed)
+                     ->  Sort (never executed)
+                           Sort Key: m1_8."time", m1_8.device_id
+                           ->  Custom Scan (DecompressChunk) on _hyper_2_11_chunk m1_8 (never executed)
+                                 ->  Seq Scan on compress_hyper_6_21_chunk (never executed)
+                     ->  Sort (never executed)
+                           Sort Key: m1_9."time", m1_9.device_id
+                           ->  Sort (never executed)
+                                 Sort Key: m1_9."time", m1_9.device_id
+                                 ->  Seq Scan on _hyper_2_12_chunk m1_9 (never executed)
+         ->  Materialize (actual rows=50 loops=1)
+               ->  Custom Scan (ChunkAppend) on metrics_space m2 (actual rows=11 loops=1)
+                     Order: m2."time"
                      ->  Merge Append (actual rows=11 loops=1)
-                           Sort Key: m1_1."time"
+                           Sort Key: m2_1."time"
                            ->  Sort (actual rows=3 loops=1)
-                                 Sort Key: m1_1."time"
-                                 Sort Method: quicksort 
-                                 ->  Sort (actual rows=360 loops=1)
-                                       Sort Key: m1_1."time"
-                                       Sort Method: quicksort 
-                                       ->  Custom Scan (DecompressChunk) on _hyper_2_4_chunk m1_1 (actual rows=360 loops=1)
-                                             ->  Seq Scan on compress_hyper_6_17_chunk (actual rows=1 loops=1)
-                           ->  Sort (actual rows=7 loops=1)
-                                 Sort Key: m1_2."time"
-                                 Sort Method: quicksort 
-                                 ->  Sort (actual rows=1080 loops=1)
-                                       Sort Key: m1_2."time"
-                                       Sort Method: quicksort 
-                                       ->  Custom Scan (DecompressChunk) on _hyper_2_5_chunk m1_2 (actual rows=1080 loops=1)
-                                             ->  Seq Scan on compress_hyper_6_18_chunk (actual rows=3 loops=1)
-                           ->  Sort (actual rows=3 loops=1)
-                                 Sort Key: m1_3."time"
-                                 Sort Method: quicksort 
-                                 ->  Sort (actual rows=360 loops=1)
-                                       Sort Key: m1_3."time"
-                                       Sort Method: quicksort 
-                                       ->  Custom Scan (DecompressChunk) on _hyper_2_6_chunk m1_3 (actual rows=360 loops=1)
-                                             ->  Seq Scan on compress_hyper_6_19_chunk (actual rows=1 loops=1)
-                     ->  Merge Append (never executed)
-                           Sort Key: m1_4."time"
-                           ->  Index Scan Backward using _hyper_2_7_chunk_metrics_space_time_idx on _hyper_2_7_chunk m1_4 (never executed)
-                           ->  Index Scan Backward using _hyper_2_8_chunk_metrics_space_time_idx on _hyper_2_8_chunk m1_5 (never executed)
-                           ->  Index Scan Backward using _hyper_2_9_chunk_metrics_space_time_idx on _hyper_2_9_chunk m1_6 (never executed)
-                     ->  Merge Append (never executed)
-                           Sort Key: m1_7."time"
-                           ->  Sort (never executed)
-                                 Sort Key: m1_7."time"
-                                 ->  Sort (never executed)
-                                       Sort Key: m1_7."time"
-                                       ->  Custom Scan (DecompressChunk) on _hyper_2_10_chunk m1_7 (never executed)
-                                             ->  Seq Scan on compress_hyper_6_20_chunk (never executed)
-                           ->  Sort (never executed)
-                                 Sort Key: m1_8."time"
-                                 ->  Sort (never executed)
-                                       Sort Key: m1_8."time"
-                                       ->  Custom Scan (DecompressChunk) on _hyper_2_11_chunk m1_8 (never executed)
-                                             ->  Seq Scan on compress_hyper_6_21_chunk (never executed)
-                           ->  Index Scan Backward using _hyper_2_12_chunk_metrics_space_time_idx on _hyper_2_12_chunk m1_9 (never executed)
-               ->  Materialize (actual rows=51 loops=1)
-                     ->  Custom Scan (ChunkAppend) on metrics_space m2 (actual rows=11 loops=1)
-                           Order: m2."time"
-                           ->  Merge Append (actual rows=11 loops=1)
                                  Sort Key: m2_1."time"
-                                 ->  Sort (actual rows=3 loops=1)
+                                 Sort Method: quicksort 
+                                 ->  Sort (actual rows=360 loops=1)
                                        Sort Key: m2_1."time"
                                        Sort Method: quicksort 
-                                       ->  Sort (actual rows=360 loops=1)
-                                             Sort Key: m2_1."time"
-                                             Sort Method: quicksort 
-                                             ->  Custom Scan (DecompressChunk) on _hyper_2_4_chunk m2_1 (actual rows=360 loops=1)
-                                                   ->  Seq Scan on compress_hyper_6_17_chunk compress_hyper_6_17_chunk_1 (actual rows=1 loops=1)
-                                 ->  Sort (actual rows=7 loops=1)
+                                       ->  Custom Scan (DecompressChunk) on _hyper_2_4_chunk m2_1 (actual rows=360 loops=1)
+                                             ->  Seq Scan on compress_hyper_6_17_chunk compress_hyper_6_17_chunk_1 (actual rows=1 loops=1)
+                           ->  Sort (actual rows=7 loops=1)
+                                 Sort Key: m2_2."time"
+                                 Sort Method: quicksort 
+                                 ->  Sort (actual rows=1080 loops=1)
                                        Sort Key: m2_2."time"
                                        Sort Method: quicksort 
-                                       ->  Sort (actual rows=1080 loops=1)
-                                             Sort Key: m2_2."time"
-                                             Sort Method: quicksort 
-                                             ->  Custom Scan (DecompressChunk) on _hyper_2_5_chunk m2_2 (actual rows=1080 loops=1)
-                                                   ->  Seq Scan on compress_hyper_6_18_chunk compress_hyper_6_18_chunk_1 (actual rows=3 loops=1)
-                                 ->  Sort (actual rows=3 loops=1)
+                                       ->  Custom Scan (DecompressChunk) on _hyper_2_5_chunk m2_2 (actual rows=1080 loops=1)
+                                             ->  Seq Scan on compress_hyper_6_18_chunk compress_hyper_6_18_chunk_1 (actual rows=3 loops=1)
+                           ->  Sort (actual rows=3 loops=1)
+                                 Sort Key: m2_3."time"
+                                 Sort Method: quicksort 
+                                 ->  Sort (actual rows=360 loops=1)
                                        Sort Key: m2_3."time"
                                        Sort Method: quicksort 
-                                       ->  Sort (actual rows=360 loops=1)
-                                             Sort Key: m2_3."time"
-                                             Sort Method: quicksort 
-                                             ->  Custom Scan (DecompressChunk) on _hyper_2_6_chunk m2_3 (actual rows=360 loops=1)
-                                                   ->  Seq Scan on compress_hyper_6_19_chunk compress_hyper_6_19_chunk_1 (actual rows=1 loops=1)
-                           ->  Merge Append (never executed)
-                                 Sort Key: m2_4."time"
-                                 ->  Index Scan Backward using _hyper_2_7_chunk_metrics_space_time_idx on _hyper_2_7_chunk m2_4 (never executed)
-                                 ->  Index Scan Backward using _hyper_2_8_chunk_metrics_space_time_idx on _hyper_2_8_chunk m2_5 (never executed)
-                                 ->  Index Scan Backward using _hyper_2_9_chunk_metrics_space_time_idx on _hyper_2_9_chunk m2_6 (never executed)
-                           ->  Merge Append (never executed)
+                                       ->  Custom Scan (DecompressChunk) on _hyper_2_6_chunk m2_3 (actual rows=360 loops=1)
+                                             ->  Seq Scan on compress_hyper_6_19_chunk compress_hyper_6_19_chunk_1 (actual rows=1 loops=1)
+                     ->  Merge Append (never executed)
+                           Sort Key: m2_4."time"
+                           ->  Index Scan Backward using _hyper_2_7_chunk_metrics_space_time_idx on _hyper_2_7_chunk m2_4 (never executed)
+                           ->  Index Scan Backward using _hyper_2_8_chunk_metrics_space_time_idx on _hyper_2_8_chunk m2_5 (never executed)
+                           ->  Index Scan Backward using _hyper_2_9_chunk_metrics_space_time_idx on _hyper_2_9_chunk m2_6 (never executed)
+                     ->  Merge Append (never executed)
+                           Sort Key: m2_7."time"
+                           ->  Sort (never executed)
                                  Sort Key: m2_7."time"
                                  ->  Sort (never executed)
                                        Sort Key: m2_7."time"
-                                       ->  Sort (never executed)
-                                             Sort Key: m2_7."time"
-                                             ->  Custom Scan (DecompressChunk) on _hyper_2_10_chunk m2_7 (never executed)
-                                                   ->  Seq Scan on compress_hyper_6_20_chunk compress_hyper_6_20_chunk_1 (never executed)
+                                       ->  Custom Scan (DecompressChunk) on _hyper_2_10_chunk m2_7 (never executed)
+                                             ->  Seq Scan on compress_hyper_6_20_chunk compress_hyper_6_20_chunk_1 (never executed)
+                           ->  Sort (never executed)
+                                 Sort Key: m2_8."time"
                                  ->  Sort (never executed)
                                        Sort Key: m2_8."time"
-                                       ->  Sort (never executed)
-                                             Sort Key: m2_8."time"
-                                             ->  Custom Scan (DecompressChunk) on _hyper_2_11_chunk m2_8 (never executed)
-                                                   ->  Seq Scan on compress_hyper_6_21_chunk compress_hyper_6_21_chunk_1 (never executed)
-                                 ->  Index Scan Backward using _hyper_2_12_chunk_metrics_space_time_idx on _hyper_2_12_chunk m2_9 (never executed)
-(106 rows)
+                                       ->  Custom Scan (DecompressChunk) on _hyper_2_11_chunk m2_8 (never executed)
+                                             ->  Seq Scan on compress_hyper_6_21_chunk compress_hyper_6_21_chunk_1 (never executed)
+                           ->  Index Scan Backward using _hyper_2_12_chunk_metrics_space_time_idx on _hyper_2_12_chunk m2_9 (never executed)
+(105 rows)
 
 :PREFIX
 SELECT *
@@ -7491,8 +7325,8 @@ ORDER BY m1.time,
     m2.time,
     m2.device_id
 LIMIT 100;
-                                                                    QUERY PLAN                                                                     
----------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                         QUERY PLAN                                                                          
+-------------------------------------------------------------------------------------------------------------------------------------------------------------
  Limit (actual rows=100 loops=1)
    ->  Incremental Sort (actual rows=100 loops=1)
          Sort Key: m1."time", m1.device_id, m2."time", m2.device_id
@@ -7507,29 +7341,20 @@ LIMIT 100;
                      ->  Merge Append (actual rows=101 loops=1)
                            Sort Key: m1_1."time"
                            ->  Sort (actual rows=21 loops=1)
-                                 Sort Key: m1_1."time"
+                                 Sort Key: m1_1."time", m1_1.device_id
                                  Sort Method: quicksort 
-                                 ->  Sort (actual rows=360 loops=1)
-                                       Sort Key: m1_1."time"
-                                       Sort Method: quicksort 
-                                       ->  Custom Scan (DecompressChunk) on _hyper_2_4_chunk m1_1 (actual rows=360 loops=1)
-                                             ->  Seq Scan on compress_hyper_6_17_chunk (actual rows=1 loops=1)
+                                 ->  Custom Scan (DecompressChunk) on _hyper_2_4_chunk m1_1 (actual rows=360 loops=1)
+                                       ->  Seq Scan on compress_hyper_6_17_chunk (actual rows=1 loops=1)
                            ->  Sort (actual rows=61 loops=1)
-                                 Sort Key: m1_2."time"
+                                 Sort Key: m1_2."time", m1_2.device_id
                                  Sort Method: quicksort 
-                                 ->  Sort (actual rows=1080 loops=1)
-                                       Sort Key: m1_2."time"
-                                       Sort Method: quicksort 
-                                       ->  Custom Scan (DecompressChunk) on _hyper_2_5_chunk m1_2 (actual rows=1080 loops=1)
-                                             ->  Seq Scan on compress_hyper_6_18_chunk (actual rows=3 loops=1)
+                                 ->  Custom Scan (DecompressChunk) on _hyper_2_5_chunk m1_2 (actual rows=1080 loops=1)
+                                       ->  Seq Scan on compress_hyper_6_18_chunk (actual rows=3 loops=1)
                            ->  Sort (actual rows=21 loops=1)
-                                 Sort Key: m1_3."time"
+                                 Sort Key: m1_3."time", m1_3.device_id
                                  Sort Method: quicksort 
-                                 ->  Sort (actual rows=360 loops=1)
-                                       Sort Key: m1_3."time"
-                                       Sort Method: quicksort 
-                                       ->  Custom Scan (DecompressChunk) on _hyper_2_6_chunk m1_3 (actual rows=360 loops=1)
-                                             ->  Seq Scan on compress_hyper_6_19_chunk (actual rows=1 loops=1)
+                                 ->  Custom Scan (DecompressChunk) on _hyper_2_6_chunk m1_3 (actual rows=360 loops=1)
+                                       ->  Seq Scan on compress_hyper_6_19_chunk (actual rows=1 loops=1)
                      ->  Merge Append (never executed)
                            Sort Key: m1_4."time"
                            ->  Index Scan Backward using _hyper_2_7_chunk_metrics_space_time_idx on _hyper_2_7_chunk m1_4 (never executed)
@@ -7538,17 +7363,13 @@ LIMIT 100;
                      ->  Merge Append (never executed)
                            Sort Key: m1_7."time"
                            ->  Sort (never executed)
-                                 Sort Key: m1_7."time"
-                                 ->  Sort (never executed)
-                                       Sort Key: m1_7."time"
-                                       ->  Custom Scan (DecompressChunk) on _hyper_2_10_chunk m1_7 (never executed)
-                                             ->  Seq Scan on compress_hyper_6_20_chunk (never executed)
+                                 Sort Key: m1_7."time", m1_7.device_id
+                                 ->  Custom Scan (DecompressChunk) on _hyper_2_10_chunk m1_7 (never executed)
+                                       ->  Seq Scan on compress_hyper_6_20_chunk (never executed)
                            ->  Sort (never executed)
-                                 Sort Key: m1_8."time"
-                                 ->  Sort (never executed)
-                                       Sort Key: m1_8."time"
-                                       ->  Custom Scan (DecompressChunk) on _hyper_2_11_chunk m1_8 (never executed)
-                                             ->  Seq Scan on compress_hyper_6_21_chunk (never executed)
+                                 Sort Key: m1_8."time", m1_8.device_id
+                                 ->  Custom Scan (DecompressChunk) on _hyper_2_11_chunk m1_8 (never executed)
+                                       ->  Seq Scan on compress_hyper_6_21_chunk (never executed)
                            ->  Index Scan Backward using _hyper_2_12_chunk_metrics_space_time_idx on _hyper_2_12_chunk m1_9 (never executed)
                ->  Materialize (actual rows=102 loops=1)
                      ->  Custom Scan (ChunkAppend) on metrics_space m2 (actual rows=22 loops=1)
@@ -7587,12 +7408,12 @@ LIMIT 100;
                                                          Rows Removed by Filter: 1
                            ->  Merge Append (never executed)
                                  Sort Key: m2_4."time"
-                                 ->  Index Scan Backward using _hyper_2_7_chunk_metrics_space_time_idx on _hyper_2_7_chunk m2_4 (never executed)
-                                       Filter: (device_id = 2)
-                                 ->  Index Scan Backward using _hyper_2_8_chunk_metrics_space_time_idx on _hyper_2_8_chunk m2_5 (never executed)
-                                       Filter: (device_id = 2)
-                                 ->  Index Scan Backward using _hyper_2_9_chunk_metrics_space_time_idx on _hyper_2_9_chunk m2_6 (never executed)
-                                       Filter: (device_id = 2)
+                                 ->  Index Scan Backward using _hyper_2_7_chunk_metrics_space_device_id_time_idx on _hyper_2_7_chunk m2_4 (never executed)
+                                       Index Cond: (device_id = 2)
+                                 ->  Index Scan Backward using _hyper_2_8_chunk_metrics_space_device_id_time_idx on _hyper_2_8_chunk m2_5 (never executed)
+                                       Index Cond: (device_id = 2)
+                                 ->  Index Scan Backward using _hyper_2_9_chunk_metrics_space_device_id_time_idx on _hyper_2_9_chunk m2_6 (never executed)
+                                       Index Cond: (device_id = 2)
                            ->  Merge Append (never executed)
                                  Sort Key: m2_7."time"
                                  ->  Sort (never executed)
@@ -7609,9 +7430,9 @@ LIMIT 100;
                                              ->  Custom Scan (DecompressChunk) on _hyper_2_11_chunk m2_8 (never executed)
                                                    ->  Seq Scan on compress_hyper_6_21_chunk compress_hyper_6_21_chunk_1 (never executed)
                                                          Filter: (device_id = 2)
-                                 ->  Index Scan Backward using _hyper_2_12_chunk_metrics_space_time_idx on _hyper_2_12_chunk m2_9 (never executed)
-                                       Filter: (device_id = 2)
-(118 rows)
+                                 ->  Index Scan Backward using _hyper_2_12_chunk_metrics_space_device_id_time_idx on _hyper_2_12_chunk m2_9 (never executed)
+                                       Index Cond: (device_id = 2)
+(105 rows)
 
 :PREFIX
 SELECT *
@@ -7624,33 +7445,35 @@ ORDER BY m1.time,
     m2.time,
     m2.device_id
 LIMIT 100;
-                                                                    QUERY PLAN                                                                     
----------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                         QUERY PLAN                                                                          
+-------------------------------------------------------------------------------------------------------------------------------------------------------------
  Limit (actual rows=100 loops=1)
    ->  Incremental Sort (actual rows=100 loops=1)
          Sort Key: m1."time", m1.device_id, m2."time", m2.device_id
-         Presorted Key: m1."time"
-         Full-sort Groups: 3  Sort Method: quicksort 
+         Presorted Key: m1."time", m1.device_id
+         Full-sort Groups: 4  Sort Method: quicksort 
          ->  Merge Left Join (actual rows=101 loops=1)
                Merge Cond: (m1."time" = m2."time")
                Join Filter: (m1.device_id = 1)
-               Rows Removed by Join Filter: 81
+               Rows Removed by Join Filter: 80
                ->  Custom Scan (ChunkAppend) on metrics m1 (actual rows=101 loops=1)
-                     Order: m1."time"
+                     Order: m1."time", m1.device_id
                      ->  Sort (actual rows=101 loops=1)
-                           Sort Key: m1_1."time"
+                           Sort Key: m1_1."time", m1_1.device_id
                            Sort Method: quicksort 
                            ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk m1_1 (actual rows=1800 loops=1)
                                  ->  Seq Scan on compress_hyper_5_15_chunk (actual rows=5 loops=1)
-                     ->  Index Scan Backward using _hyper_1_2_chunk_metrics_time_idx on _hyper_1_2_chunk m1_2 (never executed)
                      ->  Sort (never executed)
-                           Sort Key: m1_3."time"
+                           Sort Key: m1_2."time", m1_2.device_id
+                           ->  Seq Scan on _hyper_1_2_chunk m1_2 (never executed)
+                     ->  Sort (never executed)
+                           Sort Key: m1_3."time", m1_3.device_id
                            ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk m1_3 (never executed)
                                  ->  Seq Scan on compress_hyper_5_16_chunk (never executed)
-               ->  Materialize (actual rows=102 loops=1)
-                     ->  Custom Scan (ChunkAppend) on metrics_space m2 (actual rows=22 loops=1)
+               ->  Materialize (actual rows=101 loops=1)
+                     ->  Custom Scan (ChunkAppend) on metrics_space m2 (actual rows=21 loops=1)
                            Order: m2."time"
-                           ->  Merge Append (actual rows=22 loops=1)
+                           ->  Merge Append (actual rows=21 loops=1)
                                  Sort Key: m2_1."time"
                                  ->  Sort (actual rows=0 loops=1)
                                        Sort Key: m2_1."time"
@@ -7662,7 +7485,7 @@ LIMIT 100;
                                                    ->  Seq Scan on compress_hyper_6_17_chunk (actual rows=0 loops=1)
                                                          Filter: (device_id = 2)
                                                          Rows Removed by Filter: 1
-                                 ->  Sort (actual rows=22 loops=1)
+                                 ->  Sort (actual rows=21 loops=1)
                                        Sort Key: m2_2."time"
                                        Sort Method: quicksort 
                                        ->  Sort (actual rows=360 loops=1)
@@ -7684,12 +7507,12 @@ LIMIT 100;
                                                          Rows Removed by Filter: 1
                            ->  Merge Append (never executed)
                                  Sort Key: m2_4."time"
-                                 ->  Index Scan Backward using _hyper_2_7_chunk_metrics_space_time_idx on _hyper_2_7_chunk m2_4 (never executed)
-                                       Filter: (device_id = 2)
-                                 ->  Index Scan Backward using _hyper_2_8_chunk_metrics_space_time_idx on _hyper_2_8_chunk m2_5 (never executed)
-                                       Filter: (device_id = 2)
-                                 ->  Index Scan Backward using _hyper_2_9_chunk_metrics_space_time_idx on _hyper_2_9_chunk m2_6 (never executed)
-                                       Filter: (device_id = 2)
+                                 ->  Index Scan Backward using _hyper_2_7_chunk_metrics_space_device_id_time_idx on _hyper_2_7_chunk m2_4 (never executed)
+                                       Index Cond: (device_id = 2)
+                                 ->  Index Scan Backward using _hyper_2_8_chunk_metrics_space_device_id_time_idx on _hyper_2_8_chunk m2_5 (never executed)
+                                       Index Cond: (device_id = 2)
+                                 ->  Index Scan Backward using _hyper_2_9_chunk_metrics_space_device_id_time_idx on _hyper_2_9_chunk m2_6 (never executed)
+                                       Index Cond: (device_id = 2)
                            ->  Merge Append (never executed)
                                  Sort Key: m2_7."time"
                                  ->  Sort (never executed)
@@ -7706,9 +7529,9 @@ LIMIT 100;
                                              ->  Custom Scan (DecompressChunk) on _hyper_2_11_chunk m2_8 (never executed)
                                                    ->  Seq Scan on compress_hyper_6_21_chunk (never executed)
                                                          Filter: (device_id = 2)
-                                 ->  Index Scan Backward using _hyper_2_12_chunk_metrics_space_time_idx on _hyper_2_12_chunk m2_9 (never executed)
-                                       Filter: (device_id = 2)
-(82 rows)
+                                 ->  Index Scan Backward using _hyper_2_12_chunk_metrics_space_device_id_time_idx on _hyper_2_12_chunk m2_9 (never executed)
+                                       Index Cond: (device_id = 2)
+(84 rows)
 
 -- test implicit self-join
 :PREFIX
@@ -7735,29 +7558,20 @@ LIMIT 20;
                      ->  Merge Append (actual rows=6 loops=1)
                            Sort Key: m1_1."time"
                            ->  Sort (actual rows=2 loops=1)
-                                 Sort Key: m1_1."time"
+                                 Sort Key: m1_1."time", m1_1.device_id
                                  Sort Method: quicksort 
-                                 ->  Sort (actual rows=360 loops=1)
-                                       Sort Key: m1_1."time"
-                                       Sort Method: quicksort 
-                                       ->  Custom Scan (DecompressChunk) on _hyper_2_4_chunk m1_1 (actual rows=360 loops=1)
-                                             ->  Seq Scan on compress_hyper_6_17_chunk (actual rows=1 loops=1)
+                                 ->  Custom Scan (DecompressChunk) on _hyper_2_4_chunk m1_1 (actual rows=360 loops=1)
+                                       ->  Seq Scan on compress_hyper_6_17_chunk (actual rows=1 loops=1)
                            ->  Sort (actual rows=4 loops=1)
-                                 Sort Key: m1_2."time"
+                                 Sort Key: m1_2."time", m1_2.device_id
                                  Sort Method: quicksort 
-                                 ->  Sort (actual rows=1080 loops=1)
-                                       Sort Key: m1_2."time"
-                                       Sort Method: quicksort 
-                                       ->  Custom Scan (DecompressChunk) on _hyper_2_5_chunk m1_2 (actual rows=1080 loops=1)
-                                             ->  Seq Scan on compress_hyper_6_18_chunk (actual rows=3 loops=1)
+                                 ->  Custom Scan (DecompressChunk) on _hyper_2_5_chunk m1_2 (actual rows=1080 loops=1)
+                                       ->  Seq Scan on compress_hyper_6_18_chunk (actual rows=3 loops=1)
                            ->  Sort (actual rows=2 loops=1)
-                                 Sort Key: m1_3."time"
+                                 Sort Key: m1_3."time", m1_3.device_id
                                  Sort Method: quicksort 
-                                 ->  Sort (actual rows=360 loops=1)
-                                       Sort Key: m1_3."time"
-                                       Sort Method: quicksort 
-                                       ->  Custom Scan (DecompressChunk) on _hyper_2_6_chunk m1_3 (actual rows=360 loops=1)
-                                             ->  Seq Scan on compress_hyper_6_19_chunk (actual rows=1 loops=1)
+                                 ->  Custom Scan (DecompressChunk) on _hyper_2_6_chunk m1_3 (actual rows=360 loops=1)
+                                       ->  Seq Scan on compress_hyper_6_19_chunk (actual rows=1 loops=1)
                      ->  Merge Append (never executed)
                            Sort Key: m1_4."time"
                            ->  Index Scan Backward using _hyper_2_7_chunk_metrics_space_time_idx on _hyper_2_7_chunk m1_4 (never executed)
@@ -7766,17 +7580,13 @@ LIMIT 20;
                      ->  Merge Append (never executed)
                            Sort Key: m1_7."time"
                            ->  Sort (never executed)
-                                 Sort Key: m1_7."time"
-                                 ->  Sort (never executed)
-                                       Sort Key: m1_7."time"
-                                       ->  Custom Scan (DecompressChunk) on _hyper_2_10_chunk m1_7 (never executed)
-                                             ->  Seq Scan on compress_hyper_6_20_chunk (never executed)
+                                 Sort Key: m1_7."time", m1_7.device_id
+                                 ->  Custom Scan (DecompressChunk) on _hyper_2_10_chunk m1_7 (never executed)
+                                       ->  Seq Scan on compress_hyper_6_20_chunk (never executed)
                            ->  Sort (never executed)
-                                 Sort Key: m1_8."time"
-                                 ->  Sort (never executed)
-                                       Sort Key: m1_8."time"
-                                       ->  Custom Scan (DecompressChunk) on _hyper_2_11_chunk m1_8 (never executed)
-                                             ->  Seq Scan on compress_hyper_6_21_chunk (never executed)
+                                 Sort Key: m1_8."time", m1_8.device_id
+                                 ->  Custom Scan (DecompressChunk) on _hyper_2_11_chunk m1_8 (never executed)
+                                       ->  Seq Scan on compress_hyper_6_21_chunk (never executed)
                            ->  Index Scan Backward using _hyper_2_12_chunk_metrics_space_time_idx on _hyper_2_12_chunk m1_9 (never executed)
                ->  Materialize (actual rows=26 loops=1)
                      ->  Custom Scan (ChunkAppend) on metrics_space m2 (actual rows=6 loops=1)
@@ -7786,27 +7596,18 @@ LIMIT 20;
                                  ->  Sort (actual rows=2 loops=1)
                                        Sort Key: m2_1."time"
                                        Sort Method: quicksort 
-                                       ->  Sort (actual rows=360 loops=1)
-                                             Sort Key: m2_1."time"
-                                             Sort Method: quicksort 
-                                             ->  Custom Scan (DecompressChunk) on _hyper_2_4_chunk m2_1 (actual rows=360 loops=1)
-                                                   ->  Seq Scan on compress_hyper_6_17_chunk compress_hyper_6_17_chunk_1 (actual rows=1 loops=1)
+                                       ->  Custom Scan (DecompressChunk) on _hyper_2_4_chunk m2_1 (actual rows=360 loops=1)
+                                             ->  Seq Scan on compress_hyper_6_17_chunk compress_hyper_6_17_chunk_1 (actual rows=1 loops=1)
                                  ->  Sort (actual rows=4 loops=1)
                                        Sort Key: m2_2."time"
                                        Sort Method: quicksort 
-                                       ->  Sort (actual rows=1080 loops=1)
-                                             Sort Key: m2_2."time"
-                                             Sort Method: quicksort 
-                                             ->  Custom Scan (DecompressChunk) on _hyper_2_5_chunk m2_2 (actual rows=1080 loops=1)
-                                                   ->  Seq Scan on compress_hyper_6_18_chunk compress_hyper_6_18_chunk_1 (actual rows=3 loops=1)
+                                       ->  Custom Scan (DecompressChunk) on _hyper_2_5_chunk m2_2 (actual rows=1080 loops=1)
+                                             ->  Seq Scan on compress_hyper_6_18_chunk compress_hyper_6_18_chunk_1 (actual rows=3 loops=1)
                                  ->  Sort (actual rows=2 loops=1)
                                        Sort Key: m2_3."time"
                                        Sort Method: quicksort 
-                                       ->  Sort (actual rows=360 loops=1)
-                                             Sort Key: m2_3."time"
-                                             Sort Method: quicksort 
-                                             ->  Custom Scan (DecompressChunk) on _hyper_2_6_chunk m2_3 (actual rows=360 loops=1)
-                                                   ->  Seq Scan on compress_hyper_6_19_chunk compress_hyper_6_19_chunk_1 (actual rows=1 loops=1)
+                                       ->  Custom Scan (DecompressChunk) on _hyper_2_6_chunk m2_3 (actual rows=360 loops=1)
+                                             ->  Seq Scan on compress_hyper_6_19_chunk compress_hyper_6_19_chunk_1 (actual rows=1 loops=1)
                            ->  Merge Append (never executed)
                                  Sort Key: m2_4."time"
                                  ->  Index Scan Backward using _hyper_2_7_chunk_metrics_space_time_idx on _hyper_2_7_chunk m2_4 (never executed)
@@ -7816,18 +7617,14 @@ LIMIT 20;
                                  Sort Key: m2_7."time"
                                  ->  Sort (never executed)
                                        Sort Key: m2_7."time"
-                                       ->  Sort (never executed)
-                                             Sort Key: m2_7."time"
-                                             ->  Custom Scan (DecompressChunk) on _hyper_2_10_chunk m2_7 (never executed)
-                                                   ->  Seq Scan on compress_hyper_6_20_chunk compress_hyper_6_20_chunk_1 (never executed)
+                                       ->  Custom Scan (DecompressChunk) on _hyper_2_10_chunk m2_7 (never executed)
+                                             ->  Seq Scan on compress_hyper_6_20_chunk compress_hyper_6_20_chunk_1 (never executed)
                                  ->  Sort (never executed)
                                        Sort Key: m2_8."time"
-                                       ->  Sort (never executed)
-                                             Sort Key: m2_8."time"
-                                             ->  Custom Scan (DecompressChunk) on _hyper_2_11_chunk m2_8 (never executed)
-                                                   ->  Seq Scan on compress_hyper_6_21_chunk compress_hyper_6_21_chunk_1 (never executed)
+                                       ->  Custom Scan (DecompressChunk) on _hyper_2_11_chunk m2_8 (never executed)
+                                             ->  Seq Scan on compress_hyper_6_21_chunk compress_hyper_6_21_chunk_1 (never executed)
                                  ->  Index Scan Backward using _hyper_2_12_chunk_metrics_space_time_idx on _hyper_2_12_chunk m2_9 (never executed)
-(104 rows)
+(78 rows)
 
 -- test self-join with sub-query
 :PREFIX
@@ -7856,29 +7653,20 @@ LIMIT 10;
                      ->  Merge Append (actual rows=6 loops=1)
                            Sort Key: m1_1."time"
                            ->  Sort (actual rows=2 loops=1)
-                                 Sort Key: m1_1."time"
+                                 Sort Key: m1_1."time", m1_1.device_id
                                  Sort Method: quicksort 
-                                 ->  Sort (actual rows=360 loops=1)
-                                       Sort Key: m1_1."time"
-                                       Sort Method: quicksort 
-                                       ->  Custom Scan (DecompressChunk) on _hyper_2_4_chunk m1_1 (actual rows=360 loops=1)
-                                             ->  Seq Scan on compress_hyper_6_17_chunk (actual rows=1 loops=1)
+                                 ->  Custom Scan (DecompressChunk) on _hyper_2_4_chunk m1_1 (actual rows=360 loops=1)
+                                       ->  Seq Scan on compress_hyper_6_17_chunk (actual rows=1 loops=1)
                            ->  Sort (actual rows=4 loops=1)
-                                 Sort Key: m1_2."time"
+                                 Sort Key: m1_2."time", m1_2.device_id
                                  Sort Method: quicksort 
-                                 ->  Sort (actual rows=1080 loops=1)
-                                       Sort Key: m1_2."time"
-                                       Sort Method: quicksort 
-                                       ->  Custom Scan (DecompressChunk) on _hyper_2_5_chunk m1_2 (actual rows=1080 loops=1)
-                                             ->  Seq Scan on compress_hyper_6_18_chunk (actual rows=3 loops=1)
+                                 ->  Custom Scan (DecompressChunk) on _hyper_2_5_chunk m1_2 (actual rows=1080 loops=1)
+                                       ->  Seq Scan on compress_hyper_6_18_chunk (actual rows=3 loops=1)
                            ->  Sort (actual rows=2 loops=1)
-                                 Sort Key: m1_3."time"
+                                 Sort Key: m1_3."time", m1_3.device_id
                                  Sort Method: quicksort 
-                                 ->  Sort (actual rows=360 loops=1)
-                                       Sort Key: m1_3."time"
-                                       Sort Method: quicksort 
-                                       ->  Custom Scan (DecompressChunk) on _hyper_2_6_chunk m1_3 (actual rows=360 loops=1)
-                                             ->  Seq Scan on compress_hyper_6_19_chunk (actual rows=1 loops=1)
+                                 ->  Custom Scan (DecompressChunk) on _hyper_2_6_chunk m1_3 (actual rows=360 loops=1)
+                                       ->  Seq Scan on compress_hyper_6_19_chunk (actual rows=1 loops=1)
                      ->  Merge Append (never executed)
                            Sort Key: m1_4."time"
                            ->  Index Scan Backward using _hyper_2_7_chunk_metrics_space_time_idx on _hyper_2_7_chunk m1_4 (never executed)
@@ -7887,17 +7675,13 @@ LIMIT 10;
                      ->  Merge Append (never executed)
                            Sort Key: m1_7."time"
                            ->  Sort (never executed)
-                                 Sort Key: m1_7."time"
-                                 ->  Sort (never executed)
-                                       Sort Key: m1_7."time"
-                                       ->  Custom Scan (DecompressChunk) on _hyper_2_10_chunk m1_7 (never executed)
-                                             ->  Seq Scan on compress_hyper_6_20_chunk (never executed)
+                                 Sort Key: m1_7."time", m1_7.device_id
+                                 ->  Custom Scan (DecompressChunk) on _hyper_2_10_chunk m1_7 (never executed)
+                                       ->  Seq Scan on compress_hyper_6_20_chunk (never executed)
                            ->  Sort (never executed)
-                                 Sort Key: m1_8."time"
-                                 ->  Sort (never executed)
-                                       Sort Key: m1_8."time"
-                                       ->  Custom Scan (DecompressChunk) on _hyper_2_11_chunk m1_8 (never executed)
-                                             ->  Seq Scan on compress_hyper_6_21_chunk (never executed)
+                                 Sort Key: m1_8."time", m1_8.device_id
+                                 ->  Custom Scan (DecompressChunk) on _hyper_2_11_chunk m1_8 (never executed)
+                                       ->  Seq Scan on compress_hyper_6_21_chunk (never executed)
                            ->  Index Scan Backward using _hyper_2_12_chunk_metrics_space_time_idx on _hyper_2_12_chunk m1_9 (never executed)
                ->  Materialize (actual rows=26 loops=1)
                      ->  Custom Scan (ChunkAppend) on metrics_space m2 (actual rows=6 loops=1)
@@ -7907,27 +7691,18 @@ LIMIT 10;
                                  ->  Sort (actual rows=2 loops=1)
                                        Sort Key: m2_1."time"
                                        Sort Method: quicksort 
-                                       ->  Sort (actual rows=360 loops=1)
-                                             Sort Key: m2_1."time"
-                                             Sort Method: quicksort 
-                                             ->  Custom Scan (DecompressChunk) on _hyper_2_4_chunk m2_1 (actual rows=360 loops=1)
-                                                   ->  Seq Scan on compress_hyper_6_17_chunk compress_hyper_6_17_chunk_1 (actual rows=1 loops=1)
+                                       ->  Custom Scan (DecompressChunk) on _hyper_2_4_chunk m2_1 (actual rows=360 loops=1)
+                                             ->  Seq Scan on compress_hyper_6_17_chunk compress_hyper_6_17_chunk_1 (actual rows=1 loops=1)
                                  ->  Sort (actual rows=4 loops=1)
                                        Sort Key: m2_2."time"
                                        Sort Method: quicksort 
-                                       ->  Sort (actual rows=1080 loops=1)
-                                             Sort Key: m2_2."time"
-                                             Sort Method: quicksort 
-                                             ->  Custom Scan (DecompressChunk) on _hyper_2_5_chunk m2_2 (actual rows=1080 loops=1)
-                                                   ->  Seq Scan on compress_hyper_6_18_chunk compress_hyper_6_18_chunk_1 (actual rows=3 loops=1)
+                                       ->  Custom Scan (DecompressChunk) on _hyper_2_5_chunk m2_2 (actual rows=1080 loops=1)
+                                             ->  Seq Scan on compress_hyper_6_18_chunk compress_hyper_6_18_chunk_1 (actual rows=3 loops=1)
                                  ->  Sort (actual rows=2 loops=1)
                                        Sort Key: m2_3."time"
                                        Sort Method: quicksort 
-                                       ->  Sort (actual rows=360 loops=1)
-                                             Sort Key: m2_3."time"
-                                             Sort Method: quicksort 
-                                             ->  Custom Scan (DecompressChunk) on _hyper_2_6_chunk m2_3 (actual rows=360 loops=1)
-                                                   ->  Seq Scan on compress_hyper_6_19_chunk compress_hyper_6_19_chunk_1 (actual rows=1 loops=1)
+                                       ->  Custom Scan (DecompressChunk) on _hyper_2_6_chunk m2_3 (actual rows=360 loops=1)
+                                             ->  Seq Scan on compress_hyper_6_19_chunk compress_hyper_6_19_chunk_1 (actual rows=1 loops=1)
                            ->  Merge Append (never executed)
                                  Sort Key: m2_4."time"
                                  ->  Index Scan Backward using _hyper_2_7_chunk_metrics_space_time_idx on _hyper_2_7_chunk m2_4 (never executed)
@@ -7937,18 +7712,14 @@ LIMIT 10;
                                  Sort Key: m2_7."time"
                                  ->  Sort (never executed)
                                        Sort Key: m2_7."time"
-                                       ->  Sort (never executed)
-                                             Sort Key: m2_7."time"
-                                             ->  Custom Scan (DecompressChunk) on _hyper_2_10_chunk m2_7 (never executed)
-                                                   ->  Seq Scan on compress_hyper_6_20_chunk compress_hyper_6_20_chunk_1 (never executed)
+                                       ->  Custom Scan (DecompressChunk) on _hyper_2_10_chunk m2_7 (never executed)
+                                             ->  Seq Scan on compress_hyper_6_20_chunk compress_hyper_6_20_chunk_1 (never executed)
                                  ->  Sort (never executed)
                                        Sort Key: m2_8."time"
-                                       ->  Sort (never executed)
-                                             Sort Key: m2_8."time"
-                                             ->  Custom Scan (DecompressChunk) on _hyper_2_11_chunk m2_8 (never executed)
-                                                   ->  Seq Scan on compress_hyper_6_21_chunk compress_hyper_6_21_chunk_1 (never executed)
+                                       ->  Custom Scan (DecompressChunk) on _hyper_2_11_chunk m2_8 (never executed)
+                                             ->  Seq Scan on compress_hyper_6_21_chunk compress_hyper_6_21_chunk_1 (never executed)
                                  ->  Index Scan Backward using _hyper_2_12_chunk_metrics_space_time_idx on _hyper_2_12_chunk m2_9 (never executed)
-(104 rows)
+(78 rows)
 
 :PREFIX
 SELECT *
@@ -8213,39 +7984,34 @@ FROM metrics,
 WHERE metrics.time > metrics_space.time
     AND metrics.device_id = metrics_space.device_id
     AND metrics.time < metrics_space.time;
-                                                                      QUERY PLAN                                                                      
-------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                         QUERY PLAN                                                                                         
+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Nested Loop (actual rows=0 loops=1)
+   Join Filter: ((_hyper_1_1_chunk."time" > _hyper_2_4_chunk."time") AND (_hyper_1_1_chunk."time" < _hyper_2_4_chunk."time") AND (_hyper_2_4_chunk.device_id = _hyper_1_1_chunk.device_id))
+   Rows Removed by Join Filter: 46785600
    ->  Append (actual rows=6840 loops=1)
-         ->  Custom Scan (DecompressChunk) on _hyper_2_4_chunk (actual rows=360 loops=1)
-               ->  Index Scan using compress_hyper_6_17_chunk_c_space_index_2 on compress_hyper_6_17_chunk (actual rows=1 loops=1)
-         ->  Custom Scan (DecompressChunk) on _hyper_2_5_chunk (actual rows=1080 loops=1)
-               ->  Index Scan using compress_hyper_6_18_chunk_c_space_index_2 on compress_hyper_6_18_chunk (actual rows=3 loops=1)
-         ->  Custom Scan (DecompressChunk) on _hyper_2_6_chunk (actual rows=360 loops=1)
-               ->  Index Scan using compress_hyper_6_19_chunk_c_space_index_2 on compress_hyper_6_19_chunk (actual rows=1 loops=1)
-         ->  Index Scan Backward using _hyper_2_7_chunk_metrics_space_device_id_device_id_peer_v0_v1_2 on _hyper_2_7_chunk (actual rows=504 loops=1)
-         ->  Index Scan Backward using _hyper_2_8_chunk_metrics_space_device_id_device_id_peer_v0_v1_2 on _hyper_2_8_chunk (actual rows=1512 loops=1)
-         ->  Index Scan Backward using _hyper_2_9_chunk_metrics_space_device_id_device_id_peer_v0_v1_2 on _hyper_2_9_chunk (actual rows=504 loops=1)
-         ->  Custom Scan (DecompressChunk) on _hyper_2_10_chunk (actual rows=504 loops=1)
-               ->  Index Scan using compress_hyper_6_20_chunk_c_space_index_2 on compress_hyper_6_20_chunk (actual rows=1 loops=1)
-         ->  Custom Scan (DecompressChunk) on _hyper_2_11_chunk (actual rows=1512 loops=1)
-               ->  Index Scan using compress_hyper_6_21_chunk_c_space_index_2 on compress_hyper_6_21_chunk (actual rows=3 loops=1)
-         ->  Index Scan Backward using _hyper_2_12_chunk_metrics_space_device_id_device_id_peer_v0_v_2 on _hyper_2_12_chunk (actual rows=504 loops=1)
-   ->  Append (actual rows=0 loops=6840)
-         ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk (actual rows=0 loops=6840)
-               Filter: (("time" > _hyper_2_4_chunk."time") AND ("time" < _hyper_2_4_chunk."time"))
-               Rows Removed by Filter: 360
-               ->  Index Scan using compress_hyper_5_15_chunk_c_index_2 on compress_hyper_5_15_chunk (actual rows=1 loops=6840)
-                     Index Cond: (device_id = _hyper_2_4_chunk.device_id)
-         ->  Index Scan using _hyper_1_2_chunk_metrics_time_idx on _hyper_1_2_chunk (actual rows=0 loops=6840)
-               Index Cond: (("time" > _hyper_2_4_chunk."time") AND ("time" < _hyper_2_4_chunk."time"))
-               Filter: (_hyper_2_4_chunk.device_id = device_id)
-         ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk (actual rows=0 loops=6840)
-               Filter: (("time" > _hyper_2_4_chunk."time") AND ("time" < _hyper_2_4_chunk."time"))
-               Rows Removed by Filter: 504
-               ->  Index Scan using compress_hyper_5_16_chunk_c_index_2 on compress_hyper_5_16_chunk (actual rows=1 loops=6840)
-                     Index Cond: (device_id = _hyper_2_4_chunk.device_id)
-(30 rows)
+         ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk (actual rows=1800 loops=1)
+               ->  Index Scan using compress_hyper_5_15_chunk_c_index_2 on compress_hyper_5_15_chunk (actual rows=5 loops=1)
+         ->  Seq Scan on _hyper_1_2_chunk (actual rows=2520 loops=1)
+         ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk (actual rows=2520 loops=1)
+               ->  Index Scan using compress_hyper_5_16_chunk_c_index_2 on compress_hyper_5_16_chunk (actual rows=5 loops=1)
+   ->  Materialize (actual rows=6840 loops=6840)
+         ->  Append (actual rows=6840 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_2_4_chunk (actual rows=360 loops=1)
+                     ->  Index Scan using compress_hyper_6_17_chunk_c_space_index_2 on compress_hyper_6_17_chunk (actual rows=1 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_2_5_chunk (actual rows=1080 loops=1)
+                     ->  Index Scan using compress_hyper_6_18_chunk_c_space_index_2 on compress_hyper_6_18_chunk (actual rows=3 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_2_6_chunk (actual rows=360 loops=1)
+                     ->  Index Scan using compress_hyper_6_19_chunk_c_space_index_2 on compress_hyper_6_19_chunk (actual rows=1 loops=1)
+               ->  Index Scan Backward using _hyper_2_7_chunk_metrics_space_device_id_device_id_peer_v0_v1_2 on _hyper_2_7_chunk (actual rows=504 loops=1)
+               ->  Index Scan Backward using _hyper_2_8_chunk_metrics_space_device_id_device_id_peer_v0_v1_2 on _hyper_2_8_chunk (actual rows=1512 loops=1)
+               ->  Index Scan Backward using _hyper_2_9_chunk_metrics_space_device_id_device_id_peer_v0_v1_2 on _hyper_2_9_chunk (actual rows=504 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_2_10_chunk (actual rows=504 loops=1)
+                     ->  Index Scan using compress_hyper_6_20_chunk_c_space_index_2 on compress_hyper_6_20_chunk (actual rows=1 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_2_11_chunk (actual rows=1512 loops=1)
+                     ->  Index Scan using compress_hyper_6_21_chunk_c_space_index_2 on compress_hyper_6_21_chunk (actual rows=3 loops=1)
+               ->  Index Scan Backward using _hyper_2_12_chunk_metrics_space_device_id_device_id_peer_v0_v_2 on _hyper_2_12_chunk (actual rows=504 loops=1)
+(25 rows)
 
 SET enable_seqscan = TRUE;
 SET enable_bitmapscan = TRUE;

--- a/tsl/test/shared/expected/ordered_append_join-16.out
+++ b/tsl/test/shared/expected/ordered_append_join-16.out
@@ -1869,20 +1869,25 @@ ORDER BY time DESC
 LIMIT 2;
 QUERY PLAN
  Limit (actual rows=2 loops=1)
-   ->  Sort (actual rows=2 loops=1)
-         Sort Key: _hyper_X_X_chunk."time" DESC
-         Sort Method: top-N heapsort 
-         ->  Nested Loop (actual rows=136740 loops=1)
-               ->  Append (actual rows=68370 loops=1)
+   ->  Nested Loop (actual rows=2 loops=1)
+         ->  Custom Scan (ChunkAppend) on metrics_compressed (actual rows=1 loops=1)
+               Order: metrics_compressed."time" DESC
+               ->  Sort (actual rows=1 loops=1)
+                     Sort Key: _hyper_X_X_chunk."time" DESC
+                     Sort Method: quicksort 
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=25190 loops=1)
                            ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=30 loops=1)
-                     ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=25190 loops=1)
-                           ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=30 loops=1)
-                     ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=17990 loops=1)
-                           ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=20 loops=1)
-               ->  Materialize (actual rows=2 loops=68370)
-                     ->  Values Scan on "*VALUES*" (actual rows=2 loops=1)
-(14 rows)
+               ->  Sort (never executed)
+                     Sort Key: _hyper_X_X_chunk."time" DESC
+                     ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (never executed)
+                           ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
+               ->  Sort (never executed)
+                     Sort Key: _hyper_X_X_chunk."time" DESC
+                     ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (never executed)
+                           ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
+         ->  Materialize (actual rows=2 loops=1)
+               ->  Values Scan on "*VALUES*" (actual rows=2 loops=1)
+(19 rows)
 
 -- test LATERAL with ordered append in the lateral query
 :PREFIX
@@ -1902,18 +1907,23 @@ QUERY PLAN
    ->  Materialize (actual rows=2 loops=2)
          ->  Subquery Scan on l (actual rows=2 loops=1)
                ->  Limit (actual rows=2 loops=1)
-                     ->  Sort (actual rows=2 loops=1)
-                           Sort Key: _hyper_X_X_chunk."time" DESC
-                           Sort Method: top-N heapsort 
-                           ->  Result (actual rows=68370 loops=1)
-                                 ->  Append (actual rows=68370 loops=1)
+                     ->  Result (actual rows=2 loops=1)
+                           ->  Custom Scan (ChunkAppend) on metrics_compressed (actual rows=2 loops=1)
+                                 Order: metrics_compressed."time" DESC
+                                 ->  Sort (actual rows=2 loops=1)
+                                       Sort Key: _hyper_X_X_chunk."time" DESC
+                                       Sort Method: top-N heapsort 
                                        ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=25190 loops=1)
                                              ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=30 loops=1)
-                                       ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=25190 loops=1)
-                                             ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=30 loops=1)
-                                       ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=17990 loops=1)
-                                             ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=20 loops=1)
-(16 rows)
+                                 ->  Sort (never executed)
+                                       Sort Key: _hyper_X_X_chunk."time" DESC
+                                       ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (never executed)
+                                             ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
+                                 ->  Sort (never executed)
+                                       Sort Key: _hyper_X_X_chunk."time" DESC
+                                       ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (never executed)
+                                             ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
+(21 rows)
 
 -- test plan with best index is chosen
 -- this should use device_id, time index
@@ -1948,17 +1958,22 @@ ORDER BY time DESC
 LIMIT 1;
 QUERY PLAN
  Limit (actual rows=1 loops=1)
-   ->  Sort (actual rows=1 loops=1)
-         Sort Key: _hyper_X_X_chunk."time" DESC
-         Sort Method: top-N heapsort 
-         ->  Append (actual rows=68370 loops=1)
+   ->  Custom Scan (ChunkAppend) on metrics_compressed (actual rows=1 loops=1)
+         Order: metrics_compressed."time" DESC
+         ->  Sort (actual rows=1 loops=1)
+               Sort Key: _hyper_X_X_chunk."time" DESC
+               Sort Method: top-N heapsort 
                ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=25190 loops=1)
                      ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=30 loops=1)
-               ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=25190 loops=1)
-                     ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=30 loops=1)
-               ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=17990 loops=1)
-                     ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=20 loops=1)
-(11 rows)
+         ->  Sort (never executed)
+               Sort Key: _hyper_X_X_chunk."time" DESC
+               ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (never executed)
+                     ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
+         ->  Sort (never executed)
+               Sort Key: _hyper_X_X_chunk."time" DESC
+               ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (never executed)
+                     ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
+(16 rows)
 
 -- test LATERAL with correlated query
 -- only last chunk should be executed
@@ -1977,28 +1992,33 @@ QUERY PLAN
  Nested Loop Left Join (actual rows=3 loops=1)
    ->  Function Scan on generate_series g (actual rows=3 loops=1)
    ->  Limit (actual rows=1 loops=3)
-         ->  Sort (actual rows=1 loops=3)
-               Sort Key: o."time" DESC
-               Sort Method: top-N heapsort 
-               ->  Result (actual rows=3600 loops=3)
-                     ->  Custom Scan (ChunkAppend) on metrics_compressed o (actual rows=3600 loops=3)
-                           Chunks excluded during startup: 0
-                           Chunks excluded during runtime: 2
+         ->  Result (actual rows=1 loops=3)
+               ->  Custom Scan (ChunkAppend) on metrics_compressed o (actual rows=1 loops=3)
+                     Order: o."time" DESC
+                     Chunks excluded during startup: 0
+                     Chunks excluded during runtime: 2
+                     ->  Sort (never executed)
+                           Sort Key: o_1."time" DESC
                            ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o_1 (never executed)
                                  Filter: (("time" >= g."time") AND ("time" < (g."time" + '@ 1 day'::interval)))
                                  ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
                                        Filter: ((_ts_meta_max_1 >= g."time") AND (_ts_meta_min_1 < (g."time" + '@ 1 day'::interval)))
+                     ->  Sort (never executed)
+                           Sort Key: o_2."time" DESC
                            ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o_2 (never executed)
                                  Filter: (("time" >= g."time") AND ("time" < (g."time" + '@ 1 day'::interval)))
                                  ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
                                        Filter: ((_ts_meta_max_1 >= g."time") AND (_ts_meta_min_1 < (g."time" + '@ 1 day'::interval)))
+                     ->  Sort (actual rows=1 loops=3)
+                           Sort Key: o_3."time" DESC
+                           Sort Method: top-N heapsort 
                            ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o_3 (actual rows=3600 loops=3)
                                  Filter: (("time" >= g."time") AND ("time" < (g."time" + '@ 1 day'::interval)))
                                  Rows Removed by Filter: 4063
                                  ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=8 loops=3)
                                        Filter: ((_ts_meta_max_1 >= g."time") AND (_ts_meta_min_1 < (g."time" + '@ 1 day'::interval)))
                                        Rows Removed by Filter: 12
-(24 rows)
+(29 rows)
 
 -- test LATERAL with correlated query
 -- only 2nd chunk should be executed
@@ -2017,28 +2037,33 @@ QUERY PLAN
  Nested Loop Left Join (actual rows=2 loops=1)
    ->  Function Scan on generate_series g (actual rows=2 loops=1)
    ->  Limit (actual rows=1 loops=2)
-         ->  Sort (actual rows=1 loops=2)
-               Sort Key: o."time"
-               Sort Method: top-N heapsort 
-               ->  Result (actual rows=3600 loops=2)
-                     ->  Custom Scan (ChunkAppend) on metrics_compressed o (actual rows=3600 loops=2)
-                           Chunks excluded during startup: 0
-                           Chunks excluded during runtime: 2
+         ->  Result (actual rows=1 loops=2)
+               ->  Custom Scan (ChunkAppend) on metrics_compressed o (actual rows=1 loops=2)
+                     Order: o."time"
+                     Chunks excluded during startup: 0
+                     Chunks excluded during runtime: 2
+                     ->  Sort (never executed)
+                           Sort Key: o_1."time"
                            ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o_1 (never executed)
                                  Filter: (("time" >= g."time") AND ("time" < (g."time" + '@ 1 day'::interval)))
                                  ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
                                        Filter: ((_ts_meta_max_1 >= g."time") AND (_ts_meta_min_1 < (g."time" + '@ 1 day'::interval)))
+                     ->  Sort (actual rows=1 loops=2)
+                           Sort Key: o_2."time"
+                           Sort Method: top-N heapsort 
                            ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o_2 (actual rows=3600 loops=2)
                                  Filter: (("time" >= g."time") AND ("time" < (g."time" + '@ 1 day'::interval)))
                                  Rows Removed by Filter: 3900
                                  ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=8 loops=2)
                                        Filter: ((_ts_meta_max_1 >= g."time") AND (_ts_meta_min_1 < (g."time" + '@ 1 day'::interval)))
                                        Rows Removed by Filter: 22
+                     ->  Sort (never executed)
+                           Sort Key: o_3."time"
                            ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o_3 (never executed)
                                  Filter: (("time" >= g."time") AND ("time" < (g."time" + '@ 1 day'::interval)))
                                  ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
                                        Filter: ((_ts_meta_max_1 >= g."time") AND (_ts_meta_min_1 < (g."time" + '@ 1 day'::interval)))
-(24 rows)
+(29 rows)
 
 -- test startup and runtime exclusion together
 :PREFIX
@@ -2057,28 +2082,33 @@ QUERY PLAN
  Nested Loop Left Join (actual rows=3 loops=1)
    ->  Function Scan on generate_series g (actual rows=3 loops=1)
    ->  Limit (actual rows=1 loops=3)
-         ->  Sort (actual rows=1 loops=3)
-               Sort Key: o."time" DESC
-               Sort Method: top-N heapsort 
-               ->  Result (actual rows=3600 loops=3)
-                     ->  Custom Scan (ChunkAppend) on metrics_compressed o (actual rows=3600 loops=3)
-                           Chunks excluded during startup: 0
-                           Chunks excluded during runtime: 2
+         ->  Result (actual rows=1 loops=3)
+               ->  Custom Scan (ChunkAppend) on metrics_compressed o (actual rows=1 loops=3)
+                     Order: o."time" DESC
+                     Chunks excluded during startup: 0
+                     Chunks excluded during runtime: 2
+                     ->  Sort (never executed)
+                           Sort Key: o_1."time" DESC
                            ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o_1 (never executed)
                                  Filter: (("time" >= g."time") AND ("time" < (g."time" + '@ 1 day'::interval)) AND ("time" < now()))
                                  ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
                                        Filter: ((_ts_meta_max_1 >= g."time") AND (_ts_meta_min_1 < (g."time" + '@ 1 day'::interval)))
+                     ->  Sort (never executed)
+                           Sort Key: o_2."time" DESC
                            ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o_2 (never executed)
                                  Filter: (("time" >= g."time") AND ("time" < (g."time" + '@ 1 day'::interval)) AND ("time" < now()))
                                  ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
                                        Filter: ((_ts_meta_max_1 >= g."time") AND (_ts_meta_min_1 < (g."time" + '@ 1 day'::interval)))
+                     ->  Sort (actual rows=1 loops=3)
+                           Sort Key: o_3."time" DESC
+                           Sort Method: top-N heapsort 
                            ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o_3 (actual rows=3600 loops=3)
                                  Filter: (("time" >= g."time") AND ("time" < (g."time" + '@ 1 day'::interval)) AND ("time" < now()))
                                  Rows Removed by Filter: 4063
                                  ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=8 loops=3)
                                        Filter: ((_ts_meta_max_1 >= g."time") AND (_ts_meta_min_1 < (g."time" + '@ 1 day'::interval)))
                                        Rows Removed by Filter: 12
-(24 rows)
+(29 rows)
 
 -- test startup and runtime exclusion together
 -- all chunks should be filtered
@@ -2098,13 +2128,11 @@ QUERY PLAN
  Nested Loop Left Join (actual rows=3 loops=1)
    ->  Function Scan on generate_series g (actual rows=3 loops=1)
    ->  Limit (actual rows=0 loops=3)
-         ->  Sort (actual rows=0 loops=3)
-               Sort Key: o."time" DESC
-               Sort Method: quicksort 
-               ->  Result (actual rows=0 loops=3)
-                     ->  Custom Scan (ChunkAppend) on metrics_compressed o (actual rows=0 loops=3)
-                           Chunks excluded during startup: 3
-(9 rows)
+         ->  Result (actual rows=0 loops=3)
+               ->  Custom Scan (ChunkAppend) on metrics_compressed o (actual rows=0 loops=3)
+                     Order: o."time" DESC
+                     Chunks excluded during startup: 3
+(7 rows)
 
 -- test JOIN
 -- no exclusion on joined table because quals are not propagated yet
@@ -2176,34 +2204,40 @@ LIMIT 10;
 QUERY PLAN
  Limit (actual rows=10 loops=1)
    ->  Merge Join (actual rows=10 loops=1)
-         Merge Cond: (o1_1."time" = o2_1."time")
-         ->  Sort (actual rows=2 loops=1)
-               Sort Key: o1_1."time"
-               Sort Method: quicksort 
-               ->  Append (actual rows=26390 loops=1)
+         Merge Cond: (o1."time" = o2."time")
+         ->  Custom Scan (ChunkAppend) on metrics_compressed o1 (actual rows=2 loops=1)
+               Order: o1."time"
+               ->  Sort (actual rows=2 loops=1)
+                     Sort Key: o1_1."time"
+                     Sort Method: quicksort 
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o1_1 (actual rows=17990 loops=1)
                            Vectorized Filter: ("time" < 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
                            ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=20 loops=1)
                                  Filter: (_ts_meta_min_1 < 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
-                     ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o1_2 (actual rows=8400 loops=1)
+               ->  Sort (never executed)
+                     Sort Key: o1_2."time"
+                     ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o1_2 (never executed)
                            Vectorized Filter: ("time" < 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
-                           Rows Removed by Filter: 1790
-                           ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=15 loops=1)
+                           ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
                                  Filter: (_ts_meta_min_1 < 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
-                                 Rows Removed by Filter: 15
          ->  Materialize (actual rows=10 loops=1)
-               ->  Sort (actual rows=6 loops=1)
-                     Sort Key: o2_1."time"
-                     Sort Method: quicksort 
-                     ->  Result (actual rows=68370 loops=1)
-                           ->  Append (actual rows=68370 loops=1)
+               ->  Result (actual rows=6 loops=1)
+                     ->  Custom Scan (ChunkAppend) on metrics_compressed o2 (actual rows=6 loops=1)
+                           Order: o2."time"
+                           ->  Sort (actual rows=6 loops=1)
+                                 Sort Key: o2_1."time"
+                                 Sort Method: quicksort 
                                  ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o2_1 (actual rows=17990 loops=1)
                                        ->  Seq Scan on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (actual rows=20 loops=1)
-                                 ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o2_2 (actual rows=25190 loops=1)
-                                       ->  Seq Scan on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (actual rows=30 loops=1)
-                                 ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o2_3 (actual rows=25190 loops=1)
-                                       ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=30 loops=1)
-(29 rows)
+                           ->  Sort (never executed)
+                                 Sort Key: o2_2."time"
+                                 ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o2_2 (never executed)
+                                       ->  Seq Scan on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (never executed)
+                           ->  Sort (never executed)
+                                 Sort Key: o2_3."time"
+                                 ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o2_3 (never executed)
+                                       ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
+(35 rows)
 
 -- test join against max query
 -- not ChunkAppend so no chunk exclusion
@@ -2221,7 +2255,7 @@ WHERE o1.device_id = 1
 ORDER BY time;
 QUERY PLAN
  Merge Join (actual rows=1 loops=1)
-   Merge Cond: (o1."time" = (max(_hyper_X_X_chunk."time")))
+   Merge Cond: (o1."time" = ($0))
    ->  Custom Scan (ChunkAppend) on metrics_compressed o1 (actual rows=13674 loops=1)
          Order: o1."time"
          ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o1_1 (actual rows=3598 loops=1)
@@ -2234,20 +2268,30 @@ QUERY PLAN
                ->  Index Scan Backward using compress_hyper_X_X_chunk__compressed_hypertable_4_device_id__t on compress_hyper_X_X_chunk (actual rows=6 loops=1)
                      Index Cond: (device_id = 1)
    ->  Sort (actual rows=1 loops=1)
-         Sort Key: (max(_hyper_X_X_chunk."time"))
+         Sort Key: ($0)
          Sort Method: quicksort 
-         ->  Finalize Aggregate (actual rows=1 loops=1)
-               ->  Append (actual rows=3 loops=1)
-                     ->  Partial Aggregate (actual rows=1 loops=1)
-                           ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=17990 loops=1)
-                                 ->  Seq Scan on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (actual rows=20 loops=1)
-                     ->  Partial Aggregate (actual rows=1 loops=1)
-                           ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=25190 loops=1)
-                                 ->  Seq Scan on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (actual rows=30 loops=1)
-                     ->  Partial Aggregate (actual rows=1 loops=1)
-                           ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=25190 loops=1)
-                                 ->  Seq Scan on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (actual rows=30 loops=1)
-(27 rows)
+         ->  Result (actual rows=1 loops=1)
+               InitPlan 1 (returns $0)
+                 ->  Limit (actual rows=1 loops=1)
+                       ->  Custom Scan (ChunkAppend) on metrics_compressed (actual rows=1 loops=1)
+                             Order: metrics_compressed."time" DESC
+                             ->  Sort (actual rows=1 loops=1)
+                                   Sort Key: _hyper_X_X_chunk."time" DESC
+                                   Sort Method: top-N heapsort 
+                                   ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=25190 loops=1)
+                                         Filter: ("time" IS NOT NULL)
+                                         ->  Seq Scan on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (actual rows=30 loops=1)
+                             ->  Sort (never executed)
+                                   Sort Key: _hyper_X_X_chunk."time" DESC
+                                   ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (never executed)
+                                         Filter: ("time" IS NOT NULL)
+                                         ->  Seq Scan on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (never executed)
+                             ->  Sort (never executed)
+                                   Sort Key: _hyper_X_X_chunk."time" DESC
+                                   ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (never executed)
+                                         Filter: ("time" IS NOT NULL)
+                                         ->  Seq Scan on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (never executed)
+(37 rows)
 
 RESET enable_hashjoin;
 RESET enable_nestloop;
@@ -2608,13 +2652,13 @@ QUERY PLAN
                ->  Append (actual rows=100 loops=1)
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o2_1 (actual rows=100 loops=1)
                            ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_4_device_id__t on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (actual rows=1 loops=1)
-                                 Index Cond: (device_id = 1)
+                                 Index Cond: ((device_id = 1) AND (device_id = 1))
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o2_2 (never executed)
                            ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_4_device_id__t on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (never executed)
-                                 Index Cond: (device_id = 1)
+                                 Index Cond: ((device_id = 1) AND (device_id = 1))
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o2_3 (never executed)
                            ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_4_device_id__t on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (never executed)
-                                 Index Cond: (device_id = 1)
+                                 Index Cond: ((device_id = 1) AND (device_id = 1))
 (24 rows)
 
 -- test JOIN on time column with implicit join
@@ -2739,32 +2783,57 @@ ORDER BY time DESC
 LIMIT 2;
 QUERY PLAN
  Limit (actual rows=2 loops=1)
-   ->  Sort (actual rows=2 loops=1)
-         Sort Key: _hyper_X_X_chunk."time" DESC
-         Sort Method: top-N heapsort 
-         ->  Nested Loop (actual rows=136740 loops=1)
-               ->  Append (actual rows=68370 loops=1)
-                     ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=5038 loops=1)
-                           ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=6 loops=1)
-                     ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=15114 loops=1)
-                           ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=18 loops=1)
-                     ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=5038 loops=1)
-                           ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=6 loops=1)
-                     ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=5038 loops=1)
-                           ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=6 loops=1)
-                     ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=15114 loops=1)
-                           ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=18 loops=1)
-                     ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=5038 loops=1)
-                           ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=6 loops=1)
-                     ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=3598 loops=1)
-                           ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=4 loops=1)
-                     ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=10794 loops=1)
-                           ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=12 loops=1)
-                     ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=3598 loops=1)
-                           ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=4 loops=1)
-               ->  Materialize (actual rows=2 loops=68370)
-                     ->  Values Scan on "*VALUES*" (actual rows=2 loops=1)
-(26 rows)
+   ->  Nested Loop (actual rows=2 loops=1)
+         ->  Custom Scan (ChunkAppend) on metrics_space_compressed (actual rows=1 loops=1)
+               Order: metrics_space_compressed."time" DESC
+               ->  Merge Append (actual rows=1 loops=1)
+                     Sort Key: _hyper_X_X_chunk."time" DESC
+                     ->  Sort (actual rows=1 loops=1)
+                           Sort Key: _hyper_X_X_chunk."time" DESC
+                           Sort Method: quicksort 
+                           ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=5038 loops=1)
+                                 ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=6 loops=1)
+                     ->  Sort (actual rows=1 loops=1)
+                           Sort Key: _hyper_X_X_chunk."time" DESC
+                           Sort Method: quicksort 
+                           ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=15114 loops=1)
+                                 ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=18 loops=1)
+                     ->  Sort (actual rows=1 loops=1)
+                           Sort Key: _hyper_X_X_chunk."time" DESC
+                           Sort Method: quicksort 
+                           ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=5038 loops=1)
+                                 ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=6 loops=1)
+               ->  Merge Append (never executed)
+                     Sort Key: _hyper_X_X_chunk."time" DESC
+                     ->  Sort (never executed)
+                           Sort Key: _hyper_X_X_chunk."time" DESC
+                           ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (never executed)
+                                 ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
+                     ->  Sort (never executed)
+                           Sort Key: _hyper_X_X_chunk."time" DESC
+                           ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (never executed)
+                                 ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
+                     ->  Sort (never executed)
+                           Sort Key: _hyper_X_X_chunk."time" DESC
+                           ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (never executed)
+                                 ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
+               ->  Merge Append (never executed)
+                     Sort Key: _hyper_X_X_chunk."time" DESC
+                     ->  Sort (never executed)
+                           Sort Key: _hyper_X_X_chunk."time" DESC
+                           ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (never executed)
+                                 ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
+                     ->  Sort (never executed)
+                           Sort Key: _hyper_X_X_chunk."time" DESC
+                           ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (never executed)
+                                 ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
+                     ->  Sort (never executed)
+                           Sort Key: _hyper_X_X_chunk."time" DESC
+                           ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (never executed)
+                                 ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
+         ->  Materialize (actual rows=2 loops=1)
+               ->  Values Scan on "*VALUES*" (actual rows=2 loops=1)
+(51 rows)
 
 -- test LATERAL with ordered append in the lateral query
 :PREFIX
@@ -2784,30 +2853,55 @@ QUERY PLAN
    ->  Materialize (actual rows=2 loops=2)
          ->  Subquery Scan on l (actual rows=2 loops=1)
                ->  Limit (actual rows=2 loops=1)
-                     ->  Sort (actual rows=2 loops=1)
-                           Sort Key: _hyper_X_X_chunk."time" DESC
-                           Sort Method: top-N heapsort 
-                           ->  Result (actual rows=68370 loops=1)
-                                 ->  Append (actual rows=68370 loops=1)
-                                       ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=5038 loops=1)
-                                             ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=6 loops=1)
-                                       ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=15114 loops=1)
-                                             ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=18 loops=1)
-                                       ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=5038 loops=1)
-                                             ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=6 loops=1)
-                                       ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=5038 loops=1)
-                                             ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=6 loops=1)
-                                       ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=15114 loops=1)
-                                             ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=18 loops=1)
-                                       ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=5038 loops=1)
-                                             ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=6 loops=1)
-                                       ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=3598 loops=1)
-                                             ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=4 loops=1)
-                                       ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=10794 loops=1)
-                                             ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=12 loops=1)
-                                       ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=3598 loops=1)
-                                             ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=4 loops=1)
-(28 rows)
+                     ->  Result (actual rows=2 loops=1)
+                           ->  Custom Scan (ChunkAppend) on metrics_space_compressed (actual rows=2 loops=1)
+                                 Order: metrics_space_compressed."time" DESC
+                                 ->  Merge Append (actual rows=2 loops=1)
+                                       Sort Key: _hyper_X_X_chunk."time" DESC
+                                       ->  Sort (actual rows=2 loops=1)
+                                             Sort Key: _hyper_X_X_chunk."time" DESC
+                                             Sort Method: top-N heapsort 
+                                             ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=5038 loops=1)
+                                                   ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=6 loops=1)
+                                       ->  Sort (actual rows=1 loops=1)
+                                             Sort Key: _hyper_X_X_chunk."time" DESC
+                                             Sort Method: top-N heapsort 
+                                             ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=15114 loops=1)
+                                                   ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=18 loops=1)
+                                       ->  Sort (actual rows=1 loops=1)
+                                             Sort Key: _hyper_X_X_chunk."time" DESC
+                                             Sort Method: top-N heapsort 
+                                             ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=5038 loops=1)
+                                                   ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=6 loops=1)
+                                 ->  Merge Append (never executed)
+                                       Sort Key: _hyper_X_X_chunk."time" DESC
+                                       ->  Sort (never executed)
+                                             Sort Key: _hyper_X_X_chunk."time" DESC
+                                             ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (never executed)
+                                                   ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
+                                       ->  Sort (never executed)
+                                             Sort Key: _hyper_X_X_chunk."time" DESC
+                                             ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (never executed)
+                                                   ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
+                                       ->  Sort (never executed)
+                                             Sort Key: _hyper_X_X_chunk."time" DESC
+                                             ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (never executed)
+                                                   ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
+                                 ->  Merge Append (never executed)
+                                       Sort Key: _hyper_X_X_chunk."time" DESC
+                                       ->  Sort (never executed)
+                                             Sort Key: _hyper_X_X_chunk."time" DESC
+                                             ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (never executed)
+                                                   ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
+                                       ->  Sort (never executed)
+                                             Sort Key: _hyper_X_X_chunk."time" DESC
+                                             ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (never executed)
+                                                   ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
+                                       ->  Sort (never executed)
+                                             Sort Key: _hyper_X_X_chunk."time" DESC
+                                             ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (never executed)
+                                                   ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
+(53 rows)
 
 -- test plan with best index is chosen
 -- this should use device_id, time index
@@ -2849,29 +2943,54 @@ ORDER BY time DESC
 LIMIT 1;
 QUERY PLAN
  Limit (actual rows=1 loops=1)
-   ->  Sort (actual rows=1 loops=1)
-         Sort Key: _hyper_X_X_chunk."time" DESC
-         Sort Method: top-N heapsort 
-         ->  Append (actual rows=68370 loops=1)
-               ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=5038 loops=1)
-                     ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=6 loops=1)
-               ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=15114 loops=1)
-                     ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=18 loops=1)
-               ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=5038 loops=1)
-                     ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=6 loops=1)
-               ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=5038 loops=1)
-                     ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=6 loops=1)
-               ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=15114 loops=1)
-                     ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=18 loops=1)
-               ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=5038 loops=1)
-                     ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=6 loops=1)
-               ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=3598 loops=1)
-                     ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=4 loops=1)
-               ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=10794 loops=1)
-                     ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=12 loops=1)
-               ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=3598 loops=1)
-                     ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=4 loops=1)
-(23 rows)
+   ->  Custom Scan (ChunkAppend) on metrics_space_compressed (actual rows=1 loops=1)
+         Order: metrics_space_compressed."time" DESC
+         ->  Merge Append (actual rows=1 loops=1)
+               Sort Key: _hyper_X_X_chunk."time" DESC
+               ->  Sort (actual rows=1 loops=1)
+                     Sort Key: _hyper_X_X_chunk."time" DESC
+                     Sort Method: top-N heapsort 
+                     ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=5038 loops=1)
+                           ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=6 loops=1)
+               ->  Sort (actual rows=1 loops=1)
+                     Sort Key: _hyper_X_X_chunk."time" DESC
+                     Sort Method: top-N heapsort 
+                     ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=15114 loops=1)
+                           ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=18 loops=1)
+               ->  Sort (actual rows=1 loops=1)
+                     Sort Key: _hyper_X_X_chunk."time" DESC
+                     Sort Method: top-N heapsort 
+                     ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=5038 loops=1)
+                           ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=6 loops=1)
+         ->  Merge Append (never executed)
+               Sort Key: _hyper_X_X_chunk."time" DESC
+               ->  Sort (never executed)
+                     Sort Key: _hyper_X_X_chunk."time" DESC
+                     ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (never executed)
+                           ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
+               ->  Sort (never executed)
+                     Sort Key: _hyper_X_X_chunk."time" DESC
+                     ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (never executed)
+                           ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
+               ->  Sort (never executed)
+                     Sort Key: _hyper_X_X_chunk."time" DESC
+                     ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (never executed)
+                           ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
+         ->  Merge Append (never executed)
+               Sort Key: _hyper_X_X_chunk."time" DESC
+               ->  Sort (never executed)
+                     Sort Key: _hyper_X_X_chunk."time" DESC
+                     ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (never executed)
+                           ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
+               ->  Sort (never executed)
+                     Sort Key: _hyper_X_X_chunk."time" DESC
+                     ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (never executed)
+                           ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
+               ->  Sort (never executed)
+                     Sort Key: _hyper_X_X_chunk."time" DESC
+                     ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (never executed)
+                           ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
+(48 rows)
 
 -- test LATERAL with correlated query
 -- only last chunk should be executed
@@ -2890,63 +3009,91 @@ QUERY PLAN
  Nested Loop Left Join (actual rows=3 loops=1)
    ->  Function Scan on generate_series g (actual rows=3 loops=1)
    ->  Limit (actual rows=1 loops=3)
-         ->  Sort (actual rows=1 loops=3)
-               Sort Key: o."time" DESC
-               Sort Method: top-N heapsort 
-               ->  Result (actual rows=3600 loops=3)
-                     ->  Custom Scan (ChunkAppend) on metrics_space_compressed o (actual rows=3600 loops=3)
-                           ->  Merge Append (actual rows=0 loops=3)
+         ->  Result (actual rows=1 loops=3)
+               ->  Custom Scan (ChunkAppend) on metrics_space_compressed o (actual rows=1 loops=3)
+                     Order: o."time" DESC
+                     ->  Merge Append (actual rows=0 loops=3)
+                           Sort Key: o_1."time" DESC
+                           ->  Sort (actual rows=0 loops=3)
+                                 Sort Key: o_1."time" DESC
+                                 Sort Method: quicksort 
                                  ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o_1 (actual rows=0 loops=3)
                                        Filter: (("time" >= g."time") AND ("time" < (g."time" + '@ 1 day'::interval)))
                                        ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=0 loops=3)
                                              Filter: ((_ts_meta_max_1 >= g."time") AND (_ts_meta_min_1 < (g."time" + '@ 1 day'::interval)))
                                              Rows Removed by Filter: 6
+                           ->  Sort (actual rows=0 loops=3)
+                                 Sort Key: o_2."time" DESC
+                                 Sort Method: quicksort 
                                  ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o_2 (actual rows=0 loops=3)
                                        Filter: (("time" >= g."time") AND ("time" < (g."time" + '@ 1 day'::interval)))
                                        ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=0 loops=3)
                                              Filter: ((_ts_meta_max_1 >= g."time") AND (_ts_meta_min_1 < (g."time" + '@ 1 day'::interval)))
                                              Rows Removed by Filter: 18
+                           ->  Sort (actual rows=0 loops=3)
+                                 Sort Key: o_3."time" DESC
+                                 Sort Method: quicksort 
                                  ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o_3 (actual rows=0 loops=3)
                                        Filter: (("time" >= g."time") AND ("time" < (g."time" + '@ 1 day'::interval)))
                                        ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=0 loops=3)
                                              Filter: ((_ts_meta_max_1 >= g."time") AND (_ts_meta_min_1 < (g."time" + '@ 1 day'::interval)))
                                              Rows Removed by Filter: 6
-                           ->  Merge Append (actual rows=0 loops=3)
+                     ->  Merge Append (actual rows=0 loops=3)
+                           Sort Key: o_4."time" DESC
+                           ->  Sort (actual rows=0 loops=3)
+                                 Sort Key: o_4."time" DESC
+                                 Sort Method: quicksort 
                                  ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o_4 (actual rows=0 loops=3)
                                        Filter: (("time" >= g."time") AND ("time" < (g."time" + '@ 1 day'::interval)))
                                        ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=0 loops=3)
                                              Filter: ((_ts_meta_max_1 >= g."time") AND (_ts_meta_min_1 < (g."time" + '@ 1 day'::interval)))
                                              Rows Removed by Filter: 6
+                           ->  Sort (actual rows=0 loops=3)
+                                 Sort Key: o_5."time" DESC
+                                 Sort Method: quicksort 
                                  ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o_5 (actual rows=0 loops=3)
                                        Filter: (("time" >= g."time") AND ("time" < (g."time" + '@ 1 day'::interval)))
                                        ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=0 loops=3)
                                              Filter: ((_ts_meta_max_1 >= g."time") AND (_ts_meta_min_1 < (g."time" + '@ 1 day'::interval)))
                                              Rows Removed by Filter: 18
+                           ->  Sort (actual rows=0 loops=3)
+                                 Sort Key: o_6."time" DESC
+                                 Sort Method: quicksort 
                                  ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o_6 (actual rows=0 loops=3)
                                        Filter: (("time" >= g."time") AND ("time" < (g."time" + '@ 1 day'::interval)))
                                        ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=0 loops=3)
                                              Filter: ((_ts_meta_max_1 >= g."time") AND (_ts_meta_min_1 < (g."time" + '@ 1 day'::interval)))
                                              Rows Removed by Filter: 6
-                           ->  Merge Append (actual rows=3600 loops=3)
+                     ->  Merge Append (actual rows=1 loops=3)
+                           Sort Key: o_7."time" DESC
+                           ->  Sort (actual rows=1 loops=3)
+                                 Sort Key: o_7."time" DESC
+                                 Sort Method: top-N heapsort 
                                  ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o_7 (actual rows=720 loops=3)
                                        Filter: (("time" >= g."time") AND ("time" < (g."time" + '@ 1 day'::interval)))
                                        Rows Removed by Filter: 813
                                        ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=2 loops=3)
                                              Filter: ((_ts_meta_max_1 >= g."time") AND (_ts_meta_min_1 < (g."time" + '@ 1 day'::interval)))
                                              Rows Removed by Filter: 2
+                           ->  Sort (actual rows=1 loops=3)
+                                 Sort Key: o_8."time" DESC
+                                 Sort Method: top-N heapsort 
                                  ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o_8 (actual rows=2160 loops=3)
                                        Filter: (("time" >= g."time") AND ("time" < (g."time" + '@ 1 day'::interval)))
                                        Rows Removed by Filter: 2438
                                        ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=5 loops=3)
                                              Filter: ((_ts_meta_max_1 >= g."time") AND (_ts_meta_min_1 < (g."time" + '@ 1 day'::interval)))
                                              Rows Removed by Filter: 7
+                           ->  Sort (actual rows=1 loops=3)
+                                 Sort Key: o_9."time" DESC
+                                 Sort Method: top-N heapsort 
                                  ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o_9 (actual rows=720 loops=3)
                                        Filter: (("time" >= g."time") AND ("time" < (g."time" + '@ 1 day'::interval)))
                                        Rows Removed by Filter: 813
                                        ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=2 loops=3)
                                              Filter: ((_ts_meta_max_1 >= g."time") AND (_ts_meta_min_1 < (g."time" + '@ 1 day'::interval)))
                                              Rows Removed by Filter: 2
-(59 rows)
+(87 rows)
 
 -- test LATERAL with correlated query
 -- only 2nd chunk should be executed
@@ -2965,63 +3112,85 @@ QUERY PLAN
  Nested Loop Left Join (actual rows=2 loops=1)
    ->  Function Scan on generate_series g (actual rows=2 loops=1)
    ->  Limit (actual rows=1 loops=2)
-         ->  Sort (actual rows=1 loops=2)
-               Sort Key: o."time"
-               Sort Method: top-N heapsort 
-               ->  Result (actual rows=3600 loops=2)
-                     ->  Custom Scan (ChunkAppend) on metrics_space_compressed o (actual rows=3600 loops=2)
-                           ->  Merge Append (actual rows=0 loops=2)
+         ->  Result (actual rows=1 loops=2)
+               ->  Custom Scan (ChunkAppend) on metrics_space_compressed o (actual rows=1 loops=2)
+                     Order: o."time"
+                     ->  Merge Append (actual rows=0 loops=2)
+                           Sort Key: o_1."time"
+                           ->  Sort (actual rows=0 loops=2)
+                                 Sort Key: o_1."time"
+                                 Sort Method: quicksort 
                                  ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o_1 (actual rows=0 loops=2)
                                        Filter: (("time" >= g."time") AND ("time" < (g."time" + '@ 1 day'::interval)))
                                        ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=0 loops=2)
                                              Filter: ((_ts_meta_max_1 >= g."time") AND (_ts_meta_min_1 < (g."time" + '@ 1 day'::interval)))
                                              Rows Removed by Filter: 4
+                           ->  Sort (actual rows=0 loops=2)
+                                 Sort Key: o_2."time"
+                                 Sort Method: quicksort 
                                  ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o_2 (actual rows=0 loops=2)
                                        Filter: (("time" >= g."time") AND ("time" < (g."time" + '@ 1 day'::interval)))
                                        ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=0 loops=2)
                                              Filter: ((_ts_meta_max_1 >= g."time") AND (_ts_meta_min_1 < (g."time" + '@ 1 day'::interval)))
                                              Rows Removed by Filter: 12
+                           ->  Sort (actual rows=0 loops=2)
+                                 Sort Key: o_3."time"
+                                 Sort Method: quicksort 
                                  ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o_3 (actual rows=0 loops=2)
                                        Filter: (("time" >= g."time") AND ("time" < (g."time" + '@ 1 day'::interval)))
                                        ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=0 loops=2)
                                              Filter: ((_ts_meta_max_1 >= g."time") AND (_ts_meta_min_1 < (g."time" + '@ 1 day'::interval)))
                                              Rows Removed by Filter: 4
-                           ->  Merge Append (actual rows=3600 loops=2)
+                     ->  Merge Append (actual rows=1 loops=2)
+                           Sort Key: o_4."time"
+                           ->  Sort (actual rows=1 loops=2)
+                                 Sort Key: o_4."time"
+                                 Sort Method: top-N heapsort 
                                  ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o_4 (actual rows=720 loops=2)
                                        Filter: (("time" >= g."time") AND ("time" < (g."time" + '@ 1 day'::interval)))
                                        Rows Removed by Filter: 780
                                        ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=2 loops=2)
                                              Filter: ((_ts_meta_max_1 >= g."time") AND (_ts_meta_min_1 < (g."time" + '@ 1 day'::interval)))
                                              Rows Removed by Filter: 4
+                           ->  Sort (actual rows=1 loops=2)
+                                 Sort Key: o_5."time"
+                                 Sort Method: top-N heapsort 
                                  ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o_5 (actual rows=2160 loops=2)
                                        Filter: (("time" >= g."time") AND ("time" < (g."time" + '@ 1 day'::interval)))
                                        Rows Removed by Filter: 2340
                                        ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=4 loops=2)
                                              Filter: ((_ts_meta_max_1 >= g."time") AND (_ts_meta_min_1 < (g."time" + '@ 1 day'::interval)))
                                              Rows Removed by Filter: 14
+                           ->  Sort (actual rows=1 loops=2)
+                                 Sort Key: o_6."time"
+                                 Sort Method: top-N heapsort 
                                  ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o_6 (actual rows=720 loops=2)
                                        Filter: (("time" >= g."time") AND ("time" < (g."time" + '@ 1 day'::interval)))
                                        Rows Removed by Filter: 780
                                        ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=2 loops=2)
                                              Filter: ((_ts_meta_max_1 >= g."time") AND (_ts_meta_min_1 < (g."time" + '@ 1 day'::interval)))
                                              Rows Removed by Filter: 4
-                           ->  Merge Append (actual rows=0 loops=2)
-                                 ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o_7 (actual rows=0 loops=2)
+                     ->  Merge Append (never executed)
+                           Sort Key: o_7."time"
+                           ->  Sort (never executed)
+                                 Sort Key: o_7."time"
+                                 ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o_7 (never executed)
                                        Filter: (("time" >= g."time") AND ("time" < (g."time" + '@ 1 day'::interval)))
-                                       ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=0 loops=2)
+                                       ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
                                              Filter: ((_ts_meta_max_1 >= g."time") AND (_ts_meta_min_1 < (g."time" + '@ 1 day'::interval)))
-                                             Rows Removed by Filter: 6
-                                 ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o_8 (actual rows=0 loops=2)
+                           ->  Sort (never executed)
+                                 Sort Key: o_8."time"
+                                 ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o_8 (never executed)
                                        Filter: (("time" >= g."time") AND ("time" < (g."time" + '@ 1 day'::interval)))
-                                       ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=0 loops=2)
+                                       ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
                                              Filter: ((_ts_meta_max_1 >= g."time") AND (_ts_meta_min_1 < (g."time" + '@ 1 day'::interval)))
-                                             Rows Removed by Filter: 18
-                                 ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o_9 (actual rows=0 loops=2)
+                           ->  Sort (never executed)
+                                 Sort Key: o_9."time"
+                                 ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o_9 (never executed)
                                        Filter: (("time" >= g."time") AND ("time" < (g."time" + '@ 1 day'::interval)))
-                                       ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=0 loops=2)
+                                       ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
                                              Filter: ((_ts_meta_max_1 >= g."time") AND (_ts_meta_min_1 < (g."time" + '@ 1 day'::interval)))
-                                             Rows Removed by Filter: 6
-(59 rows)
+(81 rows)
 
 -- test startup and runtime exclusion together
 :PREFIX
@@ -3040,63 +3209,91 @@ QUERY PLAN
  Nested Loop Left Join (actual rows=3 loops=1)
    ->  Function Scan on generate_series g (actual rows=3 loops=1)
    ->  Limit (actual rows=1 loops=3)
-         ->  Sort (actual rows=1 loops=3)
-               Sort Key: o."time" DESC
-               Sort Method: top-N heapsort 
-               ->  Result (actual rows=3600 loops=3)
-                     ->  Custom Scan (ChunkAppend) on metrics_space_compressed o (actual rows=3600 loops=3)
-                           ->  Merge Append (actual rows=0 loops=3)
+         ->  Result (actual rows=1 loops=3)
+               ->  Custom Scan (ChunkAppend) on metrics_space_compressed o (actual rows=1 loops=3)
+                     Order: o."time" DESC
+                     ->  Merge Append (actual rows=0 loops=3)
+                           Sort Key: o_1."time" DESC
+                           ->  Sort (actual rows=0 loops=3)
+                                 Sort Key: o_1."time" DESC
+                                 Sort Method: quicksort 
                                  ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o_1 (actual rows=0 loops=3)
                                        Filter: (("time" >= g."time") AND ("time" < (g."time" + '@ 1 day'::interval)) AND ("time" < now()))
                                        ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=0 loops=3)
                                              Filter: ((_ts_meta_max_1 >= g."time") AND (_ts_meta_min_1 < (g."time" + '@ 1 day'::interval)))
                                              Rows Removed by Filter: 6
+                           ->  Sort (actual rows=0 loops=3)
+                                 Sort Key: o_2."time" DESC
+                                 Sort Method: quicksort 
                                  ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o_2 (actual rows=0 loops=3)
                                        Filter: (("time" >= g."time") AND ("time" < (g."time" + '@ 1 day'::interval)) AND ("time" < now()))
                                        ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=0 loops=3)
                                              Filter: ((_ts_meta_max_1 >= g."time") AND (_ts_meta_min_1 < (g."time" + '@ 1 day'::interval)))
                                              Rows Removed by Filter: 18
+                           ->  Sort (actual rows=0 loops=3)
+                                 Sort Key: o_3."time" DESC
+                                 Sort Method: quicksort 
                                  ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o_3 (actual rows=0 loops=3)
                                        Filter: (("time" >= g."time") AND ("time" < (g."time" + '@ 1 day'::interval)) AND ("time" < now()))
                                        ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=0 loops=3)
                                              Filter: ((_ts_meta_max_1 >= g."time") AND (_ts_meta_min_1 < (g."time" + '@ 1 day'::interval)))
                                              Rows Removed by Filter: 6
-                           ->  Merge Append (actual rows=0 loops=3)
+                     ->  Merge Append (actual rows=0 loops=3)
+                           Sort Key: o_4."time" DESC
+                           ->  Sort (actual rows=0 loops=3)
+                                 Sort Key: o_4."time" DESC
+                                 Sort Method: quicksort 
                                  ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o_4 (actual rows=0 loops=3)
                                        Filter: (("time" >= g."time") AND ("time" < (g."time" + '@ 1 day'::interval)) AND ("time" < now()))
                                        ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=0 loops=3)
                                              Filter: ((_ts_meta_max_1 >= g."time") AND (_ts_meta_min_1 < (g."time" + '@ 1 day'::interval)))
                                              Rows Removed by Filter: 6
+                           ->  Sort (actual rows=0 loops=3)
+                                 Sort Key: o_5."time" DESC
+                                 Sort Method: quicksort 
                                  ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o_5 (actual rows=0 loops=3)
                                        Filter: (("time" >= g."time") AND ("time" < (g."time" + '@ 1 day'::interval)) AND ("time" < now()))
                                        ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=0 loops=3)
                                              Filter: ((_ts_meta_max_1 >= g."time") AND (_ts_meta_min_1 < (g."time" + '@ 1 day'::interval)))
                                              Rows Removed by Filter: 18
+                           ->  Sort (actual rows=0 loops=3)
+                                 Sort Key: o_6."time" DESC
+                                 Sort Method: quicksort 
                                  ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o_6 (actual rows=0 loops=3)
                                        Filter: (("time" >= g."time") AND ("time" < (g."time" + '@ 1 day'::interval)) AND ("time" < now()))
                                        ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=0 loops=3)
                                              Filter: ((_ts_meta_max_1 >= g."time") AND (_ts_meta_min_1 < (g."time" + '@ 1 day'::interval)))
                                              Rows Removed by Filter: 6
-                           ->  Merge Append (actual rows=3600 loops=3)
+                     ->  Merge Append (actual rows=1 loops=3)
+                           Sort Key: o_7."time" DESC
+                           ->  Sort (actual rows=1 loops=3)
+                                 Sort Key: o_7."time" DESC
+                                 Sort Method: top-N heapsort 
                                  ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o_7 (actual rows=720 loops=3)
                                        Filter: (("time" >= g."time") AND ("time" < (g."time" + '@ 1 day'::interval)) AND ("time" < now()))
                                        Rows Removed by Filter: 813
                                        ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=2 loops=3)
                                              Filter: ((_ts_meta_max_1 >= g."time") AND (_ts_meta_min_1 < (g."time" + '@ 1 day'::interval)))
                                              Rows Removed by Filter: 2
+                           ->  Sort (actual rows=1 loops=3)
+                                 Sort Key: o_8."time" DESC
+                                 Sort Method: top-N heapsort 
                                  ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o_8 (actual rows=2160 loops=3)
                                        Filter: (("time" >= g."time") AND ("time" < (g."time" + '@ 1 day'::interval)) AND ("time" < now()))
                                        Rows Removed by Filter: 2438
                                        ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=5 loops=3)
                                              Filter: ((_ts_meta_max_1 >= g."time") AND (_ts_meta_min_1 < (g."time" + '@ 1 day'::interval)))
                                              Rows Removed by Filter: 7
+                           ->  Sort (actual rows=1 loops=3)
+                                 Sort Key: o_9."time" DESC
+                                 Sort Method: top-N heapsort 
                                  ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o_9 (actual rows=720 loops=3)
                                        Filter: (("time" >= g."time") AND ("time" < (g."time" + '@ 1 day'::interval)) AND ("time" < now()))
                                        Rows Removed by Filter: 813
                                        ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=2 loops=3)
                                              Filter: ((_ts_meta_max_1 >= g."time") AND (_ts_meta_min_1 < (g."time" + '@ 1 day'::interval)))
                                              Rows Removed by Filter: 2
-(59 rows)
+(87 rows)
 
 -- test startup and runtime exclusion together
 -- all chunks should be filtered
@@ -3116,63 +3313,91 @@ QUERY PLAN
  Nested Loop Left Join (actual rows=3 loops=1)
    ->  Function Scan on generate_series g (actual rows=3 loops=1)
    ->  Limit (actual rows=0 loops=3)
-         ->  Sort (actual rows=0 loops=3)
-               Sort Key: o."time" DESC
-               Sort Method: quicksort 
-               ->  Result (actual rows=0 loops=3)
-                     ->  Custom Scan (ChunkAppend) on metrics_space_compressed o (actual rows=0 loops=3)
-                           ->  Merge Append (actual rows=0 loops=3)
+         ->  Result (actual rows=0 loops=3)
+               ->  Custom Scan (ChunkAppend) on metrics_space_compressed o (actual rows=0 loops=3)
+                     Order: o."time" DESC
+                     ->  Merge Append (actual rows=0 loops=3)
+                           Sort Key: o_1."time" DESC
+                           ->  Sort (actual rows=0 loops=3)
+                                 Sort Key: o_1."time" DESC
+                                 Sort Method: quicksort 
                                  ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o_1 (actual rows=0 loops=3)
                                        Filter: (("time" >= g."time") AND ("time" < (g."time" + '@ 1 day'::interval)) AND ("time" > now()))
                                        ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=0 loops=3)
                                              Filter: ((_ts_meta_max_1 >= g."time") AND (_ts_meta_min_1 < (g."time" + '@ 1 day'::interval)))
                                              Rows Removed by Filter: 6
+                           ->  Sort (actual rows=0 loops=3)
+                                 Sort Key: o_2."time" DESC
+                                 Sort Method: quicksort 
                                  ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o_2 (actual rows=0 loops=3)
                                        Filter: (("time" >= g."time") AND ("time" < (g."time" + '@ 1 day'::interval)) AND ("time" > now()))
                                        ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=0 loops=3)
                                              Filter: ((_ts_meta_max_1 >= g."time") AND (_ts_meta_min_1 < (g."time" + '@ 1 day'::interval)))
                                              Rows Removed by Filter: 18
+                           ->  Sort (actual rows=0 loops=3)
+                                 Sort Key: o_3."time" DESC
+                                 Sort Method: quicksort 
                                  ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o_3 (actual rows=0 loops=3)
                                        Filter: (("time" >= g."time") AND ("time" < (g."time" + '@ 1 day'::interval)) AND ("time" > now()))
                                        ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=0 loops=3)
                                              Filter: ((_ts_meta_max_1 >= g."time") AND (_ts_meta_min_1 < (g."time" + '@ 1 day'::interval)))
                                              Rows Removed by Filter: 6
-                           ->  Merge Append (actual rows=0 loops=3)
+                     ->  Merge Append (actual rows=0 loops=3)
+                           Sort Key: o_4."time" DESC
+                           ->  Sort (actual rows=0 loops=3)
+                                 Sort Key: o_4."time" DESC
+                                 Sort Method: quicksort 
                                  ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o_4 (actual rows=0 loops=3)
                                        Filter: (("time" >= g."time") AND ("time" < (g."time" + '@ 1 day'::interval)) AND ("time" > now()))
                                        ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=0 loops=3)
                                              Filter: ((_ts_meta_max_1 >= g."time") AND (_ts_meta_min_1 < (g."time" + '@ 1 day'::interval)))
                                              Rows Removed by Filter: 6
+                           ->  Sort (actual rows=0 loops=3)
+                                 Sort Key: o_5."time" DESC
+                                 Sort Method: quicksort 
                                  ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o_5 (actual rows=0 loops=3)
                                        Filter: (("time" >= g."time") AND ("time" < (g."time" + '@ 1 day'::interval)) AND ("time" > now()))
                                        ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=0 loops=3)
                                              Filter: ((_ts_meta_max_1 >= g."time") AND (_ts_meta_min_1 < (g."time" + '@ 1 day'::interval)))
                                              Rows Removed by Filter: 18
+                           ->  Sort (actual rows=0 loops=3)
+                                 Sort Key: o_6."time" DESC
+                                 Sort Method: quicksort 
                                  ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o_6 (actual rows=0 loops=3)
                                        Filter: (("time" >= g."time") AND ("time" < (g."time" + '@ 1 day'::interval)) AND ("time" > now()))
                                        ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=0 loops=3)
                                              Filter: ((_ts_meta_max_1 >= g."time") AND (_ts_meta_min_1 < (g."time" + '@ 1 day'::interval)))
                                              Rows Removed by Filter: 6
-                           ->  Merge Append (actual rows=0 loops=3)
+                     ->  Merge Append (actual rows=0 loops=3)
+                           Sort Key: o_7."time" DESC
+                           ->  Sort (actual rows=0 loops=3)
+                                 Sort Key: o_7."time" DESC
+                                 Sort Method: quicksort 
                                  ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o_7 (actual rows=0 loops=3)
                                        Filter: (("time" >= g."time") AND ("time" < (g."time" + '@ 1 day'::interval)) AND ("time" > now()))
                                        Rows Removed by Filter: 1533
                                        ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=2 loops=3)
                                              Filter: ((_ts_meta_max_1 >= g."time") AND (_ts_meta_min_1 < (g."time" + '@ 1 day'::interval)))
                                              Rows Removed by Filter: 2
+                           ->  Sort (actual rows=0 loops=3)
+                                 Sort Key: o_8."time" DESC
+                                 Sort Method: quicksort 
                                  ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o_8 (actual rows=0 loops=3)
                                        Filter: (("time" >= g."time") AND ("time" < (g."time" + '@ 1 day'::interval)) AND ("time" > now()))
                                        Rows Removed by Filter: 4598
                                        ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=5 loops=3)
                                              Filter: ((_ts_meta_max_1 >= g."time") AND (_ts_meta_min_1 < (g."time" + '@ 1 day'::interval)))
                                              Rows Removed by Filter: 7
+                           ->  Sort (actual rows=0 loops=3)
+                                 Sort Key: o_9."time" DESC
+                                 Sort Method: quicksort 
                                  ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o_9 (actual rows=0 loops=3)
                                        Filter: (("time" >= g."time") AND ("time" < (g."time" + '@ 1 day'::interval)) AND ("time" > now()))
                                        Rows Removed by Filter: 1533
                                        ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=2 loops=3)
                                              Filter: ((_ts_meta_max_1 >= g."time") AND (_ts_meta_min_1 < (g."time" + '@ 1 day'::interval)))
                                              Rows Removed by Filter: 2
-(59 rows)
+(87 rows)
 
 -- test JOIN
 -- no exclusion on joined table because quals are not propagated yet
@@ -3244,66 +3469,102 @@ LIMIT 10;
 QUERY PLAN
  Limit (actual rows=10 loops=1)
    ->  Merge Join (actual rows=10 loops=1)
-         Merge Cond: (o1_1."time" = o2_1."time")
-         ->  Sort (actual rows=2 loops=1)
-               Sort Key: o1_1."time"
-               Sort Method: quicksort 
-               ->  Append (actual rows=26390 loops=1)
-                     ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o1_1 (actual rows=3598 loops=1)
-                           Vectorized Filter: ("time" < 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
-                           ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=4 loops=1)
-                                 Filter: (_ts_meta_min_1 < 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
-                     ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o1_2 (actual rows=10794 loops=1)
-                           Vectorized Filter: ("time" < 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
-                           ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=12 loops=1)
-                                 Filter: (_ts_meta_min_1 < 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
-                     ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o1_3 (actual rows=3598 loops=1)
-                           Vectorized Filter: ("time" < 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
-                           ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=4 loops=1)
-                                 Filter: (_ts_meta_min_1 < 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
-                     ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o1_4 (actual rows=1680 loops=1)
-                           Vectorized Filter: ("time" < 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
-                           Rows Removed by Filter: 358
-                           ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=3 loops=1)
-                                 Filter: (_ts_meta_min_1 < 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
-                                 Rows Removed by Filter: 3
-                     ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o1_5 (actual rows=5040 loops=1)
-                           Vectorized Filter: ("time" < 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
-                           Rows Removed by Filter: 1074
-                           ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=9 loops=1)
-                                 Filter: (_ts_meta_min_1 < 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
-                                 Rows Removed by Filter: 9
-                     ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o1_6 (actual rows=1680 loops=1)
-                           Vectorized Filter: ("time" < 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
-                           Rows Removed by Filter: 358
-                           ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=3 loops=1)
-                                 Filter: (_ts_meta_min_1 < 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
-                                 Rows Removed by Filter: 3
+         Merge Cond: (o1."time" = o2."time")
+         ->  Custom Scan (ChunkAppend) on metrics_space_compressed o1 (actual rows=2 loops=1)
+               Order: o1."time"
+               ->  Merge Append (actual rows=2 loops=1)
+                     Sort Key: o1_1."time"
+                     ->  Sort (actual rows=2 loops=1)
+                           Sort Key: o1_1."time"
+                           Sort Method: quicksort 
+                           ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o1_1 (actual rows=3598 loops=1)
+                                 Vectorized Filter: ("time" < 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
+                                 ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=4 loops=1)
+                                       Filter: (_ts_meta_min_1 < 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
+                     ->  Sort (actual rows=1 loops=1)
+                           Sort Key: o1_2."time"
+                           Sort Method: quicksort 
+                           ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o1_2 (actual rows=10794 loops=1)
+                                 Vectorized Filter: ("time" < 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
+                                 ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=12 loops=1)
+                                       Filter: (_ts_meta_min_1 < 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
+                     ->  Sort (actual rows=1 loops=1)
+                           Sort Key: o1_3."time"
+                           Sort Method: quicksort 
+                           ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o1_3 (actual rows=3598 loops=1)
+                                 Vectorized Filter: ("time" < 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
+                                 ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=4 loops=1)
+                                       Filter: (_ts_meta_min_1 < 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
+               ->  Merge Append (never executed)
+                     Sort Key: o1_4."time"
+                     ->  Sort (never executed)
+                           Sort Key: o1_4."time"
+                           ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o1_4 (never executed)
+                                 Vectorized Filter: ("time" < 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
+                                 ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
+                                       Filter: (_ts_meta_min_1 < 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
+                     ->  Sort (never executed)
+                           Sort Key: o1_5."time"
+                           ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o1_5 (never executed)
+                                 Vectorized Filter: ("time" < 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
+                                 ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
+                                       Filter: (_ts_meta_min_1 < 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
+                     ->  Sort (never executed)
+                           Sort Key: o1_6."time"
+                           ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o1_6 (never executed)
+                                 Vectorized Filter: ("time" < 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
+                                 ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
+                                       Filter: (_ts_meta_min_1 < 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
          ->  Materialize (actual rows=10 loops=1)
-               ->  Sort (actual rows=6 loops=1)
-                     Sort Key: o2_1."time"
-                     Sort Method: quicksort 
-                     ->  Result (actual rows=68370 loops=1)
-                           ->  Append (actual rows=68370 loops=1)
-                                 ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o2_1 (actual rows=3598 loops=1)
-                                       ->  Seq Scan on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (actual rows=4 loops=1)
-                                 ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o2_2 (actual rows=10794 loops=1)
-                                       ->  Seq Scan on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (actual rows=12 loops=1)
-                                 ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o2_3 (actual rows=3598 loops=1)
-                                       ->  Seq Scan on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (actual rows=4 loops=1)
-                                 ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o2_4 (actual rows=5038 loops=1)
-                                       ->  Seq Scan on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (actual rows=6 loops=1)
-                                 ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o2_5 (actual rows=15114 loops=1)
-                                       ->  Seq Scan on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (actual rows=18 loops=1)
-                                 ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o2_6 (actual rows=5038 loops=1)
-                                       ->  Seq Scan on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (actual rows=6 loops=1)
-                                 ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o2_7 (actual rows=5038 loops=1)
-                                       ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=6 loops=1)
-                                 ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o2_8 (actual rows=15114 loops=1)
-                                       ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=18 loops=1)
-                                 ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o2_9 (actual rows=5038 loops=1)
-                                       ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=6 loops=1)
-(61 rows)
+               ->  Result (actual rows=6 loops=1)
+                     ->  Custom Scan (ChunkAppend) on metrics_space_compressed o2 (actual rows=6 loops=1)
+                           Order: o2."time"
+                           ->  Merge Append (actual rows=6 loops=1)
+                                 Sort Key: o2_1."time"
+                                 ->  Sort (actual rows=2 loops=1)
+                                       Sort Key: o2_1."time"
+                                       Sort Method: quicksort 
+                                       ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o2_1 (actual rows=3598 loops=1)
+                                             ->  Seq Scan on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (actual rows=4 loops=1)
+                                 ->  Sort (actual rows=4 loops=1)
+                                       Sort Key: o2_2."time"
+                                       Sort Method: quicksort 
+                                       ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o2_2 (actual rows=10794 loops=1)
+                                             ->  Seq Scan on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (actual rows=12 loops=1)
+                                 ->  Sort (actual rows=2 loops=1)
+                                       Sort Key: o2_3."time"
+                                       Sort Method: quicksort 
+                                       ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o2_3 (actual rows=3598 loops=1)
+                                             ->  Seq Scan on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (actual rows=4 loops=1)
+                           ->  Merge Append (never executed)
+                                 Sort Key: o2_4."time"
+                                 ->  Sort (never executed)
+                                       Sort Key: o2_4."time"
+                                       ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o2_4 (never executed)
+                                             ->  Seq Scan on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (never executed)
+                                 ->  Sort (never executed)
+                                       Sort Key: o2_5."time"
+                                       ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o2_5 (never executed)
+                                             ->  Seq Scan on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (never executed)
+                                 ->  Sort (never executed)
+                                       Sort Key: o2_6."time"
+                                       ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o2_6 (never executed)
+                                             ->  Seq Scan on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (never executed)
+                           ->  Merge Append (never executed)
+                                 Sort Key: o2_7."time"
+                                 ->  Sort (never executed)
+                                       Sort Key: o2_7."time"
+                                       ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o2_7 (never executed)
+                                             ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
+                                 ->  Sort (never executed)
+                                       Sort Key: o2_8."time"
+                                       ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o2_8 (never executed)
+                                             ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
+                                 ->  Sort (never executed)
+                                       Sort Key: o2_9."time"
+                                       ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o2_9 (never executed)
+                                             ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
+(97 rows)
 
 -- test join against max query
 -- not ChunkAppend so no chunk exclusion
@@ -3321,7 +3582,7 @@ WHERE o1.device_id = 1
 ORDER BY time;
 QUERY PLAN
  Merge Join (actual rows=1 loops=1)
-   Merge Cond: (o1."time" = (max(_hyper_X_X_chunk."time")))
+   Merge Cond: (o1."time" = ($0))
    ->  Custom Scan (ChunkAppend) on metrics_space_compressed o1 (actual rows=13674 loops=1)
          Order: o1."time"
          ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o1_1 (actual rows=3598 loops=1)
@@ -3334,38 +3595,68 @@ QUERY PLAN
                ->  Index Scan Backward using compress_hyper_X_X_chunk__compressed_hypertable_6_device_id__t on compress_hyper_X_X_chunk (actual rows=6 loops=1)
                      Index Cond: (device_id = 1)
    ->  Sort (actual rows=1 loops=1)
-         Sort Key: (max(_hyper_X_X_chunk."time"))
+         Sort Key: ($0)
          Sort Method: quicksort 
-         ->  Finalize Aggregate (actual rows=1 loops=1)
-               ->  Append (actual rows=9 loops=1)
-                     ->  Partial Aggregate (actual rows=1 loops=1)
-                           ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=3598 loops=1)
-                                 ->  Seq Scan on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (actual rows=4 loops=1)
-                     ->  Partial Aggregate (actual rows=1 loops=1)
-                           ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=10794 loops=1)
-                                 ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=12 loops=1)
-                     ->  Partial Aggregate (actual rows=1 loops=1)
-                           ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=3598 loops=1)
-                                 ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=4 loops=1)
-                     ->  Partial Aggregate (actual rows=1 loops=1)
-                           ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=5038 loops=1)
-                                 ->  Seq Scan on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (actual rows=6 loops=1)
-                     ->  Partial Aggregate (actual rows=1 loops=1)
-                           ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=15114 loops=1)
-                                 ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=18 loops=1)
-                     ->  Partial Aggregate (actual rows=1 loops=1)
-                           ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=5038 loops=1)
-                                 ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=6 loops=1)
-                     ->  Partial Aggregate (actual rows=1 loops=1)
-                           ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=5038 loops=1)
-                                 ->  Seq Scan on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (actual rows=6 loops=1)
-                     ->  Partial Aggregate (actual rows=1 loops=1)
-                           ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=15114 loops=1)
-                                 ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=18 loops=1)
-                     ->  Partial Aggregate (actual rows=1 loops=1)
-                           ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=5038 loops=1)
-                                 ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=6 loops=1)
-(45 rows)
+         ->  Result (actual rows=1 loops=1)
+               InitPlan 1 (returns $0)
+                 ->  Limit (actual rows=1 loops=1)
+                       ->  Custom Scan (ChunkAppend) on metrics_space_compressed (actual rows=1 loops=1)
+                             Order: metrics_space_compressed."time" DESC
+                             ->  Merge Append (actual rows=1 loops=1)
+                                   Sort Key: _hyper_X_X_chunk."time" DESC
+                                   ->  Sort (actual rows=1 loops=1)
+                                         Sort Key: _hyper_X_X_chunk."time" DESC
+                                         Sort Method: top-N heapsort 
+                                         ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=5038 loops=1)
+                                               Filter: ("time" IS NOT NULL)
+                                               ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=6 loops=1)
+                                   ->  Sort (actual rows=1 loops=1)
+                                         Sort Key: _hyper_X_X_chunk."time" DESC
+                                         Sort Method: top-N heapsort 
+                                         ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=15114 loops=1)
+                                               Filter: ("time" IS NOT NULL)
+                                               ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=18 loops=1)
+                                   ->  Sort (actual rows=1 loops=1)
+                                         Sort Key: _hyper_X_X_chunk."time" DESC
+                                         Sort Method: top-N heapsort 
+                                         ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=5038 loops=1)
+                                               Filter: ("time" IS NOT NULL)
+                                               ->  Seq Scan on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (actual rows=6 loops=1)
+                             ->  Merge Append (never executed)
+                                   Sort Key: _hyper_X_X_chunk."time" DESC
+                                   ->  Sort (never executed)
+                                         Sort Key: _hyper_X_X_chunk."time" DESC
+                                         ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (never executed)
+                                               Filter: ("time" IS NOT NULL)
+                                               ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
+                                   ->  Sort (never executed)
+                                         Sort Key: _hyper_X_X_chunk."time" DESC
+                                         ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (never executed)
+                                               Filter: ("time" IS NOT NULL)
+                                               ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
+                                   ->  Sort (never executed)
+                                         Sort Key: _hyper_X_X_chunk."time" DESC
+                                         ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (never executed)
+                                               Filter: ("time" IS NOT NULL)
+                                               ->  Seq Scan on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (never executed)
+                             ->  Merge Append (never executed)
+                                   Sort Key: _hyper_X_X_chunk."time" DESC
+                                   ->  Sort (never executed)
+                                         Sort Key: _hyper_X_X_chunk."time" DESC
+                                         ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (never executed)
+                                               Filter: ("time" IS NOT NULL)
+                                               ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
+                                   ->  Sort (never executed)
+                                         Sort Key: _hyper_X_X_chunk."time" DESC
+                                         ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (never executed)
+                                               Filter: ("time" IS NOT NULL)
+                                               ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
+                                   ->  Sort (never executed)
+                                         Sort Key: _hyper_X_X_chunk."time" DESC
+                                         ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (never executed)
+                                               Filter: ("time" IS NOT NULL)
+                                               ->  Seq Scan on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (never executed)
+(75 rows)
 
 RESET enable_hashjoin;
 RESET enable_nestloop;
@@ -3750,13 +4041,13 @@ QUERY PLAN
                ->  Append (actual rows=100 loops=1)
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o2_1 (actual rows=100 loops=1)
                            ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_6_device_id__t on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (actual rows=1 loops=1)
-                                 Index Cond: (device_id = 1)
+                                 Index Cond: ((device_id = 1) AND (device_id = 1))
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o2_2 (never executed)
                            ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_6_device_id__t on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (never executed)
-                                 Index Cond: (device_id = 1)
+                                 Index Cond: ((device_id = 1) AND (device_id = 1))
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o2_3 (never executed)
                            ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_6_device_id__t on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (never executed)
-                                 Index Cond: (device_id = 1)
+                                 Index Cond: ((device_id = 1) AND (device_id = 1))
 (24 rows)
 
 -- test JOIN on time column with implicit join


### PR DESCRIPTION
Mark the EquivalenceMember for the compressed chunk as derived to
prevent an infinite recursion.

Disable-check: force-changelog-file
Disable-check: commit-count