### PR TITLE
Fix missing result assignment for bms_del_member

### DIFF
--- a/.unreleased/pr_6264
+++ b/.unreleased/pr_6264
@@ -1,0 +1,1 @@
+Fixes: #6264 Fix missing bms_del_member result assignment

--- a/tsl/src/nodes/decompress_chunk/batch_array.c
+++ b/tsl/src/nodes/decompress_chunk/batch_array.c
@@ -123,7 +123,8 @@ batch_array_get_free_slot(DecompressChunkState *chunk_state)
 	Assert(next_free_batch < chunk_state->n_batch_states);
 	Assert(TupIsNull(batch_array_get_at(chunk_state, next_free_batch)->decompressed_scan_slot));
 
-	bms_del_member(chunk_state->unused_batch_states, next_free_batch);
+	chunk_state->unused_batch_states =
+		bms_del_member(chunk_state->unused_batch_states, next_free_batch);
 
 	return next_free_batch;
 }


### PR DESCRIPTION
This was causing memory corruption in the PG16 tests but affects previous PG versions as well.