### PR TITLE
Simplify compress_chunk calls in tests

### DIFF
--- a/test/sql/updates/post.compression.sql
+++ b/test/sql/updates/post.compression.sql
@@ -8,14 +8,7 @@ INSERT INTO compress
 SELECT g, 'QW', g::text, 2, 0, (100,4)::custom_type_for_compression, false
 FROM generate_series('2019-11-01 00:00'::timestamp, '2019-12-15 00:00'::timestamp, '1 day') g;
 
-SELECT
-  count(compress_chunk(chunk.schema_name || '.' || chunk.table_name)) AS count_compressed
-FROM
-  _timescaledb_catalog.chunk chunk
-  INNER JOIN _timescaledb_catalog.hypertable hypertable ON (chunk.hypertable_id = hypertable.id)
-WHERE
-  hypertable.table_name = 'compress'
-  AND chunk.compressed_chunk_id IS NULL;
+SELECT count(compress_chunk(ch, true)) FROM show_chunks('compress') ch;
 
 SELECT * FROM compress ORDER BY time DESC, small_cardinality, large_cardinality, some_double, some_int, some_custom, some_bool;
 

--- a/test/sql/updates/setup.compression.sql
+++ b/test/sql/updates/setup.compression.sql
@@ -30,11 +30,7 @@ FROM generate_series('2018-11-01 00:00'::timestamp, '2018-12-15 00:00'::timestam
 
 ALTER TABLE compress SET (timescaledb.compress, timescaledb.compress_segmentby='small_cardinality');
 
-SELECT compress_chunk(chunk.schema_name|| '.' || chunk.table_name) as count_compressed
-FROM _timescaledb_catalog.chunk chunk
-INNER JOIN _timescaledb_catalog.hypertable hypertable ON (chunk.hypertable_id = hypertable.id)
-WHERE hypertable.table_name = 'compress' and chunk.compressed_chunk_id IS NULL
-ORDER BY chunk.id;
+SELECT count(compress_chunk(ch, true)) FROM show_chunks('compress') ch;
 
 \if :WITH_ROLES
 GRANT SELECT ON compress TO tsdbadmin;

--- a/tsl/test/expected/compress_bgw_reorder_drop_chunks.out
+++ b/tsl/test/expected/compress_bgw_reorder_drop_chunks.out
@@ -94,13 +94,10 @@ SELECT * FROM _timescaledb_config.bgw_job where id=:retention_job_id;
 
 --turn on compression and compress all chunks
 ALTER TABLE test_retention_table set (timescaledb.compress, timescaledb.compress_orderby = 'time DESC');
-SELECT count(compress_chunk(chunk.schema_name|| '.' || chunk.table_name)) as count_compressed
-FROM _timescaledb_catalog.chunk chunk
-INNER JOIN _timescaledb_catalog.hypertable hypertable ON (chunk.hypertable_id = hypertable.id)
-WHERE hypertable.table_name like 'test_retention_table' and chunk.compressed_chunk_id IS NULL;
- count_compressed 
-------------------
-                5
+SELECT count(compress_chunk(ch)) FROM show_chunks('test_retention_table') ch;
+ count 
+-------
+     5
 (1 row)
 
 --make sure same # of compressed and uncompressed chunks before policy

--- a/tsl/test/expected/compressed_collation.out
+++ b/tsl/test/expected/compressed_collation.out
@@ -24,14 +24,10 @@ alter table compressed_collation_ht set (timescaledb.compress,
     timescaledb.compress_segmentby = 'name', timescaledb.compress_orderby = 'time');
 insert into compressed_collation_ht values ('2021-01-01 01:01:01', 'á', '1'),
     ('2021-01-01 01:01:02', 'b', '2'), ('2021-01-01 01:01:03', 'ç', '2');
-select 1 from (
-	select compress_chunk(chunk_schema || '.' || chunk_name)
-	from timescaledb_information.chunks
-	where hypertable_name = 'compressed_collation_ht'
-) t;
- ?column? 
-----------
-        1
+SELECT count(compress_chunk(ch)) FROM show_chunks('compressed_collation_ht') ch;
+ count 
+-------
+     1
 (1 row)
 
 select ht.schema_name || '.' || ht.table_name as "CHUNK"

--- a/tsl/test/expected/compression.out
+++ b/tsl/test/expected/compression.out
@@ -314,8 +314,7 @@ select tableoid::regclass, count(*) from conditions group by tableoid order by t
  _timescaledb_internal._hyper_5_13_chunk |    20
 (2 rows)
 
-select  compress_chunk(ch1.schema_name|| '.' || ch1.table_name)
-FROM _timescaledb_catalog.chunk ch1, _timescaledb_catalog.hypertable ht where ch1.hypertable_id = ht.id and ht.table_name like 'conditions' ORDER BY ch1.id limit 1;
+SELECT compress_chunk(ch) FROM show_chunks('conditions') ch LIMIT 1;
              compress_chunk              
 -----------------------------------------
  _timescaledb_internal._hyper_5_12_chunk
@@ -329,8 +328,7 @@ select tableoid::regclass, count(*) from conditions group by tableoid order by t
  _timescaledb_internal._hyper_5_13_chunk |    20
 (1 row)
 
-select  compress_chunk(ch1.schema_name|| '.' || ch1.table_name)
-FROM _timescaledb_catalog.chunk ch1, _timescaledb_catalog.hypertable ht where ch1.hypertable_id = ht.id and ht.table_name like 'conditions' and ch1.compressed_chunk_id IS NULL;
+SELECT compress_chunk(ch, true) FROM show_chunks('conditions') ch ORDER BY ch::text DESC LIMIT 1;
              compress_chunk              
 -----------------------------------------
  _timescaledb_internal._hyper_5_13_chunk
@@ -484,15 +482,11 @@ data_nodes          |
 tablespaces         | 
 
 \x
-SELECT decompress_chunk(ch1.schema_name|| '.' || ch1.table_name) AS chunk
-FROM _timescaledb_catalog.chunk ch1, _timescaledb_catalog.hypertable ht
-WHERE ch1.hypertable_id = ht.id and ht.table_name LIKE 'conditions'
-ORDER BY chunk;
-                  chunk                  
------------------------------------------
- _timescaledb_internal._hyper_5_12_chunk
- _timescaledb_internal._hyper_5_13_chunk
-(2 rows)
+SELECT count(decompress_chunk(ch)) FROM show_chunks('conditions') ch;
+ count 
+-------
+     2
+(1 row)
 
 SELECT count(*), count(*) = :'ORIGINAL_CHUNK_COUNT' from :CHUNK_NAME;
  count | ?column? 
@@ -615,9 +609,7 @@ select generate_series('2018-01-01 00:00'::timestamp, '2018-01-10 00:00'::timest
 insert into test_collation
 select generate_series('2018-01-01 00:00'::timestamp, '2018-01-10 00:00'::timestamp, '2 hour'), NULL, 'device_5', gen_rand_minstd(), gen_rand_minstd();
 --compress 2 chunks
-SELECT compress_chunk(ch1.schema_name|| '.' || ch1.table_name)
-FROM _timescaledb_catalog.chunk ch1, _timescaledb_catalog.hypertable ht where ch1.hypertable_id = ht.id
-and ht.table_name like 'test_collation' ORDER BY ch1.id LIMIT 2;
+SELECT compress_chunk(ch) FROM show_chunks('test_collation') ch LIMIT 2;
              compress_chunk              
 -----------------------------------------
  _timescaledb_internal._hyper_9_19_chunk
@@ -906,12 +898,10 @@ WARNING:  column type "timestamp without time zone" used for "timestamp_column" 
 
 ALTER TABLE datatype_test SET (timescaledb.compress);
 INSERT INTO datatype_test VALUES ('2000-01-01',2,4,8,4.0,8.0,'2000-01-01','2001-01-01 12:00','2001-01-01 6:00','1 week', 3.41, 4.2, 'text', 'x');
-SELECT compress_chunk(ch1.schema_name|| '.' || ch1.table_name)
-FROM _timescaledb_catalog.chunk ch1, _timescaledb_catalog.hypertable ht where ch1.hypertable_id = ht.id
-and ht.table_name like 'datatype_test' ORDER BY ch1.id;
-              compress_chunk              
-------------------------------------------
- _timescaledb_internal._hyper_11_31_chunk
+SELECT count(compress_chunk(ch)) FROM show_chunks('datatype_test') ch;
+ count 
+-------
+     1
 (1 row)
 
 SELECT
@@ -995,9 +985,7 @@ SELECT count(*) FROM rescan_test;
 (1 row)
 
 -- compress first chunk
-SELECT compress_chunk(ch1.schema_name|| '.' || ch1.table_name)
-FROM _timescaledb_catalog.chunk ch1, _timescaledb_catalog.hypertable ht where ch1.hypertable_id = ht.id
-and ht.table_name like 'rescan_test' ORDER BY ch1.id LIMIT 1;
+SELECT compress_chunk(ch) FROM show_chunks('rescan_test') ch LIMIT 1;
               compress_chunk              
 ------------------------------------------
  _timescaledb_internal._hyper_16_36_chunk
@@ -1214,17 +1202,11 @@ SELECT table_name FROM create_hypertable ('compressed_ht', 'time');
 ALTER TABLE compressed_ht SET (timescaledb.compress);
 INSERT INTO compressed_ht
   VALUES ('2020-04-20 01:01', 100, 1), ('2020-05-20 01:01', 100, 1);
-SELECT compress_chunk (ch1.schema_name || '.' || ch1.table_name)
-FROM _timescaledb_catalog.chunk ch1,
-  _timescaledb_catalog.hypertable ht
-WHERE ch1.hypertable_id = ht.id
-  AND ht.table_name LIKE 'compressed_ht'
-ORDER BY ch1.id;
-              compress_chunk              
-------------------------------------------
- _timescaledb_internal._hyper_25_51_chunk
- _timescaledb_internal._hyper_25_52_chunk
-(2 rows)
+SELECT count(compress_chunk(ch)) FROM show_chunks('compressed_ht') ch;
+ count 
+-------
+     2
+(1 row)
 
 BEGIN;
 WITH compressed AS (
@@ -1453,10 +1435,7 @@ SELECT create_hypertable('stattest2', 'time', chunk_time_interval=>'1 day'::inte
 ALTER TABLE stattest2 SET (timescaledb.compress, timescaledb.compress_segmentby='c1');
 INSERT INTO stattest2 SELECT '2020/06/20 01:00'::TIMESTAMPTZ ,1 , generate_series(1, 200, 1);
 INSERT INTO stattest2 SELECT '2020/07/20 01:00'::TIMESTAMPTZ ,1 , generate_series(1, 200, 1);
-SELECT  compress_chunk(ch1.schema_name|| '.' || ch1.table_name)
-FROM _timescaledb_catalog.chunk ch1, _timescaledb_catalog.hypertable ht
-WHERE ch1.hypertable_id = ht.id and ht.table_name like 'stattest2'
- ORDER BY ch1.id limit 1;
+SELECT compress_chunk(ch) FROM show_chunks('stattest2') ch LIMIT 1;
               compress_chunk              
 ------------------------------------------
  _timescaledb_internal._hyper_29_58_chunk
@@ -1582,8 +1561,7 @@ SELECT approximate_row_count('approx_count');
 DROP TABLE approx_count;
 --TEST drop_chunks from a compressed hypertable (that has caggs defined).
 -- chunk metadata is still retained. verify correct status for chunk
-SELECT count(*)
-FROM (SELECT compress_chunk(ch) FROM show_chunks('metrics') ch ) q;
+SELECT count(compress_chunk(ch)) FROM show_chunks('metrics') ch;
  count 
 -------
      2
@@ -1621,8 +1599,7 @@ SELECT "time", cnt  FROM cagg_expr ORDER BY time LIMIT 5;
 --now reload data into the dropped chunks region, then compress
 -- then verify chunk status/dropped column
 INSERT INTO metrics SELECT generate_series('2000-01-01'::timestamptz,'2000-01-10','1m'),1,0.25,0.75;
-SELECT count(*)
-FROM (SELECT compress_chunk(ch) FROM show_chunks('metrics') ch) q;
+SELECT count(compress_chunk(ch)) FROM show_chunks('metrics') ch;
  count 
 -------
      2

--- a/tsl/test/expected/compression_ddl.out
+++ b/tsl/test/expected/compression_ddl.out
@@ -40,18 +40,10 @@ NOTICE:  adding not-null constraint to column "Time"
 
 INSERT INTO test1 SELECT t,  gen_rand_minstd(), gen_rand_minstd(), gen_rand_minstd()::text FROM generate_series('2018-03-02 1:00'::TIMESTAMPTZ, '2018-03-28 1:00', '1 hour') t;
 ALTER TABLE test1 set (timescaledb.compress, timescaledb.compress_segmentby = 'b', timescaledb.compress_orderby = '"Time" DESC');
-SELECT COUNT(*) AS count_compressed
-FROM
-(
-SELECT compress_chunk(chunk.schema_name|| '.' || chunk.table_name)
-FROM _timescaledb_catalog.chunk chunk
-INNER JOIN _timescaledb_catalog.hypertable hypertable ON (chunk.hypertable_id = hypertable.id)
-WHERE hypertable.table_name like 'test1' and chunk.compressed_chunk_id IS NULL ORDER BY chunk.id
-)
-AS sub;
- count_compressed 
-------------------
-               27
+SELECT count(compress_chunk(ch)) FROM show_chunks('test1') ch;
+ count 
+-------
+    27
 (1 row)
 
 --make sure allowed ddl still work
@@ -568,18 +560,10 @@ SELECT a.rolname from pg_class c INNER JOIN pg_authid a ON(c.relowner = a.oid) W
 --
 -- turn off compression
 --
-SELECT COUNT(*) AS count_compressed
-FROM
-(
-SELECT decompress_chunk(chunk.schema_name|| '.' || chunk.table_name)
-FROM _timescaledb_catalog.chunk chunk
-INNER JOIN _timescaledb_catalog.hypertable hypertable ON (chunk.hypertable_id = hypertable.id)
-WHERE hypertable.table_name like 'test1' and chunk.compressed_chunk_id IS NOT NULL ORDER BY chunk.id
-)
-AS sub;
- count_compressed 
-------------------
-                1
+SELECT count(decompress_chunk(ch)) FROM show_chunks('test1') ch;
+ count 
+-------
+     1
 (1 row)
 
 select add_compression_policy('test1', interval '1 day');
@@ -638,18 +622,10 @@ ERROR:  permission denied for tablespace "tablespace2" by table owner "default_p
 ALTER TABLESPACE tablespace2 OWNER TO :ROLE_DEFAULT_PERM_USER_2;
 \set ON_ERROR_STOP 1
 ALTER TABLE test1 set (timescaledb.compress, timescaledb.compress_segmentby = 'b', timescaledb.compress_orderby = '"Time" DESC');
-SELECT COUNT(*) AS count_compressed
-FROM
-(
-SELECT compress_chunk(chunk.schema_name|| '.' || chunk.table_name)
-FROM _timescaledb_catalog.chunk chunk
-INNER JOIN _timescaledb_catalog.hypertable hypertable ON (chunk.hypertable_id = hypertable.id)
-WHERE hypertable.table_name like 'test1' and chunk.compressed_chunk_id IS NULL ORDER BY chunk.id
-)
-AS sub;
- count_compressed 
-------------------
-                1
+SELECT count(compress_chunk(ch)) FROM show_chunks('test1') ch;
+ count 
+-------
+     1
 (1 row)
 
 DROP TABLE test1 CASCADE;
@@ -687,26 +663,16 @@ INSERT INTO test1 SELECT '2018-03-02 1:05'::TIMESTAMPTZ, 2;
 NOTICE:   raise notice test1_print_trigger called 
 NOTICE:   raise notice test1_print_trigger called 
 ALTER TABLE test1 set (timescaledb.compress, timescaledb.compress_orderby = '"Time" DESC');
-SELECT COUNT(*) AS count_compressed FROM
-(
-SELECT compress_chunk(chunk.schema_name|| '.' || chunk.table_name)
-FROM _timescaledb_catalog.chunk chunk
-INNER JOIN _timescaledb_catalog.hypertable hypertable ON (chunk.hypertable_id = hypertable.id)
-WHERE hypertable.table_name like 'test1' and chunk.compressed_chunk_id IS NULL ORDER BY chunk.id) AS subq;
- count_compressed 
-------------------
-                2
+SELECT count(compress_chunk(ch)) FROM show_chunks('test1') ch;
+ count 
+-------
+     2
 (1 row)
 
-SELECT COUNT(*) AS count_compressed FROM
-(
-SELECT decompress_chunk(chunk.schema_name|| '.' || chunk.table_name)
-FROM _timescaledb_catalog.chunk chunk
-INNER JOIN _timescaledb_catalog.hypertable hypertable ON (chunk.hypertable_id = hypertable.id)
-WHERE hypertable.table_name like 'test1'  ORDER BY chunk.id ) as subq;
- count_compressed 
-------------------
-                2
+SELECT count(decompress_chunk(ch)) FROM show_chunks('test1') ch;
+ count 
+-------
+     2
 (1 row)
 
 DROP TABLE test1;
@@ -800,18 +766,10 @@ FROM generate_series('2018-03-02 1:00'::TIMESTAMPTZ, '2018-03-05 1:00', '1 hour'
 INSERT INTO test1
 SELECT '2018-03-04 2:00', 100, 200, 'hello' ;
 ALTER TABLE test1 set (timescaledb.compress, timescaledb.compress_segmentby = 'bntcol', timescaledb.compress_orderby = '"Time" DESC');
-SELECT COUNT(*) AS count_compressed
-FROM
-(
-SELECT compress_chunk(chunk.schema_name|| '.' || chunk.table_name)
-FROM _timescaledb_catalog.chunk chunk
-INNER JOIN _timescaledb_catalog.hypertable hypertable ON (chunk.hypertable_id = hypertable.id)
-WHERE hypertable.table_name like 'test1' and chunk.compressed_chunk_id IS NULL ORDER BY chunk.id
-)
-AS sub;
- count_compressed 
-------------------
-                4
+SELECT count(compress_chunk(ch)) FROM show_chunks('test1') ch;
+ count 
+-------
+     4
 (1 row)
 
 -- TEST: ALTER TABLE add column tests --
@@ -842,19 +800,10 @@ SELECT count(*) from test1 where new_colv is null;
 (1 row)
 
 --decompress 1 chunk and query again
-SELECT COUNT(*) AS count_compressed
-FROM
-(
-SELECT decompress_chunk(chunk.schema_name|| '.' || chunk.table_name)
-FROM _timescaledb_catalog.chunk chunk
-INNER JOIN _timescaledb_catalog.hypertable hypertable ON (chunk.hypertable_id = hypertable.id)
-WHERE hypertable.table_name like 'test1' and chunk.compressed_chunk_id IS NOT NULL ORDER BY chunk.id
-LIMIT 1
-)
-AS sub;
- count_compressed 
-------------------
-                1
+SELECT count(decompress_chunk(ch)) FROM show_chunks('test1') ch LIMIT 1;
+ count 
+-------
+     4
 (1 row)
 
 SELECT count(*) from test1 where new_coli is not null;
@@ -885,18 +834,10 @@ SELECT count(*) from test1 where new_colv  = '101t';
     25
 (1 row)
 
-SELECT COUNT(*) AS count_compressed
-FROM
-(
-SELECT compress_chunk(chunk.schema_name|| '.' || chunk.table_name)
-FROM _timescaledb_catalog.chunk chunk
-INNER JOIN _timescaledb_catalog.hypertable hypertable ON (chunk.hypertable_id = hypertable.id)
-WHERE hypertable.table_name like 'test1' and chunk.compressed_chunk_id IS NULL ORDER BY chunk.id
-)
-AS sub;
- count_compressed 
-------------------
-                3
+SELECT count(compress_chunk(ch, true)) FROM show_chunks('test1') ch;
+ count 
+-------
+     6
 (1 row)
 
 SELECT count(*) from test1 where new_coli  = 100;
@@ -960,17 +901,16 @@ SELECT * from test1 WHERE bigintcol = 200;
 
 -- add a new chunk and compress
 INSERT INTO test1 SELECT '2019-03-04 2:00', 99, 800, 'newchunk' ;
-SELECT COUNT(*) AS count_compressed
-FROM
-(
-SELECT compress_chunk(chunk.schema_name|| '.' || chunk.table_name)
-FROM _timescaledb_catalog.chunk chunk
-INNER JOIN _timescaledb_catalog.hypertable hypertable ON (chunk.hypertable_id = hypertable.id)
-WHERE hypertable.table_name = 'test1' and chunk.compressed_chunk_id IS NULL ORDER BY chunk.id
-) q;
- count_compressed 
-------------------
-                1
+SELECT count(compress_chunk(ch, true)) FROM show_chunks('test1') ch;
+psql:include/compression_alter.sql:74: NOTICE:  chunk "_hyper_13_74_chunk" is already compressed
+psql:include/compression_alter.sql:74: NOTICE:  chunk "_hyper_13_75_chunk" is already compressed
+psql:include/compression_alter.sql:74: NOTICE:  chunk "_hyper_13_76_chunk" is already compressed
+psql:include/compression_alter.sql:74: NOTICE:  chunk "_hyper_13_77_chunk" is already compressed
+psql:include/compression_alter.sql:74: NOTICE:  chunk "_hyper_13_82_chunk" is already compressed
+psql:include/compression_alter.sql:74: NOTICE:  chunk "_hyper_13_83_chunk" is already compressed
+ count 
+-------
+     7
 (1 row)
 
 --check if all chunks have new column names
@@ -1012,7 +952,7 @@ FROM ( SELECT attrelid::regclass, attname FROM pg_attribute
 -- check if the name change is reflected for settings
 ALTER TABLE test1 RENAME  bigintcol TO
 ccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccabdeeeeeeccccccccccccc;
-psql:include/compression_alter.sql:135: NOTICE:  identifier "ccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccabdeeeeeeccccccccccccc" will be truncated to "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccca"
+psql:include/compression_alter.sql:103: NOTICE:  identifier "ccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccabdeeeeeeccccccccccccc" will be truncated to "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccca"
 SELECT * from timescaledb_information.compression_settings
 WHERE hypertable_name = 'test1' and attname like 'ccc%';
  hypertable_schema | hypertable_name |                             attname                             | segmentby_column_index | orderby_column_index | orderby_asc | orderby_nullsfirst 
@@ -1033,7 +973,7 @@ FROM ( SELECT attrelid::regclass, attname FROM pg_attribute
 ALTER TABLE test1 RENAME
 ccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccabdeeeeeeccccccccccccc
 TO bigintcol;
-psql:include/compression_alter.sql:148: NOTICE:  identifier "ccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccabdeeeeeeccccccccccccc" will be truncated to "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccca"
+psql:include/compression_alter.sql:116: NOTICE:  identifier "ccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccabdeeeeeeccccccccccccc" will be truncated to "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccca"
 SELECT * from timescaledb_information.compression_settings
 WHERE hypertable_name = 'test1' and attname = 'bigintcol' ;
  hypertable_schema | hypertable_name |  attname  | segmentby_column_index | orderby_column_index | orderby_asc | orderby_nullsfirst 
@@ -1057,7 +997,7 @@ INSERT INTO test_defaults SELECT '2001-01-01', 1;
 SELECT compress_chunk(show_chunks) AS compressed_chunk FROM show_chunks('test_defaults') ORDER BY show_chunks::text LIMIT 1;
              compressed_chunk             
 ------------------------------------------
- _timescaledb_internal._hyper_15_89_chunk
+ _timescaledb_internal._hyper_15_92_chunk
 (1 row)
 
 SELECT * FROM test_defaults ORDER BY 1;
@@ -1106,10 +1046,10 @@ SELECT *,assert_equal(c3,43) FROM test_defaults ORDER BY 1,2;
 (3 rows)
 
 select decompress_chunk(show_chunks('test_defaults'),true);
-psql:include/compression_alter.sql:179: NOTICE:  chunk "_hyper_15_90_chunk" is not compressed
+psql:include/compression_alter.sql:147: NOTICE:  chunk "_hyper_15_93_chunk" is not compressed
              decompress_chunk             
 ------------------------------------------
- _timescaledb_internal._hyper_15_89_chunk
+ _timescaledb_internal._hyper_15_92_chunk
  
 (2 rows)
 
@@ -1124,8 +1064,8 @@ SELECT *,assert_equal(c3,43) FROM test_defaults ORDER BY 1,2;
 select compress_chunk(show_chunks('test_defaults'));
               compress_chunk              
 ------------------------------------------
- _timescaledb_internal._hyper_15_89_chunk
- _timescaledb_internal._hyper_15_90_chunk
+ _timescaledb_internal._hyper_15_92_chunk
+ _timescaledb_internal._hyper_15_93_chunk
 (2 rows)
 
 SELECT *,assert_equal(c3,43) FROM test_defaults ORDER BY 1,2;
@@ -1139,7 +1079,7 @@ SELECT *,assert_equal(c3,43) FROM test_defaults ORDER BY 1,2;
 -- test dropping columns from compressed
 CREATE TABLE test_drop(f1 text, f2 text, f3 text, time timestamptz, device int, o1 text, o2 text);
 SELECT create_hypertable('test_drop','time');
-psql:include/compression_alter.sql:186: NOTICE:  adding not-null constraint to column "time"
+psql:include/compression_alter.sql:154: NOTICE:  adding not-null constraint to column "time"
     create_hypertable    
 -------------------------
  (17,public,test_drop,t)
@@ -1149,13 +1089,13 @@ ALTER TABLE test_drop SET (timescaledb.compress,timescaledb.compress_segmentby='
 -- dropping segmentby or orderby columns will fail
 \set ON_ERROR_STOP 0
 ALTER TABLE test_drop DROP COLUMN time;
-psql:include/compression_alter.sql:191: ERROR:  cannot drop column named in partition key
+psql:include/compression_alter.sql:159: ERROR:  cannot drop column named in partition key
 ALTER TABLE test_drop DROP COLUMN o1;
-psql:include/compression_alter.sql:192: ERROR:  cannot drop orderby or segmentby column from a hypertable with compression enabled
+psql:include/compression_alter.sql:160: ERROR:  cannot drop orderby or segmentby column from a hypertable with compression enabled
 ALTER TABLE test_drop DROP COLUMN o2;
-psql:include/compression_alter.sql:193: ERROR:  cannot drop orderby or segmentby column from a hypertable with compression enabled
+psql:include/compression_alter.sql:161: ERROR:  cannot drop orderby or segmentby column from a hypertable with compression enabled
 ALTER TABLE test_drop DROP COLUMN device;
-psql:include/compression_alter.sql:194: ERROR:  cannot drop orderby or segmentby column from a hypertable with compression enabled
+psql:include/compression_alter.sql:162: ERROR:  cannot drop orderby or segmentby column from a hypertable with compression enabled
 \set ON_ERROR_STOP 1
 -- switch to WARNING only to suppress compress_chunk NOTICEs
 SET client_min_messages TO WARNING;
@@ -1172,7 +1112,7 @@ ALTER TABLE test_drop DROP COLUMN f2;
 -- test non-existant column
 \set ON_ERROR_STOP 0
 ALTER TABLE test_drop DROP COLUMN f10;
-psql:include/compression_alter.sql:208: ERROR:  column "f10" of relation "test_drop" does not exist
+psql:include/compression_alter.sql:176: ERROR:  column "f10" of relation "test_drop" does not exist
 \set ON_ERROR_STOP 1
 ALTER TABLE test_drop DROP COLUMN IF EXISTS f10;
 INSERT INTO test_drop SELECT NULL,'2001-01-01',2,'o1','o2';
@@ -1258,8 +1198,8 @@ WHERE reltablespace in
 -------------------------------------------------------
  _compressed_hypertable_20
  _compressed_hypertable_20_i__ts_meta_sequence_num_idx
- _hyper_19_104_chunk
- _hyper_19_104_chunk_test2_timec_idx
+ _hyper_19_107_chunk
+ _hyper_19_107_chunk_test2_timec_idx
  pg_toast_XXX
  pg_toast_XXX_index
  test2
@@ -1272,7 +1212,7 @@ SELECT decompress_chunk(ch) INTO decompressed_chunks FROM show_chunks('test2') c
 SELECT compress_chunk(ch) FROM show_chunks('test2') ch;
               compress_chunk               
 -------------------------------------------
- _timescaledb_internal._hyper_19_104_chunk
+ _timescaledb_internal._hyper_19_107_chunk
 (1 row)
 
 -- the chunk, compressed chunk + index + toast tables are in tablespace2 now .
@@ -1288,7 +1228,7 @@ WHERE reltablespace in
 (1 row)
 
 DROP TABLE test2 CASCADE;
-NOTICE:  drop cascades to table _timescaledb_internal.compress_hyper_20_106_chunk
+NOTICE:  drop cascades to table _timescaledb_internal.compress_hyper_20_109_chunk
 DROP TABLESPACE tablespace2;
 -- Create a table with a compressed table and then delete the
 -- compressed table and see that the drop of the hypertable does not
@@ -1444,11 +1384,7 @@ ALTER TABLE compression_insert SET (timescaledb.compress, timescaledb.compress_o
 INSERT INTO compression_insert(time,device_id,v0,v1,v2,v3)
 SELECT time, device_id, device_id+1,  device_id + 2, device_id + 0.5, NULL
 FROM generate_series('2000-01-01 0:00:00+0'::timestamptz,'2000-01-03 23:55:00+0','2m') gtime(time), generate_series(1,5,1) gdevice(device_id);
-SELECT compress_chunk(c.schema_name|| '.' || c.table_name) as "CHUNK_NAME"
-FROM _timescaledb_catalog.chunk c, _timescaledb_catalog.hypertable ht
-WHERE c.hypertable_id = ht.id and ht.table_name = 'compression_insert'
-AND c.compressed_chunk_id IS NULL
-ORDER BY c.table_name DESC \gset
+SELECT compress_chunk(ch, true) AS "CHUNK_NAME" FROM show_chunks('compression_insert') ch ORDER BY ch DESC \gset
 INSERT INTO compression_insert(time,device_id,v0,v1,v2,v3)
 SELECT time, device_id, device_id+1,  device_id + 2, device_id + 0.5, NULL
 FROM generate_series('2000-01-04 0:00:00+0'::timestamptz,'2000-01-05 23:55:00+0','2m') gtime(time), generate_series(1,5,1) gdevice(device_id);
@@ -1476,17 +1412,17 @@ ORDER BY device_id;
                                                                   QUERY PLAN                                                                   
 -----------------------------------------------------------------------------------------------------------------------------------------------
  Finalize GroupAggregate
-   Group Key: _hyper_32_107_chunk.device_id
+   Group Key: _hyper_32_110_chunk.device_id
    ->  Sort
-         Sort Key: _hyper_32_107_chunk.device_id
+         Sort Key: _hyper_32_110_chunk.device_id
          ->  Append
                ->  Partial GroupAggregate
-                     Group Key: _hyper_32_107_chunk.device_id
-                     ->  Custom Scan (DecompressChunk) on _hyper_32_107_chunk
-                           ->  Index Scan using compress_hyper_33_108_chunk__compressed_hypertable_33_device_id on compress_hyper_33_108_chunk
+                     Group Key: _hyper_32_110_chunk.device_id
+                     ->  Custom Scan (DecompressChunk) on _hyper_32_110_chunk
+                           ->  Index Scan using compress_hyper_33_111_chunk__compressed_hypertable_33_device_id on compress_hyper_33_111_chunk
                ->  Partial GroupAggregate
-                     Group Key: _hyper_32_107_chunk.device_id
-                     ->  Index Only Scan using _hyper_32_107_chunk_compression_insert_device_id_time_idx on _hyper_32_107_chunk
+                     Group Key: _hyper_32_110_chunk.device_id
+                     ->  Index Only Scan using _hyper_32_110_chunk_compression_insert_device_id_time_idx on _hyper_32_110_chunk
 (12 rows)
 
 SELECT device_id, count(*)
@@ -1531,12 +1467,10 @@ INSERT INTO compression_insert(time,device_id,v0,v1,v2,v3)
 SELECT time, device_id, device_id+1,  device_id + 2, device_id + 0.5, NULL
 FROM generate_series('2000-01-07 0:00:00+0'::timestamptz,'2000-01-09 23:55:00+0','2m') gtime(time), generate_series(1,5,1) gdevice(device_id);
 ALTER TABLE compression_insert DROP COLUMN filler_1;
-SELECT compress_chunk(c.schema_name|| '.' || c.table_name) as "CHUNK_NAME"
-FROM _timescaledb_catalog.chunk c, _timescaledb_catalog.hypertable ht
-WHERE c.hypertable_id = ht.id
-AND ht.table_name = 'compression_insert'
-AND c.compressed_chunk_id IS NULL
-ORDER BY c.table_name DESC \gset
+SELECT compress_chunk(format('%I.%I',chunk_schema,chunk_name)) AS "CHUNK_NAME"
+FROM timescaledb_information.chunks
+WHERE hypertable_name = 'compression_insert' AND NOT is_compressed
+ORDER BY chunk_name DESC \gset
 INSERT INTO compression_insert(time,device_id,v0,v1,v2,v3)
 SELECT time, device_id, device_id+1,  device_id + 2, device_id + 0.5, NULL
 FROM generate_series('2000-01-10 0:00:00+0'::timestamptz,'2000-01-11 23:55:00+0','2m') gtime(time), generate_series(1,5,1) gdevice(device_id);
@@ -1558,21 +1492,21 @@ ORDER BY device_id;
                                                                   QUERY PLAN                                                                   
 -----------------------------------------------------------------------------------------------------------------------------------------------
  Finalize GroupAggregate
-   Group Key: _hyper_32_107_chunk.device_id
+   Group Key: _hyper_32_110_chunk.device_id
    ->  Sort
-         Sort Key: _hyper_32_107_chunk.device_id
+         Sort Key: _hyper_32_110_chunk.device_id
          ->  Append
                ->  Partial GroupAggregate
-                     Group Key: _hyper_32_107_chunk.device_id
-                     ->  Custom Scan (DecompressChunk) on _hyper_32_107_chunk
-                           ->  Index Scan using compress_hyper_33_108_chunk__compressed_hypertable_33_device_id on compress_hyper_33_108_chunk
+                     Group Key: _hyper_32_110_chunk.device_id
+                     ->  Custom Scan (DecompressChunk) on _hyper_32_110_chunk
+                           ->  Index Scan using compress_hyper_33_111_chunk__compressed_hypertable_33_device_id on compress_hyper_33_111_chunk
                ->  Partial GroupAggregate
-                     Group Key: _hyper_32_109_chunk.device_id
-                     ->  Custom Scan (DecompressChunk) on _hyper_32_109_chunk
-                           ->  Index Scan using compress_hyper_33_110_chunk__compressed_hypertable_33_device_id on compress_hyper_33_110_chunk
+                     Group Key: _hyper_32_112_chunk.device_id
+                     ->  Custom Scan (DecompressChunk) on _hyper_32_112_chunk
+                           ->  Index Scan using compress_hyper_33_113_chunk__compressed_hypertable_33_device_id on compress_hyper_33_113_chunk
                ->  Partial GroupAggregate
-                     Group Key: _hyper_32_109_chunk.device_id
-                     ->  Index Only Scan using _hyper_32_109_chunk_compression_insert_device_id_time_idx on _hyper_32_109_chunk
+                     Group Key: _hyper_32_112_chunk.device_id
+                     ->  Index Only Scan using _hyper_32_112_chunk_compression_insert_device_id_time_idx on _hyper_32_112_chunk
 (16 rows)
 
 SELECT device_id, count(*)
@@ -1616,12 +1550,10 @@ SET enable_seqscan = default;
 INSERT INTO compression_insert(time,device_id,v0,v1,v2,v3)
 SELECT time, device_id, device_id+1, device_id + 2, device_id + 0.5, NULL
 FROM generate_series('2000-01-15 0:00:00+0'::timestamptz,'2000-01-17 23:55:00+0','2m') gtime(time), generate_series(1,5,1) gdevice(device_id);
-SELECT compress_chunk(c.schema_name|| '.' || c.table_name) as "CHUNK_NAME"
-FROM _timescaledb_catalog.chunk c, _timescaledb_catalog.hypertable ht
-WHERE c.hypertable_id = ht.id
-AND ht.table_name = 'compression_insert'
-AND c.compressed_chunk_id IS NULL
-ORDER BY c.table_name DESC \gset
+SELECT compress_chunk(format('%I.%I',chunk_schema,chunk_name)) AS "CHUNK_NAME"
+FROM timescaledb_information.chunks
+WHERE hypertable_name = 'compression_insert' AND NOT is_compressed
+ORDER BY chunk_name DESC \gset
 ALTER TABLE compression_insert DROP COLUMN filler_2;
 INSERT INTO compression_insert(time,device_id,v0,v1,v2,v3)
 SELECT time, device_id, device_id+1, device_id + 2, device_id + 0.5, NULL
@@ -1644,25 +1576,25 @@ ORDER BY device_id;
                                                                   QUERY PLAN                                                                   
 -----------------------------------------------------------------------------------------------------------------------------------------------
  Finalize GroupAggregate
-   Group Key: _hyper_32_107_chunk.device_id
+   Group Key: _hyper_32_110_chunk.device_id
    ->  Sort
-         Sort Key: _hyper_32_107_chunk.device_id
+         Sort Key: _hyper_32_110_chunk.device_id
          ->  Append
                ->  Partial GroupAggregate
-                     Group Key: _hyper_32_107_chunk.device_id
-                     ->  Custom Scan (DecompressChunk) on _hyper_32_107_chunk
-                           ->  Index Scan using compress_hyper_33_108_chunk__compressed_hypertable_33_device_id on compress_hyper_33_108_chunk
+                     Group Key: _hyper_32_110_chunk.device_id
+                     ->  Custom Scan (DecompressChunk) on _hyper_32_110_chunk
+                           ->  Index Scan using compress_hyper_33_111_chunk__compressed_hypertable_33_device_id on compress_hyper_33_111_chunk
                ->  Partial GroupAggregate
-                     Group Key: _hyper_32_109_chunk.device_id
-                     ->  Custom Scan (DecompressChunk) on _hyper_32_109_chunk
-                           ->  Index Scan using compress_hyper_33_110_chunk__compressed_hypertable_33_device_id on compress_hyper_33_110_chunk
+                     Group Key: _hyper_32_112_chunk.device_id
+                     ->  Custom Scan (DecompressChunk) on _hyper_32_112_chunk
+                           ->  Index Scan using compress_hyper_33_113_chunk__compressed_hypertable_33_device_id on compress_hyper_33_113_chunk
                ->  Partial GroupAggregate
-                     Group Key: _hyper_32_111_chunk.device_id
-                     ->  Custom Scan (DecompressChunk) on _hyper_32_111_chunk
-                           ->  Index Scan using compress_hyper_33_112_chunk__compressed_hypertable_33_device_id on compress_hyper_33_112_chunk
+                     Group Key: _hyper_32_114_chunk.device_id
+                     ->  Custom Scan (DecompressChunk) on _hyper_32_114_chunk
+                           ->  Index Scan using compress_hyper_33_115_chunk__compressed_hypertable_33_device_id on compress_hyper_33_115_chunk
                ->  Partial GroupAggregate
-                     Group Key: _hyper_32_111_chunk.device_id
-                     ->  Index Only Scan using _hyper_32_111_chunk_compression_insert_device_id_time_idx on _hyper_32_111_chunk
+                     Group Key: _hyper_32_114_chunk.device_id
+                     ->  Index Only Scan using _hyper_32_114_chunk_compression_insert_device_id_time_idx on _hyper_32_114_chunk
 (20 rows)
 
 SELECT device_id, count(*)
@@ -1707,12 +1639,10 @@ INSERT INTO compression_insert(time,device_id,v0,v1,v2,v3)
 SELECT time, device_id, device_id+1, device_id + 2, device_id + 0.5, NULL
 FROM generate_series('2000-01-22 0:00:00+0'::timestamptz,'2000-01-24 23:55:00+0','2m') gtime(time), generate_series(1,5,1) gdevice(device_id);
 ALTER TABLE compression_insert ADD COLUMN filler_4 int;
-SELECT compress_chunk(c.schema_name|| '.' || c.table_name) as "CHUNK_NAME"
-FROM _timescaledb_catalog.chunk c, _timescaledb_catalog.hypertable ht
-WHERE c.hypertable_id = ht.id
-AND ht.table_name = 'compression_insert'
-AND c.compressed_chunk_id IS NULL
-ORDER BY c.table_name DESC \gset
+SELECT compress_chunk(format('%I.%I',chunk_schema,chunk_name)) AS "CHUNK_NAME"
+FROM timescaledb_information.chunks
+WHERE hypertable_name = 'compression_insert' AND NOT is_compressed
+ORDER BY chunk_name DESC \gset
 INSERT INTO compression_insert(time,device_id,v0,v1,v2,v3)
 SELECT time, device_id, device_id+1, device_id + 2, device_id + 0.5, NULL
 FROM generate_series('2000-01-25 0:00:00+0'::timestamptz,'2000-01-26 23:55:00+0','2m') gtime(time), generate_series(1,5,1) gdevice(device_id);
@@ -1734,29 +1664,29 @@ ORDER BY device_id;
                                                                   QUERY PLAN                                                                   
 -----------------------------------------------------------------------------------------------------------------------------------------------
  Finalize GroupAggregate
-   Group Key: _hyper_32_107_chunk.device_id
+   Group Key: _hyper_32_110_chunk.device_id
    ->  Sort
-         Sort Key: _hyper_32_107_chunk.device_id
+         Sort Key: _hyper_32_110_chunk.device_id
          ->  Append
                ->  Partial GroupAggregate
-                     Group Key: _hyper_32_107_chunk.device_id
-                     ->  Custom Scan (DecompressChunk) on _hyper_32_107_chunk
-                           ->  Index Scan using compress_hyper_33_108_chunk__compressed_hypertable_33_device_id on compress_hyper_33_108_chunk
+                     Group Key: _hyper_32_110_chunk.device_id
+                     ->  Custom Scan (DecompressChunk) on _hyper_32_110_chunk
+                           ->  Index Scan using compress_hyper_33_111_chunk__compressed_hypertable_33_device_id on compress_hyper_33_111_chunk
                ->  Partial GroupAggregate
-                     Group Key: _hyper_32_109_chunk.device_id
-                     ->  Custom Scan (DecompressChunk) on _hyper_32_109_chunk
-                           ->  Index Scan using compress_hyper_33_110_chunk__compressed_hypertable_33_device_id on compress_hyper_33_110_chunk
+                     Group Key: _hyper_32_112_chunk.device_id
+                     ->  Custom Scan (DecompressChunk) on _hyper_32_112_chunk
+                           ->  Index Scan using compress_hyper_33_113_chunk__compressed_hypertable_33_device_id on compress_hyper_33_113_chunk
                ->  Partial GroupAggregate
-                     Group Key: _hyper_32_111_chunk.device_id
-                     ->  Custom Scan (DecompressChunk) on _hyper_32_111_chunk
-                           ->  Index Scan using compress_hyper_33_112_chunk__compressed_hypertable_33_device_id on compress_hyper_33_112_chunk
+                     Group Key: _hyper_32_114_chunk.device_id
+                     ->  Custom Scan (DecompressChunk) on _hyper_32_114_chunk
+                           ->  Index Scan using compress_hyper_33_115_chunk__compressed_hypertable_33_device_id on compress_hyper_33_115_chunk
                ->  Partial GroupAggregate
-                     Group Key: _hyper_32_113_chunk.device_id
-                     ->  Custom Scan (DecompressChunk) on _hyper_32_113_chunk
-                           ->  Index Scan using compress_hyper_33_114_chunk__compressed_hypertable_33_device_id on compress_hyper_33_114_chunk
+                     Group Key: _hyper_32_116_chunk.device_id
+                     ->  Custom Scan (DecompressChunk) on _hyper_32_116_chunk
+                           ->  Index Scan using compress_hyper_33_117_chunk__compressed_hypertable_33_device_id on compress_hyper_33_117_chunk
                ->  Partial GroupAggregate
-                     Group Key: _hyper_32_113_chunk.device_id
-                     ->  Index Only Scan using _hyper_32_113_chunk_compression_insert_device_id_time_idx on _hyper_32_113_chunk
+                     Group Key: _hyper_32_116_chunk.device_id
+                     ->  Index Only Scan using _hyper_32_116_chunk_compression_insert_device_id_time_idx on _hyper_32_116_chunk
 (24 rows)
 
 SELECT device_id, count(*)
@@ -1800,12 +1730,10 @@ SET enable_seqscan = default;
 INSERT INTO compression_insert(time,device_id,v0,v1,v2,v3)
 SELECT time, device_id, device_id+1, device_id + 2, device_id + 0.5, NULL
 FROM generate_series('2000-01-28 0:00:00+0'::timestamptz,'2000-01-30 23:55:00+0','2m') gtime(time), generate_series(1,5,1) gdevice(device_id);
-SELECT compress_chunk(c.schema_name|| '.' || c.table_name) as "CHUNK_NAME"
-FROM _timescaledb_catalog.chunk c, _timescaledb_catalog.hypertable ht
-WHERE c.hypertable_id = ht.id
-AND ht.table_name = 'compression_insert'
-AND c.compressed_chunk_id IS NULL
-ORDER BY c.table_name DESC \gset
+SELECT compress_chunk(format('%I.%I',chunk_schema,chunk_name)) AS "CHUNK_NAME"
+FROM timescaledb_information.chunks
+WHERE hypertable_name = 'compression_insert' AND NOT is_compressed
+ORDER BY chunk_name DESC \gset
 ALTER TABLE compression_insert ADD COLUMN filler_5 int;
 INSERT INTO compression_insert(time,device_id,v0,v1,v2,v3)
 SELECT time, device_id, device_id+1, device_id + 2, device_id + 0.5, NULL
@@ -1828,33 +1756,33 @@ ORDER BY device_id;
                                                                   QUERY PLAN                                                                   
 -----------------------------------------------------------------------------------------------------------------------------------------------
  Finalize GroupAggregate
-   Group Key: _hyper_32_107_chunk.device_id
+   Group Key: _hyper_32_110_chunk.device_id
    ->  Sort
-         Sort Key: _hyper_32_107_chunk.device_id
+         Sort Key: _hyper_32_110_chunk.device_id
          ->  Append
                ->  Partial GroupAggregate
-                     Group Key: _hyper_32_107_chunk.device_id
-                     ->  Custom Scan (DecompressChunk) on _hyper_32_107_chunk
-                           ->  Index Scan using compress_hyper_33_108_chunk__compressed_hypertable_33_device_id on compress_hyper_33_108_chunk
+                     Group Key: _hyper_32_110_chunk.device_id
+                     ->  Custom Scan (DecompressChunk) on _hyper_32_110_chunk
+                           ->  Index Scan using compress_hyper_33_111_chunk__compressed_hypertable_33_device_id on compress_hyper_33_111_chunk
                ->  Partial GroupAggregate
-                     Group Key: _hyper_32_109_chunk.device_id
-                     ->  Custom Scan (DecompressChunk) on _hyper_32_109_chunk
-                           ->  Index Scan using compress_hyper_33_110_chunk__compressed_hypertable_33_device_id on compress_hyper_33_110_chunk
+                     Group Key: _hyper_32_112_chunk.device_id
+                     ->  Custom Scan (DecompressChunk) on _hyper_32_112_chunk
+                           ->  Index Scan using compress_hyper_33_113_chunk__compressed_hypertable_33_device_id on compress_hyper_33_113_chunk
                ->  Partial GroupAggregate
-                     Group Key: _hyper_32_111_chunk.device_id
-                     ->  Custom Scan (DecompressChunk) on _hyper_32_111_chunk
-                           ->  Index Scan using compress_hyper_33_112_chunk__compressed_hypertable_33_device_id on compress_hyper_33_112_chunk
+                     Group Key: _hyper_32_114_chunk.device_id
+                     ->  Custom Scan (DecompressChunk) on _hyper_32_114_chunk
+                           ->  Index Scan using compress_hyper_33_115_chunk__compressed_hypertable_33_device_id on compress_hyper_33_115_chunk
                ->  Partial GroupAggregate
-                     Group Key: _hyper_32_113_chunk.device_id
-                     ->  Custom Scan (DecompressChunk) on _hyper_32_113_chunk
-                           ->  Index Scan using compress_hyper_33_114_chunk__compressed_hypertable_33_device_id on compress_hyper_33_114_chunk
+                     Group Key: _hyper_32_116_chunk.device_id
+                     ->  Custom Scan (DecompressChunk) on _hyper_32_116_chunk
+                           ->  Index Scan using compress_hyper_33_117_chunk__compressed_hypertable_33_device_id on compress_hyper_33_117_chunk
                ->  Partial GroupAggregate
-                     Group Key: _hyper_32_115_chunk.device_id
-                     ->  Custom Scan (DecompressChunk) on _hyper_32_115_chunk
-                           ->  Index Scan using compress_hyper_33_116_chunk__compressed_hypertable_33_device_id on compress_hyper_33_116_chunk
+                     Group Key: _hyper_32_118_chunk.device_id
+                     ->  Custom Scan (DecompressChunk) on _hyper_32_118_chunk
+                           ->  Index Scan using compress_hyper_33_119_chunk__compressed_hypertable_33_device_id on compress_hyper_33_119_chunk
                ->  Partial GroupAggregate
-                     Group Key: _hyper_32_115_chunk.device_id
-                     ->  Index Only Scan using _hyper_32_115_chunk_compression_insert_device_id_time_idx on _hyper_32_115_chunk
+                     Group Key: _hyper_32_118_chunk.device_id
+                     ->  Index Only Scan using _hyper_32_118_chunk_compression_insert_device_id_time_idx on _hyper_32_118_chunk
 (28 rows)
 
 SELECT device_id, count(*)
@@ -1920,9 +1848,9 @@ ALTER TABLE test_partials SET (timescaledb.compress);
 SELECT compress_chunk(show_chunks('test_partials'));
               compress_chunk               
 -------------------------------------------
- _timescaledb_internal._hyper_34_117_chunk
- _timescaledb_internal._hyper_34_118_chunk
- _timescaledb_internal._hyper_34_119_chunk
+ _timescaledb_internal._hyper_34_120_chunk
+ _timescaledb_internal._hyper_34_121_chunk
+ _timescaledb_internal._hyper_34_122_chunk
 (3 rows)
 
 -- fully compressed
@@ -1931,18 +1859,18 @@ EXPLAIN (costs off) SELECT * FROM test_partials ORDER BY time;
 --------------------------------------------------------------------------------
  Custom Scan (ChunkAppend) on test_partials
    Order: test_partials."time"
-   ->  Custom Scan (DecompressChunk) on _hyper_34_117_chunk
+   ->  Custom Scan (DecompressChunk) on _hyper_34_120_chunk
          ->  Sort
-               Sort Key: compress_hyper_35_120_chunk._ts_meta_sequence_num DESC
-               ->  Seq Scan on compress_hyper_35_120_chunk
-   ->  Custom Scan (DecompressChunk) on _hyper_34_118_chunk
+               Sort Key: compress_hyper_35_123_chunk._ts_meta_sequence_num DESC
+               ->  Seq Scan on compress_hyper_35_123_chunk
+   ->  Custom Scan (DecompressChunk) on _hyper_34_121_chunk
          ->  Sort
-               Sort Key: compress_hyper_35_121_chunk._ts_meta_sequence_num DESC
-               ->  Seq Scan on compress_hyper_35_121_chunk
-   ->  Custom Scan (DecompressChunk) on _hyper_34_119_chunk
+               Sort Key: compress_hyper_35_124_chunk._ts_meta_sequence_num DESC
+               ->  Seq Scan on compress_hyper_35_124_chunk
+   ->  Custom Scan (DecompressChunk) on _hyper_34_122_chunk
          ->  Sort
-               Sort Key: compress_hyper_35_122_chunk._ts_meta_sequence_num DESC
-               ->  Seq Scan on compress_hyper_35_122_chunk
+               Sort Key: compress_hyper_35_125_chunk._ts_meta_sequence_num DESC
+               ->  Seq Scan on compress_hyper_35_125_chunk
 (14 rows)
 
 -- test P, F, F
@@ -1953,22 +1881,22 @@ EXPLAIN (costs off) SELECT * FROM test_partials ORDER BY time;
  Custom Scan (ChunkAppend) on test_partials
    Order: test_partials."time"
    ->  Merge Append
-         Sort Key: _hyper_34_117_chunk."time"
-         ->  Custom Scan (DecompressChunk) on _hyper_34_117_chunk
+         Sort Key: _hyper_34_120_chunk."time"
+         ->  Custom Scan (DecompressChunk) on _hyper_34_120_chunk
                ->  Sort
-                     Sort Key: compress_hyper_35_120_chunk._ts_meta_sequence_num DESC
-                     ->  Seq Scan on compress_hyper_35_120_chunk
+                     Sort Key: compress_hyper_35_123_chunk._ts_meta_sequence_num DESC
+                     ->  Seq Scan on compress_hyper_35_123_chunk
          ->  Sort
-               Sort Key: _hyper_34_117_chunk."time"
-               ->  Seq Scan on _hyper_34_117_chunk
-   ->  Custom Scan (DecompressChunk) on _hyper_34_118_chunk
+               Sort Key: _hyper_34_120_chunk."time"
+               ->  Seq Scan on _hyper_34_120_chunk
+   ->  Custom Scan (DecompressChunk) on _hyper_34_121_chunk
          ->  Sort
-               Sort Key: compress_hyper_35_121_chunk._ts_meta_sequence_num DESC
-               ->  Seq Scan on compress_hyper_35_121_chunk
-   ->  Custom Scan (DecompressChunk) on _hyper_34_119_chunk
+               Sort Key: compress_hyper_35_124_chunk._ts_meta_sequence_num DESC
+               ->  Seq Scan on compress_hyper_35_124_chunk
+   ->  Custom Scan (DecompressChunk) on _hyper_34_122_chunk
          ->  Sort
-               Sort Key: compress_hyper_35_122_chunk._ts_meta_sequence_num DESC
-               ->  Seq Scan on compress_hyper_35_122_chunk
+               Sort Key: compress_hyper_35_125_chunk._ts_meta_sequence_num DESC
+               ->  Seq Scan on compress_hyper_35_125_chunk
 (19 rows)
 
 -- verify correct results
@@ -1994,27 +1922,27 @@ EXPLAIN (costs off) SELECT * FROM test_partials ORDER BY time;
  Custom Scan (ChunkAppend) on test_partials
    Order: test_partials."time"
    ->  Merge Append
-         Sort Key: _hyper_34_117_chunk."time"
-         ->  Custom Scan (DecompressChunk) on _hyper_34_117_chunk
+         Sort Key: _hyper_34_120_chunk."time"
+         ->  Custom Scan (DecompressChunk) on _hyper_34_120_chunk
                ->  Sort
-                     Sort Key: compress_hyper_35_120_chunk._ts_meta_sequence_num DESC
-                     ->  Seq Scan on compress_hyper_35_120_chunk
+                     Sort Key: compress_hyper_35_123_chunk._ts_meta_sequence_num DESC
+                     ->  Seq Scan on compress_hyper_35_123_chunk
          ->  Sort
-               Sort Key: _hyper_34_117_chunk."time"
-               ->  Seq Scan on _hyper_34_117_chunk
+               Sort Key: _hyper_34_120_chunk."time"
+               ->  Seq Scan on _hyper_34_120_chunk
    ->  Merge Append
-         Sort Key: _hyper_34_118_chunk."time"
-         ->  Custom Scan (DecompressChunk) on _hyper_34_118_chunk
+         Sort Key: _hyper_34_121_chunk."time"
+         ->  Custom Scan (DecompressChunk) on _hyper_34_121_chunk
                ->  Sort
-                     Sort Key: compress_hyper_35_121_chunk._ts_meta_sequence_num DESC
-                     ->  Seq Scan on compress_hyper_35_121_chunk
+                     Sort Key: compress_hyper_35_124_chunk._ts_meta_sequence_num DESC
+                     ->  Seq Scan on compress_hyper_35_124_chunk
          ->  Sort
-               Sort Key: _hyper_34_118_chunk."time"
-               ->  Seq Scan on _hyper_34_118_chunk
-   ->  Custom Scan (DecompressChunk) on _hyper_34_119_chunk
+               Sort Key: _hyper_34_121_chunk."time"
+               ->  Seq Scan on _hyper_34_121_chunk
+   ->  Custom Scan (DecompressChunk) on _hyper_34_122_chunk
          ->  Sort
-               Sort Key: compress_hyper_35_122_chunk._ts_meta_sequence_num DESC
-               ->  Seq Scan on compress_hyper_35_122_chunk
+               Sort Key: compress_hyper_35_125_chunk._ts_meta_sequence_num DESC
+               ->  Seq Scan on compress_hyper_35_125_chunk
 (24 rows)
 
 -- verify correct results
@@ -2042,33 +1970,33 @@ EXPLAIN (costs off) SELECT * FROM test_partials ORDER BY time;
  Custom Scan (ChunkAppend) on test_partials
    Order: test_partials."time"
    ->  Merge Append
-         Sort Key: _hyper_34_117_chunk."time"
-         ->  Custom Scan (DecompressChunk) on _hyper_34_117_chunk
+         Sort Key: _hyper_34_120_chunk."time"
+         ->  Custom Scan (DecompressChunk) on _hyper_34_120_chunk
                ->  Sort
-                     Sort Key: compress_hyper_35_120_chunk._ts_meta_sequence_num DESC
-                     ->  Seq Scan on compress_hyper_35_120_chunk
+                     Sort Key: compress_hyper_35_123_chunk._ts_meta_sequence_num DESC
+                     ->  Seq Scan on compress_hyper_35_123_chunk
          ->  Sort
-               Sort Key: _hyper_34_117_chunk."time"
-               ->  Seq Scan on _hyper_34_117_chunk
+               Sort Key: _hyper_34_120_chunk."time"
+               ->  Seq Scan on _hyper_34_120_chunk
    ->  Merge Append
-         Sort Key: _hyper_34_118_chunk."time"
-         ->  Custom Scan (DecompressChunk) on _hyper_34_118_chunk
+         Sort Key: _hyper_34_121_chunk."time"
+         ->  Custom Scan (DecompressChunk) on _hyper_34_121_chunk
                ->  Sort
-                     Sort Key: compress_hyper_35_121_chunk._ts_meta_sequence_num DESC
-                     ->  Seq Scan on compress_hyper_35_121_chunk
+                     Sort Key: compress_hyper_35_124_chunk._ts_meta_sequence_num DESC
+                     ->  Seq Scan on compress_hyper_35_124_chunk
          ->  Sort
-               Sort Key: _hyper_34_118_chunk."time"
-               ->  Seq Scan on _hyper_34_118_chunk
+               Sort Key: _hyper_34_121_chunk."time"
+               ->  Seq Scan on _hyper_34_121_chunk
    ->  Merge Append
-         Sort Key: _hyper_34_119_chunk."time"
-         ->  Custom Scan (DecompressChunk) on _hyper_34_119_chunk
+         Sort Key: _hyper_34_122_chunk."time"
+         ->  Custom Scan (DecompressChunk) on _hyper_34_122_chunk
                ->  Sort
-                     Sort Key: compress_hyper_35_122_chunk._ts_meta_sequence_num DESC
-                     ->  Seq Scan on compress_hyper_35_122_chunk
+                     Sort Key: compress_hyper_35_125_chunk._ts_meta_sequence_num DESC
+                     ->  Seq Scan on compress_hyper_35_125_chunk
          ->  Sort
-               Sort Key: _hyper_34_119_chunk."time"
-               ->  Seq Scan on _hyper_34_119_chunk
-   ->  Index Scan Backward using _hyper_34_123_chunk_test_partials_time_idx on _hyper_34_123_chunk
+               Sort Key: _hyper_34_122_chunk."time"
+               ->  Seq Scan on _hyper_34_122_chunk
+   ->  Index Scan Backward using _hyper_34_126_chunk_test_partials_time_idx on _hyper_34_126_chunk
 (30 rows)
 
 -- F, F, P, U
@@ -2092,24 +2020,24 @@ EXPLAIN (COSTS OFF) SELECT * FROM test_partials ORDER BY time;
 ---------------------------------------------------------------------------------------------------
  Custom Scan (ChunkAppend) on test_partials
    Order: test_partials."time"
-   ->  Custom Scan (DecompressChunk) on _hyper_34_117_chunk
+   ->  Custom Scan (DecompressChunk) on _hyper_34_120_chunk
          ->  Sort
-               Sort Key: compress_hyper_35_124_chunk._ts_meta_sequence_num DESC
-               ->  Seq Scan on compress_hyper_35_124_chunk
-   ->  Custom Scan (DecompressChunk) on _hyper_34_118_chunk
+               Sort Key: compress_hyper_35_127_chunk._ts_meta_sequence_num DESC
+               ->  Seq Scan on compress_hyper_35_127_chunk
+   ->  Custom Scan (DecompressChunk) on _hyper_34_121_chunk
          ->  Sort
-               Sort Key: compress_hyper_35_125_chunk._ts_meta_sequence_num DESC
-               ->  Seq Scan on compress_hyper_35_125_chunk
+               Sort Key: compress_hyper_35_128_chunk._ts_meta_sequence_num DESC
+               ->  Seq Scan on compress_hyper_35_128_chunk
    ->  Merge Append
-         Sort Key: _hyper_34_119_chunk."time"
-         ->  Custom Scan (DecompressChunk) on _hyper_34_119_chunk
+         Sort Key: _hyper_34_122_chunk."time"
+         ->  Custom Scan (DecompressChunk) on _hyper_34_122_chunk
                ->  Sort
-                     Sort Key: compress_hyper_35_126_chunk._ts_meta_sequence_num DESC
-                     ->  Seq Scan on compress_hyper_35_126_chunk
+                     Sort Key: compress_hyper_35_129_chunk._ts_meta_sequence_num DESC
+                     ->  Seq Scan on compress_hyper_35_129_chunk
          ->  Sort
-               Sort Key: _hyper_34_119_chunk."time"
-               ->  Seq Scan on _hyper_34_119_chunk
-   ->  Index Scan Backward using _hyper_34_123_chunk_test_partials_time_idx on _hyper_34_123_chunk
+               Sort Key: _hyper_34_122_chunk."time"
+               ->  Seq Scan on _hyper_34_122_chunk
+   ->  Index Scan Backward using _hyper_34_126_chunk_test_partials_time_idx on _hyper_34_126_chunk
 (20 rows)
 
 -- F, F, P, F, F
@@ -2117,8 +2045,8 @@ INSERT INTO test_partials VALUES ('2024-01-01 00:02', 1, 2);
 SELECT compress_chunk(c) FROM show_chunks('test_partials', newer_than => '2022-01-01') c;
               compress_chunk               
 -------------------------------------------
- _timescaledb_internal._hyper_34_123_chunk
- _timescaledb_internal._hyper_34_127_chunk
+ _timescaledb_internal._hyper_34_126_chunk
+ _timescaledb_internal._hyper_34_130_chunk
 (2 rows)
 
 EXPLAIN (costs off) SELECT * FROM test_partials ORDER BY time;
@@ -2126,31 +2054,31 @@ EXPLAIN (costs off) SELECT * FROM test_partials ORDER BY time;
 --------------------------------------------------------------------------------------
  Custom Scan (ChunkAppend) on test_partials
    Order: test_partials."time"
-   ->  Custom Scan (DecompressChunk) on _hyper_34_117_chunk
+   ->  Custom Scan (DecompressChunk) on _hyper_34_120_chunk
          ->  Sort
-               Sort Key: compress_hyper_35_124_chunk._ts_meta_sequence_num DESC
-               ->  Seq Scan on compress_hyper_35_124_chunk
-   ->  Custom Scan (DecompressChunk) on _hyper_34_118_chunk
-         ->  Sort
-               Sort Key: compress_hyper_35_125_chunk._ts_meta_sequence_num DESC
-               ->  Seq Scan on compress_hyper_35_125_chunk
-   ->  Merge Append
-         Sort Key: _hyper_34_119_chunk."time"
-         ->  Custom Scan (DecompressChunk) on _hyper_34_119_chunk
-               ->  Sort
-                     Sort Key: compress_hyper_35_126_chunk._ts_meta_sequence_num DESC
-                     ->  Seq Scan on compress_hyper_35_126_chunk
-         ->  Sort
-               Sort Key: _hyper_34_119_chunk."time"
-               ->  Seq Scan on _hyper_34_119_chunk
-   ->  Custom Scan (DecompressChunk) on _hyper_34_123_chunk
+               Sort Key: compress_hyper_35_127_chunk._ts_meta_sequence_num DESC
+               ->  Seq Scan on compress_hyper_35_127_chunk
+   ->  Custom Scan (DecompressChunk) on _hyper_34_121_chunk
          ->  Sort
                Sort Key: compress_hyper_35_128_chunk._ts_meta_sequence_num DESC
                ->  Seq Scan on compress_hyper_35_128_chunk
-   ->  Custom Scan (DecompressChunk) on _hyper_34_127_chunk
+   ->  Merge Append
+         Sort Key: _hyper_34_122_chunk."time"
+         ->  Custom Scan (DecompressChunk) on _hyper_34_122_chunk
+               ->  Sort
+                     Sort Key: compress_hyper_35_129_chunk._ts_meta_sequence_num DESC
+                     ->  Seq Scan on compress_hyper_35_129_chunk
          ->  Sort
-               Sort Key: compress_hyper_35_129_chunk._ts_meta_sequence_num DESC
-               ->  Seq Scan on compress_hyper_35_129_chunk
+               Sort Key: _hyper_34_122_chunk."time"
+               ->  Seq Scan on _hyper_34_122_chunk
+   ->  Custom Scan (DecompressChunk) on _hyper_34_126_chunk
+         ->  Sort
+               Sort Key: compress_hyper_35_131_chunk._ts_meta_sequence_num DESC
+               ->  Seq Scan on compress_hyper_35_131_chunk
+   ->  Custom Scan (DecompressChunk) on _hyper_34_130_chunk
+         ->  Sort
+               Sort Key: compress_hyper_35_132_chunk._ts_meta_sequence_num DESC
+               ->  Seq Scan on compress_hyper_35_132_chunk
 (27 rows)
 
 -- verify result correctness
@@ -2198,8 +2126,8 @@ ALTER TABLE space_part SET (timescaledb.compress);
 SELECT compress_chunk(show_chunks('space_part'));
               compress_chunk               
 -------------------------------------------
- _timescaledb_internal._hyper_36_130_chunk
- _timescaledb_internal._hyper_36_131_chunk
+ _timescaledb_internal._hyper_36_133_chunk
+ _timescaledb_internal._hyper_36_134_chunk
 (2 rows)
 
 -- make first chunk partial
@@ -2221,18 +2149,18 @@ EXPLAIN (COSTS OFF) SELECT * FROM space_part ORDER BY time;
  Custom Scan (ChunkAppend) on space_part
    Order: space_part."time"
    ->  Merge Append
-         Sort Key: _hyper_36_130_chunk."time"
-         ->  Custom Scan (DecompressChunk) on _hyper_36_130_chunk
+         Sort Key: _hyper_36_133_chunk."time"
+         ->  Custom Scan (DecompressChunk) on _hyper_36_133_chunk
                ->  Sort
-                     Sort Key: compress_hyper_37_132_chunk._ts_meta_sequence_num DESC
-                     ->  Seq Scan on compress_hyper_37_132_chunk
+                     Sort Key: compress_hyper_37_135_chunk._ts_meta_sequence_num DESC
+                     ->  Seq Scan on compress_hyper_37_135_chunk
          ->  Sort
-               Sort Key: _hyper_36_130_chunk."time"
-               ->  Seq Scan on _hyper_36_130_chunk
-   ->  Custom Scan (DecompressChunk) on _hyper_36_131_chunk
+               Sort Key: _hyper_36_133_chunk."time"
+               ->  Seq Scan on _hyper_36_133_chunk
+   ->  Custom Scan (DecompressChunk) on _hyper_36_134_chunk
          ->  Sort
-               Sort Key: compress_hyper_37_133_chunk._ts_meta_sequence_num DESC
-               ->  Seq Scan on compress_hyper_37_133_chunk
+               Sort Key: compress_hyper_37_136_chunk._ts_meta_sequence_num DESC
+               ->  Seq Scan on compress_hyper_37_136_chunk
 (15 rows)
 
 -- now add more chunks that do adhere to the new space partitioning
@@ -2249,34 +2177,34 @@ EXPLAIN (COSTS OFF) SELECT * FROM space_part ORDER BY time;
  Custom Scan (ChunkAppend) on space_part
    Order: space_part."time"
    ->  Merge Append
-         Sort Key: _hyper_36_130_chunk."time"
-         ->  Custom Scan (DecompressChunk) on _hyper_36_130_chunk
+         Sort Key: _hyper_36_133_chunk."time"
+         ->  Custom Scan (DecompressChunk) on _hyper_36_133_chunk
                ->  Sort
-                     Sort Key: compress_hyper_37_132_chunk._ts_meta_sequence_num DESC
-                     ->  Seq Scan on compress_hyper_37_132_chunk
+                     Sort Key: compress_hyper_37_135_chunk._ts_meta_sequence_num DESC
+                     ->  Seq Scan on compress_hyper_37_135_chunk
          ->  Sort
-               Sort Key: _hyper_36_130_chunk."time"
-               ->  Seq Scan on _hyper_36_130_chunk
-   ->  Custom Scan (DecompressChunk) on _hyper_36_131_chunk
+               Sort Key: _hyper_36_133_chunk."time"
+               ->  Seq Scan on _hyper_36_133_chunk
+   ->  Custom Scan (DecompressChunk) on _hyper_36_134_chunk
          ->  Sort
-               Sort Key: compress_hyper_37_133_chunk._ts_meta_sequence_num DESC
-               ->  Seq Scan on compress_hyper_37_133_chunk
+               Sort Key: compress_hyper_37_136_chunk._ts_meta_sequence_num DESC
+               ->  Seq Scan on compress_hyper_37_136_chunk
    ->  Merge Append
-         Sort Key: _hyper_36_134_chunk."time"
-         ->  Index Scan Backward using _hyper_36_134_chunk_space_part_time_idx on _hyper_36_134_chunk
-         ->  Index Scan Backward using _hyper_36_135_chunk_space_part_time_idx on _hyper_36_135_chunk
+         Sort Key: _hyper_36_137_chunk."time"
+         ->  Index Scan Backward using _hyper_36_137_chunk_space_part_time_idx on _hyper_36_137_chunk
+         ->  Index Scan Backward using _hyper_36_138_chunk_space_part_time_idx on _hyper_36_138_chunk
 (19 rows)
 
 -- compress them
 SELECT compress_chunk(c, if_not_compressed=>true) FROM show_chunks('space_part') c;
-NOTICE:  chunk "_hyper_36_130_chunk" is already compressed
-NOTICE:  chunk "_hyper_36_131_chunk" is already compressed
+NOTICE:  chunk "_hyper_36_133_chunk" is already compressed
+NOTICE:  chunk "_hyper_36_134_chunk" is already compressed
               compress_chunk               
 -------------------------------------------
- _timescaledb_internal._hyper_36_130_chunk
- _timescaledb_internal._hyper_36_131_chunk
+ _timescaledb_internal._hyper_36_133_chunk
  _timescaledb_internal._hyper_36_134_chunk
- _timescaledb_internal._hyper_36_135_chunk
+ _timescaledb_internal._hyper_36_137_chunk
+ _timescaledb_internal._hyper_36_138_chunk
 (4 rows)
 
 -- plan still ok
@@ -2286,28 +2214,28 @@ EXPLAIN (COSTS OFF) SELECT * FROM space_part ORDER BY time;
  Custom Scan (ChunkAppend) on space_part
    Order: space_part."time"
    ->  Merge Append
-         Sort Key: _hyper_36_130_chunk."time"
-         ->  Custom Scan (DecompressChunk) on _hyper_36_130_chunk
+         Sort Key: _hyper_36_133_chunk."time"
+         ->  Custom Scan (DecompressChunk) on _hyper_36_133_chunk
                ->  Sort
-                     Sort Key: compress_hyper_37_132_chunk._ts_meta_sequence_num DESC
-                     ->  Seq Scan on compress_hyper_37_132_chunk
+                     Sort Key: compress_hyper_37_135_chunk._ts_meta_sequence_num DESC
+                     ->  Seq Scan on compress_hyper_37_135_chunk
          ->  Sort
-               Sort Key: _hyper_36_130_chunk."time"
-               ->  Seq Scan on _hyper_36_130_chunk
-   ->  Custom Scan (DecompressChunk) on _hyper_36_131_chunk
+               Sort Key: _hyper_36_133_chunk."time"
+               ->  Seq Scan on _hyper_36_133_chunk
+   ->  Custom Scan (DecompressChunk) on _hyper_36_134_chunk
          ->  Sort
-               Sort Key: compress_hyper_37_133_chunk._ts_meta_sequence_num DESC
-               ->  Seq Scan on compress_hyper_37_133_chunk
+               Sort Key: compress_hyper_37_136_chunk._ts_meta_sequence_num DESC
+               ->  Seq Scan on compress_hyper_37_136_chunk
    ->  Merge Append
-         Sort Key: _hyper_36_134_chunk."time"
-         ->  Custom Scan (DecompressChunk) on _hyper_36_134_chunk
+         Sort Key: _hyper_36_137_chunk."time"
+         ->  Custom Scan (DecompressChunk) on _hyper_36_137_chunk
                ->  Sort
-                     Sort Key: compress_hyper_37_136_chunk._ts_meta_sequence_num DESC
-                     ->  Seq Scan on compress_hyper_37_136_chunk
-         ->  Custom Scan (DecompressChunk) on _hyper_36_135_chunk
+                     Sort Key: compress_hyper_37_139_chunk._ts_meta_sequence_num DESC
+                     ->  Seq Scan on compress_hyper_37_139_chunk
+         ->  Custom Scan (DecompressChunk) on _hyper_36_138_chunk
                ->  Sort
-                     Sort Key: compress_hyper_37_137_chunk._ts_meta_sequence_num DESC
-                     ->  Seq Scan on compress_hyper_37_137_chunk
+                     Sort Key: compress_hyper_37_140_chunk._ts_meta_sequence_num DESC
+                     ->  Seq Scan on compress_hyper_37_140_chunk
 (25 rows)
 
 -- make second one of them partial
@@ -2320,33 +2248,33 @@ EXPLAIN (COSTS OFF) SELECT * FROM space_part ORDER BY time;
  Custom Scan (ChunkAppend) on space_part
    Order: space_part."time"
    ->  Merge Append
-         Sort Key: _hyper_36_130_chunk."time"
-         ->  Custom Scan (DecompressChunk) on _hyper_36_130_chunk
+         Sort Key: _hyper_36_133_chunk."time"
+         ->  Custom Scan (DecompressChunk) on _hyper_36_133_chunk
                ->  Sort
-                     Sort Key: compress_hyper_37_132_chunk._ts_meta_sequence_num DESC
-                     ->  Seq Scan on compress_hyper_37_132_chunk
+                     Sort Key: compress_hyper_37_135_chunk._ts_meta_sequence_num DESC
+                     ->  Seq Scan on compress_hyper_37_135_chunk
          ->  Sort
-               Sort Key: _hyper_36_130_chunk."time"
-               ->  Seq Scan on _hyper_36_130_chunk
-   ->  Custom Scan (DecompressChunk) on _hyper_36_131_chunk
+               Sort Key: _hyper_36_133_chunk."time"
+               ->  Seq Scan on _hyper_36_133_chunk
+   ->  Custom Scan (DecompressChunk) on _hyper_36_134_chunk
          ->  Sort
-               Sort Key: compress_hyper_37_133_chunk._ts_meta_sequence_num DESC
-               ->  Seq Scan on compress_hyper_37_133_chunk
+               Sort Key: compress_hyper_37_136_chunk._ts_meta_sequence_num DESC
+               ->  Seq Scan on compress_hyper_37_136_chunk
    ->  Merge Append
-         Sort Key: _hyper_36_134_chunk."time"
-         ->  Custom Scan (DecompressChunk) on _hyper_36_134_chunk
+         Sort Key: _hyper_36_137_chunk."time"
+         ->  Custom Scan (DecompressChunk) on _hyper_36_137_chunk
                ->  Sort
-                     Sort Key: compress_hyper_37_136_chunk._ts_meta_sequence_num DESC
-                     ->  Seq Scan on compress_hyper_37_136_chunk
-         ->  Custom Scan (DecompressChunk) on _hyper_36_135_chunk
+                     Sort Key: compress_hyper_37_139_chunk._ts_meta_sequence_num DESC
+                     ->  Seq Scan on compress_hyper_37_139_chunk
+         ->  Custom Scan (DecompressChunk) on _hyper_36_138_chunk
                ->  Sort
-                     Sort Key: compress_hyper_37_137_chunk._ts_meta_sequence_num DESC
-                     ->  Seq Scan on compress_hyper_37_137_chunk
+                     Sort Key: compress_hyper_37_140_chunk._ts_meta_sequence_num DESC
+                     ->  Seq Scan on compress_hyper_37_140_chunk
          ->  Sort
-               Sort Key: _hyper_36_135_chunk."time"
+               Sort Key: _hyper_36_138_chunk."time"
                ->  Sort
-                     Sort Key: _hyper_36_135_chunk."time"
-                     ->  Seq Scan on _hyper_36_135_chunk
+                     Sort Key: _hyper_36_138_chunk."time"
+                     ->  Seq Scan on _hyper_36_138_chunk
 (30 rows)
 
 -- make other one partial too
@@ -2358,38 +2286,38 @@ EXPLAIN (COSTS OFF) SELECT * FROM space_part ORDER BY time;
  Custom Scan (ChunkAppend) on space_part
    Order: space_part."time"
    ->  Merge Append
-         Sort Key: _hyper_36_130_chunk."time"
-         ->  Custom Scan (DecompressChunk) on _hyper_36_130_chunk
+         Sort Key: _hyper_36_133_chunk."time"
+         ->  Custom Scan (DecompressChunk) on _hyper_36_133_chunk
                ->  Sort
-                     Sort Key: compress_hyper_37_132_chunk._ts_meta_sequence_num DESC
-                     ->  Seq Scan on compress_hyper_37_132_chunk
+                     Sort Key: compress_hyper_37_135_chunk._ts_meta_sequence_num DESC
+                     ->  Seq Scan on compress_hyper_37_135_chunk
          ->  Sort
-               Sort Key: _hyper_36_130_chunk."time"
-               ->  Seq Scan on _hyper_36_130_chunk
-   ->  Custom Scan (DecompressChunk) on _hyper_36_131_chunk
+               Sort Key: _hyper_36_133_chunk."time"
+               ->  Seq Scan on _hyper_36_133_chunk
+   ->  Custom Scan (DecompressChunk) on _hyper_36_134_chunk
          ->  Sort
-               Sort Key: compress_hyper_37_133_chunk._ts_meta_sequence_num DESC
-               ->  Seq Scan on compress_hyper_37_133_chunk
+               Sort Key: compress_hyper_37_136_chunk._ts_meta_sequence_num DESC
+               ->  Seq Scan on compress_hyper_37_136_chunk
    ->  Merge Append
-         Sort Key: _hyper_36_134_chunk."time"
-         ->  Custom Scan (DecompressChunk) on _hyper_36_134_chunk
+         Sort Key: _hyper_36_137_chunk."time"
+         ->  Custom Scan (DecompressChunk) on _hyper_36_137_chunk
                ->  Sort
-                     Sort Key: compress_hyper_37_136_chunk._ts_meta_sequence_num DESC
-                     ->  Seq Scan on compress_hyper_37_136_chunk
+                     Sort Key: compress_hyper_37_139_chunk._ts_meta_sequence_num DESC
+                     ->  Seq Scan on compress_hyper_37_139_chunk
          ->  Sort
-               Sort Key: _hyper_36_134_chunk."time"
+               Sort Key: _hyper_36_137_chunk."time"
                ->  Sort
-                     Sort Key: _hyper_36_134_chunk."time"
-                     ->  Seq Scan on _hyper_36_134_chunk
-         ->  Custom Scan (DecompressChunk) on _hyper_36_135_chunk
+                     Sort Key: _hyper_36_137_chunk."time"
+                     ->  Seq Scan on _hyper_36_137_chunk
+         ->  Custom Scan (DecompressChunk) on _hyper_36_138_chunk
                ->  Sort
-                     Sort Key: compress_hyper_37_137_chunk._ts_meta_sequence_num DESC
-                     ->  Seq Scan on compress_hyper_37_137_chunk
+                     Sort Key: compress_hyper_37_140_chunk._ts_meta_sequence_num DESC
+                     ->  Seq Scan on compress_hyper_37_140_chunk
          ->  Sort
-               Sort Key: _hyper_36_135_chunk."time"
+               Sort Key: _hyper_36_138_chunk."time"
                ->  Sort
-                     Sort Key: _hyper_36_135_chunk."time"
-                     ->  Seq Scan on _hyper_36_135_chunk
+                     Sort Key: _hyper_36_138_chunk."time"
+                     ->  Seq Scan on _hyper_36_138_chunk
 (35 rows)
 
 -- test creation of unique expression index does not interfere with enabling compression
@@ -2418,14 +2346,14 @@ values ('meter1', 1, 2.3, '2022-01-01'::timestamptz, '2022-01-01'::timestamptz),
 select compress_chunk(show_chunks('mytab'));
               compress_chunk               
 -------------------------------------------
- _timescaledb_internal._hyper_38_138_chunk
+ _timescaledb_internal._hyper_38_141_chunk
 (1 row)
 
 REINDEX TABLE mytab; -- should update index
 select decompress_chunk(show_chunks('mytab'));
              decompress_chunk              
 -------------------------------------------
- _timescaledb_internal._hyper_38_138_chunk
+ _timescaledb_internal._hyper_38_141_chunk
 (1 row)
 
 \set EXPLAIN 'EXPLAIN (costs off,timing off,summary off)'
@@ -2436,7 +2364,7 @@ set enable_indexscan = on;
 :EXPLAIN_ANALYZE select * from mytab where lower(col1::text) = 'meter1';
                                             QUERY PLAN                                            
 --------------------------------------------------------------------------------------------------
- Index Scan using _hyper_38_138_chunk_myidx_unique on _hyper_38_138_chunk (actual rows=3 loops=1)
+ Index Scan using _hyper_38_141_chunk_myidx_unique on _hyper_38_141_chunk (actual rows=3 loops=1)
    Index Cond: (lower((col1)::text) = 'meter1'::text)
 (2 rows)
 
@@ -2454,19 +2382,19 @@ WHERE (value > 2.4 AND value < 3);
 select compress_chunk(show_chunks('mytab'));
               compress_chunk               
 -------------------------------------------
- _timescaledb_internal._hyper_38_138_chunk
+ _timescaledb_internal._hyper_38_141_chunk
 (1 row)
 
 select decompress_chunk(show_chunks('mytab'));
              decompress_chunk              
 -------------------------------------------
- _timescaledb_internal._hyper_38_138_chunk
+ _timescaledb_internal._hyper_38_141_chunk
 (1 row)
 
 :EXPLAIN_ANALYZE SELECT * FROM mytab WHERE value BETWEEN 2.4 AND 2.8;
                                       QUERY PLAN                                       
 ---------------------------------------------------------------------------------------
- Seq Scan on _hyper_38_138_chunk (actual rows=1 loops=1)
+ Seq Scan on _hyper_38_141_chunk (actual rows=1 loops=1)
    Filter: ((value >= '2.4'::double precision) AND (value <= '2.8'::double precision))
    Rows Removed by Filter: 2
 (3 rows)
@@ -2513,14 +2441,14 @@ alter table hyper_unique_deferred set (timescaledb.compress);
 select compress_chunk(show_chunks('hyper_unique_deferred')); -- also worked fine before 2.11.0
               compress_chunk               
 -------------------------------------------
- _timescaledb_internal._hyper_41_142_chunk
+ _timescaledb_internal._hyper_41_145_chunk
 (1 row)
 
 select decompress_chunk(show_chunks('hyper_unique_deferred'));
              decompress_chunk              
 -------------------------------------------
- _timescaledb_internal._hyper_41_142_chunk
+ _timescaledb_internal._hyper_41_145_chunk
 (1 row)
 
 begin; insert INTO hyper_unique_deferred values (1257987700000000000, 'dev1', 1); abort;
-ERROR:  new row for relation "_hyper_41_142_chunk" violates check constraint "hyper_unique_deferred_sensor_1_check"
+ERROR:  new row for relation "_hyper_41_145_chunk" violates check constraint "hyper_unique_deferred_sensor_1_check"

--- a/tsl/test/expected/compression_errors-13.out
+++ b/tsl/test/expected/compression_errors-13.out
@@ -230,13 +230,14 @@ select hc.* from _timescaledb_catalog.hypertable_compression hc inner join _time
             15 | t       |                        2 |                        |                      |             | 
 (5 rows)
 
-select decompress_chunk(ch1.schema_name|| '.' || ch1.table_name)
-FROM _timescaledb_catalog.chunk ch1, _timescaledb_catalog.hypertable ht where ch1.hypertable_id = ht.id and ht.table_name like 'foo' ORDER BY ch1.id limit 1;
+SELECT decompress_chunk(ch) FROM show_chunks('foo') ch limit 1;
 ERROR:  chunk "_hyper_15_2_chunk" is not compressed
 --test changing the segment by columns
 ALTER TABLE foo set (timescaledb.compress, timescaledb.compress_orderby = 'a', timescaledb.compress_segmentby = 'b');
-select ch1.schema_name|| '.' || ch1.table_name AS "CHUNK_NAME"
-FROM _timescaledb_catalog.chunk ch1, _timescaledb_catalog.hypertable ht where ch1.hypertable_id = ht.id and ht.table_name like 'foo' ORDER BY ch1.id limit 1 \gset
+SELECT format('%I.%I',chunk_schema,chunk_name) AS "CHUNK_NAME"
+FROM timescaledb_information.chunks
+WHERE hypertable_name = 'foo'
+ORDER BY chunk_name LIMIT 1\gset
 select decompress_chunk(:'CHUNK_NAME');
 ERROR:  chunk "_hyper_15_2_chunk" is not compressed
 select decompress_chunk(:'CHUNK_NAME', if_compressed=>true);
@@ -262,8 +263,7 @@ NOTICE:  chunk "_hyper_15_2_chunk" is already compressed
  _timescaledb_internal._hyper_15_2_chunk
 (1 row)
 
-select compress_chunk(ch1.schema_name|| '.' || ch1.table_name)
-FROM _timescaledb_catalog.chunk ch1, _timescaledb_catalog.hypertable ht where ch1.hypertable_id = ht.id and ht.table_name like 'non_compressed' ORDER BY ch1.id limit 1;
+SELECT compress_chunk(ch) FROM show_chunks('non_compressed') ch LIMIT 1;
 ERROR:  compression not enabled on "non_compressed"
 DETAIL:  It is not possible to compress chunks on a hypertable or continuous aggregate that does not have compression enabled.
 HINT:  Enable compression using ALTER TABLE/MATERIALIZED VIEW with the timescaledb.compress option.
@@ -275,16 +275,20 @@ ERROR:  cannot change configuration on already compressed chunks
 DETAIL:  There are compressed chunks that prevent changing the existing compression configuration.
 ALTER TABLE foo reset (timescaledb.compress);
 ERROR:  compression options cannot be reset
-select decompress_chunk(ch1.schema_name|| '.' || ch1.table_name)
-FROM _timescaledb_catalog.chunk ch1, _timescaledb_catalog.hypertable ht where ch1.hypertable_id = ht.id and ht.table_name like 'non_compressed' ORDER BY ch1.id limit 1;
+SELECT decompress_chunk(ch) FROM show_chunks('non_compressed') ch LIMIT 1;
 ERROR:  missing compressed hypertable
 --should succeed
-select decompress_chunk(ch1.schema_name|| '.' || ch1.table_name)
-FROM _timescaledb_catalog.chunk ch1, _timescaledb_catalog.hypertable ht where ch1.hypertable_id = ht.id and ht.table_name like 'foo' and ch1.compressed_chunk_id IS NOT NULL;
+SELECT decompress_chunk(ch, true) FROM show_chunks('foo') ch;
+NOTICE:  chunk "_hyper_15_3_chunk" is not compressed
+NOTICE:  chunk "_hyper_15_4_chunk" is not compressed
+NOTICE:  chunk "_hyper_15_5_chunk" is not compressed
             decompress_chunk             
 -----------------------------------------
  _timescaledb_internal._hyper_15_2_chunk
-(1 row)
+ 
+ 
+ 
+(4 rows)
 
 --should succeed
 ALTER TABLE foo set (timescaledb.compress, timescaledb.compress_orderby = 'a', timescaledb.compress_segmentby = 'b');

--- a/tsl/test/expected/compression_errors-14.out
+++ b/tsl/test/expected/compression_errors-14.out
@@ -230,13 +230,14 @@ select hc.* from _timescaledb_catalog.hypertable_compression hc inner join _time
             15 | t       |                        2 |                        |                      |             | 
 (5 rows)
 
-select decompress_chunk(ch1.schema_name|| '.' || ch1.table_name)
-FROM _timescaledb_catalog.chunk ch1, _timescaledb_catalog.hypertable ht where ch1.hypertable_id = ht.id and ht.table_name like 'foo' ORDER BY ch1.id limit 1;
+SELECT decompress_chunk(ch) FROM show_chunks('foo') ch limit 1;
 ERROR:  chunk "_hyper_15_2_chunk" is not compressed
 --test changing the segment by columns
 ALTER TABLE foo set (timescaledb.compress, timescaledb.compress_orderby = 'a', timescaledb.compress_segmentby = 'b');
-select ch1.schema_name|| '.' || ch1.table_name AS "CHUNK_NAME"
-FROM _timescaledb_catalog.chunk ch1, _timescaledb_catalog.hypertable ht where ch1.hypertable_id = ht.id and ht.table_name like 'foo' ORDER BY ch1.id limit 1 \gset
+SELECT format('%I.%I',chunk_schema,chunk_name) AS "CHUNK_NAME"
+FROM timescaledb_information.chunks
+WHERE hypertable_name = 'foo'
+ORDER BY chunk_name LIMIT 1\gset
 select decompress_chunk(:'CHUNK_NAME');
 ERROR:  chunk "_hyper_15_2_chunk" is not compressed
 select decompress_chunk(:'CHUNK_NAME', if_compressed=>true);
@@ -262,8 +263,7 @@ NOTICE:  chunk "_hyper_15_2_chunk" is already compressed
  _timescaledb_internal._hyper_15_2_chunk
 (1 row)
 
-select compress_chunk(ch1.schema_name|| '.' || ch1.table_name)
-FROM _timescaledb_catalog.chunk ch1, _timescaledb_catalog.hypertable ht where ch1.hypertable_id = ht.id and ht.table_name like 'non_compressed' ORDER BY ch1.id limit 1;
+SELECT compress_chunk(ch) FROM show_chunks('non_compressed') ch LIMIT 1;
 ERROR:  compression not enabled on "non_compressed"
 DETAIL:  It is not possible to compress chunks on a hypertable or continuous aggregate that does not have compression enabled.
 HINT:  Enable compression using ALTER TABLE/MATERIALIZED VIEW with the timescaledb.compress option.
@@ -275,16 +275,20 @@ ERROR:  cannot change configuration on already compressed chunks
 DETAIL:  There are compressed chunks that prevent changing the existing compression configuration.
 ALTER TABLE foo reset (timescaledb.compress);
 ERROR:  compression options cannot be reset
-select decompress_chunk(ch1.schema_name|| '.' || ch1.table_name)
-FROM _timescaledb_catalog.chunk ch1, _timescaledb_catalog.hypertable ht where ch1.hypertable_id = ht.id and ht.table_name like 'non_compressed' ORDER BY ch1.id limit 1;
+SELECT decompress_chunk(ch) FROM show_chunks('non_compressed') ch LIMIT 1;
 ERROR:  missing compressed hypertable
 --should succeed
-select decompress_chunk(ch1.schema_name|| '.' || ch1.table_name)
-FROM _timescaledb_catalog.chunk ch1, _timescaledb_catalog.hypertable ht where ch1.hypertable_id = ht.id and ht.table_name like 'foo' and ch1.compressed_chunk_id IS NOT NULL;
+SELECT decompress_chunk(ch, true) FROM show_chunks('foo') ch;
+NOTICE:  chunk "_hyper_15_3_chunk" is not compressed
+NOTICE:  chunk "_hyper_15_4_chunk" is not compressed
+NOTICE:  chunk "_hyper_15_5_chunk" is not compressed
             decompress_chunk             
 -----------------------------------------
  _timescaledb_internal._hyper_15_2_chunk
-(1 row)
+ 
+ 
+ 
+(4 rows)
 
 --should succeed
 ALTER TABLE foo set (timescaledb.compress, timescaledb.compress_orderby = 'a', timescaledb.compress_segmentby = 'b');

--- a/tsl/test/expected/compression_errors-15.out
+++ b/tsl/test/expected/compression_errors-15.out
@@ -230,13 +230,14 @@ select hc.* from _timescaledb_catalog.hypertable_compression hc inner join _time
             15 | t       |                        2 |                        |                      |             | 
 (5 rows)
 
-select decompress_chunk(ch1.schema_name|| '.' || ch1.table_name)
-FROM _timescaledb_catalog.chunk ch1, _timescaledb_catalog.hypertable ht where ch1.hypertable_id = ht.id and ht.table_name like 'foo' ORDER BY ch1.id limit 1;
+SELECT decompress_chunk(ch) FROM show_chunks('foo') ch limit 1;
 ERROR:  chunk "_hyper_15_2_chunk" is not compressed
 --test changing the segment by columns
 ALTER TABLE foo set (timescaledb.compress, timescaledb.compress_orderby = 'a', timescaledb.compress_segmentby = 'b');
-select ch1.schema_name|| '.' || ch1.table_name AS "CHUNK_NAME"
-FROM _timescaledb_catalog.chunk ch1, _timescaledb_catalog.hypertable ht where ch1.hypertable_id = ht.id and ht.table_name like 'foo' ORDER BY ch1.id limit 1 \gset
+SELECT format('%I.%I',chunk_schema,chunk_name) AS "CHUNK_NAME"
+FROM timescaledb_information.chunks
+WHERE hypertable_name = 'foo'
+ORDER BY chunk_name LIMIT 1\gset
 select decompress_chunk(:'CHUNK_NAME');
 ERROR:  chunk "_hyper_15_2_chunk" is not compressed
 select decompress_chunk(:'CHUNK_NAME', if_compressed=>true);
@@ -262,8 +263,7 @@ NOTICE:  chunk "_hyper_15_2_chunk" is already compressed
  _timescaledb_internal._hyper_15_2_chunk
 (1 row)
 
-select compress_chunk(ch1.schema_name|| '.' || ch1.table_name)
-FROM _timescaledb_catalog.chunk ch1, _timescaledb_catalog.hypertable ht where ch1.hypertable_id = ht.id and ht.table_name like 'non_compressed' ORDER BY ch1.id limit 1;
+SELECT compress_chunk(ch) FROM show_chunks('non_compressed') ch LIMIT 1;
 ERROR:  compression not enabled on "non_compressed"
 DETAIL:  It is not possible to compress chunks on a hypertable or continuous aggregate that does not have compression enabled.
 HINT:  Enable compression using ALTER TABLE/MATERIALIZED VIEW with the timescaledb.compress option.
@@ -275,16 +275,20 @@ ERROR:  cannot change configuration on already compressed chunks
 DETAIL:  There are compressed chunks that prevent changing the existing compression configuration.
 ALTER TABLE foo reset (timescaledb.compress);
 ERROR:  compression options cannot be reset
-select decompress_chunk(ch1.schema_name|| '.' || ch1.table_name)
-FROM _timescaledb_catalog.chunk ch1, _timescaledb_catalog.hypertable ht where ch1.hypertable_id = ht.id and ht.table_name like 'non_compressed' ORDER BY ch1.id limit 1;
+SELECT decompress_chunk(ch) FROM show_chunks('non_compressed') ch LIMIT 1;
 ERROR:  missing compressed hypertable
 --should succeed
-select decompress_chunk(ch1.schema_name|| '.' || ch1.table_name)
-FROM _timescaledb_catalog.chunk ch1, _timescaledb_catalog.hypertable ht where ch1.hypertable_id = ht.id and ht.table_name like 'foo' and ch1.compressed_chunk_id IS NOT NULL;
+SELECT decompress_chunk(ch, true) FROM show_chunks('foo') ch;
+NOTICE:  chunk "_hyper_15_3_chunk" is not compressed
+NOTICE:  chunk "_hyper_15_4_chunk" is not compressed
+NOTICE:  chunk "_hyper_15_5_chunk" is not compressed
             decompress_chunk             
 -----------------------------------------
  _timescaledb_internal._hyper_15_2_chunk
-(1 row)
+ 
+ 
+ 
+(4 rows)
 
 --should succeed
 ALTER TABLE foo set (timescaledb.compress, timescaledb.compress_orderby = 'a', timescaledb.compress_segmentby = 'b');

--- a/tsl/test/expected/compression_errors-16.out
+++ b/tsl/test/expected/compression_errors-16.out
@@ -230,13 +230,14 @@ select hc.* from _timescaledb_catalog.hypertable_compression hc inner join _time
             15 | t       |                        2 |                        |                      |             | 
 (5 rows)
 
-select decompress_chunk(ch1.schema_name|| '.' || ch1.table_name)
-FROM _timescaledb_catalog.chunk ch1, _timescaledb_catalog.hypertable ht where ch1.hypertable_id = ht.id and ht.table_name like 'foo' ORDER BY ch1.id limit 1;
+SELECT decompress_chunk(ch) FROM show_chunks('foo') ch limit 1;
 ERROR:  chunk "_hyper_15_2_chunk" is not compressed
 --test changing the segment by columns
 ALTER TABLE foo set (timescaledb.compress, timescaledb.compress_orderby = 'a', timescaledb.compress_segmentby = 'b');
-select ch1.schema_name|| '.' || ch1.table_name AS "CHUNK_NAME"
-FROM _timescaledb_catalog.chunk ch1, _timescaledb_catalog.hypertable ht where ch1.hypertable_id = ht.id and ht.table_name like 'foo' ORDER BY ch1.id limit 1 \gset
+SELECT format('%I.%I',chunk_schema,chunk_name) AS "CHUNK_NAME"
+FROM timescaledb_information.chunks
+WHERE hypertable_name = 'foo'
+ORDER BY chunk_name LIMIT 1\gset
 select decompress_chunk(:'CHUNK_NAME');
 ERROR:  chunk "_hyper_15_2_chunk" is not compressed
 select decompress_chunk(:'CHUNK_NAME', if_compressed=>true);
@@ -262,8 +263,7 @@ NOTICE:  chunk "_hyper_15_2_chunk" is already compressed
  _timescaledb_internal._hyper_15_2_chunk
 (1 row)
 
-select compress_chunk(ch1.schema_name|| '.' || ch1.table_name)
-FROM _timescaledb_catalog.chunk ch1, _timescaledb_catalog.hypertable ht where ch1.hypertable_id = ht.id and ht.table_name like 'non_compressed' ORDER BY ch1.id limit 1;
+SELECT compress_chunk(ch) FROM show_chunks('non_compressed') ch LIMIT 1;
 ERROR:  compression not enabled on "non_compressed"
 DETAIL:  It is not possible to compress chunks on a hypertable or continuous aggregate that does not have compression enabled.
 HINT:  Enable compression using ALTER TABLE/MATERIALIZED VIEW with the timescaledb.compress option.
@@ -275,16 +275,20 @@ ERROR:  cannot change configuration on already compressed chunks
 DETAIL:  There are compressed chunks that prevent changing the existing compression configuration.
 ALTER TABLE foo reset (timescaledb.compress);
 ERROR:  compression options cannot be reset
-select decompress_chunk(ch1.schema_name|| '.' || ch1.table_name)
-FROM _timescaledb_catalog.chunk ch1, _timescaledb_catalog.hypertable ht where ch1.hypertable_id = ht.id and ht.table_name like 'non_compressed' ORDER BY ch1.id limit 1;
+SELECT decompress_chunk(ch) FROM show_chunks('non_compressed') ch LIMIT 1;
 ERROR:  missing compressed hypertable
 --should succeed
-select decompress_chunk(ch1.schema_name|| '.' || ch1.table_name)
-FROM _timescaledb_catalog.chunk ch1, _timescaledb_catalog.hypertable ht where ch1.hypertable_id = ht.id and ht.table_name like 'foo' and ch1.compressed_chunk_id IS NOT NULL;
+SELECT decompress_chunk(ch, true) FROM show_chunks('foo') ch;
+NOTICE:  chunk "_hyper_15_3_chunk" is not compressed
+NOTICE:  chunk "_hyper_15_4_chunk" is not compressed
+NOTICE:  chunk "_hyper_15_5_chunk" is not compressed
             decompress_chunk             
 -----------------------------------------
  _timescaledb_internal._hyper_15_2_chunk
-(1 row)
+ 
+ 
+ 
+(4 rows)
 
 --should succeed
 ALTER TABLE foo set (timescaledb.compress, timescaledb.compress_orderby = 'a', timescaledb.compress_segmentby = 'b');

--- a/tsl/test/expected/compression_hypertable.out
+++ b/tsl/test/expected/compression_hypertable.out
@@ -118,9 +118,9 @@ psql:include/compression_test_hypertable.sql:7: NOTICE:  table "original_result"
 -- Please see the included NOTICE for copyright information and
 -- LICENSE-TIMESCALE for a copy of the license.
 \set ECHO errors
- count_compressed 
-------------------
-               27
+ count 
+-------
+    27
 (1 row)
 
  min_correct | max_correct 
@@ -171,8 +171,8 @@ select * from _timescaledb_internal._hyper_1_10_chunk;
  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_10_chunk (actual rows=24 loops=1)
    Output: _hyper_1_10_chunk."Time", _hyper_1_10_chunk.i, _hyper_1_10_chunk.b, _hyper_1_10_chunk.t
    Bulk Decompression: true
-   ->  Seq Scan on _timescaledb_internal.compress_hyper_2_64_chunk (actual rows=1 loops=1)
-         Output: compress_hyper_2_64_chunk."Time", compress_hyper_2_64_chunk.i, compress_hyper_2_64_chunk.b, compress_hyper_2_64_chunk.t, compress_hyper_2_64_chunk._ts_meta_count, compress_hyper_2_64_chunk._ts_meta_sequence_num, compress_hyper_2_64_chunk._ts_meta_min_1, compress_hyper_2_64_chunk._ts_meta_max_1
+   ->  Seq Scan on _timescaledb_internal.compress_hyper_2_55_chunk (actual rows=1 loops=1)
+         Output: compress_hyper_2_55_chunk."Time", compress_hyper_2_55_chunk.i, compress_hyper_2_55_chunk.b, compress_hyper_2_55_chunk.t, compress_hyper_2_55_chunk._ts_meta_count, compress_hyper_2_55_chunk._ts_meta_sequence_num, compress_hyper_2_55_chunk._ts_meta_min_1, compress_hyper_2_55_chunk._ts_meta_max_1
 (5 rows)
 
 set timescaledb.enable_bulk_decompression to false;
@@ -183,8 +183,8 @@ select * from _timescaledb_internal._hyper_1_10_chunk;
  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_10_chunk (actual rows=24 loops=1)
    Output: _hyper_1_10_chunk."Time", _hyper_1_10_chunk.i, _hyper_1_10_chunk.b, _hyper_1_10_chunk.t
    Bulk Decompression: false
-   ->  Seq Scan on _timescaledb_internal.compress_hyper_2_64_chunk (actual rows=1 loops=1)
-         Output: compress_hyper_2_64_chunk."Time", compress_hyper_2_64_chunk.i, compress_hyper_2_64_chunk.b, compress_hyper_2_64_chunk.t, compress_hyper_2_64_chunk._ts_meta_count, compress_hyper_2_64_chunk._ts_meta_sequence_num, compress_hyper_2_64_chunk._ts_meta_min_1, compress_hyper_2_64_chunk._ts_meta_max_1
+   ->  Seq Scan on _timescaledb_internal.compress_hyper_2_55_chunk (actual rows=1 loops=1)
+         Output: compress_hyper_2_55_chunk."Time", compress_hyper_2_55_chunk.i, compress_hyper_2_55_chunk.b, compress_hyper_2_55_chunk.t, compress_hyper_2_55_chunk._ts_meta_count, compress_hyper_2_55_chunk._ts_meta_sequence_num, compress_hyper_2_55_chunk._ts_meta_min_1, compress_hyper_2_55_chunk._ts_meta_max_1
 (5 rows)
 
 reset timescaledb.enable_bulk_decompression;
@@ -274,9 +274,9 @@ ALTER TABLE test2 set (timescaledb.compress, timescaledb.compress_segmentby = ''
 -- Please see the included NOTICE for copyright information and
 -- LICENSE-TIMESCALE for a copy of the license.
 \set ECHO errors
- count_compressed 
-------------------
-                5
+ count 
+-------
+     5
 (1 row)
 
  min_correct | max_correct 
@@ -293,9 +293,14 @@ ALTER TABLE test2 set (timescaledb.compress, timescaledb.compress_segmentby = ''
 -- Please see the included NOTICE for copyright information and
 -- LICENSE-TIMESCALE for a copy of the license.
 \set ECHO errors
- count_compressed 
-------------------
-                0
+psql:include/compression_test_hypertable_segment_meta.sql:10: NOTICE:  chunk "_hyper_3_82_chunk" is already compressed
+psql:include/compression_test_hypertable_segment_meta.sql:10: NOTICE:  chunk "_hyper_3_83_chunk" is already compressed
+psql:include/compression_test_hypertable_segment_meta.sql:10: NOTICE:  chunk "_hyper_3_84_chunk" is already compressed
+psql:include/compression_test_hypertable_segment_meta.sql:10: NOTICE:  chunk "_hyper_3_85_chunk" is already compressed
+psql:include/compression_test_hypertable_segment_meta.sql:10: NOTICE:  chunk "_hyper_3_86_chunk" is already compressed
+ count 
+-------
+     5
 (1 row)
 
  min_correct | max_correct 
@@ -386,9 +391,9 @@ group by location ORDER BY location;
 -- Please see the included NOTICE for copyright information and
 -- LICENSE-TIMESCALE for a copy of the license.
 \set ECHO errors
- count_compressed 
-------------------
-                1
+ count 
+-------
+     1
 (1 row)
 
  min_correct | max_correct 
@@ -499,9 +504,9 @@ select generate_series('2018-01-01 00:00'::timestamp, '2018-01-10 00:00'::timest
 -- Please see the included NOTICE for copyright information and
 -- LICENSE-TIMESCALE for a copy of the license.
 \set ECHO errors
- count_compressed 
-------------------
-               10
+ count 
+-------
+    10
 (1 row)
 
  min_correct | max_correct 
@@ -579,9 +584,9 @@ INSERT INTO test6 SELECT t, NULL, customtype_in(t::TEXT::cstring)
 -- Please see the included NOTICE for copyright information and
 -- LICENSE-TIMESCALE for a copy of the license.
 \set ECHO errors
- count_compressed 
-------------------
-                5
+ count 
+-------
+     5
 (1 row)
 
  min_correct | max_correct 
@@ -656,9 +661,9 @@ INSERT INTO test7
 -- Please see the included NOTICE for copyright information and
 -- LICENSE-TIMESCALE for a copy of the license.
 \set ECHO errors
- count_compressed 
-------------------
-                1
+ count 
+-------
+     1
 (1 row)
 
  min_correct | max_correct 

--- a/tsl/test/expected/compression_merge.out
+++ b/tsl/test/expected/compression_merge.out
@@ -64,9 +64,9 @@ psql:include/compression_test_merge.sql:7: NOTICE:  table "merge_result" does no
  Number of rows different between original and query on compressed data (expect 0) |     0
 (1 row)
 
- count_decompressed 
---------------------
-                 12
+ count 
+-------
+    12
 (1 row)
 
                                                    ?column?                                                   | count 
@@ -83,9 +83,9 @@ psql:include/compression_test_merge.sql:7: NOTICE:  table "merge_result" does no
 -- Please see the included NOTICE for copyright information and
 -- LICENSE-TIMESCALE for a copy of the license.
 \set ECHO errors
- count_compressed 
-------------------
-               12
+ count 
+-------
+    12
 (1 row)
 
  min_correct | max_correct 
@@ -129,9 +129,9 @@ SELECT 'test2' AS "HYPERTABLE_NAME" \gset
  Number of rows different between original and query on compressed data (expect 0) |     0
 (1 row)
 
- count_decompressed 
---------------------
-                  3
+ count 
+-------
+     3
 (1 row)
 
                                                    ?column?                                                   | count 
@@ -148,9 +148,9 @@ SELECT 'test2' AS "HYPERTABLE_NAME" \gset
 -- Please see the included NOTICE for copyright information and
 -- LICENSE-TIMESCALE for a copy of the license.
 \set ECHO errors
- count_compressed 
-------------------
-                3
+ count 
+-------
+     3
 (1 row)
 
  min_correct | max_correct 
@@ -199,9 +199,9 @@ SELECT 'test3' AS "HYPERTABLE_NAME" \gset
  Number of rows different between original and query on compressed data (expect 0) |     0
 (1 row)
 
- count_decompressed 
---------------------
-                 13
+ count 
+-------
+    13
 (1 row)
 
                                                    ?column?                                                   | count 
@@ -218,9 +218,9 @@ SELECT 'test3' AS "HYPERTABLE_NAME" \gset
 -- Please see the included NOTICE for copyright information and
 -- LICENSE-TIMESCALE for a copy of the license.
 \set ECHO errors
- count_compressed 
-------------------
-               13
+ count 
+-------
+    13
 (1 row)
 
  min_correct | max_correct 
@@ -326,9 +326,9 @@ psql:include/compression_test_merge.sql:12: NOTICE:  chunk "_hyper_9_163_chunk" 
  Number of rows different between original and query on compressed data (expect 0) |     0
 (1 row)
 
- count_decompressed 
---------------------
-                  1
+ count 
+-------
+     1
 (1 row)
 
                                                    ?column?                                                   | count 
@@ -617,9 +617,9 @@ SELECT 'test7' AS "HYPERTABLE_NAME" \gset
  Number of rows different between original and query on compressed data (expect 0) |     0
 (1 row)
 
- count_decompressed 
---------------------
-                 12
+ count 
+-------
+    12
 (1 row)
 
                                                    ?column?                                                   | count 

--- a/tsl/test/expected/compression_permissions.out
+++ b/tsl/test/expected/compression_permissions.out
@@ -58,11 +58,9 @@ alter table conditions set (timescaledb.compress, timescaledb.compress_segmentby
 ERROR:  must be owner of table conditions
 --- compress_chunks and decompress_chunks fail without correct perm --
 \c :TEST_DBNAME :ROLE_DEFAULT_PERM_USER_2
-select  compress_chunk(ch1.schema_name|| '.' || ch1.table_name)
-FROM _timescaledb_catalog.chunk ch1, _timescaledb_catalog.hypertable ht where ch1.hypertable_id = ht.id and ht.table_name like 'conditions' and ch1.compressed_chunk_id IS NULL;
+SELECT compress_chunk(show_chunks('conditions'));
 ERROR:  must be owner of hypertable "conditions"
-select decompress_chunk(ch1.schema_name|| '.' || ch1.table_name)
-FROM _timescaledb_catalog.chunk ch1, _timescaledb_catalog.hypertable ht where ch1.hypertable_id = ht.id and ht.table_name like 'conditions';
+SELECT decompress_chunk(show_chunks('conditions'));
 ERROR:  must be owner of hypertable "conditions"
 select add_compression_policy('conditions', '1day'::interval);
 ERROR:  must be owner of hypertable "conditions"
@@ -81,9 +79,7 @@ ERROR:  must be owner of hypertable "conditions"
 -- as owner grant select , compress chunk and check SELECT works
 \c :TEST_DBNAME :ROLE_DEFAULT_PERM_USER
 GRANT SELECT on conditions to :ROLE_DEFAULT_PERM_USER_2;
-select count(*) from
-(select  compress_chunk(ch1.schema_name|| '.' || ch1.table_name)
-FROM _timescaledb_catalog.chunk ch1, _timescaledb_catalog.hypertable ht where ch1.hypertable_id = ht.id and ht.table_name like 'conditions' and ch1.compressed_chunk_id IS NULL ) as subq;
+SELECT count(compress_chunk(ch)) FROM show_chunks('conditions') ch;
  count 
 -------
      2

--- a/tsl/test/expected/continuous_aggs-13.out
+++ b/tsl/test/expected/continuous_aggs-13.out
@@ -1602,7 +1602,7 @@ ORDER BY 1, 2, 3;
 ALTER MATERIALIZED VIEW search_query_count_3 SET (timescaledb.compress = 'false');
 ERROR:  cannot change configuration on already compressed chunks
 \set ON_ERROR_STOP 1
-SELECT decompress_chunk(schema_name || '.' || table_name)
+SELECT decompress_chunk(format('%I.%I', schema_name, table_name))
 FROM _timescaledb_catalog.chunk
 WHERE hypertable_id = :'MAT_HTID' and status = 1;
              decompress_chunk             

--- a/tsl/test/expected/continuous_aggs-14.out
+++ b/tsl/test/expected/continuous_aggs-14.out
@@ -1601,7 +1601,7 @@ ORDER BY 1, 2, 3;
 ALTER MATERIALIZED VIEW search_query_count_3 SET (timescaledb.compress = 'false');
 ERROR:  cannot change configuration on already compressed chunks
 \set ON_ERROR_STOP 1
-SELECT decompress_chunk(schema_name || '.' || table_name)
+SELECT decompress_chunk(format('%I.%I', schema_name, table_name))
 FROM _timescaledb_catalog.chunk
 WHERE hypertable_id = :'MAT_HTID' and status = 1;
              decompress_chunk             

--- a/tsl/test/expected/continuous_aggs-15.out
+++ b/tsl/test/expected/continuous_aggs-15.out
@@ -1601,7 +1601,7 @@ ORDER BY 1, 2, 3;
 ALTER MATERIALIZED VIEW search_query_count_3 SET (timescaledb.compress = 'false');
 ERROR:  cannot change configuration on already compressed chunks
 \set ON_ERROR_STOP 1
-SELECT decompress_chunk(schema_name || '.' || table_name)
+SELECT decompress_chunk(format('%I.%I', schema_name, table_name))
 FROM _timescaledb_catalog.chunk
 WHERE hypertable_id = :'MAT_HTID' and status = 1;
              decompress_chunk             

--- a/tsl/test/expected/continuous_aggs-16.out
+++ b/tsl/test/expected/continuous_aggs-16.out
@@ -1601,7 +1601,7 @@ ORDER BY 1, 2, 3;
 ALTER MATERIALIZED VIEW search_query_count_3 SET (timescaledb.compress = 'false');
 ERROR:  cannot change configuration on already compressed chunks
 \set ON_ERROR_STOP 1
-SELECT decompress_chunk(schema_name || '.' || table_name)
+SELECT decompress_chunk(format('%I.%I', schema_name, table_name))
 FROM _timescaledb_catalog.chunk
 WHERE hypertable_id = :'MAT_HTID' and status = 1;
              decompress_chunk             

--- a/tsl/test/expected/continuous_aggs_deprecated-13.out
+++ b/tsl/test/expected/continuous_aggs_deprecated-13.out
@@ -1637,7 +1637,7 @@ ORDER BY 1, 2, 3;
 ALTER MATERIALIZED VIEW search_query_count_3 SET (timescaledb.compress = 'false');
 ERROR:  cannot change configuration on already compressed chunks
 \set ON_ERROR_STOP 1
-SELECT decompress_chunk(schema_name || '.' || table_name)
+SELECT decompress_chunk(format('%I.%I', schema_name, table_name))
 FROM _timescaledb_catalog.chunk
 WHERE hypertable_id = :'MAT_HTID' and status = 1;
              decompress_chunk             

--- a/tsl/test/expected/continuous_aggs_deprecated-14.out
+++ b/tsl/test/expected/continuous_aggs_deprecated-14.out
@@ -1636,7 +1636,7 @@ ORDER BY 1, 2, 3;
 ALTER MATERIALIZED VIEW search_query_count_3 SET (timescaledb.compress = 'false');
 ERROR:  cannot change configuration on already compressed chunks
 \set ON_ERROR_STOP 1
-SELECT decompress_chunk(schema_name || '.' || table_name)
+SELECT decompress_chunk(format('%I.%I', schema_name, table_name))
 FROM _timescaledb_catalog.chunk
 WHERE hypertable_id = :'MAT_HTID' and status = 1;
  decompress_chunk 

--- a/tsl/test/expected/continuous_aggs_deprecated-15.out
+++ b/tsl/test/expected/continuous_aggs_deprecated-15.out
@@ -1636,7 +1636,7 @@ ORDER BY 1, 2, 3;
 ALTER MATERIALIZED VIEW search_query_count_3 SET (timescaledb.compress = 'false');
 ERROR:  cannot change configuration on already compressed chunks
 \set ON_ERROR_STOP 1
-SELECT decompress_chunk(schema_name || '.' || table_name)
+SELECT decompress_chunk(format('%I.%I', schema_name, table_name))
 FROM _timescaledb_catalog.chunk
 WHERE hypertable_id = :'MAT_HTID' and status = 1;
  decompress_chunk 

--- a/tsl/test/expected/continuous_aggs_deprecated-16.out
+++ b/tsl/test/expected/continuous_aggs_deprecated-16.out
@@ -1636,7 +1636,7 @@ ORDER BY 1, 2, 3;
 ALTER MATERIALIZED VIEW search_query_count_3 SET (timescaledb.compress = 'false');
 ERROR:  cannot change configuration on already compressed chunks
 \set ON_ERROR_STOP 1
-SELECT decompress_chunk(schema_name || '.' || table_name)
+SELECT decompress_chunk(format('%I.%I', schema_name, table_name))
 FROM _timescaledb_catalog.chunk
 WHERE hypertable_id = :'MAT_HTID' and status = 1;
  decompress_chunk 

--- a/tsl/test/expected/merge_compress.out
+++ b/tsl/test/expected/merge_compress.out
@@ -27,9 +27,7 @@ INSERT INTO target (series_id, value, partition_column)
   SELECT s,1,t from generate_series(:'start_date'::timestamptz, :'start_date'::timestamptz + interval '1 day', '5m') t cross join
     generate_series(1,3, 1) s;
 -- compress chunks
-SELECT count(compress_chunk(c.schema_name|| '.' || c.table_name))
-  FROM _timescaledb_catalog.chunk c, _timescaledb_catalog.hypertable ht where
-    c.hypertable_id = ht.id and ht.table_name = 'target' and c.compressed_chunk_id IS NULL;
+SELECT count(compress_chunk(ch)) FROM show_chunks('target') ch;
  count 
 -------
      4

--- a/tsl/test/expected/transparent_decompression-13.out
+++ b/tsl/test/expected/transparent_decompression-13.out
@@ -8118,18 +8118,11 @@ CREATE INDEX ON metrics_ordered(device_id,device_id_peer,time);
 CREATE INDEX ON metrics_ordered(device_id,time);
 CREATE INDEX ON metrics_ordered(device_id_peer,time);
 -- compress all chunks
-SELECT
-  compress_chunk(c.schema_name || '.' || c.table_name)
-FROM _timescaledb_catalog.chunk c
-  INNER JOIN _timescaledb_catalog.hypertable ht ON c.hypertable_id=ht.id
-WHERE ht.table_name = 'metrics_ordered'
-ORDER BY c.id;
-              compress_chunk              
-------------------------------------------
- _timescaledb_internal._hyper_11_26_chunk
- _timescaledb_internal._hyper_11_27_chunk
- _timescaledb_internal._hyper_11_28_chunk
-(3 rows)
+SELECT count(compress_chunk(ch)) FROM show_chunks('metrics_ordered') ch;
+ count 
+-------
+     3
+(1 row)
 
 -- reindexing compressed hypertable to update statistics
 DO
@@ -8366,10 +8359,7 @@ psql:include/transparent_decompression_undiffed.sql:12: NOTICE:  adding not-null
 
 ALTER TABLE readings SET (timescaledb.compress, timescaledb.compress_segmentby = 'tags_id', timescaledb.compress_orderby = 'time desc');
 INSERT into readings select g, 1, 1.3 from generate_series('2001-03-01 01:01:01', '2003-02-01 01:01:01', '1 day'::interval) g;
-SELECT count(compress_chunk(chunk.schema_name|| '.' || chunk.table_name))
-FROM _timescaledb_catalog.chunk chunk
-INNER JOIN _timescaledb_catalog.hypertable hypertable ON (chunk.hypertable_id = hypertable.id)
-WHERE hypertable.table_name = 'readings' and chunk.compressed_chunk_id IS NULL;
+SELECT count(compress_chunk(ch)) FROM show_chunks('readings') ch;
  count 
 -------
    703

--- a/tsl/test/expected/transparent_decompression-14.out
+++ b/tsl/test/expected/transparent_decompression-14.out
@@ -8106,18 +8106,11 @@ CREATE INDEX ON metrics_ordered(device_id,device_id_peer,time);
 CREATE INDEX ON metrics_ordered(device_id,time);
 CREATE INDEX ON metrics_ordered(device_id_peer,time);
 -- compress all chunks
-SELECT
-  compress_chunk(c.schema_name || '.' || c.table_name)
-FROM _timescaledb_catalog.chunk c
-  INNER JOIN _timescaledb_catalog.hypertable ht ON c.hypertable_id=ht.id
-WHERE ht.table_name = 'metrics_ordered'
-ORDER BY c.id;
-              compress_chunk              
-------------------------------------------
- _timescaledb_internal._hyper_11_26_chunk
- _timescaledb_internal._hyper_11_27_chunk
- _timescaledb_internal._hyper_11_28_chunk
-(3 rows)
+SELECT count(compress_chunk(ch)) FROM show_chunks('metrics_ordered') ch;
+ count 
+-------
+     3
+(1 row)
 
 -- reindexing compressed hypertable to update statistics
 DO
@@ -8354,10 +8347,7 @@ psql:include/transparent_decompression_undiffed.sql:12: NOTICE:  adding not-null
 
 ALTER TABLE readings SET (timescaledb.compress, timescaledb.compress_segmentby = 'tags_id', timescaledb.compress_orderby = 'time desc');
 INSERT into readings select g, 1, 1.3 from generate_series('2001-03-01 01:01:01', '2003-02-01 01:01:01', '1 day'::interval) g;
-SELECT count(compress_chunk(chunk.schema_name|| '.' || chunk.table_name))
-FROM _timescaledb_catalog.chunk chunk
-INNER JOIN _timescaledb_catalog.hypertable hypertable ON (chunk.hypertable_id = hypertable.id)
-WHERE hypertable.table_name = 'readings' and chunk.compressed_chunk_id IS NULL;
+SELECT count(compress_chunk(ch)) FROM show_chunks('readings') ch;
  count 
 -------
    703

--- a/tsl/test/expected/transparent_decompression-15.out
+++ b/tsl/test/expected/transparent_decompression-15.out
@@ -8080,18 +8080,11 @@ CREATE INDEX ON metrics_ordered(device_id,device_id_peer,time);
 CREATE INDEX ON metrics_ordered(device_id,time);
 CREATE INDEX ON metrics_ordered(device_id_peer,time);
 -- compress all chunks
-SELECT
-  compress_chunk(c.schema_name || '.' || c.table_name)
-FROM _timescaledb_catalog.chunk c
-  INNER JOIN _timescaledb_catalog.hypertable ht ON c.hypertable_id=ht.id
-WHERE ht.table_name = 'metrics_ordered'
-ORDER BY c.id;
-              compress_chunk              
-------------------------------------------
- _timescaledb_internal._hyper_11_26_chunk
- _timescaledb_internal._hyper_11_27_chunk
- _timescaledb_internal._hyper_11_28_chunk
-(3 rows)
+SELECT count(compress_chunk(ch)) FROM show_chunks('metrics_ordered') ch;
+ count 
+-------
+     3
+(1 row)
 
 -- reindexing compressed hypertable to update statistics
 DO
@@ -8329,10 +8322,7 @@ psql:include/transparent_decompression_undiffed.sql:12: NOTICE:  adding not-null
 
 ALTER TABLE readings SET (timescaledb.compress, timescaledb.compress_segmentby = 'tags_id', timescaledb.compress_orderby = 'time desc');
 INSERT into readings select g, 1, 1.3 from generate_series('2001-03-01 01:01:01', '2003-02-01 01:01:01', '1 day'::interval) g;
-SELECT count(compress_chunk(chunk.schema_name|| '.' || chunk.table_name))
-FROM _timescaledb_catalog.chunk chunk
-INNER JOIN _timescaledb_catalog.hypertable hypertable ON (chunk.hypertable_id = hypertable.id)
-WHERE hypertable.table_name = 'readings' and chunk.compressed_chunk_id IS NULL;
+SELECT count(compress_chunk(ch)) FROM show_chunks('readings') ch;
  count 
 -------
    703

--- a/tsl/test/expected/transparent_decompression-16.out
+++ b/tsl/test/expected/transparent_decompression-16.out
@@ -8038,18 +8038,11 @@ CREATE INDEX ON metrics_ordered(device_id,device_id_peer,time);
 CREATE INDEX ON metrics_ordered(device_id,time);
 CREATE INDEX ON metrics_ordered(device_id_peer,time);
 -- compress all chunks
-SELECT
-  compress_chunk(c.schema_name || '.' || c.table_name)
-FROM _timescaledb_catalog.chunk c
-  INNER JOIN _timescaledb_catalog.hypertable ht ON c.hypertable_id=ht.id
-WHERE ht.table_name = 'metrics_ordered'
-ORDER BY c.id;
-              compress_chunk              
-------------------------------------------
- _timescaledb_internal._hyper_11_26_chunk
- _timescaledb_internal._hyper_11_27_chunk
- _timescaledb_internal._hyper_11_28_chunk
-(3 rows)
+SELECT count(compress_chunk(ch)) FROM show_chunks('metrics_ordered') ch;
+ count 
+-------
+     3
+(1 row)
 
 -- reindexing compressed hypertable to update statistics
 DO
@@ -8287,10 +8280,7 @@ psql:include/transparent_decompression_undiffed.sql:12: NOTICE:  adding not-null
 
 ALTER TABLE readings SET (timescaledb.compress, timescaledb.compress_segmentby = 'tags_id', timescaledb.compress_orderby = 'time desc');
 INSERT into readings select g, 1, 1.3 from generate_series('2001-03-01 01:01:01', '2003-02-01 01:01:01', '1 day'::interval) g;
-SELECT count(compress_chunk(chunk.schema_name|| '.' || chunk.table_name))
-FROM _timescaledb_catalog.chunk chunk
-INNER JOIN _timescaledb_catalog.hypertable hypertable ON (chunk.hypertable_id = hypertable.id)
-WHERE hypertable.table_name = 'readings' and chunk.compressed_chunk_id IS NULL;
+SELECT count(compress_chunk(ch)) FROM show_chunks('readings') ch;
  count 
 -------
    703

--- a/tsl/test/expected/transparent_decompression_ordered_index-13.out
+++ b/tsl/test/expected/transparent_decompression_ordered_index-13.out
@@ -75,19 +75,11 @@ INSERT INTO nodetime
 \set PREFIX_VERBOSE ''
 \set ECHO none
 --compress all chunks for metrics_ordered_idx table --
-SELECT compress_chunk (c.schema_name || '.' || c.table_name)
-FROM _timescaledb_catalog.chunk c
-    INNER JOIN _timescaledb_catalog.hypertable ht ON c.hypertable_id = ht.id
-WHERE ht.table_name = 'metrics_ordered_idx'
-ORDER BY c.id;
-             compress_chunk             
-----------------------------------------
- _timescaledb_internal._hyper_1_1_chunk
- _timescaledb_internal._hyper_1_2_chunk
- _timescaledb_internal._hyper_1_3_chunk
- _timescaledb_internal._hyper_1_4_chunk
- _timescaledb_internal._hyper_1_5_chunk
-(5 rows)
+SELECT count(compress_chunk(ch)) FROM show_chunks('metrics_ordered_idx') ch;
+ count 
+-------
+     5
+(1 row)
 
 -- reindexing compressed hypertable to update statistics
 DO
@@ -141,15 +133,10 @@ SELECT create_hypertable('metrics_ordered_idx2','time', chunk_time_interval=>'2d
 
 ALTER TABLE metrics_ordered_idx2 SET (timescaledb.compress, timescaledb.compress_orderby='time ASC, v0 desc',timescaledb.compress_segmentby='device_id,device_id_peer');
 INSERT INTO metrics_ordered_idx2(time,device_id,device_id_peer,v0, v1) SELECT generate_series('2000-01-20 0:00:00+0'::timestamptz,'2000-01-20 11:55:00+0','10s') , 3, 3, generate_series(1,5,1) , generate_series(555,559,1);
-SELECT
-  compress_chunk(c.schema_name || '.' || c.table_name)
-FROM _timescaledb_catalog.chunk c
-  INNER JOIN _timescaledb_catalog.hypertable ht ON c.hypertable_id=ht.id
-WHERE ht.table_name = 'metrics_ordered_idx2'
-ORDER BY c.id;
-             compress_chunk              
------------------------------------------
- _timescaledb_internal._hyper_3_11_chunk
+SELECT count(compress_chunk(ch)) FROM show_chunks('metrics_ordered_idx2') ch;
+ count 
+-------
+     1
 (1 row)
 
 --all queries have only prefix of compress_orderby in ORDER BY clause

--- a/tsl/test/expected/transparent_decompression_ordered_index-14.out
+++ b/tsl/test/expected/transparent_decompression_ordered_index-14.out
@@ -75,19 +75,11 @@ INSERT INTO nodetime
 \set PREFIX_VERBOSE ''
 \set ECHO none
 --compress all chunks for metrics_ordered_idx table --
-SELECT compress_chunk (c.schema_name || '.' || c.table_name)
-FROM _timescaledb_catalog.chunk c
-    INNER JOIN _timescaledb_catalog.hypertable ht ON c.hypertable_id = ht.id
-WHERE ht.table_name = 'metrics_ordered_idx'
-ORDER BY c.id;
-             compress_chunk             
-----------------------------------------
- _timescaledb_internal._hyper_1_1_chunk
- _timescaledb_internal._hyper_1_2_chunk
- _timescaledb_internal._hyper_1_3_chunk
- _timescaledb_internal._hyper_1_4_chunk
- _timescaledb_internal._hyper_1_5_chunk
-(5 rows)
+SELECT count(compress_chunk(ch)) FROM show_chunks('metrics_ordered_idx') ch;
+ count 
+-------
+     5
+(1 row)
 
 -- reindexing compressed hypertable to update statistics
 DO
@@ -141,15 +133,10 @@ SELECT create_hypertable('metrics_ordered_idx2','time', chunk_time_interval=>'2d
 
 ALTER TABLE metrics_ordered_idx2 SET (timescaledb.compress, timescaledb.compress_orderby='time ASC, v0 desc',timescaledb.compress_segmentby='device_id,device_id_peer');
 INSERT INTO metrics_ordered_idx2(time,device_id,device_id_peer,v0, v1) SELECT generate_series('2000-01-20 0:00:00+0'::timestamptz,'2000-01-20 11:55:00+0','10s') , 3, 3, generate_series(1,5,1) , generate_series(555,559,1);
-SELECT
-  compress_chunk(c.schema_name || '.' || c.table_name)
-FROM _timescaledb_catalog.chunk c
-  INNER JOIN _timescaledb_catalog.hypertable ht ON c.hypertable_id=ht.id
-WHERE ht.table_name = 'metrics_ordered_idx2'
-ORDER BY c.id;
-             compress_chunk              
------------------------------------------
- _timescaledb_internal._hyper_3_11_chunk
+SELECT count(compress_chunk(ch)) FROM show_chunks('metrics_ordered_idx2') ch;
+ count 
+-------
+     1
 (1 row)
 
 --all queries have only prefix of compress_orderby in ORDER BY clause

--- a/tsl/test/expected/transparent_decompression_ordered_index-15.out
+++ b/tsl/test/expected/transparent_decompression_ordered_index-15.out
@@ -75,19 +75,11 @@ INSERT INTO nodetime
 \set PREFIX_VERBOSE ''
 \set ECHO none
 --compress all chunks for metrics_ordered_idx table --
-SELECT compress_chunk (c.schema_name || '.' || c.table_name)
-FROM _timescaledb_catalog.chunk c
-    INNER JOIN _timescaledb_catalog.hypertable ht ON c.hypertable_id = ht.id
-WHERE ht.table_name = 'metrics_ordered_idx'
-ORDER BY c.id;
-             compress_chunk             
-----------------------------------------
- _timescaledb_internal._hyper_1_1_chunk
- _timescaledb_internal._hyper_1_2_chunk
- _timescaledb_internal._hyper_1_3_chunk
- _timescaledb_internal._hyper_1_4_chunk
- _timescaledb_internal._hyper_1_5_chunk
-(5 rows)
+SELECT count(compress_chunk(ch)) FROM show_chunks('metrics_ordered_idx') ch;
+ count 
+-------
+     5
+(1 row)
 
 -- reindexing compressed hypertable to update statistics
 DO
@@ -141,15 +133,10 @@ SELECT create_hypertable('metrics_ordered_idx2','time', chunk_time_interval=>'2d
 
 ALTER TABLE metrics_ordered_idx2 SET (timescaledb.compress, timescaledb.compress_orderby='time ASC, v0 desc',timescaledb.compress_segmentby='device_id,device_id_peer');
 INSERT INTO metrics_ordered_idx2(time,device_id,device_id_peer,v0, v1) SELECT generate_series('2000-01-20 0:00:00+0'::timestamptz,'2000-01-20 11:55:00+0','10s') , 3, 3, generate_series(1,5,1) , generate_series(555,559,1);
-SELECT
-  compress_chunk(c.schema_name || '.' || c.table_name)
-FROM _timescaledb_catalog.chunk c
-  INNER JOIN _timescaledb_catalog.hypertable ht ON c.hypertable_id=ht.id
-WHERE ht.table_name = 'metrics_ordered_idx2'
-ORDER BY c.id;
-             compress_chunk              
------------------------------------------
- _timescaledb_internal._hyper_3_11_chunk
+SELECT count(compress_chunk(ch)) FROM show_chunks('metrics_ordered_idx2') ch;
+ count 
+-------
+     1
 (1 row)
 
 --all queries have only prefix of compress_orderby in ORDER BY clause

--- a/tsl/test/expected/transparent_decompression_ordered_index-16.out
+++ b/tsl/test/expected/transparent_decompression_ordered_index-16.out
@@ -75,19 +75,11 @@ INSERT INTO nodetime
 \set PREFIX_VERBOSE ''
 \set ECHO none
 --compress all chunks for metrics_ordered_idx table --
-SELECT compress_chunk (c.schema_name || '.' || c.table_name)
-FROM _timescaledb_catalog.chunk c
-    INNER JOIN _timescaledb_catalog.hypertable ht ON c.hypertable_id = ht.id
-WHERE ht.table_name = 'metrics_ordered_idx'
-ORDER BY c.id;
-             compress_chunk             
-----------------------------------------
- _timescaledb_internal._hyper_1_1_chunk
- _timescaledb_internal._hyper_1_2_chunk
- _timescaledb_internal._hyper_1_3_chunk
- _timescaledb_internal._hyper_1_4_chunk
- _timescaledb_internal._hyper_1_5_chunk
-(5 rows)
+SELECT count(compress_chunk(ch)) FROM show_chunks('metrics_ordered_idx') ch;
+ count 
+-------
+     5
+(1 row)
 
 -- reindexing compressed hypertable to update statistics
 DO
@@ -141,15 +133,10 @@ SELECT create_hypertable('metrics_ordered_idx2','time', chunk_time_interval=>'2d
 
 ALTER TABLE metrics_ordered_idx2 SET (timescaledb.compress, timescaledb.compress_orderby='time ASC, v0 desc',timescaledb.compress_segmentby='device_id,device_id_peer');
 INSERT INTO metrics_ordered_idx2(time,device_id,device_id_peer,v0, v1) SELECT generate_series('2000-01-20 0:00:00+0'::timestamptz,'2000-01-20 11:55:00+0','10s') , 3, 3, generate_series(1,5,1) , generate_series(555,559,1);
-SELECT
-  compress_chunk(c.schema_name || '.' || c.table_name)
-FROM _timescaledb_catalog.chunk c
-  INNER JOIN _timescaledb_catalog.hypertable ht ON c.hypertable_id=ht.id
-WHERE ht.table_name = 'metrics_ordered_idx2'
-ORDER BY c.id;
-             compress_chunk              
------------------------------------------
- _timescaledb_internal._hyper_3_11_chunk
+SELECT count(compress_chunk(ch)) FROM show_chunks('metrics_ordered_idx2') ch;
+ count 
+-------
+     1
 (1 row)
 
 --all queries have only prefix of compress_orderby in ORDER BY clause

--- a/tsl/test/expected/transparent_decompression_queries.out
+++ b/tsl/test/expected/transparent_decompression_queries.out
@@ -67,12 +67,7 @@ ALTER TABLE merge_sort SET (timescaledb.compress = true, timescaledb.compress_or
 INSERT INTO merge_sort SELECT time, 1, 1, extract(epoch from time) * 0.001 FROM generate_series('2000-01-01'::timestamp,'2000-02-01'::timestamp,'1h'::interval) g1(time);
 ANALYZE merge_sort;
 --compress first chunk
-SELECT
-  compress_chunk(c.schema_name || '.' || c.table_name)
-FROM _timescaledb_catalog.chunk c
-  INNER JOIN _timescaledb_catalog.hypertable ht ON c.hypertable_id=ht.id
-WHERE ht.table_name = 'merge_sort'
-ORDER BY c.id LIMIT 1;
+SELECT compress_chunk(ch) FROM show_chunks('merge_sort') ch LIMIT 1;
              compress_chunk             
 ----------------------------------------
  _timescaledb_internal._hyper_3_5_chunk

--- a/tsl/test/shared/expected/compression_dml.out
+++ b/tsl/test/shared/expected/compression_dml.out
@@ -50,9 +50,7 @@ SELECT '2022-10-10 14:33:44.1234+05:30' as start_date \gset
 INSERT INTO metric_5m (time, series_id, value)
     SELECT t, s,1 from generate_series(:'start_date'::timestamptz, :'start_date'::timestamptz + interval '1 day', '10s') t cross join generate_series(1,10, 1) s;
 -- manually compress all chunks
-SELECT count(compress_chunk(c.schema_name|| '.' || c.table_name))
-    FROM _timescaledb_catalog.chunk c, _timescaledb_catalog.hypertable ht where
-    c.hypertable_id = ht.id and ht.table_name = 'metric_5m' and c.compressed_chunk_id IS NULL;
+SELECT count(compress_chunk(c)) FROM show_chunks('metric_5m') c;
  count 
    289
 (1 row)

--- a/tsl/test/shared/sql/compression_dml.sql
+++ b/tsl/test/shared/sql/compression_dml.sql
@@ -44,9 +44,7 @@ SELECT '2022-10-10 14:33:44.1234+05:30' as start_date \gset
 INSERT INTO metric_5m (time, series_id, value)
     SELECT t, s,1 from generate_series(:'start_date'::timestamptz, :'start_date'::timestamptz + interval '1 day', '10s') t cross join generate_series(1,10, 1) s;
 -- manually compress all chunks
-SELECT count(compress_chunk(c.schema_name|| '.' || c.table_name))
-    FROM _timescaledb_catalog.chunk c, _timescaledb_catalog.hypertable ht where
-    c.hypertable_id = ht.id and ht.table_name = 'metric_5m' and c.compressed_chunk_id IS NULL;
+SELECT count(compress_chunk(c)) FROM show_chunks('metric_5m') c;
 
 -- populate into compressed hypertable, this should not crash
 INSERT INTO metric_5m (time, series_id, value)

--- a/tsl/test/shared/sql/include/shared_setup.sql
+++ b/tsl/test/shared/sql/include/shared_setup.sql
@@ -57,9 +57,8 @@ ANALYZE metrics_compressed;
 
 -- compress chunks
 ALTER TABLE metrics_compressed SET (timescaledb.compress, timescaledb.compress_orderby='time DESC', timescaledb.compress_segmentby='device_id');
-SELECT compress_chunk(c.schema_name|| '.' || c.table_name)
-FROM _timescaledb_catalog.chunk c, _timescaledb_catalog.hypertable ht where c.hypertable_id = ht.id and ht.table_name = 'metrics_compressed' and c.compressed_chunk_id IS NULL
-ORDER BY c.table_name DESC;
+SELECT compress_chunk(show_chunks('metrics_compressed'));
+
 -- Reindexing compressed hypertable to update statistics
 -- this is for planner tests which depend on them
 -- necessary because this operation was previously done by compress_chunk
@@ -81,9 +80,8 @@ ANALYZE metrics_space_compressed;
 
 -- compress chunks
 ALTER TABLE metrics_space_compressed SET (timescaledb.compress, timescaledb.compress_orderby='time DESC', timescaledb.compress_segmentby='device_id');
-SELECT compress_chunk(c.schema_name|| '.' || c.table_name)
-FROM _timescaledb_catalog.chunk c, _timescaledb_catalog.hypertable ht where c.hypertable_id = ht.id and ht.table_name = 'metrics_space_compressed' and c.compressed_chunk_id IS NULL
-ORDER BY c.table_name DESC;
+SELECT compress_chunk(show_chunks('metrics_space_compressed'));
+
 -- Reindexing compressed hypertable to update statistics
 -- this is for planner tests which depend on them
 -- necessary because this operation was previously done by compress_chunk

--- a/tsl/test/sql/compress_bgw_reorder_drop_chunks.sql
+++ b/tsl/test/sql/compress_bgw_reorder_drop_chunks.sql
@@ -60,10 +60,7 @@ SELECT * FROM _timescaledb_config.bgw_job where id=:retention_job_id;
 
 --turn on compression and compress all chunks
 ALTER TABLE test_retention_table set (timescaledb.compress, timescaledb.compress_orderby = 'time DESC');
-SELECT count(compress_chunk(chunk.schema_name|| '.' || chunk.table_name)) as count_compressed
-FROM _timescaledb_catalog.chunk chunk
-INNER JOIN _timescaledb_catalog.hypertable hypertable ON (chunk.hypertable_id = hypertable.id)
-WHERE hypertable.table_name like 'test_retention_table' and chunk.compressed_chunk_id IS NULL;
+SELECT count(compress_chunk(ch)) FROM show_chunks('test_retention_table') ch;
 
 --make sure same # of compressed and uncompressed chunks before policy
 SELECT count(*) as count_chunks_uncompressed

--- a/tsl/test/sql/compressed_collation.sql
+++ b/tsl/test/sql/compressed_collation.sql
@@ -24,11 +24,7 @@ alter table compressed_collation_ht set (timescaledb.compress,
 insert into compressed_collation_ht values ('2021-01-01 01:01:01', 'á', '1'),
     ('2021-01-01 01:01:02', 'b', '2'), ('2021-01-01 01:01:03', 'ç', '2');
 
-select 1 from (
-	select compress_chunk(chunk_schema || '.' || chunk_name)
-	from timescaledb_information.chunks
-	where hypertable_name = 'compressed_collation_ht'
-) t;
+SELECT count(compress_chunk(ch)) FROM show_chunks('compressed_collation_ht') ch;
 
 select ht.schema_name || '.' || ht.table_name as "CHUNK"
 from _timescaledb_catalog.hypertable ht

--- a/tsl/test/sql/compression_errors.sql.in
+++ b/tsl/test/sql/compression_errors.sql.in
@@ -117,15 +117,15 @@ ALTER TABLE foo DROP CONSTRAINT chk_existing;
 --note that the time column "a" should not be added to the end of the order by list again (should appear first)
 select hc.* from _timescaledb_catalog.hypertable_compression hc inner join _timescaledb_catalog.hypertable h on (h.id = hc.hypertable_id) where h.table_name = 'foo' order by attname;
 
-select decompress_chunk(ch1.schema_name|| '.' || ch1.table_name)
-FROM _timescaledb_catalog.chunk ch1, _timescaledb_catalog.hypertable ht where ch1.hypertable_id = ht.id and ht.table_name like 'foo' ORDER BY ch1.id limit 1;
+SELECT decompress_chunk(ch) FROM show_chunks('foo') ch limit 1;
 
 --test changing the segment by columns
 ALTER TABLE foo set (timescaledb.compress, timescaledb.compress_orderby = 'a', timescaledb.compress_segmentby = 'b');
 
-select ch1.schema_name|| '.' || ch1.table_name AS "CHUNK_NAME"
-FROM _timescaledb_catalog.chunk ch1, _timescaledb_catalog.hypertable ht where ch1.hypertable_id = ht.id and ht.table_name like 'foo' ORDER BY ch1.id limit 1 \gset
-
+SELECT format('%I.%I',chunk_schema,chunk_name) AS "CHUNK_NAME"
+FROM timescaledb_information.chunks
+WHERE hypertable_name = 'foo'
+ORDER BY chunk_name LIMIT 1\gset
 
 select decompress_chunk(:'CHUNK_NAME');
 select decompress_chunk(:'CHUNK_NAME', if_compressed=>true);
@@ -135,19 +135,16 @@ select compress_chunk(:'CHUNK_NAME');
 select compress_chunk(:'CHUNK_NAME');
 select compress_chunk(:'CHUNK_NAME', if_not_compressed=>true);
 
-select compress_chunk(ch1.schema_name|| '.' || ch1.table_name)
-FROM _timescaledb_catalog.chunk ch1, _timescaledb_catalog.hypertable ht where ch1.hypertable_id = ht.id and ht.table_name like 'non_compressed' ORDER BY ch1.id limit 1;
+SELECT compress_chunk(ch) FROM show_chunks('non_compressed') ch LIMIT 1;
 
 ALTER TABLE foo set (timescaledb.compress, timescaledb.compress_orderby = 'a', timescaledb.compress_segmentby = 'c');
 ALTER TABLE foo set (timescaledb.compress='f');
 ALTER TABLE foo reset (timescaledb.compress);
 
-select decompress_chunk(ch1.schema_name|| '.' || ch1.table_name)
-FROM _timescaledb_catalog.chunk ch1, _timescaledb_catalog.hypertable ht where ch1.hypertable_id = ht.id and ht.table_name like 'non_compressed' ORDER BY ch1.id limit 1;
+SELECT decompress_chunk(ch) FROM show_chunks('non_compressed') ch LIMIT 1;
 
 --should succeed
-select decompress_chunk(ch1.schema_name|| '.' || ch1.table_name)
-FROM _timescaledb_catalog.chunk ch1, _timescaledb_catalog.hypertable ht where ch1.hypertable_id = ht.id and ht.table_name like 'foo' and ch1.compressed_chunk_id IS NOT NULL;
+SELECT decompress_chunk(ch, true) FROM show_chunks('foo') ch;
 
 --should succeed
 ALTER TABLE foo set (timescaledb.compress, timescaledb.compress_orderby = 'a', timescaledb.compress_segmentby = 'b');

--- a/tsl/test/sql/compression_permissions.sql
+++ b/tsl/test/sql/compression_permissions.sql
@@ -59,10 +59,8 @@ alter table conditions set (timescaledb.compress, timescaledb.compress_segmentby
 
 --- compress_chunks and decompress_chunks fail without correct perm --
 \c :TEST_DBNAME :ROLE_DEFAULT_PERM_USER_2
-select  compress_chunk(ch1.schema_name|| '.' || ch1.table_name)
-FROM _timescaledb_catalog.chunk ch1, _timescaledb_catalog.hypertable ht where ch1.hypertable_id = ht.id and ht.table_name like 'conditions' and ch1.compressed_chunk_id IS NULL;
-select decompress_chunk(ch1.schema_name|| '.' || ch1.table_name)
-FROM _timescaledb_catalog.chunk ch1, _timescaledb_catalog.hypertable ht where ch1.hypertable_id = ht.id and ht.table_name like 'conditions';
+SELECT compress_chunk(show_chunks('conditions'));
+SELECT decompress_chunk(show_chunks('conditions'));
 select add_compression_policy('conditions', '1day'::interval);
 
 \c :TEST_DBNAME :ROLE_DEFAULT_PERM_USER
@@ -75,9 +73,7 @@ select remove_compression_policy('conditions', true);
 -- as owner grant select , compress chunk and check SELECT works
 \c :TEST_DBNAME :ROLE_DEFAULT_PERM_USER
 GRANT SELECT on conditions to :ROLE_DEFAULT_PERM_USER_2;
-select count(*) from
-(select  compress_chunk(ch1.schema_name|| '.' || ch1.table_name)
-FROM _timescaledb_catalog.chunk ch1, _timescaledb_catalog.hypertable ht where ch1.hypertable_id = ht.id and ht.table_name like 'conditions' and ch1.compressed_chunk_id IS NULL ) as subq;
+SELECT count(compress_chunk(ch)) FROM show_chunks('conditions') ch;
 \c :TEST_DBNAME :ROLE_DEFAULT_PERM_USER_2
 select count(*) from conditions;
 

--- a/tsl/test/sql/continuous_aggs.sql.in
+++ b/tsl/test/sql/continuous_aggs.sql.in
@@ -1156,7 +1156,7 @@ ORDER BY 1, 2, 3;
 ALTER MATERIALIZED VIEW search_query_count_3 SET (timescaledb.compress = 'false');
 \set ON_ERROR_STOP 1
 
-SELECT decompress_chunk(schema_name || '.' || table_name)
+SELECT decompress_chunk(format('%I.%I', schema_name, table_name))
 FROM _timescaledb_catalog.chunk
 WHERE hypertable_id = :'MAT_HTID' and status = 1;
 

--- a/tsl/test/sql/continuous_aggs_deprecated.sql.in
+++ b/tsl/test/sql/continuous_aggs_deprecated.sql.in
@@ -1160,7 +1160,7 @@ ORDER BY 1, 2, 3;
 ALTER MATERIALIZED VIEW search_query_count_3 SET (timescaledb.compress = 'false');
 \set ON_ERROR_STOP 1
 
-SELECT decompress_chunk(schema_name || '.' || table_name)
+SELECT decompress_chunk(format('%I.%I', schema_name, table_name))
 FROM _timescaledb_catalog.chunk
 WHERE hypertable_id = :'MAT_HTID' and status = 1;
 

--- a/tsl/test/sql/dist_compression.sql.in
+++ b/tsl/test/sql/dist_compression.sql.in
@@ -192,15 +192,7 @@ SELECT count(*) from compressed where new_coli is not null;
 INSERT INTO compressed
 SELECT '2019-08-01 00:00',  100, 100, 1, 'newcolv' ;
 
-SELECT COUNT(*) AS count_compressed
-FROM
-(
-SELECT compress_chunk(chunk.schema_name|| '.' || chunk.table_name, true)
-FROM _timescaledb_catalog.chunk chunk
-INNER JOIN _timescaledb_catalog.hypertable hypertable ON (chunk.hypertable_id = hypertable.id)
-WHERE hypertable.table_name like 'compressed' and chunk.compressed_chunk_id IS NULL ORDER BY chunk.id
-)
-AS sub;
+SELECT count(compress_chunk('compressed',true));
 
 SELECT * from compressed where new_coli is not null;
 

--- a/tsl/test/sql/include/compression_test_hypertable_segment_meta.sql
+++ b/tsl/test/sql/include/compression_test_hypertable_segment_meta.sql
@@ -7,10 +7,7 @@
 SELECT 'NULL::'||:'TYPE' as "NULLTYPE" \gset
 
 --compress the data
-SELECT count(compress_chunk(chunk.schema_name|| '.' || chunk.table_name)) as count_compressed
-FROM _timescaledb_catalog.chunk chunk
-INNER JOIN _timescaledb_catalog.hypertable hypertable ON (chunk.hypertable_id = hypertable.id)
-WHERE hypertable.table_name like :'HYPERTABLE_NAME' and chunk.compressed_chunk_id IS NULL;
+SELECT count(compress_chunk(ch, true)) FROM show_chunks(:'HYPERTABLE_NAME') ch;
 
 SELECT
     comp_hypertable.schema_name AS "COMP_SCHEMA_NAME",

--- a/tsl/test/sql/include/compression_test_merge.sql
+++ b/tsl/test/sql/include/compression_test_merge.sql
@@ -22,11 +22,7 @@ FROM original
 FULL OUTER JOIN compressed ON (original.row_number = compressed.row_number)
 WHERE (original.*) IS DISTINCT FROM (compressed.*);
 
-SELECT count(decompress_chunk(chunk.schema_name|| '.' || chunk.table_name)) as count_decompressed
-FROM _timescaledb_catalog.chunk chunk
-INNER JOIN _timescaledb_catalog.hypertable hypertable ON (chunk.hypertable_id = hypertable.id)
-WHERE hypertable.table_name like :'HYPERTABLE_NAME' and chunk.compressed_chunk_id IS NOT NULL;
-
+SELECT count(decompress_chunk(ch)) FROM show_chunks(:'HYPERTABLE_NAME') ch;
 
 --run data on data that's been compressed and decompressed, make sure it's the same.
 with original AS (

--- a/tsl/test/sql/include/transparent_decompression_ordered.sql
+++ b/tsl/test/sql/include/transparent_decompression_ordered.sql
@@ -15,12 +15,8 @@ CREATE INDEX ON metrics_ordered(device_id,time);
 CREATE INDEX ON metrics_ordered(device_id_peer,time);
 
 -- compress all chunks
-SELECT
-  compress_chunk(c.schema_name || '.' || c.table_name)
-FROM _timescaledb_catalog.chunk c
-  INNER JOIN _timescaledb_catalog.hypertable ht ON c.hypertable_id=ht.id
-WHERE ht.table_name = 'metrics_ordered'
-ORDER BY c.id;
+SELECT count(compress_chunk(ch)) FROM show_chunks('metrics_ordered') ch;
+
 -- reindexing compressed hypertable to update statistics
 DO
 $$

--- a/tsl/test/sql/include/transparent_decompression_ordered_indexplan.sql
+++ b/tsl/test/sql/include/transparent_decompression_ordered_indexplan.sql
@@ -10,12 +10,7 @@ SELECT create_hypertable('metrics_ordered_idx2','time', chunk_time_interval=>'2d
 ALTER TABLE metrics_ordered_idx2 SET (timescaledb.compress, timescaledb.compress_orderby='time ASC, v0 desc',timescaledb.compress_segmentby='device_id,device_id_peer');
 INSERT INTO metrics_ordered_idx2(time,device_id,device_id_peer,v0, v1) SELECT generate_series('2000-01-20 0:00:00+0'::timestamptz,'2000-01-20 11:55:00+0','10s') , 3, 3, generate_series(1,5,1) , generate_series(555,559,1);
 
-SELECT
-  compress_chunk(c.schema_name || '.' || c.table_name)
-FROM _timescaledb_catalog.chunk c
-  INNER JOIN _timescaledb_catalog.hypertable ht ON c.hypertable_id=ht.id
-WHERE ht.table_name = 'metrics_ordered_idx2'
-ORDER BY c.id;
+SELECT count(compress_chunk(ch)) FROM show_chunks('metrics_ordered_idx2') ch;
 
 --all queries have only prefix of compress_orderby in ORDER BY clause
 

--- a/tsl/test/sql/include/transparent_decompression_undiffed.sql
+++ b/tsl/test/sql/include/transparent_decompression_undiffed.sql
@@ -14,10 +14,7 @@ ALTER TABLE readings SET (timescaledb.compress, timescaledb.compress_segmentby =
 
 INSERT into readings select g, 1, 1.3 from generate_series('2001-03-01 01:01:01', '2003-02-01 01:01:01', '1 day'::interval) g;
 
-SELECT count(compress_chunk(chunk.schema_name|| '.' || chunk.table_name))
-FROM _timescaledb_catalog.chunk chunk
-INNER JOIN _timescaledb_catalog.hypertable hypertable ON (chunk.hypertable_id = hypertable.id)
-WHERE hypertable.table_name = 'readings' and chunk.compressed_chunk_id IS NULL;
+SELECT count(compress_chunk(ch)) FROM show_chunks('readings') ch;
 
 EXPLAIN (costs off) SELECT t.fleet as fleet, min(r.fuel_consumption) AS avg_fuel_consumption
 FROM tags t

--- a/tsl/test/sql/merge_compress.sql
+++ b/tsl/test/sql/merge_compress.sql
@@ -27,9 +27,7 @@ INSERT INTO target (series_id, value, partition_column)
     generate_series(1,3, 1) s;
 
 -- compress chunks
-SELECT count(compress_chunk(c.schema_name|| '.' || c.table_name))
-  FROM _timescaledb_catalog.chunk c, _timescaledb_catalog.hypertable ht where
-    c.hypertable_id = ht.id and ht.table_name = 'target' and c.compressed_chunk_id IS NULL;
+SELECT count(compress_chunk(ch)) FROM show_chunks('target') ch;
 
 CREATE TABLE source (
         time TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP NOT NULL,

--- a/tsl/test/sql/transparent_decompression_ordered_index.sql.in
+++ b/tsl/test/sql/transparent_decompression_ordered_index.sql.in
@@ -92,11 +92,8 @@ RESET client_min_messages;
 
 \set ECHO all
 --compress all chunks for metrics_ordered_idx table --
-SELECT compress_chunk (c.schema_name || '.' || c.table_name)
-FROM _timescaledb_catalog.chunk c
-    INNER JOIN _timescaledb_catalog.hypertable ht ON c.hypertable_id = ht.id
-WHERE ht.table_name = 'metrics_ordered_idx'
-ORDER BY c.id;
+SELECT count(compress_chunk(ch)) FROM show_chunks('metrics_ordered_idx') ch;
+
 -- reindexing compressed hypertable to update statistics
 DO
 $$

--- a/tsl/test/sql/transparent_decompression_queries.sql
+++ b/tsl/test/sql/transparent_decompression_queries.sql
@@ -38,12 +38,7 @@ INSERT INTO merge_sort SELECT time, 1, 1, extract(epoch from time) * 0.001 FROM 
 ANALYZE merge_sort;
 
 --compress first chunk
-SELECT
-  compress_chunk(c.schema_name || '.' || c.table_name)
-FROM _timescaledb_catalog.chunk c
-  INNER JOIN _timescaledb_catalog.hypertable ht ON c.hypertable_id=ht.id
-WHERE ht.table_name = 'merge_sort'
-ORDER BY c.id LIMIT 1;
+SELECT compress_chunk(ch) FROM show_chunks('merge_sort') ch LIMIT 1;
 
 -- this should have a MergeAppend with children wrapped in Sort nodes
 EXPLAIN (analyze,costs off,timing off,summary off) SELECT


### PR DESCRIPTION
Dont construct chunk names from internal catalog tables in tests but instead use show_chunks and the informational views.

Disable-check: force-changelog-file
