### PR TITLE
Fix compression for tables with large oids

### DIFF
--- a/.unreleased/pr_6275
+++ b/.unreleased/pr_6275
@@ -1,0 +1,3 @@
+Fixes: #6275 Fix negative bitmapset member not allowed in compression
+
+Thanks: @torazem for reporting an issue with compression and large oids


### PR DESCRIPTION
Oids should not be stored in Bitmapsets as storing Oids that way is very inefficient and may potentially consume a lot of memory depending on the values of the oids. Storing them as list is more efficient instead.

Fixes #6252 