### PR TITLE
PG16: Fix telemetry tests without OpenSSL

### DIFF
--- a/test/src/telemetry/test_telemetry.c
+++ b/test/src/telemetry/test_telemetry.c
@@ -116,8 +116,7 @@ ts_test_status_ssl(PG_FUNCTION_ARGS)
 
 	snprintf(buf, sizeof(buf) - 1, "{\"status\":%d}", status);
 
-	PG_RETURN_JSONB_P(DirectFunctionCall1(jsonb_in, CStringGetDatum(buf)));
-	;
+	PG_RETURN_JSONB_P(DatumGetJsonbP(DirectFunctionCall1(jsonb_in, CStringGetDatum(buf))));
 #endif
 }
 


### PR DESCRIPTION
Telemetry tests without OpenSSL was failing to build because PG16 converted the *GetDatum() and DatumGet*() macros to inline functions that enable compiler to catch wrong usage of Datums.

postgres/postgres@c8b2ef0

Disable-check: force-changelog-file
