### PR TITLE
PG16: Fix join recursion

### DIFF
--- a/tsl/test/shared/expected/decompress_join.out
+++ b/tsl/test/shared/expected/decompress_join.out
@@ -60,3 +60,12 @@ SELECT * FROM partial_join m1 INNER JOIN partial_join m2 ON m1.device = m2.devic
 (4 rows)
 
 DROP TABLE partial_join;
+-- This resulted in a recursion in the join planner code on PG16
+SELECT * FROM metrics_tstz as m
+INNER JOIN metrics_space as ms on (true)
+INNER JOIN metrics_space_compressed as msc on (true)
+WHERE CASE WHEN m.device_id is not NULL and ms.v2 is not NULL THEN NULL::int2 end = msc.device_id;
+ time | device_id | v1 | v2 | time | device_id | v0 | v1 | v2 | v3 | time | device_id | v0 | v1 | v2 | v3 
+------+-----------+----+----+------+-----------+----+----+----+----+------+-----------+----+----+----+----
+(0 rows)
+

--- a/tsl/test/shared/sql/decompress_join.sql
+++ b/tsl/test/shared/sql/decompress_join.sql
@@ -35,3 +35,9 @@ SELECT * FROM partial_join m1 INNER JOIN partial_join m2 ON m1.device = m2.devic
 
 DROP TABLE partial_join;
 
+-- This resulted in a recursion in the join planner code on PG16
+SELECT * FROM metrics_tstz as m
+INNER JOIN metrics_space as ms on (true)
+INNER JOIN metrics_space_compressed as msc on (true)
+WHERE CASE WHEN m.device_id is not NULL and ms.v2 is not NULL THEN NULL::int2 end = msc.device_id;
+


### PR DESCRIPTION
The initial approach to mark EquivalenceMember as derived had some loopholes still leading to infinite recursion with certain join conditions.

Disable-check: force-changelog-file

