### PR TITLE
Use bulk heap insert API for decompression

### DIFF
--- a/src/guc.c
+++ b/src/guc.c
@@ -152,6 +152,7 @@ static const struct config_enum_entry require_vector_qual_options[] = {
 #endif
 
 DebugRequireVectorQual ts_guc_debug_require_vector_qual = RVQ_Allow;
+bool ts_guc_debug_compression_path_info = false;
 
 static bool ts_guc_enable_hypertable_create = true;
 static bool ts_guc_enable_hypertable_compression = true;
@@ -821,6 +822,17 @@ _guc_init(void)
 							 /* valueAddr= */ (int *) &ts_guc_debug_require_vector_qual,
 							 /* bootValue= */ RVQ_Allow,
 							 /* options = */ require_vector_qual_options,
+							 /* context= */ PGC_USERSET,
+							 /* flags= */ 0,
+							 /* check_hook= */ NULL,
+							 /* assign_hook= */ NULL,
+							 /* show_hook= */ NULL);
+
+	DefineCustomBoolVariable(/* name= */ "timescaledb.debug_compression_path_info",
+							 /* short_desc= */ "show various compression-related debug info",
+							 /* long_desc= */ "this is for debugging purposes",
+							 /* valueAddr= */ &ts_guc_debug_compression_path_info,
+							 /* bootValue= */ false,
 							 /* context= */ PGC_USERSET,
 							 /* flags= */ 0,
 							 /* check_hook= */ NULL,

--- a/src/guc.h
+++ b/src/guc.h
@@ -124,6 +124,8 @@ typedef enum DebugRequireVectorQual
 
 extern TSDLLEXPORT DebugRequireVectorQual ts_guc_debug_require_vector_qual;
 
+extern TSDLLEXPORT bool ts_guc_debug_compression_path_info;
+
 extern TSDLLEXPORT bool ts_guc_debug_require_batch_sorted_merge;
 
 void _guc_init(void);

--- a/tsl/src/compression/api.c
+++ b/tsl/src/compression/api.c
@@ -1484,7 +1484,7 @@ tsl_recompress_chunk_segmentwise(PG_FUNCTION_ARGS)
 							  decompressor.compressed_datums,
 							  decompressor.compressed_is_nulls);
 
-			row_decompressor_decompress_row(&decompressor, segment_tuplesortstate);
+			row_decompressor_decompress_row_to_tuplesort(&decompressor, segment_tuplesortstate);
 
 			simple_table_tuple_delete(compressed_chunk_rel, &(slot->tts_tid), snapshot);
 
@@ -1529,7 +1529,7 @@ tsl_recompress_chunk_segmentwise(PG_FUNCTION_ARGS)
 							  decompressor.compressed_datums,
 							  decompressor.compressed_is_nulls);
 
-			row_decompressor_decompress_row(&decompressor, segment_tuplesortstate);
+			row_decompressor_decompress_row_to_tuplesort(&decompressor, segment_tuplesortstate);
 
 			simple_table_tuple_delete(compressed_chunk_rel, &(slot->tts_tid), snapshot);
 			/* because this is the first tuple of the new segment */

--- a/tsl/test/expected/compress_default.out
+++ b/tsl/test/expected/compress_default.out
@@ -1,0 +1,72 @@
+-- This file and its contents are licensed under the Timescale License.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-TIMESCALE for a copy of the license.
+-- Use a weird compression configuration to test decompression of all-default
+-- batch.
+create table t(ts int);
+select create_hypertable('t', 'ts');
+NOTICE:  adding not-null constraint to column "ts"
+ create_hypertable 
+-------------------
+ (1,public,t,t)
+(1 row)
+
+alter table t set(timescaledb.compress, timescaledb.compress_segmentby = 'ts',
+    timescaledb.compress_orderby = '');
+insert into t select generate_series(1, 10000);
+select count(*) from t;
+ count 
+-------
+ 10000
+(1 row)
+
+select count(compress_chunk(x, true)) from show_chunks('t') x;
+ count 
+-------
+     1
+(1 row)
+
+select count(*) from t;
+ count 
+-------
+ 10000
+(1 row)
+
+select count(decompress_chunk(x, true)) from show_chunks('t') x;
+ count 
+-------
+     1
+(1 row)
+
+select count(*) from t;
+ count 
+-------
+ 10000
+(1 row)
+
+-- Now add a column which will be all default in the compressed chunk
+select count(compress_chunk(x, true)) from show_chunks('t') x;
+ count 
+-------
+     1
+(1 row)
+
+alter table t add column x int default 7;
+select count(*), x from t group by x;
+ count | x 
+-------+---
+ 10000 | 7
+(1 row)
+
+select count(decompress_chunk(x, true)) from show_chunks('t') x;
+ count 
+-------
+     1
+(1 row)
+
+select count(*), x from t group by x;
+ count | x 
+-------+---
+ 10000 | 7
+(1 row)
+

--- a/tsl/test/expected/compression_indexscan.out
+++ b/tsl/test/expected/compression_indexscan.out
@@ -2,7 +2,7 @@
 -- Please see the included NOTICE for copyright information and
 -- LICENSE-TIMESCALE for a copy of the license.
 --Enable compression path info
-SET timescaledb.show_compression_path_info= 'on';
+SET timescaledb.debug_compression_path_info= 'on';
 --Table creation
 CREATE TABLE tab1 (
     time timestamptz not null,
@@ -953,4 +953,4 @@ drop index predicate;
 DROP TABLE tab1;
 DROP TABLE tab2;
 DROP TABLE tab3;
-SET timescaledb.show_compression_path_info = 'off';
+SET timescaledb.debug_compression_path_info = 'off';

--- a/tsl/test/expected/compression_update_delete.out
+++ b/tsl/test/expected/compression_update_delete.out
@@ -1308,12 +1308,10 @@ FROM _timescaledb_catalog.chunk ch1, _timescaledb_catalog.hypertable ht
 WHERE ch1.hypertable_id = ht.id AND ch1.table_name LIKE 'compress_%'
 ORDER BY ch1.id LIMIT 1 \gset
 -- check that you uncompress and delete only for exact SEGMENTBY value
-SET client_min_messages TO DEBUG1;
+SET timescaledb.debug_compression_path_info TO true;
 BEGIN;
-LOG:  statement: BEGIN;
 -- report 10 rows
 SELECT COUNT(*) FROM :COMPRESS_CHUNK_1 where c4 = 5;
-LOG:  statement: SELECT COUNT(*) FROM _timescaledb_internal.compress_hyper_20_38_chunk where c4 = 5;
  count 
 -------
     10
@@ -1321,7 +1319,6 @@ LOG:  statement: SELECT COUNT(*) FROM _timescaledb_internal.compress_hyper_20_38
 
 -- report 10k rows
 SELECT COUNT(*) FROM sample_table WHERE c4 = 5;
-LOG:  statement: SELECT COUNT(*) FROM sample_table WHERE c4 = 5;
  count 
 -------
  10000
@@ -1329,16 +1326,12 @@ LOG:  statement: SELECT COUNT(*) FROM sample_table WHERE c4 = 5;
 
 -- fetch total and number of affected rows
 SELECT COUNT(*) AS "total_rows" FROM sample_table \gset
-LOG:  statement: SELECT COUNT(*) AS "total_rows" FROM sample_table 
 SELECT COUNT(*) AS "total_affected_rows" FROM sample_table WHERE c4 = 5 \gset
-LOG:  statement: SELECT COUNT(*) AS "total_affected_rows" FROM sample_table WHERE c4 = 5 
 -- delete 10k rows
 DELETE FROM sample_table WHERE c4 = 5;
-LOG:  statement: DELETE FROM sample_table WHERE c4 = 5;
-DEBUG:  Number of compressed rows fetched from index: 10. Number of compressed rows filtered by orderby columns: 0.
+INFO:  Number of compressed rows fetched from index: 10. Number of compressed rows filtered by orderby columns: 0.
 -- report 0 rows
 SELECT count(*) FROM sample_table WHERE c4 = 5;
-LOG:  statement: SELECT count(*) FROM sample_table WHERE c4 = 5;
  count 
 -------
      0
@@ -1346,7 +1339,6 @@ LOG:  statement: SELECT count(*) FROM sample_table WHERE c4 = 5;
 
 -- report 0 rows in uncompressed chunk
 SELECT COUNT(*) FROM ONLY :CHUNK_1;
-LOG:  statement: SELECT COUNT(*) FROM ONLY _timescaledb_internal._hyper_19_37_chunk;
  count 
 -------
      0
@@ -1354,7 +1346,6 @@ LOG:  statement: SELECT COUNT(*) FROM ONLY _timescaledb_internal._hyper_19_37_ch
 
 -- report 0 rows in compressed chunk
 SELECT COUNT(*) FROM :COMPRESS_CHUNK_1 where c4 = 5;
-LOG:  statement: SELECT COUNT(*) FROM _timescaledb_internal.compress_hyper_20_38_chunk where c4 = 5;
  count 
 -------
      0
@@ -1363,20 +1354,16 @@ LOG:  statement: SELECT COUNT(*) FROM _timescaledb_internal.compress_hyper_20_38
 -- validate correct number of rows was deleted
 -- report true
 SELECT COUNT(*) = :total_rows - :total_affected_rows FROM sample_table;
-LOG:  statement: SELECT COUNT(*) = 100000 - 10000 FROM sample_table;
  ?column? 
 ----------
  t
 (1 row)
 
 ROLLBACK;
-LOG:  statement: ROLLBACK;
 -- check that you uncompress and delete only for less than SEGMENTBY value
 BEGIN;
-LOG:  statement: BEGIN;
 -- report 50 rows
 SELECT COUNT(*) FROM :COMPRESS_CHUNK_1 where c4 < 5;
-LOG:  statement: SELECT COUNT(*) FROM _timescaledb_internal.compress_hyper_20_38_chunk where c4 < 5;
  count 
 -------
     50
@@ -1384,7 +1371,6 @@ LOG:  statement: SELECT COUNT(*) FROM _timescaledb_internal.compress_hyper_20_38
 
 -- report 50k rows
 SELECT COUNT(*) FROM sample_table WHERE c4 < 5;
-LOG:  statement: SELECT COUNT(*) FROM sample_table WHERE c4 < 5;
  count 
 -------
  50000
@@ -1392,16 +1378,12 @@ LOG:  statement: SELECT COUNT(*) FROM sample_table WHERE c4 < 5;
 
 -- fetch total and number of affected rows
 SELECT COUNT(*) AS "total_rows" FROM sample_table \gset
-LOG:  statement: SELECT COUNT(*) AS "total_rows" FROM sample_table 
 SELECT COUNT(*) AS "total_affected_rows" FROM sample_table WHERE c4 < 5 \gset
-LOG:  statement: SELECT COUNT(*) AS "total_affected_rows" FROM sample_table WHERE c4 < 5 
 -- delete 50k rows
 DELETE FROM sample_table WHERE c4 < 5;
-LOG:  statement: DELETE FROM sample_table WHERE c4 < 5;
-DEBUG:  Number of compressed rows fetched from index: 50. Number of compressed rows filtered by orderby columns: 0.
+INFO:  Number of compressed rows fetched from index: 50. Number of compressed rows filtered by orderby columns: 0.
 -- report 0 rows
 SELECT count(*) FROM sample_table WHERE c4 < 5;
-LOG:  statement: SELECT count(*) FROM sample_table WHERE c4 < 5;
  count 
 -------
      0
@@ -1409,7 +1391,6 @@ LOG:  statement: SELECT count(*) FROM sample_table WHERE c4 < 5;
 
 -- report 0 rows in uncompressed chunk
 SELECT COUNT(*) FROM ONLY :CHUNK_1;
-LOG:  statement: SELECT COUNT(*) FROM ONLY _timescaledb_internal._hyper_19_37_chunk;
  count 
 -------
      0
@@ -1417,7 +1398,6 @@ LOG:  statement: SELECT COUNT(*) FROM ONLY _timescaledb_internal._hyper_19_37_ch
 
 -- report 0 rows in compressed chunk
 SELECT COUNT(*) FROM :COMPRESS_CHUNK_1 where c4 < 5;
-LOG:  statement: SELECT COUNT(*) FROM _timescaledb_internal.compress_hyper_20_38_chunk where c4 < 5;
  count 
 -------
      0
@@ -1426,20 +1406,16 @@ LOG:  statement: SELECT COUNT(*) FROM _timescaledb_internal.compress_hyper_20_38
 -- validate correct number of rows was deleted
 -- report true
 SELECT COUNT(*) = :total_rows - :total_affected_rows FROM sample_table;
-LOG:  statement: SELECT COUNT(*) = 100000 - 50000 FROM sample_table;
  ?column? 
 ----------
  t
 (1 row)
 
 ROLLBACK;
-LOG:  statement: ROLLBACK;
 -- check that you uncompress and delete only for greater and equal than SEGMENTBY value
 BEGIN;
-LOG:  statement: BEGIN;
 -- report 50 rows
 SELECT COUNT(*) FROM :COMPRESS_CHUNK_1 where c4 >= 5;
-LOG:  statement: SELECT COUNT(*) FROM _timescaledb_internal.compress_hyper_20_38_chunk where c4 >= 5;
  count 
 -------
     50
@@ -1447,7 +1423,6 @@ LOG:  statement: SELECT COUNT(*) FROM _timescaledb_internal.compress_hyper_20_38
 
 -- report 50k rows
 SELECT COUNT(*) FROM sample_table WHERE c4 >= 5;
-LOG:  statement: SELECT COUNT(*) FROM sample_table WHERE c4 >= 5;
  count 
 -------
  50000
@@ -1455,16 +1430,12 @@ LOG:  statement: SELECT COUNT(*) FROM sample_table WHERE c4 >= 5;
 
 -- fetch total and number of affected rows
 SELECT COUNT(*) AS "total_rows" FROM sample_table \gset
-LOG:  statement: SELECT COUNT(*) AS "total_rows" FROM sample_table 
 SELECT COUNT(*) AS "total_affected_rows" FROM sample_table WHERE c4 >= 5 \gset
-LOG:  statement: SELECT COUNT(*) AS "total_affected_rows" FROM sample_table WHERE c4 >= 5 
 -- delete 50k rows
 DELETE FROM sample_table WHERE c4 >= 5;
-LOG:  statement: DELETE FROM sample_table WHERE c4 >= 5;
-DEBUG:  Number of compressed rows fetched from index: 50. Number of compressed rows filtered by orderby columns: 0.
+INFO:  Number of compressed rows fetched from index: 50. Number of compressed rows filtered by orderby columns: 0.
 -- report 0 rows
 SELECT count(*) FROM sample_table WHERE c4 >= 5;
-LOG:  statement: SELECT count(*) FROM sample_table WHERE c4 >= 5;
  count 
 -------
      0
@@ -1472,7 +1443,6 @@ LOG:  statement: SELECT count(*) FROM sample_table WHERE c4 >= 5;
 
 -- report 0 rows in uncompressed chunk
 SELECT COUNT(*) FROM ONLY :CHUNK_1;
-LOG:  statement: SELECT COUNT(*) FROM ONLY _timescaledb_internal._hyper_19_37_chunk;
  count 
 -------
      0
@@ -1480,7 +1450,6 @@ LOG:  statement: SELECT COUNT(*) FROM ONLY _timescaledb_internal._hyper_19_37_ch
 
 -- report 0 rows in compressed chunk
 SELECT COUNT(*) FROM :COMPRESS_CHUNK_1 where c4 >= 5;
-LOG:  statement: SELECT COUNT(*) FROM _timescaledb_internal.compress_hyper_20_38_chunk where c4 >= 5;
  count 
 -------
      0
@@ -1489,21 +1458,17 @@ LOG:  statement: SELECT COUNT(*) FROM _timescaledb_internal.compress_hyper_20_38
 -- validate correct number of rows was deleted
 -- report true
 SELECT COUNT(*) = :total_rows - :total_affected_rows FROM sample_table;
-LOG:  statement: SELECT COUNT(*) = 100000 - 50000 FROM sample_table;
  ?column? 
 ----------
  t
 (1 row)
 
 ROLLBACK;
-LOG:  statement: ROLLBACK;
 -- check that you uncompress and delete only for exact ORDERBY value
 -- this will uncompress segments which have min <= value and max >= value
 BEGIN;
-LOG:  statement: BEGIN;
 -- report 10k rows
 SELECT COUNT(*) FROM sample_table WHERE c2 = 3;
-LOG:  statement: SELECT COUNT(*) FROM sample_table WHERE c2 = 3;
  count 
 -------
  10000
@@ -1511,7 +1476,6 @@ LOG:  statement: SELECT COUNT(*) FROM sample_table WHERE c2 = 3;
 
 -- report 100 rows
 SELECT COUNT(*) FROM :COMPRESS_CHUNK_1 WHERE _ts_meta_min_2 <= 3 and _ts_meta_max_2 >= 3;
-LOG:  statement: SELECT COUNT(*) FROM _timescaledb_internal.compress_hyper_20_38_chunk WHERE _ts_meta_min_2 <= 3 and _ts_meta_max_2 >= 3;
  count 
 -------
    100
@@ -1519,15 +1483,11 @@ LOG:  statement: SELECT COUNT(*) FROM _timescaledb_internal.compress_hyper_20_38
 
 -- fetch total and number of affected rows
 SELECT COUNT(*) AS "total_rows" FROM sample_table \gset
-LOG:  statement: SELECT COUNT(*) AS "total_rows" FROM sample_table 
 SELECT COUNT(*) AS "total_affected_rows" FROM sample_table WHERE c2 = 3 \gset
-LOG:  statement: SELECT COUNT(*) AS "total_affected_rows" FROM sample_table WHERE c2 = 3 
 -- delete 10k rows
 DELETE FROM sample_table WHERE c2 = 3;
-LOG:  statement: DELETE FROM sample_table WHERE c2 = 3;
 -- report 0 rows
 SELECT count(*) FROM sample_table WHERE c2 = 3;
-LOG:  statement: SELECT count(*) FROM sample_table WHERE c2 = 3;
  count 
 -------
      0
@@ -1535,7 +1495,6 @@ LOG:  statement: SELECT count(*) FROM sample_table WHERE c2 = 3;
 
 -- report 90k rows in uncompressed chunk
 SELECT COUNT(*) FROM ONLY :CHUNK_1;
-LOG:  statement: SELECT COUNT(*) FROM ONLY _timescaledb_internal._hyper_19_37_chunk;
  count 
 -------
  90000
@@ -1543,7 +1502,6 @@ LOG:  statement: SELECT COUNT(*) FROM ONLY _timescaledb_internal._hyper_19_37_ch
 
 -- report 0 rows
 SELECT COUNT(*) FROM :COMPRESS_CHUNK_1 WHERE _ts_meta_min_2 <= 3 and _ts_meta_max_2 >= 3;
-LOG:  statement: SELECT COUNT(*) FROM _timescaledb_internal.compress_hyper_20_38_chunk WHERE _ts_meta_min_2 <= 3 and _ts_meta_max_2 >= 3;
  count 
 -------
      0
@@ -1552,21 +1510,17 @@ LOG:  statement: SELECT COUNT(*) FROM _timescaledb_internal.compress_hyper_20_38
 -- validate correct number of rows was deleted
 -- report true
 SELECT COUNT(*) = :total_rows - :total_affected_rows FROM sample_table;
-LOG:  statement: SELECT COUNT(*) = 100000 - 10000 FROM sample_table;
  ?column? 
 ----------
  t
 (1 row)
 
 ROLLBACK;
-LOG:  statement: ROLLBACK;
 -- check that you uncompress and delete only for less then ORDERBY value
 -- this will uncompress segments which have min < value
 BEGIN;
-LOG:  statement: BEGIN;
 -- report 20k rows
 SELECT COUNT(*) FROM sample_table WHERE c1 < 2;
-LOG:  statement: SELECT COUNT(*) FROM sample_table WHERE c1 < 2;
  count 
 -------
  20000
@@ -1574,7 +1528,6 @@ LOG:  statement: SELECT COUNT(*) FROM sample_table WHERE c1 < 2;
 
 -- report 20 rows
 SELECT COUNT(*) FROM :COMPRESS_CHUNK_1 WHERE _ts_meta_max_1 < 2;
-LOG:  statement: SELECT COUNT(*) FROM _timescaledb_internal.compress_hyper_20_38_chunk WHERE _ts_meta_max_1 < 2;
  count 
 -------
     20
@@ -1582,15 +1535,11 @@ LOG:  statement: SELECT COUNT(*) FROM _timescaledb_internal.compress_hyper_20_38
 
 -- fetch total and number of affected rows
 SELECT COUNT(*) AS "total_rows" FROM sample_table \gset
-LOG:  statement: SELECT COUNT(*) AS "total_rows" FROM sample_table 
 SELECT COUNT(*) AS "total_affected_rows" FROM sample_table WHERE c1 < 2 \gset
-LOG:  statement: SELECT COUNT(*) AS "total_affected_rows" FROM sample_table WHERE c1 < 2 
 -- delete 20k rows
 DELETE FROM sample_table WHERE c1 < 2;
-LOG:  statement: DELETE FROM sample_table WHERE c1 < 2;
 -- report 0 rows
 SELECT count(*) FROM sample_table WHERE c1 < 2;
-LOG:  statement: SELECT count(*) FROM sample_table WHERE c1 < 2;
  count 
 -------
      0
@@ -1598,7 +1547,6 @@ LOG:  statement: SELECT count(*) FROM sample_table WHERE c1 < 2;
 
 -- report 0 rows in uncompressed chunk
 SELECT COUNT(*) FROM ONLY :CHUNK_1;
-LOG:  statement: SELECT COUNT(*) FROM ONLY _timescaledb_internal._hyper_19_37_chunk;
  count 
 -------
      0
@@ -1606,7 +1554,6 @@ LOG:  statement: SELECT COUNT(*) FROM ONLY _timescaledb_internal._hyper_19_37_ch
 
 -- report 0 rows in compressed chunk
 SELECT COUNT(*) FROM :COMPRESS_CHUNK_1 WHERE _ts_meta_max_1 < 2;
-LOG:  statement: SELECT COUNT(*) FROM _timescaledb_internal.compress_hyper_20_38_chunk WHERE _ts_meta_max_1 < 2;
  count 
 -------
      0
@@ -1615,21 +1562,17 @@ LOG:  statement: SELECT COUNT(*) FROM _timescaledb_internal.compress_hyper_20_38
 -- validate correct number of rows was deleted
 -- report true
 SELECT COUNT(*) = :total_rows - :total_affected_rows FROM sample_table;
-LOG:  statement: SELECT COUNT(*) = 100000 - 20000 FROM sample_table;
  ?column? 
 ----------
  t
 (1 row)
 
 ROLLBACK;
-LOG:  statement: ROLLBACK;
 -- check that you uncompress and delete only for greater or equal then ORDERBY value
 -- this will uncompress segments which have max >= value
 BEGIN;
-LOG:  statement: BEGIN;
 -- report 30k rows
 SELECT COUNT(*) FROM sample_table WHERE c1 >= 7;
-LOG:  statement: SELECT COUNT(*) FROM sample_table WHERE c1 >= 7;
  count 
 -------
  30000
@@ -1637,7 +1580,6 @@ LOG:  statement: SELECT COUNT(*) FROM sample_table WHERE c1 >= 7;
 
 -- report 30 rows
 SELECT COUNT(*) FROM :COMPRESS_CHUNK_1 WHERE _ts_meta_min_1 >= 7;
-LOG:  statement: SELECT COUNT(*) FROM _timescaledb_internal.compress_hyper_20_38_chunk WHERE _ts_meta_min_1 >= 7;
  count 
 -------
     30
@@ -1645,15 +1587,11 @@ LOG:  statement: SELECT COUNT(*) FROM _timescaledb_internal.compress_hyper_20_38
 
 -- fetch total and number of affected rows
 SELECT COUNT(*) AS "total_rows" FROM sample_table \gset
-LOG:  statement: SELECT COUNT(*) AS "total_rows" FROM sample_table 
 SELECT COUNT(*) AS "total_affected_rows" FROM sample_table WHERE c1 >= 7 \gset
-LOG:  statement: SELECT COUNT(*) AS "total_affected_rows" FROM sample_table WHERE c1 >= 7 
 -- delete 30k rows
 DELETE FROM sample_table WHERE c1 >= 7;
-LOG:  statement: DELETE FROM sample_table WHERE c1 >= 7;
 -- report 0 rows
 SELECT count(*) FROM sample_table WHERE c1 >= 7;
-LOG:  statement: SELECT count(*) FROM sample_table WHERE c1 >= 7;
  count 
 -------
      0
@@ -1661,7 +1599,6 @@ LOG:  statement: SELECT count(*) FROM sample_table WHERE c1 >= 7;
 
 -- report 0 rows in uncompressed chunk
 SELECT COUNT(*) FROM ONLY :CHUNK_1;
-LOG:  statement: SELECT COUNT(*) FROM ONLY _timescaledb_internal._hyper_19_37_chunk;
  count 
 -------
      0
@@ -1669,7 +1606,6 @@ LOG:  statement: SELECT COUNT(*) FROM ONLY _timescaledb_internal._hyper_19_37_ch
 
 -- report 0 rows in compressed chunks
 SELECT COUNT(*) FROM :COMPRESS_CHUNK_1 WHERE _ts_meta_min_1 >= 7;
-LOG:  statement: SELECT COUNT(*) FROM _timescaledb_internal.compress_hyper_20_38_chunk WHERE _ts_meta_min_1 >= 7;
  count 
 -------
      0
@@ -1678,22 +1614,18 @@ LOG:  statement: SELECT COUNT(*) FROM _timescaledb_internal.compress_hyper_20_38
 -- validate correct number of rows was deleted
 -- report true
 SELECT COUNT(*) = :total_rows - :total_affected_rows FROM sample_table;
-LOG:  statement: SELECT COUNT(*) = 100000 - 30000 FROM sample_table;
  ?column? 
 ----------
  t
 (1 row)
 
 ROLLBACK;
-LOG:  statement: ROLLBACK;
 -- check that you uncompress and delete only tuples which satisfy SEGMENTBY
 -- and ORDERBY qualifiers, segments only contain one distinct value for
 -- these qualifiers, everything should be deleted that was decompressed
 BEGIN;
-LOG:  statement: BEGIN;
 -- report 1k rows
 SELECT COUNT(*) FROM sample_table WHERE c4 = 5 and c1 = 5;
-LOG:  statement: SELECT COUNT(*) FROM sample_table WHERE c4 = 5 and c1 = 5;
  count 
 -------
   1000
@@ -1701,7 +1633,6 @@ LOG:  statement: SELECT COUNT(*) FROM sample_table WHERE c4 = 5 and c1 = 5;
 
 -- report 1 row in compressed chunks
 SELECT COUNT(*) FROM :COMPRESS_CHUNK_1 WHERE c4 = 5 AND _ts_meta_min_1 <= 5 and _ts_meta_max_1 >= 5;
-LOG:  statement: SELECT COUNT(*) FROM _timescaledb_internal.compress_hyper_20_38_chunk WHERE c4 = 5 AND _ts_meta_min_1 <= 5 and _ts_meta_max_1 >= 5;
  count 
 -------
      1
@@ -1709,16 +1640,12 @@ LOG:  statement: SELECT COUNT(*) FROM _timescaledb_internal.compress_hyper_20_38
 
 -- fetch total and number of affected rows
 SELECT COUNT(*) AS "total_rows" FROM sample_table \gset
-LOG:  statement: SELECT COUNT(*) AS "total_rows" FROM sample_table 
 SELECT COUNT(*) AS "total_affected_rows" FROM sample_table WHERE c4 = 5 and c1 = 5 \gset
-LOG:  statement: SELECT COUNT(*) AS "total_affected_rows" FROM sample_table WHERE c4 = 5 and c1 = 5 
 -- delete 1k rows
 DELETE FROM sample_table WHERE c4 = 5 and c1 = 5;
-LOG:  statement: DELETE FROM sample_table WHERE c4 = 5 and c1 = 5;
-DEBUG:  Number of compressed rows fetched from index: 10. Number of compressed rows filtered by orderby columns: 9.
+INFO:  Number of compressed rows fetched from index: 10. Number of compressed rows filtered by orderby columns: 9.
 -- report 0 rows
 SELECT count(*) FROM sample_table WHERE c4 = 5 and c1 = 5;
-LOG:  statement: SELECT count(*) FROM sample_table WHERE c4 = 5 and c1 = 5;
  count 
 -------
      0
@@ -1726,7 +1653,6 @@ LOG:  statement: SELECT count(*) FROM sample_table WHERE c4 = 5 and c1 = 5;
 
 -- report 0 rows in uncompressed chunk
 SELECT COUNT(*) FROM ONLY :CHUNK_1;
-LOG:  statement: SELECT COUNT(*) FROM ONLY _timescaledb_internal._hyper_19_37_chunk;
  count 
 -------
      0
@@ -1734,7 +1660,6 @@ LOG:  statement: SELECT COUNT(*) FROM ONLY _timescaledb_internal._hyper_19_37_ch
 
 -- report 0 rows in compressed chunks
 SELECT COUNT(*) FROM :COMPRESS_CHUNK_1 WHERE c4 = 5 AND _ts_meta_min_1 <= 5 and _ts_meta_max_1 >= 5;
-LOG:  statement: SELECT COUNT(*) FROM _timescaledb_internal.compress_hyper_20_38_chunk WHERE c4 = 5 AND _ts_meta_min_1 <= 5 and _ts_meta_max_1 >= 5;
  count 
 -------
      0
@@ -1743,22 +1668,18 @@ LOG:  statement: SELECT COUNT(*) FROM _timescaledb_internal.compress_hyper_20_38
 -- validate correct number of rows was deleted
 -- report true
 SELECT COUNT(*) = :total_rows - :total_affected_rows FROM sample_table;
-LOG:  statement: SELECT COUNT(*) = 100000 - 1000 FROM sample_table;
  ?column? 
 ----------
  t
 (1 row)
 
 ROLLBACK;
-LOG:  statement: ROLLBACK;
 -- check that you uncompress and delete only tuples which satisfy SEGMENTBY
 -- and ORDERBY qualifiers, segments contain more than one distinct value for
 -- these qualifiers, not everything should be deleted that was decompressed
 BEGIN;
-LOG:  statement: BEGIN;
 -- report 4k rows
 SELECT COUNT(*) FROM sample_table WHERE c4 > 5 and c2 = 5;
-LOG:  statement: SELECT COUNT(*) FROM sample_table WHERE c4 > 5 and c2 = 5;
  count 
 -------
   4000
@@ -1766,7 +1687,6 @@ LOG:  statement: SELECT COUNT(*) FROM sample_table WHERE c4 > 5 and c2 = 5;
 
 -- report 40 rows in compressed chunks
 SELECT COUNT(*) FROM :COMPRESS_CHUNK_1 WHERE c4 > 5 AND _ts_meta_min_2 <= 5 and _ts_meta_max_2 >= 5;
-LOG:  statement: SELECT COUNT(*) FROM _timescaledb_internal.compress_hyper_20_38_chunk WHERE c4 > 5 AND _ts_meta_min_2 <= 5 and _ts_meta_max_2 >= 5;
  count 
 -------
     40
@@ -1774,16 +1694,12 @@ LOG:  statement: SELECT COUNT(*) FROM _timescaledb_internal.compress_hyper_20_38
 
 -- fetch total and number of affected rows
 SELECT COUNT(*) AS "total_rows" FROM sample_table \gset
-LOG:  statement: SELECT COUNT(*) AS "total_rows" FROM sample_table 
 SELECT COUNT(*) AS "total_affected_rows" FROM sample_table WHERE c4 > 5 and c2 = 5 \gset
-LOG:  statement: SELECT COUNT(*) AS "total_affected_rows" FROM sample_table WHERE c4 > 5 and c2 = 5 
 -- delete 4k rows
 DELETE FROM sample_table WHERE c4 > 5 and c2 = 5;
-LOG:  statement: DELETE FROM sample_table WHERE c4 > 5 and c2 = 5;
-DEBUG:  Number of compressed rows fetched from index: 40. Number of compressed rows filtered by orderby columns: 0.
+INFO:  Number of compressed rows fetched from index: 40. Number of compressed rows filtered by orderby columns: 0.
 -- report 0 rows
 SELECT count(*) FROM sample_table WHERE c4 > 5 and c2 = 5;
-LOG:  statement: SELECT count(*) FROM sample_table WHERE c4 > 5 and c2 = 5;
  count 
 -------
      0
@@ -1791,7 +1707,6 @@ LOG:  statement: SELECT count(*) FROM sample_table WHERE c4 > 5 and c2 = 5;
 
 -- report 36k rows in uncompressed chunk
 SELECT COUNT(*) FROM ONLY :CHUNK_1;
-LOG:  statement: SELECT COUNT(*) FROM ONLY _timescaledb_internal._hyper_19_37_chunk;
  count 
 -------
  36000
@@ -1799,7 +1714,6 @@ LOG:  statement: SELECT COUNT(*) FROM ONLY _timescaledb_internal._hyper_19_37_ch
 
 -- report 0 rows in compressed chunks
 SELECT COUNT(*) FROM :COMPRESS_CHUNK_1 WHERE c4 > 5 AND _ts_meta_min_2 <= 5 and _ts_meta_max_2 >= 5;
-LOG:  statement: SELECT COUNT(*) FROM _timescaledb_internal.compress_hyper_20_38_chunk WHERE c4 > 5 AND _ts_meta_min_2 <= 5 and _ts_meta_max_2 >= 5;
  count 
 -------
      0
@@ -1808,14 +1722,12 @@ LOG:  statement: SELECT COUNT(*) FROM _timescaledb_internal.compress_hyper_20_38
 -- validate correct number of rows was deleted
 -- report true
 SELECT COUNT(*) = :total_rows - :total_affected_rows FROM sample_table;
-LOG:  statement: SELECT COUNT(*) = 100000 - 4000 FROM sample_table;
  ?column? 
 ----------
  t
 (1 row)
 
 ROLLBACK;
-LOG:  statement: ROLLBACK;
 -- check that you uncompress and delete only tuples which satisfy SEGMENTBY
 -- and ORDERBY qualifiers.
 -- no: of rows satisfying SEGMENTBY qualifiers is 10
@@ -1823,10 +1735,8 @@ LOG:  statement: ROLLBACK;
 -- Once both qualifiers are applied ensure that only 7 rows are present in
 -- compressed chunk
 BEGIN;
-LOG:  statement: BEGIN;
 -- report 0 rows in uncompressed chunk
 SELECT COUNT(*) FROM ONLY :CHUNK_1;
-LOG:  statement: SELECT COUNT(*) FROM ONLY _timescaledb_internal._hyper_19_37_chunk;
  count 
 -------
      0
@@ -1834,7 +1744,6 @@ LOG:  statement: SELECT COUNT(*) FROM ONLY _timescaledb_internal._hyper_19_37_ch
 
 -- report 10 compressed rows for given condition c4 = 4
 SELECT COUNT(*) FROM :COMPRESS_CHUNK_1 WHERE c4 = 4;
-LOG:  statement: SELECT COUNT(*) FROM _timescaledb_internal.compress_hyper_20_38_chunk WHERE c4 = 4;
  count 
 -------
     10
@@ -1842,22 +1751,17 @@ LOG:  statement: SELECT COUNT(*) FROM _timescaledb_internal.compress_hyper_20_38
 
 -- report 3 compressed rows for given condition c4 = 4 and c1 >= 7
 SELECT COUNT(*) FROM :COMPRESS_CHUNK_1 WHERE c4 = 4 AND _ts_meta_max_1 >= 7;
-LOG:  statement: SELECT COUNT(*) FROM _timescaledb_internal.compress_hyper_20_38_chunk WHERE c4 = 4 AND _ts_meta_max_1 >= 7;
  count 
 -------
      3
 (1 row)
 
 SELECT COUNT(*) AS "total_rows" FROM :COMPRESS_CHUNK_1 WHERE c4 = 4 \gset
-LOG:  statement: SELECT COUNT(*) AS "total_rows" FROM _timescaledb_internal.compress_hyper_20_38_chunk WHERE c4 = 4 
 SELECT COUNT(*) AS "total_affected_rows" FROM :COMPRESS_CHUNK_1 WHERE c4 = 4 AND _ts_meta_max_1 >= 7 \gset
-LOG:  statement: SELECT COUNT(*) AS "total_affected_rows" FROM _timescaledb_internal.compress_hyper_20_38_chunk WHERE c4 = 4 AND _ts_meta_max_1 >= 7 
 UPDATE sample_table SET c3 = c3 + 0 WHERE c4 = 4 AND c1 >= 7;
-LOG:  statement: UPDATE sample_table SET c3 = c3 + 0 WHERE c4 = 4 AND c1 >= 7;
-DEBUG:  Number of compressed rows fetched from index: 10. Number of compressed rows filtered by orderby columns: 7.
+INFO:  Number of compressed rows fetched from index: 10. Number of compressed rows filtered by orderby columns: 7.
 -- report 7 rows
 SELECT COUNT(*) FROM :COMPRESS_CHUNK_1 WHERE c4 = 4;
-LOG:  statement: SELECT COUNT(*) FROM _timescaledb_internal.compress_hyper_20_38_chunk WHERE c4 = 4;
  count 
 -------
      7
@@ -1866,16 +1770,13 @@ LOG:  statement: SELECT COUNT(*) FROM _timescaledb_internal.compress_hyper_20_38
 -- ensure correct number of rows are moved from compressed chunk
 -- report true
 SELECT COUNT(*) = :total_rows - :total_affected_rows FROM :COMPRESS_CHUNK_1 WHERE c4 = 4;
-LOG:  statement: SELECT COUNT(*) = 10 - 3 FROM _timescaledb_internal.compress_hyper_20_38_chunk WHERE c4 = 4;
  ?column? 
 ----------
  t
 (1 row)
 
 ROLLBACK;
-LOG:  statement: ROLLBACK;
-RESET client_min_messages;
-LOG:  statement: RESET client_min_messages;
+RESET timescaledb.debug_compression_path_info;
 --github issue: 5640
 CREATE TABLE tab1(filler_1 int, filler_2 int, filler_3 int, time timestamptz NOT NULL, device_id int, v0 int, v1 int, v2 float, v3 float);
 CREATE INDEX ON tab1(time);
@@ -2451,10 +2352,8 @@ ERROR:  UPDATE/DELETE is disabled on compressed chunks
 --github issue: 5586
 --testcase with multiple indexes
 \c :TEST_DBNAME :ROLE_SUPERUSER
-DROP DATABASE IF EXISTS test WITH (FORCE);
-NOTICE:  database "test" does not exist, skipping
-CREATE DATABASE test;
-\c test :ROLE_SUPERUSER
+CREATE DATABASE test5586;
+\c test5586 :ROLE_SUPERUSER
 SET client_min_messages = ERROR;
 CREATE EXTENSION timescaledb CASCADE;
 CREATE TABLE tab1(filler_1 int, filler_2 int, filler_3 int, time timestamptz NOT NULL, device_id int, v0 int, v1 int, v2 float, v3 float);
@@ -2483,72 +2382,58 @@ SELECT compress_chunk(show_chunks('tab1'));
  _timescaledb_internal._hyper_1_1_chunk
 (1 row)
 
-SET client_min_messages TO DEBUG2;
+set timescaledb.debug_compression_path_info to on;
 BEGIN;
-LOG:  statement: BEGIN;
 SELECT COUNT(*) FROM tab1 WHERE filler_3 = 5 AND filler_2 = 4;
-LOG:  statement: SELECT COUNT(*) FROM tab1 WHERE filler_3 = 5 AND filler_2 = 4;
  count 
 -------
   3598
 (1 row)
 
 UPDATE tab1 SET v0 = v1 + v2 WHERE filler_3 = 5 AND filler_2 = 4;
-LOG:  statement: UPDATE tab1 SET v0 = v1 + v2 WHERE filler_3 = 5 AND filler_2 = 4;
-DEBUG:  index "compress_hyper_2_2_chunk_filler_2_filler_3" is used for scan. 
-DEBUG:  Number of compressed rows fetched from index: 4. Number of compressed rows filtered by orderby columns: 0.
+INFO:  Number of compressed rows fetched from index: 4. Number of compressed rows filtered by orderby columns: 0.
 ROLLBACK;
-LOG:  statement: ROLLBACK;
 BEGIN;
-LOG:  statement: BEGIN;
 SELECT COUNT(*) FROM tab1 WHERE filler_1 < 5 AND filler_2 = 4;
-LOG:  statement: SELECT COUNT(*) FROM tab1 WHERE filler_1 < 5 AND filler_2 = 4;
  count 
 -------
   3598
 (1 row)
 
 UPDATE tab1 SET v0 = v1 + v2 WHERE filler_1 < 5 AND filler_2 = 4;
-LOG:  statement: UPDATE tab1 SET v0 = v1 + v2 WHERE filler_1 < 5 AND filler_2 = 4;
-DEBUG:  index "compress_hyper_2_2_chunk_filler_1_filler_2" is used for scan. 
-DEBUG:  Number of compressed rows fetched from index: 4. Number of compressed rows filtered by orderby columns: 0.
+INFO:  Number of compressed rows fetched from index: 4. Number of compressed rows filtered by orderby columns: 0.
 ROLLBACK;
-LOG:  statement: ROLLBACK;
 -- idealy filler_1 index should be selected,
 -- instead first matching index is selected
 BEGIN;
-LOG:  statement: BEGIN;
 SELECT COUNT(*) FROM tab1 WHERE filler_1 < 5;
-LOG:  statement: SELECT COUNT(*) FROM tab1 WHERE filler_1 < 5;
  count 
 -------
  14392
 (1 row)
 
 UPDATE tab1 SET v0 = v1 + v2 WHERE filler_1 < 5;
-LOG:  statement: UPDATE tab1 SET v0 = v1 + v2 WHERE filler_1 < 5;
-DEBUG:  index "compress_hyper_2_2_chunk__compressed_hypertable_2__ts_meta_mi_2" is used for scan. 
-DEBUG:  Number of compressed rows fetched from index: 16. Number of compressed rows filtered by orderby columns: 0.
+INFO:  Number of compressed rows fetched from index: 16. Number of compressed rows filtered by orderby columns: 0.
 ROLLBACK;
-LOG:  statement: ROLLBACK;
-RESET client_min_messages;
-LOG:  statement: RESET client_min_messages;
+RESET timescaledb.debug_compression_path_info;
 DROP TABLE tab1;
+\c :TEST_DBNAME :ROLE_SUPERUSER
+DROP DATABASE test5586;
 --issue: #6024
 CREATE TABLE t(a integer, b integer);
 SELECT create_hypertable('t', 'a', chunk_time_interval=> 10);
 NOTICE:  adding not-null constraint to column "a"
  create_hypertable 
 -------------------
- (3,public,t,t)
+ (31,public,t,t)
 (1 row)
 
 INSERT INTO t values(1, 2);
 ALTER TABLE t SET (timescaledb.compress);
 SELECT compress_chunk(show_chunks('t'));
-             compress_chunk             
-----------------------------------------
- _timescaledb_internal._hyper_3_3_chunk
+              compress_chunk              
+------------------------------------------
+ _timescaledb_internal._hyper_31_62_chunk
 (1 row)
 
 -- should not crash

--- a/tsl/test/expected/decompress_index.out
+++ b/tsl/test/expected/decompress_index.out
@@ -1,0 +1,115 @@
+-- This file and its contents are licensed under the Timescale License.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-TIMESCALE for a copy of the license.
+\c :TEST_DBNAME :ROLE_CLUSTER_SUPERUSER;
+CREATE TABLE ht_metrics_compressed(time timestamptz, device int, value float, tag text);
+ALTER TABLE ht_metrics_compressed SET (autovacuum_enabled = false);
+SELECT create_hypertable('ht_metrics_compressed','time',create_default_indexes:=false, chunk_time_interval => interval '100 day');
+NOTICE:  adding not-null constraint to column "time"
+         create_hypertable          
+------------------------------------
+ (1,public,ht_metrics_compressed,t)
+(1 row)
+
+ALTER TABLE ht_metrics_compressed SET (timescaledb.compress, timescaledb.compress_segmentby='device', timescaledb.compress_orderby='time');
+-- helper function: float -> pseudorandom float [0..1].
+CREATE OR REPLACE FUNCTION mix(x float4) RETURNS float4 AS $$ SELECT ((hashfloat4(x) / (pow(2., 31) - 1) + 1) / 2)::float4 $$ LANGUAGE SQL;
+INSERT INTO ht_metrics_compressed
+SELECT
+    '2020-05-18'::timestamptz + interval '1 second' * (x + 0.1 * mix(device + x * 10)),
+    device,
+    100 * mix(device) * sin(x / 3600)
+        + 100 * mix(device + 1) * sin(x / (3600 * 24))
+        + 100 * mix(device + 2) * sin(x / (3600 * 24 * 7))
+        + mix(device + x * 10 + 1),
+     format('this-is-a-long-tag-#%s', x % 29)
+FROM generate_series(1, 3600 * 24 * 90, 100) x, generate_series(1,2) device;
+analyze ht_metrics_compressed;
+select show_chunks('ht_metrics_compressed') as "CHUNK" limit 1 \gset
+select count(*) from :CHUNK;
+ count  
+--------
+ 155520
+(1 row)
+
+select count(distinct tag) from :CHUNK;
+ count 
+-------
+    29
+(1 row)
+
+select device, min(time), max(time) from :CHUNK group by 1 order by 1, 2, 3;
+ device |                 min                 |                max                 
+--------+-------------------------------------+------------------------------------
+      1 | Mon May 18 00:00:01.037881 2020 PDT | Sat Aug 15 23:58:21.04471 2020 PDT
+      2 | Mon May 18 00:00:01.013087 2020 PDT | Sat Aug 15 23:58:21.04471 2020 PDT
+(2 rows)
+
+-- decompress with no indexes
+select where compress_chunk(:'CHUNK') is null;
+--
+(0 rows)
+
+select where decompress_chunk(:'CHUNK') is null;
+--
+(0 rows)
+
+-- decompress with one index
+select where compress_chunk(:'CHUNK') is null;
+--
+(0 rows)
+
+create index on :CHUNK(device, time);
+select where decompress_chunk(:'CHUNK') is null;
+--
+(0 rows)
+
+-- decompress with two indexes
+select where compress_chunk(:'CHUNK') is null;
+--
+(0 rows)
+
+create index on :CHUNK(tag);
+select where decompress_chunk(:'CHUNK') is null;
+--
+(0 rows)
+
+-- check the data after decompression
+set enable_seqscan to off;
+select count(*) from :CHUNK;
+ count  
+--------
+ 155520
+(1 row)
+
+select count(distinct tag) from :CHUNK;
+ count 
+-------
+    29
+(1 row)
+
+select distinct on (device) device, time from :CHUNK order by 1, 2;
+ device |                time                 
+--------+-------------------------------------
+      1 | Mon May 18 00:00:01.037881 2020 PDT
+      2 | Mon May 18 00:00:01.013087 2020 PDT
+(2 rows)
+
+-- check that the indexes are used
+explain (costs off) select count(distinct tag) from :CHUNK;
+                                QUERY PLAN                                
+--------------------------------------------------------------------------
+ Aggregate
+   ->  Index Only Scan using _hyper_1_1_chunk_tag_idx on _hyper_1_1_chunk
+(2 rows)
+
+explain (costs off) select distinct on (device) device, time from :CHUNK order by 1, 2;
+                                       QUERY PLAN                                       
+----------------------------------------------------------------------------------------
+ Unique
+   ->  Custom Scan (SkipScan) on _hyper_1_1_chunk
+         ->  Index Only Scan using _hyper_1_1_chunk_device_time_idx on _hyper_1_1_chunk
+               Index Cond: (device > NULL::integer)
+(4 rows)
+
+drop table ht_metrics_compressed;

--- a/tsl/test/expected/decompress_memory.out
+++ b/tsl/test/expected/decompress_memory.out
@@ -1,0 +1,69 @@
+-- This file and its contents are licensed under the Timescale License.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-TIMESCALE for a copy of the license.
+\c :TEST_DBNAME :ROLE_CLUSTER_SUPERUSER;
+CREATE TABLE ht_metrics_compressed(time timestamptz, device int, value float, tag text);
+ALTER TABLE ht_metrics_compressed SET (autovacuum_enabled = false);
+SELECT create_hypertable('ht_metrics_compressed','time',create_default_indexes:=false);
+NOTICE:  adding not-null constraint to column "time"
+         create_hypertable          
+------------------------------------
+ (1,public,ht_metrics_compressed,t)
+(1 row)
+
+ALTER TABLE ht_metrics_compressed SET (timescaledb.compress, timescaledb.compress_segmentby='device', timescaledb.compress_orderby='time');
+-- helper function: float -> pseudorandom float [0..1].
+CREATE OR REPLACE FUNCTION mix(x float4) RETURNS float4 AS $$ SELECT ((hashfloat4(x) / (pow(2., 31) - 1) + 1) / 2)::float4 $$ LANGUAGE SQL;
+INSERT INTO ht_metrics_compressed
+SELECT
+    '2020-01-08'::timestamptz + interval '1 second' * (x + 0.1 * mix(device + x * 10)),
+    device,
+    100 * mix(device) * sin(x / 3600)
+        + 100 * mix(device + 1) * sin(x / (3600 * 24))
+        + 100 * mix(device + 2) * sin(x / (3600 * 24 * 7))
+        + mix(device + x * 10 + 1),
+     format('this-is-a-long-tag-#%s', x % 29)
+FROM generate_series(1, 3600 * 24 * 356, 100) x, generate_series(1,2) device;
+-- compress it all
+SELECT count(compress_chunk(c, true)) FROM show_chunks('ht_metrics_compressed') c;
+ count 
+-------
+    52
+(1 row)
+
+select count(*) from ht_metrics_compressed;
+ count  
+--------
+ 615168
+(1 row)
+
+-- Helper function that returns the amount of memory currently allocated in a
+-- given memory context.
+create or replace function ts_debug_allocated_bytes(text = 'PortalContext') returns bigint
+    as :MODULE_PATHNAME, 'ts_debug_allocated_bytes'
+    language c strict volatile;
+-- Check that decompression doesn't leak memory. Record memory usage after each
+-- compressed chunk, and use linear regression to tell if memory usage grows.
+with log as materialized (
+        select rank() over (order by c) n, ts_debug_allocated_bytes() b, decompress_chunk(c, true)
+        from show_chunks('ht_metrics_compressed') c order by c)
+    , regression as (select regr_slope(b, n) slope, regr_intercept(b, n) intercept from log)
+select * from log
+    where (select slope / intercept::float > 0.01 from regression)
+;
+ n | b | decompress_chunk 
+---+---+------------------
+(0 rows)
+
+-- Same as above but for compression.
+with log as materialized (
+        select rank() over (order by c) n, ts_debug_allocated_bytes() b, compress_chunk(c, true)
+        from show_chunks('ht_metrics_compressed') c order by c)
+    , regression as (select regr_slope(b, n) slope, regr_intercept(b, n) intercept from log)
+select * from log
+    where (select slope / intercept::float > 0.01 from regression)
+;
+ n | b | compress_chunk 
+---+---+----------------
+(0 rows)
+

--- a/tsl/test/sql/CMakeLists.txt
+++ b/tsl/test/sql/CMakeLists.txt
@@ -13,12 +13,14 @@ set(TEST_FILES
     cagg_refresh.sql
     cagg_utils.sql
     cagg_watermark.sql
+    compress_default.sql
     compressed_collation.sql
     compression_create_compressed_table.sql
     compression_conflicts.sql
     compression_insert.sql
     compression_policy.sql
     compression_qualpushdown.sql
+    decompress_index.sql
     exp_cagg_monthly.sql
     exp_cagg_next_gen.sql
     exp_cagg_origin.sql
@@ -74,6 +76,7 @@ if(CMAKE_BUILD_TYPE MATCHES Debug)
     cagg_tableam.sql
     cagg_policy_run.sql
     ddl_hook.sql
+    decompress_memory.sql
     decompress_vector_qual.sql
     hypertable_generalization.sql
     insert_memory_usage.sql
@@ -122,10 +125,10 @@ endif(CMAKE_BUILD_TYPE MATCHES Debug)
 
 if((${PG_VERSION_MAJOR} GREATER_EQUAL "14"))
   if(CMAKE_BUILD_TYPE MATCHES Debug)
-    list(APPEND TEST_FILES chunk_utils_internal.sql)
+    list(APPEND TEST_FILES chunk_utils_internal.sql
+         compression_update_delete.sql)
   endif()
-  list(APPEND TEST_FILES compression.sql compression_update_delete.sql
-       compression_permissions.sql)
+  list(APPEND TEST_FILES compression.sql compression_permissions.sql)
 endif()
 
 if((${PG_VERSION_MAJOR} GREATER_EQUAL "15"))

--- a/tsl/test/sql/compress_default.sql
+++ b/tsl/test/sql/compress_default.sql
@@ -1,0 +1,28 @@
+-- This file and its contents are licensed under the Timescale License.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-TIMESCALE for a copy of the license.
+
+-- Use a weird compression configuration to test decompression of all-default
+-- batch.
+create table t(ts int);
+select create_hypertable('t', 'ts');
+alter table t set(timescaledb.compress, timescaledb.compress_segmentby = 'ts',
+    timescaledb.compress_orderby = '');
+insert into t select generate_series(1, 10000);
+select count(*) from t;
+
+select count(compress_chunk(x, true)) from show_chunks('t') x;
+select count(*) from t;
+
+select count(decompress_chunk(x, true)) from show_chunks('t') x;
+select count(*) from t;
+
+
+-- Now add a column which will be all default in the compressed chunk
+select count(compress_chunk(x, true)) from show_chunks('t') x;
+
+alter table t add column x int default 7;
+select count(*), x from t group by x;
+
+select count(decompress_chunk(x, true)) from show_chunks('t') x;
+select count(*), x from t group by x;

--- a/tsl/test/sql/compression_indexscan.sql
+++ b/tsl/test/sql/compression_indexscan.sql
@@ -3,7 +3,7 @@
 -- LICENSE-TIMESCALE for a copy of the license.
 
 --Enable compression path info
-SET timescaledb.show_compression_path_info= 'on';
+SET timescaledb.debug_compression_path_info= 'on';
 --Table creation
 CREATE TABLE tab1 (
     time timestamptz not null,
@@ -263,4 +263,4 @@ drop index predicate;
 DROP TABLE tab1;
 DROP TABLE tab2;
 DROP TABLE tab3;
-SET timescaledb.show_compression_path_info = 'off';
+SET timescaledb.debug_compression_path_info = 'off';

--- a/tsl/test/sql/compression_update_delete.sql
+++ b/tsl/test/sql/compression_update_delete.sql
@@ -762,7 +762,7 @@ WHERE ch1.hypertable_id = ht.id AND ch1.table_name LIKE 'compress_%'
 ORDER BY ch1.id LIMIT 1 \gset
 
 -- check that you uncompress and delete only for exact SEGMENTBY value
-SET client_min_messages TO DEBUG1;
+SET timescaledb.debug_compression_path_info TO true;
 BEGIN;
 -- report 10 rows
 SELECT COUNT(*) FROM :COMPRESS_CHUNK_1 where c4 = 5;
@@ -967,7 +967,7 @@ SELECT COUNT(*) FROM :COMPRESS_CHUNK_1 WHERE c4 = 4;
 -- report true
 SELECT COUNT(*) = :total_rows - :total_affected_rows FROM :COMPRESS_CHUNK_1 WHERE c4 = 4;
 ROLLBACK;
-RESET client_min_messages;
+RESET timescaledb.debug_compression_path_info;
 
 --github issue: 5640
 CREATE TABLE tab1(filler_1 int, filler_2 int, filler_3 int, time timestamptz NOT NULL, device_id int, v0 int, v1 int, v2 float, v3 float);
@@ -1258,9 +1258,8 @@ DELETE FROM sample_table WHERE time >= '2023-03-17 00:00:00-00'::timestamptz;
 --github issue: 5586
 --testcase with multiple indexes
 \c :TEST_DBNAME :ROLE_SUPERUSER
-DROP DATABASE IF EXISTS test WITH (FORCE);
-CREATE DATABASE test;
-\c test :ROLE_SUPERUSER
+CREATE DATABASE test5586;
+\c test5586 :ROLE_SUPERUSER
 SET client_min_messages = ERROR;
 CREATE EXTENSION timescaledb CASCADE;
 CREATE TABLE tab1(filler_1 int, filler_2 int, filler_3 int, time timestamptz NOT NULL, device_id int, v0 int, v1 int, v2 float, v3 float);
@@ -1281,7 +1280,7 @@ CREATE INDEX filler_1_filler_2 ON _timescaledb_internal._compressed_hypertable_2
 CREATE INDEX filler_2_filler_3 ON _timescaledb_internal._compressed_hypertable_2 (filler_2, filler_3);
 
 SELECT compress_chunk(show_chunks('tab1'));
-SET client_min_messages TO DEBUG2;
+set timescaledb.debug_compression_path_info to on;
 BEGIN;
 SELECT COUNT(*) FROM tab1 WHERE filler_3 = 5 AND filler_2 = 4;
 UPDATE tab1 SET v0 = v1 + v2 WHERE filler_3 = 5 AND filler_2 = 4;
@@ -1299,8 +1298,11 @@ SELECT COUNT(*) FROM tab1 WHERE filler_1 < 5;
 UPDATE tab1 SET v0 = v1 + v2 WHERE filler_1 < 5;
 ROLLBACK;
 
-RESET client_min_messages;
+RESET timescaledb.debug_compression_path_info;
 DROP TABLE tab1;
+\c :TEST_DBNAME :ROLE_SUPERUSER
+DROP DATABASE test5586;
+
 
 --issue: #6024
 CREATE TABLE t(a integer, b integer);

--- a/tsl/test/sql/decompress_index.sql
+++ b/tsl/test/sql/decompress_index.sql
@@ -1,0 +1,62 @@
+-- This file and its contents are licensed under the Timescale License.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-TIMESCALE for a copy of the license.
+
+\c :TEST_DBNAME :ROLE_CLUSTER_SUPERUSER;
+
+CREATE TABLE ht_metrics_compressed(time timestamptz, device int, value float, tag text);
+ALTER TABLE ht_metrics_compressed SET (autovacuum_enabled = false);
+SELECT create_hypertable('ht_metrics_compressed','time',create_default_indexes:=false, chunk_time_interval => interval '100 day');
+ALTER TABLE ht_metrics_compressed SET (timescaledb.compress, timescaledb.compress_segmentby='device', timescaledb.compress_orderby='time');
+-- helper function: float -> pseudorandom float [0..1].
+CREATE OR REPLACE FUNCTION mix(x float4) RETURNS float4 AS $$ SELECT ((hashfloat4(x) / (pow(2., 31) - 1) + 1) / 2)::float4 $$ LANGUAGE SQL;
+
+
+INSERT INTO ht_metrics_compressed
+SELECT
+    '2020-05-18'::timestamptz + interval '1 second' * (x + 0.1 * mix(device + x * 10)),
+    device,
+    100 * mix(device) * sin(x / 3600)
+        + 100 * mix(device + 1) * sin(x / (3600 * 24))
+        + 100 * mix(device + 2) * sin(x / (3600 * 24 * 7))
+        + mix(device + x * 10 + 1),
+     format('this-is-a-long-tag-#%s', x % 29)
+FROM generate_series(1, 3600 * 24 * 90, 100) x, generate_series(1,2) device;
+
+analyze ht_metrics_compressed;
+
+select show_chunks('ht_metrics_compressed') as "CHUNK" limit 1 \gset
+select count(*) from :CHUNK;
+select count(distinct tag) from :CHUNK;
+select device, min(time), max(time) from :CHUNK group by 1 order by 1, 2, 3;
+
+-- decompress with no indexes
+select where compress_chunk(:'CHUNK') is null;
+select where decompress_chunk(:'CHUNK') is null;
+
+
+-- decompress with one index
+select where compress_chunk(:'CHUNK') is null;
+create index on :CHUNK(device, time);
+select where decompress_chunk(:'CHUNK') is null;
+
+
+-- decompress with two indexes
+select where compress_chunk(:'CHUNK') is null;
+create index on :CHUNK(tag);
+select where decompress_chunk(:'CHUNK') is null;
+
+
+-- check the data after decompression
+set enable_seqscan to off;
+select count(*) from :CHUNK;
+select count(distinct tag) from :CHUNK;
+select distinct on (device) device, time from :CHUNK order by 1, 2;
+
+
+-- check that the indexes are used
+explain (costs off) select count(distinct tag) from :CHUNK;
+explain (costs off) select distinct on (device) device, time from :CHUNK order by 1, 2;
+
+
+drop table ht_metrics_compressed;

--- a/tsl/test/sql/decompress_memory.sql
+++ b/tsl/test/sql/decompress_memory.sql
@@ -1,0 +1,54 @@
+-- This file and its contents are licensed under the Timescale License.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-TIMESCALE for a copy of the license.
+
+\c :TEST_DBNAME :ROLE_CLUSTER_SUPERUSER;
+
+CREATE TABLE ht_metrics_compressed(time timestamptz, device int, value float, tag text);
+ALTER TABLE ht_metrics_compressed SET (autovacuum_enabled = false);
+SELECT create_hypertable('ht_metrics_compressed','time',create_default_indexes:=false);
+ALTER TABLE ht_metrics_compressed SET (timescaledb.compress, timescaledb.compress_segmentby='device', timescaledb.compress_orderby='time');
+-- helper function: float -> pseudorandom float [0..1].
+CREATE OR REPLACE FUNCTION mix(x float4) RETURNS float4 AS $$ SELECT ((hashfloat4(x) / (pow(2., 31) - 1) + 1) / 2)::float4 $$ LANGUAGE SQL;
+
+
+INSERT INTO ht_metrics_compressed
+SELECT
+    '2020-01-08'::timestamptz + interval '1 second' * (x + 0.1 * mix(device + x * 10)),
+    device,
+    100 * mix(device) * sin(x / 3600)
+        + 100 * mix(device + 1) * sin(x / (3600 * 24))
+        + 100 * mix(device + 2) * sin(x / (3600 * 24 * 7))
+        + mix(device + x * 10 + 1),
+     format('this-is-a-long-tag-#%s', x % 29)
+FROM generate_series(1, 3600 * 24 * 356, 100) x, generate_series(1,2) device;
+
+-- compress it all
+SELECT count(compress_chunk(c, true)) FROM show_chunks('ht_metrics_compressed') c;
+
+select count(*) from ht_metrics_compressed;
+
+-- Helper function that returns the amount of memory currently allocated in a
+-- given memory context.
+create or replace function ts_debug_allocated_bytes(text = 'PortalContext') returns bigint
+    as :MODULE_PATHNAME, 'ts_debug_allocated_bytes'
+    language c strict volatile;
+
+-- Check that decompression doesn't leak memory. Record memory usage after each
+-- compressed chunk, and use linear regression to tell if memory usage grows.
+with log as materialized (
+        select rank() over (order by c) n, ts_debug_allocated_bytes() b, decompress_chunk(c, true)
+        from show_chunks('ht_metrics_compressed') c order by c)
+    , regression as (select regr_slope(b, n) slope, regr_intercept(b, n) intercept from log)
+select * from log
+    where (select slope / intercept::float > 0.01 from regression)
+;
+
+-- Same as above but for compression.
+with log as materialized (
+        select rank() over (order by c) n, ts_debug_allocated_bytes() b, compress_chunk(c, true)
+        from show_chunks('ht_metrics_compressed') c order by c)
+    , regression as (select regr_slope(b, n) slope, regr_intercept(b, n) intercept from log)
+select * from log
+    where (select slope / intercept::float > 0.01 from regression)
+;


### PR DESCRIPTION
This should improve the throughput somewhat.

This PR does several things:
1. Simplify loop condition in decompressing the compressed batch by using the count metadata column.
2. Split out a separate function that decompresses the entire compressed batch and saves the decompressed tuples slot into `RowDecompressor`.
3. Use bulk table insert function for inserting the decompressed rows, this reduces WAL activity.
4. If we have indexes on uncompressed chunk, update them one index for entire batch at a time, to reduce load on shared buffers cache. Before that we used to update all indexes for one row, then for another, etc.
5. Add a test for memory leaks during (de)compression.
6. Update the `compression_update_delete` test to use INFO messages + a debug GUC instead of DEBUG messages which are flaky.

This gives 10%-30% speedup on tsbench for `decompress_chunk` and various compressed DML queries. This is very far from the performance we had in 2.10, but still a nice improvement.
https://grafana.ops.savannah-dev.timescale.com/d/fasYic_4z/compare-akuzm?orgId=1&var-branch=All&var-run1=2900&var-run2=2903&var-threshold=0&var-use_historical_thresholds&viewPanel=4

Disable-check: force-changelog-file