### PR TITLE
Fix ABI check on PG 16

### DIFF
--- a/.github/workflows/abi.yaml
+++ b/.github/workflows/abi.yaml
@@ -14,6 +14,9 @@ name: ABI Test
   push:
     branches:
       - prerelease_test
+      - trigger/abi
+  pull_request:
+    paths: .github/workflows/abi.yaml
 jobs:
   config:
     runs-on: ubuntu-latest
@@ -88,19 +91,17 @@ jobs:
       run: |
         BUILDER_IMAGE="postgres:${{matrix.builder}}-alpine"
 
-        # Recent versions of alpine have OpenSSL 3 as the
-        # default version which is unfortunately not packaged
-        # for the earliest versions we check against in this
-        # test. So we pin the version we compile against to
-        # OpenSSL 1.1 in the backwards test.
-        if [[ "${{ matrix.test }}" == *backward ]]; then
-          EXTRA_PKGS="openssl1.1-compat-dev"
-        else
-          EXTRA_PKGS="openssl-dev"
-        fi
-
+        docker pull ${BUILDER_IMAGE}
+        docker buildx imagetools inspect ${BUILDER_IMAGE}
         docker run -i --rm -v $(pwd):/mnt -e EXTRA_PKGS="${EXTRA_PKGS}" ${BUILDER_IMAGE} bash <<"EOF"
           apk add cmake gcc make build-base krb5-dev git ${EXTRA_PKGS}
+          # We run the same extension on different docker images, old versions
+          # have OpenSSL 1.1 and the new versions have OpenSSL 3, so we try to
+          # pin the 1.1. Note that depending on PG version, both images might
+          # have 1.1 or 3, so we first try to install the versioned 1.1 package,
+          # and if it's not present, it means the unversioned package is 1.1, so
+          # we install it.
+          apk add openssl1.1-compat-dev || apk add openssl-dev
           git config --global --add safe.directory /mnt
           cd /mnt
           BUILD_DIR=build_abi BUILD_FORCE_REMOVE=true ./bootstrap -DENABLE_MULTINODE_TESTS=ON
@@ -114,14 +115,11 @@ jobs:
       run: |
         TEST_IMAGE="postgres:${{ matrix.tester }}-alpine"
 
-        if [[ "${{ matrix.test }}" == *backward ]]; then
-          EXTRA_PKGS="openssl-dev"
-        else
-          EXTRA_PKGS="openssl1.1-compat-dev"
-        fi
-
+        docker pull ${TEST_IMAGE}
+        docker buildx imagetools inspect ${TEST_IMAGE}
         docker run -i --rm -v $(pwd):/mnt -e EXTRA_PKGS="${EXTRA_PKGS}" ${TEST_IMAGE} bash <<"EOF"
           apk add cmake gcc make build-base krb5-dev sudo ${EXTRA_PKGS}
+          apk add openssl1.1-compat-dev || apk add openssl-dev
           cd /mnt
           cp build_abi/install_ext/* `pg_config --sharedir`/extension/
           cp build_abi/install_lib/* `pg_config --pkglibdir`


### PR DESCRIPTION
This changes the way of pinning OpenSSL 1.1, so that it supports the case of PG16 where both the oldest and the newest alpine docker images have OpenSSL 3. Depending on the PG versions, both old and new images might have either 1.1 or 3, so we just try to install both packages.

Disable-check: force-changelog-file