### PR TITLE
PG16: Fix ignored workflow for Windows on CI

### DIFF
--- a/.github/workflows/windows-build-and-test-ignored.yaml
+++ b/.github/workflows/windows-build-and-test-ignored.yaml
@@ -45,7 +45,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        pg: [ 13, 14, 15 ]
+        pg: [ 13, 14, 15, 16 ]
         os: [ windows-2022 ]
         build_type: ${{ fromJson(needs.config.outputs.build_type) }}
     steps:


### PR DESCRIPTION
In ef505760 we enabled PG16 on Windows CI but forgot the add it to the ignored workflow.

Disable-check: force-changelog-file
