### PR TITLE
Fix segfault creating cagg with NULL bucket width

### DIFF
--- a/.unreleased/pr_6297
+++ b/.unreleased/pr_6297
@@ -1,0 +1,1 @@
+Fixes: #6297 Fix segfault when creating a cagg using a NULL width in time bucket function

--- a/tsl/src/continuous_aggs/common.c
+++ b/tsl/src/continuous_aggs/common.c
@@ -319,6 +319,11 @@ caggtimebucket_validate(CAggTimebucketInfo *tbinfo, List *groupClause, List *tar
 				Const *width = castNode(Const, width_arg);
 				tbinfo->bucket_width_type = width->consttype;
 
+				if (width->constisnull)
+					ereport(ERROR,
+							(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
+							 errmsg("invalid bucket width for time bucket function")));
+
 				if (width->consttype == INTERVALOID)
 				{
 					tbinfo->interval = DatumGetIntervalP(width->constvalue);

--- a/tsl/test/expected/cagg_errors.out
+++ b/tsl/test/expected/cagg_errors.out
@@ -256,6 +256,14 @@ SELECT time_bucket('1 week', timec)
 GROUP BY time_bucket('1 week', timec);
 ERROR:  cannot create continuous aggregate with CREATE VIEW
 HINT:  Use CREATE MATERIALIZED VIEW to create a continuous aggregate.
+-- invalid `bucket_width` for `time_bucket` function
+CREATE MATERIALIZED VIEW mat_m1 WITH (timescaledb.continuous, timescaledb.materialized_only=false)
+AS
+SELECT time_bucket(NULL, timec), sum(temperature), min(location)
+FROM conditions
+GROUP BY 1
+WITH NO DATA;
+ERROR:  invalid bucket width for time bucket function
 -- row security on table
 create table rowsec_tab( a bigint, b integer, c integer);
 select table_name from create_hypertable( 'rowsec_tab', 'a', chunk_time_interval=>10);

--- a/tsl/test/sql/cagg_errors.sql
+++ b/tsl/test/sql/cagg_errors.sql
@@ -236,6 +236,14 @@ SELECT time_bucket('1 week', timec)
   FROM conditions
 GROUP BY time_bucket('1 week', timec);
 
+-- invalid `bucket_width` for `time_bucket` function
+CREATE MATERIALIZED VIEW mat_m1 WITH (timescaledb.continuous, timescaledb.materialized_only=false)
+AS
+SELECT time_bucket(NULL, timec), sum(temperature), min(location)
+FROM conditions
+GROUP BY 1
+WITH NO DATA;
+
 -- row security on table
 create table rowsec_tab( a bigint, b integer, c integer);
 select table_name from create_hypertable( 'rowsec_tab', 'a', chunk_time_interval=>10);


### PR DESCRIPTION
When creating a Continuous Aggregate using a NULL `bucket_width` in the `time_bucket` function it lead to a segfault, for example:

CREATE MATERIALIZED VIEW cagg WITH (timescaledb.continuous) AS SELECT time_bucket(NULL, time), count(*)
FROM metrics
GROUP BY 1;

Fixed it by raising an ERROR if a NULL `bucked_width` is used during the Continuous Aggregate query validation.