### PR TITLE
Adjust restore points test for PG 16

### DIFF
--- a/.github/workflows/cron-tests.yaml
+++ b/.github/workflows/cron-tests.yaml
@@ -4,6 +4,8 @@ name: Additional tests
     branches:
       - main
       - prerelease_test
+      - trigger/additional_tests
+
 jobs:
   config:
     runs-on: ubuntu-latest

--- a/scripts/test_restore_points.sh
+++ b/scripts/test_restore_points.sh
@@ -297,6 +297,11 @@ if [ ${PG_VERSION_MAJOR} -lt 13 ]; then
   exit 1
 fi
 
+if [ ${PG_VERSION_MAJOR} -ge 16 ]; then
+  echo "Multi-node is currently not supported on PG >= 16"
+  exit 0
+fi
+
 mkdir -p ${RESULT_DIR}
 
 echo "Running single node tests"


### PR DESCRIPTION
Currently, MN is not supported on PG16. Therefore, the creation of distributed restore points fails on PG16. This patch disables the CI test for this PG version.

---
Disable-check: force-changelog-file
Link to broken CI run: https://github.com/timescale/timescaledb/actions/runs/6808663440/job/18513494748
Link to fixed CI run: https://github.com/timescale/timescaledb/actions/runs/6809128223/job/18514813987?pr=6298