### PR TITLE
Default compression orderby setting to ASC

### DIFF
--- a/tsl/src/compression/create.c
+++ b/tsl/src/compression/create.c
@@ -771,12 +771,12 @@ add_time_to_order_by_if_not_included(List *orderby_cols, List *segmentby_cols, H
 
 	if (!found)
 	{
-		/* Add time DESC NULLS FIRST to order by list */
+		/* Add time to order by list */
 		CompressedParsedCol *col = palloc(sizeof(*col));
 		*col = (CompressedParsedCol){
 			.index = list_length(orderby_cols),
-			.asc = false,
-			.nullsfirst = true,
+			.asc = true,
+            .nullsfirst = false,
 		};
 		namestrcpy(&col->colname, time_col_name);
 		orderby_cols = lappend(orderby_cols, col);


### PR DESCRIPTION
Default compression orderby setting uses
DESC ordering on primary dimension. Using ascending order benefits chunk rollups during compression by avoiding performance degradation caused by recompression.

TSBench run: https://grafana.ops.savannah-dev.timescale.com/d/NdmLnOk4z/compare-benchmark-runs?orgId=1&var-run1=2904&var-run2=2917&var-postgres=15&var-branch=tsbench_test&var-threshold=0.02

- [x] Checked regression for queries with `ORDER BY device, time DESC`, its an obvious regression since we cannot use the index scan anymore
- [x] Checked regression for `WHERE device = CONSTANT ORDER BY time DESC`, regression in range of 10% due to backward index scan vs forward index scan