### PR TITLE
Stabilize CI by excluding debug messages

### DIFF
--- a/test/runner.sh
+++ b/test/runner.sh
@@ -141,4 +141,6 @@ ${PSQL} -U ${TEST_PGUSER} \
                -e 's! Average  Peak Memory: [0-9]\{1,\}kB!!' | \
           grep -v 'DEBUG:  rehashing catalog cache id' | \
           grep -v 'DEBUG:  compacted fsync request queue from' | \
+          grep -v 'DEBUG:  creating and filling new WAL file' | \
+          grep -v 'DEBUG:  done creating and filling new WAL file' | \
           grep -v 'NOTICE:  cancelling the background worker for job'

--- a/test/runner_shared.sh
+++ b/test/runner_shared.sh
@@ -89,4 +89,6 @@ ${PSQL} -U ${TEST_PGUSER} \
                -e 's! Average  Peak Memory: [0-9]\{1,\}kB!!' | \
           grep -v 'DEBUG:  rehashing catalog cache id' | \
           grep -v 'DEBUG:  compacted fsync request queue from' | \
+          grep -v 'DEBUG:  creating and filling new WAL file' | \
+          grep -v 'DEBUG:  done creating and filling new WAL file' | \
           grep -v 'NOTICE:  cancelling the background worker for job'


### PR DESCRIPTION
The CI tests on Windows log the creation of a new WAL file in a non-deterministic way. This message causes the regression tests to fail. This PR removed these messages from the test output.

---
Disable-check: force-changelog-file
Link to failed CI run: https://github.com/timescale/timescaledb/actions/runs/6809123385/job/18514803292?pr=6298