### PR TITLE
Make _timescaledb_functions.makeaclitem strict

### DIFF
--- a/.unreleased/fix_6305
+++ b/.unreleased/fix_6305
@@ -1,0 +1,1 @@
+Fixes: #6305 Make _timescaledb_functions.makeaclitem strict

--- a/sql/maintenance_utils.sql
+++ b/sql/maintenance_utils.sql
@@ -126,7 +126,7 @@ $$ LANGUAGE plpgsql;
 -- This is intended for internal usage and interface might change.
 CREATE FUNCTION _timescaledb_functions.makeaclitem(regrole, regrole, text, bool)
 RETURNS AclItem AS '@MODULE_PATHNAME@', 'ts_makeaclitem'
-LANGUAGE C STABLE PARALLEL SAFE;
+LANGUAGE C STABLE PARALLEL SAFE STRICT;
 
 -- Repair relation ACL by removing roles that do not exist in pg_authid.
 CREATE PROCEDURE _timescaledb_functions.repair_relation_acls()

--- a/test/expected/util.out
+++ b/test/expected/util.out
@@ -2,3 +2,17 @@
 -- Please see the included NOTICE for copyright information and
 -- LICENSE-APACHE for a copy of the license.
 \set ECHO errors
+        item        
+--------------------
+ wizard=a/wizard
+ wizard=ar/wizard
+ wizard=a*/wizard
+ wizard=a*r*/wizard
+ [NULL]
+ [NULL]
+ [NULL]
+ [NULL]
+ =a*r*/wizard
+ wizard=a*r*/0
+(10 rows)
+

--- a/test/sql/util.sql
+++ b/test/sql/util.sql
@@ -4,6 +4,7 @@
 
 \set ECHO errors
 \set VERBOSITY default
+\c :TEST_DBNAME :ROLE_SUPERUSER
 
 DO $$
 BEGIN
@@ -11,3 +12,20 @@ BEGIN
   ASSERT( _timescaledb_functions.get_partition_for_key('dev1'::text) = 1129986420 );
   ASSERT( _timescaledb_functions.get_partition_for_key('longlonglonglongpartitionkey'::text) = 1169179734);
 END$$;
+
+\pset null '[NULL]'
+CREATE USER wizard;
+SELECT * FROM (
+    VALUES
+       (_timescaledb_functions.makeaclitem('wizard', 'wizard', 'insert', false)),
+       (_timescaledb_functions.makeaclitem('wizard', 'wizard', 'insert,select', false)),
+       (_timescaledb_functions.makeaclitem('wizard', 'wizard', 'insert', true)),
+       (_timescaledb_functions.makeaclitem('wizard', 'wizard', 'insert,select', true)),
+       (_timescaledb_functions.makeaclitem(NULL, 'wizard', 'insert,select', true)),
+       (_timescaledb_functions.makeaclitem('wizard', NULL, 'insert,select', true)),
+       (_timescaledb_functions.makeaclitem('wizard', 'wizard', NULL, true)),
+       (_timescaledb_functions.makeaclitem('wizard', 'wizard', 'insert,select', NULL)),
+       (_timescaledb_functions.makeaclitem(0, 'wizard', 'insert,select', true)),
+       (_timescaledb_functions.makeaclitem('wizard', 0, 'insert,select', true))
+    ) AS t(item);
+DROP USER wizard;


### PR DESCRIPTION
Function `_timescaledb_functions.makeaclitem` needs to be strict since if it is called with NULL values, it should return NULL.