### PR TITLE
Fix solo test for dist_util

### DIFF
--- a/tsl/test/sql/CMakeLists.txt
+++ b/tsl/test/sql/CMakeLists.txt
@@ -150,7 +150,7 @@ set(SOLO_TESTS
     cagg_bgw
     cagg_ddl-${PG_VERSION_MAJOR}
     cagg_dump
-    dist_util
+    dist_util-${PG_VERSION_MAJOR}
     move
     remote_connection_cache
     remote_copy


### PR DESCRIPTION
In 068534e31730154b894dc8e4fb5315054e1ae51c we make the dist_util regression test version specific. However, the solo test declaration for this test was not adjusted, which makes this test flaky. This PR fixes the declaration.

---

Disable-check: force-changelog-file

Fixed CI run: https://github.com/timescale/timescaledb/actions/runs/6864087479/job/18665114320?pr=6311

```
test dist_util-13                 ... ok         8627 ms
...
test dist_util-15                 ... ok         8302 ms
```