### PR TITLE
Remove useless table lock

### DIFF
--- a/sql/size_utils.sql
+++ b/sql/size_utils.sql
@@ -212,9 +212,6 @@ BEGIN
                 END IF;
         END IF;
 
-        /* Lock hypertable to avoid risk of concurrent process dropping chunks */
-        EXECUTE format('LOCK TABLE %I.%I IN ACCESS SHARE MODE', schema_name, table_name);
-
         CASE WHEN is_distributed THEN
 			RETURN QUERY
 			SELECT *, NULL::name

--- a/src/utils.c
+++ b/src/utils.c
@@ -37,6 +37,7 @@
 
 #include "compat/compat.h"
 #include "chunk.h"
+#include "debug_point.h"
 #include "guc.h"
 #include "hypertable_cache.h"
 #include "utils.h"
@@ -995,6 +996,7 @@ ts_relation_size_impl(Oid relid)
 	Datum reloid = ObjectIdGetDatum(relid);
 	Relation rel;
 
+	DEBUG_WAITPOINT("relation_size_before_lock");
 	/* Open relation earlier to keep a lock during all function calls */
 	rel = try_relation_open(relid, AccessShareLock);
 

--- a/test/isolation/expected/concurrent_query_and_drop_chunks.out
+++ b/test/isolation/expected/concurrent_query_and_drop_chunks.out
@@ -1,4 +1,4 @@
-Parsed test spec with 2 sessions
+Parsed test spec with 4 sessions
 
 starting permutation: s2_query s1_wp_enable s2_query s1_drop_chunks s1_wp_release s2_show_num_chunks
 step s2_query: SELECT * FROM measurements ORDER BY 1;
@@ -34,6 +34,33 @@ Sun Jan 03 10:30:00 2021 PST|     2|   2
 (1 row)
 
 step s2_show_num_chunks: SELECT count(*) FROM show_chunks('measurements') ORDER BY 1;
+count
+-----
+    1
+(1 row)
+
+
+starting permutation: s3_wp_enable s4_hypertable_size s3_drop_chunks s3_wp_release
+step s3_wp_enable: SELECT debug_waitpoint_enable('relation_size_before_lock');
+debug_waitpoint_enable
+----------------------
+                      
+(1 row)
+
+step s4_hypertable_size: SELECT count(*) FROM hypertable_size('measurements'); <waiting ...>
+step s3_drop_chunks: SELECT count(*) FROM drop_chunks('measurements', TIMESTAMPTZ '2020-03-01');
+count
+-----
+    1
+(1 row)
+
+step s3_wp_release: SELECT debug_waitpoint_release('relation_size_before_lock');
+debug_waitpoint_release
+-----------------------
+                       
+(1 row)
+
+step s4_hypertable_size: <... completed>
 count
 -----
     1

--- a/test/isolation/specs/concurrent_query_and_drop_chunks.spec
+++ b/test/isolation/specs/concurrent_query_and_drop_chunks.spec
@@ -13,10 +13,9 @@ teardown {
   DROP TABLE measurements;
 }
 
-# Test concurrent querying and drop chunks. The wait point happens
-# after chunks have been found for table expansion, but before the
-# chunks are locked. Because one chunk will dropped before the lock is
-# acqurired, the chunk should also be ignored.
+#
+# Test concurrent querying and drop chunks.
+#
 
 session "s1"
 step "s1_wp_enable" { SELECT debug_waitpoint_enable('hypertable_expansion_before_lock_chunk'); }
@@ -27,4 +26,21 @@ session "s2"
 step "s2_show_num_chunks"  { SELECT count(*) FROM show_chunks('measurements') ORDER BY 1; }
 step "s2_query"  { SELECT * FROM measurements ORDER BY 1; }
 
+session "s3"
+step "s3_wp_enable" { SELECT debug_waitpoint_enable('relation_size_before_lock'); }
+step "s3_wp_release" { SELECT debug_waitpoint_release('relation_size_before_lock'); }
+step "s3_drop_chunks" { SELECT count(*) FROM drop_chunks('measurements', TIMESTAMPTZ '2020-03-01'); }
+
+session "s4"
+step "s4_hypertable_size"  { SELECT count(*) FROM hypertable_size('measurements'); }
+
+# The wait point happens after chunks have been found for table
+# expansion, but before the chunks are locked. Because one chunk
+# will dropped before the lock is acqurired, the chunk should
+# also be ignored.
 permutation "s2_query" "s1_wp_enable" "s2_query" "s1_drop_chunks" "s1_wp_release" "s2_show_num_chunks"
+
+# The wait point happens before the relation_size get the lock
+# for the relation and one chunk will be dropped in another session
+# don't leading to race conditions
+permutation "s3_wp_enable" "s4_hypertable_size" "s3_drop_chunks" "s3_wp_release"


### PR DESCRIPTION
In https://github.com/timescale/timescaledb/commit/ae21ee96565f58efade65d82611354679745b5b8 we fixed a race condition when running a query to get the
hypertable sizes and one or more chunks was dropped in a concurrent
session leading to exception because the chunks does not exist.

In fact the table lock introduced is useless because we also addad
proper joins with Postgres catalog tables to ensure that the relation
exists in the database when calculation the sizes. And even worse with
this table lock now dropping chunks wait for the functions that
calculate the hypertable sizes.

Fixed it by removing the useless table lock and also added isolation
tests to make sure we'll not end up with race conditions again.

Disable-check: force-changelog-file
