### PR TITLE
Use test-specific temporary roles

### DIFF
--- a/test/expected/repair.out
+++ b/test/expected/repair.out
@@ -4,7 +4,8 @@
 -- We are testing different repair functions here to make sure that
 -- they work as expected.
 \c :TEST_DBNAME :ROLE_SUPERUSER
-CREATE USER wizard;
+\set TMP_USER :TEST_DBNAME _wizard
+CREATE USER :TMP_USER;
 CREATE USER "Random L User";
 CREATE TABLE test_table_1(time timestamptz not null, temp float);
 SELECT create_hypertable('test_table_1', by_range('time', '1 day'::interval));
@@ -34,12 +35,12 @@ SELECT time, 100 * random()
            '2000-01-05'::timestamptz,
            '1min'::interval
        ) time;
-GRANT ALL ON test_table_1 TO wizard;
-GRANT ALL ON test_table_2 TO wizard;
+GRANT ALL ON test_table_1 TO :TMP_USER;
+GRANT ALL ON test_table_2 TO :TMP_USER;
 GRANT SELECT, INSERT ON test_table_1 TO "Random L User";
 GRANT INSERT ON test_table_2 TO "Random L User";
 -- Break the relacl of the table by deleting users
-DELETE FROM pg_authid WHERE rolname IN ('wizard', 'Random L User');
+DELETE FROM pg_authid WHERE rolname IN (:'TMP_USER', 'Random L User');
 CREATE TABLE saved (LIKE pg_class);
 INSERT INTO saved SELECT * FROM pg_class;
 CALL _timescaledb_functions.repair_relation_acls();

--- a/test/expected/util.out
+++ b/test/expected/util.out
@@ -2,17 +2,17 @@
 -- Please see the included NOTICE for copyright information and
 -- LICENSE-APACHE for a copy of the license.
 \set ECHO errors
-        item        
---------------------
- wizard=a/wizard
- wizard=ar/wizard
- wizard=a*/wizard
- wizard=a*r*/wizard
+                item                
+------------------------------------
+ db_util_wizard=a/db_util_wizard
+ db_util_wizard=ar/db_util_wizard
+ db_util_wizard=a*/db_util_wizard
+ db_util_wizard=a*r*/db_util_wizard
  [NULL]
  [NULL]
  [NULL]
  [NULL]
- =a*r*/wizard
- wizard=a*r*/0
+ =a*r*/db_util_wizard
+ db_util_wizard=a*r*/0
 (10 rows)
 

--- a/test/sql/repair.sql
+++ b/test/sql/repair.sql
@@ -7,7 +7,9 @@
 
 \c :TEST_DBNAME :ROLE_SUPERUSER
 
-CREATE USER wizard;
+\set TMP_USER :TEST_DBNAME _wizard
+
+CREATE USER :TMP_USER;
 CREATE USER "Random L User";
 
 CREATE TABLE test_table_1(time timestamptz not null, temp float);
@@ -32,13 +34,13 @@ SELECT time, 100 * random()
            '1min'::interval
        ) time;
 
-GRANT ALL ON test_table_1 TO wizard;
-GRANT ALL ON test_table_2 TO wizard;
+GRANT ALL ON test_table_1 TO :TMP_USER;
+GRANT ALL ON test_table_2 TO :TMP_USER;
 GRANT SELECT, INSERT ON test_table_1 TO "Random L User";
 GRANT INSERT ON test_table_2 TO "Random L User";
 
 -- Break the relacl of the table by deleting users
-DELETE FROM pg_authid WHERE rolname IN ('wizard', 'Random L User');
+DELETE FROM pg_authid WHERE rolname IN (:'TMP_USER', 'Random L User');
 
 CREATE TABLE saved (LIKE pg_class);
 INSERT INTO saved SELECT * FROM pg_class;

--- a/test/sql/util.sql
+++ b/test/sql/util.sql
@@ -6,6 +6,8 @@
 \set VERBOSITY default
 \c :TEST_DBNAME :ROLE_SUPERUSER
 
+\set TMP_USER :TEST_DBNAME _wizard
+
 DO $$
 BEGIN
   ASSERT( _timescaledb_functions.get_partition_for_key(''::text) = 669664877 );
@@ -14,18 +16,18 @@ BEGIN
 END$$;
 
 \pset null '[NULL]'
-CREATE USER wizard;
+CREATE USER :TMP_USER;
 SELECT * FROM (
     VALUES
-       (_timescaledb_functions.makeaclitem('wizard', 'wizard', 'insert', false)),
-       (_timescaledb_functions.makeaclitem('wizard', 'wizard', 'insert,select', false)),
-       (_timescaledb_functions.makeaclitem('wizard', 'wizard', 'insert', true)),
-       (_timescaledb_functions.makeaclitem('wizard', 'wizard', 'insert,select', true)),
-       (_timescaledb_functions.makeaclitem(NULL, 'wizard', 'insert,select', true)),
-       (_timescaledb_functions.makeaclitem('wizard', NULL, 'insert,select', true)),
-       (_timescaledb_functions.makeaclitem('wizard', 'wizard', NULL, true)),
-       (_timescaledb_functions.makeaclitem('wizard', 'wizard', 'insert,select', NULL)),
-       (_timescaledb_functions.makeaclitem(0, 'wizard', 'insert,select', true)),
-       (_timescaledb_functions.makeaclitem('wizard', 0, 'insert,select', true))
+       (_timescaledb_functions.makeaclitem(:'TMP_USER', :'TMP_USER', 'insert', false)),
+       (_timescaledb_functions.makeaclitem(:'TMP_USER', :'TMP_USER', 'insert,select', false)),
+       (_timescaledb_functions.makeaclitem(:'TMP_USER', :'TMP_USER', 'insert', true)),
+       (_timescaledb_functions.makeaclitem(:'TMP_USER', :'TMP_USER', 'insert,select', true)),
+       (_timescaledb_functions.makeaclitem(NULL, :'TMP_USER', 'insert,select', true)),
+       (_timescaledb_functions.makeaclitem(:'TMP_USER', NULL, 'insert,select', true)),
+       (_timescaledb_functions.makeaclitem(:'TMP_USER', :'TMP_USER', NULL, true)),
+       (_timescaledb_functions.makeaclitem(:'TMP_USER', :'TMP_USER', 'insert,select', NULL)),
+       (_timescaledb_functions.makeaclitem(0, :'TMP_USER', 'insert,select', true)),
+       (_timescaledb_functions.makeaclitem(:'TMP_USER', 0, 'insert,select', true))
     ) AS t(item);
-DROP USER wizard;
+DROP USER :TMP_USER;


### PR DESCRIPTION
Tests `util` and `repair` both used the same user name, so when executing in the same parallel suite they could cause conflict.

Instead, use different role names for different tests.

Disable-check: force-changelog-file