### PR TITLE
Make batch sorted merge cost depend on number of unique segmentby values

### DIFF
--- a/tsl/src/nodes/decompress_chunk/decompress_chunk.c
+++ b/tsl/src/nodes/decompress_chunk/decompress_chunk.c
@@ -825,7 +825,7 @@ ts_decompress_chunk_generate_paths(PlannerInfo *root, RelOptInfo *chunk_rel, Hyp
 		path = (Path *) decompress_chunk_path_create(root, compression_info, 0, compressed_path);
 
 		/*
-		 * Create a path for the sorted merge append optimization. This optimization performs a
+		 * Create a path for the batch sorted merge optimization. This optimization performs a
 		 * merge append of the involved batches by using a binary heap and preserving the
 		 * compression order. This optimization is only taken into consideration if we can't push
 		 * down the sort to the compressed chunk. If we can push down the sort, the batches can be

--- a/tsl/src/nodes/decompress_chunk/decompress_chunk.c
+++ b/tsl/src/nodes/decompress_chunk/decompress_chunk.c
@@ -37,15 +37,7 @@
 #include "nodes/decompress_chunk/qual_pushdown.h"
 #include "utils.h"
 
-#define DECOMPRESS_CHUNK_CPU_TUPLE_COST 0.01
-
 #define DECOMPRESS_CHUNK_BATCH_SIZE 1000
-
-/* We have to decompress the compressed batches in parallel. Therefore, we need a high
- * amount of memory. Set the tuple cost for this algorithm a very high value to prevent
- * that this algorithm is chosen when a lot of batches needs to be merged. For more details,
- * see the discussion in cost_decompress_sorted_merge_append(). */
-#define DECOMPRESS_CHUNK_HEAP_MERGE_CPU_TUPLE_COST 0.8
 
 static CustomPathMethods decompress_chunk_path_methods = {
 	.CustomName = "DecompressChunk",
@@ -334,8 +326,17 @@ cost_decompress_chunk(Path *path, Path *compressed_path)
 		path->startup_cost = compressed_path->total_cost / compressed_path->rows;
 
 	/* total_cost is cost for fetching all tuples */
-	path->total_cost = compressed_path->total_cost + path->rows * DECOMPRESS_CHUNK_CPU_TUPLE_COST;
+	path->total_cost = compressed_path->total_cost + path->rows * cpu_tuple_cost;
 	path->rows = compressed_path->rows * DECOMPRESS_CHUNK_BATCH_SIZE;
+}
+
+/* Smoothstep function S1 (the h01 cubic Hermite spline). */
+static double
+smoothstep(double x, double start, double end)
+{
+	x = (x - start) / (end - start);
+	x = x < 0 ? 0 : x > 1 ? 1 : x;
+	return x * x * (3.0f - 2.0f * x);
 }
 
 /*
@@ -343,8 +344,8 @@ cost_decompress_chunk(Path *path, Path *compressed_path)
  * a binary heap.
  */
 static void
-cost_decompress_sorted_merge_append(PlannerInfo *root, DecompressChunkPath *dcpath,
-									Path *child_path)
+cost_batch_sorted_merge(PlannerInfo *root, CompressionInfo *compression_info,
+						DecompressChunkPath *dcpath, Path *compressed_path)
 {
 	Path sort_path; /* dummy for result of cost_sort */
 
@@ -358,41 +359,105 @@ cost_decompress_sorted_merge_append(PlannerInfo *root, DecompressChunkPath *dcpa
 	cost_sort(&sort_path,
 			  root,
 			  dcpath->compressed_pathkeys,
-			  child_path->total_cost,
-			  child_path->rows,
-			  child_path->pathtarget->width,
+			  compressed_path->total_cost,
+			  compressed_path->rows,
+			  compressed_path->pathtarget->width,
 			  0.0,
 			  work_mem,
 			  -1);
 	enable_sort = old_enable_sort;
 
-	/* startup_cost is cost before fetching first tuple */
-	dcpath->custom_path.path.startup_cost = sort_path.total_cost;
+	/*
+	 * In compressed batch sorted merge, for each distinct segmentby value we
+	 * have to keep the corresponding latest batch open. Estimate the number of
+	 * these batches with the usual Postgres estimator for grouping cardinality.
+	 */
+	List *segmentby_groupexprs = NIL;
+	for (int segmentby_attno = bms_next_member(compression_info->chunk_segmentby_attnos, -1);
+		 segmentby_attno > 0;
+		 segmentby_attno =
+			 bms_next_member(compression_info->chunk_segmentby_attnos, segmentby_attno))
+	{
+		Var *var = palloc(sizeof(Var));
+		*var = (Var){ .xpr.type = T_Var,
+					  .varno = compression_info->compressed_rel->relid,
+					  .varattno = segmentby_attno };
+		segmentby_groupexprs = lappend(segmentby_groupexprs, var);
+	}
+	const double open_batches_estimated = estimate_num_groups_compat(root,
+																	 segmentby_groupexprs,
+																	 dcpath->custom_path.path.rows,
+																	 NULL,
+																	 NULL);
+	Assert(open_batches_estimated > 0);
 
 	/*
-	 * The cost model for the normal chunk decompression produces the following total
-	 * costs.
-	 *
-	 * Segments  Total costs
-	 * 10         711.84
-	 * 50        4060.91
-	 * 100       8588.32
-	 * 10000   119281.84
-	 *
-	 * The cost model of the regular decompression is roughly linear. Opening multiple batches in
-	 * parallel needs resources and merging a high amount of batches becomes inefficient at some
-	 * point. So, we use a quadratic cost model here to have higher costs than the normal
-	 * decompression when more than ~100 batches are used. We set
-	 * DECOMPRESS_CHUNK_HEAP_MERGE_CPU_TUPLE_COST to 0.8 to become most costly as soon as we have to
-	 * process more than 120 batches.
-	 *
-	 * Note: To behave similarly to the cost model of the regular decompression path, this cost
-	 * model does not consider the number of tuples.
+	 * We can't have more open batches than the total number of compressed rows,
+	 * so clamp it for sanity of the following calculations.
 	 */
-	dcpath->custom_path.path.total_cost =
-		sort_path.total_cost + pow(sort_path.rows, 2) * DECOMPRESS_CHUNK_HEAP_MERGE_CPU_TUPLE_COST;
+	const double open_batches_clamped = Min(open_batches_estimated, sort_path.rows);
 
-	dcpath->custom_path.path.rows = sort_path.rows * DECOMPRESS_CHUNK_BATCH_SIZE;
+	/*
+	 * Keeping a lot of batches open might use a lot of memory. The batch sorted
+	 * merge can't offload anything to disk, so we just penalize it heavily if
+	 * we expect it to go over the work_mem. First, estimate the amount of
+	 * memory we'll need. We do this on the basis of uncompressed chunk width,
+	 * as if we had to materialize entire decompressed batches. This might
+	 * be less precise when bulk decompression is not used, because we
+	 * materialize only the compressed data which is smaller. But it accounts
+	 * for projections, which is probably more important than precision, because
+	 * we often read a small subset of columns in analytical queries. The
+	 * compressed chunk is never projected so we can't use it for that.
+	 */
+	const double work_mem_bytes = work_mem * 1024;
+	const double needed_memory_bytes = open_batches_clamped * DECOMPRESS_CHUNK_BATCH_SIZE *
+									   dcpath->custom_path.path.pathtarget->width;
+
+	fprintf(stderr,
+			"open batches %lf, needed_bytes %lf\n",
+			open_batches_clamped,
+			needed_memory_bytes);
+
+	/*
+	 * Next, calculate the cost penalty. It is a smooth step, starting at 75% of
+	 * work_mem, and ending at 125%. We want to effectively disable this plan
+	 * if it doesn't fit into the available memory, so the penalty should be
+	 * comparable to disable_cost but still less than it, so that the
+	 * manual disables still have priority.
+	 */
+	const double work_mem_penalty =
+		0.1 * disable_cost *
+		smoothstep(needed_memory_bytes, 0.75 * work_mem_bytes, 1.25 * work_mem_bytes);
+	Assert(work_mem_penalty >= 0);
+
+	/*
+	 * startup_cost is cost before fetching first tuple. Batch sorted merge has
+	 * to load at least the number of batches we expect to be open
+	 * simultaneously, before it can produce the first row.
+	 */
+	const double sort_path_cost_for_startup =
+		sort_path.startup_cost +
+		(sort_path.total_cost - sort_path.startup_cost) * (open_batches_clamped / sort_path.rows);
+	Assert(sort_path_cost_for_startup >= 0);
+	dcpath->custom_path.path.startup_cost = sort_path_cost_for_startup + work_mem_penalty;
+
+	/*
+	 * Finally, to run this path to completion, we have to complete the
+	 * underlying sort path, and return all uncompressed rows. Getting one
+	 * uncompressed row involves replacing the top row in the heap, which costs
+	 * O(log(heap size)). The constant multiplier is found empirically by
+	 * benchmarking the queries returning 1 - 1e9 tuples, with segmentby
+	 * cardinality 1 to 1e4, and adjusting the cost so that the fastest plan is
+	 * used. The "+ 1" under the logarithm is to avoid zero uncompressed row cost
+	 * when we expect to have only 1 batch open.
+	 */
+	const double sort_path_cost_rest = sort_path.total_cost - sort_path_cost_for_startup;
+	Assert(sort_path_cost_rest >= 0);
+	const double uncompressed_row_cost = 1.5 * log(open_batches_clamped + 1) * cpu_tuple_cost;
+	Assert(uncompressed_row_cost > 0);
+	dcpath->custom_path.path.total_cost = dcpath->custom_path.path.startup_cost +
+										  sort_path_cost_rest +
+										  dcpath->custom_path.path.rows * uncompressed_row_cost;
 }
 
 /*
@@ -454,7 +519,7 @@ cost_decompress_sorted_merge_append(PlannerInfo *root, DecompressChunkPath *dcpa
  * compatible and the optimization can be used.
  */
 static MergeBatchResult
-can_sorted_merge_append(PlannerInfo *root, CompressionInfo *info, Chunk *chunk)
+can_batch_sorted_merge(PlannerInfo *root, CompressionInfo *info, Chunk *chunk)
 {
 	PathKey *pk;
 	Var *var;
@@ -563,13 +628,13 @@ can_sorted_merge_append(PlannerInfo *root, CompressionInfo *info, Chunk *chunk)
  */
 static void
 add_chunk_sorted_paths(PlannerInfo *root, RelOptInfo *chunk_rel, Hypertable *ht, Index ht_relid,
-					   Path *decompress_chunk_path, Path *child_path)
+					   Path *decompress_chunk_path, Path *compressed_path)
 {
 	if (root->query_pathkeys == NIL || hypertable_is_distributed(ht))
 		return;
 
 	/* We are only interested in regular (i.e., non index) paths */
-	if (!IsA(child_path, Path))
+	if (!IsA(compressed_path, Path))
 		return;
 
 	/* Iterate over the sort_pathkeys and generate all possible useful sortings */
@@ -620,14 +685,14 @@ ts_decompress_chunk_generate_paths(PlannerInfo *root, RelOptInfo *chunk_rel, Hyp
 	double new_row_estimate;
 	Index ht_relid = 0;
 
-	CompressionInfo *info = build_compressioninfo(root, ht, chunk_rel);
+	CompressionInfo *compression_info = build_compressioninfo(root, ht, chunk_rel);
 
 	/* double check we don't end up here on single chunk queries with ONLY */
-	Assert(info->chunk_rel->reloptkind == RELOPT_OTHER_MEMBER_REL ||
-		   (info->chunk_rel->reloptkind == RELOPT_BASEREL &&
-			ts_rte_is_marked_for_expansion(info->chunk_rte)));
+	Assert(compression_info->chunk_rel->reloptkind == RELOPT_OTHER_MEMBER_REL ||
+		   (compression_info->chunk_rel->reloptkind == RELOPT_BASEREL &&
+			ts_rte_is_marked_for_expansion(compression_info->chunk_rte)));
 
-	SortInfo sort_info = build_sortinfo(chunk, chunk_rel, info, root->query_pathkeys);
+	SortInfo sort_info = build_sortinfo(chunk, chunk_rel, compression_info, root->query_pathkeys);
 
 	Assert(chunk->fd.compressed_chunk_id > 0);
 
@@ -637,20 +702,24 @@ ts_decompress_chunk_generate_paths(PlannerInfo *root, RelOptInfo *chunk_rel, Hyp
 	chunk_rel->partial_pathlist = NIL;
 
 	/* add RangeTblEntry and RelOptInfo for compressed chunk */
-	decompress_chunk_add_plannerinfo(root, info, chunk, chunk_rel, sort_info.needs_sequence_num);
-	compressed_rel = info->compressed_rel;
+	decompress_chunk_add_plannerinfo(root,
+									 compression_info,
+									 chunk,
+									 chunk_rel,
+									 sort_info.needs_sequence_num);
+	compressed_rel = compression_info->compressed_rel;
 
 	compressed_rel->consider_parallel = chunk_rel->consider_parallel;
 	/* translate chunk_rel->baserestrictinfo */
 	pushdown_quals(root,
 				   chunk_rel,
 				   compressed_rel,
-				   info->hypertable_compression_info,
+				   compression_info->hypertable_compression_info,
 				   ts_chunk_is_partial(chunk));
 	set_baserel_size_estimates(root, compressed_rel);
 	new_row_estimate = compressed_rel->rows * DECOMPRESS_CHUNK_BATCH_SIZE;
 
-	if (!info->single_chunk)
+	if (!compression_info->single_chunk)
 	{
 		/* adjust the parent's estimate by the diff of new and old estimate */
 		AppendRelInfo *chunk_info = ts_get_appendrelinfo(root, chunk_rel->relid, false);
@@ -662,17 +731,17 @@ ts_decompress_chunk_generate_paths(PlannerInfo *root, RelOptInfo *chunk_rel, Hyp
 
 	chunk_rel->rows = new_row_estimate;
 
-	create_compressed_scan_paths(root, compressed_rel, info, &sort_info);
+	create_compressed_scan_paths(root, compressed_rel, compression_info, &sort_info);
 
 	/* compute parent relids of the chunk and use it to filter paths*/
 	Relids parent_relids = NULL;
-	if (!info->single_chunk)
+	if (!compression_info->single_chunk)
 		parent_relids = find_childrel_parents(root, chunk_rel);
 
 	/* create non-parallel paths */
 	foreach (lc, compressed_rel->pathlist)
 	{
-		Path *child_path = lfirst(lc);
+		Path *compressed_path = lfirst(lc);
 		Path *path;
 
 		/*
@@ -683,7 +752,7 @@ ts_decompress_chunk_generate_paths(PlannerInfo *root, RelOptInfo *chunk_rel, Hyp
 		 * that would have invalid references due to our
 		 * EquivalenceClasses.
 		 */
-		if (IsA(child_path, BitmapHeapPath) && child_path->param_info)
+		if (IsA(compressed_path, BitmapHeapPath) && compressed_path->param_info)
 			continue;
 
 		/*
@@ -697,9 +766,9 @@ ts_decompress_chunk_generate_paths(PlannerInfo *root, RelOptInfo *chunk_rel, Hyp
 		 * The parent-child relationship between chunk_rel and ht is known
 		 * to PG and so it does not try to create meaningless rinfos for that case.
 		 */
-		if (child_path->param_info != NULL)
+		if (compressed_path->param_info != NULL)
 		{
-			if (bms_is_member(chunk_rel->relid, child_path->param_info->ppi_req_outer))
+			if (bms_is_member(chunk_rel->relid, compressed_path->param_info->ppi_req_outer))
 				continue;
 			/* check if this is path made with references between
 			 * compressed_rel + hypertable or a nesting subquery.
@@ -707,7 +776,7 @@ ts_decompress_chunk_generate_paths(PlannerInfo *root, RelOptInfo *chunk_rel, Hyp
 			 * happens since PG is not aware that the nesting
 			 * subquery that references the hypertable is a parent of compressed_rel as well.
 			 */
-			if (bms_overlap(parent_relids, child_path->param_info->ppi_req_outer))
+			if (bms_overlap(parent_relids, compressed_path->param_info->ppi_req_outer))
 				continue;
 
 			ListCell *lc_ri;
@@ -722,16 +791,16 @@ ts_decompress_chunk_generate_paths(PlannerInfo *root, RelOptInfo *chunk_rel, Hyp
 			 * compatible. Therefore we skip any Path that is
 			 * parameterized on a compressed column here.
 			 */
-			foreach (lc_ri, child_path->param_info->ppi_clauses)
+			foreach (lc_ri, compressed_path->param_info->ppi_clauses)
 			{
 				RestrictInfo *ri = lfirst_node(RestrictInfo, lc_ri);
 
 				if (ri->right_em && IsA(ri->right_em->em_expr, Var) &&
 					(Index) castNode(Var, ri->right_em->em_expr)->varno ==
-						info->compressed_rel->relid)
+						compression_info->compressed_rel->relid)
 				{
 					Var *var = castNode(Var, ri->right_em->em_expr);
-					if (is_compressed_column(info, var->vartype))
+					if (is_compressed_column(compression_info, var->vartype))
 					{
 						references_compressed = true;
 						break;
@@ -739,10 +808,10 @@ ts_decompress_chunk_generate_paths(PlannerInfo *root, RelOptInfo *chunk_rel, Hyp
 				}
 				if (ri->left_em && IsA(ri->left_em->em_expr, Var) &&
 					(Index) castNode(Var, ri->left_em->em_expr)->varno ==
-						info->compressed_rel->relid)
+						compression_info->compressed_rel->relid)
 				{
 					Var *var = castNode(Var, ri->left_em->em_expr);
-					if (is_compressed_column(info, var->vartype))
+					if (is_compressed_column(compression_info, var->vartype))
 					{
 						references_compressed = true;
 						break;
@@ -753,7 +822,7 @@ ts_decompress_chunk_generate_paths(PlannerInfo *root, RelOptInfo *chunk_rel, Hyp
 				continue;
 		}
 
-		path = (Path *) decompress_chunk_path_create(root, info, 0, child_path);
+		path = (Path *) decompress_chunk_path_create(root, compression_info, 0, compressed_path);
 
 		/*
 		 * Create a path for the sorted merge append optimization. This optimization performs a
@@ -766,7 +835,7 @@ ts_decompress_chunk_generate_paths(PlannerInfo *root, RelOptInfo *chunk_rel, Hyp
 
 		if (ts_guc_enable_decompression_sorted_merge && !sort_info.can_pushdown_sort)
 		{
-			MergeBatchResult merge_result = can_sorted_merge_append(root, info, chunk);
+			MergeBatchResult merge_result = can_batch_sorted_merge(root, compression_info, chunk);
 			if (merge_result != MERGE_NOT_POSSIBLE)
 			{
 				batch_merge_path = copy_decompress_chunk_path((DecompressChunkPath *) path);
@@ -779,7 +848,7 @@ ts_decompress_chunk_generate_paths(PlannerInfo *root, RelOptInfo *chunk_rel, Hyp
 				 * query here.
 				 */
 				batch_merge_path->custom_path.path.pathkeys = root->query_pathkeys;
-				cost_decompress_sorted_merge_append(root, batch_merge_path, child_path);
+				cost_batch_sorted_merge(root, compression_info, batch_merge_path, compressed_path);
 
 				/* If the chunk is partially compressed, prepare the path only and add it later
 				 * to a merge append path when we are able to generate the ordered result for the
@@ -808,16 +877,16 @@ ts_decompress_chunk_generate_paths(PlannerInfo *root, RelOptInfo *chunk_rel, Hyp
 			 * creation. Examples of this in: create_merge_append_path &
 			 * create_merge_append_plan
 			 */
-			if (!pathkeys_contained_in(dcpath->compressed_pathkeys, child_path->pathkeys))
+			if (!pathkeys_contained_in(dcpath->compressed_pathkeys, compressed_path->pathkeys))
 			{
 				Path sort_path; /* dummy for result of cost_sort */
 
 				cost_sort(&sort_path,
 						  root,
 						  dcpath->compressed_pathkeys,
-						  child_path->total_cost,
-						  child_path->rows,
-						  child_path->pathtarget->width,
+						  compressed_path->total_cost,
+						  compressed_path->rows,
+						  compressed_path->pathtarget->width,
 						  0.0,
 						  work_mem,
 						  -1);
@@ -891,7 +960,7 @@ ts_decompress_chunk_generate_paths(PlannerInfo *root, RelOptInfo *chunk_rel, Hyp
 		}
 
 		/* Add useful sorted versions of the decompress path */
-		add_chunk_sorted_paths(root, chunk_rel, ht, ht_relid, path, child_path);
+		add_chunk_sorted_paths(root, chunk_rel, ht, ht_relid, path, compressed_path);
 
 		/* this has to go after the path is copied for the ordered path since path can get freed in
 		 * add_path */
@@ -906,20 +975,22 @@ ts_decompress_chunk_generate_paths(PlannerInfo *root, RelOptInfo *chunk_rel, Hyp
 	{
 		foreach (lc, compressed_rel->partial_pathlist)
 		{
-			Path *child_path = lfirst(lc);
+			Path *compressed_path = lfirst(lc);
 			Path *path;
-			if (child_path->param_info != NULL &&
-				(bms_is_member(chunk_rel->relid, child_path->param_info->ppi_req_outer) ||
-				 (!info->single_chunk &&
-				  bms_is_member(ht_relid, child_path->param_info->ppi_req_outer))))
+			if (compressed_path->param_info != NULL &&
+				(bms_is_member(chunk_rel->relid, compressed_path->param_info->ppi_req_outer) ||
+				 (!compression_info->single_chunk &&
+				  bms_is_member(ht_relid, compressed_path->param_info->ppi_req_outer))))
 				continue;
 
 			/*
 			 * If this is a partially compressed chunk we have to combine data
 			 * from compressed and uncompressed chunk.
 			 */
-			path = (Path *)
-				decompress_chunk_path_create(root, info, child_path->parallel_workers, child_path);
+			path = (Path *) decompress_chunk_path_create(root,
+														 compression_info,
+														 compressed_path->parallel_workers,
+														 compressed_path);
 
 			if (ts_chunk_is_partial(chunk))
 			{

--- a/tsl/src/nodes/decompress_chunk/exec.c
+++ b/tsl/src/nodes/decompress_chunk/exec.c
@@ -79,7 +79,7 @@ static const struct BatchQueueFunctions BatchQueueFunctionsHeap = {
 /*
  * Build the sortkeys data structure from the list structure in the
  * custom_private field of the custom scan. This sort info is used to sort
- * binary heap used for sorted merge append.
+ * binary heap used for batch sorted merge.
  */
 static void
 build_batch_sorted_merge_info(DecompressChunkState *chunk_state)
@@ -892,7 +892,7 @@ decompress_chunk_explain(CustomScanState *node, List *ancestors, ExplainState *e
 	{
 		if (chunk_state->batch_sorted_merge)
 		{
-			ExplainPropertyBool("Sorted merge append", chunk_state->batch_sorted_merge, es);
+			ExplainPropertyBool("Batch Sorted Merge", chunk_state->batch_sorted_merge, es);
 		}
 
 		if (es->analyze && (es->verbose || es->format != EXPLAIN_FORMAT_TEXT))

--- a/tsl/test/expected/compress_sorted_merge_filter.out
+++ b/tsl/test/expected/compress_sorted_merge_filter.out
@@ -22,6 +22,7 @@ select compress_chunk(x, true) from show_chunks('batches') x;
 
 analyze batches;
 set timescaledb.debug_require_batch_sorted_merge to true;
+set enable_sort to off;
 select ts from batches where ts != '2022-02-02 00:00:02' order by ts;
             ts            
 --------------------------

--- a/tsl/test/expected/compression.out
+++ b/tsl/test/expected/compression.out
@@ -2133,7 +2133,7 @@ ORDER BY timestamp desc  LIMIT 1 ) a ON true;
                ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_43_81_chunk
                      Output: _hyper_43_81_chunk."timestamp", _hyper_43_81_chunk.attr_id, _hyper_43_81_chunk.number_val
                      Filter: ((_hyper_43_81_chunk."timestamp" > 'Fri Jun 30 00:00:00 2023'::timestamp without time zone) AND (_hyper_43_81_chunk."timestamp" < 'Thu Jul 06 00:00:00 2023'::timestamp without time zone))
-                     Sorted merge append: true
+                     Batch Sorted Merge: true
                      ->  Sort
                            Output: compress_hyper_44_84_chunk."timestamp", compress_hyper_44_84_chunk.attr_id, compress_hyper_44_84_chunk.number_val, compress_hyper_44_84_chunk._ts_meta_count, compress_hyper_44_84_chunk._ts_meta_sequence_num, compress_hyper_44_84_chunk._ts_meta_min_1, compress_hyper_44_84_chunk._ts_meta_max_1
                            Sort Key: compress_hyper_44_84_chunk._ts_meta_max_1 DESC
@@ -2144,7 +2144,7 @@ ORDER BY timestamp desc  LIMIT 1 ) a ON true;
                ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_43_80_chunk
                      Output: _hyper_43_80_chunk."timestamp", _hyper_43_80_chunk.attr_id, _hyper_43_80_chunk.number_val
                      Filter: ((_hyper_43_80_chunk."timestamp" > 'Fri Jun 30 00:00:00 2023'::timestamp without time zone) AND (_hyper_43_80_chunk."timestamp" < 'Thu Jul 06 00:00:00 2023'::timestamp without time zone))
-                     Sorted merge append: true
+                     Batch Sorted Merge: true
                      ->  Sort
                            Output: compress_hyper_44_83_chunk."timestamp", compress_hyper_44_83_chunk.attr_id, compress_hyper_44_83_chunk.number_val, compress_hyper_44_83_chunk._ts_meta_count, compress_hyper_44_83_chunk._ts_meta_sequence_num, compress_hyper_44_83_chunk._ts_meta_min_1, compress_hyper_44_83_chunk._ts_meta_max_1
                            Sort Key: compress_hyper_44_83_chunk._ts_meta_max_1 DESC
@@ -2155,7 +2155,7 @@ ORDER BY timestamp desc  LIMIT 1 ) a ON true;
                ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_43_79_chunk
                      Output: _hyper_43_79_chunk."timestamp", _hyper_43_79_chunk.attr_id, _hyper_43_79_chunk.number_val
                      Filter: ((_hyper_43_79_chunk."timestamp" > 'Fri Jun 30 00:00:00 2023'::timestamp without time zone) AND (_hyper_43_79_chunk."timestamp" < 'Thu Jul 06 00:00:00 2023'::timestamp without time zone))
-                     Sorted merge append: true
+                     Batch Sorted Merge: true
                      ->  Sort
                            Output: compress_hyper_44_82_chunk."timestamp", compress_hyper_44_82_chunk.attr_id, compress_hyper_44_82_chunk.number_val, compress_hyper_44_82_chunk._ts_meta_count, compress_hyper_44_82_chunk._ts_meta_sequence_num, compress_hyper_44_82_chunk._ts_meta_min_1, compress_hyper_44_82_chunk._ts_meta_max_1
                            Sort Key: compress_hyper_44_82_chunk._ts_meta_max_1 DESC
@@ -2235,7 +2235,7 @@ SELECT * FROM sensor_data_compressed ORDER BY time DESC LIMIT 5;
  Mon Apr 07 16:00:00 1980 PST |         1 |   2 |           1
 (5 rows)
 
--- Only the first chunks should be accessed (sorted merge append is enabled)
+-- Only the first chunks should be accessed (batch sorted merge is enabled)
 :PREFIX
 SELECT * FROM sensor_data_compressed ORDER BY time DESC LIMIT 5;
                                                                                                                                                                               QUERY PLAN                                                                                                                                                                              
@@ -2257,7 +2257,7 @@ SELECT * FROM sensor_data_compressed ORDER BY time DESC LIMIT 5;
                Output: _hyper_45_88_chunk."time", _hyper_45_88_chunk.sensor_id, _hyper_45_88_chunk.cpu, _hyper_45_88_chunk.temperature
          ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_45_87_chunk (never executed)
                Output: _hyper_45_87_chunk."time", _hyper_45_87_chunk.sensor_id, _hyper_45_87_chunk.cpu, _hyper_45_87_chunk.temperature
-               Sorted merge append: true
+               Batch Sorted Merge: true
                Bulk Decompression: false
                ->  Sort (never executed)
                      Output: compress_hyper_46_94_chunk."time", compress_hyper_46_94_chunk.sensor_id, compress_hyper_46_94_chunk.cpu, compress_hyper_46_94_chunk.temperature, compress_hyper_46_94_chunk._ts_meta_count, compress_hyper_46_94_chunk._ts_meta_sequence_num, compress_hyper_46_94_chunk._ts_meta_min_1, compress_hyper_46_94_chunk._ts_meta_max_1
@@ -2266,7 +2266,7 @@ SELECT * FROM sensor_data_compressed ORDER BY time DESC LIMIT 5;
                            Output: compress_hyper_46_94_chunk."time", compress_hyper_46_94_chunk.sensor_id, compress_hyper_46_94_chunk.cpu, compress_hyper_46_94_chunk.temperature, compress_hyper_46_94_chunk._ts_meta_count, compress_hyper_46_94_chunk._ts_meta_sequence_num, compress_hyper_46_94_chunk._ts_meta_min_1, compress_hyper_46_94_chunk._ts_meta_max_1
          ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_45_86_chunk (never executed)
                Output: _hyper_45_86_chunk."time", _hyper_45_86_chunk.sensor_id, _hyper_45_86_chunk.cpu, _hyper_45_86_chunk.temperature
-               Sorted merge append: true
+               Batch Sorted Merge: true
                Bulk Decompression: false
                ->  Sort (never executed)
                      Output: compress_hyper_46_93_chunk."time", compress_hyper_46_93_chunk.sensor_id, compress_hyper_46_93_chunk.cpu, compress_hyper_46_93_chunk.temperature, compress_hyper_46_93_chunk._ts_meta_count, compress_hyper_46_93_chunk._ts_meta_sequence_num, compress_hyper_46_93_chunk._ts_meta_min_1, compress_hyper_46_93_chunk._ts_meta_max_1
@@ -2275,7 +2275,7 @@ SELECT * FROM sensor_data_compressed ORDER BY time DESC LIMIT 5;
                            Output: compress_hyper_46_93_chunk."time", compress_hyper_46_93_chunk.sensor_id, compress_hyper_46_93_chunk.cpu, compress_hyper_46_93_chunk.temperature, compress_hyper_46_93_chunk._ts_meta_count, compress_hyper_46_93_chunk._ts_meta_sequence_num, compress_hyper_46_93_chunk._ts_meta_min_1, compress_hyper_46_93_chunk._ts_meta_max_1
          ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_45_85_chunk (never executed)
                Output: _hyper_45_85_chunk."time", _hyper_45_85_chunk.sensor_id, _hyper_45_85_chunk.cpu, _hyper_45_85_chunk.temperature
-               Sorted merge append: true
+               Batch Sorted Merge: true
                Bulk Decompression: false
                ->  Sort (never executed)
                      Output: compress_hyper_46_92_chunk."time", compress_hyper_46_92_chunk.sensor_id, compress_hyper_46_92_chunk.cpu, compress_hyper_46_92_chunk.temperature, compress_hyper_46_92_chunk._ts_meta_count, compress_hyper_46_92_chunk._ts_meta_sequence_num, compress_hyper_46_92_chunk._ts_meta_min_1, compress_hyper_46_92_chunk._ts_meta_max_1
@@ -2284,7 +2284,7 @@ SELECT * FROM sensor_data_compressed ORDER BY time DESC LIMIT 5;
                            Output: compress_hyper_46_92_chunk."time", compress_hyper_46_92_chunk.sensor_id, compress_hyper_46_92_chunk.cpu, compress_hyper_46_92_chunk.temperature, compress_hyper_46_92_chunk._ts_meta_count, compress_hyper_46_92_chunk._ts_meta_sequence_num, compress_hyper_46_92_chunk._ts_meta_min_1, compress_hyper_46_92_chunk._ts_meta_max_1
 (42 rows)
 
--- Only the first chunks should be accessed (sorted merge append is disabled)
+-- Only the first chunks should be accessed (batch sorted merge is disabled)
 SET timescaledb.enable_decompression_sorted_merge = FALSE;
 :PREFIX
 SELECT * FROM sensor_data_compressed ORDER BY time DESC LIMIT 5;
@@ -2358,7 +2358,7 @@ SELECT * FROM sensor_data_compressed ORDER BY time DESC LIMIT 5;
  Mon Apr 07 16:00:00 1980 PST |         1 |   2 |           1
 (5 rows)
 
--- Only the first chunks should be accessed (sorted merge append is enabled)
+-- Only the first chunks should be accessed (batch sorted merge is enabled)
 :PREFIX
 SELECT * FROM sensor_data_compressed ORDER BY time DESC LIMIT 5;
                                                                                                                                                                               QUERY PLAN                                                                                                                                                                              
@@ -2372,7 +2372,7 @@ SELECT * FROM sensor_data_compressed ORDER BY time DESC LIMIT 5;
          Runtime Exclusion: false
          ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_45_91_chunk (actual rows=2 loops=1)
                Output: _hyper_45_91_chunk."time", _hyper_45_91_chunk.sensor_id, _hyper_45_91_chunk.cpu, _hyper_45_91_chunk.temperature
-               Sorted merge append: true
+               Batch Sorted Merge: true
                Bulk Decompression: false
                ->  Sort (actual rows=2 loops=1)
                      Output: compress_hyper_46_98_chunk."time", compress_hyper_46_98_chunk.sensor_id, compress_hyper_46_98_chunk.cpu, compress_hyper_46_98_chunk.temperature, compress_hyper_46_98_chunk._ts_meta_count, compress_hyper_46_98_chunk._ts_meta_sequence_num, compress_hyper_46_98_chunk._ts_meta_min_1, compress_hyper_46_98_chunk._ts_meta_max_1
@@ -2382,7 +2382,7 @@ SELECT * FROM sensor_data_compressed ORDER BY time DESC LIMIT 5;
                            Output: compress_hyper_46_98_chunk."time", compress_hyper_46_98_chunk.sensor_id, compress_hyper_46_98_chunk.cpu, compress_hyper_46_98_chunk.temperature, compress_hyper_46_98_chunk._ts_meta_count, compress_hyper_46_98_chunk._ts_meta_sequence_num, compress_hyper_46_98_chunk._ts_meta_min_1, compress_hyper_46_98_chunk._ts_meta_max_1
          ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_45_90_chunk (actual rows=2 loops=1)
                Output: _hyper_45_90_chunk."time", _hyper_45_90_chunk.sensor_id, _hyper_45_90_chunk.cpu, _hyper_45_90_chunk.temperature
-               Sorted merge append: true
+               Batch Sorted Merge: true
                Bulk Decompression: false
                ->  Sort (actual rows=2 loops=1)
                      Output: compress_hyper_46_97_chunk."time", compress_hyper_46_97_chunk.sensor_id, compress_hyper_46_97_chunk.cpu, compress_hyper_46_97_chunk.temperature, compress_hyper_46_97_chunk._ts_meta_count, compress_hyper_46_97_chunk._ts_meta_sequence_num, compress_hyper_46_97_chunk._ts_meta_min_1, compress_hyper_46_97_chunk._ts_meta_max_1
@@ -2392,7 +2392,7 @@ SELECT * FROM sensor_data_compressed ORDER BY time DESC LIMIT 5;
                            Output: compress_hyper_46_97_chunk."time", compress_hyper_46_97_chunk.sensor_id, compress_hyper_46_97_chunk.cpu, compress_hyper_46_97_chunk.temperature, compress_hyper_46_97_chunk._ts_meta_count, compress_hyper_46_97_chunk._ts_meta_sequence_num, compress_hyper_46_97_chunk._ts_meta_min_1, compress_hyper_46_97_chunk._ts_meta_max_1
          ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_45_89_chunk (actual rows=1 loops=1)
                Output: _hyper_45_89_chunk."time", _hyper_45_89_chunk.sensor_id, _hyper_45_89_chunk.cpu, _hyper_45_89_chunk.temperature
-               Sorted merge append: true
+               Batch Sorted Merge: true
                Bulk Decompression: false
                ->  Sort (actual rows=2 loops=1)
                      Output: compress_hyper_46_96_chunk."time", compress_hyper_46_96_chunk.sensor_id, compress_hyper_46_96_chunk.cpu, compress_hyper_46_96_chunk.temperature, compress_hyper_46_96_chunk._ts_meta_count, compress_hyper_46_96_chunk._ts_meta_sequence_num, compress_hyper_46_96_chunk._ts_meta_min_1, compress_hyper_46_96_chunk._ts_meta_max_1
@@ -2402,7 +2402,7 @@ SELECT * FROM sensor_data_compressed ORDER BY time DESC LIMIT 5;
                            Output: compress_hyper_46_96_chunk."time", compress_hyper_46_96_chunk.sensor_id, compress_hyper_46_96_chunk.cpu, compress_hyper_46_96_chunk.temperature, compress_hyper_46_96_chunk._ts_meta_count, compress_hyper_46_96_chunk._ts_meta_sequence_num, compress_hyper_46_96_chunk._ts_meta_min_1, compress_hyper_46_96_chunk._ts_meta_max_1
          ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_45_88_chunk (never executed)
                Output: _hyper_45_88_chunk."time", _hyper_45_88_chunk.sensor_id, _hyper_45_88_chunk.cpu, _hyper_45_88_chunk.temperature
-               Sorted merge append: true
+               Batch Sorted Merge: true
                Bulk Decompression: false
                ->  Sort (never executed)
                      Output: compress_hyper_46_95_chunk."time", compress_hyper_46_95_chunk.sensor_id, compress_hyper_46_95_chunk.cpu, compress_hyper_46_95_chunk.temperature, compress_hyper_46_95_chunk._ts_meta_count, compress_hyper_46_95_chunk._ts_meta_sequence_num, compress_hyper_46_95_chunk._ts_meta_min_1, compress_hyper_46_95_chunk._ts_meta_max_1
@@ -2411,7 +2411,7 @@ SELECT * FROM sensor_data_compressed ORDER BY time DESC LIMIT 5;
                            Output: compress_hyper_46_95_chunk."time", compress_hyper_46_95_chunk.sensor_id, compress_hyper_46_95_chunk.cpu, compress_hyper_46_95_chunk.temperature, compress_hyper_46_95_chunk._ts_meta_count, compress_hyper_46_95_chunk._ts_meta_sequence_num, compress_hyper_46_95_chunk._ts_meta_min_1, compress_hyper_46_95_chunk._ts_meta_max_1
          ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_45_87_chunk (never executed)
                Output: _hyper_45_87_chunk."time", _hyper_45_87_chunk.sensor_id, _hyper_45_87_chunk.cpu, _hyper_45_87_chunk.temperature
-               Sorted merge append: true
+               Batch Sorted Merge: true
                Bulk Decompression: false
                ->  Sort (never executed)
                      Output: compress_hyper_46_94_chunk."time", compress_hyper_46_94_chunk.sensor_id, compress_hyper_46_94_chunk.cpu, compress_hyper_46_94_chunk.temperature, compress_hyper_46_94_chunk._ts_meta_count, compress_hyper_46_94_chunk._ts_meta_sequence_num, compress_hyper_46_94_chunk._ts_meta_min_1, compress_hyper_46_94_chunk._ts_meta_max_1
@@ -2420,7 +2420,7 @@ SELECT * FROM sensor_data_compressed ORDER BY time DESC LIMIT 5;
                            Output: compress_hyper_46_94_chunk."time", compress_hyper_46_94_chunk.sensor_id, compress_hyper_46_94_chunk.cpu, compress_hyper_46_94_chunk.temperature, compress_hyper_46_94_chunk._ts_meta_count, compress_hyper_46_94_chunk._ts_meta_sequence_num, compress_hyper_46_94_chunk._ts_meta_min_1, compress_hyper_46_94_chunk._ts_meta_max_1
          ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_45_86_chunk (never executed)
                Output: _hyper_45_86_chunk."time", _hyper_45_86_chunk.sensor_id, _hyper_45_86_chunk.cpu, _hyper_45_86_chunk.temperature
-               Sorted merge append: true
+               Batch Sorted Merge: true
                Bulk Decompression: false
                ->  Sort (never executed)
                      Output: compress_hyper_46_93_chunk."time", compress_hyper_46_93_chunk.sensor_id, compress_hyper_46_93_chunk.cpu, compress_hyper_46_93_chunk.temperature, compress_hyper_46_93_chunk._ts_meta_count, compress_hyper_46_93_chunk._ts_meta_sequence_num, compress_hyper_46_93_chunk._ts_meta_min_1, compress_hyper_46_93_chunk._ts_meta_max_1
@@ -2429,7 +2429,7 @@ SELECT * FROM sensor_data_compressed ORDER BY time DESC LIMIT 5;
                            Output: compress_hyper_46_93_chunk."time", compress_hyper_46_93_chunk.sensor_id, compress_hyper_46_93_chunk.cpu, compress_hyper_46_93_chunk.temperature, compress_hyper_46_93_chunk._ts_meta_count, compress_hyper_46_93_chunk._ts_meta_sequence_num, compress_hyper_46_93_chunk._ts_meta_min_1, compress_hyper_46_93_chunk._ts_meta_max_1
          ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_45_85_chunk (never executed)
                Output: _hyper_45_85_chunk."time", _hyper_45_85_chunk.sensor_id, _hyper_45_85_chunk.cpu, _hyper_45_85_chunk.temperature
-               Sorted merge append: true
+               Batch Sorted Merge: true
                Bulk Decompression: false
                ->  Sort (never executed)
                      Output: compress_hyper_46_92_chunk."time", compress_hyper_46_92_chunk.sensor_id, compress_hyper_46_92_chunk.cpu, compress_hyper_46_92_chunk.temperature, compress_hyper_46_92_chunk._ts_meta_count, compress_hyper_46_92_chunk._ts_meta_sequence_num, compress_hyper_46_92_chunk._ts_meta_min_1, compress_hyper_46_92_chunk._ts_meta_max_1
@@ -2438,7 +2438,7 @@ SELECT * FROM sensor_data_compressed ORDER BY time DESC LIMIT 5;
                            Output: compress_hyper_46_92_chunk."time", compress_hyper_46_92_chunk.sensor_id, compress_hyper_46_92_chunk.cpu, compress_hyper_46_92_chunk.temperature, compress_hyper_46_92_chunk._ts_meta_count, compress_hyper_46_92_chunk._ts_meta_sequence_num, compress_hyper_46_92_chunk._ts_meta_min_1, compress_hyper_46_92_chunk._ts_meta_max_1
 (73 rows)
 
--- Only the first chunks should be accessed (sorted merge append is disabled)
+-- Only the first chunks should be accessed (batch sorted merge is disabled)
 SET timescaledb.enable_decompression_sorted_merge = FALSE;
 :PREFIX
 SELECT * FROM sensor_data_compressed ORDER BY time DESC LIMIT 5;
@@ -2516,7 +2516,7 @@ RESET timescaledb.enable_decompression_sorted_merge;
 -- Convert the last chunk into a partially compressed chunk
 INSERT INTO sensor_data_compressed (time, sensor_id, cpu, temperature)
    VALUES ('1980-01-02 01:00:00-00', 2, 4, 14.0);
--- Only the first chunks should be accessed (sorted merge append is enabled)
+-- Only the first chunks should be accessed (batch sorted merge is enabled)
 :PREFIX
 SELECT * FROM sensor_data_compressed ORDER BY time DESC LIMIT 5;
                                                                                                                                                                                  QUERY PLAN                                                                                                                                                                                 
@@ -2530,7 +2530,7 @@ SELECT * FROM sensor_data_compressed ORDER BY time DESC LIMIT 5;
          Runtime Exclusion: false
          ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_45_91_chunk (actual rows=2 loops=1)
                Output: _hyper_45_91_chunk."time", _hyper_45_91_chunk.sensor_id, _hyper_45_91_chunk.cpu, _hyper_45_91_chunk.temperature
-               Sorted merge append: true
+               Batch Sorted Merge: true
                Bulk Decompression: false
                ->  Sort (actual rows=2 loops=1)
                      Output: compress_hyper_46_98_chunk."time", compress_hyper_46_98_chunk.sensor_id, compress_hyper_46_98_chunk.cpu, compress_hyper_46_98_chunk.temperature, compress_hyper_46_98_chunk._ts_meta_count, compress_hyper_46_98_chunk._ts_meta_sequence_num, compress_hyper_46_98_chunk._ts_meta_min_1, compress_hyper_46_98_chunk._ts_meta_max_1
@@ -2540,7 +2540,7 @@ SELECT * FROM sensor_data_compressed ORDER BY time DESC LIMIT 5;
                            Output: compress_hyper_46_98_chunk."time", compress_hyper_46_98_chunk.sensor_id, compress_hyper_46_98_chunk.cpu, compress_hyper_46_98_chunk.temperature, compress_hyper_46_98_chunk._ts_meta_count, compress_hyper_46_98_chunk._ts_meta_sequence_num, compress_hyper_46_98_chunk._ts_meta_min_1, compress_hyper_46_98_chunk._ts_meta_max_1
          ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_45_90_chunk (actual rows=2 loops=1)
                Output: _hyper_45_90_chunk."time", _hyper_45_90_chunk.sensor_id, _hyper_45_90_chunk.cpu, _hyper_45_90_chunk.temperature
-               Sorted merge append: true
+               Batch Sorted Merge: true
                Bulk Decompression: false
                ->  Sort (actual rows=2 loops=1)
                      Output: compress_hyper_46_97_chunk."time", compress_hyper_46_97_chunk.sensor_id, compress_hyper_46_97_chunk.cpu, compress_hyper_46_97_chunk.temperature, compress_hyper_46_97_chunk._ts_meta_count, compress_hyper_46_97_chunk._ts_meta_sequence_num, compress_hyper_46_97_chunk._ts_meta_min_1, compress_hyper_46_97_chunk._ts_meta_max_1
@@ -2550,7 +2550,7 @@ SELECT * FROM sensor_data_compressed ORDER BY time DESC LIMIT 5;
                            Output: compress_hyper_46_97_chunk."time", compress_hyper_46_97_chunk.sensor_id, compress_hyper_46_97_chunk.cpu, compress_hyper_46_97_chunk.temperature, compress_hyper_46_97_chunk._ts_meta_count, compress_hyper_46_97_chunk._ts_meta_sequence_num, compress_hyper_46_97_chunk._ts_meta_min_1, compress_hyper_46_97_chunk._ts_meta_max_1
          ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_45_89_chunk (actual rows=1 loops=1)
                Output: _hyper_45_89_chunk."time", _hyper_45_89_chunk.sensor_id, _hyper_45_89_chunk.cpu, _hyper_45_89_chunk.temperature
-               Sorted merge append: true
+               Batch Sorted Merge: true
                Bulk Decompression: false
                ->  Sort (actual rows=2 loops=1)
                      Output: compress_hyper_46_96_chunk."time", compress_hyper_46_96_chunk.sensor_id, compress_hyper_46_96_chunk.cpu, compress_hyper_46_96_chunk.temperature, compress_hyper_46_96_chunk._ts_meta_count, compress_hyper_46_96_chunk._ts_meta_sequence_num, compress_hyper_46_96_chunk._ts_meta_min_1, compress_hyper_46_96_chunk._ts_meta_max_1
@@ -2560,7 +2560,7 @@ SELECT * FROM sensor_data_compressed ORDER BY time DESC LIMIT 5;
                            Output: compress_hyper_46_96_chunk."time", compress_hyper_46_96_chunk.sensor_id, compress_hyper_46_96_chunk.cpu, compress_hyper_46_96_chunk.temperature, compress_hyper_46_96_chunk._ts_meta_count, compress_hyper_46_96_chunk._ts_meta_sequence_num, compress_hyper_46_96_chunk._ts_meta_min_1, compress_hyper_46_96_chunk._ts_meta_max_1
          ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_45_88_chunk (never executed)
                Output: _hyper_45_88_chunk."time", _hyper_45_88_chunk.sensor_id, _hyper_45_88_chunk.cpu, _hyper_45_88_chunk.temperature
-               Sorted merge append: true
+               Batch Sorted Merge: true
                Bulk Decompression: false
                ->  Sort (never executed)
                      Output: compress_hyper_46_95_chunk."time", compress_hyper_46_95_chunk.sensor_id, compress_hyper_46_95_chunk.cpu, compress_hyper_46_95_chunk.temperature, compress_hyper_46_95_chunk._ts_meta_count, compress_hyper_46_95_chunk._ts_meta_sequence_num, compress_hyper_46_95_chunk._ts_meta_min_1, compress_hyper_46_95_chunk._ts_meta_max_1
@@ -2569,7 +2569,7 @@ SELECT * FROM sensor_data_compressed ORDER BY time DESC LIMIT 5;
                            Output: compress_hyper_46_95_chunk."time", compress_hyper_46_95_chunk.sensor_id, compress_hyper_46_95_chunk.cpu, compress_hyper_46_95_chunk.temperature, compress_hyper_46_95_chunk._ts_meta_count, compress_hyper_46_95_chunk._ts_meta_sequence_num, compress_hyper_46_95_chunk._ts_meta_min_1, compress_hyper_46_95_chunk._ts_meta_max_1
          ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_45_87_chunk (never executed)
                Output: _hyper_45_87_chunk."time", _hyper_45_87_chunk.sensor_id, _hyper_45_87_chunk.cpu, _hyper_45_87_chunk.temperature
-               Sorted merge append: true
+               Batch Sorted Merge: true
                Bulk Decompression: false
                ->  Sort (never executed)
                      Output: compress_hyper_46_94_chunk."time", compress_hyper_46_94_chunk.sensor_id, compress_hyper_46_94_chunk.cpu, compress_hyper_46_94_chunk.temperature, compress_hyper_46_94_chunk._ts_meta_count, compress_hyper_46_94_chunk._ts_meta_sequence_num, compress_hyper_46_94_chunk._ts_meta_min_1, compress_hyper_46_94_chunk._ts_meta_max_1
@@ -2578,7 +2578,7 @@ SELECT * FROM sensor_data_compressed ORDER BY time DESC LIMIT 5;
                            Output: compress_hyper_46_94_chunk."time", compress_hyper_46_94_chunk.sensor_id, compress_hyper_46_94_chunk.cpu, compress_hyper_46_94_chunk.temperature, compress_hyper_46_94_chunk._ts_meta_count, compress_hyper_46_94_chunk._ts_meta_sequence_num, compress_hyper_46_94_chunk._ts_meta_min_1, compress_hyper_46_94_chunk._ts_meta_max_1
          ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_45_86_chunk (never executed)
                Output: _hyper_45_86_chunk."time", _hyper_45_86_chunk.sensor_id, _hyper_45_86_chunk.cpu, _hyper_45_86_chunk.temperature
-               Sorted merge append: true
+               Batch Sorted Merge: true
                Bulk Decompression: false
                ->  Sort (never executed)
                      Output: compress_hyper_46_93_chunk."time", compress_hyper_46_93_chunk.sensor_id, compress_hyper_46_93_chunk.cpu, compress_hyper_46_93_chunk.temperature, compress_hyper_46_93_chunk._ts_meta_count, compress_hyper_46_93_chunk._ts_meta_sequence_num, compress_hyper_46_93_chunk._ts_meta_min_1, compress_hyper_46_93_chunk._ts_meta_max_1
@@ -2589,7 +2589,7 @@ SELECT * FROM sensor_data_compressed ORDER BY time DESC LIMIT 5;
                Sort Key: _hyper_45_85_chunk."time" DESC
                ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_45_85_chunk (never executed)
                      Output: _hyper_45_85_chunk."time", _hyper_45_85_chunk.sensor_id, _hyper_45_85_chunk.cpu, _hyper_45_85_chunk.temperature
-                     Sorted merge append: true
+                     Batch Sorted Merge: true
                      Bulk Decompression: false
                      ->  Sort (never executed)
                            Output: compress_hyper_46_92_chunk."time", compress_hyper_46_92_chunk.sensor_id, compress_hyper_46_92_chunk.cpu, compress_hyper_46_92_chunk.temperature, compress_hyper_46_92_chunk._ts_meta_count, compress_hyper_46_92_chunk._ts_meta_sequence_num, compress_hyper_46_92_chunk._ts_meta_min_1, compress_hyper_46_92_chunk._ts_meta_max_1
@@ -2600,7 +2600,7 @@ SELECT * FROM sensor_data_compressed ORDER BY time DESC LIMIT 5;
                      Output: _hyper_45_85_chunk."time", _hyper_45_85_chunk.sensor_id, _hyper_45_85_chunk.cpu, _hyper_45_85_chunk.temperature
 (77 rows)
 
--- Only the first chunks should be accessed (sorted merge append is disabled)
+-- Only the first chunks should be accessed (batch sorted merge is disabled)
 SET timescaledb.enable_decompression_sorted_merge = FALSE;
 :PREFIX
 SELECT * FROM sensor_data_compressed ORDER BY time DESC LIMIT 5;

--- a/tsl/test/expected/compression.out
+++ b/tsl/test/expected/compression.out
@@ -2213,6 +2213,8 @@ INSERT INTO sensor_data_compressed (time, sensor_id, cpu, temperature)
    ('1980-06-02 00:00:00-00', 1, 1, 45.0),
    ('1980-06-03 00:00:00-00', 3, 3, 44.0);
 ALTER TABLE sensor_data_compressed SET (timescaledb.compress, timescaledb.compress_segmentby='sensor_id', timescaledb.compress_orderby = 'time DESC');
+-- Increase work_mem slightly so that the batch sorted merge plan is not disabled.
+SET work_mem = '16MB';
 -- Compress three of the chunks
 SELECT compress_chunk(ch) FROM show_chunks('sensor_data_compressed') ch LIMIT 3;
               compress_chunk              

--- a/tsl/test/expected/compression_sorted_merge-13.out
+++ b/tsl/test/expected/compression_sorted_merge-13.out
@@ -86,7 +86,7 @@ SELECT * FROM test1 ORDER BY time DESC;
 -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_1_chunk (actual rows=4 loops=1)
    Output: _hyper_1_1_chunk."time", _hyper_1_1_chunk.x1, _hyper_1_1_chunk.x2, _hyper_1_1_chunk.x3, _hyper_1_1_chunk.x4, _hyper_1_1_chunk.x5
-   Sorted merge append: true
+   Batch Sorted Merge: true
    Bulk Decompression: false
    ->  Sort (actual rows=3 loops=1)
          Output: compress_hyper_2_2_chunk."time", compress_hyper_2_2_chunk.x1, compress_hyper_2_2_chunk.x2, compress_hyper_2_2_chunk.x3, compress_hyper_2_2_chunk.x4, compress_hyper_2_2_chunk.x5, compress_hyper_2_2_chunk._ts_meta_count, compress_hyper_2_2_chunk._ts_meta_sequence_num, compress_hyper_2_2_chunk._ts_meta_min_1, compress_hyper_2_2_chunk._ts_meta_max_1, compress_hyper_2_2_chunk._ts_meta_min_2, compress_hyper_2_2_chunk._ts_meta_max_2, compress_hyper_2_2_chunk._ts_meta_min_3, compress_hyper_2_2_chunk._ts_meta_max_3
@@ -103,7 +103,7 @@ SELECT * FROM test1 ORDER BY time DESC NULLS FIRST;
 -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_1_chunk (actual rows=4 loops=1)
    Output: _hyper_1_1_chunk."time", _hyper_1_1_chunk.x1, _hyper_1_1_chunk.x2, _hyper_1_1_chunk.x3, _hyper_1_1_chunk.x4, _hyper_1_1_chunk.x5
-   Sorted merge append: true
+   Batch Sorted Merge: true
    Bulk Decompression: false
    ->  Sort (actual rows=3 loops=1)
          Output: compress_hyper_2_2_chunk."time", compress_hyper_2_2_chunk.x1, compress_hyper_2_2_chunk.x2, compress_hyper_2_2_chunk.x3, compress_hyper_2_2_chunk.x4, compress_hyper_2_2_chunk.x5, compress_hyper_2_2_chunk._ts_meta_count, compress_hyper_2_2_chunk._ts_meta_sequence_num, compress_hyper_2_2_chunk._ts_meta_min_1, compress_hyper_2_2_chunk._ts_meta_max_1, compress_hyper_2_2_chunk._ts_meta_min_2, compress_hyper_2_2_chunk._ts_meta_max_2, compress_hyper_2_2_chunk._ts_meta_min_3, compress_hyper_2_2_chunk._ts_meta_max_3
@@ -136,7 +136,7 @@ SELECT * FROM test1 ORDER BY time ASC;
 -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_1_chunk (actual rows=4 loops=1)
    Output: _hyper_1_1_chunk."time", _hyper_1_1_chunk.x1, _hyper_1_1_chunk.x2, _hyper_1_1_chunk.x3, _hyper_1_1_chunk.x4, _hyper_1_1_chunk.x5
-   Sorted merge append: true
+   Batch Sorted Merge: true
    Bulk Decompression: false
    ->  Sort (actual rows=3 loops=1)
          Output: compress_hyper_2_2_chunk."time", compress_hyper_2_2_chunk.x1, compress_hyper_2_2_chunk.x2, compress_hyper_2_2_chunk.x3, compress_hyper_2_2_chunk.x4, compress_hyper_2_2_chunk.x5, compress_hyper_2_2_chunk._ts_meta_count, compress_hyper_2_2_chunk._ts_meta_sequence_num, compress_hyper_2_2_chunk._ts_meta_min_1, compress_hyper_2_2_chunk._ts_meta_max_1, compress_hyper_2_2_chunk._ts_meta_min_2, compress_hyper_2_2_chunk._ts_meta_max_2, compress_hyper_2_2_chunk._ts_meta_min_3, compress_hyper_2_2_chunk._ts_meta_max_3
@@ -153,7 +153,7 @@ SELECT * FROM test1 ORDER BY time ASC NULLS LAST;
 -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_1_chunk (actual rows=4 loops=1)
    Output: _hyper_1_1_chunk."time", _hyper_1_1_chunk.x1, _hyper_1_1_chunk.x2, _hyper_1_1_chunk.x3, _hyper_1_1_chunk.x4, _hyper_1_1_chunk.x5
-   Sorted merge append: true
+   Batch Sorted Merge: true
    Bulk Decompression: false
    ->  Sort (actual rows=3 loops=1)
          Output: compress_hyper_2_2_chunk."time", compress_hyper_2_2_chunk.x1, compress_hyper_2_2_chunk.x2, compress_hyper_2_2_chunk.x3, compress_hyper_2_2_chunk.x4, compress_hyper_2_2_chunk.x5, compress_hyper_2_2_chunk._ts_meta_count, compress_hyper_2_2_chunk._ts_meta_sequence_num, compress_hyper_2_2_chunk._ts_meta_min_1, compress_hyper_2_2_chunk._ts_meta_max_1, compress_hyper_2_2_chunk._ts_meta_min_2, compress_hyper_2_2_chunk._ts_meta_max_2, compress_hyper_2_2_chunk._ts_meta_min_3, compress_hyper_2_2_chunk._ts_meta_max_3
@@ -186,7 +186,7 @@ SELECT * FROM test1 ORDER BY time DESC NULLS FIRST, x3 ASC NULLS LAST;
 -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_1_chunk (actual rows=4 loops=1)
    Output: _hyper_1_1_chunk."time", _hyper_1_1_chunk.x1, _hyper_1_1_chunk.x2, _hyper_1_1_chunk.x3, _hyper_1_1_chunk.x4, _hyper_1_1_chunk.x5
-   Sorted merge append: true
+   Batch Sorted Merge: true
    Bulk Decompression: false
    ->  Sort (actual rows=3 loops=1)
          Output: compress_hyper_2_2_chunk."time", compress_hyper_2_2_chunk.x1, compress_hyper_2_2_chunk.x2, compress_hyper_2_2_chunk.x3, compress_hyper_2_2_chunk.x4, compress_hyper_2_2_chunk.x5, compress_hyper_2_2_chunk._ts_meta_count, compress_hyper_2_2_chunk._ts_meta_sequence_num, compress_hyper_2_2_chunk._ts_meta_min_1, compress_hyper_2_2_chunk._ts_meta_max_1, compress_hyper_2_2_chunk._ts_meta_min_2, compress_hyper_2_2_chunk._ts_meta_max_2, compress_hyper_2_2_chunk._ts_meta_min_3, compress_hyper_2_2_chunk._ts_meta_max_3
@@ -203,7 +203,7 @@ SELECT * FROM test1 ORDER BY time DESC NULLS FIRST, x3 ASC NULLS LAST, x4 ASC NU
 -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_1_chunk (actual rows=4 loops=1)
    Output: _hyper_1_1_chunk."time", _hyper_1_1_chunk.x1, _hyper_1_1_chunk.x2, _hyper_1_1_chunk.x3, _hyper_1_1_chunk.x4, _hyper_1_1_chunk.x5
-   Sorted merge append: true
+   Batch Sorted Merge: true
    Bulk Decompression: false
    ->  Sort (actual rows=3 loops=1)
          Output: compress_hyper_2_2_chunk."time", compress_hyper_2_2_chunk.x1, compress_hyper_2_2_chunk.x2, compress_hyper_2_2_chunk.x3, compress_hyper_2_2_chunk.x4, compress_hyper_2_2_chunk.x5, compress_hyper_2_2_chunk._ts_meta_count, compress_hyper_2_2_chunk._ts_meta_sequence_num, compress_hyper_2_2_chunk._ts_meta_min_1, compress_hyper_2_2_chunk._ts_meta_max_1, compress_hyper_2_2_chunk._ts_meta_min_2, compress_hyper_2_2_chunk._ts_meta_max_2, compress_hyper_2_2_chunk._ts_meta_min_3, compress_hyper_2_2_chunk._ts_meta_max_3
@@ -236,7 +236,7 @@ SELECT * FROM test1 ORDER BY time ASC NULLS LAST;
 -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_1_chunk (actual rows=4 loops=1)
    Output: _hyper_1_1_chunk."time", _hyper_1_1_chunk.x1, _hyper_1_1_chunk.x2, _hyper_1_1_chunk.x3, _hyper_1_1_chunk.x4, _hyper_1_1_chunk.x5
-   Sorted merge append: true
+   Batch Sorted Merge: true
    Bulk Decompression: false
    ->  Sort (actual rows=3 loops=1)
          Output: compress_hyper_2_2_chunk."time", compress_hyper_2_2_chunk.x1, compress_hyper_2_2_chunk.x2, compress_hyper_2_2_chunk.x3, compress_hyper_2_2_chunk.x4, compress_hyper_2_2_chunk.x5, compress_hyper_2_2_chunk._ts_meta_count, compress_hyper_2_2_chunk._ts_meta_sequence_num, compress_hyper_2_2_chunk._ts_meta_min_1, compress_hyper_2_2_chunk._ts_meta_max_1, compress_hyper_2_2_chunk._ts_meta_min_2, compress_hyper_2_2_chunk._ts_meta_max_2, compress_hyper_2_2_chunk._ts_meta_min_3, compress_hyper_2_2_chunk._ts_meta_max_3
@@ -253,7 +253,7 @@ SELECT * FROM test1 ORDER BY time ASC NULLS LAST, x3 DESC NULLS FIRST;
 -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_1_chunk (actual rows=4 loops=1)
    Output: _hyper_1_1_chunk."time", _hyper_1_1_chunk.x1, _hyper_1_1_chunk.x2, _hyper_1_1_chunk.x3, _hyper_1_1_chunk.x4, _hyper_1_1_chunk.x5
-   Sorted merge append: true
+   Batch Sorted Merge: true
    Bulk Decompression: false
    ->  Sort (actual rows=3 loops=1)
          Output: compress_hyper_2_2_chunk."time", compress_hyper_2_2_chunk.x1, compress_hyper_2_2_chunk.x2, compress_hyper_2_2_chunk.x3, compress_hyper_2_2_chunk.x4, compress_hyper_2_2_chunk.x5, compress_hyper_2_2_chunk._ts_meta_count, compress_hyper_2_2_chunk._ts_meta_sequence_num, compress_hyper_2_2_chunk._ts_meta_min_1, compress_hyper_2_2_chunk._ts_meta_max_1, compress_hyper_2_2_chunk._ts_meta_min_2, compress_hyper_2_2_chunk._ts_meta_max_2, compress_hyper_2_2_chunk._ts_meta_min_3, compress_hyper_2_2_chunk._ts_meta_max_3
@@ -270,7 +270,7 @@ SELECT * FROM test1 ORDER BY time ASC NULLS LAST, x3 DESC NULLS FIRST, x4 DESC N
 -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_1_chunk (actual rows=4 loops=1)
    Output: _hyper_1_1_chunk."time", _hyper_1_1_chunk.x1, _hyper_1_1_chunk.x2, _hyper_1_1_chunk.x3, _hyper_1_1_chunk.x4, _hyper_1_1_chunk.x5
-   Sorted merge append: true
+   Batch Sorted Merge: true
    Bulk Decompression: false
    ->  Sort (actual rows=3 loops=1)
          Output: compress_hyper_2_2_chunk."time", compress_hyper_2_2_chunk.x1, compress_hyper_2_2_chunk.x2, compress_hyper_2_2_chunk.x3, compress_hyper_2_2_chunk.x4, compress_hyper_2_2_chunk.x5, compress_hyper_2_2_chunk._ts_meta_count, compress_hyper_2_2_chunk._ts_meta_sequence_num, compress_hyper_2_2_chunk._ts_meta_min_1, compress_hyper_2_2_chunk._ts_meta_max_1, compress_hyper_2_2_chunk._ts_meta_min_2, compress_hyper_2_2_chunk._ts_meta_max_2, compress_hyper_2_2_chunk._ts_meta_min_3, compress_hyper_2_2_chunk._ts_meta_max_3
@@ -303,7 +303,7 @@ SELECT * FROM test2 ORDER BY time ASC;
 -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_3_3_chunk (actual rows=4 loops=1)
    Output: _hyper_3_3_chunk."time", _hyper_3_3_chunk.x1, _hyper_3_3_chunk.x2, _hyper_3_3_chunk.x3, _hyper_3_3_chunk.x4, _hyper_3_3_chunk.x5
-   Sorted merge append: true
+   Batch Sorted Merge: true
    Bulk Decompression: false
    ->  Sort (actual rows=3 loops=1)
          Output: compress_hyper_4_4_chunk."time", compress_hyper_4_4_chunk.x1, compress_hyper_4_4_chunk.x2, compress_hyper_4_4_chunk.x3, compress_hyper_4_4_chunk.x4, compress_hyper_4_4_chunk.x5, compress_hyper_4_4_chunk._ts_meta_count, compress_hyper_4_4_chunk._ts_meta_sequence_num, compress_hyper_4_4_chunk._ts_meta_min_1, compress_hyper_4_4_chunk._ts_meta_max_1, compress_hyper_4_4_chunk._ts_meta_min_2, compress_hyper_4_4_chunk._ts_meta_max_2, compress_hyper_4_4_chunk._ts_meta_min_3, compress_hyper_4_4_chunk._ts_meta_max_3
@@ -320,7 +320,7 @@ SELECT * FROM test2 ORDER BY time ASC, x3 DESC;
 -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_3_3_chunk (actual rows=4 loops=1)
    Output: _hyper_3_3_chunk."time", _hyper_3_3_chunk.x1, _hyper_3_3_chunk.x2, _hyper_3_3_chunk.x3, _hyper_3_3_chunk.x4, _hyper_3_3_chunk.x5
-   Sorted merge append: true
+   Batch Sorted Merge: true
    Bulk Decompression: false
    ->  Sort (actual rows=3 loops=1)
          Output: compress_hyper_4_4_chunk."time", compress_hyper_4_4_chunk.x1, compress_hyper_4_4_chunk.x2, compress_hyper_4_4_chunk.x3, compress_hyper_4_4_chunk.x4, compress_hyper_4_4_chunk.x5, compress_hyper_4_4_chunk._ts_meta_count, compress_hyper_4_4_chunk._ts_meta_sequence_num, compress_hyper_4_4_chunk._ts_meta_min_1, compress_hyper_4_4_chunk._ts_meta_max_1, compress_hyper_4_4_chunk._ts_meta_min_2, compress_hyper_4_4_chunk._ts_meta_max_2, compress_hyper_4_4_chunk._ts_meta_min_3, compress_hyper_4_4_chunk._ts_meta_max_3
@@ -337,7 +337,7 @@ SELECT * FROM test2 ORDER BY time ASC, x3 DESC, x4 DESC;
 -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_3_3_chunk (actual rows=4 loops=1)
    Output: _hyper_3_3_chunk."time", _hyper_3_3_chunk.x1, _hyper_3_3_chunk.x2, _hyper_3_3_chunk.x3, _hyper_3_3_chunk.x4, _hyper_3_3_chunk.x5
-   Sorted merge append: true
+   Batch Sorted Merge: true
    Bulk Decompression: false
    ->  Sort (actual rows=3 loops=1)
          Output: compress_hyper_4_4_chunk."time", compress_hyper_4_4_chunk.x1, compress_hyper_4_4_chunk.x2, compress_hyper_4_4_chunk.x3, compress_hyper_4_4_chunk.x4, compress_hyper_4_4_chunk.x5, compress_hyper_4_4_chunk._ts_meta_count, compress_hyper_4_4_chunk._ts_meta_sequence_num, compress_hyper_4_4_chunk._ts_meta_min_1, compress_hyper_4_4_chunk._ts_meta_max_1, compress_hyper_4_4_chunk._ts_meta_min_2, compress_hyper_4_4_chunk._ts_meta_max_2, compress_hyper_4_4_chunk._ts_meta_min_3, compress_hyper_4_4_chunk._ts_meta_max_3
@@ -386,7 +386,7 @@ SELECT * FROM test2 ORDER BY time DESC NULLS FIRST;
 -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_3_3_chunk (actual rows=4 loops=1)
    Output: _hyper_3_3_chunk."time", _hyper_3_3_chunk.x1, _hyper_3_3_chunk.x2, _hyper_3_3_chunk.x3, _hyper_3_3_chunk.x4, _hyper_3_3_chunk.x5
-   Sorted merge append: true
+   Batch Sorted Merge: true
    Bulk Decompression: false
    ->  Sort (actual rows=3 loops=1)
          Output: compress_hyper_4_4_chunk."time", compress_hyper_4_4_chunk.x1, compress_hyper_4_4_chunk.x2, compress_hyper_4_4_chunk.x3, compress_hyper_4_4_chunk.x4, compress_hyper_4_4_chunk.x5, compress_hyper_4_4_chunk._ts_meta_count, compress_hyper_4_4_chunk._ts_meta_sequence_num, compress_hyper_4_4_chunk._ts_meta_min_1, compress_hyper_4_4_chunk._ts_meta_max_1, compress_hyper_4_4_chunk._ts_meta_min_2, compress_hyper_4_4_chunk._ts_meta_max_2, compress_hyper_4_4_chunk._ts_meta_min_3, compress_hyper_4_4_chunk._ts_meta_max_3
@@ -403,7 +403,7 @@ SELECT * FROM test2 ORDER BY time DESC NULLS FIRST, x3 ASC NULLS LAST;
 -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_3_3_chunk (actual rows=4 loops=1)
    Output: _hyper_3_3_chunk."time", _hyper_3_3_chunk.x1, _hyper_3_3_chunk.x2, _hyper_3_3_chunk.x3, _hyper_3_3_chunk.x4, _hyper_3_3_chunk.x5
-   Sorted merge append: true
+   Batch Sorted Merge: true
    Bulk Decompression: false
    ->  Sort (actual rows=3 loops=1)
          Output: compress_hyper_4_4_chunk."time", compress_hyper_4_4_chunk.x1, compress_hyper_4_4_chunk.x2, compress_hyper_4_4_chunk.x3, compress_hyper_4_4_chunk.x4, compress_hyper_4_4_chunk.x5, compress_hyper_4_4_chunk._ts_meta_count, compress_hyper_4_4_chunk._ts_meta_sequence_num, compress_hyper_4_4_chunk._ts_meta_min_1, compress_hyper_4_4_chunk._ts_meta_max_1, compress_hyper_4_4_chunk._ts_meta_min_2, compress_hyper_4_4_chunk._ts_meta_max_2, compress_hyper_4_4_chunk._ts_meta_min_3, compress_hyper_4_4_chunk._ts_meta_max_3
@@ -420,7 +420,7 @@ SELECT * FROM test2 ORDER BY time DESC NULLS FIRST, x3 ASC NULLS LAST, x4 NULLS 
 -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_3_3_chunk (actual rows=4 loops=1)
    Output: _hyper_3_3_chunk."time", _hyper_3_3_chunk.x1, _hyper_3_3_chunk.x2, _hyper_3_3_chunk.x3, _hyper_3_3_chunk.x4, _hyper_3_3_chunk.x5
-   Sorted merge append: true
+   Batch Sorted Merge: true
    Bulk Decompression: false
    ->  Sort (actual rows=3 loops=1)
          Output: compress_hyper_4_4_chunk."time", compress_hyper_4_4_chunk.x1, compress_hyper_4_4_chunk.x2, compress_hyper_4_4_chunk.x3, compress_hyper_4_4_chunk.x4, compress_hyper_4_4_chunk.x5, compress_hyper_4_4_chunk._ts_meta_count, compress_hyper_4_4_chunk._ts_meta_sequence_num, compress_hyper_4_4_chunk._ts_meta_min_1, compress_hyper_4_4_chunk._ts_meta_max_1, compress_hyper_4_4_chunk._ts_meta_min_2, compress_hyper_4_4_chunk._ts_meta_max_2, compress_hyper_4_4_chunk._ts_meta_min_3, compress_hyper_4_4_chunk._ts_meta_max_3
@@ -469,7 +469,7 @@ SELECT * FROM test_with_defined_null ORDER BY x2 ASC NULLS FIRST;
 -----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_5_5_chunk (actual rows=4 loops=1)
    Output: _hyper_5_5_chunk."time", _hyper_5_5_chunk.x1, _hyper_5_5_chunk.x2, _hyper_5_5_chunk.x3
-   Sorted merge append: true
+   Batch Sorted Merge: true
    Bulk Decompression: false
    ->  Sort (actual rows=2 loops=1)
          Output: compress_hyper_6_6_chunk."time", compress_hyper_6_6_chunk.x1, compress_hyper_6_6_chunk.x2, compress_hyper_6_6_chunk.x3, compress_hyper_6_6_chunk._ts_meta_count, compress_hyper_6_6_chunk._ts_meta_sequence_num, compress_hyper_6_6_chunk._ts_meta_min_2, compress_hyper_6_6_chunk._ts_meta_max_2, compress_hyper_6_6_chunk._ts_meta_min_1, compress_hyper_6_6_chunk._ts_meta_max_1
@@ -486,7 +486,7 @@ SELECT * FROM test_with_defined_null ORDER BY x2 DESC NULLS LAST;
 -----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_5_5_chunk (actual rows=4 loops=1)
    Output: _hyper_5_5_chunk."time", _hyper_5_5_chunk.x1, _hyper_5_5_chunk.x2, _hyper_5_5_chunk.x3
-   Sorted merge append: true
+   Batch Sorted Merge: true
    Bulk Decompression: false
    ->  Sort (actual rows=2 loops=1)
          Output: compress_hyper_6_6_chunk."time", compress_hyper_6_6_chunk.x1, compress_hyper_6_6_chunk.x2, compress_hyper_6_6_chunk.x3, compress_hyper_6_6_chunk._ts_meta_count, compress_hyper_6_6_chunk._ts_meta_sequence_num, compress_hyper_6_6_chunk._ts_meta_min_2, compress_hyper_6_6_chunk._ts_meta_max_2, compress_hyper_6_6_chunk._ts_meta_min_1, compress_hyper_6_6_chunk._ts_meta_max_1
@@ -539,7 +539,7 @@ SELECT * FROM test1 WHERE x4 > 0 ORDER BY time DESC;
  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_1_chunk (actual rows=4 loops=1)
    Output: _hyper_1_1_chunk."time", _hyper_1_1_chunk.x1, _hyper_1_1_chunk.x2, _hyper_1_1_chunk.x3, _hyper_1_1_chunk.x4, _hyper_1_1_chunk.x5
    Filter: (_hyper_1_1_chunk.x4 > 0)
-   Sorted merge append: true
+   Batch Sorted Merge: true
    Bulk Decompression: false
    ->  Sort (actual rows=3 loops=1)
          Output: compress_hyper_2_2_chunk."time", compress_hyper_2_2_chunk.x1, compress_hyper_2_2_chunk.x2, compress_hyper_2_2_chunk.x3, compress_hyper_2_2_chunk.x4, compress_hyper_2_2_chunk.x5, compress_hyper_2_2_chunk._ts_meta_count, compress_hyper_2_2_chunk._ts_meta_sequence_num, compress_hyper_2_2_chunk._ts_meta_min_1, compress_hyper_2_2_chunk._ts_meta_max_1, compress_hyper_2_2_chunk._ts_meta_min_2, compress_hyper_2_2_chunk._ts_meta_max_2, compress_hyper_2_2_chunk._ts_meta_min_3, compress_hyper_2_2_chunk._ts_meta_max_3
@@ -558,7 +558,7 @@ SELECT * FROM test1 WHERE x4 > 100 ORDER BY time DESC;
  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_1_chunk (actual rows=0 loops=1)
    Output: _hyper_1_1_chunk."time", _hyper_1_1_chunk.x1, _hyper_1_1_chunk.x2, _hyper_1_1_chunk.x3, _hyper_1_1_chunk.x4, _hyper_1_1_chunk.x5
    Filter: (_hyper_1_1_chunk.x4 > 100)
-   Sorted merge append: true
+   Batch Sorted Merge: true
    Bulk Decompression: false
    ->  Sort (actual rows=0 loops=1)
          Output: compress_hyper_2_2_chunk."time", compress_hyper_2_2_chunk.x1, compress_hyper_2_2_chunk.x2, compress_hyper_2_2_chunk.x3, compress_hyper_2_2_chunk.x4, compress_hyper_2_2_chunk.x5, compress_hyper_2_2_chunk._ts_meta_count, compress_hyper_2_2_chunk._ts_meta_sequence_num, compress_hyper_2_2_chunk._ts_meta_min_1, compress_hyper_2_2_chunk._ts_meta_max_1, compress_hyper_2_2_chunk._ts_meta_min_2, compress_hyper_2_2_chunk._ts_meta_max_2, compress_hyper_2_2_chunk._ts_meta_min_3, compress_hyper_2_2_chunk._ts_meta_max_3
@@ -578,7 +578,7 @@ SELECT * FROM test1 WHERE x4 > 100 ORDER BY time DESC, x3, x4;
  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_1_chunk (actual rows=0 loops=1)
    Output: _hyper_1_1_chunk."time", _hyper_1_1_chunk.x1, _hyper_1_1_chunk.x2, _hyper_1_1_chunk.x3, _hyper_1_1_chunk.x4, _hyper_1_1_chunk.x5
    Filter: (_hyper_1_1_chunk.x4 > 100)
-   Sorted merge append: true
+   Batch Sorted Merge: true
    Bulk Decompression: false
    ->  Sort (actual rows=0 loops=1)
          Output: compress_hyper_2_2_chunk."time", compress_hyper_2_2_chunk.x1, compress_hyper_2_2_chunk.x2, compress_hyper_2_2_chunk.x3, compress_hyper_2_2_chunk.x4, compress_hyper_2_2_chunk.x5, compress_hyper_2_2_chunk._ts_meta_count, compress_hyper_2_2_chunk._ts_meta_sequence_num, compress_hyper_2_2_chunk._ts_meta_min_1, compress_hyper_2_2_chunk._ts_meta_max_1, compress_hyper_2_2_chunk._ts_meta_min_2, compress_hyper_2_2_chunk._ts_meta_max_2, compress_hyper_2_2_chunk._ts_meta_min_3, compress_hyper_2_2_chunk._ts_meta_max_3
@@ -598,7 +598,7 @@ SELECT * FROM test1 WHERE x4 > 100 ORDER BY time DESC, x3, x3;
  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_1_chunk (actual rows=0 loops=1)
    Output: _hyper_1_1_chunk."time", _hyper_1_1_chunk.x1, _hyper_1_1_chunk.x2, _hyper_1_1_chunk.x3, _hyper_1_1_chunk.x4, _hyper_1_1_chunk.x5
    Filter: (_hyper_1_1_chunk.x4 > 100)
-   Sorted merge append: true
+   Batch Sorted Merge: true
    Bulk Decompression: false
    ->  Sort (actual rows=0 loops=1)
          Output: compress_hyper_2_2_chunk."time", compress_hyper_2_2_chunk.x1, compress_hyper_2_2_chunk.x2, compress_hyper_2_2_chunk.x3, compress_hyper_2_2_chunk.x4, compress_hyper_2_2_chunk.x5, compress_hyper_2_2_chunk._ts_meta_count, compress_hyper_2_2_chunk._ts_meta_sequence_num, compress_hyper_2_2_chunk._ts_meta_min_1, compress_hyper_2_2_chunk._ts_meta_max_1, compress_hyper_2_2_chunk._ts_meta_min_2, compress_hyper_2_2_chunk._ts_meta_max_2, compress_hyper_2_2_chunk._ts_meta_min_3, compress_hyper_2_2_chunk._ts_meta_max_3
@@ -618,7 +618,7 @@ SELECT * FROM test1 WHERE x4 > 100 ORDER BY time DESC, x3, x4, x3, x4;
  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_1_chunk (actual rows=0 loops=1)
    Output: _hyper_1_1_chunk."time", _hyper_1_1_chunk.x1, _hyper_1_1_chunk.x2, _hyper_1_1_chunk.x3, _hyper_1_1_chunk.x4, _hyper_1_1_chunk.x5
    Filter: (_hyper_1_1_chunk.x4 > 100)
-   Sorted merge append: true
+   Batch Sorted Merge: true
    Bulk Decompression: false
    ->  Sort (actual rows=0 loops=1)
          Output: compress_hyper_2_2_chunk."time", compress_hyper_2_2_chunk.x1, compress_hyper_2_2_chunk.x2, compress_hyper_2_2_chunk.x3, compress_hyper_2_2_chunk.x4, compress_hyper_2_2_chunk.x5, compress_hyper_2_2_chunk._ts_meta_count, compress_hyper_2_2_chunk._ts_meta_sequence_num, compress_hyper_2_2_chunk._ts_meta_min_1, compress_hyper_2_2_chunk._ts_meta_max_1, compress_hyper_2_2_chunk._ts_meta_min_2, compress_hyper_2_2_chunk._ts_meta_max_2, compress_hyper_2_2_chunk._ts_meta_min_3, compress_hyper_2_2_chunk._ts_meta_max_3
@@ -676,7 +676,7 @@ SELECT * FROM test1 ORDER BY time DESC;
 -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_1_chunk (actual rows=4 loops=1)
    Output: _hyper_1_1_chunk."time", _hyper_1_1_chunk.x1, _hyper_1_1_chunk.x2, _hyper_1_1_chunk.x3, _hyper_1_1_chunk.x4, _hyper_1_1_chunk.x5
-   Sorted merge append: true
+   Batch Sorted Merge: true
    Bulk Decompression: false
    ->  Sort (actual rows=3 loops=1)
          Output: compress_hyper_2_2_chunk."time", compress_hyper_2_2_chunk.x1, compress_hyper_2_2_chunk.x2, compress_hyper_2_2_chunk.x3, compress_hyper_2_2_chunk.x4, compress_hyper_2_2_chunk.x5, compress_hyper_2_2_chunk._ts_meta_count, compress_hyper_2_2_chunk._ts_meta_sequence_num, compress_hyper_2_2_chunk._ts_meta_min_1, compress_hyper_2_2_chunk._ts_meta_max_1, compress_hyper_2_2_chunk._ts_meta_min_2, compress_hyper_2_2_chunk._ts_meta_max_2, compress_hyper_2_2_chunk._ts_meta_min_3, compress_hyper_2_2_chunk._ts_meta_max_3
@@ -832,7 +832,7 @@ EXPLAIN (verbose) SELECT 1 as one, 2 as two, 3 as three, time, x2 FROM test1 ORD
    Output: 1, 2, 3, _hyper_1_1_chunk."time", _hyper_1_1_chunk.x2
    ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_1_chunk  (cost=1.06..63.44 rows=3000 width=12)
          Output: _hyper_1_1_chunk."time", _hyper_1_1_chunk.x2
-         Sorted merge append: true
+         Batch Sorted Merge: true
          ->  Sort  (cost=0.00..0.00 rows=0 width=0)
                Output: compress_hyper_2_2_chunk."time", compress_hyper_2_2_chunk.x1, compress_hyper_2_2_chunk.x2, compress_hyper_2_2_chunk.x3, compress_hyper_2_2_chunk.x4, compress_hyper_2_2_chunk.x5, compress_hyper_2_2_chunk._ts_meta_count, compress_hyper_2_2_chunk._ts_meta_sequence_num, compress_hyper_2_2_chunk._ts_meta_min_1, compress_hyper_2_2_chunk._ts_meta_max_1, compress_hyper_2_2_chunk._ts_meta_min_2, compress_hyper_2_2_chunk._ts_meta_max_2, compress_hyper_2_2_chunk._ts_meta_min_3, compress_hyper_2_2_chunk._ts_meta_max_3
                Sort Key: compress_hyper_2_2_chunk._ts_meta_max_1 DESC
@@ -857,7 +857,7 @@ EXPLAIN (verbose) SELECT 1 as one, 2 as two, 3 as three, x2, time FROM test1 ORD
    Output: 1, 2, 3, _hyper_1_1_chunk.x2, _hyper_1_1_chunk."time"
    ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_1_chunk  (cost=1.06..63.44 rows=3000 width=12)
          Output: _hyper_1_1_chunk.x2, _hyper_1_1_chunk."time"
-         Sorted merge append: true
+         Batch Sorted Merge: true
          ->  Sort  (cost=0.00..0.00 rows=0 width=0)
                Output: compress_hyper_2_2_chunk."time", compress_hyper_2_2_chunk.x1, compress_hyper_2_2_chunk.x2, compress_hyper_2_2_chunk.x3, compress_hyper_2_2_chunk.x4, compress_hyper_2_2_chunk.x5, compress_hyper_2_2_chunk._ts_meta_count, compress_hyper_2_2_chunk._ts_meta_sequence_num, compress_hyper_2_2_chunk._ts_meta_min_1, compress_hyper_2_2_chunk._ts_meta_max_1, compress_hyper_2_2_chunk._ts_meta_min_2, compress_hyper_2_2_chunk._ts_meta_max_2, compress_hyper_2_2_chunk._ts_meta_min_3, compress_hyper_2_2_chunk._ts_meta_max_3
                Sort Key: compress_hyper_2_2_chunk._ts_meta_max_1 DESC
@@ -954,7 +954,7 @@ SELECT * FROM test1 ORDER BY time DESC;
 -----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_1_chunk (actual rows=4 loops=1)
    Output: _hyper_1_1_chunk."time", _hyper_1_1_chunk.x1, _hyper_1_1_chunk.x2, _hyper_1_1_chunk.x3, _hyper_1_1_chunk.x4, _hyper_1_1_chunk.x5, _hyper_1_1_chunk.c1, _hyper_1_1_chunk.c2
-   Sorted merge append: true
+   Batch Sorted Merge: true
    Bulk Decompression: false
    ->  Sort (actual rows=3 loops=1)
          Output: compress_hyper_2_7_chunk."time", compress_hyper_2_7_chunk._ts_meta_min_1, compress_hyper_2_7_chunk._ts_meta_max_1, compress_hyper_2_7_chunk.x1, compress_hyper_2_7_chunk.x2, compress_hyper_2_7_chunk.x3, compress_hyper_2_7_chunk._ts_meta_min_2, compress_hyper_2_7_chunk._ts_meta_max_2, compress_hyper_2_7_chunk.x4, compress_hyper_2_7_chunk._ts_meta_min_3, compress_hyper_2_7_chunk._ts_meta_max_3, compress_hyper_2_7_chunk.x5, compress_hyper_2_7_chunk.c1, compress_hyper_2_7_chunk.c2, compress_hyper_2_7_chunk._ts_meta_count
@@ -980,7 +980,7 @@ SELECT time, x2, x1, c2 FROM test1 ORDER BY time DESC;
 -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_1_chunk (actual rows=4 loops=1)
    Output: _hyper_1_1_chunk."time", _hyper_1_1_chunk.x2, _hyper_1_1_chunk.x1, _hyper_1_1_chunk.c2
-   Sorted merge append: true
+   Batch Sorted Merge: true
    Bulk Decompression: false
    ->  Sort (actual rows=3 loops=1)
          Output: compress_hyper_2_7_chunk."time", compress_hyper_2_7_chunk._ts_meta_min_1, compress_hyper_2_7_chunk._ts_meta_max_1, compress_hyper_2_7_chunk.x2, compress_hyper_2_7_chunk.x1, compress_hyper_2_7_chunk.c2, compress_hyper_2_7_chunk._ts_meta_count
@@ -1006,7 +1006,7 @@ SELECT x2, x1, c2, time FROM test1 ORDER BY time DESC;
 -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_1_chunk (actual rows=4 loops=1)
    Output: _hyper_1_1_chunk.x2, _hyper_1_1_chunk.x1, _hyper_1_1_chunk.c2, _hyper_1_1_chunk."time"
-   Sorted merge append: true
+   Batch Sorted Merge: true
    Bulk Decompression: false
    ->  Sort (actual rows=3 loops=1)
          Output: compress_hyper_2_7_chunk.x2, compress_hyper_2_7_chunk.x1, compress_hyper_2_7_chunk.c2, compress_hyper_2_7_chunk."time", compress_hyper_2_7_chunk._ts_meta_min_1, compress_hyper_2_7_chunk._ts_meta_max_1, compress_hyper_2_7_chunk._ts_meta_count
@@ -1034,7 +1034,7 @@ SELECT 1 as one, 2 as two, 3 as three, x2, x1, c2, time FROM test1 ORDER BY time
    Output: 1, 2, 3, _hyper_1_1_chunk.x2, _hyper_1_1_chunk.x1, _hyper_1_1_chunk.c2, _hyper_1_1_chunk."time"
    ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_1_chunk (actual rows=4 loops=1)
          Output: _hyper_1_1_chunk.x2, _hyper_1_1_chunk.x1, _hyper_1_1_chunk.c2, _hyper_1_1_chunk."time"
-         Sorted merge append: true
+         Batch Sorted Merge: true
          Bulk Decompression: false
          ->  Sort (actual rows=3 loops=1)
                Output: compress_hyper_2_7_chunk.x2, compress_hyper_2_7_chunk.x1, compress_hyper_2_7_chunk.c2, compress_hyper_2_7_chunk."time", compress_hyper_2_7_chunk._ts_meta_min_1, compress_hyper_2_7_chunk._ts_meta_max_1, compress_hyper_2_7_chunk._ts_meta_count
@@ -1100,7 +1100,7 @@ SELECT * FROM test1 ORDER BY time ASC NULLS LAST;
 -----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_1_chunk (actual rows=4 loops=1)
    Output: _hyper_1_1_chunk."time", _hyper_1_1_chunk.x1, _hyper_1_1_chunk.x2, _hyper_1_1_chunk.x3, _hyper_1_1_chunk.x4, _hyper_1_1_chunk.x5, _hyper_1_1_chunk.c1, _hyper_1_1_chunk.c2
-   Sorted merge append: true
+   Batch Sorted Merge: true
    Bulk Decompression: false
    ->  Sort (actual rows=3 loops=1)
          Output: compress_hyper_2_7_chunk."time", compress_hyper_2_7_chunk._ts_meta_min_1, compress_hyper_2_7_chunk._ts_meta_max_1, compress_hyper_2_7_chunk.x1, compress_hyper_2_7_chunk.x2, compress_hyper_2_7_chunk.x3, compress_hyper_2_7_chunk._ts_meta_min_2, compress_hyper_2_7_chunk._ts_meta_max_2, compress_hyper_2_7_chunk.x4, compress_hyper_2_7_chunk._ts_meta_min_3, compress_hyper_2_7_chunk._ts_meta_max_3, compress_hyper_2_7_chunk.x5, compress_hyper_2_7_chunk.c1, compress_hyper_2_7_chunk.c2, compress_hyper_2_7_chunk._ts_meta_count
@@ -1126,7 +1126,7 @@ SELECT * FROM test1 ORDER BY time ASC NULLS LAST;
          Sort Key: _hyper_1_1_chunk."time"
          ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_1_chunk (actual rows=4 loops=1)
                Output: _hyper_1_1_chunk."time", _hyper_1_1_chunk.x1, _hyper_1_1_chunk.x2, _hyper_1_1_chunk.x3, _hyper_1_1_chunk.x4, _hyper_1_1_chunk.x5, _hyper_1_1_chunk.c1, _hyper_1_1_chunk.c2
-               Sorted merge append: true
+               Batch Sorted Merge: true
                Bulk Decompression: false
                ->  Sort (actual rows=3 loops=1)
                      Output: compress_hyper_2_7_chunk."time", compress_hyper_2_7_chunk._ts_meta_min_1, compress_hyper_2_7_chunk._ts_meta_max_1, compress_hyper_2_7_chunk.x1, compress_hyper_2_7_chunk.x2, compress_hyper_2_7_chunk.x3, compress_hyper_2_7_chunk._ts_meta_min_2, compress_hyper_2_7_chunk._ts_meta_max_2, compress_hyper_2_7_chunk.x4, compress_hyper_2_7_chunk._ts_meta_min_3, compress_hyper_2_7_chunk._ts_meta_max_3, compress_hyper_2_7_chunk.x5, compress_hyper_2_7_chunk.c1, compress_hyper_2_7_chunk.c2, compress_hyper_2_7_chunk._ts_meta_count
@@ -1209,7 +1209,7 @@ SELECT * FROM sensor_data ORDER BY time DESC LIMIT 1;
          Runtime Exclusion: false
          ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_7_13_chunk (actual rows=1 loops=1)
                Output: _hyper_7_13_chunk."time", _hyper_7_13_chunk.sensor_id, _hyper_7_13_chunk.cpu, _hyper_7_13_chunk.temperature
-               Sorted merge append: true
+               Batch Sorted Merge: true
                Bulk Decompression: false
                ->  Sort (actual rows=2 loops=1)
                      Output: compress_hyper_8_19_chunk."time", compress_hyper_8_19_chunk.sensor_id, compress_hyper_8_19_chunk.cpu, compress_hyper_8_19_chunk.temperature, compress_hyper_8_19_chunk._ts_meta_count, compress_hyper_8_19_chunk._ts_meta_sequence_num, compress_hyper_8_19_chunk._ts_meta_min_1, compress_hyper_8_19_chunk._ts_meta_max_1
@@ -1219,7 +1219,7 @@ SELECT * FROM sensor_data ORDER BY time DESC LIMIT 1;
                            Output: compress_hyper_8_19_chunk."time", compress_hyper_8_19_chunk.sensor_id, compress_hyper_8_19_chunk.cpu, compress_hyper_8_19_chunk.temperature, compress_hyper_8_19_chunk._ts_meta_count, compress_hyper_8_19_chunk._ts_meta_sequence_num, compress_hyper_8_19_chunk._ts_meta_min_1, compress_hyper_8_19_chunk._ts_meta_max_1
          ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_7_12_chunk (never executed)
                Output: _hyper_7_12_chunk."time", _hyper_7_12_chunk.sensor_id, _hyper_7_12_chunk.cpu, _hyper_7_12_chunk.temperature
-               Sorted merge append: true
+               Batch Sorted Merge: true
                Bulk Decompression: false
                ->  Sort (never executed)
                      Output: compress_hyper_8_18_chunk."time", compress_hyper_8_18_chunk.sensor_id, compress_hyper_8_18_chunk.cpu, compress_hyper_8_18_chunk.temperature, compress_hyper_8_18_chunk._ts_meta_count, compress_hyper_8_18_chunk._ts_meta_sequence_num, compress_hyper_8_18_chunk._ts_meta_min_1, compress_hyper_8_18_chunk._ts_meta_max_1
@@ -1228,7 +1228,7 @@ SELECT * FROM sensor_data ORDER BY time DESC LIMIT 1;
                            Output: compress_hyper_8_18_chunk."time", compress_hyper_8_18_chunk.sensor_id, compress_hyper_8_18_chunk.cpu, compress_hyper_8_18_chunk.temperature, compress_hyper_8_18_chunk._ts_meta_count, compress_hyper_8_18_chunk._ts_meta_sequence_num, compress_hyper_8_18_chunk._ts_meta_min_1, compress_hyper_8_18_chunk._ts_meta_max_1
          ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_7_11_chunk (never executed)
                Output: _hyper_7_11_chunk."time", _hyper_7_11_chunk.sensor_id, _hyper_7_11_chunk.cpu, _hyper_7_11_chunk.temperature
-               Sorted merge append: true
+               Batch Sorted Merge: true
                Bulk Decompression: false
                ->  Sort (never executed)
                      Output: compress_hyper_8_17_chunk."time", compress_hyper_8_17_chunk.sensor_id, compress_hyper_8_17_chunk.cpu, compress_hyper_8_17_chunk.temperature, compress_hyper_8_17_chunk._ts_meta_count, compress_hyper_8_17_chunk._ts_meta_sequence_num, compress_hyper_8_17_chunk._ts_meta_min_1, compress_hyper_8_17_chunk._ts_meta_max_1
@@ -1237,7 +1237,7 @@ SELECT * FROM sensor_data ORDER BY time DESC LIMIT 1;
                            Output: compress_hyper_8_17_chunk."time", compress_hyper_8_17_chunk.sensor_id, compress_hyper_8_17_chunk.cpu, compress_hyper_8_17_chunk.temperature, compress_hyper_8_17_chunk._ts_meta_count, compress_hyper_8_17_chunk._ts_meta_sequence_num, compress_hyper_8_17_chunk._ts_meta_min_1, compress_hyper_8_17_chunk._ts_meta_max_1
          ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_7_10_chunk (never executed)
                Output: _hyper_7_10_chunk."time", _hyper_7_10_chunk.sensor_id, _hyper_7_10_chunk.cpu, _hyper_7_10_chunk.temperature
-               Sorted merge append: true
+               Batch Sorted Merge: true
                Bulk Decompression: false
                ->  Sort (never executed)
                      Output: compress_hyper_8_16_chunk."time", compress_hyper_8_16_chunk.sensor_id, compress_hyper_8_16_chunk.cpu, compress_hyper_8_16_chunk.temperature, compress_hyper_8_16_chunk._ts_meta_count, compress_hyper_8_16_chunk._ts_meta_sequence_num, compress_hyper_8_16_chunk._ts_meta_min_1, compress_hyper_8_16_chunk._ts_meta_max_1
@@ -1246,7 +1246,7 @@ SELECT * FROM sensor_data ORDER BY time DESC LIMIT 1;
                            Output: compress_hyper_8_16_chunk."time", compress_hyper_8_16_chunk.sensor_id, compress_hyper_8_16_chunk.cpu, compress_hyper_8_16_chunk.temperature, compress_hyper_8_16_chunk._ts_meta_count, compress_hyper_8_16_chunk._ts_meta_sequence_num, compress_hyper_8_16_chunk._ts_meta_min_1, compress_hyper_8_16_chunk._ts_meta_max_1
          ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_7_9_chunk (never executed)
                Output: _hyper_7_9_chunk."time", _hyper_7_9_chunk.sensor_id, _hyper_7_9_chunk.cpu, _hyper_7_9_chunk.temperature
-               Sorted merge append: true
+               Batch Sorted Merge: true
                Bulk Decompression: false
                ->  Sort (never executed)
                      Output: compress_hyper_8_15_chunk."time", compress_hyper_8_15_chunk.sensor_id, compress_hyper_8_15_chunk.cpu, compress_hyper_8_15_chunk.temperature, compress_hyper_8_15_chunk._ts_meta_count, compress_hyper_8_15_chunk._ts_meta_sequence_num, compress_hyper_8_15_chunk._ts_meta_min_1, compress_hyper_8_15_chunk._ts_meta_max_1
@@ -1255,7 +1255,7 @@ SELECT * FROM sensor_data ORDER BY time DESC LIMIT 1;
                            Output: compress_hyper_8_15_chunk."time", compress_hyper_8_15_chunk.sensor_id, compress_hyper_8_15_chunk.cpu, compress_hyper_8_15_chunk.temperature, compress_hyper_8_15_chunk._ts_meta_count, compress_hyper_8_15_chunk._ts_meta_sequence_num, compress_hyper_8_15_chunk._ts_meta_min_1, compress_hyper_8_15_chunk._ts_meta_max_1
          ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_7_8_chunk (never executed)
                Output: _hyper_7_8_chunk."time", _hyper_7_8_chunk.sensor_id, _hyper_7_8_chunk.cpu, _hyper_7_8_chunk.temperature
-               Sorted merge append: true
+               Batch Sorted Merge: true
                Bulk Decompression: false
                ->  Sort (never executed)
                      Output: compress_hyper_8_14_chunk."time", compress_hyper_8_14_chunk.sensor_id, compress_hyper_8_14_chunk.cpu, compress_hyper_8_14_chunk.temperature, compress_hyper_8_14_chunk._ts_meta_count, compress_hyper_8_14_chunk._ts_meta_sequence_num, compress_hyper_8_14_chunk._ts_meta_min_1, compress_hyper_8_14_chunk._ts_meta_max_1
@@ -1370,7 +1370,7 @@ SELECT time, segment_by, x1 FROM test_costs ORDER BY time DESC;
 --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_9_20_chunk (actual rows=100 loops=1)
    Output: _hyper_9_20_chunk."time", _hyper_9_20_chunk.segment_by, _hyper_9_20_chunk.x1
-   Sorted merge append: true
+   Batch Sorted Merge: true
    Bulk Decompression: false
    ->  Sort (actual rows=100 loops=1)
          Output: compress_hyper_10_21_chunk."time", compress_hyper_10_21_chunk.segment_by, compress_hyper_10_21_chunk.x1, compress_hyper_10_21_chunk._ts_meta_count, compress_hyper_10_21_chunk._ts_meta_sequence_num, compress_hyper_10_21_chunk._ts_meta_min_1, compress_hyper_10_21_chunk._ts_meta_max_1, compress_hyper_10_21_chunk._ts_meta_min_2, compress_hyper_10_21_chunk._ts_meta_max_2
@@ -1434,7 +1434,7 @@ SELECT time, segment_by, x1 FROM test_costs WHERE segment_by > 900 and segment_b
 --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_9_20_chunk (actual rows=98 loops=1)
    Output: _hyper_9_20_chunk."time", _hyper_9_20_chunk.segment_by, _hyper_9_20_chunk.x1
-   Sorted merge append: true
+   Batch Sorted Merge: true
    Bulk Decompression: false
    ->  Sort (actual rows=98 loops=1)
          Output: compress_hyper_10_22_chunk."time", compress_hyper_10_22_chunk.segment_by, compress_hyper_10_22_chunk.x1, compress_hyper_10_22_chunk._ts_meta_count, compress_hyper_10_22_chunk._ts_meta_sequence_num, compress_hyper_10_22_chunk._ts_meta_min_1, compress_hyper_10_22_chunk._ts_meta_max_1, compress_hyper_10_22_chunk._ts_meta_min_2, compress_hyper_10_22_chunk._ts_meta_max_2
@@ -1487,7 +1487,7 @@ SELECT "time","hin"::text,"model"::text,"block"::text,"message_name"::text,"sign
 ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_11_23_chunk (actual rows=1 loops=1)
    Output: _hyper_11_23_chunk."time", (_hyper_11_23_chunk.hin)::text, (_hyper_11_23_chunk.model)::text, (_hyper_11_23_chunk.block)::text, (_hyper_11_23_chunk.message_name)::text, (_hyper_11_23_chunk.signal_name)::text, _hyper_11_23_chunk.signal_numeric_value, (_hyper_11_23_chunk.signal_string_value)::text
-   Sorted merge append: true
+   Batch Sorted Merge: true
    Bulk Decompression: false
    ->  Sort (actual rows=1 loops=1)
          Output: compress_hyper_12_24_chunk."time", compress_hyper_12_24_chunk.hin, compress_hyper_12_24_chunk.model, compress_hyper_12_24_chunk.block, compress_hyper_12_24_chunk.message_name, compress_hyper_12_24_chunk.signal_name, compress_hyper_12_24_chunk.signal_numeric_value, compress_hyper_12_24_chunk.signal_string_value, compress_hyper_12_24_chunk._ts_meta_count, compress_hyper_12_24_chunk._ts_meta_sequence_num, compress_hyper_12_24_chunk._ts_meta_min_1, compress_hyper_12_24_chunk._ts_meta_max_1

--- a/tsl/test/expected/compression_sorted_merge-13.out
+++ b/tsl/test/expected/compression_sorted_merge-13.out
@@ -1,6 +1,10 @@
 -- This file and its contents are licensed under the Timescale License.
 -- Please see the included NOTICE for copyright information and
 -- LICENSE-TIMESCALE for a copy of the license.
+-- Increase the working memory limit slightly, otherwise the batch sorted merge
+-- will be penalized for segmentby cardinalities larger than 100, where it is
+-- still faster than sort.
+SET work_mem to '16MB';
 \set PREFIX 'EXPLAIN (analyze, verbose, costs off, timing off, summary off)'
 CREATE TABLE test1 (
 time timestamptz NOT NULL,
@@ -824,9 +828,9 @@ SELECT time,x3 FROM test1 ORDER BY time DESC;
 EXPLAIN (verbose) SELECT 1 as one, 2 as two, 3 as three, time, x2 FROM test1 ORDER BY time DESC;
                                                                                                                                                                                                                                                                          QUERY PLAN                                                                                                                                                                                                                                                                          
 -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
- Result  (cost=1.06..38.26 rows=3000 width=24)
+ Result  (cost=1.06..93.44 rows=3000 width=24)
    Output: 1, 2, 3, _hyper_1_1_chunk."time", _hyper_1_1_chunk.x2
-   ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_1_chunk  (cost=1.06..8.26 rows=3000 width=12)
+   ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_1_chunk  (cost=1.06..63.44 rows=3000 width=12)
          Output: _hyper_1_1_chunk."time", _hyper_1_1_chunk.x2
          Sorted merge append: true
          ->  Sort  (cost=0.00..0.00 rows=0 width=0)
@@ -849,9 +853,9 @@ SELECT 1 as one, 2 as two, 3 as three, time, x2 FROM test1 ORDER BY time DESC;
 EXPLAIN (verbose) SELECT 1 as one, 2 as two, 3 as three, x2, time FROM test1 ORDER BY time DESC;
                                                                                                                                                                                                                                                                          QUERY PLAN                                                                                                                                                                                                                                                                          
 -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
- Result  (cost=1.06..38.26 rows=3000 width=24)
+ Result  (cost=1.06..93.44 rows=3000 width=24)
    Output: 1, 2, 3, _hyper_1_1_chunk.x2, _hyper_1_1_chunk."time"
-   ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_1_chunk  (cost=1.06..8.26 rows=3000 width=12)
+   ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_1_chunk  (cost=1.06..63.44 rows=3000 width=12)
          Output: _hyper_1_1_chunk.x2, _hyper_1_1_chunk."time"
          Sorted merge append: true
          ->  Sort  (cost=0.00..0.00 rows=0 width=0)

--- a/tsl/test/expected/compression_sorted_merge-14.out
+++ b/tsl/test/expected/compression_sorted_merge-14.out
@@ -86,7 +86,7 @@ SELECT * FROM test1 ORDER BY time DESC;
 -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_1_chunk (actual rows=4 loops=1)
    Output: _hyper_1_1_chunk."time", _hyper_1_1_chunk.x1, _hyper_1_1_chunk.x2, _hyper_1_1_chunk.x3, _hyper_1_1_chunk.x4, _hyper_1_1_chunk.x5
-   Sorted merge append: true
+   Batch Sorted Merge: true
    Bulk Decompression: false
    ->  Sort (actual rows=3 loops=1)
          Output: compress_hyper_2_2_chunk."time", compress_hyper_2_2_chunk.x1, compress_hyper_2_2_chunk.x2, compress_hyper_2_2_chunk.x3, compress_hyper_2_2_chunk.x4, compress_hyper_2_2_chunk.x5, compress_hyper_2_2_chunk._ts_meta_count, compress_hyper_2_2_chunk._ts_meta_sequence_num, compress_hyper_2_2_chunk._ts_meta_min_1, compress_hyper_2_2_chunk._ts_meta_max_1, compress_hyper_2_2_chunk._ts_meta_min_2, compress_hyper_2_2_chunk._ts_meta_max_2, compress_hyper_2_2_chunk._ts_meta_min_3, compress_hyper_2_2_chunk._ts_meta_max_3
@@ -103,7 +103,7 @@ SELECT * FROM test1 ORDER BY time DESC NULLS FIRST;
 -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_1_chunk (actual rows=4 loops=1)
    Output: _hyper_1_1_chunk."time", _hyper_1_1_chunk.x1, _hyper_1_1_chunk.x2, _hyper_1_1_chunk.x3, _hyper_1_1_chunk.x4, _hyper_1_1_chunk.x5
-   Sorted merge append: true
+   Batch Sorted Merge: true
    Bulk Decompression: false
    ->  Sort (actual rows=3 loops=1)
          Output: compress_hyper_2_2_chunk."time", compress_hyper_2_2_chunk.x1, compress_hyper_2_2_chunk.x2, compress_hyper_2_2_chunk.x3, compress_hyper_2_2_chunk.x4, compress_hyper_2_2_chunk.x5, compress_hyper_2_2_chunk._ts_meta_count, compress_hyper_2_2_chunk._ts_meta_sequence_num, compress_hyper_2_2_chunk._ts_meta_min_1, compress_hyper_2_2_chunk._ts_meta_max_1, compress_hyper_2_2_chunk._ts_meta_min_2, compress_hyper_2_2_chunk._ts_meta_max_2, compress_hyper_2_2_chunk._ts_meta_min_3, compress_hyper_2_2_chunk._ts_meta_max_3
@@ -136,7 +136,7 @@ SELECT * FROM test1 ORDER BY time ASC;
 -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_1_chunk (actual rows=4 loops=1)
    Output: _hyper_1_1_chunk."time", _hyper_1_1_chunk.x1, _hyper_1_1_chunk.x2, _hyper_1_1_chunk.x3, _hyper_1_1_chunk.x4, _hyper_1_1_chunk.x5
-   Sorted merge append: true
+   Batch Sorted Merge: true
    Bulk Decompression: false
    ->  Sort (actual rows=3 loops=1)
          Output: compress_hyper_2_2_chunk."time", compress_hyper_2_2_chunk.x1, compress_hyper_2_2_chunk.x2, compress_hyper_2_2_chunk.x3, compress_hyper_2_2_chunk.x4, compress_hyper_2_2_chunk.x5, compress_hyper_2_2_chunk._ts_meta_count, compress_hyper_2_2_chunk._ts_meta_sequence_num, compress_hyper_2_2_chunk._ts_meta_min_1, compress_hyper_2_2_chunk._ts_meta_max_1, compress_hyper_2_2_chunk._ts_meta_min_2, compress_hyper_2_2_chunk._ts_meta_max_2, compress_hyper_2_2_chunk._ts_meta_min_3, compress_hyper_2_2_chunk._ts_meta_max_3
@@ -153,7 +153,7 @@ SELECT * FROM test1 ORDER BY time ASC NULLS LAST;
 -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_1_chunk (actual rows=4 loops=1)
    Output: _hyper_1_1_chunk."time", _hyper_1_1_chunk.x1, _hyper_1_1_chunk.x2, _hyper_1_1_chunk.x3, _hyper_1_1_chunk.x4, _hyper_1_1_chunk.x5
-   Sorted merge append: true
+   Batch Sorted Merge: true
    Bulk Decompression: false
    ->  Sort (actual rows=3 loops=1)
          Output: compress_hyper_2_2_chunk."time", compress_hyper_2_2_chunk.x1, compress_hyper_2_2_chunk.x2, compress_hyper_2_2_chunk.x3, compress_hyper_2_2_chunk.x4, compress_hyper_2_2_chunk.x5, compress_hyper_2_2_chunk._ts_meta_count, compress_hyper_2_2_chunk._ts_meta_sequence_num, compress_hyper_2_2_chunk._ts_meta_min_1, compress_hyper_2_2_chunk._ts_meta_max_1, compress_hyper_2_2_chunk._ts_meta_min_2, compress_hyper_2_2_chunk._ts_meta_max_2, compress_hyper_2_2_chunk._ts_meta_min_3, compress_hyper_2_2_chunk._ts_meta_max_3
@@ -186,7 +186,7 @@ SELECT * FROM test1 ORDER BY time DESC NULLS FIRST, x3 ASC NULLS LAST;
 -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_1_chunk (actual rows=4 loops=1)
    Output: _hyper_1_1_chunk."time", _hyper_1_1_chunk.x1, _hyper_1_1_chunk.x2, _hyper_1_1_chunk.x3, _hyper_1_1_chunk.x4, _hyper_1_1_chunk.x5
-   Sorted merge append: true
+   Batch Sorted Merge: true
    Bulk Decompression: false
    ->  Sort (actual rows=3 loops=1)
          Output: compress_hyper_2_2_chunk."time", compress_hyper_2_2_chunk.x1, compress_hyper_2_2_chunk.x2, compress_hyper_2_2_chunk.x3, compress_hyper_2_2_chunk.x4, compress_hyper_2_2_chunk.x5, compress_hyper_2_2_chunk._ts_meta_count, compress_hyper_2_2_chunk._ts_meta_sequence_num, compress_hyper_2_2_chunk._ts_meta_min_1, compress_hyper_2_2_chunk._ts_meta_max_1, compress_hyper_2_2_chunk._ts_meta_min_2, compress_hyper_2_2_chunk._ts_meta_max_2, compress_hyper_2_2_chunk._ts_meta_min_3, compress_hyper_2_2_chunk._ts_meta_max_3
@@ -203,7 +203,7 @@ SELECT * FROM test1 ORDER BY time DESC NULLS FIRST, x3 ASC NULLS LAST, x4 ASC NU
 -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_1_chunk (actual rows=4 loops=1)
    Output: _hyper_1_1_chunk."time", _hyper_1_1_chunk.x1, _hyper_1_1_chunk.x2, _hyper_1_1_chunk.x3, _hyper_1_1_chunk.x4, _hyper_1_1_chunk.x5
-   Sorted merge append: true
+   Batch Sorted Merge: true
    Bulk Decompression: false
    ->  Sort (actual rows=3 loops=1)
          Output: compress_hyper_2_2_chunk."time", compress_hyper_2_2_chunk.x1, compress_hyper_2_2_chunk.x2, compress_hyper_2_2_chunk.x3, compress_hyper_2_2_chunk.x4, compress_hyper_2_2_chunk.x5, compress_hyper_2_2_chunk._ts_meta_count, compress_hyper_2_2_chunk._ts_meta_sequence_num, compress_hyper_2_2_chunk._ts_meta_min_1, compress_hyper_2_2_chunk._ts_meta_max_1, compress_hyper_2_2_chunk._ts_meta_min_2, compress_hyper_2_2_chunk._ts_meta_max_2, compress_hyper_2_2_chunk._ts_meta_min_3, compress_hyper_2_2_chunk._ts_meta_max_3
@@ -236,7 +236,7 @@ SELECT * FROM test1 ORDER BY time ASC NULLS LAST;
 -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_1_chunk (actual rows=4 loops=1)
    Output: _hyper_1_1_chunk."time", _hyper_1_1_chunk.x1, _hyper_1_1_chunk.x2, _hyper_1_1_chunk.x3, _hyper_1_1_chunk.x4, _hyper_1_1_chunk.x5
-   Sorted merge append: true
+   Batch Sorted Merge: true
    Bulk Decompression: false
    ->  Sort (actual rows=3 loops=1)
          Output: compress_hyper_2_2_chunk."time", compress_hyper_2_2_chunk.x1, compress_hyper_2_2_chunk.x2, compress_hyper_2_2_chunk.x3, compress_hyper_2_2_chunk.x4, compress_hyper_2_2_chunk.x5, compress_hyper_2_2_chunk._ts_meta_count, compress_hyper_2_2_chunk._ts_meta_sequence_num, compress_hyper_2_2_chunk._ts_meta_min_1, compress_hyper_2_2_chunk._ts_meta_max_1, compress_hyper_2_2_chunk._ts_meta_min_2, compress_hyper_2_2_chunk._ts_meta_max_2, compress_hyper_2_2_chunk._ts_meta_min_3, compress_hyper_2_2_chunk._ts_meta_max_3
@@ -253,7 +253,7 @@ SELECT * FROM test1 ORDER BY time ASC NULLS LAST, x3 DESC NULLS FIRST;
 -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_1_chunk (actual rows=4 loops=1)
    Output: _hyper_1_1_chunk."time", _hyper_1_1_chunk.x1, _hyper_1_1_chunk.x2, _hyper_1_1_chunk.x3, _hyper_1_1_chunk.x4, _hyper_1_1_chunk.x5
-   Sorted merge append: true
+   Batch Sorted Merge: true
    Bulk Decompression: false
    ->  Sort (actual rows=3 loops=1)
          Output: compress_hyper_2_2_chunk."time", compress_hyper_2_2_chunk.x1, compress_hyper_2_2_chunk.x2, compress_hyper_2_2_chunk.x3, compress_hyper_2_2_chunk.x4, compress_hyper_2_2_chunk.x5, compress_hyper_2_2_chunk._ts_meta_count, compress_hyper_2_2_chunk._ts_meta_sequence_num, compress_hyper_2_2_chunk._ts_meta_min_1, compress_hyper_2_2_chunk._ts_meta_max_1, compress_hyper_2_2_chunk._ts_meta_min_2, compress_hyper_2_2_chunk._ts_meta_max_2, compress_hyper_2_2_chunk._ts_meta_min_3, compress_hyper_2_2_chunk._ts_meta_max_3
@@ -270,7 +270,7 @@ SELECT * FROM test1 ORDER BY time ASC NULLS LAST, x3 DESC NULLS FIRST, x4 DESC N
 -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_1_chunk (actual rows=4 loops=1)
    Output: _hyper_1_1_chunk."time", _hyper_1_1_chunk.x1, _hyper_1_1_chunk.x2, _hyper_1_1_chunk.x3, _hyper_1_1_chunk.x4, _hyper_1_1_chunk.x5
-   Sorted merge append: true
+   Batch Sorted Merge: true
    Bulk Decompression: false
    ->  Sort (actual rows=3 loops=1)
          Output: compress_hyper_2_2_chunk."time", compress_hyper_2_2_chunk.x1, compress_hyper_2_2_chunk.x2, compress_hyper_2_2_chunk.x3, compress_hyper_2_2_chunk.x4, compress_hyper_2_2_chunk.x5, compress_hyper_2_2_chunk._ts_meta_count, compress_hyper_2_2_chunk._ts_meta_sequence_num, compress_hyper_2_2_chunk._ts_meta_min_1, compress_hyper_2_2_chunk._ts_meta_max_1, compress_hyper_2_2_chunk._ts_meta_min_2, compress_hyper_2_2_chunk._ts_meta_max_2, compress_hyper_2_2_chunk._ts_meta_min_3, compress_hyper_2_2_chunk._ts_meta_max_3
@@ -303,7 +303,7 @@ SELECT * FROM test2 ORDER BY time ASC;
 -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_3_3_chunk (actual rows=4 loops=1)
    Output: _hyper_3_3_chunk."time", _hyper_3_3_chunk.x1, _hyper_3_3_chunk.x2, _hyper_3_3_chunk.x3, _hyper_3_3_chunk.x4, _hyper_3_3_chunk.x5
-   Sorted merge append: true
+   Batch Sorted Merge: true
    Bulk Decompression: false
    ->  Sort (actual rows=3 loops=1)
          Output: compress_hyper_4_4_chunk."time", compress_hyper_4_4_chunk.x1, compress_hyper_4_4_chunk.x2, compress_hyper_4_4_chunk.x3, compress_hyper_4_4_chunk.x4, compress_hyper_4_4_chunk.x5, compress_hyper_4_4_chunk._ts_meta_count, compress_hyper_4_4_chunk._ts_meta_sequence_num, compress_hyper_4_4_chunk._ts_meta_min_1, compress_hyper_4_4_chunk._ts_meta_max_1, compress_hyper_4_4_chunk._ts_meta_min_2, compress_hyper_4_4_chunk._ts_meta_max_2, compress_hyper_4_4_chunk._ts_meta_min_3, compress_hyper_4_4_chunk._ts_meta_max_3
@@ -320,7 +320,7 @@ SELECT * FROM test2 ORDER BY time ASC, x3 DESC;
 -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_3_3_chunk (actual rows=4 loops=1)
    Output: _hyper_3_3_chunk."time", _hyper_3_3_chunk.x1, _hyper_3_3_chunk.x2, _hyper_3_3_chunk.x3, _hyper_3_3_chunk.x4, _hyper_3_3_chunk.x5
-   Sorted merge append: true
+   Batch Sorted Merge: true
    Bulk Decompression: false
    ->  Sort (actual rows=3 loops=1)
          Output: compress_hyper_4_4_chunk."time", compress_hyper_4_4_chunk.x1, compress_hyper_4_4_chunk.x2, compress_hyper_4_4_chunk.x3, compress_hyper_4_4_chunk.x4, compress_hyper_4_4_chunk.x5, compress_hyper_4_4_chunk._ts_meta_count, compress_hyper_4_4_chunk._ts_meta_sequence_num, compress_hyper_4_4_chunk._ts_meta_min_1, compress_hyper_4_4_chunk._ts_meta_max_1, compress_hyper_4_4_chunk._ts_meta_min_2, compress_hyper_4_4_chunk._ts_meta_max_2, compress_hyper_4_4_chunk._ts_meta_min_3, compress_hyper_4_4_chunk._ts_meta_max_3
@@ -337,7 +337,7 @@ SELECT * FROM test2 ORDER BY time ASC, x3 DESC, x4 DESC;
 -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_3_3_chunk (actual rows=4 loops=1)
    Output: _hyper_3_3_chunk."time", _hyper_3_3_chunk.x1, _hyper_3_3_chunk.x2, _hyper_3_3_chunk.x3, _hyper_3_3_chunk.x4, _hyper_3_3_chunk.x5
-   Sorted merge append: true
+   Batch Sorted Merge: true
    Bulk Decompression: false
    ->  Sort (actual rows=3 loops=1)
          Output: compress_hyper_4_4_chunk."time", compress_hyper_4_4_chunk.x1, compress_hyper_4_4_chunk.x2, compress_hyper_4_4_chunk.x3, compress_hyper_4_4_chunk.x4, compress_hyper_4_4_chunk.x5, compress_hyper_4_4_chunk._ts_meta_count, compress_hyper_4_4_chunk._ts_meta_sequence_num, compress_hyper_4_4_chunk._ts_meta_min_1, compress_hyper_4_4_chunk._ts_meta_max_1, compress_hyper_4_4_chunk._ts_meta_min_2, compress_hyper_4_4_chunk._ts_meta_max_2, compress_hyper_4_4_chunk._ts_meta_min_3, compress_hyper_4_4_chunk._ts_meta_max_3
@@ -386,7 +386,7 @@ SELECT * FROM test2 ORDER BY time DESC NULLS FIRST;
 -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_3_3_chunk (actual rows=4 loops=1)
    Output: _hyper_3_3_chunk."time", _hyper_3_3_chunk.x1, _hyper_3_3_chunk.x2, _hyper_3_3_chunk.x3, _hyper_3_3_chunk.x4, _hyper_3_3_chunk.x5
-   Sorted merge append: true
+   Batch Sorted Merge: true
    Bulk Decompression: false
    ->  Sort (actual rows=3 loops=1)
          Output: compress_hyper_4_4_chunk."time", compress_hyper_4_4_chunk.x1, compress_hyper_4_4_chunk.x2, compress_hyper_4_4_chunk.x3, compress_hyper_4_4_chunk.x4, compress_hyper_4_4_chunk.x5, compress_hyper_4_4_chunk._ts_meta_count, compress_hyper_4_4_chunk._ts_meta_sequence_num, compress_hyper_4_4_chunk._ts_meta_min_1, compress_hyper_4_4_chunk._ts_meta_max_1, compress_hyper_4_4_chunk._ts_meta_min_2, compress_hyper_4_4_chunk._ts_meta_max_2, compress_hyper_4_4_chunk._ts_meta_min_3, compress_hyper_4_4_chunk._ts_meta_max_3
@@ -403,7 +403,7 @@ SELECT * FROM test2 ORDER BY time DESC NULLS FIRST, x3 ASC NULLS LAST;
 -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_3_3_chunk (actual rows=4 loops=1)
    Output: _hyper_3_3_chunk."time", _hyper_3_3_chunk.x1, _hyper_3_3_chunk.x2, _hyper_3_3_chunk.x3, _hyper_3_3_chunk.x4, _hyper_3_3_chunk.x5
-   Sorted merge append: true
+   Batch Sorted Merge: true
    Bulk Decompression: false
    ->  Sort (actual rows=3 loops=1)
          Output: compress_hyper_4_4_chunk."time", compress_hyper_4_4_chunk.x1, compress_hyper_4_4_chunk.x2, compress_hyper_4_4_chunk.x3, compress_hyper_4_4_chunk.x4, compress_hyper_4_4_chunk.x5, compress_hyper_4_4_chunk._ts_meta_count, compress_hyper_4_4_chunk._ts_meta_sequence_num, compress_hyper_4_4_chunk._ts_meta_min_1, compress_hyper_4_4_chunk._ts_meta_max_1, compress_hyper_4_4_chunk._ts_meta_min_2, compress_hyper_4_4_chunk._ts_meta_max_2, compress_hyper_4_4_chunk._ts_meta_min_3, compress_hyper_4_4_chunk._ts_meta_max_3
@@ -420,7 +420,7 @@ SELECT * FROM test2 ORDER BY time DESC NULLS FIRST, x3 ASC NULLS LAST, x4 NULLS 
 -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_3_3_chunk (actual rows=4 loops=1)
    Output: _hyper_3_3_chunk."time", _hyper_3_3_chunk.x1, _hyper_3_3_chunk.x2, _hyper_3_3_chunk.x3, _hyper_3_3_chunk.x4, _hyper_3_3_chunk.x5
-   Sorted merge append: true
+   Batch Sorted Merge: true
    Bulk Decompression: false
    ->  Sort (actual rows=3 loops=1)
          Output: compress_hyper_4_4_chunk."time", compress_hyper_4_4_chunk.x1, compress_hyper_4_4_chunk.x2, compress_hyper_4_4_chunk.x3, compress_hyper_4_4_chunk.x4, compress_hyper_4_4_chunk.x5, compress_hyper_4_4_chunk._ts_meta_count, compress_hyper_4_4_chunk._ts_meta_sequence_num, compress_hyper_4_4_chunk._ts_meta_min_1, compress_hyper_4_4_chunk._ts_meta_max_1, compress_hyper_4_4_chunk._ts_meta_min_2, compress_hyper_4_4_chunk._ts_meta_max_2, compress_hyper_4_4_chunk._ts_meta_min_3, compress_hyper_4_4_chunk._ts_meta_max_3
@@ -469,7 +469,7 @@ SELECT * FROM test_with_defined_null ORDER BY x2 ASC NULLS FIRST;
 -----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_5_5_chunk (actual rows=4 loops=1)
    Output: _hyper_5_5_chunk."time", _hyper_5_5_chunk.x1, _hyper_5_5_chunk.x2, _hyper_5_5_chunk.x3
-   Sorted merge append: true
+   Batch Sorted Merge: true
    Bulk Decompression: false
    ->  Sort (actual rows=2 loops=1)
          Output: compress_hyper_6_6_chunk."time", compress_hyper_6_6_chunk.x1, compress_hyper_6_6_chunk.x2, compress_hyper_6_6_chunk.x3, compress_hyper_6_6_chunk._ts_meta_count, compress_hyper_6_6_chunk._ts_meta_sequence_num, compress_hyper_6_6_chunk._ts_meta_min_2, compress_hyper_6_6_chunk._ts_meta_max_2, compress_hyper_6_6_chunk._ts_meta_min_1, compress_hyper_6_6_chunk._ts_meta_max_1
@@ -486,7 +486,7 @@ SELECT * FROM test_with_defined_null ORDER BY x2 DESC NULLS LAST;
 -----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_5_5_chunk (actual rows=4 loops=1)
    Output: _hyper_5_5_chunk."time", _hyper_5_5_chunk.x1, _hyper_5_5_chunk.x2, _hyper_5_5_chunk.x3
-   Sorted merge append: true
+   Batch Sorted Merge: true
    Bulk Decompression: false
    ->  Sort (actual rows=2 loops=1)
          Output: compress_hyper_6_6_chunk."time", compress_hyper_6_6_chunk.x1, compress_hyper_6_6_chunk.x2, compress_hyper_6_6_chunk.x3, compress_hyper_6_6_chunk._ts_meta_count, compress_hyper_6_6_chunk._ts_meta_sequence_num, compress_hyper_6_6_chunk._ts_meta_min_2, compress_hyper_6_6_chunk._ts_meta_max_2, compress_hyper_6_6_chunk._ts_meta_min_1, compress_hyper_6_6_chunk._ts_meta_max_1
@@ -539,7 +539,7 @@ SELECT * FROM test1 WHERE x4 > 0 ORDER BY time DESC;
  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_1_chunk (actual rows=4 loops=1)
    Output: _hyper_1_1_chunk."time", _hyper_1_1_chunk.x1, _hyper_1_1_chunk.x2, _hyper_1_1_chunk.x3, _hyper_1_1_chunk.x4, _hyper_1_1_chunk.x5
    Filter: (_hyper_1_1_chunk.x4 > 0)
-   Sorted merge append: true
+   Batch Sorted Merge: true
    Bulk Decompression: false
    ->  Sort (actual rows=3 loops=1)
          Output: compress_hyper_2_2_chunk."time", compress_hyper_2_2_chunk.x1, compress_hyper_2_2_chunk.x2, compress_hyper_2_2_chunk.x3, compress_hyper_2_2_chunk.x4, compress_hyper_2_2_chunk.x5, compress_hyper_2_2_chunk._ts_meta_count, compress_hyper_2_2_chunk._ts_meta_sequence_num, compress_hyper_2_2_chunk._ts_meta_min_1, compress_hyper_2_2_chunk._ts_meta_max_1, compress_hyper_2_2_chunk._ts_meta_min_2, compress_hyper_2_2_chunk._ts_meta_max_2, compress_hyper_2_2_chunk._ts_meta_min_3, compress_hyper_2_2_chunk._ts_meta_max_3
@@ -558,7 +558,7 @@ SELECT * FROM test1 WHERE x4 > 100 ORDER BY time DESC;
  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_1_chunk (actual rows=0 loops=1)
    Output: _hyper_1_1_chunk."time", _hyper_1_1_chunk.x1, _hyper_1_1_chunk.x2, _hyper_1_1_chunk.x3, _hyper_1_1_chunk.x4, _hyper_1_1_chunk.x5
    Filter: (_hyper_1_1_chunk.x4 > 100)
-   Sorted merge append: true
+   Batch Sorted Merge: true
    Bulk Decompression: false
    ->  Sort (actual rows=0 loops=1)
          Output: compress_hyper_2_2_chunk."time", compress_hyper_2_2_chunk.x1, compress_hyper_2_2_chunk.x2, compress_hyper_2_2_chunk.x3, compress_hyper_2_2_chunk.x4, compress_hyper_2_2_chunk.x5, compress_hyper_2_2_chunk._ts_meta_count, compress_hyper_2_2_chunk._ts_meta_sequence_num, compress_hyper_2_2_chunk._ts_meta_min_1, compress_hyper_2_2_chunk._ts_meta_max_1, compress_hyper_2_2_chunk._ts_meta_min_2, compress_hyper_2_2_chunk._ts_meta_max_2, compress_hyper_2_2_chunk._ts_meta_min_3, compress_hyper_2_2_chunk._ts_meta_max_3
@@ -578,7 +578,7 @@ SELECT * FROM test1 WHERE x4 > 100 ORDER BY time DESC, x3, x4;
  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_1_chunk (actual rows=0 loops=1)
    Output: _hyper_1_1_chunk."time", _hyper_1_1_chunk.x1, _hyper_1_1_chunk.x2, _hyper_1_1_chunk.x3, _hyper_1_1_chunk.x4, _hyper_1_1_chunk.x5
    Filter: (_hyper_1_1_chunk.x4 > 100)
-   Sorted merge append: true
+   Batch Sorted Merge: true
    Bulk Decompression: false
    ->  Sort (actual rows=0 loops=1)
          Output: compress_hyper_2_2_chunk."time", compress_hyper_2_2_chunk.x1, compress_hyper_2_2_chunk.x2, compress_hyper_2_2_chunk.x3, compress_hyper_2_2_chunk.x4, compress_hyper_2_2_chunk.x5, compress_hyper_2_2_chunk._ts_meta_count, compress_hyper_2_2_chunk._ts_meta_sequence_num, compress_hyper_2_2_chunk._ts_meta_min_1, compress_hyper_2_2_chunk._ts_meta_max_1, compress_hyper_2_2_chunk._ts_meta_min_2, compress_hyper_2_2_chunk._ts_meta_max_2, compress_hyper_2_2_chunk._ts_meta_min_3, compress_hyper_2_2_chunk._ts_meta_max_3
@@ -598,7 +598,7 @@ SELECT * FROM test1 WHERE x4 > 100 ORDER BY time DESC, x3, x3;
  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_1_chunk (actual rows=0 loops=1)
    Output: _hyper_1_1_chunk."time", _hyper_1_1_chunk.x1, _hyper_1_1_chunk.x2, _hyper_1_1_chunk.x3, _hyper_1_1_chunk.x4, _hyper_1_1_chunk.x5
    Filter: (_hyper_1_1_chunk.x4 > 100)
-   Sorted merge append: true
+   Batch Sorted Merge: true
    Bulk Decompression: false
    ->  Sort (actual rows=0 loops=1)
          Output: compress_hyper_2_2_chunk."time", compress_hyper_2_2_chunk.x1, compress_hyper_2_2_chunk.x2, compress_hyper_2_2_chunk.x3, compress_hyper_2_2_chunk.x4, compress_hyper_2_2_chunk.x5, compress_hyper_2_2_chunk._ts_meta_count, compress_hyper_2_2_chunk._ts_meta_sequence_num, compress_hyper_2_2_chunk._ts_meta_min_1, compress_hyper_2_2_chunk._ts_meta_max_1, compress_hyper_2_2_chunk._ts_meta_min_2, compress_hyper_2_2_chunk._ts_meta_max_2, compress_hyper_2_2_chunk._ts_meta_min_3, compress_hyper_2_2_chunk._ts_meta_max_3
@@ -618,7 +618,7 @@ SELECT * FROM test1 WHERE x4 > 100 ORDER BY time DESC, x3, x4, x3, x4;
  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_1_chunk (actual rows=0 loops=1)
    Output: _hyper_1_1_chunk."time", _hyper_1_1_chunk.x1, _hyper_1_1_chunk.x2, _hyper_1_1_chunk.x3, _hyper_1_1_chunk.x4, _hyper_1_1_chunk.x5
    Filter: (_hyper_1_1_chunk.x4 > 100)
-   Sorted merge append: true
+   Batch Sorted Merge: true
    Bulk Decompression: false
    ->  Sort (actual rows=0 loops=1)
          Output: compress_hyper_2_2_chunk."time", compress_hyper_2_2_chunk.x1, compress_hyper_2_2_chunk.x2, compress_hyper_2_2_chunk.x3, compress_hyper_2_2_chunk.x4, compress_hyper_2_2_chunk.x5, compress_hyper_2_2_chunk._ts_meta_count, compress_hyper_2_2_chunk._ts_meta_sequence_num, compress_hyper_2_2_chunk._ts_meta_min_1, compress_hyper_2_2_chunk._ts_meta_max_1, compress_hyper_2_2_chunk._ts_meta_min_2, compress_hyper_2_2_chunk._ts_meta_max_2, compress_hyper_2_2_chunk._ts_meta_min_3, compress_hyper_2_2_chunk._ts_meta_max_3
@@ -676,7 +676,7 @@ SELECT * FROM test1 ORDER BY time DESC;
 -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_1_chunk (actual rows=4 loops=1)
    Output: _hyper_1_1_chunk."time", _hyper_1_1_chunk.x1, _hyper_1_1_chunk.x2, _hyper_1_1_chunk.x3, _hyper_1_1_chunk.x4, _hyper_1_1_chunk.x5
-   Sorted merge append: true
+   Batch Sorted Merge: true
    Bulk Decompression: false
    ->  Sort (actual rows=3 loops=1)
          Output: compress_hyper_2_2_chunk."time", compress_hyper_2_2_chunk.x1, compress_hyper_2_2_chunk.x2, compress_hyper_2_2_chunk.x3, compress_hyper_2_2_chunk.x4, compress_hyper_2_2_chunk.x5, compress_hyper_2_2_chunk._ts_meta_count, compress_hyper_2_2_chunk._ts_meta_sequence_num, compress_hyper_2_2_chunk._ts_meta_min_1, compress_hyper_2_2_chunk._ts_meta_max_1, compress_hyper_2_2_chunk._ts_meta_min_2, compress_hyper_2_2_chunk._ts_meta_max_2, compress_hyper_2_2_chunk._ts_meta_min_3, compress_hyper_2_2_chunk._ts_meta_max_3
@@ -832,7 +832,7 @@ EXPLAIN (verbose) SELECT 1 as one, 2 as two, 3 as three, time, x2 FROM test1 ORD
    Output: 1, 2, 3, _hyper_1_1_chunk."time", _hyper_1_1_chunk.x2
    ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_1_chunk  (cost=1.06..63.44 rows=3000 width=12)
          Output: _hyper_1_1_chunk."time", _hyper_1_1_chunk.x2
-         Sorted merge append: true
+         Batch Sorted Merge: true
          ->  Sort  (cost=0.00..0.00 rows=0 width=0)
                Output: compress_hyper_2_2_chunk."time", compress_hyper_2_2_chunk.x1, compress_hyper_2_2_chunk.x2, compress_hyper_2_2_chunk.x3, compress_hyper_2_2_chunk.x4, compress_hyper_2_2_chunk.x5, compress_hyper_2_2_chunk._ts_meta_count, compress_hyper_2_2_chunk._ts_meta_sequence_num, compress_hyper_2_2_chunk._ts_meta_min_1, compress_hyper_2_2_chunk._ts_meta_max_1, compress_hyper_2_2_chunk._ts_meta_min_2, compress_hyper_2_2_chunk._ts_meta_max_2, compress_hyper_2_2_chunk._ts_meta_min_3, compress_hyper_2_2_chunk._ts_meta_max_3
                Sort Key: compress_hyper_2_2_chunk._ts_meta_max_1 DESC
@@ -857,7 +857,7 @@ EXPLAIN (verbose) SELECT 1 as one, 2 as two, 3 as three, x2, time FROM test1 ORD
    Output: 1, 2, 3, _hyper_1_1_chunk.x2, _hyper_1_1_chunk."time"
    ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_1_chunk  (cost=1.06..63.44 rows=3000 width=12)
          Output: _hyper_1_1_chunk.x2, _hyper_1_1_chunk."time"
-         Sorted merge append: true
+         Batch Sorted Merge: true
          ->  Sort  (cost=0.00..0.00 rows=0 width=0)
                Output: compress_hyper_2_2_chunk."time", compress_hyper_2_2_chunk.x1, compress_hyper_2_2_chunk.x2, compress_hyper_2_2_chunk.x3, compress_hyper_2_2_chunk.x4, compress_hyper_2_2_chunk.x5, compress_hyper_2_2_chunk._ts_meta_count, compress_hyper_2_2_chunk._ts_meta_sequence_num, compress_hyper_2_2_chunk._ts_meta_min_1, compress_hyper_2_2_chunk._ts_meta_max_1, compress_hyper_2_2_chunk._ts_meta_min_2, compress_hyper_2_2_chunk._ts_meta_max_2, compress_hyper_2_2_chunk._ts_meta_min_3, compress_hyper_2_2_chunk._ts_meta_max_3
                Sort Key: compress_hyper_2_2_chunk._ts_meta_max_1 DESC
@@ -954,7 +954,7 @@ SELECT * FROM test1 ORDER BY time DESC;
 -----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_1_chunk (actual rows=4 loops=1)
    Output: _hyper_1_1_chunk."time", _hyper_1_1_chunk.x1, _hyper_1_1_chunk.x2, _hyper_1_1_chunk.x3, _hyper_1_1_chunk.x4, _hyper_1_1_chunk.x5, _hyper_1_1_chunk.c1, _hyper_1_1_chunk.c2
-   Sorted merge append: true
+   Batch Sorted Merge: true
    Bulk Decompression: false
    ->  Sort (actual rows=3 loops=1)
          Output: compress_hyper_2_7_chunk."time", compress_hyper_2_7_chunk._ts_meta_min_1, compress_hyper_2_7_chunk._ts_meta_max_1, compress_hyper_2_7_chunk.x1, compress_hyper_2_7_chunk.x2, compress_hyper_2_7_chunk.x3, compress_hyper_2_7_chunk._ts_meta_min_2, compress_hyper_2_7_chunk._ts_meta_max_2, compress_hyper_2_7_chunk.x4, compress_hyper_2_7_chunk._ts_meta_min_3, compress_hyper_2_7_chunk._ts_meta_max_3, compress_hyper_2_7_chunk.x5, compress_hyper_2_7_chunk.c1, compress_hyper_2_7_chunk.c2, compress_hyper_2_7_chunk._ts_meta_count
@@ -980,7 +980,7 @@ SELECT time, x2, x1, c2 FROM test1 ORDER BY time DESC;
 -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_1_chunk (actual rows=4 loops=1)
    Output: _hyper_1_1_chunk."time", _hyper_1_1_chunk.x2, _hyper_1_1_chunk.x1, _hyper_1_1_chunk.c2
-   Sorted merge append: true
+   Batch Sorted Merge: true
    Bulk Decompression: false
    ->  Sort (actual rows=3 loops=1)
          Output: compress_hyper_2_7_chunk."time", compress_hyper_2_7_chunk._ts_meta_min_1, compress_hyper_2_7_chunk._ts_meta_max_1, compress_hyper_2_7_chunk.x2, compress_hyper_2_7_chunk.x1, compress_hyper_2_7_chunk.c2, compress_hyper_2_7_chunk._ts_meta_count
@@ -1006,7 +1006,7 @@ SELECT x2, x1, c2, time FROM test1 ORDER BY time DESC;
 -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_1_chunk (actual rows=4 loops=1)
    Output: _hyper_1_1_chunk.x2, _hyper_1_1_chunk.x1, _hyper_1_1_chunk.c2, _hyper_1_1_chunk."time"
-   Sorted merge append: true
+   Batch Sorted Merge: true
    Bulk Decompression: false
    ->  Sort (actual rows=3 loops=1)
          Output: compress_hyper_2_7_chunk.x2, compress_hyper_2_7_chunk.x1, compress_hyper_2_7_chunk.c2, compress_hyper_2_7_chunk."time", compress_hyper_2_7_chunk._ts_meta_min_1, compress_hyper_2_7_chunk._ts_meta_max_1, compress_hyper_2_7_chunk._ts_meta_count
@@ -1034,7 +1034,7 @@ SELECT 1 as one, 2 as two, 3 as three, x2, x1, c2, time FROM test1 ORDER BY time
    Output: 1, 2, 3, _hyper_1_1_chunk.x2, _hyper_1_1_chunk.x1, _hyper_1_1_chunk.c2, _hyper_1_1_chunk."time"
    ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_1_chunk (actual rows=4 loops=1)
          Output: _hyper_1_1_chunk.x2, _hyper_1_1_chunk.x1, _hyper_1_1_chunk.c2, _hyper_1_1_chunk."time"
-         Sorted merge append: true
+         Batch Sorted Merge: true
          Bulk Decompression: false
          ->  Sort (actual rows=3 loops=1)
                Output: compress_hyper_2_7_chunk.x2, compress_hyper_2_7_chunk.x1, compress_hyper_2_7_chunk.c2, compress_hyper_2_7_chunk."time", compress_hyper_2_7_chunk._ts_meta_min_1, compress_hyper_2_7_chunk._ts_meta_max_1, compress_hyper_2_7_chunk._ts_meta_count
@@ -1100,7 +1100,7 @@ SELECT * FROM test1 ORDER BY time ASC NULLS LAST;
 -----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_1_chunk (actual rows=4 loops=1)
    Output: _hyper_1_1_chunk."time", _hyper_1_1_chunk.x1, _hyper_1_1_chunk.x2, _hyper_1_1_chunk.x3, _hyper_1_1_chunk.x4, _hyper_1_1_chunk.x5, _hyper_1_1_chunk.c1, _hyper_1_1_chunk.c2
-   Sorted merge append: true
+   Batch Sorted Merge: true
    Bulk Decompression: false
    ->  Sort (actual rows=3 loops=1)
          Output: compress_hyper_2_7_chunk."time", compress_hyper_2_7_chunk._ts_meta_min_1, compress_hyper_2_7_chunk._ts_meta_max_1, compress_hyper_2_7_chunk.x1, compress_hyper_2_7_chunk.x2, compress_hyper_2_7_chunk.x3, compress_hyper_2_7_chunk._ts_meta_min_2, compress_hyper_2_7_chunk._ts_meta_max_2, compress_hyper_2_7_chunk.x4, compress_hyper_2_7_chunk._ts_meta_min_3, compress_hyper_2_7_chunk._ts_meta_max_3, compress_hyper_2_7_chunk.x5, compress_hyper_2_7_chunk.c1, compress_hyper_2_7_chunk.c2, compress_hyper_2_7_chunk._ts_meta_count
@@ -1126,7 +1126,7 @@ SELECT * FROM test1 ORDER BY time ASC NULLS LAST;
          Sort Key: _hyper_1_1_chunk."time"
          ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_1_chunk (actual rows=4 loops=1)
                Output: _hyper_1_1_chunk."time", _hyper_1_1_chunk.x1, _hyper_1_1_chunk.x2, _hyper_1_1_chunk.x3, _hyper_1_1_chunk.x4, _hyper_1_1_chunk.x5, _hyper_1_1_chunk.c1, _hyper_1_1_chunk.c2
-               Sorted merge append: true
+               Batch Sorted Merge: true
                Bulk Decompression: false
                ->  Sort (actual rows=3 loops=1)
                      Output: compress_hyper_2_7_chunk."time", compress_hyper_2_7_chunk._ts_meta_min_1, compress_hyper_2_7_chunk._ts_meta_max_1, compress_hyper_2_7_chunk.x1, compress_hyper_2_7_chunk.x2, compress_hyper_2_7_chunk.x3, compress_hyper_2_7_chunk._ts_meta_min_2, compress_hyper_2_7_chunk._ts_meta_max_2, compress_hyper_2_7_chunk.x4, compress_hyper_2_7_chunk._ts_meta_min_3, compress_hyper_2_7_chunk._ts_meta_max_3, compress_hyper_2_7_chunk.x5, compress_hyper_2_7_chunk.c1, compress_hyper_2_7_chunk.c2, compress_hyper_2_7_chunk._ts_meta_count
@@ -1209,7 +1209,7 @@ SELECT * FROM sensor_data ORDER BY time DESC LIMIT 1;
          Runtime Exclusion: false
          ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_7_13_chunk (actual rows=1 loops=1)
                Output: _hyper_7_13_chunk."time", _hyper_7_13_chunk.sensor_id, _hyper_7_13_chunk.cpu, _hyper_7_13_chunk.temperature
-               Sorted merge append: true
+               Batch Sorted Merge: true
                Bulk Decompression: false
                ->  Sort (actual rows=2 loops=1)
                      Output: compress_hyper_8_19_chunk."time", compress_hyper_8_19_chunk.sensor_id, compress_hyper_8_19_chunk.cpu, compress_hyper_8_19_chunk.temperature, compress_hyper_8_19_chunk._ts_meta_count, compress_hyper_8_19_chunk._ts_meta_sequence_num, compress_hyper_8_19_chunk._ts_meta_min_1, compress_hyper_8_19_chunk._ts_meta_max_1
@@ -1219,7 +1219,7 @@ SELECT * FROM sensor_data ORDER BY time DESC LIMIT 1;
                            Output: compress_hyper_8_19_chunk."time", compress_hyper_8_19_chunk.sensor_id, compress_hyper_8_19_chunk.cpu, compress_hyper_8_19_chunk.temperature, compress_hyper_8_19_chunk._ts_meta_count, compress_hyper_8_19_chunk._ts_meta_sequence_num, compress_hyper_8_19_chunk._ts_meta_min_1, compress_hyper_8_19_chunk._ts_meta_max_1
          ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_7_12_chunk (never executed)
                Output: _hyper_7_12_chunk."time", _hyper_7_12_chunk.sensor_id, _hyper_7_12_chunk.cpu, _hyper_7_12_chunk.temperature
-               Sorted merge append: true
+               Batch Sorted Merge: true
                Bulk Decompression: false
                ->  Sort (never executed)
                      Output: compress_hyper_8_18_chunk."time", compress_hyper_8_18_chunk.sensor_id, compress_hyper_8_18_chunk.cpu, compress_hyper_8_18_chunk.temperature, compress_hyper_8_18_chunk._ts_meta_count, compress_hyper_8_18_chunk._ts_meta_sequence_num, compress_hyper_8_18_chunk._ts_meta_min_1, compress_hyper_8_18_chunk._ts_meta_max_1
@@ -1228,7 +1228,7 @@ SELECT * FROM sensor_data ORDER BY time DESC LIMIT 1;
                            Output: compress_hyper_8_18_chunk."time", compress_hyper_8_18_chunk.sensor_id, compress_hyper_8_18_chunk.cpu, compress_hyper_8_18_chunk.temperature, compress_hyper_8_18_chunk._ts_meta_count, compress_hyper_8_18_chunk._ts_meta_sequence_num, compress_hyper_8_18_chunk._ts_meta_min_1, compress_hyper_8_18_chunk._ts_meta_max_1
          ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_7_11_chunk (never executed)
                Output: _hyper_7_11_chunk."time", _hyper_7_11_chunk.sensor_id, _hyper_7_11_chunk.cpu, _hyper_7_11_chunk.temperature
-               Sorted merge append: true
+               Batch Sorted Merge: true
                Bulk Decompression: false
                ->  Sort (never executed)
                      Output: compress_hyper_8_17_chunk."time", compress_hyper_8_17_chunk.sensor_id, compress_hyper_8_17_chunk.cpu, compress_hyper_8_17_chunk.temperature, compress_hyper_8_17_chunk._ts_meta_count, compress_hyper_8_17_chunk._ts_meta_sequence_num, compress_hyper_8_17_chunk._ts_meta_min_1, compress_hyper_8_17_chunk._ts_meta_max_1
@@ -1237,7 +1237,7 @@ SELECT * FROM sensor_data ORDER BY time DESC LIMIT 1;
                            Output: compress_hyper_8_17_chunk."time", compress_hyper_8_17_chunk.sensor_id, compress_hyper_8_17_chunk.cpu, compress_hyper_8_17_chunk.temperature, compress_hyper_8_17_chunk._ts_meta_count, compress_hyper_8_17_chunk._ts_meta_sequence_num, compress_hyper_8_17_chunk._ts_meta_min_1, compress_hyper_8_17_chunk._ts_meta_max_1
          ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_7_10_chunk (never executed)
                Output: _hyper_7_10_chunk."time", _hyper_7_10_chunk.sensor_id, _hyper_7_10_chunk.cpu, _hyper_7_10_chunk.temperature
-               Sorted merge append: true
+               Batch Sorted Merge: true
                Bulk Decompression: false
                ->  Sort (never executed)
                      Output: compress_hyper_8_16_chunk."time", compress_hyper_8_16_chunk.sensor_id, compress_hyper_8_16_chunk.cpu, compress_hyper_8_16_chunk.temperature, compress_hyper_8_16_chunk._ts_meta_count, compress_hyper_8_16_chunk._ts_meta_sequence_num, compress_hyper_8_16_chunk._ts_meta_min_1, compress_hyper_8_16_chunk._ts_meta_max_1
@@ -1246,7 +1246,7 @@ SELECT * FROM sensor_data ORDER BY time DESC LIMIT 1;
                            Output: compress_hyper_8_16_chunk."time", compress_hyper_8_16_chunk.sensor_id, compress_hyper_8_16_chunk.cpu, compress_hyper_8_16_chunk.temperature, compress_hyper_8_16_chunk._ts_meta_count, compress_hyper_8_16_chunk._ts_meta_sequence_num, compress_hyper_8_16_chunk._ts_meta_min_1, compress_hyper_8_16_chunk._ts_meta_max_1
          ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_7_9_chunk (never executed)
                Output: _hyper_7_9_chunk."time", _hyper_7_9_chunk.sensor_id, _hyper_7_9_chunk.cpu, _hyper_7_9_chunk.temperature
-               Sorted merge append: true
+               Batch Sorted Merge: true
                Bulk Decompression: false
                ->  Sort (never executed)
                      Output: compress_hyper_8_15_chunk."time", compress_hyper_8_15_chunk.sensor_id, compress_hyper_8_15_chunk.cpu, compress_hyper_8_15_chunk.temperature, compress_hyper_8_15_chunk._ts_meta_count, compress_hyper_8_15_chunk._ts_meta_sequence_num, compress_hyper_8_15_chunk._ts_meta_min_1, compress_hyper_8_15_chunk._ts_meta_max_1
@@ -1255,7 +1255,7 @@ SELECT * FROM sensor_data ORDER BY time DESC LIMIT 1;
                            Output: compress_hyper_8_15_chunk."time", compress_hyper_8_15_chunk.sensor_id, compress_hyper_8_15_chunk.cpu, compress_hyper_8_15_chunk.temperature, compress_hyper_8_15_chunk._ts_meta_count, compress_hyper_8_15_chunk._ts_meta_sequence_num, compress_hyper_8_15_chunk._ts_meta_min_1, compress_hyper_8_15_chunk._ts_meta_max_1
          ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_7_8_chunk (never executed)
                Output: _hyper_7_8_chunk."time", _hyper_7_8_chunk.sensor_id, _hyper_7_8_chunk.cpu, _hyper_7_8_chunk.temperature
-               Sorted merge append: true
+               Batch Sorted Merge: true
                Bulk Decompression: false
                ->  Sort (never executed)
                      Output: compress_hyper_8_14_chunk."time", compress_hyper_8_14_chunk.sensor_id, compress_hyper_8_14_chunk.cpu, compress_hyper_8_14_chunk.temperature, compress_hyper_8_14_chunk._ts_meta_count, compress_hyper_8_14_chunk._ts_meta_sequence_num, compress_hyper_8_14_chunk._ts_meta_min_1, compress_hyper_8_14_chunk._ts_meta_max_1
@@ -1370,7 +1370,7 @@ SELECT time, segment_by, x1 FROM test_costs ORDER BY time DESC;
 --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_9_20_chunk (actual rows=100 loops=1)
    Output: _hyper_9_20_chunk."time", _hyper_9_20_chunk.segment_by, _hyper_9_20_chunk.x1
-   Sorted merge append: true
+   Batch Sorted Merge: true
    Bulk Decompression: false
    ->  Sort (actual rows=100 loops=1)
          Output: compress_hyper_10_21_chunk."time", compress_hyper_10_21_chunk.segment_by, compress_hyper_10_21_chunk.x1, compress_hyper_10_21_chunk._ts_meta_count, compress_hyper_10_21_chunk._ts_meta_sequence_num, compress_hyper_10_21_chunk._ts_meta_min_1, compress_hyper_10_21_chunk._ts_meta_max_1, compress_hyper_10_21_chunk._ts_meta_min_2, compress_hyper_10_21_chunk._ts_meta_max_2
@@ -1434,7 +1434,7 @@ SELECT time, segment_by, x1 FROM test_costs WHERE segment_by > 900 and segment_b
 --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_9_20_chunk (actual rows=98 loops=1)
    Output: _hyper_9_20_chunk."time", _hyper_9_20_chunk.segment_by, _hyper_9_20_chunk.x1
-   Sorted merge append: true
+   Batch Sorted Merge: true
    Bulk Decompression: false
    ->  Sort (actual rows=98 loops=1)
          Output: compress_hyper_10_22_chunk."time", compress_hyper_10_22_chunk.segment_by, compress_hyper_10_22_chunk.x1, compress_hyper_10_22_chunk._ts_meta_count, compress_hyper_10_22_chunk._ts_meta_sequence_num, compress_hyper_10_22_chunk._ts_meta_min_1, compress_hyper_10_22_chunk._ts_meta_max_1, compress_hyper_10_22_chunk._ts_meta_min_2, compress_hyper_10_22_chunk._ts_meta_max_2
@@ -1487,7 +1487,7 @@ SELECT "time","hin"::text,"model"::text,"block"::text,"message_name"::text,"sign
 ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_11_23_chunk (actual rows=1 loops=1)
    Output: _hyper_11_23_chunk."time", (_hyper_11_23_chunk.hin)::text, (_hyper_11_23_chunk.model)::text, (_hyper_11_23_chunk.block)::text, (_hyper_11_23_chunk.message_name)::text, (_hyper_11_23_chunk.signal_name)::text, _hyper_11_23_chunk.signal_numeric_value, (_hyper_11_23_chunk.signal_string_value)::text
-   Sorted merge append: true
+   Batch Sorted Merge: true
    Bulk Decompression: false
    ->  Sort (actual rows=1 loops=1)
          Output: compress_hyper_12_24_chunk."time", compress_hyper_12_24_chunk.hin, compress_hyper_12_24_chunk.model, compress_hyper_12_24_chunk.block, compress_hyper_12_24_chunk.message_name, compress_hyper_12_24_chunk.signal_name, compress_hyper_12_24_chunk.signal_numeric_value, compress_hyper_12_24_chunk.signal_string_value, compress_hyper_12_24_chunk._ts_meta_count, compress_hyper_12_24_chunk._ts_meta_sequence_num, compress_hyper_12_24_chunk._ts_meta_min_1, compress_hyper_12_24_chunk._ts_meta_max_1

--- a/tsl/test/expected/compression_sorted_merge-14.out
+++ b/tsl/test/expected/compression_sorted_merge-14.out
@@ -1,6 +1,10 @@
 -- This file and its contents are licensed under the Timescale License.
 -- Please see the included NOTICE for copyright information and
 -- LICENSE-TIMESCALE for a copy of the license.
+-- Increase the working memory limit slightly, otherwise the batch sorted merge
+-- will be penalized for segmentby cardinalities larger than 100, where it is
+-- still faster than sort.
+SET work_mem to '16MB';
 \set PREFIX 'EXPLAIN (analyze, verbose, costs off, timing off, summary off)'
 CREATE TABLE test1 (
 time timestamptz NOT NULL,
@@ -824,9 +828,9 @@ SELECT time,x3 FROM test1 ORDER BY time DESC;
 EXPLAIN (verbose) SELECT 1 as one, 2 as two, 3 as three, time, x2 FROM test1 ORDER BY time DESC;
                                                                                                                                                                                                                                                                          QUERY PLAN                                                                                                                                                                                                                                                                          
 -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
- Result  (cost=1.06..38.26 rows=3000 width=24)
+ Result  (cost=1.06..93.44 rows=3000 width=24)
    Output: 1, 2, 3, _hyper_1_1_chunk."time", _hyper_1_1_chunk.x2
-   ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_1_chunk  (cost=1.06..8.26 rows=3000 width=12)
+   ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_1_chunk  (cost=1.06..63.44 rows=3000 width=12)
          Output: _hyper_1_1_chunk."time", _hyper_1_1_chunk.x2
          Sorted merge append: true
          ->  Sort  (cost=0.00..0.00 rows=0 width=0)
@@ -849,9 +853,9 @@ SELECT 1 as one, 2 as two, 3 as three, time, x2 FROM test1 ORDER BY time DESC;
 EXPLAIN (verbose) SELECT 1 as one, 2 as two, 3 as three, x2, time FROM test1 ORDER BY time DESC;
                                                                                                                                                                                                                                                                          QUERY PLAN                                                                                                                                                                                                                                                                          
 -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
- Result  (cost=1.06..38.26 rows=3000 width=24)
+ Result  (cost=1.06..93.44 rows=3000 width=24)
    Output: 1, 2, 3, _hyper_1_1_chunk.x2, _hyper_1_1_chunk."time"
-   ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_1_chunk  (cost=1.06..8.26 rows=3000 width=12)
+   ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_1_chunk  (cost=1.06..63.44 rows=3000 width=12)
          Output: _hyper_1_1_chunk.x2, _hyper_1_1_chunk."time"
          Sorted merge append: true
          ->  Sort  (cost=0.00..0.00 rows=0 width=0)

--- a/tsl/test/expected/compression_sorted_merge-15.out
+++ b/tsl/test/expected/compression_sorted_merge-15.out
@@ -86,7 +86,7 @@ SELECT * FROM test1 ORDER BY time DESC;
 -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_1_chunk (actual rows=4 loops=1)
    Output: _hyper_1_1_chunk."time", _hyper_1_1_chunk.x1, _hyper_1_1_chunk.x2, _hyper_1_1_chunk.x3, _hyper_1_1_chunk.x4, _hyper_1_1_chunk.x5
-   Sorted merge append: true
+   Batch Sorted Merge: true
    Bulk Decompression: false
    ->  Sort (actual rows=3 loops=1)
          Output: compress_hyper_2_2_chunk."time", compress_hyper_2_2_chunk.x1, compress_hyper_2_2_chunk.x2, compress_hyper_2_2_chunk.x3, compress_hyper_2_2_chunk.x4, compress_hyper_2_2_chunk.x5, compress_hyper_2_2_chunk._ts_meta_count, compress_hyper_2_2_chunk._ts_meta_sequence_num, compress_hyper_2_2_chunk._ts_meta_min_1, compress_hyper_2_2_chunk._ts_meta_max_1, compress_hyper_2_2_chunk._ts_meta_min_2, compress_hyper_2_2_chunk._ts_meta_max_2, compress_hyper_2_2_chunk._ts_meta_min_3, compress_hyper_2_2_chunk._ts_meta_max_3
@@ -103,7 +103,7 @@ SELECT * FROM test1 ORDER BY time DESC NULLS FIRST;
 -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_1_chunk (actual rows=4 loops=1)
    Output: _hyper_1_1_chunk."time", _hyper_1_1_chunk.x1, _hyper_1_1_chunk.x2, _hyper_1_1_chunk.x3, _hyper_1_1_chunk.x4, _hyper_1_1_chunk.x5
-   Sorted merge append: true
+   Batch Sorted Merge: true
    Bulk Decompression: false
    ->  Sort (actual rows=3 loops=1)
          Output: compress_hyper_2_2_chunk."time", compress_hyper_2_2_chunk.x1, compress_hyper_2_2_chunk.x2, compress_hyper_2_2_chunk.x3, compress_hyper_2_2_chunk.x4, compress_hyper_2_2_chunk.x5, compress_hyper_2_2_chunk._ts_meta_count, compress_hyper_2_2_chunk._ts_meta_sequence_num, compress_hyper_2_2_chunk._ts_meta_min_1, compress_hyper_2_2_chunk._ts_meta_max_1, compress_hyper_2_2_chunk._ts_meta_min_2, compress_hyper_2_2_chunk._ts_meta_max_2, compress_hyper_2_2_chunk._ts_meta_min_3, compress_hyper_2_2_chunk._ts_meta_max_3
@@ -136,7 +136,7 @@ SELECT * FROM test1 ORDER BY time ASC;
 -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_1_chunk (actual rows=4 loops=1)
    Output: _hyper_1_1_chunk."time", _hyper_1_1_chunk.x1, _hyper_1_1_chunk.x2, _hyper_1_1_chunk.x3, _hyper_1_1_chunk.x4, _hyper_1_1_chunk.x5
-   Sorted merge append: true
+   Batch Sorted Merge: true
    Bulk Decompression: false
    ->  Sort (actual rows=3 loops=1)
          Output: compress_hyper_2_2_chunk."time", compress_hyper_2_2_chunk.x1, compress_hyper_2_2_chunk.x2, compress_hyper_2_2_chunk.x3, compress_hyper_2_2_chunk.x4, compress_hyper_2_2_chunk.x5, compress_hyper_2_2_chunk._ts_meta_count, compress_hyper_2_2_chunk._ts_meta_sequence_num, compress_hyper_2_2_chunk._ts_meta_min_1, compress_hyper_2_2_chunk._ts_meta_max_1, compress_hyper_2_2_chunk._ts_meta_min_2, compress_hyper_2_2_chunk._ts_meta_max_2, compress_hyper_2_2_chunk._ts_meta_min_3, compress_hyper_2_2_chunk._ts_meta_max_3
@@ -153,7 +153,7 @@ SELECT * FROM test1 ORDER BY time ASC NULLS LAST;
 -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_1_chunk (actual rows=4 loops=1)
    Output: _hyper_1_1_chunk."time", _hyper_1_1_chunk.x1, _hyper_1_1_chunk.x2, _hyper_1_1_chunk.x3, _hyper_1_1_chunk.x4, _hyper_1_1_chunk.x5
-   Sorted merge append: true
+   Batch Sorted Merge: true
    Bulk Decompression: false
    ->  Sort (actual rows=3 loops=1)
          Output: compress_hyper_2_2_chunk."time", compress_hyper_2_2_chunk.x1, compress_hyper_2_2_chunk.x2, compress_hyper_2_2_chunk.x3, compress_hyper_2_2_chunk.x4, compress_hyper_2_2_chunk.x5, compress_hyper_2_2_chunk._ts_meta_count, compress_hyper_2_2_chunk._ts_meta_sequence_num, compress_hyper_2_2_chunk._ts_meta_min_1, compress_hyper_2_2_chunk._ts_meta_max_1, compress_hyper_2_2_chunk._ts_meta_min_2, compress_hyper_2_2_chunk._ts_meta_max_2, compress_hyper_2_2_chunk._ts_meta_min_3, compress_hyper_2_2_chunk._ts_meta_max_3
@@ -186,7 +186,7 @@ SELECT * FROM test1 ORDER BY time DESC NULLS FIRST, x3 ASC NULLS LAST;
 -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_1_chunk (actual rows=4 loops=1)
    Output: _hyper_1_1_chunk."time", _hyper_1_1_chunk.x1, _hyper_1_1_chunk.x2, _hyper_1_1_chunk.x3, _hyper_1_1_chunk.x4, _hyper_1_1_chunk.x5
-   Sorted merge append: true
+   Batch Sorted Merge: true
    Bulk Decompression: false
    ->  Sort (actual rows=3 loops=1)
          Output: compress_hyper_2_2_chunk."time", compress_hyper_2_2_chunk.x1, compress_hyper_2_2_chunk.x2, compress_hyper_2_2_chunk.x3, compress_hyper_2_2_chunk.x4, compress_hyper_2_2_chunk.x5, compress_hyper_2_2_chunk._ts_meta_count, compress_hyper_2_2_chunk._ts_meta_sequence_num, compress_hyper_2_2_chunk._ts_meta_min_1, compress_hyper_2_2_chunk._ts_meta_max_1, compress_hyper_2_2_chunk._ts_meta_min_2, compress_hyper_2_2_chunk._ts_meta_max_2, compress_hyper_2_2_chunk._ts_meta_min_3, compress_hyper_2_2_chunk._ts_meta_max_3
@@ -203,7 +203,7 @@ SELECT * FROM test1 ORDER BY time DESC NULLS FIRST, x3 ASC NULLS LAST, x4 ASC NU
 -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_1_chunk (actual rows=4 loops=1)
    Output: _hyper_1_1_chunk."time", _hyper_1_1_chunk.x1, _hyper_1_1_chunk.x2, _hyper_1_1_chunk.x3, _hyper_1_1_chunk.x4, _hyper_1_1_chunk.x5
-   Sorted merge append: true
+   Batch Sorted Merge: true
    Bulk Decompression: false
    ->  Sort (actual rows=3 loops=1)
          Output: compress_hyper_2_2_chunk."time", compress_hyper_2_2_chunk.x1, compress_hyper_2_2_chunk.x2, compress_hyper_2_2_chunk.x3, compress_hyper_2_2_chunk.x4, compress_hyper_2_2_chunk.x5, compress_hyper_2_2_chunk._ts_meta_count, compress_hyper_2_2_chunk._ts_meta_sequence_num, compress_hyper_2_2_chunk._ts_meta_min_1, compress_hyper_2_2_chunk._ts_meta_max_1, compress_hyper_2_2_chunk._ts_meta_min_2, compress_hyper_2_2_chunk._ts_meta_max_2, compress_hyper_2_2_chunk._ts_meta_min_3, compress_hyper_2_2_chunk._ts_meta_max_3
@@ -236,7 +236,7 @@ SELECT * FROM test1 ORDER BY time ASC NULLS LAST;
 -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_1_chunk (actual rows=4 loops=1)
    Output: _hyper_1_1_chunk."time", _hyper_1_1_chunk.x1, _hyper_1_1_chunk.x2, _hyper_1_1_chunk.x3, _hyper_1_1_chunk.x4, _hyper_1_1_chunk.x5
-   Sorted merge append: true
+   Batch Sorted Merge: true
    Bulk Decompression: false
    ->  Sort (actual rows=3 loops=1)
          Output: compress_hyper_2_2_chunk."time", compress_hyper_2_2_chunk.x1, compress_hyper_2_2_chunk.x2, compress_hyper_2_2_chunk.x3, compress_hyper_2_2_chunk.x4, compress_hyper_2_2_chunk.x5, compress_hyper_2_2_chunk._ts_meta_count, compress_hyper_2_2_chunk._ts_meta_sequence_num, compress_hyper_2_2_chunk._ts_meta_min_1, compress_hyper_2_2_chunk._ts_meta_max_1, compress_hyper_2_2_chunk._ts_meta_min_2, compress_hyper_2_2_chunk._ts_meta_max_2, compress_hyper_2_2_chunk._ts_meta_min_3, compress_hyper_2_2_chunk._ts_meta_max_3
@@ -253,7 +253,7 @@ SELECT * FROM test1 ORDER BY time ASC NULLS LAST, x3 DESC NULLS FIRST;
 -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_1_chunk (actual rows=4 loops=1)
    Output: _hyper_1_1_chunk."time", _hyper_1_1_chunk.x1, _hyper_1_1_chunk.x2, _hyper_1_1_chunk.x3, _hyper_1_1_chunk.x4, _hyper_1_1_chunk.x5
-   Sorted merge append: true
+   Batch Sorted Merge: true
    Bulk Decompression: false
    ->  Sort (actual rows=3 loops=1)
          Output: compress_hyper_2_2_chunk."time", compress_hyper_2_2_chunk.x1, compress_hyper_2_2_chunk.x2, compress_hyper_2_2_chunk.x3, compress_hyper_2_2_chunk.x4, compress_hyper_2_2_chunk.x5, compress_hyper_2_2_chunk._ts_meta_count, compress_hyper_2_2_chunk._ts_meta_sequence_num, compress_hyper_2_2_chunk._ts_meta_min_1, compress_hyper_2_2_chunk._ts_meta_max_1, compress_hyper_2_2_chunk._ts_meta_min_2, compress_hyper_2_2_chunk._ts_meta_max_2, compress_hyper_2_2_chunk._ts_meta_min_3, compress_hyper_2_2_chunk._ts_meta_max_3
@@ -270,7 +270,7 @@ SELECT * FROM test1 ORDER BY time ASC NULLS LAST, x3 DESC NULLS FIRST, x4 DESC N
 -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_1_chunk (actual rows=4 loops=1)
    Output: _hyper_1_1_chunk."time", _hyper_1_1_chunk.x1, _hyper_1_1_chunk.x2, _hyper_1_1_chunk.x3, _hyper_1_1_chunk.x4, _hyper_1_1_chunk.x5
-   Sorted merge append: true
+   Batch Sorted Merge: true
    Bulk Decompression: false
    ->  Sort (actual rows=3 loops=1)
          Output: compress_hyper_2_2_chunk."time", compress_hyper_2_2_chunk.x1, compress_hyper_2_2_chunk.x2, compress_hyper_2_2_chunk.x3, compress_hyper_2_2_chunk.x4, compress_hyper_2_2_chunk.x5, compress_hyper_2_2_chunk._ts_meta_count, compress_hyper_2_2_chunk._ts_meta_sequence_num, compress_hyper_2_2_chunk._ts_meta_min_1, compress_hyper_2_2_chunk._ts_meta_max_1, compress_hyper_2_2_chunk._ts_meta_min_2, compress_hyper_2_2_chunk._ts_meta_max_2, compress_hyper_2_2_chunk._ts_meta_min_3, compress_hyper_2_2_chunk._ts_meta_max_3
@@ -303,7 +303,7 @@ SELECT * FROM test2 ORDER BY time ASC;
 -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_3_3_chunk (actual rows=4 loops=1)
    Output: _hyper_3_3_chunk."time", _hyper_3_3_chunk.x1, _hyper_3_3_chunk.x2, _hyper_3_3_chunk.x3, _hyper_3_3_chunk.x4, _hyper_3_3_chunk.x5
-   Sorted merge append: true
+   Batch Sorted Merge: true
    Bulk Decompression: false
    ->  Sort (actual rows=3 loops=1)
          Output: compress_hyper_4_4_chunk."time", compress_hyper_4_4_chunk.x1, compress_hyper_4_4_chunk.x2, compress_hyper_4_4_chunk.x3, compress_hyper_4_4_chunk.x4, compress_hyper_4_4_chunk.x5, compress_hyper_4_4_chunk._ts_meta_count, compress_hyper_4_4_chunk._ts_meta_sequence_num, compress_hyper_4_4_chunk._ts_meta_min_1, compress_hyper_4_4_chunk._ts_meta_max_1, compress_hyper_4_4_chunk._ts_meta_min_2, compress_hyper_4_4_chunk._ts_meta_max_2, compress_hyper_4_4_chunk._ts_meta_min_3, compress_hyper_4_4_chunk._ts_meta_max_3
@@ -320,7 +320,7 @@ SELECT * FROM test2 ORDER BY time ASC, x3 DESC;
 -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_3_3_chunk (actual rows=4 loops=1)
    Output: _hyper_3_3_chunk."time", _hyper_3_3_chunk.x1, _hyper_3_3_chunk.x2, _hyper_3_3_chunk.x3, _hyper_3_3_chunk.x4, _hyper_3_3_chunk.x5
-   Sorted merge append: true
+   Batch Sorted Merge: true
    Bulk Decompression: false
    ->  Sort (actual rows=3 loops=1)
          Output: compress_hyper_4_4_chunk."time", compress_hyper_4_4_chunk.x1, compress_hyper_4_4_chunk.x2, compress_hyper_4_4_chunk.x3, compress_hyper_4_4_chunk.x4, compress_hyper_4_4_chunk.x5, compress_hyper_4_4_chunk._ts_meta_count, compress_hyper_4_4_chunk._ts_meta_sequence_num, compress_hyper_4_4_chunk._ts_meta_min_1, compress_hyper_4_4_chunk._ts_meta_max_1, compress_hyper_4_4_chunk._ts_meta_min_2, compress_hyper_4_4_chunk._ts_meta_max_2, compress_hyper_4_4_chunk._ts_meta_min_3, compress_hyper_4_4_chunk._ts_meta_max_3
@@ -337,7 +337,7 @@ SELECT * FROM test2 ORDER BY time ASC, x3 DESC, x4 DESC;
 -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_3_3_chunk (actual rows=4 loops=1)
    Output: _hyper_3_3_chunk."time", _hyper_3_3_chunk.x1, _hyper_3_3_chunk.x2, _hyper_3_3_chunk.x3, _hyper_3_3_chunk.x4, _hyper_3_3_chunk.x5
-   Sorted merge append: true
+   Batch Sorted Merge: true
    Bulk Decompression: false
    ->  Sort (actual rows=3 loops=1)
          Output: compress_hyper_4_4_chunk."time", compress_hyper_4_4_chunk.x1, compress_hyper_4_4_chunk.x2, compress_hyper_4_4_chunk.x3, compress_hyper_4_4_chunk.x4, compress_hyper_4_4_chunk.x5, compress_hyper_4_4_chunk._ts_meta_count, compress_hyper_4_4_chunk._ts_meta_sequence_num, compress_hyper_4_4_chunk._ts_meta_min_1, compress_hyper_4_4_chunk._ts_meta_max_1, compress_hyper_4_4_chunk._ts_meta_min_2, compress_hyper_4_4_chunk._ts_meta_max_2, compress_hyper_4_4_chunk._ts_meta_min_3, compress_hyper_4_4_chunk._ts_meta_max_3
@@ -386,7 +386,7 @@ SELECT * FROM test2 ORDER BY time DESC NULLS FIRST;
 -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_3_3_chunk (actual rows=4 loops=1)
    Output: _hyper_3_3_chunk."time", _hyper_3_3_chunk.x1, _hyper_3_3_chunk.x2, _hyper_3_3_chunk.x3, _hyper_3_3_chunk.x4, _hyper_3_3_chunk.x5
-   Sorted merge append: true
+   Batch Sorted Merge: true
    Bulk Decompression: false
    ->  Sort (actual rows=3 loops=1)
          Output: compress_hyper_4_4_chunk."time", compress_hyper_4_4_chunk.x1, compress_hyper_4_4_chunk.x2, compress_hyper_4_4_chunk.x3, compress_hyper_4_4_chunk.x4, compress_hyper_4_4_chunk.x5, compress_hyper_4_4_chunk._ts_meta_count, compress_hyper_4_4_chunk._ts_meta_sequence_num, compress_hyper_4_4_chunk._ts_meta_min_1, compress_hyper_4_4_chunk._ts_meta_max_1, compress_hyper_4_4_chunk._ts_meta_min_2, compress_hyper_4_4_chunk._ts_meta_max_2, compress_hyper_4_4_chunk._ts_meta_min_3, compress_hyper_4_4_chunk._ts_meta_max_3
@@ -403,7 +403,7 @@ SELECT * FROM test2 ORDER BY time DESC NULLS FIRST, x3 ASC NULLS LAST;
 -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_3_3_chunk (actual rows=4 loops=1)
    Output: _hyper_3_3_chunk."time", _hyper_3_3_chunk.x1, _hyper_3_3_chunk.x2, _hyper_3_3_chunk.x3, _hyper_3_3_chunk.x4, _hyper_3_3_chunk.x5
-   Sorted merge append: true
+   Batch Sorted Merge: true
    Bulk Decompression: false
    ->  Sort (actual rows=3 loops=1)
          Output: compress_hyper_4_4_chunk."time", compress_hyper_4_4_chunk.x1, compress_hyper_4_4_chunk.x2, compress_hyper_4_4_chunk.x3, compress_hyper_4_4_chunk.x4, compress_hyper_4_4_chunk.x5, compress_hyper_4_4_chunk._ts_meta_count, compress_hyper_4_4_chunk._ts_meta_sequence_num, compress_hyper_4_4_chunk._ts_meta_min_1, compress_hyper_4_4_chunk._ts_meta_max_1, compress_hyper_4_4_chunk._ts_meta_min_2, compress_hyper_4_4_chunk._ts_meta_max_2, compress_hyper_4_4_chunk._ts_meta_min_3, compress_hyper_4_4_chunk._ts_meta_max_3
@@ -420,7 +420,7 @@ SELECT * FROM test2 ORDER BY time DESC NULLS FIRST, x3 ASC NULLS LAST, x4 NULLS 
 -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_3_3_chunk (actual rows=4 loops=1)
    Output: _hyper_3_3_chunk."time", _hyper_3_3_chunk.x1, _hyper_3_3_chunk.x2, _hyper_3_3_chunk.x3, _hyper_3_3_chunk.x4, _hyper_3_3_chunk.x5
-   Sorted merge append: true
+   Batch Sorted Merge: true
    Bulk Decompression: false
    ->  Sort (actual rows=3 loops=1)
          Output: compress_hyper_4_4_chunk."time", compress_hyper_4_4_chunk.x1, compress_hyper_4_4_chunk.x2, compress_hyper_4_4_chunk.x3, compress_hyper_4_4_chunk.x4, compress_hyper_4_4_chunk.x5, compress_hyper_4_4_chunk._ts_meta_count, compress_hyper_4_4_chunk._ts_meta_sequence_num, compress_hyper_4_4_chunk._ts_meta_min_1, compress_hyper_4_4_chunk._ts_meta_max_1, compress_hyper_4_4_chunk._ts_meta_min_2, compress_hyper_4_4_chunk._ts_meta_max_2, compress_hyper_4_4_chunk._ts_meta_min_3, compress_hyper_4_4_chunk._ts_meta_max_3
@@ -469,7 +469,7 @@ SELECT * FROM test_with_defined_null ORDER BY x2 ASC NULLS FIRST;
 -----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_5_5_chunk (actual rows=4 loops=1)
    Output: _hyper_5_5_chunk."time", _hyper_5_5_chunk.x1, _hyper_5_5_chunk.x2, _hyper_5_5_chunk.x3
-   Sorted merge append: true
+   Batch Sorted Merge: true
    Bulk Decompression: false
    ->  Sort (actual rows=2 loops=1)
          Output: compress_hyper_6_6_chunk."time", compress_hyper_6_6_chunk.x1, compress_hyper_6_6_chunk.x2, compress_hyper_6_6_chunk.x3, compress_hyper_6_6_chunk._ts_meta_count, compress_hyper_6_6_chunk._ts_meta_sequence_num, compress_hyper_6_6_chunk._ts_meta_min_2, compress_hyper_6_6_chunk._ts_meta_max_2, compress_hyper_6_6_chunk._ts_meta_min_1, compress_hyper_6_6_chunk._ts_meta_max_1
@@ -486,7 +486,7 @@ SELECT * FROM test_with_defined_null ORDER BY x2 DESC NULLS LAST;
 -----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_5_5_chunk (actual rows=4 loops=1)
    Output: _hyper_5_5_chunk."time", _hyper_5_5_chunk.x1, _hyper_5_5_chunk.x2, _hyper_5_5_chunk.x3
-   Sorted merge append: true
+   Batch Sorted Merge: true
    Bulk Decompression: false
    ->  Sort (actual rows=2 loops=1)
          Output: compress_hyper_6_6_chunk."time", compress_hyper_6_6_chunk.x1, compress_hyper_6_6_chunk.x2, compress_hyper_6_6_chunk.x3, compress_hyper_6_6_chunk._ts_meta_count, compress_hyper_6_6_chunk._ts_meta_sequence_num, compress_hyper_6_6_chunk._ts_meta_min_2, compress_hyper_6_6_chunk._ts_meta_max_2, compress_hyper_6_6_chunk._ts_meta_min_1, compress_hyper_6_6_chunk._ts_meta_max_1
@@ -539,7 +539,7 @@ SELECT * FROM test1 WHERE x4 > 0 ORDER BY time DESC;
  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_1_chunk (actual rows=4 loops=1)
    Output: _hyper_1_1_chunk."time", _hyper_1_1_chunk.x1, _hyper_1_1_chunk.x2, _hyper_1_1_chunk.x3, _hyper_1_1_chunk.x4, _hyper_1_1_chunk.x5
    Filter: (_hyper_1_1_chunk.x4 > 0)
-   Sorted merge append: true
+   Batch Sorted Merge: true
    Bulk Decompression: false
    ->  Sort (actual rows=3 loops=1)
          Output: compress_hyper_2_2_chunk."time", compress_hyper_2_2_chunk.x1, compress_hyper_2_2_chunk.x2, compress_hyper_2_2_chunk.x3, compress_hyper_2_2_chunk.x4, compress_hyper_2_2_chunk.x5, compress_hyper_2_2_chunk._ts_meta_count, compress_hyper_2_2_chunk._ts_meta_sequence_num, compress_hyper_2_2_chunk._ts_meta_min_1, compress_hyper_2_2_chunk._ts_meta_max_1, compress_hyper_2_2_chunk._ts_meta_min_2, compress_hyper_2_2_chunk._ts_meta_max_2, compress_hyper_2_2_chunk._ts_meta_min_3, compress_hyper_2_2_chunk._ts_meta_max_3
@@ -558,7 +558,7 @@ SELECT * FROM test1 WHERE x4 > 100 ORDER BY time DESC;
  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_1_chunk (actual rows=0 loops=1)
    Output: _hyper_1_1_chunk."time", _hyper_1_1_chunk.x1, _hyper_1_1_chunk.x2, _hyper_1_1_chunk.x3, _hyper_1_1_chunk.x4, _hyper_1_1_chunk.x5
    Filter: (_hyper_1_1_chunk.x4 > 100)
-   Sorted merge append: true
+   Batch Sorted Merge: true
    Bulk Decompression: false
    ->  Sort (actual rows=0 loops=1)
          Output: compress_hyper_2_2_chunk."time", compress_hyper_2_2_chunk.x1, compress_hyper_2_2_chunk.x2, compress_hyper_2_2_chunk.x3, compress_hyper_2_2_chunk.x4, compress_hyper_2_2_chunk.x5, compress_hyper_2_2_chunk._ts_meta_count, compress_hyper_2_2_chunk._ts_meta_sequence_num, compress_hyper_2_2_chunk._ts_meta_min_1, compress_hyper_2_2_chunk._ts_meta_max_1, compress_hyper_2_2_chunk._ts_meta_min_2, compress_hyper_2_2_chunk._ts_meta_max_2, compress_hyper_2_2_chunk._ts_meta_min_3, compress_hyper_2_2_chunk._ts_meta_max_3
@@ -578,7 +578,7 @@ SELECT * FROM test1 WHERE x4 > 100 ORDER BY time DESC, x3, x4;
  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_1_chunk (actual rows=0 loops=1)
    Output: _hyper_1_1_chunk."time", _hyper_1_1_chunk.x1, _hyper_1_1_chunk.x2, _hyper_1_1_chunk.x3, _hyper_1_1_chunk.x4, _hyper_1_1_chunk.x5
    Filter: (_hyper_1_1_chunk.x4 > 100)
-   Sorted merge append: true
+   Batch Sorted Merge: true
    Bulk Decompression: false
    ->  Sort (actual rows=0 loops=1)
          Output: compress_hyper_2_2_chunk."time", compress_hyper_2_2_chunk.x1, compress_hyper_2_2_chunk.x2, compress_hyper_2_2_chunk.x3, compress_hyper_2_2_chunk.x4, compress_hyper_2_2_chunk.x5, compress_hyper_2_2_chunk._ts_meta_count, compress_hyper_2_2_chunk._ts_meta_sequence_num, compress_hyper_2_2_chunk._ts_meta_min_1, compress_hyper_2_2_chunk._ts_meta_max_1, compress_hyper_2_2_chunk._ts_meta_min_2, compress_hyper_2_2_chunk._ts_meta_max_2, compress_hyper_2_2_chunk._ts_meta_min_3, compress_hyper_2_2_chunk._ts_meta_max_3
@@ -598,7 +598,7 @@ SELECT * FROM test1 WHERE x4 > 100 ORDER BY time DESC, x3, x3;
  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_1_chunk (actual rows=0 loops=1)
    Output: _hyper_1_1_chunk."time", _hyper_1_1_chunk.x1, _hyper_1_1_chunk.x2, _hyper_1_1_chunk.x3, _hyper_1_1_chunk.x4, _hyper_1_1_chunk.x5
    Filter: (_hyper_1_1_chunk.x4 > 100)
-   Sorted merge append: true
+   Batch Sorted Merge: true
    Bulk Decompression: false
    ->  Sort (actual rows=0 loops=1)
          Output: compress_hyper_2_2_chunk."time", compress_hyper_2_2_chunk.x1, compress_hyper_2_2_chunk.x2, compress_hyper_2_2_chunk.x3, compress_hyper_2_2_chunk.x4, compress_hyper_2_2_chunk.x5, compress_hyper_2_2_chunk._ts_meta_count, compress_hyper_2_2_chunk._ts_meta_sequence_num, compress_hyper_2_2_chunk._ts_meta_min_1, compress_hyper_2_2_chunk._ts_meta_max_1, compress_hyper_2_2_chunk._ts_meta_min_2, compress_hyper_2_2_chunk._ts_meta_max_2, compress_hyper_2_2_chunk._ts_meta_min_3, compress_hyper_2_2_chunk._ts_meta_max_3
@@ -618,7 +618,7 @@ SELECT * FROM test1 WHERE x4 > 100 ORDER BY time DESC, x3, x4, x3, x4;
  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_1_chunk (actual rows=0 loops=1)
    Output: _hyper_1_1_chunk."time", _hyper_1_1_chunk.x1, _hyper_1_1_chunk.x2, _hyper_1_1_chunk.x3, _hyper_1_1_chunk.x4, _hyper_1_1_chunk.x5
    Filter: (_hyper_1_1_chunk.x4 > 100)
-   Sorted merge append: true
+   Batch Sorted Merge: true
    Bulk Decompression: false
    ->  Sort (actual rows=0 loops=1)
          Output: compress_hyper_2_2_chunk."time", compress_hyper_2_2_chunk.x1, compress_hyper_2_2_chunk.x2, compress_hyper_2_2_chunk.x3, compress_hyper_2_2_chunk.x4, compress_hyper_2_2_chunk.x5, compress_hyper_2_2_chunk._ts_meta_count, compress_hyper_2_2_chunk._ts_meta_sequence_num, compress_hyper_2_2_chunk._ts_meta_min_1, compress_hyper_2_2_chunk._ts_meta_max_1, compress_hyper_2_2_chunk._ts_meta_min_2, compress_hyper_2_2_chunk._ts_meta_max_2, compress_hyper_2_2_chunk._ts_meta_min_3, compress_hyper_2_2_chunk._ts_meta_max_3
@@ -676,7 +676,7 @@ SELECT * FROM test1 ORDER BY time DESC;
 -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_1_chunk (actual rows=4 loops=1)
    Output: _hyper_1_1_chunk."time", _hyper_1_1_chunk.x1, _hyper_1_1_chunk.x2, _hyper_1_1_chunk.x3, _hyper_1_1_chunk.x4, _hyper_1_1_chunk.x5
-   Sorted merge append: true
+   Batch Sorted Merge: true
    Bulk Decompression: false
    ->  Sort (actual rows=3 loops=1)
          Output: compress_hyper_2_2_chunk."time", compress_hyper_2_2_chunk.x1, compress_hyper_2_2_chunk.x2, compress_hyper_2_2_chunk.x3, compress_hyper_2_2_chunk.x4, compress_hyper_2_2_chunk.x5, compress_hyper_2_2_chunk._ts_meta_count, compress_hyper_2_2_chunk._ts_meta_sequence_num, compress_hyper_2_2_chunk._ts_meta_min_1, compress_hyper_2_2_chunk._ts_meta_max_1, compress_hyper_2_2_chunk._ts_meta_min_2, compress_hyper_2_2_chunk._ts_meta_max_2, compress_hyper_2_2_chunk._ts_meta_min_3, compress_hyper_2_2_chunk._ts_meta_max_3
@@ -832,7 +832,7 @@ EXPLAIN (verbose) SELECT 1 as one, 2 as two, 3 as three, time, x2 FROM test1 ORD
    Output: 1, 2, 3, _hyper_1_1_chunk."time", _hyper_1_1_chunk.x2
    ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_1_chunk  (cost=1.06..63.44 rows=3000 width=12)
          Output: _hyper_1_1_chunk."time", _hyper_1_1_chunk.x2
-         Sorted merge append: true
+         Batch Sorted Merge: true
          ->  Sort  (cost=0.00..0.00 rows=0 width=0)
                Output: compress_hyper_2_2_chunk."time", compress_hyper_2_2_chunk.x1, compress_hyper_2_2_chunk.x2, compress_hyper_2_2_chunk.x3, compress_hyper_2_2_chunk.x4, compress_hyper_2_2_chunk.x5, compress_hyper_2_2_chunk._ts_meta_count, compress_hyper_2_2_chunk._ts_meta_sequence_num, compress_hyper_2_2_chunk._ts_meta_min_1, compress_hyper_2_2_chunk._ts_meta_max_1, compress_hyper_2_2_chunk._ts_meta_min_2, compress_hyper_2_2_chunk._ts_meta_max_2, compress_hyper_2_2_chunk._ts_meta_min_3, compress_hyper_2_2_chunk._ts_meta_max_3
                Sort Key: compress_hyper_2_2_chunk._ts_meta_max_1 DESC
@@ -857,7 +857,7 @@ EXPLAIN (verbose) SELECT 1 as one, 2 as two, 3 as three, x2, time FROM test1 ORD
    Output: 1, 2, 3, _hyper_1_1_chunk.x2, _hyper_1_1_chunk."time"
    ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_1_chunk  (cost=1.06..63.44 rows=3000 width=12)
          Output: _hyper_1_1_chunk.x2, _hyper_1_1_chunk."time"
-         Sorted merge append: true
+         Batch Sorted Merge: true
          ->  Sort  (cost=0.00..0.00 rows=0 width=0)
                Output: compress_hyper_2_2_chunk."time", compress_hyper_2_2_chunk.x1, compress_hyper_2_2_chunk.x2, compress_hyper_2_2_chunk.x3, compress_hyper_2_2_chunk.x4, compress_hyper_2_2_chunk.x5, compress_hyper_2_2_chunk._ts_meta_count, compress_hyper_2_2_chunk._ts_meta_sequence_num, compress_hyper_2_2_chunk._ts_meta_min_1, compress_hyper_2_2_chunk._ts_meta_max_1, compress_hyper_2_2_chunk._ts_meta_min_2, compress_hyper_2_2_chunk._ts_meta_max_2, compress_hyper_2_2_chunk._ts_meta_min_3, compress_hyper_2_2_chunk._ts_meta_max_3
                Sort Key: compress_hyper_2_2_chunk._ts_meta_max_1 DESC
@@ -954,7 +954,7 @@ SELECT * FROM test1 ORDER BY time DESC;
 -----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_1_chunk (actual rows=4 loops=1)
    Output: _hyper_1_1_chunk."time", _hyper_1_1_chunk.x1, _hyper_1_1_chunk.x2, _hyper_1_1_chunk.x3, _hyper_1_1_chunk.x4, _hyper_1_1_chunk.x5, _hyper_1_1_chunk.c1, _hyper_1_1_chunk.c2
-   Sorted merge append: true
+   Batch Sorted Merge: true
    Bulk Decompression: false
    ->  Sort (actual rows=3 loops=1)
          Output: compress_hyper_2_7_chunk."time", compress_hyper_2_7_chunk._ts_meta_min_1, compress_hyper_2_7_chunk._ts_meta_max_1, compress_hyper_2_7_chunk.x1, compress_hyper_2_7_chunk.x2, compress_hyper_2_7_chunk.x3, compress_hyper_2_7_chunk._ts_meta_min_2, compress_hyper_2_7_chunk._ts_meta_max_2, compress_hyper_2_7_chunk.x4, compress_hyper_2_7_chunk._ts_meta_min_3, compress_hyper_2_7_chunk._ts_meta_max_3, compress_hyper_2_7_chunk.x5, compress_hyper_2_7_chunk.c1, compress_hyper_2_7_chunk.c2, compress_hyper_2_7_chunk._ts_meta_count
@@ -980,7 +980,7 @@ SELECT time, x2, x1, c2 FROM test1 ORDER BY time DESC;
 -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_1_chunk (actual rows=4 loops=1)
    Output: _hyper_1_1_chunk."time", _hyper_1_1_chunk.x2, _hyper_1_1_chunk.x1, _hyper_1_1_chunk.c2
-   Sorted merge append: true
+   Batch Sorted Merge: true
    Bulk Decompression: false
    ->  Sort (actual rows=3 loops=1)
          Output: compress_hyper_2_7_chunk."time", compress_hyper_2_7_chunk._ts_meta_min_1, compress_hyper_2_7_chunk._ts_meta_max_1, compress_hyper_2_7_chunk.x2, compress_hyper_2_7_chunk.x1, compress_hyper_2_7_chunk.c2, compress_hyper_2_7_chunk._ts_meta_count
@@ -1006,7 +1006,7 @@ SELECT x2, x1, c2, time FROM test1 ORDER BY time DESC;
 -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_1_chunk (actual rows=4 loops=1)
    Output: _hyper_1_1_chunk.x2, _hyper_1_1_chunk.x1, _hyper_1_1_chunk.c2, _hyper_1_1_chunk."time"
-   Sorted merge append: true
+   Batch Sorted Merge: true
    Bulk Decompression: false
    ->  Sort (actual rows=3 loops=1)
          Output: compress_hyper_2_7_chunk.x2, compress_hyper_2_7_chunk.x1, compress_hyper_2_7_chunk.c2, compress_hyper_2_7_chunk."time", compress_hyper_2_7_chunk._ts_meta_min_1, compress_hyper_2_7_chunk._ts_meta_max_1, compress_hyper_2_7_chunk._ts_meta_count
@@ -1034,7 +1034,7 @@ SELECT 1 as one, 2 as two, 3 as three, x2, x1, c2, time FROM test1 ORDER BY time
    Output: 1, 2, 3, _hyper_1_1_chunk.x2, _hyper_1_1_chunk.x1, _hyper_1_1_chunk.c2, _hyper_1_1_chunk."time"
    ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_1_chunk (actual rows=4 loops=1)
          Output: _hyper_1_1_chunk.x2, _hyper_1_1_chunk.x1, _hyper_1_1_chunk.c2, _hyper_1_1_chunk."time"
-         Sorted merge append: true
+         Batch Sorted Merge: true
          Bulk Decompression: false
          ->  Sort (actual rows=3 loops=1)
                Output: compress_hyper_2_7_chunk.x2, compress_hyper_2_7_chunk.x1, compress_hyper_2_7_chunk.c2, compress_hyper_2_7_chunk."time", compress_hyper_2_7_chunk._ts_meta_min_1, compress_hyper_2_7_chunk._ts_meta_max_1, compress_hyper_2_7_chunk._ts_meta_count
@@ -1100,7 +1100,7 @@ SELECT * FROM test1 ORDER BY time ASC NULLS LAST;
 -----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_1_chunk (actual rows=4 loops=1)
    Output: _hyper_1_1_chunk."time", _hyper_1_1_chunk.x1, _hyper_1_1_chunk.x2, _hyper_1_1_chunk.x3, _hyper_1_1_chunk.x4, _hyper_1_1_chunk.x5, _hyper_1_1_chunk.c1, _hyper_1_1_chunk.c2
-   Sorted merge append: true
+   Batch Sorted Merge: true
    Bulk Decompression: false
    ->  Sort (actual rows=3 loops=1)
          Output: compress_hyper_2_7_chunk."time", compress_hyper_2_7_chunk._ts_meta_min_1, compress_hyper_2_7_chunk._ts_meta_max_1, compress_hyper_2_7_chunk.x1, compress_hyper_2_7_chunk.x2, compress_hyper_2_7_chunk.x3, compress_hyper_2_7_chunk._ts_meta_min_2, compress_hyper_2_7_chunk._ts_meta_max_2, compress_hyper_2_7_chunk.x4, compress_hyper_2_7_chunk._ts_meta_min_3, compress_hyper_2_7_chunk._ts_meta_max_3, compress_hyper_2_7_chunk.x5, compress_hyper_2_7_chunk.c1, compress_hyper_2_7_chunk.c2, compress_hyper_2_7_chunk._ts_meta_count
@@ -1126,7 +1126,7 @@ SELECT * FROM test1 ORDER BY time ASC NULLS LAST;
          Sort Key: _hyper_1_1_chunk."time"
          ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_1_chunk (actual rows=4 loops=1)
                Output: _hyper_1_1_chunk."time", _hyper_1_1_chunk.x1, _hyper_1_1_chunk.x2, _hyper_1_1_chunk.x3, _hyper_1_1_chunk.x4, _hyper_1_1_chunk.x5, _hyper_1_1_chunk.c1, _hyper_1_1_chunk.c2
-               Sorted merge append: true
+               Batch Sorted Merge: true
                Bulk Decompression: false
                ->  Sort (actual rows=3 loops=1)
                      Output: compress_hyper_2_7_chunk."time", compress_hyper_2_7_chunk._ts_meta_min_1, compress_hyper_2_7_chunk._ts_meta_max_1, compress_hyper_2_7_chunk.x1, compress_hyper_2_7_chunk.x2, compress_hyper_2_7_chunk.x3, compress_hyper_2_7_chunk._ts_meta_min_2, compress_hyper_2_7_chunk._ts_meta_max_2, compress_hyper_2_7_chunk.x4, compress_hyper_2_7_chunk._ts_meta_min_3, compress_hyper_2_7_chunk._ts_meta_max_3, compress_hyper_2_7_chunk.x5, compress_hyper_2_7_chunk.c1, compress_hyper_2_7_chunk.c2, compress_hyper_2_7_chunk._ts_meta_count
@@ -1209,7 +1209,7 @@ SELECT * FROM sensor_data ORDER BY time DESC LIMIT 1;
          Runtime Exclusion: false
          ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_7_13_chunk (actual rows=1 loops=1)
                Output: _hyper_7_13_chunk."time", _hyper_7_13_chunk.sensor_id, _hyper_7_13_chunk.cpu, _hyper_7_13_chunk.temperature
-               Sorted merge append: true
+               Batch Sorted Merge: true
                Bulk Decompression: false
                ->  Sort (actual rows=2 loops=1)
                      Output: compress_hyper_8_19_chunk."time", compress_hyper_8_19_chunk.sensor_id, compress_hyper_8_19_chunk.cpu, compress_hyper_8_19_chunk.temperature, compress_hyper_8_19_chunk._ts_meta_count, compress_hyper_8_19_chunk._ts_meta_sequence_num, compress_hyper_8_19_chunk._ts_meta_min_1, compress_hyper_8_19_chunk._ts_meta_max_1
@@ -1219,7 +1219,7 @@ SELECT * FROM sensor_data ORDER BY time DESC LIMIT 1;
                            Output: compress_hyper_8_19_chunk."time", compress_hyper_8_19_chunk.sensor_id, compress_hyper_8_19_chunk.cpu, compress_hyper_8_19_chunk.temperature, compress_hyper_8_19_chunk._ts_meta_count, compress_hyper_8_19_chunk._ts_meta_sequence_num, compress_hyper_8_19_chunk._ts_meta_min_1, compress_hyper_8_19_chunk._ts_meta_max_1
          ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_7_12_chunk (never executed)
                Output: _hyper_7_12_chunk."time", _hyper_7_12_chunk.sensor_id, _hyper_7_12_chunk.cpu, _hyper_7_12_chunk.temperature
-               Sorted merge append: true
+               Batch Sorted Merge: true
                Bulk Decompression: false
                ->  Sort (never executed)
                      Output: compress_hyper_8_18_chunk."time", compress_hyper_8_18_chunk.sensor_id, compress_hyper_8_18_chunk.cpu, compress_hyper_8_18_chunk.temperature, compress_hyper_8_18_chunk._ts_meta_count, compress_hyper_8_18_chunk._ts_meta_sequence_num, compress_hyper_8_18_chunk._ts_meta_min_1, compress_hyper_8_18_chunk._ts_meta_max_1
@@ -1228,7 +1228,7 @@ SELECT * FROM sensor_data ORDER BY time DESC LIMIT 1;
                            Output: compress_hyper_8_18_chunk."time", compress_hyper_8_18_chunk.sensor_id, compress_hyper_8_18_chunk.cpu, compress_hyper_8_18_chunk.temperature, compress_hyper_8_18_chunk._ts_meta_count, compress_hyper_8_18_chunk._ts_meta_sequence_num, compress_hyper_8_18_chunk._ts_meta_min_1, compress_hyper_8_18_chunk._ts_meta_max_1
          ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_7_11_chunk (never executed)
                Output: _hyper_7_11_chunk."time", _hyper_7_11_chunk.sensor_id, _hyper_7_11_chunk.cpu, _hyper_7_11_chunk.temperature
-               Sorted merge append: true
+               Batch Sorted Merge: true
                Bulk Decompression: false
                ->  Sort (never executed)
                      Output: compress_hyper_8_17_chunk."time", compress_hyper_8_17_chunk.sensor_id, compress_hyper_8_17_chunk.cpu, compress_hyper_8_17_chunk.temperature, compress_hyper_8_17_chunk._ts_meta_count, compress_hyper_8_17_chunk._ts_meta_sequence_num, compress_hyper_8_17_chunk._ts_meta_min_1, compress_hyper_8_17_chunk._ts_meta_max_1
@@ -1237,7 +1237,7 @@ SELECT * FROM sensor_data ORDER BY time DESC LIMIT 1;
                            Output: compress_hyper_8_17_chunk."time", compress_hyper_8_17_chunk.sensor_id, compress_hyper_8_17_chunk.cpu, compress_hyper_8_17_chunk.temperature, compress_hyper_8_17_chunk._ts_meta_count, compress_hyper_8_17_chunk._ts_meta_sequence_num, compress_hyper_8_17_chunk._ts_meta_min_1, compress_hyper_8_17_chunk._ts_meta_max_1
          ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_7_10_chunk (never executed)
                Output: _hyper_7_10_chunk."time", _hyper_7_10_chunk.sensor_id, _hyper_7_10_chunk.cpu, _hyper_7_10_chunk.temperature
-               Sorted merge append: true
+               Batch Sorted Merge: true
                Bulk Decompression: false
                ->  Sort (never executed)
                      Output: compress_hyper_8_16_chunk."time", compress_hyper_8_16_chunk.sensor_id, compress_hyper_8_16_chunk.cpu, compress_hyper_8_16_chunk.temperature, compress_hyper_8_16_chunk._ts_meta_count, compress_hyper_8_16_chunk._ts_meta_sequence_num, compress_hyper_8_16_chunk._ts_meta_min_1, compress_hyper_8_16_chunk._ts_meta_max_1
@@ -1246,7 +1246,7 @@ SELECT * FROM sensor_data ORDER BY time DESC LIMIT 1;
                            Output: compress_hyper_8_16_chunk."time", compress_hyper_8_16_chunk.sensor_id, compress_hyper_8_16_chunk.cpu, compress_hyper_8_16_chunk.temperature, compress_hyper_8_16_chunk._ts_meta_count, compress_hyper_8_16_chunk._ts_meta_sequence_num, compress_hyper_8_16_chunk._ts_meta_min_1, compress_hyper_8_16_chunk._ts_meta_max_1
          ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_7_9_chunk (never executed)
                Output: _hyper_7_9_chunk."time", _hyper_7_9_chunk.sensor_id, _hyper_7_9_chunk.cpu, _hyper_7_9_chunk.temperature
-               Sorted merge append: true
+               Batch Sorted Merge: true
                Bulk Decompression: false
                ->  Sort (never executed)
                      Output: compress_hyper_8_15_chunk."time", compress_hyper_8_15_chunk.sensor_id, compress_hyper_8_15_chunk.cpu, compress_hyper_8_15_chunk.temperature, compress_hyper_8_15_chunk._ts_meta_count, compress_hyper_8_15_chunk._ts_meta_sequence_num, compress_hyper_8_15_chunk._ts_meta_min_1, compress_hyper_8_15_chunk._ts_meta_max_1
@@ -1255,7 +1255,7 @@ SELECT * FROM sensor_data ORDER BY time DESC LIMIT 1;
                            Output: compress_hyper_8_15_chunk."time", compress_hyper_8_15_chunk.sensor_id, compress_hyper_8_15_chunk.cpu, compress_hyper_8_15_chunk.temperature, compress_hyper_8_15_chunk._ts_meta_count, compress_hyper_8_15_chunk._ts_meta_sequence_num, compress_hyper_8_15_chunk._ts_meta_min_1, compress_hyper_8_15_chunk._ts_meta_max_1
          ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_7_8_chunk (never executed)
                Output: _hyper_7_8_chunk."time", _hyper_7_8_chunk.sensor_id, _hyper_7_8_chunk.cpu, _hyper_7_8_chunk.temperature
-               Sorted merge append: true
+               Batch Sorted Merge: true
                Bulk Decompression: false
                ->  Sort (never executed)
                      Output: compress_hyper_8_14_chunk."time", compress_hyper_8_14_chunk.sensor_id, compress_hyper_8_14_chunk.cpu, compress_hyper_8_14_chunk.temperature, compress_hyper_8_14_chunk._ts_meta_count, compress_hyper_8_14_chunk._ts_meta_sequence_num, compress_hyper_8_14_chunk._ts_meta_min_1, compress_hyper_8_14_chunk._ts_meta_max_1
@@ -1370,7 +1370,7 @@ SELECT time, segment_by, x1 FROM test_costs ORDER BY time DESC;
 --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_9_20_chunk (actual rows=100 loops=1)
    Output: _hyper_9_20_chunk."time", _hyper_9_20_chunk.segment_by, _hyper_9_20_chunk.x1
-   Sorted merge append: true
+   Batch Sorted Merge: true
    Bulk Decompression: false
    ->  Sort (actual rows=100 loops=1)
          Output: compress_hyper_10_21_chunk."time", compress_hyper_10_21_chunk.segment_by, compress_hyper_10_21_chunk.x1, compress_hyper_10_21_chunk._ts_meta_count, compress_hyper_10_21_chunk._ts_meta_sequence_num, compress_hyper_10_21_chunk._ts_meta_min_1, compress_hyper_10_21_chunk._ts_meta_max_1, compress_hyper_10_21_chunk._ts_meta_min_2, compress_hyper_10_21_chunk._ts_meta_max_2
@@ -1434,7 +1434,7 @@ SELECT time, segment_by, x1 FROM test_costs WHERE segment_by > 900 and segment_b
 --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_9_20_chunk (actual rows=98 loops=1)
    Output: _hyper_9_20_chunk."time", _hyper_9_20_chunk.segment_by, _hyper_9_20_chunk.x1
-   Sorted merge append: true
+   Batch Sorted Merge: true
    Bulk Decompression: false
    ->  Sort (actual rows=98 loops=1)
          Output: compress_hyper_10_22_chunk."time", compress_hyper_10_22_chunk.segment_by, compress_hyper_10_22_chunk.x1, compress_hyper_10_22_chunk._ts_meta_count, compress_hyper_10_22_chunk._ts_meta_sequence_num, compress_hyper_10_22_chunk._ts_meta_min_1, compress_hyper_10_22_chunk._ts_meta_max_1, compress_hyper_10_22_chunk._ts_meta_min_2, compress_hyper_10_22_chunk._ts_meta_max_2
@@ -1489,7 +1489,7 @@ SELECT "time","hin"::text,"model"::text,"block"::text,"message_name"::text,"sign
    Output: _hyper_11_23_chunk."time", (_hyper_11_23_chunk.hin)::text, (_hyper_11_23_chunk.model)::text, (_hyper_11_23_chunk.block)::text, (_hyper_11_23_chunk.message_name)::text, (_hyper_11_23_chunk.signal_name)::text, _hyper_11_23_chunk.signal_numeric_value, (_hyper_11_23_chunk.signal_string_value)::text
    ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_11_23_chunk (actual rows=1 loops=1)
          Output: _hyper_11_23_chunk."time", _hyper_11_23_chunk.hin, _hyper_11_23_chunk.model, _hyper_11_23_chunk.block, _hyper_11_23_chunk.message_name, _hyper_11_23_chunk.signal_name, _hyper_11_23_chunk.signal_numeric_value, _hyper_11_23_chunk.signal_string_value
-         Sorted merge append: true
+         Batch Sorted Merge: true
          Bulk Decompression: false
          ->  Sort (actual rows=1 loops=1)
                Output: compress_hyper_12_24_chunk."time", compress_hyper_12_24_chunk.hin, compress_hyper_12_24_chunk.model, compress_hyper_12_24_chunk.block, compress_hyper_12_24_chunk.message_name, compress_hyper_12_24_chunk.signal_name, compress_hyper_12_24_chunk.signal_numeric_value, compress_hyper_12_24_chunk.signal_string_value, compress_hyper_12_24_chunk._ts_meta_count, compress_hyper_12_24_chunk._ts_meta_sequence_num, compress_hyper_12_24_chunk._ts_meta_min_1, compress_hyper_12_24_chunk._ts_meta_max_1

--- a/tsl/test/expected/compression_sorted_merge-15.out
+++ b/tsl/test/expected/compression_sorted_merge-15.out
@@ -1,6 +1,10 @@
 -- This file and its contents are licensed under the Timescale License.
 -- Please see the included NOTICE for copyright information and
 -- LICENSE-TIMESCALE for a copy of the license.
+-- Increase the working memory limit slightly, otherwise the batch sorted merge
+-- will be penalized for segmentby cardinalities larger than 100, where it is
+-- still faster than sort.
+SET work_mem to '16MB';
 \set PREFIX 'EXPLAIN (analyze, verbose, costs off, timing off, summary off)'
 CREATE TABLE test1 (
 time timestamptz NOT NULL,
@@ -824,9 +828,9 @@ SELECT time,x3 FROM test1 ORDER BY time DESC;
 EXPLAIN (verbose) SELECT 1 as one, 2 as two, 3 as three, time, x2 FROM test1 ORDER BY time DESC;
                                                                                                                                                                                                                                                                          QUERY PLAN                                                                                                                                                                                                                                                                          
 -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
- Result  (cost=1.06..38.26 rows=3000 width=24)
+ Result  (cost=1.06..93.44 rows=3000 width=24)
    Output: 1, 2, 3, _hyper_1_1_chunk."time", _hyper_1_1_chunk.x2
-   ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_1_chunk  (cost=1.06..8.26 rows=3000 width=12)
+   ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_1_chunk  (cost=1.06..63.44 rows=3000 width=12)
          Output: _hyper_1_1_chunk."time", _hyper_1_1_chunk.x2
          Sorted merge append: true
          ->  Sort  (cost=0.00..0.00 rows=0 width=0)
@@ -849,9 +853,9 @@ SELECT 1 as one, 2 as two, 3 as three, time, x2 FROM test1 ORDER BY time DESC;
 EXPLAIN (verbose) SELECT 1 as one, 2 as two, 3 as three, x2, time FROM test1 ORDER BY time DESC;
                                                                                                                                                                                                                                                                          QUERY PLAN                                                                                                                                                                                                                                                                          
 -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
- Result  (cost=1.06..38.26 rows=3000 width=24)
+ Result  (cost=1.06..93.44 rows=3000 width=24)
    Output: 1, 2, 3, _hyper_1_1_chunk.x2, _hyper_1_1_chunk."time"
-   ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_1_chunk  (cost=1.06..8.26 rows=3000 width=12)
+   ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_1_chunk  (cost=1.06..63.44 rows=3000 width=12)
          Output: _hyper_1_1_chunk.x2, _hyper_1_1_chunk."time"
          Sorted merge append: true
          ->  Sort  (cost=0.00..0.00 rows=0 width=0)

--- a/tsl/test/expected/compression_sorted_merge-16.out
+++ b/tsl/test/expected/compression_sorted_merge-16.out
@@ -86,7 +86,7 @@ SELECT * FROM test1 ORDER BY time DESC;
 -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_1_chunk (actual rows=4 loops=1)
    Output: _hyper_1_1_chunk."time", _hyper_1_1_chunk.x1, _hyper_1_1_chunk.x2, _hyper_1_1_chunk.x3, _hyper_1_1_chunk.x4, _hyper_1_1_chunk.x5
-   Sorted merge append: true
+   Batch Sorted Merge: true
    Bulk Decompression: false
    ->  Sort (actual rows=3 loops=1)
          Output: compress_hyper_2_2_chunk."time", compress_hyper_2_2_chunk.x1, compress_hyper_2_2_chunk.x2, compress_hyper_2_2_chunk.x3, compress_hyper_2_2_chunk.x4, compress_hyper_2_2_chunk.x5, compress_hyper_2_2_chunk._ts_meta_count, compress_hyper_2_2_chunk._ts_meta_sequence_num, compress_hyper_2_2_chunk._ts_meta_min_1, compress_hyper_2_2_chunk._ts_meta_max_1, compress_hyper_2_2_chunk._ts_meta_min_2, compress_hyper_2_2_chunk._ts_meta_max_2, compress_hyper_2_2_chunk._ts_meta_min_3, compress_hyper_2_2_chunk._ts_meta_max_3
@@ -103,7 +103,7 @@ SELECT * FROM test1 ORDER BY time DESC NULLS FIRST;
 -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_1_chunk (actual rows=4 loops=1)
    Output: _hyper_1_1_chunk."time", _hyper_1_1_chunk.x1, _hyper_1_1_chunk.x2, _hyper_1_1_chunk.x3, _hyper_1_1_chunk.x4, _hyper_1_1_chunk.x5
-   Sorted merge append: true
+   Batch Sorted Merge: true
    Bulk Decompression: false
    ->  Sort (actual rows=3 loops=1)
          Output: compress_hyper_2_2_chunk."time", compress_hyper_2_2_chunk.x1, compress_hyper_2_2_chunk.x2, compress_hyper_2_2_chunk.x3, compress_hyper_2_2_chunk.x4, compress_hyper_2_2_chunk.x5, compress_hyper_2_2_chunk._ts_meta_count, compress_hyper_2_2_chunk._ts_meta_sequence_num, compress_hyper_2_2_chunk._ts_meta_min_1, compress_hyper_2_2_chunk._ts_meta_max_1, compress_hyper_2_2_chunk._ts_meta_min_2, compress_hyper_2_2_chunk._ts_meta_max_2, compress_hyper_2_2_chunk._ts_meta_min_3, compress_hyper_2_2_chunk._ts_meta_max_3
@@ -136,7 +136,7 @@ SELECT * FROM test1 ORDER BY time ASC;
 -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_1_chunk (actual rows=4 loops=1)
    Output: _hyper_1_1_chunk."time", _hyper_1_1_chunk.x1, _hyper_1_1_chunk.x2, _hyper_1_1_chunk.x3, _hyper_1_1_chunk.x4, _hyper_1_1_chunk.x5
-   Sorted merge append: true
+   Batch Sorted Merge: true
    Bulk Decompression: false
    ->  Sort (actual rows=3 loops=1)
          Output: compress_hyper_2_2_chunk."time", compress_hyper_2_2_chunk.x1, compress_hyper_2_2_chunk.x2, compress_hyper_2_2_chunk.x3, compress_hyper_2_2_chunk.x4, compress_hyper_2_2_chunk.x5, compress_hyper_2_2_chunk._ts_meta_count, compress_hyper_2_2_chunk._ts_meta_sequence_num, compress_hyper_2_2_chunk._ts_meta_min_1, compress_hyper_2_2_chunk._ts_meta_max_1, compress_hyper_2_2_chunk._ts_meta_min_2, compress_hyper_2_2_chunk._ts_meta_max_2, compress_hyper_2_2_chunk._ts_meta_min_3, compress_hyper_2_2_chunk._ts_meta_max_3
@@ -153,7 +153,7 @@ SELECT * FROM test1 ORDER BY time ASC NULLS LAST;
 -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_1_chunk (actual rows=4 loops=1)
    Output: _hyper_1_1_chunk."time", _hyper_1_1_chunk.x1, _hyper_1_1_chunk.x2, _hyper_1_1_chunk.x3, _hyper_1_1_chunk.x4, _hyper_1_1_chunk.x5
-   Sorted merge append: true
+   Batch Sorted Merge: true
    Bulk Decompression: false
    ->  Sort (actual rows=3 loops=1)
          Output: compress_hyper_2_2_chunk."time", compress_hyper_2_2_chunk.x1, compress_hyper_2_2_chunk.x2, compress_hyper_2_2_chunk.x3, compress_hyper_2_2_chunk.x4, compress_hyper_2_2_chunk.x5, compress_hyper_2_2_chunk._ts_meta_count, compress_hyper_2_2_chunk._ts_meta_sequence_num, compress_hyper_2_2_chunk._ts_meta_min_1, compress_hyper_2_2_chunk._ts_meta_max_1, compress_hyper_2_2_chunk._ts_meta_min_2, compress_hyper_2_2_chunk._ts_meta_max_2, compress_hyper_2_2_chunk._ts_meta_min_3, compress_hyper_2_2_chunk._ts_meta_max_3
@@ -186,7 +186,7 @@ SELECT * FROM test1 ORDER BY time DESC NULLS FIRST, x3 ASC NULLS LAST;
 -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_1_chunk (actual rows=4 loops=1)
    Output: _hyper_1_1_chunk."time", _hyper_1_1_chunk.x1, _hyper_1_1_chunk.x2, _hyper_1_1_chunk.x3, _hyper_1_1_chunk.x4, _hyper_1_1_chunk.x5
-   Sorted merge append: true
+   Batch Sorted Merge: true
    Bulk Decompression: false
    ->  Sort (actual rows=3 loops=1)
          Output: compress_hyper_2_2_chunk."time", compress_hyper_2_2_chunk.x1, compress_hyper_2_2_chunk.x2, compress_hyper_2_2_chunk.x3, compress_hyper_2_2_chunk.x4, compress_hyper_2_2_chunk.x5, compress_hyper_2_2_chunk._ts_meta_count, compress_hyper_2_2_chunk._ts_meta_sequence_num, compress_hyper_2_2_chunk._ts_meta_min_1, compress_hyper_2_2_chunk._ts_meta_max_1, compress_hyper_2_2_chunk._ts_meta_min_2, compress_hyper_2_2_chunk._ts_meta_max_2, compress_hyper_2_2_chunk._ts_meta_min_3, compress_hyper_2_2_chunk._ts_meta_max_3
@@ -203,7 +203,7 @@ SELECT * FROM test1 ORDER BY time DESC NULLS FIRST, x3 ASC NULLS LAST, x4 ASC NU
 -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_1_chunk (actual rows=4 loops=1)
    Output: _hyper_1_1_chunk."time", _hyper_1_1_chunk.x1, _hyper_1_1_chunk.x2, _hyper_1_1_chunk.x3, _hyper_1_1_chunk.x4, _hyper_1_1_chunk.x5
-   Sorted merge append: true
+   Batch Sorted Merge: true
    Bulk Decompression: false
    ->  Sort (actual rows=3 loops=1)
          Output: compress_hyper_2_2_chunk."time", compress_hyper_2_2_chunk.x1, compress_hyper_2_2_chunk.x2, compress_hyper_2_2_chunk.x3, compress_hyper_2_2_chunk.x4, compress_hyper_2_2_chunk.x5, compress_hyper_2_2_chunk._ts_meta_count, compress_hyper_2_2_chunk._ts_meta_sequence_num, compress_hyper_2_2_chunk._ts_meta_min_1, compress_hyper_2_2_chunk._ts_meta_max_1, compress_hyper_2_2_chunk._ts_meta_min_2, compress_hyper_2_2_chunk._ts_meta_max_2, compress_hyper_2_2_chunk._ts_meta_min_3, compress_hyper_2_2_chunk._ts_meta_max_3
@@ -236,7 +236,7 @@ SELECT * FROM test1 ORDER BY time ASC NULLS LAST;
 -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_1_chunk (actual rows=4 loops=1)
    Output: _hyper_1_1_chunk."time", _hyper_1_1_chunk.x1, _hyper_1_1_chunk.x2, _hyper_1_1_chunk.x3, _hyper_1_1_chunk.x4, _hyper_1_1_chunk.x5
-   Sorted merge append: true
+   Batch Sorted Merge: true
    Bulk Decompression: false
    ->  Sort (actual rows=3 loops=1)
          Output: compress_hyper_2_2_chunk."time", compress_hyper_2_2_chunk.x1, compress_hyper_2_2_chunk.x2, compress_hyper_2_2_chunk.x3, compress_hyper_2_2_chunk.x4, compress_hyper_2_2_chunk.x5, compress_hyper_2_2_chunk._ts_meta_count, compress_hyper_2_2_chunk._ts_meta_sequence_num, compress_hyper_2_2_chunk._ts_meta_min_1, compress_hyper_2_2_chunk._ts_meta_max_1, compress_hyper_2_2_chunk._ts_meta_min_2, compress_hyper_2_2_chunk._ts_meta_max_2, compress_hyper_2_2_chunk._ts_meta_min_3, compress_hyper_2_2_chunk._ts_meta_max_3
@@ -253,7 +253,7 @@ SELECT * FROM test1 ORDER BY time ASC NULLS LAST, x3 DESC NULLS FIRST;
 -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_1_chunk (actual rows=4 loops=1)
    Output: _hyper_1_1_chunk."time", _hyper_1_1_chunk.x1, _hyper_1_1_chunk.x2, _hyper_1_1_chunk.x3, _hyper_1_1_chunk.x4, _hyper_1_1_chunk.x5
-   Sorted merge append: true
+   Batch Sorted Merge: true
    Bulk Decompression: false
    ->  Sort (actual rows=3 loops=1)
          Output: compress_hyper_2_2_chunk."time", compress_hyper_2_2_chunk.x1, compress_hyper_2_2_chunk.x2, compress_hyper_2_2_chunk.x3, compress_hyper_2_2_chunk.x4, compress_hyper_2_2_chunk.x5, compress_hyper_2_2_chunk._ts_meta_count, compress_hyper_2_2_chunk._ts_meta_sequence_num, compress_hyper_2_2_chunk._ts_meta_min_1, compress_hyper_2_2_chunk._ts_meta_max_1, compress_hyper_2_2_chunk._ts_meta_min_2, compress_hyper_2_2_chunk._ts_meta_max_2, compress_hyper_2_2_chunk._ts_meta_min_3, compress_hyper_2_2_chunk._ts_meta_max_3
@@ -270,7 +270,7 @@ SELECT * FROM test1 ORDER BY time ASC NULLS LAST, x3 DESC NULLS FIRST, x4 DESC N
 -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_1_chunk (actual rows=4 loops=1)
    Output: _hyper_1_1_chunk."time", _hyper_1_1_chunk.x1, _hyper_1_1_chunk.x2, _hyper_1_1_chunk.x3, _hyper_1_1_chunk.x4, _hyper_1_1_chunk.x5
-   Sorted merge append: true
+   Batch Sorted Merge: true
    Bulk Decompression: false
    ->  Sort (actual rows=3 loops=1)
          Output: compress_hyper_2_2_chunk."time", compress_hyper_2_2_chunk.x1, compress_hyper_2_2_chunk.x2, compress_hyper_2_2_chunk.x3, compress_hyper_2_2_chunk.x4, compress_hyper_2_2_chunk.x5, compress_hyper_2_2_chunk._ts_meta_count, compress_hyper_2_2_chunk._ts_meta_sequence_num, compress_hyper_2_2_chunk._ts_meta_min_1, compress_hyper_2_2_chunk._ts_meta_max_1, compress_hyper_2_2_chunk._ts_meta_min_2, compress_hyper_2_2_chunk._ts_meta_max_2, compress_hyper_2_2_chunk._ts_meta_min_3, compress_hyper_2_2_chunk._ts_meta_max_3
@@ -303,7 +303,7 @@ SELECT * FROM test2 ORDER BY time ASC;
 -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_3_3_chunk (actual rows=4 loops=1)
    Output: _hyper_3_3_chunk."time", _hyper_3_3_chunk.x1, _hyper_3_3_chunk.x2, _hyper_3_3_chunk.x3, _hyper_3_3_chunk.x4, _hyper_3_3_chunk.x5
-   Sorted merge append: true
+   Batch Sorted Merge: true
    Bulk Decompression: false
    ->  Sort (actual rows=3 loops=1)
          Output: compress_hyper_4_4_chunk."time", compress_hyper_4_4_chunk.x1, compress_hyper_4_4_chunk.x2, compress_hyper_4_4_chunk.x3, compress_hyper_4_4_chunk.x4, compress_hyper_4_4_chunk.x5, compress_hyper_4_4_chunk._ts_meta_count, compress_hyper_4_4_chunk._ts_meta_sequence_num, compress_hyper_4_4_chunk._ts_meta_min_1, compress_hyper_4_4_chunk._ts_meta_max_1, compress_hyper_4_4_chunk._ts_meta_min_2, compress_hyper_4_4_chunk._ts_meta_max_2, compress_hyper_4_4_chunk._ts_meta_min_3, compress_hyper_4_4_chunk._ts_meta_max_3
@@ -320,7 +320,7 @@ SELECT * FROM test2 ORDER BY time ASC, x3 DESC;
 -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_3_3_chunk (actual rows=4 loops=1)
    Output: _hyper_3_3_chunk."time", _hyper_3_3_chunk.x1, _hyper_3_3_chunk.x2, _hyper_3_3_chunk.x3, _hyper_3_3_chunk.x4, _hyper_3_3_chunk.x5
-   Sorted merge append: true
+   Batch Sorted Merge: true
    Bulk Decompression: false
    ->  Sort (actual rows=3 loops=1)
          Output: compress_hyper_4_4_chunk."time", compress_hyper_4_4_chunk.x1, compress_hyper_4_4_chunk.x2, compress_hyper_4_4_chunk.x3, compress_hyper_4_4_chunk.x4, compress_hyper_4_4_chunk.x5, compress_hyper_4_4_chunk._ts_meta_count, compress_hyper_4_4_chunk._ts_meta_sequence_num, compress_hyper_4_4_chunk._ts_meta_min_1, compress_hyper_4_4_chunk._ts_meta_max_1, compress_hyper_4_4_chunk._ts_meta_min_2, compress_hyper_4_4_chunk._ts_meta_max_2, compress_hyper_4_4_chunk._ts_meta_min_3, compress_hyper_4_4_chunk._ts_meta_max_3
@@ -337,7 +337,7 @@ SELECT * FROM test2 ORDER BY time ASC, x3 DESC, x4 DESC;
 -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_3_3_chunk (actual rows=4 loops=1)
    Output: _hyper_3_3_chunk."time", _hyper_3_3_chunk.x1, _hyper_3_3_chunk.x2, _hyper_3_3_chunk.x3, _hyper_3_3_chunk.x4, _hyper_3_3_chunk.x5
-   Sorted merge append: true
+   Batch Sorted Merge: true
    Bulk Decompression: false
    ->  Sort (actual rows=3 loops=1)
          Output: compress_hyper_4_4_chunk."time", compress_hyper_4_4_chunk.x1, compress_hyper_4_4_chunk.x2, compress_hyper_4_4_chunk.x3, compress_hyper_4_4_chunk.x4, compress_hyper_4_4_chunk.x5, compress_hyper_4_4_chunk._ts_meta_count, compress_hyper_4_4_chunk._ts_meta_sequence_num, compress_hyper_4_4_chunk._ts_meta_min_1, compress_hyper_4_4_chunk._ts_meta_max_1, compress_hyper_4_4_chunk._ts_meta_min_2, compress_hyper_4_4_chunk._ts_meta_max_2, compress_hyper_4_4_chunk._ts_meta_min_3, compress_hyper_4_4_chunk._ts_meta_max_3
@@ -386,7 +386,7 @@ SELECT * FROM test2 ORDER BY time DESC NULLS FIRST;
 -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_3_3_chunk (actual rows=4 loops=1)
    Output: _hyper_3_3_chunk."time", _hyper_3_3_chunk.x1, _hyper_3_3_chunk.x2, _hyper_3_3_chunk.x3, _hyper_3_3_chunk.x4, _hyper_3_3_chunk.x5
-   Sorted merge append: true
+   Batch Sorted Merge: true
    Bulk Decompression: false
    ->  Sort (actual rows=3 loops=1)
          Output: compress_hyper_4_4_chunk."time", compress_hyper_4_4_chunk.x1, compress_hyper_4_4_chunk.x2, compress_hyper_4_4_chunk.x3, compress_hyper_4_4_chunk.x4, compress_hyper_4_4_chunk.x5, compress_hyper_4_4_chunk._ts_meta_count, compress_hyper_4_4_chunk._ts_meta_sequence_num, compress_hyper_4_4_chunk._ts_meta_min_1, compress_hyper_4_4_chunk._ts_meta_max_1, compress_hyper_4_4_chunk._ts_meta_min_2, compress_hyper_4_4_chunk._ts_meta_max_2, compress_hyper_4_4_chunk._ts_meta_min_3, compress_hyper_4_4_chunk._ts_meta_max_3
@@ -403,7 +403,7 @@ SELECT * FROM test2 ORDER BY time DESC NULLS FIRST, x3 ASC NULLS LAST;
 -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_3_3_chunk (actual rows=4 loops=1)
    Output: _hyper_3_3_chunk."time", _hyper_3_3_chunk.x1, _hyper_3_3_chunk.x2, _hyper_3_3_chunk.x3, _hyper_3_3_chunk.x4, _hyper_3_3_chunk.x5
-   Sorted merge append: true
+   Batch Sorted Merge: true
    Bulk Decompression: false
    ->  Sort (actual rows=3 loops=1)
          Output: compress_hyper_4_4_chunk."time", compress_hyper_4_4_chunk.x1, compress_hyper_4_4_chunk.x2, compress_hyper_4_4_chunk.x3, compress_hyper_4_4_chunk.x4, compress_hyper_4_4_chunk.x5, compress_hyper_4_4_chunk._ts_meta_count, compress_hyper_4_4_chunk._ts_meta_sequence_num, compress_hyper_4_4_chunk._ts_meta_min_1, compress_hyper_4_4_chunk._ts_meta_max_1, compress_hyper_4_4_chunk._ts_meta_min_2, compress_hyper_4_4_chunk._ts_meta_max_2, compress_hyper_4_4_chunk._ts_meta_min_3, compress_hyper_4_4_chunk._ts_meta_max_3
@@ -420,7 +420,7 @@ SELECT * FROM test2 ORDER BY time DESC NULLS FIRST, x3 ASC NULLS LAST, x4 NULLS 
 -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_3_3_chunk (actual rows=4 loops=1)
    Output: _hyper_3_3_chunk."time", _hyper_3_3_chunk.x1, _hyper_3_3_chunk.x2, _hyper_3_3_chunk.x3, _hyper_3_3_chunk.x4, _hyper_3_3_chunk.x5
-   Sorted merge append: true
+   Batch Sorted Merge: true
    Bulk Decompression: false
    ->  Sort (actual rows=3 loops=1)
          Output: compress_hyper_4_4_chunk."time", compress_hyper_4_4_chunk.x1, compress_hyper_4_4_chunk.x2, compress_hyper_4_4_chunk.x3, compress_hyper_4_4_chunk.x4, compress_hyper_4_4_chunk.x5, compress_hyper_4_4_chunk._ts_meta_count, compress_hyper_4_4_chunk._ts_meta_sequence_num, compress_hyper_4_4_chunk._ts_meta_min_1, compress_hyper_4_4_chunk._ts_meta_max_1, compress_hyper_4_4_chunk._ts_meta_min_2, compress_hyper_4_4_chunk._ts_meta_max_2, compress_hyper_4_4_chunk._ts_meta_min_3, compress_hyper_4_4_chunk._ts_meta_max_3
@@ -469,7 +469,7 @@ SELECT * FROM test_with_defined_null ORDER BY x2 ASC NULLS FIRST;
 -----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_5_5_chunk (actual rows=4 loops=1)
    Output: _hyper_5_5_chunk."time", _hyper_5_5_chunk.x1, _hyper_5_5_chunk.x2, _hyper_5_5_chunk.x3
-   Sorted merge append: true
+   Batch Sorted Merge: true
    Bulk Decompression: false
    ->  Sort (actual rows=2 loops=1)
          Output: compress_hyper_6_6_chunk."time", compress_hyper_6_6_chunk.x1, compress_hyper_6_6_chunk.x2, compress_hyper_6_6_chunk.x3, compress_hyper_6_6_chunk._ts_meta_count, compress_hyper_6_6_chunk._ts_meta_sequence_num, compress_hyper_6_6_chunk._ts_meta_min_2, compress_hyper_6_6_chunk._ts_meta_max_2, compress_hyper_6_6_chunk._ts_meta_min_1, compress_hyper_6_6_chunk._ts_meta_max_1
@@ -486,7 +486,7 @@ SELECT * FROM test_with_defined_null ORDER BY x2 DESC NULLS LAST;
 -----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_5_5_chunk (actual rows=4 loops=1)
    Output: _hyper_5_5_chunk."time", _hyper_5_5_chunk.x1, _hyper_5_5_chunk.x2, _hyper_5_5_chunk.x3
-   Sorted merge append: true
+   Batch Sorted Merge: true
    Bulk Decompression: false
    ->  Sort (actual rows=2 loops=1)
          Output: compress_hyper_6_6_chunk."time", compress_hyper_6_6_chunk.x1, compress_hyper_6_6_chunk.x2, compress_hyper_6_6_chunk.x3, compress_hyper_6_6_chunk._ts_meta_count, compress_hyper_6_6_chunk._ts_meta_sequence_num, compress_hyper_6_6_chunk._ts_meta_min_2, compress_hyper_6_6_chunk._ts_meta_max_2, compress_hyper_6_6_chunk._ts_meta_min_1, compress_hyper_6_6_chunk._ts_meta_max_1
@@ -539,7 +539,7 @@ SELECT * FROM test1 WHERE x4 > 0 ORDER BY time DESC;
  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_1_chunk (actual rows=4 loops=1)
    Output: _hyper_1_1_chunk."time", _hyper_1_1_chunk.x1, _hyper_1_1_chunk.x2, _hyper_1_1_chunk.x3, _hyper_1_1_chunk.x4, _hyper_1_1_chunk.x5
    Filter: (_hyper_1_1_chunk.x4 > 0)
-   Sorted merge append: true
+   Batch Sorted Merge: true
    Bulk Decompression: false
    ->  Sort (actual rows=3 loops=1)
          Output: compress_hyper_2_2_chunk."time", compress_hyper_2_2_chunk.x1, compress_hyper_2_2_chunk.x2, compress_hyper_2_2_chunk.x3, compress_hyper_2_2_chunk.x4, compress_hyper_2_2_chunk.x5, compress_hyper_2_2_chunk._ts_meta_count, compress_hyper_2_2_chunk._ts_meta_sequence_num, compress_hyper_2_2_chunk._ts_meta_min_1, compress_hyper_2_2_chunk._ts_meta_max_1, compress_hyper_2_2_chunk._ts_meta_min_2, compress_hyper_2_2_chunk._ts_meta_max_2, compress_hyper_2_2_chunk._ts_meta_min_3, compress_hyper_2_2_chunk._ts_meta_max_3
@@ -558,7 +558,7 @@ SELECT * FROM test1 WHERE x4 > 100 ORDER BY time DESC;
  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_1_chunk (actual rows=0 loops=1)
    Output: _hyper_1_1_chunk."time", _hyper_1_1_chunk.x1, _hyper_1_1_chunk.x2, _hyper_1_1_chunk.x3, _hyper_1_1_chunk.x4, _hyper_1_1_chunk.x5
    Filter: (_hyper_1_1_chunk.x4 > 100)
-   Sorted merge append: true
+   Batch Sorted Merge: true
    Bulk Decompression: false
    ->  Sort (actual rows=0 loops=1)
          Output: compress_hyper_2_2_chunk."time", compress_hyper_2_2_chunk.x1, compress_hyper_2_2_chunk.x2, compress_hyper_2_2_chunk.x3, compress_hyper_2_2_chunk.x4, compress_hyper_2_2_chunk.x5, compress_hyper_2_2_chunk._ts_meta_count, compress_hyper_2_2_chunk._ts_meta_sequence_num, compress_hyper_2_2_chunk._ts_meta_min_1, compress_hyper_2_2_chunk._ts_meta_max_1, compress_hyper_2_2_chunk._ts_meta_min_2, compress_hyper_2_2_chunk._ts_meta_max_2, compress_hyper_2_2_chunk._ts_meta_min_3, compress_hyper_2_2_chunk._ts_meta_max_3
@@ -578,7 +578,7 @@ SELECT * FROM test1 WHERE x4 > 100 ORDER BY time DESC, x3, x4;
  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_1_chunk (actual rows=0 loops=1)
    Output: _hyper_1_1_chunk."time", _hyper_1_1_chunk.x1, _hyper_1_1_chunk.x2, _hyper_1_1_chunk.x3, _hyper_1_1_chunk.x4, _hyper_1_1_chunk.x5
    Filter: (_hyper_1_1_chunk.x4 > 100)
-   Sorted merge append: true
+   Batch Sorted Merge: true
    Bulk Decompression: false
    ->  Sort (actual rows=0 loops=1)
          Output: compress_hyper_2_2_chunk."time", compress_hyper_2_2_chunk.x1, compress_hyper_2_2_chunk.x2, compress_hyper_2_2_chunk.x3, compress_hyper_2_2_chunk.x4, compress_hyper_2_2_chunk.x5, compress_hyper_2_2_chunk._ts_meta_count, compress_hyper_2_2_chunk._ts_meta_sequence_num, compress_hyper_2_2_chunk._ts_meta_min_1, compress_hyper_2_2_chunk._ts_meta_max_1, compress_hyper_2_2_chunk._ts_meta_min_2, compress_hyper_2_2_chunk._ts_meta_max_2, compress_hyper_2_2_chunk._ts_meta_min_3, compress_hyper_2_2_chunk._ts_meta_max_3
@@ -598,7 +598,7 @@ SELECT * FROM test1 WHERE x4 > 100 ORDER BY time DESC, x3, x3;
  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_1_chunk (actual rows=0 loops=1)
    Output: _hyper_1_1_chunk."time", _hyper_1_1_chunk.x1, _hyper_1_1_chunk.x2, _hyper_1_1_chunk.x3, _hyper_1_1_chunk.x4, _hyper_1_1_chunk.x5
    Filter: (_hyper_1_1_chunk.x4 > 100)
-   Sorted merge append: true
+   Batch Sorted Merge: true
    Bulk Decompression: false
    ->  Sort (actual rows=0 loops=1)
          Output: compress_hyper_2_2_chunk."time", compress_hyper_2_2_chunk.x1, compress_hyper_2_2_chunk.x2, compress_hyper_2_2_chunk.x3, compress_hyper_2_2_chunk.x4, compress_hyper_2_2_chunk.x5, compress_hyper_2_2_chunk._ts_meta_count, compress_hyper_2_2_chunk._ts_meta_sequence_num, compress_hyper_2_2_chunk._ts_meta_min_1, compress_hyper_2_2_chunk._ts_meta_max_1, compress_hyper_2_2_chunk._ts_meta_min_2, compress_hyper_2_2_chunk._ts_meta_max_2, compress_hyper_2_2_chunk._ts_meta_min_3, compress_hyper_2_2_chunk._ts_meta_max_3
@@ -618,7 +618,7 @@ SELECT * FROM test1 WHERE x4 > 100 ORDER BY time DESC, x3, x4, x3, x4;
  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_1_chunk (actual rows=0 loops=1)
    Output: _hyper_1_1_chunk."time", _hyper_1_1_chunk.x1, _hyper_1_1_chunk.x2, _hyper_1_1_chunk.x3, _hyper_1_1_chunk.x4, _hyper_1_1_chunk.x5
    Filter: (_hyper_1_1_chunk.x4 > 100)
-   Sorted merge append: true
+   Batch Sorted Merge: true
    Bulk Decompression: false
    ->  Sort (actual rows=0 loops=1)
          Output: compress_hyper_2_2_chunk."time", compress_hyper_2_2_chunk.x1, compress_hyper_2_2_chunk.x2, compress_hyper_2_2_chunk.x3, compress_hyper_2_2_chunk.x4, compress_hyper_2_2_chunk.x5, compress_hyper_2_2_chunk._ts_meta_count, compress_hyper_2_2_chunk._ts_meta_sequence_num, compress_hyper_2_2_chunk._ts_meta_min_1, compress_hyper_2_2_chunk._ts_meta_max_1, compress_hyper_2_2_chunk._ts_meta_min_2, compress_hyper_2_2_chunk._ts_meta_max_2, compress_hyper_2_2_chunk._ts_meta_min_3, compress_hyper_2_2_chunk._ts_meta_max_3
@@ -676,7 +676,7 @@ SELECT * FROM test1 ORDER BY time DESC;
 -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_1_chunk (actual rows=4 loops=1)
    Output: _hyper_1_1_chunk."time", _hyper_1_1_chunk.x1, _hyper_1_1_chunk.x2, _hyper_1_1_chunk.x3, _hyper_1_1_chunk.x4, _hyper_1_1_chunk.x5
-   Sorted merge append: true
+   Batch Sorted Merge: true
    Bulk Decompression: false
    ->  Sort (actual rows=3 loops=1)
          Output: compress_hyper_2_2_chunk."time", compress_hyper_2_2_chunk.x1, compress_hyper_2_2_chunk.x2, compress_hyper_2_2_chunk.x3, compress_hyper_2_2_chunk.x4, compress_hyper_2_2_chunk.x5, compress_hyper_2_2_chunk._ts_meta_count, compress_hyper_2_2_chunk._ts_meta_sequence_num, compress_hyper_2_2_chunk._ts_meta_min_1, compress_hyper_2_2_chunk._ts_meta_max_1, compress_hyper_2_2_chunk._ts_meta_min_2, compress_hyper_2_2_chunk._ts_meta_max_2, compress_hyper_2_2_chunk._ts_meta_min_3, compress_hyper_2_2_chunk._ts_meta_max_3
@@ -832,7 +832,7 @@ EXPLAIN (verbose) SELECT 1 as one, 2 as two, 3 as three, time, x2 FROM test1 ORD
    Output: 1, 2, 3, _hyper_1_1_chunk."time", _hyper_1_1_chunk.x2
    ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_1_chunk  (cost=1.06..63.44 rows=3000 width=12)
          Output: _hyper_1_1_chunk."time", _hyper_1_1_chunk.x2
-         Sorted merge append: true
+         Batch Sorted Merge: true
          ->  Sort  (cost=0.00..0.00 rows=0 width=0)
                Output: compress_hyper_2_2_chunk."time", compress_hyper_2_2_chunk.x1, compress_hyper_2_2_chunk.x2, compress_hyper_2_2_chunk.x3, compress_hyper_2_2_chunk.x4, compress_hyper_2_2_chunk.x5, compress_hyper_2_2_chunk._ts_meta_count, compress_hyper_2_2_chunk._ts_meta_sequence_num, compress_hyper_2_2_chunk._ts_meta_min_1, compress_hyper_2_2_chunk._ts_meta_max_1, compress_hyper_2_2_chunk._ts_meta_min_2, compress_hyper_2_2_chunk._ts_meta_max_2, compress_hyper_2_2_chunk._ts_meta_min_3, compress_hyper_2_2_chunk._ts_meta_max_3
                Sort Key: compress_hyper_2_2_chunk._ts_meta_max_1 DESC
@@ -857,7 +857,7 @@ EXPLAIN (verbose) SELECT 1 as one, 2 as two, 3 as three, x2, time FROM test1 ORD
    Output: 1, 2, 3, _hyper_1_1_chunk.x2, _hyper_1_1_chunk."time"
    ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_1_chunk  (cost=1.06..63.44 rows=3000 width=12)
          Output: _hyper_1_1_chunk.x2, _hyper_1_1_chunk."time"
-         Sorted merge append: true
+         Batch Sorted Merge: true
          ->  Sort  (cost=0.00..0.00 rows=0 width=0)
                Output: compress_hyper_2_2_chunk."time", compress_hyper_2_2_chunk.x1, compress_hyper_2_2_chunk.x2, compress_hyper_2_2_chunk.x3, compress_hyper_2_2_chunk.x4, compress_hyper_2_2_chunk.x5, compress_hyper_2_2_chunk._ts_meta_count, compress_hyper_2_2_chunk._ts_meta_sequence_num, compress_hyper_2_2_chunk._ts_meta_min_1, compress_hyper_2_2_chunk._ts_meta_max_1, compress_hyper_2_2_chunk._ts_meta_min_2, compress_hyper_2_2_chunk._ts_meta_max_2, compress_hyper_2_2_chunk._ts_meta_min_3, compress_hyper_2_2_chunk._ts_meta_max_3
                Sort Key: compress_hyper_2_2_chunk._ts_meta_max_1 DESC
@@ -954,7 +954,7 @@ SELECT * FROM test1 ORDER BY time DESC;
 -----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_1_chunk (actual rows=4 loops=1)
    Output: _hyper_1_1_chunk."time", _hyper_1_1_chunk.x1, _hyper_1_1_chunk.x2, _hyper_1_1_chunk.x3, _hyper_1_1_chunk.x4, _hyper_1_1_chunk.x5, _hyper_1_1_chunk.c1, _hyper_1_1_chunk.c2
-   Sorted merge append: true
+   Batch Sorted Merge: true
    Bulk Decompression: false
    ->  Sort (actual rows=3 loops=1)
          Output: compress_hyper_2_7_chunk."time", compress_hyper_2_7_chunk._ts_meta_min_1, compress_hyper_2_7_chunk._ts_meta_max_1, compress_hyper_2_7_chunk.x1, compress_hyper_2_7_chunk.x2, compress_hyper_2_7_chunk.x3, compress_hyper_2_7_chunk._ts_meta_min_2, compress_hyper_2_7_chunk._ts_meta_max_2, compress_hyper_2_7_chunk.x4, compress_hyper_2_7_chunk._ts_meta_min_3, compress_hyper_2_7_chunk._ts_meta_max_3, compress_hyper_2_7_chunk.x5, compress_hyper_2_7_chunk.c1, compress_hyper_2_7_chunk.c2, compress_hyper_2_7_chunk._ts_meta_count
@@ -980,7 +980,7 @@ SELECT time, x2, x1, c2 FROM test1 ORDER BY time DESC;
 -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_1_chunk (actual rows=4 loops=1)
    Output: _hyper_1_1_chunk."time", _hyper_1_1_chunk.x2, _hyper_1_1_chunk.x1, _hyper_1_1_chunk.c2
-   Sorted merge append: true
+   Batch Sorted Merge: true
    Bulk Decompression: false
    ->  Sort (actual rows=3 loops=1)
          Output: compress_hyper_2_7_chunk."time", compress_hyper_2_7_chunk._ts_meta_min_1, compress_hyper_2_7_chunk._ts_meta_max_1, compress_hyper_2_7_chunk.x2, compress_hyper_2_7_chunk.x1, compress_hyper_2_7_chunk.c2, compress_hyper_2_7_chunk._ts_meta_count
@@ -1006,7 +1006,7 @@ SELECT x2, x1, c2, time FROM test1 ORDER BY time DESC;
 -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_1_chunk (actual rows=4 loops=1)
    Output: _hyper_1_1_chunk.x2, _hyper_1_1_chunk.x1, _hyper_1_1_chunk.c2, _hyper_1_1_chunk."time"
-   Sorted merge append: true
+   Batch Sorted Merge: true
    Bulk Decompression: false
    ->  Sort (actual rows=3 loops=1)
          Output: compress_hyper_2_7_chunk.x2, compress_hyper_2_7_chunk.x1, compress_hyper_2_7_chunk.c2, compress_hyper_2_7_chunk."time", compress_hyper_2_7_chunk._ts_meta_min_1, compress_hyper_2_7_chunk._ts_meta_max_1, compress_hyper_2_7_chunk._ts_meta_count
@@ -1034,7 +1034,7 @@ SELECT 1 as one, 2 as two, 3 as three, x2, x1, c2, time FROM test1 ORDER BY time
    Output: 1, 2, 3, _hyper_1_1_chunk.x2, _hyper_1_1_chunk.x1, _hyper_1_1_chunk.c2, _hyper_1_1_chunk."time"
    ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_1_chunk (actual rows=4 loops=1)
          Output: _hyper_1_1_chunk.x2, _hyper_1_1_chunk.x1, _hyper_1_1_chunk.c2, _hyper_1_1_chunk."time"
-         Sorted merge append: true
+         Batch Sorted Merge: true
          Bulk Decompression: false
          ->  Sort (actual rows=3 loops=1)
                Output: compress_hyper_2_7_chunk.x2, compress_hyper_2_7_chunk.x1, compress_hyper_2_7_chunk.c2, compress_hyper_2_7_chunk."time", compress_hyper_2_7_chunk._ts_meta_min_1, compress_hyper_2_7_chunk._ts_meta_max_1, compress_hyper_2_7_chunk._ts_meta_count
@@ -1100,7 +1100,7 @@ SELECT * FROM test1 ORDER BY time ASC NULLS LAST;
 -----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_1_chunk (actual rows=4 loops=1)
    Output: _hyper_1_1_chunk."time", _hyper_1_1_chunk.x1, _hyper_1_1_chunk.x2, _hyper_1_1_chunk.x3, _hyper_1_1_chunk.x4, _hyper_1_1_chunk.x5, _hyper_1_1_chunk.c1, _hyper_1_1_chunk.c2
-   Sorted merge append: true
+   Batch Sorted Merge: true
    Bulk Decompression: false
    ->  Sort (actual rows=3 loops=1)
          Output: compress_hyper_2_7_chunk."time", compress_hyper_2_7_chunk._ts_meta_min_1, compress_hyper_2_7_chunk._ts_meta_max_1, compress_hyper_2_7_chunk.x1, compress_hyper_2_7_chunk.x2, compress_hyper_2_7_chunk.x3, compress_hyper_2_7_chunk._ts_meta_min_2, compress_hyper_2_7_chunk._ts_meta_max_2, compress_hyper_2_7_chunk.x4, compress_hyper_2_7_chunk._ts_meta_min_3, compress_hyper_2_7_chunk._ts_meta_max_3, compress_hyper_2_7_chunk.x5, compress_hyper_2_7_chunk.c1, compress_hyper_2_7_chunk.c2, compress_hyper_2_7_chunk._ts_meta_count
@@ -1126,7 +1126,7 @@ SELECT * FROM test1 ORDER BY time ASC NULLS LAST;
          Sort Key: _hyper_1_1_chunk."time"
          ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_1_chunk (actual rows=4 loops=1)
                Output: _hyper_1_1_chunk."time", _hyper_1_1_chunk.x1, _hyper_1_1_chunk.x2, _hyper_1_1_chunk.x3, _hyper_1_1_chunk.x4, _hyper_1_1_chunk.x5, _hyper_1_1_chunk.c1, _hyper_1_1_chunk.c2
-               Sorted merge append: true
+               Batch Sorted Merge: true
                Bulk Decompression: false
                ->  Sort (actual rows=3 loops=1)
                      Output: compress_hyper_2_7_chunk."time", compress_hyper_2_7_chunk._ts_meta_min_1, compress_hyper_2_7_chunk._ts_meta_max_1, compress_hyper_2_7_chunk.x1, compress_hyper_2_7_chunk.x2, compress_hyper_2_7_chunk.x3, compress_hyper_2_7_chunk._ts_meta_min_2, compress_hyper_2_7_chunk._ts_meta_max_2, compress_hyper_2_7_chunk.x4, compress_hyper_2_7_chunk._ts_meta_min_3, compress_hyper_2_7_chunk._ts_meta_max_3, compress_hyper_2_7_chunk.x5, compress_hyper_2_7_chunk.c1, compress_hyper_2_7_chunk.c2, compress_hyper_2_7_chunk._ts_meta_count
@@ -1209,7 +1209,7 @@ SELECT * FROM sensor_data ORDER BY time DESC LIMIT 1;
          Runtime Exclusion: false
          ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_7_13_chunk (actual rows=1 loops=1)
                Output: _hyper_7_13_chunk."time", _hyper_7_13_chunk.sensor_id, _hyper_7_13_chunk.cpu, _hyper_7_13_chunk.temperature
-               Sorted merge append: true
+               Batch Sorted Merge: true
                Bulk Decompression: false
                ->  Sort (actual rows=2 loops=1)
                      Output: compress_hyper_8_19_chunk."time", compress_hyper_8_19_chunk.sensor_id, compress_hyper_8_19_chunk.cpu, compress_hyper_8_19_chunk.temperature, compress_hyper_8_19_chunk._ts_meta_count, compress_hyper_8_19_chunk._ts_meta_sequence_num, compress_hyper_8_19_chunk._ts_meta_min_1, compress_hyper_8_19_chunk._ts_meta_max_1
@@ -1219,7 +1219,7 @@ SELECT * FROM sensor_data ORDER BY time DESC LIMIT 1;
                            Output: compress_hyper_8_19_chunk."time", compress_hyper_8_19_chunk.sensor_id, compress_hyper_8_19_chunk.cpu, compress_hyper_8_19_chunk.temperature, compress_hyper_8_19_chunk._ts_meta_count, compress_hyper_8_19_chunk._ts_meta_sequence_num, compress_hyper_8_19_chunk._ts_meta_min_1, compress_hyper_8_19_chunk._ts_meta_max_1
          ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_7_12_chunk (never executed)
                Output: _hyper_7_12_chunk."time", _hyper_7_12_chunk.sensor_id, _hyper_7_12_chunk.cpu, _hyper_7_12_chunk.temperature
-               Sorted merge append: true
+               Batch Sorted Merge: true
                Bulk Decompression: false
                ->  Sort (never executed)
                      Output: compress_hyper_8_18_chunk."time", compress_hyper_8_18_chunk.sensor_id, compress_hyper_8_18_chunk.cpu, compress_hyper_8_18_chunk.temperature, compress_hyper_8_18_chunk._ts_meta_count, compress_hyper_8_18_chunk._ts_meta_sequence_num, compress_hyper_8_18_chunk._ts_meta_min_1, compress_hyper_8_18_chunk._ts_meta_max_1
@@ -1228,7 +1228,7 @@ SELECT * FROM sensor_data ORDER BY time DESC LIMIT 1;
                            Output: compress_hyper_8_18_chunk."time", compress_hyper_8_18_chunk.sensor_id, compress_hyper_8_18_chunk.cpu, compress_hyper_8_18_chunk.temperature, compress_hyper_8_18_chunk._ts_meta_count, compress_hyper_8_18_chunk._ts_meta_sequence_num, compress_hyper_8_18_chunk._ts_meta_min_1, compress_hyper_8_18_chunk._ts_meta_max_1
          ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_7_11_chunk (never executed)
                Output: _hyper_7_11_chunk."time", _hyper_7_11_chunk.sensor_id, _hyper_7_11_chunk.cpu, _hyper_7_11_chunk.temperature
-               Sorted merge append: true
+               Batch Sorted Merge: true
                Bulk Decompression: false
                ->  Sort (never executed)
                      Output: compress_hyper_8_17_chunk."time", compress_hyper_8_17_chunk.sensor_id, compress_hyper_8_17_chunk.cpu, compress_hyper_8_17_chunk.temperature, compress_hyper_8_17_chunk._ts_meta_count, compress_hyper_8_17_chunk._ts_meta_sequence_num, compress_hyper_8_17_chunk._ts_meta_min_1, compress_hyper_8_17_chunk._ts_meta_max_1
@@ -1237,7 +1237,7 @@ SELECT * FROM sensor_data ORDER BY time DESC LIMIT 1;
                            Output: compress_hyper_8_17_chunk."time", compress_hyper_8_17_chunk.sensor_id, compress_hyper_8_17_chunk.cpu, compress_hyper_8_17_chunk.temperature, compress_hyper_8_17_chunk._ts_meta_count, compress_hyper_8_17_chunk._ts_meta_sequence_num, compress_hyper_8_17_chunk._ts_meta_min_1, compress_hyper_8_17_chunk._ts_meta_max_1
          ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_7_10_chunk (never executed)
                Output: _hyper_7_10_chunk."time", _hyper_7_10_chunk.sensor_id, _hyper_7_10_chunk.cpu, _hyper_7_10_chunk.temperature
-               Sorted merge append: true
+               Batch Sorted Merge: true
                Bulk Decompression: false
                ->  Sort (never executed)
                      Output: compress_hyper_8_16_chunk."time", compress_hyper_8_16_chunk.sensor_id, compress_hyper_8_16_chunk.cpu, compress_hyper_8_16_chunk.temperature, compress_hyper_8_16_chunk._ts_meta_count, compress_hyper_8_16_chunk._ts_meta_sequence_num, compress_hyper_8_16_chunk._ts_meta_min_1, compress_hyper_8_16_chunk._ts_meta_max_1
@@ -1246,7 +1246,7 @@ SELECT * FROM sensor_data ORDER BY time DESC LIMIT 1;
                            Output: compress_hyper_8_16_chunk."time", compress_hyper_8_16_chunk.sensor_id, compress_hyper_8_16_chunk.cpu, compress_hyper_8_16_chunk.temperature, compress_hyper_8_16_chunk._ts_meta_count, compress_hyper_8_16_chunk._ts_meta_sequence_num, compress_hyper_8_16_chunk._ts_meta_min_1, compress_hyper_8_16_chunk._ts_meta_max_1
          ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_7_9_chunk (never executed)
                Output: _hyper_7_9_chunk."time", _hyper_7_9_chunk.sensor_id, _hyper_7_9_chunk.cpu, _hyper_7_9_chunk.temperature
-               Sorted merge append: true
+               Batch Sorted Merge: true
                Bulk Decompression: false
                ->  Sort (never executed)
                      Output: compress_hyper_8_15_chunk."time", compress_hyper_8_15_chunk.sensor_id, compress_hyper_8_15_chunk.cpu, compress_hyper_8_15_chunk.temperature, compress_hyper_8_15_chunk._ts_meta_count, compress_hyper_8_15_chunk._ts_meta_sequence_num, compress_hyper_8_15_chunk._ts_meta_min_1, compress_hyper_8_15_chunk._ts_meta_max_1
@@ -1255,7 +1255,7 @@ SELECT * FROM sensor_data ORDER BY time DESC LIMIT 1;
                            Output: compress_hyper_8_15_chunk."time", compress_hyper_8_15_chunk.sensor_id, compress_hyper_8_15_chunk.cpu, compress_hyper_8_15_chunk.temperature, compress_hyper_8_15_chunk._ts_meta_count, compress_hyper_8_15_chunk._ts_meta_sequence_num, compress_hyper_8_15_chunk._ts_meta_min_1, compress_hyper_8_15_chunk._ts_meta_max_1
          ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_7_8_chunk (never executed)
                Output: _hyper_7_8_chunk."time", _hyper_7_8_chunk.sensor_id, _hyper_7_8_chunk.cpu, _hyper_7_8_chunk.temperature
-               Sorted merge append: true
+               Batch Sorted Merge: true
                Bulk Decompression: false
                ->  Sort (never executed)
                      Output: compress_hyper_8_14_chunk."time", compress_hyper_8_14_chunk.sensor_id, compress_hyper_8_14_chunk.cpu, compress_hyper_8_14_chunk.temperature, compress_hyper_8_14_chunk._ts_meta_count, compress_hyper_8_14_chunk._ts_meta_sequence_num, compress_hyper_8_14_chunk._ts_meta_min_1, compress_hyper_8_14_chunk._ts_meta_max_1
@@ -1370,7 +1370,7 @@ SELECT time, segment_by, x1 FROM test_costs ORDER BY time DESC;
 --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_9_20_chunk (actual rows=100 loops=1)
    Output: _hyper_9_20_chunk."time", _hyper_9_20_chunk.segment_by, _hyper_9_20_chunk.x1
-   Sorted merge append: true
+   Batch Sorted Merge: true
    Bulk Decompression: false
    ->  Sort (actual rows=100 loops=1)
          Output: compress_hyper_10_21_chunk."time", compress_hyper_10_21_chunk.segment_by, compress_hyper_10_21_chunk.x1, compress_hyper_10_21_chunk._ts_meta_count, compress_hyper_10_21_chunk._ts_meta_sequence_num, compress_hyper_10_21_chunk._ts_meta_min_1, compress_hyper_10_21_chunk._ts_meta_max_1, compress_hyper_10_21_chunk._ts_meta_min_2, compress_hyper_10_21_chunk._ts_meta_max_2
@@ -1434,7 +1434,7 @@ SELECT time, segment_by, x1 FROM test_costs WHERE segment_by > 900 and segment_b
 --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_9_20_chunk (actual rows=98 loops=1)
    Output: _hyper_9_20_chunk."time", _hyper_9_20_chunk.segment_by, _hyper_9_20_chunk.x1
-   Sorted merge append: true
+   Batch Sorted Merge: true
    Bulk Decompression: false
    ->  Sort (actual rows=98 loops=1)
          Output: compress_hyper_10_22_chunk."time", compress_hyper_10_22_chunk.segment_by, compress_hyper_10_22_chunk.x1, compress_hyper_10_22_chunk._ts_meta_count, compress_hyper_10_22_chunk._ts_meta_sequence_num, compress_hyper_10_22_chunk._ts_meta_min_1, compress_hyper_10_22_chunk._ts_meta_max_1, compress_hyper_10_22_chunk._ts_meta_min_2, compress_hyper_10_22_chunk._ts_meta_max_2
@@ -1489,7 +1489,7 @@ SELECT "time","hin"::text,"model"::text,"block"::text,"message_name"::text,"sign
    Output: _hyper_11_23_chunk."time", (_hyper_11_23_chunk.hin)::text, (_hyper_11_23_chunk.model)::text, (_hyper_11_23_chunk.block)::text, (_hyper_11_23_chunk.message_name)::text, (_hyper_11_23_chunk.signal_name)::text, _hyper_11_23_chunk.signal_numeric_value, (_hyper_11_23_chunk.signal_string_value)::text
    ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_11_23_chunk (actual rows=1 loops=1)
          Output: _hyper_11_23_chunk."time", _hyper_11_23_chunk.hin, _hyper_11_23_chunk.model, _hyper_11_23_chunk.block, _hyper_11_23_chunk.message_name, _hyper_11_23_chunk.signal_name, _hyper_11_23_chunk.signal_numeric_value, _hyper_11_23_chunk.signal_string_value
-         Sorted merge append: true
+         Batch Sorted Merge: true
          Bulk Decompression: false
          ->  Sort (actual rows=1 loops=1)
                Output: compress_hyper_12_24_chunk."time", compress_hyper_12_24_chunk.hin, compress_hyper_12_24_chunk.model, compress_hyper_12_24_chunk.block, compress_hyper_12_24_chunk.message_name, compress_hyper_12_24_chunk.signal_name, compress_hyper_12_24_chunk.signal_numeric_value, compress_hyper_12_24_chunk.signal_string_value, compress_hyper_12_24_chunk._ts_meta_count, compress_hyper_12_24_chunk._ts_meta_sequence_num, compress_hyper_12_24_chunk._ts_meta_min_1, compress_hyper_12_24_chunk._ts_meta_max_1

--- a/tsl/test/expected/compression_sorted_merge-16.out
+++ b/tsl/test/expected/compression_sorted_merge-16.out
@@ -1,6 +1,10 @@
 -- This file and its contents are licensed under the Timescale License.
 -- Please see the included NOTICE for copyright information and
 -- LICENSE-TIMESCALE for a copy of the license.
+-- Increase the working memory limit slightly, otherwise the batch sorted merge
+-- will be penalized for segmentby cardinalities larger than 100, where it is
+-- still faster than sort.
+SET work_mem to '16MB';
 \set PREFIX 'EXPLAIN (analyze, verbose, costs off, timing off, summary off)'
 CREATE TABLE test1 (
 time timestamptz NOT NULL,
@@ -824,9 +828,9 @@ SELECT time,x3 FROM test1 ORDER BY time DESC;
 EXPLAIN (verbose) SELECT 1 as one, 2 as two, 3 as three, time, x2 FROM test1 ORDER BY time DESC;
                                                                                                                                                                                                                                                                          QUERY PLAN                                                                                                                                                                                                                                                                          
 -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
- Result  (cost=1.06..38.26 rows=3000 width=24)
+ Result  (cost=1.06..93.44 rows=3000 width=24)
    Output: 1, 2, 3, _hyper_1_1_chunk."time", _hyper_1_1_chunk.x2
-   ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_1_chunk  (cost=1.06..8.26 rows=3000 width=12)
+   ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_1_chunk  (cost=1.06..63.44 rows=3000 width=12)
          Output: _hyper_1_1_chunk."time", _hyper_1_1_chunk.x2
          Sorted merge append: true
          ->  Sort  (cost=0.00..0.00 rows=0 width=0)
@@ -849,9 +853,9 @@ SELECT 1 as one, 2 as two, 3 as three, time, x2 FROM test1 ORDER BY time DESC;
 EXPLAIN (verbose) SELECT 1 as one, 2 as two, 3 as three, x2, time FROM test1 ORDER BY time DESC;
                                                                                                                                                                                                                                                                          QUERY PLAN                                                                                                                                                                                                                                                                          
 -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
- Result  (cost=1.06..38.26 rows=3000 width=24)
+ Result  (cost=1.06..93.44 rows=3000 width=24)
    Output: 1, 2, 3, _hyper_1_1_chunk.x2, _hyper_1_1_chunk."time"
-   ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_1_chunk  (cost=1.06..8.26 rows=3000 width=12)
+   ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_1_chunk  (cost=1.06..63.44 rows=3000 width=12)
          Output: _hyper_1_1_chunk.x2, _hyper_1_1_chunk."time"
          Sorted merge append: true
          ->  Sort  (cost=0.00..0.00 rows=0 width=0)

--- a/tsl/test/expected/compression_sorted_merge_distinct.out
+++ b/tsl/test/expected/compression_sorted_merge_distinct.out
@@ -1,0 +1,118 @@
+-- This file and its contents are licensed under the Timescale License.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-TIMESCALE for a copy of the license.
+-- Test that the compressed batch sorted merge plan is chosen based on the
+-- cardinality of the segmentby columns.
+-- helper function: float -> pseudorandom float [0..1].
+create or replace function mix(x float4) returns float4 as $$ select ((hashfloat4(x) / (pow(2., 31) - 1) + 1) / 2)::float4 $$ language sql;
+create table t(ts timestamp, low_card int, high_card int, value float);
+select create_hypertable('t', 'ts');
+WARNING:  column type "timestamp without time zone" used for "ts" does not follow best practices
+NOTICE:  adding not-null constraint to column "ts"
+ create_hypertable 
+-------------------
+ (1,public,t,t)
+(1 row)
+
+insert into t select
+    '2020-01-01'::timestamp
+        + interval '1 second' * (x + 0.1 * mix(low_card + high_card + x)),
+    low_card,
+    high_card,
+    100 * mix(low_card + high_card) * sin(x / mix(low_card + high_card + 1))
+from generate_series(1, 400) x, generate_series(1, 3) low_card, generate_series(1, 700) high_card;
+alter table t set (timescaledb.compress = true, timescaledb.compress_segmentby = 'low_card,high_card');
+select count(compress_chunk(x, true)) from show_chunks('t') x;
+ count 
+-------
+     1
+(1 row)
+
+analyze t;
+explain (costs off) select * from t order by ts;
+                       QUERY PLAN                        
+---------------------------------------------------------
+ Sort
+   Sort Key: _hyper_1_1_chunk.ts
+   ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk
+         ->  Seq Scan on compress_hyper_2_2_chunk
+(4 rows)
+
+explain (costs off) select * from t where low_card = 1 order by ts;
+                                                        QUERY PLAN                                                        
+--------------------------------------------------------------------------------------------------------------------------
+ Sort
+   Sort Key: _hyper_1_1_chunk.ts
+   ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk
+         ->  Index Scan using compress_hyper_2_2_chunk__compressed_hypertable_2_low_card_high on compress_hyper_2_2_chunk
+               Index Cond: (low_card = 1)
+(5 rows)
+
+explain (costs off) select * from t where high_card = 1 order by ts;
+                                                        QUERY PLAN                                                        
+--------------------------------------------------------------------------------------------------------------------------
+ Custom Scan (DecompressChunk) on _hyper_1_1_chunk
+   ->  Sort
+         Sort Key: compress_hyper_2_2_chunk._ts_meta_min_1
+         ->  Index Scan using compress_hyper_2_2_chunk__compressed_hypertable_2_low_card_high on compress_hyper_2_2_chunk
+               Index Cond: (high_card = 1)
+(5 rows)
+
+explain (costs off) select * from t where low_card = 1 and high_card = 1 order by ts;
+                                                        QUERY PLAN                                                        
+--------------------------------------------------------------------------------------------------------------------------
+ Custom Scan (DecompressChunk) on _hyper_1_1_chunk
+   ->  Sort
+         Sort Key: compress_hyper_2_2_chunk._ts_meta_sequence_num DESC
+         ->  Index Scan using compress_hyper_2_2_chunk__compressed_hypertable_2_low_card_high on compress_hyper_2_2_chunk
+               Index Cond: ((low_card = 1) AND (high_card = 1))
+(5 rows)
+
+-- Test that batch sorted merge is not disabled by enable_sort. We have another
+-- GUC to disable it.
+set enable_sort to off;
+explain (costs off) select * from t where high_card = 1 order by ts;
+                                                        QUERY PLAN                                                        
+--------------------------------------------------------------------------------------------------------------------------
+ Custom Scan (DecompressChunk) on _hyper_1_1_chunk
+   ->  Sort
+         Sort Key: compress_hyper_2_2_chunk._ts_meta_min_1
+         ->  Index Scan using compress_hyper_2_2_chunk__compressed_hypertable_2_low_card_high on compress_hyper_2_2_chunk
+               Index Cond: (high_card = 1)
+(5 rows)
+
+reset enable_sort;
+-- Test that inequality conditions in WHERE also influence the estimates.
+explain (costs off) select * from t where high_card < 10 order by ts;
+                                                        QUERY PLAN                                                        
+--------------------------------------------------------------------------------------------------------------------------
+ Custom Scan (DecompressChunk) on _hyper_1_1_chunk
+   ->  Sort
+         Sort Key: compress_hyper_2_2_chunk._ts_meta_min_1
+         ->  Index Scan using compress_hyper_2_2_chunk__compressed_hypertable_2_low_card_high on compress_hyper_2_2_chunk
+               Index Cond: (high_card < 10)
+(5 rows)
+
+explain (costs off) select * from t where high_card < 500 order by ts;
+                       QUERY PLAN                        
+---------------------------------------------------------
+ Sort
+   Sort Key: _hyper_1_1_chunk.ts
+   ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk
+         ->  Seq Scan on compress_hyper_2_2_chunk
+               Filter: (high_card < 500)
+(5 rows)
+
+-- Test that batch sorted merge respects the working memory limit.
+set work_mem to 64;
+explain (costs off) select * from t where high_card < 10 order by ts;
+                                                        QUERY PLAN                                                        
+--------------------------------------------------------------------------------------------------------------------------
+ Sort
+   Sort Key: _hyper_1_1_chunk.ts
+   ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk
+         ->  Index Scan using compress_hyper_2_2_chunk__compressed_hypertable_2_low_card_high on compress_hyper_2_2_chunk
+               Index Cond: (high_card < 10)
+(5 rows)
+
+reset work_mem;

--- a/tsl/test/expected/transparent_decompression_ordered_index-13.out
+++ b/tsl/test/expected/transparent_decompression_ordered_index-13.out
@@ -527,47 +527,31 @@ ORDER BY time;
                                                 QUERY PLAN                                                
 ----------------------------------------------------------------------------------------------------------
  Sort (actual rows=48 loops=1)
-   Sort Key: mt."time"
+   Sort Key: mt_1."time"
    Sort Method: quicksort 
    ->  Merge Join (actual rows=48 loops=1)
-         Merge Cond: (nd.node = mt.device_id)
-         Join Filter: ((mt."time" > nd.start_time) AND (mt."time" < nd.stop_time))
+         Merge Cond: (nd.node = mt_1.device_id)
+         Join Filter: ((mt_1."time" > nd.start_time) AND (mt_1."time" < nd.stop_time))
          Rows Removed by Join Filter: 289
          ->  Sort (actual rows=1 loops=1)
                Sort Key: nd.node
                Sort Method: quicksort 
                ->  Seq Scan on nodetime nd (actual rows=1 loops=1)
          ->  Sort (actual rows=1250 loops=1)
-               Sort Key: mt.device_id
+               Sort Key: mt_1.device_id
                Sort Method: quicksort 
-               ->  Custom Scan (ChunkAppend) on metrics_ordered_idx mt (actual rows=1541 loops=1)
-                     Order: mt."time"
+               ->  Append (actual rows=1541 loops=1)
                      ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk mt_1 (actual rows=480 loops=1)
-                           ->  Sort (actual rows=5 loops=1)
-                                 Sort Key: compress_hyper_2_6_chunk._ts_meta_min_1
-                                 Sort Method: quicksort 
-                                 ->  Seq Scan on compress_hyper_2_6_chunk (actual rows=5 loops=1)
+                           ->  Seq Scan on compress_hyper_2_6_chunk (actual rows=5 loops=1)
                      ->  Custom Scan (DecompressChunk) on _hyper_1_2_chunk mt_2 (actual rows=960 loops=1)
-                           ->  Sort (actual rows=5 loops=1)
-                                 Sort Key: compress_hyper_2_7_chunk._ts_meta_min_1
-                                 Sort Method: quicksort 
-                                 ->  Seq Scan on compress_hyper_2_7_chunk (actual rows=5 loops=1)
+                           ->  Seq Scan on compress_hyper_2_7_chunk (actual rows=5 loops=1)
                      ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk mt_3 (actual rows=48 loops=1)
-                           ->  Sort (actual rows=1 loops=1)
-                                 Sort Key: compress_hyper_2_8_chunk._ts_meta_min_1
-                                 Sort Method: quicksort 
-                                 ->  Seq Scan on compress_hyper_2_8_chunk (actual rows=1 loops=1)
+                           ->  Seq Scan on compress_hyper_2_8_chunk (actual rows=1 loops=1)
                      ->  Custom Scan (DecompressChunk) on _hyper_1_4_chunk mt_4 (actual rows=48 loops=1)
-                           ->  Sort (actual rows=1 loops=1)
-                                 Sort Key: compress_hyper_2_9_chunk._ts_meta_min_1
-                                 Sort Method: quicksort 
-                                 ->  Seq Scan on compress_hyper_2_9_chunk (actual rows=1 loops=1)
+                           ->  Seq Scan on compress_hyper_2_9_chunk (actual rows=1 loops=1)
                      ->  Custom Scan (DecompressChunk) on _hyper_1_5_chunk mt_5 (actual rows=5 loops=1)
-                           ->  Sort (actual rows=5 loops=1)
-                                 Sort Key: compress_hyper_2_10_chunk._ts_meta_min_1
-                                 Sort Method: quicksort 
-                                 ->  Seq Scan on compress_hyper_2_10_chunk (actual rows=5 loops=1)
-(41 rows)
+                           ->  Seq Scan on compress_hyper_2_10_chunk (actual rows=5 loops=1)
+(25 rows)
 
 SET enable_mergejoin = FALSE;
 SET enable_hashjoin = TRUE;

--- a/tsl/test/expected/transparent_decompression_ordered_index-14.out
+++ b/tsl/test/expected/transparent_decompression_ordered_index-14.out
@@ -527,47 +527,31 @@ ORDER BY time;
                                                 QUERY PLAN                                                
 ----------------------------------------------------------------------------------------------------------
  Sort (actual rows=48 loops=1)
-   Sort Key: mt."time"
+   Sort Key: mt_1."time"
    Sort Method: quicksort 
    ->  Merge Join (actual rows=48 loops=1)
-         Merge Cond: (nd.node = mt.device_id)
-         Join Filter: ((mt."time" > nd.start_time) AND (mt."time" < nd.stop_time))
+         Merge Cond: (nd.node = mt_1.device_id)
+         Join Filter: ((mt_1."time" > nd.start_time) AND (mt_1."time" < nd.stop_time))
          Rows Removed by Join Filter: 289
          ->  Sort (actual rows=1 loops=1)
                Sort Key: nd.node
                Sort Method: quicksort 
                ->  Seq Scan on nodetime nd (actual rows=1 loops=1)
          ->  Sort (actual rows=1250 loops=1)
-               Sort Key: mt.device_id
+               Sort Key: mt_1.device_id
                Sort Method: quicksort 
-               ->  Custom Scan (ChunkAppend) on metrics_ordered_idx mt (actual rows=1541 loops=1)
-                     Order: mt."time"
+               ->  Append (actual rows=1541 loops=1)
                      ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk mt_1 (actual rows=480 loops=1)
-                           ->  Sort (actual rows=5 loops=1)
-                                 Sort Key: compress_hyper_2_6_chunk._ts_meta_min_1
-                                 Sort Method: quicksort 
-                                 ->  Seq Scan on compress_hyper_2_6_chunk (actual rows=5 loops=1)
+                           ->  Seq Scan on compress_hyper_2_6_chunk (actual rows=5 loops=1)
                      ->  Custom Scan (DecompressChunk) on _hyper_1_2_chunk mt_2 (actual rows=960 loops=1)
-                           ->  Sort (actual rows=5 loops=1)
-                                 Sort Key: compress_hyper_2_7_chunk._ts_meta_min_1
-                                 Sort Method: quicksort 
-                                 ->  Seq Scan on compress_hyper_2_7_chunk (actual rows=5 loops=1)
+                           ->  Seq Scan on compress_hyper_2_7_chunk (actual rows=5 loops=1)
                      ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk mt_3 (actual rows=48 loops=1)
-                           ->  Sort (actual rows=1 loops=1)
-                                 Sort Key: compress_hyper_2_8_chunk._ts_meta_min_1
-                                 Sort Method: quicksort 
-                                 ->  Seq Scan on compress_hyper_2_8_chunk (actual rows=1 loops=1)
+                           ->  Seq Scan on compress_hyper_2_8_chunk (actual rows=1 loops=1)
                      ->  Custom Scan (DecompressChunk) on _hyper_1_4_chunk mt_4 (actual rows=48 loops=1)
-                           ->  Sort (actual rows=1 loops=1)
-                                 Sort Key: compress_hyper_2_9_chunk._ts_meta_min_1
-                                 Sort Method: quicksort 
-                                 ->  Seq Scan on compress_hyper_2_9_chunk (actual rows=1 loops=1)
+                           ->  Seq Scan on compress_hyper_2_9_chunk (actual rows=1 loops=1)
                      ->  Custom Scan (DecompressChunk) on _hyper_1_5_chunk mt_5 (actual rows=5 loops=1)
-                           ->  Sort (actual rows=5 loops=1)
-                                 Sort Key: compress_hyper_2_10_chunk._ts_meta_min_1
-                                 Sort Method: quicksort 
-                                 ->  Seq Scan on compress_hyper_2_10_chunk (actual rows=5 loops=1)
-(41 rows)
+                           ->  Seq Scan on compress_hyper_2_10_chunk (actual rows=5 loops=1)
+(25 rows)
 
 SET enable_mergejoin = FALSE;
 SET enable_hashjoin = TRUE;

--- a/tsl/test/expected/transparent_decompression_ordered_index-15.out
+++ b/tsl/test/expected/transparent_decompression_ordered_index-15.out
@@ -529,47 +529,31 @@ ORDER BY time;
                                                 QUERY PLAN                                                
 ----------------------------------------------------------------------------------------------------------
  Sort (actual rows=48 loops=1)
-   Sort Key: mt."time"
+   Sort Key: mt_1."time"
    Sort Method: quicksort 
    ->  Merge Join (actual rows=48 loops=1)
-         Merge Cond: (nd.node = mt.device_id)
-         Join Filter: ((mt."time" > nd.start_time) AND (mt."time" < nd.stop_time))
+         Merge Cond: (nd.node = mt_1.device_id)
+         Join Filter: ((mt_1."time" > nd.start_time) AND (mt_1."time" < nd.stop_time))
          Rows Removed by Join Filter: 289
          ->  Sort (actual rows=1 loops=1)
                Sort Key: nd.node
                Sort Method: quicksort 
                ->  Seq Scan on nodetime nd (actual rows=1 loops=1)
          ->  Sort (actual rows=1250 loops=1)
-               Sort Key: mt.device_id
+               Sort Key: mt_1.device_id
                Sort Method: quicksort 
-               ->  Custom Scan (ChunkAppend) on metrics_ordered_idx mt (actual rows=1541 loops=1)
-                     Order: mt."time"
+               ->  Append (actual rows=1541 loops=1)
                      ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk mt_1 (actual rows=480 loops=1)
-                           ->  Sort (actual rows=5 loops=1)
-                                 Sort Key: compress_hyper_2_6_chunk._ts_meta_min_1
-                                 Sort Method: quicksort 
-                                 ->  Seq Scan on compress_hyper_2_6_chunk (actual rows=5 loops=1)
+                           ->  Seq Scan on compress_hyper_2_6_chunk (actual rows=5 loops=1)
                      ->  Custom Scan (DecompressChunk) on _hyper_1_2_chunk mt_2 (actual rows=960 loops=1)
-                           ->  Sort (actual rows=5 loops=1)
-                                 Sort Key: compress_hyper_2_7_chunk._ts_meta_min_1
-                                 Sort Method: quicksort 
-                                 ->  Seq Scan on compress_hyper_2_7_chunk (actual rows=5 loops=1)
+                           ->  Seq Scan on compress_hyper_2_7_chunk (actual rows=5 loops=1)
                      ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk mt_3 (actual rows=48 loops=1)
-                           ->  Sort (actual rows=1 loops=1)
-                                 Sort Key: compress_hyper_2_8_chunk._ts_meta_min_1
-                                 Sort Method: quicksort 
-                                 ->  Seq Scan on compress_hyper_2_8_chunk (actual rows=1 loops=1)
+                           ->  Seq Scan on compress_hyper_2_8_chunk (actual rows=1 loops=1)
                      ->  Custom Scan (DecompressChunk) on _hyper_1_4_chunk mt_4 (actual rows=48 loops=1)
-                           ->  Sort (actual rows=1 loops=1)
-                                 Sort Key: compress_hyper_2_9_chunk._ts_meta_min_1
-                                 Sort Method: quicksort 
-                                 ->  Seq Scan on compress_hyper_2_9_chunk (actual rows=1 loops=1)
+                           ->  Seq Scan on compress_hyper_2_9_chunk (actual rows=1 loops=1)
                      ->  Custom Scan (DecompressChunk) on _hyper_1_5_chunk mt_5 (actual rows=5 loops=1)
-                           ->  Sort (actual rows=5 loops=1)
-                                 Sort Key: compress_hyper_2_10_chunk._ts_meta_min_1
-                                 Sort Method: quicksort 
-                                 ->  Seq Scan on compress_hyper_2_10_chunk (actual rows=5 loops=1)
-(41 rows)
+                           ->  Seq Scan on compress_hyper_2_10_chunk (actual rows=5 loops=1)
+(25 rows)
 
 SET enable_mergejoin = FALSE;
 SET enable_hashjoin = TRUE;

--- a/tsl/test/expected/transparent_decompression_ordered_index-16.out
+++ b/tsl/test/expected/transparent_decompression_ordered_index-16.out
@@ -529,47 +529,31 @@ ORDER BY time;
                                                 QUERY PLAN                                                
 ----------------------------------------------------------------------------------------------------------
  Sort (actual rows=48 loops=1)
-   Sort Key: mt."time"
+   Sort Key: mt_1."time"
    Sort Method: quicksort 
    ->  Merge Join (actual rows=48 loops=1)
-         Merge Cond: (nd.node = mt.device_id)
-         Join Filter: ((mt."time" > nd.start_time) AND (mt."time" < nd.stop_time))
+         Merge Cond: (nd.node = mt_1.device_id)
+         Join Filter: ((mt_1."time" > nd.start_time) AND (mt_1."time" < nd.stop_time))
          Rows Removed by Join Filter: 289
          ->  Sort (actual rows=1 loops=1)
                Sort Key: nd.node
                Sort Method: quicksort 
                ->  Seq Scan on nodetime nd (actual rows=1 loops=1)
          ->  Sort (actual rows=1250 loops=1)
-               Sort Key: mt.device_id
+               Sort Key: mt_1.device_id
                Sort Method: quicksort 
-               ->  Custom Scan (ChunkAppend) on metrics_ordered_idx mt (actual rows=1541 loops=1)
-                     Order: mt."time"
+               ->  Append (actual rows=1541 loops=1)
                      ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk mt_1 (actual rows=480 loops=1)
-                           ->  Sort (actual rows=5 loops=1)
-                                 Sort Key: compress_hyper_2_6_chunk._ts_meta_min_1
-                                 Sort Method: quicksort 
-                                 ->  Seq Scan on compress_hyper_2_6_chunk (actual rows=5 loops=1)
+                           ->  Seq Scan on compress_hyper_2_6_chunk (actual rows=5 loops=1)
                      ->  Custom Scan (DecompressChunk) on _hyper_1_2_chunk mt_2 (actual rows=960 loops=1)
-                           ->  Sort (actual rows=5 loops=1)
-                                 Sort Key: compress_hyper_2_7_chunk._ts_meta_min_1
-                                 Sort Method: quicksort 
-                                 ->  Seq Scan on compress_hyper_2_7_chunk (actual rows=5 loops=1)
+                           ->  Seq Scan on compress_hyper_2_7_chunk (actual rows=5 loops=1)
                      ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk mt_3 (actual rows=48 loops=1)
-                           ->  Sort (actual rows=1 loops=1)
-                                 Sort Key: compress_hyper_2_8_chunk._ts_meta_min_1
-                                 Sort Method: quicksort 
-                                 ->  Seq Scan on compress_hyper_2_8_chunk (actual rows=1 loops=1)
+                           ->  Seq Scan on compress_hyper_2_8_chunk (actual rows=1 loops=1)
                      ->  Custom Scan (DecompressChunk) on _hyper_1_4_chunk mt_4 (actual rows=48 loops=1)
-                           ->  Sort (actual rows=1 loops=1)
-                                 Sort Key: compress_hyper_2_9_chunk._ts_meta_min_1
-                                 Sort Method: quicksort 
-                                 ->  Seq Scan on compress_hyper_2_9_chunk (actual rows=1 loops=1)
+                           ->  Seq Scan on compress_hyper_2_9_chunk (actual rows=1 loops=1)
                      ->  Custom Scan (DecompressChunk) on _hyper_1_5_chunk mt_5 (actual rows=5 loops=1)
-                           ->  Sort (actual rows=5 loops=1)
-                                 Sort Key: compress_hyper_2_10_chunk._ts_meta_min_1
-                                 Sort Method: quicksort 
-                                 ->  Seq Scan on compress_hyper_2_10_chunk (actual rows=5 loops=1)
-(41 rows)
+                           ->  Seq Scan on compress_hyper_2_10_chunk (actual rows=5 loops=1)
+(25 rows)
 
 SET enable_mergejoin = FALSE;
 SET enable_hashjoin = TRUE;

--- a/tsl/test/expected/transparent_decompression_queries.out
+++ b/tsl/test/expected/transparent_decompression_queries.out
@@ -182,17 +182,17 @@ WHERE check_equal_228(rtt) ORDER BY ts;
 EXPLAIN (analyze,costs off,timing off,summary off)
 SELECT * from test_chartab
 WHERE check_equal_228(rtt) and ts < '2019-12-15 00:00:00' order by ts;
-                                                QUERY PLAN                                                 
------------------------------------------------------------------------------------------------------------
- Custom Scan (ChunkAppend) on test_chartab (actual rows=1 loops=1)
-   Order: test_chartab.ts
-   Chunks excluded during startup: 0
-   ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk (actual rows=1 loops=1)
-         Filter: ((ts < 'Sun Dec 15 00:00:00 2019'::timestamp without time zone) AND check_equal_228(rtt))
-         Rows Removed by Filter: 2
-         ->  Sort (actual rows=3 loops=1)
-               Sort Key: compress_hyper_2_3_chunk._ts_meta_min_1
-               Sort Method: quicksort 
+                                               QUERY PLAN                                               
+--------------------------------------------------------------------------------------------------------
+ Sort (actual rows=1 loops=1)
+   Sort Key: test_chartab.ts
+   Sort Method: quicksort 
+   ->  Custom Scan (ChunkAppend) on test_chartab (actual rows=1 loops=1)
+         Chunks excluded during startup: 0
+         ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk (actual rows=1 loops=1)
+               Filter: check_equal_228(rtt)
+               Rows Removed by Filter: 2
+               Vectorized Filter: (ts < 'Sun Dec 15 00:00:00 2019'::timestamp without time zone)
                ->  Seq Scan on compress_hyper_2_3_chunk (actual rows=3 loops=1)
                      Filter: (_ts_meta_min_1 < 'Sun Dec 15 00:00:00 2019'::timestamp without time zone)
 (11 rows)

--- a/tsl/test/sql/CMakeLists.txt
+++ b/tsl/test/sql/CMakeLists.txt
@@ -20,6 +20,7 @@ set(TEST_FILES
     compression_insert.sql
     compression_policy.sql
     compression_qualpushdown.sql
+    compression_sorted_merge_distinct.sql
     decompress_index.sql
     exp_cagg_monthly.sql
     exp_cagg_next_gen.sql

--- a/tsl/test/sql/compress_sorted_merge_filter.sql
+++ b/tsl/test/sql/compress_sorted_merge_filter.sql
@@ -17,6 +17,7 @@ select compress_chunk(x, true) from show_chunks('batches') x;
 analyze batches;
 
 set timescaledb.debug_require_batch_sorted_merge to true;
+set enable_sort to off;
 
 select ts from batches where ts != '2022-02-02 00:00:02' order by ts;
 

--- a/tsl/test/sql/compression.sql
+++ b/tsl/test/sql/compression.sql
@@ -1023,6 +1023,9 @@ INSERT INTO sensor_data_compressed (time, sensor_id, cpu, temperature)
 
 ALTER TABLE sensor_data_compressed SET (timescaledb.compress, timescaledb.compress_segmentby='sensor_id', timescaledb.compress_orderby = 'time DESC');
 
+-- Increase work_mem slightly so that the batch sorted merge plan is not disabled.
+SET work_mem = '16MB';
+
 -- Compress three of the chunks
 SELECT compress_chunk(ch) FROM show_chunks('sensor_data_compressed') ch LIMIT 3;
 ANALYZE sensor_data_compressed;

--- a/tsl/test/sql/compression.sql
+++ b/tsl/test/sql/compression.sql
@@ -1032,11 +1032,11 @@ ANALYZE sensor_data_compressed;
 
 SELECT * FROM sensor_data_compressed ORDER BY time DESC LIMIT 5;
 
--- Only the first chunks should be accessed (sorted merge append is enabled)
+-- Only the first chunks should be accessed (batch sorted merge is enabled)
 :PREFIX
 SELECT * FROM sensor_data_compressed ORDER BY time DESC LIMIT 5;
 
--- Only the first chunks should be accessed (sorted merge append is disabled)
+-- Only the first chunks should be accessed (batch sorted merge is disabled)
 SET timescaledb.enable_decompression_sorted_merge = FALSE;
 :PREFIX
 SELECT * FROM sensor_data_compressed ORDER BY time DESC LIMIT 5;
@@ -1047,11 +1047,11 @@ SELECT compress_chunk(ch, if_not_compressed => true) FROM show_chunks('sensor_da
 
 SELECT * FROM sensor_data_compressed ORDER BY time DESC LIMIT 5;
 
--- Only the first chunks should be accessed (sorted merge append is enabled)
+-- Only the first chunks should be accessed (batch sorted merge is enabled)
 :PREFIX
 SELECT * FROM sensor_data_compressed ORDER BY time DESC LIMIT 5;
 
--- Only the first chunks should be accessed (sorted merge append is disabled)
+-- Only the first chunks should be accessed (batch sorted merge is disabled)
 SET timescaledb.enable_decompression_sorted_merge = FALSE;
 :PREFIX
 SELECT * FROM sensor_data_compressed ORDER BY time DESC LIMIT 5;
@@ -1061,11 +1061,11 @@ RESET timescaledb.enable_decompression_sorted_merge;
 INSERT INTO sensor_data_compressed (time, sensor_id, cpu, temperature)
    VALUES ('1980-01-02 01:00:00-00', 2, 4, 14.0);
 
--- Only the first chunks should be accessed (sorted merge append is enabled)
+-- Only the first chunks should be accessed (batch sorted merge is enabled)
 :PREFIX
 SELECT * FROM sensor_data_compressed ORDER BY time DESC LIMIT 5;
 
--- Only the first chunks should be accessed (sorted merge append is disabled)
+-- Only the first chunks should be accessed (batch sorted merge is disabled)
 SET timescaledb.enable_decompression_sorted_merge = FALSE;
 :PREFIX
 SELECT * FROM sensor_data_compressed ORDER BY time DESC LIMIT 5;

--- a/tsl/test/sql/compression_sorted_merge.sql.in
+++ b/tsl/test/sql/compression_sorted_merge.sql.in
@@ -2,6 +2,11 @@
 -- Please see the included NOTICE for copyright information and
 -- LICENSE-TIMESCALE for a copy of the license.
 
+-- Increase the working memory limit slightly, otherwise the batch sorted merge
+-- will be penalized for segmentby cardinalities larger than 100, where it is
+-- still faster than sort.
+SET work_mem to '16MB';
+
 \set PREFIX 'EXPLAIN (analyze, verbose, costs off, timing off, summary off)'
 
 CREATE TABLE test1 (

--- a/tsl/test/sql/compression_sorted_merge_distinct.sql
+++ b/tsl/test/sql/compression_sorted_merge_distinct.sql
@@ -1,0 +1,45 @@
+-- This file and its contents are licensed under the Timescale License.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-TIMESCALE for a copy of the license.
+
+-- Test that the compressed batch sorted merge plan is chosen based on the
+-- cardinality of the segmentby columns.
+
+-- helper function: float -> pseudorandom float [0..1].
+create or replace function mix(x float4) returns float4 as $$ select ((hashfloat4(x) / (pow(2., 31) - 1) + 1) / 2)::float4 $$ language sql;
+
+create table t(ts timestamp, low_card int, high_card int, value float);
+select create_hypertable('t', 'ts');
+
+insert into t select
+    '2020-01-01'::timestamp
+        + interval '1 second' * (x + 0.1 * mix(low_card + high_card + x)),
+    low_card,
+    high_card,
+    100 * mix(low_card + high_card) * sin(x / mix(low_card + high_card + 1))
+from generate_series(1, 400) x, generate_series(1, 3) low_card, generate_series(1, 700) high_card;
+
+alter table t set (timescaledb.compress = true, timescaledb.compress_segmentby = 'low_card,high_card');
+select count(compress_chunk(x, true)) from show_chunks('t') x;
+analyze t;
+
+explain (costs off) select * from t order by ts;
+explain (costs off) select * from t where low_card = 1 order by ts;
+explain (costs off) select * from t where high_card = 1 order by ts;
+explain (costs off) select * from t where low_card = 1 and high_card = 1 order by ts;
+
+-- Test that batch sorted merge is not disabled by enable_sort. We have another
+-- GUC to disable it.
+set enable_sort to off;
+explain (costs off) select * from t where high_card = 1 order by ts;
+reset enable_sort;
+
+-- Test that inequality conditions in WHERE also influence the estimates.
+explain (costs off) select * from t where high_card < 10 order by ts;
+explain (costs off) select * from t where high_card < 500 order by ts;
+
+
+-- Test that batch sorted merge respects the working memory limit.
+set work_mem to 64;
+explain (costs off) select * from t where high_card < 10 order by ts;
+reset work_mem;


### PR DESCRIPTION
This PR makes several modifications to the cost model of batch sorted merge, that should allow us to apply it in more cases where it's beneficial:

1. When doing batch sorted merge, we have to hold the latest batch open for each distinct value of segmentby columns. This commit adds estimation for this number with the usual Postgres estimators for grouping cardinality.
 1. The number of open batches is used to estimates the amount of required memory. If it is above `work_mem`, the batch sorted merge cost is penalized.
 1. The cost function is changed to `O(uncompressed_rows * log(open_batches))`, which reflects the nature of the algorithm. 


Disable-check: force-changelog-file
Disable-check: commit-count