### PR TITLE
Remove superfluous checks in partialize_agg

### DIFF
--- a/tsl/src/partialize_agg.c
+++ b/tsl/src/partialize_agg.c
@@ -46,12 +46,14 @@ is_vectorizable_agg_path(PlannerInfo *root, AggPath *agg_path, Path *path)
 	if (!is_decompress_chunk)
 		return false;
 
+#ifdef USE_ASSERT_CHECKING
 	DecompressChunkPath *decompress_path = (DecompressChunkPath *) path;
 	Assert(decompress_path->custom_path.custom_paths != NIL);
 
 	/* Hypertable compression info is already fetched from the catalog */
 	Assert(decompress_path->info != NULL);
 	Assert(decompress_path->info->hypertable_compression_info != NULL);
+#endif
 
 	/* No filters on the compressed attributes are supported at the moment */
 	if ((list_length(path->parent->baserestrictinfo) > 0 || path->parent->joininfo != NULL))
@@ -74,55 +76,6 @@ is_vectorizable_agg_path(PlannerInfo *root, AggPath *agg_path, Path *path)
 
 	if (aggref->aggfnoid != F_SUM_INT4)
 		return false;
-
-	/*
-	 * Check that the input columns of the aggregate can be processed by our vectorized
-	 * implementation. This is possible for (1) segment_by columns and (2) for columns which allow
-	 * bulk decompression.
-	 *
-	 * Bulk decompression is needed to produce the ArrowArray and perform the vectorized operations.
-	 * Bulk decompression should always be possible in the current implementation since we check for
-	 * the data type above. However, when we lift the restriction, the check becomes necessary.
-	 *
-	 * Note: decompress_path->bulk_decompression_column is not populated at this point. So, we have
-	 * to get this data from hypertable_compression_info.
-	 */
-	ListCell *lc;
-	foreach (lc, aggref->args)
-	{
-		Node *agg_arg = lfirst(lc);
-
-		if (!IsA(agg_arg, TargetEntry))
-			return false;
-
-		TargetEntry *target_entry = castNode(TargetEntry, agg_arg);
-
-		if (!IsA(target_entry->expr, Var))
-			continue;
-
-		Var *var = castNode(Var, target_entry->expr);
-
-		/* Agg input var is on the compressed relation */
-		Assert((Index) var->varno == path->parent->relid);
-		Assert((Index) var->varno == decompress_path->info->chunk_rel->relid);
-
-		char *column_name =
-			get_attname(decompress_path->info->chunk_rte->relid, var->varattno, false);
-
-		FormData_hypertable_compression *ci =
-			get_column_compressioninfo(decompress_path->info->hypertable_compression_info,
-									   column_name);
-		Assert(ci);
-
-		/* If this is a segment_by value, allow vectorization for sum */
-		if (ci->segmentby_column_index > 0)
-			continue;
-
-		bool bulk_decompression_possible = (tsl_get_decompress_all_function(ci->algo_id) != NULL);
-
-		if (!bulk_decompression_possible)
-			return false;
-	}
 
 	return true;
 }


### PR DESCRIPTION
Remove checks that will always return true in current implementation to make refactoring easier. Aggref->args will always be list of TargetEntry, and the bulk_decompression check will always return true as well.

Disable-check: force-changelog-file
