### PR TITLE
Reset compressor between recompression runs

### DIFF
--- a/tsl/src/compression/api.c
+++ b/tsl/src/compression/api.c
@@ -1500,6 +1500,7 @@ tsl_recompress_chunk_segmentwise(PG_FUNCTION_ARGS)
 
 			tuplesort_performsort(segment_tuplesortstate);
 
+			row_compressor_reset(&row_compressor);
 			recompress_segment(segment_tuplesortstate, uncompressed_chunk_rel, &row_compressor);
 
 			/* now any pointers returned will be garbage */
@@ -1556,6 +1557,7 @@ tsl_recompress_chunk_segmentwise(PG_FUNCTION_ARGS)
 														 uncompressed_chunk_rel,
 														 current_segment);
 		tuplesort_performsort(segment_tuplesortstate);
+		row_compressor_reset(&row_compressor);
 		recompress_segment(segment_tuplesortstate, uncompressed_chunk_rel, &row_compressor);
 		tuplesort_end(segment_tuplesortstate);
 
@@ -1582,6 +1584,7 @@ tsl_recompress_chunk_segmentwise(PG_FUNCTION_ARGS)
 	if (unmatched_rows_exist)
 	{
 		tuplesort_performsort(segment_tuplesortstate);
+		row_compressor_reset(&row_compressor);
 		row_compressor_append_sorted_rows(&row_compressor,
 										  segment_tuplesortstate,
 										  RelationGetDescr(uncompressed_chunk_rel));

--- a/tsl/src/compression/compression.c
+++ b/tsl/src/compression/compression.c
@@ -1293,6 +1293,12 @@ row_compressor_flush(RowCompressor *row_compressor, CommandId mycid, bool change
 }
 
 void
+row_compressor_reset(RowCompressor *row_compressor)
+{
+	row_compressor->first_iteration = true;
+}
+
+void
 row_compressor_finish(RowCompressor *row_compressor)
 {
 	if (row_compressor->bistate)

--- a/tsl/src/compression/compression.h
+++ b/tsl/src/compression/compression.h
@@ -359,6 +359,7 @@ extern void row_compressor_init(RowCompressor *row_compressor, TupleDesc uncompr
 								const ColumnCompressionInfo **column_compression_info,
 								int16 *column_offsets, int16 num_columns_in_compressed_table,
 								bool need_bistate, bool reset_sequence, int insert_options);
+extern void row_compressor_reset(RowCompressor *row_compressor);
 extern void row_compressor_finish(RowCompressor *row_compressor);
 extern void row_compressor_append_sorted_rows(RowCompressor *row_compressor,
 											  Tuplesortstate *sorted_rel, TupleDesc sorted_desc);


### PR DESCRIPTION
If we reuse the compressor to recompress multiple sets of tuples, internal state gets left behind from the previous run which can contain invalid data. Resetting the compressor first iteration field between runs fixes this.

Issue was caught by the sanitizer run with the following stacktrace:
```
#10 0x00005592c652336d in toast_raw_datum_size (value=108370616179040)
    at detoast.c:550
        attr = 0x62900014d960
        result = <optimized out>
#11 0x00005592c8093bfe in texteq (fcinfo=0x62900014c2f8) at varlena.c:1799
        arg1 = 108370616179040
        arg2 = 108095738524216
        len1 = <optimized out>
        len2 = <optimized out>
        collid = <optimized out>
        result = <optimized out>
#12 0x00007f40a20e230a in segment_info_datum_is_in_group (
    segment_info=segment_info@entry=0x625000185868, datum=<optimized out>, 
    is_null=<optimized out>)
    at /home/runner/work/timescaledb/timescaledb/tsl/src/compression/compression.c:1366
        eq_fcinfo = 0x62900014c2f8
        data_is_eq = <optimized out>
#13 0x00007f40a20eeb72 in row_compressor_new_row_is_in_new_group (
    row_compressor=0x7f40ada7a160, row=<optimized out>)
    at /home/runner/work/timescaledb/timescaledb/tsl/src/compression/compression.c:1110
        column = <optimized out>
        datum = <optimized out>
        is_null = <optimized out>
        col = 1
```

Issue happened because the compressor was reused multiple times on different set of tuples which were removed from the current memory context and also used in the internal state of the compressor.

Disable-check: force-changelog-file