### PR TITLE
Fix ts_array_position when entry is not found

### DIFF
--- a/src/ts_catalog/array_utils.h
+++ b/src/ts_catalog/array_utils.h
@@ -18,3 +18,5 @@
 extern TSDLLEXPORT int ts_array_length(ArrayType *arr);
 extern TSDLLEXPORT bool ts_array_is_member(ArrayType *arr, const char *name);
 extern TSDLLEXPORT int ts_array_position(ArrayType *arr, const char *name);
+extern TSDLLEXPORT bool ts_array_get_element_bool(ArrayType *arr, int position);
+extern TSDLLEXPORT const char *ts_array_get_element_text(ArrayType *arr, int position);


### PR DESCRIPTION
This patch fixes ts_array_position when the entry was not found. Previously it would return the position of the last element in that case. This patch also adds a NULL check to ts_array_length and an Assert for TEXT array to ts_array_is_member and ts_array_position. Current code should not be affected by any of these changes.

Disable-check: force-changelog-file
