### PR TITLE
Add missing new lines to changelog script

### DIFF
--- a/scripts/merge_changelogs.sh
+++ b/scripts/merge_changelogs.sh
@@ -3,9 +3,12 @@
 # skip the template file
 echo "**Features**"
 grep -i '^Implements:' .unreleased/* | grep -v '.unreleased/template.rfc822' | cut -d: -f3- | sort | uniq | sed -e 's/^[[:space:]]*//' -e 's/^/* /'
+echo
 
 echo "**Bugfixes**"
 grep -i '^Fixes:' .unreleased/* | grep -v '.unreleased/template.rfc822' | cut -d: -f3- | sort | uniq | sed -e 's/^[[:space:]]*//' -e 's/^/* /'
+echo
 
 echo "**Thanks**"
 grep -i '^Thanks:' .unreleased/* | grep -v '.unreleased/template.rfc822' | cut -d: -f3- | sort | sed -e 's/^[[:space:]]*//' -e 's/^/* /'
+echo


### PR DESCRIPTION
Our changelog contains empty lines between the version sections. These empty lines were missing in the script output so far.

---
Disable-check: force-changelog-file
