### PR TITLE
Adjust required CMake version

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.10)
+cmake_minimum_required(VERSION 3.15)
 
 list(APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/cmake)
 


### PR DESCRIPTION
Since a664e685cd, we are using the PREPEND statement in our CMake files, which was added in CMake 3.15. This PR adjusts the required CMake version.

---
See: https://cmake.org/cmake/help/latest/release/3.15.html
Disable-check: force-changelog-file
