### PR TITLE
Upgrade PostgreSQL versions on Windows

### DIFF
--- a/.github/workflows/windows-packages.yaml
+++ b/.github/workflows/windows-packages.yaml
@@ -50,13 +50,13 @@ jobs:
             pkg_version: ${{ fromJson(needs.config.outputs.pg14_earliest) }}.1
           - test: 14max
             pg: 14
-            pkg_version: 14.5.1 # hardcoded due to issues with PG14.7 on chocolatey
+            pkg_version: 14.9 # hardcoded since 14.10 is not available on chocolatey
           - test: 15min
             pg: 15
             pkg_version: ${{ fromJson(needs.config.outputs.pg15_earliest) }}.1
           - test: 15max
             pg: 15
-            pkg_version: 15.0.1 # hardcoded due to issues with PG15.2 on chocolatey
+            pkg_version: 15.4 # hardcoded since 15.5 is not available on chocolatey
     env:
       # PostgreSQL configuration
       PGPORT: 6543


### PR DESCRIPTION
Due to some issues, we used some hard-coded versions for the Windows tests. Chocolatey released new versions for Windows and this patch upgrades some of the hard-coded values.

---
Disable-check: force-changelog-file