### PR TITLE
Fix CAgg bucket function metadata

### DIFF
--- a/tsl/src/continuous_aggs/create.c
+++ b/tsl/src/continuous_aggs/create.c
@@ -856,9 +856,18 @@ cagg_create(const CreateTableAsStmt *create_stmt, ViewStmt *stmt, Query *panquer
 		 * Until then the choice was made in favor of the most generic schema
 		 * that can be optimized later.
 		 */
+		Oid bucket_func_schema_oid = get_func_namespace(bucket_info->bucket_func->funcid);
+		Ensure(OidIsValid(bucket_func_schema_oid),
+			   "namespace for funcid %d not found",
+			   bucket_info->bucket_func->funcid);
+		char *bucket_func_schema_name = get_namespace_name(bucket_func_schema_oid);
+		Ensure(bucket_func_schema_name != NULL,
+			   "unable to get namespace name for Oid %d",
+			   bucket_func_schema_oid);
+		bool is_experimental =
+			(strncmp(bucket_func_schema_name, EXPERIMENTAL_SCHEMA_NAME, NAMEDATALEN) == 0);
 		create_bucket_function_catalog_entry(materialize_hypertable_id,
-											 get_func_namespace(bucket_info->bucket_func->funcid) !=
-												 PG_PUBLIC_NAMESPACE,
+											 is_experimental,
 											 get_func_name(bucket_info->bucket_func->funcid),
 											 bucket_width,
 											 origin,

--- a/tsl/test/expected/exp_cagg_next_gen.out
+++ b/tsl/test/expected/exp_cagg_next_gen.out
@@ -140,3 +140,52 @@ NOTICE:  drop cascades to 9 other objects
 NOTICE:  drop cascades to table _timescaledb_internal._hyper_4_18_chunk
 NOTICE:  drop cascades to table _timescaledb_internal._hyper_5_19_chunk
 NOTICE:  drop cascades to table _timescaledb_internal._hyper_6_20_chunk
+-- Experimental functions using different schema for installation than PUBLIC
+\c :TEST_DBNAME :ROLE_SUPERUSER
+CREATE DATABASE test;
+\c test :ROLE_SUPERUSER
+CREATE SCHEMA test;
+SET client_min_messages TO ERROR;
+CREATE EXTENSION timescaledb SCHEMA test;
+CREATE TABLE conditions(
+  tstamp TIMESTAMP NOT NULL,
+  city text NOT NULL,
+  temperature INT NOT NULL);
+SELECT test.create_hypertable(
+  'conditions', 'tstamp',
+  chunk_time_interval => INTERVAL '1 day'
+);
+    create_hypertable    
+-------------------------
+ (1,public,conditions,t)
+(1 row)
+
+CREATE MATERIALIZED VIEW conditions_summary_monthly
+WITH (timescaledb.continuous) AS
+SELECT city,
+       timescaledb_experimental.time_bucket_ng('1 month', tstamp) AS bucket,
+       MIN(temperature),
+       MAX(temperature)
+FROM conditions
+GROUP BY city, bucket
+WITH NO DATA;
+CREATE MATERIALIZED VIEW conditions_summary_yearly
+WITH (timescaledb.continuous) AS
+SELECT city,
+       test.time_bucket('1 year', tstamp) AS bucket,
+       MIN(temperature),
+       MAX(temperature)
+FROM conditions
+GROUP BY city, bucket
+WITH NO DATA;
+-- experimental should be FALSE for time_bucket
+-- experimental should be TRUE for time_bucket_bg
+SELECT name, bucket_width, experimental FROM _timescaledb_catalog.continuous_aggs_bucket_function ORDER BY 1;
+      name      | bucket_width | experimental 
+----------------+--------------+--------------
+ time_bucket    | @ 1 year     | f
+ time_bucket_ng | @ 1 mon      | t
+(2 rows)
+
+\c :TEST_DBNAME :ROLE_SUPERUSER
+DROP DATABASE test WITH (FORCE);


### PR DESCRIPTION
When a Continuous Aggregate with variable size bucket is created is added one entry into the
`_timescaledb_catalog.continuous_aggs_bucket_function` catalog table.

The problem is that the `experimental` flag was not properly updated if the extension is installed into a schema other than PUBLIC.

Fixed it by checking if the bucket function resides or not on the experimental schema (aka `timescaledb_experimental`).

Disable-check: force-changelog-file
