### PR TITLE
Modularize batch queue in transparent decompression

### DIFF
--- a/tsl/src/nodes/decompress_chunk/CMakeLists.txt
+++ b/tsl/src/nodes/decompress_chunk/CMakeLists.txt
@@ -2,6 +2,7 @@
 set(SOURCES
     ${CMAKE_CURRENT_SOURCE_DIR}/batch_array.c
     ${CMAKE_CURRENT_SOURCE_DIR}/batch_queue_heap.c
+    ${CMAKE_CURRENT_SOURCE_DIR}/batch_queue_fifo.c
     ${CMAKE_CURRENT_SOURCE_DIR}/compressed_batch.c
     ${CMAKE_CURRENT_SOURCE_DIR}/decompress_chunk.c
     ${CMAKE_CURRENT_SOURCE_DIR}/exec.c

--- a/tsl/src/nodes/decompress_chunk/batch_queue.h
+++ b/tsl/src/nodes/decompress_chunk/batch_queue.h
@@ -1,0 +1,38 @@
+/*
+ * This file and its contents are licensed under the Timescale License.
+ * Please see the included NOTICE for copyright information and
+ * LICENSE-TIMESCALE for a copy of the license.
+ */
+#ifndef TIMESCALEDB_BATCH_QUEUE_H
+#define TIMESCALEDB_BATCH_QUEUE_H
+
+#include <postgres.h>
+#include <executor/tuptable.h>
+
+#include "decompress_context.h"
+
+/* Initial amount of batch states */
+#define INITIAL_BATCH_CAPACITY 16
+
+struct BatchQueue;
+
+typedef struct BatchQueueFunctions
+{
+	void (*free)(struct BatchQueue *);
+	bool (*needs_next_batch)(struct BatchQueue *);
+	void (*pop)(struct BatchQueue *, DecompressContext *);
+	void (*push_batch)(struct BatchQueue *, DecompressContext *, TupleTableSlot *);
+	void (*reset)(struct BatchQueue *);
+	TupleTableSlot *(*top_tuple)(struct BatchQueue *);
+} BatchQueueFunctions;
+
+typedef struct BatchQueue
+{
+	BatchArray batch_array;
+	const BatchQueueFunctions *funcs;
+} BatchQueue;
+
+#include "batch_queue_fifo.h"
+#include "batch_queue_heap.h"
+
+#endif /* TIMESCALEDB_BATCH_QUEUE_H */

--- a/tsl/src/nodes/decompress_chunk/batch_queue_fifo.c
+++ b/tsl/src/nodes/decompress_chunk/batch_queue_fifo.c
@@ -1,0 +1,31 @@
+/*
+ * This file and its contents are licensed under the Timescale License.
+ * Please see the included NOTICE for copyright information and
+ * LICENSE-TIMESCALE for a copy of the license.
+ */
+#include <postgres.h>
+#include "batch_array.h"
+#include "batch_queue_fifo.h"
+
+/*
+ * Create a FIFO batch queue.
+ *
+ * Pass the function struct as argument to ensure it is a pointer to the
+ * struct that is inlined at the place this function is called. This is mostly
+ * to be able to later Assert() that the struct pointer is pointing to the
+ * expected function struct.
+ */
+BatchQueue *
+batch_queue_fifo_create(int num_compressed_cols, Size batch_memory_context_bytes,
+						const BatchQueueFunctions *funcs)
+{
+	BatchQueue *bq = palloc0(sizeof(BatchQueue));
+
+	batch_array_init(&bq->batch_array,
+					 INITIAL_BATCH_CAPACITY,
+					 num_compressed_cols,
+					 batch_memory_context_bytes);
+	bq->funcs = funcs;
+
+	return bq;
+}

--- a/tsl/src/nodes/decompress_chunk/batch_queue_fifo.h
+++ b/tsl/src/nodes/decompress_chunk/batch_queue_fifo.h
@@ -3,71 +3,71 @@
  * Please see the included NOTICE for copyright information and
  * LICENSE-TIMESCALE for a copy of the license.
  */
+#ifndef TIMESCALEDB_BATCH_QUEUE_FIFO_H
+#define TIMESCALEDB_BATCH_QUEUE_FIFO_H
 
-#pragma once
+#include "batch_queue.h"
+#include "compressed_batch.h"
 
-#include "compression/compression.h"
-#include "nodes/decompress_chunk/exec.h"
-#include "nodes/decompress_chunk/compressed_batch.h"
-#include "nodes/decompress_chunk/batch_array.h"
-
-inline static void
-batch_queue_fifo_create(DecompressChunkState *chunk_state)
+static inline void
+batch_queue_fifo_free(BatchQueue *bq)
 {
-	DecompressContext *dcontext = &chunk_state->decompress_context;
-
-	batch_array_init(&dcontext->batch_array,
-					 1,
-					 chunk_state->num_compressed_columns,
-					 dcontext->batch_memory_context_bytes);
+	batch_array_destroy(&bq->batch_array);
+	pfree(bq);
 }
 
-inline static void
-batch_queue_fifo_free(DecompressChunkState *chunk_state)
+static inline bool
+batch_queue_fifo_needs_next_batch(BatchQueue *bq)
 {
-	batch_array_destroy(&chunk_state->decompress_context.batch_array);
+	return TupIsNull(batch_array_get_at(&bq->batch_array, 0)->decompressed_scan_slot);
 }
 
-inline static bool
-batch_queue_fifo_needs_next_batch(DecompressChunkState *chunk_state)
+static inline void
+batch_queue_fifo_pop(BatchQueue *bq, DecompressContext *dcontext)
 {
-	return TupIsNull(batch_array_get_at(&chunk_state->decompress_context.batch_array, 0)
-						 ->decompressed_scan_slot);
-}
-
-inline static void
-batch_queue_fifo_pop(DecompressChunkState *chunk_state)
-{
-	DecompressBatchState *batch_state =
-		batch_array_get_at(&chunk_state->decompress_context.batch_array, 0);
+	DecompressBatchState *batch_state = batch_array_get_at(&bq->batch_array, 0);
 	if (TupIsNull(batch_state->decompressed_scan_slot))
 	{
 		/* Allow this function to be called on the initial empty queue. */
 		return;
 	}
 
-	compressed_batch_advance(chunk_state, batch_state);
+	compressed_batch_advance(dcontext, batch_state);
 }
 
-inline static void
-batch_queue_fifo_push_batch(DecompressChunkState *chunk_state, TupleTableSlot *compressed_slot)
+static inline void
+batch_queue_fifo_push_batch(BatchQueue *bq, DecompressContext *dcontext,
+							TupleTableSlot *compressed_slot)
 {
-	BatchArray *batch_array = &chunk_state->decompress_context.batch_array;
+	BatchArray *batch_array = &bq->batch_array;
 	DecompressBatchState *batch_state = batch_array_get_at(batch_array, 0);
 	Assert(TupIsNull(batch_array_get_at(batch_array, 0)->decompressed_scan_slot));
-	compressed_batch_set_compressed_tuple(chunk_state, batch_state, compressed_slot);
-	compressed_batch_advance(chunk_state, batch_state);
+	compressed_batch_set_compressed_tuple(dcontext, batch_state, compressed_slot);
+	compressed_batch_advance(dcontext, batch_state);
 }
 
-inline static void
-batch_queue_fifo_reset(DecompressChunkState *chunk_state)
+static inline void
+batch_queue_fifo_reset(BatchQueue *bq)
 {
-	batch_array_clear_at(&chunk_state->decompress_context.batch_array, 0);
+	batch_array_clear_all(&bq->batch_array);
 }
 
-inline static TupleTableSlot *
-batch_queue_fifo_top_tuple(DecompressChunkState *chunk_state)
+static inline TupleTableSlot *
+batch_queue_fifo_top_tuple(BatchQueue *bq)
 {
-	return batch_array_get_at(&chunk_state->decompress_context.batch_array, 0)
-		->decompressed_scan_slot;
+	return batch_array_get_at(&bq->batch_array, 0)->decompressed_scan_slot;
 }
+
+static const struct BatchQueueFunctions BatchQueueFunctionsFifo = {
+	.free = batch_queue_fifo_free,
+	.needs_next_batch = batch_queue_fifo_needs_next_batch,
+	.pop = batch_queue_fifo_pop,
+	.push_batch = batch_queue_fifo_push_batch,
+	.reset = batch_queue_fifo_reset,
+	.top_tuple = batch_queue_fifo_top_tuple,
+};
+
+extern BatchQueue *batch_queue_fifo_create(int num_compressed_cols, Size batch_memory_context_bytes,
+										   const BatchQueueFunctions *funcs);
+
+#endif /* TIMESCALEDB_BATCH_QUEUE_FIFO_H */

--- a/tsl/src/nodes/decompress_chunk/batch_queue_heap.h
+++ b/tsl/src/nodes/decompress_chunk/batch_queue_heap.h
@@ -3,26 +3,15 @@
  * Please see the included NOTICE for copyright information and
  * LICENSE-TIMESCALE for a copy of the license.
  */
+#ifndef TIMESCALEDB_BATCH_QUEUE_HEAP_H
+#define TIMESCALEDB_BATCH_QUEUE_HEAP_H
 
-#ifndef TIMESCALEDB_DECOMPRESS_SORTED_MERGE_H
-#define TIMESCALEDB_DECOMPRESS_SORTED_MERGE_H
+#include "batch_queue.h"
 
-#include "compression/compression.h"
-#include "nodes/decompress_chunk/exec.h"
+extern BatchQueue *batch_queue_heap_create(int num_compressed_cols, Size batch_memory_context_bytes,
+										   const List *sortinfo, const TupleDesc result_tupdesc,
+										   const BatchQueueFunctions *funcs);
 
-extern void batch_queue_heap_free(DecompressChunkState *chunk_state);
+extern const struct BatchQueueFunctions BatchQueueFunctionsHeap;
 
-extern bool batch_queue_heap_needs_next_batch(DecompressChunkState *chunk_state);
-
-extern void batch_queue_heap_push_batch(DecompressChunkState *chunk_state,
-										TupleTableSlot *compressed_slot);
-
-extern TupleTableSlot *batch_queue_heap_top_tuple(DecompressChunkState *chunk_state);
-
-void batch_queue_heap_pop(DecompressChunkState *chunk_state);
-
-void batch_queue_heap_create(DecompressChunkState *chunk_state);
-
-void batch_queue_heap_reset(DecompressChunkState *chunk_state);
-
-#endif
+#endif /* TIMESCALEDB_BATCH_QUEUE_HEAP_H */

--- a/tsl/src/nodes/decompress_chunk/compressed_batch.c
+++ b/tsl/src/nodes/decompress_chunk/compressed_batch.c
@@ -79,10 +79,9 @@ make_single_value_arrow(Oid pgtype, Datum datum, bool isnull)
 }
 
 static void
-decompress_column(DecompressChunkState *chunk_state, DecompressBatchState *batch_state, int i)
+decompress_column(DecompressContext *dcontext, DecompressBatchState *batch_state, int i)
 {
-	DecompressContext *dcontext = &chunk_state->decompress_context;
-	DecompressChunkColumnDescription *column_description = &chunk_state->template_columns[i];
+	DecompressChunkColumnDescription *column_description = &dcontext->template_columns[i];
 	CompressedColumnValues *column_values = &batch_state->compressed_columns[i];
 	column_values->iterator = NULL;
 	column_values->arrow = NULL;
@@ -169,9 +168,9 @@ decompress_column(DecompressChunkState *chunk_state, DecompressBatchState *batch
  * optimizations.
  */
 static bool
-compute_vector_quals(DecompressChunkState *chunk_state, DecompressBatchState *batch_state)
+compute_vector_quals(DecompressContext *dcontext, DecompressBatchState *batch_state)
 {
-	if (!chunk_state->vectorized_quals_constified)
+	if (!dcontext->vectorized_quals_constified)
 	{
 		return true;
 	}
@@ -198,7 +197,7 @@ compute_vector_quals(DecompressChunkState *chunk_state, DecompressBatchState *ba
 	 * Compute the quals.
 	 */
 	ListCell *lc;
-	foreach (lc, chunk_state->vectorized_quals_constified)
+	foreach (lc, dcontext->vectorized_quals_constified)
 	{
 		/*
 		 * For now we support "Var ? Const" predicates and
@@ -233,22 +232,22 @@ compute_vector_quals(DecompressChunkState *chunk_state, DecompressBatchState *ba
 		Var *var = castNode(Var, linitial(args));
 		DecompressChunkColumnDescription *column_description = NULL;
 		int column_index = 0;
-		for (; column_index < chunk_state->num_total_columns; column_index++)
+		for (; column_index < dcontext->num_total_columns; column_index++)
 		{
-			column_description = &chunk_state->template_columns[column_index];
+			column_description = &dcontext->template_columns[column_index];
 			if (column_description->output_attno == var->varattno)
 			{
 				break;
 			}
 		}
-		Ensure(column_index < chunk_state->num_total_columns,
+		Ensure(column_index < dcontext->num_total_columns,
 			   "decompressed column %d not found in batch",
 			   var->varattno);
 		Assert(column_description != NULL);
 		Assert(column_description->typid == var->vartype);
 		Ensure(column_description->type == COMPRESSED_COLUMN,
 			   "only compressed columns are supported in vectorized quals");
-		Assert(column_index < chunk_state->num_compressed_columns);
+		Assert(column_index < dcontext->num_compressed_columns);
 
 		CompressedColumnValues *column_values = &batch_state->compressed_columns[column_index];
 
@@ -259,7 +258,7 @@ compute_vector_quals(DecompressChunkState *chunk_state, DecompressBatchState *ba
 			 * skip decompressing some columns if the entire batch doesn't pass
 			 * the quals.
 			 */
-			decompress_column(chunk_state, batch_state, column_index);
+			decompress_column(dcontext, batch_state, column_index);
 			Assert(column_values->value_bytes != 0);
 		}
 
@@ -378,11 +377,9 @@ compute_vector_quals(DecompressChunkState *chunk_state, DecompressBatchState *ba
  * Initialize the batch decompression state with the new compressed  tuple.
  */
 void
-compressed_batch_set_compressed_tuple(DecompressChunkState *chunk_state,
+compressed_batch_set_compressed_tuple(DecompressContext *dcontext,
 									  DecompressBatchState *batch_state, TupleTableSlot *subslot)
 {
-	DecompressContext *dcontext = &chunk_state->decompress_context;
-
 	Assert(TupIsNull(batch_state->decompressed_scan_slot));
 
 	/*
@@ -399,27 +396,27 @@ compressed_batch_set_compressed_tuple(DecompressChunkState *chunk_state,
 		Assert(batch_state->compressed_slot == NULL);
 
 		/* Create a non ref-counted copy of the tuple descriptor */
-		if (chunk_state->compressed_slot_tdesc == NULL)
-			chunk_state->compressed_slot_tdesc =
+		if (dcontext->compressed_slot_tdesc == NULL)
+			dcontext->compressed_slot_tdesc =
 				CreateTupleDescCopyConstr(subslot->tts_tupleDescriptor);
-		Assert(chunk_state->compressed_slot_tdesc->tdrefcount == -1);
+		Assert(dcontext->compressed_slot_tdesc->tdrefcount == -1);
 
 		batch_state->compressed_slot =
-			MakeSingleTupleTableSlot(chunk_state->compressed_slot_tdesc, subslot->tts_ops);
+			MakeSingleTupleTableSlot(dcontext->compressed_slot_tdesc, subslot->tts_ops);
 
 		Assert(batch_state->decompressed_scan_slot == NULL);
 
 		/* Get a reference the the output TupleTableSlot */
-		TupleTableSlot *slot = chunk_state->csstate.ss.ss_ScanTupleSlot;
+		TupleTableSlot *slot = dcontext->decompressed_slot;
 
 		/* Create a non ref-counted copy of the tuple descriptor */
-		if (chunk_state->decompressed_slot_scan_tdesc == NULL)
-			chunk_state->decompressed_slot_scan_tdesc =
+		if (dcontext->decompressed_slot_scan_tdesc == NULL)
+			dcontext->decompressed_slot_scan_tdesc =
 				CreateTupleDescCopyConstr(slot->tts_tupleDescriptor);
-		Assert(chunk_state->decompressed_slot_scan_tdesc->tdrefcount == -1);
+		Assert(dcontext->decompressed_slot_scan_tdesc->tdrefcount == -1);
 
 		batch_state->decompressed_scan_slot =
-			MakeSingleTupleTableSlot(chunk_state->decompressed_slot_scan_tdesc, slot->tts_ops);
+			MakeSingleTupleTableSlot(dcontext->decompressed_slot_scan_tdesc, slot->tts_ops);
 
 		/* Ensure that all fields are empty. Calling ExecClearTuple is not enough
 		 * because some attributes might not be populated (e.g., due to a dropped
@@ -442,15 +439,15 @@ compressed_batch_set_compressed_tuple(DecompressChunkState *chunk_state,
 	MemoryContext old_context = MemoryContextSwitchTo(batch_state->per_batch_context);
 	MemoryContextReset(batch_state->per_batch_context);
 
-	for (int i = 0; i < chunk_state->num_total_columns; i++)
+	for (int i = 0; i < dcontext->num_total_columns; i++)
 	{
-		DecompressChunkColumnDescription *column_description = &chunk_state->template_columns[i];
+		DecompressChunkColumnDescription *column_description = &dcontext->template_columns[i];
 
 		switch (column_description->type)
 		{
 			case COMPRESSED_COLUMN:
 			{
-				Assert(i < chunk_state->num_compressed_columns);
+				Assert(i < dcontext->num_compressed_columns);
 				/*
 				 * We decompress the compressed columns on demand, so that we can
 				 * skip decompressing some columns if the entire batch doesn't pass
@@ -506,8 +503,8 @@ compressed_batch_set_compressed_tuple(DecompressChunkState *chunk_state,
 		}
 	}
 
-	const bool have_passing_rows = compute_vector_quals(chunk_state, batch_state);
-	if (!have_passing_rows && !chunk_state->batch_sorted_merge)
+	const bool have_passing_rows = compute_vector_quals(dcontext, batch_state);
+	if (!have_passing_rows && !dcontext->batch_sorted_merge)
 	{
 		/*
 		 * The entire batch doesn't pass the vectorized quals, so we might be
@@ -515,8 +512,9 @@ compressed_batch_set_compressed_tuple(DecompressChunkState *chunk_state,
 		 * the end.
 		 */
 		batch_state->next_batch_row = batch_state->total_batch_rows;
-		InstrCountTuples2(chunk_state, 1);
-		InstrCountFiltered1(chunk_state, batch_state->total_batch_rows);
+
+		InstrCountTuples2(dcontext->ps, 1);
+		InstrCountFiltered1(dcontext->ps, batch_state->total_batch_rows);
 
 		/*
 		 * Note that this optimization can't work with "batch sorted merge",
@@ -525,7 +523,7 @@ compressed_batch_set_compressed_tuple(DecompressChunkState *chunk_state,
 		 * columns. This is not a problem at the moment, because for batch
 		 * sorted merge we disable bulk decompression entirely, at planning time.
 		 */
-		Assert(!chunk_state->batch_sorted_merge);
+		Assert(!dcontext->batch_sorted_merge);
 	}
 	else
 	{
@@ -533,13 +531,13 @@ compressed_batch_set_compressed_tuple(DecompressChunkState *chunk_state,
 		 * We have some rows in the batch that pass the vectorized filters, so
 		 * we have to decompress the rest of the compressed columns.
 		 */
-		const int num_compressed_columns = chunk_state->num_compressed_columns;
+		const int num_compressed_columns = dcontext->num_compressed_columns;
 		for (int i = 0; i < num_compressed_columns; i++)
 		{
 			CompressedColumnValues *column_values = &batch_state->compressed_columns[i];
 			if (column_values->value_bytes == 0)
 			{
-				decompress_column(chunk_state, batch_state, i);
+				decompress_column(dcontext, batch_state, i);
 				Assert(column_values->value_bytes != 0);
 			}
 		}
@@ -553,9 +551,8 @@ compressed_batch_set_compressed_tuple(DecompressChunkState *chunk_state,
  * Doesn't check the quals.
  */
 static void
-make_next_tuple(DecompressChunkState *chunk_state, DecompressBatchState *batch_state)
+make_next_tuple(DecompressContext *dcontext, DecompressBatchState *batch_state)
 {
-	DecompressContext *dcontext = &chunk_state->decompress_context;
 	TupleTableSlot *decompressed_scan_slot = batch_state->decompressed_scan_slot;
 	Assert(decompressed_scan_slot != NULL);
 
@@ -566,7 +563,7 @@ make_next_tuple(DecompressChunkState *chunk_state, DecompressBatchState *batch_s
 	const size_t arrow_row =
 		unlikely(dcontext->reverse) ? batch_state->total_batch_rows - 1 - output_row : output_row;
 
-	const int num_compressed_columns = chunk_state->num_compressed_columns;
+	const int num_compressed_columns = dcontext->num_compressed_columns;
 	for (int i = 0; i < num_compressed_columns; i++)
 	{
 		CompressedColumnValues *column_values = &batch_state->compressed_columns[i];
@@ -639,16 +636,13 @@ make_next_tuple(DecompressChunkState *chunk_state, DecompressBatchState *batch_s
 }
 
 static bool
-vector_qual(DecompressChunkState *chunk_state, DecompressBatchState *batch_state)
+vector_qual(DecompressBatchState *batch_state, bool reverse)
 {
-	DecompressContext *dcontext = &chunk_state->decompress_context;
-
 	Assert(batch_state->total_batch_rows > 0);
 	Assert(batch_state->next_batch_row < batch_state->total_batch_rows);
 
 	const int output_row = batch_state->next_batch_row;
-	const size_t arrow_row =
-		dcontext->reverse ? batch_state->total_batch_rows - 1 - output_row : output_row;
+	const size_t arrow_row = reverse ? batch_state->total_batch_rows - 1 - output_row : output_row;
 
 	if (!batch_state->vector_qual_result)
 	{
@@ -659,21 +653,21 @@ vector_qual(DecompressChunkState *chunk_state, DecompressBatchState *batch_state
 }
 
 static bool
-postgres_qual(DecompressChunkState *chunk_state, DecompressBatchState *batch_state)
+postgres_qual(DecompressContext *dcontext, DecompressBatchState *batch_state)
 {
 	TupleTableSlot *decompressed_scan_slot = batch_state->decompressed_scan_slot;
 	Assert(!TupIsNull(decompressed_scan_slot));
 
-	if (!chunk_state->csstate.ss.ps.qual)
+	if (dcontext->ps == NULL || dcontext->ps->qual == NULL)
 	{
 		return true;
 	}
 
 	/* Perform the usual Postgres selection. */
-	ExprContext *econtext = chunk_state->csstate.ss.ps.ps_ExprContext;
+	ExprContext *econtext = dcontext->ps->ps_ExprContext;
 	econtext->ecxt_scantuple = decompressed_scan_slot;
 	ResetExprContext(econtext);
-	return ExecQual(chunk_state->csstate.ss.ps.qual, econtext);
+	return ExecQual(dcontext->ps->qual, econtext);
 }
 
 /*
@@ -682,19 +676,19 @@ postgres_qual(DecompressChunkState *chunk_state, DecompressBatchState *batch_sta
  * is entirely processed.
  */
 void
-compressed_batch_advance(DecompressChunkState *chunk_state, DecompressBatchState *batch_state)
+compressed_batch_advance(DecompressContext *dcontext, DecompressBatchState *batch_state)
 {
 	Assert(batch_state->total_batch_rows > 0);
 
 	TupleTableSlot *decompressed_scan_slot = batch_state->decompressed_scan_slot;
 	Assert(decompressed_scan_slot != NULL);
 
-	const int num_compressed_columns = chunk_state->num_compressed_columns;
+	const int num_compressed_columns = dcontext->num_compressed_columns;
 
 	for (; batch_state->next_batch_row < batch_state->total_batch_rows;
 		 batch_state->next_batch_row++)
 	{
-		if (!vector_qual(chunk_state, batch_state))
+		if (!vector_qual(batch_state, dcontext->reverse))
 		{
 			/*
 			 * This row doesn't pass the vectorized quals. Advance the iterated
@@ -709,19 +703,20 @@ compressed_batch_advance(DecompressChunkState *chunk_state, DecompressBatchState
 					column_values->iterator->try_next(column_values->iterator);
 				}
 			}
-			InstrCountFiltered1(&chunk_state->csstate, 1);
+
+			InstrCountFiltered1(dcontext->ps, 1);
 			continue;
 		}
 
-		make_next_tuple(chunk_state, batch_state);
+		make_next_tuple(dcontext, batch_state);
 
-		if (!postgres_qual(chunk_state, batch_state))
+		if (!postgres_qual(dcontext, batch_state))
 		{
 			/*
 			 * The tuple didn't pass the qual, fetch the next one in the next
 			 * iteration.
 			 */
-			InstrCountFiltered1(&chunk_state->csstate, 1);
+			InstrCountFiltered1(dcontext->ps, 1);
 			continue;
 		}
 
@@ -759,8 +754,7 @@ compressed_batch_advance(DecompressChunkState *chunk_state, DecompressBatchState
  * needed for batch sorted merge.
  */
 void
-compressed_batch_save_first_tuple(DecompressChunkState *chunk_state,
-								  DecompressBatchState *batch_state,
+compressed_batch_save_first_tuple(DecompressContext *dcontext, DecompressBatchState *batch_state,
 								  TupleTableSlot *first_tuple_slot)
 {
 	Assert(batch_state->next_batch_row == 0);
@@ -776,7 +770,7 @@ compressed_batch_save_first_tuple(DecompressChunkState *chunk_state,
 	 * happen.
 	 */
 #ifdef USE_ASSERT_CHECKING
-	const int num_compressed_columns = chunk_state->num_compressed_columns;
+	const int num_compressed_columns = dcontext->num_compressed_columns;
 	for (int i = 0; i < num_compressed_columns; i++)
 	{
 		CompressedColumnValues *column_values = &batch_state->compressed_columns[i];
@@ -785,7 +779,7 @@ compressed_batch_save_first_tuple(DecompressChunkState *chunk_state,
 #endif
 
 	/* Make the first tuple and save it. */
-	make_next_tuple(chunk_state, batch_state);
+	make_next_tuple(dcontext, batch_state);
 	ExecCopySlot(first_tuple_slot, batch_state->decompressed_scan_slot);
 
 	/*
@@ -793,12 +787,12 @@ compressed_batch_save_first_tuple(DecompressChunkState *chunk_state,
 	 * for the subsequent calls (matching tuple is in decompressed scan slot).
 	 */
 	const bool qual_passed =
-		vector_qual(chunk_state, batch_state) && postgres_qual(chunk_state, batch_state);
+		vector_qual(batch_state, dcontext->reverse) && postgres_qual(dcontext, batch_state);
 	batch_state->next_batch_row++;
 
 	if (!qual_passed)
 	{
-		InstrCountFiltered1(&chunk_state->csstate, 1);
-		compressed_batch_advance(chunk_state, batch_state);
+		InstrCountFiltered1(dcontext->ps, 1);
+		compressed_batch_advance(dcontext, batch_state);
 	}
 }

--- a/tsl/src/nodes/decompress_chunk/compressed_batch.c
+++ b/tsl/src/nodes/decompress_chunk/compressed_batch.c
@@ -16,7 +16,6 @@
 #include "debug_assert.h"
 #include "guc.h"
 #include "nodes/decompress_chunk/compressed_batch.h"
-#include "nodes/decompress_chunk/exec.h"
 #include "nodes/decompress_chunk/vector_predicates.h"
 
 /*
@@ -81,7 +80,7 @@ make_single_value_arrow(Oid pgtype, Datum datum, bool isnull)
 static void
 decompress_column(DecompressContext *dcontext, DecompressBatchState *batch_state, int i)
 {
-	DecompressChunkColumnDescription *column_description = &dcontext->template_columns[i];
+	CompressionColumnDescription *column_description = &dcontext->template_columns[i];
 	CompressedColumnValues *column_values = &batch_state->compressed_columns[i];
 	column_values->iterator = NULL;
 	column_values->arrow = NULL;
@@ -230,7 +229,7 @@ compute_vector_quals(DecompressContext *dcontext, DecompressBatchState *batch_st
 		 * Find the compressed column referred to by the Var.
 		 */
 		Var *var = castNode(Var, linitial(args));
-		DecompressChunkColumnDescription *column_description = NULL;
+		CompressionColumnDescription *column_description = NULL;
 		int column_index = 0;
 		for (; column_index < dcontext->num_total_columns; column_index++)
 		{
@@ -441,7 +440,7 @@ compressed_batch_set_compressed_tuple(DecompressContext *dcontext,
 
 	for (int i = 0; i < dcontext->num_total_columns; i++)
 	{
-		DecompressChunkColumnDescription *column_description = &dcontext->template_columns[i];
+		CompressionColumnDescription *column_description = &dcontext->template_columns[i];
 
 		switch (column_description->type)
 		{

--- a/tsl/src/nodes/decompress_chunk/compressed_batch.h
+++ b/tsl/src/nodes/decompress_chunk/compressed_batch.h
@@ -7,7 +7,7 @@
 #pragma once
 
 #include "compression/compression.h"
-#include "nodes/decompress_chunk/exec.h"
+#include "nodes/decompress_chunk/decompress_context.h"
 
 typedef struct ArrowArray ArrowArray;
 

--- a/tsl/src/nodes/decompress_chunk/compressed_batch.h
+++ b/tsl/src/nodes/decompress_chunk/compressed_batch.h
@@ -63,14 +63,14 @@ typedef struct DecompressBatchState
 	CompressedColumnValues compressed_columns[FLEXIBLE_ARRAY_MEMBER];
 } DecompressBatchState;
 
-extern void compressed_batch_set_compressed_tuple(DecompressChunkState *chunk_state,
+extern void compressed_batch_set_compressed_tuple(DecompressContext *dcontext,
 												  DecompressBatchState *batch_state,
 												  TupleTableSlot *subslot);
 
-extern void compressed_batch_advance(DecompressChunkState *chunk_state,
+extern void compressed_batch_advance(DecompressContext *dcontext,
 									 DecompressBatchState *batch_state);
 
-extern void compressed_batch_save_first_tuple(DecompressChunkState *chunk_state,
+extern void compressed_batch_save_first_tuple(DecompressContext *dcontext,
 											  DecompressBatchState *batch_state,
 											  TupleTableSlot *first_tuple_slot);
 

--- a/tsl/src/nodes/decompress_chunk/decompress_chunk.c
+++ b/tsl/src/nodes/decompress_chunk/decompress_chunk.c
@@ -31,7 +31,7 @@
 #include "import/planner.h"
 #include "import/allpaths.h"
 #include "compression/create.h"
-#include "nodes/decompress_chunk/batch_queue_heap.h"
+#include "compression/compression.h"
 #include "nodes/decompress_chunk/decompress_chunk.h"
 #include "nodes/decompress_chunk/planner.h"
 #include "nodes/decompress_chunk/qual_pushdown.h"

--- a/tsl/src/nodes/decompress_chunk/decompress_context.h
+++ b/tsl/src/nodes/decompress_chunk/decompress_context.h
@@ -1,0 +1,79 @@
+/*
+ * This file and its contents are licensed under the Timescale License.
+ * Please see the included NOTICE for copyright information and
+ * LICENSE-TIMESCALE for a copy of the license.
+ */
+#ifndef TIMESCALEDB_DECOMPRESS_CONTEXT_H
+#define TIMESCALEDB_DECOMPRESS_CONTEXT_H
+
+#include <postgres.h>
+#include <access/attnum.h>
+#include <executor/tuptable.h>
+#include <nodes/execnodes.h>
+#include <nodes/pg_list.h>
+
+#include "batch_array.h"
+
+typedef enum DecompressChunkColumnType
+{
+	SEGMENTBY_COLUMN,
+	COMPRESSED_COLUMN,
+	COUNT_COLUMN,
+	SEQUENCE_NUM_COLUMN,
+} DecompressChunkColumnType;
+
+typedef struct DecompressChunkColumnDescription
+{
+	DecompressChunkColumnType type;
+	Oid typid;
+	int value_bytes;
+
+	/*
+	 * Attno of the decompressed column in the output of DecompressChunk node.
+	 * Negative values are special columns that do not have a representation in
+	 * the decompressed chunk, but are still used for decompression. They should
+	 * have the respective `type` field.
+	 */
+	AttrNumber output_attno;
+
+	/*
+	 * Attno of the compressed column in the input compressed chunk scan.
+	 */
+	AttrNumber compressed_scan_attno;
+
+	bool bulk_decompression_supported;
+} DecompressChunkColumnDescription;
+
+typedef struct DecompressContext
+{
+	DecompressChunkColumnDescription *template_columns;
+	int num_total_columns;
+	int num_compressed_columns;
+	List *vectorized_quals_constified;
+	Size batch_memory_context_bytes;
+	bool reverse;
+	bool batch_sorted_merge; /* Merge append optimization enabled */
+	bool enable_bulk_decompression;
+
+	/*
+	 * Scratch space for bulk decompression which might need a lot of temporary
+	 * data.
+	 */
+	MemoryContext bulk_decompression_context;
+
+	TupleTableSlot *decompressed_slot;
+	/*
+	 * Make non-refcounted copies of the tupdesc for reuse across all batch states
+	 * and avoid spending CPU in ResourceOwner when creating a big number of table
+	 * slots. This happens because each new slot pins its tuple descriptor using
+	 * PinTupleDesc, and for reference-counting tuples this involves adding a new
+	 * reference to ResourceOwner, which is not very efficient for a large number of
+	 * references.
+	 */
+	TupleDesc decompressed_slot_scan_tdesc;
+	TupleDesc compressed_slot_tdesc;
+
+	PlanState *ps; /* Set for filtering and instrumentation */
+} DecompressContext;
+
+#endif /* TIMESCALEDB_DECOMPRESS_CONTEXT_H */

--- a/tsl/src/nodes/decompress_chunk/decompress_context.h
+++ b/tsl/src/nodes/decompress_chunk/decompress_context.h
@@ -14,17 +14,17 @@
 
 #include "batch_array.h"
 
-typedef enum DecompressChunkColumnType
+typedef enum CompressionColumnType
 {
 	SEGMENTBY_COLUMN,
 	COMPRESSED_COLUMN,
 	COUNT_COLUMN,
 	SEQUENCE_NUM_COLUMN,
-} DecompressChunkColumnType;
+} CompressionColumnType;
 
-typedef struct DecompressChunkColumnDescription
+typedef struct CompressionColumnDescription
 {
-	DecompressChunkColumnType type;
+	CompressionColumnType type;
 	Oid typid;
 	int value_bytes;
 
@@ -42,11 +42,11 @@ typedef struct DecompressChunkColumnDescription
 	AttrNumber compressed_scan_attno;
 
 	bool bulk_decompression_supported;
-} DecompressChunkColumnDescription;
+} CompressionColumnDescription;
 
 typedef struct DecompressContext
 {
-	DecompressChunkColumnDescription *template_columns;
+	CompressionColumnDescription *template_columns;
 	int num_total_columns;
 	int num_compressed_columns;
 	List *vectorized_quals_constified;

--- a/tsl/src/nodes/decompress_chunk/exec.c
+++ b/tsl/src/nodes/decompress_chunk/exec.c
@@ -262,7 +262,7 @@ decompress_chunk_begin(CustomScanState *node, EState *estate, int eflags)
 	Assert(num_compressed <= num_total);
 	dcontext->num_compressed_columns = num_compressed;
 	dcontext->num_total_columns = num_total;
-	dcontext->template_columns = palloc0(sizeof(DecompressChunkColumnDescription) * num_total);
+	dcontext->template_columns = palloc0(sizeof(CompressionColumnDescription) * num_total);
 	dcontext->decompressed_slot = node->ss.ss_ScanTupleSlot;
 	dcontext->ps = &node->ss.ps;
 
@@ -277,7 +277,7 @@ decompress_chunk_begin(CustomScanState *node, EState *estate, int eflags)
 	for (int compressed_index = 0; compressed_index < list_length(chunk_state->decompression_map);
 		 compressed_index++)
 	{
-		DecompressChunkColumnDescription column = {
+		CompressionColumnDescription column = {
 			.compressed_scan_attno = AttrOffsetGetAttrNumber(compressed_index),
 			.output_attno = list_nth_int(chunk_state->decompression_map, compressed_index),
 			.bulk_decompression_supported =
@@ -360,7 +360,7 @@ decompress_chunk_begin(CustomScanState *node, EState *estate, int eflags)
 	{
 		for (int i = 0; i < num_total; i++)
 		{
-			DecompressChunkColumnDescription *column = &dcontext->template_columns[i];
+			CompressionColumnDescription *column = &dcontext->template_columns[i];
 			if (column->bulk_decompression_supported)
 			{
 				/* Values array, with 64 element padding (actually we have less). */
@@ -488,7 +488,7 @@ perform_vectorized_sum_int4(DecompressChunkState *chunk_state, Aggref *aggref)
 	/* Two columns are decompressed, the column that needs to be aggregated and the count column */
 	Assert(dcontext->num_total_columns == 2);
 
-	DecompressChunkColumnDescription *column_description = &dcontext->template_columns[0];
+	CompressionColumnDescription *column_description = &dcontext->template_columns[0];
 	Assert(dcontext->template_columns[1].type == COUNT_COLUMN);
 
 	/* Get a free batch slot */
@@ -529,7 +529,7 @@ perform_vectorized_sum_int4(DecompressChunkState *chunk_state, Aggref *aggref)
 		 * To calculate the sum for a segment by value, we need to multiply the value of the segment
 		 * by column with the number of compressed tuples in this batch.
 		 */
-		DecompressChunkColumnDescription *column_description_count = &dcontext->template_columns[1];
+		CompressionColumnDescription *column_description_count = &dcontext->template_columns[1];
 
 		while (true)
 		{

--- a/tsl/src/nodes/decompress_chunk/exec.h
+++ b/tsl/src/nodes/decompress_chunk/exec.h
@@ -10,54 +10,11 @@
 #include <postgres.h>
 
 #include <nodes/extensible.h>
-#include "batch_array.h"
+#include "batch_queue.h"
+#include "decompress_context.h"
 
 #define DECOMPRESS_CHUNK_COUNT_ID -9
 #define DECOMPRESS_CHUNK_SEQUENCE_NUM_ID -10
-
-typedef enum DecompressChunkColumnType
-{
-	SEGMENTBY_COLUMN,
-	COMPRESSED_COLUMN,
-	COUNT_COLUMN,
-	SEQUENCE_NUM_COLUMN,
-} DecompressChunkColumnType;
-
-typedef struct DecompressChunkColumnDescription
-{
-	DecompressChunkColumnType type;
-	Oid typid;
-	int value_bytes;
-
-	/*
-	 * Attno of the decompressed column in the output of DecompressChunk node.
-	 * Negative values are special columns that do not have a representation in
-	 * the decompressed chunk, but are still used for decompression. They should
-	 * have the respective `type` field.
-	 */
-	AttrNumber output_attno;
-
-	/*
-	 * Attno of the compressed column in the input compressed chunk scan.
-	 */
-	AttrNumber compressed_scan_attno;
-
-	bool bulk_decompression_supported;
-} DecompressChunkColumnDescription;
-
-typedef struct DecompressContext
-{
-	BatchArray batch_array;
-	Size batch_memory_context_bytes;
-	bool reverse;
-	bool enable_bulk_decompression;
-
-	/*
-	 * Scratch space for bulk decompression which might need a lot of temporary
-	 * data.
-	 */
-	MemoryContext bulk_decompression_context;
-} DecompressContext;
 
 typedef struct DecompressChunkState
 {
@@ -67,24 +24,16 @@ typedef struct DecompressChunkState
 	List *bulk_decompression_column;
 	List *aggregated_column_type;
 	List *custom_scan_tlist;
-	int num_total_columns;
-	int num_compressed_columns;
 
 	DecompressContext decompress_context;
-	DecompressChunkColumnDescription *template_columns;
 
 	int hypertable_id;
 	Oid chunk_relid;
 
-	const struct BatchQueueFunctions *batch_queue;
+	BatchQueue *batch_queue;
 	CustomExecMethods exec_methods;
 
-	bool batch_sorted_merge; /* Merge append optimization enabled */
 	List *sortinfo;
-	struct binaryheap *merge_heap; /* Binary heap of slot indices */
-	int n_sortkeys;				   /* Number of sort keys for heap compare function */
-	SortSupportData *sortkeys;	   /* Sort keys for binary heap compare function */
-	TupleTableSlot *last_batch_first_tuple;
 
 	/* Perform calculation of the aggregate directly in the decompress chunk node and emit partials
 	 */
@@ -99,19 +48,7 @@ typedef struct DecompressChunkState
 	 * evaluate to constant false, hence the flag.
 	 */
 	List *vectorized_quals_original;
-	List *vectorized_quals_constified;
 	bool have_constant_false_vectorized_qual;
-
-	/*
-	 * Make non-refcounted copies of the tupdesc for reuse across all batch states
-	 * and avoid spending CPU in ResourceOwner when creating a big number of table
-	 * slots. This happens because each new slot pins its tuple descriptor using
-	 * PinTupleDesc, and for reference-counting tuples this involves adding a new
-	 * reference to ResourceOwner, which is not very efficient for a large number of
-	 * references.
-	 */
-	TupleDesc decompressed_slot_scan_tdesc;
-	TupleDesc compressed_slot_tdesc;
 } DecompressChunkState;
 
 extern Node *decompress_chunk_state_create(CustomScan *cscan);


### PR DESCRIPTION
The batch queue implementation, which is part of transparent decompression, is refactored to be its own self-contained module. Previously, the batch queue functionality consisted of functions that operated on the DecompressChunkState node instead of its own distinct object.
    
The two batch queue types, heap and fifo, are now modularized in their separate source files with a common interface exposed in `batch_queue.h`. The state related to the two batch queue implementations is moved from DecompressChunkState into the respective modules depending on type. For example, the heap state and related initialization code is moved to the heap-based batch queue.

The DecompressContext is also moved to its own header file so that other modules need not include everything related to DecompressChunkState.

In a separate commit, the DecompressChunkColumnDescription is renamed to CompressionColumnDescription to reflect that this type is decoupled  from DecompressChunkState.

Disable-check: force-changelog-file
Disable-check: commit-count