### PR TITLE
Enable PG16 package tests

### DIFF
--- a/.github/workflows/apt-arm-packages.yaml
+++ b/.github/workflows/apt-arm-packages.yaml
@@ -9,6 +9,7 @@ name: APT ARM64 packages
     - '*'
     branches:
     - release_test
+    - trigger/package_test
 jobs:
   apt_tests:
     name: APT ARM64 ${{ matrix.image }} PG${{ matrix.pg }}
@@ -17,7 +18,7 @@ jobs:
       fail-fast: false
       matrix:
         image: [ "debian:10-slim","debian:11-slim","debian:12-slim","ubuntu:20.04","ubuntu:22.04"]
-        pg: [ 13, 14, 15 ]
+        pg: [ 13, 14, 15, 16 ]
 
     steps:
     - name: Setup emulation

--- a/.github/workflows/apt-packages.yaml
+++ b/.github/workflows/apt-packages.yaml
@@ -9,6 +9,7 @@ name: APT packages
     - '*'
     branches:
     - release_test
+    - trigger/package_test
 jobs:
   apt_tests:
     name: APT ${{ matrix.image }} PG${{ matrix.pg }} ${{ matrix.license }}
@@ -21,7 +22,7 @@ jobs:
       fail-fast: false
       matrix:
         image: [ "debian:10-slim", "debian:11-slim", "debian:12-slim", "ubuntu:20.04", "ubuntu:22.04", "ubuntu:23.04" ]
-        pg: [ 13, 14, 15 ]
+        pg: [ 13, 14, 15, 16 ]
         license: [ "TSL", "Apache"]
         include:
           - license: Apache
@@ -81,7 +82,8 @@ jobs:
         fi
 
     - name: Test Downgrade
-      if: matrix.image != 'ubuntu:23.04'
+      # TSB 2.13.0 is the first version with PG 16 support, so no downgrades are supported at the moment
+      if: matrix.pg != '16'
       run: |
         # Since this runs nightly on main we have to get the previous version
         # from the last released version and not current branch.

--- a/.github/workflows/homebrew.yaml
+++ b/.github/workflows/homebrew.yaml
@@ -9,6 +9,7 @@ name: Homebrew
     - '*'
     branches:
     - release_test
+    - trigger/package_test
 
 jobs:
   homebrew:

--- a/.github/workflows/rpm-packages.yaml
+++ b/.github/workflows/rpm-packages.yaml
@@ -9,6 +9,7 @@ name: RPM packages
     - '*'
     branches:
     - release_test
+    - trigger/package_test
 
 jobs:
   rpm_tests:
@@ -20,11 +21,15 @@ jobs:
       fail-fast: false
       matrix:
         image: [ "centos:centos7", "rockylinux:8", "rockylinux:9" ]
-        pg: [ 13, 14, 15 ]
+        pg: [ 13, 14, 15, 16 ]
         license: [ "TSL", "Apache"]
         include:
           - license: Apache
             pkg_suffix: "-oss"
+        exclude:
+          # PG 16 is not available on centos7
+          - image: centos:centos7
+            pg: 16
 
     steps:
     - name: Add postgres repositories
@@ -95,6 +100,8 @@ jobs:
         fi
 
     - name: Test Downgrade
+      # TSB 2.13.0 is the first version with PG 16 support, so no downgrades are supported at the moment
+      if: matrix.pg != '16'
       run: |
         # Since this runs nightly on main we have to get the previous version
         # from the last released version and not current branch.


### PR DESCRIPTION
Since TSDB 2.13.0, we create packages for PG16. This patch enables the nightly package tests for this PostgreSQL version.

---

Should be merged after: https://github.com/timescale/timescaledb/pull/6368
Disable-check: force-changelog-file