### PR TITLE
Rename vectorized aggregation GUC

### DIFF
--- a/src/guc.c
+++ b/src/guc.c
@@ -581,7 +581,7 @@ _guc_init(void)
 							 NULL,
 							 NULL);
 
-	DefineCustomBoolVariable("timescaledb.vectorized_aggregation",
+	DefineCustomBoolVariable("timescaledb.enable_vectorized_aggregation",
 							 "Enable vectorized aggregation",
 							 "Enable vectorized aggregation for compressed data",
 							 &ts_guc_enable_vectorized_aggregation,

--- a/tsl/test/expected/vectorized_aggregation.out
+++ b/tsl/test/expected/vectorized_aggregation.out
@@ -1064,7 +1064,7 @@ SELECT sum(int_value) FROM testtable;
 (57 rows)
 
 -- Vectorized aggregation NOT possible
-SET timescaledb.vectorized_aggregation = OFF;
+SET timescaledb.enable_vectorized_aggregation = OFF;
 :EXPLAIN
 SELECT sum(int_value) FROM testtable;
                                                                                                                                                                                    QUERY PLAN                                                                                                                                                                                    
@@ -1141,7 +1141,7 @@ SELECT sum(int_value) FROM testtable;
                            Output: _hyper_1_1_chunk.int_value
 (70 rows)
 
-RESET timescaledb.vectorized_aggregation;
+RESET timescaledb.enable_vectorized_aggregation;
 -- Vectorized aggregation NOT possible without bulk decompression
 SET timescaledb.enable_bulk_decompression = OFF;
 :EXPLAIN
@@ -1752,28 +1752,28 @@ SELECT sum(int_value) FROM testtable WHERE segment_by_value > 5;
  2440
 (1 row)
 
-SET timescaledb.vectorized_aggregation = OFF;
+SET timescaledb.enable_vectorized_aggregation = OFF;
 SELECT sum(int_value) FROM testtable WHERE segment_by_value > 5;
  sum  
 ------
  2440
 (1 row)
 
-RESET timescaledb.vectorized_aggregation;
+RESET timescaledb.enable_vectorized_aggregation;
 SELECT sum(int_value) FROM testtable WHERE segment_by_value > 10;
  sum 
 -----
     
 (1 row)
 
-SET timescaledb.vectorized_aggregation = OFF;
+SET timescaledb.enable_vectorized_aggregation = OFF;
 SELECT sum(int_value) FROM testtable WHERE segment_by_value > 10;
  sum 
 -----
     
 (1 row)
 
-RESET timescaledb.vectorized_aggregation;
+RESET timescaledb.enable_vectorized_aggregation;
 ---
 -- Tests with parallel plans
 ---
@@ -2159,14 +2159,14 @@ SELECT sum(segment_by_value) FILTER (WHERE segment_by_value > 99999) FROM testta
                                  Output: compress_hyper_2_100_chunk."time", compress_hyper_2_100_chunk.segment_by_value, compress_hyper_2_100_chunk.int_value, compress_hyper_2_100_chunk.float_value, compress_hyper_2_100_chunk._ts_meta_count, compress_hyper_2_100_chunk._ts_meta_sequence_num, compress_hyper_2_100_chunk._ts_meta_min_1, compress_hyper_2_100_chunk._ts_meta_max_1
 (66 rows)
 
-SET timescaledb.vectorized_aggregation = OFF;
+SET timescaledb.enable_vectorized_aggregation = OFF;
 SELECT sum(segment_by_value) FILTER (WHERE segment_by_value > 99999) FROM testtable;
  sum 
 -----
     
 (1 row)
 
-RESET timescaledb.vectorized_aggregation;
+RESET timescaledb.enable_vectorized_aggregation;
 SELECT sum(segment_by_value) FILTER (WHERE segment_by_value > 99999) FROM testtable;
  sum 
 -----

--- a/tsl/test/sql/vectorized_aggregation.sql
+++ b/tsl/test/sql/vectorized_aggregation.sql
@@ -117,12 +117,12 @@ SELECT sum(int_value) FROM testtable;
 SELECT sum(int_value) FROM testtable;
 
 -- Vectorized aggregation NOT possible
-SET timescaledb.vectorized_aggregation = OFF;
+SET timescaledb.enable_vectorized_aggregation = OFF;
 
 :EXPLAIN
 SELECT sum(int_value) FROM testtable;
 
-RESET timescaledb.vectorized_aggregation;
+RESET timescaledb.enable_vectorized_aggregation;
 
 -- Vectorized aggregation NOT possible without bulk decompression
 SET timescaledb.enable_bulk_decompression = OFF;
@@ -206,15 +206,15 @@ SELECT sum(int_value) FROM testtable WHERE segment_by_value > 5;
 
 SELECT sum(int_value) FROM testtable WHERE segment_by_value > 5;
 
-SET timescaledb.vectorized_aggregation = OFF;
+SET timescaledb.enable_vectorized_aggregation = OFF;
 SELECT sum(int_value) FROM testtable WHERE segment_by_value > 5;
-RESET timescaledb.vectorized_aggregation;
+RESET timescaledb.enable_vectorized_aggregation;
 
 SELECT sum(int_value) FROM testtable WHERE segment_by_value > 10;
 
-SET timescaledb.vectorized_aggregation = OFF;
+SET timescaledb.enable_vectorized_aggregation = OFF;
 SELECT sum(int_value) FROM testtable WHERE segment_by_value > 10;
-RESET timescaledb.vectorized_aggregation;
+RESET timescaledb.enable_vectorized_aggregation;
 
 ---
 -- Tests with parallel plans
@@ -314,9 +314,9 @@ SELECT sum(int_value) FROM testtable;
 :EXPLAIN
 SELECT sum(segment_by_value) FILTER (WHERE segment_by_value > 99999) FROM testtable;
 
-SET timescaledb.vectorized_aggregation = OFF;
+SET timescaledb.enable_vectorized_aggregation = OFF;
 SELECT sum(segment_by_value) FILTER (WHERE segment_by_value > 99999) FROM testtable;
-RESET timescaledb.vectorized_aggregation;
+RESET timescaledb.enable_vectorized_aggregation;
 
 SELECT sum(segment_by_value) FILTER (WHERE segment_by_value > 99999) FROM testtable;
 


### PR DESCRIPTION
This PR renames the GUC for vectorized aggregation from `timescaledb.vectorized_aggregation` to
`timescaledb.enable_vectorized_aggregation` to be consistent with the naming of our other GUCs.

---
Disable-check: force-changelog-file