### PR TITLE
Remove direct c.h include

### DIFF
--- a/src/debug_assert.h
+++ b/src/debug_assert.h
@@ -6,7 +6,6 @@
 #ifndef TIMESCALEDB_DEBUG_ASSERT_H
 #define TIMESCALEDB_DEBUG_ASSERT_H
 
-#include <c.h>
 #include <postgres.h>
 
 /*

--- a/src/with_clause_parser.c
+++ b/src/with_clause_parser.c
@@ -4,7 +4,6 @@
  * LICENSE-APACHE for a copy of the license.
  */
 #include <postgres.h>
-#include <c.h>
 #include <fmgr.h>
 
 #include <access/htup_details.h>

--- a/src/with_clause_parser.h
+++ b/src/with_clause_parser.h
@@ -6,7 +6,6 @@
 #ifndef TIMESCALEDB_WITH_CLAUSE_PARSER_H
 #define TIMESCALEDB_WITH_CLAUSE_PARSER_H
 #include <postgres.h>
-#include <c.h>
 
 #include <nodes/parsenodes.h>
 #include <utils.h>

--- a/tsl/src/bgw_policy/job.h
+++ b/tsl/src/bgw_policy/job.h
@@ -6,7 +6,8 @@
 #ifndef TIMESCALEDB_TSL_BGW_POLICY_JOB_H
 #define TIMESCALEDB_TSL_BGW_POLICY_JOB_H
 
-#include <c.h>
+#include <postgres.h>
+#include <utils/jsonb.h>
 
 #include <bgw/job.h>
 #include <hypertable.h>

--- a/tsl/src/compression/array.h
+++ b/tsl/src/compression/array.h
@@ -12,9 +12,7 @@
 #ifndef TIMESCALEDB_TSL_COMPRESSION_ARRAY_H
 #define TIMESCALEDB_TSL_COMPRESSION_ARRAY_H
 
-#include <c.h>
 #include <postgres.h>
-
 #include <fmgr.h>
 
 #include "compression/compression.h"

--- a/tsl/src/compression/compression.h
+++ b/tsl/src/compression/compression.h
@@ -7,7 +7,6 @@
 #define TIMESCALEDB_TSL_COMPRESSION_COMPRESSION_H
 
 #include <postgres.h>
-#include <c.h>
 #include <executor/tuptable.h>
 #include <fmgr.h>
 #include <lib/stringinfo.h>

--- a/tsl/src/compression/deltadelta.h
+++ b/tsl/src/compression/deltadelta.h
@@ -18,7 +18,6 @@
 #define TIMESCALEDB_TSL_COMPRESSION_DELTA_DELTA_H
 
 #include <postgres.h>
-#include <c.h>
 #include <fmgr.h>
 #include <lib/stringinfo.h>
 


### PR DESCRIPTION
Since postgres.h includes c.h and we are including that in almost every file there is no need to directly include c.h in those same files.

Disable-check: force-changelog-file

