### PR TITLE
Run MacOS and no-telemetry tests only on latest PG

### DIFF
--- a/.github/gh_matrix_builder.py
+++ b/.github/gh_matrix_builder.py
@@ -200,21 +200,11 @@ m["include"].append(
 # test timescaledb with release config on latest postgres release in MacOS
 m["include"].append(
     build_release_config(
-        macos_config({"pg": PG15_LATEST, "ignored_tests": ignored_tests})
-    )
-)
-
-m["include"].append(
-    build_release_config(
         macos_config({"pg": PG16_LATEST, "ignored_tests": ignored_tests})
     )
 )
 
 # test latest postgres release without telemetry
-m["include"].append(
-    build_without_telemetry({"pg": PG15_LATEST, "ignored_tests": ignored_tests})
-)
-
 m["include"].append(
     build_without_telemetry(
         {


### PR DESCRIPTION
Since we now have all PG16 patches merged we dont need to run MacOS and no-telemetry build tests on multiple PG versions. Especially the MacOS test is quite time-consuming.

Disable-check: force-changelog-file
