### PR TITLE
Simplify is_compressed_column in DecompressChunk

### DIFF
--- a/tsl/src/nodes/decompress_chunk/decompress_chunk.h
+++ b/tsl/src/nodes/decompress_chunk/decompress_chunk.h
@@ -22,6 +22,8 @@ typedef struct CompressionInfo
 	RangeTblEntry *compressed_rte;
 	RangeTblEntry *ht_rte;
 
+	Oid compresseddata_oid;
+
 	int hypertable_id;
 	List *hypertable_compression_info;
 


### PR DESCRIPTION
Change the is_compressed_column implementation to determine whether a column is compressed based on datatype. Any column with type _timescaledb_internal.compressed_data is considered compressed. The new implementation should return exactly the same result as the old one.

Disable-check: force-changelog-file

