### PR TITLE
Limit ts_array_length to 1 dimensional arrays

### DIFF
--- a/src/ts_catalog/array_utils.h
+++ b/src/ts_catalog/array_utils.h
@@ -20,3 +20,5 @@ extern TSDLLEXPORT bool ts_array_is_member(ArrayType *arr, const char *name);
 extern TSDLLEXPORT int ts_array_position(ArrayType *arr, const char *name);
 extern TSDLLEXPORT bool ts_array_get_element_bool(ArrayType *arr, int position);
 extern TSDLLEXPORT const char *ts_array_get_element_text(ArrayType *arr, int position);
+extern TSDLLEXPORT ArrayType *ts_array_add_element_text(ArrayType *arr, const char *value);
+extern TSDLLEXPORT ArrayType *ts_array_add_element_bool(ArrayType *arr, bool value);

--- a/tsl/src/chunk_api.c
+++ b/tsl/src/chunk_api.c
@@ -44,6 +44,7 @@
 #include "remote/stmt_params.h"
 #include "remote/dist_commands.h"
 #include "remote/tuplefactory.h"
+#include "ts_catalog/array_utils.h"
 #include "ts_catalog/catalog.h"
 #include "ts_catalog/chunk_data_node.h"
 
@@ -1017,7 +1018,7 @@ chunk_update_colstats(Chunk *chunk, int16 attnum, float nullfract, int32 width, 
 		Assert(HeapTupleIsValid(type_tuple));
 		type = (Form_pg_type) GETSTRUCT(type_tuple);
 		Assert(slot_values[k] != NULL);
-		nelems = ARR_DIMS(slot_values[k])[0];
+		nelems = ts_array_length(slot_values[k]);
 
 		decoded_data = palloc0(nelems * sizeof(Datum));
 

--- a/tsl/src/compression/create.c
+++ b/tsl/src/compression/create.c
@@ -40,6 +40,7 @@
 #include "compression_with_clause.h"
 #include "compression.h"
 #include "hypertable_cache.h"
+#include "ts_catalog/array_utils.h"
 #include "ts_catalog/hypertable_compression.h"
 #include "custom_type_cache.h"
 #include "trigger.h"
@@ -842,7 +843,7 @@ validate_existing_constraints(Hypertable *ht, CompressColInfo *colinfo, List **i
 			}
 
 			arr = DatumGetArrayTypeP(adatum); /* ensure not toasted */
-			numkeys = ARR_DIMS(arr)[0];
+			numkeys = ts_array_length(arr);
 			if (ARR_NDIM(arr) != 1 || numkeys < 0 || ARR_HASNULL(arr) ||
 				ARR_ELEMTYPE(arr) != INT2OID)
 				elog(ERROR, "conkey is not a 1-D smallint array");

--- a/tsl/src/remote/dist_commands.c
+++ b/tsl/src/remote/dist_commands.c
@@ -567,7 +567,7 @@ ts_dist_cmd_exec(PG_FUNCTION_ARGS)
 					 errmsg("invalid data nodes list"),
 					 errdetail("The array of data nodes cannot contain null values.")));
 
-		ndatanodes = ts_array_length(data_nodes);
+		ndatanodes = ArrayGetNItems(ARR_NDIM(data_nodes), ARR_DIMS(data_nodes));
 
 		if (ndatanodes == 0)
 			ereport(ERROR,


### PR DESCRIPTION
This change makes ts_array_length constraints consistant with the constraints of the other array helper functions. Previously ts_array_length would also work on multidimensional arrays but by limiting to 1-dimensional arrays we can optimize the code path. This patch also adds helper functions for appending an element to an array.

Disable-check: force-changelog-file

