### PR TITLE
Remove unused segmentby_index_index from struct RowCompressor

### DIFF
--- a/tsl/src/compression/compression.h
+++ b/tsl/src/compression/compression.h
@@ -232,8 +232,6 @@ typedef struct RowCompressor
 	Oid index_oid;
 	/* relation info necessary to update indexes on compressed table */
 	ResultRelInfo *resultRelInfo;
-	/* segment by index index in the RelInfo if any */
-	int8 segmentby_index_index;
 
 	/* in theory we could have more input columns than outputted ones, so we
 	   store the number of inputs/compressors separately */


### PR DESCRIPTION
This field was added in fb0df1ae but never actually used for anything.

Disable-check: force-changelog-file
