### PR TITLE
Use a stateful detoaster for compressed data

### DIFF
--- a/tsl/src/compression/compression.h
+++ b/tsl/src/compression/compression.h
@@ -15,6 +15,7 @@
 typedef struct BulkInsertStateData *BulkInsertState;
 
 #include "compat/compat.h"
+#include "nodes/decompress_chunk/detoaster.h"
 #include "hypertable.h"
 #include "segment_meta.h"
 #include "ts_catalog/compression_settings.h"
@@ -148,6 +149,8 @@ typedef struct RowDecompressor
 	int64 tuples_decompressed;
 
 	TupleTableSlot **decompressed_slots;
+
+	Detoaster detoaster;
 } RowDecompressor;
 
 /*
@@ -358,13 +361,14 @@ extern void row_compressor_init(CompressionSettings *settings, RowCompressor *ro
 								int16 num_columns_in_compressed_table, bool need_bistate,
 								bool reset_sequence, int insert_options);
 extern void row_compressor_reset(RowCompressor *row_compressor);
-extern void row_compressor_finish(RowCompressor *row_compressor);
+extern void row_compressor_close(RowCompressor *row_compressor);
 extern void row_compressor_append_sorted_rows(RowCompressor *row_compressor,
 											  Tuplesortstate *sorted_rel, TupleDesc sorted_desc);
 extern void segment_info_update(SegmentInfo *segment_info, Datum val, bool is_null);
 
 extern RowDecompressor build_decompressor(Relation in_rel, Relation out_rel);
 
+extern void row_decompressor_close(RowDecompressor *decompressor);
 extern enum CompressionAlgorithms compress_get_default_algorithm(Oid typeoid);
 /*
  * A convenience macro to throw an error about the corrupted compressed data, if

--- a/tsl/src/nodes/decompress_chunk/CMakeLists.txt
+++ b/tsl/src/nodes/decompress_chunk/CMakeLists.txt
@@ -5,6 +5,7 @@ set(SOURCES
     ${CMAKE_CURRENT_SOURCE_DIR}/batch_queue_fifo.c
     ${CMAKE_CURRENT_SOURCE_DIR}/compressed_batch.c
     ${CMAKE_CURRENT_SOURCE_DIR}/decompress_chunk.c
+    ${CMAKE_CURRENT_SOURCE_DIR}/detoaster.c
     ${CMAKE_CURRENT_SOURCE_DIR}/exec.c
     ${CMAKE_CURRENT_SOURCE_DIR}/planner.c
     ${CMAKE_CURRENT_SOURCE_DIR}/pred_vector_array.c

--- a/tsl/src/nodes/decompress_chunk/compressed_batch.c
+++ b/tsl/src/nodes/decompress_chunk/compressed_batch.c
@@ -111,8 +111,12 @@ decompress_column(DecompressContext *dcontext, DecompressBatchState *batch_state
 		return;
 	}
 
+	/* Detoast the compressed datum. */
+	value = PointerGetDatum(
+		detoaster_detoast_attr((struct varlena *) DatumGetPointer(value), &dcontext->detoaster));
+
 	/* Decompress the entire batch if it is supported. */
-	CompressedDataHeader *header = (CompressedDataHeader *) PG_DETOAST_DATUM(value);
+	CompressedDataHeader *header = (CompressedDataHeader *) value;
 	ArrowArray *arrow = NULL;
 	if (dcontext->enable_bulk_decompression && column_description->bulk_decompression_supported)
 	{

--- a/tsl/src/nodes/decompress_chunk/decompress_context.h
+++ b/tsl/src/nodes/decompress_chunk/decompress_context.h
@@ -13,6 +13,7 @@
 #include <nodes/pg_list.h>
 
 #include "batch_array.h"
+#include "detoaster.h"
 
 typedef enum CompressionColumnType
 {
@@ -74,6 +75,8 @@ typedef struct DecompressContext
 	TupleDesc compressed_slot_tdesc;
 
 	PlanState *ps; /* Set for filtering and instrumentation */
+
+	Detoaster detoaster;
 } DecompressContext;
 
 #endif /* TIMESCALEDB_DECOMPRESS_CONTEXT_H */

--- a/tsl/src/nodes/decompress_chunk/detoaster.c
+++ b/tsl/src/nodes/decompress_chunk/detoaster.c
@@ -1,0 +1,406 @@
+/*
+ * This file and its contents are licensed under the Timescale License.
+ * Please see the included NOTICE for copyright information and
+ * LICENSE-TIMESCALE for a copy of the license.
+ */
+
+#include "detoaster.h"
+
+#include <access/detoast.h>
+#include <access/genam.h>
+#include <access/heaptoast.h>
+#include <access/relscan.h>
+#include <access/skey.h>
+#include <access/stratnum.h>
+#include <access/table.h>
+#include <access/tableam.h>
+#include <access/toast_internals.h>
+#include <utils/fmgroids.h>
+#include <utils/expandeddatum.h>
+#include <utils/rel.h>
+#include <utils/relcache.h>
+
+#include <compat/compat.h>
+#include "debug_assert.h"
+
+#if PG14_LT
+#define VARATT_EXTERNAL_GET_EXTSIZE(toast_pointer) (toast_pointer).va_extsize
+#endif
+
+/* We redefine this postgres macro to fix a warning about signed integer comparison. */
+#define TS_VARATT_EXTERNAL_IS_COMPRESSED(toast_pointer)                                            \
+	(((int32) VARATT_EXTERNAL_GET_EXTSIZE(toast_pointer)) < (toast_pointer).va_rawsize - VARHDRSZ)
+
+/*
+ * Fetch a TOAST slice from a heap table.
+ *
+ * This function is a modified copy of heap_fetch_toast_slice(). The difference
+ * is that it holds the open toast relation, index and other intermediate data
+ * for detoasting in the Detoaster struct, to allow them to be reused over many
+ * input tuples.
+ */
+static void
+ts_fetch_toast(Detoaster *detoaster, struct varatt_external *toast_pointer, struct varlena *result)
+{
+	const Oid valueid = toast_pointer->va_valueid;
+
+	/*
+	 * Open the toast relation and its indexes
+	 */
+	if (detoaster->toastrel == NULL)
+	{
+		MemoryContext old_mctx = MemoryContextSwitchTo(detoaster->mctx);
+		detoaster->toastrel = table_open(toast_pointer->va_toastrelid, AccessShareLock);
+
+		int num_indexes;
+		Relation *toastidxs;
+		/* Look for the valid index of toast relation */
+		const int validIndex =
+			toast_open_indexes(detoaster->toastrel, AccessShareLock, &toastidxs, &num_indexes);
+		detoaster->index = toastidxs[validIndex];
+		for (int i = 0; i < num_indexes; i++)
+		{
+			if (i != validIndex)
+			{
+				index_close(toastidxs[i], AccessShareLock);
+			}
+		}
+
+		/* Set up a scan key to fetch from the index. */
+		ScanKeyInit(&detoaster->toastkey,
+					(AttrNumber) 1,
+					BTEqualStrategyNumber,
+					F_OIDEQ,
+					ObjectIdGetDatum(valueid));
+
+		/* Prepare for scan */
+		init_toast_snapshot(&detoaster->SnapshotToast);
+		detoaster->toastscan = systable_beginscan_ordered(detoaster->toastrel,
+														  detoaster->index,
+														  &detoaster->SnapshotToast,
+														  1,
+														  &detoaster->toastkey);
+		MemoryContextSwitchTo(old_mctx);
+	}
+	else
+	{
+		Ensure(detoaster->toastrel->rd_id == toast_pointer->va_toastrelid,
+			   "unexpected toast pointer relid %d, expected %d",
+			   toast_pointer->va_toastrelid,
+			   detoaster->toastrel->rd_id);
+		detoaster->toastkey.sk_argument = ObjectIdGetDatum(valueid);
+		index_rescan(detoaster->toastscan->iscan, &detoaster->toastkey, 1, NULL, 0);
+	}
+
+	TupleDesc toasttupDesc = detoaster->toastrel->rd_att;
+
+	///////////////////////////////////////////////
+
+	/*
+	 * Read the chunks by index
+	 *
+	 * The index is on (valueid, chunkidx) so they will come in order
+	 */
+	const int32 attrsize = VARATT_EXTERNAL_GET_EXTSIZE(*toast_pointer);
+	const int32 totalchunks = ((attrsize - 1) / TOAST_MAX_CHUNK_SIZE) + 1;
+	const int startchunk = 0;
+	const int endchunk = (attrsize - 1) / TOAST_MAX_CHUNK_SIZE;
+	Assert(endchunk <= totalchunks);
+	HeapTuple ttup;
+	int32 expectedchunk = startchunk;
+	while ((ttup = systable_getnext_ordered(detoaster->toastscan, ForwardScanDirection)) != NULL)
+	{
+		int32 curchunk;
+		Pointer chunk;
+		bool isnull;
+		char *chunkdata;
+		int32 chunksize;
+		int32 expected_size;
+		int32 chcpystrt;
+		int32 chcpyend;
+
+		/*
+		 * Have a chunk, extract the sequence number and the data
+		 */
+		curchunk = DatumGetInt32(fastgetattr(ttup, 2, toasttupDesc, &isnull));
+		Assert(!isnull);
+		chunk = DatumGetPointer(fastgetattr(ttup, 3, toasttupDesc, &isnull));
+		Assert(!isnull);
+		if (!VARATT_IS_EXTENDED(chunk))
+		{
+			chunksize = VARSIZE(chunk) - VARHDRSZ;
+			chunkdata = VARDATA(chunk);
+		}
+		else if (VARATT_IS_SHORT(chunk))
+		{
+			/* could happen due to heap_form_tuple doing its thing */
+			chunksize = VARSIZE_SHORT(chunk) - VARHDRSZ_SHORT;
+			chunkdata = VARDATA_SHORT(chunk);
+		}
+		else
+		{
+			/* should never happen */
+			elog(ERROR,
+				 "found toasted toast chunk for toast value %u in %s",
+				 valueid,
+				 RelationGetRelationName(detoaster->toastrel));
+			chunksize = 0; /* keep compiler quiet */
+			chunkdata = NULL;
+		}
+
+		/*
+		 * Some checks on the data we've found
+		 */
+		if (curchunk != expectedchunk)
+			ereport(ERROR,
+					(errcode(ERRCODE_DATA_CORRUPTED),
+					 errmsg_internal("unexpected chunk number %d (expected %d) for toast value %u "
+									 "in %s",
+									 curchunk,
+									 expectedchunk,
+									 valueid,
+									 RelationGetRelationName(detoaster->toastrel))));
+		if (curchunk > endchunk)
+			ereport(ERROR,
+					(errcode(ERRCODE_DATA_CORRUPTED),
+					 errmsg_internal("unexpected chunk number %d (out of range %d..%d) for toast "
+									 "value %u in %s",
+									 curchunk,
+									 startchunk,
+									 endchunk,
+									 valueid,
+									 RelationGetRelationName(detoaster->toastrel))));
+		expected_size = curchunk < totalchunks - 1 ?
+							TOAST_MAX_CHUNK_SIZE :
+							attrsize - ((totalchunks - 1) * TOAST_MAX_CHUNK_SIZE);
+		if (chunksize != expected_size)
+			ereport(ERROR,
+					(errcode(ERRCODE_DATA_CORRUPTED),
+					 errmsg_internal("unexpected chunk size %d (expected %d) in chunk %d of %d for "
+									 "toast value %u in %s",
+									 chunksize,
+									 expected_size,
+									 curchunk,
+									 totalchunks,
+									 valueid,
+									 RelationGetRelationName(detoaster->toastrel))));
+
+		/*
+		 * Copy the data into proper place in our result
+		 */
+		chcpystrt = 0;
+		chcpyend = chunksize - 1;
+		if (curchunk == startchunk)
+			chcpystrt = 0;
+		if (curchunk == endchunk)
+			chcpyend = (attrsize - 1) % TOAST_MAX_CHUNK_SIZE;
+
+		memcpy(VARDATA(result) + (curchunk * TOAST_MAX_CHUNK_SIZE) + chcpystrt,
+			   chunkdata + chcpystrt,
+			   (chcpyend - chcpystrt) + 1);
+
+		expectedchunk++;
+	}
+
+	/*
+	 * Final checks that we successfully fetched the datum
+	 */
+	if (expectedchunk != (endchunk + 1))
+		ereport(ERROR,
+				(errcode(ERRCODE_DATA_CORRUPTED),
+				 errmsg_internal("missing chunk number %d for toast value %u in %s",
+								 expectedchunk,
+								 valueid,
+								 RelationGetRelationName(detoaster->toastrel))));
+}
+
+/*
+ * The memory context is used to store intermediate data, and is supposed to
+ * live over the calls to detoaster_detoast_attr().
+ * That function itself can be called in a short-lived memory context.
+ */
+void
+detoaster_init(Detoaster *detoaster, MemoryContext mctx)
+{
+	detoaster->toastrel = NULL;
+	detoaster->mctx = mctx;
+}
+
+void
+detoaster_close(Detoaster *detoaster)
+{
+	/* Close toast table */
+	if (detoaster->toastrel != NULL)
+	{
+		systable_endscan_ordered(detoaster->toastscan);
+		table_close(detoaster->toastrel, AccessShareLock);
+		index_close(detoaster->index, AccessShareLock);
+		detoaster->toastrel = NULL;
+		detoaster->index = NULL;
+	}
+}
+
+/*
+ * Copy of Postgres' toast_fetch_datum(): Reconstruct an in memory Datum from
+ * the chunks saved in the toast relation.
+ */
+static struct varlena *
+ts_toast_fetch_datum(struct varlena *attr, Detoaster *detoaster)
+{
+	struct varlena *result;
+	struct varatt_external toast_pointer;
+	int32 attrsize;
+
+	if (!VARATT_IS_EXTERNAL_ONDISK(attr))
+		elog(ERROR, "toast_fetch_datum shouldn't be called for non-ondisk datums");
+
+	/* Must copy to access aligned fields */
+	VARATT_EXTERNAL_GET_POINTER(toast_pointer, attr);
+
+	attrsize = VARATT_EXTERNAL_GET_EXTSIZE(toast_pointer);
+
+	result = (struct varlena *) palloc(attrsize + VARHDRSZ);
+
+	if (TS_VARATT_EXTERNAL_IS_COMPRESSED(toast_pointer))
+		SET_VARSIZE_COMPRESSED(result, attrsize + VARHDRSZ);
+	else
+		SET_VARSIZE(result, attrsize + VARHDRSZ);
+
+	if (attrsize == 0)
+		return result; /* Probably shouldn't happen, but just in
+						* case. */
+
+	/* Fetch all chunks */
+	ts_fetch_toast(detoaster, &toast_pointer, result);
+
+	return result;
+}
+
+/*
+ * Copy of Postgres' toast_decompress_datum(): Decompress a compressed version
+ * of a varlena datum
+ * The decompression functions have changed since PG13, so we have to keep two
+ * implementations.
+ */
+#if PG14_LT
+
+#include <common/pg_lzcompress.h>
+
+static struct varlena *
+ts_toast_decompress_datum(struct varlena *attr)
+{
+	struct varlena *result;
+
+	Assert(VARATT_IS_COMPRESSED(attr));
+
+	result = (struct varlena *) palloc(TOAST_COMPRESS_RAWSIZE(attr) + VARHDRSZ);
+	SET_VARSIZE(result, TOAST_COMPRESS_RAWSIZE(attr) + VARHDRSZ);
+
+	if (pglz_decompress(TOAST_COMPRESS_RAWDATA(attr),
+						TOAST_COMPRESS_SIZE(attr),
+						VARDATA(result),
+						TOAST_COMPRESS_RAWSIZE(attr),
+						true) < 0)
+		elog(ERROR, "compressed data is corrupted");
+
+	return result;
+}
+
+#else
+
+#include <access/toast_compression.h>
+
+static struct varlena *
+ts_toast_decompress_datum(struct varlena *attr)
+{
+	ToastCompressionId cmid;
+
+	Assert(VARATT_IS_COMPRESSED(attr));
+
+	/*
+	 * Fetch the compression method id stored in the compression header and
+	 * decompress the data using the appropriate decompression routine.
+	 */
+	cmid = TOAST_COMPRESS_METHOD(attr);
+	switch (cmid)
+	{
+		case TOAST_PGLZ_COMPRESSION_ID:
+			return pglz_decompress_datum(attr);
+		case TOAST_LZ4_COMPRESSION_ID:
+			return lz4_decompress_datum(attr);
+		default:
+			elog(ERROR, "invalid compression method id %d", cmid);
+			return NULL; /* keep compiler quiet */
+	}
+}
+#endif
+
+/*
+ * Modification of Postgres' detoast_attr() where we use the stateful Detoaster
+ * and skip some cases that don't occur for the toasted compressed data.
+ */
+struct varlena *
+detoaster_detoast_attr(struct varlena *attr, Detoaster *detoaster)
+{
+	if (!VARATT_IS_EXTENDED(attr))
+	{
+		/* Nothing to do here. */
+		return attr;
+	}
+
+	if (VARATT_IS_EXTERNAL_ONDISK(attr))
+	{
+		/*
+		 * This is an externally stored datum --- fetch it back from there.
+		 */
+		attr = ts_toast_fetch_datum(attr, detoaster);
+		/* If it's compressed, decompress it */
+		if (VARATT_IS_COMPRESSED(attr))
+		{
+			struct varlena *tmp = attr;
+
+			attr = ts_toast_decompress_datum(tmp);
+			pfree(tmp);
+		}
+
+		return attr;
+	}
+
+	/*
+	 * Can't get indirect TOAST here (out-of-line Datum that's stored in memory),
+	 * because we're reading from the compressed chunk table.
+	 */
+	Ensure(!VARATT_IS_EXTERNAL_INDIRECT(attr), "got indirect TOAST for compressed data");
+
+	/*
+	 * Compressed data doesn't have an expanded representation.
+	 */
+	Ensure(!VARATT_IS_EXTERNAL_EXPANDED(attr), "got expanded TOAST for compressed data");
+
+	if (VARATT_IS_COMPRESSED(attr))
+	{
+		/*
+		 * This is a compressed value stored inline in the main tuple. It rarely
+		 * occurs in practice, because we set a low toast_tuple_target = 128
+		 * for the compressed chunks, but is still technically possible.
+		 */
+		return ts_toast_decompress_datum(attr);
+	}
+
+	/*
+	 * The only option left is a short-header varlena --- convert to 4-byte
+	 * header format.
+	 */
+	Ensure(VARATT_IS_SHORT(attr), "got unexpected TOAST type for compressed data");
+
+	Size data_size = VARSIZE_SHORT(attr) - VARHDRSZ_SHORT;
+	Size new_size = data_size + VARHDRSZ;
+	struct varlena *new_attr;
+
+	new_attr = (struct varlena *) palloc(new_size);
+	SET_VARSIZE(new_attr, new_size);
+	memcpy(VARDATA(new_attr), VARDATA_SHORT(attr), data_size);
+	attr = new_attr;
+
+	return attr;
+}

--- a/tsl/src/nodes/decompress_chunk/detoaster.h
+++ b/tsl/src/nodes/decompress_chunk/detoaster.h
@@ -1,0 +1,30 @@
+/*
+ * This file and its contents are licensed under the Timescale License.
+ * Please see the included NOTICE for copyright information and
+ * LICENSE-TIMESCALE for a copy of the license.
+ */
+
+#pragma once
+
+#include <postgres.h>
+
+#include <access/genam.h>
+#include <access/relscan.h>
+#include <access/skey.h>
+#include <utils/snapshot.h>
+
+typedef struct RelationData *Relation;
+
+typedef struct Detoaster
+{
+	MemoryContext mctx;
+	Relation toastrel;
+	Relation index;
+	SnapshotData SnapshotToast;
+	ScanKeyData toastkey;
+	SysScanDesc toastscan;
+} Detoaster;
+
+void detoaster_init(Detoaster *detoaster, MemoryContext mctx);
+void detoaster_close(Detoaster *detoaster);
+struct varlena *detoaster_detoast_attr(struct varlena *attr, Detoaster *detoaster);

--- a/tsl/test/expected/compressed_detoaster.out
+++ b/tsl/test/expected/compressed_detoaster.out
@@ -1,0 +1,48 @@
+-- This file and its contents are licensed under the Timescale License.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-TIMESCALE for a copy of the license.
+-- Make a compressed table with a compressed string of varying length, to test
+-- the various ways the compressed data can be toasted.
+create table longstr(ts int default 1, s1 text);
+select create_hypertable('longstr', 'ts');
+NOTICE:  adding not-null constraint to column "ts"
+  create_hypertable   
+----------------------
+ (1,public,longstr,t)
+(1 row)
+
+alter table longstr set (timescaledb.compress);
+-- We want to test the case for inline compression. It is technically possible,
+-- but very hard to hit with the usual toast_tuple_target = 128 on compressed
+-- chunks. So here we increase the toast_tuple_target to simplify
+-- testing.
+select format('%I.%I', schema_name, table_name) compressed_table
+from _timescaledb_catalog.hypertable
+where id = (select compressed_hypertable_id from _timescaledb_catalog.hypertable
+    where table_name = 'longstr')
+\gset
+alter table :compressed_table set (toast_tuple_target = 512);
+-- Now, test compression and decompression with various string lengths.
+create function test(repeats int, decompress bool) returns table(ns bigint) as $$ begin
+    raise log 'repeats %', repeats;
+    truncate longstr;
+    insert into longstr(s1) select repeat('aaaa', repeats);
+    perform count(compress_chunk(x, true)) from show_chunks('longstr') x;
+    if decompress then
+        perform decompress_chunk(x) from show_chunks('longstr') x;
+    end if;
+    return query select sum(length(s1)) from longstr;
+end; $$ language plpgsql volatile;
+select sum(t) from generate_series(1, 30) x, lateral test(x * x * x, false) t;
+  sum   
+--------
+ 864900
+(1 row)
+
+-- Also test decompression which uses the detoaster as well.
+select sum(t) from generate_series(1, 30) x, lateral test(x * x * x, true) t;
+  sum   
+--------
+ 864900
+(1 row)
+

--- a/tsl/test/sql/CMakeLists.txt
+++ b/tsl/test/sql/CMakeLists.txt
@@ -14,6 +14,7 @@ set(TEST_FILES
     cagg_utils.sql
     cagg_watermark.sql
     compress_default.sql
+    compressed_detoaster.sql
     compressed_collation.sql
     compression_create_compressed_table.sql
     compression_conflicts.sql

--- a/tsl/test/sql/compressed_detoaster.sql
+++ b/tsl/test/sql/compressed_detoaster.sql
@@ -1,0 +1,39 @@
+-- This file and its contents are licensed under the Timescale License.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-TIMESCALE for a copy of the license.
+
+-- Make a compressed table with a compressed string of varying length, to test
+-- the various ways the compressed data can be toasted.
+create table longstr(ts int default 1, s1 text);
+select create_hypertable('longstr', 'ts');
+alter table longstr set (timescaledb.compress);
+
+
+-- We want to test the case for inline compression. It is technically possible,
+-- but very hard to hit with the usual toast_tuple_target = 128 on compressed
+-- chunks. So here we increase the toast_tuple_target to simplify
+-- testing.
+select format('%I.%I', schema_name, table_name) compressed_table
+from _timescaledb_catalog.hypertable
+where id = (select compressed_hypertable_id from _timescaledb_catalog.hypertable
+    where table_name = 'longstr')
+\gset
+alter table :compressed_table set (toast_tuple_target = 512);
+
+
+-- Now, test compression and decompression with various string lengths.
+create function test(repeats int, decompress bool) returns table(ns bigint) as $$ begin
+    raise log 'repeats %', repeats;
+    truncate longstr;
+    insert into longstr(s1) select repeat('aaaa', repeats);
+    perform count(compress_chunk(x, true)) from show_chunks('longstr') x;
+    if decompress then
+        perform decompress_chunk(x) from show_chunks('longstr') x;
+    end if;
+    return query select sum(length(s1)) from longstr;
+end; $$ language plpgsql volatile;
+
+select sum(t) from generate_series(1, 30) x, lateral test(x * x * x, false) t;
+
+-- Also test decompression which uses the detoaster as well.
+select sum(t) from generate_series(1, 30) x, lateral test(x * x * x, true) t;


### PR DESCRIPTION
The normal Postgres detoasting code locks and opens toast tables and indexes for each toast value, which can take a large percentage CPU time on simple queries. Since in decompression we're working with one table at a time, the toast table and index are the same for every datum, so we don't have to redo this work.

Gives up to 60% speedup on some queries to compressed hypertables: https://grafana.ops.savannah-dev.timescale.com/d/fasYic_4z/compare-akuzm?orgId=1&var-branch=All&var-run1=3012&var-run2=3018&var-threshold=0&var-use_historical_thresholds=true&var-threshold_expression=2.0%20*%20percentile_disc(0.90)&var-exact_suite_version=false


Disable-check: force-changelog-file