### PR TITLE
Disable vectorized sum for expressions

### DIFF
--- a/.unreleased/fix_6393
+++ b/.unreleased/fix_6393
@@ -1,0 +1,2 @@
+Fixes: #6393 Disable vectorized sum for expressions.
+

--- a/tsl/src/partialize_agg.c
+++ b/tsl/src/partialize_agg.c
@@ -77,6 +77,13 @@ is_vectorizable_agg_path(PlannerInfo *root, AggPath *agg_path, Path *path)
 	if (aggref->aggfnoid != F_SUM_INT4)
 		return false;
 
+	/* Can aggregate only a bare decompressed column, not an expression. */
+	TargetEntry *argument = castNode(TargetEntry, linitial(aggref->args));
+	if (!IsA(argument->expr, Var))
+	{
+		return false;
+	}
+
 	return true;
 }
 

--- a/tsl/test/expected/vectorized_aggregation.out
+++ b/tsl/test/expected/vectorized_aggregation.out
@@ -1063,6 +1063,89 @@ SELECT sum(int_value) FROM testtable;
                      Output: compress_hyper_2_20_chunk."time", compress_hyper_2_20_chunk.segment_by_value, compress_hyper_2_20_chunk.int_value, compress_hyper_2_20_chunk.float_value, compress_hyper_2_20_chunk._ts_meta_count, compress_hyper_2_20_chunk._ts_meta_sequence_num, compress_hyper_2_20_chunk._ts_meta_min_1, compress_hyper_2_20_chunk._ts_meta_max_1
 (57 rows)
 
+--Vectorized aggregation not possible for expression
+SELECT sum(abs(int_value)) FROM testtable;
+  sum   
+--------
+ 311405
+(1 row)
+
+:EXPLAIN
+SELECT sum(abs(int_value)) FROM testtable;
+                                                                                                                                                                                   QUERY PLAN                                                                                                                                                                                    
+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Finalize Aggregate
+   Output: sum(abs(_hyper_1_1_chunk.int_value))
+   ->  Gather
+         Output: (PARTIAL sum(abs(_hyper_1_1_chunk.int_value)))
+         Workers Planned: 2
+         ->  Parallel Append
+               ->  Partial Aggregate
+                     Output: PARTIAL sum(abs(_hyper_1_1_chunk.int_value))
+                     ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_1_chunk
+                           Output: _hyper_1_1_chunk.int_value
+                           ->  Parallel Seq Scan on _timescaledb_internal.compress_hyper_2_11_chunk
+                                 Output: compress_hyper_2_11_chunk."time", compress_hyper_2_11_chunk.segment_by_value, compress_hyper_2_11_chunk.int_value, compress_hyper_2_11_chunk.float_value, compress_hyper_2_11_chunk._ts_meta_count, compress_hyper_2_11_chunk._ts_meta_sequence_num, compress_hyper_2_11_chunk._ts_meta_min_1, compress_hyper_2_11_chunk._ts_meta_max_1
+               ->  Partial Aggregate
+                     Output: PARTIAL sum(abs(_hyper_1_2_chunk.int_value))
+                     ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_2_chunk
+                           Output: _hyper_1_2_chunk.int_value
+                           ->  Parallel Seq Scan on _timescaledb_internal.compress_hyper_2_12_chunk
+                                 Output: compress_hyper_2_12_chunk."time", compress_hyper_2_12_chunk.segment_by_value, compress_hyper_2_12_chunk.int_value, compress_hyper_2_12_chunk.float_value, compress_hyper_2_12_chunk._ts_meta_count, compress_hyper_2_12_chunk._ts_meta_sequence_num, compress_hyper_2_12_chunk._ts_meta_min_1, compress_hyper_2_12_chunk._ts_meta_max_1
+               ->  Partial Aggregate
+                     Output: PARTIAL sum(abs(_hyper_1_3_chunk.int_value))
+                     ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_3_chunk
+                           Output: _hyper_1_3_chunk.int_value
+                           ->  Parallel Seq Scan on _timescaledb_internal.compress_hyper_2_13_chunk
+                                 Output: compress_hyper_2_13_chunk."time", compress_hyper_2_13_chunk.segment_by_value, compress_hyper_2_13_chunk.int_value, compress_hyper_2_13_chunk.float_value, compress_hyper_2_13_chunk._ts_meta_count, compress_hyper_2_13_chunk._ts_meta_sequence_num, compress_hyper_2_13_chunk._ts_meta_min_1, compress_hyper_2_13_chunk._ts_meta_max_1
+               ->  Partial Aggregate
+                     Output: PARTIAL sum(abs(_hyper_1_4_chunk.int_value))
+                     ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_4_chunk
+                           Output: _hyper_1_4_chunk.int_value
+                           ->  Parallel Seq Scan on _timescaledb_internal.compress_hyper_2_14_chunk
+                                 Output: compress_hyper_2_14_chunk."time", compress_hyper_2_14_chunk.segment_by_value, compress_hyper_2_14_chunk.int_value, compress_hyper_2_14_chunk.float_value, compress_hyper_2_14_chunk._ts_meta_count, compress_hyper_2_14_chunk._ts_meta_sequence_num, compress_hyper_2_14_chunk._ts_meta_min_1, compress_hyper_2_14_chunk._ts_meta_max_1
+               ->  Partial Aggregate
+                     Output: PARTIAL sum(abs(_hyper_1_5_chunk.int_value))
+                     ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_5_chunk
+                           Output: _hyper_1_5_chunk.int_value
+                           ->  Parallel Seq Scan on _timescaledb_internal.compress_hyper_2_15_chunk
+                                 Output: compress_hyper_2_15_chunk."time", compress_hyper_2_15_chunk.segment_by_value, compress_hyper_2_15_chunk.int_value, compress_hyper_2_15_chunk.float_value, compress_hyper_2_15_chunk._ts_meta_count, compress_hyper_2_15_chunk._ts_meta_sequence_num, compress_hyper_2_15_chunk._ts_meta_min_1, compress_hyper_2_15_chunk._ts_meta_max_1
+               ->  Partial Aggregate
+                     Output: PARTIAL sum(abs(_hyper_1_6_chunk.int_value))
+                     ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_6_chunk
+                           Output: _hyper_1_6_chunk.int_value
+                           ->  Parallel Seq Scan on _timescaledb_internal.compress_hyper_2_16_chunk
+                                 Output: compress_hyper_2_16_chunk."time", compress_hyper_2_16_chunk.segment_by_value, compress_hyper_2_16_chunk.int_value, compress_hyper_2_16_chunk.float_value, compress_hyper_2_16_chunk._ts_meta_count, compress_hyper_2_16_chunk._ts_meta_sequence_num, compress_hyper_2_16_chunk._ts_meta_min_1, compress_hyper_2_16_chunk._ts_meta_max_1
+               ->  Partial Aggregate
+                     Output: PARTIAL sum(abs(_hyper_1_7_chunk.int_value))
+                     ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_7_chunk
+                           Output: _hyper_1_7_chunk.int_value
+                           ->  Parallel Seq Scan on _timescaledb_internal.compress_hyper_2_17_chunk
+                                 Output: compress_hyper_2_17_chunk."time", compress_hyper_2_17_chunk.segment_by_value, compress_hyper_2_17_chunk.int_value, compress_hyper_2_17_chunk.float_value, compress_hyper_2_17_chunk._ts_meta_count, compress_hyper_2_17_chunk._ts_meta_sequence_num, compress_hyper_2_17_chunk._ts_meta_min_1, compress_hyper_2_17_chunk._ts_meta_max_1
+               ->  Partial Aggregate
+                     Output: PARTIAL sum(abs(_hyper_1_8_chunk.int_value))
+                     ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_8_chunk
+                           Output: _hyper_1_8_chunk.int_value
+                           ->  Parallel Seq Scan on _timescaledb_internal.compress_hyper_2_18_chunk
+                                 Output: compress_hyper_2_18_chunk."time", compress_hyper_2_18_chunk.segment_by_value, compress_hyper_2_18_chunk.int_value, compress_hyper_2_18_chunk.float_value, compress_hyper_2_18_chunk._ts_meta_count, compress_hyper_2_18_chunk._ts_meta_sequence_num, compress_hyper_2_18_chunk._ts_meta_min_1, compress_hyper_2_18_chunk._ts_meta_max_1
+               ->  Partial Aggregate
+                     Output: PARTIAL sum(abs(_hyper_1_9_chunk.int_value))
+                     ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_9_chunk
+                           Output: _hyper_1_9_chunk.int_value
+                           ->  Parallel Seq Scan on _timescaledb_internal.compress_hyper_2_19_chunk
+                                 Output: compress_hyper_2_19_chunk."time", compress_hyper_2_19_chunk.segment_by_value, compress_hyper_2_19_chunk.int_value, compress_hyper_2_19_chunk.float_value, compress_hyper_2_19_chunk._ts_meta_count, compress_hyper_2_19_chunk._ts_meta_sequence_num, compress_hyper_2_19_chunk._ts_meta_min_1, compress_hyper_2_19_chunk._ts_meta_max_1
+               ->  Partial Aggregate
+                     Output: PARTIAL sum(abs(_hyper_1_10_chunk.int_value))
+                     ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_10_chunk
+                           Output: _hyper_1_10_chunk.int_value
+                           ->  Parallel Seq Scan on _timescaledb_internal.compress_hyper_2_20_chunk
+                                 Output: compress_hyper_2_20_chunk."time", compress_hyper_2_20_chunk.segment_by_value, compress_hyper_2_20_chunk.int_value, compress_hyper_2_20_chunk.float_value, compress_hyper_2_20_chunk._ts_meta_count, compress_hyper_2_20_chunk._ts_meta_sequence_num, compress_hyper_2_20_chunk._ts_meta_min_1, compress_hyper_2_20_chunk._ts_meta_max_1
+               ->  Partial Aggregate
+                     Output: PARTIAL sum(abs(_hyper_1_1_chunk.int_value))
+                     ->  Parallel Seq Scan on _timescaledb_internal._hyper_1_1_chunk
+                           Output: _hyper_1_1_chunk.int_value
+(70 rows)
+
 -- Vectorized aggregation NOT possible
 SET timescaledb.enable_vectorized_aggregation = OFF;
 :EXPLAIN

--- a/tsl/test/sql/vectorized_aggregation.sql
+++ b/tsl/test/sql/vectorized_aggregation.sql
@@ -116,6 +116,14 @@ SELECT sum(int_value) FROM testtable;
 :EXPLAIN
 SELECT sum(int_value) FROM testtable;
 
+
+--Vectorized aggregation not possible for expression
+SELECT sum(abs(int_value)) FROM testtable;
+
+:EXPLAIN
+SELECT sum(abs(int_value)) FROM testtable;
+
+
 -- Vectorized aggregation NOT possible
 SET timescaledb.enable_vectorized_aggregation = OFF;
 


### PR DESCRIPTION
This is not supported at the moment, we can only aggregate bare columns, but we forgot to check this at the planning stage, so it fails.