### PR TITLE
Use #pragma once instead of include guards

### DIFF
--- a/src/adts/bit_array.h
+++ b/src/adts/bit_array.h
@@ -3,8 +3,7 @@
  * Please see the included NOTICE for copyright information and
  * LICENSE-APACHE for a copy of the license.
  */
-#ifndef TIMESCALEDB_ADT_BITARRAY_H
-#define TIMESCALEDB_ADT_BITARRAY_H
+#pragma once
 
 #include <postgres.h>
 
@@ -54,5 +53,3 @@ static uint64 bit_array_num_bits(const BitArray *array);
 static uint32 bit_array_num_buckets(const BitArray *array);
 static uint64 *bit_array_buckets(const BitArray *array);
 static size_t bit_array_data_bytes_used(const BitArray *array);
-
-#endif

--- a/src/adts/bit_array_impl.h
+++ b/src/adts/bit_array_impl.h
@@ -3,8 +3,7 @@
  * Please see the included NOTICE for copyright information and
  * LICENSE-APACHE for a copy of the license.
  */
-#ifndef TIMESCALEDB_ADT_BITARRAY_IMPL_H
-#define TIMESCALEDB_ADT_BITARRAY_IMPL_H
+#pragma once
 
 #include <postgres.h>
 
@@ -353,5 +352,3 @@ bit_array_low_bits_mask(uint8 bits_used)
 	else
 		return (UINT64CONST(1) << bits_used) - UINT64CONST(1);
 }
-
-#endif

--- a/src/adts/char_vec.h
+++ b/src/adts/char_vec.h
@@ -3,8 +3,7 @@
  * Please see the included NOTICE for copyright information and
  * LICENSE-APACHE for a copy of the license.
  */
-#ifndef TIMESCALEDB_ADT_CHAR_VEC_H
-#define TIMESCALEDB_ADT_CHAR_VEC_H
+#pragma once
 
 #define VEC_PREFIX char
 #define VEC_ELEMENT_TYPE char
@@ -12,5 +11,3 @@
 #define VEC_DEFINE 1
 #define VEC_SCOPE static inline
 #include <adts/vec.h>
-
-#endif

--- a/src/adts/uint64_vec.h
+++ b/src/adts/uint64_vec.h
@@ -3,8 +3,7 @@
  * Please see the included NOTICE for copyright information and
  * LICENSE-APACHE for a copy of the license.
  */
-#ifndef TIMESCALEDB_ADT_UINT64_VEC_H
-#define TIMESCALEDB_ADT_UINT64_VEC_H
+#pragma once
 
 #define VEC_PREFIX uint64
 #define VEC_ELEMENT_TYPE uint64
@@ -12,5 +11,3 @@
 #define VEC_DEFINE 1
 #define VEC_SCOPE static inline
 #include <adts/vec.h>
-
-#endif

--- a/src/annotations.h
+++ b/src/annotations.h
@@ -3,8 +3,7 @@
  * Please see the included NOTICE for copyright information and
  * LICENSE-APACHE for a copy of the license.
  */
-#ifndef TIMESCALEDB_ANNOTATIONS_H
-#define TIMESCALEDB_ANNOTATIONS_H
+#pragma once
 
 /* Supported since clang 12 and GCC 7 */
 #if defined __has_attribute
@@ -26,5 +25,3 @@
 #else
 #define TS_USED
 #endif
-
-#endif /* TIMESCALEDB_ANNOTATIONS_H */

--- a/src/bgw/job.h
+++ b/src/bgw/job.h
@@ -3,8 +3,7 @@
  * Please see the included NOTICE for copyright information and
  * LICENSE-APACHE for a copy of the license.
  */
-#ifndef BGW_JOB_H
-#define BGW_JOB_H
+#pragma once
 
 #include <postgres.h>
 #include <storage/lock.h>
@@ -69,5 +68,3 @@ extern TSDLLEXPORT void ts_bgw_job_validate_schedule_interval(Interval *schedule
 extern TSDLLEXPORT char *ts_bgw_job_validate_timezone(Datum timezone);
 
 extern TSDLLEXPORT bool ts_is_telemetry_job(BgwJob *job);
-
-#endif /* BGW_JOB_H */

--- a/src/bgw/job_stat.h
+++ b/src/bgw/job_stat.h
@@ -3,8 +3,7 @@
  * Please see the included NOTICE for copyright information and
  * LICENSE-APACHE for a copy of the license.
  */
-#ifndef BGW_JOB_STAT_H
-#define BGW_JOB_STAT_H
+#pragma once
 
 #include "ts_catalog/catalog.h"
 #include "job.h"
@@ -45,4 +44,3 @@ extern TSDLLEXPORT void ts_bgw_job_stat_mark_crash_reported(int32 bgw_job_id);
 
 extern TSDLLEXPORT TimestampTz ts_get_next_scheduled_execution_slot(BgwJob *job,
 																	TimestampTz finish_time);
-#endif /* BGW_JOB_STAT_H */

--- a/src/bgw/launcher_interface.h
+++ b/src/bgw/launcher_interface.h
@@ -3,8 +3,7 @@
  * Please see the included NOTICE for copyright information and
  * LICENSE-APACHE for a copy of the license.
  */
-#ifndef TIMESCALEDB_BGW_LAUNCHER_INTERFACE_H
-#define TIMESCALEDB_BGW_LAUNCHER_INTERFACE_H
+#pragma once
 
 #include <postgres.h>
 
@@ -13,4 +12,3 @@ extern void ts_bgw_worker_release(void);
 extern int ts_bgw_num_unreserved(void);
 extern int ts_bgw_loader_api_version(void);
 extern void ts_bgw_check_loader_api_version(void);
-#endif /* TIMESCALEDB_BGW_LAUNCHER_INTERFACE_H */

--- a/src/bgw/scheduler.h
+++ b/src/bgw/scheduler.h
@@ -3,8 +3,8 @@
  * Please see the included NOTICE for copyright information and
  * LICENSE-APACHE for a copy of the license.
  */
-#ifndef BGW_SCHEDULER_H
-#define BGW_SCHEDULER_H
+#pragma once
+
 #include <postgres.h>
 #include <fmgr.h>
 #include "compat/compat.h"
@@ -36,5 +36,3 @@ extern void ts_bgw_scheduler_register_signal_handlers(void);
 extern void ts_bgw_scheduler_setup_mctx(void);
 
 extern BackgroundWorkerHandle *ts_bgw_start_worker(const char *name, const BgwParams *bgw_params);
-
-#endif /* BGW_SCHEDULER_H */

--- a/src/bgw/timer.h
+++ b/src/bgw/timer.h
@@ -3,8 +3,7 @@
  * Please see the included NOTICE for copyright information and
  * LICENSE-APACHE for a copy of the license.
  */
-#ifndef BGW_TIMER_H
-#define BGW_TIMER_H
+#pragma once
 
 #include <postgres.h>
 #include <utils/timestamp.h>
@@ -26,5 +25,3 @@ extern TSDLLEXPORT TimestampTz ts_timer_get_current_timestamp(void);
 extern void ts_timer_set(const Timer *timer);
 extern const Timer *ts_get_standard_timer(void);
 #endif
-
-#endif /* BGW_TIMER_H */

--- a/src/bgw/worker.h
+++ b/src/bgw/worker.h
@@ -3,9 +3,7 @@
  * Please see the included NOTICE for copyright information and
  * LICENSE-APACHE for a copy of the license.
  */
-
-#ifndef BGW_WORKER_H
-#define BGW_WORKER_H
+#pragma once
 
 #include <postgres.h>
 
@@ -49,5 +47,3 @@ typedef struct BgwParams
  */
 StaticAssertDecl(sizeof(BgwParams) <= sizeof(((BackgroundWorker *) 0)->bgw_extra),
 				 "sizeof(BgwParams) exceeds sizeof(bgw_extra) field of BackgroundWorker");
-
-#endif /* BGW_WORKER_H */

--- a/src/bgw_policy/chunk_stats.h
+++ b/src/bgw_policy/chunk_stats.h
@@ -3,9 +3,7 @@
  * Please see the included NOTICE for copyright information and
  * LICENSE-APACHE for a copy of the license.
  */
-
-#ifndef TIMESCALEDB_BGW_JOB_CHUNK_STATS_H
-#define TIMESCALEDB_BGW_JOB_CHUNK_STATS_H
+#pragma once
 
 #include "ts_catalog/catalog.h"
 #include "export.h"
@@ -21,5 +19,3 @@ extern void ts_bgw_policy_chunk_stats_delete_row_only_by_job_id(int32 job_id);
 extern void ts_bgw_policy_chunk_stats_delete_by_chunk_id(int32 chunk_id);
 extern TSDLLEXPORT void ts_bgw_policy_chunk_stats_record_job_run(int32 job_id, int32 chunk_id,
 																 TimestampTz last_time_job_run);
-
-#endif /* TIMESCALEDB_BGW_JOB_CHUNK_STATS_H */

--- a/src/bgw_policy/policy.h
+++ b/src/bgw_policy/policy.h
@@ -3,9 +3,7 @@
  * Please see the included NOTICE for copyright information and
  * LICENSE-APACHE for a copy of the license.
  */
-
-#ifndef TIMESCALEDB_BGW_POLICY_POLICY_H
-#define TIMESCALEDB_BGW_POLICY_POLICY_H
+#pragma once
 
 #include "scanner.h"
 #include "ts_catalog/catalog.h"
@@ -15,5 +13,3 @@
 extern ScanTupleResult ts_bgw_policy_delete_row_only_tuple_found(TupleInfo *ti, void *const data);
 
 extern void ts_bgw_policy_delete_by_hypertable_id(int32 hypertable_id);
-
-#endif /* TIMESCALEDB_BGW_POLICY_POLICY_H */

--- a/src/cache.h
+++ b/src/cache.h
@@ -3,8 +3,7 @@
  * Please see the included NOTICE for copyright information and
  * LICENSE-APACHE for a copy of the license.
  */
-#ifndef TIMESCALEDB_CACHE_H
-#define TIMESCALEDB_CACHE_H
+#pragma once
 
 #include <postgres.h>
 #include <utils/memutils.h>
@@ -71,5 +70,3 @@ extern TSDLLEXPORT int ts_cache_release(Cache *cache);
 
 extern void _cache_init(void);
 extern void _cache_fini(void);
-
-#endif /* TIMESCALEDB_CACHE_H */

--- a/src/cache_invalidate.h
+++ b/src/cache_invalidate.h
@@ -3,11 +3,8 @@
  * Please see the included NOTICE for copyright information and
  * LICENSE-APACHE for a copy of the license.
  */
-#ifndef TIMESCALEDB_CACHE_INVALIDATE_H
-#define TIMESCALEDB_CACHE_INVALIDATE_H
+#pragma once
 
 #include <postgres.h>
 
 extern void ts_cache_invalidate_set_proxy_tables(Oid hypertable_proxy_oid, Oid bgw_proxy_oid);
-
-#endif /* TIMESCALEDB_CACHE_INVALIDATE_H */

--- a/src/chunk.h
+++ b/src/chunk.h
@@ -3,8 +3,7 @@
  * Please see the included NOTICE for copyright information and
  * LICENSE-APACHE for a copy of the license.
  */
-#ifndef TIMESCALEDB_CHUNK_H
-#define TIMESCALEDB_CHUNK_H
+#pragma once
 
 #include <postgres.h>
 #include <access/htup.h>
@@ -330,5 +329,3 @@ extern TSDLLEXPORT void ts_chunk_merge_on_dimension(const Hypertable *ht, Chunk 
 extern TSDLLEXPORT bool ts_chunk_clear_status(Chunk *chunk, int32 status);
 extern bool ts_osm_chunk_range_is_invalid(int64 range_start, int64 range_end);
 extern int32 ts_chunk_get_osm_slice_id(int32 chunk_id, int32 time_dim_id);
-
-#endif /* TIMESCALEDB_CHUNK_H */

--- a/src/chunk_adaptive.h
+++ b/src/chunk_adaptive.h
@@ -1,8 +1,7 @@
 /*
  * NOTE: adaptive chunking is still in BETA
  */
-#ifndef TIMESCALEDB_CHUNK_ADAPTIVE_H
-#define TIMESCALEDB_CHUNK_ADAPTIVE_H
+#pragma once
 
 #include <postgres.h>
 
@@ -28,5 +27,3 @@ extern void ts_chunk_sizing_func_validate(regproc func, ChunkSizingInfo *info);
 extern TSDLLEXPORT ChunkSizingInfo *ts_chunk_sizing_info_get_default_disabled(Oid table_relid);
 
 extern TSDLLEXPORT int64 ts_chunk_calculate_initial_chunk_target_size(void);
-
-#endif /* TIMESCALEDB_CHUNK_ADAPTIVE_H */

--- a/src/chunk_constraint.h
+++ b/src/chunk_constraint.h
@@ -3,8 +3,7 @@
  * Please see the included NOTICE for copyright information and
  * LICENSE-APACHE for a copy of the license.
  */
-#ifndef TIMESCALEDB_CHUNK_CONSTRAINT_H
-#define TIMESCALEDB_CHUNK_CONSTRAINT_H
+#pragma once
 
 #include <postgres.h>
 #include <nodes/pg_list.h>
@@ -89,5 +88,3 @@ extern ChunkConstraint *ts_chunk_constraints_add_from_tuple(ChunkConstraints *cc
 extern ScanIterator ts_chunk_constraint_scan_iterator_create(MemoryContext result_mcxt);
 extern void ts_chunk_constraint_scan_iterator_set_slice_id(ScanIterator *it, int32 slice_id);
 extern void ts_chunk_constraint_scan_iterator_set_chunk_id(ScanIterator *it, int32 chunk_id);
-
-#endif /* TIMESCALEDB_CHUNK_CONSTRAINT_H */

--- a/src/chunk_index.h
+++ b/src/chunk_index.h
@@ -3,8 +3,7 @@
  * Please see the included NOTICE for copyright information and
  * LICENSE-APACHE for a copy of the license.
  */
-#ifndef TIMESCALEDB_CHUNK_INDEX_H
-#define TIMESCALEDB_CHUNK_INDEX_H
+#pragma once
 
 #include <postgres.h>
 #include <nodes/execnodes.h>
@@ -100,5 +99,3 @@ chunk_index_need_attnos_adjustment(TupleDesc htdesc, TupleDesc chunkdesc)
 {
 	return chunk_index_columns_changed(htdesc->natts, chunkdesc);
 }
-
-#endif /* TIMESCALEDB_CHUNK_INDEX_H */

--- a/src/chunk_scan.h
+++ b/src/chunk_scan.h
@@ -3,8 +3,7 @@
  * Please see the included NOTICE for copyright information and
  * LICENSE-APACHE for a copy of the license.
  */
-#ifndef TIMESCALEDB_CHUNK_SCAN_H
-#define TIMESCALEDB_CHUNK_SCAN_H
+#pragma once
 
 #include <postgres.h>
 
@@ -12,5 +11,3 @@
 
 extern Chunk **ts_chunk_scan_by_chunk_ids(const Hyperspace *hs, const List *chunk_ids,
 										  unsigned int *num_chunks);
-
-#endif /* TIMESCALEDB_CHUNK_SCAN_H */

--- a/src/compat/compat-msvc-enter.h
+++ b/src/compat/compat-msvc-enter.h
@@ -3,8 +3,7 @@
  * Please see the included NOTICE for copyright information and
  * LICENSE-APACHE for a copy of the license.
  */
-#ifndef TIMESCALEDB_COMPAT_MSVC_ENTER_H
-#define TIMESCALEDB_COMPAT_MSVC_ENTER_H
+#pragma once
 
 #include <postgres.h>
 
@@ -43,5 +42,3 @@
 #endif
 
 #endif /* _MSC_VER */
-
-#endif /* TIMESCALEDB_COMPAT_MSVC_ENTER_H */

--- a/src/compat/compat-msvc-exit.h
+++ b/src/compat/compat-msvc-exit.h
@@ -3,8 +3,7 @@
  * Please see the included NOTICE for copyright information and
  * LICENSE-APACHE for a copy of the license.
  */
-#ifndef TIMESCALEDB_COMPAT_MSVC_EXIT_H
-#define TIMESCALEDB_COMPAT_MSVC_EXIT_H
+#pragma once
 
 /*
  * Included after all files that need compatibility are included, this undoes
@@ -15,5 +14,3 @@
 #undef PGDLLIMPORT
 #define PGDLLIMPORT __declspec(dllexport)
 #endif /* _MSC_VER */
-
-#endif /* TIMESCALEDB_COMPAT_MSVC_EXIT_H */

--- a/src/compat/compat.h
+++ b/src/compat/compat.h
@@ -3,8 +3,7 @@
  * Please see the included NOTICE for copyright information and
  * LICENSE-APACHE for a copy of the license.
  */
-#ifndef TIMESCALEDB_COMPAT_H
-#define TIMESCALEDB_COMPAT_H
+#pragma once
 
 #include <postgres.h>
 #include <commands/cluster.h>
@@ -1059,5 +1058,3 @@ error_severity(int elevel)
 	return prefix;
 }
 #endif
-
-#endif /* TIMESCALEDB_COMPAT_H */

--- a/src/compression_with_clause.h
+++ b/src/compression_with_clause.h
@@ -3,8 +3,8 @@
  * Please see the included NOTICE for copyright information and
  * LICENSE-APACHE for a copy of the license.
  */
-#ifndef TIMESCALEDB_COMPRESSION_WITH_CLAUSE_H
-#define TIMESCALEDB_COMPRESSION_WITH_CLAUSE_H
+#pragma once
+
 #include <postgres.h>
 #include <catalog/pg_type.h>
 
@@ -38,5 +38,3 @@ extern TSDLLEXPORT List *ts_compress_hypertable_parse_order_by(WithClauseResult 
 extern TSDLLEXPORT Interval *
 ts_compress_hypertable_parse_chunk_time_interval(WithClauseResult *parsed_options,
 												 Hypertable *hypertable);
-
-#endif

--- a/src/constraint.h
+++ b/src/constraint.h
@@ -3,8 +3,7 @@
  * Please see the included NOTICE for copyright information and
  * LICENSE-APACHE for a copy of the license.
  */
-#ifndef TIMESCALEDB_CONSTRAINT_H
-#define TIMESCALEDB_CONSTRAINT_H
+#pragma once
 
 #include <postgres.h>
 #include <access/htup.h>
@@ -28,5 +27,3 @@ typedef enum ConstraintProcessStatus
 
 typedef ConstraintProcessStatus (*constraint_func)(HeapTuple constraint_tuple, void *ctx);
 extern TSDLLEXPORT int ts_constraint_process(Oid relid, constraint_func process_func, void *ctx);
-
-#endif /* TIMESCALEDB_CONSTRAINT_H */

--- a/src/copy.h
+++ b/src/copy.h
@@ -3,8 +3,7 @@
  * Please see the included NOTICE for copyright information and
  * LICENSE-APACHE for a copy of the license.
  */
-#ifndef TIMESCALEDB_COPY_H
-#define TIMESCALEDB_COPY_H
+#pragma once
 
 #include <postgres.h>
 #include <nodes/parsenodes.h>
@@ -35,5 +34,3 @@ typedef struct CopyChunkState
 extern void timescaledb_DoCopy(const CopyStmt *stmt, const char *queryString, uint64 *processed,
 							   Hypertable *ht);
 extern void timescaledb_move_from_table_to_chunks(Hypertable *ht, LOCKMODE lockmode);
-
-#endif /* TIMESCALEDB_COPY_H */

--- a/src/cross_module_fn.h
+++ b/src/cross_module_fn.h
@@ -3,8 +3,7 @@
  * Please see the included NOTICE for copyright information and
  * LICENSE-APACHE for a copy of the license.
  */
-#ifndef TIMESCALEDB_CROSS_MODULE_FN_H
-#define TIMESCALEDB_CROSS_MODULE_FN_H
+#pragma once
 
 #include <postgres.h>
 #include <fmgr.h>
@@ -220,5 +219,3 @@ typedef struct CrossModuleFunctions
 
 extern TSDLLEXPORT CrossModuleFunctions *ts_cm_functions;
 extern TSDLLEXPORT CrossModuleFunctions ts_cm_functions_default;
-
-#endif /* TIMESCALEDB_CROSS_MODULE_FN_H */

--- a/src/custom_type_cache.h
+++ b/src/custom_type_cache.h
@@ -3,8 +3,7 @@
  * Please see the included NOTICE for copyright information and
  * LICENSE-APACHE for a copy of the license.
  */
-#ifndef TIMESCALEDB_TYPE_CACHE_H
-#define TIMESCALEDB_TYPE_CACHE_H
+#pragma once
 
 #include <postgres.h>
 #include "compat/compat.h"
@@ -26,5 +25,3 @@ typedef struct CustomTypeInfo
 } CustomTypeInfo;
 
 extern TSDLLEXPORT CustomTypeInfo *ts_custom_type_cache_get(CustomType type);
-
-#endif /* TIMESCALEDB_TYPE_CACHE_H */

--- a/src/debug_assert.h
+++ b/src/debug_assert.h
@@ -3,8 +3,7 @@
  * Please see the included NOTICE for copyright information and
  * LICENSE-APACHE for a copy of the license.
  */
-#ifndef TIMESCALEDB_DEBUG_ASSERT_H
-#define TIMESCALEDB_DEBUG_ASSERT_H
+#pragma once
 
 #include <postgres.h>
 
@@ -37,5 +36,3 @@
 					 errmsg(FMT, ##__VA_ARGS__)));                                                 \
 	} while (0)
 #endif
-
-#endif /* TIMESCALEDB_DEBUG_ASSERT_H */

--- a/src/debug_guc.h
+++ b/src/debug_guc.h
@@ -3,8 +3,7 @@
  * Please see the included NOTICE for copyright information and
  * LICENSE-APACHE for a copy of the license.
  */
-#ifndef TIMESCALEDB_DEBUG_GUC_H
-#define TIMESCALEDB_DEBUG_GUC_H
+#pragma once
 
 #include <postgres.h>
 #include <fmgr.h>
@@ -43,5 +42,3 @@ typedef struct DebugOptimizerFlags
 extern TSDLLEXPORT DebugOptimizerFlags ts_debug_optimizer_flags;
 
 extern void ts_debug_init(void);
-
-#endif /* TIMESCALEDB_DEBUG_GUC_H */

--- a/src/debug_point.h
+++ b/src/debug_point.h
@@ -3,8 +3,7 @@
  * Please see the included NOTICE for copyright information and
  * LICENSE-APACHE for a copy of the license.
  */
-#ifndef TIMESCALEDB_DEBUG_POINT_H_
-#define TIMESCALEDB_DEBUG_POINT_H_
+#pragma once
 
 #include <postgres.h>
 #include "export.h"
@@ -25,5 +24,3 @@ extern TSDLLEXPORT void ts_debug_point_raise_error_if_enabled(const char *name);
 #define DEBUG_ERROR_INJECTION(NAME)
 
 #endif
-
-#endif /* TIMESCALEDB_DEBUG_POINT_H_ */

--- a/src/dimension.h
+++ b/src/dimension.h
@@ -3,8 +3,7 @@
  * Please see the included NOTICE for copyright information and
  * LICENSE-APACHE for a copy of the license.
  */
-#ifndef TIMESCALEDB_DIMENSION_H
-#define TIMESCALEDB_DIMENSION_H
+#pragma once
 
 #include <postgres.h>
 #include <access/attnum.h>
@@ -168,5 +167,3 @@ extern TSDLLEXPORT Datum ts_dimension_info_out(PG_FUNCTION_ARGS);
 	ts_hyperspace_get_dimension(space, DIMENSION_TYPE_OPEN, i)
 #define hyperspace_get_closed_dimension(space, i)                                                  \
 	ts_hyperspace_get_dimension(space, DIMENSION_TYPE_CLOSED, i)
-
-#endif /* TIMESCALEDB_DIMENSION_H */

--- a/src/dimension_slice.h
+++ b/src/dimension_slice.h
@@ -3,8 +3,7 @@
  * Please see the included NOTICE for copyright information and
  * LICENSE-APACHE for a copy of the license.
  */
-#ifndef TIMESCALEDB_DIMENSION_SLICE_H
-#define TIMESCALEDB_DIMENSION_SLICE_H
+#pragma once
 
 #include <postgres.h>
 #include <nodes/pg_list.h>
@@ -115,5 +114,3 @@ extern int ts_dimension_slice_update_by_id(int32 dimension_slice_id,
 
 #define dimension_slice_collision_scan(dimension_id, range_start, range_end)                       \
 	ts_dimension_slice_collision_scan_limit(dimension_id, range_start, range_end, 0)
-
-#endif /* TIMESCALEDB_DIMENSION_SLICE_H */

--- a/src/dimension_vector.h
+++ b/src/dimension_vector.h
@@ -3,8 +3,7 @@
  * Please see the included NOTICE for copyright information and
  * LICENSE-APACHE for a copy of the license.
  */
-#ifndef TIMESCALEDB_DIMENSION_VECTOR_H
-#define TIMESCALEDB_DIMENSION_VECTOR_H
+#pragma once
 
 #include <postgres.h>
 
@@ -39,5 +38,3 @@ extern DimensionSlice *ts_dimension_vec_find_slice(const DimensionVec *vec, int6
 extern int ts_dimension_vec_find_slice_index(const DimensionVec *vec, int32 dimension_slice_id);
 extern const DimensionSlice *ts_dimension_vec_get(const DimensionVec *vec, int32 index);
 extern void ts_dimension_vec_free(DimensionVec *vec);
-
-#endif /* TIMESCALEDB_DIMENSION_VECTOR_H */

--- a/src/error_utils.h
+++ b/src/error_utils.h
@@ -3,8 +3,7 @@
  * Please see the included NOTICE for copyright information and
  * LICENSE-APACHE for a copy of the license.
  */
-#ifndef TIMESCALEDB_ERROR_UTILS_H
-#define TIMESCALEDB_ERROR_UTILS_H
+#pragma once
 
 #define GETARG_NOTNULL_OID(var, arg, name)                                                         \
 	{                                                                                              \
@@ -32,5 +31,3 @@
 					 errmsg("%s cannot be NULL", name)));                                          \
 		var = PG_GETARG_##type(arg);                                                               \
 	}
-
-#endif /* TIMESCALEDB_ERROR_UTILS_H */

--- a/src/errors.h
+++ b/src/errors.h
@@ -3,6 +3,8 @@
  * Please see the included NOTICE for copyright information and
  * LICENSE-APACHE for a copy of the license.
  */
+#pragma once
+
 /* Defines error codes used
 -- PREFIX TS
 */

--- a/src/estimate.h
+++ b/src/estimate.h
@@ -3,8 +3,7 @@
  * Please see the included NOTICE for copyright information and
  * LICENSE-APACHE for a copy of the license.
  */
-#ifndef TIMESCALEDB_ESTIMATE_H
-#define TIMESCALEDB_ESTIMATE_H
+#pragma once
 
 #include <postgres.h>
 
@@ -14,5 +13,3 @@
 extern double ts_estimate_group_expr_interval(PlannerInfo *root, Expr *expr,
 											  double interval_period);
 extern double ts_estimate_group(PlannerInfo *root, double path_rows);
-
-#endif /* TIMESCALEDB_ESTIMATE_H */

--- a/src/event_trigger.h
+++ b/src/event_trigger.h
@@ -3,8 +3,7 @@
  * Please see the included NOTICE for copyright information and
  * LICENSE-APACHE for a copy of the license.
  */
-#ifndef TIMESCALEDB_EVENT_TRIGGER_H
-#define TIMESCALEDB_EVENT_TRIGGER_H
+#pragma once
 
 #include <postgres.h>
 #include <nodes/pg_list.h>
@@ -72,5 +71,3 @@ extern List *ts_event_trigger_dropped_objects(void);
 extern List *ts_event_trigger_ddl_commands(void);
 extern void _event_trigger_init(void);
 extern void _event_trigger_fini(void);
-
-#endif /* TIMESCALEDB_EVENT_TRIGGER_H */

--- a/src/export.h
+++ b/src/export.h
@@ -3,8 +3,7 @@
  * Please see the included NOTICE for copyright information and
  * LICENSE-APACHE for a copy of the license.
  */
-#ifndef TIMESCALEDB_EXPORT_H
-#define TIMESCALEDB_EXPORT_H
+#pragma once
 
 #include <postgres.h>
 
@@ -56,5 +55,3 @@
 #define TS_FUNCTION_INFO_V1(fn)                                                                    \
 	PGDLLEXPORT Datum fn(PG_FUNCTION_ARGS);                                     \
 	PG_FUNCTION_INFO_V1(fn)
-
-#endif /* TIMESCALEDB_EXPORT_H */

--- a/src/extension.h
+++ b/src/extension.h
@@ -3,8 +3,8 @@
  * Please see the included NOTICE for copyright information and
  * LICENSE-APACHE for a copy of the license.
  */
-#ifndef TIMESCALEDB_EXTENSION_H
-#define TIMESCALEDB_EXTENSION_H
+#pragma once
+
 #include <postgres.h>
 #include <nodes/parsenodes.h>
 
@@ -22,5 +22,3 @@ extern const char *ts_extension_get_so_name(void);
 extern TSDLLEXPORT const char *ts_extension_get_version(void);
 extern bool ts_extension_is_proxy_table_relid(Oid relid);
 extern TSDLLEXPORT Oid ts_extension_get_oid(void);
-
-#endif /* TIMESCALEDB_EXTENSION_H */

--- a/src/extension_constants.h
+++ b/src/extension_constants.h
@@ -3,8 +3,7 @@
  * Please see the included NOTICE for copyright information and
  * LICENSE-APACHE for a copy of the license.
  */
-#ifndef TIMESCALEDB_EXTENSION_CONSTANTS_H
-#define TIMESCALEDB_EXTENSION_CONSTANTS_H
+#pragma once
 
 /* No function definitions here, only potentially globally available defines as this is used by the
  * loader*/
@@ -46,5 +45,3 @@ typedef enum TsExtensionSchemas
 extern const char *const ts_extension_schema_names[];
 
 #define RENDEZVOUS_BGW_LOADER_API_VERSION "timescaledb.bgw_loader_api_version"
-
-#endif /* TIMESCALEDB_EXTENSION_CONSTANTS_H */

--- a/src/func_cache.h
+++ b/src/func_cache.h
@@ -3,8 +3,7 @@
  * Please see the included NOTICE for copyright information and
  * LICENSE-APACHE for a copy of the license.
  */
-#ifndef TIMESCALEDB_FUNC_CACHE_H
-#define TIMESCALEDB_FUNC_CACHE_H
+#pragma once
 
 #include <postgres.h>
 #include <nodes/primnodes.h>
@@ -48,5 +47,3 @@ typedef struct FuncInfo
 
 extern TSDLLEXPORT FuncInfo *ts_func_cache_get(Oid funcid);
 extern TSDLLEXPORT FuncInfo *ts_func_cache_get_bucketing_func(Oid funcid);
-
-#endif /* TIMESCALEDB_FUNC_CACHE_H */

--- a/src/gapfill.h
+++ b/src/gapfill.h
@@ -3,11 +3,8 @@
  * Please see the included NOTICE for copyright information and
  * LICENSE-APACHE for a copy of the license.
  */
-#ifndef TIMESCALEDB_GAPFILL_H
-#define TIMESCALEDB_GAPFILL_H
+#pragma once
 
 #define GAPFILL_PATH_NAME "GapFill"
 
 extern bool ts_is_gapfill_path(Path *path);
-
-#endif

--- a/src/guc.h
+++ b/src/guc.h
@@ -3,8 +3,7 @@
  * Please see the included NOTICE for copyright information and
  * LICENSE-APACHE for a copy of the license.
  */
-#ifndef TIMESCALEDB_GUC_H
-#define TIMESCALEDB_GUC_H
+#pragma once
 
 #include <postgres.h>
 #include "export.h"
@@ -133,5 +132,3 @@ typedef enum
 } FeatureFlagType;
 
 extern TSDLLEXPORT void ts_feature_flag_check(FeatureFlagType);
-
-#endif /* TIMESCALEDB_GUC_H */

--- a/src/hypercube.h
+++ b/src/hypercube.h
@@ -3,8 +3,7 @@
  * Please see the included NOTICE for copyright information and
  * LICENSE-APACHE for a copy of the license.
  */
-#ifndef TIMESCALEDB_HYPERCUBE_H
-#define TIMESCALEDB_HYPERCUBE_H
+#pragma once
 
 #include <postgres.h>
 
@@ -45,5 +44,3 @@ extern TSDLLEXPORT const DimensionSlice *ts_hypercube_get_slice_by_dimension_id(
 extern Hypercube *ts_hypercube_copy(const Hypercube *hc);
 extern bool ts_hypercube_equal(const Hypercube *hc1, const Hypercube *hc2);
 extern void ts_hypercube_slice_sort(Hypercube *hc);
-
-#endif /* TIMESCALEDB_HYPERCUBE_H */

--- a/src/hypertable.h
+++ b/src/hypertable.h
@@ -3,8 +3,7 @@
  * Please see the included NOTICE for copyright information and
  * LICENSE-APACHE for a copy of the license.
  */
-#ifndef TIMESCALEDB_HYPERTABLE_H
-#define TIMESCALEDB_HYPERTABLE_H
+#pragma once
 
 #include <postgres.h>
 #include <nodes/primnodes.h>
@@ -202,5 +201,3 @@ extern TSDLLEXPORT int16 ts_validate_replication_factor(const char *hypertable_n
 	(hypertable_is_distributed(ht) ? RELKIND_FOREIGN_TABLE : RELKIND_RELATION)
 #define hypertable_is_distributed_member(ht)                                                       \
 	((ht)->fd.replication_factor == HYPERTABLE_DISTRIBUTED_MEMBER)
-
-#endif /* TIMESCALEDB_HYPERTABLE_H */

--- a/src/hypertable_cache.h
+++ b/src/hypertable_cache.h
@@ -3,8 +3,7 @@
  * Please see the included NOTICE for copyright information and
  * LICENSE-APACHE for a copy of the license.
  */
-#ifndef TIMESCALEDB_HYPERTABLE_CACHE_H
-#define TIMESCALEDB_HYPERTABLE_CACHE_H
+#pragma once
 
 #include <postgres.h>
 
@@ -59,5 +58,3 @@ extern TSDLLEXPORT Cache *ts_hypertable_cache_pin(void);
 
 extern void _hypertable_cache_init(void);
 extern void _hypertable_cache_fini(void);
-
-#endif /* TIMESCALEDB_HYPERTABLE_CACHE_H */

--- a/src/hypertable_restrict_info.h
+++ b/src/hypertable_restrict_info.h
@@ -3,8 +3,7 @@
  * Please see the included NOTICE for copyright information and
  * LICENSE-APACHE for a copy of the license.
  */
-#ifndef TIMESCALEDB_HYPERTABLE_RESTRICT_INFO_H
-#define TIMESCALEDB_HYPERTABLE_RESTRICT_INFO_H
+#pragma once
 
 #include "hypertable.h"
 
@@ -29,5 +28,3 @@ extern Chunk **ts_hypertable_restrict_info_get_chunks_ordered(HypertableRestrict
 															  Hypertable *ht, Chunk **chunks,
 															  bool reverse, List **nested_oids,
 															  unsigned int *num_chunks);
-
-#endif /* TIMESCALEDB_HYPERTABLE_RESTRICT_INFO_H */

--- a/src/import/allpaths.h
+++ b/src/import/allpaths.h
@@ -3,8 +3,7 @@
  * Please see the included NOTICE for copyright information and
  * LICENSE-APACHE for a copy of the license.
  */
-#ifndef TIMESCALEDB_IMPORT_ALLPATHS_H
-#define TIMESCALEDB_IMPORT_ALLPATHS_H
+#pragma once
 
 #include <postgres.h>
 #include <nodes/pathnodes.h>
@@ -15,5 +14,3 @@ extern void ts_set_rel_size(PlannerInfo *root, RelOptInfo *rel, Index rti, Range
 extern void ts_set_append_rel_pathlist(PlannerInfo *root, RelOptInfo *rel, Index rti,
 									   RangeTblEntry *rte);
 extern TSDLLEXPORT void ts_set_dummy_rel_pathlist(RelOptInfo *rel);
-
-#endif /* TIMESCALEDB_IMPORT_ALLPATHS_H */

--- a/src/import/ht_hypertable_modify.h
+++ b/src/import/ht_hypertable_modify.h
@@ -3,6 +3,7 @@
  * Please see the included NOTICE for copyright information and
  * LICENSE-APACHE for a copy of the license.
  */
+#pragma once
 
 /*
  * This file contains source code that was copied and/or modified from the

--- a/src/import/planner.h
+++ b/src/import/planner.h
@@ -3,6 +3,7 @@
  * Please see the included NOTICE for copyright information and
  * LICENSE-APACHE for a copy of the license.
  */
+#pragma once
 
 /*
  * This file contains source code that was copied and/or modified from
@@ -14,8 +15,6 @@
  * they were declared static in the core planner, but we need them for
  * our manipulations.
  */
-#ifndef TIMESCALEDB_PLANNER_IMPORT_H
-#define TIMESCALEDB_PLANNER_IMPORT_H
 
 #include <postgres.h>
 #include <nodes/execnodes.h>
@@ -52,5 +51,3 @@ extern TSDLLEXPORT PathKey *ts_make_pathkey_from_sortop(PlannerInfo *root, Expr 
 extern TSDLLEXPORT List *ts_build_path_tlist(PlannerInfo *root, Path *path);
 
 extern void ts_ExecSetTupleBound(int64 tuples_needed, PlanState *child_node);
-
-#endif /* TIMESCALEDB_PLANNER_IMPORT_H */

--- a/src/import/ts_explain.h
+++ b/src/import/ts_explain.h
@@ -3,6 +3,7 @@
  * Please see the included NOTICE for copyright information and
  * LICENSE-APACHE for a copy of the license.
  */
+#pragma once
 
 /*
  * This file contains source code that was copied and/or modified from
@@ -10,8 +11,6 @@
  * PostgreSQL License. Please see the NOTICE at the top level
  * directory for a copy of the PostgreSQL License.
  */
-
-#pragma once
 
 #include <postgres.h>
 

--- a/src/indexing.h
+++ b/src/indexing.h
@@ -3,8 +3,7 @@
  * Please see the included NOTICE for copyright information and
  * LICENSE-APACHE for a copy of the license.
  */
-#ifndef TIMESCALEDB_INDEXING_H
-#define TIMESCALEDB_INDEXING_H
+#pragma once
 
 #include <postgres.h>
 #include <nodes/pg_list.h>
@@ -25,5 +24,3 @@ extern TSDLLEXPORT Oid ts_indexing_find_clustered_index(Oid table_relid);
 extern void ts_indexing_mark_as_valid(Oid index_id);
 extern bool ts_indexing_mark_as_invalid(Oid index_id);
 extern bool TSDLLEXPORT ts_indexing_relation_has_primary_or_unique_index(Relation htrel);
-
-#endif /* TIMESCALEDB_INDEXING_H */

--- a/src/jsonb_utils.h
+++ b/src/jsonb_utils.h
@@ -3,8 +3,7 @@
  * Please see the included NOTICE for copyright information and
  * LICENSE-APACHE for a copy of the license.
  */
-#ifndef TIMESCALEDB_JSONB_UTILS_H
-#define TIMESCALEDB_JSONB_UTILS_H
+#pragma once
 
 #include <utils/datetime.h>
 #include <utils/json.h>
@@ -37,5 +36,3 @@ extern TSDLLEXPORT int32 ts_jsonb_get_int32_field(const Jsonb *json, const char 
 												  bool *field_found);
 extern TSDLLEXPORT int64 ts_jsonb_get_int64_field(const Jsonb *json, const char *key,
 												  bool *field_found);
-
-#endif /* TIMESCALEDB_JSONB_UTILS_H */

--- a/src/license_guc.h
+++ b/src/license_guc.h
@@ -3,8 +3,7 @@
  * Please see the included NOTICE for copyright information and
  * LICENSE-APACHE for a copy of the license.
  */
-#ifndef TIMESCALEDB_LICENSE_GUC_H
-#define TIMESCALEDB_LICENSE_GUC_H
+#pragma once
 
 #include <postgres.h>
 #include <fmgr.h>
@@ -30,5 +29,3 @@ extern void ts_license_guc_assign_hook(const char *newval, void *extra);
 
 extern TSDLLEXPORT void ts_license_enable_module_loading(void);
 extern bool ts_license_is_apache(void);
-
-#endif /* TIMESCALEDB_LICENSE_GUC_H */

--- a/src/loader/bgw_counter.h
+++ b/src/loader/bgw_counter.h
@@ -3,9 +3,7 @@
  * Please see the included NOTICE for copyright information and
  * LICENSE-APACHE for a copy of the license.
  */
-
-#ifndef TIMESCALEDB_BGW_COUNTER_H
-#define TIMESCALEDB_BGW_COUNTER_H
+#pragma once
 
 #include <postgres.h>
 
@@ -22,5 +20,3 @@ extern void ts_bgw_total_workers_decrement(void);
 extern int ts_bgw_total_workers_get(void);
 extern bool ts_bgw_total_workers_increment_by(int increment_by);
 extern void ts_bgw_total_workers_decrement_by(int decrement_by);
-
-#endif /* TIMESCALEDB_BGW_COUNTER_H */

--- a/src/loader/bgw_interface.h
+++ b/src/loader/bgw_interface.h
@@ -3,12 +3,9 @@
  * Please see the included NOTICE for copyright information and
  * LICENSE-APACHE for a copy of the license.
  */
-#ifndef TIMESCALEDB_BGW_INTERFACE_H
-#define TIMESCALEDB_BGW_INTERFACE_H
+#pragma once
 
 #include <postgres.h>
 
 extern void ts_bgw_interface_register_api_version(void);
 extern const int32 ts_bgw_loader_api_version;
-
-#endif

--- a/src/loader/bgw_launcher.h
+++ b/src/loader/bgw_launcher.h
@@ -3,9 +3,7 @@
  * Please see the included NOTICE for copyright information and
  * LICENSE-APACHE for a copy of the license.
  */
-
-#ifndef TIMESCALEDB_BGW_LAUNCHER_H
-#define TIMESCALEDB_BGW_LAUNCHER_H
+#pragma once
 
 #include <postgres.h>
 #include <fmgr.h>
@@ -15,5 +13,3 @@ extern void ts_bgw_cluster_launcher_register(void);
 /*called by postmaster at launcher bgw startup*/
 TSDLLEXPORT extern Datum ts_bgw_cluster_launcher_main(PG_FUNCTION_ARGS);
 TSDLLEXPORT extern Datum ts_bgw_db_scheduler_entrypoint(PG_FUNCTION_ARGS);
-
-#endif /* TIMESCALEDB_BGW_LAUNCHER_H */

--- a/src/loader/bgw_message_queue.h
+++ b/src/loader/bgw_message_queue.h
@@ -3,8 +3,7 @@
  * Please see the included NOTICE for copyright information and
  * LICENSE-APACHE for a copy of the license.
  */
-#ifndef TIMESCALEDB_BGW_MESSAGE_QUEUE_H
-#define TIMESCALEDB_BGW_MESSAGE_QUEUE_H
+#pragma once
 
 #include <postgres.h>
 #include <storage/dsm.h>
@@ -39,5 +38,3 @@ extern void ts_bgw_message_queue_alloc(void);
 /*called in every backend during shmem startup hook*/
 extern void ts_bgw_message_queue_shmem_startup(void);
 extern void ts_bgw_message_queue_shmem_cleanup(void);
-
-#endif /* TIMESCALEDB_BGW_MESSAGE_QUEUE_H */

--- a/src/loader/function_telemetry.h
+++ b/src/loader/function_telemetry.h
@@ -4,9 +4,7 @@
  * Please see the included NOTICE for copyright information and
  * LICENSE-APACHE for a copy of the license.
  */
-
-#ifndef TIMESCALEDB_LOADER_FUNCTION_TELEMETRY_H
-#define TIMESCALEDB_LOADER_FUNCTION_TELEMETRY_H
+#pragma once
 
 #define RENDEZVOUS_FUNCTION_TELEMENTRY "ts_function_telemetry"
 #define FN_TELEMETRY_LWLOCK_TRANCHE_NAME "ts_fn_telemetry_lwlock_tranche"
@@ -26,5 +24,3 @@ typedef struct FnTelemetryHashEntry
 extern void ts_function_telemetry_shmem_startup(void);
 
 extern void ts_function_telemetry_shmem_alloc(void);
-
-#endif /* TIMESCALEDB_LOADER_FUNCTION_TELEMETRY_H */

--- a/src/loader/loader.h
+++ b/src/loader/loader.h
@@ -3,8 +3,7 @@
  * Please see the included NOTICE for copyright information and
  * LICENSE-APACHE for a copy of the license.
  */
-#ifndef TIMESCALEDB_LOADER_H
-#define TIMESCALEDB_LOADER_H
+#pragma once
 
 #include <postgres.h>
 
@@ -24,5 +23,3 @@ extern void ts_loader_extension_check(void);
 
 /* GUC to control launcher timeout */
 extern int ts_guc_bgw_launcher_poll_time;
-
-#endif /* TIMESCALEDB_LOADER_H */

--- a/src/loader/lwlocks.h
+++ b/src/loader/lwlocks.h
@@ -3,13 +3,9 @@
  * Please see the included NOTICE for copyright information and
  * LICENSE-APACHE for a copy of the license.
  */
-
-#ifndef TIMESCALEDB_LOADER_LWLOCKS_H
-#define TIMESCALEDB_LOADER_LWLOCKS_H
+#pragma once
 
 #define RENDEZVOUS_CHUNK_APPEND_LWLOCK "ts_chunk_append_lwlock"
 
 void ts_lwlocks_shmem_startup(void);
 void ts_lwlocks_shmem_alloc(void);
-
-#endif /* TIMESCALEDB_LOADER_LWLOCKS_H */

--- a/src/loader/seclabel.h
+++ b/src/loader/seclabel.h
@@ -3,8 +3,7 @@
  * Please see the included NOTICE for copyright information and
  * LICENSE-APACHE for a copy of the license.
  */
-#ifndef TIMESCALEDB_SECLABEL_H
-#define TIMESCALEDB_SECLABEL_H
+#pragma once
 
 #include <postgres.h>
 #include <fmgr.h>
@@ -23,5 +22,3 @@
 
 extern bool ts_seclabel_get_dist_uuid(Oid dbid, char **uuid);
 extern void ts_seclabel_init(void);
-
-#endif /* TIMESCALEDB_SECLABEL_H */

--- a/src/net/conn.h
+++ b/src/net/conn.h
@@ -3,8 +3,7 @@
  * Please see the included NOTICE for copyright information and
  * LICENSE-APACHE for a copy of the license.
  */
-#ifndef TIMESCALEDB_NET_CONN_H
-#define TIMESCALEDB_NET_CONN_H
+#pragma once
 
 #include <postgres.h>
 
@@ -39,5 +38,3 @@ extern void ts_connection_close(Connection *conn);
 extern void ts_connection_destroy(Connection *conn);
 extern int ts_connection_set_timeout_millis(Connection *conn, unsigned long millis);
 extern const char *ts_connection_get_and_clear_error(Connection *conn);
-
-#endif /* TIMESCALEDB_NET_CONN_H */

--- a/src/net/conn_internal.h
+++ b/src/net/conn_internal.h
@@ -3,8 +3,7 @@
  * Please see the included NOTICE for copyright information and
  * LICENSE-APACHE for a copy of the license.
  */
-#ifndef TIMESCALEDB_CONN_INTERNAL_H
-#define TIMESCALEDB_CONN_INTERNAL_H
+#pragma once
 
 #include "conn.h"
 
@@ -21,5 +20,3 @@ typedef struct ConnOps
 } ConnOps;
 
 extern int ts_connection_register(ConnectionType type, ConnOps *ops);
-
-#endif /* TIMESCALEDB_CONN_INTERNAL_H */

--- a/src/net/conn_plain.h
+++ b/src/net/conn_plain.h
@@ -3,8 +3,7 @@
  * Please see the included NOTICE for copyright information and
  * LICENSE-APACHE for a copy of the license.
  */
-#ifndef TIMESCALEDB_CONN_PLAIN_H
-#define TIMESCALEDB_CONN_PLAIN_H
+#pragma once
 
 typedef struct Connection Connection;
 
@@ -19,5 +18,3 @@ extern int ts_plain_connect(Connection *conn, const char *host, const char *serv
 extern void ts_plain_close(Connection *conn);
 extern int ts_plain_set_timeout(Connection *conn, unsigned long millis);
 extern const char *ts_plain_errmsg(Connection *conn);
-
-#endif /* TIMESCALEDB_CONN_PLAIN_H */

--- a/src/net/http.h
+++ b/src/net/http.h
@@ -3,8 +3,7 @@
  * Please see the included NOTICE for copyright information and
  * LICENSE-APACHE for a copy of the license.
  */
-#ifndef TIMESCALEDB_NET_HTTP_H
-#define TIMESCALEDB_NET_HTTP_H
+#pragma once
 
 #include <postgres.h>
 
@@ -100,5 +99,3 @@ extern bool ts_http_response_state_parse(HttpResponseState *state, size_t bytes)
 extern const char *ts_http_strerror(HttpError http_errno);
 extern HttpError ts_http_send_and_recv(Connection *conn, HttpRequest *req,
 									   HttpResponseState *state);
-
-#endif /* TIMESCALEDB_HTTP_H */

--- a/src/nodes/chunk_append/chunk_append.h
+++ b/src/nodes/chunk_append/chunk_append.h
@@ -3,8 +3,7 @@
  * Please see the included NOTICE for copyright information and
  * LICENSE-APACHE for a copy of the license.
  */
-#ifndef TIMESCALEDB_CHUNK_APPEND_H
-#define TIMESCALEDB_CHUNK_APPEND_H
+#pragma once
 
 #include <postgres.h>
 #include <nodes/extensible.h>
@@ -40,5 +39,3 @@ extern TSDLLEXPORT bool ts_is_chunk_append_plan(Plan *plan);
 extern Scan *ts_chunk_append_get_scan_plan(Plan *plan);
 
 void _chunk_append_init(void);
-
-#endif /* TIMESCALEDB_CHUNK_APPEND_H */

--- a/src/nodes/chunk_append/transform.h
+++ b/src/nodes/chunk_append/transform.h
@@ -3,12 +3,9 @@
  * Please see the included NOTICE for copyright information and
  * LICENSE-APACHE for a copy of the license.
  */
-#ifndef TIMESCALEDB_CHUNK_APPEND_TRANSFORM_H
-#define TIMESCALEDB_CHUNK_APPEND_TRANSFORM_H
+#pragma once
 
 #include <postgres.h>
 #include <nodes/extensible.h>
 
 extern Expr *ts_transform_cross_datatype_comparison(Expr *clause);
-
-#endif /* TIMESCALEDB_CHUNK_APPEND_TRANSFORM_H */

--- a/src/nodes/chunk_dispatch/chunk_dispatch.h
+++ b/src/nodes/chunk_dispatch/chunk_dispatch.h
@@ -3,8 +3,7 @@
  * Please see the included NOTICE for copyright information and
  * LICENSE-APACHE for a copy of the license.
  */
-#ifndef TIMESCALEDB_NODES_CHUNK_DISPATCH_H
-#define TIMESCALEDB_NODES_CHUNK_DISPATCH_H
+#pragma once
 
 #include <postgres.h>
 #include <nodes/extensible.h>
@@ -93,5 +92,3 @@ ts_chunk_dispatch_get_chunk_insert_state(ChunkDispatch *dispatch, Point *p, Tupl
 
 extern TSDLLEXPORT Path *ts_chunk_dispatch_path_create(PlannerInfo *root, ModifyTablePath *mtpath,
 													   Index hypertable_rti, int subpath_index);
-
-#endif /* TIMESCALEDB_NODES_CHUNK_DISPATCH_H */

--- a/src/nodes/chunk_dispatch/chunk_insert_state.h
+++ b/src/nodes/chunk_dispatch/chunk_insert_state.h
@@ -3,8 +3,7 @@
  * Please see the included NOTICE for copyright information and
  * LICENSE-APACHE for a copy of the license.
  */
-#ifndef TIMESCALEDB_CHUNK_INSERT_STATE_H
-#define TIMESCALEDB_CHUNK_INSERT_STATE_H
+#pragma once
 
 #include <postgres.h>
 #include <funcapi.h>
@@ -64,4 +63,3 @@ extern void ts_chunk_insert_state_destroy(ChunkInsertState *state);
 
 OnConflictAction chunk_dispatch_get_on_conflict_action(const ChunkDispatch *dispatch);
 void ts_set_compression_status(ChunkInsertState *state, const Chunk *chunk);
-#endif /* TIMESCALEDB_CHUNK_INSERT_STATE_H */

--- a/src/nodes/constraint_aware_append/constraint_aware_append.h
+++ b/src/nodes/constraint_aware_append/constraint_aware_append.h
@@ -3,8 +3,7 @@
  * Please see the included NOTICE for copyright information and
  * LICENSE-APACHE for a copy of the license.
  */
-#ifndef TIMESCALEDB_CONSTRAINT_AWARE_APPEND_H
-#define TIMESCALEDB_CONSTRAINT_AWARE_APPEND_H
+#pragma once
 
 #include <postgres.h>
 #include <nodes/extensible.h>
@@ -28,5 +27,3 @@ extern bool ts_constraint_aware_append_possible(Path *path);
 extern TSDLLEXPORT Path *ts_constraint_aware_append_path_create(PlannerInfo *root, Path *subpath);
 extern TSDLLEXPORT bool ts_is_constraint_aware_append_path(Path *path);
 extern void _constraint_aware_append_init(void);
-
-#endif /* TIMESCALEDB_CONSTRAINT_AWARE_APPEND_H */

--- a/src/nodes/hypertable_modify.h
+++ b/src/nodes/hypertable_modify.h
@@ -3,8 +3,7 @@
  * Please see the included NOTICE for copyright information and
  * LICENSE-APACHE for a copy of the license.
  */
-#ifndef TIMESCALEDB_HYPERTABLE_MODIFY_H
-#define TIMESCALEDB_HYPERTABLE_MODIFY_H
+#pragma once
 
 #include <postgres.h>
 #include <nodes/execnodes.h>
@@ -43,5 +42,3 @@ extern List *ts_replace_rowid_vars(PlannerInfo *root, List *tlist, int varno);
 extern TupleTableSlot *ExecInsert(ModifyTableContext *context, ResultRelInfo *resultRelInfo,
 								  TupleTableSlot *slot, bool canSetTag);
 #endif
-
-#endif /* TIMESCALEDB_HYPERTABLE_MODIFY_H */

--- a/src/osm_callbacks.h
+++ b/src/osm_callbacks.h
@@ -3,8 +3,7 @@
  * Please see the included NOTICE for copyright information and
  * LICENSE-APACHE for a copy of the license.
  */
-#ifndef TIMESCALEDB_OSM_CALLBACKS_H
-#define TIMESCALEDB_OSM_CALLBACKS_H
+#pragma once
 
 #include <postgres.h>
 #include <catalog/objectaddress.h>
@@ -43,5 +42,3 @@ typedef struct
 extern chunk_insert_check_hook_type ts_get_osm_chunk_insert_hook(void);
 extern hypertable_drop_hook_type ts_get_osm_hypertable_drop_hook(void);
 extern hypertable_drop_chunks_hook_type ts_get_osm_hypertable_drop_chunks_hook(void);
-
-#endif /* TIMESCALEDB_OSM_CALLBACKS_H */

--- a/src/partitioning.h
+++ b/src/partitioning.h
@@ -3,8 +3,7 @@
  * Please see the included NOTICE for copyright information and
  * LICENSE-APACHE for a copy of the license.
  */
-#ifndef TIMESCALEDB_PARTITIONING_H
-#define TIMESCALEDB_PARTITIONING_H
+#pragma once
 
 #define KEYSPACE_PT_NO_PARTITIONING -1
 
@@ -58,5 +57,3 @@ extern TSDLLEXPORT Datum ts_partitioning_func_apply(PartitioningInfo *pinfo, Oid
  */
 extern TSDLLEXPORT Datum ts_partitioning_func_apply_slot(PartitioningInfo *pinfo,
 														 TupleTableSlot *slot, bool *isnull);
-
-#endif /* TIMESCALEDB_PARTITIONING_H */

--- a/src/planner/partialize.h
+++ b/src/planner/partialize.h
@@ -3,8 +3,7 @@
  * Please see the included NOTICE for copyright information and
  * LICENSE-APACHE for a copy of the license.
  */
-#ifndef TIMESCALEDB_PLAN_PARTIALIZE_H
-#define TIMESCALEDB_PLAN_PARTIALIZE_H
+#pragma once
 
 #include <postgres.h>
 #include <nodes/pathnodes.h>
@@ -14,5 +13,3 @@
 
 void ts_pushdown_partial_agg(PlannerInfo *root, Hypertable *ht, RelOptInfo *input_rel,
 							 RelOptInfo *output_rel, void *extra);
-
-#endif /* TIMESCALEDB_PLAN_PARTIALIZE_H */

--- a/src/planner/planner.h
+++ b/src/planner/planner.h
@@ -3,8 +3,7 @@
  * Please see the included NOTICE for copyright information and
  * LICENSE-APACHE for a copy of the license.
  */
-#ifndef TIMESCALEDB_PLANNER_H
-#define TIMESCALEDB_PLANNER_H
+#pragma once
 
 #include <postgres.h>
 #include <nodes/pg_list.h>
@@ -112,5 +111,3 @@ extern Node *ts_add_space_constraints(PlannerInfo *root, List *rtable, Node *nod
 extern TSDLLEXPORT void ts_add_baserel_cache_entry_for_chunk(Oid chunk_reloid,
 															 Hypertable *hypertable);
 TsRelType ts_classify_relation(const PlannerInfo *root, const RelOptInfo *rel, Hypertable **ht);
-
-#endif /* TIMESCALEDB_PLANNER_H */

--- a/src/process_utility.h
+++ b/src/process_utility.h
@@ -3,8 +3,7 @@
  * Please see the included NOTICE for copyright information and
  * LICENSE-APACHE for a copy of the license.
  */
-#ifndef TIMESCALEDB_PROCESS_UTILITY_H
-#define TIMESCALEDB_PROCESS_UTILITY_H
+#pragma once
 
 #include <postgres.h>
 #include <nodes/plannodes.h>
@@ -39,5 +38,3 @@ typedef enum
 typedef DDLResult (*ts_process_utility_handler_t)(ProcessUtilityArgs *args);
 
 extern void ts_process_utility_set_expect_chunk_modification(bool expect);
-
-#endif /* TIMESCALEDB_PROCESS_UTILITY_H */

--- a/src/scan_iterator.h
+++ b/src/scan_iterator.h
@@ -3,8 +3,7 @@
  * Please see the included NOTICE for copyright information and
  * LICENSE-APACHE for a copy of the license.
  */
-#ifndef TIMESCALEDB_SCAN_ITERATOR_H
-#define TIMESCALEDB_SCAN_ITERATOR_H
+#pragma once
 
 #include <postgres.h>
 #include <utils/palloc.h>
@@ -127,5 +126,3 @@ ts_scan_iterator_start_or_restart_scan(ScanIterator *iterator)
 #define ts_scanner_foreach(scan_iterator)                                                          \
 	for (ts_scan_iterator_start_scan((scan_iterator));                                             \
 		 ts_scan_iterator_next(scan_iterator) != NULL;)
-
-#endif /* TIMESCALEDB_SCAN_ITERATOR_H */

--- a/src/scanner.h
+++ b/src/scanner.h
@@ -3,8 +3,7 @@
  * Please see the included NOTICE for copyright information and
  * LICENSE-APACHE for a copy of the license.
  */
-#ifndef TIMESCALEDB_SCANNER_H
-#define TIMESCALEDB_SCANNER_H
+#pragma once
 
 #include <postgres.h>
 #include <access/genam.h>
@@ -161,5 +160,3 @@ extern TSDLLEXPORT HeapTuple ts_scanner_fetch_heap_tuple(const TupleInfo *ti, bo
 														 bool *should_free);
 extern TSDLLEXPORT TupleDesc ts_scanner_get_tupledesc(const TupleInfo *ti);
 extern TSDLLEXPORT void *ts_scanner_alloc_result(const TupleInfo *ti, Size size);
-
-#endif /* TIMESCALEDB_SCANNER_H */

--- a/src/sort_transform.h
+++ b/src/sort_transform.h
@@ -3,11 +3,8 @@
  * Please see the included NOTICE for copyright information and
  * LICENSE-APACHE for a copy of the license.
  */
-#ifndef TIMESCALEDB_SORT_TRANSFORM_H
-#define TIMESCALEDB_SORT_TRANSFORM_H
+#pragma once
 
 #include <postgres.h>
 
 extern Expr *ts_sort_transform_expr(Expr *expr);
-
-#endif /* TIMESCALEDB_SORT_TRANSFORM_H */

--- a/src/subspace_store.h
+++ b/src/subspace_store.h
@@ -3,8 +3,7 @@
  * Please see the included NOTICE for copyright information and
  * LICENSE-APACHE for a copy of the license.
  */
-#ifndef TIMESCALEDB_SUBSPACE_STORE_H
-#define TIMESCALEDB_SUBSPACE_STORE_H
+#pragma once
 
 #include <postgres.h>
 #include "dimension.h"
@@ -32,5 +31,3 @@ extern void ts_subspace_store_add(SubspaceStore *subspace_store, const Hypercube
 extern void *ts_subspace_store_get(const SubspaceStore *subspace_store, const Point *target);
 extern void ts_subspace_store_free(SubspaceStore *subspace_store);
 extern MemoryContext ts_subspace_store_mcxt(const SubspaceStore *subspace_store);
-
-#endif /* TIMESCALEDB_SUBSPACE_STORE_H */

--- a/src/telemetry/functions.h
+++ b/src/telemetry/functions.h
@@ -3,8 +3,7 @@
  * Please see the included NOTICE for copyright information and
  * LICENSE-APACHE for a copy of the license.
  */
-#ifndef TIMESCALEDB_TELEMETRY_FUNCTIONS_H
-#define TIMESCALEDB_TELEMETRY_FUNCTIONS_H
+#pragma once
 
 #include <postgres.h>
 
@@ -26,5 +25,3 @@ extern void ts_telemetry_function_info_gather(Query *query);
 extern fn_telemetry_entry_vec *ts_function_telemetry_read(const char **visible_extensions,
 														  int num_visible_extensions);
 extern void ts_function_telemetry_reset_counts(void);
-
-#endif /* TIMESCALEDB_TELEMETRY_FUNCTIONS_H */

--- a/src/telemetry/replication.h
+++ b/src/telemetry/replication.h
@@ -3,8 +3,7 @@
  * Please see the included NOTICE for copyright information and
  * LICENSE-APACHE for a copy of the license.
  */
-#ifndef TIMESCALEDB_TELEMETRY_REPLICATION_H
-#define TIMESCALEDB_TELEMETRY_REPLICATION_H
+#pragma once
 
 #include <postgres.h>
 
@@ -20,5 +19,3 @@ typedef struct ReplicationInfo
 } ReplicationInfo;
 
 extern ReplicationInfo ts_telemetry_replication_info_gather(void);
-
-#endif /* TIMESCALEDB_TELEMETRY_REPLICATION_H */

--- a/src/telemetry/stats.h
+++ b/src/telemetry/stats.h
@@ -3,9 +3,7 @@
  * Please see the included NOTICE for copyright information and
  * LICENSE-APACHE for a copy of the license.
  */
-#ifndef TIMESCALEDB_TELEMETRY_STATS_H
-#define TIMESCALEDB_TELEMETRY_STATS_H
-
+#pragma once
 #include <postgres.h>
 
 #include "utils.h"
@@ -105,5 +103,3 @@ typedef struct TelemetryJobStats
 } TelemetryJobStats;
 
 extern void ts_telemetry_stats_gather(TelemetryStats *stats);
-
-#endif /* TIMESCALEDB_TELEMETRY_STATS_H */

--- a/src/telemetry/telemetry.h
+++ b/src/telemetry/telemetry.h
@@ -3,8 +3,8 @@
  * Please see the included NOTICE for copyright information and
  * LICENSE-APACHE for a copy of the license.
  */
-#ifndef TIMESCALEDB_TELEMETRY_TELEMETRY_H
-#define TIMESCALEDB_TELEMETRY_TELEMETRY_H
+#pragma once
+
 #include <postgres.h>
 #include <fmgr.h>
 #include <utils/builtins.h>
@@ -58,5 +58,3 @@ extern void ts_check_version_response(const char *json);
 extern bool ts_telemetry_main(const char *host, const char *path, const char *service);
 extern TSDLLEXPORT bool ts_telemetry_main_wrapper(void);
 extern TSDLLEXPORT Datum ts_telemetry_get_report_jsonb(PG_FUNCTION_ARGS);
-
-#endif /* TIMESCALEDB_TELEMETRY_TELEMETRY_H */

--- a/src/telemetry/telemetry_metadata.h
+++ b/src/telemetry/telemetry_metadata.h
@@ -3,8 +3,7 @@
  * Please see the included NOTICE for copyright information and
  * LICENSE-APACHE for a copy of the license.
  */
-#ifndef TIMESCALEDB_TELEMETRY_TELEMETRY_METADATA_H
-#define TIMESCALEDB_TELEMETRY_TELEMETRY_METADATA_H
+#pragma once
 
 #include <postgres.h>
 #include <utils/jsonb.h>
@@ -14,5 +13,3 @@
 extern void ts_telemetry_metadata_add_values(JsonbParseState *state);
 extern void ts_telemetry_events_add(JsonbParseState *state);
 extern void ts_telemetry_event_truncate(void);
-
-#endif /* TIMESCALEDB_TELEMETRY_TELEMETRY_METADATA_H */

--- a/src/time_bucket.h
+++ b/src/time_bucket.h
@@ -3,8 +3,7 @@
  * Please see the included NOTICE for copyright information and
  * LICENSE-APACHE for a copy of the license.
  */
-#ifndef TIMESCALEDB_TIME_BUCKET_H
-#define TIMESCALEDB_TIME_BUCKET_H
+#pragma once
 
 #include <postgres.h>
 #include <fmgr.h>
@@ -24,5 +23,3 @@ extern TSDLLEXPORT Datum ts_time_bucket_ng_timestamp(PG_FUNCTION_ARGS);
 extern TSDLLEXPORT Datum ts_time_bucket_ng_timestamptz(PG_FUNCTION_ARGS);
 extern TSDLLEXPORT Datum ts_time_bucket_ng_timezone(PG_FUNCTION_ARGS);
 extern TSDLLEXPORT Datum ts_time_bucket_ng_timezone_origin(PG_FUNCTION_ARGS);
-
-#endif /* TIMESCALEDB_TIME_BUCKET_H */

--- a/src/time_utils.h
+++ b/src/time_utils.h
@@ -3,8 +3,7 @@
  * Please see the included NOTICE for copyright information and
  * LICENSE-APACHE for a copy of the license.
  */
-#ifndef TIMESCALEDB_TIME_UTILS_H
-#define TIMESCALEDB_TIME_UTILS_H
+#pragma once
 
 #include <postgres.h>
 
@@ -92,5 +91,3 @@ extern TSDLLEXPORT int64 ts_subtract_integer_from_now_saturating(Oid now_func, i
 #ifdef TS_DEBUG
 extern TSDLLEXPORT Datum ts_get_mock_time_or_current_time(void);
 #endif
-
-#endif /* TIMESCALEDB_TIME_UTILS_H */

--- a/src/timezones.h
+++ b/src/timezones.h
@@ -4,11 +4,8 @@
  * LICENSE-APACHE for a copy of the license.
  */
 
-#ifndef TIMESCALEDB_TIMEZONES_H
-#define TIMESCALEDB_TIMEZONES_H
+#pragma once
 
 #include "export.h"
 
 extern TSDLLEXPORT bool ts_is_valid_timezone_name(const char *tz_name);
-
-#endif /* TIMESCALEDB_TIMEZONES_H */

--- a/src/trigger.h
+++ b/src/trigger.h
@@ -3,8 +3,7 @@
  * Please see the included NOTICE for copyright information and
  * LICENSE-APACHE for a copy of the license.
  */
-#ifndef TIMESCALEDB_TRIGGER_H
-#define TIMESCALEDB_TRIGGER_H
+#pragma once
 
 #include <postgres.h>
 #include <catalog/pg_trigger.h>
@@ -19,5 +18,3 @@ extern void ts_trigger_create_on_chunk(Oid trigger_oid, const char *chunk_schema
 									   const char *chunk_table_name);
 extern TSDLLEXPORT void ts_trigger_create_all_on_chunk(const Chunk *chunk);
 extern bool ts_relation_has_transition_table_trigger(Oid relid);
-
-#endif /* TIMESCALEDB_TRIGGER_H */

--- a/src/ts_catalog/array_utils.h
+++ b/src/ts_catalog/array_utils.h
@@ -3,6 +3,8 @@
  * Please see the included NOTICE for copyright information and
  * LICENSE-APACHE for a copy of the license.
  */
+#pragma once
+
 #include <postgres.h>
 #include <utils/array.h>
 

--- a/src/ts_catalog/catalog.h
+++ b/src/ts_catalog/catalog.h
@@ -3,8 +3,7 @@
  * Please see the included NOTICE for copyright information and
  * LICENSE-APACHE for a copy of the license.
  */
-#ifndef TIMESCALEDB_CATALOG_H
-#define TIMESCALEDB_CATALOG_H
+#pragma once
 
 #include <postgres.h>
 #include <utils/jsonb.h>
@@ -1568,5 +1567,3 @@ bool TSDLLEXPORT ts_catalog_scan_one(CatalogTable table, int indexid, ScanKeyDat
 void TSDLLEXPORT ts_catalog_scan_all(CatalogTable table, int indexid, ScanKeyData *scankey,
 									 int num_keys, tuple_found_func tuple_found, LOCKMODE lockmode,
 									 void *data);
-
-#endif /* TIMESCALEDB_CATALOG_H */

--- a/src/ts_catalog/chunk_data_node.h
+++ b/src/ts_catalog/chunk_data_node.h
@@ -3,8 +3,7 @@
  * Please see the included NOTICE for copyright information and
  * LICENSE-APACHE for a copy of the license.
  */
-#ifndef TIMESCALEDB_CHUNK_DATA_NODE_H
-#define TIMESCALEDB_CHUNK_DATA_NODE_H
+#pragma once
 
 #include "ts_catalog/catalog.h"
 #include "chunk.h"
@@ -40,4 +39,3 @@ extern TSDLLEXPORT void ts_chunk_data_nodes_scan_iterator_set_chunk_id(ScanItera
 																	   int32 chunk_id);
 extern TSDLLEXPORT void ts_chunk_data_nodes_scan_iterator_set_node_name(ScanIterator *it,
 																		const char *node_name);
-#endif /* TIMESCALEDB_CHUNK_DATA_NODE_H */

--- a/src/ts_catalog/compression_chunk_size.h
+++ b/src/ts_catalog/compression_chunk_size.h
@@ -3,8 +3,8 @@
  * Please see the included NOTICE for copyright information and
  * LICENSE-APACHE for a copy of the license.
  */
-#ifndef TIMESCALEDB_COMPRESSION_CHUNK_SIZE_H
-#define TIMESCALEDB_COMPRESSION_CHUNK_SIZE_H
+#pragma once
+
 #include <postgres.h>
 #include <compat/compat.h>
 
@@ -22,5 +22,3 @@ typedef struct TotalSizes
 
 extern TSDLLEXPORT TotalSizes ts_compression_chunk_size_totals(void);
 extern TSDLLEXPORT int64 ts_compression_chunk_size_row_count(int32 uncompressed_chunk_id);
-
-#endif

--- a/src/ts_catalog/continuous_agg.h
+++ b/src/ts_catalog/continuous_agg.h
@@ -3,9 +3,8 @@
  * Please see the included NOTICE for copyright information and
  * LICENSE-APACHE for a copy of the license.
  */
+#pragma once
 
-#ifndef TIMESCALEDB_CONTINUOUS_AGG_H
-#define TIMESCALEDB_CONTINUOUS_AGG_H
 #include <postgres.h>
 #include <catalog/pg_type.h>
 #include <nodes/parsenodes.h>
@@ -229,5 +228,3 @@ extern TSDLLEXPORT int64 ts_compute_beginning_of_the_next_bucket_variable(
 	int64 timeval, const ContinuousAggsBucketFunction *bf);
 
 extern TSDLLEXPORT Query *ts_continuous_agg_get_query(ContinuousAgg *cagg);
-
-#endif /* TIMESCALEDB_CONTINUOUS_AGG_H */

--- a/src/ts_catalog/continuous_aggs_watermark.h
+++ b/src/ts_catalog/continuous_aggs_watermark.h
@@ -3,9 +3,7 @@
  * Please see the included NOTICE for copyright information and
  * LICENSE-APACHE for a copy of the license.
  */
-
-#ifndef TIMESCALEDB_CONTINUOUS_AGGS_WATERMARK_H
-#define TIMESCALEDB_CONTINUOUS_AGGS_WATERMARK_H
+#pragma once
 
 #include <postgres.h>
 
@@ -17,5 +15,3 @@ extern TSDLLEXPORT void ts_cagg_watermark_insert(Hypertable *mat_ht, int64 water
 												 bool watermark_isnull);
 extern TSDLLEXPORT void ts_cagg_watermark_update(Hypertable *mat_ht, int64 watermark,
 												 bool watermark_isnull, bool force_update);
-
-#endif /* TIMESCALEDB_CONTINUOUS_AGGS_WATERMARK_H */

--- a/src/ts_catalog/dimension_partition.h
+++ b/src/ts_catalog/dimension_partition.h
@@ -3,8 +3,7 @@
  * Please see the included NOTICE for copyright information and
  * LICENSE-APACHE for a copy of the license.
  */
-#ifndef TIMESCALEDB_DIMENSION_PARTITION_H
-#define TIMESCALEDB_DIMENSION_PARTITION_H
+#pragma once
 
 #include <postgres.h>
 
@@ -31,5 +30,3 @@ extern TSDLLEXPORT DimensionPartitionInfo *
 ts_dimension_partition_info_recreate(int32 dimension_id, unsigned int num_partitions,
 									 List *data_nodes, int replication_factor);
 extern void ts_dimension_partition_info_delete(int dimension_id);
-
-#endif /* TIMESCALEDB_DIMENSION_PARTITION_H */

--- a/src/ts_catalog/hypertable_compression.h
+++ b/src/ts_catalog/hypertable_compression.h
@@ -3,8 +3,8 @@
  * Please see the included NOTICE for copyright information and
  * LICENSE-APACHE for a copy of the license.
  */
-#ifndef TIMESCALEDB_HYPERTABLE_COMPRESSION_H
-#define TIMESCALEDB_HYPERTABLE_COMPRESSION_H
+#pragma once
+
 #include <postgres.h>
 #include <catalog/pg_type.h>
 
@@ -22,5 +22,3 @@ extern TSDLLEXPORT bool ts_hypertable_compression_delete_by_hypertable_id(int32 
 extern TSDLLEXPORT bool ts_hypertable_compression_delete_by_pkey(int32 htid, const char *attname);
 extern TSDLLEXPORT void ts_hypertable_compression_rename_column(int32 htid, char *old_column_name,
 																char *new_column_name);
-
-#endif

--- a/src/ts_catalog/hypertable_data_node.h
+++ b/src/ts_catalog/hypertable_data_node.h
@@ -3,8 +3,7 @@
  * Please see the included NOTICE for copyright information and
  * LICENSE-APACHE for a copy of the license.
  */
-#ifndef TIMESCALEDB_HYPERTABLE_DATA_NODE_H
-#define TIMESCALEDB_HYPERTABLE_DATA_NODE_H
+#pragma once
 
 #include "ts_catalog/catalog.h"
 #include "export.h"
@@ -26,5 +25,3 @@ ts_hypertable_data_node_delete_by_node_name_and_hypertable_id(const char *node_n
 															  int32 hypertable_id);
 extern TSDLLEXPORT int
 ts_hypertable_data_node_update(const HypertableDataNode *hypertable_data_node);
-
-#endif /* TIMESCALEDB_HYPERTABLE_DATA_NODE_H */

--- a/src/ts_catalog/metadata.h
+++ b/src/ts_catalog/metadata.h
@@ -3,8 +3,7 @@
  * Please see the included NOTICE for copyright information and
  * LICENSE-APACHE for a copy of the license.
  */
-#ifndef TIMESCALEDB_METADATA_H
-#define TIMESCALEDB_METADATA_H
+#pragma once
 
 #include <postgres.h>
 #include "export.h"
@@ -30,5 +29,3 @@ extern TSDLLEXPORT void ts_metadata_drop(const char *metadata_key);
 extern TSDLLEXPORT Datum ts_metadata_get_uuid(void);
 extern Datum ts_metadata_get_exported_uuid(void);
 extern Datum ts_metadata_get_install_timestamp(void);
-
-#endif /* TIMESCALEDB_METADATA_H */

--- a/src/ts_catalog/tablespace.h
+++ b/src/ts_catalog/tablespace.h
@@ -3,8 +3,7 @@
  * Please see the included NOTICE for copyright information and
  * LICENSE-APACHE for a copy of the license.
  */
-#ifndef TIMESCALEDB_TABLESPACE_H
-#define TIMESCALEDB_TABLESPACE_H
+#pragma once
 
 #include <postgres.h>
 #include <nodes/parsenodes.h>
@@ -34,5 +33,3 @@ extern int ts_tablespace_delete(int32 hypertable_id, const char *tspcname, Oid t
 extern int ts_tablespace_count_attached(const char *tspcname);
 extern void ts_tablespace_validate_revoke(GrantStmt *stmt);
 extern void ts_tablespace_validate_revoke_role(GrantRoleStmt *stmt);
-
-#endif /* TIMESCALEDB_TABLESPACE_H */

--- a/src/utils.h
+++ b/src/utils.h
@@ -3,8 +3,7 @@
  * Please see the included NOTICE for copyright information and
  * LICENSE-APACHE for a copy of the license.
  */
-#ifndef TIMESCALEDB_UTILS_H
-#define TIMESCALEDB_UTILS_H
+#pragma once
 
 #include <postgres.h>
 #include <access/htup_details.h>
@@ -249,5 +248,3 @@ ts_get_relation_relid(char const *schema_name, char const *relation_name, bool r
 		return InvalidOid;
 	}
 }
-
-#endif /* TIMESCALEDB_UTILS_H */

--- a/src/uuid.h
+++ b/src/uuid.h
@@ -3,12 +3,9 @@
  * Please see the included NOTICE for copyright information and
  * LICENSE-APACHE for a copy of the license.
  */
-#ifndef TIMESCALEDB_TELEMETRY_UUID_H
-#define TIMESCALEDB_TELEMETRY_UUID_H
+#pragma once
 
 #include <postgres.h>
 #include <utils/uuid.h>
 
 extern pg_uuid_t *ts_uuid_create(void);
-
-#endif /* TIMESCALEDB_TELEMETRY_UUID_H */

--- a/src/version.h
+++ b/src/version.h
@@ -3,8 +3,7 @@
  * Please see the included NOTICE for copyright information and
  * LICENSE-APACHE for a copy of the license.
  */
-#ifndef TIMESCALEDB_VERSION_H
-#define TIMESCALEDB_VERSION_H
+#pragma once
 
 #include <postgres.h>
 
@@ -20,5 +19,3 @@ typedef struct VersionOSInfo
 } VersionOSInfo;
 
 extern bool ts_version_get_os_info(VersionOSInfo *info);
-
-#endif /* TIMESCALEDB_VERSION_H */

--- a/src/with_clause_parser.h
+++ b/src/with_clause_parser.h
@@ -3,8 +3,8 @@
  * Please see the included NOTICE for copyright information and
  * LICENSE-APACHE for a copy of the license.
  */
-#ifndef TIMESCALEDB_WITH_CLAUSE_PARSER_H
-#define TIMESCALEDB_WITH_CLAUSE_PARSER_H
+#pragma once
+
 #include <postgres.h>
 
 #include <nodes/parsenodes.h>
@@ -33,4 +33,3 @@ extern TSDLLEXPORT WithClauseResult *
 ts_with_clauses_parse(const List *def_elems, const WithClauseDefinition *args, Size nargs);
 
 extern TSDLLEXPORT char *ts_with_clause_result_deparse_value(const WithClauseResult *result);
-#endif /* TIMESCALEDB_WITH_CLAUSE_PARSER_H */

--- a/test/src/bgw/log.h
+++ b/test/src/bgw/log.h
@@ -3,10 +3,7 @@
  * Please see the included NOTICE for copyright information and
  * LICENSE-APACHE for a copy of the license.
  */
-#ifndef TEST_BGW_LOG_H
-#define TEST_BGW_LOG_H
+#pragma once
 
 extern void ts_bgw_log_set_application_name(char *name);
 extern void ts_register_emit_log_hook(void);
-
-#endif /* TEST_BGW_LOG_H */

--- a/test/src/bgw/params.h
+++ b/test/src/bgw/params.h
@@ -3,8 +3,8 @@
  * Please see the included NOTICE for copyright information and
  * LICENSE-APACHE for a copy of the license.
  */
-#ifndef TEST_BGW_PARAMS_H
-#define TEST_BGW_PARAMS_H
+#pragma once
+
 #include <postgres.h>
 #include <storage/latch.h>
 
@@ -28,5 +28,3 @@ extern TestParams *ts_params_get(void);
 extern void ts_params_set_time(int64 new_val, bool set_latch);
 extern void ts_initialize_timer_latch(void);
 extern void ts_reset_and_wait_timer_latch(void);
-
-#endif /* TEST_BGW_PARAMS_H */

--- a/test/src/bgw/timer_mock.h
+++ b/test/src/bgw/timer_mock.h
@@ -3,8 +3,7 @@
  * Please see the included NOTICE for copyright information and
  * LICENSE-APACHE for a copy of the license.
  */
-#ifndef TIMESCALEDB_BGW_TIMER_MOCK_H
-#define TIMESCALEDB_BGW_TIMER_MOCK_H
+#pragma once
 
 #include <postgres.h>
 #include <postmaster/bgworker.h>
@@ -15,5 +14,3 @@ extern void ts_timer_mock_register_bgw_handle(BackgroundWorkerHandle *handle,
 											  MemoryContext scheduler_mctx);
 
 extern const Timer ts_mock_timer;
-
-#endif /* TIMESCALEDB_BGW_TIMER_MOCK_H */

--- a/test/src/net/conn_mock.h
+++ b/test/src/net/conn_mock.h
@@ -3,13 +3,10 @@
  * Please see the included NOTICE for copyright information and
  * LICENSE-APACHE for a copy of the license.
  */
-#ifndef TIMESCALEDB_CONN_MOCK_H
-#define TIMESCALEDB_CONN_MOCK_H
+#pragma once
 
 #include <sys/socket.h>
 
 typedef struct Connection Connection;
 
 extern ssize_t ts_connection_mock_set_recv_buf(Connection *conn, char *buf, size_t buf_len);
-
-#endif /* TIMESCALEDB_CONN_MOCK_H */

--- a/test/src/test_utils.h
+++ b/test/src/test_utils.h
@@ -3,8 +3,7 @@
  * Please see the included NOTICE for copyright information and
  * LICENSE-APACHE for a copy of the license.
  */
-#ifndef TIMESCALEDB_TEST_UTILS_H
-#define TIMESCALEDB_TEST_UTILS_H
+#pragma once
 
 #include <postgres.h>
 #include <access/xact.h>
@@ -95,5 +94,3 @@ strip_path(const char *filename)
 #define TS_TEST_FN(name)                                                                           \
 	TS_FUNCTION_INFO_V1(name);                                                                     \
 	Datum name(PG_FUNCTION_ARGS)
-
-#endif /* TIMESCALEDB_TEST_UTILS_H */

--- a/tsl/src/bgw_policy/compression_api.h
+++ b/tsl/src/bgw_policy/compression_api.h
@@ -3,9 +3,7 @@
  * Please see the included NOTICE for copyright information and
  * LICENSE-TIMESCALE for a copy of the license.
  */
-
-#ifndef TIMESCALEDB_TSL_BGW_POLICY_COMPRESSION_API_H
-#define TIMESCALEDB_TSL_BGW_POLICY_COMPRESSION_API_H
+#pragma once
 
 #include <postgres.h>
 #include <utils/jsonb.h>
@@ -33,5 +31,3 @@ Datum policy_compression_add_internal(Oid user_rel_oid, Datum compress_after_dat
 									  bool fixed_schedule, TimestampTz initial_start,
 									  const char *timezone);
 bool policy_compression_remove_internal(Oid user_rel_oid, bool if_exists);
-
-#endif /* TIMESCALEDB_TSL_BGW_POLICY_COMPRESSION_API_H */

--- a/tsl/src/bgw_policy/continuous_aggregate_api.h
+++ b/tsl/src/bgw_policy/continuous_aggregate_api.h
@@ -3,9 +3,7 @@
  * Please see the included NOTICE for copyright information and
  * LICENSE-TIMESCALE for a copy of the license.
  */
-
-#ifndef TIMESCALEDB_TSL_BGW_POLICY_CAGG_API_H
-#define TIMESCALEDB_TSL_BGW_POLICY_CAGG_API_H
+#pragma once
 
 #include <postgres.h>
 #include <utils/jsonb.h>
@@ -32,5 +30,3 @@ Datum policy_refresh_cagg_add_internal(Oid cagg_oid, Oid start_offset_type,
 									   bool if_not_exists, bool fixed_schedule,
 									   TimestampTz initial_start, const char *timezone);
 Datum policy_refresh_cagg_remove_internal(Oid cagg_oid, bool if_exists);
-
-#endif /* TIMESCALEDB_TSL_BGW_POLICY_CAGG_API_H */

--- a/tsl/src/bgw_policy/job.h
+++ b/tsl/src/bgw_policy/job.h
@@ -3,8 +3,7 @@
  * Please see the included NOTICE for copyright information and
  * LICENSE-TIMESCALE for a copy of the license.
  */
-#ifndef TIMESCALEDB_TSL_BGW_POLICY_JOB_H
-#define TIMESCALEDB_TSL_BGW_POLICY_JOB_H
+#pragma once
 
 #include <postgres.h>
 #include <utils/jsonb.h>
@@ -65,5 +64,3 @@ extern void policy_compression_read_and_validate_config(Jsonb *config,
 extern void policy_recompression_read_and_validate_config(Jsonb *config,
 														  PolicyCompressionData *policy_data);
 extern bool job_execute(BgwJob *job);
-
-#endif /* TIMESCALEDB_TSL_BGW_POLICY_JOB_H */

--- a/tsl/src/bgw_policy/job_api.h
+++ b/tsl/src/bgw_policy/job_api.h
@@ -3,9 +3,7 @@
  * Please see the included NOTICE for copyright information and
  * LICENSE-TIMESCALE for a copy of the license.
  */
-
-#ifndef TSL_BGW_POLICY_JOB_API_H
-#define TSL_BGW_POLICY_JOB_API_H
+#pragma once
 
 #include <postgres.h>
 
@@ -14,5 +12,3 @@ extern Datum job_alter(PG_FUNCTION_ARGS);
 extern Datum job_delete(PG_FUNCTION_ARGS);
 extern Datum job_run(PG_FUNCTION_ARGS);
 extern Datum job_alter_set_hypertable_id(PG_FUNCTION_ARGS);
-
-#endif /* TSL_BGW_POLICY_JOB_API_H */

--- a/tsl/src/bgw_policy/policies_v2.h
+++ b/tsl/src/bgw_policy/policies_v2.h
@@ -3,6 +3,7 @@
  * Please see the included NOTICE for copyright information and
  * LICENSE-TIMESCALE for a copy of the license.
  */
+#pragma once
 
 #include <postgres.h>
 #include <utils/jsonb.h>

--- a/tsl/src/bgw_policy/policy_utils.h
+++ b/tsl/src/bgw_policy/policy_utils.h
@@ -3,9 +3,7 @@
  * Please see the included NOTICE for copyright information and
  * LICENSE-TIMESCALE for a copy of the license.
  */
-
-#ifndef TIMESCALEDB_TSL_BGW_POLICY_UTILS_H
-#define TIMESCALEDB_TSL_BGW_POLICY_UTILS_H
+#pragma once
 
 #include <postgres.h>
 #include "job.h"
@@ -16,4 +14,3 @@ int64 subtract_integer_from_now_internal(int64 interval, Oid time_dim_type, Oid 
 Datum subtract_interval_from_now(Interval *lag, Oid time_dim_type);
 const Dimension *get_open_dimension_for_hypertable(const Hypertable *ht, bool fail_if_not_found);
 bool policy_get_verbose_log(const Jsonb *config);
-#endif /* TIMESCALEDB_TSL_BGW_POLICY_UTILS_H */

--- a/tsl/src/bgw_policy/reorder_api.h
+++ b/tsl/src/bgw_policy/reorder_api.h
@@ -3,9 +3,7 @@
  * Please see the included NOTICE for copyright information and
  * LICENSE-TIMESCALE for a copy of the license.
  */
-
-#ifndef TIMESCALEDB_TSL_BGW_POLICY_REORDER_API_H
-#define TIMESCALEDB_TSL_BGW_POLICY_REORDER_API_H
+#pragma once
 
 #include <postgres.h>
 
@@ -17,5 +15,3 @@ extern Datum policy_reorder_check(PG_FUNCTION_ARGS);
 
 extern int32 policy_reorder_get_hypertable_id(const Jsonb *config);
 extern char *policy_reorder_get_index_name(const Jsonb *config);
-
-#endif /* TIMESCALEDB_TSL_BGW_POLICY_REORDER_API_H */

--- a/tsl/src/bgw_policy/retention_api.h
+++ b/tsl/src/bgw_policy/retention_api.h
@@ -3,9 +3,7 @@
  * Please see the included NOTICE for copyright information and
  * LICENSE-TIMESCALE for a copy of the license.
  */
-
-#ifndef TIMESCALEDB_TSL_BGW_POLICY_RETENTION_API_H
-#define TIMESCALEDB_TSL_BGW_POLICY_RETENTION_API_H
+#pragma once
 
 #include <postgres.h>
 
@@ -25,4 +23,3 @@ Datum policy_retention_add_internal(Oid ht_oid, Oid window_type, Datum window_da
 									bool if_not_exists, bool fixed_schedule,
 									TimestampTz initial_start, const char *timezone);
 Datum policy_retention_remove_internal(Oid table_oid, bool if_exists);
-#endif /* TIMESCALEDB_TSL_BGW_POLICY_RETENTION_API_H */

--- a/tsl/src/chunk.h
+++ b/tsl/src/chunk.h
@@ -3,8 +3,7 @@
  * Please see the included NOTICE for copyright information and
  * LICENSE-TIMESCALE for a copy of the license.
  */
-#ifndef TIMESCALEDB_TSL_CHUNK_H
-#define TIMESCALEDB_TSL_CHUNK_H
+#pragma once
 
 #include <postgres.h>
 #include <fmgr.h>
@@ -22,5 +21,3 @@ extern int chunk_invoke_drop_chunks(Oid relid, Datum older_than, Datum older_tha
 									bool use_creation_time);
 extern Datum chunk_create_replica_table(PG_FUNCTION_ARGS);
 extern void chunk_update_stale_metadata(Chunk *new_chunk, List *chunk_data_nodes);
-
-#endif /* TIMESCALEDB_TSL_CHUNK_H */

--- a/tsl/src/chunk_api.h
+++ b/tsl/src/chunk_api.h
@@ -3,8 +3,7 @@
  * Please see the included NOTICE for copyright information and
  * LICENSE-TIMESCALE for a copy of the license.
  */
-#ifndef TIMESCALEDB_TSL_CHUNK_API_H
-#define TIMESCALEDB_TSL_CHUNK_API_H
+#pragma once
 
 #include <postgres.h>
 
@@ -26,5 +25,3 @@ extern void chunk_api_call_create_empty_chunk_table(const Hypertable *ht, const 
 													const char *node_name);
 extern void chunk_api_call_chunk_drop_replica(const Chunk *chunk, const char *node_name,
 											  Oid serverid);
-
-#endif /* TIMESCALEDB_TSL_CHUNK_API_H */

--- a/tsl/src/chunk_copy.h
+++ b/tsl/src/chunk_copy.h
@@ -3,11 +3,8 @@
  * Please see the included NOTICE for copyright information and
  * LICENSE-TIMESCALE for a copy of the license.
  */
-#ifndef TIMESCALEDB_TSL_CHUNK_COPY_H
-#define TIMESCALEDB_TSL_CHUNK_COPY_H
+#pragma once
 
 extern void chunk_copy(Oid chunk_relid, const char *src_node, const char *dst_node,
 					   const char *op_id, bool delete_on_src_node);
 extern void chunk_copy_cleanup(const char *operation_id);
-
-#endif /* TIMESCALEDB_TSL_CHUNK_COPY_H */

--- a/tsl/src/compression/api.h
+++ b/tsl/src/compression/api.h
@@ -3,8 +3,7 @@
  * Please see the included NOTICE for copyright information and
  * LICENSE-TIMESCALE for a copy of the license.
  */
-#ifndef TIMESCALEDB_TSL_COMPRESSION_API_H
-#define TIMESCALEDB_TSL_COMPRESSION_API_H
+#pragma once
 
 #include <postgres.h>
 #include <fmgr.h>
@@ -19,5 +18,3 @@ extern Datum tsl_recompress_chunk_segmentwise(PG_FUNCTION_ARGS);
 
 extern Datum tsl_get_compressed_chunk_index_for_recompression(
 	PG_FUNCTION_ARGS); // arg is oid of uncompressed chunk
-
-#endif /* TIMESCALEDB_TSL_COMPRESSION_API_H */

--- a/tsl/src/compression/array.h
+++ b/tsl/src/compression/array.h
@@ -3,14 +3,14 @@
  * Please see the included NOTICE for copyright information and
  * LICENSE-TIMESCALE for a copy of the license.
  */
+#pragma once
+
 /*
  * The `array` compression method can store any type of data. It simply puts it into an
  * array-like structure and does not compress it. TOAST-based compression should be applied on top.
  *
  * Array compression is are also used as a building block for dictionary compression.
  */
-#ifndef TIMESCALEDB_TSL_COMPRESSION_ARRAY_H
-#define TIMESCALEDB_TSL_COMPRESSION_ARRAY_H
 
 #include <postgres.h>
 #include <fmgr.h>
@@ -73,5 +73,3 @@ extern Datum tsl_array_compressor_finish(PG_FUNCTION_ARGS);
 		.compressor_for_type = array_compressor_for_type,                                          \
 		.compressed_data_storage = TOAST_STORAGE_EXTENDED,                                         \
 	}
-
-#endif

--- a/tsl/src/compression/arrow_c_data_interface.h
+++ b/tsl/src/compression/arrow_c_data_interface.h
@@ -3,6 +3,7 @@
  * Please see the included NOTICE for copyright information and
  * LICENSE-TIMESCALE for a copy of the license.
  */
+#pragma once
 
 /*
  * This header describes the Arrow C data interface which is a well-known
@@ -21,8 +22,6 @@
  * Applications and libraries can therefore work with Arrow memory without
  * necessarily using Arrow libraries or reinventing the wheel.
  */
-
-#pragma once
 
 #ifndef ARROW_C_DATA_INTERFACE
 #define ARROW_C_DATA_INTERFACE

--- a/tsl/src/compression/compression.h
+++ b/tsl/src/compression/compression.h
@@ -3,8 +3,7 @@
  * Please see the included NOTICE for copyright information and
  * LICENSE-TIMESCALE for a copy of the license.
  */
-#ifndef TIMESCALEDB_TSL_COMPRESSION_COMPRESSION_H
-#define TIMESCALEDB_TSL_COMPRESSION_COMPRESSION_H
+#pragma once
 
 #include <postgres.h>
 #include <executor/tuptable.h>
@@ -401,5 +400,3 @@ consumeCompressedData(StringInfo si, int bytes)
  * We use this limit for sanity checks in case the compressed data is corrupt.
  */
 #define GLOBAL_MAX_ROWS_PER_COMPRESSION 1015
-
-#endif

--- a/tsl/src/compression/create.h
+++ b/tsl/src/compression/create.h
@@ -3,8 +3,8 @@
  * Please see the included NOTICE for copyright information and
  * LICENSE-TIMESCALE for a copy of the license.
  */
-#ifndef TIMESCALEDB_TSL_COMPRESSION_CREATE_H
-#define TIMESCALEDB_TSL_COMPRESSION_CREATE_H
+#pragma once
+
 #include <postgres.h>
 #include <nodes/parsenodes.h>
 
@@ -27,5 +27,3 @@ Chunk *create_compress_chunk(Hypertable *compress_ht, Chunk *src_chunk, Oid tabl
 
 char *column_segment_min_name(int16 column_index);
 char *column_segment_max_name(int16 column_index);
-
-#endif /* TIMESCALEDB_TSL_COMPRESSION_CREATE_H */

--- a/tsl/src/compression/datum_serialize.h
+++ b/tsl/src/compression/datum_serialize.h
@@ -3,8 +3,7 @@
  * Please see the included NOTICE for copyright information and
  * LICENSE-TIMESCALE for a copy of the license.
  */
-#ifndef TIMESCALEDB_TSL_COMPRESSION_DATUM_SERIALIZE_H
-#define TIMESCALEDB_TSL_COMPRESSION_DATUM_SERIALIZE_H
+#pragma once
 
 #include <postgres.h>
 #include <lib/stringinfo.h>
@@ -46,5 +45,3 @@ Datum bytes_to_datum_and_advance(DatumDeserializer *deserializer, const char **p
 Datum binary_string_to_datum(DatumDeserializer *deserializer, BinaryStringEncoding encoding,
 							 StringInfo buffer);
 Oid binary_string_get_type(StringInfo buffer);
-
-#endif

--- a/tsl/src/compression/deltadelta.h
+++ b/tsl/src/compression/deltadelta.h
@@ -3,6 +3,8 @@
  * Please see the included NOTICE for copyright information and
  * LICENSE-TIMESCALE for a copy of the license.
  */
+#pragma once
+
 /*
  * Deltadelta is used to encode integers or integer-like objects (e.g. timestamps). It's input is a
  * series of integers. first convert that series to a series of delta-of-deltas between
@@ -14,8 +16,6 @@
  * First we zigzag encodes the delta-of-deltas
  * Second, we simple8b_rle encode the zig-zag encoding
  */
-#ifndef TIMESCALEDB_TSL_COMPRESSION_DELTA_DELTA_H
-#define TIMESCALEDB_TSL_COMPRESSION_DELTA_DELTA_H
 
 #include <postgres.h>
 #include <fmgr.h>
@@ -64,5 +64,3 @@ extern Datum tsl_deltadelta_compressor_finish(PG_FUNCTION_ARGS);
 		.compressor_for_type = delta_delta_compressor_for_type,                                    \
 		.compressed_data_storage = TOAST_STORAGE_EXTERNAL,                                         \
 	}
-
-#endif

--- a/tsl/src/compression/dictionary.h
+++ b/tsl/src/compression/dictionary.h
@@ -3,6 +3,8 @@
  * Please see the included NOTICE for copyright information and
  * LICENSE-TIMESCALE for a copy of the license.
  */
+#pragma once
+
 /*
  * The Dictionary compressions scheme can store any type of data but is optimized for
  * low-cardinality data sets. The dictionary of distinct items is stored as an `array` compressed
@@ -10,8 +12,6 @@
  * dictionary array ordered by row number (called dictionary_indexes; compressed using
  * `simple8b_rle`).
  */
-#ifndef TIMESCALEDB_TSL_DICTIONARY_COMPRESSION_H
-#define TIMESCALEDB_TSL_DICTIONARY_COMPRESSION_H
 
 #include <postgres.h>
 #include <lib/stringinfo.h>
@@ -56,5 +56,3 @@ extern Datum tsl_dictionary_compressor_finish(PG_FUNCTION_ARGS);
 		.compressor_for_type = dictionary_compressor_for_type,                                     \
 		.compressed_data_storage = TOAST_STORAGE_EXTENDED,                                         \
 	}
-
-#endif

--- a/tsl/src/compression/dictionary_hash.h
+++ b/tsl/src/compression/dictionary_hash.h
@@ -3,6 +3,8 @@
  * Please see the included NOTICE for copyright information and
  * LICENSE-TIMESCALE for a copy of the license.
  */
+#pragma once
+
 /*
  * The Dictionary compressions scheme can store any type of data but is optimized for
  * low-cardinality data sets. The dictionary of distinct items is stored as an `array` compressed
@@ -10,9 +12,6 @@
  * dictionary array ordered by row number (called dictionary_indexes; compressed using
  * `simple8b_rle`).
  */
-#ifndef TIMESCALEDB_TSL_COMPRESSION_DICTIONARY_HASH_H
-#define TIMESCALEDB_TSL_COMPRESSION_DICTIONARY_HASH_H
-
 #include <postgres.h>
 #include <funcapi.h>
 #include <utils/typcache.h>
@@ -106,5 +105,3 @@ dictionary_hash_alloc(TypeCacheEntry *tentry)
 
 	return dictionary_create(CurrentMemoryContext, 10, meta);
 }
-
-#endif

--- a/tsl/src/compression/float_utils.h
+++ b/tsl/src/compression/float_utils.h
@@ -3,8 +3,7 @@
  * Please see the included NOTICE for copyright information and
  * LICENSE-TIMESCALE for a copy of the license.
  */
-#ifndef TIMESCALEDB_TSL_COMPRESSION_FLOAT_UTILS_H
-#define TIMESCALEDB_TSL_COMPRESSION_FLOAT_UTILS_H
+#pragma once
 
 #include <postgres.h>
 
@@ -47,5 +46,3 @@ bits_get_double(uint64 bits)
 	memcpy(&out, &bits, sizeof(double));
 	return out;
 }
-
-#endif

--- a/tsl/src/compression/gorilla.h
+++ b/tsl/src/compression/gorilla.h
@@ -3,6 +3,8 @@
  * Please see the included NOTICE for copyright information and
  * LICENSE-TIMESCALE for a copy of the license.
  */
+#pragma once
+
 /*
  *  The Gorilla algorithm compresses floats and is modeled after the Facebook Gorilla paper:
  *  "Gorilla: A Fast, Scalable, In-Memory Time Series Database" by Tuomas Pelkonen et. al.
@@ -57,8 +59,6 @@
  *     you are done.
  *
  */
-#ifndef TIMESCALEDB_TSL_FLOAT_COMPRESSION_H
-#define TIMESCALEDB_TSL_FLOAT_COMPRESSION_H
 
 #include <postgres.h>
 #include <c.h>
@@ -104,5 +104,3 @@ extern Datum tsl_gorilla_compressor_finish(PG_FUNCTION_ARGS);
 		.compressor_for_type = gorilla_compressor_for_type,                                        \
 		.compressed_data_storage = TOAST_STORAGE_EXTERNAL,                                         \
 	}
-
-#endif

--- a/tsl/src/compression/segment_meta.h
+++ b/tsl/src/compression/segment_meta.h
@@ -3,8 +3,7 @@
  * Please see the included NOTICE for copyright information and
  * LICENSE-TIMESCALE for a copy of the license.
  */
-#ifndef TIMESCALEDB_TSL_COMPRESSION_SEGMENT_META_H
-#define TIMESCALEDB_TSL_COMPRESSION_SEGMENT_META_H
+#pragma once
 
 #include <postgres.h>
 #include <fmgr.h>
@@ -35,4 +34,3 @@ Datum segment_meta_min_max_builder_max(SegmentMetaMinMaxBuilder *builder);
 bool segment_meta_min_max_builder_empty(SegmentMetaMinMaxBuilder *builder);
 
 void segment_meta_min_max_builder_reset(SegmentMetaMinMaxBuilder *builder);
-#endif

--- a/tsl/src/compression/simple8b_rle.h
+++ b/tsl/src/compression/simple8b_rle.h
@@ -3,8 +3,7 @@
  * Please see the included NOTICE for copyright information and
  * LICENSE-TIMESCALE for a copy of the license.
  */
-#ifndef TIMESCALEDB_TSL_SIMPLE8B_RLE_OOB_H
-#define TIMESCALEDB_TSL_SIMPLE8B_RLE_OOB_H
+#pragma once
 
 #include <postgres.h>
 #include <c.h>
@@ -894,5 +893,3 @@ simple8brle_bits_for_value(uint64 v)
 	}
 	return r;
 }
-
-#endif

--- a/tsl/src/compression/simple8b_rle_bitmap.h
+++ b/tsl/src/compression/simple8b_rle_bitmap.h
@@ -3,13 +3,12 @@
  * Please see the included NOTICE for copyright information and
  * LICENSE-TIMESCALE for a copy of the license.
  */
+#pragma once
 
 /*
  * This is a specialization of Simple8bRLE decoder for bitmaps, i.e. where the
  * elements are only 0 and 1. It also counts the number of ones.
  */
-
-#pragma once
 
 #include "compression/simple8b_rle.h"
 

--- a/tsl/src/continuous_aggs/common.h
+++ b/tsl/src/continuous_aggs/common.h
@@ -3,9 +3,7 @@
  * Please see the included NOTICE for copyright information and
  * LICENSE-TIMESCALE for a copy of the license.
  */
-
-#ifndef TIMESCALEDB_TSL_CONTINUOUS_AGGS_COMMON_H
-#define TIMESCALEDB_TSL_CONTINUOUS_AGGS_COMMON_H
+#pragma once
 
 #include <postgres.h>
 
@@ -133,5 +131,3 @@ extern Query *build_union_query(CAggTimebucketInfo *tbinfo, int matpartcolno, Qu
 extern void mattablecolumninfo_init(MatTableColumnInfo *matcolinfo, List *grouplist);
 extern void mattablecolumninfo_addinternal(MatTableColumnInfo *matcolinfo);
 extern bool function_allowed_in_cagg_definition(Oid funcid);
-
-#endif /* TIMESCALEDB_TSL_CONTINUOUS_AGGS_COMMON_H */

--- a/tsl/src/continuous_aggs/create.h
+++ b/tsl/src/continuous_aggs/create.h
@@ -3,8 +3,8 @@
  * Please see the included NOTICE for copyright information and
  * LICENSE-TIMESCALE for a copy of the license.
  */
-#ifndef TIMESCALEDB_TSL_CONTINUOUS_AGGS_CAGG_CREATE_H
-#define TIMESCALEDB_TSL_CONTINUOUS_AGGS_CAGG_CREATE_H
+#pragma once
+
 #include <postgres.h>
 
 #include <process_utility.h>
@@ -16,5 +16,3 @@ DDLResult tsl_process_continuous_agg_viewstmt(Node *node, const char *query_stri
 
 extern void cagg_flip_realtime_view_definition(ContinuousAgg *agg, Hypertable *mat_ht);
 extern void cagg_rename_view_columns(ContinuousAgg *agg);
-
-#endif /* TIMESCALEDB_TSL_CONTINUOUS_AGGS_CAGG_CREATE_H */

--- a/tsl/src/continuous_aggs/finalize.h
+++ b/tsl/src/continuous_aggs/finalize.h
@@ -3,8 +3,7 @@
  * Please see the included NOTICE for copyright information and
  * LICENSE-TIMESCALE for a copy of the license.
  */
-#ifndef TIMESCALEDB_TSL_CONTINUOUS_AGGS_FINALIZE_H
-#define TIMESCALEDB_TSL_CONTINUOUS_AGGS_FINALIZE_H
+#pragma once
 
 #include <postgres.h>
 
@@ -36,4 +35,3 @@ extern void finalizequery_init(FinalizeQueryInfo *inp, Query *orig_query,
 							   MatTableColumnInfo *mattblinfo);
 extern Query *finalizequery_get_select_query(FinalizeQueryInfo *inp, List *matcollist,
 											 ObjectAddress *mattbladdress, char *relname);
-#endif /* TIMESCALEDB_TSL_CONTINUOUS_AGGS_FINALIZE_H */

--- a/tsl/src/continuous_aggs/insert.h
+++ b/tsl/src/continuous_aggs/insert.h
@@ -3,8 +3,7 @@
  * Please see the included NOTICE for copyright information and
  * LICENSE-TIMESCALE for a copy of the license.
  */
-#ifndef TIMESCALEDB_TSL_CONTINUOUS_AGGS_INSERT_H
-#define TIMESCALEDB_TSL_CONTINUOUS_AGGS_INSERT_H
+#pragma once
 
 #include <postgres.h>
 
@@ -16,5 +15,3 @@ extern void execute_cagg_trigger(int32 hypertable_id, Relation chunk_rel, HeapTu
 								 HeapTuple chunk_newtuple, bool update,
 								 bool is_distributed_hypertable_trigger,
 								 int32 parent_hypertable_id);
-
-#endif /* TIMESCALEDB_TSL_CONTINUOUS_AGGS_INSERT_H */

--- a/tsl/src/continuous_aggs/invalidation.h
+++ b/tsl/src/continuous_aggs/invalidation.h
@@ -3,8 +3,7 @@
  * Please see the included NOTICE for copyright information and
  * LICENSE-TIMESCALE for a copy of the license.
  */
-#ifndef TIMESCALEDB_TSL_CONTINUOUS_AGGS_INVALIDATION_H
-#define TIMESCALEDB_TSL_CONTINUOUS_AGGS_INVALIDATION_H
+#pragma once
 
 #include <postgres.h>
 
@@ -73,5 +72,3 @@ extern Datum tsl_drop_dist_ht_invalidation_trigger(PG_FUNCTION_ARGS);
 extern void remote_drop_dist_ht_invalidation_trigger(int32 raw_hypertable_id);
 
 extern void invalidation_store_free(InvalidationStore *store);
-
-#endif /* TIMESCALEDB_TSL_CONTINUOUS_AGGS_INVALIDATION_H */

--- a/tsl/src/continuous_aggs/invalidation_threshold.h
+++ b/tsl/src/continuous_aggs/invalidation_threshold.h
@@ -3,8 +3,7 @@
  * Please see the included NOTICE for copyright information and
  * LICENSE-TIMESCALE for a copy of the license.
  */
-#ifndef TIMESCALEDB_TSL_CONTINUOUS_AGGS_INVALIDATION_THRESHOLD_H
-#define TIMESCALEDB_TSL_CONTINUOUS_AGGS_INVALIDATION_THRESHOLD_H
+#pragma once
 
 #include <postgres.h>
 
@@ -17,5 +16,3 @@ extern int64 invalidation_threshold_set_or_get(const ContinuousAgg *cagg,
 extern int64 invalidation_threshold_compute(const ContinuousAgg *cagg,
 											const InternalTimeRange *refresh_window);
 extern void invalidation_threshold_initialize(const ContinuousAgg *cagg);
-
-#endif /* TIMESCALEDB_TSL_CONTINUOUS_AGGS_INVALIDATION_THRESHOLD_H */

--- a/tsl/src/continuous_aggs/materialize.h
+++ b/tsl/src/continuous_aggs/materialize.h
@@ -3,8 +3,7 @@
  * Please see the included NOTICE for copyright information and
  * LICENSE-TIMESCALE for a copy of the license.
  */
-#ifndef TIMESCALEDB_TSL_CONTINUOUS_AGGS_MATERIALIZE_H
-#define TIMESCALEDB_TSL_CONTINUOUS_AGGS_MATERIALIZE_H
+#pragma once
 
 #include <postgres.h>
 #include <fmgr.h>
@@ -41,4 +40,3 @@ void continuous_agg_update_materialization(Hypertable *mat_ht, SchemaAndName par
 										   const NameData *time_column_name,
 										   InternalTimeRange new_materialization_range,
 										   InternalTimeRange invalidation_range, int32 chunk_id);
-#endif /* TIMESCALEDB_TSL_CONTINUOUS_AGGS_MATERIALIZE_H */

--- a/tsl/src/continuous_aggs/options.h
+++ b/tsl/src/continuous_aggs/options.h
@@ -3,8 +3,8 @@
  * Please see the included NOTICE for copyright information and
  * LICENSE-TIMESCALE for a copy of the license.
  */
-#ifndef TIMESCALEDB_TSL_CONTINUOUS_AGGS_OPTIONS_H
-#define TIMESCALEDB_TSL_CONTINUOUS_AGGS_OPTIONS_H
+#pragma once
+
 #include <postgres.h>
 
 #include "with_clause_parser.h"
@@ -12,5 +12,3 @@
 
 extern void continuous_agg_update_options(ContinuousAgg *cagg,
 										  WithClauseResult *with_clause_options);
-
-#endif /* TIMESCALEDB_TSL_CONTINUOUS_AGGS_OPTIONS_H */

--- a/tsl/src/continuous_aggs/refresh.h
+++ b/tsl/src/continuous_aggs/refresh.h
@@ -3,8 +3,7 @@
  * Please see the included NOTICE for copyright information and
  * LICENSE-TIMESCALE for a copy of the license.
  */
-#ifndef TIMESCALEDB_TSL_CONTINUOUS_AGGS_REFRESH_H
-#define TIMESCALEDB_TSL_CONTINUOUS_AGGS_REFRESH_H
+#pragma once
 
 #include <postgres.h>
 #include <fmgr.h>
@@ -30,5 +29,3 @@ extern void continuous_agg_refresh_internal(const ContinuousAgg *cagg,
 											const InternalTimeRange *refresh_window,
 											const CaggRefreshCallContext callctx,
 											const bool start_isnull, const bool end_isnull);
-
-#endif /* TIMESCALEDB_TSL_CONTINUOUS_AGGS_REFRESH_H */

--- a/tsl/src/continuous_aggs/repair.h
+++ b/tsl/src/continuous_aggs/repair.h
@@ -3,8 +3,8 @@
  * Please see the included NOTICE for copyright information and
  * LICENSE-TIMESCALE for a copy of the license.
  */
-#ifndef TIMESCALEDB_TSL_CONTINUOUS_AGGS_CAGG_REPAIR_H
-#define TIMESCALEDB_TSL_CONTINUOUS_AGGS_CAGG_REPAIR_H
+#pragma once
+
 #include <postgres.h>
 
 #include <commands/view.h>
@@ -15,5 +15,3 @@
 #include "ts_catalog/continuous_agg.h"
 
 extern Datum tsl_cagg_try_repair(PG_FUNCTION_ARGS);
-
-#endif

--- a/tsl/src/continuous_aggs/utils.h
+++ b/tsl/src/continuous_aggs/utils.h
@@ -3,9 +3,7 @@
  * Please see the included NOTICE for copyright information and
  * LICENSE-TIMESCALE for a copy of the license.
  */
-
-#ifndef TIMESCALEDB_TSL_CONTINUOUS_AGGS_UTILS_H
-#define TIMESCALEDB_TSL_CONTINUOUS_AGGS_UTILS_H
+#pragma once
 
 #include <postgres.h>
 #include <funcapi.h>
@@ -18,5 +16,3 @@
 #include "compat/compat.h"
 
 extern Datum continuous_agg_validate_query(PG_FUNCTION_ARGS);
-
-#endif /* TIMESCALEDB_TSL_CONTINUOUS_AGGS_UTILS_H */

--- a/tsl/src/data_node.h
+++ b/tsl/src/data_node.h
@@ -3,8 +3,7 @@
  * Please see the included NOTICE for copyright information and
  * LICENSE-TIMESCALE for a copy of the license.
  */
-#ifndef TIMESCALEDB_TSL_DATA_NODE_H
-#define TIMESCALEDB_TSL_DATA_NODE_H
+#pragma once
 
 #include <foreign/foreign.h>
 
@@ -49,5 +48,3 @@ extern HypertableDataNode *data_node_hypertable_get_by_node_name(const Hypertabl
 
 /* This should only be used for testing */
 extern Datum data_node_add_without_dist_id(PG_FUNCTION_ARGS);
-
-#endif /* TIMESCALEDB_TSL_DATA_NODE_H */

--- a/tsl/src/debug.h
+++ b/tsl/src/debug.h
@@ -3,8 +3,7 @@
  * Please see the included NOTICE for copyright information and
  * LICENSE-TIMESCALE for a copy of the license.
  */
-#ifndef TIMESCALEDB_DEBUG_H
-#define TIMESCALEDB_DEBUG_H
+#pragma once
 
 #include <postgres.h>
 #include <lib/stringinfo.h>
@@ -17,5 +16,3 @@
 extern void tsl_debug_log_rel_with_paths(PlannerInfo *root, RelOptInfo *rel,
 										 UpperRelationKind *upper_stage);
 #endif
-
-#endif /* TIMESCALEDB_DEBUG_H */

--- a/tsl/src/deparse.h
+++ b/tsl/src/deparse.h
@@ -3,8 +3,7 @@
  * Please see the included NOTICE for copyright information and
  * LICENSE-TIMESCALE for a copy of the license.
  */
-#ifndef TIMESCALEDB_DEPARSE_H
-#define TIMESCALEDB_DEPARSE_H
+#pragma once
 
 #include <postgres.h>
 #include <nodes/pg_list.h>
@@ -52,5 +51,3 @@ const char *deparse_func_call(FunctionCallInfo fcinfo);
 const char *deparse_oid_function_call_coll(Oid funcid, Oid collation, unsigned int num_args, ...);
 const char *deparse_grant_revoke_on_database(const GrantStmt *stmt, const char *dbname);
 const char *deparse_create_trigger(CreateTrigStmt *stmt);
-
-#endif

--- a/tsl/src/dist_backup.h
+++ b/tsl/src/dist_backup.h
@@ -3,11 +3,8 @@
  * Please see the included NOTICE for copyright information and
  * LICENSE-TIMESCALE for a copy of the license.
  */
-#ifndef TIMESCALEDB_TSL_DIST_BACKUP_H
-#define TIMESCALEDB_TSL_DIST_BACKUP_H
+#pragma once
 
 #include <postgres.h>
 
 extern Datum create_distributed_restore_point(PG_FUNCTION_ARGS);
-
-#endif /* TIMESCALEDB_TSL_DIST_BACKUP_H */

--- a/tsl/src/dist_util.h
+++ b/tsl/src/dist_util.h
@@ -3,8 +3,7 @@
  * Please see the included NOTICE for copyright information and
  * LICENSE-TIMESCALE for a copy of the license.
  */
-#ifndef TIMESCALEDB_TSL_DIST_UTIL_H
-#define TIMESCALEDB_TSL_DIST_UTIL_H
+#pragma once
 
 #include <postgres.h>
 #include <fmgr.h>
@@ -38,5 +37,3 @@ Datum dist_util_remote_hypertable_index_info(PG_FUNCTION_ARGS);
 void validate_data_node_settings(void);
 bool dist_util_is_compatible_version(const char *data_node_version,
 									 const char *access_node_version);
-
-#endif /* TIMESCALEDB_TSL_DIST_UTIL_H */

--- a/tsl/src/fdw/data_node_chunk_assignment.h
+++ b/tsl/src/fdw/data_node_chunk_assignment.h
@@ -3,8 +3,7 @@
  * Please see the included NOTICE for copyright information and
  * LICENSE-TIMESCALE for a copy of the license.
  */
-#ifndef TIMESCALEDB_TSL_DATA_NODE_CHUNK_ASSIGNMENT
-#define TIMESCALEDB_TSL_DATA_NODE_CHUNK_ASSIGNMENT
+#pragma once
 
 #include <postgres.h>
 #include <nodes/pathnodes.h>
@@ -68,5 +67,3 @@ extern void data_node_chunk_assignments_init(DataNodeChunkAssignments *scas,
 
 extern bool data_node_chunk_assignments_are_overlapping(DataNodeChunkAssignments *scas,
 														int32 partitioning_dimension_id);
-
-#endif /* TIMESCALEDB_TSL_DATA_NODE_CHUNK_ASSIGNMENT */

--- a/tsl/src/fdw/data_node_scan_exec.h
+++ b/tsl/src/fdw/data_node_scan_exec.h
@@ -3,8 +3,7 @@
  * Please see the included NOTICE for copyright information and
  * LICENSE-TIMESCALE for a copy of the license.
  */
-#ifndef TIMESCALEDB_TSL_FDW_DATA_NODE_SCAN_EXEC_H
-#define TIMESCALEDB_TSL_FDW_DATA_NODE_SCAN_EXEC_H
+#pragma once
 
 #include <postgres.h>
 #include <nodes/plannodes.h>
@@ -13,5 +12,3 @@
 #include "remote/async.h"
 
 extern Node *data_node_scan_state_create(CustomScan *cscan);
-
-#endif /* TIMESCALEDB_TSL_FDW_DATA_NODE_SCAN_EXEC_H */

--- a/tsl/src/fdw/data_node_scan_plan.h
+++ b/tsl/src/fdw/data_node_scan_plan.h
@@ -3,8 +3,7 @@
  * Please see the included NOTICE for copyright information and
  * LICENSE-TIMESCALE for a copy of the license.
  */
-#ifndef TIMESCALEDB_TSL_FDW_DATA_NODE_SCAN_H
-#define TIMESCALEDB_TSL_FDW_DATA_NODE_SCAN_H
+#pragma once
 
 #include <postgres.h>
 #include <nodes/plannodes.h>
@@ -28,5 +27,3 @@ typedef enum
 	DataNodeScanSystemcol,
 	DataNodeScanFetcherType,
 } DataNodeScanPrivateIndex;
-
-#endif /* TIMESCALEDB_TSL_FDW_DATA_NODE_SCAN_H */

--- a/tsl/src/fdw/deparse.h
+++ b/tsl/src/fdw/deparse.h
@@ -3,8 +3,7 @@
  * Please see the included NOTICE for copyright information and
  * LICENSE-TIMESCALE for a copy of the license.
  */
-#ifndef TIMESCALEDB_TSL_FDW_DEPARSE_H
-#define TIMESCALEDB_TSL_FDW_DEPARSE_H
+#pragma once
 
 #include <postgres.h>
 #include "data_node_chunk_assignment.h"
@@ -55,5 +54,3 @@ extern const char *get_jointype_name(JoinType jointype);
 extern void deparseStringLiteral(StringInfo buf, const char *val);
 extern void deparseAnalyzeSizeSql(StringInfo buf, Relation rel);
 extern void deparseAnalyzeSql(StringInfo buf, Relation rel, List **retrieved_attrs);
-
-#endif /* TIMESCALEDB_TSL_FDW_DEPARSE_H */

--- a/tsl/src/fdw/estimate.h
+++ b/tsl/src/fdw/estimate.h
@@ -3,8 +3,7 @@
  * Please see the included NOTICE for copyright information and
  * LICENSE-TIMESCALE for a copy of the license.
  */
-#ifndef TIMESCALEDB_TSL_FDW_ESTIMATE_H
-#define TIMESCALEDB_TSL_FDW_ESTIMATE_H
+#pragma once
 
 #include <postgres.h>
 #include <nodes/pathnodes.h>
@@ -13,5 +12,3 @@
 extern void fdw_estimate_path_cost_size(PlannerInfo *root, RelOptInfo *rel, List *pathkeys,
 										double *p_rows, int *p_width, Cost *p_startup_cost,
 										Cost *p_total_cost);
-
-#endif /* TIMESCALEDB_TSL_FDW_ESTIMATE_H */

--- a/tsl/src/fdw/fdw.h
+++ b/tsl/src/fdw/fdw.h
@@ -3,8 +3,7 @@
  * Please see the included NOTICE for copyright information and
  * LICENSE-TIMESCALE for a copy of the license.
  */
-#ifndef TIMESCALEDB_TSL_FDW_FDW_H
-#define TIMESCALEDB_TSL_FDW_FDW_H
+#pragma once
 
 #include <postgres.h>
 #include <fmgr.h>
@@ -16,5 +15,3 @@ extern void tsl_mn_get_foreign_join_paths(PlannerInfo *root, RelOptInfo *joinrel
 
 extern Datum timescaledb_fdw_handler(PG_FUNCTION_ARGS);
 extern Datum timescaledb_fdw_validator(PG_FUNCTION_ARGS);
-
-#endif /* TIMESCALEDB_TSL_FDW_FDW_H */

--- a/tsl/src/fdw/fdw_utils.h
+++ b/tsl/src/fdw/fdw_utils.h
@@ -3,8 +3,7 @@
  * Please see the included NOTICE for copyright information and
  * LICENSE-TIMESCALE for a copy of the license.
  */
-#ifndef TIMESCALEDB_TSL_FDW_FDW_UTILS_H
-#define TIMESCALEDB_TSL_FDW_FDW_UTILS_H
+#pragma once
 
 #include <postgres.h>
 #include <optimizer/paths.h>
@@ -21,5 +20,3 @@ extern void fdw_utils_free_path(ConsideredPath *path);
 #define fdw_utils_add_path(rel, path) add_path(rel, path);
 
 #endif /* TS_DEBUG */
-
-#endif /* TIMESCALEDB_TSL_FDW_FDW_UTILS_H */

--- a/tsl/src/fdw/modify_exec.h
+++ b/tsl/src/fdw/modify_exec.h
@@ -3,8 +3,7 @@
  * Please see the included NOTICE for copyright information and
  * LICENSE-TIMESCALE for a copy of the license.
  */
-#ifndef TIMESCALEDB_TSL_FDW_MODIFY_EXEC_H
-#define TIMESCALEDB_TSL_FDW_MODIFY_EXEC_H
+#pragma once
 
 #include <postgres.h>
 #include <commands/explain.h>
@@ -32,5 +31,3 @@ extern TupleTableSlot *fdw_exec_foreign_update_or_delete(TsFdwModifyState *fmsta
 extern void fdw_finish_foreign_modify(TsFdwModifyState *fmstate);
 extern void fdw_explain_modify(PlanState *ps, ResultRelInfo *rri, List *fdw_private,
 							   int subplan_index, ExplainState *es);
-
-#endif /* TIMESCALEDB_TSL_FDW_MODIFY_EXEC_H */

--- a/tsl/src/fdw/modify_plan.h
+++ b/tsl/src/fdw/modify_plan.h
@@ -3,13 +3,10 @@
  * Please see the included NOTICE for copyright information and
  * LICENSE-TIMESCALE for a copy of the license.
  */
-#ifndef TIMESCALEDB_TSL_FDW_MODIFY_PLAN_H
-#define TIMESCALEDB_TSL_FDW_MODIFY_PLAN_H
+#pragma once
 
 #include <postgres.h>
 
 extern List *fdw_plan_foreign_modify(PlannerInfo *root, ModifyTable *plan, Index result_relation,
 									 int subplan_index);
 extern List *get_chunk_data_nodes(Oid relid);
-
-#endif /* TIMESCALEDB_TSL_FDW_MODIFY_PLAN_H */

--- a/tsl/src/fdw/option.h
+++ b/tsl/src/fdw/option.h
@@ -3,8 +3,7 @@
  * Please see the included NOTICE for copyright information and
  * LICENSE-TIMESCALE for a copy of the license.
  */
-#ifndef TIMESCALEDB_TSL_FDW_OPTION_H
-#define TIMESCALEDB_TSL_FDW_OPTION_H
+#pragma once
 
 #include <postgres.h>
 
@@ -12,5 +11,3 @@ extern void option_validate(List *options_list, Oid catalog);
 extern List *option_extract_extension_list(const char *extensions_string, bool warn_on_missing);
 extern List *option_extract_join_ref_table_list(const char *join_tables);
 extern bool option_get_from_options_list_int(List *options, const char *optionname, int *value);
-
-#endif /* TIMESCALEDB_TSL_FDW_OPTION_H */

--- a/tsl/src/fdw/relinfo.h
+++ b/tsl/src/fdw/relinfo.h
@@ -3,8 +3,7 @@
  * Please see the included NOTICE for copyright information and
  * LICENSE-TIMESCALE for a copy of the license.
  */
-#ifndef TIMESCALEDB_TSL_FDW_RELINFO_H
-#define TIMESCALEDB_TSL_FDW_RELINFO_H
+#pragma once
 
 #include <postgres.h>
 #include <foreign/foreign.h>
@@ -166,5 +165,3 @@ extern TsFdwRelInfo *fdw_relinfo_create(PlannerInfo *root, RelOptInfo *rel, Oid 
 extern TsFdwRelInfo *fdw_relinfo_alloc_or_get(RelOptInfo *rel);
 extern TsFdwRelInfo *fdw_relinfo_get(RelOptInfo *rel);
 extern void apply_fdw_and_server_options(TsFdwRelInfo *fpinfo);
-
-#endif /* TIMESCALEDB_TSL_FDW_RELINFO_H */

--- a/tsl/src/fdw/scan_exec.h
+++ b/tsl/src/fdw/scan_exec.h
@@ -3,8 +3,7 @@
  * Please see the included NOTICE for copyright information and
  * LICENSE-TIMESCALE for a copy of the license.
  */
-#ifndef TIMESCALEDB_TSL_FDW_SCAN_EXEC_H
-#define TIMESCALEDB_TSL_FDW_SCAN_EXEC_H
+#pragma once
 
 #include <postgres.h>
 #include <utils/rel.h>
@@ -68,5 +67,3 @@ extern TimestampTz ts_current_timestamp_override_value;
 /* Allow tests to specify the time to push down in place of now() */
 extern void fdw_scan_debug_override_current_timestamp(TimestampTz time);
 #endif
-
-#endif /* TIMESCALEDB_TSL_FDW_SCAN_EXEC_H */

--- a/tsl/src/fdw/scan_plan.h
+++ b/tsl/src/fdw/scan_plan.h
@@ -3,8 +3,7 @@
  * Please see the included NOTICE for copyright information and
  * LICENSE-TIMESCALE for a copy of the license.
  */
-#ifndef TIMESCALEDB_TSL_FDW_SCAN_PLAN_H
-#define TIMESCALEDB_TSL_FDW_SCAN_PLAN_H
+#pragma once
 
 #include <postgres.h>
 #include <commands/explain.h>
@@ -52,5 +51,3 @@ extern void fdw_create_upper_paths(TsFdwRelInfo *input_fpinfo, PlannerInfo *root
 								   UpperRelationKind stage, RelOptInfo *input_rel,
 								   RelOptInfo *output_rel, void *extra,
 								   CreateUpperPathFunc create_paths);
-
-#endif /* TIMESCALEDB_TSL_FDW_SCAN_PLAN_H */

--- a/tsl/src/fdw/shippable.h
+++ b/tsl/src/fdw/shippable.h
@@ -3,8 +3,7 @@
  * Please see the included NOTICE for copyright information and
  * LICENSE-TIMESCALE for a copy of the license.
  */
-#ifndef TIMESCALEDB_TSL_FDW_SHIPPABLE_H
-#define TIMESCALEDB_TSL_FDW_SHIPPABLE_H
+#pragma once
 
 #include <postgres.h>
 
@@ -12,5 +11,3 @@ typedef struct TsFdwRelInfo TsFdwRelInfo;
 
 extern bool is_builtin(Oid objectId);
 extern bool is_shippable(Oid objectId, Oid classId, TsFdwRelInfo *fpinfo);
-
-#endif /* TIMESCALEDB_TSL_FDW_SHIPPABLE_H */

--- a/tsl/src/hypertable.h
+++ b/tsl/src/hypertable.h
@@ -3,8 +3,7 @@
  * Please see the included NOTICE for copyright information and
  * LICENSE-TIMESCALE for a copy of the license.
  */
-#ifndef TIMESCALEDB_TSL_HYPERTABLE_H
-#define TIMESCALEDB_TSL_HYPERTABLE_H
+#pragma once
 
 #include <hypertable.h>
 #include "dimension.h"
@@ -19,5 +18,3 @@ extern void hypertable_make_distributed(Hypertable *ht, List *data_node_names);
 extern List *hypertable_assign_data_nodes(int32 hypertable_id, List *nodes);
 extern List *hypertable_get_and_validate_data_nodes(ArrayType *nodearr);
 extern Datum hypertable_set_replication_factor(PG_FUNCTION_ARGS);
-
-#endif /* TIMESCALEDB_TSL_HYPERTABLE_H */

--- a/tsl/src/nodes/async_append.h
+++ b/tsl/src/nodes/async_append.h
@@ -3,8 +3,7 @@
  * Please see the included NOTICE for copyright information and
  * LICENSE-TIMESCALE for a copy of the license.
  */
-#ifndef TIMESCALEDB_TSL_ASYNC_APPEND_H
-#define TIMESCALEDB_TSL_ASYNC_APPEND_H
+#pragma once
 
 #include <postgres.h>
 #include <nodes/execnodes.h>
@@ -33,5 +32,3 @@ typedef struct AsyncScanState
 } AsyncScanState;
 
 extern void async_append_add_paths(PlannerInfo *root, RelOptInfo *final_rel);
-
-#endif

--- a/tsl/src/nodes/compress_dml/compress_dml.h
+++ b/tsl/src/nodes/compress_dml/compress_dml.h
@@ -3,8 +3,7 @@
  * Please see the included NOTICE for copyright information and
  * LICENSE-TIMESCALE for a copy of the license.
  */
-#ifndef TIMESCALEDB_COMPRESS_CHUNK_DML_H
-#define TIMESCALEDB_COMPRESS_CHUNK_DML_H
+#pragma once
 
 #include <postgres.h>
 #include <nodes/execnodes.h>
@@ -27,4 +26,3 @@ typedef struct CompressChunkDmlState
 Path *compress_chunk_dml_generate_paths(Path *subpath, Chunk *chunk);
 
 #define COMPRESS_CHUNK_DML_STATE_NAME "CompressChunkDmlState"
-#endif

--- a/tsl/src/nodes/data_node_copy.h
+++ b/tsl/src/nodes/data_node_copy.h
@@ -3,8 +3,7 @@
  * Please see the included NOTICE for copyright information and
  * LICENSE-TIMESCALE for a copy of the license.
  */
-#ifndef TIMESCALEDB_TSL_DATA_NODE_COPY_H
-#define TIMESCALEDB_TSL_DATA_NODE_COPY_H
+#pragma once
 
 #include <nodes/extensible.h>
 #include <nodes/plannodes.h>
@@ -12,5 +11,3 @@
 
 extern Path *data_node_copy_path_create(PlannerInfo *root, ModifyTablePath *mtpath,
 										Index hypertable_rti, int subplan_index);
-
-#endif /* TIMESCALEDB_TSL_DATA_NODE_COPY_H */

--- a/tsl/src/nodes/data_node_dispatch.h
+++ b/tsl/src/nodes/data_node_dispatch.h
@@ -3,8 +3,7 @@
  * Please see the included NOTICE for copyright information and
  * LICENSE-TIMESCALE for a copy of the license.
  */
-#ifndef TIMESCALEDB_TSL_DATA_NODE_DISPATCH_H
-#define TIMESCALEDB_TSL_DATA_NODE_DISPATCH_H
+#pragma once
 
 #include <nodes/extensible.h>
 #include <nodes/plannodes.h>
@@ -14,5 +13,3 @@
 
 Path *data_node_dispatch_path_create(PlannerInfo *root, ModifyTablePath *mtpath,
 									 Index hypertable_rti, int subplan_index);
-
-#endif /* TIMESCALEDB_TSL_DATA_NODE_DISPATCH_H */

--- a/tsl/src/nodes/decompress_chunk/batch_queue_fifo.h
+++ b/tsl/src/nodes/decompress_chunk/batch_queue_fifo.h
@@ -3,8 +3,7 @@
  * Please see the included NOTICE for copyright information and
  * LICENSE-TIMESCALE for a copy of the license.
  */
-#ifndef TIMESCALEDB_BATCH_QUEUE_FIFO_H
-#define TIMESCALEDB_BATCH_QUEUE_FIFO_H
+#pragma once
 
 #include "batch_queue.h"
 #include "compressed_batch.h"
@@ -69,5 +68,3 @@ static const struct BatchQueueFunctions BatchQueueFunctionsFifo = {
 
 extern BatchQueue *batch_queue_fifo_create(int num_compressed_cols, Size batch_memory_context_bytes,
 										   const BatchQueueFunctions *funcs);
-
-#endif /* TIMESCALEDB_BATCH_QUEUE_FIFO_H */

--- a/tsl/src/nodes/decompress_chunk/batch_queue_heap.h
+++ b/tsl/src/nodes/decompress_chunk/batch_queue_heap.h
@@ -3,8 +3,7 @@
  * Please see the included NOTICE for copyright information and
  * LICENSE-TIMESCALE for a copy of the license.
  */
-#ifndef TIMESCALEDB_BATCH_QUEUE_HEAP_H
-#define TIMESCALEDB_BATCH_QUEUE_HEAP_H
+#pragma once
 
 #include "batch_queue.h"
 
@@ -13,5 +12,3 @@ extern BatchQueue *batch_queue_heap_create(int num_compressed_cols, Size batch_m
 										   const BatchQueueFunctions *funcs);
 
 extern const struct BatchQueueFunctions BatchQueueFunctionsHeap;
-
-#endif /* TIMESCALEDB_BATCH_QUEUE_HEAP_H */

--- a/tsl/src/nodes/decompress_chunk/compressed_batch.h
+++ b/tsl/src/nodes/decompress_chunk/compressed_batch.h
@@ -3,7 +3,6 @@
  * Please see the included NOTICE for copyright information and
  * LICENSE-TIMESCALE for a copy of the license.
  */
-
 #pragma once
 
 #include "compression/compression.h"

--- a/tsl/src/nodes/decompress_chunk/decompress_chunk.h
+++ b/tsl/src/nodes/decompress_chunk/decompress_chunk.h
@@ -3,8 +3,7 @@
  * Please see the included NOTICE for copyright information and
  * LICENSE-TIMESCALE for a copy of the license.
  */
-#ifndef TIMESCALEDB_DECOMPRESS_CHUNK_H
-#define TIMESCALEDB_DECOMPRESS_CHUNK_H
+#pragma once
 
 #include <postgres.h>
 #include <nodes/bitmapset.h>
@@ -120,5 +119,3 @@ FormData_hypertable_compression *get_column_compressioninfo(List *hypertable_com
 															char *column_name);
 
 extern bool ts_is_decompress_chunk_path(Path *path);
-
-#endif /* TIMESCALEDB_DECOMPRESS_CHUNK_H */

--- a/tsl/src/nodes/decompress_chunk/exec.h
+++ b/tsl/src/nodes/decompress_chunk/exec.h
@@ -3,9 +3,7 @@
  * Please see the included NOTICE for copyright information and
  * LICENSE-TIMESCALE for a copy of the license.
  */
-
-#ifndef TIMESCALEDB_DECOMPRESS_CHUNK_EXEC_H
-#define TIMESCALEDB_DECOMPRESS_CHUNK_EXEC_H
+#pragma once
 
 #include <postgres.h>
 
@@ -52,5 +50,3 @@ typedef struct DecompressChunkState
 } DecompressChunkState;
 
 extern Node *decompress_chunk_state_create(CustomScan *cscan);
-
-#endif /* TIMESCALEDB_DECOMPRESS_CHUNK_EXEC_H */

--- a/tsl/src/nodes/decompress_chunk/planner.h
+++ b/tsl/src/nodes/decompress_chunk/planner.h
@@ -3,9 +3,7 @@
  * Please see the included NOTICE for copyright information and
  * LICENSE-TIMESCALE for a copy of the license.
  */
-
-#ifndef TIMESCALEDB_DECOMPRESS_CHUNK_PLANNER_H
-#define TIMESCALEDB_DECOMPRESS_CHUNK_PLANNER_H
+#pragma once
 
 #include <postgres.h>
 
@@ -13,5 +11,3 @@ extern Plan *decompress_chunk_plan_create(PlannerInfo *root, RelOptInfo *rel, Cu
 										  List *tlist, List *clauses, List *custom_plans);
 
 extern void _decompress_chunk_init(void);
-
-#endif /* TIMESCALEDB_DECOMPRESS_CHUNK_PLANNER_H */

--- a/tsl/src/nodes/decompress_chunk/qual_pushdown.h
+++ b/tsl/src/nodes/decompress_chunk/qual_pushdown.h
@@ -3,6 +3,7 @@
  * Please see the included NOTICE for copyright information and
  * LICENSE-TIMESCALE for a copy of the license.
  */
+#pragma once
 
 #include <postgres.h>
 

--- a/tsl/src/nodes/decompress_chunk/vector_predicates.h
+++ b/tsl/src/nodes/decompress_chunk/vector_predicates.h
@@ -7,7 +7,6 @@
 /*
  * Functions for working with vectorized predicates.
  */
-
 #pragma once
 
 typedef void(VectorPredicate)(const ArrowArray *, Datum, uint64 *restrict);

--- a/tsl/src/nodes/frozen_chunk_dml/frozen_chunk_dml.h
+++ b/tsl/src/nodes/frozen_chunk_dml/frozen_chunk_dml.h
@@ -3,8 +3,7 @@
  * Please see the included NOTICE for copyright information and
  * LICENSE-TIMESCALE for a copy of the license.
  */
-#ifndef TIMESCALEDB_FROZEN_CHUNK_DML_H
-#define TIMESCALEDB_FROZEN_CHUNK_DML_H
+#pragma once
 
 #include <postgres.h>
 #include <nodes/execnodes.h>
@@ -26,4 +25,3 @@ typedef struct FrozenChunkDmlState
 Path *frozen_chunk_dml_generate_path(Path *subpath, Chunk *chunk);
 
 #define FROZEN_CHUNK_DML_STATE_NAME "FrozenChunkDmlState"
-#endif

--- a/tsl/src/nodes/gapfill/gapfill.h
+++ b/tsl/src/nodes/gapfill/gapfill.h
@@ -3,9 +3,7 @@
  * Please see the included NOTICE for copyright information and
  * LICENSE-TIMESCALE for a copy of the license.
  */
-
-#ifndef TIMESCALEDB_TSL_NODES_GAPFILL_H
-#define TIMESCALEDB_TSL_NODES_GAPFILL_H
+#pragma once
 
 #include <postgres.h>
 #include <nodes/pathnodes.h>
@@ -25,5 +23,3 @@ typedef struct GapFillPath
 	CustomPath cpath;
 	FuncExpr *func; /* time_bucket_gapfill function call */
 } GapFillPath;
-
-#endif /* TIMESCALEDB_TSL_NODES_GAPFILL_H */

--- a/tsl/src/nodes/gapfill/gapfill_functions.h
+++ b/tsl/src/nodes/gapfill/gapfill_functions.h
@@ -3,14 +3,12 @@
  * Please see the included NOTICE for copyright information and
  * LICENSE-TIMESCALE for a copy of the license.
  */
+#pragma once
 
 /*
  * Functions used by gapfill which are exported to SQL.
  * Shell functions for these are defined in src/gapfill.c
  */
-
-#ifndef TIMESCALEDB_TSL_NODES_GAPFILL_FUNCTIONS_H
-#define TIMESCALEDB_TSL_NODES_GAPFILL_FUNCTIONS_H
 
 #include <postgres.h>
 #include <fmgr.h>
@@ -23,5 +21,3 @@ extern Datum gapfill_timestamp_time_bucket(PG_FUNCTION_ARGS);
 extern Datum gapfill_timestamptz_time_bucket(PG_FUNCTION_ARGS);
 extern Datum gapfill_timestamptz_timezone_time_bucket(PG_FUNCTION_ARGS);
 extern Datum gapfill_date_time_bucket(PG_FUNCTION_ARGS);
-
-#endif /* TIMESCALEDB_TSL_NODES_GAPFILL_FUNCTIONS_H */

--- a/tsl/src/nodes/gapfill/gapfill_internal.h
+++ b/tsl/src/nodes/gapfill/gapfill_internal.h
@@ -3,8 +3,7 @@
  * Please see the included NOTICE for copyright information and
  * LICENSE-TIMESCALE for a copy of the license.
  */
-#ifndef TIMESCALEDB_TSL_NODES_GAPFILL_INTERNAL_H
-#define TIMESCALEDB_TSL_NODES_GAPFILL_INTERNAL_H
+#pragma once
 
 #include <postgres.h>
 #include <nodes/execnodes.h>
@@ -126,5 +125,3 @@ Node *gapfill_state_create(CustomScan *);
 Expr *gapfill_adjust_varnos(GapFillState *state, Expr *expr);
 Datum gapfill_exec_expr(GapFillState *state, Expr *expr, bool *isnull);
 int64 gapfill_datum_get_internal(Datum, Oid);
-
-#endif /* TIMESCALEDB_TSL_NODES_GAPFILL_INTERNAL_H */

--- a/tsl/src/nodes/gapfill/interpolate.h
+++ b/tsl/src/nodes/gapfill/interpolate.h
@@ -3,8 +3,7 @@
  * Please see the included NOTICE for copyright information and
  * LICENSE-TIMESCALE for a copy of the license.
  */
-#ifndef TIMESCALEDB_TSL_NODES_GAPFILL_INTERPOLATE_H
-#define TIMESCALEDB_TSL_NODES_GAPFILL_INTERPOLATE_H
+#pragma once
 
 #include "gapfill_internal.h"
 
@@ -30,5 +29,3 @@ void gapfill_interpolate_tuple_fetched(GapFillInterpolateColumnState *, int64, D
 void gapfill_interpolate_tuple_returned(GapFillInterpolateColumnState *, int64, Datum, bool);
 void gapfill_interpolate_calculate(GapFillInterpolateColumnState *, GapFillState *, int64, Datum *,
 								   bool *);
-
-#endif /* TIMESCALEDB_TSL_NODES_GAPFILL_INTERPOLATE_H */

--- a/tsl/src/nodes/gapfill/locf.h
+++ b/tsl/src/nodes/gapfill/locf.h
@@ -3,9 +3,7 @@
  * Please see the included NOTICE for copyright information and
  * LICENSE-TIMESCALE for a copy of the license.
  */
-
-#ifndef TIMESCALEDB_TSL_NODES_GAPFILL_LOCF_H
-#define TIMESCALEDB_TSL_NODES_GAPFILL_LOCF_H
+#pragma once
 
 #include <postgres.h>
 
@@ -24,5 +22,3 @@ void gapfill_locf_initialize(GapFillLocfColumnState *, GapFillState *, FuncExpr 
 void gapfill_locf_group_change(GapFillLocfColumnState *);
 void gapfill_locf_tuple_returned(GapFillLocfColumnState *, Datum, bool);
 void gapfill_locf_calculate(GapFillLocfColumnState *, GapFillState *, int64, Datum *, bool *);
-
-#endif /* TIMESCALEDB_TSL_NODES_GAPFILL_LOCF_H */

--- a/tsl/src/nodes/skip_scan/skip_scan.h
+++ b/tsl/src/nodes/skip_scan/skip_scan.h
@@ -3,8 +3,7 @@
  * Please see the included NOTICE for copyright information and
  * LICENSE-TIMESCALE for a copy of the license.
  */
-#ifndef TIMESCALEDB_TSL_NODES_SKIP_SCAN_H
-#define TIMESCALEDB_TSL_NODES_SKIP_SCAN_H
+#pragma once
 
 #include <postgres.h>
 #include <nodes/plannodes.h>
@@ -13,5 +12,3 @@ extern void tsl_skip_scan_paths_add(PlannerInfo *root, RelOptInfo *input_rel,
 									RelOptInfo *output_rel);
 extern Node *tsl_skip_scan_state_create(CustomScan *cscan);
 extern void _skip_scan_init(void);
-
-#endif /* TIMESCALEDB_TSL_NODES_SKIP_SCAN_H */

--- a/tsl/src/partialize_agg.h
+++ b/tsl/src/partialize_agg.h
@@ -3,7 +3,6 @@
  * Please see the included NOTICE for copyright information and
  * LICENSE-TIMESCALE for a copy of the license.
  */
-
 #pragma once
 
 extern bool apply_vectorized_agg_optimization(PlannerInfo *root, AggPath *aggregation_path,

--- a/tsl/src/partialize_finalize.h
+++ b/tsl/src/partialize_finalize.h
@@ -3,9 +3,7 @@
  * Please see the included NOTICE for copyright information and
  * LICENSE-TIMESCALE for a copy of the license.
  */
-
-#ifndef TIMESCALEDB_TSL_PARTIALIZE_FINALIZE_H
-#define TIMESCALEDB_TSL_PARTIALIZE_FINALIZE_H
+#pragma once
 
 #include <postgres.h>
 #include <fmgr.h>
@@ -17,5 +15,3 @@
 extern Datum tsl_finalize_agg_sfunc(PG_FUNCTION_ARGS);
 extern Datum tsl_finalize_agg_ffunc(PG_FUNCTION_ARGS);
 extern Datum tsl_partialize_agg(PG_FUNCTION_ARGS);
-
-#endif

--- a/tsl/src/planner.h
+++ b/tsl/src/planner.h
@@ -3,8 +3,7 @@
  * Please see the included NOTICE for copyright information and
  * LICENSE-TIMESCALE for a copy of the license.
  */
-#ifndef TIMESCALEDB_TSL_PLANNER_H
-#define TIMESCALEDB_TSL_PLANNER_H
+#pragma once
 
 #include <postgres.h>
 #include <optimizer/planner.h>
@@ -19,5 +18,3 @@ void tsl_set_rel_pathlist_dml(PlannerInfo *, RelOptInfo *, Index, RangeTblEntry 
 void tsl_set_rel_pathlist(PlannerInfo *root, RelOptInfo *rel, Index rti, RangeTblEntry *rte);
 Path *tsl_create_distributed_insert_path(PlannerInfo *root, ModifyTablePath *mtpath,
 										 Index hypertable_rti, int subplan_index);
-
-#endif /* TIMESCALEDB_TSL_PLANNER_H */

--- a/tsl/src/process_utility.h
+++ b/tsl/src/process_utility.h
@@ -3,8 +3,7 @@
  * Please see the included NOTICE for copyright information and
  * LICENSE-TIMESCALE for a copy of the license.
  */
-#ifndef TIMESCALEDB_TSL_PROCESS_UTILITY_H
-#define TIMESCALEDB_TSL_PROCESS_UTILITY_H
+#pragma once
 
 #include <process_utility.h>
 
@@ -16,5 +15,3 @@ extern void tsl_ddl_command_end(EventTriggerData *command);
 extern void tsl_sql_drop(List *dropped_objects);
 extern void tsl_process_altertable_cmd(Hypertable *ht, const AlterTableCmd *cmd);
 extern void tsl_process_rename_cmd(Oid relid, Cache *hcache, const RenameStmt *stmt);
-
-#endif /* TIMESCALEDB_TSL_PROCESS_UTILITY_H */

--- a/tsl/src/remote/async.h
+++ b/tsl/src/remote/async.h
@@ -3,8 +3,7 @@
  * Please see the included NOTICE for copyright information and
  * LICENSE-TIMESCALE for a copy of the license.
  */
-#ifndef TIMESCALEDB_TSL_REMOTE_ASYNC_H
-#define TIMESCALEDB_TSL_REMOTE_ASYNC_H
+#pragma once
 
 #include <postgres.h>
 #include <libpq-fe.h>
@@ -149,5 +148,3 @@ extern void async_request_discard_response(AsyncRequest *req);
 
 /* Prepared Statements */
 extern void prepared_stmt_close(PreparedStmt *stmt);
-
-#endif /* TIMESCALEDB_TSL_REMOTE_ASYNC_H */

--- a/tsl/src/remote/connection.h
+++ b/tsl/src/remote/connection.h
@@ -3,8 +3,7 @@
  * Please see the included NOTICE for copyright information and
  * LICENSE-TIMESCALE for a copy of the license.
  */
-#ifndef TIMESCALEDB_TSL_REMOTE_CONNECTION_H
-#define TIMESCALEDB_TSL_REMOTE_CONNECTION_H
+#pragma once
 
 #include <postgres.h>
 #include <foreign/foreign.h>
@@ -208,5 +207,3 @@ extern void remote_connection_get_result_error(const PGresult *res, TSConnection
 
 extern void _remote_connection_init(void);
 extern void _remote_connection_fini(void);
-
-#endif /* TIMESCALEDB_TSL_REMOTE_CONNECTION_H */

--- a/tsl/src/remote/connection_cache.h
+++ b/tsl/src/remote/connection_cache.h
@@ -3,8 +3,7 @@
  * Please see the included NOTICE for copyright information and
  * LICENSE-TIMESCALE for a copy of the license.
  */
-#ifndef TIMESCALEDB_TSL_REMOTE_CONNECTION_CACHE_H
-#define TIMESCALEDB_TSL_REMOTE_CONNECTION_CACHE_H
+#pragma once
 
 #include <postgres.h>
 
@@ -29,5 +28,3 @@ extern void remote_connection_cache_dropped_role_callback(const char *rolename);
 extern Datum remote_connection_cache_show(PG_FUNCTION_ARGS);
 extern void _remote_connection_cache_init(void);
 extern void _remote_connection_cache_fini(void);
-
-#endif /* TIMESCALEDB_TSL_REMOTE_CONNECTION_CACHE_H */

--- a/tsl/src/remote/copy_fetcher.h
+++ b/tsl/src/remote/copy_fetcher.h
@@ -3,8 +3,7 @@
  * Please see the included NOTICE for copyright information and
  * LICENSE-TIMESCALE for a copy of the license.
  */
-#ifndef TIMESCALEDB_TSL_COPY_FETCHER_H
-#define TIMESCALEDB_TSL_COPY_FETCHER_H
+#pragma once
 
 #include <postgres.h>
 
@@ -12,5 +11,3 @@
 
 extern DataFetcher *copy_fetcher_create_for_scan(TSConnection *conn, const char *stmt,
 												 StmtParams *params, TupleFactory *tf);
-
-#endif /* TIMESCALEDB_TSL_COPY_FETCHER_H */

--- a/tsl/src/remote/cursor_fetcher.h
+++ b/tsl/src/remote/cursor_fetcher.h
@@ -3,8 +3,7 @@
  * Please see the included NOTICE for copyright information and
  * LICENSE-TIMESCALE for a copy of the license.
  */
-#ifndef TIMESCALEDB_TSL_CURSOR_FETCHER_H
-#define TIMESCALEDB_TSL_CURSOR_FETCHER_H
+#pragma once
 
 #include <postgres.h>
 
@@ -12,5 +11,3 @@
 
 extern DataFetcher *cursor_fetcher_create_for_scan(TSConnection *conn, const char *stmt,
 												   StmtParams *params, TupleFactory *tf);
-
-#endif /* TIMESCALEDB_TSL_CURSOR_FETCHER_H */

--- a/tsl/src/remote/data_fetcher.h
+++ b/tsl/src/remote/data_fetcher.h
@@ -3,8 +3,7 @@
  * Please see the included NOTICE for copyright information and
  * LICENSE-TIMESCALE for a copy of the license.
  */
-#ifndef TIMESCALEDB_TSL_REMOTE_DATA_FETCHER_H
-#define TIMESCALEDB_TSL_REMOTE_DATA_FETCHER_H
+#pragma once
 
 #include <postgres.h>
 #include <access/tupdesc.h>
@@ -100,5 +99,3 @@ assert_df_type(DataFetcherType type, DataFetcher *df)
 #else
 #define cast_fetcher(type, dfptr) ((type *) dfptr)
 #endif /* USE_ASSERT_CHECKING */
-
-#endif /* TIMESCALEDB_TSL_REMOTE_DATA_FETCHER_H */

--- a/tsl/src/remote/data_format.h
+++ b/tsl/src/remote/data_format.h
@@ -3,8 +3,7 @@
  * Please see the included NOTICE for copyright information and
  * LICENSE-TIMESCALE for a copy of the license.
  */
-#ifndef TIMESCALEDB_TSL_REMOTE_DATA_FORMAT_H
-#define TIMESCALEDB_TSL_REMOTE_DATA_FORMAT_H
+#pragma once
 
 #include <postgres.h>
 #include <fmgr.h>
@@ -28,5 +27,3 @@ extern AttConvInMetadata *data_format_create_att_conv_in_metadata(TupleDesc tupd
 extern Oid data_format_get_type_output_func(Oid type, bool *is_binary, bool force_text);
 extern Oid data_format_get_type_input_func(Oid type, bool *is_binary, bool force_text,
 										   Oid *type_io_param);
-
-#endif

--- a/tsl/src/remote/dist_commands.h
+++ b/tsl/src/remote/dist_commands.h
@@ -3,8 +3,7 @@
  * Please see the included NOTICE for copyright information and
  * LICENSE-TIMESCALE for a copy of the license.
  */
-#ifndef TIMESCALEDB_TSL_REMOTE_DIST_COMMANDS_H
-#define TIMESCALEDB_TSL_REMOTE_DIST_COMMANDS_H
+#pragma once
 
 #include "ts_catalog/catalog.h"
 
@@ -62,5 +61,3 @@ extern DistCmdResult *ts_dist_cmd_invoke_prepared_command(PreparedDistCmd *comma
 extern void ts_dist_cmd_close_prepared_command(PreparedDistCmd *command);
 
 extern Datum ts_dist_cmd_exec(PG_FUNCTION_ARGS);
-
-#endif

--- a/tsl/src/remote/dist_copy.h
+++ b/tsl/src/remote/dist_copy.h
@@ -3,8 +3,7 @@
  * Please see the included NOTICE for copyright information and
  * LICENSE-TIMESCALE for a copy of the license.
  */
-#ifndef TIMESCALEDB_TSL_REMOTE_DIST_COPY_H
-#define TIMESCALEDB_TSL_REMOTE_DIST_COPY_H
+#pragma once
 
 #include <postgres.h>
 #include <commands/copy.h>
@@ -22,5 +21,3 @@ extern void remote_copy_end_on_success(RemoteCopyContext *context);
 extern void remote_copy_send_slot(RemoteCopyContext *context, TupleTableSlot *slot,
 								  const ChunkInsertState *cis);
 extern const char *remote_copy_get_copycmd(RemoteCopyContext *context);
-
-#endif /* TIMESCALEDB_TSL_REMOTE_DIST_COPY_H */

--- a/tsl/src/remote/dist_ddl.h
+++ b/tsl/src/remote/dist_ddl.h
@@ -3,8 +3,7 @@
  * Please see the included NOTICE for copyright information and
  * LICENSE-TIMESCALE for a copy of the license.
  */
-#ifndef TIMESCALEDB_TSL_REMOTE_DIST_DDL_H
-#define TIMESCALEDB_TSL_REMOTE_DIST_DDL_H
+#pragma once
 
 #include <process_utility.h>
 
@@ -13,5 +12,3 @@ extern void dist_ddl_state_reset(void);
 extern void dist_ddl_start(ProcessUtilityArgs *args);
 extern void dist_ddl_end(EventTriggerData *command);
 extern void dist_ddl_drop(List *dropped_objects);
-
-#endif /* TIMESCALEDB_TSL_REMOTE_DIST_DDL_H */

--- a/tsl/src/remote/dist_txn.h
+++ b/tsl/src/remote/dist_txn.h
@@ -3,8 +3,7 @@
  * Please see the included NOTICE for copyright information and
  * LICENSE-TIMESCALE for a copy of the license.
  */
-#ifndef TIMESCALEDB_TSL_REMOTE_DIST_TXN_H
-#define TIMESCALEDB_TSL_REMOTE_DIST_TXN_H
+#pragma once
 
 #include <postgres.h>
 #include <foreign/foreign.h>
@@ -49,5 +48,3 @@ extern const char *remote_dist_txn_event_name(const DistTransactionEvent event);
 
 void _remote_dist_txn_init(void);
 void _remote_dist_txn_fini(void);
-
-#endif /* TIMESCALEDB_TSL_REMOTE_DIST_TXN_H */

--- a/tsl/src/remote/healthcheck.h
+++ b/tsl/src/remote/healthcheck.h
@@ -3,11 +3,9 @@
  * Please see the included NOTICE for copyright information and
  * LICENSE-TIMESCALE for a copy of the license.
  */
-#ifndef TIMESCALEDB_TSL_REMOTE_HEALTHCHECK_H
+#pragma once
 
 #include <postgres.h>
 #include <fmgr.h>
 
 extern Datum ts_dist_health_check(PG_FUNCTION_ARGS);
-
-#endif /* TIMESCALEDB_TSL_REMOTE_HEALTHCHECK_H */

--- a/tsl/src/remote/prepared_statement_fetcher.h
+++ b/tsl/src/remote/prepared_statement_fetcher.h
@@ -3,8 +3,7 @@
  * Please see the included NOTICE for copyright information and
  * LICENSE-TIMESCALE for a copy of the license.
  */
-#ifndef TIMESCALEDB_TSL_PREPARED_STATEMENT_FETCHER_H
-#define TIMESCALEDB_TSL_PREPARED_STATEMENT_FETCHER_H
+#pragma once
 
 #include <postgres.h>
 
@@ -13,5 +12,3 @@
 extern DataFetcher *prepared_statement_fetcher_create_for_scan(TSConnection *conn, const char *stmt,
 															   StmtParams *params,
 															   TupleFactory *tf);
-
-#endif /* TIMESCALEDB_TSL_PREPARED_STATEMENT_FETCHER_H */

--- a/tsl/src/remote/stmt_params.h
+++ b/tsl/src/remote/stmt_params.h
@@ -3,8 +3,7 @@
  * Please see the included NOTICE for copyright information and
  * LICENSE-TIMESCALE for a copy of the license.
  */
-#ifndef TIMESCALEDB_TSL_REMOTE_STMT_PARAMS_H
-#define TIMESCALEDB_TSL_REMOTE_STMT_PARAMS_H
+#pragma once
 
 #include <postgres.h>
 #include <fmgr.h>
@@ -29,5 +28,3 @@ extern void stmt_params_reset(StmtParams *params);
 extern void stmt_params_free(StmtParams *params);
 extern int stmt_params_total_values(StmtParams *stmt_params);
 extern int stmt_params_converted_tuples(StmtParams *stmt_params);
-
-#endif

--- a/tsl/src/remote/tuplefactory.h
+++ b/tsl/src/remote/tuplefactory.h
@@ -3,8 +3,7 @@
  * Please see the included NOTICE for copyright information and
  * LICENSE-TIMESCALE for a copy of the license.
  */
-#ifndef TIMESCALEDB_TSL_REMOTE_TUPLEFACTORY_H
-#define TIMESCALEDB_TSL_REMOTE_TUPLEFACTORY_H
+#pragma once
 
 #include <postgres.h>
 #include <funcapi.h>
@@ -32,5 +31,3 @@ extern struct AttConvInMetadata *tuplefactory_get_attconv(TupleFactory *tf);
 extern TupleDesc tuplefactory_get_tupdesc(TupleFactory *tf);
 extern List *tuplefactory_get_retrieved_attrs(TupleFactory *tf);
 extern int tuplefactory_get_nattrs(TupleFactory *tf);
-
-#endif /* TIMESCALEDB_TSL_REMOTE_TUPLEFACTORY_H */

--- a/tsl/src/remote/txn.h
+++ b/tsl/src/remote/txn.h
@@ -3,8 +3,7 @@
  * Please see the included NOTICE for copyright information and
  * LICENSE-TIMESCALE for a copy of the license.
  */
-#ifndef TIMESCALEDB_TSL_REMOTE_TXN_H
-#define TIMESCALEDB_TSL_REMOTE_TXN_H
+#pragma once
 
 #include <postgres.h>
 #include <access/xact.h>
@@ -57,5 +56,3 @@ extern int remote_txn_persistent_record_delete_for_data_node(Oid foreign_server_
 /* Debugging functions used in testing */
 extern void remote_txn_check_for_leaked_prepared_statements(RemoteTxn *entry);
 #endif
-
-#endif /* TIMESCALEDB_TSL_REMOTE_TXN_H */

--- a/tsl/src/remote/txn_id.h
+++ b/tsl/src/remote/txn_id.h
@@ -3,8 +3,7 @@
  * Please see the included NOTICE for copyright information and
  * LICENSE-TIMESCALE for a copy of the license.
  */
-#ifndef TIMESCALEDB_TSL_REMOTE_TXN_ID_H
-#define TIMESCALEDB_TSL_REMOTE_TXN_ID_H
+#pragma once
 
 #include <postgres.h>
 #include <utils/fmgrprotos.h>
@@ -58,5 +57,3 @@ extern Datum remote_txn_id_out_pg(PG_FUNCTION_ARGS);
 extern const char *remote_txn_id_prepare_transaction_sql(RemoteTxnId *);
 extern const char *remote_txn_id_commit_prepared_sql(RemoteTxnId *);
 extern const char *remote_txn_id_rollback_prepared_sql(RemoteTxnId *);
-
-#endif /* TIMESCALEDB_TSL_REMOTE_TXN_ID_H */

--- a/tsl/src/remote/txn_resolve.h
+++ b/tsl/src/remote/txn_resolve.h
@@ -3,8 +3,8 @@
  * Please see the included NOTICE for copyright information and
  * LICENSE-TIMESCALE for a copy of the license.
  */
-#ifndef TIMESCALEDB_TSL_REMOTE_TXN_RESOLVE_H
-#define TIMESCALEDB_TSL_REMOTE_TXN_RESOLVE_H
+#pragma once
+
 #include <postgres.h>
 
 #include "txn_id.h"
@@ -83,5 +83,3 @@ typedef enum RemoteTxnResolution
 extern RemoteTxnResolution remote_txn_resolution(Oid foreign_server,
 												 const RemoteTxnId *transaction_id);
 extern Datum remote_txn_heal_data_node(PG_FUNCTION_ARGS);
-
-#endif /* TIMESCALEDB_TSL_REMOTE_TXN_RESOLVE_H */

--- a/tsl/src/remote/txn_store.h
+++ b/tsl/src/remote/txn_store.h
@@ -3,8 +3,7 @@
  * Please see the included NOTICE for copyright information and
  * LICENSE-TIMESCALE for a copy of the license.
  */
-#ifndef TIMESCALEDB_TSL_REMOTE_TXN_STORE_H
-#define TIMESCALEDB_TSL_REMOTE_TXN_STORE_H
+#pragma once
 
 #include <postgres.h>
 #include <utils/hsearch.h>
@@ -33,5 +32,3 @@ extern void remote_txn_store_destroy(RemoteTxnStore *store);
 #define remote_txn_store_foreach(store, remote_txn)                                                \
 	for (hash_seq_init(&store->scan, store->hashtable);                                            \
 		 NULL != (remote_txn = (RemoteTxn *) hash_seq_search(&store->scan));)
-
-#endif /* TIMESCALEDB_TSL_REMOTE_TXN_STORE_H */

--- a/tsl/src/remote/utils.h
+++ b/tsl/src/remote/utils.h
@@ -3,13 +3,10 @@
  * Please see the included NOTICE for copyright information and
  * LICENSE-TIMESCALE for a copy of the license.
  */
-#ifndef TIMESCALEDB_TSL_REMOTE_UTILS_H
-#define TIMESCALEDB_TSL_REMOTE_UTILS_H
+#pragma once
 
 #include <postgres.h>
 #include <foreign/foreign.h>
 
 extern int set_transmission_modes(void);
 extern void reset_transmission_modes(int nestlevel);
-
-#endif /* TIMESCALEDB_TSL_REMOTE_UTILS_H */

--- a/tsl/src/reorder.h
+++ b/tsl/src/reorder.h
@@ -3,9 +3,7 @@
  * Please see the included NOTICE for copyright information and
  * LICENSE-TIMESCALE for a copy of the license.
  */
-
-#ifndef TIMESCALEDB_TSL_REORDER_H
-#define TIMESCALEDB_TSL_REORDER_H
+#pragma once
 
 #include <postgres.h>
 
@@ -17,5 +15,3 @@ extern Datum tsl_copy_chunk_cleanup_proc(PG_FUNCTION_ARGS);
 extern Datum tsl_subscription_exec(PG_FUNCTION_ARGS);
 extern void reorder_chunk(Oid chunk_id, Oid index_id, bool verbose, Oid wait_id,
 						  Oid destination_tablespace, Oid index_tablespace);
-
-#endif /* TIMESCALEDB_TSL_REORDER_H */

--- a/tsl/src/telemetry.h
+++ b/tsl/src/telemetry.h
@@ -3,8 +3,7 @@
  * Please see the included NOTICE for copyright information and
  * LICENSE-TIMESCALE for a copy of the license.
  */
-#ifndef TIMESCALEDB_TSL_TELEMETRY_H
-#define TIMESCALEDB_TSL_TELEMETRY_H
+#pragma once
 
 #include <postgres.h>
 #include <utils/jsonb.h>
@@ -12,5 +11,3 @@
 #include "telemetry/telemetry.h"
 
 void tsl_telemetry_add_info(JsonbParseState **parse_state);
-
-#endif /* TIMESCALEDB_TSL_TELEMETRY_H */

--- a/tsl/test/src/remote/connection.h
+++ b/tsl/test/src/remote/connection.h
@@ -3,8 +3,7 @@
  * Please see the included NOTICE for copyright information and
  * LICENSE-TIMESCALE for a copy of the license.
  */
-#ifndef TIMESCALEDB_TSL_TEST_REMOTE_CONNECTION_H
-#define TIMESCALEDB_TSL_TEST_REMOTE_CONNECTION_H
+#pragma once
 
 #include <postgres.h>
 #include <libpq-fe.h>
@@ -14,5 +13,3 @@
 extern TSConnection *get_connection(void);
 extern pid_t remote_connection_get_remote_pid(const TSConnection *conn);
 extern char *remote_connection_get_application_name(const TSConnection *conn);
-
-#endif /* TIMESCALEDB_TSL_TEST_REMOTE_CONNECTION_H */

--- a/tsl/test/src/remote/node_killer.h
+++ b/tsl/test/src/remote/node_killer.h
@@ -3,8 +3,7 @@
  * Please see the included NOTICE for copyright information and
  * LICENSE-TIMESCALE for a copy of the license.
  */
-#ifndef TIMESCALEDB_TSL_REMOTE_NODE_KILLER_H
-#define TIMESCALEDB_TSL_REMOTE_NODE_KILLER_H
+#pragma once
 
 #include <postgres.h>
 #include <libpq-fe.h>
@@ -25,5 +24,3 @@ extern void remote_node_killer_init(RemoteNodeKiller *rnk, const TSConnection *c
 void remote_node_killer_kill(RemoteNodeKiller *rnk);
 
 extern void remote_node_killer_kill_on_event(const char *event);
-
-#endif /* TIMESCALEDB_TSL_REMOTE_NODE_KILLER_H */


### PR DESCRIPTION
We used a mixture of include guards and pragma once in our header files. This patch changes our headers to always use pragma once because it is less error prone, can be copy/pasted, doesnt require a unique identifier and is also shorter.

Disable-check: force-changelog-file

