### PR TITLE
Remove unused compression policy helper functions

### DIFF
--- a/tsl/src/bgw_policy/compression_api.c
+++ b/tsl/src/bgw_policy/compression_api.c
@@ -66,52 +66,6 @@ policy_compression_get_hypertable_id(const Jsonb *config)
 }
 
 int64
-policy_compression_get_compress_after_int(const Jsonb *config)
-{
-	bool found;
-	int64 compress_after =
-		ts_jsonb_get_int64_field(config, POL_COMPRESSION_CONF_KEY_COMPRESS_AFTER, &found);
-
-	if (!found)
-		ereport(ERROR,
-				(errcode(ERRCODE_INTERNAL_ERROR),
-				 errmsg("could not find %s in config for job",
-						POL_COMPRESSION_CONF_KEY_COMPRESS_AFTER)));
-
-	return compress_after;
-}
-
-Interval *
-policy_compression_get_compress_after_interval(const Jsonb *config)
-{
-	Interval *interval =
-		ts_jsonb_get_interval_field(config, POL_COMPRESSION_CONF_KEY_COMPRESS_AFTER);
-
-	if (interval == NULL)
-		ereport(ERROR,
-				(errcode(ERRCODE_INTERNAL_ERROR),
-				 errmsg("could not find %s in config for job",
-						POL_COMPRESSION_CONF_KEY_COMPRESS_AFTER)));
-
-	return interval;
-}
-
-Interval *
-policy_compression_get_compress_created_before_interval(const Jsonb *config)
-{
-	Interval *interval =
-		ts_jsonb_get_interval_field(config, POL_COMPRESSION_CONF_KEY_COMPRESS_CREATED_BEFORE);
-
-	if (interval == NULL)
-		ereport(ERROR,
-				(errcode(ERRCODE_INTERNAL_ERROR),
-				 errmsg("could not find %s in config for job",
-						POL_COMPRESSION_CONF_KEY_COMPRESS_CREATED_BEFORE)));
-
-	return interval;
-}
-
-int64
 policy_recompression_get_recompress_after_int(const Jsonb *config)
 {
 	bool found;

--- a/tsl/src/bgw_policy/compression_api.h
+++ b/tsl/src/bgw_policy/compression_api.h
@@ -19,9 +19,6 @@ extern Datum policy_recompression_proc(PG_FUNCTION_ARGS);
 extern Datum policy_compression_check(PG_FUNCTION_ARGS);
 
 int32 policy_compression_get_hypertable_id(const Jsonb *config);
-int64 policy_compression_get_compress_after_int(const Jsonb *config);
-Interval *policy_compression_get_compress_after_interval(const Jsonb *config);
-Interval *policy_compression_get_compress_created_before_interval(const Jsonb *config);
 int32 policy_compression_get_maxchunks_per_job(const Jsonb *config);
 int64 policy_recompression_get_recompress_after_int(const Jsonb *config);
 Interval *policy_recompression_get_recompress_after_interval(const Jsonb *config);


### PR DESCRIPTION
This patch removes the following unused functions:

- policy_compression_get_compress_after_int(const Jsonb *config)
- policy_compression_get_compress_after_interval(const Jsonb *config)
- policy_compression_get_compress_created_before_interval(const Jsonb *config)

Disable-check: force-changelog-file