### PR TITLE
Add Coccinelle rule to use NameStr

### DIFF
--- a/coccinelle/namedata.cocci
+++ b/coccinelle/namedata.cocci
@@ -22,3 +22,26 @@ symbol NAMEDATALEN;
 - strlcpy(E1, E2, NAMEDATALEN);
 + /* You are using strlcpy with NAMEDATALEN, please consider using NameData and namestrcpy instead. */
 + namestrcpy(E1, E2);
+
+@@
+typedef NameData;
+NameData E;
+@@
+- E.data
++ /* Use NameStr rather than accessing data member directly */
++ NameStr(E)
+
+@@
+NameData *E;
+@@
+- E->data
++ /* Use NameStr rather than accessing data member directly */
++ NameStr(*E)
+
+@@
+typedef Name;
+Name E;
+@@
+- E->data
++ /* Use NameStr rather than accessing data member directly */
++ NameStr(*E)

--- a/tsl/src/deparse.c
+++ b/tsl/src/deparse.c
@@ -151,7 +151,7 @@ column_is_serial(Relation rel, Name column)
 											   NameStr(rel->rd_rel->relname));
 	InitFunctionCallInfoData(*fcinfo, NULL, 2, InvalidOid, NULL, NULL);
 	FC_ARG(fcinfo, 0) = CStringGetTextDatum(relation_name);
-	FC_ARG(fcinfo, 1) = CStringGetTextDatum(column->data);
+	FC_ARG(fcinfo, 1) = CStringGetTextDatum(NameStr(*column));
 	FC_NULL(fcinfo, 0) = false;
 	FC_NULL(fcinfo, 1) = false;
 	pg_get_serial_sequence(fcinfo);


### PR DESCRIPTION
Direct access of the `.data` member of `NameData` structures are discuraged and `NameStr` should be used instead.

Also adding one instance that was missed in #5336.

Disable-check: force-changelog-file