### PR TITLE
Read watermark from materialized data

### DIFF
--- a/tsl/src/continuous_aggs/materialize.c
+++ b/tsl/src/continuous_aggs/materialize.c
@@ -290,7 +290,7 @@ spi_insert_materializations(Hypertable *mat_ht, SchemaAndName partial_view,
 {
 	int res;
 	StringInfo command = makeStringInfo();
-	Oid out_fn, timetype;
+	Oid out_fn;
 	bool type_is_varlena;
 	char *materialization_start;
 	char *materialization_end;
@@ -332,24 +332,17 @@ spi_insert_materializations(Hypertable *mat_ht, SchemaAndName partial_view,
 		int64 watermark;
 		bool isnull;
 		Datum maxdat;
-		const Dimension *dim = hyperspace_get_open_dimension(mat_ht->space, 0);
-
-		if (NULL == dim)
-			elog(ERROR, "invalid open dimension index 0");
-
-		timetype = ts_dimension_get_partition_type(dim);
 
 		resetStringInfo(command);
 		appendStringInfo(command,
-						 "SELECT pg_catalog.max(%s) FROM %s.%s AS I "
-						 "WHERE I.%s >= %s AND I.%s < %s %s;",
+						 "SELECT %s FROM %s.%s AS I "
+						 "WHERE I.%s >= %s %s "
+						 "ORDER BY 1 DESC LIMIT 1;",
 						 quote_identifier(NameStr(*time_column_name)),
-						 quote_identifier(NameStr(*partial_view.schema)),
-						 quote_identifier(NameStr(*partial_view.name)),
+						 quote_identifier(NameStr(*materialization_table.schema)),
+						 quote_identifier(NameStr(*materialization_table.name)),
 						 quote_identifier(NameStr(*time_column_name)),
 						 quote_literal_cstr(materialization_start),
-						 quote_identifier(NameStr(*time_column_name)),
-						 quote_literal_cstr(materialization_end),
 						 chunk_condition);
 
 		res = SPI_execute(command->data, false /* read_only */, 0 /*count*/);
@@ -357,15 +350,15 @@ spi_insert_materializations(Hypertable *mat_ht, SchemaAndName partial_view,
 		if (res < 0)
 			elog(ERROR, "could not get the last bucket of the materialized data");
 
-		Ensure(SPI_gettypeid(SPI_tuptable->tupdesc, 1) == timetype,
+		Ensure(SPI_gettypeid(SPI_tuptable->tupdesc, 1) == materialization_range.type,
 			   "partition types for result (%d) and dimension (%d) do not match",
 			   SPI_gettypeid(SPI_tuptable->tupdesc, 1),
-			   ts_dimension_get_partition_type(dim));
+			   materialization_range.type);
 		maxdat = SPI_getbinval(SPI_tuptable->vals[0], SPI_tuptable->tupdesc, 1, &isnull);
 
 		if (!isnull)
 		{
-			watermark = ts_time_value_to_internal(maxdat, timetype);
+			watermark = ts_time_value_to_internal(maxdat, materialization_range.type);
 			ts_cagg_watermark_update(mat_ht, watermark, isnull, false);
 		}
 	}

--- a/tsl/test/expected/cagg_refresh.out
+++ b/tsl/test/expected/cagg_refresh.out
@@ -127,7 +127,7 @@ DEBUG:  hypertable 1 existing watermark >= new invalidation threshold 1588723200
 DEBUG:  invalidation refresh on "daily_temp" in window [ Thu Apr 30 17:00:00 2020 PDT, Sat May 02 17:00:00 2020 PDT ]
 LOG:  deleted 0 row(s) from materialization table "_timescaledb_internal._materialized_hypertable_2"
 LOG:  inserted 8 row(s) into materialization table "_timescaledb_internal._materialized_hypertable_2"
-DEBUG:  hypertable 2 existing watermark >= new watermark 1588723200000000 1588464000000000
+DEBUG:  hypertable 2 existing watermark >= new watermark 1588723200000000 1588723200000000
 RESET client_min_messages;
 LOG:  statement: RESET client_min_messages;
 -- Compare the aggregate to the equivalent query on the source table


### PR DESCRIPTION
In 38fcd1b we improved the cagg_watermark performance by storing it into a metadata table and update it during the refresh.
    
But we made a minor mistake here reading the watermark from the partial view instead of the already materialized data that should be much fast because we're reading already aggregated data.
    
Fixed this mistake by reading the watermark from the underlying materialization hypertable (already aggregated data).

Disable-check: force-changelog-file
