### PR TITLE
Speed up bgw scheduler tests

### DIFF
--- a/tsl/test/expected/bgw_db_scheduler_fixed.out
+++ b/tsl/test/expected/bgw_db_scheduler_fixed.out
@@ -1790,7 +1790,7 @@ ORDER BY job_id;
 -- test ability to switch from one type of schedule to another
 CREATE OR REPLACE PROCEDURE job_test(jobid int, config jsonb) language plpgsql as $$
 BEGIN
-PERFORM pg_sleep(10);
+PERFORM pg_sleep(0.5);
 END
 $$;
 SELECT add_job('job_test', '8 min', fixed_schedule => false) AS jobid_drifting_1 \gset

--- a/tsl/test/expected/job_errors_permissions.out
+++ b/tsl/test/expected/job_errors_permissions.out
@@ -25,7 +25,7 @@ CREATE OR REPLACE PROCEDURE custom_proc1(jobid int, config jsonb) LANGUAGE PLPGS
 $$
 BEGIN
   UPDATE my_table SET b = 1 WHERE a = 0;
-  PERFORM pg_sleep(10);
+  PERFORM pg_sleep(5);
   COMMIT;
 END
 $$;
@@ -35,7 +35,7 @@ CREATE OR REPLACE PROCEDURE custom_proc2(jobid int, config jsonb) LANGUAGE PLPGS
 $$
 BEGIN
   UPDATE my_table SET b = 2 WHERE a = 0;
-  PERFORM pg_sleep(10);
+  PERFORM pg_sleep(5);
   COMMIT;
 END
 $$;
@@ -48,7 +48,7 @@ SELECT _timescaledb_functions.start_background_workers();
  t
 (1 row)
 
-SELECT pg_sleep(20);
+SELECT pg_sleep(6);
  pg_sleep 
 ----------
  

--- a/tsl/test/expected/scheduler_fixed.out
+++ b/tsl/test/expected/scheduler_fixed.out
@@ -36,12 +36,12 @@ DELETE FROM _timescaledb_config.bgw_job;
 TRUNCATE _timescaledb_internal.bgw_job_stat;
 create or replace procedure job_20(jobid int, config jsonb) language plpgsql as $$
 begin
-perform pg_sleep(20);
+perform pg_sleep(5);
 end
 $$;
 create or replace procedure job_5(jobid int, config jsonb) language plpgsql as $$
 begin
-perform pg_sleep(5);
+perform pg_sleep(1);
 end
 $$;
 select * from _timescaledb_internal.bgw_job_stat;
@@ -95,7 +95,7 @@ select next_start as next_start_long from timescaledb_information.job_stats wher
 select :'next_start_long'::timestamptz - :'initial_start_long'::timestamptz as schedule_diff;
  schedule_diff 
 ---------------
- @ 30 secs
+ @ 15 secs
 (1 row)
 
 -- test some possible schedule_interval, finish_time, initial_start combinations

--- a/tsl/test/sql/bgw_db_scheduler_fixed.sql
+++ b/tsl/test/sql/bgw_db_scheduler_fixed.sql
@@ -763,7 +763,7 @@ ORDER BY job_id;
 -- test ability to switch from one type of schedule to another
 CREATE OR REPLACE PROCEDURE job_test(jobid int, config jsonb) language plpgsql as $$
 BEGIN
-PERFORM pg_sleep(10);
+PERFORM pg_sleep(0.5);
 END
 $$;
 

--- a/tsl/test/sql/job_errors_permissions.sql
+++ b/tsl/test/sql/job_errors_permissions.sql
@@ -26,7 +26,7 @@ CREATE OR REPLACE PROCEDURE custom_proc1(jobid int, config jsonb) LANGUAGE PLPGS
 $$
 BEGIN
   UPDATE my_table SET b = 1 WHERE a = 0;
-  PERFORM pg_sleep(10);
+  PERFORM pg_sleep(5);
   COMMIT;
 END
 $$;
@@ -39,7 +39,7 @@ CREATE OR REPLACE PROCEDURE custom_proc2(jobid int, config jsonb) LANGUAGE PLPGS
 $$
 BEGIN
   UPDATE my_table SET b = 2 WHERE a = 0;
-  PERFORM pg_sleep(10);
+  PERFORM pg_sleep(5);
   COMMIT;
 END
 $$;
@@ -49,7 +49,7 @@ select add_job('custom_proc2', '2 min', initial_start => now() + interval '5 sec
 
 SET ROLE :ROLE_SUPERUSER;
 SELECT _timescaledb_functions.start_background_workers();
-SELECT pg_sleep(20);
+SELECT pg_sleep(6);
 
 \d timescaledb_information.job_errors
 

--- a/tsl/test/sql/scheduler_fixed.sql
+++ b/tsl/test/sql/scheduler_fixed.sql
@@ -42,13 +42,13 @@ TRUNCATE _timescaledb_internal.bgw_job_stat;
 
 create or replace procedure job_20(jobid int, config jsonb) language plpgsql as $$
 begin
-perform pg_sleep(20);
+perform pg_sleep(5);
 end
 $$;
 
 create or replace procedure job_5(jobid int, config jsonb) language plpgsql as $$
 begin
-perform pg_sleep(5);
+perform pg_sleep(1);
 end
 $$;
 


### PR DESCRIPTION
Speed up bgw tests by reducing the amount of time we wait in pg_sleep.

Disable-check: force-changelog-file
