### PR TITLE
Fix OpenSSL issues by using latest MacOSx

### DIFF
--- a/.github/gh_matrix_builder.py
+++ b/.github/gh_matrix_builder.py
@@ -146,7 +146,7 @@ def macos_config(overrides):
                 "remote_connection",
                 "compressed_collation",
             },
-            "os": "macos-11",
+            "os": "macos-13",
             "pg_extra_args": "--with-libraries=/usr/local/opt/openssl/lib --with-includes=/usr/local/opt/openssl/include --without-icu",
             "pginstallcheck": True,
             "tsdb_build_args": "-DASSERTIONS=ON -DREQUIRE_ALL_TESTS=ON -DOPENSSL_ROOT_DIR=/usr/local/opt/openssl",

--- a/.github/workflows/linux-build-and-test.yaml
+++ b/.github/workflows/linux-build-and-test.yaml
@@ -69,10 +69,7 @@ jobs:
     - name: Install macOS Dependencies
       if: runner.os == 'macOS'
       run: |
-        # This is needed because GitHub image macos-10.15 version
-        # 20210927.1 did not install OpenSSL so we install openssl
-        # explicitly.
-        brew install openssl gawk
+        brew install gawk
         sudo perl -MCPAN -e "CPAN::Shell->notest('install', 'IPC::Run')"
         sudo perl -MCPAN -e "CPAN::Shell->notest('install', 'Test::Most')"
 


### PR DESCRIPTION
The latest OpenSSL 3.2.0 version has known issues with Postgres. MacOSX
CI runs were failing because of this. We now use macos-13 visavis the
earlier macos-11. That seems to solve this OpenSSL issue.

Disable-check: force-changelog-file