### PR TITLE
Remove useless AggPartCxt data structure

### DIFF
--- a/tsl/src/continuous_aggs/common.h
+++ b/tsl/src/continuous_aggs/common.h
@@ -83,28 +83,6 @@ typedef struct CAggTimebucketInfo
 	Timestamp origin;
 } CAggTimebucketInfo;
 
-typedef struct AggPartCxt
-{
-	struct MatTableColumnInfo *mattblinfo;
-	bool added_aggref_col;
-	/*
-	 * Set to true when you come across a Var
-	 * that is not inside an Aggref node.
-	 */
-	bool var_outside_of_aggref;
-	Oid ignore_aggoid;
-	int original_query_resno;
-	/*
-	 * "Original variables" are the Var nodes of the target list of the original
-	 * CREATE MATERIALIZED VIEW query. "Mapped variables" are the Var nodes of the materialization
-	 * table columns. The partialization query is the one that populates those columns. The
-	 * finalization query should use the "mapped variables" to populate the user view.
-	 */
-	List *orig_vars; /* List of Var nodes that have been mapped to materialization table columns */
-	List *mapped_vars; /* List of Var nodes of the corresponding materialization table columns */
-					   /* orig_vars and mapped_vars lists are mapped 1 to 1 */
-} AggPartCxt;
-
 #define CAGG_MAKEQUERY(selquery, srcquery)                                                         \
 	do                                                                                             \
 	{                                                                                              \

--- a/tsl/src/continuous_aggs/finalize.c
+++ b/tsl/src/continuous_aggs/finalize.c
@@ -46,21 +46,12 @@ makeMaterializeColumnName(char *colbuf, const char *type, int original_query_res
 void
 finalizequery_init(FinalizeQueryInfo *inp, Query *orig_query, MatTableColumnInfo *mattblinfo)
 {
-	AggPartCxt cxt;
 	ListCell *lc;
 	int resno = 1;
 
 	inp->final_userquery = copyObject(orig_query);
 	inp->final_seltlist = NIL;
 	inp->final_havingqual = NULL;
-
-	/* Set up the final_seltlist and final_havingqual entries */
-	cxt.mattblinfo = mattblinfo;
-	cxt.ignore_aggoid = InvalidOid;
-
-	/* Set up the left over variable mapping lists */
-	cxt.orig_vars = NIL;
-	cxt.mapped_vars = NIL;
 
 	/*
 	 * We want all the entries in the targetlist (resjunk or not)
@@ -75,21 +66,18 @@ finalizequery_init(FinalizeQueryInfo *inp, Query *orig_query, MatTableColumnInfo
 	{
 		TargetEntry *tle = (TargetEntry *) lfirst(lc);
 		TargetEntry *modte = copyObject(tle);
-		cxt.added_aggref_col = false;
-		cxt.var_outside_of_aggref = false;
-		cxt.original_query_resno = resno;
 
 		/*
 		 * We need columns for non-aggregate targets.
 		 * If it is not a resjunk OR appears in the grouping clause.
 		 */
-		if (cxt.added_aggref_col == false && (tle->resjunk == false || tle->ressortgroupref > 0))
+		if (tle->resjunk == false || tle->ressortgroupref > 0)
 		{
 			Var *var;
 			bool skip_adding = false;
-			var = mattablecolumninfo_addentry(cxt.mattblinfo,
+			var = mattablecolumninfo_addentry(mattblinfo,
 											  (Node *) tle,
-											  cxt.original_query_resno,
+											  resno,
 											  inp->finalized,
 											  &skip_adding);
 


### PR DESCRIPTION
This data structure is a leftover of 78490c47 where we removed the support for creating Continuous Aggregate in the old format.

Disable-check: force-changelog-file
