### PR TITLE
Backport CI fixes to 2.13.x branch

### DIFF
--- a/.github/gh_matrix_builder.py
+++ b/.github/gh_matrix_builder.py
@@ -151,7 +151,7 @@ def macos_config(overrides):
                 "remote_connection",
                 "compressed_collation",
             },
-            "os": "macos-11",
+            "os": "macos-13",
             "pg_extra_args": "--with-libraries=/usr/local/opt/openssl/lib --with-includes=/usr/local/opt/openssl/include --without-icu",
             "pginstallcheck": True,
             "tsdb_build_args": "-DASSERTIONS=ON -DREQUIRE_ALL_TESTS=ON -DOPENSSL_ROOT_DIR=/usr/local/opt/openssl",

--- a/.github/workflows/linux-build-and-test.yaml
+++ b/.github/workflows/linux-build-and-test.yaml
@@ -69,10 +69,7 @@ jobs:
     - name: Install macOS Dependencies
       if: runner.os == 'macOS'
       run: |
-        # This is needed because GitHub image macos-10.15 version
-        # 20210927.1 did not install OpenSSL so we install openssl
-        # explicitly.
-        brew install openssl gawk
+        brew install gawk
         sudo perl -MCPAN -e "CPAN::Shell->notest('install', 'IPC::Run')"
         sudo perl -MCPAN -e "CPAN::Shell->notest('install', 'Test::Most')"
 

--- a/.github/workflows/linux-build-and-test.yaml
+++ b/.github/workflows/linux-build-and-test.yaml
@@ -282,4 +282,6 @@ jobs:
             GITHUB_PR_NUMBER=0
         fi
         export GITHUB_PR_NUMBER
+        PSQL="${HOME}/${PG_INSTALL_DIR}/bin/psql"
+        export PSQL
         scripts/upload_ci_stats.sh

--- a/scripts/upload_ci_stats.sh
+++ b/scripts/upload_ci_stats.sh
@@ -8,7 +8,8 @@ then
     exit 0
 fi
 
-PSQL=(psql "${CI_STATS_DB}" -qtAX "--set=ON_ERROR_STOP=1")
+PSQL=${PSQL:-psql}
+PSQL=("${PSQL}" "${CI_STATS_DB}" -qtAX "--set=ON_ERROR_STOP=1")
 
 # The tables we are going to use. This schema is here just as a reminder, you'll
 # have to create them manually. After you manually change the actual DB schema,

--- a/test/sql/updates/post.repair.cagg_joins.sql
+++ b/test/sql/updates/post.repair.cagg_joins.sql
@@ -2,7 +2,7 @@
 -- Please see the included NOTICE for copyright information and
 -- LICENSE-APACHE for a copy of the license.
 
-SELECT current_setting('server_version_num')::int >=  130000 AS has_cagg_join_using \gset
+SELECT current_setting('server_version_num')::int >=  140000 AS pg14ge \gset
 
 \d+ cagg_joins_upgrade_test_with_realtime
 SELECT * FROM cagg_joins_upgrade_test_with_realtime ORDER BY bucket;
@@ -13,12 +13,12 @@ SELECT * FROM cagg_joins_upgrade_test ORDER BY bucket;
 \d+ cagg_joins_where
 SELECT * FROM cagg_joins_where ORDER BY bucket;
 
-\if :has_cagg_join_using
+\if :pg14ge
     \d+ cagg_joins_upgrade_test_with_realtime_using
-    SELECT * FROM cagg_joins_upgrade_test_with_realtime_using ORDER BY bucket;
-
-    \d+ cagg_joins_upgrade_test_using
-    SELECT * FROM cagg_joins_upgrade_test_using ORDER BY bucket;
-
 \endif
+SELECT * FROM cagg_joins_upgrade_test_with_realtime_using ORDER BY bucket;
+
+\d+ cagg_joins_upgrade_test_using
+SELECT * FROM cagg_joins_upgrade_test_using ORDER BY bucket;
+
 


### PR DESCRIPTION
This is necessary in order to get the CI to function properly on the 2.13.x branch