### PR TITLE
Don't add unneded null test in sorted query plan for minmax

### DIFF
--- a/test/expected/agg_bookends.out
+++ b/test/expected/agg_bookends.out
@@ -73,8 +73,7 @@ SELECT setting, current_setting(setting) AS value from (VALUES ('timescaledb.ena
    InitPlan 1 (returns $0)
      ->  Limit (actual rows=1 loops=1)
            ->  Index Scan Backward using _hyper_1_1_chunk_btest_time_idx on _hyper_1_1_chunk (actual rows=1 loops=1)
-                 Index Cond: ("time" IS NOT NULL)
-(5 rows)
+(4 rows)
 
 :PREFIX SELECT last(temp, time_alt) FROM btest;
                          QUERY PLAN                         
@@ -398,16 +397,11 @@ INSERT INTO btest_numeric VALUES('2020-01-20T09:00:43', 30.5);
            ->  Custom Scan (ChunkAppend) on btest (actual rows=1 loops=1)
                  Order: btest."time"
                  ->  Index Scan Backward using _hyper_1_4_chunk_btest_time_idx on _hyper_1_4_chunk (actual rows=1 loops=1)
-                       Index Cond: ("time" IS NOT NULL)
                  ->  Index Scan Backward using _hyper_1_1_chunk_btest_time_idx on _hyper_1_1_chunk (never executed)
-                       Index Cond: ("time" IS NOT NULL)
                  ->  Index Scan Backward using _hyper_1_2_chunk_btest_time_idx on _hyper_1_2_chunk (never executed)
-                       Index Cond: ("time" IS NOT NULL)
                  ->  Index Scan Backward using _hyper_1_3_chunk_btest_time_idx on _hyper_1_3_chunk (never executed)
-                       Index Cond: ("time" IS NOT NULL)
                  ->  Index Scan Backward using _hyper_1_5_chunk_btest_time_idx on _hyper_1_5_chunk (never executed)
-                       Index Cond: ("time" IS NOT NULL)
-(15 rows)
+(10 rows)
 
 -- can't do index scan when ordering on non-index column
 :PREFIX SELECT first(temp, time_alt) FROM btest;
@@ -517,16 +511,11 @@ INSERT INTO btest_numeric VALUES('2020-01-20T09:00:43', 30.5);
            ->  Custom Scan (ChunkAppend) on btest btest_1 (actual rows=1 loops=1)
                  Order: btest_1."time"
                  ->  Index Scan Backward using _hyper_1_4_chunk_btest_time_idx on _hyper_1_4_chunk _hyper_1_4_chunk_1 (actual rows=1 loops=1)
-                       Index Cond: ("time" IS NOT NULL)
                  ->  Index Scan Backward using _hyper_1_1_chunk_btest_time_idx on _hyper_1_1_chunk _hyper_1_1_chunk_1 (never executed)
-                       Index Cond: ("time" IS NOT NULL)
                  ->  Index Scan Backward using _hyper_1_2_chunk_btest_time_idx on _hyper_1_2_chunk _hyper_1_2_chunk_1 (never executed)
-                       Index Cond: ("time" IS NOT NULL)
                  ->  Index Scan Backward using _hyper_1_3_chunk_btest_time_idx on _hyper_1_3_chunk _hyper_1_3_chunk_1 (never executed)
-                       Index Cond: ("time" IS NOT NULL)
                  ->  Index Scan Backward using _hyper_1_5_chunk_btest_time_idx on _hyper_1_5_chunk _hyper_1_5_chunk_1 (never executed)
-                       Index Cond: ("time" IS NOT NULL)
-(29 rows)
+(24 rows)
 
 -- verify results when using both FIRST and LAST
 :PREFIX SELECT first(temp, time), last(temp, time) FROM btest;
@@ -552,16 +541,11 @@ INSERT INTO btest_numeric VALUES('2020-01-20T09:00:43', 30.5);
            ->  Custom Scan (ChunkAppend) on btest btest_1 (actual rows=1 loops=1)
                  Order: btest_1."time"
                  ->  Index Scan Backward using _hyper_1_4_chunk_btest_time_idx on _hyper_1_4_chunk _hyper_1_4_chunk_1 (actual rows=1 loops=1)
-                       Index Cond: ("time" IS NOT NULL)
                  ->  Index Scan Backward using _hyper_1_1_chunk_btest_time_idx on _hyper_1_1_chunk _hyper_1_1_chunk_1 (never executed)
-                       Index Cond: ("time" IS NOT NULL)
                  ->  Index Scan Backward using _hyper_1_2_chunk_btest_time_idx on _hyper_1_2_chunk _hyper_1_2_chunk_1 (never executed)
-                       Index Cond: ("time" IS NOT NULL)
                  ->  Index Scan Backward using _hyper_1_3_chunk_btest_time_idx on _hyper_1_3_chunk _hyper_1_3_chunk_1 (never executed)
-                       Index Cond: ("time" IS NOT NULL)
                  ->  Index Scan Backward using _hyper_1_5_chunk_btest_time_idx on _hyper_1_5_chunk _hyper_1_5_chunk_1 (never executed)
-                       Index Cond: ("time" IS NOT NULL)
-(29 rows)
+(24 rows)
 
 -- do index scan when using WHERE
 :PREFIX SELECT last(temp, time) FROM btest WHERE time <= '2017-01-20T09:00:02';
@@ -661,21 +645,21 @@ INSERT INTO btest_numeric VALUES('2020-01-20T09:00:43', 30.5);
 -- SELECT first(temp, time) FROM btest WHERE time >= '2017-01-20 09:00:47';
 -- do index scan
 :PREFIX SELECT first(temp, time) FROM btest WHERE time >= '2017-01-20 09:00:47';
-                                                            QUERY PLAN                                                            
-----------------------------------------------------------------------------------------------------------------------------------
+                                                        QUERY PLAN                                                         
+---------------------------------------------------------------------------------------------------------------------------
  Result (actual rows=1 loops=1)
    InitPlan 1 (returns $0)
      ->  Limit (actual rows=1 loops=1)
            ->  Custom Scan (ChunkAppend) on btest (actual rows=1 loops=1)
                  Order: btest."time"
                  ->  Index Scan Backward using _hyper_1_1_chunk_btest_time_idx on _hyper_1_1_chunk (actual rows=1 loops=1)
-                       Index Cond: (("time" IS NOT NULL) AND ("time" >= 'Fri Jan 20 09:00:47 2017'::timestamp without time zone))
+                       Index Cond: ("time" >= 'Fri Jan 20 09:00:47 2017'::timestamp without time zone)
                  ->  Index Scan Backward using _hyper_1_2_chunk_btest_time_idx on _hyper_1_2_chunk (never executed)
-                       Index Cond: (("time" IS NOT NULL) AND ("time" >= 'Fri Jan 20 09:00:47 2017'::timestamp without time zone))
+                       Index Cond: ("time" >= 'Fri Jan 20 09:00:47 2017'::timestamp without time zone)
                  ->  Index Scan Backward using _hyper_1_3_chunk_btest_time_idx on _hyper_1_3_chunk (never executed)
-                       Index Cond: (("time" IS NOT NULL) AND ("time" >= 'Fri Jan 20 09:00:47 2017'::timestamp without time zone))
+                       Index Cond: ("time" >= 'Fri Jan 20 09:00:47 2017'::timestamp without time zone)
                  ->  Index Scan Backward using _hyper_1_5_chunk_btest_time_idx on _hyper_1_5_chunk (never executed)
-                       Index Cond: (("time" IS NOT NULL) AND ("time" >= 'Fri Jan 20 09:00:47 2017'::timestamp without time zone))
+                       Index Cond: ("time" >= 'Fri Jan 20 09:00:47 2017'::timestamp without time zone)
 (13 rows)
 
 -- can't do index scan when using WINDOW function
@@ -811,8 +795,7 @@ INSERT INTO btest_numeric VALUES('2018-01-20T09:00:43', NULL);
    InitPlan 1 (returns $0)
      ->  Limit (actual rows=1 loops=1)
            ->  Index Scan Backward using _hyper_2_8_chunk_btest_numeric_time_idx on _hyper_2_8_chunk (actual rows=1 loops=1)
-                 Index Cond: ("time" IS NOT NULL)
-(5 rows)
+(4 rows)
 
 :PREFIX SELECT last(quantity, time) FROM btest_numeric;
                                                      QUERY PLAN                                                     
@@ -850,10 +833,8 @@ INSERT INTO btest_numeric VALUES('2019-01-20T09:00:43', 2);
            ->  Custom Scan (ChunkAppend) on btest_numeric (actual rows=1 loops=1)
                  Order: btest_numeric."time"
                  ->  Index Scan Backward using _hyper_2_8_chunk_btest_numeric_time_idx on _hyper_2_8_chunk (actual rows=1 loops=1)
-                       Index Cond: ("time" IS NOT NULL)
                  ->  Index Scan Backward using _hyper_2_9_chunk_btest_numeric_time_idx on _hyper_2_9_chunk (never executed)
-                       Index Cond: ("time" IS NOT NULL)
-(9 rows)
+(7 rows)
 
 :PREFIX SELECT last(quantity, time) FROM btest_numeric;
                                                         QUERY PLAN                                                        
@@ -912,10 +893,8 @@ INSERT INTO btest_numeric VALUES('2018-01-20T09:00:43', NULL);
            ->  Custom Scan (ChunkAppend) on btest_numeric (actual rows=1 loops=1)
                  Order: btest_numeric."time"
                  ->  Index Scan Backward using _hyper_2_11_chunk_btest_numeric_time_idx on _hyper_2_11_chunk (actual rows=1 loops=1)
-                       Index Cond: ("time" IS NOT NULL)
                  ->  Index Scan Backward using _hyper_2_10_chunk_btest_numeric_time_idx on _hyper_2_10_chunk (never executed)
-                       Index Cond: ("time" IS NOT NULL)
-(9 rows)
+(7 rows)
 
 :PREFIX SELECT last(quantity, time) FROM btest_numeric;
                                                          QUERY PLAN                                                         

--- a/test/expected/plan_expand_hypertable-13.out
+++ b/test/expected/plan_expand_hypertable-13.out
@@ -2828,8 +2828,7 @@ SET enable_seqscan=false;
    InitPlan 1 (returns $0)
      ->  Limit
            ->  Index Scan Backward using _hyper_1_1_chunk_hyper_time_idx on _hyper_1_1_chunk h
-                 Index Cond: ("time" IS NOT NULL)
-(5 rows)
+(4 rows)
 
 \set ON_ERROR_STOP 0
 SELECT * FROM hyper WHERE _timescaledb_functions.chunks_in(hyper, ARRAY[1,2]) AND _timescaledb_functions.chunks_in(hyper, ARRAY[2,3]);

--- a/test/expected/plan_expand_hypertable-14.out
+++ b/test/expected/plan_expand_hypertable-14.out
@@ -2828,8 +2828,7 @@ SET enable_seqscan=false;
    InitPlan 1 (returns $0)
      ->  Limit
            ->  Index Scan Backward using _hyper_1_1_chunk_hyper_time_idx on _hyper_1_1_chunk h
-                 Index Cond: ("time" IS NOT NULL)
-(5 rows)
+(4 rows)
 
 \set ON_ERROR_STOP 0
 SELECT * FROM hyper WHERE _timescaledb_functions.chunks_in(hyper, ARRAY[1,2]) AND _timescaledb_functions.chunks_in(hyper, ARRAY[2,3]);

--- a/test/expected/plan_expand_hypertable-15.out
+++ b/test/expected/plan_expand_hypertable-15.out
@@ -2828,8 +2828,7 @@ SET enable_seqscan=false;
    InitPlan 1 (returns $0)
      ->  Limit
            ->  Index Scan Backward using _hyper_1_1_chunk_hyper_time_idx on _hyper_1_1_chunk h
-                 Index Cond: ("time" IS NOT NULL)
-(5 rows)
+(4 rows)
 
 \set ON_ERROR_STOP 0
 SELECT * FROM hyper WHERE _timescaledb_functions.chunks_in(hyper, ARRAY[1,2]) AND _timescaledb_functions.chunks_in(hyper, ARRAY[2,3]);

--- a/test/expected/plan_expand_hypertable-16.out
+++ b/test/expected/plan_expand_hypertable-16.out
@@ -2826,8 +2826,7 @@ SET enable_seqscan=false;
    InitPlan 1 (returns $0)
      ->  Limit
            ->  Index Scan Backward using _hyper_1_1_chunk_hyper_time_idx on _hyper_1_1_chunk h
-                 Index Cond: ("time" IS NOT NULL)
-(5 rows)
+(4 rows)
 
 \set ON_ERROR_STOP 0
 SELECT * FROM hyper WHERE _timescaledb_functions.chunks_in(hyper, ARRAY[1,2]) AND _timescaledb_functions.chunks_in(hyper, ARRAY[2,3]);

--- a/tsl/test/shared/expected/ordered_append-13.out
+++ b/tsl/test/shared/expected/ordered_append-13.out
@@ -412,15 +412,12 @@ QUERY PLAN
            ->  Custom Scan (ChunkAppend) on metrics (actual rows=1 loops=1)
                  Order: metrics."time"
                  ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
-                       Index Cond: ("time" IS NOT NULL)
                        Heap Fetches: 1
                  ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk (never executed)
-                       Index Cond: ("time" IS NOT NULL)
                        Heap Fetches: 0
                  ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk (never executed)
-                       Index Cond: ("time" IS NOT NULL)
                        Heap Fetches: 0
-(14 rows)
+(11 rows)
 
 :PREFIX
 SELECT last(time, time)
@@ -1439,37 +1436,28 @@ QUERY PLAN
                  ->  Merge Append (actual rows=1 loops=1)
                        Sort Key: _hyper_X_X_chunk."time"
                        ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
-                             Index Cond: ("time" IS NOT NULL)
                              Heap Fetches: 1
                        ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
-                             Index Cond: ("time" IS NOT NULL)
                              Heap Fetches: 1
                        ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
-                             Index Cond: ("time" IS NOT NULL)
                              Heap Fetches: 1
                  ->  Merge Append (never executed)
                        Sort Key: _hyper_X_X_chunk."time"
                        ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
-                             Index Cond: ("time" IS NOT NULL)
                              Heap Fetches: 0
                        ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
-                             Index Cond: ("time" IS NOT NULL)
                              Heap Fetches: 0
                        ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
-                             Index Cond: ("time" IS NOT NULL)
                              Heap Fetches: 0
                  ->  Merge Append (never executed)
                        Sort Key: _hyper_X_X_chunk."time"
                        ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
-                             Index Cond: ("time" IS NOT NULL)
                              Heap Fetches: 0
                        ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
-                             Index Cond: ("time" IS NOT NULL)
                              Heap Fetches: 0
                        ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
-                             Index Cond: ("time" IS NOT NULL)
                              Heap Fetches: 0
-(38 rows)
+(29 rows)
 
 :PREFIX
 SELECT last(time, time)
@@ -2626,19 +2614,16 @@ QUERY PLAN
                        Sort Key: _hyper_X_X_chunk."time"
                        Sort Method: top-N heapsort 
                        ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=17990 loops=1)
-                             Vectorized Filter: ("time" IS NOT NULL)
                              ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=20 loops=1)
                  ->  Sort (never executed)
                        Sort Key: _hyper_X_X_chunk."time"
                        ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (never executed)
-                             Vectorized Filter: ("time" IS NOT NULL)
                              ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
                  ->  Sort (never executed)
                        Sort Key: _hyper_X_X_chunk."time"
                        ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (never executed)
-                             Vectorized Filter: ("time" IS NOT NULL)
                              ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
-(21 rows)
+(18 rows)
 
 :PREFIX
 SELECT last(time, time)
@@ -4185,55 +4170,46 @@ QUERY PLAN
                              Sort Key: _hyper_X_X_chunk."time"
                              Sort Method: top-N heapsort 
                              ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=3598 loops=1)
-                                   Vectorized Filter: ("time" IS NOT NULL)
                                    ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=4 loops=1)
                        ->  Sort (actual rows=1 loops=1)
                              Sort Key: _hyper_X_X_chunk."time"
                              Sort Method: top-N heapsort 
                              ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=10794 loops=1)
-                                   Vectorized Filter: ("time" IS NOT NULL)
                                    ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=12 loops=1)
                        ->  Sort (actual rows=1 loops=1)
                              Sort Key: _hyper_X_X_chunk."time"
                              Sort Method: top-N heapsort 
                              ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=3598 loops=1)
-                                   Vectorized Filter: ("time" IS NOT NULL)
                                    ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=4 loops=1)
                  ->  Merge Append (never executed)
                        Sort Key: _hyper_X_X_chunk."time"
                        ->  Sort (never executed)
                              Sort Key: _hyper_X_X_chunk."time"
                              ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (never executed)
-                                   Vectorized Filter: ("time" IS NOT NULL)
                                    ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
                        ->  Sort (never executed)
                              Sort Key: _hyper_X_X_chunk."time"
                              ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (never executed)
-                                   Vectorized Filter: ("time" IS NOT NULL)
                                    ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
                        ->  Sort (never executed)
                              Sort Key: _hyper_X_X_chunk."time"
                              ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (never executed)
-                                   Vectorized Filter: ("time" IS NOT NULL)
                                    ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
                  ->  Merge Append (never executed)
                        Sort Key: _hyper_X_X_chunk."time"
                        ->  Sort (never executed)
                              Sort Key: _hyper_X_X_chunk."time"
                              ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (never executed)
-                                   Vectorized Filter: ("time" IS NOT NULL)
                                    ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
                        ->  Sort (never executed)
                              Sort Key: _hyper_X_X_chunk."time"
                              ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (never executed)
-                                   Vectorized Filter: ("time" IS NOT NULL)
                                    ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
                        ->  Sort (never executed)
                              Sort Key: _hyper_X_X_chunk."time"
                              ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (never executed)
-                                   Vectorized Filter: ("time" IS NOT NULL)
                                    ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
-(59 rows)
+(50 rows)
 
 :PREFIX
 SELECT last(time, time)

--- a/tsl/test/shared/expected/ordered_append-14.out
+++ b/tsl/test/shared/expected/ordered_append-14.out
@@ -412,15 +412,12 @@ QUERY PLAN
            ->  Custom Scan (ChunkAppend) on metrics (actual rows=1 loops=1)
                  Order: metrics."time"
                  ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
-                       Index Cond: ("time" IS NOT NULL)
                        Heap Fetches: 1
                  ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk (never executed)
-                       Index Cond: ("time" IS NOT NULL)
                        Heap Fetches: 0
                  ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk (never executed)
-                       Index Cond: ("time" IS NOT NULL)
                        Heap Fetches: 0
-(14 rows)
+(11 rows)
 
 :PREFIX
 SELECT last(time, time)
@@ -1439,37 +1436,28 @@ QUERY PLAN
                  ->  Merge Append (actual rows=1 loops=1)
                        Sort Key: _hyper_X_X_chunk."time"
                        ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
-                             Index Cond: ("time" IS NOT NULL)
                              Heap Fetches: 1
                        ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
-                             Index Cond: ("time" IS NOT NULL)
                              Heap Fetches: 1
                        ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
-                             Index Cond: ("time" IS NOT NULL)
                              Heap Fetches: 1
                  ->  Merge Append (never executed)
                        Sort Key: _hyper_X_X_chunk."time"
                        ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
-                             Index Cond: ("time" IS NOT NULL)
                              Heap Fetches: 0
                        ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
-                             Index Cond: ("time" IS NOT NULL)
                              Heap Fetches: 0
                        ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
-                             Index Cond: ("time" IS NOT NULL)
                              Heap Fetches: 0
                  ->  Merge Append (never executed)
                        Sort Key: _hyper_X_X_chunk."time"
                        ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
-                             Index Cond: ("time" IS NOT NULL)
                              Heap Fetches: 0
                        ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
-                             Index Cond: ("time" IS NOT NULL)
                              Heap Fetches: 0
                        ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
-                             Index Cond: ("time" IS NOT NULL)
                              Heap Fetches: 0
-(38 rows)
+(29 rows)
 
 :PREFIX
 SELECT last(time, time)
@@ -2626,19 +2614,16 @@ QUERY PLAN
                        Sort Key: _hyper_X_X_chunk."time"
                        Sort Method: top-N heapsort 
                        ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=17990 loops=1)
-                             Vectorized Filter: ("time" IS NOT NULL)
                              ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=20 loops=1)
                  ->  Sort (never executed)
                        Sort Key: _hyper_X_X_chunk."time"
                        ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (never executed)
-                             Vectorized Filter: ("time" IS NOT NULL)
                              ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
                  ->  Sort (never executed)
                        Sort Key: _hyper_X_X_chunk."time"
                        ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (never executed)
-                             Vectorized Filter: ("time" IS NOT NULL)
                              ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
-(21 rows)
+(18 rows)
 
 :PREFIX
 SELECT last(time, time)
@@ -4185,55 +4170,46 @@ QUERY PLAN
                              Sort Key: _hyper_X_X_chunk."time"
                              Sort Method: top-N heapsort 
                              ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=3598 loops=1)
-                                   Vectorized Filter: ("time" IS NOT NULL)
                                    ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=4 loops=1)
                        ->  Sort (actual rows=1 loops=1)
                              Sort Key: _hyper_X_X_chunk."time"
                              Sort Method: top-N heapsort 
                              ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=10794 loops=1)
-                                   Vectorized Filter: ("time" IS NOT NULL)
                                    ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=12 loops=1)
                        ->  Sort (actual rows=1 loops=1)
                              Sort Key: _hyper_X_X_chunk."time"
                              Sort Method: top-N heapsort 
                              ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=3598 loops=1)
-                                   Vectorized Filter: ("time" IS NOT NULL)
                                    ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=4 loops=1)
                  ->  Merge Append (never executed)
                        Sort Key: _hyper_X_X_chunk."time"
                        ->  Sort (never executed)
                              Sort Key: _hyper_X_X_chunk."time"
                              ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (never executed)
-                                   Vectorized Filter: ("time" IS NOT NULL)
                                    ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
                        ->  Sort (never executed)
                              Sort Key: _hyper_X_X_chunk."time"
                              ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (never executed)
-                                   Vectorized Filter: ("time" IS NOT NULL)
                                    ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
                        ->  Sort (never executed)
                              Sort Key: _hyper_X_X_chunk."time"
                              ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (never executed)
-                                   Vectorized Filter: ("time" IS NOT NULL)
                                    ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
                  ->  Merge Append (never executed)
                        Sort Key: _hyper_X_X_chunk."time"
                        ->  Sort (never executed)
                              Sort Key: _hyper_X_X_chunk."time"
                              ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (never executed)
-                                   Vectorized Filter: ("time" IS NOT NULL)
                                    ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
                        ->  Sort (never executed)
                              Sort Key: _hyper_X_X_chunk."time"
                              ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (never executed)
-                                   Vectorized Filter: ("time" IS NOT NULL)
                                    ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
                        ->  Sort (never executed)
                              Sort Key: _hyper_X_X_chunk."time"
                              ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (never executed)
-                                   Vectorized Filter: ("time" IS NOT NULL)
                                    ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
-(59 rows)
+(50 rows)
 
 :PREFIX
 SELECT last(time, time)

--- a/tsl/test/shared/expected/ordered_append-15.out
+++ b/tsl/test/shared/expected/ordered_append-15.out
@@ -416,15 +416,12 @@ QUERY PLAN
                  ->  Custom Scan (ChunkAppend) on metrics (actual rows=1 loops=1)
                        Order: metrics."time"
                        ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
-                             Index Cond: ("time" IS NOT NULL)
                              Heap Fetches: 1
                        ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk (never executed)
-                             Index Cond: ("time" IS NOT NULL)
                              Heap Fetches: 0
                        ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk (never executed)
-                             Index Cond: ("time" IS NOT NULL)
                              Heap Fetches: 0
-(15 rows)
+(12 rows)
 
 :PREFIX
 SELECT last(time, time)
@@ -1452,37 +1449,28 @@ QUERY PLAN
                        ->  Merge Append (actual rows=1 loops=1)
                              Sort Key: _hyper_X_X_chunk."time"
                              ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
-                                   Index Cond: ("time" IS NOT NULL)
                                    Heap Fetches: 1
                              ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
-                                   Index Cond: ("time" IS NOT NULL)
                                    Heap Fetches: 1
                              ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
-                                   Index Cond: ("time" IS NOT NULL)
                                    Heap Fetches: 1
                        ->  Merge Append (never executed)
                              Sort Key: _hyper_X_X_chunk."time"
                              ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
-                                   Index Cond: ("time" IS NOT NULL)
                                    Heap Fetches: 0
                              ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
-                                   Index Cond: ("time" IS NOT NULL)
                                    Heap Fetches: 0
                              ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
-                                   Index Cond: ("time" IS NOT NULL)
                                    Heap Fetches: 0
                        ->  Merge Append (never executed)
                              Sort Key: _hyper_X_X_chunk."time"
                              ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
-                                   Index Cond: ("time" IS NOT NULL)
                                    Heap Fetches: 0
                              ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
-                                   Index Cond: ("time" IS NOT NULL)
                                    Heap Fetches: 0
                              ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
-                                   Index Cond: ("time" IS NOT NULL)
                                    Heap Fetches: 0
-(39 rows)
+(30 rows)
 
 :PREFIX
 SELECT last(time, time)
@@ -2648,19 +2636,16 @@ QUERY PLAN
                              Sort Key: _hyper_X_X_chunk."time"
                              Sort Method: top-N heapsort 
                              ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=17990 loops=1)
-                                   Vectorized Filter: ("time" IS NOT NULL)
                                    ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=20 loops=1)
                        ->  Sort (never executed)
                              Sort Key: _hyper_X_X_chunk."time"
                              ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (never executed)
-                                   Vectorized Filter: ("time" IS NOT NULL)
                                    ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
                        ->  Sort (never executed)
                              Sort Key: _hyper_X_X_chunk."time"
                              ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (never executed)
-                                   Vectorized Filter: ("time" IS NOT NULL)
                                    ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
-(22 rows)
+(19 rows)
 
 :PREFIX
 SELECT last(time, time)
@@ -4213,55 +4198,46 @@ QUERY PLAN
                                    Sort Key: _hyper_X_X_chunk."time"
                                    Sort Method: top-N heapsort 
                                    ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=3598 loops=1)
-                                         Vectorized Filter: ("time" IS NOT NULL)
                                          ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=4 loops=1)
                              ->  Sort (actual rows=1 loops=1)
                                    Sort Key: _hyper_X_X_chunk."time"
                                    Sort Method: top-N heapsort 
                                    ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=10794 loops=1)
-                                         Vectorized Filter: ("time" IS NOT NULL)
                                          ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=12 loops=1)
                              ->  Sort (actual rows=1 loops=1)
                                    Sort Key: _hyper_X_X_chunk."time"
                                    Sort Method: top-N heapsort 
                                    ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=3598 loops=1)
-                                         Vectorized Filter: ("time" IS NOT NULL)
                                          ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=4 loops=1)
                        ->  Merge Append (never executed)
                              Sort Key: _hyper_X_X_chunk."time"
                              ->  Sort (never executed)
                                    Sort Key: _hyper_X_X_chunk."time"
                                    ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (never executed)
-                                         Vectorized Filter: ("time" IS NOT NULL)
                                          ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
                              ->  Sort (never executed)
                                    Sort Key: _hyper_X_X_chunk."time"
                                    ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (never executed)
-                                         Vectorized Filter: ("time" IS NOT NULL)
                                          ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
                              ->  Sort (never executed)
                                    Sort Key: _hyper_X_X_chunk."time"
                                    ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (never executed)
-                                         Vectorized Filter: ("time" IS NOT NULL)
                                          ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
                        ->  Merge Append (never executed)
                              Sort Key: _hyper_X_X_chunk."time"
                              ->  Sort (never executed)
                                    Sort Key: _hyper_X_X_chunk."time"
                                    ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (never executed)
-                                         Vectorized Filter: ("time" IS NOT NULL)
                                          ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
                              ->  Sort (never executed)
                                    Sort Key: _hyper_X_X_chunk."time"
                                    ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (never executed)
-                                         Vectorized Filter: ("time" IS NOT NULL)
                                          ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
                              ->  Sort (never executed)
                                    Sort Key: _hyper_X_X_chunk."time"
                                    ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (never executed)
-                                         Vectorized Filter: ("time" IS NOT NULL)
                                          ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
-(60 rows)
+(51 rows)
 
 :PREFIX
 SELECT last(time, time)

--- a/tsl/test/shared/expected/ordered_append-16.out
+++ b/tsl/test/shared/expected/ordered_append-16.out
@@ -416,15 +416,12 @@ QUERY PLAN
                  ->  Custom Scan (ChunkAppend) on metrics (actual rows=1 loops=1)
                        Order: metrics."time"
                        ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
-                             Index Cond: ("time" IS NOT NULL)
                              Heap Fetches: 1
                        ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk (never executed)
-                             Index Cond: ("time" IS NOT NULL)
                              Heap Fetches: 0
                        ->  Index Only Scan Backward using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk (never executed)
-                             Index Cond: ("time" IS NOT NULL)
                              Heap Fetches: 0
-(15 rows)
+(12 rows)
 
 :PREFIX
 SELECT last(time, time)
@@ -1452,37 +1449,28 @@ QUERY PLAN
                        ->  Merge Append (actual rows=1 loops=1)
                              Sort Key: _hyper_X_X_chunk."time"
                              ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
-                                   Index Cond: ("time" IS NOT NULL)
                                    Heap Fetches: 1
                              ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
-                                   Index Cond: ("time" IS NOT NULL)
                                    Heap Fetches: 1
                              ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
-                                   Index Cond: ("time" IS NOT NULL)
                                    Heap Fetches: 1
                        ->  Merge Append (never executed)
                              Sort Key: _hyper_X_X_chunk."time"
                              ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
-                                   Index Cond: ("time" IS NOT NULL)
                                    Heap Fetches: 0
                              ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
-                                   Index Cond: ("time" IS NOT NULL)
                                    Heap Fetches: 0
                              ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
-                                   Index Cond: ("time" IS NOT NULL)
                                    Heap Fetches: 0
                        ->  Merge Append (never executed)
                              Sort Key: _hyper_X_X_chunk."time"
                              ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
-                                   Index Cond: ("time" IS NOT NULL)
                                    Heap Fetches: 0
                              ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
-                                   Index Cond: ("time" IS NOT NULL)
                                    Heap Fetches: 0
                              ->  Index Only Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
-                                   Index Cond: ("time" IS NOT NULL)
                                    Heap Fetches: 0
-(39 rows)
+(30 rows)
 
 :PREFIX
 SELECT last(time, time)
@@ -2648,19 +2636,16 @@ QUERY PLAN
                              Sort Key: _hyper_X_X_chunk."time"
                              Sort Method: top-N heapsort 
                              ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=17990 loops=1)
-                                   Vectorized Filter: ("time" IS NOT NULL)
                                    ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=20 loops=1)
                        ->  Sort (never executed)
                              Sort Key: _hyper_X_X_chunk."time"
                              ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (never executed)
-                                   Vectorized Filter: ("time" IS NOT NULL)
                                    ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
                        ->  Sort (never executed)
                              Sort Key: _hyper_X_X_chunk."time"
                              ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (never executed)
-                                   Vectorized Filter: ("time" IS NOT NULL)
                                    ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
-(22 rows)
+(19 rows)
 
 :PREFIX
 SELECT last(time, time)
@@ -4213,55 +4198,46 @@ QUERY PLAN
                                    Sort Key: _hyper_X_X_chunk."time"
                                    Sort Method: top-N heapsort 
                                    ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=3598 loops=1)
-                                         Vectorized Filter: ("time" IS NOT NULL)
                                          ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=4 loops=1)
                              ->  Sort (actual rows=1 loops=1)
                                    Sort Key: _hyper_X_X_chunk."time"
                                    Sort Method: top-N heapsort 
                                    ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=10794 loops=1)
-                                         Vectorized Filter: ("time" IS NOT NULL)
                                          ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=12 loops=1)
                              ->  Sort (actual rows=1 loops=1)
                                    Sort Key: _hyper_X_X_chunk."time"
                                    Sort Method: top-N heapsort 
                                    ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=3598 loops=1)
-                                         Vectorized Filter: ("time" IS NOT NULL)
                                          ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=4 loops=1)
                        ->  Merge Append (never executed)
                              Sort Key: _hyper_X_X_chunk."time"
                              ->  Sort (never executed)
                                    Sort Key: _hyper_X_X_chunk."time"
                                    ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (never executed)
-                                         Vectorized Filter: ("time" IS NOT NULL)
                                          ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
                              ->  Sort (never executed)
                                    Sort Key: _hyper_X_X_chunk."time"
                                    ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (never executed)
-                                         Vectorized Filter: ("time" IS NOT NULL)
                                          ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
                              ->  Sort (never executed)
                                    Sort Key: _hyper_X_X_chunk."time"
                                    ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (never executed)
-                                         Vectorized Filter: ("time" IS NOT NULL)
                                          ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
                        ->  Merge Append (never executed)
                              Sort Key: _hyper_X_X_chunk."time"
                              ->  Sort (never executed)
                                    Sort Key: _hyper_X_X_chunk."time"
                                    ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (never executed)
-                                         Vectorized Filter: ("time" IS NOT NULL)
                                          ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
                              ->  Sort (never executed)
                                    Sort Key: _hyper_X_X_chunk."time"
                                    ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (never executed)
-                                         Vectorized Filter: ("time" IS NOT NULL)
                                          ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
                              ->  Sort (never executed)
                                    Sort Key: _hyper_X_X_chunk."time"
                                    ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (never executed)
-                                         Vectorized Filter: ("time" IS NOT NULL)
                                          ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
-(60 rows)
+(51 rows)
 
 :PREFIX
 SELECT last(time, time)


### PR DESCRIPTION
If we use NULLS LAST, we don't need the null test. This saves some CPU.

Disable-check: force-changelog-file