### PR TITLE
Fix flaky SQL test

### DIFF
--- a/test/expected/bgw_launcher.out
+++ b/test/expected/bgw_launcher.out
@@ -609,6 +609,14 @@ SELECT pg_terminate_backend(pid) FROM pg_stat_activity WHERE application_name = 
 (1 row)
 
 \c :TEST_DBNAME_2 :ROLE_SUPERUSER
+-- make sure nobody is using it
+SET client_min_messages TO error;
+REVOKE CONNECT ON DATABASE :TEST_DBNAME FROM public;
+SELECT count(pg_terminate_backend(pg_stat_activity.pid)) AS TERMINATED
+FROM pg_stat_activity
+WHERE pg_stat_activity.datname = :'TEST_DBNAME'
+AND pg_stat_activity.pid <> pg_backend_pid() \gset
+RESET client_min_messages;
 -- Change tablespace
 ALTER DATABASE :TEST_DBNAME SET TABLESPACE tablespace1;
 WARNING:  you may need to manually restart any running background workers after this command

--- a/test/expected/pg_dump.out
+++ b/test/expected/pg_dump.out
@@ -655,4 +655,12 @@ SELECT * FROM test_tz ORDER BY time;
 (4 rows)
 
 \c :TEST_DBNAME :ROLE_SUPERUSER
+-- make sure nobody is using it
+SET client_min_messages TO ERROR;
+REVOKE CONNECT ON DATABASE :TEST_DBNAME_EXTRA FROM public;
+SELECT count(pg_terminate_backend(pg_stat_activity.pid)) AS TERMINATED
+FROM pg_stat_activity
+WHERE pg_stat_activity.datname = :'TEST_DBNAME_EXTRA'
+AND pg_stat_activity.pid <> pg_backend_pid() \gset
+RESET client_min_messages;
 DROP DATABASE :TEST_DBNAME_EXTRA WITH (FORCE);

--- a/test/sql/bgw_launcher.sql
+++ b/test/sql/bgw_launcher.sql
@@ -262,10 +262,20 @@ SELECT _timescaledb_functions.stop_background_workers();
 SELECT pg_terminate_backend(pid) FROM pg_stat_activity WHERE application_name = 'TimescaleDB Background Worker Launcher';
 \c :TEST_DBNAME_2 :ROLE_SUPERUSER
 
+-- make sure nobody is using it
+SET client_min_messages TO error;
+REVOKE CONNECT ON DATABASE :TEST_DBNAME FROM public;
+SELECT count(pg_terminate_backend(pg_stat_activity.pid)) AS TERMINATED
+FROM pg_stat_activity
+WHERE pg_stat_activity.datname = :'TEST_DBNAME'
+AND pg_stat_activity.pid <> pg_backend_pid() \gset
+RESET client_min_messages;
+
 -- Change tablespace
 ALTER DATABASE :TEST_DBNAME SET TABLESPACE tablespace1;
 
 -- tear down test and clean up additional database
 \c :TEST_DBNAME :ROLE_SUPERUSER
+
 DROP DATABASE :TEST_DBNAME_2 WITH (force);
 

--- a/test/sql/pg_dump.sql
+++ b/test/sql/pg_dump.sql
@@ -226,5 +226,14 @@ SELECT * FROM test_tz ORDER BY time;
 
 \c :TEST_DBNAME :ROLE_SUPERUSER
 
+-- make sure nobody is using it
+SET client_min_messages TO ERROR;
+REVOKE CONNECT ON DATABASE :TEST_DBNAME_EXTRA FROM public;
+SELECT count(pg_terminate_backend(pg_stat_activity.pid)) AS TERMINATED
+FROM pg_stat_activity
+WHERE pg_stat_activity.datname = :'TEST_DBNAME_EXTRA'
+AND pg_stat_activity.pid <> pg_backend_pid() \gset
+RESET client_min_messages;
+
 DROP DATABASE :TEST_DBNAME_EXTRA WITH (FORCE);
 


### PR DESCRIPTION
During dropping of the database used in the various tests we can encounter an error if something is still connected to the database, making the output unpredicatable. This change should reduce the possibility of that happening.

Disable-check: force-changelog-file