### PR TITLE
Display the welcome message as NOTICE

### DIFF
--- a/sql/notice.sql
+++ b/sql/notice.sql
@@ -17,7 +17,7 @@ BEGIN
     telemetry_string = E'';
   END CASE;
 
-  RAISE WARNING E'%\n%\n',
+  RAISE NOTICE E'%\n%\n',
     E'\nWELCOME TO\n' ||
     E' _____ _                               _     ____________  \n' ||
     E'|_   _(_)                             | |    |  _  \\ ___ \\ \n' ||


### PR DESCRIPTION
Now we display it as WARNING and it makes it harder to grep the logs for failures such as broken memory contexts or tupdesc reference leaks, which are also reported as warnings.

Disable-check: force-changelog-file