### PR TITLE
Fix pg_dump flakiness

### DIFF
--- a/test/expected/pg_dump.out
+++ b/test/expected/pg_dump.out
@@ -612,6 +612,7 @@ SELECT bgw_wait(:'TEST_DBNAME', 60, FALSE);
 (1 row)
 
 -- Force other sessions connected to the TEST_DBNAME to be finished
+REVOKE CONNECT ON DATABASE :TEST_DBNAME FROM public;
 SET client_min_messages TO ERROR;
 SELECT COUNT(pg_catalog.pg_terminate_backend(pid))>=0
 FROM pg_stat_activity
@@ -624,6 +625,7 @@ AND datname = ':TEST_DBNAME';
 
 RESET client_min_messages;
 CREATE DATABASE :TEST_DBNAME_EXTRA WITH TEMPLATE :TEST_DBNAME;
+GRANT CONNECT ON DATABASE :TEST_DBNAME TO public;
 -- Connect to the database and do some basic stuff to check that the
 -- extension works.
 \c :TEST_DBNAME_EXTRA :ROLE_DEFAULT_PERM_USER

--- a/test/sql/pg_dump.sql
+++ b/test/sql/pg_dump.sql
@@ -200,6 +200,7 @@ SELECT timescaledb_pre_restore();
 SELECT bgw_wait(:'TEST_DBNAME', 60, FALSE);
 
 -- Force other sessions connected to the TEST_DBNAME to be finished
+REVOKE CONNECT ON DATABASE :TEST_DBNAME FROM public;
 SET client_min_messages TO ERROR;
 SELECT COUNT(pg_catalog.pg_terminate_backend(pid))>=0
 FROM pg_stat_activity
@@ -208,6 +209,7 @@ AND datname = ':TEST_DBNAME';
 RESET client_min_messages;
 
 CREATE DATABASE :TEST_DBNAME_EXTRA WITH TEMPLATE :TEST_DBNAME;
+GRANT CONNECT ON DATABASE :TEST_DBNAME TO public;
 
 -- Connect to the database and do some basic stuff to check that the
 -- extension works.


### PR DESCRIPTION
During pg_dump creation of extra database, we terminate all processes connected to the template database but we don't revoke connection to it. This is why we still see random failures to create the new database.

Disable-check: force-changelog-file