### PR TITLE
Fix upload test results for macos regression CI 

### DIFF
--- a/.github/workflows/linux-build-and-test.yaml
+++ b/.github/workflows/linux-build-and-test.yaml
@@ -282,6 +282,10 @@ jobs:
             GITHUB_PR_NUMBER=0
         fi
         export GITHUB_PR_NUMBER
-        PSQL="${HOME}/${PG_INSTALL_DIR}/bin/psql"
-        export PSQL
+        if [[ "${{ runner.os }}" == "macOS" ]] ;
+        then
+          # Add libpq to PATH so psql can be used for uploading
+          # test results
+          export PATH="/usr/local/opt/libpq/bin:$PATH"
+        fi
         scripts/upload_ci_stats.sh


### PR DESCRIPTION
Most if not all commits have failed on the main branch due to macos-13 regression tests failing to upload test results to CI database. Switching to using libpq psql seems to fix the issue.

https://github.com/timescale/timescaledb/actions/workflows/linux-build-and-test.yaml?query=is%3Afailure+branch%3Amain

This PR success CI run: https://github.com/timescale/timescaledb/actions/runs/7276339952/job/19826008689?pr=6449

Disable-check: force-changelog-file