### PR TITLE
Store per chunk compression settings

### DIFF
--- a/src/chunk.c
+++ b/src/chunk.c
@@ -67,6 +67,7 @@
 #include "trigger.h"
 #include "ts_catalog/catalog.h"
 #include "ts_catalog/compression_chunk_size.h"
+#include "ts_catalog/compression_settings.h"
 #include "ts_catalog/continuous_agg.h"
 #include "ts_catalog/continuous_aggs_watermark.h"
 #include "utils.h"
@@ -2927,9 +2928,12 @@ chunk_tuple_delete(TupleInfo *ti, DropBehavior behavior, bool preserve_chunk_cat
 
 		/* The chunk may have been delete by a CASCADE */
 		if (compressed_chunk != NULL)
+		{
 			/* Plain drop without preserving catalog row because this is the compressed
 			 * chunk */
+			ts_compression_settings_delete(compressed_chunk->table_id);
 			ts_chunk_drop(compressed_chunk, behavior, DEBUG1);
+		}
 	}
 
 	ts_catalog_database_info_become_owner(ts_catalog_database_info_get(), &sec_ctx);

--- a/src/event_trigger.c
+++ b/src/event_trigger.c
@@ -143,7 +143,7 @@ make_event_trigger_drop_index(const char *index_name, const char *schema)
 }
 
 static EventTriggerDropRelation *
-make_event_trigger_drop_table(const char *table_name, const char *schema, char relkind)
+make_event_trigger_drop_table(Oid relid, const char *table_name, const char *schema, char relkind)
 {
 	EventTriggerDropRelation *obj = palloc(sizeof(EventTriggerDropRelation));
 
@@ -151,6 +151,7 @@ make_event_trigger_drop_table(const char *table_name, const char *schema, char r
 		.obj = {
 			.type = (relkind == RELKIND_RELATION) ? EVENT_TRIGGER_DROP_TABLE : EVENT_TRIGGER_DROP_FOREIGN_TABLE,
 		},
+    .relid = relid,
 		.name = table_name,
 		.schema = schema,
 	};
@@ -278,9 +279,12 @@ ts_event_trigger_dropped_objects(void)
 					eventobj =
 						make_event_trigger_drop_index(lsecond(addrnames), linitial(addrnames));
 				else if (strcmp(objtype, "table") == 0)
-					eventobj = make_event_trigger_drop_table(lsecond(addrnames),
+				{
+					eventobj = make_event_trigger_drop_table(DatumGetInt32(values[1]),
+															 lsecond(addrnames),
 															 linitial(addrnames),
 															 RELKIND_RELATION);
+				}
 				else if (strcmp(objtype, "view") == 0)
 				{
 					List *addrnames = extract_addrnames(DatumGetArrayTypeP(values[10]));
@@ -290,7 +294,8 @@ ts_event_trigger_dropped_objects(void)
 																   linitial(addrnames)));
 				}
 				else if (strcmp(objtype, "foreign table") == 0)
-					eventobj = make_event_trigger_drop_table(lsecond(addrnames),
+					eventobj = make_event_trigger_drop_table(DatumGetInt32(values[1]),
+															 lsecond(addrnames),
 															 linitial(addrnames),
 															 RELKIND_FOREIGN_TABLE);
 				break;

--- a/src/event_trigger.h
+++ b/src/event_trigger.h
@@ -36,6 +36,7 @@ typedef struct EventTriggerDropTableConstraint
 typedef struct EventTriggerDropRelation
 {
 	EventTriggerDropObject obj;
+	Oid relid;
 	const char *name;
 	const char *schema;
 } EventTriggerDropRelation;

--- a/src/hypertable.c
+++ b/src/hypertable.c
@@ -614,9 +614,6 @@ hypertable_tuple_delete(TupleInfo *ti, void *data)
 	/* Remove any dependent continuous aggs */
 	ts_continuous_agg_drop_hypertable_callback(hypertable_id);
 
-	/* remove any associated compression definitions */
-	ts_compression_settings_delete(ts_hypertable_id_to_relid(hypertable_id, true));
-
 	if (!compressed_hypertable_id_isnull)
 	{
 		Hypertable *compressed_hypertable = ts_hypertable_get_by_id(compressed_hypertable_id);
@@ -709,6 +706,7 @@ ts_hypertable_drop(Hypertable *hypertable, DropBehavior behavior)
 		/* Drop the postgres table */
 		performDeletion(&hypertable_addr, behavior, 0);
 	}
+
 	/* Clean up catalog */
 	ts_hypertable_delete_by_name(NameStr(hypertable->fd.schema_name),
 								 NameStr(hypertable->fd.table_name));

--- a/src/process_utility.c
+++ b/src/process_utility.c
@@ -1889,7 +1889,7 @@ process_rename_column(ProcessUtilityArgs *args, Cache *hcache, Oid relid, Rename
 	 * we don't do anything. */
 	if (ht)
 	{
-		ts_compression_settings_rename_column(ht->main_table_relid, stmt->subname, stmt->newname);
+		ts_compression_settings_rename_column_hypertable(ht, stmt->subname, stmt->newname);
 		add_hypertable_to_process_args(args, ht);
 		dim = ts_hyperspace_get_mutable_dimension_by_name(ht->space,
 														  DIMENSION_TYPE_ANY,
@@ -4235,6 +4235,7 @@ process_drop_table(EventTriggerDropObject *obj)
 	Assert(obj->type == EVENT_TRIGGER_DROP_TABLE || obj->type == EVENT_TRIGGER_DROP_FOREIGN_TABLE);
 	ts_hypertable_delete_by_name(table->schema, table->name);
 	ts_chunk_delete_by_name(table->schema, table->name, DROP_RESTRICT);
+	ts_compression_settings_delete(table->relid);
 }
 
 static void

--- a/src/ts_catalog/compression_settings.h
+++ b/src/ts_catalog/compression_settings.h
@@ -20,7 +20,11 @@ TSDLLEXPORT CompressionSettings *ts_compression_settings_create(Oid relid, Array
 																ArrayType *orderby_desc,
 																ArrayType *orderby_nullsfirst);
 TSDLLEXPORT CompressionSettings *ts_compression_settings_get(Oid relid);
+TSDLLEXPORT CompressionSettings *ts_compression_settings_materialize(Oid ht_relid, Oid dst_relid);
 TSDLLEXPORT bool ts_compression_settings_delete(Oid relid);
+
 TSDLLEXPORT int ts_compression_settings_update(CompressionSettings *settings);
 
 TSDLLEXPORT void ts_compression_settings_rename_column(Oid relid, char *old, char *new);
+TSDLLEXPORT void ts_compression_settings_rename_column_hypertable(Hypertable *ht, char *old,
+																  char *new);

--- a/tsl/src/compression/compression.h
+++ b/tsl/src/compression/compression.h
@@ -321,8 +321,7 @@ pg_attribute_unused() assert_num_compression_algorithms_sane(void)
 extern CompressionStorage compression_get_toast_storage(CompressionAlgorithm algo);
 extern CompressionAlgorithm compression_get_default_algorithm(Oid typeoid);
 
-extern CompressionStats compress_chunk(Hypertable *ht, Oid in_table, Oid out_table,
-									   int insert_options);
+extern CompressionStats compress_chunk(Oid in_table, Oid out_table, int insert_options);
 extern void decompress_chunk(Oid in_table, Oid out_table);
 
 extern DecompressionIterator *(*tsl_get_decompression_iterator_init(

--- a/tsl/test/expected/compression_settings.out
+++ b/tsl/test/expected/compression_settings.out
@@ -1,0 +1,98 @@
+-- This file and its contents are licensed under the Timescale License.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-TIMESCALE for a copy of the license.
+\set ECHO ALL
+CREATE TABLE metrics(time timestamptz, device text, value float);
+SELECT create_hypertable('metrics','time');
+NOTICE:  adding not-null constraint to column "time"
+  create_hypertable   
+----------------------
+ (1,public,metrics,t)
+(1 row)
+
+ALTER TABLE metrics SET (timescaledb.compress, timescaledb.compress_segmentby='device');
+SELECT * FROM _timescaledb_catalog.compression_settings;
+  relid  | segmentby | orderby | orderby_desc | orderby_nullsfirst 
+---------+-----------+---------+--------------+--------------------
+ metrics | {device}  | {time}  | {t}          | {t}
+(1 row)
+
+-- create 2 chunks
+INSERT INTO metrics VALUES ('2000-01-01'), ('2001-01-01');
+-- no change to settings
+SELECT * FROM _timescaledb_catalog.compression_settings;
+  relid  | segmentby | orderby | orderby_desc | orderby_nullsfirst 
+---------+-----------+---------+--------------+--------------------
+ metrics | {device}  | {time}  | {t}          | {t}
+(1 row)
+
+SELECT compress_chunk('_timescaledb_internal._hyper_1_1_chunk');
+             compress_chunk             
+----------------------------------------
+ _timescaledb_internal._hyper_1_1_chunk
+(1 row)
+
+SELECT * FROM _timescaledb_catalog.compression_settings;
+                     relid                      | segmentby | orderby | orderby_desc | orderby_nullsfirst 
+------------------------------------------------+-----------+---------+--------------+--------------------
+ metrics                                        | {device}  | {time}  | {t}          | {t}
+ _timescaledb_internal.compress_hyper_2_3_chunk | {device}  | {time}  | {t}          | {t}
+(2 rows)
+
+SELECT compress_chunk('_timescaledb_internal._hyper_1_2_chunk');
+             compress_chunk             
+----------------------------------------
+ _timescaledb_internal._hyper_1_2_chunk
+(1 row)
+
+SELECT * FROM _timescaledb_catalog.compression_settings;
+                     relid                      | segmentby | orderby | orderby_desc | orderby_nullsfirst 
+------------------------------------------------+-----------+---------+--------------+--------------------
+ metrics                                        | {device}  | {time}  | {t}          | {t}
+ _timescaledb_internal.compress_hyper_2_3_chunk | {device}  | {time}  | {t}          | {t}
+ _timescaledb_internal.compress_hyper_2_4_chunk | {device}  | {time}  | {t}          | {t}
+(3 rows)
+
+-- dropping chunk should remove that chunks compression settings
+DROP TABLE _timescaledb_internal._hyper_1_1_chunk;
+SELECT * FROM _timescaledb_catalog.compression_settings;
+                     relid                      | segmentby | orderby | orderby_desc | orderby_nullsfirst 
+------------------------------------------------+-----------+---------+--------------+--------------------
+ metrics                                        | {device}  | {time}  | {t}          | {t}
+ _timescaledb_internal.compress_hyper_2_4_chunk | {device}  | {time}  | {t}          | {t}
+(2 rows)
+
+-- decompress_chunk should remove settings for that chunk
+SELECT decompress_chunk('_timescaledb_internal._hyper_1_2_chunk');
+            decompress_chunk            
+----------------------------------------
+ _timescaledb_internal._hyper_1_2_chunk
+(1 row)
+
+SELECT * FROM _timescaledb_catalog.compression_settings;
+  relid  | segmentby | orderby | orderby_desc | orderby_nullsfirst 
+---------+-----------+---------+--------------+--------------------
+ metrics | {device}  | {time}  | {t}          | {t}
+(1 row)
+
+-- compress_chunk should add settings back
+SELECT compress_chunk('_timescaledb_internal._hyper_1_2_chunk');
+             compress_chunk             
+----------------------------------------
+ _timescaledb_internal._hyper_1_2_chunk
+(1 row)
+
+SELECT * FROM _timescaledb_catalog.compression_settings;
+                     relid                      | segmentby | orderby | orderby_desc | orderby_nullsfirst 
+------------------------------------------------+-----------+---------+--------------+--------------------
+ metrics                                        | {device}  | {time}  | {t}          | {t}
+ _timescaledb_internal.compress_hyper_2_5_chunk | {device}  | {time}  | {t}          | {t}
+(2 rows)
+
+-- dropping hypertable should remove all settings
+DROP TABLE metrics;
+SELECT * FROM _timescaledb_catalog.compression_settings;
+ relid | segmentby | orderby | orderby_desc | orderby_nullsfirst 
+-------+-----------+---------+--------------+--------------------
+(0 rows)
+

--- a/tsl/test/sql/CMakeLists.txt
+++ b/tsl/test/sql/CMakeLists.txt
@@ -21,6 +21,7 @@ set(TEST_FILES
     compression_insert.sql
     compression_policy.sql
     compression_qualpushdown.sql
+    compression_settings.sql
     compression_sorted_merge_distinct.sql
     decompress_index.sql
     exp_cagg_monthly.sql

--- a/tsl/test/sql/compression_settings.sql
+++ b/tsl/test/sql/compression_settings.sql
@@ -1,0 +1,38 @@
+-- This file and its contents are licensed under the Timescale License.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-TIMESCALE for a copy of the license.
+
+\set ECHO ALL
+
+CREATE TABLE metrics(time timestamptz, device text, value float);
+SELECT create_hypertable('metrics','time');
+
+ALTER TABLE metrics SET (timescaledb.compress, timescaledb.compress_segmentby='device');
+SELECT * FROM _timescaledb_catalog.compression_settings;
+
+-- create 2 chunks
+INSERT INTO metrics VALUES ('2000-01-01'), ('2001-01-01');
+-- no change to settings
+SELECT * FROM _timescaledb_catalog.compression_settings;
+
+SELECT compress_chunk('_timescaledb_internal._hyper_1_1_chunk');
+SELECT * FROM _timescaledb_catalog.compression_settings;
+
+SELECT compress_chunk('_timescaledb_internal._hyper_1_2_chunk');
+SELECT * FROM _timescaledb_catalog.compression_settings;
+
+-- dropping chunk should remove that chunks compression settings
+DROP TABLE _timescaledb_internal._hyper_1_1_chunk;
+SELECT * FROM _timescaledb_catalog.compression_settings;
+
+-- decompress_chunk should remove settings for that chunk
+SELECT decompress_chunk('_timescaledb_internal._hyper_1_2_chunk');
+SELECT * FROM _timescaledb_catalog.compression_settings;
+
+-- compress_chunk should add settings back
+SELECT compress_chunk('_timescaledb_internal._hyper_1_2_chunk');
+SELECT * FROM _timescaledb_catalog.compression_settings;
+
+-- dropping hypertable should remove all settings
+DROP TABLE metrics;
+SELECT * FROM _timescaledb_catalog.compression_settings;


### PR DESCRIPTION
This patch materializes the hypertable compression configuration when the compressed chunk is created and adjusts the code to use the per chunk settings whenever working with compressed data. Allowing chunk settings to differ from hypertable settings will be implemented in a follow-up patch.

Disable-check: force-changelog-file
