### PR TITLE
Disallow database connection in pg_dump

### DIFF
--- a/test/expected/pg_dump.out
+++ b/test/expected/pg_dump.out
@@ -612,12 +612,13 @@ SELECT bgw_wait(:'TEST_DBNAME', 60, FALSE);
 (1 row)
 
 -- Force other sessions connected to the TEST_DBNAME to be finished
+\c postgres :ROLE_SUPERUSER
 REVOKE CONNECT ON DATABASE :TEST_DBNAME FROM public;
+ALTER DATABASE :TEST_DBNAME allow_connections = off;
 SET client_min_messages TO ERROR;
 SELECT COUNT(pg_catalog.pg_terminate_backend(pid))>=0
 FROM pg_stat_activity
-WHERE pid <> pg_backend_pid()
-AND datname = ':TEST_DBNAME';
+WHERE datname = ':TEST_DBNAME';
  ?column? 
 ----------
  t
@@ -625,6 +626,7 @@ AND datname = ':TEST_DBNAME';
 
 RESET client_min_messages;
 CREATE DATABASE :TEST_DBNAME_EXTRA WITH TEMPLATE :TEST_DBNAME;
+ALTER DATABASE :TEST_DBNAME allow_connections = on;
 GRANT CONNECT ON DATABASE :TEST_DBNAME TO public;
 -- Connect to the database and do some basic stuff to check that the
 -- extension works.

--- a/test/sql/pg_dump.sql
+++ b/test/sql/pg_dump.sql
@@ -200,15 +200,17 @@ SELECT timescaledb_pre_restore();
 SELECT bgw_wait(:'TEST_DBNAME', 60, FALSE);
 
 -- Force other sessions connected to the TEST_DBNAME to be finished
+\c postgres :ROLE_SUPERUSER
 REVOKE CONNECT ON DATABASE :TEST_DBNAME FROM public;
+ALTER DATABASE :TEST_DBNAME allow_connections = off;
 SET client_min_messages TO ERROR;
 SELECT COUNT(pg_catalog.pg_terminate_backend(pid))>=0
 FROM pg_stat_activity
-WHERE pid <> pg_backend_pid()
-AND datname = ':TEST_DBNAME';
+WHERE datname = ':TEST_DBNAME';
 RESET client_min_messages;
 
 CREATE DATABASE :TEST_DBNAME_EXTRA WITH TEMPLATE :TEST_DBNAME;
+ALTER DATABASE :TEST_DBNAME allow_connections = on;
 GRANT CONNECT ON DATABASE :TEST_DBNAME TO public;
 
 -- Connect to the database and do some basic stuff to check that the


### PR DESCRIPTION
Another try to reduce the flakiness of this test. Previously added REVOKE CONNECT does not stop db owners or superusers connecting. Altering the database with allow_connections = off should stop everybody from connecting.

Disable-check: force-changelog-file