### PR TITLE
Vectorize NullTest

### DIFF
--- a/tsl/src/nodes/decompress_chunk/compressed_batch.c
+++ b/tsl/src/nodes/decompress_chunk/compressed_batch.c
@@ -213,14 +213,20 @@ compute_vector_quals(DecompressContext *dcontext, DecompressBatchState *batch_st
 	foreach (lc, dcontext->vectorized_quals_constified)
 	{
 		/*
-		 * For now we support "Var ? Const" predicates and
+		 * For now, we support NullTest, "Var ? Const" predicates and
 		 * ScalarArrayOperations.
 		 */
 		List *args = NULL;
 		RegProcedure vector_const_opcode = InvalidOid;
 		ScalarArrayOpExpr *saop = NULL;
 		OpExpr *opexpr = NULL;
-		if (IsA(lfirst(lc), ScalarArrayOpExpr))
+		NullTest *nulltest = NULL;
+		if (IsA(lfirst(lc), NullTest))
+		{
+			nulltest = castNode(NullTest, lfirst(lc));
+			args = list_make1(nulltest->arg);
+		}
+		else if (IsA(lfirst(lc), ScalarArrayOpExpr))
 		{
 			saop = castNode(ScalarArrayOpExpr, lfirst(lc));
 			args = saop->args;
@@ -232,12 +238,6 @@ compute_vector_quals(DecompressContext *dcontext, DecompressBatchState *batch_st
 			args = opexpr->args;
 			vector_const_opcode = get_opcode(opexpr->opno);
 		}
-
-		/*
-		 * Find the vector_const predicate.
-		 */
-		VectorPredicate *vector_const_predicate = get_vector_const_predicate(vector_const_opcode);
-		Assert(vector_const_predicate != NULL);
 
 		/*
 		 * Find the compressed column referred to by the Var.
@@ -311,36 +311,53 @@ compute_vector_quals(DecompressContext *dcontext, DecompressBatchState *batch_st
 			predicate_result = &default_value_predicate_result;
 		}
 
-		/*
-		 * The vectorizable predicates should be STRICT, so we shouldn't see null
-		 * constants here.
-		 */
-		Const *constnode = castNode(Const, lsecond(args));
-		Ensure(!constnode->constisnull, "vectorized predicate called for a null value");
-
-		/*
-		 * At last, compute the predicate.
-		 */
-		if (saop)
+		if (nulltest)
 		{
-			vector_array_predicate(vector_const_predicate,
-								   saop->useOr,
-								   vector,
-								   constnode->constvalue,
-								   predicate_result);
+			vector_nulltest(vector, nulltest->nulltesttype, predicate_result);
 		}
 		else
 		{
-			vector_const_predicate(vector, constnode->constvalue, predicate_result);
-		}
+			/*
+			 * Find the vector_const predicate.
+			 */
+			VectorPredicate *vector_const_predicate =
+				get_vector_const_predicate(vector_const_opcode);
+			Assert(vector_const_predicate != NULL);
 
-		/* Account for nulls which shouldn't pass the predicate. */
-		const size_t n = vector->length;
-		const size_t n_words = (n + 63) / 64;
-		const uint64 *restrict validity = (uint64 *restrict) vector->buffers[0];
-		for (size_t i = 0; i < n_words; i++)
-		{
-			predicate_result[i] &= validity[i];
+			Ensure(IsA(lsecond(args), Const),
+				   "failed to evaluate runtime constant in vectorized filter");
+
+			/*
+			 * The vectorizable predicates should be STRICT, so we shouldn't see null
+			 * constants here.
+			 */
+			Const *constnode = castNode(Const, lsecond(args));
+			Ensure(!constnode->constisnull, "vectorized predicate called for a null value");
+
+			/*
+			 * At last, compute the predicate.
+			 */
+			if (saop)
+			{
+				vector_array_predicate(vector_const_predicate,
+									   saop->useOr,
+									   vector,
+									   constnode->constvalue,
+									   predicate_result);
+			}
+			else
+			{
+				vector_const_predicate(vector, constnode->constvalue, predicate_result);
+			}
+
+			/* Account for nulls which shouldn't pass the predicate. */
+			const size_t n = vector->length;
+			const size_t n_words = (n + 63) / 64;
+			const uint64 *restrict validity = (uint64 *restrict) vector->buffers[0];
+			for (size_t i = 0; i < n_words; i++)
+			{
+				predicate_result[i] &= validity[i];
+			}
 		}
 
 		/* Process the result. */

--- a/tsl/src/nodes/decompress_chunk/exec.c
+++ b/tsl/src/nodes/decompress_chunk/exec.c
@@ -453,17 +453,6 @@ decompress_chunk_begin(CustomScanState *node, EState *estate, int eflags)
 			}
 		}
 
-		List *args;
-		if (IsA(constified, OpExpr))
-		{
-			args = castNode(OpExpr, constified)->args;
-		}
-		else
-		{
-			args = castNode(ScalarArrayOpExpr, constified)->args;
-		}
-		Ensure(IsA(lsecond(args), Const),
-			   "failed to evaluate runtime constant in vectorized filter");
 		dcontext->vectorized_quals_constified =
 			lappend(dcontext->vectorized_quals_constified, constified);
 	}

--- a/tsl/src/nodes/decompress_chunk/qual_pushdown.c
+++ b/tsl/src/nodes/decompress_chunk/qual_pushdown.c
@@ -360,6 +360,14 @@ modify_expression(Node *node, QualPushdownContext *context)
 		{
 			Var *var = castNode(Var, node);
 			Assert((Index) var->varno == context->chunk_rel->relid);
+
+			if (var->varattno <= 0)
+			{
+				/* Can't do this for system columns such as whole-row var. */
+				context->can_pushdown = false;
+				return NULL;
+			}
+
 			char *attname = get_attname(context->chunk_rte->relid, var->varattno, false);
 			/* we can only push down quals for segmentby columns */
 			if (!ts_array_is_member(context->settings->fd.segmentby, attname))

--- a/tsl/src/nodes/decompress_chunk/vector_predicates.c
+++ b/tsl/src/nodes/decompress_chunk/vector_predicates.c
@@ -42,3 +42,23 @@ get_vector_const_predicate(Oid pg_predicate)
 	}
 	return NULL;
 }
+
+void
+vector_nulltest(const ArrowArray *arrow, int test_type, uint64 *restrict result)
+{
+	const bool should_be_null = test_type == IS_NULL;
+
+	const uint16 bitmap_words = (arrow->length + 63) / 64;
+	const uint64 *restrict validity = (const uint64 *) arrow->buffers[0];
+	for (uint16 i = 0; i < bitmap_words; i++)
+	{
+		if (should_be_null)
+		{
+			result[i] &= ~validity[i];
+		}
+		else
+		{
+			result[i] &= validity[i];
+		}
+	}
+}

--- a/tsl/src/nodes/decompress_chunk/vector_predicates.h
+++ b/tsl/src/nodes/decompress_chunk/vector_predicates.h
@@ -15,3 +15,5 @@ VectorPredicate *get_vector_const_predicate(Oid pg_predicate);
 
 void vector_array_predicate(VectorPredicate *scalar_predicate, bool is_or, const ArrowArray *vector,
 							Datum array, uint64 *restrict result);
+
+void vector_nulltest(const ArrowArray *arrow, int test_type, uint64 *restrict result);

--- a/tsl/test/expected/decompress_vector_qual.out
+++ b/tsl/test/expected/decompress_vector_qual.out
@@ -208,8 +208,8 @@ select count(*) from vectorqual where 777 === metric3;
      2
 (1 row)
 
--- NullTest is not vectorized.
-set timescaledb.debug_require_vector_qual to 'forbid';
+-- NullTest is vectorized.
+set timescaledb.debug_require_vector_qual to 'only';
 select count(*) from vectorqual where metric4 is null;
  count 
 -------
@@ -220,6 +220,28 @@ select count(*) from vectorqual where metric4 is not null;
  count 
 -------
      2
+(1 row)
+
+-- Can't vectorize conditions on system columns. Have to check this on a single
+-- chunk, otherwise the whole-row var will be masked by ConvertRowType.
+select show_chunks('vectorqual') chunk1 limit 1 \gset
+set timescaledb.debug_require_vector_qual to 'forbid';
+select count(*) from :chunk1 t where t is null;
+ count 
+-------
+     0
+(1 row)
+
+select count(*) from :chunk1 t where t.* is null;
+ count 
+-------
+     0
+(1 row)
+
+select count(*) from :chunk1 t where tableoid is null;
+ count 
+-------
+     0
 (1 row)
 
 -- Scalar array operators are vectorized if the operator is vectorizable.
@@ -616,7 +638,7 @@ set timescaledb.debug_require_vector_qual to 'forbid';
 select count(*) from vectorqual where metric4 > 4;
 ERROR:  debug: encountered vector quals when they are disabled
 set timescaledb.debug_require_vector_qual to 'only';
-select count(*) from vectorqual where metric4 is null;
+select count(*) from vectorqual where metric3 === 4;
 ERROR:  debug: encountered non-vector quals when they are disabled
 \set ON_ERROR_STOP 1
 -- Date columns

--- a/tsl/test/shared/expected/ordered_append-13.out
+++ b/tsl/test/shared/expected/ordered_append-13.out
@@ -2571,17 +2571,17 @@ QUERY PLAN
                        Sort Key: _hyper_X_X_chunk."time" DESC
                        Sort Method: top-N heapsort 
                        ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=25190 loops=1)
-                             Filter: ("time" IS NOT NULL)
+                             Vectorized Filter: ("time" IS NOT NULL)
                              ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=30 loops=1)
                  ->  Sort (never executed)
                        Sort Key: _hyper_X_X_chunk."time" DESC
                        ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (never executed)
-                             Filter: ("time" IS NOT NULL)
+                             Vectorized Filter: ("time" IS NOT NULL)
                              ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
                  ->  Sort (never executed)
                        Sort Key: _hyper_X_X_chunk."time" DESC
                        ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (never executed)
-                             Filter: ("time" IS NOT NULL)
+                             Vectorized Filter: ("time" IS NOT NULL)
                              ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
 (21 rows)
 
@@ -2598,17 +2598,17 @@ QUERY PLAN
                        Sort Key: _hyper_X_X_chunk."time"
                        Sort Method: top-N heapsort 
                        ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=17990 loops=1)
-                             Filter: ("time" IS NOT NULL)
+                             Vectorized Filter: ("time" IS NOT NULL)
                              ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=20 loops=1)
                  ->  Sort (never executed)
                        Sort Key: _hyper_X_X_chunk."time"
                        ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (never executed)
-                             Filter: ("time" IS NOT NULL)
+                             Vectorized Filter: ("time" IS NOT NULL)
                              ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
                  ->  Sort (never executed)
                        Sort Key: _hyper_X_X_chunk."time"
                        ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (never executed)
-                             Filter: ("time" IS NOT NULL)
+                             Vectorized Filter: ("time" IS NOT NULL)
                              ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
 (21 rows)
 
@@ -2626,17 +2626,17 @@ QUERY PLAN
                        Sort Key: _hyper_X_X_chunk."time"
                        Sort Method: top-N heapsort 
                        ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=17990 loops=1)
-                             Filter: ("time" IS NOT NULL)
+                             Vectorized Filter: ("time" IS NOT NULL)
                              ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=20 loops=1)
                  ->  Sort (never executed)
                        Sort Key: _hyper_X_X_chunk."time"
                        ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (never executed)
-                             Filter: ("time" IS NOT NULL)
+                             Vectorized Filter: ("time" IS NOT NULL)
                              ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
                  ->  Sort (never executed)
                        Sort Key: _hyper_X_X_chunk."time"
                        ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (never executed)
-                             Filter: ("time" IS NOT NULL)
+                             Vectorized Filter: ("time" IS NOT NULL)
                              ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
 (21 rows)
 
@@ -2653,17 +2653,17 @@ QUERY PLAN
                        Sort Key: _hyper_X_X_chunk."time" DESC
                        Sort Method: top-N heapsort 
                        ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=25190 loops=1)
-                             Filter: ("time" IS NOT NULL)
+                             Vectorized Filter: ("time" IS NOT NULL)
                              ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=30 loops=1)
                  ->  Sort (never executed)
                        Sort Key: _hyper_X_X_chunk."time" DESC
                        ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (never executed)
-                             Filter: ("time" IS NOT NULL)
+                             Vectorized Filter: ("time" IS NOT NULL)
                              ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
                  ->  Sort (never executed)
                        Sort Key: _hyper_X_X_chunk."time" DESC
                        ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (never executed)
-                             Filter: ("time" IS NOT NULL)
+                             Vectorized Filter: ("time" IS NOT NULL)
                              ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
 (21 rows)
 
@@ -2935,17 +2935,17 @@ QUERY PLAN
                                Sort Key: _hyper_X_X_chunk_1."time" DESC
                                Sort Method: top-N heapsort 
                                ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk _hyper_X_X_chunk_1 (actual rows=25190 loops=1)
-                                     Filter: ("time" IS NOT NULL)
+                                     Vectorized Filter: ("time" IS NOT NULL)
                                      ->  Seq Scan on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (actual rows=30 loops=1)
                          ->  Sort (never executed)
                                Sort Key: _hyper_X_X_chunk_1."time" DESC
                                ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk _hyper_X_X_chunk_1 (never executed)
-                                     Filter: ("time" IS NOT NULL)
+                                     Vectorized Filter: ("time" IS NOT NULL)
                                      ->  Seq Scan on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (never executed)
                          ->  Sort (never executed)
                                Sort Key: _hyper_X_X_chunk_1."time" DESC
                                ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk _hyper_X_X_chunk_1 (never executed)
-                                     Filter: ("time" IS NOT NULL)
+                                     Vectorized Filter: ("time" IS NOT NULL)
                                      ->  Seq Scan on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (never executed)
    ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (never executed)
          Filter: ("time" = $1)
@@ -4054,53 +4054,53 @@ QUERY PLAN
                              Sort Key: _hyper_X_X_chunk."time" DESC
                              Sort Method: top-N heapsort 
                              ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=5038 loops=1)
-                                   Filter: ("time" IS NOT NULL)
+                                   Vectorized Filter: ("time" IS NOT NULL)
                                    ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=6 loops=1)
                        ->  Sort (actual rows=1 loops=1)
                              Sort Key: _hyper_X_X_chunk."time" DESC
                              Sort Method: top-N heapsort 
                              ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=15114 loops=1)
-                                   Filter: ("time" IS NOT NULL)
+                                   Vectorized Filter: ("time" IS NOT NULL)
                                    ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=18 loops=1)
                        ->  Sort (actual rows=1 loops=1)
                              Sort Key: _hyper_X_X_chunk."time" DESC
                              Sort Method: top-N heapsort 
                              ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=5038 loops=1)
-                                   Filter: ("time" IS NOT NULL)
+                                   Vectorized Filter: ("time" IS NOT NULL)
                                    ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=6 loops=1)
                  ->  Merge Append (never executed)
                        Sort Key: _hyper_X_X_chunk."time" DESC
                        ->  Sort (never executed)
                              Sort Key: _hyper_X_X_chunk."time" DESC
                              ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (never executed)
-                                   Filter: ("time" IS NOT NULL)
+                                   Vectorized Filter: ("time" IS NOT NULL)
                                    ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
                        ->  Sort (never executed)
                              Sort Key: _hyper_X_X_chunk."time" DESC
                              ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (never executed)
-                                   Filter: ("time" IS NOT NULL)
+                                   Vectorized Filter: ("time" IS NOT NULL)
                                    ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
                        ->  Sort (never executed)
                              Sort Key: _hyper_X_X_chunk."time" DESC
                              ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (never executed)
-                                   Filter: ("time" IS NOT NULL)
+                                   Vectorized Filter: ("time" IS NOT NULL)
                                    ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
                  ->  Merge Append (never executed)
                        Sort Key: _hyper_X_X_chunk."time" DESC
                        ->  Sort (never executed)
                              Sort Key: _hyper_X_X_chunk."time" DESC
                              ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (never executed)
-                                   Filter: ("time" IS NOT NULL)
+                                   Vectorized Filter: ("time" IS NOT NULL)
                                    ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
                        ->  Sort (never executed)
                              Sort Key: _hyper_X_X_chunk."time" DESC
                              ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (never executed)
-                                   Filter: ("time" IS NOT NULL)
+                                   Vectorized Filter: ("time" IS NOT NULL)
                                    ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
                        ->  Sort (never executed)
                              Sort Key: _hyper_X_X_chunk."time" DESC
                              ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (never executed)
-                                   Filter: ("time" IS NOT NULL)
+                                   Vectorized Filter: ("time" IS NOT NULL)
                                    ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
 (59 rows)
 
@@ -4119,53 +4119,53 @@ QUERY PLAN
                              Sort Key: _hyper_X_X_chunk."time"
                              Sort Method: top-N heapsort 
                              ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=3598 loops=1)
-                                   Filter: ("time" IS NOT NULL)
+                                   Vectorized Filter: ("time" IS NOT NULL)
                                    ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=4 loops=1)
                        ->  Sort (actual rows=1 loops=1)
                              Sort Key: _hyper_X_X_chunk."time"
                              Sort Method: top-N heapsort 
                              ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=10794 loops=1)
-                                   Filter: ("time" IS NOT NULL)
+                                   Vectorized Filter: ("time" IS NOT NULL)
                                    ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=12 loops=1)
                        ->  Sort (actual rows=1 loops=1)
                              Sort Key: _hyper_X_X_chunk."time"
                              Sort Method: top-N heapsort 
                              ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=3598 loops=1)
-                                   Filter: ("time" IS NOT NULL)
+                                   Vectorized Filter: ("time" IS NOT NULL)
                                    ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=4 loops=1)
                  ->  Merge Append (never executed)
                        Sort Key: _hyper_X_X_chunk."time"
                        ->  Sort (never executed)
                              Sort Key: _hyper_X_X_chunk."time"
                              ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (never executed)
-                                   Filter: ("time" IS NOT NULL)
+                                   Vectorized Filter: ("time" IS NOT NULL)
                                    ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
                        ->  Sort (never executed)
                              Sort Key: _hyper_X_X_chunk."time"
                              ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (never executed)
-                                   Filter: ("time" IS NOT NULL)
+                                   Vectorized Filter: ("time" IS NOT NULL)
                                    ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
                        ->  Sort (never executed)
                              Sort Key: _hyper_X_X_chunk."time"
                              ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (never executed)
-                                   Filter: ("time" IS NOT NULL)
+                                   Vectorized Filter: ("time" IS NOT NULL)
                                    ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
                  ->  Merge Append (never executed)
                        Sort Key: _hyper_X_X_chunk."time"
                        ->  Sort (never executed)
                              Sort Key: _hyper_X_X_chunk."time"
                              ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (never executed)
-                                   Filter: ("time" IS NOT NULL)
+                                   Vectorized Filter: ("time" IS NOT NULL)
                                    ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
                        ->  Sort (never executed)
                              Sort Key: _hyper_X_X_chunk."time"
                              ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (never executed)
-                                   Filter: ("time" IS NOT NULL)
+                                   Vectorized Filter: ("time" IS NOT NULL)
                                    ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
                        ->  Sort (never executed)
                              Sort Key: _hyper_X_X_chunk."time"
                              ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (never executed)
-                                   Filter: ("time" IS NOT NULL)
+                                   Vectorized Filter: ("time" IS NOT NULL)
                                    ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
 (59 rows)
 
@@ -4185,53 +4185,53 @@ QUERY PLAN
                              Sort Key: _hyper_X_X_chunk."time"
                              Sort Method: top-N heapsort 
                              ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=3598 loops=1)
-                                   Filter: ("time" IS NOT NULL)
+                                   Vectorized Filter: ("time" IS NOT NULL)
                                    ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=4 loops=1)
                        ->  Sort (actual rows=1 loops=1)
                              Sort Key: _hyper_X_X_chunk."time"
                              Sort Method: top-N heapsort 
                              ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=10794 loops=1)
-                                   Filter: ("time" IS NOT NULL)
+                                   Vectorized Filter: ("time" IS NOT NULL)
                                    ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=12 loops=1)
                        ->  Sort (actual rows=1 loops=1)
                              Sort Key: _hyper_X_X_chunk."time"
                              Sort Method: top-N heapsort 
                              ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=3598 loops=1)
-                                   Filter: ("time" IS NOT NULL)
+                                   Vectorized Filter: ("time" IS NOT NULL)
                                    ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=4 loops=1)
                  ->  Merge Append (never executed)
                        Sort Key: _hyper_X_X_chunk."time"
                        ->  Sort (never executed)
                              Sort Key: _hyper_X_X_chunk."time"
                              ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (never executed)
-                                   Filter: ("time" IS NOT NULL)
+                                   Vectorized Filter: ("time" IS NOT NULL)
                                    ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
                        ->  Sort (never executed)
                              Sort Key: _hyper_X_X_chunk."time"
                              ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (never executed)
-                                   Filter: ("time" IS NOT NULL)
+                                   Vectorized Filter: ("time" IS NOT NULL)
                                    ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
                        ->  Sort (never executed)
                              Sort Key: _hyper_X_X_chunk."time"
                              ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (never executed)
-                                   Filter: ("time" IS NOT NULL)
+                                   Vectorized Filter: ("time" IS NOT NULL)
                                    ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
                  ->  Merge Append (never executed)
                        Sort Key: _hyper_X_X_chunk."time"
                        ->  Sort (never executed)
                              Sort Key: _hyper_X_X_chunk."time"
                              ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (never executed)
-                                   Filter: ("time" IS NOT NULL)
+                                   Vectorized Filter: ("time" IS NOT NULL)
                                    ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
                        ->  Sort (never executed)
                              Sort Key: _hyper_X_X_chunk."time"
                              ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (never executed)
-                                   Filter: ("time" IS NOT NULL)
+                                   Vectorized Filter: ("time" IS NOT NULL)
                                    ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
                        ->  Sort (never executed)
                              Sort Key: _hyper_X_X_chunk."time"
                              ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (never executed)
-                                   Filter: ("time" IS NOT NULL)
+                                   Vectorized Filter: ("time" IS NOT NULL)
                                    ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
 (59 rows)
 
@@ -4250,53 +4250,53 @@ QUERY PLAN
                              Sort Key: _hyper_X_X_chunk."time" DESC
                              Sort Method: top-N heapsort 
                              ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=5038 loops=1)
-                                   Filter: ("time" IS NOT NULL)
+                                   Vectorized Filter: ("time" IS NOT NULL)
                                    ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=6 loops=1)
                        ->  Sort (actual rows=1 loops=1)
                              Sort Key: _hyper_X_X_chunk."time" DESC
                              Sort Method: top-N heapsort 
                              ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=15114 loops=1)
-                                   Filter: ("time" IS NOT NULL)
+                                   Vectorized Filter: ("time" IS NOT NULL)
                                    ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=18 loops=1)
                        ->  Sort (actual rows=1 loops=1)
                              Sort Key: _hyper_X_X_chunk."time" DESC
                              Sort Method: top-N heapsort 
                              ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=5038 loops=1)
-                                   Filter: ("time" IS NOT NULL)
+                                   Vectorized Filter: ("time" IS NOT NULL)
                                    ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=6 loops=1)
                  ->  Merge Append (never executed)
                        Sort Key: _hyper_X_X_chunk."time" DESC
                        ->  Sort (never executed)
                              Sort Key: _hyper_X_X_chunk."time" DESC
                              ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (never executed)
-                                   Filter: ("time" IS NOT NULL)
+                                   Vectorized Filter: ("time" IS NOT NULL)
                                    ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
                        ->  Sort (never executed)
                              Sort Key: _hyper_X_X_chunk."time" DESC
                              ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (never executed)
-                                   Filter: ("time" IS NOT NULL)
+                                   Vectorized Filter: ("time" IS NOT NULL)
                                    ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
                        ->  Sort (never executed)
                              Sort Key: _hyper_X_X_chunk."time" DESC
                              ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (never executed)
-                                   Filter: ("time" IS NOT NULL)
+                                   Vectorized Filter: ("time" IS NOT NULL)
                                    ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
                  ->  Merge Append (never executed)
                        Sort Key: _hyper_X_X_chunk."time" DESC
                        ->  Sort (never executed)
                              Sort Key: _hyper_X_X_chunk."time" DESC
                              ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (never executed)
-                                   Filter: ("time" IS NOT NULL)
+                                   Vectorized Filter: ("time" IS NOT NULL)
                                    ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
                        ->  Sort (never executed)
                              Sort Key: _hyper_X_X_chunk."time" DESC
                              ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (never executed)
-                                   Filter: ("time" IS NOT NULL)
+                                   Vectorized Filter: ("time" IS NOT NULL)
                                    ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
                        ->  Sort (never executed)
                              Sort Key: _hyper_X_X_chunk."time" DESC
                              ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (never executed)
-                                   Filter: ("time" IS NOT NULL)
+                                   Vectorized Filter: ("time" IS NOT NULL)
                                    ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
 (59 rows)
 
@@ -4729,53 +4729,53 @@ QUERY PLAN
                                      Sort Key: _hyper_X_X_chunk_1."time" DESC
                                      Sort Method: top-N heapsort 
                                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk _hyper_X_X_chunk_1 (actual rows=5038 loops=1)
-                                           Filter: ("time" IS NOT NULL)
+                                           Vectorized Filter: ("time" IS NOT NULL)
                                            ->  Seq Scan on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (actual rows=6 loops=1)
                                ->  Sort (actual rows=1 loops=1)
                                      Sort Key: _hyper_X_X_chunk_1."time" DESC
                                      Sort Method: top-N heapsort 
                                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk _hyper_X_X_chunk_1 (actual rows=15114 loops=1)
-                                           Filter: ("time" IS NOT NULL)
+                                           Vectorized Filter: ("time" IS NOT NULL)
                                            ->  Seq Scan on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (actual rows=18 loops=1)
                                ->  Sort (actual rows=1 loops=1)
                                      Sort Key: _hyper_X_X_chunk_1."time" DESC
                                      Sort Method: top-N heapsort 
                                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk _hyper_X_X_chunk_1 (actual rows=5038 loops=1)
-                                           Filter: ("time" IS NOT NULL)
+                                           Vectorized Filter: ("time" IS NOT NULL)
                                            ->  Seq Scan on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (actual rows=6 loops=1)
                          ->  Merge Append (never executed)
                                Sort Key: _hyper_X_X_chunk_1."time" DESC
                                ->  Sort (never executed)
                                      Sort Key: _hyper_X_X_chunk_1."time" DESC
                                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk _hyper_X_X_chunk_1 (never executed)
-                                           Filter: ("time" IS NOT NULL)
+                                           Vectorized Filter: ("time" IS NOT NULL)
                                            ->  Seq Scan on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (never executed)
                                ->  Sort (never executed)
                                      Sort Key: _hyper_X_X_chunk_1."time" DESC
                                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk _hyper_X_X_chunk_1 (never executed)
-                                           Filter: ("time" IS NOT NULL)
+                                           Vectorized Filter: ("time" IS NOT NULL)
                                            ->  Seq Scan on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (never executed)
                                ->  Sort (never executed)
                                      Sort Key: _hyper_X_X_chunk_1."time" DESC
                                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk _hyper_X_X_chunk_1 (never executed)
-                                           Filter: ("time" IS NOT NULL)
+                                           Vectorized Filter: ("time" IS NOT NULL)
                                            ->  Seq Scan on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (never executed)
                          ->  Merge Append (never executed)
                                Sort Key: _hyper_X_X_chunk_1."time" DESC
                                ->  Sort (never executed)
                                      Sort Key: _hyper_X_X_chunk_1."time" DESC
                                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk _hyper_X_X_chunk_1 (never executed)
-                                           Filter: ("time" IS NOT NULL)
+                                           Vectorized Filter: ("time" IS NOT NULL)
                                            ->  Seq Scan on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (never executed)
                                ->  Sort (never executed)
                                      Sort Key: _hyper_X_X_chunk_1."time" DESC
                                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk _hyper_X_X_chunk_1 (never executed)
-                                           Filter: ("time" IS NOT NULL)
+                                           Vectorized Filter: ("time" IS NOT NULL)
                                            ->  Seq Scan on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (never executed)
                                ->  Sort (never executed)
                                      Sort Key: _hyper_X_X_chunk_1."time" DESC
                                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk _hyper_X_X_chunk_1 (never executed)
-                                           Filter: ("time" IS NOT NULL)
+                                           Vectorized Filter: ("time" IS NOT NULL)
                                            ->  Seq Scan on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (never executed)
    ->  Merge Append (actual rows=0 loops=1)
          ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=0 loops=1)

--- a/tsl/test/shared/expected/ordered_append-14.out
+++ b/tsl/test/shared/expected/ordered_append-14.out
@@ -2571,17 +2571,17 @@ QUERY PLAN
                        Sort Key: _hyper_X_X_chunk."time" DESC
                        Sort Method: top-N heapsort 
                        ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=25190 loops=1)
-                             Filter: ("time" IS NOT NULL)
+                             Vectorized Filter: ("time" IS NOT NULL)
                              ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=30 loops=1)
                  ->  Sort (never executed)
                        Sort Key: _hyper_X_X_chunk."time" DESC
                        ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (never executed)
-                             Filter: ("time" IS NOT NULL)
+                             Vectorized Filter: ("time" IS NOT NULL)
                              ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
                  ->  Sort (never executed)
                        Sort Key: _hyper_X_X_chunk."time" DESC
                        ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (never executed)
-                             Filter: ("time" IS NOT NULL)
+                             Vectorized Filter: ("time" IS NOT NULL)
                              ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
 (21 rows)
 
@@ -2598,17 +2598,17 @@ QUERY PLAN
                        Sort Key: _hyper_X_X_chunk."time"
                        Sort Method: top-N heapsort 
                        ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=17990 loops=1)
-                             Filter: ("time" IS NOT NULL)
+                             Vectorized Filter: ("time" IS NOT NULL)
                              ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=20 loops=1)
                  ->  Sort (never executed)
                        Sort Key: _hyper_X_X_chunk."time"
                        ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (never executed)
-                             Filter: ("time" IS NOT NULL)
+                             Vectorized Filter: ("time" IS NOT NULL)
                              ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
                  ->  Sort (never executed)
                        Sort Key: _hyper_X_X_chunk."time"
                        ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (never executed)
-                             Filter: ("time" IS NOT NULL)
+                             Vectorized Filter: ("time" IS NOT NULL)
                              ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
 (21 rows)
 
@@ -2626,17 +2626,17 @@ QUERY PLAN
                        Sort Key: _hyper_X_X_chunk."time"
                        Sort Method: top-N heapsort 
                        ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=17990 loops=1)
-                             Filter: ("time" IS NOT NULL)
+                             Vectorized Filter: ("time" IS NOT NULL)
                              ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=20 loops=1)
                  ->  Sort (never executed)
                        Sort Key: _hyper_X_X_chunk."time"
                        ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (never executed)
-                             Filter: ("time" IS NOT NULL)
+                             Vectorized Filter: ("time" IS NOT NULL)
                              ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
                  ->  Sort (never executed)
                        Sort Key: _hyper_X_X_chunk."time"
                        ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (never executed)
-                             Filter: ("time" IS NOT NULL)
+                             Vectorized Filter: ("time" IS NOT NULL)
                              ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
 (21 rows)
 
@@ -2653,17 +2653,17 @@ QUERY PLAN
                        Sort Key: _hyper_X_X_chunk."time" DESC
                        Sort Method: top-N heapsort 
                        ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=25190 loops=1)
-                             Filter: ("time" IS NOT NULL)
+                             Vectorized Filter: ("time" IS NOT NULL)
                              ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=30 loops=1)
                  ->  Sort (never executed)
                        Sort Key: _hyper_X_X_chunk."time" DESC
                        ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (never executed)
-                             Filter: ("time" IS NOT NULL)
+                             Vectorized Filter: ("time" IS NOT NULL)
                              ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
                  ->  Sort (never executed)
                        Sort Key: _hyper_X_X_chunk."time" DESC
                        ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (never executed)
-                             Filter: ("time" IS NOT NULL)
+                             Vectorized Filter: ("time" IS NOT NULL)
                              ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
 (21 rows)
 
@@ -2935,17 +2935,17 @@ QUERY PLAN
                                Sort Key: _hyper_X_X_chunk_1."time" DESC
                                Sort Method: top-N heapsort 
                                ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk _hyper_X_X_chunk_1 (actual rows=25190 loops=1)
-                                     Filter: ("time" IS NOT NULL)
+                                     Vectorized Filter: ("time" IS NOT NULL)
                                      ->  Seq Scan on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (actual rows=30 loops=1)
                          ->  Sort (never executed)
                                Sort Key: _hyper_X_X_chunk_1."time" DESC
                                ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk _hyper_X_X_chunk_1 (never executed)
-                                     Filter: ("time" IS NOT NULL)
+                                     Vectorized Filter: ("time" IS NOT NULL)
                                      ->  Seq Scan on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (never executed)
                          ->  Sort (never executed)
                                Sort Key: _hyper_X_X_chunk_1."time" DESC
                                ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk _hyper_X_X_chunk_1 (never executed)
-                                     Filter: ("time" IS NOT NULL)
+                                     Vectorized Filter: ("time" IS NOT NULL)
                                      ->  Seq Scan on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (never executed)
    ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (never executed)
          Filter: ("time" = $1)
@@ -4054,53 +4054,53 @@ QUERY PLAN
                              Sort Key: _hyper_X_X_chunk."time" DESC
                              Sort Method: top-N heapsort 
                              ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=5038 loops=1)
-                                   Filter: ("time" IS NOT NULL)
+                                   Vectorized Filter: ("time" IS NOT NULL)
                                    ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=6 loops=1)
                        ->  Sort (actual rows=1 loops=1)
                              Sort Key: _hyper_X_X_chunk."time" DESC
                              Sort Method: top-N heapsort 
                              ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=15114 loops=1)
-                                   Filter: ("time" IS NOT NULL)
+                                   Vectorized Filter: ("time" IS NOT NULL)
                                    ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=18 loops=1)
                        ->  Sort (actual rows=1 loops=1)
                              Sort Key: _hyper_X_X_chunk."time" DESC
                              Sort Method: top-N heapsort 
                              ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=5038 loops=1)
-                                   Filter: ("time" IS NOT NULL)
+                                   Vectorized Filter: ("time" IS NOT NULL)
                                    ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=6 loops=1)
                  ->  Merge Append (never executed)
                        Sort Key: _hyper_X_X_chunk."time" DESC
                        ->  Sort (never executed)
                              Sort Key: _hyper_X_X_chunk."time" DESC
                              ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (never executed)
-                                   Filter: ("time" IS NOT NULL)
+                                   Vectorized Filter: ("time" IS NOT NULL)
                                    ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
                        ->  Sort (never executed)
                              Sort Key: _hyper_X_X_chunk."time" DESC
                              ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (never executed)
-                                   Filter: ("time" IS NOT NULL)
+                                   Vectorized Filter: ("time" IS NOT NULL)
                                    ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
                        ->  Sort (never executed)
                              Sort Key: _hyper_X_X_chunk."time" DESC
                              ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (never executed)
-                                   Filter: ("time" IS NOT NULL)
+                                   Vectorized Filter: ("time" IS NOT NULL)
                                    ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
                  ->  Merge Append (never executed)
                        Sort Key: _hyper_X_X_chunk."time" DESC
                        ->  Sort (never executed)
                              Sort Key: _hyper_X_X_chunk."time" DESC
                              ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (never executed)
-                                   Filter: ("time" IS NOT NULL)
+                                   Vectorized Filter: ("time" IS NOT NULL)
                                    ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
                        ->  Sort (never executed)
                              Sort Key: _hyper_X_X_chunk."time" DESC
                              ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (never executed)
-                                   Filter: ("time" IS NOT NULL)
+                                   Vectorized Filter: ("time" IS NOT NULL)
                                    ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
                        ->  Sort (never executed)
                              Sort Key: _hyper_X_X_chunk."time" DESC
                              ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (never executed)
-                                   Filter: ("time" IS NOT NULL)
+                                   Vectorized Filter: ("time" IS NOT NULL)
                                    ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
 (59 rows)
 
@@ -4119,53 +4119,53 @@ QUERY PLAN
                              Sort Key: _hyper_X_X_chunk."time"
                              Sort Method: top-N heapsort 
                              ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=3598 loops=1)
-                                   Filter: ("time" IS NOT NULL)
+                                   Vectorized Filter: ("time" IS NOT NULL)
                                    ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=4 loops=1)
                        ->  Sort (actual rows=1 loops=1)
                              Sort Key: _hyper_X_X_chunk."time"
                              Sort Method: top-N heapsort 
                              ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=10794 loops=1)
-                                   Filter: ("time" IS NOT NULL)
+                                   Vectorized Filter: ("time" IS NOT NULL)
                                    ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=12 loops=1)
                        ->  Sort (actual rows=1 loops=1)
                              Sort Key: _hyper_X_X_chunk."time"
                              Sort Method: top-N heapsort 
                              ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=3598 loops=1)
-                                   Filter: ("time" IS NOT NULL)
+                                   Vectorized Filter: ("time" IS NOT NULL)
                                    ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=4 loops=1)
                  ->  Merge Append (never executed)
                        Sort Key: _hyper_X_X_chunk."time"
                        ->  Sort (never executed)
                              Sort Key: _hyper_X_X_chunk."time"
                              ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (never executed)
-                                   Filter: ("time" IS NOT NULL)
+                                   Vectorized Filter: ("time" IS NOT NULL)
                                    ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
                        ->  Sort (never executed)
                              Sort Key: _hyper_X_X_chunk."time"
                              ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (never executed)
-                                   Filter: ("time" IS NOT NULL)
+                                   Vectorized Filter: ("time" IS NOT NULL)
                                    ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
                        ->  Sort (never executed)
                              Sort Key: _hyper_X_X_chunk."time"
                              ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (never executed)
-                                   Filter: ("time" IS NOT NULL)
+                                   Vectorized Filter: ("time" IS NOT NULL)
                                    ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
                  ->  Merge Append (never executed)
                        Sort Key: _hyper_X_X_chunk."time"
                        ->  Sort (never executed)
                              Sort Key: _hyper_X_X_chunk."time"
                              ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (never executed)
-                                   Filter: ("time" IS NOT NULL)
+                                   Vectorized Filter: ("time" IS NOT NULL)
                                    ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
                        ->  Sort (never executed)
                              Sort Key: _hyper_X_X_chunk."time"
                              ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (never executed)
-                                   Filter: ("time" IS NOT NULL)
+                                   Vectorized Filter: ("time" IS NOT NULL)
                                    ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
                        ->  Sort (never executed)
                              Sort Key: _hyper_X_X_chunk."time"
                              ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (never executed)
-                                   Filter: ("time" IS NOT NULL)
+                                   Vectorized Filter: ("time" IS NOT NULL)
                                    ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
 (59 rows)
 
@@ -4185,53 +4185,53 @@ QUERY PLAN
                              Sort Key: _hyper_X_X_chunk."time"
                              Sort Method: top-N heapsort 
                              ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=3598 loops=1)
-                                   Filter: ("time" IS NOT NULL)
+                                   Vectorized Filter: ("time" IS NOT NULL)
                                    ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=4 loops=1)
                        ->  Sort (actual rows=1 loops=1)
                              Sort Key: _hyper_X_X_chunk."time"
                              Sort Method: top-N heapsort 
                              ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=10794 loops=1)
-                                   Filter: ("time" IS NOT NULL)
+                                   Vectorized Filter: ("time" IS NOT NULL)
                                    ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=12 loops=1)
                        ->  Sort (actual rows=1 loops=1)
                              Sort Key: _hyper_X_X_chunk."time"
                              Sort Method: top-N heapsort 
                              ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=3598 loops=1)
-                                   Filter: ("time" IS NOT NULL)
+                                   Vectorized Filter: ("time" IS NOT NULL)
                                    ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=4 loops=1)
                  ->  Merge Append (never executed)
                        Sort Key: _hyper_X_X_chunk."time"
                        ->  Sort (never executed)
                              Sort Key: _hyper_X_X_chunk."time"
                              ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (never executed)
-                                   Filter: ("time" IS NOT NULL)
+                                   Vectorized Filter: ("time" IS NOT NULL)
                                    ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
                        ->  Sort (never executed)
                              Sort Key: _hyper_X_X_chunk."time"
                              ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (never executed)
-                                   Filter: ("time" IS NOT NULL)
+                                   Vectorized Filter: ("time" IS NOT NULL)
                                    ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
                        ->  Sort (never executed)
                              Sort Key: _hyper_X_X_chunk."time"
                              ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (never executed)
-                                   Filter: ("time" IS NOT NULL)
+                                   Vectorized Filter: ("time" IS NOT NULL)
                                    ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
                  ->  Merge Append (never executed)
                        Sort Key: _hyper_X_X_chunk."time"
                        ->  Sort (never executed)
                              Sort Key: _hyper_X_X_chunk."time"
                              ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (never executed)
-                                   Filter: ("time" IS NOT NULL)
+                                   Vectorized Filter: ("time" IS NOT NULL)
                                    ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
                        ->  Sort (never executed)
                              Sort Key: _hyper_X_X_chunk."time"
                              ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (never executed)
-                                   Filter: ("time" IS NOT NULL)
+                                   Vectorized Filter: ("time" IS NOT NULL)
                                    ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
                        ->  Sort (never executed)
                              Sort Key: _hyper_X_X_chunk."time"
                              ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (never executed)
-                                   Filter: ("time" IS NOT NULL)
+                                   Vectorized Filter: ("time" IS NOT NULL)
                                    ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
 (59 rows)
 
@@ -4250,53 +4250,53 @@ QUERY PLAN
                              Sort Key: _hyper_X_X_chunk."time" DESC
                              Sort Method: top-N heapsort 
                              ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=5038 loops=1)
-                                   Filter: ("time" IS NOT NULL)
+                                   Vectorized Filter: ("time" IS NOT NULL)
                                    ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=6 loops=1)
                        ->  Sort (actual rows=1 loops=1)
                              Sort Key: _hyper_X_X_chunk."time" DESC
                              Sort Method: top-N heapsort 
                              ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=15114 loops=1)
-                                   Filter: ("time" IS NOT NULL)
+                                   Vectorized Filter: ("time" IS NOT NULL)
                                    ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=18 loops=1)
                        ->  Sort (actual rows=1 loops=1)
                              Sort Key: _hyper_X_X_chunk."time" DESC
                              Sort Method: top-N heapsort 
                              ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=5038 loops=1)
-                                   Filter: ("time" IS NOT NULL)
+                                   Vectorized Filter: ("time" IS NOT NULL)
                                    ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=6 loops=1)
                  ->  Merge Append (never executed)
                        Sort Key: _hyper_X_X_chunk."time" DESC
                        ->  Sort (never executed)
                              Sort Key: _hyper_X_X_chunk."time" DESC
                              ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (never executed)
-                                   Filter: ("time" IS NOT NULL)
+                                   Vectorized Filter: ("time" IS NOT NULL)
                                    ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
                        ->  Sort (never executed)
                              Sort Key: _hyper_X_X_chunk."time" DESC
                              ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (never executed)
-                                   Filter: ("time" IS NOT NULL)
+                                   Vectorized Filter: ("time" IS NOT NULL)
                                    ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
                        ->  Sort (never executed)
                              Sort Key: _hyper_X_X_chunk."time" DESC
                              ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (never executed)
-                                   Filter: ("time" IS NOT NULL)
+                                   Vectorized Filter: ("time" IS NOT NULL)
                                    ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
                  ->  Merge Append (never executed)
                        Sort Key: _hyper_X_X_chunk."time" DESC
                        ->  Sort (never executed)
                              Sort Key: _hyper_X_X_chunk."time" DESC
                              ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (never executed)
-                                   Filter: ("time" IS NOT NULL)
+                                   Vectorized Filter: ("time" IS NOT NULL)
                                    ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
                        ->  Sort (never executed)
                              Sort Key: _hyper_X_X_chunk."time" DESC
                              ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (never executed)
-                                   Filter: ("time" IS NOT NULL)
+                                   Vectorized Filter: ("time" IS NOT NULL)
                                    ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
                        ->  Sort (never executed)
                              Sort Key: _hyper_X_X_chunk."time" DESC
                              ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (never executed)
-                                   Filter: ("time" IS NOT NULL)
+                                   Vectorized Filter: ("time" IS NOT NULL)
                                    ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
 (59 rows)
 
@@ -4729,53 +4729,53 @@ QUERY PLAN
                                      Sort Key: _hyper_X_X_chunk_1."time" DESC
                                      Sort Method: top-N heapsort 
                                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk _hyper_X_X_chunk_1 (actual rows=5038 loops=1)
-                                           Filter: ("time" IS NOT NULL)
+                                           Vectorized Filter: ("time" IS NOT NULL)
                                            ->  Seq Scan on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (actual rows=6 loops=1)
                                ->  Sort (actual rows=1 loops=1)
                                      Sort Key: _hyper_X_X_chunk_1."time" DESC
                                      Sort Method: top-N heapsort 
                                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk _hyper_X_X_chunk_1 (actual rows=15114 loops=1)
-                                           Filter: ("time" IS NOT NULL)
+                                           Vectorized Filter: ("time" IS NOT NULL)
                                            ->  Seq Scan on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (actual rows=18 loops=1)
                                ->  Sort (actual rows=1 loops=1)
                                      Sort Key: _hyper_X_X_chunk_1."time" DESC
                                      Sort Method: top-N heapsort 
                                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk _hyper_X_X_chunk_1 (actual rows=5038 loops=1)
-                                           Filter: ("time" IS NOT NULL)
+                                           Vectorized Filter: ("time" IS NOT NULL)
                                            ->  Seq Scan on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (actual rows=6 loops=1)
                          ->  Merge Append (never executed)
                                Sort Key: _hyper_X_X_chunk_1."time" DESC
                                ->  Sort (never executed)
                                      Sort Key: _hyper_X_X_chunk_1."time" DESC
                                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk _hyper_X_X_chunk_1 (never executed)
-                                           Filter: ("time" IS NOT NULL)
+                                           Vectorized Filter: ("time" IS NOT NULL)
                                            ->  Seq Scan on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (never executed)
                                ->  Sort (never executed)
                                      Sort Key: _hyper_X_X_chunk_1."time" DESC
                                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk _hyper_X_X_chunk_1 (never executed)
-                                           Filter: ("time" IS NOT NULL)
+                                           Vectorized Filter: ("time" IS NOT NULL)
                                            ->  Seq Scan on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (never executed)
                                ->  Sort (never executed)
                                      Sort Key: _hyper_X_X_chunk_1."time" DESC
                                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk _hyper_X_X_chunk_1 (never executed)
-                                           Filter: ("time" IS NOT NULL)
+                                           Vectorized Filter: ("time" IS NOT NULL)
                                            ->  Seq Scan on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (never executed)
                          ->  Merge Append (never executed)
                                Sort Key: _hyper_X_X_chunk_1."time" DESC
                                ->  Sort (never executed)
                                      Sort Key: _hyper_X_X_chunk_1."time" DESC
                                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk _hyper_X_X_chunk_1 (never executed)
-                                           Filter: ("time" IS NOT NULL)
+                                           Vectorized Filter: ("time" IS NOT NULL)
                                            ->  Seq Scan on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (never executed)
                                ->  Sort (never executed)
                                      Sort Key: _hyper_X_X_chunk_1."time" DESC
                                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk _hyper_X_X_chunk_1 (never executed)
-                                           Filter: ("time" IS NOT NULL)
+                                           Vectorized Filter: ("time" IS NOT NULL)
                                            ->  Seq Scan on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (never executed)
                                ->  Sort (never executed)
                                      Sort Key: _hyper_X_X_chunk_1."time" DESC
                                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk _hyper_X_X_chunk_1 (never executed)
-                                           Filter: ("time" IS NOT NULL)
+                                           Vectorized Filter: ("time" IS NOT NULL)
                                            ->  Seq Scan on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (never executed)
    ->  Merge Append (actual rows=0 loops=1)
          ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=0 loops=1)

--- a/tsl/test/shared/expected/ordered_append-15.out
+++ b/tsl/test/shared/expected/ordered_append-15.out
@@ -2592,17 +2592,17 @@ QUERY PLAN
                        Sort Key: _hyper_X_X_chunk."time" DESC
                        Sort Method: top-N heapsort 
                        ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=25190 loops=1)
-                             Filter: ("time" IS NOT NULL)
+                             Vectorized Filter: ("time" IS NOT NULL)
                              ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=30 loops=1)
                  ->  Sort (never executed)
                        Sort Key: _hyper_X_X_chunk."time" DESC
                        ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (never executed)
-                             Filter: ("time" IS NOT NULL)
+                             Vectorized Filter: ("time" IS NOT NULL)
                              ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
                  ->  Sort (never executed)
                        Sort Key: _hyper_X_X_chunk."time" DESC
                        ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (never executed)
-                             Filter: ("time" IS NOT NULL)
+                             Vectorized Filter: ("time" IS NOT NULL)
                              ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
 (21 rows)
 
@@ -2619,17 +2619,17 @@ QUERY PLAN
                        Sort Key: _hyper_X_X_chunk."time"
                        Sort Method: top-N heapsort 
                        ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=17990 loops=1)
-                             Filter: ("time" IS NOT NULL)
+                             Vectorized Filter: ("time" IS NOT NULL)
                              ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=20 loops=1)
                  ->  Sort (never executed)
                        Sort Key: _hyper_X_X_chunk."time"
                        ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (never executed)
-                             Filter: ("time" IS NOT NULL)
+                             Vectorized Filter: ("time" IS NOT NULL)
                              ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
                  ->  Sort (never executed)
                        Sort Key: _hyper_X_X_chunk."time"
                        ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (never executed)
-                             Filter: ("time" IS NOT NULL)
+                             Vectorized Filter: ("time" IS NOT NULL)
                              ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
 (21 rows)
 
@@ -2648,17 +2648,17 @@ QUERY PLAN
                              Sort Key: _hyper_X_X_chunk."time"
                              Sort Method: top-N heapsort 
                              ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=17990 loops=1)
-                                   Filter: ("time" IS NOT NULL)
+                                   Vectorized Filter: ("time" IS NOT NULL)
                                    ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=20 loops=1)
                        ->  Sort (never executed)
                              Sort Key: _hyper_X_X_chunk."time"
                              ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (never executed)
-                                   Filter: ("time" IS NOT NULL)
+                                   Vectorized Filter: ("time" IS NOT NULL)
                                    ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
                        ->  Sort (never executed)
                              Sort Key: _hyper_X_X_chunk."time"
                              ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (never executed)
-                                   Filter: ("time" IS NOT NULL)
+                                   Vectorized Filter: ("time" IS NOT NULL)
                                    ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
 (22 rows)
 
@@ -2676,17 +2676,17 @@ QUERY PLAN
                              Sort Key: _hyper_X_X_chunk."time" DESC
                              Sort Method: top-N heapsort 
                              ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=25190 loops=1)
-                                   Filter: ("time" IS NOT NULL)
+                                   Vectorized Filter: ("time" IS NOT NULL)
                                    ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=30 loops=1)
                        ->  Sort (never executed)
                              Sort Key: _hyper_X_X_chunk."time" DESC
                              ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (never executed)
-                                   Filter: ("time" IS NOT NULL)
+                                   Vectorized Filter: ("time" IS NOT NULL)
                                    ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
                        ->  Sort (never executed)
                              Sort Key: _hyper_X_X_chunk."time" DESC
                              ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (never executed)
-                                   Filter: ("time" IS NOT NULL)
+                                   Vectorized Filter: ("time" IS NOT NULL)
                                    ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
 (22 rows)
 
@@ -2959,17 +2959,17 @@ QUERY PLAN
                                Sort Key: _hyper_X_X_chunk_1."time" DESC
                                Sort Method: top-N heapsort 
                                ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk _hyper_X_X_chunk_1 (actual rows=25190 loops=1)
-                                     Filter: ("time" IS NOT NULL)
+                                     Vectorized Filter: ("time" IS NOT NULL)
                                      ->  Seq Scan on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (actual rows=30 loops=1)
                          ->  Sort (never executed)
                                Sort Key: _hyper_X_X_chunk_1."time" DESC
                                ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk _hyper_X_X_chunk_1 (never executed)
-                                     Filter: ("time" IS NOT NULL)
+                                     Vectorized Filter: ("time" IS NOT NULL)
                                      ->  Seq Scan on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (never executed)
                          ->  Sort (never executed)
                                Sort Key: _hyper_X_X_chunk_1."time" DESC
                                ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk _hyper_X_X_chunk_1 (never executed)
-                                     Filter: ("time" IS NOT NULL)
+                                     Vectorized Filter: ("time" IS NOT NULL)
                                      ->  Seq Scan on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (never executed)
    ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (never executed)
          Filter: ("time" = $1)
@@ -4081,53 +4081,53 @@ QUERY PLAN
                              Sort Key: _hyper_X_X_chunk."time" DESC
                              Sort Method: top-N heapsort 
                              ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=5038 loops=1)
-                                   Filter: ("time" IS NOT NULL)
+                                   Vectorized Filter: ("time" IS NOT NULL)
                                    ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=6 loops=1)
                        ->  Sort (actual rows=1 loops=1)
                              Sort Key: _hyper_X_X_chunk."time" DESC
                              Sort Method: top-N heapsort 
                              ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=15114 loops=1)
-                                   Filter: ("time" IS NOT NULL)
+                                   Vectorized Filter: ("time" IS NOT NULL)
                                    ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=18 loops=1)
                        ->  Sort (actual rows=1 loops=1)
                              Sort Key: _hyper_X_X_chunk."time" DESC
                              Sort Method: top-N heapsort 
                              ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=5038 loops=1)
-                                   Filter: ("time" IS NOT NULL)
+                                   Vectorized Filter: ("time" IS NOT NULL)
                                    ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=6 loops=1)
                  ->  Merge Append (never executed)
                        Sort Key: _hyper_X_X_chunk."time" DESC
                        ->  Sort (never executed)
                              Sort Key: _hyper_X_X_chunk."time" DESC
                              ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (never executed)
-                                   Filter: ("time" IS NOT NULL)
+                                   Vectorized Filter: ("time" IS NOT NULL)
                                    ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
                        ->  Sort (never executed)
                              Sort Key: _hyper_X_X_chunk."time" DESC
                              ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (never executed)
-                                   Filter: ("time" IS NOT NULL)
+                                   Vectorized Filter: ("time" IS NOT NULL)
                                    ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
                        ->  Sort (never executed)
                              Sort Key: _hyper_X_X_chunk."time" DESC
                              ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (never executed)
-                                   Filter: ("time" IS NOT NULL)
+                                   Vectorized Filter: ("time" IS NOT NULL)
                                    ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
                  ->  Merge Append (never executed)
                        Sort Key: _hyper_X_X_chunk."time" DESC
                        ->  Sort (never executed)
                              Sort Key: _hyper_X_X_chunk."time" DESC
                              ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (never executed)
-                                   Filter: ("time" IS NOT NULL)
+                                   Vectorized Filter: ("time" IS NOT NULL)
                                    ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
                        ->  Sort (never executed)
                              Sort Key: _hyper_X_X_chunk."time" DESC
                              ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (never executed)
-                                   Filter: ("time" IS NOT NULL)
+                                   Vectorized Filter: ("time" IS NOT NULL)
                                    ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
                        ->  Sort (never executed)
                              Sort Key: _hyper_X_X_chunk."time" DESC
                              ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (never executed)
-                                   Filter: ("time" IS NOT NULL)
+                                   Vectorized Filter: ("time" IS NOT NULL)
                                    ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
 (59 rows)
 
@@ -4146,53 +4146,53 @@ QUERY PLAN
                              Sort Key: _hyper_X_X_chunk."time"
                              Sort Method: top-N heapsort 
                              ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=3598 loops=1)
-                                   Filter: ("time" IS NOT NULL)
+                                   Vectorized Filter: ("time" IS NOT NULL)
                                    ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=4 loops=1)
                        ->  Sort (actual rows=1 loops=1)
                              Sort Key: _hyper_X_X_chunk."time"
                              Sort Method: top-N heapsort 
                              ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=10794 loops=1)
-                                   Filter: ("time" IS NOT NULL)
+                                   Vectorized Filter: ("time" IS NOT NULL)
                                    ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=12 loops=1)
                        ->  Sort (actual rows=1 loops=1)
                              Sort Key: _hyper_X_X_chunk."time"
                              Sort Method: top-N heapsort 
                              ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=3598 loops=1)
-                                   Filter: ("time" IS NOT NULL)
+                                   Vectorized Filter: ("time" IS NOT NULL)
                                    ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=4 loops=1)
                  ->  Merge Append (never executed)
                        Sort Key: _hyper_X_X_chunk."time"
                        ->  Sort (never executed)
                              Sort Key: _hyper_X_X_chunk."time"
                              ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (never executed)
-                                   Filter: ("time" IS NOT NULL)
+                                   Vectorized Filter: ("time" IS NOT NULL)
                                    ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
                        ->  Sort (never executed)
                              Sort Key: _hyper_X_X_chunk."time"
                              ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (never executed)
-                                   Filter: ("time" IS NOT NULL)
+                                   Vectorized Filter: ("time" IS NOT NULL)
                                    ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
                        ->  Sort (never executed)
                              Sort Key: _hyper_X_X_chunk."time"
                              ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (never executed)
-                                   Filter: ("time" IS NOT NULL)
+                                   Vectorized Filter: ("time" IS NOT NULL)
                                    ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
                  ->  Merge Append (never executed)
                        Sort Key: _hyper_X_X_chunk."time"
                        ->  Sort (never executed)
                              Sort Key: _hyper_X_X_chunk."time"
                              ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (never executed)
-                                   Filter: ("time" IS NOT NULL)
+                                   Vectorized Filter: ("time" IS NOT NULL)
                                    ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
                        ->  Sort (never executed)
                              Sort Key: _hyper_X_X_chunk."time"
                              ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (never executed)
-                                   Filter: ("time" IS NOT NULL)
+                                   Vectorized Filter: ("time" IS NOT NULL)
                                    ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
                        ->  Sort (never executed)
                              Sort Key: _hyper_X_X_chunk."time"
                              ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (never executed)
-                                   Filter: ("time" IS NOT NULL)
+                                   Vectorized Filter: ("time" IS NOT NULL)
                                    ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
 (59 rows)
 
@@ -4213,53 +4213,53 @@ QUERY PLAN
                                    Sort Key: _hyper_X_X_chunk."time"
                                    Sort Method: top-N heapsort 
                                    ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=3598 loops=1)
-                                         Filter: ("time" IS NOT NULL)
+                                         Vectorized Filter: ("time" IS NOT NULL)
                                          ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=4 loops=1)
                              ->  Sort (actual rows=1 loops=1)
                                    Sort Key: _hyper_X_X_chunk."time"
                                    Sort Method: top-N heapsort 
                                    ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=10794 loops=1)
-                                         Filter: ("time" IS NOT NULL)
+                                         Vectorized Filter: ("time" IS NOT NULL)
                                          ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=12 loops=1)
                              ->  Sort (actual rows=1 loops=1)
                                    Sort Key: _hyper_X_X_chunk."time"
                                    Sort Method: top-N heapsort 
                                    ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=3598 loops=1)
-                                         Filter: ("time" IS NOT NULL)
+                                         Vectorized Filter: ("time" IS NOT NULL)
                                          ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=4 loops=1)
                        ->  Merge Append (never executed)
                              Sort Key: _hyper_X_X_chunk."time"
                              ->  Sort (never executed)
                                    Sort Key: _hyper_X_X_chunk."time"
                                    ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (never executed)
-                                         Filter: ("time" IS NOT NULL)
+                                         Vectorized Filter: ("time" IS NOT NULL)
                                          ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
                              ->  Sort (never executed)
                                    Sort Key: _hyper_X_X_chunk."time"
                                    ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (never executed)
-                                         Filter: ("time" IS NOT NULL)
+                                         Vectorized Filter: ("time" IS NOT NULL)
                                          ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
                              ->  Sort (never executed)
                                    Sort Key: _hyper_X_X_chunk."time"
                                    ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (never executed)
-                                         Filter: ("time" IS NOT NULL)
+                                         Vectorized Filter: ("time" IS NOT NULL)
                                          ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
                        ->  Merge Append (never executed)
                              Sort Key: _hyper_X_X_chunk."time"
                              ->  Sort (never executed)
                                    Sort Key: _hyper_X_X_chunk."time"
                                    ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (never executed)
-                                         Filter: ("time" IS NOT NULL)
+                                         Vectorized Filter: ("time" IS NOT NULL)
                                          ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
                              ->  Sort (never executed)
                                    Sort Key: _hyper_X_X_chunk."time"
                                    ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (never executed)
-                                         Filter: ("time" IS NOT NULL)
+                                         Vectorized Filter: ("time" IS NOT NULL)
                                          ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
                              ->  Sort (never executed)
                                    Sort Key: _hyper_X_X_chunk."time"
                                    ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (never executed)
-                                         Filter: ("time" IS NOT NULL)
+                                         Vectorized Filter: ("time" IS NOT NULL)
                                          ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
 (60 rows)
 
@@ -4279,53 +4279,53 @@ QUERY PLAN
                                    Sort Key: _hyper_X_X_chunk."time" DESC
                                    Sort Method: top-N heapsort 
                                    ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=5038 loops=1)
-                                         Filter: ("time" IS NOT NULL)
+                                         Vectorized Filter: ("time" IS NOT NULL)
                                          ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=6 loops=1)
                              ->  Sort (actual rows=1 loops=1)
                                    Sort Key: _hyper_X_X_chunk."time" DESC
                                    Sort Method: top-N heapsort 
                                    ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=15114 loops=1)
-                                         Filter: ("time" IS NOT NULL)
+                                         Vectorized Filter: ("time" IS NOT NULL)
                                          ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=18 loops=1)
                              ->  Sort (actual rows=1 loops=1)
                                    Sort Key: _hyper_X_X_chunk."time" DESC
                                    Sort Method: top-N heapsort 
                                    ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=5038 loops=1)
-                                         Filter: ("time" IS NOT NULL)
+                                         Vectorized Filter: ("time" IS NOT NULL)
                                          ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=6 loops=1)
                        ->  Merge Append (never executed)
                              Sort Key: _hyper_X_X_chunk."time" DESC
                              ->  Sort (never executed)
                                    Sort Key: _hyper_X_X_chunk."time" DESC
                                    ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (never executed)
-                                         Filter: ("time" IS NOT NULL)
+                                         Vectorized Filter: ("time" IS NOT NULL)
                                          ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
                              ->  Sort (never executed)
                                    Sort Key: _hyper_X_X_chunk."time" DESC
                                    ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (never executed)
-                                         Filter: ("time" IS NOT NULL)
+                                         Vectorized Filter: ("time" IS NOT NULL)
                                          ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
                              ->  Sort (never executed)
                                    Sort Key: _hyper_X_X_chunk."time" DESC
                                    ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (never executed)
-                                         Filter: ("time" IS NOT NULL)
+                                         Vectorized Filter: ("time" IS NOT NULL)
                                          ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
                        ->  Merge Append (never executed)
                              Sort Key: _hyper_X_X_chunk."time" DESC
                              ->  Sort (never executed)
                                    Sort Key: _hyper_X_X_chunk."time" DESC
                                    ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (never executed)
-                                         Filter: ("time" IS NOT NULL)
+                                         Vectorized Filter: ("time" IS NOT NULL)
                                          ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
                              ->  Sort (never executed)
                                    Sort Key: _hyper_X_X_chunk."time" DESC
                                    ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (never executed)
-                                         Filter: ("time" IS NOT NULL)
+                                         Vectorized Filter: ("time" IS NOT NULL)
                                          ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
                              ->  Sort (never executed)
                                    Sort Key: _hyper_X_X_chunk."time" DESC
                                    ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (never executed)
-                                         Filter: ("time" IS NOT NULL)
+                                         Vectorized Filter: ("time" IS NOT NULL)
                                          ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
 (60 rows)
 
@@ -4759,53 +4759,53 @@ QUERY PLAN
                                      Sort Key: _hyper_X_X_chunk_1."time" DESC
                                      Sort Method: top-N heapsort 
                                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk _hyper_X_X_chunk_1 (actual rows=5038 loops=1)
-                                           Filter: ("time" IS NOT NULL)
+                                           Vectorized Filter: ("time" IS NOT NULL)
                                            ->  Seq Scan on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (actual rows=6 loops=1)
                                ->  Sort (actual rows=1 loops=1)
                                      Sort Key: _hyper_X_X_chunk_1."time" DESC
                                      Sort Method: top-N heapsort 
                                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk _hyper_X_X_chunk_1 (actual rows=15114 loops=1)
-                                           Filter: ("time" IS NOT NULL)
+                                           Vectorized Filter: ("time" IS NOT NULL)
                                            ->  Seq Scan on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (actual rows=18 loops=1)
                                ->  Sort (actual rows=1 loops=1)
                                      Sort Key: _hyper_X_X_chunk_1."time" DESC
                                      Sort Method: top-N heapsort 
                                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk _hyper_X_X_chunk_1 (actual rows=5038 loops=1)
-                                           Filter: ("time" IS NOT NULL)
+                                           Vectorized Filter: ("time" IS NOT NULL)
                                            ->  Seq Scan on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (actual rows=6 loops=1)
                          ->  Merge Append (never executed)
                                Sort Key: _hyper_X_X_chunk_1."time" DESC
                                ->  Sort (never executed)
                                      Sort Key: _hyper_X_X_chunk_1."time" DESC
                                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk _hyper_X_X_chunk_1 (never executed)
-                                           Filter: ("time" IS NOT NULL)
+                                           Vectorized Filter: ("time" IS NOT NULL)
                                            ->  Seq Scan on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (never executed)
                                ->  Sort (never executed)
                                      Sort Key: _hyper_X_X_chunk_1."time" DESC
                                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk _hyper_X_X_chunk_1 (never executed)
-                                           Filter: ("time" IS NOT NULL)
+                                           Vectorized Filter: ("time" IS NOT NULL)
                                            ->  Seq Scan on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (never executed)
                                ->  Sort (never executed)
                                      Sort Key: _hyper_X_X_chunk_1."time" DESC
                                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk _hyper_X_X_chunk_1 (never executed)
-                                           Filter: ("time" IS NOT NULL)
+                                           Vectorized Filter: ("time" IS NOT NULL)
                                            ->  Seq Scan on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (never executed)
                          ->  Merge Append (never executed)
                                Sort Key: _hyper_X_X_chunk_1."time" DESC
                                ->  Sort (never executed)
                                      Sort Key: _hyper_X_X_chunk_1."time" DESC
                                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk _hyper_X_X_chunk_1 (never executed)
-                                           Filter: ("time" IS NOT NULL)
+                                           Vectorized Filter: ("time" IS NOT NULL)
                                            ->  Seq Scan on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (never executed)
                                ->  Sort (never executed)
                                      Sort Key: _hyper_X_X_chunk_1."time" DESC
                                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk _hyper_X_X_chunk_1 (never executed)
-                                           Filter: ("time" IS NOT NULL)
+                                           Vectorized Filter: ("time" IS NOT NULL)
                                            ->  Seq Scan on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (never executed)
                                ->  Sort (never executed)
                                      Sort Key: _hyper_X_X_chunk_1."time" DESC
                                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk _hyper_X_X_chunk_1 (never executed)
-                                           Filter: ("time" IS NOT NULL)
+                                           Vectorized Filter: ("time" IS NOT NULL)
                                            ->  Seq Scan on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (never executed)
    ->  Merge Append (actual rows=0 loops=1)
          ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=0 loops=1)

--- a/tsl/test/shared/expected/ordered_append-16.out
+++ b/tsl/test/shared/expected/ordered_append-16.out
@@ -2592,17 +2592,17 @@ QUERY PLAN
                        Sort Key: _hyper_X_X_chunk."time" DESC
                        Sort Method: top-N heapsort 
                        ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=25190 loops=1)
-                             Filter: ("time" IS NOT NULL)
+                             Vectorized Filter: ("time" IS NOT NULL)
                              ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=30 loops=1)
                  ->  Sort (never executed)
                        Sort Key: _hyper_X_X_chunk."time" DESC
                        ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (never executed)
-                             Filter: ("time" IS NOT NULL)
+                             Vectorized Filter: ("time" IS NOT NULL)
                              ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
                  ->  Sort (never executed)
                        Sort Key: _hyper_X_X_chunk."time" DESC
                        ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (never executed)
-                             Filter: ("time" IS NOT NULL)
+                             Vectorized Filter: ("time" IS NOT NULL)
                              ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
 (21 rows)
 
@@ -2619,17 +2619,17 @@ QUERY PLAN
                        Sort Key: _hyper_X_X_chunk."time"
                        Sort Method: top-N heapsort 
                        ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=17990 loops=1)
-                             Filter: ("time" IS NOT NULL)
+                             Vectorized Filter: ("time" IS NOT NULL)
                              ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=20 loops=1)
                  ->  Sort (never executed)
                        Sort Key: _hyper_X_X_chunk."time"
                        ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (never executed)
-                             Filter: ("time" IS NOT NULL)
+                             Vectorized Filter: ("time" IS NOT NULL)
                              ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
                  ->  Sort (never executed)
                        Sort Key: _hyper_X_X_chunk."time"
                        ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (never executed)
-                             Filter: ("time" IS NOT NULL)
+                             Vectorized Filter: ("time" IS NOT NULL)
                              ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
 (21 rows)
 
@@ -2648,17 +2648,17 @@ QUERY PLAN
                              Sort Key: _hyper_X_X_chunk."time"
                              Sort Method: top-N heapsort 
                              ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=17990 loops=1)
-                                   Filter: ("time" IS NOT NULL)
+                                   Vectorized Filter: ("time" IS NOT NULL)
                                    ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=20 loops=1)
                        ->  Sort (never executed)
                              Sort Key: _hyper_X_X_chunk."time"
                              ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (never executed)
-                                   Filter: ("time" IS NOT NULL)
+                                   Vectorized Filter: ("time" IS NOT NULL)
                                    ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
                        ->  Sort (never executed)
                              Sort Key: _hyper_X_X_chunk."time"
                              ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (never executed)
-                                   Filter: ("time" IS NOT NULL)
+                                   Vectorized Filter: ("time" IS NOT NULL)
                                    ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
 (22 rows)
 
@@ -2676,17 +2676,17 @@ QUERY PLAN
                              Sort Key: _hyper_X_X_chunk."time" DESC
                              Sort Method: top-N heapsort 
                              ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=25190 loops=1)
-                                   Filter: ("time" IS NOT NULL)
+                                   Vectorized Filter: ("time" IS NOT NULL)
                                    ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=30 loops=1)
                        ->  Sort (never executed)
                              Sort Key: _hyper_X_X_chunk."time" DESC
                              ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (never executed)
-                                   Filter: ("time" IS NOT NULL)
+                                   Vectorized Filter: ("time" IS NOT NULL)
                                    ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
                        ->  Sort (never executed)
                              Sort Key: _hyper_X_X_chunk."time" DESC
                              ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (never executed)
-                                   Filter: ("time" IS NOT NULL)
+                                   Vectorized Filter: ("time" IS NOT NULL)
                                    ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
 (22 rows)
 
@@ -2959,17 +2959,17 @@ QUERY PLAN
                                Sort Key: _hyper_X_X_chunk_1."time" DESC
                                Sort Method: top-N heapsort 
                                ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk _hyper_X_X_chunk_1 (actual rows=25190 loops=1)
-                                     Filter: ("time" IS NOT NULL)
+                                     Vectorized Filter: ("time" IS NOT NULL)
                                      ->  Seq Scan on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (actual rows=30 loops=1)
                          ->  Sort (never executed)
                                Sort Key: _hyper_X_X_chunk_1."time" DESC
                                ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk _hyper_X_X_chunk_1 (never executed)
-                                     Filter: ("time" IS NOT NULL)
+                                     Vectorized Filter: ("time" IS NOT NULL)
                                      ->  Seq Scan on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (never executed)
                          ->  Sort (never executed)
                                Sort Key: _hyper_X_X_chunk_1."time" DESC
                                ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk _hyper_X_X_chunk_1 (never executed)
-                                     Filter: ("time" IS NOT NULL)
+                                     Vectorized Filter: ("time" IS NOT NULL)
                                      ->  Seq Scan on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (never executed)
    ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (never executed)
          Filter: ("time" = $1)
@@ -4081,53 +4081,53 @@ QUERY PLAN
                              Sort Key: _hyper_X_X_chunk."time" DESC
                              Sort Method: top-N heapsort 
                              ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=5038 loops=1)
-                                   Filter: ("time" IS NOT NULL)
+                                   Vectorized Filter: ("time" IS NOT NULL)
                                    ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=6 loops=1)
                        ->  Sort (actual rows=1 loops=1)
                              Sort Key: _hyper_X_X_chunk."time" DESC
                              Sort Method: top-N heapsort 
                              ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=15114 loops=1)
-                                   Filter: ("time" IS NOT NULL)
+                                   Vectorized Filter: ("time" IS NOT NULL)
                                    ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=18 loops=1)
                        ->  Sort (actual rows=1 loops=1)
                              Sort Key: _hyper_X_X_chunk."time" DESC
                              Sort Method: top-N heapsort 
                              ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=5038 loops=1)
-                                   Filter: ("time" IS NOT NULL)
+                                   Vectorized Filter: ("time" IS NOT NULL)
                                    ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=6 loops=1)
                  ->  Merge Append (never executed)
                        Sort Key: _hyper_X_X_chunk."time" DESC
                        ->  Sort (never executed)
                              Sort Key: _hyper_X_X_chunk."time" DESC
                              ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (never executed)
-                                   Filter: ("time" IS NOT NULL)
+                                   Vectorized Filter: ("time" IS NOT NULL)
                                    ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
                        ->  Sort (never executed)
                              Sort Key: _hyper_X_X_chunk."time" DESC
                              ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (never executed)
-                                   Filter: ("time" IS NOT NULL)
+                                   Vectorized Filter: ("time" IS NOT NULL)
                                    ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
                        ->  Sort (never executed)
                              Sort Key: _hyper_X_X_chunk."time" DESC
                              ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (never executed)
-                                   Filter: ("time" IS NOT NULL)
+                                   Vectorized Filter: ("time" IS NOT NULL)
                                    ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
                  ->  Merge Append (never executed)
                        Sort Key: _hyper_X_X_chunk."time" DESC
                        ->  Sort (never executed)
                              Sort Key: _hyper_X_X_chunk."time" DESC
                              ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (never executed)
-                                   Filter: ("time" IS NOT NULL)
+                                   Vectorized Filter: ("time" IS NOT NULL)
                                    ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
                        ->  Sort (never executed)
                              Sort Key: _hyper_X_X_chunk."time" DESC
                              ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (never executed)
-                                   Filter: ("time" IS NOT NULL)
+                                   Vectorized Filter: ("time" IS NOT NULL)
                                    ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
                        ->  Sort (never executed)
                              Sort Key: _hyper_X_X_chunk."time" DESC
                              ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (never executed)
-                                   Filter: ("time" IS NOT NULL)
+                                   Vectorized Filter: ("time" IS NOT NULL)
                                    ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
 (59 rows)
 
@@ -4146,53 +4146,53 @@ QUERY PLAN
                              Sort Key: _hyper_X_X_chunk."time"
                              Sort Method: top-N heapsort 
                              ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=3598 loops=1)
-                                   Filter: ("time" IS NOT NULL)
+                                   Vectorized Filter: ("time" IS NOT NULL)
                                    ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=4 loops=1)
                        ->  Sort (actual rows=1 loops=1)
                              Sort Key: _hyper_X_X_chunk."time"
                              Sort Method: top-N heapsort 
                              ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=10794 loops=1)
-                                   Filter: ("time" IS NOT NULL)
+                                   Vectorized Filter: ("time" IS NOT NULL)
                                    ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=12 loops=1)
                        ->  Sort (actual rows=1 loops=1)
                              Sort Key: _hyper_X_X_chunk."time"
                              Sort Method: top-N heapsort 
                              ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=3598 loops=1)
-                                   Filter: ("time" IS NOT NULL)
+                                   Vectorized Filter: ("time" IS NOT NULL)
                                    ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=4 loops=1)
                  ->  Merge Append (never executed)
                        Sort Key: _hyper_X_X_chunk."time"
                        ->  Sort (never executed)
                              Sort Key: _hyper_X_X_chunk."time"
                              ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (never executed)
-                                   Filter: ("time" IS NOT NULL)
+                                   Vectorized Filter: ("time" IS NOT NULL)
                                    ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
                        ->  Sort (never executed)
                              Sort Key: _hyper_X_X_chunk."time"
                              ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (never executed)
-                                   Filter: ("time" IS NOT NULL)
+                                   Vectorized Filter: ("time" IS NOT NULL)
                                    ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
                        ->  Sort (never executed)
                              Sort Key: _hyper_X_X_chunk."time"
                              ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (never executed)
-                                   Filter: ("time" IS NOT NULL)
+                                   Vectorized Filter: ("time" IS NOT NULL)
                                    ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
                  ->  Merge Append (never executed)
                        Sort Key: _hyper_X_X_chunk."time"
                        ->  Sort (never executed)
                              Sort Key: _hyper_X_X_chunk."time"
                              ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (never executed)
-                                   Filter: ("time" IS NOT NULL)
+                                   Vectorized Filter: ("time" IS NOT NULL)
                                    ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
                        ->  Sort (never executed)
                              Sort Key: _hyper_X_X_chunk."time"
                              ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (never executed)
-                                   Filter: ("time" IS NOT NULL)
+                                   Vectorized Filter: ("time" IS NOT NULL)
                                    ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
                        ->  Sort (never executed)
                              Sort Key: _hyper_X_X_chunk."time"
                              ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (never executed)
-                                   Filter: ("time" IS NOT NULL)
+                                   Vectorized Filter: ("time" IS NOT NULL)
                                    ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
 (59 rows)
 
@@ -4213,53 +4213,53 @@ QUERY PLAN
                                    Sort Key: _hyper_X_X_chunk."time"
                                    Sort Method: top-N heapsort 
                                    ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=3598 loops=1)
-                                         Filter: ("time" IS NOT NULL)
+                                         Vectorized Filter: ("time" IS NOT NULL)
                                          ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=4 loops=1)
                              ->  Sort (actual rows=1 loops=1)
                                    Sort Key: _hyper_X_X_chunk."time"
                                    Sort Method: top-N heapsort 
                                    ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=10794 loops=1)
-                                         Filter: ("time" IS NOT NULL)
+                                         Vectorized Filter: ("time" IS NOT NULL)
                                          ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=12 loops=1)
                              ->  Sort (actual rows=1 loops=1)
                                    Sort Key: _hyper_X_X_chunk."time"
                                    Sort Method: top-N heapsort 
                                    ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=3598 loops=1)
-                                         Filter: ("time" IS NOT NULL)
+                                         Vectorized Filter: ("time" IS NOT NULL)
                                          ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=4 loops=1)
                        ->  Merge Append (never executed)
                              Sort Key: _hyper_X_X_chunk."time"
                              ->  Sort (never executed)
                                    Sort Key: _hyper_X_X_chunk."time"
                                    ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (never executed)
-                                         Filter: ("time" IS NOT NULL)
+                                         Vectorized Filter: ("time" IS NOT NULL)
                                          ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
                              ->  Sort (never executed)
                                    Sort Key: _hyper_X_X_chunk."time"
                                    ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (never executed)
-                                         Filter: ("time" IS NOT NULL)
+                                         Vectorized Filter: ("time" IS NOT NULL)
                                          ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
                              ->  Sort (never executed)
                                    Sort Key: _hyper_X_X_chunk."time"
                                    ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (never executed)
-                                         Filter: ("time" IS NOT NULL)
+                                         Vectorized Filter: ("time" IS NOT NULL)
                                          ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
                        ->  Merge Append (never executed)
                              Sort Key: _hyper_X_X_chunk."time"
                              ->  Sort (never executed)
                                    Sort Key: _hyper_X_X_chunk."time"
                                    ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (never executed)
-                                         Filter: ("time" IS NOT NULL)
+                                         Vectorized Filter: ("time" IS NOT NULL)
                                          ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
                              ->  Sort (never executed)
                                    Sort Key: _hyper_X_X_chunk."time"
                                    ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (never executed)
-                                         Filter: ("time" IS NOT NULL)
+                                         Vectorized Filter: ("time" IS NOT NULL)
                                          ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
                              ->  Sort (never executed)
                                    Sort Key: _hyper_X_X_chunk."time"
                                    ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (never executed)
-                                         Filter: ("time" IS NOT NULL)
+                                         Vectorized Filter: ("time" IS NOT NULL)
                                          ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
 (60 rows)
 
@@ -4279,53 +4279,53 @@ QUERY PLAN
                                    Sort Key: _hyper_X_X_chunk."time" DESC
                                    Sort Method: top-N heapsort 
                                    ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=5038 loops=1)
-                                         Filter: ("time" IS NOT NULL)
+                                         Vectorized Filter: ("time" IS NOT NULL)
                                          ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=6 loops=1)
                              ->  Sort (actual rows=1 loops=1)
                                    Sort Key: _hyper_X_X_chunk."time" DESC
                                    Sort Method: top-N heapsort 
                                    ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=15114 loops=1)
-                                         Filter: ("time" IS NOT NULL)
+                                         Vectorized Filter: ("time" IS NOT NULL)
                                          ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=18 loops=1)
                              ->  Sort (actual rows=1 loops=1)
                                    Sort Key: _hyper_X_X_chunk."time" DESC
                                    Sort Method: top-N heapsort 
                                    ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=5038 loops=1)
-                                         Filter: ("time" IS NOT NULL)
+                                         Vectorized Filter: ("time" IS NOT NULL)
                                          ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=6 loops=1)
                        ->  Merge Append (never executed)
                              Sort Key: _hyper_X_X_chunk."time" DESC
                              ->  Sort (never executed)
                                    Sort Key: _hyper_X_X_chunk."time" DESC
                                    ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (never executed)
-                                         Filter: ("time" IS NOT NULL)
+                                         Vectorized Filter: ("time" IS NOT NULL)
                                          ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
                              ->  Sort (never executed)
                                    Sort Key: _hyper_X_X_chunk."time" DESC
                                    ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (never executed)
-                                         Filter: ("time" IS NOT NULL)
+                                         Vectorized Filter: ("time" IS NOT NULL)
                                          ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
                              ->  Sort (never executed)
                                    Sort Key: _hyper_X_X_chunk."time" DESC
                                    ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (never executed)
-                                         Filter: ("time" IS NOT NULL)
+                                         Vectorized Filter: ("time" IS NOT NULL)
                                          ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
                        ->  Merge Append (never executed)
                              Sort Key: _hyper_X_X_chunk."time" DESC
                              ->  Sort (never executed)
                                    Sort Key: _hyper_X_X_chunk."time" DESC
                                    ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (never executed)
-                                         Filter: ("time" IS NOT NULL)
+                                         Vectorized Filter: ("time" IS NOT NULL)
                                          ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
                              ->  Sort (never executed)
                                    Sort Key: _hyper_X_X_chunk."time" DESC
                                    ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (never executed)
-                                         Filter: ("time" IS NOT NULL)
+                                         Vectorized Filter: ("time" IS NOT NULL)
                                          ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
                              ->  Sort (never executed)
                                    Sort Key: _hyper_X_X_chunk."time" DESC
                                    ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (never executed)
-                                         Filter: ("time" IS NOT NULL)
+                                         Vectorized Filter: ("time" IS NOT NULL)
                                          ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
 (60 rows)
 
@@ -4759,53 +4759,53 @@ QUERY PLAN
                                      Sort Key: _hyper_X_X_chunk_1."time" DESC
                                      Sort Method: top-N heapsort 
                                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk _hyper_X_X_chunk_1 (actual rows=5038 loops=1)
-                                           Filter: ("time" IS NOT NULL)
+                                           Vectorized Filter: ("time" IS NOT NULL)
                                            ->  Seq Scan on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (actual rows=6 loops=1)
                                ->  Sort (actual rows=1 loops=1)
                                      Sort Key: _hyper_X_X_chunk_1."time" DESC
                                      Sort Method: top-N heapsort 
                                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk _hyper_X_X_chunk_1 (actual rows=15114 loops=1)
-                                           Filter: ("time" IS NOT NULL)
+                                           Vectorized Filter: ("time" IS NOT NULL)
                                            ->  Seq Scan on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (actual rows=18 loops=1)
                                ->  Sort (actual rows=1 loops=1)
                                      Sort Key: _hyper_X_X_chunk_1."time" DESC
                                      Sort Method: top-N heapsort 
                                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk _hyper_X_X_chunk_1 (actual rows=5038 loops=1)
-                                           Filter: ("time" IS NOT NULL)
+                                           Vectorized Filter: ("time" IS NOT NULL)
                                            ->  Seq Scan on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (actual rows=6 loops=1)
                          ->  Merge Append (never executed)
                                Sort Key: _hyper_X_X_chunk_1."time" DESC
                                ->  Sort (never executed)
                                      Sort Key: _hyper_X_X_chunk_1."time" DESC
                                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk _hyper_X_X_chunk_1 (never executed)
-                                           Filter: ("time" IS NOT NULL)
+                                           Vectorized Filter: ("time" IS NOT NULL)
                                            ->  Seq Scan on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (never executed)
                                ->  Sort (never executed)
                                      Sort Key: _hyper_X_X_chunk_1."time" DESC
                                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk _hyper_X_X_chunk_1 (never executed)
-                                           Filter: ("time" IS NOT NULL)
+                                           Vectorized Filter: ("time" IS NOT NULL)
                                            ->  Seq Scan on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (never executed)
                                ->  Sort (never executed)
                                      Sort Key: _hyper_X_X_chunk_1."time" DESC
                                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk _hyper_X_X_chunk_1 (never executed)
-                                           Filter: ("time" IS NOT NULL)
+                                           Vectorized Filter: ("time" IS NOT NULL)
                                            ->  Seq Scan on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (never executed)
                          ->  Merge Append (never executed)
                                Sort Key: _hyper_X_X_chunk_1."time" DESC
                                ->  Sort (never executed)
                                      Sort Key: _hyper_X_X_chunk_1."time" DESC
                                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk _hyper_X_X_chunk_1 (never executed)
-                                           Filter: ("time" IS NOT NULL)
+                                           Vectorized Filter: ("time" IS NOT NULL)
                                            ->  Seq Scan on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (never executed)
                                ->  Sort (never executed)
                                      Sort Key: _hyper_X_X_chunk_1."time" DESC
                                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk _hyper_X_X_chunk_1 (never executed)
-                                           Filter: ("time" IS NOT NULL)
+                                           Vectorized Filter: ("time" IS NOT NULL)
                                            ->  Seq Scan on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (never executed)
                                ->  Sort (never executed)
                                      Sort Key: _hyper_X_X_chunk_1."time" DESC
                                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk _hyper_X_X_chunk_1 (never executed)
-                                           Filter: ("time" IS NOT NULL)
+                                           Vectorized Filter: ("time" IS NOT NULL)
                                            ->  Seq Scan on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (never executed)
    ->  Merge Append (actual rows=0 loops=1)
          ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=0 loops=1)

--- a/tsl/test/shared/expected/ordered_append_join-13.out
+++ b/tsl/test/shared/expected/ordered_append_join-13.out
@@ -2264,17 +2264,17 @@ QUERY PLAN
                                    Sort Key: _hyper_X_X_chunk."time" DESC
                                    Sort Method: top-N heapsort 
                                    ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=25190 loops=1)
-                                         Filter: ("time" IS NOT NULL)
+                                         Vectorized Filter: ("time" IS NOT NULL)
                                          ->  Seq Scan on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (actual rows=30 loops=1)
                              ->  Sort (never executed)
                                    Sort Key: _hyper_X_X_chunk."time" DESC
                                    ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (never executed)
-                                         Filter: ("time" IS NOT NULL)
+                                         Vectorized Filter: ("time" IS NOT NULL)
                                          ->  Seq Scan on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (never executed)
                              ->  Sort (never executed)
                                    Sort Key: _hyper_X_X_chunk."time" DESC
                                    ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (never executed)
-                                         Filter: ("time" IS NOT NULL)
+                                         Vectorized Filter: ("time" IS NOT NULL)
                                          ->  Seq Scan on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (never executed)
 (37 rows)
 
@@ -3605,53 +3605,53 @@ QUERY PLAN
                                          Sort Key: _hyper_X_X_chunk."time" DESC
                                          Sort Method: top-N heapsort 
                                          ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=5038 loops=1)
-                                               Filter: ("time" IS NOT NULL)
+                                               Vectorized Filter: ("time" IS NOT NULL)
                                                ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=6 loops=1)
                                    ->  Sort (actual rows=1 loops=1)
                                          Sort Key: _hyper_X_X_chunk."time" DESC
                                          Sort Method: top-N heapsort 
                                          ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=15114 loops=1)
-                                               Filter: ("time" IS NOT NULL)
+                                               Vectorized Filter: ("time" IS NOT NULL)
                                                ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=18 loops=1)
                                    ->  Sort (actual rows=1 loops=1)
                                          Sort Key: _hyper_X_X_chunk."time" DESC
                                          Sort Method: top-N heapsort 
                                          ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=5038 loops=1)
-                                               Filter: ("time" IS NOT NULL)
+                                               Vectorized Filter: ("time" IS NOT NULL)
                                                ->  Seq Scan on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (actual rows=6 loops=1)
                              ->  Merge Append (never executed)
                                    Sort Key: _hyper_X_X_chunk."time" DESC
                                    ->  Sort (never executed)
                                          Sort Key: _hyper_X_X_chunk."time" DESC
                                          ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (never executed)
-                                               Filter: ("time" IS NOT NULL)
+                                               Vectorized Filter: ("time" IS NOT NULL)
                                                ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
                                    ->  Sort (never executed)
                                          Sort Key: _hyper_X_X_chunk."time" DESC
                                          ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (never executed)
-                                               Filter: ("time" IS NOT NULL)
+                                               Vectorized Filter: ("time" IS NOT NULL)
                                                ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
                                    ->  Sort (never executed)
                                          Sort Key: _hyper_X_X_chunk."time" DESC
                                          ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (never executed)
-                                               Filter: ("time" IS NOT NULL)
+                                               Vectorized Filter: ("time" IS NOT NULL)
                                                ->  Seq Scan on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (never executed)
                              ->  Merge Append (never executed)
                                    Sort Key: _hyper_X_X_chunk."time" DESC
                                    ->  Sort (never executed)
                                          Sort Key: _hyper_X_X_chunk."time" DESC
                                          ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (never executed)
-                                               Filter: ("time" IS NOT NULL)
+                                               Vectorized Filter: ("time" IS NOT NULL)
                                                ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
                                    ->  Sort (never executed)
                                          Sort Key: _hyper_X_X_chunk."time" DESC
                                          ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (never executed)
-                                               Filter: ("time" IS NOT NULL)
+                                               Vectorized Filter: ("time" IS NOT NULL)
                                                ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
                                    ->  Sort (never executed)
                                          Sort Key: _hyper_X_X_chunk."time" DESC
                                          ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (never executed)
-                                               Filter: ("time" IS NOT NULL)
+                                               Vectorized Filter: ("time" IS NOT NULL)
                                                ->  Seq Scan on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (never executed)
 (75 rows)
 

--- a/tsl/test/shared/expected/ordered_append_join-14.out
+++ b/tsl/test/shared/expected/ordered_append_join-14.out
@@ -2264,17 +2264,17 @@ QUERY PLAN
                                    Sort Key: _hyper_X_X_chunk."time" DESC
                                    Sort Method: top-N heapsort 
                                    ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=25190 loops=1)
-                                         Filter: ("time" IS NOT NULL)
+                                         Vectorized Filter: ("time" IS NOT NULL)
                                          ->  Seq Scan on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (actual rows=30 loops=1)
                              ->  Sort (never executed)
                                    Sort Key: _hyper_X_X_chunk."time" DESC
                                    ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (never executed)
-                                         Filter: ("time" IS NOT NULL)
+                                         Vectorized Filter: ("time" IS NOT NULL)
                                          ->  Seq Scan on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (never executed)
                              ->  Sort (never executed)
                                    Sort Key: _hyper_X_X_chunk."time" DESC
                                    ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (never executed)
-                                         Filter: ("time" IS NOT NULL)
+                                         Vectorized Filter: ("time" IS NOT NULL)
                                          ->  Seq Scan on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (never executed)
 (37 rows)
 
@@ -3605,53 +3605,53 @@ QUERY PLAN
                                          Sort Key: _hyper_X_X_chunk."time" DESC
                                          Sort Method: top-N heapsort 
                                          ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=5038 loops=1)
-                                               Filter: ("time" IS NOT NULL)
+                                               Vectorized Filter: ("time" IS NOT NULL)
                                                ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=6 loops=1)
                                    ->  Sort (actual rows=1 loops=1)
                                          Sort Key: _hyper_X_X_chunk."time" DESC
                                          Sort Method: top-N heapsort 
                                          ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=15114 loops=1)
-                                               Filter: ("time" IS NOT NULL)
+                                               Vectorized Filter: ("time" IS NOT NULL)
                                                ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=18 loops=1)
                                    ->  Sort (actual rows=1 loops=1)
                                          Sort Key: _hyper_X_X_chunk."time" DESC
                                          Sort Method: top-N heapsort 
                                          ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=5038 loops=1)
-                                               Filter: ("time" IS NOT NULL)
+                                               Vectorized Filter: ("time" IS NOT NULL)
                                                ->  Seq Scan on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (actual rows=6 loops=1)
                              ->  Merge Append (never executed)
                                    Sort Key: _hyper_X_X_chunk."time" DESC
                                    ->  Sort (never executed)
                                          Sort Key: _hyper_X_X_chunk."time" DESC
                                          ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (never executed)
-                                               Filter: ("time" IS NOT NULL)
+                                               Vectorized Filter: ("time" IS NOT NULL)
                                                ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
                                    ->  Sort (never executed)
                                          Sort Key: _hyper_X_X_chunk."time" DESC
                                          ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (never executed)
-                                               Filter: ("time" IS NOT NULL)
+                                               Vectorized Filter: ("time" IS NOT NULL)
                                                ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
                                    ->  Sort (never executed)
                                          Sort Key: _hyper_X_X_chunk."time" DESC
                                          ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (never executed)
-                                               Filter: ("time" IS NOT NULL)
+                                               Vectorized Filter: ("time" IS NOT NULL)
                                                ->  Seq Scan on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (never executed)
                              ->  Merge Append (never executed)
                                    Sort Key: _hyper_X_X_chunk."time" DESC
                                    ->  Sort (never executed)
                                          Sort Key: _hyper_X_X_chunk."time" DESC
                                          ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (never executed)
-                                               Filter: ("time" IS NOT NULL)
+                                               Vectorized Filter: ("time" IS NOT NULL)
                                                ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
                                    ->  Sort (never executed)
                                          Sort Key: _hyper_X_X_chunk."time" DESC
                                          ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (never executed)
-                                               Filter: ("time" IS NOT NULL)
+                                               Vectorized Filter: ("time" IS NOT NULL)
                                                ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
                                    ->  Sort (never executed)
                                          Sort Key: _hyper_X_X_chunk."time" DESC
                                          ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (never executed)
-                                               Filter: ("time" IS NOT NULL)
+                                               Vectorized Filter: ("time" IS NOT NULL)
                                                ->  Seq Scan on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (never executed)
 (75 rows)
 

--- a/tsl/test/shared/expected/ordered_append_join-15.out
+++ b/tsl/test/shared/expected/ordered_append_join-15.out
@@ -2282,17 +2282,17 @@ QUERY PLAN
                                    Sort Key: _hyper_X_X_chunk."time" DESC
                                    Sort Method: top-N heapsort 
                                    ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=25190 loops=1)
-                                         Filter: ("time" IS NOT NULL)
+                                         Vectorized Filter: ("time" IS NOT NULL)
                                          ->  Seq Scan on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (actual rows=30 loops=1)
                              ->  Sort (never executed)
                                    Sort Key: _hyper_X_X_chunk."time" DESC
                                    ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (never executed)
-                                         Filter: ("time" IS NOT NULL)
+                                         Vectorized Filter: ("time" IS NOT NULL)
                                          ->  Seq Scan on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (never executed)
                              ->  Sort (never executed)
                                    Sort Key: _hyper_X_X_chunk."time" DESC
                                    ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (never executed)
-                                         Filter: ("time" IS NOT NULL)
+                                         Vectorized Filter: ("time" IS NOT NULL)
                                          ->  Seq Scan on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (never executed)
 (37 rows)
 
@@ -3629,53 +3629,53 @@ QUERY PLAN
                                          Sort Key: _hyper_X_X_chunk."time" DESC
                                          Sort Method: top-N heapsort 
                                          ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=5038 loops=1)
-                                               Filter: ("time" IS NOT NULL)
+                                               Vectorized Filter: ("time" IS NOT NULL)
                                                ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=6 loops=1)
                                    ->  Sort (actual rows=1 loops=1)
                                          Sort Key: _hyper_X_X_chunk."time" DESC
                                          Sort Method: top-N heapsort 
                                          ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=15114 loops=1)
-                                               Filter: ("time" IS NOT NULL)
+                                               Vectorized Filter: ("time" IS NOT NULL)
                                                ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=18 loops=1)
                                    ->  Sort (actual rows=1 loops=1)
                                          Sort Key: _hyper_X_X_chunk."time" DESC
                                          Sort Method: top-N heapsort 
                                          ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=5038 loops=1)
-                                               Filter: ("time" IS NOT NULL)
+                                               Vectorized Filter: ("time" IS NOT NULL)
                                                ->  Seq Scan on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (actual rows=6 loops=1)
                              ->  Merge Append (never executed)
                                    Sort Key: _hyper_X_X_chunk."time" DESC
                                    ->  Sort (never executed)
                                          Sort Key: _hyper_X_X_chunk."time" DESC
                                          ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (never executed)
-                                               Filter: ("time" IS NOT NULL)
+                                               Vectorized Filter: ("time" IS NOT NULL)
                                                ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
                                    ->  Sort (never executed)
                                          Sort Key: _hyper_X_X_chunk."time" DESC
                                          ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (never executed)
-                                               Filter: ("time" IS NOT NULL)
+                                               Vectorized Filter: ("time" IS NOT NULL)
                                                ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
                                    ->  Sort (never executed)
                                          Sort Key: _hyper_X_X_chunk."time" DESC
                                          ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (never executed)
-                                               Filter: ("time" IS NOT NULL)
+                                               Vectorized Filter: ("time" IS NOT NULL)
                                                ->  Seq Scan on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (never executed)
                              ->  Merge Append (never executed)
                                    Sort Key: _hyper_X_X_chunk."time" DESC
                                    ->  Sort (never executed)
                                          Sort Key: _hyper_X_X_chunk."time" DESC
                                          ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (never executed)
-                                               Filter: ("time" IS NOT NULL)
+                                               Vectorized Filter: ("time" IS NOT NULL)
                                                ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
                                    ->  Sort (never executed)
                                          Sort Key: _hyper_X_X_chunk."time" DESC
                                          ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (never executed)
-                                               Filter: ("time" IS NOT NULL)
+                                               Vectorized Filter: ("time" IS NOT NULL)
                                                ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
                                    ->  Sort (never executed)
                                          Sort Key: _hyper_X_X_chunk."time" DESC
                                          ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (never executed)
-                                               Filter: ("time" IS NOT NULL)
+                                               Vectorized Filter: ("time" IS NOT NULL)
                                                ->  Seq Scan on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (never executed)
 (75 rows)
 

--- a/tsl/test/shared/expected/ordered_append_join-16.out
+++ b/tsl/test/shared/expected/ordered_append_join-16.out
@@ -2282,17 +2282,17 @@ QUERY PLAN
                                    Sort Key: _hyper_X_X_chunk."time" DESC
                                    Sort Method: top-N heapsort 
                                    ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=25190 loops=1)
-                                         Filter: ("time" IS NOT NULL)
+                                         Vectorized Filter: ("time" IS NOT NULL)
                                          ->  Seq Scan on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (actual rows=30 loops=1)
                              ->  Sort (never executed)
                                    Sort Key: _hyper_X_X_chunk."time" DESC
                                    ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (never executed)
-                                         Filter: ("time" IS NOT NULL)
+                                         Vectorized Filter: ("time" IS NOT NULL)
                                          ->  Seq Scan on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (never executed)
                              ->  Sort (never executed)
                                    Sort Key: _hyper_X_X_chunk."time" DESC
                                    ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (never executed)
-                                         Filter: ("time" IS NOT NULL)
+                                         Vectorized Filter: ("time" IS NOT NULL)
                                          ->  Seq Scan on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (never executed)
 (37 rows)
 
@@ -3629,53 +3629,53 @@ QUERY PLAN
                                          Sort Key: _hyper_X_X_chunk."time" DESC
                                          Sort Method: top-N heapsort 
                                          ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=5038 loops=1)
-                                               Filter: ("time" IS NOT NULL)
+                                               Vectorized Filter: ("time" IS NOT NULL)
                                                ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=6 loops=1)
                                    ->  Sort (actual rows=1 loops=1)
                                          Sort Key: _hyper_X_X_chunk."time" DESC
                                          Sort Method: top-N heapsort 
                                          ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=15114 loops=1)
-                                               Filter: ("time" IS NOT NULL)
+                                               Vectorized Filter: ("time" IS NOT NULL)
                                                ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=18 loops=1)
                                    ->  Sort (actual rows=1 loops=1)
                                          Sort Key: _hyper_X_X_chunk."time" DESC
                                          Sort Method: top-N heapsort 
                                          ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=5038 loops=1)
-                                               Filter: ("time" IS NOT NULL)
+                                               Vectorized Filter: ("time" IS NOT NULL)
                                                ->  Seq Scan on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (actual rows=6 loops=1)
                              ->  Merge Append (never executed)
                                    Sort Key: _hyper_X_X_chunk."time" DESC
                                    ->  Sort (never executed)
                                          Sort Key: _hyper_X_X_chunk."time" DESC
                                          ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (never executed)
-                                               Filter: ("time" IS NOT NULL)
+                                               Vectorized Filter: ("time" IS NOT NULL)
                                                ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
                                    ->  Sort (never executed)
                                          Sort Key: _hyper_X_X_chunk."time" DESC
                                          ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (never executed)
-                                               Filter: ("time" IS NOT NULL)
+                                               Vectorized Filter: ("time" IS NOT NULL)
                                                ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
                                    ->  Sort (never executed)
                                          Sort Key: _hyper_X_X_chunk."time" DESC
                                          ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (never executed)
-                                               Filter: ("time" IS NOT NULL)
+                                               Vectorized Filter: ("time" IS NOT NULL)
                                                ->  Seq Scan on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (never executed)
                              ->  Merge Append (never executed)
                                    Sort Key: _hyper_X_X_chunk."time" DESC
                                    ->  Sort (never executed)
                                          Sort Key: _hyper_X_X_chunk."time" DESC
                                          ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (never executed)
-                                               Filter: ("time" IS NOT NULL)
+                                               Vectorized Filter: ("time" IS NOT NULL)
                                                ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
                                    ->  Sort (never executed)
                                          Sort Key: _hyper_X_X_chunk."time" DESC
                                          ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (never executed)
-                                               Filter: ("time" IS NOT NULL)
+                                               Vectorized Filter: ("time" IS NOT NULL)
                                                ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
                                    ->  Sort (never executed)
                                          Sort Key: _hyper_X_X_chunk."time" DESC
                                          ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (never executed)
-                                               Filter: ("time" IS NOT NULL)
+                                               Vectorized Filter: ("time" IS NOT NULL)
                                                ->  Seq Scan on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (never executed)
 (75 rows)
 


### PR DESCRIPTION
For checks like `variable IS (NOT) NULL`.

Up to 20% speedup on some queries we have in tsbench: https://grafana.ops.savannah-dev.timescale.com/d/fasYic_4z/compare-akuzm?orgId=1&var-branch=All&var-run1=3093&var-run2=3080&var-threshold=0&var-use_historical_thresholds=true&var-threshold_expression=2.5%20*%20percentile_cont(0.90)&var-exact_suite_version=false

Disable-check: force-changelog-file