### PR TITLE
Fix upload test results for macos regression CI

### DIFF
--- a/.github/workflows/linux-build-and-test.yaml
+++ b/.github/workflows/linux-build-and-test.yaml
@@ -289,4 +289,10 @@ jobs:
             GITHUB_PR_NUMBER=0
         fi
         export GITHUB_PR_NUMBER
+        if [[ "${{ runner.os }}" == "macOS" ]] ;
+        then
+          # Add libpq to PATH so psql can be used for uploading
+          # test results
+          export PATH="/usr/local/opt/libpq/bin:$PATH"
+        fi
         scripts/upload_ci_stats.sh


### PR DESCRIPTION
Disable-check: force-changelog-file

(cherry picked from commit ffe8c768f07c3948e85f674fec414bd7efdf932b)