### PR TITLE
Fix use of freed path in decompression sort logic

### DIFF
--- a/.unreleased/fix_6465
+++ b/.unreleased/fix_6465
@@ -1,0 +1,1 @@
+Fixes: #6465 Fix use of freed path in decompression sort logic

--- a/tsl/test/expected/transparent_decompression_queries.out
+++ b/tsl/test/expected/transparent_decompression_queries.out
@@ -219,3 +219,59 @@ SELECT * FROM pseudo WHERE now() IS NOT NULL;
  Sat Jan 01 00:00:00 2000 PST
 (1 row)
 
+-- ensure needed decompression paths underneath a sort node
+-- are not recycled by PostgreSQL
+SET random_page_cost = 4.0;
+DROP TABLE IF EXISTS options_data;
+NOTICE:  table "options_data" does not exist, skipping
+CREATE TABLE IF NOT EXISTS options_data (
+    date            date NOT NULL,
+    contract_code   text NOT NULL,
+    expiry_code     text NOT NULL,
+    option_type     character(1) NOT NULL,
+    strike          real NOT NULL,
+    price           double precision,
+    source          text NOT NULL,
+    meta            text
+);
+SELECT create_hypertable('options_data', 'date', chunk_time_interval => interval '1 day');
+     create_hypertable     
+---------------------------
+ (7,public,options_data,t)
+(1 row)
+
+INSERT INTO options_data (date, contract_code, expiry_code, option_type, strike, price, source, meta)
+SELECT
+    date_series,
+    'CONTRACT' || date_series::text,
+    'EXPIRY' || date_series::text,
+    CASE WHEN random() < 0.5 THEN 'C' ELSE 'P' END, -- Randomly choose 'C' or 'P' for option_type
+   random() * 100, -- Random strike value between 0 and 100
+   random() * 100, -- Random price value between 0 and 100
+   'SOURCE' || date_series::text,
+   'META' || date_series::text
+FROM generate_series(
+    '2023-12-01 00:00:00',
+    '2023-12-05 00:00:00',
+    INTERVAL '10 minute'
+) AS date_series;
+ALTER TABLE options_data SET (timescaledb.compress,
+    timescaledb.compress_segmentby = 'contract_code, expiry_code, option_type, strike, source',
+    timescaledb.compress_orderby = 'date DESC');
+SELECT compress_chunk(ch) FROM show_chunks('options_data', older_than=> '2023-12-05') ch;
+             compress_chunk              
+-----------------------------------------
+ _timescaledb_internal._hyper_7_13_chunk
+ _timescaledb_internal._hyper_7_14_chunk
+ _timescaledb_internal._hyper_7_15_chunk
+ _timescaledb_internal._hyper_7_16_chunk
+(4 rows)
+
+ANALYZE options_data;
+SELECT max(date) AS date FROM options_data WHERE contract_code='CONTRACT2023-12-03 04:00:00+01';
+ date 
+------
+ 
+(1 row)
+
+RESET random_page_cost;

--- a/tsl/test/shared/expected/transparent_decompress_chunk-16.out
+++ b/tsl/test/shared/expected/transparent_decompress_chunk-16.out
@@ -713,7 +713,7 @@ QUERY PLAN
                      ->  Sort
                            Sort Key: m3."time"
                            ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk m3
-                                 ->  Parallel Seq Scan on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_2
+                                 ->  Seq Scan on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_2
                                        Filter: (device_id = 3)
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk m1
                            ->  Seq Scan on compress_hyper_X_X_chunk


### PR DESCRIPTION
In the function add_chunk_sorted_paths, we create sorted versions of the decompress paths. We construct a sort node and place it on top of the decompressed chunk to do this. However, the decompress chunk path will also be added to the relation via add_path. This function can recycle the provided path if better paths are already known. Therefore, we need our own private copy for the sorted paths.