### PR TITLE
Improve core dump handling on OS X

### DIFF
--- a/.github/workflows/linux-build-and-test.yaml
+++ b/.github/workflows/linux-build-and-test.yaml
@@ -79,6 +79,10 @@ jobs:
         curl -L https://raw.githubusercontent.com/Homebrew/homebrew-core/e68186ba5a05a6ea9a30d6c7744de9a46bd3aadd/Formula/o/openssl@3.rb > openssl@3.rb
         brew install openssl@3.rb
 
+    - name: Setup macOS coredump directory
+      if: runner.os == 'macOS'
+      run: sudo chmod 777 /cores
+
     - name: Checkout TimescaleDB
       uses: actions/checkout@v3
 
@@ -164,6 +168,7 @@ jobs:
     - name: make installcheck
       id: installcheck
       run: |
+        ulimit -c unlimited
         set -o pipefail
         make -k -C build installcheck IGNORES="${{ join(matrix.ignored_tests, ' ') }}" \
             SKIPS="${{ join(matrix.skipped_tests, ' ') }}" ${{ matrix.installcheck_args }} \
@@ -202,6 +207,8 @@ jobs:
           if coredumpctl -q list >/dev/null; then echo "coredumps=true" >>$GITHUB_OUTPUT; fi
           # print OOM killer information
           sudo journalctl --system -q --facility=kern --grep "Killed process" || true
+        elif [[ "${{ runner.os }}" == "macOS" ]] ; then
+           if [ $(find /cores -type f | wc -l) -gt 0 ]; then echo "coredumps=true" >>$GITHUB_OUTPUT; fi
         fi
         if [[ -s regression.log ]]; then echo "regression_diff=true" >>$GITHUB_OUTPUT; fi
         grep -e 'FAILED' -e 'failed (ignored)' installcheck.log || true
@@ -223,8 +230,8 @@ jobs:
         name: PostgreSQL log ${{ matrix.os }} ${{ matrix.name }} ${{ matrix.pg }}
         path: postgres.log
 
-    - name: Stack trace
-      if: always() && steps.collectlogs.outputs.coredumps == 'true'
+    - name: Stack trace Linux
+      if: always() && steps.collectlogs.outputs.coredumps == 'true' && runner.os == 'Linux'
       run: |
         sudo coredumpctl debug --debugger=gdb --debugger-arguments='' <<<"
           set verbose on
@@ -247,6 +254,11 @@ jobs:
         " 2>&1 | tee stacktrace.log
         ./scripts/bundle_coredumps.sh
         grep -C40 "was terminated by signal" postgres.log > postgres-failure.log ||:
+
+    - name: Stack trace macOS
+      if: always() && steps.collectlogs.outputs.coredumps == 'true' && runner.os == 'macOS'
+      run: |
+        ~/$PG_SRC_DIR/src/tools/ci/cores_backtrace.sh macos /cores
 
     - name: Coredumps
       if: always() && steps.collectlogs.outputs.coredumps == 'true'


### PR DESCRIPTION
So far, we have analyzed the core dumps only on Linux. This patch adds some logic to get a stack trace on OS X.

--- 
###
Sample output: https://github.com/timescale/timescaledb/actions/runs/7313532618/job/19925218573?pr=6468

(Please check the raw output from the action, since we had a lot of core dumps, we also ran out of disk space during decoding and the GitHub UI does not show log outputs for incomplete steps in the UI.)

```
(lldb) target create --core "/cores/core.51370"
Core file '/cores/core.51370' (x86_64) was loaded.
(lldb) thread backtrace all
* thread #1
  * frame #0: 0x00007ff80d8aa1e2 libsystem_kernel.dylib`__pthread_kill + 10
    frame #1: 0x00007ff80d8e1ee6 libsystem_pthread.dylib`pthread_kill + 263
    frame #2: 0x00007ff80d808b45 libsystem_c.dylib`abort + 123
    frame #3: 0x00007ff80d71f752 libsystem_malloc.dylib`malloc_vreport + 888
    frame #4: 0x00007ff80d734a08 libsystem_malloc.dylib`malloc_zone_error + 183
    frame #5: 0x00007ff80d717a61 libsystem_malloc.dylib`tiny_free_list_add_ptr + 885
    frame #6: 0x00007ff80d717243 libsystem_malloc.dylib`tiny_free_no_lock + 1109
    frame #7: 0x00007ff80d716cb6 libsystem_malloc.dylib`free_tiny + 523
    frame #8: 0x000000010ae66746 libcrypto.3.dylib`EVP_RAND_CTX_free + 58
    frame #9: 0x000000010af67070 libcrypto.3.dylib`rand_delete_thread_state + 61
    frame #10: 0x000000010ae8794c libcrypto.3.dylib`init_thread_stop + 165
    frame #11: 0x000000010ae87882 libcrypto.3.dylib`OPENSSL_thread_stop + 55
    frame #12: 0x000000010ae86e22 libcrypto.3.dylib`OPENSSL_cleanup + 48
    frame #13: 0x00007ff80d7b3ba8 libsystem_c.dylib`__cxa_finalize_ranges + 416
    frame #14: 0x00007ff80d7b39bb libsystem_c.dylib`exit + 35
    frame #15: 0x000000010a1b5065 postgres`proc_exit + 101
    frame #16: 0x000000010a151751 postgres`BackendInitialize + 913
    frame #17: 0x000000010a15006e postgres`ServerLoop + 7966
    frame #18: 0x000000010a14d229 postgres`PostmasterMain + 3657
    frame #19: 0x000000010a077aef postgres`main + 815
    frame #20: 0x00007ff80d58841f dyld`start + 1903
(lldb) quit
```

Disable-check: force-changelog-file