### PR TITLE
Use OpenSSL 3.1.4 for OS X builds

### DIFF
--- a/.github/gh_matrix_builder.py
+++ b/.github/gh_matrix_builder.py
@@ -147,9 +147,9 @@ def macos_config(overrides):
                 "compressed_collation",
             },
             "os": "macos-13",
-            "pg_extra_args": "--with-libraries=/usr/local/opt/openssl/lib --with-includes=/usr/local/opt/openssl/include --without-icu",
+            "pg_extra_args": "--with-libraries=/usr/local/opt/openssl@3/lib --with-includes=/usr/local/opt/openssl@3/include --without-icu",
             "pginstallcheck": True,
-            "tsdb_build_args": "-DASSERTIONS=ON -DREQUIRE_ALL_TESTS=ON -DOPENSSL_ROOT_DIR=/usr/local/opt/openssl",
+            "tsdb_build_args": "-DASSERTIONS=ON -DREQUIRE_ALL_TESTS=ON -DOPENSSL_ROOT_DIR=/usr/local/opt/openssl@3",
         }
     )
     base_config.update(overrides)

--- a/.github/workflows/linux-build-and-test.yaml
+++ b/.github/workflows/linux-build-and-test.yaml
@@ -73,6 +73,12 @@ jobs:
         sudo perl -MCPAN -e "CPAN::Shell->notest('install', 'IPC::Run')"
         sudo perl -MCPAN -e "CPAN::Shell->notest('install', 'Test::Most')"
 
+        # Force use of OpenSSL 3.1.4, since OpenSSL 3.2.0 crashes with recent
+        # PostgreSQL versions on OS X (see https://github.com/Homebrew/homebrew-core/issues/155651)
+        brew unlink openssl@3
+        curl -L https://raw.githubusercontent.com/Homebrew/homebrew-core/e68186ba5a05a6ea9a30d6c7744de9a46bd3aadd/Formula/o/openssl@3.rb > openssl@3.rb
+        brew install openssl@3.rb
+
     - name: Checkout TimescaleDB
       uses: actions/checkout@v3
 
@@ -125,6 +131,7 @@ jobs:
       run: |
         make -C ~/$PG_SRC_DIR install
         make -C ~/$PG_SRC_DIR/contrib/postgres_fdw install
+        echo "$HOME/$PG_INSTALL_DIR/bin" >> "${GITHUB_PATH}"
 
     - name: Upload config.log
       if: always() && steps.cache-postgresql.outputs.cache-hit != 'true'
@@ -160,7 +167,7 @@ jobs:
         set -o pipefail
         make -k -C build installcheck IGNORES="${{ join(matrix.ignored_tests, ' ') }}" \
             SKIPS="${{ join(matrix.skipped_tests, ' ') }}" ${{ matrix.installcheck_args }} \
-            PSQL="${HOME}/${PG_INSTALL_DIR}/bin/psql" | tee installcheck.log
+            | tee installcheck.log
 
     - name: pginstallcheck
       if: matrix.pginstallcheck
@@ -282,10 +289,4 @@ jobs:
             GITHUB_PR_NUMBER=0
         fi
         export GITHUB_PR_NUMBER
-        if [[ "${{ runner.os }}" == "macOS" ]] ;
-        then
-          # Add libpq to PATH so psql can be used for uploading
-          # test results
-          export PATH="/usr/local/opt/libpq/bin:$PATH"
-        fi
         scripts/upload_ci_stats.sh


### PR DESCRIPTION
This patch changes the OpenSSL version for the OS X builds to 3.1.4,
since recent PostgreSQL versions contain a bug in the SSL handling and
crash on OS X when OpenSSL 3.2.0 is used.

See: https://github.com/Homebrew/homebrew-core/issues/155651

---
This also fixes the build problem in our 2.13.x branch
Link to current CI failures: https://github.com/timescale/timescaledb/actions/runs/7310652505/job/19919464262?pr=6467
Link to successful CI run in our 2.13.x branch: https://github.com/timescale/timescaledb/actions/runs/7314107994/job/19926391007?pr=6470
Disable-check: force-changelog-file