### PR TITLE
Backport to 2.13.x: Fix perl modules installation on OS X

### DIFF
--- a/.github/workflows/linux-build-and-test.yaml
+++ b/.github/workflows/linux-build-and-test.yaml
@@ -70,14 +70,16 @@ jobs:
       if: runner.os == 'macOS'
       run: |
         brew install gawk
-        sudo perl -MCPAN -e "CPAN::Shell->notest('install', 'IPC::Run')"
-        sudo perl -MCPAN -e "CPAN::Shell->notest('install', 'Test::Most')"
 
         # Force use of OpenSSL 3.1.4, since OpenSSL 3.2.0 crashes with recent
         # PostgreSQL versions on OS X (see https://github.com/Homebrew/homebrew-core/issues/155651)
         brew unlink openssl@3
         curl -L https://raw.githubusercontent.com/Homebrew/homebrew-core/e68186ba5a05a6ea9a30d6c7744de9a46bd3aadd/Formula/o/openssl@3.rb > openssl@3.rb
         brew install openssl@3.rb
+
+        # Install perl modules after last Homebew call, since Homebrew can change the perl version
+        sudo perl -MCPAN -e "CPAN::Shell->notest('install', 'IPC::Run')"
+        sudo perl -MCPAN -e "CPAN::Shell->notest('install', 'Test::Most')"
 
     - name: Checkout TimescaleDB
       uses: actions/checkout@v3


### PR DESCRIPTION
Homebrew can change the installed Perl version. Therefore, the installation of custom modules should be done after the last Homebrew call.