### PR TITLE
Release 2.13.1

### DIFF
--- a/.unreleased/fix_6365
+++ b/.unreleased/fix_6365
@@ -1,1 +1,0 @@
-Fixes: #6365 Use numrows_pre_compression in approximate row count

--- a/.unreleased/fix_6377
+++ b/.unreleased/fix_6377
@@ -1,1 +1,0 @@
-Fixes: #6377 Use processed group clauses in PG16

--- a/.unreleased/fix_6384
+++ b/.unreleased/fix_6384
@@ -1,1 +1,0 @@
-Fixes: #6384 Change bgw_log_level to use PGC_SUSET

--- a/.unreleased/fix_6393
+++ b/.unreleased/fix_6393
@@ -1,2 +1,0 @@
-Fixes: #6393 Disable vectorized sum for expressions.
-

--- a/.unreleased/fix_6408
+++ b/.unreleased/fix_6408
@@ -1,2 +1,0 @@
-Fixes: #6408 Fix groupby pathkeys for gapfill in PG16
-Thanks: @MA-MacDonald for reporting an issue with gapfill in PG16

--- a/.unreleased/fix_6428
+++ b/.unreleased/fix_6428
@@ -1,1 +1,0 @@
-Fixes: #6428 Fix index matching during DML decompression

--- a/.unreleased/fix_6443
+++ b/.unreleased/fix_6443
@@ -1,1 +1,0 @@
-Fixes: #6443 Fix lost concurrent CAgg updates

--- a/.unreleased/fix_6465
+++ b/.unreleased/fix_6465
@@ -1,1 +1,0 @@
-Fixes: #6465 Fix use of freed path in decompression sort logic

--- a/.unreleased/pr_6439
+++ b/.unreleased/pr_6439
@@ -1,3 +1,0 @@
-Fixes: #6439 Fix compressed chunk permission handling on PG16
-
-Thanks: @adriangb for reporting an issue with security barrier views on pg16

--- a/.unreleased/pr_6454
+++ b/.unreleased/pr_6454
@@ -1,2 +1,0 @@
-Fixes: #6454 Fix unique expression indexes on compressed chunks
-Thanks: @aarondglover for reporting an issue with unique expression indexes on compressed chunks

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,29 @@
 `psql` with the `-X` flag to prevent any `.psqlrc` commands from
 accidentally triggering the load of a previous DB version.**
 
+## 2.13.1 (2024-01-08)
+
+This release contains bug fixes since the 2.13.0 release.
+We recommend that you upgrade at the next available opportunity.
+
+**Bugfixes**
+* #6365 Use numrows_pre_compression in approximate row count
+* #6377 Use processed group clauses in PG16
+* #6384 Change bgw_log_level to use PGC_SUSET
+* #6393 Disable vectorized sum for expressions.
+* #6405 Read CAgg watermark from materialized data
+* #6408 Fix groupby pathkeys for gapfill in PG16
+* #6428 Fix index matching during DML decompression
+* #6439 Fix compressed chunk permission handling on PG16
+* #6443 Fix lost concurrent CAgg updates
+* #6454 Fix unique expression indexes on compressed chunks
+* #6465 Fix use of freed path in decompression sort logic
+
+**Thanks**
+* @MA-MacDonald for reporting an issue with gapfill in PG16
+* @aarondglover for reporting an issue with unique expression indexes on compressed chunks
+* @adriangb for reporting an issue with security barrier views on pg16
+
 ## 2.13.0 (2023-11-28)
 
 This release contains performance improvements, an improved hypertable DDL API

--- a/cmake/GenerateScripts.cmake
+++ b/cmake/GenerateScripts.cmake
@@ -185,9 +185,9 @@ function(generate_downgrade_script)
   # Save the current PROJECT_VERSION_MOD
   set(SAVED_PROJECT_VERSION_MOD ${PROJECT_VERSION_MOD})
   # To use PROJECT_VERSION_MOD variable as a target version in downgrade scripts
-  # we should set it as the UPDATE_FROM_VERSION because it means the target version
+  # we should set it as the DOWNGRADE_TO_VERSION because it means the target version
   # when executing the downgrade scripts
-  set(PROJECT_VERSION_MOD ${UPDATE_FROM_VERSION})
+  set(PROJECT_VERSION_MOD ${DOWNGRADE_TO_VERSION})
   generate_script(
     VERSION
     ${_downgrade_TARGET_VERSION}

--- a/sql/CMakeLists.txt
+++ b/sql/CMakeLists.txt
@@ -41,7 +41,8 @@ set(MOD_FILES
     updates/2.11.2--2.12.0.sql
     updates/2.12.0--2.12.1.sql
     updates/2.12.1--2.12.2.sql
-    updates/2.12.2--2.13.0.sql)
+    updates/2.12.2--2.13.0.sql
+    updates/2.13.0--2.13.1.sql)
 
 # The downgrade file to generate a downgrade script for the current version, as
 # specified in version.config

--- a/version.config
+++ b/version.config
@@ -1,3 +1,3 @@
 version = 2.14.0-dev
-update_from_version = 2.13.0
+update_from_version = 2.13.1
 downgrade_to_version = 2.13.0


### PR DESCRIPTION
This release contains bug fixes since the 2.13.0 release. We recommend that you upgrade at the next available opportunity.

**Bugfixes**
* #6365 Use numrows_pre_compression in approximate row count
* #6377 Use processed group clauses in PG16
* #6384 Change bgw_log_level to use PGC_SUSET
* #6393 Disable vectorized sum for expressions.
* #6408 Fix groupby pathkeys for gapfill in PG16
* #6428 Fix index matching during DML decompression
* #6439 Fix compressed chunk permission handling on PG16
* #6443 Fix lost concurrent CAgg updates
* #6454 Fix unique expression indexes on compressed chunks
* #6465 Fix use of freed path in decompression sort logic

**Thanks**
* @MA-MacDonald for reporting an issue with gapfill in PG16
* @aarondglover for reporting an issue with unique expression indexes on compressed chunks
* @adriangb for reporting an issue with security barrier views on pg16

---

Disable-check: force-changelog-file
