### PR TITLE
Fix create_hypertable referenced by fk succeeds

### DIFF
--- a/.unreleased/fix_6494
+++ b/.unreleased/fix_6494
@@ -1,0 +1,1 @@
+Fixes: #6494 Fix create_hypertable referenced by fk succeeds

--- a/src/hypertable.c
+++ b/src/hypertable.c
@@ -1218,9 +1218,11 @@ hypertable_create_schema(const char *schema_name)
 /*
  * Check that existing table constraints are supported.
  *
- * Hypertables do not support some constraints. For instance, NO INHERIT
- * constraints cannot be enforced on a hypertable since they only exist on the
- * parent table, which will have no tuples.
+ * Hypertables do not support the following constraints:
+ *
+ * - NO INHERIT constraints cannot be enforced on a hypertable since they only
+ *   exist on the parent table, which will have no tuples.
+ * - FOREIGN KEY constraints referencing a hypertable.
  */
 static void
 hypertable_validate_constraints(Oid relid)
@@ -1250,6 +1252,31 @@ hypertable_validate_constraints(Oid relid)
 					 errmsg("cannot have NO INHERIT constraints on hypertable \"%s\"",
 							get_rel_name(relid)),
 					 errhint("Remove all NO INHERIT constraints from table \"%s\" before "
+							 "making it a hypertable.",
+							 get_rel_name(relid))));
+	}
+
+	systable_endscan(scan);
+
+	/* Check for foreign keys that reference this table */
+	ScanKeyInit(&scankey,
+				Anum_pg_constraint_confrelid,
+				BTEqualStrategyNumber,
+				F_OIDEQ,
+				ObjectIdGetDatum(relid));
+
+	scan = systable_beginscan(catalog, 0, false, NULL, 1, &scankey);
+
+	while (HeapTupleIsValid(tuple = systable_getnext(scan)))
+	{
+		Form_pg_constraint form = (Form_pg_constraint) GETSTRUCT(tuple);
+
+		if (form->contype == CONSTRAINT_FOREIGN)
+			ereport(ERROR,
+					(errcode(ERRCODE_INVALID_TABLE_DEFINITION),
+					 errmsg("cannot have FOREIGN KEY constraints to hypertable \"%s\"",
+							get_rel_name(relid)),
+					 errhint("Remove all FOREIGN KEY constraints to table \"%s\" before "
 							 "making it a hypertable.",
 							 get_rel_name(relid))));
 	}

--- a/test/expected/create_hypertable.out
+++ b/test/expected/create_hypertable.out
@@ -1053,3 +1053,18 @@ select * from tidrangescan_test where time > '2023-02-12 00:00:00+02:40'::timest
 (3 rows)
 
 drop table tidrangescan_test;
+\set ON_ERROR_STOP 0
+\set VERBOSITY default
+set client_min_messages = WARNING;
+-- test creating a hypertable from table referenced by a foreign key fails with
+-- error "cannot have FOREIGN KEY constraints to hypertable".
+create table test_schema.fk_parent(time timestamptz, id int, unique(time, id));
+create table test_schema.fk_child(
+  time timestamptz,
+  id int,
+  foreign key (time, id) references test_schema.fk_parent(time, id)
+);
+select create_hypertable ('test_schema.fk_parent', 'time');
+ERROR:  cannot have FOREIGN KEY constraints to hypertable "fk_parent"
+HINT:  Remove all FOREIGN KEY constraints to table "fk_parent" before making it a hypertable.
+\set ON_ERROR_STOP 1

--- a/test/sql/create_hypertable.sql
+++ b/test/sql/create_hypertable.sql
@@ -631,3 +631,17 @@ insert into tidrangescan_test (time, some_column) values ('2023-02-12 00:00:20+0
 select * from tidrangescan_test where time > '2023-02-12 00:00:00+02:40'::timestamp with time zone - interval '5 years' and ctid < '(1,1)'::tid ORDER BY time;
 
 drop table tidrangescan_test;
+
+\set ON_ERROR_STOP 0
+\set VERBOSITY default
+set client_min_messages = WARNING;
+-- test creating a hypertable from table referenced by a foreign key fails with
+-- error "cannot have FOREIGN KEY constraints to hypertable".
+create table test_schema.fk_parent(time timestamptz, id int, unique(time, id));
+create table test_schema.fk_child(
+  time timestamptz,
+  id int,
+  foreign key (time, id) references test_schema.fk_parent(time, id)
+);
+select create_hypertable ('test_schema.fk_parent', 'time');
+\set ON_ERROR_STOP 1


### PR DESCRIPTION
 Foreign keys pointing to hypertables are not supported. Creating a
hypertable from a table referenced by foreign key succeeds, but it
leaves the referencing (child) table in a broken state, failing on every
insert with a `violates foreign key constraint` error.

To prevent this scenario, if a foreign key reference to the table exists
before converting it to a hypertable, the following error will be
raised:

```
cannot have FOREIGN KEY contraints to hypertable "<table_name>"
HINT: Remove all FOREIGN KEY constraints to table "<table_name>"
  before making it a hypertable.
```

Fixes #6452
