### PR TITLE
Disable changelog check for backports

### DIFF
--- a/.github/workflows/changelog-check.yaml
+++ b/.github/workflows/changelog-check.yaml
@@ -2,10 +2,8 @@ name: Check for changelog entry file
 "on":
   pull_request:
     types: [opened, synchronize, reopened, edited]
-    # It's important to check that the changelog is updated with bug fixes that
-    # we backport to the release branches, so these branches are included as
-    # well.
-    branches: ["main", "[0-9]+.[0-9]+.x"]
+    branches:
+      - main
 jobs:
   # Check if the PR creates a sperate file with changelog entry in the
   # ".unreleased"  folder


### PR DESCRIPTION
So far, we have also checked the changelog files on our backport branch. However, the test always failed since the backported PR numbers did not match the changelog PR numbers. This PR disables the changelog check on the backport branch.

---

Disable-check: force-changelog-file
Link to failed CI run: https://github.com/timescale/timescaledb/actions/runs/7395253176/job/20118061456