### PR TITLE
Don't analyze the uncompressed chunk before compressing it

### DIFF
--- a/tsl/test/expected/agg_partials_pushdown.out
+++ b/tsl/test/expected/agg_partials_pushdown.out
@@ -23,6 +23,7 @@ SELECT compress_chunk(c) FROM show_chunks('testtable') c;
  _timescaledb_internal._hyper_1_2_chunk
 (2 rows)
 
+ANALYZE testtable;
 -- Pushdown aggregation to the chunk level
 SELECT count(*), sum(v0), sum(v1), sum(v2), sum(v3) FROM testtable WHERE time >= '2000-01-01 00:00:00+0' AND time <= '2000-02-01 00:00:00+0';
  count | sum | sum | sum | sum 
@@ -61,6 +62,7 @@ SELECT count(*), sum(v0), sum(v1), sum(v2), sum(v3) FROM testtable WHERE time >=
 INSERT INTO testtable(time,device_id,v0,v1,v2,v3)
 SELECT time, device_id, device_id+1,  device_id + 2, device_id + 0.5, NULL
 FROM generate_series('2000-01-01 0:00:00+0'::timestamptz,'2000-01-10 23:55:00+0','1day') gtime(time), generate_series(1,5,1) gdevice(device_id);
+ANALYZE testtable;
 -- Pushdown aggregation to the chunk level
 SELECT count(*), sum(v0), sum(v1), sum(v2), sum(v3) FROM testtable WHERE time >= '2000-01-01 00:00:00+0' AND time <= '2000-02-01 00:00:00+0';
  count | sum | sum | sum | sum 
@@ -177,10 +179,11 @@ SELECT count(*), sum(v0), sum(v1), sum(v2), sum(v3) FROM testtable WHERE time >=
                            Filter: ((compress_hyper_2_4_chunk._ts_meta_max_1 >= ('2000-01-09 00:00:00+0'::cstring)::timestamp with time zone) AND (compress_hyper_2_4_chunk._ts_meta_min_1 <= ('2000-02-01 00:00:00+0'::cstring)::timestamp with time zone))
          ->  Partial Aggregate (actual rows=1 loops=1)
                Output: PARTIAL count(*), PARTIAL sum(_hyper_1_2_chunk.v0), PARTIAL sum(_hyper_1_2_chunk.v1), PARTIAL sum(_hyper_1_2_chunk.v2), PARTIAL sum(_hyper_1_2_chunk.v3)
-               ->  Index Scan using _hyper_1_2_chunk_testtable_time_idx on _timescaledb_internal._hyper_1_2_chunk (actual rows=10 loops=1)
+               ->  Seq Scan on _timescaledb_internal._hyper_1_2_chunk (actual rows=10 loops=1)
                      Output: _hyper_1_2_chunk.v0, _hyper_1_2_chunk.v1, _hyper_1_2_chunk.v2, _hyper_1_2_chunk.v3
-                     Index Cond: ((_hyper_1_2_chunk."time" >= ('2000-01-09 00:00:00+0'::cstring)::timestamp with time zone) AND (_hyper_1_2_chunk."time" <= ('2000-02-01 00:00:00+0'::cstring)::timestamp with time zone))
-(22 rows)
+                     Filter: ((_hyper_1_2_chunk."time" >= ('2000-01-09 00:00:00+0'::cstring)::timestamp with time zone) AND (_hyper_1_2_chunk."time" <= ('2000-02-01 00:00:00+0'::cstring)::timestamp with time zone))
+                     Rows Removed by Filter: 15
+(23 rows)
 
 -- Force plain / sorted aggregation
 SET enable_hashagg = OFF;

--- a/tsl/test/expected/compression.out
+++ b/tsl/test/expected/compression.out
@@ -1282,12 +1282,6 @@ SELECT relpages, CASE WHEN reltuples > 0 THEN reltuples ELSE 0 END as reltuples 
         0 |         0
 (1 row)
 
-SELECT histogram_bounds FROM pg_stats WHERE tablename = :statchunk AND attname = 'c1';
-                                                       histogram_bounds                                                        
--------------------------------------------------------------------------------------------------------------------------------
- {0,250,500,750,1000,1250,1500,1750,2000,2250,2500,2750,3000,3250,3500,3750,4000,4250,4500,4750,5000,5250,5500,5750,6000,6250}
-(1 row)
-
 SELECT compch.table_name  as "STAT_COMP_CHUNK_NAME"
 FROM _timescaledb_catalog.hypertable ht, _timescaledb_catalog.chunk ch
        , _timescaledb_catalog.chunk compch
@@ -1300,15 +1294,8 @@ SELECT relpages, CASE WHEN reltuples > 0 THEN reltuples ELSE 0 END as reltuples 
         0 |         0
 (1 row)
 
--- Now verify stats are updated on compressed chunk table when we analyze the hypertable.
-ANALYZE stattest;
-SELECT histogram_bounds FROM pg_stats WHERE tablename = :statchunk AND attname = 'c1';
-                                                       histogram_bounds                                                        
--------------------------------------------------------------------------------------------------------------------------------
- {0,250,500,750,1000,1250,1500,1750,2000,2250,2500,2750,3000,3250,3500,3750,4000,4250,4500,4750,5000,5250,5500,5750,6000,6250}
-(1 row)
-
 -- Unfortunately, the stats on the hypertable won't find any rows to sample from the chunk
+ANALYZE stattest;
 SELECT histogram_bounds FROM pg_stats WHERE tablename = 'stattest' AND attname = 'c1';
  histogram_bounds 
 ------------------

--- a/tsl/test/expected/compression_sorted_merge-13.out
+++ b/tsl/test/expected/compression_sorted_merge-13.out
@@ -1481,6 +1481,7 @@ SELECT compress_chunk(i) FROM show_chunks('bugtab') i;
  _timescaledb_internal._hyper_11_23_chunk
 (1 row)
 
+ANALYZE bugtab;
 :PREFIX
 SELECT "time","hin"::text,"model"::text,"block"::text,"message_name"::text,"signal_name"::text,"signal_numeric_value","signal_string_value"::text FROM :chunk_table_bugtab ORDER BY "time" DESC;
                                                                                                                                                                                                                                                             QUERY PLAN                                                                                                                                                                                                                                                            

--- a/tsl/test/expected/compression_sorted_merge-14.out
+++ b/tsl/test/expected/compression_sorted_merge-14.out
@@ -1481,6 +1481,7 @@ SELECT compress_chunk(i) FROM show_chunks('bugtab') i;
  _timescaledb_internal._hyper_11_23_chunk
 (1 row)
 
+ANALYZE bugtab;
 :PREFIX
 SELECT "time","hin"::text,"model"::text,"block"::text,"message_name"::text,"signal_name"::text,"signal_numeric_value","signal_string_value"::text FROM :chunk_table_bugtab ORDER BY "time" DESC;
                                                                                                                                                                                                                                                             QUERY PLAN                                                                                                                                                                                                                                                            

--- a/tsl/test/expected/compression_sorted_merge-15.out
+++ b/tsl/test/expected/compression_sorted_merge-15.out
@@ -1481,6 +1481,7 @@ SELECT compress_chunk(i) FROM show_chunks('bugtab') i;
  _timescaledb_internal._hyper_11_23_chunk
 (1 row)
 
+ANALYZE bugtab;
 :PREFIX
 SELECT "time","hin"::text,"model"::text,"block"::text,"message_name"::text,"signal_name"::text,"signal_numeric_value","signal_string_value"::text FROM :chunk_table_bugtab ORDER BY "time" DESC;
                                                                                                                                                                                                                                                                QUERY PLAN                                                                                                                                                                                                                                                               

--- a/tsl/test/expected/compression_sorted_merge-16.out
+++ b/tsl/test/expected/compression_sorted_merge-16.out
@@ -1481,6 +1481,7 @@ SELECT compress_chunk(i) FROM show_chunks('bugtab') i;
  _timescaledb_internal._hyper_11_23_chunk
 (1 row)
 
+ANALYZE bugtab;
 :PREFIX
 SELECT "time","hin"::text,"model"::text,"block"::text,"message_name"::text,"signal_name"::text,"signal_numeric_value","signal_string_value"::text FROM :chunk_table_bugtab ORDER BY "time" DESC;
                                                                                                                                                                                                                                                                QUERY PLAN                                                                                                                                                                                                                                                               

--- a/tsl/test/expected/transparent_decompression_join_index-13.out
+++ b/tsl/test/expected/transparent_decompression_join_index-13.out
@@ -1,7 +1,6 @@
 -- This file and its contents are licensed under the Timescale License.
 -- Please see the included NOTICE for copyright information and
 -- LICENSE-TIMESCALE for a copy of the license.
-\c :TEST_DBNAME :ROLE_SUPERUSER
 -- github issue 5585
 create table test (
     time timestamptz not null,
@@ -33,8 +32,11 @@ select compress_chunk(show_chunks('test'));
 
 -- force an index scan
 set enable_seqscan = 'off';
--- disable jit to avoid test flakiness
+-- make some tweaks to avoid flakiness
+analyze test;
+analyze test_copy;
 set jit = off;
+set max_parallel_workers_per_gather = 0;
 explain (costs off) with query_params as (
 	select distinct a, b
 	from test_copy

--- a/tsl/test/expected/transparent_decompression_join_index-14.out
+++ b/tsl/test/expected/transparent_decompression_join_index-14.out
@@ -1,7 +1,6 @@
 -- This file and its contents are licensed under the Timescale License.
 -- Please see the included NOTICE for copyright information and
 -- LICENSE-TIMESCALE for a copy of the license.
-\c :TEST_DBNAME :ROLE_SUPERUSER
 -- github issue 5585
 create table test (
     time timestamptz not null,
@@ -33,8 +32,11 @@ select compress_chunk(show_chunks('test'));
 
 -- force an index scan
 set enable_seqscan = 'off';
--- disable jit to avoid test flakiness
+-- make some tweaks to avoid flakiness
+analyze test;
+analyze test_copy;
 set jit = off;
+set max_parallel_workers_per_gather = 0;
 explain (costs off) with query_params as (
 	select distinct a, b
 	from test_copy

--- a/tsl/test/expected/transparent_decompression_join_index-15.out
+++ b/tsl/test/expected/transparent_decompression_join_index-15.out
@@ -1,7 +1,6 @@
 -- This file and its contents are licensed under the Timescale License.
 -- Please see the included NOTICE for copyright information and
 -- LICENSE-TIMESCALE for a copy of the license.
-\c :TEST_DBNAME :ROLE_SUPERUSER
 -- github issue 5585
 create table test (
     time timestamptz not null,
@@ -33,8 +32,11 @@ select compress_chunk(show_chunks('test'));
 
 -- force an index scan
 set enable_seqscan = 'off';
--- disable jit to avoid test flakiness
+-- make some tweaks to avoid flakiness
+analyze test;
+analyze test_copy;
 set jit = off;
+set max_parallel_workers_per_gather = 0;
 explain (costs off) with query_params as (
 	select distinct a, b
 	from test_copy

--- a/tsl/test/expected/transparent_decompression_join_index-16.out
+++ b/tsl/test/expected/transparent_decompression_join_index-16.out
@@ -1,7 +1,6 @@
 -- This file and its contents are licensed under the Timescale License.
 -- Please see the included NOTICE for copyright information and
 -- LICENSE-TIMESCALE for a copy of the license.
-\c :TEST_DBNAME :ROLE_SUPERUSER
 -- github issue 5585
 create table test (
     time timestamptz not null,
@@ -33,8 +32,11 @@ select compress_chunk(show_chunks('test'));
 
 -- force an index scan
 set enable_seqscan = 'off';
--- disable jit to avoid test flakiness
+-- make some tweaks to avoid flakiness
+analyze test;
+analyze test_copy;
 set jit = off;
+set max_parallel_workers_per_gather = 0;
 explain (costs off) with query_params as (
 	select distinct a, b
 	from test_copy

--- a/tsl/test/shared/expected/decompress_tracking.out
+++ b/tsl/test/shared/expected/decompress_tracking.out
@@ -18,6 +18,7 @@ SELECT count(compress_chunk(ch)) FROM show_chunks('decompress_tracking') ch;
      2
 (1 row)
 
+ANALYZE decompress_tracking;
 -- no tracking without analyze
 :EXPLAIN UPDATE decompress_tracking SET value = value + 3;
 QUERY PLAN
@@ -131,31 +132,35 @@ QUERY PLAN
 -- test prepared statements EXPLAIN still works after execution
 SET plan_cache_mode TO force_generic_plan;
 PREPARE p1 AS UPDATE decompress_tracking SET value = value + 3 WHERE device = 'd1';
-BEGIN; EXPLAIN EXECUTE p1; EXECUTE p1; EXPLAIN EXECUTE p1; ROLLBACK;
+BEGIN;
+    EXPLAIN (COSTS OFF) EXECUTE p1;
 QUERY PLAN
- Custom Scan (HypertableModify)  (cost=0.00..70.83 rows=433 width=18)
-   ->  Update on decompress_tracking  (cost=0.00..70.83 rows=433 width=18)
+ Custom Scan (HypertableModify)
+   ->  Update on decompress_tracking
          Update on _hyper_X_X_chunk decompress_tracking_1
          Update on _hyper_X_X_chunk decompress_tracking_2
-         ->  Result  (cost=0.00..70.83 rows=433 width=18)
-               ->  Append  (cost=0.00..65.42 rows=433 width=18)
-                     ->  Seq Scan on _hyper_X_X_chunk decompress_tracking_1  (cost=0.00..31.62 rows=432 width=18)
+         ->  Result
+               ->  Append
+                     ->  Seq Scan on _hyper_X_X_chunk decompress_tracking_1
                            Filter: (device = 'd1'::text)
-                     ->  Seq Scan on _hyper_X_X_chunk decompress_tracking_2  (cost=0.00..31.62 rows=1 width=18)
+                     ->  Seq Scan on _hyper_X_X_chunk decompress_tracking_2
                            Filter: (device = 'd1'::text)
 (10 rows)
 
+    EXECUTE p1;
+    EXPLAIN (COSTS OFF) EXECUTE p1;
 QUERY PLAN
- Custom Scan (HypertableModify)  (cost=0.00..70.83 rows=433 width=18)
-   ->  Update on decompress_tracking  (cost=0.00..70.83 rows=433 width=18)
+ Custom Scan (HypertableModify)
+   ->  Update on decompress_tracking
          Update on _hyper_X_X_chunk decompress_tracking_1
          Update on _hyper_X_X_chunk decompress_tracking_2
-         ->  Result  (cost=0.00..70.83 rows=433 width=18)
-               ->  Append  (cost=0.00..65.42 rows=433 width=18)
-                     ->  Seq Scan on _hyper_X_X_chunk decompress_tracking_1  (cost=0.00..31.62 rows=432 width=18)
+         ->  Result
+               ->  Append
+                     ->  Seq Scan on _hyper_X_X_chunk decompress_tracking_1
                            Filter: (device = 'd1'::text)
-                     ->  Seq Scan on _hyper_X_X_chunk decompress_tracking_2  (cost=0.00..31.62 rows=1 width=18)
+                     ->  Seq Scan on _hyper_X_X_chunk decompress_tracking_2
                            Filter: (device = 'd1'::text)
 (10 rows)
 
+ROLLBACK;
 DROP TABLE decompress_tracking;

--- a/tsl/test/shared/sql/decompress_tracking.sql
+++ b/tsl/test/shared/sql/decompress_tracking.sql
@@ -15,6 +15,8 @@ INSERT INTO decompress_tracking SELECT '2020-01-01'::timestamptz + format('%s ho
 
 SELECT count(compress_chunk(ch)) FROM show_chunks('decompress_tracking') ch;
 
+ANALYZE decompress_tracking;
+
 -- no tracking without analyze
 :EXPLAIN UPDATE decompress_tracking SET value = value + 3;
 
@@ -30,6 +32,10 @@ BEGIN; :EXPLAIN_ANALYZE INSERT INTO decompress_tracking (VALUES ('2020-01-01 1:3
 -- test prepared statements EXPLAIN still works after execution
 SET plan_cache_mode TO force_generic_plan;
 PREPARE p1 AS UPDATE decompress_tracking SET value = value + 3 WHERE device = 'd1';
-BEGIN; EXPLAIN EXECUTE p1; EXECUTE p1; EXPLAIN EXECUTE p1; ROLLBACK;
+BEGIN;
+    EXPLAIN (COSTS OFF) EXECUTE p1;
+    EXECUTE p1;
+    EXPLAIN (COSTS OFF) EXECUTE p1;
+ROLLBACK;
 
 DROP TABLE decompress_tracking;

--- a/tsl/test/sql/agg_partials_pushdown.sql
+++ b/tsl/test/sql/agg_partials_pushdown.sql
@@ -18,6 +18,8 @@ FROM generate_series('2000-01-01 0:00:00+0'::timestamptz,'2000-01-10 23:55:00+0'
 
 SELECT compress_chunk(c) FROM show_chunks('testtable') c;
 
+ANALYZE testtable;
+
 -- Pushdown aggregation to the chunk level
 SELECT count(*), sum(v0), sum(v1), sum(v2), sum(v3) FROM testtable WHERE time >= '2000-01-01 00:00:00+0' AND time <= '2000-02-01 00:00:00+0';
 
@@ -28,6 +30,8 @@ SELECT count(*), sum(v0), sum(v1), sum(v2), sum(v3) FROM testtable WHERE time >=
 INSERT INTO testtable(time,device_id,v0,v1,v2,v3)
 SELECT time, device_id, device_id+1,  device_id + 2, device_id + 0.5, NULL
 FROM generate_series('2000-01-01 0:00:00+0'::timestamptz,'2000-01-10 23:55:00+0','1day') gtime(time), generate_series(1,5,1) gdevice(device_id);
+
+ANALYZE testtable;
 
 -- Pushdown aggregation to the chunk level
 SELECT count(*), sum(v0), sum(v1), sum(v2), sum(v3) FROM testtable WHERE time >= '2000-01-01 00:00:00+0' AND time <= '2000-02-01 00:00:00+0';

--- a/tsl/test/sql/compression.sql
+++ b/tsl/test/sql/compression.sql
@@ -542,7 +542,6 @@ SELECT count(*) from stattest;
 -- Uncompressed chunk table is empty since we just compressed the chunk and moved everything to compressed chunk table.
 -- reltuples is initially -1 on PG14 before VACUUM/ANALYZE was run
 SELECT relpages, CASE WHEN reltuples > 0 THEN reltuples ELSE 0 END as reltuples FROM pg_class WHERE relname = :statchunk;
-SELECT histogram_bounds FROM pg_stats WHERE tablename = :statchunk AND attname = 'c1';
 
 SELECT compch.table_name  as "STAT_COMP_CHUNK_NAME"
 FROM _timescaledb_catalog.hypertable ht, _timescaledb_catalog.chunk ch
@@ -553,10 +552,8 @@ FROM _timescaledb_catalog.hypertable ht, _timescaledb_catalog.chunk ch
 -- reltuples is initially -1 on PG14 before VACUUM/ANALYZE was run
 SELECT relpages, CASE WHEN reltuples > 0 THEN reltuples ELSE 0 END as reltuples FROM pg_class WHERE relname = :'STAT_COMP_CHUNK_NAME';
 
--- Now verify stats are updated on compressed chunk table when we analyze the hypertable.
-ANALYZE stattest;
-SELECT histogram_bounds FROM pg_stats WHERE tablename = :statchunk AND attname = 'c1';
 -- Unfortunately, the stats on the hypertable won't find any rows to sample from the chunk
+ANALYZE stattest;
 SELECT histogram_bounds FROM pg_stats WHERE tablename = 'stattest' AND attname = 'c1';
 SELECT relpages, reltuples FROM pg_class WHERE relname = :statchunk;
 

--- a/tsl/test/sql/compression_sorted_merge.sql.in
+++ b/tsl/test/sql/compression_sorted_merge.sql.in
@@ -524,6 +524,8 @@ SELECT chunk_schema || '.' || chunk_name AS "chunk_table_bugtab"
 
 SELECT compress_chunk(i) FROM show_chunks('bugtab') i;
 
+ANALYZE bugtab;
+
 :PREFIX
 SELECT "time","hin"::text,"model"::text,"block"::text,"message_name"::text,"signal_name"::text,"signal_numeric_value","signal_string_value"::text FROM :chunk_table_bugtab ORDER BY "time" DESC;
 

--- a/tsl/test/sql/transparent_decompression_join_index.sql.in
+++ b/tsl/test/sql/transparent_decompression_join_index.sql.in
@@ -2,8 +2,6 @@
 -- Please see the included NOTICE for copyright information and
 -- LICENSE-TIMESCALE for a copy of the license.
 
-\c :TEST_DBNAME :ROLE_SUPERUSER
-
 -- github issue 5585
 create table test (
     time timestamptz not null,
@@ -28,8 +26,11 @@ alter table test set (timescaledb.compress, timescaledb.compress_segmentby='a, b
 select compress_chunk(show_chunks('test'));
 -- force an index scan
 set enable_seqscan = 'off';
--- disable jit to avoid test flakiness
+-- make some tweaks to avoid flakiness
+analyze test;
+analyze test_copy;
 set jit = off;
+set max_parallel_workers_per_gather = 0;
 
 explain (costs off) with query_params as (
 	select distinct a, b


### PR DESCRIPTION
Disable-check: force-changelog-file

This speeds up the compression queries by 10% to 300%: https://grafana.ops.savannah-dev.timescale.com/d/fasYic_4z/compare-akuzm?orgId=1&var-branch=All&var-run1=3116&var-run2=3117&var-threshold=0&var-use_historical_thresholds=true&var-threshold_expression=2.5%20*%20percentile_cont(0.90)&var-exact_suite_version=false

Apparently we don't use the statistics on the uncompressed chunk anyway:
<details>

```
schemaname             │ _timescaledb_internal
tablename              │ _hyper_5_174_chunk
attname                │ country
inherited              │ f
null_frac              │ 0
avg_width              │ 13
n_distinct             │ 112
most_common_vals       │ {"GREATER LONDON","GREATER MANCHESTER","WEST YORKSHIRE","WEST MIDLANDS",LANCASHIRE,KENT,MERSEYSIDE,ESSEX,"SOUTH YORKSHIRE",HAMPSHIRE,"TYNE AND WEAR",SURREY,NORFOLK,LINCOLNSHIRE,STAFFORDSHIRE,DEVON,NOTTINGHAMSHIRE,DERBYSHIRE,HERTFORDSHIRE,SUFFOLK,"WEST SUSSEX","NORTH YORKSHIRE",CUMBRIA,"COUNTY DURHAM",GLOUCESTERSHIRE,LEICESTERSHIRE,SOMERSET,CORNWALL,"EAST SUSSEX",OXFORDSHIRE,WARWICKSHIRE,CAMBRIDGESHIRE,WORCESTERSHIRE,"BOURNEMOUTH, CHRISTCHURCH AND POOLE",WILTSHIRE,"CHESHIRE EAST","EAST RIDING OF YORKSHIRE",BUCKINGHAMSHIRE,"WEST NORTHAMPTONSHIRE",DORSET,"CHESHIRE WEST AND CHESTER","CITY OF BRISTOL","NORTH NORTHAMPTONSHIRE",NORTHUMBERLAND,SHROPSHIRE,STOKE-ON-TRENT,"CENTRAL BEDFORDSHIRE","CITY OF KINGSTON UPON HULL",CARDIFF,"CITY OF PLYMOUTH",SWINDON,MEDWAY,"RHONDDA CYNON TAFF","SOUTH GLOUCESTERSHIRE","MILTON KEYNES","CITY OF NOTTINGHAM","CITY OF DERBY","BRIGHTON AND HOVE","NORTH SOMERSET",STOCKTON-ON-TEES,SWANSEA,SOUTHAMPTON,YORK,PORTSMOUTH,"CITY OF PETERBOROUGH",BLACKPOOL,WARRINGTON,"NORTH EAST LINCOLNSHIRE",TORBAY,LEICESTER,SOUTHEND-ON-SEA,HEREFORDSHIRE,"NORTH LINCOLNSHIRE",CARMARTHENSHIRE,"REDCAR AND CLEVELAND",WREKIN,"ISLE OF WIGHT",MIDDLESBROUGH,FLINTSHIRE,"BATH AND NORTH EAST SOMERSET",CAERPHILLY,BEDFORD,DARLINGTON,THURROCK,LUTON,BRIDGEND,"BLACKBURN WITH DARWEN",READING,PEMBROKESHIRE,"NEATH PORT TALBOT","THE VALE OF GLAMORGAN",NEWPORT,CONWY,WOKINGHAM,"WEST BERKSHIRE",POWYS,HARTLEPOOL,WREXHAM,"WINDSOR AND MAIDENHEAD",GWYNEDD,HALTON,DENBIGHSHIRE,"BRACKNELL FOREST",TORFAEN,MONMOUTHSHIRE,"ISLE OF ANGLESEY",SLOUGH,"BLAENAU GWENT",CEREDIGION,"MERTHYR TYDFIL",RUTLAND,"ISLES OF SCILLY"}
most_common_freqs      │ {0.08440667,0.048466668,0.043233335,0.04158,0.028333334,0.027853332,0.02562,0.0252,0.023686666,0.023593333,0.020913333,0.019133333,0.018393334,0.01828,0.01688,0.016873334,0.016833333,0.0165,0.01622,0.015006667,0.01432,0.013886667,0.01232,0.01226,0.01224,0.012033333,0.011606666,0.0113,0.011193333,0.011053333,0.010693333,0.010606667,0.010153334,0.008806666,0.00878,0.0085,0.008273333,0.008186666,0.0076,0.0075066667,0.0073266667,0.0071133333,0.00662,0.006413333,0.0059066666,0.0054,0.0050933333,0.005073333,0.00502,0.004893333,0.0048066666,0.0048,0.0047333334,0.00468,0.0046266667,0.00456,0.0044266665,0.00442,0.004286667,0.0041733333,0.00416,0.0039933333,0.0039933333,0.00394,0.0039333333,0.0039066668,0.0038266666,0.0038133333,0.0037666666,0.0036666666,0.00352,0.0035066667,0.00348,0.00344,0.0033133333,0.0032,0.0031733334,0.00308,0.00296,0.0028733334,0.00286,0.00272,0.0026733333,0.0026266666,0.0026066666,0.0025866667,0.00258,0.0025733334,0.0025666666,0.00252,0.0025066666,0.0024933333,0.0024666667,0.0024133334,0.0024066668,0.0023733333,0.0023533334,0.0022533333,0.0022333334,0.0021666666,0.0020333333,0.0019333333,0.0018733334,0.0015266667,0.0015,0.0014066667,0.0013133333,0.0012933334,0.0011933333,0.00098,0.0006866667,3.3333334e-05}
histogram_bounds       │ ¤
correlation            │ 0.013350017
most_common_elems      │ ¤
most_common_elem_freqs │ ¤
elem_count_histogram   │ ¤


test=# explain select * from uk_price_paid where country = 'GREATER LONDON';
                                              QUERY PLAN                                              
──────────────────────────────────────────────────────────────────────────────────────────────────────
 Append  (cost=0.07..102903.28 rows=20228000 width=78)
   ->  Custom Scan (DecompressChunk) on _hyper_5_170_chunk  (cost=0.07..155.85 rows=2285000 width=78)
         Vectorized Filter: (country = 'GREATER LONDON'::text)
         ->  Seq Scan on compress_hyper_6_194_chunk  (cost=0.00..155.85 rows=2285 width=470)
   ->  Custom Scan (DecompressChunk) on _hyper_5_171_chunk  (cost=0.11..240.64 rows=2264000 width=78)
         Vectorized Filter: (country = 'GREATER LONDON'::text)
         ->  Seq Scan on compress_hyper_6_181_chunk  (cost=0.00..240.64 rows=2264 width=470)
   ->  Custom Scan (DecompressChunk) on _hyper_5_172_chunk  (cost=0.07..160.82 rows=2282000 width=78)
         Vectorized Filter: (country = 'GREATER LONDON'::text)
         ->  Seq Scan on compress_hyper_6_182_chunk  (cost=0.00..160.82 rows=2282 width=470)
   ->  Custom Scan (DecompressChunk) on _hyper_5_173_chunk  (cost=0.08..179.71 rows=2271000 width=78)
         Vectorized Filter: (country = 'GREATER LONDON'::text)
         ->  Seq Scan on compress_hyper_6_183_chunk  (cost=0.00..179.71 rows=2271 width=470)
   ->  Custom Scan (DecompressChunk) on _hyper_5_174_chunk  (cost=0.08..183.73 rows=2273000 width=78)
         Vectorized Filter: (country = 'GREATER LONDON'::text)
         ->  Seq Scan on compress_hyper_6_184_chunk  (cost=0.00..183.73 rows=2273 width=470)
   ->  Custom Scan (DecompressChunk) on _hyper_5_175_chunk  (cost=0.07..160.79 rows=2279000 width=78)
         Vectorized Filter: (country = 'GREATER LONDON'::text)
         ->  Seq Scan on compress_hyper_6_185_chunk  (cost=0.00..160.79 rows=2279 width=470)
   ->  Custom Scan (DecompressChunk) on _hyper_5_176_chunk  (cost=0.11..247.59 rows=2259000 width=78)
         Vectorized Filter: (country = 'GREATER LONDON'::text)
         ->  Seq Scan on compress_hyper_6_186_chunk  (cost=0.00..247.59 rows=2259 width=470)
   ->  Custom Scan (DecompressChunk) on _hyper_5_177_chunk  (cost=0.08..181.78 rows=2278000 width=79)
         Vectorized Filter: (country = 'GREATER LONDON'::text)
         ->  Seq Scan on compress_hyper_6_187_chunk  (cost=0.00..181.78 rows=2278 width=470)
   ->  Custom Scan (DecompressChunk) on _hyper_5_178_chunk  (cost=0.12..247.96 rows=1996000 width=79)
         Vectorized Filter: (country = 'GREATER LONDON'::text)
         ->  Seq Scan on compress_hyper_6_188_chunk  (cost=0.00..247.96 rows=1996 width=470)
   ->  Custom Scan (DecompressChunk) on _hyper_5_179_chunk  (cost=0.11..4.41 rows=41000 width=80)
         Vectorized Filter: (country = 'GREATER LONDON'::text)
         ->  Seq Scan on compress_hyper_6_189_chunk  (cost=0.00..4.41 rows=41 width=472)
(31 rows)

Time: 13.892 ms
test=# explain select * from uk_price_paid where country = 'SLOUGH';
                                              QUERY PLAN                                              
──────────────────────────────────────────────────────────────────────────────────────────────────────
 Append  (cost=0.07..102903.28 rows=20228000 width=78)
   ->  Custom Scan (DecompressChunk) on _hyper_5_170_chunk  (cost=0.07..155.85 rows=2285000 width=78)
         Vectorized Filter: (country = 'SLOUGH'::text)
         ->  Seq Scan on compress_hyper_6_194_chunk  (cost=0.00..155.85 rows=2285 width=470)
   ->  Custom Scan (DecompressChunk) on _hyper_5_171_chunk  (cost=0.11..240.64 rows=2264000 width=78)
         Vectorized Filter: (country = 'SLOUGH'::text)
         ->  Seq Scan on compress_hyper_6_181_chunk  (cost=0.00..240.64 rows=2264 width=470)
   ->  Custom Scan (DecompressChunk) on _hyper_5_172_chunk  (cost=0.07..160.82 rows=2282000 width=78)
         Vectorized Filter: (country = 'SLOUGH'::text)
         ->  Seq Scan on compress_hyper_6_182_chunk  (cost=0.00..160.82 rows=2282 width=470)
   ->  Custom Scan (DecompressChunk) on _hyper_5_173_chunk  (cost=0.08..179.71 rows=2271000 width=78)
         Vectorized Filter: (country = 'SLOUGH'::text)
         ->  Seq Scan on compress_hyper_6_183_chunk  (cost=0.00..179.71 rows=2271 width=470)
   ->  Custom Scan (DecompressChunk) on _hyper_5_174_chunk  (cost=0.08..183.73 rows=2273000 width=78)
         Vectorized Filter: (country = 'SLOUGH'::text)
         ->  Seq Scan on compress_hyper_6_184_chunk  (cost=0.00..183.73 rows=2273 width=470)
   ->  Custom Scan (DecompressChunk) on _hyper_5_175_chunk  (cost=0.07..160.79 rows=2279000 width=78)
         Vectorized Filter: (country = 'SLOUGH'::text)
         ->  Seq Scan on compress_hyper_6_185_chunk  (cost=0.00..160.79 rows=2279 width=470)
   ->  Custom Scan (DecompressChunk) on _hyper_5_176_chunk  (cost=0.11..247.59 rows=2259000 width=78)
         Vectorized Filter: (country = 'SLOUGH'::text)
         ->  Seq Scan on compress_hyper_6_186_chunk  (cost=0.00..247.59 rows=2259 width=470)
   ->  Custom Scan (DecompressChunk) on _hyper_5_177_chunk  (cost=0.08..181.78 rows=2278000 width=79)
         Vectorized Filter: (country = 'SLOUGH'::text)
         ->  Seq Scan on compress_hyper_6_187_chunk  (cost=0.00..181.78 rows=2278 width=470)
   ->  Custom Scan (DecompressChunk) on _hyper_5_178_chunk  (cost=0.12..247.96 rows=1996000 width=79)
         Vectorized Filter: (country = 'SLOUGH'::text)
         ->  Seq Scan on compress_hyper_6_188_chunk  (cost=0.00..247.96 rows=1996 width=470)
   ->  Custom Scan (DecompressChunk) on _hyper_5_179_chunk  (cost=0.11..4.41 rows=41000 width=80)
         Vectorized Filter: (country = 'SLOUGH'::text)
         ->  Seq Scan on compress_hyper_6_189_chunk  (cost=0.00..4.41 rows=41 width=472)
(31 rows)
```

</details>