### PR TITLE
Fix OS X build

### DIFF
--- a/.github/workflows/linux-build-and-test.yaml
+++ b/.github/workflows/linux-build-and-test.yaml
@@ -73,6 +73,7 @@ jobs:
 
         # Force use of OpenSSL 3.1.4, since OpenSSL 3.2.0 crashes with recent
         # PostgreSQL versions on OS X (see https://github.com/Homebrew/homebrew-core/issues/155651)
+        brew install --overwrite python@3.11
         brew unlink openssl@3
         curl -L https://raw.githubusercontent.com/Homebrew/homebrew-core/e68186ba5a05a6ea9a30d6c7744de9a46bd3aadd/Formula/o/openssl@3.rb > openssl@3.rb
         brew install openssl@3.rb


### PR DESCRIPTION
The OS X build currently fails with a brew link error for Python. This PR fixes the problem by allowing the overwriting of existing files in the Python install step.

---

Disable-check: force-changelog-file
Failed CI run: https://github.com/timescale/timescaledb/actions/runs/7458415023/job/20292684115?pr=6497
Fixed CI run: https://github.com/timescale/timescaledb/actions/runs/7458792901/job/20293479793?pr=6503