### PR TITLE
Remove references to compressed hypertable internals from tests

### DIFF
--- a/tsl/test/expected/cagg_errors.out
+++ b/tsl/test/expected/cagg_errors.out
@@ -625,7 +625,7 @@ FROM
   _timescaledb_catalog.hypertable ht
   INNER JOIN _timescaledb_catalog.hypertable uncompress ON (ht.id = uncompress.compressed_hypertable_id
       AND uncompress.table_name = 'comp_ht_test') \gset
-CREATE MATERIALIZED VIEW cagg1 WITH(timescaledb.continuous, timescaledb.materialized_only=false) AS SELECT time_bucket('1h',_ts_meta_min_1) FROM :INTERNALTABLE GROUP BY 1;
+CREATE MATERIALIZED VIEW cagg1 WITH(timescaledb.continuous, timescaledb.materialized_only=false) AS SELECT time_bucket('1h',now()) FROM :INTERNALTABLE GROUP BY 1;
 ERROR:  hypertable is an internal compressed hypertable
 --TEST ht + cagg, do not enable compression on ht and try to compress chunk on ht.
 --Check error handling for this case

--- a/tsl/test/expected/compressed_collation.out
+++ b/tsl/test/expected/compressed_collation.out
@@ -30,19 +30,19 @@ SELECT count(compress_chunk(ch)) FROM show_chunks('compressed_collation_ht') ch;
      1
 (1 row)
 
-select ht.schema_name || '.' || ht.table_name as "CHUNK"
-from _timescaledb_catalog.hypertable ht
-    inner join _timescaledb_catalog.hypertable ht2
-    on ht.id = ht2.compressed_hypertable_id
-        and ht2.table_name = 'compressed_collation_ht' \gset
+SELECT format('%I.%I',ch.schema_name, ch.table_name) AS "CHUNK"
+FROM _timescaledb_catalog.hypertable ht
+    INNER JOIN _timescaledb_catalog.chunk ch
+    ON ch.hypertable_id = ht.compressed_hypertable_id
+        AND ht.table_name = 'compressed_collation_ht' \gset
 create index on :CHUNK (name);
 set enable_seqscan to off;
 explain (costs off)
 select * from compressed_collation_ht order by name;
-                                                  QUERY PLAN                                                   
----------------------------------------------------------------------------------------------------------------
+                                      QUERY PLAN                                      
+--------------------------------------------------------------------------------------
  Custom Scan (DecompressChunk) on _hyper_1_1_chunk
-   ->  Index Scan using compress_hyper_2_2_chunk__compressed_hypertable_2_name_idx on compress_hyper_2_2_chunk
+   ->  Index Scan using compress_hyper_2_2_chunk_name_idx on compress_hyper_2_2_chunk
 (2 rows)
 
 select * from compressed_collation_ht order by name;

--- a/tsl/test/expected/reorder.out
+++ b/tsl/test/expected/reorder.out
@@ -1366,7 +1366,6 @@ FROM
   INNER JOIN _timescaledb_catalog.hypertable uncompress ON (ht.id = uncompress.compressed_hypertable_id
       AND uncompress.table_name = 'comp_ht_test') \gset
 \c :TEST_DBNAME :ROLE_SUPERUSER
-CREATE INDEX internal_idx ON :INTERNALTABLE(_ts_meta_min_1);
 \set ON_ERROR_STOP 0
 SELECT add_reorder_policy(:'INTERNALTABLE','internal_idx');
 ERROR:  cannot add reorder policy to compressed hypertable "_compressed_hypertable_5"

--- a/tsl/test/sql/cagg_errors.sql
+++ b/tsl/test/sql/cagg_errors.sql
@@ -517,7 +517,7 @@ FROM
   INNER JOIN _timescaledb_catalog.hypertable uncompress ON (ht.id = uncompress.compressed_hypertable_id
       AND uncompress.table_name = 'comp_ht_test') \gset
 
-CREATE MATERIALIZED VIEW cagg1 WITH(timescaledb.continuous, timescaledb.materialized_only=false) AS SELECT time_bucket('1h',_ts_meta_min_1) FROM :INTERNALTABLE GROUP BY 1;
+CREATE MATERIALIZED VIEW cagg1 WITH(timescaledb.continuous, timescaledb.materialized_only=false) AS SELECT time_bucket('1h',now()) FROM :INTERNALTABLE GROUP BY 1;
 
 --TEST ht + cagg, do not enable compression on ht and try to compress chunk on ht.
 --Check error handling for this case

--- a/tsl/test/sql/compressed_collation.sql
+++ b/tsl/test/sql/compressed_collation.sql
@@ -26,11 +26,11 @@ insert into compressed_collation_ht values ('2021-01-01 01:01:01', 'á', '1'),
 
 SELECT count(compress_chunk(ch)) FROM show_chunks('compressed_collation_ht') ch;
 
-select ht.schema_name || '.' || ht.table_name as "CHUNK"
-from _timescaledb_catalog.hypertable ht
-    inner join _timescaledb_catalog.hypertable ht2
-    on ht.id = ht2.compressed_hypertable_id
-        and ht2.table_name = 'compressed_collation_ht' \gset
+SELECT format('%I.%I',ch.schema_name, ch.table_name) AS "CHUNK"
+FROM _timescaledb_catalog.hypertable ht
+    INNER JOIN _timescaledb_catalog.chunk ch
+    ON ch.hypertable_id = ht.compressed_hypertable_id
+        AND ht.table_name = 'compressed_collation_ht' \gset
 
 create index on :CHUNK (name);
 

--- a/tsl/test/sql/reorder.sql
+++ b/tsl/test/sql/reorder.sql
@@ -259,7 +259,6 @@ FROM
       AND uncompress.table_name = 'comp_ht_test') \gset
 
 \c :TEST_DBNAME :ROLE_SUPERUSER
-CREATE INDEX internal_idx ON :INTERNALTABLE(_ts_meta_min_1);
 \set ON_ERROR_STOP 0
 SELECT add_reorder_policy(:'INTERNALTABLE','internal_idx');
 \set ON_ERROR_STOP 1


### PR DESCRIPTION
Adjust tests to not access columns in the compressed hypertable. While this is currently possible a followup patch will remove this functionality.