### PR TITLE
Use parameterized time_bucket for chunk exclusion

### DIFF
--- a/.github/workflows/changelog-check.yaml
+++ b/.github/workflows/changelog-check.yaml
@@ -22,15 +22,26 @@ jobs:
     name: Check for file with CHANGELOG entry
     runs-on: ubuntu-latest
     steps:
+      - name: Install Linux Dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install pip
+
+      - name: Install Python Dependencies
+        run: |
+          pip install PyGithub
+
       - name: Checkout source
         uses: actions/checkout@v3
         with:
           ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: 0
+
       - name: Check if the pull request adds file in ".unreleased" folder
         shell: bash --norc --noprofile {0}
         env:
           BODY: ${{ github.event.pull_request.body }}
+          GITHUB_TOKEN: ${{ secrets.ORG_AUTOMATION_TOKEN }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
         run: |
           folder=".unreleased"

--- a/.unreleased/fix-parameterized-time-bucket
+++ b/.unreleased/fix-parameterized-time-bucket
@@ -1,0 +1,2 @@
+Fixes: #6498 Suboptimal query plans when using time_bucket with query parameters
+Thanks: @jbx1 for reporting suboptimal query plans when using time_bucket with query parameters

--- a/scripts/check_changelog_format.py
+++ b/scripts/check_changelog_format.py
@@ -4,6 +4,68 @@ import sys
 import re
 import os
 
+import github  # this is PyGithub.
+
+import requests
+import string
+
+
+def run_query(query):
+    """A simple function to use requests.post to make the GraphQL API call."""
+
+    request = requests.post(
+        "https://api.github.com/graphql",
+        json={"query": query},
+        headers={"Authorization": f'Bearer {os.environ.get("GITHUB_TOKEN")}'},
+        timeout=20,
+    )
+    response = request.json()
+
+    # Have to work around the unique GraphQL convention of returning 200 for errors.
+    if request.status_code != 200 or "errors" in response:
+        raise ValueError(
+            f"Query failed to run by returning code of {request.status_code}."
+            f"\nQuery: '{query}'"
+            f"\nResponse: '{request.json()}'"
+        )
+
+    return response
+
+
+def get_referenced_issues(pr_number):
+    """Get the numbers of issue fixed by the given pull request."""
+
+    ref_result = run_query(
+        string.Template(
+            """
+        query {
+            repository(owner: "timescale", name: "timescaledb") {
+              pullRequest(number: $pr_number) {
+                closingIssuesReferences(first: 100) {
+                  edges {
+                    node {
+                      number
+                    }
+                  }
+                }
+              }
+            }
+          }
+          """
+        ).substitute({"pr_number": pr_number})
+    )
+
+    # The above returns {'data': {'repository': {'pullRequest': {'closingIssuesReferences': {'edges': [{'node': {'number': 4944}}]}}}}}
+
+    ref_edges = ref_result["data"]["repository"]["pullRequest"][
+        "closingIssuesReferences"
+    ]["edges"]
+
+    if not ref_edges:
+        return []
+
+    return [edge["node"]["number"] for edge in ref_edges if edge]
+
 
 # Check if a line matches any of the specified patterns
 def is_valid_line(line):
@@ -15,28 +77,63 @@ def is_valid_line(line):
 
 
 def main():
+    github_obj = github.Github(os.environ.get("GITHUB_TOKEN"))
+    repo = github_obj.get_repo("timescale/timescaledb")
     # Get the file name from the command line argument
-    if len(sys.argv) > 1:
-        file_name = sys.argv[1]
-        pr_number_seen = False
-        pr_num_str = f'#{os.environ["PR_NUMBER"]} '
-        # Read the file and check non-empty lines
-        with open(file_name, "r", encoding="utf-8") as file:
-            for line in file:
-                line = line.strip()
-                pr_number_seen |= pr_num_str in line
-                if line and not is_valid_line(line):
-                    print(f'Invalid entry in change log: "{line}"')
-                    sys.exit(1)
-        if not pr_number_seen:
-            print(
-                f'Expected that the changelog contains a reference to the PR: "{pr_num_str}"'
-            )
-            sys.exit(1)
-    else:
+    if len(sys.argv) != 2:
         print("Please provide a file name as a command-line argument.")
         sys.exit(1)
-    sys.exit(0)
+
+    file_name = sys.argv[1]
+    this_pr_number = int(os.environ["PR_NUMBER"])
+    pr_issues = set(get_referenced_issues(this_pr_number))
+
+    # Read the file and check non-empty lines
+    changelog_issues = set()
+    with open(file_name, "r", encoding="utf-8") as file:
+        for line in file:
+            line = line.strip()
+            if not is_valid_line(line):
+                print(f'Invalid entry in change log: "{line}"')
+                sys.exit(1)
+
+            # The referenced issue number should be valid.
+            for issue_number in re.findall("#([0-9]+)", line):
+                issue_number = int(issue_number)
+                try:
+                    issue = repo.get_issue(number=issue_number)
+                except github.UnknownObjectException:
+                    print(
+                        f"The changelog entry references an invalid issue #{issue_number}:\n{line}"
+                    )
+                    sys.exit(1)
+
+                as_pr = None
+                try:
+                    as_pr = issue.as_pull_request()
+                except github.UnknownObjectException:
+                    # Not a pull request
+                    pass
+
+                # Accept references to PR itself.
+                if as_pr:
+                    if issue_number != this_pr_number:
+                        print(
+                            f"The changelog for PR #{this_pr_number} references another PR #{issue_number}"
+                        )
+                        sys.exit(1)
+                    changelog_issues = pr_issues
+                else:
+                    changelog_issues.add(issue_number)
+
+    if changelog_issues != pr_issues:
+        print(
+            "Instead of "
+            + (f"the issues {pr_issues}" if pr_issues else "no issues")
+            + f" linked to the PR #{this_pr_number}, the changelog references "
+            + (f"the issues {changelog_issues}" if changelog_issues else "no issues")
+        )
+        sys.exit(1)
 
 
 if __name__ == "__main__":

--- a/src/nodes/chunk_append/chunk_append.c
+++ b/src/nodes/chunk_append/chunk_append.c
@@ -158,10 +158,20 @@ ts_chunk_append_path_create(PlannerInfo *root, RelOptInfo *rel, Hypertable *ht, 
 	{
 		RestrictInfo *rinfo = (RestrictInfo *) lfirst(lc);
 
-		if (contain_mutable_functions((Node *) rinfo->clause))
+		/*
+		 * The external parameters (e.g. from parameterized prepared statements)
+		 * are constant during query run time, so we can use them for startup
+		 * exclusion.
+		 * The join parameters have multiple values, so they are only used for
+		 * runtime exclusion.
+		 */
+		if (contain_mutable_functions((Node *) rinfo->clause) ||
+			ts_contains_external_param((Node *) rinfo->clause))
+		{
 			path->startup_exclusion = true;
+		}
 
-		if (ts_guc_enable_runtime_exclusion && ts_contain_param((Node *) rinfo->clause))
+		if (ts_guc_enable_runtime_exclusion && ts_contains_join_param((Node *) rinfo->clause))
 		{
 			ListCell *lc_var;
 

--- a/src/planner/planner.h
+++ b/src/planner/planner.h
@@ -42,7 +42,8 @@ typedef struct TimescaleDBPrivate
 
 extern TSDLLEXPORT bool ts_rte_is_hypertable(const RangeTblEntry *rte);
 extern TSDLLEXPORT bool ts_rte_is_marked_for_expansion(const RangeTblEntry *rte);
-extern TSDLLEXPORT bool ts_contain_param(Node *node);
+extern TSDLLEXPORT bool ts_contains_external_param(Node *node);
+extern TSDLLEXPORT bool ts_contains_join_param(Node *node);
 
 static inline TimescaleDBPrivate *
 ts_create_private_reloptinfo(RelOptInfo *rel)
@@ -98,6 +99,7 @@ extern void ts_plan_add_hashagg(PlannerInfo *root, RelOptInfo *input_rel, RelOpt
 extern void ts_preprocess_first_last_aggregates(PlannerInfo *root, List *tlist);
 extern void ts_plan_expand_hypertable_chunks(Hypertable *ht, PlannerInfo *root, RelOptInfo *rel);
 extern void ts_plan_expand_timebucket_annotate(PlannerInfo *root, RelOptInfo *rel);
+extern Expr *ts_transform_time_bucket_comparison(Expr *);
 extern Node *ts_constify_now(PlannerInfo *root, List *rtable, Node *node);
 extern void ts_planner_constraint_cleanup(PlannerInfo *root, RelOptInfo *rel);
 extern Node *ts_add_space_constraints(PlannerInfo *root, List *rtable, Node *node);

--- a/test/expected/plan_expand_hypertable-13.out
+++ b/test/expected/plan_expand_hypertable-13.out
@@ -1217,6 +1217,445 @@ transformation would be out of range
          Filter: (time_bucket('@ 1000 days'::interval, "time") < 'Sat Jan 01 00:00:00 294276 PST'::timestamp with time zone)
 (12 rows)
 
+\qecho time_bucket exclusion with run-time constants
+time_bucket exclusion with run-time constants
+-- These queries have a stable time_bucket expression, because the text::interval conversion is stable.
+PREPARE P1(text    , text) AS SELECT * FROM metrics_timestamptz WHERE time_bucket($1::interval, time) > $2::timestamptz ORDER BY time;
+PREPARE P2(text    , text) AS SELECT * FROM metrics_timestamp   WHERE time_bucket($1::interval, time) > $2::timestamptz ORDER BY time;
+PREPARE P3(text    , text) AS SELECT * FROM metrics_timestamptz WHERE time_bucket($1::interval, time) > $2::timestamp   ORDER BY time;
+PREPARE P4(text    , text) AS SELECT * FROM metrics_timestamp   WHERE time_bucket($1::interval, time) > $2::timestamp   ORDER BY time;
+-- These queries have an immutable time_bucket expression, because the parameter is passed as interval, and no conversion is involved.
+PREPARE P5(interval, text) AS SELECT * FROM metrics_timestamptz WHERE time_bucket($1::interval, time) > $2::timestamptz ORDER BY time;
+PREPARE P6(interval, text) AS SELECT * FROM metrics_timestamp   WHERE time_bucket($1::interval, time) > $2::timestamptz ORDER BY time;
+PREPARE P7(interval, text) AS SELECT * FROM metrics_timestamptz WHERE time_bucket($1::interval, time) > $2::timestamp   ORDER BY time;
+PREPARE P8(interval, text) AS SELECT * FROM metrics_timestamp   WHERE time_bucket($1::interval, time) > $2::timestamp   ORDER BY time;
+SET plan_cache_mode TO 'force_custom_plan';
+:PREFIX EXECUTE P1('60 mins', '2024-01-01 UTC');
+                    QUERY PLAN                    
+--------------------------------------------------
+ Custom Scan (ChunkAppend) on metrics_timestamptz
+   Order: metrics_timestamptz."time"
+   Chunks excluded during startup: 5
+(3 rows)
+
+:PREFIX EXECUTE P2('60 mins', '2024-01-01 UTC');
+                   QUERY PLAN                   
+------------------------------------------------
+ Custom Scan (ChunkAppend) on metrics_timestamp
+   Order: metrics_timestamp."time"
+   Chunks excluded during startup: 5
+(3 rows)
+
+:PREFIX EXECUTE P3('60 mins', '2024-01-01 UTC');
+                    QUERY PLAN                    
+--------------------------------------------------
+ Custom Scan (ChunkAppend) on metrics_timestamptz
+   Order: metrics_timestamptz."time"
+   Chunks excluded during startup: 5
+(3 rows)
+
+:PREFIX EXECUTE P4('60 mins', '2024-01-01 UTC');
+                   QUERY PLAN                   
+------------------------------------------------
+ Custom Scan (ChunkAppend) on metrics_timestamp
+   Order: metrics_timestamp."time"
+   Chunks excluded during startup: 5
+(3 rows)
+
+:PREFIX EXECUTE P5('60 mins', '2024-01-01 UTC');
+                    QUERY PLAN                    
+--------------------------------------------------
+ Custom Scan (ChunkAppend) on metrics_timestamptz
+   Order: metrics_timestamptz."time"
+   Chunks excluded during startup: 5
+(3 rows)
+
+:PREFIX EXECUTE P6('60 mins', '2024-01-01 UTC');
+                   QUERY PLAN                   
+------------------------------------------------
+ Custom Scan (ChunkAppend) on metrics_timestamp
+   Order: metrics_timestamp."time"
+   Chunks excluded during startup: 5
+(3 rows)
+
+:PREFIX EXECUTE P7('60 mins', '2024-01-01 UTC');
+                    QUERY PLAN                    
+--------------------------------------------------
+ Custom Scan (ChunkAppend) on metrics_timestamptz
+   Order: metrics_timestamptz."time"
+   Chunks excluded during startup: 5
+(3 rows)
+
+:PREFIX EXECUTE P8('60 mins', '2024-01-01 UTC');
+                   QUERY PLAN                   
+------------------------------------------------
+ Custom Scan (ChunkAppend) on metrics_timestamp
+   Order: metrics_timestamp."time"
+   Chunks excluded during startup: 5
+(3 rows)
+
+:PREFIX EXECUTE P1('60 mins', '2000-01-01 UTC');
+                                                          QUERY PLAN                                                           
+-------------------------------------------------------------------------------------------------------------------------------
+ Custom Scan (ChunkAppend) on metrics_timestamptz
+   Order: metrics_timestamptz."time"
+   Chunks excluded during startup: 0
+   ->  Index Scan Backward using _hyper_6_160_chunk_metrics_timestamptz_time_idx on _hyper_6_160_chunk
+         Filter: (time_bucket(('60 mins'::cstring)::interval, "time") > ('2000-01-01 UTC'::cstring)::timestamp with time zone)
+   ->  Index Scan Backward using _hyper_6_161_chunk_metrics_timestamptz_time_idx on _hyper_6_161_chunk
+         Filter: (time_bucket(('60 mins'::cstring)::interval, "time") > ('2000-01-01 UTC'::cstring)::timestamp with time zone)
+   ->  Index Scan Backward using _hyper_6_162_chunk_metrics_timestamptz_time_idx on _hyper_6_162_chunk
+         Filter: (time_bucket(('60 mins'::cstring)::interval, "time") > ('2000-01-01 UTC'::cstring)::timestamp with time zone)
+   ->  Index Scan Backward using _hyper_6_163_chunk_metrics_timestamptz_time_idx on _hyper_6_163_chunk
+         Filter: (time_bucket(('60 mins'::cstring)::interval, "time") > ('2000-01-01 UTC'::cstring)::timestamp with time zone)
+   ->  Index Scan Backward using _hyper_6_164_chunk_metrics_timestamptz_time_idx on _hyper_6_164_chunk
+         Filter: (time_bucket(('60 mins'::cstring)::interval, "time") > ('2000-01-01 UTC'::cstring)::timestamp with time zone)
+(13 rows)
+
+:PREFIX EXECUTE P2('60 mins', '2000-01-01 UTC');
+                                                          QUERY PLAN                                                           
+-------------------------------------------------------------------------------------------------------------------------------
+ Custom Scan (ChunkAppend) on metrics_timestamp
+   Order: metrics_timestamp."time"
+   Chunks excluded during startup: 0
+   ->  Index Only Scan Backward using _hyper_5_155_chunk_metrics_timestamp_time_idx on _hyper_5_155_chunk
+         Filter: (time_bucket(('60 mins'::cstring)::interval, "time") > ('2000-01-01 UTC'::cstring)::timestamp with time zone)
+   ->  Index Only Scan Backward using _hyper_5_156_chunk_metrics_timestamp_time_idx on _hyper_5_156_chunk
+         Filter: (time_bucket(('60 mins'::cstring)::interval, "time") > ('2000-01-01 UTC'::cstring)::timestamp with time zone)
+   ->  Index Only Scan Backward using _hyper_5_157_chunk_metrics_timestamp_time_idx on _hyper_5_157_chunk
+         Filter: (time_bucket(('60 mins'::cstring)::interval, "time") > ('2000-01-01 UTC'::cstring)::timestamp with time zone)
+   ->  Index Only Scan Backward using _hyper_5_158_chunk_metrics_timestamp_time_idx on _hyper_5_158_chunk
+         Filter: (time_bucket(('60 mins'::cstring)::interval, "time") > ('2000-01-01 UTC'::cstring)::timestamp with time zone)
+   ->  Index Only Scan Backward using _hyper_5_159_chunk_metrics_timestamp_time_idx on _hyper_5_159_chunk
+         Filter: (time_bucket(('60 mins'::cstring)::interval, "time") > ('2000-01-01 UTC'::cstring)::timestamp with time zone)
+(13 rows)
+
+:PREFIX EXECUTE P3('60 mins', '2000-01-01 UTC');
+                                                            QUERY PLAN                                                            
+----------------------------------------------------------------------------------------------------------------------------------
+ Custom Scan (ChunkAppend) on metrics_timestamptz
+   Order: metrics_timestamptz."time"
+   Chunks excluded during startup: 0
+   ->  Index Scan Backward using _hyper_6_160_chunk_metrics_timestamptz_time_idx on _hyper_6_160_chunk
+         Filter: (time_bucket(('60 mins'::cstring)::interval, "time") > ('2000-01-01 UTC'::cstring)::timestamp without time zone)
+   ->  Index Scan Backward using _hyper_6_161_chunk_metrics_timestamptz_time_idx on _hyper_6_161_chunk
+         Filter: (time_bucket(('60 mins'::cstring)::interval, "time") > ('2000-01-01 UTC'::cstring)::timestamp without time zone)
+   ->  Index Scan Backward using _hyper_6_162_chunk_metrics_timestamptz_time_idx on _hyper_6_162_chunk
+         Filter: (time_bucket(('60 mins'::cstring)::interval, "time") > ('2000-01-01 UTC'::cstring)::timestamp without time zone)
+   ->  Index Scan Backward using _hyper_6_163_chunk_metrics_timestamptz_time_idx on _hyper_6_163_chunk
+         Filter: (time_bucket(('60 mins'::cstring)::interval, "time") > ('2000-01-01 UTC'::cstring)::timestamp without time zone)
+   ->  Index Scan Backward using _hyper_6_164_chunk_metrics_timestamptz_time_idx on _hyper_6_164_chunk
+         Filter: (time_bucket(('60 mins'::cstring)::interval, "time") > ('2000-01-01 UTC'::cstring)::timestamp without time zone)
+(13 rows)
+
+:PREFIX EXECUTE P4('60 mins', '2000-01-01 UTC');
+                                                            QUERY PLAN                                                            
+----------------------------------------------------------------------------------------------------------------------------------
+ Custom Scan (ChunkAppend) on metrics_timestamp
+   Order: metrics_timestamp."time"
+   Chunks excluded during startup: 0
+   ->  Index Only Scan Backward using _hyper_5_155_chunk_metrics_timestamp_time_idx on _hyper_5_155_chunk
+         Filter: (time_bucket(('60 mins'::cstring)::interval, "time") > ('2000-01-01 UTC'::cstring)::timestamp without time zone)
+   ->  Index Only Scan Backward using _hyper_5_156_chunk_metrics_timestamp_time_idx on _hyper_5_156_chunk
+         Filter: (time_bucket(('60 mins'::cstring)::interval, "time") > ('2000-01-01 UTC'::cstring)::timestamp without time zone)
+   ->  Index Only Scan Backward using _hyper_5_157_chunk_metrics_timestamp_time_idx on _hyper_5_157_chunk
+         Filter: (time_bucket(('60 mins'::cstring)::interval, "time") > ('2000-01-01 UTC'::cstring)::timestamp without time zone)
+   ->  Index Only Scan Backward using _hyper_5_158_chunk_metrics_timestamp_time_idx on _hyper_5_158_chunk
+         Filter: (time_bucket(('60 mins'::cstring)::interval, "time") > ('2000-01-01 UTC'::cstring)::timestamp without time zone)
+   ->  Index Only Scan Backward using _hyper_5_159_chunk_metrics_timestamp_time_idx on _hyper_5_159_chunk
+         Filter: (time_bucket(('60 mins'::cstring)::interval, "time") > ('2000-01-01 UTC'::cstring)::timestamp without time zone)
+(13 rows)
+
+:PREFIX EXECUTE P5('60 mins', '2000-01-01 UTC');
+                                                     QUERY PLAN                                                      
+---------------------------------------------------------------------------------------------------------------------
+ Custom Scan (ChunkAppend) on metrics_timestamptz
+   Order: metrics_timestamptz."time"
+   Chunks excluded during startup: 0
+   ->  Index Scan Backward using _hyper_6_160_chunk_metrics_timestamptz_time_idx on _hyper_6_160_chunk
+         Filter: (time_bucket('@ 1 hour'::interval, "time") > ('2000-01-01 UTC'::cstring)::timestamp with time zone)
+   ->  Index Scan Backward using _hyper_6_161_chunk_metrics_timestamptz_time_idx on _hyper_6_161_chunk
+         Filter: (time_bucket('@ 1 hour'::interval, "time") > ('2000-01-01 UTC'::cstring)::timestamp with time zone)
+   ->  Index Scan Backward using _hyper_6_162_chunk_metrics_timestamptz_time_idx on _hyper_6_162_chunk
+         Filter: (time_bucket('@ 1 hour'::interval, "time") > ('2000-01-01 UTC'::cstring)::timestamp with time zone)
+   ->  Index Scan Backward using _hyper_6_163_chunk_metrics_timestamptz_time_idx on _hyper_6_163_chunk
+         Filter: (time_bucket('@ 1 hour'::interval, "time") > ('2000-01-01 UTC'::cstring)::timestamp with time zone)
+   ->  Index Scan Backward using _hyper_6_164_chunk_metrics_timestamptz_time_idx on _hyper_6_164_chunk
+         Filter: (time_bucket('@ 1 hour'::interval, "time") > ('2000-01-01 UTC'::cstring)::timestamp with time zone)
+(13 rows)
+
+:PREFIX EXECUTE P6('60 mins', '2000-01-01 UTC');
+                                                     QUERY PLAN                                                      
+---------------------------------------------------------------------------------------------------------------------
+ Custom Scan (ChunkAppend) on metrics_timestamp
+   Order: metrics_timestamp."time"
+   Chunks excluded during startup: 0
+   ->  Index Only Scan Backward using _hyper_5_155_chunk_metrics_timestamp_time_idx on _hyper_5_155_chunk
+         Filter: (time_bucket('@ 1 hour'::interval, "time") > ('2000-01-01 UTC'::cstring)::timestamp with time zone)
+   ->  Index Only Scan Backward using _hyper_5_156_chunk_metrics_timestamp_time_idx on _hyper_5_156_chunk
+         Filter: (time_bucket('@ 1 hour'::interval, "time") > ('2000-01-01 UTC'::cstring)::timestamp with time zone)
+   ->  Index Only Scan Backward using _hyper_5_157_chunk_metrics_timestamp_time_idx on _hyper_5_157_chunk
+         Filter: (time_bucket('@ 1 hour'::interval, "time") > ('2000-01-01 UTC'::cstring)::timestamp with time zone)
+   ->  Index Only Scan Backward using _hyper_5_158_chunk_metrics_timestamp_time_idx on _hyper_5_158_chunk
+         Filter: (time_bucket('@ 1 hour'::interval, "time") > ('2000-01-01 UTC'::cstring)::timestamp with time zone)
+   ->  Index Only Scan Backward using _hyper_5_159_chunk_metrics_timestamp_time_idx on _hyper_5_159_chunk
+         Filter: (time_bucket('@ 1 hour'::interval, "time") > ('2000-01-01 UTC'::cstring)::timestamp with time zone)
+(13 rows)
+
+:PREFIX EXECUTE P7('60 mins', '2000-01-01 UTC');
+                                                       QUERY PLAN                                                       
+------------------------------------------------------------------------------------------------------------------------
+ Custom Scan (ChunkAppend) on metrics_timestamptz
+   Order: metrics_timestamptz."time"
+   Chunks excluded during startup: 0
+   ->  Index Scan Backward using _hyper_6_160_chunk_metrics_timestamptz_time_idx on _hyper_6_160_chunk
+         Filter: (time_bucket('@ 1 hour'::interval, "time") > ('2000-01-01 UTC'::cstring)::timestamp without time zone)
+   ->  Index Scan Backward using _hyper_6_161_chunk_metrics_timestamptz_time_idx on _hyper_6_161_chunk
+         Filter: (time_bucket('@ 1 hour'::interval, "time") > ('2000-01-01 UTC'::cstring)::timestamp without time zone)
+   ->  Index Scan Backward using _hyper_6_162_chunk_metrics_timestamptz_time_idx on _hyper_6_162_chunk
+         Filter: (time_bucket('@ 1 hour'::interval, "time") > ('2000-01-01 UTC'::cstring)::timestamp without time zone)
+   ->  Index Scan Backward using _hyper_6_163_chunk_metrics_timestamptz_time_idx on _hyper_6_163_chunk
+         Filter: (time_bucket('@ 1 hour'::interval, "time") > ('2000-01-01 UTC'::cstring)::timestamp without time zone)
+   ->  Index Scan Backward using _hyper_6_164_chunk_metrics_timestamptz_time_idx on _hyper_6_164_chunk
+         Filter: (time_bucket('@ 1 hour'::interval, "time") > ('2000-01-01 UTC'::cstring)::timestamp without time zone)
+(13 rows)
+
+:PREFIX EXECUTE P8('60 mins', '2000-01-01 UTC');
+                                                       QUERY PLAN                                                       
+------------------------------------------------------------------------------------------------------------------------
+ Custom Scan (ChunkAppend) on metrics_timestamp
+   Order: metrics_timestamp."time"
+   Chunks excluded during startup: 0
+   ->  Index Only Scan Backward using _hyper_5_155_chunk_metrics_timestamp_time_idx on _hyper_5_155_chunk
+         Filter: (time_bucket('@ 1 hour'::interval, "time") > ('2000-01-01 UTC'::cstring)::timestamp without time zone)
+   ->  Index Only Scan Backward using _hyper_5_156_chunk_metrics_timestamp_time_idx on _hyper_5_156_chunk
+         Filter: (time_bucket('@ 1 hour'::interval, "time") > ('2000-01-01 UTC'::cstring)::timestamp without time zone)
+   ->  Index Only Scan Backward using _hyper_5_157_chunk_metrics_timestamp_time_idx on _hyper_5_157_chunk
+         Filter: (time_bucket('@ 1 hour'::interval, "time") > ('2000-01-01 UTC'::cstring)::timestamp without time zone)
+   ->  Index Only Scan Backward using _hyper_5_158_chunk_metrics_timestamp_time_idx on _hyper_5_158_chunk
+         Filter: (time_bucket('@ 1 hour'::interval, "time") > ('2000-01-01 UTC'::cstring)::timestamp without time zone)
+   ->  Index Only Scan Backward using _hyper_5_159_chunk_metrics_timestamp_time_idx on _hyper_5_159_chunk
+         Filter: (time_bucket('@ 1 hour'::interval, "time") > ('2000-01-01 UTC'::cstring)::timestamp without time zone)
+(13 rows)
+
+SET plan_cache_mode TO 'force_generic_plan';
+:PREFIX EXECUTE P1('60 mins', '2024-01-01 UTC');
+                    QUERY PLAN                    
+--------------------------------------------------
+ Custom Scan (ChunkAppend) on metrics_timestamptz
+   Order: metrics_timestamptz."time"
+   Chunks excluded during startup: 5
+(3 rows)
+
+:PREFIX EXECUTE P2('60 mins', '2024-01-01 UTC');
+                   QUERY PLAN                   
+------------------------------------------------
+ Custom Scan (ChunkAppend) on metrics_timestamp
+   Order: metrics_timestamp."time"
+   Chunks excluded during startup: 5
+(3 rows)
+
+:PREFIX EXECUTE P3('60 mins', '2024-01-01 UTC');
+                    QUERY PLAN                    
+--------------------------------------------------
+ Custom Scan (ChunkAppend) on metrics_timestamptz
+   Order: metrics_timestamptz."time"
+   Chunks excluded during startup: 5
+(3 rows)
+
+:PREFIX EXECUTE P4('60 mins', '2024-01-01 UTC');
+                   QUERY PLAN                   
+------------------------------------------------
+ Custom Scan (ChunkAppend) on metrics_timestamp
+   Order: metrics_timestamp."time"
+   Chunks excluded during startup: 5
+(3 rows)
+
+:PREFIX EXECUTE P5('60 mins', '2024-01-01 UTC');
+                    QUERY PLAN                    
+--------------------------------------------------
+ Custom Scan (ChunkAppend) on metrics_timestamptz
+   Order: metrics_timestamptz."time"
+   Chunks excluded during startup: 5
+(3 rows)
+
+:PREFIX EXECUTE P6('60 mins', '2024-01-01 UTC');
+                   QUERY PLAN                   
+------------------------------------------------
+ Custom Scan (ChunkAppend) on metrics_timestamp
+   Order: metrics_timestamp."time"
+   Chunks excluded during startup: 5
+(3 rows)
+
+:PREFIX EXECUTE P7('60 mins', '2024-01-01 UTC');
+                    QUERY PLAN                    
+--------------------------------------------------
+ Custom Scan (ChunkAppend) on metrics_timestamptz
+   Order: metrics_timestamptz."time"
+   Chunks excluded during startup: 5
+(3 rows)
+
+:PREFIX EXECUTE P8('60 mins', '2024-01-01 UTC');
+                   QUERY PLAN                   
+------------------------------------------------
+ Custom Scan (ChunkAppend) on metrics_timestamp
+   Order: metrics_timestamp."time"
+   Chunks excluded during startup: 5
+(3 rows)
+
+:PREFIX EXECUTE P1('60 mins', '2000-01-01 UTC');
+                                              QUERY PLAN                                               
+-------------------------------------------------------------------------------------------------------
+ Custom Scan (ChunkAppend) on metrics_timestamptz
+   Order: metrics_timestamptz."time"
+   Chunks excluded during startup: 0
+   ->  Index Scan Backward using _hyper_6_160_chunk_metrics_timestamptz_time_idx on _hyper_6_160_chunk
+         Filter: (time_bucket(($1)::interval, "time") > ($2)::timestamp with time zone)
+   ->  Index Scan Backward using _hyper_6_161_chunk_metrics_timestamptz_time_idx on _hyper_6_161_chunk
+         Filter: (time_bucket(($1)::interval, "time") > ($2)::timestamp with time zone)
+   ->  Index Scan Backward using _hyper_6_162_chunk_metrics_timestamptz_time_idx on _hyper_6_162_chunk
+         Filter: (time_bucket(($1)::interval, "time") > ($2)::timestamp with time zone)
+   ->  Index Scan Backward using _hyper_6_163_chunk_metrics_timestamptz_time_idx on _hyper_6_163_chunk
+         Filter: (time_bucket(($1)::interval, "time") > ($2)::timestamp with time zone)
+   ->  Index Scan Backward using _hyper_6_164_chunk_metrics_timestamptz_time_idx on _hyper_6_164_chunk
+         Filter: (time_bucket(($1)::interval, "time") > ($2)::timestamp with time zone)
+(13 rows)
+
+:PREFIX EXECUTE P2('60 mins', '2000-01-01 UTC');
+                                                QUERY PLAN                                                
+----------------------------------------------------------------------------------------------------------
+ Custom Scan (ChunkAppend) on metrics_timestamp
+   Order: metrics_timestamp."time"
+   Chunks excluded during startup: 0
+   ->  Index Only Scan Backward using _hyper_5_155_chunk_metrics_timestamp_time_idx on _hyper_5_155_chunk
+         Filter: (time_bucket(($1)::interval, "time") > ($2)::timestamp with time zone)
+   ->  Index Only Scan Backward using _hyper_5_156_chunk_metrics_timestamp_time_idx on _hyper_5_156_chunk
+         Filter: (time_bucket(($1)::interval, "time") > ($2)::timestamp with time zone)
+   ->  Index Only Scan Backward using _hyper_5_157_chunk_metrics_timestamp_time_idx on _hyper_5_157_chunk
+         Filter: (time_bucket(($1)::interval, "time") > ($2)::timestamp with time zone)
+   ->  Index Only Scan Backward using _hyper_5_158_chunk_metrics_timestamp_time_idx on _hyper_5_158_chunk
+         Filter: (time_bucket(($1)::interval, "time") > ($2)::timestamp with time zone)
+   ->  Index Only Scan Backward using _hyper_5_159_chunk_metrics_timestamp_time_idx on _hyper_5_159_chunk
+         Filter: (time_bucket(($1)::interval, "time") > ($2)::timestamp with time zone)
+(13 rows)
+
+:PREFIX EXECUTE P3('60 mins', '2000-01-01 UTC');
+                                              QUERY PLAN                                               
+-------------------------------------------------------------------------------------------------------
+ Custom Scan (ChunkAppend) on metrics_timestamptz
+   Order: metrics_timestamptz."time"
+   Chunks excluded during startup: 0
+   ->  Index Scan Backward using _hyper_6_160_chunk_metrics_timestamptz_time_idx on _hyper_6_160_chunk
+         Filter: (time_bucket(($1)::interval, "time") > ($2)::timestamp without time zone)
+   ->  Index Scan Backward using _hyper_6_161_chunk_metrics_timestamptz_time_idx on _hyper_6_161_chunk
+         Filter: (time_bucket(($1)::interval, "time") > ($2)::timestamp without time zone)
+   ->  Index Scan Backward using _hyper_6_162_chunk_metrics_timestamptz_time_idx on _hyper_6_162_chunk
+         Filter: (time_bucket(($1)::interval, "time") > ($2)::timestamp without time zone)
+   ->  Index Scan Backward using _hyper_6_163_chunk_metrics_timestamptz_time_idx on _hyper_6_163_chunk
+         Filter: (time_bucket(($1)::interval, "time") > ($2)::timestamp without time zone)
+   ->  Index Scan Backward using _hyper_6_164_chunk_metrics_timestamptz_time_idx on _hyper_6_164_chunk
+         Filter: (time_bucket(($1)::interval, "time") > ($2)::timestamp without time zone)
+(13 rows)
+
+:PREFIX EXECUTE P4('60 mins', '2000-01-01 UTC');
+                                                QUERY PLAN                                                
+----------------------------------------------------------------------------------------------------------
+ Custom Scan (ChunkAppend) on metrics_timestamp
+   Order: metrics_timestamp."time"
+   Chunks excluded during startup: 0
+   ->  Index Only Scan Backward using _hyper_5_155_chunk_metrics_timestamp_time_idx on _hyper_5_155_chunk
+         Filter: (time_bucket(($1)::interval, "time") > ($2)::timestamp without time zone)
+   ->  Index Only Scan Backward using _hyper_5_156_chunk_metrics_timestamp_time_idx on _hyper_5_156_chunk
+         Filter: (time_bucket(($1)::interval, "time") > ($2)::timestamp without time zone)
+   ->  Index Only Scan Backward using _hyper_5_157_chunk_metrics_timestamp_time_idx on _hyper_5_157_chunk
+         Filter: (time_bucket(($1)::interval, "time") > ($2)::timestamp without time zone)
+   ->  Index Only Scan Backward using _hyper_5_158_chunk_metrics_timestamp_time_idx on _hyper_5_158_chunk
+         Filter: (time_bucket(($1)::interval, "time") > ($2)::timestamp without time zone)
+   ->  Index Only Scan Backward using _hyper_5_159_chunk_metrics_timestamp_time_idx on _hyper_5_159_chunk
+         Filter: (time_bucket(($1)::interval, "time") > ($2)::timestamp without time zone)
+(13 rows)
+
+:PREFIX EXECUTE P5('60 mins', '2000-01-01 UTC');
+                                              QUERY PLAN                                               
+-------------------------------------------------------------------------------------------------------
+ Custom Scan (ChunkAppend) on metrics_timestamptz
+   Order: metrics_timestamptz."time"
+   Chunks excluded during startup: 0
+   ->  Index Scan Backward using _hyper_6_160_chunk_metrics_timestamptz_time_idx on _hyper_6_160_chunk
+         Filter: (time_bucket($1, "time") > ($2)::timestamp with time zone)
+   ->  Index Scan Backward using _hyper_6_161_chunk_metrics_timestamptz_time_idx on _hyper_6_161_chunk
+         Filter: (time_bucket($1, "time") > ($2)::timestamp with time zone)
+   ->  Index Scan Backward using _hyper_6_162_chunk_metrics_timestamptz_time_idx on _hyper_6_162_chunk
+         Filter: (time_bucket($1, "time") > ($2)::timestamp with time zone)
+   ->  Index Scan Backward using _hyper_6_163_chunk_metrics_timestamptz_time_idx on _hyper_6_163_chunk
+         Filter: (time_bucket($1, "time") > ($2)::timestamp with time zone)
+   ->  Index Scan Backward using _hyper_6_164_chunk_metrics_timestamptz_time_idx on _hyper_6_164_chunk
+         Filter: (time_bucket($1, "time") > ($2)::timestamp with time zone)
+(13 rows)
+
+:PREFIX EXECUTE P6('60 mins', '2000-01-01 UTC');
+                                                QUERY PLAN                                                
+----------------------------------------------------------------------------------------------------------
+ Custom Scan (ChunkAppend) on metrics_timestamp
+   Order: metrics_timestamp."time"
+   Chunks excluded during startup: 0
+   ->  Index Only Scan Backward using _hyper_5_155_chunk_metrics_timestamp_time_idx on _hyper_5_155_chunk
+         Filter: (time_bucket($1, "time") > ($2)::timestamp with time zone)
+   ->  Index Only Scan Backward using _hyper_5_156_chunk_metrics_timestamp_time_idx on _hyper_5_156_chunk
+         Filter: (time_bucket($1, "time") > ($2)::timestamp with time zone)
+   ->  Index Only Scan Backward using _hyper_5_157_chunk_metrics_timestamp_time_idx on _hyper_5_157_chunk
+         Filter: (time_bucket($1, "time") > ($2)::timestamp with time zone)
+   ->  Index Only Scan Backward using _hyper_5_158_chunk_metrics_timestamp_time_idx on _hyper_5_158_chunk
+         Filter: (time_bucket($1, "time") > ($2)::timestamp with time zone)
+   ->  Index Only Scan Backward using _hyper_5_159_chunk_metrics_timestamp_time_idx on _hyper_5_159_chunk
+         Filter: (time_bucket($1, "time") > ($2)::timestamp with time zone)
+(13 rows)
+
+:PREFIX EXECUTE P7('60 mins', '2000-01-01 UTC');
+                                              QUERY PLAN                                               
+-------------------------------------------------------------------------------------------------------
+ Custom Scan (ChunkAppend) on metrics_timestamptz
+   Order: metrics_timestamptz."time"
+   Chunks excluded during startup: 0
+   ->  Index Scan Backward using _hyper_6_160_chunk_metrics_timestamptz_time_idx on _hyper_6_160_chunk
+         Filter: (time_bucket($1, "time") > ($2)::timestamp without time zone)
+   ->  Index Scan Backward using _hyper_6_161_chunk_metrics_timestamptz_time_idx on _hyper_6_161_chunk
+         Filter: (time_bucket($1, "time") > ($2)::timestamp without time zone)
+   ->  Index Scan Backward using _hyper_6_162_chunk_metrics_timestamptz_time_idx on _hyper_6_162_chunk
+         Filter: (time_bucket($1, "time") > ($2)::timestamp without time zone)
+   ->  Index Scan Backward using _hyper_6_163_chunk_metrics_timestamptz_time_idx on _hyper_6_163_chunk
+         Filter: (time_bucket($1, "time") > ($2)::timestamp without time zone)
+   ->  Index Scan Backward using _hyper_6_164_chunk_metrics_timestamptz_time_idx on _hyper_6_164_chunk
+         Filter: (time_bucket($1, "time") > ($2)::timestamp without time zone)
+(13 rows)
+
+:PREFIX EXECUTE P8('60 mins', '2000-01-01 UTC');
+                                                QUERY PLAN                                                
+----------------------------------------------------------------------------------------------------------
+ Custom Scan (ChunkAppend) on metrics_timestamp
+   Order: metrics_timestamp."time"
+   Chunks excluded during startup: 0
+   ->  Index Only Scan Backward using _hyper_5_155_chunk_metrics_timestamp_time_idx on _hyper_5_155_chunk
+         Filter: (time_bucket($1, "time") > ($2)::timestamp without time zone)
+   ->  Index Only Scan Backward using _hyper_5_156_chunk_metrics_timestamp_time_idx on _hyper_5_156_chunk
+         Filter: (time_bucket($1, "time") > ($2)::timestamp without time zone)
+   ->  Index Only Scan Backward using _hyper_5_157_chunk_metrics_timestamp_time_idx on _hyper_5_157_chunk
+         Filter: (time_bucket($1, "time") > ($2)::timestamp without time zone)
+   ->  Index Only Scan Backward using _hyper_5_158_chunk_metrics_timestamp_time_idx on _hyper_5_158_chunk
+         Filter: (time_bucket($1, "time") > ($2)::timestamp without time zone)
+   ->  Index Only Scan Backward using _hyper_5_159_chunk_metrics_timestamp_time_idx on _hyper_5_159_chunk
+         Filter: (time_bucket($1, "time") > ($2)::timestamp without time zone)
+(13 rows)
+
+RESET plan_cache_mode;
+DEALLOCATE P1;
+DEALLOCATE P2;
+DEALLOCATE P3;
+DEALLOCATE P4;
+DEALLOCATE P5;
+DEALLOCATE P6;
+DEALLOCATE P7;
+DEALLOCATE P8;
 :PREFIX SELECT * FROM hyper WHERE time_bucket(10, time) > 10 AND time_bucket(10, time) < 100 ORDER BY time;
                                                                           QUERY PLAN                                                                           
 ---------------------------------------------------------------------------------------------------------------------------------------------------------------

--- a/test/expected/plan_expand_hypertable-14.out
+++ b/test/expected/plan_expand_hypertable-14.out
@@ -1217,6 +1217,445 @@ transformation would be out of range
          Filter: (time_bucket('@ 1000 days'::interval, "time") < 'Sat Jan 01 00:00:00 294276 PST'::timestamp with time zone)
 (12 rows)
 
+\qecho time_bucket exclusion with run-time constants
+time_bucket exclusion with run-time constants
+-- These queries have a stable time_bucket expression, because the text::interval conversion is stable.
+PREPARE P1(text    , text) AS SELECT * FROM metrics_timestamptz WHERE time_bucket($1::interval, time) > $2::timestamptz ORDER BY time;
+PREPARE P2(text    , text) AS SELECT * FROM metrics_timestamp   WHERE time_bucket($1::interval, time) > $2::timestamptz ORDER BY time;
+PREPARE P3(text    , text) AS SELECT * FROM metrics_timestamptz WHERE time_bucket($1::interval, time) > $2::timestamp   ORDER BY time;
+PREPARE P4(text    , text) AS SELECT * FROM metrics_timestamp   WHERE time_bucket($1::interval, time) > $2::timestamp   ORDER BY time;
+-- These queries have an immutable time_bucket expression, because the parameter is passed as interval, and no conversion is involved.
+PREPARE P5(interval, text) AS SELECT * FROM metrics_timestamptz WHERE time_bucket($1::interval, time) > $2::timestamptz ORDER BY time;
+PREPARE P6(interval, text) AS SELECT * FROM metrics_timestamp   WHERE time_bucket($1::interval, time) > $2::timestamptz ORDER BY time;
+PREPARE P7(interval, text) AS SELECT * FROM metrics_timestamptz WHERE time_bucket($1::interval, time) > $2::timestamp   ORDER BY time;
+PREPARE P8(interval, text) AS SELECT * FROM metrics_timestamp   WHERE time_bucket($1::interval, time) > $2::timestamp   ORDER BY time;
+SET plan_cache_mode TO 'force_custom_plan';
+:PREFIX EXECUTE P1('60 mins', '2024-01-01 UTC');
+                    QUERY PLAN                    
+--------------------------------------------------
+ Custom Scan (ChunkAppend) on metrics_timestamptz
+   Order: metrics_timestamptz."time"
+   Chunks excluded during startup: 5
+(3 rows)
+
+:PREFIX EXECUTE P2('60 mins', '2024-01-01 UTC');
+                   QUERY PLAN                   
+------------------------------------------------
+ Custom Scan (ChunkAppend) on metrics_timestamp
+   Order: metrics_timestamp."time"
+   Chunks excluded during startup: 5
+(3 rows)
+
+:PREFIX EXECUTE P3('60 mins', '2024-01-01 UTC');
+                    QUERY PLAN                    
+--------------------------------------------------
+ Custom Scan (ChunkAppend) on metrics_timestamptz
+   Order: metrics_timestamptz."time"
+   Chunks excluded during startup: 5
+(3 rows)
+
+:PREFIX EXECUTE P4('60 mins', '2024-01-01 UTC');
+                   QUERY PLAN                   
+------------------------------------------------
+ Custom Scan (ChunkAppend) on metrics_timestamp
+   Order: metrics_timestamp."time"
+   Chunks excluded during startup: 5
+(3 rows)
+
+:PREFIX EXECUTE P5('60 mins', '2024-01-01 UTC');
+                    QUERY PLAN                    
+--------------------------------------------------
+ Custom Scan (ChunkAppend) on metrics_timestamptz
+   Order: metrics_timestamptz."time"
+   Chunks excluded during startup: 5
+(3 rows)
+
+:PREFIX EXECUTE P6('60 mins', '2024-01-01 UTC');
+                   QUERY PLAN                   
+------------------------------------------------
+ Custom Scan (ChunkAppend) on metrics_timestamp
+   Order: metrics_timestamp."time"
+   Chunks excluded during startup: 5
+(3 rows)
+
+:PREFIX EXECUTE P7('60 mins', '2024-01-01 UTC');
+                    QUERY PLAN                    
+--------------------------------------------------
+ Custom Scan (ChunkAppend) on metrics_timestamptz
+   Order: metrics_timestamptz."time"
+   Chunks excluded during startup: 5
+(3 rows)
+
+:PREFIX EXECUTE P8('60 mins', '2024-01-01 UTC');
+                   QUERY PLAN                   
+------------------------------------------------
+ Custom Scan (ChunkAppend) on metrics_timestamp
+   Order: metrics_timestamp."time"
+   Chunks excluded during startup: 5
+(3 rows)
+
+:PREFIX EXECUTE P1('60 mins', '2000-01-01 UTC');
+                                                          QUERY PLAN                                                           
+-------------------------------------------------------------------------------------------------------------------------------
+ Custom Scan (ChunkAppend) on metrics_timestamptz
+   Order: metrics_timestamptz."time"
+   Chunks excluded during startup: 0
+   ->  Index Scan Backward using _hyper_6_160_chunk_metrics_timestamptz_time_idx on _hyper_6_160_chunk
+         Filter: (time_bucket(('60 mins'::cstring)::interval, "time") > ('2000-01-01 UTC'::cstring)::timestamp with time zone)
+   ->  Index Scan Backward using _hyper_6_161_chunk_metrics_timestamptz_time_idx on _hyper_6_161_chunk
+         Filter: (time_bucket(('60 mins'::cstring)::interval, "time") > ('2000-01-01 UTC'::cstring)::timestamp with time zone)
+   ->  Index Scan Backward using _hyper_6_162_chunk_metrics_timestamptz_time_idx on _hyper_6_162_chunk
+         Filter: (time_bucket(('60 mins'::cstring)::interval, "time") > ('2000-01-01 UTC'::cstring)::timestamp with time zone)
+   ->  Index Scan Backward using _hyper_6_163_chunk_metrics_timestamptz_time_idx on _hyper_6_163_chunk
+         Filter: (time_bucket(('60 mins'::cstring)::interval, "time") > ('2000-01-01 UTC'::cstring)::timestamp with time zone)
+   ->  Index Scan Backward using _hyper_6_164_chunk_metrics_timestamptz_time_idx on _hyper_6_164_chunk
+         Filter: (time_bucket(('60 mins'::cstring)::interval, "time") > ('2000-01-01 UTC'::cstring)::timestamp with time zone)
+(13 rows)
+
+:PREFIX EXECUTE P2('60 mins', '2000-01-01 UTC');
+                                                          QUERY PLAN                                                           
+-------------------------------------------------------------------------------------------------------------------------------
+ Custom Scan (ChunkAppend) on metrics_timestamp
+   Order: metrics_timestamp."time"
+   Chunks excluded during startup: 0
+   ->  Index Only Scan Backward using _hyper_5_155_chunk_metrics_timestamp_time_idx on _hyper_5_155_chunk
+         Filter: (time_bucket(('60 mins'::cstring)::interval, "time") > ('2000-01-01 UTC'::cstring)::timestamp with time zone)
+   ->  Index Only Scan Backward using _hyper_5_156_chunk_metrics_timestamp_time_idx on _hyper_5_156_chunk
+         Filter: (time_bucket(('60 mins'::cstring)::interval, "time") > ('2000-01-01 UTC'::cstring)::timestamp with time zone)
+   ->  Index Only Scan Backward using _hyper_5_157_chunk_metrics_timestamp_time_idx on _hyper_5_157_chunk
+         Filter: (time_bucket(('60 mins'::cstring)::interval, "time") > ('2000-01-01 UTC'::cstring)::timestamp with time zone)
+   ->  Index Only Scan Backward using _hyper_5_158_chunk_metrics_timestamp_time_idx on _hyper_5_158_chunk
+         Filter: (time_bucket(('60 mins'::cstring)::interval, "time") > ('2000-01-01 UTC'::cstring)::timestamp with time zone)
+   ->  Index Only Scan Backward using _hyper_5_159_chunk_metrics_timestamp_time_idx on _hyper_5_159_chunk
+         Filter: (time_bucket(('60 mins'::cstring)::interval, "time") > ('2000-01-01 UTC'::cstring)::timestamp with time zone)
+(13 rows)
+
+:PREFIX EXECUTE P3('60 mins', '2000-01-01 UTC');
+                                                            QUERY PLAN                                                            
+----------------------------------------------------------------------------------------------------------------------------------
+ Custom Scan (ChunkAppend) on metrics_timestamptz
+   Order: metrics_timestamptz."time"
+   Chunks excluded during startup: 0
+   ->  Index Scan Backward using _hyper_6_160_chunk_metrics_timestamptz_time_idx on _hyper_6_160_chunk
+         Filter: (time_bucket(('60 mins'::cstring)::interval, "time") > ('2000-01-01 UTC'::cstring)::timestamp without time zone)
+   ->  Index Scan Backward using _hyper_6_161_chunk_metrics_timestamptz_time_idx on _hyper_6_161_chunk
+         Filter: (time_bucket(('60 mins'::cstring)::interval, "time") > ('2000-01-01 UTC'::cstring)::timestamp without time zone)
+   ->  Index Scan Backward using _hyper_6_162_chunk_metrics_timestamptz_time_idx on _hyper_6_162_chunk
+         Filter: (time_bucket(('60 mins'::cstring)::interval, "time") > ('2000-01-01 UTC'::cstring)::timestamp without time zone)
+   ->  Index Scan Backward using _hyper_6_163_chunk_metrics_timestamptz_time_idx on _hyper_6_163_chunk
+         Filter: (time_bucket(('60 mins'::cstring)::interval, "time") > ('2000-01-01 UTC'::cstring)::timestamp without time zone)
+   ->  Index Scan Backward using _hyper_6_164_chunk_metrics_timestamptz_time_idx on _hyper_6_164_chunk
+         Filter: (time_bucket(('60 mins'::cstring)::interval, "time") > ('2000-01-01 UTC'::cstring)::timestamp without time zone)
+(13 rows)
+
+:PREFIX EXECUTE P4('60 mins', '2000-01-01 UTC');
+                                                            QUERY PLAN                                                            
+----------------------------------------------------------------------------------------------------------------------------------
+ Custom Scan (ChunkAppend) on metrics_timestamp
+   Order: metrics_timestamp."time"
+   Chunks excluded during startup: 0
+   ->  Index Only Scan Backward using _hyper_5_155_chunk_metrics_timestamp_time_idx on _hyper_5_155_chunk
+         Filter: (time_bucket(('60 mins'::cstring)::interval, "time") > ('2000-01-01 UTC'::cstring)::timestamp without time zone)
+   ->  Index Only Scan Backward using _hyper_5_156_chunk_metrics_timestamp_time_idx on _hyper_5_156_chunk
+         Filter: (time_bucket(('60 mins'::cstring)::interval, "time") > ('2000-01-01 UTC'::cstring)::timestamp without time zone)
+   ->  Index Only Scan Backward using _hyper_5_157_chunk_metrics_timestamp_time_idx on _hyper_5_157_chunk
+         Filter: (time_bucket(('60 mins'::cstring)::interval, "time") > ('2000-01-01 UTC'::cstring)::timestamp without time zone)
+   ->  Index Only Scan Backward using _hyper_5_158_chunk_metrics_timestamp_time_idx on _hyper_5_158_chunk
+         Filter: (time_bucket(('60 mins'::cstring)::interval, "time") > ('2000-01-01 UTC'::cstring)::timestamp without time zone)
+   ->  Index Only Scan Backward using _hyper_5_159_chunk_metrics_timestamp_time_idx on _hyper_5_159_chunk
+         Filter: (time_bucket(('60 mins'::cstring)::interval, "time") > ('2000-01-01 UTC'::cstring)::timestamp without time zone)
+(13 rows)
+
+:PREFIX EXECUTE P5('60 mins', '2000-01-01 UTC');
+                                                     QUERY PLAN                                                      
+---------------------------------------------------------------------------------------------------------------------
+ Custom Scan (ChunkAppend) on metrics_timestamptz
+   Order: metrics_timestamptz."time"
+   Chunks excluded during startup: 0
+   ->  Index Scan Backward using _hyper_6_160_chunk_metrics_timestamptz_time_idx on _hyper_6_160_chunk
+         Filter: (time_bucket('@ 1 hour'::interval, "time") > ('2000-01-01 UTC'::cstring)::timestamp with time zone)
+   ->  Index Scan Backward using _hyper_6_161_chunk_metrics_timestamptz_time_idx on _hyper_6_161_chunk
+         Filter: (time_bucket('@ 1 hour'::interval, "time") > ('2000-01-01 UTC'::cstring)::timestamp with time zone)
+   ->  Index Scan Backward using _hyper_6_162_chunk_metrics_timestamptz_time_idx on _hyper_6_162_chunk
+         Filter: (time_bucket('@ 1 hour'::interval, "time") > ('2000-01-01 UTC'::cstring)::timestamp with time zone)
+   ->  Index Scan Backward using _hyper_6_163_chunk_metrics_timestamptz_time_idx on _hyper_6_163_chunk
+         Filter: (time_bucket('@ 1 hour'::interval, "time") > ('2000-01-01 UTC'::cstring)::timestamp with time zone)
+   ->  Index Scan Backward using _hyper_6_164_chunk_metrics_timestamptz_time_idx on _hyper_6_164_chunk
+         Filter: (time_bucket('@ 1 hour'::interval, "time") > ('2000-01-01 UTC'::cstring)::timestamp with time zone)
+(13 rows)
+
+:PREFIX EXECUTE P6('60 mins', '2000-01-01 UTC');
+                                                     QUERY PLAN                                                      
+---------------------------------------------------------------------------------------------------------------------
+ Custom Scan (ChunkAppend) on metrics_timestamp
+   Order: metrics_timestamp."time"
+   Chunks excluded during startup: 0
+   ->  Index Only Scan Backward using _hyper_5_155_chunk_metrics_timestamp_time_idx on _hyper_5_155_chunk
+         Filter: (time_bucket('@ 1 hour'::interval, "time") > ('2000-01-01 UTC'::cstring)::timestamp with time zone)
+   ->  Index Only Scan Backward using _hyper_5_156_chunk_metrics_timestamp_time_idx on _hyper_5_156_chunk
+         Filter: (time_bucket('@ 1 hour'::interval, "time") > ('2000-01-01 UTC'::cstring)::timestamp with time zone)
+   ->  Index Only Scan Backward using _hyper_5_157_chunk_metrics_timestamp_time_idx on _hyper_5_157_chunk
+         Filter: (time_bucket('@ 1 hour'::interval, "time") > ('2000-01-01 UTC'::cstring)::timestamp with time zone)
+   ->  Index Only Scan Backward using _hyper_5_158_chunk_metrics_timestamp_time_idx on _hyper_5_158_chunk
+         Filter: (time_bucket('@ 1 hour'::interval, "time") > ('2000-01-01 UTC'::cstring)::timestamp with time zone)
+   ->  Index Only Scan Backward using _hyper_5_159_chunk_metrics_timestamp_time_idx on _hyper_5_159_chunk
+         Filter: (time_bucket('@ 1 hour'::interval, "time") > ('2000-01-01 UTC'::cstring)::timestamp with time zone)
+(13 rows)
+
+:PREFIX EXECUTE P7('60 mins', '2000-01-01 UTC');
+                                                       QUERY PLAN                                                       
+------------------------------------------------------------------------------------------------------------------------
+ Custom Scan (ChunkAppend) on metrics_timestamptz
+   Order: metrics_timestamptz."time"
+   Chunks excluded during startup: 0
+   ->  Index Scan Backward using _hyper_6_160_chunk_metrics_timestamptz_time_idx on _hyper_6_160_chunk
+         Filter: (time_bucket('@ 1 hour'::interval, "time") > ('2000-01-01 UTC'::cstring)::timestamp without time zone)
+   ->  Index Scan Backward using _hyper_6_161_chunk_metrics_timestamptz_time_idx on _hyper_6_161_chunk
+         Filter: (time_bucket('@ 1 hour'::interval, "time") > ('2000-01-01 UTC'::cstring)::timestamp without time zone)
+   ->  Index Scan Backward using _hyper_6_162_chunk_metrics_timestamptz_time_idx on _hyper_6_162_chunk
+         Filter: (time_bucket('@ 1 hour'::interval, "time") > ('2000-01-01 UTC'::cstring)::timestamp without time zone)
+   ->  Index Scan Backward using _hyper_6_163_chunk_metrics_timestamptz_time_idx on _hyper_6_163_chunk
+         Filter: (time_bucket('@ 1 hour'::interval, "time") > ('2000-01-01 UTC'::cstring)::timestamp without time zone)
+   ->  Index Scan Backward using _hyper_6_164_chunk_metrics_timestamptz_time_idx on _hyper_6_164_chunk
+         Filter: (time_bucket('@ 1 hour'::interval, "time") > ('2000-01-01 UTC'::cstring)::timestamp without time zone)
+(13 rows)
+
+:PREFIX EXECUTE P8('60 mins', '2000-01-01 UTC');
+                                                       QUERY PLAN                                                       
+------------------------------------------------------------------------------------------------------------------------
+ Custom Scan (ChunkAppend) on metrics_timestamp
+   Order: metrics_timestamp."time"
+   Chunks excluded during startup: 0
+   ->  Index Only Scan Backward using _hyper_5_155_chunk_metrics_timestamp_time_idx on _hyper_5_155_chunk
+         Filter: (time_bucket('@ 1 hour'::interval, "time") > ('2000-01-01 UTC'::cstring)::timestamp without time zone)
+   ->  Index Only Scan Backward using _hyper_5_156_chunk_metrics_timestamp_time_idx on _hyper_5_156_chunk
+         Filter: (time_bucket('@ 1 hour'::interval, "time") > ('2000-01-01 UTC'::cstring)::timestamp without time zone)
+   ->  Index Only Scan Backward using _hyper_5_157_chunk_metrics_timestamp_time_idx on _hyper_5_157_chunk
+         Filter: (time_bucket('@ 1 hour'::interval, "time") > ('2000-01-01 UTC'::cstring)::timestamp without time zone)
+   ->  Index Only Scan Backward using _hyper_5_158_chunk_metrics_timestamp_time_idx on _hyper_5_158_chunk
+         Filter: (time_bucket('@ 1 hour'::interval, "time") > ('2000-01-01 UTC'::cstring)::timestamp without time zone)
+   ->  Index Only Scan Backward using _hyper_5_159_chunk_metrics_timestamp_time_idx on _hyper_5_159_chunk
+         Filter: (time_bucket('@ 1 hour'::interval, "time") > ('2000-01-01 UTC'::cstring)::timestamp without time zone)
+(13 rows)
+
+SET plan_cache_mode TO 'force_generic_plan';
+:PREFIX EXECUTE P1('60 mins', '2024-01-01 UTC');
+                    QUERY PLAN                    
+--------------------------------------------------
+ Custom Scan (ChunkAppend) on metrics_timestamptz
+   Order: metrics_timestamptz."time"
+   Chunks excluded during startup: 5
+(3 rows)
+
+:PREFIX EXECUTE P2('60 mins', '2024-01-01 UTC');
+                   QUERY PLAN                   
+------------------------------------------------
+ Custom Scan (ChunkAppend) on metrics_timestamp
+   Order: metrics_timestamp."time"
+   Chunks excluded during startup: 5
+(3 rows)
+
+:PREFIX EXECUTE P3('60 mins', '2024-01-01 UTC');
+                    QUERY PLAN                    
+--------------------------------------------------
+ Custom Scan (ChunkAppend) on metrics_timestamptz
+   Order: metrics_timestamptz."time"
+   Chunks excluded during startup: 5
+(3 rows)
+
+:PREFIX EXECUTE P4('60 mins', '2024-01-01 UTC');
+                   QUERY PLAN                   
+------------------------------------------------
+ Custom Scan (ChunkAppend) on metrics_timestamp
+   Order: metrics_timestamp."time"
+   Chunks excluded during startup: 5
+(3 rows)
+
+:PREFIX EXECUTE P5('60 mins', '2024-01-01 UTC');
+                    QUERY PLAN                    
+--------------------------------------------------
+ Custom Scan (ChunkAppend) on metrics_timestamptz
+   Order: metrics_timestamptz."time"
+   Chunks excluded during startup: 5
+(3 rows)
+
+:PREFIX EXECUTE P6('60 mins', '2024-01-01 UTC');
+                   QUERY PLAN                   
+------------------------------------------------
+ Custom Scan (ChunkAppend) on metrics_timestamp
+   Order: metrics_timestamp."time"
+   Chunks excluded during startup: 5
+(3 rows)
+
+:PREFIX EXECUTE P7('60 mins', '2024-01-01 UTC');
+                    QUERY PLAN                    
+--------------------------------------------------
+ Custom Scan (ChunkAppend) on metrics_timestamptz
+   Order: metrics_timestamptz."time"
+   Chunks excluded during startup: 5
+(3 rows)
+
+:PREFIX EXECUTE P8('60 mins', '2024-01-01 UTC');
+                   QUERY PLAN                   
+------------------------------------------------
+ Custom Scan (ChunkAppend) on metrics_timestamp
+   Order: metrics_timestamp."time"
+   Chunks excluded during startup: 5
+(3 rows)
+
+:PREFIX EXECUTE P1('60 mins', '2000-01-01 UTC');
+                                              QUERY PLAN                                               
+-------------------------------------------------------------------------------------------------------
+ Custom Scan (ChunkAppend) on metrics_timestamptz
+   Order: metrics_timestamptz."time"
+   Chunks excluded during startup: 0
+   ->  Index Scan Backward using _hyper_6_160_chunk_metrics_timestamptz_time_idx on _hyper_6_160_chunk
+         Filter: (time_bucket(($1)::interval, "time") > ($2)::timestamp with time zone)
+   ->  Index Scan Backward using _hyper_6_161_chunk_metrics_timestamptz_time_idx on _hyper_6_161_chunk
+         Filter: (time_bucket(($1)::interval, "time") > ($2)::timestamp with time zone)
+   ->  Index Scan Backward using _hyper_6_162_chunk_metrics_timestamptz_time_idx on _hyper_6_162_chunk
+         Filter: (time_bucket(($1)::interval, "time") > ($2)::timestamp with time zone)
+   ->  Index Scan Backward using _hyper_6_163_chunk_metrics_timestamptz_time_idx on _hyper_6_163_chunk
+         Filter: (time_bucket(($1)::interval, "time") > ($2)::timestamp with time zone)
+   ->  Index Scan Backward using _hyper_6_164_chunk_metrics_timestamptz_time_idx on _hyper_6_164_chunk
+         Filter: (time_bucket(($1)::interval, "time") > ($2)::timestamp with time zone)
+(13 rows)
+
+:PREFIX EXECUTE P2('60 mins', '2000-01-01 UTC');
+                                                QUERY PLAN                                                
+----------------------------------------------------------------------------------------------------------
+ Custom Scan (ChunkAppend) on metrics_timestamp
+   Order: metrics_timestamp."time"
+   Chunks excluded during startup: 0
+   ->  Index Only Scan Backward using _hyper_5_155_chunk_metrics_timestamp_time_idx on _hyper_5_155_chunk
+         Filter: (time_bucket(($1)::interval, "time") > ($2)::timestamp with time zone)
+   ->  Index Only Scan Backward using _hyper_5_156_chunk_metrics_timestamp_time_idx on _hyper_5_156_chunk
+         Filter: (time_bucket(($1)::interval, "time") > ($2)::timestamp with time zone)
+   ->  Index Only Scan Backward using _hyper_5_157_chunk_metrics_timestamp_time_idx on _hyper_5_157_chunk
+         Filter: (time_bucket(($1)::interval, "time") > ($2)::timestamp with time zone)
+   ->  Index Only Scan Backward using _hyper_5_158_chunk_metrics_timestamp_time_idx on _hyper_5_158_chunk
+         Filter: (time_bucket(($1)::interval, "time") > ($2)::timestamp with time zone)
+   ->  Index Only Scan Backward using _hyper_5_159_chunk_metrics_timestamp_time_idx on _hyper_5_159_chunk
+         Filter: (time_bucket(($1)::interval, "time") > ($2)::timestamp with time zone)
+(13 rows)
+
+:PREFIX EXECUTE P3('60 mins', '2000-01-01 UTC');
+                                              QUERY PLAN                                               
+-------------------------------------------------------------------------------------------------------
+ Custom Scan (ChunkAppend) on metrics_timestamptz
+   Order: metrics_timestamptz."time"
+   Chunks excluded during startup: 0
+   ->  Index Scan Backward using _hyper_6_160_chunk_metrics_timestamptz_time_idx on _hyper_6_160_chunk
+         Filter: (time_bucket(($1)::interval, "time") > ($2)::timestamp without time zone)
+   ->  Index Scan Backward using _hyper_6_161_chunk_metrics_timestamptz_time_idx on _hyper_6_161_chunk
+         Filter: (time_bucket(($1)::interval, "time") > ($2)::timestamp without time zone)
+   ->  Index Scan Backward using _hyper_6_162_chunk_metrics_timestamptz_time_idx on _hyper_6_162_chunk
+         Filter: (time_bucket(($1)::interval, "time") > ($2)::timestamp without time zone)
+   ->  Index Scan Backward using _hyper_6_163_chunk_metrics_timestamptz_time_idx on _hyper_6_163_chunk
+         Filter: (time_bucket(($1)::interval, "time") > ($2)::timestamp without time zone)
+   ->  Index Scan Backward using _hyper_6_164_chunk_metrics_timestamptz_time_idx on _hyper_6_164_chunk
+         Filter: (time_bucket(($1)::interval, "time") > ($2)::timestamp without time zone)
+(13 rows)
+
+:PREFIX EXECUTE P4('60 mins', '2000-01-01 UTC');
+                                                QUERY PLAN                                                
+----------------------------------------------------------------------------------------------------------
+ Custom Scan (ChunkAppend) on metrics_timestamp
+   Order: metrics_timestamp."time"
+   Chunks excluded during startup: 0
+   ->  Index Only Scan Backward using _hyper_5_155_chunk_metrics_timestamp_time_idx on _hyper_5_155_chunk
+         Filter: (time_bucket(($1)::interval, "time") > ($2)::timestamp without time zone)
+   ->  Index Only Scan Backward using _hyper_5_156_chunk_metrics_timestamp_time_idx on _hyper_5_156_chunk
+         Filter: (time_bucket(($1)::interval, "time") > ($2)::timestamp without time zone)
+   ->  Index Only Scan Backward using _hyper_5_157_chunk_metrics_timestamp_time_idx on _hyper_5_157_chunk
+         Filter: (time_bucket(($1)::interval, "time") > ($2)::timestamp without time zone)
+   ->  Index Only Scan Backward using _hyper_5_158_chunk_metrics_timestamp_time_idx on _hyper_5_158_chunk
+         Filter: (time_bucket(($1)::interval, "time") > ($2)::timestamp without time zone)
+   ->  Index Only Scan Backward using _hyper_5_159_chunk_metrics_timestamp_time_idx on _hyper_5_159_chunk
+         Filter: (time_bucket(($1)::interval, "time") > ($2)::timestamp without time zone)
+(13 rows)
+
+:PREFIX EXECUTE P5('60 mins', '2000-01-01 UTC');
+                                              QUERY PLAN                                               
+-------------------------------------------------------------------------------------------------------
+ Custom Scan (ChunkAppend) on metrics_timestamptz
+   Order: metrics_timestamptz."time"
+   Chunks excluded during startup: 0
+   ->  Index Scan Backward using _hyper_6_160_chunk_metrics_timestamptz_time_idx on _hyper_6_160_chunk
+         Filter: (time_bucket($1, "time") > ($2)::timestamp with time zone)
+   ->  Index Scan Backward using _hyper_6_161_chunk_metrics_timestamptz_time_idx on _hyper_6_161_chunk
+         Filter: (time_bucket($1, "time") > ($2)::timestamp with time zone)
+   ->  Index Scan Backward using _hyper_6_162_chunk_metrics_timestamptz_time_idx on _hyper_6_162_chunk
+         Filter: (time_bucket($1, "time") > ($2)::timestamp with time zone)
+   ->  Index Scan Backward using _hyper_6_163_chunk_metrics_timestamptz_time_idx on _hyper_6_163_chunk
+         Filter: (time_bucket($1, "time") > ($2)::timestamp with time zone)
+   ->  Index Scan Backward using _hyper_6_164_chunk_metrics_timestamptz_time_idx on _hyper_6_164_chunk
+         Filter: (time_bucket($1, "time") > ($2)::timestamp with time zone)
+(13 rows)
+
+:PREFIX EXECUTE P6('60 mins', '2000-01-01 UTC');
+                                                QUERY PLAN                                                
+----------------------------------------------------------------------------------------------------------
+ Custom Scan (ChunkAppend) on metrics_timestamp
+   Order: metrics_timestamp."time"
+   Chunks excluded during startup: 0
+   ->  Index Only Scan Backward using _hyper_5_155_chunk_metrics_timestamp_time_idx on _hyper_5_155_chunk
+         Filter: (time_bucket($1, "time") > ($2)::timestamp with time zone)
+   ->  Index Only Scan Backward using _hyper_5_156_chunk_metrics_timestamp_time_idx on _hyper_5_156_chunk
+         Filter: (time_bucket($1, "time") > ($2)::timestamp with time zone)
+   ->  Index Only Scan Backward using _hyper_5_157_chunk_metrics_timestamp_time_idx on _hyper_5_157_chunk
+         Filter: (time_bucket($1, "time") > ($2)::timestamp with time zone)
+   ->  Index Only Scan Backward using _hyper_5_158_chunk_metrics_timestamp_time_idx on _hyper_5_158_chunk
+         Filter: (time_bucket($1, "time") > ($2)::timestamp with time zone)
+   ->  Index Only Scan Backward using _hyper_5_159_chunk_metrics_timestamp_time_idx on _hyper_5_159_chunk
+         Filter: (time_bucket($1, "time") > ($2)::timestamp with time zone)
+(13 rows)
+
+:PREFIX EXECUTE P7('60 mins', '2000-01-01 UTC');
+                                              QUERY PLAN                                               
+-------------------------------------------------------------------------------------------------------
+ Custom Scan (ChunkAppend) on metrics_timestamptz
+   Order: metrics_timestamptz."time"
+   Chunks excluded during startup: 0
+   ->  Index Scan Backward using _hyper_6_160_chunk_metrics_timestamptz_time_idx on _hyper_6_160_chunk
+         Filter: (time_bucket($1, "time") > ($2)::timestamp without time zone)
+   ->  Index Scan Backward using _hyper_6_161_chunk_metrics_timestamptz_time_idx on _hyper_6_161_chunk
+         Filter: (time_bucket($1, "time") > ($2)::timestamp without time zone)
+   ->  Index Scan Backward using _hyper_6_162_chunk_metrics_timestamptz_time_idx on _hyper_6_162_chunk
+         Filter: (time_bucket($1, "time") > ($2)::timestamp without time zone)
+   ->  Index Scan Backward using _hyper_6_163_chunk_metrics_timestamptz_time_idx on _hyper_6_163_chunk
+         Filter: (time_bucket($1, "time") > ($2)::timestamp without time zone)
+   ->  Index Scan Backward using _hyper_6_164_chunk_metrics_timestamptz_time_idx on _hyper_6_164_chunk
+         Filter: (time_bucket($1, "time") > ($2)::timestamp without time zone)
+(13 rows)
+
+:PREFIX EXECUTE P8('60 mins', '2000-01-01 UTC');
+                                                QUERY PLAN                                                
+----------------------------------------------------------------------------------------------------------
+ Custom Scan (ChunkAppend) on metrics_timestamp
+   Order: metrics_timestamp."time"
+   Chunks excluded during startup: 0
+   ->  Index Only Scan Backward using _hyper_5_155_chunk_metrics_timestamp_time_idx on _hyper_5_155_chunk
+         Filter: (time_bucket($1, "time") > ($2)::timestamp without time zone)
+   ->  Index Only Scan Backward using _hyper_5_156_chunk_metrics_timestamp_time_idx on _hyper_5_156_chunk
+         Filter: (time_bucket($1, "time") > ($2)::timestamp without time zone)
+   ->  Index Only Scan Backward using _hyper_5_157_chunk_metrics_timestamp_time_idx on _hyper_5_157_chunk
+         Filter: (time_bucket($1, "time") > ($2)::timestamp without time zone)
+   ->  Index Only Scan Backward using _hyper_5_158_chunk_metrics_timestamp_time_idx on _hyper_5_158_chunk
+         Filter: (time_bucket($1, "time") > ($2)::timestamp without time zone)
+   ->  Index Only Scan Backward using _hyper_5_159_chunk_metrics_timestamp_time_idx on _hyper_5_159_chunk
+         Filter: (time_bucket($1, "time") > ($2)::timestamp without time zone)
+(13 rows)
+
+RESET plan_cache_mode;
+DEALLOCATE P1;
+DEALLOCATE P2;
+DEALLOCATE P3;
+DEALLOCATE P4;
+DEALLOCATE P5;
+DEALLOCATE P6;
+DEALLOCATE P7;
+DEALLOCATE P8;
 :PREFIX SELECT * FROM hyper WHERE time_bucket(10, time) > 10 AND time_bucket(10, time) < 100 ORDER BY time;
                                                                           QUERY PLAN                                                                           
 ---------------------------------------------------------------------------------------------------------------------------------------------------------------

--- a/test/expected/plan_expand_hypertable-15.out
+++ b/test/expected/plan_expand_hypertable-15.out
@@ -1217,6 +1217,445 @@ transformation would be out of range
          Filter: (time_bucket('@ 1000 days'::interval, "time") < 'Sat Jan 01 00:00:00 294276 PST'::timestamp with time zone)
 (12 rows)
 
+\qecho time_bucket exclusion with run-time constants
+time_bucket exclusion with run-time constants
+-- These queries have a stable time_bucket expression, because the text::interval conversion is stable.
+PREPARE P1(text    , text) AS SELECT * FROM metrics_timestamptz WHERE time_bucket($1::interval, time) > $2::timestamptz ORDER BY time;
+PREPARE P2(text    , text) AS SELECT * FROM metrics_timestamp   WHERE time_bucket($1::interval, time) > $2::timestamptz ORDER BY time;
+PREPARE P3(text    , text) AS SELECT * FROM metrics_timestamptz WHERE time_bucket($1::interval, time) > $2::timestamp   ORDER BY time;
+PREPARE P4(text    , text) AS SELECT * FROM metrics_timestamp   WHERE time_bucket($1::interval, time) > $2::timestamp   ORDER BY time;
+-- These queries have an immutable time_bucket expression, because the parameter is passed as interval, and no conversion is involved.
+PREPARE P5(interval, text) AS SELECT * FROM metrics_timestamptz WHERE time_bucket($1::interval, time) > $2::timestamptz ORDER BY time;
+PREPARE P6(interval, text) AS SELECT * FROM metrics_timestamp   WHERE time_bucket($1::interval, time) > $2::timestamptz ORDER BY time;
+PREPARE P7(interval, text) AS SELECT * FROM metrics_timestamptz WHERE time_bucket($1::interval, time) > $2::timestamp   ORDER BY time;
+PREPARE P8(interval, text) AS SELECT * FROM metrics_timestamp   WHERE time_bucket($1::interval, time) > $2::timestamp   ORDER BY time;
+SET plan_cache_mode TO 'force_custom_plan';
+:PREFIX EXECUTE P1('60 mins', '2024-01-01 UTC');
+                    QUERY PLAN                    
+--------------------------------------------------
+ Custom Scan (ChunkAppend) on metrics_timestamptz
+   Order: metrics_timestamptz."time"
+   Chunks excluded during startup: 5
+(3 rows)
+
+:PREFIX EXECUTE P2('60 mins', '2024-01-01 UTC');
+                   QUERY PLAN                   
+------------------------------------------------
+ Custom Scan (ChunkAppend) on metrics_timestamp
+   Order: metrics_timestamp."time"
+   Chunks excluded during startup: 5
+(3 rows)
+
+:PREFIX EXECUTE P3('60 mins', '2024-01-01 UTC');
+                    QUERY PLAN                    
+--------------------------------------------------
+ Custom Scan (ChunkAppend) on metrics_timestamptz
+   Order: metrics_timestamptz."time"
+   Chunks excluded during startup: 5
+(3 rows)
+
+:PREFIX EXECUTE P4('60 mins', '2024-01-01 UTC');
+                   QUERY PLAN                   
+------------------------------------------------
+ Custom Scan (ChunkAppend) on metrics_timestamp
+   Order: metrics_timestamp."time"
+   Chunks excluded during startup: 5
+(3 rows)
+
+:PREFIX EXECUTE P5('60 mins', '2024-01-01 UTC');
+                    QUERY PLAN                    
+--------------------------------------------------
+ Custom Scan (ChunkAppend) on metrics_timestamptz
+   Order: metrics_timestamptz."time"
+   Chunks excluded during startup: 5
+(3 rows)
+
+:PREFIX EXECUTE P6('60 mins', '2024-01-01 UTC');
+                   QUERY PLAN                   
+------------------------------------------------
+ Custom Scan (ChunkAppend) on metrics_timestamp
+   Order: metrics_timestamp."time"
+   Chunks excluded during startup: 5
+(3 rows)
+
+:PREFIX EXECUTE P7('60 mins', '2024-01-01 UTC');
+                    QUERY PLAN                    
+--------------------------------------------------
+ Custom Scan (ChunkAppend) on metrics_timestamptz
+   Order: metrics_timestamptz."time"
+   Chunks excluded during startup: 5
+(3 rows)
+
+:PREFIX EXECUTE P8('60 mins', '2024-01-01 UTC');
+                   QUERY PLAN                   
+------------------------------------------------
+ Custom Scan (ChunkAppend) on metrics_timestamp
+   Order: metrics_timestamp."time"
+   Chunks excluded during startup: 5
+(3 rows)
+
+:PREFIX EXECUTE P1('60 mins', '2000-01-01 UTC');
+                                                          QUERY PLAN                                                           
+-------------------------------------------------------------------------------------------------------------------------------
+ Custom Scan (ChunkAppend) on metrics_timestamptz
+   Order: metrics_timestamptz."time"
+   Chunks excluded during startup: 0
+   ->  Index Scan Backward using _hyper_6_160_chunk_metrics_timestamptz_time_idx on _hyper_6_160_chunk
+         Filter: (time_bucket(('60 mins'::cstring)::interval, "time") > ('2000-01-01 UTC'::cstring)::timestamp with time zone)
+   ->  Index Scan Backward using _hyper_6_161_chunk_metrics_timestamptz_time_idx on _hyper_6_161_chunk
+         Filter: (time_bucket(('60 mins'::cstring)::interval, "time") > ('2000-01-01 UTC'::cstring)::timestamp with time zone)
+   ->  Index Scan Backward using _hyper_6_162_chunk_metrics_timestamptz_time_idx on _hyper_6_162_chunk
+         Filter: (time_bucket(('60 mins'::cstring)::interval, "time") > ('2000-01-01 UTC'::cstring)::timestamp with time zone)
+   ->  Index Scan Backward using _hyper_6_163_chunk_metrics_timestamptz_time_idx on _hyper_6_163_chunk
+         Filter: (time_bucket(('60 mins'::cstring)::interval, "time") > ('2000-01-01 UTC'::cstring)::timestamp with time zone)
+   ->  Index Scan Backward using _hyper_6_164_chunk_metrics_timestamptz_time_idx on _hyper_6_164_chunk
+         Filter: (time_bucket(('60 mins'::cstring)::interval, "time") > ('2000-01-01 UTC'::cstring)::timestamp with time zone)
+(13 rows)
+
+:PREFIX EXECUTE P2('60 mins', '2000-01-01 UTC');
+                                                          QUERY PLAN                                                           
+-------------------------------------------------------------------------------------------------------------------------------
+ Custom Scan (ChunkAppend) on metrics_timestamp
+   Order: metrics_timestamp."time"
+   Chunks excluded during startup: 0
+   ->  Index Only Scan Backward using _hyper_5_155_chunk_metrics_timestamp_time_idx on _hyper_5_155_chunk
+         Filter: (time_bucket(('60 mins'::cstring)::interval, "time") > ('2000-01-01 UTC'::cstring)::timestamp with time zone)
+   ->  Index Only Scan Backward using _hyper_5_156_chunk_metrics_timestamp_time_idx on _hyper_5_156_chunk
+         Filter: (time_bucket(('60 mins'::cstring)::interval, "time") > ('2000-01-01 UTC'::cstring)::timestamp with time zone)
+   ->  Index Only Scan Backward using _hyper_5_157_chunk_metrics_timestamp_time_idx on _hyper_5_157_chunk
+         Filter: (time_bucket(('60 mins'::cstring)::interval, "time") > ('2000-01-01 UTC'::cstring)::timestamp with time zone)
+   ->  Index Only Scan Backward using _hyper_5_158_chunk_metrics_timestamp_time_idx on _hyper_5_158_chunk
+         Filter: (time_bucket(('60 mins'::cstring)::interval, "time") > ('2000-01-01 UTC'::cstring)::timestamp with time zone)
+   ->  Index Only Scan Backward using _hyper_5_159_chunk_metrics_timestamp_time_idx on _hyper_5_159_chunk
+         Filter: (time_bucket(('60 mins'::cstring)::interval, "time") > ('2000-01-01 UTC'::cstring)::timestamp with time zone)
+(13 rows)
+
+:PREFIX EXECUTE P3('60 mins', '2000-01-01 UTC');
+                                                            QUERY PLAN                                                            
+----------------------------------------------------------------------------------------------------------------------------------
+ Custom Scan (ChunkAppend) on metrics_timestamptz
+   Order: metrics_timestamptz."time"
+   Chunks excluded during startup: 0
+   ->  Index Scan Backward using _hyper_6_160_chunk_metrics_timestamptz_time_idx on _hyper_6_160_chunk
+         Filter: (time_bucket(('60 mins'::cstring)::interval, "time") > ('2000-01-01 UTC'::cstring)::timestamp without time zone)
+   ->  Index Scan Backward using _hyper_6_161_chunk_metrics_timestamptz_time_idx on _hyper_6_161_chunk
+         Filter: (time_bucket(('60 mins'::cstring)::interval, "time") > ('2000-01-01 UTC'::cstring)::timestamp without time zone)
+   ->  Index Scan Backward using _hyper_6_162_chunk_metrics_timestamptz_time_idx on _hyper_6_162_chunk
+         Filter: (time_bucket(('60 mins'::cstring)::interval, "time") > ('2000-01-01 UTC'::cstring)::timestamp without time zone)
+   ->  Index Scan Backward using _hyper_6_163_chunk_metrics_timestamptz_time_idx on _hyper_6_163_chunk
+         Filter: (time_bucket(('60 mins'::cstring)::interval, "time") > ('2000-01-01 UTC'::cstring)::timestamp without time zone)
+   ->  Index Scan Backward using _hyper_6_164_chunk_metrics_timestamptz_time_idx on _hyper_6_164_chunk
+         Filter: (time_bucket(('60 mins'::cstring)::interval, "time") > ('2000-01-01 UTC'::cstring)::timestamp without time zone)
+(13 rows)
+
+:PREFIX EXECUTE P4('60 mins', '2000-01-01 UTC');
+                                                            QUERY PLAN                                                            
+----------------------------------------------------------------------------------------------------------------------------------
+ Custom Scan (ChunkAppend) on metrics_timestamp
+   Order: metrics_timestamp."time"
+   Chunks excluded during startup: 0
+   ->  Index Only Scan Backward using _hyper_5_155_chunk_metrics_timestamp_time_idx on _hyper_5_155_chunk
+         Filter: (time_bucket(('60 mins'::cstring)::interval, "time") > ('2000-01-01 UTC'::cstring)::timestamp without time zone)
+   ->  Index Only Scan Backward using _hyper_5_156_chunk_metrics_timestamp_time_idx on _hyper_5_156_chunk
+         Filter: (time_bucket(('60 mins'::cstring)::interval, "time") > ('2000-01-01 UTC'::cstring)::timestamp without time zone)
+   ->  Index Only Scan Backward using _hyper_5_157_chunk_metrics_timestamp_time_idx on _hyper_5_157_chunk
+         Filter: (time_bucket(('60 mins'::cstring)::interval, "time") > ('2000-01-01 UTC'::cstring)::timestamp without time zone)
+   ->  Index Only Scan Backward using _hyper_5_158_chunk_metrics_timestamp_time_idx on _hyper_5_158_chunk
+         Filter: (time_bucket(('60 mins'::cstring)::interval, "time") > ('2000-01-01 UTC'::cstring)::timestamp without time zone)
+   ->  Index Only Scan Backward using _hyper_5_159_chunk_metrics_timestamp_time_idx on _hyper_5_159_chunk
+         Filter: (time_bucket(('60 mins'::cstring)::interval, "time") > ('2000-01-01 UTC'::cstring)::timestamp without time zone)
+(13 rows)
+
+:PREFIX EXECUTE P5('60 mins', '2000-01-01 UTC');
+                                                     QUERY PLAN                                                      
+---------------------------------------------------------------------------------------------------------------------
+ Custom Scan (ChunkAppend) on metrics_timestamptz
+   Order: metrics_timestamptz."time"
+   Chunks excluded during startup: 0
+   ->  Index Scan Backward using _hyper_6_160_chunk_metrics_timestamptz_time_idx on _hyper_6_160_chunk
+         Filter: (time_bucket('@ 1 hour'::interval, "time") > ('2000-01-01 UTC'::cstring)::timestamp with time zone)
+   ->  Index Scan Backward using _hyper_6_161_chunk_metrics_timestamptz_time_idx on _hyper_6_161_chunk
+         Filter: (time_bucket('@ 1 hour'::interval, "time") > ('2000-01-01 UTC'::cstring)::timestamp with time zone)
+   ->  Index Scan Backward using _hyper_6_162_chunk_metrics_timestamptz_time_idx on _hyper_6_162_chunk
+         Filter: (time_bucket('@ 1 hour'::interval, "time") > ('2000-01-01 UTC'::cstring)::timestamp with time zone)
+   ->  Index Scan Backward using _hyper_6_163_chunk_metrics_timestamptz_time_idx on _hyper_6_163_chunk
+         Filter: (time_bucket('@ 1 hour'::interval, "time") > ('2000-01-01 UTC'::cstring)::timestamp with time zone)
+   ->  Index Scan Backward using _hyper_6_164_chunk_metrics_timestamptz_time_idx on _hyper_6_164_chunk
+         Filter: (time_bucket('@ 1 hour'::interval, "time") > ('2000-01-01 UTC'::cstring)::timestamp with time zone)
+(13 rows)
+
+:PREFIX EXECUTE P6('60 mins', '2000-01-01 UTC');
+                                                     QUERY PLAN                                                      
+---------------------------------------------------------------------------------------------------------------------
+ Custom Scan (ChunkAppend) on metrics_timestamp
+   Order: metrics_timestamp."time"
+   Chunks excluded during startup: 0
+   ->  Index Only Scan Backward using _hyper_5_155_chunk_metrics_timestamp_time_idx on _hyper_5_155_chunk
+         Filter: (time_bucket('@ 1 hour'::interval, "time") > ('2000-01-01 UTC'::cstring)::timestamp with time zone)
+   ->  Index Only Scan Backward using _hyper_5_156_chunk_metrics_timestamp_time_idx on _hyper_5_156_chunk
+         Filter: (time_bucket('@ 1 hour'::interval, "time") > ('2000-01-01 UTC'::cstring)::timestamp with time zone)
+   ->  Index Only Scan Backward using _hyper_5_157_chunk_metrics_timestamp_time_idx on _hyper_5_157_chunk
+         Filter: (time_bucket('@ 1 hour'::interval, "time") > ('2000-01-01 UTC'::cstring)::timestamp with time zone)
+   ->  Index Only Scan Backward using _hyper_5_158_chunk_metrics_timestamp_time_idx on _hyper_5_158_chunk
+         Filter: (time_bucket('@ 1 hour'::interval, "time") > ('2000-01-01 UTC'::cstring)::timestamp with time zone)
+   ->  Index Only Scan Backward using _hyper_5_159_chunk_metrics_timestamp_time_idx on _hyper_5_159_chunk
+         Filter: (time_bucket('@ 1 hour'::interval, "time") > ('2000-01-01 UTC'::cstring)::timestamp with time zone)
+(13 rows)
+
+:PREFIX EXECUTE P7('60 mins', '2000-01-01 UTC');
+                                                       QUERY PLAN                                                       
+------------------------------------------------------------------------------------------------------------------------
+ Custom Scan (ChunkAppend) on metrics_timestamptz
+   Order: metrics_timestamptz."time"
+   Chunks excluded during startup: 0
+   ->  Index Scan Backward using _hyper_6_160_chunk_metrics_timestamptz_time_idx on _hyper_6_160_chunk
+         Filter: (time_bucket('@ 1 hour'::interval, "time") > ('2000-01-01 UTC'::cstring)::timestamp without time zone)
+   ->  Index Scan Backward using _hyper_6_161_chunk_metrics_timestamptz_time_idx on _hyper_6_161_chunk
+         Filter: (time_bucket('@ 1 hour'::interval, "time") > ('2000-01-01 UTC'::cstring)::timestamp without time zone)
+   ->  Index Scan Backward using _hyper_6_162_chunk_metrics_timestamptz_time_idx on _hyper_6_162_chunk
+         Filter: (time_bucket('@ 1 hour'::interval, "time") > ('2000-01-01 UTC'::cstring)::timestamp without time zone)
+   ->  Index Scan Backward using _hyper_6_163_chunk_metrics_timestamptz_time_idx on _hyper_6_163_chunk
+         Filter: (time_bucket('@ 1 hour'::interval, "time") > ('2000-01-01 UTC'::cstring)::timestamp without time zone)
+   ->  Index Scan Backward using _hyper_6_164_chunk_metrics_timestamptz_time_idx on _hyper_6_164_chunk
+         Filter: (time_bucket('@ 1 hour'::interval, "time") > ('2000-01-01 UTC'::cstring)::timestamp without time zone)
+(13 rows)
+
+:PREFIX EXECUTE P8('60 mins', '2000-01-01 UTC');
+                                                       QUERY PLAN                                                       
+------------------------------------------------------------------------------------------------------------------------
+ Custom Scan (ChunkAppend) on metrics_timestamp
+   Order: metrics_timestamp."time"
+   Chunks excluded during startup: 0
+   ->  Index Only Scan Backward using _hyper_5_155_chunk_metrics_timestamp_time_idx on _hyper_5_155_chunk
+         Filter: (time_bucket('@ 1 hour'::interval, "time") > ('2000-01-01 UTC'::cstring)::timestamp without time zone)
+   ->  Index Only Scan Backward using _hyper_5_156_chunk_metrics_timestamp_time_idx on _hyper_5_156_chunk
+         Filter: (time_bucket('@ 1 hour'::interval, "time") > ('2000-01-01 UTC'::cstring)::timestamp without time zone)
+   ->  Index Only Scan Backward using _hyper_5_157_chunk_metrics_timestamp_time_idx on _hyper_5_157_chunk
+         Filter: (time_bucket('@ 1 hour'::interval, "time") > ('2000-01-01 UTC'::cstring)::timestamp without time zone)
+   ->  Index Only Scan Backward using _hyper_5_158_chunk_metrics_timestamp_time_idx on _hyper_5_158_chunk
+         Filter: (time_bucket('@ 1 hour'::interval, "time") > ('2000-01-01 UTC'::cstring)::timestamp without time zone)
+   ->  Index Only Scan Backward using _hyper_5_159_chunk_metrics_timestamp_time_idx on _hyper_5_159_chunk
+         Filter: (time_bucket('@ 1 hour'::interval, "time") > ('2000-01-01 UTC'::cstring)::timestamp without time zone)
+(13 rows)
+
+SET plan_cache_mode TO 'force_generic_plan';
+:PREFIX EXECUTE P1('60 mins', '2024-01-01 UTC');
+                    QUERY PLAN                    
+--------------------------------------------------
+ Custom Scan (ChunkAppend) on metrics_timestamptz
+   Order: metrics_timestamptz."time"
+   Chunks excluded during startup: 5
+(3 rows)
+
+:PREFIX EXECUTE P2('60 mins', '2024-01-01 UTC');
+                   QUERY PLAN                   
+------------------------------------------------
+ Custom Scan (ChunkAppend) on metrics_timestamp
+   Order: metrics_timestamp."time"
+   Chunks excluded during startup: 5
+(3 rows)
+
+:PREFIX EXECUTE P3('60 mins', '2024-01-01 UTC');
+                    QUERY PLAN                    
+--------------------------------------------------
+ Custom Scan (ChunkAppend) on metrics_timestamptz
+   Order: metrics_timestamptz."time"
+   Chunks excluded during startup: 5
+(3 rows)
+
+:PREFIX EXECUTE P4('60 mins', '2024-01-01 UTC');
+                   QUERY PLAN                   
+------------------------------------------------
+ Custom Scan (ChunkAppend) on metrics_timestamp
+   Order: metrics_timestamp."time"
+   Chunks excluded during startup: 5
+(3 rows)
+
+:PREFIX EXECUTE P5('60 mins', '2024-01-01 UTC');
+                    QUERY PLAN                    
+--------------------------------------------------
+ Custom Scan (ChunkAppend) on metrics_timestamptz
+   Order: metrics_timestamptz."time"
+   Chunks excluded during startup: 5
+(3 rows)
+
+:PREFIX EXECUTE P6('60 mins', '2024-01-01 UTC');
+                   QUERY PLAN                   
+------------------------------------------------
+ Custom Scan (ChunkAppend) on metrics_timestamp
+   Order: metrics_timestamp."time"
+   Chunks excluded during startup: 5
+(3 rows)
+
+:PREFIX EXECUTE P7('60 mins', '2024-01-01 UTC');
+                    QUERY PLAN                    
+--------------------------------------------------
+ Custom Scan (ChunkAppend) on metrics_timestamptz
+   Order: metrics_timestamptz."time"
+   Chunks excluded during startup: 5
+(3 rows)
+
+:PREFIX EXECUTE P8('60 mins', '2024-01-01 UTC');
+                   QUERY PLAN                   
+------------------------------------------------
+ Custom Scan (ChunkAppend) on metrics_timestamp
+   Order: metrics_timestamp."time"
+   Chunks excluded during startup: 5
+(3 rows)
+
+:PREFIX EXECUTE P1('60 mins', '2000-01-01 UTC');
+                                              QUERY PLAN                                               
+-------------------------------------------------------------------------------------------------------
+ Custom Scan (ChunkAppend) on metrics_timestamptz
+   Order: metrics_timestamptz."time"
+   Chunks excluded during startup: 0
+   ->  Index Scan Backward using _hyper_6_160_chunk_metrics_timestamptz_time_idx on _hyper_6_160_chunk
+         Filter: (time_bucket(($1)::interval, "time") > ($2)::timestamp with time zone)
+   ->  Index Scan Backward using _hyper_6_161_chunk_metrics_timestamptz_time_idx on _hyper_6_161_chunk
+         Filter: (time_bucket(($1)::interval, "time") > ($2)::timestamp with time zone)
+   ->  Index Scan Backward using _hyper_6_162_chunk_metrics_timestamptz_time_idx on _hyper_6_162_chunk
+         Filter: (time_bucket(($1)::interval, "time") > ($2)::timestamp with time zone)
+   ->  Index Scan Backward using _hyper_6_163_chunk_metrics_timestamptz_time_idx on _hyper_6_163_chunk
+         Filter: (time_bucket(($1)::interval, "time") > ($2)::timestamp with time zone)
+   ->  Index Scan Backward using _hyper_6_164_chunk_metrics_timestamptz_time_idx on _hyper_6_164_chunk
+         Filter: (time_bucket(($1)::interval, "time") > ($2)::timestamp with time zone)
+(13 rows)
+
+:PREFIX EXECUTE P2('60 mins', '2000-01-01 UTC');
+                                                QUERY PLAN                                                
+----------------------------------------------------------------------------------------------------------
+ Custom Scan (ChunkAppend) on metrics_timestamp
+   Order: metrics_timestamp."time"
+   Chunks excluded during startup: 0
+   ->  Index Only Scan Backward using _hyper_5_155_chunk_metrics_timestamp_time_idx on _hyper_5_155_chunk
+         Filter: (time_bucket(($1)::interval, "time") > ($2)::timestamp with time zone)
+   ->  Index Only Scan Backward using _hyper_5_156_chunk_metrics_timestamp_time_idx on _hyper_5_156_chunk
+         Filter: (time_bucket(($1)::interval, "time") > ($2)::timestamp with time zone)
+   ->  Index Only Scan Backward using _hyper_5_157_chunk_metrics_timestamp_time_idx on _hyper_5_157_chunk
+         Filter: (time_bucket(($1)::interval, "time") > ($2)::timestamp with time zone)
+   ->  Index Only Scan Backward using _hyper_5_158_chunk_metrics_timestamp_time_idx on _hyper_5_158_chunk
+         Filter: (time_bucket(($1)::interval, "time") > ($2)::timestamp with time zone)
+   ->  Index Only Scan Backward using _hyper_5_159_chunk_metrics_timestamp_time_idx on _hyper_5_159_chunk
+         Filter: (time_bucket(($1)::interval, "time") > ($2)::timestamp with time zone)
+(13 rows)
+
+:PREFIX EXECUTE P3('60 mins', '2000-01-01 UTC');
+                                              QUERY PLAN                                               
+-------------------------------------------------------------------------------------------------------
+ Custom Scan (ChunkAppend) on metrics_timestamptz
+   Order: metrics_timestamptz."time"
+   Chunks excluded during startup: 0
+   ->  Index Scan Backward using _hyper_6_160_chunk_metrics_timestamptz_time_idx on _hyper_6_160_chunk
+         Filter: (time_bucket(($1)::interval, "time") > ($2)::timestamp without time zone)
+   ->  Index Scan Backward using _hyper_6_161_chunk_metrics_timestamptz_time_idx on _hyper_6_161_chunk
+         Filter: (time_bucket(($1)::interval, "time") > ($2)::timestamp without time zone)
+   ->  Index Scan Backward using _hyper_6_162_chunk_metrics_timestamptz_time_idx on _hyper_6_162_chunk
+         Filter: (time_bucket(($1)::interval, "time") > ($2)::timestamp without time zone)
+   ->  Index Scan Backward using _hyper_6_163_chunk_metrics_timestamptz_time_idx on _hyper_6_163_chunk
+         Filter: (time_bucket(($1)::interval, "time") > ($2)::timestamp without time zone)
+   ->  Index Scan Backward using _hyper_6_164_chunk_metrics_timestamptz_time_idx on _hyper_6_164_chunk
+         Filter: (time_bucket(($1)::interval, "time") > ($2)::timestamp without time zone)
+(13 rows)
+
+:PREFIX EXECUTE P4('60 mins', '2000-01-01 UTC');
+                                                QUERY PLAN                                                
+----------------------------------------------------------------------------------------------------------
+ Custom Scan (ChunkAppend) on metrics_timestamp
+   Order: metrics_timestamp."time"
+   Chunks excluded during startup: 0
+   ->  Index Only Scan Backward using _hyper_5_155_chunk_metrics_timestamp_time_idx on _hyper_5_155_chunk
+         Filter: (time_bucket(($1)::interval, "time") > ($2)::timestamp without time zone)
+   ->  Index Only Scan Backward using _hyper_5_156_chunk_metrics_timestamp_time_idx on _hyper_5_156_chunk
+         Filter: (time_bucket(($1)::interval, "time") > ($2)::timestamp without time zone)
+   ->  Index Only Scan Backward using _hyper_5_157_chunk_metrics_timestamp_time_idx on _hyper_5_157_chunk
+         Filter: (time_bucket(($1)::interval, "time") > ($2)::timestamp without time zone)
+   ->  Index Only Scan Backward using _hyper_5_158_chunk_metrics_timestamp_time_idx on _hyper_5_158_chunk
+         Filter: (time_bucket(($1)::interval, "time") > ($2)::timestamp without time zone)
+   ->  Index Only Scan Backward using _hyper_5_159_chunk_metrics_timestamp_time_idx on _hyper_5_159_chunk
+         Filter: (time_bucket(($1)::interval, "time") > ($2)::timestamp without time zone)
+(13 rows)
+
+:PREFIX EXECUTE P5('60 mins', '2000-01-01 UTC');
+                                              QUERY PLAN                                               
+-------------------------------------------------------------------------------------------------------
+ Custom Scan (ChunkAppend) on metrics_timestamptz
+   Order: metrics_timestamptz."time"
+   Chunks excluded during startup: 0
+   ->  Index Scan Backward using _hyper_6_160_chunk_metrics_timestamptz_time_idx on _hyper_6_160_chunk
+         Filter: (time_bucket($1, "time") > ($2)::timestamp with time zone)
+   ->  Index Scan Backward using _hyper_6_161_chunk_metrics_timestamptz_time_idx on _hyper_6_161_chunk
+         Filter: (time_bucket($1, "time") > ($2)::timestamp with time zone)
+   ->  Index Scan Backward using _hyper_6_162_chunk_metrics_timestamptz_time_idx on _hyper_6_162_chunk
+         Filter: (time_bucket($1, "time") > ($2)::timestamp with time zone)
+   ->  Index Scan Backward using _hyper_6_163_chunk_metrics_timestamptz_time_idx on _hyper_6_163_chunk
+         Filter: (time_bucket($1, "time") > ($2)::timestamp with time zone)
+   ->  Index Scan Backward using _hyper_6_164_chunk_metrics_timestamptz_time_idx on _hyper_6_164_chunk
+         Filter: (time_bucket($1, "time") > ($2)::timestamp with time zone)
+(13 rows)
+
+:PREFIX EXECUTE P6('60 mins', '2000-01-01 UTC');
+                                                QUERY PLAN                                                
+----------------------------------------------------------------------------------------------------------
+ Custom Scan (ChunkAppend) on metrics_timestamp
+   Order: metrics_timestamp."time"
+   Chunks excluded during startup: 0
+   ->  Index Only Scan Backward using _hyper_5_155_chunk_metrics_timestamp_time_idx on _hyper_5_155_chunk
+         Filter: (time_bucket($1, "time") > ($2)::timestamp with time zone)
+   ->  Index Only Scan Backward using _hyper_5_156_chunk_metrics_timestamp_time_idx on _hyper_5_156_chunk
+         Filter: (time_bucket($1, "time") > ($2)::timestamp with time zone)
+   ->  Index Only Scan Backward using _hyper_5_157_chunk_metrics_timestamp_time_idx on _hyper_5_157_chunk
+         Filter: (time_bucket($1, "time") > ($2)::timestamp with time zone)
+   ->  Index Only Scan Backward using _hyper_5_158_chunk_metrics_timestamp_time_idx on _hyper_5_158_chunk
+         Filter: (time_bucket($1, "time") > ($2)::timestamp with time zone)
+   ->  Index Only Scan Backward using _hyper_5_159_chunk_metrics_timestamp_time_idx on _hyper_5_159_chunk
+         Filter: (time_bucket($1, "time") > ($2)::timestamp with time zone)
+(13 rows)
+
+:PREFIX EXECUTE P7('60 mins', '2000-01-01 UTC');
+                                              QUERY PLAN                                               
+-------------------------------------------------------------------------------------------------------
+ Custom Scan (ChunkAppend) on metrics_timestamptz
+   Order: metrics_timestamptz."time"
+   Chunks excluded during startup: 0
+   ->  Index Scan Backward using _hyper_6_160_chunk_metrics_timestamptz_time_idx on _hyper_6_160_chunk
+         Filter: (time_bucket($1, "time") > ($2)::timestamp without time zone)
+   ->  Index Scan Backward using _hyper_6_161_chunk_metrics_timestamptz_time_idx on _hyper_6_161_chunk
+         Filter: (time_bucket($1, "time") > ($2)::timestamp without time zone)
+   ->  Index Scan Backward using _hyper_6_162_chunk_metrics_timestamptz_time_idx on _hyper_6_162_chunk
+         Filter: (time_bucket($1, "time") > ($2)::timestamp without time zone)
+   ->  Index Scan Backward using _hyper_6_163_chunk_metrics_timestamptz_time_idx on _hyper_6_163_chunk
+         Filter: (time_bucket($1, "time") > ($2)::timestamp without time zone)
+   ->  Index Scan Backward using _hyper_6_164_chunk_metrics_timestamptz_time_idx on _hyper_6_164_chunk
+         Filter: (time_bucket($1, "time") > ($2)::timestamp without time zone)
+(13 rows)
+
+:PREFIX EXECUTE P8('60 mins', '2000-01-01 UTC');
+                                                QUERY PLAN                                                
+----------------------------------------------------------------------------------------------------------
+ Custom Scan (ChunkAppend) on metrics_timestamp
+   Order: metrics_timestamp."time"
+   Chunks excluded during startup: 0
+   ->  Index Only Scan Backward using _hyper_5_155_chunk_metrics_timestamp_time_idx on _hyper_5_155_chunk
+         Filter: (time_bucket($1, "time") > ($2)::timestamp without time zone)
+   ->  Index Only Scan Backward using _hyper_5_156_chunk_metrics_timestamp_time_idx on _hyper_5_156_chunk
+         Filter: (time_bucket($1, "time") > ($2)::timestamp without time zone)
+   ->  Index Only Scan Backward using _hyper_5_157_chunk_metrics_timestamp_time_idx on _hyper_5_157_chunk
+         Filter: (time_bucket($1, "time") > ($2)::timestamp without time zone)
+   ->  Index Only Scan Backward using _hyper_5_158_chunk_metrics_timestamp_time_idx on _hyper_5_158_chunk
+         Filter: (time_bucket($1, "time") > ($2)::timestamp without time zone)
+   ->  Index Only Scan Backward using _hyper_5_159_chunk_metrics_timestamp_time_idx on _hyper_5_159_chunk
+         Filter: (time_bucket($1, "time") > ($2)::timestamp without time zone)
+(13 rows)
+
+RESET plan_cache_mode;
+DEALLOCATE P1;
+DEALLOCATE P2;
+DEALLOCATE P3;
+DEALLOCATE P4;
+DEALLOCATE P5;
+DEALLOCATE P6;
+DEALLOCATE P7;
+DEALLOCATE P8;
 :PREFIX SELECT * FROM hyper WHERE time_bucket(10, time) > 10 AND time_bucket(10, time) < 100 ORDER BY time;
                                                                           QUERY PLAN                                                                           
 ---------------------------------------------------------------------------------------------------------------------------------------------------------------

--- a/test/expected/plan_expand_hypertable-16.out
+++ b/test/expected/plan_expand_hypertable-16.out
@@ -1217,6 +1217,445 @@ transformation would be out of range
          Filter: (time_bucket('@ 1000 days'::interval, "time") < 'Sat Jan 01 00:00:00 294276 PST'::timestamp with time zone)
 (12 rows)
 
+\qecho time_bucket exclusion with run-time constants
+time_bucket exclusion with run-time constants
+-- These queries have a stable time_bucket expression, because the text::interval conversion is stable.
+PREPARE P1(text    , text) AS SELECT * FROM metrics_timestamptz WHERE time_bucket($1::interval, time) > $2::timestamptz ORDER BY time;
+PREPARE P2(text    , text) AS SELECT * FROM metrics_timestamp   WHERE time_bucket($1::interval, time) > $2::timestamptz ORDER BY time;
+PREPARE P3(text    , text) AS SELECT * FROM metrics_timestamptz WHERE time_bucket($1::interval, time) > $2::timestamp   ORDER BY time;
+PREPARE P4(text    , text) AS SELECT * FROM metrics_timestamp   WHERE time_bucket($1::interval, time) > $2::timestamp   ORDER BY time;
+-- These queries have an immutable time_bucket expression, because the parameter is passed as interval, and no conversion is involved.
+PREPARE P5(interval, text) AS SELECT * FROM metrics_timestamptz WHERE time_bucket($1::interval, time) > $2::timestamptz ORDER BY time;
+PREPARE P6(interval, text) AS SELECT * FROM metrics_timestamp   WHERE time_bucket($1::interval, time) > $2::timestamptz ORDER BY time;
+PREPARE P7(interval, text) AS SELECT * FROM metrics_timestamptz WHERE time_bucket($1::interval, time) > $2::timestamp   ORDER BY time;
+PREPARE P8(interval, text) AS SELECT * FROM metrics_timestamp   WHERE time_bucket($1::interval, time) > $2::timestamp   ORDER BY time;
+SET plan_cache_mode TO 'force_custom_plan';
+:PREFIX EXECUTE P1('60 mins', '2024-01-01 UTC');
+                    QUERY PLAN                    
+--------------------------------------------------
+ Custom Scan (ChunkAppend) on metrics_timestamptz
+   Order: metrics_timestamptz."time"
+   Chunks excluded during startup: 5
+(3 rows)
+
+:PREFIX EXECUTE P2('60 mins', '2024-01-01 UTC');
+                   QUERY PLAN                   
+------------------------------------------------
+ Custom Scan (ChunkAppend) on metrics_timestamp
+   Order: metrics_timestamp."time"
+   Chunks excluded during startup: 5
+(3 rows)
+
+:PREFIX EXECUTE P3('60 mins', '2024-01-01 UTC');
+                    QUERY PLAN                    
+--------------------------------------------------
+ Custom Scan (ChunkAppend) on metrics_timestamptz
+   Order: metrics_timestamptz."time"
+   Chunks excluded during startup: 5
+(3 rows)
+
+:PREFIX EXECUTE P4('60 mins', '2024-01-01 UTC');
+                   QUERY PLAN                   
+------------------------------------------------
+ Custom Scan (ChunkAppend) on metrics_timestamp
+   Order: metrics_timestamp."time"
+   Chunks excluded during startup: 5
+(3 rows)
+
+:PREFIX EXECUTE P5('60 mins', '2024-01-01 UTC');
+                    QUERY PLAN                    
+--------------------------------------------------
+ Custom Scan (ChunkAppend) on metrics_timestamptz
+   Order: metrics_timestamptz."time"
+   Chunks excluded during startup: 5
+(3 rows)
+
+:PREFIX EXECUTE P6('60 mins', '2024-01-01 UTC');
+                   QUERY PLAN                   
+------------------------------------------------
+ Custom Scan (ChunkAppend) on metrics_timestamp
+   Order: metrics_timestamp."time"
+   Chunks excluded during startup: 5
+(3 rows)
+
+:PREFIX EXECUTE P7('60 mins', '2024-01-01 UTC');
+                    QUERY PLAN                    
+--------------------------------------------------
+ Custom Scan (ChunkAppend) on metrics_timestamptz
+   Order: metrics_timestamptz."time"
+   Chunks excluded during startup: 5
+(3 rows)
+
+:PREFIX EXECUTE P8('60 mins', '2024-01-01 UTC');
+                   QUERY PLAN                   
+------------------------------------------------
+ Custom Scan (ChunkAppend) on metrics_timestamp
+   Order: metrics_timestamp."time"
+   Chunks excluded during startup: 5
+(3 rows)
+
+:PREFIX EXECUTE P1('60 mins', '2000-01-01 UTC');
+                                                          QUERY PLAN                                                           
+-------------------------------------------------------------------------------------------------------------------------------
+ Custom Scan (ChunkAppend) on metrics_timestamptz
+   Order: metrics_timestamptz."time"
+   Chunks excluded during startup: 0
+   ->  Index Scan Backward using _hyper_6_160_chunk_metrics_timestamptz_time_idx on _hyper_6_160_chunk
+         Filter: (time_bucket(('60 mins'::cstring)::interval, "time") > ('2000-01-01 UTC'::cstring)::timestamp with time zone)
+   ->  Index Scan Backward using _hyper_6_161_chunk_metrics_timestamptz_time_idx on _hyper_6_161_chunk
+         Filter: (time_bucket(('60 mins'::cstring)::interval, "time") > ('2000-01-01 UTC'::cstring)::timestamp with time zone)
+   ->  Index Scan Backward using _hyper_6_162_chunk_metrics_timestamptz_time_idx on _hyper_6_162_chunk
+         Filter: (time_bucket(('60 mins'::cstring)::interval, "time") > ('2000-01-01 UTC'::cstring)::timestamp with time zone)
+   ->  Index Scan Backward using _hyper_6_163_chunk_metrics_timestamptz_time_idx on _hyper_6_163_chunk
+         Filter: (time_bucket(('60 mins'::cstring)::interval, "time") > ('2000-01-01 UTC'::cstring)::timestamp with time zone)
+   ->  Index Scan Backward using _hyper_6_164_chunk_metrics_timestamptz_time_idx on _hyper_6_164_chunk
+         Filter: (time_bucket(('60 mins'::cstring)::interval, "time") > ('2000-01-01 UTC'::cstring)::timestamp with time zone)
+(13 rows)
+
+:PREFIX EXECUTE P2('60 mins', '2000-01-01 UTC');
+                                                          QUERY PLAN                                                           
+-------------------------------------------------------------------------------------------------------------------------------
+ Custom Scan (ChunkAppend) on metrics_timestamp
+   Order: metrics_timestamp."time"
+   Chunks excluded during startup: 0
+   ->  Index Only Scan Backward using _hyper_5_155_chunk_metrics_timestamp_time_idx on _hyper_5_155_chunk
+         Filter: (time_bucket(('60 mins'::cstring)::interval, "time") > ('2000-01-01 UTC'::cstring)::timestamp with time zone)
+   ->  Index Only Scan Backward using _hyper_5_156_chunk_metrics_timestamp_time_idx on _hyper_5_156_chunk
+         Filter: (time_bucket(('60 mins'::cstring)::interval, "time") > ('2000-01-01 UTC'::cstring)::timestamp with time zone)
+   ->  Index Only Scan Backward using _hyper_5_157_chunk_metrics_timestamp_time_idx on _hyper_5_157_chunk
+         Filter: (time_bucket(('60 mins'::cstring)::interval, "time") > ('2000-01-01 UTC'::cstring)::timestamp with time zone)
+   ->  Index Only Scan Backward using _hyper_5_158_chunk_metrics_timestamp_time_idx on _hyper_5_158_chunk
+         Filter: (time_bucket(('60 mins'::cstring)::interval, "time") > ('2000-01-01 UTC'::cstring)::timestamp with time zone)
+   ->  Index Only Scan Backward using _hyper_5_159_chunk_metrics_timestamp_time_idx on _hyper_5_159_chunk
+         Filter: (time_bucket(('60 mins'::cstring)::interval, "time") > ('2000-01-01 UTC'::cstring)::timestamp with time zone)
+(13 rows)
+
+:PREFIX EXECUTE P3('60 mins', '2000-01-01 UTC');
+                                                            QUERY PLAN                                                            
+----------------------------------------------------------------------------------------------------------------------------------
+ Custom Scan (ChunkAppend) on metrics_timestamptz
+   Order: metrics_timestamptz."time"
+   Chunks excluded during startup: 0
+   ->  Index Scan Backward using _hyper_6_160_chunk_metrics_timestamptz_time_idx on _hyper_6_160_chunk
+         Filter: (time_bucket(('60 mins'::cstring)::interval, "time") > ('2000-01-01 UTC'::cstring)::timestamp without time zone)
+   ->  Index Scan Backward using _hyper_6_161_chunk_metrics_timestamptz_time_idx on _hyper_6_161_chunk
+         Filter: (time_bucket(('60 mins'::cstring)::interval, "time") > ('2000-01-01 UTC'::cstring)::timestamp without time zone)
+   ->  Index Scan Backward using _hyper_6_162_chunk_metrics_timestamptz_time_idx on _hyper_6_162_chunk
+         Filter: (time_bucket(('60 mins'::cstring)::interval, "time") > ('2000-01-01 UTC'::cstring)::timestamp without time zone)
+   ->  Index Scan Backward using _hyper_6_163_chunk_metrics_timestamptz_time_idx on _hyper_6_163_chunk
+         Filter: (time_bucket(('60 mins'::cstring)::interval, "time") > ('2000-01-01 UTC'::cstring)::timestamp without time zone)
+   ->  Index Scan Backward using _hyper_6_164_chunk_metrics_timestamptz_time_idx on _hyper_6_164_chunk
+         Filter: (time_bucket(('60 mins'::cstring)::interval, "time") > ('2000-01-01 UTC'::cstring)::timestamp without time zone)
+(13 rows)
+
+:PREFIX EXECUTE P4('60 mins', '2000-01-01 UTC');
+                                                            QUERY PLAN                                                            
+----------------------------------------------------------------------------------------------------------------------------------
+ Custom Scan (ChunkAppend) on metrics_timestamp
+   Order: metrics_timestamp."time"
+   Chunks excluded during startup: 0
+   ->  Index Only Scan Backward using _hyper_5_155_chunk_metrics_timestamp_time_idx on _hyper_5_155_chunk
+         Filter: (time_bucket(('60 mins'::cstring)::interval, "time") > ('2000-01-01 UTC'::cstring)::timestamp without time zone)
+   ->  Index Only Scan Backward using _hyper_5_156_chunk_metrics_timestamp_time_idx on _hyper_5_156_chunk
+         Filter: (time_bucket(('60 mins'::cstring)::interval, "time") > ('2000-01-01 UTC'::cstring)::timestamp without time zone)
+   ->  Index Only Scan Backward using _hyper_5_157_chunk_metrics_timestamp_time_idx on _hyper_5_157_chunk
+         Filter: (time_bucket(('60 mins'::cstring)::interval, "time") > ('2000-01-01 UTC'::cstring)::timestamp without time zone)
+   ->  Index Only Scan Backward using _hyper_5_158_chunk_metrics_timestamp_time_idx on _hyper_5_158_chunk
+         Filter: (time_bucket(('60 mins'::cstring)::interval, "time") > ('2000-01-01 UTC'::cstring)::timestamp without time zone)
+   ->  Index Only Scan Backward using _hyper_5_159_chunk_metrics_timestamp_time_idx on _hyper_5_159_chunk
+         Filter: (time_bucket(('60 mins'::cstring)::interval, "time") > ('2000-01-01 UTC'::cstring)::timestamp without time zone)
+(13 rows)
+
+:PREFIX EXECUTE P5('60 mins', '2000-01-01 UTC');
+                                                     QUERY PLAN                                                      
+---------------------------------------------------------------------------------------------------------------------
+ Custom Scan (ChunkAppend) on metrics_timestamptz
+   Order: metrics_timestamptz."time"
+   Chunks excluded during startup: 0
+   ->  Index Scan Backward using _hyper_6_160_chunk_metrics_timestamptz_time_idx on _hyper_6_160_chunk
+         Filter: (time_bucket('@ 1 hour'::interval, "time") > ('2000-01-01 UTC'::cstring)::timestamp with time zone)
+   ->  Index Scan Backward using _hyper_6_161_chunk_metrics_timestamptz_time_idx on _hyper_6_161_chunk
+         Filter: (time_bucket('@ 1 hour'::interval, "time") > ('2000-01-01 UTC'::cstring)::timestamp with time zone)
+   ->  Index Scan Backward using _hyper_6_162_chunk_metrics_timestamptz_time_idx on _hyper_6_162_chunk
+         Filter: (time_bucket('@ 1 hour'::interval, "time") > ('2000-01-01 UTC'::cstring)::timestamp with time zone)
+   ->  Index Scan Backward using _hyper_6_163_chunk_metrics_timestamptz_time_idx on _hyper_6_163_chunk
+         Filter: (time_bucket('@ 1 hour'::interval, "time") > ('2000-01-01 UTC'::cstring)::timestamp with time zone)
+   ->  Index Scan Backward using _hyper_6_164_chunk_metrics_timestamptz_time_idx on _hyper_6_164_chunk
+         Filter: (time_bucket('@ 1 hour'::interval, "time") > ('2000-01-01 UTC'::cstring)::timestamp with time zone)
+(13 rows)
+
+:PREFIX EXECUTE P6('60 mins', '2000-01-01 UTC');
+                                                     QUERY PLAN                                                      
+---------------------------------------------------------------------------------------------------------------------
+ Custom Scan (ChunkAppend) on metrics_timestamp
+   Order: metrics_timestamp."time"
+   Chunks excluded during startup: 0
+   ->  Index Only Scan Backward using _hyper_5_155_chunk_metrics_timestamp_time_idx on _hyper_5_155_chunk
+         Filter: (time_bucket('@ 1 hour'::interval, "time") > ('2000-01-01 UTC'::cstring)::timestamp with time zone)
+   ->  Index Only Scan Backward using _hyper_5_156_chunk_metrics_timestamp_time_idx on _hyper_5_156_chunk
+         Filter: (time_bucket('@ 1 hour'::interval, "time") > ('2000-01-01 UTC'::cstring)::timestamp with time zone)
+   ->  Index Only Scan Backward using _hyper_5_157_chunk_metrics_timestamp_time_idx on _hyper_5_157_chunk
+         Filter: (time_bucket('@ 1 hour'::interval, "time") > ('2000-01-01 UTC'::cstring)::timestamp with time zone)
+   ->  Index Only Scan Backward using _hyper_5_158_chunk_metrics_timestamp_time_idx on _hyper_5_158_chunk
+         Filter: (time_bucket('@ 1 hour'::interval, "time") > ('2000-01-01 UTC'::cstring)::timestamp with time zone)
+   ->  Index Only Scan Backward using _hyper_5_159_chunk_metrics_timestamp_time_idx on _hyper_5_159_chunk
+         Filter: (time_bucket('@ 1 hour'::interval, "time") > ('2000-01-01 UTC'::cstring)::timestamp with time zone)
+(13 rows)
+
+:PREFIX EXECUTE P7('60 mins', '2000-01-01 UTC');
+                                                       QUERY PLAN                                                       
+------------------------------------------------------------------------------------------------------------------------
+ Custom Scan (ChunkAppend) on metrics_timestamptz
+   Order: metrics_timestamptz."time"
+   Chunks excluded during startup: 0
+   ->  Index Scan Backward using _hyper_6_160_chunk_metrics_timestamptz_time_idx on _hyper_6_160_chunk
+         Filter: (time_bucket('@ 1 hour'::interval, "time") > ('2000-01-01 UTC'::cstring)::timestamp without time zone)
+   ->  Index Scan Backward using _hyper_6_161_chunk_metrics_timestamptz_time_idx on _hyper_6_161_chunk
+         Filter: (time_bucket('@ 1 hour'::interval, "time") > ('2000-01-01 UTC'::cstring)::timestamp without time zone)
+   ->  Index Scan Backward using _hyper_6_162_chunk_metrics_timestamptz_time_idx on _hyper_6_162_chunk
+         Filter: (time_bucket('@ 1 hour'::interval, "time") > ('2000-01-01 UTC'::cstring)::timestamp without time zone)
+   ->  Index Scan Backward using _hyper_6_163_chunk_metrics_timestamptz_time_idx on _hyper_6_163_chunk
+         Filter: (time_bucket('@ 1 hour'::interval, "time") > ('2000-01-01 UTC'::cstring)::timestamp without time zone)
+   ->  Index Scan Backward using _hyper_6_164_chunk_metrics_timestamptz_time_idx on _hyper_6_164_chunk
+         Filter: (time_bucket('@ 1 hour'::interval, "time") > ('2000-01-01 UTC'::cstring)::timestamp without time zone)
+(13 rows)
+
+:PREFIX EXECUTE P8('60 mins', '2000-01-01 UTC');
+                                                       QUERY PLAN                                                       
+------------------------------------------------------------------------------------------------------------------------
+ Custom Scan (ChunkAppend) on metrics_timestamp
+   Order: metrics_timestamp."time"
+   Chunks excluded during startup: 0
+   ->  Index Only Scan Backward using _hyper_5_155_chunk_metrics_timestamp_time_idx on _hyper_5_155_chunk
+         Filter: (time_bucket('@ 1 hour'::interval, "time") > ('2000-01-01 UTC'::cstring)::timestamp without time zone)
+   ->  Index Only Scan Backward using _hyper_5_156_chunk_metrics_timestamp_time_idx on _hyper_5_156_chunk
+         Filter: (time_bucket('@ 1 hour'::interval, "time") > ('2000-01-01 UTC'::cstring)::timestamp without time zone)
+   ->  Index Only Scan Backward using _hyper_5_157_chunk_metrics_timestamp_time_idx on _hyper_5_157_chunk
+         Filter: (time_bucket('@ 1 hour'::interval, "time") > ('2000-01-01 UTC'::cstring)::timestamp without time zone)
+   ->  Index Only Scan Backward using _hyper_5_158_chunk_metrics_timestamp_time_idx on _hyper_5_158_chunk
+         Filter: (time_bucket('@ 1 hour'::interval, "time") > ('2000-01-01 UTC'::cstring)::timestamp without time zone)
+   ->  Index Only Scan Backward using _hyper_5_159_chunk_metrics_timestamp_time_idx on _hyper_5_159_chunk
+         Filter: (time_bucket('@ 1 hour'::interval, "time") > ('2000-01-01 UTC'::cstring)::timestamp without time zone)
+(13 rows)
+
+SET plan_cache_mode TO 'force_generic_plan';
+:PREFIX EXECUTE P1('60 mins', '2024-01-01 UTC');
+                    QUERY PLAN                    
+--------------------------------------------------
+ Custom Scan (ChunkAppend) on metrics_timestamptz
+   Order: metrics_timestamptz."time"
+   Chunks excluded during startup: 5
+(3 rows)
+
+:PREFIX EXECUTE P2('60 mins', '2024-01-01 UTC');
+                   QUERY PLAN                   
+------------------------------------------------
+ Custom Scan (ChunkAppend) on metrics_timestamp
+   Order: metrics_timestamp."time"
+   Chunks excluded during startup: 5
+(3 rows)
+
+:PREFIX EXECUTE P3('60 mins', '2024-01-01 UTC');
+                    QUERY PLAN                    
+--------------------------------------------------
+ Custom Scan (ChunkAppend) on metrics_timestamptz
+   Order: metrics_timestamptz."time"
+   Chunks excluded during startup: 5
+(3 rows)
+
+:PREFIX EXECUTE P4('60 mins', '2024-01-01 UTC');
+                   QUERY PLAN                   
+------------------------------------------------
+ Custom Scan (ChunkAppend) on metrics_timestamp
+   Order: metrics_timestamp."time"
+   Chunks excluded during startup: 5
+(3 rows)
+
+:PREFIX EXECUTE P5('60 mins', '2024-01-01 UTC');
+                    QUERY PLAN                    
+--------------------------------------------------
+ Custom Scan (ChunkAppend) on metrics_timestamptz
+   Order: metrics_timestamptz."time"
+   Chunks excluded during startup: 5
+(3 rows)
+
+:PREFIX EXECUTE P6('60 mins', '2024-01-01 UTC');
+                   QUERY PLAN                   
+------------------------------------------------
+ Custom Scan (ChunkAppend) on metrics_timestamp
+   Order: metrics_timestamp."time"
+   Chunks excluded during startup: 5
+(3 rows)
+
+:PREFIX EXECUTE P7('60 mins', '2024-01-01 UTC');
+                    QUERY PLAN                    
+--------------------------------------------------
+ Custom Scan (ChunkAppend) on metrics_timestamptz
+   Order: metrics_timestamptz."time"
+   Chunks excluded during startup: 5
+(3 rows)
+
+:PREFIX EXECUTE P8('60 mins', '2024-01-01 UTC');
+                   QUERY PLAN                   
+------------------------------------------------
+ Custom Scan (ChunkAppend) on metrics_timestamp
+   Order: metrics_timestamp."time"
+   Chunks excluded during startup: 5
+(3 rows)
+
+:PREFIX EXECUTE P1('60 mins', '2000-01-01 UTC');
+                                              QUERY PLAN                                               
+-------------------------------------------------------------------------------------------------------
+ Custom Scan (ChunkAppend) on metrics_timestamptz
+   Order: metrics_timestamptz."time"
+   Chunks excluded during startup: 0
+   ->  Index Scan Backward using _hyper_6_160_chunk_metrics_timestamptz_time_idx on _hyper_6_160_chunk
+         Filter: (time_bucket(($1)::interval, "time") > ($2)::timestamp with time zone)
+   ->  Index Scan Backward using _hyper_6_161_chunk_metrics_timestamptz_time_idx on _hyper_6_161_chunk
+         Filter: (time_bucket(($1)::interval, "time") > ($2)::timestamp with time zone)
+   ->  Index Scan Backward using _hyper_6_162_chunk_metrics_timestamptz_time_idx on _hyper_6_162_chunk
+         Filter: (time_bucket(($1)::interval, "time") > ($2)::timestamp with time zone)
+   ->  Index Scan Backward using _hyper_6_163_chunk_metrics_timestamptz_time_idx on _hyper_6_163_chunk
+         Filter: (time_bucket(($1)::interval, "time") > ($2)::timestamp with time zone)
+   ->  Index Scan Backward using _hyper_6_164_chunk_metrics_timestamptz_time_idx on _hyper_6_164_chunk
+         Filter: (time_bucket(($1)::interval, "time") > ($2)::timestamp with time zone)
+(13 rows)
+
+:PREFIX EXECUTE P2('60 mins', '2000-01-01 UTC');
+                                                QUERY PLAN                                                
+----------------------------------------------------------------------------------------------------------
+ Custom Scan (ChunkAppend) on metrics_timestamp
+   Order: metrics_timestamp."time"
+   Chunks excluded during startup: 0
+   ->  Index Only Scan Backward using _hyper_5_155_chunk_metrics_timestamp_time_idx on _hyper_5_155_chunk
+         Filter: (time_bucket(($1)::interval, "time") > ($2)::timestamp with time zone)
+   ->  Index Only Scan Backward using _hyper_5_156_chunk_metrics_timestamp_time_idx on _hyper_5_156_chunk
+         Filter: (time_bucket(($1)::interval, "time") > ($2)::timestamp with time zone)
+   ->  Index Only Scan Backward using _hyper_5_157_chunk_metrics_timestamp_time_idx on _hyper_5_157_chunk
+         Filter: (time_bucket(($1)::interval, "time") > ($2)::timestamp with time zone)
+   ->  Index Only Scan Backward using _hyper_5_158_chunk_metrics_timestamp_time_idx on _hyper_5_158_chunk
+         Filter: (time_bucket(($1)::interval, "time") > ($2)::timestamp with time zone)
+   ->  Index Only Scan Backward using _hyper_5_159_chunk_metrics_timestamp_time_idx on _hyper_5_159_chunk
+         Filter: (time_bucket(($1)::interval, "time") > ($2)::timestamp with time zone)
+(13 rows)
+
+:PREFIX EXECUTE P3('60 mins', '2000-01-01 UTC');
+                                              QUERY PLAN                                               
+-------------------------------------------------------------------------------------------------------
+ Custom Scan (ChunkAppend) on metrics_timestamptz
+   Order: metrics_timestamptz."time"
+   Chunks excluded during startup: 0
+   ->  Index Scan Backward using _hyper_6_160_chunk_metrics_timestamptz_time_idx on _hyper_6_160_chunk
+         Filter: (time_bucket(($1)::interval, "time") > ($2)::timestamp without time zone)
+   ->  Index Scan Backward using _hyper_6_161_chunk_metrics_timestamptz_time_idx on _hyper_6_161_chunk
+         Filter: (time_bucket(($1)::interval, "time") > ($2)::timestamp without time zone)
+   ->  Index Scan Backward using _hyper_6_162_chunk_metrics_timestamptz_time_idx on _hyper_6_162_chunk
+         Filter: (time_bucket(($1)::interval, "time") > ($2)::timestamp without time zone)
+   ->  Index Scan Backward using _hyper_6_163_chunk_metrics_timestamptz_time_idx on _hyper_6_163_chunk
+         Filter: (time_bucket(($1)::interval, "time") > ($2)::timestamp without time zone)
+   ->  Index Scan Backward using _hyper_6_164_chunk_metrics_timestamptz_time_idx on _hyper_6_164_chunk
+         Filter: (time_bucket(($1)::interval, "time") > ($2)::timestamp without time zone)
+(13 rows)
+
+:PREFIX EXECUTE P4('60 mins', '2000-01-01 UTC');
+                                                QUERY PLAN                                                
+----------------------------------------------------------------------------------------------------------
+ Custom Scan (ChunkAppend) on metrics_timestamp
+   Order: metrics_timestamp."time"
+   Chunks excluded during startup: 0
+   ->  Index Only Scan Backward using _hyper_5_155_chunk_metrics_timestamp_time_idx on _hyper_5_155_chunk
+         Filter: (time_bucket(($1)::interval, "time") > ($2)::timestamp without time zone)
+   ->  Index Only Scan Backward using _hyper_5_156_chunk_metrics_timestamp_time_idx on _hyper_5_156_chunk
+         Filter: (time_bucket(($1)::interval, "time") > ($2)::timestamp without time zone)
+   ->  Index Only Scan Backward using _hyper_5_157_chunk_metrics_timestamp_time_idx on _hyper_5_157_chunk
+         Filter: (time_bucket(($1)::interval, "time") > ($2)::timestamp without time zone)
+   ->  Index Only Scan Backward using _hyper_5_158_chunk_metrics_timestamp_time_idx on _hyper_5_158_chunk
+         Filter: (time_bucket(($1)::interval, "time") > ($2)::timestamp without time zone)
+   ->  Index Only Scan Backward using _hyper_5_159_chunk_metrics_timestamp_time_idx on _hyper_5_159_chunk
+         Filter: (time_bucket(($1)::interval, "time") > ($2)::timestamp without time zone)
+(13 rows)
+
+:PREFIX EXECUTE P5('60 mins', '2000-01-01 UTC');
+                                              QUERY PLAN                                               
+-------------------------------------------------------------------------------------------------------
+ Custom Scan (ChunkAppend) on metrics_timestamptz
+   Order: metrics_timestamptz."time"
+   Chunks excluded during startup: 0
+   ->  Index Scan Backward using _hyper_6_160_chunk_metrics_timestamptz_time_idx on _hyper_6_160_chunk
+         Filter: (time_bucket($1, "time") > ($2)::timestamp with time zone)
+   ->  Index Scan Backward using _hyper_6_161_chunk_metrics_timestamptz_time_idx on _hyper_6_161_chunk
+         Filter: (time_bucket($1, "time") > ($2)::timestamp with time zone)
+   ->  Index Scan Backward using _hyper_6_162_chunk_metrics_timestamptz_time_idx on _hyper_6_162_chunk
+         Filter: (time_bucket($1, "time") > ($2)::timestamp with time zone)
+   ->  Index Scan Backward using _hyper_6_163_chunk_metrics_timestamptz_time_idx on _hyper_6_163_chunk
+         Filter: (time_bucket($1, "time") > ($2)::timestamp with time zone)
+   ->  Index Scan Backward using _hyper_6_164_chunk_metrics_timestamptz_time_idx on _hyper_6_164_chunk
+         Filter: (time_bucket($1, "time") > ($2)::timestamp with time zone)
+(13 rows)
+
+:PREFIX EXECUTE P6('60 mins', '2000-01-01 UTC');
+                                                QUERY PLAN                                                
+----------------------------------------------------------------------------------------------------------
+ Custom Scan (ChunkAppend) on metrics_timestamp
+   Order: metrics_timestamp."time"
+   Chunks excluded during startup: 0
+   ->  Index Only Scan Backward using _hyper_5_155_chunk_metrics_timestamp_time_idx on _hyper_5_155_chunk
+         Filter: (time_bucket($1, "time") > ($2)::timestamp with time zone)
+   ->  Index Only Scan Backward using _hyper_5_156_chunk_metrics_timestamp_time_idx on _hyper_5_156_chunk
+         Filter: (time_bucket($1, "time") > ($2)::timestamp with time zone)
+   ->  Index Only Scan Backward using _hyper_5_157_chunk_metrics_timestamp_time_idx on _hyper_5_157_chunk
+         Filter: (time_bucket($1, "time") > ($2)::timestamp with time zone)
+   ->  Index Only Scan Backward using _hyper_5_158_chunk_metrics_timestamp_time_idx on _hyper_5_158_chunk
+         Filter: (time_bucket($1, "time") > ($2)::timestamp with time zone)
+   ->  Index Only Scan Backward using _hyper_5_159_chunk_metrics_timestamp_time_idx on _hyper_5_159_chunk
+         Filter: (time_bucket($1, "time") > ($2)::timestamp with time zone)
+(13 rows)
+
+:PREFIX EXECUTE P7('60 mins', '2000-01-01 UTC');
+                                              QUERY PLAN                                               
+-------------------------------------------------------------------------------------------------------
+ Custom Scan (ChunkAppend) on metrics_timestamptz
+   Order: metrics_timestamptz."time"
+   Chunks excluded during startup: 0
+   ->  Index Scan Backward using _hyper_6_160_chunk_metrics_timestamptz_time_idx on _hyper_6_160_chunk
+         Filter: (time_bucket($1, "time") > ($2)::timestamp without time zone)
+   ->  Index Scan Backward using _hyper_6_161_chunk_metrics_timestamptz_time_idx on _hyper_6_161_chunk
+         Filter: (time_bucket($1, "time") > ($2)::timestamp without time zone)
+   ->  Index Scan Backward using _hyper_6_162_chunk_metrics_timestamptz_time_idx on _hyper_6_162_chunk
+         Filter: (time_bucket($1, "time") > ($2)::timestamp without time zone)
+   ->  Index Scan Backward using _hyper_6_163_chunk_metrics_timestamptz_time_idx on _hyper_6_163_chunk
+         Filter: (time_bucket($1, "time") > ($2)::timestamp without time zone)
+   ->  Index Scan Backward using _hyper_6_164_chunk_metrics_timestamptz_time_idx on _hyper_6_164_chunk
+         Filter: (time_bucket($1, "time") > ($2)::timestamp without time zone)
+(13 rows)
+
+:PREFIX EXECUTE P8('60 mins', '2000-01-01 UTC');
+                                                QUERY PLAN                                                
+----------------------------------------------------------------------------------------------------------
+ Custom Scan (ChunkAppend) on metrics_timestamp
+   Order: metrics_timestamp."time"
+   Chunks excluded during startup: 0
+   ->  Index Only Scan Backward using _hyper_5_155_chunk_metrics_timestamp_time_idx on _hyper_5_155_chunk
+         Filter: (time_bucket($1, "time") > ($2)::timestamp without time zone)
+   ->  Index Only Scan Backward using _hyper_5_156_chunk_metrics_timestamp_time_idx on _hyper_5_156_chunk
+         Filter: (time_bucket($1, "time") > ($2)::timestamp without time zone)
+   ->  Index Only Scan Backward using _hyper_5_157_chunk_metrics_timestamp_time_idx on _hyper_5_157_chunk
+         Filter: (time_bucket($1, "time") > ($2)::timestamp without time zone)
+   ->  Index Only Scan Backward using _hyper_5_158_chunk_metrics_timestamp_time_idx on _hyper_5_158_chunk
+         Filter: (time_bucket($1, "time") > ($2)::timestamp without time zone)
+   ->  Index Only Scan Backward using _hyper_5_159_chunk_metrics_timestamp_time_idx on _hyper_5_159_chunk
+         Filter: (time_bucket($1, "time") > ($2)::timestamp without time zone)
+(13 rows)
+
+RESET plan_cache_mode;
+DEALLOCATE P1;
+DEALLOCATE P2;
+DEALLOCATE P3;
+DEALLOCATE P4;
+DEALLOCATE P5;
+DEALLOCATE P6;
+DEALLOCATE P7;
+DEALLOCATE P8;
 :PREFIX SELECT * FROM hyper WHERE time_bucket(10, time) > 10 AND time_bucket(10, time) < 100 ORDER BY time;
                                                                           QUERY PLAN                                                                           
 ---------------------------------------------------------------------------------------------------------------------------------------------------------------

--- a/tsl/test/shared/expected/constraint_exclusion_prepared.out
+++ b/tsl/test/shared/expected/constraint_exclusion_prepared.out
@@ -554,38 +554,24 @@ PREPARE prep(timestamptz) AS SELECT device_id, time FROM :TEST_TABLE WHERE time 
 :PREFIX EXECUTE prep('2000-01-01 23:42');
 QUERY PLAN
  Custom Scan (ChunkAppend) on metrics (actual rows=5 loops=1)
-   Chunks excluded during runtime: 2
+   Chunks excluded during startup: 2
    ->  Index Scan using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk (actual rows=5 loops=1)
          Index Cond: ("time" = $1)
-   ->  Index Scan using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk (never executed)
-         Index Cond: ("time" = $1)
-   ->  Index Scan using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk (never executed)
-         Index Cond: ("time" = $1)
-(8 rows)
+(4 rows)
 
 :PREFIX EXECUTE prep('2000-01-10 23:42');
 QUERY PLAN
  Custom Scan (ChunkAppend) on metrics (actual rows=5 loops=1)
-   Chunks excluded during runtime: 2
-   ->  Index Scan using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk (never executed)
-         Index Cond: ("time" = $1)
+   Chunks excluded during startup: 2
    ->  Index Scan using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk (actual rows=5 loops=1)
          Index Cond: ("time" = $1)
-   ->  Index Scan using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk (never executed)
-         Index Cond: ("time" = $1)
-(8 rows)
+(4 rows)
 
 :PREFIX EXECUTE prep(now());
 QUERY PLAN
  Custom Scan (ChunkAppend) on metrics (actual rows=0 loops=1)
-   Chunks excluded during runtime: 3
-   ->  Index Scan using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk (never executed)
-         Index Cond: ("time" = $1)
-   ->  Index Scan using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk (never executed)
-         Index Cond: ("time" = $1)
-   ->  Index Scan using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk (never executed)
-         Index Cond: ("time" = $1)
-(8 rows)
+   Chunks excluded during startup: 3
+(2 rows)
 
 DEALLOCATE prep;
 RESET plan_cache_mode;
@@ -1390,74 +1376,32 @@ PREPARE prep(timestamptz) AS SELECT device_id, time FROM :TEST_TABLE WHERE time 
 :PREFIX EXECUTE prep('2000-01-01 23:42');
 QUERY PLAN
  Custom Scan (ChunkAppend) on metrics_space (actual rows=5 loops=1)
-   Chunks excluded during runtime: 6
+   Chunks excluded during startup: 6
    ->  Index Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
          Index Cond: ("time" = $1)
    ->  Index Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (actual rows=3 loops=1)
          Index Cond: ("time" = $1)
    ->  Index Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
          Index Cond: ("time" = $1)
-   ->  Index Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
-         Index Cond: ("time" = $1)
-   ->  Index Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
-         Index Cond: ("time" = $1)
-   ->  Index Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
-         Index Cond: ("time" = $1)
-   ->  Index Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
-         Index Cond: ("time" = $1)
-   ->  Index Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
-         Index Cond: ("time" = $1)
-   ->  Index Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
-         Index Cond: ("time" = $1)
-(20 rows)
+(8 rows)
 
 :PREFIX EXECUTE prep('2000-01-10 23:42');
 QUERY PLAN
  Custom Scan (ChunkAppend) on metrics_space (actual rows=5 loops=1)
-   Chunks excluded during runtime: 6
-   ->  Index Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
-         Index Cond: ("time" = $1)
-   ->  Index Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
-         Index Cond: ("time" = $1)
-   ->  Index Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
-         Index Cond: ("time" = $1)
+   Chunks excluded during startup: 6
    ->  Index Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
          Index Cond: ("time" = $1)
    ->  Index Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (actual rows=3 loops=1)
          Index Cond: ("time" = $1)
    ->  Index Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (actual rows=1 loops=1)
          Index Cond: ("time" = $1)
-   ->  Index Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
-         Index Cond: ("time" = $1)
-   ->  Index Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
-         Index Cond: ("time" = $1)
-   ->  Index Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
-         Index Cond: ("time" = $1)
-(20 rows)
+(8 rows)
 
 :PREFIX EXECUTE prep(now());
 QUERY PLAN
  Custom Scan (ChunkAppend) on metrics_space (actual rows=0 loops=1)
-   Chunks excluded during runtime: 9
-   ->  Index Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
-         Index Cond: ("time" = $1)
-   ->  Index Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
-         Index Cond: ("time" = $1)
-   ->  Index Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
-         Index Cond: ("time" = $1)
-   ->  Index Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
-         Index Cond: ("time" = $1)
-   ->  Index Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
-         Index Cond: ("time" = $1)
-   ->  Index Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
-         Index Cond: ("time" = $1)
-   ->  Index Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
-         Index Cond: ("time" = $1)
-   ->  Index Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
-         Index Cond: ("time" = $1)
-   ->  Index Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk (never executed)
-         Index Cond: ("time" = $1)
-(20 rows)
+   Chunks excluded during startup: 9
+(2 rows)
 
 DEALLOCATE prep;
 RESET plan_cache_mode;
@@ -2122,60 +2066,32 @@ PREPARE prep(timestamptz) AS SELECT device_id, time FROM :TEST_TABLE WHERE time 
 :PREFIX EXECUTE prep('2000-01-01 23:42');
 QUERY PLAN
  Custom Scan (ChunkAppend) on metrics_compressed (actual rows=5 loops=1)
-   Chunks excluded during runtime: 2
+   Chunks excluded during startup: 2
    ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=5 loops=1)
          Vectorized Filter: ("time" = $1)
          Rows Removed by Filter: 4995
          ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=5 loops=1)
                Filter: ((_ts_meta_min_1 <= $1) AND (_ts_meta_max_1 >= $1))
                Rows Removed by Filter: 15
-   ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (never executed)
-         Vectorized Filter: ("time" = $1)
-         ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
-               Filter: ((_ts_meta_min_1 <= $1) AND (_ts_meta_max_1 >= $1))
-   ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (never executed)
-         Vectorized Filter: ("time" = $1)
-         ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
-               Filter: ((_ts_meta_min_1 <= $1) AND (_ts_meta_max_1 >= $1))
-(16 rows)
+(8 rows)
 
 :PREFIX EXECUTE prep('2000-01-10 23:42');
 QUERY PLAN
  Custom Scan (ChunkAppend) on metrics_compressed (actual rows=5 loops=1)
-   Chunks excluded during runtime: 2
-   ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (never executed)
-         Vectorized Filter: ("time" = $1)
-         ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
-               Filter: ((_ts_meta_min_1 <= $1) AND (_ts_meta_max_1 >= $1))
+   Chunks excluded during startup: 2
    ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=5 loops=1)
          Vectorized Filter: ("time" = $1)
          Rows Removed by Filter: 4995
          ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=5 loops=1)
                Filter: ((_ts_meta_min_1 <= $1) AND (_ts_meta_max_1 >= $1))
                Rows Removed by Filter: 25
-   ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (never executed)
-         Vectorized Filter: ("time" = $1)
-         ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
-               Filter: ((_ts_meta_min_1 <= $1) AND (_ts_meta_max_1 >= $1))
-(16 rows)
+(8 rows)
 
 :PREFIX EXECUTE prep(now());
 QUERY PLAN
  Custom Scan (ChunkAppend) on metrics_compressed (actual rows=0 loops=1)
-   Chunks excluded during runtime: 3
-   ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (never executed)
-         Vectorized Filter: ("time" = $1)
-         ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
-               Filter: ((_ts_meta_min_1 <= $1) AND (_ts_meta_max_1 >= $1))
-   ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (never executed)
-         Vectorized Filter: ("time" = $1)
-         ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
-               Filter: ((_ts_meta_min_1 <= $1) AND (_ts_meta_max_1 >= $1))
-   ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (never executed)
-         Vectorized Filter: ("time" = $1)
-         ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
-               Filter: ((_ts_meta_min_1 <= $1) AND (_ts_meta_max_1 >= $1))
-(14 rows)
+   Chunks excluded during startup: 3
+(2 rows)
 
 DEALLOCATE prep;
 RESET plan_cache_mode;
@@ -3355,7 +3271,7 @@ PREPARE prep(timestamptz) AS SELECT device_id, time FROM :TEST_TABLE WHERE time 
 :PREFIX EXECUTE prep('2000-01-01 23:42');
 QUERY PLAN
  Custom Scan (ChunkAppend) on metrics_space_compressed (actual rows=5 loops=1)
-   Chunks excluded during runtime: 6
+   Chunks excluded during startup: 6
    ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=1 loops=1)
          Vectorized Filter: ("time" = $1)
          Rows Removed by Filter: 999
@@ -3374,48 +3290,12 @@ QUERY PLAN
          ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=1 loops=1)
                Filter: ((_ts_meta_min_1 <= $1) AND (_ts_meta_max_1 >= $1))
                Rows Removed by Filter: 3
-   ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (never executed)
-         Vectorized Filter: ("time" = $1)
-         ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
-               Filter: ((_ts_meta_min_1 <= $1) AND (_ts_meta_max_1 >= $1))
-   ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (never executed)
-         Vectorized Filter: ("time" = $1)
-         ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
-               Filter: ((_ts_meta_min_1 <= $1) AND (_ts_meta_max_1 >= $1))
-   ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (never executed)
-         Vectorized Filter: ("time" = $1)
-         ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
-               Filter: ((_ts_meta_min_1 <= $1) AND (_ts_meta_max_1 >= $1))
-   ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (never executed)
-         Vectorized Filter: ("time" = $1)
-         ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
-               Filter: ((_ts_meta_min_1 <= $1) AND (_ts_meta_max_1 >= $1))
-   ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (never executed)
-         Vectorized Filter: ("time" = $1)
-         ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
-               Filter: ((_ts_meta_min_1 <= $1) AND (_ts_meta_max_1 >= $1))
-   ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (never executed)
-         Vectorized Filter: ("time" = $1)
-         ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
-               Filter: ((_ts_meta_min_1 <= $1) AND (_ts_meta_max_1 >= $1))
-(44 rows)
+(20 rows)
 
 :PREFIX EXECUTE prep('2000-01-10 23:42');
 QUERY PLAN
  Custom Scan (ChunkAppend) on metrics_space_compressed (actual rows=5 loops=1)
-   Chunks excluded during runtime: 6
-   ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (never executed)
-         Vectorized Filter: ("time" = $1)
-         ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
-               Filter: ((_ts_meta_min_1 <= $1) AND (_ts_meta_max_1 >= $1))
-   ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (never executed)
-         Vectorized Filter: ("time" = $1)
-         ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
-               Filter: ((_ts_meta_min_1 <= $1) AND (_ts_meta_max_1 >= $1))
-   ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (never executed)
-         Vectorized Filter: ("time" = $1)
-         ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
-               Filter: ((_ts_meta_min_1 <= $1) AND (_ts_meta_max_1 >= $1))
+   Chunks excluded during startup: 6
    ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=1 loops=1)
          Vectorized Filter: ("time" = $1)
          Rows Removed by Filter: 999
@@ -3434,61 +3314,13 @@ QUERY PLAN
          ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=1 loops=1)
                Filter: ((_ts_meta_min_1 <= $1) AND (_ts_meta_max_1 >= $1))
                Rows Removed by Filter: 5
-   ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (never executed)
-         Vectorized Filter: ("time" = $1)
-         ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
-               Filter: ((_ts_meta_min_1 <= $1) AND (_ts_meta_max_1 >= $1))
-   ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (never executed)
-         Vectorized Filter: ("time" = $1)
-         ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
-               Filter: ((_ts_meta_min_1 <= $1) AND (_ts_meta_max_1 >= $1))
-   ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (never executed)
-         Vectorized Filter: ("time" = $1)
-         ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
-               Filter: ((_ts_meta_min_1 <= $1) AND (_ts_meta_max_1 >= $1))
-(44 rows)
+(20 rows)
 
 :PREFIX EXECUTE prep(now());
 QUERY PLAN
  Custom Scan (ChunkAppend) on metrics_space_compressed (actual rows=0 loops=1)
-   Chunks excluded during runtime: 9
-   ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (never executed)
-         Vectorized Filter: ("time" = $1)
-         ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
-               Filter: ((_ts_meta_min_1 <= $1) AND (_ts_meta_max_1 >= $1))
-   ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (never executed)
-         Vectorized Filter: ("time" = $1)
-         ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
-               Filter: ((_ts_meta_min_1 <= $1) AND (_ts_meta_max_1 >= $1))
-   ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (never executed)
-         Vectorized Filter: ("time" = $1)
-         ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
-               Filter: ((_ts_meta_min_1 <= $1) AND (_ts_meta_max_1 >= $1))
-   ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (never executed)
-         Vectorized Filter: ("time" = $1)
-         ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
-               Filter: ((_ts_meta_min_1 <= $1) AND (_ts_meta_max_1 >= $1))
-   ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (never executed)
-         Vectorized Filter: ("time" = $1)
-         ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
-               Filter: ((_ts_meta_min_1 <= $1) AND (_ts_meta_max_1 >= $1))
-   ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (never executed)
-         Vectorized Filter: ("time" = $1)
-         ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
-               Filter: ((_ts_meta_min_1 <= $1) AND (_ts_meta_max_1 >= $1))
-   ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (never executed)
-         Vectorized Filter: ("time" = $1)
-         ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
-               Filter: ((_ts_meta_min_1 <= $1) AND (_ts_meta_max_1 >= $1))
-   ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (never executed)
-         Vectorized Filter: ("time" = $1)
-         ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
-               Filter: ((_ts_meta_min_1 <= $1) AND (_ts_meta_max_1 >= $1))
-   ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (never executed)
-         Vectorized Filter: ("time" = $1)
-         ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
-               Filter: ((_ts_meta_min_1 <= $1) AND (_ts_meta_max_1 >= $1))
-(38 rows)
+   Chunks excluded during startup: 9
+(2 rows)
 
 DEALLOCATE prep;
 RESET plan_cache_mode;


### PR DESCRIPTION
When time_bucket is compared to constant in WHERE, we also add condition on the underlying time variable (ts_transform_time_bucket_comparison). Unfortunately we only do this for plan-time constants, which prevents chunk exclusion when the interval is given by a query parameter, and a generic plan is used. This commit also tries to apply this optimization after applying the execution-time constants.

This PR also enables startup exclusion based on parameterized filters.

Fixes https://github.com/timescale/timescaledb/issues/6498

Disable-check: force-changelog-file
Disable-check: commit-count