### PR TITLE
Make extension state available through function

### DIFF
--- a/.unreleased/fix_6509
+++ b/.unreleased/fix_6509
@@ -1,0 +1,1 @@
+Fixes: #6509 Make extension state available through function

--- a/cmake/ScriptFiles.cmake
+++ b/cmake/ScriptFiles.cmake
@@ -58,6 +58,10 @@ set(SOURCE_FILES
     osm_api.sql)
 
 if(ENABLE_DEBUG_UTILS AND CMAKE_BUILD_TYPE MATCHES Debug)
+  list(APPEND SOURCE_FILES debug_build_utils.sql)
+endif()
+
+if(ENABLE_DEBUG_UTILS)
   list(APPEND SOURCE_FILES debug_utils.sql)
 endif()
 

--- a/sql/debug_build_utils.sql
+++ b/sql/debug_build_utils.sql
@@ -1,0 +1,15 @@
+-- This file and its contents are licensed under the Apache License 2.0.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-APACHE for a copy of the license.
+
+-- This file contains utility functions that are only used in debug
+-- builds for debugging and testing.
+
+CREATE OR REPLACE FUNCTION debug_waitpoint_enable(TEXT) RETURNS VOID LANGUAGE C VOLATILE STRICT
+AS '@MODULE_PATHNAME@', 'ts_debug_point_enable';
+
+CREATE OR REPLACE FUNCTION debug_waitpoint_release(TEXT) RETURNS VOID LANGUAGE C VOLATILE STRICT
+AS '@MODULE_PATHNAME@', 'ts_debug_point_release';
+
+CREATE OR REPLACE FUNCTION debug_waitpoint_id(TEXT) RETURNS BIGINT LANGUAGE C VOLATILE STRICT
+AS '@MODULE_PATHNAME@', 'ts_debug_point_id';

--- a/sql/debug_utils.sql
+++ b/sql/debug_utils.sql
@@ -2,14 +2,9 @@
 -- Please see the included NOTICE for copyright information and
 -- LICENSE-APACHE for a copy of the license.
 
--- This file contains utility functions that are only used in debug
--- builds for debugging and testing.
+-- This file contains utility functions and views that are used for
+-- debugging in release builds. These are all placed in the schema
+-- _timescaledb_debug.
 
-CREATE OR REPLACE FUNCTION debug_waitpoint_enable(TEXT) RETURNS VOID LANGUAGE C VOLATILE STRICT
-AS '@MODULE_PATHNAME@', 'ts_debug_point_enable';
-
-CREATE OR REPLACE FUNCTION debug_waitpoint_release(TEXT) RETURNS VOID LANGUAGE C VOLATILE STRICT
-AS '@MODULE_PATHNAME@', 'ts_debug_point_release';
-
-CREATE OR REPLACE FUNCTION debug_waitpoint_id(TEXT) RETURNS BIGINT LANGUAGE C VOLATILE STRICT
-AS '@MODULE_PATHNAME@', 'ts_debug_point_id';
+CREATE OR REPLACE FUNCTION _timescaledb_debug.extension_state() RETURNS TEXT
+AS '@MODULE_PATHNAME@', 'ts_extension_get_state' LANGUAGE C;

--- a/sql/pre_install/schemas.sql
+++ b/sql/pre_install/schemas.sql
@@ -11,6 +11,15 @@ CREATE SCHEMA _timescaledb_cache;
 CREATE SCHEMA _timescaledb_config;
 CREATE SCHEMA timescaledb_experimental;
 CREATE SCHEMA timescaledb_information;
+CREATE SCHEMA _timescaledb_debug;
 
-GRANT USAGE ON SCHEMA _timescaledb_cache, _timescaledb_catalog, _timescaledb_functions, _timescaledb_internal, _timescaledb_config, timescaledb_information, timescaledb_experimental TO PUBLIC;
+GRANT USAGE ON SCHEMA
+      _timescaledb_cache,
+      _timescaledb_catalog,
+      _timescaledb_functions,
+      _timescaledb_internal,
+      _timescaledb_config,
+      timescaledb_information,
+      timescaledb_experimental
+TO PUBLIC;
 

--- a/sql/updates/latest-dev.sql
+++ b/sql/updates/latest-dev.sql
@@ -316,3 +316,5 @@ ALTER TABLE _timescaledb_catalog.dimension
     ADD CONSTRAINT dimension_hypertable_id_fkey FOREIGN KEY (hypertable_id) REFERENCES _timescaledb_catalog.hypertable(id) ON DELETE CASCADE;
 ALTER TABLE _timescaledb_catalog.tablespace
     ADD CONSTRAINT tablespace_hypertable_id_fkey FOREIGN KEY (hypertable_id) REFERENCES _timescaledb_catalog.hypertable(id) ON DELETE CASCADE;
+
+CREATE SCHEMA _timescaledb_debug;

--- a/sql/updates/reverse-dev.sql
+++ b/sql/updates/reverse-dev.sql
@@ -623,3 +623,5 @@ ALTER TABLE _timescaledb_catalog.hypertable_data_node
 ALTER TABLE _timescaledb_catalog.tablespace
     ADD CONSTRAINT tablespace_hypertable_id_fkey FOREIGN KEY (hypertable_id) REFERENCES _timescaledb_catalog.hypertable(id) ON DELETE CASCADE;
 
+DROP FUNCTION IF EXISTS _timescaledb_debug.extension_state;
+DROP SCHEMA IF EXISTS _timescaledb_debug;

--- a/src/extension.c
+++ b/src/extension.c
@@ -349,7 +349,6 @@ ts_extension_is_proxy_table_relid(Oid relid)
 	return relid == extension_proxy_oid;
 }
 
-#ifdef TS_DEBUG
 TS_FUNCTION_INFO_V1(ts_extension_get_state);
 
 Datum
@@ -357,4 +356,3 @@ ts_extension_get_state(PG_FUNCTION_ARGS)
 {
 	PG_RETURN_TEXT_P(cstring_to_text(extstate_str[extstate]));
 }
-#endif

--- a/test/expected/debug_utils.out
+++ b/test/expected/debug_utils.out
@@ -1,0 +1,15 @@
+-- This file and its contents are licensed under the Apache License 2.0.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-APACHE for a copy of the license.
+\c :TEST_DBNAME :ROLE_SUPERUSER
+SELECT _timescaledb_debug.extension_state();
+ extension_state 
+-----------------
+ created
+(1 row)
+
+SET ROLE :ROLE_DEFAULT_PERM_USER;
+\set ON_ERROR_STOP 0
+SELECT _timescaledb_debug.extension_state();
+ERROR:  permission denied for schema _timescaledb_debug at character 8
+\set ON_ERROR_STOP 1

--- a/test/sql/CMakeLists.txt
+++ b/test/sql/CMakeLists.txt
@@ -16,6 +16,7 @@ set(TEST_FILES
     copy.sql
     copy_where.sql
     ddl_errors.sql
+    debug_utils.sql
     drop_extension.sql
     drop_hypertable.sql
     drop_owned.sql

--- a/test/sql/debug_utils.sql
+++ b/test/sql/debug_utils.sql
@@ -1,0 +1,12 @@
+-- This file and its contents are licensed under the Apache License 2.0.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-APACHE for a copy of the license.
+
+\c :TEST_DBNAME :ROLE_SUPERUSER
+SELECT _timescaledb_debug.extension_state();
+
+SET ROLE :ROLE_DEFAULT_PERM_USER;
+
+\set ON_ERROR_STOP 0
+SELECT _timescaledb_debug.extension_state();
+\set ON_ERROR_STOP 1

--- a/tsl/test/shared/expected/extension.out
+++ b/tsl/test/shared/expected/extension.out
@@ -19,6 +19,7 @@ FROM pg_proc p
     e.oid = d.refobjid
 WHERE proname <> 'get_telemetry_report'
 ORDER BY pronamespace::regnamespace::text COLLATE "C", p.oid::regprocedure::text COLLATE "C";
+ _timescaledb_debug.extension_state()
  _timescaledb_functions.alter_job_set_hypertable_id(integer,regclass)
  _timescaledb_functions.attach_osm_table_chunk(regclass,regclass)
  _timescaledb_functions.bookend_deserializefunc(bytea,internal)


### PR DESCRIPTION
The extension state is not easily accessible in release builds, which makes debugging issue with the loader very difficult. This commit introduces a new schema `timescaledb_debug` and makes the function `ts_extension_get_state` available also in release builds as `timescaledb_debug.extension_state`.

See #1682