### PR TITLE
Check the spelling in our code

### DIFF
--- a/.github/gh_matrix_builder.py
+++ b/.github/gh_matrix_builder.py
@@ -337,9 +337,9 @@ elif len(sys.argv) > 2:
             tests = set()
             break
         basename = os.path.basename(f)
-        splitted = basename.split(".")
-        name = splitted[0]
-        ext = splitted[-1]
+        split = basename.split(".")
+        name = split[0]
+        ext = split[-1]
         if ext == "out":
             # Account for the version number.
             tests.add(name)

--- a/.github/workflows/changelog-check.yaml
+++ b/.github/workflows/changelog-check.yaml
@@ -5,7 +5,7 @@ name: Check for changelog entry file
     branches:
       - main
 jobs:
-  # Check if the PR creates a sperate file with changelog entry in the
+  # Check if the PR creates a separate file with changelog entry in the
   # ".unreleased"  folder
   #
   # This check can be disabled by adding the following line in the PR text

--- a/.github/workflows/code_style.yaml
+++ b/.github/workflows/code_style.yaml
@@ -5,6 +5,7 @@ name: Code style
       - main
       - prerelease_test
   pull_request:
+
 jobs:
   cmake_checks:
     name: Check CMake files
@@ -53,6 +54,20 @@ jobs:
         run: |
           find . -type f \( -name "*.yaml" -or -name "*.yml" \) -print -exec yamllint {} \+
 
+  spelling_checks:
+    name: Check spelling
+    runs-on: ubuntu-latest
+    steps:
+      - name: Install prerequisites
+        run: |
+          pip install codespell
+      - name: Checkout source
+        uses: actions/checkout@v3
+      - name: Run codespell
+        run: |
+          find . -type f \( -name "*.c" -or -name "*.h" -or -name "*.yaml" -or -name "*.sh" \) \
+            -exec codespell -L "inh,larg,inout" {} \+
+
   cc_checks:
     name: Check code formatting
     runs-on: ubuntu-22.04
@@ -100,7 +115,7 @@ jobs:
           git diff --exit-code
 
   misc_checks:
-    name: Check license, update scripts, git hooks, missing gitignore entries and unecessary template tests
+    name: Check license, update scripts, git hooks, missing gitignore entries and unnecessary template tests
     runs-on: ubuntu-22.04
     strategy:
       fail-fast: false
@@ -124,7 +139,7 @@ jobs:
     - name: Check for missing gitignore entries for template test files
       if: always()
       run: ./scripts/check_missing_gitignore_for_template_tests.sh
-    - name: Check for unecessary template test files
+    - name: Check for unnecessary template test files
       if: always()
       run: ./scripts/check_unecessary_template_tests.sh
 

--- a/.github/workflows/update-test.yaml
+++ b/.github/workflows/update-test.yaml
@@ -78,7 +78,7 @@ jobs:
         UPDATE_FROM_TAG=${DOWNGRADE_TO}-pg${PG_MAJOR}
         export UPDATE_FROM_TAG
         # We need to use same libssl version used in the latest official TimescaleDB container images.
-        # So we will use the fixed alpine version, this will guarantee that libssl version wont change.
+        # So we will use the fixed alpine version, this will guarantee that libssl version won't change.
         PG_IMAGE_TAG="${PG_VERSION}-alpine3.17" scripts/test_downgrade_from_tag.sh
 
     - name: Downgrade diff

--- a/scripts/check_file_license.sh
+++ b/scripts/check_file_license.sh
@@ -58,7 +58,7 @@ check_file() {
             return 0;
             ;;
         (*)
-            echo "Unkown flag" ${1}
+            echo "Unknown flag" ${1}
             return 1;
     esac
 

--- a/scripts/githooks/commit_msg.py
+++ b/scripts/githooks/commit_msg.py
@@ -131,7 +131,7 @@ class GitCommitMessage:
 
     def check_body_uses_why(self):
         "Rule 7: Use the body to explain what and why vs. how"
-        # Not enforcable
+        # Not enforceable
         return True
 
     rule_funcs = [

--- a/scripts/test_downgrade_from_tag.sh
+++ b/scripts/test_downgrade_from_tag.sh
@@ -142,7 +142,7 @@ wait_for_pg() {
         if docker_exec $1 "pg_isready -U postgres"
         then
             # this makes the test less flaky, although not
-            # ideal. Apperently, pg_isready is not always a good
+            # ideal. Apparently, pg_isready is not always a good
             # indication of whether the DB is actually ready to accept
             # queries
             sleep 1
@@ -187,7 +187,7 @@ docker_pgcmd ${CONTAINER_ORIG} "CHECKPOINT;"
 
 # We need the previous version shared libraries as well, so we copy
 # all shared libraries out from the original container before stopping
-# it. We could limit it to just the preceeding version, but this is
+# it. We could limit it to just the preceding version, but this is
 # more straightforward.
 srcdir=$(docker exec ${CONTAINER_ORIG} /bin/bash -c 'pg_config --pkglibdir')
 FILES=$(docker exec ${CONTAINER_ORIG} /bin/bash -c "ls $srcdir/timescaledb*.so")

--- a/scripts/test_repair_from_tag.sh
+++ b/scripts/test_repair_from_tag.sh
@@ -88,7 +88,7 @@ wait_for_pg() {
 
         if docker_exec $1 "pg_isready -h localhost -U postgres"; then
             # this makes the test less flaky, although not
-            # ideal. Apperently, pg_isready is not always a good
+            # ideal. Apparently, pg_isready is not always a good
             # indication of whether the DB is actually ready to accept
             # queries
             sleep 5

--- a/scripts/test_update_from_tag.sh
+++ b/scripts/test_update_from_tag.sh
@@ -144,7 +144,7 @@ wait_for_pg() {
         if docker_exec $1 "pg_isready -U postgres"
         then
             # this makes the test less flaky, although not
-            # ideal. Apperently, pg_isready is not always a good
+            # ideal. Apparently, pg_isready is not always a good
             # indication of whether the DB is actually ready to accept
             # queries
             sleep 1

--- a/src/cache.c
+++ b/src/cache.c
@@ -50,7 +50,7 @@ ts_cache_init(Cache *cache)
 
 	/*
 	 * We always want to be explicit about the memory context our hash table
-	 * ends up in to ensure it's not accidently put in TopMemoryContext.
+	 * ends up in to ensure it's not accidentally put in TopMemoryContext.
 	 */
 	Assert(cache->flags & HASH_CONTEXT);
 	cache->htab = hash_create(cache->name, cache->numelements, &cache->hctl, cache->flags);

--- a/src/chunk.c
+++ b/src/chunk.c
@@ -509,7 +509,7 @@ chunk_collides(const Hypertable *ht, const Hypercube *hc)
 }
 
 /*-
- * Resolve collisions and perform alignmment.
+ * Resolve collisions and perform alignment.
  *
  * Chunks collide only if their hypercubes overlap in all dimensions. For
  * instance, the 2D chunks below collide because they overlap in both the X and
@@ -2122,7 +2122,7 @@ ts_chunk_show_chunks(PG_FUNCTION_ARGS)
 		funcctx = SRF_FIRSTCALL_INIT();
 		/*
 		 * For INTEGER type dimensions, we support querying using intervals or any
-		 * timetamp or date input. For such INTEGER dimensions, we get the chunks
+		 * timestamp or date input. For such INTEGER dimensions, we get the chunks
 		 * using their creation time values.
 		 */
 		if (IS_INTEGER_TYPE(time_type) && (arg_type == INTERVALOID || IS_TIMESTAMP_TYPE(arg_type)))
@@ -3497,7 +3497,7 @@ ts_chunk_is_frozen(Chunk *chunk)
 }
 
 /* only caller used to be ts_chunk_unset_frozen. This code was in PG14 block as we run into
- * defined but unsed error in CI/CD builds for PG < 14. But now called from recompress as well
+ * a "defined but unset" error in CI/CD builds for PG < 14. But now called from recompress as well
  */
 bool
 ts_chunk_clear_status(Chunk *chunk, int32 status)
@@ -3857,7 +3857,7 @@ ts_chunk_do_drop_chunks(Hypertable *ht, int64 older_than, int64 newer_than, int3
 	{
 		/*
 		 * For INTEGER type dimensions, we support querying using intervals or any
-		 * timetamp or date input. For such INTEGER dimensions, we get the chunks
+		 * timestamp or date input. For such INTEGER dimensions, we get the chunks
 		 * using their creation time values.
 		 */
 		if (IS_INTEGER_TYPE(time_type) && (arg_type == INTERVALOID || IS_TIMESTAMP_TYPE(arg_type)))
@@ -4206,7 +4206,7 @@ ts_chunk_drop_chunks(PG_FUNCTION_ARGS)
 
 	/*
 	 * For INTEGER type dimensions, we support querying using intervals or any
-	 * timetamp or date input. For such INTEGER dimensions, we get the chunks
+	 * timestamp or date input. For such INTEGER dimensions, we get the chunks
 	 * using their creation time values.
 	 */
 	if (IS_INTEGER_TYPE(time_type) && (arg_type == INTERVALOID || IS_TIMESTAMP_TYPE(arg_type)))
@@ -4645,7 +4645,7 @@ add_foreign_table_as_chunk(Oid relid, Hypertable *parent_ht)
 														   chunk->relkind,
 														   chunk->hypertable_relid);
 	chunk_create_table_constraints(parent_ht, chunk);
-	/* Add dimension constriants for the chunk */
+	/* Add dimension constraints for the chunk */
 	ts_chunk_constraints_add_dimension_constraints(chunk->constraints, chunk->fd.id, chunk->cube);
 	ts_chunk_constraints_insert_metadata(chunk->constraints);
 	chunk_add_inheritance(chunk, parent_ht);
@@ -4657,7 +4657,7 @@ add_foreign_table_as_chunk(Oid relid, Hypertable *parent_ht)
 	 * Noncontiguous flag should not be set since the chunk should be empty upon
 	 * creation, with an invalid range assigned, so ordered append should be allowed.
 	 * Once the data is moved into the OSM chunk, then our catalog should be
-	 * udpated with proper API calls from the OSM extension.
+	 * updated with proper API calls from the OSM extension.
 	 */
 	parent_ht->fd.status =
 		ts_set_flags_32(parent_ht->fd.status,

--- a/src/chunk_constraint.c
+++ b/src/chunk_constraint.c
@@ -913,7 +913,7 @@ chunk_constraint_delete_metadata(TupleInfo *ti)
 
 		/*
 		 * If this is an index constraint, we need to cleanup the index
-		 * metadata. Don't drop the index though, since that will happend when
+		 * metadata. Don't drop the index though, since that will happen when
 		 * the constraint is dropped.
 		 */
 		if (OidIsValid(index_relid))

--- a/src/compat/compat.h
+++ b/src/compat/compat.h
@@ -535,7 +535,7 @@ get_reindex_options(ReindexStmt *stmt)
 /*
  * PG15 added additional `force_flush` argument to shm_mq_send().
  *
- * Our _compat() version currently uses force_flush = true on PG15 to preseve
+ * Our _compat() version currently uses force_flush = true on PG15 to preserve
  * the same behaviour on all supported PostgreSQL versions.
  *
  * https://git.postgresql.org/gitweb/?p=postgresql.git;a=commit;h=46846433

--- a/src/constraint.h
+++ b/src/constraint.h
@@ -11,7 +11,7 @@
 #include "export.h"
 
 /*
- * Return status for constraint processsing function.
+ * Return status for constraint processing function.
  *
  * PROCESSED - count the constraint as processed
  * IGNORED - the constraint wasn't processed

--- a/src/hypertable.c
+++ b/src/hypertable.c
@@ -1497,7 +1497,7 @@ ts_hypertable_create_internal(FunctionCallInfo fcinfo, Oid table_relid,
 		ts_cache_release(hcache);
 
 		/*
-		 * Validate create_hypertable arguments and use defaults accoring to the
+		 * Validate create_hypertable arguments and use defaults according to the
 		 * hypertable_distributed_default guc.
 		 *
 		 * Validate data nodes and check permissions on them if this is a

--- a/src/nodes/chunk_append/chunk_append.c
+++ b/src/nodes/chunk_append/chunk_append.c
@@ -396,7 +396,7 @@ ts_chunk_append_path_create(PlannerInfo *root, RelOptInfo *rel, Hypertable *ht, 
 		Assert(flat == NULL);
 
 		/*
-		 * if we do not have scans as direct childs of this
+		 * if we do not have scans as direct children of this
 		 * node we disable startup and runtime exclusion
 		 * in this node
 		 */

--- a/src/nodes/chunk_dispatch/chunk_insert_state.c
+++ b/src/nodes/chunk_dispatch/chunk_insert_state.c
@@ -367,7 +367,7 @@ setup_on_conflict_state(ChunkInsertState *state, ChunkDispatch *dispatch,
 
 	/*
 	 * If the chunk's tuple descriptor matches exactly the hypertable
-	 * (the common case), we can re-use most of the parent's ON
+	 * (the common case), we can reuse most of the parent's ON
 	 * CONFLICT SET state, skipping a bunch of work.  Otherwise, we
 	 * need to create state specific to this partition.
 	 */

--- a/src/nodes/constraint_aware_append/constraint_aware_append.c
+++ b/src/nodes/constraint_aware_append/constraint_aware_append.c
@@ -198,7 +198,7 @@ ca_append_begin(CustomScanState *node, EState *estate, int eflags)
 
 	/*
 	 * clauses should always have the same length as appendplans because
-	 * thats the base for building the lists
+	 * that's the base for building the lists
 	 */
 	Assert(list_length(old_appendplans) == list_length(chunk_ri_clauses));
 	Assert(list_length(chunk_relids) == list_length(chunk_ri_clauses));

--- a/src/partitioning.c
+++ b/src/partitioning.c
@@ -258,7 +258,7 @@ ts_partitioning_func_apply(PartitioningInfo *pinfo, Oid collation, Datum value)
  * Helper function to find the right partition value from a tuple,
  * for space partitioned hypertables. Since attributes in tuple can
  * be of different order when compared to physical table columns order,
- * we pass partition_col_idx which points to correct space parititioned
+ * we pass partition_col_idx which points to correct space partitioned
  * column in the given tuple.
  */
 TSDLLEXPORT Datum

--- a/src/planner/expand_hypertable.c
+++ b/src/planner/expand_hypertable.c
@@ -1319,7 +1319,7 @@ ts_plan_expand_hypertable_chunks(Hypertable *ht, PlannerInfo *root, RelOptInfo *
 #if PG16_LT
 		childrte->requiredPerms = 0;
 #else
-		/* Since PG16, the permission info is maintained separetely. Unlink
+		/* Since PG16, the permission info is maintained separately. Unlink
 		 * the old perminfo from the RTE to disable permission checking.
 		 */
 		childrte->perminfoindex = 0;

--- a/src/planner/planner.c
+++ b/src/planner/planner.c
@@ -846,7 +846,7 @@ should_chunk_append(Hypertable *ht, PlannerInfo *root, RelOptInfo *rel, Path *pa
 				 * Even though ordered is true on the RelOptInfo we have to
 				 * double check that current Path fulfills requirements for
 				 * Ordered Append transformation because the RelOptInfo may
-				 * be used for multiple Pathes.
+				 * be used for multiple Paths.
 				 */
 				Expr *em_expr = find_em_expr_for_rel(pk->pk_eclass, rel);
 

--- a/src/process_utility.c
+++ b/src/process_utility.c
@@ -2447,7 +2447,7 @@ process_index_chunk_multitransaction(int32 hypertable_id, Oid chunk_relid, void 
 	 * We grab a ShareLock on the chunk, because that's what CREATE INDEX
 	 * does. For the hypertable's index, we are ok using the weaker
 	 * AccessShareLock, since we only need to prevent the index itself from
-	 * being ALTERed or DROPed during this part of index creation.
+	 * being ALTERed or DROPped during this part of index creation.
 	 */
 	chunk_rel = table_open(chunk_relid, ShareLock);
 	chunk = ts_chunk_get_by_relid(chunk_relid, true);
@@ -2573,7 +2573,7 @@ process_index_start(ProcessUtilityArgs *args)
 				ts_cache_release(hcache);
 				ereport(ERROR,
 						(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
-						 errmsg("operation not supported on continuous aggreates that are not "
+						 errmsg("operation not supported on continuous aggregates that are not "
 								"finalized"),
 						 errhint("Recreate the continuous aggregate to allow index creation.")));
 			}
@@ -2722,7 +2722,7 @@ process_index_start(ProcessUtilityArgs *args)
 	 * Lock the index for the remainder of the command. Since we're using
 	 * multiple transactions for index creation, a regular
 	 * transaction-level lock won't prevent the index from being
-	 * concurrently ALTERed or DELETEed. Instead, we grab a session level
+	 * concurrently ALTERed or DELETEd. Instead, we grab a session level
 	 * lock on the index, which we'll release when the command is
 	 * finished. (This is the same strategy postgres uses in CREATE INDEX
 	 * CONCURRENTLY)
@@ -4423,7 +4423,7 @@ process_ddl_event_sql_drop(EventTriggerData *trigdata)
 TS_FUNCTION_INFO_V1(ts_timescaledb_process_ddl_event);
 
 /*
- * Event trigger hook for DDL commands that have alread been handled by
+ * Event trigger hook for DDL commands that have already been handled by
  * PostgreSQL (i.e., "ddl_command_end" and "sql_drop" events).
  */
 Datum

--- a/src/telemetry/functions.c
+++ b/src/telemetry/functions.c
@@ -42,7 +42,7 @@ typedef struct AllowedFnHashEntry
 } AllowedFnHashEntry;
 
 // Get a HTAB of AllowedFnHashEntrys containing all and only those functions
-// that are withing visible_extensions. This function should be equivalent to
+// that are within visible_extensions. This function should be equivalent to
 // the SQL
 //     SELECT objid
 //     FROM pg_catalog.pg_depend, pg_catalog.pg_extension extension
@@ -222,7 +222,7 @@ ts_function_telemetry_read(const char **visible_extensions, int num_visible_exte
  * This function resets the shared function counts after we send back telemetry
  * in preparation for the next recording cycle. Note that there is no way to
  * atomically read and reset the counts in the shared hashmap, so writes that
- * occur between sending the old counts and reseting for the next cycle will be
+ * occur between sending the old counts and resetting for the next cycle will be
  * lost. Since this this telemetry is only ever an approximation of reality, we
  * believe this loss is acceptable considering that the alternatives are
  * resetting the counts whenever the telemetry is read (potentially even more

--- a/src/ts_catalog/continuous_aggs_watermark.c
+++ b/src/ts_catalog/continuous_aggs_watermark.c
@@ -250,7 +250,7 @@ TS_FUNCTION_INFO_V1(ts_continuous_agg_watermark_materialized);
  *
  * The difference between this function and `ts_continuous_agg_watermark` is
  * that this one get the max open dimension of the materialization hypertable
- * insted of get the stored value in the catalog table.
+ * instead of get the stored value in the catalog table.
  */
 Datum
 ts_continuous_agg_watermark_materialized(PG_FUNCTION_ARGS)

--- a/test/runner.sh
+++ b/test/runner.sh
@@ -59,7 +59,7 @@ EOF
 trap cleanup EXIT
 
 # setup clusterwide settings on first run
-# we use mkdir here because it is an atomic operation unlike existance of a lockfile
+# we use mkdir here because it is an atomic operation unlike existence of a lockfile
 # where creating and checking are 2 separate operations
 if mkdir ${TEST_OUTPUT_DIR}/.pg_init 2>/dev/null; then
   ${PSQL} "$@" -U ${USER} -d template1 -v ECHO=none >/dev/null 2>&1 <<EOF

--- a/test/runner_shared.sh
+++ b/test/runner_shared.sh
@@ -36,7 +36,7 @@ TEST_ROLE_DEFAULT_PERM_USER_2=${TEST_ROLE_DEFAULT_PERM_USER_2:-default_perm_user
 shift
 
 # setup clusterwide settings on first run
-# we use mkdir here because it is an atomic operation unlike existance of a lockfile
+# we use mkdir here because it is an atomic operation unlike existence of a lockfile
 # where creating and checking are 2 separate operations
 if mkdir ${TEST_OUTPUT_DIR}/.pg_init 2>/dev/null; then
   ${PSQL} "$@" -U ${USER} -d postgres -v ECHO=none -c "ALTER USER ${TEST_ROLE_SUPERUSER} WITH SUPERUSER;" >/dev/null

--- a/test/src/bgw/log.c
+++ b/test/src/bgw/log.c
@@ -47,7 +47,7 @@ bgw_log_insert_relation(Relation rel, char *msg)
 
 /* Insert a new entry into public.bgw_log
  * This table is used for testing as a way for mock background jobs
- * to insert messges into a log that could then be output into the golden file
+ * to insert messages into a log that could then be output into the golden file
  */
 static void
 bgw_log_insert(char *msg)

--- a/test/src/net/test_http.c
+++ b/test/src/net/test_http.c
@@ -75,7 +75,7 @@ num_test_strings()
 	return sizeof(TEST_LENGTHS) / sizeof(TEST_LENGTHS[0]);
 }
 
-/*  Check we can succesfully parse partial by well-formed HTTP responses */
+/*  Check we can successfully parse partial by well-formed HTTP responses */
 Datum
 ts_test_http_parsing(PG_FUNCTION_ARGS)
 {

--- a/tsl/src/compression/api.c
+++ b/tsl/src/compression/api.c
@@ -403,7 +403,7 @@ check_is_chunk_order_violated_by_merge(CompressChunkCxt *cxt, const Dimension *t
 	const DimensionSlice *mergable_slice =
 		ts_hypercube_get_slice_by_dimension_id(mergable_chunk->cube, time_dim->fd.id);
 	if (!mergable_slice)
-		elog(ERROR, "mergable chunk has no time dimension slice");
+		elog(ERROR, "mergeable chunk has no time dimension slice");
 	const DimensionSlice *compressed_slice =
 		ts_hypercube_get_slice_by_dimension_id(cxt->srcht_chunk->cube, time_dim->fd.id);
 	if (!compressed_slice)
@@ -501,7 +501,7 @@ compress_chunk_impl(Oid hypertable_relid, Oid chunk_relid)
 	 *
 	 * In contrast, when the compressed chunk part is created in the same transaction as the tuples
 	 * are written, the compressed chunk (i.e., the catalog entry) becomes visible to other
-	 * transactions only after the transaction that performs the compression is commited and
+	 * transactions only after the transaction that performs the compression is committed and
 	 * the uncompressed chunk is truncated.
 	 */
 	int insert_options = new_compressed_chunk ? HEAP_INSERT_FROZEN : 0;
@@ -724,7 +724,7 @@ tsl_create_compressed_chunk(PG_FUNCTION_ARGS)
 	LockRelationOid(cxt.compress_ht->main_table_relid, AccessShareLock);
 	LockRelationOid(cxt.srcht_chunk->table_id, ShareLock);
 
-	/* Aquire locks on catalog tables to keep till end of txn */
+	/* Acquire locks on catalog tables to keep till end of txn */
 	LockRelationOid(catalog_get_table_id(ts_catalog_get(), CHUNK), RowExclusiveLock);
 
 	/* Create compressed chunk using existing table */
@@ -1126,7 +1126,7 @@ tsl_recompress_chunk_segmentwise(PG_FUNCTION_ARGS)
 	ts_chunk_clear_status(uncompressed_chunk,
 						  CHUNK_STATUS_COMPRESSED_UNORDERED | CHUNK_STATUS_COMPRESSED_PARTIAL);
 
-	/* lock both chunks, compresssed and uncompressed */
+	/* lock both chunks, compressed and uncompressed */
 	/* TODO: Take RowExclusive locks instead of AccessExclusive */
 	Relation uncompressed_chunk_rel = table_open(uncompressed_chunk->table_id, ExclusiveLock);
 	Relation compressed_chunk_rel = table_open(compressed_chunk->table_id, ExclusiveLock);

--- a/tsl/src/compression/array.c
+++ b/tsl/src/compression/array.c
@@ -56,7 +56,7 @@ pg_attribute_unused() assertions(void)
 	 * we simply align the start of data[] on a MAXALIGN (8-byte) boundary. Individual items in the
 	 * array are then aligned as specified by the array element type. See top of array.h header in
 	 * Postgres source code since it uses the same trick. Thus, we make sure that all fields
-	 * before the alignment sentinal are 8-byte aligned, and also that the two Simple8bRleSerialized
+	 * before the alignment sentinel are 8-byte aligned, and also that the two Simple8bRleSerialized
 	 * elements before the data element are themselves 8-byte aligned as well.
 	 */
 

--- a/tsl/src/compression/compression.c
+++ b/tsl/src/compression/compression.c
@@ -557,7 +557,7 @@ compress_chunk_populate_sort_info_for_column(CompressionSettings *settings, Oid 
 		elog(ERROR, "table \"%s\" does not have column \"%s\"", get_rel_name(table), attname);
 
 	att_tup = (Form_pg_attribute) GETSTRUCT(tp);
-	/* Other valdation checks beyond just existence of a valid comparison operator could be useful
+	/* Other validation checks beyond just existence of a valid comparison operator could be useful
 	 */
 
 	*att_nums = att_tup->attnum;
@@ -1388,7 +1388,7 @@ build_decompressor(Relation in_rel, Relation out_rel)
 	/*
 	 * We need to make sure decompressed_is_nulls is in a defined state. While this
 	 * will get written for normal columns it will not get written for dropped columns
-	 * since dropped columns don't exist in the compressed chunk so we initiallize
+	 * since dropped columns don't exist in the compressed chunk so we initialize
 	 * with true here.
 	 */
 	memset(decompressor.decompressed_is_nulls, true, out_desc->natts);

--- a/tsl/src/compression/compression.h
+++ b/tsl/src/compression/compression.h
@@ -300,7 +300,7 @@ pg_attribute_unused() assert_num_compression_algorithms_sane(void)
 {
 	/* make sure not too many compression algorithms   */
 	StaticAssertStmt(_END_COMPRESSION_ALGORITHMS <= _MAX_NUM_COMPRESSION_ALGORITHMS,
-					 "Too many compression algorthims, make sure a decision on variable-length "
+					 "Too many compression algorithms, make sure a decision on variable-length "
 					 "version field has been made.");
 
 	/* existing indexes that MUST NEVER CHANGE */

--- a/tsl/src/compression/compression_test.c
+++ b/tsl/src/compression/compression_test.c
@@ -38,7 +38,7 @@ get_compression_algorithm(char *name)
 		return COMPRESSION_ALGORITHM_DICTIONARY;
 	}
 
-	ereport(ERROR, (errmsg("unknown comrpession algorithm %s", name)));
+	ereport(ERROR, (errmsg("unknown compression algorithm %s", name)));
 	return _INVALID_COMPRESSION_ALGORITHM;
 }
 

--- a/tsl/src/compression/datum_serialize.c
+++ b/tsl/src/compression/datum_serialize.c
@@ -72,17 +72,17 @@ datum_serializer_value_may_be_toasted(DatumSerializer *serializer)
 }
 
 static inline void
-load_send_fn(DatumSerializer *ser)
+load_send_fn(DatumSerializer *serializer)
 {
-	if (ser->send_info_set)
+	if (serializer->send_info_set)
 		return;
 
-	ser->send_info_set = true;
+	serializer->send_info_set = true;
 
-	if (ser->use_binary_send)
-		fmgr_info(ser->type_send, &ser->send_flinfo);
+	if (serializer->use_binary_send)
+		fmgr_info(serializer->type_send, &serializer->send_flinfo);
 	else
-		fmgr_info(ser->type_out, &ser->send_flinfo);
+		fmgr_info(serializer->type_out, &serializer->send_flinfo);
 }
 
 #define TYPE_IS_PACKABLE(typlen, typstorage) ((typlen) == -1 && (typstorage) != 'p')

--- a/tsl/src/compression/simple8b_rle.h
+++ b/tsl/src/compression/simple8b_rle.h
@@ -260,15 +260,15 @@ bytes_serialize_simple8b_and_advance(char *dest, size_t expected_size,
 static Simple8bRleSerialized *
 bytes_deserialize_simple8b_and_advance(StringInfo si)
 {
-	Simple8bRleSerialized *ser = consumeCompressedData(si, sizeof(Simple8bRleSerialized));
-	consumeCompressedData(si, simple8brle_serialized_slot_size(ser));
+	Simple8bRleSerialized *serialized = consumeCompressedData(si, sizeof(Simple8bRleSerialized));
+	consumeCompressedData(si, simple8brle_serialized_slot_size(serialized));
 
-	CheckCompressedData(ser->num_elements <= GLOBAL_MAX_ROWS_PER_COMPRESSION);
-	CheckCompressedData(ser->num_elements > 0);
-	CheckCompressedData(ser->num_blocks > 0);
-	CheckCompressedData(ser->num_elements >= ser->num_blocks);
+	CheckCompressedData(serialized->num_elements <= GLOBAL_MAX_ROWS_PER_COMPRESSION);
+	CheckCompressedData(serialized->num_elements > 0);
+	CheckCompressedData(serialized->num_blocks > 0);
+	CheckCompressedData(serialized->num_elements >= serialized->num_blocks);
 
-	return ser;
+	return serialized;
 }
 
 static size_t
@@ -390,7 +390,7 @@ simple8brle_compressor_finish(Simple8bRleCompressor *compressor)
 
 	compressed_size = simple8brle_compressor_compressed_size(compressor);
 	/* we use palloc0 despite initializing the entire structure,
-	 * to ensure padding bits are zeroed, and that there's a 0 seletor at the end.
+	 * to ensure padding bits are zeroed, and that there's a 0 selector at the end.
 	 * It would be more efficient to ensure there are no padding bits in the struct,
 	 * and initialize everything ourselves
 	 */
@@ -634,7 +634,7 @@ simple8brle_decompression_iterator_init_reverse(Simple8bRleDecompressionIterator
 
 /* returning a struct produces noticeably better assembly on x86_64 than returning
  * is_done and is_null via pointers; it uses two registers instead of any memory reads.
- * Since it is also easier to read, we perfer it here.
+ * Since it is also easier to read, we prefer it here.
  */
 static Simple8bRleDecompressResult
 simple8brle_decompression_iterator_try_next_forward(Simple8bRleDecompressionIterator *iter)

--- a/tsl/src/compression/simple8b_rle_bitmap.h
+++ b/tsl/src/compression/simple8b_rle_bitmap.h
@@ -161,7 +161,7 @@ simple8brle_bitmap_prefixsums(Simple8bRleSerialized *compressed)
 			current_prefix_sum += __builtin_popcountll(block_data);
 #else
 			/*
-			 * Unfortunatly, we have to have this fallback for Windows.
+			 * Unfortunately, we have to have this fallback for Windows.
 			 */
 			for (uint16 i = 0; i < 64; i++)
 			{

--- a/tsl/src/continuous_aggs/common.c
+++ b/tsl/src/continuous_aggs/common.c
@@ -113,7 +113,7 @@ RemoveRangeTableEntries(Query *query)
  * Extract the final view from the UNION ALL query.
  *
  * q1 is the query on the materialization hypertable with the finalize call
- * q2 is the query on the raw hypertable which was supplied in the inital CREATE VIEW statement
+ * q2 is the query on the raw hypertable which was supplied in the initial CREATE VIEW statement
  * returns q1 from:
  * SELECT * from (  SELECT * from q1 where <coale_qual>
  *                  UNION ALL
@@ -1173,7 +1173,7 @@ makeRangeTblEntry(Query *query, const char *aliasname)
  * Build union query combining the materialized data with data from the raw data hypertable.
  *
  * q1 is the query on the materialization hypertable with the finalize call
- * q2 is the query on the raw hypertable which was supplied in the inital CREATE VIEW statement
+ * q2 is the query on the raw hypertable which was supplied in the initial CREATE VIEW statement
  * returns a query as
  * SELECT * from (  SELECT * from q1 where <coale_qual>
  *                  UNION ALL

--- a/tsl/src/continuous_aggs/create.c
+++ b/tsl/src/continuous_aggs/create.c
@@ -653,7 +653,7 @@ fixup_userview_query_tlist(Query *userquery, List *tlist_aliases)
  *               so don't recreate invalidation trigger.
 
  * Since 1.7, we support real time aggregation.
- * If real time aggregation is off i.e. materialized only, the mcagg vew is as described in Step 2.
+ * If real time aggregation is off i.e. materialized only, the mcagg view is as described in Step 2.
  * If it is turned on
  * we build a union query that selects from the internal mat view and the raw hypertable
  *     (see build_union_query for details)

--- a/tsl/src/continuous_aggs/finalize.c
+++ b/tsl/src/continuous_aggs/finalize.c
@@ -249,7 +249,7 @@ finalizequery_get_select_query(FinalizeQueryInfo *inp, List *matcollist,
 	{
 		TargetEntry *tle = (TargetEntry *) lfirst(lc);
 		/*
-		 * In case when this is a cagg wth joins, the Var from the normal table
+		 * In case when this is a cagg with joins, the Var from the normal table
 		 * already has resorigtbl populated and we need to use that to resolve
 		 * the Var. Hence only modify the tle when resorigtbl is unset
 		 * which means it is Var of the Hypertable

--- a/tsl/src/continuous_aggs/insert.c
+++ b/tsl/src/continuous_aggs/insert.c
@@ -327,7 +327,7 @@ cache_inval_entry_write(ContinuousAggsCacheInvalEntry *entry)
 		return;
 
 	/* The materialization worker uses a READ COMMITTED isolation level by default. Therefore, if we
-	 * use a stronger isolation level, the isolation thereshold could update without us seeing the
+	 * use a stronger isolation level, the isolation threshold could update without us seeing the
 	 * new value. In order to prevent serialization errors, we always append invalidation entries in
 	 * the case when we're using a strong enough isolation level that we won't see the new
 	 * threshold. The same applies for distributed member invalidation triggers of hypertables.

--- a/tsl/src/continuous_aggs/invalidation.c
+++ b/tsl/src/continuous_aggs/invalidation.c
@@ -303,7 +303,7 @@ invalidation_hyper_log_add_entry(int32 hyper_id, int64 start, int64 end)
  * Add an invalidation in the given range. The invalidation is added either to
  * the hypertable invalidation log or the continuous aggregate invalidation
  * log depending on the type of the given hypertable. If the hypertable is a
- * "raw" hypertable (i.e., one that has one or more continous aggregates), the
+ * "raw" hypertable (i.e., one that has one or more continuous aggregates), the
  * entry is added to the hypertable invalidation log and will invalidate all
  * the associated continuous aggregates. If the hypertable is instead an
  * materialized hypertable, the entry is added to the cagg invalidation log

--- a/tsl/src/continuous_aggs/refresh.c
+++ b/tsl/src/continuous_aggs/refresh.c
@@ -481,7 +481,7 @@ continuous_agg_scan_refresh_window_ranges(const InternalTimeRange *refresh_windo
  * Invalid ranges:           [-----] [-]   [--] [-] [---]
  * Merged range:             [---------------------------)
  *
- * The maximum number of individual (non-mergable) ranges are
+ * The maximum number of individual (non-mergeable) ranges are
  * #buckets_in_window/2 (i.e., every other bucket is invalid).
  *
  * Since it might not be efficient to materialize a lot buckets separately

--- a/tsl/src/nodes/decompress_chunk/decompress_chunk.c
+++ b/tsl/src/nodes/decompress_chunk/decompress_chunk.c
@@ -622,7 +622,7 @@ can_batch_sorted_merge(PlannerInfo *root, CompressionInfo *info, Chunk *chunk)
  * The logic is inspired by PostgreSQL's add_paths_with_pathkeys_for_rel() function.
  *
  * Note: This function adds only non-partial paths. In parallel plans PostgreSQL prefers sorting
- * directly under the gather (merge) node and the per-chunk sortings are not used in parallel plans.
+ * directly under the gather (merge) node and the per-chunk sorting are not used in parallel plans.
  * To save planning time, we therefore refrain from adding them.
  */
 static void
@@ -644,7 +644,7 @@ add_chunk_sorted_paths(PlannerInfo *root, RelOptInfo *chunk_rel, Hypertable *ht,
 	DecompressChunkPath *decompress_chunk_path =
 		copy_decompress_chunk_path((DecompressChunkPath *) path);
 
-	/* Iterate over the sort_pathkeys and generate all possible useful sortings */
+	/* Iterate over the sort_pathkeys and generate all possible useful sorting */
 	List *useful_pathkeys = NIL;
 	ListCell *lc;
 	foreach (lc, root->query_pathkeys)
@@ -1794,12 +1794,12 @@ create_compressed_scan_paths(PlannerInfo *root, RelOptInfo *compressed_rel, Comp
 	}
 
 	/*
-	 * We set enable_bitmapscan to false here to ensure any pathes with bitmapscan do not
-	 * displace other pathes. Note that setting the postgres GUC will not actually disable
+	 * We set enable_bitmapscan to false here to ensure any paths with bitmapscan do not
+	 * displace other paths. Note that setting the postgres GUC will not actually disable
 	 * the bitmapscan path creation but will instead create them with very high cost.
 	 * If bitmapscan were the dominant path after postgres planning we could end up
 	 * in a situation where we have no valid plan for this relation because we remove
-	 * bitmapscan pathes from the pathlist.
+	 * bitmapscan paths from the pathlist.
 	 */
 
 	bool old_bitmapscan = enable_bitmapscan;
@@ -2010,7 +2010,7 @@ build_sortinfo(Chunk *chunk, RelOptInfo *chunk_rel, CompressionInfo *info, List 
 		}
 
 		/*
-		 * if pathkeys still has items but we didnt find all segmentby columns
+		 * if pathkeys still has items but we didn't find all segmentby columns
 		 * we cannot push down sort
 		 */
 		if (lc != NULL && bms_num_members(segmentby_columns) != info->num_segmentby_columns)

--- a/tsl/src/nodes/decompress_chunk/exec.c
+++ b/tsl/src/nodes/decompress_chunk/exec.c
@@ -506,7 +506,7 @@ perform_vectorized_sum_int4(DecompressChunkState *chunk_state, Aggref *aggref)
 	Assert(decompressed_scan_slot->tts_tupleDescriptor->natts == 1);
 
 	/* Set all attributes of the result tuple to NULL. So, we return NULL if no data is processed
-	 * by our implementation. In addition, the call marks the slot as beeing used (i.e., no
+	 * by our implementation. In addition, the call marks the slot as being used (i.e., no
 	 * ExecStoreVirtualTuple call is required). */
 	ExecStoreAllNullTuple(decompressed_scan_slot);
 	Assert(!TupIsNull(decompressed_scan_slot));

--- a/tsl/src/nodes/decompress_chunk/planner.c
+++ b/tsl/src/nodes/decompress_chunk/planner.c
@@ -724,7 +724,7 @@ decompress_chunk_plan_create(PlannerInfo *root, RelOptInfo *rel, CustomPath *pat
 				   &chunk_attrs_needed);
 
 	/*
-	 * Determine which compressed colum goes to which output column.
+	 * Determine which compressed column goes to which output column.
 	 */
 	build_decompression_map(root, dcpath, compressed_scan->plan.targetlist, chunk_attrs_needed);
 
@@ -783,7 +783,7 @@ decompress_chunk_plan_create(PlannerInfo *root, RelOptInfo *rel, CustomPath *pat
 				}
 
 				Ensure(IsA(em->em_expr, Var),
-					   "non-Var pathkey not expected for compressed batch sorted mege");
+					   "non-Var pathkey not expected for compressed batch sorted merge");
 
 				/*
 				 * We found a Var equivalence member that belongs to the

--- a/tsl/src/nodes/decompress_chunk/qual_pushdown.c
+++ b/tsl/src/nodes/decompress_chunk/qual_pushdown.c
@@ -160,7 +160,7 @@ expr_has_metadata(QualPushdownContext *context, Expr *expr, int16 *index)
 	if ((Index) var->varno != context->chunk_rel->relid)
 		return false;
 
-	/* ignore system attibutes or whole row references */
+	/* ignore system attributes or whole row references */
 	if (var->varattno <= 0)
 		return false;
 

--- a/tsl/src/nodes/gapfill/gapfill_exec.c
+++ b/tsl/src/nodes/gapfill/gapfill_exec.c
@@ -654,7 +654,7 @@ gapfill_advance_timestamp(GapFillState *state)
 		case TIMESTAMPTZOID:
 			/*
 			 * To be consistent with time_bucket we do UTC bucketing unless
-			 * a different timezone got explicity passed to the function.
+			 * a different timezone got explicitly passed to the function.
 			 */
 			if (state->have_timezone)
 			{

--- a/tsl/src/nodes/gapfill/gapfill_plan.c
+++ b/tsl/src/nodes/gapfill/gapfill_plan.c
@@ -323,7 +323,7 @@ gapfill_build_pathtarget(PathTarget *pt_upper, PathTarget *pt_path, PathTarget *
  * Create a Gapfill Path node.
  *
  * The gap fill node needs rows to be sorted by time ASC
- * so we insert sort pathes if the query order does not match
+ * so we insert sort paths if the query order does not match
  * that
  */
 static Path *

--- a/tsl/src/nodes/skip_scan/planner.c
+++ b/tsl/src/nodes/skip_scan/planner.c
@@ -181,7 +181,7 @@ tsl_skip_scan_paths_add(PlannerInfo *root, RelOptInfo *input_rel, RelOptInfo *ou
 	/*
 	 * look for Unique Path so we dont have repeat some of
 	 * the calculations done by postgres and can also assume
-	 * that the DISTINCT clause is elegible for sort based
+	 * that the DISTINCT clause is eligible for sort based
 	 * DISTINCT
 	 */
 	foreach (lc, output_rel->pathlist)
@@ -205,8 +205,8 @@ tsl_skip_scan_paths_add(PlannerInfo *root, RelOptInfo *input_rel, RelOptInfo *ou
 	}
 
 	/* no UniquePath found so this query might not be
-	 * elegible for sort-based DISTINCT and therefore
-	 * not elegible for SkipScan either */
+	 * eligible for sort-based DISTINCT and therefore
+	 * not eligible for SkipScan either */
 	if (!unique)
 		return;
 

--- a/tsl/test/src/test_compression.c
+++ b/tsl/test/src/test_compression.c
@@ -247,21 +247,21 @@ test_gorilla_int()
 	{
 		StringInfoData buf;
 		bytea *sent;
-		StringInfoData transmition;
+		StringInfoData transmission;
 		GorillaCompressed *compressed_recv;
 
 		pq_begintypsend(&buf);
 		gorilla_compressed_send((CompressedDataHeader *) compressed, &buf);
 		sent = pq_endtypsend(&buf);
 
-		transmition = (StringInfoData){
+		transmission = (StringInfoData){
 			.data = VARDATA(sent),
 			.len = VARSIZE(sent),
 			.maxlen = VARSIZE(sent),
 		};
 
 		compressed_recv =
-			(GorillaCompressed *) DatumGetPointer(gorilla_compressed_recv(&transmition));
+			(GorillaCompressed *) DatumGetPointer(gorilla_compressed_recv(&transmission));
 		iter = gorilla_decompression_iterator_from_datum_forward(PointerGetDatum(compressed_recv),
 																 INT8OID);
 		for (DecompressResult r = gorilla_decompression_iterator_try_next_forward(iter); !r.is_done;


### PR DESCRIPTION
Use codespell. It works well enough for everything except Python where it tries to edit GraphQL API calls and regular expressions, so I don't run it for Python scripts.

Disable-check: force-changelog-file