### PR TITLE
Improve multinode detection in update script

### DIFF
--- a/sql/updates/latest-dev.sql
+++ b/sql/updates/latest-dev.sql
@@ -28,6 +28,13 @@ BEGIN
       MESSAGE = 'cannot upgrade because multi-node has been removed in 2.14.0',
       DETAIL = 'The following data nodes should be removed: '||data_nodes;
   END IF;
+
+  IF EXISTS(SELECT FROM _timescaledb_catalog.metadata WHERE key = 'dist_uuid') THEN
+    RAISE USING
+      ERRCODE = 'feature_not_supported',
+      MESSAGE = 'cannot upgrade because multi-node has been removed in 2.14.0',
+      DETAIL = 'This node appears to be part of a multi-node installation';
+  END IF;
 END $$;
 
 DROP FUNCTION IF EXISTS _timescaledb_functions.ping_data_node;


### PR DESCRIPTION
Previously we would only check for data nodes defined or distributed hypertables being present which might not be true on data nodes so we prevent update on any installation that has dist_uuid defined which is also true on data nodes.