### PR TITLE
Add apt update to libfuzzer workflow

### DIFF
--- a/.github/workflows/libfuzzer.yaml
+++ b/.github/workflows/libfuzzer.yaml
@@ -135,7 +135,9 @@ jobs:
 
     steps:
     - name: Install Linux dependencies
-      run: sudo apt install 7zip systemd-coredump gdb
+      run: |
+        sudo apt update
+        sudo apt install 7zip systemd-coredump gdb
 
     - name: Checkout TimescaleDB
       uses: actions/checkout@v3


### PR DESCRIPTION
Fixes the package install failures: https://github.com/timescale/timescaledb/actions/runs/7500828565/job/20421673435


Disable-check: force-changelog-file