### PR TITLE
Reduce transparent_decompress_chunk test flakiness

### DIFF
--- a/tsl/src/nodes/decompress_chunk/planner.c
+++ b/tsl/src/nodes/decompress_chunk/planner.c
@@ -376,7 +376,7 @@ is_not_runtime_constant_walker(Node *node, void *context)
 			/*
 			 * We might want to support these nodes to have vectorizable join
 			 * clauses (T_Var) or join clauses referencing a variable that is
-			 * above outer join (T_PlaceHolderVar). We don't suppor them at the
+			 * above outer join (T_PlaceHolderVar). We don't support them at the
 			 * moment.
 			 */
 			return true;

--- a/tsl/test/shared/expected/transparent_decompress_chunk-13.out
+++ b/tsl/test/shared/expected/transparent_decompress_chunk-13.out
@@ -751,6 +751,7 @@ FROM metrics m1
     INNER JOIN metrics_space m2 ON m1.time = m2.time
         AND m1.device_id = 1
         AND m2.device_id = 2
+	WHERE m1.v1 = 3 -- additional filter to force m1 as inner relation in join
     ORDER BY m1.time,
         m1.device_id,
         m2.time,
@@ -764,10 +765,13 @@ QUERY PLAN
                Order: m1."time"
                ->  Index Scan Backward using _hyper_X_X_chunk_metrics_device_id_time_idx on _hyper_X_X_chunk m1_1
                      Index Cond: (device_id = 1)
+                     Filter: (v1 = 3)
                ->  Index Scan Backward using _hyper_X_X_chunk_metrics_device_id_time_idx on _hyper_X_X_chunk m1_2
                      Index Cond: (device_id = 1)
+                     Filter: (v1 = 3)
                ->  Index Scan Backward using _hyper_X_X_chunk_metrics_device_id_time_idx on _hyper_X_X_chunk m1_3
                      Index Cond: (device_id = 1)
+                     Filter: (v1 = 3)
          ->  Materialize
                ->  Custom Scan (ChunkAppend) on metrics_space m2
                      Order: m2."time"
@@ -777,7 +781,7 @@ QUERY PLAN
                            Index Cond: (device_id = 2)
                      ->  Index Scan using _hyper_X_X_chunk_metrics_space_device_id_time_idx on _hyper_X_X_chunk m2_3
                            Index Cond: (device_id = 2)
-(20 rows)
+(23 rows)
 
 -- test OUTER JOIN
 SET min_parallel_table_scan_size TO '0';

--- a/tsl/test/shared/expected/transparent_decompress_chunk-14.out
+++ b/tsl/test/shared/expected/transparent_decompress_chunk-14.out
@@ -751,6 +751,7 @@ FROM metrics m1
     INNER JOIN metrics_space m2 ON m1.time = m2.time
         AND m1.device_id = 1
         AND m2.device_id = 2
+	WHERE m1.v1 = 3 -- additional filter to force m1 as inner relation in join
     ORDER BY m1.time,
         m1.device_id,
         m2.time,
@@ -764,10 +765,13 @@ QUERY PLAN
                Order: m1."time"
                ->  Index Scan Backward using _hyper_X_X_chunk_metrics_device_id_time_idx on _hyper_X_X_chunk m1_1
                      Index Cond: (device_id = 1)
+                     Filter: (v1 = 3)
                ->  Index Scan Backward using _hyper_X_X_chunk_metrics_device_id_time_idx on _hyper_X_X_chunk m1_2
                      Index Cond: (device_id = 1)
+                     Filter: (v1 = 3)
                ->  Index Scan Backward using _hyper_X_X_chunk_metrics_device_id_time_idx on _hyper_X_X_chunk m1_3
                      Index Cond: (device_id = 1)
+                     Filter: (v1 = 3)
          ->  Materialize
                ->  Custom Scan (ChunkAppend) on metrics_space m2
                      Order: m2."time"
@@ -777,7 +781,7 @@ QUERY PLAN
                            Index Cond: (device_id = 2)
                      ->  Index Scan using _hyper_X_X_chunk_metrics_space_device_id_time_idx on _hyper_X_X_chunk m2_3
                            Index Cond: (device_id = 2)
-(20 rows)
+(23 rows)
 
 -- test OUTER JOIN
 SET min_parallel_table_scan_size TO '0';

--- a/tsl/test/shared/expected/transparent_decompress_chunk-15.out
+++ b/tsl/test/shared/expected/transparent_decompress_chunk-15.out
@@ -753,6 +753,7 @@ FROM metrics m1
     INNER JOIN metrics_space m2 ON m1.time = m2.time
         AND m1.device_id = 1
         AND m2.device_id = 2
+	WHERE m1.v1 = 3 -- additional filter to force m1 as inner relation in join
     ORDER BY m1.time,
         m1.device_id,
         m2.time,
@@ -766,10 +767,13 @@ QUERY PLAN
                Order: m1."time"
                ->  Index Scan Backward using _hyper_X_X_chunk_metrics_device_id_time_idx on _hyper_X_X_chunk m1_1
                      Index Cond: (device_id = 1)
+                     Filter: (v1 = 3)
                ->  Index Scan Backward using _hyper_X_X_chunk_metrics_device_id_time_idx on _hyper_X_X_chunk m1_2
                      Index Cond: (device_id = 1)
+                     Filter: (v1 = 3)
                ->  Index Scan Backward using _hyper_X_X_chunk_metrics_device_id_time_idx on _hyper_X_X_chunk m1_3
                      Index Cond: (device_id = 1)
+                     Filter: (v1 = 3)
          ->  Materialize
                ->  Custom Scan (ChunkAppend) on metrics_space m2
                      Order: m2."time"
@@ -779,7 +783,7 @@ QUERY PLAN
                            Index Cond: (device_id = 2)
                      ->  Index Scan using _hyper_X_X_chunk_metrics_space_device_id_time_idx on _hyper_X_X_chunk m2_3
                            Index Cond: (device_id = 2)
-(20 rows)
+(23 rows)
 
 -- test OUTER JOIN
 SET min_parallel_table_scan_size TO '0';

--- a/tsl/test/shared/expected/transparent_decompress_chunk-16.out
+++ b/tsl/test/shared/expected/transparent_decompress_chunk-16.out
@@ -750,6 +750,7 @@ FROM metrics m1
     INNER JOIN metrics_space m2 ON m1.time = m2.time
         AND m1.device_id = 1
         AND m2.device_id = 2
+	WHERE m1.v1 = 3 -- additional filter to force m1 as inner relation in join
     ORDER BY m1.time,
         m1.device_id,
         m2.time,
@@ -763,10 +764,13 @@ QUERY PLAN
                Order: m1."time"
                ->  Index Scan Backward using _hyper_X_X_chunk_metrics_device_id_time_idx on _hyper_X_X_chunk m1_1
                      Index Cond: (device_id = 1)
+                     Filter: (v1 = 3)
                ->  Index Scan Backward using _hyper_X_X_chunk_metrics_device_id_time_idx on _hyper_X_X_chunk m1_2
                      Index Cond: (device_id = 1)
+                     Filter: (v1 = 3)
                ->  Index Scan Backward using _hyper_X_X_chunk_metrics_device_id_time_idx on _hyper_X_X_chunk m1_3
                      Index Cond: (device_id = 1)
+                     Filter: (v1 = 3)
          ->  Materialize
                ->  Custom Scan (ChunkAppend) on metrics_space m2
                      Order: m2."time"
@@ -776,7 +780,7 @@ QUERY PLAN
                            Index Cond: (device_id = 2)
                      ->  Index Scan using _hyper_X_X_chunk_metrics_space_device_id_time_idx on _hyper_X_X_chunk m2_3
                            Index Cond: (device_id = 2)
-(20 rows)
+(23 rows)
 
 -- test OUTER JOIN
 SET min_parallel_table_scan_size TO '0';

--- a/tsl/test/shared/sql/include/shared_setup.sql
+++ b/tsl/test/shared/sql/include/shared_setup.sql
@@ -14,8 +14,6 @@ CREATE SCHEMA test;
 
 -- create normal hypertable with dropped columns, each chunk will have different attribute numbers
 CREATE TABLE metrics(filler_1 int, filler_2 int, filler_3 int, time timestamptz NOT NULL, device_id int, v0 int, v1 int, v2 float, v3 float);
-CREATE INDEX ON metrics(time DESC);
-CREATE INDEX ON metrics(device_id,time DESC);
 SELECT create_hypertable('metrics','time',create_default_indexes:=false);
 
 ALTER TABLE metrics DROP COLUMN filler_1;
@@ -24,12 +22,12 @@ ALTER TABLE metrics DROP COLUMN filler_2;
 INSERT INTO metrics(time,device_id,v0,v1,v2,v3) SELECT time, device_id, device_id-1, device_id + 2, device_id + 0.5, NULL FROM generate_series('2000-01-06 0:00:00+0'::timestamptz,'2000-01-12 23:55:00+0','2m') gtime(time), generate_series(1,5,1) gdevice(device_id);
 ALTER TABLE metrics DROP COLUMN filler_3;
 INSERT INTO metrics(time,device_id,v0,v1,v2,v3) SELECT time, device_id, device_id, device_id + 2, device_id + 0.5, NULL FROM generate_series('2000-01-13 0:00:00+0'::timestamptz,'2000-01-19 23:55:00+0','2m') gtime(time), generate_series(1,5,1) gdevice(device_id);
+CREATE INDEX ON metrics(time DESC);
+CREATE INDEX ON metrics(device_id,time DESC);
 ANALYZE metrics;
 
 -- create identical hypertable with space partitioning
 CREATE TABLE metrics_space(filler_1 int, filler_2 int, filler_3 int, time timestamptz NOT NULL, device_id int, v0 int, v1 int, v2 float, v3 float);
-CREATE INDEX ON metrics_space(time);
-CREATE INDEX ON metrics_space(device_id,time);
 SELECT create_hypertable('metrics_space','time','device_id',3,create_default_indexes:=false);
 
 ALTER TABLE metrics_space DROP COLUMN filler_1;
@@ -38,13 +36,13 @@ ALTER TABLE metrics_space DROP COLUMN filler_2;
 INSERT INTO metrics_space(time,device_id,v0,v1,v2,v3) SELECT time, device_id, device_id+1, device_id + 2, device_id + 0.5, NULL FROM generate_series('2000-01-06 0:00:00+0'::timestamptz,'2000-01-12 23:55:00+0','2m') gtime(time), generate_series(1,5,1) gdevice(device_id);
 ALTER TABLE metrics_space DROP COLUMN filler_3;
 INSERT INTO metrics_space(time,device_id,v0,v1,v2,v3) SELECT time, device_id, device_id+1, device_id + 2, device_id + 0.5, NULL FROM generate_series('2000-01-13 0:00:00+0'::timestamptz,'2000-01-19 23:55:00+0','2m') gtime(time), generate_series(1,5,1) gdevice(device_id);
+CREATE INDEX ON metrics_space(time);
+CREATE INDEX ON metrics_space(device_id,time);
 ANALYZE metrics_space;
 
 
 -- create hypertable with compression
 CREATE TABLE metrics_compressed(filler_1 int, filler_2 int, filler_3 int, time timestamptz NOT NULL, device_id int, v0 int, v1 int, v2 float, v3 float);
-CREATE INDEX ON metrics_compressed(time);
-CREATE INDEX ON metrics_compressed(device_id,time);
 SELECT create_hypertable('metrics_compressed','time',create_default_indexes:=false);
 
 ALTER TABLE metrics_compressed DROP COLUMN filler_1;
@@ -53,6 +51,8 @@ ALTER TABLE metrics_compressed DROP COLUMN filler_2;
 INSERT INTO metrics_compressed(time,device_id,v0,v1,v2,v3) SELECT time, device_id, device_id-1, device_id + 2, device_id + 0.5, NULL FROM generate_series('2000-01-06 0:00:00+0'::timestamptz,'2000-01-12 23:55:00+0','2m') gtime(time), generate_series(1,5,1) gdevice(device_id);
 ALTER TABLE metrics_compressed DROP COLUMN filler_3;
 INSERT INTO metrics_compressed(time,device_id,v0,v1,v2,v3) SELECT time, device_id, device_id, device_id + 2, device_id + 0.5, NULL FROM generate_series('2000-01-13 0:00:00+0'::timestamptz,'2000-01-19 23:55:00+0','2m') gtime(time), generate_series(1,5,1) gdevice(device_id);
+CREATE INDEX ON metrics_compressed(time);
+CREATE INDEX ON metrics_compressed(device_id,time);
 ANALYZE metrics_compressed;
 
 -- compress chunks
@@ -66,8 +66,6 @@ REINDEX TABLE _timescaledb_internal._compressed_hypertable_4;
 
 -- create hypertable with space partitioning and compression
 CREATE TABLE metrics_space_compressed(filler_1 int, filler_2 int, filler_3 int, time timestamptz NOT NULL, device_id int, v0 int, v1 int, v2 float, v3 float);
-CREATE INDEX ON metrics_space_compressed(time);
-CREATE INDEX ON metrics_space_compressed(device_id,time);
 SELECT create_hypertable('metrics_space_compressed','time','device_id',3,create_default_indexes:=false);
 
 ALTER TABLE metrics_space_compressed DROP COLUMN filler_1;
@@ -76,6 +74,8 @@ ALTER TABLE metrics_space_compressed DROP COLUMN filler_2;
 INSERT INTO metrics_space_compressed(time,device_id,v0,v1,v2,v3) SELECT time, device_id, device_id+1, device_id + 2, device_id + 0.5, NULL FROM generate_series('2000-01-06 0:00:00+0'::timestamptz,'2000-01-12 23:55:00+0','2m') gtime(time), generate_series(1,5,1) gdevice(device_id);
 ALTER TABLE metrics_space_compressed DROP COLUMN filler_3;
 INSERT INTO metrics_space_compressed(time,device_id,v0,v1,v2,v3) SELECT time, device_id, device_id+1, device_id + 2, device_id + 0.5, NULL FROM generate_series('2000-01-13 0:00:00+0'::timestamptz,'2000-01-19 23:55:00+0','2m') gtime(time), generate_series(1,5,1) gdevice(device_id);
+CREATE INDEX ON metrics_space_compressed(time);
+CREATE INDEX ON metrics_space_compressed(device_id,time);
 ANALYZE metrics_space_compressed;
 
 -- compress chunks

--- a/tsl/test/shared/sql/transparent_decompress_chunk.sql.in
+++ b/tsl/test/shared/sql/transparent_decompress_chunk.sql.in
@@ -229,6 +229,7 @@ FROM metrics m1
     INNER JOIN metrics_space m2 ON m1.time = m2.time
         AND m1.device_id = 1
         AND m2.device_id = 2
+	WHERE m1.v1 = 3 -- additional filter to force m1 as inner relation in join
     ORDER BY m1.time,
         m1.device_id,
         m2.time,


### PR DESCRIPTION
One of the merge join queries is known to switch inner and outer join relations because the costs seem to be the same. Adding an additional filter on one of the relations should change the costs enough so they are not interchangeable.

Fixes #5424 

 Disable-check: force-changelog-file