### PR TITLE
Reenable clang-tidy in CI

### DIFF
--- a/.github/gh_config_reader.py
+++ b/.github/gh_config_reader.py
@@ -19,5 +19,5 @@ import os
 for key in dir(ci_settings):
     if not key.startswith("__"):
         value = getattr(ci_settings, key)
-        with open(os.environ["GITHUB_OUTPUT"], "a") as output:
+        with open(os.environ["GITHUB_OUTPUT"], "a", encoding="utf-8") as output:
             print(str.format("{0}={1}", key, json.dumps(value)), file=output)

--- a/.github/gh_matrix_builder.py
+++ b/.github/gh_matrix_builder.py
@@ -167,14 +167,7 @@ if pull_request:
 
 # always test debug build on latest of all supported pg versions
 m["include"].append(
-    build_debug_config(
-        {
-            "pg": PG13_LATEST,
-            "cc": "clang-14",
-            "cxx": "clang++-14",
-            "ignored_tests": ignored_tests,
-        }
-    )
+    build_debug_config({"pg": PG13_LATEST, "ignored_tests": ignored_tests})
 )
 
 m["include"].append(
@@ -196,12 +189,16 @@ m["include"].append(
     )
 )
 
-# test latest postgres release without telemetry
+# Test latest postgres release without telemetry. Also run clang-tidy on it
+# because it's the fastest one.
 m["include"].append(
     build_without_telemetry(
         {
             "pg": PG16_LATEST,
+            "cc": "clang-14",
+            "cxx": "clang++-14",
             "ignored_tests": ignored_tests,
+            "tsdb_build_args": "-DLINTER=ON -DWARNINGS_AS_ERRORS=ON",
         }
     )
 )
@@ -364,5 +361,5 @@ elif len(sys.argv) > 2:
         )
 
 # generate command to set github action variable
-with open(os.environ["GITHUB_OUTPUT"], "a") as output:
+with open(os.environ["GITHUB_OUTPUT"], "a", encoding="utf-8") as output:
     print(str.format("matrix={0}", json.dumps(m, default=list)), file=output)

--- a/.github/workflows/linux-build-and-test.yaml
+++ b/.github/workflows/linux-build-and-test.yaml
@@ -161,7 +161,7 @@ jobs:
       run: |
         ./bootstrap -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} \
           -DPG_SOURCE_DIR=~/$PG_SRC_DIR -DPG_PATH=~/$PG_INSTALL_DIR \
-          ${{ matrix.tsdb_build_args }} -DCODECOVERAGE=${{ matrix.coverage }} -DLINTER_STRICT=ON
+          ${{ matrix.tsdb_build_args }} -DCODECOVERAGE=${{ matrix.coverage }}
         make -j $MAKE_JOBS -C build
         make -C build install
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -498,11 +498,7 @@ else()
 endif()
 
 # Linter support via clang-tidy. Enabled when using clang as compiler
-option(LINTER "Enable linter support using clang-tidy (ON when using clang)"
-       OFF)
-
-set(LINTER_STRICT_DEFAULT OFF)
-option(LINTER_STRICT "Treat linter warnings as errors" ${LINTER_STRICT_DEFAULT})
+option(LINTER "Enable linter support using clang-tidy" OFF)
 
 if(LINTER)
   find_program(
@@ -512,14 +508,39 @@ if(LINTER)
     DOC "The path to the clang-tidy linter")
 
   if(CLANG_TIDY)
-    message(STATUS "Linter support (clang-tidy) enabled")
-    if(LINTER_STRICT)
-      set(CMAKE_C_CLANG_TIDY
-          "${CLANG_TIDY};--checks=clang-diagnostic-*,clang-analyzer-*,-*,clang-analyzer-core.*,clang-diagnostic-*,readability-redundant-control-flow,bugprone-argument-comment,bugprone-macro-parentheses,readability-suspicious-call-argument,readability-misleading-indentation,readability-inconsistent-declaration-parameter-name;--warnings-as-errors=*"
-      )
+    message(STATUS "Using clang-tidy ${CLANG_TIDY}")
+    execute_process(COMMAND ${CLANG_TIDY} --version)
+    string(
+      CONCAT
+        CMAKE_C_CLANG_TIDY
+        "${CLANG_TIDY}"
+        ";--checks=clang-diagnostic-*,clang-analyzer-*"
+        ",-clang-analyzer-security.insecureAPI.DeprecatedOrUnsafeBufferHandling"
+        ",-clang-analyzer-deadcode.DeadStores"
+        ",bugprone-*"
+        ",-bugprone-branch-clone"
+        ",-bugprone-easily-swappable-parameters"
+        ",-bugprone-implicit-widening-of-multiplication-result"
+        ",-bugprone-narrowing-conversions"
+        ",-bugprone-reserved-identifier"
+        ",-bugprone-suspicious-include"
+        ",readability-*"
+        ",-readability-avoid-const-params-in-decls"
+        ",-readability-braces-around-statements"
+        ",-readability-else-after-return"
+        ",-readability-function-cognitive-complexity"
+        ",-readability-function-size"
+        ",-readability-identifier-length"
+        ",-readability-isolate-declaration"
+        ",-readability-magic-numbers"
+        ",-readability-non-const-parameter"
+        # ";--fix-errors"
+    )
+    if(WARNINGS_AS_ERRORS)
+      set(CMAKE_C_CLANG_TIDY "${CMAKE_C_CLANG_TIDY};--warnings-as-errors=*")
     else()
-      set(CMAKE_C_CLANG_TIDY "${CLANG_TIDY};--quiet")
-    endif(LINTER_STRICT)
+      set(CMAKE_C_CLANG_TIDY "${CMAKE_C_CLANG_TIDY};--quiet")
+    endif(WARNINGS_AS_ERRORS)
   else()
     message(STATUS "Install clang-tidy to enable code linting")
   endif(CLANG_TIDY)

--- a/src/bgw/job.c
+++ b/src/bgw/job.c
@@ -605,8 +605,8 @@ ts_bgw_job_find_with_lock(int32 bgw_job_id, MemoryContext mctx, LOCKMODE tuple_l
 	LOCKTAG tag;
 
 	/* take advisory lock before relation lock */
-	if (!(*got_lock =
-			  ts_lock_job_id(bgw_job_id, tuple_lock_mode, lock_type == SESSION_LOCK, &tag, block)))
+	*got_lock = ts_lock_job_id(bgw_job_id, tuple_lock_mode, lock_type == SESSION_LOCK, &tag, block);
+	if (!*got_lock)
 	{
 		/* return NULL if lock could not be acquired */
 		Assert(!block);

--- a/src/bgw/scheduler.c
+++ b/src/bgw/scheduler.c
@@ -229,8 +229,6 @@ worker_state_cleanup(ScheduledBgwJob *sjob)
 			 */
 			elog(LOG, "job %d failed", sjob->job.fd.id);
 			mark_job_as_ended(sjob, JOB_FAILURE);
-			/* reload updated value */
-			job_stat = ts_bgw_job_stat_find(sjob->job.fd.id);
 		}
 		else
 		{

--- a/src/chunk.c
+++ b/src/chunk.c
@@ -2716,11 +2716,11 @@ ts_chunk_exists_relid(Oid relid)
  * Returns 0 if there is no chunk with such reloid.
  */
 int32
-ts_chunk_get_hypertable_id_by_reloid(Oid reliod)
+ts_chunk_get_hypertable_id_by_reloid(Oid reloid)
 {
 	FormData_chunk form;
 
-	if (chunk_simple_scan_by_reloid(reliod, &form, /* missing_ok = */ true))
+	if (chunk_simple_scan_by_reloid(reloid, &form, /* missing_ok = */ true))
 	{
 		return form.hypertable_id;
 	}
@@ -4553,7 +4553,6 @@ ts_chunk_scan_iterator_set_chunk_id(ScanIterator *it, int32 chunk_id)
 								   Int32GetDatum(chunk_id));
 }
 
-#include "hypercube.h"
 /*
  * Create a hypercube for the OSM chunk
  * The initial range for the OSM chunk will be from INT64_MAX - 1 to INT64_MAX.

--- a/src/chunk.h
+++ b/src/chunk.h
@@ -176,7 +176,7 @@ extern TSDLLEXPORT Chunk *ts_chunk_get_by_id(int32 id, bool fail_if_not_found);
 extern TSDLLEXPORT Chunk *ts_chunk_get_by_relid(Oid relid, bool fail_if_not_found);
 extern TSDLLEXPORT void ts_chunk_free(Chunk *chunk);
 extern bool ts_chunk_exists(const char *schema_name, const char *table_name);
-extern TSDLLEXPORT int32 ts_chunk_get_hypertable_id_by_reloid(Oid relid);
+extern TSDLLEXPORT int32 ts_chunk_get_hypertable_id_by_reloid(Oid reloid);
 extern TSDLLEXPORT int32 ts_chunk_get_compressed_chunk_id(int32 chunk_id);
 extern TSDLLEXPORT FormData_chunk ts_chunk_get_formdata(int32 chunk_id);
 extern TSDLLEXPORT Oid ts_chunk_get_relid(int32 chunk_id, bool missing_ok);

--- a/src/debug_guc.c
+++ b/src/debug_guc.c
@@ -107,10 +107,10 @@ get_show_upper_mask(const char *paths, size_t paths_len)
 static bool
 set_debug_flag(const char *flag_string, size_t length, DebugOptimizerFlags *flags)
 {
-	char *end;
 	size_t flag_length;
 
-	if ((end = strchr(flag_string, '=')) != NULL)
+	char *end = strchr(flag_string, '=');
+	if (end != NULL)
 	{
 		Ensure(end - flag_string >= 0, "bad flag string format \"%s\"", flag_string);
 		flag_length = end - flag_string;

--- a/src/dimension.c
+++ b/src/dimension.c
@@ -32,7 +32,6 @@
 #include "time_utils.h"
 #include "utils.h"
 #include "errors.h"
-#include "error_utils.h"
 #include "debug_point.h"
 
 /* add_dimension record attribute numbers */

--- a/src/dimension_vector.c
+++ b/src/dimension_vector.c
@@ -115,9 +115,7 @@ ts_dimension_vec_add_unique_slice(DimensionVec **vecptr, DimensionSlice *slice)
 DimensionVec *
 ts_dimension_vec_add_slice_sort(DimensionVec **vecptr, DimensionSlice *slice)
 {
-	DimensionVec *vec;
-
-	*vecptr = vec = ts_dimension_vec_add_slice(vecptr, slice);
+	*vecptr = ts_dimension_vec_add_slice(vecptr, slice);
 	return ts_dimension_vec_sort(vecptr);
 }
 

--- a/src/hypertable.c
+++ b/src/hypertable.c
@@ -50,10 +50,8 @@
 #include "hypertable_cache.h"
 #include "trigger.h"
 #include "scanner.h"
-#include "ts_catalog/catalog.h"
 #include "dimension_slice.h"
 #include "dimension_vector.h"
-#include "hypercube.h"
 #include "indexing.h"
 #include "guc.h"
 #include "errors.h"
@@ -2396,7 +2394,8 @@ ts_hypertable_get_open_dim_max_value(const Hypertable *ht, int dimension_index, 
 	int64 max_value =
 		max_isnull ? ts_time_get_min(timetype) : ts_time_value_to_internal(maxdat, timetype);
 
-	if ((res = SPI_finish()) != SPI_OK_FINISH)
+	res = SPI_finish();
+	if (res != SPI_OK_FINISH)
 		elog(ERROR, "SPI_finish failed: %s", SPI_result_code_string(res));
 
 	return max_value;

--- a/src/hypertable.h
+++ b/src/hypertable.h
@@ -91,7 +91,7 @@ typedef enum HypertableCreateFlags
 
 extern TSDLLEXPORT bool ts_hypertable_create_from_info(Oid table_relid, int32 hypertable_id,
 													   uint32 flags, DimensionInfo *time_dim_info,
-													   DimensionInfo *space_dim_info,
+													   DimensionInfo *closed_dim_info,
 													   Name associated_schema_name,
 													   Name associated_table_prefix,
 													   ChunkSizingInfo *chunk_sizing_info);

--- a/src/import/allpaths.h
+++ b/src/import/allpaths.h
@@ -11,5 +11,5 @@
 #include "export.h"
 
 extern void ts_set_rel_size(PlannerInfo *root, RelOptInfo *rel, Index rti, RangeTblEntry *rte);
-extern void ts_set_append_rel_pathlist(PlannerInfo *root, RelOptInfo *rel, Index rti,
-									   RangeTblEntry *rte);
+extern void ts_set_append_rel_pathlist(PlannerInfo *root, RelOptInfo *parent_rel,
+									   Index parent_rt_index, RangeTblEntry *parent_rte);

--- a/src/init.c
+++ b/src/init.c
@@ -60,7 +60,9 @@ extern void _conn_mock_fini();
 
 extern void _chunk_append_init();
 
+#if PG16_LT
 extern void TSDLLEXPORT _PG_init(void);
+#endif
 
 TS_FUNCTION_INFO_V1(ts_post_load_init);
 

--- a/src/loader/bgw_launcher.c
+++ b/src/loader/bgw_launcher.c
@@ -741,7 +741,7 @@ ts_bgw_cluster_launcher_main(PG_FUNCTION_ARGS)
 	pgstat_report_appname(MyBgworkerEntry->bgw_name);
 	ereport(LOG, (errmsg("TimescaleDB background worker launcher connected to shared catalogs")));
 
-	htab_storage = MemoryContextAllocZero(TopMemoryContext, sizeof(*htab_storage));
+	htab_storage = MemoryContextAllocZero(TopMemoryContext, sizeof(void *));
 
 	/*
 	 * We must setup the cleanup function _before_ initializing any state it

--- a/src/loader/loader.c
+++ b/src/loader/loader.c
@@ -95,7 +95,10 @@ PG_MODULE_MAGIC;
 
 #define CalledInParallelWorker()                                                                   \
 	(MyBgworkerEntry != NULL && (MyBgworkerEntry->bgw_flags & BGWORKER_CLASS_PARALLEL) != 0)
+
+#if PG16_LT
 extern void TSDLLEXPORT _PG_init(void);
+#endif
 
 /* was the versioned-extension loaded*/
 static bool loader_present = true;
@@ -162,13 +165,14 @@ TsExtension extensions[] = {
 	},
 };
 
-inline static void extension_check(TsExtension *);
+inline static void extension_check(TsExtension * /*ext*/);
 #if PG14_LT
 static void call_extension_post_parse_analyze_hook(ParseState *pstate, Query *query,
 												   TsExtension const *);
 #else
 static void call_extension_post_parse_analyze_hook(ParseState *pstate, Query *query,
-												   TsExtension const *, JumbleState *jstate);
+												   TsExtension const * /*ext*/,
+												   JumbleState *jstate);
 #endif
 
 static bool

--- a/src/planner/expand_hypertable.c
+++ b/src/planner/expand_hypertable.c
@@ -488,7 +488,7 @@ transform_time_bucket_comparison(PlannerInfo *root, OpExpr *op)
 					return op;
 
 				/* bail out if interval->time can't be exactly represented as a double */
-				if (interval->time >= 0x3FFFFFFFFFFFFFll)
+				if (interval->time >= 0x3FFFFFFFFFFFFFLL)
 					return op;
 
 				integralValue = const_datum_get_int(castNode(Const, value));

--- a/src/planner/planner.c
+++ b/src/planner/planner.c
@@ -860,7 +860,8 @@ should_chunk_append(Hypertable *ht, PlannerInfo *root, RelOptInfo *rel, Path *pa
 
 				if (IsA(em_expr, Var) && castNode(Var, em_expr)->varattno == order_attno)
 					return true;
-				else if (IsA(em_expr, FuncExpr) && list_length(path->pathkeys) == 1)
+
+				if (IsA(em_expr, FuncExpr) && list_length(path->pathkeys) == 1)
 				{
 					FuncExpr *func = castNode(FuncExpr, em_expr);
 					FuncInfo *info = ts_func_cache_get_bucketing_func(func->funcid);
@@ -1531,7 +1532,8 @@ check_cagg_view_rte(RangeTblEntry *rte)
 		if (!OidIsValid(rte->relid))
 			break;
 
-		if ((cagg = ts_continuous_agg_find_by_relid(rte->relid)) != NULL)
+		cagg = ts_continuous_agg_find_by_relid(rte->relid);
+		if (cagg != NULL)
 			found = true;
 	}
 	return found;

--- a/src/telemetry/replication.c
+++ b/src/telemetry/replication.c
@@ -55,7 +55,8 @@ ts_telemetry_replication_info_gather(void)
 		info.got_is_wal_receiver = true;
 	}
 
-	if ((res = SPI_finish()) != SPI_OK_FINISH)
+	res = SPI_finish();
+	if (res != SPI_OK_FINISH)
 		elog(ERROR, "SPI_finish failed: %s", SPI_result_code_string(res));
 
 	return info;

--- a/src/ts_catalog/continuous_aggs_watermark.c
+++ b/src/ts_catalog/continuous_aggs_watermark.c
@@ -399,8 +399,6 @@ ts_cagg_watermark_update(Hypertable *mat_ht, int64 watermark, bool watermark_isn
 
 	watermark = cagg_compute_watermark(cagg, watermark, watermark_isnull);
 	cagg_watermark_update_internal(mat_ht->fd.id, watermark, force_update);
-
-	return;
 }
 
 TSDLLEXPORT void

--- a/src/version.c
+++ b/src/version.c
@@ -12,7 +12,6 @@
 #include <storage/fd.h>
 #include <utils/timestamp.h>
 
-#include "fmgr.h"
 #include "compat/compat.h"
 #include "annotations.h"
 #include "gitcommit.h"

--- a/test/src/loader/init.c
+++ b/test/src/loader/init.c
@@ -26,7 +26,9 @@
 PG_MODULE_MAGIC;
 #endif
 
+#if PG16_LT
 extern void PGDLLEXPORT _PG_init(void);
+#endif
 
 static post_parse_analyze_hook_type prev_post_parse_analyze_hook;
 

--- a/test/src/loader/osm_init.c
+++ b/test/src/loader/osm_init.c
@@ -25,7 +25,10 @@ static void osm_process_utility_hook(PlannedStmt *pstmt, const char *queryString
 									 QueryEnvironment *queryEnv, DestReceiver *dest,
 									 QueryCompletion *qc);
 
+#if PG16_LT
 extern void PGDLLEXPORT _PG_init(void);
+#endif
+
 void
 _PG_init(void)
 {

--- a/tsl/src/bgw_policy/continuous_aggregate_api.c
+++ b/tsl/src/bgw_policy/continuous_aggregate_api.c
@@ -23,7 +23,6 @@
 #include "hypertable_cache.h"
 #include "time_utils.h"
 #include "policy_utils.h"
-#include "time_utils.h"
 #include "guc.h"
 #include "bgw_policy/policies_v2.h"
 #include "bgw/job_stat.h"

--- a/tsl/src/bgw_policy/job.c
+++ b/tsl/src/bgw_policy/job.c
@@ -51,8 +51,6 @@
 #include "dimension.h"
 #include "dimension_slice.h"
 #include "dimension_vector.h"
-#include "errors.h"
-#include "job.h"
 #include "reorder.h"
 #include "utils.h"
 

--- a/tsl/src/chunk.c
+++ b/tsl/src/chunk.c
@@ -25,12 +25,10 @@
 #include <utils/snapmgr.h>
 #include <executor/executor.h>
 #include <parser/parse_func.h>
-#include <storage/lmgr.h>
 #include <funcapi.h>
 #include <miscadmin.h>
 #include <fmgr.h>
 #ifdef USE_ASSERT_CHECKING
-#include <funcapi.h>
 #endif
 
 #include <compat/compat.h>

--- a/tsl/src/compression/api.c
+++ b/tsl/src/compression/api.c
@@ -44,7 +44,6 @@
 #include "create.h"
 #include "api.h"
 #include "compression.h"
-#include "compat/compat.h"
 #include "scanner.h"
 #include "scan_iterator.h"
 #include "utils.h"

--- a/tsl/src/compression/compression.c
+++ b/tsl/src/compression/compression.c
@@ -149,7 +149,7 @@ static void row_compressor_flush(RowCompressor *row_compressor, CommandId mycid,
 static int create_segment_filter_scankey(RowDecompressor *decompressor,
 										 char *segment_filter_col_name, StrategyNumber strategy,
 										 ScanKeyData *scankeys, int num_scankeys,
-										 Bitmapset **null_columns, Datum value, bool isnull);
+										 Bitmapset **null_columns, Datum value, bool is_null_check);
 static void create_per_compressed_column(RowDecompressor *decompressor);
 
 /********************
@@ -1097,10 +1097,9 @@ row_compressor_append_row(RowCompressor *row_compressor, TupleTableSlot *row)
 static void
 row_compressor_flush(RowCompressor *row_compressor, CommandId mycid, bool changed_groups)
 {
-	int16 col;
 	HeapTuple compressed_tuple;
 
-	for (col = 0; col < row_compressor->n_input_columns; col++)
+	for (int col = 0; col < row_compressor->n_input_columns; col++)
 	{
 		PerColumn *column = &row_compressor->per_column[col];
 		Compressor *compressor;
@@ -1189,7 +1188,7 @@ row_compressor_flush(RowCompressor *row_compressor, CommandId mycid, bool change
 
 	/* free the compressed values now that we're done with them (the old compressor is freed in
 	 * finish()) */
-	for (col = 0; col < row_compressor->n_input_columns; col++)
+	for (int col = 0; col < row_compressor->n_input_columns; col++)
 	{
 		PerColumn *column = &row_compressor->per_column[col];
 		int16 compressed_col;
@@ -1439,7 +1438,7 @@ create_per_compressed_column(RowDecompressor *decompressor)
 
 	Assert(OidIsValid(compressed_data_type_oid));
 
-	for (int16 col = 0; col < decompressor->in_desc->natts; col++)
+	for (int col = 0; col < decompressor->in_desc->natts; col++)
 	{
 		Oid decompressed_type;
 		bool is_compressed;

--- a/tsl/src/compression/compression_test.c
+++ b/tsl/src/compression/compression_test.c
@@ -126,6 +126,7 @@ read_compressed_data_file_impl(int algo, Oid type, const char *path, bool bulk, 
 		 * Skip empty data, because we'll just get "no data left in message"
 		 * right away.
 		 */
+		fclose(f);
 		return;
 	}
 
@@ -134,6 +135,7 @@ read_compressed_data_file_impl(int algo, Oid type, const char *path, bool bulk, 
 
 	if (elements_read != 1)
 	{
+		fclose(f);
 		ereport(ERROR, (errcode(ERRCODE_UNDEFINED_FILE), errmsg("failed to read file '%s'", path)));
 	}
 

--- a/tsl/src/compression/create.c
+++ b/tsl/src/compression/create.c
@@ -10,7 +10,6 @@
 #include <access/xact.h>
 #include <catalog/index.h>
 #include <catalog/indexing.h>
-#include <catalog/indexing.h>
 #include <catalog/objectaccess.h>
 #include <catalog/pg_constraint_d.h>
 #include <catalog/pg_constraint.h>
@@ -42,7 +41,6 @@
 #include "compression_with_clause.h"
 #include "compression.h"
 #include "hypertable_cache.h"
-#include "ts_catalog/array_utils.h"
 #include "custom_type_cache.h"
 #include "trigger.h"
 #include "utils.h"
@@ -1198,6 +1196,7 @@ compression_settings_update(CompressionSettings *settings, WithClauseResult *wit
 	}
 	else if (orderby_cols && !settings->fd.orderby)
 	{
+		Assert(list_length(orderby_cols) > 0);
 		List *cols = NIL;
 		List *desc = NIL;
 		List *nullsfirst = NIL;

--- a/tsl/src/compression/decompress_arithmetic_test_impl.c
+++ b/tsl/src/compression/decompress_arithmetic_test_impl.c
@@ -164,6 +164,11 @@ FUNCTION_NAME3(decompress, ALGO, PG_TYPE_PREFIX)(const uint8 *Data, size_t Size,
 	int nn = 0;
 	for (DecompressResult r = iter->try_next(iter); !r.is_done; r = iter->try_next(iter))
 	{
+		if (nn >= n)
+		{
+			elog(ERROR, "the repeated recompression result doesn't match");
+		}
+
 		if (r.is_null != results[nn].is_null)
 		{
 			elog(ERROR, "the repeated decompression result doesn't match");
@@ -189,11 +194,6 @@ FUNCTION_NAME3(decompress, ALGO, PG_TYPE_PREFIX)(const uint8 *Data, size_t Size,
 		}
 
 		nn++;
-
-		if (nn > n)
-		{
-			elog(ERROR, "the repeated recompression result doesn't match");
-		}
 	}
 
 	/*

--- a/tsl/src/compression/decompress_text_test_impl.c
+++ b/tsl/src/compression/decompress_text_test_impl.c
@@ -101,6 +101,11 @@ decompress_generic_text(const uint8 *Data, size_t Size, bool bulk, int requested
 	int nn = 0;
 	for (DecompressResult r = iter->try_next(iter); !r.is_done; r = iter->try_next(iter))
 	{
+		if (nn >= n)
+		{
+			elog(ERROR, "the repeated recompression result doesn't match");
+		}
+
 		if (r.is_null != results[nn].is_null)
 		{
 			elog(ERROR, "the repeated decompression result doesn't match");
@@ -122,18 +127,13 @@ decompress_generic_text(const uint8 *Data, size_t Size, bool bulk, int requested
 
 			if (strncmp(VARDATA_ANY(old_value),
 						VARDATA_ANY(new_value),
-						VARSIZE_ANY_EXHDR(new_value)))
+						VARSIZE_ANY_EXHDR(new_value)) != 0)
 			{
 				elog(ERROR, "the repeated decompression result doesn't match");
 			}
 		}
 
 		nn++;
-
-		if (nn > n)
-		{
-			elog(ERROR, "the repeated recompression result doesn't match");
-		}
 	}
 
 	return n;

--- a/tsl/src/compression/deltadelta.c
+++ b/tsl/src/compression/deltadelta.c
@@ -736,7 +736,7 @@ zig_zag_encode(uint64 value)
 	/* since shift is underspecified, we use (value < 0 ? 0xFFFFFFFFFFFFFFFFull : 0)
 	 * which compiles to the correct asm, and is well defined
 	 */
-	return (value << 1) ^ (((int64) value) < 0 ? 0xFFFFFFFFFFFFFFFFull : 0);
+	return (value << 1) ^ (((int64) value) < 0 ? 0xFFFFFFFFFFFFFFFFULL : 0);
 }
 
 static pg_attribute_always_inline uint64

--- a/tsl/src/compression/dictionary.c
+++ b/tsl/src/compression/dictionary.c
@@ -49,7 +49,7 @@ typedef struct DictionaryCompressed
 static void
 pg_attribute_unused() assertions(void)
 {
-	DictionaryCompressed test_val = { .vl_len_ = { 0 } };
+	DictionaryCompressed test_val;
 	/* make sure no padding bytes make it to disk */
 	StaticAssertStmt(sizeof(DictionaryCompressed) ==
 						 sizeof(test_val.vl_len_) + sizeof(test_val.compression_algorithm) +

--- a/tsl/src/compression/gorilla.c
+++ b/tsl/src/compression/gorilla.c
@@ -870,7 +870,7 @@ unpack_leading_zeros_array(BitArray *bitarray, uint8 *restrict dest)
 
 			uint8 output = this_input >> startbit_rel;
 			output |= ((uint64) next_input) << offs;
-			output &= (1ull << BITS_PER_LEADING_ZEROS) - 1ull;
+			output &= (1ULL << BITS_PER_LEADING_ZEROS) - 1ULL;
 
 			lane_dest[output_in_lane] = output;
 		}

--- a/tsl/src/continuous_aggs/common.c
+++ b/tsl/src/continuous_aggs/common.c
@@ -15,7 +15,7 @@ static void caggtimebucketinfo_init(CAggTimebucketInfo *src, int32 hypertable_id
 static void caggtimebucket_validate(CAggTimebucketInfo *tbinfo, List *groupClause, List *targetList,
 									bool is_cagg_create);
 static bool cagg_query_supported(const Query *query, StringInfo hint, StringInfo detail,
-								 const bool finalized);
+								 bool finalized);
 static Oid cagg_get_boundary_converter_funcoid(Oid typoid);
 static FuncExpr *build_conversion_call(Oid type, FuncExpr *boundary);
 static FuncExpr *build_boundary_call(int32 ht_id, Oid type);

--- a/tsl/src/continuous_aggs/create.c
+++ b/tsl/src/continuous_aggs/create.c
@@ -68,7 +68,6 @@
 #include "hypertable_cache.h"
 #include "hypertable.h"
 #include "invalidation.h"
-#include "dimension.h"
 #include "options.h"
 #include "time_utils.h"
 #include "utils.h"
@@ -93,18 +92,10 @@ static bool check_trigger_exists_hypertable(Oid relid, char *trigname);
 #endif
 static void cagg_add_trigger_hypertable(Oid relid, int32 hypertable_id);
 static void mattablecolumninfo_add_mattable_index(MatTableColumnInfo *matcolinfo, Hypertable *ht);
-static int32 mattablecolumninfo_create_materialization_table(
-	MatTableColumnInfo *matcolinfo, int32 hypertable_id, RangeVar *mat_rel,
-	CAggTimebucketInfo *bucket_info, bool create_addl_index, char *const tablespacename,
-	char *const table_access_method, ObjectAddress *mataddress);
-static Query *mattablecolumninfo_get_partial_select_query(MatTableColumnInfo *mattblinfo,
-														  Query *userview_query, bool finalized);
 static ObjectAddress create_view_for_query(Query *selquery, RangeVar *viewrel);
 static void fixup_userview_query_tlist(Query *userquery, List *tlist_aliases);
 static void cagg_create(const CreateTableAsStmt *create_stmt, ViewStmt *stmt, Query *panquery,
 						CAggTimebucketInfo *bucket_info, WithClauseResult *with_clause_options);
-void cagg_flip_realtime_view_definition(ContinuousAgg *agg, Hypertable *mat_ht);
-void cagg_rename_view_columns(ContinuousAgg *agg);
 
 #define MATPARTCOL_INTERVAL_FACTOR 10
 #define CAGG_INVALIDATION_TRIGGER "continuous_agg_invalidation_trigger"

--- a/tsl/src/continuous_aggs/insert.c
+++ b/tsl/src/continuous_aggs/insert.c
@@ -81,14 +81,11 @@ static int64 get_lowest_invalidated_time_for_hypertable(Oid hypertable_relid);
 static HTAB *continuous_aggs_cache_inval_htab = NULL;
 static MemoryContext continuous_aggs_trigger_mctx = NULL;
 
-void _continuous_aggs_cache_inval_init(void);
-void _continuous_aggs_cache_inval_fini(void);
-
 static int64 tuple_get_time(Dimension *d, HeapTuple tuple, AttrNumber col, TupleDesc tupdesc);
 static inline void cache_inval_entry_init(ContinuousAggsCacheInvalEntry *cache_entry,
 										  int32 hypertable_id, int32 entry_id);
 static inline void cache_entry_switch_to_chunk(ContinuousAggsCacheInvalEntry *cache_entry,
-											   Oid chunk_id, Relation chunk_relation);
+											   Oid chunk_reloid, Relation chunk_relation);
 static inline void update_cache_entry(ContinuousAggsCacheInvalEntry *cache_entry, int64 timeval);
 static void cache_inval_entry_write(ContinuousAggsCacheInvalEntry *entry);
 static void cache_inval_cleanup(void);

--- a/tsl/src/continuous_aggs/insert.h
+++ b/tsl/src/continuous_aggs/insert.h
@@ -9,8 +9,8 @@
 
 extern Datum continuous_agg_trigfn(PG_FUNCTION_ARGS);
 
-extern void _continuous_aggs_cache_inval_init();
-extern void _continuous_aggs_cache_inval_fini();
+extern void _continuous_aggs_cache_inval_init(void);
+extern void _continuous_aggs_cache_inval_fini(void);
 extern void execute_cagg_trigger(int32 hypertable_id, Relation chunk_rel, HeapTuple chunk_tuple,
 								 HeapTuple chunk_newtuple, bool update,
 								 bool is_distributed_hypertable_trigger,

--- a/tsl/src/continuous_aggs/refresh.c
+++ b/tsl/src/continuous_aggs/refresh.c
@@ -739,10 +739,10 @@ continuous_agg_refresh_internal(const ContinuousAgg *cagg,
 	int32 mat_id = cagg->data.mat_hypertable_id;
 	InternalTimeRange refresh_window = *refresh_window_arg;
 	int64 invalidation_threshold;
-	int rc;
 
 	/* Connect to SPI manager due to the underlying SPI calls */
-	if ((rc = SPI_connect_ext(SPI_OPT_NONATOMIC) != SPI_OK_CONNECT))
+	int rc = SPI_connect_ext(SPI_OPT_NONATOMIC);
+	if (rc != SPI_OK_CONNECT)
 		elog(ERROR, "SPI_connect failed: %s", SPI_result_code_string(rc));
 
 	/* Lock down search_path */
@@ -833,7 +833,8 @@ continuous_agg_refresh_internal(const ContinuousAgg *cagg,
 	{
 		emit_up_to_date_notice(cagg, callctx);
 
-		if ((rc = SPI_finish()) != SPI_OK_FINISH)
+		rc = SPI_finish();
+		if (rc != SPI_OK_FINISH)
 			elog(ERROR, "SPI_finish failed: %s", SPI_result_code_string(rc));
 
 		return;
@@ -855,6 +856,7 @@ continuous_agg_refresh_internal(const ContinuousAgg *cagg,
 	if (!process_cagg_invalidations_and_refresh(cagg, &refresh_window, callctx, INVALID_CHUNK_ID))
 		emit_up_to_date_notice(cagg, callctx);
 
-	if ((rc = SPI_finish()) != SPI_OK_FINISH)
+	rc = SPI_finish();
+	if (rc != SPI_OK_FINISH)
 		elog(ERROR, "SPI_finish failed: %s", SPI_result_code_string(rc));
 }

--- a/tsl/src/init.c
+++ b/tsl/src/init.c
@@ -53,7 +53,9 @@ PG_MODULE_MAGIC;
 #error "cannot compile the TSL for ApacheOnly mode"
 #endif
 
+#if PG16_LT
 extern void PGDLLEXPORT _PG_init(void);
+#endif
 
 /*
  * Cross module function initialization.

--- a/tsl/src/nodes/decompress_chunk/decompress_chunk.c
+++ b/tsl/src/nodes/decompress_chunk/decompress_chunk.c
@@ -338,7 +338,7 @@ smoothstep(double x, double start, double end)
 {
 	x = (x - start) / (end - start);
 	x = x < 0 ? 0 : x > 1 ? 1 : x;
-	return x * x * (3.0f - 2.0f * x);
+	return x * x * (3.0F - 2.0F * x);
 }
 
 /*
@@ -1169,8 +1169,8 @@ compressed_rel_setup_reltarget(RelOptInfo *compressed_rel, CompressionInfo *info
 													&attrs_used);
 
 			/* if the column is an orderby, add it's metadata columns too */
-			int16 index;
-			if ((index = ts_array_position(info->settings->fd.orderby, column_name)))
+			int16 index = ts_array_position(info->settings->fd.orderby, column_name);
+			if (index != 0)
 			{
 				compressed_reltarget_add_var_for_column(compressed_rel,
 														compressed_relid,

--- a/tsl/src/reorder.c
+++ b/tsl/src/reorder.c
@@ -57,7 +57,6 @@
 #include <utils/syscache.h>
 #include <utils/tuplesort.h>
 #include <executor/spi.h>
-#include <utils/snapmgr.h>
 
 #include "compat/compat.h"
 #include <access/toast_internals.h>

--- a/tsl/test/src/test_compression.c
+++ b/tsl/test/src/test_compression.c
@@ -18,7 +18,6 @@
 #include <utils/rel.h>
 #include <utils/syscache.h>
 #include <utils/typcache.h>
-#include <fmgr.h>
 
 #include "ts_catalog/catalog.h"
 #include <export.h>
@@ -281,15 +280,14 @@ test_gorilla_float()
 	GorillaCompressor *compressor = gorilla_compressor_alloc();
 	GorillaCompressed *compressed;
 	DecompressionIterator *iter;
-	float i;
-	for (i = 0.0; i < TEST_ELEMENTS; i++)
-		gorilla_compressor_append_value(compressor, float_get_bits(i));
+	for (int i = 0.0; i < TEST_ELEMENTS; i++)
+		gorilla_compressor_append_value(compressor, float_get_bits((float) i));
 
 	compressed = gorilla_compressor_finish(compressor);
 	TestAssertTrue(compressed != NULL);
 	TestAssertInt64Eq(VARSIZE(compressed), 1200);
 
-	i = 0;
+	float i = 0;
 	iter =
 		gorilla_decompression_iterator_from_datum_forward(PointerGetDatum(compressed), FLOAT4OID);
 	for (DecompressResult r = gorilla_decompression_iterator_try_next_forward(iter); !r.is_done;


### PR DESCRIPTION
Looks like it doesn't work now. Also add a warning about passing a bool as an int argument.


Disable-check: force-changelog-file

Disable-check: loader-change