### PR TITLE
Enable debug info about compression scan paths

### DIFF
--- a/src/guc.c
+++ b/src/guc.c
@@ -579,6 +579,19 @@ _guc_init(void)
 							 NULL,
 							 NULL,
 							 NULL);
+
+	/* this information is useful in general on customer deployments */
+	DefineCustomBoolVariable(/* name= */ "timescaledb.debug_compression_path_info",
+							 /* short_desc= */ "show various compression-related debug info",
+							 /* long_desc= */ "this is for debugging/information purposes",
+							 /* valueAddr= */ &ts_guc_debug_compression_path_info,
+							 /* bootValue= */ false,
+							 /* context= */ PGC_USERSET,
+							 /* flags= */ 0,
+							 /* check_hook= */ NULL,
+							 /* assign_hook= */ NULL,
+							 /* show_hook= */ NULL);
+
 #ifdef USE_TELEMETRY
 	DefineCustomStringVariable(/* name= */ "timescaledb_telemetry.cloud",
 							   /* short_desc= */ "cloud provider",
@@ -627,17 +640,6 @@ _guc_init(void)
 							 /* valueAddr= */ (int *) &ts_guc_debug_require_vector_qual,
 							 /* bootValue= */ RVQ_Allow,
 							 /* options = */ require_vector_qual_options,
-							 /* context= */ PGC_USERSET,
-							 /* flags= */ 0,
-							 /* check_hook= */ NULL,
-							 /* assign_hook= */ NULL,
-							 /* show_hook= */ NULL);
-
-	DefineCustomBoolVariable(/* name= */ "timescaledb.debug_compression_path_info",
-							 /* short_desc= */ "show various compression-related debug info",
-							 /* long_desc= */ "this is for debugging purposes",
-							 /* valueAddr= */ &ts_guc_debug_compression_path_info,
-							 /* bootValue= */ false,
 							 /* context= */ PGC_USERSET,
 							 /* flags= */ 0,
 							 /* check_hook= */ NULL,

--- a/tsl/test/expected/compression_settings.out
+++ b/tsl/test/expected/compression_settings.out
@@ -26,12 +26,16 @@ SELECT * FROM _timescaledb_catalog.compression_settings;
  metrics | {device}  | {time}  | {t}          | {t}
 (1 row)
 
+--Enable compression path info
+SET timescaledb.debug_compression_path_info= 'on';
 SELECT compress_chunk('_timescaledb_internal._hyper_1_1_chunk');
+INFO:  compress_chunk_tuplesort_start
              compress_chunk             
 ----------------------------------------
  _timescaledb_internal._hyper_1_1_chunk
 (1 row)
 
+RESET timescaledb.debug_compression_path_info;
 SELECT * FROM _timescaledb_catalog.compression_settings;
                      relid                      | segmentby | orderby | orderby_desc | orderby_nullsfirst 
 ------------------------------------------------+-----------+---------+--------------+--------------------

--- a/tsl/test/sql/compression_settings.sql
+++ b/tsl/test/sql/compression_settings.sql
@@ -15,7 +15,11 @@ INSERT INTO metrics VALUES ('2000-01-01'), ('2001-01-01');
 -- no change to settings
 SELECT * FROM _timescaledb_catalog.compression_settings;
 
+--Enable compression path info
+SET timescaledb.debug_compression_path_info= 'on';
 SELECT compress_chunk('_timescaledb_internal._hyper_1_1_chunk');
+RESET timescaledb.debug_compression_path_info;
+
 SELECT * FROM _timescaledb_catalog.compression_settings;
 
 SELECT compress_chunk('_timescaledb_internal._hyper_1_2_chunk');


### PR DESCRIPTION
We enabled scans using indexes for a chunk that is to be compressed. The theory was that avoding tuplesort will be a win if there's a matching index to the compression settings. However, a few customers have reported very slow compress timings with lots of disk usage. It's important to know which scan is being used for the compression in such cases to help debug the issue. There's an existing GUC parameter which was "DEBUG" only till now. Make it available in release builds as well.

Disable-check: force-changelog-file