### PR TITLE
Add isolation test for parallel compression

### DIFF
--- a/tsl/test/isolation/expected/parallel_compression.out
+++ b/tsl/test/isolation/expected/parallel_compression.out
@@ -1,0 +1,141 @@
+Parsed test spec with 2 sessions
+
+starting permutation: s1_begin s2_begin s1_compress s2_compress s2_commit s1_commit
+step s1_begin: BEGIN;
+step s2_begin: BEGIN;
+step s1_compress: 
+	SELECT compress_chunk(name) IS NOT NULL AS compress FROM (SELECT name FROM chunks_to_compress ORDER BY id LIMIT 1 OFFSET 0) ch;
+
+compress
+--------
+t       
+(1 row)
+
+step s2_compress: 
+	SELECT compress_chunk(name) IS NOT NULL AS compress FROM (SELECT name FROM chunks_to_compress ORDER BY id LIMIT 1 OFFSET 1) ch;
+
+compress
+--------
+t       
+(1 row)
+
+step s2_commit: COMMIT;
+step s1_commit: COMMIT;
+
+starting permutation: s1_begin s2_begin s1_compress s2_compress s2_decompress s1_decompress s2_commit s1_commit
+step s1_begin: BEGIN;
+step s2_begin: BEGIN;
+step s1_compress: 
+	SELECT compress_chunk(name) IS NOT NULL AS compress FROM (SELECT name FROM chunks_to_compress ORDER BY id LIMIT 1 OFFSET 0) ch;
+
+compress
+--------
+t       
+(1 row)
+
+step s2_compress: 
+	SELECT compress_chunk(name) IS NOT NULL AS compress FROM (SELECT name FROM chunks_to_compress ORDER BY id LIMIT 1 OFFSET 1) ch;
+
+compress
+--------
+t       
+(1 row)
+
+step s2_decompress: 
+	SELECT decompress_chunk(name) IS NOT NULL AS decompress  FROM (SELECT name FROM chunks_to_compress ORDER BY id LIMIT 1 OFFSET 1) ch;
+
+decompress
+----------
+t         
+(1 row)
+
+step s1_decompress: 
+	SELECT decompress_chunk(name) IS NOT NULL AS decompress FROM (SELECT name FROM chunks_to_compress ORDER BY id LIMIT 1 OFFSET 0) ch;
+
+decompress
+----------
+t         
+(1 row)
+
+step s2_commit: COMMIT;
+step s1_commit: COMMIT;
+
+starting permutation: s1_begin s2_begin s1_compress s2_compress s2_commit s2_begin s2_decompress s1_decompress s2_commit s1_commit
+step s1_begin: BEGIN;
+step s2_begin: BEGIN;
+step s1_compress: 
+	SELECT compress_chunk(name) IS NOT NULL AS compress FROM (SELECT name FROM chunks_to_compress ORDER BY id LIMIT 1 OFFSET 0) ch;
+
+compress
+--------
+t       
+(1 row)
+
+step s2_compress: 
+	SELECT compress_chunk(name) IS NOT NULL AS compress FROM (SELECT name FROM chunks_to_compress ORDER BY id LIMIT 1 OFFSET 1) ch;
+
+compress
+--------
+t       
+(1 row)
+
+step s2_commit: COMMIT;
+step s2_begin: BEGIN;
+step s2_decompress: 
+	SELECT decompress_chunk(name) IS NOT NULL AS decompress  FROM (SELECT name FROM chunks_to_compress ORDER BY id LIMIT 1 OFFSET 1) ch;
+
+decompress
+----------
+t         
+(1 row)
+
+step s1_decompress: 
+	SELECT decompress_chunk(name) IS NOT NULL AS decompress FROM (SELECT name FROM chunks_to_compress ORDER BY id LIMIT 1 OFFSET 0) ch;
+
+decompress
+----------
+t         
+(1 row)
+
+step s2_commit: COMMIT;
+step s1_commit: COMMIT;
+
+starting permutation: s1_begin s2_begin s1_compress s2_compress s1_commit s1_begin s2_decompress s1_decompress s2_commit s1_commit
+step s1_begin: BEGIN;
+step s2_begin: BEGIN;
+step s1_compress: 
+	SELECT compress_chunk(name) IS NOT NULL AS compress FROM (SELECT name FROM chunks_to_compress ORDER BY id LIMIT 1 OFFSET 0) ch;
+
+compress
+--------
+t       
+(1 row)
+
+step s2_compress: 
+	SELECT compress_chunk(name) IS NOT NULL AS compress FROM (SELECT name FROM chunks_to_compress ORDER BY id LIMIT 1 OFFSET 1) ch;
+
+compress
+--------
+t       
+(1 row)
+
+step s1_commit: COMMIT;
+step s1_begin: BEGIN;
+step s2_decompress: 
+	SELECT decompress_chunk(name) IS NOT NULL AS decompress  FROM (SELECT name FROM chunks_to_compress ORDER BY id LIMIT 1 OFFSET 1) ch;
+
+decompress
+----------
+t         
+(1 row)
+
+step s1_decompress: 
+	SELECT decompress_chunk(name) IS NOT NULL AS decompress FROM (SELECT name FROM chunks_to_compress ORDER BY id LIMIT 1 OFFSET 0) ch;
+
+decompress
+----------
+t         
+(1 row)
+
+step s2_commit: COMMIT;
+step s1_commit: COMMIT;

--- a/tsl/test/isolation/specs/CMakeLists.txt
+++ b/tsl/test/isolation/specs/CMakeLists.txt
@@ -15,6 +15,7 @@ list(
   cagg_multi_iso.spec
   cagg_concurrent_refresh.spec
   deadlock_drop_chunks_compress.spec
+  parallel_compression.spec
   osm_range_updates_iso.spec)
 
 if(PG_VERSION VERSION_GREATER_EQUAL "14.0")

--- a/tsl/test/isolation/specs/parallel_compression.spec
+++ b/tsl/test/isolation/specs/parallel_compression.spec
@@ -1,0 +1,62 @@
+# This file and its contents are licensed under the Timescale License.
+# Please see the included NOTICE for copyright information and
+# LICENSE-TIMESCALE for a copy of the license.
+
+###
+# Test parallel operations on distinct chunks of the same hypertable
+###
+
+setup
+{
+  CREATE TABLE metrics (time timestamptz not null, device text, value float);
+
+  SELECT FROM create_hypertable('metrics','time');
+  ALTER TABLE metrics SET (timescaledb.compress, timescaledb.compress_segmentby = 'device');
+
+  INSERT INTO metrics SELECT '2000-01-01', 'device1', random() FROM generate_series(1,20000);
+  INSERT INTO metrics SELECT '2001-01-01', 'device2', random() FROM generate_series(1,20000);
+
+  CREATE VIEW chunks_to_compress AS SELECT ch.id, format('%I.%I',ch.schema_name,ch.table_name) AS name from _timescaledb_catalog.chunk ch INNER JOIN _timescaledb_catalog.hypertable ht ON ht.id=ch.hypertable_id AND ht.table_name='metrics' ORDER BY ch.id;
+
+}
+
+teardown {
+	DROP TABLE metrics;
+	DROP VIEW chunks_to_compress;
+}
+
+session "s1"
+setup	{
+	SET LOCAL lock_timeout = '500ms';
+	SET LOCAL deadlock_timeout = '300ms';
+}
+
+step "s1_begin"	{ BEGIN; }
+step "s1_compress"	 {
+	SELECT compress_chunk(name) IS NOT NULL AS compress FROM (SELECT name FROM chunks_to_compress ORDER BY id LIMIT 1 OFFSET 0) ch;
+}
+step "s1_decompress"	 {
+	SELECT decompress_chunk(name) IS NOT NULL AS decompress FROM (SELECT name FROM chunks_to_compress ORDER BY id LIMIT 1 OFFSET 0) ch;
+}
+step "s1_commit" { COMMIT; }
+
+session "s2"
+setup	{
+	SET LOCAL lock_timeout = '500ms';
+	SET LOCAL deadlock_timeout = '300ms';
+}
+
+step "s2_begin"	{ BEGIN; }
+step "s2_commit"   { COMMIT; }
+step "s2_compress" {
+	SELECT compress_chunk(name) IS NOT NULL AS compress FROM (SELECT name FROM chunks_to_compress ORDER BY id LIMIT 1 OFFSET 1) ch;
+}
+step "s2_decompress" {
+	SELECT decompress_chunk(name) IS NOT NULL AS decompress  FROM (SELECT name FROM chunks_to_compress ORDER BY id LIMIT 1 OFFSET 1) ch;
+}
+
+permutation s1_begin s2_begin s1_compress s2_compress s2_commit s1_commit
+permutation s1_begin s2_begin s1_compress s2_compress s2_decompress s1_decompress s2_commit s1_commit
+permutation s1_begin s2_begin s1_compress s2_compress s2_commit s2_begin s2_decompress s1_decompress s2_commit s1_commit
+permutation s1_begin s2_begin s1_compress s2_compress s1_commit s1_begin s2_decompress s1_decompress s2_commit s1_commit
+


### PR DESCRIPTION
The changes for per chunk compression settings got rid of some locking that previously prevented compressing different chunks of the same hypertable. This patch just adds an isolation test for that functionality.