### PR TITLE
Don't dump unnecessary extension tables

### DIFF
--- a/sql/pre_install/cache.sql
+++ b/sql/pre_install/cache.sql
@@ -18,10 +18,5 @@ CREATE TABLE _timescaledb_cache.cache_inval_bgw_job();
 -- etc.
 CREATE TABLE _timescaledb_cache.cache_inval_extension();
 
--- not actually strictly needed but good for sanity as all tables should be dumped.
-SELECT pg_catalog.pg_extension_config_dump('_timescaledb_cache.cache_inval_hypertable', '');
-SELECT pg_catalog.pg_extension_config_dump('_timescaledb_cache.cache_inval_extension', '');
-SELECT pg_catalog.pg_extension_config_dump('_timescaledb_cache.cache_inval_bgw_job', '');
-
 GRANT SELECT ON ALL TABLES IN SCHEMA _timescaledb_cache TO PUBLIC;
 

--- a/sql/pre_install/tables.sql
+++ b/sql/pre_install/tables.sql
@@ -66,7 +66,7 @@ CREATE TABLE _timescaledb_catalog.hypertable (
 ALTER SEQUENCE _timescaledb_catalog.hypertable_id_seq OWNED BY _timescaledb_catalog.hypertable.id;
 SELECT pg_catalog.pg_extension_config_dump('_timescaledb_catalog.hypertable_id_seq', '');
 
-SELECT pg_catalog.pg_extension_config_dump('_timescaledb_catalog.hypertable', '');
+SELECT pg_catalog.pg_extension_config_dump('_timescaledb_catalog.hypertable', 'WHERE id >= 1');
 
 -- The tablespace table maps tablespaces to hypertables.
 -- This allows spreading a hypertable's chunks across multiple disks.
@@ -481,8 +481,6 @@ CREATE TABLE _timescaledb_internal.job_errors (
   finish_time timestamptz,
   error_data jsonb
 );
-
-SELECT pg_catalog.pg_extension_config_dump('_timescaledb_internal.job_errors', '');
 
 -- Set table permissions
 -- We need to grant SELECT to PUBLIC for all tables even those not

--- a/sql/updates/latest-dev.sql
+++ b/sql/updates/latest-dev.sql
@@ -286,7 +286,6 @@ WHERE EXISTS (
 );
 
 ALTER SEQUENCE _timescaledb_catalog.hypertable_id_seq OWNED BY _timescaledb_catalog.hypertable.id;
-SELECT pg_catalog.pg_extension_config_dump('_timescaledb_catalog.hypertable', 'WHERE id >= 1');
 SELECT pg_catalog.pg_extension_config_dump('_timescaledb_catalog.hypertable_id_seq', '');
 
 GRANT SELECT ON _timescaledb_catalog.hypertable TO PUBLIC;
@@ -412,3 +411,19 @@ CREATE TRIGGER metadata_insert_trigger BEFORE INSERT ON _timescaledb_catalog.met
 
 SELECT pg_catalog.pg_extension_config_dump('_timescaledb_catalog.metadata', $$ WHERE key <> 'uuid' $$);
 
+-- Remove unwanted entries from extconfig and extcondition in pg_extension
+-- We use ALTER EXTENSION DROP TABLE to remove these entries.
+ALTER EXTENSION timescaledb DROP TABLE _timescaledb_cache.cache_inval_hypertable;
+ALTER EXTENSION timescaledb DROP TABLE _timescaledb_cache.cache_inval_extension;
+ALTER EXTENSION timescaledb DROP TABLE _timescaledb_cache.cache_inval_bgw_job;
+ALTER EXTENSION timescaledb DROP TABLE _timescaledb_internal.job_errors;
+
+-- Associate the above tables back to keep the dependencies safe
+ALTER EXTENSION timescaledb ADD TABLE _timescaledb_cache.cache_inval_hypertable;
+ALTER EXTENSION timescaledb ADD TABLE _timescaledb_cache.cache_inval_extension;
+ALTER EXTENSION timescaledb ADD TABLE _timescaledb_cache.cache_inval_bgw_job;
+ALTER EXTENSION timescaledb ADD TABLE _timescaledb_internal.job_errors;
+
+ALTER EXTENSION timescaledb DROP TABLE _timescaledb_catalog.hypertable;
+ALTER EXTENSION timescaledb ADD TABLE _timescaledb_catalog.hypertable;
+SELECT pg_catalog.pg_extension_config_dump('_timescaledb_catalog.hypertable', 'WHERE id >= 1');

--- a/sql/updates/reverse-dev.sql
+++ b/sql/updates/reverse-dev.sql
@@ -711,7 +711,6 @@ FROM
 ORDER BY id;
 
 ALTER SEQUENCE _timescaledb_catalog.hypertable_id_seq OWNED BY _timescaledb_catalog.hypertable.id;
-SELECT pg_catalog.pg_extension_config_dump('_timescaledb_catalog.hypertable', 'WHERE id >= 1');
 SELECT pg_catalog.pg_extension_config_dump('_timescaledb_catalog.hypertable_id_seq', '');
 
 GRANT SELECT ON _timescaledb_catalog.hypertable TO PUBLIC;
@@ -768,10 +767,24 @@ CREATE FUNCTION _timescaledb_functions.hypertable_constraint_add_table_fk_constr
 CREATE FUNCTION _timescaledb_functions.chunks_in(record RECORD, chunks INTEGER[]) RETURNS BOOL
 AS 'BEGIN END' LANGUAGE PLPGSQL SET search_path TO pg_catalog,pg_temp;
 
-SELECT pg_catalog.pg_extension_config_dump('_timescaledb_catalog.metadata', $$ WHERE KEY = 'exported_uuid' $$);
+SELECT pg_catalog.pg_extension_config_dump('_timescaledb_catalog.metadata', $$
+  WHERE KEY = 'exported_uuid' $$);
 
 DROP TRIGGER metadata_insert_trigger ON _timescaledb_catalog.metadata;
 DROP FUNCTION _timescaledb_functions.metadata_insert_trigger();
 
 DROP FUNCTION IF EXISTS _timescaledb_functions.get_orderby_defaults(regclass,text[]);
 DROP FUNCTION IF EXISTS _timescaledb_functions.get_segmentby_defaults(regclass);
+
+--- re-include in the pg_dump config
+SELECT pg_catalog.pg_extension_config_dump('_timescaledb_cache.cache_inval_hypertable', '');
+SELECT pg_catalog.pg_extension_config_dump('_timescaledb_cache.cache_inval_extension', '');
+SELECT pg_catalog.pg_extension_config_dump('_timescaledb_cache.cache_inval_bgw_job', '');
+SELECT pg_catalog.pg_extension_config_dump('_timescaledb_internal.job_errors', '');
+
+-- Remove unwanted entry from extconfig and extcondition in pg_extension
+ALTER EXTENSION timescaledb DROP TABLE _timescaledb_catalog.hypertable;
+-- Associate the above table back to keep the dependencies safe
+ALTER EXTENSION timescaledb ADD TABLE _timescaledb_catalog.hypertable;
+-- include this now in the config
+SELECT pg_catalog.pg_extension_config_dump('_timescaledb_catalog.hypertable', '');

--- a/test/expected/pg_dump.out
+++ b/test/expected/pg_dump.out
@@ -546,7 +546,8 @@ SELECT * FROM ONLY "test_schema"."two_Partitions";
 ------------+-----------+----------+----------+----------+-------------+----------
 (0 rows)
 
---query for the extension tables/sequences that will not be dumped by pg_dump (should be empty except for views)
+--query for the extension tables/sequences that will not be dumped by pg_dump (should
+--be empty except for views and explicitly excluded tables)
 SELECT objid::regclass
 FROM pg_catalog.pg_depend
 WHERE   refclassid = 'pg_catalog.pg_extension'::pg_catalog.regclass AND
@@ -557,6 +558,9 @@ WHERE   refclassid = 'pg_catalog.pg_extension'::pg_catalog.regclass AND
         ORDER BY objid::regclass::text COLLATE "C";
                        objid                       
 ---------------------------------------------------
+ _timescaledb_cache.cache_inval_bgw_job
+ _timescaledb_cache.cache_inval_extension
+ _timescaledb_cache.cache_inval_hypertable
  _timescaledb_catalog.compression_algorithm
  _timescaledb_catalog.tablespace_id_seq
  _timescaledb_catalog.telemetry_event
@@ -564,6 +568,7 @@ WHERE   refclassid = 'pg_catalog.pg_extension'::pg_catalog.regclass AND
  _timescaledb_internal.bgw_policy_chunk_stats
  _timescaledb_internal.compressed_chunk_stats
  _timescaledb_internal.hypertable_chunk_local_size
+ _timescaledb_internal.job_errors
  timescaledb_experimental.policies
  timescaledb_information.chunks
  timescaledb_information.compression_settings
@@ -573,7 +578,7 @@ WHERE   refclassid = 'pg_catalog.pg_extension'::pg_catalog.regclass AND
  timescaledb_information.job_errors
  timescaledb_information.job_stats
  timescaledb_information.jobs
-(16 rows)
+(20 rows)
 
 -- Make sure we can't run our restoring functions as a normal perm user as that would disable functionality for the whole db
 \c :TEST_DBNAME :ROLE_DEFAULT_PERM_USER

--- a/test/expected/pg_dump_unprivileged.out
+++ b/test/expected/pg_dump_unprivileged.out
@@ -9,6 +9,15 @@ CREATE USER dump_unprivileged CREATEDB;
 \c template1 dump_unprivileged
 CREATE database dump_unprivileged;
 \! utils/pg_dump_unprivileged.sh
+\c dump_unprivileged :ROLE_SUPERUSER
+DROP EXTENSION timescaledb;
+GRANT ALL ON DATABASE dump_unprivileged TO dump_unprivileged;
+\c dump_unprivileged dump_unprivileged
+-- Create the timescale extension and table as underprivileged user
+CREATE EXTENSION timescaledb;
+CREATE TABLE t1 (a int);
+-- pg_dump currently fails when dumped
+\! utils/pg_dump_unprivileged.sh
 \c template1 :ROLE_SUPERUSER
 DROP EXTENSION timescaledb;
 DROP DATABASE dump_unprivileged WITH (FORCE);

--- a/test/sql/pg_dump.sql
+++ b/test/sql/pg_dump.sql
@@ -164,7 +164,8 @@ INSERT INTO "test_schema"."two_Partitions"("timeCustom", device_id, series_0, se
 
 SELECT * FROM ONLY "test_schema"."two_Partitions";
 
---query for the extension tables/sequences that will not be dumped by pg_dump (should be empty except for views)
+--query for the extension tables/sequences that will not be dumped by pg_dump (should
+--be empty except for views and explicitly excluded tables)
 SELECT objid::regclass
 FROM pg_catalog.pg_depend
 WHERE   refclassid = 'pg_catalog.pg_extension'::pg_catalog.regclass AND

--- a/test/sql/pg_dump_unprivileged.sql
+++ b/test/sql/pg_dump_unprivileged.sql
@@ -15,6 +15,16 @@ CREATE database dump_unprivileged;
 
 \! utils/pg_dump_unprivileged.sh
 
+\c dump_unprivileged :ROLE_SUPERUSER
+DROP EXTENSION timescaledb;
+GRANT ALL ON DATABASE dump_unprivileged TO dump_unprivileged;
+\c dump_unprivileged dump_unprivileged
+-- Create the timescale extension and table as underprivileged user
+CREATE EXTENSION timescaledb;
+CREATE TABLE t1 (a int);
+-- pg_dump currently fails when dumped
+\! utils/pg_dump_unprivileged.sh
+
 \c template1 :ROLE_SUPERUSER
 DROP EXTENSION timescaledb;
 DROP DATABASE dump_unprivileged WITH (FORCE);

--- a/test/sql/updates/post.catalog.sql
+++ b/test/sql/updates/post.catalog.sql
@@ -43,7 +43,7 @@ SELECT count(*)
      AND refobjid = (SELECT oid FROM pg_extension WHERE extname = 'timescaledb');
 
 -- The list of tables configured to be dumped.
-SELECT unnest(extconfig)::regclass::text AS obj FROM pg_extension WHERE extname='timescaledb' ORDER BY 1;
+SELECT unnest(extconfig)::regclass::text, unnest(extcondition) FROM pg_extension WHERE extname = 'timescaledb' ORDER BY 1;
 
 -- Show dropped chunks
 SELECT id, hypertable_id, schema_name, table_name, dropped


### PR DESCRIPTION
Logging and caching related tables from the timescaledb extension should not be dumped using pg_dump. Our scripts specify a few such unwanted tables. Apart from being unnecessary, the "job_errors" had some restricted permissions causing additional problems in pg_dump.

We now don't include such tables for dumping.

Fixes #5449

Disable-check: force-changelog-file