### PR TITLE
Vectorize more arithmetic functions

### DIFF
--- a/tsl/src/nodes/decompress_chunk/pred_vector_const_arithmetic_all.c
+++ b/tsl/src/nodes/decompress_chunk/pred_vector_const_arithmetic_all.c
@@ -37,27 +37,19 @@
 
 #include "pred_vector_const_arithmetic_type_pair.c"
 
-/* int4 functions. */
-#define VECTOR_CTYPE int32
-#define CONST_CTYPE int32
-#define CONST_CONVERSION(X) DatumGetInt32(X)
-#define PG_PREDICATE(X) F_INT4##X
-
-#include "pred_vector_const_arithmetic_type_pair.c"
-
-/* int24 functions. */
-#define VECTOR_CTYPE int16
-#define CONST_CTYPE int32
-#define CONST_CONVERSION(X) DatumGetInt32(X)
-#define PG_PREDICATE(X) F_INT24##X
-
-#include "pred_vector_const_arithmetic_type_pair.c"
-
 /* int84 functions. */
 #define VECTOR_CTYPE int64
 #define CONST_CTYPE int32
 #define CONST_CONVERSION(X) DatumGetInt32(X)
 #define PG_PREDICATE(X) F_INT84##X
+
+#include "pred_vector_const_arithmetic_type_pair.c"
+
+/* int82 functions. */
+#define VECTOR_CTYPE int64
+#define CONST_CTYPE int16
+#define CONST_CONVERSION(X) DatumGetInt16(X)
+#define PG_PREDICATE(X) F_INT82##X
 
 #include "pred_vector_const_arithmetic_type_pair.c"
 
@@ -69,11 +61,66 @@
 
 #include "pred_vector_const_arithmetic_type_pair.c"
 
+/* int4 functions. */
+#define VECTOR_CTYPE int32
+#define CONST_CTYPE int32
+#define CONST_CONVERSION(X) DatumGetInt32(X)
+#define PG_PREDICATE(X) F_INT4##X
+
+#include "pred_vector_const_arithmetic_type_pair.c"
+
+/* int42 functions. */
+#define VECTOR_CTYPE int32
+#define CONST_CTYPE int16
+#define CONST_CONVERSION(X) DatumGetInt16(X)
+#define PG_PREDICATE(X) F_INT42##X
+
+#include "pred_vector_const_arithmetic_type_pair.c"
+
+/* int28 functions. */
+#define VECTOR_CTYPE int16
+#define CONST_CTYPE int64
+#define CONST_CONVERSION(X) DatumGetInt64(X)
+#define PG_PREDICATE(X) F_INT28##X
+
+#include "pred_vector_const_arithmetic_type_pair.c"
+
+/* int24 functions. */
+#define VECTOR_CTYPE int16
+#define CONST_CTYPE int32
+#define CONST_CONVERSION(X) DatumGetInt32(X)
+#define PG_PREDICATE(X) F_INT24##X
+
+#include "pred_vector_const_arithmetic_type_pair.c"
+/* int2 functions. */
+#define VECTOR_CTYPE int16
+#define CONST_CTYPE int16
+#define CONST_CONVERSION(X) DatumGetInt16(X)
+#define PG_PREDICATE(X) F_INT2##X
+
+#include "pred_vector_const_arithmetic_type_pair.c"
+
 /* float8 functions. */
 #define VECTOR_CTYPE float8
 #define CONST_CTYPE float8
 #define CONST_CONVERSION(X) DatumGetFloat8(X)
 #define PG_PREDICATE(X) F_FLOAT8##X
+
+#include "pred_vector_const_arithmetic_type_pair.c"
+
+/* float84 functions. */
+#define VECTOR_CTYPE float8
+#define CONST_CTYPE float4
+#define CONST_CONVERSION(X) DatumGetFloat4(X)
+#define PG_PREDICATE(X) F_FLOAT84##X
+
+#include "pred_vector_const_arithmetic_type_pair.c"
+
+/* float48 functions. */
+#define VECTOR_CTYPE float4
+#define CONST_CTYPE float8
+#define CONST_CONVERSION(X) DatumGetFloat8(X)
+#define PG_PREDICATE(X) F_FLOAT48##X
 
 #include "pred_vector_const_arithmetic_type_pair.c"
 

--- a/tsl/test/expected/decompress_vector_qual.out
+++ b/tsl/test/expected/decompress_vector_qual.out
@@ -108,6 +108,38 @@ select count(*) from vectorqual where device = 1 /* can't apply vector ops to th
      1
 (1 row)
 
+-- Test various combinations of arithmetic types.
+create table arithmetic(ts int, a int2, b int4, c int8, d float4, e float8,
+    ax int2, bx int4, cx int8, dx float4, ex float8);
+select create_hypertable('arithmetic', 'ts');
+NOTICE:  adding not-null constraint to column "ts"
+    create_hypertable    
+-------------------------
+ (3,public,arithmetic,t)
+(1 row)
+
+alter table arithmetic set (timescaledb.compress);
+insert into arithmetic values (100, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1),
+    (101, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11);
+select count(compress_chunk(x, true)) from show_chunks('arithmetic') x;
+ count 
+-------
+     1
+(1 row)
+
+set timescaledb.debug_require_vector_qual to 'only';
+select * from arithmetic where
+        a > 1::int2 and a > 1::int4 and a > 1::int8
+    and b > 1::int2 and b > 1::int4 and b > 1::int8
+    and c > 1::int2 and c > 1::int4 and c > 1::int8
+    and d > 1::int2 and d > 1::int4 and d > 1::int8 and d > 1::float4 and d > 1::float8
+    and e > 1::int2 and e > 1::int4 and e > 1::int8 and e > 1::float4 and e > 1::float8
+;
+ ts  | a | b | c | d | e | ax | bx | cx | dx | ex 
+-----+---+---+---+---+---+----+----+----+----+----
+ 101 | 2 | 3 | 4 | 5 | 6 |  7 |  8 |  9 | 10 | 11
+(1 row)
+
 -- Test columns that don't support bulk decompression.
 alter table vectorqual add column tag text;
 insert into vectorqual(ts, device, metric2, metric3, metric4, tag) values ('2025-01-01 00:00:00', 5, 52, 53, 54, 'tag5');
@@ -376,7 +408,7 @@ select create_hypertable('singlebatch', 'ts');
 WARNING:  column type "timestamp without time zone" used for "ts" does not follow best practices
     create_hypertable     
 --------------------------
- (3,public,singlebatch,t)
+ (5,public,singlebatch,t)
 (1 row)
 
 alter table singlebatch set (timescaledb.compress);
@@ -695,7 +727,7 @@ select create_hypertable('date_table', 'ts');
 NOTICE:  adding not-null constraint to column "ts"
     create_hypertable    
 -------------------------
- (5,public,date_table,t)
+ (7,public,date_table,t)
 (1 row)
 
 alter table date_table set (timescaledb.compress);

--- a/tsl/test/sql/decompress_vector_qual.sql
+++ b/tsl/test/sql/decompress_vector_qual.sql
@@ -38,6 +38,24 @@ set timescaledb.debug_require_vector_qual to 'forbid';
 select count(*) from vectorqual where device = 1 /* can't apply vector ops to the segmentby column */;
 
 
+-- Test various combinations of arithmetic types.
+create table arithmetic(ts int, a int2, b int4, c int8, d float4, e float8,
+    ax int2, bx int4, cx int8, dx float4, ex float8);
+select create_hypertable('arithmetic', 'ts');
+alter table arithmetic set (timescaledb.compress);
+insert into arithmetic values (100, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1),
+    (101, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11);
+select count(compress_chunk(x, true)) from show_chunks('arithmetic') x;
+set timescaledb.debug_require_vector_qual to 'only';
+select * from arithmetic where
+        a > 1::int2 and a > 1::int4 and a > 1::int8
+    and b > 1::int2 and b > 1::int4 and b > 1::int8
+    and c > 1::int2 and c > 1::int4 and c > 1::int8
+    and d > 1::int2 and d > 1::int4 and d > 1::int8 and d > 1::float4 and d > 1::float8
+    and e > 1::int2 and e > 1::int4 and e > 1::int8 and e > 1::float4 and e > 1::float8
+;
+
+
 -- Test columns that don't support bulk decompression.
 alter table vectorqual add column tag text;
 insert into vectorqual(ts, device, metric2, metric3, metric4, tag) values ('2025-01-01 00:00:00', 5, 52, 53, 54, 'tag5');


### PR DESCRIPTION
We didn't account for some permutations of types like comparing int4 to int2.

Disable-check: force-changelog-file