### PR TITLE
Remove restrictions for changing compression settings

### DIFF
--- a/.unreleased/pr_6545
+++ b/.unreleased/pr_6545
@@ -1,0 +1,1 @@
+Implements: #6545 Remove restrictions for changing compression settings

--- a/src/compression_with_clause.c
+++ b/src/compression_with_clause.c
@@ -5,19 +5,21 @@
  */
 
 #include <postgres.h>
-#include <fmgr.h>
 #include <access/htup_details.h>
 #include <catalog/dependency.h>
 #include <catalog/namespace.h>
-#include <catalog/pg_type.h>
 #include <catalog/pg_trigger.h>
+#include <catalog/pg_type.h>
 #include <commands/trigger.h>
+#include <fmgr.h>
+#include <parser/parser.h>
 #include <storage/lmgr.h>
 #include <utils/builtins.h>
 #include <utils/lsyscache.h>
-#include <parser/parser.h>
+#include <utils/typcache.h>
 
 #include "compat/compat.h"
+#include "ts_catalog/array_utils.h"
 
 #include "compression_with_clause.h"
 
@@ -73,7 +75,7 @@ select_stmt_as_expected(SelectStmt *stmt)
 	return true;
 }
 
-static List *
+static ArrayType *
 parse_segment_collist(char *inpstr, Hypertable *hypertable)
 {
 	StringInfoData buf;
@@ -83,7 +85,7 @@ parse_segment_collist(char *inpstr, Hypertable *hypertable)
 	RawStmt *raw;
 
 	if (strlen(inpstr) == 0)
-		return NIL;
+		return NULL;
 
 	initStringInfo(&buf);
 
@@ -121,7 +123,7 @@ parse_segment_collist(char *inpstr, Hypertable *hypertable)
 	if (select->sortClause != NIL)
 		throw_segment_by_error(inpstr);
 
-	List *collist = NIL;
+	ArrayType *segmentby = NULL;
 	foreach (lc, select->groupClause)
 	{
 		if (!IsA(lfirst(lc), ColumnRef))
@@ -134,10 +136,32 @@ parse_segment_collist(char *inpstr, Hypertable *hypertable)
 		if (!IsA(linitial(cf->fields), String))
 			throw_segment_by_error(inpstr);
 
-		collist = lappend(collist, pstrdup(strVal(linitial(cf->fields))));
+		char *colname = strVal(linitial(cf->fields));
+		AttrNumber col_attno = get_attnum(hypertable->main_table_relid, colname);
+		if (col_attno == InvalidAttrNumber)
+		{
+			ereport(ERROR,
+					(errcode(ERRCODE_SYNTAX_ERROR),
+					 errmsg("column \"%s\" does not exist", colname),
+					 errhint("The timescaledb.compress_segmentby option must reference a valid "
+							 "column.")));
+		}
+
+		/* get normalized column name */
+		colname = get_attname(hypertable->main_table_relid, col_attno, false);
+
+		/* check if segmentby columns are distinct. */
+		if (ts_array_is_member(segmentby, colname))
+			ereport(ERROR,
+					(errcode(ERRCODE_SYNTAX_ERROR),
+					 errmsg("duplicate column name \"%s\"", colname),
+					 errhint("The timescaledb.compress_segmentby option must reference distinct "
+							 "column.")));
+
+		segmentby = ts_array_add_element_text(segmentby, pstrdup(colname));
 	}
 
-	return collist;
+	return segmentby;
 }
 
 static inline void
@@ -152,7 +176,7 @@ throw_order_by_error(char *order_by)
 }
 
 /* compress_orderby is parsed same as order by in select queries */
-static List *
+static OrderBySettings
 parse_order_collist(char *inpstr, Hypertable *hypertable)
 {
 	StringInfoData buf;
@@ -160,9 +184,10 @@ parse_order_collist(char *inpstr, Hypertable *hypertable)
 	ListCell *lc;
 	SelectStmt *select;
 	RawStmt *raw;
+	OrderBySettings settings = { 0 };
 
 	if (strlen(inpstr) == 0)
-		return NIL;
+		return settings;
 
 	initStringInfo(&buf);
 
@@ -199,12 +224,12 @@ parse_order_collist(char *inpstr, Hypertable *hypertable)
 	if (select->groupClause != NIL)
 		throw_order_by_error(inpstr);
 
-	List *collist = NIL;
 	foreach (lc, select->sortClause)
 	{
 		SortBy *sort_by;
 		ColumnRef *cf;
 		CompressedParsedCol *col = (CompressedParsedCol *) palloc(sizeof(*col));
+		bool desc, nullsfirst;
 
 		if (!IsA(lfirst(lc), SortBy))
 			throw_order_by_error(inpstr);
@@ -221,32 +246,65 @@ parse_order_collist(char *inpstr, Hypertable *hypertable)
 			throw_order_by_error(inpstr);
 
 		namestrcpy(&col->colname, strVal(linitial(cf->fields)));
+		char *colname = strVal(linitial(cf->fields));
+
+		AttrNumber col_attno = get_attnum(hypertable->main_table_relid, colname);
+		if (col_attno == InvalidAttrNumber)
+			ereport(ERROR,
+					(errcode(ERRCODE_SYNTAX_ERROR),
+					 errmsg("column \"%s\" does not exist", NameStr(col->colname)),
+					 errhint("The timescaledb.compress_orderby option must reference a valid "
+							 "column.")));
+
+		Oid col_type = get_atttype(hypertable->main_table_relid, col_attno);
+		TypeCacheEntry *type = lookup_type_cache(col_type, TYPECACHE_LT_OPR);
+
+		if (!OidIsValid(type->lt_opr))
+			ereport(ERROR,
+					(errcode(ERRCODE_UNDEFINED_FUNCTION),
+					 errmsg("invalid ordering column type %s", format_type_be(col_type)),
+					 errdetail("Could not identify a less-than operator for the type.")));
+
+		/* get normalized column name */
+		colname = get_attname(hypertable->main_table_relid, col_attno, false);
+
+		/* check if orderby columns are distinct. */
+		if (ts_array_is_member(settings.orderby, colname))
+			ereport(ERROR,
+					(errcode(ERRCODE_SYNTAX_ERROR),
+					 errmsg("duplicate column name \"%s\"", colname),
+					 errhint("The timescaledb.compress_orderby option must reference distinct "
+							 "column.")));
 
 		if (sort_by->sortby_dir != SORTBY_ASC && sort_by->sortby_dir != SORTBY_DESC &&
 			sort_by->sortby_dir != SORTBY_DEFAULT)
 			throw_order_by_error(inpstr);
-		col->desc = sort_by->sortby_dir == SORTBY_DESC;
+
+		desc = sort_by->sortby_dir == SORTBY_DESC;
 
 		if (sort_by->sortby_nulls == SORTBY_NULLS_DEFAULT)
 		{
 			/* default null ordering is LAST for ASC, FIRST for DESC */
-			col->nullsfirst = col->desc;
+			nullsfirst = desc;
 		}
 		else
 		{
-			col->nullsfirst = sort_by->sortby_nulls == SORTBY_NULLS_FIRST;
+			nullsfirst = sort_by->sortby_nulls == SORTBY_NULLS_FIRST;
 		}
 
-		collist = lappend(collist, (void *) col);
+		settings.orderby = ts_array_add_element_text(settings.orderby, pstrdup(colname));
+		settings.orderby_desc = ts_array_add_element_bool(settings.orderby_desc, desc);
+		settings.orderby_nullsfirst =
+			ts_array_add_element_bool(settings.orderby_nullsfirst, nullsfirst);
 	}
 
-	return collist;
+	return settings;
 }
 
 /* returns List of CompressedParsedCol
  * compress_segmentby = `col1,col2,col3`
  */
-List *
+ArrayType *
 ts_compress_hypertable_parse_segment_by(WithClauseResult *parsed_options, Hypertable *hypertable)
 {
 	if (parsed_options[CompressSegmentBy].is_default == false)
@@ -255,13 +313,13 @@ ts_compress_hypertable_parse_segment_by(WithClauseResult *parsed_options, Hypert
 		return parse_segment_collist(TextDatumGetCString(textarg), hypertable);
 	}
 	else
-		return NIL;
+		return NULL;
 }
 
 /* returns List of CompressedParsedCol
  * E.g. timescaledb.compress_orderby = 'col1 asc nulls first,col2 desc,col3'
  */
-List *
+OrderBySettings
 ts_compress_hypertable_parse_order_by(WithClauseResult *parsed_options, Hypertable *hypertable)
 {
 	if (parsed_options[CompressOrderBy].is_default == false)
@@ -270,7 +328,7 @@ ts_compress_hypertable_parse_order_by(WithClauseResult *parsed_options, Hypertab
 		return parse_order_collist(TextDatumGetCString(textarg), hypertable);
 	}
 	else
-		return NIL;
+		return (OrderBySettings){ 0 };
 }
 
 /* returns List of CompressedParsedCol

--- a/src/compression_with_clause.h
+++ b/src/compression_with_clause.h
@@ -29,11 +29,18 @@ typedef struct
 	bool desc;
 } CompressedParsedCol;
 
+typedef struct
+{
+	ArrayType *orderby;
+	ArrayType *orderby_desc;
+	ArrayType *orderby_nullsfirst;
+} OrderBySettings;
+
 extern TSDLLEXPORT WithClauseResult *ts_compress_hypertable_set_clause_parse(const List *defelems);
-extern TSDLLEXPORT List *ts_compress_hypertable_parse_segment_by(WithClauseResult *parsed_options,
-																 Hypertable *hypertable);
-extern TSDLLEXPORT List *ts_compress_hypertable_parse_order_by(WithClauseResult *parsed_options,
-															   Hypertable *hypertable);
+extern TSDLLEXPORT ArrayType *
+ts_compress_hypertable_parse_segment_by(WithClauseResult *parsed_options, Hypertable *hypertable);
+extern TSDLLEXPORT OrderBySettings
+ts_compress_hypertable_parse_order_by(WithClauseResult *parsed_options, Hypertable *hypertable);
 extern TSDLLEXPORT Interval *
 ts_compress_hypertable_parse_chunk_time_interval(WithClauseResult *parsed_options,
 												 Hypertable *hypertable);

--- a/src/hypertable.c
+++ b/src/hypertable.c
@@ -2214,7 +2214,6 @@ bool
 ts_hypertable_set_compress_interval(Hypertable *ht, int64 compress_interval)
 {
 	Assert(!TS_HYPERTABLE_IS_INTERNAL_COMPRESSION_TABLE(ht));
-	Assert(TS_HYPERTABLE_HAS_COMPRESSION_ENABLED(ht));
 
 	Dimension *time_dimension =
 		ts_hyperspace_get_mutable_dimension(ht->space, DIMENSION_TYPE_OPEN, 0);

--- a/src/process_utility.c
+++ b/src/process_utility.c
@@ -3969,19 +3969,8 @@ process_altertable_set_options(AlterTableCmd *cmd, Hypertable *ht)
 	Assert(IsA(cmd->def, List));
 	inpdef = (List *) cmd->def;
 	ts_with_clause_filter(inpdef, &compress_options, &pg_options);
-	if (compress_options)
-	{
-		parse_results = ts_compress_hypertable_set_clause_parse(compress_options);
-		/* We allow updating compress chunk time interval independently of other compression
-		 * options. */
-		if (parse_results[CompressEnabled].is_default &&
-			parse_results[CompressChunkTimeInterval].is_default)
-			ereport(ERROR,
-					(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
-					 errmsg("the option timescaledb.compress must be set to true to enable "
-							"compression")));
-	}
-	else
+
+	if (!compress_options)
 		return DDL_CONTINUE;
 
 	if (pg_options != NIL)
@@ -3989,6 +3978,9 @@ process_altertable_set_options(AlterTableCmd *cmd, Hypertable *ht)
 				(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
 				 errmsg("only timescaledb.compress parameters allowed when specifying compression "
 						"parameters for hypertable")));
+
+	parse_results = ts_compress_hypertable_set_clause_parse(compress_options);
+
 	ts_cm_functions->process_compress_table(cmd, ht, parse_results);
 	return DDL_DONE;
 }

--- a/tsl/src/compression/api.c
+++ b/tsl/src/compression/api.c
@@ -576,6 +576,11 @@ decompress_chunk_impl(Oid uncompressed_hypertable_relid, Oid uncompressed_chunk_
 
 	ts_hypertable_permissions_check(uncompressed_hypertable->main_table_relid, GetUserId());
 
+	if (TS_HYPERTABLE_IS_INTERNAL_COMPRESSION_TABLE(uncompressed_hypertable))
+		ereport(ERROR,
+				(errcode(ERRCODE_INTERNAL_ERROR),
+				 errmsg("decompress_chunk must not be called on the internal compressed chunk")));
+
 	compressed_hypertable =
 		ts_hypertable_get_by_id(uncompressed_hypertable->fd.compressed_hypertable_id);
 	if (compressed_hypertable == NULL)

--- a/tsl/src/compression/compression_storage.c
+++ b/tsl/src/compression/compression_storage.c
@@ -66,6 +66,8 @@ compression_hypertable_create(Hypertable *ht, Oid owner, Oid tablespace_oid)
 	RangeVar *compress_rel;
 	int32 compress_hypertable_id;
 
+	Assert(!TS_HYPERTABLE_HAS_COMPRESSION_TABLE(ht));
+
 	create = makeNode(CreateStmt);
 	create->tableElts = NIL;
 	create->inhRelations = NIL;

--- a/tsl/src/compression/create.c
+++ b/tsl/src/compression/create.c
@@ -50,6 +50,8 @@
 static void validate_hypertable_for_compression(Hypertable *ht);
 static List *build_columndefs(CompressionSettings *settings, Oid src_relid);
 static ColumnDef *build_columndef_singlecolumn(const char *colname, Oid typid);
+static void compression_settings_update(Hypertable *ht, CompressionSettings *settings,
+										WithClauseResult *with_clause_options);
 
 static char *
 compression_column_segment_metadata_name(int16 column_index, const char *type)
@@ -80,88 +82,6 @@ column_segment_max_name(int16 column_index)
 {
 	return compression_column_segment_metadata_name(column_index,
 													COMPRESSION_COLUMN_METADATA_MAX_COLUMN_NAME);
-}
-
-static void
-check_segmentby(Oid relid, List *segmentby_cols)
-{
-	ListCell *lc;
-	ArrayType *segmentby = NULL;
-
-	foreach (lc, segmentby_cols)
-	{
-		char *colname = lfirst(lc);
-		AttrNumber col_attno = get_attnum(relid, colname);
-		if (col_attno == InvalidAttrNumber)
-		{
-			ereport(ERROR,
-					(errcode(ERRCODE_SYNTAX_ERROR),
-					 errmsg("column \"%s\" does not exist", colname),
-					 errhint("The timescaledb.compress_segmentby option must reference a valid "
-							 "column.")));
-		}
-
-		const char *col_attname = get_attname(relid, col_attno, false);
-
-		/* check if segmentby columns are distinct. */
-		if (ts_array_is_member(segmentby, col_attname))
-			ereport(ERROR,
-					(errcode(ERRCODE_SYNTAX_ERROR),
-					 errmsg("duplicate column name \"%s\"", colname),
-					 errhint("The timescaledb.compress_segmentby option must reference distinct "
-							 "column.")));
-		segmentby = ts_array_add_element_text(segmentby, col_attname);
-	}
-}
-
-static void
-check_orderby(Oid relid, List *orderby_cols, ArrayType *segmentby)
-{
-	ArrayType *orderby = NULL;
-	ListCell *lc;
-
-	foreach (lc, orderby_cols)
-	{
-		CompressedParsedCol *col = (CompressedParsedCol *) lfirst(lc);
-		AttrNumber col_attno = get_attnum(relid, NameStr(col->colname));
-
-		if (col_attno == InvalidAttrNumber)
-			ereport(ERROR,
-					(errcode(ERRCODE_SYNTAX_ERROR),
-					 errmsg("column \"%s\" does not exist", NameStr(col->colname)),
-					 errhint("The timescaledb.compress_orderby option must reference a valid "
-							 "column.")));
-
-		Oid col_type = get_atttype(relid, col_attno);
-		TypeCacheEntry *type = lookup_type_cache(col_type, TYPECACHE_LT_OPR);
-
-		if (!OidIsValid(type->lt_opr))
-			ereport(ERROR,
-					(errcode(ERRCODE_UNDEFINED_FUNCTION),
-					 errmsg("invalid ordering column type %s", format_type_be(col_type)),
-					 errdetail("Could not identify a less-than operator for the type.")));
-
-		const char *col_attname = get_attname(relid, col_attno, false);
-
-		/* check if orderby columns are distinct. */
-		if (ts_array_is_member(orderby, col_attname))
-			ereport(ERROR,
-					(errcode(ERRCODE_SYNTAX_ERROR),
-					 errmsg("duplicate column name \"%s\"", NameStr(col->colname)),
-					 errhint("The timescaledb.compress_orderby option must reference distinct "
-							 "column.")));
-
-		/* check if orderby_cols and segmentby_cols are distinct */
-		if (ts_array_is_member(segmentby, col_attname))
-			ereport(ERROR,
-					(errcode(ERRCODE_SYNTAX_ERROR),
-					 errmsg("cannot use column \"%s\" for both ordering and segmenting",
-							col_attname),
-					 errhint("Use separate columns for the timescaledb.compress_orderby and"
-							 " timescaledb.compress_segmentby options.")));
-
-		orderby = ts_array_add_element_text(orderby, col_attname);
-	}
 }
 
 /*
@@ -393,10 +313,9 @@ create_compress_chunk(Hypertable *compress_ht, Chunk *src_chunk, Oid table_id)
 
 /* Add  the hypertable time column to the end of the orderby list if
  * it's not already in the orderby or segmentby. */
-static List *
-add_time_to_order_by_if_not_included(List *orderby_cols, List *segmentby_cols, Hypertable *ht)
+static OrderBySettings
+add_time_to_order_by_if_not_included(OrderBySettings obs, ArrayType *segmentby, Hypertable *ht)
 {
-	ListCell *lc;
 	const Dimension *time_dim;
 	const char *time_col_name;
 	bool found = false;
@@ -404,30 +323,20 @@ add_time_to_order_by_if_not_included(List *orderby_cols, List *segmentby_cols, H
 	time_dim = hyperspace_get_open_dimension(ht->space, 0);
 	time_col_name = get_attname(ht->main_table_relid, time_dim->column_attno, false);
 
-	foreach (lc, orderby_cols)
-	{
-		CompressedParsedCol *col = (CompressedParsedCol *) lfirst(lc);
-		if (namestrcmp(&col->colname, time_col_name) == 0)
-			found = true;
-	}
-	foreach (lc, segmentby_cols)
-	{
-		if (strncmp(lfirst(lc), time_col_name, NAMEDATALEN) == 0)
-			found = true;
-	}
+	if (ts_array_is_member(obs.orderby, time_col_name))
+		found = true;
+
+	if (ts_array_is_member(segmentby, time_col_name))
+		found = true;
 
 	if (!found)
 	{
-		/* Add time DESC NULLS FIRST to order by list */
-		CompressedParsedCol *col = palloc(sizeof(*col));
-		*col = (CompressedParsedCol){
-			.desc = true,
-			.nullsfirst = true,
-		};
-		namestrcpy(&col->colname, time_col_name);
-		orderby_cols = lappend(orderby_cols, col);
+		/* Add time DESC NULLS FIRST to order by settings */
+		obs.orderby = ts_array_add_element_text(obs.orderby, pstrdup(time_col_name));
+		obs.orderby_desc = ts_array_add_element_bool(obs.orderby_desc, true);
+		obs.orderby_nullsfirst = ts_array_add_element_bool(obs.orderby_nullsfirst, true);
 	}
-	return orderby_cols;
+	return obs;
 }
 
 /* returns list of constraints that need to be cloned on the compressed hypertable
@@ -591,70 +500,13 @@ validate_existing_indexes(Hypertable *ht, CompressionSettings *settings)
 }
 
 static void
-check_modify_compression_options(Hypertable *ht, CompressionSettings *settings,
-								 WithClauseResult *with_clause_options, List *parsed_orderby_cols)
-{
-	bool compress_enable = DatumGetBool(with_clause_options[CompressEnabled].parsed);
-	bool compressed_chunks_exist;
-	bool compression_already_enabled = TS_HYPERTABLE_HAS_COMPRESSION_ENABLED(ht);
-	compressed_chunks_exist =
-		compression_already_enabled && ts_chunk_exists_with_compression(ht->fd.id);
-
-	if (compressed_chunks_exist)
-		ereport(ERROR,
-				(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
-				 errmsg("cannot change configuration on already compressed chunks"),
-				 errdetail("There are compressed chunks that prevent changing"
-						   " the existing compression configuration.")));
-
-	/* Require both order by and segment by when altering if they were previously set because
-	 * otherwise it's not clear what the default value means: does it mean leave as-is or is it an
-	 * empty list.
-	 * In the case where orderby is already set to the default value (time DESC),
-	 * both interpretations should lead to orderby being set to the default value,
-	 * so we allow skipping orderby if the default is the already set value. */
-	if (compress_enable && compression_already_enabled)
-	{
-		if (with_clause_options[CompressOrderBy].is_default && settings->fd.orderby)
-		{
-			bool orderby_time_default_matches = false;
-			const char *colname = NULL;
-			CompressedParsedCol *parsed = NULL;
-			/* If the orderby that's already set is only the time column DESC (which is the
-			 default), and we pass the default again, then no need to give an error */
-			if (list_length(parsed_orderby_cols) == 1)
-			{
-				colname = ts_array_get_element_text(settings->fd.orderby, 1);
-				bool orderby_desc = ts_array_get_element_bool(settings->fd.orderby_desc, 1);
-				parsed = lfirst(list_nth_cell(parsed_orderby_cols, 0));
-				orderby_time_default_matches = (orderby_desc == parsed->desc);
-			}
-
-			// this is okay only if the orderby that's already set is only the time column
-			// check for the same attribute name and same order (desc)
-			if (!(ts_array_length(settings->fd.orderby) == 1 &&
-				  list_length(parsed_orderby_cols) == 1 && parsed &&
-				  (namestrcmp(&parsed->colname, colname) == 0) && orderby_time_default_matches))
-				ereport(ERROR,
-						(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
-						 errmsg("must specify a column to order by"),
-						 errdetail("The timescaledb.compress_orderby option was"
-								   " previously set and must also be specified"
-								   " in the updated configuration.")));
-		}
-		if (with_clause_options[CompressSegmentBy].is_default && settings->fd.segmentby)
-			ereport(ERROR,
-					(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
-					 errmsg("must specify a column to segment by"),
-					 errdetail("The timescaledb.compress_segmentby option was"
-							   " previously set and must also be specified"
-							   " in the updated configuration.")));
-	}
-}
-
-static void
 drop_existing_compression_table(Hypertable *ht)
 {
+	if (ts_chunk_exists_with_compression(ht->fd.id))
+		ereport(ERROR,
+				(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
+				 errmsg("cannot drop compression hypertable with compressed chunks")));
+
 	Hypertable *compressed = ts_hypertable_get_by_id(ht->fd.compressed_hypertable_id);
 	if (compressed == NULL)
 		ereport(ERROR,
@@ -673,23 +525,14 @@ drop_existing_compression_table(Hypertable *ht)
 static bool
 disable_compression(Hypertable *ht, WithClauseResult *with_clause_options)
 {
-	bool compression_already_enabled = TS_HYPERTABLE_HAS_COMPRESSION_ENABLED(ht);
-	if (!with_clause_options[CompressOrderBy].is_default ||
-		!with_clause_options[CompressSegmentBy].is_default)
-		ereport(ERROR,
-				(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
-				 errmsg("invalid compression configuration"),
-				 errdetail("Cannot set additional compression options when"
-						   " disabling compression.")));
-
-	if (!compression_already_enabled)
+	if (!TS_HYPERTABLE_HAS_COMPRESSION_ENABLED(ht))
 		/* compression is not enabled, so just return */
 		return false;
 
-	CompressionSettings *settings = ts_compression_settings_get(ht->main_table_relid);
-
-	/* compression is enabled. can we turn it off? */
-	check_modify_compression_options(ht, settings, with_clause_options, NIL);
+	if (ts_chunk_exists_with_compression(ht->fd.id))
+		ereport(ERROR,
+				(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
+				 errmsg("cannot disable compression on hypertable with compressed chunks")));
 
 	if (TS_HYPERTABLE_HAS_COMPRESSION_TABLE(ht))
 		drop_existing_compression_table(ht);
@@ -756,10 +599,6 @@ update_compress_chunk_time_interval(Hypertable *ht, WithClauseResult *with_claus
 	return ts_hypertable_set_compress_interval(ht, compress_interval_usec);
 }
 
-static void compression_settings_update(CompressionSettings *settings,
-										WithClauseResult *with_clause_options, List *segmentby_cols,
-										List *orderby_cols);
-
 /*
  * enables compression for the passed in table by
  * creating a compression hypertable with special properties
@@ -778,10 +617,8 @@ tsl_process_compress_table(AlterTableCmd *cmd, Hypertable *ht,
 						   WithClauseResult *with_clause_options)
 {
 	int32 compress_htid;
-	bool compress_enable = DatumGetBool(with_clause_options[CompressEnabled].parsed);
-	Oid ownerid;
-	List *segmentby_cols;
-	List *orderby_cols;
+	bool compress_disable = !with_clause_options[CompressEnabled].is_default &&
+							!DatumGetBool(with_clause_options[CompressEnabled].parsed);
 	CompressionSettings *settings;
 
 	ts_feature_flag_check(FEATURE_HYPERTABLE_COMPRESSION);
@@ -794,55 +631,33 @@ tsl_process_compress_table(AlterTableCmd *cmd, Hypertable *ht,
 	/* reload info after lock */
 	ht = ts_hypertable_get_by_id(ht->fd.id);
 
+	if (compress_disable)
+	{
+		return disable_compression(ht, with_clause_options);
+	}
+
 	settings = ts_compression_settings_get(ht->main_table_relid);
 	if (!settings)
 	{
 		settings = ts_compression_settings_create(ht->main_table_relid, NULL, NULL, NULL, NULL);
 	}
 
-	/* If we are not enabling compression, we must be just altering compressed chunk interval. */
-	if (with_clause_options[CompressEnabled].is_default)
+	compression_settings_update(ht, settings, with_clause_options);
+
+	if (!TS_HYPERTABLE_HAS_COMPRESSION_TABLE(ht))
 	{
-		return update_compress_chunk_time_interval(ht, with_clause_options);
-	}
-	if (!compress_enable)
-	{
-		return disable_compression(ht, with_clause_options);
-	}
-	ownerid = ts_rel_get_owner(ht->main_table_relid);
-	segmentby_cols = ts_compress_hypertable_parse_segment_by(with_clause_options, ht);
-	orderby_cols = ts_compress_hypertable_parse_order_by(with_clause_options, ht);
-	orderby_cols = add_time_to_order_by_if_not_included(orderby_cols, segmentby_cols, ht);
+		/* take explicit locks on catalog tables and keep them till end of txn */
+		LockRelationOid(catalog_get_table_id(ts_catalog_get(), HYPERTABLE), RowExclusiveLock);
 
-	if (TS_HYPERTABLE_HAS_COMPRESSION_ENABLED(ht))
-		check_modify_compression_options(ht, settings, with_clause_options, orderby_cols);
+		/* Check if we can create a compressed hypertable with existing
+		 * constraints and indexes. */
+		validate_existing_constraints(ht, settings);
+		validate_existing_indexes(ht, settings);
 
-	compression_settings_update(settings, with_clause_options, segmentby_cols, orderby_cols);
-
-	check_segmentby(ht->main_table_relid, segmentby_cols);
-	check_orderby(ht->main_table_relid, orderby_cols, settings->fd.segmentby);
-
-	/* take explicit locks on catalog tables and keep them till end of txn */
-	LockRelationOid(catalog_get_table_id(ts_catalog_get(), HYPERTABLE), RowExclusiveLock);
-
-	if (TS_HYPERTABLE_HAS_COMPRESSION_TABLE(ht))
-	{
-		/* compression is enabled */
-		drop_existing_compression_table(ht);
-	}
-
-	/* Check if we can create a compressed hypertable with existing
-	 * constraints and indexes. */
-	validate_existing_constraints(ht, settings);
-	validate_existing_indexes(ht, settings);
-
-	Oid tablespace_oid = get_rel_tablespace(ht->main_table_relid);
-	compress_htid = compression_hypertable_create(ht, ownerid, tablespace_oid);
-	ts_hypertable_set_compressed(ht, compress_htid);
-
-	if (!with_clause_options[CompressChunkTimeInterval].is_default)
-	{
-		update_compress_chunk_time_interval(ht, with_clause_options);
+		Oid ownerid = ts_rel_get_owner(ht->main_table_relid);
+		Oid tablespace_oid = get_rel_tablespace(ht->main_table_relid);
+		compress_htid = compression_hypertable_create(ht, ownerid, tablespace_oid);
+		ts_hypertable_set_compressed(ht, compress_htid);
 	}
 
 	/* do not release any locks, will get released by xact end */
@@ -910,37 +725,31 @@ validate_hypertable_for_compression(Hypertable *ht)
 }
 
 static void
-compression_settings_update(CompressionSettings *settings, WithClauseResult *with_clause_options,
-							List *segmentby_cols, List *orderby_cols)
+compression_settings_update(Hypertable *ht, CompressionSettings *settings,
+							WithClauseResult *with_clause_options)
 {
 	/* orderby arrays should always be in sync either all NULL or none */
 	Assert(
 		(settings->fd.orderby && settings->fd.orderby_desc && settings->fd.orderby_nullsfirst) ||
 		(!settings->fd.orderby && !settings->fd.orderby_desc && !settings->fd.orderby_nullsfirst));
 
+	if (!with_clause_options[CompressChunkTimeInterval].is_default)
+	{
+		update_compress_chunk_time_interval(ht, with_clause_options);
+	}
+
 	if (!with_clause_options[CompressSegmentBy].is_default)
 	{
-		settings->fd.segmentby = ts_array_create_from_list_text(segmentby_cols);
+		settings->fd.segmentby = ts_compress_hypertable_parse_segment_by(with_clause_options, ht);
 	}
 
 	if (!with_clause_options[CompressOrderBy].is_default || !settings->fd.orderby)
 	{
-		List *cols = NIL;
-		List *desc = NIL;
-		List *nullsfirst = NIL;
-		ListCell *lc;
-
-		foreach (lc, orderby_cols)
-		{
-			CompressedParsedCol *col = lfirst(lc);
-			cols = lappend(cols, (void *) NameStr(col->colname));
-			desc = lappend_int(desc, col->desc);
-			nullsfirst = lappend_int(nullsfirst, col->nullsfirst);
-		}
-
-		settings->fd.orderby = ts_array_create_from_list_text(cols);
-		settings->fd.orderby_desc = ts_array_create_from_list_bool(desc);
-		settings->fd.orderby_nullsfirst = ts_array_create_from_list_bool(nullsfirst);
+		OrderBySettings obs = ts_compress_hypertable_parse_order_by(with_clause_options, ht);
+		obs = add_time_to_order_by_if_not_included(obs, settings->fd.segmentby, ht);
+		settings->fd.orderby = obs.orderby;
+		settings->fd.orderby_desc = obs.orderby_desc;
+		settings->fd.orderby_nullsfirst = obs.orderby_nullsfirst;
 	}
 
 	ts_compression_settings_update(settings);

--- a/tsl/test/expected/cagg_ddl-13.out
+++ b/tsl/test/expected/cagg_ddl-13.out
@@ -1677,7 +1677,7 @@ CREATE TABLE transactions
 SELECT create_hypertable('transactions', 'time');
      create_hypertable      
 ----------------------------
- (46,public,transactions,t)
+ (44,public,transactions,t)
 (1 row)
 
 INSERT INTO transactions VALUES ( '2018-01-01 09:20:00-08', 0, 0, 0, 0, 0, 1, 10);
@@ -1720,7 +1720,7 @@ WHERE user_view_name = 'cashflows'
 -- Show both the columns and the view definitions to see that
 -- references are correct in the view as well.
 \d+ "_timescaledb_internal".:"DIRECT_VIEW_NAME"
-                         View "_timescaledb_internal._direct_view_47"
+                         View "_timescaledb_internal._direct_view_45"
   Column   |           Type           | Collation | Nullable | Default | Storage | Description 
 -----------+--------------------------+-----------+----------+---------+---------+-------------
  bucket    | timestamp with time zone |           |          |         | plain   | 
@@ -1739,7 +1739,7 @@ View definition:
   GROUP BY (time_bucket('@ 1 day'::interval, transactions."time")), transactions.amount;
 
 \d+ "_timescaledb_internal".:"PART_VIEW_NAME"
-                         View "_timescaledb_internal._partial_view_47"
+                         View "_timescaledb_internal._partial_view_45"
   Column   |           Type           | Collation | Nullable | Default | Storage | Description 
 -----------+--------------------------+-----------+----------+---------+---------+-------------
  bucket    | timestamp with time zone |           |          |         | plain   | 
@@ -1758,7 +1758,7 @@ View definition:
   GROUP BY (time_bucket('@ 1 day'::interval, transactions."time")), transactions.amount;
 
 \d+ "_timescaledb_internal".:"MAT_TABLE_NAME"
-                          Table "_timescaledb_internal._materialized_hypertable_47"
+                          Table "_timescaledb_internal._materialized_hypertable_45"
   Column   |           Type           | Collation | Nullable | Default | Storage | Stats target | Description 
 -----------+--------------------------+-----------+----------+---------+---------+--------------+-------------
  bucket    | timestamp with time zone |           | not null |         | plain   |              | 
@@ -1766,12 +1766,12 @@ View definition:
  cashflow  | bigint                   |           |          |         | plain   |              | 
  cashflow2 | bigint                   |           |          |         | plain   |              | 
 Indexes:
-    "_materialized_hypertable_47_amount_bucket_idx" btree (amount, bucket DESC)
-    "_materialized_hypertable_47_bucket_idx" btree (bucket DESC)
+    "_materialized_hypertable_45_amount_bucket_idx" btree (amount, bucket DESC)
+    "_materialized_hypertable_45_bucket_idx" btree (bucket DESC)
 Triggers:
-    ts_insert_blocker BEFORE INSERT ON _timescaledb_internal._materialized_hypertable_47 FOR EACH ROW EXECUTE FUNCTION _timescaledb_functions.insert_blocker()
-Child tables: _timescaledb_internal._hyper_47_52_chunk,
-              _timescaledb_internal._hyper_47_53_chunk
+    ts_insert_blocker BEFORE INSERT ON _timescaledb_internal._materialized_hypertable_45 FOR EACH ROW EXECUTE FUNCTION _timescaledb_functions.insert_blocker()
+Child tables: _timescaledb_internal._hyper_45_52_chunk,
+              _timescaledb_internal._hyper_45_53_chunk
 
 \d+ 'cashflows'
                                     View "public.cashflows"
@@ -1782,11 +1782,11 @@ Child tables: _timescaledb_internal._hyper_47_52_chunk,
  cashflow  | bigint                   |           |          |         | plain   | 
  cashflow2 | bigint                   |           |          |         | plain   | 
 View definition:
- SELECT _materialized_hypertable_47.bucket,
-    _materialized_hypertable_47.amount,
-    _materialized_hypertable_47.cashflow,
-    _materialized_hypertable_47.cashflow2
-   FROM _timescaledb_internal._materialized_hypertable_47;
+ SELECT _materialized_hypertable_45.bucket,
+    _materialized_hypertable_45.amount,
+    _materialized_hypertable_45.cashflow,
+    _materialized_hypertable_45.cashflow2
+   FROM _timescaledb_internal._materialized_hypertable_45;
 
 SELECT * FROM cashflows;
             bucket            | amount | cashflow | cashflow2 
@@ -1911,7 +1911,7 @@ CREATE TABLE conditions (
 SELECT create_hypertable('conditions', 'time');
     create_hypertable     
 --------------------------
- (54,public,conditions,t)
+ (52,public,conditions,t)
 (1 row)
 
 INSERT INTO conditions VALUES ( '2018-01-01 09:20:00-08', 'SFO', 55);
@@ -1941,10 +1941,10 @@ WITH NO DATA;
  bucket   | timestamp with time zone |           |          |         | plain    | 
  avg      | double precision         |           |          |         | plain    | 
 View definition:
- SELECT _materialized_hypertable_55.location,
-    _materialized_hypertable_55.bucket,
-    _materialized_hypertable_55.avg
-   FROM _timescaledb_internal._materialized_hypertable_55;
+ SELECT _materialized_hypertable_53.location,
+    _materialized_hypertable_53.bucket,
+    _materialized_hypertable_53.avg
+   FROM _timescaledb_internal._materialized_hypertable_53;
 
 -- Should return NO ROWS
 SELECT * FROM conditions_daily ORDER BY bucket, avg;
@@ -1961,17 +1961,17 @@ ALTER MATERIALIZED VIEW conditions_daily SET (timescaledb.materialized_only=fals
  bucket   | timestamp with time zone |           |          |         | plain    | 
  avg      | double precision         |           |          |         | plain    | 
 View definition:
- SELECT _materialized_hypertable_55.location,
-    _materialized_hypertable_55.bucket,
-    _materialized_hypertable_55.avg
-   FROM _timescaledb_internal._materialized_hypertable_55
-  WHERE _materialized_hypertable_55.bucket < COALESCE(_timescaledb_functions.to_timestamp(_timescaledb_functions.cagg_watermark(55)), '-infinity'::timestamp with time zone)
+ SELECT _materialized_hypertable_53.location,
+    _materialized_hypertable_53.bucket,
+    _materialized_hypertable_53.avg
+   FROM _timescaledb_internal._materialized_hypertable_53
+  WHERE _materialized_hypertable_53.bucket < COALESCE(_timescaledb_functions.to_timestamp(_timescaledb_functions.cagg_watermark(53)), '-infinity'::timestamp with time zone)
 UNION ALL
  SELECT conditions.location,
     time_bucket('@ 1 day'::interval, conditions."time") AS bucket,
     avg(conditions.temperature) AS avg
    FROM conditions
-  WHERE conditions."time" >= COALESCE(_timescaledb_functions.to_timestamp(_timescaledb_functions.cagg_watermark(55)), '-infinity'::timestamp with time zone)
+  WHERE conditions."time" >= COALESCE(_timescaledb_functions.to_timestamp(_timescaledb_functions.cagg_watermark(53)), '-infinity'::timestamp with time zone)
   GROUP BY conditions.location, (time_bucket('@ 1 day'::interval, conditions."time"));
 
 -- Should return ROWS because now it is realtime
@@ -1996,10 +1996,10 @@ ALTER MATERIALIZED VIEW conditions_daily SET (timescaledb.materialized_only=true
  bucket   | timestamp with time zone |           |          |         | plain    | 
  avg      | double precision         |           |          |         | plain    | 
 View definition:
- SELECT _materialized_hypertable_55.location,
-    _materialized_hypertable_55.bucket,
-    _materialized_hypertable_55.avg
-   FROM _timescaledb_internal._materialized_hypertable_55;
+ SELECT _materialized_hypertable_53.location,
+    _materialized_hypertable_53.bucket,
+    _materialized_hypertable_53.avg
+   FROM _timescaledb_internal._materialized_hypertable_53;
 
 CALL refresh_continuous_aggregate('conditions_daily', NULL, NULL);
 SELECT * FROM conditions_daily ORDER BY bucket, avg;

--- a/tsl/test/expected/cagg_ddl-14.out
+++ b/tsl/test/expected/cagg_ddl-14.out
@@ -1677,7 +1677,7 @@ CREATE TABLE transactions
 SELECT create_hypertable('transactions', 'time');
      create_hypertable      
 ----------------------------
- (46,public,transactions,t)
+ (44,public,transactions,t)
 (1 row)
 
 INSERT INTO transactions VALUES ( '2018-01-01 09:20:00-08', 0, 0, 0, 0, 0, 1, 10);
@@ -1720,7 +1720,7 @@ WHERE user_view_name = 'cashflows'
 -- Show both the columns and the view definitions to see that
 -- references are correct in the view as well.
 \d+ "_timescaledb_internal".:"DIRECT_VIEW_NAME"
-                         View "_timescaledb_internal._direct_view_47"
+                         View "_timescaledb_internal._direct_view_45"
   Column   |           Type           | Collation | Nullable | Default | Storage | Description 
 -----------+--------------------------+-----------+----------+---------+---------+-------------
  bucket    | timestamp with time zone |           |          |         | plain   | 
@@ -1739,7 +1739,7 @@ View definition:
   GROUP BY (time_bucket('@ 1 day'::interval, transactions."time")), transactions.amount;
 
 \d+ "_timescaledb_internal".:"PART_VIEW_NAME"
-                         View "_timescaledb_internal._partial_view_47"
+                         View "_timescaledb_internal._partial_view_45"
   Column   |           Type           | Collation | Nullable | Default | Storage | Description 
 -----------+--------------------------+-----------+----------+---------+---------+-------------
  bucket    | timestamp with time zone |           |          |         | plain   | 
@@ -1758,7 +1758,7 @@ View definition:
   GROUP BY (time_bucket('@ 1 day'::interval, transactions."time")), transactions.amount;
 
 \d+ "_timescaledb_internal".:"MAT_TABLE_NAME"
-                          Table "_timescaledb_internal._materialized_hypertable_47"
+                          Table "_timescaledb_internal._materialized_hypertable_45"
   Column   |           Type           | Collation | Nullable | Default | Storage | Stats target | Description 
 -----------+--------------------------+-----------+----------+---------+---------+--------------+-------------
  bucket    | timestamp with time zone |           | not null |         | plain   |              | 
@@ -1766,12 +1766,12 @@ View definition:
  cashflow  | bigint                   |           |          |         | plain   |              | 
  cashflow2 | bigint                   |           |          |         | plain   |              | 
 Indexes:
-    "_materialized_hypertable_47_amount_bucket_idx" btree (amount, bucket DESC)
-    "_materialized_hypertable_47_bucket_idx" btree (bucket DESC)
+    "_materialized_hypertable_45_amount_bucket_idx" btree (amount, bucket DESC)
+    "_materialized_hypertable_45_bucket_idx" btree (bucket DESC)
 Triggers:
-    ts_insert_blocker BEFORE INSERT ON _timescaledb_internal._materialized_hypertable_47 FOR EACH ROW EXECUTE FUNCTION _timescaledb_functions.insert_blocker()
-Child tables: _timescaledb_internal._hyper_47_52_chunk,
-              _timescaledb_internal._hyper_47_53_chunk
+    ts_insert_blocker BEFORE INSERT ON _timescaledb_internal._materialized_hypertable_45 FOR EACH ROW EXECUTE FUNCTION _timescaledb_functions.insert_blocker()
+Child tables: _timescaledb_internal._hyper_45_52_chunk,
+              _timescaledb_internal._hyper_45_53_chunk
 
 \d+ 'cashflows'
                                     View "public.cashflows"
@@ -1782,11 +1782,11 @@ Child tables: _timescaledb_internal._hyper_47_52_chunk,
  cashflow  | bigint                   |           |          |         | plain   | 
  cashflow2 | bigint                   |           |          |         | plain   | 
 View definition:
- SELECT _materialized_hypertable_47.bucket,
-    _materialized_hypertable_47.amount,
-    _materialized_hypertable_47.cashflow,
-    _materialized_hypertable_47.cashflow2
-   FROM _timescaledb_internal._materialized_hypertable_47;
+ SELECT _materialized_hypertable_45.bucket,
+    _materialized_hypertable_45.amount,
+    _materialized_hypertable_45.cashflow,
+    _materialized_hypertable_45.cashflow2
+   FROM _timescaledb_internal._materialized_hypertable_45;
 
 SELECT * FROM cashflows;
             bucket            | amount | cashflow | cashflow2 
@@ -1911,7 +1911,7 @@ CREATE TABLE conditions (
 SELECT create_hypertable('conditions', 'time');
     create_hypertable     
 --------------------------
- (54,public,conditions,t)
+ (52,public,conditions,t)
 (1 row)
 
 INSERT INTO conditions VALUES ( '2018-01-01 09:20:00-08', 'SFO', 55);
@@ -1941,10 +1941,10 @@ WITH NO DATA;
  bucket   | timestamp with time zone |           |          |         | plain    | 
  avg      | double precision         |           |          |         | plain    | 
 View definition:
- SELECT _materialized_hypertable_55.location,
-    _materialized_hypertable_55.bucket,
-    _materialized_hypertable_55.avg
-   FROM _timescaledb_internal._materialized_hypertable_55;
+ SELECT _materialized_hypertable_53.location,
+    _materialized_hypertable_53.bucket,
+    _materialized_hypertable_53.avg
+   FROM _timescaledb_internal._materialized_hypertable_53;
 
 -- Should return NO ROWS
 SELECT * FROM conditions_daily ORDER BY bucket, avg;
@@ -1961,17 +1961,17 @@ ALTER MATERIALIZED VIEW conditions_daily SET (timescaledb.materialized_only=fals
  bucket   | timestamp with time zone |           |          |         | plain    | 
  avg      | double precision         |           |          |         | plain    | 
 View definition:
- SELECT _materialized_hypertable_55.location,
-    _materialized_hypertable_55.bucket,
-    _materialized_hypertable_55.avg
-   FROM _timescaledb_internal._materialized_hypertable_55
-  WHERE _materialized_hypertable_55.bucket < COALESCE(_timescaledb_functions.to_timestamp(_timescaledb_functions.cagg_watermark(55)), '-infinity'::timestamp with time zone)
+ SELECT _materialized_hypertable_53.location,
+    _materialized_hypertable_53.bucket,
+    _materialized_hypertable_53.avg
+   FROM _timescaledb_internal._materialized_hypertable_53
+  WHERE _materialized_hypertable_53.bucket < COALESCE(_timescaledb_functions.to_timestamp(_timescaledb_functions.cagg_watermark(53)), '-infinity'::timestamp with time zone)
 UNION ALL
  SELECT conditions.location,
     time_bucket('@ 1 day'::interval, conditions."time") AS bucket,
     avg(conditions.temperature) AS avg
    FROM conditions
-  WHERE conditions."time" >= COALESCE(_timescaledb_functions.to_timestamp(_timescaledb_functions.cagg_watermark(55)), '-infinity'::timestamp with time zone)
+  WHERE conditions."time" >= COALESCE(_timescaledb_functions.to_timestamp(_timescaledb_functions.cagg_watermark(53)), '-infinity'::timestamp with time zone)
   GROUP BY conditions.location, (time_bucket('@ 1 day'::interval, conditions."time"));
 
 -- Should return ROWS because now it is realtime
@@ -1996,10 +1996,10 @@ ALTER MATERIALIZED VIEW conditions_daily SET (timescaledb.materialized_only=true
  bucket   | timestamp with time zone |           |          |         | plain    | 
  avg      | double precision         |           |          |         | plain    | 
 View definition:
- SELECT _materialized_hypertable_55.location,
-    _materialized_hypertable_55.bucket,
-    _materialized_hypertable_55.avg
-   FROM _timescaledb_internal._materialized_hypertable_55;
+ SELECT _materialized_hypertable_53.location,
+    _materialized_hypertable_53.bucket,
+    _materialized_hypertable_53.avg
+   FROM _timescaledb_internal._materialized_hypertable_53;
 
 CALL refresh_continuous_aggregate('conditions_daily', NULL, NULL);
 SELECT * FROM conditions_daily ORDER BY bucket, avg;

--- a/tsl/test/expected/cagg_ddl-15.out
+++ b/tsl/test/expected/cagg_ddl-15.out
@@ -1677,7 +1677,7 @@ CREATE TABLE transactions
 SELECT create_hypertable('transactions', 'time');
      create_hypertable      
 ----------------------------
- (46,public,transactions,t)
+ (44,public,transactions,t)
 (1 row)
 
 INSERT INTO transactions VALUES ( '2018-01-01 09:20:00-08', 0, 0, 0, 0, 0, 1, 10);
@@ -1720,7 +1720,7 @@ WHERE user_view_name = 'cashflows'
 -- Show both the columns and the view definitions to see that
 -- references are correct in the view as well.
 \d+ "_timescaledb_internal".:"DIRECT_VIEW_NAME"
-                         View "_timescaledb_internal._direct_view_47"
+                         View "_timescaledb_internal._direct_view_45"
   Column   |           Type           | Collation | Nullable | Default | Storage | Description 
 -----------+--------------------------+-----------+----------+---------+---------+-------------
  bucket    | timestamp with time zone |           |          |         | plain   | 
@@ -1739,7 +1739,7 @@ View definition:
   GROUP BY (time_bucket('@ 1 day'::interval, transactions."time")), transactions.amount;
 
 \d+ "_timescaledb_internal".:"PART_VIEW_NAME"
-                         View "_timescaledb_internal._partial_view_47"
+                         View "_timescaledb_internal._partial_view_45"
   Column   |           Type           | Collation | Nullable | Default | Storage | Description 
 -----------+--------------------------+-----------+----------+---------+---------+-------------
  bucket    | timestamp with time zone |           |          |         | plain   | 
@@ -1758,7 +1758,7 @@ View definition:
   GROUP BY (time_bucket('@ 1 day'::interval, transactions."time")), transactions.amount;
 
 \d+ "_timescaledb_internal".:"MAT_TABLE_NAME"
-                          Table "_timescaledb_internal._materialized_hypertable_47"
+                          Table "_timescaledb_internal._materialized_hypertable_45"
   Column   |           Type           | Collation | Nullable | Default | Storage | Stats target | Description 
 -----------+--------------------------+-----------+----------+---------+---------+--------------+-------------
  bucket    | timestamp with time zone |           | not null |         | plain   |              | 
@@ -1766,12 +1766,12 @@ View definition:
  cashflow  | bigint                   |           |          |         | plain   |              | 
  cashflow2 | bigint                   |           |          |         | plain   |              | 
 Indexes:
-    "_materialized_hypertable_47_amount_bucket_idx" btree (amount, bucket DESC)
-    "_materialized_hypertable_47_bucket_idx" btree (bucket DESC)
+    "_materialized_hypertable_45_amount_bucket_idx" btree (amount, bucket DESC)
+    "_materialized_hypertable_45_bucket_idx" btree (bucket DESC)
 Triggers:
-    ts_insert_blocker BEFORE INSERT ON _timescaledb_internal._materialized_hypertable_47 FOR EACH ROW EXECUTE FUNCTION _timescaledb_functions.insert_blocker()
-Child tables: _timescaledb_internal._hyper_47_52_chunk,
-              _timescaledb_internal._hyper_47_53_chunk
+    ts_insert_blocker BEFORE INSERT ON _timescaledb_internal._materialized_hypertable_45 FOR EACH ROW EXECUTE FUNCTION _timescaledb_functions.insert_blocker()
+Child tables: _timescaledb_internal._hyper_45_52_chunk,
+              _timescaledb_internal._hyper_45_53_chunk
 
 \d+ 'cashflows'
                                     View "public.cashflows"
@@ -1782,11 +1782,11 @@ Child tables: _timescaledb_internal._hyper_47_52_chunk,
  cashflow  | bigint                   |           |          |         | plain   | 
  cashflow2 | bigint                   |           |          |         | plain   | 
 View definition:
- SELECT _materialized_hypertable_47.bucket,
-    _materialized_hypertable_47.amount,
-    _materialized_hypertable_47.cashflow,
-    _materialized_hypertable_47.cashflow2
-   FROM _timescaledb_internal._materialized_hypertable_47;
+ SELECT _materialized_hypertable_45.bucket,
+    _materialized_hypertable_45.amount,
+    _materialized_hypertable_45.cashflow,
+    _materialized_hypertable_45.cashflow2
+   FROM _timescaledb_internal._materialized_hypertable_45;
 
 SELECT * FROM cashflows;
             bucket            | amount | cashflow | cashflow2 
@@ -1911,7 +1911,7 @@ CREATE TABLE conditions (
 SELECT create_hypertable('conditions', 'time');
     create_hypertable     
 --------------------------
- (54,public,conditions,t)
+ (52,public,conditions,t)
 (1 row)
 
 INSERT INTO conditions VALUES ( '2018-01-01 09:20:00-08', 'SFO', 55);
@@ -1941,10 +1941,10 @@ WITH NO DATA;
  bucket   | timestamp with time zone |           |          |         | plain    | 
  avg      | double precision         |           |          |         | plain    | 
 View definition:
- SELECT _materialized_hypertable_55.location,
-    _materialized_hypertable_55.bucket,
-    _materialized_hypertable_55.avg
-   FROM _timescaledb_internal._materialized_hypertable_55;
+ SELECT _materialized_hypertable_53.location,
+    _materialized_hypertable_53.bucket,
+    _materialized_hypertable_53.avg
+   FROM _timescaledb_internal._materialized_hypertable_53;
 
 -- Should return NO ROWS
 SELECT * FROM conditions_daily ORDER BY bucket, avg;
@@ -1961,17 +1961,17 @@ ALTER MATERIALIZED VIEW conditions_daily SET (timescaledb.materialized_only=fals
  bucket   | timestamp with time zone |           |          |         | plain    | 
  avg      | double precision         |           |          |         | plain    | 
 View definition:
- SELECT _materialized_hypertable_55.location,
-    _materialized_hypertable_55.bucket,
-    _materialized_hypertable_55.avg
-   FROM _timescaledb_internal._materialized_hypertable_55
-  WHERE _materialized_hypertable_55.bucket < COALESCE(_timescaledb_functions.to_timestamp(_timescaledb_functions.cagg_watermark(55)), '-infinity'::timestamp with time zone)
+ SELECT _materialized_hypertable_53.location,
+    _materialized_hypertable_53.bucket,
+    _materialized_hypertable_53.avg
+   FROM _timescaledb_internal._materialized_hypertable_53
+  WHERE _materialized_hypertable_53.bucket < COALESCE(_timescaledb_functions.to_timestamp(_timescaledb_functions.cagg_watermark(53)), '-infinity'::timestamp with time zone)
 UNION ALL
  SELECT conditions.location,
     time_bucket('@ 1 day'::interval, conditions."time") AS bucket,
     avg(conditions.temperature) AS avg
    FROM conditions
-  WHERE conditions."time" >= COALESCE(_timescaledb_functions.to_timestamp(_timescaledb_functions.cagg_watermark(55)), '-infinity'::timestamp with time zone)
+  WHERE conditions."time" >= COALESCE(_timescaledb_functions.to_timestamp(_timescaledb_functions.cagg_watermark(53)), '-infinity'::timestamp with time zone)
   GROUP BY conditions.location, (time_bucket('@ 1 day'::interval, conditions."time"));
 
 -- Should return ROWS because now it is realtime
@@ -1996,10 +1996,10 @@ ALTER MATERIALIZED VIEW conditions_daily SET (timescaledb.materialized_only=true
  bucket   | timestamp with time zone |           |          |         | plain    | 
  avg      | double precision         |           |          |         | plain    | 
 View definition:
- SELECT _materialized_hypertable_55.location,
-    _materialized_hypertable_55.bucket,
-    _materialized_hypertable_55.avg
-   FROM _timescaledb_internal._materialized_hypertable_55;
+ SELECT _materialized_hypertable_53.location,
+    _materialized_hypertable_53.bucket,
+    _materialized_hypertable_53.avg
+   FROM _timescaledb_internal._materialized_hypertable_53;
 
 CALL refresh_continuous_aggregate('conditions_daily', NULL, NULL);
 SELECT * FROM conditions_daily ORDER BY bucket, avg;

--- a/tsl/test/expected/cagg_ddl-16.out
+++ b/tsl/test/expected/cagg_ddl-16.out
@@ -1677,7 +1677,7 @@ CREATE TABLE transactions
 SELECT create_hypertable('transactions', 'time');
      create_hypertable      
 ----------------------------
- (46,public,transactions,t)
+ (44,public,transactions,t)
 (1 row)
 
 INSERT INTO transactions VALUES ( '2018-01-01 09:20:00-08', 0, 0, 0, 0, 0, 1, 10);
@@ -1720,7 +1720,7 @@ WHERE user_view_name = 'cashflows'
 -- Show both the columns and the view definitions to see that
 -- references are correct in the view as well.
 \d+ "_timescaledb_internal".:"DIRECT_VIEW_NAME"
-                         View "_timescaledb_internal._direct_view_47"
+                         View "_timescaledb_internal._direct_view_45"
   Column   |           Type           | Collation | Nullable | Default | Storage | Description 
 -----------+--------------------------+-----------+----------+---------+---------+-------------
  bucket    | timestamp with time zone |           |          |         | plain   | 
@@ -1739,7 +1739,7 @@ View definition:
   GROUP BY (time_bucket('@ 1 day'::interval, "time")), amount;
 
 \d+ "_timescaledb_internal".:"PART_VIEW_NAME"
-                         View "_timescaledb_internal._partial_view_47"
+                         View "_timescaledb_internal._partial_view_45"
   Column   |           Type           | Collation | Nullable | Default | Storage | Description 
 -----------+--------------------------+-----------+----------+---------+---------+-------------
  bucket    | timestamp with time zone |           |          |         | plain   | 
@@ -1758,7 +1758,7 @@ View definition:
   GROUP BY (time_bucket('@ 1 day'::interval, "time")), amount;
 
 \d+ "_timescaledb_internal".:"MAT_TABLE_NAME"
-                          Table "_timescaledb_internal._materialized_hypertable_47"
+                          Table "_timescaledb_internal._materialized_hypertable_45"
   Column   |           Type           | Collation | Nullable | Default | Storage | Stats target | Description 
 -----------+--------------------------+-----------+----------+---------+---------+--------------+-------------
  bucket    | timestamp with time zone |           | not null |         | plain   |              | 
@@ -1766,12 +1766,12 @@ View definition:
  cashflow  | bigint                   |           |          |         | plain   |              | 
  cashflow2 | bigint                   |           |          |         | plain   |              | 
 Indexes:
-    "_materialized_hypertable_47_amount_bucket_idx" btree (amount, bucket DESC)
-    "_materialized_hypertable_47_bucket_idx" btree (bucket DESC)
+    "_materialized_hypertable_45_amount_bucket_idx" btree (amount, bucket DESC)
+    "_materialized_hypertable_45_bucket_idx" btree (bucket DESC)
 Triggers:
-    ts_insert_blocker BEFORE INSERT ON _timescaledb_internal._materialized_hypertable_47 FOR EACH ROW EXECUTE FUNCTION _timescaledb_functions.insert_blocker()
-Child tables: _timescaledb_internal._hyper_47_52_chunk,
-              _timescaledb_internal._hyper_47_53_chunk
+    ts_insert_blocker BEFORE INSERT ON _timescaledb_internal._materialized_hypertable_45 FOR EACH ROW EXECUTE FUNCTION _timescaledb_functions.insert_blocker()
+Child tables: _timescaledb_internal._hyper_45_52_chunk,
+              _timescaledb_internal._hyper_45_53_chunk
 
 \d+ 'cashflows'
                                     View "public.cashflows"
@@ -1786,7 +1786,7 @@ View definition:
     amount,
     cashflow,
     cashflow2
-   FROM _timescaledb_internal._materialized_hypertable_47;
+   FROM _timescaledb_internal._materialized_hypertable_45;
 
 SELECT * FROM cashflows;
             bucket            | amount | cashflow | cashflow2 
@@ -1911,7 +1911,7 @@ CREATE TABLE conditions (
 SELECT create_hypertable('conditions', 'time');
     create_hypertable     
 --------------------------
- (54,public,conditions,t)
+ (52,public,conditions,t)
 (1 row)
 
 INSERT INTO conditions VALUES ( '2018-01-01 09:20:00-08', 'SFO', 55);
@@ -1944,7 +1944,7 @@ View definition:
  SELECT location,
     bucket,
     avg
-   FROM _timescaledb_internal._materialized_hypertable_55;
+   FROM _timescaledb_internal._materialized_hypertable_53;
 
 -- Should return NO ROWS
 SELECT * FROM conditions_daily ORDER BY bucket, avg;
@@ -1961,17 +1961,17 @@ ALTER MATERIALIZED VIEW conditions_daily SET (timescaledb.materialized_only=fals
  bucket   | timestamp with time zone |           |          |         | plain    | 
  avg      | double precision         |           |          |         | plain    | 
 View definition:
- SELECT _materialized_hypertable_55.location,
-    _materialized_hypertable_55.bucket,
-    _materialized_hypertable_55.avg
-   FROM _timescaledb_internal._materialized_hypertable_55
-  WHERE _materialized_hypertable_55.bucket < COALESCE(_timescaledb_functions.to_timestamp(_timescaledb_functions.cagg_watermark(55)), '-infinity'::timestamp with time zone)
+ SELECT _materialized_hypertable_53.location,
+    _materialized_hypertable_53.bucket,
+    _materialized_hypertable_53.avg
+   FROM _timescaledb_internal._materialized_hypertable_53
+  WHERE _materialized_hypertable_53.bucket < COALESCE(_timescaledb_functions.to_timestamp(_timescaledb_functions.cagg_watermark(53)), '-infinity'::timestamp with time zone)
 UNION ALL
  SELECT conditions.location,
     time_bucket('@ 1 day'::interval, conditions."time") AS bucket,
     avg(conditions.temperature) AS avg
    FROM conditions
-  WHERE conditions."time" >= COALESCE(_timescaledb_functions.to_timestamp(_timescaledb_functions.cagg_watermark(55)), '-infinity'::timestamp with time zone)
+  WHERE conditions."time" >= COALESCE(_timescaledb_functions.to_timestamp(_timescaledb_functions.cagg_watermark(53)), '-infinity'::timestamp with time zone)
   GROUP BY conditions.location, (time_bucket('@ 1 day'::interval, conditions."time"));
 
 -- Should return ROWS because now it is realtime
@@ -1999,7 +1999,7 @@ View definition:
  SELECT location,
     bucket,
     avg
-   FROM _timescaledb_internal._materialized_hypertable_55;
+   FROM _timescaledb_internal._materialized_hypertable_53;
 
 CALL refresh_continuous_aggregate('conditions_daily', NULL, NULL);
 SELECT * FROM conditions_daily ORDER BY bucket, avg;

--- a/tsl/test/expected/cagg_errors.out
+++ b/tsl/test/expected/cagg_errors.out
@@ -572,13 +572,12 @@ SELECT compress_chunk(ch) FROM show_chunks('i2980_cagg2') ch;
 (1 row)
 
 ALTER MATERIALIZED VIEW i2980_cagg2 SET ( timescaledb.compress = 'false');
-ERROR:  cannot change configuration on already compressed chunks
+ERROR:  cannot disable compression on hypertable with compressed chunks
 ALTER MATERIALIZED VIEW i2980_cagg2 SET ( timescaledb.compress = 'true');
 NOTICE:  defaulting compress_orderby to bucket
-ERROR:  cannot change configuration on already compressed chunks
 ALTER MATERIALIZED VIEW i2980_cagg2 SET ( timescaledb.compress, timescaledb.compress_segmentby = 'bucket');
 NOTICE:  defaulting compress_orderby to bucket
-ERROR:  cannot change configuration on already compressed chunks
+ERROR:  cannot use column "bucket" for both ordering and segmenting
 --Errors with compression policy on caggs--
 select add_continuous_aggregate_policy('i2980_cagg2', interval '10 day', interval '2 day' ,'4h') AS job_id ;
  job_id 

--- a/tsl/test/expected/compression_ddl.out
+++ b/tsl/test/expected/compression_ddl.out
@@ -1354,7 +1354,7 @@ CREATE INDEX ON compression_insert(device_id,time);
 SELECT create_hypertable('compression_insert','time',create_default_indexes:=false);
         create_hypertable         
 ----------------------------------
- (32,public,compression_insert,t)
+ (31,public,compression_insert,t)
 (1 row)
 
 ALTER TABLE compression_insert SET (timescaledb.compress, timescaledb.compress_orderby='time DESC', timescaledb.compress_segmentby='device_id');
@@ -1393,17 +1393,17 @@ ORDER BY device_id;
                                                                   QUERY PLAN                                                                   
 -----------------------------------------------------------------------------------------------------------------------------------------------
  Finalize GroupAggregate
-   Group Key: _hyper_32_110_chunk.device_id
+   Group Key: _hyper_31_110_chunk.device_id
    ->  Sort
-         Sort Key: _hyper_32_110_chunk.device_id
+         Sort Key: _hyper_31_110_chunk.device_id
          ->  Append
                ->  Partial GroupAggregate
-                     Group Key: _hyper_32_110_chunk.device_id
-                     ->  Custom Scan (DecompressChunk) on _hyper_32_110_chunk
-                           ->  Index Scan using compress_hyper_33_111_chunk_device_id__ts_meta_sequence_num_idx on compress_hyper_33_111_chunk
+                     Group Key: _hyper_31_110_chunk.device_id
+                     ->  Custom Scan (DecompressChunk) on _hyper_31_110_chunk
+                           ->  Index Scan using compress_hyper_32_111_chunk_device_id__ts_meta_sequence_num_idx on compress_hyper_32_111_chunk
                ->  Partial GroupAggregate
-                     Group Key: _hyper_32_110_chunk.device_id
-                     ->  Index Only Scan using _hyper_32_110_chunk_compression_insert_device_id_time_idx on _hyper_32_110_chunk
+                     Group Key: _hyper_31_110_chunk.device_id
+                     ->  Index Only Scan using _hyper_31_110_chunk_compression_insert_device_id_time_idx on _hyper_31_110_chunk
 (12 rows)
 
 SELECT device_id, count(*)
@@ -1473,21 +1473,21 @@ ORDER BY device_id;
                                                                   QUERY PLAN                                                                   
 -----------------------------------------------------------------------------------------------------------------------------------------------
  Finalize GroupAggregate
-   Group Key: _hyper_32_110_chunk.device_id
+   Group Key: _hyper_31_110_chunk.device_id
    ->  Sort
-         Sort Key: _hyper_32_110_chunk.device_id
+         Sort Key: _hyper_31_110_chunk.device_id
          ->  Append
                ->  Partial GroupAggregate
-                     Group Key: _hyper_32_110_chunk.device_id
-                     ->  Custom Scan (DecompressChunk) on _hyper_32_110_chunk
-                           ->  Index Scan using compress_hyper_33_111_chunk_device_id__ts_meta_sequence_num_idx on compress_hyper_33_111_chunk
+                     Group Key: _hyper_31_110_chunk.device_id
+                     ->  Custom Scan (DecompressChunk) on _hyper_31_110_chunk
+                           ->  Index Scan using compress_hyper_32_111_chunk_device_id__ts_meta_sequence_num_idx on compress_hyper_32_111_chunk
                ->  Partial GroupAggregate
-                     Group Key: _hyper_32_112_chunk.device_id
-                     ->  Custom Scan (DecompressChunk) on _hyper_32_112_chunk
-                           ->  Index Scan using compress_hyper_33_113_chunk_device_id__ts_meta_sequence_num_idx on compress_hyper_33_113_chunk
+                     Group Key: _hyper_31_112_chunk.device_id
+                     ->  Custom Scan (DecompressChunk) on _hyper_31_112_chunk
+                           ->  Index Scan using compress_hyper_32_113_chunk_device_id__ts_meta_sequence_num_idx on compress_hyper_32_113_chunk
                ->  Partial GroupAggregate
-                     Group Key: _hyper_32_112_chunk.device_id
-                     ->  Index Only Scan using _hyper_32_112_chunk_compression_insert_device_id_time_idx on _hyper_32_112_chunk
+                     Group Key: _hyper_31_112_chunk.device_id
+                     ->  Index Only Scan using _hyper_31_112_chunk_compression_insert_device_id_time_idx on _hyper_31_112_chunk
 (16 rows)
 
 SELECT device_id, count(*)
@@ -1557,25 +1557,25 @@ ORDER BY device_id;
                                                                   QUERY PLAN                                                                   
 -----------------------------------------------------------------------------------------------------------------------------------------------
  Finalize GroupAggregate
-   Group Key: _hyper_32_110_chunk.device_id
+   Group Key: _hyper_31_110_chunk.device_id
    ->  Sort
-         Sort Key: _hyper_32_110_chunk.device_id
+         Sort Key: _hyper_31_110_chunk.device_id
          ->  Append
                ->  Partial GroupAggregate
-                     Group Key: _hyper_32_110_chunk.device_id
-                     ->  Custom Scan (DecompressChunk) on _hyper_32_110_chunk
-                           ->  Index Scan using compress_hyper_33_111_chunk_device_id__ts_meta_sequence_num_idx on compress_hyper_33_111_chunk
+                     Group Key: _hyper_31_110_chunk.device_id
+                     ->  Custom Scan (DecompressChunk) on _hyper_31_110_chunk
+                           ->  Index Scan using compress_hyper_32_111_chunk_device_id__ts_meta_sequence_num_idx on compress_hyper_32_111_chunk
                ->  Partial GroupAggregate
-                     Group Key: _hyper_32_112_chunk.device_id
-                     ->  Custom Scan (DecompressChunk) on _hyper_32_112_chunk
-                           ->  Index Scan using compress_hyper_33_113_chunk_device_id__ts_meta_sequence_num_idx on compress_hyper_33_113_chunk
+                     Group Key: _hyper_31_112_chunk.device_id
+                     ->  Custom Scan (DecompressChunk) on _hyper_31_112_chunk
+                           ->  Index Scan using compress_hyper_32_113_chunk_device_id__ts_meta_sequence_num_idx on compress_hyper_32_113_chunk
                ->  Partial GroupAggregate
-                     Group Key: _hyper_32_114_chunk.device_id
-                     ->  Custom Scan (DecompressChunk) on _hyper_32_114_chunk
-                           ->  Index Scan using compress_hyper_33_115_chunk_device_id__ts_meta_sequence_num_idx on compress_hyper_33_115_chunk
+                     Group Key: _hyper_31_114_chunk.device_id
+                     ->  Custom Scan (DecompressChunk) on _hyper_31_114_chunk
+                           ->  Index Scan using compress_hyper_32_115_chunk_device_id__ts_meta_sequence_num_idx on compress_hyper_32_115_chunk
                ->  Partial GroupAggregate
-                     Group Key: _hyper_32_114_chunk.device_id
-                     ->  Index Only Scan using _hyper_32_114_chunk_compression_insert_device_id_time_idx on _hyper_32_114_chunk
+                     Group Key: _hyper_31_114_chunk.device_id
+                     ->  Index Only Scan using _hyper_31_114_chunk_compression_insert_device_id_time_idx on _hyper_31_114_chunk
 (20 rows)
 
 SELECT device_id, count(*)
@@ -1645,29 +1645,29 @@ ORDER BY device_id;
                                                                   QUERY PLAN                                                                   
 -----------------------------------------------------------------------------------------------------------------------------------------------
  Finalize GroupAggregate
-   Group Key: _hyper_32_110_chunk.device_id
+   Group Key: _hyper_31_110_chunk.device_id
    ->  Sort
-         Sort Key: _hyper_32_110_chunk.device_id
+         Sort Key: _hyper_31_110_chunk.device_id
          ->  Append
                ->  Partial GroupAggregate
-                     Group Key: _hyper_32_110_chunk.device_id
-                     ->  Custom Scan (DecompressChunk) on _hyper_32_110_chunk
-                           ->  Index Scan using compress_hyper_33_111_chunk_device_id__ts_meta_sequence_num_idx on compress_hyper_33_111_chunk
+                     Group Key: _hyper_31_110_chunk.device_id
+                     ->  Custom Scan (DecompressChunk) on _hyper_31_110_chunk
+                           ->  Index Scan using compress_hyper_32_111_chunk_device_id__ts_meta_sequence_num_idx on compress_hyper_32_111_chunk
                ->  Partial GroupAggregate
-                     Group Key: _hyper_32_112_chunk.device_id
-                     ->  Custom Scan (DecompressChunk) on _hyper_32_112_chunk
-                           ->  Index Scan using compress_hyper_33_113_chunk_device_id__ts_meta_sequence_num_idx on compress_hyper_33_113_chunk
+                     Group Key: _hyper_31_112_chunk.device_id
+                     ->  Custom Scan (DecompressChunk) on _hyper_31_112_chunk
+                           ->  Index Scan using compress_hyper_32_113_chunk_device_id__ts_meta_sequence_num_idx on compress_hyper_32_113_chunk
                ->  Partial GroupAggregate
-                     Group Key: _hyper_32_114_chunk.device_id
-                     ->  Custom Scan (DecompressChunk) on _hyper_32_114_chunk
-                           ->  Index Scan using compress_hyper_33_115_chunk_device_id__ts_meta_sequence_num_idx on compress_hyper_33_115_chunk
+                     Group Key: _hyper_31_114_chunk.device_id
+                     ->  Custom Scan (DecompressChunk) on _hyper_31_114_chunk
+                           ->  Index Scan using compress_hyper_32_115_chunk_device_id__ts_meta_sequence_num_idx on compress_hyper_32_115_chunk
                ->  Partial GroupAggregate
-                     Group Key: _hyper_32_116_chunk.device_id
-                     ->  Custom Scan (DecompressChunk) on _hyper_32_116_chunk
-                           ->  Index Scan using compress_hyper_33_117_chunk_device_id__ts_meta_sequence_num_idx on compress_hyper_33_117_chunk
+                     Group Key: _hyper_31_116_chunk.device_id
+                     ->  Custom Scan (DecompressChunk) on _hyper_31_116_chunk
+                           ->  Index Scan using compress_hyper_32_117_chunk_device_id__ts_meta_sequence_num_idx on compress_hyper_32_117_chunk
                ->  Partial GroupAggregate
-                     Group Key: _hyper_32_116_chunk.device_id
-                     ->  Index Only Scan using _hyper_32_116_chunk_compression_insert_device_id_time_idx on _hyper_32_116_chunk
+                     Group Key: _hyper_31_116_chunk.device_id
+                     ->  Index Only Scan using _hyper_31_116_chunk_compression_insert_device_id_time_idx on _hyper_31_116_chunk
 (24 rows)
 
 SELECT device_id, count(*)
@@ -1737,33 +1737,33 @@ ORDER BY device_id;
                                                                   QUERY PLAN                                                                   
 -----------------------------------------------------------------------------------------------------------------------------------------------
  Finalize GroupAggregate
-   Group Key: _hyper_32_110_chunk.device_id
+   Group Key: _hyper_31_110_chunk.device_id
    ->  Sort
-         Sort Key: _hyper_32_110_chunk.device_id
+         Sort Key: _hyper_31_110_chunk.device_id
          ->  Append
                ->  Partial GroupAggregate
-                     Group Key: _hyper_32_110_chunk.device_id
-                     ->  Custom Scan (DecompressChunk) on _hyper_32_110_chunk
-                           ->  Index Scan using compress_hyper_33_111_chunk_device_id__ts_meta_sequence_num_idx on compress_hyper_33_111_chunk
+                     Group Key: _hyper_31_110_chunk.device_id
+                     ->  Custom Scan (DecompressChunk) on _hyper_31_110_chunk
+                           ->  Index Scan using compress_hyper_32_111_chunk_device_id__ts_meta_sequence_num_idx on compress_hyper_32_111_chunk
                ->  Partial GroupAggregate
-                     Group Key: _hyper_32_112_chunk.device_id
-                     ->  Custom Scan (DecompressChunk) on _hyper_32_112_chunk
-                           ->  Index Scan using compress_hyper_33_113_chunk_device_id__ts_meta_sequence_num_idx on compress_hyper_33_113_chunk
+                     Group Key: _hyper_31_112_chunk.device_id
+                     ->  Custom Scan (DecompressChunk) on _hyper_31_112_chunk
+                           ->  Index Scan using compress_hyper_32_113_chunk_device_id__ts_meta_sequence_num_idx on compress_hyper_32_113_chunk
                ->  Partial GroupAggregate
-                     Group Key: _hyper_32_114_chunk.device_id
-                     ->  Custom Scan (DecompressChunk) on _hyper_32_114_chunk
-                           ->  Index Scan using compress_hyper_33_115_chunk_device_id__ts_meta_sequence_num_idx on compress_hyper_33_115_chunk
+                     Group Key: _hyper_31_114_chunk.device_id
+                     ->  Custom Scan (DecompressChunk) on _hyper_31_114_chunk
+                           ->  Index Scan using compress_hyper_32_115_chunk_device_id__ts_meta_sequence_num_idx on compress_hyper_32_115_chunk
                ->  Partial GroupAggregate
-                     Group Key: _hyper_32_116_chunk.device_id
-                     ->  Custom Scan (DecompressChunk) on _hyper_32_116_chunk
-                           ->  Index Scan using compress_hyper_33_117_chunk_device_id__ts_meta_sequence_num_idx on compress_hyper_33_117_chunk
+                     Group Key: _hyper_31_116_chunk.device_id
+                     ->  Custom Scan (DecompressChunk) on _hyper_31_116_chunk
+                           ->  Index Scan using compress_hyper_32_117_chunk_device_id__ts_meta_sequence_num_idx on compress_hyper_32_117_chunk
                ->  Partial GroupAggregate
-                     Group Key: _hyper_32_118_chunk.device_id
-                     ->  Custom Scan (DecompressChunk) on _hyper_32_118_chunk
-                           ->  Index Scan using compress_hyper_33_119_chunk_device_id__ts_meta_sequence_num_idx on compress_hyper_33_119_chunk
+                     Group Key: _hyper_31_118_chunk.device_id
+                     ->  Custom Scan (DecompressChunk) on _hyper_31_118_chunk
+                           ->  Index Scan using compress_hyper_32_119_chunk_device_id__ts_meta_sequence_num_idx on compress_hyper_32_119_chunk
                ->  Partial GroupAggregate
-                     Group Key: _hyper_32_118_chunk.device_id
-                     ->  Index Only Scan using _hyper_32_118_chunk_compression_insert_device_id_time_idx on _hyper_32_118_chunk
+                     Group Key: _hyper_31_118_chunk.device_id
+                     ->  Index Only Scan using _hyper_31_118_chunk_compression_insert_device_id_time_idx on _hyper_31_118_chunk
 (28 rows)
 
 SELECT device_id, count(*)
@@ -1810,7 +1810,7 @@ CREATE TABLE test_partials (time timestamptz NOT NULL, a int, b int);
 SELECT create_hypertable('test_partials', 'time');
       create_hypertable      
 -----------------------------
- (34,public,test_partials,t)
+ (33,public,test_partials,t)
 (1 row)
 
 INSERT INTO test_partials
@@ -1829,9 +1829,9 @@ ALTER TABLE test_partials SET (timescaledb.compress);
 SELECT compress_chunk(show_chunks('test_partials'));
               compress_chunk               
 -------------------------------------------
- _timescaledb_internal._hyper_34_120_chunk
- _timescaledb_internal._hyper_34_121_chunk
- _timescaledb_internal._hyper_34_122_chunk
+ _timescaledb_internal._hyper_33_120_chunk
+ _timescaledb_internal._hyper_33_121_chunk
+ _timescaledb_internal._hyper_33_122_chunk
 (3 rows)
 
 -- fully compressed
@@ -1840,18 +1840,18 @@ EXPLAIN (costs off) SELECT * FROM test_partials ORDER BY time;
 --------------------------------------------------------------------------------
  Custom Scan (ChunkAppend) on test_partials
    Order: test_partials."time"
-   ->  Custom Scan (DecompressChunk) on _hyper_34_120_chunk
+   ->  Custom Scan (DecompressChunk) on _hyper_33_120_chunk
          ->  Sort
-               Sort Key: compress_hyper_35_123_chunk._ts_meta_sequence_num DESC
-               ->  Seq Scan on compress_hyper_35_123_chunk
-   ->  Custom Scan (DecompressChunk) on _hyper_34_121_chunk
+               Sort Key: compress_hyper_34_123_chunk._ts_meta_sequence_num DESC
+               ->  Seq Scan on compress_hyper_34_123_chunk
+   ->  Custom Scan (DecompressChunk) on _hyper_33_121_chunk
          ->  Sort
-               Sort Key: compress_hyper_35_124_chunk._ts_meta_sequence_num DESC
-               ->  Seq Scan on compress_hyper_35_124_chunk
-   ->  Custom Scan (DecompressChunk) on _hyper_34_122_chunk
+               Sort Key: compress_hyper_34_124_chunk._ts_meta_sequence_num DESC
+               ->  Seq Scan on compress_hyper_34_124_chunk
+   ->  Custom Scan (DecompressChunk) on _hyper_33_122_chunk
          ->  Sort
-               Sort Key: compress_hyper_35_125_chunk._ts_meta_sequence_num DESC
-               ->  Seq Scan on compress_hyper_35_125_chunk
+               Sort Key: compress_hyper_34_125_chunk._ts_meta_sequence_num DESC
+               ->  Seq Scan on compress_hyper_34_125_chunk
 (14 rows)
 
 -- test P, F, F
@@ -1862,22 +1862,22 @@ EXPLAIN (costs off) SELECT * FROM test_partials ORDER BY time;
  Custom Scan (ChunkAppend) on test_partials
    Order: test_partials."time"
    ->  Merge Append
-         Sort Key: _hyper_34_120_chunk."time"
-         ->  Custom Scan (DecompressChunk) on _hyper_34_120_chunk
+         Sort Key: _hyper_33_120_chunk."time"
+         ->  Custom Scan (DecompressChunk) on _hyper_33_120_chunk
                ->  Sort
-                     Sort Key: compress_hyper_35_123_chunk._ts_meta_sequence_num DESC
-                     ->  Seq Scan on compress_hyper_35_123_chunk
+                     Sort Key: compress_hyper_34_123_chunk._ts_meta_sequence_num DESC
+                     ->  Seq Scan on compress_hyper_34_123_chunk
          ->  Sort
-               Sort Key: _hyper_34_120_chunk."time"
-               ->  Seq Scan on _hyper_34_120_chunk
-   ->  Custom Scan (DecompressChunk) on _hyper_34_121_chunk
+               Sort Key: _hyper_33_120_chunk."time"
+               ->  Seq Scan on _hyper_33_120_chunk
+   ->  Custom Scan (DecompressChunk) on _hyper_33_121_chunk
          ->  Sort
-               Sort Key: compress_hyper_35_124_chunk._ts_meta_sequence_num DESC
-               ->  Seq Scan on compress_hyper_35_124_chunk
-   ->  Custom Scan (DecompressChunk) on _hyper_34_122_chunk
+               Sort Key: compress_hyper_34_124_chunk._ts_meta_sequence_num DESC
+               ->  Seq Scan on compress_hyper_34_124_chunk
+   ->  Custom Scan (DecompressChunk) on _hyper_33_122_chunk
          ->  Sort
-               Sort Key: compress_hyper_35_125_chunk._ts_meta_sequence_num DESC
-               ->  Seq Scan on compress_hyper_35_125_chunk
+               Sort Key: compress_hyper_34_125_chunk._ts_meta_sequence_num DESC
+               ->  Seq Scan on compress_hyper_34_125_chunk
 (19 rows)
 
 -- verify correct results
@@ -1903,27 +1903,27 @@ EXPLAIN (costs off) SELECT * FROM test_partials ORDER BY time;
  Custom Scan (ChunkAppend) on test_partials
    Order: test_partials."time"
    ->  Merge Append
-         Sort Key: _hyper_34_120_chunk."time"
-         ->  Custom Scan (DecompressChunk) on _hyper_34_120_chunk
+         Sort Key: _hyper_33_120_chunk."time"
+         ->  Custom Scan (DecompressChunk) on _hyper_33_120_chunk
                ->  Sort
-                     Sort Key: compress_hyper_35_123_chunk._ts_meta_sequence_num DESC
-                     ->  Seq Scan on compress_hyper_35_123_chunk
+                     Sort Key: compress_hyper_34_123_chunk._ts_meta_sequence_num DESC
+                     ->  Seq Scan on compress_hyper_34_123_chunk
          ->  Sort
-               Sort Key: _hyper_34_120_chunk."time"
-               ->  Seq Scan on _hyper_34_120_chunk
+               Sort Key: _hyper_33_120_chunk."time"
+               ->  Seq Scan on _hyper_33_120_chunk
    ->  Merge Append
-         Sort Key: _hyper_34_121_chunk."time"
-         ->  Custom Scan (DecompressChunk) on _hyper_34_121_chunk
+         Sort Key: _hyper_33_121_chunk."time"
+         ->  Custom Scan (DecompressChunk) on _hyper_33_121_chunk
                ->  Sort
-                     Sort Key: compress_hyper_35_124_chunk._ts_meta_sequence_num DESC
-                     ->  Seq Scan on compress_hyper_35_124_chunk
+                     Sort Key: compress_hyper_34_124_chunk._ts_meta_sequence_num DESC
+                     ->  Seq Scan on compress_hyper_34_124_chunk
          ->  Sort
-               Sort Key: _hyper_34_121_chunk."time"
-               ->  Seq Scan on _hyper_34_121_chunk
-   ->  Custom Scan (DecompressChunk) on _hyper_34_122_chunk
+               Sort Key: _hyper_33_121_chunk."time"
+               ->  Seq Scan on _hyper_33_121_chunk
+   ->  Custom Scan (DecompressChunk) on _hyper_33_122_chunk
          ->  Sort
-               Sort Key: compress_hyper_35_125_chunk._ts_meta_sequence_num DESC
-               ->  Seq Scan on compress_hyper_35_125_chunk
+               Sort Key: compress_hyper_34_125_chunk._ts_meta_sequence_num DESC
+               ->  Seq Scan on compress_hyper_34_125_chunk
 (24 rows)
 
 -- verify correct results
@@ -1951,33 +1951,33 @@ EXPLAIN (costs off) SELECT * FROM test_partials ORDER BY time;
  Custom Scan (ChunkAppend) on test_partials
    Order: test_partials."time"
    ->  Merge Append
-         Sort Key: _hyper_34_120_chunk."time"
-         ->  Custom Scan (DecompressChunk) on _hyper_34_120_chunk
+         Sort Key: _hyper_33_120_chunk."time"
+         ->  Custom Scan (DecompressChunk) on _hyper_33_120_chunk
                ->  Sort
-                     Sort Key: compress_hyper_35_123_chunk._ts_meta_sequence_num DESC
-                     ->  Seq Scan on compress_hyper_35_123_chunk
+                     Sort Key: compress_hyper_34_123_chunk._ts_meta_sequence_num DESC
+                     ->  Seq Scan on compress_hyper_34_123_chunk
          ->  Sort
-               Sort Key: _hyper_34_120_chunk."time"
-               ->  Seq Scan on _hyper_34_120_chunk
+               Sort Key: _hyper_33_120_chunk."time"
+               ->  Seq Scan on _hyper_33_120_chunk
    ->  Merge Append
-         Sort Key: _hyper_34_121_chunk."time"
-         ->  Custom Scan (DecompressChunk) on _hyper_34_121_chunk
+         Sort Key: _hyper_33_121_chunk."time"
+         ->  Custom Scan (DecompressChunk) on _hyper_33_121_chunk
                ->  Sort
-                     Sort Key: compress_hyper_35_124_chunk._ts_meta_sequence_num DESC
-                     ->  Seq Scan on compress_hyper_35_124_chunk
+                     Sort Key: compress_hyper_34_124_chunk._ts_meta_sequence_num DESC
+                     ->  Seq Scan on compress_hyper_34_124_chunk
          ->  Sort
-               Sort Key: _hyper_34_121_chunk."time"
-               ->  Seq Scan on _hyper_34_121_chunk
+               Sort Key: _hyper_33_121_chunk."time"
+               ->  Seq Scan on _hyper_33_121_chunk
    ->  Merge Append
-         Sort Key: _hyper_34_122_chunk."time"
-         ->  Custom Scan (DecompressChunk) on _hyper_34_122_chunk
+         Sort Key: _hyper_33_122_chunk."time"
+         ->  Custom Scan (DecompressChunk) on _hyper_33_122_chunk
                ->  Sort
-                     Sort Key: compress_hyper_35_125_chunk._ts_meta_sequence_num DESC
-                     ->  Seq Scan on compress_hyper_35_125_chunk
+                     Sort Key: compress_hyper_34_125_chunk._ts_meta_sequence_num DESC
+                     ->  Seq Scan on compress_hyper_34_125_chunk
          ->  Sort
-               Sort Key: _hyper_34_122_chunk."time"
-               ->  Seq Scan on _hyper_34_122_chunk
-   ->  Index Scan Backward using _hyper_34_126_chunk_test_partials_time_idx on _hyper_34_126_chunk
+               Sort Key: _hyper_33_122_chunk."time"
+               ->  Seq Scan on _hyper_33_122_chunk
+   ->  Index Scan Backward using _hyper_33_126_chunk_test_partials_time_idx on _hyper_33_126_chunk
 (30 rows)
 
 -- F, F, P, U
@@ -2001,24 +2001,24 @@ EXPLAIN (COSTS OFF) SELECT * FROM test_partials ORDER BY time;
 ---------------------------------------------------------------------------------------------------
  Custom Scan (ChunkAppend) on test_partials
    Order: test_partials."time"
-   ->  Custom Scan (DecompressChunk) on _hyper_34_120_chunk
+   ->  Custom Scan (DecompressChunk) on _hyper_33_120_chunk
          ->  Sort
-               Sort Key: compress_hyper_35_127_chunk._ts_meta_sequence_num DESC
-               ->  Seq Scan on compress_hyper_35_127_chunk
-   ->  Custom Scan (DecompressChunk) on _hyper_34_121_chunk
+               Sort Key: compress_hyper_34_127_chunk._ts_meta_sequence_num DESC
+               ->  Seq Scan on compress_hyper_34_127_chunk
+   ->  Custom Scan (DecompressChunk) on _hyper_33_121_chunk
          ->  Sort
-               Sort Key: compress_hyper_35_128_chunk._ts_meta_sequence_num DESC
-               ->  Seq Scan on compress_hyper_35_128_chunk
+               Sort Key: compress_hyper_34_128_chunk._ts_meta_sequence_num DESC
+               ->  Seq Scan on compress_hyper_34_128_chunk
    ->  Merge Append
-         Sort Key: _hyper_34_122_chunk."time"
-         ->  Custom Scan (DecompressChunk) on _hyper_34_122_chunk
+         Sort Key: _hyper_33_122_chunk."time"
+         ->  Custom Scan (DecompressChunk) on _hyper_33_122_chunk
                ->  Sort
-                     Sort Key: compress_hyper_35_129_chunk._ts_meta_sequence_num DESC
-                     ->  Seq Scan on compress_hyper_35_129_chunk
+                     Sort Key: compress_hyper_34_129_chunk._ts_meta_sequence_num DESC
+                     ->  Seq Scan on compress_hyper_34_129_chunk
          ->  Sort
-               Sort Key: _hyper_34_122_chunk."time"
-               ->  Seq Scan on _hyper_34_122_chunk
-   ->  Index Scan Backward using _hyper_34_126_chunk_test_partials_time_idx on _hyper_34_126_chunk
+               Sort Key: _hyper_33_122_chunk."time"
+               ->  Seq Scan on _hyper_33_122_chunk
+   ->  Index Scan Backward using _hyper_33_126_chunk_test_partials_time_idx on _hyper_33_126_chunk
 (20 rows)
 
 -- F, F, P, F, F
@@ -2026,8 +2026,8 @@ INSERT INTO test_partials VALUES ('2024-01-01 00:02', 1, 2);
 SELECT compress_chunk(c) FROM show_chunks('test_partials', newer_than => '2022-01-01') c;
               compress_chunk               
 -------------------------------------------
- _timescaledb_internal._hyper_34_126_chunk
- _timescaledb_internal._hyper_34_130_chunk
+ _timescaledb_internal._hyper_33_126_chunk
+ _timescaledb_internal._hyper_33_130_chunk
 (2 rows)
 
 EXPLAIN (costs off) SELECT * FROM test_partials ORDER BY time;
@@ -2035,31 +2035,31 @@ EXPLAIN (costs off) SELECT * FROM test_partials ORDER BY time;
 --------------------------------------------------------------------------------------
  Custom Scan (ChunkAppend) on test_partials
    Order: test_partials."time"
-   ->  Custom Scan (DecompressChunk) on _hyper_34_120_chunk
+   ->  Custom Scan (DecompressChunk) on _hyper_33_120_chunk
          ->  Sort
-               Sort Key: compress_hyper_35_127_chunk._ts_meta_sequence_num DESC
-               ->  Seq Scan on compress_hyper_35_127_chunk
-   ->  Custom Scan (DecompressChunk) on _hyper_34_121_chunk
+               Sort Key: compress_hyper_34_127_chunk._ts_meta_sequence_num DESC
+               ->  Seq Scan on compress_hyper_34_127_chunk
+   ->  Custom Scan (DecompressChunk) on _hyper_33_121_chunk
          ->  Sort
-               Sort Key: compress_hyper_35_128_chunk._ts_meta_sequence_num DESC
-               ->  Seq Scan on compress_hyper_35_128_chunk
+               Sort Key: compress_hyper_34_128_chunk._ts_meta_sequence_num DESC
+               ->  Seq Scan on compress_hyper_34_128_chunk
    ->  Merge Append
-         Sort Key: _hyper_34_122_chunk."time"
-         ->  Custom Scan (DecompressChunk) on _hyper_34_122_chunk
+         Sort Key: _hyper_33_122_chunk."time"
+         ->  Custom Scan (DecompressChunk) on _hyper_33_122_chunk
                ->  Sort
-                     Sort Key: compress_hyper_35_129_chunk._ts_meta_sequence_num DESC
-                     ->  Seq Scan on compress_hyper_35_129_chunk
+                     Sort Key: compress_hyper_34_129_chunk._ts_meta_sequence_num DESC
+                     ->  Seq Scan on compress_hyper_34_129_chunk
          ->  Sort
-               Sort Key: _hyper_34_122_chunk."time"
-               ->  Seq Scan on _hyper_34_122_chunk
-   ->  Custom Scan (DecompressChunk) on _hyper_34_126_chunk
+               Sort Key: _hyper_33_122_chunk."time"
+               ->  Seq Scan on _hyper_33_122_chunk
+   ->  Custom Scan (DecompressChunk) on _hyper_33_126_chunk
          ->  Sort
-               Sort Key: compress_hyper_35_131_chunk._ts_meta_sequence_num DESC
-               ->  Seq Scan on compress_hyper_35_131_chunk
-   ->  Custom Scan (DecompressChunk) on _hyper_34_130_chunk
+               Sort Key: compress_hyper_34_131_chunk._ts_meta_sequence_num DESC
+               ->  Seq Scan on compress_hyper_34_131_chunk
+   ->  Custom Scan (DecompressChunk) on _hyper_33_130_chunk
          ->  Sort
-               Sort Key: compress_hyper_35_132_chunk._ts_meta_sequence_num DESC
-               ->  Seq Scan on compress_hyper_35_132_chunk
+               Sort Key: compress_hyper_34_132_chunk._ts_meta_sequence_num DESC
+               ->  Seq Scan on compress_hyper_34_132_chunk
 (27 rows)
 
 -- verify result correctness
@@ -2087,7 +2087,7 @@ SELECT create_hypertable('space_part', 'time', chunk_time_interval => INTERVAL '
 NOTICE:  adding not-null constraint to column "time"
     create_hypertable     
 --------------------------
- (36,public,space_part,t)
+ (35,public,space_part,t)
 (1 row)
 
 INSERT INTO space_part VALUES
@@ -2107,8 +2107,8 @@ ALTER TABLE space_part SET (timescaledb.compress);
 SELECT compress_chunk(show_chunks('space_part'));
               compress_chunk               
 -------------------------------------------
- _timescaledb_internal._hyper_36_133_chunk
- _timescaledb_internal._hyper_36_134_chunk
+ _timescaledb_internal._hyper_35_133_chunk
+ _timescaledb_internal._hyper_35_134_chunk
 (2 rows)
 
 -- make first chunk partial
@@ -2130,18 +2130,18 @@ EXPLAIN (COSTS OFF) SELECT * FROM space_part ORDER BY time;
  Custom Scan (ChunkAppend) on space_part
    Order: space_part."time"
    ->  Merge Append
-         Sort Key: _hyper_36_133_chunk."time"
-         ->  Custom Scan (DecompressChunk) on _hyper_36_133_chunk
+         Sort Key: _hyper_35_133_chunk."time"
+         ->  Custom Scan (DecompressChunk) on _hyper_35_133_chunk
                ->  Sort
-                     Sort Key: compress_hyper_37_135_chunk._ts_meta_sequence_num DESC
-                     ->  Seq Scan on compress_hyper_37_135_chunk
+                     Sort Key: compress_hyper_36_135_chunk._ts_meta_sequence_num DESC
+                     ->  Seq Scan on compress_hyper_36_135_chunk
          ->  Sort
-               Sort Key: _hyper_36_133_chunk."time"
-               ->  Seq Scan on _hyper_36_133_chunk
-   ->  Custom Scan (DecompressChunk) on _hyper_36_134_chunk
+               Sort Key: _hyper_35_133_chunk."time"
+               ->  Seq Scan on _hyper_35_133_chunk
+   ->  Custom Scan (DecompressChunk) on _hyper_35_134_chunk
          ->  Sort
-               Sort Key: compress_hyper_37_136_chunk._ts_meta_sequence_num DESC
-               ->  Seq Scan on compress_hyper_37_136_chunk
+               Sort Key: compress_hyper_36_136_chunk._ts_meta_sequence_num DESC
+               ->  Seq Scan on compress_hyper_36_136_chunk
 (15 rows)
 
 -- now add more chunks that do adhere to the new space partitioning
@@ -2158,34 +2158,34 @@ EXPLAIN (COSTS OFF) SELECT * FROM space_part ORDER BY time;
  Custom Scan (ChunkAppend) on space_part
    Order: space_part."time"
    ->  Merge Append
-         Sort Key: _hyper_36_133_chunk."time"
-         ->  Custom Scan (DecompressChunk) on _hyper_36_133_chunk
+         Sort Key: _hyper_35_133_chunk."time"
+         ->  Custom Scan (DecompressChunk) on _hyper_35_133_chunk
                ->  Sort
-                     Sort Key: compress_hyper_37_135_chunk._ts_meta_sequence_num DESC
-                     ->  Seq Scan on compress_hyper_37_135_chunk
+                     Sort Key: compress_hyper_36_135_chunk._ts_meta_sequence_num DESC
+                     ->  Seq Scan on compress_hyper_36_135_chunk
          ->  Sort
-               Sort Key: _hyper_36_133_chunk."time"
-               ->  Seq Scan on _hyper_36_133_chunk
-   ->  Custom Scan (DecompressChunk) on _hyper_36_134_chunk
+               Sort Key: _hyper_35_133_chunk."time"
+               ->  Seq Scan on _hyper_35_133_chunk
+   ->  Custom Scan (DecompressChunk) on _hyper_35_134_chunk
          ->  Sort
-               Sort Key: compress_hyper_37_136_chunk._ts_meta_sequence_num DESC
-               ->  Seq Scan on compress_hyper_37_136_chunk
+               Sort Key: compress_hyper_36_136_chunk._ts_meta_sequence_num DESC
+               ->  Seq Scan on compress_hyper_36_136_chunk
    ->  Merge Append
-         Sort Key: _hyper_36_137_chunk."time"
-         ->  Index Scan Backward using _hyper_36_137_chunk_space_part_time_idx on _hyper_36_137_chunk
-         ->  Index Scan Backward using _hyper_36_138_chunk_space_part_time_idx on _hyper_36_138_chunk
+         Sort Key: _hyper_35_137_chunk."time"
+         ->  Index Scan Backward using _hyper_35_137_chunk_space_part_time_idx on _hyper_35_137_chunk
+         ->  Index Scan Backward using _hyper_35_138_chunk_space_part_time_idx on _hyper_35_138_chunk
 (19 rows)
 
 -- compress them
 SELECT compress_chunk(c, if_not_compressed=>true) FROM show_chunks('space_part') c;
-NOTICE:  chunk "_hyper_36_133_chunk" is already compressed
-NOTICE:  chunk "_hyper_36_134_chunk" is already compressed
+NOTICE:  chunk "_hyper_35_133_chunk" is already compressed
+NOTICE:  chunk "_hyper_35_134_chunk" is already compressed
               compress_chunk               
 -------------------------------------------
- _timescaledb_internal._hyper_36_133_chunk
- _timescaledb_internal._hyper_36_134_chunk
- _timescaledb_internal._hyper_36_137_chunk
- _timescaledb_internal._hyper_36_138_chunk
+ _timescaledb_internal._hyper_35_133_chunk
+ _timescaledb_internal._hyper_35_134_chunk
+ _timescaledb_internal._hyper_35_137_chunk
+ _timescaledb_internal._hyper_35_138_chunk
 (4 rows)
 
 -- plan still ok
@@ -2195,28 +2195,28 @@ EXPLAIN (COSTS OFF) SELECT * FROM space_part ORDER BY time;
  Custom Scan (ChunkAppend) on space_part
    Order: space_part."time"
    ->  Merge Append
-         Sort Key: _hyper_36_133_chunk."time"
-         ->  Custom Scan (DecompressChunk) on _hyper_36_133_chunk
+         Sort Key: _hyper_35_133_chunk."time"
+         ->  Custom Scan (DecompressChunk) on _hyper_35_133_chunk
                ->  Sort
-                     Sort Key: compress_hyper_37_135_chunk._ts_meta_sequence_num DESC
-                     ->  Seq Scan on compress_hyper_37_135_chunk
+                     Sort Key: compress_hyper_36_135_chunk._ts_meta_sequence_num DESC
+                     ->  Seq Scan on compress_hyper_36_135_chunk
          ->  Sort
-               Sort Key: _hyper_36_133_chunk."time"
-               ->  Seq Scan on _hyper_36_133_chunk
-   ->  Custom Scan (DecompressChunk) on _hyper_36_134_chunk
+               Sort Key: _hyper_35_133_chunk."time"
+               ->  Seq Scan on _hyper_35_133_chunk
+   ->  Custom Scan (DecompressChunk) on _hyper_35_134_chunk
          ->  Sort
-               Sort Key: compress_hyper_37_136_chunk._ts_meta_sequence_num DESC
-               ->  Seq Scan on compress_hyper_37_136_chunk
+               Sort Key: compress_hyper_36_136_chunk._ts_meta_sequence_num DESC
+               ->  Seq Scan on compress_hyper_36_136_chunk
    ->  Merge Append
-         Sort Key: _hyper_36_137_chunk."time"
-         ->  Custom Scan (DecompressChunk) on _hyper_36_137_chunk
+         Sort Key: _hyper_35_137_chunk."time"
+         ->  Custom Scan (DecompressChunk) on _hyper_35_137_chunk
                ->  Sort
-                     Sort Key: compress_hyper_37_139_chunk._ts_meta_sequence_num DESC
-                     ->  Seq Scan on compress_hyper_37_139_chunk
-         ->  Custom Scan (DecompressChunk) on _hyper_36_138_chunk
+                     Sort Key: compress_hyper_36_139_chunk._ts_meta_sequence_num DESC
+                     ->  Seq Scan on compress_hyper_36_139_chunk
+         ->  Custom Scan (DecompressChunk) on _hyper_35_138_chunk
                ->  Sort
-                     Sort Key: compress_hyper_37_140_chunk._ts_meta_sequence_num DESC
-                     ->  Seq Scan on compress_hyper_37_140_chunk
+                     Sort Key: compress_hyper_36_140_chunk._ts_meta_sequence_num DESC
+                     ->  Seq Scan on compress_hyper_36_140_chunk
 (25 rows)
 
 -- make second one of them partial
@@ -2229,33 +2229,33 @@ EXPLAIN (COSTS OFF) SELECT * FROM space_part ORDER BY time;
  Custom Scan (ChunkAppend) on space_part
    Order: space_part."time"
    ->  Merge Append
-         Sort Key: _hyper_36_133_chunk."time"
-         ->  Custom Scan (DecompressChunk) on _hyper_36_133_chunk
+         Sort Key: _hyper_35_133_chunk."time"
+         ->  Custom Scan (DecompressChunk) on _hyper_35_133_chunk
                ->  Sort
-                     Sort Key: compress_hyper_37_135_chunk._ts_meta_sequence_num DESC
-                     ->  Seq Scan on compress_hyper_37_135_chunk
+                     Sort Key: compress_hyper_36_135_chunk._ts_meta_sequence_num DESC
+                     ->  Seq Scan on compress_hyper_36_135_chunk
          ->  Sort
-               Sort Key: _hyper_36_133_chunk."time"
-               ->  Seq Scan on _hyper_36_133_chunk
-   ->  Custom Scan (DecompressChunk) on _hyper_36_134_chunk
+               Sort Key: _hyper_35_133_chunk."time"
+               ->  Seq Scan on _hyper_35_133_chunk
+   ->  Custom Scan (DecompressChunk) on _hyper_35_134_chunk
          ->  Sort
-               Sort Key: compress_hyper_37_136_chunk._ts_meta_sequence_num DESC
-               ->  Seq Scan on compress_hyper_37_136_chunk
+               Sort Key: compress_hyper_36_136_chunk._ts_meta_sequence_num DESC
+               ->  Seq Scan on compress_hyper_36_136_chunk
    ->  Merge Append
-         Sort Key: _hyper_36_137_chunk."time"
-         ->  Custom Scan (DecompressChunk) on _hyper_36_137_chunk
+         Sort Key: _hyper_35_137_chunk."time"
+         ->  Custom Scan (DecompressChunk) on _hyper_35_137_chunk
                ->  Sort
-                     Sort Key: compress_hyper_37_139_chunk._ts_meta_sequence_num DESC
-                     ->  Seq Scan on compress_hyper_37_139_chunk
-         ->  Custom Scan (DecompressChunk) on _hyper_36_138_chunk
+                     Sort Key: compress_hyper_36_139_chunk._ts_meta_sequence_num DESC
+                     ->  Seq Scan on compress_hyper_36_139_chunk
+         ->  Custom Scan (DecompressChunk) on _hyper_35_138_chunk
                ->  Sort
-                     Sort Key: compress_hyper_37_140_chunk._ts_meta_sequence_num DESC
-                     ->  Seq Scan on compress_hyper_37_140_chunk
+                     Sort Key: compress_hyper_36_140_chunk._ts_meta_sequence_num DESC
+                     ->  Seq Scan on compress_hyper_36_140_chunk
          ->  Sort
-               Sort Key: _hyper_36_138_chunk."time"
+               Sort Key: _hyper_35_138_chunk."time"
                ->  Sort
-                     Sort Key: _hyper_36_138_chunk."time"
-                     ->  Seq Scan on _hyper_36_138_chunk
+                     Sort Key: _hyper_35_138_chunk."time"
+                     ->  Seq Scan on _hyper_35_138_chunk
 (30 rows)
 
 -- make other one partial too
@@ -2267,38 +2267,38 @@ EXPLAIN (COSTS OFF) SELECT * FROM space_part ORDER BY time;
  Custom Scan (ChunkAppend) on space_part
    Order: space_part."time"
    ->  Merge Append
-         Sort Key: _hyper_36_133_chunk."time"
-         ->  Custom Scan (DecompressChunk) on _hyper_36_133_chunk
+         Sort Key: _hyper_35_133_chunk."time"
+         ->  Custom Scan (DecompressChunk) on _hyper_35_133_chunk
                ->  Sort
-                     Sort Key: compress_hyper_37_135_chunk._ts_meta_sequence_num DESC
-                     ->  Seq Scan on compress_hyper_37_135_chunk
+                     Sort Key: compress_hyper_36_135_chunk._ts_meta_sequence_num DESC
+                     ->  Seq Scan on compress_hyper_36_135_chunk
          ->  Sort
-               Sort Key: _hyper_36_133_chunk."time"
-               ->  Seq Scan on _hyper_36_133_chunk
-   ->  Custom Scan (DecompressChunk) on _hyper_36_134_chunk
+               Sort Key: _hyper_35_133_chunk."time"
+               ->  Seq Scan on _hyper_35_133_chunk
+   ->  Custom Scan (DecompressChunk) on _hyper_35_134_chunk
          ->  Sort
-               Sort Key: compress_hyper_37_136_chunk._ts_meta_sequence_num DESC
-               ->  Seq Scan on compress_hyper_37_136_chunk
+               Sort Key: compress_hyper_36_136_chunk._ts_meta_sequence_num DESC
+               ->  Seq Scan on compress_hyper_36_136_chunk
    ->  Merge Append
-         Sort Key: _hyper_36_137_chunk."time"
-         ->  Custom Scan (DecompressChunk) on _hyper_36_137_chunk
+         Sort Key: _hyper_35_137_chunk."time"
+         ->  Custom Scan (DecompressChunk) on _hyper_35_137_chunk
                ->  Sort
-                     Sort Key: compress_hyper_37_139_chunk._ts_meta_sequence_num DESC
-                     ->  Seq Scan on compress_hyper_37_139_chunk
+                     Sort Key: compress_hyper_36_139_chunk._ts_meta_sequence_num DESC
+                     ->  Seq Scan on compress_hyper_36_139_chunk
          ->  Sort
-               Sort Key: _hyper_36_137_chunk."time"
+               Sort Key: _hyper_35_137_chunk."time"
                ->  Sort
-                     Sort Key: _hyper_36_137_chunk."time"
-                     ->  Seq Scan on _hyper_36_137_chunk
-         ->  Custom Scan (DecompressChunk) on _hyper_36_138_chunk
+                     Sort Key: _hyper_35_137_chunk."time"
+                     ->  Seq Scan on _hyper_35_137_chunk
+         ->  Custom Scan (DecompressChunk) on _hyper_35_138_chunk
                ->  Sort
-                     Sort Key: compress_hyper_37_140_chunk._ts_meta_sequence_num DESC
-                     ->  Seq Scan on compress_hyper_37_140_chunk
+                     Sort Key: compress_hyper_36_140_chunk._ts_meta_sequence_num DESC
+                     ->  Seq Scan on compress_hyper_36_140_chunk
          ->  Sort
-               Sort Key: _hyper_36_138_chunk."time"
+               Sort Key: _hyper_35_138_chunk."time"
                ->  Sort
-                     Sort Key: _hyper_36_138_chunk."time"
-                     ->  Seq Scan on _hyper_36_138_chunk
+                     Sort Key: _hyper_35_138_chunk."time"
+                     ->  Seq Scan on _hyper_35_138_chunk
 (35 rows)
 
 -- test creation of unique expression index does not interfere with enabling compression
@@ -2310,7 +2310,7 @@ select create_hypertable('mytab', 'departure_ts');
 WARNING:  column type "character varying" used for "col1" does not follow best practices
   create_hypertable  
 ---------------------
- (38,public,mytab,t)
+ (37,public,mytab,t)
 (1 row)
 
 create unique index myidx_unique ON
@@ -2327,14 +2327,14 @@ values ('meter1', 1, 2.3, '2022-01-01'::timestamptz, '2022-01-01'::timestamptz),
 select compress_chunk(show_chunks('mytab'));
               compress_chunk               
 -------------------------------------------
- _timescaledb_internal._hyper_38_141_chunk
+ _timescaledb_internal._hyper_37_141_chunk
 (1 row)
 
 REINDEX TABLE mytab; -- should update index
 select decompress_chunk(show_chunks('mytab'));
              decompress_chunk              
 -------------------------------------------
- _timescaledb_internal._hyper_38_141_chunk
+ _timescaledb_internal._hyper_37_141_chunk
 (1 row)
 
 \set EXPLAIN 'EXPLAIN (costs off,timing off,summary off)'
@@ -2345,7 +2345,7 @@ set enable_indexscan = on;
 :EXPLAIN_ANALYZE select * from mytab where lower(col1::text) = 'meter1';
                                             QUERY PLAN                                            
 --------------------------------------------------------------------------------------------------
- Index Scan using _hyper_38_141_chunk_myidx_unique on _hyper_38_141_chunk (actual rows=3 loops=1)
+ Index Scan using _hyper_37_141_chunk_myidx_unique on _hyper_37_141_chunk (actual rows=3 loops=1)
    Index Cond: (lower((col1)::text) = 'meter1'::text)
 (2 rows)
 
@@ -2363,19 +2363,19 @@ WHERE (value > 2.4 AND value < 3);
 select compress_chunk(show_chunks('mytab'));
               compress_chunk               
 -------------------------------------------
- _timescaledb_internal._hyper_38_141_chunk
+ _timescaledb_internal._hyper_37_141_chunk
 (1 row)
 
 select decompress_chunk(show_chunks('mytab'));
              decompress_chunk              
 -------------------------------------------
- _timescaledb_internal._hyper_38_141_chunk
+ _timescaledb_internal._hyper_37_141_chunk
 (1 row)
 
 :EXPLAIN_ANALYZE SELECT * FROM mytab WHERE value BETWEEN 2.4 AND 2.8;
                                       QUERY PLAN                                       
 ---------------------------------------------------------------------------------------
- Seq Scan on _hyper_38_141_chunk (actual rows=1 loops=1)
+ Seq Scan on _hyper_37_141_chunk (actual rows=1 loops=1)
    Filter: ((value >= '2.4'::double precision) AND (value <= '2.8'::double precision))
    Rows Removed by Filter: 2
 (3 rows)
@@ -2394,7 +2394,7 @@ SELECT * FROM create_hypertable('hyper_ex', 'time', chunk_time_interval=> interv
 NOTICE:  adding not-null constraint to column "time"
  hypertable_id | schema_name | table_name | created 
 ---------------+-------------+------------+---------
-            40 | public      | hyper_ex   | t
+            39 | public      | hyper_ex   | t
 (1 row)
 
 INSERT INTO hyper_ex(time, device_id,sensor_1) VALUES
@@ -2414,7 +2414,7 @@ SELECT * FROM create_hypertable('hyper_unique_deferred', 'time', chunk_time_inte
 NOTICE:  adding not-null constraint to column "time"
  hypertable_id | schema_name |      table_name       | created 
 ---------------+-------------+-----------------------+---------
-            41 | public      | hyper_unique_deferred | t
+            40 | public      | hyper_unique_deferred | t
 (1 row)
 
 INSERT INTO hyper_unique_deferred(time, device_id,sensor_1) VALUES (1257987700000000000, 'dev2', 11);
@@ -2422,14 +2422,14 @@ alter table hyper_unique_deferred set (timescaledb.compress);
 select compress_chunk(show_chunks('hyper_unique_deferred')); -- also worked fine before 2.11.0
               compress_chunk               
 -------------------------------------------
- _timescaledb_internal._hyper_41_145_chunk
+ _timescaledb_internal._hyper_40_145_chunk
 (1 row)
 
 select decompress_chunk(show_chunks('hyper_unique_deferred'));
              decompress_chunk              
 -------------------------------------------
- _timescaledb_internal._hyper_41_145_chunk
+ _timescaledb_internal._hyper_40_145_chunk
 (1 row)
 
 begin; insert INTO hyper_unique_deferred values (1257987700000000000, 'dev1', 1); abort;
-ERROR:  new row for relation "_hyper_41_145_chunk" violates check constraint "hyper_unique_deferred_sensor_1_check"
+ERROR:  new row for relation "_hyper_40_145_chunk" violates check constraint "hyper_unique_deferred_sensor_1_check"

--- a/tsl/test/expected/compression_errors-13.out
+++ b/tsl/test/expected/compression_errors-13.out
@@ -34,7 +34,8 @@ DETAIL:  Dimensions cannot have NULL values.
 
 insert into non_compressed values( 3 , 16 , 20, 4);
 ALTER TABLE foo2 set (timescaledb.compress_segmentby = '"bacB toD",c' , timescaledb.compress_orderby = 'c');
-ERROR:  the option timescaledb.compress must be set to true to enable compression
+ERROR:  cannot use column "c" for both ordering and segmenting
+HINT:  Use separate columns for the timescaledb.compress_orderby and timescaledb.compress_segmentby options.
 ALTER TABLE foo2 set (timescaledb.compress, timescaledb.compress_segmentby = '"bacB toD",c' , timescaledb.compress_orderby = 'c');
 ERROR:  cannot use column "c" for both ordering and segmenting
 HINT:  Use separate columns for the timescaledb.compress_orderby and timescaledb.compress_segmentby options.
@@ -46,7 +47,7 @@ create table default_skipped (a integer not null, b integer, c integer, d intege
 select create_hypertable('default_skipped', 'a', chunk_time_interval=> 10);
       create_hypertable       
 ------------------------------
- (6,public,default_skipped,t)
+ (5,public,default_skipped,t)
 (1 row)
 
 alter table default_skipped set (timescaledb.compress, timescaledb.compress_segmentby = 'c');
@@ -78,12 +79,8 @@ ALTER TABLE foo3 set (timescaledb.compress, timescaledb.compress_orderby='d Asc 
 ALTER TABLE foo3 set (timescaledb.compress, timescaledb.compress_segmentby = '"bacB toD",c', timescaledb.compress_orderby = 'd DeSc NullS lAsT');
 -- Negative test cases ---
 ALTER TABLE foo2 set (timescaledb.compress, timescaledb.compress_segmentby = '"bacB toD",c');
-ERROR:  must specify a column to order by
-DETAIL:  The timescaledb.compress_orderby option was previously set and must also be specified in the updated configuration.
 alter table default_skipped set (timescaledb.compress, timescaledb.compress_orderby = 'a asc', timescaledb.compress_segmentby = 'c');
 alter table default_skipped set (timescaledb.compress, timescaledb.compress_segmentby = 'c');
-ERROR:  must specify a column to order by
-DETAIL:  The timescaledb.compress_orderby option was previously set and must also be specified in the updated configuration.
 create table reserved_column_prefix (a integer, _ts_meta_foo integer, "bacB toD" integer, c integer, d integer);
 select table_name from create_hypertable('reserved_column_prefix', 'a', chunk_time_interval=> 10);
 NOTICE:  adding not-null constraint to column "a"
@@ -221,7 +218,7 @@ SELECT * FROM _timescaledb_catalog.compression_settings WHERE relid = 'foo'::reg
 (1 row)
 
 SELECT decompress_chunk(ch) FROM show_chunks('foo') ch limit 1;
-ERROR:  chunk "_hyper_15_2_chunk" is not compressed
+ERROR:  chunk "_hyper_10_2_chunk" is not compressed
 --test changing the segment by columns
 ALTER TABLE foo set (timescaledb.compress, timescaledb.compress_orderby = 'a', timescaledb.compress_segmentby = 'b');
 SELECT format('%I.%I',chunk_schema,chunk_name) AS "CHUNK_NAME"
@@ -229,9 +226,9 @@ FROM timescaledb_information.chunks
 WHERE hypertable_name = 'foo'
 ORDER BY chunk_name LIMIT 1\gset
 select decompress_chunk(:'CHUNK_NAME');
-ERROR:  chunk "_hyper_15_2_chunk" is not compressed
+ERROR:  chunk "_hyper_10_2_chunk" is not compressed
 select decompress_chunk(:'CHUNK_NAME', if_compressed=>true);
-NOTICE:  chunk "_hyper_15_2_chunk" is not compressed
+NOTICE:  chunk "_hyper_10_2_chunk" is not compressed
  decompress_chunk 
 ------------------
  
@@ -241,16 +238,16 @@ NOTICE:  chunk "_hyper_15_2_chunk" is not compressed
 select compress_chunk(:'CHUNK_NAME');
              compress_chunk              
 -----------------------------------------
- _timescaledb_internal._hyper_15_2_chunk
+ _timescaledb_internal._hyper_10_2_chunk
 (1 row)
 
 select compress_chunk(:'CHUNK_NAME');
-ERROR:  chunk "_hyper_15_2_chunk" is already compressed
+ERROR:  chunk "_hyper_10_2_chunk" is already compressed
 select compress_chunk(:'CHUNK_NAME', if_not_compressed=>true);
-NOTICE:  chunk "_hyper_15_2_chunk" is already compressed
+NOTICE:  chunk "_hyper_10_2_chunk" is already compressed
              compress_chunk              
 -----------------------------------------
- _timescaledb_internal._hyper_15_2_chunk
+ _timescaledb_internal._hyper_10_2_chunk
 (1 row)
 
 SELECT compress_chunk(ch) FROM show_chunks('non_compressed') ch LIMIT 1;
@@ -258,23 +255,20 @@ ERROR:  compression not enabled on "non_compressed"
 DETAIL:  It is not possible to compress chunks on a hypertable or continuous aggregate that does not have compression enabled.
 HINT:  Enable compression using ALTER TABLE/MATERIALIZED VIEW with the timescaledb.compress option.
 ALTER TABLE foo set (timescaledb.compress, timescaledb.compress_orderby = 'a', timescaledb.compress_segmentby = 'c');
-ERROR:  cannot change configuration on already compressed chunks
-DETAIL:  There are compressed chunks that prevent changing the existing compression configuration.
 ALTER TABLE foo set (timescaledb.compress='f');
-ERROR:  cannot change configuration on already compressed chunks
-DETAIL:  There are compressed chunks that prevent changing the existing compression configuration.
+ERROR:  cannot disable compression on hypertable with compressed chunks
 ALTER TABLE foo reset (timescaledb.compress);
 ERROR:  compression options cannot be reset
 SELECT decompress_chunk(ch) FROM show_chunks('non_compressed') ch LIMIT 1;
 ERROR:  missing compressed hypertable
 --should succeed
 SELECT decompress_chunk(ch, true) FROM show_chunks('foo') ch;
-NOTICE:  chunk "_hyper_15_3_chunk" is not compressed
-NOTICE:  chunk "_hyper_15_4_chunk" is not compressed
-NOTICE:  chunk "_hyper_15_5_chunk" is not compressed
+NOTICE:  chunk "_hyper_10_3_chunk" is not compressed
+NOTICE:  chunk "_hyper_10_4_chunk" is not compressed
+NOTICE:  chunk "_hyper_10_5_chunk" is not compressed
             decompress_chunk             
 -----------------------------------------
- _timescaledb_internal._hyper_15_2_chunk
+ _timescaledb_internal._hyper_10_2_chunk
  
  
  
@@ -293,7 +287,7 @@ FROM _timescaledb_catalog.hypertable comp_hyper
 INNER JOIN _timescaledb_catalog.hypertable uncomp_hyper ON (comp_hyper.id = uncomp_hyper.compressed_hypertable_id)
 WHERE uncomp_hyper.table_name like 'foo' ORDER BY comp_hyper.id LIMIT 1 \gset
 select add_retention_policy(:'COMPRESSED_HYPER_NAME', INTERVAL '4 months', true);
-ERROR:  cannot add retention policy to compressed hypertable "_compressed_hypertable_18"
+ERROR:  cannot add retention policy to compressed hypertable "_compressed_hypertable_11"
 HINT:  Please add the policy to the corresponding uncompressed hypertable instead.
 --Constraint checking for compression
 create table fortable(col integer primary key);
@@ -367,7 +361,7 @@ CREATE TABLE table_fk (
 SELECT create_hypertable('table_fk', 'time');
    create_hypertable    
 ------------------------
- (23,public,table_fk,t)
+ (16,public,table_fk,t)
 (1 row)
 
 ALTER TABLE table_fk DROP COLUMN id1;
@@ -386,7 +380,7 @@ ORDER BY ch1.id limit 1 \gset
 select compress_chunk(:'CHUNK_NAME');
              compress_chunk              
 -----------------------------------------
- _timescaledb_internal._hyper_19_7_chunk
+ _timescaledb_internal._hyper_12_7_chunk
 (1 row)
 
 SELECT  total_chunks , number_compressed_chunks
@@ -423,17 +417,16 @@ WHERE ch1.hypertable_id = ht.id and ht.table_name like 'table_constr2' \gset
 SELECT compress_chunk(:'CHUNK_NAME');
               compress_chunk              
 ------------------------------------------
- _timescaledb_internal._hyper_25_10_chunk
+ _timescaledb_internal._hyper_18_10_chunk
 (1 row)
 
 ALTER TABLE table_constr2 set (timescaledb.compress=false);
-ERROR:  cannot change configuration on already compressed chunks
-DETAIL:  There are compressed chunks that prevent changing the existing compression configuration.
+ERROR:  cannot disable compression on hypertable with compressed chunks
 --decompress all chunks and disable compression.
 SELECT decompress_chunk(:'CHUNK_NAME');
              decompress_chunk             
 ------------------------------------------
- _timescaledb_internal._hyper_25_10_chunk
+ _timescaledb_internal._hyper_18_10_chunk
 (1 row)
 
 ALTER TABLE table_constr2 SET (timescaledb.compress=false);
@@ -445,7 +438,7 @@ NOTICE:  adding not-null constraint to column "time"
 DETAIL:  Dimensions cannot have NULL values.
       create_hypertable       
 ------------------------------
- (27,public,test_table_int,t)
+ (20,public,test_table_int,t)
 (1 row)
 
 CREATE OR REPLACE function dummy_now() returns BIGINT LANGUAGE SQL IMMUTABLE as  'SELECT 5::BIGINT';
@@ -466,7 +459,7 @@ WHERE id = :compressjob_id;
 SELECT config FROM _timescaledb_config.bgw_job WHERE id = :compressjob_id;
         config         
 -----------------------
- {"hypertable_id": 27}
+ {"hypertable_id": 20}
 (1 row)
 
 --should fail
@@ -513,7 +506,7 @@ CREATE TABLE metric (time TIMESTAMPTZ NOT NULL, val FLOAT8 NOT NULL, dev_id INT4
 SELECT create_hypertable('metric', 'time', 'dev_id', 10);
   create_hypertable   
 ----------------------
- (29,public,metric,t)
+ (22,public,metric,t)
 (1 row)
 
 ALTER TABLE metric SET (
@@ -528,7 +521,7 @@ FROM generate_series('2021-08-17 00:00:00'::timestamp,
 SELECT compress_chunk(show_chunks('metric'));
               compress_chunk              
 ------------------------------------------
- _timescaledb_internal._hyper_29_17_chunk
+ _timescaledb_internal._hyper_22_17_chunk
 (1 row)
 
 -- column does not exist the first time
@@ -554,7 +547,7 @@ WARNING:  column type "timestamp without time zone" used for "time" does not fol
 HINT:  Use datatype TIMESTAMPTZ instead.
  create_hypertable  
 --------------------
- (31,public,test,t)
+ (24,public,test,t)
 (1 row)
 
 INSERT INTO test VALUES ('2001-01-01 00:00', 'home'),
@@ -579,14 +572,14 @@ EXPLAIN (COSTS OFF, TIMING OFF, SUMMARY OFF) SELECT DISTINCT 1 FROM test;
 --------------------------------------------
  Unique
    ->  Result
-         ->  Seq Scan on _hyper_31_19_chunk
+         ->  Seq Scan on _hyper_24_19_chunk
 (3 rows)
 
 --compress chunks
 SELECT COMPRESS_CHUNK(X) FROM SHOW_CHUNKS('test') X;
               compress_chunk              
 ------------------------------------------
- _timescaledb_internal._hyper_31_19_chunk
+ _timescaledb_internal._hyper_24_19_chunk
 (1 row)
 
 ANALYZE test;
@@ -603,8 +596,8 @@ EXPLAIN (COSTS OFF, TIMING OFF, SUMMARY OFF) SELECT DISTINCT 1 FROM test;
 -----------------------------------------------------------------
  Unique
    ->  Result
-         ->  Custom Scan (DecompressChunk) on _hyper_31_19_chunk
-               ->  Seq Scan on compress_hyper_32_20_chunk
+         ->  Custom Scan (DecompressChunk) on _hyper_24_19_chunk
+               ->  Seq Scan on compress_hyper_25_20_chunk
 (4 rows)
 
 --github issue 4398
@@ -616,7 +609,7 @@ NOTICE:  adding not-null constraint to column "tm"
 DETAIL:  Dimensions cannot have NULL values.
  hypertable_id | schema_name | table_name | created 
 ---------------+-------------+------------+---------
-            33 | public      | ts_table   | t
+            26 | public      | ts_table   | t
 (1 row)
 
 --should report a warning
@@ -639,7 +632,7 @@ SELECT create_hypertable('readings', 'time', chunk_time_interval => interval '12
 NOTICE:  migrating data to chunks
    create_hypertable    
 ------------------------
- (35,public,readings,t)
+ (28,public,readings,t)
 (1 row)
 
 create unique index readings_uniq_idx on readings("time",battery_temperature);
@@ -647,7 +640,7 @@ ALTER TABLE readings SET (timescaledb.compress,timescaledb.compress_segmentby = 
 SELECT compress_chunk(show_chunks('readings'));
               compress_chunk              
 ------------------------------------------
- _timescaledb_internal._hyper_35_22_chunk
+ _timescaledb_internal._hyper_28_22_chunk
 (1 row)
 
 ALTER TABLE readings DROP COLUMN battery_status;
@@ -661,25 +654,25 @@ SELECT readings FROM readings;
 
 -- #5577 On-insert decompression after schema changes may not work properly
 SELECT decompress_chunk(show_chunks('readings'),true);
-NOTICE:  chunk "_hyper_35_24_chunk" is not compressed
+NOTICE:  chunk "_hyper_28_24_chunk" is not compressed
              decompress_chunk             
 ------------------------------------------
- _timescaledb_internal._hyper_35_22_chunk
+ _timescaledb_internal._hyper_28_22_chunk
  
 (2 rows)
 
 SELECT compress_chunk(show_chunks('readings'),true);
               compress_chunk              
 ------------------------------------------
- _timescaledb_internal._hyper_35_22_chunk
- _timescaledb_internal._hyper_35_24_chunk
+ _timescaledb_internal._hyper_28_22_chunk
+ _timescaledb_internal._hyper_28_24_chunk
 (2 rows)
 
 \set ON_ERROR_STOP 0
 INSERT INTO readings ("time", battery_temperature) VALUES
     ('2022-11-11 11:11:11',0.2) -- same record as inserted
 ;
-ERROR:  duplicate key value violates unique constraint "_hyper_35_24_chunk_readings_uniq_idx"
+ERROR:  duplicate key value violates unique constraint "_hyper_28_24_chunk_readings_uniq_idx"
 \set ON_ERROR_STOP 1
 SELECT * from readings;
              time             | battery_temperature 
@@ -698,8 +691,8 @@ SELECT assert_equal(count(1), 2::bigint) FROM readings;
 SELECT decompress_chunk(show_chunks('readings'),true);
              decompress_chunk             
 ------------------------------------------
- _timescaledb_internal._hyper_35_22_chunk
- _timescaledb_internal._hyper_35_24_chunk
+ _timescaledb_internal._hyper_28_22_chunk
+ _timescaledb_internal._hyper_28_24_chunk
 (2 rows)
 
 -- #5553 Unique constraints are not always respected on compressed tables
@@ -711,7 +704,7 @@ NOTICE:  adding not-null constraint to column "time"
 NOTICE:  migrating data to chunks
     create_hypertable     
 --------------------------
- (37,public,main_table,t)
+ (30,public,main_table,t)
 (1 row)
 
 ALTER TABLE main_table SET (
@@ -721,19 +714,19 @@ ALTER TABLE main_table SET (
 SELECT compress_chunk(show_chunks('main_table'));
               compress_chunk              
 ------------------------------------------
- _timescaledb_internal._hyper_37_27_chunk
+ _timescaledb_internal._hyper_30_27_chunk
 (1 row)
 
 -- insert rejected
 \set ON_ERROR_STOP 0
 INSERT INTO main_table VALUES
     ('2011-11-11 11:11:11', 'foo');
-ERROR:  duplicate key value violates unique constraint "_hyper_37_27_chunk_xm"
+ERROR:  duplicate key value violates unique constraint "_hyper_30_27_chunk_xm"
 -- insert rejected in case 1st row doesn't violate constraint with different segmentby
 INSERT INTO main_table VALUES
     ('2011-11-11 11:12:11', 'bar'),
     ('2011-11-11 11:11:11', 'foo');
-ERROR:  duplicate key value violates unique constraint "_hyper_37_27_chunk_xm"
+ERROR:  duplicate key value violates unique constraint "_hyper_30_27_chunk_xm"
 \set ON_ERROR_STOP 1
 SELECT assert_equal(count(1), 1::bigint) FROM main_table;
  assert_equal 
@@ -745,7 +738,7 @@ SELECT assert_equal(count(1), 1::bigint) FROM main_table;
 SELECT decompress_chunk(show_chunks('main_table'), TRUE);
              decompress_chunk             
 ------------------------------------------
- _timescaledb_internal._hyper_37_27_chunk
+ _timescaledb_internal._hyper_30_27_chunk
 (1 row)
 
 DROP TABLE IF EXISTS readings;
@@ -759,7 +752,7 @@ CREATE TABLE readings(
 SELECT create_hypertable('readings', 'time', chunk_time_interval => interval '12 hour');
    create_hypertable    
 ------------------------
- (39,public,readings,t)
+ (32,public,readings,t)
 (1 row)
 
 CREATE UNIQUE INDEX readings_uniq_idx ON readings("time", battery_temperature);
@@ -771,7 +764,7 @@ INSERT INTO readings("time", candy, battery_temperature)
 SELECT compress_chunk(show_chunks('readings'), TRUE);
               compress_chunk              
 ------------------------------------------
- _timescaledb_internal._hyper_39_29_chunk
+ _timescaledb_internal._hyper_32_29_chunk
 (1 row)
 
 -- no error happens

--- a/tsl/test/expected/compression_errors-14.out
+++ b/tsl/test/expected/compression_errors-14.out
@@ -34,7 +34,8 @@ DETAIL:  Dimensions cannot have NULL values.
 
 insert into non_compressed values( 3 , 16 , 20, 4);
 ALTER TABLE foo2 set (timescaledb.compress_segmentby = '"bacB toD",c' , timescaledb.compress_orderby = 'c');
-ERROR:  the option timescaledb.compress must be set to true to enable compression
+ERROR:  cannot use column "c" for both ordering and segmenting
+HINT:  Use separate columns for the timescaledb.compress_orderby and timescaledb.compress_segmentby options.
 ALTER TABLE foo2 set (timescaledb.compress, timescaledb.compress_segmentby = '"bacB toD",c' , timescaledb.compress_orderby = 'c');
 ERROR:  cannot use column "c" for both ordering and segmenting
 HINT:  Use separate columns for the timescaledb.compress_orderby and timescaledb.compress_segmentby options.
@@ -46,7 +47,7 @@ create table default_skipped (a integer not null, b integer, c integer, d intege
 select create_hypertable('default_skipped', 'a', chunk_time_interval=> 10);
       create_hypertable       
 ------------------------------
- (6,public,default_skipped,t)
+ (5,public,default_skipped,t)
 (1 row)
 
 alter table default_skipped set (timescaledb.compress, timescaledb.compress_segmentby = 'c');
@@ -78,12 +79,8 @@ ALTER TABLE foo3 set (timescaledb.compress, timescaledb.compress_orderby='d Asc 
 ALTER TABLE foo3 set (timescaledb.compress, timescaledb.compress_segmentby = '"bacB toD",c', timescaledb.compress_orderby = 'd DeSc NullS lAsT');
 -- Negative test cases ---
 ALTER TABLE foo2 set (timescaledb.compress, timescaledb.compress_segmentby = '"bacB toD",c');
-ERROR:  must specify a column to order by
-DETAIL:  The timescaledb.compress_orderby option was previously set and must also be specified in the updated configuration.
 alter table default_skipped set (timescaledb.compress, timescaledb.compress_orderby = 'a asc', timescaledb.compress_segmentby = 'c');
 alter table default_skipped set (timescaledb.compress, timescaledb.compress_segmentby = 'c');
-ERROR:  must specify a column to order by
-DETAIL:  The timescaledb.compress_orderby option was previously set and must also be specified in the updated configuration.
 create table reserved_column_prefix (a integer, _ts_meta_foo integer, "bacB toD" integer, c integer, d integer);
 select table_name from create_hypertable('reserved_column_prefix', 'a', chunk_time_interval=> 10);
 NOTICE:  adding not-null constraint to column "a"
@@ -221,7 +218,7 @@ SELECT * FROM _timescaledb_catalog.compression_settings WHERE relid = 'foo'::reg
 (1 row)
 
 SELECT decompress_chunk(ch) FROM show_chunks('foo') ch limit 1;
-ERROR:  chunk "_hyper_15_2_chunk" is not compressed
+ERROR:  chunk "_hyper_10_2_chunk" is not compressed
 --test changing the segment by columns
 ALTER TABLE foo set (timescaledb.compress, timescaledb.compress_orderby = 'a', timescaledb.compress_segmentby = 'b');
 SELECT format('%I.%I',chunk_schema,chunk_name) AS "CHUNK_NAME"
@@ -229,9 +226,9 @@ FROM timescaledb_information.chunks
 WHERE hypertable_name = 'foo'
 ORDER BY chunk_name LIMIT 1\gset
 select decompress_chunk(:'CHUNK_NAME');
-ERROR:  chunk "_hyper_15_2_chunk" is not compressed
+ERROR:  chunk "_hyper_10_2_chunk" is not compressed
 select decompress_chunk(:'CHUNK_NAME', if_compressed=>true);
-NOTICE:  chunk "_hyper_15_2_chunk" is not compressed
+NOTICE:  chunk "_hyper_10_2_chunk" is not compressed
  decompress_chunk 
 ------------------
  
@@ -241,16 +238,16 @@ NOTICE:  chunk "_hyper_15_2_chunk" is not compressed
 select compress_chunk(:'CHUNK_NAME');
              compress_chunk              
 -----------------------------------------
- _timescaledb_internal._hyper_15_2_chunk
+ _timescaledb_internal._hyper_10_2_chunk
 (1 row)
 
 select compress_chunk(:'CHUNK_NAME');
-ERROR:  chunk "_hyper_15_2_chunk" is already compressed
+ERROR:  chunk "_hyper_10_2_chunk" is already compressed
 select compress_chunk(:'CHUNK_NAME', if_not_compressed=>true);
-NOTICE:  chunk "_hyper_15_2_chunk" is already compressed
+NOTICE:  chunk "_hyper_10_2_chunk" is already compressed
              compress_chunk              
 -----------------------------------------
- _timescaledb_internal._hyper_15_2_chunk
+ _timescaledb_internal._hyper_10_2_chunk
 (1 row)
 
 SELECT compress_chunk(ch) FROM show_chunks('non_compressed') ch LIMIT 1;
@@ -258,23 +255,20 @@ ERROR:  compression not enabled on "non_compressed"
 DETAIL:  It is not possible to compress chunks on a hypertable or continuous aggregate that does not have compression enabled.
 HINT:  Enable compression using ALTER TABLE/MATERIALIZED VIEW with the timescaledb.compress option.
 ALTER TABLE foo set (timescaledb.compress, timescaledb.compress_orderby = 'a', timescaledb.compress_segmentby = 'c');
-ERROR:  cannot change configuration on already compressed chunks
-DETAIL:  There are compressed chunks that prevent changing the existing compression configuration.
 ALTER TABLE foo set (timescaledb.compress='f');
-ERROR:  cannot change configuration on already compressed chunks
-DETAIL:  There are compressed chunks that prevent changing the existing compression configuration.
+ERROR:  cannot disable compression on hypertable with compressed chunks
 ALTER TABLE foo reset (timescaledb.compress);
 ERROR:  compression options cannot be reset
 SELECT decompress_chunk(ch) FROM show_chunks('non_compressed') ch LIMIT 1;
 ERROR:  missing compressed hypertable
 --should succeed
 SELECT decompress_chunk(ch, true) FROM show_chunks('foo') ch;
-NOTICE:  chunk "_hyper_15_3_chunk" is not compressed
-NOTICE:  chunk "_hyper_15_4_chunk" is not compressed
-NOTICE:  chunk "_hyper_15_5_chunk" is not compressed
+NOTICE:  chunk "_hyper_10_3_chunk" is not compressed
+NOTICE:  chunk "_hyper_10_4_chunk" is not compressed
+NOTICE:  chunk "_hyper_10_5_chunk" is not compressed
             decompress_chunk             
 -----------------------------------------
- _timescaledb_internal._hyper_15_2_chunk
+ _timescaledb_internal._hyper_10_2_chunk
  
  
  
@@ -293,7 +287,7 @@ FROM _timescaledb_catalog.hypertable comp_hyper
 INNER JOIN _timescaledb_catalog.hypertable uncomp_hyper ON (comp_hyper.id = uncomp_hyper.compressed_hypertable_id)
 WHERE uncomp_hyper.table_name like 'foo' ORDER BY comp_hyper.id LIMIT 1 \gset
 select add_retention_policy(:'COMPRESSED_HYPER_NAME', INTERVAL '4 months', true);
-ERROR:  cannot add retention policy to compressed hypertable "_compressed_hypertable_18"
+ERROR:  cannot add retention policy to compressed hypertable "_compressed_hypertable_11"
 HINT:  Please add the policy to the corresponding uncompressed hypertable instead.
 --Constraint checking for compression
 create table fortable(col integer primary key);
@@ -367,7 +361,7 @@ CREATE TABLE table_fk (
 SELECT create_hypertable('table_fk', 'time');
    create_hypertable    
 ------------------------
- (23,public,table_fk,t)
+ (16,public,table_fk,t)
 (1 row)
 
 ALTER TABLE table_fk DROP COLUMN id1;
@@ -386,7 +380,7 @@ ORDER BY ch1.id limit 1 \gset
 select compress_chunk(:'CHUNK_NAME');
              compress_chunk              
 -----------------------------------------
- _timescaledb_internal._hyper_19_7_chunk
+ _timescaledb_internal._hyper_12_7_chunk
 (1 row)
 
 SELECT  total_chunks , number_compressed_chunks
@@ -423,17 +417,16 @@ WHERE ch1.hypertable_id = ht.id and ht.table_name like 'table_constr2' \gset
 SELECT compress_chunk(:'CHUNK_NAME');
               compress_chunk              
 ------------------------------------------
- _timescaledb_internal._hyper_25_10_chunk
+ _timescaledb_internal._hyper_18_10_chunk
 (1 row)
 
 ALTER TABLE table_constr2 set (timescaledb.compress=false);
-ERROR:  cannot change configuration on already compressed chunks
-DETAIL:  There are compressed chunks that prevent changing the existing compression configuration.
+ERROR:  cannot disable compression on hypertable with compressed chunks
 --decompress all chunks and disable compression.
 SELECT decompress_chunk(:'CHUNK_NAME');
              decompress_chunk             
 ------------------------------------------
- _timescaledb_internal._hyper_25_10_chunk
+ _timescaledb_internal._hyper_18_10_chunk
 (1 row)
 
 ALTER TABLE table_constr2 SET (timescaledb.compress=false);
@@ -445,7 +438,7 @@ NOTICE:  adding not-null constraint to column "time"
 DETAIL:  Dimensions cannot have NULL values.
       create_hypertable       
 ------------------------------
- (27,public,test_table_int,t)
+ (20,public,test_table_int,t)
 (1 row)
 
 CREATE OR REPLACE function dummy_now() returns BIGINT LANGUAGE SQL IMMUTABLE as  'SELECT 5::BIGINT';
@@ -466,7 +459,7 @@ WHERE id = :compressjob_id;
 SELECT config FROM _timescaledb_config.bgw_job WHERE id = :compressjob_id;
         config         
 -----------------------
- {"hypertable_id": 27}
+ {"hypertable_id": 20}
 (1 row)
 
 --should fail
@@ -513,7 +506,7 @@ CREATE TABLE metric (time TIMESTAMPTZ NOT NULL, val FLOAT8 NOT NULL, dev_id INT4
 SELECT create_hypertable('metric', 'time', 'dev_id', 10);
   create_hypertable   
 ----------------------
- (29,public,metric,t)
+ (22,public,metric,t)
 (1 row)
 
 ALTER TABLE metric SET (
@@ -528,7 +521,7 @@ FROM generate_series('2021-08-17 00:00:00'::timestamp,
 SELECT compress_chunk(show_chunks('metric'));
               compress_chunk              
 ------------------------------------------
- _timescaledb_internal._hyper_29_17_chunk
+ _timescaledb_internal._hyper_22_17_chunk
 (1 row)
 
 -- column does not exist the first time
@@ -554,7 +547,7 @@ WARNING:  column type "timestamp without time zone" used for "time" does not fol
 HINT:  Use datatype TIMESTAMPTZ instead.
  create_hypertable  
 --------------------
- (31,public,test,t)
+ (24,public,test,t)
 (1 row)
 
 INSERT INTO test VALUES ('2001-01-01 00:00', 'home'),
@@ -579,14 +572,14 @@ EXPLAIN (COSTS OFF, TIMING OFF, SUMMARY OFF) SELECT DISTINCT 1 FROM test;
 --------------------------------------------
  Unique
    ->  Result
-         ->  Seq Scan on _hyper_31_19_chunk
+         ->  Seq Scan on _hyper_24_19_chunk
 (3 rows)
 
 --compress chunks
 SELECT COMPRESS_CHUNK(X) FROM SHOW_CHUNKS('test') X;
               compress_chunk              
 ------------------------------------------
- _timescaledb_internal._hyper_31_19_chunk
+ _timescaledb_internal._hyper_24_19_chunk
 (1 row)
 
 ANALYZE test;
@@ -603,8 +596,8 @@ EXPLAIN (COSTS OFF, TIMING OFF, SUMMARY OFF) SELECT DISTINCT 1 FROM test;
 -----------------------------------------------------------------
  Unique
    ->  Result
-         ->  Custom Scan (DecompressChunk) on _hyper_31_19_chunk
-               ->  Seq Scan on compress_hyper_32_20_chunk
+         ->  Custom Scan (DecompressChunk) on _hyper_24_19_chunk
+               ->  Seq Scan on compress_hyper_25_20_chunk
 (4 rows)
 
 --github issue 4398
@@ -616,7 +609,7 @@ NOTICE:  adding not-null constraint to column "tm"
 DETAIL:  Dimensions cannot have NULL values.
  hypertable_id | schema_name | table_name | created 
 ---------------+-------------+------------+---------
-            33 | public      | ts_table   | t
+            26 | public      | ts_table   | t
 (1 row)
 
 --should report a warning
@@ -639,7 +632,7 @@ SELECT create_hypertable('readings', 'time', chunk_time_interval => interval '12
 NOTICE:  migrating data to chunks
    create_hypertable    
 ------------------------
- (35,public,readings,t)
+ (28,public,readings,t)
 (1 row)
 
 create unique index readings_uniq_idx on readings("time",battery_temperature);
@@ -647,7 +640,7 @@ ALTER TABLE readings SET (timescaledb.compress,timescaledb.compress_segmentby = 
 SELECT compress_chunk(show_chunks('readings'));
               compress_chunk              
 ------------------------------------------
- _timescaledb_internal._hyper_35_22_chunk
+ _timescaledb_internal._hyper_28_22_chunk
 (1 row)
 
 ALTER TABLE readings DROP COLUMN battery_status;
@@ -661,25 +654,25 @@ SELECT readings FROM readings;
 
 -- #5577 On-insert decompression after schema changes may not work properly
 SELECT decompress_chunk(show_chunks('readings'),true);
-NOTICE:  chunk "_hyper_35_24_chunk" is not compressed
+NOTICE:  chunk "_hyper_28_24_chunk" is not compressed
              decompress_chunk             
 ------------------------------------------
- _timescaledb_internal._hyper_35_22_chunk
+ _timescaledb_internal._hyper_28_22_chunk
  
 (2 rows)
 
 SELECT compress_chunk(show_chunks('readings'),true);
               compress_chunk              
 ------------------------------------------
- _timescaledb_internal._hyper_35_22_chunk
- _timescaledb_internal._hyper_35_24_chunk
+ _timescaledb_internal._hyper_28_22_chunk
+ _timescaledb_internal._hyper_28_24_chunk
 (2 rows)
 
 \set ON_ERROR_STOP 0
 INSERT INTO readings ("time", battery_temperature) VALUES
     ('2022-11-11 11:11:11',0.2) -- same record as inserted
 ;
-ERROR:  duplicate key value violates unique constraint "_hyper_35_24_chunk_readings_uniq_idx"
+ERROR:  duplicate key value violates unique constraint "_hyper_28_24_chunk_readings_uniq_idx"
 \set ON_ERROR_STOP 1
 SELECT * from readings;
              time             | battery_temperature 
@@ -698,8 +691,8 @@ SELECT assert_equal(count(1), 2::bigint) FROM readings;
 SELECT decompress_chunk(show_chunks('readings'),true);
              decompress_chunk             
 ------------------------------------------
- _timescaledb_internal._hyper_35_22_chunk
- _timescaledb_internal._hyper_35_24_chunk
+ _timescaledb_internal._hyper_28_22_chunk
+ _timescaledb_internal._hyper_28_24_chunk
 (2 rows)
 
 -- #5553 Unique constraints are not always respected on compressed tables
@@ -711,7 +704,7 @@ NOTICE:  adding not-null constraint to column "time"
 NOTICE:  migrating data to chunks
     create_hypertable     
 --------------------------
- (37,public,main_table,t)
+ (30,public,main_table,t)
 (1 row)
 
 ALTER TABLE main_table SET (
@@ -721,19 +714,19 @@ ALTER TABLE main_table SET (
 SELECT compress_chunk(show_chunks('main_table'));
               compress_chunk              
 ------------------------------------------
- _timescaledb_internal._hyper_37_27_chunk
+ _timescaledb_internal._hyper_30_27_chunk
 (1 row)
 
 -- insert rejected
 \set ON_ERROR_STOP 0
 INSERT INTO main_table VALUES
     ('2011-11-11 11:11:11', 'foo');
-ERROR:  duplicate key value violates unique constraint "_hyper_37_27_chunk_xm"
+ERROR:  duplicate key value violates unique constraint "_hyper_30_27_chunk_xm"
 -- insert rejected in case 1st row doesn't violate constraint with different segmentby
 INSERT INTO main_table VALUES
     ('2011-11-11 11:12:11', 'bar'),
     ('2011-11-11 11:11:11', 'foo');
-ERROR:  duplicate key value violates unique constraint "_hyper_37_27_chunk_xm"
+ERROR:  duplicate key value violates unique constraint "_hyper_30_27_chunk_xm"
 \set ON_ERROR_STOP 1
 SELECT assert_equal(count(1), 1::bigint) FROM main_table;
  assert_equal 
@@ -745,7 +738,7 @@ SELECT assert_equal(count(1), 1::bigint) FROM main_table;
 SELECT decompress_chunk(show_chunks('main_table'), TRUE);
              decompress_chunk             
 ------------------------------------------
- _timescaledb_internal._hyper_37_27_chunk
+ _timescaledb_internal._hyper_30_27_chunk
 (1 row)
 
 DROP TABLE IF EXISTS readings;
@@ -759,7 +752,7 @@ CREATE TABLE readings(
 SELECT create_hypertable('readings', 'time', chunk_time_interval => interval '12 hour');
    create_hypertable    
 ------------------------
- (39,public,readings,t)
+ (32,public,readings,t)
 (1 row)
 
 CREATE UNIQUE INDEX readings_uniq_idx ON readings("time", battery_temperature);
@@ -771,7 +764,7 @@ INSERT INTO readings("time", candy, battery_temperature)
 SELECT compress_chunk(show_chunks('readings'), TRUE);
               compress_chunk              
 ------------------------------------------
- _timescaledb_internal._hyper_39_29_chunk
+ _timescaledb_internal._hyper_32_29_chunk
 (1 row)
 
 -- no error happens

--- a/tsl/test/expected/compression_errors-15.out
+++ b/tsl/test/expected/compression_errors-15.out
@@ -34,7 +34,8 @@ DETAIL:  Dimensions cannot have NULL values.
 
 insert into non_compressed values( 3 , 16 , 20, 4);
 ALTER TABLE foo2 set (timescaledb.compress_segmentby = '"bacB toD",c' , timescaledb.compress_orderby = 'c');
-ERROR:  the option timescaledb.compress must be set to true to enable compression
+ERROR:  cannot use column "c" for both ordering and segmenting
+HINT:  Use separate columns for the timescaledb.compress_orderby and timescaledb.compress_segmentby options.
 ALTER TABLE foo2 set (timescaledb.compress, timescaledb.compress_segmentby = '"bacB toD",c' , timescaledb.compress_orderby = 'c');
 ERROR:  cannot use column "c" for both ordering and segmenting
 HINT:  Use separate columns for the timescaledb.compress_orderby and timescaledb.compress_segmentby options.
@@ -46,7 +47,7 @@ create table default_skipped (a integer not null, b integer, c integer, d intege
 select create_hypertable('default_skipped', 'a', chunk_time_interval=> 10);
       create_hypertable       
 ------------------------------
- (6,public,default_skipped,t)
+ (5,public,default_skipped,t)
 (1 row)
 
 alter table default_skipped set (timescaledb.compress, timescaledb.compress_segmentby = 'c');
@@ -78,12 +79,8 @@ ALTER TABLE foo3 set (timescaledb.compress, timescaledb.compress_orderby='d Asc 
 ALTER TABLE foo3 set (timescaledb.compress, timescaledb.compress_segmentby = '"bacB toD",c', timescaledb.compress_orderby = 'd DeSc NullS lAsT');
 -- Negative test cases ---
 ALTER TABLE foo2 set (timescaledb.compress, timescaledb.compress_segmentby = '"bacB toD",c');
-ERROR:  must specify a column to order by
-DETAIL:  The timescaledb.compress_orderby option was previously set and must also be specified in the updated configuration.
 alter table default_skipped set (timescaledb.compress, timescaledb.compress_orderby = 'a asc', timescaledb.compress_segmentby = 'c');
 alter table default_skipped set (timescaledb.compress, timescaledb.compress_segmentby = 'c');
-ERROR:  must specify a column to order by
-DETAIL:  The timescaledb.compress_orderby option was previously set and must also be specified in the updated configuration.
 create table reserved_column_prefix (a integer, _ts_meta_foo integer, "bacB toD" integer, c integer, d integer);
 select table_name from create_hypertable('reserved_column_prefix', 'a', chunk_time_interval=> 10);
 NOTICE:  adding not-null constraint to column "a"
@@ -221,7 +218,7 @@ SELECT * FROM _timescaledb_catalog.compression_settings WHERE relid = 'foo'::reg
 (1 row)
 
 SELECT decompress_chunk(ch) FROM show_chunks('foo') ch limit 1;
-ERROR:  chunk "_hyper_15_2_chunk" is not compressed
+ERROR:  chunk "_hyper_10_2_chunk" is not compressed
 --test changing the segment by columns
 ALTER TABLE foo set (timescaledb.compress, timescaledb.compress_orderby = 'a', timescaledb.compress_segmentby = 'b');
 SELECT format('%I.%I',chunk_schema,chunk_name) AS "CHUNK_NAME"
@@ -229,9 +226,9 @@ FROM timescaledb_information.chunks
 WHERE hypertable_name = 'foo'
 ORDER BY chunk_name LIMIT 1\gset
 select decompress_chunk(:'CHUNK_NAME');
-ERROR:  chunk "_hyper_15_2_chunk" is not compressed
+ERROR:  chunk "_hyper_10_2_chunk" is not compressed
 select decompress_chunk(:'CHUNK_NAME', if_compressed=>true);
-NOTICE:  chunk "_hyper_15_2_chunk" is not compressed
+NOTICE:  chunk "_hyper_10_2_chunk" is not compressed
  decompress_chunk 
 ------------------
  
@@ -241,16 +238,16 @@ NOTICE:  chunk "_hyper_15_2_chunk" is not compressed
 select compress_chunk(:'CHUNK_NAME');
              compress_chunk              
 -----------------------------------------
- _timescaledb_internal._hyper_15_2_chunk
+ _timescaledb_internal._hyper_10_2_chunk
 (1 row)
 
 select compress_chunk(:'CHUNK_NAME');
-ERROR:  chunk "_hyper_15_2_chunk" is already compressed
+ERROR:  chunk "_hyper_10_2_chunk" is already compressed
 select compress_chunk(:'CHUNK_NAME', if_not_compressed=>true);
-NOTICE:  chunk "_hyper_15_2_chunk" is already compressed
+NOTICE:  chunk "_hyper_10_2_chunk" is already compressed
              compress_chunk              
 -----------------------------------------
- _timescaledb_internal._hyper_15_2_chunk
+ _timescaledb_internal._hyper_10_2_chunk
 (1 row)
 
 SELECT compress_chunk(ch) FROM show_chunks('non_compressed') ch LIMIT 1;
@@ -258,23 +255,20 @@ ERROR:  compression not enabled on "non_compressed"
 DETAIL:  It is not possible to compress chunks on a hypertable or continuous aggregate that does not have compression enabled.
 HINT:  Enable compression using ALTER TABLE/MATERIALIZED VIEW with the timescaledb.compress option.
 ALTER TABLE foo set (timescaledb.compress, timescaledb.compress_orderby = 'a', timescaledb.compress_segmentby = 'c');
-ERROR:  cannot change configuration on already compressed chunks
-DETAIL:  There are compressed chunks that prevent changing the existing compression configuration.
 ALTER TABLE foo set (timescaledb.compress='f');
-ERROR:  cannot change configuration on already compressed chunks
-DETAIL:  There are compressed chunks that prevent changing the existing compression configuration.
+ERROR:  cannot disable compression on hypertable with compressed chunks
 ALTER TABLE foo reset (timescaledb.compress);
 ERROR:  compression options cannot be reset
 SELECT decompress_chunk(ch) FROM show_chunks('non_compressed') ch LIMIT 1;
 ERROR:  missing compressed hypertable
 --should succeed
 SELECT decompress_chunk(ch, true) FROM show_chunks('foo') ch;
-NOTICE:  chunk "_hyper_15_3_chunk" is not compressed
-NOTICE:  chunk "_hyper_15_4_chunk" is not compressed
-NOTICE:  chunk "_hyper_15_5_chunk" is not compressed
+NOTICE:  chunk "_hyper_10_3_chunk" is not compressed
+NOTICE:  chunk "_hyper_10_4_chunk" is not compressed
+NOTICE:  chunk "_hyper_10_5_chunk" is not compressed
             decompress_chunk             
 -----------------------------------------
- _timescaledb_internal._hyper_15_2_chunk
+ _timescaledb_internal._hyper_10_2_chunk
  
  
  
@@ -293,7 +287,7 @@ FROM _timescaledb_catalog.hypertable comp_hyper
 INNER JOIN _timescaledb_catalog.hypertable uncomp_hyper ON (comp_hyper.id = uncomp_hyper.compressed_hypertable_id)
 WHERE uncomp_hyper.table_name like 'foo' ORDER BY comp_hyper.id LIMIT 1 \gset
 select add_retention_policy(:'COMPRESSED_HYPER_NAME', INTERVAL '4 months', true);
-ERROR:  cannot add retention policy to compressed hypertable "_compressed_hypertable_18"
+ERROR:  cannot add retention policy to compressed hypertable "_compressed_hypertable_11"
 HINT:  Please add the policy to the corresponding uncompressed hypertable instead.
 --Constraint checking for compression
 create table fortable(col integer primary key);
@@ -367,7 +361,7 @@ CREATE TABLE table_fk (
 SELECT create_hypertable('table_fk', 'time');
    create_hypertable    
 ------------------------
- (23,public,table_fk,t)
+ (16,public,table_fk,t)
 (1 row)
 
 ALTER TABLE table_fk DROP COLUMN id1;
@@ -386,7 +380,7 @@ ORDER BY ch1.id limit 1 \gset
 select compress_chunk(:'CHUNK_NAME');
              compress_chunk              
 -----------------------------------------
- _timescaledb_internal._hyper_19_7_chunk
+ _timescaledb_internal._hyper_12_7_chunk
 (1 row)
 
 SELECT  total_chunks , number_compressed_chunks
@@ -423,17 +417,16 @@ WHERE ch1.hypertable_id = ht.id and ht.table_name like 'table_constr2' \gset
 SELECT compress_chunk(:'CHUNK_NAME');
               compress_chunk              
 ------------------------------------------
- _timescaledb_internal._hyper_25_10_chunk
+ _timescaledb_internal._hyper_18_10_chunk
 (1 row)
 
 ALTER TABLE table_constr2 set (timescaledb.compress=false);
-ERROR:  cannot change configuration on already compressed chunks
-DETAIL:  There are compressed chunks that prevent changing the existing compression configuration.
+ERROR:  cannot disable compression on hypertable with compressed chunks
 --decompress all chunks and disable compression.
 SELECT decompress_chunk(:'CHUNK_NAME');
              decompress_chunk             
 ------------------------------------------
- _timescaledb_internal._hyper_25_10_chunk
+ _timescaledb_internal._hyper_18_10_chunk
 (1 row)
 
 ALTER TABLE table_constr2 SET (timescaledb.compress=false);
@@ -445,7 +438,7 @@ NOTICE:  adding not-null constraint to column "time"
 DETAIL:  Dimensions cannot have NULL values.
       create_hypertable       
 ------------------------------
- (27,public,test_table_int,t)
+ (20,public,test_table_int,t)
 (1 row)
 
 CREATE OR REPLACE function dummy_now() returns BIGINT LANGUAGE SQL IMMUTABLE as  'SELECT 5::BIGINT';
@@ -466,7 +459,7 @@ WHERE id = :compressjob_id;
 SELECT config FROM _timescaledb_config.bgw_job WHERE id = :compressjob_id;
         config         
 -----------------------
- {"hypertable_id": 27}
+ {"hypertable_id": 20}
 (1 row)
 
 --should fail
@@ -513,7 +506,7 @@ CREATE TABLE metric (time TIMESTAMPTZ NOT NULL, val FLOAT8 NOT NULL, dev_id INT4
 SELECT create_hypertable('metric', 'time', 'dev_id', 10);
   create_hypertable   
 ----------------------
- (29,public,metric,t)
+ (22,public,metric,t)
 (1 row)
 
 ALTER TABLE metric SET (
@@ -528,7 +521,7 @@ FROM generate_series('2021-08-17 00:00:00'::timestamp,
 SELECT compress_chunk(show_chunks('metric'));
               compress_chunk              
 ------------------------------------------
- _timescaledb_internal._hyper_29_17_chunk
+ _timescaledb_internal._hyper_22_17_chunk
 (1 row)
 
 -- column does not exist the first time
@@ -554,7 +547,7 @@ WARNING:  column type "timestamp without time zone" used for "time" does not fol
 HINT:  Use datatype TIMESTAMPTZ instead.
  create_hypertable  
 --------------------
- (31,public,test,t)
+ (24,public,test,t)
 (1 row)
 
 INSERT INTO test VALUES ('2001-01-01 00:00', 'home'),
@@ -579,14 +572,14 @@ EXPLAIN (COSTS OFF, TIMING OFF, SUMMARY OFF) SELECT DISTINCT 1 FROM test;
 --------------------------------------------
  Unique
    ->  Result
-         ->  Seq Scan on _hyper_31_19_chunk
+         ->  Seq Scan on _hyper_24_19_chunk
 (3 rows)
 
 --compress chunks
 SELECT COMPRESS_CHUNK(X) FROM SHOW_CHUNKS('test') X;
               compress_chunk              
 ------------------------------------------
- _timescaledb_internal._hyper_31_19_chunk
+ _timescaledb_internal._hyper_24_19_chunk
 (1 row)
 
 ANALYZE test;
@@ -603,8 +596,8 @@ EXPLAIN (COSTS OFF, TIMING OFF, SUMMARY OFF) SELECT DISTINCT 1 FROM test;
 -----------------------------------------------------------------
  Unique
    ->  Result
-         ->  Custom Scan (DecompressChunk) on _hyper_31_19_chunk
-               ->  Seq Scan on compress_hyper_32_20_chunk
+         ->  Custom Scan (DecompressChunk) on _hyper_24_19_chunk
+               ->  Seq Scan on compress_hyper_25_20_chunk
 (4 rows)
 
 --github issue 4398
@@ -616,7 +609,7 @@ NOTICE:  adding not-null constraint to column "tm"
 DETAIL:  Dimensions cannot have NULL values.
  hypertable_id | schema_name | table_name | created 
 ---------------+-------------+------------+---------
-            33 | public      | ts_table   | t
+            26 | public      | ts_table   | t
 (1 row)
 
 --should report a warning
@@ -639,7 +632,7 @@ SELECT create_hypertable('readings', 'time', chunk_time_interval => interval '12
 NOTICE:  migrating data to chunks
    create_hypertable    
 ------------------------
- (35,public,readings,t)
+ (28,public,readings,t)
 (1 row)
 
 create unique index readings_uniq_idx on readings("time",battery_temperature);
@@ -647,7 +640,7 @@ ALTER TABLE readings SET (timescaledb.compress,timescaledb.compress_segmentby = 
 SELECT compress_chunk(show_chunks('readings'));
               compress_chunk              
 ------------------------------------------
- _timescaledb_internal._hyper_35_22_chunk
+ _timescaledb_internal._hyper_28_22_chunk
 (1 row)
 
 ALTER TABLE readings DROP COLUMN battery_status;
@@ -661,25 +654,25 @@ SELECT readings FROM readings;
 
 -- #5577 On-insert decompression after schema changes may not work properly
 SELECT decompress_chunk(show_chunks('readings'),true);
-NOTICE:  chunk "_hyper_35_24_chunk" is not compressed
+NOTICE:  chunk "_hyper_28_24_chunk" is not compressed
              decompress_chunk             
 ------------------------------------------
- _timescaledb_internal._hyper_35_22_chunk
+ _timescaledb_internal._hyper_28_22_chunk
  
 (2 rows)
 
 SELECT compress_chunk(show_chunks('readings'),true);
               compress_chunk              
 ------------------------------------------
- _timescaledb_internal._hyper_35_22_chunk
- _timescaledb_internal._hyper_35_24_chunk
+ _timescaledb_internal._hyper_28_22_chunk
+ _timescaledb_internal._hyper_28_24_chunk
 (2 rows)
 
 \set ON_ERROR_STOP 0
 INSERT INTO readings ("time", battery_temperature) VALUES
     ('2022-11-11 11:11:11',0.2) -- same record as inserted
 ;
-ERROR:  duplicate key value violates unique constraint "_hyper_35_24_chunk_readings_uniq_idx"
+ERROR:  duplicate key value violates unique constraint "_hyper_28_24_chunk_readings_uniq_idx"
 \set ON_ERROR_STOP 1
 SELECT * from readings;
              time             | battery_temperature 
@@ -698,8 +691,8 @@ SELECT assert_equal(count(1), 2::bigint) FROM readings;
 SELECT decompress_chunk(show_chunks('readings'),true);
              decompress_chunk             
 ------------------------------------------
- _timescaledb_internal._hyper_35_22_chunk
- _timescaledb_internal._hyper_35_24_chunk
+ _timescaledb_internal._hyper_28_22_chunk
+ _timescaledb_internal._hyper_28_24_chunk
 (2 rows)
 
 -- #5553 Unique constraints are not always respected on compressed tables
@@ -711,7 +704,7 @@ NOTICE:  adding not-null constraint to column "time"
 NOTICE:  migrating data to chunks
     create_hypertable     
 --------------------------
- (37,public,main_table,t)
+ (30,public,main_table,t)
 (1 row)
 
 ALTER TABLE main_table SET (
@@ -721,19 +714,19 @@ ALTER TABLE main_table SET (
 SELECT compress_chunk(show_chunks('main_table'));
               compress_chunk              
 ------------------------------------------
- _timescaledb_internal._hyper_37_27_chunk
+ _timescaledb_internal._hyper_30_27_chunk
 (1 row)
 
 -- insert rejected
 \set ON_ERROR_STOP 0
 INSERT INTO main_table VALUES
     ('2011-11-11 11:11:11', 'foo');
-ERROR:  duplicate key value violates unique constraint "_hyper_37_27_chunk_xm"
+ERROR:  duplicate key value violates unique constraint "_hyper_30_27_chunk_xm"
 -- insert rejected in case 1st row doesn't violate constraint with different segmentby
 INSERT INTO main_table VALUES
     ('2011-11-11 11:12:11', 'bar'),
     ('2011-11-11 11:11:11', 'foo');
-ERROR:  duplicate key value violates unique constraint "_hyper_37_27_chunk_xm"
+ERROR:  duplicate key value violates unique constraint "_hyper_30_27_chunk_xm"
 \set ON_ERROR_STOP 1
 SELECT assert_equal(count(1), 1::bigint) FROM main_table;
  assert_equal 
@@ -745,7 +738,7 @@ SELECT assert_equal(count(1), 1::bigint) FROM main_table;
 SELECT decompress_chunk(show_chunks('main_table'), TRUE);
              decompress_chunk             
 ------------------------------------------
- _timescaledb_internal._hyper_37_27_chunk
+ _timescaledb_internal._hyper_30_27_chunk
 (1 row)
 
 DROP TABLE IF EXISTS readings;
@@ -759,7 +752,7 @@ CREATE TABLE readings(
 SELECT create_hypertable('readings', 'time', chunk_time_interval => interval '12 hour');
    create_hypertable    
 ------------------------
- (39,public,readings,t)
+ (32,public,readings,t)
 (1 row)
 
 CREATE UNIQUE INDEX readings_uniq_idx ON readings("time", battery_temperature);
@@ -771,7 +764,7 @@ INSERT INTO readings("time", candy, battery_temperature)
 SELECT compress_chunk(show_chunks('readings'), TRUE);
               compress_chunk              
 ------------------------------------------
- _timescaledb_internal._hyper_39_29_chunk
+ _timescaledb_internal._hyper_32_29_chunk
 (1 row)
 
 -- no error happens

--- a/tsl/test/expected/compression_errors-16.out
+++ b/tsl/test/expected/compression_errors-16.out
@@ -34,7 +34,8 @@ DETAIL:  Dimensions cannot have NULL values.
 
 insert into non_compressed values( 3 , 16 , 20, 4);
 ALTER TABLE foo2 set (timescaledb.compress_segmentby = '"bacB toD",c' , timescaledb.compress_orderby = 'c');
-ERROR:  the option timescaledb.compress must be set to true to enable compression
+ERROR:  cannot use column "c" for both ordering and segmenting
+HINT:  Use separate columns for the timescaledb.compress_orderby and timescaledb.compress_segmentby options.
 ALTER TABLE foo2 set (timescaledb.compress, timescaledb.compress_segmentby = '"bacB toD",c' , timescaledb.compress_orderby = 'c');
 ERROR:  cannot use column "c" for both ordering and segmenting
 HINT:  Use separate columns for the timescaledb.compress_orderby and timescaledb.compress_segmentby options.
@@ -46,7 +47,7 @@ create table default_skipped (a integer not null, b integer, c integer, d intege
 select create_hypertable('default_skipped', 'a', chunk_time_interval=> 10);
       create_hypertable       
 ------------------------------
- (6,public,default_skipped,t)
+ (5,public,default_skipped,t)
 (1 row)
 
 alter table default_skipped set (timescaledb.compress, timescaledb.compress_segmentby = 'c');
@@ -78,12 +79,8 @@ ALTER TABLE foo3 set (timescaledb.compress, timescaledb.compress_orderby='d Asc 
 ALTER TABLE foo3 set (timescaledb.compress, timescaledb.compress_segmentby = '"bacB toD",c', timescaledb.compress_orderby = 'd DeSc NullS lAsT');
 -- Negative test cases ---
 ALTER TABLE foo2 set (timescaledb.compress, timescaledb.compress_segmentby = '"bacB toD",c');
-ERROR:  must specify a column to order by
-DETAIL:  The timescaledb.compress_orderby option was previously set and must also be specified in the updated configuration.
 alter table default_skipped set (timescaledb.compress, timescaledb.compress_orderby = 'a asc', timescaledb.compress_segmentby = 'c');
 alter table default_skipped set (timescaledb.compress, timescaledb.compress_segmentby = 'c');
-ERROR:  must specify a column to order by
-DETAIL:  The timescaledb.compress_orderby option was previously set and must also be specified in the updated configuration.
 create table reserved_column_prefix (a integer, _ts_meta_foo integer, "bacB toD" integer, c integer, d integer);
 select table_name from create_hypertable('reserved_column_prefix', 'a', chunk_time_interval=> 10);
 NOTICE:  adding not-null constraint to column "a"
@@ -221,7 +218,7 @@ SELECT * FROM _timescaledb_catalog.compression_settings WHERE relid = 'foo'::reg
 (1 row)
 
 SELECT decompress_chunk(ch) FROM show_chunks('foo') ch limit 1;
-ERROR:  chunk "_hyper_15_2_chunk" is not compressed
+ERROR:  chunk "_hyper_10_2_chunk" is not compressed
 --test changing the segment by columns
 ALTER TABLE foo set (timescaledb.compress, timescaledb.compress_orderby = 'a', timescaledb.compress_segmentby = 'b');
 SELECT format('%I.%I',chunk_schema,chunk_name) AS "CHUNK_NAME"
@@ -229,9 +226,9 @@ FROM timescaledb_information.chunks
 WHERE hypertable_name = 'foo'
 ORDER BY chunk_name LIMIT 1\gset
 select decompress_chunk(:'CHUNK_NAME');
-ERROR:  chunk "_hyper_15_2_chunk" is not compressed
+ERROR:  chunk "_hyper_10_2_chunk" is not compressed
 select decompress_chunk(:'CHUNK_NAME', if_compressed=>true);
-NOTICE:  chunk "_hyper_15_2_chunk" is not compressed
+NOTICE:  chunk "_hyper_10_2_chunk" is not compressed
  decompress_chunk 
 ------------------
  
@@ -241,16 +238,16 @@ NOTICE:  chunk "_hyper_15_2_chunk" is not compressed
 select compress_chunk(:'CHUNK_NAME');
              compress_chunk              
 -----------------------------------------
- _timescaledb_internal._hyper_15_2_chunk
+ _timescaledb_internal._hyper_10_2_chunk
 (1 row)
 
 select compress_chunk(:'CHUNK_NAME');
-ERROR:  chunk "_hyper_15_2_chunk" is already compressed
+ERROR:  chunk "_hyper_10_2_chunk" is already compressed
 select compress_chunk(:'CHUNK_NAME', if_not_compressed=>true);
-NOTICE:  chunk "_hyper_15_2_chunk" is already compressed
+NOTICE:  chunk "_hyper_10_2_chunk" is already compressed
              compress_chunk              
 -----------------------------------------
- _timescaledb_internal._hyper_15_2_chunk
+ _timescaledb_internal._hyper_10_2_chunk
 (1 row)
 
 SELECT compress_chunk(ch) FROM show_chunks('non_compressed') ch LIMIT 1;
@@ -258,23 +255,20 @@ ERROR:  compression not enabled on "non_compressed"
 DETAIL:  It is not possible to compress chunks on a hypertable or continuous aggregate that does not have compression enabled.
 HINT:  Enable compression using ALTER TABLE/MATERIALIZED VIEW with the timescaledb.compress option.
 ALTER TABLE foo set (timescaledb.compress, timescaledb.compress_orderby = 'a', timescaledb.compress_segmentby = 'c');
-ERROR:  cannot change configuration on already compressed chunks
-DETAIL:  There are compressed chunks that prevent changing the existing compression configuration.
 ALTER TABLE foo set (timescaledb.compress='f');
-ERROR:  cannot change configuration on already compressed chunks
-DETAIL:  There are compressed chunks that prevent changing the existing compression configuration.
+ERROR:  cannot disable compression on hypertable with compressed chunks
 ALTER TABLE foo reset (timescaledb.compress);
 ERROR:  compression options cannot be reset
 SELECT decompress_chunk(ch) FROM show_chunks('non_compressed') ch LIMIT 1;
 ERROR:  missing compressed hypertable
 --should succeed
 SELECT decompress_chunk(ch, true) FROM show_chunks('foo') ch;
-NOTICE:  chunk "_hyper_15_3_chunk" is not compressed
-NOTICE:  chunk "_hyper_15_4_chunk" is not compressed
-NOTICE:  chunk "_hyper_15_5_chunk" is not compressed
+NOTICE:  chunk "_hyper_10_3_chunk" is not compressed
+NOTICE:  chunk "_hyper_10_4_chunk" is not compressed
+NOTICE:  chunk "_hyper_10_5_chunk" is not compressed
             decompress_chunk             
 -----------------------------------------
- _timescaledb_internal._hyper_15_2_chunk
+ _timescaledb_internal._hyper_10_2_chunk
  
  
  
@@ -293,7 +287,7 @@ FROM _timescaledb_catalog.hypertable comp_hyper
 INNER JOIN _timescaledb_catalog.hypertable uncomp_hyper ON (comp_hyper.id = uncomp_hyper.compressed_hypertable_id)
 WHERE uncomp_hyper.table_name like 'foo' ORDER BY comp_hyper.id LIMIT 1 \gset
 select add_retention_policy(:'COMPRESSED_HYPER_NAME', INTERVAL '4 months', true);
-ERROR:  cannot add retention policy to compressed hypertable "_compressed_hypertable_18"
+ERROR:  cannot add retention policy to compressed hypertable "_compressed_hypertable_11"
 HINT:  Please add the policy to the corresponding uncompressed hypertable instead.
 --Constraint checking for compression
 create table fortable(col integer primary key);
@@ -367,7 +361,7 @@ CREATE TABLE table_fk (
 SELECT create_hypertable('table_fk', 'time');
    create_hypertable    
 ------------------------
- (23,public,table_fk,t)
+ (16,public,table_fk,t)
 (1 row)
 
 ALTER TABLE table_fk DROP COLUMN id1;
@@ -386,7 +380,7 @@ ORDER BY ch1.id limit 1 \gset
 select compress_chunk(:'CHUNK_NAME');
              compress_chunk              
 -----------------------------------------
- _timescaledb_internal._hyper_19_7_chunk
+ _timescaledb_internal._hyper_12_7_chunk
 (1 row)
 
 SELECT  total_chunks , number_compressed_chunks
@@ -423,17 +417,16 @@ WHERE ch1.hypertable_id = ht.id and ht.table_name like 'table_constr2' \gset
 SELECT compress_chunk(:'CHUNK_NAME');
               compress_chunk              
 ------------------------------------------
- _timescaledb_internal._hyper_25_10_chunk
+ _timescaledb_internal._hyper_18_10_chunk
 (1 row)
 
 ALTER TABLE table_constr2 set (timescaledb.compress=false);
-ERROR:  cannot change configuration on already compressed chunks
-DETAIL:  There are compressed chunks that prevent changing the existing compression configuration.
+ERROR:  cannot disable compression on hypertable with compressed chunks
 --decompress all chunks and disable compression.
 SELECT decompress_chunk(:'CHUNK_NAME');
              decompress_chunk             
 ------------------------------------------
- _timescaledb_internal._hyper_25_10_chunk
+ _timescaledb_internal._hyper_18_10_chunk
 (1 row)
 
 ALTER TABLE table_constr2 SET (timescaledb.compress=false);
@@ -445,7 +438,7 @@ NOTICE:  adding not-null constraint to column "time"
 DETAIL:  Dimensions cannot have NULL values.
       create_hypertable       
 ------------------------------
- (27,public,test_table_int,t)
+ (20,public,test_table_int,t)
 (1 row)
 
 CREATE OR REPLACE function dummy_now() returns BIGINT LANGUAGE SQL IMMUTABLE as  'SELECT 5::BIGINT';
@@ -466,7 +459,7 @@ WHERE id = :compressjob_id;
 SELECT config FROM _timescaledb_config.bgw_job WHERE id = :compressjob_id;
         config         
 -----------------------
- {"hypertable_id": 27}
+ {"hypertable_id": 20}
 (1 row)
 
 --should fail
@@ -513,7 +506,7 @@ CREATE TABLE metric (time TIMESTAMPTZ NOT NULL, val FLOAT8 NOT NULL, dev_id INT4
 SELECT create_hypertable('metric', 'time', 'dev_id', 10);
   create_hypertable   
 ----------------------
- (29,public,metric,t)
+ (22,public,metric,t)
 (1 row)
 
 ALTER TABLE metric SET (
@@ -528,7 +521,7 @@ FROM generate_series('2021-08-17 00:00:00'::timestamp,
 SELECT compress_chunk(show_chunks('metric'));
               compress_chunk              
 ------------------------------------------
- _timescaledb_internal._hyper_29_17_chunk
+ _timescaledb_internal._hyper_22_17_chunk
 (1 row)
 
 -- column does not exist the first time
@@ -554,7 +547,7 @@ WARNING:  column type "timestamp without time zone" used for "time" does not fol
 HINT:  Use datatype TIMESTAMPTZ instead.
  create_hypertable  
 --------------------
- (31,public,test,t)
+ (24,public,test,t)
 (1 row)
 
 INSERT INTO test VALUES ('2001-01-01 00:00', 'home'),
@@ -579,14 +572,14 @@ EXPLAIN (COSTS OFF, TIMING OFF, SUMMARY OFF) SELECT DISTINCT 1 FROM test;
 --------------------------------------------
  Limit
    ->  Result
-         ->  Seq Scan on _hyper_31_19_chunk
+         ->  Seq Scan on _hyper_24_19_chunk
 (3 rows)
 
 --compress chunks
 SELECT COMPRESS_CHUNK(X) FROM SHOW_CHUNKS('test') X;
               compress_chunk              
 ------------------------------------------
- _timescaledb_internal._hyper_31_19_chunk
+ _timescaledb_internal._hyper_24_19_chunk
 (1 row)
 
 ANALYZE test;
@@ -603,8 +596,8 @@ EXPLAIN (COSTS OFF, TIMING OFF, SUMMARY OFF) SELECT DISTINCT 1 FROM test;
 -----------------------------------------------------------------
  Limit
    ->  Result
-         ->  Custom Scan (DecompressChunk) on _hyper_31_19_chunk
-               ->  Seq Scan on compress_hyper_32_20_chunk
+         ->  Custom Scan (DecompressChunk) on _hyper_24_19_chunk
+               ->  Seq Scan on compress_hyper_25_20_chunk
 (4 rows)
 
 --github issue 4398
@@ -616,7 +609,7 @@ NOTICE:  adding not-null constraint to column "tm"
 DETAIL:  Dimensions cannot have NULL values.
  hypertable_id | schema_name | table_name | created 
 ---------------+-------------+------------+---------
-            33 | public      | ts_table   | t
+            26 | public      | ts_table   | t
 (1 row)
 
 --should report a warning
@@ -639,7 +632,7 @@ SELECT create_hypertable('readings', 'time', chunk_time_interval => interval '12
 NOTICE:  migrating data to chunks
    create_hypertable    
 ------------------------
- (35,public,readings,t)
+ (28,public,readings,t)
 (1 row)
 
 create unique index readings_uniq_idx on readings("time",battery_temperature);
@@ -647,7 +640,7 @@ ALTER TABLE readings SET (timescaledb.compress,timescaledb.compress_segmentby = 
 SELECT compress_chunk(show_chunks('readings'));
               compress_chunk              
 ------------------------------------------
- _timescaledb_internal._hyper_35_22_chunk
+ _timescaledb_internal._hyper_28_22_chunk
 (1 row)
 
 ALTER TABLE readings DROP COLUMN battery_status;
@@ -661,25 +654,25 @@ SELECT readings FROM readings;
 
 -- #5577 On-insert decompression after schema changes may not work properly
 SELECT decompress_chunk(show_chunks('readings'),true);
-NOTICE:  chunk "_hyper_35_24_chunk" is not compressed
+NOTICE:  chunk "_hyper_28_24_chunk" is not compressed
              decompress_chunk             
 ------------------------------------------
- _timescaledb_internal._hyper_35_22_chunk
+ _timescaledb_internal._hyper_28_22_chunk
  
 (2 rows)
 
 SELECT compress_chunk(show_chunks('readings'),true);
               compress_chunk              
 ------------------------------------------
- _timescaledb_internal._hyper_35_22_chunk
- _timescaledb_internal._hyper_35_24_chunk
+ _timescaledb_internal._hyper_28_22_chunk
+ _timescaledb_internal._hyper_28_24_chunk
 (2 rows)
 
 \set ON_ERROR_STOP 0
 INSERT INTO readings ("time", battery_temperature) VALUES
     ('2022-11-11 11:11:11',0.2) -- same record as inserted
 ;
-ERROR:  duplicate key value violates unique constraint "_hyper_35_24_chunk_readings_uniq_idx"
+ERROR:  duplicate key value violates unique constraint "_hyper_28_24_chunk_readings_uniq_idx"
 \set ON_ERROR_STOP 1
 SELECT * from readings;
              time             | battery_temperature 
@@ -698,8 +691,8 @@ SELECT assert_equal(count(1), 2::bigint) FROM readings;
 SELECT decompress_chunk(show_chunks('readings'),true);
              decompress_chunk             
 ------------------------------------------
- _timescaledb_internal._hyper_35_22_chunk
- _timescaledb_internal._hyper_35_24_chunk
+ _timescaledb_internal._hyper_28_22_chunk
+ _timescaledb_internal._hyper_28_24_chunk
 (2 rows)
 
 -- #5553 Unique constraints are not always respected on compressed tables
@@ -711,7 +704,7 @@ NOTICE:  adding not-null constraint to column "time"
 NOTICE:  migrating data to chunks
     create_hypertable     
 --------------------------
- (37,public,main_table,t)
+ (30,public,main_table,t)
 (1 row)
 
 ALTER TABLE main_table SET (
@@ -721,19 +714,19 @@ ALTER TABLE main_table SET (
 SELECT compress_chunk(show_chunks('main_table'));
               compress_chunk              
 ------------------------------------------
- _timescaledb_internal._hyper_37_27_chunk
+ _timescaledb_internal._hyper_30_27_chunk
 (1 row)
 
 -- insert rejected
 \set ON_ERROR_STOP 0
 INSERT INTO main_table VALUES
     ('2011-11-11 11:11:11', 'foo');
-ERROR:  duplicate key value violates unique constraint "_hyper_37_27_chunk_xm"
+ERROR:  duplicate key value violates unique constraint "_hyper_30_27_chunk_xm"
 -- insert rejected in case 1st row doesn't violate constraint with different segmentby
 INSERT INTO main_table VALUES
     ('2011-11-11 11:12:11', 'bar'),
     ('2011-11-11 11:11:11', 'foo');
-ERROR:  duplicate key value violates unique constraint "_hyper_37_27_chunk_xm"
+ERROR:  duplicate key value violates unique constraint "_hyper_30_27_chunk_xm"
 \set ON_ERROR_STOP 1
 SELECT assert_equal(count(1), 1::bigint) FROM main_table;
  assert_equal 
@@ -745,7 +738,7 @@ SELECT assert_equal(count(1), 1::bigint) FROM main_table;
 SELECT decompress_chunk(show_chunks('main_table'), TRUE);
              decompress_chunk             
 ------------------------------------------
- _timescaledb_internal._hyper_37_27_chunk
+ _timescaledb_internal._hyper_30_27_chunk
 (1 row)
 
 DROP TABLE IF EXISTS readings;
@@ -759,7 +752,7 @@ CREATE TABLE readings(
 SELECT create_hypertable('readings', 'time', chunk_time_interval => interval '12 hour');
    create_hypertable    
 ------------------------
- (39,public,readings,t)
+ (32,public,readings,t)
 (1 row)
 
 CREATE UNIQUE INDEX readings_uniq_idx ON readings("time", battery_temperature);
@@ -771,7 +764,7 @@ INSERT INTO readings("time", candy, battery_temperature)
 SELECT compress_chunk(show_chunks('readings'), TRUE);
               compress_chunk              
 ------------------------------------------
- _timescaledb_internal._hyper_39_29_chunk
+ _timescaledb_internal._hyper_32_29_chunk
 (1 row)
 
 -- no error happens

--- a/tsl/test/expected/compression_indexscan.out
+++ b/tsl/test/expected/compression_indexscan.out
@@ -717,44 +717,44 @@ INFO:  compress_chunk_tuplesort_start
 INFO:  compress_chunk_tuplesort_start
 INFO:  compress_chunk_tuplesort_start
 INFO:  compress_chunk_tuplesort_start
-              compress_chunk              
-------------------------------------------
- _timescaledb_internal._hyper_22_93_chunk
- _timescaledb_internal._hyper_22_94_chunk
- _timescaledb_internal._hyper_22_95_chunk
- _timescaledb_internal._hyper_22_96_chunk
+             compress_chunk              
+-----------------------------------------
+ _timescaledb_internal._hyper_5_93_chunk
+ _timescaledb_internal._hyper_5_94_chunk
+ _timescaledb_internal._hyper_5_95_chunk
+ _timescaledb_internal._hyper_5_96_chunk
 (4 rows)
 
 SELECT decompress_chunk(show_chunks('tab3'));
-             decompress_chunk             
-------------------------------------------
- _timescaledb_internal._hyper_22_93_chunk
- _timescaledb_internal._hyper_22_94_chunk
- _timescaledb_internal._hyper_22_95_chunk
- _timescaledb_internal._hyper_22_96_chunk
+            decompress_chunk             
+-----------------------------------------
+ _timescaledb_internal._hyper_5_93_chunk
+ _timescaledb_internal._hyper_5_94_chunk
+ _timescaledb_internal._hyper_5_95_chunk
+ _timescaledb_internal._hyper_5_96_chunk
 (4 rows)
 
 CREATE INDEX idxcol_asc_null_first ON tab3(name, time ASC NULLS FIRST);
 SELECT compress_chunk(show_chunks('tab3'));
-INFO:  compress_chunk_indexscan_start matched index "_hyper_22_93_chunk_idxcol_asc_null_first"
-INFO:  compress_chunk_indexscan_start matched index "_hyper_22_94_chunk_idxcol_asc_null_first"
-INFO:  compress_chunk_indexscan_start matched index "_hyper_22_95_chunk_idxcol_asc_null_first"
-INFO:  compress_chunk_indexscan_start matched index "_hyper_22_96_chunk_idxcol_asc_null_first"
-              compress_chunk              
-------------------------------------------
- _timescaledb_internal._hyper_22_93_chunk
- _timescaledb_internal._hyper_22_94_chunk
- _timescaledb_internal._hyper_22_95_chunk
- _timescaledb_internal._hyper_22_96_chunk
+INFO:  compress_chunk_indexscan_start matched index "_hyper_5_93_chunk_idxcol_asc_null_first"
+INFO:  compress_chunk_indexscan_start matched index "_hyper_5_94_chunk_idxcol_asc_null_first"
+INFO:  compress_chunk_indexscan_start matched index "_hyper_5_95_chunk_idxcol_asc_null_first"
+INFO:  compress_chunk_indexscan_start matched index "_hyper_5_96_chunk_idxcol_asc_null_first"
+             compress_chunk              
+-----------------------------------------
+ _timescaledb_internal._hyper_5_93_chunk
+ _timescaledb_internal._hyper_5_94_chunk
+ _timescaledb_internal._hyper_5_95_chunk
+ _timescaledb_internal._hyper_5_96_chunk
 (4 rows)
 
 SELECT decompress_chunk(show_chunks('tab3'));
-             decompress_chunk             
-------------------------------------------
- _timescaledb_internal._hyper_22_93_chunk
- _timescaledb_internal._hyper_22_94_chunk
- _timescaledb_internal._hyper_22_95_chunk
- _timescaledb_internal._hyper_22_96_chunk
+            decompress_chunk             
+-----------------------------------------
+ _timescaledb_internal._hyper_5_93_chunk
+ _timescaledb_internal._hyper_5_94_chunk
+ _timescaledb_internal._hyper_5_95_chunk
+ _timescaledb_internal._hyper_5_96_chunk
 (4 rows)
 
 DROP INDEX idx_asc_null_first;
@@ -767,44 +767,44 @@ INFO:  compress_chunk_tuplesort_start
 INFO:  compress_chunk_tuplesort_start
 INFO:  compress_chunk_tuplesort_start
 INFO:  compress_chunk_tuplesort_start
-              compress_chunk              
-------------------------------------------
- _timescaledb_internal._hyper_22_93_chunk
- _timescaledb_internal._hyper_22_94_chunk
- _timescaledb_internal._hyper_22_95_chunk
- _timescaledb_internal._hyper_22_96_chunk
+             compress_chunk              
+-----------------------------------------
+ _timescaledb_internal._hyper_5_93_chunk
+ _timescaledb_internal._hyper_5_94_chunk
+ _timescaledb_internal._hyper_5_95_chunk
+ _timescaledb_internal._hyper_5_96_chunk
 (4 rows)
 
 SELECT decompress_chunk(show_chunks('tab3'));
-             decompress_chunk             
-------------------------------------------
- _timescaledb_internal._hyper_22_93_chunk
- _timescaledb_internal._hyper_22_94_chunk
- _timescaledb_internal._hyper_22_95_chunk
- _timescaledb_internal._hyper_22_96_chunk
+            decompress_chunk             
+-----------------------------------------
+ _timescaledb_internal._hyper_5_93_chunk
+ _timescaledb_internal._hyper_5_94_chunk
+ _timescaledb_internal._hyper_5_95_chunk
+ _timescaledb_internal._hyper_5_96_chunk
 (4 rows)
 
 CREATE INDEX idxcol_asc_null_first ON tab3(name, time ASC NULLS FIRST);
 SELECT compress_chunk(show_chunks('tab3'));
-INFO:  compress_chunk_indexscan_start matched index "_hyper_22_93_chunk_idxcol_asc_null_first"
-INFO:  compress_chunk_indexscan_start matched index "_hyper_22_94_chunk_idxcol_asc_null_first"
-INFO:  compress_chunk_indexscan_start matched index "_hyper_22_95_chunk_idxcol_asc_null_first"
-INFO:  compress_chunk_indexscan_start matched index "_hyper_22_96_chunk_idxcol_asc_null_first"
-              compress_chunk              
-------------------------------------------
- _timescaledb_internal._hyper_22_93_chunk
- _timescaledb_internal._hyper_22_94_chunk
- _timescaledb_internal._hyper_22_95_chunk
- _timescaledb_internal._hyper_22_96_chunk
+INFO:  compress_chunk_indexscan_start matched index "_hyper_5_93_chunk_idxcol_asc_null_first"
+INFO:  compress_chunk_indexscan_start matched index "_hyper_5_94_chunk_idxcol_asc_null_first"
+INFO:  compress_chunk_indexscan_start matched index "_hyper_5_95_chunk_idxcol_asc_null_first"
+INFO:  compress_chunk_indexscan_start matched index "_hyper_5_96_chunk_idxcol_asc_null_first"
+             compress_chunk              
+-----------------------------------------
+ _timescaledb_internal._hyper_5_93_chunk
+ _timescaledb_internal._hyper_5_94_chunk
+ _timescaledb_internal._hyper_5_95_chunk
+ _timescaledb_internal._hyper_5_96_chunk
 (4 rows)
 
 SELECT decompress_chunk(show_chunks('tab3'));
-             decompress_chunk             
-------------------------------------------
- _timescaledb_internal._hyper_22_93_chunk
- _timescaledb_internal._hyper_22_94_chunk
- _timescaledb_internal._hyper_22_95_chunk
- _timescaledb_internal._hyper_22_96_chunk
+            decompress_chunk             
+-----------------------------------------
+ _timescaledb_internal._hyper_5_93_chunk
+ _timescaledb_internal._hyper_5_94_chunk
+ _timescaledb_internal._hyper_5_95_chunk
+ _timescaledb_internal._hyper_5_96_chunk
 (4 rows)
 
 DROP INDEX idx_asc_null_first;

--- a/tsl/test/expected/compression_settings.out
+++ b/tsl/test/expected/compression_settings.out
@@ -2,16 +2,16 @@
 -- Please see the included NOTICE for copyright information and
 -- LICENSE-TIMESCALE for a copy of the license.
 \set ECHO ALL
-CREATE TABLE metrics(time timestamptz, device text, value float);
-SELECT create_hypertable('metrics','time');
-NOTICE:  adding not-null constraint to column "time"
-  create_hypertable   
-----------------------
- (1,public,metrics,t)
+CREATE VIEW settings AS SELECT * FROM _timescaledb_catalog.compression_settings ORDER BY upper(relid::text) COLLATE "C";
+CREATE TABLE metrics(time timestamptz not null, device text, value float);
+SELECT table_name FROM create_hypertable('metrics','time');
+ table_name 
+------------
+ metrics
 (1 row)
 
 ALTER TABLE metrics SET (timescaledb.compress, timescaledb.compress_segmentby='device');
-SELECT * FROM _timescaledb_catalog.compression_settings;
+SELECT * FROM settings;
   relid  | segmentby | orderby | orderby_desc | orderby_nullsfirst 
 ---------+-----------+---------+--------------+--------------------
  metrics | {device}  | {time}  | {t}          | {t}
@@ -20,7 +20,7 @@ SELECT * FROM _timescaledb_catalog.compression_settings;
 -- create 2 chunks
 INSERT INTO metrics VALUES ('2000-01-01'), ('2001-01-01');
 -- no change to settings
-SELECT * FROM _timescaledb_catalog.compression_settings;
+SELECT * FROM settings;
   relid  | segmentby | orderby | orderby_desc | orderby_nullsfirst 
 ---------+-----------+---------+--------------+--------------------
  metrics | {device}  | {time}  | {t}          | {t}
@@ -49,7 +49,7 @@ SELECT compress_chunk('_timescaledb_internal._hyper_1_2_chunk');
  _timescaledb_internal._hyper_1_2_chunk
 (1 row)
 
-SELECT * FROM _timescaledb_catalog.compression_settings;
+SELECT * FROM settings;
                      relid                      | segmentby | orderby | orderby_desc | orderby_nullsfirst 
 ------------------------------------------------+-----------+---------+--------------+--------------------
  metrics                                        | {device}  | {time}  | {t}          | {t}
@@ -59,7 +59,7 @@ SELECT * FROM _timescaledb_catalog.compression_settings;
 
 -- dropping chunk should remove that chunks compression settings
 DROP TABLE _timescaledb_internal._hyper_1_1_chunk;
-SELECT * FROM _timescaledb_catalog.compression_settings;
+SELECT * FROM settings;
                      relid                      | segmentby | orderby | orderby_desc | orderby_nullsfirst 
 ------------------------------------------------+-----------+---------+--------------+--------------------
  metrics                                        | {device}  | {time}  | {t}          | {t}
@@ -73,7 +73,7 @@ SELECT decompress_chunk('_timescaledb_internal._hyper_1_2_chunk');
  _timescaledb_internal._hyper_1_2_chunk
 (1 row)
 
-SELECT * FROM _timescaledb_catalog.compression_settings;
+SELECT * FROM settings;
   relid  | segmentby | orderby | orderby_desc | orderby_nullsfirst 
 ---------+-----------+---------+--------------+--------------------
  metrics | {device}  | {time}  | {t}          | {t}
@@ -86,7 +86,7 @@ SELECT compress_chunk('_timescaledb_internal._hyper_1_2_chunk');
  _timescaledb_internal._hyper_1_2_chunk
 (1 row)
 
-SELECT * FROM _timescaledb_catalog.compression_settings;
+SELECT * FROM settings;
                      relid                      | segmentby | orderby | orderby_desc | orderby_nullsfirst 
 ------------------------------------------------+-----------+---------+--------------+--------------------
  metrics                                        | {device}  | {time}  | {t}          | {t}
@@ -95,8 +95,113 @@ SELECT * FROM _timescaledb_catalog.compression_settings;
 
 -- dropping hypertable should remove all settings
 DROP TABLE metrics;
-SELECT * FROM _timescaledb_catalog.compression_settings;
+SELECT * FROM settings;
  relid | segmentby | orderby | orderby_desc | orderby_nullsfirst 
 -------+-----------+---------+--------------+--------------------
 (0 rows)
+
+CREATE TABLE metrics(time timestamptz not null, d1 text, d2 text, value float);
+SELECT table_name FROM create_hypertable('metrics','time');
+ table_name 
+------------
+ metrics
+(1 row)
+
+ALTER TABLE metrics SET (timescaledb.compress);
+-- hypertable should have default settings now
+SELECT * FROM settings;
+  relid  | segmentby | orderby | orderby_desc | orderby_nullsfirst 
+---------+-----------+---------+--------------+--------------------
+ metrics |           | {time}  | {t}          | {t}
+(1 row)
+
+-- create chunk
+INSERT INTO metrics VALUES ('2000-01-01');
+ALTER TABLE metrics SET (timescaledb.compress_segmentby='d1');
+-- settings should be updated
+SELECT * FROM settings;
+  relid  | segmentby | orderby | orderby_desc | orderby_nullsfirst 
+---------+-----------+---------+--------------+--------------------
+ metrics | {d1}      | {time}  | {t}          | {t}
+(1 row)
+
+SELECT compress_chunk(show_chunks('metrics'));
+             compress_chunk             
+----------------------------------------
+ _timescaledb_internal._hyper_3_6_chunk
+(1 row)
+
+-- settings for compressed chunk should be present
+SELECT * FROM settings;
+                     relid                      | segmentby | orderby | orderby_desc | orderby_nullsfirst 
+------------------------------------------------+-----------+---------+--------------+--------------------
+ metrics                                        | {d1}      | {time}  | {t}          | {t}
+ _timescaledb_internal.compress_hyper_4_7_chunk | {d1}      | {time}  | {t}          | {t}
+(2 rows)
+
+-- changing settings should update settings for hypertable but not existing compressed chunks
+ALTER TABLE metrics SET (timescaledb.compress_segmentby='d2');
+SELECT * FROM settings;
+                     relid                      | segmentby | orderby | orderby_desc | orderby_nullsfirst 
+------------------------------------------------+-----------+---------+--------------+--------------------
+ metrics                                        | {d2}      | {time}  | {t}          | {t}
+ _timescaledb_internal.compress_hyper_4_7_chunk | {d1}      | {time}  | {t}          | {t}
+(2 rows)
+
+-- changing settings should update settings for hypertable but not existing compressed chunks
+ALTER TABLE metrics SET (timescaledb.compress_segmentby='');
+SELECT * FROM settings;
+                     relid                      | segmentby | orderby | orderby_desc | orderby_nullsfirst 
+------------------------------------------------+-----------+---------+--------------+--------------------
+ metrics                                        |           | {time}  | {t}          | {t}
+ _timescaledb_internal.compress_hyper_4_7_chunk | {d1}      | {time}  | {t}          | {t}
+(2 rows)
+
+-- create another chunk
+INSERT INTO metrics VALUES ('2000-02-01');
+SELECT compress_chunk(show_chunks('metrics'), true);
+NOTICE:  chunk "_hyper_3_6_chunk" is already compressed
+             compress_chunk             
+----------------------------------------
+ _timescaledb_internal._hyper_3_6_chunk
+ _timescaledb_internal._hyper_3_8_chunk
+(2 rows)
+
+SELECT * FROM settings;
+                     relid                      | segmentby | orderby | orderby_desc | orderby_nullsfirst 
+------------------------------------------------+-----------+---------+--------------+--------------------
+ metrics                                        |           | {time}  | {t}          | {t}
+ _timescaledb_internal.compress_hyper_4_7_chunk | {d1}      | {time}  | {t}          | {t}
+ _timescaledb_internal.compress_hyper_4_9_chunk |           | {time}  | {t}          | {t}
+(3 rows)
+
+ALTER TABLE metrics SET (timescaledb.compress_segmentby='d2');
+SELECT format('%I.%I', schema_name, table_name) AS "CHUNK" FROM _timescaledb_catalog.chunk WHERE compressed_chunk_id IS NOT NULL ORDER BY id LIMIT 1 OFFSET 1\gset
+-- recompressing chunks should apply current hypertable settings
+SELECT decompress_chunk(:'CHUNK');
+            decompress_chunk            
+----------------------------------------
+ _timescaledb_internal._hyper_3_8_chunk
+(1 row)
+
+SELECT * FROM settings;
+                     relid                      | segmentby | orderby | orderby_desc | orderby_nullsfirst 
+------------------------------------------------+-----------+---------+--------------+--------------------
+ metrics                                        | {d2}      | {time}  | {t}          | {t}
+ _timescaledb_internal.compress_hyper_4_7_chunk | {d1}      | {time}  | {t}          | {t}
+(2 rows)
+
+SELECT compress_chunk(:'CHUNK');
+             compress_chunk             
+----------------------------------------
+ _timescaledb_internal._hyper_3_8_chunk
+(1 row)
+
+SELECT * FROM settings;
+                      relid                      | segmentby | orderby | orderby_desc | orderby_nullsfirst 
+-------------------------------------------------+-----------+---------+--------------+--------------------
+ metrics                                         | {d2}      | {time}  | {t}          | {t}
+ _timescaledb_internal.compress_hyper_4_10_chunk | {d2}      | {time}  | {t}          | {t}
+ _timescaledb_internal.compress_hyper_4_7_chunk  | {d1}      | {time}  | {t}          | {t}
+(3 rows)
 

--- a/tsl/test/expected/continuous_aggs-13.out
+++ b/tsl/test/expected/continuous_aggs-13.out
@@ -1600,7 +1600,7 @@ ORDER BY 1, 2, 3;
 --now disable compression , will error out --
 \set ON_ERROR_STOP 0
 ALTER MATERIALIZED VIEW search_query_count_3 SET (timescaledb.compress = 'false');
-ERROR:  cannot change configuration on already compressed chunks
+ERROR:  cannot disable compression on hypertable with compressed chunks
 \set ON_ERROR_STOP 1
 SELECT decompress_chunk(format('%I.%I', schema_name, table_name))
 FROM _timescaledb_catalog.chunk

--- a/tsl/test/expected/continuous_aggs-14.out
+++ b/tsl/test/expected/continuous_aggs-14.out
@@ -1599,7 +1599,7 @@ ORDER BY 1, 2, 3;
 --now disable compression , will error out --
 \set ON_ERROR_STOP 0
 ALTER MATERIALIZED VIEW search_query_count_3 SET (timescaledb.compress = 'false');
-ERROR:  cannot change configuration on already compressed chunks
+ERROR:  cannot disable compression on hypertable with compressed chunks
 \set ON_ERROR_STOP 1
 SELECT decompress_chunk(format('%I.%I', schema_name, table_name))
 FROM _timescaledb_catalog.chunk

--- a/tsl/test/expected/continuous_aggs-15.out
+++ b/tsl/test/expected/continuous_aggs-15.out
@@ -1599,7 +1599,7 @@ ORDER BY 1, 2, 3;
 --now disable compression , will error out --
 \set ON_ERROR_STOP 0
 ALTER MATERIALIZED VIEW search_query_count_3 SET (timescaledb.compress = 'false');
-ERROR:  cannot change configuration on already compressed chunks
+ERROR:  cannot disable compression on hypertable with compressed chunks
 \set ON_ERROR_STOP 1
 SELECT decompress_chunk(format('%I.%I', schema_name, table_name))
 FROM _timescaledb_catalog.chunk

--- a/tsl/test/expected/continuous_aggs-16.out
+++ b/tsl/test/expected/continuous_aggs-16.out
@@ -1599,7 +1599,7 @@ ORDER BY 1, 2, 3;
 --now disable compression , will error out --
 \set ON_ERROR_STOP 0
 ALTER MATERIALIZED VIEW search_query_count_3 SET (timescaledb.compress = 'false');
-ERROR:  cannot change configuration on already compressed chunks
+ERROR:  cannot disable compression on hypertable with compressed chunks
 \set ON_ERROR_STOP 1
 SELECT decompress_chunk(format('%I.%I', schema_name, table_name))
 FROM _timescaledb_catalog.chunk

--- a/tsl/test/sql/compression_settings.sql
+++ b/tsl/test/sql/compression_settings.sql
@@ -4,16 +4,18 @@
 
 \set ECHO ALL
 
-CREATE TABLE metrics(time timestamptz, device text, value float);
-SELECT create_hypertable('metrics','time');
+CREATE VIEW settings AS SELECT * FROM _timescaledb_catalog.compression_settings ORDER BY upper(relid::text) COLLATE "C";
+
+CREATE TABLE metrics(time timestamptz not null, device text, value float);
+SELECT table_name FROM create_hypertable('metrics','time');
 
 ALTER TABLE metrics SET (timescaledb.compress, timescaledb.compress_segmentby='device');
-SELECT * FROM _timescaledb_catalog.compression_settings;
+SELECT * FROM settings;
 
 -- create 2 chunks
 INSERT INTO metrics VALUES ('2000-01-01'), ('2001-01-01');
 -- no change to settings
-SELECT * FROM _timescaledb_catalog.compression_settings;
+SELECT * FROM settings;
 
 --Enable compression path info
 SET timescaledb.debug_compression_path_info= 'on';
@@ -23,20 +25,63 @@ RESET timescaledb.debug_compression_path_info;
 SELECT * FROM _timescaledb_catalog.compression_settings;
 
 SELECT compress_chunk('_timescaledb_internal._hyper_1_2_chunk');
-SELECT * FROM _timescaledb_catalog.compression_settings;
+SELECT * FROM settings;
 
 -- dropping chunk should remove that chunks compression settings
 DROP TABLE _timescaledb_internal._hyper_1_1_chunk;
-SELECT * FROM _timescaledb_catalog.compression_settings;
+SELECT * FROM settings;
 
 -- decompress_chunk should remove settings for that chunk
 SELECT decompress_chunk('_timescaledb_internal._hyper_1_2_chunk');
-SELECT * FROM _timescaledb_catalog.compression_settings;
+SELECT * FROM settings;
 
 -- compress_chunk should add settings back
 SELECT compress_chunk('_timescaledb_internal._hyper_1_2_chunk');
-SELECT * FROM _timescaledb_catalog.compression_settings;
+SELECT * FROM settings;
 
 -- dropping hypertable should remove all settings
 DROP TABLE metrics;
-SELECT * FROM _timescaledb_catalog.compression_settings;
+SELECT * FROM settings;
+
+CREATE TABLE metrics(time timestamptz not null, d1 text, d2 text, value float);
+SELECT table_name FROM create_hypertable('metrics','time');
+
+ALTER TABLE metrics SET (timescaledb.compress);
+-- hypertable should have default settings now
+SELECT * FROM settings;
+
+-- create chunk
+INSERT INTO metrics VALUES ('2000-01-01');
+ALTER TABLE metrics SET (timescaledb.compress_segmentby='d1');
+-- settings should be updated
+SELECT * FROM settings;
+
+SELECT compress_chunk(show_chunks('metrics'));
+-- settings for compressed chunk should be present
+SELECT * FROM settings;
+
+-- changing settings should update settings for hypertable but not existing compressed chunks
+ALTER TABLE metrics SET (timescaledb.compress_segmentby='d2');
+SELECT * FROM settings;
+
+-- changing settings should update settings for hypertable but not existing compressed chunks
+ALTER TABLE metrics SET (timescaledb.compress_segmentby='');
+SELECT * FROM settings;
+
+-- create another chunk
+INSERT INTO metrics VALUES ('2000-02-01');
+SELECT compress_chunk(show_chunks('metrics'), true);
+
+SELECT * FROM settings;
+ALTER TABLE metrics SET (timescaledb.compress_segmentby='d2');
+
+SELECT format('%I.%I', schema_name, table_name) AS "CHUNK" FROM _timescaledb_catalog.chunk WHERE compressed_chunk_id IS NOT NULL ORDER BY id LIMIT 1 OFFSET 1\gset
+
+-- recompressing chunks should apply current hypertable settings
+SELECT decompress_chunk(:'CHUNK');
+SELECT * FROM settings;
+SELECT compress_chunk(:'CHUNK');
+SELECT * FROM settings;
+
+
+


### PR DESCRIPTION
This patch removes the restrictions preventing changing compression settings when compressed chunks exist. Compression settings can now be changed at any time and will not affect existing compressed chunks but any subsequent compress_chunk will apply the changed settings. A decompress_chunk/compress_chunk cycle will also compress the chunk with the new settings.