### PR TITLE
Remove outdated checks from update scripts

### DIFF
--- a/test/sql/updates/setup.policies.sql
+++ b/test/sql/updates/setup.policies.sql
@@ -26,15 +26,14 @@ BEGIN
   FROM timescale_version;
 
   PERFORM add_reorder_policy('policy_test_timestamptz','policy_test_timestamptz_time_idx');
+  PERFORM add_retention_policy('policy_test_timestamptz','60d'::interval);
 
   -- some policy API functions got renamed for 2.0 so we need to make
   -- sure to use the right name for the version. The schedule_interval
   -- parameter of add_compression_policy was introduced in 2.8.0
   IF ts_major = 2 AND ts_minor < 8 THEN
-    PERFORM add_retention_policy('policy_test_timestamptz','60d'::interval);
     PERFORM add_compression_policy('policy_test_timestamptz','10d'::interval);
   ELSE
-    PERFORM add_retention_policy('policy_test_timestamptz','60d'::interval);
     PERFORM add_compression_policy('policy_test_timestamptz','10d'::interval, schedule_interval => '3 days 12:00:00'::interval);
   END IF;
 END


### PR DESCRIPTION
This patch removes some version checks that are now superfluous. The oldest version our update process needs to be able to handle is 2.1.0 as previous versions will not work with currently supported postgres versions.