### PR TITLE
Support all time_bucket variants in plan time chunk exclusion

### DIFF
--- a/test/expected/plan_expand_hypertable-13.out
+++ b/test/expected/plan_expand_hypertable-13.out
@@ -1113,6 +1113,455 @@ time_bucket exclusion
                Filter: (("time" < '21'::bigint) AND ('11'::bigint > time_bucket('10'::bigint, "time")))
 (9 rows)
 
+:PREFIX SELECT * FROM hyper WHERE time_bucket(10, time, 5) < 10::bigint ORDER BY time;
+                                                     QUERY PLAN                                                      
+---------------------------------------------------------------------------------------------------------------------
+ Sort
+   Sort Key: _hyper_1_1_chunk."time"
+   ->  Append
+         ->  Seq Scan on _hyper_1_1_chunk
+               Filter: (("time" < '20'::bigint) AND (time_bucket('10'::bigint, "time", '5'::bigint) < '10'::bigint))
+         ->  Seq Scan on _hyper_1_2_chunk
+               Filter: (("time" < '20'::bigint) AND (time_bucket('10'::bigint, "time", '5'::bigint) < '10'::bigint))
+(7 rows)
+
+:PREFIX SELECT * FROM hyper WHERE time_bucket(10, time, 5) < 11::bigint ORDER BY time;
+                                                     QUERY PLAN                                                      
+---------------------------------------------------------------------------------------------------------------------
+ Sort
+   Sort Key: _hyper_1_1_chunk."time"
+   ->  Append
+         ->  Seq Scan on _hyper_1_1_chunk
+               Filter: (("time" < '21'::bigint) AND (time_bucket('10'::bigint, "time", '5'::bigint) < '11'::bigint))
+         ->  Seq Scan on _hyper_1_2_chunk
+               Filter: (("time" < '21'::bigint) AND (time_bucket('10'::bigint, "time", '5'::bigint) < '11'::bigint))
+         ->  Seq Scan on _hyper_1_3_chunk
+               Filter: (("time" < '21'::bigint) AND (time_bucket('10'::bigint, "time", '5'::bigint) < '11'::bigint))
+(9 rows)
+
+:PREFIX SELECT * FROM hyper WHERE time_bucket(10, time, 5) <= 10::bigint ORDER BY time;
+                                                      QUERY PLAN                                                       
+-----------------------------------------------------------------------------------------------------------------------
+ Sort
+   Sort Key: _hyper_1_1_chunk."time"
+   ->  Append
+         ->  Seq Scan on _hyper_1_1_chunk
+               Filter: (("time" <= '20'::bigint) AND (time_bucket('10'::bigint, "time", '5'::bigint) <= '10'::bigint))
+         ->  Seq Scan on _hyper_1_2_chunk
+               Filter: (("time" <= '20'::bigint) AND (time_bucket('10'::bigint, "time", '5'::bigint) <= '10'::bigint))
+         ->  Seq Scan on _hyper_1_3_chunk
+               Filter: (("time" <= '20'::bigint) AND (time_bucket('10'::bigint, "time", '5'::bigint) <= '10'::bigint))
+(9 rows)
+
+:PREFIX SELECT * FROM hyper WHERE 10::bigint > time_bucket(10, time, 5) ORDER BY time;
+                                                     QUERY PLAN                                                      
+---------------------------------------------------------------------------------------------------------------------
+ Sort
+   Sort Key: _hyper_1_1_chunk."time"
+   ->  Append
+         ->  Seq Scan on _hyper_1_1_chunk
+               Filter: (("time" < '20'::bigint) AND ('10'::bigint > time_bucket('10'::bigint, "time", '5'::bigint)))
+         ->  Seq Scan on _hyper_1_2_chunk
+               Filter: (("time" < '20'::bigint) AND ('10'::bigint > time_bucket('10'::bigint, "time", '5'::bigint)))
+(7 rows)
+
+:PREFIX SELECT * FROM hyper WHERE 11::bigint > time_bucket(10, time, 5) ORDER BY time;
+                                                     QUERY PLAN                                                      
+---------------------------------------------------------------------------------------------------------------------
+ Sort
+   Sort Key: _hyper_1_1_chunk."time"
+   ->  Append
+         ->  Seq Scan on _hyper_1_1_chunk
+               Filter: (("time" < '21'::bigint) AND ('11'::bigint > time_bucket('10'::bigint, "time", '5'::bigint)))
+         ->  Seq Scan on _hyper_1_2_chunk
+               Filter: (("time" < '21'::bigint) AND ('11'::bigint > time_bucket('10'::bigint, "time", '5'::bigint)))
+         ->  Seq Scan on _hyper_1_3_chunk
+               Filter: (("time" < '21'::bigint) AND ('11'::bigint > time_bucket('10'::bigint, "time", '5'::bigint)))
+(9 rows)
+
+\qecho timestamp time_bucket exclusion
+timestamp time_bucket exclusion
+SELECT count(DISTINCT tableoid) FROM metrics_timestamp;
+ count 
+-------
+     5
+(1 row)
+
+:PREFIX SELECT * FROM metrics_timestamp WHERE time_bucket('7d',time) < '2000-01-05' ORDER BY time;
+                                                      QUERY PLAN                                                       
+-----------------------------------------------------------------------------------------------------------------------
+ Custom Scan (ChunkAppend) on metrics_timestamp
+   Order: metrics_timestamp."time"
+   ->  Index Only Scan Backward using _hyper_5_155_chunk_metrics_timestamp_time_idx on _hyper_5_155_chunk
+         Index Cond: ("time" < 'Wed Jan 12 00:00:00 2000'::timestamp without time zone)
+         Filter: (time_bucket('@ 7 days'::interval, "time") < 'Wed Jan 05 00:00:00 2000'::timestamp without time zone)
+   ->  Index Only Scan Backward using _hyper_5_156_chunk_metrics_timestamp_time_idx on _hyper_5_156_chunk
+         Index Cond: ("time" < 'Wed Jan 12 00:00:00 2000'::timestamp without time zone)
+         Filter: (time_bucket('@ 7 days'::interval, "time") < 'Wed Jan 05 00:00:00 2000'::timestamp without time zone)
+(8 rows)
+
+:PREFIX SELECT * FROM metrics_timestamp WHERE time_bucket('7d',time) <= '2000-01-05' ORDER BY time;
+                                                       QUERY PLAN                                                       
+------------------------------------------------------------------------------------------------------------------------
+ Custom Scan (ChunkAppend) on metrics_timestamp
+   Order: metrics_timestamp."time"
+   ->  Index Only Scan Backward using _hyper_5_155_chunk_metrics_timestamp_time_idx on _hyper_5_155_chunk
+         Index Cond: ("time" <= 'Wed Jan 12 00:00:00 2000'::timestamp without time zone)
+         Filter: (time_bucket('@ 7 days'::interval, "time") <= 'Wed Jan 05 00:00:00 2000'::timestamp without time zone)
+   ->  Index Only Scan Backward using _hyper_5_156_chunk_metrics_timestamp_time_idx on _hyper_5_156_chunk
+         Index Cond: ("time" <= 'Wed Jan 12 00:00:00 2000'::timestamp without time zone)
+         Filter: (time_bucket('@ 7 days'::interval, "time") <= 'Wed Jan 05 00:00:00 2000'::timestamp without time zone)
+(8 rows)
+
+:PREFIX SELECT * FROM metrics_timestamp WHERE time_bucket('7d',time) > '2000-01-25' ORDER BY time;
+                                                      QUERY PLAN                                                       
+-----------------------------------------------------------------------------------------------------------------------
+ Custom Scan (ChunkAppend) on metrics_timestamp
+   Order: metrics_timestamp."time"
+   ->  Index Only Scan Backward using _hyper_5_158_chunk_metrics_timestamp_time_idx on _hyper_5_158_chunk
+         Index Cond: ("time" > 'Tue Jan 25 00:00:00 2000'::timestamp without time zone)
+         Filter: (time_bucket('@ 7 days'::interval, "time") > 'Tue Jan 25 00:00:00 2000'::timestamp without time zone)
+   ->  Index Only Scan Backward using _hyper_5_159_chunk_metrics_timestamp_time_idx on _hyper_5_159_chunk
+         Index Cond: ("time" > 'Tue Jan 25 00:00:00 2000'::timestamp without time zone)
+         Filter: (time_bucket('@ 7 days'::interval, "time") > 'Tue Jan 25 00:00:00 2000'::timestamp without time zone)
+(8 rows)
+
+:PREFIX SELECT * FROM metrics_timestamp WHERE time_bucket('7d',time) >= '2000-01-15' ORDER BY time;
+                                                       QUERY PLAN                                                       
+------------------------------------------------------------------------------------------------------------------------
+ Custom Scan (ChunkAppend) on metrics_timestamp
+   Order: metrics_timestamp."time"
+   ->  Index Only Scan Backward using _hyper_5_157_chunk_metrics_timestamp_time_idx on _hyper_5_157_chunk
+         Index Cond: ("time" >= 'Sat Jan 15 00:00:00 2000'::timestamp without time zone)
+         Filter: (time_bucket('@ 7 days'::interval, "time") >= 'Sat Jan 15 00:00:00 2000'::timestamp without time zone)
+   ->  Index Only Scan Backward using _hyper_5_158_chunk_metrics_timestamp_time_idx on _hyper_5_158_chunk
+         Index Cond: ("time" >= 'Sat Jan 15 00:00:00 2000'::timestamp without time zone)
+         Filter: (time_bucket('@ 7 days'::interval, "time") >= 'Sat Jan 15 00:00:00 2000'::timestamp without time zone)
+   ->  Index Only Scan Backward using _hyper_5_159_chunk_metrics_timestamp_time_idx on _hyper_5_159_chunk
+         Index Cond: ("time" >= 'Sat Jan 15 00:00:00 2000'::timestamp without time zone)
+         Filter: (time_bucket('@ 7 days'::interval, "time") >= 'Sat Jan 15 00:00:00 2000'::timestamp without time zone)
+(11 rows)
+
+:PREFIX SELECT * FROM metrics_timestamp WHERE time_bucket('7d',time,'3d'::interval) < '2000-01-05' ORDER BY time;
+                                                                 QUERY PLAN                                                                  
+---------------------------------------------------------------------------------------------------------------------------------------------
+ Custom Scan (ChunkAppend) on metrics_timestamp
+   Order: metrics_timestamp."time"
+   ->  Index Only Scan Backward using _hyper_5_155_chunk_metrics_timestamp_time_idx on _hyper_5_155_chunk
+         Index Cond: ("time" < 'Wed Jan 12 00:00:00 2000'::timestamp without time zone)
+         Filter: (time_bucket('@ 7 days'::interval, "time", '@ 3 days'::interval) < 'Wed Jan 05 00:00:00 2000'::timestamp without time zone)
+   ->  Index Only Scan Backward using _hyper_5_156_chunk_metrics_timestamp_time_idx on _hyper_5_156_chunk
+         Index Cond: ("time" < 'Wed Jan 12 00:00:00 2000'::timestamp without time zone)
+         Filter: (time_bucket('@ 7 days'::interval, "time", '@ 3 days'::interval) < 'Wed Jan 05 00:00:00 2000'::timestamp without time zone)
+(8 rows)
+
+:PREFIX SELECT * FROM metrics_timestamp WHERE time_bucket('7d',time,'3d'::interval) <= '2000-01-05' ORDER BY time;
+                                                                  QUERY PLAN                                                                  
+----------------------------------------------------------------------------------------------------------------------------------------------
+ Custom Scan (ChunkAppend) on metrics_timestamp
+   Order: metrics_timestamp."time"
+   ->  Index Only Scan Backward using _hyper_5_155_chunk_metrics_timestamp_time_idx on _hyper_5_155_chunk
+         Index Cond: ("time" <= 'Wed Jan 12 00:00:00 2000'::timestamp without time zone)
+         Filter: (time_bucket('@ 7 days'::interval, "time", '@ 3 days'::interval) <= 'Wed Jan 05 00:00:00 2000'::timestamp without time zone)
+   ->  Index Only Scan Backward using _hyper_5_156_chunk_metrics_timestamp_time_idx on _hyper_5_156_chunk
+         Index Cond: ("time" <= 'Wed Jan 12 00:00:00 2000'::timestamp without time zone)
+         Filter: (time_bucket('@ 7 days'::interval, "time", '@ 3 days'::interval) <= 'Wed Jan 05 00:00:00 2000'::timestamp without time zone)
+(8 rows)
+
+:PREFIX SELECT * FROM metrics_timestamp WHERE time_bucket('7d',time,'3d'::interval) > '2000-01-25' ORDER BY time;
+                                                                 QUERY PLAN                                                                  
+---------------------------------------------------------------------------------------------------------------------------------------------
+ Custom Scan (ChunkAppend) on metrics_timestamp
+   Order: metrics_timestamp."time"
+   ->  Index Only Scan Backward using _hyper_5_158_chunk_metrics_timestamp_time_idx on _hyper_5_158_chunk
+         Index Cond: ("time" > 'Tue Jan 25 00:00:00 2000'::timestamp without time zone)
+         Filter: (time_bucket('@ 7 days'::interval, "time", '@ 3 days'::interval) > 'Tue Jan 25 00:00:00 2000'::timestamp without time zone)
+   ->  Index Only Scan Backward using _hyper_5_159_chunk_metrics_timestamp_time_idx on _hyper_5_159_chunk
+         Index Cond: ("time" > 'Tue Jan 25 00:00:00 2000'::timestamp without time zone)
+         Filter: (time_bucket('@ 7 days'::interval, "time", '@ 3 days'::interval) > 'Tue Jan 25 00:00:00 2000'::timestamp without time zone)
+(8 rows)
+
+:PREFIX SELECT * FROM metrics_timestamp WHERE time_bucket('7d',time,'3d'::interval) >= '2000-01-25' ORDER BY time;
+                                                                  QUERY PLAN                                                                  
+----------------------------------------------------------------------------------------------------------------------------------------------
+ Custom Scan (ChunkAppend) on metrics_timestamp
+   Order: metrics_timestamp."time"
+   ->  Index Only Scan Backward using _hyper_5_158_chunk_metrics_timestamp_time_idx on _hyper_5_158_chunk
+         Index Cond: ("time" >= 'Tue Jan 25 00:00:00 2000'::timestamp without time zone)
+         Filter: (time_bucket('@ 7 days'::interval, "time", '@ 3 days'::interval) >= 'Tue Jan 25 00:00:00 2000'::timestamp without time zone)
+   ->  Index Only Scan Backward using _hyper_5_159_chunk_metrics_timestamp_time_idx on _hyper_5_159_chunk
+         Index Cond: ("time" >= 'Tue Jan 25 00:00:00 2000'::timestamp without time zone)
+         Filter: (time_bucket('@ 7 days'::interval, "time", '@ 3 days'::interval) >= 'Tue Jan 25 00:00:00 2000'::timestamp without time zone)
+(8 rows)
+
+:PREFIX SELECT * FROM metrics_timestamp WHERE time_bucket('7d',time,'2000-01-10'::timestamp) < '2000-01-05' ORDER BY time;
+                                                                                   QUERY PLAN                                                                                   
+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Custom Scan (ChunkAppend) on metrics_timestamp
+   Order: metrics_timestamp."time"
+   ->  Index Only Scan Backward using _hyper_5_155_chunk_metrics_timestamp_time_idx on _hyper_5_155_chunk
+         Index Cond: ("time" < 'Wed Jan 12 00:00:00 2000'::timestamp without time zone)
+         Filter: (time_bucket('@ 7 days'::interval, "time", 'Mon Jan 10 00:00:00 2000'::timestamp without time zone) < 'Wed Jan 05 00:00:00 2000'::timestamp without time zone)
+   ->  Index Only Scan Backward using _hyper_5_156_chunk_metrics_timestamp_time_idx on _hyper_5_156_chunk
+         Index Cond: ("time" < 'Wed Jan 12 00:00:00 2000'::timestamp without time zone)
+         Filter: (time_bucket('@ 7 days'::interval, "time", 'Mon Jan 10 00:00:00 2000'::timestamp without time zone) < 'Wed Jan 05 00:00:00 2000'::timestamp without time zone)
+(8 rows)
+
+:PREFIX SELECT * FROM metrics_timestamp WHERE time_bucket('7d',time,'2000-01-10'::timestamp) <= '2000-01-05' ORDER BY time;
+                                                                                   QUERY PLAN                                                                                    
+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Custom Scan (ChunkAppend) on metrics_timestamp
+   Order: metrics_timestamp."time"
+   ->  Index Only Scan Backward using _hyper_5_155_chunk_metrics_timestamp_time_idx on _hyper_5_155_chunk
+         Index Cond: ("time" <= 'Wed Jan 12 00:00:00 2000'::timestamp without time zone)
+         Filter: (time_bucket('@ 7 days'::interval, "time", 'Mon Jan 10 00:00:00 2000'::timestamp without time zone) <= 'Wed Jan 05 00:00:00 2000'::timestamp without time zone)
+   ->  Index Only Scan Backward using _hyper_5_156_chunk_metrics_timestamp_time_idx on _hyper_5_156_chunk
+         Index Cond: ("time" <= 'Wed Jan 12 00:00:00 2000'::timestamp without time zone)
+         Filter: (time_bucket('@ 7 days'::interval, "time", 'Mon Jan 10 00:00:00 2000'::timestamp without time zone) <= 'Wed Jan 05 00:00:00 2000'::timestamp without time zone)
+(8 rows)
+
+:PREFIX SELECT * FROM metrics_timestamp WHERE time_bucket('7d',time,'2000-01-10'::timestamp) > '2000-01-25' ORDER BY time;
+                                                                                   QUERY PLAN                                                                                   
+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Custom Scan (ChunkAppend) on metrics_timestamp
+   Order: metrics_timestamp."time"
+   ->  Index Only Scan Backward using _hyper_5_158_chunk_metrics_timestamp_time_idx on _hyper_5_158_chunk
+         Index Cond: ("time" > 'Tue Jan 25 00:00:00 2000'::timestamp without time zone)
+         Filter: (time_bucket('@ 7 days'::interval, "time", 'Mon Jan 10 00:00:00 2000'::timestamp without time zone) > 'Tue Jan 25 00:00:00 2000'::timestamp without time zone)
+   ->  Index Only Scan Backward using _hyper_5_159_chunk_metrics_timestamp_time_idx on _hyper_5_159_chunk
+         Index Cond: ("time" > 'Tue Jan 25 00:00:00 2000'::timestamp without time zone)
+         Filter: (time_bucket('@ 7 days'::interval, "time", 'Mon Jan 10 00:00:00 2000'::timestamp without time zone) > 'Tue Jan 25 00:00:00 2000'::timestamp without time zone)
+(8 rows)
+
+:PREFIX SELECT * FROM metrics_timestamp WHERE time_bucket('7d',time,'2000-01-10'::timestamp) >= '2000-01-25' ORDER BY time;
+                                                                                   QUERY PLAN                                                                                    
+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Custom Scan (ChunkAppend) on metrics_timestamp
+   Order: metrics_timestamp."time"
+   ->  Index Only Scan Backward using _hyper_5_158_chunk_metrics_timestamp_time_idx on _hyper_5_158_chunk
+         Index Cond: ("time" >= 'Tue Jan 25 00:00:00 2000'::timestamp without time zone)
+         Filter: (time_bucket('@ 7 days'::interval, "time", 'Mon Jan 10 00:00:00 2000'::timestamp without time zone) >= 'Tue Jan 25 00:00:00 2000'::timestamp without time zone)
+   ->  Index Only Scan Backward using _hyper_5_159_chunk_metrics_timestamp_time_idx on _hyper_5_159_chunk
+         Index Cond: ("time" >= 'Tue Jan 25 00:00:00 2000'::timestamp without time zone)
+         Filter: (time_bucket('@ 7 days'::interval, "time", 'Mon Jan 10 00:00:00 2000'::timestamp without time zone) >= 'Tue Jan 25 00:00:00 2000'::timestamp without time zone)
+(8 rows)
+
+\qecho timestamptz time_bucket exclusion
+timestamptz time_bucket exclusion
+SELECT count(DISTINCT tableoid) FROM metrics_timestamptz;
+ count 
+-------
+     5
+(1 row)
+
+:PREFIX SELECT * FROM metrics_timestamptz WHERE time_bucket('7d',time) < '2000-01-05' ORDER BY time;
+                                                       QUERY PLAN                                                       
+------------------------------------------------------------------------------------------------------------------------
+ Custom Scan (ChunkAppend) on metrics_timestamptz
+   Order: metrics_timestamptz."time"
+   ->  Index Scan Backward using _hyper_6_160_chunk_metrics_timestamptz_time_idx on _hyper_6_160_chunk
+         Index Cond: ("time" < 'Wed Jan 12 00:00:00 2000 PST'::timestamp with time zone)
+         Filter: (time_bucket('@ 7 days'::interval, "time") < 'Wed Jan 05 00:00:00 2000 PST'::timestamp with time zone)
+   ->  Index Scan Backward using _hyper_6_161_chunk_metrics_timestamptz_time_idx on _hyper_6_161_chunk
+         Index Cond: ("time" < 'Wed Jan 12 00:00:00 2000 PST'::timestamp with time zone)
+         Filter: (time_bucket('@ 7 days'::interval, "time") < 'Wed Jan 05 00:00:00 2000 PST'::timestamp with time zone)
+(8 rows)
+
+:PREFIX SELECT * FROM metrics_timestamptz WHERE time_bucket('7d',time) <= '2000-01-05' ORDER BY time;
+                                                       QUERY PLAN                                                        
+-------------------------------------------------------------------------------------------------------------------------
+ Custom Scan (ChunkAppend) on metrics_timestamptz
+   Order: metrics_timestamptz."time"
+   ->  Index Scan Backward using _hyper_6_160_chunk_metrics_timestamptz_time_idx on _hyper_6_160_chunk
+         Index Cond: ("time" <= 'Wed Jan 12 00:00:00 2000 PST'::timestamp with time zone)
+         Filter: (time_bucket('@ 7 days'::interval, "time") <= 'Wed Jan 05 00:00:00 2000 PST'::timestamp with time zone)
+   ->  Index Scan Backward using _hyper_6_161_chunk_metrics_timestamptz_time_idx on _hyper_6_161_chunk
+         Index Cond: ("time" <= 'Wed Jan 12 00:00:00 2000 PST'::timestamp with time zone)
+         Filter: (time_bucket('@ 7 days'::interval, "time") <= 'Wed Jan 05 00:00:00 2000 PST'::timestamp with time zone)
+(8 rows)
+
+:PREFIX SELECT * FROM metrics_timestamptz WHERE time_bucket('7d',time) > '2000-01-25' ORDER BY time;
+                                                       QUERY PLAN                                                       
+------------------------------------------------------------------------------------------------------------------------
+ Custom Scan (ChunkAppend) on metrics_timestamptz
+   Order: metrics_timestamptz."time"
+   ->  Index Scan Backward using _hyper_6_163_chunk_metrics_timestamptz_time_idx on _hyper_6_163_chunk
+         Index Cond: ("time" > 'Tue Jan 25 00:00:00 2000 PST'::timestamp with time zone)
+         Filter: (time_bucket('@ 7 days'::interval, "time") > 'Tue Jan 25 00:00:00 2000 PST'::timestamp with time zone)
+   ->  Index Scan Backward using _hyper_6_164_chunk_metrics_timestamptz_time_idx on _hyper_6_164_chunk
+         Index Cond: ("time" > 'Tue Jan 25 00:00:00 2000 PST'::timestamp with time zone)
+         Filter: (time_bucket('@ 7 days'::interval, "time") > 'Tue Jan 25 00:00:00 2000 PST'::timestamp with time zone)
+(8 rows)
+
+:PREFIX SELECT * FROM metrics_timestamptz WHERE time_bucket('7d',time) >= '2000-01-25' ORDER BY time;
+                                                       QUERY PLAN                                                        
+-------------------------------------------------------------------------------------------------------------------------
+ Custom Scan (ChunkAppend) on metrics_timestamptz
+   Order: metrics_timestamptz."time"
+   ->  Index Scan Backward using _hyper_6_163_chunk_metrics_timestamptz_time_idx on _hyper_6_163_chunk
+         Index Cond: ("time" >= 'Tue Jan 25 00:00:00 2000 PST'::timestamp with time zone)
+         Filter: (time_bucket('@ 7 days'::interval, "time") >= 'Tue Jan 25 00:00:00 2000 PST'::timestamp with time zone)
+   ->  Index Scan Backward using _hyper_6_164_chunk_metrics_timestamptz_time_idx on _hyper_6_164_chunk
+         Index Cond: ("time" >= 'Tue Jan 25 00:00:00 2000 PST'::timestamp with time zone)
+         Filter: (time_bucket('@ 7 days'::interval, "time") >= 'Tue Jan 25 00:00:00 2000 PST'::timestamp with time zone)
+(8 rows)
+
+:PREFIX SELECT * FROM metrics_timestamptz WHERE time_bucket('7d',time,'3d'::interval) < '2000-01-05' ORDER BY time;
+                                                                  QUERY PLAN                                                                  
+----------------------------------------------------------------------------------------------------------------------------------------------
+ Custom Scan (ChunkAppend) on metrics_timestamptz
+   Order: metrics_timestamptz."time"
+   ->  Index Scan Backward using _hyper_6_160_chunk_metrics_timestamptz_time_idx on _hyper_6_160_chunk
+         Index Cond: ("time" < 'Wed Jan 12 00:00:00 2000 PST'::timestamp with time zone)
+         Filter: (time_bucket('@ 7 days'::interval, "time", '@ 3 days'::interval) < 'Wed Jan 05 00:00:00 2000 PST'::timestamp with time zone)
+   ->  Index Scan Backward using _hyper_6_161_chunk_metrics_timestamptz_time_idx on _hyper_6_161_chunk
+         Index Cond: ("time" < 'Wed Jan 12 00:00:00 2000 PST'::timestamp with time zone)
+         Filter: (time_bucket('@ 7 days'::interval, "time", '@ 3 days'::interval) < 'Wed Jan 05 00:00:00 2000 PST'::timestamp with time zone)
+(8 rows)
+
+:PREFIX SELECT * FROM metrics_timestamptz WHERE time_bucket('7d',time,'3d'::interval) <= '2000-01-05' ORDER BY time;
+                                                                  QUERY PLAN                                                                   
+-----------------------------------------------------------------------------------------------------------------------------------------------
+ Custom Scan (ChunkAppend) on metrics_timestamptz
+   Order: metrics_timestamptz."time"
+   ->  Index Scan Backward using _hyper_6_160_chunk_metrics_timestamptz_time_idx on _hyper_6_160_chunk
+         Index Cond: ("time" <= 'Wed Jan 12 00:00:00 2000 PST'::timestamp with time zone)
+         Filter: (time_bucket('@ 7 days'::interval, "time", '@ 3 days'::interval) <= 'Wed Jan 05 00:00:00 2000 PST'::timestamp with time zone)
+   ->  Index Scan Backward using _hyper_6_161_chunk_metrics_timestamptz_time_idx on _hyper_6_161_chunk
+         Index Cond: ("time" <= 'Wed Jan 12 00:00:00 2000 PST'::timestamp with time zone)
+         Filter: (time_bucket('@ 7 days'::interval, "time", '@ 3 days'::interval) <= 'Wed Jan 05 00:00:00 2000 PST'::timestamp with time zone)
+(8 rows)
+
+:PREFIX SELECT * FROM metrics_timestamptz WHERE time_bucket('7d',time,'3d'::interval) > '2000-01-25' ORDER BY time;
+                                                                  QUERY PLAN                                                                  
+----------------------------------------------------------------------------------------------------------------------------------------------
+ Custom Scan (ChunkAppend) on metrics_timestamptz
+   Order: metrics_timestamptz."time"
+   ->  Index Scan Backward using _hyper_6_163_chunk_metrics_timestamptz_time_idx on _hyper_6_163_chunk
+         Index Cond: ("time" > 'Tue Jan 25 00:00:00 2000 PST'::timestamp with time zone)
+         Filter: (time_bucket('@ 7 days'::interval, "time", '@ 3 days'::interval) > 'Tue Jan 25 00:00:00 2000 PST'::timestamp with time zone)
+   ->  Index Scan Backward using _hyper_6_164_chunk_metrics_timestamptz_time_idx on _hyper_6_164_chunk
+         Index Cond: ("time" > 'Tue Jan 25 00:00:00 2000 PST'::timestamp with time zone)
+         Filter: (time_bucket('@ 7 days'::interval, "time", '@ 3 days'::interval) > 'Tue Jan 25 00:00:00 2000 PST'::timestamp with time zone)
+(8 rows)
+
+:PREFIX SELECT * FROM metrics_timestamptz WHERE time_bucket('7d',time,'3d'::interval) >= '2000-01-25' ORDER BY time;
+                                                                  QUERY PLAN                                                                   
+-----------------------------------------------------------------------------------------------------------------------------------------------
+ Custom Scan (ChunkAppend) on metrics_timestamptz
+   Order: metrics_timestamptz."time"
+   ->  Index Scan Backward using _hyper_6_163_chunk_metrics_timestamptz_time_idx on _hyper_6_163_chunk
+         Index Cond: ("time" >= 'Tue Jan 25 00:00:00 2000 PST'::timestamp with time zone)
+         Filter: (time_bucket('@ 7 days'::interval, "time", '@ 3 days'::interval) >= 'Tue Jan 25 00:00:00 2000 PST'::timestamp with time zone)
+   ->  Index Scan Backward using _hyper_6_164_chunk_metrics_timestamptz_time_idx on _hyper_6_164_chunk
+         Index Cond: ("time" >= 'Tue Jan 25 00:00:00 2000 PST'::timestamp with time zone)
+         Filter: (time_bucket('@ 7 days'::interval, "time", '@ 3 days'::interval) >= 'Tue Jan 25 00:00:00 2000 PST'::timestamp with time zone)
+(8 rows)
+
+:PREFIX SELECT * FROM metrics_timestamptz WHERE time_bucket('7d',time,'2000-01-10'::timestamptz) < '2000-01-05' ORDER BY time;
+                                                                                    QUERY PLAN                                                                                    
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Custom Scan (ChunkAppend) on metrics_timestamptz
+   Order: metrics_timestamptz."time"
+   ->  Index Scan Backward using _hyper_6_160_chunk_metrics_timestamptz_time_idx on _hyper_6_160_chunk
+         Index Cond: ("time" < 'Wed Jan 12 00:00:00 2000 PST'::timestamp with time zone)
+         Filter: (time_bucket('@ 7 days'::interval, "time", 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone) < 'Wed Jan 05 00:00:00 2000 PST'::timestamp with time zone)
+   ->  Index Scan Backward using _hyper_6_161_chunk_metrics_timestamptz_time_idx on _hyper_6_161_chunk
+         Index Cond: ("time" < 'Wed Jan 12 00:00:00 2000 PST'::timestamp with time zone)
+         Filter: (time_bucket('@ 7 days'::interval, "time", 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone) < 'Wed Jan 05 00:00:00 2000 PST'::timestamp with time zone)
+(8 rows)
+
+:PREFIX SELECT * FROM metrics_timestamptz WHERE time_bucket('7d',time,'2000-01-10'::timestamptz) <= '2000-01-05' ORDER BY time;
+                                                                                    QUERY PLAN                                                                                     
+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Custom Scan (ChunkAppend) on metrics_timestamptz
+   Order: metrics_timestamptz."time"
+   ->  Index Scan Backward using _hyper_6_160_chunk_metrics_timestamptz_time_idx on _hyper_6_160_chunk
+         Index Cond: ("time" <= 'Wed Jan 12 00:00:00 2000 PST'::timestamp with time zone)
+         Filter: (time_bucket('@ 7 days'::interval, "time", 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone) <= 'Wed Jan 05 00:00:00 2000 PST'::timestamp with time zone)
+   ->  Index Scan Backward using _hyper_6_161_chunk_metrics_timestamptz_time_idx on _hyper_6_161_chunk
+         Index Cond: ("time" <= 'Wed Jan 12 00:00:00 2000 PST'::timestamp with time zone)
+         Filter: (time_bucket('@ 7 days'::interval, "time", 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone) <= 'Wed Jan 05 00:00:00 2000 PST'::timestamp with time zone)
+(8 rows)
+
+:PREFIX SELECT * FROM metrics_timestamptz WHERE time_bucket('7d',time,'2000-01-10'::timestamptz) > '2000-01-25' ORDER BY time;
+                                                                                    QUERY PLAN                                                                                    
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Custom Scan (ChunkAppend) on metrics_timestamptz
+   Order: metrics_timestamptz."time"
+   ->  Index Scan Backward using _hyper_6_163_chunk_metrics_timestamptz_time_idx on _hyper_6_163_chunk
+         Index Cond: ("time" > 'Tue Jan 25 00:00:00 2000 PST'::timestamp with time zone)
+         Filter: (time_bucket('@ 7 days'::interval, "time", 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone) > 'Tue Jan 25 00:00:00 2000 PST'::timestamp with time zone)
+   ->  Index Scan Backward using _hyper_6_164_chunk_metrics_timestamptz_time_idx on _hyper_6_164_chunk
+         Index Cond: ("time" > 'Tue Jan 25 00:00:00 2000 PST'::timestamp with time zone)
+         Filter: (time_bucket('@ 7 days'::interval, "time", 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone) > 'Tue Jan 25 00:00:00 2000 PST'::timestamp with time zone)
+(8 rows)
+
+:PREFIX SELECT * FROM metrics_timestamptz WHERE time_bucket('7d',time,'2000-01-10'::timestamptz) >= '2000-01-25' ORDER BY time;
+                                                                                    QUERY PLAN                                                                                     
+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Custom Scan (ChunkAppend) on metrics_timestamptz
+   Order: metrics_timestamptz."time"
+   ->  Index Scan Backward using _hyper_6_163_chunk_metrics_timestamptz_time_idx on _hyper_6_163_chunk
+         Index Cond: ("time" >= 'Tue Jan 25 00:00:00 2000 PST'::timestamp with time zone)
+         Filter: (time_bucket('@ 7 days'::interval, "time", 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone) >= 'Tue Jan 25 00:00:00 2000 PST'::timestamp with time zone)
+   ->  Index Scan Backward using _hyper_6_164_chunk_metrics_timestamptz_time_idx on _hyper_6_164_chunk
+         Index Cond: ("time" >= 'Tue Jan 25 00:00:00 2000 PST'::timestamp with time zone)
+         Filter: (time_bucket('@ 7 days'::interval, "time", 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone) >= 'Tue Jan 25 00:00:00 2000 PST'::timestamp with time zone)
+(8 rows)
+
+:PREFIX SELECT * FROM metrics_timestamptz WHERE time_bucket('7d',time,'Europe/Berlin') < '2000-01-05' ORDER BY time;
+                                                                                          QUERY PLAN                                                                                           
+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Custom Scan (ChunkAppend) on metrics_timestamptz
+   Order: metrics_timestamptz."time"
+   ->  Index Scan Backward using _hyper_6_160_chunk_metrics_timestamptz_time_idx on _hyper_6_160_chunk
+         Index Cond: ("time" < 'Wed Jan 12 00:00:00 2000 PST'::timestamp with time zone)
+         Filter: (time_bucket('@ 7 days'::interval, "time", 'Europe/Berlin'::text, NULL::timestamp with time zone, NULL::interval) < 'Wed Jan 05 00:00:00 2000 PST'::timestamp with time zone)
+   ->  Index Scan Backward using _hyper_6_161_chunk_metrics_timestamptz_time_idx on _hyper_6_161_chunk
+         Index Cond: ("time" < 'Wed Jan 12 00:00:00 2000 PST'::timestamp with time zone)
+         Filter: (time_bucket('@ 7 days'::interval, "time", 'Europe/Berlin'::text, NULL::timestamp with time zone, NULL::interval) < 'Wed Jan 05 00:00:00 2000 PST'::timestamp with time zone)
+(8 rows)
+
+:PREFIX SELECT * FROM metrics_timestamptz WHERE time_bucket('7d',time,'Europe/Berlin') <= '2000-01-05' ORDER BY time;
+                                                                                           QUERY PLAN                                                                                           
+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Custom Scan (ChunkAppend) on metrics_timestamptz
+   Order: metrics_timestamptz."time"
+   ->  Index Scan Backward using _hyper_6_160_chunk_metrics_timestamptz_time_idx on _hyper_6_160_chunk
+         Index Cond: ("time" <= 'Wed Jan 12 00:00:00 2000 PST'::timestamp with time zone)
+         Filter: (time_bucket('@ 7 days'::interval, "time", 'Europe/Berlin'::text, NULL::timestamp with time zone, NULL::interval) <= 'Wed Jan 05 00:00:00 2000 PST'::timestamp with time zone)
+   ->  Index Scan Backward using _hyper_6_161_chunk_metrics_timestamptz_time_idx on _hyper_6_161_chunk
+         Index Cond: ("time" <= 'Wed Jan 12 00:00:00 2000 PST'::timestamp with time zone)
+         Filter: (time_bucket('@ 7 days'::interval, "time", 'Europe/Berlin'::text, NULL::timestamp with time zone, NULL::interval) <= 'Wed Jan 05 00:00:00 2000 PST'::timestamp with time zone)
+(8 rows)
+
+:PREFIX SELECT * FROM metrics_timestamptz WHERE time_bucket('7d',time,'Europe/Berlin') > '2000-01-25' ORDER BY time;
+                                                                                          QUERY PLAN                                                                                           
+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Custom Scan (ChunkAppend) on metrics_timestamptz
+   Order: metrics_timestamptz."time"
+   ->  Index Scan Backward using _hyper_6_163_chunk_metrics_timestamptz_time_idx on _hyper_6_163_chunk
+         Index Cond: ("time" > 'Tue Jan 25 00:00:00 2000 PST'::timestamp with time zone)
+         Filter: (time_bucket('@ 7 days'::interval, "time", 'Europe/Berlin'::text, NULL::timestamp with time zone, NULL::interval) > 'Tue Jan 25 00:00:00 2000 PST'::timestamp with time zone)
+   ->  Index Scan Backward using _hyper_6_164_chunk_metrics_timestamptz_time_idx on _hyper_6_164_chunk
+         Index Cond: ("time" > 'Tue Jan 25 00:00:00 2000 PST'::timestamp with time zone)
+         Filter: (time_bucket('@ 7 days'::interval, "time", 'Europe/Berlin'::text, NULL::timestamp with time zone, NULL::interval) > 'Tue Jan 25 00:00:00 2000 PST'::timestamp with time zone)
+(8 rows)
+
+:PREFIX SELECT * FROM metrics_timestamptz WHERE time_bucket('7d',time,'Europe/Berlin') >= '2000-01-25' ORDER BY time;
+                                                                                           QUERY PLAN                                                                                           
+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Custom Scan (ChunkAppend) on metrics_timestamptz
+   Order: metrics_timestamptz."time"
+   ->  Index Scan Backward using _hyper_6_163_chunk_metrics_timestamptz_time_idx on _hyper_6_163_chunk
+         Index Cond: ("time" >= 'Tue Jan 25 00:00:00 2000 PST'::timestamp with time zone)
+         Filter: (time_bucket('@ 7 days'::interval, "time", 'Europe/Berlin'::text, NULL::timestamp with time zone, NULL::interval) >= 'Tue Jan 25 00:00:00 2000 PST'::timestamp with time zone)
+   ->  Index Scan Backward using _hyper_6_164_chunk_metrics_timestamptz_time_idx on _hyper_6_164_chunk
+         Index Cond: ("time" >= 'Tue Jan 25 00:00:00 2000 PST'::timestamp with time zone)
+         Filter: (time_bucket('@ 7 days'::interval, "time", 'Europe/Berlin'::text, NULL::timestamp with time zone, NULL::interval) >= 'Tue Jan 25 00:00:00 2000 PST'::timestamp with time zone)
+(8 rows)
+
 \qecho test overflow behaviour of time_bucket exclusion
 test overflow behaviour of time_bucket exclusion
 :PREFIX SELECT * FROM hyper WHERE time > 950 AND time_bucket(10, time) < '9223372036854775807'::bigint ORDER BY time;

--- a/test/expected/plan_expand_hypertable-14.out
+++ b/test/expected/plan_expand_hypertable-14.out
@@ -1113,6 +1113,455 @@ time_bucket exclusion
                Filter: (("time" < '21'::bigint) AND ('11'::bigint > time_bucket('10'::bigint, "time")))
 (9 rows)
 
+:PREFIX SELECT * FROM hyper WHERE time_bucket(10, time, 5) < 10::bigint ORDER BY time;
+                                                     QUERY PLAN                                                      
+---------------------------------------------------------------------------------------------------------------------
+ Sort
+   Sort Key: _hyper_1_1_chunk."time"
+   ->  Append
+         ->  Seq Scan on _hyper_1_1_chunk
+               Filter: (("time" < '20'::bigint) AND (time_bucket('10'::bigint, "time", '5'::bigint) < '10'::bigint))
+         ->  Seq Scan on _hyper_1_2_chunk
+               Filter: (("time" < '20'::bigint) AND (time_bucket('10'::bigint, "time", '5'::bigint) < '10'::bigint))
+(7 rows)
+
+:PREFIX SELECT * FROM hyper WHERE time_bucket(10, time, 5) < 11::bigint ORDER BY time;
+                                                     QUERY PLAN                                                      
+---------------------------------------------------------------------------------------------------------------------
+ Sort
+   Sort Key: _hyper_1_1_chunk."time"
+   ->  Append
+         ->  Seq Scan on _hyper_1_1_chunk
+               Filter: (("time" < '21'::bigint) AND (time_bucket('10'::bigint, "time", '5'::bigint) < '11'::bigint))
+         ->  Seq Scan on _hyper_1_2_chunk
+               Filter: (("time" < '21'::bigint) AND (time_bucket('10'::bigint, "time", '5'::bigint) < '11'::bigint))
+         ->  Seq Scan on _hyper_1_3_chunk
+               Filter: (("time" < '21'::bigint) AND (time_bucket('10'::bigint, "time", '5'::bigint) < '11'::bigint))
+(9 rows)
+
+:PREFIX SELECT * FROM hyper WHERE time_bucket(10, time, 5) <= 10::bigint ORDER BY time;
+                                                      QUERY PLAN                                                       
+-----------------------------------------------------------------------------------------------------------------------
+ Sort
+   Sort Key: _hyper_1_1_chunk."time"
+   ->  Append
+         ->  Seq Scan on _hyper_1_1_chunk
+               Filter: (("time" <= '20'::bigint) AND (time_bucket('10'::bigint, "time", '5'::bigint) <= '10'::bigint))
+         ->  Seq Scan on _hyper_1_2_chunk
+               Filter: (("time" <= '20'::bigint) AND (time_bucket('10'::bigint, "time", '5'::bigint) <= '10'::bigint))
+         ->  Seq Scan on _hyper_1_3_chunk
+               Filter: (("time" <= '20'::bigint) AND (time_bucket('10'::bigint, "time", '5'::bigint) <= '10'::bigint))
+(9 rows)
+
+:PREFIX SELECT * FROM hyper WHERE 10::bigint > time_bucket(10, time, 5) ORDER BY time;
+                                                     QUERY PLAN                                                      
+---------------------------------------------------------------------------------------------------------------------
+ Sort
+   Sort Key: _hyper_1_1_chunk."time"
+   ->  Append
+         ->  Seq Scan on _hyper_1_1_chunk
+               Filter: (("time" < '20'::bigint) AND ('10'::bigint > time_bucket('10'::bigint, "time", '5'::bigint)))
+         ->  Seq Scan on _hyper_1_2_chunk
+               Filter: (("time" < '20'::bigint) AND ('10'::bigint > time_bucket('10'::bigint, "time", '5'::bigint)))
+(7 rows)
+
+:PREFIX SELECT * FROM hyper WHERE 11::bigint > time_bucket(10, time, 5) ORDER BY time;
+                                                     QUERY PLAN                                                      
+---------------------------------------------------------------------------------------------------------------------
+ Sort
+   Sort Key: _hyper_1_1_chunk."time"
+   ->  Append
+         ->  Seq Scan on _hyper_1_1_chunk
+               Filter: (("time" < '21'::bigint) AND ('11'::bigint > time_bucket('10'::bigint, "time", '5'::bigint)))
+         ->  Seq Scan on _hyper_1_2_chunk
+               Filter: (("time" < '21'::bigint) AND ('11'::bigint > time_bucket('10'::bigint, "time", '5'::bigint)))
+         ->  Seq Scan on _hyper_1_3_chunk
+               Filter: (("time" < '21'::bigint) AND ('11'::bigint > time_bucket('10'::bigint, "time", '5'::bigint)))
+(9 rows)
+
+\qecho timestamp time_bucket exclusion
+timestamp time_bucket exclusion
+SELECT count(DISTINCT tableoid) FROM metrics_timestamp;
+ count 
+-------
+     5
+(1 row)
+
+:PREFIX SELECT * FROM metrics_timestamp WHERE time_bucket('7d',time) < '2000-01-05' ORDER BY time;
+                                                      QUERY PLAN                                                       
+-----------------------------------------------------------------------------------------------------------------------
+ Custom Scan (ChunkAppend) on metrics_timestamp
+   Order: metrics_timestamp."time"
+   ->  Index Only Scan Backward using _hyper_5_155_chunk_metrics_timestamp_time_idx on _hyper_5_155_chunk
+         Index Cond: ("time" < 'Wed Jan 12 00:00:00 2000'::timestamp without time zone)
+         Filter: (time_bucket('@ 7 days'::interval, "time") < 'Wed Jan 05 00:00:00 2000'::timestamp without time zone)
+   ->  Index Only Scan Backward using _hyper_5_156_chunk_metrics_timestamp_time_idx on _hyper_5_156_chunk
+         Index Cond: ("time" < 'Wed Jan 12 00:00:00 2000'::timestamp without time zone)
+         Filter: (time_bucket('@ 7 days'::interval, "time") < 'Wed Jan 05 00:00:00 2000'::timestamp without time zone)
+(8 rows)
+
+:PREFIX SELECT * FROM metrics_timestamp WHERE time_bucket('7d',time) <= '2000-01-05' ORDER BY time;
+                                                       QUERY PLAN                                                       
+------------------------------------------------------------------------------------------------------------------------
+ Custom Scan (ChunkAppend) on metrics_timestamp
+   Order: metrics_timestamp."time"
+   ->  Index Only Scan Backward using _hyper_5_155_chunk_metrics_timestamp_time_idx on _hyper_5_155_chunk
+         Index Cond: ("time" <= 'Wed Jan 12 00:00:00 2000'::timestamp without time zone)
+         Filter: (time_bucket('@ 7 days'::interval, "time") <= 'Wed Jan 05 00:00:00 2000'::timestamp without time zone)
+   ->  Index Only Scan Backward using _hyper_5_156_chunk_metrics_timestamp_time_idx on _hyper_5_156_chunk
+         Index Cond: ("time" <= 'Wed Jan 12 00:00:00 2000'::timestamp without time zone)
+         Filter: (time_bucket('@ 7 days'::interval, "time") <= 'Wed Jan 05 00:00:00 2000'::timestamp without time zone)
+(8 rows)
+
+:PREFIX SELECT * FROM metrics_timestamp WHERE time_bucket('7d',time) > '2000-01-25' ORDER BY time;
+                                                      QUERY PLAN                                                       
+-----------------------------------------------------------------------------------------------------------------------
+ Custom Scan (ChunkAppend) on metrics_timestamp
+   Order: metrics_timestamp."time"
+   ->  Index Only Scan Backward using _hyper_5_158_chunk_metrics_timestamp_time_idx on _hyper_5_158_chunk
+         Index Cond: ("time" > 'Tue Jan 25 00:00:00 2000'::timestamp without time zone)
+         Filter: (time_bucket('@ 7 days'::interval, "time") > 'Tue Jan 25 00:00:00 2000'::timestamp without time zone)
+   ->  Index Only Scan Backward using _hyper_5_159_chunk_metrics_timestamp_time_idx on _hyper_5_159_chunk
+         Index Cond: ("time" > 'Tue Jan 25 00:00:00 2000'::timestamp without time zone)
+         Filter: (time_bucket('@ 7 days'::interval, "time") > 'Tue Jan 25 00:00:00 2000'::timestamp without time zone)
+(8 rows)
+
+:PREFIX SELECT * FROM metrics_timestamp WHERE time_bucket('7d',time) >= '2000-01-15' ORDER BY time;
+                                                       QUERY PLAN                                                       
+------------------------------------------------------------------------------------------------------------------------
+ Custom Scan (ChunkAppend) on metrics_timestamp
+   Order: metrics_timestamp."time"
+   ->  Index Only Scan Backward using _hyper_5_157_chunk_metrics_timestamp_time_idx on _hyper_5_157_chunk
+         Index Cond: ("time" >= 'Sat Jan 15 00:00:00 2000'::timestamp without time zone)
+         Filter: (time_bucket('@ 7 days'::interval, "time") >= 'Sat Jan 15 00:00:00 2000'::timestamp without time zone)
+   ->  Index Only Scan Backward using _hyper_5_158_chunk_metrics_timestamp_time_idx on _hyper_5_158_chunk
+         Index Cond: ("time" >= 'Sat Jan 15 00:00:00 2000'::timestamp without time zone)
+         Filter: (time_bucket('@ 7 days'::interval, "time") >= 'Sat Jan 15 00:00:00 2000'::timestamp without time zone)
+   ->  Index Only Scan Backward using _hyper_5_159_chunk_metrics_timestamp_time_idx on _hyper_5_159_chunk
+         Index Cond: ("time" >= 'Sat Jan 15 00:00:00 2000'::timestamp without time zone)
+         Filter: (time_bucket('@ 7 days'::interval, "time") >= 'Sat Jan 15 00:00:00 2000'::timestamp without time zone)
+(11 rows)
+
+:PREFIX SELECT * FROM metrics_timestamp WHERE time_bucket('7d',time,'3d'::interval) < '2000-01-05' ORDER BY time;
+                                                                 QUERY PLAN                                                                  
+---------------------------------------------------------------------------------------------------------------------------------------------
+ Custom Scan (ChunkAppend) on metrics_timestamp
+   Order: metrics_timestamp."time"
+   ->  Index Only Scan Backward using _hyper_5_155_chunk_metrics_timestamp_time_idx on _hyper_5_155_chunk
+         Index Cond: ("time" < 'Wed Jan 12 00:00:00 2000'::timestamp without time zone)
+         Filter: (time_bucket('@ 7 days'::interval, "time", '@ 3 days'::interval) < 'Wed Jan 05 00:00:00 2000'::timestamp without time zone)
+   ->  Index Only Scan Backward using _hyper_5_156_chunk_metrics_timestamp_time_idx on _hyper_5_156_chunk
+         Index Cond: ("time" < 'Wed Jan 12 00:00:00 2000'::timestamp without time zone)
+         Filter: (time_bucket('@ 7 days'::interval, "time", '@ 3 days'::interval) < 'Wed Jan 05 00:00:00 2000'::timestamp without time zone)
+(8 rows)
+
+:PREFIX SELECT * FROM metrics_timestamp WHERE time_bucket('7d',time,'3d'::interval) <= '2000-01-05' ORDER BY time;
+                                                                  QUERY PLAN                                                                  
+----------------------------------------------------------------------------------------------------------------------------------------------
+ Custom Scan (ChunkAppend) on metrics_timestamp
+   Order: metrics_timestamp."time"
+   ->  Index Only Scan Backward using _hyper_5_155_chunk_metrics_timestamp_time_idx on _hyper_5_155_chunk
+         Index Cond: ("time" <= 'Wed Jan 12 00:00:00 2000'::timestamp without time zone)
+         Filter: (time_bucket('@ 7 days'::interval, "time", '@ 3 days'::interval) <= 'Wed Jan 05 00:00:00 2000'::timestamp without time zone)
+   ->  Index Only Scan Backward using _hyper_5_156_chunk_metrics_timestamp_time_idx on _hyper_5_156_chunk
+         Index Cond: ("time" <= 'Wed Jan 12 00:00:00 2000'::timestamp without time zone)
+         Filter: (time_bucket('@ 7 days'::interval, "time", '@ 3 days'::interval) <= 'Wed Jan 05 00:00:00 2000'::timestamp without time zone)
+(8 rows)
+
+:PREFIX SELECT * FROM metrics_timestamp WHERE time_bucket('7d',time,'3d'::interval) > '2000-01-25' ORDER BY time;
+                                                                 QUERY PLAN                                                                  
+---------------------------------------------------------------------------------------------------------------------------------------------
+ Custom Scan (ChunkAppend) on metrics_timestamp
+   Order: metrics_timestamp."time"
+   ->  Index Only Scan Backward using _hyper_5_158_chunk_metrics_timestamp_time_idx on _hyper_5_158_chunk
+         Index Cond: ("time" > 'Tue Jan 25 00:00:00 2000'::timestamp without time zone)
+         Filter: (time_bucket('@ 7 days'::interval, "time", '@ 3 days'::interval) > 'Tue Jan 25 00:00:00 2000'::timestamp without time zone)
+   ->  Index Only Scan Backward using _hyper_5_159_chunk_metrics_timestamp_time_idx on _hyper_5_159_chunk
+         Index Cond: ("time" > 'Tue Jan 25 00:00:00 2000'::timestamp without time zone)
+         Filter: (time_bucket('@ 7 days'::interval, "time", '@ 3 days'::interval) > 'Tue Jan 25 00:00:00 2000'::timestamp without time zone)
+(8 rows)
+
+:PREFIX SELECT * FROM metrics_timestamp WHERE time_bucket('7d',time,'3d'::interval) >= '2000-01-25' ORDER BY time;
+                                                                  QUERY PLAN                                                                  
+----------------------------------------------------------------------------------------------------------------------------------------------
+ Custom Scan (ChunkAppend) on metrics_timestamp
+   Order: metrics_timestamp."time"
+   ->  Index Only Scan Backward using _hyper_5_158_chunk_metrics_timestamp_time_idx on _hyper_5_158_chunk
+         Index Cond: ("time" >= 'Tue Jan 25 00:00:00 2000'::timestamp without time zone)
+         Filter: (time_bucket('@ 7 days'::interval, "time", '@ 3 days'::interval) >= 'Tue Jan 25 00:00:00 2000'::timestamp without time zone)
+   ->  Index Only Scan Backward using _hyper_5_159_chunk_metrics_timestamp_time_idx on _hyper_5_159_chunk
+         Index Cond: ("time" >= 'Tue Jan 25 00:00:00 2000'::timestamp without time zone)
+         Filter: (time_bucket('@ 7 days'::interval, "time", '@ 3 days'::interval) >= 'Tue Jan 25 00:00:00 2000'::timestamp without time zone)
+(8 rows)
+
+:PREFIX SELECT * FROM metrics_timestamp WHERE time_bucket('7d',time,'2000-01-10'::timestamp) < '2000-01-05' ORDER BY time;
+                                                                                   QUERY PLAN                                                                                   
+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Custom Scan (ChunkAppend) on metrics_timestamp
+   Order: metrics_timestamp."time"
+   ->  Index Only Scan Backward using _hyper_5_155_chunk_metrics_timestamp_time_idx on _hyper_5_155_chunk
+         Index Cond: ("time" < 'Wed Jan 12 00:00:00 2000'::timestamp without time zone)
+         Filter: (time_bucket('@ 7 days'::interval, "time", 'Mon Jan 10 00:00:00 2000'::timestamp without time zone) < 'Wed Jan 05 00:00:00 2000'::timestamp without time zone)
+   ->  Index Only Scan Backward using _hyper_5_156_chunk_metrics_timestamp_time_idx on _hyper_5_156_chunk
+         Index Cond: ("time" < 'Wed Jan 12 00:00:00 2000'::timestamp without time zone)
+         Filter: (time_bucket('@ 7 days'::interval, "time", 'Mon Jan 10 00:00:00 2000'::timestamp without time zone) < 'Wed Jan 05 00:00:00 2000'::timestamp without time zone)
+(8 rows)
+
+:PREFIX SELECT * FROM metrics_timestamp WHERE time_bucket('7d',time,'2000-01-10'::timestamp) <= '2000-01-05' ORDER BY time;
+                                                                                   QUERY PLAN                                                                                    
+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Custom Scan (ChunkAppend) on metrics_timestamp
+   Order: metrics_timestamp."time"
+   ->  Index Only Scan Backward using _hyper_5_155_chunk_metrics_timestamp_time_idx on _hyper_5_155_chunk
+         Index Cond: ("time" <= 'Wed Jan 12 00:00:00 2000'::timestamp without time zone)
+         Filter: (time_bucket('@ 7 days'::interval, "time", 'Mon Jan 10 00:00:00 2000'::timestamp without time zone) <= 'Wed Jan 05 00:00:00 2000'::timestamp without time zone)
+   ->  Index Only Scan Backward using _hyper_5_156_chunk_metrics_timestamp_time_idx on _hyper_5_156_chunk
+         Index Cond: ("time" <= 'Wed Jan 12 00:00:00 2000'::timestamp without time zone)
+         Filter: (time_bucket('@ 7 days'::interval, "time", 'Mon Jan 10 00:00:00 2000'::timestamp without time zone) <= 'Wed Jan 05 00:00:00 2000'::timestamp without time zone)
+(8 rows)
+
+:PREFIX SELECT * FROM metrics_timestamp WHERE time_bucket('7d',time,'2000-01-10'::timestamp) > '2000-01-25' ORDER BY time;
+                                                                                   QUERY PLAN                                                                                   
+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Custom Scan (ChunkAppend) on metrics_timestamp
+   Order: metrics_timestamp."time"
+   ->  Index Only Scan Backward using _hyper_5_158_chunk_metrics_timestamp_time_idx on _hyper_5_158_chunk
+         Index Cond: ("time" > 'Tue Jan 25 00:00:00 2000'::timestamp without time zone)
+         Filter: (time_bucket('@ 7 days'::interval, "time", 'Mon Jan 10 00:00:00 2000'::timestamp without time zone) > 'Tue Jan 25 00:00:00 2000'::timestamp without time zone)
+   ->  Index Only Scan Backward using _hyper_5_159_chunk_metrics_timestamp_time_idx on _hyper_5_159_chunk
+         Index Cond: ("time" > 'Tue Jan 25 00:00:00 2000'::timestamp without time zone)
+         Filter: (time_bucket('@ 7 days'::interval, "time", 'Mon Jan 10 00:00:00 2000'::timestamp without time zone) > 'Tue Jan 25 00:00:00 2000'::timestamp without time zone)
+(8 rows)
+
+:PREFIX SELECT * FROM metrics_timestamp WHERE time_bucket('7d',time,'2000-01-10'::timestamp) >= '2000-01-25' ORDER BY time;
+                                                                                   QUERY PLAN                                                                                    
+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Custom Scan (ChunkAppend) on metrics_timestamp
+   Order: metrics_timestamp."time"
+   ->  Index Only Scan Backward using _hyper_5_158_chunk_metrics_timestamp_time_idx on _hyper_5_158_chunk
+         Index Cond: ("time" >= 'Tue Jan 25 00:00:00 2000'::timestamp without time zone)
+         Filter: (time_bucket('@ 7 days'::interval, "time", 'Mon Jan 10 00:00:00 2000'::timestamp without time zone) >= 'Tue Jan 25 00:00:00 2000'::timestamp without time zone)
+   ->  Index Only Scan Backward using _hyper_5_159_chunk_metrics_timestamp_time_idx on _hyper_5_159_chunk
+         Index Cond: ("time" >= 'Tue Jan 25 00:00:00 2000'::timestamp without time zone)
+         Filter: (time_bucket('@ 7 days'::interval, "time", 'Mon Jan 10 00:00:00 2000'::timestamp without time zone) >= 'Tue Jan 25 00:00:00 2000'::timestamp without time zone)
+(8 rows)
+
+\qecho timestamptz time_bucket exclusion
+timestamptz time_bucket exclusion
+SELECT count(DISTINCT tableoid) FROM metrics_timestamptz;
+ count 
+-------
+     5
+(1 row)
+
+:PREFIX SELECT * FROM metrics_timestamptz WHERE time_bucket('7d',time) < '2000-01-05' ORDER BY time;
+                                                       QUERY PLAN                                                       
+------------------------------------------------------------------------------------------------------------------------
+ Custom Scan (ChunkAppend) on metrics_timestamptz
+   Order: metrics_timestamptz."time"
+   ->  Index Scan Backward using _hyper_6_160_chunk_metrics_timestamptz_time_idx on _hyper_6_160_chunk
+         Index Cond: ("time" < 'Wed Jan 12 00:00:00 2000 PST'::timestamp with time zone)
+         Filter: (time_bucket('@ 7 days'::interval, "time") < 'Wed Jan 05 00:00:00 2000 PST'::timestamp with time zone)
+   ->  Index Scan Backward using _hyper_6_161_chunk_metrics_timestamptz_time_idx on _hyper_6_161_chunk
+         Index Cond: ("time" < 'Wed Jan 12 00:00:00 2000 PST'::timestamp with time zone)
+         Filter: (time_bucket('@ 7 days'::interval, "time") < 'Wed Jan 05 00:00:00 2000 PST'::timestamp with time zone)
+(8 rows)
+
+:PREFIX SELECT * FROM metrics_timestamptz WHERE time_bucket('7d',time) <= '2000-01-05' ORDER BY time;
+                                                       QUERY PLAN                                                        
+-------------------------------------------------------------------------------------------------------------------------
+ Custom Scan (ChunkAppend) on metrics_timestamptz
+   Order: metrics_timestamptz."time"
+   ->  Index Scan Backward using _hyper_6_160_chunk_metrics_timestamptz_time_idx on _hyper_6_160_chunk
+         Index Cond: ("time" <= 'Wed Jan 12 00:00:00 2000 PST'::timestamp with time zone)
+         Filter: (time_bucket('@ 7 days'::interval, "time") <= 'Wed Jan 05 00:00:00 2000 PST'::timestamp with time zone)
+   ->  Index Scan Backward using _hyper_6_161_chunk_metrics_timestamptz_time_idx on _hyper_6_161_chunk
+         Index Cond: ("time" <= 'Wed Jan 12 00:00:00 2000 PST'::timestamp with time zone)
+         Filter: (time_bucket('@ 7 days'::interval, "time") <= 'Wed Jan 05 00:00:00 2000 PST'::timestamp with time zone)
+(8 rows)
+
+:PREFIX SELECT * FROM metrics_timestamptz WHERE time_bucket('7d',time) > '2000-01-25' ORDER BY time;
+                                                       QUERY PLAN                                                       
+------------------------------------------------------------------------------------------------------------------------
+ Custom Scan (ChunkAppend) on metrics_timestamptz
+   Order: metrics_timestamptz."time"
+   ->  Index Scan Backward using _hyper_6_163_chunk_metrics_timestamptz_time_idx on _hyper_6_163_chunk
+         Index Cond: ("time" > 'Tue Jan 25 00:00:00 2000 PST'::timestamp with time zone)
+         Filter: (time_bucket('@ 7 days'::interval, "time") > 'Tue Jan 25 00:00:00 2000 PST'::timestamp with time zone)
+   ->  Index Scan Backward using _hyper_6_164_chunk_metrics_timestamptz_time_idx on _hyper_6_164_chunk
+         Index Cond: ("time" > 'Tue Jan 25 00:00:00 2000 PST'::timestamp with time zone)
+         Filter: (time_bucket('@ 7 days'::interval, "time") > 'Tue Jan 25 00:00:00 2000 PST'::timestamp with time zone)
+(8 rows)
+
+:PREFIX SELECT * FROM metrics_timestamptz WHERE time_bucket('7d',time) >= '2000-01-25' ORDER BY time;
+                                                       QUERY PLAN                                                        
+-------------------------------------------------------------------------------------------------------------------------
+ Custom Scan (ChunkAppend) on metrics_timestamptz
+   Order: metrics_timestamptz."time"
+   ->  Index Scan Backward using _hyper_6_163_chunk_metrics_timestamptz_time_idx on _hyper_6_163_chunk
+         Index Cond: ("time" >= 'Tue Jan 25 00:00:00 2000 PST'::timestamp with time zone)
+         Filter: (time_bucket('@ 7 days'::interval, "time") >= 'Tue Jan 25 00:00:00 2000 PST'::timestamp with time zone)
+   ->  Index Scan Backward using _hyper_6_164_chunk_metrics_timestamptz_time_idx on _hyper_6_164_chunk
+         Index Cond: ("time" >= 'Tue Jan 25 00:00:00 2000 PST'::timestamp with time zone)
+         Filter: (time_bucket('@ 7 days'::interval, "time") >= 'Tue Jan 25 00:00:00 2000 PST'::timestamp with time zone)
+(8 rows)
+
+:PREFIX SELECT * FROM metrics_timestamptz WHERE time_bucket('7d',time,'3d'::interval) < '2000-01-05' ORDER BY time;
+                                                                  QUERY PLAN                                                                  
+----------------------------------------------------------------------------------------------------------------------------------------------
+ Custom Scan (ChunkAppend) on metrics_timestamptz
+   Order: metrics_timestamptz."time"
+   ->  Index Scan Backward using _hyper_6_160_chunk_metrics_timestamptz_time_idx on _hyper_6_160_chunk
+         Index Cond: ("time" < 'Wed Jan 12 00:00:00 2000 PST'::timestamp with time zone)
+         Filter: (time_bucket('@ 7 days'::interval, "time", '@ 3 days'::interval) < 'Wed Jan 05 00:00:00 2000 PST'::timestamp with time zone)
+   ->  Index Scan Backward using _hyper_6_161_chunk_metrics_timestamptz_time_idx on _hyper_6_161_chunk
+         Index Cond: ("time" < 'Wed Jan 12 00:00:00 2000 PST'::timestamp with time zone)
+         Filter: (time_bucket('@ 7 days'::interval, "time", '@ 3 days'::interval) < 'Wed Jan 05 00:00:00 2000 PST'::timestamp with time zone)
+(8 rows)
+
+:PREFIX SELECT * FROM metrics_timestamptz WHERE time_bucket('7d',time,'3d'::interval) <= '2000-01-05' ORDER BY time;
+                                                                  QUERY PLAN                                                                   
+-----------------------------------------------------------------------------------------------------------------------------------------------
+ Custom Scan (ChunkAppend) on metrics_timestamptz
+   Order: metrics_timestamptz."time"
+   ->  Index Scan Backward using _hyper_6_160_chunk_metrics_timestamptz_time_idx on _hyper_6_160_chunk
+         Index Cond: ("time" <= 'Wed Jan 12 00:00:00 2000 PST'::timestamp with time zone)
+         Filter: (time_bucket('@ 7 days'::interval, "time", '@ 3 days'::interval) <= 'Wed Jan 05 00:00:00 2000 PST'::timestamp with time zone)
+   ->  Index Scan Backward using _hyper_6_161_chunk_metrics_timestamptz_time_idx on _hyper_6_161_chunk
+         Index Cond: ("time" <= 'Wed Jan 12 00:00:00 2000 PST'::timestamp with time zone)
+         Filter: (time_bucket('@ 7 days'::interval, "time", '@ 3 days'::interval) <= 'Wed Jan 05 00:00:00 2000 PST'::timestamp with time zone)
+(8 rows)
+
+:PREFIX SELECT * FROM metrics_timestamptz WHERE time_bucket('7d',time,'3d'::interval) > '2000-01-25' ORDER BY time;
+                                                                  QUERY PLAN                                                                  
+----------------------------------------------------------------------------------------------------------------------------------------------
+ Custom Scan (ChunkAppend) on metrics_timestamptz
+   Order: metrics_timestamptz."time"
+   ->  Index Scan Backward using _hyper_6_163_chunk_metrics_timestamptz_time_idx on _hyper_6_163_chunk
+         Index Cond: ("time" > 'Tue Jan 25 00:00:00 2000 PST'::timestamp with time zone)
+         Filter: (time_bucket('@ 7 days'::interval, "time", '@ 3 days'::interval) > 'Tue Jan 25 00:00:00 2000 PST'::timestamp with time zone)
+   ->  Index Scan Backward using _hyper_6_164_chunk_metrics_timestamptz_time_idx on _hyper_6_164_chunk
+         Index Cond: ("time" > 'Tue Jan 25 00:00:00 2000 PST'::timestamp with time zone)
+         Filter: (time_bucket('@ 7 days'::interval, "time", '@ 3 days'::interval) > 'Tue Jan 25 00:00:00 2000 PST'::timestamp with time zone)
+(8 rows)
+
+:PREFIX SELECT * FROM metrics_timestamptz WHERE time_bucket('7d',time,'3d'::interval) >= '2000-01-25' ORDER BY time;
+                                                                  QUERY PLAN                                                                   
+-----------------------------------------------------------------------------------------------------------------------------------------------
+ Custom Scan (ChunkAppend) on metrics_timestamptz
+   Order: metrics_timestamptz."time"
+   ->  Index Scan Backward using _hyper_6_163_chunk_metrics_timestamptz_time_idx on _hyper_6_163_chunk
+         Index Cond: ("time" >= 'Tue Jan 25 00:00:00 2000 PST'::timestamp with time zone)
+         Filter: (time_bucket('@ 7 days'::interval, "time", '@ 3 days'::interval) >= 'Tue Jan 25 00:00:00 2000 PST'::timestamp with time zone)
+   ->  Index Scan Backward using _hyper_6_164_chunk_metrics_timestamptz_time_idx on _hyper_6_164_chunk
+         Index Cond: ("time" >= 'Tue Jan 25 00:00:00 2000 PST'::timestamp with time zone)
+         Filter: (time_bucket('@ 7 days'::interval, "time", '@ 3 days'::interval) >= 'Tue Jan 25 00:00:00 2000 PST'::timestamp with time zone)
+(8 rows)
+
+:PREFIX SELECT * FROM metrics_timestamptz WHERE time_bucket('7d',time,'2000-01-10'::timestamptz) < '2000-01-05' ORDER BY time;
+                                                                                    QUERY PLAN                                                                                    
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Custom Scan (ChunkAppend) on metrics_timestamptz
+   Order: metrics_timestamptz."time"
+   ->  Index Scan Backward using _hyper_6_160_chunk_metrics_timestamptz_time_idx on _hyper_6_160_chunk
+         Index Cond: ("time" < 'Wed Jan 12 00:00:00 2000 PST'::timestamp with time zone)
+         Filter: (time_bucket('@ 7 days'::interval, "time", 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone) < 'Wed Jan 05 00:00:00 2000 PST'::timestamp with time zone)
+   ->  Index Scan Backward using _hyper_6_161_chunk_metrics_timestamptz_time_idx on _hyper_6_161_chunk
+         Index Cond: ("time" < 'Wed Jan 12 00:00:00 2000 PST'::timestamp with time zone)
+         Filter: (time_bucket('@ 7 days'::interval, "time", 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone) < 'Wed Jan 05 00:00:00 2000 PST'::timestamp with time zone)
+(8 rows)
+
+:PREFIX SELECT * FROM metrics_timestamptz WHERE time_bucket('7d',time,'2000-01-10'::timestamptz) <= '2000-01-05' ORDER BY time;
+                                                                                    QUERY PLAN                                                                                     
+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Custom Scan (ChunkAppend) on metrics_timestamptz
+   Order: metrics_timestamptz."time"
+   ->  Index Scan Backward using _hyper_6_160_chunk_metrics_timestamptz_time_idx on _hyper_6_160_chunk
+         Index Cond: ("time" <= 'Wed Jan 12 00:00:00 2000 PST'::timestamp with time zone)
+         Filter: (time_bucket('@ 7 days'::interval, "time", 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone) <= 'Wed Jan 05 00:00:00 2000 PST'::timestamp with time zone)
+   ->  Index Scan Backward using _hyper_6_161_chunk_metrics_timestamptz_time_idx on _hyper_6_161_chunk
+         Index Cond: ("time" <= 'Wed Jan 12 00:00:00 2000 PST'::timestamp with time zone)
+         Filter: (time_bucket('@ 7 days'::interval, "time", 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone) <= 'Wed Jan 05 00:00:00 2000 PST'::timestamp with time zone)
+(8 rows)
+
+:PREFIX SELECT * FROM metrics_timestamptz WHERE time_bucket('7d',time,'2000-01-10'::timestamptz) > '2000-01-25' ORDER BY time;
+                                                                                    QUERY PLAN                                                                                    
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Custom Scan (ChunkAppend) on metrics_timestamptz
+   Order: metrics_timestamptz."time"
+   ->  Index Scan Backward using _hyper_6_163_chunk_metrics_timestamptz_time_idx on _hyper_6_163_chunk
+         Index Cond: ("time" > 'Tue Jan 25 00:00:00 2000 PST'::timestamp with time zone)
+         Filter: (time_bucket('@ 7 days'::interval, "time", 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone) > 'Tue Jan 25 00:00:00 2000 PST'::timestamp with time zone)
+   ->  Index Scan Backward using _hyper_6_164_chunk_metrics_timestamptz_time_idx on _hyper_6_164_chunk
+         Index Cond: ("time" > 'Tue Jan 25 00:00:00 2000 PST'::timestamp with time zone)
+         Filter: (time_bucket('@ 7 days'::interval, "time", 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone) > 'Tue Jan 25 00:00:00 2000 PST'::timestamp with time zone)
+(8 rows)
+
+:PREFIX SELECT * FROM metrics_timestamptz WHERE time_bucket('7d',time,'2000-01-10'::timestamptz) >= '2000-01-25' ORDER BY time;
+                                                                                    QUERY PLAN                                                                                     
+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Custom Scan (ChunkAppend) on metrics_timestamptz
+   Order: metrics_timestamptz."time"
+   ->  Index Scan Backward using _hyper_6_163_chunk_metrics_timestamptz_time_idx on _hyper_6_163_chunk
+         Index Cond: ("time" >= 'Tue Jan 25 00:00:00 2000 PST'::timestamp with time zone)
+         Filter: (time_bucket('@ 7 days'::interval, "time", 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone) >= 'Tue Jan 25 00:00:00 2000 PST'::timestamp with time zone)
+   ->  Index Scan Backward using _hyper_6_164_chunk_metrics_timestamptz_time_idx on _hyper_6_164_chunk
+         Index Cond: ("time" >= 'Tue Jan 25 00:00:00 2000 PST'::timestamp with time zone)
+         Filter: (time_bucket('@ 7 days'::interval, "time", 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone) >= 'Tue Jan 25 00:00:00 2000 PST'::timestamp with time zone)
+(8 rows)
+
+:PREFIX SELECT * FROM metrics_timestamptz WHERE time_bucket('7d',time,'Europe/Berlin') < '2000-01-05' ORDER BY time;
+                                                                                          QUERY PLAN                                                                                           
+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Custom Scan (ChunkAppend) on metrics_timestamptz
+   Order: metrics_timestamptz."time"
+   ->  Index Scan Backward using _hyper_6_160_chunk_metrics_timestamptz_time_idx on _hyper_6_160_chunk
+         Index Cond: ("time" < 'Wed Jan 12 00:00:00 2000 PST'::timestamp with time zone)
+         Filter: (time_bucket('@ 7 days'::interval, "time", 'Europe/Berlin'::text, NULL::timestamp with time zone, NULL::interval) < 'Wed Jan 05 00:00:00 2000 PST'::timestamp with time zone)
+   ->  Index Scan Backward using _hyper_6_161_chunk_metrics_timestamptz_time_idx on _hyper_6_161_chunk
+         Index Cond: ("time" < 'Wed Jan 12 00:00:00 2000 PST'::timestamp with time zone)
+         Filter: (time_bucket('@ 7 days'::interval, "time", 'Europe/Berlin'::text, NULL::timestamp with time zone, NULL::interval) < 'Wed Jan 05 00:00:00 2000 PST'::timestamp with time zone)
+(8 rows)
+
+:PREFIX SELECT * FROM metrics_timestamptz WHERE time_bucket('7d',time,'Europe/Berlin') <= '2000-01-05' ORDER BY time;
+                                                                                           QUERY PLAN                                                                                           
+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Custom Scan (ChunkAppend) on metrics_timestamptz
+   Order: metrics_timestamptz."time"
+   ->  Index Scan Backward using _hyper_6_160_chunk_metrics_timestamptz_time_idx on _hyper_6_160_chunk
+         Index Cond: ("time" <= 'Wed Jan 12 00:00:00 2000 PST'::timestamp with time zone)
+         Filter: (time_bucket('@ 7 days'::interval, "time", 'Europe/Berlin'::text, NULL::timestamp with time zone, NULL::interval) <= 'Wed Jan 05 00:00:00 2000 PST'::timestamp with time zone)
+   ->  Index Scan Backward using _hyper_6_161_chunk_metrics_timestamptz_time_idx on _hyper_6_161_chunk
+         Index Cond: ("time" <= 'Wed Jan 12 00:00:00 2000 PST'::timestamp with time zone)
+         Filter: (time_bucket('@ 7 days'::interval, "time", 'Europe/Berlin'::text, NULL::timestamp with time zone, NULL::interval) <= 'Wed Jan 05 00:00:00 2000 PST'::timestamp with time zone)
+(8 rows)
+
+:PREFIX SELECT * FROM metrics_timestamptz WHERE time_bucket('7d',time,'Europe/Berlin') > '2000-01-25' ORDER BY time;
+                                                                                          QUERY PLAN                                                                                           
+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Custom Scan (ChunkAppend) on metrics_timestamptz
+   Order: metrics_timestamptz."time"
+   ->  Index Scan Backward using _hyper_6_163_chunk_metrics_timestamptz_time_idx on _hyper_6_163_chunk
+         Index Cond: ("time" > 'Tue Jan 25 00:00:00 2000 PST'::timestamp with time zone)
+         Filter: (time_bucket('@ 7 days'::interval, "time", 'Europe/Berlin'::text, NULL::timestamp with time zone, NULL::interval) > 'Tue Jan 25 00:00:00 2000 PST'::timestamp with time zone)
+   ->  Index Scan Backward using _hyper_6_164_chunk_metrics_timestamptz_time_idx on _hyper_6_164_chunk
+         Index Cond: ("time" > 'Tue Jan 25 00:00:00 2000 PST'::timestamp with time zone)
+         Filter: (time_bucket('@ 7 days'::interval, "time", 'Europe/Berlin'::text, NULL::timestamp with time zone, NULL::interval) > 'Tue Jan 25 00:00:00 2000 PST'::timestamp with time zone)
+(8 rows)
+
+:PREFIX SELECT * FROM metrics_timestamptz WHERE time_bucket('7d',time,'Europe/Berlin') >= '2000-01-25' ORDER BY time;
+                                                                                           QUERY PLAN                                                                                           
+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Custom Scan (ChunkAppend) on metrics_timestamptz
+   Order: metrics_timestamptz."time"
+   ->  Index Scan Backward using _hyper_6_163_chunk_metrics_timestamptz_time_idx on _hyper_6_163_chunk
+         Index Cond: ("time" >= 'Tue Jan 25 00:00:00 2000 PST'::timestamp with time zone)
+         Filter: (time_bucket('@ 7 days'::interval, "time", 'Europe/Berlin'::text, NULL::timestamp with time zone, NULL::interval) >= 'Tue Jan 25 00:00:00 2000 PST'::timestamp with time zone)
+   ->  Index Scan Backward using _hyper_6_164_chunk_metrics_timestamptz_time_idx on _hyper_6_164_chunk
+         Index Cond: ("time" >= 'Tue Jan 25 00:00:00 2000 PST'::timestamp with time zone)
+         Filter: (time_bucket('@ 7 days'::interval, "time", 'Europe/Berlin'::text, NULL::timestamp with time zone, NULL::interval) >= 'Tue Jan 25 00:00:00 2000 PST'::timestamp with time zone)
+(8 rows)
+
 \qecho test overflow behaviour of time_bucket exclusion
 test overflow behaviour of time_bucket exclusion
 :PREFIX SELECT * FROM hyper WHERE time > 950 AND time_bucket(10, time) < '9223372036854775807'::bigint ORDER BY time;

--- a/test/expected/plan_expand_hypertable-15.out
+++ b/test/expected/plan_expand_hypertable-15.out
@@ -1113,6 +1113,455 @@ time_bucket exclusion
                Filter: (("time" < '21'::bigint) AND ('11'::bigint > time_bucket('10'::bigint, "time")))
 (9 rows)
 
+:PREFIX SELECT * FROM hyper WHERE time_bucket(10, time, 5) < 10::bigint ORDER BY time;
+                                                     QUERY PLAN                                                      
+---------------------------------------------------------------------------------------------------------------------
+ Sort
+   Sort Key: _hyper_1_1_chunk."time"
+   ->  Append
+         ->  Seq Scan on _hyper_1_1_chunk
+               Filter: (("time" < '20'::bigint) AND (time_bucket('10'::bigint, "time", '5'::bigint) < '10'::bigint))
+         ->  Seq Scan on _hyper_1_2_chunk
+               Filter: (("time" < '20'::bigint) AND (time_bucket('10'::bigint, "time", '5'::bigint) < '10'::bigint))
+(7 rows)
+
+:PREFIX SELECT * FROM hyper WHERE time_bucket(10, time, 5) < 11::bigint ORDER BY time;
+                                                     QUERY PLAN                                                      
+---------------------------------------------------------------------------------------------------------------------
+ Sort
+   Sort Key: _hyper_1_1_chunk."time"
+   ->  Append
+         ->  Seq Scan on _hyper_1_1_chunk
+               Filter: (("time" < '21'::bigint) AND (time_bucket('10'::bigint, "time", '5'::bigint) < '11'::bigint))
+         ->  Seq Scan on _hyper_1_2_chunk
+               Filter: (("time" < '21'::bigint) AND (time_bucket('10'::bigint, "time", '5'::bigint) < '11'::bigint))
+         ->  Seq Scan on _hyper_1_3_chunk
+               Filter: (("time" < '21'::bigint) AND (time_bucket('10'::bigint, "time", '5'::bigint) < '11'::bigint))
+(9 rows)
+
+:PREFIX SELECT * FROM hyper WHERE time_bucket(10, time, 5) <= 10::bigint ORDER BY time;
+                                                      QUERY PLAN                                                       
+-----------------------------------------------------------------------------------------------------------------------
+ Sort
+   Sort Key: _hyper_1_1_chunk."time"
+   ->  Append
+         ->  Seq Scan on _hyper_1_1_chunk
+               Filter: (("time" <= '20'::bigint) AND (time_bucket('10'::bigint, "time", '5'::bigint) <= '10'::bigint))
+         ->  Seq Scan on _hyper_1_2_chunk
+               Filter: (("time" <= '20'::bigint) AND (time_bucket('10'::bigint, "time", '5'::bigint) <= '10'::bigint))
+         ->  Seq Scan on _hyper_1_3_chunk
+               Filter: (("time" <= '20'::bigint) AND (time_bucket('10'::bigint, "time", '5'::bigint) <= '10'::bigint))
+(9 rows)
+
+:PREFIX SELECT * FROM hyper WHERE 10::bigint > time_bucket(10, time, 5) ORDER BY time;
+                                                     QUERY PLAN                                                      
+---------------------------------------------------------------------------------------------------------------------
+ Sort
+   Sort Key: _hyper_1_1_chunk."time"
+   ->  Append
+         ->  Seq Scan on _hyper_1_1_chunk
+               Filter: (("time" < '20'::bigint) AND ('10'::bigint > time_bucket('10'::bigint, "time", '5'::bigint)))
+         ->  Seq Scan on _hyper_1_2_chunk
+               Filter: (("time" < '20'::bigint) AND ('10'::bigint > time_bucket('10'::bigint, "time", '5'::bigint)))
+(7 rows)
+
+:PREFIX SELECT * FROM hyper WHERE 11::bigint > time_bucket(10, time, 5) ORDER BY time;
+                                                     QUERY PLAN                                                      
+---------------------------------------------------------------------------------------------------------------------
+ Sort
+   Sort Key: _hyper_1_1_chunk."time"
+   ->  Append
+         ->  Seq Scan on _hyper_1_1_chunk
+               Filter: (("time" < '21'::bigint) AND ('11'::bigint > time_bucket('10'::bigint, "time", '5'::bigint)))
+         ->  Seq Scan on _hyper_1_2_chunk
+               Filter: (("time" < '21'::bigint) AND ('11'::bigint > time_bucket('10'::bigint, "time", '5'::bigint)))
+         ->  Seq Scan on _hyper_1_3_chunk
+               Filter: (("time" < '21'::bigint) AND ('11'::bigint > time_bucket('10'::bigint, "time", '5'::bigint)))
+(9 rows)
+
+\qecho timestamp time_bucket exclusion
+timestamp time_bucket exclusion
+SELECT count(DISTINCT tableoid) FROM metrics_timestamp;
+ count 
+-------
+     5
+(1 row)
+
+:PREFIX SELECT * FROM metrics_timestamp WHERE time_bucket('7d',time) < '2000-01-05' ORDER BY time;
+                                                      QUERY PLAN                                                       
+-----------------------------------------------------------------------------------------------------------------------
+ Custom Scan (ChunkAppend) on metrics_timestamp
+   Order: metrics_timestamp."time"
+   ->  Index Only Scan Backward using _hyper_5_155_chunk_metrics_timestamp_time_idx on _hyper_5_155_chunk
+         Index Cond: ("time" < 'Wed Jan 12 00:00:00 2000'::timestamp without time zone)
+         Filter: (time_bucket('@ 7 days'::interval, "time") < 'Wed Jan 05 00:00:00 2000'::timestamp without time zone)
+   ->  Index Only Scan Backward using _hyper_5_156_chunk_metrics_timestamp_time_idx on _hyper_5_156_chunk
+         Index Cond: ("time" < 'Wed Jan 12 00:00:00 2000'::timestamp without time zone)
+         Filter: (time_bucket('@ 7 days'::interval, "time") < 'Wed Jan 05 00:00:00 2000'::timestamp without time zone)
+(8 rows)
+
+:PREFIX SELECT * FROM metrics_timestamp WHERE time_bucket('7d',time) <= '2000-01-05' ORDER BY time;
+                                                       QUERY PLAN                                                       
+------------------------------------------------------------------------------------------------------------------------
+ Custom Scan (ChunkAppend) on metrics_timestamp
+   Order: metrics_timestamp."time"
+   ->  Index Only Scan Backward using _hyper_5_155_chunk_metrics_timestamp_time_idx on _hyper_5_155_chunk
+         Index Cond: ("time" <= 'Wed Jan 12 00:00:00 2000'::timestamp without time zone)
+         Filter: (time_bucket('@ 7 days'::interval, "time") <= 'Wed Jan 05 00:00:00 2000'::timestamp without time zone)
+   ->  Index Only Scan Backward using _hyper_5_156_chunk_metrics_timestamp_time_idx on _hyper_5_156_chunk
+         Index Cond: ("time" <= 'Wed Jan 12 00:00:00 2000'::timestamp without time zone)
+         Filter: (time_bucket('@ 7 days'::interval, "time") <= 'Wed Jan 05 00:00:00 2000'::timestamp without time zone)
+(8 rows)
+
+:PREFIX SELECT * FROM metrics_timestamp WHERE time_bucket('7d',time) > '2000-01-25' ORDER BY time;
+                                                      QUERY PLAN                                                       
+-----------------------------------------------------------------------------------------------------------------------
+ Custom Scan (ChunkAppend) on metrics_timestamp
+   Order: metrics_timestamp."time"
+   ->  Index Only Scan Backward using _hyper_5_158_chunk_metrics_timestamp_time_idx on _hyper_5_158_chunk
+         Index Cond: ("time" > 'Tue Jan 25 00:00:00 2000'::timestamp without time zone)
+         Filter: (time_bucket('@ 7 days'::interval, "time") > 'Tue Jan 25 00:00:00 2000'::timestamp without time zone)
+   ->  Index Only Scan Backward using _hyper_5_159_chunk_metrics_timestamp_time_idx on _hyper_5_159_chunk
+         Index Cond: ("time" > 'Tue Jan 25 00:00:00 2000'::timestamp without time zone)
+         Filter: (time_bucket('@ 7 days'::interval, "time") > 'Tue Jan 25 00:00:00 2000'::timestamp without time zone)
+(8 rows)
+
+:PREFIX SELECT * FROM metrics_timestamp WHERE time_bucket('7d',time) >= '2000-01-15' ORDER BY time;
+                                                       QUERY PLAN                                                       
+------------------------------------------------------------------------------------------------------------------------
+ Custom Scan (ChunkAppend) on metrics_timestamp
+   Order: metrics_timestamp."time"
+   ->  Index Only Scan Backward using _hyper_5_157_chunk_metrics_timestamp_time_idx on _hyper_5_157_chunk
+         Index Cond: ("time" >= 'Sat Jan 15 00:00:00 2000'::timestamp without time zone)
+         Filter: (time_bucket('@ 7 days'::interval, "time") >= 'Sat Jan 15 00:00:00 2000'::timestamp without time zone)
+   ->  Index Only Scan Backward using _hyper_5_158_chunk_metrics_timestamp_time_idx on _hyper_5_158_chunk
+         Index Cond: ("time" >= 'Sat Jan 15 00:00:00 2000'::timestamp without time zone)
+         Filter: (time_bucket('@ 7 days'::interval, "time") >= 'Sat Jan 15 00:00:00 2000'::timestamp without time zone)
+   ->  Index Only Scan Backward using _hyper_5_159_chunk_metrics_timestamp_time_idx on _hyper_5_159_chunk
+         Index Cond: ("time" >= 'Sat Jan 15 00:00:00 2000'::timestamp without time zone)
+         Filter: (time_bucket('@ 7 days'::interval, "time") >= 'Sat Jan 15 00:00:00 2000'::timestamp without time zone)
+(11 rows)
+
+:PREFIX SELECT * FROM metrics_timestamp WHERE time_bucket('7d',time,'3d'::interval) < '2000-01-05' ORDER BY time;
+                                                                 QUERY PLAN                                                                  
+---------------------------------------------------------------------------------------------------------------------------------------------
+ Custom Scan (ChunkAppend) on metrics_timestamp
+   Order: metrics_timestamp."time"
+   ->  Index Only Scan Backward using _hyper_5_155_chunk_metrics_timestamp_time_idx on _hyper_5_155_chunk
+         Index Cond: ("time" < 'Wed Jan 12 00:00:00 2000'::timestamp without time zone)
+         Filter: (time_bucket('@ 7 days'::interval, "time", '@ 3 days'::interval) < 'Wed Jan 05 00:00:00 2000'::timestamp without time zone)
+   ->  Index Only Scan Backward using _hyper_5_156_chunk_metrics_timestamp_time_idx on _hyper_5_156_chunk
+         Index Cond: ("time" < 'Wed Jan 12 00:00:00 2000'::timestamp without time zone)
+         Filter: (time_bucket('@ 7 days'::interval, "time", '@ 3 days'::interval) < 'Wed Jan 05 00:00:00 2000'::timestamp without time zone)
+(8 rows)
+
+:PREFIX SELECT * FROM metrics_timestamp WHERE time_bucket('7d',time,'3d'::interval) <= '2000-01-05' ORDER BY time;
+                                                                  QUERY PLAN                                                                  
+----------------------------------------------------------------------------------------------------------------------------------------------
+ Custom Scan (ChunkAppend) on metrics_timestamp
+   Order: metrics_timestamp."time"
+   ->  Index Only Scan Backward using _hyper_5_155_chunk_metrics_timestamp_time_idx on _hyper_5_155_chunk
+         Index Cond: ("time" <= 'Wed Jan 12 00:00:00 2000'::timestamp without time zone)
+         Filter: (time_bucket('@ 7 days'::interval, "time", '@ 3 days'::interval) <= 'Wed Jan 05 00:00:00 2000'::timestamp without time zone)
+   ->  Index Only Scan Backward using _hyper_5_156_chunk_metrics_timestamp_time_idx on _hyper_5_156_chunk
+         Index Cond: ("time" <= 'Wed Jan 12 00:00:00 2000'::timestamp without time zone)
+         Filter: (time_bucket('@ 7 days'::interval, "time", '@ 3 days'::interval) <= 'Wed Jan 05 00:00:00 2000'::timestamp without time zone)
+(8 rows)
+
+:PREFIX SELECT * FROM metrics_timestamp WHERE time_bucket('7d',time,'3d'::interval) > '2000-01-25' ORDER BY time;
+                                                                 QUERY PLAN                                                                  
+---------------------------------------------------------------------------------------------------------------------------------------------
+ Custom Scan (ChunkAppend) on metrics_timestamp
+   Order: metrics_timestamp."time"
+   ->  Index Only Scan Backward using _hyper_5_158_chunk_metrics_timestamp_time_idx on _hyper_5_158_chunk
+         Index Cond: ("time" > 'Tue Jan 25 00:00:00 2000'::timestamp without time zone)
+         Filter: (time_bucket('@ 7 days'::interval, "time", '@ 3 days'::interval) > 'Tue Jan 25 00:00:00 2000'::timestamp without time zone)
+   ->  Index Only Scan Backward using _hyper_5_159_chunk_metrics_timestamp_time_idx on _hyper_5_159_chunk
+         Index Cond: ("time" > 'Tue Jan 25 00:00:00 2000'::timestamp without time zone)
+         Filter: (time_bucket('@ 7 days'::interval, "time", '@ 3 days'::interval) > 'Tue Jan 25 00:00:00 2000'::timestamp without time zone)
+(8 rows)
+
+:PREFIX SELECT * FROM metrics_timestamp WHERE time_bucket('7d',time,'3d'::interval) >= '2000-01-25' ORDER BY time;
+                                                                  QUERY PLAN                                                                  
+----------------------------------------------------------------------------------------------------------------------------------------------
+ Custom Scan (ChunkAppend) on metrics_timestamp
+   Order: metrics_timestamp."time"
+   ->  Index Only Scan Backward using _hyper_5_158_chunk_metrics_timestamp_time_idx on _hyper_5_158_chunk
+         Index Cond: ("time" >= 'Tue Jan 25 00:00:00 2000'::timestamp without time zone)
+         Filter: (time_bucket('@ 7 days'::interval, "time", '@ 3 days'::interval) >= 'Tue Jan 25 00:00:00 2000'::timestamp without time zone)
+   ->  Index Only Scan Backward using _hyper_5_159_chunk_metrics_timestamp_time_idx on _hyper_5_159_chunk
+         Index Cond: ("time" >= 'Tue Jan 25 00:00:00 2000'::timestamp without time zone)
+         Filter: (time_bucket('@ 7 days'::interval, "time", '@ 3 days'::interval) >= 'Tue Jan 25 00:00:00 2000'::timestamp without time zone)
+(8 rows)
+
+:PREFIX SELECT * FROM metrics_timestamp WHERE time_bucket('7d',time,'2000-01-10'::timestamp) < '2000-01-05' ORDER BY time;
+                                                                                   QUERY PLAN                                                                                   
+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Custom Scan (ChunkAppend) on metrics_timestamp
+   Order: metrics_timestamp."time"
+   ->  Index Only Scan Backward using _hyper_5_155_chunk_metrics_timestamp_time_idx on _hyper_5_155_chunk
+         Index Cond: ("time" < 'Wed Jan 12 00:00:00 2000'::timestamp without time zone)
+         Filter: (time_bucket('@ 7 days'::interval, "time", 'Mon Jan 10 00:00:00 2000'::timestamp without time zone) < 'Wed Jan 05 00:00:00 2000'::timestamp without time zone)
+   ->  Index Only Scan Backward using _hyper_5_156_chunk_metrics_timestamp_time_idx on _hyper_5_156_chunk
+         Index Cond: ("time" < 'Wed Jan 12 00:00:00 2000'::timestamp without time zone)
+         Filter: (time_bucket('@ 7 days'::interval, "time", 'Mon Jan 10 00:00:00 2000'::timestamp without time zone) < 'Wed Jan 05 00:00:00 2000'::timestamp without time zone)
+(8 rows)
+
+:PREFIX SELECT * FROM metrics_timestamp WHERE time_bucket('7d',time,'2000-01-10'::timestamp) <= '2000-01-05' ORDER BY time;
+                                                                                   QUERY PLAN                                                                                    
+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Custom Scan (ChunkAppend) on metrics_timestamp
+   Order: metrics_timestamp."time"
+   ->  Index Only Scan Backward using _hyper_5_155_chunk_metrics_timestamp_time_idx on _hyper_5_155_chunk
+         Index Cond: ("time" <= 'Wed Jan 12 00:00:00 2000'::timestamp without time zone)
+         Filter: (time_bucket('@ 7 days'::interval, "time", 'Mon Jan 10 00:00:00 2000'::timestamp without time zone) <= 'Wed Jan 05 00:00:00 2000'::timestamp without time zone)
+   ->  Index Only Scan Backward using _hyper_5_156_chunk_metrics_timestamp_time_idx on _hyper_5_156_chunk
+         Index Cond: ("time" <= 'Wed Jan 12 00:00:00 2000'::timestamp without time zone)
+         Filter: (time_bucket('@ 7 days'::interval, "time", 'Mon Jan 10 00:00:00 2000'::timestamp without time zone) <= 'Wed Jan 05 00:00:00 2000'::timestamp without time zone)
+(8 rows)
+
+:PREFIX SELECT * FROM metrics_timestamp WHERE time_bucket('7d',time,'2000-01-10'::timestamp) > '2000-01-25' ORDER BY time;
+                                                                                   QUERY PLAN                                                                                   
+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Custom Scan (ChunkAppend) on metrics_timestamp
+   Order: metrics_timestamp."time"
+   ->  Index Only Scan Backward using _hyper_5_158_chunk_metrics_timestamp_time_idx on _hyper_5_158_chunk
+         Index Cond: ("time" > 'Tue Jan 25 00:00:00 2000'::timestamp without time zone)
+         Filter: (time_bucket('@ 7 days'::interval, "time", 'Mon Jan 10 00:00:00 2000'::timestamp without time zone) > 'Tue Jan 25 00:00:00 2000'::timestamp without time zone)
+   ->  Index Only Scan Backward using _hyper_5_159_chunk_metrics_timestamp_time_idx on _hyper_5_159_chunk
+         Index Cond: ("time" > 'Tue Jan 25 00:00:00 2000'::timestamp without time zone)
+         Filter: (time_bucket('@ 7 days'::interval, "time", 'Mon Jan 10 00:00:00 2000'::timestamp without time zone) > 'Tue Jan 25 00:00:00 2000'::timestamp without time zone)
+(8 rows)
+
+:PREFIX SELECT * FROM metrics_timestamp WHERE time_bucket('7d',time,'2000-01-10'::timestamp) >= '2000-01-25' ORDER BY time;
+                                                                                   QUERY PLAN                                                                                    
+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Custom Scan (ChunkAppend) on metrics_timestamp
+   Order: metrics_timestamp."time"
+   ->  Index Only Scan Backward using _hyper_5_158_chunk_metrics_timestamp_time_idx on _hyper_5_158_chunk
+         Index Cond: ("time" >= 'Tue Jan 25 00:00:00 2000'::timestamp without time zone)
+         Filter: (time_bucket('@ 7 days'::interval, "time", 'Mon Jan 10 00:00:00 2000'::timestamp without time zone) >= 'Tue Jan 25 00:00:00 2000'::timestamp without time zone)
+   ->  Index Only Scan Backward using _hyper_5_159_chunk_metrics_timestamp_time_idx on _hyper_5_159_chunk
+         Index Cond: ("time" >= 'Tue Jan 25 00:00:00 2000'::timestamp without time zone)
+         Filter: (time_bucket('@ 7 days'::interval, "time", 'Mon Jan 10 00:00:00 2000'::timestamp without time zone) >= 'Tue Jan 25 00:00:00 2000'::timestamp without time zone)
+(8 rows)
+
+\qecho timestamptz time_bucket exclusion
+timestamptz time_bucket exclusion
+SELECT count(DISTINCT tableoid) FROM metrics_timestamptz;
+ count 
+-------
+     5
+(1 row)
+
+:PREFIX SELECT * FROM metrics_timestamptz WHERE time_bucket('7d',time) < '2000-01-05' ORDER BY time;
+                                                       QUERY PLAN                                                       
+------------------------------------------------------------------------------------------------------------------------
+ Custom Scan (ChunkAppend) on metrics_timestamptz
+   Order: metrics_timestamptz."time"
+   ->  Index Scan Backward using _hyper_6_160_chunk_metrics_timestamptz_time_idx on _hyper_6_160_chunk
+         Index Cond: ("time" < 'Wed Jan 12 00:00:00 2000 PST'::timestamp with time zone)
+         Filter: (time_bucket('@ 7 days'::interval, "time") < 'Wed Jan 05 00:00:00 2000 PST'::timestamp with time zone)
+   ->  Index Scan Backward using _hyper_6_161_chunk_metrics_timestamptz_time_idx on _hyper_6_161_chunk
+         Index Cond: ("time" < 'Wed Jan 12 00:00:00 2000 PST'::timestamp with time zone)
+         Filter: (time_bucket('@ 7 days'::interval, "time") < 'Wed Jan 05 00:00:00 2000 PST'::timestamp with time zone)
+(8 rows)
+
+:PREFIX SELECT * FROM metrics_timestamptz WHERE time_bucket('7d',time) <= '2000-01-05' ORDER BY time;
+                                                       QUERY PLAN                                                        
+-------------------------------------------------------------------------------------------------------------------------
+ Custom Scan (ChunkAppend) on metrics_timestamptz
+   Order: metrics_timestamptz."time"
+   ->  Index Scan Backward using _hyper_6_160_chunk_metrics_timestamptz_time_idx on _hyper_6_160_chunk
+         Index Cond: ("time" <= 'Wed Jan 12 00:00:00 2000 PST'::timestamp with time zone)
+         Filter: (time_bucket('@ 7 days'::interval, "time") <= 'Wed Jan 05 00:00:00 2000 PST'::timestamp with time zone)
+   ->  Index Scan Backward using _hyper_6_161_chunk_metrics_timestamptz_time_idx on _hyper_6_161_chunk
+         Index Cond: ("time" <= 'Wed Jan 12 00:00:00 2000 PST'::timestamp with time zone)
+         Filter: (time_bucket('@ 7 days'::interval, "time") <= 'Wed Jan 05 00:00:00 2000 PST'::timestamp with time zone)
+(8 rows)
+
+:PREFIX SELECT * FROM metrics_timestamptz WHERE time_bucket('7d',time) > '2000-01-25' ORDER BY time;
+                                                       QUERY PLAN                                                       
+------------------------------------------------------------------------------------------------------------------------
+ Custom Scan (ChunkAppend) on metrics_timestamptz
+   Order: metrics_timestamptz."time"
+   ->  Index Scan Backward using _hyper_6_163_chunk_metrics_timestamptz_time_idx on _hyper_6_163_chunk
+         Index Cond: ("time" > 'Tue Jan 25 00:00:00 2000 PST'::timestamp with time zone)
+         Filter: (time_bucket('@ 7 days'::interval, "time") > 'Tue Jan 25 00:00:00 2000 PST'::timestamp with time zone)
+   ->  Index Scan Backward using _hyper_6_164_chunk_metrics_timestamptz_time_idx on _hyper_6_164_chunk
+         Index Cond: ("time" > 'Tue Jan 25 00:00:00 2000 PST'::timestamp with time zone)
+         Filter: (time_bucket('@ 7 days'::interval, "time") > 'Tue Jan 25 00:00:00 2000 PST'::timestamp with time zone)
+(8 rows)
+
+:PREFIX SELECT * FROM metrics_timestamptz WHERE time_bucket('7d',time) >= '2000-01-25' ORDER BY time;
+                                                       QUERY PLAN                                                        
+-------------------------------------------------------------------------------------------------------------------------
+ Custom Scan (ChunkAppend) on metrics_timestamptz
+   Order: metrics_timestamptz."time"
+   ->  Index Scan Backward using _hyper_6_163_chunk_metrics_timestamptz_time_idx on _hyper_6_163_chunk
+         Index Cond: ("time" >= 'Tue Jan 25 00:00:00 2000 PST'::timestamp with time zone)
+         Filter: (time_bucket('@ 7 days'::interval, "time") >= 'Tue Jan 25 00:00:00 2000 PST'::timestamp with time zone)
+   ->  Index Scan Backward using _hyper_6_164_chunk_metrics_timestamptz_time_idx on _hyper_6_164_chunk
+         Index Cond: ("time" >= 'Tue Jan 25 00:00:00 2000 PST'::timestamp with time zone)
+         Filter: (time_bucket('@ 7 days'::interval, "time") >= 'Tue Jan 25 00:00:00 2000 PST'::timestamp with time zone)
+(8 rows)
+
+:PREFIX SELECT * FROM metrics_timestamptz WHERE time_bucket('7d',time,'3d'::interval) < '2000-01-05' ORDER BY time;
+                                                                  QUERY PLAN                                                                  
+----------------------------------------------------------------------------------------------------------------------------------------------
+ Custom Scan (ChunkAppend) on metrics_timestamptz
+   Order: metrics_timestamptz."time"
+   ->  Index Scan Backward using _hyper_6_160_chunk_metrics_timestamptz_time_idx on _hyper_6_160_chunk
+         Index Cond: ("time" < 'Wed Jan 12 00:00:00 2000 PST'::timestamp with time zone)
+         Filter: (time_bucket('@ 7 days'::interval, "time", '@ 3 days'::interval) < 'Wed Jan 05 00:00:00 2000 PST'::timestamp with time zone)
+   ->  Index Scan Backward using _hyper_6_161_chunk_metrics_timestamptz_time_idx on _hyper_6_161_chunk
+         Index Cond: ("time" < 'Wed Jan 12 00:00:00 2000 PST'::timestamp with time zone)
+         Filter: (time_bucket('@ 7 days'::interval, "time", '@ 3 days'::interval) < 'Wed Jan 05 00:00:00 2000 PST'::timestamp with time zone)
+(8 rows)
+
+:PREFIX SELECT * FROM metrics_timestamptz WHERE time_bucket('7d',time,'3d'::interval) <= '2000-01-05' ORDER BY time;
+                                                                  QUERY PLAN                                                                   
+-----------------------------------------------------------------------------------------------------------------------------------------------
+ Custom Scan (ChunkAppend) on metrics_timestamptz
+   Order: metrics_timestamptz."time"
+   ->  Index Scan Backward using _hyper_6_160_chunk_metrics_timestamptz_time_idx on _hyper_6_160_chunk
+         Index Cond: ("time" <= 'Wed Jan 12 00:00:00 2000 PST'::timestamp with time zone)
+         Filter: (time_bucket('@ 7 days'::interval, "time", '@ 3 days'::interval) <= 'Wed Jan 05 00:00:00 2000 PST'::timestamp with time zone)
+   ->  Index Scan Backward using _hyper_6_161_chunk_metrics_timestamptz_time_idx on _hyper_6_161_chunk
+         Index Cond: ("time" <= 'Wed Jan 12 00:00:00 2000 PST'::timestamp with time zone)
+         Filter: (time_bucket('@ 7 days'::interval, "time", '@ 3 days'::interval) <= 'Wed Jan 05 00:00:00 2000 PST'::timestamp with time zone)
+(8 rows)
+
+:PREFIX SELECT * FROM metrics_timestamptz WHERE time_bucket('7d',time,'3d'::interval) > '2000-01-25' ORDER BY time;
+                                                                  QUERY PLAN                                                                  
+----------------------------------------------------------------------------------------------------------------------------------------------
+ Custom Scan (ChunkAppend) on metrics_timestamptz
+   Order: metrics_timestamptz."time"
+   ->  Index Scan Backward using _hyper_6_163_chunk_metrics_timestamptz_time_idx on _hyper_6_163_chunk
+         Index Cond: ("time" > 'Tue Jan 25 00:00:00 2000 PST'::timestamp with time zone)
+         Filter: (time_bucket('@ 7 days'::interval, "time", '@ 3 days'::interval) > 'Tue Jan 25 00:00:00 2000 PST'::timestamp with time zone)
+   ->  Index Scan Backward using _hyper_6_164_chunk_metrics_timestamptz_time_idx on _hyper_6_164_chunk
+         Index Cond: ("time" > 'Tue Jan 25 00:00:00 2000 PST'::timestamp with time zone)
+         Filter: (time_bucket('@ 7 days'::interval, "time", '@ 3 days'::interval) > 'Tue Jan 25 00:00:00 2000 PST'::timestamp with time zone)
+(8 rows)
+
+:PREFIX SELECT * FROM metrics_timestamptz WHERE time_bucket('7d',time,'3d'::interval) >= '2000-01-25' ORDER BY time;
+                                                                  QUERY PLAN                                                                   
+-----------------------------------------------------------------------------------------------------------------------------------------------
+ Custom Scan (ChunkAppend) on metrics_timestamptz
+   Order: metrics_timestamptz."time"
+   ->  Index Scan Backward using _hyper_6_163_chunk_metrics_timestamptz_time_idx on _hyper_6_163_chunk
+         Index Cond: ("time" >= 'Tue Jan 25 00:00:00 2000 PST'::timestamp with time zone)
+         Filter: (time_bucket('@ 7 days'::interval, "time", '@ 3 days'::interval) >= 'Tue Jan 25 00:00:00 2000 PST'::timestamp with time zone)
+   ->  Index Scan Backward using _hyper_6_164_chunk_metrics_timestamptz_time_idx on _hyper_6_164_chunk
+         Index Cond: ("time" >= 'Tue Jan 25 00:00:00 2000 PST'::timestamp with time zone)
+         Filter: (time_bucket('@ 7 days'::interval, "time", '@ 3 days'::interval) >= 'Tue Jan 25 00:00:00 2000 PST'::timestamp with time zone)
+(8 rows)
+
+:PREFIX SELECT * FROM metrics_timestamptz WHERE time_bucket('7d',time,'2000-01-10'::timestamptz) < '2000-01-05' ORDER BY time;
+                                                                                    QUERY PLAN                                                                                    
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Custom Scan (ChunkAppend) on metrics_timestamptz
+   Order: metrics_timestamptz."time"
+   ->  Index Scan Backward using _hyper_6_160_chunk_metrics_timestamptz_time_idx on _hyper_6_160_chunk
+         Index Cond: ("time" < 'Wed Jan 12 00:00:00 2000 PST'::timestamp with time zone)
+         Filter: (time_bucket('@ 7 days'::interval, "time", 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone) < 'Wed Jan 05 00:00:00 2000 PST'::timestamp with time zone)
+   ->  Index Scan Backward using _hyper_6_161_chunk_metrics_timestamptz_time_idx on _hyper_6_161_chunk
+         Index Cond: ("time" < 'Wed Jan 12 00:00:00 2000 PST'::timestamp with time zone)
+         Filter: (time_bucket('@ 7 days'::interval, "time", 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone) < 'Wed Jan 05 00:00:00 2000 PST'::timestamp with time zone)
+(8 rows)
+
+:PREFIX SELECT * FROM metrics_timestamptz WHERE time_bucket('7d',time,'2000-01-10'::timestamptz) <= '2000-01-05' ORDER BY time;
+                                                                                    QUERY PLAN                                                                                     
+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Custom Scan (ChunkAppend) on metrics_timestamptz
+   Order: metrics_timestamptz."time"
+   ->  Index Scan Backward using _hyper_6_160_chunk_metrics_timestamptz_time_idx on _hyper_6_160_chunk
+         Index Cond: ("time" <= 'Wed Jan 12 00:00:00 2000 PST'::timestamp with time zone)
+         Filter: (time_bucket('@ 7 days'::interval, "time", 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone) <= 'Wed Jan 05 00:00:00 2000 PST'::timestamp with time zone)
+   ->  Index Scan Backward using _hyper_6_161_chunk_metrics_timestamptz_time_idx on _hyper_6_161_chunk
+         Index Cond: ("time" <= 'Wed Jan 12 00:00:00 2000 PST'::timestamp with time zone)
+         Filter: (time_bucket('@ 7 days'::interval, "time", 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone) <= 'Wed Jan 05 00:00:00 2000 PST'::timestamp with time zone)
+(8 rows)
+
+:PREFIX SELECT * FROM metrics_timestamptz WHERE time_bucket('7d',time,'2000-01-10'::timestamptz) > '2000-01-25' ORDER BY time;
+                                                                                    QUERY PLAN                                                                                    
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Custom Scan (ChunkAppend) on metrics_timestamptz
+   Order: metrics_timestamptz."time"
+   ->  Index Scan Backward using _hyper_6_163_chunk_metrics_timestamptz_time_idx on _hyper_6_163_chunk
+         Index Cond: ("time" > 'Tue Jan 25 00:00:00 2000 PST'::timestamp with time zone)
+         Filter: (time_bucket('@ 7 days'::interval, "time", 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone) > 'Tue Jan 25 00:00:00 2000 PST'::timestamp with time zone)
+   ->  Index Scan Backward using _hyper_6_164_chunk_metrics_timestamptz_time_idx on _hyper_6_164_chunk
+         Index Cond: ("time" > 'Tue Jan 25 00:00:00 2000 PST'::timestamp with time zone)
+         Filter: (time_bucket('@ 7 days'::interval, "time", 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone) > 'Tue Jan 25 00:00:00 2000 PST'::timestamp with time zone)
+(8 rows)
+
+:PREFIX SELECT * FROM metrics_timestamptz WHERE time_bucket('7d',time,'2000-01-10'::timestamptz) >= '2000-01-25' ORDER BY time;
+                                                                                    QUERY PLAN                                                                                     
+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Custom Scan (ChunkAppend) on metrics_timestamptz
+   Order: metrics_timestamptz."time"
+   ->  Index Scan Backward using _hyper_6_163_chunk_metrics_timestamptz_time_idx on _hyper_6_163_chunk
+         Index Cond: ("time" >= 'Tue Jan 25 00:00:00 2000 PST'::timestamp with time zone)
+         Filter: (time_bucket('@ 7 days'::interval, "time", 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone) >= 'Tue Jan 25 00:00:00 2000 PST'::timestamp with time zone)
+   ->  Index Scan Backward using _hyper_6_164_chunk_metrics_timestamptz_time_idx on _hyper_6_164_chunk
+         Index Cond: ("time" >= 'Tue Jan 25 00:00:00 2000 PST'::timestamp with time zone)
+         Filter: (time_bucket('@ 7 days'::interval, "time", 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone) >= 'Tue Jan 25 00:00:00 2000 PST'::timestamp with time zone)
+(8 rows)
+
+:PREFIX SELECT * FROM metrics_timestamptz WHERE time_bucket('7d',time,'Europe/Berlin') < '2000-01-05' ORDER BY time;
+                                                                                          QUERY PLAN                                                                                           
+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Custom Scan (ChunkAppend) on metrics_timestamptz
+   Order: metrics_timestamptz."time"
+   ->  Index Scan Backward using _hyper_6_160_chunk_metrics_timestamptz_time_idx on _hyper_6_160_chunk
+         Index Cond: ("time" < 'Wed Jan 12 00:00:00 2000 PST'::timestamp with time zone)
+         Filter: (time_bucket('@ 7 days'::interval, "time", 'Europe/Berlin'::text, NULL::timestamp with time zone, NULL::interval) < 'Wed Jan 05 00:00:00 2000 PST'::timestamp with time zone)
+   ->  Index Scan Backward using _hyper_6_161_chunk_metrics_timestamptz_time_idx on _hyper_6_161_chunk
+         Index Cond: ("time" < 'Wed Jan 12 00:00:00 2000 PST'::timestamp with time zone)
+         Filter: (time_bucket('@ 7 days'::interval, "time", 'Europe/Berlin'::text, NULL::timestamp with time zone, NULL::interval) < 'Wed Jan 05 00:00:00 2000 PST'::timestamp with time zone)
+(8 rows)
+
+:PREFIX SELECT * FROM metrics_timestamptz WHERE time_bucket('7d',time,'Europe/Berlin') <= '2000-01-05' ORDER BY time;
+                                                                                           QUERY PLAN                                                                                           
+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Custom Scan (ChunkAppend) on metrics_timestamptz
+   Order: metrics_timestamptz."time"
+   ->  Index Scan Backward using _hyper_6_160_chunk_metrics_timestamptz_time_idx on _hyper_6_160_chunk
+         Index Cond: ("time" <= 'Wed Jan 12 00:00:00 2000 PST'::timestamp with time zone)
+         Filter: (time_bucket('@ 7 days'::interval, "time", 'Europe/Berlin'::text, NULL::timestamp with time zone, NULL::interval) <= 'Wed Jan 05 00:00:00 2000 PST'::timestamp with time zone)
+   ->  Index Scan Backward using _hyper_6_161_chunk_metrics_timestamptz_time_idx on _hyper_6_161_chunk
+         Index Cond: ("time" <= 'Wed Jan 12 00:00:00 2000 PST'::timestamp with time zone)
+         Filter: (time_bucket('@ 7 days'::interval, "time", 'Europe/Berlin'::text, NULL::timestamp with time zone, NULL::interval) <= 'Wed Jan 05 00:00:00 2000 PST'::timestamp with time zone)
+(8 rows)
+
+:PREFIX SELECT * FROM metrics_timestamptz WHERE time_bucket('7d',time,'Europe/Berlin') > '2000-01-25' ORDER BY time;
+                                                                                          QUERY PLAN                                                                                           
+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Custom Scan (ChunkAppend) on metrics_timestamptz
+   Order: metrics_timestamptz."time"
+   ->  Index Scan Backward using _hyper_6_163_chunk_metrics_timestamptz_time_idx on _hyper_6_163_chunk
+         Index Cond: ("time" > 'Tue Jan 25 00:00:00 2000 PST'::timestamp with time zone)
+         Filter: (time_bucket('@ 7 days'::interval, "time", 'Europe/Berlin'::text, NULL::timestamp with time zone, NULL::interval) > 'Tue Jan 25 00:00:00 2000 PST'::timestamp with time zone)
+   ->  Index Scan Backward using _hyper_6_164_chunk_metrics_timestamptz_time_idx on _hyper_6_164_chunk
+         Index Cond: ("time" > 'Tue Jan 25 00:00:00 2000 PST'::timestamp with time zone)
+         Filter: (time_bucket('@ 7 days'::interval, "time", 'Europe/Berlin'::text, NULL::timestamp with time zone, NULL::interval) > 'Tue Jan 25 00:00:00 2000 PST'::timestamp with time zone)
+(8 rows)
+
+:PREFIX SELECT * FROM metrics_timestamptz WHERE time_bucket('7d',time,'Europe/Berlin') >= '2000-01-25' ORDER BY time;
+                                                                                           QUERY PLAN                                                                                           
+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Custom Scan (ChunkAppend) on metrics_timestamptz
+   Order: metrics_timestamptz."time"
+   ->  Index Scan Backward using _hyper_6_163_chunk_metrics_timestamptz_time_idx on _hyper_6_163_chunk
+         Index Cond: ("time" >= 'Tue Jan 25 00:00:00 2000 PST'::timestamp with time zone)
+         Filter: (time_bucket('@ 7 days'::interval, "time", 'Europe/Berlin'::text, NULL::timestamp with time zone, NULL::interval) >= 'Tue Jan 25 00:00:00 2000 PST'::timestamp with time zone)
+   ->  Index Scan Backward using _hyper_6_164_chunk_metrics_timestamptz_time_idx on _hyper_6_164_chunk
+         Index Cond: ("time" >= 'Tue Jan 25 00:00:00 2000 PST'::timestamp with time zone)
+         Filter: (time_bucket('@ 7 days'::interval, "time", 'Europe/Berlin'::text, NULL::timestamp with time zone, NULL::interval) >= 'Tue Jan 25 00:00:00 2000 PST'::timestamp with time zone)
+(8 rows)
+
 \qecho test overflow behaviour of time_bucket exclusion
 test overflow behaviour of time_bucket exclusion
 :PREFIX SELECT * FROM hyper WHERE time > 950 AND time_bucket(10, time) < '9223372036854775807'::bigint ORDER BY time;

--- a/test/expected/plan_expand_hypertable-16.out
+++ b/test/expected/plan_expand_hypertable-16.out
@@ -1113,6 +1113,455 @@ time_bucket exclusion
                Filter: (("time" < '21'::bigint) AND ('11'::bigint > time_bucket('10'::bigint, "time")))
 (9 rows)
 
+:PREFIX SELECT * FROM hyper WHERE time_bucket(10, time, 5) < 10::bigint ORDER BY time;
+                                                     QUERY PLAN                                                      
+---------------------------------------------------------------------------------------------------------------------
+ Sort
+   Sort Key: _hyper_1_1_chunk."time"
+   ->  Append
+         ->  Seq Scan on _hyper_1_1_chunk
+               Filter: (("time" < '20'::bigint) AND (time_bucket('10'::bigint, "time", '5'::bigint) < '10'::bigint))
+         ->  Seq Scan on _hyper_1_2_chunk
+               Filter: (("time" < '20'::bigint) AND (time_bucket('10'::bigint, "time", '5'::bigint) < '10'::bigint))
+(7 rows)
+
+:PREFIX SELECT * FROM hyper WHERE time_bucket(10, time, 5) < 11::bigint ORDER BY time;
+                                                     QUERY PLAN                                                      
+---------------------------------------------------------------------------------------------------------------------
+ Sort
+   Sort Key: _hyper_1_1_chunk."time"
+   ->  Append
+         ->  Seq Scan on _hyper_1_1_chunk
+               Filter: (("time" < '21'::bigint) AND (time_bucket('10'::bigint, "time", '5'::bigint) < '11'::bigint))
+         ->  Seq Scan on _hyper_1_2_chunk
+               Filter: (("time" < '21'::bigint) AND (time_bucket('10'::bigint, "time", '5'::bigint) < '11'::bigint))
+         ->  Seq Scan on _hyper_1_3_chunk
+               Filter: (("time" < '21'::bigint) AND (time_bucket('10'::bigint, "time", '5'::bigint) < '11'::bigint))
+(9 rows)
+
+:PREFIX SELECT * FROM hyper WHERE time_bucket(10, time, 5) <= 10::bigint ORDER BY time;
+                                                      QUERY PLAN                                                       
+-----------------------------------------------------------------------------------------------------------------------
+ Sort
+   Sort Key: _hyper_1_1_chunk."time"
+   ->  Append
+         ->  Seq Scan on _hyper_1_1_chunk
+               Filter: (("time" <= '20'::bigint) AND (time_bucket('10'::bigint, "time", '5'::bigint) <= '10'::bigint))
+         ->  Seq Scan on _hyper_1_2_chunk
+               Filter: (("time" <= '20'::bigint) AND (time_bucket('10'::bigint, "time", '5'::bigint) <= '10'::bigint))
+         ->  Seq Scan on _hyper_1_3_chunk
+               Filter: (("time" <= '20'::bigint) AND (time_bucket('10'::bigint, "time", '5'::bigint) <= '10'::bigint))
+(9 rows)
+
+:PREFIX SELECT * FROM hyper WHERE 10::bigint > time_bucket(10, time, 5) ORDER BY time;
+                                                     QUERY PLAN                                                      
+---------------------------------------------------------------------------------------------------------------------
+ Sort
+   Sort Key: _hyper_1_1_chunk."time"
+   ->  Append
+         ->  Seq Scan on _hyper_1_1_chunk
+               Filter: (("time" < '20'::bigint) AND ('10'::bigint > time_bucket('10'::bigint, "time", '5'::bigint)))
+         ->  Seq Scan on _hyper_1_2_chunk
+               Filter: (("time" < '20'::bigint) AND ('10'::bigint > time_bucket('10'::bigint, "time", '5'::bigint)))
+(7 rows)
+
+:PREFIX SELECT * FROM hyper WHERE 11::bigint > time_bucket(10, time, 5) ORDER BY time;
+                                                     QUERY PLAN                                                      
+---------------------------------------------------------------------------------------------------------------------
+ Sort
+   Sort Key: _hyper_1_1_chunk."time"
+   ->  Append
+         ->  Seq Scan on _hyper_1_1_chunk
+               Filter: (("time" < '21'::bigint) AND ('11'::bigint > time_bucket('10'::bigint, "time", '5'::bigint)))
+         ->  Seq Scan on _hyper_1_2_chunk
+               Filter: (("time" < '21'::bigint) AND ('11'::bigint > time_bucket('10'::bigint, "time", '5'::bigint)))
+         ->  Seq Scan on _hyper_1_3_chunk
+               Filter: (("time" < '21'::bigint) AND ('11'::bigint > time_bucket('10'::bigint, "time", '5'::bigint)))
+(9 rows)
+
+\qecho timestamp time_bucket exclusion
+timestamp time_bucket exclusion
+SELECT count(DISTINCT tableoid) FROM metrics_timestamp;
+ count 
+-------
+     5
+(1 row)
+
+:PREFIX SELECT * FROM metrics_timestamp WHERE time_bucket('7d',time) < '2000-01-05' ORDER BY time;
+                                                      QUERY PLAN                                                       
+-----------------------------------------------------------------------------------------------------------------------
+ Custom Scan (ChunkAppend) on metrics_timestamp
+   Order: metrics_timestamp."time"
+   ->  Index Only Scan Backward using _hyper_5_155_chunk_metrics_timestamp_time_idx on _hyper_5_155_chunk
+         Index Cond: ("time" < 'Wed Jan 12 00:00:00 2000'::timestamp without time zone)
+         Filter: (time_bucket('@ 7 days'::interval, "time") < 'Wed Jan 05 00:00:00 2000'::timestamp without time zone)
+   ->  Index Only Scan Backward using _hyper_5_156_chunk_metrics_timestamp_time_idx on _hyper_5_156_chunk
+         Index Cond: ("time" < 'Wed Jan 12 00:00:00 2000'::timestamp without time zone)
+         Filter: (time_bucket('@ 7 days'::interval, "time") < 'Wed Jan 05 00:00:00 2000'::timestamp without time zone)
+(8 rows)
+
+:PREFIX SELECT * FROM metrics_timestamp WHERE time_bucket('7d',time) <= '2000-01-05' ORDER BY time;
+                                                       QUERY PLAN                                                       
+------------------------------------------------------------------------------------------------------------------------
+ Custom Scan (ChunkAppend) on metrics_timestamp
+   Order: metrics_timestamp."time"
+   ->  Index Only Scan Backward using _hyper_5_155_chunk_metrics_timestamp_time_idx on _hyper_5_155_chunk
+         Index Cond: ("time" <= 'Wed Jan 12 00:00:00 2000'::timestamp without time zone)
+         Filter: (time_bucket('@ 7 days'::interval, "time") <= 'Wed Jan 05 00:00:00 2000'::timestamp without time zone)
+   ->  Index Only Scan Backward using _hyper_5_156_chunk_metrics_timestamp_time_idx on _hyper_5_156_chunk
+         Index Cond: ("time" <= 'Wed Jan 12 00:00:00 2000'::timestamp without time zone)
+         Filter: (time_bucket('@ 7 days'::interval, "time") <= 'Wed Jan 05 00:00:00 2000'::timestamp without time zone)
+(8 rows)
+
+:PREFIX SELECT * FROM metrics_timestamp WHERE time_bucket('7d',time) > '2000-01-25' ORDER BY time;
+                                                      QUERY PLAN                                                       
+-----------------------------------------------------------------------------------------------------------------------
+ Custom Scan (ChunkAppend) on metrics_timestamp
+   Order: metrics_timestamp."time"
+   ->  Index Only Scan Backward using _hyper_5_158_chunk_metrics_timestamp_time_idx on _hyper_5_158_chunk
+         Index Cond: ("time" > 'Tue Jan 25 00:00:00 2000'::timestamp without time zone)
+         Filter: (time_bucket('@ 7 days'::interval, "time") > 'Tue Jan 25 00:00:00 2000'::timestamp without time zone)
+   ->  Index Only Scan Backward using _hyper_5_159_chunk_metrics_timestamp_time_idx on _hyper_5_159_chunk
+         Index Cond: ("time" > 'Tue Jan 25 00:00:00 2000'::timestamp without time zone)
+         Filter: (time_bucket('@ 7 days'::interval, "time") > 'Tue Jan 25 00:00:00 2000'::timestamp without time zone)
+(8 rows)
+
+:PREFIX SELECT * FROM metrics_timestamp WHERE time_bucket('7d',time) >= '2000-01-15' ORDER BY time;
+                                                       QUERY PLAN                                                       
+------------------------------------------------------------------------------------------------------------------------
+ Custom Scan (ChunkAppend) on metrics_timestamp
+   Order: metrics_timestamp."time"
+   ->  Index Only Scan Backward using _hyper_5_157_chunk_metrics_timestamp_time_idx on _hyper_5_157_chunk
+         Index Cond: ("time" >= 'Sat Jan 15 00:00:00 2000'::timestamp without time zone)
+         Filter: (time_bucket('@ 7 days'::interval, "time") >= 'Sat Jan 15 00:00:00 2000'::timestamp without time zone)
+   ->  Index Only Scan Backward using _hyper_5_158_chunk_metrics_timestamp_time_idx on _hyper_5_158_chunk
+         Index Cond: ("time" >= 'Sat Jan 15 00:00:00 2000'::timestamp without time zone)
+         Filter: (time_bucket('@ 7 days'::interval, "time") >= 'Sat Jan 15 00:00:00 2000'::timestamp without time zone)
+   ->  Index Only Scan Backward using _hyper_5_159_chunk_metrics_timestamp_time_idx on _hyper_5_159_chunk
+         Index Cond: ("time" >= 'Sat Jan 15 00:00:00 2000'::timestamp without time zone)
+         Filter: (time_bucket('@ 7 days'::interval, "time") >= 'Sat Jan 15 00:00:00 2000'::timestamp without time zone)
+(11 rows)
+
+:PREFIX SELECT * FROM metrics_timestamp WHERE time_bucket('7d',time,'3d'::interval) < '2000-01-05' ORDER BY time;
+                                                                 QUERY PLAN                                                                  
+---------------------------------------------------------------------------------------------------------------------------------------------
+ Custom Scan (ChunkAppend) on metrics_timestamp
+   Order: metrics_timestamp."time"
+   ->  Index Only Scan Backward using _hyper_5_155_chunk_metrics_timestamp_time_idx on _hyper_5_155_chunk
+         Index Cond: ("time" < 'Wed Jan 12 00:00:00 2000'::timestamp without time zone)
+         Filter: (time_bucket('@ 7 days'::interval, "time", '@ 3 days'::interval) < 'Wed Jan 05 00:00:00 2000'::timestamp without time zone)
+   ->  Index Only Scan Backward using _hyper_5_156_chunk_metrics_timestamp_time_idx on _hyper_5_156_chunk
+         Index Cond: ("time" < 'Wed Jan 12 00:00:00 2000'::timestamp without time zone)
+         Filter: (time_bucket('@ 7 days'::interval, "time", '@ 3 days'::interval) < 'Wed Jan 05 00:00:00 2000'::timestamp without time zone)
+(8 rows)
+
+:PREFIX SELECT * FROM metrics_timestamp WHERE time_bucket('7d',time,'3d'::interval) <= '2000-01-05' ORDER BY time;
+                                                                  QUERY PLAN                                                                  
+----------------------------------------------------------------------------------------------------------------------------------------------
+ Custom Scan (ChunkAppend) on metrics_timestamp
+   Order: metrics_timestamp."time"
+   ->  Index Only Scan Backward using _hyper_5_155_chunk_metrics_timestamp_time_idx on _hyper_5_155_chunk
+         Index Cond: ("time" <= 'Wed Jan 12 00:00:00 2000'::timestamp without time zone)
+         Filter: (time_bucket('@ 7 days'::interval, "time", '@ 3 days'::interval) <= 'Wed Jan 05 00:00:00 2000'::timestamp without time zone)
+   ->  Index Only Scan Backward using _hyper_5_156_chunk_metrics_timestamp_time_idx on _hyper_5_156_chunk
+         Index Cond: ("time" <= 'Wed Jan 12 00:00:00 2000'::timestamp without time zone)
+         Filter: (time_bucket('@ 7 days'::interval, "time", '@ 3 days'::interval) <= 'Wed Jan 05 00:00:00 2000'::timestamp without time zone)
+(8 rows)
+
+:PREFIX SELECT * FROM metrics_timestamp WHERE time_bucket('7d',time,'3d'::interval) > '2000-01-25' ORDER BY time;
+                                                                 QUERY PLAN                                                                  
+---------------------------------------------------------------------------------------------------------------------------------------------
+ Custom Scan (ChunkAppend) on metrics_timestamp
+   Order: metrics_timestamp."time"
+   ->  Index Only Scan Backward using _hyper_5_158_chunk_metrics_timestamp_time_idx on _hyper_5_158_chunk
+         Index Cond: ("time" > 'Tue Jan 25 00:00:00 2000'::timestamp without time zone)
+         Filter: (time_bucket('@ 7 days'::interval, "time", '@ 3 days'::interval) > 'Tue Jan 25 00:00:00 2000'::timestamp without time zone)
+   ->  Index Only Scan Backward using _hyper_5_159_chunk_metrics_timestamp_time_idx on _hyper_5_159_chunk
+         Index Cond: ("time" > 'Tue Jan 25 00:00:00 2000'::timestamp without time zone)
+         Filter: (time_bucket('@ 7 days'::interval, "time", '@ 3 days'::interval) > 'Tue Jan 25 00:00:00 2000'::timestamp without time zone)
+(8 rows)
+
+:PREFIX SELECT * FROM metrics_timestamp WHERE time_bucket('7d',time,'3d'::interval) >= '2000-01-25' ORDER BY time;
+                                                                  QUERY PLAN                                                                  
+----------------------------------------------------------------------------------------------------------------------------------------------
+ Custom Scan (ChunkAppend) on metrics_timestamp
+   Order: metrics_timestamp."time"
+   ->  Index Only Scan Backward using _hyper_5_158_chunk_metrics_timestamp_time_idx on _hyper_5_158_chunk
+         Index Cond: ("time" >= 'Tue Jan 25 00:00:00 2000'::timestamp without time zone)
+         Filter: (time_bucket('@ 7 days'::interval, "time", '@ 3 days'::interval) >= 'Tue Jan 25 00:00:00 2000'::timestamp without time zone)
+   ->  Index Only Scan Backward using _hyper_5_159_chunk_metrics_timestamp_time_idx on _hyper_5_159_chunk
+         Index Cond: ("time" >= 'Tue Jan 25 00:00:00 2000'::timestamp without time zone)
+         Filter: (time_bucket('@ 7 days'::interval, "time", '@ 3 days'::interval) >= 'Tue Jan 25 00:00:00 2000'::timestamp without time zone)
+(8 rows)
+
+:PREFIX SELECT * FROM metrics_timestamp WHERE time_bucket('7d',time,'2000-01-10'::timestamp) < '2000-01-05' ORDER BY time;
+                                                                                   QUERY PLAN                                                                                   
+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Custom Scan (ChunkAppend) on metrics_timestamp
+   Order: metrics_timestamp."time"
+   ->  Index Only Scan Backward using _hyper_5_155_chunk_metrics_timestamp_time_idx on _hyper_5_155_chunk
+         Index Cond: ("time" < 'Wed Jan 12 00:00:00 2000'::timestamp without time zone)
+         Filter: (time_bucket('@ 7 days'::interval, "time", 'Mon Jan 10 00:00:00 2000'::timestamp without time zone) < 'Wed Jan 05 00:00:00 2000'::timestamp without time zone)
+   ->  Index Only Scan Backward using _hyper_5_156_chunk_metrics_timestamp_time_idx on _hyper_5_156_chunk
+         Index Cond: ("time" < 'Wed Jan 12 00:00:00 2000'::timestamp without time zone)
+         Filter: (time_bucket('@ 7 days'::interval, "time", 'Mon Jan 10 00:00:00 2000'::timestamp without time zone) < 'Wed Jan 05 00:00:00 2000'::timestamp without time zone)
+(8 rows)
+
+:PREFIX SELECT * FROM metrics_timestamp WHERE time_bucket('7d',time,'2000-01-10'::timestamp) <= '2000-01-05' ORDER BY time;
+                                                                                   QUERY PLAN                                                                                    
+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Custom Scan (ChunkAppend) on metrics_timestamp
+   Order: metrics_timestamp."time"
+   ->  Index Only Scan Backward using _hyper_5_155_chunk_metrics_timestamp_time_idx on _hyper_5_155_chunk
+         Index Cond: ("time" <= 'Wed Jan 12 00:00:00 2000'::timestamp without time zone)
+         Filter: (time_bucket('@ 7 days'::interval, "time", 'Mon Jan 10 00:00:00 2000'::timestamp without time zone) <= 'Wed Jan 05 00:00:00 2000'::timestamp without time zone)
+   ->  Index Only Scan Backward using _hyper_5_156_chunk_metrics_timestamp_time_idx on _hyper_5_156_chunk
+         Index Cond: ("time" <= 'Wed Jan 12 00:00:00 2000'::timestamp without time zone)
+         Filter: (time_bucket('@ 7 days'::interval, "time", 'Mon Jan 10 00:00:00 2000'::timestamp without time zone) <= 'Wed Jan 05 00:00:00 2000'::timestamp without time zone)
+(8 rows)
+
+:PREFIX SELECT * FROM metrics_timestamp WHERE time_bucket('7d',time,'2000-01-10'::timestamp) > '2000-01-25' ORDER BY time;
+                                                                                   QUERY PLAN                                                                                   
+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Custom Scan (ChunkAppend) on metrics_timestamp
+   Order: metrics_timestamp."time"
+   ->  Index Only Scan Backward using _hyper_5_158_chunk_metrics_timestamp_time_idx on _hyper_5_158_chunk
+         Index Cond: ("time" > 'Tue Jan 25 00:00:00 2000'::timestamp without time zone)
+         Filter: (time_bucket('@ 7 days'::interval, "time", 'Mon Jan 10 00:00:00 2000'::timestamp without time zone) > 'Tue Jan 25 00:00:00 2000'::timestamp without time zone)
+   ->  Index Only Scan Backward using _hyper_5_159_chunk_metrics_timestamp_time_idx on _hyper_5_159_chunk
+         Index Cond: ("time" > 'Tue Jan 25 00:00:00 2000'::timestamp without time zone)
+         Filter: (time_bucket('@ 7 days'::interval, "time", 'Mon Jan 10 00:00:00 2000'::timestamp without time zone) > 'Tue Jan 25 00:00:00 2000'::timestamp without time zone)
+(8 rows)
+
+:PREFIX SELECT * FROM metrics_timestamp WHERE time_bucket('7d',time,'2000-01-10'::timestamp) >= '2000-01-25' ORDER BY time;
+                                                                                   QUERY PLAN                                                                                    
+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Custom Scan (ChunkAppend) on metrics_timestamp
+   Order: metrics_timestamp."time"
+   ->  Index Only Scan Backward using _hyper_5_158_chunk_metrics_timestamp_time_idx on _hyper_5_158_chunk
+         Index Cond: ("time" >= 'Tue Jan 25 00:00:00 2000'::timestamp without time zone)
+         Filter: (time_bucket('@ 7 days'::interval, "time", 'Mon Jan 10 00:00:00 2000'::timestamp without time zone) >= 'Tue Jan 25 00:00:00 2000'::timestamp without time zone)
+   ->  Index Only Scan Backward using _hyper_5_159_chunk_metrics_timestamp_time_idx on _hyper_5_159_chunk
+         Index Cond: ("time" >= 'Tue Jan 25 00:00:00 2000'::timestamp without time zone)
+         Filter: (time_bucket('@ 7 days'::interval, "time", 'Mon Jan 10 00:00:00 2000'::timestamp without time zone) >= 'Tue Jan 25 00:00:00 2000'::timestamp without time zone)
+(8 rows)
+
+\qecho timestamptz time_bucket exclusion
+timestamptz time_bucket exclusion
+SELECT count(DISTINCT tableoid) FROM metrics_timestamptz;
+ count 
+-------
+     5
+(1 row)
+
+:PREFIX SELECT * FROM metrics_timestamptz WHERE time_bucket('7d',time) < '2000-01-05' ORDER BY time;
+                                                       QUERY PLAN                                                       
+------------------------------------------------------------------------------------------------------------------------
+ Custom Scan (ChunkAppend) on metrics_timestamptz
+   Order: metrics_timestamptz."time"
+   ->  Index Scan Backward using _hyper_6_160_chunk_metrics_timestamptz_time_idx on _hyper_6_160_chunk
+         Index Cond: ("time" < 'Wed Jan 12 00:00:00 2000 PST'::timestamp with time zone)
+         Filter: (time_bucket('@ 7 days'::interval, "time") < 'Wed Jan 05 00:00:00 2000 PST'::timestamp with time zone)
+   ->  Index Scan Backward using _hyper_6_161_chunk_metrics_timestamptz_time_idx on _hyper_6_161_chunk
+         Index Cond: ("time" < 'Wed Jan 12 00:00:00 2000 PST'::timestamp with time zone)
+         Filter: (time_bucket('@ 7 days'::interval, "time") < 'Wed Jan 05 00:00:00 2000 PST'::timestamp with time zone)
+(8 rows)
+
+:PREFIX SELECT * FROM metrics_timestamptz WHERE time_bucket('7d',time) <= '2000-01-05' ORDER BY time;
+                                                       QUERY PLAN                                                        
+-------------------------------------------------------------------------------------------------------------------------
+ Custom Scan (ChunkAppend) on metrics_timestamptz
+   Order: metrics_timestamptz."time"
+   ->  Index Scan Backward using _hyper_6_160_chunk_metrics_timestamptz_time_idx on _hyper_6_160_chunk
+         Index Cond: ("time" <= 'Wed Jan 12 00:00:00 2000 PST'::timestamp with time zone)
+         Filter: (time_bucket('@ 7 days'::interval, "time") <= 'Wed Jan 05 00:00:00 2000 PST'::timestamp with time zone)
+   ->  Index Scan Backward using _hyper_6_161_chunk_metrics_timestamptz_time_idx on _hyper_6_161_chunk
+         Index Cond: ("time" <= 'Wed Jan 12 00:00:00 2000 PST'::timestamp with time zone)
+         Filter: (time_bucket('@ 7 days'::interval, "time") <= 'Wed Jan 05 00:00:00 2000 PST'::timestamp with time zone)
+(8 rows)
+
+:PREFIX SELECT * FROM metrics_timestamptz WHERE time_bucket('7d',time) > '2000-01-25' ORDER BY time;
+                                                       QUERY PLAN                                                       
+------------------------------------------------------------------------------------------------------------------------
+ Custom Scan (ChunkAppend) on metrics_timestamptz
+   Order: metrics_timestamptz."time"
+   ->  Index Scan Backward using _hyper_6_163_chunk_metrics_timestamptz_time_idx on _hyper_6_163_chunk
+         Index Cond: ("time" > 'Tue Jan 25 00:00:00 2000 PST'::timestamp with time zone)
+         Filter: (time_bucket('@ 7 days'::interval, "time") > 'Tue Jan 25 00:00:00 2000 PST'::timestamp with time zone)
+   ->  Index Scan Backward using _hyper_6_164_chunk_metrics_timestamptz_time_idx on _hyper_6_164_chunk
+         Index Cond: ("time" > 'Tue Jan 25 00:00:00 2000 PST'::timestamp with time zone)
+         Filter: (time_bucket('@ 7 days'::interval, "time") > 'Tue Jan 25 00:00:00 2000 PST'::timestamp with time zone)
+(8 rows)
+
+:PREFIX SELECT * FROM metrics_timestamptz WHERE time_bucket('7d',time) >= '2000-01-25' ORDER BY time;
+                                                       QUERY PLAN                                                        
+-------------------------------------------------------------------------------------------------------------------------
+ Custom Scan (ChunkAppend) on metrics_timestamptz
+   Order: metrics_timestamptz."time"
+   ->  Index Scan Backward using _hyper_6_163_chunk_metrics_timestamptz_time_idx on _hyper_6_163_chunk
+         Index Cond: ("time" >= 'Tue Jan 25 00:00:00 2000 PST'::timestamp with time zone)
+         Filter: (time_bucket('@ 7 days'::interval, "time") >= 'Tue Jan 25 00:00:00 2000 PST'::timestamp with time zone)
+   ->  Index Scan Backward using _hyper_6_164_chunk_metrics_timestamptz_time_idx on _hyper_6_164_chunk
+         Index Cond: ("time" >= 'Tue Jan 25 00:00:00 2000 PST'::timestamp with time zone)
+         Filter: (time_bucket('@ 7 days'::interval, "time") >= 'Tue Jan 25 00:00:00 2000 PST'::timestamp with time zone)
+(8 rows)
+
+:PREFIX SELECT * FROM metrics_timestamptz WHERE time_bucket('7d',time,'3d'::interval) < '2000-01-05' ORDER BY time;
+                                                                  QUERY PLAN                                                                  
+----------------------------------------------------------------------------------------------------------------------------------------------
+ Custom Scan (ChunkAppend) on metrics_timestamptz
+   Order: metrics_timestamptz."time"
+   ->  Index Scan Backward using _hyper_6_160_chunk_metrics_timestamptz_time_idx on _hyper_6_160_chunk
+         Index Cond: ("time" < 'Wed Jan 12 00:00:00 2000 PST'::timestamp with time zone)
+         Filter: (time_bucket('@ 7 days'::interval, "time", '@ 3 days'::interval) < 'Wed Jan 05 00:00:00 2000 PST'::timestamp with time zone)
+   ->  Index Scan Backward using _hyper_6_161_chunk_metrics_timestamptz_time_idx on _hyper_6_161_chunk
+         Index Cond: ("time" < 'Wed Jan 12 00:00:00 2000 PST'::timestamp with time zone)
+         Filter: (time_bucket('@ 7 days'::interval, "time", '@ 3 days'::interval) < 'Wed Jan 05 00:00:00 2000 PST'::timestamp with time zone)
+(8 rows)
+
+:PREFIX SELECT * FROM metrics_timestamptz WHERE time_bucket('7d',time,'3d'::interval) <= '2000-01-05' ORDER BY time;
+                                                                  QUERY PLAN                                                                   
+-----------------------------------------------------------------------------------------------------------------------------------------------
+ Custom Scan (ChunkAppend) on metrics_timestamptz
+   Order: metrics_timestamptz."time"
+   ->  Index Scan Backward using _hyper_6_160_chunk_metrics_timestamptz_time_idx on _hyper_6_160_chunk
+         Index Cond: ("time" <= 'Wed Jan 12 00:00:00 2000 PST'::timestamp with time zone)
+         Filter: (time_bucket('@ 7 days'::interval, "time", '@ 3 days'::interval) <= 'Wed Jan 05 00:00:00 2000 PST'::timestamp with time zone)
+   ->  Index Scan Backward using _hyper_6_161_chunk_metrics_timestamptz_time_idx on _hyper_6_161_chunk
+         Index Cond: ("time" <= 'Wed Jan 12 00:00:00 2000 PST'::timestamp with time zone)
+         Filter: (time_bucket('@ 7 days'::interval, "time", '@ 3 days'::interval) <= 'Wed Jan 05 00:00:00 2000 PST'::timestamp with time zone)
+(8 rows)
+
+:PREFIX SELECT * FROM metrics_timestamptz WHERE time_bucket('7d',time,'3d'::interval) > '2000-01-25' ORDER BY time;
+                                                                  QUERY PLAN                                                                  
+----------------------------------------------------------------------------------------------------------------------------------------------
+ Custom Scan (ChunkAppend) on metrics_timestamptz
+   Order: metrics_timestamptz."time"
+   ->  Index Scan Backward using _hyper_6_163_chunk_metrics_timestamptz_time_idx on _hyper_6_163_chunk
+         Index Cond: ("time" > 'Tue Jan 25 00:00:00 2000 PST'::timestamp with time zone)
+         Filter: (time_bucket('@ 7 days'::interval, "time", '@ 3 days'::interval) > 'Tue Jan 25 00:00:00 2000 PST'::timestamp with time zone)
+   ->  Index Scan Backward using _hyper_6_164_chunk_metrics_timestamptz_time_idx on _hyper_6_164_chunk
+         Index Cond: ("time" > 'Tue Jan 25 00:00:00 2000 PST'::timestamp with time zone)
+         Filter: (time_bucket('@ 7 days'::interval, "time", '@ 3 days'::interval) > 'Tue Jan 25 00:00:00 2000 PST'::timestamp with time zone)
+(8 rows)
+
+:PREFIX SELECT * FROM metrics_timestamptz WHERE time_bucket('7d',time,'3d'::interval) >= '2000-01-25' ORDER BY time;
+                                                                  QUERY PLAN                                                                   
+-----------------------------------------------------------------------------------------------------------------------------------------------
+ Custom Scan (ChunkAppend) on metrics_timestamptz
+   Order: metrics_timestamptz."time"
+   ->  Index Scan Backward using _hyper_6_163_chunk_metrics_timestamptz_time_idx on _hyper_6_163_chunk
+         Index Cond: ("time" >= 'Tue Jan 25 00:00:00 2000 PST'::timestamp with time zone)
+         Filter: (time_bucket('@ 7 days'::interval, "time", '@ 3 days'::interval) >= 'Tue Jan 25 00:00:00 2000 PST'::timestamp with time zone)
+   ->  Index Scan Backward using _hyper_6_164_chunk_metrics_timestamptz_time_idx on _hyper_6_164_chunk
+         Index Cond: ("time" >= 'Tue Jan 25 00:00:00 2000 PST'::timestamp with time zone)
+         Filter: (time_bucket('@ 7 days'::interval, "time", '@ 3 days'::interval) >= 'Tue Jan 25 00:00:00 2000 PST'::timestamp with time zone)
+(8 rows)
+
+:PREFIX SELECT * FROM metrics_timestamptz WHERE time_bucket('7d',time,'2000-01-10'::timestamptz) < '2000-01-05' ORDER BY time;
+                                                                                    QUERY PLAN                                                                                    
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Custom Scan (ChunkAppend) on metrics_timestamptz
+   Order: metrics_timestamptz."time"
+   ->  Index Scan Backward using _hyper_6_160_chunk_metrics_timestamptz_time_idx on _hyper_6_160_chunk
+         Index Cond: ("time" < 'Wed Jan 12 00:00:00 2000 PST'::timestamp with time zone)
+         Filter: (time_bucket('@ 7 days'::interval, "time", 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone) < 'Wed Jan 05 00:00:00 2000 PST'::timestamp with time zone)
+   ->  Index Scan Backward using _hyper_6_161_chunk_metrics_timestamptz_time_idx on _hyper_6_161_chunk
+         Index Cond: ("time" < 'Wed Jan 12 00:00:00 2000 PST'::timestamp with time zone)
+         Filter: (time_bucket('@ 7 days'::interval, "time", 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone) < 'Wed Jan 05 00:00:00 2000 PST'::timestamp with time zone)
+(8 rows)
+
+:PREFIX SELECT * FROM metrics_timestamptz WHERE time_bucket('7d',time,'2000-01-10'::timestamptz) <= '2000-01-05' ORDER BY time;
+                                                                                    QUERY PLAN                                                                                     
+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Custom Scan (ChunkAppend) on metrics_timestamptz
+   Order: metrics_timestamptz."time"
+   ->  Index Scan Backward using _hyper_6_160_chunk_metrics_timestamptz_time_idx on _hyper_6_160_chunk
+         Index Cond: ("time" <= 'Wed Jan 12 00:00:00 2000 PST'::timestamp with time zone)
+         Filter: (time_bucket('@ 7 days'::interval, "time", 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone) <= 'Wed Jan 05 00:00:00 2000 PST'::timestamp with time zone)
+   ->  Index Scan Backward using _hyper_6_161_chunk_metrics_timestamptz_time_idx on _hyper_6_161_chunk
+         Index Cond: ("time" <= 'Wed Jan 12 00:00:00 2000 PST'::timestamp with time zone)
+         Filter: (time_bucket('@ 7 days'::interval, "time", 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone) <= 'Wed Jan 05 00:00:00 2000 PST'::timestamp with time zone)
+(8 rows)
+
+:PREFIX SELECT * FROM metrics_timestamptz WHERE time_bucket('7d',time,'2000-01-10'::timestamptz) > '2000-01-25' ORDER BY time;
+                                                                                    QUERY PLAN                                                                                    
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Custom Scan (ChunkAppend) on metrics_timestamptz
+   Order: metrics_timestamptz."time"
+   ->  Index Scan Backward using _hyper_6_163_chunk_metrics_timestamptz_time_idx on _hyper_6_163_chunk
+         Index Cond: ("time" > 'Tue Jan 25 00:00:00 2000 PST'::timestamp with time zone)
+         Filter: (time_bucket('@ 7 days'::interval, "time", 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone) > 'Tue Jan 25 00:00:00 2000 PST'::timestamp with time zone)
+   ->  Index Scan Backward using _hyper_6_164_chunk_metrics_timestamptz_time_idx on _hyper_6_164_chunk
+         Index Cond: ("time" > 'Tue Jan 25 00:00:00 2000 PST'::timestamp with time zone)
+         Filter: (time_bucket('@ 7 days'::interval, "time", 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone) > 'Tue Jan 25 00:00:00 2000 PST'::timestamp with time zone)
+(8 rows)
+
+:PREFIX SELECT * FROM metrics_timestamptz WHERE time_bucket('7d',time,'2000-01-10'::timestamptz) >= '2000-01-25' ORDER BY time;
+                                                                                    QUERY PLAN                                                                                     
+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Custom Scan (ChunkAppend) on metrics_timestamptz
+   Order: metrics_timestamptz."time"
+   ->  Index Scan Backward using _hyper_6_163_chunk_metrics_timestamptz_time_idx on _hyper_6_163_chunk
+         Index Cond: ("time" >= 'Tue Jan 25 00:00:00 2000 PST'::timestamp with time zone)
+         Filter: (time_bucket('@ 7 days'::interval, "time", 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone) >= 'Tue Jan 25 00:00:00 2000 PST'::timestamp with time zone)
+   ->  Index Scan Backward using _hyper_6_164_chunk_metrics_timestamptz_time_idx on _hyper_6_164_chunk
+         Index Cond: ("time" >= 'Tue Jan 25 00:00:00 2000 PST'::timestamp with time zone)
+         Filter: (time_bucket('@ 7 days'::interval, "time", 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone) >= 'Tue Jan 25 00:00:00 2000 PST'::timestamp with time zone)
+(8 rows)
+
+:PREFIX SELECT * FROM metrics_timestamptz WHERE time_bucket('7d',time,'Europe/Berlin') < '2000-01-05' ORDER BY time;
+                                                                                          QUERY PLAN                                                                                           
+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Custom Scan (ChunkAppend) on metrics_timestamptz
+   Order: metrics_timestamptz."time"
+   ->  Index Scan Backward using _hyper_6_160_chunk_metrics_timestamptz_time_idx on _hyper_6_160_chunk
+         Index Cond: ("time" < 'Wed Jan 12 00:00:00 2000 PST'::timestamp with time zone)
+         Filter: (time_bucket('@ 7 days'::interval, "time", 'Europe/Berlin'::text, NULL::timestamp with time zone, NULL::interval) < 'Wed Jan 05 00:00:00 2000 PST'::timestamp with time zone)
+   ->  Index Scan Backward using _hyper_6_161_chunk_metrics_timestamptz_time_idx on _hyper_6_161_chunk
+         Index Cond: ("time" < 'Wed Jan 12 00:00:00 2000 PST'::timestamp with time zone)
+         Filter: (time_bucket('@ 7 days'::interval, "time", 'Europe/Berlin'::text, NULL::timestamp with time zone, NULL::interval) < 'Wed Jan 05 00:00:00 2000 PST'::timestamp with time zone)
+(8 rows)
+
+:PREFIX SELECT * FROM metrics_timestamptz WHERE time_bucket('7d',time,'Europe/Berlin') <= '2000-01-05' ORDER BY time;
+                                                                                           QUERY PLAN                                                                                           
+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Custom Scan (ChunkAppend) on metrics_timestamptz
+   Order: metrics_timestamptz."time"
+   ->  Index Scan Backward using _hyper_6_160_chunk_metrics_timestamptz_time_idx on _hyper_6_160_chunk
+         Index Cond: ("time" <= 'Wed Jan 12 00:00:00 2000 PST'::timestamp with time zone)
+         Filter: (time_bucket('@ 7 days'::interval, "time", 'Europe/Berlin'::text, NULL::timestamp with time zone, NULL::interval) <= 'Wed Jan 05 00:00:00 2000 PST'::timestamp with time zone)
+   ->  Index Scan Backward using _hyper_6_161_chunk_metrics_timestamptz_time_idx on _hyper_6_161_chunk
+         Index Cond: ("time" <= 'Wed Jan 12 00:00:00 2000 PST'::timestamp with time zone)
+         Filter: (time_bucket('@ 7 days'::interval, "time", 'Europe/Berlin'::text, NULL::timestamp with time zone, NULL::interval) <= 'Wed Jan 05 00:00:00 2000 PST'::timestamp with time zone)
+(8 rows)
+
+:PREFIX SELECT * FROM metrics_timestamptz WHERE time_bucket('7d',time,'Europe/Berlin') > '2000-01-25' ORDER BY time;
+                                                                                          QUERY PLAN                                                                                           
+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Custom Scan (ChunkAppend) on metrics_timestamptz
+   Order: metrics_timestamptz."time"
+   ->  Index Scan Backward using _hyper_6_163_chunk_metrics_timestamptz_time_idx on _hyper_6_163_chunk
+         Index Cond: ("time" > 'Tue Jan 25 00:00:00 2000 PST'::timestamp with time zone)
+         Filter: (time_bucket('@ 7 days'::interval, "time", 'Europe/Berlin'::text, NULL::timestamp with time zone, NULL::interval) > 'Tue Jan 25 00:00:00 2000 PST'::timestamp with time zone)
+   ->  Index Scan Backward using _hyper_6_164_chunk_metrics_timestamptz_time_idx on _hyper_6_164_chunk
+         Index Cond: ("time" > 'Tue Jan 25 00:00:00 2000 PST'::timestamp with time zone)
+         Filter: (time_bucket('@ 7 days'::interval, "time", 'Europe/Berlin'::text, NULL::timestamp with time zone, NULL::interval) > 'Tue Jan 25 00:00:00 2000 PST'::timestamp with time zone)
+(8 rows)
+
+:PREFIX SELECT * FROM metrics_timestamptz WHERE time_bucket('7d',time,'Europe/Berlin') >= '2000-01-25' ORDER BY time;
+                                                                                           QUERY PLAN                                                                                           
+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Custom Scan (ChunkAppend) on metrics_timestamptz
+   Order: metrics_timestamptz."time"
+   ->  Index Scan Backward using _hyper_6_163_chunk_metrics_timestamptz_time_idx on _hyper_6_163_chunk
+         Index Cond: ("time" >= 'Tue Jan 25 00:00:00 2000 PST'::timestamp with time zone)
+         Filter: (time_bucket('@ 7 days'::interval, "time", 'Europe/Berlin'::text, NULL::timestamp with time zone, NULL::interval) >= 'Tue Jan 25 00:00:00 2000 PST'::timestamp with time zone)
+   ->  Index Scan Backward using _hyper_6_164_chunk_metrics_timestamptz_time_idx on _hyper_6_164_chunk
+         Index Cond: ("time" >= 'Tue Jan 25 00:00:00 2000 PST'::timestamp with time zone)
+         Filter: (time_bucket('@ 7 days'::interval, "time", 'Europe/Berlin'::text, NULL::timestamp with time zone, NULL::interval) >= 'Tue Jan 25 00:00:00 2000 PST'::timestamp with time zone)
+(8 rows)
+
 \qecho test overflow behaviour of time_bucket exclusion
 test overflow behaviour of time_bucket exclusion
 :PREFIX SELECT * FROM hyper WHERE time > 950 AND time_bucket(10, time) < '9223372036854775807'::bigint ORDER BY time;

--- a/test/sql/include/plan_expand_hypertable_query.sql
+++ b/test/sql/include/plan_expand_hypertable_query.sql
@@ -165,6 +165,46 @@ SELECT * FROM cte ORDER BY value;
 :PREFIX SELECT * FROM hyper WHERE 10::bigint > time_bucket(10, time) ORDER BY time;
 :PREFIX SELECT * FROM hyper WHERE 11::bigint > time_bucket(10, time) ORDER BY time;
 
+:PREFIX SELECT * FROM hyper WHERE time_bucket(10, time, 5) < 10::bigint ORDER BY time;
+:PREFIX SELECT * FROM hyper WHERE time_bucket(10, time, 5) < 11::bigint ORDER BY time;
+:PREFIX SELECT * FROM hyper WHERE time_bucket(10, time, 5) <= 10::bigint ORDER BY time;
+:PREFIX SELECT * FROM hyper WHERE 10::bigint > time_bucket(10, time, 5) ORDER BY time;
+:PREFIX SELECT * FROM hyper WHERE 11::bigint > time_bucket(10, time, 5) ORDER BY time;
+
+\qecho timestamp time_bucket exclusion
+SELECT count(DISTINCT tableoid) FROM metrics_timestamp;
+:PREFIX SELECT * FROM metrics_timestamp WHERE time_bucket('7d',time) < '2000-01-05' ORDER BY time;
+:PREFIX SELECT * FROM metrics_timestamp WHERE time_bucket('7d',time) <= '2000-01-05' ORDER BY time;
+:PREFIX SELECT * FROM metrics_timestamp WHERE time_bucket('7d',time) > '2000-01-25' ORDER BY time;
+:PREFIX SELECT * FROM metrics_timestamp WHERE time_bucket('7d',time) >= '2000-01-15' ORDER BY time;
+:PREFIX SELECT * FROM metrics_timestamp WHERE time_bucket('7d',time,'3d'::interval) < '2000-01-05' ORDER BY time;
+:PREFIX SELECT * FROM metrics_timestamp WHERE time_bucket('7d',time,'3d'::interval) <= '2000-01-05' ORDER BY time;
+:PREFIX SELECT * FROM metrics_timestamp WHERE time_bucket('7d',time,'3d'::interval) > '2000-01-25' ORDER BY time;
+:PREFIX SELECT * FROM metrics_timestamp WHERE time_bucket('7d',time,'3d'::interval) >= '2000-01-25' ORDER BY time;
+:PREFIX SELECT * FROM metrics_timestamp WHERE time_bucket('7d',time,'2000-01-10'::timestamp) < '2000-01-05' ORDER BY time;
+:PREFIX SELECT * FROM metrics_timestamp WHERE time_bucket('7d',time,'2000-01-10'::timestamp) <= '2000-01-05' ORDER BY time;
+:PREFIX SELECT * FROM metrics_timestamp WHERE time_bucket('7d',time,'2000-01-10'::timestamp) > '2000-01-25' ORDER BY time;
+:PREFIX SELECT * FROM metrics_timestamp WHERE time_bucket('7d',time,'2000-01-10'::timestamp) >= '2000-01-25' ORDER BY time;
+
+\qecho timestamptz time_bucket exclusion
+SELECT count(DISTINCT tableoid) FROM metrics_timestamptz;
+:PREFIX SELECT * FROM metrics_timestamptz WHERE time_bucket('7d',time) < '2000-01-05' ORDER BY time;
+:PREFIX SELECT * FROM metrics_timestamptz WHERE time_bucket('7d',time) <= '2000-01-05' ORDER BY time;
+:PREFIX SELECT * FROM metrics_timestamptz WHERE time_bucket('7d',time) > '2000-01-25' ORDER BY time;
+:PREFIX SELECT * FROM metrics_timestamptz WHERE time_bucket('7d',time) >= '2000-01-25' ORDER BY time;
+:PREFIX SELECT * FROM metrics_timestamptz WHERE time_bucket('7d',time,'3d'::interval) < '2000-01-05' ORDER BY time;
+:PREFIX SELECT * FROM metrics_timestamptz WHERE time_bucket('7d',time,'3d'::interval) <= '2000-01-05' ORDER BY time;
+:PREFIX SELECT * FROM metrics_timestamptz WHERE time_bucket('7d',time,'3d'::interval) > '2000-01-25' ORDER BY time;
+:PREFIX SELECT * FROM metrics_timestamptz WHERE time_bucket('7d',time,'3d'::interval) >= '2000-01-25' ORDER BY time;
+:PREFIX SELECT * FROM metrics_timestamptz WHERE time_bucket('7d',time,'2000-01-10'::timestamptz) < '2000-01-05' ORDER BY time;
+:PREFIX SELECT * FROM metrics_timestamptz WHERE time_bucket('7d',time,'2000-01-10'::timestamptz) <= '2000-01-05' ORDER BY time;
+:PREFIX SELECT * FROM metrics_timestamptz WHERE time_bucket('7d',time,'2000-01-10'::timestamptz) > '2000-01-25' ORDER BY time;
+:PREFIX SELECT * FROM metrics_timestamptz WHERE time_bucket('7d',time,'2000-01-10'::timestamptz) >= '2000-01-25' ORDER BY time;
+:PREFIX SELECT * FROM metrics_timestamptz WHERE time_bucket('7d',time,'Europe/Berlin') < '2000-01-05' ORDER BY time;
+:PREFIX SELECT * FROM metrics_timestamptz WHERE time_bucket('7d',time,'Europe/Berlin') <= '2000-01-05' ORDER BY time;
+:PREFIX SELECT * FROM metrics_timestamptz WHERE time_bucket('7d',time,'Europe/Berlin') > '2000-01-25' ORDER BY time;
+:PREFIX SELECT * FROM metrics_timestamptz WHERE time_bucket('7d',time,'Europe/Berlin') >= '2000-01-25' ORDER BY time;
+
 \qecho test overflow behaviour of time_bucket exclusion
 :PREFIX SELECT * FROM hyper WHERE time > 950 AND time_bucket(10, time) < '9223372036854775807'::bigint ORDER BY time;
 


### PR DESCRIPTION
Since the optional time_bucket arguments like offset, origin and timezone shift the output by at most bucket width we can optimize these similar to how we optimize the other time_bucket constraints.

Fixes #4825