### PR TITLE
Include _timescaledb_catalog.metadata in dumps

### DIFF
--- a/sql/metadata.sql
+++ b/sql/metadata.sql
@@ -5,16 +5,40 @@
 CREATE OR REPLACE FUNCTION _timescaledb_functions.generate_uuid() RETURNS UUID
 AS '@MODULE_PATHNAME@', 'ts_uuid_generate' LANGUAGE C VOLATILE STRICT;
 
--- Insert uuid and install_timestamp on database creation. Don't
--- create exported_uuid because it gets exported and installed during
--- pg_dump, which would cause a conflict.
-INSERT INTO _timescaledb_catalog.metadata
-SELECT 'uuid', _timescaledb_functions.generate_uuid(), TRUE ON CONFLICT DO NOTHING;
-INSERT INTO _timescaledb_catalog.metadata
-SELECT 'install_timestamp', now(), TRUE ON CONFLICT DO NOTHING;
+-- Trigger to change INSERT into UPDATE if key already exists.
+--
+-- During extension installation we create 3 entries in the metadata table which are
+-- included in dumps. To allow loading logical dumps we need this trigger to turn INSERTs
+-- into UPDATEs if the key already exists.
+CREATE OR REPLACE FUNCTION _timescaledb_functions.metadata_insert_trigger() RETURNS TRIGGER LANGUAGE PLPGSQL
+AS $$
+BEGIN
+  IF EXISTS (SELECT FROM _timescaledb_catalog.metadata WHERE key = NEW.key) THEN
+    UPDATE _timescaledb_catalog.metadata SET value = NEW.value WHERE key = NEW.key;
+    RETURN NULL;
+  END IF;
+  RETURN NEW;
+END
+$$ SET search_path TO pg_catalog, pg_temp;
+
+-- CREATE OR REPLACE TRIGGER is PG14+ only
+DROP TRIGGER IF EXISTS metadata_insert_trigger ON _timescaledb_catalog.metadata;
+CREATE TRIGGER metadata_insert_trigger BEFORE INSERT ON _timescaledb_catalog.metadata FOR EACH ROW EXECUTE PROCEDURE _timescaledb_functions.metadata_insert_trigger();
+
+-- Insert uuid and install_timestamp on database creation since the trigger
+-- will turn these into UPDATEs on conflicts we can't use ON CONFLICT DO NOTHING.
+DO $$
+BEGIN
+  IF (NOT EXISTS (SELECT FROM _timescaledb_catalog.metadata WHERE key = 'uuid')) THEN
+    INSERT INTO _timescaledb_catalog.metadata SELECT 'uuid', _timescaledb_functions.generate_uuid(), TRUE;
+  END IF;
+  IF (NOT EXISTS (SELECT FROM _timescaledb_catalog.metadata WHERE key = 'install_timestamp')) THEN
+    INSERT INTO _timescaledb_catalog.metadata SELECT 'install_timestamp', now(), TRUE;
+  END IF;
+END
+$$;
 
 -- Install catalog version on database installation and upgrade.
 -- This allows us to detect catalog mismatches in dump/restore cycle.
-INSERT INTO _timescaledb_catalog.metadata (key, value, include_in_telemetry)
-SELECT 'timescaledb_version', '@PROJECT_VERSION_MOD@', FALSE ON CONFLICT (key) DO UPDATE SET value = excluded.value;
+INSERT INTO _timescaledb_catalog.metadata (key, value, include_in_telemetry) SELECT 'timescaledb_version', '@PROJECT_VERSION_MOD@', FALSE;
 

--- a/sql/pre_install/tables.sql
+++ b/sql/pre_install/tables.sql
@@ -292,8 +292,7 @@ CREATE TABLE _timescaledb_catalog.metadata (
   CONSTRAINT metadata_pkey PRIMARY KEY (key)
 );
 
-SELECT pg_catalog.pg_extension_config_dump('_timescaledb_catalog.metadata', $$
-  WHERE KEY = 'exported_uuid' $$);
+SELECT pg_catalog.pg_extension_config_dump('_timescaledb_catalog.metadata', $$ WHERE key <> 'uuid' $$);
 
 -- Log with events that will be sent out with the telemetry. The log
 -- will be flushed after it has been sent out. We do not save it to

--- a/sql/restoring.sql
+++ b/sql/restoring.sql
@@ -12,7 +12,6 @@ BEGIN
     SET SESSION timescaledb.restoring = 'on';
     PERFORM _timescaledb_functions.stop_background_workers();
     --exported uuid may be included in the dump so backup the version
-    UPDATE _timescaledb_catalog.metadata SET key='exported_uuid_bak' WHERE key='exported_uuid';
     RETURN true;
 END
 $BODY$
@@ -39,12 +38,6 @@ BEGIN
     -- we cannot use reset here because the reset_val might not be off
     SET timescaledb.restoring TO off;
     PERFORM _timescaledb_functions.restart_background_workers();
-
-    --try to restore the backed up uuid, if the restore did not set one
-    INSERT INTO _timescaledb_catalog.metadata
-       SELECT 'exported_uuid', value, include_in_telemetry FROM _timescaledb_catalog.metadata WHERE key='exported_uuid_bak'
-       ON CONFLICT DO NOTHING;
-    DELETE FROM _timescaledb_catalog.metadata WHERE key='exported_uuid_bak';
 
     RETURN true;
 END

--- a/sql/updates/latest-dev.sql
+++ b/sql/updates/latest-dev.sql
@@ -397,3 +397,18 @@ CREATE FUNCTION _timescaledb_functions.constraint_clone(constraint_oid OID,targe
 DROP FUNCTION IF EXISTS _timescaledb_functions.chunks_in;
 DROP FUNCTION IF EXISTS _timescaledb_internal.chunks_in;
 
+CREATE FUNCTION _timescaledb_functions.metadata_insert_trigger() RETURNS TRIGGER LANGUAGE PLPGSQL
+AS $$
+BEGIN
+  IF EXISTS (SELECT FROM _timescaledb_catalog.metadata WHERE key = NEW.key) THEN
+    UPDATE _timescaledb_catalog.metadata SET value = NEW.value WHERE key = NEW.key;
+    RETURN NULL;
+  END IF;
+  RETURN NEW;
+END
+$$ SET search_path TO pg_catalog, pg_temp;
+
+CREATE TRIGGER metadata_insert_trigger BEFORE INSERT ON _timescaledb_catalog.metadata FOR EACH ROW EXECUTE PROCEDURE _timescaledb_functions.metadata_insert_trigger();
+
+SELECT pg_catalog.pg_extension_config_dump('_timescaledb_catalog.metadata', $$ WHERE key <> 'uuid' $$);
+

--- a/sql/updates/reverse-dev.sql
+++ b/sql/updates/reverse-dev.sql
@@ -768,5 +768,10 @@ CREATE FUNCTION _timescaledb_functions.hypertable_constraint_add_table_fk_constr
 CREATE FUNCTION _timescaledb_functions.chunks_in(record RECORD, chunks INTEGER[]) RETURNS BOOL
 AS 'BEGIN END' LANGUAGE PLPGSQL SET search_path TO pg_catalog,pg_temp;
 
+SELECT pg_catalog.pg_extension_config_dump('_timescaledb_catalog.metadata', $$ WHERE KEY = 'exported_uuid' $$);
+
+DROP TRIGGER metadata_insert_trigger ON _timescaledb_catalog.metadata;
+DROP FUNCTION _timescaledb_functions.metadata_insert_trigger();
+
 DROP FUNCTION IF EXISTS _timescaledb_functions.get_orderby_defaults(regclass,text[]);
 DROP FUNCTION IF EXISTS _timescaledb_functions.get_segmentby_defaults(regclass);

--- a/test/expected/metadata.out
+++ b/test/expected/metadata.out
@@ -8,12 +8,13 @@ CREATE OR REPLACE FUNCTION _timescaledb_internal.test_exported_uuid() RETURNS UU
     AS :MODULE_PATHNAME, 'ts_test_exported_uuid' LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE OR REPLACE FUNCTION _timescaledb_internal.test_install_timestamp() RETURNS TIMESTAMPTZ
     AS :MODULE_PATHNAME, 'ts_test_install_timestamp' LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+INSERT INTO _timescaledb_catalog.metadata (key, value, include_in_telemetry) SELECT 'metadata_test', 'FOO', TRUE;
 \c :TEST_DBNAME :ROLE_DEFAULT_PERM_USER
 -- uuid and install_timestamp should already be in the table before we generate
 SELECT COUNT(*) from _timescaledb_catalog.metadata;
  count 
 -------
-     3
+     4
 (1 row)
 
 SELECT _timescaledb_internal.test_uuid() as uuid_1 \gset
@@ -90,7 +91,7 @@ ALTER DATABASE :TEST_DBNAME SET timescaledb.restoring='off';
 SELECT COUNT(*) FROM _timescaledb_catalog.metadata;
  count 
 -------
-     4
+     5
 (1 row)
 
 -- Verify that this is the old exported_uuid
@@ -100,17 +101,24 @@ SELECT _timescaledb_internal.test_exported_uuid() = :'uuid_ex_1' as exported_uui
  t
 (1 row)
 
--- Verify that the uuid and timestamp are new
+-- Verify that the uuid is new
 SELECT _timescaledb_internal.test_uuid() = :'uuid_1' as exported_uuids_diff;
  exported_uuids_diff 
 ---------------------
  f
 (1 row)
 
-SELECT _timescaledb_internal.test_install_timestamp() = :'timestamp_1' as exported_uuids_diff;
- exported_uuids_diff 
----------------------
- f
+-- Verify that the install_timestamp got restored
+SELECT _timescaledb_internal.test_install_timestamp() = :'timestamp_1' as timestamps_equal;
+ timestamps_equal 
+------------------
+ t
+(1 row)
+
+SELECT * FROM _timescaledb_catalog.metadata WHERE key = 'metadata_test';
+      key      | value | include_in_telemetry 
+---------------+-------+----------------------
+ metadata_test | FOO   | t
 (1 row)
 
 -- check metadata version matches expected value

--- a/test/expected/pg_dump.out
+++ b/test/expected/pg_dump.out
@@ -262,8 +262,8 @@ SELECT * FROM _timescaledb_catalog.chunk_constraint;
         4 |                    | 4_4_timecustom_device_id_series_2_key | timecustom_device_id_series_2_key
 (12 rows)
 
---force a value to exist for exported_uuid
 INSERT INTO _timescaledb_catalog.metadata VALUES ('exported_uuid', 'original_uuid', true);
+INSERT INTO _timescaledb_catalog.metadata VALUES ('metadata_test', 'FOO', false);
 \c postgres :ROLE_SUPERUSER
 -- We shell out to a script in order to grab the correct hostname from the
 -- environmental variables that originally called this psql command. Sadly
@@ -348,6 +348,13 @@ SELECT count(*) = 1 FROM _timescaledb_catalog.metadata WHERE key LIKE 'exported%
  ?column? 
 ----------
  t
+(1 row)
+
+--we should have the original value of metadata_test
+SELECT * FROM _timescaledb_catalog.metadata  WHERE key='metadata_test';
+      key      | value | include_in_telemetry 
+---------------+-------+----------------------
+ metadata_test | FOO   | f
 (1 row)
 
 --main table and chunk schemas should be the same

--- a/test/sql/pg_dump.sql
+++ b/test/sql/pg_dump.sql
@@ -81,8 +81,8 @@ SELECT * FROM _timescaledb_internal._hyper_1_2_chunk ORDER BY "timeCustom", devi
 SELECT * FROM _timescaledb_catalog.chunk_index;
 SELECT * FROM _timescaledb_catalog.chunk_constraint;
 
---force a value to exist for exported_uuid
 INSERT INTO _timescaledb_catalog.metadata VALUES ('exported_uuid', 'original_uuid', true);
+INSERT INTO _timescaledb_catalog.metadata VALUES ('metadata_test', 'FOO', false);
 
 \c postgres :ROLE_SUPERUSER
 -- We shell out to a script in order to grab the correct hostname from the
@@ -105,7 +105,6 @@ SHOW timescaledb.restoring;
 SHOW timescaledb.restoring;
 
 \! utils/pg_dump_aux_restore.sh dump/pg_dump.sql
-
 
 -- Inserting with restoring ON in current session causes tuples to be
 -- inserted on main table, but this should be protected by the insert
@@ -131,6 +130,9 @@ SELECT count(*) = :num_dependent_objects as dependent_objects_match
 --we should have the original uuid from the backed up db set as the exported_uuid
 SELECT value = 'original_uuid' FROM _timescaledb_catalog.metadata  WHERE key='exported_uuid';
 SELECT count(*) = 1 FROM _timescaledb_catalog.metadata WHERE key LIKE 'exported%';
+
+--we should have the original value of metadata_test
+SELECT * FROM _timescaledb_catalog.metadata  WHERE key='metadata_test';
 
 --main table and chunk schemas should be the same
 SELECT * FROM test.show_columns('"test_schema"."two_Partitions"');

--- a/tsl/test/shared/expected/extension.out
+++ b/tsl/test/shared/expected/extension.out
@@ -99,6 +99,7 @@ ORDER BY pronamespace::regnamespace::text COLLATE "C", p.oid::regprocedure::text
  _timescaledb_functions.last_sfunc(internal,anyelement,"any")
  _timescaledb_functions.makeaclitem(regrole,regrole,text,boolean)
  _timescaledb_functions.materialization_invalidation_log_delete(integer)
+ _timescaledb_functions.metadata_insert_trigger()
  _timescaledb_functions.partialize_agg(anyelement)
  _timescaledb_functions.policy_compression(integer,jsonb)
  _timescaledb_functions.policy_compression_check(jsonb)


### PR DESCRIPTION
This patch changes the dump configuration for
_timescaledb_catalog.metadata to include all entries. To allow loading logical dumps with this configuration an insert trigger is added that turns uniqueness conflicts into updates to not block the restore.