### PR TITLE
Change GitHub token for changelog check

### DIFF
--- a/.github/workflows/changelog-check.yaml
+++ b/.github/workflows/changelog-check.yaml
@@ -41,7 +41,7 @@ jobs:
         shell: bash --norc --noprofile {0}
         env:
           BODY: ${{ github.event.pull_request.body }}
-          GITHUB_TOKEN: ${{ secrets.ORG_AUTOMATION_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
         run: |
           folder=".unreleased"

--- a/scripts/check_changelog_format.py
+++ b/scripts/check_changelog_format.py
@@ -77,7 +77,13 @@ def is_valid_line(line):
 
 
 def main():
-    github_obj = github.Github(os.environ.get("GITHUB_TOKEN"))
+    github_token = os.environ.get("GITHUB_TOKEN")
+
+    if not github_token:
+        print("Please populate the GITHUB_TOKEN environment variable.")
+        sys.exit(1)
+
+    github_obj = github.Github(github_token)
     repo = github_obj.get_repo("timescale/timescaledb")
     # Get the file name from the command line argument
     if len(sys.argv) != 2:


### PR DESCRIPTION
Since #6505, the changelog script tries to access
`secrets.ORG_AUTOMATION_TOKEN`. However, accessing secrets is not possible
for PRs. This PR changes the token to the default access token, which is available in PRs
and provides read access to the issue API.

---

Disable-check: force-changelog-file
Fixed CI run: https://github.com/timescale/timescaledb/actions/runs/7613913110/job/20734963199?pr=6560
Failed CI run: https://github.com/timescale/timescaledb/actions/runs/7610536985/job/20724062414?pr=6325