### PR TITLE
Fix OSM build failure

### DIFF
--- a/tsl/test/expected/chunk_utils_internal.out
+++ b/tsl/test/expected/chunk_utils_internal.out
@@ -1330,6 +1330,27 @@ SELECT * FROM test_chunkapp ORDER BY 1;
  Thu Jan 02 01:00:00 2020 PST | 2
 (2 rows)
 
+\set ON_ERROR_STOP 0
+-- test adding constraint directly on OSM chunk is blocked
+ALTER TABLE test_chunkapp_fdw_child ADD CHECK (a > 0); -- non-dimensional
+ERROR:  operation not supported on OSM chunk tables
+ALTER TABLE test_chunkapp_fdw_child ADD CHECK (time > '1600-01-01'::timestamptz); -- dimensional
+ERROR:  operation not supported on OSM chunk tables
+-- but on hypertable, it is allowed
+ALTER TABLE test_chunkapp ADD CHECK (a > 0);
+\d+ test_chunkapp_fdw_child
+                                     Foreign table "public.test_chunkapp_fdw_child"
+ Column |           Type           | Collation | Nullable | Default | FDW options | Storage | Stats target | Description 
+--------+--------------------------+-----------+----------+---------+-------------+---------+--------------+-------------
+ time   | timestamp with time zone |           | not null |         |             | plain   |              | 
+ a      | integer                  |           |          |         |             | plain   |              | 
+Check constraints:
+    "test_chunkapp_a_check" CHECK (a > 0)
+Server: s3_server
+FDW options: (schema_name 'public', table_name 'test_chunkapp_fdw')
+Inherits: test_chunkapp
+
+\set ON_ERROR_STOP 1
 -- test error is triggered when time dimension not found
 CREATE TABLE test2(time timestamptz not null, a int);
 SELECT create_hypertable('test2', 'time');

--- a/tsl/test/sql/chunk_utils_internal.sql
+++ b/tsl/test/sql/chunk_utils_internal.sql
@@ -704,6 +704,15 @@ SELECT _timescaledb_functions.hypertable_osm_range_update('test_chunkapp', NULL:
 EXPLAIN SELECT * FROM test_chunkapp ORDER BY 1;
 SELECT * FROM test_chunkapp ORDER BY 1;
 
+\set ON_ERROR_STOP 0
+-- test adding constraint directly on OSM chunk is blocked
+ALTER TABLE test_chunkapp_fdw_child ADD CHECK (a > 0); -- non-dimensional
+ALTER TABLE test_chunkapp_fdw_child ADD CHECK (time > '1600-01-01'::timestamptz); -- dimensional
+-- but on hypertable, it is allowed
+ALTER TABLE test_chunkapp ADD CHECK (a > 0);
+\d+ test_chunkapp_fdw_child
+\set ON_ERROR_STOP 1
+
 -- test error is triggered when time dimension not found
 CREATE TABLE test2(time timestamptz not null, a int);
 SELECT create_hypertable('test2', 'time');


### PR DESCRIPTION
The commit #6513 removed some restricted chunk operations, enabling adding constraints to OSM chunks directly. This operation is blocked on OSM chunks. The present commit ensures that adding a constraint directly on an OSM chunk is blocked.