### PR TITLE
Properly set job failure on compression policies

### DIFF
--- a/tsl/test/expected/bgw_custom-13.out
+++ b/tsl/test/expected/bgw_custom-13.out
@@ -953,6 +953,7 @@ SELECT count(*) > 1
 -- is dynamic and it will be printed in those messages.
 SET client_min_messages TO ERROR;
 CALL run_job(:compressjob_id);
+ERROR:  compression policy failure
 SET client_min_messages TO NOTICE;
 -- check compression status is not changed for the chunk whose status was manually updated
 SELECT status FROM _timescaledb_catalog.chunk where table_name = :'new_uncompressed_chunk_name';

--- a/tsl/test/expected/bgw_custom-14.out
+++ b/tsl/test/expected/bgw_custom-14.out
@@ -953,6 +953,7 @@ SELECT count(*) > 1
 -- is dynamic and it will be printed in those messages.
 SET client_min_messages TO ERROR;
 CALL run_job(:compressjob_id);
+ERROR:  compression policy failure
 SET client_min_messages TO NOTICE;
 -- check compression status is not changed for the chunk whose status was manually updated
 SELECT status FROM _timescaledb_catalog.chunk where table_name = :'new_uncompressed_chunk_name';

--- a/tsl/test/expected/bgw_custom-15.out
+++ b/tsl/test/expected/bgw_custom-15.out
@@ -953,6 +953,7 @@ SELECT count(*) > 1
 -- is dynamic and it will be printed in those messages.
 SET client_min_messages TO ERROR;
 CALL run_job(:compressjob_id);
+ERROR:  compression policy failure
 SET client_min_messages TO NOTICE;
 -- check compression status is not changed for the chunk whose status was manually updated
 SELECT status FROM _timescaledb_catalog.chunk where table_name = :'new_uncompressed_chunk_name';

--- a/tsl/test/expected/bgw_custom-16.out
+++ b/tsl/test/expected/bgw_custom-16.out
@@ -953,6 +953,7 @@ SELECT count(*) > 1
 -- is dynamic and it will be printed in those messages.
 SET client_min_messages TO ERROR;
 CALL run_job(:compressjob_id);
+ERROR:  compression policy failure
 SET client_min_messages TO NOTICE;
 -- check compression status is not changed for the chunk whose status was manually updated
 SELECT status FROM _timescaledb_catalog.chunk where table_name = :'new_uncompressed_chunk_name';

--- a/tsl/test/expected/read_only.out
+++ b/tsl/test/expected/read_only.out
@@ -206,6 +206,7 @@ FROM _timescaledb_config.bgw_job WHERE id = :comp_job_id \gset
 SET default_transaction_read_only TO on;
 CALL _timescaledb_functions.policy_compression(:comp_job_id, :'comp_job_config');
 WARNING:  compressing chunk "_timescaledb_internal._hyper_4_2_chunk" failed when compression policy is executed
+ERROR:  compression policy failure
 SET default_transaction_read_only TO off;
 --verify chunks are not compressed
 SELECT count(*) , count(*) FILTER ( WHERE is_compressed is true)


### PR DESCRIPTION
In #4770 we changed the behavior of compression policies to continue compressing chunks even if a failure happens in one of them.

The problem is if a failure happens in one or all the chunks the job is marked as successful, and this is wrong because a failure happens so if an exception occurs when compressing chunks we'll raise an exception at the end of the procedure in order to mark the job as failed.

Disable-check: force-changelog-file
