### PR TITLE
Move public recompress_chunk procedure

### DIFF
--- a/sql/updates/latest-dev.sql
+++ b/sql/updates/latest-dev.sql
@@ -428,6 +428,7 @@ ALTER EXTENSION timescaledb DROP TABLE _timescaledb_catalog.hypertable;
 ALTER EXTENSION timescaledb ADD TABLE _timescaledb_catalog.hypertable;
 SELECT pg_catalog.pg_extension_config_dump('_timescaledb_catalog.hypertable', 'WHERE id >= 1');
 
+<<<<<<< HEAD
 CREATE FUNCTION _timescaledb_functions.relation_approximate_size(relation REGCLASS)
 RETURNS TABLE (total_size BIGINT, heap_size BIGINT, index_size BIGINT, toast_size BIGINT)
 AS '@MODULE_PATHNAME@', 'ts_relation_approximate_size' LANGUAGE C STRICT VOLATILE;
@@ -445,3 +446,9 @@ $BODY$
    SELECT sum(total_bytes)::bigint
    FROM @extschema@.hypertable_approximate_detailed_size(hypertable);
 $BODY$ SET search_path TO pg_catalog, pg_temp;
+=======
+DROP PROCEDURE IF EXISTS @@extschema@@.recompress_chunk;
+-- create stub for recompress_chunk
+CREATE FUNCTION _timescaledb_functions.recompress_chunk(chunk REGCLASS) RETURNS REGCLASS LANGUAGE PLPGSQL AS $$BEGIN END$$ SET search_path TO pg_catalog, pg_temp;
+
+>>>>>>> 47bc8d73c (Remove public recompress_chunk procedure)

--- a/sql/updates/latest-dev.sql
+++ b/sql/updates/latest-dev.sql
@@ -428,7 +428,6 @@ ALTER EXTENSION timescaledb DROP TABLE _timescaledb_catalog.hypertable;
 ALTER EXTENSION timescaledb ADD TABLE _timescaledb_catalog.hypertable;
 SELECT pg_catalog.pg_extension_config_dump('_timescaledb_catalog.hypertable', 'WHERE id >= 1');
 
-<<<<<<< HEAD
 CREATE FUNCTION _timescaledb_functions.relation_approximate_size(relation REGCLASS)
 RETURNS TABLE (total_size BIGINT, heap_size BIGINT, index_size BIGINT, toast_size BIGINT)
 AS '@MODULE_PATHNAME@', 'ts_relation_approximate_size' LANGUAGE C STRICT VOLATILE;
@@ -446,9 +445,8 @@ $BODY$
    SELECT sum(total_bytes)::bigint
    FROM @extschema@.hypertable_approximate_detailed_size(hypertable);
 $BODY$ SET search_path TO pg_catalog, pg_temp;
-=======
+
 DROP PROCEDURE IF EXISTS @@extschema@@.recompress_chunk;
 -- create stub for recompress_chunk
 CREATE FUNCTION _timescaledb_functions.recompress_chunk(chunk REGCLASS) RETURNS REGCLASS LANGUAGE PLPGSQL AS $$BEGIN END$$ SET search_path TO pg_catalog, pg_temp;
 
->>>>>>> 47bc8d73c (Remove public recompress_chunk procedure)

--- a/sql/updates/reverse-dev.sql
+++ b/sql/updates/reverse-dev.sql
@@ -788,6 +788,14 @@ ALTER EXTENSION timescaledb DROP TABLE _timescaledb_catalog.hypertable;
 ALTER EXTENSION timescaledb ADD TABLE _timescaledb_catalog.hypertable;
 -- include this now in the config
 SELECT pg_catalog.pg_extension_config_dump('_timescaledb_catalog.hypertable', '');
+<<<<<<< HEAD
 DROP FUNCTION IF EXISTS _timescaledb_functions.relation_approximate_size(relation REGCLASS);
 DROP FUNCTION IF EXISTS @extschema@.hypertable_approximate_detailed_size(relation REGCLASS);
 DROP FUNCTION IF EXISTS @extschema@.hypertable_approximate_size(hypertable REGCLASS);
+=======
+
+DROP FUNCTION _timescaledb_functions.recompress_chunk;
+-- create stub for recompress_chunk
+CREATE PROCEDURE @@extschema@@.recompress_chunk(chunk REGCLASS, if_not_compressed BOOLEAN) LANGUAGE PLPGSQL AS $$BEGIN END$$ SET search_path TO pg_catalog, pg_temp;
+
+>>>>>>> 47bc8d73c (Remove public recompress_chunk procedure)

--- a/sql/updates/reverse-dev.sql
+++ b/sql/updates/reverse-dev.sql
@@ -788,14 +788,12 @@ ALTER EXTENSION timescaledb DROP TABLE _timescaledb_catalog.hypertable;
 ALTER EXTENSION timescaledb ADD TABLE _timescaledb_catalog.hypertable;
 -- include this now in the config
 SELECT pg_catalog.pg_extension_config_dump('_timescaledb_catalog.hypertable', '');
-<<<<<<< HEAD
+
 DROP FUNCTION IF EXISTS _timescaledb_functions.relation_approximate_size(relation REGCLASS);
 DROP FUNCTION IF EXISTS @extschema@.hypertable_approximate_detailed_size(relation REGCLASS);
 DROP FUNCTION IF EXISTS @extschema@.hypertable_approximate_size(hypertable REGCLASS);
-=======
 
 DROP FUNCTION _timescaledb_functions.recompress_chunk;
 -- create stub for recompress_chunk
 CREATE PROCEDURE @@extschema@@.recompress_chunk(chunk REGCLASS, if_not_compressed BOOLEAN) LANGUAGE PLPGSQL AS $$BEGIN END$$ SET search_path TO pg_catalog, pg_temp;
 
->>>>>>> 47bc8d73c (Remove public recompress_chunk procedure)

--- a/tsl/test/expected/compression_bgw-15.out
+++ b/tsl/test/expected/compression_bgw-15.out
@@ -433,10 +433,20 @@ SELECT count(*) from test2;
 -- it contains transaction-terminating commands.
 \set ON_ERROR_STOP 0
 START TRANSACTION;
-CALL recompress_chunk(:'CHUNK_NAME'::regclass);
+SELECT _timescaledb_functions.recompress_chunk(:'CHUNK_NAME'::regclass);
+             recompress_chunk             
+------------------------------------------
+ _timescaledb_internal._hyper_14_62_chunk
+(1 row)
+
 ROLLBACK;
 \set ON_ERROR_STOP 1
-CALL recompress_chunk(:'CHUNK_NAME'::regclass);
+SELECT _timescaledb_functions.recompress_chunk(:'CHUNK_NAME'::regclass);
+             recompress_chunk             
+------------------------------------------
+ _timescaledb_internal._hyper_14_62_chunk
+(1 row)
+
 -- Demonstrate that no locks are held on the hypertable, chunk, or the
 -- compressed chunk after recompress_chunk has executed.
 SELECT pid, locktype, relation, relation::regclass, mode, granted
@@ -506,11 +516,11 @@ WHERE hypertable_name = 'test2' ORDER BY chunk_name;
 
 \set ON_ERROR_STOP 0
 -- call recompress_chunk when status is not unordered
-CALL recompress_chunk(:'CHUNK_NAME'::regclass, true);
-psql:include/recompress_basic.sql:115: NOTICE:  nothing to recompress in chunk "_hyper_14_62_chunk"
+SELECT _timescaledb_functions.recompress_chunk(:'CHUNK_NAME'::regclass, true);
+psql:include/recompress_basic.sql:115: ERROR:  function _timescaledb_functions.recompress_chunk(regclass, boolean) does not exist at character 8
 -- This will succeed and compress the chunk for the test below.
-CALL recompress_chunk(:'CHUNK_NAME'::regclass, false);
-psql:include/recompress_basic.sql:118: ERROR:  nothing to recompress in chunk "_hyper_14_62_chunk"
+SELECT _timescaledb_functions.recompress_chunk(:'CHUNK_NAME'::regclass, false);
+psql:include/recompress_basic.sql:118: ERROR:  function _timescaledb_functions.recompress_chunk(regclass, boolean) does not exist at character 8
 --now decompress it , then try and recompress
 SELECT decompress_chunk(:'CHUNK_NAME'::regclass);
              decompress_chunk             
@@ -518,8 +528,12 @@ SELECT decompress_chunk(:'CHUNK_NAME'::regclass);
  _timescaledb_internal._hyper_14_62_chunk
 (1 row)
 
-CALL recompress_chunk(:'CHUNK_NAME'::regclass);
-psql:include/recompress_basic.sql:122: ERROR:  call compress_chunk instead of recompress_chunk
+SELECT _timescaledb_functions.recompress_chunk(:'CHUNK_NAME'::regclass);
+             recompress_chunk             
+------------------------------------------
+ _timescaledb_internal._hyper_14_62_chunk
+(1 row)
+
 \set ON_ERROR_STOP 1
 -- test recompress policy
 CREATE TABLE metrics(time timestamptz NOT NULL);

--- a/tsl/test/expected/compression_ddl.out
+++ b/tsl/test/expected/compression_ddl.out
@@ -1018,7 +1018,12 @@ SELECT * FROM test_defaults ORDER BY 1,2;
  Mon Jan 01 00:00:00 2001 PST |         1 |    | 42
 (3 rows)
 
-CALL recompress_all_chunks('test_defaults', 1, false);
+SELECT _timescaledb_functions.recompress_chunk(chunk) FROM show_chunks('test_defaults') chunk LIMIT 1;
+             recompress_chunk             
+------------------------------------------
+ _timescaledb_internal._hyper_15_92_chunk
+(1 row)
+
 SELECT * FROM test_defaults ORDER BY 1,2;
              time             | device_id | c1 | c2 
 ------------------------------+-----------+----+----
@@ -1419,7 +1424,12 @@ ORDER BY device_id;
          5 |  3596
 (5 rows)
 
-CALL recompress_chunk(:'CHUNK_NAME'::regclass);
+SELECT _timescaledb_functions.recompress_chunk(:'CHUNK_NAME'::regclass);
+             recompress_chunk              
+-------------------------------------------
+ _timescaledb_internal._hyper_31_110_chunk
+(1 row)
+
 SELECT count(*), sum(v0), sum(v1), sum(v2), sum(v3)
 FROM compression_insert
 WHERE time >= '2000-01-01 0:00:00+0'
@@ -1503,7 +1513,12 @@ ORDER BY device_id;
          5 |  7192
 (5 rows)
 
-CALL recompress_chunk(:'CHUNK_NAME'::regclass);
+SELECT _timescaledb_functions.recompress_chunk(:'CHUNK_NAME'::regclass);
+             recompress_chunk              
+-------------------------------------------
+ _timescaledb_internal._hyper_31_112_chunk
+(1 row)
+
 SELECT count(*), sum(v0), sum(v1), sum(v2), sum(v3)
 FROM compression_insert
 WHERE time >= '2000-01-07 0:00:00+0'
@@ -1591,7 +1606,12 @@ ORDER BY device_id;
          5 | 10788
 (5 rows)
 
-CALL recompress_chunk(:'CHUNK_NAME'::regclass);
+SELECT _timescaledb_functions.recompress_chunk(:'CHUNK_NAME'::regclass);
+             recompress_chunk              
+-------------------------------------------
+ _timescaledb_internal._hyper_31_114_chunk
+(1 row)
+
 SELECT count(*), sum(v0), sum(v1), sum(v2), sum(v3)
 FROM compression_insert
 WHERE time >= '2000-01-15 0:00:00+0'
@@ -1683,7 +1703,12 @@ ORDER BY device_id;
          5 | 14384
 (5 rows)
 
-CALL recompress_chunk(:'CHUNK_NAME'::regclass);
+SELECT _timescaledb_functions.recompress_chunk(:'CHUNK_NAME'::regclass);
+             recompress_chunk              
+-------------------------------------------
+ _timescaledb_internal._hyper_31_116_chunk
+(1 row)
+
 SELECT count(*), sum(v0), sum(v1), sum(v2), sum(v3)
 FROM compression_insert
 WHERE time >= '2000-01-22 0:00:00+0'
@@ -1779,7 +1804,12 @@ ORDER BY device_id;
          5 | 17980
 (5 rows)
 
-CALL recompress_chunk(:'CHUNK_NAME'::regclass);
+SELECT _timescaledb_functions.recompress_chunk(:'CHUNK_NAME'::regclass);
+             recompress_chunk              
+-------------------------------------------
+ _timescaledb_internal._hyper_31_118_chunk
+(1 row)
+
 SELECT count(*), sum(v0), sum(v1), sum(v2), sum(v3)
 FROM compression_insert
 WHERE time >= '2000-01-28 0:00:00+0'

--- a/tsl/test/expected/compression_update_delete.out
+++ b/tsl/test/expected/compression_update_delete.out
@@ -125,8 +125,18 @@ WHERE hypertable_name = 'sample_table' ORDER BY chunk_name;
 (2 rows)
 
 -- recompress the partial chunks
-CALL recompress_chunk('_timescaledb_internal._hyper_1_1_chunk');
-CALL recompress_chunk('_timescaledb_internal._hyper_1_2_chunk');
+SELECT _timescaledb_functions.recompress_chunk('_timescaledb_internal._hyper_1_1_chunk');
+            recompress_chunk            
+----------------------------------------
+ _timescaledb_internal._hyper_1_1_chunk
+(1 row)
+
+SELECT _timescaledb_functions.recompress_chunk('_timescaledb_internal._hyper_1_2_chunk');
+            recompress_chunk            
+----------------------------------------
+ _timescaledb_internal._hyper_1_2_chunk
+(1 row)
+
 -- check chunk compression status
 SELECT chunk_status,
        chunk_name as "CHUNK_NAME"
@@ -166,8 +176,18 @@ WHERE hypertable_name = 'sample_table' ORDER BY chunk_name;
 (2 rows)
 
 -- recompress the paritial chunks
-CALL recompress_chunk('_timescaledb_internal._hyper_1_1_chunk');
-CALL recompress_chunk('_timescaledb_internal._hyper_1_2_chunk');
+SELECT _timescaledb_functions.recompress_chunk('_timescaledb_internal._hyper_1_1_chunk');
+            recompress_chunk            
+----------------------------------------
+ _timescaledb_internal._hyper_1_1_chunk
+(1 row)
+
+SELECT _timescaledb_functions.recompress_chunk('_timescaledb_internal._hyper_1_2_chunk');
+            recompress_chunk            
+----------------------------------------
+ _timescaledb_internal._hyper_1_2_chunk
+(1 row)
+
 -- test for IS NULL checks
 -- should not UPDATE any rows
 UPDATE sample_table SET temperature = 34.21 WHERE sensor_id IS NULL;
@@ -197,8 +217,18 @@ WHERE hypertable_name = 'sample_table' ORDER BY chunk_name;
 (2 rows)
 
 -- recompress the paritial chunks
-CALL recompress_chunk('_timescaledb_internal._hyper_1_1_chunk');
-CALL recompress_chunk('_timescaledb_internal._hyper_1_2_chunk');
+SELECT _timescaledb_functions.recompress_chunk('_timescaledb_internal._hyper_1_1_chunk');
+            recompress_chunk            
+----------------------------------------
+ _timescaledb_internal._hyper_1_1_chunk
+(1 row)
+
+SELECT _timescaledb_functions.recompress_chunk('_timescaledb_internal._hyper_1_2_chunk');
+            recompress_chunk            
+----------------------------------------
+ _timescaledb_internal._hyper_1_2_chunk
+(1 row)
+
 -- check chunk compression status
 SELECT chunk_status,
        chunk_name as "CHUNK_NAME"

--- a/tsl/test/expected/recompress_chunk_segmentwise.out
+++ b/tsl/test/expected/recompress_chunk_segmentwise.out
@@ -282,7 +282,12 @@ SELECT * FROM test_defaults ORDER BY 1,2;
  Mon Jan 01 00:00:00 2001 PST |         1 |    | 42
 (3 rows)
 
-call recompress_chunk(:'compressed_chunk');
+SELECT _timescaledb_functions.recompress_chunk(:'compressed_chunk');
+            recompress_chunk            
+----------------------------------------
+ _timescaledb_internal._hyper_7_7_chunk
+(1 row)
+
 SELECT * FROM test_defaults ORDER BY 1,2;
              time             | device_id | c1 | c2 
 ------------------------------+-----------+----+----
@@ -344,7 +349,12 @@ EXECUTE p1;
 (3 rows)
 
 -- check plan again after recompression
-CALL recompress_chunk(:'chunk_to_compress_prep');
+SELECT _timescaledb_functions.recompress_chunk(:'chunk_to_compress_prep');
+            recompress_chunk             
+-----------------------------------------
+ _timescaledb_internal._hyper_9_10_chunk
+(1 row)
+
 EXPLAIN (COSTS OFF) EXECUTE p1;
                                                   QUERY PLAN                                                   
 ---------------------------------------------------------------------------------------------------------------
@@ -386,7 +396,12 @@ select compress_chunk(show_chunks('mytab'));
 select compressed_chunk_name as compressed_chunk_name_before_recompression from compressed_chunk_info_view where hypertable_name = 'mytab' \gset
 INSERT INTO mytab VALUES ('2023-01-01'::timestamptz, 2, 3, 2);
 -- segmentwise recompression should not create a new compressed chunk, so verify compressed chunk is the same after recompression
-call recompress_chunk(:'chunk_to_compress_mytab');
+SELECT _timescaledb_functions.recompress_chunk(:'chunk_to_compress_mytab');
+             recompress_chunk             
+------------------------------------------
+ _timescaledb_internal._hyper_11_12_chunk
+(1 row)
+
 select compressed_chunk_name as compressed_chunk_name_after_recompression from compressed_chunk_info_view where hypertable_name = 'mytab' \gset
 select :'compressed_chunk_name_before_recompression' as before_segmentwise_recompression, :'compressed_chunk_name_after_recompression' as after_segmentwise_recompression;
  before_segmentwise_recompression | after_segmentwise_recompression 
@@ -399,7 +414,12 @@ SELECT t, a, 3, 2
 FROM generate_series('2023-01-01'::timestamptz, '2023-01-02'::timestamptz, '1 hour'::interval) t
 CROSS JOIN generate_series(1, 10, 1) a;
 -- recompress will insert newly inserted tuples into compressed chunk along with inserting into the compressed chunk index
-CALL recompress_chunk(:'chunk_to_compress_mytab');
+SELECT _timescaledb_functions.recompress_chunk(:'chunk_to_compress_mytab');
+             recompress_chunk             
+------------------------------------------
+ _timescaledb_internal._hyper_11_12_chunk
+(1 row)
+
 -- make sure we are hitting the index and that the index contains the tuples
 SET enable_seqscan TO off;
 EXPLAIN (COSTS OFF) SELECT count(*) FROM mytab where a = 2;
@@ -435,7 +455,12 @@ select compress_chunk(show_chunks('mytab'));
 select compressed_chunk_name as compressed_chunk_name_before_recompression from compressed_chunk_info_view where hypertable_name = 'mytab' \gset
 INSERT INTO mytab VALUES ('2023-01-01'::timestamptz, 2, 3, 2);
 -- expect to see a different compressed chunk after recompressing now as the operation is decompress + compress
-call recompress_chunk(:'chunk_to_compress_mytab');
+SELECT _timescaledb_functions.recompress_chunk(:'chunk_to_compress_mytab');
+             recompress_chunk             
+------------------------------------------
+ _timescaledb_internal._hyper_11_12_chunk
+(1 row)
+
 select compressed_chunk_name as compressed_chunk_name_after_recompression from compressed_chunk_info_view where hypertable_name = 'mytab' \gset
 select :'compressed_chunk_name_before_recompression' as before_recompression, :'compressed_chunk_name_after_recompression' as after_recompression;
     before_recompression    |    after_recompression     
@@ -464,7 +489,12 @@ select compress_chunk(show_chunks('nullseg_one'));
 insert into nullseg_one values (:'start_time', NULL, 4);
 select show_chunks as chunk_to_compress from show_chunks('nullseg_one') limit 1 \gset
 select compressed_chunk_schema || '.' || compressed_chunk_name as compressed_chunk_name from compressed_chunk_info_view where hypertable_name = 'nullseg_one' \gset
-call recompress_chunk(:'chunk_to_compress');
+SELECT _timescaledb_functions.recompress_chunk(:'chunk_to_compress');
+             recompress_chunk             
+------------------------------------------
+ _timescaledb_internal._hyper_14_16_chunk
+(1 row)
+
 select * from :compressed_chunk_name;
                                  time                                 | a |                            b                             | _ts_meta_count | _ts_meta_sequence_num |        _ts_meta_min_1        |        _ts_meta_max_1        
 ----------------------------------------------------------------------+---+----------------------------------------------------------+----------------+-----------------------+------------------------------+------------------------------
@@ -475,7 +505,12 @@ select * from :compressed_chunk_name;
 
 -- insert again, check both index insertion works and NULL values properly handled
 insert into nullseg_one values (:'start_time', NULL, 4);
-call recompress_chunk(:'chunk_to_compress');
+SELECT _timescaledb_functions.recompress_chunk(:'chunk_to_compress');
+             recompress_chunk             
+------------------------------------------
+ _timescaledb_internal._hyper_14_16_chunk
+(1 row)
+
 select * from :compressed_chunk_name;
                                  time                                 | a |                            b                             | _ts_meta_count | _ts_meta_sequence_num |        _ts_meta_min_1        |        _ts_meta_max_1        
 ----------------------------------------------------------------------+---+----------------------------------------------------------+----------------+-----------------------+------------------------------+------------------------------
@@ -505,7 +540,12 @@ select compress_chunk(show_chunks('nullseg_many'));
 insert into nullseg_many values (:'start_time', 1, 4, NULL);
 select show_chunks as chunk_to_compress from show_chunks('nullseg_many') limit 1 \gset
 select compressed_chunk_schema || '.' || compressed_chunk_name as compressed_chunk_name from compressed_chunk_info_view where hypertable_name = 'nullseg_many' \gset
-call recompress_chunk(:'chunk_to_compress');
+SELECT _timescaledb_functions.recompress_chunk(:'chunk_to_compress');
+             recompress_chunk             
+------------------------------------------
+ _timescaledb_internal._hyper_16_18_chunk
+(1 row)
+
 select * from :compressed_chunk_name;
                                  time                                 | a |                                            b                                             | c | _ts_meta_count | _ts_meta_sequence_num |        _ts_meta_min_1        |        _ts_meta_max_1        
 ----------------------------------------------------------------------+---+------------------------------------------------------------------------------------------+---+----------------+-----------------------+------------------------------+------------------------------
@@ -519,7 +559,12 @@ select * from :compressed_chunk_name;
 -- insert again, check both index insertion works and NULL values properly handled
 -- should match existing segment (1, NULL)
 insert into nullseg_many values (:'start_time', 1, NULL, NULL);
-call recompress_chunk(:'chunk_to_compress');
+SELECT _timescaledb_functions.recompress_chunk(:'chunk_to_compress');
+             recompress_chunk             
+------------------------------------------
+ _timescaledb_internal._hyper_16_18_chunk
+(1 row)
+
 select * from :compressed_chunk_name;
                                  time                                 | a |                                            b                                             | c | _ts_meta_count | _ts_meta_sequence_num |        _ts_meta_min_1        |        _ts_meta_max_1        
 ----------------------------------------------------------------------+---+------------------------------------------------------------------------------------------+---+----------------+-----------------------+------------------------------+------------------------------

--- a/tsl/test/sql/compression_ddl.sql
+++ b/tsl/test/sql/compression_ddl.sql
@@ -634,7 +634,7 @@ SELECT device_id, count(*)
 FROM compression_insert
 GROUP BY device_id
 ORDER BY device_id;
-CALL recompress_chunk(:'CHUNK_NAME'::regclass);
+SELECT _timescaledb_functions.recompress_chunk(:'CHUNK_NAME'::regclass);
 SELECT count(*), sum(v0), sum(v1), sum(v2), sum(v3)
 FROM compression_insert
 WHERE time >= '2000-01-01 0:00:00+0'
@@ -675,7 +675,7 @@ SELECT device_id, count(*)
 FROM compression_insert
 GROUP BY device_id
 ORDER BY device_id;
-CALL recompress_chunk(:'CHUNK_NAME'::regclass);
+SELECT _timescaledb_functions.recompress_chunk(:'CHUNK_NAME'::regclass);
 SELECT count(*), sum(v0), sum(v1), sum(v2), sum(v3)
 FROM compression_insert
 WHERE time >= '2000-01-07 0:00:00+0'
@@ -715,7 +715,7 @@ SELECT device_id, count(*)
 FROM compression_insert
 GROUP BY device_id
 ORDER BY device_id;
-CALL recompress_chunk(:'CHUNK_NAME'::regclass);
+SELECT _timescaledb_functions.recompress_chunk(:'CHUNK_NAME'::regclass);
 SELECT count(*), sum(v0), sum(v1), sum(v2), sum(v3)
 FROM compression_insert
 WHERE time >= '2000-01-15 0:00:00+0'
@@ -756,7 +756,7 @@ SELECT device_id, count(*)
 FROM compression_insert
 GROUP BY device_id
 ORDER BY device_id;
-CALL recompress_chunk(:'CHUNK_NAME'::regclass);
+SELECT _timescaledb_functions.recompress_chunk(:'CHUNK_NAME'::regclass);
 SELECT count(*), sum(v0), sum(v1), sum(v2), sum(v3)
 FROM compression_insert
 WHERE time >= '2000-01-22 0:00:00+0'
@@ -795,7 +795,7 @@ SELECT device_id, count(*)
 FROM compression_insert
 GROUP BY device_id
 ORDER BY device_id;
-CALL recompress_chunk(:'CHUNK_NAME'::regclass);
+SELECT _timescaledb_functions.recompress_chunk(:'CHUNK_NAME'::regclass);
 SELECT count(*), sum(v0), sum(v1), sum(v2), sum(v3)
 FROM compression_insert
 WHERE time >= '2000-01-28 0:00:00+0'

--- a/tsl/test/sql/compression_update_delete.sql
+++ b/tsl/test/sql/compression_update_delete.sql
@@ -95,8 +95,8 @@ FROM compressed_chunk_info_view
 WHERE hypertable_name = 'sample_table' ORDER BY chunk_name;
 
 -- recompress the partial chunks
-CALL recompress_chunk('_timescaledb_internal._hyper_1_1_chunk');
-CALL recompress_chunk('_timescaledb_internal._hyper_1_2_chunk');
+SELECT _timescaledb_functions.recompress_chunk('_timescaledb_internal._hyper_1_1_chunk');
+SELECT _timescaledb_functions.recompress_chunk('_timescaledb_internal._hyper_1_2_chunk');
 
 -- check chunk compression status
 SELECT chunk_status,
@@ -118,8 +118,8 @@ FROM compressed_chunk_info_view
 WHERE hypertable_name = 'sample_table' ORDER BY chunk_name;
 
 -- recompress the paritial chunks
-CALL recompress_chunk('_timescaledb_internal._hyper_1_1_chunk');
-CALL recompress_chunk('_timescaledb_internal._hyper_1_2_chunk');
+SELECT _timescaledb_functions.recompress_chunk('_timescaledb_internal._hyper_1_1_chunk');
+SELECT _timescaledb_functions.recompress_chunk('_timescaledb_internal._hyper_1_2_chunk');
 
 -- test for IS NULL checks
 -- should not UPDATE any rows
@@ -142,8 +142,8 @@ FROM compressed_chunk_info_view
 WHERE hypertable_name = 'sample_table' ORDER BY chunk_name;
 
 -- recompress the paritial chunks
-CALL recompress_chunk('_timescaledb_internal._hyper_1_1_chunk');
-CALL recompress_chunk('_timescaledb_internal._hyper_1_2_chunk');
+SELECT _timescaledb_functions.recompress_chunk('_timescaledb_internal._hyper_1_1_chunk');
+SELECT _timescaledb_functions.recompress_chunk('_timescaledb_internal._hyper_1_2_chunk');
 
 -- check chunk compression status
 SELECT chunk_status,

--- a/tsl/test/sql/include/compression_alter.sql
+++ b/tsl/test/sql/include/compression_alter.sql
@@ -133,7 +133,7 @@ SELECT * FROM test_defaults ORDER BY 1,2;
 -- try insert into compressed and recompress
 INSERT INTO test_defaults SELECT '2000-01-01', 2;
 SELECT * FROM test_defaults ORDER BY 1,2;
-CALL recompress_all_chunks('test_defaults', 1, false);
+SELECT _timescaledb_functions.recompress_chunk(chunk) FROM show_chunks('test_defaults') chunk LIMIT 1;
 SELECT * FROM test_defaults ORDER BY 1,2;
 
 -- timescale/timescaledb#5412

--- a/tsl/test/sql/include/compression_utils.sql
+++ b/tsl/test/sql/include/compression_utils.sql
@@ -119,7 +119,7 @@ DECLARE
 BEGIN
   FOR chunk IN SELECT show_chunks(hypertable) ORDER BY 1 LIMIT lim
   LOOP
-    CALL public.recompress_chunk(chunk, if_not_compressed);
+    PERFORM _timescaledb_functions.recompress_chunk(chunk, if_not_compressed);
   END LOOP;
 END $$ LANGUAGE plpgsql;
 
@@ -132,7 +132,7 @@ DECLARE
 BEGIN
   FOR chunk IN SELECT show_chunks(hypertable) ORDER BY 1
   LOOP
-    CALL public.recompress_chunk(chunk, if_not_compressed);
+    PERFORM _timescaledb_functions.recompress_chunk(chunk, if_not_compressed);
   END LOOP;
 END $$ LANGUAGE plpgsql;
 

--- a/tsl/test/sql/include/recompress_basic.sql
+++ b/tsl/test/sql/include/recompress_basic.sql
@@ -59,11 +59,11 @@ SELECT count(*) from test2;
 -- it contains transaction-terminating commands.
 \set ON_ERROR_STOP 0
 START TRANSACTION;
-CALL recompress_chunk(:'CHUNK_NAME'::regclass);
+SELECT _timescaledb_functions.recompress_chunk(:'CHUNK_NAME'::regclass);
 ROLLBACK;
 \set ON_ERROR_STOP 1
 
-CALL recompress_chunk(:'CHUNK_NAME'::regclass);
+SELECT _timescaledb_functions.recompress_chunk(:'CHUNK_NAME'::regclass);
 
 -- Demonstrate that no locks are held on the hypertable, chunk, or the
 -- compressed chunk after recompress_chunk has executed.
@@ -112,14 +112,14 @@ WHERE hypertable_name = 'test2' ORDER BY chunk_name;
 
 \set ON_ERROR_STOP 0
 -- call recompress_chunk when status is not unordered
-CALL recompress_chunk(:'CHUNK_NAME'::regclass, true);
+SELECT _timescaledb_functions.recompress_chunk(:'CHUNK_NAME'::regclass, true);
 
 -- This will succeed and compress the chunk for the test below.
-CALL recompress_chunk(:'CHUNK_NAME'::regclass, false);
+SELECT _timescaledb_functions.recompress_chunk(:'CHUNK_NAME'::regclass, false);
 
 --now decompress it , then try and recompress
 SELECT decompress_chunk(:'CHUNK_NAME'::regclass);
-CALL recompress_chunk(:'CHUNK_NAME'::regclass);
+SELECT _timescaledb_functions.recompress_chunk(:'CHUNK_NAME'::regclass);
 \set ON_ERROR_STOP 1
 
 -- test recompress policy


### PR DESCRIPTION
Remove the recompress_chunk procedure from the public schema and change it into a function living in _timescaledb_functions schema. This is also adjusts the behaviour of the function to error out less and do the appropriate operation depending on the chunk state.