### PR TITLE
Fix compressed chunk not found during upserts

### DIFF
--- a/.unreleased/fix_6575
+++ b/.unreleased/fix_6575
@@ -1,0 +1,1 @@
+Fixes: #6575 Fix compressed chunk not found during upserts

--- a/src/cross_module_fn.h
+++ b/src/cross_module_fn.h
@@ -126,8 +126,7 @@ typedef struct CrossModuleFunctions
 	PGFunction create_compressed_chunk;
 	PGFunction compress_chunk;
 	PGFunction decompress_chunk;
-	void (*decompress_batches_for_insert)(ChunkInsertState *state, Chunk *chunk,
-										  TupleTableSlot *slot);
+	void (*decompress_batches_for_insert)(const ChunkInsertState *state, TupleTableSlot *slot);
 	bool (*decompress_target_segments)(HypertableModifyState *ht_state);
 	/* The compression functions below are not installed in SQL as part of create extension;
 	 *  They are installed and tested during testing scripts. They are exposed in cross-module

--- a/src/nodes/chunk_dispatch/chunk_insert_state.c
+++ b/src/nodes/chunk_dispatch/chunk_insert_state.c
@@ -19,6 +19,7 @@
 #include <rewrite/rewriteManip.h>
 #include <utils/builtins.h>
 #include <utils/guc.h>
+#include <utils/inval.h>
 #include <utils/lsyscache.h>
 #include <utils/memutils.h>
 #include <utils/rel.h>
@@ -28,10 +29,10 @@
 #include "errors.h"
 #include "chunk_dispatch.h"
 #include "chunk_insert_state.h"
+#include "debug_point.h"
 #include "ts_catalog/continuous_agg.h"
 #include "chunk_index.h"
 #include "indexing.h"
-#include <utils/inval.h>
 
 /* Just like ExecPrepareExpr except that it doesn't switch to the query memory context */
 static inline ExprState *
@@ -582,6 +583,7 @@ ts_chunk_insert_state_create(const Chunk *chunk, ChunkDispatch *dispatch)
 
 	ts_chunk_validate_chunk_status_for_operation(chunk, CHUNK_INSERT, true);
 
+	DEBUG_WAITPOINT("chunk_insert_before_lock");
 	rel = table_open(chunk->table_id, RowExclusiveLock);
 
 	MemoryContext old_mcxt = MemoryContextSwitchTo(cis_context);

--- a/src/nodes/chunk_dispatch/chunk_insert_state.c
+++ b/src/nodes/chunk_dispatch/chunk_insert_state.c
@@ -136,7 +136,7 @@ create_chunk_rri_constraint_expr(ResultRelInfo *rri, Relation rel)
  * The Hypertable ResultRelInfo is used as a template for the chunk's new ResultRelInfo.
  */
 static inline ResultRelInfo *
-create_chunk_result_relation_info(ChunkDispatch *dispatch, Relation rel)
+create_chunk_result_relation_info(const ChunkDispatch *dispatch, Relation rel)
 {
 	ResultRelInfo *rri;
 	ResultRelInfo *rri_orig = dispatch->hypertable_result_rel_info;
@@ -331,7 +331,7 @@ adjust_chunk_colnos(List *colnos, ResultRelInfo *chunk_rri)
  * columns, etc.
  */
 static void
-setup_on_conflict_state(ChunkInsertState *state, ChunkDispatch *dispatch,
+setup_on_conflict_state(ChunkInsertState *state, const ChunkDispatch *dispatch,
 						TupleConversionMap *chunk_map)
 {
 	TupleConversionMap *map = state->hyper_to_chunk_map;
@@ -485,7 +485,7 @@ destroy_on_conflict_state(ChunkInsertState *state)
 
 /* Translate hypertable indexes to chunk indexes in the arbiter clause */
 static void
-set_arbiter_indexes(ChunkInsertState *state, ChunkDispatch *dispatch)
+set_arbiter_indexes(ChunkInsertState *state, const ChunkDispatch *dispatch)
 {
 	List *arbiter_indexes = chunk_dispatch_get_arbiter_indexes(dispatch);
 	ListCell *lc;
@@ -519,7 +519,7 @@ set_arbiter_indexes(ChunkInsertState *state, ChunkDispatch *dispatch)
 
 /* Change the projections to work with chunks instead of hypertables */
 static void
-adjust_projections(ChunkInsertState *cis, ChunkDispatch *dispatch, Oid rowtype)
+adjust_projections(ChunkInsertState *cis, const ChunkDispatch *dispatch, Oid rowtype)
 {
 	ResultRelInfo *chunk_rri = cis->result_relation_info;
 	Relation hyper_rel = dispatch->hypertable_result_rel_info->ri_RelationDesc;
@@ -564,7 +564,7 @@ adjust_projections(ChunkInsertState *cis, ChunkDispatch *dispatch, Oid rowtype)
  * ResultRelInfo should be similar to ExecInitModifyTable().
  */
 extern ChunkInsertState *
-ts_chunk_insert_state_create(const Chunk *chunk, ChunkDispatch *dispatch)
+ts_chunk_insert_state_create(Oid chunk_relid, const ChunkDispatch *dispatch)
 {
 	ChunkInsertState *state;
 	Relation rel, parent_rel;
@@ -573,18 +573,33 @@ ts_chunk_insert_state_create(const Chunk *chunk, ChunkDispatch *dispatch)
 													  ALLOCSET_DEFAULT_SIZES);
 	OnConflictAction onconflict_action = chunk_dispatch_get_on_conflict_action(dispatch);
 	ResultRelInfo *relinfo;
+	const Chunk *chunk;
 
 	/* permissions NOT checked here; were checked at hypertable level */
-	if (check_enable_rls(chunk->table_id, InvalidOid, false) == RLS_ENABLED)
+	if (check_enable_rls(chunk_relid, InvalidOid, false) == RLS_ENABLED)
 		ereport(ERROR,
 				(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
 				 errmsg("hypertables do not support row-level security")));
-	Assert(chunk->relkind == RELKIND_RELATION || chunk->relkind == RELKIND_FOREIGN_TABLE);
 
-	ts_chunk_validate_chunk_status_for_operation(chunk, CHUNK_INSERT, true);
-
+	/*
+	 * Since we insert data and won't modify metadata, a RowExclusiveLock
+	 * should be sufficient. This should conflict with any metadata-modifying
+	 * operations as they should take higher-level locks (ShareLock and
+	 * above).
+	 */
 	DEBUG_WAITPOINT("chunk_insert_before_lock");
-	rel = table_open(chunk->table_id, RowExclusiveLock);
+	rel = table_open(chunk_relid, RowExclusiveLock);
+
+	/*
+	 * A concurrent chunk operation (e.g., compression) might have changed the
+	 * chunk metadata before we got a lock, so re-read it.
+	 *
+	 * This works even in higher levels of isolation since catalog data is
+	 * always read from latest snapshot.
+	 */
+	chunk = ts_chunk_get_by_relid(chunk_relid, true);
+	Assert(chunk->relkind == RELKIND_RELATION || chunk->relkind == RELKIND_FOREIGN_TABLE);
+	ts_chunk_validate_chunk_status_for_operation(chunk, CHUNK_INSERT, true);
 
 	MemoryContext old_mcxt = MemoryContextSwitchTo(cis_context);
 	relinfo = create_chunk_result_relation_info(dispatch, rel);
@@ -643,7 +658,9 @@ ts_chunk_insert_state_create(const Chunk *chunk, ChunkDispatch *dispatch)
 										   table_slot_callbacks(relinfo->ri_RelationDesc));
 	table_close(parent_rel, AccessShareLock);
 
+	state->hypertable_relid = chunk->hypertable_relid;
 	state->chunk_id = chunk->fd.id;
+	state->compressed_chunk_id = chunk->fd.compressed_chunk_id;
 
 	if (chunk->relkind == RELKIND_FOREIGN_TABLE)
 	{

--- a/src/nodes/chunk_dispatch/chunk_insert_state.h
+++ b/src/nodes/chunk_dispatch/chunk_insert_state.h
@@ -47,7 +47,9 @@ typedef struct ChunkInsertState
 	TupleConversionMap *hyper_to_chunk_map;
 	MemoryContext mctx;
 	EState *estate;
+	Oid hypertable_relid;
 	int32 chunk_id;
+	int32 compressed_chunk_id;
 	Oid user_id;
 
 	/* for tracking compressed chunks */
@@ -57,7 +59,8 @@ typedef struct ChunkInsertState
 
 typedef struct ChunkDispatch ChunkDispatch;
 
-extern ChunkInsertState *ts_chunk_insert_state_create(const Chunk *chunk, ChunkDispatch *dispatch);
+extern ChunkInsertState *ts_chunk_insert_state_create(Oid chunk_relid,
+													  const ChunkDispatch *dispatch);
 extern void ts_chunk_insert_state_destroy(ChunkInsertState *state);
 
 OnConflictAction chunk_dispatch_get_on_conflict_action(const ChunkDispatch *dispatch);

--- a/tsl/src/compression/compression.c
+++ b/tsl/src/compression/compression.c
@@ -2141,7 +2141,7 @@ compressed_insert_key_columns(Relation relation)
 }
 
 void
-decompress_batches_for_insert(ChunkInsertState *cis, Chunk *chunk, TupleTableSlot *slot)
+decompress_batches_for_insert(const ChunkInsertState *cis, TupleTableSlot *slot)
 {
 	/* COPY operation can end up flushing an empty buffer which
 	 * could in turn send an empty slot our way. No need to decompress
@@ -2168,15 +2168,15 @@ decompress_batches_for_insert(ChunkInsertState *cis, Chunk *chunk, TupleTableSlo
 				 errmsg("inserting into compressed chunk with unique constraints disabled"),
 				 errhint("Set timescaledb.enable_dml_decompression to TRUE.")));
 
-	Chunk *comp = ts_chunk_get_by_id(chunk->fd.compressed_chunk_id, true);
-	Relation in_rel = relation_open(comp->table_id, RowExclusiveLock);
+	Oid comp_relid = ts_chunk_get_relid(cis->compressed_chunk_id, false);
+	Relation in_rel = relation_open(comp_relid, RowExclusiveLock);
 
 	RowDecompressor decompressor = build_decompressor(in_rel, out_rel);
 	Bitmapset *key_columns = compressed_insert_key_columns(out_rel);
 	Bitmapset *null_columns = NULL;
 
 	int num_scankeys;
-	ScanKeyData *scankeys = build_scankeys(chunk->hypertable_relid,
+	ScanKeyData *scankeys = build_scankeys(cis->hypertable_relid,
 										   in_rel->rd_id,
 										   &decompressor,
 										   key_columns,

--- a/tsl/src/compression/compression.h
+++ b/tsl/src/compression/compression.h
@@ -332,8 +332,7 @@ extern DecompressAllFunction tsl_get_decompress_all_function(CompressionAlgorith
 
 typedef struct Chunk Chunk;
 typedef struct ChunkInsertState ChunkInsertState;
-extern void decompress_batches_for_insert(ChunkInsertState *cis, Chunk *chunk,
-										  TupleTableSlot *slot);
+extern void decompress_batches_for_insert(const ChunkInsertState *cis, TupleTableSlot *slot);
 #if PG14_GE
 typedef struct HypertableModifyState HypertableModifyState;
 extern bool decompress_target_segments(HypertableModifyState *ht_state);

--- a/tsl/test/isolation/expected/compression_recompress.out
+++ b/tsl/test/isolation/expected/compression_recompress.out
@@ -1,4 +1,4 @@
-Parsed test spec with 2 sessions
+Parsed test spec with 3 sessions
 
 starting permutation: s2_block_on_compressed_chunk_size s1_begin s1_recompress_chunk s2_select_from_compressed_chunk s2_wait_for_select_to_finish s2_unblock s1_rollback
 step s2_block_on_compressed_chunk_size: 
@@ -35,3 +35,99 @@ recompress
 step s1_rollback: 
 	ROLLBACK;
 
+
+starting permutation: s1_compress s3_block_chunk_insert s2_insert s1_decompress s1_compress s3_release_chunk_insert
+step s1_compress: 
+   SELECT compression_status FROM chunk_compression_stats('sensor_data');
+   SELECT count(*) FROM (SELECT compress_chunk(i, if_not_compressed => true) FROM show_chunks('sensor_data') i) i;
+   SELECT compression_status FROM chunk_compression_stats('sensor_data');
+   SELECT count(*) FROM sensor_data;
+
+compression_status
+------------------
+Compressed        
+(1 row)
+
+s1: NOTICE:  chunk "_hyper_X_X_chunk" is already compressed
+count
+-----
+    1
+(1 row)
+
+compression_status
+------------------
+Compressed        
+(1 row)
+
+count
+-----
+15840
+(1 row)
+
+step s3_block_chunk_insert: 
+	SELECT debug_waitpoint_enable('chunk_insert_before_lock');
+
+debug_waitpoint_enable
+----------------------
+                      
+(1 row)
+
+step s2_insert: 
+   INSERT INTO sensor_data VALUES ('2022-01-01 20:00'::timestamptz, 1, 1.0, 1.0), ('2022-01-01 21:00'::timestamptz, 2, 2.0, 2.0) ON CONFLICT (time, sensor_id) DO NOTHING;
+ <waiting ...>
+step s1_decompress: 
+   SELECT count(*) FROM (SELECT decompress_chunk(i) FROM show_chunks('sensor_data') i) i;
+   SELECT compression_status FROM chunk_compression_stats('sensor_data');
+   SELECT count(*) FROM sensor_data;
+
+count
+-----
+    1
+(1 row)
+
+compression_status
+------------------
+Uncompressed      
+(1 row)
+
+count
+-----
+15840
+(1 row)
+
+step s1_compress: 
+   SELECT compression_status FROM chunk_compression_stats('sensor_data');
+   SELECT count(*) FROM (SELECT compress_chunk(i, if_not_compressed => true) FROM show_chunks('sensor_data') i) i;
+   SELECT compression_status FROM chunk_compression_stats('sensor_data');
+   SELECT count(*) FROM sensor_data;
+
+compression_status
+------------------
+Uncompressed      
+(1 row)
+
+count
+-----
+    1
+(1 row)
+
+compression_status
+------------------
+Compressed        
+(1 row)
+
+count
+-----
+15840
+(1 row)
+
+step s3_release_chunk_insert: 
+	SELECT debug_waitpoint_release('chunk_insert_before_lock');
+
+debug_waitpoint_release
+-----------------------
+                       
+(1 row)
+
+step s2_insert: <... completed>
+ERROR:  chunk not found

--- a/tsl/test/isolation/expected/compression_recompress.out
+++ b/tsl/test/isolation/expected/compression_recompress.out
@@ -130,4 +130,3 @@ debug_waitpoint_release
 (1 row)
 
 step s2_insert: <... completed>
-ERROR:  chunk not found


### PR DESCRIPTION
When inserting into a compressed chunk with an ON CONFLICT clause, and there is a concurrent recompression of the chunk, an error can occur due to a failed lookup of the compressed chunk.

The error happens because the chunk information is re-read from an outdated cache holding a compressed chunk ID that no longer exists after the chunk was recompressed (recompression effectively removes the compressed chunk and creates it again).

Fix this issue by ensuring that the insert path only uses up-to-date chunk metadata read _after_ the lock on the chunk was taken.

Disable-Check: commit-count