### PR TITLE
Change boolean default value for compress_chunk and decompress_chunk

### DIFF
--- a/.unreleased/pr_6579
+++ b/.unreleased/pr_6579
@@ -1,0 +1,1 @@
+Implements: #6579 Change compress_chunk and decompress_chunk to idempotent version by default

--- a/tsl/test/expected/compression.out
+++ b/tsl/test/expected/compression.out
@@ -172,8 +172,8 @@ where ch1.compressed_chunk_id = ch2.id;
 (2 rows)
 
 \set ON_ERROR_STOP 0
---cannot recompress the chunk the second time around
-select compress_chunk( '_timescaledb_internal._hyper_1_2_chunk');
+--cannot compress the chunk the second time around
+select compress_chunk( '_timescaledb_internal._hyper_1_2_chunk', false);
 ERROR:  chunk "_hyper_1_2_chunk" is already compressed
 --TEST2a try DML on a compressed chunk
 BEGIN;

--- a/tsl/test/expected/compression_errors-13.out
+++ b/tsl/test/expected/compression_errors-13.out
@@ -217,7 +217,7 @@ SELECT * FROM _timescaledb_catalog.compression_settings WHERE relid = 'foo'::reg
  foo   |           | {a,b}   | {f,f}        | {f,f}
 (1 row)
 
-SELECT decompress_chunk(ch) FROM show_chunks('foo') ch limit 1;
+SELECT decompress_chunk(ch, false) FROM show_chunks('foo') ch limit 1;
 ERROR:  chunk "_hyper_10_2_chunk" is not compressed
 --test changing the segment by columns
 ALTER TABLE foo set (timescaledb.compress, timescaledb.compress_orderby = 'a', timescaledb.compress_segmentby = 'b');
@@ -225,9 +225,9 @@ SELECT format('%I.%I',chunk_schema,chunk_name) AS "CHUNK_NAME"
 FROM timescaledb_information.chunks
 WHERE hypertable_name = 'foo'
 ORDER BY chunk_name LIMIT 1\gset
-select decompress_chunk(:'CHUNK_NAME');
+select decompress_chunk(:'CHUNK_NAME', if_compressed=>false);
 ERROR:  chunk "_hyper_10_2_chunk" is not compressed
-select decompress_chunk(:'CHUNK_NAME', if_compressed=>true);
+select decompress_chunk(:'CHUNK_NAME');
 NOTICE:  chunk "_hyper_10_2_chunk" is not compressed
  decompress_chunk 
 ------------------
@@ -241,9 +241,9 @@ select compress_chunk(:'CHUNK_NAME');
  _timescaledb_internal._hyper_10_2_chunk
 (1 row)
 
-select compress_chunk(:'CHUNK_NAME');
+select compress_chunk(:'CHUNK_NAME', if_not_compressed=>false);
 ERROR:  chunk "_hyper_10_2_chunk" is already compressed
-select compress_chunk(:'CHUNK_NAME', if_not_compressed=>true);
+select compress_chunk(:'CHUNK_NAME');
 NOTICE:  chunk "_hyper_10_2_chunk" is already compressed
              compress_chunk              
 -----------------------------------------

--- a/tsl/test/expected/compression_errors-14.out
+++ b/tsl/test/expected/compression_errors-14.out
@@ -217,7 +217,7 @@ SELECT * FROM _timescaledb_catalog.compression_settings WHERE relid = 'foo'::reg
  foo   |           | {a,b}   | {f,f}        | {f,f}
 (1 row)
 
-SELECT decompress_chunk(ch) FROM show_chunks('foo') ch limit 1;
+SELECT decompress_chunk(ch, false) FROM show_chunks('foo') ch limit 1;
 ERROR:  chunk "_hyper_10_2_chunk" is not compressed
 --test changing the segment by columns
 ALTER TABLE foo set (timescaledb.compress, timescaledb.compress_orderby = 'a', timescaledb.compress_segmentby = 'b');
@@ -225,9 +225,9 @@ SELECT format('%I.%I',chunk_schema,chunk_name) AS "CHUNK_NAME"
 FROM timescaledb_information.chunks
 WHERE hypertable_name = 'foo'
 ORDER BY chunk_name LIMIT 1\gset
-select decompress_chunk(:'CHUNK_NAME');
+select decompress_chunk(:'CHUNK_NAME', if_compressed=>false);
 ERROR:  chunk "_hyper_10_2_chunk" is not compressed
-select decompress_chunk(:'CHUNK_NAME', if_compressed=>true);
+select decompress_chunk(:'CHUNK_NAME');
 NOTICE:  chunk "_hyper_10_2_chunk" is not compressed
  decompress_chunk 
 ------------------
@@ -241,9 +241,9 @@ select compress_chunk(:'CHUNK_NAME');
  _timescaledb_internal._hyper_10_2_chunk
 (1 row)
 
-select compress_chunk(:'CHUNK_NAME');
+select compress_chunk(:'CHUNK_NAME', if_not_compressed=>false);
 ERROR:  chunk "_hyper_10_2_chunk" is already compressed
-select compress_chunk(:'CHUNK_NAME', if_not_compressed=>true);
+select compress_chunk(:'CHUNK_NAME');
 NOTICE:  chunk "_hyper_10_2_chunk" is already compressed
              compress_chunk              
 -----------------------------------------

--- a/tsl/test/expected/compression_errors-15.out
+++ b/tsl/test/expected/compression_errors-15.out
@@ -217,7 +217,7 @@ SELECT * FROM _timescaledb_catalog.compression_settings WHERE relid = 'foo'::reg
  foo   |           | {a,b}   | {f,f}        | {f,f}
 (1 row)
 
-SELECT decompress_chunk(ch) FROM show_chunks('foo') ch limit 1;
+SELECT decompress_chunk(ch, false) FROM show_chunks('foo') ch limit 1;
 ERROR:  chunk "_hyper_10_2_chunk" is not compressed
 --test changing the segment by columns
 ALTER TABLE foo set (timescaledb.compress, timescaledb.compress_orderby = 'a', timescaledb.compress_segmentby = 'b');
@@ -225,9 +225,9 @@ SELECT format('%I.%I',chunk_schema,chunk_name) AS "CHUNK_NAME"
 FROM timescaledb_information.chunks
 WHERE hypertable_name = 'foo'
 ORDER BY chunk_name LIMIT 1\gset
-select decompress_chunk(:'CHUNK_NAME');
+select decompress_chunk(:'CHUNK_NAME', if_compressed=>false);
 ERROR:  chunk "_hyper_10_2_chunk" is not compressed
-select decompress_chunk(:'CHUNK_NAME', if_compressed=>true);
+select decompress_chunk(:'CHUNK_NAME');
 NOTICE:  chunk "_hyper_10_2_chunk" is not compressed
  decompress_chunk 
 ------------------
@@ -241,9 +241,9 @@ select compress_chunk(:'CHUNK_NAME');
  _timescaledb_internal._hyper_10_2_chunk
 (1 row)
 
-select compress_chunk(:'CHUNK_NAME');
+select compress_chunk(:'CHUNK_NAME', if_not_compressed=>false);
 ERROR:  chunk "_hyper_10_2_chunk" is already compressed
-select compress_chunk(:'CHUNK_NAME', if_not_compressed=>true);
+select compress_chunk(:'CHUNK_NAME');
 NOTICE:  chunk "_hyper_10_2_chunk" is already compressed
              compress_chunk              
 -----------------------------------------

--- a/tsl/test/expected/compression_errors-16.out
+++ b/tsl/test/expected/compression_errors-16.out
@@ -217,7 +217,7 @@ SELECT * FROM _timescaledb_catalog.compression_settings WHERE relid = 'foo'::reg
  foo   |           | {a,b}   | {f,f}        | {f,f}
 (1 row)
 
-SELECT decompress_chunk(ch) FROM show_chunks('foo') ch limit 1;
+SELECT decompress_chunk(ch, false) FROM show_chunks('foo') ch limit 1;
 ERROR:  chunk "_hyper_10_2_chunk" is not compressed
 --test changing the segment by columns
 ALTER TABLE foo set (timescaledb.compress, timescaledb.compress_orderby = 'a', timescaledb.compress_segmentby = 'b');
@@ -225,9 +225,9 @@ SELECT format('%I.%I',chunk_schema,chunk_name) AS "CHUNK_NAME"
 FROM timescaledb_information.chunks
 WHERE hypertable_name = 'foo'
 ORDER BY chunk_name LIMIT 1\gset
-select decompress_chunk(:'CHUNK_NAME');
+select decompress_chunk(:'CHUNK_NAME', if_compressed=>false);
 ERROR:  chunk "_hyper_10_2_chunk" is not compressed
-select decompress_chunk(:'CHUNK_NAME', if_compressed=>true);
+select decompress_chunk(:'CHUNK_NAME');
 NOTICE:  chunk "_hyper_10_2_chunk" is not compressed
  decompress_chunk 
 ------------------
@@ -241,9 +241,9 @@ select compress_chunk(:'CHUNK_NAME');
  _timescaledb_internal._hyper_10_2_chunk
 (1 row)
 
-select compress_chunk(:'CHUNK_NAME');
+select compress_chunk(:'CHUNK_NAME', if_not_compressed=>false);
 ERROR:  chunk "_hyper_10_2_chunk" is already compressed
-select compress_chunk(:'CHUNK_NAME', if_not_compressed=>true);
+select compress_chunk(:'CHUNK_NAME');
 NOTICE:  chunk "_hyper_10_2_chunk" is already compressed
              compress_chunk              
 -----------------------------------------

--- a/tsl/test/isolation/expected/compression_ddl_iso.out
+++ b/tsl/test/isolation/expected/compression_ddl_iso.out
@@ -20,7 +20,7 @@ step C1:
   SET LOCAL lock_timeout = '500ms';
   SET LOCAL deadlock_timeout = '10ms';
   SELECT
-    CASE WHEN compress_chunk(format('%I.%I',ch.schema_name, ch.table_name)) IS NOT NULL THEN true ELSE false END AS compress
+    compress_chunk(format('%I.%I',ch.schema_name, ch.table_name)) IS NOT NULL AS compress
   FROM _timescaledb_catalog.hypertable ht, _timescaledb_catalog.chunk ch
   WHERE ch.hypertable_id = ht.id AND ht.table_name like 'ts_device_table'
   ORDER BY ch.id LIMIT 1;
@@ -67,7 +67,7 @@ step C1:
   SET LOCAL lock_timeout = '500ms';
   SET LOCAL deadlock_timeout = '10ms';
   SELECT
-    CASE WHEN compress_chunk(format('%I.%I',ch.schema_name, ch.table_name)) IS NOT NULL THEN true ELSE false END AS compress
+    compress_chunk(format('%I.%I',ch.schema_name, ch.table_name)) IS NOT NULL AS compress
   FROM _timescaledb_catalog.hypertable ht, _timescaledb_catalog.chunk ch
   WHERE ch.hypertable_id = ht.id AND ht.table_name like 'ts_device_table'
   ORDER BY ch.id LIMIT 1;
@@ -104,7 +104,7 @@ step C1:
   SET LOCAL lock_timeout = '500ms';
   SET LOCAL deadlock_timeout = '10ms';
   SELECT
-    CASE WHEN compress_chunk(format('%I.%I',ch.schema_name, ch.table_name)) IS NOT NULL THEN true ELSE false END AS compress
+    compress_chunk(format('%I.%I',ch.schema_name, ch.table_name)) IS NOT NULL AS compress
   FROM _timescaledb_catalog.hypertable ht, _timescaledb_catalog.chunk ch
   WHERE ch.hypertable_id = ht.id AND ht.table_name like 'ts_device_table'
   ORDER BY ch.id LIMIT 1;
@@ -136,7 +136,7 @@ step C1:
   SET LOCAL lock_timeout = '500ms';
   SET LOCAL deadlock_timeout = '10ms';
   SELECT
-    CASE WHEN compress_chunk(format('%I.%I',ch.schema_name, ch.table_name)) IS NOT NULL THEN true ELSE false END AS compress
+    compress_chunk(format('%I.%I',ch.schema_name, ch.table_name)) IS NOT NULL AS compress
   FROM _timescaledb_catalog.hypertable ht, _timescaledb_catalog.chunk ch
   WHERE ch.hypertable_id = ht.id AND ht.table_name like 'ts_device_table'
   ORDER BY ch.id LIMIT 1;
@@ -171,7 +171,7 @@ step C1:
   SET LOCAL lock_timeout = '500ms';
   SET LOCAL deadlock_timeout = '10ms';
   SELECT
-    CASE WHEN compress_chunk(format('%I.%I',ch.schema_name, ch.table_name)) IS NOT NULL THEN true ELSE false END AS compress
+    compress_chunk(format('%I.%I',ch.schema_name, ch.table_name)) IS NOT NULL AS compress
   FROM _timescaledb_catalog.hypertable ht, _timescaledb_catalog.chunk ch
   WHERE ch.hypertable_id = ht.id AND ht.table_name like 'ts_device_table'
   ORDER BY ch.id LIMIT 1;
@@ -180,7 +180,7 @@ step D1:
   BEGIN;
   SET LOCAL client_min_messages TO WARNING;
   SELECT
-    CASE WHEN decompress_chunk(ch, true) IS NOT NULL THEN true ELSE false END AS decompress
+    decompress_chunk(ch) IS NOT NULL AS decompress
   FROM show_chunks('ts_device_table') AS ch
   ORDER BY ch::text LIMIT 1;
 
@@ -218,7 +218,7 @@ step C1:
   SET LOCAL lock_timeout = '500ms';
   SET LOCAL deadlock_timeout = '10ms';
   SELECT
-    CASE WHEN compress_chunk(format('%I.%I',ch.schema_name, ch.table_name)) IS NOT NULL THEN true ELSE false END AS compress
+    compress_chunk(format('%I.%I',ch.schema_name, ch.table_name)) IS NOT NULL AS compress
   FROM _timescaledb_catalog.hypertable ht, _timescaledb_catalog.chunk ch
   WHERE ch.hypertable_id = ht.id AND ht.table_name like 'ts_device_table'
   ORDER BY ch.id LIMIT 1;
@@ -263,7 +263,7 @@ step C1:
   SET LOCAL lock_timeout = '500ms';
   SET LOCAL deadlock_timeout = '10ms';
   SELECT
-    CASE WHEN compress_chunk(format('%I.%I',ch.schema_name, ch.table_name)) IS NOT NULL THEN true ELSE false END AS compress
+    compress_chunk(format('%I.%I',ch.schema_name, ch.table_name)) IS NOT NULL AS compress
   FROM _timescaledb_catalog.hypertable ht, _timescaledb_catalog.chunk ch
   WHERE ch.hypertable_id = ht.id AND ht.table_name like 'ts_device_table'
   ORDER BY ch.id LIMIT 1;
@@ -295,7 +295,7 @@ step C1:
   SET LOCAL lock_timeout = '500ms';
   SET LOCAL deadlock_timeout = '10ms';
   SELECT
-    CASE WHEN compress_chunk(format('%I.%I',ch.schema_name, ch.table_name)) IS NOT NULL THEN true ELSE false END AS compress
+    compress_chunk(format('%I.%I',ch.schema_name, ch.table_name)) IS NOT NULL AS compress
   FROM _timescaledb_catalog.hypertable ht, _timescaledb_catalog.chunk ch
   WHERE ch.hypertable_id = ht.id AND ht.table_name like 'ts_device_table'
   ORDER BY ch.id LIMIT 1;
@@ -337,7 +337,7 @@ step C1:
   SET LOCAL lock_timeout = '500ms';
   SET LOCAL deadlock_timeout = '10ms';
   SELECT
-    CASE WHEN compress_chunk(format('%I.%I',ch.schema_name, ch.table_name)) IS NOT NULL THEN true ELSE false END AS compress
+    compress_chunk(format('%I.%I',ch.schema_name, ch.table_name)) IS NOT NULL AS compress
   FROM _timescaledb_catalog.hypertable ht, _timescaledb_catalog.chunk ch
   WHERE ch.hypertable_id = ht.id AND ht.table_name like 'ts_device_table'
   ORDER BY ch.id LIMIT 1;
@@ -379,7 +379,7 @@ step C1:
   SET LOCAL lock_timeout = '500ms';
   SET LOCAL deadlock_timeout = '10ms';
   SELECT
-    CASE WHEN compress_chunk(format('%I.%I',ch.schema_name, ch.table_name)) IS NOT NULL THEN true ELSE false END AS compress
+    compress_chunk(format('%I.%I',ch.schema_name, ch.table_name)) IS NOT NULL AS compress
   FROM _timescaledb_catalog.hypertable ht, _timescaledb_catalog.chunk ch
   WHERE ch.hypertable_id = ht.id AND ht.table_name like 'ts_device_table'
   ORDER BY ch.id LIMIT 1;
@@ -431,7 +431,7 @@ step C1:
   SET LOCAL lock_timeout = '500ms';
   SET LOCAL deadlock_timeout = '10ms';
   SELECT
-    CASE WHEN compress_chunk(format('%I.%I',ch.schema_name, ch.table_name)) IS NOT NULL THEN true ELSE false END AS compress
+    compress_chunk(format('%I.%I',ch.schema_name, ch.table_name)) IS NOT NULL AS compress
   FROM _timescaledb_catalog.hypertable ht, _timescaledb_catalog.chunk ch
   WHERE ch.hypertable_id = ht.id AND ht.table_name like 'ts_device_table'
   ORDER BY ch.id LIMIT 1;
@@ -481,7 +481,7 @@ starting permutation: CA1 CAc I1 Ic SChunkStat LockChunk1 RC1 IN1 UnlockChunk IN
 step CA1: 
   BEGIN;
   SELECT
-    CASE WHEN compress_chunk(ch) IS NOT NULL THEN true ELSE false END AS compress
+    compress_chunk(ch) IS NOT NULL AS compress
   FROM show_chunks('ts_device_table') AS ch
   ORDER BY ch::text;
 
@@ -589,7 +589,7 @@ starting permutation: CA1 CAc I1 Ic SChunkStat LockChunk1 RC1 RC2 UnlockChunk SH
 step CA1: 
   BEGIN;
   SELECT
-    CASE WHEN compress_chunk(ch) IS NOT NULL THEN true ELSE false END AS compress
+    compress_chunk(ch) IS NOT NULL AS compress
   FROM show_chunks('ts_device_table') AS ch
   ORDER BY ch::text;
 
@@ -646,7 +646,7 @@ step RC2:
       SELECT ch FROM show_chunks('ts_device_table') ch
        ORDER BY ch::text LIMIT 1
      LOOP
-         CALL recompress_chunk(chunk_name);
+         CALL recompress_chunk(chunk_name, false);
      END LOOP;
   END;
   $$;

--- a/tsl/test/isolation/specs/compression_ddl_iso.spec
+++ b/tsl/test/isolation/specs/compression_ddl_iso.spec
@@ -72,7 +72,7 @@ step "C1"   {
   SET LOCAL lock_timeout = '500ms';
   SET LOCAL deadlock_timeout = '10ms';
   SELECT
-    CASE WHEN compress_chunk(format('%I.%I',ch.schema_name, ch.table_name)) IS NOT NULL THEN true ELSE false END AS compress
+    compress_chunk(format('%I.%I',ch.schema_name, ch.table_name)) IS NOT NULL AS compress
   FROM _timescaledb_catalog.hypertable ht, _timescaledb_catalog.chunk ch
   WHERE ch.hypertable_id = ht.id AND ht.table_name like 'ts_device_table'
   ORDER BY ch.id LIMIT 1;
@@ -88,7 +88,7 @@ step "D1"   {
   BEGIN;
   SET LOCAL client_min_messages TO WARNING;
   SELECT
-    CASE WHEN decompress_chunk(ch, true) IS NOT NULL THEN true ELSE false END AS decompress
+    decompress_chunk(ch) IS NOT NULL AS decompress
   FROM show_chunks('ts_device_table') AS ch
   ORDER BY ch::text LIMIT 1;
 }
@@ -98,7 +98,7 @@ session "CompressAll"
 step "CA1" {
   BEGIN;
   SELECT
-    CASE WHEN compress_chunk(ch) IS NOT NULL THEN true ELSE false END AS compress
+    compress_chunk(ch) IS NOT NULL AS compress
   FROM show_chunks('ts_device_table') AS ch
   ORDER BY ch::text;
 }
@@ -130,7 +130,7 @@ step "RC2" {
       SELECT ch FROM show_chunks('ts_device_table') ch
        ORDER BY ch::text LIMIT 1
      LOOP
-         CALL recompress_chunk(chunk_name);
+         CALL recompress_chunk(chunk_name, false);
      END LOOP;
   END;
   $$;

--- a/tsl/test/sql/compression.sql
+++ b/tsl/test/sql/compression.sql
@@ -56,8 +56,8 @@ _timescaledb_catalog.chunk ch1, _timescaledb_catalog.chunk ch2
 where ch1.compressed_chunk_id = ch2.id;
 
 \set ON_ERROR_STOP 0
---cannot recompress the chunk the second time around
-select compress_chunk( '_timescaledb_internal._hyper_1_2_chunk');
+--cannot compress the chunk the second time around
+select compress_chunk( '_timescaledb_internal._hyper_1_2_chunk', false);
 
 --TEST2a try DML on a compressed chunk
 BEGIN;

--- a/tsl/test/sql/compression_errors.sql.in
+++ b/tsl/test/sql/compression_errors.sql.in
@@ -117,7 +117,7 @@ ALTER TABLE foo DROP CONSTRAINT chk_existing;
 --note that the time column "a" should not be added to the end of the order by list again (should appear first)
 SELECT * FROM _timescaledb_catalog.compression_settings WHERE relid = 'foo'::regclass;
 
-SELECT decompress_chunk(ch) FROM show_chunks('foo') ch limit 1;
+SELECT decompress_chunk(ch, false) FROM show_chunks('foo') ch limit 1;
 
 --test changing the segment by columns
 ALTER TABLE foo set (timescaledb.compress, timescaledb.compress_orderby = 'a', timescaledb.compress_segmentby = 'b');
@@ -127,13 +127,13 @@ FROM timescaledb_information.chunks
 WHERE hypertable_name = 'foo'
 ORDER BY chunk_name LIMIT 1\gset
 
+select decompress_chunk(:'CHUNK_NAME', if_compressed=>false);
 select decompress_chunk(:'CHUNK_NAME');
-select decompress_chunk(:'CHUNK_NAME', if_compressed=>true);
 
 --should succeed
 select compress_chunk(:'CHUNK_NAME');
+select compress_chunk(:'CHUNK_NAME', if_not_compressed=>false);
 select compress_chunk(:'CHUNK_NAME');
-select compress_chunk(:'CHUNK_NAME', if_not_compressed=>true);
 
 SELECT compress_chunk(ch) FROM show_chunks('non_compressed') ch LIMIT 1;
 


### PR DESCRIPTION
This patch changes those functions to no longer error by default when the chunk is not the expected state, instead a warning is raised. This is in preparation for changing compress_chunk to forward to the appropriate operation depending on the chunk state.