### PR TITLE
Fix openssl issues on MacOSX on CI

### DIFF
--- a/.github/ci_settings.py
+++ b/.github/ci_settings.py
@@ -9,6 +9,9 @@
 # EARLIEST is the minimum postgres version required when building from source
 # LATEST is the maximum postgres version that is supported
 # ABI_MIN is the minimum postgres version required when the extension was build against LATEST
+#
+# TODO: Enable tests uploading in linux-build-and-test.yaml for macos once we
+# move to a new minor version below
 
 PG13_EARLIEST = "13.2"
 PG13_LATEST = "13.13"

--- a/.github/workflows/linux-build-and-test.yaml
+++ b/.github/workflows/linux-build-and-test.yaml
@@ -70,14 +70,6 @@ jobs:
       if: runner.os == 'macOS'
       run: |
         brew install gawk
-
-        # Force use of OpenSSL 3.1.4, since OpenSSL 3.2.0 crashes with recent
-        # PostgreSQL versions on OS X (see https://github.com/Homebrew/homebrew-core/issues/155651)
-        brew install --overwrite python@3.12
-        brew unlink openssl@3
-        curl -L https://raw.githubusercontent.com/Homebrew/homebrew-core/e68186ba5a05a6ea9a30d6c7744de9a46bd3aadd/Formula/o/openssl@3.rb > openssl@3.rb
-        brew install openssl@3.rb
-
         # Install perl modules after last Homebew call, since Homebrew can change the perl version
         sudo perl -MCPAN -e "CPAN::Shell->notest('install', 'IPC::Run')"
         sudo perl -MCPAN -e "CPAN::Shell->notest('install', 'Test::Most')"
@@ -281,8 +273,9 @@ jobs:
 
     - name: Upload test results to the database
       # Don't upload the results of the flaky check, because the db schema only
-      # supports running one test once per job.
-      if: always() && (! contains(matrix.name, 'Flaky'))
+      # supports running one test once per job. Also disable uploading of the
+      # tests on macOS till the next MINOR release of PG
+      if: always() && (! contains(matrix.name, 'Flaky')) && (! runner.os == 'macOS')
       env:
         # GitHub Actions allow you neither to use the env context for the job name,
         # nor to access the job name from the step context, so we have to


### PR DESCRIPTION
Issues due to OpenSSL 3.2 seem to be resolved via components
installing 3.1.x. So, remove our temporary changes.

We also disable uploading of test stats till the next minor release
 of PG on macOS.

Disable-check: force-changelog-file