### PR TITLE
Bump pgspot to 0.7.0

### DIFF
--- a/.github/workflows/pgspot.yaml
+++ b/.github/workflows/pgspot.yaml
@@ -47,7 +47,7 @@ jobs:
 
     - name: Install pgspot
       run: |
-        python -m pip install pgspot==0.6.0
+        python -m pip install pgspot==0.7.0
 
     - name: Build timescaledb sqlfiles
       run: |


### PR DESCRIPTION
Use pgspot 0.7.0 in our CI which updates the parser used by pgspot to the PG16 parser.