### PR TITLE
Vectorize cross-datatype timestamp comparisons

### DIFF
--- a/src/nodes/chunk_append/transform.h
+++ b/src/nodes/chunk_append/transform.h
@@ -8,4 +8,6 @@
 #include <postgres.h>
 #include <nodes/extensible.h>
 
-extern Expr *ts_transform_cross_datatype_comparison(Expr *clause);
+#include "export.h"
+
+extern TSDLLEXPORT Expr *ts_transform_cross_datatype_comparison(Expr *clause);

--- a/tsl/src/nodes/decompress_chunk/planner.c
+++ b/tsl/src/nodes/decompress_chunk/planner.c
@@ -32,6 +32,7 @@
 #include "nodes/decompress_chunk/decompress_chunk.h"
 #include "nodes/decompress_chunk/exec.h"
 #include "nodes/decompress_chunk/planner.h"
+#include "nodes/chunk_append/transform.h"
 #include "vector_predicates.h"
 #include "ts_catalog/array_utils.h"
 
@@ -639,7 +640,17 @@ find_vectorized_quals(DecompressChunkPath *path, List *qual_list, List **vectori
 	foreach (lc, qual_list)
 	{
 		Node *source_qual = lfirst(lc);
-		Node *vectorized_qual = make_vectorized_qual(path, source_qual);
+
+		/*
+		 * We can't vectorize the stable cross-type operators (for example
+		 * timestamp > timestamptz), so try to cast the constant to the same
+		 * type to convert it to the same-type operator. We do the same thing
+		 * for chunk exclusion.
+		 */
+		Node *transformed_comparison =
+			(Node *) ts_transform_cross_datatype_comparison((Expr *) source_qual);
+
+		Node *vectorized_qual = make_vectorized_qual(path, transformed_comparison);
 		if (vectorized_qual)
 		{
 			*vectorized = lappend(*vectorized, vectorized_qual);

--- a/tsl/test/expected/decompress_vector_qual.out
+++ b/tsl/test/expected/decompress_vector_qual.out
@@ -950,19 +950,24 @@ select count(*) from vectorqual where ts < LOCALTIMESTAMP + '3 years'::interval;
      5
 (1 row)
 
--- This filter is not vectorized because the 'timestamp > timestamptz'
--- operator is stable, not immutable, because it uses the current session
--- timezone. We could transform it to something like
--- 'timestamp > timestamptz::timestamp' to allow our stable function evaluation
--- to handle this case, but we don't do it at the moment.
-set timescaledb.debug_require_vector_qual to 'forbid';
+-- These filters are not vectorizable as written, because the 'timestamp > timestamptz'
+-- operator is stable, not immutable. We will try to cast the constant to the
+-- same type in this case.
+set timescaledb.debug_require_vector_qual to 'only';
 select count(*) from vectorqual where ts > '2021-01-01 00:00:00'::timestamptz;
  count 
 -------
      3
 (1 row)
 
+select count(*) from vectorqual where ts < LOCALTIMESTAMP at time zone 'UTC' + '3 years'::interval;
+ count 
+-------
+     5
+(1 row)
+
 -- Can't vectorize comparison with a volatile function.
+set timescaledb.debug_require_vector_qual to 'forbid';
 select count(*) from vectorqual where metric3 > random()::int - 100;
  count 
 -------

--- a/tsl/test/expected/transparent_decompression_queries.out
+++ b/tsl/test/expected/transparent_decompression_queries.out
@@ -92,7 +92,7 @@ GROUP BY 2, 3;
          ->  Merge Append (actual rows=745 loops=1)
                Sort Key: _hyper_3_5_chunk.device_id, _hyper_3_5_chunk.measure_id
                ->  Custom Scan (DecompressChunk) on _hyper_3_5_chunk (actual rows=120 loops=1)
-                     Filter: ("time" < now())
+                     Vectorized Filter: ("time" < "timestamp"(now()))
                      ->  Index Scan using compress_hyper_4_10_chunk_device_id_measure_id__ts_meta_seq_idx on compress_hyper_4_10_chunk (actual rows=1 loops=1)
                ->  Sort (actual rows=168 loops=1)
                      Sort Key: _hyper_3_6_chunk.device_id, _hyper_3_6_chunk.measure_id


### PR DESCRIPTION
Apply the same approach we use for chunk exclusion: try to cast the constant to the same type.

Disable-check: force-changelog-file