### PR TITLE
Remove double initialization of time_bucket origin

### DIFF
--- a/src/time_bucket.c
+++ b/src/time_bucket.c
@@ -272,11 +272,6 @@ ts_timestamptz_bucket(PG_FUNCTION_ARGS)
 	if (TIMESTAMP_NOT_FINITE(timestamp))
 		PG_RETURN_TIMESTAMPTZ(timestamp);
 
-	if (PG_NARGS() > 2)
-	{
-		origin = PG_GETARG_TIMESTAMPTZ(2);
-	}
-
 	if (interval->month)
 	{
 		DateADT origin_date = 0;


### PR DESCRIPTION
The variable origin in ts_timestamptz_bucket was initialized two times. This commit removes one of the initializations.

---

Disable-check: force-changelog-file