### PR TITLE
Report progress in compression related APIs

### DIFF
--- a/tsl/src/compression/compression.h
+++ b/tsl/src/compression/compression.h
@@ -361,7 +361,8 @@ extern void row_compressor_init(CompressionSettings *settings, RowCompressor *ro
 extern void row_compressor_reset(RowCompressor *row_compressor);
 extern void row_compressor_close(RowCompressor *row_compressor);
 extern void row_compressor_append_sorted_rows(RowCompressor *row_compressor,
-											  Tuplesortstate *sorted_rel, TupleDesc sorted_desc);
+											  Tuplesortstate *sorted_rel, TupleDesc sorted_desc,
+											  Relation in_rel);
 extern Oid get_compressed_chunk_index(ResultRelInfo *resultRelInfo, CompressionSettings *settings);
 
 extern void segment_info_update(SegmentInfo *segment_info, Datum val, bool is_null);

--- a/tsl/test/expected/compression_bgw-13.out
+++ b/tsl/test/expected/compression_bgw-13.out
@@ -344,6 +344,11 @@ SELECT alter_job(id,config:=jsonb_set(config,'{verbose_log}', 'true'))
 set client_min_messages TO LOG;
 CALL run_job(:job_id);
 LOG:  statement: CALL run_job(1004);
+LOG:  acquiring locks for compressing "_timescaledb_internal._hyper_11_40_chunk"
+LOG:  locks acquired for compressing "_timescaledb_internal._hyper_11_40_chunk"
+LOG:  new compressed chunk "_timescaledb_internal.compress_hyper_13_61_chunk" created
+LOG:  using index "_hyper_11_40_chunk_conditions_time_idx" to scan rows for compression
+LOG:  finished compressing 144 rows from "_hyper_11_40_chunk"
 LOG:  job 1004 completed processing chunk _timescaledb_internal._hyper_11_40_chunk
 set client_min_messages TO NOTICE;
 LOG:  statement: set client_min_messages TO NOTICE;

--- a/tsl/test/expected/compression_bgw-14.out
+++ b/tsl/test/expected/compression_bgw-14.out
@@ -344,6 +344,11 @@ SELECT alter_job(id,config:=jsonb_set(config,'{verbose_log}', 'true'))
 set client_min_messages TO LOG;
 CALL run_job(:job_id);
 LOG:  statement: CALL run_job(1004);
+LOG:  acquiring locks for compressing "_timescaledb_internal._hyper_11_40_chunk"
+LOG:  locks acquired for compressing "_timescaledb_internal._hyper_11_40_chunk"
+LOG:  new compressed chunk "_timescaledb_internal.compress_hyper_13_61_chunk" created
+LOG:  using index "_hyper_11_40_chunk_conditions_time_idx" to scan rows for compression
+LOG:  finished compressing 144 rows from "_hyper_11_40_chunk"
 LOG:  job 1004 completed processing chunk _timescaledb_internal._hyper_11_40_chunk
 set client_min_messages TO NOTICE;
 LOG:  statement: set client_min_messages TO NOTICE;

--- a/tsl/test/expected/compression_bgw-15.out
+++ b/tsl/test/expected/compression_bgw-15.out
@@ -344,6 +344,11 @@ SELECT alter_job(id,config:=jsonb_set(config,'{verbose_log}', 'true'))
 set client_min_messages TO LOG;
 CALL run_job(:job_id);
 LOG:  statement: CALL run_job(1004);
+LOG:  acquiring locks for compressing "_timescaledb_internal._hyper_11_40_chunk"
+LOG:  locks acquired for compressing "_timescaledb_internal._hyper_11_40_chunk"
+LOG:  new compressed chunk "_timescaledb_internal.compress_hyper_13_61_chunk" created
+LOG:  using index "_hyper_11_40_chunk_conditions_time_idx" to scan rows for compression
+LOG:  finished compressing 144 rows from "_hyper_11_40_chunk"
 LOG:  job 1004 completed processing chunk _timescaledb_internal._hyper_11_40_chunk
 set client_min_messages TO NOTICE;
 LOG:  statement: set client_min_messages TO NOTICE;

--- a/tsl/test/expected/compression_bgw-16.out
+++ b/tsl/test/expected/compression_bgw-16.out
@@ -344,6 +344,11 @@ SELECT alter_job(id,config:=jsonb_set(config,'{verbose_log}', 'true'))
 set client_min_messages TO LOG;
 CALL run_job(:job_id);
 LOG:  statement: CALL run_job(1004);
+LOG:  acquiring locks for compressing "_timescaledb_internal._hyper_11_40_chunk"
+LOG:  locks acquired for compressing "_timescaledb_internal._hyper_11_40_chunk"
+LOG:  new compressed chunk "_timescaledb_internal.compress_hyper_13_61_chunk" created
+LOG:  using index "_hyper_11_40_chunk_conditions_time_idx" to scan rows for compression
+LOG:  finished compressing 144 rows from "_hyper_11_40_chunk"
 LOG:  job 1004 completed processing chunk _timescaledb_internal._hyper_11_40_chunk
 set client_min_messages TO NOTICE;
 LOG:  statement: set client_min_messages TO NOTICE;

--- a/tsl/test/expected/compression_indexscan.out
+++ b/tsl/test/expected/compression_indexscan.out
@@ -948,6 +948,54 @@ select count(*) from tab1;
  62400
 (1 row)
 
+-- Check compression progression messages
+SET client_min_messages TO LOG;
+select compress_chunk('_timescaledb_internal._hyper_1_1_chunk');
+LOG:  statement: select compress_chunk('_timescaledb_internal._hyper_1_1_chunk');
+LOG:  acquiring locks for compressing "_timescaledb_internal._hyper_1_1_chunk"
+LOG:  locks acquired for compressing "_timescaledb_internal._hyper_1_1_chunk"
+LOG:  new compressed chunk "_timescaledb_internal.compress_hyper_3_133_chunk" created
+INFO:  compress_chunk_tuplesort_start
+LOG:  using tuplesort to scan rows from "_hyper_1_1_chunk" for compression
+LOG:  finished compressing 13500 rows from "_hyper_1_1_chunk"
+             compress_chunk             
+----------------------------------------
+ _timescaledb_internal._hyper_1_1_chunk
+(1 row)
+
+RESET client_min_messages;
+LOG:  statement: RESET client_min_messages;
+-- Analyze and use stats now on a larger data set
+INSERT INTO tab1
+SELECT
+time + (INTERVAL '1 minute' * random()) AS time,
+id,
+random() AS c1,
+random()* 100 AS c2
+FROM
+generate_series('2018-03-02 1:00'::TIMESTAMPTZ, '2018-03-28 1:00', '5 minutes') AS g1(time),
+generate_series(1, 100, 1 ) AS g2(id)
+ORDER BY
+time;
+ANALYZE _timescaledb_internal._hyper_1_2_chunk;
+SET client_min_messages TO LOG;
+select compress_chunk('_timescaledb_internal._hyper_1_2_chunk');
+LOG:  statement: select compress_chunk('_timescaledb_internal._hyper_1_2_chunk');
+LOG:  acquiring locks for compressing "_timescaledb_internal._hyper_1_2_chunk"
+LOG:  locks acquired for compressing "_timescaledb_internal._hyper_1_2_chunk"
+LOG:  new compressed chunk "_timescaledb_internal.compress_hyper_3_134_chunk" created
+INFO:  compress_chunk_tuplesort_start
+LOG:  using tuplesort to scan rows from "_hyper_1_2_chunk" for compression
+LOG:  compressed 100000 rows from "_hyper_1_2_chunk"
+LOG:  compressed 200000 rows from "_hyper_1_2_chunk"
+LOG:  finished compressing 218400 rows from "_hyper_1_2_chunk"
+             compress_chunk             
+----------------------------------------
+ _timescaledb_internal._hyper_1_2_chunk
+(1 row)
+
+RESET client_min_messages;
+LOG:  statement: RESET client_min_messages;
 drop index predicate;
 --Tear down
 DROP TABLE tab1;

--- a/tsl/test/sql/compression_indexscan.sql
+++ b/tsl/test/sql/compression_indexscan.sql
@@ -257,6 +257,27 @@ select count(*) from tab1;
 select compress_chunk(show_chunks('tab1'));
 select decompress_chunk(show_chunks('tab1'));
 select count(*) from tab1;
+
+-- Check compression progression messages
+SET client_min_messages TO LOG;
+select compress_chunk('_timescaledb_internal._hyper_1_1_chunk');
+RESET client_min_messages;
+-- Analyze and use stats now on a larger data set
+INSERT INTO tab1
+SELECT
+time + (INTERVAL '1 minute' * random()) AS time,
+id,
+random() AS c1,
+random()* 100 AS c2
+FROM
+generate_series('2018-03-02 1:00'::TIMESTAMPTZ, '2018-03-28 1:00', '5 minutes') AS g1(time),
+generate_series(1, 100, 1 ) AS g2(id)
+ORDER BY
+time;
+ANALYZE _timescaledb_internal._hyper_1_2_chunk;
+SET client_min_messages TO LOG;
+select compress_chunk('_timescaledb_internal._hyper_1_2_chunk');
+RESET client_min_messages;
 drop index predicate;
 
 --Tear down


### PR DESCRIPTION
Log progress of the compression/decompression APIs into the postgresql
    log file. In case of issues in the field, we really do not have much
    idea about which stage the compression function is stuck at. Hopefully
    we will have a better idea now with these log messages in place. We
    want to keep things simple and enable logging of the progress by
    default for these APIs. We can relook if the users complaint about the
    chattiness later.

Disable-check: force-changelog-file

