### PR TITLE
Add PG source dir to system includes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -380,8 +380,17 @@ find_path(
   PATH_SUFFIXES postgres postgresql pgsql
   DOC "The path to the PostgreSQL source tree")
 
+option(PG_SOURCE_INCLUDES "Add PG source to include directories" OFF)
+
 if(PG_SOURCE_DIR)
   message(STATUS "Found PostgreSQL source in ${PG_SOURCE_DIR}")
+  if(PG_SOURCE_INCLUDES)
+    # Add the PostgreSQL source dir include directories to the build system
+    # includes BEFORE the installed PG include files. This will allow the LSP
+    # (e.g., clangd) to navigate to the PostgreSQL source instead of the install
+    # path directory that only has the headers.
+    include_directories(BEFORE SYSTEM ${PG_SOURCE_DIR}/src/include)
+  endif(PG_SOURCE_INCLUDES)
 endif(PG_SOURCE_DIR)
 
 set(EXT_CONTROL_FILE ${PROJECT_NAME}.control)


### PR DESCRIPTION
Add a CMake option to add the PostgreSQL source directory as a system include for the build system. This will ensure that the PG source include directory will end up in a generated `compile_commands.json`, which can be used by language servers (e.g., clangd) to navigate from the TimescaleDB source directly to the PostgreSQL source.

Disable-check: force-changelog-file