### PR TITLE
Fix recompression ignoring partial compressed chunks

### DIFF
--- a/.unreleased/pr_6592
+++ b/.unreleased/pr_6592
@@ -1,0 +1,1 @@
+Fixes: #6592 Fix recompression policy ignoring partially compressed chunks

--- a/tsl/src/bgw_policy/job.c
+++ b/tsl/src/bgw_policy/job.c
@@ -509,8 +509,10 @@ policy_recompression_execute(int32 job_id, Jsonb *config)
 		StartTransactionCommand();
 		int32 chunkid = lfirst_int(lc);
 		Chunk *chunk = ts_chunk_get_by_id(chunkid, true);
-		if (!chunk || !ts_chunk_is_unordered(chunk))
+		Assert(chunk);
+		if (!ts_chunk_is_unordered(chunk) && !ts_chunk_is_partial(chunk))
 			continue;
+
 		tsl_recompress_chunk_wrapper(chunk);
 
 		elog(LOG,

--- a/tsl/src/compression/api.c
+++ b/tsl/src/compression/api.c
@@ -817,7 +817,7 @@ tsl_recompress_chunk_wrapper(Chunk *uncompressed_chunk)
 {
 	Oid uncompressed_chunk_relid = uncompressed_chunk->table_id;
 
-	if (ts_chunk_is_unordered(uncompressed_chunk))
+	if (ts_chunk_is_compressed(uncompressed_chunk))
 	{
 		if (!decompress_chunk_impl(uncompressed_chunk->hypertable_relid,
 								   uncompressed_chunk_relid,

--- a/tsl/test/expected/compression_bgw-13.out
+++ b/tsl/test/expected/compression_bgw-13.out
@@ -646,7 +646,7 @@ CALL run_job(:JOB_RECOMPRESS);
 SELECT chunk_status FROM compressed_chunk_info_view WHERE hypertable_name = 'metrics';
  chunk_status 
 --------------
-            9
+            1
 (1 row)
 
 SELECT delete_job(:JOB_RECOMPRESS);

--- a/tsl/test/expected/compression_bgw-14.out
+++ b/tsl/test/expected/compression_bgw-14.out
@@ -646,7 +646,7 @@ CALL run_job(:JOB_RECOMPRESS);
 SELECT chunk_status FROM compressed_chunk_info_view WHERE hypertable_name = 'metrics';
  chunk_status 
 --------------
-            9
+            1
 (1 row)
 
 SELECT delete_job(:JOB_RECOMPRESS);

--- a/tsl/test/expected/compression_bgw-15.out
+++ b/tsl/test/expected/compression_bgw-15.out
@@ -646,7 +646,7 @@ CALL run_job(:JOB_RECOMPRESS);
 SELECT chunk_status FROM compressed_chunk_info_view WHERE hypertable_name = 'metrics';
  chunk_status 
 --------------
-            9
+            1
 (1 row)
 
 SELECT delete_job(:JOB_RECOMPRESS);

--- a/tsl/test/expected/compression_bgw-16.out
+++ b/tsl/test/expected/compression_bgw-16.out
@@ -646,7 +646,7 @@ CALL run_job(:JOB_RECOMPRESS);
 SELECT chunk_status FROM compressed_chunk_info_view WHERE hypertable_name = 'metrics';
  chunk_status 
 --------------
-            9
+            1
 (1 row)
 
 SELECT delete_job(:JOB_RECOMPRESS);


### PR DESCRIPTION
The recompression policy only recompresses unordered chunks which will be rarely created but does not deal with partial chunks which are the result of DML operations into compressed chunks.

Disable-check: commit-count
