### PR TITLE
Fix handling of expressions evaluated to Const in OR

### DIFF
--- a/.github/workflows/sqlsmith.yaml
+++ b/.github/workflows/sqlsmith.yaml
@@ -74,7 +74,8 @@ jobs:
         /usr/lib/postgresql/${{ matrix.pg }}/bin/pg_ctl initdb -D ~/pgdata
         /usr/lib/postgresql/${{ matrix.pg }}/bin/pg_ctl -D ~/pgdata start \
             -o "-cshared_preload_libraries=timescaledb" -o "-cmax_connections=200" \
-            -o "-cmax_prepared_transactions=100" -o "-cunix_socket_directories=/tmp"
+            -o "-cmax_prepared_transactions=100" -o "-cunix_socket_directories=/tmp" \
+            -o "-clog_statement=all" -l postgres.log
         psql -h /tmp postgres -c 'CREATE DATABASE smith;'
         psql -h /tmp smith -c 'CREATE EXTENSION timescaledb;'
         psql -h /tmp smith -c '\i ${{ github.workspace }}/tsl/test/shared/sql/include/shared_setup.sql'
@@ -84,6 +85,7 @@ jobs:
     # so total runtime should be around 200 minutes in nightly run and 40 minutes otherwise
     - name: Run SQLsmith
       run: |
+        set -xeu
         set -o pipefail
         if [ "${{ github.event_name }}" == "schedule" ]; then
           LOOPS=20
@@ -96,6 +98,10 @@ jobs:
             ./sqlsmith --seed=$((16#$(openssl rand -hex 3))) --exclude-catalog \
                 --target="host=/tmp dbname=smith" --max-queries=10000 \
             2>&1 | tee -a sqlsmith.log
+
+            psql "host=/tmp dbname=smith" -c "select 1"
+
+            truncate --size=0 postgres.log
         done
 
     - name: Check for coredumps
@@ -116,9 +122,9 @@ jobs:
           set verbose on
           set trace-commands on
           show debug-file-directory
-          printf "'"'"query = '%s'\n\n"'"'", debug_query_string
+          printf "'"'"query = '%s'\n\n"'"'", (char *) debug_query_string
           frame function ExceptionalCondition
-          printf "'"'"condition = '%s'\n"'"'", conditionName
+          printf "'"'"condition = '%s'\n"'"'", (char *) conditionName
           up 1
           l
           info args
@@ -134,6 +140,13 @@ jobs:
       with:
         name: Coredumps sqlsmith ${{ matrix.os }} PG${{ matrix.pg }}
         path: coredumps
+
+    - name: Save PostgreSQL log
+      if: always() && steps.collectlogs.outputs.coredumps == 'true'
+      uses: actions/upload-artifact@v4
+      with:
+        name: PostgreSQL log for PG${{ matrix.pg }}
+        path: postgres.log
 
     - name: Upload test results to the database
       if: always()

--- a/tsl/src/nodes/decompress_chunk/exec.c
+++ b/tsl/src/nodes/decompress_chunk/exec.c
@@ -421,7 +421,6 @@ decompress_chunk_begin(CustomScanState *node, EState *estate, int eflags)
 	}
 
 	/* Constify stable expressions in vectorized predicates. */
-	chunk_state->have_constant_false_vectorized_qual = false;
 	PlannerGlobal glob = {
 		.boundParams = node->ss.ps.state->es_param_list_info,
 	};
@@ -432,31 +431,6 @@ decompress_chunk_begin(CustomScanState *node, EState *estate, int eflags)
 	foreach (lc, chunk_state->vectorized_quals_original)
 	{
 		Node *constified = estimate_expression_value(&root, (Node *) lfirst(lc));
-
-		/*
-		 * Note that some expressions are evaluated to a null Const, like a
-		 * strict comparison with stable expression that evaluates to null. If
-		 * we have such filter, no rows can pass, so we set a special flag to
-		 * return early.
-		 */
-		if (IsA(constified, Const))
-		{
-			Const *c = castNode(Const, constified);
-			if (c->constisnull || !DatumGetBool(c->constvalue))
-			{
-				chunk_state->have_constant_false_vectorized_qual = true;
-				break;
-			}
-			else
-			{
-				/*
-				 * This is a constant true qual, every row passes and we can
-				 * just ignore it. No idea how it can happen though.
-				 */
-				Assert(false);
-				continue;
-			}
-		}
 
 		dcontext->vectorized_quals_constified =
 			lappend(dcontext->vectorized_quals_constified, constified);
@@ -736,11 +710,6 @@ decompress_chunk_exec_impl(DecompressChunkState *chunk_state, const BatchQueueFu
 	if (chunk_state->perform_vectorized_aggregation)
 	{
 		return perform_vectorized_aggregation(chunk_state);
-	}
-
-	if (chunk_state->have_constant_false_vectorized_qual)
-	{
-		return NULL;
 	}
 
 	bqfuncs->pop(bq, dcontext);

--- a/tsl/src/nodes/decompress_chunk/exec.h
+++ b/tsl/src/nodes/decompress_chunk/exec.h
@@ -46,7 +46,6 @@ typedef struct DecompressChunkState
 	 * evaluate to constant false, hence the flag.
 	 */
 	List *vectorized_quals_original;
-	bool have_constant_false_vectorized_qual;
 } DecompressChunkState;
 
 extern Node *decompress_chunk_state_create(CustomScan *cscan);

--- a/tsl/test/expected/decompress_vector_qual.out
+++ b/tsl/test/expected/decompress_vector_qual.out
@@ -2,6 +2,7 @@
 -- Please see the included NOTICE for copyright information and
 -- LICENSE-TIMESCALE for a copy of the license.
 \c :TEST_DBNAME :ROLE_SUPERUSER
+create function stable_identity(x anyelement) returns anyelement as $$ select x $$ language sql stable;
 create table vectorqual(metric1 int8, ts timestamp, metric2 int8, device int8);
 select create_hypertable('vectorqual', 'ts');
 WARNING:  column type "timestamp without time zone" used for "ts" does not follow best practices
@@ -201,7 +202,6 @@ execute p(33);
 
 deallocate p;
 -- Also try query parameter in combination with a stable function.
-create function stable_identity(x anyelement) returns anyelement as $$ select x $$ language sql stable;
 prepare p(int4) as select count(*) from vectorqual where metric3 = stable_identity($1);
 execute p(33);
  count 
@@ -304,6 +304,14 @@ select count(*) from vectorqual where metric2 < 0 or metric3  < -1;
      0
 (1 row)
 
+-- expression evaluated to null at run time
+select count(*) from vectorqual where metric3 = 777
+    or metric3 > case when now() > now() - interval '1s' then null else 1 end;
+ count 
+-------
+     2
+(1 row)
+
 reset timescaledb.enable_bulk_decompression;
 -- Test with unary operator.
 set timescaledb.debug_require_vector_qual to 'forbid';
@@ -348,11 +356,89 @@ select count(*) from vectorqual where metric3 = 777 or metric3 === 777;
      2
 (1 row)
 
--- It also doesn't have a commutator.
+-- Custom operator that can be vectorized but doesn't have a negator.
+create operator !!! (function = 'int4ne', rightarg = int4, leftarg = int4);
+set timescaledb.debug_require_vector_qual to 'only';
+select count(*) from vectorqual where metric3 !!! 777;
+ count 
+-------
+     3
+(1 row)
+
+select count(*) from vectorqual where metric3 !!! any(array[777, 888]);
+ count 
+-------
+     5
+(1 row)
+
+select count(*) from vectorqual where metric3 !!! 777 or metric3 !!! 888;
+ count 
+-------
+     5
+(1 row)
+
+select count(*) from vectorqual where metric3 !!! 666 and (metric3 !!! 777 or metric3 !!! 888);
+ count 
+-------
+     5
+(1 row)
+
+select count(*) from vectorqual where metric3 !!! 666 and (metric3 !!! 777 or metric3 !!! stable_identity(888));
+ count 
+-------
+     5
+(1 row)
+
+set timescaledb.debug_require_vector_qual to 'forbid';
+select count(*) from vectorqual where not metric3 !!! 777;
+ count 
+-------
+     2
+(1 row)
+
+select count(*) from vectorqual where metric3 !!! 666 or (metric3 !!! 777 and not metric3 !!! 888);
+ count 
+-------
+     5
+(1 row)
+
+select count(*) from vectorqual where metric3 !!! 666 or not (metric3 !!! 777 and not metric3 !!! 888);
+ count 
+-------
+     5
+(1 row)
+
+set timescaledb.debug_require_vector_qual to 'allow';
+select count(*) from vectorqual where metric3 !!! 777 or not metric3 !!! 888;
+ count 
+-------
+     3
+(1 row)
+
+select count(*) from vectorqual where metric3 !!! 777 and not metric3 !!! 888;
+ count 
+-------
+     0
+(1 row)
+
+select count(*) from vectorqual where not(metric3 !!! 666 or not (metric3 !!! 777 and not metric3 !!! 888));
+ count 
+-------
+     0
+(1 row)
+
+-- These operators don't have a commutator.
+set timescaledb.debug_require_vector_qual to 'forbid';
 select count(*) from vectorqual where 777 === metric3;
  count 
 -------
      2
+(1 row)
+
+select count(*) from vectorqual where 777 !!! metric3;
+ count 
+-------
+     3
 (1 row)
 
 -- NullTest is vectorized.
@@ -367,6 +453,18 @@ select count(*) from vectorqual where metric4 is not null;
  count 
 -------
      2
+(1 row)
+
+select count(*) from vectorqual where metric3 = 777 or metric4 is not null;
+ count 
+-------
+     4
+(1 row)
+
+select count(*) from vectorqual where metric3 = stable_identity(777) or metric4 is null;
+ count 
+-------
+     3
 (1 row)
 
 -- Can't vectorize conditions on system columns. Have to check this on a single


### PR DESCRIPTION
We had this handling for top-level AND, but not for deeper boolean expressions. Make it general.

Found by SQLSmith: https://github.com/timescale/timescaledb/actions/runs/7750432562/job/21136641284


Disable-check: force-changelog-file