### PR TITLE
Improve SkipScan unsupported node type error message

### DIFF
--- a/tsl/src/nodes/skip_scan/planner.c
+++ b/tsl/src/nodes/skip_scan/planner.c
@@ -104,7 +104,7 @@ skip_scan_plan_create(PlannerInfo *root, RelOptInfo *relopt, CustomPath *best_pa
 			sort_indexquals(index_path->indexinfo, lcons(op, idx_plan->indexqual));
 	}
 	else
-		elog(ERROR, "bad subplan type for SkipScan: %d", plan->type);
+		elog(ERROR, "unsupported subplan type for SkipScan: %s", ts_get_node_name((Node *) plan));
 
 	skip_plan->scan.plan.targetlist = tlist;
 	skip_plan->custom_scan_tlist = list_copy(tlist);


### PR DESCRIPTION
Improve the error message when we encounter unexpected node types by printing the node name instead of the node id.