### PR TITLE
Fix overflowing integer expression.

### DIFF
--- a/src/utils.c
+++ b/src/utils.c
@@ -1072,7 +1072,7 @@ ts_try_relation_cached_size(Relation rel, bool verbose)
 						RelationGetRelationName(rel))));
 
 	/* convert the size into bytes and return */
-	return nblocks * BLCKSZ;
+	return (int64) nblocks * BLCKSZ;
 }
 
 static RelationSize


### PR DESCRIPTION
Fix potentially overflowing expression. Reported by Coverity.

Disable-check: force-changelog-file