### PR TITLE
Add recompress optional argument to compress_chunk

### DIFF
--- a/.unreleased/pr_6609
+++ b/.unreleased/pr_6609
@@ -1,0 +1,2 @@
+Implements: #6609 Deprecate recompress_chunk
+Implements: #6609 Add optional recompress argument to compress_chunk

--- a/sql/updates/latest-dev.sql
+++ b/sql/updates/latest-dev.sql
@@ -445,3 +445,7 @@ $BODY$
    SELECT sum(total_bytes)::bigint
    FROM @extschema@.hypertable_approximate_detailed_size(hypertable);
 $BODY$ SET search_path TO pg_catalog, pg_temp;
+
+DROP FUNCTION IF EXISTS @extschema@.compress_chunk;
+CREATE FUNCTION @extschema@.compress_chunk(uncompressed_chunk REGCLASS, if_not_compressed BOOLEAN = true, recompress BOOLEAN = false) RETURNS REGCLASS AS '' LANGUAGE SQL SET search_path TO pg_catalog, pg_temp;
+

--- a/sql/updates/reverse-dev.sql
+++ b/sql/updates/reverse-dev.sql
@@ -791,3 +791,7 @@ SELECT pg_catalog.pg_extension_config_dump('_timescaledb_catalog.hypertable', ''
 DROP FUNCTION IF EXISTS _timescaledb_functions.relation_approximate_size(relation REGCLASS);
 DROP FUNCTION IF EXISTS @extschema@.hypertable_approximate_detailed_size(relation REGCLASS);
 DROP FUNCTION IF EXISTS @extschema@.hypertable_approximate_size(hypertable REGCLASS);
+
+DROP FUNCTION IF EXISTS @extschema@.compress_chunk;
+CREATE FUNCTION @extschema@.compress_chunk(uncompressed_chunk REGCLASS, if_not_compressed BOOLEAN = true) RETURNS REGCLASS AS '' LANGUAGE SQL SET search_path TO pg_catalog,pg_temp;
+

--- a/tsl/src/bgw_policy/job.c
+++ b/tsl/src/bgw_policy/job.c
@@ -513,7 +513,7 @@ policy_recompression_execute(int32 job_id, Jsonb *config)
 		if (!ts_chunk_needs_recompression(chunk))
 			continue;
 
-		tsl_recompress_chunk_wrapper(chunk);
+		tsl_compress_chunk_wrapper(chunk, true, false);
 
 		elog(LOG,
 			 "completed recompressing chunk \"%s.%s\"",

--- a/tsl/src/compression/api.c
+++ b/tsl/src/compression/api.c
@@ -579,7 +579,7 @@ compress_chunk_impl(Oid hypertable_relid, Oid chunk_relid)
 		if (chunk_unordered)
 		{
 			ts_chunk_set_unordered(mergable_chunk);
-			tsl_recompress_chunk_wrapper(mergable_chunk);
+			tsl_compress_chunk_wrapper(mergable_chunk, true, false);
 		}
 	}
 
@@ -779,20 +779,45 @@ tsl_compress_chunk(PG_FUNCTION_ARGS)
 {
 	Oid uncompressed_chunk_id = PG_ARGISNULL(0) ? InvalidOid : PG_GETARG_OID(0);
 	bool if_not_compressed = PG_ARGISNULL(1) ? true : PG_GETARG_BOOL(1);
+	bool recompress = PG_ARGISNULL(2) ? false : PG_GETARG_BOOL(2);
 
 	ts_feature_flag_check(FEATURE_HYPERTABLE_COMPRESSION);
 
 	TS_PREVENT_FUNC_IF_READ_ONLY();
 	Chunk *chunk = ts_chunk_get_by_relid(uncompressed_chunk_id, true);
 
+	uncompressed_chunk_id = tsl_compress_chunk_wrapper(chunk, if_not_compressed, recompress);
+
+	PG_RETURN_OID(uncompressed_chunk_id);
+}
+
+Oid
+tsl_compress_chunk_wrapper(Chunk *chunk, bool if_not_compressed, bool recompress)
+{
+	Oid uncompressed_chunk_id = chunk->table_id;
+
 	if (ts_chunk_is_compressed(chunk))
 	{
+		if (recompress)
+		{
+			CompressionSettings *ht_settings = ts_compression_settings_get(chunk->hypertable_relid);
+			Oid compressed_chunk_relid = ts_chunk_get_relid(chunk->fd.compressed_chunk_id, true);
+			CompressionSettings *chunk_settings =
+				ts_compression_settings_get(compressed_chunk_relid);
+
+			if (!ts_compression_settings_equal(ht_settings, chunk_settings))
+			{
+				decompress_chunk_impl(chunk, false);
+				compress_chunk_impl(chunk->hypertable_relid, chunk->table_id);
+				return uncompressed_chunk_id;
+			}
+		}
 		if (!ts_chunk_needs_recompression(chunk))
 		{
 			ereport((if_not_compressed ? NOTICE : ERROR),
 					(errcode(ERRCODE_DUPLICATE_OBJECT),
 					 errmsg("chunk \"%s\" is already compressed", get_rel_name(chunk->table_id))));
-			PG_RETURN_OID(uncompressed_chunk_id);
+			return uncompressed_chunk_id;
 		}
 
 		if (get_compressed_chunk_index_for_recompression(chunk))
@@ -810,7 +835,7 @@ tsl_compress_chunk(PG_FUNCTION_ARGS)
 		uncompressed_chunk_id = compress_chunk_impl(chunk->hypertable_relid, chunk->table_id);
 	}
 
-	PG_RETURN_OID(uncompressed_chunk_id);
+	return uncompressed_chunk_id;
 }
 
 Datum
@@ -842,29 +867,6 @@ tsl_decompress_chunk(PG_FUNCTION_ARGS)
 	decompress_chunk_impl(uncompressed_chunk, if_compressed);
 
 	PG_RETURN_OID(uncompressed_chunk_id);
-}
-
-bool
-tsl_recompress_chunk_wrapper(Chunk *uncompressed_chunk)
-{
-	Oid uncompressed_chunk_relid = uncompressed_chunk->table_id;
-
-	Hypertable *ht = ts_hypertable_get_by_id(uncompressed_chunk->fd.hypertable_id);
-	ts_hypertable_permissions_check(ht->main_table_relid, GetUserId());
-
-	if (!ht->fd.compressed_hypertable_id)
-		ereport(ERROR, (errcode(ERRCODE_INTERNAL_ERROR), errmsg("missing compressed hypertable")));
-
-	if (ts_chunk_is_compressed(uncompressed_chunk))
-	{
-		decompress_chunk_impl(uncompressed_chunk, false);
-	}
-
-	Chunk *chunk = ts_chunk_get_by_relid(uncompressed_chunk_relid, true);
-	Assert(!ts_chunk_is_compressed(chunk));
-	compress_chunk_impl(chunk->hypertable_relid, chunk->table_id);
-
-	return true;
 }
 
 /* Sort the tuples and recompress them */

--- a/tsl/src/compression/api.h
+++ b/tsl/src/compression/api.h
@@ -8,11 +8,12 @@
 #include <postgres.h>
 #include <fmgr.h>
 
+#include "chunk.h"
+
 extern Datum tsl_create_compressed_chunk(PG_FUNCTION_ARGS);
 extern Datum tsl_compress_chunk(PG_FUNCTION_ARGS);
 extern Datum tsl_decompress_chunk(PG_FUNCTION_ARGS);
-extern Datum tsl_recompress_chunk(PG_FUNCTION_ARGS);
-extern bool tsl_recompress_chunk_wrapper(Chunk *chunk);
+extern Oid tsl_compress_chunk_wrapper(Chunk *chunk, bool if_not_compressed, bool recompress);
 extern Datum tsl_recompress_chunk_segmentwise(PG_FUNCTION_ARGS);
 
 extern Datum tsl_get_compressed_chunk_index_for_recompression(

--- a/tsl/test/expected/compression.out
+++ b/tsl/test/expected/compression.out
@@ -2667,3 +2667,109 @@ SELECT approximate_row_count('stattest');
 (1 row)
 
 DROP TABLE stattest;
+-- test that all variants of compress_chunk produce a fully compressed chunk
+CREATE TABLE compress_chunk_test(time TIMESTAMPTZ NOT NULL, device text, value float);
+SELECT create_hypertable('compress_chunk_test', 'time');
+         create_hypertable         
+-----------------------------------
+ (47,public,compress_chunk_test,t)
+(1 row)
+
+INSERT INTO compress_chunk_test SELECT '2020-01-01', 'r2d2', 3.14;
+ALTER TABLE compress_chunk_test SET (timescaledb.compress);
+SELECT show_chunks('compress_chunk_test') AS "CHUNK" \gset
+-- initial call will compress the chunk
+SELECT compress_chunk(:'CHUNK');
+              compress_chunk               
+-------------------------------------------
+ _timescaledb_internal._hyper_47_100_chunk
+(1 row)
+
+-- subsequent calls will be noop
+SELECT compress_chunk(:'CHUNK');
+NOTICE:  chunk "_hyper_47_100_chunk" is already compressed
+              compress_chunk               
+-------------------------------------------
+ _timescaledb_internal._hyper_47_100_chunk
+(1 row)
+
+-- unless if_not_compressed is set to false
+\set ON_ERROR_STOP 0
+SELECT compress_chunk(:'CHUNK', false);
+ERROR:  chunk "_hyper_47_100_chunk" is already compressed
+\set ON_ERROR_STOP 1
+ALTER TABLE compress_chunk_test SET (timescaledb.compress_segmentby='device');
+SELECT compressed_chunk_id from _timescaledb_catalog.chunk ch INNER JOIN _timescaledb_catalog.hypertable ht ON ht.id = ch.hypertable_id AND ht.table_name='compress_chunk_test';
+ compressed_chunk_id 
+---------------------
+                 101
+(1 row)
+
+-- changing compression settings will not recompress the chunk by default
+SELECT compress_chunk(:'CHUNK');
+NOTICE:  chunk "_hyper_47_100_chunk" is already compressed
+              compress_chunk               
+-------------------------------------------
+ _timescaledb_internal._hyper_47_100_chunk
+(1 row)
+
+-- unless we specify recompress := true
+SELECT compress_chunk(:'CHUNK', recompress := true);
+              compress_chunk               
+-------------------------------------------
+ _timescaledb_internal._hyper_47_100_chunk
+(1 row)
+
+-- compressed_chunk_id should be different now
+SELECT compressed_chunk_id from _timescaledb_catalog.chunk ch INNER JOIN _timescaledb_catalog.hypertable ht ON ht.id = ch.hypertable_id AND ht.table_name='compress_chunk_test';
+ compressed_chunk_id 
+---------------------
+                 102
+(1 row)
+
+--test partial handling
+INSERT INTO compress_chunk_test SELECT '2020-01-01', 'c3po', 3.14;
+-- should result in merging uncompressed data into compressed chunk
+SELECT compress_chunk(:'CHUNK');
+              compress_chunk               
+-------------------------------------------
+ _timescaledb_internal._hyper_47_100_chunk
+(1 row)
+
+-- compressed_chunk_id should not have changed
+SELECT compressed_chunk_id from _timescaledb_catalog.chunk ch INNER JOIN _timescaledb_catalog.hypertable ht ON ht.id = ch.hypertable_id AND ht.table_name='compress_chunk_test';
+ compressed_chunk_id 
+---------------------
+                 102
+(1 row)
+
+-- should return no rows
+SELECT * FROM ONLY :CHUNK;
+ time | device | value 
+------+--------+-------
+(0 rows)
+
+ALTER TABLE compress_chunk_test SET (timescaledb.compress_segmentby='');
+-- create another chunk
+INSERT INTO compress_chunk_test SELECT '2021-01-01', 'c3po', 3.14;
+SELECT show_chunks('compress_chunk_test') AS "CHUNK2" LIMIT 1 OFFSET 1 \gset
+SELECT compress_chunk(:'CHUNK2');
+              compress_chunk               
+-------------------------------------------
+ _timescaledb_internal._hyper_47_103_chunk
+(1 row)
+
+-- make it partial and compress again
+INSERT INTO compress_chunk_test SELECT '2021-01-01', 'r2d2', 3.14;
+SELECT compress_chunk(:'CHUNK2');
+              compress_chunk               
+-------------------------------------------
+ _timescaledb_internal._hyper_47_103_chunk
+(1 row)
+
+-- should return no rows
+SELECT * FROM ONLY :CHUNK2;
+ time | device | value 
+------+--------+-------
+(0 rows)
+

--- a/tsl/test/expected/compression_bgw-13.out
+++ b/tsl/test/expected/compression_bgw-13.out
@@ -434,14 +434,12 @@ SELECT count(*) from test2;
     29
 (1 row)
 
--- call recompress_chunk inside a transaction. This should fails since
--- it contains transaction-terminating commands.
-\set ON_ERROR_STOP 0
-START TRANSACTION;
-CALL recompress_chunk(:'CHUNK_NAME'::regclass);
-ROLLBACK;
-\set ON_ERROR_STOP 1
-CALL recompress_chunk(:'CHUNK_NAME'::regclass);
+SELECT compress_chunk(:'CHUNK_NAME'::regclass);
+              compress_chunk              
+------------------------------------------
+ _timescaledb_internal._hyper_14_62_chunk
+(1 row)
+
 -- Demonstrate that no locks are held on the hypertable, chunk, or the
 -- compressed chunk after recompress_chunk has executed.
 SELECT pid, locktype, relation, relation::regclass, mode, granted
@@ -510,12 +508,22 @@ WHERE hypertable_name = 'test2' ORDER BY chunk_name;
 (2 rows)
 
 \set ON_ERROR_STOP 0
--- call recompress_chunk when status is not unordered
-CALL recompress_chunk(:'CHUNK_NAME'::regclass, true);
-psql:include/recompress_basic.sql:115: NOTICE:  nothing to recompress in chunk "_hyper_14_62_chunk"
+-- call compress_chunk when status is not unordered
+SELECT compress_chunk(:'CHUNK_NAME'::regclass);
+psql:include/recompress_basic.sql:107: NOTICE:  chunk "_hyper_14_62_chunk" is already compressed
+              compress_chunk              
+------------------------------------------
+ _timescaledb_internal._hyper_14_62_chunk
+(1 row)
+
 -- This will succeed and compress the chunk for the test below.
-CALL recompress_chunk(:'CHUNK_NAME'::regclass, false);
-psql:include/recompress_basic.sql:118: ERROR:  nothing to recompress in chunk "_hyper_14_62_chunk"
+SELECT compress_chunk(:'CHUNK_NAME'::regclass);
+psql:include/recompress_basic.sql:110: NOTICE:  chunk "_hyper_14_62_chunk" is already compressed
+              compress_chunk              
+------------------------------------------
+ _timescaledb_internal._hyper_14_62_chunk
+(1 row)
+
 --now decompress it , then try and recompress
 SELECT decompress_chunk(:'CHUNK_NAME'::regclass);
              decompress_chunk             
@@ -523,8 +531,12 @@ SELECT decompress_chunk(:'CHUNK_NAME'::regclass);
  _timescaledb_internal._hyper_14_62_chunk
 (1 row)
 
-CALL recompress_chunk(:'CHUNK_NAME'::regclass);
-psql:include/recompress_basic.sql:122: ERROR:  call compress_chunk instead of recompress_chunk
+SELECT compress_chunk(:'CHUNK_NAME'::regclass);
+              compress_chunk              
+------------------------------------------
+ _timescaledb_internal._hyper_14_62_chunk
+(1 row)
+
 \set ON_ERROR_STOP 1
 -- test recompress policy
 CREATE TABLE metrics(time timestamptz NOT NULL);
@@ -629,7 +641,7 @@ SELECT chunk_status FROM compressed_chunk_info_view WHERE hypertable_name = 'met
 
 ---- nothing to do yet
 CALL run_job(:JOB_RECOMPRESS);
-psql:include/recompress_basic.sql:194: NOTICE:  no chunks for hypertable "public.metrics" that satisfy recompress chunk policy
+psql:include/recompress_basic.sql:186: NOTICE:  no chunks for hypertable "public.metrics" that satisfy recompress chunk policy
 ---- status should be 1
 SELECT chunk_status FROM compressed_chunk_info_view WHERE hypertable_name = 'metrics';
  chunk_status 

--- a/tsl/test/expected/compression_bgw-14.out
+++ b/tsl/test/expected/compression_bgw-14.out
@@ -434,14 +434,12 @@ SELECT count(*) from test2;
     29
 (1 row)
 
--- call recompress_chunk inside a transaction. This should fails since
--- it contains transaction-terminating commands.
-\set ON_ERROR_STOP 0
-START TRANSACTION;
-CALL recompress_chunk(:'CHUNK_NAME'::regclass);
-ROLLBACK;
-\set ON_ERROR_STOP 1
-CALL recompress_chunk(:'CHUNK_NAME'::regclass);
+SELECT compress_chunk(:'CHUNK_NAME'::regclass);
+              compress_chunk              
+------------------------------------------
+ _timescaledb_internal._hyper_14_62_chunk
+(1 row)
+
 -- Demonstrate that no locks are held on the hypertable, chunk, or the
 -- compressed chunk after recompress_chunk has executed.
 SELECT pid, locktype, relation, relation::regclass, mode, granted
@@ -510,12 +508,22 @@ WHERE hypertable_name = 'test2' ORDER BY chunk_name;
 (2 rows)
 
 \set ON_ERROR_STOP 0
--- call recompress_chunk when status is not unordered
-CALL recompress_chunk(:'CHUNK_NAME'::regclass, true);
-psql:include/recompress_basic.sql:115: NOTICE:  nothing to recompress in chunk "_hyper_14_62_chunk"
+-- call compress_chunk when status is not unordered
+SELECT compress_chunk(:'CHUNK_NAME'::regclass);
+psql:include/recompress_basic.sql:107: NOTICE:  chunk "_hyper_14_62_chunk" is already compressed
+              compress_chunk              
+------------------------------------------
+ _timescaledb_internal._hyper_14_62_chunk
+(1 row)
+
 -- This will succeed and compress the chunk for the test below.
-CALL recompress_chunk(:'CHUNK_NAME'::regclass, false);
-psql:include/recompress_basic.sql:118: ERROR:  nothing to recompress in chunk "_hyper_14_62_chunk"
+SELECT compress_chunk(:'CHUNK_NAME'::regclass);
+psql:include/recompress_basic.sql:110: NOTICE:  chunk "_hyper_14_62_chunk" is already compressed
+              compress_chunk              
+------------------------------------------
+ _timescaledb_internal._hyper_14_62_chunk
+(1 row)
+
 --now decompress it , then try and recompress
 SELECT decompress_chunk(:'CHUNK_NAME'::regclass);
              decompress_chunk             
@@ -523,8 +531,12 @@ SELECT decompress_chunk(:'CHUNK_NAME'::regclass);
  _timescaledb_internal._hyper_14_62_chunk
 (1 row)
 
-CALL recompress_chunk(:'CHUNK_NAME'::regclass);
-psql:include/recompress_basic.sql:122: ERROR:  call compress_chunk instead of recompress_chunk
+SELECT compress_chunk(:'CHUNK_NAME'::regclass);
+              compress_chunk              
+------------------------------------------
+ _timescaledb_internal._hyper_14_62_chunk
+(1 row)
+
 \set ON_ERROR_STOP 1
 -- test recompress policy
 CREATE TABLE metrics(time timestamptz NOT NULL);
@@ -629,7 +641,7 @@ SELECT chunk_status FROM compressed_chunk_info_view WHERE hypertable_name = 'met
 
 ---- nothing to do yet
 CALL run_job(:JOB_RECOMPRESS);
-psql:include/recompress_basic.sql:194: NOTICE:  no chunks for hypertable "public.metrics" that satisfy recompress chunk policy
+psql:include/recompress_basic.sql:186: NOTICE:  no chunks for hypertable "public.metrics" that satisfy recompress chunk policy
 ---- status should be 1
 SELECT chunk_status FROM compressed_chunk_info_view WHERE hypertable_name = 'metrics';
  chunk_status 

--- a/tsl/test/expected/compression_bgw-15.out
+++ b/tsl/test/expected/compression_bgw-15.out
@@ -434,14 +434,12 @@ SELECT count(*) from test2;
     29
 (1 row)
 
--- call recompress_chunk inside a transaction. This should fails since
--- it contains transaction-terminating commands.
-\set ON_ERROR_STOP 0
-START TRANSACTION;
-CALL recompress_chunk(:'CHUNK_NAME'::regclass);
-ROLLBACK;
-\set ON_ERROR_STOP 1
-CALL recompress_chunk(:'CHUNK_NAME'::regclass);
+SELECT compress_chunk(:'CHUNK_NAME'::regclass);
+              compress_chunk              
+------------------------------------------
+ _timescaledb_internal._hyper_14_62_chunk
+(1 row)
+
 -- Demonstrate that no locks are held on the hypertable, chunk, or the
 -- compressed chunk after recompress_chunk has executed.
 SELECT pid, locktype, relation, relation::regclass, mode, granted
@@ -510,12 +508,22 @@ WHERE hypertable_name = 'test2' ORDER BY chunk_name;
 (2 rows)
 
 \set ON_ERROR_STOP 0
--- call recompress_chunk when status is not unordered
-CALL recompress_chunk(:'CHUNK_NAME'::regclass, true);
-psql:include/recompress_basic.sql:115: NOTICE:  nothing to recompress in chunk "_hyper_14_62_chunk"
+-- call compress_chunk when status is not unordered
+SELECT compress_chunk(:'CHUNK_NAME'::regclass);
+psql:include/recompress_basic.sql:107: NOTICE:  chunk "_hyper_14_62_chunk" is already compressed
+              compress_chunk              
+------------------------------------------
+ _timescaledb_internal._hyper_14_62_chunk
+(1 row)
+
 -- This will succeed and compress the chunk for the test below.
-CALL recompress_chunk(:'CHUNK_NAME'::regclass, false);
-psql:include/recompress_basic.sql:118: ERROR:  nothing to recompress in chunk "_hyper_14_62_chunk"
+SELECT compress_chunk(:'CHUNK_NAME'::regclass);
+psql:include/recompress_basic.sql:110: NOTICE:  chunk "_hyper_14_62_chunk" is already compressed
+              compress_chunk              
+------------------------------------------
+ _timescaledb_internal._hyper_14_62_chunk
+(1 row)
+
 --now decompress it , then try and recompress
 SELECT decompress_chunk(:'CHUNK_NAME'::regclass);
              decompress_chunk             
@@ -523,8 +531,12 @@ SELECT decompress_chunk(:'CHUNK_NAME'::regclass);
  _timescaledb_internal._hyper_14_62_chunk
 (1 row)
 
-CALL recompress_chunk(:'CHUNK_NAME'::regclass);
-psql:include/recompress_basic.sql:122: ERROR:  call compress_chunk instead of recompress_chunk
+SELECT compress_chunk(:'CHUNK_NAME'::regclass);
+              compress_chunk              
+------------------------------------------
+ _timescaledb_internal._hyper_14_62_chunk
+(1 row)
+
 \set ON_ERROR_STOP 1
 -- test recompress policy
 CREATE TABLE metrics(time timestamptz NOT NULL);
@@ -629,7 +641,7 @@ SELECT chunk_status FROM compressed_chunk_info_view WHERE hypertable_name = 'met
 
 ---- nothing to do yet
 CALL run_job(:JOB_RECOMPRESS);
-psql:include/recompress_basic.sql:194: NOTICE:  no chunks for hypertable "public.metrics" that satisfy recompress chunk policy
+psql:include/recompress_basic.sql:186: NOTICE:  no chunks for hypertable "public.metrics" that satisfy recompress chunk policy
 ---- status should be 1
 SELECT chunk_status FROM compressed_chunk_info_view WHERE hypertable_name = 'metrics';
  chunk_status 

--- a/tsl/test/expected/compression_bgw-16.out
+++ b/tsl/test/expected/compression_bgw-16.out
@@ -434,14 +434,12 @@ SELECT count(*) from test2;
     29
 (1 row)
 
--- call recompress_chunk inside a transaction. This should fails since
--- it contains transaction-terminating commands.
-\set ON_ERROR_STOP 0
-START TRANSACTION;
-CALL recompress_chunk(:'CHUNK_NAME'::regclass);
-ROLLBACK;
-\set ON_ERROR_STOP 1
-CALL recompress_chunk(:'CHUNK_NAME'::regclass);
+SELECT compress_chunk(:'CHUNK_NAME'::regclass);
+              compress_chunk              
+------------------------------------------
+ _timescaledb_internal._hyper_14_62_chunk
+(1 row)
+
 -- Demonstrate that no locks are held on the hypertable, chunk, or the
 -- compressed chunk after recompress_chunk has executed.
 SELECT pid, locktype, relation, relation::regclass, mode, granted
@@ -510,12 +508,22 @@ WHERE hypertable_name = 'test2' ORDER BY chunk_name;
 (2 rows)
 
 \set ON_ERROR_STOP 0
--- call recompress_chunk when status is not unordered
-CALL recompress_chunk(:'CHUNK_NAME'::regclass, true);
-psql:include/recompress_basic.sql:115: NOTICE:  nothing to recompress in chunk "_hyper_14_62_chunk"
+-- call compress_chunk when status is not unordered
+SELECT compress_chunk(:'CHUNK_NAME'::regclass);
+psql:include/recompress_basic.sql:107: NOTICE:  chunk "_hyper_14_62_chunk" is already compressed
+              compress_chunk              
+------------------------------------------
+ _timescaledb_internal._hyper_14_62_chunk
+(1 row)
+
 -- This will succeed and compress the chunk for the test below.
-CALL recompress_chunk(:'CHUNK_NAME'::regclass, false);
-psql:include/recompress_basic.sql:118: ERROR:  nothing to recompress in chunk "_hyper_14_62_chunk"
+SELECT compress_chunk(:'CHUNK_NAME'::regclass);
+psql:include/recompress_basic.sql:110: NOTICE:  chunk "_hyper_14_62_chunk" is already compressed
+              compress_chunk              
+------------------------------------------
+ _timescaledb_internal._hyper_14_62_chunk
+(1 row)
+
 --now decompress it , then try and recompress
 SELECT decompress_chunk(:'CHUNK_NAME'::regclass);
              decompress_chunk             
@@ -523,8 +531,12 @@ SELECT decompress_chunk(:'CHUNK_NAME'::regclass);
  _timescaledb_internal._hyper_14_62_chunk
 (1 row)
 
-CALL recompress_chunk(:'CHUNK_NAME'::regclass);
-psql:include/recompress_basic.sql:122: ERROR:  call compress_chunk instead of recompress_chunk
+SELECT compress_chunk(:'CHUNK_NAME'::regclass);
+              compress_chunk              
+------------------------------------------
+ _timescaledb_internal._hyper_14_62_chunk
+(1 row)
+
 \set ON_ERROR_STOP 1
 -- test recompress policy
 CREATE TABLE metrics(time timestamptz NOT NULL);
@@ -629,7 +641,7 @@ SELECT chunk_status FROM compressed_chunk_info_view WHERE hypertable_name = 'met
 
 ---- nothing to do yet
 CALL run_job(:JOB_RECOMPRESS);
-psql:include/recompress_basic.sql:194: NOTICE:  no chunks for hypertable "public.metrics" that satisfy recompress chunk policy
+psql:include/recompress_basic.sql:186: NOTICE:  no chunks for hypertable "public.metrics" that satisfy recompress chunk policy
 ---- status should be 1
 SELECT chunk_status FROM compressed_chunk_info_view WHERE hypertable_name = 'metrics';
  chunk_status 

--- a/tsl/test/expected/compression_ddl.out
+++ b/tsl/test/expected/compression_ddl.out
@@ -1018,7 +1018,12 @@ SELECT * FROM test_defaults ORDER BY 1,2;
  Mon Jan 01 00:00:00 2001 PST |         1 |    | 42
 (3 rows)
 
-CALL recompress_all_chunks('test_defaults', 1, false);
+SELECT compress_chunk(ch) FROM show_chunks('test_defaults') ch LIMIT 1;
+              compress_chunk              
+------------------------------------------
+ _timescaledb_internal._hyper_15_92_chunk
+(1 row)
+
 SELECT * FROM test_defaults ORDER BY 1,2;
              time             | device_id | c1 | c2 
 ------------------------------+-----------+----+----
@@ -1419,7 +1424,12 @@ ORDER BY device_id;
          5 |  3596
 (5 rows)
 
-CALL recompress_chunk(:'CHUNK_NAME'::regclass);
+SELECT compress_chunk(:'CHUNK_NAME'::regclass);
+              compress_chunk               
+-------------------------------------------
+ _timescaledb_internal._hyper_31_110_chunk
+(1 row)
+
 SELECT count(*), sum(v0), sum(v1), sum(v2), sum(v3)
 FROM compression_insert
 WHERE time >= '2000-01-01 0:00:00+0'
@@ -1503,7 +1513,12 @@ ORDER BY device_id;
          5 |  7192
 (5 rows)
 
-CALL recompress_chunk(:'CHUNK_NAME'::regclass);
+SELECT compress_chunk(:'CHUNK_NAME'::regclass);
+              compress_chunk               
+-------------------------------------------
+ _timescaledb_internal._hyper_31_112_chunk
+(1 row)
+
 SELECT count(*), sum(v0), sum(v1), sum(v2), sum(v3)
 FROM compression_insert
 WHERE time >= '2000-01-07 0:00:00+0'
@@ -1591,7 +1606,12 @@ ORDER BY device_id;
          5 | 10788
 (5 rows)
 
-CALL recompress_chunk(:'CHUNK_NAME'::regclass);
+SELECT compress_chunk(:'CHUNK_NAME'::regclass);
+              compress_chunk               
+-------------------------------------------
+ _timescaledb_internal._hyper_31_114_chunk
+(1 row)
+
 SELECT count(*), sum(v0), sum(v1), sum(v2), sum(v3)
 FROM compression_insert
 WHERE time >= '2000-01-15 0:00:00+0'
@@ -1683,7 +1703,12 @@ ORDER BY device_id;
          5 | 14384
 (5 rows)
 
-CALL recompress_chunk(:'CHUNK_NAME'::regclass);
+SELECT compress_chunk(:'CHUNK_NAME'::regclass);
+              compress_chunk               
+-------------------------------------------
+ _timescaledb_internal._hyper_31_116_chunk
+(1 row)
+
 SELECT count(*), sum(v0), sum(v1), sum(v2), sum(v3)
 FROM compression_insert
 WHERE time >= '2000-01-22 0:00:00+0'
@@ -1779,7 +1804,12 @@ ORDER BY device_id;
          5 | 17980
 (5 rows)
 
-CALL recompress_chunk(:'CHUNK_NAME'::regclass);
+SELECT compress_chunk(:'CHUNK_NAME'::regclass);
+              compress_chunk               
+-------------------------------------------
+ _timescaledb_internal._hyper_31_118_chunk
+(1 row)
+
 SELECT count(*), sum(v0), sum(v1), sum(v2), sum(v3)
 FROM compression_insert
 WHERE time >= '2000-01-28 0:00:00+0'

--- a/tsl/test/expected/compression_merge.out
+++ b/tsl/test/expected/compression_merge.out
@@ -260,14 +260,18 @@ SELECT
 SELECT compress_chunk(i) FROM show_chunks('test5') i LIMIT 4;
               compress_chunk              
 ------------------------------------------
- _timescaledb_internal._hyper_9_163_chunk
- _timescaledb_internal._hyper_9_163_chunk
- _timescaledb_internal._hyper_9_163_chunk
- _timescaledb_internal._hyper_9_163_chunk
+ _timescaledb_internal._hyper_9_142_chunk
+ _timescaledb_internal._hyper_9_142_chunk
+ _timescaledb_internal._hyper_9_142_chunk
+ _timescaledb_internal._hyper_9_142_chunk
 (4 rows)
 
+SELECT format('%I.%I',ch.schema_name,ch.table_name) AS "CHUNK"
+  FROM _timescaledb_catalog.chunk ch
+  JOIN _timescaledb_catalog.hypertable ht ON ht.id=ch.hypertable_id
+  JOIN _timescaledb_catalog.hypertable ht2 ON ht.id=ht2.compressed_hypertable_id AND ht2.table_name='test5' \gset
 -- Make sure sequence numbers are correctly fetched from index.
-SELECT _ts_meta_sequence_num FROM _timescaledb_internal.compress_hyper_10_187_chunk where i = 1;
+SELECT _ts_meta_sequence_num FROM :CHUNK  where i = 1;
  _ts_meta_sequence_num 
 -----------------------
                     10
@@ -285,18 +289,18 @@ DROP INDEX :INDEXNAME;
 -- We dropped the index from compressed chunk thats needed to determine sequence numbers
 -- during merge, merging will fallback to doing heap scans and work just fine.
 SELECT compress_chunk(i, true) FROM show_chunks('test5') i LIMIT 5;
-NOTICE:  chunk "_hyper_9_163_chunk" is already compressed
+NOTICE:  chunk "_hyper_9_142_chunk" is already compressed
               compress_chunk              
 ------------------------------------------
- _timescaledb_internal._hyper_9_163_chunk
- _timescaledb_internal._hyper_9_163_chunk
- _timescaledb_internal._hyper_9_163_chunk
- _timescaledb_internal._hyper_9_163_chunk
- _timescaledb_internal._hyper_9_163_chunk
+ _timescaledb_internal._hyper_9_142_chunk
+ _timescaledb_internal._hyper_9_142_chunk
+ _timescaledb_internal._hyper_9_142_chunk
+ _timescaledb_internal._hyper_9_142_chunk
+ _timescaledb_internal._hyper_9_142_chunk
 (5 rows)
 
 -- Make sure sequence numbers are correctly fetched from heap.
-SELECT _ts_meta_sequence_num FROM _timescaledb_internal.compress_hyper_10_187_chunk where i = 1;
+SELECT _ts_meta_sequence_num FROM :CHUNK where i = 1;
  _ts_meta_sequence_num 
 -----------------------
                     10
@@ -315,7 +319,7 @@ SELECT 'test5' AS "HYPERTABLE_NAME" \gset
 -- Please see the included NOTICE for copyright information and
 -- LICENSE-TIMESCALE for a copy of the license.
 \set ECHO errors
-psql:include/compression_test_merge.sql:12: NOTICE:  chunk "_hyper_9_163_chunk" is already compressed
+psql:include/compression_test_merge.sql:12: NOTICE:  chunk "_hyper_9_142_chunk" is already compressed
  count_compressed 
 ------------------
                17
@@ -355,30 +359,30 @@ ALTER TABLE test6 set (timescaledb.compress, timescaledb.compress_segmentby='i',
 SELECT compress_chunk(i) FROM show_chunks('test6') i;
               compress_chunk               
 -------------------------------------------
- _timescaledb_internal._hyper_11_188_chunk
- _timescaledb_internal._hyper_11_188_chunk
- _timescaledb_internal._hyper_11_190_chunk
- _timescaledb_internal._hyper_11_190_chunk
- _timescaledb_internal._hyper_11_192_chunk
- _timescaledb_internal._hyper_11_192_chunk
- _timescaledb_internal._hyper_11_194_chunk
- _timescaledb_internal._hyper_11_194_chunk
- _timescaledb_internal._hyper_11_196_chunk
- _timescaledb_internal._hyper_11_196_chunk
- _timescaledb_internal._hyper_11_198_chunk
- _timescaledb_internal._hyper_11_198_chunk
- _timescaledb_internal._hyper_11_200_chunk
- _timescaledb_internal._hyper_11_200_chunk
- _timescaledb_internal._hyper_11_202_chunk
- _timescaledb_internal._hyper_11_202_chunk
- _timescaledb_internal._hyper_11_204_chunk
- _timescaledb_internal._hyper_11_204_chunk
- _timescaledb_internal._hyper_11_206_chunk
- _timescaledb_internal._hyper_11_206_chunk
- _timescaledb_internal._hyper_11_208_chunk
- _timescaledb_internal._hyper_11_208_chunk
- _timescaledb_internal._hyper_11_210_chunk
- _timescaledb_internal._hyper_11_210_chunk
+ _timescaledb_internal._hyper_11_167_chunk
+ _timescaledb_internal._hyper_11_167_chunk
+ _timescaledb_internal._hyper_11_169_chunk
+ _timescaledb_internal._hyper_11_169_chunk
+ _timescaledb_internal._hyper_11_171_chunk
+ _timescaledb_internal._hyper_11_171_chunk
+ _timescaledb_internal._hyper_11_173_chunk
+ _timescaledb_internal._hyper_11_173_chunk
+ _timescaledb_internal._hyper_11_175_chunk
+ _timescaledb_internal._hyper_11_175_chunk
+ _timescaledb_internal._hyper_11_177_chunk
+ _timescaledb_internal._hyper_11_177_chunk
+ _timescaledb_internal._hyper_11_179_chunk
+ _timescaledb_internal._hyper_11_179_chunk
+ _timescaledb_internal._hyper_11_181_chunk
+ _timescaledb_internal._hyper_11_181_chunk
+ _timescaledb_internal._hyper_11_183_chunk
+ _timescaledb_internal._hyper_11_183_chunk
+ _timescaledb_internal._hyper_11_185_chunk
+ _timescaledb_internal._hyper_11_185_chunk
+ _timescaledb_internal._hyper_11_187_chunk
+ _timescaledb_internal._hyper_11_187_chunk
+ _timescaledb_internal._hyper_11_189_chunk
+ _timescaledb_internal._hyper_11_189_chunk
 (24 rows)
 
 SELECT count(*) as number_of_chunks FROM show_chunks('test6');
@@ -395,56 +399,56 @@ CROSS JOIN generate_series(1, 5, 1) i;
 -- Altering compress chunk time interval will cause us to create 6 chunks from the additional 24 chunks.
 ALTER TABLE test6 set (timescaledb.compress_chunk_time_interval='4 hours');
 SELECT compress_chunk(i, true) FROM show_chunks('test6') i;
-NOTICE:  chunk "_hyper_11_188_chunk" is already compressed
-NOTICE:  chunk "_hyper_11_190_chunk" is already compressed
-NOTICE:  chunk "_hyper_11_192_chunk" is already compressed
-NOTICE:  chunk "_hyper_11_194_chunk" is already compressed
-NOTICE:  chunk "_hyper_11_196_chunk" is already compressed
-NOTICE:  chunk "_hyper_11_198_chunk" is already compressed
-NOTICE:  chunk "_hyper_11_200_chunk" is already compressed
-NOTICE:  chunk "_hyper_11_202_chunk" is already compressed
-NOTICE:  chunk "_hyper_11_204_chunk" is already compressed
-NOTICE:  chunk "_hyper_11_206_chunk" is already compressed
-NOTICE:  chunk "_hyper_11_208_chunk" is already compressed
-NOTICE:  chunk "_hyper_11_210_chunk" is already compressed
+NOTICE:  chunk "_hyper_11_167_chunk" is already compressed
+NOTICE:  chunk "_hyper_11_169_chunk" is already compressed
+NOTICE:  chunk "_hyper_11_171_chunk" is already compressed
+NOTICE:  chunk "_hyper_11_173_chunk" is already compressed
+NOTICE:  chunk "_hyper_11_175_chunk" is already compressed
+NOTICE:  chunk "_hyper_11_177_chunk" is already compressed
+NOTICE:  chunk "_hyper_11_179_chunk" is already compressed
+NOTICE:  chunk "_hyper_11_181_chunk" is already compressed
+NOTICE:  chunk "_hyper_11_183_chunk" is already compressed
+NOTICE:  chunk "_hyper_11_185_chunk" is already compressed
+NOTICE:  chunk "_hyper_11_187_chunk" is already compressed
+NOTICE:  chunk "_hyper_11_189_chunk" is already compressed
               compress_chunk               
 -------------------------------------------
- _timescaledb_internal._hyper_11_188_chunk
- _timescaledb_internal._hyper_11_190_chunk
- _timescaledb_internal._hyper_11_192_chunk
- _timescaledb_internal._hyper_11_194_chunk
- _timescaledb_internal._hyper_11_196_chunk
- _timescaledb_internal._hyper_11_198_chunk
- _timescaledb_internal._hyper_11_200_chunk
- _timescaledb_internal._hyper_11_202_chunk
- _timescaledb_internal._hyper_11_204_chunk
- _timescaledb_internal._hyper_11_206_chunk
- _timescaledb_internal._hyper_11_208_chunk
- _timescaledb_internal._hyper_11_210_chunk
- _timescaledb_internal._hyper_11_210_chunk
- _timescaledb_internal._hyper_11_210_chunk
- _timescaledb_internal._hyper_11_226_chunk
- _timescaledb_internal._hyper_11_226_chunk
- _timescaledb_internal._hyper_11_226_chunk
- _timescaledb_internal._hyper_11_226_chunk
- _timescaledb_internal._hyper_11_230_chunk
- _timescaledb_internal._hyper_11_230_chunk
- _timescaledb_internal._hyper_11_230_chunk
- _timescaledb_internal._hyper_11_230_chunk
- _timescaledb_internal._hyper_11_234_chunk
- _timescaledb_internal._hyper_11_234_chunk
- _timescaledb_internal._hyper_11_234_chunk
- _timescaledb_internal._hyper_11_234_chunk
- _timescaledb_internal._hyper_11_238_chunk
- _timescaledb_internal._hyper_11_238_chunk
- _timescaledb_internal._hyper_11_238_chunk
- _timescaledb_internal._hyper_11_238_chunk
- _timescaledb_internal._hyper_11_242_chunk
- _timescaledb_internal._hyper_11_242_chunk
- _timescaledb_internal._hyper_11_242_chunk
- _timescaledb_internal._hyper_11_242_chunk
- _timescaledb_internal._hyper_11_246_chunk
- _timescaledb_internal._hyper_11_246_chunk
+ _timescaledb_internal._hyper_11_167_chunk
+ _timescaledb_internal._hyper_11_169_chunk
+ _timescaledb_internal._hyper_11_171_chunk
+ _timescaledb_internal._hyper_11_173_chunk
+ _timescaledb_internal._hyper_11_175_chunk
+ _timescaledb_internal._hyper_11_177_chunk
+ _timescaledb_internal._hyper_11_179_chunk
+ _timescaledb_internal._hyper_11_181_chunk
+ _timescaledb_internal._hyper_11_183_chunk
+ _timescaledb_internal._hyper_11_185_chunk
+ _timescaledb_internal._hyper_11_187_chunk
+ _timescaledb_internal._hyper_11_189_chunk
+ _timescaledb_internal._hyper_11_189_chunk
+ _timescaledb_internal._hyper_11_189_chunk
+ _timescaledb_internal._hyper_11_205_chunk
+ _timescaledb_internal._hyper_11_205_chunk
+ _timescaledb_internal._hyper_11_205_chunk
+ _timescaledb_internal._hyper_11_205_chunk
+ _timescaledb_internal._hyper_11_209_chunk
+ _timescaledb_internal._hyper_11_209_chunk
+ _timescaledb_internal._hyper_11_209_chunk
+ _timescaledb_internal._hyper_11_209_chunk
+ _timescaledb_internal._hyper_11_213_chunk
+ _timescaledb_internal._hyper_11_213_chunk
+ _timescaledb_internal._hyper_11_213_chunk
+ _timescaledb_internal._hyper_11_213_chunk
+ _timescaledb_internal._hyper_11_217_chunk
+ _timescaledb_internal._hyper_11_217_chunk
+ _timescaledb_internal._hyper_11_217_chunk
+ _timescaledb_internal._hyper_11_217_chunk
+ _timescaledb_internal._hyper_11_221_chunk
+ _timescaledb_internal._hyper_11_221_chunk
+ _timescaledb_internal._hyper_11_221_chunk
+ _timescaledb_internal._hyper_11_221_chunk
+ _timescaledb_internal._hyper_11_225_chunk
+ _timescaledb_internal._hyper_11_225_chunk
 (36 rows)
 
 SELECT count(*) as number_of_chunks FROM show_chunks('test6');
@@ -463,47 +467,47 @@ CROSS JOIN generate_series(1, 5, 1) i;
 ALTER TABLE test6 set (timescaledb.compress_chunk_time_interval='30 minutes');
 WARNING:  compress chunk interval is not a multiple of chunk interval, you should use a factor of chunk interval to merge as much as possible
 SELECT compress_chunk(i, true) FROM show_chunks('test6') i;
-NOTICE:  chunk "_hyper_11_188_chunk" is already compressed
-NOTICE:  chunk "_hyper_11_190_chunk" is already compressed
-NOTICE:  chunk "_hyper_11_192_chunk" is already compressed
-NOTICE:  chunk "_hyper_11_194_chunk" is already compressed
-NOTICE:  chunk "_hyper_11_196_chunk" is already compressed
-NOTICE:  chunk "_hyper_11_198_chunk" is already compressed
-NOTICE:  chunk "_hyper_11_200_chunk" is already compressed
-NOTICE:  chunk "_hyper_11_202_chunk" is already compressed
-NOTICE:  chunk "_hyper_11_204_chunk" is already compressed
-NOTICE:  chunk "_hyper_11_206_chunk" is already compressed
-NOTICE:  chunk "_hyper_11_208_chunk" is already compressed
-NOTICE:  chunk "_hyper_11_210_chunk" is already compressed
-NOTICE:  chunk "_hyper_11_226_chunk" is already compressed
-NOTICE:  chunk "_hyper_11_230_chunk" is already compressed
-NOTICE:  chunk "_hyper_11_234_chunk" is already compressed
-NOTICE:  chunk "_hyper_11_238_chunk" is already compressed
-NOTICE:  chunk "_hyper_11_242_chunk" is already compressed
-NOTICE:  chunk "_hyper_11_246_chunk" is already compressed
+NOTICE:  chunk "_hyper_11_167_chunk" is already compressed
+NOTICE:  chunk "_hyper_11_169_chunk" is already compressed
+NOTICE:  chunk "_hyper_11_171_chunk" is already compressed
+NOTICE:  chunk "_hyper_11_173_chunk" is already compressed
+NOTICE:  chunk "_hyper_11_175_chunk" is already compressed
+NOTICE:  chunk "_hyper_11_177_chunk" is already compressed
+NOTICE:  chunk "_hyper_11_179_chunk" is already compressed
+NOTICE:  chunk "_hyper_11_181_chunk" is already compressed
+NOTICE:  chunk "_hyper_11_183_chunk" is already compressed
+NOTICE:  chunk "_hyper_11_185_chunk" is already compressed
+NOTICE:  chunk "_hyper_11_187_chunk" is already compressed
+NOTICE:  chunk "_hyper_11_189_chunk" is already compressed
+NOTICE:  chunk "_hyper_11_205_chunk" is already compressed
+NOTICE:  chunk "_hyper_11_209_chunk" is already compressed
+NOTICE:  chunk "_hyper_11_213_chunk" is already compressed
+NOTICE:  chunk "_hyper_11_217_chunk" is already compressed
+NOTICE:  chunk "_hyper_11_221_chunk" is already compressed
+NOTICE:  chunk "_hyper_11_225_chunk" is already compressed
               compress_chunk               
 -------------------------------------------
- _timescaledb_internal._hyper_11_188_chunk
- _timescaledb_internal._hyper_11_190_chunk
- _timescaledb_internal._hyper_11_192_chunk
- _timescaledb_internal._hyper_11_194_chunk
- _timescaledb_internal._hyper_11_196_chunk
- _timescaledb_internal._hyper_11_198_chunk
- _timescaledb_internal._hyper_11_200_chunk
- _timescaledb_internal._hyper_11_202_chunk
- _timescaledb_internal._hyper_11_204_chunk
- _timescaledb_internal._hyper_11_206_chunk
- _timescaledb_internal._hyper_11_208_chunk
- _timescaledb_internal._hyper_11_210_chunk
- _timescaledb_internal._hyper_11_226_chunk
- _timescaledb_internal._hyper_11_230_chunk
+ _timescaledb_internal._hyper_11_167_chunk
+ _timescaledb_internal._hyper_11_169_chunk
+ _timescaledb_internal._hyper_11_171_chunk
+ _timescaledb_internal._hyper_11_173_chunk
+ _timescaledb_internal._hyper_11_175_chunk
+ _timescaledb_internal._hyper_11_177_chunk
+ _timescaledb_internal._hyper_11_179_chunk
+ _timescaledb_internal._hyper_11_181_chunk
+ _timescaledb_internal._hyper_11_183_chunk
+ _timescaledb_internal._hyper_11_185_chunk
+ _timescaledb_internal._hyper_11_187_chunk
+ _timescaledb_internal._hyper_11_189_chunk
+ _timescaledb_internal._hyper_11_205_chunk
+ _timescaledb_internal._hyper_11_209_chunk
+ _timescaledb_internal._hyper_11_213_chunk
+ _timescaledb_internal._hyper_11_217_chunk
+ _timescaledb_internal._hyper_11_221_chunk
+ _timescaledb_internal._hyper_11_225_chunk
+ _timescaledb_internal._hyper_11_233_chunk
  _timescaledb_internal._hyper_11_234_chunk
- _timescaledb_internal._hyper_11_238_chunk
- _timescaledb_internal._hyper_11_242_chunk
- _timescaledb_internal._hyper_11_246_chunk
- _timescaledb_internal._hyper_11_254_chunk
- _timescaledb_internal._hyper_11_255_chunk
- _timescaledb_internal._hyper_11_256_chunk
+ _timescaledb_internal._hyper_11_235_chunk
 (21 rows)
 
 SELECT count(*) as number_of_chunks FROM show_chunks('test6');
@@ -521,53 +525,53 @@ CROSS JOIN generate_series(1, 5, 1) i;
 -- Setting compressed chunk to anything less than chunk interval should disable merging chunks.
 ALTER TABLE test6 set (timescaledb.compress_chunk_time_interval=0);
 SELECT compress_chunk(i, true) FROM show_chunks('test6') i;
-NOTICE:  chunk "_hyper_11_188_chunk" is already compressed
-NOTICE:  chunk "_hyper_11_190_chunk" is already compressed
-NOTICE:  chunk "_hyper_11_192_chunk" is already compressed
-NOTICE:  chunk "_hyper_11_194_chunk" is already compressed
-NOTICE:  chunk "_hyper_11_196_chunk" is already compressed
-NOTICE:  chunk "_hyper_11_198_chunk" is already compressed
-NOTICE:  chunk "_hyper_11_200_chunk" is already compressed
-NOTICE:  chunk "_hyper_11_202_chunk" is already compressed
-NOTICE:  chunk "_hyper_11_204_chunk" is already compressed
-NOTICE:  chunk "_hyper_11_206_chunk" is already compressed
-NOTICE:  chunk "_hyper_11_208_chunk" is already compressed
-NOTICE:  chunk "_hyper_11_210_chunk" is already compressed
-NOTICE:  chunk "_hyper_11_226_chunk" is already compressed
-NOTICE:  chunk "_hyper_11_230_chunk" is already compressed
+NOTICE:  chunk "_hyper_11_167_chunk" is already compressed
+NOTICE:  chunk "_hyper_11_169_chunk" is already compressed
+NOTICE:  chunk "_hyper_11_171_chunk" is already compressed
+NOTICE:  chunk "_hyper_11_173_chunk" is already compressed
+NOTICE:  chunk "_hyper_11_175_chunk" is already compressed
+NOTICE:  chunk "_hyper_11_177_chunk" is already compressed
+NOTICE:  chunk "_hyper_11_179_chunk" is already compressed
+NOTICE:  chunk "_hyper_11_181_chunk" is already compressed
+NOTICE:  chunk "_hyper_11_183_chunk" is already compressed
+NOTICE:  chunk "_hyper_11_185_chunk" is already compressed
+NOTICE:  chunk "_hyper_11_187_chunk" is already compressed
+NOTICE:  chunk "_hyper_11_189_chunk" is already compressed
+NOTICE:  chunk "_hyper_11_205_chunk" is already compressed
+NOTICE:  chunk "_hyper_11_209_chunk" is already compressed
+NOTICE:  chunk "_hyper_11_213_chunk" is already compressed
+NOTICE:  chunk "_hyper_11_217_chunk" is already compressed
+NOTICE:  chunk "_hyper_11_221_chunk" is already compressed
+NOTICE:  chunk "_hyper_11_225_chunk" is already compressed
+NOTICE:  chunk "_hyper_11_233_chunk" is already compressed
 NOTICE:  chunk "_hyper_11_234_chunk" is already compressed
-NOTICE:  chunk "_hyper_11_238_chunk" is already compressed
-NOTICE:  chunk "_hyper_11_242_chunk" is already compressed
-NOTICE:  chunk "_hyper_11_246_chunk" is already compressed
-NOTICE:  chunk "_hyper_11_254_chunk" is already compressed
-NOTICE:  chunk "_hyper_11_255_chunk" is already compressed
-NOTICE:  chunk "_hyper_11_256_chunk" is already compressed
+NOTICE:  chunk "_hyper_11_235_chunk" is already compressed
               compress_chunk               
 -------------------------------------------
- _timescaledb_internal._hyper_11_188_chunk
- _timescaledb_internal._hyper_11_190_chunk
- _timescaledb_internal._hyper_11_192_chunk
- _timescaledb_internal._hyper_11_194_chunk
- _timescaledb_internal._hyper_11_196_chunk
- _timescaledb_internal._hyper_11_198_chunk
- _timescaledb_internal._hyper_11_200_chunk
- _timescaledb_internal._hyper_11_202_chunk
- _timescaledb_internal._hyper_11_204_chunk
- _timescaledb_internal._hyper_11_206_chunk
- _timescaledb_internal._hyper_11_208_chunk
- _timescaledb_internal._hyper_11_210_chunk
- _timescaledb_internal._hyper_11_226_chunk
- _timescaledb_internal._hyper_11_230_chunk
+ _timescaledb_internal._hyper_11_167_chunk
+ _timescaledb_internal._hyper_11_169_chunk
+ _timescaledb_internal._hyper_11_171_chunk
+ _timescaledb_internal._hyper_11_173_chunk
+ _timescaledb_internal._hyper_11_175_chunk
+ _timescaledb_internal._hyper_11_177_chunk
+ _timescaledb_internal._hyper_11_179_chunk
+ _timescaledb_internal._hyper_11_181_chunk
+ _timescaledb_internal._hyper_11_183_chunk
+ _timescaledb_internal._hyper_11_185_chunk
+ _timescaledb_internal._hyper_11_187_chunk
+ _timescaledb_internal._hyper_11_189_chunk
+ _timescaledb_internal._hyper_11_205_chunk
+ _timescaledb_internal._hyper_11_209_chunk
+ _timescaledb_internal._hyper_11_213_chunk
+ _timescaledb_internal._hyper_11_217_chunk
+ _timescaledb_internal._hyper_11_221_chunk
+ _timescaledb_internal._hyper_11_225_chunk
+ _timescaledb_internal._hyper_11_233_chunk
  _timescaledb_internal._hyper_11_234_chunk
- _timescaledb_internal._hyper_11_238_chunk
- _timescaledb_internal._hyper_11_242_chunk
- _timescaledb_internal._hyper_11_246_chunk
- _timescaledb_internal._hyper_11_254_chunk
- _timescaledb_internal._hyper_11_255_chunk
- _timescaledb_internal._hyper_11_256_chunk
- _timescaledb_internal._hyper_11_260_chunk
- _timescaledb_internal._hyper_11_261_chunk
- _timescaledb_internal._hyper_11_262_chunk
+ _timescaledb_internal._hyper_11_235_chunk
+ _timescaledb_internal._hyper_11_239_chunk
+ _timescaledb_internal._hyper_11_240_chunk
+ _timescaledb_internal._hyper_11_241_chunk
 (24 rows)
 
 SELECT count(*) as number_of_chunks FROM show_chunks('test6');
@@ -644,10 +648,10 @@ INSERT INTO test8 (time, series_id, value) SELECT t, s, 1 FROM generate_series(N
 SELECT compress_chunk(c, true) FROM show_chunks('test8') c LIMIT 4;
               compress_chunk               
 -------------------------------------------
- _timescaledb_internal._hyper_15_314_chunk
- _timescaledb_internal._hyper_15_314_chunk
- _timescaledb_internal._hyper_15_314_chunk
- _timescaledb_internal._hyper_15_314_chunk
+ _timescaledb_internal._hyper_15_281_chunk
+ _timescaledb_internal._hyper_15_281_chunk
+ _timescaledb_internal._hyper_15_281_chunk
+ _timescaledb_internal._hyper_15_281_chunk
 (4 rows)
 
 SET enable_indexscan TO OFF;
@@ -676,7 +680,7 @@ INSERT INTO test9 (time, series_id, value) SELECT '2020-01-01 00:00:00'::TIMESTA
 SELECT compress_chunk(show_chunks('test9'), true);
               compress_chunk               
 -------------------------------------------
- _timescaledb_internal._hyper_17_320_chunk
+ _timescaledb_internal._hyper_17_287_chunk
 (1 row)
 
 INSERT INTO test9 (time, series_id, value) SELECT '2020-01-01 01:00:00'::TIMESTAMPTZ, 1, 1;
@@ -689,11 +693,11 @@ SELECT hypertable_name, range_start, range_end FROM timescaledb_information.chun
 (2 rows)
 
 SELECT compress_chunk(show_chunks('test9'), true);
-NOTICE:  chunk "_hyper_17_320_chunk" is already compressed
+NOTICE:  chunk "_hyper_17_287_chunk" is already compressed
               compress_chunk               
 -------------------------------------------
- _timescaledb_internal._hyper_17_320_chunk
- _timescaledb_internal._hyper_17_320_chunk
+ _timescaledb_internal._hyper_17_287_chunk
+ _timescaledb_internal._hyper_17_287_chunk
 (2 rows)
 
 -- should be 1 chunk because of rollup
@@ -715,11 +719,11 @@ SELECT hypertable_name, range_start, range_end FROM timescaledb_information.chun
 ALTER TABLE test9 SET (timescaledb.compress_segmentby = '');
 BEGIN;
   SELECT compress_chunk(show_chunks('test9'), true);
-NOTICE:  chunk "_hyper_17_320_chunk" is already compressed
+NOTICE:  chunk "_hyper_17_287_chunk" is already compressed
               compress_chunk               
 -------------------------------------------
- _timescaledb_internal._hyper_17_320_chunk
- _timescaledb_internal._hyper_17_323_chunk
+ _timescaledb_internal._hyper_17_287_chunk
+ _timescaledb_internal._hyper_17_290_chunk
 (2 rows)
 
   -- should not be rolled up
@@ -734,11 +738,11 @@ ROLLBACK;
 ALTER TABLE test9 SET (timescaledb.compress_segmentby = 'series_id', timescaledb.compress_orderby = 'time DESC');
 BEGIN;
   SELECT compress_chunk(show_chunks('test9'), true);
-NOTICE:  chunk "_hyper_17_320_chunk" is already compressed
+NOTICE:  chunk "_hyper_17_287_chunk" is already compressed
               compress_chunk               
 -------------------------------------------
- _timescaledb_internal._hyper_17_320_chunk
- _timescaledb_internal._hyper_17_323_chunk
+ _timescaledb_internal._hyper_17_287_chunk
+ _timescaledb_internal._hyper_17_290_chunk
 (2 rows)
 
   -- should not be rolled up
@@ -753,11 +757,11 @@ ROLLBACK;
 ALTER TABLE test9 SET (timescaledb.compress_segmentby = 'series_id', timescaledb.compress_orderby = 'time NULLS FIRST');
 BEGIN;
   SELECT compress_chunk(show_chunks('test9'), true);
-NOTICE:  chunk "_hyper_17_320_chunk" is already compressed
+NOTICE:  chunk "_hyper_17_287_chunk" is already compressed
               compress_chunk               
 -------------------------------------------
- _timescaledb_internal._hyper_17_320_chunk
- _timescaledb_internal._hyper_17_323_chunk
+ _timescaledb_internal._hyper_17_287_chunk
+ _timescaledb_internal._hyper_17_290_chunk
 (2 rows)
 
   -- should not be rolled up
@@ -773,11 +777,11 @@ ROLLBACK;
 ALTER TABLE test9 SET (timescaledb.compress_segmentby = 'series_id', timescaledb.compress_orderby = 'time');
 BEGIN;
   SELECT compress_chunk(show_chunks('test9'), true);
-NOTICE:  chunk "_hyper_17_320_chunk" is already compressed
+NOTICE:  chunk "_hyper_17_287_chunk" is already compressed
               compress_chunk               
 -------------------------------------------
- _timescaledb_internal._hyper_17_320_chunk
- _timescaledb_internal._hyper_17_320_chunk
+ _timescaledb_internal._hyper_17_287_chunk
+ _timescaledb_internal._hyper_17_287_chunk
 (2 rows)
 
   -- should be rolled up

--- a/tsl/test/expected/compression_update_delete.out
+++ b/tsl/test/expected/compression_update_delete.out
@@ -125,8 +125,18 @@ WHERE hypertable_name = 'sample_table' ORDER BY chunk_name;
 (2 rows)
 
 -- recompress the partial chunks
-CALL recompress_chunk('_timescaledb_internal._hyper_1_1_chunk');
-CALL recompress_chunk('_timescaledb_internal._hyper_1_2_chunk');
+SELECT compress_chunk('_timescaledb_internal._hyper_1_1_chunk');
+             compress_chunk             
+----------------------------------------
+ _timescaledb_internal._hyper_1_1_chunk
+(1 row)
+
+SELECT compress_chunk('_timescaledb_internal._hyper_1_2_chunk');
+             compress_chunk             
+----------------------------------------
+ _timescaledb_internal._hyper_1_2_chunk
+(1 row)
+
 -- check chunk compression status
 SELECT chunk_status,
        chunk_name as "CHUNK_NAME"
@@ -166,8 +176,18 @@ WHERE hypertable_name = 'sample_table' ORDER BY chunk_name;
 (2 rows)
 
 -- recompress the paritial chunks
-CALL recompress_chunk('_timescaledb_internal._hyper_1_1_chunk');
-CALL recompress_chunk('_timescaledb_internal._hyper_1_2_chunk');
+SELECT compress_chunk('_timescaledb_internal._hyper_1_1_chunk');
+             compress_chunk             
+----------------------------------------
+ _timescaledb_internal._hyper_1_1_chunk
+(1 row)
+
+SELECT compress_chunk('_timescaledb_internal._hyper_1_2_chunk');
+             compress_chunk             
+----------------------------------------
+ _timescaledb_internal._hyper_1_2_chunk
+(1 row)
+
 -- test for IS NULL checks
 -- should not UPDATE any rows
 UPDATE sample_table SET temperature = 34.21 WHERE sensor_id IS NULL;
@@ -197,8 +217,18 @@ WHERE hypertable_name = 'sample_table' ORDER BY chunk_name;
 (2 rows)
 
 -- recompress the paritial chunks
-CALL recompress_chunk('_timescaledb_internal._hyper_1_1_chunk');
-CALL recompress_chunk('_timescaledb_internal._hyper_1_2_chunk');
+SELECT compress_chunk('_timescaledb_internal._hyper_1_1_chunk');
+             compress_chunk             
+----------------------------------------
+ _timescaledb_internal._hyper_1_1_chunk
+(1 row)
+
+SELECT compress_chunk('_timescaledb_internal._hyper_1_2_chunk');
+             compress_chunk             
+----------------------------------------
+ _timescaledb_internal._hyper_1_2_chunk
+(1 row)
+
 -- check chunk compression status
 SELECT chunk_status,
        chunk_name as "CHUNK_NAME"

--- a/tsl/test/expected/decompress_vector_qual.out
+++ b/tsl/test/expected/decompress_vector_qual.out
@@ -1202,9 +1202,13 @@ select count(compress_chunk(x, true)) from show_chunks('text_table') x;
      1
 (1 row)
 
-select format('call recompress_chunk(''%s'')', x) from show_chunks('text_table') x \gexec
-call recompress_chunk('_timescaledb_internal._hyper_9_17_chunk')
-NOTICE:  nothing to recompress in chunk "_hyper_9_17_chunk"
+select compress_chunk(x) from show_chunks('text_table') x;
+NOTICE:  chunk "_hyper_9_17_chunk" is already compressed
+             compress_chunk              
+-----------------------------------------
+ _timescaledb_internal._hyper_9_17_chunk
+(1 row)
+
 set timescaledb.enable_bulk_decompression to on;
 set timescaledb.debug_require_vector_qual to 'forbid';
 select sum(length(a)) from text_table;

--- a/tsl/test/expected/recompress_chunk_segmentwise.out
+++ b/tsl/test/expected/recompress_chunk_segmentwise.out
@@ -282,7 +282,12 @@ SELECT * FROM test_defaults ORDER BY 1,2;
  Mon Jan 01 00:00:00 2001 PST |         1 |    | 42
 (3 rows)
 
-call recompress_chunk(:'compressed_chunk');
+SELECT compress_chunk(:'compressed_chunk');
+             compress_chunk             
+----------------------------------------
+ _timescaledb_internal._hyper_7_7_chunk
+(1 row)
+
 SELECT * FROM test_defaults ORDER BY 1,2;
              time             | device_id | c1 | c2 
 ------------------------------+-----------+----+----
@@ -344,7 +349,12 @@ EXECUTE p1;
 (3 rows)
 
 -- check plan again after recompression
-CALL recompress_chunk(:'chunk_to_compress_prep');
+SELECT compress_chunk(:'chunk_to_compress_prep');
+             compress_chunk              
+-----------------------------------------
+ _timescaledb_internal._hyper_9_10_chunk
+(1 row)
+
 EXPLAIN (COSTS OFF) EXECUTE p1;
                                                   QUERY PLAN                                                   
 ---------------------------------------------------------------------------------------------------------------
@@ -386,7 +396,12 @@ select compress_chunk(show_chunks('mytab'));
 select compressed_chunk_name as compressed_chunk_name_before_recompression from compressed_chunk_info_view where hypertable_name = 'mytab' \gset
 INSERT INTO mytab VALUES ('2023-01-01'::timestamptz, 2, 3, 2);
 -- segmentwise recompression should not create a new compressed chunk, so verify compressed chunk is the same after recompression
-call recompress_chunk(:'chunk_to_compress_mytab');
+SELECT compress_chunk(:'chunk_to_compress_mytab');
+              compress_chunk              
+------------------------------------------
+ _timescaledb_internal._hyper_11_12_chunk
+(1 row)
+
 select compressed_chunk_name as compressed_chunk_name_after_recompression from compressed_chunk_info_view where hypertable_name = 'mytab' \gset
 select :'compressed_chunk_name_before_recompression' as before_segmentwise_recompression, :'compressed_chunk_name_after_recompression' as after_segmentwise_recompression;
  before_segmentwise_recompression | after_segmentwise_recompression 
@@ -399,7 +414,12 @@ SELECT t, a, 3, 2
 FROM generate_series('2023-01-01'::timestamptz, '2023-01-02'::timestamptz, '1 hour'::interval) t
 CROSS JOIN generate_series(1, 10, 1) a;
 -- recompress will insert newly inserted tuples into compressed chunk along with inserting into the compressed chunk index
-CALL recompress_chunk(:'chunk_to_compress_mytab');
+SELECT compress_chunk(:'chunk_to_compress_mytab');
+              compress_chunk              
+------------------------------------------
+ _timescaledb_internal._hyper_11_12_chunk
+(1 row)
+
 -- make sure we are hitting the index and that the index contains the tuples
 SET enable_seqscan TO off;
 EXPLAIN (COSTS OFF) SELECT count(*) FROM mytab where a = 2;
@@ -435,7 +455,12 @@ select compress_chunk(show_chunks('mytab'));
 select compressed_chunk_name as compressed_chunk_name_before_recompression from compressed_chunk_info_view where hypertable_name = 'mytab' \gset
 INSERT INTO mytab VALUES ('2023-01-01'::timestamptz, 2, 3, 2);
 -- expect to see a different compressed chunk after recompressing now as the operation is decompress + compress
-call recompress_chunk(:'chunk_to_compress_mytab');
+SELECT compress_chunk(:'chunk_to_compress_mytab');
+              compress_chunk              
+------------------------------------------
+ _timescaledb_internal._hyper_11_12_chunk
+(1 row)
+
 select compressed_chunk_name as compressed_chunk_name_after_recompression from compressed_chunk_info_view where hypertable_name = 'mytab' \gset
 select :'compressed_chunk_name_before_recompression' as before_recompression, :'compressed_chunk_name_after_recompression' as after_recompression;
     before_recompression    |    after_recompression     
@@ -464,7 +489,12 @@ select compress_chunk(show_chunks('nullseg_one'));
 insert into nullseg_one values (:'start_time', NULL, 4);
 select show_chunks as chunk_to_compress from show_chunks('nullseg_one') limit 1 \gset
 select compressed_chunk_schema || '.' || compressed_chunk_name as compressed_chunk_name from compressed_chunk_info_view where hypertable_name = 'nullseg_one' \gset
-call recompress_chunk(:'chunk_to_compress');
+SELECT compress_chunk(:'chunk_to_compress');
+              compress_chunk              
+------------------------------------------
+ _timescaledb_internal._hyper_14_16_chunk
+(1 row)
+
 select * from :compressed_chunk_name;
                                  time                                 | a |                            b                             | _ts_meta_count | _ts_meta_sequence_num |        _ts_meta_min_1        |        _ts_meta_max_1        
 ----------------------------------------------------------------------+---+----------------------------------------------------------+----------------+-----------------------+------------------------------+------------------------------
@@ -475,7 +505,12 @@ select * from :compressed_chunk_name;
 
 -- insert again, check both index insertion works and NULL values properly handled
 insert into nullseg_one values (:'start_time', NULL, 4);
-call recompress_chunk(:'chunk_to_compress');
+SELECT compress_chunk(:'chunk_to_compress');
+              compress_chunk              
+------------------------------------------
+ _timescaledb_internal._hyper_14_16_chunk
+(1 row)
+
 select * from :compressed_chunk_name;
                                  time                                 | a |                            b                             | _ts_meta_count | _ts_meta_sequence_num |        _ts_meta_min_1        |        _ts_meta_max_1        
 ----------------------------------------------------------------------+---+----------------------------------------------------------+----------------+-----------------------+------------------------------+------------------------------
@@ -505,7 +540,12 @@ select compress_chunk(show_chunks('nullseg_many'));
 insert into nullseg_many values (:'start_time', 1, 4, NULL);
 select show_chunks as chunk_to_compress from show_chunks('nullseg_many') limit 1 \gset
 select compressed_chunk_schema || '.' || compressed_chunk_name as compressed_chunk_name from compressed_chunk_info_view where hypertable_name = 'nullseg_many' \gset
-call recompress_chunk(:'chunk_to_compress');
+SELECT compress_chunk(:'chunk_to_compress');
+              compress_chunk              
+------------------------------------------
+ _timescaledb_internal._hyper_16_18_chunk
+(1 row)
+
 select * from :compressed_chunk_name;
                                  time                                 | a |                                            b                                             | c | _ts_meta_count | _ts_meta_sequence_num |        _ts_meta_min_1        |        _ts_meta_max_1        
 ----------------------------------------------------------------------+---+------------------------------------------------------------------------------------------+---+----------------+-----------------------+------------------------------+------------------------------
@@ -519,7 +559,12 @@ select * from :compressed_chunk_name;
 -- insert again, check both index insertion works and NULL values properly handled
 -- should match existing segment (1, NULL)
 insert into nullseg_many values (:'start_time', 1, NULL, NULL);
-call recompress_chunk(:'chunk_to_compress');
+SELECT compress_chunk(:'chunk_to_compress');
+              compress_chunk              
+------------------------------------------
+ _timescaledb_internal._hyper_16_18_chunk
+(1 row)
+
 select * from :compressed_chunk_name;
                                  time                                 | a |                                            b                                             | c | _ts_meta_count | _ts_meta_sequence_num |        _ts_meta_min_1        |        _ts_meta_max_1        
 ----------------------------------------------------------------------+---+------------------------------------------------------------------------------------------+---+----------------+-----------------------+------------------------------+------------------------------

--- a/tsl/test/isolation/expected/compression_conflicts_iso.out
+++ b/tsl/test/isolation/expected/compression_conflicts_iso.out
@@ -1563,7 +1563,7 @@ step RC:
       SELECT ch FROM show_chunks('ts_device_table') ch
        ORDER BY ch::text LIMIT 1
      LOOP
-         CALL recompress_chunk(chunk_name);
+         PERFORM compress_chunk(chunk_name);
      END LOOP;
   END;
   $$;
@@ -1651,7 +1651,7 @@ step RC:
       SELECT ch FROM show_chunks('ts_device_table') ch
        ORDER BY ch::text LIMIT 1
      LOOP
-         CALL recompress_chunk(chunk_name);
+         PERFORM compress_chunk(chunk_name);
      END LOOP;
   END;
   $$;
@@ -1739,7 +1739,7 @@ step RC:
       SELECT ch FROM show_chunks('ts_device_table') ch
        ORDER BY ch::text LIMIT 1
      LOOP
-         CALL recompress_chunk(chunk_name);
+         PERFORM compress_chunk(chunk_name);
      END LOOP;
   END;
   $$;
@@ -1827,7 +1827,7 @@ step RC:
       SELECT ch FROM show_chunks('ts_device_table') ch
        ORDER BY ch::text LIMIT 1
      LOOP
-         CALL recompress_chunk(chunk_name);
+         PERFORM compress_chunk(chunk_name);
      END LOOP;
   END;
   $$;
@@ -1915,7 +1915,7 @@ step RC:
       SELECT ch FROM show_chunks('ts_device_table') ch
        ORDER BY ch::text LIMIT 1
      LOOP
-         CALL recompress_chunk(chunk_name);
+         PERFORM compress_chunk(chunk_name);
      END LOOP;
   END;
   $$;
@@ -2009,7 +2009,7 @@ step RC:
       SELECT ch FROM show_chunks('ts_device_table') ch
        ORDER BY ch::text LIMIT 1
      LOOP
-         CALL recompress_chunk(chunk_name);
+         PERFORM compress_chunk(chunk_name);
      END LOOP;
   END;
   $$;
@@ -2103,7 +2103,7 @@ step RC:
       SELECT ch FROM show_chunks('ts_device_table') ch
        ORDER BY ch::text LIMIT 1
      LOOP
-         CALL recompress_chunk(chunk_name);
+         PERFORM compress_chunk(chunk_name);
      END LOOP;
   END;
   $$;
@@ -2188,7 +2188,7 @@ step RC:
       SELECT ch FROM show_chunks('ts_device_table') ch
        ORDER BY ch::text LIMIT 1
      LOOP
-         CALL recompress_chunk(chunk_name);
+         PERFORM compress_chunk(chunk_name);
      END LOOP;
   END;
   $$;
@@ -2283,7 +2283,7 @@ step RC:
       SELECT ch FROM show_chunks('ts_device_table') ch
        ORDER BY ch::text LIMIT 1
      LOOP
-         CALL recompress_chunk(chunk_name);
+         PERFORM compress_chunk(chunk_name);
      END LOOP;
   END;
   $$;
@@ -2371,7 +2371,7 @@ step RC:
       SELECT ch FROM show_chunks('ts_device_table') ch
        ORDER BY ch::text LIMIT 1
      LOOP
-         CALL recompress_chunk(chunk_name);
+         PERFORM compress_chunk(chunk_name);
      END LOOP;
   END;
   $$;
@@ -2459,7 +2459,7 @@ step RC:
       SELECT ch FROM show_chunks('ts_device_table') ch
        ORDER BY ch::text LIMIT 1
      LOOP
-         CALL recompress_chunk(chunk_name);
+         PERFORM compress_chunk(chunk_name);
      END LOOP;
   END;
   $$;
@@ -2547,7 +2547,7 @@ step RC:
       SELECT ch FROM show_chunks('ts_device_table') ch
        ORDER BY ch::text LIMIT 1
      LOOP
-         CALL recompress_chunk(chunk_name);
+         PERFORM compress_chunk(chunk_name);
      END LOOP;
   END;
   $$;
@@ -2641,7 +2641,7 @@ step RC:
       SELECT ch FROM show_chunks('ts_device_table') ch
        ORDER BY ch::text LIMIT 1
      LOOP
-         CALL recompress_chunk(chunk_name);
+         PERFORM compress_chunk(chunk_name);
      END LOOP;
   END;
   $$;
@@ -2735,7 +2735,7 @@ step RC:
       SELECT ch FROM show_chunks('ts_device_table') ch
        ORDER BY ch::text LIMIT 1
      LOOP
-         CALL recompress_chunk(chunk_name);
+         PERFORM compress_chunk(chunk_name);
      END LOOP;
   END;
   $$;
@@ -2826,7 +2826,7 @@ step RC:
       SELECT ch FROM show_chunks('ts_device_table') ch
        ORDER BY ch::text LIMIT 1
      LOOP
-         CALL recompress_chunk(chunk_name);
+         PERFORM compress_chunk(chunk_name);
      END LOOP;
   END;
   $$;
@@ -2911,7 +2911,7 @@ step RC:
       SELECT ch FROM show_chunks('ts_device_table') ch
        ORDER BY ch::text LIMIT 1
      LOOP
-         CALL recompress_chunk(chunk_name);
+         PERFORM compress_chunk(chunk_name);
      END LOOP;
   END;
   $$;

--- a/tsl/test/isolation/expected/compression_ddl_iso.out
+++ b/tsl/test/isolation/expected/compression_ddl_iso.out
@@ -524,7 +524,7 @@ step RC1:
       SELECT ch FROM show_chunks('ts_device_table') ch
       LIMIT 1
      LOOP
-         CALL recompress_chunk(chunk_name);
+         PERFORM compress_chunk(chunk_name);
      END LOOP;
   END;
   $$;
@@ -632,7 +632,7 @@ step RC1:
       SELECT ch FROM show_chunks('ts_device_table') ch
       LIMIT 1
      LOOP
-         CALL recompress_chunk(chunk_name);
+         PERFORM compress_chunk(chunk_name);
      END LOOP;
   END;
   $$;
@@ -646,7 +646,7 @@ step RC2:
       SELECT ch FROM show_chunks('ts_device_table') ch
        ORDER BY ch::text LIMIT 1
      LOOP
-         CALL recompress_chunk(chunk_name, false);
+         PERFORM compress_chunk(chunk_name, false);
      END LOOP;
   END;
   $$;
@@ -654,7 +654,6 @@ step RC2:
 step UnlockChunk: ROLLBACK;
 step RC1: <... completed>
 step RC2: <... completed>
-ERROR:  nothing to recompress in chunk _timescaledb_internal._hyper_X_X_chunk
 step SH: SELECT total_chunks, number_compressed_chunks from hypertable_compression_stats('ts_device_table');
 total_chunks|number_compressed_chunks
 ------------+------------------------

--- a/tsl/test/isolation/expected/deadlock_recompress_chunk.out
+++ b/tsl/test/isolation/expected/deadlock_recompress_chunk.out
@@ -35,7 +35,7 @@ step recompress_chunks_start:
       chunk regclass;
     BEGIN
       SELECT show_chunks('hyper') INTO chunk;
-      CALL recompress_chunk(chunk);
+      PERFORM compress_chunk(chunk);
     END;
     $$;
  <waiting ...>

--- a/tsl/test/isolation/specs/compression_conflicts_iso.spec
+++ b/tsl/test/isolation/specs/compression_conflicts_iso.spec
@@ -108,7 +108,7 @@ step "RC" {
       SELECT ch FROM show_chunks('ts_device_table') ch
        ORDER BY ch::text LIMIT 1
      LOOP
-         CALL recompress_chunk(chunk_name);
+         PERFORM compress_chunk(chunk_name);
      END LOOP;
   END;
   $$;

--- a/tsl/test/isolation/specs/compression_ddl_iso.spec
+++ b/tsl/test/isolation/specs/compression_ddl_iso.spec
@@ -114,7 +114,7 @@ step "RC1" {
       SELECT ch FROM show_chunks('ts_device_table') ch
       LIMIT 1
      LOOP
-         CALL recompress_chunk(chunk_name);
+         PERFORM compress_chunk(chunk_name);
      END LOOP;
   END;
   $$;
@@ -130,7 +130,7 @@ step "RC2" {
       SELECT ch FROM show_chunks('ts_device_table') ch
        ORDER BY ch::text LIMIT 1
      LOOP
-         CALL recompress_chunk(chunk_name, false);
+         PERFORM compress_chunk(chunk_name, false);
      END LOOP;
   END;
   $$;

--- a/tsl/test/isolation/specs/deadlock_recompress_chunk.spec
+++ b/tsl/test/isolation/specs/deadlock_recompress_chunk.spec
@@ -84,7 +84,7 @@ step "recompress_chunks_start" {
       chunk regclass;
     BEGIN
       SELECT show_chunks('hyper') INTO chunk;
-      CALL recompress_chunk(chunk);
+      PERFORM compress_chunk(chunk);
     END;
     $$;
 }

--- a/tsl/test/shared/expected/compat.out
+++ b/tsl/test/shared/expected/compat.out
@@ -317,6 +317,9 @@ CALL _timescaledb_internal.policy_reorder(0,NULL);
 WARNING:  procedure _timescaledb_internal.policy_reorder(integer,jsonb) is deprecated and has been moved to _timescaledb_functions schema. this compatibility function will be removed in a future version.
 CALL _timescaledb_internal.policy_retention(0,NULL);
 WARNING:  procedure _timescaledb_internal.policy_retention(integer,jsonb) is deprecated and has been moved to _timescaledb_functions schema. this compatibility function will be removed in a future version.
+CALL public.recompress_chunk(0);
+WARNING:  procedure public.recompress_chunk(regclass,boolean) is deprecated and the functionality is now included in public.compress_chunk. this compatibility function will be removed in a future version.
+ERROR:  invalid Oid
 \set ON_ERROR_STOP 1
 -- tests for the cagg invalidation trigger on the deprecated schema
 CREATE TABLE sensor_data (

--- a/tsl/test/shared/expected/extension.out
+++ b/tsl/test/shared/expected/extension.out
@@ -237,7 +237,7 @@ ORDER BY pronamespace::regnamespace::text COLLATE "C", p.oid::regprocedure::text
  cagg_migrate(regclass,boolean,boolean)
  chunk_compression_stats(regclass)
  chunks_detailed_size(regclass)
- compress_chunk(regclass,boolean)
+ compress_chunk(regclass,boolean,boolean)
  create_hypertable(regclass,_timescaledb_internal.dimension_info,boolean,boolean,boolean)
  create_hypertable(regclass,name,name,integer,name,name,anyelement,boolean,boolean,regproc,boolean,text,regproc,regproc)
  decompress_chunk(regclass,boolean)

--- a/tsl/test/shared/sql/compat.sql
+++ b/tsl/test/shared/sql/compat.sql
@@ -83,6 +83,7 @@ CALL _timescaledb_internal.policy_recompression(0,NULL);
 CALL _timescaledb_internal.policy_refresh_continuous_aggregate(0,NULL);
 CALL _timescaledb_internal.policy_reorder(0,NULL);
 CALL _timescaledb_internal.policy_retention(0,NULL);
+CALL public.recompress_chunk(0);
 \set ON_ERROR_STOP 1
 
 -- tests for the cagg invalidation trigger on the deprecated schema

--- a/tsl/test/sql/compression_ddl.sql
+++ b/tsl/test/sql/compression_ddl.sql
@@ -634,7 +634,7 @@ SELECT device_id, count(*)
 FROM compression_insert
 GROUP BY device_id
 ORDER BY device_id;
-CALL recompress_chunk(:'CHUNK_NAME'::regclass);
+SELECT compress_chunk(:'CHUNK_NAME'::regclass);
 SELECT count(*), sum(v0), sum(v1), sum(v2), sum(v3)
 FROM compression_insert
 WHERE time >= '2000-01-01 0:00:00+0'
@@ -675,7 +675,7 @@ SELECT device_id, count(*)
 FROM compression_insert
 GROUP BY device_id
 ORDER BY device_id;
-CALL recompress_chunk(:'CHUNK_NAME'::regclass);
+SELECT compress_chunk(:'CHUNK_NAME'::regclass);
 SELECT count(*), sum(v0), sum(v1), sum(v2), sum(v3)
 FROM compression_insert
 WHERE time >= '2000-01-07 0:00:00+0'
@@ -715,7 +715,7 @@ SELECT device_id, count(*)
 FROM compression_insert
 GROUP BY device_id
 ORDER BY device_id;
-CALL recompress_chunk(:'CHUNK_NAME'::regclass);
+SELECT compress_chunk(:'CHUNK_NAME'::regclass);
 SELECT count(*), sum(v0), sum(v1), sum(v2), sum(v3)
 FROM compression_insert
 WHERE time >= '2000-01-15 0:00:00+0'
@@ -756,7 +756,7 @@ SELECT device_id, count(*)
 FROM compression_insert
 GROUP BY device_id
 ORDER BY device_id;
-CALL recompress_chunk(:'CHUNK_NAME'::regclass);
+SELECT compress_chunk(:'CHUNK_NAME'::regclass);
 SELECT count(*), sum(v0), sum(v1), sum(v2), sum(v3)
 FROM compression_insert
 WHERE time >= '2000-01-22 0:00:00+0'
@@ -795,7 +795,7 @@ SELECT device_id, count(*)
 FROM compression_insert
 GROUP BY device_id
 ORDER BY device_id;
-CALL recompress_chunk(:'CHUNK_NAME'::regclass);
+SELECT compress_chunk(:'CHUNK_NAME'::regclass);
 SELECT count(*), sum(v0), sum(v1), sum(v2), sum(v3)
 FROM compression_insert
 WHERE time >= '2000-01-28 0:00:00+0'

--- a/tsl/test/sql/compression_merge.sql
+++ b/tsl/test/sql/compression_merge.sql
@@ -112,8 +112,13 @@ SELECT
 
 SELECT compress_chunk(i) FROM show_chunks('test5') i LIMIT 4;
 
+SELECT format('%I.%I',ch.schema_name,ch.table_name) AS "CHUNK"
+  FROM _timescaledb_catalog.chunk ch
+  JOIN _timescaledb_catalog.hypertable ht ON ht.id=ch.hypertable_id
+  JOIN _timescaledb_catalog.hypertable ht2 ON ht.id=ht2.compressed_hypertable_id AND ht2.table_name='test5' \gset
+
 -- Make sure sequence numbers are correctly fetched from index.
-SELECT _ts_meta_sequence_num FROM _timescaledb_internal.compress_hyper_10_187_chunk where i = 1;
+SELECT _ts_meta_sequence_num FROM :CHUNK  where i = 1;
 
 SELECT schemaname || '.' || indexname AS "INDEXNAME"
 FROM pg_indexes i
@@ -129,7 +134,7 @@ DROP INDEX :INDEXNAME;
 SELECT compress_chunk(i, true) FROM show_chunks('test5') i LIMIT 5;
 
 -- Make sure sequence numbers are correctly fetched from heap.
-SELECT _ts_meta_sequence_num FROM _timescaledb_internal.compress_hyper_10_187_chunk where i = 1;
+SELECT _ts_meta_sequence_num FROM :CHUNK where i = 1;
 
 SELECT 'test5' AS "HYPERTABLE_NAME" \gset
 \ir include/compression_test_merge.sql

--- a/tsl/test/sql/compression_update_delete.sql
+++ b/tsl/test/sql/compression_update_delete.sql
@@ -95,8 +95,8 @@ FROM compressed_chunk_info_view
 WHERE hypertable_name = 'sample_table' ORDER BY chunk_name;
 
 -- recompress the partial chunks
-CALL recompress_chunk('_timescaledb_internal._hyper_1_1_chunk');
-CALL recompress_chunk('_timescaledb_internal._hyper_1_2_chunk');
+SELECT compress_chunk('_timescaledb_internal._hyper_1_1_chunk');
+SELECT compress_chunk('_timescaledb_internal._hyper_1_2_chunk');
 
 -- check chunk compression status
 SELECT chunk_status,
@@ -118,8 +118,8 @@ FROM compressed_chunk_info_view
 WHERE hypertable_name = 'sample_table' ORDER BY chunk_name;
 
 -- recompress the paritial chunks
-CALL recompress_chunk('_timescaledb_internal._hyper_1_1_chunk');
-CALL recompress_chunk('_timescaledb_internal._hyper_1_2_chunk');
+SELECT compress_chunk('_timescaledb_internal._hyper_1_1_chunk');
+SELECT compress_chunk('_timescaledb_internal._hyper_1_2_chunk');
 
 -- test for IS NULL checks
 -- should not UPDATE any rows
@@ -142,8 +142,8 @@ FROM compressed_chunk_info_view
 WHERE hypertable_name = 'sample_table' ORDER BY chunk_name;
 
 -- recompress the paritial chunks
-CALL recompress_chunk('_timescaledb_internal._hyper_1_1_chunk');
-CALL recompress_chunk('_timescaledb_internal._hyper_1_2_chunk');
+SELECT compress_chunk('_timescaledb_internal._hyper_1_1_chunk');
+SELECT compress_chunk('_timescaledb_internal._hyper_1_2_chunk');
 
 -- check chunk compression status
 SELECT chunk_status,

--- a/tsl/test/sql/decompress_vector_qual.sql
+++ b/tsl/test/sql/decompress_vector_qual.sql
@@ -410,7 +410,7 @@ select sum(length(a)) from text_table;
 select count(distinct a) from text_table;
 
 select count(compress_chunk(x, true)) from show_chunks('text_table') x;
-select format('call recompress_chunk(''%s'')', x) from show_chunks('text_table') x \gexec
+select compress_chunk(x) from show_chunks('text_table') x;
 
 set timescaledb.enable_bulk_decompression to on;
 set timescaledb.debug_require_vector_qual to 'forbid';

--- a/tsl/test/sql/include/compression_alter.sql
+++ b/tsl/test/sql/include/compression_alter.sql
@@ -133,7 +133,7 @@ SELECT * FROM test_defaults ORDER BY 1,2;
 -- try insert into compressed and recompress
 INSERT INTO test_defaults SELECT '2000-01-01', 2;
 SELECT * FROM test_defaults ORDER BY 1,2;
-CALL recompress_all_chunks('test_defaults', 1, false);
+SELECT compress_chunk(ch) FROM show_chunks('test_defaults') ch LIMIT 1;
 SELECT * FROM test_defaults ORDER BY 1,2;
 
 -- timescale/timescaledb#5412

--- a/tsl/test/sql/include/compression_utils.sql
+++ b/tsl/test/sql/include/compression_utils.sql
@@ -104,36 +104,4 @@ CREATE AGGREGATE _timescaledb_internal.compress_array(ANYELEMENT) (
     FINALFUNC = _timescaledb_internal.array_compressor_finish
 );
 
--- Helper functions to recompress all chunks of a hypertable
--- Parameters:
---   hypertable: The hypertable to recompress all chunks on
---   lim: number of chunks to compress
---   if_not_compressed: notice instead of error if chunk already compressed
-CREATE OR REPLACE PROCEDURE recompress_all_chunks(
-    hypertable REGCLASS,
-    lim INT,
-    if_not_compressed BOOLEAN
-) AS $$
-DECLARE
-  chunk regclass;
-BEGIN
-  FOR chunk IN SELECT show_chunks(hypertable) ORDER BY 1 LIMIT lim
-  LOOP
-    CALL public.recompress_chunk(chunk, if_not_compressed);
-  END LOOP;
-END $$ LANGUAGE plpgsql;
-
-CREATE OR REPLACE PROCEDURE recompress_all_chunks(
-    hypertable REGCLASS,
-    if_not_compressed BOOLEAN
-) AS $$
-DECLARE
-  chunk regclass;
-BEGIN
-  FOR chunk IN SELECT show_chunks(hypertable) ORDER BY 1
-  LOOP
-    CALL public.recompress_chunk(chunk, if_not_compressed);
-  END LOOP;
-END $$ LANGUAGE plpgsql;
-
 \set ECHO all

--- a/tsl/test/sql/include/recompress_basic.sql
+++ b/tsl/test/sql/include/recompress_basic.sql
@@ -55,15 +55,7 @@ WHERE hypertable_name = 'test2' \gset
 
 SELECT count(*) from test2;
 
--- call recompress_chunk inside a transaction. This should fails since
--- it contains transaction-terminating commands.
-\set ON_ERROR_STOP 0
-START TRANSACTION;
-CALL recompress_chunk(:'CHUNK_NAME'::regclass);
-ROLLBACK;
-\set ON_ERROR_STOP 1
-
-CALL recompress_chunk(:'CHUNK_NAME'::regclass);
+SELECT compress_chunk(:'CHUNK_NAME'::regclass);
 
 -- Demonstrate that no locks are held on the hypertable, chunk, or the
 -- compressed chunk after recompress_chunk has executed.
@@ -111,15 +103,15 @@ FROM compressed_chunk_info_view
 WHERE hypertable_name = 'test2' ORDER BY chunk_name;
 
 \set ON_ERROR_STOP 0
--- call recompress_chunk when status is not unordered
-CALL recompress_chunk(:'CHUNK_NAME'::regclass, true);
+-- call compress_chunk when status is not unordered
+SELECT compress_chunk(:'CHUNK_NAME'::regclass);
 
 -- This will succeed and compress the chunk for the test below.
-CALL recompress_chunk(:'CHUNK_NAME'::regclass, false);
+SELECT compress_chunk(:'CHUNK_NAME'::regclass);
 
 --now decompress it , then try and recompress
 SELECT decompress_chunk(:'CHUNK_NAME'::regclass);
-CALL recompress_chunk(:'CHUNK_NAME'::regclass);
+SELECT compress_chunk(:'CHUNK_NAME'::regclass);
 \set ON_ERROR_STOP 1
 
 -- test recompress policy

--- a/tsl/test/sql/recompress_chunk_segmentwise.sql
+++ b/tsl/test/sql/recompress_chunk_segmentwise.sql
@@ -160,7 +160,7 @@ SELECT * FROM test_defaults ORDER BY 1,2;
 INSERT INTO test_defaults SELECT '2000-01-01', 2;
 SELECT * FROM test_defaults ORDER BY 1,2;
 
-call recompress_chunk(:'compressed_chunk');
+SELECT compress_chunk(:'compressed_chunk');
 SELECT * FROM test_defaults ORDER BY 1,2;
 -- here we will have an additional compressed row after recompression because the new
 -- data corresponds to a new segment
@@ -187,7 +187,7 @@ EXPLAIN (COSTS OFF) EXECUTE p1;
 EXECUTE p1;
 
 -- check plan again after recompression
-CALL recompress_chunk(:'chunk_to_compress_prep');
+SELECT compress_chunk(:'chunk_to_compress_prep');
 EXPLAIN (COSTS OFF) EXECUTE p1;
 EXECUTE p1;
 
@@ -207,7 +207,7 @@ select compress_chunk(show_chunks('mytab'));
 select compressed_chunk_name as compressed_chunk_name_before_recompression from compressed_chunk_info_view where hypertable_name = 'mytab' \gset
 INSERT INTO mytab VALUES ('2023-01-01'::timestamptz, 2, 3, 2);
 -- segmentwise recompression should not create a new compressed chunk, so verify compressed chunk is the same after recompression
-call recompress_chunk(:'chunk_to_compress_mytab');
+SELECT compress_chunk(:'chunk_to_compress_mytab');
 select compressed_chunk_name as compressed_chunk_name_after_recompression from compressed_chunk_info_view where hypertable_name = 'mytab' \gset
 select :'compressed_chunk_name_before_recompression' as before_segmentwise_recompression, :'compressed_chunk_name_after_recompression' as after_segmentwise_recompression;
 
@@ -216,7 +216,7 @@ SELECT t, a, 3, 2
 FROM generate_series('2023-01-01'::timestamptz, '2023-01-02'::timestamptz, '1 hour'::interval) t
 CROSS JOIN generate_series(1, 10, 1) a;
 -- recompress will insert newly inserted tuples into compressed chunk along with inserting into the compressed chunk index
-CALL recompress_chunk(:'chunk_to_compress_mytab');
+SELECT compress_chunk(:'chunk_to_compress_mytab');
 -- make sure we are hitting the index and that the index contains the tuples
 SET enable_seqscan TO off;
 EXPLAIN (COSTS OFF) SELECT count(*) FROM mytab where a = 2;
@@ -230,7 +230,7 @@ select compress_chunk(show_chunks('mytab'));
 select compressed_chunk_name as compressed_chunk_name_before_recompression from compressed_chunk_info_view where hypertable_name = 'mytab' \gset
 INSERT INTO mytab VALUES ('2023-01-01'::timestamptz, 2, 3, 2);
 -- expect to see a different compressed chunk after recompressing now as the operation is decompress + compress
-call recompress_chunk(:'chunk_to_compress_mytab');
+SELECT compress_chunk(:'chunk_to_compress_mytab');
 select compressed_chunk_name as compressed_chunk_name_after_recompression from compressed_chunk_info_view where hypertable_name = 'mytab' \gset
 select :'compressed_chunk_name_before_recompression' as before_recompression, :'compressed_chunk_name_after_recompression' as after_recompression;
 
@@ -250,12 +250,12 @@ insert into nullseg_one values (:'start_time', NULL, 4);
 select show_chunks as chunk_to_compress from show_chunks('nullseg_one') limit 1 \gset
 select compressed_chunk_schema || '.' || compressed_chunk_name as compressed_chunk_name from compressed_chunk_info_view where hypertable_name = 'nullseg_one' \gset
 
-call recompress_chunk(:'chunk_to_compress');
+SELECT compress_chunk(:'chunk_to_compress');
 
 select * from :compressed_chunk_name;
 -- insert again, check both index insertion works and NULL values properly handled
 insert into nullseg_one values (:'start_time', NULL, 4);
-call recompress_chunk(:'chunk_to_compress');
+SELECT compress_chunk(:'chunk_to_compress');
 select * from :compressed_chunk_name;
 
 -- test multiple NULL segmentby columns
@@ -273,11 +273,11 @@ insert into nullseg_many values (:'start_time', 1, 4, NULL);
 select show_chunks as chunk_to_compress from show_chunks('nullseg_many') limit 1 \gset
 select compressed_chunk_schema || '.' || compressed_chunk_name as compressed_chunk_name from compressed_chunk_info_view where hypertable_name = 'nullseg_many' \gset
 
-call recompress_chunk(:'chunk_to_compress');
+SELECT compress_chunk(:'chunk_to_compress');
 
 select * from :compressed_chunk_name;
 -- insert again, check both index insertion works and NULL values properly handled
 -- should match existing segment (1, NULL)
 insert into nullseg_many values (:'start_time', 1, NULL, NULL);
-call recompress_chunk(:'chunk_to_compress');
+SELECT compress_chunk(:'chunk_to_compress');
 select * from :compressed_chunk_name;


### PR DESCRIPTION
This patch deprecates the recompress_chunk procedure as all that
functionality is covered by compress_chunk now. This patch also adds a
new optional boolean argument to compress_chunk to force applying
changed compression settings to existing compressed chunks.