### PR TITLE
Ensure qsort comparison function is transitive

### DIFF
--- a/.unreleased/fix_6610
+++ b/.unreleased/fix_6610
@@ -1,0 +1,1 @@
+Fixes: #6610 Ensure qsort comparison function is transitive

--- a/src/planner/expand_hypertable.c
+++ b/src/planner/expand_hypertable.c
@@ -858,7 +858,14 @@ collect_quals_walker(Node *node, CollectQualCtx *ctx)
 static int
 chunk_cmp_chunk_reloid(const void *c1, const void *c2)
 {
-	return (*(Chunk **) c1)->table_id - (*(Chunk **) c2)->table_id;
+	Oid lhs = (*(Chunk **) c1)->table_id;
+	Oid rhs = (*(Chunk **) c2)->table_id;
+
+	if (lhs < rhs)
+		return -1;
+	if (lhs > rhs)
+		return 1;
+	return 0;
 }
 
 static Chunk **

--- a/src/process_utility.c
+++ b/src/process_utility.c
@@ -2819,10 +2819,14 @@ process_index_start(ProcessUtilityArgs *args)
 static int
 chunk_index_mappings_cmp(const void *p1, const void *p2)
 {
-	const ChunkIndexMapping *mapping[] = { *((ChunkIndexMapping *const *) p1),
-										   *((ChunkIndexMapping *const *) p2) };
+	const ChunkIndexMapping *lhs = *((ChunkIndexMapping *const *) p1);
+	const ChunkIndexMapping *rhs = *((ChunkIndexMapping *const *) p2);
 
-	return mapping[0]->chunkoid - mapping[1]->chunkoid;
+	if (lhs->chunkoid < rhs->chunkoid)
+		return -1;
+	if (lhs->chunkoid > rhs->chunkoid)
+		return 1;
+	return 0;
 }
 
 /*


### PR DESCRIPTION
If the comparison function for qsort is non-transitive, there is a risk of out-of-bounds access. Subtraction of integers can lead to overflows, so instead use a real comparison function.