### PR TITLE
Don't disable downgrade test on PG16

### DIFF
--- a/.github/workflows/apt-packages.yaml
+++ b/.github/workflows/apt-packages.yaml
@@ -82,8 +82,6 @@ jobs:
         fi
 
     - name: Test Downgrade
-      # TSB 2.13.0 is the first version with PG 16 support, so no downgrades are supported at the moment
-      if: matrix.pg != '16'
       run: |
         # Since this runs nightly on main we have to get the previous version
         # from the last released version and not current branch.

--- a/.github/workflows/rpm-packages.yaml
+++ b/.github/workflows/rpm-packages.yaml
@@ -105,8 +105,6 @@ jobs:
         fi
 
     - name: Test Downgrade
-      # TSB 2.13.0 is the first version with PG 16 support, so no downgrades are supported at the moment
-      if: matrix.pg != '16'
       run: |
         # Since this runs nightly on main we have to get the previous version
         # from the last released version and not current branch.


### PR DESCRIPTION
Since we now have multiple versions packaged for PG16 we can enable the downgrade test in our apt and rpm package test.