### PR TITLE
Use data inheritance from VirtualTupleTableSlot in compressed batch

### DIFF
--- a/tsl/src/nodes/decompress_chunk/batch_array.c
+++ b/tsl/src/nodes/decompress_chunk/batch_array.c
@@ -35,13 +35,7 @@ batch_array_destroy(BatchArray *array)
 	for (int i = 0; i < array->n_batch_states; i++)
 	{
 		DecompressBatchState *batch_state = batch_array_get_at(array, i);
-		Assert(batch_state != NULL);
-
-		if (batch_state->compressed_slot != NULL)
-			ExecDropSingleTupleTableSlot(batch_state->compressed_slot);
-
-		if (batch_state->decompressed_scan_slot != NULL)
-			ExecDropSingleTupleTableSlot(batch_state->decompressed_scan_slot);
+		compressed_batch_destroy(batch_state);
 	}
 
 	pfree(array->batch_states);
@@ -86,16 +80,7 @@ batch_array_clear_at(BatchArray *array, int batch_index)
 	DecompressBatchState *batch_state = batch_array_get_at(array, batch_index);
 
 	/* Reset batch state */
-	batch_state->total_batch_rows = 0;
-	batch_state->next_batch_row = 0;
-	batch_state->vector_qual_result = NULL;
-
-	if (batch_state->per_batch_context != NULL)
-	{
-		ExecClearTuple(batch_state->compressed_slot);
-		ExecClearTuple(batch_state->decompressed_scan_slot);
-		MemoryContextReset(batch_state->per_batch_context);
-	}
+	compressed_batch_discard_tuples(batch_state);
 
 	array->unused_batch_states = bms_add_member(array->unused_batch_states, batch_index);
 }
@@ -124,7 +109,8 @@ batch_array_get_unused_slot(BatchArray *array)
 
 	Assert(next_unused_batch >= 0);
 	Assert(next_unused_batch < array->n_batch_states);
-	Assert(TupIsNull(batch_array_get_at(array, next_unused_batch)->decompressed_scan_slot));
+
+	Assert(TupIsNull(compressed_batch_current_tuple(batch_array_get_at(array, next_unused_batch))));
 
 	array->unused_batch_states = bms_del_member(array->unused_batch_states, next_unused_batch);
 

--- a/tsl/src/nodes/decompress_chunk/batch_queue_fifo.h
+++ b/tsl/src/nodes/decompress_chunk/batch_queue_fifo.h
@@ -18,14 +18,14 @@ batch_queue_fifo_free(BatchQueue *bq)
 static inline bool
 batch_queue_fifo_needs_next_batch(BatchQueue *bq)
 {
-	return TupIsNull(batch_array_get_at(&bq->batch_array, 0)->decompressed_scan_slot);
+	return TupIsNull(compressed_batch_current_tuple(batch_array_get_at(&bq->batch_array, 0)));
 }
 
 static inline void
 batch_queue_fifo_pop(BatchQueue *bq, DecompressContext *dcontext)
 {
 	DecompressBatchState *batch_state = batch_array_get_at(&bq->batch_array, 0);
-	if (TupIsNull(batch_state->decompressed_scan_slot))
+	if (TupIsNull(compressed_batch_current_tuple(batch_state)))
 	{
 		/* Allow this function to be called on the initial empty queue. */
 		return;
@@ -40,7 +40,7 @@ batch_queue_fifo_push_batch(BatchQueue *bq, DecompressContext *dcontext,
 {
 	BatchArray *batch_array = &bq->batch_array;
 	DecompressBatchState *batch_state = batch_array_get_at(batch_array, 0);
-	Assert(TupIsNull(batch_array_get_at(batch_array, 0)->decompressed_scan_slot));
+	Assert(TupIsNull(compressed_batch_current_tuple(batch_array_get_at(batch_array, 0))));
 	compressed_batch_set_compressed_tuple(dcontext, batch_state, compressed_slot);
 	compressed_batch_advance(dcontext, batch_state);
 }
@@ -54,7 +54,7 @@ batch_queue_fifo_reset(BatchQueue *bq)
 static inline TupleTableSlot *
 batch_queue_fifo_top_tuple(BatchQueue *bq)
 {
-	return batch_array_get_at(&bq->batch_array, 0)->decompressed_scan_slot;
+	return compressed_batch_current_tuple(batch_array_get_at(&bq->batch_array, 0));
 }
 
 static const struct BatchQueueFunctions BatchQueueFunctionsFifo = {

--- a/tsl/src/nodes/decompress_chunk/batch_queue_heap.c
+++ b/tsl/src/nodes/decompress_chunk/batch_queue_heap.c
@@ -186,7 +186,8 @@ batch_queue_heap_pop(BatchQueue *bq, DecompressContext *dcontext)
 
 	compressed_batch_advance(dcontext, top_batch);
 
-	if (TupIsNull(top_batch->decompressed_scan_slot))
+	TupleTableSlot *top_tuple = compressed_batch_current_tuple(top_batch);
+	if (TupIsNull(top_tuple))
 	{
 		/* Batch is exhausted, recycle batch_state */
 		(void) binaryheap_remove_first(queue->merge_heap);
@@ -205,11 +206,11 @@ batch_queue_heap_pop(BatchQueue *bq, DecompressContext *dcontext)
 			/*
 			 * We're working with virtual tuple slots so no need for slot_getattr().
 			 */
-			Assert(TTS_IS_VIRTUAL(top_batch->decompressed_scan_slot));
+			Assert(TTS_IS_VIRTUAL(top_tuple));
 			queue->heap_entries[top_batch_index * queue->nkeys + key].value =
-				top_batch->decompressed_scan_slot->tts_values[attr];
+				top_tuple->tts_values[attr];
 			queue->heap_entries[top_batch_index * queue->nkeys + key].null =
-				top_batch->decompressed_scan_slot->tts_isnull[attr];
+				top_tuple->tts_isnull[attr];
 		}
 
 		/* Place this batch on the heap according to its new decompressed tuple. */
@@ -287,7 +288,8 @@ batch_queue_heap_push_batch(BatchQueue *_queue, DecompressContext *dcontext,
 			queue->last_batch_first_tuple_slot->tts_isnull[attr];
 	}
 
-	if (TupIsNull(batch_state->decompressed_scan_slot))
+	TupleTableSlot *current_tuple = compressed_batch_current_tuple(batch_state);
+	if (TupIsNull(current_tuple))
 	{
 		/* Might happen if there are no tuples in the batch that pass the quals. */
 		batch_array_clear_at(batch_array, new_batch_index);
@@ -305,11 +307,11 @@ batch_queue_heap_push_batch(BatchQueue *_queue, DecompressContext *dcontext,
 		/*
 		 * We're working with virtual tuple slots so no need for slot_getattr().
 		 */
-		Assert(TTS_IS_VIRTUAL(batch_state->decompressed_scan_slot));
+		Assert(TTS_IS_VIRTUAL(current_tuple));
 		queue->heap_entries[new_batch_index * queue->nkeys + key].value =
-			batch_state->decompressed_scan_slot->tts_values[attr];
+			current_tuple->tts_values[attr];
 		queue->heap_entries[new_batch_index * queue->nkeys + key].null =
-			batch_state->decompressed_scan_slot->tts_isnull[attr];
+			current_tuple->tts_isnull[attr];
 	}
 
 	/*
@@ -331,8 +333,9 @@ batch_queue_heap_top_tuple(BatchQueue *bq)
 
 	const int top_batch_index = DatumGetInt32(binaryheap_first(bqh->merge_heap));
 	DecompressBatchState *top_batch = batch_array_get_at(batch_array, top_batch_index);
-	Assert(!TupIsNull(top_batch->decompressed_scan_slot));
-	return top_batch->decompressed_scan_slot;
+	TupleTableSlot *top_tuple = compressed_batch_current_tuple(top_batch);
+	Assert(!TupIsNull(top_tuple));
+	return top_tuple;
 }
 
 static void

--- a/tsl/src/nodes/decompress_chunk/compressed_batch.c
+++ b/tsl/src/nodes/decompress_chunk/compressed_batch.c
@@ -101,8 +101,8 @@ decompress_column(DecompressContext *dcontext, DecompressBatchState *batch_state
 	CompressedColumnValues *column_values = &batch_state->compressed_columns[i];
 	column_values->arrow = NULL;
 	const AttrNumber attr = AttrNumberGetAttrOffset(column_description->output_attno);
-	column_values->output_value = &batch_state->decompressed_scan_slot->tts_values[attr];
-	column_values->output_isnull = &batch_state->decompressed_scan_slot->tts_isnull[attr];
+	column_values->output_value = &compressed_batch_current_tuple(batch_state)->tts_values[attr];
+	column_values->output_isnull = &compressed_batch_current_tuple(batch_state)->tts_isnull[attr];
 	const int value_bytes = get_typlen(column_description->typid);
 	Assert(value_bytes != 0);
 
@@ -119,10 +119,10 @@ decompress_column(DecompressContext *dcontext, DecompressBatchState *batch_state
 		 */
 		column_values->decompression_type = DT_Default;
 
-		batch_state->decompressed_scan_slot->tts_values[attr] =
-			getmissingattr(batch_state->decompressed_scan_slot->tts_tupleDescriptor,
+		*column_values->output_value =
+			getmissingattr(dcontext->decompressed_slot->tts_tupleDescriptor,
 						   column_description->output_attno,
-						   &batch_state->decompressed_scan_slot->tts_isnull[attr]);
+						   column_values->output_isnull);
 		return;
 	}
 
@@ -556,13 +556,102 @@ compute_vector_quals(DecompressContext *dcontext, DecompressBatchState *batch_st
 }
 
 /*
+ * Scrolls the compressed batch to the end, discarding any tuples left in it.
+ * This makes the batch ready to accept the next compressed tuple, but without
+ * de-initializing its expensive reusable parts such as memory context and tuple
+ * slots. This is used when vectorized quals don't pass for the entire batch,
+ * and also in batch array to free the batch state for reuse.
+ */
+void
+compressed_batch_discard_tuples(DecompressBatchState *batch_state)
+{
+	batch_state->next_batch_row = batch_state->total_batch_rows;
+	batch_state->vector_qual_result = NULL;
+
+	if (batch_state->per_batch_context != NULL)
+	{
+		ExecClearTuple(batch_state->compressed_slot);
+		ExecClearTuple(&batch_state->decompressed_scan_slot_data.base);
+		MemoryContextReset(batch_state->per_batch_context);
+	}
+	else
+	{
+		/*
+		 * Check that we have a valid zero-initialized batch here.
+		 */
+		Assert(IsA(&batch_state->decompressed_scan_slot_data, Invalid));
+		Assert(batch_state->decompressed_scan_slot_data.base.tts_ops == NULL);
+		Assert(batch_state->compressed_slot == NULL);
+	}
+}
+
+/*
+ * Initializes the zero-initialized batch state. We do this on demand, because
+ * it involves the creation of memory context and tuple slots, which are
+ * relatively expensive.
+ */
+static void
+compressed_batch_lazy_init(DecompressContext *dcontext, DecompressBatchState *batch_state,
+						   TupleTableSlot *compressed_slot)
+{
+	/* Init memory context */
+	batch_state->per_batch_context = create_per_batch_mctx(dcontext->batch_memory_context_bytes);
+	Assert(batch_state->per_batch_context != NULL);
+
+	Assert(batch_state->compressed_slot == NULL);
+
+	/* Create a non ref-counted copy of the compressed tuple descriptor */
+	if (dcontext->compressed_slot_tdesc == NULL)
+		dcontext->compressed_slot_tdesc =
+			CreateTupleDescCopyConstr(compressed_slot->tts_tupleDescriptor);
+	Assert(dcontext->compressed_slot_tdesc->tdrefcount == -1);
+
+	batch_state->compressed_slot =
+		MakeSingleTupleTableSlot(dcontext->compressed_slot_tdesc, compressed_slot->tts_ops);
+
+	/* Get a reference to the output TupleTableSlot */
+	TupleTableSlot *decompressed_slot = dcontext->decompressed_slot;
+
+	/*
+	 * This code follows Postgres' MakeTupleTableSlot().
+	 */
+	TupleTableSlot *slot = &batch_state->decompressed_scan_slot_data.base;
+	Assert(IsA(slot, Invalid));
+	Assert(slot->tts_ops == NULL);
+
+	slot->type = T_TupleTableSlot;
+	slot->tts_flags = TTS_FLAG_EMPTY | TTS_FLAG_FIXED;
+
+	/*
+	 * The decompressed slot and the respective tuple descriptor are owned by
+	 * DecompressContext and live throughout the entire decompression process,
+	 * so here we can reuse a plain pointer to the tuple descriptor without
+	 * additional reference counting.
+	 */
+	slot->tts_tupleDescriptor = decompressed_slot->tts_tupleDescriptor;
+
+	slot->tts_mcxt = CurrentMemoryContext;
+	slot->tts_nvalid = 0;
+	slot->tts_values = palloc(MAXALIGN(slot->tts_tupleDescriptor->natts * sizeof(Datum)) +
+							  MAXALIGN(slot->tts_tupleDescriptor->natts * sizeof(bool)));
+	slot->tts_isnull = (bool *) ((char *) slot->tts_values) +
+					   MAXALIGN(slot->tts_tupleDescriptor->natts * sizeof(Datum));
+
+	/*
+	 * DecompressChunk produces virtual tuple slots.
+	 */
+	*((const TupleTableSlotOps **) &slot->tts_ops) = &TTSOpsVirtual;
+	slot->tts_ops->init(slot);
+}
+
+/*
  * Initialize the batch decompression state with the new compressed  tuple.
  */
 void
 compressed_batch_set_compressed_tuple(DecompressContext *dcontext,
 									  DecompressBatchState *batch_state, TupleTableSlot *subslot)
 {
-	Assert(TupIsNull(batch_state->decompressed_scan_slot));
+	Assert(TupIsNull(compressed_batch_current_tuple(batch_state)));
 
 	/*
 	 * The batch states are initialized on demand, because creating the memory
@@ -570,47 +659,20 @@ compressed_batch_set_compressed_tuple(DecompressContext *dcontext,
 	 */
 	if (batch_state->per_batch_context == NULL)
 	{
-		/* Init memory context */
-		batch_state->per_batch_context =
-			create_per_batch_mctx(dcontext->batch_memory_context_bytes);
-		Assert(batch_state->per_batch_context != NULL);
-
-		Assert(batch_state->compressed_slot == NULL);
-
-		/* Create a non ref-counted copy of the tuple descriptor */
-		if (dcontext->compressed_slot_tdesc == NULL)
-			dcontext->compressed_slot_tdesc =
-				CreateTupleDescCopyConstr(subslot->tts_tupleDescriptor);
-		Assert(dcontext->compressed_slot_tdesc->tdrefcount == -1);
-
-		batch_state->compressed_slot =
-			MakeSingleTupleTableSlot(dcontext->compressed_slot_tdesc, subslot->tts_ops);
-
-		Assert(batch_state->decompressed_scan_slot == NULL);
-
-		/* Get a reference the the output TupleTableSlot */
-		TupleTableSlot *slot = dcontext->decompressed_slot;
-
-		/* Create a non ref-counted copy of the tuple descriptor */
-		if (dcontext->decompressed_slot_scan_tdesc == NULL)
-			dcontext->decompressed_slot_scan_tdesc =
-				CreateTupleDescCopyConstr(slot->tts_tupleDescriptor);
-		Assert(dcontext->decompressed_slot_scan_tdesc->tdrefcount == -1);
-
-		batch_state->decompressed_scan_slot =
-			MakeSingleTupleTableSlot(dcontext->decompressed_slot_scan_tdesc, slot->tts_ops);
+		compressed_batch_lazy_init(dcontext, batch_state, subslot);
 	}
 	else
 	{
 		Assert(batch_state->compressed_slot != NULL);
-		Assert(batch_state->decompressed_scan_slot != NULL);
 	}
 
 	/* Ensure that all fields are empty. Calling ExecClearTuple is not enough
 	 * because some attributes might not be populated (e.g., due to a dropped
 	 * column) and these attributes need to be set to null. */
-	ExecStoreAllNullTuple(batch_state->decompressed_scan_slot);
-	ExecClearTuple(batch_state->decompressed_scan_slot);
+	TupleTableSlot *decompressed_tuple = compressed_batch_current_tuple(batch_state);
+	Assert(decompressed_tuple != NULL);
+	ExecStoreAllNullTuple(decompressed_tuple);
+	ExecClearTuple(decompressed_tuple);
 
 	ExecCopySlot(batch_state->compressed_slot, subslot);
 	Assert(!TupIsNull(batch_state->compressed_slot));
@@ -648,10 +710,10 @@ compressed_batch_set_compressed_tuple(DecompressContext *dcontext,
 				 * save it once per batch, which we do here.
 				 */
 				AttrNumber attr = AttrNumberGetAttrOffset(column_description->output_attno);
-				batch_state->decompressed_scan_slot->tts_values[attr] =
+				decompressed_tuple->tts_values[attr] =
 					slot_getattr(batch_state->compressed_slot,
 								 column_description->compressed_scan_attno,
-								 &batch_state->decompressed_scan_slot->tts_isnull[attr]);
+								 &decompressed_tuple->tts_isnull[attr]);
 				break;
 			}
 			case COUNT_COLUMN:
@@ -700,7 +762,7 @@ compressed_batch_set_compressed_tuple(DecompressContext *dcontext,
 		 * columns. This can be improved by only decompressing the columns
 		 * needed for sorting.
 		 */
-		batch_state->next_batch_row = batch_state->total_batch_rows;
+		compressed_batch_discard_tuples(batch_state);
 
 		InstrCountTuples2(dcontext->ps, 1);
 		InstrCountFiltered1(dcontext->ps, batch_state->total_batch_rows);
@@ -757,8 +819,7 @@ store_text_datum(CompressedColumnValues *column_values, int arrow_row)
 static void
 make_next_tuple(DecompressBatchState *batch_state, uint16 arrow_row, int num_compressed_columns)
 {
-	TupleTableSlot *decompressed_scan_slot = batch_state->decompressed_scan_slot;
-	Assert(decompressed_scan_slot != NULL);
+	TupleTableSlot *decompressed_scan_slot = &batch_state->decompressed_scan_slot_data.base;
 
 	Assert(batch_state->total_batch_rows > 0);
 	Assert(batch_state->next_batch_row < batch_state->total_batch_rows);
@@ -863,7 +924,8 @@ vector_qual(DecompressBatchState *batch_state, uint16 arrow_row)
 static bool
 postgres_qual(DecompressContext *dcontext, DecompressBatchState *batch_state)
 {
-	TupleTableSlot *decompressed_scan_slot = batch_state->decompressed_scan_slot;
+	TupleTableSlot *decompressed_scan_slot = &batch_state->decompressed_scan_slot_data.base;
+	Assert(IsA(decompressed_scan_slot, TupleTableSlot));
 	Assert(!TupIsNull(decompressed_scan_slot));
 
 	if (dcontext->ps == NULL || dcontext->ps->qual == NULL)
@@ -888,8 +950,7 @@ compressed_batch_advance(DecompressContext *dcontext, DecompressBatchState *batc
 {
 	Assert(batch_state->total_batch_rows > 0);
 
-	TupleTableSlot *decompressed_scan_slot = batch_state->decompressed_scan_slot;
-	Assert(decompressed_scan_slot != NULL);
+	TupleTableSlot *decompressed_scan_slot = &batch_state->decompressed_scan_slot_data.base;
 
 	const bool reverse = dcontext->reverse;
 	const int num_compressed_columns = dcontext->num_compressed_columns;
@@ -973,7 +1034,7 @@ compressed_batch_save_first_tuple(DecompressContext *dcontext, DecompressBatchSt
 {
 	Assert(batch_state->next_batch_row == 0);
 	Assert(batch_state->total_batch_rows > 0);
-	Assert(TupIsNull(batch_state->decompressed_scan_slot));
+	Assert(TupIsNull(compressed_batch_current_tuple(batch_state)));
 
 	/*
 	 * Check that we have decompressed all columns even if the vector quals
@@ -994,7 +1055,7 @@ compressed_batch_save_first_tuple(DecompressContext *dcontext, DecompressBatchSt
 	Assert(batch_state->next_batch_row == 0);
 	const uint16 arrow_row = dcontext->reverse ? batch_state->total_batch_rows - 1 : 0;
 	make_next_tuple(batch_state, arrow_row, dcontext->num_compressed_columns);
-	ExecCopySlot(first_tuple_slot, batch_state->decompressed_scan_slot);
+	ExecCopySlot(first_tuple_slot, &batch_state->decompressed_scan_slot_data.base);
 
 	/*
 	 * Check the quals and advance, so that the batch is in the correct state
@@ -1008,5 +1069,36 @@ compressed_batch_save_first_tuple(DecompressContext *dcontext, DecompressBatchSt
 	{
 		InstrCountFiltered1(dcontext->ps, 1);
 		compressed_batch_advance(dcontext, batch_state);
+	}
+}
+
+/*
+ * Frees all resources used by the compressed batch.
+ *
+ * If the batch is intended to be reused, use compressed_batch_discard_tuples()
+ * instead.
+ */
+void
+compressed_batch_destroy(DecompressBatchState *batch_state)
+{
+	Assert(batch_state != NULL);
+
+	if (batch_state->per_batch_context != NULL)
+	{
+		MemoryContextDelete(batch_state->per_batch_context);
+		batch_state->per_batch_context = NULL;
+	}
+
+	if (batch_state->compressed_slot != NULL)
+	{
+		/*
+		 * Can be separately NULL in the current simplified prototype for
+		 * vectorized aggregation, but ideally it should change together with
+		 * per-batch context.
+		 */
+		ExecDropSingleTupleTableSlot(batch_state->compressed_slot);
+		batch_state->compressed_slot = NULL;
+
+		pfree(batch_state->decompressed_scan_slot_data.base.tts_values);
 	}
 }

--- a/tsl/src/nodes/decompress_chunk/compressed_batch.h
+++ b/tsl/src/nodes/decompress_chunk/compressed_batch.h
@@ -56,7 +56,32 @@ typedef struct CompressedColumnValues
  */
 typedef struct DecompressBatchState
 {
-	TupleTableSlot *decompressed_scan_slot; /* A slot for the decompressed data */
+	/*
+	 * The slot for the decompressed tuple.
+	 *
+	 * We embed it into the batch state as the first member (data inheritance),
+	 * so that it's easier to pass out to parent nodes, while following the usual
+	 * Postgres interface of passing the tuple table slots.
+	 * We use &batch_state->decompressed_scan_slot_data.base everywhere where we
+	 * need the TupleTableSlot*, and some parent nodes can cast this pointer to
+	 * DecompressBatchState* to use our custom interfaces.
+	 *
+	 * The slot itself follows the TTSVirtualOps tuple slot protocol, because Postgres
+	 * expression executor has special fast path for virtual tuples, and we don't
+	 * really need the custom tuple slot protocol for anything. One potential use
+	 * case for it would be late decompression by implementing custom slot_getattr().
+	 * It was actually implemented and didn't show any benefits in the preliminary
+	 * testing, compared to what we already achieve with lazy decompression after
+	 * vectorized filters. One reason is that the Postgres expression compiler
+	 * can be eager in requesting materialization. For example, it would call
+	 * slot_getattr up to the last attribute used by every filter in a qualifier,
+	 * before running any qualifiers. This might be possible to configure, but
+	 * the area needs more research.
+	 *
+	 * See the PR #6628 for context.
+	 */
+	VirtualTupleTableSlot decompressed_scan_slot_data;
+
 	/*
 	 * Compressed target slot. We have to keep a local copy when doing batch
 	 * sorted merge, because the segmentby column values might reference the
@@ -91,7 +116,7 @@ extern void compressed_batch_save_first_tuple(DecompressContext *dcontext,
 
 #define create_bulk_decompression_mctx(parent_mctx)                                                \
 	AllocSetContextCreate(parent_mctx,                                                             \
-						  "Bulk decompression",                                                    \
+						  "DecompressBatchState bulk decompression",                               \
 						  /* minContextSize = */ 0,                                                \
 						  /* initBlockSize = */ 64 * 1024,                                         \
 						  /* maxBlockSize = */ 64 * 1024);
@@ -106,7 +131,33 @@ extern void compressed_batch_save_first_tuple(DecompressContext *dcontext,
  */
 #define create_per_batch_mctx(block_size_bytes)                                                    \
 	AllocSetContextCreate(CurrentMemoryContext,                                                    \
-						  "Per-batch decompression",                                               \
+						  "DecompressBatchState per-batch",                                        \
 						  0,                                                                       \
 						  block_size_bytes,                                                        \
 						  block_size_bytes);
+
+extern void compressed_batch_destroy(DecompressBatchState *batch_state);
+
+extern void compressed_batch_discard_tuples(DecompressBatchState *batch_state);
+
+/*
+ * Returns the current decompressed tuple in the compressed batch.
+ */
+inline static TupleTableSlot *
+compressed_batch_current_tuple(DecompressBatchState *batch_state)
+{
+	if (IsA(&batch_state->decompressed_scan_slot_data, Invalid))
+	{
+		/*
+		 * For convenience, we want a zero-initialized batch to be a valid
+		 * "empty" state, but unfortunately a zero-initialized TupleTableSlotData
+		 * is not a valid tuple slot, so here we have to work around this mismatch.
+		 */
+		Assert(batch_state->decompressed_scan_slot_data.base.tts_ops == NULL);
+		Assert(batch_state->per_batch_context == NULL);
+		return NULL;
+	}
+
+	Assert(batch_state->per_batch_context != NULL);
+	return &batch_state->decompressed_scan_slot_data.base;
+}

--- a/tsl/src/nodes/decompress_chunk/decompress_context.h
+++ b/tsl/src/nodes/decompress_chunk/decompress_context.h
@@ -63,6 +63,7 @@ typedef struct DecompressContext
 	MemoryContext bulk_decompression_context;
 
 	TupleTableSlot *decompressed_slot;
+
 	/*
 	 * Make non-refcounted copies of the tupdesc for reuse across all batch states
 	 * and avoid spending CPU in ResourceOwner when creating a big number of table
@@ -70,8 +71,12 @@ typedef struct DecompressContext
 	 * PinTupleDesc, and for reference-counting tuples this involves adding a new
 	 * reference to ResourceOwner, which is not very efficient for a large number of
 	 * references.
+	 *
+	 * We don't have to do this for the decompressed slot tuple descriptor,
+	 * because there we use custom tuple slot (de)initialization functions, which
+	 * don't use reference counting and just use a raw pointer to the tuple
+	 * descriptor.
 	 */
-	TupleDesc decompressed_slot_scan_tdesc;
 	TupleDesc compressed_slot_tdesc;
 
 	PlanState *ps; /* Set for filtering and instrumentation */


### PR DESCRIPTION
This simplifies passing the columnar data out of the DecompressChunk to Vectorized Aggregation node which we plan to implement. Also this should improve memory locality and bring us closer to the architecture used in TAM for ArrowTupleSlot.


Disable-check: force-changelog-file