### PR TITLE
Separate the scan targetlist from result targetlist in DecompressChunk

### DIFF
--- a/tsl/src/nodes/decompress_chunk/compressed_batch.c
+++ b/tsl/src/nodes/decompress_chunk/compressed_batch.c
@@ -122,7 +122,7 @@ decompress_column(DecompressContext *dcontext, DecompressBatchState *batch_state
 
 		batch_state->decompressed_scan_slot->tts_values[column_description->scan_column_index] =
 			getmissingattr(dcontext->uncompressed_chunk_tupdesc,
-						   column_description->uncompressed_chunk_attno, // fixme
+						   column_description->uncompressed_chunk_attno,
 						   &batch_state->decompressed_scan_slot
 								->tts_isnull[column_description->scan_column_index]);
 		return;
@@ -294,8 +294,13 @@ compute_plain_qual(DecompressContext *dcontext, DecompressBatchState *batch_stat
 	for (; column_index < dcontext->num_total_columns; column_index++)
 	{
 		column_description = &dcontext->template_columns[column_index];
-		// if (column_description->uncompressed_chunk_attno == var->varattno)
-		if (column_description->scan_column_index + 1 == var->varattno)
+//		fprintf(stderr, "column %d type %d scan index %d ucattno %d\n",
+//			column_index,
+//			column_description->type,
+//			column_description->scan_column_index,
+//			column_description->uncompressed_chunk_attno);
+		if (column_description->uncompressed_chunk_attno == var->varattno)
+		// if (column_description->scan_column_index + 1 == var->varattno)
 		{
 			break;
 		}

--- a/tsl/src/nodes/decompress_chunk/decompress_chunk.h
+++ b/tsl/src/nodes/decompress_chunk/decompress_chunk.h
@@ -49,6 +49,7 @@ typedef struct CompressionInfo
 typedef struct ColumnCompressionInfo
 {
 	bool bulk_decompression_possible;
+	int scan_targetlist_index;
 } DecompressChunkColumnCompression;
 
 typedef struct DecompressChunkPath

--- a/tsl/src/nodes/decompress_chunk/decompress_context.h
+++ b/tsl/src/nodes/decompress_chunk/decompress_context.h
@@ -30,12 +30,14 @@ typedef struct CompressionColumnDescription
 	int value_bytes;
 
 	/*
-	 * Attno of the decompressed column in the output of DecompressChunk node.
+	 * Index of the decompressed column in the scan targetlist of DecompressChunk node.
 	 * Negative values are special columns that do not have a representation in
 	 * the decompressed chunk, but are still used for decompression. They should
 	 * have the respective `type` field.
 	 */
-	AttrNumber output_attno;
+	int scan_column_index;
+
+	AttrNumber uncompressed_chunk_attno;
 
 	/*
 	 * Attno of the compressed column in the input compressed chunk scan.
@@ -73,6 +75,8 @@ typedef struct DecompressContext
 	 */
 	TupleDesc decompressed_slot_scan_tdesc;
 	TupleDesc compressed_slot_tdesc;
+
+	TupleDesc uncompressed_chunk_tupdesc;
 
 	PlanState *ps; /* Set for filtering and instrumentation */
 

--- a/tsl/src/nodes/decompress_chunk/exec.c
+++ b/tsl/src/nodes/decompress_chunk/exec.c
@@ -182,13 +182,44 @@ decompress_chunk_exec_heap(CustomScanState *node)
 static void
 decompress_chunk_begin(CustomScanState *node, EState *estate, int eflags)
 {
+	ListCell *lc;
 	DecompressChunkState *chunk_state = (DecompressChunkState *) node;
 	DecompressContext *dcontext = &chunk_state->decompress_context;
 	CustomScan *cscan = castNode(CustomScan, node->ss.ps.plan);
 	Plan *compressed_scan = linitial(cscan->custom_plans);
 	Assert(list_length(cscan->custom_plans) == 1);
 
+//	/*
+//	 * Have to rebuild scan tupdesc and projection after removing the whole-row
+//	 * variable.
+//	 */
+//	ListCell *lc;
+//	foreach(lc, cscan->custom_scan_tlist)
+//	{
+//		TargetEntry *te = castNode(TargetEntry, lfirst(lc));
+//		if (!IsA(te->expr, Var))
+//		{
+//			continue;
+//		}
+//
+//		Var *var = castNode(Var, te->expr);
+//
+//		if (var->varattno == InvalidAttrNumber)
+//		{
+//			cscan->custom_scan_tlist = list_delete_cell(cscan->custom_scan_tlist, lc);
+//			break;
+//		}
+//	}
+//	TupleDesc scan_tupdesc = ExecTypeFromTL(cscan->custom_scan_tlist);
+//	ExecInitScanTupleSlot(estate, &node->ss, scan_tupdesc, &TTSOpsVirtual);
+
 	PlanState *ps = &node->ss.ps;
+//	fprintf(stderr, "planstate targetlist is:\n");
+//	my_print(ps->plan->targetlist);
+//	fprintf(stderr, "scan tdesc is:\n");
+//	my_print_tdesc(node->ss.ss_ScanTupleSlot->tts_tupleDescriptor);
+//	fprintf(stderr, "result tdesc is:\n");
+//	my_print_tdesc(ps->ps_ResultTupleSlot->tts_tupleDescriptor);
 	if (ps->ps_ProjInfo)
 	{
 		/*
@@ -277,7 +308,7 @@ decompress_chunk_begin(CustomScanState *node, EState *estate, int eflags)
 	for (int compressed_index = 0; compressed_index < list_length(chunk_state->decompression_map);
 		 compressed_index++)
 	{
-		const AttrNumber scan_attno =
+		const AttrNumber uncompressed_scan_attno =
 			list_nth_int(chunk_state->decompression_map, compressed_index);
 
 		CompressionColumnDescription column = {
@@ -288,15 +319,15 @@ decompress_chunk_begin(CustomScanState *node, EState *estate, int eflags)
 				list_nth_int(chunk_state->bulk_decompression_column, compressed_index)
 		};
 
-		if (scan_attno == 0)
+		if (uncompressed_scan_attno == 0)
 		{
 			/* We are asked not to decompress this column, skip it. */
 			continue;
 		}
 
-		if (scan_attno > 0)
+		if (uncompressed_scan_attno > 0)
 		{
-			column.scan_column_index = AttrNumberGetAttrOffset(scan_attno);
+			column.scan_column_index = AttrNumberGetAttrOffset(uncompressed_scan_attno);
 			if (chunk_state->custom_scan_tlist)
 			{
 				const TargetEntry *tentry =
@@ -306,7 +337,7 @@ decompress_chunk_begin(CustomScanState *node, EState *estate, int eflags)
 			else
 			{
 				/* I have no idea what I'm doing lol */
-				column.uncompressed_chunk_attno = scan_attno;
+				column.uncompressed_chunk_attno = uncompressed_scan_attno;
 			}
 
 			if (chunk_state->perform_vectorized_aggregation &&
@@ -334,7 +365,7 @@ decompress_chunk_begin(CustomScanState *node, EState *estate, int eflags)
 		else
 		{
 			/* metadata columns */
-			switch (scan_attno)
+			switch (uncompressed_scan_attno)
 			{
 				case DECOMPRESS_CHUNK_COUNT_ID:
 					column.type = COUNT_COLUMN;
@@ -343,7 +374,7 @@ decompress_chunk_begin(CustomScanState *node, EState *estate, int eflags)
 					column.type = SEQUENCE_NUM_COLUMN;
 					break;
 				default:
-					elog(ERROR, "Invalid column attno \"%d\"", scan_attno);
+					elog(ERROR, "Invalid column attno \"%d\"", uncompressed_scan_attno);
 					break;
 			}
 		}
@@ -445,7 +476,6 @@ decompress_chunk_begin(CustomScanState *node, EState *estate, int eflags)
 	PlannerInfo root = {
 		.glob = &glob,
 	};
-	ListCell *lc;
 	foreach (lc, chunk_state->vectorized_quals_original)
 	{
 		Node *constified = estimate_expression_value(&root, (Node *) lfirst(lc));
@@ -743,9 +773,9 @@ decompress_chunk_exec_impl(DecompressChunkState *chunk_state, const BatchQueueFu
 
 		bqfuncs->push_batch(bq, dcontext, subslot);
 	}
-	TupleTableSlot *result_slot = bqfuncs->top_tuple(bq);
+	TupleTableSlot *scan_slot = bqfuncs->top_tuple(bq);
 
-	if (TupIsNull(result_slot))
+	if (TupIsNull(scan_slot))
 	{
 		return NULL;
 	}
@@ -753,11 +783,13 @@ decompress_chunk_exec_impl(DecompressChunkState *chunk_state, const BatchQueueFu
 	if (chunk_state->csstate.ss.ps.ps_ProjInfo)
 	{
 		ExprContext *econtext = chunk_state->csstate.ss.ps.ps_ExprContext;
-		econtext->ecxt_scantuple = result_slot;
+		econtext->ecxt_scantuple = scan_slot;
+//		fprintf(stderr, "scan slot tupdesc is:\n");
+//		my_print_tdesc(scan_slot->tts_tupleDescriptor);
 		return ExecProject(chunk_state->csstate.ss.ps.ps_ProjInfo);
 	}
 
-	return result_slot;
+	return scan_slot;
 }
 
 static void


### PR DESCRIPTION
This can avoid materializing extra columns.