### PR TITLE
Nico/playground

### DIFF
--- a/.unreleased/pr_6620
+++ b/.unreleased/pr_6620
@@ -1,0 +1,1 @@
+Implements: #6620 Add first iteration of create_playground function

--- a/cmake/ScriptFiles.cmake
+++ b/cmake/ScriptFiles.cmake
@@ -55,7 +55,8 @@ set(SOURCE_FILES
     cagg_migrate.sql
     job_error_log_retention.sql
     osm_api.sql
-    compression_defaults.sql)
+    compression_defaults.sql
+    playground.sql)
 
 if(ENABLE_DEBUG_UTILS AND CMAKE_BUILD_TYPE MATCHES Debug)
   list(APPEND SOURCE_FILES debug_build_utils.sql)

--- a/sql/playground.sql
+++ b/sql/playground.sql
@@ -1,0 +1,93 @@
+-- This file and its contents are licensed under the Apache License 2.0.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-APACHE for a copy of the license.
+
+-- This function allows users to create playground hypertables with production-like data for feature testing.
+
+CREATE OR REPLACE FUNCTION _timescaledb_functions.create_playground(
+    src_hypertable REGCLASS,
+    compressed BOOL = false
+) RETURNS TEXT AS
+$BODY$
+DECLARE
+    _table_name NAME;
+    _schema_name NAME;
+    _src_relation NAME;
+    _playground_table NAME;
+    _chunk_name NAME;
+    _chunk_check BOOL;
+    _playground_schema_check BOOL;
+    _next_id INTEGER;
+    _dimension TEXT;
+    _interval TEXT;
+BEGIN
+    SELECT EXISTS(SELECT 1 FROM information_schema.schemata
+    WHERE schema_name = 'tsdb_playground') INTO _playground_schema_check;
+
+    IF NOT _playground_schema_check THEN
+        RAISE EXCEPTION '"tsdb_playground" schema must be created before running this';
+    END IF;
+
+    -- get schema and table name
+    SELECT n.nspname, c.relname INTO _schema_name, _table_name
+    FROM pg_class c
+    INNER JOIN pg_namespace n ON (n.oid = c.relnamespace)
+    INNER JOIN timescaledb_information.hypertables i ON (i.hypertable_name = c.relname )
+    WHERE c.oid = src_hypertable;
+
+    IF _table_name IS NULL THEN
+        RAISE EXCEPTION '% is not a hypertable', src_hypertable;
+    END IF;
+
+    SELECT EXISTS(SELECT 1 FROM timescaledb_information.chunks WHERE hypertable_name = _table_name AND hypertable_schema = _schema_name) INTO _chunk_check;
+
+    IF NOT _chunk_check THEN
+        RAISE EXCEPTION '% has no chunks for playground testing', src_hypertable;
+    END IF;
+
+    EXECUTE pg_catalog.format($$ CREATE SEQUENCE IF NOT EXISTS tsdb_playground.%I $$, _table_name||'_seq');
+    SELECT pg_catalog.nextval('tsdb_playground.' || pg_catalog.quote_ident(_table_name || '_seq')) INTO _next_id;
+
+    SELECT pg_catalog.format('%I.%I', _schema_name, _table_name) INTO _src_relation;
+
+    SELECT pg_catalog.format('tsdb_playground.%I', _table_name || '_' || _next_id::text) INTO _playground_table;
+    EXECUTE pg_catalog.format(
+        $$ CREATE TABLE %s (like %s including comments including constraints including defaults including indexes) $$
+        , _playground_table, _src_relation
+        );
+
+    -- get dimension column from src ht for partitioning playground ht
+    SELECT column_name, time_interval INTO _dimension, _interval FROM timescaledb_information.dimensions WHERE hypertable_name = _table_name AND hypertable_schema = _schema_name LIMIT 1;
+
+    PERFORM public.create_hypertable(_playground_table::REGCLASS, _dimension::NAME, chunk_time_interval := _interval::interval);
+
+    -- Ideally, it should pick up the latest complete chunk (second last chunk) from this hypertable.
+    -- If num_chunks > 1 then it will get true, converted into 1, taking the second row, otherwise it'll get false converted to 0 and get no offset.
+    SELECT
+        format('%I.%I',chunk_schema,chunk_name)
+    INTO STRICT
+        _chunk_name
+    FROM
+        timescaledb_information.chunks
+    WHERE
+        hypertable_schema = _schema_name AND
+        hypertable_name = _table_name
+    ORDER BY
+        chunk_creation_time DESC OFFSET (
+            SELECT
+                (num_chunks > 1)::integer
+            FROM timescaledb_information.hypertables
+            WHERE
+                hypertable_name = _table_name)
+    LIMIT 1;
+	EXECUTE pg_catalog.format($$ INSERT INTO %s SELECT * FROM %s $$, _playground_table, _chunk_name);
+
+    -- ToDo,
+    --if compressed:
+    -- --retrieve compression settings
+    -- --compress
+    --retrieve space dimension if there is any, otherwise get time one
+	RETURN _playground_table;
+END
+$BODY$
+LANGUAGE PLPGSQL SET search_path TO pg_catalog, pg_temp;

--- a/sql/updates/reverse-dev.sql
+++ b/sql/updates/reverse-dev.sql
@@ -1,4 +1,4 @@
 
 DROP VIEW IF EXISTS timescaledb_information.hypertable_compression_settings;
 DROP VIEW IF EXISTS timescaledb_information.chunk_compression_settings;
-
+DROP FUNCTION IF EXISTS _timescaledb_functions.create_playground;

--- a/tsl/test/expected/playground.out
+++ b/tsl/test/expected/playground.out
@@ -1,0 +1,95 @@
+-- This file and its contents are licensed under the Timescale License.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-TIMESCALE for a copy of the license.
+\c :TEST_DBNAME :ROLE_SUPERUSER
+-- attempt to create playground without creating the schema first
+DROP SCHEMA IF EXISTS tsdb_playground;
+NOTICE:  schema "tsdb_playground" does not exist, skipping
+DROP SCHEMA
+
+SELECT _timescaledb_functions.create_playground('public.conditions_1');
+ERROR:  "tsdb_playground" schema must be created before running this
+CONTEXT:  PL/pgSQL function _timescaledb_functions.create_playground(regclass,boolean) line 18 at RAISE
+
+CREATE SCHEMA IF NOT EXISTS tsdb_playground;
+CREATE SCHEMA
+
+CREATE TABLE public.conditions_1 (
+                time TIMESTAMPTZ NOT NULL,
+                temperature NUMERIC
+                );
+CREATE TABLE
+
+-- test creating playground on raw table
+SELECT _timescaledb_functions.create_playground('public.conditions_1');
+ERROR:  public.conditions_1 is not a hypertable
+CONTEXT:  PL/pgSQL function _timescaledb_functions.create_playground(regclass,boolean) line 29 at RAISE
+
+
+SELECT table_name FROM public.create_hypertable('public.conditions_1', 'time');
+  table_name  
+--------------
+ conditions_1
+(1 row)
+
+-- Attempt to create playground on empty hypertable
+SELECT _timescaledb_functions.create_playground('public.conditions_1');
+ERROR:  public.conditions_1 has no chunks for playground testing
+CONTEXT:  PL/pgSQL function _timescaledb_functions.create_playground(regclass,boolean) line 35 at RAISE
+
+INSERT INTO public.conditions_1
+        SELECT generate_series('2021-01-01 00:00'::timestamp, '2021-01-2 23:59:59'::timestamp, '1 hour'), random()*100;
+INSERT 0 48
+
+SELECT _timescaledb_functions.create_playground('public.conditions_1');
+       create_playground        
+--------------------------------
+ tsdb_playground.conditions_1_1
+(1 row)
+
+SELECT count(*) FROM tsdb_playground.conditions_1_1;
+ count 
+-------
+    48
+(1 row)
+
+SELECT _timescaledb_functions.create_playground('public.conditions_1');
+NOTICE:  relation "conditions_1_seq" already exists, skipping
+       create_playground        
+--------------------------------
+ tsdb_playground.conditions_1_2
+(1 row)
+
+SELECT count(*) FROM tsdb_playground.conditions_1_2;
+ count 
+-------
+    48
+(1 row)
+
+-- use table names with space characters
+CREATE TABLE public."bar foo" (
+                time TIMESTAMPTZ NOT NULL,                                                                             
+                temperature NUMERIC
+                );
+CREATE TABLE
+SELECT table_name FROM public.create_hypertable('public."bar foo"', 'time');
+ table_name 
+------------
+ bar foo
+(1 row)
+
+INSERT INTO public."bar foo"
+        SELECT generate_series('2021-01-01 00:00'::timestamp, '2021-01-2 23:59:59'::timestamp, '1 hour'), random()*100;
+INSERT 0 48
+SELECT _timescaledb_functions.create_playground('public."bar foo"');
+      create_playground      
+-----------------------------
+ tsdb_playground."bar foo_1"
+(1 row)
+
+SELECT _timescaledb_functions.create_playground('public."bar foo"');
+NOTICE:  relation "bar foo_seq" already exists, skipping
+      create_playground      
+-----------------------------
+ tsdb_playground."bar foo_2"
+(1 row)

--- a/tsl/test/shared/expected/extension.out
+++ b/tsl/test/shared/expected/extension.out
@@ -57,6 +57,7 @@ ORDER BY pronamespace::regnamespace::text COLLATE "C", p.oid::regprocedure::text
  _timescaledb_functions.create_chunk(regclass,jsonb,name,name,regclass)
  _timescaledb_functions.create_chunk_table(regclass,jsonb,name,name)
  _timescaledb_functions.create_compressed_chunk(regclass,regclass,bigint,bigint,bigint,bigint,bigint,bigint,bigint,bigint)
+ _timescaledb_functions.create_playground(regclass,boolean)
  _timescaledb_functions.dimension_info_in(cstring)
  _timescaledb_functions.dimension_info_out(_timescaledb_internal.dimension_info)
  _timescaledb_functions.drop_chunk(regclass)

--- a/tsl/test/sql/CMakeLists.txt
+++ b/tsl/test/sql/CMakeLists.txt
@@ -25,6 +25,7 @@ set(TEST_FILES
     compression_settings.sql
     compression_sorted_merge_distinct.sql
     compression_sorted_merge_columns.sql
+    create_playground.sql
     decompress_index.sql
     exp_cagg_monthly.sql
     exp_cagg_next_gen.sql

--- a/tsl/test/sql/playground.sql
+++ b/tsl/test/sql/playground.sql
@@ -1,0 +1,52 @@
+-- This file and its contents are licensed under the Timescale License.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-TIMESCALE for a copy of the license.
+
+\c :TEST_DBNAME :ROLE_SUPERUSER
+
+-- attempt to create playground without creating the schema first
+DROP SCHEMA IF EXISTS tsdb_playground;
+
+SELECT _timescaledb_functions.create_playground('public.conditions_1');
+
+CREATE SCHEMA IF NOT EXISTS tsdb_playground;
+
+CREATE TABLE public.conditions_1 (
+		time TIMESTAMPTZ NOT NULL,
+		temperature NUMERIC
+		);
+
+-- test creating playground on raw table
+SELECT _timescaledb_functions.create_playground('public.conditions_1');
+
+SELECT table_name FROM public.create_hypertable('public.conditions_1', 'time');
+
+-- Attempt to create playground on empty hypertable
+SELECT _timescaledb_functions.create_playground('public.conditions_1');
+
+
+INSERT INTO public.conditions_1
+	SELECT generate_series('2021-01-01 00:00'::timestamp, '2021-01-2 23:59:59'::timestamp, '1 hour'), random()*100;
+
+SELECT _timescaledb_functions.create_playground('public.conditions_1');
+
+SELECT count(*) FROM tsdb_playground.conditions_1_1;
+
+SELECT _timescaledb_functions.create_playground('public.conditions_1');
+
+SELECT count(*) FROM tsdb_playground.conditions_1_2;
+
+-- use table names with space characters
+CREATE TABLE public."bar foo" (
+                time TIMESTAMPTZ NOT NULL,
+                temperature NUMERIC
+                );
+
+SELECT table_name FROM public.create_hypertable('public."bar foo"', 'time');
+
+INSERT INTO public."bar foo"
+        SELECT generate_series('2021-01-01 00:00'::timestamp, '2021-01-2 23:59:59'::timestamp, '1 hour'), random()*100;
+
+SELECT _timescaledb_functions.create_playground('public."bar foo"');
+
+SELECT _timescaledb_functions.create_playground('public."bar foo"');


### PR DESCRIPTION
Add `create_playground` function, this function will take a source hypertable and clone it within the playground schema, using only one chunk of the source hypertable. The use case for this playground hypertables is for feature testing.