### PR TITLE
Bump PG versions used in CI

### DIFF
--- a/.github/ci_settings.py
+++ b/.github/ci_settings.py
@@ -10,23 +10,21 @@
 # LATEST is the maximum postgres version that is supported
 # ABI_MIN is the minimum postgres version required when the extension was build against LATEST
 #
-# TODO: Enable tests uploading in linux-build-and-test.yaml for macos once we
-# move to a new minor version below
 
 PG13_EARLIEST = "13.2"
-PG13_LATEST = "13.13"
+PG13_LATEST = "13.14"
 PG13_ABI_MIN = "13.5"
 
 PG14_EARLIEST = "14.0"
-PG14_LATEST = "14.10"
+PG14_LATEST = "14.11"
 PG14_ABI_MIN = "14.0"
 
 PG15_EARLIEST = "15.0"
-PG15_LATEST = "15.5"
+PG15_LATEST = "15.6"
 PG15_ABI_MIN = "15.0"
 
 PG16_EARLIEST = "16.0"
-PG16_LATEST = "16.1"
+PG16_LATEST = "16.2"
 PG16_ABI_MIN = "16.0"
 
 PG_LATEST = [PG13_LATEST, PG14_LATEST, PG15_LATEST, PG16_LATEST]

--- a/.github/workflows/linux-build-and-test.yaml
+++ b/.github/workflows/linux-build-and-test.yaml
@@ -274,9 +274,8 @@ jobs:
 
     - name: Upload test results to the database
       # Don't upload the results of the flaky check, because the db schema only
-      # supports running one test once per job. Also disable uploading of the
-      # tests on macOS till the next MINOR release of PG
-      if: always() && (! contains(matrix.name, 'Flaky')) && ( runner.os != 'macOS' )
+      # supports running one test once per job.
+      if: always() && (! contains(matrix.name, 'Flaky'))
       env:
         # GitHub Actions allow you neither to use the env context for the job name,
         # nor to access the job name from the step context, so we have to

--- a/.github/workflows/update-test.yaml
+++ b/.github/workflows/update-test.yaml
@@ -79,7 +79,7 @@ jobs:
         export UPDATE_FROM_TAG
         # We need to use same libssl version used in the latest official TimescaleDB container images.
         # So we will use the fixed alpine version, this will guarantee that libssl version won't change.
-        PG_IMAGE_TAG="${PG_VERSION}-alpine3.17" scripts/test_downgrade_from_tag.sh
+        PG_IMAGE_TAG="${PG_VERSION}-alpine3.18" scripts/test_downgrade_from_tag.sh
 
     - name: Downgrade diff
       if: failure()


### PR DESCRIPTION
Use newly released 13.14, 14.11, 15.6 and 16.2 in CI.

Disable-check: force-changelog-file
