### PR TITLE
Make CAgg time_bucket catalog table more generic

### DIFF
--- a/sql/pre_install/tables.sql
+++ b/sql/pre_install/tables.sql
@@ -333,16 +333,18 @@ SELECT pg_catalog.pg_extension_config_dump('_timescaledb_catalog.continuous_agg'
 -- See the comments for ContinuousAggsBucketFunction structure.
 CREATE TABLE _timescaledb_catalog.continuous_aggs_bucket_function (
   mat_hypertable_id integer NOT NULL,
-  -- The schema of the function. Equals TRUE for "timescaledb_experimental", FALSE otherwise.
-  experimental bool NOT NULL,
-  -- Name of the bucketing function, e.g. "time_bucket" or "time_bucket_ng"
-  name text NOT NULL,
+  -- The bucket function
+  bucket_func regprocedure NOT NULL,
   -- `bucket_width` argument of the function, e.g. "1 month"
   bucket_width text NOT NULL,
-  -- `origin` argument of the function provided by the user
-  origin text NOT NULL,
-  -- `timezone` argument of the function provided by the user
-  timezone text NOT NULL,
+  -- optional `origin` argument of the function provided by the user
+  bucket_origin text,
+  -- optional `offset` argument of the function provided by the user
+  bucket_offset text,
+  -- optional `timezone` argument of the function provided by the user
+  bucket_timezone text,
+  -- fixed or variable sized bucket
+  bucket_fixed_width bool NOT NULL,
   -- table constraints
   CONSTRAINT continuous_aggs_bucket_function_pkey PRIMARY KEY (mat_hypertable_id),
   CONSTRAINT continuous_aggs_bucket_function_mat_hypertable_id_fkey FOREIGN KEY (mat_hypertable_id) REFERENCES _timescaledb_catalog.hypertable (id) ON DELETE CASCADE

--- a/sql/updates/latest-dev.sql
+++ b/sql/updates/latest-dev.sql
@@ -75,3 +75,69 @@ $$ SET search_path TO pg_catalog, pg_temp;
 
 SELECT _timescaledb_functions.remove_dropped_chunk_metadata(id) AS chunks_metadata_removed
 FROM _timescaledb_catalog.hypertable;
+
+--
+-- Rebuild the catalog table `_timescaledb_catalog.continuous_aggs_bucket_function`
+--
+
+CREATE OR REPLACE FUNCTION _timescaledb_functions.cagg_get_bucket_function(
+    mat_hypertable_id INTEGER
+) RETURNS regprocedure AS '@MODULE_PATHNAME@', 'ts_continuous_agg_get_bucket_function' LANGUAGE C STRICT VOLATILE;
+
+-- Since we need now the regclass of the used bucket function, we have to recover it
+-- by parsing the view query by calling 'cagg_get_bucket_function'.
+CREATE TABLE _timescaledb_catalog._tmp_continuous_aggs_bucket_function AS
+    SELECT
+      mat_hypertable_id,
+      _timescaledb_functions.cagg_get_bucket_function(mat_hypertable_id),
+      bucket_width,
+      origin,
+      NULL::text AS bucket_offset,
+      timezone,
+      false AS bucket_fixed_width
+    FROM
+      _timescaledb_catalog.continuous_aggs_bucket_function
+    ORDER BY
+         mat_hypertable_id;
+
+ALTER EXTENSION timescaledb
+    DROP TABLE _timescaledb_catalog.continuous_aggs_bucket_function;
+
+DROP TABLE _timescaledb_catalog.continuous_aggs_bucket_function;
+
+CREATE TABLE _timescaledb_catalog.continuous_aggs_bucket_function (
+  mat_hypertable_id integer NOT NULL,
+  -- The bucket function
+  bucket_func regprocedure NOT NULL,
+  -- `bucket_width` argument of the function, e.g. "1 month"
+  bucket_width text NOT NULL,
+  -- optional `origin` argument of the function provided by the user
+  bucket_origin text,
+  -- optional `offset` argument of the function provided by the user
+  bucket_offset text,
+  -- optional `timezone` argument of the function provided by the user
+  bucket_timezone text,
+  -- fixed or variable sized bucket
+  bucket_fixed_width bool NOT NULL,
+  -- table constraints
+  CONSTRAINT continuous_aggs_bucket_function_pkey PRIMARY KEY (mat_hypertable_id),
+  CONSTRAINT continuous_aggs_bucket_function_mat_hypertable_id_fkey FOREIGN KEY (mat_hypertable_id) REFERENCES _timescaledb_catalog.hypertable (id) ON DELETE CASCADE
+);
+
+INSERT INTO _timescaledb_catalog.continuous_aggs_bucket_function
+  SELECT * FROM _timescaledb_catalog._tmp_continuous_aggs_bucket_function;
+
+DROP TABLE _timescaledb_catalog._tmp_continuous_aggs_bucket_function;
+
+SELECT pg_catalog.pg_extension_config_dump('_timescaledb_catalog.continuous_aggs_bucket_function', '');
+
+GRANT SELECT ON TABLE _timescaledb_catalog.continuous_aggs_bucket_function TO PUBLIC;
+
+ANALYZE _timescaledb_catalog.continuous_aggs_bucket_function;
+
+ALTER EXTENSION timescaledb DROP FUNCTION _timescaledb_functions.cagg_get_bucket_function(INTEGER);
+DROP FUNCTION IF EXISTS _timescaledb_functions.cagg_get_bucket_function(INTEGER);
+
+--
+-- End rebuild the catalog table `_timescaledb_catalog.continuous_aggs_bucket_function`
+--

--- a/sql/updates/reverse-dev.sql
+++ b/sql/updates/reverse-dev.sql
@@ -1,1 +1,54 @@
 DROP FUNCTION IF EXISTS _timescaledb_functions.remove_dropped_chunk_metadata(INTEGER);
+
+--
+-- Rebuild the catalog table `_timescaledb_catalog.continuous_aggs_bucket_function`
+--
+CREATE TABLE _timescaledb_catalog._tmp_continuous_aggs_bucket_function AS
+    SELECT
+      mat_hypertable_id,
+      CASE WHEN bucket_func::text like 'timescaledb_experimental%' THEN true ELSE false END,
+      split_part(bucket_func::regproc::text, '.', 2),
+      bucket_width,
+      bucket_origin,
+      bucket_timezone
+    FROM
+      _timescaledb_catalog.continuous_aggs_bucket_function
+    ORDER BY
+         mat_hypertable_id;
+
+ALTER EXTENSION timescaledb
+    DROP TABLE _timescaledb_catalog.continuous_aggs_bucket_function;
+
+DROP TABLE _timescaledb_catalog.continuous_aggs_bucket_function;
+
+CREATE TABLE _timescaledb_catalog.continuous_aggs_bucket_function (
+  mat_hypertable_id integer NOT NULL,
+  -- The schema of the function. Equals TRUE for "timescaledb_experimental", FALSE otherwise.
+  experimental bool NOT NULL,
+  -- Name of the bucketing function, e.g. "time_bucket" or "time_bucket_ng"
+  name text NOT NULL,
+  -- `bucket_width` argument of the function, e.g. "1 month"
+  bucket_width text NOT NULL,
+  -- `origin` argument of the function provided by the user
+  origin text NOT NULL,
+  -- `timezone` argument of the function provided by the user
+  timezone text NOT NULL,
+  -- table constraints
+  CONSTRAINT continuous_aggs_bucket_function_pkey PRIMARY KEY (mat_hypertable_id),
+  CONSTRAINT continuous_aggs_bucket_function_mat_hypertable_id_fkey FOREIGN KEY (mat_hypertable_id) REFERENCES _timescaledb_catalog.hypertable (id) ON DELETE CASCADE
+);
+
+INSERT INTO _timescaledb_catalog.continuous_aggs_bucket_function
+  SELECT * FROM _timescaledb_catalog._tmp_continuous_aggs_bucket_function;
+
+DROP TABLE _timescaledb_catalog._tmp_continuous_aggs_bucket_function;
+
+SELECT pg_catalog.pg_extension_config_dump('_timescaledb_catalog.continuous_aggs_bucket_function', '');
+
+GRANT SELECT ON TABLE _timescaledb_catalog.continuous_aggs_bucket_function TO PUBLIC;
+
+ANALYZE _timescaledb_catalog.continuous_aggs_bucket_function;
+
+--
+-- End rebuild the catalog table `_timescaledb_catalog.continuous_aggs_bucket_function`
+--

--- a/src/cross_module_fn.c
+++ b/src/cross_module_fn.c
@@ -82,6 +82,7 @@ CROSSMODULE_WRAPPER(decompress_chunk);
 CROSSMODULE_WRAPPER(continuous_agg_invalidation_trigger);
 CROSSMODULE_WRAPPER(continuous_agg_refresh);
 CROSSMODULE_WRAPPER(continuous_agg_validate_query);
+CROSSMODULE_WRAPPER(continuous_agg_get_bucket_function);
 CROSSMODULE_WRAPPER(cagg_try_repair);
 
 CROSSMODULE_WRAPPER(chunk_freeze_chunk);
@@ -336,6 +337,7 @@ TSDLLEXPORT CrossModuleFunctions ts_cm_functions_default = {
 	.continuous_agg_invalidate_mat_ht = continuous_agg_invalidate_mat_ht_all_default,
 	.continuous_agg_update_options = continuous_agg_update_options_default,
 	.continuous_agg_validate_query = error_no_default_fn_pg_community,
+	.continuous_agg_get_bucket_function = error_no_default_fn_pg_community,
 	.cagg_try_repair = process_cagg_try_repair,
 
 	/* compression */

--- a/src/cross_module_fn.h
+++ b/src/cross_module_fn.h
@@ -109,6 +109,7 @@ typedef struct CrossModuleFunctions
 	void (*continuous_agg_update_options)(ContinuousAgg *cagg,
 										  WithClauseResult *with_clause_options);
 	PGFunction continuous_agg_validate_query;
+	PGFunction continuous_agg_get_bucket_function;
 	PGFunction cagg_try_repair;
 
 	PGFunction compressed_data_send;

--- a/src/ts_catalog/catalog.c
+++ b/src/ts_catalog/catalog.c
@@ -198,7 +198,7 @@ static const TableIndexDef catalog_table_index_definitions[_MAX_CATALOG_TABLES] 
 		.length = _MAX_CONTINUOUS_AGG_INDEX,
 		.names = (char *[]) {
 			[CONTINUOUS_AGG_PARTIAL_VIEW_SCHEMA_PARTIAL_VIEW_NAME_KEY] = "continuous_agg_partial_view_schema_partial_view_name_key",
-			[CONTINUOUS_AGG_PKEY] = "continuous_agg_pkey",
+			[CONTINUOUS_AGG_PKEY] = TS_CAGG_CATALOG_IDX,
 			[CONTINUOUS_AGG_USER_VIEW_SCHEMA_USER_VIEW_NAME_KEY] = "continuous_agg_user_view_schema_user_view_name_key",
 			[CONTINUOUS_AGG_RAW_HYPERTABLE_ID_IDX] = "continuous_agg_raw_hypertable_id_idx"
 		},

--- a/src/ts_catalog/catalog.h
+++ b/src/ts_catalog/catalog.h
@@ -69,6 +69,8 @@ typedef struct TableIndexDef
 	char **names;
 } TableIndexDef;
 
+#define TS_CAGG_CATALOG_IDX "continuous_agg_pkey"
+
 #define INVALID_CATALOG_TABLE _MAX_CATALOG_TABLES
 #define INVALID_INDEXID -1
 
@@ -882,11 +884,12 @@ typedef enum Anum_continuous_agg_raw_hypertable_id_idx
 typedef enum Anum_continuous_aggs_bucket_function
 {
 	Anum_continuous_aggs_bucket_function_mat_hypertable_id = 1,
-	Anum_continuous_aggs_bucket_function_experimental,
-	Anum_continuous_aggs_bucket_function_name,
+	Anum_continuous_aggs_bucket_function_function,
 	Anum_continuous_aggs_bucket_function_bucket_width,
-	Anum_continuous_aggs_bucket_function_origin,
-	Anum_continuous_aggs_bucket_function_timezone,
+	Anum_continuous_aggs_bucket_function_bucket_origin,
+	Anum_continuous_aggs_bucket_function_bucket_offset,
+	Anum_continuous_aggs_bucket_function_bucket_timezone,
+	Anum_continuous_aggs_bucket_function_bucket_fixed_width,
 	_Anum_continuous_aggs_bucket_function_max,
 } Anum_continuous_aggs_bucket_function;
 

--- a/src/ts_catalog/continuous_agg.h
+++ b/src/ts_catalog/continuous_agg.h
@@ -73,22 +73,33 @@ ts_continuous_agg_get_compression_defelems(const WithClauseResult *with_clauses)
  */
 typedef struct ContinuousAggsBucketFunction
 {
-	/*
-	 * Schema of the bucketing function.
-	 * Equals TRUE for "timescaledb_experimental", FALSE otherwise.
-	 */
-	bool experimental;
-	/* Name of the bucketing function, e.g. "time_bucket" or "time_bucket_ng" */
-	char *name;
-	/* `bucket_width` argument of the function */
+	/* Oid of the bucketing function. In the catalog table, the regprocedure is used. This ensures
+	 * that the Oid is mapped to a string when a backup is taken and the string is converted back to
+	 * the Oid when the backup is restored. This way, we can use an Oid in the catalog table even
+	 * when a backup is restored and the Oid may have changed. However, the dependency management in
+	 * PostgreSQL does not track the Oid. If the function is dropped and a new one is created, the
+	 * Oid changes and this value points to a non-existing Oid. This can not happen in real-world
+	 * situations since PostgreSQL protects the bucket_function from deletion until the CAgg is
+	 * defined. */
+	Oid bucket_function;
+
+	/* `bucket_width` argument of the function. */
 	Interval *bucket_width;
+
 	/*
 	 * Custom origin value stored as UTC timestamp.
 	 * If not specified, stores infinity.
 	 */
-	Timestamp origin;
-	/* `timezone` argument of the function provided by the user */
+	Timestamp bucket_origin;
+
+	/* `bucket_offset` argument of the function. */
+	Interval *bucket_offest;
+
+	/* `timezone` argument of the function provided by the user. */
 	char *timezone;
+
+	/* Is the interval of the bucket fixed? */
+	bool bucket_fixed_interval;
 } ContinuousAggsBucketFunction;
 
 typedef struct ContinuousAgg

--- a/tsl/src/continuous_aggs/create.c
+++ b/tsl/src/continuous_aggs/create.c
@@ -82,9 +82,10 @@ static void create_cagg_catalog_entry(int32 matht_id, int32 rawht_id, const char
 									  bool materialized_only, const char *direct_schema,
 									  const char *direct_view, const bool finalized,
 									  const int32 parent_mat_hypertable_id);
-static void create_bucket_function_catalog_entry(int32 matht_id, bool experimental,
-												 const char *name, const char *bucket_width,
-												 const char *origin, const char *timezone);
+static void create_bucket_function_catalog_entry(int32 matht_id, Oid bucket_function,
+												 const char *bucket_width, const char *origin,
+												 const char *offset, const char *timezone,
+												 const bool bucket_fixed_width);
 static void cagg_create_hypertable(int32 hypertable_id, Oid mat_tbloid, const char *matpartcolname,
 								   int64 mat_tbltimecol_interval);
 #if PG14_LT
@@ -186,9 +187,9 @@ create_cagg_catalog_entry(int32 matht_id, int32 rawht_id, const char *user_schem
  * CONTINUOUS_AGGS_BUCKET_FUNCTION.
  */
 static void
-create_bucket_function_catalog_entry(int32 matht_id, bool experimental, const char *name,
-									 const char *bucket_width, const char *origin,
-									 const char *timezone)
+create_bucket_function_catalog_entry(int32 matht_id, Oid bucket_function, const char *bucket_width,
+									 const char *origin, const char *offset, const char *timezone,
+									 const bool bucket_fixed_width)
 {
 	Catalog *catalog = ts_catalog_get();
 	Relation rel;
@@ -202,17 +203,20 @@ create_bucket_function_catalog_entry(int32 matht_id, bool experimental, const ch
 	desc = RelationGetDescr(rel);
 
 	memset(values, 0, sizeof(values));
-	values[AttrNumberGetAttrOffset(Anum_continuous_agg_mat_hypertable_id)] = matht_id;
-	values[AttrNumberGetAttrOffset(Anum_continuous_aggs_bucket_function_experimental)] =
-		BoolGetDatum(experimental);
-	values[AttrNumberGetAttrOffset(Anum_continuous_aggs_bucket_function_name)] =
-		CStringGetTextDatum(name);
+	values[AttrNumberGetAttrOffset(Anum_continuous_aggs_bucket_function_mat_hypertable_id)] =
+		matht_id;
+	values[AttrNumberGetAttrOffset(Anum_continuous_aggs_bucket_function_function)] =
+		ObjectIdGetDatum(bucket_function);
 	values[AttrNumberGetAttrOffset(Anum_continuous_aggs_bucket_function_bucket_width)] =
 		CStringGetTextDatum(bucket_width);
-	values[AttrNumberGetAttrOffset(Anum_continuous_aggs_bucket_function_origin)] =
+	values[AttrNumberGetAttrOffset(Anum_continuous_aggs_bucket_function_bucket_origin)] =
 		CStringGetTextDatum(origin);
-	values[AttrNumberGetAttrOffset(Anum_continuous_aggs_bucket_function_timezone)] =
+	values[AttrNumberGetAttrOffset(Anum_continuous_aggs_bucket_function_bucket_offset)] =
+		CStringGetTextDatum(offset);
+	values[AttrNumberGetAttrOffset(Anum_continuous_aggs_bucket_function_bucket_timezone)] =
 		CStringGetTextDatum(timezone ? timezone : "");
+	values[AttrNumberGetAttrOffset(Anum_continuous_aggs_bucket_function_bucket_fixed_width)] =
+		BoolGetDatum(bucket_fixed_width);
 
 	ts_catalog_database_info_become_owner(ts_catalog_database_info_get(), &sec_ctx);
 	ts_catalog_insert_values(rel, desc, values, nulls);
@@ -782,6 +786,7 @@ cagg_create(const CreateTableAsStmt *create_stmt, ViewStmt *stmt, Query *panquer
 	{
 		const char *bucket_width;
 		const char *origin = "";
+		const char *offset = "";
 
 		/*
 		 * Variable-sized buckets work only with intervals.
@@ -796,29 +801,13 @@ cagg_create(const CreateTableAsStmt *create_stmt, ViewStmt *stmt, Query *panquer
 				DirectFunctionCall1(timestamp_out, TimestampGetDatum(bucket_info->origin)));
 		}
 
-		/*
-		 * These values are not used for anything except Assert's yet
-		 * for the same reasons. Once the design of variable-sized buckets
-		 * is finalized we will have a better idea of what schema is needed exactly.
-		 * Until then the choice was made in favor of the most generic schema
-		 * that can be optimized later.
-		 */
-		Oid bucket_func_schema_oid = get_func_namespace(bucket_info->bucket_func->funcid);
-		Ensure(OidIsValid(bucket_func_schema_oid),
-			   "namespace for funcid %d not found",
-			   bucket_info->bucket_func->funcid);
-		char *bucket_func_schema_name = get_namespace_name(bucket_func_schema_oid);
-		Ensure(bucket_func_schema_name != NULL,
-			   "unable to get namespace name for Oid %d",
-			   bucket_func_schema_oid);
-		bool is_experimental =
-			(strncmp(bucket_func_schema_name, EXPERIMENTAL_SCHEMA_NAME, NAMEDATALEN) == 0);
 		create_bucket_function_catalog_entry(materialize_hypertable_id,
-											 is_experimental,
-											 get_func_name(bucket_info->bucket_func->funcid),
+											 bucket_info->bucket_func->funcid,
 											 bucket_width,
 											 origin,
-											 bucket_info->timezone);
+											 offset,
+											 bucket_info->timezone,
+											 bucket_info->bucket_width != BUCKET_WIDTH_VARIABLE);
 	}
 
 	/* Step 5: Create trigger on raw hypertable -specified in the user view query. */

--- a/tsl/src/continuous_aggs/repair.c
+++ b/tsl/src/continuous_aggs/repair.c
@@ -6,6 +6,11 @@
 
 #include "repair.h"
 
+#include <funcapi.h>
+#include <utils/snapmgr.h>
+
+#include "func_cache.h"
+
 static void cagg_rebuild_view_definition(ContinuousAgg *agg, Hypertable *mat_ht,
 										 bool force_rebuild);
 
@@ -240,4 +245,155 @@ tsl_cagg_try_repair(PG_FUNCTION_ARGS)
 	ts_cache_release(hcache);
 
 	PG_RETURN_VOID();
+}
+
+typedef struct
+{
+	/* Input parameter */
+	int32 mat_hypertable_id;
+
+	/* Output parameter */
+	Oid bucket_fuction;
+} CaggQueryWalkerContext;
+
+/* Process the CAgg query and find all used (usually one) time_bucket functions. It returns
+ * InvalidOid is no or more than one bucket function is found. */
+static bool
+cagg_query_walker(Node *node, CaggQueryWalkerContext *context)
+{
+	if (node == NULL)
+		return false;
+
+	if (IsA(node, FuncExpr))
+	{
+		FuncExpr *func_expr = castNode(FuncExpr, node);
+
+		/* Is the used function a bucket function?
+		 * We can not call ts_func_cache_get_bucketing_func at this point, since
+		 */
+		FuncInfo *func_info = ts_func_cache_get_bucketing_func(func_expr->funcid);
+		if (func_info != NULL)
+		{
+			/* First bucket function found */
+			if (!OidIsValid(context->bucket_fuction))
+			{
+				context->bucket_fuction = func_expr->funcid;
+			}
+			else
+			{
+				/* Got multiple bucket functions. Should never happen because this is checked during
+				 * CAgg query validation.
+				 */
+				ereport(ERROR,
+						(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
+						 errmsg("found multiple time_bucket functions in CAgg definition for "
+								"mat_ht_id: %d",
+								context->mat_hypertable_id)));
+				pg_unreachable();
+			}
+		}
+	}
+	else if (IsA(node, Query))
+	{
+		Query *query = castNode(Query, node);
+		return query_tree_walker(query, cagg_query_walker, context, 0);
+	}
+
+	return expression_tree_walker(node, cagg_query_walker, context);
+}
+
+/* Get the Oid of the direct view of the CAgg. We cannot use the TimescaleDB internal
+ * functions such as ts_continuous_agg_find_by_mat_hypertable_id() at this point since this
+ * function can be called during an extension upgrade and ts_catalog_get() does not work.
+ */
+static Oid
+get_direct_view_oid(int32 mat_hypertable_id)
+{
+	RangeVar *ts_cagg = makeRangeVar(CATALOG_SCHEMA_NAME,
+									 CONTINUOUS_AGG_TABLE_NAME,
+									 -1 /* taken location unknown */);
+	Relation cagg_rel = relation_openrv_extended(ts_cagg, AccessShareLock, /* missing ok */ true);
+
+	RangeVar *ts_cagg_idx =
+		makeRangeVar(CATALOG_SCHEMA_NAME, TS_CAGG_CATALOG_IDX, -1 /* taken location unknown */);
+	Relation cagg_idx_rel =
+		relation_openrv_extended(ts_cagg_idx, AccessShareLock, /* missing ok */ true);
+
+	/* Prepare relation scan */
+	TupleTableSlot *slot = table_slot_create(cagg_rel, NULL);
+	ScanKeyData scankeys[1];
+	ScanKeyEntryInitialize(&scankeys[0],
+						   0,
+						   1,
+						   BTEqualStrategyNumber,
+						   InvalidOid,
+						   InvalidOid,
+						   F_INT4EQ,
+						   Int32GetDatum(mat_hypertable_id));
+
+	/* Prepare index scan */
+	IndexScanDesc indexscan =
+		index_beginscan(cagg_rel, cagg_idx_rel, GetTransactionSnapshot(), 1, 0);
+	index_rescan(indexscan, scankeys, 1, NULL, 0);
+
+	/* Read tuple from relation */
+	bool got_next_slot = index_getnext_slot(indexscan, ForwardScanDirection, slot);
+	Ensure(got_next_slot, "unable to find CAgg definition for mat_ht %d", mat_hypertable_id);
+
+	bool is_null = false;
+
+	char *view_schema =
+		DatumGetCString(slot_getattr(slot, Anum_continuous_agg_direct_view_schema, &is_null));
+	Ensure(!is_null, "unable to get view schema for oid %d", mat_hypertable_id);
+	Assert(view_schema != NULL);
+
+	char *view_name =
+		DatumGetCString(slot_getattr(slot, Anum_continuous_agg_direct_view_name, &is_null));
+	Ensure(!is_null, "unable to get view name for oid %d", mat_hypertable_id);
+	Assert(view_name != NULL);
+
+	got_next_slot = index_getnext_slot(indexscan, ForwardScanDirection, slot);
+	Ensure(!got_next_slot, "found duplicate definitions for CAgg mat_ht %d", mat_hypertable_id);
+
+	/* End relation scan */
+	index_endscan(indexscan);
+	ExecDropSingleTupleTableSlot(slot);
+	relation_close(cagg_rel, AccessShareLock);
+	relation_close(cagg_idx_rel, AccessShareLock);
+
+	/* Get Oid of user view */
+	Oid direct_view_oid = ts_get_relation_relid(view_schema, view_name, false);
+	Assert(OidIsValid(direct_view_oid));
+	return direct_view_oid;
+}
+
+/*
+ * In older TimescaleDB versions, information about the Timezone and the Oid of the time_bucket
+ * function are not stored in the catalog table. This function gets the data from the used
+ * view definition and return it.
+ */
+Datum
+continuous_agg_get_bucket_function(PG_FUNCTION_ARGS)
+{
+	const int32 mat_hypertable_id = PG_GETARG_INT32(0);
+
+	/* Get the user view query of the user defined CAGG.  */
+	Oid direct_view_oid = get_direct_view_oid(mat_hypertable_id);
+	Assert(OidIsValid(direct_view_oid));
+
+	Relation direct_view_rel = relation_open(direct_view_oid, AccessShareLock);
+	Query *direct_query = copyObject(get_view_query(direct_view_rel));
+	relation_close(direct_view_rel, NoLock);
+
+	Assert(direct_query != NULL);
+	Assert(direct_query->commandType == CMD_SELECT);
+
+	/* Process the query and collect function information */
+	CaggQueryWalkerContext context = { 0 };
+	context.mat_hypertable_id = mat_hypertable_id;
+	context.bucket_fuction = InvalidOid;
+
+	cagg_query_walker((Node *) direct_query, &context);
+
+	PG_RETURN_DATUM(ObjectIdGetDatum(context.bucket_fuction));
 }

--- a/tsl/src/continuous_aggs/repair.h
+++ b/tsl/src/continuous_aggs/repair.h
@@ -15,3 +15,4 @@
 #include "ts_catalog/continuous_agg.h"
 
 extern Datum tsl_cagg_try_repair(PG_FUNCTION_ARGS);
+extern Datum continuous_agg_get_bucket_function(PG_FUNCTION_ARGS);

--- a/tsl/src/init.c
+++ b/tsl/src/init.c
@@ -132,6 +132,7 @@ CrossModuleFunctions tsl_cm_functions = {
 	.continuous_agg_invalidate_mat_ht = continuous_agg_invalidate_mat_ht,
 	.continuous_agg_update_options = continuous_agg_update_options,
 	.continuous_agg_validate_query = continuous_agg_validate_query,
+	.continuous_agg_get_bucket_function = continuous_agg_get_bucket_function,
 	.cagg_try_repair = tsl_cagg_try_repair,
 
 	/* Compression */

--- a/tsl/test/expected/cagg_utils.out
+++ b/tsl/test/expected/cagg_utils.out
@@ -255,3 +255,104 @@ SELECT * FROM cagg_validate_query($$ SELECT time_bucket('1 year', bucket) AS buc
  t        |             |            |               |              | 
 (1 row)
 
+--
+-- Test bucket Oid recovery
+--
+\c :TEST_DBNAME :ROLE_SUPERUSER
+CREATE OR REPLACE FUNCTION cagg_get_bucket_function(
+    mat_hypertable_id INTEGER
+) RETURNS regprocedure AS :MODULE_PATHNAME, 'ts_continuous_agg_get_bucket_function' LANGUAGE C STRICT VOLATILE;
+\c :TEST_DBNAME :ROLE_DEFAULT_PERM_USER
+CREATE TABLE timestamp_ht (
+  time timestamp NOT NULL,
+  value float
+);
+SELECT create_hypertable('timestamp_ht', 'time');
+WARNING:  column type "timestamp without time zone" used for "time" does not follow best practices
+     create_hypertable     
+---------------------------
+ (4,public,timestamp_ht,t)
+(1 row)
+
+INSERT INTO timestamp_ht
+  SELECT time, ceil(random() * 100)::int
+    FROM generate_series('2000-01-01 0:00:00+0'::timestamptz,
+                         '2000-01-01 23:59:59+0','1m') time;
+CREATE MATERIALIZED VIEW temperature_4h
+  WITH  (timescaledb.continuous) AS
+  SELECT time_bucket('4 hour', time), avg(value)
+    FROM timestamp_ht
+    GROUP BY 1 ORDER BY 1;
+NOTICE:  refreshing continuous aggregate "temperature_4h"
+CREATE TABLE timestamptz_ht (
+  time timestamptz NOT NULL,
+  value float
+);
+SELECT create_hypertable('timestamptz_ht', 'time');
+      create_hypertable      
+-----------------------------
+ (6,public,timestamptz_ht,t)
+(1 row)
+
+INSERT INTO timestamptz_ht
+  SELECT time, ceil(random() * 100)::int
+    FROM generate_series('2000-01-01 0:00:00+0'::timestamptz,
+                         '2000-01-01 23:59:59+0','1m') time;
+CREATE MATERIALIZED VIEW temperature_tz_4h
+  WITH  (timescaledb.continuous) AS
+  SELECT time_bucket('4 hour', time), avg(value)
+    FROM timestamptz_ht
+    GROUP BY 1 ORDER BY 1;
+NOTICE:  refreshing continuous aggregate "temperature_tz_4h"
+CREATE MATERIALIZED VIEW temperature_tz_4h_ts
+  WITH  (timescaledb.continuous) AS
+  SELECT time_bucket('4 hour', time, 'Europe/Berlin'), avg(value)
+    FROM timestamptz_ht
+    GROUP BY 1 ORDER BY 1;
+NOTICE:  refreshing continuous aggregate "temperature_tz_4h_ts"
+CREATE MATERIALIZED VIEW temperature_tz_4h_ts_ng
+  WITH  (timescaledb.continuous) AS
+  SELECT timescaledb_experimental.time_bucket_ng('4 hour', time, 'Asia/Shanghai'), avg(value)
+    FROM timestamptz_ht
+    GROUP BY 1 ORDER BY 1;
+NOTICE:  refreshing continuous aggregate "temperature_tz_4h_ts_ng"
+CREATE TABLE integer_ht(a integer, b integer, c integer);
+SELECT table_name FROM create_hypertable('integer_ht', 'a', chunk_time_interval=> 10);
+NOTICE:  adding not-null constraint to column "a"
+ table_name 
+------------
+ integer_ht
+(1 row)
+
+CREATE OR REPLACE FUNCTION integer_now_integer_ht() returns int LANGUAGE SQL STABLE as $$ SELECT coalesce(max(a), 0) FROM integer_ht $$;
+SELECT set_integer_now_func('integer_ht', 'integer_now_integer_ht');
+ set_integer_now_func 
+----------------------
+ 
+(1 row)
+
+CREATE MATERIALIZED VIEW integer_ht_cagg
+  WITH (timescaledb.continuous) AS
+  SELECT a, count(b)
+     FROM integer_ht
+     GROUP BY time_bucket(1, a), a;
+NOTICE:  continuous aggregate "integer_ht_cagg" is already up-to-date
+--- Get the bucket Oids
+SELECT user_view_name,
+       cagg_get_bucket_function(mat_hypertable_id)
+       FROM _timescaledb_catalog.continuous_agg
+       WHERE user_view_name in('temperature_4h', 'temperature_tz_4h', 'temperature_tz_4h_ts', 'temperature_tz_4h_ts_ng', 'integer_ht_cagg')
+       ORDER BY user_view_name;
+     user_view_name      |                               cagg_get_bucket_function                                
+-------------------------+---------------------------------------------------------------------------------------
+ integer_ht_cagg         | time_bucket(integer,integer)
+ temperature_4h          | time_bucket(interval,timestamp without time zone)
+ temperature_tz_4h       | time_bucket(interval,timestamp with time zone)
+ temperature_tz_4h_ts    | time_bucket(interval,timestamp with time zone,text,timestamp with time zone,interval)
+ temperature_tz_4h_ts_ng | timescaledb_experimental.time_bucket_ng(interval,timestamp with time zone,text)
+(5 rows)
+
+--- Cleanup
+\c :TEST_DBNAME :ROLE_SUPERUSER
+DROP FUNCTION IF EXISTS cagg_get_bucket_function(INTEGER);
+\c :TEST_DBNAME :ROLE_DEFAULT_PERM_USER

--- a/tsl/test/expected/exp_cagg_monthly.out
+++ b/tsl/test/expected/exp_cagg_monthly.out
@@ -70,12 +70,12 @@ WHERE mat_hypertable_id = :cagg_id;
            -1
 (1 row)
 
-SELECT experimental, name, bucket_width, origin, timezone
+SELECT bucket_func, bucket_width, bucket_origin, bucket_timezone, bucket_fixed_width
 FROM _timescaledb_catalog.continuous_aggs_bucket_function
 WHERE mat_hypertable_id = :cagg_id;
- experimental |      name      | bucket_width | origin | timezone 
---------------+----------------+--------------+--------+----------
- t            | time_bucket_ng | @ 1 mon      |        | 
+                      bucket_func                       | bucket_width | bucket_origin | bucket_timezone | bucket_fixed_width 
+--------------------------------------------------------+--------------+---------------+-----------------+--------------------
+ timescaledb_experimental.time_bucket_ng(interval,date) | @ 1 mon      |               |                 | f
 (1 row)
 
 -- Check that the saved invalidation threshold is -infinity
@@ -329,8 +329,8 @@ WHERE mat_hypertable_id = :cagg_id;
 
 SELECT * FROM _timescaledb_catalog.continuous_aggs_bucket_function
 WHERE mat_hypertable_id = :cagg_id;
- mat_hypertable_id | experimental | name | bucket_width | origin | timezone 
--------------------+--------------+------+--------------+--------+----------
+ mat_hypertable_id | bucket_func | bucket_width | bucket_origin | bucket_offset | bucket_timezone | bucket_fixed_width 
+-------------------+-------------+--------------+---------------+---------------+-----------------+--------------------
 (0 rows)
 
 -- Re-create cagg, this time WITH DATA

--- a/tsl/test/expected/exp_cagg_next_gen.out
+++ b/tsl/test/expected/exp_cagg_next_gen.out
@@ -178,13 +178,12 @@ SELECT city,
 FROM conditions
 GROUP BY city, bucket
 WITH NO DATA;
--- experimental should be FALSE for time_bucket
--- experimental should be TRUE for time_bucket_bg
-SELECT name, bucket_width, experimental FROM _timescaledb_catalog.continuous_aggs_bucket_function ORDER BY 1;
-      name      | bucket_width | experimental 
-----------------+--------------+--------------
- time_bucket    | @ 1 year     | f
- time_bucket_ng | @ 1 mon      | t
+SELECT bucket_func, bucket_width, bucket_origin, bucket_timezone, bucket_fixed_width
+FROM _timescaledb_catalog.continuous_aggs_bucket_function ORDER BY 1;
+                                  bucket_func                                  | bucket_width | bucket_origin | bucket_timezone | bucket_fixed_width 
+-------------------------------------------------------------------------------+--------------+---------------+-----------------+--------------------
+ test.time_bucket(interval,timestamp without time zone)                        | @ 1 year     |               |                 | f
+ timescaledb_experimental.time_bucket_ng(interval,timestamp without time zone) | @ 1 mon      |               |                 | f
 (2 rows)
 
 \c :TEST_DBNAME :ROLE_SUPERUSER

--- a/tsl/test/expected/exp_cagg_timezone.out
+++ b/tsl/test/expected/exp_cagg_timezone.out
@@ -117,12 +117,12 @@ WHERE mat_hypertable_id = :cagg_id_tz;
 (1 row)
 
 -- Make sure the timezone is saved in the catalog table
-SELECT experimental, name, bucket_width, origin, timezone
+SELECT bucket_func, bucket_width, bucket_origin, bucket_timezone, bucket_fixed_width
 FROM _timescaledb_catalog.continuous_aggs_bucket_function
 WHERE mat_hypertable_id = :cagg_id_tz;
- experimental |      name      | bucket_width | origin | timezone 
---------------+----------------+--------------+--------+----------
- t            | time_bucket_ng | @ 1 mon      |        | MSK
+                                   bucket_func                                   | bucket_width | bucket_origin | bucket_timezone | bucket_fixed_width 
+---------------------------------------------------------------------------------+--------------+---------------+-----------------+--------------------
+ timescaledb_experimental.time_bucket_ng(interval,timestamp with time zone,text) | @ 1 mon      |               | MSK             | f
 (1 row)
 
 -- Make sure that buckets with specified timezone are always treated as
@@ -149,12 +149,12 @@ WHERE mat_hypertable_id = :cagg_id_1w;
 (1 row)
 
 -- Make sure the timezone is saved in the catalog table
-SELECT experimental, name, bucket_width, origin, timezone
+SELECT bucket_func, bucket_width, bucket_origin, bucket_timezone, bucket_fixed_width
 FROM _timescaledb_catalog.continuous_aggs_bucket_function
 WHERE mat_hypertable_id = :cagg_id_1w;
- experimental |      name      | bucket_width | origin | timezone 
---------------+----------------+--------------+--------+----------
- t            | time_bucket_ng | @ 7 days     |        | MSK
+                                   bucket_func                                   | bucket_width | bucket_origin | bucket_timezone | bucket_fixed_width 
+---------------------------------------------------------------------------------+--------------+---------------+-----------------+--------------------
+ timescaledb_experimental.time_bucket_ng(interval,timestamp with time zone,text) | @ 7 days     |               | MSK             | f
 (1 row)
 
 -- Check the invalidation threshold is -infinity

--- a/tsl/test/sql/exp_cagg_monthly.sql
+++ b/tsl/test/sql/exp_cagg_monthly.sql
@@ -70,7 +70,7 @@ SELECT bucket_width
 FROM _timescaledb_catalog.continuous_agg
 WHERE mat_hypertable_id = :cagg_id;
 
-SELECT experimental, name, bucket_width, origin, timezone
+SELECT bucket_func, bucket_width, bucket_origin, bucket_timezone, bucket_fixed_width
 FROM _timescaledb_catalog.continuous_aggs_bucket_function
 WHERE mat_hypertable_id = :cagg_id;
 

--- a/tsl/test/sql/exp_cagg_next_gen.sql
+++ b/tsl/test/sql/exp_cagg_next_gen.sql
@@ -147,9 +147,8 @@ FROM conditions
 GROUP BY city, bucket
 WITH NO DATA;
 
--- experimental should be FALSE for time_bucket
--- experimental should be TRUE for time_bucket_bg
-SELECT name, bucket_width, experimental FROM _timescaledb_catalog.continuous_aggs_bucket_function ORDER BY 1;
+SELECT bucket_func, bucket_width, bucket_origin, bucket_timezone, bucket_fixed_width
+FROM _timescaledb_catalog.continuous_aggs_bucket_function ORDER BY 1;
 
 \c :TEST_DBNAME :ROLE_SUPERUSER
 DROP DATABASE test WITH (FORCE);

--- a/tsl/test/sql/exp_cagg_timezone.sql
+++ b/tsl/test/sql/exp_cagg_timezone.sql
@@ -118,7 +118,7 @@ FROM _timescaledb_catalog.continuous_agg
 WHERE mat_hypertable_id = :cagg_id_tz;
 
 -- Make sure the timezone is saved in the catalog table
-SELECT experimental, name, bucket_width, origin, timezone
+SELECT bucket_func, bucket_width, bucket_origin, bucket_timezone, bucket_fixed_width
 FROM _timescaledb_catalog.continuous_aggs_bucket_function
 WHERE mat_hypertable_id = :cagg_id_tz;
 
@@ -145,7 +145,7 @@ FROM _timescaledb_catalog.continuous_agg
 WHERE mat_hypertable_id = :cagg_id_1w;
 
 -- Make sure the timezone is saved in the catalog table
-SELECT experimental, name, bucket_width, origin, timezone
+SELECT bucket_func, bucket_width, bucket_origin, bucket_timezone, bucket_fixed_width
 FROM _timescaledb_catalog.continuous_aggs_bucket_function
 WHERE mat_hypertable_id = :cagg_id_1w;
 


### PR DESCRIPTION
The catalog table continuous_aggs_bucket_function is currently only used for variable bucket sizes. Information about the fixed-size buckets is stored in the table continuous_agg only. This causes some problems (e.g., we have redundant fields for the bucket_size, fixes size buckets with offsets are not supported, ...).

This commit is the first in a row of commits that refactor the catalog for the CAgg time_bucket function. The goals are:

* Remove the CAgg redundant attributes in the catalog 
* Create an entry in continuous_aggs_bucket_function for all CAggs that use time_bucket

This first commit refactors the continuous_aggs_bucket_function table and prepares it for more generic use. Not all attributes are used yet, but these will change in follow-up PRs.

---
Should be merged after: https://github.com/timescale/timescaledb/pull/6661
Disable-check: force-changelog-file
