### PR TITLE
Remove unused function get_vacuum_options

### DIFF
--- a/src/event_trigger.c
+++ b/src/event_trigger.c
@@ -11,6 +11,7 @@
 #include <catalog/pg_trigger.h>
 #include <commands/event_trigger.h>
 #include <executor/executor.h>
+#include <utils/array.h>
 #include <utils/builtins.h>
 
 #include "compat/compat.h"

--- a/src/utils.h
+++ b/src/utils.h
@@ -41,14 +41,6 @@
 /* find the length of a statically sized array */
 #define TS_ARRAY_LEN(array) (sizeof(array) / sizeof(*array))
 
-/* Use condition to check if out of memory */
-#define TS_OOM_CHECK(COND, FMT, ...)                                                               \
-	do                                                                                             \
-	{                                                                                              \
-		if (!(COND))                                                                               \
-			ereport(ERROR, (errcode(ERRCODE_OUT_OF_MEMORY), errmsg(FMT, ##__VA_ARGS__)));          \
-	} while (0)
-
 extern TSDLLEXPORT bool ts_type_is_int8_binary_compatible(Oid sourcetype);
 
 typedef enum TimevalInfinity

--- a/tsl/src/bgw_policy/job.c
+++ b/tsl/src/bgw_policy/job.c
@@ -8,6 +8,7 @@
 #include <access/xact.h>
 #include <catalog/namespace.h>
 #include <catalog/pg_type.h>
+#include <commands/defrem.h>
 #include <funcapi.h>
 #include <hypertable_cache.h>
 #include <nodes/makefuncs.h>

--- a/tsl/src/partialize_finalize.c
+++ b/tsl/src/partialize_finalize.c
@@ -12,6 +12,7 @@
 #include <fmgr.h>
 #include <parser/parse_agg.h>
 #include <parser/parse_coerce.h>
+#include <utils/array.h>
 #include <utils/builtins.h>
 #include <utils/datum.h>
 #include <utils/fmgroids.h>


### PR DESCRIPTION
The last caller for this was removed as part of multinode removal.