### PR TITLE
Report the PG version and path before complaining it's incorrect

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -342,14 +342,17 @@ else()
 endif()
 set(PG_VERSION "${PG_VERSION_MAJOR}.${PG_VERSION_MINOR}")
 
+message(
+  STATUS
+    "Compiling against PostgreSQL version ${PG_VERSION} using pg_config '${PG_CONFIG}'"
+)
+
 # Ensure that PostgreSQL version is supported and consistent with src/compat.h
 # version check
 if((${PG_VERSION_MAJOR} LESS "13")
    OR (${PG_VERSION_MAJOR} GREATER "16")
    AND NOT (${EXPERIMENTAL}))
   message(FATAL_ERROR "TimescaleDB only supports PostgreSQL 13, 14, 15 and 16")
-else()
-  message(STATUS "Compiling against PostgreSQL version ${PG_VERSION}")
 endif()
 
 # Get PostgreSQL configuration from pg_config


### PR DESCRIPTION
Helps to investigate errors where a wrong PG version gets picked.

Related to https://github.com/timescale/timescaledb/issues/6474

Disable-check: force-changelog-file