### PR TITLE
Avoid excessive reallocation in row compressors 

### DIFF
--- a/src/adts/bit_array.h
+++ b/src/adts/bit_array.h
@@ -25,7 +25,7 @@ typedef struct BitArray BitArray;
 typedef struct BitArrayIterator BitArrayIterator;
 
 /* Main Interface */
-static void bit_array_init(BitArray *array);
+static void bit_array_init(BitArray *array, int expected_bits);
 
 /* Append num_bits to the array */
 static void bit_array_append(BitArray *array, uint8 num_bits, uint64 bits);

--- a/src/adts/bit_array_impl.h
+++ b/src/adts/bit_array_impl.h
@@ -45,12 +45,12 @@ static inline void bit_array_wrap_internal(BitArray *array, uint32 num_buckets,
  ************************/
 
 static inline void
-bit_array_init(BitArray *array)
+bit_array_init(BitArray *array, int expected_bits)
 {
 	*array = (BitArray){
 		.bits_used_in_last_bucket = 0,
 	};
-	uint64_vec_init(&array->buckets, CurrentMemoryContext, 0);
+	uint64_vec_init(&array->buckets, CurrentMemoryContext, expected_bits / 64);
 }
 
 /* This initializes the bit array by wrapping buckets. Note, that the bit array will

--- a/src/adts/vec.h
+++ b/src/adts/vec.h
@@ -110,8 +110,11 @@ VEC_RESERVE(VEC_TYPE *vec, uint32 additional)
 	if (num_new_elements == 0 || vec->num_elements + num_new_elements <= vec->max_elements)
 		return;
 
-	if (num_new_elements < vec->num_elements / 2)
-		num_new_elements = vec->num_elements / 2;
+	if (num_new_elements < vec->num_elements)
+	{
+		/* Follow the usual doubling progression of allocation sizes. */
+		num_new_elements = vec->num_elements;
+	}
 
 	num_elements = vec->num_elements + num_new_elements;
 	Assert(num_elements > vec->num_elements);

--- a/test/src/adt_tests.c
+++ b/test/src/adt_tests.c
@@ -105,7 +105,7 @@ bit_array_test(void)
 	BitArray bits;
 	BitArrayIterator iter;
 	int i;
-	bit_array_init(&bits);
+	bit_array_init(&bits, 0);
 
 	for (i = 0; i < 65; i++)
 		bit_array_append(&bits, i, i);

--- a/tsl/src/compression/simple8b_rle.h
+++ b/tsl/src/compression/simple8b_rle.h
@@ -304,8 +304,20 @@ simple8brle_compressor_init(Simple8bRleCompressor *compressor)
 		.num_elements = 0,
 		.num_uncompressed_elements = 0,
 	};
-	uint64_vec_init(&compressor->compressed_data, CurrentMemoryContext, 0);
-	bit_array_init(&compressor->selectors);
+	/*
+	 * It is good to have some estimate of the resulting size of compressed
+	 * data, because it helps to allocate memory in advance to avoid frequent
+	 * reallocations. Here we use a completely arbitrary but pretty realistic
+	 * ratio of 10.
+	 */
+	const int expected_compression_ratio = 10;
+	uint64_vec_init(&compressor->compressed_data,
+					CurrentMemoryContext,
+					GLOBAL_MAX_ROWS_PER_COMPRESSION / expected_compression_ratio);
+	bit_array_init(&compressor->selectors,
+				   /* expected_bits = */ (GLOBAL_MAX_ROWS_PER_COMPRESSION *
+										  SIMPLE8B_BITS_PER_SELECTOR) /
+					   expected_compression_ratio);
 }
 
 static void


### PR DESCRIPTION
Memory operations can add up to tens of percents of the total
compression CPU load. To reduce the need for them, reserve for the
expected array sizes when initializing the compressor.

Based on measurements in this issue: https://github.com/timescale/Support-Dev-Collab/issues/1498#issuecomment-1936607692

We don't have a dataset which reproduces it well in tsbench, but I think it's a safe change anyway: https://grafana.ops.savannah-dev.timescale.com/d/fasYic_4z/compare-akuzm?orgId=1&var-branch=All&var-run1=3238&var-run2=3239&var-threshold=0.02&var-use_historical_thresholds=true&var-threshold_expression=2.5%20%2A%20percentile_cont%280.90%29&var-exact_suite_version=true


Disable-check: force-changelog-file