### PR TITLE
Remove function ts_number_of_continuous_aggs

### DIFF
--- a/src/ts_catalog/continuous_agg.c
+++ b/src/ts_catalog/continuous_agg.c
@@ -1225,17 +1225,6 @@ ts_continuous_agg_rename_view(const char *old_schema, const char *old_name, cons
 	ts_scanner_scan(&scanctx);
 }
 
-TSDLLEXPORT int32
-ts_number_of_continuous_aggs()
-{
-	int32 count = 0;
-	ScanIterator iterator =
-		ts_scan_iterator_create(CONTINUOUS_AGG, AccessShareLock, CurrentMemoryContext);
-	ts_scanner_foreach(&iterator) { count++; }
-
-	return count;
-}
-
 static int32
 find_raw_hypertable_for_materialization(int32 mat_hypertable_id)
 {

--- a/src/ts_catalog/continuous_agg.h
+++ b/src/ts_catalog/continuous_agg.h
@@ -184,8 +184,6 @@ extern TSDLLEXPORT void ts_continuous_agg_rename_view(const char *old_schema, co
 													  const char *new_schema, const char *new_name,
 													  ObjectType *object_type);
 
-extern TSDLLEXPORT int32 ts_number_of_continuous_aggs(void);
-
 extern TSDLLEXPORT const Dimension *
 ts_continuous_agg_find_integer_now_func_by_materialization_id(int32 mat_htid);
 extern ContinuousAgg *ts_continuous_agg_find_userview_name(const char *schema, const char *name);


### PR DESCRIPTION
This commit removes the unused function ts_number_of_continuous_aggs.

---

Disable-check: force-changelog-file
