### PR TITLE
Remove multinode related GUC

### DIFF
--- a/src/guc.c
+++ b/src/guc.c
@@ -87,7 +87,6 @@ char *ts_telemetry_cloud = NULL;
 TSDLLEXPORT char *ts_guc_license = TS_LICENSE_DEFAULT;
 char *ts_last_tune_time = NULL;
 char *ts_last_tune_version = NULL;
-TSDLLEXPORT int ts_guc_max_insert_batch_size = 1000;
 
 bool ts_guc_debug_require_batch_sorted_merge = false;
 
@@ -449,23 +448,6 @@ _guc_init(void)
 							 NULL,
 							 NULL,
 							 NULL);
-
-	DefineCustomIntVariable("timescaledb.max_insert_batch_size",
-							"The max number of tuples to batch before sending to a data node",
-							"When acting as a access node, TimescaleDB splits batches of "
-							"inserted tuples across multiple data nodes. It will batch up to the "
-							"configured batch size tuples per data node before flushing. "
-							"Setting this to 0 disables batching, reverting to tuple-by-tuple "
-							"inserts",
-							&ts_guc_max_insert_batch_size,
-							1000,
-							0,
-							65536,
-							PGC_USERSET,
-							0,
-							NULL,
-							NULL,
-							NULL);
 
 	DefineCustomBoolVariable("timescaledb.enable_async_append",
 							 "Enable async query execution on data nodes",

--- a/src/guc.h
+++ b/src/guc.h
@@ -56,7 +56,6 @@ extern TSDLLEXPORT char *ts_guc_license;
 extern char *ts_last_tune_time;
 extern char *ts_last_tune_version;
 extern TSDLLEXPORT bool ts_guc_enable_2pc;
-extern TSDLLEXPORT int ts_guc_max_insert_batch_size;
 extern TSDLLEXPORT bool ts_guc_enable_compression_indexscan;
 extern TSDLLEXPORT bool ts_guc_enable_bulk_decompression;
 extern TSDLLEXPORT int ts_guc_bgw_log_level;


### PR DESCRIPTION
Leftover GUC `ts_guc_max_insert_batch_size` from multinode removal.

Disable-check: force-changelog-file