### PR TITLE
Use "unlikely" with Ensure

### DIFF
--- a/src/debug_assert.h
+++ b/src/debug_assert.h
@@ -29,7 +29,7 @@
 #define Ensure(COND, FMT, ...)                                                                     \
 	do                                                                                             \
 	{                                                                                              \
-		if (!(COND))                                                                               \
+		if (!unlikely(COND))                                                                       \
 			ereport(ERROR,                                                                         \
 					(errcode(ERRCODE_INTERNAL_ERROR),                                              \
 					 errdetail("Assertion '" #COND "' failed."),                                   \


### PR DESCRIPTION
Since conditions used with `Ensure` are not expected to fire except in rare circumstances, we should always treat this as unlikely.

Disable-check: force-changelog-file