### PR TITLE
Backport to 2.14.x: #6626: Adjust pg_dump_unprivileged test to only run on versions with fixed pg_dump

### DIFF
--- a/test/expected/pg_dump_unprivileged.out
+++ b/test/expected/pg_dump_unprivileged.out
@@ -9,6 +9,7 @@ CREATE USER dump_unprivileged CREATEDB;
 \c template1 dump_unprivileged
 CREATE database dump_unprivileged;
 \! utils/pg_dump_unprivileged.sh
+Database dumped successfully
 \c dump_unprivileged :ROLE_SUPERUSER
 DROP EXTENSION timescaledb;
 GRANT ALL ON DATABASE dump_unprivileged TO dump_unprivileged;
@@ -18,6 +19,7 @@ CREATE EXTENSION timescaledb;
 CREATE TABLE t1 (a int);
 -- pg_dump currently fails when dumped
 \! utils/pg_dump_unprivileged.sh
+Database dumped successfully
 \c template1 :ROLE_SUPERUSER
 DROP EXTENSION timescaledb;
 DROP DATABASE dump_unprivileged WITH (FORCE);

--- a/test/sql/CMakeLists.txt
+++ b/test/sql/CMakeLists.txt
@@ -36,7 +36,6 @@ set(TEST_FILES
     null_exclusion.sql
     partition.sql
     partitioning.sql
-    pg_dump_unprivileged.sql
     pg_join.sql
     plain.sql
     plan_hypertable_inline.sql
@@ -126,6 +125,19 @@ endif()
 if((${PG_VERSION_MAJOR} GREATER_EQUAL "15"))
   list(APPEND TEST_FILES merge.sql)
   list(APPEND TEST_TEMPLATES ts_merge.sql.in)
+endif()
+
+# pg_dump_unprivileged.sql was fixed by an upstream change to pg_dump in 13.14,
+# 14.11, 15.6, and 16.2
+if(((${PG_VERSION_MAJOR} EQUAL "13") AND (${PG_VERSION_MINOR} GREATER_EQUAL "14"
+                                         ))
+   OR ((${PG_VERSION_MAJOR} EQUAL "14") AND (${PG_VERSION_MINOR} GREATER_EQUAL
+                                             "11"))
+   OR ((${PG_VERSION_MAJOR} EQUAL "15") AND (${PG_VERSION_MINOR} GREATER_EQUAL
+                                             "6"))
+   OR ((${PG_VERSION_MAJOR} EQUAL "16") AND (${PG_VERSION_MINOR} GREATER_EQUAL
+                                             "2")))
+  list(APPEND TEST_FILES pg_dump_unprivileged.sql)
 endif()
 
 # only test custom type if we are in 64-bit architecture


### PR DESCRIPTION
pg_dump_unprivileged.sql was fixed by an upstream change to pg_dump in 13.14, 14.11, 15.6, and 16.2