### PR TITLE
Fix downgrade script to make backports easier

### DIFF
--- a/sql/updates/2.14.0--2.13.1.sql
+++ b/sql/updates/2.14.0--2.13.1.sql
@@ -88,7 +88,7 @@ BEGIN
 
     -- restore columns from the compressed hypertable
     FOR column_name, column_type IN
-      SELECT attname, atttypid::regtype FROM pg_attribute WHERE attrelid = chunk AND attnum > 0
+      SELECT attname, atttypid::regtype FROM pg_attribute WHERE attrelid = chunk AND attnum > 0 AND NOT attisdropped
     LOOP
       cmd := format('ALTER TABLE %s ADD COLUMN %I %s', hypertable, column_name, column_type);
       EXECUTE cmd;


### PR DESCRIPTION
While the downgrade script doesnt combine multiple version into a single script since we only create the script for the previous version, fixing this will make backporting in the release branch easier.