### PR TITLE
Fix segfault in cagg_validate_query

### DIFF
--- a/.unreleased/pr_6655
+++ b/.unreleased/pr_6655
@@ -1,0 +1,2 @@
+Fixes: #6655 Fix segfault in cagg_validate_query
+Thanks: @kav23alex for reporting a segfault in cagg_validate_query

--- a/tsl/src/continuous_aggs/utils.c
+++ b/tsl/src/continuous_aggs/utils.c
@@ -101,7 +101,13 @@ continuous_agg_validate_query(PG_FUNCTION_ARGS)
 
 		tree = pg_parse_query(sql);
 
-		if (list_length(tree) > 1)
+		if (tree == NIL)
+		{
+			edata->elevel = ERROR;
+			edata->sqlerrcode = ERRCODE_INTERNAL_ERROR;
+			edata->message = "failed to parse query";
+		}
+		else if (list_length(tree) > 1)
 		{
 			edata->elevel = WARNING;
 			edata->sqlerrcode = ERRCODE_FEATURE_NOT_SUPPORTED;

--- a/tsl/test/expected/cagg_utils.out
+++ b/tsl/test/expected/cagg_utils.out
@@ -39,6 +39,25 @@ SELECT * FROM cagg_validate_query(NULL);
           |             |            |               |              | 
 (1 row)
 
+-- nothing to parse
+SELECT * FROM cagg_validate_query('');
+ is_valid | error_level | error_code |     error_message     | error_detail | error_hint 
+----------+-------------+------------+-----------------------+--------------+------------
+ f        | ERROR       | XX000      | failed to parse query |              | 
+(1 row)
+
+SELECT * FROM cagg_validate_query('--');
+ is_valid | error_level | error_code |     error_message     | error_detail | error_hint 
+----------+-------------+------------+-----------------------+--------------+------------
+ f        | ERROR       | XX000      | failed to parse query |              | 
+(1 row)
+
+SELECT * FROM cagg_validate_query(';');
+ is_valid | error_level | error_code |     error_message     | error_detail | error_hint 
+----------+-------------+------------+-----------------------+--------------+------------
+ f        | ERROR       | XX000      | failed to parse query |              | 
+(1 row)
+
 -- syntax error
 SELECT * FROM cagg_validate_query('blahh');
  is_valid | error_level | error_code |          error_message          | error_detail | error_hint 

--- a/tsl/test/sql/cagg_utils.sql
+++ b/tsl/test/sql/cagg_utils.sql
@@ -38,6 +38,11 @@ WITH NO DATA;
 -- return NULL
 SELECT * FROM cagg_validate_query(NULL);
 
+-- nothing to parse
+SELECT * FROM cagg_validate_query('');
+SELECT * FROM cagg_validate_query('--');
+SELECT * FROM cagg_validate_query(';');
+
 -- syntax error
 SELECT * FROM cagg_validate_query('blahh');
 SELECT * FROM cagg_validate_query($$ SELECT time_bucket(blahh "time") FROM metrics GROUP BY 1 $$);


### PR DESCRIPTION
With the input to pg_parse_query does not contain anything to parse it will return NIL. This patch adds a check for NIL to prevent the segfault that would otherwise happen later in the code.

Fixes: #6625