### PR TITLE
Fix refresh on empty CAgg with variable bucket

### DIFF
--- a/.unreleased/bugfix_6660
+++ b/.unreleased/bugfix_6660
@@ -1,0 +1,1 @@
+Fixes: #6660 Fix refresh on empty CAgg with variable bucket

--- a/tsl/test/expected/cagg_invalidation.out
+++ b/tsl/test/expected/cagg_invalidation.out
@@ -1226,3 +1226,52 @@ CALL refresh_continuous_aggregate('cond_10', 0, 200);
 WARNING:  invalid value for session variable "timescaledb.materializations_per_refresh_window"
 DETAIL:  Expected an integer but current value is "-".
 \set VERBOSITY terse
+-- Test refresh with undefined invalidation threshold and variable sized buckets
+CREATE TABLE timestamp_ht (
+  time timestamptz NOT NULL,
+  value float
+);
+SELECT create_hypertable('timestamp_ht', 'time');
+     create_hypertable     
+---------------------------
+ (9,public,timestamp_ht,t)
+(1 row)
+
+CREATE MATERIALIZED VIEW temperature_4h
+  WITH  (timescaledb.continuous) AS
+  SELECT time_bucket('4 hour', time), avg(value)
+    FROM timestamp_ht
+    GROUP BY 1 ORDER BY 1;
+NOTICE:  continuous aggregate "temperature_4h" is already up-to-date
+-- We also treat time_buckets with an hourly interval that uses a time-zone
+-- as a variable see caggtimebucket_validate().
+CREATE MATERIALIZED VIEW temperature_4h_2
+  WITH  (timescaledb.continuous) AS
+  SELECT time_bucket('4 hour', time, 'Europe/Berlin') AS bucket_4h, avg(value) AS average
+    FROM timestamp_ht
+    GROUP BY 1 ORDER BY 1;
+NOTICE:  continuous aggregate "temperature_4h_2" is already up-to-date
+CREATE MATERIALIZED VIEW temperature_1month
+  WITH  (timescaledb.continuous) AS
+  SELECT time_bucket('1 month', time), avg(value)
+    FROM timestamp_ht
+    GROUP BY 1 ORDER BY 1;
+NOTICE:  continuous aggregate "temperature_1month" is already up-to-date
+CREATE MATERIALIZED VIEW temperature_1month_ts
+  WITH  (timescaledb.continuous) AS
+  SELECT time_bucket('1 month', time, 'Europe/Berlin'), avg(value)
+    FROM timestamp_ht
+    GROUP BY 1 ORDER BY 1;
+NOTICE:  continuous aggregate "temperature_1month_ts" is already up-to-date
+CREATE MATERIALIZED VIEW temperature_1month_hierarchical
+  WITH  (timescaledb.continuous) AS
+  SELECT time_bucket('1 month', bucket_4h), avg(average)
+    FROM temperature_4h_2
+    GROUP BY 1 ORDER BY 1;
+NOTICE:  continuous aggregate "temperature_1month_hierarchical" is already up-to-date
+CREATE MATERIALIZED VIEW temperature_1month_hierarchical_ts
+  WITH  (timescaledb.continuous) AS
+  SELECT time_bucket('1 month', bucket_4h, 'Europe/Berlin'), avg(average)
+    FROM temperature_4h_2
+    GROUP BY 1 ORDER BY 1;
+NOTICE:  continuous aggregate "temperature_1month_hierarchical_ts" is already up-to-date


### PR DESCRIPTION
So far, we have not handled CAggs with variable buckets correctly. The CAgg refresh on a hypertable without any data lead to the error message "timestamp out of range". This patch fixes the problem by declaring empty CAggs as up-to-date.