### PR TITLE
Use compressed chunk tupdesc to check which metadata columns we have

### DIFF
--- a/tsl/src/compression/create.h
+++ b/tsl/src/compression/create.h
@@ -17,6 +17,7 @@
 	COMPRESSION_COLUMN_METADATA_PREFIX "sequence_num"
 #define COMPRESSION_COLUMN_METADATA_MIN_COLUMN_NAME "min"
 #define COMPRESSION_COLUMN_METADATA_MAX_COLUMN_NAME "max"
+#define COMPRESSION_COLUMN_METADATA_PATTERN_V1 "_ts_meta_%s_%d"
 
 bool tsl_process_compress_table(AlterTableCmd *cmd, Hypertable *ht,
 								WithClauseResult *with_clause_options);
@@ -27,3 +28,8 @@ Chunk *create_compress_chunk(Hypertable *compress_ht, Chunk *src_chunk, Oid tabl
 
 char *column_segment_min_name(int16 column_index);
 char *column_segment_max_name(int16 column_index);
+
+typedef struct CompressionSettings CompressionSettings;
+int compressed_column_metadata_attno(CompressionSettings *settings, Oid chunk_reloid,
+									 AttrNumber chunk_attno, Oid compressed_reloid,
+									 char *metadata_type);


### PR DESCRIPTION
The compressed qual pushdown will look at presence of metadata columns in the compressed chunk, not at whether the uncompressed column is an orderby. This way, the decision on which columns have metadata is made only during the creation of compressed chunk.

This doesn't introduce any behavior changes, just changes the decision about which columns have metadata to happen in a single place. This will simplify experimenting with configurable metadata columns.