### PR TITLE
Don't try to compress osm chunks

### DIFF
--- a/sql/policy_internal.sql
+++ b/sql/policy_internal.sql
@@ -95,7 +95,7 @@ BEGIN
       INNER JOIN pg_namespace pgns ON pgc.relnamespace = pgns.oid
       INNER JOIN _timescaledb_catalog.chunk ch ON ch.table_name = pgc.relname AND ch.schema_name = pgns.nspname AND ch.hypertable_id = htid
     WHERE
-      ch.dropped IS FALSE
+      NOT ch.dropped AND NOT ch.osm_chunk
       AND (
         ch.status = 0 OR
         (

--- a/tsl/src/chunk.c
+++ b/tsl/src/chunk.c
@@ -58,7 +58,7 @@ chunk_freeze_chunk(PG_FUNCTION_ARGS)
 	{
 		ereport(ERROR,
 				(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
-				 errmsg("operation not supported on distributed chunk or foreign table \"%s\"",
+				 errmsg("operation not supported on tiered chunk \"%s\"",
 						get_rel_name(chunk_relid))));
 	}
 	if (ts_chunk_is_frozen(chunk))

--- a/tsl/src/compression/compression.c
+++ b/tsl/src/compression/compression.c
@@ -281,6 +281,10 @@ compress_chunk(Oid in_table, Oid out_table, int insert_options)
 	 */
 	Relation out_rel = relation_open(out_table, ExclusiveLock);
 
+	/* Sanity check we are dealing with relations */
+	Ensure(in_rel->rd_rel->relkind == RELKIND_RELATION, "compress_chunk called on non-relation");
+	Ensure(out_rel->rd_rel->relkind == RELKIND_RELATION, "compress_chunk called on non-relation");
+
 	TupleDesc in_desc = RelationGetDescr(in_rel);
 	TupleDesc out_desc = RelationGetDescr(out_rel);
 	/* Before calling row compressor relation should be segmented and sorted as configured

--- a/tsl/test/expected/compression_errors-13.out
+++ b/tsl/test/expected/compression_errors-13.out
@@ -810,3 +810,16 @@ ALTER TABLE table_unique_index SET (timescaledb.compress, timescaledb.compress_s
 ALTER TABLE table_unique_index SET (timescaledb.compress = off);
 ALTER TABLE table_unique_index SET (timescaledb.compress, timescaledb.compress_segmentby = 'time,location,device_id');
 ALTER TABLE table_unique_index SET (timescaledb.compress = off);
+-- try compressing osm chunk
+CREATE TABLE osm_table (time timestamptz NOT NULL, device_id text, value float);
+SELECT table_name FROM create_hypertable('osm_table', 'time');
+ table_name 
+------------
+ osm_table
+(1 row)
+
+ALTER TABLE osm_table SET (timescaledb.compress);
+INSERT INTO osm_table VALUES ('2022-11-11 11:11:11', 'foo', 1.0);
+UPDATE _timescaledb_catalog.chunk ch SET osm_chunk = true FROM _timescaledb_catalog.hypertable ht WHERE ch.hypertable_id = ht.id AND ht.table_name='osm_table';
+SELECT compress_chunk(show_chunks('osm_table'));
+ERROR:  compress_chunk not permitted on tiered chunk "_hyper_43_31_chunk" 

--- a/tsl/test/expected/compression_errors-14.out
+++ b/tsl/test/expected/compression_errors-14.out
@@ -810,3 +810,16 @@ ALTER TABLE table_unique_index SET (timescaledb.compress, timescaledb.compress_s
 ALTER TABLE table_unique_index SET (timescaledb.compress = off);
 ALTER TABLE table_unique_index SET (timescaledb.compress, timescaledb.compress_segmentby = 'time,location,device_id');
 ALTER TABLE table_unique_index SET (timescaledb.compress = off);
+-- try compressing osm chunk
+CREATE TABLE osm_table (time timestamptz NOT NULL, device_id text, value float);
+SELECT table_name FROM create_hypertable('osm_table', 'time');
+ table_name 
+------------
+ osm_table
+(1 row)
+
+ALTER TABLE osm_table SET (timescaledb.compress);
+INSERT INTO osm_table VALUES ('2022-11-11 11:11:11', 'foo', 1.0);
+UPDATE _timescaledb_catalog.chunk ch SET osm_chunk = true FROM _timescaledb_catalog.hypertable ht WHERE ch.hypertable_id = ht.id AND ht.table_name='osm_table';
+SELECT compress_chunk(show_chunks('osm_table'));
+ERROR:  compress_chunk not permitted on tiered chunk "_hyper_43_31_chunk" 

--- a/tsl/test/expected/compression_errors-15.out
+++ b/tsl/test/expected/compression_errors-15.out
@@ -810,3 +810,16 @@ ALTER TABLE table_unique_index SET (timescaledb.compress, timescaledb.compress_s
 ALTER TABLE table_unique_index SET (timescaledb.compress = off);
 ALTER TABLE table_unique_index SET (timescaledb.compress, timescaledb.compress_segmentby = 'time,location,device_id');
 ALTER TABLE table_unique_index SET (timescaledb.compress = off);
+-- try compressing osm chunk
+CREATE TABLE osm_table (time timestamptz NOT NULL, device_id text, value float);
+SELECT table_name FROM create_hypertable('osm_table', 'time');
+ table_name 
+------------
+ osm_table
+(1 row)
+
+ALTER TABLE osm_table SET (timescaledb.compress);
+INSERT INTO osm_table VALUES ('2022-11-11 11:11:11', 'foo', 1.0);
+UPDATE _timescaledb_catalog.chunk ch SET osm_chunk = true FROM _timescaledb_catalog.hypertable ht WHERE ch.hypertable_id = ht.id AND ht.table_name='osm_table';
+SELECT compress_chunk(show_chunks('osm_table'));
+ERROR:  compress_chunk not permitted on tiered chunk "_hyper_43_31_chunk" 

--- a/tsl/test/expected/compression_errors-16.out
+++ b/tsl/test/expected/compression_errors-16.out
@@ -810,3 +810,16 @@ ALTER TABLE table_unique_index SET (timescaledb.compress, timescaledb.compress_s
 ALTER TABLE table_unique_index SET (timescaledb.compress = off);
 ALTER TABLE table_unique_index SET (timescaledb.compress, timescaledb.compress_segmentby = 'time,location,device_id');
 ALTER TABLE table_unique_index SET (timescaledb.compress = off);
+-- try compressing osm chunk
+CREATE TABLE osm_table (time timestamptz NOT NULL, device_id text, value float);
+SELECT table_name FROM create_hypertable('osm_table', 'time');
+ table_name 
+------------
+ osm_table
+(1 row)
+
+ALTER TABLE osm_table SET (timescaledb.compress);
+INSERT INTO osm_table VALUES ('2022-11-11 11:11:11', 'foo', 1.0);
+UPDATE _timescaledb_catalog.chunk ch SET osm_chunk = true FROM _timescaledb_catalog.hypertable ht WHERE ch.hypertable_id = ht.id AND ht.table_name='osm_table';
+SELECT compress_chunk(show_chunks('osm_table'));
+ERROR:  compress_chunk not permitted on tiered chunk "_hyper_43_31_chunk" 

--- a/tsl/test/sql/compression_errors.sql.in
+++ b/tsl/test/sql/compression_errors.sql.in
@@ -500,3 +500,14 @@ ALTER TABLE table_unique_index SET (timescaledb.compress = off);
 ALTER TABLE table_unique_index SET (timescaledb.compress, timescaledb.compress_segmentby = 'time,location,device_id');
 ALTER TABLE table_unique_index SET (timescaledb.compress = off);
 
+-- try compressing osm chunk
+CREATE TABLE osm_table (time timestamptz NOT NULL, device_id text, value float);
+SELECT table_name FROM create_hypertable('osm_table', 'time');
+ALTER TABLE osm_table SET (timescaledb.compress);
+
+INSERT INTO osm_table VALUES ('2022-11-11 11:11:11', 'foo', 1.0);
+
+UPDATE _timescaledb_catalog.chunk ch SET osm_chunk = true FROM _timescaledb_catalog.hypertable ht WHERE ch.hypertable_id = ht.id AND ht.table_name='osm_table';
+
+SELECT compress_chunk(show_chunks('osm_table'));
+


### PR DESCRIPTION
This patch filters out the osm chunk in the compression policy and adds some additional checks so we dont run compress_chunk on osm chunks.