### PR TITLE
Grant write permissions to pr handling workflow

### DIFF
--- a/.github/workflows/pr-handling.yaml
+++ b/.github/workflows/pr-handling.yaml
@@ -17,6 +17,8 @@ name: Assign PR to author and reviewers
 jobs:
   assign-pr:
     name: Assign PR to author
+    permissions:
+      contents: write
     runs-on: ubuntu-latest
     steps:
       - uses: toshimaru/auto-author-assign@v2.1.0


### PR DESCRIPTION
The job assigning PR needs write permissions and the pull requests to function.