### PR TITLE
Adjust PR handling workflow permissions

### DIFF
--- a/.github/workflows/pr-handling.yaml
+++ b/.github/workflows/pr-handling.yaml
@@ -18,7 +18,8 @@ jobs:
   assign-pr:
     name: Assign PR to author
     permissions:
-      contents: write
+      contents: read
+      pull-requests: write
     runs-on: ubuntu-latest
     steps:
       - uses: toshimaru/auto-author-assign@v2.1.0


### PR DESCRIPTION
Any key not present in the permissions will be set to none so we need contents:read even though that is the default.

https://github.blog/changelog/2021-04-20-github-actions-control-permissions-for-github_token/