### PR TITLE
Fix snapshot usage in CAgg invalidation scanner

### DIFF
--- a/.unreleased/bugfix_6677
+++ b/.unreleased/bugfix_6677
@@ -1,0 +1,1 @@
+Fixes: #6677 Fix snapshot usage in CAgg invalidation scanner 

--- a/test/runner_isolation.sh
+++ b/test/runner_isolation.sh
@@ -13,5 +13,5 @@ shift
 
 $ISOLATIONTEST "$@" | \
    sed -e 's!_[0-9]\{1,\}_[0-9]\{1,\}_chunk!_X_X_chunk!g' | \
-   sed -e 's!hypertable_[0-9]\{1,\}_!hypertable_X_!g'
+   sed -e 's!hypertable_[0-9]\{1,\}!hypertable_X!g'
  

--- a/tsl/src/continuous_aggs/common.h
+++ b/tsl/src/continuous_aggs/common.h
@@ -38,6 +38,7 @@
 
 #define CONTINUOUS_AGG_MAX_JOIN_RELATIONS 2
 #define DEFAULT_MATPARTCOLUMN_NAME "time_partition_col"
+#define CAGG_INVALIDATION_THRESHOLD_NAME "invalidation threshold watermark"
 
 typedef struct FinalizeQueryInfo
 {

--- a/tsl/src/continuous_aggs/invalidation_threshold.c
+++ b/tsl/src/continuous_aggs/invalidation_threshold.c
@@ -202,7 +202,7 @@ invalidation_threshold_set_or_get(const ContinuousAgg *cagg,
 				F_INT4EQ,
 				Int32GetDatum(cagg->data.raw_hypertable_id));
 
-	found = ts_scanner_scan_one(&scanctx, false, "invalidation threshold");
+	found = ts_scanner_scan_one(&scanctx, false, CAGG_INVALIDATION_THRESHOLD_NAME);
 	Ensure(found,
 		   "invalidation threshold for hypertable %d not found",
 		   cagg->data.raw_hypertable_id);
@@ -308,7 +308,7 @@ invalidation_threshold_initialize(const ContinuousAgg *cagg)
 				F_INT4EQ,
 				Int32GetDatum(cagg->data.raw_hypertable_id));
 
-	found = ts_scanner_scan_one(&scanctx, false, "invalidation threshold");
+	found = ts_scanner_scan_one(&scanctx, false, CAGG_INVALIDATION_THRESHOLD_NAME);
 
 	if (!found)
 	{

--- a/tsl/test/isolation/expected/cagg_concurrent_invalidation.out
+++ b/tsl/test/isolation/expected/cagg_concurrent_invalidation.out
@@ -10,10 +10,10 @@ debug_waitpoint_enable
 (1 row)
 
 step s1_run_update: 
-   CALL refresh_continuous_aggregate('cagg_1', '2020-01-01 00:00:00', '2021-01-01 00:00:00');
+   CALL refresh_continuous_aggregate('cagg_1', '2020-01-01 00:00:00', '2025-01-01 00:00:00');
  <waiting ...>
 step s2_run_update: 
-   CALL refresh_continuous_aggregate('cagg_2', '2020-01-01 00:00:00', '2021-01-01 00:00:00');
+   CALL refresh_continuous_aggregate('cagg_2', '2020-01-01 00:00:00', '2025-01-01 00:00:00');
  <waiting ...>
 step s3_release_invalidation: 
    SELECT debug_waitpoint_release('invalidation_threshold_scan_update_enter');
@@ -36,3 +36,37 @@ Wed Jan 01 16:00:00 2020 PST
 Wed Jan 01 16:00:00 2020 PST
 (2 rows)
 
+
+starting permutation: s2_insert_new_data_2022 s3_lock_invalidation_tuple_found s2_insert_new_data_2023 s1_run_update s3_release_invalidation_tuple_found
+step s2_insert_new_data_2022: 
+  INSERT INTO temperature
+    SELECT time, ceil(random() * 100)::int
+      FROM generate_series('2022-01-01 0:00:00+0'::timestamptz,
+                          '2022-01-01 23:59:59+0','1m') time;
+
+step s3_lock_invalidation_tuple_found: 
+   SELECT debug_waitpoint_enable('invalidation_tuple_found_done');
+
+debug_waitpoint_enable
+----------------------
+                      
+(1 row)
+
+step s2_insert_new_data_2023: 
+  INSERT INTO temperature
+    SELECT time, ceil(random() * 100)::int
+      FROM generate_series('2023-01-01 0:00:00+0'::timestamptz,
+                          '2023-01-01 23:59:59+0','1m') time;
+ <waiting ...>
+step s1_run_update: 
+   CALL refresh_continuous_aggregate('cagg_1', '2020-01-01 00:00:00', '2025-01-01 00:00:00');
+
+step s3_release_invalidation_tuple_found: 
+   SELECT debug_waitpoint_release('invalidation_tuple_found_done');
+
+debug_waitpoint_release
+-----------------------
+                       
+(1 row)
+
+step s2_insert_new_data_2023: <... completed>

--- a/tsl/test/isolation/expected/cagg_watermark_concurrent_update.out
+++ b/tsl/test/isolation/expected/cagg_watermark_concurrent_update.out
@@ -71,9 +71,9 @@ step s2_select:
 QUERY PLAN                                                                                                                   
 -----------------------------------------------------------------------------------------------------------------------------
 Merge Append                                                                                                                 
-  Sort Key: _materialized_hypertable_140.time_bucket                                                                         
-  ->  Custom Scan (ChunkAppend) on _materialized_hypertable_140                                                              
-        Order: _materialized_hypertable_140.time_bucket                                                                      
+  Sort Key: _materialized_hypertable_X.time_bucket                                                                         
+  ->  Custom Scan (ChunkAppend) on _materialized_hypertable_X                                                              
+        Order: _materialized_hypertable_X.time_bucket                                                                      
         ->  Index Scan Backward using _hyper_X_X_chunk__materialized_hypertable_X_time_bucket_i on _hyper_X_X_chunk
               Index Cond: (time_bucket < 'Wed Jan 01 16:00:00 2020 PST'::timestamp with time zone)                           
         ->  Index Scan Backward using _hyper_X_X_chunk__materialized_hypertable_X_time_bucket_i on _hyper_X_X_chunk
@@ -92,9 +92,9 @@ step s1_select:
 QUERY PLAN                                                                                                                   
 -----------------------------------------------------------------------------------------------------------------------------
 Merge Append                                                                                                                 
-  Sort Key: _materialized_hypertable_140.time_bucket                                                                         
-  ->  Custom Scan (ChunkAppend) on _materialized_hypertable_140                                                              
-        Order: _materialized_hypertable_140.time_bucket                                                                      
+  Sort Key: _materialized_hypertable_X.time_bucket                                                                         
+  ->  Custom Scan (ChunkAppend) on _materialized_hypertable_X                                                              
+        Order: _materialized_hypertable_X.time_bucket                                                                      
         ->  Index Scan Backward using _hyper_X_X_chunk__materialized_hypertable_X_time_bucket_i on _hyper_X_X_chunk
               Index Cond: (time_bucket < 'Wed Jan 01 16:00:00 2020 PST'::timestamp with time zone)                           
         ->  Index Scan Backward using _hyper_X_X_chunk__materialized_hypertable_X_time_bucket_i on _hyper_X_X_chunk
@@ -187,9 +187,9 @@ step s2_select:
 QUERY PLAN                                                                                                                   
 -----------------------------------------------------------------------------------------------------------------------------
 Merge Append                                                                                                                 
-  Sort Key: _materialized_hypertable_142.time_bucket                                                                         
-  ->  Custom Scan (ChunkAppend) on _materialized_hypertable_142                                                              
-        Order: _materialized_hypertable_142.time_bucket                                                                      
+  Sort Key: _materialized_hypertable_X.time_bucket                                                                         
+  ->  Custom Scan (ChunkAppend) on _materialized_hypertable_X                                                              
+        Order: _materialized_hypertable_X.time_bucket                                                                      
         ->  Index Scan Backward using _hyper_X_X_chunk__materialized_hypertable_X_time_bucket_i on _hyper_X_X_chunk
               Index Cond: (time_bucket < 'Wed Jan 01 16:00:00 2020 PST'::timestamp with time zone)                           
         ->  Index Scan Backward using _hyper_X_X_chunk__materialized_hypertable_X_time_bucket_i on _hyper_X_X_chunk
@@ -216,9 +216,9 @@ step s2_select:
 QUERY PLAN                                                                                                                   
 -----------------------------------------------------------------------------------------------------------------------------
 Merge Append                                                                                                                 
-  Sort Key: _materialized_hypertable_142.time_bucket                                                                         
-  ->  Custom Scan (ChunkAppend) on _materialized_hypertable_142                                                              
-        Order: _materialized_hypertable_142.time_bucket                                                                      
+  Sort Key: _materialized_hypertable_X.time_bucket                                                                         
+  ->  Custom Scan (ChunkAppend) on _materialized_hypertable_X                                                              
+        Order: _materialized_hypertable_X.time_bucket                                                                      
         ->  Index Scan Backward using _hyper_X_X_chunk__materialized_hypertable_X_time_bucket_i on _hyper_X_X_chunk
               Index Cond: (time_bucket < 'Thu Jan 02 16:00:00 2020 PST'::timestamp with time zone)                           
         ->  Index Scan Backward using _hyper_X_X_chunk__materialized_hypertable_X_time_bucket_i on _hyper_X_X_chunk

--- a/tsl/test/isolation/expected/cagg_watermark_concurrent_update_1.out
+++ b/tsl/test/isolation/expected/cagg_watermark_concurrent_update_1.out
@@ -73,9 +73,9 @@ step s2_select:
 QUERY PLAN                                                                                                                   
 -----------------------------------------------------------------------------------------------------------------------------
 Merge Append                                                                                                                 
-  Sort Key: _materialized_hypertable_140.time_bucket                                                                         
-  ->  Custom Scan (ChunkAppend) on _materialized_hypertable_140                                                              
-        Order: _materialized_hypertable_140.time_bucket                                                                      
+  Sort Key: _materialized_hypertable_X.time_bucket                                                                         
+  ->  Custom Scan (ChunkAppend) on _materialized_hypertable_X                                                              
+        Order: _materialized_hypertable_X.time_bucket                                                                      
         ->  Index Scan Backward using _hyper_X_X_chunk__materialized_hypertable_X_time_bucket_i on _hyper_X_X_chunk
               Index Cond: (time_bucket < 'Wed Jan 01 16:00:00 2020 PST'::timestamp with time zone)                           
         ->  Index Scan Backward using _hyper_X_X_chunk__materialized_hypertable_X_time_bucket_i on _hyper_X_X_chunk
@@ -94,9 +94,9 @@ step s1_select:
 QUERY PLAN                                                                                                                   
 -----------------------------------------------------------------------------------------------------------------------------
 Merge Append                                                                                                                 
-  Sort Key: _materialized_hypertable_140.time_bucket                                                                         
-  ->  Custom Scan (ChunkAppend) on _materialized_hypertable_140                                                              
-        Order: _materialized_hypertable_140.time_bucket                                                                      
+  Sort Key: _materialized_hypertable_X.time_bucket                                                                         
+  ->  Custom Scan (ChunkAppend) on _materialized_hypertable_X                                                              
+        Order: _materialized_hypertable_X.time_bucket                                                                      
         ->  Index Scan Backward using _hyper_X_X_chunk__materialized_hypertable_X_time_bucket_i on _hyper_X_X_chunk
               Index Cond: (time_bucket < 'Wed Jan 01 16:00:00 2020 PST'::timestamp with time zone)                           
         ->  Index Scan Backward using _hyper_X_X_chunk__materialized_hypertable_X_time_bucket_i on _hyper_X_X_chunk
@@ -191,9 +191,9 @@ step s2_select:
 QUERY PLAN                                                                                                                   
 -----------------------------------------------------------------------------------------------------------------------------
 Merge Append                                                                                                                 
-  Sort Key: _materialized_hypertable_142.time_bucket                                                                         
-  ->  Custom Scan (ChunkAppend) on _materialized_hypertable_142                                                              
-        Order: _materialized_hypertable_142.time_bucket                                                                      
+  Sort Key: _materialized_hypertable_X.time_bucket                                                                         
+  ->  Custom Scan (ChunkAppend) on _materialized_hypertable_X                                                              
+        Order: _materialized_hypertable_X.time_bucket                                                                      
         ->  Index Scan Backward using _hyper_X_X_chunk__materialized_hypertable_X_time_bucket_i on _hyper_X_X_chunk
               Index Cond: (time_bucket < 'Wed Jan 01 16:00:00 2020 PST'::timestamp with time zone)                           
         ->  Index Scan Backward using _hyper_X_X_chunk__materialized_hypertable_X_time_bucket_i on _hyper_X_X_chunk
@@ -220,9 +220,9 @@ step s2_select:
 QUERY PLAN                                                                                                                   
 -----------------------------------------------------------------------------------------------------------------------------
 Merge Append                                                                                                                 
-  Sort Key: _materialized_hypertable_142.time_bucket                                                                         
-  ->  Custom Scan (ChunkAppend) on _materialized_hypertable_142                                                              
-        Order: _materialized_hypertable_142.time_bucket                                                                      
+  Sort Key: _materialized_hypertable_X.time_bucket                                                                         
+  ->  Custom Scan (ChunkAppend) on _materialized_hypertable_X                                                              
+        Order: _materialized_hypertable_X.time_bucket                                                                      
         ->  Index Scan Backward using _hyper_X_X_chunk__materialized_hypertable_X_time_bucket_i on _hyper_X_X_chunk
               Index Cond: (time_bucket < 'Thu Jan 02 16:00:00 2020 PST'::timestamp with time zone)                           
         ->  Index Scan Backward using _hyper_X_X_chunk__materialized_hypertable_X_time_bucket_i on _hyper_X_X_chunk


### PR DESCRIPTION
So far, the scanner in `get_lowest_invalidated_time_for_hypertable()` used a Snapshot that includes the data of all committed transactions (and not only the transactions that are started before the snapshot was created - `SNAPSHOT_SELF`). This could lead to a situation where we see the old and the new value of a parallel updated tuple. Since `get_lowest_invalidated_time_for_hypertable() `expects exactly one tuple to be found during the scan, we end up with an error. Since this is performed in our insert path (i.e., it is executed by the invalidation trigger), this error could reject inserts on the hypertable (`ERROR: more than one invalidation watermark found`).

---

Should be merged after: https://github.com/timescale/timescaledb/pull/6678
