### PR TITLE
Make isolation tests more robust

### DIFF
--- a/test/runner_isolation.sh
+++ b/test/runner_isolation.sh
@@ -12,5 +12,6 @@ ISOLATIONTEST=$1
 shift
 
 $ISOLATIONTEST "$@" | \
-   sed -e 's!_[0-9]\{1,\}_[0-9]\{1,\}_chunk!_X_X_chunk!g'
+   sed -e 's!_[0-9]\{1,\}_[0-9]\{1,\}_chunk!_X_X_chunk!g' | \
+   sed -e 's!hypertable_[0-9]\{1,\}_!hypertable_X_!g'
  

--- a/tsl/test/isolation/expected/cagg_watermark_concurrent_update.out
+++ b/tsl/test/isolation/expected/cagg_watermark_concurrent_update.out
@@ -22,7 +22,7 @@ QUERY PLAN
 -----------------------------------------------------------------------------------------------------------------------
 Merge Append                                                                                                           
   Sort Key: _hyper_X_X_chunk.time_bucket                                                                           
-  ->  Index Scan Backward using _hyper_X_X_chunk__materialized_hypertable_140_time_bucket_i on _hyper_X_X_chunk
+  ->  Index Scan Backward using _hyper_X_X_chunk__materialized_hypertable_X_time_bucket_i on _hyper_X_X_chunk
         Index Cond: (time_bucket < 'Sat Jan 01 16:00:00 2000 PST'::timestamp with time zone)                           
   ->  GroupAggregate                                                                                                   
         Group Key: (time_bucket('@ 4 hours'::interval, temperature."time"))                                            
@@ -44,7 +44,7 @@ QUERY PLAN
 -----------------------------------------------------------------------------------------------------------------------
 Merge Append                                                                                                           
   Sort Key: _hyper_X_X_chunk.time_bucket                                                                           
-  ->  Index Scan Backward using _hyper_X_X_chunk__materialized_hypertable_140_time_bucket_i on _hyper_X_X_chunk
+  ->  Index Scan Backward using _hyper_X_X_chunk__materialized_hypertable_X_time_bucket_i on _hyper_X_X_chunk
         Index Cond: (time_bucket < 'Sat Jan 01 16:00:00 2000 PST'::timestamp with time zone)                           
   ->  GroupAggregate                                                                                                   
         Group Key: (time_bucket('@ 4 hours'::interval, temperature."time"))                                            
@@ -74,9 +74,9 @@ Merge Append
   Sort Key: _materialized_hypertable_140.time_bucket                                                                         
   ->  Custom Scan (ChunkAppend) on _materialized_hypertable_140                                                              
         Order: _materialized_hypertable_140.time_bucket                                                                      
-        ->  Index Scan Backward using _hyper_X_X_chunk__materialized_hypertable_140_time_bucket_i on _hyper_X_X_chunk
+        ->  Index Scan Backward using _hyper_X_X_chunk__materialized_hypertable_X_time_bucket_i on _hyper_X_X_chunk
               Index Cond: (time_bucket < 'Wed Jan 01 16:00:00 2020 PST'::timestamp with time zone)                           
-        ->  Index Scan Backward using _hyper_X_X_chunk__materialized_hypertable_140_time_bucket_i on _hyper_X_X_chunk
+        ->  Index Scan Backward using _hyper_X_X_chunk__materialized_hypertable_X_time_bucket_i on _hyper_X_X_chunk
               Index Cond: (time_bucket < 'Wed Jan 01 16:00:00 2020 PST'::timestamp with time zone)                           
   ->  GroupAggregate                                                                                                         
         Group Key: (time_bucket('@ 4 hours'::interval, "time"))                                                              
@@ -95,9 +95,9 @@ Merge Append
   Sort Key: _materialized_hypertable_140.time_bucket                                                                         
   ->  Custom Scan (ChunkAppend) on _materialized_hypertable_140                                                              
         Order: _materialized_hypertable_140.time_bucket                                                                      
-        ->  Index Scan Backward using _hyper_X_X_chunk__materialized_hypertable_140_time_bucket_i on _hyper_X_X_chunk
+        ->  Index Scan Backward using _hyper_X_X_chunk__materialized_hypertable_X_time_bucket_i on _hyper_X_X_chunk
               Index Cond: (time_bucket < 'Wed Jan 01 16:00:00 2020 PST'::timestamp with time zone)                           
-        ->  Index Scan Backward using _hyper_X_X_chunk__materialized_hypertable_140_time_bucket_i on _hyper_X_X_chunk
+        ->  Index Scan Backward using _hyper_X_X_chunk__materialized_hypertable_X_time_bucket_i on _hyper_X_X_chunk
               Index Cond: (time_bucket < 'Wed Jan 01 16:00:00 2020 PST'::timestamp with time zone)                           
   ->  GroupAggregate                                                                                                         
         Group Key: (time_bucket('@ 4 hours'::interval, "time"))                                                              
@@ -124,7 +124,7 @@ QUERY PLAN
 -----------------------------------------------------------------------------------------------------------------------
 Merge Append                                                                                                           
   Sort Key: _hyper_X_X_chunk.time_bucket                                                                           
-  ->  Index Scan Backward using _hyper_X_X_chunk__materialized_hypertable_142_time_bucket_i on _hyper_X_X_chunk
+  ->  Index Scan Backward using _hyper_X_X_chunk__materialized_hypertable_X_time_bucket_i on _hyper_X_X_chunk
         Index Cond: (time_bucket < 'Sat Jan 01 16:00:00 2000 PST'::timestamp with time zone)                           
   ->  GroupAggregate                                                                                                   
         Group Key: (time_bucket('@ 4 hours'::interval, temperature."time"))                                            
@@ -146,7 +146,7 @@ QUERY PLAN
 -----------------------------------------------------------------------------------------------------------------------
 Merge Append                                                                                                           
   Sort Key: _hyper_X_X_chunk.time_bucket                                                                           
-  ->  Index Scan Backward using _hyper_X_X_chunk__materialized_hypertable_142_time_bucket_i on _hyper_X_X_chunk
+  ->  Index Scan Backward using _hyper_X_X_chunk__materialized_hypertable_X_time_bucket_i on _hyper_X_X_chunk
         Index Cond: (time_bucket < 'Sat Jan 01 16:00:00 2000 PST'::timestamp with time zone)                           
   ->  GroupAggregate                                                                                                   
         Group Key: (time_bucket('@ 4 hours'::interval, temperature."time"))                                            
@@ -190,9 +190,9 @@ Merge Append
   Sort Key: _materialized_hypertable_142.time_bucket                                                                         
   ->  Custom Scan (ChunkAppend) on _materialized_hypertable_142                                                              
         Order: _materialized_hypertable_142.time_bucket                                                                      
-        ->  Index Scan Backward using _hyper_X_X_chunk__materialized_hypertable_142_time_bucket_i on _hyper_X_X_chunk
+        ->  Index Scan Backward using _hyper_X_X_chunk__materialized_hypertable_X_time_bucket_i on _hyper_X_X_chunk
               Index Cond: (time_bucket < 'Wed Jan 01 16:00:00 2020 PST'::timestamp with time zone)                           
-        ->  Index Scan Backward using _hyper_X_X_chunk__materialized_hypertable_142_time_bucket_i on _hyper_X_X_chunk
+        ->  Index Scan Backward using _hyper_X_X_chunk__materialized_hypertable_X_time_bucket_i on _hyper_X_X_chunk
               Index Cond: (time_bucket < 'Wed Jan 01 16:00:00 2020 PST'::timestamp with time zone)                           
   ->  GroupAggregate                                                                                                         
         Group Key: (time_bucket('@ 4 hours'::interval, _hyper_X_X_chunk."time"))                                         
@@ -219,9 +219,9 @@ Merge Append
   Sort Key: _materialized_hypertable_142.time_bucket                                                                         
   ->  Custom Scan (ChunkAppend) on _materialized_hypertable_142                                                              
         Order: _materialized_hypertable_142.time_bucket                                                                      
-        ->  Index Scan Backward using _hyper_X_X_chunk__materialized_hypertable_142_time_bucket_i on _hyper_X_X_chunk
+        ->  Index Scan Backward using _hyper_X_X_chunk__materialized_hypertable_X_time_bucket_i on _hyper_X_X_chunk
               Index Cond: (time_bucket < 'Thu Jan 02 16:00:00 2020 PST'::timestamp with time zone)                           
-        ->  Index Scan Backward using _hyper_X_X_chunk__materialized_hypertable_142_time_bucket_i on _hyper_X_X_chunk
+        ->  Index Scan Backward using _hyper_X_X_chunk__materialized_hypertable_X_time_bucket_i on _hyper_X_X_chunk
               Index Cond: (time_bucket < 'Thu Jan 02 16:00:00 2020 PST'::timestamp with time zone)                           
   ->  GroupAggregate                                                                                                         
         Group Key: (time_bucket('@ 4 hours'::interval, _hyper_X_X_chunk."time"))                                         

--- a/tsl/test/isolation/expected/cagg_watermark_concurrent_update_1.out
+++ b/tsl/test/isolation/expected/cagg_watermark_concurrent_update_1.out
@@ -22,7 +22,7 @@ QUERY PLAN
 -----------------------------------------------------------------------------------------------------------------------
 Merge Append                                                                                                           
   Sort Key: _hyper_X_X_chunk.time_bucket                                                                           
-  ->  Index Scan Backward using _hyper_X_X_chunk__materialized_hypertable_140_time_bucket_i on _hyper_X_X_chunk
+  ->  Index Scan Backward using _hyper_X_X_chunk__materialized_hypertable_X_time_bucket_i on _hyper_X_X_chunk
         Index Cond: (time_bucket < 'Sat Jan 01 16:00:00 2000 PST'::timestamp with time zone)                           
   ->  GroupAggregate                                                                                                   
         Group Key: (time_bucket('@ 4 hours'::interval, temperature."time"))                                            
@@ -45,7 +45,7 @@ QUERY PLAN
 -----------------------------------------------------------------------------------------------------------------------
 Merge Append                                                                                                           
   Sort Key: _hyper_X_X_chunk.time_bucket                                                                           
-  ->  Index Scan Backward using _hyper_X_X_chunk__materialized_hypertable_140_time_bucket_i on _hyper_X_X_chunk
+  ->  Index Scan Backward using _hyper_X_X_chunk__materialized_hypertable_X_time_bucket_i on _hyper_X_X_chunk
         Index Cond: (time_bucket < 'Sat Jan 01 16:00:00 2000 PST'::timestamp with time zone)                           
   ->  GroupAggregate                                                                                                   
         Group Key: (time_bucket('@ 4 hours'::interval, temperature."time"))                                            
@@ -76,9 +76,9 @@ Merge Append
   Sort Key: _materialized_hypertable_140.time_bucket                                                                         
   ->  Custom Scan (ChunkAppend) on _materialized_hypertable_140                                                              
         Order: _materialized_hypertable_140.time_bucket                                                                      
-        ->  Index Scan Backward using _hyper_X_X_chunk__materialized_hypertable_140_time_bucket_i on _hyper_X_X_chunk
+        ->  Index Scan Backward using _hyper_X_X_chunk__materialized_hypertable_X_time_bucket_i on _hyper_X_X_chunk
               Index Cond: (time_bucket < 'Wed Jan 01 16:00:00 2020 PST'::timestamp with time zone)                           
-        ->  Index Scan Backward using _hyper_X_X_chunk__materialized_hypertable_140_time_bucket_i on _hyper_X_X_chunk
+        ->  Index Scan Backward using _hyper_X_X_chunk__materialized_hypertable_X_time_bucket_i on _hyper_X_X_chunk
               Index Cond: (time_bucket < 'Wed Jan 01 16:00:00 2020 PST'::timestamp with time zone)                           
   ->  GroupAggregate                                                                                                         
         Group Key: (time_bucket('@ 4 hours'::interval, "time"))                                                              
@@ -97,9 +97,9 @@ Merge Append
   Sort Key: _materialized_hypertable_140.time_bucket                                                                         
   ->  Custom Scan (ChunkAppend) on _materialized_hypertable_140                                                              
         Order: _materialized_hypertable_140.time_bucket                                                                      
-        ->  Index Scan Backward using _hyper_X_X_chunk__materialized_hypertable_140_time_bucket_i on _hyper_X_X_chunk
+        ->  Index Scan Backward using _hyper_X_X_chunk__materialized_hypertable_X_time_bucket_i on _hyper_X_X_chunk
               Index Cond: (time_bucket < 'Wed Jan 01 16:00:00 2020 PST'::timestamp with time zone)                           
-        ->  Index Scan Backward using _hyper_X_X_chunk__materialized_hypertable_140_time_bucket_i on _hyper_X_X_chunk
+        ->  Index Scan Backward using _hyper_X_X_chunk__materialized_hypertable_X_time_bucket_i on _hyper_X_X_chunk
               Index Cond: (time_bucket < 'Wed Jan 01 16:00:00 2020 PST'::timestamp with time zone)                           
   ->  GroupAggregate                                                                                                         
         Group Key: (time_bucket('@ 4 hours'::interval, "time"))                                                              
@@ -126,7 +126,7 @@ QUERY PLAN
 -----------------------------------------------------------------------------------------------------------------------
 Merge Append                                                                                                           
   Sort Key: _hyper_X_X_chunk.time_bucket                                                                           
-  ->  Index Scan Backward using _hyper_X_X_chunk__materialized_hypertable_142_time_bucket_i on _hyper_X_X_chunk
+  ->  Index Scan Backward using _hyper_X_X_chunk__materialized_hypertable_X_time_bucket_i on _hyper_X_X_chunk
         Index Cond: (time_bucket < 'Sat Jan 01 16:00:00 2000 PST'::timestamp with time zone)                           
   ->  GroupAggregate                                                                                                   
         Group Key: (time_bucket('@ 4 hours'::interval, temperature."time"))                                            
@@ -149,7 +149,7 @@ QUERY PLAN
 -----------------------------------------------------------------------------------------------------------------------
 Merge Append                                                                                                           
   Sort Key: _hyper_X_X_chunk.time_bucket                                                                           
-  ->  Index Scan Backward using _hyper_X_X_chunk__materialized_hypertable_142_time_bucket_i on _hyper_X_X_chunk
+  ->  Index Scan Backward using _hyper_X_X_chunk__materialized_hypertable_X_time_bucket_i on _hyper_X_X_chunk
         Index Cond: (time_bucket < 'Sat Jan 01 16:00:00 2000 PST'::timestamp with time zone)                           
   ->  GroupAggregate                                                                                                   
         Group Key: (time_bucket('@ 4 hours'::interval, temperature."time"))                                            
@@ -194,9 +194,9 @@ Merge Append
   Sort Key: _materialized_hypertable_142.time_bucket                                                                         
   ->  Custom Scan (ChunkAppend) on _materialized_hypertable_142                                                              
         Order: _materialized_hypertable_142.time_bucket                                                                      
-        ->  Index Scan Backward using _hyper_X_X_chunk__materialized_hypertable_142_time_bucket_i on _hyper_X_X_chunk
+        ->  Index Scan Backward using _hyper_X_X_chunk__materialized_hypertable_X_time_bucket_i on _hyper_X_X_chunk
               Index Cond: (time_bucket < 'Wed Jan 01 16:00:00 2020 PST'::timestamp with time zone)                           
-        ->  Index Scan Backward using _hyper_X_X_chunk__materialized_hypertable_142_time_bucket_i on _hyper_X_X_chunk
+        ->  Index Scan Backward using _hyper_X_X_chunk__materialized_hypertable_X_time_bucket_i on _hyper_X_X_chunk
               Index Cond: (time_bucket < 'Wed Jan 01 16:00:00 2020 PST'::timestamp with time zone)                           
   ->  GroupAggregate                                                                                                         
         Group Key: (time_bucket('@ 4 hours'::interval, _hyper_X_X_chunk."time"))                                         
@@ -223,9 +223,9 @@ Merge Append
   Sort Key: _materialized_hypertable_142.time_bucket                                                                         
   ->  Custom Scan (ChunkAppend) on _materialized_hypertable_142                                                              
         Order: _materialized_hypertable_142.time_bucket                                                                      
-        ->  Index Scan Backward using _hyper_X_X_chunk__materialized_hypertable_142_time_bucket_i on _hyper_X_X_chunk
+        ->  Index Scan Backward using _hyper_X_X_chunk__materialized_hypertable_X_time_bucket_i on _hyper_X_X_chunk
               Index Cond: (time_bucket < 'Thu Jan 02 16:00:00 2020 PST'::timestamp with time zone)                           
-        ->  Index Scan Backward using _hyper_X_X_chunk__materialized_hypertable_142_time_bucket_i on _hyper_X_X_chunk
+        ->  Index Scan Backward using _hyper_X_X_chunk__materialized_hypertable_X_time_bucket_i on _hyper_X_X_chunk
               Index Cond: (time_bucket < 'Thu Jan 02 16:00:00 2020 PST'::timestamp with time zone)                           
   ->  GroupAggregate                                                                                                         
         Group Key: (time_bucket('@ 4 hours'::interval, _hyper_X_X_chunk."time"))                                         


### PR DESCRIPTION
This patch makes the isolation tests more robust by replacing chunk IDs with X. So, even if the chunk ID changes, the tests will not fail.

---

Disable-check: force-changelog-file
