### PR TITLE
Fix branch prediction in Ensure

### DIFF
--- a/src/debug_assert.h
+++ b/src/debug_assert.h
@@ -29,7 +29,7 @@
 #define Ensure(COND, FMT, ...)                                                                     \
 	do                                                                                             \
 	{                                                                                              \
-		if (!unlikely(COND))                                                                       \
+		if (unlikely(!(COND)))                                                                     \
 			ereport(ERROR,                                                                         \
 					(errcode(ERRCODE_INTERNAL_ERROR),                                              \
 					 errdetail("Assertion '" #COND "' failed."),                                   \


### PR DESCRIPTION
PR #6648 introduces a branch prediction in the Ensure macro. However, the checked condition needs to be negated to be unlikely. Therefore, the check predicts the branch likelihood wrongly. In other words, reporting an error in Ensure should be the unlikely case, and the condition should be fulfilled in most calls. This commit fixes the branch prediction.

---

Disable-check: force-changelog-file