### PR TITLE
Add macro to execute with memory context

### DIFF
--- a/coccinelle/with_mcxt.cocci
+++ b/coccinelle/with_mcxt.cocci
@@ -1,0 +1,29 @@
+@r1@
+expression mcxt;
+identifier oldmcxt;
+@@
+ {
+-MemoryContext oldmcxt;
+...
+-oldmcxt = MemoryContextSwitchTo(mcxt);
++TS_WITH_MEMORY_CONTEXT(mcxt, WRAP(
+...
+-MemoryContextSwitchTo(oldmcxt);
++));
+ ...
+ }
+
+@r2@
+expression mcxt;
+identifier oldmcxt;
+@@
+ {
+-MemoryContext oldmcxt = MemoryContextSwitchTo(mcxt);
++/* Replace the WRAP macro with braces */
++TS_WITH_MEMORY_CONTEXT(mcxt, WRAP(
+ ...
+-MemoryContextSwitchTo(oldmcxt);
++));
++/* End of WRAP macro */
+ ...
+ }

--- a/coccinelle/with_mcxt.cocci
+++ b/coccinelle/with_mcxt.cocci
@@ -6,10 +6,12 @@ identifier oldmcxt;
 -MemoryContext oldmcxt;
 ...
 -oldmcxt = MemoryContextSwitchTo(mcxt);
++/* Replace the WRAP macro with braces */
 +TS_WITH_MEMORY_CONTEXT(mcxt, WRAP(
 ...
 -MemoryContextSwitchTo(oldmcxt);
 +));
++/* End of WRAP macro */
  ...
  }
 

--- a/src/chunk_constraint.c
+++ b/src/chunk_constraint.c
@@ -75,16 +75,14 @@ ts_chunk_constraints_copy(ChunkConstraints *chunk_constraints)
 static void
 chunk_constraints_expand(ChunkConstraints *ccs, int16 new_capacity)
 {
-	MemoryContext old;
-
 	if (new_capacity <= ccs->capacity)
 		return;
 
-	old = MemoryContextSwitchTo(ccs->mctx);
-	ccs->capacity = new_capacity;
-	Assert(ccs->constraints); /* repalloc() does not work with NULL argument */
-	ccs->constraints = repalloc(ccs->constraints, CHUNK_CONSTRAINTS_SIZE(new_capacity));
-	MemoryContextSwitchTo(old);
+	TS_WITH_MEMORY_CONTEXT(ccs->mctx, {
+		ccs->capacity = new_capacity;
+		Assert(ccs->constraints); /* repalloc() does not work with NULL argument */
+		ccs->constraints = repalloc(ccs->constraints, CHUNK_CONSTRAINTS_SIZE(new_capacity));
+	});
 }
 
 static void

--- a/src/copy.c
+++ b/src/copy.c
@@ -298,7 +298,7 @@ TSCopyMultiInsertInfoIsFull(TSCopyMultiInsertInfo *miinfo)
 static inline int
 TSCopyMultiInsertBufferFlush(TSCopyMultiInsertInfo *miinfo, TSCopyMultiInsertBuffer *buffer)
 {
-	MemoryContext oldcontext;
+	ExplicitMemoryContext oldcontext;
 	int i;
 
 	Assert(miinfo != NULL);

--- a/src/dimension.c
+++ b/src/dimension.c
@@ -194,8 +194,6 @@ dimension_fill_in_from_tuple(Dimension *d, TupleInfo *ti, Oid main_table_relid)
 	if (!isnull[AttrNumberGetAttrOffset(Anum_dimension_partitioning_func_schema)] &&
 		!isnull[AttrNumberGetAttrOffset(Anum_dimension_partitioning_func)])
 	{
-		MemoryContext old;
-
 		d->fd.num_slices =
 			DatumGetInt16(values[AttrNumberGetAttrOffset(Anum_dimension_num_slices)]);
 
@@ -206,14 +204,13 @@ dimension_fill_in_from_tuple(Dimension *d, TupleInfo *ti, Oid main_table_relid)
 				   DatumGetCString(
 					   values[AttrNumberGetAttrOffset(Anum_dimension_partitioning_func)]));
 
-		old = MemoryContextSwitchTo(ti->mctx);
-		d->partitioning = ts_partitioning_info_create(NameStr(d->fd.partitioning_func_schema),
-													  NameStr(d->fd.partitioning_func),
-													  NameStr(d->fd.column_name),
-													  d->type,
-													  main_table_relid);
-
-		MemoryContextSwitchTo(old);
+		TS_WITH_MEMORY_CONTEXT(ti->mctx, {
+			d->partitioning = ts_partitioning_info_create(NameStr(d->fd.partitioning_func_schema),
+														  NameStr(d->fd.partitioning_func),
+														  NameStr(d->fd.column_name),
+														  d->type,
+														  main_table_relid);
+		});
 	}
 
 	if (!isnull[AttrNumberGetAttrOffset(Anum_dimension_integer_now_func_schema)] &&

--- a/src/hypercube.c
+++ b/src/hypercube.c
@@ -182,11 +182,9 @@ ts_hypercube_from_constraints(const ChunkConstraints *constraints, ScanIterator 
 {
 	Hypercube *hc;
 	int i;
-	MemoryContext old;
 
-	old = MemoryContextSwitchTo(ts_scan_iterator_get_result_memory_context(slice_it));
-	hc = ts_hypercube_alloc(constraints->num_dimension_constraints);
-	MemoryContextSwitchTo(old);
+	TS_WITH_MEMORY_CONTEXT(ts_scan_iterator_get_result_memory_context(slice_it),
+						   { hc = ts_hypercube_alloc(constraints->num_dimension_constraints); });
 
 	for (i = 0; i < constraints->num_constraints; i++)
 	{

--- a/src/hypertable.c
+++ b/src/hypertable.c
@@ -936,17 +936,14 @@ hypertable_chunk_store_free(void *entry)
 static Chunk *
 hypertable_chunk_store_add(const Hypertable *h, const Chunk *input_chunk)
 {
-	MemoryContext old_mcxt;
-
-	/* Add the chunk to the subspace store */
-	old_mcxt = MemoryContextSwitchTo(ts_subspace_store_mcxt(h->chunk_cache));
-	Chunk *cached_chunk = ts_chunk_copy(input_chunk);
-	ts_subspace_store_add(h->chunk_cache,
-						  cached_chunk->cube,
-						  cached_chunk,
-						  hypertable_chunk_store_free);
-	MemoryContextSwitchTo(old_mcxt);
-
+	Chunk *cached_chunk;
+	TS_WITH_MEMORY_CONTEXT(ts_subspace_store_mcxt(h->chunk_cache), {
+		cached_chunk = ts_chunk_copy(input_chunk);
+		ts_subspace_store_add(h->chunk_cache,
+							  cached_chunk->cube,
+							  cached_chunk,
+							  hypertable_chunk_store_free);
+	});
 	return cached_chunk;
 }
 

--- a/src/net/http_response.c
+++ b/src/net/http_response.c
@@ -8,6 +8,7 @@
 #include <utils/memutils.h>
 
 #include "http.h"
+#include "utils.h"
 
 #define CARRIAGE_RETURN '\r'
 #define NEW_LINE '\n'
@@ -199,12 +200,12 @@ static void
 http_response_state_add_header(HttpResponseState *state, const char *name, size_t name_len,
 							   const char *value, size_t value_len)
 {
-	MemoryContext old = MemoryContextSwitchTo(state->context);
-	HttpHeader *new_header =
-		ts_http_header_create(name, name_len, value, value_len, state->headers);
+	TS_WITH_MEMORY_CONTEXT(state->context, {
+		HttpHeader *new_header =
+			ts_http_header_create(name, name_len, value, value_len, state->headers);
 
-	state->headers = new_header;
-	MemoryContextSwitchTo(old);
+		state->headers = new_header;
+	});
 }
 
 static void

--- a/src/process_utility.c
+++ b/src/process_utility.c
@@ -1049,9 +1049,7 @@ process_truncate(ProcessUtilityArgs *args)
 		/* Append the relation to the list in the same parse tree memory context */
 		if (list_append)
 		{
-			MemoryContext oldctx = MemoryContextSwitchTo(parsetreectx);
-			relations = lappend(relations, rv);
-			MemoryContextSwitchTo(oldctx);
+			TS_WITH_MEMORY_CONTEXT(parsetreectx, relations = lappend(relations, rv););
 		}
 	}
 

--- a/src/scan_iterator.c
+++ b/src/scan_iterator.c
@@ -31,8 +31,6 @@ TSDLLEXPORT void
 ts_scan_iterator_scan_key_init(ScanIterator *iterator, AttrNumber attributeNumber,
 							   StrategyNumber strategy, RegProcedure procedure, Datum argument)
 {
-	MemoryContext oldmcxt;
-
 	Assert(iterator->ctx.scankey == NULL || iterator->ctx.scankey == iterator->scankey);
 	iterator->ctx.scankey = iterator->scankey;
 
@@ -44,13 +42,13 @@ ts_scan_iterator_scan_key_init(ScanIterator *iterator, AttrNumber attributeNumbe
 	 * sure the scan key is initialized on the long-lived scankey memory
 	 * context.
 	 */
-	oldmcxt = MemoryContextSwitchTo(iterator->ctx.internal.scan_mcxt);
-	ScanKeyInit(&iterator->scankey[iterator->ctx.nkeys++],
-				attributeNumber,
-				strategy,
-				procedure,
-				argument);
-	MemoryContextSwitchTo(oldmcxt);
+	TS_WITH_MEMORY_CONTEXT(iterator->ctx.internal.scan_mcxt, {
+		ScanKeyInit(&iterator->scankey[iterator->ctx.nkeys++],
+					attributeNumber,
+					strategy,
+					procedure,
+					argument);
+	});
 }
 
 TSDLLEXPORT void

--- a/src/subspace_store.c
+++ b/src/subspace_store.c
@@ -72,21 +72,22 @@ subspace_store_internal_node_descendants(SubspaceStoreInternalNode *node, int in
 SubspaceStore *
 ts_subspace_store_init(const Hyperspace *space, MemoryContext mcxt, int16 max_items)
 {
-	MemoryContext old = MemoryContextSwitchTo(mcxt);
-	SubspaceStore *sst = palloc(sizeof(SubspaceStore));
+	SubspaceStore *sst;
+	TS_WITH_MEMORY_CONTEXT(mcxt, {
+		sst = palloc(sizeof(SubspaceStore));
 
-	/*
-	 * make sure that the first dimension is a time dimension, otherwise the
-	 * tree will grow in a way that makes pruning less effective.
-	 */
-	Assert(space->num_dimensions < 1 || space->dimensions[0].type == DIMENSION_TYPE_OPEN);
+		/*
+		 * make sure that the first dimension is a time dimension, otherwise the
+		 * tree will grow in a way that makes pruning less effective.
+		 */
+		Assert(space->num_dimensions < 1 || space->dimensions[0].type == DIMENSION_TYPE_OPEN);
 
-	sst->origin = subspace_store_internal_node_create(space->num_dimensions == 1);
-	sst->num_dimensions = space->num_dimensions;
-	/* max_items = 0 is treated as unlimited */
-	sst->max_items = max_items;
-	sst->mcxt = mcxt;
-	MemoryContextSwitchTo(old);
+		sst->origin = subspace_store_internal_node_create(space->num_dimensions == 1);
+		sst->num_dimensions = space->num_dimensions;
+		/* max_items = 0 is treated as unlimited */
+		sst->max_items = max_items;
+		sst->mcxt = mcxt;
+	});
 	return sst;
 }
 

--- a/src/ts_catalog/tablespace.c
+++ b/src/ts_catalog/tablespace.c
@@ -752,15 +752,12 @@ ts_tablespace_show(PG_FUNCTION_ARGS)
 
 	if (SRF_IS_FIRSTCALL())
 	{
-		MemoryContext oldcontext;
-
 		if (!OidIsValid(hypertable_oid))
 			elog(ERROR, "invalid argument");
 
 		funcctx = SRF_FIRSTCALL_INIT();
-		oldcontext = MemoryContextSwitchTo(funcctx->multi_call_memory_ctx);
-		funcctx->user_fctx = ts_hypertable_cache_pin();
-		MemoryContextSwitchTo(oldcontext);
+		TS_WITH_MEMORY_CONTEXT(funcctx->multi_call_memory_ctx,
+							   funcctx->user_fctx = ts_hypertable_cache_pin(););
 	}
 
 	funcctx = SRF_PERCALL_SETUP();

--- a/src/utils.h
+++ b/src/utils.h
@@ -19,6 +19,25 @@
 #include "compat/compat.h"
 
 /*
+ * Convenience macro to execute a simple or complex statement inside a memory
+ * context to avoid missing to restore context after being used.
+ */
+#define TS_WITH_MEMORY_CONTEXT(MCXT, STMT)                                                         \
+	do                                                                                             \
+	{                                                                                              \
+		MemoryContext _oldmcxt = MemoryContextSwitchTo((MCXT));                                    \
+		do                                                                                         \
+			STMT while (0);                                                                        \
+		MemoryContextSwitchTo(_oldmcxt);                                                           \
+	} while (0)
+
+/*
+ * Use this typedef if you want to avoid triggering the Coccinelle rule that
+ * will suggest to rewrite code to use the macro above.
+ */
+typedef MemoryContext ExplicitMemoryContext;
+
+/*
  * Get the function name in a PG_FUNCTION.
  *
  * The function name is resolved from the function Oid in the functioncall

--- a/tsl/src/bgw_policy/policies_v2.c
+++ b/tsl/src/bgw_policy/policies_v2.c
@@ -649,16 +649,12 @@ policies_show(PG_FUNCTION_ARGS)
 	pushJsonbValue(&parse_state, WJB_BEGIN_OBJECT, NULL);
 	if (SRF_IS_FIRSTCALL())
 	{
-		MemoryContext oldcontext;
-
 		funcctx = SRF_FIRSTCALL_INIT();
-		oldcontext = MemoryContextSwitchTo(funcctx->multi_call_memory_ctx);
-
 		/* Use top-level memory context to preserve the global static list */
-		jobs = ts_bgw_job_find_by_hypertable_id(cagg->data.mat_hypertable_id);
-
-		funcctx->user_fctx = list_head(jobs);
-		MemoryContextSwitchTo(oldcontext);
+		TS_WITH_MEMORY_CONTEXT(funcctx->multi_call_memory_ctx, {
+			jobs = ts_bgw_job_find_by_hypertable_id(cagg->data.mat_hypertable_id);
+			funcctx->user_fctx = list_head(jobs);
+		});
 	}
 
 	funcctx = SRF_PERCALL_SETUP();

--- a/tsl/src/nodes/decompress_chunk/compressed_batch.c
+++ b/tsl/src/nodes/decompress_chunk/compressed_batch.c
@@ -146,16 +146,13 @@ decompress_column(DecompressContext *dcontext, DecompressBatchState *batch_state
 											column_description->typid);
 		Assert(decompress_all != NULL);
 
-		MemoryContext context_before_decompression =
-			MemoryContextSwitchTo(dcontext->bulk_decompression_context);
+		TS_WITH_MEMORY_CONTEXT(dcontext->bulk_decompression_context, {
+			arrow = decompress_all(PointerGetDatum(header),
+								   column_description->typid,
+								   batch_state->per_batch_context);
 
-		arrow = decompress_all(PointerGetDatum(header),
-							   column_description->typid,
-							   batch_state->per_batch_context);
-
-		MemoryContextReset(dcontext->bulk_decompression_context);
-
-		MemoryContextSwitchTo(context_before_decompression);
+			MemoryContextReset(dcontext->bulk_decompression_context);
+		});
 	}
 
 	if (arrow == NULL)

--- a/tsl/src/nodes/decompress_chunk/decompress_chunk.c
+++ b/tsl/src/nodes/decompress_chunk/decompress_chunk.c
@@ -84,7 +84,7 @@ static EquivalenceClass *
 append_ec_for_seqnum(PlannerInfo *root, CompressionInfo *info, SortInfo *sort_info, Var *var,
 					 Oid sortop, bool nulls_first)
 {
-	MemoryContext oldcontext = MemoryContextSwitchTo(root->planner_cxt);
+	ExplicitMemoryContext oldcontext = MemoryContextSwitchTo(root->planner_cxt);
 
 	Oid opfamily, opcintype, equality_op;
 	int16 strategy;


### PR DESCRIPTION
TTo avoid making mistakes when temporarily switching memory context for a short piece of code and also make the code easier to read we introduce a macro `TS_WITH_MEMORY_CONTEXT` that will execute a piece of code in a specified memory context and restore the original memory context after.

It also adds a Coccinelle rule to capture and check cases that warrant replacement, and a typedef `ExplicitMemoryContext` that will not trigger the Coccinelle rule when used, if you have long streaks of code where explicit calls of `MemoryContextSwitchTo` is easier to follow.

Disable-check: force-changelog-file