### PR TITLE
Add missing schedule trigger for i386 test

### DIFF
--- a/.github/workflows/linux-32bit-build-and-test.yaml
+++ b/.github/workflows/linux-32bit-build-and-test.yaml
@@ -1,5 +1,8 @@
 name: Regression Linux i386
 "on":
+  schedule:
+    # run daily 0:00 on main branch
+    - cron: '0 0 * * *'
   push:
     branches:
       - main


### PR DESCRIPTION
The CI workflow for i386 test was missing the schedule trigger. Therefore, no scheduled builds are performed, and the status badge of our README file returns an "unknown" status.

---

Disable-check: force-changelog-file