### PR TITLE
Make bgw_db_scheduler test more predictable

### DIFF
--- a/tsl/test/expected/bgw_db_scheduler.out
+++ b/tsl/test/expected/bgw_db_scheduler.out
@@ -873,7 +873,9 @@ SELECT ts_bgw_db_scheduler_test_wait_for_scheduler_finish();
  
 (1 row)
 
-SELECT * FROM sorted_bgw_log;
+-- The number of scheduler restarts is not deterministic during [..]_wait_for_scheduler_finish().
+-- Therefore, we filter these messages to get a deterministic test output.
+SELECT * FROM sorted_bgw_log WHERE msg NOT LIKE '[TESTING] Wait until%';
  msg_no | application_name |                      msg                      
 --------+------------------+-----------------------------------------------
       0 | DB Scheduler     | bgw scheduler stopped due to shutdown_bgw guc
@@ -1715,17 +1717,16 @@ SELECT job_id, last_run_success, total_runs, total_successes, total_failures, to
    1027 | f                |          1 |               0 |              1 |             0
 (1 row)
 
-SELECT * FROM sorted_bgw_log;
+-- We increase the mock time a lot to ensure the job does not get restarted. However, the amount of scheduler sleep/wakeup cycles
+-- is not deterministic. Therefore, we filter these messages to get a deterministic test output.
+SELECT * FROM sorted_bgw_log WHERE msg NOT LIKE '[TESTING] Wait until%';
  msg_no |   application_name   |                            msg                            
 --------+----------------------+-----------------------------------------------------------
       0 | DB Scheduler         | [TESTING] Registered new background worker
-      1 | DB Scheduler         | [TESTING] Wait until (RANDOM), started at (RANDOM)
       1 | bgw_test_job_2_error | job 1027 reached max_retries after 1 consecutive failures
       2 | bgw_test_job_2_error | job 1027 threw an error
       3 | bgw_test_job_2_error | Error job 2
-      2 | DB Scheduler         | [TESTING] Wait until (RANDOM), started at (RANDOM)
-      0 | DB Scheduler         | [TESTING] Wait until (RANDOM), started at (RANDOM)
-(7 rows)
+(4 rows)
 
 SELECT last_finish, last_successful_finish, last_run_success FROM _timescaledb_internal.bgw_job_stat;
          last_finish          | last_successful_finish | last_run_success 

--- a/tsl/test/sql/bgw_db_scheduler.sql
+++ b/tsl/test/sql/bgw_db_scheduler.sql
@@ -368,7 +368,9 @@ SHOW timescaledb.shutdown_bgw_scheduler;
 
 SELECT ts_bgw_db_scheduler_test_wait_for_scheduler_finish();
 
-SELECT * FROM sorted_bgw_log;
+-- The number of scheduler restarts is not deterministic during [..]_wait_for_scheduler_finish().
+-- Therefore, we filter these messages to get a deterministic test output.
+SELECT * FROM sorted_bgw_log WHERE msg NOT LIKE '[TESTING] Wait until%';
 
 ALTER SYSTEM RESET timescaledb.shutdown_bgw_scheduler;
 SELECT pg_reload_conf();
@@ -719,7 +721,9 @@ SELECT last_finish, last_successful_finish, last_run_success FROM _timescaledb_i
 -- Run the second time
 SELECT ts_bgw_db_scheduler_test_run_and_wait_for_scheduler_finish(100, 50);
 SELECT job_id, last_run_success, total_runs, total_successes, total_failures, total_crashes FROM _timescaledb_internal.bgw_job_stat;
-SELECT * FROM sorted_bgw_log;
+-- We increase the mock time a lot to ensure the job does not get restarted. However, the amount of scheduler sleep/wakeup cycles
+-- is not deterministic. Therefore, we filter these messages to get a deterministic test output.
+SELECT * FROM sorted_bgw_log WHERE msg NOT LIKE '[TESTING] Wait until%';
 SELECT last_finish, last_successful_finish, last_run_success FROM _timescaledb_internal.bgw_job_stat;
 
 -- clean up jobs


### PR DESCRIPTION
When the tests wait for a scheduler run that spans multiple wakeup cycles, the amount of scheduler wakeups is not deterministic. This commit adds filters for the logfile to avoid failing tests due to a different number of scheduler wakeups.

--

Disable-check: force-changelog-file

Link to failed CI runs: 

https://github.com/timescale/timescaledb/actions/runs/8050436144/job/21986044894
https://github.com/timescale/timescaledb/actions/runs/8050436144/job/21986047758