### PR TITLE
Fix flaky transparent_decompress_chunk test

### DIFF
--- a/tsl/test/shared/expected/transparent_decompress_chunk-13.out
+++ b/tsl/test/shared/expected/transparent_decompress_chunk-13.out
@@ -401,20 +401,17 @@ QUERY PLAN
 (8 rows)
 
 --functions not yet optimized
-:PREFIX SELECT * FROM :TEST_TABLE WHERE time < now() ORDER BY time, device_id LIMIT 10;
+:PREFIX_NO_VERBOSE SELECT * FROM :TEST_TABLE WHERE time < now() ORDER BY time, device_id LIMIT 10;
 QUERY PLAN
- Limit (actual rows=10 loops=1)
-   ->  Gather Merge (actual rows=10 loops=1)
+ Limit
+   ->  Gather Merge
          Workers Planned: 2
-         Workers Launched: 2
-         ->  Sort (actual rows=10 loops=2)
+         ->  Sort
                Sort Key: _hyper_X_X_chunk."time", _hyper_X_X_chunk.device_id
-               Worker 0:  Sort Method: top-N heapsort 
-               Worker 1:  Sort Method: top-N heapsort 
-               ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=8995 loops=2)
+               ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk
                      Vectorized Filter: ("time" < now())
-                     ->  Parallel Seq Scan on compress_hyper_X_X_chunk (actual rows=10 loops=2)
-(11 rows)
+                     ->  Parallel Seq Scan on compress_hyper_X_X_chunk
+(8 rows)
 
 -- test sort optimization interaction
 :PREFIX_NO_VERBOSE SELECT time FROM :TEST_TABLE ORDER BY time DESC LIMIT 10;

--- a/tsl/test/shared/expected/transparent_decompress_chunk-14.out
+++ b/tsl/test/shared/expected/transparent_decompress_chunk-14.out
@@ -401,20 +401,17 @@ QUERY PLAN
 (8 rows)
 
 --functions not yet optimized
-:PREFIX SELECT * FROM :TEST_TABLE WHERE time < now() ORDER BY time, device_id LIMIT 10;
+:PREFIX_NO_VERBOSE SELECT * FROM :TEST_TABLE WHERE time < now() ORDER BY time, device_id LIMIT 10;
 QUERY PLAN
- Limit (actual rows=10 loops=1)
-   ->  Gather Merge (actual rows=10 loops=1)
+ Limit
+   ->  Gather Merge
          Workers Planned: 2
-         Workers Launched: 2
-         ->  Sort (actual rows=10 loops=2)
+         ->  Sort
                Sort Key: _hyper_X_X_chunk."time", _hyper_X_X_chunk.device_id
-               Worker 0:  Sort Method: top-N heapsort 
-               Worker 1:  Sort Method: top-N heapsort 
-               ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=8995 loops=2)
+               ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk
                      Vectorized Filter: ("time" < now())
-                     ->  Parallel Seq Scan on compress_hyper_X_X_chunk (actual rows=10 loops=2)
-(11 rows)
+                     ->  Parallel Seq Scan on compress_hyper_X_X_chunk
+(8 rows)
 
 -- test sort optimization interaction
 :PREFIX_NO_VERBOSE SELECT time FROM :TEST_TABLE ORDER BY time DESC LIMIT 10;

--- a/tsl/test/shared/expected/transparent_decompress_chunk-15.out
+++ b/tsl/test/shared/expected/transparent_decompress_chunk-15.out
@@ -403,20 +403,17 @@ QUERY PLAN
 (8 rows)
 
 --functions not yet optimized
-:PREFIX SELECT * FROM :TEST_TABLE WHERE time < now() ORDER BY time, device_id LIMIT 10;
+:PREFIX_NO_VERBOSE SELECT * FROM :TEST_TABLE WHERE time < now() ORDER BY time, device_id LIMIT 10;
 QUERY PLAN
- Limit (actual rows=10 loops=1)
-   ->  Gather Merge (actual rows=10 loops=1)
+ Limit
+   ->  Gather Merge
          Workers Planned: 2
-         Workers Launched: 2
-         ->  Sort (actual rows=10 loops=2)
+         ->  Sort
                Sort Key: _hyper_X_X_chunk."time", _hyper_X_X_chunk.device_id
-               Worker 0:  Sort Method: top-N heapsort 
-               Worker 1:  Sort Method: top-N heapsort 
-               ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=8995 loops=2)
+               ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk
                      Vectorized Filter: ("time" < now())
-                     ->  Parallel Seq Scan on compress_hyper_X_X_chunk (actual rows=10 loops=2)
-(11 rows)
+                     ->  Parallel Seq Scan on compress_hyper_X_X_chunk
+(8 rows)
 
 -- test sort optimization interaction
 :PREFIX_NO_VERBOSE SELECT time FROM :TEST_TABLE ORDER BY time DESC LIMIT 10;

--- a/tsl/test/shared/expected/transparent_decompress_chunk-16.out
+++ b/tsl/test/shared/expected/transparent_decompress_chunk-16.out
@@ -403,20 +403,17 @@ QUERY PLAN
 (8 rows)
 
 --functions not yet optimized
-:PREFIX SELECT * FROM :TEST_TABLE WHERE time < now() ORDER BY time, device_id LIMIT 10;
+:PREFIX_NO_VERBOSE SELECT * FROM :TEST_TABLE WHERE time < now() ORDER BY time, device_id LIMIT 10;
 QUERY PLAN
- Limit (actual rows=10 loops=1)
-   ->  Gather Merge (actual rows=10 loops=1)
+ Limit
+   ->  Gather Merge
          Workers Planned: 2
-         Workers Launched: 2
-         ->  Sort (actual rows=10 loops=2)
+         ->  Sort
                Sort Key: _hyper_X_X_chunk."time", _hyper_X_X_chunk.device_id
-               Worker 0:  Sort Method: top-N heapsort 
-               Worker 1:  Sort Method: top-N heapsort 
-               ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=8995 loops=2)
+               ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk
                      Vectorized Filter: ("time" < now())
-                     ->  Parallel Seq Scan on compress_hyper_X_X_chunk (actual rows=10 loops=2)
-(11 rows)
+                     ->  Parallel Seq Scan on compress_hyper_X_X_chunk
+(8 rows)
 
 -- test sort optimization interaction
 :PREFIX_NO_VERBOSE SELECT time FROM :TEST_TABLE ORDER BY time DESC LIMIT 10;

--- a/tsl/test/shared/sql/transparent_decompress_chunk.sql.in
+++ b/tsl/test/shared/sql/transparent_decompress_chunk.sql.in
@@ -108,7 +108,7 @@ ORDER BY time, device_id;
 :PREFIX_NO_VERBOSE SELECT * FROM :TEST_TABLE WHERE time > '2000-01-01 1:00:00+0' OR device_id = 1 ORDER BY time, device_id LIMIT 10;
 
 --functions not yet optimized
-:PREFIX SELECT * FROM :TEST_TABLE WHERE time < now() ORDER BY time, device_id LIMIT 10;
+:PREFIX_NO_VERBOSE SELECT * FROM :TEST_TABLE WHERE time < now() ORDER BY time, device_id LIMIT 10;
 
 -- test sort optimization interaction
 :PREFIX_NO_VERBOSE SELECT time FROM :TEST_TABLE ORDER BY time DESC LIMIT 10;


### PR DESCRIPTION
Most of the tests in the test suite are executed with PREFIX_NO_VERBOSE. However, one of the parallel tests with two workers was executed using PREFIX. Since it uses multiple workers, the query plans are non-deterministic. This patch also changes this specific test to use PREFIX_NO_VERBOSE to get stable query plans.

---
Disable-check: force-changelog-file
Failed CI run: https://github.com/timescale/timescaledb/actions/runs/8050436144/job/21986047423