### PR TITLE
Fix missing varlen header in DimensionInfo

### DIFF
--- a/src/dimension.c
+++ b/src/dimension.c
@@ -1748,7 +1748,10 @@ ts_dimension_info_out(PG_FUNCTION_ARGS)
 static DimensionInfo *
 make_dimension_info(Name colname, DimensionType dimtype)
 {
-	DimensionInfo *info = palloc0(sizeof(DimensionInfo));
+	size_t size = sizeof(DimensionInfo);
+	DimensionInfo *info = palloc0(size);
+	SET_VARSIZE(info, size);
+
 	info->type = dimtype;
 	namestrcpy(&info->colname, NameStr(*colname));
 	return info;

--- a/src/dimension.h
+++ b/src/dimension.h
@@ -93,6 +93,11 @@ typedef struct Hypertable Hypertable;
  */
 typedef struct DimensionInfo
 {
+	/* We declare the SQL type dimension_info with INTERNALLENGTH = VARIABLE.
+	 * So, PostgreSQL expects a proper length info field (varlena header).
+	 */
+	int32 vl_len_;
+
 	Oid table_relid;
 	int32 dimension_id;
 	NameData colname;

--- a/tsl/test/expected/hypertable_generalization.out
+++ b/tsl/test/expected/hypertable_generalization.out
@@ -55,6 +55,31 @@ SELECT by_hash('id', 3, partition_func => 'part_func');
  hash//id//3//part_func
 (1 row)
 
+-- Check if we handle the varlength of the datatype properly
+SELECT * FROM by_range('id') WHERE by_range IS NOT NULL;
+    by_range     
+-----------------
+ range//id//-//-
+(1 row)
+
+SELECT * FROM by_range('id', partition_func => 'part_func') WHERE by_range IS NOT NULL;
+        by_range         
+-------------------------
+ range//id//-//part_func
+(1 row)
+
+SELECT * FROM by_hash('id', 3) WHERE by_hash IS NOT NULL;
+    by_hash     
+----------------
+ hash//id//3//-
+(1 row)
+
+SELECT * FROM by_hash('id', 3, partition_func => 'part_func') WHERE by_hash IS NOT NULL;
+        by_hash         
+------------------------
+ hash//id//3//part_func
+(1 row)
+
 \set ON_ERROR_STOP 0
 SELECT 'hash//id//3//-'::_timescaledb_internal.dimension_info;
 ERROR:  cannot construct type "dimension_info" from string at character 8

--- a/tsl/test/sql/hypertable_generalization.sql
+++ b/tsl/test/sql/hypertable_generalization.sql
@@ -27,6 +27,12 @@ SELECT by_range('id', '1 week'::interval, 'part_func'::regproc);
 SELECT by_hash('id', 3);
 SELECT by_hash('id', 3, partition_func => 'part_func');
 
+-- Check if we handle the varlength of the datatype properly
+SELECT * FROM by_range('id') WHERE by_range IS NOT NULL;
+SELECT * FROM by_range('id', partition_func => 'part_func') WHERE by_range IS NOT NULL;
+SELECT * FROM by_hash('id', 3) WHERE by_hash IS NOT NULL;
+SELECT * FROM by_hash('id', 3, partition_func => 'part_func') WHERE by_hash IS NOT NULL;
+
 \set ON_ERROR_STOP 0
 SELECT 'hash//id//3//-'::_timescaledb_internal.dimension_info;
 SELECT by_range(NULL::name);


### PR DESCRIPTION
The SQL data type _timescaledb_internal.dimension_info is declared with INTERNALLENGTH = VARIABLE. This requires a varlen header, which was missing. Therefore, the needed space of the function result was not handled properly. This commit introduces the missing header.

---

Disable-check: force-changelog-file
Found by SQLSmith: https://github.com/timescale/timescaledb/actions/runs/8058580265/job/22011569432


```sql
smith=# update public.metrics_compressed set 
smith-#   time = public.metrics_compressed.time, 
smith-#   device_id = pg_catalog.btint42cmp(
smith(#     cast(public.metrics_compressed.v1 as int4),
smith(#     cast(case when (cast(null as box) >^ cast(null as box)) 
smith(#         and ((select schedule_interval from timescaledb_experimental.policies limit 1 offset 3)
smith(#              >= (select schedule_interval from timescaledb_experimental.policies limit 1 offset 5)
smith(#             ) then cast(null as int2) else cast(null as int2) end
smith(#        as int2)), 
smith-#   v0 = public.metrics_compressed.v0, 
smith-#   v2 = public.metrics_compressed.v3, 
smith-#   v3 = (select v2 from public.metrics_compressed limit 1 offset 5)
smith-#     
smith-# returning 
smith-#   public.metrics_compressed.v3 as c0, 
smith-#   public.metrics_compressed.time as c1, 
smith-#   public.by_range(
smith(#     cast(cast(coalesce(pg_catalog.session_user(),
smith(#       pg_catalog.getdatabaseencoding()) as name) as name),
smith(#     cast(public.metrics_compressed.v3 as float8),
smith(#     cast(pg_catalog.to_regproc(
smith(#       cast(cast(coalesce(cast(nullif((select name from public.devices limit 1 offset 4)
smith(#             ,
smith(#           cast(null as text)) as text),
smith(#         case when public.metrics_compressed.v3 <> public.metrics_compressed.v2 then (select name from public.sensors limit 1 offset 3)
smith(#              else (select name from public.sensors limit 1 offset 3)
smith(#              end
smith(#           ) as text) as text)) as regproc)) as c2, 
smith-#   public.metrics_compressed.time as c3, 
smith-#   77 as c4;
 c0  |           c1           |         c2         |           c3           | c4 
-----+------------------------+--------------------+------------------------+----
 1.5 | 2000-01-06 00:54:00+01 | range//jan//1.5//- | 2000-01-06 00:54:00+01 | 77
 1.5 | 2000-01-06 00:52:00+01 | range//jan//1.5//- | 2000-01-06 00:52:00+01 | 77
 [...]
UPDATE 68370
```