### PR TITLE
Add write permissions for the backport workflow

### DIFF
--- a/.github/workflows/backport.yaml
+++ b/.github/workflows/backport.yaml
@@ -17,6 +17,10 @@ on:
       # branches that are not main, so it's inconvenient.
       - backport/trigger
 
+# The workflow needs the permission to push branches
+permissions:
+  contents: write
+
 jobs:
   backport:
     name: Backport Bug Fixes


### PR DESCRIPTION
The GitHub token only provides read-only access per default since a few days. This PR adjusts the backport workflow to request the write permissions for the repository.

--

Disable-check: force-changelog-file
Failed CI runs: https://github.com/timescale/timescaledb/actions/workflows/backport.yaml
Fixed CI run: https://github.com/timescale/timescaledb/actions/runs/8077881034/job/22069053250?pr=6706