### PR TITLE
Fix ABI backwards test for PG16

### DIFF
--- a/.github/workflows/abi.yaml
+++ b/.github/workflows/abi.yaml
@@ -77,6 +77,9 @@ jobs:
             pg: 16
             builder: ${{ fromJson(needs.config.outputs.pg16_latest) }}-alpine3.18
             tester: ${{ fromJson(needs.config.outputs.pg16_abi_min) }}-alpine
+            # this test has issues with 16.0 version of pg_dump binary
+            # which affects backwards test only 
+            ignores: pg_dump_unprivileged
           - dir: forward
             pg: 16
             builder: ${{ fromJson(needs.config.outputs.pg16_abi_min) }}-alpine


### PR DESCRIPTION
There was a recent change in pg_dump that affected how it works for version 16.1 of PG. Ignoring for backwards test since that uses 16.0 version of the binary which causes issues.

Disable-check: force-changelog-file