### PR TITLE
Updated reviewer list for pull-review bot

### DIFF
--- a/.pull-review
+++ b/.pull-review
@@ -46,7 +46,6 @@ reviewers:
   akuzm: {}
   gayyappan: {}
   jnidzwetzki: {}
-  mahipv: {}
   antekresic: {}
 
 # list of users who will never be notified


### PR DESCRIPTION
The pull-review bot requires that the chosen accounts be part of the organization. Updating the reviewer list to ensure the bot works.

---


Disable-check: force-changelog-file
