### PR TITLE
Fix constify cagg_watermark using window functions

### DIFF
--- a/.unreleased/pr_6726
+++ b/.unreleased/pr_6726
@@ -1,0 +1,2 @@
+Fixes: #6726 Fix constify cagg_watermark using window function when querying a CAgg
+Thanks: @rovo89 For reporting constify cagg_watermark not working using window function when querying a CAgg

--- a/tsl/src/continuous_aggs/planner.c
+++ b/tsl/src/continuous_aggs/planner.c
@@ -193,7 +193,7 @@ could_be_realtime_cagg_query(Query *query)
 	if (query->commandType != CMD_SELECT)
 		return false;
 
-	if (query->hasWindowFuncs || query->hasTargetSRFs)
+	if (query->hasTargetSRFs)
 		return false;
 
 	/* One range table, could be a query direct on a CAgg or a CTE expression */

--- a/tsl/test/expected/cagg_watermark-13.out
+++ b/tsl/test/expected/cagg_watermark-13.out
@@ -1801,3 +1801,22 @@ UNION ALL
 TRUNCATE _timescaledb_catalog.continuous_aggs_hypertable_invalidation_log;
 TRUNCATE _timescaledb_catalog.continuous_aggs_invalidation_threshold;
 \c :TEST_DBNAME :ROLE_DEFAULT_PERM_USER
+-- Issue #6722: constify cagg_watermark using window func when querying a cagg
+:EXPLAIN_ANALYZE
+SELECT time_bucket, lead(count) OVER (ORDER BY time_bucket) FROM small_integer_ht_cagg;
+                                                                   QUERY PLAN                                                                    
+-------------------------------------------------------------------------------------------------------------------------------------------------
+ WindowAgg (actual rows=6 loops=1)
+   ->  Sort (actual rows=6 loops=1)
+         Sort Key: _hyper_15_64_chunk.time_bucket
+         Sort Method: quicksort 
+         ->  Append (actual rows=6 loops=1)
+               ->  Index Scan using _hyper_15_64_chunk__materialized_hypertable_15_time_bucket_idx on _hyper_15_64_chunk (actual rows=6 loops=1)
+                     Index Cond: (time_bucket < '30'::bigint)
+               ->  HashAggregate (actual rows=0 loops=1)
+                     Group Key: time_bucket('5'::bigint, "time")
+                     Batches: 1 
+                     ->  Result (actual rows=0 loops=1)
+                           One-Time Filter: false
+(12 rows)
+

--- a/tsl/test/expected/cagg_watermark-14.out
+++ b/tsl/test/expected/cagg_watermark-14.out
@@ -1801,3 +1801,22 @@ UNION ALL
 TRUNCATE _timescaledb_catalog.continuous_aggs_hypertable_invalidation_log;
 TRUNCATE _timescaledb_catalog.continuous_aggs_invalidation_threshold;
 \c :TEST_DBNAME :ROLE_DEFAULT_PERM_USER
+-- Issue #6722: constify cagg_watermark using window func when querying a cagg
+:EXPLAIN_ANALYZE
+SELECT time_bucket, lead(count) OVER (ORDER BY time_bucket) FROM small_integer_ht_cagg;
+                                                                   QUERY PLAN                                                                    
+-------------------------------------------------------------------------------------------------------------------------------------------------
+ WindowAgg (actual rows=6 loops=1)
+   ->  Sort (actual rows=6 loops=1)
+         Sort Key: _hyper_15_64_chunk.time_bucket
+         Sort Method: quicksort 
+         ->  Append (actual rows=6 loops=1)
+               ->  Index Scan using _hyper_15_64_chunk__materialized_hypertable_15_time_bucket_idx on _hyper_15_64_chunk (actual rows=6 loops=1)
+                     Index Cond: (time_bucket < '30'::bigint)
+               ->  HashAggregate (actual rows=0 loops=1)
+                     Group Key: time_bucket('5'::bigint, "time")
+                     Batches: 1 
+                     ->  Result (actual rows=0 loops=1)
+                           One-Time Filter: false
+(12 rows)
+

--- a/tsl/test/expected/cagg_watermark-15.out
+++ b/tsl/test/expected/cagg_watermark-15.out
@@ -1808,3 +1808,22 @@ UNION ALL
 TRUNCATE _timescaledb_catalog.continuous_aggs_hypertable_invalidation_log;
 TRUNCATE _timescaledb_catalog.continuous_aggs_invalidation_threshold;
 \c :TEST_DBNAME :ROLE_DEFAULT_PERM_USER
+-- Issue #6722: constify cagg_watermark using window func when querying a cagg
+:EXPLAIN_ANALYZE
+SELECT time_bucket, lead(count) OVER (ORDER BY time_bucket) FROM small_integer_ht_cagg;
+                                                                   QUERY PLAN                                                                    
+-------------------------------------------------------------------------------------------------------------------------------------------------
+ WindowAgg (actual rows=6 loops=1)
+   ->  Sort (actual rows=6 loops=1)
+         Sort Key: _hyper_15_64_chunk.time_bucket
+         Sort Method: quicksort 
+         ->  Append (actual rows=6 loops=1)
+               ->  Index Scan using _hyper_15_64_chunk__materialized_hypertable_15_time_bucket_idx on _hyper_15_64_chunk (actual rows=6 loops=1)
+                     Index Cond: (time_bucket < '30'::bigint)
+               ->  HashAggregate (actual rows=0 loops=1)
+                     Group Key: time_bucket('5'::bigint, "time")
+                     Batches: 1 
+                     ->  Result (actual rows=0 loops=1)
+                           One-Time Filter: false
+(12 rows)
+

--- a/tsl/test/expected/cagg_watermark-16.out
+++ b/tsl/test/expected/cagg_watermark-16.out
@@ -1808,3 +1808,22 @@ UNION ALL
 TRUNCATE _timescaledb_catalog.continuous_aggs_hypertable_invalidation_log;
 TRUNCATE _timescaledb_catalog.continuous_aggs_invalidation_threshold;
 \c :TEST_DBNAME :ROLE_DEFAULT_PERM_USER
+-- Issue #6722: constify cagg_watermark using window func when querying a cagg
+:EXPLAIN_ANALYZE
+SELECT time_bucket, lead(count) OVER (ORDER BY time_bucket) FROM small_integer_ht_cagg;
+                                                                   QUERY PLAN                                                                    
+-------------------------------------------------------------------------------------------------------------------------------------------------
+ WindowAgg (actual rows=6 loops=1)
+   ->  Sort (actual rows=6 loops=1)
+         Sort Key: _hyper_15_64_chunk.time_bucket
+         Sort Method: quicksort 
+         ->  Append (actual rows=6 loops=1)
+               ->  Index Scan using _hyper_15_64_chunk__materialized_hypertable_15_time_bucket_idx on _hyper_15_64_chunk (actual rows=6 loops=1)
+                     Index Cond: (time_bucket < '30'::bigint)
+               ->  HashAggregate (actual rows=0 loops=1)
+                     Group Key: time_bucket('5'::bigint, "time")
+                     Batches: 1 
+                     ->  Result (actual rows=0 loops=1)
+                           One-Time Filter: false
+(12 rows)
+

--- a/tsl/test/sql/cagg_watermark.sql.in
+++ b/tsl/test/sql/cagg_watermark.sql.in
@@ -565,3 +565,7 @@ UNION ALL
 TRUNCATE _timescaledb_catalog.continuous_aggs_hypertable_invalidation_log;
 TRUNCATE _timescaledb_catalog.continuous_aggs_invalidation_threshold;
 \c :TEST_DBNAME :ROLE_DEFAULT_PERM_USER
+
+-- Issue #6722: constify cagg_watermark using window func when querying a cagg
+:EXPLAIN_ANALYZE
+SELECT time_bucket, lead(count) OVER (ORDER BY time_bucket) FROM small_integer_ht_cagg;


### PR DESCRIPTION
When querying a realtime Continuous Aggregate using window functions the new planner optimization to constify the `cagg_watermark` function call is not working because we're checking for window function usage on the query tree but actually this is a current limitation when creating a new Continuous Aggregate, but users can use window functions when querying it.

Fixed it by removing the check for `query->hasWindowFuncs` to prevent the process of constification of the `cagg_watermak` function call.

Fixes #6722