### PR TITLE
Allow multi-commit PRs with squash auto-merge

### DIFF
--- a/.github/workflows/pr-validation.yaml
+++ b/.github/workflows/pr-validation.yaml
@@ -36,7 +36,7 @@ jobs:
         BODY: ${{ github.event.pull_request.body }}
       run: |
         echo "$BODY" | egrep -qsi '^disable-check:.*\<commit-count\>'
-        if [[ $? -ne 0 ]] && [[ "${{ github.event.pull_request.auto_merge }}" != "squash" ]]
+        if [[ $? -ne 0 ]] && [[ "${{ github.event.pull_request.auto_merge.merge_method }}" != "squash" ]]
         then
           base=${{ github.event.pull_request.base.sha }}
           head=${{ github.event.pull_request.head.sha }}

--- a/.github/workflows/pr-validation.yaml
+++ b/.github/workflows/pr-validation.yaml
@@ -1,7 +1,7 @@
 name: Pull Request Validation
 "on":
   pull_request:
-    types: [opened, synchronize, reopened, edited]
+    types: [opened, synchronize, reopened, edited, auto_merge_enabled, auto_merge_disabled]
     branches: [main]
 jobs:
   # Count the number of commits in a pull request. This can be

--- a/.github/workflows/pr-validation.yaml
+++ b/.github/workflows/pr-validation.yaml
@@ -36,7 +36,8 @@ jobs:
         BODY: ${{ github.event.pull_request.body }}
       run: |
         echo "$BODY" | egrep -qsi '^disable-check:.*\<commit-count\>'
-        if [[ $? -ne 0 ]]; then
+        if [[ $? -ne 0 ]] && [[ "${{ github.event.pull_request.auto_merge }}" != "squash" ]]
+        then
           base=${{ github.event.pull_request.base.sha }}
           head=${{ github.event.pull_request.head.sha }}
           count=`git rev-list --count $base..$head`


### PR DESCRIPTION
It's convenient to squash the cleanup commits using the GitHub interface, but currently the PR validation prevents the squash merge from succeeding. Fix this.

Disable-check: force-changelog-file