### PR TITLE
Use INVALID_HYPERTABLE_ID constant when necessary

### DIFF
--- a/src/bgw/job.c
+++ b/src/bgw/job.c
@@ -1464,7 +1464,7 @@ ts_bgw_job_insert_relation(Name application_name, Interval *schedule_interval,
 			TimestampTzGetDatum(initial_start);
 	}
 
-	if (hypertable_id == 0)
+	if (hypertable_id == INVALID_HYPERTABLE_ID)
 		nulls[AttrNumberGetAttrOffset(Anum_bgw_job_hypertable_id)] = true;
 	else
 		values[AttrNumberGetAttrOffset(Anum_bgw_job_hypertable_id)] = Int32GetDatum(hypertable_id);

--- a/tsl/src/bgw_policy/job_api.c
+++ b/tsl/src/bgw_policy/job_api.c
@@ -183,7 +183,7 @@ job_add(PG_FUNCTION_ARGS)
 										owner,
 										scheduled,
 										fixed_schedule,
-										0,
+										INVALID_HYPERTABLE_ID,
 										config,
 										initial_start,
 										valid_timezone);


### PR DESCRIPTION
Instead of checking an invalid hypertable id against an arbitrary integer number (in this case zero) use the existing constant INVALID_HYPERTABLE_ID.

Disable-check: force-changelog-file
