### PR TITLE
Refactor returning time dimension MINIMUM value

### DIFF
--- a/tsl/src/continuous_aggs/create.c
+++ b/tsl/src/continuous_aggs/create.c
@@ -958,9 +958,7 @@ tsl_process_continuous_agg_viewstmt(Node *node, const char *query_string, void *
 		 * - ts_compute_inscribed_bucketed_refresh_window_variable()
 		 * - ts_compute_circumscribed_bucketed_refresh_window_variable()
 		 */
-		refresh_window.start = ts_continuous_agg_bucket_width_variable(cagg) ?
-								   ts_time_get_nobegin(refresh_window.type) :
-								   ts_time_get_min(refresh_window.type);
+		refresh_window.start = cagg_get_time_min(cagg);
 		refresh_window.end = ts_time_get_noend_or_max(refresh_window.type);
 
 		continuous_agg_refresh_internal(cagg, &refresh_window, CAGG_REFRESH_CREATION, true, true);

--- a/tsl/src/continuous_aggs/invalidation_threshold.c
+++ b/tsl/src/continuous_aggs/invalidation_threshold.c
@@ -237,28 +237,7 @@ invalidation_threshold_compute(const ContinuousAgg *cagg, const InternalTimeRang
 		if (isnull)
 		{
 			/* No data in hypertable */
-			if (ts_continuous_agg_bucket_width_variable(cagg))
-			{
-				/*
-				 * To determine inscribed/circumscribed refresh window for variable-sized
-				 * buckets we should be able to calculate time_bucket(window.begin) and
-				 * time_bucket(window.end). This, however, is not possible in general case.
-				 * As an example, the minimum date is 4714-11-24 BC, which is before any
-				 * reasonable default `origin` value. Thus for variable-sized buckets
-				 * instead of minimum date we use -infinity since time_bucket(-infinity)
-				 * is well-defined as -infinity.
-				 *
-				 * For more details see:
-				 * - ts_compute_inscribed_bucketed_refresh_window_variable()
-				 * - ts_compute_circumscribed_bucketed_refresh_window_variable()
-				 */
-				return ts_time_get_nobegin(refresh_window->type);
-			}
-			else
-			{
-				/* For fixed-sized buckets return min (start of time) */
-				return ts_time_get_min(refresh_window->type);
-			}
+			return cagg_get_time_min(cagg);
 		}
 		else
 		{
@@ -320,9 +299,7 @@ invalidation_threshold_initialize(const ContinuousAgg *cagg)
 		bool nulls[Natts_continuous_aggs_invalidation_threshold] = { false };
 		CatalogSecurityContext sec_ctx;
 		/* get the MIN value for the partition type */
-		int64 min_value = ts_continuous_agg_bucket_width_variable(cagg) ?
-							  ts_time_get_nobegin(cagg->partition_type) :
-							  ts_time_get_min(cagg->partition_type);
+		int64 min_value = cagg_get_time_min(cagg);
 
 		values[AttrNumberGetAttrOffset(Anum_continuous_aggs_invalidation_threshold_hypertable_id)] =
 			Int32GetDatum(cagg->data.raw_hypertable_id);

--- a/tsl/src/continuous_aggs/refresh.c
+++ b/tsl/src/continuous_aggs/refresh.c
@@ -597,22 +597,8 @@ continuous_agg_refresh(PG_FUNCTION_ARGS)
 													  refresh_window.type,
 													  true);
 	else
-		/*
-		 * To determine inscribed/circumscribed refresh window for variable-sized
-		 * buckets we should be able to calculate time_bucket(window.begin) and
-		 * time_bucket(window.end). This, however, is not possible in general case.
-		 * As an example, the minimum date is 4714-11-24 BC, which is before any
-		 * reasonable default `origin` value. Thus for variable-sized buckets
-		 * instead of minimum date we use -infinity since time_bucket(-infinity)
-		 * is well-defined as -infinity.
-		 *
-		 * For more details see:
-		 * - ts_compute_inscribed_bucketed_refresh_window_variable()
-		 * - ts_compute_circumscribed_bucketed_refresh_window_variable()
-		 */
-		refresh_window.start = ts_continuous_agg_bucket_width_variable(cagg) ?
-								   ts_time_get_nobegin_or_min(refresh_window.type) :
-								   ts_time_get_min(refresh_window.type);
+		/* get min time for a cagg depending of the primary partition type */
+		refresh_window.start = cagg_get_time_min(cagg);
 
 	if (!PG_ARGISNULL(2))
 		refresh_window.end = ts_time_value_from_arg(PG_GETARG_DATUM(2),


### PR DESCRIPTION
Encapsulate the logic for getting the MINIMUM value of a time dimension for a Continuous Aggregate in a single place instead of spread the logic everywhere that can lead to wrong usage specially because there are a difference between fixed and variable size buckets.

Disable-check: force-changelog-file
