### PR TITLE
Convert max materializations setting to GUC

### DIFF
--- a/src/guc.c
+++ b/src/guc.c
@@ -62,6 +62,7 @@ bool ts_guc_enable_qual_propagation = true;
 bool ts_guc_enable_cagg_reorder_groupby = true;
 bool ts_guc_enable_now_constify = true;
 TSDLLEXPORT bool ts_guc_enable_cagg_watermark_constify = true;
+TSDLLEXPORT int ts_guc_cagg_max_individual_materializations = 10;
 bool ts_guc_enable_osm_reads = true;
 TSDLLEXPORT bool ts_guc_enable_dml_decompression = true;
 TSDLLEXPORT int ts_guc_max_tuples_decompressed_per_dml = 100000;
@@ -436,6 +437,26 @@ _guc_init(void)
 							 NULL,
 							 NULL,
 							 NULL);
+
+	/*
+	 * Define the limit on number of invalidation-based refreshes we allow per
+	 * refresh call. If this limit is exceeded, fall back to a single refresh that
+	 * covers the range decided by the min and max invalidated time.
+	 */
+	DefineCustomIntVariable(MAKE_EXTOPTION("materializations_per_refresh_window"),
+							"Max number of materializations per cagg refresh window",
+							"The maximal number of individual refreshes per cagg refresh. If more "
+							"refreshes need to be performed, they are merged into a larger "
+							"single refresh.",
+							&ts_guc_cagg_max_individual_materializations,
+							10,
+							0,
+							INT_MAX,
+							PGC_USERSET,
+							0,
+							NULL,
+							NULL,
+							NULL);
 
 	DefineCustomBoolVariable(MAKE_EXTOPTION("enable_tiered_reads"),
 							 "Enable tiered data reads",

--- a/src/guc.h
+++ b/src/guc.h
@@ -24,6 +24,7 @@ extern bool ts_guc_enable_qual_propagation;
 extern bool ts_guc_enable_runtime_exclusion;
 extern bool ts_guc_enable_constraint_exclusion;
 extern bool ts_guc_enable_cagg_reorder_groupby;
+extern TSDLLEXPORT int ts_guc_cagg_max_individual_materializations;
 extern bool ts_guc_enable_now_constify;
 extern TSDLLEXPORT bool ts_guc_enable_cagg_watermark_constify;
 extern bool ts_guc_enable_osm_reads;

--- a/tsl/test/expected/cagg_invalidation.out
+++ b/tsl/test/expected/cagg_invalidation.out
@@ -1201,32 +1201,33 @@ INSERT INTO conditions VALUES (120, 1, 1.0);
 INSERT INTO conditions VALUES (140, 1, 1.0);
 CALL refresh_continuous_aggregate('cond_10', 0, 200);
 \set VERBOSITY default
+\set ON_ERROR_STOP 0
 -- Test acceptable values for materializations per refresh
 SET timescaledb.materializations_per_refresh_window=' 5 ';
 INSERT INTO conditions VALUES (140, 1, 1.0);
 CALL refresh_continuous_aggregate('cond_10', 0, 200);
 -- Large value will be treated as LONG_MAX
 SET timescaledb.materializations_per_refresh_window=342239897234023842394249234766923492347;
+ERROR:  invalid value for parameter "timescaledb.materializations_per_refresh_window": "342239897234023842394249234766923492347"
+HINT:  Value exceeds integer range.
 INSERT INTO conditions VALUES (140, 1, 1.0);
 CALL refresh_continuous_aggregate('cond_10', 0, 200);
 -- Test bad values for materializations per refresh
 SET timescaledb.materializations_per_refresh_window='foo';
+ERROR:  invalid value for parameter "timescaledb.materializations_per_refresh_window": "foo"
 INSERT INTO conditions VALUES (140, 1, 1.0);
 CALL refresh_continuous_aggregate('cond_10', 0, 200);
-WARNING:  invalid value for session variable "timescaledb.materializations_per_refresh_window"
-DETAIL:  Expected an integer but current value is "foo".
 SET timescaledb.materializations_per_refresh_window='2bar';
+ERROR:  invalid value for parameter "timescaledb.materializations_per_refresh_window": "2bar"
 INSERT INTO conditions VALUES (140, 1, 1.0);
 CALL refresh_continuous_aggregate('cond_10', 0, 200);
-WARNING:  invalid value for session variable "timescaledb.materializations_per_refresh_window"
-DETAIL:  Expected an integer but current value is "2bar".
 SET timescaledb.materializations_per_refresh_window='-';
+ERROR:  invalid value for parameter "timescaledb.materializations_per_refresh_window": "-"
 INSERT INTO conditions VALUES (140, 1, 1.0);
 CALL refresh_continuous_aggregate('cond_10', 0, 200);
-WARNING:  invalid value for session variable "timescaledb.materializations_per_refresh_window"
-DETAIL:  Expected an integer but current value is "-".
 \set VERBOSITY terse
 RESET timescaledb.materializations_per_refresh_window;
+\set ON_ERROR_STOP 1
 -- Test refresh with undefined invalidation threshold and variable sized buckets
 CREATE TABLE timestamp_ht (
   time timestamptz NOT NULL,

--- a/tsl/test/sql/cagg_invalidation.sql
+++ b/tsl/test/sql/cagg_invalidation.sql
@@ -698,6 +698,7 @@ INSERT INTO conditions VALUES (140, 1, 1.0);
 CALL refresh_continuous_aggregate('cond_10', 0, 200);
 
 \set VERBOSITY default
+\set ON_ERROR_STOP 0
 -- Test acceptable values for materializations per refresh
 SET timescaledb.materializations_per_refresh_window=' 5 ';
 INSERT INTO conditions VALUES (140, 1, 1.0);
@@ -720,6 +721,7 @@ INSERT INTO conditions VALUES (140, 1, 1.0);
 CALL refresh_continuous_aggregate('cond_10', 0, 200);
 \set VERBOSITY terse
 RESET timescaledb.materializations_per_refresh_window;
+\set ON_ERROR_STOP 1
 
 -- Test refresh with undefined invalidation threshold and variable sized buckets
 CREATE TABLE timestamp_ht (


### PR DESCRIPTION
PR #2926 introduced a session-based configuration parameter for the CAgg refresh behavior. If more individual refreshes have to be carried out than specified by this setting, a refresh for a larger window is performed.

It is mentioned in the original PR that this setting should be converted into a GUC later. This PR performs the proposed change.

---

Disable-check: force-changelog-file
BGW tests are contained in: #6756