### PR TITLE
Check for missing memory context switch back

### DIFF
--- a/coccinelle/mcxt.cocci
+++ b/coccinelle/mcxt.cocci
@@ -1,0 +1,21 @@
+// find MemoryContextSwitchTo missing a context switch back
+@ MemoryContextSwitch @
+local idexpression oldctx;
+position p;
+@@
+oldctx@p = MemoryContextSwitchTo(...);
+
+@safelist@
+local idexpression MemoryContextSwitch.oldctx;
+position MemoryContextSwitch.p;
+@@
+oldctx@p = MemoryContextSwitchTo(...);
+...
+MemoryContextSwitchTo(oldctx)
+
+@depends on !safelist@
+expression oldctx;
+position MemoryContextSwitch.p;
+@@
++ /* MemoryContextSwitch missing context switch back */
+  oldctx@p = MemoryContextSwitchTo(...);


### PR DESCRIPTION
If memory context is switched temporarily and there is no switch back, it will cause strange errors.

This adds a Coccinelle rule that checks for a case where the memory context is saved in a temporary variable but this variable is not used to switch back to the original memory context.

Disable-check: force-changelog-file