### PR TITLE
Remove autovacuum setting from compressed chunks

### DIFF
--- a/.unreleased/bugfix_6752
+++ b/.unreleased/bugfix_6752
@@ -1,0 +1,1 @@
+Fixes: #6752 Remove custom autovacuum setting from compressed chunks


### PR DESCRIPTION
In old TSDB versions, we disabled autovacuum for compressed chunks to keep the statistics. However, this restriction was removed in #5118, but no migration was performed to reset the custom autovacuum setting for existing chunks.