### PR TITLE
Log CAgg refresh details in BGW

### DIFF
--- a/tsl/src/continuous_aggs/common.h
+++ b/tsl/src/continuous_aggs/common.h
@@ -84,6 +84,13 @@ typedef struct CAggTimebucketInfo
 	TimestampTz origin;
 } CAggTimebucketInfo;
 
+typedef enum CaggRefreshCallContext
+{
+	CAGG_REFRESH_CREATION,
+	CAGG_REFRESH_WINDOW,
+	CAGG_REFRESH_POLICY,
+} CaggRefreshCallContext;
+
 #define CAGG_MAKEQUERY(selquery, srcquery)                                                         \
 	do                                                                                             \
 	{                                                                                              \

--- a/tsl/src/continuous_aggs/invalidation.c
+++ b/tsl/src/continuous_aggs/invalidation.c
@@ -1015,7 +1015,8 @@ InvalidationStore *
 invalidation_process_cagg_log(int32 mat_hypertable_id, int32 raw_hypertable_id,
 							  const InternalTimeRange *refresh_window,
 							  const CaggsInfo *all_caggs_info, const long max_materializations,
-							  bool *do_merged_refresh, InternalTimeRange *ret_merged_refresh_window)
+							  bool *do_merged_refresh, InternalTimeRange *ret_merged_refresh_window,
+							  const CaggRefreshCallContext callctx)
 {
 	CaggInvalidationState state;
 	InvalidationStore *store = NULL;
@@ -1057,7 +1058,8 @@ invalidation_process_cagg_log(int32 mat_hypertable_id, int32 raw_hypertable_id,
 													   store,
 													   state.bucket_width,
 													   state.bucket_function,
-													   &merged_refresh_window);
+													   &merged_refresh_window,
+													   callctx);
 		*do_merged_refresh = true;
 		*ret_merged_refresh_window = merged_refresh_window;
 		invalidation_store_free(store);

--- a/tsl/src/continuous_aggs/invalidation.h
+++ b/tsl/src/continuous_aggs/invalidation.h
@@ -48,6 +48,6 @@ extern void invalidation_process_hypertable_log(int32 mat_hypertable_id, int32 r
 extern InvalidationStore *invalidation_process_cagg_log(
 	int32 mat_hypertable_id, int32 raw_hypertable_id, const InternalTimeRange *refresh_window,
 	const CaggsInfo *all_caggs_info, const long max_materializations, bool *do_merged_refresh,
-	InternalTimeRange *ret_merged_refresh_window);
+	InternalTimeRange *ret_merged_refresh_window, const CaggRefreshCallContext callctx);
 
 extern void invalidation_store_free(InvalidationStore *store);

--- a/tsl/src/continuous_aggs/refresh.h
+++ b/tsl/src/continuous_aggs/refresh.h
@@ -12,19 +12,11 @@
 #include "materialize.h"
 #include "invalidation.h"
 
-typedef enum CaggRefreshCallContext
-{
-	CAGG_REFRESH_CREATION,
-	CAGG_REFRESH_WINDOW,
-	CAGG_REFRESH_CHUNK,
-	CAGG_REFRESH_POLICY,
-} CaggRefreshCallContext;
-
 extern Datum continuous_agg_refresh(PG_FUNCTION_ARGS);
 extern void continuous_agg_calculate_merged_refresh_window(
 	const InternalTimeRange *refresh_window, const InvalidationStore *invalidations,
 	const int64 bucket_width, const ContinuousAggsBucketFunction *bucket_function,
-	InternalTimeRange *merged_refresh_window);
+	InternalTimeRange *merged_refresh_window, const CaggRefreshCallContext callctx);
 extern void continuous_agg_refresh_internal(const ContinuousAgg *cagg,
 											const InternalTimeRange *refresh_window,
 											const CaggRefreshCallContext callctx,

--- a/tsl/test/expected/cagg_bgw-13.out
+++ b/tsl/test/expected/cagg_bgw-13.out
@@ -145,11 +145,11 @@ SELECT ts_bgw_db_scheduler_test_run_and_wait_for_scheduler_finish(25);
 (1 row)
 
 SELECT * FROM sorted_bgw_log;
- msg_no | mock_time |              application_name              |                                               msg                                               
---------+-----------+--------------------------------------------+-------------------------------------------------------------------------------------------------
+ msg_no | mock_time |              application_name              |                                                        msg                                                        
+--------+-----------+--------------------------------------------+-------------------------------------------------------------------------------------------------------------------
       0 |         0 | DB Scheduler                               | [TESTING] Registered new background worker
       1 |         0 | DB Scheduler                               | [TESTING] Wait until (RANDOM), started at (RANDOM)
-      0 |         0 | Refresh Continuous Aggregate Policy [1000] | refreshing continuous aggregate "test_continuous_agg_view" in window [ -2147483648, 6 ]
+      0 |         0 | Refresh Continuous Aggregate Policy [1000] | continuous aggregate refresh (individual invalidation) on "test_continuous_agg_view" in window [ -2147483648, 6 ]
       1 |         0 | Refresh Continuous Aggregate Policy [1000] | deleted 0 row(s) from materialization table "_timescaledb_internal._materialized_hypertable_2"
       2 |         0 | Refresh Continuous Aggregate Policy [1000] | inserted 3 row(s) into materialization table "_timescaledb_internal._materialized_hypertable_2"
 (5 rows)
@@ -380,11 +380,11 @@ SELECT ts_bgw_db_scheduler_test_run_and_wait_for_scheduler_finish(25);
 (1 row)
 
 SELECT * FROM sorted_bgw_log;
- msg_no | mock_time |              application_name              |                                               msg                                               
---------+-----------+--------------------------------------------+-------------------------------------------------------------------------------------------------
+ msg_no | mock_time |              application_name              |                                                    msg                                                     
+--------+-----------+--------------------------------------------+------------------------------------------------------------------------------------------------------------
       0 |         0 | DB Scheduler                               | [TESTING] Registered new background worker
       1 |         0 | DB Scheduler                               | [TESTING] Wait until (RANDOM), started at (RANDOM)
-      0 |         0 | Refresh Continuous Aggregate Policy [1001] | refreshing continuous aggregate "test_continuous_agg_view" in window [ -90, 12 ]
+      0 |         0 | Refresh Continuous Aggregate Policy [1001] | continuous aggregate refresh (individual invalidation) on "test_continuous_agg_view" in window [ -90, 12 ]
       1 |         0 | Refresh Continuous Aggregate Policy [1001] | deleted 0 row(s) from materialization table "_timescaledb_internal._materialized_hypertable_3"
       2 |         0 | Refresh Continuous Aggregate Policy [1001] | inserted 6 row(s) into materialization table "_timescaledb_internal._materialized_hypertable_3"
 (5 rows)
@@ -427,16 +427,16 @@ SELECT ts_bgw_db_scheduler_test_run_and_wait_for_scheduler_finish(25, 25);
 (1 row)
 
 SELECT * FROM sorted_bgw_log;
- msg_no |  mock_time  |              application_name              |                                               msg                                               
---------+-------------+--------------------------------------------+-------------------------------------------------------------------------------------------------
+ msg_no |  mock_time  |              application_name              |                                                    msg                                                     
+--------+-------------+--------------------------------------------+------------------------------------------------------------------------------------------------------------
       0 |           0 | DB Scheduler                               | [TESTING] Registered new background worker
       1 |           0 | DB Scheduler                               | [TESTING] Wait until (RANDOM), started at (RANDOM)
-      0 |           0 | Refresh Continuous Aggregate Policy [1001] | refreshing continuous aggregate "test_continuous_agg_view" in window [ -90, 12 ]
+      0 |           0 | Refresh Continuous Aggregate Policy [1001] | continuous aggregate refresh (individual invalidation) on "test_continuous_agg_view" in window [ -90, 12 ]
       1 |           0 | Refresh Continuous Aggregate Policy [1001] | deleted 0 row(s) from materialization table "_timescaledb_internal._materialized_hypertable_3"
       2 |           0 | Refresh Continuous Aggregate Policy [1001] | inserted 6 row(s) into materialization table "_timescaledb_internal._materialized_hypertable_3"
       0 | 43200000000 | DB Scheduler                               | [TESTING] Registered new background worker
       1 | 43200000000 | DB Scheduler                               | [TESTING] Wait until (RANDOM), started at (RANDOM)
-      0 | 43200000000 | Refresh Continuous Aggregate Policy [1001] | refreshing continuous aggregate "test_continuous_agg_view" in window [ -90, 12 ]
+      0 | 43200000000 | Refresh Continuous Aggregate Policy [1001] | continuous aggregate refresh (individual invalidation) on "test_continuous_agg_view" in window [ 6, 8 ]
       1 | 43200000000 | Refresh Continuous Aggregate Policy [1001] | deleted 1 row(s) from materialization table "_timescaledb_internal._materialized_hypertable_3"
       2 | 43200000000 | Refresh Continuous Aggregate Policy [1001] | inserted 1 row(s) into materialization table "_timescaledb_internal._materialized_hypertable_3"
 (10 rows)
@@ -490,6 +490,59 @@ job_status        | Scheduled
 last_run_duration | 
 
 \x off
+-- test merged refresh (change data in two chunks)
+UPDATE test_continuous_agg_table SET data = 11;
+\c :TEST_DBNAME :ROLE_CLUSTER_SUPERUSER
+ALTER SYSTEM SET timescaledb.materializations_per_refresh_window = 0;
+SELECT pg_reload_conf();
+ pg_reload_conf 
+----------------
+ t
+(1 row)
+
+SET ROLE :ROLE_DEFAULT_PERM_USER;
+--advance time by 1day so that job runs one more time
+SELECT ts_bgw_params_reset_time(extract(epoch from interval '1day')::bigint * 1000000, true);
+ ts_bgw_params_reset_time 
+--------------------------
+ 
+(1 row)
+
+SELECT ts_bgw_db_scheduler_test_run_and_wait_for_scheduler_finish(50, 50);
+ ts_bgw_db_scheduler_test_run_and_wait_for_scheduler_finish 
+------------------------------------------------------------
+ 
+(1 row)
+
+SELECT * FROM sorted_bgw_log;
+ msg_no |  mock_time  |              application_name              |                                                    msg                                                     
+--------+-------------+--------------------------------------------+------------------------------------------------------------------------------------------------------------
+      0 |           0 | DB Scheduler                               | [TESTING] Registered new background worker
+      1 |           0 | DB Scheduler                               | [TESTING] Wait until (RANDOM), started at (RANDOM)
+      0 |           0 | Refresh Continuous Aggregate Policy [1001] | continuous aggregate refresh (individual invalidation) on "test_continuous_agg_view" in window [ -90, 12 ]
+      1 |           0 | Refresh Continuous Aggregate Policy [1001] | deleted 0 row(s) from materialization table "_timescaledb_internal._materialized_hypertable_3"
+      2 |           0 | Refresh Continuous Aggregate Policy [1001] | inserted 6 row(s) into materialization table "_timescaledb_internal._materialized_hypertable_3"
+      0 | 43200000000 | DB Scheduler                               | [TESTING] Registered new background worker
+      1 | 43200000000 | DB Scheduler                               | [TESTING] Wait until (RANDOM), started at (RANDOM)
+      0 | 43200000000 | Refresh Continuous Aggregate Policy [1001] | continuous aggregate refresh (individual invalidation) on "test_continuous_agg_view" in window [ 6, 8 ]
+      1 | 43200000000 | Refresh Continuous Aggregate Policy [1001] | deleted 1 row(s) from materialization table "_timescaledb_internal._materialized_hypertable_3"
+      2 | 43200000000 | Refresh Continuous Aggregate Policy [1001] | inserted 1 row(s) into materialization table "_timescaledb_internal._materialized_hypertable_3"
+      0 | 86400000000 | DB Scheduler                               | [TESTING] Registered new background worker
+      1 | 86400000000 | DB Scheduler                               | [TESTING] Wait until (RANDOM), started at (RANDOM)
+      0 | 86400000000 | Refresh Continuous Aggregate Policy [1001] | continuous aggregate refresh (merged invalidation) on "test_continuous_agg_view" in window [ 0, 12 ]
+      1 | 86400000000 | Refresh Continuous Aggregate Policy [1001] | deleted 6 row(s) from materialization table "_timescaledb_internal._materialized_hypertable_3"
+      2 | 86400000000 | Refresh Continuous Aggregate Policy [1001] | inserted 6 row(s) into materialization table "_timescaledb_internal._materialized_hypertable_3"
+(15 rows)
+
+\c :TEST_DBNAME :ROLE_CLUSTER_SUPERUSER
+ALTER SYSTEM RESET timescaledb.materializations_per_refresh_window;
+SELECT pg_reload_conf();
+ pg_reload_conf 
+----------------
+ t
+(1 row)
+
+SET ROLE :ROLE_DEFAULT_PERM_USER;
 DROP MATERIALIZED VIEW test_continuous_agg_view;
 NOTICE:  drop cascades to table _timescaledb_internal._hyper_3_4_chunk
 --create a view with a function that it has no permission to execute
@@ -650,11 +703,11 @@ SELECT * FROM test_continuous_agg_view_user_2;
 
 \c :TEST_DBNAME :ROLE_DEFAULT_PERM_USER
 SELECT * from sorted_bgw_log;
- msg_no |  mock_time  |              application_name              |                                               msg                                               
---------+-------------+--------------------------------------------+-------------------------------------------------------------------------------------------------
+ msg_no |  mock_time  |              application_name              |                                                           msg                                                            
+--------+-------------+--------------------------------------------+--------------------------------------------------------------------------------------------------------------------------
       0 |           0 | DB Scheduler                               | [TESTING] Registered new background worker
       1 |           0 | DB Scheduler                               | [TESTING] Wait until (RANDOM), started at (RANDOM)
-      0 |           0 | Refresh Continuous Aggregate Policy [1003] | refreshing continuous aggregate "test_continuous_agg_view_user_2" in window [ -2147483648, 2 ]
+      0 |           0 | Refresh Continuous Aggregate Policy [1003] | continuous aggregate refresh (individual invalidation) on "test_continuous_agg_view_user_2" in window [ -2147483648, 2 ]
       1 |           0 | Refresh Continuous Aggregate Policy [1003] | deleted 0 row(s) from materialization table "_timescaledb_internal._materialized_hypertable_6"
       2 |           0 | Refresh Continuous Aggregate Policy [1003] | inserted 1 row(s) into materialization table "_timescaledb_internal._materialized_hypertable_6"
       0 | 43200000000 | DB Scheduler                               | [TESTING] Registered new background worker

--- a/tsl/test/expected/cagg_bgw-14.out
+++ b/tsl/test/expected/cagg_bgw-14.out
@@ -145,11 +145,11 @@ SELECT ts_bgw_db_scheduler_test_run_and_wait_for_scheduler_finish(25);
 (1 row)
 
 SELECT * FROM sorted_bgw_log;
- msg_no | mock_time |              application_name              |                                               msg                                               
---------+-----------+--------------------------------------------+-------------------------------------------------------------------------------------------------
+ msg_no | mock_time |              application_name              |                                                        msg                                                        
+--------+-----------+--------------------------------------------+-------------------------------------------------------------------------------------------------------------------
       0 |         0 | DB Scheduler                               | [TESTING] Registered new background worker
       1 |         0 | DB Scheduler                               | [TESTING] Wait until (RANDOM), started at (RANDOM)
-      0 |         0 | Refresh Continuous Aggregate Policy [1000] | refreshing continuous aggregate "test_continuous_agg_view" in window [ -2147483648, 6 ]
+      0 |         0 | Refresh Continuous Aggregate Policy [1000] | continuous aggregate refresh (individual invalidation) on "test_continuous_agg_view" in window [ -2147483648, 6 ]
       1 |         0 | Refresh Continuous Aggregate Policy [1000] | deleted 0 row(s) from materialization table "_timescaledb_internal._materialized_hypertable_2"
       2 |         0 | Refresh Continuous Aggregate Policy [1000] | inserted 3 row(s) into materialization table "_timescaledb_internal._materialized_hypertable_2"
 (5 rows)
@@ -380,11 +380,11 @@ SELECT ts_bgw_db_scheduler_test_run_and_wait_for_scheduler_finish(25);
 (1 row)
 
 SELECT * FROM sorted_bgw_log;
- msg_no | mock_time |              application_name              |                                               msg                                               
---------+-----------+--------------------------------------------+-------------------------------------------------------------------------------------------------
+ msg_no | mock_time |              application_name              |                                                    msg                                                     
+--------+-----------+--------------------------------------------+------------------------------------------------------------------------------------------------------------
       0 |         0 | DB Scheduler                               | [TESTING] Registered new background worker
       1 |         0 | DB Scheduler                               | [TESTING] Wait until (RANDOM), started at (RANDOM)
-      0 |         0 | Refresh Continuous Aggregate Policy [1001] | refreshing continuous aggregate "test_continuous_agg_view" in window [ -90, 12 ]
+      0 |         0 | Refresh Continuous Aggregate Policy [1001] | continuous aggregate refresh (individual invalidation) on "test_continuous_agg_view" in window [ -90, 12 ]
       1 |         0 | Refresh Continuous Aggregate Policy [1001] | deleted 0 row(s) from materialization table "_timescaledb_internal._materialized_hypertable_3"
       2 |         0 | Refresh Continuous Aggregate Policy [1001] | inserted 6 row(s) into materialization table "_timescaledb_internal._materialized_hypertable_3"
 (5 rows)
@@ -427,16 +427,16 @@ SELECT ts_bgw_db_scheduler_test_run_and_wait_for_scheduler_finish(25, 25);
 (1 row)
 
 SELECT * FROM sorted_bgw_log;
- msg_no |  mock_time  |              application_name              |                                               msg                                               
---------+-------------+--------------------------------------------+-------------------------------------------------------------------------------------------------
+ msg_no |  mock_time  |              application_name              |                                                    msg                                                     
+--------+-------------+--------------------------------------------+------------------------------------------------------------------------------------------------------------
       0 |           0 | DB Scheduler                               | [TESTING] Registered new background worker
       1 |           0 | DB Scheduler                               | [TESTING] Wait until (RANDOM), started at (RANDOM)
-      0 |           0 | Refresh Continuous Aggregate Policy [1001] | refreshing continuous aggregate "test_continuous_agg_view" in window [ -90, 12 ]
+      0 |           0 | Refresh Continuous Aggregate Policy [1001] | continuous aggregate refresh (individual invalidation) on "test_continuous_agg_view" in window [ -90, 12 ]
       1 |           0 | Refresh Continuous Aggregate Policy [1001] | deleted 0 row(s) from materialization table "_timescaledb_internal._materialized_hypertable_3"
       2 |           0 | Refresh Continuous Aggregate Policy [1001] | inserted 6 row(s) into materialization table "_timescaledb_internal._materialized_hypertable_3"
       0 | 43200000000 | DB Scheduler                               | [TESTING] Registered new background worker
       1 | 43200000000 | DB Scheduler                               | [TESTING] Wait until (RANDOM), started at (RANDOM)
-      0 | 43200000000 | Refresh Continuous Aggregate Policy [1001] | refreshing continuous aggregate "test_continuous_agg_view" in window [ -90, 12 ]
+      0 | 43200000000 | Refresh Continuous Aggregate Policy [1001] | continuous aggregate refresh (individual invalidation) on "test_continuous_agg_view" in window [ 6, 8 ]
       1 | 43200000000 | Refresh Continuous Aggregate Policy [1001] | deleted 1 row(s) from materialization table "_timescaledb_internal._materialized_hypertable_3"
       2 | 43200000000 | Refresh Continuous Aggregate Policy [1001] | inserted 1 row(s) into materialization table "_timescaledb_internal._materialized_hypertable_3"
 (10 rows)
@@ -490,6 +490,59 @@ job_status        | Scheduled
 last_run_duration | 
 
 \x off
+-- test merged refresh (change data in two chunks)
+UPDATE test_continuous_agg_table SET data = 11;
+\c :TEST_DBNAME :ROLE_CLUSTER_SUPERUSER
+ALTER SYSTEM SET timescaledb.materializations_per_refresh_window = 0;
+SELECT pg_reload_conf();
+ pg_reload_conf 
+----------------
+ t
+(1 row)
+
+SET ROLE :ROLE_DEFAULT_PERM_USER;
+--advance time by 1day so that job runs one more time
+SELECT ts_bgw_params_reset_time(extract(epoch from interval '1day')::bigint * 1000000, true);
+ ts_bgw_params_reset_time 
+--------------------------
+ 
+(1 row)
+
+SELECT ts_bgw_db_scheduler_test_run_and_wait_for_scheduler_finish(50, 50);
+ ts_bgw_db_scheduler_test_run_and_wait_for_scheduler_finish 
+------------------------------------------------------------
+ 
+(1 row)
+
+SELECT * FROM sorted_bgw_log;
+ msg_no |  mock_time  |              application_name              |                                                    msg                                                     
+--------+-------------+--------------------------------------------+------------------------------------------------------------------------------------------------------------
+      0 |           0 | DB Scheduler                               | [TESTING] Registered new background worker
+      1 |           0 | DB Scheduler                               | [TESTING] Wait until (RANDOM), started at (RANDOM)
+      0 |           0 | Refresh Continuous Aggregate Policy [1001] | continuous aggregate refresh (individual invalidation) on "test_continuous_agg_view" in window [ -90, 12 ]
+      1 |           0 | Refresh Continuous Aggregate Policy [1001] | deleted 0 row(s) from materialization table "_timescaledb_internal._materialized_hypertable_3"
+      2 |           0 | Refresh Continuous Aggregate Policy [1001] | inserted 6 row(s) into materialization table "_timescaledb_internal._materialized_hypertable_3"
+      0 | 43200000000 | DB Scheduler                               | [TESTING] Registered new background worker
+      1 | 43200000000 | DB Scheduler                               | [TESTING] Wait until (RANDOM), started at (RANDOM)
+      0 | 43200000000 | Refresh Continuous Aggregate Policy [1001] | continuous aggregate refresh (individual invalidation) on "test_continuous_agg_view" in window [ 6, 8 ]
+      1 | 43200000000 | Refresh Continuous Aggregate Policy [1001] | deleted 1 row(s) from materialization table "_timescaledb_internal._materialized_hypertable_3"
+      2 | 43200000000 | Refresh Continuous Aggregate Policy [1001] | inserted 1 row(s) into materialization table "_timescaledb_internal._materialized_hypertable_3"
+      0 | 86400000000 | DB Scheduler                               | [TESTING] Registered new background worker
+      1 | 86400000000 | DB Scheduler                               | [TESTING] Wait until (RANDOM), started at (RANDOM)
+      0 | 86400000000 | Refresh Continuous Aggregate Policy [1001] | continuous aggregate refresh (merged invalidation) on "test_continuous_agg_view" in window [ 0, 12 ]
+      1 | 86400000000 | Refresh Continuous Aggregate Policy [1001] | deleted 6 row(s) from materialization table "_timescaledb_internal._materialized_hypertable_3"
+      2 | 86400000000 | Refresh Continuous Aggregate Policy [1001] | inserted 6 row(s) into materialization table "_timescaledb_internal._materialized_hypertable_3"
+(15 rows)
+
+\c :TEST_DBNAME :ROLE_CLUSTER_SUPERUSER
+ALTER SYSTEM RESET timescaledb.materializations_per_refresh_window;
+SELECT pg_reload_conf();
+ pg_reload_conf 
+----------------
+ t
+(1 row)
+
+SET ROLE :ROLE_DEFAULT_PERM_USER;
 DROP MATERIALIZED VIEW test_continuous_agg_view;
 NOTICE:  drop cascades to table _timescaledb_internal._hyper_3_4_chunk
 --create a view with a function that it has no permission to execute
@@ -650,11 +703,11 @@ SELECT * FROM test_continuous_agg_view_user_2;
 
 \c :TEST_DBNAME :ROLE_DEFAULT_PERM_USER
 SELECT * from sorted_bgw_log;
- msg_no |  mock_time  |              application_name              |                                               msg                                               
---------+-------------+--------------------------------------------+-------------------------------------------------------------------------------------------------
+ msg_no |  mock_time  |              application_name              |                                                           msg                                                            
+--------+-------------+--------------------------------------------+--------------------------------------------------------------------------------------------------------------------------
       0 |           0 | DB Scheduler                               | [TESTING] Registered new background worker
       1 |           0 | DB Scheduler                               | [TESTING] Wait until (RANDOM), started at (RANDOM)
-      0 |           0 | Refresh Continuous Aggregate Policy [1003] | refreshing continuous aggregate "test_continuous_agg_view_user_2" in window [ -2147483648, 2 ]
+      0 |           0 | Refresh Continuous Aggregate Policy [1003] | continuous aggregate refresh (individual invalidation) on "test_continuous_agg_view_user_2" in window [ -2147483648, 2 ]
       1 |           0 | Refresh Continuous Aggregate Policy [1003] | deleted 0 row(s) from materialization table "_timescaledb_internal._materialized_hypertable_6"
       2 |           0 | Refresh Continuous Aggregate Policy [1003] | inserted 1 row(s) into materialization table "_timescaledb_internal._materialized_hypertable_6"
       0 | 43200000000 | DB Scheduler                               | [TESTING] Registered new background worker

--- a/tsl/test/expected/cagg_bgw-15.out
+++ b/tsl/test/expected/cagg_bgw-15.out
@@ -145,11 +145,11 @@ SELECT ts_bgw_db_scheduler_test_run_and_wait_for_scheduler_finish(25);
 (1 row)
 
 SELECT * FROM sorted_bgw_log;
- msg_no | mock_time |              application_name              |                                               msg                                               
---------+-----------+--------------------------------------------+-------------------------------------------------------------------------------------------------
+ msg_no | mock_time |              application_name              |                                                        msg                                                        
+--------+-----------+--------------------------------------------+-------------------------------------------------------------------------------------------------------------------
       0 |         0 | DB Scheduler                               | [TESTING] Registered new background worker
       1 |         0 | DB Scheduler                               | [TESTING] Wait until (RANDOM), started at (RANDOM)
-      0 |         0 | Refresh Continuous Aggregate Policy [1000] | refreshing continuous aggregate "test_continuous_agg_view" in window [ -2147483648, 6 ]
+      0 |         0 | Refresh Continuous Aggregate Policy [1000] | continuous aggregate refresh (individual invalidation) on "test_continuous_agg_view" in window [ -2147483648, 6 ]
       1 |         0 | Refresh Continuous Aggregate Policy [1000] | deleted 0 row(s) from materialization table "_timescaledb_internal._materialized_hypertable_2"
       2 |         0 | Refresh Continuous Aggregate Policy [1000] | inserted 3 row(s) into materialization table "_timescaledb_internal._materialized_hypertable_2"
 (5 rows)
@@ -380,11 +380,11 @@ SELECT ts_bgw_db_scheduler_test_run_and_wait_for_scheduler_finish(25);
 (1 row)
 
 SELECT * FROM sorted_bgw_log;
- msg_no | mock_time |              application_name              |                                               msg                                               
---------+-----------+--------------------------------------------+-------------------------------------------------------------------------------------------------
+ msg_no | mock_time |              application_name              |                                                    msg                                                     
+--------+-----------+--------------------------------------------+------------------------------------------------------------------------------------------------------------
       0 |         0 | DB Scheduler                               | [TESTING] Registered new background worker
       1 |         0 | DB Scheduler                               | [TESTING] Wait until (RANDOM), started at (RANDOM)
-      0 |         0 | Refresh Continuous Aggregate Policy [1001] | refreshing continuous aggregate "test_continuous_agg_view" in window [ -90, 12 ]
+      0 |         0 | Refresh Continuous Aggregate Policy [1001] | continuous aggregate refresh (individual invalidation) on "test_continuous_agg_view" in window [ -90, 12 ]
       1 |         0 | Refresh Continuous Aggregate Policy [1001] | deleted 0 row(s) from materialization table "_timescaledb_internal._materialized_hypertable_3"
       2 |         0 | Refresh Continuous Aggregate Policy [1001] | inserted 6 row(s) into materialization table "_timescaledb_internal._materialized_hypertable_3"
 (5 rows)
@@ -427,16 +427,16 @@ SELECT ts_bgw_db_scheduler_test_run_and_wait_for_scheduler_finish(25, 25);
 (1 row)
 
 SELECT * FROM sorted_bgw_log;
- msg_no |  mock_time  |              application_name              |                                               msg                                               
---------+-------------+--------------------------------------------+-------------------------------------------------------------------------------------------------
+ msg_no |  mock_time  |              application_name              |                                                    msg                                                     
+--------+-------------+--------------------------------------------+------------------------------------------------------------------------------------------------------------
       0 |           0 | DB Scheduler                               | [TESTING] Registered new background worker
       1 |           0 | DB Scheduler                               | [TESTING] Wait until (RANDOM), started at (RANDOM)
-      0 |           0 | Refresh Continuous Aggregate Policy [1001] | refreshing continuous aggregate "test_continuous_agg_view" in window [ -90, 12 ]
+      0 |           0 | Refresh Continuous Aggregate Policy [1001] | continuous aggregate refresh (individual invalidation) on "test_continuous_agg_view" in window [ -90, 12 ]
       1 |           0 | Refresh Continuous Aggregate Policy [1001] | deleted 0 row(s) from materialization table "_timescaledb_internal._materialized_hypertable_3"
       2 |           0 | Refresh Continuous Aggregate Policy [1001] | inserted 6 row(s) into materialization table "_timescaledb_internal._materialized_hypertable_3"
       0 | 43200000000 | DB Scheduler                               | [TESTING] Registered new background worker
       1 | 43200000000 | DB Scheduler                               | [TESTING] Wait until (RANDOM), started at (RANDOM)
-      0 | 43200000000 | Refresh Continuous Aggregate Policy [1001] | refreshing continuous aggregate "test_continuous_agg_view" in window [ -90, 12 ]
+      0 | 43200000000 | Refresh Continuous Aggregate Policy [1001] | continuous aggregate refresh (individual invalidation) on "test_continuous_agg_view" in window [ 6, 8 ]
       1 | 43200000000 | Refresh Continuous Aggregate Policy [1001] | deleted 1 row(s) from materialization table "_timescaledb_internal._materialized_hypertable_3"
       2 | 43200000000 | Refresh Continuous Aggregate Policy [1001] | inserted 1 row(s) into materialization table "_timescaledb_internal._materialized_hypertable_3"
 (10 rows)
@@ -490,6 +490,59 @@ job_status        | Scheduled
 last_run_duration | 
 
 \x off
+-- test merged refresh (change data in two chunks)
+UPDATE test_continuous_agg_table SET data = 11;
+\c :TEST_DBNAME :ROLE_CLUSTER_SUPERUSER
+ALTER SYSTEM SET timescaledb.materializations_per_refresh_window = 0;
+SELECT pg_reload_conf();
+ pg_reload_conf 
+----------------
+ t
+(1 row)
+
+SET ROLE :ROLE_DEFAULT_PERM_USER;
+--advance time by 1day so that job runs one more time
+SELECT ts_bgw_params_reset_time(extract(epoch from interval '1day')::bigint * 1000000, true);
+ ts_bgw_params_reset_time 
+--------------------------
+ 
+(1 row)
+
+SELECT ts_bgw_db_scheduler_test_run_and_wait_for_scheduler_finish(50, 50);
+ ts_bgw_db_scheduler_test_run_and_wait_for_scheduler_finish 
+------------------------------------------------------------
+ 
+(1 row)
+
+SELECT * FROM sorted_bgw_log;
+ msg_no |  mock_time  |              application_name              |                                                    msg                                                     
+--------+-------------+--------------------------------------------+------------------------------------------------------------------------------------------------------------
+      0 |           0 | DB Scheduler                               | [TESTING] Registered new background worker
+      1 |           0 | DB Scheduler                               | [TESTING] Wait until (RANDOM), started at (RANDOM)
+      0 |           0 | Refresh Continuous Aggregate Policy [1001] | continuous aggregate refresh (individual invalidation) on "test_continuous_agg_view" in window [ -90, 12 ]
+      1 |           0 | Refresh Continuous Aggregate Policy [1001] | deleted 0 row(s) from materialization table "_timescaledb_internal._materialized_hypertable_3"
+      2 |           0 | Refresh Continuous Aggregate Policy [1001] | inserted 6 row(s) into materialization table "_timescaledb_internal._materialized_hypertable_3"
+      0 | 43200000000 | DB Scheduler                               | [TESTING] Registered new background worker
+      1 | 43200000000 | DB Scheduler                               | [TESTING] Wait until (RANDOM), started at (RANDOM)
+      0 | 43200000000 | Refresh Continuous Aggregate Policy [1001] | continuous aggregate refresh (individual invalidation) on "test_continuous_agg_view" in window [ 6, 8 ]
+      1 | 43200000000 | Refresh Continuous Aggregate Policy [1001] | deleted 1 row(s) from materialization table "_timescaledb_internal._materialized_hypertable_3"
+      2 | 43200000000 | Refresh Continuous Aggregate Policy [1001] | inserted 1 row(s) into materialization table "_timescaledb_internal._materialized_hypertable_3"
+      0 | 86400000000 | DB Scheduler                               | [TESTING] Registered new background worker
+      1 | 86400000000 | DB Scheduler                               | [TESTING] Wait until (RANDOM), started at (RANDOM)
+      0 | 86400000000 | Refresh Continuous Aggregate Policy [1001] | continuous aggregate refresh (merged invalidation) on "test_continuous_agg_view" in window [ 0, 12 ]
+      1 | 86400000000 | Refresh Continuous Aggregate Policy [1001] | deleted 6 row(s) from materialization table "_timescaledb_internal._materialized_hypertable_3"
+      2 | 86400000000 | Refresh Continuous Aggregate Policy [1001] | inserted 6 row(s) into materialization table "_timescaledb_internal._materialized_hypertable_3"
+(15 rows)
+
+\c :TEST_DBNAME :ROLE_CLUSTER_SUPERUSER
+ALTER SYSTEM RESET timescaledb.materializations_per_refresh_window;
+SELECT pg_reload_conf();
+ pg_reload_conf 
+----------------
+ t
+(1 row)
+
+SET ROLE :ROLE_DEFAULT_PERM_USER;
 DROP MATERIALIZED VIEW test_continuous_agg_view;
 NOTICE:  drop cascades to table _timescaledb_internal._hyper_3_4_chunk
 --create a view with a function that it has no permission to execute
@@ -650,11 +703,11 @@ SELECT * FROM test_continuous_agg_view_user_2;
 
 \c :TEST_DBNAME :ROLE_DEFAULT_PERM_USER
 SELECT * from sorted_bgw_log;
- msg_no |  mock_time  |              application_name              |                                               msg                                               
---------+-------------+--------------------------------------------+-------------------------------------------------------------------------------------------------
+ msg_no |  mock_time  |              application_name              |                                                           msg                                                            
+--------+-------------+--------------------------------------------+--------------------------------------------------------------------------------------------------------------------------
       0 |           0 | DB Scheduler                               | [TESTING] Registered new background worker
       1 |           0 | DB Scheduler                               | [TESTING] Wait until (RANDOM), started at (RANDOM)
-      0 |           0 | Refresh Continuous Aggregate Policy [1003] | refreshing continuous aggregate "test_continuous_agg_view_user_2" in window [ -2147483648, 2 ]
+      0 |           0 | Refresh Continuous Aggregate Policy [1003] | continuous aggregate refresh (individual invalidation) on "test_continuous_agg_view_user_2" in window [ -2147483648, 2 ]
       1 |           0 | Refresh Continuous Aggregate Policy [1003] | deleted 0 row(s) from materialization table "_timescaledb_internal._materialized_hypertable_6"
       2 |           0 | Refresh Continuous Aggregate Policy [1003] | inserted 1 row(s) into materialization table "_timescaledb_internal._materialized_hypertable_6"
       0 | 43200000000 | DB Scheduler                               | [TESTING] Registered new background worker

--- a/tsl/test/expected/cagg_bgw-16.out
+++ b/tsl/test/expected/cagg_bgw-16.out
@@ -145,11 +145,11 @@ SELECT ts_bgw_db_scheduler_test_run_and_wait_for_scheduler_finish(25);
 (1 row)
 
 SELECT * FROM sorted_bgw_log;
- msg_no | mock_time |              application_name              |                                               msg                                               
---------+-----------+--------------------------------------------+-------------------------------------------------------------------------------------------------
+ msg_no | mock_time |              application_name              |                                                        msg                                                        
+--------+-----------+--------------------------------------------+-------------------------------------------------------------------------------------------------------------------
       0 |         0 | DB Scheduler                               | [TESTING] Registered new background worker
       1 |         0 | DB Scheduler                               | [TESTING] Wait until (RANDOM), started at (RANDOM)
-      0 |         0 | Refresh Continuous Aggregate Policy [1000] | refreshing continuous aggregate "test_continuous_agg_view" in window [ -2147483648, 6 ]
+      0 |         0 | Refresh Continuous Aggregate Policy [1000] | continuous aggregate refresh (individual invalidation) on "test_continuous_agg_view" in window [ -2147483648, 6 ]
       1 |         0 | Refresh Continuous Aggregate Policy [1000] | deleted 0 row(s) from materialization table "_timescaledb_internal._materialized_hypertable_2"
       2 |         0 | Refresh Continuous Aggregate Policy [1000] | inserted 3 row(s) into materialization table "_timescaledb_internal._materialized_hypertable_2"
 (5 rows)
@@ -380,11 +380,11 @@ SELECT ts_bgw_db_scheduler_test_run_and_wait_for_scheduler_finish(25);
 (1 row)
 
 SELECT * FROM sorted_bgw_log;
- msg_no | mock_time |              application_name              |                                               msg                                               
---------+-----------+--------------------------------------------+-------------------------------------------------------------------------------------------------
+ msg_no | mock_time |              application_name              |                                                    msg                                                     
+--------+-----------+--------------------------------------------+------------------------------------------------------------------------------------------------------------
       0 |         0 | DB Scheduler                               | [TESTING] Registered new background worker
       1 |         0 | DB Scheduler                               | [TESTING] Wait until (RANDOM), started at (RANDOM)
-      0 |         0 | Refresh Continuous Aggregate Policy [1001] | refreshing continuous aggregate "test_continuous_agg_view" in window [ -90, 12 ]
+      0 |         0 | Refresh Continuous Aggregate Policy [1001] | continuous aggregate refresh (individual invalidation) on "test_continuous_agg_view" in window [ -90, 12 ]
       1 |         0 | Refresh Continuous Aggregate Policy [1001] | deleted 0 row(s) from materialization table "_timescaledb_internal._materialized_hypertable_3"
       2 |         0 | Refresh Continuous Aggregate Policy [1001] | inserted 6 row(s) into materialization table "_timescaledb_internal._materialized_hypertable_3"
 (5 rows)
@@ -427,16 +427,16 @@ SELECT ts_bgw_db_scheduler_test_run_and_wait_for_scheduler_finish(25, 25);
 (1 row)
 
 SELECT * FROM sorted_bgw_log;
- msg_no |  mock_time  |              application_name              |                                               msg                                               
---------+-------------+--------------------------------------------+-------------------------------------------------------------------------------------------------
+ msg_no |  mock_time  |              application_name              |                                                    msg                                                     
+--------+-------------+--------------------------------------------+------------------------------------------------------------------------------------------------------------
       0 |           0 | DB Scheduler                               | [TESTING] Registered new background worker
       1 |           0 | DB Scheduler                               | [TESTING] Wait until (RANDOM), started at (RANDOM)
-      0 |           0 | Refresh Continuous Aggregate Policy [1001] | refreshing continuous aggregate "test_continuous_agg_view" in window [ -90, 12 ]
+      0 |           0 | Refresh Continuous Aggregate Policy [1001] | continuous aggregate refresh (individual invalidation) on "test_continuous_agg_view" in window [ -90, 12 ]
       1 |           0 | Refresh Continuous Aggregate Policy [1001] | deleted 0 row(s) from materialization table "_timescaledb_internal._materialized_hypertable_3"
       2 |           0 | Refresh Continuous Aggregate Policy [1001] | inserted 6 row(s) into materialization table "_timescaledb_internal._materialized_hypertable_3"
       0 | 43200000000 | DB Scheduler                               | [TESTING] Registered new background worker
       1 | 43200000000 | DB Scheduler                               | [TESTING] Wait until (RANDOM), started at (RANDOM)
-      0 | 43200000000 | Refresh Continuous Aggregate Policy [1001] | refreshing continuous aggregate "test_continuous_agg_view" in window [ -90, 12 ]
+      0 | 43200000000 | Refresh Continuous Aggregate Policy [1001] | continuous aggregate refresh (individual invalidation) on "test_continuous_agg_view" in window [ 6, 8 ]
       1 | 43200000000 | Refresh Continuous Aggregate Policy [1001] | deleted 1 row(s) from materialization table "_timescaledb_internal._materialized_hypertable_3"
       2 | 43200000000 | Refresh Continuous Aggregate Policy [1001] | inserted 1 row(s) into materialization table "_timescaledb_internal._materialized_hypertable_3"
 (10 rows)
@@ -490,6 +490,59 @@ job_status        | Scheduled
 last_run_duration | 
 
 \x off
+-- test merged refresh (change data in two chunks)
+UPDATE test_continuous_agg_table SET data = 11;
+\c :TEST_DBNAME :ROLE_CLUSTER_SUPERUSER
+ALTER SYSTEM SET timescaledb.materializations_per_refresh_window = 0;
+SELECT pg_reload_conf();
+ pg_reload_conf 
+----------------
+ t
+(1 row)
+
+SET ROLE :ROLE_DEFAULT_PERM_USER;
+--advance time by 1day so that job runs one more time
+SELECT ts_bgw_params_reset_time(extract(epoch from interval '1day')::bigint * 1000000, true);
+ ts_bgw_params_reset_time 
+--------------------------
+ 
+(1 row)
+
+SELECT ts_bgw_db_scheduler_test_run_and_wait_for_scheduler_finish(50, 50);
+ ts_bgw_db_scheduler_test_run_and_wait_for_scheduler_finish 
+------------------------------------------------------------
+ 
+(1 row)
+
+SELECT * FROM sorted_bgw_log;
+ msg_no |  mock_time  |              application_name              |                                                    msg                                                     
+--------+-------------+--------------------------------------------+------------------------------------------------------------------------------------------------------------
+      0 |           0 | DB Scheduler                               | [TESTING] Registered new background worker
+      1 |           0 | DB Scheduler                               | [TESTING] Wait until (RANDOM), started at (RANDOM)
+      0 |           0 | Refresh Continuous Aggregate Policy [1001] | continuous aggregate refresh (individual invalidation) on "test_continuous_agg_view" in window [ -90, 12 ]
+      1 |           0 | Refresh Continuous Aggregate Policy [1001] | deleted 0 row(s) from materialization table "_timescaledb_internal._materialized_hypertable_3"
+      2 |           0 | Refresh Continuous Aggregate Policy [1001] | inserted 6 row(s) into materialization table "_timescaledb_internal._materialized_hypertable_3"
+      0 | 43200000000 | DB Scheduler                               | [TESTING] Registered new background worker
+      1 | 43200000000 | DB Scheduler                               | [TESTING] Wait until (RANDOM), started at (RANDOM)
+      0 | 43200000000 | Refresh Continuous Aggregate Policy [1001] | continuous aggregate refresh (individual invalidation) on "test_continuous_agg_view" in window [ 6, 8 ]
+      1 | 43200000000 | Refresh Continuous Aggregate Policy [1001] | deleted 1 row(s) from materialization table "_timescaledb_internal._materialized_hypertable_3"
+      2 | 43200000000 | Refresh Continuous Aggregate Policy [1001] | inserted 1 row(s) into materialization table "_timescaledb_internal._materialized_hypertable_3"
+      0 | 86400000000 | DB Scheduler                               | [TESTING] Registered new background worker
+      1 | 86400000000 | DB Scheduler                               | [TESTING] Wait until (RANDOM), started at (RANDOM)
+      0 | 86400000000 | Refresh Continuous Aggregate Policy [1001] | continuous aggregate refresh (merged invalidation) on "test_continuous_agg_view" in window [ 0, 12 ]
+      1 | 86400000000 | Refresh Continuous Aggregate Policy [1001] | deleted 6 row(s) from materialization table "_timescaledb_internal._materialized_hypertable_3"
+      2 | 86400000000 | Refresh Continuous Aggregate Policy [1001] | inserted 6 row(s) into materialization table "_timescaledb_internal._materialized_hypertable_3"
+(15 rows)
+
+\c :TEST_DBNAME :ROLE_CLUSTER_SUPERUSER
+ALTER SYSTEM RESET timescaledb.materializations_per_refresh_window;
+SELECT pg_reload_conf();
+ pg_reload_conf 
+----------------
+ t
+(1 row)
+
+SET ROLE :ROLE_DEFAULT_PERM_USER;
 DROP MATERIALIZED VIEW test_continuous_agg_view;
 NOTICE:  drop cascades to table _timescaledb_internal._hyper_3_4_chunk
 --create a view with a function that it has no permission to execute
@@ -650,11 +703,11 @@ SELECT * FROM test_continuous_agg_view_user_2;
 
 \c :TEST_DBNAME :ROLE_DEFAULT_PERM_USER
 SELECT * from sorted_bgw_log;
- msg_no |  mock_time  |              application_name              |                                               msg                                               
---------+-------------+--------------------------------------------+-------------------------------------------------------------------------------------------------
+ msg_no |  mock_time  |              application_name              |                                                           msg                                                            
+--------+-------------+--------------------------------------------+--------------------------------------------------------------------------------------------------------------------------
       0 |           0 | DB Scheduler                               | [TESTING] Registered new background worker
       1 |           0 | DB Scheduler                               | [TESTING] Wait until (RANDOM), started at (RANDOM)
-      0 |           0 | Refresh Continuous Aggregate Policy [1003] | refreshing continuous aggregate "test_continuous_agg_view_user_2" in window [ -2147483648, 2 ]
+      0 |           0 | Refresh Continuous Aggregate Policy [1003] | continuous aggregate refresh (individual invalidation) on "test_continuous_agg_view_user_2" in window [ -2147483648, 2 ]
       1 |           0 | Refresh Continuous Aggregate Policy [1003] | deleted 0 row(s) from materialization table "_timescaledb_internal._materialized_hypertable_6"
       2 |           0 | Refresh Continuous Aggregate Policy [1003] | inserted 1 row(s) into materialization table "_timescaledb_internal._materialized_hypertable_6"
       0 | 43200000000 | DB Scheduler                               | [TESTING] Registered new background worker

--- a/tsl/test/expected/cagg_refresh.out
+++ b/tsl/test/expected/cagg_refresh.out
@@ -122,9 +122,8 @@ ORDER BY day DESC, device;
 SET client_min_messages TO DEBUG1;
 CALL refresh_continuous_aggregate('daily_temp', '2020-04-30', '2020-05-04');
 LOG:  statement: CALL refresh_continuous_aggregate('daily_temp', '2020-04-30', '2020-05-04');
-DEBUG:  refreshing continuous aggregate "daily_temp" in window [ Thu Apr 30 17:00:00 2020 PDT, Sun May 03 17:00:00 2020 PDT ]
 DEBUG:  hypertable 1 existing watermark >= new invalidation threshold 1588723200000000 1588550400000000
-DEBUG:  invalidation refresh on "daily_temp" in window [ Thu Apr 30 17:00:00 2020 PDT, Sat May 02 17:00:00 2020 PDT ]
+DEBUG:  continuous aggregate refresh (individual invalidation) on "daily_temp" in window [ Thu Apr 30 17:00:00 2020 PDT, Sat May 02 17:00:00 2020 PDT ]
 LOG:  deleted 0 row(s) from materialization table "_timescaledb_internal._materialized_hypertable_2"
 LOG:  inserted 8 row(s) into materialization table "_timescaledb_internal._materialized_hypertable_2"
 DEBUG:  hypertable 2 existing watermark >= new watermark 1588723200000000 1588723200000000

--- a/tsl/test/sql/cagg_bgw.sql.in
+++ b/tsl/test/sql/cagg_bgw.sql.in
@@ -286,6 +286,26 @@ and cagg.materialization_hypertable_name = ps.hypertable_name;
 
 \x off
 
+-- test merged refresh (change data in two chunks)
+UPDATE test_continuous_agg_table SET data = 11;
+
+\c :TEST_DBNAME :ROLE_CLUSTER_SUPERUSER
+ALTER SYSTEM SET timescaledb.materializations_per_refresh_window = 0;
+SELECT pg_reload_conf();
+SET ROLE :ROLE_DEFAULT_PERM_USER;
+
+--advance time by 1day so that job runs one more time
+SELECT ts_bgw_params_reset_time(extract(epoch from interval '1day')::bigint * 1000000, true);
+
+SELECT ts_bgw_db_scheduler_test_run_and_wait_for_scheduler_finish(50, 50);
+
+SELECT * FROM sorted_bgw_log;
+
+\c :TEST_DBNAME :ROLE_CLUSTER_SUPERUSER
+ALTER SYSTEM RESET timescaledb.materializations_per_refresh_window;
+SELECT pg_reload_conf();
+SET ROLE :ROLE_DEFAULT_PERM_USER;
+
 DROP MATERIALIZED VIEW test_continuous_agg_view;
 
 --create a view with a function that it has no permission to execute


### PR DESCRIPTION
Currently, when a CAgg is refreshed using a background worker, only the refresh invocation is logged. However, the details of the refresh, such as the number of individual ranges that are refreshed, are not logged. This PR changes the log level for these details in background workers to INFO, to ensure the information is captured.

---

Disable-check: force-changelog-file
Should be merged after: #6740
