### PR TITLE
Build release builds with debug info

### DIFF
--- a/.github/gh_matrix_builder.py
+++ b/.github/gh_matrix_builder.py
@@ -92,7 +92,7 @@ def build_release_config(overrides):
     release_config = dict(
         {
             "name": "Release",
-            "build_type": "Release",
+            "build_type": "RelWithDebInfo",
             "tsdb_build_args": "-DWARNINGS_AS_ERRORS=ON -DREQUIRE_ALL_TESTS=ON",
             "coverage": False,
         }
@@ -120,7 +120,7 @@ def build_apache_config(overrides):
     apache_config = dict(
         {
             "name": "ApacheOnly",
-            "build_type": "Release",
+            "build_type": "RelWithDebInfo",
             "tsdb_build_args": "-DWARNINGS_AS_ERRORS=ON -DREQUIRE_ALL_TESTS=ON -DAPACHE_ONLY=1",
             "coverage": False,
         }


### PR DESCRIPTION
It is not possible to get anything sensible out of core dumps that do not contain debug info, so make sure that release builds are built with debug information by using `RelWithDebInfo`.

Disable-check: force-changelog-file