### PR TITLE
Make CAgg error message more clear

### DIFF
--- a/tsl/src/continuous_aggs/common.c
+++ b/tsl/src/continuous_aggs/common.c
@@ -201,8 +201,8 @@ caggtimebucket_validate(CAggTimebucketInfo *tbinfo, List *groupClause, List *tar
 			if (!(IsA(col_arg, Var)) || ((Var *) col_arg)->varattno != tbinfo->htpartcolno)
 				ereport(ERROR,
 						(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
-						 errmsg(
-							 "time bucket function must reference a hypertable dimension column")));
+						 errmsg("time bucket function must reference the primary hypertable "
+								"dimension column")));
 
 			if (list_length(fe->args) >= 3)
 			{

--- a/tsl/test/expected/cagg_errors.out
+++ b/tsl/test/expected/cagg_errors.out
@@ -70,14 +70,14 @@ AS
 Select max(temperature)
 from conditions
  group by time_bucket('1week', timemeasure) , location WITH NO DATA;
-ERROR:  time bucket function must reference a hypertable dimension column
+ERROR:  time bucket function must reference the primary hypertable dimension column
 --time_bucket on expression
 CREATE MATERIALIZED VIEW mat_m1 WITH (timescaledb.continuous, timescaledb.materialized_only=false)
 AS
 Select max(temperature)
 from conditions
  group by time_bucket('1week', timec+ '10 minutes'::interval) , location WITH NO DATA;
-ERROR:  time bucket function must reference a hypertable dimension column
+ERROR:  time bucket function must reference the primary hypertable dimension column
 --multiple time_bucket functions
 CREATE MATERIALIZED VIEW mat_m1 WITH (timescaledb.continuous, timescaledb.materialized_only=false)
 AS
@@ -369,14 +369,14 @@ as
 select time_bucket(100, timec), min(location), sum(temperature),sum(humidity)
 from conditions
 group by time_bucket(100, timec) WITH NO DATA;
-ERROR:  time bucket function must reference a hypertable dimension column
+ERROR:  time bucket function must reference the primary hypertable dimension column
 create materialized view mat_with_test( timec, minl, sumt , sumh)
 WITH (timescaledb.continuous, timescaledb.materialized_only=false)
 as
 select time_bucket(100, timec), min(location), sum(temperature),sum(humidity)
 from conditions
 group by time_bucket(100, timec) WITH NO DATA;
-ERROR:  time bucket function must reference a hypertable dimension column
+ERROR:  time bucket function must reference the primary hypertable dimension column
 ALTER TABLE conditions ALTER timec type int;
 create materialized view mat_with_test( timec, minl, sumt , sumh)
 WITH (timescaledb.continuous, timescaledb.materialized_only=false)


### PR DESCRIPTION
When creating a Continuous Aggregate we can only reference the primary hypertable dimension column on the `time_bucket` function, so reworded a bit the error message to be more clear.

Disable-check: force-changelog-file
