### PR TITLE
Exclude is_sparse_index_type in non assert builds

### DIFF
--- a/tsl/src/compression/create.c
+++ b/tsl/src/compression/create.c
@@ -51,6 +51,7 @@
 
 static const char *sparse_index_types[] = { "min", "max" };
 
+#ifdef USE_ASSERT_CHECKING
 static bool
 is_sparse_index_type(const char *type)
 {
@@ -64,6 +65,7 @@ is_sparse_index_type(const char *type)
 
 	return false;
 }
+#endif
 
 static void validate_hypertable_for_compression(Hypertable *ht);
 static List *build_columndefs(CompressionSettings *settings, Oid src_relid);


### PR DESCRIPTION
PR #6705 introduces the function is_sparse_index_type. However, it is only used for assert checking. If no assets are checked, the function is unused, and some compilers error out. This PR includes the function only if asserts are checked.

---

Disable-check: force-changelog-file
Failed CI run: https://github.com/timescale/timescaledb/actions/runs/8263661782/job/22605588883
Fixed CI run: https://github.com/timescale/timescaledb/actions/runs/8264499578/job/22608227365?pr=6764