### PR TITLE
Move cagg_invalidation to solo tests

### DIFF
--- a/tsl/test/sql/CMakeLists.txt
+++ b/tsl/test/sql/CMakeLists.txt
@@ -121,6 +121,7 @@ set(SOLO_TESTS
     cagg_bgw
     cagg_ddl-${PG_VERSION_MAJOR}
     cagg_dump
+    cagg_invalidation
     move
     reorder
     telemetry_stats-${PG_VERSION_MAJOR})


### PR DESCRIPTION
The cagg_invalidation test [stops](https://github.com/timescale/timescaledb/blob/8dcb6eed993b06e6fbb6703bfcb54a61b23d692d/tsl/test/sql/cagg_invalidation.sql#L5) the background workers and performs
tests with invalidations. However, they the test was running in a
parallel group, and background workers could be activated by other
tests, leading to flaky test behavior. This PR moves the
cagg_invalidation tests to the solo tests.

---
Disable-check: force-changelog-file
Failed CI run: https://github.com/timescale/timescaledb/actions/runs/8264761038/job/22611014318, https://github.com/timescale/timescaledb/actions/runs/8264761038/job/22611013928
Fixed CI run: https://github.com/timescale/timescaledb/actions/runs/8267219857/job/22617100451?pr=6765, https://github.com/timescale/timescaledb/actions/runs/8267219857/job/22617100841?pr=6765
