### PR TITLE
Unify dimension min handling

### DIFF
--- a/tsl/src/bgw_policy/continuous_aggregate_api.c
+++ b/tsl/src/bgw_policy/continuous_aggregate_api.c
@@ -119,11 +119,8 @@ policy_refresh_cagg_get_refresh_start(const ContinuousAgg *cagg, const Dimension
 	/* interpret NULL as min value for that type */
 	if (*start_isnull)
 	{
-		Oid type = ts_dimension_get_partition_type(dim);
-
-		return cagg->bucket_function->bucket_fixed_interval == false ?
-				   ts_time_get_nobegin_or_min(type) :
-				   ts_time_get_min(type);
+		Assert(cagg->partition_type == ts_dimension_get_partition_type(dim));
+		return cagg_get_time_min(cagg);
 	}
 
 	return res;


### PR DESCRIPTION
PR #6737 introduced a new function to determine the min value for a given data type. This patch uses the function in a further place.

---

Disable-check: force-changelog-file
