### PR TITLE
Backport to 2.14.x: #6738: Disable homebrew automatic dependency upgrades

### DIFF
--- a/.github/workflows/linux-build-and-test.yaml
+++ b/.github/workflows/linux-build-and-test.yaml
@@ -69,7 +69,9 @@ jobs:
     - name: Install macOS Dependencies
       if: runner.os == 'macOS'
       run: |
-        brew install gawk
+        # Disable the automatic dependency upgrade executed by `brew install`
+        # https://docs.brew.sh/Manpage#install-options-formulacask-
+        HOMEBREW_NO_INSTALLED_DEPENDENTS_CHECK=1 brew install gawk
         # Install perl modules after last Homebew call, since Homebrew can change the perl version
         sudo perl -MCPAN -e "CPAN::Shell->notest('install', 'IPC::Run')"
         sudo perl -MCPAN -e "CPAN::Shell->notest('install', 'Test::Most')"


### PR DESCRIPTION
Backport of Fabrizio's commit: https://github.com/timescale/timescaledb/commit/b719787aa66e16433172d73ec02c16ec39b81e52 To 2.14.x branch.

Setting the HOMEBREW_NO_INSTALLED_DEPENDENTS_CHECK=1 when using brew install will turn off the automatic dependency upgrade when using this command.

Reference:
https://docs.brew.sh/Manpage#install-options-formulacask-

CI failure:
https://github.com/timescale/timescaledb/actions/runs/8277163080/job/22649592824?pr=6769

Disable-check: force-changelog-file