### PR TITLE
Fully recompress unordered compressed chunks

### DIFF
--- a/tsl/src/compression/api.c
+++ b/tsl/src/compression/api.c
@@ -743,7 +743,7 @@ tsl_compress_chunk_wrapper(Chunk *chunk, bool if_not_compressed, bool recompress
 			return uncompressed_chunk_id;
 		}
 
-		if (get_compressed_chunk_index_for_recompression(chunk))
+		if (ts_chunk_is_partial(chunk) && get_compressed_chunk_index_for_recompression(chunk))
 		{
 			uncompressed_chunk_id = recompress_chunk_segmentwise_impl(chunk);
 		}
@@ -1047,7 +1047,7 @@ tsl_recompress_chunk_segmentwise(PG_FUNCTION_ARGS)
 	TS_PREVENT_FUNC_IF_READ_ONLY();
 	Chunk *chunk = ts_chunk_get_by_relid(uncompressed_chunk_id, true);
 
-	if (!ts_chunk_needs_recompression(chunk))
+	if (!ts_chunk_is_partial(chunk))
 	{
 		int elevel = if_not_compressed ? NOTICE : ERROR;
 		elog(elevel,
@@ -1075,8 +1075,7 @@ recompress_chunk_segmentwise_impl(Chunk *uncompressed_chunk)
 	 * 4: frozen
 	 * 8: compressed_partial
 	 */
-	if (!ts_chunk_is_compressed(uncompressed_chunk) &&
-		ts_chunk_needs_recompression(uncompressed_chunk))
+	if (!ts_chunk_is_compressed(uncompressed_chunk) && ts_chunk_is_partial(uncompressed_chunk))
 		elog(ERROR,
 			 "unexpected chunk status %d in chunk %s.%s",
 			 uncompressed_chunk->fd.status,

--- a/tsl/test/expected/compression_merge.out
+++ b/tsl/test/expected/compression_merge.out
@@ -109,6 +109,30 @@ FROM generate_series('2018-03-02 1:00'::TIMESTAMPTZ, '2018-03-03 0:59', '1 minut
 CROSS JOIN generate_series(1, 5, 1) i;
 -- Compression is set to merge those 24 chunks into 3 chunks, two 10 hour chunks and a single 4 hour chunk.
 ALTER TABLE test2 set (timescaledb.compress, timescaledb.compress_segmentby='i', timescaledb.compress_orderby='loc,"Time"', timescaledb.compress_chunk_time_interval='10 hours');
+-- Verify we are fully recompressing unordered chunks
+BEGIN;
+  SELECT count(compress_chunk(chunk,  true)) FROM show_chunks('test2') chunk;
+ count 
+-------
+    24
+(1 row)
+
+  SELECT format('%I.%I',ch.schema_name,ch.table_name) AS "CHUNK"
+    FROM _timescaledb_catalog.chunk ch
+    JOIN _timescaledb_catalog.hypertable ht ON ht.id=ch.hypertable_id
+    JOIN _timescaledb_catalog.hypertable ht2 ON ht.id=ht2.compressed_hypertable_id AND ht2.table_name='test2' LIMIT 1 \gset
+  -- Not using time as first column in orderby makes the merged chunks unordered
+  -- We want to sure we are fully recompressing them which will make only
+  -- a single batch per segment group
+  SELECT count(*)
+  FROM :CHUNK
+  WHERE i = 1;
+ count 
+-------
+     1
+(1 row)
+
+ROLLBACK;
 SELECT
   $$
   SELECT * FROM test2 ORDER BY i, "Time"
@@ -264,10 +288,10 @@ SELECT
 SELECT compress_chunk(i) FROM show_chunks('test5') i LIMIT 4;
               compress_chunk              
 ------------------------------------------
- _timescaledb_internal._hyper_9_142_chunk
- _timescaledb_internal._hyper_9_142_chunk
- _timescaledb_internal._hyper_9_142_chunk
- _timescaledb_internal._hyper_9_142_chunk
+ _timescaledb_internal._hyper_9_187_chunk
+ _timescaledb_internal._hyper_9_187_chunk
+ _timescaledb_internal._hyper_9_187_chunk
+ _timescaledb_internal._hyper_9_187_chunk
 (4 rows)
 
 SELECT format('%I.%I',ch.schema_name,ch.table_name) AS "CHUNK"
@@ -293,14 +317,14 @@ DROP INDEX :INDEXNAME;
 -- We dropped the index from compressed chunk thats needed to determine sequence numbers
 -- during merge, merging will fallback to doing heap scans and work just fine.
 SELECT compress_chunk(i, true) FROM show_chunks('test5') i LIMIT 5;
-NOTICE:  chunk "_hyper_9_142_chunk" is already compressed
+NOTICE:  chunk "_hyper_9_187_chunk" is already compressed
               compress_chunk              
 ------------------------------------------
- _timescaledb_internal._hyper_9_142_chunk
- _timescaledb_internal._hyper_9_142_chunk
- _timescaledb_internal._hyper_9_142_chunk
- _timescaledb_internal._hyper_9_142_chunk
- _timescaledb_internal._hyper_9_142_chunk
+ _timescaledb_internal._hyper_9_187_chunk
+ _timescaledb_internal._hyper_9_187_chunk
+ _timescaledb_internal._hyper_9_187_chunk
+ _timescaledb_internal._hyper_9_187_chunk
+ _timescaledb_internal._hyper_9_187_chunk
 (5 rows)
 
 -- Make sure sequence numbers are correctly fetched from heap.
@@ -323,7 +347,7 @@ SELECT 'test5' AS "HYPERTABLE_NAME" \gset
 -- Please see the included NOTICE for copyright information and
 -- LICENSE-TIMESCALE for a copy of the license.
 \set ECHO errors
-psql:include/compression_test_merge.sql:12: NOTICE:  chunk "_hyper_9_142_chunk" is already compressed
+psql:include/compression_test_merge.sql:12: NOTICE:  chunk "_hyper_9_187_chunk" is already compressed
  count_compressed 
 ------------------
                17
@@ -363,30 +387,30 @@ ALTER TABLE test6 set (timescaledb.compress, timescaledb.compress_segmentby='i',
 SELECT compress_chunk(i) FROM show_chunks('test6') i;
               compress_chunk               
 -------------------------------------------
- _timescaledb_internal._hyper_11_167_chunk
- _timescaledb_internal._hyper_11_167_chunk
- _timescaledb_internal._hyper_11_169_chunk
- _timescaledb_internal._hyper_11_169_chunk
- _timescaledb_internal._hyper_11_171_chunk
- _timescaledb_internal._hyper_11_171_chunk
- _timescaledb_internal._hyper_11_173_chunk
- _timescaledb_internal._hyper_11_173_chunk
- _timescaledb_internal._hyper_11_175_chunk
- _timescaledb_internal._hyper_11_175_chunk
- _timescaledb_internal._hyper_11_177_chunk
- _timescaledb_internal._hyper_11_177_chunk
- _timescaledb_internal._hyper_11_179_chunk
- _timescaledb_internal._hyper_11_179_chunk
- _timescaledb_internal._hyper_11_181_chunk
- _timescaledb_internal._hyper_11_181_chunk
- _timescaledb_internal._hyper_11_183_chunk
- _timescaledb_internal._hyper_11_183_chunk
- _timescaledb_internal._hyper_11_185_chunk
- _timescaledb_internal._hyper_11_185_chunk
- _timescaledb_internal._hyper_11_187_chunk
- _timescaledb_internal._hyper_11_187_chunk
- _timescaledb_internal._hyper_11_189_chunk
- _timescaledb_internal._hyper_11_189_chunk
+ _timescaledb_internal._hyper_11_212_chunk
+ _timescaledb_internal._hyper_11_212_chunk
+ _timescaledb_internal._hyper_11_214_chunk
+ _timescaledb_internal._hyper_11_214_chunk
+ _timescaledb_internal._hyper_11_216_chunk
+ _timescaledb_internal._hyper_11_216_chunk
+ _timescaledb_internal._hyper_11_218_chunk
+ _timescaledb_internal._hyper_11_218_chunk
+ _timescaledb_internal._hyper_11_220_chunk
+ _timescaledb_internal._hyper_11_220_chunk
+ _timescaledb_internal._hyper_11_222_chunk
+ _timescaledb_internal._hyper_11_222_chunk
+ _timescaledb_internal._hyper_11_224_chunk
+ _timescaledb_internal._hyper_11_224_chunk
+ _timescaledb_internal._hyper_11_226_chunk
+ _timescaledb_internal._hyper_11_226_chunk
+ _timescaledb_internal._hyper_11_228_chunk
+ _timescaledb_internal._hyper_11_228_chunk
+ _timescaledb_internal._hyper_11_230_chunk
+ _timescaledb_internal._hyper_11_230_chunk
+ _timescaledb_internal._hyper_11_232_chunk
+ _timescaledb_internal._hyper_11_232_chunk
+ _timescaledb_internal._hyper_11_234_chunk
+ _timescaledb_internal._hyper_11_234_chunk
 (24 rows)
 
 SELECT count(*) as number_of_chunks FROM show_chunks('test6');
@@ -403,56 +427,56 @@ CROSS JOIN generate_series(1, 5, 1) i;
 -- Altering compress chunk time interval will cause us to create 6 chunks from the additional 24 chunks.
 ALTER TABLE test6 set (timescaledb.compress_chunk_time_interval='4 hours');
 SELECT compress_chunk(i, true) FROM show_chunks('test6') i;
-NOTICE:  chunk "_hyper_11_167_chunk" is already compressed
-NOTICE:  chunk "_hyper_11_169_chunk" is already compressed
-NOTICE:  chunk "_hyper_11_171_chunk" is already compressed
-NOTICE:  chunk "_hyper_11_173_chunk" is already compressed
-NOTICE:  chunk "_hyper_11_175_chunk" is already compressed
-NOTICE:  chunk "_hyper_11_177_chunk" is already compressed
-NOTICE:  chunk "_hyper_11_179_chunk" is already compressed
-NOTICE:  chunk "_hyper_11_181_chunk" is already compressed
-NOTICE:  chunk "_hyper_11_183_chunk" is already compressed
-NOTICE:  chunk "_hyper_11_185_chunk" is already compressed
-NOTICE:  chunk "_hyper_11_187_chunk" is already compressed
-NOTICE:  chunk "_hyper_11_189_chunk" is already compressed
+NOTICE:  chunk "_hyper_11_212_chunk" is already compressed
+NOTICE:  chunk "_hyper_11_214_chunk" is already compressed
+NOTICE:  chunk "_hyper_11_216_chunk" is already compressed
+NOTICE:  chunk "_hyper_11_218_chunk" is already compressed
+NOTICE:  chunk "_hyper_11_220_chunk" is already compressed
+NOTICE:  chunk "_hyper_11_222_chunk" is already compressed
+NOTICE:  chunk "_hyper_11_224_chunk" is already compressed
+NOTICE:  chunk "_hyper_11_226_chunk" is already compressed
+NOTICE:  chunk "_hyper_11_228_chunk" is already compressed
+NOTICE:  chunk "_hyper_11_230_chunk" is already compressed
+NOTICE:  chunk "_hyper_11_232_chunk" is already compressed
+NOTICE:  chunk "_hyper_11_234_chunk" is already compressed
               compress_chunk               
 -------------------------------------------
- _timescaledb_internal._hyper_11_167_chunk
- _timescaledb_internal._hyper_11_169_chunk
- _timescaledb_internal._hyper_11_171_chunk
- _timescaledb_internal._hyper_11_173_chunk
- _timescaledb_internal._hyper_11_175_chunk
- _timescaledb_internal._hyper_11_177_chunk
- _timescaledb_internal._hyper_11_179_chunk
- _timescaledb_internal._hyper_11_181_chunk
- _timescaledb_internal._hyper_11_183_chunk
- _timescaledb_internal._hyper_11_185_chunk
- _timescaledb_internal._hyper_11_187_chunk
- _timescaledb_internal._hyper_11_189_chunk
- _timescaledb_internal._hyper_11_189_chunk
- _timescaledb_internal._hyper_11_189_chunk
- _timescaledb_internal._hyper_11_205_chunk
- _timescaledb_internal._hyper_11_205_chunk
- _timescaledb_internal._hyper_11_205_chunk
- _timescaledb_internal._hyper_11_205_chunk
- _timescaledb_internal._hyper_11_209_chunk
- _timescaledb_internal._hyper_11_209_chunk
- _timescaledb_internal._hyper_11_209_chunk
- _timescaledb_internal._hyper_11_209_chunk
- _timescaledb_internal._hyper_11_213_chunk
- _timescaledb_internal._hyper_11_213_chunk
- _timescaledb_internal._hyper_11_213_chunk
- _timescaledb_internal._hyper_11_213_chunk
- _timescaledb_internal._hyper_11_217_chunk
- _timescaledb_internal._hyper_11_217_chunk
- _timescaledb_internal._hyper_11_217_chunk
- _timescaledb_internal._hyper_11_217_chunk
- _timescaledb_internal._hyper_11_221_chunk
- _timescaledb_internal._hyper_11_221_chunk
- _timescaledb_internal._hyper_11_221_chunk
- _timescaledb_internal._hyper_11_221_chunk
- _timescaledb_internal._hyper_11_225_chunk
- _timescaledb_internal._hyper_11_225_chunk
+ _timescaledb_internal._hyper_11_212_chunk
+ _timescaledb_internal._hyper_11_214_chunk
+ _timescaledb_internal._hyper_11_216_chunk
+ _timescaledb_internal._hyper_11_218_chunk
+ _timescaledb_internal._hyper_11_220_chunk
+ _timescaledb_internal._hyper_11_222_chunk
+ _timescaledb_internal._hyper_11_224_chunk
+ _timescaledb_internal._hyper_11_226_chunk
+ _timescaledb_internal._hyper_11_228_chunk
+ _timescaledb_internal._hyper_11_230_chunk
+ _timescaledb_internal._hyper_11_232_chunk
+ _timescaledb_internal._hyper_11_234_chunk
+ _timescaledb_internal._hyper_11_234_chunk
+ _timescaledb_internal._hyper_11_234_chunk
+ _timescaledb_internal._hyper_11_250_chunk
+ _timescaledb_internal._hyper_11_250_chunk
+ _timescaledb_internal._hyper_11_250_chunk
+ _timescaledb_internal._hyper_11_250_chunk
+ _timescaledb_internal._hyper_11_254_chunk
+ _timescaledb_internal._hyper_11_254_chunk
+ _timescaledb_internal._hyper_11_254_chunk
+ _timescaledb_internal._hyper_11_254_chunk
+ _timescaledb_internal._hyper_11_258_chunk
+ _timescaledb_internal._hyper_11_258_chunk
+ _timescaledb_internal._hyper_11_258_chunk
+ _timescaledb_internal._hyper_11_258_chunk
+ _timescaledb_internal._hyper_11_262_chunk
+ _timescaledb_internal._hyper_11_262_chunk
+ _timescaledb_internal._hyper_11_262_chunk
+ _timescaledb_internal._hyper_11_262_chunk
+ _timescaledb_internal._hyper_11_266_chunk
+ _timescaledb_internal._hyper_11_266_chunk
+ _timescaledb_internal._hyper_11_266_chunk
+ _timescaledb_internal._hyper_11_266_chunk
+ _timescaledb_internal._hyper_11_270_chunk
+ _timescaledb_internal._hyper_11_270_chunk
 (36 rows)
 
 SELECT count(*) as number_of_chunks FROM show_chunks('test6');
@@ -471,47 +495,47 @@ CROSS JOIN generate_series(1, 5, 1) i;
 ALTER TABLE test6 set (timescaledb.compress_chunk_time_interval='30 minutes');
 WARNING:  compress chunk interval is not a multiple of chunk interval, you should use a factor of chunk interval to merge as much as possible
 SELECT compress_chunk(i, true) FROM show_chunks('test6') i;
-NOTICE:  chunk "_hyper_11_167_chunk" is already compressed
-NOTICE:  chunk "_hyper_11_169_chunk" is already compressed
-NOTICE:  chunk "_hyper_11_171_chunk" is already compressed
-NOTICE:  chunk "_hyper_11_173_chunk" is already compressed
-NOTICE:  chunk "_hyper_11_175_chunk" is already compressed
-NOTICE:  chunk "_hyper_11_177_chunk" is already compressed
-NOTICE:  chunk "_hyper_11_179_chunk" is already compressed
-NOTICE:  chunk "_hyper_11_181_chunk" is already compressed
-NOTICE:  chunk "_hyper_11_183_chunk" is already compressed
-NOTICE:  chunk "_hyper_11_185_chunk" is already compressed
-NOTICE:  chunk "_hyper_11_187_chunk" is already compressed
-NOTICE:  chunk "_hyper_11_189_chunk" is already compressed
-NOTICE:  chunk "_hyper_11_205_chunk" is already compressed
-NOTICE:  chunk "_hyper_11_209_chunk" is already compressed
-NOTICE:  chunk "_hyper_11_213_chunk" is already compressed
-NOTICE:  chunk "_hyper_11_217_chunk" is already compressed
-NOTICE:  chunk "_hyper_11_221_chunk" is already compressed
-NOTICE:  chunk "_hyper_11_225_chunk" is already compressed
+NOTICE:  chunk "_hyper_11_212_chunk" is already compressed
+NOTICE:  chunk "_hyper_11_214_chunk" is already compressed
+NOTICE:  chunk "_hyper_11_216_chunk" is already compressed
+NOTICE:  chunk "_hyper_11_218_chunk" is already compressed
+NOTICE:  chunk "_hyper_11_220_chunk" is already compressed
+NOTICE:  chunk "_hyper_11_222_chunk" is already compressed
+NOTICE:  chunk "_hyper_11_224_chunk" is already compressed
+NOTICE:  chunk "_hyper_11_226_chunk" is already compressed
+NOTICE:  chunk "_hyper_11_228_chunk" is already compressed
+NOTICE:  chunk "_hyper_11_230_chunk" is already compressed
+NOTICE:  chunk "_hyper_11_232_chunk" is already compressed
+NOTICE:  chunk "_hyper_11_234_chunk" is already compressed
+NOTICE:  chunk "_hyper_11_250_chunk" is already compressed
+NOTICE:  chunk "_hyper_11_254_chunk" is already compressed
+NOTICE:  chunk "_hyper_11_258_chunk" is already compressed
+NOTICE:  chunk "_hyper_11_262_chunk" is already compressed
+NOTICE:  chunk "_hyper_11_266_chunk" is already compressed
+NOTICE:  chunk "_hyper_11_270_chunk" is already compressed
               compress_chunk               
 -------------------------------------------
- _timescaledb_internal._hyper_11_167_chunk
- _timescaledb_internal._hyper_11_169_chunk
- _timescaledb_internal._hyper_11_171_chunk
- _timescaledb_internal._hyper_11_173_chunk
- _timescaledb_internal._hyper_11_175_chunk
- _timescaledb_internal._hyper_11_177_chunk
- _timescaledb_internal._hyper_11_179_chunk
- _timescaledb_internal._hyper_11_181_chunk
- _timescaledb_internal._hyper_11_183_chunk
- _timescaledb_internal._hyper_11_185_chunk
- _timescaledb_internal._hyper_11_187_chunk
- _timescaledb_internal._hyper_11_189_chunk
- _timescaledb_internal._hyper_11_205_chunk
- _timescaledb_internal._hyper_11_209_chunk
- _timescaledb_internal._hyper_11_213_chunk
- _timescaledb_internal._hyper_11_217_chunk
- _timescaledb_internal._hyper_11_221_chunk
- _timescaledb_internal._hyper_11_225_chunk
- _timescaledb_internal._hyper_11_233_chunk
+ _timescaledb_internal._hyper_11_212_chunk
+ _timescaledb_internal._hyper_11_214_chunk
+ _timescaledb_internal._hyper_11_216_chunk
+ _timescaledb_internal._hyper_11_218_chunk
+ _timescaledb_internal._hyper_11_220_chunk
+ _timescaledb_internal._hyper_11_222_chunk
+ _timescaledb_internal._hyper_11_224_chunk
+ _timescaledb_internal._hyper_11_226_chunk
+ _timescaledb_internal._hyper_11_228_chunk
+ _timescaledb_internal._hyper_11_230_chunk
+ _timescaledb_internal._hyper_11_232_chunk
  _timescaledb_internal._hyper_11_234_chunk
- _timescaledb_internal._hyper_11_235_chunk
+ _timescaledb_internal._hyper_11_250_chunk
+ _timescaledb_internal._hyper_11_254_chunk
+ _timescaledb_internal._hyper_11_258_chunk
+ _timescaledb_internal._hyper_11_262_chunk
+ _timescaledb_internal._hyper_11_266_chunk
+ _timescaledb_internal._hyper_11_270_chunk
+ _timescaledb_internal._hyper_11_278_chunk
+ _timescaledb_internal._hyper_11_279_chunk
+ _timescaledb_internal._hyper_11_280_chunk
 (21 rows)
 
 SELECT count(*) as number_of_chunks FROM show_chunks('test6');
@@ -529,53 +553,53 @@ CROSS JOIN generate_series(1, 5, 1) i;
 -- Setting compressed chunk to anything less than chunk interval should disable merging chunks.
 ALTER TABLE test6 set (timescaledb.compress_chunk_time_interval=0);
 SELECT compress_chunk(i, true) FROM show_chunks('test6') i;
-NOTICE:  chunk "_hyper_11_167_chunk" is already compressed
-NOTICE:  chunk "_hyper_11_169_chunk" is already compressed
-NOTICE:  chunk "_hyper_11_171_chunk" is already compressed
-NOTICE:  chunk "_hyper_11_173_chunk" is already compressed
-NOTICE:  chunk "_hyper_11_175_chunk" is already compressed
-NOTICE:  chunk "_hyper_11_177_chunk" is already compressed
-NOTICE:  chunk "_hyper_11_179_chunk" is already compressed
-NOTICE:  chunk "_hyper_11_181_chunk" is already compressed
-NOTICE:  chunk "_hyper_11_183_chunk" is already compressed
-NOTICE:  chunk "_hyper_11_185_chunk" is already compressed
-NOTICE:  chunk "_hyper_11_187_chunk" is already compressed
-NOTICE:  chunk "_hyper_11_189_chunk" is already compressed
-NOTICE:  chunk "_hyper_11_205_chunk" is already compressed
-NOTICE:  chunk "_hyper_11_209_chunk" is already compressed
-NOTICE:  chunk "_hyper_11_213_chunk" is already compressed
-NOTICE:  chunk "_hyper_11_217_chunk" is already compressed
-NOTICE:  chunk "_hyper_11_221_chunk" is already compressed
-NOTICE:  chunk "_hyper_11_225_chunk" is already compressed
-NOTICE:  chunk "_hyper_11_233_chunk" is already compressed
+NOTICE:  chunk "_hyper_11_212_chunk" is already compressed
+NOTICE:  chunk "_hyper_11_214_chunk" is already compressed
+NOTICE:  chunk "_hyper_11_216_chunk" is already compressed
+NOTICE:  chunk "_hyper_11_218_chunk" is already compressed
+NOTICE:  chunk "_hyper_11_220_chunk" is already compressed
+NOTICE:  chunk "_hyper_11_222_chunk" is already compressed
+NOTICE:  chunk "_hyper_11_224_chunk" is already compressed
+NOTICE:  chunk "_hyper_11_226_chunk" is already compressed
+NOTICE:  chunk "_hyper_11_228_chunk" is already compressed
+NOTICE:  chunk "_hyper_11_230_chunk" is already compressed
+NOTICE:  chunk "_hyper_11_232_chunk" is already compressed
 NOTICE:  chunk "_hyper_11_234_chunk" is already compressed
-NOTICE:  chunk "_hyper_11_235_chunk" is already compressed
+NOTICE:  chunk "_hyper_11_250_chunk" is already compressed
+NOTICE:  chunk "_hyper_11_254_chunk" is already compressed
+NOTICE:  chunk "_hyper_11_258_chunk" is already compressed
+NOTICE:  chunk "_hyper_11_262_chunk" is already compressed
+NOTICE:  chunk "_hyper_11_266_chunk" is already compressed
+NOTICE:  chunk "_hyper_11_270_chunk" is already compressed
+NOTICE:  chunk "_hyper_11_278_chunk" is already compressed
+NOTICE:  chunk "_hyper_11_279_chunk" is already compressed
+NOTICE:  chunk "_hyper_11_280_chunk" is already compressed
               compress_chunk               
 -------------------------------------------
- _timescaledb_internal._hyper_11_167_chunk
- _timescaledb_internal._hyper_11_169_chunk
- _timescaledb_internal._hyper_11_171_chunk
- _timescaledb_internal._hyper_11_173_chunk
- _timescaledb_internal._hyper_11_175_chunk
- _timescaledb_internal._hyper_11_177_chunk
- _timescaledb_internal._hyper_11_179_chunk
- _timescaledb_internal._hyper_11_181_chunk
- _timescaledb_internal._hyper_11_183_chunk
- _timescaledb_internal._hyper_11_185_chunk
- _timescaledb_internal._hyper_11_187_chunk
- _timescaledb_internal._hyper_11_189_chunk
- _timescaledb_internal._hyper_11_205_chunk
- _timescaledb_internal._hyper_11_209_chunk
- _timescaledb_internal._hyper_11_213_chunk
- _timescaledb_internal._hyper_11_217_chunk
- _timescaledb_internal._hyper_11_221_chunk
- _timescaledb_internal._hyper_11_225_chunk
- _timescaledb_internal._hyper_11_233_chunk
+ _timescaledb_internal._hyper_11_212_chunk
+ _timescaledb_internal._hyper_11_214_chunk
+ _timescaledb_internal._hyper_11_216_chunk
+ _timescaledb_internal._hyper_11_218_chunk
+ _timescaledb_internal._hyper_11_220_chunk
+ _timescaledb_internal._hyper_11_222_chunk
+ _timescaledb_internal._hyper_11_224_chunk
+ _timescaledb_internal._hyper_11_226_chunk
+ _timescaledb_internal._hyper_11_228_chunk
+ _timescaledb_internal._hyper_11_230_chunk
+ _timescaledb_internal._hyper_11_232_chunk
  _timescaledb_internal._hyper_11_234_chunk
- _timescaledb_internal._hyper_11_235_chunk
- _timescaledb_internal._hyper_11_239_chunk
- _timescaledb_internal._hyper_11_240_chunk
- _timescaledb_internal._hyper_11_241_chunk
+ _timescaledb_internal._hyper_11_250_chunk
+ _timescaledb_internal._hyper_11_254_chunk
+ _timescaledb_internal._hyper_11_258_chunk
+ _timescaledb_internal._hyper_11_262_chunk
+ _timescaledb_internal._hyper_11_266_chunk
+ _timescaledb_internal._hyper_11_270_chunk
+ _timescaledb_internal._hyper_11_278_chunk
+ _timescaledb_internal._hyper_11_279_chunk
+ _timescaledb_internal._hyper_11_280_chunk
+ _timescaledb_internal._hyper_11_284_chunk
+ _timescaledb_internal._hyper_11_285_chunk
+ _timescaledb_internal._hyper_11_286_chunk
 (24 rows)
 
 SELECT count(*) as number_of_chunks FROM show_chunks('test6');
@@ -652,10 +676,10 @@ INSERT INTO test8 (time, series_id, value) SELECT t, s, 1 FROM generate_series(N
 SELECT compress_chunk(c, true) FROM show_chunks('test8') c LIMIT 4;
               compress_chunk               
 -------------------------------------------
- _timescaledb_internal._hyper_15_281_chunk
- _timescaledb_internal._hyper_15_281_chunk
- _timescaledb_internal._hyper_15_281_chunk
- _timescaledb_internal._hyper_15_281_chunk
+ _timescaledb_internal._hyper_15_338_chunk
+ _timescaledb_internal._hyper_15_338_chunk
+ _timescaledb_internal._hyper_15_338_chunk
+ _timescaledb_internal._hyper_15_338_chunk
 (4 rows)
 
 SET enable_indexscan TO OFF;
@@ -684,7 +708,7 @@ INSERT INTO test9 (time, series_id, value) SELECT '2020-01-01 00:00:00'::TIMESTA
 SELECT compress_chunk(show_chunks('test9'), true);
               compress_chunk               
 -------------------------------------------
- _timescaledb_internal._hyper_17_287_chunk
+ _timescaledb_internal._hyper_17_344_chunk
 (1 row)
 
 INSERT INTO test9 (time, series_id, value) SELECT '2020-01-01 01:00:00'::TIMESTAMPTZ, 1, 1;
@@ -697,11 +721,11 @@ SELECT hypertable_name, range_start, range_end FROM timescaledb_information.chun
 (2 rows)
 
 SELECT compress_chunk(show_chunks('test9'), true);
-NOTICE:  chunk "_hyper_17_287_chunk" is already compressed
+NOTICE:  chunk "_hyper_17_344_chunk" is already compressed
               compress_chunk               
 -------------------------------------------
- _timescaledb_internal._hyper_17_287_chunk
- _timescaledb_internal._hyper_17_287_chunk
+ _timescaledb_internal._hyper_17_344_chunk
+ _timescaledb_internal._hyper_17_344_chunk
 (2 rows)
 
 -- should be 1 chunk because of rollup
@@ -723,11 +747,11 @@ SELECT hypertable_name, range_start, range_end FROM timescaledb_information.chun
 ALTER TABLE test9 SET (timescaledb.compress_segmentby = '');
 BEGIN;
   SELECT compress_chunk(show_chunks('test9'), true);
-NOTICE:  chunk "_hyper_17_287_chunk" is already compressed
+NOTICE:  chunk "_hyper_17_344_chunk" is already compressed
               compress_chunk               
 -------------------------------------------
- _timescaledb_internal._hyper_17_287_chunk
- _timescaledb_internal._hyper_17_290_chunk
+ _timescaledb_internal._hyper_17_344_chunk
+ _timescaledb_internal._hyper_17_347_chunk
 (2 rows)
 
   -- should not be rolled up
@@ -742,11 +766,11 @@ ROLLBACK;
 ALTER TABLE test9 SET (timescaledb.compress_segmentby = 'series_id', timescaledb.compress_orderby = 'time DESC');
 BEGIN;
   SELECT compress_chunk(show_chunks('test9'), true);
-NOTICE:  chunk "_hyper_17_287_chunk" is already compressed
+NOTICE:  chunk "_hyper_17_344_chunk" is already compressed
               compress_chunk               
 -------------------------------------------
- _timescaledb_internal._hyper_17_287_chunk
- _timescaledb_internal._hyper_17_290_chunk
+ _timescaledb_internal._hyper_17_344_chunk
+ _timescaledb_internal._hyper_17_347_chunk
 (2 rows)
 
   -- should not be rolled up
@@ -761,11 +785,11 @@ ROLLBACK;
 ALTER TABLE test9 SET (timescaledb.compress_segmentby = 'series_id', timescaledb.compress_orderby = 'time NULLS FIRST');
 BEGIN;
   SELECT compress_chunk(show_chunks('test9'), true);
-NOTICE:  chunk "_hyper_17_287_chunk" is already compressed
+NOTICE:  chunk "_hyper_17_344_chunk" is already compressed
               compress_chunk               
 -------------------------------------------
- _timescaledb_internal._hyper_17_287_chunk
- _timescaledb_internal._hyper_17_290_chunk
+ _timescaledb_internal._hyper_17_344_chunk
+ _timescaledb_internal._hyper_17_347_chunk
 (2 rows)
 
   -- should not be rolled up
@@ -781,11 +805,11 @@ ROLLBACK;
 ALTER TABLE test9 SET (timescaledb.compress_segmentby = 'series_id', timescaledb.compress_orderby = 'time');
 BEGIN;
   SELECT compress_chunk(show_chunks('test9'), true);
-NOTICE:  chunk "_hyper_17_287_chunk" is already compressed
+NOTICE:  chunk "_hyper_17_344_chunk" is already compressed
               compress_chunk               
 -------------------------------------------
- _timescaledb_internal._hyper_17_287_chunk
- _timescaledb_internal._hyper_17_287_chunk
+ _timescaledb_internal._hyper_17_344_chunk
+ _timescaledb_internal._hyper_17_344_chunk
 (2 rows)
 
   -- should be rolled up

--- a/tsl/test/expected/recompress_chunk_segmentwise.out
+++ b/tsl/test/expected/recompress_chunk_segmentwise.out
@@ -87,6 +87,15 @@ select numrows_pre_compression, numrows_post_compression from _timescaledb_catal
                        2 |                        1
 (1 row)
 
+insert into mytab_oneseg values ('2023-01-01 19:56:20.048355+02'::timestamptz, 2, NULL, 2);
+select chunk_id
+from compressed_chunk_info_view where hypertable_name = 'mytab_oneseg' \gset
+-- check we are handling unexpected chunk status (partially compressed but not compressed)
+update _timescaledb_catalog.chunk set status = 8 where id = :chunk_id;
+\set ON_ERROR_STOP 0
+select _timescaledb_functions.recompress_chunk_segmentwise(:'chunk_to_compress_1');
+ERROR:  unexpected chunk status 8 in chunk _timescaledb_internal._hyper_1_1_chunk
+\set ON_ERROR_STOP 1
 ---------------- test1: one affected segment, one unaffected --------------
 -- unaffected segment will still be recompressed in a future PR we want to avoid doing this
 create table mytab_twoseg (time timestamptz not null, a int, b int, c int);


### PR DESCRIPTION
Recent changes switched recompression of unordered compressed chunks to use segmentwise recompression which is designed to work with partial chunks only. This change reverts that back to full recompression.

Disable-check: force-changelog-file