### PR TITLE
Don't show osm chunk via show_chunks

### DIFF
--- a/tsl/src/continuous_aggs/utils.c
+++ b/tsl/src/continuous_aggs/utils.c
@@ -23,7 +23,7 @@ static Datum
 create_cagg_validate_query_datum(TupleDesc tupdesc, const bool is_valid_query,
 								 const ErrorData *edata)
 {
-	NullableDatum datums[Natts_cagg_validate_query] = { 0 };
+	NullableDatum datums[Natts_cagg_validate_query] = { { 0 } };
 	HeapTuple tuple;
 
 	tupdesc = BlessTupleDesc(tupdesc);

--- a/tsl/test/expected/chunk_utils_internal.out
+++ b/tsl/test/expected/chunk_utils_internal.out
@@ -946,6 +946,13 @@ ORDER BY id;
  16 | child_hyper_constr
 (2 rows)
 
+-- show_chunks will not show the OSM chunk which is visible via the above query
+SELECT show_chunks('hyper_constr');
+               show_chunks               
+-----------------------------------------
+ _timescaledb_internal._hyper_7_15_chunk
+(1 row)
+
 ROLLBACK;
 CALL run_job(:deljob_id);
 NOTICE:  hypertable_drop_chunks_hook 

--- a/tsl/test/expected/compression_errors-13.out
+++ b/tsl/test/expected/compression_errors-13.out
@@ -878,6 +878,16 @@ WARNING:  there was some uncertainty picking the default segment by for the hype
 NOTICE:  default segment by for hypertable "osm_table" is set to ""
 NOTICE:  default order by for hypertable "osm_table" is set to ""time" DESC"
 INSERT INTO osm_table VALUES ('2022-11-11 11:11:11', 'foo', 1.0);
+SELECT format('%I.%I',chunk_schema,chunk_name) AS "CHUNK_NAME"
+FROM timescaledb_information.chunks
+WHERE hypertable_name = 'osm_table'
+ORDER BY chunk_name LIMIT 1 \gset
 UPDATE _timescaledb_catalog.chunk ch SET osm_chunk = true FROM _timescaledb_catalog.hypertable ht WHERE ch.hypertable_id = ht.id AND ht.table_name='osm_table';
-SELECT compress_chunk(show_chunks('osm_table'));
+-- show_chunks should not show any OSM chunks
+SELECT show_chunks('osm_table');
+ show_chunks 
+-------------
+(0 rows)
+
+SELECT compress_chunk(:'CHUNK_NAME');
 ERROR:  compress_chunk not permitted on tiered chunk "_hyper_43_31_chunk" 

--- a/tsl/test/expected/compression_errors-14.out
+++ b/tsl/test/expected/compression_errors-14.out
@@ -878,6 +878,16 @@ WARNING:  there was some uncertainty picking the default segment by for the hype
 NOTICE:  default segment by for hypertable "osm_table" is set to ""
 NOTICE:  default order by for hypertable "osm_table" is set to ""time" DESC"
 INSERT INTO osm_table VALUES ('2022-11-11 11:11:11', 'foo', 1.0);
+SELECT format('%I.%I',chunk_schema,chunk_name) AS "CHUNK_NAME"
+FROM timescaledb_information.chunks
+WHERE hypertable_name = 'osm_table'
+ORDER BY chunk_name LIMIT 1 \gset
 UPDATE _timescaledb_catalog.chunk ch SET osm_chunk = true FROM _timescaledb_catalog.hypertable ht WHERE ch.hypertable_id = ht.id AND ht.table_name='osm_table';
-SELECT compress_chunk(show_chunks('osm_table'));
+-- show_chunks should not show any OSM chunks
+SELECT show_chunks('osm_table');
+ show_chunks 
+-------------
+(0 rows)
+
+SELECT compress_chunk(:'CHUNK_NAME');
 ERROR:  compress_chunk not permitted on tiered chunk "_hyper_43_31_chunk" 

--- a/tsl/test/expected/compression_errors-15.out
+++ b/tsl/test/expected/compression_errors-15.out
@@ -878,6 +878,16 @@ WARNING:  there was some uncertainty picking the default segment by for the hype
 NOTICE:  default segment by for hypertable "osm_table" is set to ""
 NOTICE:  default order by for hypertable "osm_table" is set to ""time" DESC"
 INSERT INTO osm_table VALUES ('2022-11-11 11:11:11', 'foo', 1.0);
+SELECT format('%I.%I',chunk_schema,chunk_name) AS "CHUNK_NAME"
+FROM timescaledb_information.chunks
+WHERE hypertable_name = 'osm_table'
+ORDER BY chunk_name LIMIT 1 \gset
 UPDATE _timescaledb_catalog.chunk ch SET osm_chunk = true FROM _timescaledb_catalog.hypertable ht WHERE ch.hypertable_id = ht.id AND ht.table_name='osm_table';
-SELECT compress_chunk(show_chunks('osm_table'));
+-- show_chunks should not show any OSM chunks
+SELECT show_chunks('osm_table');
+ show_chunks 
+-------------
+(0 rows)
+
+SELECT compress_chunk(:'CHUNK_NAME');
 ERROR:  compress_chunk not permitted on tiered chunk "_hyper_43_31_chunk" 

--- a/tsl/test/expected/compression_errors-16.out
+++ b/tsl/test/expected/compression_errors-16.out
@@ -878,6 +878,16 @@ WARNING:  there was some uncertainty picking the default segment by for the hype
 NOTICE:  default segment by for hypertable "osm_table" is set to ""
 NOTICE:  default order by for hypertable "osm_table" is set to ""time" DESC"
 INSERT INTO osm_table VALUES ('2022-11-11 11:11:11', 'foo', 1.0);
+SELECT format('%I.%I',chunk_schema,chunk_name) AS "CHUNK_NAME"
+FROM timescaledb_information.chunks
+WHERE hypertable_name = 'osm_table'
+ORDER BY chunk_name LIMIT 1 \gset
 UPDATE _timescaledb_catalog.chunk ch SET osm_chunk = true FROM _timescaledb_catalog.hypertable ht WHERE ch.hypertable_id = ht.id AND ht.table_name='osm_table';
-SELECT compress_chunk(show_chunks('osm_table'));
+-- show_chunks should not show any OSM chunks
+SELECT show_chunks('osm_table');
+ show_chunks 
+-------------
+(0 rows)
+
+SELECT compress_chunk(:'CHUNK_NAME');
 ERROR:  compress_chunk not permitted on tiered chunk "_hyper_43_31_chunk" 

--- a/tsl/test/sql/chunk_utils_internal.sql
+++ b/tsl/test/sql/chunk_utils_internal.sql
@@ -515,6 +515,8 @@ SELECT drop_chunks('hyper_constr', 10::int);
 SELECT id, table_name FROM _timescaledb_catalog.chunk
 where hypertable_id = (Select id from _timescaledb_catalog.hypertable where table_name = 'hyper_constr')
 ORDER BY id;
+-- show_chunks will not show the OSM chunk which is visible via the above query
+SELECT show_chunks('hyper_constr');
 ROLLBACK;
 CALL run_job(:deljob_id);
 CALL run_job(:deljob_id);

--- a/tsl/test/sql/compression_errors.sql.in
+++ b/tsl/test/sql/compression_errors.sql.in
@@ -511,7 +511,14 @@ ALTER TABLE osm_table SET (timescaledb.compress);
 
 INSERT INTO osm_table VALUES ('2022-11-11 11:11:11', 'foo', 1.0);
 
+SELECT format('%I.%I',chunk_schema,chunk_name) AS "CHUNK_NAME"
+FROM timescaledb_information.chunks
+WHERE hypertable_name = 'osm_table'
+ORDER BY chunk_name LIMIT 1 \gset
+
 UPDATE _timescaledb_catalog.chunk ch SET osm_chunk = true FROM _timescaledb_catalog.hypertable ht WHERE ch.hypertable_id = ht.id AND ht.table_name='osm_table';
 
-SELECT compress_chunk(show_chunks('osm_table'));
+-- show_chunks should not show any OSM chunks
+SELECT show_chunks('osm_table');
+SELECT compress_chunk(:'CHUNK_NAME');
 


### PR DESCRIPTION
Fix show_chunks to not to show the OSM chunk. In passing, also fix a compilation error on macOS.

Disable-check: force-changelog-file