### PR TITLE
Refactor parameter of invalidation_state_init

### DIFF
--- a/tsl/src/continuous_aggs/invalidation.h
+++ b/tsl/src/continuous_aggs/invalidation.h
@@ -42,12 +42,13 @@ extern void continuous_agg_invalidate_raw_ht(const Hypertable *raw_ht, int64 sta
 extern void continuous_agg_invalidate_mat_ht(const Hypertable *raw_ht, const Hypertable *mat_ht,
 											 int64 start, int64 end);
 
-extern void invalidation_process_hypertable_log(int32 mat_hypertable_id, int32 raw_hypertable_id,
-												Oid dimtype, const CaggsInfo *all_caggs_info);
+extern void invalidation_process_hypertable_log(const ContinuousAgg *cagg, Oid dimtype,
+												const CaggsInfo *all_caggs_info);
 
-extern InvalidationStore *invalidation_process_cagg_log(
-	int32 mat_hypertable_id, int32 raw_hypertable_id, const InternalTimeRange *refresh_window,
-	const CaggsInfo *all_caggs_info, const long max_materializations, bool *do_merged_refresh,
-	InternalTimeRange *ret_merged_refresh_window, const CaggRefreshCallContext callctx);
+extern InvalidationStore *
+invalidation_process_cagg_log(const ContinuousAgg *cagg, const InternalTimeRange *refresh_window,
+							  const CaggsInfo *all_caggs_info, const long max_materializations,
+							  bool *do_merged_refresh, InternalTimeRange *ret_merged_refresh_window,
+							  const CaggRefreshCallContext callctx);
 
 extern void invalidation_store_free(InvalidationStore *store);

--- a/tsl/src/continuous_aggs/refresh.c
+++ b/tsl/src/continuous_aggs/refresh.c
@@ -635,8 +635,7 @@ process_cagg_invalidations_and_refresh(const ContinuousAgg *cagg,
 	LockRelationOid(hyper_relid, ExclusiveLock);
 	const CaggsInfo all_caggs_info =
 		ts_continuous_agg_get_all_caggs_info(cagg->data.raw_hypertable_id);
-	invalidations = invalidation_process_cagg_log(cagg->data.mat_hypertable_id,
-												  cagg->data.raw_hypertable_id,
+	invalidations = invalidation_process_cagg_log(cagg,
 												  refresh_window,
 												  &all_caggs_info,
 												  ts_guc_cagg_max_individual_materializations,
@@ -787,10 +786,7 @@ continuous_agg_refresh_internal(const ContinuousAgg *cagg,
 	/* Process invalidations in the hypertable invalidation log */
 	const CaggsInfo all_caggs_info =
 		ts_continuous_agg_get_all_caggs_info(cagg->data.raw_hypertable_id);
-	invalidation_process_hypertable_log(cagg->data.mat_hypertable_id,
-										cagg->data.raw_hypertable_id,
-										refresh_window.type,
-										&all_caggs_info);
+	invalidation_process_hypertable_log(cagg, refresh_window.type, &all_caggs_info);
 
 	/* Commit and Start a new transaction */
 	SPI_commit_and_chain();


### PR DESCRIPTION
So far, the invalidation_state_init function used a loop to find the proper CAgg bucket function. This PR refactors the parameter of the function and passes the needed information directly.

---

Disable-check: force-changelog-file
