### PR TITLE
Fix deletes with subqueries and compression

### DIFF
--- a/.unreleased/bugfix_6789
+++ b/.unreleased/bugfix_6789
@@ -1,0 +1,2 @@
+Fixes: #6789 Fix deletes with subqueries and compression 
+Thanks: @Dzuzepppe for reporting an issue with DELETEs using subquery on compressed chunk working incorrectly.

--- a/tsl/src/nodes/decompress_chunk/decompress_chunk.c
+++ b/tsl/src/nodes/decompress_chunk/decompress_chunk.c
@@ -25,6 +25,7 @@
 #include <planner.h>
 
 #include "compat/compat.h"
+#include "cross_module_fn.h"
 #include "custom_type_cache.h"
 #include "debug_assert.h"
 #include "ts_catalog/array_utils.h"
@@ -691,6 +692,8 @@ add_chunk_sorted_paths(PlannerInfo *root, RelOptInfo *chunk_rel, Hypertable *ht,
 	}
 }
 
+#define IS_UPDL_CMD(parse)                                                                         \
+	((parse)->commandType == CMD_UPDATE || (parse)->commandType == CMD_DELETE)
 void
 ts_decompress_chunk_generate_paths(PlannerInfo *root, RelOptInfo *chunk_rel, Hypertable *ht,
 								   Chunk *chunk)
@@ -698,6 +701,31 @@ ts_decompress_chunk_generate_paths(PlannerInfo *root, RelOptInfo *chunk_rel, Hyp
 	RelOptInfo *compressed_rel;
 	ListCell *lc;
 	Index ht_relid = 0;
+	PlannerInfo *proot;
+	bool consider_partial = ts_chunk_is_partial(chunk);
+
+	/*
+	 * For UPDATE/DELETE commands, the executor decompresses and brings the rows into
+	 * the uncompressed chunk. Therefore, it's necessary to add the scan on the
+	 * uncompressed portion.
+	 */
+	if (ts_chunk_is_compressed(chunk) && ts_cm_functions->decompress_target_segments &&
+		!consider_partial)
+	{
+		for (proot = root->parent_root; proot != NULL && !consider_partial;
+			 proot = proot->parent_root)
+		{
+			/*
+			 * We could additionally check and compare that the relation involved in the subquery
+			 * and the DML target relation are one and the same. But these kinds of queries
+			 * should be rare.
+			 */
+			if (IS_UPDL_CMD(proot->parse))
+			{
+				consider_partial = true;
+			}
+		}
+	}
 
 	CompressionInfo *compression_info = build_compressioninfo(root, ht, chunk, chunk_rel);
 
@@ -725,11 +753,7 @@ ts_decompress_chunk_generate_paths(PlannerInfo *root, RelOptInfo *chunk_rel, Hyp
 
 	compressed_rel->consider_parallel = chunk_rel->consider_parallel;
 	/* translate chunk_rel->baserestrictinfo */
-	pushdown_quals(root,
-				   compression_info->settings,
-				   chunk_rel,
-				   compressed_rel,
-				   ts_chunk_is_partial(chunk));
+	pushdown_quals(root, compression_info->settings, chunk_rel, compressed_rel, consider_partial);
 	set_baserel_size_estimates(root, compressed_rel);
 	double new_row_estimate = compressed_rel->rows * TARGET_COMPRESSED_BATCH_SIZE;
 
@@ -868,7 +892,7 @@ ts_decompress_chunk_generate_paths(PlannerInfo *root, RelOptInfo *chunk_rel, Hyp
 				 * to a merge append path when we are able to generate the ordered result for the
 				 * compressed and uncompressed part of the chunk.
 				 */
-				if (!ts_chunk_is_partial(chunk))
+				if (!consider_partial)
 					add_path(chunk_rel, &batch_merge_path->custom_path.path);
 			}
 		}
@@ -917,7 +941,7 @@ ts_decompress_chunk_generate_paths(PlannerInfo *root, RelOptInfo *chunk_rel, Hyp
 		 * If this is a partially compressed chunk we have to combine data
 		 * from compressed and uncompressed chunk.
 		 */
-		if (ts_chunk_is_partial(chunk))
+		if (consider_partial)
 		{
 			Bitmapset *req_outer = PATH_REQ_OUTER(chunk_path);
 			Path *uncompressed_path =
@@ -1003,7 +1027,7 @@ ts_decompress_chunk_generate_paths(PlannerInfo *root, RelOptInfo *chunk_rel, Hyp
 														 compressed_path->parallel_workers,
 														 compressed_path);
 
-			if (ts_chunk_is_partial(chunk))
+			if (consider_partial)
 			{
 				Bitmapset *req_outer = PATH_REQ_OUTER(path);
 				Path *uncompressed_path = NULL;

--- a/tsl/test/expected/compression_update_delete.out
+++ b/tsl/test/expected/compression_update_delete.out
@@ -2742,3 +2742,176 @@ UPDATE test_limit SET id = 0;
 DELETE FROM test_limit WHERE id > 0;
 \set ON_ERROR_STOP 1
 DROP TABLE test_limit;
+-- check partial compression with DML
+CREATE TABLE test_partials (time timestamptz NOT NULL, a int, b int);
+SELECT create_hypertable('test_partials', 'time');
+      create_hypertable      
+-----------------------------
+ (35,public,test_partials,t)
+(1 row)
+
+INSERT INTO test_partials
+VALUES -- chunk1
+  ('2020-01-01 00:00'::timestamptz, 1, 2),
+  ('2020-01-01 00:01'::timestamptz, 2, 2),
+  ('2020-01-01 00:04'::timestamptz, 1, 2),
+  -- chunk2
+  ('2021-01-01 00:00'::timestamptz, 1, 2),
+  ('2021-01-01 00:04'::timestamptz, 1, 2),
+  -- chunk3
+  ('2022-01-01 00:00'::timestamptz, 1, 2),
+  ('2022-01-01 00:04'::timestamptz, 1, 2);
+-- enable compression, compress all chunks
+ALTER TABLE test_partials SET (timescaledb.compress);
+WARNING:  there was some uncertainty picking the default segment by for the hypertable: You do not have any indexes on columns that can be used for segment_by and thus we are not using segment_by for compression. Please make sure you are not missing any indexes
+NOTICE:  default segment by for hypertable "test_partials" is set to ""
+NOTICE:  default order by for hypertable "test_partials" is set to ""time" DESC"
+SELECT compress_chunk(show_chunks('test_partials'));
+              compress_chunk              
+------------------------------------------
+ _timescaledb_internal._hyper_35_68_chunk
+ _timescaledb_internal._hyper_35_69_chunk
+ _timescaledb_internal._hyper_35_70_chunk
+(3 rows)
+
+-- fully compressed
+EXPLAIN (costs off) SELECT * FROM test_partials ORDER BY time;
+                                  QUERY PLAN                                   
+-------------------------------------------------------------------------------
+ Custom Scan (ChunkAppend) on test_partials
+   Order: test_partials."time"
+   ->  Custom Scan (DecompressChunk) on _hyper_35_68_chunk
+         ->  Sort
+               Sort Key: compress_hyper_36_71_chunk._ts_meta_sequence_num DESC
+               ->  Seq Scan on compress_hyper_36_71_chunk
+   ->  Custom Scan (DecompressChunk) on _hyper_35_69_chunk
+         ->  Sort
+               Sort Key: compress_hyper_36_72_chunk._ts_meta_sequence_num DESC
+               ->  Seq Scan on compress_hyper_36_72_chunk
+   ->  Custom Scan (DecompressChunk) on _hyper_35_70_chunk
+         ->  Sort
+               Sort Key: compress_hyper_36_73_chunk._ts_meta_sequence_num DESC
+               ->  Seq Scan on compress_hyper_36_73_chunk
+(14 rows)
+
+-- verify correct results
+SELECT * FROM test_partials ORDER BY time;
+             time             | a | b 
+------------------------------+---+---
+ Wed Jan 01 00:00:00 2020 PST | 1 | 2
+ Wed Jan 01 00:01:00 2020 PST | 2 | 2
+ Wed Jan 01 00:04:00 2020 PST | 1 | 2
+ Fri Jan 01 00:00:00 2021 PST | 1 | 2
+ Fri Jan 01 00:04:00 2021 PST | 1 | 2
+ Sat Jan 01 00:00:00 2022 PST | 1 | 2
+ Sat Jan 01 00:04:00 2022 PST | 1 | 2
+(7 rows)
+
+-- check that DML causes transparent decompression and that
+-- data gets shifted to the uncompressed parts
+EXPLAIN (costs off) DELETE FROM test_partials WHERE time >= ALL(SELECT time from test_partials);
+                                        QUERY PLAN                                         
+-------------------------------------------------------------------------------------------
+ Custom Scan (HypertableModify)
+   ->  Delete on test_partials
+         Delete on _hyper_35_68_chunk test_partials_1
+         Delete on _hyper_35_69_chunk test_partials_2
+         Delete on _hyper_35_70_chunk test_partials_3
+         ->  Custom Scan (ChunkAppend) on test_partials
+               ->  Seq Scan on _hyper_35_68_chunk test_partials_1
+                     Filter: (SubPlan 1)
+                     SubPlan 1
+                       ->  Materialize
+                             ->  Append
+                                   ->  Custom Scan (DecompressChunk) on _hyper_35_68_chunk
+                                         ->  Seq Scan on compress_hyper_36_71_chunk
+                                   ->  Seq Scan on _hyper_35_68_chunk
+                                   ->  Custom Scan (DecompressChunk) on _hyper_35_69_chunk
+                                         ->  Seq Scan on compress_hyper_36_72_chunk
+                                   ->  Seq Scan on _hyper_35_69_chunk
+                                   ->  Custom Scan (DecompressChunk) on _hyper_35_70_chunk
+                                         ->  Seq Scan on compress_hyper_36_73_chunk
+                                   ->  Seq Scan on _hyper_35_70_chunk
+               ->  Seq Scan on _hyper_35_69_chunk test_partials_2
+                     Filter: (SubPlan 1)
+               ->  Seq Scan on _hyper_35_70_chunk test_partials_3
+                     Filter: (SubPlan 1)
+(24 rows)
+
+DELETE FROM test_partials WHERE time >= ALL(SELECT time from test_partials);
+-- All 3 chunks will now become partially compressed chunks
+EXPLAIN (costs off) SELECT * FROM test_partials ORDER BY time;
+                                     QUERY PLAN                                      
+-------------------------------------------------------------------------------------
+ Custom Scan (ChunkAppend) on test_partials
+   Order: test_partials."time"
+   ->  Merge Append
+         Sort Key: _hyper_35_68_chunk."time"
+         ->  Custom Scan (DecompressChunk) on _hyper_35_68_chunk
+               ->  Sort
+                     Sort Key: compress_hyper_36_71_chunk._ts_meta_sequence_num DESC
+                     ->  Seq Scan on compress_hyper_36_71_chunk
+         ->  Sort
+               Sort Key: _hyper_35_68_chunk."time"
+               ->  Seq Scan on _hyper_35_68_chunk
+   ->  Merge Append
+         Sort Key: _hyper_35_69_chunk."time"
+         ->  Custom Scan (DecompressChunk) on _hyper_35_69_chunk
+               ->  Sort
+                     Sort Key: compress_hyper_36_72_chunk._ts_meta_sequence_num DESC
+                     ->  Seq Scan on compress_hyper_36_72_chunk
+         ->  Sort
+               Sort Key: _hyper_35_69_chunk."time"
+               ->  Seq Scan on _hyper_35_69_chunk
+   ->  Merge Append
+         Sort Key: _hyper_35_70_chunk."time"
+         ->  Custom Scan (DecompressChunk) on _hyper_35_70_chunk
+               ->  Sort
+                     Sort Key: compress_hyper_36_73_chunk._ts_meta_sequence_num DESC
+                     ->  Seq Scan on compress_hyper_36_73_chunk
+         ->  Sort
+               Sort Key: _hyper_35_70_chunk."time"
+               ->  Seq Scan on _hyper_35_70_chunk
+(29 rows)
+
+-- verify correct results
+SELECT * FROM test_partials ORDER BY time;
+             time             | a | b 
+------------------------------+---+---
+ Wed Jan 01 00:00:00 2020 PST | 1 | 2
+ Wed Jan 01 00:01:00 2020 PST | 2 | 2
+ Wed Jan 01 00:04:00 2020 PST | 1 | 2
+ Fri Jan 01 00:00:00 2021 PST | 1 | 2
+ Fri Jan 01 00:04:00 2021 PST | 1 | 2
+ Sat Jan 01 00:00:00 2022 PST | 1 | 2
+(6 rows)
+
+SELECT compress_chunk(show_chunks('test_partials'));
+              compress_chunk              
+------------------------------------------
+ _timescaledb_internal._hyper_35_68_chunk
+ _timescaledb_internal._hyper_35_69_chunk
+ _timescaledb_internal._hyper_35_70_chunk
+(3 rows)
+
+-- fully compressed
+EXPLAIN (costs off) SELECT * FROM test_partials ORDER BY time;
+                                  QUERY PLAN                                   
+-------------------------------------------------------------------------------
+ Custom Scan (ChunkAppend) on test_partials
+   Order: test_partials."time"
+   ->  Custom Scan (DecompressChunk) on _hyper_35_68_chunk
+         ->  Sort
+               Sort Key: compress_hyper_36_74_chunk._ts_meta_sequence_num DESC
+               ->  Seq Scan on compress_hyper_36_74_chunk
+   ->  Custom Scan (DecompressChunk) on _hyper_35_69_chunk
+         ->  Sort
+               Sort Key: compress_hyper_36_75_chunk._ts_meta_sequence_num DESC
+               ->  Seq Scan on compress_hyper_36_75_chunk
+   ->  Custom Scan (DecompressChunk) on _hyper_35_70_chunk
+         ->  Sort
+               Sort Key: compress_hyper_36_76_chunk._ts_meta_sequence_num DESC
+               ->  Seq Scan on compress_hyper_36_76_chunk
+(14 rows)
+
+DROP TABLE test_partials;


### PR DESCRIPTION
For UPDATEs and DELETEs when a compressed chunk is involved, the code decompresses the relevant data into the uncompressed portion of the chunk. This happens during execution, so it's possible that if the planner doesn't have a plan for the uncompressed chunk then we might miss scanning out on those decompressed rows. We now check for the possibility of a compressed chunk becoming partial during the planning itself and tag on an APPEND plan on top of scans on the compressed and uncompressed parts.