### PR TITLE
Remove unneeded pg_locale.h include

### DIFF
--- a/tsl/src/nodes/decompress_chunk/pred_text.c
+++ b/tsl/src/nodes/decompress_chunk/pred_text.c
@@ -6,7 +6,6 @@
 
 #include "pred_text.h"
 
-#include <utils/pg_locale.h>
 #include <miscadmin.h>
 
 #include "compat/compat.h"


### PR DESCRIPTION
This include will pull in header files from ICU which would result in ICU being a build requirement for timescaledb.