### PR TITLE
Prevent usage of time_bucket_ng in CAgg definition

### DIFF
--- a/.unreleased/pr_6798
+++ b/.unreleased/pr_6798
@@ -1,0 +1,1 @@
+Implements: #6798 Prevent usage of deprecated time_bucket_ng in CAgg definition 

--- a/src/func_cache.c
+++ b/src/func_cache.c
@@ -366,7 +366,7 @@ static FuncInfo funcinfo[] = {
 	{
 		.origin = ORIGIN_TIMESCALE_EXPERIMENTAL,
 		.is_bucketing_func = true,
-		.allowed_in_cagg_definition = true,
+		.allowed_in_cagg_definition = false,
 		.funcname = "time_bucket_ng",
 		.nargs = 2,
 		.arg_types = { INTERVALOID, DATEOID },
@@ -376,7 +376,7 @@ static FuncInfo funcinfo[] = {
 	{
 		.origin = ORIGIN_TIMESCALE_EXPERIMENTAL,
 		.is_bucketing_func = true,
-		.allowed_in_cagg_definition = true,
+		.allowed_in_cagg_definition = false,
 		.funcname = "time_bucket_ng",
 		.nargs = 3,
 		.arg_types = { INTERVALOID, DATEOID, DATEOID },
@@ -386,7 +386,7 @@ static FuncInfo funcinfo[] = {
 	{
 		.origin = ORIGIN_TIMESCALE_EXPERIMENTAL,
 		.is_bucketing_func = true,
-		.allowed_in_cagg_definition = true,
+		.allowed_in_cagg_definition = false,
 		.funcname = "time_bucket_ng",
 		.nargs = 2,
 		.arg_types = { INTERVALOID, TIMESTAMPOID },
@@ -396,7 +396,7 @@ static FuncInfo funcinfo[] = {
 	{
 		.origin = ORIGIN_TIMESCALE_EXPERIMENTAL,
 		.is_bucketing_func = true,
-		.allowed_in_cagg_definition = true,
+		.allowed_in_cagg_definition = false,
 		.funcname = "time_bucket_ng",
 		.nargs = 3,
 		.arg_types = { INTERVALOID, TIMESTAMPOID, TIMESTAMPOID },
@@ -406,7 +406,7 @@ static FuncInfo funcinfo[] = {
 	{
 		.origin = ORIGIN_TIMESCALE_EXPERIMENTAL,
 		.is_bucketing_func = true,
-		.allowed_in_cagg_definition = true,
+		.allowed_in_cagg_definition = false,
 		.funcname = "time_bucket_ng",
 		.nargs = 3,
 		.arg_types = { INTERVALOID, TIMESTAMPTZOID, TEXTOID },
@@ -416,7 +416,7 @@ static FuncInfo funcinfo[] = {
 	{
 		.origin = ORIGIN_TIMESCALE_EXPERIMENTAL,
 		.is_bucketing_func = true,
-		.allowed_in_cagg_definition = true,
+		.allowed_in_cagg_definition = false,
 		.funcname = "time_bucket_ng",
 		.nargs = 4,
 		.arg_types = { INTERVALOID, TIMESTAMPTZOID, TIMESTAMPTZOID, TEXTOID },

--- a/src/guc.c
+++ b/src/guc.c
@@ -97,6 +97,7 @@ char *ts_last_tune_time = NULL;
 char *ts_last_tune_version = NULL;
 
 bool ts_guc_debug_require_batch_sorted_merge = false;
+bool ts_guc_debug_allow_cagg_with_deprecated_funcs = false;
 
 #ifdef TS_DEBUG
 bool ts_shutdown_bgw = false;
@@ -828,6 +829,17 @@ _guc_init(void)
 							 /* short_desc= */ "require batch sorted merge in DecompressChunk node",
 							 /* long_desc= */ "this is for debugging purposes",
 							 /* valueAddr= */ &ts_guc_debug_require_batch_sorted_merge,
+							 /* bootValue= */ false,
+							 /* context= */ PGC_USERSET,
+							 /* flags= */ 0,
+							 /* check_hook= */ NULL,
+							 /* assign_hook= */ NULL,
+							 /* show_hook= */ NULL);
+
+	DefineCustomBoolVariable(/* name= */ MAKE_EXTOPTION("debug_allow_cagg_with_deprecated_funcs"),
+							 /* short_desc= */ "allow new caggs using time_bucket_ng",
+							 /* long_desc= */ "this is for debugging/testing purposes",
+							 /* valueAddr= */ &ts_guc_debug_allow_cagg_with_deprecated_funcs,
 							 /* bootValue= */ false,
 							 /* context= */ PGC_USERSET,
 							 /* flags= */ 0,

--- a/src/guc.h
+++ b/src/guc.h
@@ -84,6 +84,8 @@ extern TSDLLEXPORT bool ts_guc_debug_compression_path_info;
 
 extern TSDLLEXPORT bool ts_guc_debug_require_batch_sorted_merge;
 
+extern TSDLLEXPORT bool ts_guc_debug_allow_cagg_with_deprecated_funcs;
+
 void _guc_init(void);
 
 typedef enum

--- a/src/ts_catalog/continuous_agg.c
+++ b/src/ts_catalog/continuous_agg.c
@@ -1375,7 +1375,9 @@ ts_continuous_agg_bucket_on_interval(Oid bucket_function)
 	FuncInfo *func_info = ts_func_cache_get(bucket_function);
 	Ensure(func_info != NULL, "unable to get function info for Oid %d", bucket_function);
 
-	Assert(func_info->allowed_in_cagg_definition);
+	/* The function has to be a currently allowed function or one of the deprecated bucketing
+	 * functions */
+	Assert(func_info->allowed_in_cagg_definition || IS_DEPRECATED_BUCKET_FUNC(func_info));
 
 	Oid first_bucket_arg = func_info->arg_types[0];
 

--- a/src/ts_catalog/continuous_agg.h
+++ b/src/ts_catalog/continuous_agg.h
@@ -40,6 +40,11 @@
 			SetUserIdAndSecContext(saved_uid, saved_secctx);                                       \
 	} while (0);
 
+/* Does the function belong to a bucket function that is no longer allowed in CAgg definitions? */
+#define IS_DEPRECATED_BUCKET_FUNC(funcinfo)                                                        \
+	((funcinfo->origin == ORIGIN_TIMESCALE_EXPERIMENTAL) &&                                        \
+	 (strcmp("time_bucket_ng", funcinfo->funcname) == 0))
+
 typedef enum ContinuousAggViewOption
 {
 	ContinuousEnabled = 0,

--- a/tsl/test/expected/cagg_deprecated_bucket_ng.out
+++ b/tsl/test/expected/cagg_deprecated_bucket_ng.out
@@ -1,0 +1,49 @@
+-- This file and its contents are licensed under the Timescale License.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-TIMESCALE for a copy of the license.
+CREATE TABLE conditions(
+  time timestamptz NOT NULL,
+  city text NOT NULL,
+  temperature INT NOT NULL);
+SELECT create_hypertable(
+  'conditions', 'time',
+  chunk_time_interval => INTERVAL '1 day'
+);
+    create_hypertable    
+-------------------------
+ (1,public,conditions,t)
+(1 row)
+
+-- Ensure no CAgg using time_bucket_ng can be created
+\set ON_ERROR_STOP 0
+-- Regular CAgg
+CREATE MATERIALIZED VIEW conditions_summary_weekly
+WITH (timescaledb.continuous, timescaledb.materialized_only=false) AS
+SELECT city,
+       timescaledb_experimental.time_bucket_ng('7 days', time, 'UTC') AS bucket,
+       MIN(temperature),
+       MAX(temperature)
+FROM conditions
+GROUP BY city, bucket WITH NO DATA;
+ERROR:  experimental bucket functions are not supported inside a CAgg definition
+-- CAgg with origin
+CREATE MATERIALIZED VIEW conditions_summary_weekly
+WITH (timescaledb.continuous, timescaledb.materialized_only=false) AS
+SELECT city,
+       timescaledb_experimental.time_bucket_ng('7 days', time, '2024-01-16 18:00:00+00') AS bucket,
+       MIN(temperature),
+       MAX(temperature)
+FROM conditions
+GROUP BY city, bucket WITH NO DATA;
+ERROR:  experimental bucket functions are not supported inside a CAgg definition
+-- CAgg with origin and timezone
+CREATE MATERIALIZED VIEW conditions_summary_weekly
+WITH (timescaledb.continuous, timescaledb.materialized_only=false) AS
+SELECT city,
+       timescaledb_experimental.time_bucket_ng('7 days', time, '2024-01-16 18:00:00+00', 'UTC') AS bucket,
+       MIN(temperature),
+       MAX(temperature)
+FROM conditions
+GROUP BY city, bucket WITH NO DATA;
+ERROR:  experimental bucket functions are not supported inside a CAgg definition
+\set ON_ERROR_STOP 1

--- a/tsl/test/expected/cagg_query.out
+++ b/tsl/test/expected/cagg_query.out
@@ -1147,7 +1147,7 @@ CREATE MATERIALIZED VIEW cagg_4_hours_offset_and_origin
   SELECT time_bucket('4 hour', time, "offset"=>'30m'::interval, origin=>'2000-01-01 01:00:00 PST'::timestamptz, timezone=>'UTC'), max(value)
     FROM temperature
     GROUP BY 1 ORDER BY 1;
-ERROR:  continuous aggregate view must include a valid time bucket function
+ERROR:  using offset and origin in a time_bucket function at the same time is not supported
 \set ON_ERROR_STOP 1
 ---
 -- Tests with CAgg processing

--- a/tsl/test/expected/cagg_usage-13.out
+++ b/tsl/test/expected/cagg_usage-13.out
@@ -473,7 +473,7 @@ CREATE MATERIALIZED VIEW cagg3 WITH (timescaledb.continuous,timescaledb.material
 ERROR:  cannot create continuous aggregate with variable-width bucket using offset or origin.
 -- offset - not supported due to variable size
 CREATE MATERIALIZED VIEW cagg4 WITH (timescaledb.continuous,timescaledb.materialized_only=true) AS SELECT time_bucket('1 month', time, 'PST8PDT', "offset":= INTERVAL '15 day') FROM metrics GROUP BY 1;
-ERROR:  continuous aggregate view must include a valid time bucket function
+ERROR:  cannot create continuous aggregate with variable-width bucket using offset or origin.
 \set ON_ERROR_STOP 1
 --
 -- drop chunks tests

--- a/tsl/test/expected/cagg_usage-14.out
+++ b/tsl/test/expected/cagg_usage-14.out
@@ -473,7 +473,7 @@ CREATE MATERIALIZED VIEW cagg3 WITH (timescaledb.continuous,timescaledb.material
 ERROR:  cannot create continuous aggregate with variable-width bucket using offset or origin.
 -- offset - not supported due to variable size
 CREATE MATERIALIZED VIEW cagg4 WITH (timescaledb.continuous,timescaledb.materialized_only=true) AS SELECT time_bucket('1 month', time, 'PST8PDT', "offset":= INTERVAL '15 day') FROM metrics GROUP BY 1;
-ERROR:  continuous aggregate view must include a valid time bucket function
+ERROR:  cannot create continuous aggregate with variable-width bucket using offset or origin.
 \set ON_ERROR_STOP 1
 --
 -- drop chunks tests

--- a/tsl/test/expected/cagg_usage-15.out
+++ b/tsl/test/expected/cagg_usage-15.out
@@ -473,7 +473,7 @@ CREATE MATERIALIZED VIEW cagg3 WITH (timescaledb.continuous,timescaledb.material
 ERROR:  cannot create continuous aggregate with variable-width bucket using offset or origin.
 -- offset - not supported due to variable size
 CREATE MATERIALIZED VIEW cagg4 WITH (timescaledb.continuous,timescaledb.materialized_only=true) AS SELECT time_bucket('1 month', time, 'PST8PDT', "offset":= INTERVAL '15 day') FROM metrics GROUP BY 1;
-ERROR:  continuous aggregate view must include a valid time bucket function
+ERROR:  cannot create continuous aggregate with variable-width bucket using offset or origin.
 \set ON_ERROR_STOP 1
 --
 -- drop chunks tests

--- a/tsl/test/expected/cagg_usage-16.out
+++ b/tsl/test/expected/cagg_usage-16.out
@@ -473,7 +473,7 @@ CREATE MATERIALIZED VIEW cagg3 WITH (timescaledb.continuous,timescaledb.material
 ERROR:  cannot create continuous aggregate with variable-width bucket using offset or origin.
 -- offset - not supported due to variable size
 CREATE MATERIALIZED VIEW cagg4 WITH (timescaledb.continuous,timescaledb.materialized_only=true) AS SELECT time_bucket('1 month', time, 'PST8PDT', "offset":= INTERVAL '15 day') FROM metrics GROUP BY 1;
-ERROR:  continuous aggregate view must include a valid time bucket function
+ERROR:  cannot create continuous aggregate with variable-width bucket using offset or origin.
 \set ON_ERROR_STOP 1
 --
 -- drop chunks tests

--- a/tsl/test/expected/cagg_utils.out
+++ b/tsl/test/expected/cagg_utils.out
@@ -310,12 +310,6 @@ CREATE MATERIALIZED VIEW temperature_tz_4h_ts
     FROM timestamptz_ht
     GROUP BY 1 ORDER BY 1;
 NOTICE:  refreshing continuous aggregate "temperature_tz_4h_ts"
-CREATE MATERIALIZED VIEW temperature_tz_4h_ts_ng
-  WITH  (timescaledb.continuous) AS
-  SELECT timescaledb_experimental.time_bucket_ng('4 hour', time, 'Asia/Shanghai'), avg(value)
-    FROM timestamptz_ht
-    GROUP BY 1 ORDER BY 1;
-NOTICE:  refreshing continuous aggregate "temperature_tz_4h_ts_ng"
 CREATE TABLE integer_ht(a integer, b integer, c integer);
 SELECT table_name FROM create_hypertable('integer_ht', 'a', chunk_time_interval=> 10);
 NOTICE:  adding not-null constraint to column "a"
@@ -341,16 +335,15 @@ NOTICE:  continuous aggregate "integer_ht_cagg" is already up-to-date
 SELECT user_view_name,
        cagg_get_bucket_function(mat_hypertable_id)
        FROM _timescaledb_catalog.continuous_agg
-       WHERE user_view_name in('temperature_4h', 'temperature_tz_4h', 'temperature_tz_4h_ts', 'temperature_tz_4h_ts_ng', 'integer_ht_cagg')
+       WHERE user_view_name in('temperature_4h', 'temperature_tz_4h', 'temperature_tz_4h_ts', 'integer_ht_cagg')
        ORDER BY user_view_name;
-     user_view_name      |                               cagg_get_bucket_function                                
--------------------------+---------------------------------------------------------------------------------------
- integer_ht_cagg         | time_bucket(integer,integer)
- temperature_4h          | time_bucket(interval,timestamp without time zone)
- temperature_tz_4h       | time_bucket(interval,timestamp with time zone)
- temperature_tz_4h_ts    | time_bucket(interval,timestamp with time zone,text,timestamp with time zone,interval)
- temperature_tz_4h_ts_ng | timescaledb_experimental.time_bucket_ng(interval,timestamp with time zone,text)
-(5 rows)
+    user_view_name    |                               cagg_get_bucket_function                                
+----------------------+---------------------------------------------------------------------------------------
+ integer_ht_cagg      | time_bucket(integer,integer)
+ temperature_4h       | time_bucket(interval,timestamp without time zone)
+ temperature_tz_4h    | time_bucket(interval,timestamp with time zone)
+ temperature_tz_4h_ts | time_bucket(interval,timestamp with time zone,text,timestamp with time zone,interval)
+(4 rows)
 
 --- Cleanup
 \c :TEST_DBNAME :ROLE_SUPERUSER

--- a/tsl/test/expected/exp_cagg_monthly.out
+++ b/tsl/test/expected/exp_cagg_monthly.out
@@ -31,6 +31,10 @@ INSERT INTO conditions (day, city, temperature) VALUES
   ('2021-06-27', 'Moscow', 31);
 -- Check that buckets like '1 month 15 days' (fixed-sized + variable-sized) are not allowed
 \set ON_ERROR_STOP 0
+-- timebucket_ng is deprecated and can not be used in new CAggs anymore.
+-- However, using this GUC the restriction can be lifted in debug builds
+-- to ensure the functionality can be tested.
+SET timescaledb.debug_allow_cagg_with_deprecated_funcs = true;
 CREATE MATERIALIZED VIEW conditions_summary
 WITH (timescaledb.continuous, timescaledb.materialized_only=true) AS
 SELECT city,
@@ -54,6 +58,8 @@ SELECT city,
 FROM conditions
 GROUP BY city, bucket
 WITH NO DATA;
+-- Reset GUC to check if the CAgg would also work in release builds
+RESET timescaledb.debug_allow_cagg_with_deprecated_funcs;
 SELECT mat_hypertable_id AS cagg_id
 FROM _timescaledb_catalog.continuous_agg
 WHERE user_view_name = 'conditions_summary'
@@ -328,6 +334,7 @@ WHERE mat_hypertable_id = :cagg_id;
 (0 rows)
 
 -- Re-create cagg, this time WITH DATA
+SET timescaledb.debug_allow_cagg_with_deprecated_funcs = true;
 CREATE MATERIALIZED VIEW conditions_summary
 WITH (timescaledb.continuous, timescaledb.materialized_only=true) AS
 SELECT city,
@@ -337,6 +344,7 @@ SELECT city,
 FROM conditions
 GROUP BY city, bucket;
 NOTICE:  refreshing continuous aggregate "conditions_summary"
+RESET timescaledb.debug_allow_cagg_with_deprecated_funcs;
 -- Make sure cagg was filled
 SELECT city, to_char(bucket, 'YYYY-MM-DD') AS month, min, max
 FROM conditions_summary
@@ -424,6 +432,7 @@ WHERE hypertable_id = :ht_id;
 -- Create a real-time aggregate
 DROP MATERIALIZED VIEW conditions_summary;
 NOTICE:  drop cascades to 4 other objects
+SET timescaledb.debug_allow_cagg_with_deprecated_funcs = true;
 CREATE MATERIALIZED VIEW conditions_summary
 WITH (timescaledb.continuous, timescaledb.materialized_only=false) AS
 SELECT city,
@@ -433,6 +442,7 @@ SELECT city,
 FROM conditions
 GROUP BY city, bucket;
 NOTICE:  refreshing continuous aggregate "conditions_summary"
+RESET timescaledb.debug_allow_cagg_with_deprecated_funcs;
 SELECT city, to_char(bucket, 'YYYY-MM-DD') AS month, min, max
 FROM conditions_summary
 ORDER by month, city;
@@ -681,6 +691,7 @@ SELECT create_hypertable(
 INSERT INTO conditions_large(day, temperature)
 SELECT ts, date_part('month', ts)*100 + date_part('day', ts)
 FROM generate_series('2010-01-01' :: date, '2020-01-01' :: date - interval '1 day', '1 day') as ts;
+SET timescaledb.debug_allow_cagg_with_deprecated_funcs = true;
 CREATE MATERIALIZED VIEW conditions_large_2m
 WITH (timescaledb.continuous, timescaledb.materialized_only=false) AS
 SELECT
@@ -690,6 +701,7 @@ SELECT
 FROM conditions_large
 GROUP BY bucket;
 NOTICE:  refreshing continuous aggregate "conditions_large_2m"
+RESET timescaledb.debug_allow_cagg_with_deprecated_funcs;
 SELECT * FROM conditions_large_2m ORDER BY bucket;
    bucket   | min  | max  
 ------------+------+------
@@ -755,6 +767,7 @@ SELECT * FROM conditions_large_2m ORDER BY bucket;
  11-01-2019 | 1101 | 1231
 (60 rows)
 
+SET timescaledb.debug_allow_cagg_with_deprecated_funcs = true;
 CREATE MATERIALIZED VIEW conditions_large_3m
 WITH (timescaledb.continuous, timescaledb.materialized_only=false) AS
 SELECT
@@ -764,6 +777,7 @@ SELECT
 FROM conditions_large
 GROUP BY bucket;
 NOTICE:  refreshing continuous aggregate "conditions_large_3m"
+RESET timescaledb.debug_allow_cagg_with_deprecated_funcs;
 SELECT * FROM conditions_large_3m ORDER BY bucket;
    bucket   | min  | max  
 ------------+------+------
@@ -809,6 +823,7 @@ SELECT * FROM conditions_large_3m ORDER BY bucket;
  10-01-2019 | 1001 | 1231
 (40 rows)
 
+SET timescaledb.debug_allow_cagg_with_deprecated_funcs = true;
 CREATE MATERIALIZED VIEW conditions_large_4m
 WITH (timescaledb.continuous, timescaledb.materialized_only=false) AS
 SELECT
@@ -818,6 +833,7 @@ SELECT
 FROM conditions_large
 GROUP BY bucket;
 NOTICE:  refreshing continuous aggregate "conditions_large_4m"
+RESET timescaledb.debug_allow_cagg_with_deprecated_funcs;
 SELECT * FROM conditions_large_4m ORDER BY bucket;
    bucket   | min | max  
 ------------+-----+------
@@ -853,6 +869,7 @@ SELECT * FROM conditions_large_4m ORDER BY bucket;
  09-01-2019 | 901 | 1231
 (30 rows)
 
+SET timescaledb.debug_allow_cagg_with_deprecated_funcs = true;
 CREATE MATERIALIZED VIEW conditions_large_5m
 WITH (timescaledb.continuous, timescaledb.materialized_only=false) AS
 SELECT
@@ -862,6 +879,7 @@ SELECT
 FROM conditions_large
 GROUP BY bucket;
 NOTICE:  refreshing continuous aggregate "conditions_large_5m"
+RESET timescaledb.debug_allow_cagg_with_deprecated_funcs;
 SELECT * FROM conditions_large_5m ORDER BY bucket;
    bucket   | min | max  
 ------------+-----+------
@@ -891,6 +909,7 @@ SELECT * FROM conditions_large_5m ORDER BY bucket;
  08-01-2019 | 801 | 1231
 (24 rows)
 
+SET timescaledb.debug_allow_cagg_with_deprecated_funcs = true;
 CREATE MATERIALIZED VIEW conditions_large_6m
 WITH (timescaledb.continuous, timescaledb.materialized_only=false) AS
 SELECT
@@ -900,6 +919,7 @@ SELECT
 FROM conditions_large
 GROUP BY bucket;
 NOTICE:  refreshing continuous aggregate "conditions_large_6m"
+RESET timescaledb.debug_allow_cagg_with_deprecated_funcs;
 SELECT * FROM conditions_large_6m ORDER BY bucket;
    bucket   | min | max  
 ------------+-----+------
@@ -925,6 +945,7 @@ SELECT * FROM conditions_large_6m ORDER BY bucket;
  07-01-2019 | 701 | 1231
 (20 rows)
 
+SET timescaledb.debug_allow_cagg_with_deprecated_funcs = true;
 CREATE MATERIALIZED VIEW conditions_large_1y
 WITH (timescaledb.continuous, timescaledb.materialized_only=false) AS
 SELECT
@@ -934,6 +955,7 @@ SELECT
 FROM conditions_large
 GROUP BY bucket;
 NOTICE:  refreshing continuous aggregate "conditions_large_1y"
+RESET timescaledb.debug_allow_cagg_with_deprecated_funcs;
 SELECT * FROM conditions_large_1y ORDER BY bucket;
    bucket   | min | max  
 ------------+-----+------
@@ -949,6 +971,7 @@ SELECT * FROM conditions_large_1y ORDER BY bucket;
  01-01-2019 | 101 | 1231
 (10 rows)
 
+SET timescaledb.debug_allow_cagg_with_deprecated_funcs = true;
 CREATE MATERIALIZED VIEW conditions_large_1y1m
 WITH (timescaledb.continuous, timescaledb.materialized_only=false) AS
 SELECT
@@ -958,6 +981,7 @@ SELECT
 FROM conditions_large
 GROUP BY bucket;
 NOTICE:  refreshing continuous aggregate "conditions_large_1y1m"
+RESET timescaledb.debug_allow_cagg_with_deprecated_funcs;
 SELECT * FROM conditions_large_1y1m ORDER BY bucket;
    bucket   | min | max  
 ------------+-----+------
@@ -977,6 +1001,7 @@ SELECT * FROM conditions_large_1y1m ORDER BY bucket;
 DROP MATERIALIZED VIEW conditions_large_1y;
 NOTICE:  drop cascades to 10 other objects
 SET timescaledb.materializations_per_refresh_window = 0;
+SET timescaledb.debug_allow_cagg_with_deprecated_funcs = true;
 CREATE MATERIALIZED VIEW conditions_large_1y
 WITH (timescaledb.continuous, timescaledb.materialized_only=true) AS
 SELECT
@@ -986,6 +1011,7 @@ SELECT
 FROM conditions_large
 GROUP BY bucket;
 NOTICE:  refreshing continuous aggregate "conditions_large_1y"
+RESET timescaledb.debug_allow_cagg_with_deprecated_funcs;
 SELECT * FROM conditions_large_1y ORDER BY bucket;
    bucket   | min | max  
 ------------+-----+------
@@ -1036,6 +1062,7 @@ SELECT create_hypertable(
  (15,public,conditions_empty,t)
 (1 row)
 
+SET timescaledb.debug_allow_cagg_with_deprecated_funcs = true;
 CREATE MATERIALIZED VIEW conditions_summary_empty
 WITH (timescaledb.continuous, timescaledb.materialized_only=true) AS
 SELECT city,
@@ -1045,6 +1072,7 @@ SELECT city,
 FROM conditions_empty
 GROUP BY city, bucket;
 NOTICE:  continuous aggregate "conditions_summary_empty" is already up-to-date
+RESET timescaledb.debug_allow_cagg_with_deprecated_funcs;
 SELECT city, to_char(bucket, 'YYYY-MM-DD') AS month, min, max
 FROM conditions_summary_empty
 ORDER by month, city;
@@ -1108,6 +1136,7 @@ INSERT INTO conditions_policy (day, city, temperature) VALUES
   ('2021-06-25', 'Moscow', 32),
   ('2021-06-26', 'Moscow', 32),
   ('2021-06-27', 'Moscow', 31);
+SET timescaledb.debug_allow_cagg_with_deprecated_funcs = true;
 CREATE MATERIALIZED VIEW conditions_summary_policy
 WITH (timescaledb.continuous, timescaledb.materialized_only=true) AS
 SELECT city,
@@ -1117,6 +1146,7 @@ SELECT city,
 FROM conditions_policy
 GROUP BY city, bucket;
 NOTICE:  refreshing continuous aggregate "conditions_summary_policy"
+RESET timescaledb.debug_allow_cagg_with_deprecated_funcs;
 SELECT * FROM conditions_summary_policy;
   city  |   bucket   | min | max 
 --------+------------+-----+-----

--- a/tsl/test/expected/exp_cagg_next_gen.out
+++ b/tsl/test/expected/exp_cagg_next_gen.out
@@ -31,6 +31,10 @@ INSERT INTO conditions (day, city, temperature) VALUES
   ('2021-06-25', 'Moscow', 32),
   ('2021-06-26', 'Moscow', 32),
   ('2021-06-27', 'Moscow', 31);
+-- timebucket_ng is deprecated and can not be used in new CAggs anymore.
+-- However, using this GUC the restriction can be lifted in debug builds
+-- to ensure the functionality can be tested.
+SET timescaledb.debug_allow_cagg_with_deprecated_funcs = true;
 CREATE MATERIALIZED VIEW conditions_summary_weekly
 WITH (timescaledb.continuous, timescaledb.materialized_only=false) AS
 SELECT city,
@@ -40,6 +44,8 @@ SELECT city,
 FROM conditions
 GROUP BY city, bucket;
 NOTICE:  refreshing continuous aggregate "conditions_summary_weekly"
+-- Reset GUC to check if the CAgg would also work in release builds
+RESET timescaledb.debug_allow_cagg_with_deprecated_funcs;
 SELECT to_char(bucket, 'YYYY-MM-DD'), city, min, max
 FROM conditions_summary_weekly
 ORDER BY bucket;
@@ -84,6 +90,7 @@ INSERT INTO conditions (tstamp, city, temperature) VALUES
   ('2021-06-14 12:32:00', 'Moscow', 32),
   ('2021-06-14 12:32:10', 'Moscow', 32),
   ('2021-06-14 12:32:20', 'Moscow', 31);
+SET timescaledb.debug_allow_cagg_with_deprecated_funcs = true;
 CREATE MATERIALIZED VIEW conditions_summary_30sec
 WITH (timescaledb.continuous, timescaledb.materialized_only=false) AS
 SELECT city,
@@ -111,6 +118,7 @@ SELECT city,
 FROM conditions
 GROUP BY city, bucket;
 NOTICE:  refreshing continuous aggregate "conditions_summary_1hour"
+RESET timescaledb.debug_allow_cagg_with_deprecated_funcs;
 SELECT city, to_char(bucket, 'YYYY-MM-DD HH:mi:ss'), min, max FROM conditions_summary_30sec ORDER BY bucket;
   city  |       to_char       | min | max 
 --------+---------------------+-----+-----
@@ -160,6 +168,7 @@ SELECT test.create_hypertable(
  (1,public,conditions,t)
 (1 row)
 
+SET timescaledb.debug_allow_cagg_with_deprecated_funcs = true;
 CREATE MATERIALIZED VIEW conditions_summary_monthly
 WITH (timescaledb.continuous) AS
 SELECT city,
@@ -169,6 +178,7 @@ SELECT city,
 FROM conditions
 GROUP BY city, bucket
 WITH NO DATA;
+RESET timescaledb.debug_allow_cagg_with_deprecated_funcs;
 CREATE MATERIALIZED VIEW conditions_summary_yearly
 WITH (timescaledb.continuous) AS
 SELECT city,

--- a/tsl/test/expected/exp_cagg_origin.out
+++ b/tsl/test/expected/exp_cagg_origin.out
@@ -30,6 +30,10 @@ INSERT INTO conditions (day, city, temperature) VALUES
   ('2021-06-26', 'Moscow', 32),
   ('2021-06-27', 'Moscow', 31);
 \set ON_ERROR_STOP 0
+-- timebucket_ng is deprecated and can not be used in new CAggs anymore.
+-- However, using this GUC the restriction can be lifted in debug builds
+-- to ensure the functionality can be tested.
+SET timescaledb.debug_allow_cagg_with_deprecated_funcs = true;
 -- Make sure 'infinity' can't be specified as an origin
 CREATE MATERIALIZED VIEW conditions_summary_weekly
 WITH (timescaledb.continuous, timescaledb.materialized_only=true) AS
@@ -62,6 +66,8 @@ SELECT city,
 FROM conditions
 GROUP BY city, bucket
 WITH NO DATA;
+-- Reset GUC to check if the CAgg would also work in release builds
+RESET timescaledb.debug_allow_cagg_with_deprecated_funcs;
 SELECT to_char(bucket, 'YYYY-MM-DD'), city, min, max
 FROM conditions_summary_weekly
 ORDER BY bucket;
@@ -183,6 +189,7 @@ WHERE hypertable_id = :ht_id;
 
 -- Check if CREATE MATERIALIZED VIEW ... WITH DATA works.
 -- Use monthly buckets this time and specify June 2000 as an origin.
+SET timescaledb.debug_allow_cagg_with_deprecated_funcs = true;
 CREATE MATERIALIZED VIEW conditions_summary_monthly
 WITH (timescaledb.continuous, timescaledb.materialized_only=true) AS
 SELECT city,
@@ -192,6 +199,7 @@ SELECT city,
 FROM conditions
 GROUP BY city, bucket;
 NOTICE:  refreshing continuous aggregate "conditions_summary_monthly"
+RESET timescaledb.debug_allow_cagg_with_deprecated_funcs;
 SELECT city, to_char(bucket, 'YYYY-MM-DD') AS month, min, max
 FROM conditions_summary_monthly
 ORDER BY month, city;
@@ -273,6 +281,7 @@ WHERE hypertable_id = :ht_id;
 (0 rows)
 
 -- Create a real-time aggregate with custom origin - June 2000
+SET timescaledb.debug_allow_cagg_with_deprecated_funcs = true;
 CREATE MATERIALIZED VIEW conditions_summary_rt
 WITH (timescaledb.continuous, timescaledb.materialized_only=false) AS
 SELECT city,
@@ -282,6 +291,7 @@ SELECT city,
 FROM conditions
 GROUP BY city, bucket;
 NOTICE:  refreshing continuous aggregate "conditions_summary_rt"
+RESET timescaledb.debug_allow_cagg_with_deprecated_funcs;
 SELECT city, to_char(bucket, 'YYYY-MM-DD') AS month, min, max
 FROM conditions_summary_rt
 ORDER BY month, city;
@@ -480,6 +490,7 @@ SELECT create_hypertable(
  (6,public,conditions_empty,t)
 (1 row)
 
+SET timescaledb.debug_allow_cagg_with_deprecated_funcs = true;
 CREATE MATERIALIZED VIEW conditions_summary_empty
 WITH (timescaledb.continuous, timescaledb.materialized_only=true) AS
 SELECT city,
@@ -489,6 +500,7 @@ SELECT city,
 FROM conditions_empty
 GROUP BY city, bucket;
 NOTICE:  continuous aggregate "conditions_summary_empty" is already up-to-date
+RESET timescaledb.debug_allow_cagg_with_deprecated_funcs;
 SELECT city, to_char(bucket, 'YYYY-MM-DD') AS month, min, max
 FROM conditions_summary_empty
 ORDER BY month, city;
@@ -556,6 +568,7 @@ INSERT INTO conditions_policy (day, city, temperature) VALUES
   ('2021-06-25', 'Moscow', 32),
   ('2021-06-26', 'Moscow', 32),
   ('2021-06-27', 'Moscow', 31);
+SET timescaledb.debug_allow_cagg_with_deprecated_funcs = true;
 CREATE MATERIALIZED VIEW conditions_summary_policy
 WITH (timescaledb.continuous, timescaledb.materialized_only=true) AS
 SELECT city,
@@ -565,6 +578,7 @@ SELECT city,
 FROM conditions_policy
 GROUP BY city, bucket;
 NOTICE:  refreshing continuous aggregate "conditions_summary_policy"
+RESET timescaledb.debug_allow_cagg_with_deprecated_funcs;
 SELECT * FROM conditions_summary_policy;
   city  |   bucket   | min | max 
 --------+------------+-----+-----
@@ -609,6 +623,7 @@ WARNING:  column type "timestamp without time zone" used for "tstamp" does not f
  (10,public,conditions_timestamp,t)
 (1 row)
 
+SET timescaledb.debug_allow_cagg_with_deprecated_funcs = true;
 CREATE MATERIALIZED VIEW conditions_summary_timestamp
 WITH (timescaledb.continuous, timescaledb.materialized_only=false) AS
 SELECT city,
@@ -618,6 +633,7 @@ SELECT city,
 FROM conditions_timestamp
 GROUP BY city, bucket;
 NOTICE:  continuous aggregate "conditions_summary_timestamp" is already up-to-date
+RESET timescaledb.debug_allow_cagg_with_deprecated_funcs;
 SELECT city, to_char(bucket, 'YYYY-MM-DD HH24:MI:SS') AS b, min, max
 FROM conditions_summary_timestamp
 ORDER BY b, city;
@@ -744,6 +760,7 @@ FROM
   generate_series('2022-01-01 00:00:00 MSK' :: timestamptz, '2022-01-02 00:00:00 MSK' :: timestamptz - interval '1 hour', '1 hour') as ts,
   unnest(array['Moscow', 'Berlin']) as city;
 \set ON_ERROR_STOP 0
+SET timescaledb.debug_allow_cagg_with_deprecated_funcs = true;
 -- For monthly buckets origin should be the first day of the month in given timezone
 -- 2020-06-02 00:00:00 MSK == 2020-06-01 21:00:00 UTC
 CREATE MATERIALIZED VIEW conditions_summary_timestamptz
@@ -775,6 +792,7 @@ SELECT city,
 FROM conditions_timestamptz
 GROUP BY city, bucket;
 NOTICE:  refreshing continuous aggregate "conditions_summary_timestamptz"
+RESET timescaledb.debug_allow_cagg_with_deprecated_func;
 -- Make sure the origin is saved in the catalog table
 SELECT mat_hypertable_id AS cagg_id
   FROM _timescaledb_catalog.continuous_agg

--- a/tsl/test/expected/exp_cagg_timezone.out
+++ b/tsl/test/expected/exp_cagg_timezone.out
@@ -17,6 +17,10 @@ WARNING:  column type "timestamp without time zone" used for "day" does not foll
 (1 row)
 
 \set ON_ERROR_STOP 0
+-- timebucket_ng is deprecated and can not be used in new CAggs anymore.
+-- However, using this GUC the restriction can be lifted in debug builds
+-- to ensure the functionality can be tested.
+SET timescaledb.debug_allow_cagg_with_deprecated_funcs = true;
 CREATE MATERIALIZED VIEW conditions
 WITH (timescaledb.continuous, timescaledb.materialized_only=true) AS
 SELECT city,
@@ -27,6 +31,8 @@ FROM conditions
 GROUP BY city, bucket
 WITH NO DATA;
 ERROR:  invalid input syntax for type timestamp: "Europe/Moscow" at character 178
+-- Reset GUC to check if the CAgg would also work in release builds
+RESET timescaledb.debug_allow_cagg_with_deprecated_funcs;
 \set ON_ERROR_STOP 1
 DROP TABLE conditions CASCADE;
 CREATE TABLE conditions_tz(
@@ -59,6 +65,7 @@ INSERT INTO conditions_tz (day, city, temperature) VALUES
   ('2021-06-27 00:00:00 MSK', 'Moscow', 31);
 \set ON_ERROR_STOP 0
 -- Check that the name of the timezone is validated
+SET timescaledb.debug_allow_cagg_with_deprecated_funcs = true;
 CREATE MATERIALIZED VIEW conditions_summary_tz
 WITH (timescaledb.continuous, timescaledb.materialized_only=true) AS
 SELECT city,
@@ -104,6 +111,7 @@ SELECT city,
 FROM conditions_tz
 GROUP BY city, bucket
 WITH NO DATA;
+RESET timescaledb.debug_allow_cagg_with_deprecated_funcs;
 SELECT mat_hypertable_id AS cagg_id_tz, raw_hypertable_id AS ht_id
 FROM _timescaledb_catalog.continuous_agg
 WHERE user_view_name = 'conditions_summary_tz'
@@ -119,6 +127,7 @@ WHERE mat_hypertable_id = :cagg_id_tz;
 
 -- Make sure that buckets with specified timezone are always treated as
 -- variable-sized, even if the interval is fixed (i.e. days and/or hours)
+SET timescaledb.debug_allow_cagg_with_deprecated_funcs = true;
 CREATE MATERIALIZED VIEW conditions_summary_1w
 WITH (timescaledb.continuous, timescaledb.materialized_only=true) AS
 SELECT city,
@@ -128,6 +137,7 @@ SELECT city,
 FROM conditions_tz
 GROUP BY city, bucket
 WITH NO DATA;
+RESET timescaledb.debug_allow_cagg_with_deprecated_funcs;
 SELECT mat_hypertable_id AS cagg_id_1w
 FROM _timescaledb_catalog.continuous_agg
 WHERE user_view_name = 'conditions_summary_1w'
@@ -208,6 +218,7 @@ WHERE hypertable_id = :ht_id;
 (1 row)
 
 -- Make sure creating CAGGs without NO DATA works the same way
+SET timescaledb.debug_allow_cagg_with_deprecated_funcs = true;
 CREATE MATERIALIZED VIEW conditions_summary_tz2
 WITH (timescaledb.continuous, timescaledb.materialized_only=true) AS
 SELECT city,
@@ -217,6 +228,7 @@ SELECT city,
 FROM conditions_tz
 GROUP BY city, bucket;
 NOTICE:  refreshing continuous aggregate "conditions_summary_tz2"
+RESET timescaledb.debug_allow_cagg_with_deprecated_funcs;
 SELECT city, to_char(bucket at time zone 'MSK', 'YYYY-MM-DD HH24:MI:SS') as month, min, max
 FROM conditions_summary_tz2
 ORDER by month, city;
@@ -377,6 +389,7 @@ NOTICE:  drop cascades to 3 other objects
 DROP MATERIALIZED VIEW conditions_summary_1w;
 NOTICE:  drop cascades to 2 other objects
 -- Create a real-time aggregate
+SET timescaledb.debug_allow_cagg_with_deprecated_funcs = true;
 CREATE MATERIALIZED VIEW conditions_summary_tz
 WITH (timescaledb.continuous, timescaledb.materialized_only=false) AS
 SELECT city,
@@ -386,6 +399,7 @@ SELECT city,
 FROM conditions_tz
 GROUP BY city, bucket;
 NOTICE:  refreshing continuous aggregate "conditions_summary_tz"
+RESET timescaledb.debug_allow_cagg_with_deprecated_funcs;
 SELECT city, to_char(bucket at time zone 'MSK', 'YYYY-MM-DD HH24:MI:SS') as month, min, max
 FROM conditions_summary_tz
 ORDER by month, city;
@@ -562,6 +576,7 @@ SELECT create_hypertable(
 (1 row)
 
 -- Create a real-time aggregate on top of empty HT
+SET timescaledb.debug_allow_cagg_with_deprecated_funcs = true;
 CREATE MATERIALIZED VIEW conditions2_summary
 WITH (timescaledb.continuous, timescaledb.materialized_only=false) AS
 SELECT city,
@@ -571,6 +586,7 @@ SELECT city,
 FROM conditions2
 GROUP BY city, bucket;
 NOTICE:  continuous aggregate "conditions2_summary" is already up-to-date
+RESET timescaledb.debug_allow_cagg_with_deprecated_funcs;
 INSERT INTO conditions2 (day, city, temperature) VALUES
   ('2021-06-14 00:00:00 MSK', 'Moscow', 26),
   ('2021-06-15 00:00:00 MSK', 'Moscow', 22),
@@ -665,6 +681,7 @@ INSERT INTO conditions_policy (day, city, temperature) VALUES
   ('2021-06-18 00:00:00 MSK', 'Moscow', 32),
   ('2021-06-18 10:00:00 MSK', 'Moscow', 31),
   ('2021-06-18 20:00:00 MSK', 'Moscow', 26);
+SET timescaledb.debug_allow_cagg_with_deprecated_funcs = true;
 CREATE MATERIALIZED VIEW conditions_summary_policy
 WITH (timescaledb.continuous, timescaledb.materialized_only=true) AS
 SELECT city,
@@ -674,6 +691,7 @@ SELECT city,
 FROM conditions_policy
 GROUP BY city, bucket;
 NOTICE:  refreshing continuous aggregate "conditions_summary_policy"
+RESET timescaledb.debug_allow_cagg_with_deprecated_funcs;
 SELECT city, to_char(bucket at time zone 'MSK', 'YYYY-MM-DD HH24:MI:SS') as month, min, max
 FROM conditions_summary_policy
 ORDER by month, city;

--- a/tsl/test/sql/CMakeLists.txt
+++ b/tsl/test/sql/CMakeLists.txt
@@ -6,6 +6,7 @@ set(TEST_FILES
     agg_partials_pushdown.sql
     bgw_security.sql
     bgw_policy.sql
+    cagg_deprecated_bucket_ng.sql
     cagg_errors.sql
     cagg_invalidation.sql
     cagg_permissions.sql
@@ -28,10 +29,6 @@ set(TEST_FILES
     compression_sorted_merge_distinct.sql
     compression_sorted_merge_columns.sql
     decompress_index.sql
-    exp_cagg_monthly.sql
-    exp_cagg_next_gen.sql
-    exp_cagg_origin.sql
-    exp_cagg_timezone.sql
     move.sql
     partialize_finalize.sql
     policy_generalization.sql
@@ -79,6 +76,10 @@ if(CMAKE_BUILD_TYPE MATCHES Debug)
     cagg_policy_run.sql
     decompress_memory.sql
     decompress_vector_qual.sql
+    exp_cagg_monthly.sql
+    exp_cagg_next_gen.sql
+    exp_cagg_origin.sql
+    exp_cagg_timezone.sql
     hypertable_generalization.sql
     insert_memory_usage.sql
     information_view_chunk_count.sql

--- a/tsl/test/sql/cagg_deprecated_bucket_ng.sql
+++ b/tsl/test/sql/cagg_deprecated_bucket_ng.sql
@@ -1,0 +1,49 @@
+-- This file and its contents are licensed under the Timescale License.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-TIMESCALE for a copy of the license.
+
+
+CREATE TABLE conditions(
+  time timestamptz NOT NULL,
+  city text NOT NULL,
+  temperature INT NOT NULL);
+
+SELECT create_hypertable(
+  'conditions', 'time',
+  chunk_time_interval => INTERVAL '1 day'
+);
+
+-- Ensure no CAgg using time_bucket_ng can be created
+\set ON_ERROR_STOP 0
+
+-- Regular CAgg
+CREATE MATERIALIZED VIEW conditions_summary_weekly
+WITH (timescaledb.continuous, timescaledb.materialized_only=false) AS
+SELECT city,
+       timescaledb_experimental.time_bucket_ng('7 days', time, 'UTC') AS bucket,
+       MIN(temperature),
+       MAX(temperature)
+FROM conditions
+GROUP BY city, bucket WITH NO DATA;
+
+-- CAgg with origin
+CREATE MATERIALIZED VIEW conditions_summary_weekly
+WITH (timescaledb.continuous, timescaledb.materialized_only=false) AS
+SELECT city,
+       timescaledb_experimental.time_bucket_ng('7 days', time, '2024-01-16 18:00:00+00') AS bucket,
+       MIN(temperature),
+       MAX(temperature)
+FROM conditions
+GROUP BY city, bucket WITH NO DATA;
+
+-- CAgg with origin and timezone
+CREATE MATERIALIZED VIEW conditions_summary_weekly
+WITH (timescaledb.continuous, timescaledb.materialized_only=false) AS
+SELECT city,
+       timescaledb_experimental.time_bucket_ng('7 days', time, '2024-01-16 18:00:00+00', 'UTC') AS bucket,
+       MIN(temperature),
+       MAX(temperature)
+FROM conditions
+GROUP BY city, bucket WITH NO DATA;
+
+\set ON_ERROR_STOP 1

--- a/tsl/test/sql/cagg_utils.sql
+++ b/tsl/test/sql/cagg_utils.sql
@@ -154,12 +154,6 @@ CREATE MATERIALIZED VIEW temperature_tz_4h_ts
     FROM timestamptz_ht
     GROUP BY 1 ORDER BY 1;
 
-CREATE MATERIALIZED VIEW temperature_tz_4h_ts_ng
-  WITH  (timescaledb.continuous) AS
-  SELECT timescaledb_experimental.time_bucket_ng('4 hour', time, 'Asia/Shanghai'), avg(value)
-    FROM timestamptz_ht
-    GROUP BY 1 ORDER BY 1;
-
 CREATE TABLE integer_ht(a integer, b integer, c integer);
 SELECT table_name FROM create_hypertable('integer_ht', 'a', chunk_time_interval=> 10);
 
@@ -176,7 +170,7 @@ CREATE MATERIALIZED VIEW integer_ht_cagg
 SELECT user_view_name,
        cagg_get_bucket_function(mat_hypertable_id)
        FROM _timescaledb_catalog.continuous_agg
-       WHERE user_view_name in('temperature_4h', 'temperature_tz_4h', 'temperature_tz_4h_ts', 'temperature_tz_4h_ts_ng', 'integer_ht_cagg')
+       WHERE user_view_name in('temperature_4h', 'temperature_tz_4h', 'temperature_tz_4h_ts', 'integer_ht_cagg')
        ORDER BY user_view_name;
 
 --- Cleanup

--- a/tsl/test/sql/exp_cagg_next_gen.sql
+++ b/tsl/test/sql/exp_cagg_next_gen.sql
@@ -31,6 +31,11 @@ INSERT INTO conditions (day, city, temperature) VALUES
   ('2021-06-26', 'Moscow', 32),
   ('2021-06-27', 'Moscow', 31);
 
+-- timebucket_ng is deprecated and can not be used in new CAggs anymore.
+-- However, using this GUC the restriction can be lifted in debug builds
+-- to ensure the functionality can be tested.
+SET timescaledb.debug_allow_cagg_with_deprecated_funcs = true;
+
 CREATE MATERIALIZED VIEW conditions_summary_weekly
 WITH (timescaledb.continuous, timescaledb.materialized_only=false) AS
 SELECT city,
@@ -39,6 +44,9 @@ SELECT city,
        MAX(temperature)
 FROM conditions
 GROUP BY city, bucket;
+
+-- Reset GUC to check if the CAgg would also work in release builds
+RESET timescaledb.debug_allow_cagg_with_deprecated_funcs;
 
 SELECT to_char(bucket, 'YYYY-MM-DD'), city, min, max
 FROM conditions_summary_weekly
@@ -74,6 +82,7 @@ INSERT INTO conditions (tstamp, city, temperature) VALUES
   ('2021-06-14 12:32:10', 'Moscow', 32),
   ('2021-06-14 12:32:20', 'Moscow', 31);
 
+SET timescaledb.debug_allow_cagg_with_deprecated_funcs = true;
 CREATE MATERIALIZED VIEW conditions_summary_30sec
 WITH (timescaledb.continuous, timescaledb.materialized_only=false) AS
 SELECT city,
@@ -100,6 +109,8 @@ SELECT city,
        MAX(temperature)
 FROM conditions
 GROUP BY city, bucket;
+RESET timescaledb.debug_allow_cagg_with_deprecated_funcs;
+
 
 SELECT city, to_char(bucket, 'YYYY-MM-DD HH:mi:ss'), min, max FROM conditions_summary_30sec ORDER BY bucket;
 SELECT city, to_char(bucket, 'YYYY-MM-DD HH:mi:ss'), min, max FROM conditions_summary_1min ORDER BY bucket;
@@ -127,6 +138,7 @@ SELECT test.create_hypertable(
   chunk_time_interval => INTERVAL '1 day'
 );
 
+SET timescaledb.debug_allow_cagg_with_deprecated_funcs = true;
 CREATE MATERIALIZED VIEW conditions_summary_monthly
 WITH (timescaledb.continuous) AS
 SELECT city,
@@ -136,6 +148,7 @@ SELECT city,
 FROM conditions
 GROUP BY city, bucket
 WITH NO DATA;
+RESET timescaledb.debug_allow_cagg_with_deprecated_funcs;
 
 CREATE MATERIALIZED VIEW conditions_summary_yearly
 WITH (timescaledb.continuous) AS


### PR DESCRIPTION
The function timescaledb_experimental.time_bucket_ng() has been
deprecated for two years. This PR removes it from the list of bucketing
functions supported in a CAgg. Existing CAggs using this function will
still be supported; however, no new CAggs using this function can be
created.

---

I added a GUC, that is only available in debug builds (similar to `debug_require_batch_sorted_merge`), to allow the creation of CAggs using `time_bucket_ng`. This GUC allows it to prove that existing CAggs using this bucket function continue to work. In addition, this GUC can be used in a further PR to introduce and test migration steps.