### PR TITLE
Remove allow_install_without_preload GUC

### DIFF
--- a/.unreleased/pr_6811
+++ b/.unreleased/pr_6811
@@ -1,0 +1,1 @@
+Implements: #6811 Remove no longer relevant timescaledb.allow_install_without_preload GUC

--- a/src/extension_utils.c
+++ b/src/extension_utils.c
@@ -174,49 +174,40 @@ extension_current_state(char const *const extension_name, char const *const sche
 	return EXTENSION_STATE_NOT_INSTALLED;
 }
 
+/* Handle extension load request without loader present */
 static void
 extension_load_without_preload()
 {
-	/* cannot use GUC variable here since extension not yet loaded */
-	char *allow_install_without_preload =
-		GetConfigOptionByName(MAKE_EXTOPTION("allow_install_without_preload"), NULL, true);
+	/*
+	 * These are FATAL because otherwise the loader ends up in a weird
+	 * half-loaded state after an ERROR
+	 */
 
-	if (allow_install_without_preload == NULL || strcmp(allow_install_without_preload, "on") != 0)
+	/* Only privileged users can get the value of `config file` */
+	if (has_privs_of_role(GetUserId(), ROLE_PG_READ_ALL_SETTINGS))
 	{
-		/*
-		 * These are FATAL because otherwise the loader ends up in a weird
-		 * half-loaded state after an ERROR
-		 */
-		/* Only privileged users can get the value of `config file` */
+		char *config_file = GetConfigOptionByName("config_file", NULL, false);
 
-		if (has_privs_of_role(GetUserId(), ROLE_PG_READ_ALL_SETTINGS))
-		{
-			char *config_file = GetConfigOptionByName("config_file", NULL, false);
-
-			ereport(FATAL,
-					(errmsg("extension \"%s\" must be preloaded", EXTENSION_NAME),
-					 errhint("Please preload the timescaledb library via "
-							 "shared_preload_libraries.\n\n"
-							 "This can be done by editing the config file at: %1$s\n"
-							 "and adding 'timescaledb' to the list in the shared_preload_libraries "
-							 "config.\n"
-							 "	# Modify postgresql.conf:\n	shared_preload_libraries = "
-							 "'timescaledb'\n\n"
-							 "Another way to do this, if not preloading other libraries, is with "
-							 "the command:\n"
-							 "	echo \"shared_preload_libraries = 'timescaledb'\" >> %1$s \n\n"
-							 "(Will require a database restart.)\n\n"
-							 "If you REALLY know what you are doing and would like to load the "
-							 "library without preloading, you can disable this check with: \n"
-							 "	SET timescaledb.allow_install_without_preload = 'on';",
-							 config_file)));
-		}
-		else
-		{
-			ereport(FATAL,
-					(errmsg("extension \"%s\" must be preloaded", EXTENSION_NAME),
-					 errhint(
-						 "Please preload the timescaledb library via shared_preload_libraries.\n\n"
+		ereport(FATAL,
+				(errmsg("extension \"%s\" must be preloaded", EXTENSION_NAME),
+				 errhint("Please preload the timescaledb library via "
+						 "shared_preload_libraries.\n\n"
+						 "This can be done by editing the config file at: %1$s\n"
+						 "and adding 'timescaledb' to the list in the shared_preload_libraries "
+						 "config.\n"
+						 "	# Modify postgresql.conf:\n	shared_preload_libraries = "
+						 "'timescaledb'\n\n"
+						 "Another way to do this, if not preloading other libraries, is with "
+						 "the command:\n"
+						 "	echo \"shared_preload_libraries = 'timescaledb'\" >> %1$s \n\n"
+						 "(Will require a database restart.)\n\n",
+						 config_file)));
+	}
+	else
+	{
+		ereport(FATAL,
+				(errmsg("extension \"%s\" must be preloaded", EXTENSION_NAME),
+				 errhint("Please preload the timescaledb library via shared_preload_libraries.\n\n"
 						 "This can be done by editing the postgres config file \n"
 						 "and adding 'timescaledb' to the list in the shared_preload_libraries "
 						 "config.\n"
@@ -226,12 +217,6 @@ extension_load_without_preload()
 						 "command:\n"
 						 "	echo \"shared_preload_libraries = 'timescaledb'\" >> "
 						 "/path/to/config/file \n\n"
-						 "(Will require a database restart.)\n\n"
-						 "If you REALLY know what you are doing and would like to load the library "
-						 "without preloading, you can disable this check with: \n"
-						 "	SET timescaledb.allow_install_without_preload = 'on';")));
-		}
-
-		return;
+						 "(Will require a database restart.)\n\n")));
 	}
 }


### PR DESCRIPTION
The GUC allow_install_without_preload allowed the installation of the extension without the preloaded loader in place. However, this way of installing TimescaleDB is not longer supported since we reuqest shared memory and rendezvous variables in the loader. This PR removes this deprecated way of installing TimescaleDB.