### PR TITLE
Add assertion flag to assert-only variables

### DIFF
--- a/src/chunk.c
+++ b/src/chunk.c
@@ -3389,7 +3389,7 @@ ts_chunk_set_name(Chunk *chunk, const char *newname)
 {
 	FormData_chunk form;
 	ItemPointerData tid;
-	bool found = lock_chunk_tuple(chunk->fd.id, &tid, &form);
+	bool found PG_USED_FOR_ASSERTS_ONLY = lock_chunk_tuple(chunk->fd.id, &tid, &form);
 	Assert(found);
 
 	namestrcpy(&form.table_name, newname);
@@ -3403,7 +3403,7 @@ ts_chunk_set_schema(Chunk *chunk, const char *newschema)
 {
 	FormData_chunk form;
 	ItemPointerData tid;
-	bool found = lock_chunk_tuple(chunk->fd.id, &tid, &form);
+	bool found PG_USED_FOR_ASSERTS_ONLY = lock_chunk_tuple(chunk->fd.id, &tid, &form);
 	Assert(found);
 
 	namestrcpy(&form.schema_name, newschema);
@@ -3484,7 +3484,7 @@ ts_chunk_clear_status(Chunk *chunk, int32 status)
 
 	FormData_chunk form;
 	ItemPointerData tid;
-	bool found = lock_chunk_tuple(chunk->fd.id, &tid, &form);
+	bool found PG_USED_FOR_ASSERTS_ONLY = lock_chunk_tuple(chunk->fd.id, &tid, &form);
 	Assert(found);
 
 	/* applying the flags after locking the metadata tuple */
@@ -3515,7 +3515,7 @@ ts_chunk_add_status(Chunk *chunk, int32 status)
 	}
 	FormData_chunk form;
 	ItemPointerData tid;
-	bool found = lock_chunk_tuple(chunk->fd.id, &tid, &form);
+	bool found PG_USED_FOR_ASSERTS_ONLY = lock_chunk_tuple(chunk->fd.id, &tid, &form);
 	Assert(found);
 
 	/* Somebody could update the status before we are able to lock it so check again */
@@ -3563,7 +3563,7 @@ ts_chunk_set_compressed_chunk(Chunk *chunk, int32 compressed_chunk_id)
 
 	FormData_chunk form;
 	ItemPointerData tid;
-	bool found = lock_chunk_tuple(chunk->fd.id, &tid, &form);
+	bool found PG_USED_FOR_ASSERTS_ONLY = lock_chunk_tuple(chunk->fd.id, &tid, &form);
 	Assert(found);
 
 	/* Somebody could update the status before we are able to lock it so check again */
@@ -3611,7 +3611,7 @@ ts_chunk_clear_compressed_chunk(Chunk *chunk)
 
 	FormData_chunk form;
 	ItemPointerData tid;
-	bool found = lock_chunk_tuple(chunk->fd.id, &tid, &form);
+	bool found PG_USED_FOR_ASSERTS_ONLY = lock_chunk_tuple(chunk->fd.id, &tid, &form);
 	Assert(found);
 
 	/* Somebody could update the status before we are able to lock it so check again */


### PR DESCRIPTION
Some compilers complain about assert-only variables as unused ones. Adding the flags to these instances so they don't cause build failures.

SQLSmith build issue: https://github.com/timescale/timescaledb/actions/runs/8609324516/job/23593073159

Disable-check: force-changelog-file