### PR TITLE
Backport of: Add telemetry for access methods

### DIFF
--- a/.github/workflows/code_style.yaml
+++ b/.github/workflows/code_style.yaml
@@ -66,7 +66,7 @@ jobs:
       - name: Run codespell
         run: |
           find . -type f \( -name "*.c" -or -name "*.h" -or -name "*.yaml" -or -name "*.sh" \) \
-            -exec codespell -L "inh,larg,inout" {} \+
+            -exec codespell -L "brin,inh,larg,inout" {} \+
 
   cc_checks:
     name: Check code formatting

--- a/.unreleased/pr_6810
+++ b/.unreleased/pr_6810
@@ -1,0 +1,1 @@
+Implements: #6810 Add telemetry for access methods

--- a/src/jsonb_utils.h
+++ b/src/jsonb_utils.h
@@ -23,6 +23,7 @@ extern TSDLLEXPORT void ts_jsonb_add_int64(JsonbParseState *state, const char *k
 										   const int64 value);
 extern TSDLLEXPORT void ts_jsonb_add_numeric(JsonbParseState *state, const char *key,
 											 const Numeric value);
+extern TSDLLEXPORT void ts_jsonb_set_value_by_type(JsonbValue *value, Oid typeid, Datum datum);
 
 extern void ts_jsonb_add_value(JsonbParseState *state, const char *key, JsonbValue *value);
 

--- a/test/expected/telemetry.out
+++ b/test/expected/telemetry.out
@@ -350,6 +350,7 @@ WHERE key != 'os_name_pretty';
  db_metadata
  replication
  build_os_name
+ access_methods
  functions_used
  install_method
  installed_time
@@ -377,7 +378,7 @@ WHERE key != 'os_name_pretty';
  num_compression_policies_fixed
  num_user_defined_actions_fixed
  num_continuous_aggs_policies_fixed
-(37 rows)
+(38 rows)
 
 CREATE MATERIALIZED VIEW telemetry_report AS
 SELECT t FROM get_telemetry_report() t;
@@ -393,6 +394,17 @@ SELECT t -> 'instance_metadata' FROM telemetry_report;
     ?column?     
 -----------------
  {"cloud": "ci"}
+(1 row)
+
+-- Check access methods
+SELECT t->'access_methods' ? 'btree',
+       t->'access_methods' ? 'heap',
+       CAST(t->'access_methods'->'btree'->'pages' AS int) > 0,
+       CAST(t->'access_methods'->'btree'->'instances' AS int) > 0
+  FROM telemetry_report;
+ ?column? | ?column? | ?column? | ?column? 
+----------+----------+----------+----------
+ t        | t        | t        | t
 (1 row)
 
 WITH t AS (

--- a/test/sql/telemetry.sql
+++ b/test/sql/telemetry.sql
@@ -166,6 +166,13 @@ SELECT t -> 'db_metadata' FROM telemetry_report;
 -- check timescaledb_telemetry.cloud
 SELECT t -> 'instance_metadata' FROM telemetry_report;
 
+-- Check access methods
+SELECT t->'access_methods' ? 'btree',
+       t->'access_methods' ? 'heap',
+       CAST(t->'access_methods'->'btree'->'pages' AS int) > 0,
+       CAST(t->'access_methods'->'btree'->'instances' AS int) > 0
+  FROM telemetry_report;
+
 WITH t AS (
 	 SELECT t -> 'relations' AS rels
 	 FROM telemetry_report


### PR DESCRIPTION
Add telemetry for tracking access methods used, number of pages for each access method, and number of instances using each access method.

Also introduces a type-based function `ts_jsonb_set_value_by_type` that can generate correct JSONB based on the PostgreSQL type. It will generate "bare" values for numerics, and strings for anything else using the output function for the type.

To test this for string values, we update `ts_jsonb_add_interval` to use this new function, which is calling the output function for the type, just like `ts_jsonb_set_value_by_type`.