### PR TITLE
Check for trigger context before accessing data

### DIFF
--- a/.unreleased/fix_6820
+++ b/.unreleased/fix_6820
@@ -1,0 +1,2 @@
+Fixes: #6820 Fix a crash when the ts_hypertable_insert_blocker was called directly
+Thanks: @brasic for reporting a crash when the ts_hypertable_insert_blocker was called directly

--- a/src/hypertable.c
+++ b/src/hypertable.c
@@ -1318,11 +1318,14 @@ TS_FUNCTION_INFO_V1(ts_hypertable_insert_blocker);
 Datum
 ts_hypertable_insert_blocker(PG_FUNCTION_ARGS)
 {
-	TriggerData *trigdata = (TriggerData *) fcinfo->context;
-	const char *relname = get_rel_name(trigdata->tg_relation->rd_id);
-
 	if (!CALLED_AS_TRIGGER(fcinfo))
 		elog(ERROR, "insert_blocker: not called by trigger manager");
+
+	TriggerData *trigdata = (TriggerData *) fcinfo->context;
+	Ensure(trigdata != NULL, "trigdata has to be set");
+	Ensure(trigdata->tg_relation != NULL, "tg_relation has to be set");
+
+	const char *relname = get_rel_name(trigdata->tg_relation->rd_id);
 
 	if (ts_guc_restoring)
 		ereport(ERROR,

--- a/test/expected/triggers.out
+++ b/test/expected/triggers.out
@@ -442,4 +442,7 @@ CREATE TRIGGER t3 AFTER UPDATE ON transition_test REFERENCING NEW TABLE AS new_t
 ERROR:  trigger with transition tables not supported on hypertables
 CREATE TRIGGER t4 AFTER DELETE ON transition_test REFERENCING OLD TABLE AS old_trans FOR EACH ROW EXECUTE FUNCTION test_trigger();
 ERROR:  trigger with transition tables not supported on hypertables
+-- Test insert blocker trigger does not crash when called directly
+SELECT _timescaledb_functions.insert_blocker();
+ERROR:  insert_blocker: not called by trigger manager
 \set ON_ERROR_STOP 1

--- a/test/sql/triggers.sql
+++ b/test/sql/triggers.sql
@@ -322,6 +322,8 @@ CREATE TRIGGER t4 AFTER DELETE ON transition_test REFERENCING OLD TABLE AS old_t
 CREATE TRIGGER t2 AFTER INSERT ON transition_test REFERENCING NEW TABLE AS new_trans FOR EACH ROW EXECUTE FUNCTION test_trigger();
 CREATE TRIGGER t3 AFTER UPDATE ON transition_test REFERENCING NEW TABLE AS new_trans OLD TABLE AS old_trans FOR EACH ROW EXECUTE FUNCTION test_trigger();
 CREATE TRIGGER t4 AFTER DELETE ON transition_test REFERENCING OLD TABLE AS old_trans FOR EACH ROW EXECUTE FUNCTION test_trigger();
+
+-- Test insert blocker trigger does not crash when called directly
+SELECT _timescaledb_functions.insert_blocker();
+
 \set ON_ERROR_STOP 1
-
-


### PR DESCRIPTION
The ts_hypertable_insert_blocker function was accessing data from the trigger context before it was tested that a trigger context actually exists. This led to a crash when the function was called directly.

Fixes: #6819