### PR TITLE
Use ignore words file with codespell

### DIFF
--- a/.github/codespell-ignore-words
+++ b/.github/codespell-ignore-words
@@ -1,0 +1,4 @@
+brin
+inh
+larg
+inout

--- a/.github/workflows/code_style.yaml
+++ b/.github/workflows/code_style.yaml
@@ -66,7 +66,7 @@ jobs:
       - name: Run codespell
         run: |
           find . -type f \( -name "*.c" -or -name "*.h" -or -name "*.yaml" -or -name "*.sh" \) \
-            -exec codespell -L "brin,inh,larg,inout" {} \+
+            -exec codespell -I .github/codespell-ignore-words {} \+
 
   cc_checks:
     name: Check code formatting


### PR DESCRIPTION
It is not possible to automatically backport pull requests that makes modifications to workflow files and since the codespell action has a hard-coded list of ignored words as options, this means that any changes to the ignored codespell words cannot be backported.

This pull request fixes this by using a ignore words file instead, which means that adding new words does not require changing a workflow file and hence the pull requests can be automatically backported.

Disable-check: force-changelog-file