### PR TITLE
Prevent range overlap for chunks using constraint

### DIFF
--- a/sql/pre_install/tables.sql
+++ b/sql/pre_install/tables.sql
@@ -126,6 +126,7 @@ CREATE TABLE _timescaledb_catalog.dimension_slice (
   -- table constraints
   CONSTRAINT dimension_slice_pkey PRIMARY KEY (id),
   CONSTRAINT dimension_slice_dimension_id_range_start_range_end_key UNIQUE (dimension_id, range_start, range_end),
+  CONSTRAINT dimension_slice_dimension_id_exclude EXCLUDE USING gist(int4range(dimension_id, dimension_id, '[]') WITH =, int8range(range_start, range_end, '[]') WITH &&),
   CONSTRAINT dimension_slice_check CHECK (range_start <= range_end),
   CONSTRAINT dimension_slice_dimension_id_fkey FOREIGN KEY (dimension_id) REFERENCES _timescaledb_catalog.dimension (id) ON DELETE CASCADE
 );

--- a/sql/updates/latest-dev.sql
+++ b/sql/updates/latest-dev.sql
@@ -392,3 +392,16 @@ DROP FUNCTION IF EXISTS _timescaledb_functions.policy_job_error_retention_check(
 --
 -- END bgw_job_stat_history
 --
+
+--
+-- START add exclusion constraint to dimension_slice
+--
+ALTER TABLE _timescaledb_catalog.dimension_slice
+    ADD CONSTRAINT dimension_slice_dimension_id_exclude
+    EXCLUDE USING gist(
+        int4range(dimension_id, dimension_id, '[]') WITH =,
+        int8range(range_start, range_end, '[]') WITH &&
+    );
+--
+-- END add exclusion constraint to dimension_slice
+--

--- a/sql/updates/reverse-dev.sql
+++ b/sql/updates/reverse-dev.sql
@@ -294,3 +294,6 @@ SET
   check_name = 'policy_job_error_retention_check'
 WHERE
   id = 2;
+
+ALTER TABLE _timescaledb_catalog.dimension_slice
+  DROP CONSTRAINT dimension_slice_dimension_id_exclude;


### PR DESCRIPTION
This exclusion constraint prevents a single (time) value to exist in multiple dimension slices.