### PR TITLE
Add ts_stat_statements callbacks

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -45,7 +45,8 @@ set(SOURCES
     trigger.c
     utils.c
     version.c
-    with_clause_parser.c)
+    with_clause_parser.c
+    tss_callbacks.c)
 
 # Add test source code in Debug builds
 if(CMAKE_BUILD_TYPE MATCHES Debug)

--- a/src/guc.c
+++ b/src/guc.c
@@ -83,6 +83,8 @@ TSDLLEXPORT bool ts_guc_enable_skip_scan = true;
 static char *ts_guc_default_segmentby_fn = NULL;
 static char *ts_guc_default_orderby_fn = NULL;
 TSDLLEXPORT bool ts_guc_enable_job_execution_logging = false;
+bool ts_guc_enable_tss_callbacks = true;
+
 /* default value of ts_guc_max_open_chunks_per_insert and ts_guc_max_cached_chunks_per_hypertable
  * will be set as their respective boot-value when the GUC mechanism starts up */
 int ts_guc_max_open_chunks_per_insert;
@@ -655,6 +657,17 @@ _guc_init(void)
 							 &ts_guc_enable_job_execution_logging,
 							 false,
 							 PGC_USERSET,
+							 0,
+							 NULL,
+							 NULL,
+							 NULL);
+
+	DefineCustomBoolVariable(MAKE_EXTOPTION("enable_tss_callbacks"),
+							 "Enable ts_stat_statements callbacks",
+							 "Enable ts_stat_statements callbacks",
+							 &ts_guc_enable_tss_callbacks,
+							 true,
+							 PGC_SUSET,
 							 0,
 							 NULL,
 							 NULL,

--- a/src/guc.h
+++ b/src/guc.h
@@ -40,6 +40,7 @@ extern bool ts_guc_restoring;
 extern int ts_guc_max_open_chunks_per_insert;
 extern int ts_guc_max_cached_chunks_per_hypertable;
 extern TSDLLEXPORT bool ts_guc_enable_job_execution_logging;
+extern bool ts_guc_enable_tss_callbacks;
 
 #ifdef USE_TELEMETRY
 typedef enum TelemetryLevel

--- a/src/tss_callbacks.c
+++ b/src/tss_callbacks.c
@@ -1,0 +1,130 @@
+/*
+ * This file and its contents are licensed under the Apache License 2.0.
+ * Please see the included NOTICE for copyright information and
+ * LICENSE-APACHE for a copy of the license.
+ */
+
+/*
+ * Currently we finish the execution of some process utility statements
+ * and don't execute other hooks in the chain.
+ *
+ * Because that reason neither ts_stat_statements and pg_stat_statements
+ * are able to track some utility statements, for example COPY ... FROM.
+ *
+ * To be able to track it on ts_stat_statements here we introduce some
+ * callbacks in order to hook pgss_store from TimescaleDB and store
+ * information about the execution of those statements.
+ *
+ * Hooking ts_stat_statements from TimescaleDB is controlled by a new GUC
+ * named `enable_tss_callbacks`.
+ */
+
+#include <postgres.h>
+
+#include <fmgr.h>
+#include <executor/instrument.h>
+#include <utils/elog.h>
+
+#include "guc.h"
+#include "tss_callbacks.h"
+
+static instr_time tss_callback_start_time;
+static BufferUsage tss_callback_start_bufusage;
+static WalUsage tss_callback_start_walusage;
+
+static TSSCallbacks *
+ts_get_tss_callbacks(void)
+{
+	TSSCallbacks **ptr = (TSSCallbacks **) find_rendezvous_variable(TSS_CALLBACKS_VAR_NAME);
+
+	return *ptr;
+}
+
+static tss_store_hook_type
+ts_get_tss_store_hook(void)
+{
+	TSSCallbacks *ptr = ts_get_tss_callbacks();
+
+	if (ptr && ptr->version_num == TSS_CALLBACKS_VERSION)
+		return ptr->tss_store_hook;
+
+	return NULL;
+}
+
+static bool
+is_tss_enabled(void)
+{
+	if (ts_guc_enable_tss_callbacks)
+	{
+		TSSCallbacks *ptr = ts_get_tss_callbacks();
+
+		if (ptr)
+		{
+			if (ptr->version_num != TSS_CALLBACKS_VERSION)
+			{
+				ereport(WARNING,
+						(errcode(ERRCODE_INTERNAL_ERROR),
+						 errmsg("version mismatch between timescaledb and ts_stat_statements "
+								"callbacks"),
+						 errdetail("Callbacks versions: TimescaleDB (%d) and ts_stat_statements "
+								   "(%d)",
+								   TSS_CALLBACKS_VERSION,
+								   ptr->version_num)));
+				return false;
+			}
+
+			return ptr->tss_enabled_hook_type(0); /* consider top level statement */
+		}
+	}
+
+	return false;
+}
+
+void
+ts_begin_tss_store_callback(void)
+{
+	if (!is_tss_enabled())
+		return;
+
+	tss_callback_start_bufusage = pgBufferUsage;
+	tss_callback_start_walusage = pgWalUsage;
+	INSTR_TIME_SET_CURRENT(tss_callback_start_time);
+}
+
+void
+ts_end_tss_store_callback(const char *query, int query_location, int query_len, uint64 query_id,
+						  uint64 rows)
+{
+	instr_time duration;
+	BufferUsage bufusage;
+	WalUsage walusage;
+	tss_store_hook_type hook;
+
+	if (!is_tss_enabled())
+		return;
+
+	hook = ts_get_tss_store_hook();
+
+	if (!hook)
+		return;
+
+	INSTR_TIME_SET_CURRENT(duration);
+	INSTR_TIME_SUBTRACT(duration, tss_callback_start_time);
+
+	/* calc differences of buffer counters. */
+	memset(&bufusage, 0, sizeof(BufferUsage));
+	BufferUsageAccumDiff(&bufusage, &pgBufferUsage, &tss_callback_start_bufusage);
+
+	/* calc differences of WAL counters. */
+	memset(&walusage, 0, sizeof(WalUsage));
+	WalUsageAccumDiff(&walusage, &pgWalUsage, &tss_callback_start_walusage);
+
+	hook(query,
+		 query_location,
+		 query_len,
+		 query_id,
+		 INSTR_TIME_GET_MICROSEC(duration),
+		 rows,
+		 &bufusage,
+		 &walusage);
+}

--- a/src/tss_callbacks.h
+++ b/src/tss_callbacks.h
@@ -1,0 +1,28 @@
+/*
+ * This file and its contents are licensed under the Apache License 2.0.
+ * Please see the included NOTICE for copyright information and
+ * LICENSE-APACHE for a copy of the license.
+ */
+#pragma once
+
+#define TSS_CALLBACKS_VAR_NAME "tss_callbacks"
+#define TSS_CALLBACKS_VERSION 1
+
+/* ts_stat_statements -> pgss_store */
+typedef void (*tss_store_hook_type)(const char *query, int query_location, int query_len,
+									uint64 query_id, uint64 total_time, uint64 rows,
+									const BufferUsage *bufusage, const WalUsage *walusage);
+/* ts_stat_statements -> pgss_enabled */
+typedef bool (*tss_enabled_hook_type)(int level);
+
+/* ts_stat_statements callbacks */
+typedef struct TSSCallbacks
+{
+	uint32_t version_num;
+	tss_store_hook_type tss_store_hook;
+	tss_enabled_hook_type tss_enabled_hook_type;
+} TSSCallbacks;
+
+extern void ts_begin_tss_store_callback(void);
+extern void ts_end_tss_store_callback(const char *query, int query_location, int query_len,
+									  uint64 query_id, uint64 rows);

--- a/test/expected/test_tss_callbacks.out
+++ b/test/expected/test_tss_callbacks.out
@@ -1,0 +1,48 @@
+-- This file and its contents are licensed under the Apache License 2.0.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-APACHE for a copy of the license.
+\c :TEST_DBNAME :ROLE_SUPERUSER
+CREATE OR REPLACE FUNCTION test.setup_tss_hook_v0() RETURNS VOID
+    AS :MODULE_PATHNAME, 'ts_setup_tss_hook_v0' LANGUAGE C VOLATILE;
+CREATE OR REPLACE FUNCTION test.setup_tss_hook_v1() RETURNS VOID
+    AS :MODULE_PATHNAME, 'ts_setup_tss_hook_v1' LANGUAGE C VOLATILE;
+CREATE OR REPLACE FUNCTION test.teardown_tss_hook_v1() RETURNS VOID
+    AS :MODULE_PATHNAME, 'ts_teardown_tss_hook_v1' LANGUAGE C VOLATILE;
+SELECT test.setup_tss_hook_v1();
+ setup_tss_hook_v1 
+-------------------
+ 
+(1 row)
+
+CREATE TABLE copy_test (
+    "time" timestamptz NOT NULL,
+    "value" double precision NOT NULL
+);
+SELECT create_hypertable('copy_test', 'time');
+   create_hypertable    
+------------------------
+ (1,public,copy_test,t)
+(1 row)
+
+-- We should se a mock message
+COPY copy_test FROM STDIN DELIMITER ',';
+NOTICE:  test_tss_callbacks (mock): query=COPY copy_test FROM STDIN DELIMITER ',';, len=39, id=0, rows=2
+SELECT test.teardown_tss_hook_v1();
+ teardown_tss_hook_v1 
+----------------------
+ 
+(1 row)
+
+-- Without the hook registered we cannot see the mock message
+COPY copy_test FROM STDIN DELIMITER ',';
+-- Test for mismatch version
+SELECT test.setup_tss_hook_v0();
+ setup_tss_hook_v0 
+-------------------
+ 
+(1 row)
+
+-- Warning because the mismatch versions
+COPY copy_test FROM STDIN DELIMITER ',';
+WARNING:  version mismatch between timescaledb and ts_stat_statements callbacks
+WARNING:  version mismatch between timescaledb and ts_stat_statements callbacks

--- a/test/sql/CMakeLists.txt
+++ b/test/sql/CMakeLists.txt
@@ -106,6 +106,7 @@ if(CMAKE_BUILD_TYPE MATCHES Debug)
     net.sql
     pg_dump.sql
     symbol_conflict.sql
+    test_tss_callbacks.sql
     test_utils.sql
     ${LOADER_TEST_FILE}.sql)
   if(USE_TELEMETRY)

--- a/test/sql/test_tss_callbacks.sql
+++ b/test/sql/test_tss_callbacks.sql
@@ -1,0 +1,46 @@
+-- This file and its contents are licensed under the Apache License 2.0.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-APACHE for a copy of the license.
+
+\c :TEST_DBNAME :ROLE_SUPERUSER
+
+CREATE OR REPLACE FUNCTION test.setup_tss_hook_v0() RETURNS VOID
+    AS :MODULE_PATHNAME, 'ts_setup_tss_hook_v0' LANGUAGE C VOLATILE;
+
+CREATE OR REPLACE FUNCTION test.setup_tss_hook_v1() RETURNS VOID
+    AS :MODULE_PATHNAME, 'ts_setup_tss_hook_v1' LANGUAGE C VOLATILE;
+
+CREATE OR REPLACE FUNCTION test.teardown_tss_hook_v1() RETURNS VOID
+    AS :MODULE_PATHNAME, 'ts_teardown_tss_hook_v1' LANGUAGE C VOLATILE;
+
+SELECT test.setup_tss_hook_v1();
+
+CREATE TABLE copy_test (
+    "time" timestamptz NOT NULL,
+    "value" double precision NOT NULL
+);
+
+SELECT create_hypertable('copy_test', 'time');
+
+-- We should se a mock message
+COPY copy_test FROM STDIN DELIMITER ',';
+2020-01-01 01:10:00+01,1
+2021-01-01 01:10:00+01,1
+\.
+
+SELECT test.teardown_tss_hook_v1();
+
+-- Without the hook registered we cannot see the mock message
+COPY copy_test FROM STDIN DELIMITER ',';
+2020-01-01 01:10:00+01,1
+2021-01-01 01:10:00+01,1
+\.
+
+-- Test for mismatch version
+SELECT test.setup_tss_hook_v0();
+
+-- Warning because the mismatch versions
+COPY copy_test FROM STDIN DELIMITER ',';
+2020-01-01 01:10:00+01,1
+2021-01-01 01:10:00+01,1
+\.

--- a/test/src/CMakeLists.txt
+++ b/test/src/CMakeLists.txt
@@ -1,12 +1,13 @@
 set(SOURCES
-    metadata.c
     adt_tests.c
+    metadata.c
     symbol_conflict.c
+    test_scanner.c
     test_time_to_internal.c
-    test_with_clause_parser.c
     test_time_utils.c
+    test_tss_callbacks.c
     test_utils.c
-    test_scanner.c)
+    test_with_clause_parser.c)
 
 include(${PROJECT_SOURCE_DIR}/src/build-defs.cmake)
 

--- a/test/src/test_tss_callbacks.c
+++ b/test/src/test_tss_callbacks.c
@@ -1,0 +1,74 @@
+/*
+ * This file and its contents are licensed under the Apache License 2.0.
+ * Please see the included NOTICE for copyright information and
+ * LICENSE-APACHE for a copy of the license.
+ */
+#include <postgres.h>
+
+#include <fmgr.h>
+#include <funcapi.h>
+
+#include "export.h"
+#include "tss_callbacks.h"
+
+static void
+test_tss_store_hook(const char *query, int query_location, int query_len, uint64 query_id,
+					uint64 total_time, uint64 rows, const BufferUsage *bufusage,
+					const WalUsage *walusage)
+{
+	elog(NOTICE,
+		 "test_tss_callbacks (mock): query=%s, len=%d, id=" INT64_FORMAT ", rows=" INT64_FORMAT,
+		 query,
+		 query_len,
+		 query_id,
+		 rows);
+}
+
+static bool
+test_tss_enabled_hook(int level)
+{
+	return true;
+}
+
+TSSCallbacks test_tss_callbacks_v1 = {
+	.version_num = 1,
+	.tss_store_hook = test_tss_store_hook,
+	.tss_enabled_hook_type = test_tss_enabled_hook,
+};
+
+TS_FUNCTION_INFO_V1(ts_setup_tss_hook_v1);
+Datum
+ts_setup_tss_hook_v1(PG_FUNCTION_ARGS)
+{
+	TSSCallbacks **ptr = (TSSCallbacks **) find_rendezvous_variable(TSS_CALLBACKS_VAR_NAME);
+	*ptr = &test_tss_callbacks_v1;
+
+	PG_RETURN_NULL();
+}
+
+TS_FUNCTION_INFO_V1(ts_teardown_tss_hook_v1);
+Datum
+ts_teardown_tss_hook_v1(PG_FUNCTION_ARGS)
+{
+	TSSCallbacks **ptr = (TSSCallbacks **) find_rendezvous_variable(TSS_CALLBACKS_VAR_NAME);
+	*ptr = NULL;
+
+	PG_RETURN_NULL();
+}
+
+/* This version will mismatch with the current supported */
+TSSCallbacks test_tss_callbacks_v0 = {
+	.version_num = 0,
+	.tss_store_hook = test_tss_store_hook,
+	.tss_enabled_hook_type = test_tss_enabled_hook,
+};
+
+TS_FUNCTION_INFO_V1(ts_setup_tss_hook_v0);
+Datum
+ts_setup_tss_hook_v0(PG_FUNCTION_ARGS)
+{
+	TSSCallbacks **ptr = (TSSCallbacks **) find_rendezvous_variable(TSS_CALLBACKS_VAR_NAME);
+	*ptr = &test_tss_callbacks_v0;
+
+	PG_RETURN_NULL();
+}


### PR DESCRIPTION
Currently we finish the execution of some process utility statements and don't execute other hooks in the chain.

Because that reason neither `ts_stat_statements` and `pg_stat_statements` are able to track some utility statements, for example COPY ... FROM.

To be able to track it on `ts_stat_statements` we're introducing some callbacks in order to hook `pgss_store` from TimescaleDB and store information about the execution of those statements.

In this PR we're also adding a new GUC `enable_tss_callbacks=fase` to enable or disable the ability to hook `ts_stat_statements` from TimescaleDB.

Disable-check: force-changelog-file
