### PR TITLE
Allow changing real-time flag on deprecated CAggs

### DIFF
--- a/tsl/src/continuous_aggs/create.c
+++ b/tsl/src/continuous_aggs/create.c
@@ -1026,7 +1026,7 @@ cagg_flip_realtime_view_definition(ContinuousAgg *agg, Hypertable *mat_ht)
 							agg->data.finalized,
 							NameStr(agg->data.user_view_schema),
 							NameStr(agg->data.user_view_name),
-							true);
+							false);
 
 	/* Flip */
 	agg->data.materialized_only = !agg->data.materialized_only;

--- a/tsl/src/continuous_aggs/repair.c
+++ b/tsl/src/continuous_aggs/repair.c
@@ -130,7 +130,7 @@ cagg_rebuild_view_definition(ContinuousAgg *agg, Hypertable *mat_ht, bool force_
 							finalized,
 							NameStr(agg->data.user_view_schema),
 							NameStr(agg->data.user_view_name),
-							true);
+							false);
 
 	mattablecolumninfo_init(&mattblinfo, copyObject(direct_query->groupClause));
 	fqi.finalized = finalized;

--- a/tsl/test/expected/exp_cagg_next_gen.out
+++ b/tsl/test/expected/exp_cagg_next_gen.out
@@ -196,5 +196,8 @@ FROM _timescaledb_catalog.continuous_aggs_bucket_function ORDER BY 1;
  timescaledb_experimental.time_bucket_ng(interval,timestamp without time zone) | @ 1 mon      |               |                 | f
 (2 rows)
 
+-- Try to toggle realtime feature on existing CAgg using timescaledb_experimental.time_bucket_ng
+ALTER MATERIALIZED VIEW conditions_summary_monthly SET (timescaledb.materialized_only=false);
+ALTER MATERIALIZED VIEW conditions_summary_monthly SET (timescaledb.materialized_only=true);
 \c :TEST_DBNAME :ROLE_SUPERUSER
 DROP DATABASE test WITH (FORCE);

--- a/tsl/test/sql/exp_cagg_next_gen.sql
+++ b/tsl/test/sql/exp_cagg_next_gen.sql
@@ -163,5 +163,9 @@ WITH NO DATA;
 SELECT bucket_func, bucket_width, bucket_origin, bucket_timezone, bucket_fixed_width
 FROM _timescaledb_catalog.continuous_aggs_bucket_function ORDER BY 1;
 
+-- Try to toggle realtime feature on existing CAgg using timescaledb_experimental.time_bucket_ng
+ALTER MATERIALIZED VIEW conditions_summary_monthly SET (timescaledb.materialized_only=false);
+ALTER MATERIALIZED VIEW conditions_summary_monthly SET (timescaledb.materialized_only=true);
+
 \c :TEST_DBNAME :ROLE_SUPERUSER
 DROP DATABASE test WITH (FORCE);


### PR DESCRIPTION
PR #6798 prevents the usage of time_bucket_ng in CAgg definitions. However, flipping the real-time functionality should still be possible.

---

Disable-check: force-changelog-file
