### PR TITLE
Correctly determine relation type of OSM chunk as standalone table

### DIFF
--- a/src/planner/planner.c
+++ b/src/planner/planner.c
@@ -717,6 +717,16 @@ ts_classify_relation(const PlannerInfo *root, const RelOptInfo *rel, Hypertable 
 
 	RangeTblEntry *rte = planner_rt_fetch(rel->relid, root);
 
+	if (rte->relkind == RELKIND_FOREIGN_TABLE)
+	{
+		/*
+		 * OSM chunk or other foreign chunk. We can't even access the
+		 * fdw_private for it, because it's a foreign chunk managed by a
+		 * different extension. Try to ignore it as much as possible.
+		 */
+		return TS_REL_OTHER;
+	}
+
 	if (!OidIsValid(rte->relid))
 	{
 		return TS_REL_OTHER;
@@ -797,16 +807,6 @@ ts_classify_relation(const PlannerInfo *root, const RelOptInfo *rel, Hypertable 
 	*ht = entry->ht;
 	if (*ht)
 	{
-		if (rte->relkind == RELKIND_FOREIGN_TABLE)
-		{
-			/*
-			 * OSM chunk or other foreign chunk. We can't even access the
-			 * fdw_private for it, because it's a foreign chunk managed by a
-			 * different extension. Try to ignore it as much as possible.
-			 */
-			return TS_REL_OTHER;
-		}
-
 		return TS_REL_CHUNK_CHILD;
 	}
 

--- a/test/test-defs.cmake
+++ b/test/test-defs.cmake
@@ -63,7 +63,7 @@ endif()
 # This variable is set differently in CI. We use it to save the logs outside the
 # tmp instance, because it is deleted by pg_regress on successful test
 # completion, and we want to run some additional checks on the logs in any case.
-option(TEST_PG_LOG_DIRECTORY "Log directory for regression tests" "log")
+set(TEST_PG_LOG_DIRECTORY "log" CACHE STRING "Log directory for regression tests")
 
 if(USE_TELEMETRY)
   set(TELEMETRY_DEFAULT_SETTING "timescaledb.telemetry_level=off")

--- a/test/test-defs.cmake
+++ b/test/test-defs.cmake
@@ -63,7 +63,9 @@ endif()
 # This variable is set differently in CI. We use it to save the logs outside the
 # tmp instance, because it is deleted by pg_regress on successful test
 # completion, and we want to run some additional checks on the logs in any case.
-set(TEST_PG_LOG_DIRECTORY "log" CACHE STRING "Log directory for regression tests")
+set(TEST_PG_LOG_DIRECTORY
+    "log"
+    CACHE STRING "Log directory for regression tests")
 
 if(USE_TELEMETRY)
   set(TELEMETRY_DEFAULT_SETTING "timescaledb.telemetry_level=off")

--- a/tsl/test/expected/chunk_utils_internal.out
+++ b/tsl/test/expected/chunk_utils_internal.out
@@ -580,6 +580,13 @@ SELECT * FROM ht_try ORDER BY 1;
  Thu May 05 01:00:00 2022 PDT |    222 |   222
 (2 rows)
 
+-- Check that the direct select from OSM chunk doesn't lead to bad effects.
+SELECT * FROM child_fdw_table;
+            timec             | acq_id | value 
+------------------------------+--------+-------
+ Wed Jan 01 01:00:00 2020 PST |    100 |  1000
+(1 row)
+
 SELECT relname, relowner::regrole FROM pg_class
 WHERE relname in ( select chunk_name FROM chunk_view
                    WHERE hypertable_name = 'ht_try' )
@@ -801,6 +808,14 @@ BEGIN
 	WHERE acq_id = 10 AND timec > now() - '15 years'::interval INTO r;
 END
 $$ LANGUAGE plpgsql;
+-- Check that the direct select from OSM chunk doesn't lead to bad effects in
+-- presence of compression.
+SELECT * FROM child_fdw_table;
+            timec             | acq_id | value 
+------------------------------+--------+-------
+ Wed Jan 01 01:00:00 2020 PST |    100 |  1000
+(1 row)
+
 --TEST insert into a OSM chunk fails. actually any insert will fail. But we just need
 -- to mock the hook and make sure the timescaledb code works correctly.
 SELECT ts_setup_osm_hook();

--- a/tsl/test/sql/chunk_utils_internal.sql
+++ b/tsl/test/sql/chunk_utils_internal.sql
@@ -352,6 +352,9 @@ ORDER BY chunk_name;
 
 SELECT * FROM ht_try ORDER BY 1;
 
+-- Check that the direct select from OSM chunk doesn't lead to bad effects.
+SELECT * FROM child_fdw_table;
+
 SELECT relname, relowner::regrole FROM pg_class
 WHERE relname in ( select chunk_name FROM chunk_view
                    WHERE hypertable_name = 'ht_try' )
@@ -427,6 +430,10 @@ BEGIN
 	WHERE acq_id = 10 AND timec > now() - '15 years'::interval INTO r;
 END
 $$ LANGUAGE plpgsql;
+
+-- Check that the direct select from OSM chunk doesn't lead to bad effects in
+-- presence of compression.
+SELECT * FROM child_fdw_table;
 
 --TEST insert into a OSM chunk fails. actually any insert will fail. But we just need
 -- to mock the hook and make sure the timescaledb code works correctly.


### PR DESCRIPTION
Previously we only handled the case of OSM chunk expanded as a child of hypertable, so in the case of direct select it segfaulted while trying to access an fdw_private which is managed by OSM.


Disable-check: force-changelog-file