### PR TITLE
Fix missing pid in job execution history

### DIFF
--- a/src/bgw/job_stat_history.c
+++ b/src/bgw/job_stat_history.c
@@ -101,7 +101,7 @@ ts_bgw_job_stat_history_insert(BgwJobStatHistoryContext *context)
 	CatalogSecurityContext sec_ctx;
 
 	ts_datum_set_int32(Anum_bgw_job_stat_history_job_id, values, context->job->fd.id, false);
-	ts_datum_set_int32(Anum_bgw_job_stat_history_pid, values, 0, true);
+	ts_datum_set_int32(Anum_bgw_job_stat_history_pid, values, MyProcPid, false);
 	ts_datum_set_timestamptz(Anum_bgw_job_stat_history_execution_start,
 							 values,
 							 context->job->job_history.execution_start,

--- a/tsl/test/expected/bgw_job_stat_history.out
+++ b/tsl/test/expected/bgw_job_stat_history.out
@@ -183,17 +183,17 @@ INFO:  wait_for_job_to_run: job execution failed
 (1 row)
 
 -- Check job execution history
-SELECT proc_schema, proc_name, succeeded, config, sqlerrcode, err_message
+SELECT job_id, pid IS NOT NULL AS pid, proc_schema, proc_name, succeeded, config, sqlerrcode, err_message
 FROM timescaledb_information.job_history
 WHERE job_id >= 1000
-ORDER BY id;
- proc_schema |    proc_name     | succeeded |   config   | sqlerrcode |   err_message    
--------------+------------------+-----------+------------+------------+------------------
- public      | custom_job_error | f         |            | 22012      | division by zero
- public      | custom_job_ok    | t         |            |            | 
- public      | custom_job_error | f         |            | 22012      | division by zero
- public      | custom_job_ok    | t         | {"foo": 1} |            | 
- public      | custom_job_error | f         | {"bar": 1} | 22012      | division by zero
+ORDER BY id, job_id;
+ job_id | pid | proc_schema |    proc_name     | succeeded |   config   | sqlerrcode |   err_message    
+--------+-----+-------------+------------------+-----------+------------+------------+------------------
+   1001 | t   | public      | custom_job_error | f         |            | 22012      | division by zero
+   1000 | t   | public      | custom_job_ok    | t         |            |            | 
+   1001 | t   | public      | custom_job_error | f         |            | 22012      | division by zero
+   1000 | t   | public      | custom_job_ok    | t         | {"foo": 1} |            | 
+   1001 | t   | public      | custom_job_error | f         | {"bar": 1} | 22012      | division by zero
 (5 rows)
 
 -- Changing the config of one job
@@ -216,15 +216,15 @@ SELECT test.wait_for_job_to_run(:job_id_1, 4);
 (1 row)
 
 -- Check job execution history
-SELECT proc_schema, proc_name, succeeded, config, sqlerrcode, err_message
+SELECT job_id, pid IS NOT NULL AS pid, proc_schema, proc_name, succeeded, config, sqlerrcode, err_message
 FROM timescaledb_information.job_history
 WHERE job_id = :job_id_1
 ORDER BY id;
- proc_schema |   proc_name   | succeeded |        config        | sqlerrcode | err_message 
--------------+---------------+-----------+----------------------+------------+-------------
- public      | custom_job_ok | t         |                      |            | 
- public      | custom_job_ok | t         | {"foo": 1}           |            | 
- public      | custom_job_ok | t         | {"bar": 1, "foo": 2} |            | 
+ job_id | pid | proc_schema |   proc_name   | succeeded |        config        | sqlerrcode | err_message 
+--------+-----+-------------+---------------+-----------+----------------------+------------+-------------
+   1000 | t   | public      | custom_job_ok | t         |                      |            | 
+   1000 | t   | public      | custom_job_ok | t         | {"foo": 1}           |            | 
+   1000 | t   | public      | custom_job_ok | t         | {"bar": 1, "foo": 2} |            | 
 (3 rows)
 
 -- Change the job procedure to alter the job configuration during the execution
@@ -249,16 +249,16 @@ SELECT test.wait_for_job_to_run(:job_id_1, 5);
 (1 row)
 
 -- Check job execution history
-SELECT proc_schema, proc_name, succeeded, config, sqlerrcode, err_message
+SELECT job_id, pid IS NOT NULL AS pid, proc_schema, proc_name, succeeded, config, sqlerrcode, err_message
 FROM timescaledb_information.job_history
 WHERE job_id = :job_id_1
 ORDER BY id;
- proc_schema |   proc_name   | succeeded |                 config                 | sqlerrcode | err_message 
--------------+---------------+-----------+----------------------------------------+------------+-------------
- public      | custom_job_ok | t         |                                        |            | 
- public      | custom_job_ok | t         | {"foo": 1}                             |            | 
- public      | custom_job_ok | t         | {"bar": 1, "foo": 2}                   |            | 
- public      | custom_job_ok | t         | {"config_changed_by_job_execution": 1} |            | 
+ job_id | pid | proc_schema |   proc_name   | succeeded |                 config                 | sqlerrcode | err_message 
+--------+-----+-------------+---------------+-----------+----------------------------------------+------------+-------------
+   1000 | t   | public      | custom_job_ok | t         |                                        |            | 
+   1000 | t   | public      | custom_job_ok | t         | {"foo": 1}                             |            | 
+   1000 | t   | public      | custom_job_ok | t         | {"bar": 1, "foo": 2}                   |            | 
+   1000 | t   | public      | custom_job_ok | t         | {"config_changed_by_job_execution": 1} |            | 
 (4 rows)
 
 -- Change the job procedure to alter the job configuration during the execution
@@ -286,17 +286,17 @@ SELECT test.wait_for_job_to_run(:job_id_1, 6);
 (1 row)
 
 -- Check job execution history
-SELECT proc_schema, proc_name, succeeded, config, sqlerrcode, err_message
+SELECT job_id, pid IS NOT NULL AS pid, proc_schema, proc_name, succeeded, config, sqlerrcode, err_message
 FROM timescaledb_information.job_history
 WHERE job_id = :job_id_1
 ORDER BY id;
- proc_schema |   proc_name   | succeeded |                 config                 | sqlerrcode | err_message 
--------------+---------------+-----------+----------------------------------------+------------+-------------
- public      | custom_job_ok | t         |                                        |            | 
- public      | custom_job_ok | t         | {"foo": 1}                             |            | 
- public      | custom_job_ok | t         | {"bar": 1, "foo": 2}                   |            | 
- public      | custom_job_ok | t         | {"config_changed_by_job_execution": 1} |            | 
- public      | custom_job_ok | t         | {"only_last_change_is_logged": 1}      |            | 
+ job_id | pid | proc_schema |   proc_name   | succeeded |                 config                 | sqlerrcode | err_message 
+--------+-----+-------------+---------------+-----------+----------------------------------------+------------+-------------
+   1000 | t   | public      | custom_job_ok | t         |                                        |            | 
+   1000 | t   | public      | custom_job_ok | t         | {"foo": 1}                             |            | 
+   1000 | t   | public      | custom_job_ok | t         | {"bar": 1, "foo": 2}                   |            | 
+   1000 | t   | public      | custom_job_ok | t         | {"config_changed_by_job_execution": 1} |            | 
+   1000 | t   | public      | custom_job_ok | t         | {"only_last_change_is_logged": 1}      |            | 
 (5 rows)
 
 -- Alter other information about the job

--- a/tsl/test/sql/bgw_job_stat_history.sql
+++ b/tsl/test/sql/bgw_job_stat_history.sql
@@ -77,10 +77,10 @@ SELECT test.wait_for_job_to_run(:job_id_1, 3);
 SELECT test.wait_for_job_to_run(:job_id_2, 3);
 
 -- Check job execution history
-SELECT proc_schema, proc_name, succeeded, config, sqlerrcode, err_message
+SELECT job_id, pid IS NOT NULL AS pid, proc_schema, proc_name, succeeded, config, sqlerrcode, err_message
 FROM timescaledb_information.job_history
 WHERE job_id >= 1000
-ORDER BY id;
+ORDER BY id, job_id;
 
 -- Changing the config of one job
 SELECT scheduled FROM alter_job(:job_id_1, config => '{"foo": 2, "bar": 1}'::jsonb);
@@ -88,7 +88,7 @@ SELECT scheduled FROM alter_job(:job_id_1, next_start => now());
 SELECT test.wait_for_job_to_run(:job_id_1, 4);
 
 -- Check job execution history
-SELECT proc_schema, proc_name, succeeded, config, sqlerrcode, err_message
+SELECT job_id, pid IS NOT NULL AS pid, proc_schema, proc_name, succeeded, config, sqlerrcode, err_message
 FROM timescaledb_information.job_history
 WHERE job_id = :job_id_1
 ORDER BY id;
@@ -107,7 +107,7 @@ SELECT scheduled FROM alter_job(:job_id_1, next_start => now());
 SELECT test.wait_for_job_to_run(:job_id_1, 5);
 
 -- Check job execution history
-SELECT proc_schema, proc_name, succeeded, config, sqlerrcode, err_message
+SELECT job_id, pid IS NOT NULL AS pid, proc_schema, proc_name, succeeded, config, sqlerrcode, err_message
 FROM timescaledb_information.job_history
 WHERE job_id = :job_id_1
 ORDER BY id;
@@ -129,7 +129,7 @@ SELECT scheduled FROM alter_job(:job_id_1, next_start => now());
 SELECT test.wait_for_job_to_run(:job_id_1, 6);
 
 -- Check job execution history
-SELECT proc_schema, proc_name, succeeded, config, sqlerrcode, err_message
+SELECT job_id, pid IS NOT NULL AS pid, proc_schema, proc_name, succeeded, config, sqlerrcode, err_message
 FROM timescaledb_information.job_history
 WHERE job_id = :job_id_1
 ORDER BY id;


### PR DESCRIPTION
When the `timescaledb.enable_job_execution_logging` is OFF we should track only errors but we're not saving the related PID.

Fixed it by using MyProcPid when inserting new tuple in `_timescaledb_internal.bgw_job_stat_history`.

Disable-check: force-changelog-file
