### PR TITLE
Use non-orderby compressed metadata in compressed DML

### DIFF
--- a/.unreleased/pr_6849
+++ b/.unreleased/pr_6849
@@ -1,0 +1,1 @@
+Fixes: #6849 Use non-orderby compressed metadata in compressed DML

--- a/tsl/test/expected/compression_update_delete.out
+++ b/tsl/test/expected/compression_update_delete.out
@@ -2915,3 +2915,32 @@ EXPLAIN (costs off) SELECT * FROM test_partials ORDER BY time;
 (14 rows)
 
 DROP TABLE test_partials;
+CREATE TABLE test_meta_filters(time timestamptz NOT NULL, device text, metric text, v1 float, v2 float);
+CREATE INDEX ON test_meta_filters(device, metric, v1);
+SELECT create_hypertable('test_meta_filters', 'time');
+        create_hypertable        
+---------------------------------
+ (37,public,test_meta_filters,t)
+(1 row)
+
+ALTER  TABLE test_meta_filters SET (timescaledb.compress, timescaledb.compress_segmentby='device', timescaledb.compress_orderby='metric,time');
+INSERT INTO test_meta_filters SELECT '2020-01-01'::timestamptz,'d1','m' || metric::text,v1,v2 FROM generate_series(1,3,1) metric, generate_series(1,1000,1) v1, generate_series(1,10,1) v2 ORDER BY 1,2,3,4,5;
+SELECT compress_chunk(show_chunks('test_meta_filters'));
+              compress_chunk              
+------------------------------------------
+ _timescaledb_internal._hyper_37_77_chunk
+(1 row)
+
+EXPLAIN (analyze, timing off, costs off, summary off) DELETE FROM test_meta_filters WHERE device = 'd1' AND metric = 'm1' AND v1 < 100;
+                                                 QUERY PLAN                                                 
+------------------------------------------------------------------------------------------------------------
+ Custom Scan (HypertableModify) (actual rows=0 loops=1)
+   Batches decompressed: 1
+   Tuples decompressed: 1000
+   ->  Delete on test_meta_filters (actual rows=0 loops=1)
+         Delete on _hyper_37_77_chunk test_meta_filters_1
+         ->  Seq Scan on _hyper_37_77_chunk test_meta_filters_1 (actual rows=990 loops=1)
+               Filter: ((v1 < '100'::double precision) AND (device = 'd1'::text) AND (metric = 'm1'::text))
+               Rows Removed by Filter: 10
+(8 rows)
+


### PR DESCRIPTION
Currently the additional metadata derived from index columns are only used for the qualifier pushdown in querying but not the decompression during compressed DML. This patch makes use of this metadata for compressed DML as well.