### PR TITLE
Use proper macros to check for invalid objects

### DIFF
--- a/src/bgw/job.c
+++ b/src/bgw/job.c
@@ -914,7 +914,7 @@ bgw_job_tuple_update_by_id(TupleInfo *ti, void *const data)
 	else
 		isnull[AttrNumberGetAttrOffset(Anum_bgw_job_config)] = true;
 
-	if (updated_job->fd.hypertable_id != 0)
+	if (updated_job->fd.hypertable_id != INVALID_HYPERTABLE_ID)
 	{
 		values[AttrNumberGetAttrOffset(Anum_bgw_job_hypertable_id)] =
 			Int32GetDatum(updated_job->fd.hypertable_id);
@@ -1144,7 +1144,7 @@ ts_bgw_job_entrypoint(PG_FUNCTION_ARGS)
 	instr_time duration;
 
 	memcpy(&params, MyBgworkerEntry->bgw_extra, sizeof(BgwParams));
-	Ensure(params.user_oid != 0 && params.job_id != 0,
+	Ensure(OidIsValid(params.user_oid) && params.job_id != 0,
 		   "job id or user oid was zero - job_id: %d, user_oid: %d",
 		   params.job_id,
 		   params.user_oid);

--- a/src/chunk.c
+++ b/src/chunk.c
@@ -1318,7 +1318,7 @@ Chunk *
 ts_chunk_find_for_point(const Hypertable *ht, const Point *p)
 {
 	int chunk_id = chunk_point_find_chunk_id(ht, p);
-	if (chunk_id == 0)
+	if (chunk_id == INVALID_CHUNK_ID)
 	{
 		return NULL;
 	}
@@ -1351,7 +1351,7 @@ ts_chunk_create_for_point(const Hypertable *ht, const Point *p, bool *found, con
 	 * aren't removed.
 	 */
 	int chunk_id = chunk_point_find_chunk_id(ht, p);
-	if (chunk_id != 0)
+	if (chunk_id != INVALID_CHUNK_ID)
 	{
 		/* The chunk might be dropped, so we don't fail if we haven't found it. */
 		Chunk *chunk = ts_chunk_get_by_id(chunk_id, /* fail_if_not_found = */ false);
@@ -1368,7 +1368,7 @@ ts_chunk_create_for_point(const Hypertable *ht, const Point *p, bool *found, con
 		}
 
 		/*
-		 * If we managed to find some metadata for the chunk (chunk_id != 0),
+		 * If we managed to find some metadata for the chunk (chunk_id != INVALID_CHUNK_ID),
 		 * but it is marked as dropped, try to resurrect it.
 		 * Not sure if this ever worked for distributed hypertables.
 		 */
@@ -1432,7 +1432,7 @@ ts_chunk_id_find_in_subspace(Hypertable *ht, List *dimension_vecs)
 				Datum datum = slot_getattr(ti->slot, Anum_chunk_constraint_chunk_id, &isnull);
 				Assert(!isnull);
 				int32 current_chunk_id = DatumGetInt32(datum);
-				Assert(current_chunk_id != 0);
+				Assert(current_chunk_id != INVALID_CHUNK_ID);
 
 				bool found = false;
 				ChunkScanEntry *entry =
@@ -1820,7 +1820,7 @@ chunk_resurrect(const Hypertable *ht, int chunk_id)
 	Chunk *chunk = NULL;
 	PG_USED_FOR_ASSERTS_ONLY int count = 0;
 
-	Assert(chunk_id != 0);
+	Assert(chunk_id != INVALID_CHUNK_ID);
 
 	iterator = ts_scan_iterator_create(CHUNK, RowExclusiveLock, CurrentMemoryContext);
 	ts_chunk_scan_iterator_set_chunk_id(&iterator, chunk_id);
@@ -1929,7 +1929,7 @@ chunk_point_find_chunk_id(const Hypertable *ht, const Point *p)
 			Datum datum = slot_getattr(ti->slot, Anum_chunk_constraint_chunk_id, &isnull);
 			Assert(!isnull);
 			int32 current_chunk_id = DatumGetInt32(datum);
-			Assert(current_chunk_id != 0);
+			Assert(current_chunk_id != INVALID_CHUNK_ID);
 
 			bool found = false;
 			ChunkScanEntry *entry = hash_search(ctx.htab, &current_chunk_id, HASH_ENTER, &found);
@@ -1959,7 +1959,7 @@ chunk_point_find_chunk_id(const Hypertable *ht, const Point *p)
 			}
 		}
 
-		if (matching_chunk_id != 0)
+		if (matching_chunk_id != INVALID_CHUNK_ID)
 		{
 			break;
 		}


### PR DESCRIPTION
* INVALID_HYPERTABLE_ID
* INVALID_CHUNK_ID
* OidIsValid

Disable-check: force-changelog-file
