### PR TITLE
Update outdated CAgg error hint

### DIFF
--- a/src/process_utility.c
+++ b/src/process_utility.c
@@ -2626,7 +2626,10 @@ process_index_start(ProcessUtilityArgs *args)
 						(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
 						 errmsg("operation not supported on continuous aggregates that are not "
 								"finalized"),
-						 errhint("Recreate the continuous aggregate to allow index creation.")));
+						 errhint("Run \"CALL cagg_migrate('%s.%s');\" to migrate to the new "
+								 "format.",
+								 NameStr(cagg->data.user_view_schema),
+								 NameStr(cagg->data.user_view_name))));
 			}
 		}
 


### PR DESCRIPTION
The CAgg error hint regarding adding indexes to non-finalized CAggs was proposing to recreate the whole CAgg. However, pointing to the migration function should be the preferred method. This PR changes the error wording.

---

Disable-check: force-changelog-file
