### PR TITLE
Remove conditional for trusted in control file

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -397,9 +397,6 @@ if(PG_SOURCE_DIR)
 endif(PG_SOURCE_DIR)
 
 set(EXT_CONTROL_FILE ${PROJECT_NAME}.control)
-if(${PG_VERSION_MAJOR} GREATER "12")
-  set(TRUSTED trusted=true)
-endif()
 
 if(APACHE_ONLY)
   set(LICENSE_EDITION "Apache 2 Edition")

--- a/timescaledb.control.in
+++ b/timescaledb.control.in
@@ -5,4 +5,4 @@ module_pathname = '$libdir/timescaledb-@PROJECT_VERSION_MOD@'
 #extension cannot be relocatable once installed because it uses multiple schemas and that is forbidden by PG.
 #(though this extension is relocatable during installation).
 relocatable = false
-@TRUSTED@
+trusted = true


### PR DESCRIPTION
All postgres versions supported by timescaledb support trusted extensions so we do no longer need the conditional in the control file.