### PR TITLE
Remove `relation_oid` duplicated function

### DIFF
--- a/tsl/src/continuous_aggs/common.c
+++ b/tsl/src/continuous_aggs/common.c
@@ -101,15 +101,6 @@ function_allowed_in_cagg_definition(Oid funcid)
 }
 
 /*
- * Return Oid for a schema-qualified relation.
- */
-Oid
-relation_oid(Name schema, Name name)
-{
-	return get_relname_relid(NameStr(*name), get_namespace_oid(NameStr(*schema), false));
-}
-
-/*
  * When a view is created (StoreViewQuery), 2 dummy rtable entries corresponding to "old" and
  * "new" are prepended to the rtable list. We remove these and adjust the varnos to recreate
  * the user or direct view query.

--- a/tsl/src/continuous_aggs/common.h
+++ b/tsl/src/continuous_aggs/common.h
@@ -114,7 +114,6 @@ extern CAggTimebucketInfo cagg_validate_query(const Query *query, const bool fin
 											  const char *cagg_schema, const char *cagg_name,
 											  const bool is_cagg_create);
 extern Query *destroy_union_query(Query *q);
-extern Oid relation_oid(Name schema, Name name);
 extern void RemoveRangeTableEntries(Query *query);
 extern Query *build_union_query(CAggTimebucketInfo *tbinfo, int matpartcolno, Query *q1, Query *q2,
 								int materialize_htid);

--- a/tsl/src/continuous_aggs/repair.c
+++ b/tsl/src/continuous_aggs/repair.c
@@ -42,7 +42,9 @@ cagg_rebuild_view_definition(ContinuousAgg *agg, Hypertable *mat_ht, bool force_
 	}
 
 	/* Cagg view created by the user. */
-	Oid user_view_oid = relation_oid(&agg->data.user_view_schema, &agg->data.user_view_name);
+	Oid user_view_oid = ts_get_relation_relid(NameStr(agg->data.user_view_schema),
+											  NameStr(agg->data.user_view_name),
+											  false);
 	Relation user_view_rel = relation_open(user_view_oid, AccessShareLock);
 	Query *user_query = get_view_query(user_view_rel);
 
@@ -77,7 +79,9 @@ cagg_rebuild_view_definition(ContinuousAgg *agg, Hypertable *mat_ht, bool force_
 		.objectId = mat_ht->main_table_relid,
 	};
 
-	Oid direct_view_oid = relation_oid(&agg->data.direct_view_schema, &agg->data.direct_view_name);
+	Oid direct_view_oid = ts_get_relation_relid(NameStr(agg->data.direct_view_schema),
+												NameStr(agg->data.direct_view_name),
+												false);
 	Relation direct_view_rel = relation_open(direct_view_oid, AccessShareLock);
 	Query *direct_query = copyObject(get_view_query(direct_view_rel));
 	RemoveRangeTableEntries(direct_query);


### PR DESCRIPTION
We already have `ts_get_relation_relid` that have the same purpose of the `relation_oid` so removed it.

Disable-check: force-changelog-file
