### PR TITLE
Remove MN leftover create distributed hypertable

### DIFF
--- a/sql/updates/2.7.2--2.8.0.sql
+++ b/sql/updates/2.7.2--2.8.0.sql
@@ -131,6 +131,7 @@ CREATE FUNCTION @extschema@.create_hypertable(
 ) RETURNS TABLE(hypertable_id INT, schema_name NAME, table_name NAME, created BOOL) AS '@MODULE_PATHNAME@', 'ts_hypertable_create' LANGUAGE C VOLATILE;
 
 -- change replication_factor to NULL by default
+-- create stub to not introduce shared library dependency
 CREATE FUNCTION @extschema@.create_distributed_hypertable(
     relation                REGCLASS,
     time_column_name        NAME,
@@ -148,4 +149,4 @@ CREATE FUNCTION @extschema@.create_distributed_hypertable(
     time_partitioning_func  REGPROC = NULL,
     replication_factor      INTEGER = NULL,
     data_nodes              NAME[] = NULL
-) RETURNS TABLE(hypertable_id INT, schema_name NAME, table_name NAME, created BOOL) AS '@MODULE_PATHNAME@', 'ts_hypertable_distributed_create' LANGUAGE C VOLATILE;
+) RETURNS TABLE(hypertable_id INT, schema_name NAME, table_name NAME, created BOOL) AS $$ SELECT NULL::int,NULL::name,NULL::name,NULL::bool; $$ LANGUAGE SQL VOLATILE;

--- a/src/hypertable.c
+++ b/src/hypertable.c
@@ -1526,7 +1526,6 @@ create_hypertable_datum(FunctionCallInfo fcinfo, const Hypertable *ht, bool crea
 }
 
 TS_FUNCTION_INFO_V1(ts_hypertable_create);
-TS_FUNCTION_INFO_V1(ts_hypertable_distributed_create);
 TS_FUNCTION_INFO_V1(ts_hypertable_create_general);
 
 /*
@@ -1703,23 +1702,6 @@ Datum
 ts_hypertable_create(PG_FUNCTION_ARGS)
 {
 	return ts_hypertable_create_time_prev(fcinfo, false);
-}
-
-Datum
-ts_hypertable_distributed_create(PG_FUNCTION_ARGS)
-{
-#if PG16_GE
-	ereport(ERROR,
-			(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
-			 errmsg("distributed hypertable is not supported"),
-			 errdetail("Multi-node is not supported anymore on PostgreSQL >= 16.")));
-#else
-	ereport(WARNING,
-			(errcode(ERRCODE_WARNING_DEPRECATED_FEATURE),
-			 errmsg("distributed hypertable is deprecated"),
-			 errdetail("Multi-node is deprecated and will be removed in future releases.")));
-#endif
-	return ts_hypertable_create_time_prev(fcinfo, true);
 }
 
 static Oid


### PR DESCRIPTION
This commit removes an unused function that was used in MN setups to create distributed hypertables.


---

Disable-check: force-changelog-file
