### PR TITLE
Update changed homebrew path

### DIFF
--- a/.github/workflows/homebrew.yaml
+++ b/.github/workflows/homebrew.yaml
@@ -10,6 +10,7 @@ name: Homebrew
     branches:
     - release_test
     - trigger/package_test
+    - trigger/homebrew_test
 
 jobs:
   homebrew:
@@ -28,7 +29,7 @@ jobs:
     - name: Setup
       run: |
         brew install postgresql@16
-        echo "/usr/local/opt/postgresql@16/bin" >> $GITHUB_PATH
+        echo "/opt/homebrew/opt/postgresql@16/bin" >> $GITHUB_PATH
         brew tap timescale/tap
         brew info timescaledb
 


### PR DESCRIPTION
The path to PostgreSQL has changed. This PR adjusts the needed environment variable.

---
Disable-check: force-changelog-file
Failed CI run: https://github.com/timescale/timescaledb/actions/runs/8822548682/job/24221008300
Fixed CI run: https://github.com/timescale/timescaledb/actions/runs/8828786893/job/24238438473?pr=6862