### PR TITLE
Tag variable with PG_USED_FOR_ASSERTS_ONLY

### DIFF
--- a/tsl/src/continuous_aggs/utils.c
+++ b/tsl/src/continuous_aggs/utils.c
@@ -693,7 +693,8 @@ continuous_agg_migrate_to_time_bucket(PG_FUNCTION_ARGS)
 	replace_time_bucket_function_in_catalog(cagg);
 
 	/* Fetch new CAgg definition from catalog */
-	ContinuousAgg *new_cagg_definition = cagg_get_by_relid_or_fail(cagg_relid);
+	ContinuousAgg PG_USED_FOR_ASSERTS_ONLY *new_cagg_definition =
+		cagg_get_by_relid_or_fail(cagg_relid);
 	Assert(new_cagg_definition->bucket_function->bucket_function == new_bucket_function);
 	Assert(cagg->bucket_function->bucket_time_origin ==
 		   new_cagg_definition->bucket_function->bucket_time_origin);


### PR DESCRIPTION
The function continuous_agg_migrate_to_time_bucket contains a variable that is used only for asserts. This PR marks this variable as PG_USED_FOR_ASSERTS_ONLY.

---

Disable-check: force-changelog-file
Failed CI run: https://github.com/timescale/timescaledb/actions/runs/8842109687/job/24280225015
Fixed CI run: https://github.com/timescale/timescaledb/actions/runs/8844950407/job/24287855023?pr=6864