### PR TITLE
Remove permission section from pr handling workflow

### DIFF
--- a/.github/workflows/pr-handling.yaml
+++ b/.github/workflows/pr-handling.yaml
@@ -15,10 +15,9 @@ name: Assign PR to author and reviewers
     types: [ opened, reopened, ready_for_review ]
 
 jobs:
+
   assign-pr:
     name: Assign PR to author
-    permissions:
-      contents: write
     runs-on: ubuntu-latest
     steps:
       - uses: toshimaru/auto-author-assign@v2.1.0


### PR DESCRIPTION
Since changing the default permissions of the GITHUB_TOKEN this workflow was failing with insufficient permissions.

Disable-check: force-changelog-file