### PR TITLE
Fix bool expression pushdown for queries on compressed chunks

### DIFF
--- a/.unreleased/pr_6870
+++ b/.unreleased/pr_6870
@@ -1,0 +1,1 @@
+Fixes: #6870 Fix bool expression pushdown for queries on compressed chunks

--- a/tsl/src/nodes/decompress_chunk/qual_pushdown.c
+++ b/tsl/src/nodes/decompress_chunk/qual_pushdown.c
@@ -328,6 +328,7 @@ modify_expression(Node *node, QualPushdownContext *context)
 			/* opexpr will still be checked for segment by columns */
 			break;
 		}
+		case T_BoolExpr:
 		case T_CoerceViaIO:
 		case T_RelabelType:
 		case T_ScalarArrayOpExpr:

--- a/tsl/test/expected/compression_qualpushdown.out
+++ b/tsl/test/expected/compression_qualpushdown.out
@@ -351,7 +351,7 @@ EXPLAIN (costs off) SELECT '1' FROM deleteme_with_bytea WHERE bdata::text = '123
 DROP table deleteme;
 DROP table deleteme_with_bytea;
 -- test sqlvaluefunction pushdown
-CREATE TABLE svf_pushdown(time timestamptz, c_date date, c_time time, c_timetz timetz, c_timestamp timestamptz, c_name text);
+CREATE TABLE svf_pushdown(time timestamptz, c_date date, c_time time, c_timetz timetz, c_timestamp timestamptz, c_name text, c_bool bool);
 SELECT table_name FROM create_hypertable('svf_pushdown', 'time');
 NOTICE:  adding not-null constraint to column "time"
   table_name  
@@ -359,7 +359,7 @@ NOTICE:  adding not-null constraint to column "time"
  svf_pushdown
 (1 row)
 
-ALTER TABLE svf_pushdown SET (timescaledb.compress,timescaledb.compress_segmentby='c_date,c_time, c_timetz,c_timestamp,c_name');
+ALTER TABLE svf_pushdown SET (timescaledb.compress,timescaledb.compress_segmentby='c_date,c_time, c_timetz,c_timestamp,c_name,c_bool');
 NOTICE:  default order by for hypertable "svf_pushdown" is set to ""time" DESC"
 INSERT INTO svf_pushdown SELECT '2020-01-01';
 SELECT compress_chunk(show_chunks('svf_pushdown'));
@@ -489,6 +489,16 @@ EXPLAIN (costs off) SELECT * FROM svf_pushdown WHERE c_name = SESSION_USER;
                Filter: (c_name = SESSION_USER)
 (5 rows)
 
+EXPLAIN (costs off) SELECT * FROM svf_pushdown WHERE c_name = CURRENT_USER OR c_name = SESSION_USER;
+                                 QUERY PLAN                                 
+----------------------------------------------------------------------------
+ Custom Scan (ChunkAppend) on svf_pushdown
+   Chunks excluded during startup: 0
+   ->  Custom Scan (DecompressChunk) on _hyper_11_12_chunk
+         ->  Seq Scan on compress_hyper_12_13_chunk
+               Filter: ((c_name = CURRENT_USER) OR (c_name = SESSION_USER))
+(5 rows)
+
 EXPLAIN (costs off) SELECT * FROM svf_pushdown WHERE c_name = CURRENT_CATALOG;
                         QUERY PLAN                         
 -----------------------------------------------------------
@@ -508,6 +518,38 @@ EXPLAIN (costs off) SELECT * FROM svf_pushdown WHERE c_name = CURRENT_SCHEMA;
          ->  Seq Scan on compress_hyper_12_13_chunk
                Filter: (c_name = CURRENT_SCHEMA)
 (5 rows)
+
+EXPLAIN (costs off) SELECT * FROM svf_pushdown WHERE c_bool;
+                                                      QUERY PLAN                                                      
+----------------------------------------------------------------------------------------------------------------------
+ Custom Scan (DecompressChunk) on _hyper_11_12_chunk
+   ->  Index Scan using compress_hyper_12_13_chunk_c_date_c_time_c_timetz_c_timesta_idx on compress_hyper_12_13_chunk
+         Index Cond: (c_bool = true)
+(3 rows)
+
+EXPLAIN (costs off) SELECT * FROM svf_pushdown WHERE c_bool = true;
+                                                      QUERY PLAN                                                      
+----------------------------------------------------------------------------------------------------------------------
+ Custom Scan (DecompressChunk) on _hyper_11_12_chunk
+   ->  Index Scan using compress_hyper_12_13_chunk_c_date_c_time_c_timetz_c_timesta_idx on compress_hyper_12_13_chunk
+         Index Cond: (c_bool = true)
+(3 rows)
+
+EXPLAIN (costs off) SELECT * FROM svf_pushdown WHERE c_bool = false;
+                                                      QUERY PLAN                                                      
+----------------------------------------------------------------------------------------------------------------------
+ Custom Scan (DecompressChunk) on _hyper_11_12_chunk
+   ->  Index Scan using compress_hyper_12_13_chunk_c_date_c_time_c_timetz_c_timesta_idx on compress_hyper_12_13_chunk
+         Index Cond: (c_bool = false)
+(3 rows)
+
+EXPLAIN (costs off) SELECT * FROM svf_pushdown WHERE NOT c_bool;
+                                                      QUERY PLAN                                                      
+----------------------------------------------------------------------------------------------------------------------
+ Custom Scan (DecompressChunk) on _hyper_11_12_chunk
+   ->  Index Scan using compress_hyper_12_13_chunk_c_date_c_time_c_timetz_c_timesta_idx on compress_hyper_12_13_chunk
+         Index Cond: (c_bool = false)
+(3 rows)
 
 -- current_query() is not a sqlvaluefunction and volatile so should not be pushed down
 EXPLAIN (costs off) SELECT * FROM svf_pushdown WHERE c_name = current_query();

--- a/tsl/test/expected/transparent_decompression-13.out
+++ b/tsl/test/expected/transparent_decompression-13.out
@@ -1141,8 +1141,8 @@ WHERE time > '2000-01-01 1:00:00+0'
 ORDER BY time,
     device_id
 LIMIT 10;
-                                                      QUERY PLAN                                                      
-----------------------------------------------------------------------------------------------------------------------
+                                                             QUERY PLAN                                                             
+------------------------------------------------------------------------------------------------------------------------------------
  Limit (actual rows=10 loops=1)
    ->  Custom Scan (ChunkAppend) on metrics (actual rows=10 loops=1)
          Order: metrics."time", metrics.device_id
@@ -1153,6 +1153,7 @@ LIMIT 10;
                      Filter: (("time" > 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone) OR (device_id = 1))
                      Rows Removed by Filter: 16
                      ->  Seq Scan on compress_hyper_5_15_chunk (actual rows=5 loops=1)
+                           Filter: ((_ts_meta_max_3 > 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone) OR (device_id = 1))
          ->  Sort (never executed)
                Sort Key: _hyper_1_2_chunk."time", _hyper_1_2_chunk.device_id
                ->  Seq Scan on _hyper_1_2_chunk (never executed)
@@ -1162,7 +1163,8 @@ LIMIT 10;
                ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk (never executed)
                      Filter: (("time" > 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone) OR (device_id = 1))
                      ->  Seq Scan on compress_hyper_5_16_chunk (never executed)
-(19 rows)
+                           Filter: ((_ts_meta_max_3 > 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone) OR (device_id = 1))
+(21 rows)
 
 --functions not yet optimized
 :PREFIX
@@ -4939,8 +4941,8 @@ WHERE time > '2000-01-01 1:00:00+0'
 ORDER BY time,
     device_id
 LIMIT 10;
-                                                            QUERY PLAN                                                            
-----------------------------------------------------------------------------------------------------------------------------------
+                                                                QUERY PLAN                                                                
+------------------------------------------------------------------------------------------------------------------------------------------
  Limit (actual rows=10 loops=1)
    ->  Custom Scan (ChunkAppend) on metrics_space (actual rows=10 loops=1)
          Order: metrics_space."time", metrics_space.device_id
@@ -4952,6 +4954,7 @@ LIMIT 10;
                      ->  Custom Scan (DecompressChunk) on _hyper_2_4_chunk (actual rows=360 loops=1)
                            Filter: (("time" > 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone) OR (device_id = 1))
                            ->  Seq Scan on compress_hyper_6_17_chunk (actual rows=1 loops=1)
+                                 Filter: ((_ts_meta_max_3 > 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone) OR (device_id = 1))
                ->  Sort (actual rows=4 loops=1)
                      Sort Key: _hyper_2_5_chunk."time", _hyper_2_5_chunk.device_id
                      Sort Method: top-N heapsort 
@@ -4959,6 +4962,7 @@ LIMIT 10;
                            Filter: (("time" > 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone) OR (device_id = 1))
                            Rows Removed by Filter: 12
                            ->  Seq Scan on compress_hyper_6_18_chunk (actual rows=3 loops=1)
+                                 Filter: ((_ts_meta_max_3 > 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone) OR (device_id = 1))
                ->  Sort (actual rows=2 loops=1)
                      Sort Key: _hyper_2_6_chunk."time", _hyper_2_6_chunk.device_id
                      Sort Method: top-N heapsort 
@@ -4966,6 +4970,7 @@ LIMIT 10;
                            Filter: (("time" > 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone) OR (device_id = 1))
                            Rows Removed by Filter: 4
                            ->  Seq Scan on compress_hyper_6_19_chunk (actual rows=1 loops=1)
+                                 Filter: ((_ts_meta_max_3 > 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone) OR (device_id = 1))
          ->  Merge Append (never executed)
                Sort Key: _hyper_2_7_chunk."time", _hyper_2_7_chunk.device_id
                ->  Sort (never executed)
@@ -4993,18 +4998,20 @@ LIMIT 10;
                      ->  Custom Scan (DecompressChunk) on _hyper_2_10_chunk (never executed)
                            Filter: (("time" > 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone) OR (device_id = 1))
                            ->  Seq Scan on compress_hyper_6_20_chunk (never executed)
+                                 Filter: ((_ts_meta_max_3 > 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone) OR (device_id = 1))
                ->  Sort (never executed)
                      Sort Key: _hyper_2_11_chunk."time", _hyper_2_11_chunk.device_id
                      ->  Custom Scan (DecompressChunk) on _hyper_2_11_chunk (never executed)
                            Filter: (("time" > 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone) OR (device_id = 1))
                            ->  Seq Scan on compress_hyper_6_21_chunk (never executed)
+                                 Filter: ((_ts_meta_max_3 > 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone) OR (device_id = 1))
                ->  Sort (never executed)
                      Sort Key: _hyper_2_12_chunk."time", _hyper_2_12_chunk.device_id
                      ->  Sort (never executed)
                            Sort Key: _hyper_2_12_chunk."time", _hyper_2_12_chunk.device_id
                            ->  Seq Scan on _hyper_2_12_chunk (never executed)
                                  Filter: (("time" > 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone) OR (device_id = 1))
-(63 rows)
+(68 rows)
 
 --functions not yet optimized
 :PREFIX

--- a/tsl/test/expected/transparent_decompression-14.out
+++ b/tsl/test/expected/transparent_decompression-14.out
@@ -1141,8 +1141,8 @@ WHERE time > '2000-01-01 1:00:00+0'
 ORDER BY time,
     device_id
 LIMIT 10;
-                                                      QUERY PLAN                                                      
-----------------------------------------------------------------------------------------------------------------------
+                                                             QUERY PLAN                                                             
+------------------------------------------------------------------------------------------------------------------------------------
  Limit (actual rows=10 loops=1)
    ->  Custom Scan (ChunkAppend) on metrics (actual rows=10 loops=1)
          Order: metrics."time", metrics.device_id
@@ -1153,6 +1153,7 @@ LIMIT 10;
                      Filter: (("time" > 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone) OR (device_id = 1))
                      Rows Removed by Filter: 16
                      ->  Seq Scan on compress_hyper_5_15_chunk (actual rows=5 loops=1)
+                           Filter: ((_ts_meta_max_3 > 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone) OR (device_id = 1))
          ->  Sort (never executed)
                Sort Key: _hyper_1_2_chunk."time", _hyper_1_2_chunk.device_id
                ->  Seq Scan on _hyper_1_2_chunk (never executed)
@@ -1162,7 +1163,8 @@ LIMIT 10;
                ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk (never executed)
                      Filter: (("time" > 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone) OR (device_id = 1))
                      ->  Seq Scan on compress_hyper_5_16_chunk (never executed)
-(19 rows)
+                           Filter: ((_ts_meta_max_3 > 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone) OR (device_id = 1))
+(21 rows)
 
 --functions not yet optimized
 :PREFIX
@@ -4939,8 +4941,8 @@ WHERE time > '2000-01-01 1:00:00+0'
 ORDER BY time,
     device_id
 LIMIT 10;
-                                                            QUERY PLAN                                                            
-----------------------------------------------------------------------------------------------------------------------------------
+                                                                QUERY PLAN                                                                
+------------------------------------------------------------------------------------------------------------------------------------------
  Limit (actual rows=10 loops=1)
    ->  Custom Scan (ChunkAppend) on metrics_space (actual rows=10 loops=1)
          Order: metrics_space."time", metrics_space.device_id
@@ -4952,6 +4954,7 @@ LIMIT 10;
                      ->  Custom Scan (DecompressChunk) on _hyper_2_4_chunk (actual rows=360 loops=1)
                            Filter: (("time" > 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone) OR (device_id = 1))
                            ->  Seq Scan on compress_hyper_6_17_chunk (actual rows=1 loops=1)
+                                 Filter: ((_ts_meta_max_3 > 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone) OR (device_id = 1))
                ->  Sort (actual rows=4 loops=1)
                      Sort Key: _hyper_2_5_chunk."time", _hyper_2_5_chunk.device_id
                      Sort Method: top-N heapsort 
@@ -4959,6 +4962,7 @@ LIMIT 10;
                            Filter: (("time" > 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone) OR (device_id = 1))
                            Rows Removed by Filter: 12
                            ->  Seq Scan on compress_hyper_6_18_chunk (actual rows=3 loops=1)
+                                 Filter: ((_ts_meta_max_3 > 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone) OR (device_id = 1))
                ->  Sort (actual rows=2 loops=1)
                      Sort Key: _hyper_2_6_chunk."time", _hyper_2_6_chunk.device_id
                      Sort Method: top-N heapsort 
@@ -4966,6 +4970,7 @@ LIMIT 10;
                            Filter: (("time" > 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone) OR (device_id = 1))
                            Rows Removed by Filter: 4
                            ->  Seq Scan on compress_hyper_6_19_chunk (actual rows=1 loops=1)
+                                 Filter: ((_ts_meta_max_3 > 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone) OR (device_id = 1))
          ->  Merge Append (never executed)
                Sort Key: _hyper_2_7_chunk."time", _hyper_2_7_chunk.device_id
                ->  Sort (never executed)
@@ -4993,18 +4998,20 @@ LIMIT 10;
                      ->  Custom Scan (DecompressChunk) on _hyper_2_10_chunk (never executed)
                            Filter: (("time" > 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone) OR (device_id = 1))
                            ->  Seq Scan on compress_hyper_6_20_chunk (never executed)
+                                 Filter: ((_ts_meta_max_3 > 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone) OR (device_id = 1))
                ->  Sort (never executed)
                      Sort Key: _hyper_2_11_chunk."time", _hyper_2_11_chunk.device_id
                      ->  Custom Scan (DecompressChunk) on _hyper_2_11_chunk (never executed)
                            Filter: (("time" > 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone) OR (device_id = 1))
                            ->  Seq Scan on compress_hyper_6_21_chunk (never executed)
+                                 Filter: ((_ts_meta_max_3 > 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone) OR (device_id = 1))
                ->  Sort (never executed)
                      Sort Key: _hyper_2_12_chunk."time", _hyper_2_12_chunk.device_id
                      ->  Sort (never executed)
                            Sort Key: _hyper_2_12_chunk."time", _hyper_2_12_chunk.device_id
                            ->  Seq Scan on _hyper_2_12_chunk (never executed)
                                  Filter: (("time" > 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone) OR (device_id = 1))
-(63 rows)
+(68 rows)
 
 --functions not yet optimized
 :PREFIX

--- a/tsl/test/expected/transparent_decompression-15.out
+++ b/tsl/test/expected/transparent_decompression-15.out
@@ -1142,8 +1142,8 @@ WHERE time > '2000-01-01 1:00:00+0'
 ORDER BY time,
     device_id
 LIMIT 10;
-                                                      QUERY PLAN                                                      
-----------------------------------------------------------------------------------------------------------------------
+                                                             QUERY PLAN                                                             
+------------------------------------------------------------------------------------------------------------------------------------
  Limit (actual rows=10 loops=1)
    ->  Custom Scan (ChunkAppend) on metrics (actual rows=10 loops=1)
          Order: metrics."time", metrics.device_id
@@ -1154,6 +1154,7 @@ LIMIT 10;
                      Filter: (("time" > 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone) OR (device_id = 1))
                      Rows Removed by Filter: 16
                      ->  Seq Scan on compress_hyper_5_15_chunk (actual rows=5 loops=1)
+                           Filter: ((_ts_meta_max_3 > 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone) OR (device_id = 1))
          ->  Sort (never executed)
                Sort Key: _hyper_1_2_chunk."time", _hyper_1_2_chunk.device_id
                ->  Seq Scan on _hyper_1_2_chunk (never executed)
@@ -1163,7 +1164,8 @@ LIMIT 10;
                ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk (never executed)
                      Filter: (("time" > 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone) OR (device_id = 1))
                      ->  Seq Scan on compress_hyper_5_16_chunk (never executed)
-(19 rows)
+                           Filter: ((_ts_meta_max_3 > 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone) OR (device_id = 1))
+(21 rows)
 
 --functions not yet optimized
 :PREFIX
@@ -4913,8 +4915,8 @@ WHERE time > '2000-01-01 1:00:00+0'
 ORDER BY time,
     device_id
 LIMIT 10;
-                                                            QUERY PLAN                                                            
-----------------------------------------------------------------------------------------------------------------------------------
+                                                                QUERY PLAN                                                                
+------------------------------------------------------------------------------------------------------------------------------------------
  Limit (actual rows=10 loops=1)
    ->  Custom Scan (ChunkAppend) on metrics_space (actual rows=10 loops=1)
          Order: metrics_space."time", metrics_space.device_id
@@ -4926,6 +4928,7 @@ LIMIT 10;
                      ->  Custom Scan (DecompressChunk) on _hyper_2_4_chunk (actual rows=360 loops=1)
                            Filter: (("time" > 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone) OR (device_id = 1))
                            ->  Seq Scan on compress_hyper_6_17_chunk (actual rows=1 loops=1)
+                                 Filter: ((_ts_meta_max_3 > 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone) OR (device_id = 1))
                ->  Sort (actual rows=4 loops=1)
                      Sort Key: _hyper_2_5_chunk."time", _hyper_2_5_chunk.device_id
                      Sort Method: top-N heapsort 
@@ -4933,6 +4936,7 @@ LIMIT 10;
                            Filter: (("time" > 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone) OR (device_id = 1))
                            Rows Removed by Filter: 12
                            ->  Seq Scan on compress_hyper_6_18_chunk (actual rows=3 loops=1)
+                                 Filter: ((_ts_meta_max_3 > 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone) OR (device_id = 1))
                ->  Sort (actual rows=2 loops=1)
                      Sort Key: _hyper_2_6_chunk."time", _hyper_2_6_chunk.device_id
                      Sort Method: top-N heapsort 
@@ -4940,6 +4944,7 @@ LIMIT 10;
                            Filter: (("time" > 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone) OR (device_id = 1))
                            Rows Removed by Filter: 4
                            ->  Seq Scan on compress_hyper_6_19_chunk (actual rows=1 loops=1)
+                                 Filter: ((_ts_meta_max_3 > 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone) OR (device_id = 1))
          ->  Merge Append (never executed)
                Sort Key: _hyper_2_7_chunk."time", _hyper_2_7_chunk.device_id
                ->  Sort (never executed)
@@ -4967,18 +4972,20 @@ LIMIT 10;
                      ->  Custom Scan (DecompressChunk) on _hyper_2_10_chunk (never executed)
                            Filter: (("time" > 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone) OR (device_id = 1))
                            ->  Seq Scan on compress_hyper_6_20_chunk (never executed)
+                                 Filter: ((_ts_meta_max_3 > 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone) OR (device_id = 1))
                ->  Sort (never executed)
                      Sort Key: _hyper_2_11_chunk."time", _hyper_2_11_chunk.device_id
                      ->  Custom Scan (DecompressChunk) on _hyper_2_11_chunk (never executed)
                            Filter: (("time" > 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone) OR (device_id = 1))
                            ->  Seq Scan on compress_hyper_6_21_chunk (never executed)
+                                 Filter: ((_ts_meta_max_3 > 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone) OR (device_id = 1))
                ->  Sort (never executed)
                      Sort Key: _hyper_2_12_chunk."time", _hyper_2_12_chunk.device_id
                      ->  Sort (never executed)
                            Sort Key: _hyper_2_12_chunk."time", _hyper_2_12_chunk.device_id
                            ->  Seq Scan on _hyper_2_12_chunk (never executed)
                                  Filter: (("time" > 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone) OR (device_id = 1))
-(63 rows)
+(68 rows)
 
 --functions not yet optimized
 :PREFIX

--- a/tsl/test/expected/transparent_decompression-16.out
+++ b/tsl/test/expected/transparent_decompression-16.out
@@ -1142,8 +1142,8 @@ WHERE time > '2000-01-01 1:00:00+0'
 ORDER BY time,
     device_id
 LIMIT 10;
-                                                      QUERY PLAN                                                      
-----------------------------------------------------------------------------------------------------------------------
+                                                             QUERY PLAN                                                             
+------------------------------------------------------------------------------------------------------------------------------------
  Limit (actual rows=10 loops=1)
    ->  Custom Scan (ChunkAppend) on metrics (actual rows=10 loops=1)
          Order: metrics."time", metrics.device_id
@@ -1154,6 +1154,7 @@ LIMIT 10;
                      Filter: (("time" > 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone) OR (device_id = 1))
                      Rows Removed by Filter: 16
                      ->  Seq Scan on compress_hyper_5_15_chunk (actual rows=5 loops=1)
+                           Filter: ((_ts_meta_max_3 > 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone) OR (device_id = 1))
          ->  Sort (never executed)
                Sort Key: _hyper_1_2_chunk."time", _hyper_1_2_chunk.device_id
                ->  Seq Scan on _hyper_1_2_chunk (never executed)
@@ -1163,7 +1164,8 @@ LIMIT 10;
                ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk (never executed)
                      Filter: (("time" > 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone) OR (device_id = 1))
                      ->  Seq Scan on compress_hyper_5_16_chunk (never executed)
-(19 rows)
+                           Filter: ((_ts_meta_max_3 > 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone) OR (device_id = 1))
+(21 rows)
 
 --functions not yet optimized
 :PREFIX
@@ -4913,8 +4915,8 @@ WHERE time > '2000-01-01 1:00:00+0'
 ORDER BY time,
     device_id
 LIMIT 10;
-                                                            QUERY PLAN                                                            
-----------------------------------------------------------------------------------------------------------------------------------
+                                                                QUERY PLAN                                                                
+------------------------------------------------------------------------------------------------------------------------------------------
  Limit (actual rows=10 loops=1)
    ->  Custom Scan (ChunkAppend) on metrics_space (actual rows=10 loops=1)
          Order: metrics_space."time", metrics_space.device_id
@@ -4926,6 +4928,7 @@ LIMIT 10;
                      ->  Custom Scan (DecompressChunk) on _hyper_2_4_chunk (actual rows=360 loops=1)
                            Filter: (("time" > 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone) OR (device_id = 1))
                            ->  Seq Scan on compress_hyper_6_17_chunk (actual rows=1 loops=1)
+                                 Filter: ((_ts_meta_max_3 > 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone) OR (device_id = 1))
                ->  Sort (actual rows=4 loops=1)
                      Sort Key: _hyper_2_5_chunk."time", _hyper_2_5_chunk.device_id
                      Sort Method: top-N heapsort 
@@ -4933,6 +4936,7 @@ LIMIT 10;
                            Filter: (("time" > 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone) OR (device_id = 1))
                            Rows Removed by Filter: 12
                            ->  Seq Scan on compress_hyper_6_18_chunk (actual rows=3 loops=1)
+                                 Filter: ((_ts_meta_max_3 > 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone) OR (device_id = 1))
                ->  Sort (actual rows=2 loops=1)
                      Sort Key: _hyper_2_6_chunk."time", _hyper_2_6_chunk.device_id
                      Sort Method: top-N heapsort 
@@ -4940,6 +4944,7 @@ LIMIT 10;
                            Filter: (("time" > 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone) OR (device_id = 1))
                            Rows Removed by Filter: 4
                            ->  Seq Scan on compress_hyper_6_19_chunk (actual rows=1 loops=1)
+                                 Filter: ((_ts_meta_max_3 > 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone) OR (device_id = 1))
          ->  Merge Append (never executed)
                Sort Key: _hyper_2_7_chunk."time", _hyper_2_7_chunk.device_id
                ->  Sort (never executed)
@@ -4967,18 +4972,20 @@ LIMIT 10;
                      ->  Custom Scan (DecompressChunk) on _hyper_2_10_chunk (never executed)
                            Filter: (("time" > 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone) OR (device_id = 1))
                            ->  Seq Scan on compress_hyper_6_20_chunk (never executed)
+                                 Filter: ((_ts_meta_max_3 > 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone) OR (device_id = 1))
                ->  Sort (never executed)
                      Sort Key: _hyper_2_11_chunk."time", _hyper_2_11_chunk.device_id
                      ->  Custom Scan (DecompressChunk) on _hyper_2_11_chunk (never executed)
                            Filter: (("time" > 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone) OR (device_id = 1))
                            ->  Seq Scan on compress_hyper_6_21_chunk (never executed)
+                                 Filter: ((_ts_meta_max_3 > 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone) OR (device_id = 1))
                ->  Sort (never executed)
                      Sort Key: _hyper_2_12_chunk."time", _hyper_2_12_chunk.device_id
                      ->  Sort (never executed)
                            Sort Key: _hyper_2_12_chunk."time", _hyper_2_12_chunk.device_id
                            ->  Seq Scan on _hyper_2_12_chunk (never executed)
                                  Filter: (("time" > 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone) OR (device_id = 1))
-(63 rows)
+(68 rows)
 
 --functions not yet optimized
 :PREFIX

--- a/tsl/test/shared/expected/transparent_decompress_chunk-13.out
+++ b/tsl/test/shared/expected/transparent_decompress_chunk-13.out
@@ -398,7 +398,8 @@ QUERY PLAN
                ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk
                      Filter: (("time" > 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone) OR (device_id = 1))
                      ->  Parallel Seq Scan on compress_hyper_X_X_chunk
-(8 rows)
+                           Filter: ((_ts_meta_max_1 > 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone) OR (device_id = 1))
+(9 rows)
 
 --functions not yet optimized
 :PREFIX_NO_VERBOSE SELECT * FROM :TEST_TABLE WHERE time < now() ORDER BY time, device_id LIMIT 10;

--- a/tsl/test/shared/expected/transparent_decompress_chunk-14.out
+++ b/tsl/test/shared/expected/transparent_decompress_chunk-14.out
@@ -398,7 +398,8 @@ QUERY PLAN
                ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk
                      Filter: (("time" > 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone) OR (device_id = 1))
                      ->  Parallel Seq Scan on compress_hyper_X_X_chunk
-(8 rows)
+                           Filter: ((_ts_meta_max_1 > 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone) OR (device_id = 1))
+(9 rows)
 
 --functions not yet optimized
 :PREFIX_NO_VERBOSE SELECT * FROM :TEST_TABLE WHERE time < now() ORDER BY time, device_id LIMIT 10;

--- a/tsl/test/shared/expected/transparent_decompress_chunk-15.out
+++ b/tsl/test/shared/expected/transparent_decompress_chunk-15.out
@@ -400,7 +400,8 @@ QUERY PLAN
                ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk
                      Filter: (("time" > 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone) OR (device_id = 1))
                      ->  Parallel Seq Scan on compress_hyper_X_X_chunk
-(8 rows)
+                           Filter: ((_ts_meta_max_1 > 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone) OR (device_id = 1))
+(9 rows)
 
 --functions not yet optimized
 :PREFIX_NO_VERBOSE SELECT * FROM :TEST_TABLE WHERE time < now() ORDER BY time, device_id LIMIT 10;

--- a/tsl/test/shared/expected/transparent_decompress_chunk-16.out
+++ b/tsl/test/shared/expected/transparent_decompress_chunk-16.out
@@ -400,7 +400,8 @@ QUERY PLAN
                ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk
                      Filter: (("time" > 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone) OR (device_id = 1))
                      ->  Parallel Seq Scan on compress_hyper_X_X_chunk
-(8 rows)
+                           Filter: ((_ts_meta_max_1 > 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone) OR (device_id = 1))
+(9 rows)
 
 --functions not yet optimized
 :PREFIX_NO_VERBOSE SELECT * FROM :TEST_TABLE WHERE time < now() ORDER BY time, device_id LIMIT 10;

--- a/tsl/test/sql/compression_qualpushdown.sql
+++ b/tsl/test/sql/compression_qualpushdown.sql
@@ -155,9 +155,9 @@ DROP table deleteme;
 DROP table deleteme_with_bytea;
 
 -- test sqlvaluefunction pushdown
-CREATE TABLE svf_pushdown(time timestamptz, c_date date, c_time time, c_timetz timetz, c_timestamp timestamptz, c_name text);
+CREATE TABLE svf_pushdown(time timestamptz, c_date date, c_time time, c_timetz timetz, c_timestamp timestamptz, c_name text, c_bool bool);
 SELECT table_name FROM create_hypertable('svf_pushdown', 'time');
-ALTER TABLE svf_pushdown SET (timescaledb.compress,timescaledb.compress_segmentby='c_date,c_time, c_timetz,c_timestamp,c_name');
+ALTER TABLE svf_pushdown SET (timescaledb.compress,timescaledb.compress_segmentby='c_date,c_time, c_timetz,c_timestamp,c_name,c_bool');
 
 INSERT INTO svf_pushdown SELECT '2020-01-01';
 SELECT compress_chunk(show_chunks('svf_pushdown'));
@@ -175,8 +175,13 @@ EXPLAIN (costs off) SELECT * FROM svf_pushdown WHERE c_timestamp = LOCALTIMESTAM
 EXPLAIN (costs off) SELECT * FROM svf_pushdown WHERE c_name = USER;
 EXPLAIN (costs off) SELECT * FROM svf_pushdown WHERE c_name = CURRENT_USER;
 EXPLAIN (costs off) SELECT * FROM svf_pushdown WHERE c_name = SESSION_USER;
+EXPLAIN (costs off) SELECT * FROM svf_pushdown WHERE c_name = CURRENT_USER OR c_name = SESSION_USER;
 EXPLAIN (costs off) SELECT * FROM svf_pushdown WHERE c_name = CURRENT_CATALOG;
 EXPLAIN (costs off) SELECT * FROM svf_pushdown WHERE c_name = CURRENT_SCHEMA;
+EXPLAIN (costs off) SELECT * FROM svf_pushdown WHERE c_bool;
+EXPLAIN (costs off) SELECT * FROM svf_pushdown WHERE c_bool = true;
+EXPLAIN (costs off) SELECT * FROM svf_pushdown WHERE c_bool = false;
+EXPLAIN (costs off) SELECT * FROM svf_pushdown WHERE NOT c_bool;
 
 -- current_query() is not a sqlvaluefunction and volatile so should not be pushed down
 EXPLAIN (costs off) SELECT * FROM svf_pushdown WHERE c_name = current_query();


### PR DESCRIPTION
`NOT column` or `column = false` result in different expressions than other boolean expressions which were not handled in the qual pushdown code. This patch enables pushdown for these expressions and also enables pushdown for OR expressions on compressed chunks.