### PR TITLE
Introduce release notes header template

### DIFF
--- a/.github/workflows/changelog-check.yaml
+++ b/.github/workflows/changelog-check.yaml
@@ -47,7 +47,7 @@ jobs:
           folder=".unreleased"
 
           # Get the list of modified files in this pull request
-          files=$(git --no-pager diff --diff-filter=ACMR --name-only $(git merge-base HEAD ${{ github.event.pull_request.base.sha }}) HEAD)
+          files=$(git --no-pager diff --diff-filter=ACMR --name-only $(git merge-base HEAD ${{ github.event.pull_request.base.sha }}) HEAD ':!.unreleased/*.j2')
 
           if  echo "$BODY" | egrep -qsi "Disable-check:[[:space:]]*force-changelog-file"; then
             # skip changelog checks if forced

--- a/.unreleased/template.release_notes.j2
+++ b/.unreleased/template.release_notes.j2
@@ -1,0 +1,16 @@
+{#
+ # Variables:
+ #   release_current = the release version that has being builded
+ #   release_previous = previous release version
+ #   release_date = date of the release in format YYYY-MM-DD
+ #}
+## {{ release_current }} ({{ release_date }})
+
+This release contains performance improvements and bug fixes since 
+the {{ release_previous }} release. We recommend that you upgrade at the next
+available opportunity.
+
+In addition, it includes these noteworthy features:
+* feature 1
+* feature 2
+* feature N

--- a/scripts/merge_changelogs.sh
+++ b/scripts/merge_changelogs.sh
@@ -1,14 +1,42 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
-# skip the template file
-echo "**Features**"
-grep -i '^Implements:' .unreleased/* | grep -v '.unreleased/template.rfc822' | cut -d: -f3- | sort | uniq | sed -e 's/^[[:space:]]*//' -e 's/^/* /'
-echo
+#
+# This script build a CHANGELOG.md entry for a new release
+#
 
-echo "**Bugfixes**"
-grep -i '^Fixes:' .unreleased/* | grep -v '.unreleased/template.rfc822' | cut -d: -f3- | sort | uniq | sed -e 's/^[[:space:]]*//' -e 's/^/* /'
-echo
+RELEASE_NOTES_TEMPLATE='.unreleased/RELEASE_NOTES.md.j2'
 
-echo "**Thanks**"
-grep -i '^Thanks:' .unreleased/* | grep -v '.unreleased/template.rfc822' | cut -d: -f3- | sort | sed -e 's/^[[:space:]]*//' -e 's/^/* /'
-echo
+echo_changelog() {
+    echo "${1}"
+    # skip the template and release notes files
+    grep -i "${2}" .unreleased/* | \
+        grep -v '.unreleased/template.*' | \
+        grep -v "${RELEASE_NOTES_TEMPLATE}" | \
+        cut -d: -f3- | sort | uniq | sed -e 's/^[[:space:]]*//' -e 's/^/* /'
+    echo
+}
+
+get_version_config_var() {
+    grep "${1}" version.config | awk '{print $3}' | sed 's/-dev//'
+}
+
+RELEASE_CURRENT=$(get_version_config_var '^version')
+RELEASE_PREVIOUS=$(get_version_config_var '^update_from_version')
+RELEASE_DATE=$(date +"%Y-%m-%d")
+
+#
+# To install jinja template client:
+#   $ pip install jinja-cli
+#
+if [ -f "${RELEASE_NOTES_TEMPLATE}" ];
+then
+    jinja \
+        -D release_current "${RELEASE_CURRENT}" \
+        -D release_previous "${RELEASE_PREVIOUS}" \
+        -D release_date "${RELEASE_DATE}" ${RELEASE_NOTES_TEMPLATE}
+    echo
+fi
+
+echo_changelog '**Features**' '^Implements:'
+echo_changelog '**Bugfixes**' '^Fixes:'
+echo_changelog '**Thanks**' '^Thanks:'


### PR DESCRIPTION
This PR introduce the release notes header template using Jinja [1]. Also improved the script to merge changelogs to include the upcoming .unreleased/RELEASE_NOTES_HEADER.md.j2 where we'll actually write the release notes header for the next release.

Disable-check: force-changelog-file
