### PR TITLE
Use session user as internal jobs owner

### DIFF
--- a/sql/job_stat_history_log_retention.sql
+++ b/sql/job_stat_history_log_retention.sql
@@ -64,7 +64,7 @@ VALUES
     INTERVAL '1h',
     '_timescaledb_functions',
     'policy_job_stat_history_retention',
-    pg_catalog.quote_ident(current_role)::regrole,
+    pg_catalog.quote_ident(session_user)::regrole,
     true,
     '{"drop_after":"1 month"}',
     '_timescaledb_functions',


### PR DESCRIPTION
During extension update (aka `ALTER EXTENSION`) Postgres switch the execution user context to the superuser because the extension is marked as trusted. So the `current_role` will return the execution context user but for internal jobs owner what we need is the session context user returned by the `session_user`.

Disable-check: force-changelog-file
