### PR TITLE
Allow DELETE on compressed chunks without decompression

### DIFF
--- a/.unreleased/pr_6882
+++ b/.unreleased/pr_6882
@@ -1,0 +1,1 @@
+Implements: #6882 Allow DELETE on compressed chunks without decompression

--- a/src/guc.c
+++ b/src/guc.c
@@ -69,6 +69,7 @@ bool ts_guc_enable_foreign_key_propagation = true;
 TSDLLEXPORT bool ts_guc_enable_cagg_watermark_constify = true;
 TSDLLEXPORT int ts_guc_cagg_max_individual_materializations = 10;
 bool ts_guc_enable_osm_reads = true;
+TSDLLEXPORT bool ts_guc_enable_compressed_direct_batch_delete = true;
 TSDLLEXPORT bool ts_guc_enable_dml_decompression = true;
 TSDLLEXPORT bool ts_guc_enable_dml_decompression_tuple_filtering = true;
 TSDLLEXPORT int ts_guc_max_tuples_decompressed_per_dml = 100000;
@@ -456,6 +457,17 @@ _guc_init(void)
 							 "Recheck tuples during DML decompression to only decompress batches "
 							 "with matching tuples",
 							 &ts_guc_enable_dml_decompression_tuple_filtering,
+							 true,
+							 PGC_USERSET,
+							 0,
+							 NULL,
+							 NULL,
+							 NULL);
+
+	DefineCustomBoolVariable(MAKE_EXTOPTION("enable_compressed_direct_batch_delete"),
+							 "Enable direct deletion of compressed batches",
+							 "Enable direct batch deletion in compressed chunks",
+							 &ts_guc_enable_compressed_direct_batch_delete,
 							 true,
 							 PGC_USERSET,
 							 0,

--- a/src/guc.h
+++ b/src/guc.h
@@ -31,6 +31,7 @@ extern TSDLLEXPORT bool ts_guc_enable_cagg_watermark_constify;
 extern bool ts_guc_enable_osm_reads;
 extern TSDLLEXPORT bool ts_guc_enable_dml_decompression;
 extern TSDLLEXPORT bool ts_guc_enable_dml_decompression_tuple_filtering;
+extern TSDLLEXPORT bool ts_guc_enable_compressed_direct_batch_delete;
 extern TSDLLEXPORT int ts_guc_max_tuples_decompressed_per_dml;
 extern TSDLLEXPORT bool ts_guc_enable_transparent_decompression;
 extern TSDLLEXPORT bool ts_guc_enable_compression_wal_markers;

--- a/src/nodes/chunk_dispatch/chunk_dispatch.h
+++ b/src/nodes/chunk_dispatch/chunk_dispatch.h
@@ -74,6 +74,7 @@ typedef struct ChunkDispatchState
 	ResultRelInfo *rri;
 	/* flag to represent dropped attributes */
 	bool is_dropped_attr_exists;
+	int64 batches_deleted;
 	int64 batches_filtered;
 	int64 batches_decompressed;
 	int64 tuples_decompressed;

--- a/src/nodes/hypertable_modify.c
+++ b/src/nodes/hypertable_modify.c
@@ -240,6 +240,7 @@ hypertable_modify_explain(CustomScanState *node, List *ancestors, ExplainState *
 		foreach (lc, chunk_dispatch_states)
 		{
 			ChunkDispatchState *cds = (ChunkDispatchState *) lfirst(lc);
+			state->batches_deleted += cds->batches_deleted;
 			state->batches_filtered += cds->batches_filtered;
 			state->batches_decompressed += cds->batches_decompressed;
 			state->tuples_decompressed += cds->tuples_decompressed;
@@ -251,6 +252,8 @@ hypertable_modify_explain(CustomScanState *node, List *ancestors, ExplainState *
 		ExplainPropertyInteger("Batches decompressed", NULL, state->batches_decompressed, es);
 	if (state->tuples_decompressed > 0)
 		ExplainPropertyInteger("Tuples decompressed", NULL, state->tuples_decompressed, es);
+	if (state->batches_deleted > 0)
+		ExplainPropertyInteger("Batches deleted", NULL, state->batches_deleted, es);
 }
 
 static CustomExecMethods hypertable_modify_state_methods = {

--- a/src/nodes/hypertable_modify.h
+++ b/src/nodes/hypertable_modify.h
@@ -32,6 +32,7 @@ typedef struct HypertableModifyState
 	int64 tuples_decompressed;
 	int64 batches_decompressed;
 	int64 batches_filtered;
+	int64 batches_deleted;
 } HypertableModifyState;
 
 extern void ts_hypertable_modify_fixup_tlist(Plan *plan);

--- a/tsl/src/compression/compression.h
+++ b/tsl/src/compression/compression.h
@@ -138,6 +138,8 @@ typedef struct RowDecompressor
 	CommandId mycid;
 	BulkInsertState bistate;
 
+	bool delete_only;
+
 	Datum *compressed_datums;
 	bool *compressed_is_nulls;
 
@@ -147,6 +149,7 @@ typedef struct RowDecompressor
 	MemoryContext per_compressed_row_ctx;
 	int64 batches_decompressed;
 	int64 tuples_decompressed;
+	int64 batches_deleted;
 
 	TupleTableSlot **decompressed_slots;
 	int unprocessed_tuples;
@@ -412,6 +415,7 @@ const CompressionAlgorithmDefinition *algorithm_definition(CompressionAlgorithm 
 
 struct decompress_batches_stats
 {
+	int64 batches_deleted;
 	int64 batches_filtered;
 	int64 batches_decompressed;
 	int64 tuples_decompressed;

--- a/tsl/test/expected/compression_update_delete.out
+++ b/tsl/test/expected/compression_update_delete.out
@@ -980,7 +980,7 @@ FROM compressed_chunk_info_view
 WHERE hypertable_name = 'sample_table' ORDER BY chunk_name;
  chunk_status |     CHUNK_NAME     
 --------------+--------------------
-            9 | _hyper_13_27_chunk
+            1 | _hyper_13_27_chunk
             1 | _hyper_13_28_chunk
 (2 rows)
 
@@ -1143,7 +1143,7 @@ WHERE hypertable_name = 'sample_table' ORDER BY chunk_name;
  chunk_status |     CHUNK_NAME     
 --------------+--------------------
             1 | _hyper_15_31_chunk
-            9 | _hyper_15_32_chunk
+            1 | _hyper_15_32_chunk
 (2 rows)
 
 -- get rowcount from compressed chunks where device_id IS NULL
@@ -2960,6 +2960,10 @@ INSERT INTO test_pushdown SELECT '2020-01-01', 'b';
 INSERT INTO test_pushdown SELECT '2020-01-01 05:00', 'c';
 CREATE TABLE devices(device text);
 INSERT INTO devices VALUES ('a'), ('b'), ('c');
+CREATE TABLE devices2(device text);
+INSERT INTO devices2 VALUES ('d'), ('e'), ('f');
+CREATE TABLE devices3(device text);
+INSERT INTO devices3 VALUES ('b'), ('d'), ('g');
 ALTER TABLE test_pushdown SET (timescaledb.compress, timescaledb.compress_segmentby='device');
 NOTICE:  default order by for hypertable "test_pushdown" is set to ""time" DESC"
 SELECT compress_chunk(show_chunks('test_pushdown'));
@@ -2969,6 +2973,7 @@ SELECT compress_chunk(show_chunks('test_pushdown'));
 (1 row)
 
 -- 3 batch decompressions means pushdown is not working so we expect less than 3 for all these queries
+SET timescaledb.enable_compressed_direct_batch_delete TO false;
 BEGIN; :EXPLAIN DELETE FROM test_pushdown WHERE 'a' = device; ROLLBACK;
                                      QUERY PLAN                                     
 ------------------------------------------------------------------------------------
@@ -3065,6 +3070,7 @@ BEGIN; :EXPLAIN DELETE FROM test_pushdown WHERE 'b' <= device; ROLLBACK;
                Filter: ('b'::text <= device)
 (7 rows)
 
+RESET timescaledb.enable_compressed_direct_batch_delete;
 -- cant pushdown OR atm
 BEGIN; :EXPLAIN DELETE FROM test_pushdown WHERE device = 'a' OR device = 'b'; ROLLBACK;
                                      QUERY PLAN                                     
@@ -3107,8 +3113,10 @@ BEGIN; :EXPLAIN DELETE FROM test_pushdown WHERE device = substring(CURRENT_USER,
                      Filter: (device = ("substring"((CURRENT_USER)::text, (length((CURRENT_USER)::text) + 1)) || 'c'::text))
 (9 rows)
 
+-- JOIN tests
 -- no filtering in decompression
-BEGIN; :EXPLAIN DELETE FROM test_pushdown p USING devices d WHERE p.device=d.device; ROLLBACK;
+SET timescaledb.enable_compressed_direct_batch_delete TO false;
+BEGIN; :EXPLAIN DELETE FROM test_pushdown p USING devices3 d WHERE p.device=d.device; SELECT * FROM test_pushdown p ORDER BY p; ROLLBACK;
                                      QUERY PLAN                                     
 ------------------------------------------------------------------------------------
  Custom Scan (HypertableModify) (actual rows=0 loops=1)
@@ -3116,20 +3124,54 @@ BEGIN; :EXPLAIN DELETE FROM test_pushdown p USING devices d WHERE p.device=d.dev
    Tuples decompressed: 3
    ->  Delete on test_pushdown p (actual rows=0 loops=1)
          Delete on _hyper_39_79_chunk p_1
-         ->  Merge Join (actual rows=3 loops=1)
+         ->  Merge Join (actual rows=1 loops=1)
                Merge Cond: (p_1.device = d.device)
                ->  Sort (actual rows=3 loops=1)
                      Sort Key: p_1.device
                      Sort Method: quicksort 
                      ->  Seq Scan on _hyper_39_79_chunk p_1 (actual rows=3 loops=1)
-               ->  Sort (actual rows=3 loops=1)
+               ->  Sort (actual rows=2 loops=1)
                      Sort Key: d.device
                      Sort Method: quicksort 
-                     ->  Seq Scan on devices d (actual rows=3 loops=1)
+                     ->  Seq Scan on devices3 d (actual rows=3 loops=1)
 (15 rows)
 
+             time             | device 
+------------------------------+--------
+ Wed Jan 01 00:00:00 2020 PST | a
+ Wed Jan 01 05:00:00 2020 PST | c
+(2 rows)
+
+RESET timescaledb.enable_compressed_direct_batch_delete;
+BEGIN; :EXPLAIN DELETE FROM test_pushdown p USING devices3 d WHERE p.device=d.device; SELECT * FROM test_pushdown p ORDER BY p; ROLLBACK;
+                                     QUERY PLAN                                     
+------------------------------------------------------------------------------------
+ Custom Scan (HypertableModify) (actual rows=0 loops=1)
+   Batches decompressed: 3
+   Tuples decompressed: 3
+   ->  Delete on test_pushdown p (actual rows=0 loops=1)
+         Delete on _hyper_39_79_chunk p_1
+         ->  Merge Join (actual rows=1 loops=1)
+               Merge Cond: (p_1.device = d.device)
+               ->  Sort (actual rows=3 loops=1)
+                     Sort Key: p_1.device
+                     Sort Method: quicksort 
+                     ->  Seq Scan on _hyper_39_79_chunk p_1 (actual rows=3 loops=1)
+               ->  Sort (actual rows=2 loops=1)
+                     Sort Key: d.device
+                     Sort Method: quicksort 
+                     ->  Seq Scan on devices3 d (actual rows=3 loops=1)
+(15 rows)
+
+             time             | device 
+------------------------------+--------
+ Wed Jan 01 00:00:00 2020 PST | a
+ Wed Jan 01 05:00:00 2020 PST | c
+(2 rows)
+
 -- can filter in decompression even before executing join
-BEGIN; :EXPLAIN DELETE FROM test_pushdown p USING devices d WHERE p.device=d.device AND d.device ='b' ; ROLLBACK;
+SET timescaledb.enable_compressed_direct_batch_delete TO false;
+BEGIN; :EXPLAIN DELETE FROM test_pushdown p USING devices d WHERE p.device=d.device AND d.device ='b'; SELECT * FROM test_pushdown p ORDER BY p; ROLLBACK;
                                      QUERY PLAN                                     
 ------------------------------------------------------------------------------------
  Custom Scan (HypertableModify) (actual rows=0 loops=1)
@@ -3146,8 +3188,39 @@ BEGIN; :EXPLAIN DELETE FROM test_pushdown p USING devices d WHERE p.device=d.dev
                            Filter: (device = 'b'::text)
 (12 rows)
 
+             time             | device 
+------------------------------+--------
+ Wed Jan 01 00:00:00 2020 PST | a
+ Wed Jan 01 05:00:00 2020 PST | c
+(2 rows)
+
+RESET timescaledb.enable_compressed_direct_batch_delete;
+BEGIN; :EXPLAIN DELETE FROM test_pushdown p USING devices d WHERE p.device=d.device AND d.device ='b'; SELECT * FROM test_pushdown p ORDER BY p; ROLLBACK;
+                                     QUERY PLAN                                     
+------------------------------------------------------------------------------------
+ Custom Scan (HypertableModify) (actual rows=0 loops=1)
+   Batches decompressed: 1
+   Tuples decompressed: 1
+   ->  Delete on test_pushdown p (actual rows=0 loops=1)
+         Delete on _hyper_39_79_chunk p_1
+         ->  Nested Loop (actual rows=1 loops=1)
+               ->  Seq Scan on devices d (actual rows=1 loops=1)
+                     Filter: (device = 'b'::text)
+                     Rows Removed by Filter: 2
+               ->  Materialize (actual rows=1 loops=1)
+                     ->  Seq Scan on _hyper_39_79_chunk p_1 (actual rows=1 loops=1)
+                           Filter: (device = 'b'::text)
+(12 rows)
+
+             time             | device 
+------------------------------+--------
+ Wed Jan 01 00:00:00 2020 PST | a
+ Wed Jan 01 05:00:00 2020 PST | c
+(2 rows)
+
 -- test prepared statement
 PREPARE q1(text) AS DELETE FROM test_pushdown WHERE device = $1;
+SET timescaledb.enable_compressed_direct_batch_delete TO false;
 BEGIN; :EXPLAIN EXECUTE q1('a'); ROLLBACK;
                                      QUERY PLAN                                     
 ------------------------------------------------------------------------------------
@@ -3160,30 +3233,50 @@ BEGIN; :EXPLAIN EXECUTE q1('a'); ROLLBACK;
                Filter: (device = 'a'::text)
 (7 rows)
 
+RESET timescaledb.enable_compressed_direct_batch_delete;
+BEGIN; :EXPLAIN EXECUTE q1('a'); ROLLBACK;
+                                     QUERY PLAN                                     
+------------------------------------------------------------------------------------
+ Custom Scan (HypertableModify) (actual rows=0 loops=1)
+   Batches deleted: 1
+   ->  Delete on test_pushdown (actual rows=0 loops=1)
+         Delete on _hyper_39_79_chunk test_pushdown_1
+         ->  Seq Scan on _hyper_39_79_chunk test_pushdown_1 (actual rows=0 loops=1)
+               Filter: (device = 'a'::text)
+(6 rows)
+
+BEGIN; :EXPLAIN EXECUTE q1('not here'); ROLLBACK;
+                                     QUERY PLAN                                     
+------------------------------------------------------------------------------------
+ Custom Scan (HypertableModify) (actual rows=0 loops=1)
+   ->  Delete on test_pushdown (actual rows=0 loops=1)
+         Delete on _hyper_39_79_chunk test_pushdown_1
+         ->  Seq Scan on _hyper_39_79_chunk test_pushdown_1 (actual rows=0 loops=1)
+               Filter: (device = 'not here'::text)
+(5 rows)
+
 -- test arrayop pushdown less than 3 decompressions are expected for successful pushdown
 BEGIN; :EXPLAIN DELETE FROM test_pushdown WHERE device IN ('a','d'); ROLLBACK;
                                      QUERY PLAN                                     
 ------------------------------------------------------------------------------------
  Custom Scan (HypertableModify) (actual rows=0 loops=1)
-   Batches decompressed: 1
-   Tuples decompressed: 1
+   Batches deleted: 1
    ->  Delete on test_pushdown (actual rows=0 loops=1)
          Delete on _hyper_39_79_chunk test_pushdown_1
-         ->  Seq Scan on _hyper_39_79_chunk test_pushdown_1 (actual rows=1 loops=1)
+         ->  Seq Scan on _hyper_39_79_chunk test_pushdown_1 (actual rows=0 loops=1)
                Filter: (device = ANY ('{a,d}'::text[]))
-(7 rows)
+(6 rows)
 
 BEGIN; :EXPLAIN DELETE FROM test_pushdown WHERE device = ANY('{a,d}'); ROLLBACK;
                                      QUERY PLAN                                     
 ------------------------------------------------------------------------------------
  Custom Scan (HypertableModify) (actual rows=0 loops=1)
-   Batches decompressed: 1
-   Tuples decompressed: 1
+   Batches deleted: 1
    ->  Delete on test_pushdown (actual rows=0 loops=1)
          Delete on _hyper_39_79_chunk test_pushdown_1
-         ->  Seq Scan on _hyper_39_79_chunk test_pushdown_1 (actual rows=1 loops=1)
+         ->  Seq Scan on _hyper_39_79_chunk test_pushdown_1 (actual rows=0 loops=1)
                Filter: (device = ANY ('{a,d}'::text[]))
-(7 rows)
+(6 rows)
 
 BEGIN; :EXPLAIN DELETE FROM test_pushdown WHERE device IN ('a',CURRENT_USER); ROLLBACK;
                                         QUERY PLAN                                        

--- a/tsl/test/expected/foreign_keys.out
+++ b/tsl/test/expected/foreign_keys.out
@@ -761,7 +761,8 @@ SELECT * FROM ht;
 (1 row)
 
 ROLLBACK;
--- ON DELETE CASCADE with compression
+-- ON DELETE CASCADE with compression without direct batch delete
+SET timescaledb.enable_compressed_direct_batch_delete TO false;
 BEGIN;
 INSERT INTO fk_cascade(fk_cascade) VALUES ('fk_cascade');
 INSERT INTO ht(time, fk_cascade) VALUES ('2020-01-01', 'fk_cascade');
@@ -787,6 +788,33 @@ EXPLAIN (analyze, costs off, timing off, summary off) SELECT * FROM ht;
          ->  Seq Scan on compress_hyper_14_20_chunk (actual rows=1 loops=1)
    ->  Seq Scan on _hyper_13_14_chunk (actual rows=0 loops=1)
 (4 rows)
+
+ROLLBACK;
+RESET timescaledb.enable_compressed_direct_batch_delete;
+-- ON DELETE CASCADE with compression and direct batch delete
+BEGIN;
+INSERT INTO fk_cascade(fk_cascade) VALUES ('fk_cascade');
+INSERT INTO ht(time, fk_cascade) VALUES ('2020-01-01', 'fk_cascade');
+SELECT count(compress_chunk(ch)) FROM show_chunks('ht') ch;
+ count 
+-------
+     1
+(1 row)
+
+-- should cascade
+DELETE FROM fk_cascade;
+SELECT * FROM ht;
+             time             | fk_no_action | fk_restrict | fk_cascade | fk_set_null | fk_set_default 
+------------------------------+--------------+-------------+------------+-------------+----------------
+ Wed Jan 01 00:00:00 2020 PST |              |             |            |             | default
+(1 row)
+
+EXPLAIN (analyze, costs off, timing off, summary off) SELECT * FROM ht;
+                                 QUERY PLAN                                  
+-----------------------------------------------------------------------------
+ Custom Scan (DecompressChunk) on _hyper_13_14_chunk (actual rows=1 loops=1)
+   ->  Seq Scan on compress_hyper_14_21_chunk (actual rows=1 loops=1)
+(2 rows)
 
 ROLLBACK;
 -- SET NULL
@@ -831,7 +859,7 @@ EXPLAIN (analyze, costs off, timing off, summary off) SELECT * FROM ht;
 -----------------------------------------------------------------------------------
  Append (actual rows=2 loops=1)
    ->  Custom Scan (DecompressChunk) on _hyper_13_14_chunk (actual rows=1 loops=1)
-         ->  Seq Scan on compress_hyper_14_21_chunk (actual rows=1 loops=1)
+         ->  Seq Scan on compress_hyper_14_22_chunk (actual rows=1 loops=1)
    ->  Seq Scan on _hyper_13_14_chunk (actual rows=1 loops=1)
 (4 rows)
 
@@ -874,7 +902,7 @@ EXPLAIN (analyze, costs off, timing off, summary off) SELECT * FROM ht;
 -----------------------------------------------------------------------------------
  Append (actual rows=2 loops=1)
    ->  Custom Scan (DecompressChunk) on _hyper_13_14_chunk (actual rows=1 loops=1)
-         ->  Seq Scan on compress_hyper_14_22_chunk (actual rows=1 loops=1)
+         ->  Seq Scan on compress_hyper_14_23_chunk (actual rows=1 loops=1)
    ->  Seq Scan on _hyper_13_14_chunk (actual rows=1 loops=1)
 (4 rows)
 
@@ -933,7 +961,7 @@ EXPLAIN (analyze, costs off, timing off, summary off) SELECT * FROM ht;
 -----------------------------------------------------------------------------------
  Append (actual rows=2 loops=1)
    ->  Custom Scan (DecompressChunk) on _hyper_13_14_chunk (actual rows=1 loops=1)
-         ->  Seq Scan on compress_hyper_14_23_chunk (actual rows=1 loops=1)
+         ->  Seq Scan on compress_hyper_14_24_chunk (actual rows=1 loops=1)
    ->  Seq Scan on _hyper_13_14_chunk (actual rows=1 loops=1)
 (4 rows)
 
@@ -981,7 +1009,7 @@ EXPLAIN (analyze, costs off, timing off, summary off) SELECT * FROM ht;
 -----------------------------------------------------------------------------------
  Append (actual rows=2 loops=1)
    ->  Custom Scan (DecompressChunk) on _hyper_13_14_chunk (actual rows=1 loops=1)
-         ->  Seq Scan on compress_hyper_14_24_chunk (actual rows=1 loops=1)
+         ->  Seq Scan on compress_hyper_14_25_chunk (actual rows=1 loops=1)
    ->  Seq Scan on _hyper_13_14_chunk (actual rows=1 loops=1)
 (4 rows)
 

--- a/tsl/test/shared/expected/compression_dml.out
+++ b/tsl/test/shared/expected/compression_dml.out
@@ -415,3 +415,170 @@ QUERY PLAN
 
 RESET timescaledb.enable_dml_decompression_tuple_filtering;
 DROP TABLE lazy_decompress;
+CREATE FUNCTION trigger_function() RETURNS TRIGGER LANGUAGE PLPGSQL
+AS $$
+BEGIN
+  RAISE WARNING 'Trigger fired';
+  RETURN NEW;
+END;
+$$;
+-- test direct delete on compressed hypertable
+CREATE TABLE direct_delete(time timestamptz not null, device text, reading text, value float);
+SELECT table_name FROM create_hypertable('direct_delete', 'time');
+  table_name   
+ direct_delete
+(1 row)
+
+ALTER TABLE direct_delete SET (timescaledb.compress, timescaledb.compress_segmentby = 'device, reading');
+NOTICE:  default order by for hypertable "direct_delete" is set to ""time" DESC"
+INSERT INTO direct_delete VALUES
+('2021-01-01', 'd1', 'r1', 1.0),
+('2021-01-01', 'd1', 'r2', 1.0),
+('2021-01-01', 'd1', 'r3', 1.0),
+('2021-01-01', 'd2', 'r1', 1.0),
+('2021-01-01', 'd2', 'r2', 1.0),
+('2021-01-01', 'd2', 'r3', 1.0);
+SELECT count(compress_chunk(c)) FROM show_chunks('direct_delete') c;
+ count 
+     1
+(1 row)
+
+BEGIN;
+-- should be 3 batches directly deleted
+:ANALYZE DELETE FROM direct_delete WHERE device='d1';
+QUERY PLAN
+ Custom Scan (HypertableModify) (actual rows=0 loops=1)
+   Batches deleted: 3
+   ->  Delete on direct_delete (actual rows=0 loops=1)
+         Delete on _hyper_X_X_chunk direct_delete_1
+         ->  Seq Scan on _hyper_X_X_chunk direct_delete_1 (actual rows=0 loops=1)
+               Filter: (device = 'd1'::text)
+(6 rows)
+
+-- double check its actually deleted
+SELECT count(*) FROM direct_delete WHERE device='d1';
+ count 
+     0
+(1 row)
+
+ROLLBACK;
+BEGIN;
+-- should be 2 batches directly deleted
+:ANALYZE DELETE FROM direct_delete WHERE reading='r2';
+QUERY PLAN
+ Custom Scan (HypertableModify) (actual rows=0 loops=1)
+   Batches deleted: 2
+   ->  Delete on direct_delete (actual rows=0 loops=1)
+         Delete on _hyper_X_X_chunk direct_delete_1
+         ->  Seq Scan on _hyper_X_X_chunk direct_delete_1 (actual rows=0 loops=1)
+               Filter: (reading = 'r2'::text)
+(6 rows)
+
+-- double check its actually deleted
+SELECT count(*) FROM direct_delete WHERE reading='r2';
+ count 
+     0
+(1 row)
+
+ROLLBACK;
+-- combining constraints on segmentby columns should work
+BEGIN;
+-- should be 1 batches directly deleted
+:ANALYZE DELETE FROM direct_delete WHERE device='d1' AND reading='r2';
+QUERY PLAN
+ Custom Scan (HypertableModify) (actual rows=0 loops=1)
+   Batches deleted: 1
+   ->  Delete on direct_delete (actual rows=0 loops=1)
+         Delete on _hyper_X_X_chunk direct_delete_1
+         ->  Seq Scan on _hyper_X_X_chunk direct_delete_1 (actual rows=0 loops=1)
+               Filter: ((device = 'd1'::text) AND (reading = 'r2'::text))
+(6 rows)
+
+-- double check its actually deleted
+SELECT count(*) FROM direct_delete WHERE device='d1' AND reading='r2';
+ count 
+     0
+(1 row)
+
+ROLLBACK;
+-- constraints involving non-segmentby columns should not directly delete
+BEGIN; :ANALYZE DELETE FROM direct_delete WHERE value = '1.0'; ROLLBACK;
+QUERY PLAN
+ Custom Scan (HypertableModify) (actual rows=0 loops=1)
+   Batches decompressed: 6
+   Tuples decompressed: 6
+   ->  Delete on direct_delete (actual rows=0 loops=1)
+         Delete on _hyper_X_X_chunk direct_delete_1
+         ->  Seq Scan on _hyper_X_X_chunk direct_delete_1 (actual rows=6 loops=1)
+               Filter: (value = '1'::double precision)
+(7 rows)
+
+BEGIN; :ANALYZE DELETE FROM direct_delete WHERE device = 'd1' AND value = '1.0'; ROLLBACK;
+QUERY PLAN
+ Custom Scan (HypertableModify) (actual rows=0 loops=1)
+   Batches decompressed: 3
+   Tuples decompressed: 3
+   ->  Delete on direct_delete (actual rows=0 loops=1)
+         Delete on _hyper_X_X_chunk direct_delete_1
+         ->  Seq Scan on _hyper_X_X_chunk direct_delete_1 (actual rows=3 loops=1)
+               Filter: ((device = 'd1'::text) AND (value = '1'::double precision))
+(7 rows)
+
+BEGIN; :ANALYZE DELETE FROM direct_delete WHERE reading = 'r1' AND value = '1.0'; ROLLBACK;
+QUERY PLAN
+ Custom Scan (HypertableModify) (actual rows=0 loops=1)
+   Batches decompressed: 2
+   Tuples decompressed: 2
+   ->  Delete on direct_delete (actual rows=0 loops=1)
+         Delete on _hyper_X_X_chunk direct_delete_1
+         ->  Seq Scan on _hyper_X_X_chunk direct_delete_1 (actual rows=2 loops=1)
+               Filter: ((reading = 'r1'::text) AND (value = '1'::double precision))
+(7 rows)
+
+BEGIN; :ANALYZE DELETE FROM direct_delete WHERE device = 'd2' AND reading = 'r3' AND value = '1.0'; ROLLBACK;
+QUERY PLAN
+ Custom Scan (HypertableModify) (actual rows=0 loops=1)
+   Batches decompressed: 1
+   Tuples decompressed: 1
+   ->  Delete on direct_delete (actual rows=0 loops=1)
+         Delete on _hyper_X_X_chunk direct_delete_1
+         ->  Seq Scan on _hyper_X_X_chunk direct_delete_1 (actual rows=1 loops=1)
+               Filter: ((device = 'd2'::text) AND (reading = 'r3'::text) AND (value = '1'::double precision))
+(7 rows)
+
+-- presence of trigger should prevent direct delete
+CREATE TRIGGER direct_delete_trigger BEFORE DELETE ON direct_delete FOR EACH ROW EXECUTE FUNCTION trigger_function();
+BEGIN; :ANALYZE DELETE FROM direct_delete WHERE device = 'd1'; ROLLBACK;
+WARNING:  Trigger fired
+WARNING:  Trigger fired
+WARNING:  Trigger fired
+QUERY PLAN
+ Custom Scan (HypertableModify) (actual rows=0 loops=1)
+   Batches decompressed: 3
+   Tuples decompressed: 3
+   ->  Delete on direct_delete (actual rows=0 loops=1)
+         Delete on _hyper_X_X_chunk direct_delete_1
+         ->  Seq Scan on _hyper_X_X_chunk direct_delete_1 (actual rows=3 loops=1)
+               Filter: (device = 'd1'::text)
+ Trigger direct_delete_trigger on _hyper_X_X_chunk: calls=3
+(8 rows)
+
+DROP TRIGGER direct_delete_trigger ON direct_delete;
+CREATE TRIGGER direct_delete_trigger AFTER DELETE ON direct_delete FOR EACH ROW EXECUTE FUNCTION trigger_function();
+BEGIN; :ANALYZE DELETE FROM direct_delete WHERE device = 'd1'; ROLLBACK;
+WARNING:  Trigger fired
+WARNING:  Trigger fired
+WARNING:  Trigger fired
+QUERY PLAN
+ Custom Scan (HypertableModify) (actual rows=0 loops=1)
+   Batches decompressed: 3
+   Tuples decompressed: 3
+   ->  Delete on direct_delete (actual rows=0 loops=1)
+         Delete on _hyper_X_X_chunk direct_delete_1
+         ->  Seq Scan on _hyper_X_X_chunk direct_delete_1 (actual rows=3 loops=1)
+               Filter: (device = 'd1'::text)
+ Trigger direct_delete_trigger on _hyper_X_X_chunk: calls=3
+(8 rows)
+
+DROP TRIGGER direct_delete_trigger ON direct_delete;
+DROP TABLE direct_delete;

--- a/tsl/test/shared/expected/decompress_tracking.out
+++ b/tsl/test/shared/expected/decompress_tracking.out
@@ -63,6 +63,7 @@ QUERY PLAN
                            Filter: (device = 'd2'::text)
 (12 rows)
 
+SET timescaledb.enable_compressed_direct_batch_delete TO false;
 BEGIN; :EXPLAIN_ANALYZE DELETE FROM decompress_tracking; ROLLBACK;
 QUERY PLAN
  Custom Scan (HypertableModify) (actual rows=0 loops=1)
@@ -90,6 +91,33 @@ QUERY PLAN
                ->  Seq Scan on _hyper_X_X_chunk decompress_tracking_2 (actual rows=15 loops=1)
                      Filter: (device = 'd3'::text)
 (11 rows)
+
+RESET timescaledb.enable_compressed_direct_batch_delete;
+BEGIN; :EXPLAIN_ANALYZE DELETE FROM decompress_tracking; ROLLBACK;
+QUERY PLAN
+ Custom Scan (HypertableModify) (actual rows=0 loops=1)
+   Batches deleted: 5
+   ->  Delete on decompress_tracking (actual rows=0 loops=1)
+         Delete on _hyper_X_X_chunk decompress_tracking_1
+         Delete on _hyper_X_X_chunk decompress_tracking_2
+         ->  Append (actual rows=0 loops=1)
+               ->  Seq Scan on _hyper_X_X_chunk decompress_tracking_1 (actual rows=0 loops=1)
+               ->  Seq Scan on _hyper_X_X_chunk decompress_tracking_2 (actual rows=0 loops=1)
+(8 rows)
+
+BEGIN; :EXPLAIN_ANALYZE DELETE FROM decompress_tracking WHERE device = 'd3'; ROLLBACK;
+QUERY PLAN
+ Custom Scan (HypertableModify) (actual rows=0 loops=1)
+   Batches deleted: 2
+   ->  Delete on decompress_tracking (actual rows=0 loops=1)
+         Delete on _hyper_X_X_chunk decompress_tracking_1
+         Delete on _hyper_X_X_chunk decompress_tracking_2
+         ->  Append (actual rows=0 loops=1)
+               ->  Seq Scan on _hyper_X_X_chunk decompress_tracking_1 (actual rows=0 loops=1)
+                     Filter: (device = 'd3'::text)
+               ->  Seq Scan on _hyper_X_X_chunk decompress_tracking_2 (actual rows=0 loops=1)
+                     Filter: (device = 'd3'::text)
+(10 rows)
 
 BEGIN; :EXPLAIN_ANALYZE INSERT INTO decompress_tracking SELECT '2020-01-01 1:30','d1',random(); ROLLBACK;
 QUERY PLAN

--- a/tsl/test/shared/sql/compression_dml.sql
+++ b/tsl/test/shared/sql/compression_dml.sql
@@ -188,3 +188,66 @@ RESET timescaledb.enable_dml_decompression_tuple_filtering;
 
 DROP TABLE lazy_decompress;
 
+CREATE FUNCTION trigger_function() RETURNS TRIGGER LANGUAGE PLPGSQL
+AS $$
+BEGIN
+  RAISE WARNING 'Trigger fired';
+  RETURN NEW;
+END;
+$$;
+
+-- test direct delete on compressed hypertable
+CREATE TABLE direct_delete(time timestamptz not null, device text, reading text, value float);
+SELECT table_name FROM create_hypertable('direct_delete', 'time');
+
+ALTER TABLE direct_delete SET (timescaledb.compress, timescaledb.compress_segmentby = 'device, reading');
+INSERT INTO direct_delete VALUES
+('2021-01-01', 'd1', 'r1', 1.0),
+('2021-01-01', 'd1', 'r2', 1.0),
+('2021-01-01', 'd1', 'r3', 1.0),
+('2021-01-01', 'd2', 'r1', 1.0),
+('2021-01-01', 'd2', 'r2', 1.0),
+('2021-01-01', 'd2', 'r3', 1.0);
+
+SELECT count(compress_chunk(c)) FROM show_chunks('direct_delete') c;
+
+BEGIN;
+-- should be 3 batches directly deleted
+:ANALYZE DELETE FROM direct_delete WHERE device='d1';
+-- double check its actually deleted
+SELECT count(*) FROM direct_delete WHERE device='d1';
+ROLLBACK;
+
+BEGIN;
+-- should be 2 batches directly deleted
+:ANALYZE DELETE FROM direct_delete WHERE reading='r2';
+-- double check its actually deleted
+SELECT count(*) FROM direct_delete WHERE reading='r2';
+ROLLBACK;
+
+-- combining constraints on segmentby columns should work
+BEGIN;
+-- should be 1 batches directly deleted
+:ANALYZE DELETE FROM direct_delete WHERE device='d1' AND reading='r2';
+-- double check its actually deleted
+SELECT count(*) FROM direct_delete WHERE device='d1' AND reading='r2';
+ROLLBACK;
+
+-- constraints involving non-segmentby columns should not directly delete
+BEGIN; :ANALYZE DELETE FROM direct_delete WHERE value = '1.0'; ROLLBACK;
+BEGIN; :ANALYZE DELETE FROM direct_delete WHERE device = 'd1' AND value = '1.0'; ROLLBACK;
+BEGIN; :ANALYZE DELETE FROM direct_delete WHERE reading = 'r1' AND value = '1.0'; ROLLBACK;
+BEGIN; :ANALYZE DELETE FROM direct_delete WHERE device = 'd2' AND reading = 'r3' AND value = '1.0'; ROLLBACK;
+
+-- presence of trigger should prevent direct delete
+CREATE TRIGGER direct_delete_trigger BEFORE DELETE ON direct_delete FOR EACH ROW EXECUTE FUNCTION trigger_function();
+BEGIN; :ANALYZE DELETE FROM direct_delete WHERE device = 'd1'; ROLLBACK;
+DROP TRIGGER direct_delete_trigger ON direct_delete;
+
+CREATE TRIGGER direct_delete_trigger AFTER DELETE ON direct_delete FOR EACH ROW EXECUTE FUNCTION trigger_function();
+BEGIN; :ANALYZE DELETE FROM direct_delete WHERE device = 'd1'; ROLLBACK;
+DROP TRIGGER direct_delete_trigger ON direct_delete;
+
+
+DROP TABLE direct_delete;
+

--- a/tsl/test/shared/sql/decompress_tracking.sql
+++ b/tsl/test/shared/sql/decompress_tracking.sql
@@ -22,8 +22,15 @@ ANALYZE decompress_tracking;
 
 BEGIN; :EXPLAIN_ANALYZE UPDATE decompress_tracking SET value = value + 3; ROLLBACK;
 BEGIN; :EXPLAIN_ANALYZE UPDATE decompress_tracking SET value = value + 3 WHERE device = 'd2'; ROLLBACK;
+
+SET timescaledb.enable_compressed_direct_batch_delete TO false;
 BEGIN; :EXPLAIN_ANALYZE DELETE FROM decompress_tracking; ROLLBACK;
 BEGIN; :EXPLAIN_ANALYZE DELETE FROM decompress_tracking WHERE device = 'd3'; ROLLBACK;
+RESET timescaledb.enable_compressed_direct_batch_delete;
+
+BEGIN; :EXPLAIN_ANALYZE DELETE FROM decompress_tracking; ROLLBACK;
+BEGIN; :EXPLAIN_ANALYZE DELETE FROM decompress_tracking WHERE device = 'd3'; ROLLBACK;
+
 BEGIN; :EXPLAIN_ANALYZE INSERT INTO decompress_tracking SELECT '2020-01-01 1:30','d1',random(); ROLLBACK;
 BEGIN; :EXPLAIN_ANALYZE INSERT INTO decompress_tracking SELECT '2020-01-01','d2',random(); ROLLBACK;
 BEGIN; :EXPLAIN_ANALYZE INSERT INTO decompress_tracking SELECT '2020-01-01','d4',random(); ROLLBACK;

--- a/tsl/test/sql/foreign_keys.sql
+++ b/tsl/test/sql/foreign_keys.sql
@@ -531,7 +531,20 @@ DELETE FROM fk_cascade;
 SELECT * FROM ht;
 ROLLBACK;
 
--- ON DELETE CASCADE with compression
+-- ON DELETE CASCADE with compression without direct batch delete
+SET timescaledb.enable_compressed_direct_batch_delete TO false;
+BEGIN;
+INSERT INTO fk_cascade(fk_cascade) VALUES ('fk_cascade');
+INSERT INTO ht(time, fk_cascade) VALUES ('2020-01-01', 'fk_cascade');
+SELECT count(compress_chunk(ch)) FROM show_chunks('ht') ch;
+-- should cascade
+DELETE FROM fk_cascade;
+SELECT * FROM ht;
+EXPLAIN (analyze, costs off, timing off, summary off) SELECT * FROM ht;
+ROLLBACK;
+RESET timescaledb.enable_compressed_direct_batch_delete;
+
+-- ON DELETE CASCADE with compression and direct batch delete
 BEGIN;
 INSERT INTO fk_cascade(fk_cascade) VALUES ('fk_cascade');
 INSERT INTO ht(time, fk_cascade) VALUES ('2020-01-01', 'fk_cascade');


### PR DESCRIPTION
When the constraints of a DELETE on a compressed chunks fully cover the batches we can optimize the DELETE to work directly on the compressed batches and skip the expensive decompression part.