### PR TITLE
Add support for transition tables

### DIFF
--- a/.unreleased/pr_6901
+++ b/.unreleased/pr_6901
@@ -1,0 +1,1 @@
+Implements: #6901 Add hypertable support for transition tables

--- a/src/hypertable.c
+++ b/src/hypertable.c
@@ -1925,13 +1925,10 @@ ts_hypertable_create_from_info(Oid table_relid, int32 hypertable_id, uint32 flag
 		hypertable_create_schema(NameStr(*associated_schema_name));
 
 	/*
-	 * Hypertables do not support transition tables in triggers, so if the
-	 * table already has such triggers we bail out
+	 * Hypertables do not support arbitrary triggers, so if the table already
+	 * has unsupported triggers we bail out
 	 */
-	if (ts_relation_has_transition_table_trigger(table_relid))
-		ereport(ERROR,
-				(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
-				 errmsg("hypertables do not support transition tables in triggers")));
+	ts_check_unsupported_triggers(table_relid);
 
 	if (NULL == chunk_sizing_info)
 		chunk_sizing_info = ts_chunk_sizing_info_get_default_disabled(table_relid);

--- a/src/planner/planner.c
+++ b/src/planner/planner.c
@@ -12,6 +12,7 @@
 #include <miscadmin.h>
 #include <nodes/makefuncs.h>
 #include <nodes/nodeFuncs.h>
+#include <nodes/parsenodes.h>
 #include <nodes/plannodes.h>
 #include <optimizer/appendinfo.h>
 #include <optimizer/clauses.h>
@@ -1272,8 +1273,15 @@ timescaledb_set_rel_pathlist(PlannerInfo *root, RelOptInfo *rel, Index rti, Rang
 	TsRelType reltype;
 	Hypertable *ht;
 
-	/* Quick exit if this is a relation we're not interested in */
-	if (!valid_hook_call() || !OidIsValid(rte->relid) || IS_DUMMY_REL(rel))
+	/*
+	 * Quick exit if this is a relation we're not interested in.
+	 *
+	 * If the rtekind is a named tuple store, it is a named tuple store *for*
+	 * the relation rte->relid (e.g., a transition table for a trigger), but
+	 * not the relation itself.
+	 */
+	if (!valid_hook_call() || rte->rtekind == RTE_NAMEDTUPLESTORE || !OidIsValid(rte->relid) ||
+		IS_DUMMY_REL(rel))
 	{
 		if (prev_set_rel_pathlist_hook != NULL)
 			(*prev_set_rel_pathlist_hook)(root, rel, rti, rte);

--- a/src/trigger.h
+++ b/src/trigger.h
@@ -17,4 +17,4 @@
 extern void ts_trigger_create_on_chunk(Oid trigger_oid, const char *chunk_schema_name,
 									   const char *chunk_table_name);
 extern TSDLLEXPORT void ts_trigger_create_all_on_chunk(const Chunk *chunk);
-extern bool ts_relation_has_transition_table_trigger(Oid relid);
+extern void ts_check_unsupported_triggers(Oid relid);

--- a/test/expected/triggers.out
+++ b/test/expected/triggers.out
@@ -416,12 +416,15 @@ DROP TABLE location;
 -- test triggers with transition tables
 -- test creating hypertable from table with triggers with transition tables
 CREATE TABLE transition_test(time timestamptz NOT NULL);
-CREATE TRIGGER t1 AFTER INSERT ON transition_test REFERENCING NEW TABLE AS new_trans FOR EACH STATEMENT EXECUTE FUNCTION test_trigger();
+CREATE TRIGGER t1_stmt AFTER INSERT ON transition_test REFERENCING NEW TABLE AS new_trans FOR EACH STATEMENT EXECUTE FUNCTION test_trigger();
+CREATE TRIGGER t1_row AFTER INSERT ON transition_test REFERENCING NEW TABLE AS new_trans FOR EACH ROW EXECUTE FUNCTION test_trigger();
+-- We do not support ROW triggers with transition tables, so we need
+-- to remove it to be able to create the hypertable.
 \set ON_ERROR_STOP 0
 SELECT create_hypertable('transition_test','time');
-ERROR:  hypertables do not support transition tables in triggers
+ERROR:  ROW triggers with transition tables are not supported on hypertables
 \set ON_ERROR_STOP 1
-DROP TRIGGER t1 ON transition_test;
+DROP TRIGGER t1_row ON transition_test;
 SELECT create_hypertable('transition_test','time');
       create_hypertable       
 ------------------------------
@@ -430,27 +433,30 @@ SELECT create_hypertable('transition_test','time');
 
 -- Insert some rows to create a chunk
 INSERT INTO transition_test values ('2020-01-10');
+WARNING:  FIRING trigger when: AFTER level: STATEMENT op: INSERT cnt: 0 trigger_name t1_stmt
 SELECT chunk FROM show_chunks('transition_test') tbl(chunk) limit 1 \gset
 -- test creating trigger with transition tables on existing hypertable
-\set ON_ERROR_STOP 0
-CREATE TRIGGER t2 AFTER INSERT ON transition_test REFERENCING NEW TABLE AS new_trans FOR EACH STATEMENT EXECUTE FUNCTION test_trigger();
-ERROR:  trigger with transition tables not supported on hypertables
 CREATE TRIGGER t3 AFTER UPDATE ON transition_test REFERENCING NEW TABLE AS new_trans OLD TABLE AS old_trans FOR EACH STATEMENT EXECUTE FUNCTION test_trigger();
-ERROR:  trigger with transition tables not supported on hypertables
 CREATE TRIGGER t4 AFTER DELETE ON transition_test REFERENCING OLD TABLE AS old_trans FOR EACH STATEMENT EXECUTE FUNCTION test_trigger();
-ERROR:  trigger with transition tables not supported on hypertables
-CREATE TRIGGER t2 AFTER INSERT ON :chunk REFERENCING NEW TABLE AS new_trans FOR EACH STATEMENT EXECUTE FUNCTION test_trigger();
-ERROR:  trigger with transition tables not supported on hypertable chunks
+INSERT INTO transition_test values ('2020-01-11');
+WARNING:  FIRING trigger when: AFTER level: STATEMENT op: INSERT cnt: 0 trigger_name t1_stmt
+COPY transition_test FROM STDIN;
+WARNING:  FIRING trigger when: AFTER level: STATEMENT op: INSERT cnt: 0 trigger_name t1_stmt
+UPDATE transition_test SET time = '2020-01-12' WHERE time = '2020-01-11';
+WARNING:  FIRING trigger when: AFTER level: STATEMENT op: UPDATE cnt: 0 trigger_name t3
+DELETE FROM transition_test WHERE time = '2020-01-12';
+WARNING:  FIRING trigger when: AFTER level: STATEMENT op: DELETE cnt: 0 trigger_name t4
+\set ON_ERROR_STOP 0
 CREATE TRIGGER t3 AFTER UPDATE ON :chunk REFERENCING NEW TABLE AS new_trans OLD TABLE AS old_trans FOR EACH STATEMENT EXECUTE FUNCTION test_trigger();
-ERROR:  trigger with transition tables not supported on hypertable chunks
+ERROR:  triggers with transition tables are not supported on hypertable chunks
 CREATE TRIGGER t4 AFTER DELETE ON :chunk REFERENCING OLD TABLE AS old_trans FOR EACH STATEMENT EXECUTE FUNCTION test_trigger();
-ERROR:  trigger with transition tables not supported on hypertable chunks
-CREATE TRIGGER t2 AFTER INSERT ON transition_test REFERENCING NEW TABLE AS new_trans FOR EACH ROW EXECUTE FUNCTION test_trigger();
-ERROR:  trigger with transition tables not supported on hypertables
-CREATE TRIGGER t3 AFTER UPDATE ON transition_test REFERENCING NEW TABLE AS new_trans OLD TABLE AS old_trans FOR EACH ROW EXECUTE FUNCTION test_trigger();
-ERROR:  trigger with transition tables not supported on hypertables
-CREATE TRIGGER t4 AFTER DELETE ON transition_test REFERENCING OLD TABLE AS old_trans FOR EACH ROW EXECUTE FUNCTION test_trigger();
-ERROR:  trigger with transition tables not supported on hypertables
+ERROR:  triggers with transition tables are not supported on hypertable chunks
+CREATE TRIGGER t5 AFTER INSERT ON transition_test REFERENCING NEW TABLE AS new_trans FOR EACH ROW EXECUTE FUNCTION test_trigger();
+ERROR:  ROW triggers with transition tables are not supported on hypertables
+CREATE TRIGGER t6 AFTER UPDATE ON transition_test REFERENCING NEW TABLE AS new_trans OLD TABLE AS old_trans FOR EACH ROW EXECUTE FUNCTION test_trigger();
+ERROR:  ROW triggers with transition tables are not supported on hypertables
+CREATE TRIGGER t7 AFTER DELETE ON transition_test REFERENCING OLD TABLE AS old_trans FOR EACH ROW EXECUTE FUNCTION test_trigger();
+ERROR:  ROW triggers with transition tables are not supported on hypertables
 -- Test insert blocker trigger does not crash when called directly
 SELECT _timescaledb_functions.insert_blocker();
 ERROR:  insert_blocker: not called by trigger manager

--- a/test/sql/triggers.sql
+++ b/test/sql/triggers.sql
@@ -305,12 +305,15 @@ DROP TABLE location;
 -- test triggers with transition tables
 -- test creating hypertable from table with triggers with transition tables
 CREATE TABLE transition_test(time timestamptz NOT NULL);
-CREATE TRIGGER t1 AFTER INSERT ON transition_test REFERENCING NEW TABLE AS new_trans FOR EACH STATEMENT EXECUTE FUNCTION test_trigger();
+CREATE TRIGGER t1_stmt AFTER INSERT ON transition_test REFERENCING NEW TABLE AS new_trans FOR EACH STATEMENT EXECUTE FUNCTION test_trigger();
+CREATE TRIGGER t1_row AFTER INSERT ON transition_test REFERENCING NEW TABLE AS new_trans FOR EACH ROW EXECUTE FUNCTION test_trigger();
 
+-- We do not support ROW triggers with transition tables, so we need
+-- to remove it to be able to create the hypertable.
 \set ON_ERROR_STOP 0
 SELECT create_hypertable('transition_test','time');
 \set ON_ERROR_STOP 1
-DROP TRIGGER t1 ON transition_test;
+DROP TRIGGER t1_row ON transition_test;
 SELECT create_hypertable('transition_test','time');
 
 -- Insert some rows to create a chunk
@@ -318,17 +321,22 @@ INSERT INTO transition_test values ('2020-01-10');
 SELECT chunk FROM show_chunks('transition_test') tbl(chunk) limit 1 \gset
 
 -- test creating trigger with transition tables on existing hypertable
-\set ON_ERROR_STOP 0
-CREATE TRIGGER t2 AFTER INSERT ON transition_test REFERENCING NEW TABLE AS new_trans FOR EACH STATEMENT EXECUTE FUNCTION test_trigger();
 CREATE TRIGGER t3 AFTER UPDATE ON transition_test REFERENCING NEW TABLE AS new_trans OLD TABLE AS old_trans FOR EACH STATEMENT EXECUTE FUNCTION test_trigger();
 CREATE TRIGGER t4 AFTER DELETE ON transition_test REFERENCING OLD TABLE AS old_trans FOR EACH STATEMENT EXECUTE FUNCTION test_trigger();
-CREATE TRIGGER t2 AFTER INSERT ON :chunk REFERENCING NEW TABLE AS new_trans FOR EACH STATEMENT EXECUTE FUNCTION test_trigger();
+
+INSERT INTO transition_test values ('2020-01-11');
+COPY transition_test FROM STDIN;
+2020-01-09
+\.
+UPDATE transition_test SET time = '2020-01-12' WHERE time = '2020-01-11';
+DELETE FROM transition_test WHERE time = '2020-01-12';
+
+\set ON_ERROR_STOP 0
 CREATE TRIGGER t3 AFTER UPDATE ON :chunk REFERENCING NEW TABLE AS new_trans OLD TABLE AS old_trans FOR EACH STATEMENT EXECUTE FUNCTION test_trigger();
 CREATE TRIGGER t4 AFTER DELETE ON :chunk REFERENCING OLD TABLE AS old_trans FOR EACH STATEMENT EXECUTE FUNCTION test_trigger();
-
-CREATE TRIGGER t2 AFTER INSERT ON transition_test REFERENCING NEW TABLE AS new_trans FOR EACH ROW EXECUTE FUNCTION test_trigger();
-CREATE TRIGGER t3 AFTER UPDATE ON transition_test REFERENCING NEW TABLE AS new_trans OLD TABLE AS old_trans FOR EACH ROW EXECUTE FUNCTION test_trigger();
-CREATE TRIGGER t4 AFTER DELETE ON transition_test REFERENCING OLD TABLE AS old_trans FOR EACH ROW EXECUTE FUNCTION test_trigger();
+CREATE TRIGGER t5 AFTER INSERT ON transition_test REFERENCING NEW TABLE AS new_trans FOR EACH ROW EXECUTE FUNCTION test_trigger();
+CREATE TRIGGER t6 AFTER UPDATE ON transition_test REFERENCING NEW TABLE AS new_trans OLD TABLE AS old_trans FOR EACH ROW EXECUTE FUNCTION test_trigger();
+CREATE TRIGGER t7 AFTER DELETE ON transition_test REFERENCING OLD TABLE AS old_trans FOR EACH ROW EXECUTE FUNCTION test_trigger();
 
 -- Test insert blocker trigger does not crash when called directly
 SELECT _timescaledb_functions.insert_blocker();

--- a/tsl/test/expected/hypercore_trigger.out
+++ b/tsl/test/expected/hypercore_trigger.out
@@ -129,6 +129,7 @@ begin
 	     insert into saved_rows select n.*, true, tg_op from new_table n;
 	     insert into saved_rows select o.*, false, tg_op from old_table o;
    end case;
+   return null;
 end;
 $$ language plpgsql;
 create function count_ops() returns trigger as $$
@@ -199,8 +200,12 @@ insert into sample(created_at, location_id, device_id, owner_id, temp, humidity)
 -- this case, the trigger will just save away the rows into a separate
 -- table and check that we get the same number of rows with the same
 -- values.
-create trigger save_insert_row_trg before insert on :chunk1 for each row execute function save_row();
-create trigger count_inserts_trg before insert on :chunk1 for each statement execute function count_ops();
+create trigger save_insert_row_trg
+       before insert on :chunk1
+       for each row execute function save_row();
+create trigger count_inserts_trg
+       before insert on :chunk1
+       for each statement execute function count_ops();
 insert into :chunk1(created_at, location_id, device_id, owner_id, temp, humidity)
 select created_at, location_id, device_id, owner_id, temp, humidity from sample limit 2;
 select * from saved_rows where kind = 'INSERT';
@@ -233,9 +238,15 @@ select sum(inserts), sum(updates), sum(deletes) from count_stmt;
 (1 row)
 
 truncate saved_rows, count_stmt;
+drop trigger save_insert_row_trg on :chunk1;
+drop trigger count_inserts_trg on :chunk1;
 -- Run update and upsert tests
-create trigger save_update_row_trg before update on :chunk1 for each row execute function save_row();
-create trigger count_update_trg before update on :chunk1 for each statement execute function count_ops();
+create trigger save_update_row_trg
+       before update on :chunk1
+       for each row execute function save_row();
+create trigger count_update_trg
+       before update on :chunk1
+       for each statement execute function count_ops();
 update :chunk1 set temp = 9.99 where device_id = 666;
 select * from saved_rows where kind = 'UPDATE';
  metric_id |          created_at          | location_id | owner_id | device_id | temp | humidity | new_row |  kind  
@@ -277,13 +288,19 @@ select * from saved_rows where kind = 'UPDATE';
 select sum(inserts), sum(updates), sum(deletes) from count_stmt;
  sum | sum | sum 
 -----+-----+-----
-   1 |   1 |   0
+   0 |   1 |   0
 (1 row)
 
 truncate saved_rows, count_stmt;
+drop trigger save_update_row_trg on :chunk1;
+drop trigger count_update_trg on :chunk1;
 -- Run delete tests
-create trigger save_delete_row_trg before delete on :chunk1 for each row execute function save_row();
-create trigger count_delete_trg before delete on :chunk1 for each statement execute function count_ops();
+create trigger save_delete_row_trg
+       before delete on :chunk1
+       for each row execute function save_row();
+create trigger count_delete_trg
+       before delete on :chunk1
+       for each statement execute function count_ops();
 delete from :chunk1 where device_id = 666;
 select * from saved_rows where kind = 'DELETE';
  metric_id |          created_at          | location_id | owner_id | device_id | temp | humidity | new_row |  kind  
@@ -300,29 +317,120 @@ select sum(inserts), sum(updates), sum(deletes) from count_stmt;
    0 |   0 |   1
 (1 row)
 
-truncate saved_rows;
--- TODO(#1084): Transition tables do not work currently for chunks at
--- all. Once this is implemented, we should get values saved in the
--- saved_rows table, so keeping the function around for the time being
--- and right now just to test that we get a proper error.
+truncate saved_rows, count_stmt;
+drop trigger save_delete_row_trg on :chunk1;
+drop trigger count_delete_trg on :chunk1;
+-- Checking that transition tables on triggers is not supported on
+-- individual chunks.
 \set ON_ERROR_STOP 0
-create trigger save_insert_transition_table_trg
+create trigger row_insert_transition_table_trg
        after insert on :chunk1
        referencing new table as new_table
        for each statement execute function save_transition_table();
-ERROR:  trigger with transition tables not supported on hypertable chunks
-create trigger save_update_transition_table_trg
+ERROR:  triggers with transition tables are not supported on hypertable chunks
+create trigger row_update_transition_table_trg
        after update on :chunk1
+       referencing new table as new_table
+       for each statement execute function save_transition_table();
+ERROR:  triggers with transition tables are not supported on hypertable chunks
+create trigger row_delete_transition_table_trg
+       after delete on :chunk1
+       referencing new table as new_table
+       for each statement execute function save_transition_table();
+ERROR:  triggers with transition tables are not supported on hypertable chunks
+create trigger row_insert_transition_table_trg
+       after insert on :chunk1
+       referencing new table as new_table
+       for each row execute function save_transition_table();
+ERROR:  triggers with transition tables are not supported on hypertable chunks
+create trigger row_update_transition_table_trg
+       after update on :chunk1
+       referencing new table as new_table
+       for each row execute function save_transition_table();
+ERROR:  triggers with transition tables are not supported on hypertable chunks
+create trigger row_delete_transition_table_trg
+       after delete on :chunk1
+       referencing new table as new_table
+       for each row execute function save_transition_table();
+ERROR:  triggers with transition tables are not supported on hypertable chunks
+\set ON_ERROR_STOP 1
+-- Remove duplicates from readings table so that we can run the tests
+-- below.
+delete from readings where created_at in (select created_at from sample);
+-- Test transition tables on hypertables using hypercore access method
+create trigger save_insert_transition_table_trg
+       after insert on readings
+       referencing new table as new_table
+       for each statement execute function save_transition_table();
+insert into readings(created_at, location_id, device_id, owner_id, temp, humidity)
+select created_at, location_id, device_id, owner_id, temp, humidity from sample
+order by created_at limit 2;
+select * from saved_rows;
+ metric_id |          created_at          | location_id | owner_id | device_id | temp | humidity | new_row |  kind  
+-----------+------------------------------+-------------+----------+-----------+------+----------+---------+--------
+     11533 | Wed Jun 01 00:01:23 2022 PDT |         999 |      111 |       666 | 3.14 |     3.14 | t       | INSERT
+     11534 | Wed Jun 01 00:02:23 2022 PDT |         999 |      112 |       666 | 3.14 |     3.14 | t       | INSERT
+(2 rows)
+
+truncate saved_rows;
+copy readings(created_at, location_id, device_id, owner_id, temp, humidity) from stdin with (format csv);
+select * from saved_rows;
+ metric_id |          created_at          | location_id | owner_id | device_id | temp | humidity | new_row |  kind  
+-----------+------------------------------+-------------+----------+-----------+------+----------+---------+--------
+     11535 | Wed Jun 01 00:01:35 2022 PDT |         999 |      111 |       666 | 3.14 |     3.14 | t       | INSERT
+(1 row)
+
+truncate saved_rows;
+create trigger save_update_transition_table_trg
+       after update on readings
        referencing new table as new_table old table as old_table
        for each statement execute function save_transition_table();
-ERROR:  trigger with transition tables not supported on hypertable chunks
+select * from readings where location_id = 999;
+ metric_id |          created_at          | location_id | owner_id | device_id | temp | humidity 
+-----------+------------------------------+-------------+----------+-----------+------+----------
+     11533 | Wed Jun 01 00:01:23 2022 PDT |         999 |      111 |       666 | 3.14 |     3.14
+     11534 | Wed Jun 01 00:02:23 2022 PDT |         999 |      112 |       666 | 3.14 |     3.14
+     11535 | Wed Jun 01 00:01:35 2022 PDT |         999 |      111 |       666 | 3.14 |     3.14
+(3 rows)
+
+update readings set humidity = 99.99 where location_id = 999;
+select * from saved_rows;
+ metric_id |          created_at          | location_id | owner_id | device_id | temp | humidity | new_row |  kind  
+-----------+------------------------------+-------------+----------+-----------+------+----------+---------+--------
+     11533 | Wed Jun 01 00:01:23 2022 PDT |         999 |      111 |       666 | 3.14 |    99.99 | t       | UPDATE
+     11534 | Wed Jun 01 00:02:23 2022 PDT |         999 |      112 |       666 | 3.14 |    99.99 | t       | UPDATE
+     11535 | Wed Jun 01 00:01:35 2022 PDT |         999 |      111 |       666 | 3.14 |    99.99 | t       | UPDATE
+     11533 | Wed Jun 01 00:01:23 2022 PDT |         999 |      111 |       666 | 3.14 |     3.14 | f       | UPDATE
+     11534 | Wed Jun 01 00:02:23 2022 PDT |         999 |      112 |       666 | 3.14 |     3.14 | f       | UPDATE
+     11535 | Wed Jun 01 00:01:35 2022 PDT |         999 |      111 |       666 | 3.14 |     3.14 | f       | UPDATE
+(6 rows)
+
+truncate saved_rows;
 create trigger save_delete_transition_table_trg
-       after delete on :chunk1
+       after delete on readings
        referencing old table as old_table
        for each statement execute function save_transition_table();
-ERROR:  trigger with transition tables not supported on hypertable chunks
-\set ON_ERROR_STOP 1
+select * from readings where location_id = 999;
+ metric_id |          created_at          | location_id | owner_id | device_id | temp | humidity 
+-----------+------------------------------+-------------+----------+-----------+------+----------
+     11533 | Wed Jun 01 00:01:23 2022 PDT |         999 |      111 |       666 | 3.14 |    99.99
+     11534 | Wed Jun 01 00:02:23 2022 PDT |         999 |      112 |       666 | 3.14 |    99.99
+     11535 | Wed Jun 01 00:01:35 2022 PDT |         999 |      111 |       666 | 3.14 |    99.99
+(3 rows)
+
+delete from readings where location_id = 999;
+select * from saved_rows;
+ metric_id |          created_at          | location_id | owner_id | device_id | temp | humidity | new_row |  kind  
+-----------+------------------------------+-------------+----------+-----------+------+----------+---------+--------
+     11533 | Wed Jun 01 00:01:23 2022 PDT |         999 |      111 |       666 | 3.14 |    99.99 | f       | DELETE
+     11534 | Wed Jun 01 00:02:23 2022 PDT |         999 |      112 |       666 | 3.14 |    99.99 | f       | DELETE
+     11535 | Wed Jun 01 00:01:35 2022 PDT |         999 |      111 |       666 | 3.14 |    99.99 | f       | DELETE
+(3 rows)
+
+truncate saved_rows;
 -- Check truncate trigger
-create trigger notify_truncate after truncate on :chunk1 for each statement execute function notify_action();
-truncate :chunk1;
-NOTICE:  table _hyper_1_1_chunk was truncated
+create trigger notify_truncate
+       after truncate on readings
+       for each statement execute function notify_action();
+truncate readings;
+NOTICE:  table readings was truncated


### PR DESCRIPTION
This adds support for using statement-level triggers with transition tables to hypertables. We deliberately do not support statement-level nor row-level triggers with transition tables on chunks and error out if attempts are made to either add such triggers to a chunk or create a hypertable from a table with such triggers.

We also change the error messages to look more like the corresponding PostgreSQL error message.