### PR TITLE
Fix telemetry stats regression test

### DIFF
--- a/src/telemetry/telemetry.c
+++ b/src/telemetry/telemetry.c
@@ -438,8 +438,8 @@ add_job_stats_by_job_type(JsonbParseState *parse_state)
 		"SELECT ("
 		"	CASE "
 		"		WHEN j.proc_schema = \'_timescaledb_functions\' AND j.proc_name ~ "
-		"\'^policy_(retention|compression|reorder|refresh_continuous_aggregate|telemetry|job_error_"
-		"retention)$\' "
+		"\'^policy_(retention|compression|reorder|refresh_continuous_aggregate|telemetry|job_stat_"
+		"history_retention)$\' "
 		"		THEN j.proc_name::TEXT "
 		"		ELSE \'user_defined_action\' "
 		"	END"
@@ -455,8 +455,8 @@ add_job_stats_by_job_type(JsonbParseState *parse_state)
 		"FROM "
 		"	_timescaledb_internal.bgw_job_stat s "
 		"	JOIN _timescaledb_config.bgw_job j on j.id = s.job_id "
-		"GROUP BY "
-		"job_type";
+		"GROUP BY job_type "
+		"ORDER BY job_type";
 
 	if (SPI_connect() != SPI_OK_CONNECT)
 		elog(ERROR, "could not connect to SPI");

--- a/tsl/test/expected/telemetry_stats.out
+++ b/tsl/test/expected/telemetry_stats.out
@@ -526,14 +526,24 @@ SELECT jsonb_pretty(get_telemetry_report() -> 'stats_by_job_type');
          "max_consecutive_failures": 1         +
      },                                        +
      "user_defined_action": {                  +
-         "total_runs": 3,                      +
-         "total_crashes": 1,                   +
+         "total_runs": 2,                      +
+         "total_crashes": 0,                   +
          "total_duration": "@ 0",              +
          "total_failures": 2,                  +
          "total_successes": 0,                 +
-         "max_consecutive_crashes": 1,         +
+         "max_consecutive_crashes": 0,         +
          "total_duration_failures": "@ 4 secs",+
          "max_consecutive_failures": 1         +
+     },                                        +
+     "policy_job_stat_history_retention": {    +
+         "total_runs": 1,                      +
+         "total_crashes": 1,                   +
+         "total_duration": "@ 0",              +
+         "total_failures": 0,                  +
+         "total_successes": 0,                 +
+         "max_consecutive_crashes": 1,         +
+         "total_duration_failures": "@ 0",     +
+         "max_consecutive_failures": 0         +
      },                                        +
      "policy_refresh_continuous_aggregate": {  +
          "total_runs": 2,                      +


### PR DESCRIPTION
In #6767 we introduced the track job execution history and renamed the `policy_job_error_retention` to `policy_job_stat_history_retention` but we forgot to adapt the telemetry to identify this change.

Fixes #6898

Disable-check: force-changelog-file
