### PR TITLE
Fix gapfill behaviour around dst switches

### DIFF
--- a/.unreleased/pr_6908
+++ b/.unreleased/pr_6908
@@ -1,0 +1,2 @@
+Fixes: #6908 Fix gapfill with timezone behaviour around dst switches
+Thanks: @DiAifU, @kiddhombre and @intermittentnrg for reporting issues with gapfill and daylight saving time

--- a/tsl/src/nodes/gapfill/gapfill_exec.c
+++ b/tsl/src/nodes/gapfill/gapfill_exec.c
@@ -654,9 +654,11 @@ gapfill_advance_timestamp(GapFillState *state)
 		case TIMESTAMPTZOID:
 			/*
 			 * To be consistent with time_bucket we do UTC bucketing unless
-			 * a different timezone got explicitly passed to the function.
+			 * a different timezone got explicitly passed to the function
+			 * and we are bucketing by non-fixed intervals.
 			 */
-			if (state->have_timezone)
+			if (state->have_timezone &&
+				(state->next_offset->day != 0 || state->next_offset->month != 0))
 			{
 				bool isnull;
 				/* TODO: optimize by constifying and caching the datum if possible */

--- a/tsl/test/shared/expected/gapfill-13.out
+++ b/tsl/test/shared/expected/gapfill-13.out
@@ -3464,3 +3464,30 @@ ORDER BY 1 DESC;
 (10 rows)
 
 DROP TABLE stocks_real_time;
+SET timezone TO 'Europe/Berlin';
+-- check dst switching is handled correctly #6788
+SELECT time_bucket_gapfill('1h', time, 'Europe/Berlin', '2024-03-31T0:00Z', '2024-03-31T02:00Z')
+FROM (SELECT NULL::timestamptz AS time LIMIT 0) s GROUP BY 1;
+      time_bucket_gapfill      
+ Sun Mar 31 01:00:00 2024 CET
+ Sun Mar 31 03:00:00 2024 CEST
+(2 rows)
+
+SELECT time_bucket_gapfill('30 minutes', time, 'Europe/Berlin', '2024-03-31T0:00Z', '2024-03-31T02:00Z')
+FROM (SELECT NULL::timestamptz AS time LIMIT 0) s GROUP BY 1;
+      time_bucket_gapfill      
+ Sun Mar 31 01:00:00 2024 CET
+ Sun Mar 31 01:30:00 2024 CET
+ Sun Mar 31 03:00:00 2024 CEST
+ Sun Mar 31 03:30:00 2024 CEST
+(4 rows)
+
+SELECT time_bucket_gapfill('1h', time, 'Europe/Berlin', '2024-10-26T23:00Z', '2024-10-27T02:00Z')
+FROM (SELECT NULL::timestamptz AS time LIMIT 0) s GROUP BY 1;
+      time_bucket_gapfill      
+ Sun Oct 27 01:00:00 2024 CEST
+ Sun Oct 27 02:00:00 2024 CEST
+ Sun Oct 27 02:00:00 2024 CET
+(3 rows)
+
+RESET timezone;

--- a/tsl/test/shared/expected/gapfill-14.out
+++ b/tsl/test/shared/expected/gapfill-14.out
@@ -3464,3 +3464,30 @@ ORDER BY 1 DESC;
 (10 rows)
 
 DROP TABLE stocks_real_time;
+SET timezone TO 'Europe/Berlin';
+-- check dst switching is handled correctly #6788
+SELECT time_bucket_gapfill('1h', time, 'Europe/Berlin', '2024-03-31T0:00Z', '2024-03-31T02:00Z')
+FROM (SELECT NULL::timestamptz AS time LIMIT 0) s GROUP BY 1;
+      time_bucket_gapfill      
+ Sun Mar 31 01:00:00 2024 CET
+ Sun Mar 31 03:00:00 2024 CEST
+(2 rows)
+
+SELECT time_bucket_gapfill('30 minutes', time, 'Europe/Berlin', '2024-03-31T0:00Z', '2024-03-31T02:00Z')
+FROM (SELECT NULL::timestamptz AS time LIMIT 0) s GROUP BY 1;
+      time_bucket_gapfill      
+ Sun Mar 31 01:00:00 2024 CET
+ Sun Mar 31 01:30:00 2024 CET
+ Sun Mar 31 03:00:00 2024 CEST
+ Sun Mar 31 03:30:00 2024 CEST
+(4 rows)
+
+SELECT time_bucket_gapfill('1h', time, 'Europe/Berlin', '2024-10-26T23:00Z', '2024-10-27T02:00Z')
+FROM (SELECT NULL::timestamptz AS time LIMIT 0) s GROUP BY 1;
+      time_bucket_gapfill      
+ Sun Oct 27 01:00:00 2024 CEST
+ Sun Oct 27 02:00:00 2024 CEST
+ Sun Oct 27 02:00:00 2024 CET
+(3 rows)
+
+RESET timezone;

--- a/tsl/test/shared/expected/gapfill-15.out
+++ b/tsl/test/shared/expected/gapfill-15.out
@@ -3464,3 +3464,30 @@ ORDER BY 1 DESC;
 (10 rows)
 
 DROP TABLE stocks_real_time;
+SET timezone TO 'Europe/Berlin';
+-- check dst switching is handled correctly #6788
+SELECT time_bucket_gapfill('1h', time, 'Europe/Berlin', '2024-03-31T0:00Z', '2024-03-31T02:00Z')
+FROM (SELECT NULL::timestamptz AS time LIMIT 0) s GROUP BY 1;
+      time_bucket_gapfill      
+ Sun Mar 31 01:00:00 2024 CET
+ Sun Mar 31 03:00:00 2024 CEST
+(2 rows)
+
+SELECT time_bucket_gapfill('30 minutes', time, 'Europe/Berlin', '2024-03-31T0:00Z', '2024-03-31T02:00Z')
+FROM (SELECT NULL::timestamptz AS time LIMIT 0) s GROUP BY 1;
+      time_bucket_gapfill      
+ Sun Mar 31 01:00:00 2024 CET
+ Sun Mar 31 01:30:00 2024 CET
+ Sun Mar 31 03:00:00 2024 CEST
+ Sun Mar 31 03:30:00 2024 CEST
+(4 rows)
+
+SELECT time_bucket_gapfill('1h', time, 'Europe/Berlin', '2024-10-26T23:00Z', '2024-10-27T02:00Z')
+FROM (SELECT NULL::timestamptz AS time LIMIT 0) s GROUP BY 1;
+      time_bucket_gapfill      
+ Sun Oct 27 01:00:00 2024 CEST
+ Sun Oct 27 02:00:00 2024 CEST
+ Sun Oct 27 02:00:00 2024 CET
+(3 rows)
+
+RESET timezone;

--- a/tsl/test/shared/expected/gapfill-16.out
+++ b/tsl/test/shared/expected/gapfill-16.out
@@ -3466,3 +3466,30 @@ ORDER BY 1 DESC;
 (10 rows)
 
 DROP TABLE stocks_real_time;
+SET timezone TO 'Europe/Berlin';
+-- check dst switching is handled correctly #6788
+SELECT time_bucket_gapfill('1h', time, 'Europe/Berlin', '2024-03-31T0:00Z', '2024-03-31T02:00Z')
+FROM (SELECT NULL::timestamptz AS time LIMIT 0) s GROUP BY 1;
+      time_bucket_gapfill      
+ Sun Mar 31 01:00:00 2024 CET
+ Sun Mar 31 03:00:00 2024 CEST
+(2 rows)
+
+SELECT time_bucket_gapfill('30 minutes', time, 'Europe/Berlin', '2024-03-31T0:00Z', '2024-03-31T02:00Z')
+FROM (SELECT NULL::timestamptz AS time LIMIT 0) s GROUP BY 1;
+      time_bucket_gapfill      
+ Sun Mar 31 01:00:00 2024 CET
+ Sun Mar 31 01:30:00 2024 CET
+ Sun Mar 31 03:00:00 2024 CEST
+ Sun Mar 31 03:30:00 2024 CEST
+(4 rows)
+
+SELECT time_bucket_gapfill('1h', time, 'Europe/Berlin', '2024-10-26T23:00Z', '2024-10-27T02:00Z')
+FROM (SELECT NULL::timestamptz AS time LIMIT 0) s GROUP BY 1;
+      time_bucket_gapfill      
+ Sun Oct 27 01:00:00 2024 CEST
+ Sun Oct 27 02:00:00 2024 CEST
+ Sun Oct 27 02:00:00 2024 CET
+(3 rows)
+
+RESET timezone;

--- a/tsl/test/shared/sql/gapfill.sql.in
+++ b/tsl/test/shared/sql/gapfill.sql.in
@@ -1576,3 +1576,16 @@ ORDER BY 1 DESC;
 
 DROP TABLE stocks_real_time;
 
+SET timezone TO 'Europe/Berlin';
+-- check dst switching is handled correctly #6788
+SELECT time_bucket_gapfill('1h', time, 'Europe/Berlin', '2024-03-31T0:00Z', '2024-03-31T02:00Z')
+FROM (SELECT NULL::timestamptz AS time LIMIT 0) s GROUP BY 1;
+
+SELECT time_bucket_gapfill('30 minutes', time, 'Europe/Berlin', '2024-03-31T0:00Z', '2024-03-31T02:00Z')
+FROM (SELECT NULL::timestamptz AS time LIMIT 0) s GROUP BY 1;
+
+SELECT time_bucket_gapfill('1h', time, 'Europe/Berlin', '2024-10-26T23:00Z', '2024-10-27T02:00Z')
+FROM (SELECT NULL::timestamptz AS time LIMIT 0) s GROUP BY 1;
+
+RESET timezone;
+


### PR DESCRIPTION
When advancing local time we might not actually advance the timestamp we process e.g. when we switch to DST in spring the local time advances by 1 hour but the UTC time stays the same. Therefore we need to keep advancing until we actually move forward.

Fixes: #6788 