### PR TITLE
Add bitnami docker workflow

### DIFF
--- a/.github/workflows/release_build_packages.yml
+++ b/.github/workflows/release_build_packages.yml
@@ -14,6 +14,7 @@ jobs:
             GH_TOKEN: ${{ secrets.ORG_AUTOMATION_TOKEN }}
           run: |
             gh workflow run docker-image.yml -R timescale/timescaledb-docker -f version=${{ github.event.release.tag_name }}
+            gh workflow run bitnami.yml -R timescale/timescaledb-docker -f version=${{ github.event.release.tag_name }}
             gh workflow run timescaledb-debian.yml -R timescale/release-build-scripts -f version=${{ github.event.release.tag_name }} -f upload-artifacts=true
             gh workflow run timescaledb-ubuntu.yml -R timescale/release-build-scripts -f version=${{ github.event.release.tag_name }} -f upload-artifacts=true
             gh workflow run timescaledb-apt-arm64.yml -R timescale/release-build-scripts -f version=${{ github.event.release.tag_name }} -f upload-artifacts=true


### PR DESCRIPTION
The bitnami docker image generation has been split into dedicated workflow and is no longer part of the docker image workflow so we have to trigger it explicitly.