### PR TITLE
Fix _timescaledb_functions.remove_dropped_chunk_metadata

### DIFF
--- a/.unreleased/pr_6911
+++ b/.unreleased/pr_6911
@@ -1,0 +1,2 @@
+Fixes: #6911 Fix dropped chunk metadata removal in update script
+Thanks: @hongquan for reporting an issue with the update script

--- a/sql/maintenance_utils.sql
+++ b/sql/maintenance_utils.sql
@@ -138,6 +138,7 @@ BEGIN
   LOOP
     _removed := _removed + 1;
     RAISE INFO 'Removing metadata of chunk % from hypertable %', _chunk_id, _hypertable_id;
+
     WITH _dimension_slice_remove AS (
         DELETE FROM _timescaledb_catalog.dimension_slice
         USING _timescaledb_catalog.chunk_constraint
@@ -148,6 +149,9 @@ BEGIN
     DELETE FROM _timescaledb_catalog.chunk_constraint
     USING _dimension_slice_remove
     WHERE chunk_constraint.dimension_slice_id = _dimension_slice_remove.id;
+
+    DELETE FROM _timescaledb_catalog.chunk_constraint
+    WHERE chunk_constraint.chunk_id = _chunk_id;
 
     DELETE FROM _timescaledb_internal.bgw_policy_chunk_stats
     WHERE bgw_policy_chunk_stats.chunk_id = _chunk_id;

--- a/sql/updates/2.14.2--2.15.0.sql
+++ b/sql/updates/2.14.2--2.15.0.sql
@@ -43,6 +43,7 @@ BEGIN
   LOOP
     _removed := _removed + 1;
     RAISE INFO 'Removing metadata of chunk % from hypertable %', _chunk_id, _hypertable_id;
+
     WITH _dimension_slice_remove AS (
         DELETE FROM _timescaledb_catalog.dimension_slice
         USING _timescaledb_catalog.chunk_constraint
@@ -53,6 +54,9 @@ BEGIN
     DELETE FROM _timescaledb_catalog.chunk_constraint
     USING _dimension_slice_remove
     WHERE chunk_constraint.dimension_slice_id = _dimension_slice_remove.id;
+
+    DELETE FROM _timescaledb_catalog.chunk_constraint
+    WHERE chunk_constraint.chunk_id = _chunk_id;
 
     DELETE FROM _timescaledb_internal.bgw_policy_chunk_stats
     WHERE bgw_policy_chunk_stats.chunk_id = _chunk_id;


### PR DESCRIPTION
The removal function would only remove chunk_constraints that are part of dimension constraints. This patch changes it to remove all constraints of a chunk.

Fixes #6905 