### PR TITLE
Skip downgrade test for Ubuntu 24.04

### DIFF
--- a/.github/workflows/apt-arm-packages.yaml
+++ b/.github/workflows/apt-arm-packages.yaml
@@ -4,6 +4,8 @@ name: APT ARM64 packages
   schedule:
     # run daily 0:00 on main branch
     - cron: '0 0 * * *'
+  pull_request:
+    paths: .github/workflows/apt-arm-packages.yaml
   push:
     tags:
     - '*'

--- a/.github/workflows/apt-packages.yaml
+++ b/.github/workflows/apt-packages.yaml
@@ -4,6 +4,8 @@ name: APT packages
   schedule:
     # run daily 0:00 on main branch
     - cron: '0 0 * * *'
+  pull_request:
+    paths: .github/workflows/apt-packages.yaml
   push:
     tags:
     - '*'
@@ -82,6 +84,7 @@ jobs:
         fi
 
     - name: Test Downgrade
+      if: matrix.image != 'ubuntu:24.04'
       run: |
         # Since this runs nightly on main we have to get the previous version
         # from the last released version and not current branch.


### PR DESCRIPTION
Since 2.15.0 is the first version available we can't do downgrade test until we released an additional version on that platform.