### PR TITLE
Fix flaky telemetry stats regression tests

### DIFF
--- a/test/sql/utils/testsupport.sql
+++ b/test/sql/utils/testsupport.sql
@@ -5,6 +5,10 @@
 
 SELECT _timescaledb_functions.stop_background_workers();
 
+-- Cleanup any system job stats that can lead to flaky test
+DELETE FROM _timescaledb_internal.bgw_job_stat_history WHERE job_id < 1000;
+DELETE FROM _timescaledb_internal.bgw_job_stat WHERE job_id < 1000;
+
 CREATE SCHEMA IF NOT EXISTS test;
 GRANT USAGE ON SCHEMA test TO PUBLIC;
 

--- a/tsl/test/expected/telemetry_stats.out
+++ b/tsl/test/expected/telemetry_stats.out
@@ -535,16 +535,6 @@ SELECT jsonb_pretty(get_telemetry_report() -> 'stats_by_job_type');
          "total_duration_failures": "@ 4 secs",+
          "max_consecutive_failures": 1         +
      },                                        +
-     "policy_job_stat_history_retention": {    +
-         "total_runs": 1,                      +
-         "total_crashes": 1,                   +
-         "total_duration": "@ 0",              +
-         "total_failures": 0,                  +
-         "total_successes": 0,                 +
-         "max_consecutive_crashes": 1,         +
-         "total_duration_failures": "@ 0",     +
-         "max_consecutive_failures": 0         +
-     },                                        +
      "policy_refresh_continuous_aggregate": {  +
          "total_runs": 2,                      +
          "total_crashes": 0,                   +


### PR DESCRIPTION
In #6907 we supposed to fix the telemetry stats regression test flakiness but unfortutanely it was not enough.

What happens is when the regression test runner setup the database for regression tests be executed we stop the scheduler and if for some reason a system job is running then it will be killed and it produces records on `bgw_job_stat` and `bgw_job_stat_history` with the crash information that can potentially lead to flaky test output.

To prevent it we cleanup system job stats metadata table just after stop the scheduler.

Disable-check: force-changelog-file
