### PR TITLE
Remove chunks when truncating a CAgg

### DIFF
--- a/src/process_utility.c
+++ b/src/process_utility.c
@@ -945,6 +945,10 @@ process_truncate(ProcessUtilityArgs *args)
 
 						/* list of materialization hypertables to reset the watermark */
 						mat_hypertables = lappend(mat_hypertables, mat_ht);
+
+						/* include the materialization hypertable to the list to be handled by the
+						 * proper hypertable and chunk truncate code-path later */
+						hypertables = lappend(hypertables, mat_ht);
 					}
 
 					list_append = true;

--- a/tsl/test/expected/cagg_ddl-14.out
+++ b/tsl/test/expected/cagg_ddl-14.out
@@ -2053,8 +2053,22 @@ SELECT _timescaledb_functions.to_timestamp(_timescaledb_functions.cagg_watermark
  Fri Nov 02 17:00:00 2018 PDT
 (1 row)
 
+-- Exists chunks before truncate the cagg (> 0)
+SELECT count(*) FROM show_chunks('conditions_daily');
+ count 
+-------
+     2
+(1 row)
+
 -- Truncate the given CAgg, it should reset the watermark to the empty state
 TRUNCATE conditions_daily;
+-- No chunks remains after truncate the cagg (= 0)
+SELECT count(*) FROM show_chunks('conditions_daily');
+ count 
+-------
+     0
+(1 row)
+
 -- Watermark should be reseted
 SELECT _timescaledb_functions.to_timestamp(_timescaledb_functions.cagg_watermark(:mat_hypertable_id)) AS watermak_after;
          watermak_after          
@@ -2096,7 +2110,7 @@ SELECT count(compress_chunk(ch)) FROM show_chunks('cagg1') ch;
 (1 row)
 
 DROP MATERIALIZED VIEW cagg1;
-NOTICE:  drop cascades to table _timescaledb_internal._hyper_52_68_chunk
+NOTICE:  drop cascades to table _timescaledb_internal._hyper_52_70_chunk
 SELECT * FROM _timescaledb_catalog.compression_settings;
  relid | segmentby | orderby | orderby_desc | orderby_nullsfirst 
 -------+-----------+---------+--------------+--------------------

--- a/tsl/test/expected/cagg_ddl-15.out
+++ b/tsl/test/expected/cagg_ddl-15.out
@@ -2053,8 +2053,22 @@ SELECT _timescaledb_functions.to_timestamp(_timescaledb_functions.cagg_watermark
  Fri Nov 02 17:00:00 2018 PDT
 (1 row)
 
+-- Exists chunks before truncate the cagg (> 0)
+SELECT count(*) FROM show_chunks('conditions_daily');
+ count 
+-------
+     2
+(1 row)
+
 -- Truncate the given CAgg, it should reset the watermark to the empty state
 TRUNCATE conditions_daily;
+-- No chunks remains after truncate the cagg (= 0)
+SELECT count(*) FROM show_chunks('conditions_daily');
+ count 
+-------
+     0
+(1 row)
+
 -- Watermark should be reseted
 SELECT _timescaledb_functions.to_timestamp(_timescaledb_functions.cagg_watermark(:mat_hypertable_id)) AS watermak_after;
          watermak_after          
@@ -2096,7 +2110,7 @@ SELECT count(compress_chunk(ch)) FROM show_chunks('cagg1') ch;
 (1 row)
 
 DROP MATERIALIZED VIEW cagg1;
-NOTICE:  drop cascades to table _timescaledb_internal._hyper_52_68_chunk
+NOTICE:  drop cascades to table _timescaledb_internal._hyper_52_70_chunk
 SELECT * FROM _timescaledb_catalog.compression_settings;
  relid | segmentby | orderby | orderby_desc | orderby_nullsfirst 
 -------+-----------+---------+--------------+--------------------

--- a/tsl/test/expected/cagg_ddl-16.out
+++ b/tsl/test/expected/cagg_ddl-16.out
@@ -2053,8 +2053,22 @@ SELECT _timescaledb_functions.to_timestamp(_timescaledb_functions.cagg_watermark
  Fri Nov 02 17:00:00 2018 PDT
 (1 row)
 
+-- Exists chunks before truncate the cagg (> 0)
+SELECT count(*) FROM show_chunks('conditions_daily');
+ count 
+-------
+     2
+(1 row)
+
 -- Truncate the given CAgg, it should reset the watermark to the empty state
 TRUNCATE conditions_daily;
+-- No chunks remains after truncate the cagg (= 0)
+SELECT count(*) FROM show_chunks('conditions_daily');
+ count 
+-------
+     0
+(1 row)
+
 -- Watermark should be reseted
 SELECT _timescaledb_functions.to_timestamp(_timescaledb_functions.cagg_watermark(:mat_hypertable_id)) AS watermak_after;
          watermak_after          
@@ -2096,7 +2110,7 @@ SELECT count(compress_chunk(ch)) FROM show_chunks('cagg1') ch;
 (1 row)
 
 DROP MATERIALIZED VIEW cagg1;
-NOTICE:  drop cascades to table _timescaledb_internal._hyper_52_68_chunk
+NOTICE:  drop cascades to table _timescaledb_internal._hyper_52_70_chunk
 SELECT * FROM _timescaledb_catalog.compression_settings;
  relid | segmentby | orderby | orderby_desc | orderby_nullsfirst 
 -------+-----------+---------+--------------+--------------------

--- a/tsl/test/expected/cagg_invalidation.out
+++ b/tsl/test/expected/cagg_invalidation.out
@@ -1091,8 +1091,8 @@ SELECT show_chunks AS chunk_to_drop
 FROM show_chunks('conditions');
               chunk_to_drop              
 -----------------------------------------
- _timescaledb_internal._hyper_1_34_chunk
- _timescaledb_internal._hyper_1_40_chunk
+ _timescaledb_internal._hyper_1_35_chunk
+ _timescaledb_internal._hyper_1_41_chunk
 (2 rows)
 
 -- Pick the first one to drop

--- a/tsl/test/expected/cagg_on_cagg.out
+++ b/tsl/test/expected/cagg_on_cagg.out
@@ -393,7 +393,6 @@ SELECT * FROM :CAGG_NAME_2TH_LEVEL ORDER BY bucket;
 
 -- DROP the 2TH level CAGG don't affect others
 DROP MATERIALIZED VIEW :CAGG_NAME_2TH_LEVEL;
-psql:include/cagg_on_cagg_common.sql:187: NOTICE:  drop cascades to table _timescaledb_internal._hyper_3_3_chunk
 \set ON_ERROR_STOP 0
 -- should error because it was dropped
 SELECT * FROM :CAGG_NAME_2TH_LEVEL ORDER BY bucket;
@@ -413,7 +412,7 @@ SELECT * FROM :CAGG_NAME_1ST_LEVEL ORDER BY bucket;
 
 -- DROP the first CAGG should work
 DROP MATERIALIZED VIEW :CAGG_NAME_1ST_LEVEL;
-psql:include/cagg_on_cagg_common.sql:197: NOTICE:  drop cascades to table _timescaledb_internal._hyper_2_2_chunk
+psql:include/cagg_on_cagg_common.sql:197: NOTICE:  drop cascades to table _timescaledb_internal._hyper_2_7_chunk
 \set ON_ERROR_STOP 0
 -- should error because it was dropped
 SELECT * FROM :CAGG_NAME_1ST_LEVEL ORDER BY bucket;
@@ -762,7 +761,7 @@ psql:include/cagg_on_cagg_common.sql:169: NOTICE:  continuous aggregate "conditi
 \set ON_ERROR_STOP 1
 -- DROP the 3TH level CAGG don't affect others
 DROP MATERIALIZED VIEW :CAGG_NAME_3TH_LEVEL;
-psql:include/cagg_on_cagg_common.sql:173: NOTICE:  drop cascades to table _timescaledb_internal._hyper_8_9_chunk
+psql:include/cagg_on_cagg_common.sql:173: NOTICE:  drop cascades to table _timescaledb_internal._hyper_8_11_chunk
 \set ON_ERROR_STOP 0
 -- should error because it was dropped
 SELECT * FROM :CAGG_NAME_3TH_LEVEL ORDER BY bucket;
@@ -790,7 +789,6 @@ SELECT * FROM :CAGG_NAME_2TH_LEVEL ORDER BY bucket;
 
 -- DROP the 2TH level CAGG don't affect others
 DROP MATERIALIZED VIEW :CAGG_NAME_2TH_LEVEL;
-psql:include/cagg_on_cagg_common.sql:187: NOTICE:  drop cascades to table _timescaledb_internal._hyper_7_8_chunk
 \set ON_ERROR_STOP 0
 -- should error because it was dropped
 SELECT * FROM :CAGG_NAME_2TH_LEVEL ORDER BY bucket;
@@ -810,7 +808,7 @@ SELECT * FROM :CAGG_NAME_1ST_LEVEL ORDER BY bucket;
 
 -- DROP the first CAGG should work
 DROP MATERIALIZED VIEW :CAGG_NAME_1ST_LEVEL;
-psql:include/cagg_on_cagg_common.sql:197: NOTICE:  drop cascades to table _timescaledb_internal._hyper_6_7_chunk
+psql:include/cagg_on_cagg_common.sql:197: NOTICE:  drop cascades to table _timescaledb_internal._hyper_6_14_chunk
 \set ON_ERROR_STOP 0
 -- should error because it was dropped
 SELECT * FROM :CAGG_NAME_1ST_LEVEL ORDER BY bucket;
@@ -1485,7 +1483,7 @@ psql:include/cagg_on_cagg_common.sql:169: NOTICE:  continuous aggregate "conditi
 \set ON_ERROR_STOP 1
 -- DROP the 3TH level CAGG don't affect others
 DROP MATERIALIZED VIEW :CAGG_NAME_3TH_LEVEL;
-psql:include/cagg_on_cagg_common.sql:173: NOTICE:  drop cascades to table _timescaledb_internal._hyper_16_14_chunk
+psql:include/cagg_on_cagg_common.sql:173: NOTICE:  drop cascades to table _timescaledb_internal._hyper_16_18_chunk
 \set ON_ERROR_STOP 0
 -- should error because it was dropped
 SELECT * FROM :CAGG_NAME_3TH_LEVEL ORDER BY bucket;
@@ -1513,7 +1511,6 @@ SELECT * FROM :CAGG_NAME_2TH_LEVEL ORDER BY bucket;
 
 -- DROP the 2TH level CAGG don't affect others
 DROP MATERIALIZED VIEW :CAGG_NAME_2TH_LEVEL;
-psql:include/cagg_on_cagg_common.sql:187: NOTICE:  drop cascades to table _timescaledb_internal._hyper_15_13_chunk
 \set ON_ERROR_STOP 0
 -- should error because it was dropped
 SELECT * FROM :CAGG_NAME_2TH_LEVEL ORDER BY bucket;
@@ -1533,7 +1530,7 @@ SELECT * FROM :CAGG_NAME_1ST_LEVEL ORDER BY bucket;
 
 -- DROP the first CAGG should work
 DROP MATERIALIZED VIEW :CAGG_NAME_1ST_LEVEL;
-psql:include/cagg_on_cagg_common.sql:197: NOTICE:  drop cascades to table _timescaledb_internal._hyper_14_12_chunk
+psql:include/cagg_on_cagg_common.sql:197: NOTICE:  drop cascades to table _timescaledb_internal._hyper_14_20_chunk
 \set ON_ERROR_STOP 0
 -- should error because it was dropped
 SELECT * FROM :CAGG_NAME_1ST_LEVEL ORDER BY bucket;
@@ -1878,7 +1875,7 @@ psql:include/cagg_on_cagg_common.sql:169: NOTICE:  continuous aggregate "conditi
 \set ON_ERROR_STOP 1
 -- DROP the 3TH level CAGG don't affect others
 DROP MATERIALIZED VIEW :CAGG_NAME_3TH_LEVEL;
-psql:include/cagg_on_cagg_common.sql:173: NOTICE:  drop cascades to table _timescaledb_internal._hyper_20_18_chunk
+psql:include/cagg_on_cagg_common.sql:173: NOTICE:  drop cascades to table _timescaledb_internal._hyper_20_24_chunk
 \set ON_ERROR_STOP 0
 -- should error because it was dropped
 SELECT * FROM :CAGG_NAME_3TH_LEVEL ORDER BY bucket;
@@ -1906,7 +1903,6 @@ SELECT * FROM :CAGG_NAME_2TH_LEVEL ORDER BY bucket;
 
 -- DROP the 2TH level CAGG don't affect others
 DROP MATERIALIZED VIEW :CAGG_NAME_2TH_LEVEL;
-psql:include/cagg_on_cagg_common.sql:187: NOTICE:  drop cascades to table _timescaledb_internal._hyper_19_17_chunk
 \set ON_ERROR_STOP 0
 -- should error because it was dropped
 SELECT * FROM :CAGG_NAME_2TH_LEVEL ORDER BY bucket;
@@ -1926,7 +1922,7 @@ SELECT * FROM :CAGG_NAME_1ST_LEVEL ORDER BY bucket;
 
 -- DROP the first CAGG should work
 DROP MATERIALIZED VIEW :CAGG_NAME_1ST_LEVEL;
-psql:include/cagg_on_cagg_common.sql:197: NOTICE:  drop cascades to table _timescaledb_internal._hyper_18_16_chunk
+psql:include/cagg_on_cagg_common.sql:197: NOTICE:  drop cascades to table _timescaledb_internal._hyper_18_26_chunk
 \set ON_ERROR_STOP 0
 -- should error because it was dropped
 SELECT * FROM :CAGG_NAME_1ST_LEVEL ORDER BY bucket;
@@ -2701,7 +2697,7 @@ psql:include/cagg_on_cagg_common.sql:169: NOTICE:  continuous aggregate "conditi
 \set ON_ERROR_STOP 1
 -- DROP the 3TH level CAGG don't affect others
 DROP MATERIALIZED VIEW :CAGG_NAME_3TH_LEVEL;
-psql:include/cagg_on_cagg_common.sql:173: NOTICE:  drop cascades to table _timescaledb_internal._hyper_29_22_chunk
+psql:include/cagg_on_cagg_common.sql:173: NOTICE:  drop cascades to table _timescaledb_internal._hyper_29_30_chunk
 \set ON_ERROR_STOP 0
 -- should error because it was dropped
 SELECT * FROM :CAGG_NAME_3TH_LEVEL ORDER BY bucket;
@@ -2729,7 +2725,6 @@ SELECT * FROM :CAGG_NAME_2TH_LEVEL ORDER BY bucket;
 
 -- DROP the 2TH level CAGG don't affect others
 DROP MATERIALIZED VIEW :CAGG_NAME_2TH_LEVEL;
-psql:include/cagg_on_cagg_common.sql:187: NOTICE:  drop cascades to table _timescaledb_internal._hyper_28_21_chunk
 \set ON_ERROR_STOP 0
 -- should error because it was dropped
 SELECT * FROM :CAGG_NAME_2TH_LEVEL ORDER BY bucket;
@@ -2749,7 +2744,7 @@ SELECT * FROM :CAGG_NAME_1ST_LEVEL ORDER BY bucket;
 
 -- DROP the first CAGG should work
 DROP MATERIALIZED VIEW :CAGG_NAME_1ST_LEVEL;
-psql:include/cagg_on_cagg_common.sql:197: NOTICE:  drop cascades to table _timescaledb_internal._hyper_27_20_chunk
+psql:include/cagg_on_cagg_common.sql:197: NOTICE:  drop cascades to table _timescaledb_internal._hyper_27_32_chunk
 \set ON_ERROR_STOP 0
 -- should error because it was dropped
 SELECT * FROM :CAGG_NAME_1ST_LEVEL ORDER BY bucket;
@@ -3093,7 +3088,7 @@ psql:include/cagg_on_cagg_common.sql:169: NOTICE:  continuous aggregate "conditi
 \set ON_ERROR_STOP 1
 -- DROP the 3TH level CAGG don't affect others
 DROP MATERIALIZED VIEW :CAGG_NAME_3TH_LEVEL;
-psql:include/cagg_on_cagg_common.sql:173: NOTICE:  drop cascades to table _timescaledb_internal._hyper_33_26_chunk
+psql:include/cagg_on_cagg_common.sql:173: NOTICE:  drop cascades to table _timescaledb_internal._hyper_33_36_chunk
 \set ON_ERROR_STOP 0
 -- should error because it was dropped
 SELECT * FROM :CAGG_NAME_3TH_LEVEL ORDER BY bucket;
@@ -3121,7 +3116,6 @@ SELECT * FROM :CAGG_NAME_2TH_LEVEL ORDER BY bucket;
 
 -- DROP the 2TH level CAGG don't affect others
 DROP MATERIALIZED VIEW :CAGG_NAME_2TH_LEVEL;
-psql:include/cagg_on_cagg_common.sql:187: NOTICE:  drop cascades to table _timescaledb_internal._hyper_32_25_chunk
 \set ON_ERROR_STOP 0
 -- should error because it was dropped
 SELECT * FROM :CAGG_NAME_2TH_LEVEL ORDER BY bucket;
@@ -3141,7 +3135,7 @@ SELECT * FROM :CAGG_NAME_1ST_LEVEL ORDER BY bucket;
 
 -- DROP the first CAGG should work
 DROP MATERIALIZED VIEW :CAGG_NAME_1ST_LEVEL;
-psql:include/cagg_on_cagg_common.sql:197: NOTICE:  drop cascades to table _timescaledb_internal._hyper_31_24_chunk
+psql:include/cagg_on_cagg_common.sql:197: NOTICE:  drop cascades to table _timescaledb_internal._hyper_31_38_chunk
 \set ON_ERROR_STOP 0
 -- should error because it was dropped
 SELECT * FROM :CAGG_NAME_1ST_LEVEL ORDER BY bucket;
@@ -4022,16 +4016,16 @@ UNION ALL
 (1 row)
 
   DROP MATERIALIZED VIEW IF EXISTS :CAGG_NAME_3TH_LEVEL;
-psql:include/cagg_on_cagg_validations.sql:79: NOTICE:  drop cascades to table _timescaledb_internal._hyper_46_31_chunk
+psql:include/cagg_on_cagg_validations.sql:79: NOTICE:  drop cascades to table _timescaledb_internal._hyper_46_43_chunk
   DELETE FROM conditions WHERE device_id = 4;
 \endif
 --
 -- Cleanup
 --
 DROP MATERIALIZED VIEW IF EXISTS :CAGG_NAME_2TH_LEVEL;
-psql:include/cagg_on_cagg_validations.sql:86: NOTICE:  drop cascades to table _timescaledb_internal._hyper_45_30_chunk
+psql:include/cagg_on_cagg_validations.sql:86: NOTICE:  drop cascades to table _timescaledb_internal._hyper_45_42_chunk
 DROP MATERIALIZED VIEW IF EXISTS :CAGG_NAME_1ST_LEVEL;
-psql:include/cagg_on_cagg_validations.sql:87: NOTICE:  drop cascades to table _timescaledb_internal._hyper_44_29_chunk
+psql:include/cagg_on_cagg_validations.sql:87: NOTICE:  drop cascades to table _timescaledb_internal._hyper_44_41_chunk
 \set INTERVAL_TEST FALSE
 --
 -- Variable bucket size with different timezones
@@ -4275,16 +4269,16 @@ UNION ALL
 (1 row)
 
   DROP MATERIALIZED VIEW IF EXISTS :CAGG_NAME_3TH_LEVEL;
-psql:include/cagg_on_cagg_validations.sql:79: NOTICE:  drop cascades to table _timescaledb_internal._hyper_51_34_chunk
+psql:include/cagg_on_cagg_validations.sql:79: NOTICE:  drop cascades to table _timescaledb_internal._hyper_51_46_chunk
   DELETE FROM conditions WHERE device_id = 4;
 \endif
 --
 -- Cleanup
 --
 DROP MATERIALIZED VIEW IF EXISTS :CAGG_NAME_2TH_LEVEL;
-psql:include/cagg_on_cagg_validations.sql:86: NOTICE:  drop cascades to table _timescaledb_internal._hyper_50_33_chunk
+psql:include/cagg_on_cagg_validations.sql:86: NOTICE:  drop cascades to table _timescaledb_internal._hyper_50_45_chunk
 DROP MATERIALIZED VIEW IF EXISTS :CAGG_NAME_1ST_LEVEL;
-psql:include/cagg_on_cagg_validations.sql:87: NOTICE:  drop cascades to table _timescaledb_internal._hyper_49_32_chunk
+psql:include/cagg_on_cagg_validations.sql:87: NOTICE:  drop cascades to table _timescaledb_internal._hyper_49_44_chunk
 \set INTERVAL_TEST FALSE
 --
 -- TZ bucket on top of non-TZ bucket
@@ -4529,16 +4523,16 @@ UNION ALL
 (1 row)
 
   DROP MATERIALIZED VIEW IF EXISTS :CAGG_NAME_3TH_LEVEL;
-psql:include/cagg_on_cagg_validations.sql:79: NOTICE:  drop cascades to table _timescaledb_internal._hyper_56_37_chunk
+psql:include/cagg_on_cagg_validations.sql:79: NOTICE:  drop cascades to table _timescaledb_internal._hyper_56_49_chunk
   DELETE FROM conditions WHERE device_id = 4;
 \endif
 --
 -- Cleanup
 --
 DROP MATERIALIZED VIEW IF EXISTS :CAGG_NAME_2TH_LEVEL;
-psql:include/cagg_on_cagg_validations.sql:86: NOTICE:  drop cascades to table _timescaledb_internal._hyper_55_36_chunk
+psql:include/cagg_on_cagg_validations.sql:86: NOTICE:  drop cascades to table _timescaledb_internal._hyper_55_48_chunk
 DROP MATERIALIZED VIEW IF EXISTS :CAGG_NAME_1ST_LEVEL;
-psql:include/cagg_on_cagg_validations.sql:87: NOTICE:  drop cascades to table _timescaledb_internal._hyper_54_35_chunk
+psql:include/cagg_on_cagg_validations.sql:87: NOTICE:  drop cascades to table _timescaledb_internal._hyper_54_47_chunk
 \set INTERVAL_TEST FALSE
 --
 -- non-TZ bucket on top of TZ bucket

--- a/tsl/test/expected/cagg_on_cagg_joins.out
+++ b/tsl/test/expected/cagg_on_cagg_joins.out
@@ -404,7 +404,6 @@ SELECT * FROM :CAGG_NAME_2TH_LEVEL ORDER BY bucket;
 
 -- DROP the 2TH level CAGG don't affect others
 DROP MATERIALIZED VIEW :CAGG_NAME_2TH_LEVEL;
-psql:include/cagg_on_cagg_common.sql:187: NOTICE:  drop cascades to table _timescaledb_internal._hyper_3_3_chunk
 \set ON_ERROR_STOP 0
 -- should error because it was dropped
 SELECT * FROM :CAGG_NAME_2TH_LEVEL ORDER BY bucket;
@@ -424,7 +423,7 @@ SELECT * FROM :CAGG_NAME_1ST_LEVEL ORDER BY bucket;
 
 -- DROP the first CAGG should work
 DROP MATERIALIZED VIEW :CAGG_NAME_1ST_LEVEL;
-psql:include/cagg_on_cagg_common.sql:197: NOTICE:  drop cascades to table _timescaledb_internal._hyper_2_2_chunk
+psql:include/cagg_on_cagg_common.sql:197: NOTICE:  drop cascades to table _timescaledb_internal._hyper_2_7_chunk
 \set ON_ERROR_STOP 0
 -- should error because it was dropped
 SELECT * FROM :CAGG_NAME_1ST_LEVEL ORDER BY bucket;
@@ -784,7 +783,7 @@ psql:include/cagg_on_cagg_common.sql:169: NOTICE:  continuous aggregate "conditi
 \set ON_ERROR_STOP 1
 -- DROP the 3TH level CAGG don't affect others
 DROP MATERIALIZED VIEW :CAGG_NAME_3TH_LEVEL;
-psql:include/cagg_on_cagg_common.sql:173: NOTICE:  drop cascades to table _timescaledb_internal._hyper_8_9_chunk
+psql:include/cagg_on_cagg_common.sql:173: NOTICE:  drop cascades to table _timescaledb_internal._hyper_8_11_chunk
 \set ON_ERROR_STOP 0
 -- should error because it was dropped
 SELECT * FROM :CAGG_NAME_3TH_LEVEL ORDER BY bucket;
@@ -812,7 +811,6 @@ SELECT * FROM :CAGG_NAME_2TH_LEVEL ORDER BY bucket;
 
 -- DROP the 2TH level CAGG don't affect others
 DROP MATERIALIZED VIEW :CAGG_NAME_2TH_LEVEL;
-psql:include/cagg_on_cagg_common.sql:187: NOTICE:  drop cascades to table _timescaledb_internal._hyper_7_8_chunk
 \set ON_ERROR_STOP 0
 -- should error because it was dropped
 SELECT * FROM :CAGG_NAME_2TH_LEVEL ORDER BY bucket;
@@ -832,7 +830,7 @@ SELECT * FROM :CAGG_NAME_1ST_LEVEL ORDER BY bucket;
 
 -- DROP the first CAGG should work
 DROP MATERIALIZED VIEW :CAGG_NAME_1ST_LEVEL;
-psql:include/cagg_on_cagg_common.sql:197: NOTICE:  drop cascades to table _timescaledb_internal._hyper_6_7_chunk
+psql:include/cagg_on_cagg_common.sql:197: NOTICE:  drop cascades to table _timescaledb_internal._hyper_6_14_chunk
 \set ON_ERROR_STOP 0
 -- should error because it was dropped
 SELECT * FROM :CAGG_NAME_1ST_LEVEL ORDER BY bucket;
@@ -1521,7 +1519,7 @@ psql:include/cagg_on_cagg_common.sql:169: NOTICE:  continuous aggregate "conditi
 \set ON_ERROR_STOP 1
 -- DROP the 3TH level CAGG don't affect others
 DROP MATERIALIZED VIEW :CAGG_NAME_3TH_LEVEL;
-psql:include/cagg_on_cagg_common.sql:173: NOTICE:  drop cascades to table _timescaledb_internal._hyper_16_14_chunk
+psql:include/cagg_on_cagg_common.sql:173: NOTICE:  drop cascades to table _timescaledb_internal._hyper_16_18_chunk
 \set ON_ERROR_STOP 0
 -- should error because it was dropped
 SELECT * FROM :CAGG_NAME_3TH_LEVEL ORDER BY bucket;
@@ -1549,7 +1547,6 @@ SELECT * FROM :CAGG_NAME_2TH_LEVEL ORDER BY bucket;
 
 -- DROP the 2TH level CAGG don't affect others
 DROP MATERIALIZED VIEW :CAGG_NAME_2TH_LEVEL;
-psql:include/cagg_on_cagg_common.sql:187: NOTICE:  drop cascades to table _timescaledb_internal._hyper_15_13_chunk
 \set ON_ERROR_STOP 0
 -- should error because it was dropped
 SELECT * FROM :CAGG_NAME_2TH_LEVEL ORDER BY bucket;
@@ -1569,7 +1566,7 @@ SELECT * FROM :CAGG_NAME_1ST_LEVEL ORDER BY bucket;
 
 -- DROP the first CAGG should work
 DROP MATERIALIZED VIEW :CAGG_NAME_1ST_LEVEL;
-psql:include/cagg_on_cagg_common.sql:197: NOTICE:  drop cascades to table _timescaledb_internal._hyper_14_12_chunk
+psql:include/cagg_on_cagg_common.sql:197: NOTICE:  drop cascades to table _timescaledb_internal._hyper_14_20_chunk
 \set ON_ERROR_STOP 0
 -- should error because it was dropped
 SELECT * FROM :CAGG_NAME_1ST_LEVEL ORDER BY bucket;
@@ -1924,7 +1921,7 @@ psql:include/cagg_on_cagg_common.sql:169: NOTICE:  continuous aggregate "conditi
 \set ON_ERROR_STOP 1
 -- DROP the 3TH level CAGG don't affect others
 DROP MATERIALIZED VIEW :CAGG_NAME_3TH_LEVEL;
-psql:include/cagg_on_cagg_common.sql:173: NOTICE:  drop cascades to table _timescaledb_internal._hyper_20_18_chunk
+psql:include/cagg_on_cagg_common.sql:173: NOTICE:  drop cascades to table _timescaledb_internal._hyper_20_24_chunk
 \set ON_ERROR_STOP 0
 -- should error because it was dropped
 SELECT * FROM :CAGG_NAME_3TH_LEVEL ORDER BY bucket;
@@ -1952,7 +1949,6 @@ SELECT * FROM :CAGG_NAME_2TH_LEVEL ORDER BY bucket;
 
 -- DROP the 2TH level CAGG don't affect others
 DROP MATERIALIZED VIEW :CAGG_NAME_2TH_LEVEL;
-psql:include/cagg_on_cagg_common.sql:187: NOTICE:  drop cascades to table _timescaledb_internal._hyper_19_17_chunk
 \set ON_ERROR_STOP 0
 -- should error because it was dropped
 SELECT * FROM :CAGG_NAME_2TH_LEVEL ORDER BY bucket;
@@ -1972,7 +1968,7 @@ SELECT * FROM :CAGG_NAME_1ST_LEVEL ORDER BY bucket;
 
 -- DROP the first CAGG should work
 DROP MATERIALIZED VIEW :CAGG_NAME_1ST_LEVEL;
-psql:include/cagg_on_cagg_common.sql:197: NOTICE:  drop cascades to table _timescaledb_internal._hyper_18_16_chunk
+psql:include/cagg_on_cagg_common.sql:197: NOTICE:  drop cascades to table _timescaledb_internal._hyper_18_26_chunk
 \set ON_ERROR_STOP 0
 -- should error because it was dropped
 SELECT * FROM :CAGG_NAME_1ST_LEVEL ORDER BY bucket;
@@ -2762,7 +2758,7 @@ psql:include/cagg_on_cagg_common.sql:169: NOTICE:  continuous aggregate "conditi
 \set ON_ERROR_STOP 1
 -- DROP the 3TH level CAGG don't affect others
 DROP MATERIALIZED VIEW :CAGG_NAME_3TH_LEVEL;
-psql:include/cagg_on_cagg_common.sql:173: NOTICE:  drop cascades to table _timescaledb_internal._hyper_29_22_chunk
+psql:include/cagg_on_cagg_common.sql:173: NOTICE:  drop cascades to table _timescaledb_internal._hyper_29_30_chunk
 \set ON_ERROR_STOP 0
 -- should error because it was dropped
 SELECT * FROM :CAGG_NAME_3TH_LEVEL ORDER BY bucket;
@@ -2790,7 +2786,6 @@ SELECT * FROM :CAGG_NAME_2TH_LEVEL ORDER BY bucket;
 
 -- DROP the 2TH level CAGG don't affect others
 DROP MATERIALIZED VIEW :CAGG_NAME_2TH_LEVEL;
-psql:include/cagg_on_cagg_common.sql:187: NOTICE:  drop cascades to table _timescaledb_internal._hyper_28_21_chunk
 \set ON_ERROR_STOP 0
 -- should error because it was dropped
 SELECT * FROM :CAGG_NAME_2TH_LEVEL ORDER BY bucket;
@@ -2810,7 +2805,7 @@ SELECT * FROM :CAGG_NAME_1ST_LEVEL ORDER BY bucket;
 
 -- DROP the first CAGG should work
 DROP MATERIALIZED VIEW :CAGG_NAME_1ST_LEVEL;
-psql:include/cagg_on_cagg_common.sql:197: NOTICE:  drop cascades to table _timescaledb_internal._hyper_27_20_chunk
+psql:include/cagg_on_cagg_common.sql:197: NOTICE:  drop cascades to table _timescaledb_internal._hyper_27_32_chunk
 \set ON_ERROR_STOP 0
 -- should error because it was dropped
 SELECT * FROM :CAGG_NAME_1ST_LEVEL ORDER BY bucket;
@@ -3165,7 +3160,7 @@ psql:include/cagg_on_cagg_common.sql:169: NOTICE:  continuous aggregate "conditi
 \set ON_ERROR_STOP 1
 -- DROP the 3TH level CAGG don't affect others
 DROP MATERIALIZED VIEW :CAGG_NAME_3TH_LEVEL;
-psql:include/cagg_on_cagg_common.sql:173: NOTICE:  drop cascades to table _timescaledb_internal._hyper_33_26_chunk
+psql:include/cagg_on_cagg_common.sql:173: NOTICE:  drop cascades to table _timescaledb_internal._hyper_33_36_chunk
 \set ON_ERROR_STOP 0
 -- should error because it was dropped
 SELECT * FROM :CAGG_NAME_3TH_LEVEL ORDER BY bucket;
@@ -3193,7 +3188,6 @@ SELECT * FROM :CAGG_NAME_2TH_LEVEL ORDER BY bucket;
 
 -- DROP the 2TH level CAGG don't affect others
 DROP MATERIALIZED VIEW :CAGG_NAME_2TH_LEVEL;
-psql:include/cagg_on_cagg_common.sql:187: NOTICE:  drop cascades to table _timescaledb_internal._hyper_32_25_chunk
 \set ON_ERROR_STOP 0
 -- should error because it was dropped
 SELECT * FROM :CAGG_NAME_2TH_LEVEL ORDER BY bucket;
@@ -3213,7 +3207,7 @@ SELECT * FROM :CAGG_NAME_1ST_LEVEL ORDER BY bucket;
 
 -- DROP the first CAGG should work
 DROP MATERIALIZED VIEW :CAGG_NAME_1ST_LEVEL;
-psql:include/cagg_on_cagg_common.sql:197: NOTICE:  drop cascades to table _timescaledb_internal._hyper_31_24_chunk
+psql:include/cagg_on_cagg_common.sql:197: NOTICE:  drop cascades to table _timescaledb_internal._hyper_31_38_chunk
 \set ON_ERROR_STOP 0
 -- should error because it was dropped
 SELECT * FROM :CAGG_NAME_1ST_LEVEL ORDER BY bucket;

--- a/tsl/test/sql/cagg_ddl.sql.in
+++ b/tsl/test/sql/cagg_ddl.sql.in
@@ -1312,8 +1312,14 @@ CALL refresh_continuous_aggregate('conditions_daily', NULL, NULL);
 -- Check the watermark after the refresh and before truncate the CAgg
 SELECT _timescaledb_functions.to_timestamp(_timescaledb_functions.cagg_watermark(:mat_hypertable_id)) AS watermak_before;
 
+-- Exists chunks before truncate the cagg (> 0)
+SELECT count(*) FROM show_chunks('conditions_daily');
+
 -- Truncate the given CAgg, it should reset the watermark to the empty state
 TRUNCATE conditions_daily;
+
+-- No chunks remains after truncate the cagg (= 0)
+SELECT count(*) FROM show_chunks('conditions_daily');
 
 -- Watermark should be reseted
 SELECT _timescaledb_functions.to_timestamp(_timescaledb_functions.cagg_watermark(:mat_hypertable_id)) AS watermak_after;


### PR DESCRIPTION
When truncating a regular hypertable all chunks are removed but for some reason it don't happen when truncating a continuous aggregate.

Improved it by removing the underlying materialization hypertable chunks when truncating a continuous aggregate.

Disable-check: force-changelog-file
