### PR TITLE
Make constification functions visible outside timescale library

### DIFF
--- a/src/nodes/chunk_append/chunk_append.h
+++ b/src/nodes/chunk_append/chunk_append.h
@@ -40,3 +40,7 @@ extern TSDLLEXPORT bool ts_is_chunk_append_plan(Plan *plan);
 extern Scan *ts_chunk_append_get_scan_plan(Plan *plan);
 
 void _chunk_append_init(void);
+
+extern TSDLLEXPORT List *ts_constify_restrictinfos(PlannerInfo *root, List *restrictinfos);
+extern TSDLLEXPORT List *ts_constify_restrictinfo_params(PlannerInfo *root, EState *state,
+														 List *restrictinfos);

--- a/src/nodes/chunk_append/exec.c
+++ b/src/nodes/chunk_append/exec.c
@@ -147,11 +147,9 @@ static CustomExecMethods chunk_append_state_methods = {
 static void choose_next_subplan_non_parallel(ChunkAppendState *state);
 static void choose_next_subplan_for_worker(ChunkAppendState *state);
 
-static List *constify_restrictinfos(PlannerInfo *root, List *restrictinfos);
 static bool can_exclude_chunk(List *constraints, List *baserestrictinfo);
 static void do_startup_exclusion(ChunkAppendState *state);
 static Node *constify_param_mutator(Node *node, void *context);
-static List *constify_restrictinfo_params(PlannerInfo *root, EState *state, List *restrictinfos);
 
 static void initialize_constraints(ChunkAppendState *state, List *initial_rt_indexes);
 static LWLock *chunk_append_get_lock_pointer(void);
@@ -254,7 +252,7 @@ do_startup_exclusion(ChunkAppendState *state)
 				ri->clause = lfirst(lc);
 				restrictinfos = lappend(restrictinfos, ri);
 			}
-			restrictinfos = constify_restrictinfos(&root, restrictinfos);
+			restrictinfos = ts_constify_restrictinfos(&root, restrictinfos);
 
 			if (can_exclude_chunk(lfirst(lc_constraints), restrictinfos))
 			{
@@ -436,7 +434,7 @@ can_exclude_constraints_using_clauses(ChunkAppendState *state, List *constraints
 		ri->clause = lfirst(lc);
 		restrictinfos = lappend(restrictinfos, ri);
 	}
-	restrictinfos = constify_restrictinfo_params(root, ps->state, restrictinfos);
+	restrictinfos = ts_constify_restrictinfo_params(root, ps->state, restrictinfos);
 
 	can_exclude = can_exclude_chunk(constraints, restrictinfos);
 
@@ -924,8 +922,8 @@ chunk_append_get_lock_pointer()
  *
  * ...WHERE time > '2017-06-02 11:26:43.935712+02'
  */
-static List *
-constify_restrictinfos(PlannerInfo *root, List *restrictinfos)
+List *
+ts_constify_restrictinfos(PlannerInfo *root, List *restrictinfos)
 {
 	List *additional_list = NIL;
 
@@ -970,8 +968,8 @@ constify_restrictinfos(PlannerInfo *root, List *restrictinfos)
 	return list_concat(restrictinfos, additional_list);
 }
 
-static List *
-constify_restrictinfo_params(PlannerInfo *root, EState *state, List *restrictinfos)
+List *
+ts_constify_restrictinfo_params(PlannerInfo *root, EState *state, List *restrictinfos)
 {
 	ListCell *lc;
 


### PR DESCRIPTION
`ts_constify_restrictinfos` and `ts_constify_restrictinfo_params` are useful functions for OSM to implement runtime chunk exclusion. This PR makes them visible from outside the library so that OSM could find and reuse them.