### PR TITLE
Simplify msvc compat stuff

### DIFF
--- a/src/compat/compat-msvc-enter.h
+++ b/src/compat/compat-msvc-enter.h
@@ -3,6 +3,7 @@
  * Please see the included NOTICE for copyright information and
  * LICENSE-APACHE for a copy of the license.
  */
+
 #pragma once
 
 #include <postgres.h>
@@ -20,7 +21,6 @@
 #define PGDLLIMPORT
 #define extern extern _declspec(dllimport)
 
-#if PG_VERSION_NUM >= 140000
 #include <catalog/genbki.h>
 #undef DECLARE_TOAST
 #undef DECLARE_INDEX
@@ -39,6 +39,5 @@
 #define DECLARE_FOREIGN_KEY_OPT(cols, reftbl, refcols)
 #define DECLARE_ARRAY_FOREIGN_KEY(cols, reftbl, refcols)
 #define DECLARE_ARRAY_FOREIGN_KEY_OPT(cols, reftbl, refcols)
-#endif
 
 #endif /* _MSC_VER */

--- a/src/compat/compat-msvc-exit.h
+++ b/src/compat/compat-msvc-exit.h
@@ -3,6 +3,7 @@
  * Please see the included NOTICE for copyright information and
  * LICENSE-APACHE for a copy of the license.
  */
+
 #pragma once
 
 /*

--- a/src/extension.c
+++ b/src/extension.c
@@ -13,11 +13,16 @@
 #include <utils/inval.h>
 #include <fmgr.h>
 
-#include "compat/compat-msvc-enter.h" /* To label externs in extension.h and
-								 * miscadmin.h correctly */
+#if PG_VERSION_NUM < 150000
+/*
+ * Some externs are mislabeled when building on Windows so we try to fix them
+ * with this hack. This is only needed for versions < 15.
+ */
+#include "compat/compat-msvc-enter.h"
 #include <commands/extension.h>
 #include <miscadmin.h>
 #include "compat/compat-msvc-exit.h"
+#endif
 
 #include <access/relscan.h>
 #include <catalog/indexing.h>

--- a/src/loader/loader.c
+++ b/src/loader/loader.c
@@ -3,25 +3,29 @@
  * Please see the included NOTICE for copyright information and
  * LICENSE-APACHE for a copy of the license.
  */
-#include <postgres.h>
 
-#include <access/xact.h>
+#include <postgres.h>
 #include <access/heapam.h>
-#include "../compat/compat-msvc-enter.h"
-#include <postmaster/bgworker.h>
-#include <commands/extension.h>
+#include <access/parallel.h>
+#include <access/xact.h>
+#include <commands/dbcommands.h>
+#include <commands/defrem.h>
 #include <commands/user.h>
-#include <miscadmin.h>
+#include <nodes/print.h>
+#include <utils/guc.h>
+#include <utils/inval.h>
+#include <pg_config.h>
+#include <postmaster/bgworker.h>
 #include <parser/analyze.h>
 #include <storage/ipc.h>
 #include <tcop/utility.h>
+
+#if PG_VERSION_NUM < 150000
+#include "../compat/compat-msvc-enter.h"
+#include <commands/extension.h>
+#include <miscadmin.h>
 #include "../compat/compat-msvc-exit.h"
-#include <utils/guc.h>
-#include <utils/inval.h>
-#include <nodes/print.h>
-#include <commands/dbcommands.h>
-#include <commands/defrem.h>
-#include <access/parallel.h>
+#endif
 
 #include "extension_utils.c"
 #include "config.h"

--- a/src/planner/add_hashagg.c
+++ b/src/planner/add_hashagg.c
@@ -15,10 +15,6 @@
 #include <optimizer/tlist.h>
 #include <parser/parsetree.h>
 
-#include "compat/compat-msvc-enter.h"
-#include <optimizer/cost.h>
-#include "compat/compat-msvc-exit.h"
-
 #include "compat/compat.h"
 #include "planner.h"
 #include "import/planner.h"

--- a/src/planner/planner.c
+++ b/src/planner/planner.c
@@ -11,12 +11,14 @@
 #include <executor/nodeAgg.h>
 #include <miscadmin.h>
 #include <nodes/makefuncs.h>
+#include <nodes/nodeFuncs.h>
 #include <nodes/plannodes.h>
 #include <optimizer/appendinfo.h>
 #include <optimizer/clauses.h>
 #include <optimizer/optimizer.h>
 #include <optimizer/pathnode.h>
 #include <optimizer/paths.h>
+#include <optimizer/plancat.h>
 #include <optimizer/planner.h>
 #include <optimizer/restrictinfo.h>
 #include <optimizer/tlist.h>
@@ -29,16 +31,6 @@
 #include <utils/memutils.h>
 #include <utils/selfuncs.h>
 #include <utils/timestamp.h>
-
-#include "compat/compat-msvc-enter.h"
-#include <catalog/pg_constraint.h>
-#include <nodes/nodeFuncs.h>
-#include <optimizer/cost.h>
-#include <optimizer/plancat.h>
-#include <parser/analyze.h>
-#include <tcop/tcopprot.h>
-#include <utils/fmgrprotos.h>
-#include "compat/compat-msvc-exit.h"
 
 #include <math.h>
 


### PR DESCRIPTION
Some of the fixes are no longer needed and it is completely fixed
upstream in PG15+.

Disable-check: loader-change
Disable-check: force-changelog-file

