### PR TITLE
Add missed changelog message for COPY segfault fix

### DIFF
--- a/.unreleased/fix_compressed_copy_segfault
+++ b/.unreleased/fix_compressed_copy_segfault
@@ -1,0 +1,2 @@
+Fixes: #6540 Segmentation fault when backfilling data with COPY into a compressed chunk
+Thanks: @iliastsa and @SystemParadox for reporting an issue with COPY into a compressed chunk


### PR DESCRIPTION
We didn't have changelog check in the required ones, I added it now.

Fixes #6540