### PR TITLE
Re-enable compressed OR boolexpr pushdown

### DIFF
--- a/tsl/test/expected/compression_qualpushdown.out
+++ b/tsl/test/expected/compression_qualpushdown.out
@@ -562,3 +562,15 @@ EXPLAIN (costs off) SELECT * FROM svf_pushdown WHERE c_name = current_query();
          ->  Seq Scan on compress_hyper_12_13_chunk
 (5 rows)
 
+-- test or constraints in lateral query #6912
+SELECT FROM svf_pushdown m1,
+LATERAL(
+  SELECT FROM svf_pushdown m2
+  WHERE
+    m1.time = m2.time AND
+    EXISTS (SELECT random()) OR
+    EXISTS (SELECT FROM meta) LIMIT 1
+) l;
+--
+(1 row)
+

--- a/tsl/test/expected/compression_qualpushdown.out
+++ b/tsl/test/expected/compression_qualpushdown.out
@@ -490,13 +490,13 @@ EXPLAIN (costs off) SELECT * FROM svf_pushdown WHERE c_name = SESSION_USER;
 (5 rows)
 
 EXPLAIN (costs off) SELECT * FROM svf_pushdown WHERE c_name = CURRENT_USER OR c_name = SESSION_USER;
-                              QUERY PLAN                              
-----------------------------------------------------------------------
+                                 QUERY PLAN                                 
+----------------------------------------------------------------------------
  Custom Scan (ChunkAppend) on svf_pushdown
    Chunks excluded during startup: 0
    ->  Custom Scan (DecompressChunk) on _hyper_11_12_chunk
-         Filter: ((c_name = CURRENT_USER) OR (c_name = SESSION_USER))
          ->  Seq Scan on compress_hyper_12_13_chunk
+               Filter: ((c_name = CURRENT_USER) OR (c_name = SESSION_USER))
 (5 rows)
 
 EXPLAIN (costs off) SELECT * FROM svf_pushdown WHERE c_name = CURRENT_CATALOG;
@@ -561,16 +561,4 @@ EXPLAIN (costs off) SELECT * FROM svf_pushdown WHERE c_name = current_query();
          Filter: (c_name = current_query())
          ->  Seq Scan on compress_hyper_12_13_chunk
 (5 rows)
-
--- test or constraints in lateral query #6912
-SELECT FROM svf_pushdown m1,
-LATERAL(
-  SELECT FROM svf_pushdown m2
-  WHERE
-    m1.time = m2.time AND
-    EXISTS (SELECT random()) OR
-    EXISTS (SELECT FROM meta) LIMIT 1
-) l;
---
-(1 row)
 

--- a/tsl/test/expected/transparent_decompression-14.out
+++ b/tsl/test/expected/transparent_decompression-14.out
@@ -1141,8 +1141,8 @@ WHERE time > '2000-01-01 1:00:00+0'
 ORDER BY time,
     device_id
 LIMIT 10;
-                                                      QUERY PLAN                                                      
-----------------------------------------------------------------------------------------------------------------------
+                                                             QUERY PLAN                                                             
+------------------------------------------------------------------------------------------------------------------------------------
  Limit (actual rows=10 loops=1)
    ->  Custom Scan (ChunkAppend) on metrics (actual rows=10 loops=1)
          Order: metrics."time", metrics.device_id
@@ -1153,6 +1153,7 @@ LIMIT 10;
                      Filter: (("time" > 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone) OR (device_id = 1))
                      Rows Removed by Filter: 16
                      ->  Seq Scan on compress_hyper_5_15_chunk (actual rows=5 loops=1)
+                           Filter: ((_ts_meta_max_3 > 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone) OR (device_id = 1))
          ->  Sort (never executed)
                Sort Key: _hyper_1_2_chunk."time", _hyper_1_2_chunk.device_id
                ->  Seq Scan on _hyper_1_2_chunk (never executed)
@@ -1162,7 +1163,8 @@ LIMIT 10;
                ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk (never executed)
                      Filter: (("time" > 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone) OR (device_id = 1))
                      ->  Seq Scan on compress_hyper_5_16_chunk (never executed)
-(19 rows)
+                           Filter: ((_ts_meta_max_3 > 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone) OR (device_id = 1))
+(21 rows)
 
 --functions not yet optimized
 :PREFIX
@@ -4939,8 +4941,8 @@ WHERE time > '2000-01-01 1:00:00+0'
 ORDER BY time,
     device_id
 LIMIT 10;
-                                                            QUERY PLAN                                                            
-----------------------------------------------------------------------------------------------------------------------------------
+                                                                QUERY PLAN                                                                
+------------------------------------------------------------------------------------------------------------------------------------------
  Limit (actual rows=10 loops=1)
    ->  Custom Scan (ChunkAppend) on metrics_space (actual rows=10 loops=1)
          Order: metrics_space."time", metrics_space.device_id
@@ -4952,6 +4954,7 @@ LIMIT 10;
                      ->  Custom Scan (DecompressChunk) on _hyper_2_4_chunk (actual rows=360 loops=1)
                            Filter: (("time" > 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone) OR (device_id = 1))
                            ->  Seq Scan on compress_hyper_6_17_chunk (actual rows=1 loops=1)
+                                 Filter: ((_ts_meta_max_3 > 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone) OR (device_id = 1))
                ->  Sort (actual rows=4 loops=1)
                      Sort Key: _hyper_2_5_chunk."time", _hyper_2_5_chunk.device_id
                      Sort Method: top-N heapsort 
@@ -4959,6 +4962,7 @@ LIMIT 10;
                            Filter: (("time" > 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone) OR (device_id = 1))
                            Rows Removed by Filter: 12
                            ->  Seq Scan on compress_hyper_6_18_chunk (actual rows=3 loops=1)
+                                 Filter: ((_ts_meta_max_3 > 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone) OR (device_id = 1))
                ->  Sort (actual rows=2 loops=1)
                      Sort Key: _hyper_2_6_chunk."time", _hyper_2_6_chunk.device_id
                      Sort Method: top-N heapsort 
@@ -4966,6 +4970,7 @@ LIMIT 10;
                            Filter: (("time" > 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone) OR (device_id = 1))
                            Rows Removed by Filter: 4
                            ->  Seq Scan on compress_hyper_6_19_chunk (actual rows=1 loops=1)
+                                 Filter: ((_ts_meta_max_3 > 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone) OR (device_id = 1))
          ->  Merge Append (never executed)
                Sort Key: _hyper_2_7_chunk."time", _hyper_2_7_chunk.device_id
                ->  Sort (never executed)
@@ -4993,18 +4998,20 @@ LIMIT 10;
                      ->  Custom Scan (DecompressChunk) on _hyper_2_10_chunk (never executed)
                            Filter: (("time" > 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone) OR (device_id = 1))
                            ->  Seq Scan on compress_hyper_6_20_chunk (never executed)
+                                 Filter: ((_ts_meta_max_3 > 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone) OR (device_id = 1))
                ->  Sort (never executed)
                      Sort Key: _hyper_2_11_chunk."time", _hyper_2_11_chunk.device_id
                      ->  Custom Scan (DecompressChunk) on _hyper_2_11_chunk (never executed)
                            Filter: (("time" > 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone) OR (device_id = 1))
                            ->  Seq Scan on compress_hyper_6_21_chunk (never executed)
+                                 Filter: ((_ts_meta_max_3 > 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone) OR (device_id = 1))
                ->  Sort (never executed)
                      Sort Key: _hyper_2_12_chunk."time", _hyper_2_12_chunk.device_id
                      ->  Sort (never executed)
                            Sort Key: _hyper_2_12_chunk."time", _hyper_2_12_chunk.device_id
                            ->  Seq Scan on _hyper_2_12_chunk (never executed)
                                  Filter: (("time" > 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone) OR (device_id = 1))
-(63 rows)
+(68 rows)
 
 --functions not yet optimized
 :PREFIX

--- a/tsl/test/expected/transparent_decompression-15.out
+++ b/tsl/test/expected/transparent_decompression-15.out
@@ -1142,8 +1142,8 @@ WHERE time > '2000-01-01 1:00:00+0'
 ORDER BY time,
     device_id
 LIMIT 10;
-                                                      QUERY PLAN                                                      
-----------------------------------------------------------------------------------------------------------------------
+                                                             QUERY PLAN                                                             
+------------------------------------------------------------------------------------------------------------------------------------
  Limit (actual rows=10 loops=1)
    ->  Custom Scan (ChunkAppend) on metrics (actual rows=10 loops=1)
          Order: metrics."time", metrics.device_id
@@ -1154,6 +1154,7 @@ LIMIT 10;
                      Filter: (("time" > 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone) OR (device_id = 1))
                      Rows Removed by Filter: 16
                      ->  Seq Scan on compress_hyper_5_15_chunk (actual rows=5 loops=1)
+                           Filter: ((_ts_meta_max_3 > 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone) OR (device_id = 1))
          ->  Sort (never executed)
                Sort Key: _hyper_1_2_chunk."time", _hyper_1_2_chunk.device_id
                ->  Seq Scan on _hyper_1_2_chunk (never executed)
@@ -1163,7 +1164,8 @@ LIMIT 10;
                ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk (never executed)
                      Filter: (("time" > 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone) OR (device_id = 1))
                      ->  Seq Scan on compress_hyper_5_16_chunk (never executed)
-(19 rows)
+                           Filter: ((_ts_meta_max_3 > 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone) OR (device_id = 1))
+(21 rows)
 
 --functions not yet optimized
 :PREFIX
@@ -4913,8 +4915,8 @@ WHERE time > '2000-01-01 1:00:00+0'
 ORDER BY time,
     device_id
 LIMIT 10;
-                                                            QUERY PLAN                                                            
-----------------------------------------------------------------------------------------------------------------------------------
+                                                                QUERY PLAN                                                                
+------------------------------------------------------------------------------------------------------------------------------------------
  Limit (actual rows=10 loops=1)
    ->  Custom Scan (ChunkAppend) on metrics_space (actual rows=10 loops=1)
          Order: metrics_space."time", metrics_space.device_id
@@ -4926,6 +4928,7 @@ LIMIT 10;
                      ->  Custom Scan (DecompressChunk) on _hyper_2_4_chunk (actual rows=360 loops=1)
                            Filter: (("time" > 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone) OR (device_id = 1))
                            ->  Seq Scan on compress_hyper_6_17_chunk (actual rows=1 loops=1)
+                                 Filter: ((_ts_meta_max_3 > 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone) OR (device_id = 1))
                ->  Sort (actual rows=4 loops=1)
                      Sort Key: _hyper_2_5_chunk."time", _hyper_2_5_chunk.device_id
                      Sort Method: top-N heapsort 
@@ -4933,6 +4936,7 @@ LIMIT 10;
                            Filter: (("time" > 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone) OR (device_id = 1))
                            Rows Removed by Filter: 12
                            ->  Seq Scan on compress_hyper_6_18_chunk (actual rows=3 loops=1)
+                                 Filter: ((_ts_meta_max_3 > 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone) OR (device_id = 1))
                ->  Sort (actual rows=2 loops=1)
                      Sort Key: _hyper_2_6_chunk."time", _hyper_2_6_chunk.device_id
                      Sort Method: top-N heapsort 
@@ -4940,6 +4944,7 @@ LIMIT 10;
                            Filter: (("time" > 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone) OR (device_id = 1))
                            Rows Removed by Filter: 4
                            ->  Seq Scan on compress_hyper_6_19_chunk (actual rows=1 loops=1)
+                                 Filter: ((_ts_meta_max_3 > 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone) OR (device_id = 1))
          ->  Merge Append (never executed)
                Sort Key: _hyper_2_7_chunk."time", _hyper_2_7_chunk.device_id
                ->  Sort (never executed)
@@ -4967,18 +4972,20 @@ LIMIT 10;
                      ->  Custom Scan (DecompressChunk) on _hyper_2_10_chunk (never executed)
                            Filter: (("time" > 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone) OR (device_id = 1))
                            ->  Seq Scan on compress_hyper_6_20_chunk (never executed)
+                                 Filter: ((_ts_meta_max_3 > 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone) OR (device_id = 1))
                ->  Sort (never executed)
                      Sort Key: _hyper_2_11_chunk."time", _hyper_2_11_chunk.device_id
                      ->  Custom Scan (DecompressChunk) on _hyper_2_11_chunk (never executed)
                            Filter: (("time" > 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone) OR (device_id = 1))
                            ->  Seq Scan on compress_hyper_6_21_chunk (never executed)
+                                 Filter: ((_ts_meta_max_3 > 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone) OR (device_id = 1))
                ->  Sort (never executed)
                      Sort Key: _hyper_2_12_chunk."time", _hyper_2_12_chunk.device_id
                      ->  Sort (never executed)
                            Sort Key: _hyper_2_12_chunk."time", _hyper_2_12_chunk.device_id
                            ->  Seq Scan on _hyper_2_12_chunk (never executed)
                                  Filter: (("time" > 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone) OR (device_id = 1))
-(63 rows)
+(68 rows)
 
 --functions not yet optimized
 :PREFIX

--- a/tsl/test/expected/transparent_decompression-16.out
+++ b/tsl/test/expected/transparent_decompression-16.out
@@ -1142,8 +1142,8 @@ WHERE time > '2000-01-01 1:00:00+0'
 ORDER BY time,
     device_id
 LIMIT 10;
-                                                      QUERY PLAN                                                      
-----------------------------------------------------------------------------------------------------------------------
+                                                             QUERY PLAN                                                             
+------------------------------------------------------------------------------------------------------------------------------------
  Limit (actual rows=10 loops=1)
    ->  Custom Scan (ChunkAppend) on metrics (actual rows=10 loops=1)
          Order: metrics."time", metrics.device_id
@@ -1154,6 +1154,7 @@ LIMIT 10;
                      Filter: (("time" > 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone) OR (device_id = 1))
                      Rows Removed by Filter: 16
                      ->  Seq Scan on compress_hyper_5_15_chunk (actual rows=5 loops=1)
+                           Filter: ((_ts_meta_max_3 > 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone) OR (device_id = 1))
          ->  Sort (never executed)
                Sort Key: _hyper_1_2_chunk."time", _hyper_1_2_chunk.device_id
                ->  Seq Scan on _hyper_1_2_chunk (never executed)
@@ -1163,7 +1164,8 @@ LIMIT 10;
                ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk (never executed)
                      Filter: (("time" > 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone) OR (device_id = 1))
                      ->  Seq Scan on compress_hyper_5_16_chunk (never executed)
-(19 rows)
+                           Filter: ((_ts_meta_max_3 > 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone) OR (device_id = 1))
+(21 rows)
 
 --functions not yet optimized
 :PREFIX
@@ -4913,8 +4915,8 @@ WHERE time > '2000-01-01 1:00:00+0'
 ORDER BY time,
     device_id
 LIMIT 10;
-                                                            QUERY PLAN                                                            
-----------------------------------------------------------------------------------------------------------------------------------
+                                                                QUERY PLAN                                                                
+------------------------------------------------------------------------------------------------------------------------------------------
  Limit (actual rows=10 loops=1)
    ->  Custom Scan (ChunkAppend) on metrics_space (actual rows=10 loops=1)
          Order: metrics_space."time", metrics_space.device_id
@@ -4926,6 +4928,7 @@ LIMIT 10;
                      ->  Custom Scan (DecompressChunk) on _hyper_2_4_chunk (actual rows=360 loops=1)
                            Filter: (("time" > 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone) OR (device_id = 1))
                            ->  Seq Scan on compress_hyper_6_17_chunk (actual rows=1 loops=1)
+                                 Filter: ((_ts_meta_max_3 > 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone) OR (device_id = 1))
                ->  Sort (actual rows=4 loops=1)
                      Sort Key: _hyper_2_5_chunk."time", _hyper_2_5_chunk.device_id
                      Sort Method: top-N heapsort 
@@ -4933,6 +4936,7 @@ LIMIT 10;
                            Filter: (("time" > 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone) OR (device_id = 1))
                            Rows Removed by Filter: 12
                            ->  Seq Scan on compress_hyper_6_18_chunk (actual rows=3 loops=1)
+                                 Filter: ((_ts_meta_max_3 > 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone) OR (device_id = 1))
                ->  Sort (actual rows=2 loops=1)
                      Sort Key: _hyper_2_6_chunk."time", _hyper_2_6_chunk.device_id
                      Sort Method: top-N heapsort 
@@ -4940,6 +4944,7 @@ LIMIT 10;
                            Filter: (("time" > 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone) OR (device_id = 1))
                            Rows Removed by Filter: 4
                            ->  Seq Scan on compress_hyper_6_19_chunk (actual rows=1 loops=1)
+                                 Filter: ((_ts_meta_max_3 > 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone) OR (device_id = 1))
          ->  Merge Append (never executed)
                Sort Key: _hyper_2_7_chunk."time", _hyper_2_7_chunk.device_id
                ->  Sort (never executed)
@@ -4967,18 +4972,20 @@ LIMIT 10;
                      ->  Custom Scan (DecompressChunk) on _hyper_2_10_chunk (never executed)
                            Filter: (("time" > 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone) OR (device_id = 1))
                            ->  Seq Scan on compress_hyper_6_20_chunk (never executed)
+                                 Filter: ((_ts_meta_max_3 > 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone) OR (device_id = 1))
                ->  Sort (never executed)
                      Sort Key: _hyper_2_11_chunk."time", _hyper_2_11_chunk.device_id
                      ->  Custom Scan (DecompressChunk) on _hyper_2_11_chunk (never executed)
                            Filter: (("time" > 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone) OR (device_id = 1))
                            ->  Seq Scan on compress_hyper_6_21_chunk (never executed)
+                                 Filter: ((_ts_meta_max_3 > 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone) OR (device_id = 1))
                ->  Sort (never executed)
                      Sort Key: _hyper_2_12_chunk."time", _hyper_2_12_chunk.device_id
                      ->  Sort (never executed)
                            Sort Key: _hyper_2_12_chunk."time", _hyper_2_12_chunk.device_id
                            ->  Seq Scan on _hyper_2_12_chunk (never executed)
                                  Filter: (("time" > 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone) OR (device_id = 1))
-(63 rows)
+(68 rows)
 
 --functions not yet optimized
 :PREFIX

--- a/tsl/test/shared/expected/transparent_decompress_chunk-14.out
+++ b/tsl/test/shared/expected/transparent_decompress_chunk-14.out
@@ -398,7 +398,8 @@ QUERY PLAN
                ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk
                      Filter: (("time" > 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone) OR (device_id = 1))
                      ->  Parallel Seq Scan on compress_hyper_X_X_chunk
-(8 rows)
+                           Filter: ((_ts_meta_max_1 > 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone) OR (device_id = 1))
+(9 rows)
 
 --functions not yet optimized
 :PREFIX_NO_VERBOSE SELECT * FROM :TEST_TABLE WHERE time < now() ORDER BY time, device_id LIMIT 10;

--- a/tsl/test/shared/expected/transparent_decompress_chunk-15.out
+++ b/tsl/test/shared/expected/transparent_decompress_chunk-15.out
@@ -400,7 +400,8 @@ QUERY PLAN
                ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk
                      Filter: (("time" > 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone) OR (device_id = 1))
                      ->  Parallel Seq Scan on compress_hyper_X_X_chunk
-(8 rows)
+                           Filter: ((_ts_meta_max_1 > 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone) OR (device_id = 1))
+(9 rows)
 
 --functions not yet optimized
 :PREFIX_NO_VERBOSE SELECT * FROM :TEST_TABLE WHERE time < now() ORDER BY time, device_id LIMIT 10;

--- a/tsl/test/shared/expected/transparent_decompress_chunk-16.out
+++ b/tsl/test/shared/expected/transparent_decompress_chunk-16.out
@@ -400,7 +400,8 @@ QUERY PLAN
                ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk
                      Filter: (("time" > 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone) OR (device_id = 1))
                      ->  Parallel Seq Scan on compress_hyper_X_X_chunk
-(8 rows)
+                           Filter: ((_ts_meta_max_1 > 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone) OR (device_id = 1))
+(9 rows)
 
 --functions not yet optimized
 :PREFIX_NO_VERBOSE SELECT * FROM :TEST_TABLE WHERE time < now() ORDER BY time, device_id LIMIT 10;

--- a/tsl/test/sql/compression_qualpushdown.sql
+++ b/tsl/test/sql/compression_qualpushdown.sql
@@ -186,3 +186,13 @@ EXPLAIN (costs off) SELECT * FROM svf_pushdown WHERE NOT c_bool;
 -- current_query() is not a sqlvaluefunction and volatile so should not be pushed down
 EXPLAIN (costs off) SELECT * FROM svf_pushdown WHERE c_name = current_query();
 
+-- test or constraints in lateral query #6912
+SELECT FROM svf_pushdown m1,
+LATERAL(
+  SELECT FROM svf_pushdown m2
+  WHERE
+    m1.time = m2.time AND
+    EXISTS (SELECT random()) OR
+    EXISTS (SELECT FROM meta) LIMIT 1
+) l;
+

--- a/tsl/test/sql/compression_qualpushdown.sql
+++ b/tsl/test/sql/compression_qualpushdown.sql
@@ -186,13 +186,3 @@ EXPLAIN (costs off) SELECT * FROM svf_pushdown WHERE NOT c_bool;
 -- current_query() is not a sqlvaluefunction and volatile so should not be pushed down
 EXPLAIN (costs off) SELECT * FROM svf_pushdown WHERE c_name = current_query();
 
--- test or constraints in lateral query #6912
-SELECT FROM svf_pushdown m1,
-LATERAL(
-  SELECT FROM svf_pushdown m2
-  WHERE
-    m1.time = m2.time AND
-    EXISTS (SELECT random()) OR
-    EXISTS (SELECT FROM meta) LIMIT 1
-) l;
-


### PR DESCRIPTION
To fix the original problem, it is enough to call
eval_const_expressions() to normalize the nested AND boolexprs.

This is a follow-up to #6917

Disable-check: force-changelog-file