### PR TITLE
Backport to 2.15.x: #6953: Silence codespell check

### DIFF
--- a/.github/codespell-ignore-words
+++ b/.github/codespell-ignore-words
@@ -2,3 +2,6 @@ brin
 inh
 larg
 inout
+textin
+clos
+isnt

--- a/.github/workflows/code_style.yaml
+++ b/.github/workflows/code_style.yaml
@@ -65,7 +65,7 @@ jobs:
         uses: actions/checkout@v4
       - name: Run codespell
         run: |
-          find . -type f \( -name "*.c" -or -name "*.h" -or -name "*.yaml" -or -name "*.sh" \) \
+          find . -type f \( -name "*.c" -or -name "*.h" -or -name "*.yaml" -or -name "*.yml" -or -name "*.sh" -or -name "*.cmake" -or -name "*.py" -or -name "*.pl" -or -name "CMakeLists.txt" \) \
             -exec codespell -I .github/codespell-ignore-words {} \+
 
   cc_checks:

--- a/cmake/GenerateScripts.cmake
+++ b/cmake/GenerateScripts.cmake
@@ -113,7 +113,7 @@ endfunction()
 # update.
 #
 # MODULE_PATHNAME: Pathname to timescale extension of the version being
-# dowgraded to. This can be used to load "old" functions from the correct
+# downgraded to. This can be used to load "old" functions from the correct
 # library.
 function(generate_downgrade_script)
   set(options)

--- a/cmake/ScriptFiles.cmake
+++ b/cmake/ScriptFiles.cmake
@@ -79,7 +79,7 @@ list(APPEND SOURCE_FILES
 list(APPEND SOURCE_FILES
   bgw_startup.sql)
 
-# These files should be pre-pended to update scripts so that they are executed
+# These files should be prepended to update scripts so that they are executed
 # before anything else during updates
 set(PRE_UPDATE_FILES updates/pre-version-change.sql updates/pre-update.sql)
 set(PRE_DOWNGRADE_FILES updates/pre-version-change.sql)

--- a/scripts/backport.py
+++ b/scripts/backport.py
@@ -68,7 +68,7 @@ def get_referenced_issue(pr_number):
     #    'title': '[Bug]: Segfault when `ts_insert_blocker` function is called',
     #    'labels': {'nodes': [{'name': 'bug'}]}}]}}}}}
     #
-    # We can have {'nodes': [None]} in case it references an inaccessble repository,
+    # We can have {'nodes': [None]} in case it references an inaccessible repository,
     # just ignore it.
 
     ref_nodes = ref_result["data"]["repository"]["pullRequest"][

--- a/scripts/export_prefix_check.sh.in
+++ b/scripts/export_prefix_check.sh.in
@@ -25,7 +25,7 @@ fi
 # we also whitelist a couple of special symbols
 #    _.*_init                     module startup functions
 #    _.*_fini                     module shutdown functions
-#    Pg_magic_func                used by postgres to check extension compatability
+#    Pg_magic_func                used by postgres to check extension compatibility
 #    timescaledb_hello            used to test that our name collision resistance works
 #    loader_hello                 used to test that our name collision resistance works
 #    test_symbol_conflict         used to test that our name collision resistance works

--- a/tsl/src/continuous_aggs/repair.c
+++ b/tsl/src/continuous_aggs/repair.c
@@ -87,7 +87,7 @@ cagg_rebuild_view_definition(ContinuousAgg *agg, Hypertable *mat_ht, bool force_
 	RemoveRangeTableEntries(direct_query);
 
 	/*
-	 * If there is a join in CAggs then rebuild it definitley,
+	 * If there is a join in CAggs then rebuild it definitely,
 	 * because v2.10.0 has created the definition with missing structs.
 	 *
 	 * Removed the check for direct_query->jointree != NULL because

--- a/tsl/test/shared/sql/CMakeLists.txt
+++ b/tsl/test/shared/sql/CMakeLists.txt
@@ -21,7 +21,7 @@ if((${PG_VERSION_MAJOR} GREATER_EQUAL "14"))
 endif()
 
 # this test was changing the contents of tables in shared_setup.sql thus causing
-# other dependent tests to fail. Hence runing this test in solo
+# other dependent tests to fail. Hence running this test in solo
 if((${PG_VERSION_MAJOR} GREATER_EQUAL "15"))
   list(APPEND SOLO_TESTS merge_dml.sql)
 endif()

--- a/tsl/test/t/003_mvcc_cagg.pl
+++ b/tsl/test/t/003_mvcc_cagg.pl
@@ -150,7 +150,7 @@ for (my $iteration = 0; $iteration < 10; $iteration++)
 				elsif ($cagg_id != $current_cagg)
 				{
 					diag(
-						"Got watermarks for differnt CAGGs, this test can not handle this ($cagg_id / $current_cagg)\n"
+						"Got watermarks for different CAGGs, this test can not handle this ($cagg_id / $current_cagg)\n"
 					);
 					fail();
 					BAIL_OUT();


### PR DESCRIPTION
(cherry picked from commit 2a3a471bb711c79c59f4d9e9b9062cd61d4aa6a1)