### PR TITLE
Fix segfault in UNION queries with top-level ordering

### DIFF
--- a/.unreleased/pr_6957
+++ b/.unreleased/pr_6957
@@ -1,0 +1,1 @@
+Fixes: #6957 Fix segfault in UNION queries with ordering on compressed chunks

--- a/tsl/test/shared/expected/transparent_decompress_chunk-14.out
+++ b/tsl/test/shared/expected/transparent_decompress_chunk-14.out
@@ -1040,3 +1040,27 @@ EXECUTE param_prep (1);
 
 DEALLOCATE param_prep;
 RESET plan_cache_mode;
+-- test hypertable being non-toplevel equivalence member #6925
+CREATE TABLE i6925_t1(observed timestamptz not null, queryid int8, total_exec_time int8);
+CREATE TABLE i6925_t2(LIKE i6925_t1);
+SELECT table_name FROM create_hypertable('i6925_t1', 'observed');
+ table_name 
+ i6925_t1
+(1 row)
+
+ALTER TABLE i6925_t1 SET (timescaledb.compress, timescaledb.compress_segmentby = 'queryid');
+NOTICE:  default order by for hypertable "i6925_t1" is set to "observed DESC"
+INSERT INTO i6925_t1 SELECT '2020-01-01', 1, 1;
+SELECT count(compress_chunk(chunk_name)) FROM show_chunks('i6925_t1') chunk_name;
+ count 
+     1
+(1 row)
+
+SELECT queryid, lag(total_exec_time) OVER (PARTITION BY queryid) FROM (SELECT * FROM i6925_t1 UNION ALL SELECT * FROM i6925_t2) q;
+ queryid | lag 
+---------+-----
+       1 |    
+(1 row)
+
+DROP TABLE i6925_t1;
+DROP TABLE i6925_t2;

--- a/tsl/test/shared/expected/transparent_decompress_chunk-15.out
+++ b/tsl/test/shared/expected/transparent_decompress_chunk-15.out
@@ -1042,3 +1042,27 @@ EXECUTE param_prep (1);
 
 DEALLOCATE param_prep;
 RESET plan_cache_mode;
+-- test hypertable being non-toplevel equivalence member #6925
+CREATE TABLE i6925_t1(observed timestamptz not null, queryid int8, total_exec_time int8);
+CREATE TABLE i6925_t2(LIKE i6925_t1);
+SELECT table_name FROM create_hypertable('i6925_t1', 'observed');
+ table_name 
+ i6925_t1
+(1 row)
+
+ALTER TABLE i6925_t1 SET (timescaledb.compress, timescaledb.compress_segmentby = 'queryid');
+NOTICE:  default order by for hypertable "i6925_t1" is set to "observed DESC"
+INSERT INTO i6925_t1 SELECT '2020-01-01', 1, 1;
+SELECT count(compress_chunk(chunk_name)) FROM show_chunks('i6925_t1') chunk_name;
+ count 
+     1
+(1 row)
+
+SELECT queryid, lag(total_exec_time) OVER (PARTITION BY queryid) FROM (SELECT * FROM i6925_t1 UNION ALL SELECT * FROM i6925_t2) q;
+ queryid | lag 
+---------+-----
+       1 |    
+(1 row)
+
+DROP TABLE i6925_t1;
+DROP TABLE i6925_t2;

--- a/tsl/test/shared/expected/transparent_decompress_chunk-16.out
+++ b/tsl/test/shared/expected/transparent_decompress_chunk-16.out
@@ -1042,3 +1042,27 @@ EXECUTE param_prep (1);
 
 DEALLOCATE param_prep;
 RESET plan_cache_mode;
+-- test hypertable being non-toplevel equivalence member #6925
+CREATE TABLE i6925_t1(observed timestamptz not null, queryid int8, total_exec_time int8);
+CREATE TABLE i6925_t2(LIKE i6925_t1);
+SELECT table_name FROM create_hypertable('i6925_t1', 'observed');
+ table_name 
+ i6925_t1
+(1 row)
+
+ALTER TABLE i6925_t1 SET (timescaledb.compress, timescaledb.compress_segmentby = 'queryid');
+NOTICE:  default order by for hypertable "i6925_t1" is set to "observed DESC"
+INSERT INTO i6925_t1 SELECT '2020-01-01', 1, 1;
+SELECT count(compress_chunk(chunk_name)) FROM show_chunks('i6925_t1') chunk_name;
+ count 
+     1
+(1 row)
+
+SELECT queryid, lag(total_exec_time) OVER (PARTITION BY queryid) FROM (SELECT * FROM i6925_t1 UNION ALL SELECT * FROM i6925_t2) q;
+ queryid | lag 
+---------+-----
+       1 |    
+(1 row)
+
+DROP TABLE i6925_t1;
+DROP TABLE i6925_t2;

--- a/tsl/test/shared/sql/transparent_decompress_chunk.sql.in
+++ b/tsl/test/shared/sql/transparent_decompress_chunk.sql.in
@@ -331,3 +331,18 @@ EXECUTE param_prep (2);
 EXECUTE param_prep (1);
 DEALLOCATE param_prep;
 RESET plan_cache_mode;
+
+-- test hypertable being non-toplevel equivalence member #6925
+CREATE TABLE i6925_t1(observed timestamptz not null, queryid int8, total_exec_time int8);
+CREATE TABLE i6925_t2(LIKE i6925_t1);
+
+SELECT table_name FROM create_hypertable('i6925_t1', 'observed');
+ALTER TABLE i6925_t1 SET (timescaledb.compress, timescaledb.compress_segmentby = 'queryid');
+INSERT INTO i6925_t1 SELECT '2020-01-01', 1, 1;
+SELECT count(compress_chunk(chunk_name)) FROM show_chunks('i6925_t1') chunk_name;
+
+SELECT queryid, lag(total_exec_time) OVER (PARTITION BY queryid) FROM (SELECT * FROM i6925_t1 UNION ALL SELECT * FROM i6925_t2) q;
+
+DROP TABLE i6925_t1;
+DROP TABLE i6925_t2;
+


### PR DESCRIPTION
We can't just filter the equivalence member based on em_is_child as our hypertable might not be top-level equivalence member.

Fixes #6925 
