### PR TITLE
Fix segfault creating CAgg on hypertable by hash

### DIFF
--- a/tsl/src/continuous_aggs/common.c
+++ b/tsl/src/continuous_aggs/common.c
@@ -903,7 +903,7 @@ cagg_validate_query(const Query *query, const bool finalized, const char *cagg_s
 	 *       change part_dimension->fd.column_type to partitioning_type
 	 *       below, along with any other fallout.
 	 */
-	if (part_dimension->partitioning != NULL)
+	if (part_dimension == NULL || part_dimension->partitioning != NULL)
 	{
 		ts_cache_release(hcache);
 		ereport(ERROR,


### PR DESCRIPTION
The new hypertable API allows create it with primary space partition and CAggs doesn't support hypertables with custom partition functions.

Fixed the segfault by properly checking if there are an open dimension available during the validation.

Disable-check: force-changelog-file
