### PR TITLE
Fix broken CI build matrix

### DIFF
--- a/.github/gh_matrix_builder.py
+++ b/.github/gh_matrix_builder.py
@@ -43,6 +43,12 @@ m = {
     "include": [],
 }
 
+# Ignored tests that are known to be flaky or have known issues.
+default_ignored_tests = {
+    "bgw_db_scheduler",
+    "bgw_db_scheduler_fixed",
+    "telemetry",
+}
 
 # helper functions to generate matrix entries
 # the release and apache config inherit from the
@@ -65,11 +71,7 @@ def build_debug_config(overrides):
             "coverage": True,
             "cxx": "g++",
             "extra_packages": "clang-14 llvm-14 llvm-14-dev llvm-14-tools",
-            "ignored_tests": {
-                "bgw_db_scheduler",
-                "bgw_db_scheduler_fixed",
-                "telemetry",
-            },
+            "ignored_tests": default_ignored_tests,
             "name": "Debug",
             "os": "ubuntu-22.04",
             "pg_extra_args": "--enable-debug --enable-cassert --with-llvm LLVM_CONFIG=llvm-config-14",
@@ -130,6 +132,11 @@ def build_apache_config(overrides):
 
 
 def macos_config(overrides):
+    macos_ignored_tests = {
+        "bgw_launcher",
+        "pg_dump",
+        "compressed_collation",
+    }
     base_config = dict(
         {
             "cc": "clang",
@@ -137,14 +144,7 @@ def macos_config(overrides):
             "coverage": False,
             "cxx": "clang++",
             "extra_packages": "",
-            "ignored_tests": {
-                "bgw_db_scheduler",
-                "bgw_db_scheduler_fixed",
-                "bgw_launcher",
-                "pg_dump",
-                "remote_connection",
-                "compressed_collation",
-            },
+            "ignored_tests": default_ignored_tests.union(macos_ignored_tests),
             "os": "macos-13",
             "pg_extra_args": "--with-libraries=/usr/local/opt/openssl@3/lib --with-includes=/usr/local/opt/openssl@3/include --without-icu",
             "pg_extensions": "postgres_fdw test_decoding",
@@ -156,34 +156,15 @@ def macos_config(overrides):
     return base_config
 
 
-# common ignored tests for all scheduled pg15 tests
-ignored_tests = {}
-
-# common ignored tests for all non-scheduled pg15 tests (e.g. PRs)
-if pull_request:
-    ignored_tests = {
-        "telemetry",
-    }
-
 # always test debug build on latest of all supported pg versions
-m["include"].append(
-    build_debug_config({"pg": PG14_LATEST, "ignored_tests": ignored_tests})
-)
+m["include"].append(build_debug_config({"pg": PG14_LATEST}))
 
-m["include"].append(
-    build_debug_config({"pg": PG15_LATEST, "ignored_tests": ignored_tests})
-)
+m["include"].append(build_debug_config({"pg": PG15_LATEST}))
 
-m["include"].append(
-    build_debug_config({"pg": PG16_LATEST, "ignored_tests": ignored_tests})
-)
+m["include"].append(build_debug_config({"pg": PG16_LATEST}))
 
 # test timescaledb with release config on latest postgres release in MacOS
-m["include"].append(
-    build_release_config(
-        macos_config({"pg": PG16_LATEST, "ignored_tests": ignored_tests})
-    )
-)
+m["include"].append(build_release_config(macos_config({"pg": PG16_LATEST})))
 
 # Test latest postgres release without telemetry. Also run clang-tidy on it
 # because it's the fastest one.
@@ -193,7 +174,6 @@ m["include"].append(
             "pg": PG16_LATEST,
             "cc": "clang-14",
             "cxx": "clang++-14",
-            "ignored_tests": ignored_tests,
             "tsdb_build_args": "-DLINTER=ON -DWARNINGS_AS_ERRORS=ON",
         }
     )
@@ -204,48 +184,37 @@ m["include"].append(
 # entries to the matrix
 if not pull_request:
     # add debug test for first supported PG14 version
+    pull_request_ignored_tests = {
+        "memoize",
+    }
     m["include"].append(
         build_debug_config(
             {
                 "pg": PG14_EARLIEST,
                 # The early releases don't build with llvm 14.
                 "pg_extra_args": "--enable-debug --enable-cassert --without-llvm",
-                "ignored_tests": {"memoize"},
+                "ignored_tests": default_ignored_tests.union(
+                    pull_request_ignored_tests
+                ),
             }
         )
     )
 
     # add debug test for first supported PG15 version
-    m["include"].append(
-        build_debug_config({"pg": PG15_EARLIEST, "ignored_tests": ignored_tests})
-    )
+    m["include"].append(build_debug_config({"pg": PG15_EARLIEST}))
 
     # add debug test for first supported PG16 version
-    m["include"].append(
-        build_debug_config({"pg": PG16_EARLIEST, "ignored_tests": ignored_tests})
-    )
+    m["include"].append(build_debug_config({"pg": PG16_EARLIEST}))
 
     # add debug tests for timescaledb on latest postgres release in MacOS
-    m["include"].append(
-        build_debug_config(
-            macos_config({"pg": PG15_LATEST, "ignored_tests": ignored_tests})
-        )
-    )
+    m["include"].append(build_debug_config(macos_config({"pg": PG15_LATEST})))
 
-    m["include"].append(
-        build_debug_config(
-            macos_config({"pg": PG16_LATEST, "ignored_tests": ignored_tests})
-        )
-    )
+    m["include"].append(build_debug_config(macos_config({"pg": PG16_LATEST})))
 
     # add release test for latest pg releases
     m["include"].append(build_release_config({"pg": PG14_LATEST}))
-    m["include"].append(
-        build_release_config({"pg": PG15_LATEST, "ignored_tests": ignored_tests})
-    )
-    m["include"].append(
-        build_release_config({"pg": PG16_LATEST, "ignored_tests": ignored_tests})
-    )
+    m["include"].append(build_release_config({"pg": PG15_LATEST}))
+    m["include"].append(build_release_config({"pg": PG16_LATEST}))
 
     # add apache only test for latest pg versions
     for PG_LATEST_VER in PG_LATEST:
@@ -253,10 +222,13 @@ if not pull_request:
 
     # to discover issues with upcoming releases we run CI against
     # the stable branches of supported PG releases
+    pg14_ignored_tests = {
+        "memoize",
+    }
     m["include"].append(
         build_debug_config(
             {
-                "ignored_tests": {"memoize"},
+                "ignored_tests": default_ignored_tests.union(pg14_ignored_tests),
                 "pg": 14,
                 "snapshot": "snapshot",
             }
@@ -267,7 +239,6 @@ if not pull_request:
             {
                 "pg": 15,
                 "snapshot": "snapshot",
-                "ignored_tests": ignored_tests,
             }
         )
     )
@@ -276,7 +247,6 @@ if not pull_request:
             {
                 "pg": 16,
                 "snapshot": "snapshot",
-                "ignored_tests": ignored_tests,
             }
         )
     )


### PR DESCRIPTION
When building the CI matrix we create a list of ignored tests that are known to be flaky but the logic was wrong leading to an empty `IGNORES` variable when running the regression.

https://github.com/timescale/timescaledb/actions/runs/9310783691

Disable-check: force-changelog-file
