### PR TITLE
Add table mappings to compression settings

### DIFF
--- a/sql/pre_install/tables.sql
+++ b/sql/pre_install/tables.sql
@@ -471,7 +471,8 @@ CREATE TABLE _timescaledb_catalog.compression_algorithm (
 );
 
 CREATE TABLE _timescaledb_catalog.compression_settings (
-	relid regclass NOT NULL,
+  relid regclass NOT NULL,
+  compress_relid regclass NULL,
   segmentby text[],
   orderby text[],
   orderby_desc bool[],
@@ -483,6 +484,7 @@ CREATE TABLE _timescaledb_catalog.compression_settings (
 );
 
 SELECT pg_catalog.pg_extension_config_dump('_timescaledb_catalog.compression_settings', '');
+CREATE INDEX compression_settings_compress_relid_idx ON _timescaledb_catalog.compression_settings (compress_relid);
 
 CREATE TABLE _timescaledb_catalog.compression_chunk_size (
   chunk_id integer NOT NULL,

--- a/sql/updates/latest-dev.sql
+++ b/sql/updates/latest-dev.sql
@@ -5,3 +5,64 @@ CREATE FUNCTION _timescaledb_functions.compressed_data_has_nulls(_timescaledb_in
 
 INSERT INTO _timescaledb_catalog.compression_algorithm( id, version, name, description) values
 ( 5, 1, 'COMPRESSION_ALGORITHM_BOOL', 'bool');
+
+
+-------------------------------
+-- Update compression settings
+-------------------------------
+CREATE TABLE _timescaledb_catalog.tempsettings (LIKE _timescaledb_catalog.compression_settings);
+INSERT INTO _timescaledb_catalog.tempsettings SELECT * FROM _timescaledb_catalog.compression_settings;
+ALTER EXTENSION timescaledb DROP TABLE _timescaledb_catalog.compression_settings;
+DROP TABLE _timescaledb_catalog.compression_settings CASCADE;
+
+CREATE TABLE _timescaledb_catalog.compression_settings (
+  relid regclass NOT NULL,
+  compress_relid regclass NULL,
+  segmentby text[],
+  orderby text[],
+  orderby_desc bool[],
+  orderby_nullsfirst bool[],
+  CONSTRAINT compression_settings_pkey PRIMARY KEY (relid),
+  CONSTRAINT compression_settings_check_segmentby CHECK (array_ndims(segmentby) = 1),
+  CONSTRAINT compression_settings_check_orderby_null CHECK ((orderby IS NULL AND orderby_desc IS NULL AND orderby_nullsfirst IS NULL) OR (orderby IS NOT NULL AND orderby_desc IS NOT NULL AND orderby_nullsfirst IS NOT NULL)),
+  CONSTRAINT compression_settings_check_orderby_cardinality CHECK (array_ndims(orderby) = 1 AND array_ndims(orderby_desc) = 1 AND array_ndims(orderby_nullsfirst) = 1 AND cardinality(orderby) = cardinality(orderby_desc) AND cardinality(orderby) = cardinality(orderby_nullsfirst))
+);
+
+-- Insert updated settings
+INSERT INTO _timescaledb_catalog.compression_settings
+SELECT
+    CASE
+        WHEN h.schema_name IS NOT NULL THEN
+            cs.relid
+        ELSE
+            format('%I.%I', ch.schema_name, ch.table_name)::regclass
+    END AS relid,
+    CASE
+        WHEN h.schema_name IS NOT NULL THEN
+            NULL
+        ELSE
+            cs.relid
+    END AS compress_relid,
+    cs.segmentby,
+    cs.orderby,
+    cs.orderby_desc,
+    cs.orderby_nullsfirst
+FROM
+    _timescaledb_catalog.tempsettings cs
+INNER JOIN
+    pg_class c ON (cs.relid = c.oid)
+INNER JOIN
+    pg_namespace ns ON (ns.oid = c.relnamespace)
+LEFT JOIN
+    _timescaledb_catalog.hypertable h ON (h.schema_name = ns.nspname AND h.table_name = c.relname)
+LEFT JOIN
+    _timescaledb_catalog.chunk cch ON (cch.schema_name = ns.nspname AND cch.table_name = c.relname)
+LEFT JOIN
+    _timescaledb_catalog.chunk ch ON (cch.id = ch.compressed_chunk_id);
+
+-- Add index on secondary compressed relid key
+CREATE INDEX compression_settings_compress_relid_idx ON _timescaledb_catalog.compression_settings (compress_relid);
+
+DROP TABLE _timescaledb_catalog.tempsettings CASCADE;
+GRANT SELECT ON _timescaledb_catalog.compression_settings TO PUBLIC;
+SELECT pg_catalog.pg_extension_config_dump('_timescaledb_catalog.compression_settings', '');

--- a/sql/updates/reverse-dev.sql
+++ b/sql/updates/reverse-dev.sql
@@ -1,3 +1,41 @@
 DROP FUNCTION IF EXISTS _timescaledb_functions.compressed_data_has_nulls(_timescaledb_internal.compressed_data);
 
 DELETE FROM _timescaledb_catalog.compression_algorithm WHERE id = 5 AND version = 1 AND name = 'COMPRESSION_ALGORITHM_BOOL';
+
+-- Update compression settings
+CREATE TABLE _timescaledb_catalog.tempsettings (LIKE _timescaledb_catalog.compression_settings);
+INSERT INTO _timescaledb_catalog.tempsettings SELECT * FROM _timescaledb_catalog.compression_settings;
+ALTER EXTENSION timescaledb DROP TABLE _timescaledb_catalog.compression_settings;
+DROP TABLE _timescaledb_catalog.compression_settings CASCADE;
+
+CREATE TABLE _timescaledb_catalog.compression_settings (
+  relid regclass NOT NULL,
+  segmentby text[],
+  orderby text[],
+  orderby_desc bool[],
+  orderby_nullsfirst bool[],
+  CONSTRAINT compression_settings_pkey PRIMARY KEY (relid),
+  CONSTRAINT compression_settings_check_segmentby CHECK (array_ndims(segmentby) = 1),
+  CONSTRAINT compression_settings_check_orderby_null CHECK ((orderby IS NULL AND orderby_desc IS NULL AND orderby_nullsfirst IS NULL) OR (orderby IS NOT NULL AND orderby_desc IS NOT NULL AND orderby_nullsfirst IS NOT NULL)),
+  CONSTRAINT compression_settings_check_orderby_cardinality CHECK (array_ndims(orderby) = 1 AND array_ndims(orderby_desc) = 1 AND array_ndims(orderby_nullsfirst) = 1 AND cardinality(orderby) = cardinality(orderby_desc) AND cardinality(orderby) = cardinality(orderby_nullsfirst))
+);
+
+-- Revert information in compression settings
+INSERT INTO _timescaledb_catalog.compression_settings
+SELECT
+    CASE
+        WHEN cs.compress_relid IS NULL THEN
+            cs.relid
+        ELSE
+            cs.compress_relid
+    END as relid,
+    cs.segmentby,
+    cs.orderby,
+    cs.orderby_desc,
+    cs.orderby_nullsfirst
+FROM
+    _timescaledb_catalog.tempsettings cs;
+
+DROP TABLE _timescaledb_catalog.tempsettings CASCADE;
+GRANT SELECT ON _timescaledb_catalog.compression_settings TO PUBLIC;
+SELECT pg_catalog.pg_extension_config_dump('_timescaledb_catalog.compression_settings', '');

--- a/sql/views.sql
+++ b/sql/views.sql
@@ -388,9 +388,8 @@ CREATE OR REPLACE VIEW timescaledb_information.chunk_compression_settings AS
 		array_to_string(segmentby,',') AS segmentby,
 		un.orderby
 	FROM _timescaledb_catalog.hypertable ht
-	INNER JOIN _timescaledb_catalog.chunk ch ON ch.hypertable_id = ht.id
-  INNER JOIN _timescaledb_catalog.chunk ch2 ON ch2.id = ch.compressed_chunk_id
-  LEFT JOIN _timescaledb_catalog.compression_settings s ON format('%I.%I',ch2.schema_name,ch2.table_name)::regclass = s.relid
+    INNER JOIN _timescaledb_catalog.chunk ch ON ch.hypertable_id = ht.id
+    INNER JOIN _timescaledb_catalog.compression_settings s ON (format('%I.%I',ch.schema_name,ch.table_name)::regclass = s.relid)
 	LEFT JOIN LATERAL (
 		SELECT
 			string_agg(

--- a/src/chunk.c
+++ b/src/chunk.c
@@ -2806,6 +2806,10 @@ typedef enum ChunkDeleteResult
 
 /* Delete the chunk tuple.
  *
+ * relid: Required when deleting via an event trigger hook, because at that
+ * point the relation is gone and it is no longer possible to resolve the Oid
+ * from the PG catalog.
+ *
  * preserve_chunk_catalog_row - instead of deleting the row, mark it as dropped.
  * this is used when we need to preserve catalog information about the chunk
  * after dropping it. Currently only used when preserving continuous aggregates
@@ -2822,7 +2826,7 @@ typedef enum ChunkDeleteResult
  * of tuples to process.
  */
 static ChunkDeleteResult
-chunk_tuple_delete(TupleInfo *ti, DropBehavior behavior, bool preserve_chunk_catalog_row)
+chunk_tuple_delete(TupleInfo *ti, Oid relid, DropBehavior behavior, bool preserve_chunk_catalog_row)
 {
 	FormData_chunk form;
 	CatalogSecurityContext sec_ctx;
@@ -2908,18 +2912,38 @@ chunk_tuple_delete(TupleInfo *ti, DropBehavior behavior, bool preserve_chunk_cat
 	/* Delete any rows in _timescaledb_catalog.chunk_column_stats corresponding to this chunk */
 	ts_chunk_column_stats_delete_by_chunk_id(form.id);
 
+	if (!OidIsValid(relid))
+	{
+		/*
+		 * If the chunk is deleted as a result of deleting the Hypertable, and
+		 * it is cleaned up in the DROP eventtrigger hook, it might not be
+		 * possible to resolve the relid because the relation is already gone
+		 * in pg_catalog. But that's OK, because compression settings will be
+		 * cleaned up when processing the eventtrigger.
+		 */
+		relid = ts_get_relation_relid(NameStr(form.schema_name), NameStr(form.table_name), true);
+	}
+
 	if (form.compressed_chunk_id != INVALID_CHUNK_ID)
 	{
 		Chunk *compressed_chunk = ts_chunk_get_by_id(form.compressed_chunk_id, false);
 
-		/* The chunk may have been delete by a CASCADE */
+		if (OidIsValid(relid))
+			ts_compression_settings_delete(relid);
+
+		/* The chunk may have been deleted by a CASCADE */
 		if (compressed_chunk != NULL)
 		{
 			/* Plain drop without preserving catalog row because this is the compressed
 			 * chunk */
-			ts_compression_settings_delete(compressed_chunk->table_id);
 			ts_chunk_drop(compressed_chunk, behavior, DEBUG1);
 		}
+	}
+	else if (OidIsValid(relid))
+	{
+		/* If there is no compressed chunk ID, this might be the actual
+		 * compressed chunk */
+		ts_compression_settings_delete_by_compress_relid(relid);
 	}
 
 	ts_catalog_database_info_become_owner(ts_catalog_database_info_get(), &sec_ctx);
@@ -2971,7 +2995,8 @@ init_scan_by_qualified_table_name(ScanIterator *iterator, const char *schema_nam
 }
 
 static int
-chunk_delete(ScanIterator *iterator, DropBehavior behavior, bool preserve_chunk_catalog_row)
+chunk_delete(ScanIterator *iterator, Oid relid, DropBehavior behavior,
+			 bool preserve_chunk_catalog_row)
 {
 	int count = 0;
 
@@ -2980,6 +3005,7 @@ chunk_delete(ScanIterator *iterator, DropBehavior behavior, bool preserve_chunk_
 		ChunkDeleteResult res;
 
 		res = chunk_tuple_delete(ts_scan_iterator_tuple_info(iterator),
+								 relid,
 								 behavior,
 								 preserve_chunk_catalog_row);
 
@@ -2999,14 +3025,14 @@ chunk_delete(ScanIterator *iterator, DropBehavior behavior, bool preserve_chunk_
 }
 
 static int
-ts_chunk_delete_by_name_internal(const char *schema, const char *table, DropBehavior behavior,
-								 bool preserve_chunk_catalog_row)
+ts_chunk_delete_by_name_internal(const char *schema, const char *table, Oid relid,
+								 DropBehavior behavior, bool preserve_chunk_catalog_row)
 {
 	ScanIterator iterator = ts_scan_iterator_create(CHUNK, RowExclusiveLock, CurrentMemoryContext);
 	int count;
 
 	init_scan_by_qualified_table_name(&iterator, schema, table);
-	count = chunk_delete(&iterator, behavior, preserve_chunk_catalog_row);
+	count = chunk_delete(&iterator, relid, behavior, preserve_chunk_catalog_row);
 
 	/* (schema,table) names and (hypertable_id) are unique so should only have
 	 * dropped one chunk or none (if not found) */
@@ -3018,17 +3044,20 @@ ts_chunk_delete_by_name_internal(const char *schema, const char *table, DropBeha
 int
 ts_chunk_delete_by_name(const char *schema, const char *table, DropBehavior behavior)
 {
-	return ts_chunk_delete_by_name_internal(schema, table, behavior, false);
+	Oid relid = ts_get_relation_relid(schema, table, false);
+	return ts_chunk_delete_by_name_internal(schema, table, relid, behavior, false);
 }
 
-static int
-ts_chunk_delete_by_relid(Oid relid, DropBehavior behavior, bool preserve_chunk_catalog_row)
+int
+ts_chunk_delete_by_relid_and_relname(Oid relid, const char *schemaname, const char *tablename,
+									 DropBehavior behavior, bool preserve_chunk_catalog_row)
 {
 	if (!OidIsValid(relid))
 		return 0;
 
-	return ts_chunk_delete_by_name_internal(get_namespace_name(get_rel_namespace(relid)),
-											get_rel_name(relid),
+	return ts_chunk_delete_by_name_internal(schemaname,
+											tablename,
+											relid,
 											behavior,
 											preserve_chunk_catalog_row);
 }
@@ -3051,7 +3080,7 @@ ts_chunk_delete_by_hypertable_id(int32 hypertable_id)
 
 	init_scan_by_hypertable_id(&iterator, hypertable_id);
 
-	return chunk_delete(&iterator, DROP_RESTRICT, false);
+	return chunk_delete(&iterator, InvalidOid, DROP_RESTRICT, false);
 }
 
 bool
@@ -3736,7 +3765,11 @@ ts_chunk_drop_internal(const Chunk *chunk, DropBehavior behavior, int32 log_leve
 			 NameStr(chunk->fd.table_name));
 
 	/* Remove the chunk from the chunk table */
-	ts_chunk_delete_by_relid(chunk->table_id, behavior, preserve_catalog_row);
+	ts_chunk_delete_by_relid_and_relname(chunk->table_id,
+										 NameStr(chunk->fd.schema_name),
+										 NameStr(chunk->fd.table_name),
+										 behavior,
+										 preserve_catalog_row);
 
 	/* Drop the table */
 	performDeletion(&objaddr, behavior, 0);

--- a/src/chunk.h
+++ b/src/chunk.h
@@ -190,6 +190,9 @@ extern void ts_chunk_recreate_all_constraints_for_dimension(Hypertable *ht, int3
 extern int ts_chunk_delete_by_hypertable_id(int32 hypertable_id);
 extern TSDLLEXPORT int ts_chunk_delete_by_name(const char *schema, const char *table,
 											   DropBehavior behavior);
+extern int ts_chunk_delete_by_relid_and_relname(Oid relid, const char *schemaname,
+												const char *tablename, DropBehavior behavior,
+												bool preserve_chunk_catalog_row);
 extern bool ts_chunk_set_name(Chunk *chunk, const char *newname);
 extern bool ts_chunk_set_schema(Chunk *chunk, const char *newschema);
 extern TSDLLEXPORT List *ts_chunk_get_window(int32 dimension_id, int64 point, int count,

--- a/src/nodes/chunk_dispatch/chunk_insert_state.c
+++ b/src/nodes/chunk_dispatch/chunk_insert_state.c
@@ -514,7 +514,6 @@ ts_chunk_insert_state_create(Oid chunk_relid, const ChunkDispatch *dispatch)
 	state->rel = rel;
 	state->result_relation_info = relinfo;
 	state->estate = dispatch->estate;
-	state->compressed_chunk_table_id = InvalidOid;
 	state->use_tam = ts_is_hypercore_am(chunk->amoid);
 	ts_set_compression_status(state, chunk);
 
@@ -565,7 +564,6 @@ ts_chunk_insert_state_create(Oid chunk_relid, const ChunkDispatch *dispatch)
 
 	state->hypertable_relid = chunk->hypertable_relid;
 	state->chunk_id = chunk->fd.id;
-	state->compressed_chunk_id = chunk->fd.compressed_chunk_id;
 
 	if (chunk->relkind == RELKIND_FOREIGN_TABLE)
 	{
@@ -633,9 +631,6 @@ ts_set_compression_status(ChunkInsertState *state, const Chunk *chunk)
 	if (state->chunk_compressed)
 	{
 		state->chunk_partial = ts_chunk_is_partial(chunk);
-		if (!OidIsValid(state->compressed_chunk_table_id))
-			state->compressed_chunk_table_id =
-				ts_chunk_get_relid(chunk->fd.compressed_chunk_id, false);
 	}
 }
 

--- a/src/nodes/chunk_dispatch/chunk_insert_state.h
+++ b/src/nodes/chunk_dispatch/chunk_insert_state.h
@@ -49,7 +49,6 @@ typedef struct ChunkInsertState
 	EState *estate;
 	Oid hypertable_relid;
 	int32 chunk_id;
-	int32 compressed_chunk_id;
 	Oid user_id;
 
 	/* for tracking compressed chunks */
@@ -58,8 +57,6 @@ typedef struct ChunkInsertState
 
 	/* Chunk uses our own table access method */
 	bool use_tam;
-
-	Oid compressed_chunk_table_id;
 } ChunkInsertState;
 
 typedef struct ChunkDispatch ChunkDispatch;

--- a/src/process_utility.c
+++ b/src/process_utility.c
@@ -2244,7 +2244,9 @@ process_rename_column(ProcessUtilityArgs *args, Cache *hcache, Oid relid, Rename
 	 * */
 	if (ht)
 	{
-		ts_compression_settings_rename_column_hypertable(ht, stmt->subname, stmt->newname);
+		ts_compression_settings_rename_column_cascade(ht->main_table_relid,
+													  stmt->subname,
+													  stmt->newname);
 		add_hypertable_to_process_args(args, ht);
 		dim = ts_hyperspace_get_mutable_dimension_by_name(ht->space,
 														  DIMENSION_TYPE_ANY,
@@ -2580,15 +2582,15 @@ validate_set_not_null(Hypertable *ht, Oid chunk_relid, void *arg)
 	{
 		StringInfoData command;
 		AlterTableCmd *cmd = (AlterTableCmd *) arg;
-		Chunk *comp_chunk = ts_chunk_get_by_id(chunk->fd.compressed_chunk_id, true);
+		const CompressionSettings *settings = ts_compression_settings_get(chunk->table_id);
+		Oid nspcid = get_rel_namespace(settings->fd.compress_relid);
 
 		initStringInfo(&command);
 		appendStringInfo(&command,
 						 "SELECT EXISTS(SELECT FROM %s.%s WHERE ",
-						 quote_identifier(NameStr(comp_chunk->fd.schema_name)),
-						 quote_identifier(NameStr(comp_chunk->fd.table_name)));
+						 quote_identifier(get_namespace_name(nspcid)),
+						 quote_identifier(get_rel_name(settings->fd.compress_relid)));
 
-		CompressionSettings *settings = ts_compression_settings_get(comp_chunk->table_id);
 		if (ts_array_is_member(settings->fd.segmentby, cmd->name))
 		{
 			/* For segmentby we can check directly whether NULLS are present */
@@ -4998,9 +5000,22 @@ process_drop_table(EventTriggerDropObject *obj)
 	EventTriggerDropRelation *table = (EventTriggerDropRelation *) obj;
 
 	Assert(obj->type == EVENT_TRIGGER_DROP_TABLE || obj->type == EVENT_TRIGGER_DROP_FOREIGN_TABLE);
+	ts_chunk_delete_by_relid_and_relname(table->relid,
+										 table->schema,
+										 table->name,
+										 DROP_RESTRICT,
+										 false);
 	ts_hypertable_delete_by_name(table->schema, table->name);
-	ts_chunk_delete_by_name(table->schema, table->name, DROP_RESTRICT);
-	ts_compression_settings_delete(table->relid);
+	/*
+	 * Normally, compression settings are cleaned up when deleting the
+	 * hypertable or chunk. However, in some cases, e.g., when a hypertable
+	 * delete cascades to chunks, the chunk relids cannot be resolved from the
+	 * schema and name because the chunk relations are already dropped by
+	 * PostgreSQL when the "drop eventtrigger" is called. Therefore, also try
+	 * to delete compression settings here since the eventtrigger gives us the
+	 * relid of dropped objects.
+	 */
+	ts_compression_settings_delete_any(table->relid);
 }
 
 static void

--- a/src/ts_catalog/catalog.c
+++ b/src/ts_catalog/catalog.c
@@ -248,6 +248,7 @@ static const TableIndexDef catalog_table_index_definitions[_MAX_CATALOG_TABLES] 
 		.length =  _MAX_COMPRESSION_SETTINGS_INDEX,
 		.names = (char *[]) {
 			[COMPRESSION_SETTINGS_PKEY] = "compression_settings_pkey",
+			[COMPRESSION_SETTINGS_COMPRESS_RELID_IDX] = "compression_settings_compress_relid_idx",
 		},
 	},
 	[COMPRESSION_CHUNK_SIZE] = {

--- a/src/ts_catalog/catalog.h
+++ b/src/ts_catalog/catalog.h
@@ -1155,6 +1155,7 @@ typedef enum Anum_continuous_aggs_watermark_pkey
 typedef enum Anum_compression_settings
 {
 	Anum_compression_settings_relid = 1,
+	Anum_compression_settings_compress_relid,
 	Anum_compression_settings_segmentby,
 	Anum_compression_settings_orderby,
 	Anum_compression_settings_orderby_desc,
@@ -1167,6 +1168,7 @@ typedef enum Anum_compression_settings
 typedef struct FormData_compression_settings
 {
 	Oid relid;
+	Oid compress_relid;
 	ArrayType *segmentby;
 	ArrayType *orderby;
 	ArrayType *orderby_desc;
@@ -1178,6 +1180,7 @@ typedef FormData_compression_settings *Form_compression_settings;
 enum
 {
 	COMPRESSION_SETTINGS_PKEY = 0,
+	COMPRESSION_SETTINGS_COMPRESS_RELID_IDX,
 	_MAX_COMPRESSION_SETTINGS_INDEX,
 };
 
@@ -1188,6 +1191,15 @@ typedef enum Anum_compression_settings_pkey
 } Anum_compression_settings_pkey;
 
 #define Natts_compression_chunk_size_pkey (_Anum_compression_chunk_size_pkey_max - 1)
+
+typedef enum Anum_compression_settings_compress_relid_idx
+{
+	Anum_compression_settings_compress_relid_idx_relid = 1,
+	_Anum_compression_settings_compress_relid_idx_max,
+} Anum_compression_settings_compress_relid_idx;
+
+#define Natts_compression_settings_compress_relid_idx                                              \
+	(_Anum_compression_settings_compress_relid_idx_max - 1)
 
 #define COMPRESSION_CHUNK_SIZE_TABLE_NAME "compression_chunk_size"
 typedef enum Anum_compression_chunk_size

--- a/src/ts_catalog/compression_settings.c
+++ b/src/ts_catalog/compression_settings.c
@@ -4,15 +4,15 @@
  * LICENSE-APACHE for a copy of the license.
  */
 #include <postgres.h>
+#include <catalog/pg_inherits.h>
 #include <utils/builtins.h>
 
-#include "chunk.h"
-#include "hypertable.h"
 #include "scan_iterator.h"
 #include "scanner.h"
 #include "ts_catalog/array_utils.h"
 #include "ts_catalog/catalog.h"
 #include "ts_catalog/compression_settings.h"
+#include <utils/palloc.h>
 
 static ScanTupleResult compression_settings_tuple_update(TupleInfo *ti, void *data);
 static HeapTuple compression_settings_formdata_make_tuple(const FormData_compression_settings *fd,
@@ -28,11 +28,10 @@ ts_compression_settings_equal(const CompressionSettings *left, const Compression
 }
 
 CompressionSettings *
-ts_compression_settings_materialize(Oid ht_relid, Oid dst_relid)
+ts_compression_settings_materialize(const CompressionSettings *src, Oid relid, Oid compress_relid)
 {
-	CompressionSettings *src = ts_compression_settings_get(ht_relid);
-	Assert(src);
-	CompressionSettings *dst = ts_compression_settings_create(dst_relid,
+	CompressionSettings *dst = ts_compression_settings_create(relid,
+															  compress_relid,
 															  src->fd.segmentby,
 															  src->fd.orderby,
 															  src->fd.orderby_desc,
@@ -42,8 +41,9 @@ ts_compression_settings_materialize(Oid ht_relid, Oid dst_relid)
 }
 
 CompressionSettings *
-ts_compression_settings_create(Oid relid, ArrayType *segmentby, ArrayType *orderby,
-							   ArrayType *orderby_desc, ArrayType *orderby_nullsfirst)
+ts_compression_settings_create(Oid relid, Oid compress_relid, ArrayType *segmentby,
+							   ArrayType *orderby, ArrayType *orderby_desc,
+							   ArrayType *orderby_nullsfirst)
 {
 	Catalog *catalog = ts_catalog_get();
 	CatalogSecurityContext sec_ctx;
@@ -61,6 +61,7 @@ ts_compression_settings_create(Oid relid, ArrayType *segmentby, ArrayType *order
 		   (!orderby && !orderby_desc && !orderby_nullsfirst));
 
 	fd.relid = relid;
+	fd.compress_relid = compress_relid;
 	fd.segmentby = segmentby;
 	fd.orderby = orderby;
 	fd.orderby_desc = orderby_desc;
@@ -95,6 +96,12 @@ compression_settings_fill_from_tuple(CompressionSettings *settings, TupleInfo *t
 
 	fd->relid = DatumGetObjectId(values[AttrNumberGetAttrOffset(Anum_compression_settings_relid)]);
 
+	if (nulls[AttrNumberGetAttrOffset(Anum_compression_settings_compress_relid)])
+		fd->compress_relid = InvalidOid;
+	else
+		fd->compress_relid = DatumGetObjectId(
+			values[AttrNumberGetAttrOffset(Anum_compression_settings_compress_relid)]);
+
 	if (nulls[AttrNumberGetAttrOffset(Anum_compression_settings_segmentby)])
 		fd->segmentby = NULL;
 	else
@@ -125,19 +132,35 @@ compression_settings_fill_from_tuple(CompressionSettings *settings, TupleInfo *t
 		heap_freetuple(tuple);
 }
 
-TSDLLEXPORT CompressionSettings *
-ts_compression_settings_get(Oid relid)
+static void
+compression_settings_iterator_init(ScanIterator *iterator, Oid relid, bool by_compress_relid)
+{
+	int indexid =
+		by_compress_relid ? COMPRESSION_SETTINGS_COMPRESS_RELID_IDX : COMPRESSION_SETTINGS_PKEY;
+	iterator->ctx.index = catalog_get_index(ts_catalog_get(), COMPRESSION_SETTINGS, indexid);
+	ts_scan_iterator_scan_key_init(iterator,
+								   by_compress_relid ?
+									   Anum_compression_settings_compress_relid_idx_relid :
+									   Anum_compression_settings_pkey_relid,
+								   BTEqualStrategyNumber,
+								   F_OIDEQ,
+								   ObjectIdGetDatum(relid));
+}
+
+/*
+ * Get compression settings for a relation.
+ *
+ * When 'by_compress_relid' is false, the 'relid' refers to the "main"
+ * relation being compressed. When it is true the 'relid' refers to the
+ * relation containing the associated compressed data.
+ */
+static CompressionSettings *
+compression_settings_get(Oid relid, bool by_compress_relid)
 {
 	CompressionSettings *settings = NULL;
 	ScanIterator iterator =
 		ts_scan_iterator_create(COMPRESSION_SETTINGS, AccessShareLock, CurrentMemoryContext);
-	iterator.ctx.index =
-		catalog_get_index(ts_catalog_get(), COMPRESSION_SETTINGS, COMPRESSION_SETTINGS_PKEY);
-	ts_scan_iterator_scan_key_init(&iterator,
-								   Anum_compression_settings_pkey_relid,
-								   BTEqualStrategyNumber,
-								   F_OIDEQ,
-								   ObjectIdGetDatum(relid));
+	compression_settings_iterator_init(&iterator, relid, by_compress_relid);
 
 	ts_scanner_start_scan(&iterator.ctx);
 	TupleInfo *ti = ts_scanner_next(&iterator.ctx);
@@ -151,8 +174,38 @@ ts_compression_settings_get(Oid relid)
 	return settings;
 }
 
-TSDLLEXPORT bool
-ts_compression_settings_delete(Oid relid)
+/*
+ * Get the compression settings for the relation referred to by 'relid'.
+ */
+TSDLLEXPORT CompressionSettings *
+ts_compression_settings_get(Oid relid)
+{
+	return compression_settings_get(relid, false);
+}
+
+/*
+ * Get the compression settings for a relation given its associated compressed
+ * relation.
+ *
+ * Ideally, settings should only be looked up by "primary key", i.e., the
+ * non-compressed chunk's 'relid', and in that case this function wouldn't be
+ * needed. It might be possible to remove this function in the future.
+ */
+TSDLLEXPORT CompressionSettings *
+ts_compression_settings_get_by_compress_relid(Oid relid)
+{
+	return compression_settings_get(relid, true);
+}
+
+/*
+ * Delete compression settings for a relation.
+ *
+ * When 'by_compress_relid' is false, the 'relid' refers to the "main"
+ * relation being compressed. When it is true the 'relid' refers to the
+ * relation containing the associated compressed data.
+ */
+static bool
+compression_settings_delete(Oid relid, bool by_compress_relid)
 {
 	if (!OidIsValid(relid))
 		return false;
@@ -160,13 +213,7 @@ ts_compression_settings_delete(Oid relid)
 	int count = 0;
 	ScanIterator iterator =
 		ts_scan_iterator_create(COMPRESSION_SETTINGS, RowExclusiveLock, CurrentMemoryContext);
-	iterator.ctx.index =
-		catalog_get_index(ts_catalog_get(), COMPRESSION_SETTINGS, COMPRESSION_SETTINGS_PKEY);
-	ts_scan_iterator_scan_key_init(&iterator,
-								   Anum_compression_settings_pkey_relid,
-								   BTEqualStrategyNumber,
-								   F_OIDEQ,
-								   ObjectIdGetDatum(relid));
+	compression_settings_iterator_init(&iterator, relid, by_compress_relid);
 
 	ts_scanner_foreach(&iterator)
 	{
@@ -177,35 +224,64 @@ ts_compression_settings_delete(Oid relid)
 	return count > 0;
 }
 
-TSDLLEXPORT void
-ts_compression_settings_rename_column_hypertable(Hypertable *ht, char *old, char *new)
+/*
+ * Delete entries matching the non-compressed relation.
+ */
+TSDLLEXPORT bool
+ts_compression_settings_delete(Oid relid)
 {
-	ts_compression_settings_rename_column(ht->main_table_relid, old, new);
-	if (ht->fd.compressed_hypertable_id)
-	{
-		ListCell *lc;
-		List *chunks = ts_chunk_get_by_hypertable_id(ht->fd.compressed_hypertable_id);
-		foreach (lc, chunks)
-		{
-			Chunk *chunk = lfirst(lc);
-			ts_compression_settings_rename_column(chunk->table_id, old, new);
-		}
-	}
+	return compression_settings_delete(relid, false);
+}
+
+/*
+ * Delete entries matching a compressed relation.
+ */
+TSDLLEXPORT bool
+ts_compression_settings_delete_by_compress_relid(Oid relid)
+{
+	return compression_settings_delete(relid, true);
+}
+
+/*
+ * Delete entries matching either the primary key (non-compressed relation) or
+ * the secondary key (compressed relation).
+ */
+TSDLLEXPORT bool
+ts_compression_settings_delete_any(Oid relid)
+{
+	if (!ts_compression_settings_delete(relid))
+		return ts_compression_settings_delete_by_compress_relid(relid);
+	return true;
+}
+
+static void
+compression_settings_rename_column(CompressionSettings *settings, const char *old, const char *new)
+{
+	settings->fd.segmentby = ts_array_replace_text(settings->fd.segmentby, old, new);
+	settings->fd.orderby = ts_array_replace_text(settings->fd.orderby, old, new);
+	ts_compression_settings_update(settings);
 }
 
 TSDLLEXPORT void
-ts_compression_settings_rename_column(Oid relid, char *old, char *new)
+ts_compression_settings_rename_column_cascade(Oid parent_relid, const char *old, const char *new)
 {
-	CompressionSettings *settings = ts_compression_settings_get(relid);
+	CompressionSettings *settings = ts_compression_settings_get(parent_relid);
 
-	if (!settings)
-		return;
+	if (settings)
+		compression_settings_rename_column(settings, old, new);
 
-	settings->fd.segmentby = ts_array_replace_text(settings->fd.segmentby, old, new);
+	List *children = find_inheritance_children(parent_relid, NoLock);
+	ListCell *lc;
 
-	settings->fd.orderby = ts_array_replace_text(settings->fd.orderby, old, new);
+	foreach (lc, children)
+	{
+		Oid relid = lfirst_oid(lc);
 
-	ts_compression_settings_update(settings);
+		settings = ts_compression_settings_get(relid);
+
+		if (settings)
+			compression_settings_rename_column(settings, old, new);
+	}
 }
 
 TSDLLEXPORT int
@@ -268,6 +344,12 @@ compression_settings_formdata_make_tuple(const FormData_compression_settings *fd
 	bool nulls[Natts_compression_settings] = { false };
 
 	values[AttrNumberGetAttrOffset(Anum_compression_settings_relid)] = ObjectIdGetDatum(fd->relid);
+
+	if (OidIsValid(fd->compress_relid))
+		values[AttrNumberGetAttrOffset(Anum_compression_settings_compress_relid)] =
+			ObjectIdGetDatum(fd->compress_relid);
+	else
+		nulls[AttrNumberGetAttrOffset(Anum_compression_settings_compress_relid)] = true;
 
 	if (fd->segmentby)
 		values[AttrNumberGetAttrOffset(Anum_compression_settings_segmentby)] =

--- a/src/ts_catalog/compression_settings.h
+++ b/src/ts_catalog/compression_settings.h
@@ -8,7 +8,6 @@
 #include <postgres.h>
 #include <catalog/pg_type.h>
 
-#include "hypertable.h"
 #include "ts_catalog/catalog.h"
 
 typedef struct CompressionSettings
@@ -16,18 +15,21 @@ typedef struct CompressionSettings
 	FormData_compression_settings fd;
 } CompressionSettings;
 
-TSDLLEXPORT CompressionSettings *ts_compression_settings_create(Oid relid, ArrayType *segmentby,
+TSDLLEXPORT CompressionSettings *ts_compression_settings_create(Oid relid, Oid compress_relid,
+																ArrayType *segmentby,
 																ArrayType *orderby,
 																ArrayType *orderby_desc,
 																ArrayType *orderby_nullsfirst);
 TSDLLEXPORT CompressionSettings *ts_compression_settings_get(Oid relid);
-TSDLLEXPORT CompressionSettings *ts_compression_settings_materialize(Oid ht_relid, Oid dst_relid);
+TSDLLEXPORT CompressionSettings *ts_compression_settings_get_by_compress_relid(Oid relid);
+TSDLLEXPORT CompressionSettings *ts_compression_settings_materialize(const CompressionSettings *src,
+																	 Oid relid, Oid compress_relid);
 TSDLLEXPORT bool ts_compression_settings_delete(Oid relid);
+TSDLLEXPORT bool ts_compression_settings_delete_by_compress_relid(Oid relid);
+TSDLLEXPORT bool ts_compression_settings_delete_any(Oid relid);
 TSDLLEXPORT bool ts_compression_settings_equal(const CompressionSettings *left,
 											   const CompressionSettings *right);
 
 TSDLLEXPORT int ts_compression_settings_update(CompressionSettings *settings);
-
-TSDLLEXPORT void ts_compression_settings_rename_column(Oid relid, char *old, char *new);
-TSDLLEXPORT void ts_compression_settings_rename_column_hypertable(Hypertable *ht, char *old,
-																  char *new);
+TSDLLEXPORT void ts_compression_settings_rename_column_cascade(Oid parent_relid, const char *old,
+															   const char *new);

--- a/tsl/src/compression/compression.h
+++ b/tsl/src/compression/compression.h
@@ -358,13 +358,13 @@ extern void compress_row_destroy(CompressSingleRowState *cr);
 extern int row_decompressor_decompress_row_to_table(RowDecompressor *row_decompressor);
 extern void row_decompressor_decompress_row_to_tuplesort(RowDecompressor *row_decompressor,
 														 Tuplesortstate *tuplesortstate);
-extern void compress_chunk_populate_sort_info_for_column(CompressionSettings *settings, Oid table,
-														 const char *attname, AttrNumber *att_nums,
-														 Oid *sort_operator, Oid *collation,
-														 bool *nulls_first);
+extern void compress_chunk_populate_sort_info_for_column(const CompressionSettings *settings,
+														 Oid table, const char *attname,
+														 AttrNumber *att_nums, Oid *sort_operator,
+														 Oid *collation, bool *nulls_first);
 extern Tuplesortstate *compression_create_tuplesort_state(CompressionSettings *settings,
 														  Relation rel);
-extern void row_compressor_init(CompressionSettings *settings, RowCompressor *row_compressor,
+extern void row_compressor_init(const CompressionSettings *settings, RowCompressor *row_compressor,
 								Relation uncompressed_table, Relation compressed_table,
 								int16 num_columns_in_compressed_table, bool need_bistate,
 								int insert_options);
@@ -373,7 +373,8 @@ extern void row_compressor_close(RowCompressor *row_compressor);
 extern void row_compressor_append_sorted_rows(RowCompressor *row_compressor,
 											  Tuplesortstate *sorted_rel, TupleDesc sorted_desc,
 											  Relation in_rel);
-extern Oid get_compressed_chunk_index(ResultRelInfo *resultRelInfo, CompressionSettings *settings);
+extern Oid get_compressed_chunk_index(ResultRelInfo *resultRelInfo,
+									  const CompressionSettings *settings);
 
 extern void segment_info_update(SegmentInfo *segment_info, Datum val, bool is_null);
 

--- a/tsl/src/compression/compression_dml.c
+++ b/tsl/src/compression/compression_dml.c
@@ -96,11 +96,9 @@ decompress_batches_for_insert(const ChunkInsertState *cis, TupleTableSlot *slot)
 		return;
 	}
 
-	Assert(OidIsValid(cis->compressed_chunk_table_id));
-	Relation in_rel = relation_open(cis->compressed_chunk_table_id, RowExclusiveLock);
-	CompressionSettings *settings = ts_compression_settings_get(cis->compressed_chunk_table_id);
-	Assert(settings);
-
+	CompressionSettings *settings = ts_compression_settings_get(RelationGetRelid(cis->rel));
+	Assert(settings && OidIsValid(settings->fd.compress_relid));
+	Relation in_rel = relation_open(settings->fd.compress_relid, RowExclusiveLock);
 	Bitmapset *index_columns = NULL;
 	Bitmapset *null_columns = NULL;
 	struct decompress_batches_stats stats;
@@ -229,7 +227,6 @@ decompress_batches_for_update_delete(HypertableModifyState *ht_state, Chunk *chu
 	Relation chunk_rel;
 	Relation comp_chunk_rel;
 	Relation matching_index_rel = NULL;
-	Chunk *comp_chunk;
 	BatchFilter *filter;
 
 	ScanKeyData *scankeys = NULL;
@@ -241,8 +238,7 @@ decompress_batches_for_update_delete(HypertableModifyState *ht_state, Chunk *chu
 	int num_mem_scankeys = 0;
 	ScanKeyData *mem_scankeys = NULL;
 
-	comp_chunk = ts_chunk_get_by_id(chunk->fd.compressed_chunk_id, true);
-	CompressionSettings *settings = ts_compression_settings_get(comp_chunk->table_id);
+	CompressionSettings *settings = ts_compression_settings_get(chunk->table_id);
 	bool delete_only = ht_state->mt->operation == CMD_DELETE && !has_joins &&
 					   can_delete_without_decompression(ht_state, settings, chunk, predicates);
 
@@ -256,7 +252,7 @@ decompress_batches_for_update_delete(HypertableModifyState *ht_state, Chunk *chu
 					   &is_null);
 
 	chunk_rel = table_open(chunk->table_id, RowExclusiveLock);
-	comp_chunk_rel = table_open(comp_chunk->table_id, RowExclusiveLock);
+	comp_chunk_rel = table_open(settings->fd.compress_relid, RowExclusiveLock);
 
 	if (index_filters)
 	{
@@ -989,14 +985,14 @@ process_predicates(Chunk *ch, CompressionSettings *settings, List *predicates,
 				}
 
 				int min_attno = compressed_column_metadata_attno(settings,
-																 ch->table_id,
-																 var->varattno,
 																 settings->fd.relid,
+																 var->varattno,
+																 settings->fd.compress_relid,
 																 "min");
 				int max_attno = compressed_column_metadata_attno(settings,
 																 ch->table_id,
 																 var->varattno,
-																 settings->fd.relid,
+																 settings->fd.compress_relid,
 																 "max");
 
 				if (min_attno != InvalidAttrNumber && max_attno != InvalidAttrNumber)
@@ -1006,66 +1002,70 @@ process_predicates(Chunk *ch, CompressionSettings *settings, List *predicates,
 						case BTEqualStrategyNumber:
 						{
 							/* orderby col = value implies min <= value and max >= value */
-							*heap_filters = lappend(*heap_filters,
-													make_batchfilter(get_attname(settings->fd.relid,
-																				 min_attno,
-																				 false),
-																	 BTLessEqualStrategyNumber,
-																	 collation,
-																	 opcode,
-																	 arg_value,
-																	 false, /* is_null_check */
-																	 false, /* is_null */
-																	 false	/* is_array_op */
-																	 ));
-							*heap_filters = lappend(*heap_filters,
-													make_batchfilter(get_attname(settings->fd.relid,
-																				 max_attno,
-																				 false),
-																	 BTGreaterEqualStrategyNumber,
-																	 collation,
-																	 opcode,
-																	 arg_value,
-																	 false, /* is_null_check */
-																	 false, /* is_null */
-																	 false	/* is_array_op */
-																	 ));
+							*heap_filters =
+								lappend(*heap_filters,
+										make_batchfilter(get_attname(settings->fd.compress_relid,
+																	 min_attno,
+																	 false),
+														 BTLessEqualStrategyNumber,
+														 collation,
+														 opcode,
+														 arg_value,
+														 false, /* is_null_check */
+														 false, /* is_null */
+														 false	/* is_array_op */
+														 ));
+							*heap_filters =
+								lappend(*heap_filters,
+										make_batchfilter(get_attname(settings->fd.compress_relid,
+																	 max_attno,
+																	 false),
+														 BTGreaterEqualStrategyNumber,
+														 collation,
+														 opcode,
+														 arg_value,
+														 false, /* is_null_check */
+														 false, /* is_null */
+														 false	/* is_array_op */
+														 ));
 						}
 						break;
 						case BTLessStrategyNumber:
 						case BTLessEqualStrategyNumber:
 						{
 							/* orderby col <[=] value implies min <[=] value */
-							*heap_filters = lappend(*heap_filters,
-													make_batchfilter(get_attname(settings->fd.relid,
-																				 min_attno,
-																				 false),
-																	 op_strategy,
-																	 collation,
-																	 opcode,
-																	 arg_value,
-																	 false, /* is_null_check */
-																	 false, /* is_null */
-																	 false	/* is_array_op */
-																	 ));
+							*heap_filters =
+								lappend(*heap_filters,
+										make_batchfilter(get_attname(settings->fd.compress_relid,
+																	 min_attno,
+																	 false),
+														 op_strategy,
+														 collation,
+														 opcode,
+														 arg_value,
+														 false, /* is_null_check */
+														 false, /* is_null */
+														 false	/* is_array_op */
+														 ));
 						}
 						break;
 						case BTGreaterStrategyNumber:
 						case BTGreaterEqualStrategyNumber:
 						{
 							/* orderby col >[=] value implies max >[=] value */
-							*heap_filters = lappend(*heap_filters,
-													make_batchfilter(get_attname(settings->fd.relid,
-																				 max_attno,
-																				 false),
-																	 op_strategy,
-																	 collation,
-																	 opcode,
-																	 arg_value,
-																	 false, /* is_null_check */
-																	 false, /* is_null */
-																	 false	/* is_array_op */
-																	 ));
+							*heap_filters =
+								lappend(*heap_filters,
+										make_batchfilter(get_attname(settings->fd.compress_relid,
+																	 max_attno,
+																	 false),
+														 op_strategy,
+														 collation,
+														 opcode,
+														 arg_value,
+														 false, /* is_null_check */
+														 false, /* is_null */
+														 false	/* is_array_op */
+														 ));
 						}
 						break;
 						default:

--- a/tsl/src/compression/create.c
+++ b/tsl/src/compression/create.c
@@ -145,7 +145,7 @@ compressed_column_metadata_name_v2(const char *metadata_type, const char *column
 }
 
 int
-compressed_column_metadata_attno(CompressionSettings *settings, Oid chunk_reloid,
+compressed_column_metadata_attno(const CompressionSettings *settings, Oid chunk_reloid,
 								 AttrNumber chunk_attno, Oid compressed_reloid, char *metadata_type)
 {
 	Assert(is_sparse_index_type(metadata_type));
@@ -440,12 +440,12 @@ create_compress_chunk(Hypertable *compress_ht, Chunk *src_chunk, Oid table_id)
 	 * for now.
 	 */
 	tablespace_oid = get_rel_tablespace(src_chunk->table_id);
+	CompressionSettings *settings = ts_compression_settings_get(src_chunk->hypertable_relid);
 
 	if (OidIsValid(table_id))
 		compress_chunk->table_id = table_id;
 	else
 	{
-		CompressionSettings *settings = ts_compression_settings_get(src_chunk->hypertable_relid);
 		List *column_defs = build_columndefs(settings, src_chunk->table_id);
 		compress_chunk->table_id =
 			compression_chunk_create(src_chunk, compress_chunk, column_defs, tablespace_oid);
@@ -455,7 +455,7 @@ create_compress_chunk(Hypertable *compress_ht, Chunk *src_chunk, Oid table_id)
 		elog(ERROR, "could not create compressed chunk table");
 
 	/* Materialize current compression settings for this chunk */
-	ts_compression_settings_materialize(src_chunk->hypertable_relid, compress_chunk->table_id);
+	ts_compression_settings_materialize(settings, src_chunk->table_id, compress_chunk->table_id);
 
 	/* if the src chunk is not in the default tablespace, the compressed indexes
 	 * should also be in a non-default tablespace. IN the usual case, this is inferred
@@ -516,6 +516,7 @@ validate_existing_constraints(Hypertable *ht, CompressionSettings *settings)
 
 	ArrayType *arr;
 
+	Assert(ht->main_table_relid == settings->fd.relid);
 	pg_constr = table_open(ConstraintRelationId, AccessShareLock);
 
 	ScanKeyInit(&scankey,
@@ -788,7 +789,12 @@ tsl_process_compress_table(AlterTableCmd *cmd, Hypertable *ht,
 	settings = ts_compression_settings_get(ht->main_table_relid);
 	if (!settings)
 	{
-		settings = ts_compression_settings_create(ht->main_table_relid, NULL, NULL, NULL, NULL);
+		settings = ts_compression_settings_create(ht->main_table_relid,
+												  InvalidOid,
+												  NULL,
+												  NULL,
+												  NULL,
+												  NULL);
 	}
 
 	compression_settings_update(ht, settings, with_clause_options);
@@ -1200,7 +1206,8 @@ tsl_process_compress_table_add_column(Hypertable *ht, ColumnDef *orig_def)
 			return;
 		}
 		ColumnDef *coldef = build_columndef_singlecolumn(orig_def->colname, coloid);
-		CompressionSettings *settings = ts_compression_settings_get(chunk->table_id);
+		CompressionSettings *settings =
+			ts_compression_settings_get_by_compress_relid(chunk->table_id);
 		add_column_to_compression_table(chunk->table_id, settings, coldef);
 	}
 }
@@ -1231,7 +1238,8 @@ tsl_process_compress_table_drop_column(Hypertable *ht, char *name)
 	foreach (lc, chunks)
 	{
 		Chunk *chunk = lfirst(lc);
-		CompressionSettings *settings = ts_compression_settings_get(chunk->table_id);
+		CompressionSettings *settings =
+			ts_compression_settings_get_by_compress_relid(chunk->table_id);
 		if (ts_array_is_member(settings->fd.segmentby, name) ||
 			ts_array_is_member(settings->fd.orderby, name))
 			ereport(ERROR,

--- a/tsl/src/compression/create.h
+++ b/tsl/src/compression/create.h
@@ -30,6 +30,6 @@ char *column_segment_max_name(int16 column_index);
 char *compressed_column_metadata_name_v2(const char *metadata_type, const char *column_name);
 
 typedef struct CompressionSettings CompressionSettings;
-int compressed_column_metadata_attno(CompressionSettings *settings, Oid chunk_reloid,
+int compressed_column_metadata_attno(const CompressionSettings *settings, Oid chunk_reloid,
 									 AttrNumber chunk_attno, Oid compressed_reloid,
 									 char *metadata_type);

--- a/tsl/src/compression/recompress.c
+++ b/tsl/src/compression/recompress.c
@@ -110,7 +110,7 @@ recompress_chunk_segmentwise_impl(Chunk *uncompressed_chunk)
 
 	/* need it to find the segby cols from the catalog */
 	Chunk *compressed_chunk = ts_chunk_get_by_id(uncompressed_chunk->fd.compressed_chunk_id, true);
-	CompressionSettings *settings = ts_compression_settings_get(compressed_chunk->table_id);
+	CompressionSettings *settings = ts_compression_settings_get(uncompressed_chunk->table_id);
 
 	/* new status after recompress should simply be compressed (1)
 	 * It is ok to update this early on in the transaction as it keeps a lock

--- a/tsl/src/nodes/decompress_chunk/decompress_chunk.h
+++ b/tsl/src/nodes/decompress_chunk/decompress_chunk.h
@@ -21,11 +21,6 @@ typedef struct CompressionInfo
 	RangeTblEntry *chunk_rte;
 	RangeTblEntry *compressed_rte;
 	RangeTblEntry *ht_rte;
-
-	FormData_chunk compressed_fd;
-	Oid compressed_reloid;
-	Oid compression_hypertable_reloid;
-
 	Oid compresseddata_oid;
 
 	CompressionSettings *settings;

--- a/tsl/test/expected/cagg_ddl-14.out
+++ b/tsl/test/expected/cagg_ddl-14.out
@@ -2117,7 +2117,7 @@ SELECT count(compress_chunk(ch)) FROM show_chunks('cagg1') ch;
 DROP MATERIALIZED VIEW cagg1;
 NOTICE:  drop cascades to table _timescaledb_internal._hyper_56_70_chunk
 SELECT * FROM _timescaledb_catalog.compression_settings;
- relid | segmentby | orderby | orderby_desc | orderby_nullsfirst 
--------+-----------+---------+--------------+--------------------
+ relid | compress_relid | segmentby | orderby | orderby_desc | orderby_nullsfirst 
+-------+----------------+-----------+---------+--------------+--------------------
 (0 rows)
 

--- a/tsl/test/expected/cagg_ddl-15.out
+++ b/tsl/test/expected/cagg_ddl-15.out
@@ -2117,7 +2117,7 @@ SELECT count(compress_chunk(ch)) FROM show_chunks('cagg1') ch;
 DROP MATERIALIZED VIEW cagg1;
 NOTICE:  drop cascades to table _timescaledb_internal._hyper_56_70_chunk
 SELECT * FROM _timescaledb_catalog.compression_settings;
- relid | segmentby | orderby | orderby_desc | orderby_nullsfirst 
--------+-----------+---------+--------------+--------------------
+ relid | compress_relid | segmentby | orderby | orderby_desc | orderby_nullsfirst 
+-------+----------------+-----------+---------+--------------+--------------------
 (0 rows)
 

--- a/tsl/test/expected/cagg_ddl-16.out
+++ b/tsl/test/expected/cagg_ddl-16.out
@@ -2117,7 +2117,7 @@ SELECT count(compress_chunk(ch)) FROM show_chunks('cagg1') ch;
 DROP MATERIALIZED VIEW cagg1;
 NOTICE:  drop cascades to table _timescaledb_internal._hyper_56_70_chunk
 SELECT * FROM _timescaledb_catalog.compression_settings;
- relid | segmentby | orderby | orderby_desc | orderby_nullsfirst 
--------+-----------+---------+--------------+--------------------
+ relid | compress_relid | segmentby | orderby | orderby_desc | orderby_nullsfirst 
+-------+----------------+-----------+---------+--------------+--------------------
 (0 rows)
 

--- a/tsl/test/expected/cagg_ddl-17.out
+++ b/tsl/test/expected/cagg_ddl-17.out
@@ -2117,7 +2117,7 @@ SELECT count(compress_chunk(ch)) FROM show_chunks('cagg1') ch;
 DROP MATERIALIZED VIEW cagg1;
 NOTICE:  drop cascades to table _timescaledb_internal._hyper_56_70_chunk
 SELECT * FROM _timescaledb_catalog.compression_settings;
- relid | segmentby | orderby | orderby_desc | orderby_nullsfirst 
--------+-----------+---------+--------------+--------------------
+ relid | compress_relid | segmentby | orderby | orderby_desc | orderby_nullsfirst 
+-------+----------------+-----------+---------+--------------+--------------------
 (0 rows)
 

--- a/tsl/test/expected/compression.out
+++ b/tsl/test/expected/compression.out
@@ -68,9 +68,9 @@ SELECT id, schema_name, table_name, compression_state as compressed, compressed_
 (2 rows)
 
 SELECT * FROM _timescaledb_catalog.compression_settings ORDER BY relid::regclass;
- relid | segmentby | orderby | orderby_desc | orderby_nullsfirst 
--------+-----------+---------+--------------+--------------------
- foo   | {a,b}     | {c,d}   | {t,f}        | {t,f}
+ relid | compress_relid | segmentby | orderby | orderby_desc | orderby_nullsfirst 
+-------+----------------+-----------+---------+--------------+--------------------
+ foo   |                | {a,b}     | {c,d}   | {t,f}        | {t,f}
 (1 row)
 
 SELECT * FROM timescaledb_information.compression_settings ORDER BY hypertable_name;
@@ -290,9 +290,9 @@ SELECT id, schema_name, table_name, compression_state as compressed, compressed_
 (1 row)
 
 SELECT * FROM _timescaledb_catalog.compression_settings WHERE relid = 'conditions'::regclass;
-   relid    | segmentby  | orderby | orderby_desc | orderby_nullsfirst 
-------------+------------+---------+--------------+--------------------
- conditions | {location} | {time}  | {f}          | {f}
+   relid    | compress_relid | segmentby  | orderby | orderby_desc | orderby_nullsfirst 
+------------+----------------+------------+---------+--------------+--------------------
+ conditions |                | {location} | {time}  | {f}          | {f}
 (1 row)
 
 select attname, attstorage, typname from pg_attribute at, pg_class cl , pg_type ty
@@ -918,9 +918,9 @@ select id, schema_name, table_name, compression_state as compressed, compressed_
 (1 row)
 
 SELECT * FROM _timescaledb_catalog.compression_settings WHERE relid='datatype_test'::regclass;
-     relid     | segmentby | orderby | orderby_desc | orderby_nullsfirst 
----------------+-----------+---------+--------------+--------------------
- datatype_test |           | {time}  | {t}          | {t}
+     relid     | compress_relid | segmentby | orderby | orderby_desc | orderby_nullsfirst 
+---------------+----------------+-----------+---------+--------------+--------------------
+ datatype_test |                |           | {time}  | {t}          | {t}
 (1 row)
 
 --TEST try to compress a hypertable that has a continuous aggregate

--- a/tsl/test/expected/compression_ddl.out
+++ b/tsl/test/expected/compression_ddl.out
@@ -722,9 +722,9 @@ WARNING:  there was some uncertainty picking the default segment by for the hype
 NOTICE:  default segment by for hypertable "i2844" is set to ""
 NOTICE:  default order by for hypertable "i2844" is set to "created_at DESC"
 SELECT * FROM _timescaledb_catalog.compression_settings WHERE relid='i2844'::regclass;
- relid | segmentby |   orderby    | orderby_desc | orderby_nullsfirst 
--------+-----------+--------------+--------------+--------------------
- i2844 |           | {created_at} | {t}          | {t}
+ relid | compress_relid | segmentby |   orderby    | orderby_desc | orderby_nullsfirst 
+-------+----------------+-----------+--------------+--------------+--------------------
+ i2844 |                |           | {created_at} | {t}          | {t}
 (1 row)
 
 SELECT compress_chunk(show_chunks) AS compressed_chunk FROM show_chunks('i2844');
@@ -887,9 +887,9 @@ SELECT * from _timescaledb_catalog.hypertable WHERE table_name = 'test1';
 (1 row)
 
 SELECT * FROM _timescaledb_catalog.compression_settings WHERE relid='test1'::regclass;
- relid | segmentby | orderby | orderby_desc | orderby_nullsfirst 
--------+-----------+---------+--------------+--------------------
- test1 | {bntcol}  | {Time}  | {t}          | {t}
+ relid | compress_relid | segmentby | orderby | orderby_desc | orderby_nullsfirst 
+-------+----------------+-----------+---------+--------------+--------------------
+ test1 |                | {bntcol}  | {Time}  | {t}          | {t}
 (1 row)
 
 ALTER TABLE test1 RENAME new_coli TO coli;
@@ -900,9 +900,9 @@ SELECT * from _timescaledb_catalog.hypertable WHERE table_name = 'test1';
 (1 row)
 
 SELECT * FROM _timescaledb_catalog.compression_settings WHERE relid='test1'::regclass;
- relid | segmentby | orderby | orderby_desc | orderby_nullsfirst 
--------+-----------+---------+--------------+--------------------
- test1 | {bntcol}  | {Time}  | {t}          | {t}
+ relid | compress_relid | segmentby | orderby | orderby_desc | orderby_nullsfirst 
+-------+----------------+-----------+---------+--------------+--------------------
+ test1 |                | {bntcol}  | {Time}  | {t}          | {t}
 (1 row)
 
 SELECT count(*) from test1 where coli  = 100;
@@ -914,9 +914,9 @@ SELECT count(*) from test1 where coli  = 100;
 --rename segment by column name
 ALTER TABLE test1 RENAME bntcol TO  bigintcol  ;
 SELECT * FROM _timescaledb_catalog.compression_settings WHERE relid='test1'::regclass;
- relid |  segmentby  | orderby | orderby_desc | orderby_nullsfirst 
--------+-------------+---------+--------------+--------------------
- test1 | {bigintcol} | {Time}  | {t}          | {t}
+ relid | compress_relid |  segmentby  | orderby | orderby_desc | orderby_nullsfirst 
+-------+----------------+-------------+---------+--------------+--------------------
+ test1 |                | {bigintcol} | {Time}  | {t}          | {t}
 (1 row)
 
 --query by segment by column name
@@ -986,9 +986,9 @@ ALTER TABLE test1 RENAME  bigintcol TO
 ccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccabdeeeeeeccccccccccccc;
 psql:include/compression_alter.sql:97: NOTICE:  identifier "ccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccabdeeeeeeccccccccccccc" will be truncated to "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccca"
 SELECT * from _timescaledb_catalog.compression_settings WHERE relid = 'test1'::regclass;
- relid |                             segmentby                             | orderby | orderby_desc | orderby_nullsfirst 
--------+-------------------------------------------------------------------+---------+--------------+--------------------
- test1 | {cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccca} | {Time}  | {t}          | {t}
+ relid | compress_relid |                             segmentby                             | orderby | orderby_desc | orderby_nullsfirst 
+-------+----------------+-------------------------------------------------------------------+---------+--------------+--------------------
+ test1 |                | {cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccca} | {Time}  | {t}          | {t}
 (1 row)
 
 SELECT * from timescaledb_information.compression_settings
@@ -1212,9 +1212,9 @@ SELECT * FROM _timescaledb_catalog.hypertable WHERE table_name = 'test_drop';
 (1 row)
 
 SELECT * FROM _timescaledb_catalog.compression_settings WHERE relid = 'test_drop'::regclass;
-   relid   | segmentby |   orderby    | orderby_desc | orderby_nullsfirst 
------------+-----------+--------------+--------------+--------------------
- test_drop | {device}  | {o1,o2,time} | {f,f,t}      | {f,f,t}
+   relid   | compress_relid | segmentby |   orderby    | orderby_desc | orderby_nullsfirst 
+-----------+----------------+-----------+--------------+--------------+--------------------
+ test_drop |                | {device}  | {o1,o2,time} | {f,f,t}      | {f,f,t}
 (1 row)
 
 --TEST tablespaces for compressed chunks with attach_tablespace interface --

--- a/tsl/test/expected/compression_defaults.out
+++ b/tsl/test/expected/compression_defaults.out
@@ -41,18 +41,18 @@ ALTER TABLE metrics SET (timescaledb.compress = true);
 NOTICE:  default segment by for hypertable "metrics" is set to "device_id"
 NOTICE:  default order by for hypertable "metrics" is set to ""time" DESC"
 SELECT * FROM _timescaledb_catalog.compression_settings;
-  relid  |  segmentby  | orderby | orderby_desc | orderby_nullsfirst 
----------+-------------+---------+--------------+--------------------
- metrics | {device_id} | {time}  | {t}          | {t}
+  relid  | compress_relid |  segmentby  | orderby | orderby_desc | orderby_nullsfirst 
+---------+----------------+-------------+---------+--------------+--------------------
+ metrics |                | {device_id} | {time}  | {t}          | {t}
 (1 row)
 
 ALTER TABLE metrics SET (timescaledb.compress = false);
 ALTER TABLE metrics SET (timescaledb.compress = true, timescaledb.compress_segmentby = 'device_id');
 NOTICE:  default order by for hypertable "metrics" is set to ""time" DESC"
 SELECT * FROM _timescaledb_catalog.compression_settings;
-  relid  |  segmentby  | orderby | orderby_desc | orderby_nullsfirst 
----------+-------------+---------+--------------+--------------------
- metrics | {device_id} | {time}  | {t}          | {t}
+  relid  | compress_relid |  segmentby  | orderby | orderby_desc | orderby_nullsfirst 
+---------+----------------+-------------+---------+--------------+--------------------
+ metrics |                | {device_id} | {time}  | {t}          | {t}
 (1 row)
 
 ALTER TABLE metrics SET (timescaledb.compress = false);
@@ -62,9 +62,9 @@ SET timescaledb.compression_orderby_default_function = '';
 ALTER TABLE metrics SET (timescaledb.compress = true);
 WARNING:  column "device_id" should be used for segmenting or ordering
 SELECT * FROM _timescaledb_catalog.compression_settings;
-  relid  | segmentby | orderby | orderby_desc | orderby_nullsfirst 
----------+-----------+---------+--------------+--------------------
- metrics |           | {time}  | {t}          | {t}
+  relid  | compress_relid | segmentby | orderby | orderby_desc | orderby_nullsfirst 
+---------+----------------+-----------+---------+--------------+--------------------
+ metrics |                |           | {time}  | {t}          | {t}
 (1 row)
 
 ALTER TABLE metrics SET (timescaledb.compress = false);
@@ -73,9 +73,9 @@ RESET timescaledb.compression_orderby_default_function;
 ALTER TABLE metrics SET (timescaledb.compress = true);
 NOTICE:  default order by for hypertable "metrics" is set to "device_id, "time" DESC"
 SELECT * FROM _timescaledb_catalog.compression_settings;
-  relid  | segmentby |     orderby      | orderby_desc | orderby_nullsfirst 
----------+-----------+------------------+--------------+--------------------
- metrics |           | {device_id,time} | {f,t}        | {f,t}
+  relid  | compress_relid | segmentby |     orderby      | orderby_desc | orderby_nullsfirst 
+---------+----------------+-----------+------------------+--------------+--------------------
+ metrics |                |           | {device_id,time} | {f,t}        | {f,t}
 (1 row)
 
 ALTER TABLE metrics SET (timescaledb.compress = false);
@@ -84,9 +84,9 @@ SET timescaledb.compression_orderby_default_function = '';
 ALTER TABLE metrics SET (timescaledb.compress = true);
 NOTICE:  default segment by for hypertable "metrics" is set to "device_id"
 SELECT * FROM _timescaledb_catalog.compression_settings;
-  relid  |  segmentby  | orderby | orderby_desc | orderby_nullsfirst 
----------+-------------+---------+--------------+--------------------
- metrics | {device_id} | {time}  | {t}          | {t}
+  relid  | compress_relid |  segmentby  | orderby | orderby_desc | orderby_nullsfirst 
+---------+----------------+-------------+---------+--------------+--------------------
+ metrics |                | {device_id} | {time}  | {t}          | {t}
 (1 row)
 
 ALTER TABLE metrics SET (timescaledb.compress = false);
@@ -203,9 +203,9 @@ WARNING:  there was some uncertainty picking the default segment by for the hype
 NOTICE:  default segment by for hypertable "metrics" is set to ""
 NOTICE:  default order by for hypertable "metrics" is set to ""time" DESC"
 SELECT * FROM _timescaledb_catalog.compression_settings;
-  relid  | segmentby | orderby | orderby_desc | orderby_nullsfirst 
----------+-----------+---------+--------------+--------------------
- metrics |           | {time}  | {t}          | {t}
+  relid  | compress_relid | segmentby | orderby | orderby_desc | orderby_nullsfirst 
+---------+----------------+-----------+---------+--------------+--------------------
+ metrics |                |           | {time}  | {t}          | {t}
 (1 row)
 
 ALTER TABLE metrics SET (timescaledb.compress = false);
@@ -376,9 +376,9 @@ SELECT _timescaledb_functions.get_orderby_defaults('table1', ARRAY['col1']::text
 ALTER TABLE table1 SET (timescaledb.compress, timescaledb.compress_segmentby = 'col1');
 NOTICE:  default order by for hypertable "table1" is set to ""
 SELECT * FROM _timescaledb_catalog.compression_settings;
- relid  | segmentby | orderby | orderby_desc | orderby_nullsfirst 
---------+-----------+---------+--------------+--------------------
- table1 | {col1}    |         |              | 
+ relid  | compress_relid | segmentby | orderby | orderby_desc | orderby_nullsfirst 
+--------+----------------+-----------+---------+--------------+--------------------
+ table1 |                | {col1}    |         |              | 
 (1 row)
 
 ALTER TABLE table1 SET (timescaledb.compress = false);

--- a/tsl/test/expected/compression_errors-14.out
+++ b/tsl/test/expected/compression_errors-14.out
@@ -67,10 +67,10 @@ ALTER TABLE with_rls set (timescaledb.compress, timescaledb.compress_orderby='a'
 ERROR:  compression cannot be used on table with row security
 --note that the time column "a" should be added to the end of the orderby list
 SELECT * FROM _timescaledb_catalog.compression_settings ORDER BY relid::text;
-      relid      |   segmentby    | orderby | orderby_desc | orderby_nullsfirst 
------------------+----------------+---------+--------------+--------------------
- default_skipped | {c}            | {a}     | {t}          | {t}
- foo2            | {"bacB toD",c} | {d,a}   | {f,t}        | {f,t}
+      relid      | compress_relid |   segmentby    | orderby | orderby_desc | orderby_nullsfirst 
+-----------------+----------------+----------------+---------+--------------+--------------------
+ default_skipped |                | {c}            | {a}     | {t}          | {t}
+ foo2            |                | {"bacB toD",c} | {d,a}   | {f,t}        | {f,t}
 (2 rows)
 
 ALTER TABLE foo3 set (timescaledb.compress, timescaledb.compress_orderby='d DeSc NullS lAsT');
@@ -254,9 +254,9 @@ ALTER TABLE foo DROP CONSTRAINT chk_existing;
 ROLLBACK;
 --note that the time column "a" should not be added to the end of the order by list again (should appear first)
 SELECT * FROM _timescaledb_catalog.compression_settings WHERE relid = 'foo'::regclass;
- relid | segmentby | orderby | orderby_desc | orderby_nullsfirst 
--------+-----------+---------+--------------+--------------------
- foo   |           | {a,b}   | {f,f}        | {f,f}
+ relid | compress_relid | segmentby | orderby | orderby_desc | orderby_nullsfirst 
+-------+----------------+-----------+---------+--------------+--------------------
+ foo   |                |           | {a,b}   | {f,f}        | {f,f}
 (1 row)
 
 SELECT decompress_chunk(ch, false) FROM show_chunks('foo') ch limit 1;
@@ -326,9 +326,9 @@ NOTICE:  chunk "_hyper_10_5_chunk" is not compressed
 --should succeed
 ALTER TABLE foo set (timescaledb.compress, timescaledb.compress_orderby = 'a', timescaledb.compress_segmentby = 'b');
 SELECT * FROM _timescaledb_catalog.compression_settings WHERE relid = 'foo'::regclass;
- relid | segmentby | orderby | orderby_desc | orderby_nullsfirst 
--------+-----------+---------+--------------+--------------------
- foo   | {b}       | {a}     | {f}          | {f}
+ relid | compress_relid | segmentby | orderby | orderby_desc | orderby_nullsfirst 
+-------+----------------+-----------+---------+--------------+--------------------
+ foo   |                | {b}       | {a}     | {f}          | {f}
 (1 row)
 
 SELECT comp_hyper.schema_name|| '.' || comp_hyper.table_name as "COMPRESSED_HYPER_NAME"

--- a/tsl/test/expected/compression_errors-15.out
+++ b/tsl/test/expected/compression_errors-15.out
@@ -67,10 +67,10 @@ ALTER TABLE with_rls set (timescaledb.compress, timescaledb.compress_orderby='a'
 ERROR:  compression cannot be used on table with row security
 --note that the time column "a" should be added to the end of the orderby list
 SELECT * FROM _timescaledb_catalog.compression_settings ORDER BY relid::text;
-      relid      |   segmentby    | orderby | orderby_desc | orderby_nullsfirst 
------------------+----------------+---------+--------------+--------------------
- default_skipped | {c}            | {a}     | {t}          | {t}
- foo2            | {"bacB toD",c} | {d,a}   | {f,t}        | {f,t}
+      relid      | compress_relid |   segmentby    | orderby | orderby_desc | orderby_nullsfirst 
+-----------------+----------------+----------------+---------+--------------+--------------------
+ default_skipped |                | {c}            | {a}     | {t}          | {t}
+ foo2            |                | {"bacB toD",c} | {d,a}   | {f,t}        | {f,t}
 (2 rows)
 
 ALTER TABLE foo3 set (timescaledb.compress, timescaledb.compress_orderby='d DeSc NullS lAsT');
@@ -254,9 +254,9 @@ ALTER TABLE foo DROP CONSTRAINT chk_existing;
 ROLLBACK;
 --note that the time column "a" should not be added to the end of the order by list again (should appear first)
 SELECT * FROM _timescaledb_catalog.compression_settings WHERE relid = 'foo'::regclass;
- relid | segmentby | orderby | orderby_desc | orderby_nullsfirst 
--------+-----------+---------+--------------+--------------------
- foo   |           | {a,b}   | {f,f}        | {f,f}
+ relid | compress_relid | segmentby | orderby | orderby_desc | orderby_nullsfirst 
+-------+----------------+-----------+---------+--------------+--------------------
+ foo   |                |           | {a,b}   | {f,f}        | {f,f}
 (1 row)
 
 SELECT decompress_chunk(ch, false) FROM show_chunks('foo') ch limit 1;
@@ -326,9 +326,9 @@ NOTICE:  chunk "_hyper_10_5_chunk" is not compressed
 --should succeed
 ALTER TABLE foo set (timescaledb.compress, timescaledb.compress_orderby = 'a', timescaledb.compress_segmentby = 'b');
 SELECT * FROM _timescaledb_catalog.compression_settings WHERE relid = 'foo'::regclass;
- relid | segmentby | orderby | orderby_desc | orderby_nullsfirst 
--------+-----------+---------+--------------+--------------------
- foo   | {b}       | {a}     | {f}          | {f}
+ relid | compress_relid | segmentby | orderby | orderby_desc | orderby_nullsfirst 
+-------+----------------+-----------+---------+--------------+--------------------
+ foo   |                | {b}       | {a}     | {f}          | {f}
 (1 row)
 
 SELECT comp_hyper.schema_name|| '.' || comp_hyper.table_name as "COMPRESSED_HYPER_NAME"

--- a/tsl/test/expected/compression_errors-16.out
+++ b/tsl/test/expected/compression_errors-16.out
@@ -67,10 +67,10 @@ ALTER TABLE with_rls set (timescaledb.compress, timescaledb.compress_orderby='a'
 ERROR:  compression cannot be used on table with row security
 --note that the time column "a" should be added to the end of the orderby list
 SELECT * FROM _timescaledb_catalog.compression_settings ORDER BY relid::text;
-      relid      |   segmentby    | orderby | orderby_desc | orderby_nullsfirst 
------------------+----------------+---------+--------------+--------------------
- default_skipped | {c}            | {a}     | {t}          | {t}
- foo2            | {"bacB toD",c} | {d,a}   | {f,t}        | {f,t}
+      relid      | compress_relid |   segmentby    | orderby | orderby_desc | orderby_nullsfirst 
+-----------------+----------------+----------------+---------+--------------+--------------------
+ default_skipped |                | {c}            | {a}     | {t}          | {t}
+ foo2            |                | {"bacB toD",c} | {d,a}   | {f,t}        | {f,t}
 (2 rows)
 
 ALTER TABLE foo3 set (timescaledb.compress, timescaledb.compress_orderby='d DeSc NullS lAsT');
@@ -254,9 +254,9 @@ ALTER TABLE foo DROP CONSTRAINT chk_existing;
 ROLLBACK;
 --note that the time column "a" should not be added to the end of the order by list again (should appear first)
 SELECT * FROM _timescaledb_catalog.compression_settings WHERE relid = 'foo'::regclass;
- relid | segmentby | orderby | orderby_desc | orderby_nullsfirst 
--------+-----------+---------+--------------+--------------------
- foo   |           | {a,b}   | {f,f}        | {f,f}
+ relid | compress_relid | segmentby | orderby | orderby_desc | orderby_nullsfirst 
+-------+----------------+-----------+---------+--------------+--------------------
+ foo   |                |           | {a,b}   | {f,f}        | {f,f}
 (1 row)
 
 SELECT decompress_chunk(ch, false) FROM show_chunks('foo') ch limit 1;
@@ -326,9 +326,9 @@ NOTICE:  chunk "_hyper_10_5_chunk" is not compressed
 --should succeed
 ALTER TABLE foo set (timescaledb.compress, timescaledb.compress_orderby = 'a', timescaledb.compress_segmentby = 'b');
 SELECT * FROM _timescaledb_catalog.compression_settings WHERE relid = 'foo'::regclass;
- relid | segmentby | orderby | orderby_desc | orderby_nullsfirst 
--------+-----------+---------+--------------+--------------------
- foo   | {b}       | {a}     | {f}          | {f}
+ relid | compress_relid | segmentby | orderby | orderby_desc | orderby_nullsfirst 
+-------+----------------+-----------+---------+--------------+--------------------
+ foo   |                | {b}       | {a}     | {f}          | {f}
 (1 row)
 
 SELECT comp_hyper.schema_name|| '.' || comp_hyper.table_name as "COMPRESSED_HYPER_NAME"

--- a/tsl/test/expected/compression_errors-17.out
+++ b/tsl/test/expected/compression_errors-17.out
@@ -67,10 +67,10 @@ ALTER TABLE with_rls set (timescaledb.compress, timescaledb.compress_orderby='a'
 ERROR:  compression cannot be used on table with row security
 --note that the time column "a" should be added to the end of the orderby list
 SELECT * FROM _timescaledb_catalog.compression_settings ORDER BY relid::text;
-      relid      |   segmentby    | orderby | orderby_desc | orderby_nullsfirst 
------------------+----------------+---------+--------------+--------------------
- default_skipped | {c}            | {a}     | {t}          | {t}
- foo2            | {"bacB toD",c} | {d,a}   | {f,t}        | {f,t}
+      relid      | compress_relid |   segmentby    | orderby | orderby_desc | orderby_nullsfirst 
+-----------------+----------------+----------------+---------+--------------+--------------------
+ default_skipped |                | {c}            | {a}     | {t}          | {t}
+ foo2            |                | {"bacB toD",c} | {d,a}   | {f,t}        | {f,t}
 (2 rows)
 
 ALTER TABLE foo3 set (timescaledb.compress, timescaledb.compress_orderby='d DeSc NullS lAsT');
@@ -254,9 +254,9 @@ ALTER TABLE foo DROP CONSTRAINT chk_existing;
 ROLLBACK;
 --note that the time column "a" should not be added to the end of the order by list again (should appear first)
 SELECT * FROM _timescaledb_catalog.compression_settings WHERE relid = 'foo'::regclass;
- relid | segmentby | orderby | orderby_desc | orderby_nullsfirst 
--------+-----------+---------+--------------+--------------------
- foo   |           | {a,b}   | {f,f}        | {f,f}
+ relid | compress_relid | segmentby | orderby | orderby_desc | orderby_nullsfirst 
+-------+----------------+-----------+---------+--------------+--------------------
+ foo   |                |           | {a,b}   | {f,f}        | {f,f}
 (1 row)
 
 SELECT decompress_chunk(ch, false) FROM show_chunks('foo') ch limit 1;
@@ -326,9 +326,9 @@ NOTICE:  chunk "_hyper_10_5_chunk" is not compressed
 --should succeed
 ALTER TABLE foo set (timescaledb.compress, timescaledb.compress_orderby = 'a', timescaledb.compress_segmentby = 'b');
 SELECT * FROM _timescaledb_catalog.compression_settings WHERE relid = 'foo'::regclass;
- relid | segmentby | orderby | orderby_desc | orderby_nullsfirst 
--------+-----------+---------+--------------+--------------------
- foo   | {b}       | {a}     | {f}          | {f}
+ relid | compress_relid | segmentby | orderby | orderby_desc | orderby_nullsfirst 
+-------+----------------+-----------+---------+--------------+--------------------
+ foo   |                | {b}       | {a}     | {f}          | {f}
 (1 row)
 
 SELECT comp_hyper.schema_name|| '.' || comp_hyper.table_name as "COMPRESSED_HYPER_NAME"

--- a/tsl/test/expected/compression_sequence_num_removal.out
+++ b/tsl/test/expected/compression_sequence_num_removal.out
@@ -456,8 +456,8 @@ UPDATE pg_class SET oid = :CHUNK_NEW_OID
 WHERE oid = :CHUNK_OID;
 UPDATE pg_attribute SET attrelid = :CHUNK_NEW_OID
 WHERE attrelid = :CHUNK_OID;
-UPDATE _timescaledb_catalog.compression_settings SET relid = :CHUNK_NEW_OID
-WHERE relid = :CHUNK_OID;
+UPDATE _timescaledb_catalog.compression_settings SET compress_relid = :CHUNK_NEW_OID
+WHERE compress_relid = :CHUNK_OID;
 :EXPLAIN SELECT * FROM hyper
 WHERE device_id = 1 ORDER BY time;
                                                                                                                         QUERY PLAN                                                                                                                        

--- a/tsl/test/expected/compression_settings.out
+++ b/tsl/test/expected/compression_settings.out
@@ -15,9 +15,9 @@ SELECT table_name FROM create_hypertable('metrics','time');
 ALTER TABLE metrics SET (timescaledb.compress, timescaledb.compress_segmentby='device');
 NOTICE:  default order by for hypertable "metrics" is set to ""time" DESC"
 SELECT * FROM settings;
-  relid  | segmentby | orderby | orderby_desc | orderby_nullsfirst 
----------+-----------+---------+--------------+--------------------
- metrics | {device}  | {time}  | {t}          | {t}
+  relid  | compress_relid | segmentby | orderby | orderby_desc | orderby_nullsfirst 
+---------+----------------+-----------+---------+--------------+--------------------
+ metrics |                | {device}  | {time}  | {t}          | {t}
 (1 row)
 
 SELECT * FROM ht_settings;
@@ -35,9 +35,9 @@ SELECT * FROM chunk_settings;
 INSERT INTO metrics VALUES ('2000-01-01'), ('2001-01-01');
 -- no change to settings
 SELECT * FROM settings;
-  relid  | segmentby | orderby | orderby_desc | orderby_nullsfirst 
----------+-----------+---------+--------------+--------------------
- metrics | {device}  | {time}  | {t}          | {t}
+  relid  | compress_relid | segmentby | orderby | orderby_desc | orderby_nullsfirst 
+---------+----------------+-----------+---------+--------------+--------------------
+ metrics |                | {device}  | {time}  | {t}          | {t}
 (1 row)
 
 --Enable compression path info
@@ -51,10 +51,10 @@ INFO:  using tuplesort to scan rows from "_hyper_1_1_chunk" for compression
 
 RESET timescaledb.debug_compression_path_info;
 SELECT * FROM settings;
-                     relid                      | segmentby | orderby | orderby_desc | orderby_nullsfirst 
-------------------------------------------------+-----------+---------+--------------+--------------------
- metrics                                        | {device}  | {time}  | {t}          | {t}
- _timescaledb_internal.compress_hyper_2_3_chunk | {device}  | {time}  | {t}          | {t}
+                 relid                  |                 compress_relid                 | segmentby | orderby | orderby_desc | orderby_nullsfirst 
+----------------------------------------+------------------------------------------------+-----------+---------+--------------+--------------------
+ metrics                                |                                                | {device}  | {time}  | {t}          | {t}
+ _timescaledb_internal._hyper_1_1_chunk | _timescaledb_internal.compress_hyper_2_3_chunk | {device}  | {time}  | {t}          | {t}
 (2 rows)
 
 SELECT * FROM chunk_settings;
@@ -70,11 +70,11 @@ SELECT compress_chunk('_timescaledb_internal._hyper_1_2_chunk');
 (1 row)
 
 SELECT * FROM settings;
-                     relid                      | segmentby | orderby | orderby_desc | orderby_nullsfirst 
-------------------------------------------------+-----------+---------+--------------+--------------------
- metrics                                        | {device}  | {time}  | {t}          | {t}
- _timescaledb_internal.compress_hyper_2_3_chunk | {device}  | {time}  | {t}          | {t}
- _timescaledb_internal.compress_hyper_2_4_chunk | {device}  | {time}  | {t}          | {t}
+                 relid                  |                 compress_relid                 | segmentby | orderby | orderby_desc | orderby_nullsfirst 
+----------------------------------------+------------------------------------------------+-----------+---------+--------------+--------------------
+ metrics                                |                                                | {device}  | {time}  | {t}          | {t}
+ _timescaledb_internal._hyper_1_1_chunk | _timescaledb_internal.compress_hyper_2_3_chunk | {device}  | {time}  | {t}          | {t}
+ _timescaledb_internal._hyper_1_2_chunk | _timescaledb_internal.compress_hyper_2_4_chunk | {device}  | {time}  | {t}          | {t}
 (3 rows)
 
 SELECT * FROM chunk_settings;
@@ -87,10 +87,10 @@ SELECT * FROM chunk_settings;
 -- dropping chunk should remove that chunks compression settings
 DROP TABLE _timescaledb_internal._hyper_1_1_chunk;
 SELECT * FROM settings;
-                     relid                      | segmentby | orderby | orderby_desc | orderby_nullsfirst 
-------------------------------------------------+-----------+---------+--------------+--------------------
- metrics                                        | {device}  | {time}  | {t}          | {t}
- _timescaledb_internal.compress_hyper_2_4_chunk | {device}  | {time}  | {t}          | {t}
+                 relid                  |                 compress_relid                 | segmentby | orderby | orderby_desc | orderby_nullsfirst 
+----------------------------------------+------------------------------------------------+-----------+---------+--------------+--------------------
+ metrics                                |                                                | {device}  | {time}  | {t}          | {t}
+ _timescaledb_internal._hyper_1_2_chunk | _timescaledb_internal.compress_hyper_2_4_chunk | {device}  | {time}  | {t}          | {t}
 (2 rows)
 
 SELECT * FROM chunk_settings;
@@ -107,9 +107,9 @@ SELECT decompress_chunk('_timescaledb_internal._hyper_1_2_chunk');
 (1 row)
 
 SELECT * FROM settings;
-  relid  | segmentby | orderby | orderby_desc | orderby_nullsfirst 
----------+-----------+---------+--------------+--------------------
- metrics | {device}  | {time}  | {t}          | {t}
+  relid  | compress_relid | segmentby | orderby | orderby_desc | orderby_nullsfirst 
+---------+----------------+-----------+---------+--------------+--------------------
+ metrics |                | {device}  | {time}  | {t}          | {t}
 (1 row)
 
 SELECT * FROM chunk_settings;
@@ -125,10 +125,10 @@ SELECT compress_chunk('_timescaledb_internal._hyper_1_2_chunk');
 (1 row)
 
 SELECT * FROM settings;
-                     relid                      | segmentby | orderby | orderby_desc | orderby_nullsfirst 
-------------------------------------------------+-----------+---------+--------------+--------------------
- metrics                                        | {device}  | {time}  | {t}          | {t}
- _timescaledb_internal.compress_hyper_2_5_chunk | {device}  | {time}  | {t}          | {t}
+                 relid                  |                 compress_relid                 | segmentby | orderby | orderby_desc | orderby_nullsfirst 
+----------------------------------------+------------------------------------------------+-----------+---------+--------------+--------------------
+ metrics                                |                                                | {device}  | {time}  | {t}          | {t}
+ _timescaledb_internal._hyper_1_2_chunk | _timescaledb_internal.compress_hyper_2_5_chunk | {device}  | {time}  | {t}          | {t}
 (2 rows)
 
 SELECT * FROM chunk_settings;
@@ -140,8 +140,8 @@ SELECT * FROM chunk_settings;
 -- dropping hypertable should remove all settings
 DROP TABLE metrics;
 SELECT * FROM settings;
- relid | segmentby | orderby | orderby_desc | orderby_nullsfirst 
--------+-----------+---------+--------------+--------------------
+ relid | compress_relid | segmentby | orderby | orderby_desc | orderby_nullsfirst 
+-------+----------------+-----------+---------+--------------+--------------------
 (0 rows)
 
 SELECT * FROM ht_settings;
@@ -167,9 +167,9 @@ NOTICE:  default segment by for hypertable "metrics" is set to ""
 NOTICE:  default order by for hypertable "metrics" is set to ""time" DESC"
 -- hypertable should have default settings now
 SELECT * FROM settings;
-  relid  | segmentby | orderby | orderby_desc | orderby_nullsfirst 
----------+-----------+---------+--------------+--------------------
- metrics |           | {time}  | {t}          | {t}
+  relid  | compress_relid | segmentby | orderby | orderby_desc | orderby_nullsfirst 
+---------+----------------+-----------+---------+--------------+--------------------
+ metrics |                |           | {time}  | {t}          | {t}
 (1 row)
 
 SELECT * FROM ht_settings;
@@ -183,9 +183,9 @@ INSERT INTO metrics VALUES ('2000-01-01');
 ALTER TABLE metrics SET (timescaledb.compress_segmentby='d1');
 -- settings should be updated
 SELECT * FROM settings;
-  relid  | segmentby | orderby | orderby_desc | orderby_nullsfirst 
----------+-----------+---------+--------------+--------------------
- metrics | {d1}      | {time}  | {t}          | {t}
+  relid  | compress_relid | segmentby | orderby | orderby_desc | orderby_nullsfirst 
+---------+----------------+-----------+---------+--------------+--------------------
+ metrics |                | {d1}      | {time}  | {t}          | {t}
 (1 row)
 
 SELECT * FROM ht_settings;
@@ -202,10 +202,10 @@ SELECT compress_chunk(show_chunks('metrics'));
 
 -- settings for compressed chunk should be present
 SELECT * FROM settings;
-                     relid                      | segmentby | orderby | orderby_desc | orderby_nullsfirst 
-------------------------------------------------+-----------+---------+--------------+--------------------
- metrics                                        | {d1}      | {time}  | {t}          | {t}
- _timescaledb_internal.compress_hyper_4_7_chunk | {d1}      | {time}  | {t}          | {t}
+                 relid                  |                 compress_relid                 | segmentby | orderby | orderby_desc | orderby_nullsfirst 
+----------------------------------------+------------------------------------------------+-----------+---------+--------------+--------------------
+ metrics                                |                                                | {d1}      | {time}  | {t}          | {t}
+ _timescaledb_internal._hyper_3_6_chunk | _timescaledb_internal.compress_hyper_4_7_chunk | {d1}      | {time}  | {t}          | {t}
 (2 rows)
 
 SELECT * FROM chunk_settings;
@@ -217,10 +217,10 @@ SELECT * FROM chunk_settings;
 -- changing settings should update settings for hypertable but not existing compressed chunks
 ALTER TABLE metrics SET (timescaledb.compress_segmentby='d2');
 SELECT * FROM settings;
-                     relid                      | segmentby | orderby | orderby_desc | orderby_nullsfirst 
-------------------------------------------------+-----------+---------+--------------+--------------------
- metrics                                        | {d2}      | {time}  | {t}          | {t}
- _timescaledb_internal.compress_hyper_4_7_chunk | {d1}      | {time}  | {t}          | {t}
+                 relid                  |                 compress_relid                 | segmentby | orderby | orderby_desc | orderby_nullsfirst 
+----------------------------------------+------------------------------------------------+-----------+---------+--------------+--------------------
+ metrics                                |                                                | {d2}      | {time}  | {t}          | {t}
+ _timescaledb_internal._hyper_3_6_chunk | _timescaledb_internal.compress_hyper_4_7_chunk | {d1}      | {time}  | {t}          | {t}
 (2 rows)
 
 SELECT * FROM ht_settings;
@@ -238,10 +238,10 @@ SELECT * FROM chunk_settings;
 -- changing settings should update settings for hypertable but not existing compressed chunks
 ALTER TABLE metrics SET (timescaledb.compress_segmentby='');
 SELECT * FROM settings;
-                     relid                      | segmentby | orderby | orderby_desc | orderby_nullsfirst 
-------------------------------------------------+-----------+---------+--------------+--------------------
- metrics                                        |           | {time}  | {t}          | {t}
- _timescaledb_internal.compress_hyper_4_7_chunk | {d1}      | {time}  | {t}          | {t}
+                 relid                  |                 compress_relid                 | segmentby | orderby | orderby_desc | orderby_nullsfirst 
+----------------------------------------+------------------------------------------------+-----------+---------+--------------+--------------------
+ metrics                                |                                                |           | {time}  | {t}          | {t}
+ _timescaledb_internal._hyper_3_6_chunk | _timescaledb_internal.compress_hyper_4_7_chunk | {d1}      | {time}  | {t}          | {t}
 (2 rows)
 
 SELECT * FROM ht_settings;
@@ -267,11 +267,11 @@ NOTICE:  chunk "_hyper_3_6_chunk" is already compressed
 (2 rows)
 
 SELECT * FROM settings;
-                     relid                      | segmentby | orderby | orderby_desc | orderby_nullsfirst 
-------------------------------------------------+-----------+---------+--------------+--------------------
- metrics                                        |           | {time}  | {t}          | {t}
- _timescaledb_internal.compress_hyper_4_7_chunk | {d1}      | {time}  | {t}          | {t}
- _timescaledb_internal.compress_hyper_4_9_chunk |           | {time}  | {t}          | {t}
+                 relid                  |                 compress_relid                 | segmentby | orderby | orderby_desc | orderby_nullsfirst 
+----------------------------------------+------------------------------------------------+-----------+---------+--------------+--------------------
+ metrics                                |                                                |           | {time}  | {t}          | {t}
+ _timescaledb_internal._hyper_3_6_chunk | _timescaledb_internal.compress_hyper_4_7_chunk | {d1}      | {time}  | {t}          | {t}
+ _timescaledb_internal._hyper_3_8_chunk | _timescaledb_internal.compress_hyper_4_9_chunk |           | {time}  | {t}          | {t}
 (3 rows)
 
 SELECT * FROM ht_settings;
@@ -297,11 +297,11 @@ SELECT compress_chunk(:'CHUNK', recompress:=true);
 (1 row)
 
 SELECT * FROM settings;
-                      relid                      | segmentby | orderby | orderby_desc | orderby_nullsfirst 
--------------------------------------------------+-----------+---------+--------------+--------------------
- metrics                                         | {d2}      | {time}  | {t}          | {t}
- _timescaledb_internal.compress_hyper_4_10_chunk | {d2}      | {time}  | {t}          | {t}
- _timescaledb_internal.compress_hyper_4_7_chunk  | {d1}      | {time}  | {t}          | {t}
+                 relid                  |                 compress_relid                  | segmentby | orderby | orderby_desc | orderby_nullsfirst 
+----------------------------------------+-------------------------------------------------+-----------+---------+--------------+--------------------
+ metrics                                |                                                 | {d2}      | {time}  | {t}          | {t}
+ _timescaledb_internal._hyper_3_6_chunk | _timescaledb_internal.compress_hyper_4_7_chunk  | {d1}      | {time}  | {t}          | {t}
+ _timescaledb_internal._hyper_3_8_chunk | _timescaledb_internal.compress_hyper_4_10_chunk | {d2}      | {time}  | {t}          | {t}
 (3 rows)
 
 SELECT * FROM ht_settings;

--- a/tsl/test/expected/hypercore_create.out
+++ b/tsl/test/expected/hypercore_create.out
@@ -188,15 +188,15 @@ where relparent='test2'::regclass;
 
 -- Show compression settings for hypercore across catalog and views
 select * from _timescaledb_catalog.compression_settings;
-                      relid                      |   segmentby   |        orderby         | orderby_desc | orderby_nullsfirst 
--------------------------------------------------+---------------+------------------------+--------------+--------------------
- test2                                           | {location_id} | {created_at,device_id} | {t,f}        | {t,f}
- _timescaledb_internal.compress_hyper_3_2_chunk  | {location_id} | {created_at,device_id} | {t,f}        | {t,f}
- _timescaledb_internal.compress_hyper_3_4_chunk  | {location_id} | {created_at,device_id} | {t,f}        | {t,f}
- _timescaledb_internal.compress_hyper_3_6_chunk  | {location_id} | {created_at,device_id} | {t,f}        | {t,f}
- _timescaledb_internal.compress_hyper_3_8_chunk  | {location_id} | {created_at,device_id} | {t,f}        | {t,f}
- _timescaledb_internal.compress_hyper_3_10_chunk | {location_id} | {created_at,device_id} | {t,f}        | {t,f}
- _timescaledb_internal.compress_hyper_3_12_chunk | {location_id} | {created_at,device_id} | {t,f}        | {t,f}
+                  relid                  |                 compress_relid                  |   segmentby   |        orderby         | orderby_desc | orderby_nullsfirst 
+-----------------------------------------+-------------------------------------------------+---------------+------------------------+--------------+--------------------
+ test2                                   |                                                 | {location_id} | {created_at,device_id} | {t,f}        | {t,f}
+ _timescaledb_internal._hyper_1_1_chunk  | _timescaledb_internal.compress_hyper_3_2_chunk  | {location_id} | {created_at,device_id} | {t,f}        | {t,f}
+ _timescaledb_internal._hyper_1_3_chunk  | _timescaledb_internal.compress_hyper_3_4_chunk  | {location_id} | {created_at,device_id} | {t,f}        | {t,f}
+ _timescaledb_internal._hyper_1_5_chunk  | _timescaledb_internal.compress_hyper_3_6_chunk  | {location_id} | {created_at,device_id} | {t,f}        | {t,f}
+ _timescaledb_internal._hyper_1_7_chunk  | _timescaledb_internal.compress_hyper_3_8_chunk  | {location_id} | {created_at,device_id} | {t,f}        | {t,f}
+ _timescaledb_internal._hyper_1_9_chunk  | _timescaledb_internal.compress_hyper_3_10_chunk | {location_id} | {created_at,device_id} | {t,f}        | {t,f}
+ _timescaledb_internal._hyper_1_11_chunk | _timescaledb_internal.compress_hyper_3_12_chunk | {location_id} | {created_at,device_id} | {t,f}        | {t,f}
 (7 rows)
 
 select * from timescaledb_information.compression_settings;

--- a/tsl/test/sql/compression_sequence_num_removal.sql
+++ b/tsl/test/sql/compression_sequence_num_removal.sql
@@ -202,8 +202,8 @@ UPDATE pg_class SET oid = :CHUNK_NEW_OID
 WHERE oid = :CHUNK_OID;
 UPDATE pg_attribute SET attrelid = :CHUNK_NEW_OID
 WHERE attrelid = :CHUNK_OID;
-UPDATE _timescaledb_catalog.compression_settings SET relid = :CHUNK_NEW_OID
-WHERE relid = :CHUNK_OID;
+UPDATE _timescaledb_catalog.compression_settings SET compress_relid = :CHUNK_NEW_OID
+WHERE compress_relid = :CHUNK_OID;
 
 :EXPLAIN SELECT * FROM hyper
 WHERE device_id = 1 ORDER BY time;

--- a/tsl/test/t/002_logrepl_decomp_marker.pl
+++ b/tsl/test/t/002_logrepl_decomp_marker.pl
@@ -90,7 +90,7 @@ query_generates_wal(
 	qq(SELECT compress_chunk('_timescaledb_internal._hyper_1_1_chunk'::regclass, TRUE);),
 	qq(message: transactional: 1 prefix: ::timescaledb-compression-start, sz: 0 content:
 table _timescaledb_catalog.chunk: INSERT: id[integer]:2 hypertable_id[integer]:2 schema_name[name]:'_timescaledb_internal' table_name[name]:'compress_hyper_2_2_chunk' compressed_chunk_id[integer]:null dropped[boolean]:false status[integer]:0 osm_chunk[boolean]:false
-table _timescaledb_catalog.compression_settings: INSERT: relid[regclass]:'_timescaledb_internal.compress_hyper_2_2_chunk' segmentby[text[]]:'{device_id}' orderby[text[]]:'{time}' orderby_desc[boolean[]]:'{f}' orderby_nullsfirst[boolean[]]:'{f}'
+table _timescaledb_catalog.compression_settings: INSERT: relid[regclass]:'_timescaledb_internal._hyper_1_1_chunk' compress_relid[regclass]:'_timescaledb_internal.compress_hyper_2_2_chunk' segmentby[text[]]:'{device_id}' orderby[text[]]:'{time}' orderby_desc[boolean[]]:'{f}' orderby_nullsfirst[boolean[]]:'{f}'
 table _timescaledb_catalog.chunk: UPDATE: id[integer]:1 hypertable_id[integer]:1 schema_name[name]:'_timescaledb_internal' table_name[name]:'_hyper_1_1_chunk' compressed_chunk_id[integer]:2 dropped[boolean]:false status[integer]:1 osm_chunk[boolean]:false
 table _timescaledb_internal.compress_hyper_2_2_chunk: INSERT: _ts_meta_count[integer]:1 device_id[bigint]:1 _ts_meta_min_1[timestamp with time zone]:'2023-06-30 17:00:00-07' _ts_meta_max_1[timestamp with time zone]:'2023-06-30 17:00:00-07' "time"[_timescaledb_internal.compressed_data]:'BAAAAqJgYhxAAAAComBiHEAAAAAAAQAAAAEAAAAAAAAADgAFRMDEOIAA' value[_timescaledb_internal.compressed_data]:'AwA/8AAAAAAAAAAAAAEAAAABAAAAAAAAAAEAAAAAAAAAAQAAAAEAAAABAAAAAAAAAAEAAAAAAAAAAQAAAAEGAAAAAAAAAAIAAAABAAAAAQAAAAAAAAAEAAAAAAAAAAoAAAABCgAAAAAAAAP/'
 table _timescaledb_catalog.compression_chunk_size: INSERT: chunk_id[integer]:1 compressed_chunk_id[integer]:2 uncompressed_heap_size[bigint]:8192 uncompressed_toast_size[bigint]:0 uncompressed_index_size[bigint]:16384 compressed_heap_size[bigint]:16384 compressed_toast_size[bigint]:8192 compressed_index_size[bigint]:16384 numrows_pre_compression[bigint]:1 numrows_post_compression[bigint]:1 numrows_frozen_immediately[bigint]:1
@@ -104,7 +104,7 @@ query_generates_wal(
 table _timescaledb_internal._hyper_1_1_chunk: INSERT: "time"[timestamp with time zone]:'2023-06-30 17:00:00-07' device_id[bigint]:1 value[double precision]:1
 table _timescaledb_catalog.compression_chunk_size: DELETE: chunk_id[integer]:1
 table _timescaledb_catalog.chunk: UPDATE: id[integer]:1 hypertable_id[integer]:1 schema_name[name]:'_timescaledb_internal' table_name[name]:'_hyper_1_1_chunk' compressed_chunk_id[integer]:null dropped[boolean]:false status[integer]:0 osm_chunk[boolean]:false
-table _timescaledb_catalog.compression_settings: DELETE: relid[regclass]:'_timescaledb_internal.compress_hyper_2_2_chunk'
+table _timescaledb_catalog.compression_settings: DELETE: relid[regclass]:'_timescaledb_internal._hyper_1_1_chunk'
 table _timescaledb_catalog.chunk: DELETE: id[integer]:2
 message: transactional: 1 prefix: ::timescaledb-decompression-end, sz: 0 content:)
 );
@@ -232,7 +232,7 @@ query_generates_wal(
 table _timescaledb_internal._hyper_1_1_chunk: INSERT: "time"[timestamp with time zone]:'2023-07-01 05:00:00-07' device_id[bigint]:1 value[double precision]:2
 table _timescaledb_catalog.compression_chunk_size: DELETE: chunk_id[integer]:1
 table _timescaledb_catalog.chunk: UPDATE: id[integer]:1 hypertable_id[integer]:1 schema_name[name]:'_timescaledb_internal' table_name[name]:'_hyper_1_1_chunk' compressed_chunk_id[integer]:null dropped[boolean]:false status[integer]:0 osm_chunk[boolean]:false
-table _timescaledb_catalog.compression_settings: DELETE: relid[regclass]:'_timescaledb_internal.compress_hyper_3_4_chunk'
+table _timescaledb_catalog.compression_settings: DELETE: relid[regclass]:'_timescaledb_internal._hyper_1_1_chunk'
 table _timescaledb_catalog.chunk: DELETE: id[integer]:4)
 );
 


### PR DESCRIPTION
Refactor the compression settings metadata table to include a mapping from a chunk's relid to its compressed chunk's relid.

This simplifies the code that looks up compression metadata as it no longer requires first looking up the corresponding compressed chunk in the "chunk" metadata table. Instead, given the non-compressed chunk's relid, the corresponding compressed chunk's relid can easily be looked up via the compression settings.

The refactoring is a step towards removing a chunk's compression table from the chunk metadata. In other words, the "compressed chunk" will no longer be a chunk, just a relation associated with the regular chunk via compression settings. However, this requires further refactoring that is left for follow-up changes.

Disable-check: force-changelog-file