### PR TITLE
Fix sort pushdown for partially compressed chunks

### DIFF
--- a/.unreleased/pr_6992
+++ b/.unreleased/pr_6992
@@ -1,0 +1,2 @@
+Fixes: #6975 Fix sort pushdown for partially compressed chunks
+Thanks: @srieding for reporting an issue with partially compressed chunks and ordering on joined columns

--- a/tsl/test/expected/merge_append_partially_compressed-14.out
+++ b/tsl/test/expected/merge_append_partially_compressed-14.out
@@ -870,6 +870,31 @@ SELECT * FROM test1 ORDER BY x1, x2, x5, time, x3 DESC LIMIT 10;
                ->  Seq Scan on _hyper_3_7_chunk (actual rows=1 loops=1)
 (12 rows)
 
+-- test append with join column in orderby
+-- #6975
+CREATE TABLE join_table (
+	x1 integer,
+	y1 float);
+INSERT INTO join_table VALUES (1, 1.0), (2,2.0);
+:PREFIX
+SELECT * FROM test1 t1 JOIN join_table jt ON t1.x1 = jt.x1
+ORDER BY t1.x1, jt.y1;
+                                               QUERY PLAN                                               
+--------------------------------------------------------------------------------------------------------
+ Sort (actual rows=4 loops=1)
+   Sort Key: t1_1.x1, jt.y1
+   Sort Method: quicksort 
+   ->  Hash Join (actual rows=4 loops=1)
+         Hash Cond: (jt.x1 = t1_1.x1)
+         ->  Seq Scan on join_table jt (actual rows=2 loops=1)
+         ->  Hash (actual rows=5 loops=1)
+               Buckets: 4096  Batches: 1 
+               ->  Append (actual rows=5 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_7_chunk t1_1 (actual rows=4 loops=1)
+                           ->  Seq Scan on compress_hyper_4_8_chunk (actual rows=3 loops=1)
+                     ->  Seq Scan on _hyper_3_7_chunk t1_1 (actual rows=1 loops=1)
+(12 rows)
+
 ---------------------------------------------------------------------------
 -- test queries without ordered append, but still eligible for sort pushdown
 ---------------------------------------------------------------------------

--- a/tsl/test/expected/merge_append_partially_compressed-15.out
+++ b/tsl/test/expected/merge_append_partially_compressed-15.out
@@ -877,6 +877,31 @@ SELECT * FROM test1 ORDER BY x1, x2, x5, time, x3 DESC LIMIT 10;
                ->  Seq Scan on _hyper_3_7_chunk (actual rows=1 loops=1)
 (12 rows)
 
+-- test append with join column in orderby
+-- #6975
+CREATE TABLE join_table (
+	x1 integer,
+	y1 float);
+INSERT INTO join_table VALUES (1, 1.0), (2,2.0);
+:PREFIX
+SELECT * FROM test1 t1 JOIN join_table jt ON t1.x1 = jt.x1
+ORDER BY t1.x1, jt.y1;
+                                               QUERY PLAN                                               
+--------------------------------------------------------------------------------------------------------
+ Sort (actual rows=4 loops=1)
+   Sort Key: t1_1.x1, jt.y1
+   Sort Method: quicksort 
+   ->  Hash Join (actual rows=4 loops=1)
+         Hash Cond: (jt.x1 = t1_1.x1)
+         ->  Seq Scan on join_table jt (actual rows=2 loops=1)
+         ->  Hash (actual rows=5 loops=1)
+               Buckets: 4096  Batches: 1 
+               ->  Append (actual rows=5 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_7_chunk t1_1 (actual rows=4 loops=1)
+                           ->  Seq Scan on compress_hyper_4_8_chunk (actual rows=3 loops=1)
+                     ->  Seq Scan on _hyper_3_7_chunk t1_1 (actual rows=1 loops=1)
+(12 rows)
+
 ---------------------------------------------------------------------------
 -- test queries without ordered append, but still eligible for sort pushdown
 ---------------------------------------------------------------------------

--- a/tsl/test/expected/merge_append_partially_compressed-16.out
+++ b/tsl/test/expected/merge_append_partially_compressed-16.out
@@ -877,6 +877,31 @@ SELECT * FROM test1 ORDER BY x1, x2, x5, time, x3 DESC LIMIT 10;
                ->  Seq Scan on _hyper_3_7_chunk (actual rows=1 loops=1)
 (12 rows)
 
+-- test append with join column in orderby
+-- #6975
+CREATE TABLE join_table (
+	x1 integer,
+	y1 float);
+INSERT INTO join_table VALUES (1, 1.0), (2,2.0);
+:PREFIX
+SELECT * FROM test1 t1 JOIN join_table jt ON t1.x1 = jt.x1
+ORDER BY t1.x1, jt.y1;
+                                               QUERY PLAN                                               
+--------------------------------------------------------------------------------------------------------
+ Sort (actual rows=4 loops=1)
+   Sort Key: t1_1.x1, jt.y1
+   Sort Method: quicksort 
+   ->  Hash Join (actual rows=4 loops=1)
+         Hash Cond: (jt.x1 = t1_1.x1)
+         ->  Seq Scan on join_table jt (actual rows=2 loops=1)
+         ->  Hash (actual rows=5 loops=1)
+               Buckets: 4096  Batches: 1 
+               ->  Append (actual rows=5 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_7_chunk t1_1 (actual rows=4 loops=1)
+                           ->  Seq Scan on compress_hyper_4_8_chunk (actual rows=3 loops=1)
+                     ->  Seq Scan on _hyper_3_7_chunk t1_1 (actual rows=1 loops=1)
+(12 rows)
+
 ---------------------------------------------------------------------------
 -- test queries without ordered append, but still eligible for sort pushdown
 ---------------------------------------------------------------------------

--- a/tsl/test/sql/merge_append_partially_compressed.sql.in
+++ b/tsl/test/sql/merge_append_partially_compressed.sql.in
@@ -138,6 +138,19 @@ SELECT * FROM test1 ORDER BY x1, x2, x5, time ASC, x3 DESC, x4 DESC LIMIT 10; --
 :PREFIX
 SELECT * FROM test1 ORDER BY x1, x2, x5, time, x3 DESC LIMIT 10;
 
+-- test append with join column in orderby
+-- #6975
+
+CREATE TABLE join_table (
+	x1 integer,
+	y1 float);
+
+INSERT INTO join_table VALUES (1, 1.0), (2,2.0);
+
+:PREFIX
+SELECT * FROM test1 t1 JOIN join_table jt ON t1.x1 = jt.x1
+ORDER BY t1.x1, jt.y1;
+
 ---------------------------------------------------------------------------
 -- test queries without ordered append, but still eligible for sort pushdown
 ---------------------------------------------------------------------------


### PR DESCRIPTION
Using all sort pathkeys with append node for partially compressed chunks ends up creating invalid plans when using joined columns in ORDER BY clause. Using the pathkey prefix that belongs to the underlying relation fixes the issue and sets us up for possible incremental sort optimization.

Fixes #6975