### PR TITLE
Fix stale code in Ensure

### DIFF
--- a/src/debug_assert.h
+++ b/src/debug_assert.h
@@ -23,16 +23,15 @@
  * of our control (e.g., unexpected changes to the metadata) so if you have a
  * test that trigger the error, this macro should not be used.
  */
-#ifdef USE_ASSERT_CHECKING
-#define Ensure(COND, FMT, ...) AssertMacro(COND)
-#else
 #define Ensure(COND, FMT, ...)                                                                     \
 	do                                                                                             \
 	{                                                                                              \
 		if (unlikely(!(COND)))                                                                     \
+		{                                                                                          \
+			Assert(false);                                                                         \
 			ereport(ERROR,                                                                         \
 					(errcode(ERRCODE_INTERNAL_ERROR),                                              \
 					 errdetail("Assertion '" #COND "' failed."),                                   \
 					 errmsg(FMT, ##__VA_ARGS__)));                                                 \
+		}                                                                                          \
 	} while (0)
-#endif

--- a/src/dimension_slice.c
+++ b/src/dimension_slice.c
@@ -832,7 +832,7 @@ ts_dimension_slice_delete_by_id(int32 dimension_slice_id, bool delete_constraint
 	ItemPointerData tid;
 	/* lock the tuple entry in the catalog table */
 	bool found = lock_dimension_slice_tuple(dimension_slice_id, &tid, &form);
-	Ensure(found, "dimension slice id %d not found", form.id);
+	Ensure(found, "dimension slice id %d not found", dimension_slice_id);
 
 	dimension_slice_delete_catalog_tuple(&tid);
 	return true;

--- a/src/dimension_slice.c
+++ b/src/dimension_slice.c
@@ -832,7 +832,7 @@ ts_dimension_slice_delete_by_id(int32 dimension_slice_id, bool delete_constraint
 	ItemPointerData tid;
 	/* lock the tuple entry in the catalog table */
 	bool found = lock_dimension_slice_tuple(dimension_slice_id, &tid, &form);
-	Ensure(found, "hypertable id %d not found", form.id);
+	Ensure(found, "dimension slice id %d not found", form.id);
 
 	dimension_slice_delete_catalog_tuple(&tid);
 	return true;

--- a/src/dimension_slice.c
+++ b/src/dimension_slice.c
@@ -832,7 +832,7 @@ ts_dimension_slice_delete_by_id(int32 dimension_slice_id, bool delete_constraint
 	ItemPointerData tid;
 	/* lock the tuple entry in the catalog table */
 	bool found = lock_dimension_slice_tuple(dimension_slice_id, &tid, &form);
-	Ensure(found, "hypertable id %d not found", slice->fd.id);
+	Ensure(found, "hypertable id %d not found", form.id);
 
 	dimension_slice_delete_catalog_tuple(&tid);
 	return true;


### PR DESCRIPTION
Also make Ensure use all its argument even in debug mode, so that these things are easier to notice.

The problem was introduced by https://github.com/timescale/timescaledb/pull/6838


Disable-check: force-changelog-file