### PR TITLE
Calendar-based chunking PoC

### DIFF
--- a/sql/ddl_api.sql
+++ b/sql/ddl_api.sql
@@ -34,7 +34,8 @@ CREATE OR REPLACE FUNCTION @extschema@.create_hypertable(
     migrate_data            BOOLEAN = FALSE,
     chunk_target_size       TEXT = NULL,
     chunk_sizing_func       REGPROC = '_timescaledb_functions.calculate_chunk_interval'::regproc,
-    time_partitioning_func  REGPROC = NULL
+    time_partitioning_func  REGPROC = NULL,
+	origin                  ANYELEMENT = NULL::timestamptz
 ) RETURNS TABLE(hypertable_id INT, schema_name NAME, table_name NAME, created BOOL) AS '@MODULE_PATHNAME@', 'ts_hypertable_create' LANGUAGE C VOLATILE;
 
 -- A generalized hypertable creation API that can be used to convert a PostgreSQL table
@@ -50,9 +51,9 @@ CREATE OR REPLACE FUNCTION @extschema@.create_hypertable(
     dimension               _timescaledb_internal.dimension_info,
     create_default_indexes  BOOLEAN = TRUE,
     if_not_exists           BOOLEAN = FALSE,
-    migrate_data            BOOLEAN = FALSE
+    migrate_data            BOOLEAN = FALSE,
+	origin                  ANYELEMENT = NULL::timestamptz
 ) RETURNS TABLE(hypertable_id INT, created BOOL) AS '@MODULE_PATHNAME@', 'ts_hypertable_create_general' LANGUAGE C VOLATILE;
-
 
 -- Set adaptive chunking. To disable, set chunk_target_size => 'off'.
 CREATE OR REPLACE FUNCTION @extschema@.set_adaptive_chunking(
@@ -73,7 +74,8 @@ CREATE OR REPLACE FUNCTION @extschema@.set_adaptive_chunking(
 CREATE OR REPLACE FUNCTION @extschema@.set_chunk_time_interval(
     hypertable              REGCLASS,
     chunk_time_interval     ANYELEMENT,
-    dimension_name          NAME = NULL
+    dimension_name          NAME = NULL,	
+	origin                  TIMESTAMPTZ = NULL
 ) RETURNS VOID AS '@MODULE_PATHNAME@', 'ts_dimension_set_interval' LANGUAGE C VOLATILE;
 
 -- Update partition_interval for a hypertable.
@@ -133,7 +135,8 @@ CREATE OR REPLACE FUNCTION @extschema@.add_dimension(
     number_partitions       INTEGER = NULL,
     chunk_time_interval     ANYELEMENT = NULL::BIGINT,
     partitioning_func       REGPROC = NULL,
-    if_not_exists           BOOLEAN = FALSE
+    if_not_exists           BOOLEAN = FALSE,
+	origin                  TIMESTAMPTZ = NULL
 ) RETURNS TABLE(dimension_id INT, schema_name NAME, table_name NAME, column_name NAME, created BOOL)
 AS '@MODULE_PATHNAME@', 'ts_dimension_add' LANGUAGE C VOLATILE;
 

--- a/sql/ddl_api.sql
+++ b/sql/ddl_api.sql
@@ -135,8 +135,7 @@ CREATE OR REPLACE FUNCTION @extschema@.add_dimension(
     number_partitions       INTEGER = NULL,
     chunk_time_interval     ANYELEMENT = NULL::BIGINT,
     partitioning_func       REGPROC = NULL,
-    if_not_exists           BOOLEAN = FALSE,
-	origin                  TIMESTAMPTZ = NULL
+    if_not_exists           BOOLEAN = FALSE
 ) RETURNS TABLE(dimension_id INT, schema_name NAME, table_name NAME, column_name NAME, created BOOL)
 AS '@MODULE_PATHNAME@', 'ts_dimension_add' LANGUAGE C VOLATILE;
 
@@ -159,7 +158,8 @@ CREATE OR REPLACE FUNCTION @extschema@.by_hash(column_name NAME, number_partitio
 
 CREATE OR REPLACE FUNCTION @extschema@.by_range(column_name NAME,
                                                 partition_interval ANYELEMENT = NULL::bigint,
-                                                partition_func regproc = NULL)
+                                                partition_func regproc = NULL,
+												partition_origin TIMESTAMPTZ = NULL)
     RETURNS _timescaledb_internal.dimension_info LANGUAGE C
     AS '@MODULE_PATHNAME@', 'ts_range_dimension';
 

--- a/sql/ddl_api.sql
+++ b/sql/ddl_api.sql
@@ -51,8 +51,7 @@ CREATE OR REPLACE FUNCTION @extschema@.create_hypertable(
     dimension               _timescaledb_internal.dimension_info,
     create_default_indexes  BOOLEAN = TRUE,
     if_not_exists           BOOLEAN = FALSE,
-    migrate_data            BOOLEAN = FALSE,
-	origin                  ANYELEMENT = NULL::timestamptz
+    migrate_data            BOOLEAN = FALSE
 ) RETURNS TABLE(hypertable_id INT, created BOOL) AS '@MODULE_PATHNAME@', 'ts_hypertable_create_general' LANGUAGE C VOLATILE;
 
 -- Set adaptive chunking. To disable, set chunk_target_size => 'off'.
@@ -135,7 +134,8 @@ CREATE OR REPLACE FUNCTION @extschema@.add_dimension(
     number_partitions       INTEGER = NULL,
     chunk_time_interval     ANYELEMENT = NULL::BIGINT,
     partitioning_func       REGPROC = NULL,
-    if_not_exists           BOOLEAN = FALSE
+    if_not_exists           BOOLEAN = FALSE,
+	origin                  ANYELEMENT = NULL::timestamptz
 ) RETURNS TABLE(dimension_id INT, schema_name NAME, table_name NAME, column_name NAME, created BOOL)
 AS '@MODULE_PATHNAME@', 'ts_dimension_add' LANGUAGE C VOLATILE;
 
@@ -159,7 +159,7 @@ CREATE OR REPLACE FUNCTION @extschema@.by_hash(column_name NAME, number_partitio
 CREATE OR REPLACE FUNCTION @extschema@.by_range(column_name NAME,
                                                 partition_interval ANYELEMENT = NULL::bigint,
                                                 partition_func regproc = NULL,
-												partition_origin TIMESTAMPTZ = NULL)
+												partition_origin "any" = NULL::TIMESTAMPTZ)
     RETURNS _timescaledb_internal.dimension_info LANGUAGE C
     AS '@MODULE_PATHNAME@', 'ts_range_dimension';
 

--- a/sql/pre_install/tables.sql
+++ b/sql/pre_install/tables.sql
@@ -94,9 +94,12 @@ CREATE TABLE _timescaledb_catalog.dimension (
   partitioning_func_schema name NULL,
   partitioning_func name NULL,
   -- open dimensions (e.g., time)
-  interval_length bigint NULL,
+  interval_origin bigint NOT NULL, -- origin of when to start chunk interval. TimestampTz or int64 (but always stored as a bigint).
+  interval interval NULL, -- calendar-based interval.
+  interval_length bigint NULL, -- integer-based interval
   -- compress interval is used by rollup procedure during compression
   -- in order to merge multiple chunks into a single one
+  compress_interval interval NULL,
   compress_interval_length bigint NULL,
   integer_now_func_schema name NULL,
   integer_now_func name NULL,

--- a/src/dimension.h
+++ b/src/dimension.h
@@ -160,6 +160,7 @@ extern TSDLLEXPORT DimensionInfo *ts_dimension_info_create_closed(Oid table_reli
 																  regproc partitioning_func);
 
 extern void ts_dimension_info_validate(DimensionInfo *info);
+extern void ts_dimension_info_set_defaults(DimensionInfo *info);
 extern int32 ts_dimension_add_from_info(DimensionInfo *info);
 extern void ts_dimensions_rename_schema_name(const char *old_name, const char *new_name);
 extern TSDLLEXPORT void ts_dimension_update(const Hypertable *ht, const NameData *dimname,

--- a/src/dimension.h
+++ b/src/dimension.h
@@ -32,6 +32,7 @@ typedef struct Dimension
 	DimensionType type;
 	AttrNumber column_attno;
 	Oid main_table_relid;
+	bool calendar_based;
 	PartitioningInfo *partitioning;
 } Dimension;
 
@@ -40,6 +41,7 @@ typedef struct Dimension
 #define IS_VALID_OPEN_DIM_TYPE(type)                                                               \
 	(IS_INTEGER_TYPE(type) || IS_TIMESTAMP_TYPE(type) || ts_type_is_int8_binary_compatible(type))
 
+#define IS_FLAT_INTERVAL(i) ((d)->day == 0 && (d)->month == 0)
 /*
  * A hyperspace defines how to partition in a N-dimensional space.
  */
@@ -106,6 +108,9 @@ typedef struct DimensionInfo
 	Datum interval_datum;
 	Oid interval_type; /* Type of the interval datum */
 	int64 interval;
+	Datum interval_origin;
+	bool interval_origin_isnull;
+	Oid interval_origin_type;
 	int32 num_slices;
 	regproc partitioning_func;
 	bool if_not_exists;
@@ -146,7 +151,9 @@ extern int ts_dimension_delete_by_hypertable_id(int32 hypertable_id, bool delete
 
 extern TSDLLEXPORT DimensionInfo *ts_dimension_info_create_open(Oid table_relid, Name column_name,
 																Datum interval, Oid interval_type,
-																regproc partitioning_func);
+																regproc partitioning_func,
+																Datum origin, bool origin_isnull,
+																Oid origin_type);
 
 extern TSDLLEXPORT DimensionInfo *ts_dimension_info_create_closed(Oid table_relid, Name column_name,
 																  int32 num_slices,

--- a/src/hypertable.c
+++ b/src/hypertable.c
@@ -1597,11 +1597,13 @@ ts_hypertable_create_time_prev(PG_FUNCTION_ARGS, bool is_dist_call)
 	text *target_size = PG_ARGISNULL(11) ? NULL : PG_GETARG_TEXT_P(11);
 	Oid sizing_func = PG_ARGISNULL(12) ? InvalidOid : PG_GETARG_OID(12);
 	regproc open_partitioning_func = PG_ARGISNULL(13) ? InvalidOid : PG_GETARG_OID(13);
-	const int origin_paramnum = is_dist_call ? 17 : 16;
+	const int origin_paramnum = 14;
 	bool origin_isnull = PG_ARGISNULL(origin_paramnum);
 	Datum origin = origin_isnull ? 0 : PG_GETARG_DATUM(origin_paramnum);
 	Oid origin_type =
 		origin_isnull ? InvalidOid : get_fn_expr_argtype(fcinfo->flinfo, origin_paramnum);
+
+	elog(NOTICE, "origin type is %s", format_type_be(origin_type));
 
 	if (!OidIsValid(table_relid))
 		ereport(ERROR,
@@ -1683,6 +1685,12 @@ ts_hypertable_create_general(PG_FUNCTION_ARGS)
 	bool create_default_indexes = PG_ARGISNULL(2) ? false : PG_GETARG_BOOL(2);
 	bool if_not_exists = PG_ARGISNULL(3) ? false : PG_GETARG_BOOL(3);
 	bool migrate_data = PG_ARGISNULL(4) ? false : PG_GETARG_BOOL(4);
+	const int origin_paramnum = 5;
+	bool origin_isnull = PG_ARGISNULL(5);
+	dim_info->interval_origin_isnull = origin_isnull;
+	dim_info->interval_origin = origin_isnull ? 0 : PG_GETARG_DATUM(5);
+	dim_info->interval_origin_type =
+		origin_isnull ? InvalidOid : get_fn_expr_argtype(fcinfo->flinfo, origin_paramnum);
 
 	/*
 	 * We do not support closed (hash) dimensions for the main partitioning

--- a/src/hypertable.c
+++ b/src/hypertable.c
@@ -1597,6 +1597,11 @@ ts_hypertable_create_time_prev(PG_FUNCTION_ARGS, bool is_dist_call)
 	text *target_size = PG_ARGISNULL(11) ? NULL : PG_GETARG_TEXT_P(11);
 	Oid sizing_func = PG_ARGISNULL(12) ? InvalidOid : PG_GETARG_OID(12);
 	regproc open_partitioning_func = PG_ARGISNULL(13) ? InvalidOid : PG_GETARG_OID(13);
+	const int origin_paramnum = is_dist_call ? 17 : 16;
+	bool origin_isnull = PG_ARGISNULL(origin_paramnum);
+	Datum origin = origin_isnull ? 0 : PG_GETARG_DATUM(origin_paramnum);
+	Oid origin_type =
+		origin_isnull ? InvalidOid : get_fn_expr_argtype(fcinfo->flinfo, origin_paramnum);
 
 	if (!OidIsValid(table_relid))
 		ereport(ERROR,
@@ -1609,11 +1614,13 @@ ts_hypertable_create_time_prev(PG_FUNCTION_ARGS, bool is_dist_call)
 
 	DimensionInfo *open_dim_info =
 		ts_dimension_info_create_open(table_relid,
-									  open_dim_name,		 /* column name */
-									  default_interval,		 /* interval */
-									  interval_type,		 /* interval type */
-									  open_partitioning_func /* partitioning func */
-		);
+									  open_dim_name,		  /* column name */
+									  default_interval,		  /* interval */
+									  interval_type,		  /* interval type */
+									  open_partitioning_func, /* partitioning func */
+									  origin,
+									  origin_isnull,
+									  origin_type);
 
 	DimensionInfo *closed_dim_info = NULL;
 	if (closed_dim_name)

--- a/src/hypertable.c
+++ b/src/hypertable.c
@@ -1685,12 +1685,6 @@ ts_hypertable_create_general(PG_FUNCTION_ARGS)
 	bool create_default_indexes = PG_ARGISNULL(2) ? false : PG_GETARG_BOOL(2);
 	bool if_not_exists = PG_ARGISNULL(3) ? false : PG_GETARG_BOOL(3);
 	bool migrate_data = PG_ARGISNULL(4) ? false : PG_GETARG_BOOL(4);
-	const int origin_paramnum = 5;
-	bool origin_isnull = PG_ARGISNULL(5);
-	dim_info->interval_origin_isnull = origin_isnull;
-	dim_info->interval_origin = origin_isnull ? 0 : PG_GETARG_DATUM(5);
-	dim_info->interval_origin_type =
-		origin_isnull ? InvalidOid : get_fn_expr_argtype(fcinfo->flinfo, origin_paramnum);
 
 	/*
 	 * We do not support closed (hash) dimensions for the main partitioning
@@ -1711,7 +1705,10 @@ ts_hypertable_create_general(PG_FUNCTION_ARGS)
 	/*
 	 * Fill in the rest of the info.
 	 */
+	AttrNumber colattr = get_attnum(table_relid, NameStr(dim_info->colname));
 	dim_info->table_relid = table_relid;
+	dim_info->coltype = get_atttype(table_relid, colattr);
+	ts_dimension_info_set_defaults(dim_info);
 
 	return ts_hypertable_create_internal(fcinfo,
 										 table_relid,

--- a/src/ts_catalog/catalog.h
+++ b/src/ts_catalog/catalog.h
@@ -182,7 +182,10 @@ enum Anum_dimension
 	Anum_dimension_num_slices,
 	Anum_dimension_partitioning_func_schema,
 	Anum_dimension_partitioning_func,
+	Anum_dimension_interval_origin,
+	Anum_dimension_interval,
 	Anum_dimension_interval_length,
+	Anum_dimension_compress_interval,
 	Anum_dimension_compress_interval_length,
 	Anum_dimension_integer_now_func_schema,
 	Anum_dimension_integer_now_func,
@@ -198,12 +201,27 @@ typedef struct FormData_dimension
 	NameData column_name;
 	Oid column_type;
 	bool aligned;
-	/* closed (space) columns */
+	/* Closed (space) dimension information */
 	int16 num_slices;
 	NameData partitioning_func_schema;
 	NameData partitioning_func;
-	/* open (time) columns */
+	/*
+	 * Open (time) dimension information
+	 *
+	 * An open dimension is divided into intervals that can either be plain
+	 * integer intervals or calendar-based intervals (days, months, years). An
+	 * interval has an origin, which for integer intervals is an integer while
+	 * calendar-based intervals have a TimestampTz origin (but encoded into
+	 * the same int64).
+	 *
+	 * Integer intervals are encoded into interval_length.
+	 *
+	 * Calendar-based intervals are encoded into a PostgreSQL interval.
+	 */
+	int64 interval_origin;
+	Interval interval;
 	int64 interval_length;
+	Interval compress_interval;
 	int64 compress_interval_length;
 	NameData integer_now_func_schema;
 	NameData integer_now_func;

--- a/src/ts_catalog/compression_settings.c
+++ b/src/ts_catalog/compression_settings.c
@@ -6,13 +6,13 @@
 #include <postgres.h>
 #include <utils/builtins.h>
 
-#include "chunk.h"
 #include "hypertable.h"
 #include "scan_iterator.h"
 #include "scanner.h"
 #include "ts_catalog/array_utils.h"
 #include "ts_catalog/catalog.h"
 #include "ts_catalog/compression_settings.h"
+#include <chunk.h>
 
 static ScanTupleResult compression_settings_tuple_update(TupleInfo *ti, void *data);
 static HeapTuple compression_settings_formdata_make_tuple(const FormData_compression_settings *fd,

--- a/src/ts_catalog/continuous_agg.h
+++ b/src/ts_catalog/continuous_agg.h
@@ -9,8 +9,8 @@
 #include <catalog/pg_type.h>
 #include <nodes/parsenodes.h>
 
-#include "chunk.h"
 #include "ts_catalog/catalog.h"
+#include <chunk.h>
 
 #include "compat/compat.h"
 #include "with_clause_parser.h"

--- a/tsl/src/continuous_aggs/create.c
+++ b/tsl/src/continuous_aggs/create.c
@@ -276,7 +276,10 @@ cagg_create_hypertable(int32 hypertable_id, Oid mat_tbloid, const char *matpartc
 												  &mat_tbltimecol,
 												  Int64GetDatum(mat_tbltimecol_interval),
 												  INT8OID,
-												  InvalidOid);
+												  InvalidOid,
+												  0,
+												  true,
+												  INT8OID);
 	/*
 	 * Ideally would like to change/expand the API so setting the column name manually is
 	 * unnecessary, but not high priority.


### PR DESCRIPTION
Initial PoC for calendar-based chunking. 

A lot of functionality is missing.

Here's some example output:

```sql
create table hyper (time timestamptz, device int, temp float);
CREATE TABLE
select create_hypertable('hyper', by_range('time', '1 month'::interval, partition_origin => '2024-01-01'::timestamptz), create_default_indexes => false);
psql:../../tsdb-scripts/calendar-chunking.sql:2: NOTICE:  adding not-null constraint to column "time"
DETAIL:  Dimensions cannot have NULL values.
 create_hypertable 
-------------------
 (1,t)
(1 row)

select * from _timescaledb_catalog.hypertable;
 id | schema_name | table_name | associated_schema_name | associated_table_prefix | num_dimensions | chunk_sizi
ng_func_schema |  chunk_sizing_func_name  | chunk_target_size | compression_state | compressed_hypertable_id | 
status 
----+-------------+------------+------------------------+-------------------------+----------------+-----------
---------------+--------------------------+-------------------+-------------------+--------------------------+-
-------
  1 | public      | hyper      | _timescaledb_internal  | _hyper_1                |              1 | _timescale
db_internal    | calculate_chunk_interval |                 0 |                 0 |                          | 
     0
(1 row)

select * from _timescaledb_catalog.dimension;
 id | hypertable_id | column_name |       column_type        | aligned | num_slices | partitioning_func_schema 
| partitioning_func | interval_origin | interval | interval_length | compress_interval | compress_interval_leng
th | integer_now_func_schema | integer_now_func 
----+---------------+-------------+--------------------------+---------+------------+--------------------------
+-------------------+-----------------+----------+-----------------+-------------------+-----------------------
---+-------------------------+------------------
  1 |             1 | time        | timestamp with time zone | t       |            |                          
|                   | 757378800000000 | 1 mon    |                 |                   |                       
   |                         | 
(1 row)

insert into hyper values ('2024-01-04 13:41', 1, 1.0);
INSERT 0 1
select * from timescaledb_information.chunks;
 hypertable_schema | hypertable_name |     chunk_schema      |    chunk_name    | primary_dimension |  primary_
dimension_type  |      range_start       |       range_end        | range_start_integer | range_end_integer | i
s_compressed | chunk_tablespace |      chunk_creation_time      
-------------------+-----------------+-----------------------+------------------+-------------------+----------
----------------+------------------------+------------------------+---------------------+-------------------+--
-------------+------------------+-------------------------------
 public            | hyper           | _timescaledb_internal | _hyper_1_1_chunk | time              | timestamp
 with time zone | 2024-01-01 00:00:00+01 | 2024-02-01 00:00:00+01 |                     |                   | f
             |                  | 2024-06-05 18:48:14.076832+02
(1 row)
```
