### PR TITLE
Backport to 2.15.x: #7005: Allow CAggs with variable sized bucked with origin/offset

### DIFF
--- a/src/ts_catalog/continuous_agg.h
+++ b/src/ts_catalog/continuous_agg.h
@@ -86,6 +86,7 @@ typedef struct ContinuousAggsBucketFunction
 	 * situations since PostgreSQL protects the bucket_function from deletion until the CAgg is
 	 * defined. */
 	Oid bucket_function;
+	Oid bucket_width_type; /* type of bucket_width */
 
 	/* Is the interval of the bucket fixed? */
 	bool bucket_fixed_interval;
@@ -146,15 +147,6 @@ typedef enum ContinuousAggHypertableStatus
 	HypertableIsRawTable = 2,
 	HypertableIsMaterializationAndRaw = HypertableIsMaterialization | HypertableIsRawTable,
 } ContinuousAggHypertableStatus;
-
-typedef struct ContinuousAggMatOptions
-{
-	bool verbose;
-	bool within_single_transaction;
-	bool process_only_invalidation;
-	int64 invalidate_prior_to_time; /* exclusive, if not bucketed, the last invalidation bucket will
-									   cover this point */
-} ContinuousAggMatOptions;
 
 typedef struct CaggsInfoData
 {

--- a/tsl/src/continuous_aggs/common.h
+++ b/tsl/src/continuous_aggs/common.h
@@ -72,18 +72,7 @@ typedef struct CAggTimebucketInfo
 	int64 htpartcol_interval_len;	/* interval length setting for primary partitioning column */
 
 	/* General bucket information */
-	FuncExpr *bucket_func; /* function call expr of the bucketing function */
-	Oid bucket_width_type; /* type of bucket_width */
-
-	/* Time based buckets */
-	Interval *bucket_time_width;	  /* stores the interval, NULL if not specified */
-	const char *bucket_time_timezone; /* the name of the timezone, NULL if not specified */
-	Interval *bucket_time_offset;	  /* the offset of set, NULL if not specified */
-	TimestampTz bucket_time_origin;	  /* origin as UTC timestamp. infinity if not specified */
-
-	/* Integer based buckets */
-	int64 bucket_integer_width;	 /* bucket_width of time_bucket */
-	int64 bucket_integer_offset; /* bucket offset of the time_bucket */
+	ContinuousAggsBucketFunction *bf;
 } CAggTimebucketInfo;
 
 typedef enum CaggRefreshCallContext
@@ -93,7 +82,8 @@ typedef enum CaggRefreshCallContext
 	CAGG_REFRESH_POLICY,
 } CaggRefreshCallContext;
 
-#define IS_TIME_BUCKET_INFO_TIME_BASED(bucket_info) (bucket_info->bucket_width_type == INTERVALOID)
+#define IS_TIME_BUCKET_INFO_TIME_BASED(bucket_info)                                                \
+	(bucket_info->bf->bucket_width_type == INTERVALOID)
 
 #define CAGG_MAKEQUERY(selquery, srcquery)                                                         \
 	do                                                                                             \

--- a/tsl/src/continuous_aggs/create.c
+++ b/tsl/src/continuous_aggs/create.c
@@ -825,47 +825,48 @@ cagg_create(const CreateTableAsStmt *create_stmt, ViewStmt *stmt, Query *panquer
 	if (IS_TIME_BUCKET_INFO_TIME_BASED(bucket_info))
 	{
 		/* Bucketing on time */
-		Assert(bucket_info->bucket_time_width != NULL);
+		Assert(bucket_info->bf->bucket_time_width != NULL);
 		bucket_width = DatumGetCString(
-			DirectFunctionCall1(interval_out, IntervalPGetDatum(bucket_info->bucket_time_width)));
+			DirectFunctionCall1(interval_out,
+								IntervalPGetDatum(bucket_info->bf->bucket_time_width)));
 
-		if (!TIMESTAMP_NOT_FINITE(bucket_info->bucket_time_origin))
+		if (!TIMESTAMP_NOT_FINITE(bucket_info->bf->bucket_time_origin))
 		{
 			bucket_origin = DatumGetCString(
 				DirectFunctionCall1(timestamptz_out,
-									TimestampTzGetDatum(bucket_info->bucket_time_origin)));
+									TimestampTzGetDatum(bucket_info->bf->bucket_time_origin)));
 		}
 
-		if (bucket_info->bucket_time_offset != NULL)
+		if (bucket_info->bf->bucket_time_offset != NULL)
 		{
 			bucket_offset = DatumGetCString(
 				DirectFunctionCall1(interval_out,
-									IntervalPGetDatum(bucket_info->bucket_time_offset)));
+									IntervalPGetDatum(bucket_info->bf->bucket_time_offset)));
 		}
 	}
 	else
 	{
 		/* Bucketing on integers */
 		bucket_width = palloc0(MAXINT8LEN + 1 * sizeof(char));
-		pg_lltoa(bucket_info->bucket_integer_width, bucket_width);
+		pg_lltoa(bucket_info->bf->bucket_integer_width, bucket_width);
 
 		/* Integer buckets with origin are not supported, so noting to do. */
 		Assert(bucket_origin == NULL);
 
-		if (bucket_info->bucket_integer_offset != 0)
+		if (bucket_info->bf->bucket_integer_offset != 0)
 		{
 			bucket_offset = palloc0(MAXINT8LEN + 1 * sizeof(char));
-			pg_lltoa(bucket_info->bucket_integer_offset, bucket_offset);
+			pg_lltoa(bucket_info->bf->bucket_integer_offset, bucket_offset);
 		}
 	}
 
 	create_bucket_function_catalog_entry(materialize_hypertable_id,
-										 bucket_info->bucket_func->funcid,
+										 bucket_info->bf->bucket_function,
 										 bucket_width,
 										 bucket_origin,
 										 bucket_offset,
-										 bucket_info->bucket_time_timezone,
-										 time_bucket_info_has_fixed_width(bucket_info));
+										 bucket_info->bf->bucket_time_timezone,
+										 bucket_info->bf->bucket_fixed_interval);
 
 	/* Step 5: Create trigger on raw hypertable -specified in the user view query. */
 	cagg_add_trigger_hypertable(bucket_info->htoid, bucket_info->htid);

--- a/tsl/test/expected/cagg_ddl-13.out
+++ b/tsl/test/expected/cagg_ddl-13.out
@@ -1811,36 +1811,29 @@ SELECT * FROM cashflows;
 -- 3. test named ts
 -- 4. test named bucket width
 -- named origin
--- Currently not supported due to a bug in time_bucket (see comment in cagg_validate_query)
-\set ON_ERROR_STOP 0
 CREATE MATERIALIZED VIEW cagg_named_origin WITH
 (timescaledb.continuous, timescaledb.materialized_only=false) AS
 SELECT time_bucket('1h', time, 'UTC', origin => '2001-01-03 01:23:45') AS bucket,
 avg(amount) as avg_amount
 FROM transactions GROUP BY 1 WITH NO DATA;
-ERROR:  cannot create continuous aggregate with variable-width bucket using offset or origin.
 -- named timezone
 CREATE MATERIALIZED VIEW cagg_named_tz_origin WITH
 (timescaledb.continuous, timescaledb.materialized_only=false) AS
 SELECT time_bucket('1h', time, timezone => 'UTC', origin => '2001-01-03 01:23:45') AS bucket,
 avg(amount) as avg_amount
 FROM transactions GROUP BY 1 WITH NO DATA;
-ERROR:  cannot create continuous aggregate with variable-width bucket using offset or origin.
 -- named ts
 CREATE MATERIALIZED VIEW cagg_named_ts_tz_origin WITH
 (timescaledb.continuous, timescaledb.materialized_only=false) AS
 SELECT time_bucket('1h', ts => time, timezone => 'UTC', origin => '2001-01-03 01:23:45') AS bucket,
 avg(amount) as avg_amount
 FROM transactions GROUP BY 1 WITH NO DATA;
-ERROR:  cannot create continuous aggregate with variable-width bucket using offset or origin.
 -- named bucket width
 CREATE MATERIALIZED VIEW cagg_named_all WITH
 (timescaledb.continuous, timescaledb.materialized_only=false) AS
 SELECT time_bucket(bucket_width => '1h', ts => time, timezone => 'UTC', origin => '2001-01-03 01:23:45') AS bucket,
 avg(amount) as avg_amount
 FROM transactions GROUP BY 1 WITH NO DATA;
-ERROR:  cannot create continuous aggregate with variable-width bucket using offset or origin.
-\set ON_ERROR_STOP 1
 -- Refreshing from the beginning (NULL) of a CAGG with variable time bucket and
 -- using an INTERVAL for the end timestamp (issue #5534)
 CREATE MATERIALIZED VIEW transactions_montly
@@ -1923,7 +1916,7 @@ CREATE TABLE conditions (
 SELECT create_hypertable('conditions', 'time');
     create_hypertable     
 --------------------------
- (48,public,conditions,t)
+ (52,public,conditions,t)
 (1 row)
 
 INSERT INTO conditions VALUES ( '2018-01-01 09:20:00-08', 'SFO', 55);
@@ -1953,10 +1946,10 @@ WITH NO DATA;
  bucket   | timestamp with time zone |           |          |         | plain    | 
  avg      | double precision         |           |          |         | plain    | 
 View definition:
- SELECT _materialized_hypertable_49.location,
-    _materialized_hypertable_49.bucket,
-    _materialized_hypertable_49.avg
-   FROM _timescaledb_internal._materialized_hypertable_49;
+ SELECT _materialized_hypertable_53.location,
+    _materialized_hypertable_53.bucket,
+    _materialized_hypertable_53.avg
+   FROM _timescaledb_internal._materialized_hypertable_53;
 
 -- Should return NO ROWS
 SELECT * FROM conditions_daily ORDER BY bucket, avg;
@@ -1973,17 +1966,17 @@ ALTER MATERIALIZED VIEW conditions_daily SET (timescaledb.materialized_only=fals
  bucket   | timestamp with time zone |           |          |         | plain    | 
  avg      | double precision         |           |          |         | plain    | 
 View definition:
- SELECT _materialized_hypertable_49.location,
-    _materialized_hypertable_49.bucket,
-    _materialized_hypertable_49.avg
-   FROM _timescaledb_internal._materialized_hypertable_49
-  WHERE _materialized_hypertable_49.bucket < COALESCE(_timescaledb_functions.to_timestamp(_timescaledb_functions.cagg_watermark(49)), '-infinity'::timestamp with time zone)
+ SELECT _materialized_hypertable_53.location,
+    _materialized_hypertable_53.bucket,
+    _materialized_hypertable_53.avg
+   FROM _timescaledb_internal._materialized_hypertable_53
+  WHERE _materialized_hypertable_53.bucket < COALESCE(_timescaledb_functions.to_timestamp(_timescaledb_functions.cagg_watermark(53)), '-infinity'::timestamp with time zone)
 UNION ALL
  SELECT conditions.location,
     time_bucket('@ 1 day'::interval, conditions."time") AS bucket,
     avg(conditions.temperature) AS avg
    FROM conditions
-  WHERE conditions."time" >= COALESCE(_timescaledb_functions.to_timestamp(_timescaledb_functions.cagg_watermark(49)), '-infinity'::timestamp with time zone)
+  WHERE conditions."time" >= COALESCE(_timescaledb_functions.to_timestamp(_timescaledb_functions.cagg_watermark(53)), '-infinity'::timestamp with time zone)
   GROUP BY conditions.location, (time_bucket('@ 1 day'::interval, conditions."time"));
 
 -- Should return ROWS because now it is realtime
@@ -2008,10 +2001,10 @@ ALTER MATERIALIZED VIEW conditions_daily SET (timescaledb.materialized_only=true
  bucket   | timestamp with time zone |           |          |         | plain    | 
  avg      | double precision         |           |          |         | plain    | 
 View definition:
- SELECT _materialized_hypertable_49.location,
-    _materialized_hypertable_49.bucket,
-    _materialized_hypertable_49.avg
-   FROM _timescaledb_internal._materialized_hypertable_49;
+ SELECT _materialized_hypertable_53.location,
+    _materialized_hypertable_53.bucket,
+    _materialized_hypertable_53.avg
+   FROM _timescaledb_internal._materialized_hypertable_53;
 
 CALL refresh_continuous_aggregate('conditions_daily', NULL, NULL);
 SELECT * FROM conditions_daily ORDER BY bucket, avg;
@@ -2088,7 +2081,7 @@ NOTICE:  refreshing continuous aggregate "cagg1"
 ALTER MATERIALIZED VIEW cagg1 SET (timescaledb.compress);
 NOTICE:  defaulting compress_orderby to time_bucket
 WARNING:  there was some uncertainty picking the default segment by for the hypertable: You do not have any indexes on columns that can be used for segment_by and thus we are not using segment_by for compression. Please make sure you are not missing any indexes
-NOTICE:  default segment by for hypertable "_materialized_hypertable_52" is set to ""
+NOTICE:  default segment by for hypertable "_materialized_hypertable_56" is set to ""
 SELECT count(compress_chunk(ch)) FROM show_chunks('cagg1') ch;
  count 
 -------
@@ -2096,7 +2089,7 @@ SELECT count(compress_chunk(ch)) FROM show_chunks('cagg1') ch;
 (1 row)
 
 DROP MATERIALIZED VIEW cagg1;
-NOTICE:  drop cascades to table _timescaledb_internal._hyper_52_68_chunk
+NOTICE:  drop cascades to table _timescaledb_internal._hyper_56_68_chunk
 SELECT * FROM _timescaledb_catalog.compression_settings;
  relid | segmentby | orderby | orderby_desc | orderby_nullsfirst 
 -------+-----------+---------+--------------+--------------------

--- a/tsl/test/expected/cagg_ddl-14.out
+++ b/tsl/test/expected/cagg_ddl-14.out
@@ -1811,36 +1811,29 @@ SELECT * FROM cashflows;
 -- 3. test named ts
 -- 4. test named bucket width
 -- named origin
--- Currently not supported due to a bug in time_bucket (see comment in cagg_validate_query)
-\set ON_ERROR_STOP 0
 CREATE MATERIALIZED VIEW cagg_named_origin WITH
 (timescaledb.continuous, timescaledb.materialized_only=false) AS
 SELECT time_bucket('1h', time, 'UTC', origin => '2001-01-03 01:23:45') AS bucket,
 avg(amount) as avg_amount
 FROM transactions GROUP BY 1 WITH NO DATA;
-ERROR:  cannot create continuous aggregate with variable-width bucket using offset or origin.
 -- named timezone
 CREATE MATERIALIZED VIEW cagg_named_tz_origin WITH
 (timescaledb.continuous, timescaledb.materialized_only=false) AS
 SELECT time_bucket('1h', time, timezone => 'UTC', origin => '2001-01-03 01:23:45') AS bucket,
 avg(amount) as avg_amount
 FROM transactions GROUP BY 1 WITH NO DATA;
-ERROR:  cannot create continuous aggregate with variable-width bucket using offset or origin.
 -- named ts
 CREATE MATERIALIZED VIEW cagg_named_ts_tz_origin WITH
 (timescaledb.continuous, timescaledb.materialized_only=false) AS
 SELECT time_bucket('1h', ts => time, timezone => 'UTC', origin => '2001-01-03 01:23:45') AS bucket,
 avg(amount) as avg_amount
 FROM transactions GROUP BY 1 WITH NO DATA;
-ERROR:  cannot create continuous aggregate with variable-width bucket using offset or origin.
 -- named bucket width
 CREATE MATERIALIZED VIEW cagg_named_all WITH
 (timescaledb.continuous, timescaledb.materialized_only=false) AS
 SELECT time_bucket(bucket_width => '1h', ts => time, timezone => 'UTC', origin => '2001-01-03 01:23:45') AS bucket,
 avg(amount) as avg_amount
 FROM transactions GROUP BY 1 WITH NO DATA;
-ERROR:  cannot create continuous aggregate with variable-width bucket using offset or origin.
-\set ON_ERROR_STOP 1
 -- Refreshing from the beginning (NULL) of a CAGG with variable time bucket and
 -- using an INTERVAL for the end timestamp (issue #5534)
 CREATE MATERIALIZED VIEW transactions_montly
@@ -1923,7 +1916,7 @@ CREATE TABLE conditions (
 SELECT create_hypertable('conditions', 'time');
     create_hypertable     
 --------------------------
- (48,public,conditions,t)
+ (52,public,conditions,t)
 (1 row)
 
 INSERT INTO conditions VALUES ( '2018-01-01 09:20:00-08', 'SFO', 55);
@@ -1953,10 +1946,10 @@ WITH NO DATA;
  bucket   | timestamp with time zone |           |          |         | plain    | 
  avg      | double precision         |           |          |         | plain    | 
 View definition:
- SELECT _materialized_hypertable_49.location,
-    _materialized_hypertable_49.bucket,
-    _materialized_hypertable_49.avg
-   FROM _timescaledb_internal._materialized_hypertable_49;
+ SELECT _materialized_hypertable_53.location,
+    _materialized_hypertable_53.bucket,
+    _materialized_hypertable_53.avg
+   FROM _timescaledb_internal._materialized_hypertable_53;
 
 -- Should return NO ROWS
 SELECT * FROM conditions_daily ORDER BY bucket, avg;
@@ -1973,17 +1966,17 @@ ALTER MATERIALIZED VIEW conditions_daily SET (timescaledb.materialized_only=fals
  bucket   | timestamp with time zone |           |          |         | plain    | 
  avg      | double precision         |           |          |         | plain    | 
 View definition:
- SELECT _materialized_hypertable_49.location,
-    _materialized_hypertable_49.bucket,
-    _materialized_hypertable_49.avg
-   FROM _timescaledb_internal._materialized_hypertable_49
-  WHERE _materialized_hypertable_49.bucket < COALESCE(_timescaledb_functions.to_timestamp(_timescaledb_functions.cagg_watermark(49)), '-infinity'::timestamp with time zone)
+ SELECT _materialized_hypertable_53.location,
+    _materialized_hypertable_53.bucket,
+    _materialized_hypertable_53.avg
+   FROM _timescaledb_internal._materialized_hypertable_53
+  WHERE _materialized_hypertable_53.bucket < COALESCE(_timescaledb_functions.to_timestamp(_timescaledb_functions.cagg_watermark(53)), '-infinity'::timestamp with time zone)
 UNION ALL
  SELECT conditions.location,
     time_bucket('@ 1 day'::interval, conditions."time") AS bucket,
     avg(conditions.temperature) AS avg
    FROM conditions
-  WHERE conditions."time" >= COALESCE(_timescaledb_functions.to_timestamp(_timescaledb_functions.cagg_watermark(49)), '-infinity'::timestamp with time zone)
+  WHERE conditions."time" >= COALESCE(_timescaledb_functions.to_timestamp(_timescaledb_functions.cagg_watermark(53)), '-infinity'::timestamp with time zone)
   GROUP BY conditions.location, (time_bucket('@ 1 day'::interval, conditions."time"));
 
 -- Should return ROWS because now it is realtime
@@ -2008,10 +2001,10 @@ ALTER MATERIALIZED VIEW conditions_daily SET (timescaledb.materialized_only=true
  bucket   | timestamp with time zone |           |          |         | plain    | 
  avg      | double precision         |           |          |         | plain    | 
 View definition:
- SELECT _materialized_hypertable_49.location,
-    _materialized_hypertable_49.bucket,
-    _materialized_hypertable_49.avg
-   FROM _timescaledb_internal._materialized_hypertable_49;
+ SELECT _materialized_hypertable_53.location,
+    _materialized_hypertable_53.bucket,
+    _materialized_hypertable_53.avg
+   FROM _timescaledb_internal._materialized_hypertable_53;
 
 CALL refresh_continuous_aggregate('conditions_daily', NULL, NULL);
 SELECT * FROM conditions_daily ORDER BY bucket, avg;
@@ -2088,7 +2081,7 @@ NOTICE:  refreshing continuous aggregate "cagg1"
 ALTER MATERIALIZED VIEW cagg1 SET (timescaledb.compress);
 NOTICE:  defaulting compress_orderby to time_bucket
 WARNING:  there was some uncertainty picking the default segment by for the hypertable: You do not have any indexes on columns that can be used for segment_by and thus we are not using segment_by for compression. Please make sure you are not missing any indexes
-NOTICE:  default segment by for hypertable "_materialized_hypertable_52" is set to ""
+NOTICE:  default segment by for hypertable "_materialized_hypertable_56" is set to ""
 SELECT count(compress_chunk(ch)) FROM show_chunks('cagg1') ch;
  count 
 -------
@@ -2096,7 +2089,7 @@ SELECT count(compress_chunk(ch)) FROM show_chunks('cagg1') ch;
 (1 row)
 
 DROP MATERIALIZED VIEW cagg1;
-NOTICE:  drop cascades to table _timescaledb_internal._hyper_52_68_chunk
+NOTICE:  drop cascades to table _timescaledb_internal._hyper_56_68_chunk
 SELECT * FROM _timescaledb_catalog.compression_settings;
  relid | segmentby | orderby | orderby_desc | orderby_nullsfirst 
 -------+-----------+---------+--------------+--------------------

--- a/tsl/test/expected/cagg_ddl-15.out
+++ b/tsl/test/expected/cagg_ddl-15.out
@@ -1811,36 +1811,29 @@ SELECT * FROM cashflows;
 -- 3. test named ts
 -- 4. test named bucket width
 -- named origin
--- Currently not supported due to a bug in time_bucket (see comment in cagg_validate_query)
-\set ON_ERROR_STOP 0
 CREATE MATERIALIZED VIEW cagg_named_origin WITH
 (timescaledb.continuous, timescaledb.materialized_only=false) AS
 SELECT time_bucket('1h', time, 'UTC', origin => '2001-01-03 01:23:45') AS bucket,
 avg(amount) as avg_amount
 FROM transactions GROUP BY 1 WITH NO DATA;
-ERROR:  cannot create continuous aggregate with variable-width bucket using offset or origin.
 -- named timezone
 CREATE MATERIALIZED VIEW cagg_named_tz_origin WITH
 (timescaledb.continuous, timescaledb.materialized_only=false) AS
 SELECT time_bucket('1h', time, timezone => 'UTC', origin => '2001-01-03 01:23:45') AS bucket,
 avg(amount) as avg_amount
 FROM transactions GROUP BY 1 WITH NO DATA;
-ERROR:  cannot create continuous aggregate with variable-width bucket using offset or origin.
 -- named ts
 CREATE MATERIALIZED VIEW cagg_named_ts_tz_origin WITH
 (timescaledb.continuous, timescaledb.materialized_only=false) AS
 SELECT time_bucket('1h', ts => time, timezone => 'UTC', origin => '2001-01-03 01:23:45') AS bucket,
 avg(amount) as avg_amount
 FROM transactions GROUP BY 1 WITH NO DATA;
-ERROR:  cannot create continuous aggregate with variable-width bucket using offset or origin.
 -- named bucket width
 CREATE MATERIALIZED VIEW cagg_named_all WITH
 (timescaledb.continuous, timescaledb.materialized_only=false) AS
 SELECT time_bucket(bucket_width => '1h', ts => time, timezone => 'UTC', origin => '2001-01-03 01:23:45') AS bucket,
 avg(amount) as avg_amount
 FROM transactions GROUP BY 1 WITH NO DATA;
-ERROR:  cannot create continuous aggregate with variable-width bucket using offset or origin.
-\set ON_ERROR_STOP 1
 -- Refreshing from the beginning (NULL) of a CAGG with variable time bucket and
 -- using an INTERVAL for the end timestamp (issue #5534)
 CREATE MATERIALIZED VIEW transactions_montly
@@ -1923,7 +1916,7 @@ CREATE TABLE conditions (
 SELECT create_hypertable('conditions', 'time');
     create_hypertable     
 --------------------------
- (48,public,conditions,t)
+ (52,public,conditions,t)
 (1 row)
 
 INSERT INTO conditions VALUES ( '2018-01-01 09:20:00-08', 'SFO', 55);
@@ -1953,10 +1946,10 @@ WITH NO DATA;
  bucket   | timestamp with time zone |           |          |         | plain    | 
  avg      | double precision         |           |          |         | plain    | 
 View definition:
- SELECT _materialized_hypertable_49.location,
-    _materialized_hypertable_49.bucket,
-    _materialized_hypertable_49.avg
-   FROM _timescaledb_internal._materialized_hypertable_49;
+ SELECT _materialized_hypertable_53.location,
+    _materialized_hypertable_53.bucket,
+    _materialized_hypertable_53.avg
+   FROM _timescaledb_internal._materialized_hypertable_53;
 
 -- Should return NO ROWS
 SELECT * FROM conditions_daily ORDER BY bucket, avg;
@@ -1973,17 +1966,17 @@ ALTER MATERIALIZED VIEW conditions_daily SET (timescaledb.materialized_only=fals
  bucket   | timestamp with time zone |           |          |         | plain    | 
  avg      | double precision         |           |          |         | plain    | 
 View definition:
- SELECT _materialized_hypertable_49.location,
-    _materialized_hypertable_49.bucket,
-    _materialized_hypertable_49.avg
-   FROM _timescaledb_internal._materialized_hypertable_49
-  WHERE _materialized_hypertable_49.bucket < COALESCE(_timescaledb_functions.to_timestamp(_timescaledb_functions.cagg_watermark(49)), '-infinity'::timestamp with time zone)
+ SELECT _materialized_hypertable_53.location,
+    _materialized_hypertable_53.bucket,
+    _materialized_hypertable_53.avg
+   FROM _timescaledb_internal._materialized_hypertable_53
+  WHERE _materialized_hypertable_53.bucket < COALESCE(_timescaledb_functions.to_timestamp(_timescaledb_functions.cagg_watermark(53)), '-infinity'::timestamp with time zone)
 UNION ALL
  SELECT conditions.location,
     time_bucket('@ 1 day'::interval, conditions."time") AS bucket,
     avg(conditions.temperature) AS avg
    FROM conditions
-  WHERE conditions."time" >= COALESCE(_timescaledb_functions.to_timestamp(_timescaledb_functions.cagg_watermark(49)), '-infinity'::timestamp with time zone)
+  WHERE conditions."time" >= COALESCE(_timescaledb_functions.to_timestamp(_timescaledb_functions.cagg_watermark(53)), '-infinity'::timestamp with time zone)
   GROUP BY conditions.location, (time_bucket('@ 1 day'::interval, conditions."time"));
 
 -- Should return ROWS because now it is realtime
@@ -2008,10 +2001,10 @@ ALTER MATERIALIZED VIEW conditions_daily SET (timescaledb.materialized_only=true
  bucket   | timestamp with time zone |           |          |         | plain    | 
  avg      | double precision         |           |          |         | plain    | 
 View definition:
- SELECT _materialized_hypertable_49.location,
-    _materialized_hypertable_49.bucket,
-    _materialized_hypertable_49.avg
-   FROM _timescaledb_internal._materialized_hypertable_49;
+ SELECT _materialized_hypertable_53.location,
+    _materialized_hypertable_53.bucket,
+    _materialized_hypertable_53.avg
+   FROM _timescaledb_internal._materialized_hypertable_53;
 
 CALL refresh_continuous_aggregate('conditions_daily', NULL, NULL);
 SELECT * FROM conditions_daily ORDER BY bucket, avg;
@@ -2088,7 +2081,7 @@ NOTICE:  refreshing continuous aggregate "cagg1"
 ALTER MATERIALIZED VIEW cagg1 SET (timescaledb.compress);
 NOTICE:  defaulting compress_orderby to time_bucket
 WARNING:  there was some uncertainty picking the default segment by for the hypertable: You do not have any indexes on columns that can be used for segment_by and thus we are not using segment_by for compression. Please make sure you are not missing any indexes
-NOTICE:  default segment by for hypertable "_materialized_hypertable_52" is set to ""
+NOTICE:  default segment by for hypertable "_materialized_hypertable_56" is set to ""
 SELECT count(compress_chunk(ch)) FROM show_chunks('cagg1') ch;
  count 
 -------
@@ -2096,7 +2089,7 @@ SELECT count(compress_chunk(ch)) FROM show_chunks('cagg1') ch;
 (1 row)
 
 DROP MATERIALIZED VIEW cagg1;
-NOTICE:  drop cascades to table _timescaledb_internal._hyper_52_68_chunk
+NOTICE:  drop cascades to table _timescaledb_internal._hyper_56_68_chunk
 SELECT * FROM _timescaledb_catalog.compression_settings;
  relid | segmentby | orderby | orderby_desc | orderby_nullsfirst 
 -------+-----------+---------+--------------+--------------------

--- a/tsl/test/expected/cagg_ddl-16.out
+++ b/tsl/test/expected/cagg_ddl-16.out
@@ -1811,36 +1811,29 @@ SELECT * FROM cashflows;
 -- 3. test named ts
 -- 4. test named bucket width
 -- named origin
--- Currently not supported due to a bug in time_bucket (see comment in cagg_validate_query)
-\set ON_ERROR_STOP 0
 CREATE MATERIALIZED VIEW cagg_named_origin WITH
 (timescaledb.continuous, timescaledb.materialized_only=false) AS
 SELECT time_bucket('1h', time, 'UTC', origin => '2001-01-03 01:23:45') AS bucket,
 avg(amount) as avg_amount
 FROM transactions GROUP BY 1 WITH NO DATA;
-ERROR:  cannot create continuous aggregate with variable-width bucket using offset or origin.
 -- named timezone
 CREATE MATERIALIZED VIEW cagg_named_tz_origin WITH
 (timescaledb.continuous, timescaledb.materialized_only=false) AS
 SELECT time_bucket('1h', time, timezone => 'UTC', origin => '2001-01-03 01:23:45') AS bucket,
 avg(amount) as avg_amount
 FROM transactions GROUP BY 1 WITH NO DATA;
-ERROR:  cannot create continuous aggregate with variable-width bucket using offset or origin.
 -- named ts
 CREATE MATERIALIZED VIEW cagg_named_ts_tz_origin WITH
 (timescaledb.continuous, timescaledb.materialized_only=false) AS
 SELECT time_bucket('1h', ts => time, timezone => 'UTC', origin => '2001-01-03 01:23:45') AS bucket,
 avg(amount) as avg_amount
 FROM transactions GROUP BY 1 WITH NO DATA;
-ERROR:  cannot create continuous aggregate with variable-width bucket using offset or origin.
 -- named bucket width
 CREATE MATERIALIZED VIEW cagg_named_all WITH
 (timescaledb.continuous, timescaledb.materialized_only=false) AS
 SELECT time_bucket(bucket_width => '1h', ts => time, timezone => 'UTC', origin => '2001-01-03 01:23:45') AS bucket,
 avg(amount) as avg_amount
 FROM transactions GROUP BY 1 WITH NO DATA;
-ERROR:  cannot create continuous aggregate with variable-width bucket using offset or origin.
-\set ON_ERROR_STOP 1
 -- Refreshing from the beginning (NULL) of a CAGG with variable time bucket and
 -- using an INTERVAL for the end timestamp (issue #5534)
 CREATE MATERIALIZED VIEW transactions_montly
@@ -1923,7 +1916,7 @@ CREATE TABLE conditions (
 SELECT create_hypertable('conditions', 'time');
     create_hypertable     
 --------------------------
- (48,public,conditions,t)
+ (52,public,conditions,t)
 (1 row)
 
 INSERT INTO conditions VALUES ( '2018-01-01 09:20:00-08', 'SFO', 55);
@@ -1956,7 +1949,7 @@ View definition:
  SELECT location,
     bucket,
     avg
-   FROM _timescaledb_internal._materialized_hypertable_49;
+   FROM _timescaledb_internal._materialized_hypertable_53;
 
 -- Should return NO ROWS
 SELECT * FROM conditions_daily ORDER BY bucket, avg;
@@ -1973,17 +1966,17 @@ ALTER MATERIALIZED VIEW conditions_daily SET (timescaledb.materialized_only=fals
  bucket   | timestamp with time zone |           |          |         | plain    | 
  avg      | double precision         |           |          |         | plain    | 
 View definition:
- SELECT _materialized_hypertable_49.location,
-    _materialized_hypertable_49.bucket,
-    _materialized_hypertable_49.avg
-   FROM _timescaledb_internal._materialized_hypertable_49
-  WHERE _materialized_hypertable_49.bucket < COALESCE(_timescaledb_functions.to_timestamp(_timescaledb_functions.cagg_watermark(49)), '-infinity'::timestamp with time zone)
+ SELECT _materialized_hypertable_53.location,
+    _materialized_hypertable_53.bucket,
+    _materialized_hypertable_53.avg
+   FROM _timescaledb_internal._materialized_hypertable_53
+  WHERE _materialized_hypertable_53.bucket < COALESCE(_timescaledb_functions.to_timestamp(_timescaledb_functions.cagg_watermark(53)), '-infinity'::timestamp with time zone)
 UNION ALL
  SELECT conditions.location,
     time_bucket('@ 1 day'::interval, conditions."time") AS bucket,
     avg(conditions.temperature) AS avg
    FROM conditions
-  WHERE conditions."time" >= COALESCE(_timescaledb_functions.to_timestamp(_timescaledb_functions.cagg_watermark(49)), '-infinity'::timestamp with time zone)
+  WHERE conditions."time" >= COALESCE(_timescaledb_functions.to_timestamp(_timescaledb_functions.cagg_watermark(53)), '-infinity'::timestamp with time zone)
   GROUP BY conditions.location, (time_bucket('@ 1 day'::interval, conditions."time"));
 
 -- Should return ROWS because now it is realtime
@@ -2011,7 +2004,7 @@ View definition:
  SELECT location,
     bucket,
     avg
-   FROM _timescaledb_internal._materialized_hypertable_49;
+   FROM _timescaledb_internal._materialized_hypertable_53;
 
 CALL refresh_continuous_aggregate('conditions_daily', NULL, NULL);
 SELECT * FROM conditions_daily ORDER BY bucket, avg;
@@ -2088,7 +2081,7 @@ NOTICE:  refreshing continuous aggregate "cagg1"
 ALTER MATERIALIZED VIEW cagg1 SET (timescaledb.compress);
 NOTICE:  defaulting compress_orderby to time_bucket
 WARNING:  there was some uncertainty picking the default segment by for the hypertable: You do not have any indexes on columns that can be used for segment_by and thus we are not using segment_by for compression. Please make sure you are not missing any indexes
-NOTICE:  default segment by for hypertable "_materialized_hypertable_52" is set to ""
+NOTICE:  default segment by for hypertable "_materialized_hypertable_56" is set to ""
 SELECT count(compress_chunk(ch)) FROM show_chunks('cagg1') ch;
  count 
 -------
@@ -2096,7 +2089,7 @@ SELECT count(compress_chunk(ch)) FROM show_chunks('cagg1') ch;
 (1 row)
 
 DROP MATERIALIZED VIEW cagg1;
-NOTICE:  drop cascades to table _timescaledb_internal._hyper_52_68_chunk
+NOTICE:  drop cascades to table _timescaledb_internal._hyper_56_68_chunk
 SELECT * FROM _timescaledb_catalog.compression_settings;
  relid | segmentby | orderby | orderby_desc | orderby_nullsfirst 
 -------+-----------+---------+--------------+--------------------

--- a/tsl/test/expected/cagg_query.out
+++ b/tsl/test/expected/cagg_query.out
@@ -808,6 +808,9 @@ SELECT set_integer_now_func('table_bigint', 'integer_now_bigint');
 INSERT INTO table_smallint VALUES(1,2);
 INSERT INTO table_int VALUES(1,2);
 INSERT INTO table_bigint VALUES(1,2);
+CREATE VIEW caggs_info AS
+SELECT user_view_schema, user_view_name, bucket_func, bucket_width, bucket_origin, bucket_offset, bucket_timezone, bucket_fixed_width
+FROM _timescaledb_catalog.continuous_aggs_bucket_function NATURAL JOIN _timescaledb_catalog.continuous_agg;
 ---
 -- Tests with CAgg creation
 ---
@@ -817,10 +820,10 @@ CREATE MATERIALIZED VIEW cagg_4_hours
     FROM temperature
     GROUP BY 1 ORDER BY 1;
 NOTICE:  refreshing continuous aggregate "cagg_4_hours"
-SELECT * FROM _timescaledb_catalog.continuous_aggs_bucket_function ORDER BY 1 DESC LIMIT 1;
- mat_hypertable_id |                      bucket_func                      | bucket_width | bucket_origin | bucket_offset | bucket_timezone | bucket_fixed_width 
--------------------+-------------------------------------------------------+--------------+---------------+---------------+-----------------+--------------------
-                10 | public.time_bucket(interval,timestamp with time zone) | @ 4 hours    |               |               |                 | t
+SELECT * FROM caggs_info WHERE user_view_name = 'cagg_4_hours';
+ user_view_schema | user_view_name |                      bucket_func                      | bucket_width | bucket_origin | bucket_offset | bucket_timezone | bucket_fixed_width 
+------------------+----------------+-------------------------------------------------------+--------------+---------------+---------------+-----------------+--------------------
+ public           | cagg_4_hours   | public.time_bucket(interval,timestamp with time zone) | @ 4 hours    |               |               |                 | t
 (1 row)
 
 DROP MATERIALIZED VIEW cagg_4_hours;
@@ -831,10 +834,10 @@ CREATE MATERIALIZED VIEW cagg_4_hours_offset
     FROM temperature
     GROUP BY 1 ORDER BY 1;
 NOTICE:  refreshing continuous aggregate "cagg_4_hours_offset"
-SELECT * FROM _timescaledb_catalog.continuous_aggs_bucket_function ORDER BY 1 DESC LIMIT 1;
- mat_hypertable_id |                          bucket_func                           | bucket_width | bucket_origin | bucket_offset | bucket_timezone | bucket_fixed_width 
--------------------+----------------------------------------------------------------+--------------+---------------+---------------+-----------------+--------------------
-                11 | public.time_bucket(interval,timestamp with time zone,interval) | @ 4 hours    |               | @ 30 mins     |                 | t
+SELECT * FROM caggs_info WHERE user_view_name = 'cagg_4_hours_offset';
+ user_view_schema |   user_view_name    |                          bucket_func                           | bucket_width | bucket_origin | bucket_offset | bucket_timezone | bucket_fixed_width 
+------------------+---------------------+----------------------------------------------------------------+--------------+---------------+---------------+-----------------+--------------------
+ public           | cagg_4_hours_offset | public.time_bucket(interval,timestamp with time zone,interval) | @ 4 hours    |               | @ 30 mins     |                 | t
 (1 row)
 
 DROP MATERIALIZED VIEW cagg_4_hours_offset;
@@ -845,43 +848,43 @@ CREATE MATERIALIZED VIEW cagg_4_hours_offset2
     FROM temperature
     GROUP BY 1 ORDER BY 1;
 NOTICE:  refreshing continuous aggregate "cagg_4_hours_offset2"
-SELECT * FROM _timescaledb_catalog.continuous_aggs_bucket_function ORDER BY 1 DESC LIMIT 1;
- mat_hypertable_id |                          bucket_func                           | bucket_width | bucket_origin | bucket_offset | bucket_timezone | bucket_fixed_width 
--------------------+----------------------------------------------------------------+--------------+---------------+---------------+-----------------+--------------------
-                12 | public.time_bucket(interval,timestamp with time zone,interval) | @ 4 hours    |               | @ 30 mins     |                 | t
+SELECT * FROM caggs_info WHERE user_view_name = 'cagg_4_hours_offset2';
+ user_view_schema |    user_view_name    |                          bucket_func                           | bucket_width | bucket_origin | bucket_offset | bucket_timezone | bucket_fixed_width 
+------------------+----------------------+----------------------------------------------------------------+--------------+---------------+---------------+-----------------+--------------------
+ public           | cagg_4_hours_offset2 | public.time_bucket(interval,timestamp with time zone,interval) | @ 4 hours    |               | @ 30 mins     |                 | t
 (1 row)
 
 DROP MATERIALIZED VIEW cagg_4_hours_offset2;
 NOTICE:  drop cascades to table _timescaledb_internal._hyper_12_16_chunk
--- Variable buckets (timezone is provided) with offset are not supported at the moment
-\set ON_ERROR_STOP 0
+-- Variable buckets (timezone is provided) with offset
 CREATE MATERIALIZED VIEW cagg_4_hours_offset_ts
   WITH (timescaledb.continuous, timescaledb.materialized_only = false) AS
   SELECT time_bucket('4 hour', time, "offset"=>'30m'::interval, timezone=>'UTC'), max(value)
     FROM temperature
     GROUP BY 1 ORDER BY 1;
-ERROR:  cannot create continuous aggregate with variable-width bucket using offset or origin.
-SELECT * FROM _timescaledb_catalog.continuous_aggs_bucket_function ORDER BY 1 DESC LIMIT 1;
- mat_hypertable_id |                      bucket_func                      | bucket_width | bucket_origin | bucket_offset | bucket_timezone | bucket_fixed_width 
--------------------+-------------------------------------------------------+--------------+---------------+---------------+-----------------+--------------------
-                 3 | public.time_bucket(interval,timestamp with time zone) | @ 1 day      |               |               |                 | t
+NOTICE:  refreshing continuous aggregate "cagg_4_hours_offset_ts"
+SELECT * FROM caggs_info WHERE user_view_name = 'cagg_4_hours_offset_ts';
+ user_view_schema |     user_view_name     |                                               bucket_func                                               | bucket_width | bucket_origin | bucket_offset | bucket_timezone | bucket_fixed_width 
+------------------+------------------------+---------------------------------------------------------------------------------------------------------+--------------+---------------+---------------+-----------------+--------------------
+ public           | cagg_4_hours_offset_ts | public.time_bucket(interval,timestamp with time zone,pg_catalog.text,timestamp with time zone,interval) | @ 4 hours    |               | @ 30 mins     | UTC             | f
 (1 row)
 
-\set ON_ERROR_STOP 1
+DROP MATERIALIZED VIEW cagg_4_hours_offset_ts;
+NOTICE:  drop cascades to table _timescaledb_internal._hyper_13_17_chunk
 CREATE MATERIALIZED VIEW cagg_4_hours_origin
   WITH (timescaledb.continuous, timescaledb.materialized_only = false) AS
   SELECT time_bucket('4 hour', time, '2000-01-01 01:00:00 PST'::timestamptz), max(value)
     FROM temperature
     GROUP BY 1 ORDER BY 1;
 NOTICE:  refreshing continuous aggregate "cagg_4_hours_origin"
-SELECT * FROM _timescaledb_catalog.continuous_aggs_bucket_function ORDER BY 1 DESC LIMIT 1;
- mat_hypertable_id |                                  bucket_func                                   | bucket_width |        bucket_origin         | bucket_offset | bucket_timezone | bucket_fixed_width 
--------------------+--------------------------------------------------------------------------------+--------------+------------------------------+---------------+-----------------+--------------------
-                13 | public.time_bucket(interval,timestamp with time zone,timestamp with time zone) | @ 4 hours    | Sat Jan 01 01:00:00 2000 PST |               |                 | t
+SELECT * FROM caggs_info WHERE user_view_name = 'cagg_4_hours_origin';
+ user_view_schema |   user_view_name    |                                  bucket_func                                   | bucket_width |        bucket_origin         | bucket_offset | bucket_timezone | bucket_fixed_width 
+------------------+---------------------+--------------------------------------------------------------------------------+--------------+------------------------------+---------------+-----------------+--------------------
+ public           | cagg_4_hours_origin | public.time_bucket(interval,timestamp with time zone,timestamp with time zone) | @ 4 hours    | Sat Jan 01 01:00:00 2000 PST |               |                 | t
 (1 row)
 
 DROP MATERIALIZED VIEW cagg_4_hours_origin;
-NOTICE:  drop cascades to table _timescaledb_internal._hyper_13_17_chunk
+NOTICE:  drop cascades to table _timescaledb_internal._hyper_14_18_chunk
 -- Using named parameter
 CREATE MATERIALIZED VIEW cagg_4_hours_origin2
   WITH (timescaledb.continuous, timescaledb.materialized_only = false) AS
@@ -889,42 +892,44 @@ CREATE MATERIALIZED VIEW cagg_4_hours_origin2
     FROM temperature
     GROUP BY 1 ORDER BY 1;
 NOTICE:  refreshing continuous aggregate "cagg_4_hours_origin2"
-SELECT * FROM _timescaledb_catalog.continuous_aggs_bucket_function ORDER BY 1 DESC LIMIT 1;
- mat_hypertable_id |                                  bucket_func                                   | bucket_width |        bucket_origin         | bucket_offset | bucket_timezone | bucket_fixed_width 
--------------------+--------------------------------------------------------------------------------+--------------+------------------------------+---------------+-----------------+--------------------
-                14 | public.time_bucket(interval,timestamp with time zone,timestamp with time zone) | @ 4 hours    | Sat Jan 01 01:00:00 2000 PST |               |                 | t
+SELECT * FROM caggs_info WHERE user_view_name = 'cagg_4_hours_origin2';
+ user_view_schema |    user_view_name    |                                  bucket_func                                   | bucket_width |        bucket_origin         | bucket_offset | bucket_timezone | bucket_fixed_width 
+------------------+----------------------+--------------------------------------------------------------------------------+--------------+------------------------------+---------------+-----------------+--------------------
+ public           | cagg_4_hours_origin2 | public.time_bucket(interval,timestamp with time zone,timestamp with time zone) | @ 4 hours    | Sat Jan 01 01:00:00 2000 PST |               |                 | t
 (1 row)
 
 DROP MATERIALIZED VIEW cagg_4_hours_origin2;
-NOTICE:  drop cascades to table _timescaledb_internal._hyper_14_18_chunk
--- Variable buckets (timezone is provided) with origin are not supported at the moment
-\set ON_ERROR_STOP 0
+NOTICE:  drop cascades to table _timescaledb_internal._hyper_15_19_chunk
+-- Variable buckets (timezone is provided) with origin
 CREATE MATERIALIZED VIEW cagg_4_hours_origin_ts
   WITH (timescaledb.continuous, timescaledb.materialized_only = false) AS
   SELECT time_bucket('4 hour', time, origin=>'2000-01-01 01:00:00 PST'::timestamptz, timezone=>'UTC'), max(value)
     FROM temperature
     GROUP BY 1 ORDER BY 1;
-ERROR:  cannot create continuous aggregate with variable-width bucket using offset or origin.
-SELECT * FROM _timescaledb_catalog.continuous_aggs_bucket_function ORDER BY 1 DESC LIMIT 1;
- mat_hypertable_id |                      bucket_func                      | bucket_width | bucket_origin | bucket_offset | bucket_timezone | bucket_fixed_width 
--------------------+-------------------------------------------------------+--------------+---------------+---------------+-----------------+--------------------
-                 3 | public.time_bucket(interval,timestamp with time zone) | @ 1 day      |               |               |                 | t
+NOTICE:  refreshing continuous aggregate "cagg_4_hours_origin_ts"
+SELECT * FROM caggs_info WHERE user_view_name = 'cagg_4_hours_origin_ts';
+ user_view_schema |     user_view_name     |                                               bucket_func                                               | bucket_width |        bucket_origin         | bucket_offset | bucket_timezone | bucket_fixed_width 
+------------------+------------------------+---------------------------------------------------------------------------------------------------------+--------------+------------------------------+---------------+-----------------+--------------------
+ public           | cagg_4_hours_origin_ts | public.time_bucket(interval,timestamp with time zone,pg_catalog.text,timestamp with time zone,interval) | @ 4 hours    | Sat Jan 01 01:00:00 2000 PST |               | UTC             | f
 (1 row)
 
+DROP MATERIALIZED VIEW cagg_4_hours_origin_ts;
+NOTICE:  drop cascades to table _timescaledb_internal._hyper_16_20_chunk
 -- Without named parameter
 CREATE MATERIALIZED VIEW cagg_4_hours_origin_ts2
   WITH (timescaledb.continuous, timescaledb.materialized_only = false) AS
   SELECT time_bucket('4 hour', time, 'UTC', '2000-01-01 01:00:00 PST'::timestamptz), max(value)
     FROM temperature
     GROUP BY 1 ORDER BY 1;
-ERROR:  cannot create continuous aggregate with variable-width bucket using offset or origin.
-SELECT * FROM _timescaledb_catalog.continuous_aggs_bucket_function ORDER BY 1 DESC LIMIT 1;
- mat_hypertable_id |                      bucket_func                      | bucket_width | bucket_origin | bucket_offset | bucket_timezone | bucket_fixed_width 
--------------------+-------------------------------------------------------+--------------+---------------+---------------+-----------------+--------------------
-                 3 | public.time_bucket(interval,timestamp with time zone) | @ 1 day      |               |               |                 | t
+NOTICE:  refreshing continuous aggregate "cagg_4_hours_origin_ts2"
+SELECT * FROM caggs_info WHERE user_view_name = 'cagg_4_hours_origin_ts2';
+ user_view_schema |     user_view_name      |                                               bucket_func                                               | bucket_width |        bucket_origin         | bucket_offset | bucket_timezone | bucket_fixed_width 
+------------------+-------------------------+---------------------------------------------------------------------------------------------------------+--------------+------------------------------+---------------+-----------------+--------------------
+ public           | cagg_4_hours_origin_ts2 | public.time_bucket(interval,timestamp with time zone,pg_catalog.text,timestamp with time zone,interval) | @ 4 hours    | Sat Jan 01 01:00:00 2000 PST |               | UTC             | f
 (1 row)
 
-\set ON_ERROR_STOP 1
+DROP MATERIALIZED VIEW cagg_4_hours_origin_ts2;
+NOTICE:  drop cascades to table _timescaledb_internal._hyper_17_21_chunk
 -- Timestamp based CAggs
 CREATE MATERIALIZED VIEW cagg_4_hours_wo_tz
   WITH (timescaledb.continuous, timescaledb.materialized_only = false) AS
@@ -932,10 +937,10 @@ CREATE MATERIALIZED VIEW cagg_4_hours_wo_tz
     FROM temperature_wo_tz
     GROUP BY 1 ORDER BY 1;
 NOTICE:  refreshing continuous aggregate "cagg_4_hours_wo_tz"
-SELECT * FROM _timescaledb_catalog.continuous_aggs_bucket_function ORDER BY 1 DESC LIMIT 1;
- mat_hypertable_id |                       bucket_func                        | bucket_width | bucket_origin | bucket_offset | bucket_timezone | bucket_fixed_width 
--------------------+----------------------------------------------------------+--------------+---------------+---------------+-----------------+--------------------
-                15 | public.time_bucket(interval,timestamp without time zone) | @ 4 hours    |               |               |                 | t
+SELECT * FROM caggs_info WHERE user_view_name = 'cagg_4_hours_wo_tz';
+ user_view_schema |   user_view_name   |                       bucket_func                        | bucket_width | bucket_origin | bucket_offset | bucket_timezone | bucket_fixed_width 
+------------------+--------------------+----------------------------------------------------------+--------------+---------------+---------------+-----------------+--------------------
+ public           | cagg_4_hours_wo_tz | public.time_bucket(interval,timestamp without time zone) | @ 4 hours    |               |               |                 | t
 (1 row)
 
 CREATE MATERIALIZED VIEW cagg_4_hours_origin_ts_wo_tz
@@ -944,42 +949,44 @@ CREATE MATERIALIZED VIEW cagg_4_hours_origin_ts_wo_tz
     FROM temperature_wo_tz
     GROUP BY 1 ORDER BY 1;
 NOTICE:  refreshing continuous aggregate "cagg_4_hours_origin_ts_wo_tz"
-SELECT * FROM _timescaledb_catalog.continuous_aggs_bucket_function ORDER BY 1 DESC LIMIT 1;
- mat_hypertable_id |                                     bucket_func                                      | bucket_width |        bucket_origin         | bucket_offset | bucket_timezone | bucket_fixed_width 
--------------------+--------------------------------------------------------------------------------------+--------------+------------------------------+---------------+-----------------+--------------------
-                16 | public.time_bucket(interval,timestamp without time zone,timestamp without time zone) | @ 4 hours    | Fri Dec 31 17:00:00 1999 PST |               |                 | t
+SELECT * FROM caggs_info WHERE user_view_name = 'cagg_4_hours_origin_ts_wo_tz';
+ user_view_schema |        user_view_name        |                                     bucket_func                                      | bucket_width |        bucket_origin         | bucket_offset | bucket_timezone | bucket_fixed_width 
+------------------+------------------------------+--------------------------------------------------------------------------------------+--------------+------------------------------+---------------+-----------------+--------------------
+ public           | cagg_4_hours_origin_ts_wo_tz | public.time_bucket(interval,timestamp without time zone,timestamp without time zone) | @ 4 hours    | Fri Dec 31 17:00:00 1999 PST |               |                 | t
 (1 row)
 
 DROP MATERIALIZED VIEW cagg_4_hours_origin_ts_wo_tz;
-NOTICE:  drop cascades to table _timescaledb_internal._hyper_16_20_chunk
--- Variable buckets (timezone is provided) with origin are not supported at the moment
-\set ON_ERROR_STOP 0
+NOTICE:  drop cascades to table _timescaledb_internal._hyper_19_23_chunk
+-- Variable buckets (timezone is provided) with origin
 CREATE MATERIALIZED VIEW cagg_4_hours_origin_ts_wo_tz2
   WITH (timescaledb.continuous, timescaledb.materialized_only = false) AS
   SELECT time_bucket('4 hour', time, origin=>'2000-01-01 01:00:00'::timestamp), max(value)
     FROM temperature_wo_tz
     GROUP BY 1 ORDER BY 1;
 NOTICE:  refreshing continuous aggregate "cagg_4_hours_origin_ts_wo_tz2"
-SELECT * FROM _timescaledb_catalog.continuous_aggs_bucket_function ORDER BY 1 DESC LIMIT 1;
- mat_hypertable_id |                                     bucket_func                                      | bucket_width |        bucket_origin         | bucket_offset | bucket_timezone | bucket_fixed_width 
--------------------+--------------------------------------------------------------------------------------+--------------+------------------------------+---------------+-----------------+--------------------
-                17 | public.time_bucket(interval,timestamp without time zone,timestamp without time zone) | @ 4 hours    | Fri Dec 31 17:00:00 1999 PST |               |                 | t
+SELECT * FROM caggs_info WHERE user_view_name = 'cagg_4_hours_origin_ts_wo_tz2';
+ user_view_schema |        user_view_name         |                                     bucket_func                                      | bucket_width |        bucket_origin         | bucket_offset | bucket_timezone | bucket_fixed_width 
+------------------+-------------------------------+--------------------------------------------------------------------------------------+--------------+------------------------------+---------------+-----------------+--------------------
+ public           | cagg_4_hours_origin_ts_wo_tz2 | public.time_bucket(interval,timestamp without time zone,timestamp without time zone) | @ 4 hours    | Fri Dec 31 17:00:00 1999 PST |               |                 | t
 (1 row)
 
-\set ON_ERROR_STOP 1
+DROP MATERIALIZED VIEW cagg_4_hours_origin_ts_wo_tz2;
+NOTICE:  drop cascades to table _timescaledb_internal._hyper_20_24_chunk
 CREATE MATERIALIZED VIEW cagg_4_hours_offset_wo_tz
   WITH (timescaledb.continuous, timescaledb.materialized_only = false) AS
   SELECT time_bucket('4 hour', time, "offset"=>'30m'::interval), max(value)
     FROM temperature_wo_tz
     GROUP BY 1 ORDER BY 1;
 NOTICE:  refreshing continuous aggregate "cagg_4_hours_offset_wo_tz"
-SELECT * FROM _timescaledb_catalog.continuous_aggs_bucket_function ORDER BY 1 DESC LIMIT 1;
- mat_hypertable_id |                            bucket_func                            | bucket_width | bucket_origin | bucket_offset | bucket_timezone | bucket_fixed_width 
--------------------+-------------------------------------------------------------------+--------------+---------------+---------------+-----------------+--------------------
-                18 | public.time_bucket(interval,timestamp without time zone,interval) | @ 4 hours    |               | @ 30 mins     |                 | t
+SELECT * FROM caggs_info WHERE user_view_name = 'cagg_4_hours_offset_wo_tz';
+ user_view_schema |      user_view_name       |                            bucket_func                            | bucket_width | bucket_origin | bucket_offset | bucket_timezone | bucket_fixed_width 
+------------------+---------------------------+-------------------------------------------------------------------+--------------+---------------+---------------+-----------------+--------------------
+ public           | cagg_4_hours_offset_wo_tz | public.time_bucket(interval,timestamp without time zone,interval) | @ 4 hours    |               | @ 30 mins     |                 | t
 (1 row)
 
 DROP MATERIALIZED VIEW cagg_4_hours_offset_wo_tz;
+NOTICE:  drop cascades to table _timescaledb_internal._hyper_21_25_chunk
+DROP MATERIALIZED VIEW cagg_4_hours_wo_tz;
 NOTICE:  drop cascades to table _timescaledb_internal._hyper_18_22_chunk
 -- Date based CAggs
 CREATE MATERIALIZED VIEW cagg_4_hours_date
@@ -988,56 +995,56 @@ CREATE MATERIALIZED VIEW cagg_4_hours_date
     FROM temperature_date
     GROUP BY 1 ORDER BY 1;
 NOTICE:  refreshing continuous aggregate "cagg_4_hours_date"
-SELECT * FROM _timescaledb_catalog.continuous_aggs_bucket_function ORDER BY 1 DESC LIMIT 1;
- mat_hypertable_id |                 bucket_func                  | bucket_width | bucket_origin | bucket_offset | bucket_timezone | bucket_fixed_width 
--------------------+----------------------------------------------+--------------+---------------+---------------+-----------------+--------------------
-                19 | public.time_bucket(interval,pg_catalog.date) | @ 4 days     |               |               |                 | t
+SELECT * FROM caggs_info WHERE user_view_name = 'cagg_4_hours_date';
+ user_view_schema |  user_view_name   |                 bucket_func                  | bucket_width | bucket_origin | bucket_offset | bucket_timezone | bucket_fixed_width 
+------------------+-------------------+----------------------------------------------+--------------+---------------+---------------+-----------------+--------------------
+ public           | cagg_4_hours_date | public.time_bucket(interval,pg_catalog.date) | @ 4 days     |               |               |                 | t
 (1 row)
 
 DROP MATERIALIZED VIEW cagg_4_hours_date;
-NOTICE:  drop cascades to table _timescaledb_internal._hyper_19_23_chunk
+NOTICE:  drop cascades to table _timescaledb_internal._hyper_22_26_chunk
 CREATE MATERIALIZED VIEW cagg_4_hours_date_origin
   WITH (timescaledb.continuous, timescaledb.materialized_only = false) AS
   SELECT time_bucket('4 days', time, '2000-01-01'::date), max(value)
     FROM temperature_date
     GROUP BY 1 ORDER BY 1;
 NOTICE:  refreshing continuous aggregate "cagg_4_hours_date_origin"
-SELECT * FROM _timescaledb_catalog.continuous_aggs_bucket_function ORDER BY 1 DESC LIMIT 1;
- mat_hypertable_id |                         bucket_func                          | bucket_width |        bucket_origin         | bucket_offset | bucket_timezone | bucket_fixed_width 
--------------------+--------------------------------------------------------------+--------------+------------------------------+---------------+-----------------+--------------------
-                20 | public.time_bucket(interval,pg_catalog.date,pg_catalog.date) | @ 4 days     | Fri Dec 31 16:00:00 1999 PST |               |                 | t
+SELECT * FROM caggs_info WHERE user_view_name = 'cagg_4_hours_date_origin';
+ user_view_schema |      user_view_name      |                         bucket_func                          | bucket_width |        bucket_origin         | bucket_offset | bucket_timezone | bucket_fixed_width 
+------------------+--------------------------+--------------------------------------------------------------+--------------+------------------------------+---------------+-----------------+--------------------
+ public           | cagg_4_hours_date_origin | public.time_bucket(interval,pg_catalog.date,pg_catalog.date) | @ 4 days     | Fri Dec 31 16:00:00 1999 PST |               |                 | t
 (1 row)
 
 DROP MATERIALIZED VIEW cagg_4_hours_date_origin;
-NOTICE:  drop cascades to table _timescaledb_internal._hyper_20_24_chunk
+NOTICE:  drop cascades to table _timescaledb_internal._hyper_23_27_chunk
 CREATE MATERIALIZED VIEW cagg_4_hours_date_origin2
   WITH (timescaledb.continuous, timescaledb.materialized_only = false) AS
   SELECT time_bucket('4 days', time, origin=>'2000-01-01'::date), max(value)
     FROM temperature_date
     GROUP BY 1 ORDER BY 1;
 NOTICE:  refreshing continuous aggregate "cagg_4_hours_date_origin2"
-SELECT * FROM _timescaledb_catalog.continuous_aggs_bucket_function ORDER BY 1 DESC LIMIT 1;
- mat_hypertable_id |                         bucket_func                          | bucket_width |        bucket_origin         | bucket_offset | bucket_timezone | bucket_fixed_width 
--------------------+--------------------------------------------------------------+--------------+------------------------------+---------------+-----------------+--------------------
-                21 | public.time_bucket(interval,pg_catalog.date,pg_catalog.date) | @ 4 days     | Fri Dec 31 16:00:00 1999 PST |               |                 | t
+SELECT * FROM caggs_info WHERE user_view_name = 'cagg_4_hours_date_origin2';
+ user_view_schema |      user_view_name       |                         bucket_func                          | bucket_width |        bucket_origin         | bucket_offset | bucket_timezone | bucket_fixed_width 
+------------------+---------------------------+--------------------------------------------------------------+--------------+------------------------------+---------------+-----------------+--------------------
+ public           | cagg_4_hours_date_origin2 | public.time_bucket(interval,pg_catalog.date,pg_catalog.date) | @ 4 days     | Fri Dec 31 16:00:00 1999 PST |               |                 | t
 (1 row)
 
 DROP MATERIALIZED VIEW cagg_4_hours_date_origin2;
-NOTICE:  drop cascades to table _timescaledb_internal._hyper_21_25_chunk
+NOTICE:  drop cascades to table _timescaledb_internal._hyper_24_28_chunk
 CREATE MATERIALIZED VIEW cagg_4_hours_date_offset
   WITH (timescaledb.continuous, timescaledb.materialized_only = false) AS
   SELECT time_bucket('4 days', time, "offset"=>'30m'::interval), max(value)
     FROM temperature_date
     GROUP BY 1 ORDER BY 1;
 NOTICE:  refreshing continuous aggregate "cagg_4_hours_date_offset"
-SELECT * FROM _timescaledb_catalog.continuous_aggs_bucket_function ORDER BY 1 DESC LIMIT 1;
- mat_hypertable_id |                      bucket_func                      | bucket_width | bucket_origin | bucket_offset | bucket_timezone | bucket_fixed_width 
--------------------+-------------------------------------------------------+--------------+---------------+---------------+-----------------+--------------------
-                22 | public.time_bucket(interval,pg_catalog.date,interval) | @ 4 days     |               | @ 30 mins     |                 | t
+SELECT * FROM caggs_info WHERE user_view_name = 'cagg_4_hours_date_offset';
+ user_view_schema |      user_view_name      |                      bucket_func                      | bucket_width | bucket_origin | bucket_offset | bucket_timezone | bucket_fixed_width 
+------------------+--------------------------+-------------------------------------------------------+--------------+---------------+---------------+-----------------+--------------------
+ public           | cagg_4_hours_date_offset | public.time_bucket(interval,pg_catalog.date,interval) | @ 4 days     |               | @ 30 mins     |                 | t
 (1 row)
 
 DROP MATERIALIZED VIEW cagg_4_hours_date_offset;
-NOTICE:  drop cascades to table _timescaledb_internal._hyper_22_26_chunk
+NOTICE:  drop cascades to table _timescaledb_internal._hyper_25_29_chunk
 -- Integer based CAggs
 CREATE MATERIALIZED VIEW cagg_smallint
     WITH (timescaledb.continuous, timescaledb.materialized_only=true)
@@ -1045,65 +1052,65 @@ CREATE MATERIALIZED VIEW cagg_smallint
         FROM table_smallint
         GROUP BY 1;
 NOTICE:  refreshing continuous aggregate "cagg_smallint"
-SELECT * FROM _timescaledb_catalog.continuous_aggs_bucket_function ORDER BY 1 DESC LIMIT 1;
- mat_hypertable_id |              bucket_func              | bucket_width | bucket_origin | bucket_offset | bucket_timezone | bucket_fixed_width 
--------------------+---------------------------------------+--------------+---------------+---------------+-----------------+--------------------
-                23 | public.time_bucket(smallint,smallint) | 2            |               |               |                 | t
+SELECT * FROM caggs_info WHERE user_view_name = 'cagg_smallint';
+ user_view_schema | user_view_name |              bucket_func              | bucket_width | bucket_origin | bucket_offset | bucket_timezone | bucket_fixed_width 
+------------------+----------------+---------------------------------------+--------------+---------------+---------------+-----------------+--------------------
+ public           | cagg_smallint  | public.time_bucket(smallint,smallint) | 2            |               |               |                 | t
 (1 row)
 
 DROP MATERIALIZED VIEW cagg_smallint;
-NOTICE:  drop cascades to table _timescaledb_internal._hyper_23_27_chunk
+NOTICE:  drop cascades to table _timescaledb_internal._hyper_26_30_chunk
 CREATE MATERIALIZED VIEW cagg_smallint_offset
     WITH (timescaledb.continuous, timescaledb.materialized_only=true)
     AS SELECT time_bucket('2', time, "offset"=>1::smallint), SUM(data) as value
         FROM table_smallint
         GROUP BY 1;
 NOTICE:  refreshing continuous aggregate "cagg_smallint_offset"
-SELECT * FROM _timescaledb_catalog.continuous_aggs_bucket_function ORDER BY 1 DESC LIMIT 1;
- mat_hypertable_id |                  bucket_func                   | bucket_width | bucket_origin | bucket_offset | bucket_timezone | bucket_fixed_width 
--------------------+------------------------------------------------+--------------+---------------+---------------+-----------------+--------------------
-                24 | public.time_bucket(smallint,smallint,smallint) | 2            |               | 1             |                 | t
+SELECT * FROM caggs_info WHERE user_view_name = 'cagg_smallint_offset';
+ user_view_schema |    user_view_name    |                  bucket_func                   | bucket_width | bucket_origin | bucket_offset | bucket_timezone | bucket_fixed_width 
+------------------+----------------------+------------------------------------------------+--------------+---------------+---------------+-----------------+--------------------
+ public           | cagg_smallint_offset | public.time_bucket(smallint,smallint,smallint) | 2            |               | 1             |                 | t
 (1 row)
 
 DROP MATERIALIZED VIEW cagg_smallint_offset;
-NOTICE:  drop cascades to table _timescaledb_internal._hyper_24_28_chunk
+NOTICE:  drop cascades to table _timescaledb_internal._hyper_27_31_chunk
 CREATE MATERIALIZED VIEW cagg_int
     WITH (timescaledb.continuous, timescaledb.materialized_only=true)
     AS SELECT time_bucket('2', time), SUM(data) as value
         FROM table_int
         GROUP BY 1;
 NOTICE:  refreshing continuous aggregate "cagg_int"
-SELECT * FROM _timescaledb_catalog.continuous_aggs_bucket_function ORDER BY 1 DESC LIMIT 1;
- mat_hypertable_id |             bucket_func             | bucket_width | bucket_origin | bucket_offset | bucket_timezone | bucket_fixed_width 
--------------------+-------------------------------------+--------------+---------------+---------------+-----------------+--------------------
-                25 | public.time_bucket(integer,integer) | 2            |               |               |                 | t
+SELECT * FROM caggs_info WHERE user_view_name = 'cagg_int';
+ user_view_schema | user_view_name |             bucket_func             | bucket_width | bucket_origin | bucket_offset | bucket_timezone | bucket_fixed_width 
+------------------+----------------+-------------------------------------+--------------+---------------+---------------+-----------------+--------------------
+ public           | cagg_int       | public.time_bucket(integer,integer) | 2            |               |               |                 | t
 (1 row)
 
 DROP MATERIALIZED VIEW cagg_int;
-NOTICE:  drop cascades to table _timescaledb_internal._hyper_25_29_chunk
+NOTICE:  drop cascades to table _timescaledb_internal._hyper_28_32_chunk
 CREATE MATERIALIZED VIEW cagg_int_offset
     WITH (timescaledb.continuous, timescaledb.materialized_only=true)
     AS SELECT time_bucket('2', time, "offset"=>1::int), SUM(data) as value
         FROM table_int
         GROUP BY 1;
 NOTICE:  refreshing continuous aggregate "cagg_int_offset"
-SELECT * FROM _timescaledb_catalog.continuous_aggs_bucket_function ORDER BY 1 DESC LIMIT 1;
- mat_hypertable_id |                 bucket_func                 | bucket_width | bucket_origin | bucket_offset | bucket_timezone | bucket_fixed_width 
--------------------+---------------------------------------------+--------------+---------------+---------------+-----------------+--------------------
-                26 | public.time_bucket(integer,integer,integer) | 2            |               | 1             |                 | t
+SELECT * FROM caggs_info WHERE user_view_name = 'cagg_int_offset';
+ user_view_schema | user_view_name  |                 bucket_func                 | bucket_width | bucket_origin | bucket_offset | bucket_timezone | bucket_fixed_width 
+------------------+-----------------+---------------------------------------------+--------------+---------------+---------------+-----------------+--------------------
+ public           | cagg_int_offset | public.time_bucket(integer,integer,integer) | 2            |               | 1             |                 | t
 (1 row)
 
 DROP MATERIALIZED VIEW cagg_int_offset;
-NOTICE:  drop cascades to table _timescaledb_internal._hyper_26_30_chunk
+NOTICE:  drop cascades to table _timescaledb_internal._hyper_29_33_chunk
 CREATE MATERIALIZED VIEW cagg_bigint
     WITH (timescaledb.continuous, timescaledb.materialized_only=true)
     AS SELECT time_bucket('2', time), SUM(data) as value
         FROM table_bigint
         GROUP BY 1 WITH NO DATA;
-SELECT * FROM _timescaledb_catalog.continuous_aggs_bucket_function ORDER BY 1 DESC LIMIT 1;
- mat_hypertable_id |            bucket_func            | bucket_width | bucket_origin | bucket_offset | bucket_timezone | bucket_fixed_width 
--------------------+-----------------------------------+--------------+---------------+---------------+-----------------+--------------------
-                27 | public.time_bucket(bigint,bigint) | 2            |               |               |                 | t
+SELECT * FROM caggs_info WHERE user_view_name = 'cagg_bigint';
+ user_view_schema | user_view_name |            bucket_func            | bucket_width | bucket_origin | bucket_offset | bucket_timezone | bucket_fixed_width 
+------------------+----------------+-----------------------------------+--------------+---------------+---------------+-----------------+--------------------
+ public           | cagg_bigint    | public.time_bucket(bigint,bigint) | 2            |               |               |                 | t
 (1 row)
 
 DROP MATERIALIZED VIEW cagg_bigint;
@@ -1112,10 +1119,10 @@ CREATE MATERIALIZED VIEW cagg_bigint_offset
     AS SELECT time_bucket('2', time, "offset"=>1::bigint), SUM(data) as value
         FROM table_bigint
         GROUP BY 1 WITH NO DATA;
-SELECT * FROM _timescaledb_catalog.continuous_aggs_bucket_function ORDER BY 1 DESC LIMIT 1;
- mat_hypertable_id |               bucket_func                | bucket_width | bucket_origin | bucket_offset | bucket_timezone | bucket_fixed_width 
--------------------+------------------------------------------+--------------+---------------+---------------+-----------------+--------------------
-                28 | public.time_bucket(bigint,bigint,bigint) | 2            |               | 1             |                 | t
+SELECT * FROM caggs_info WHERE user_view_name = 'cagg_bigint_offset';
+ user_view_schema |   user_view_name   |               bucket_func                | bucket_width | bucket_origin | bucket_offset | bucket_timezone | bucket_fixed_width 
+------------------+--------------------+------------------------------------------+--------------+---------------+---------------+-----------------+--------------------
+ public           | cagg_bigint_offset | public.time_bucket(bigint,bigint,bigint) | 2            |               | 1             |                 | t
 (1 row)
 
 DROP MATERIALIZED VIEW cagg_bigint_offset;
@@ -1125,10 +1132,10 @@ CREATE MATERIALIZED VIEW cagg_bigint_offset2
     AS SELECT time_bucket('2', time, 1::bigint), SUM(data) as value
         FROM table_bigint
         GROUP BY 1 WITH NO DATA;
-SELECT * FROM _timescaledb_catalog.continuous_aggs_bucket_function ORDER BY 1 DESC LIMIT 1;
- mat_hypertable_id |               bucket_func                | bucket_width | bucket_origin | bucket_offset | bucket_timezone | bucket_fixed_width 
--------------------+------------------------------------------+--------------+---------------+---------------+-----------------+--------------------
-                29 | public.time_bucket(bigint,bigint,bigint) | 2            |               | 1             |                 | t
+SELECT * FROM caggs_info WHERE user_view_name = 'cagg_bigint_offset2';
+ user_view_schema |   user_view_name    |               bucket_func                | bucket_width | bucket_origin | bucket_offset | bucket_timezone | bucket_fixed_width 
+------------------+---------------------+------------------------------------------+--------------+---------------+---------------+-----------------+--------------------
+ public           | cagg_bigint_offset2 | public.time_bucket(bigint,bigint,bigint) | 2            |               | 1             |                 | t
 (1 row)
 
 -- mess with the bucket_func signature to make sure it will raise an exception
@@ -1425,18 +1432,17 @@ ALTER MATERIALIZED VIEW cagg_4_hours SET (timescaledb.materialized_only=false);
 ALTER MATERIALIZED VIEW cagg_4_hours_offset SET (timescaledb.materialized_only=false);
 ALTER MATERIALIZED VIEW cagg_4_hours_origin SET (timescaledb.materialized_only=false);
 -- Check watermarks
-SELECT continuous_aggs_watermark.*, _timescaledb_functions.to_timestamp(watermark)
+SELECT continuous_agg.user_view_name, continuous_aggs_watermark.watermark, _timescaledb_functions.to_timestamp(watermark)
   FROM _timescaledb_catalog.continuous_aggs_watermark
   JOIN _timescaledb_catalog.continuous_agg USING (mat_hypertable_id)
-WHERE user_view_name LIKE 'cagg_4_hours%' ORDER BY mat_hypertable_id, watermark;
- mat_hypertable_id |    watermark     |         to_timestamp         
--------------------+------------------+------------------------------
-                15 |  946699200000000 | Fri Dec 31 20:00:00 1999 PST
-                17 |  946702800000000 | Fri Dec 31 21:00:00 1999 PST
-                30 | 1577952000000000 | Thu Jan 02 00:00:00 2020 PST
-                31 | 1577953800000000 | Thu Jan 02 00:30:00 2020 PST
-                32 | 1577955600000000 | Thu Jan 02 01:00:00 2020 PST
-(5 rows)
+WHERE user_view_name LIKE 'cagg_4_hours%'
+ORDER BY mat_hypertable_id, watermark;
+   user_view_name    |    watermark     |         to_timestamp         
+---------------------+------------------+------------------------------
+ cagg_4_hours        | 1577952000000000 | Thu Jan 02 00:00:00 2020 PST
+ cagg_4_hours_offset | 1577953800000000 | Thu Jan 02 00:30:00 2020 PST
+ cagg_4_hours_origin | 1577955600000000 | Thu Jan 02 01:00:00 2020 PST
+(3 rows)
 
 -- Insert new data
 INSERT INTO temperature values('2020-01-02 00:10:00 PST', 2222);
@@ -1510,20 +1516,20 @@ SET client_min_messages TO DEBUG1;
 CALL refresh_continuous_aggregate('cagg_4_hours', NULL, NULL);
 LOG:  statement: CALL refresh_continuous_aggregate('cagg_4_hours', NULL, NULL);
 DEBUG:  continuous aggregate refresh (individual invalidation) on "cagg_4_hours" in window [ Thu Jan 02 00:00:00 2020 PST, Thu Jan 02 12:00:00 2020 PST ]
-LOG:  deleted 0 row(s) from materialization table "_timescaledb_internal._materialized_hypertable_30"
-LOG:  inserted 3 row(s) into materialization table "_timescaledb_internal._materialized_hypertable_30"
+LOG:  deleted 0 row(s) from materialization table "_timescaledb_internal._materialized_hypertable_33"
+LOG:  inserted 3 row(s) into materialization table "_timescaledb_internal._materialized_hypertable_33"
 CALL refresh_continuous_aggregate('cagg_4_hours_offset', NULL, NULL);
 LOG:  statement: CALL refresh_continuous_aggregate('cagg_4_hours_offset', NULL, NULL);
 DEBUG:  hypertable 4 existing watermark >= new invalidation threshold 1577995200000000 1577995200000000
 DEBUG:  continuous aggregate refresh (individual invalidation) on "cagg_4_hours_offset" in window [ Wed Jan 01 20:30:00 2020 PST, Thu Jan 02 12:30:00 2020 PST ]
-LOG:  deleted 1 row(s) from materialization table "_timescaledb_internal._materialized_hypertable_31"
-LOG:  inserted 3 row(s) into materialization table "_timescaledb_internal._materialized_hypertable_31"
+LOG:  deleted 1 row(s) from materialization table "_timescaledb_internal._materialized_hypertable_34"
+LOG:  inserted 3 row(s) into materialization table "_timescaledb_internal._materialized_hypertable_34"
 CALL refresh_continuous_aggregate('cagg_4_hours_origin', NULL, NULL);
 LOG:  statement: CALL refresh_continuous_aggregate('cagg_4_hours_origin', NULL, NULL);
 DEBUG:  hypertable 4 existing watermark >= new invalidation threshold 1577995200000000 1577995200000000
 DEBUG:  continuous aggregate refresh (individual invalidation) on "cagg_4_hours_origin" in window [ Wed Jan 01 21:00:00 2020 PST, Thu Jan 02 13:00:00 2020 PST ]
-LOG:  deleted 1 row(s) from materialization table "_timescaledb_internal._materialized_hypertable_32"
-LOG:  inserted 3 row(s) into materialization table "_timescaledb_internal._materialized_hypertable_32"
+LOG:  deleted 1 row(s) from materialization table "_timescaledb_internal._materialized_hypertable_35"
+LOG:  inserted 3 row(s) into materialization table "_timescaledb_internal._materialized_hypertable_35"
 RESET client_min_messages;
 LOG:  statement: RESET client_min_messages;
 -- Query the CAggs and check that all buckets are materialized
@@ -1731,35 +1737,35 @@ CALL refresh_continuous_aggregate('cagg_4_hours', NULL, NULL);
 LOG:  statement: CALL refresh_continuous_aggregate('cagg_4_hours', NULL, NULL);
 DEBUG:  hypertable 4 existing watermark >= new invalidation threshold 1577995200000000 1577952000000000
 DEBUG:  continuous aggregate refresh (individual invalidation) on "cagg_4_hours" in window [ Sat Jan 01 00:00:00 2000 PST, Sun Jan 02 00:00:00 2000 PST ]
-LOG:  deleted 0 row(s) from materialization table "_timescaledb_internal._materialized_hypertable_30"
-LOG:  inserted 6 row(s) into materialization table "_timescaledb_internal._materialized_hypertable_30"
-DEBUG:  hypertable 30 existing watermark >= new watermark 1577995200000000 946800000000000
+LOG:  deleted 0 row(s) from materialization table "_timescaledb_internal._materialized_hypertable_33"
+LOG:  inserted 6 row(s) into materialization table "_timescaledb_internal._materialized_hypertable_33"
+DEBUG:  hypertable 33 existing watermark >= new watermark 1577995200000000 946800000000000
 DEBUG:  continuous aggregate refresh (individual invalidation) on "cagg_4_hours" in window [ Wed Jan 01 00:00:00 2020 PST, Thu Jan 02 00:00:00 2020 PST ]
-LOG:  deleted 0 row(s) from materialization table "_timescaledb_internal._materialized_hypertable_30"
-LOG:  inserted 6 row(s) into materialization table "_timescaledb_internal._materialized_hypertable_30"
-DEBUG:  hypertable 30 existing watermark >= new watermark 1577995200000000 1577952000000000
+LOG:  deleted 0 row(s) from materialization table "_timescaledb_internal._materialized_hypertable_33"
+LOG:  inserted 6 row(s) into materialization table "_timescaledb_internal._materialized_hypertable_33"
+DEBUG:  hypertable 33 existing watermark >= new watermark 1577995200000000 1577952000000000
 CALL refresh_continuous_aggregate('cagg_4_hours_offset', NULL, NULL);
 LOG:  statement: CALL refresh_continuous_aggregate('cagg_4_hours_offset', NULL, NULL);
 DEBUG:  hypertable 4 existing watermark >= new invalidation threshold 1577995200000000 1577952000000000
 DEBUG:  continuous aggregate refresh (individual invalidation) on "cagg_4_hours_offset" in window [ Fri Dec 31 20:30:00 1999 PST, Sun Jan 02 00:30:00 2000 PST ]
-LOG:  deleted 0 row(s) from materialization table "_timescaledb_internal._materialized_hypertable_31"
-LOG:  inserted 6 row(s) into materialization table "_timescaledb_internal._materialized_hypertable_31"
-DEBUG:  hypertable 31 existing watermark >= new watermark 1577997000000000 946801800000000
+LOG:  deleted 0 row(s) from materialization table "_timescaledb_internal._materialized_hypertable_34"
+LOG:  inserted 6 row(s) into materialization table "_timescaledb_internal._materialized_hypertable_34"
+DEBUG:  hypertable 34 existing watermark >= new watermark 1577997000000000 946801800000000
 DEBUG:  continuous aggregate refresh (individual invalidation) on "cagg_4_hours_offset" in window [ Tue Dec 31 20:30:00 2019 PST, Thu Jan 02 00:30:00 2020 PST ]
-LOG:  deleted 0 row(s) from materialization table "_timescaledb_internal._materialized_hypertable_31"
-LOG:  inserted 7 row(s) into materialization table "_timescaledb_internal._materialized_hypertable_31"
-DEBUG:  hypertable 31 existing watermark >= new watermark 1577997000000000 1577953800000000
+LOG:  deleted 0 row(s) from materialization table "_timescaledb_internal._materialized_hypertable_34"
+LOG:  inserted 7 row(s) into materialization table "_timescaledb_internal._materialized_hypertable_34"
+DEBUG:  hypertable 34 existing watermark >= new watermark 1577997000000000 1577953800000000
 CALL refresh_continuous_aggregate('cagg_4_hours_origin', NULL, NULL);
 LOG:  statement: CALL refresh_continuous_aggregate('cagg_4_hours_origin', NULL, NULL);
 DEBUG:  hypertable 4 existing watermark >= new invalidation threshold 1577995200000000 1577952000000000
 DEBUG:  continuous aggregate refresh (individual invalidation) on "cagg_4_hours_origin" in window [ Fri Dec 31 21:00:00 1999 PST, Sun Jan 02 01:00:00 2000 PST ]
-LOG:  deleted 0 row(s) from materialization table "_timescaledb_internal._materialized_hypertable_32"
-LOG:  inserted 6 row(s) into materialization table "_timescaledb_internal._materialized_hypertable_32"
-DEBUG:  hypertable 32 existing watermark >= new watermark 1577998800000000 946803600000000
+LOG:  deleted 0 row(s) from materialization table "_timescaledb_internal._materialized_hypertable_35"
+LOG:  inserted 6 row(s) into materialization table "_timescaledb_internal._materialized_hypertable_35"
+DEBUG:  hypertable 35 existing watermark >= new watermark 1577998800000000 946803600000000
 DEBUG:  continuous aggregate refresh (individual invalidation) on "cagg_4_hours_origin" in window [ Tue Dec 31 21:00:00 2019 PST, Thu Jan 02 01:00:00 2020 PST ]
-LOG:  deleted 0 row(s) from materialization table "_timescaledb_internal._materialized_hypertable_32"
-LOG:  inserted 7 row(s) into materialization table "_timescaledb_internal._materialized_hypertable_32"
-DEBUG:  hypertable 32 existing watermark >= new watermark 1577998800000000 1577955600000000
+LOG:  deleted 0 row(s) from materialization table "_timescaledb_internal._materialized_hypertable_35"
+LOG:  inserted 7 row(s) into materialization table "_timescaledb_internal._materialized_hypertable_35"
+DEBUG:  hypertable 35 existing watermark >= new watermark 1577998800000000 1577955600000000
 RESET client_min_messages;
 LOG:  statement: RESET client_min_messages;
 ALTER MATERIALIZED VIEW cagg_4_hours SET (timescaledb.materialized_only=true);
@@ -1944,17 +1950,13 @@ SELECT * FROM _timescaledb_catalog.continuous_aggs_materialization_invalidation_
                   2 |      1541289600000000 |     9223372036854775807
                   3 |  -9223372036854775808 |     -210866803200000001
                   3 |      1541289600000000 |     9223372036854775807
-                 15 |  -9223372036854775808 |     -210866803200000001
-                 15 |       946699200000000 |     9223372036854775807
-                 17 |  -9223372036854775808 |     -210866803200000001
-                 17 |       946699200000000 |     9223372036854775807
-                 30 |  -9223372036854775808 |     -210866803200000001
-                 30 |      1577995200000000 |     9223372036854775807
-                 31 |  -9223372036854775808 |     -210866803200000001
-                 31 |      1577995200000000 |     9223372036854775807
-                 32 |  -9223372036854775808 |     -210866803200000001
-                 32 |      1577995200000000 |     9223372036854775807
-(14 rows)
+                 33 |  -9223372036854775808 |     -210866803200000001
+                 33 |      1577995200000000 |     9223372036854775807
+                 34 |  -9223372036854775808 |     -210866803200000001
+                 34 |      1577995200000000 |     9223372036854775807
+                 35 |  -9223372036854775808 |     -210866803200000001
+                 35 |      1577995200000000 |     9223372036854775807
+(10 rows)
 
 CREATE MATERIALIZED VIEW cagg_1_year
   WITH (timescaledb.continuous, timescaledb.materialized_only = false) AS
@@ -1969,21 +1971,17 @@ SELECT * FROM _timescaledb_catalog.continuous_aggs_materialization_invalidation_
                   2 |      1541289600000000 |     9223372036854775807
                   3 |  -9223372036854775808 |     -210866803200000001
                   3 |      1541289600000000 |     9223372036854775807
-                 15 |  -9223372036854775808 |     -210866803200000001
-                 15 |       946699200000000 |     9223372036854775807
-                 17 |  -9223372036854775808 |     -210866803200000001
-                 17 |       946699200000000 |     9223372036854775807
-                 30 |  -9223372036854775808 |     -210866803200000001
-                 30 |  -9223372036854775808 |     9223372036854775807
-                 30 |      1577995200000000 |     9223372036854775807
-                 31 |  -9223372036854775808 |     -210866803200000001
-                 31 |  -9223372036854775808 |     9223372036854775807
-                 31 |      1577995200000000 |     9223372036854775807
-                 32 |  -9223372036854775808 |     -210866803200000001
-                 32 |  -9223372036854775808 |     9223372036854775807
-                 32 |      1577995200000000 |     9223372036854775807
-                 33 |      1609459200000000 |     9223372036854775807
-(18 rows)
+                 33 |  -9223372036854775808 |     -210866803200000001
+                 33 |  -9223372036854775808 |     9223372036854775807
+                 33 |      1577995200000000 |     9223372036854775807
+                 34 |  -9223372036854775808 |     -210866803200000001
+                 34 |  -9223372036854775808 |     9223372036854775807
+                 34 |      1577995200000000 |     9223372036854775807
+                 35 |  -9223372036854775808 |     -210866803200000001
+                 35 |  -9223372036854775808 |     9223372036854775807
+                 35 |      1577995200000000 |     9223372036854775807
+                 36 |      1609459200000000 |     9223372036854775807
+(14 rows)
 
 ---
 -- Tests with integer based hypertables
@@ -2220,10 +2218,10 @@ SET client_min_messages TO DEBUG1;
 CALL refresh_continuous_aggregate('cagg_int_offset', 110, 130);
 LOG:  statement: CALL refresh_continuous_aggregate('cagg_int_offset', 110, 130);
 DEBUG:  continuous aggregate refresh (individual invalidation) on "cagg_int_offset" in window [ 105, 135 ]
-LOG:  deleted 0 row(s) from materialization table "_timescaledb_internal._materialized_hypertable_35"
-DEBUG:  building index "_hyper_35_64_chunk__materialized_hypertable_35_time_bucket_idx" on table "_hyper_35_64_chunk" serially
-DEBUG:  index "_hyper_35_64_chunk__materialized_hypertable_35_time_bucket_idx" can safely use deduplication
-LOG:  inserted 1 row(s) into materialization table "_timescaledb_internal._materialized_hypertable_35"
+LOG:  deleted 0 row(s) from materialization table "_timescaledb_internal._materialized_hypertable_38"
+DEBUG:  building index "_hyper_38_67_chunk__materialized_hypertable_38_time_bucket_idx" on table "_hyper_38_67_chunk" serially
+DEBUG:  index "_hyper_38_67_chunk__materialized_hypertable_38_time_bucket_idx" can safely use deduplication
+LOG:  inserted 1 row(s) into materialization table "_timescaledb_internal._materialized_hypertable_38"
 RESET client_min_messages;
 LOG:  statement: RESET client_min_messages;
 SELECT * FROM cagg_int_offset;
@@ -2262,33 +2260,57 @@ SELECT time_bucket('10', time, "offset"=>5), SUM(data) FROM table_int GROUP BY 1
          105 |   0
 (13 rows)
 
----
--- Test with blocking a few broken configurations
----
-\set ON_ERROR_STOP 0
--- Unfortunately '\set VERBOSITY verbose' cannot be used here to check the error details
--- since it also prints the line number of the location, which is depended on the build
--- Variable sized buckets with origin are known to work incorrect. So, block usage for now.
+-- Variable sized buckets with origin
 CREATE MATERIALIZED VIEW cagg_1_hour_variable_bucket_fixed_origin
   WITH (timescaledb.continuous) AS
   SELECT time_bucket('1 year', time, origin=>'2000-01-01 01:05:00 UTC'::timestamptz, timezone=>'UTC') AS hour_bucket, max(value) AS max_value
     FROM temperature
     GROUP BY 1 ORDER BY 1;
-ERROR:  cannot create continuous aggregate with variable-width bucket using offset or origin.
+NOTICE:  refreshing continuous aggregate "cagg_1_hour_variable_bucket_fixed_origin"
+SELECT * FROM caggs_info WHERE user_view_name = 'cagg_1_hour_variable_bucket_fixed_origin';
+ user_view_schema |              user_view_name              |                                               bucket_func                                               | bucket_width |        bucket_origin         | bucket_offset | bucket_timezone | bucket_fixed_width 
+------------------+------------------------------------------+---------------------------------------------------------------------------------------------------------+--------------+------------------------------+---------------+-----------------+--------------------
+ public           | cagg_1_hour_variable_bucket_fixed_origin | public.time_bucket(interval,timestamp with time zone,pg_catalog.text,timestamp with time zone,interval) | @ 1 year     | Fri Dec 31 17:05:00 1999 PST |               | UTC             | f
+(1 row)
+
+DROP MATERIALIZED VIEW cagg_1_hour_variable_bucket_fixed_origin;
+NOTICE:  drop cascades to 2 other objects
 -- Variable due to the used timezone
 CREATE MATERIALIZED VIEW cagg_1_hour_variable_bucket_fixed_origin2
   WITH (timescaledb.continuous) AS
   SELECT time_bucket('1 hour', time, origin=>'2000-01-01 01:05:00 UTC'::timestamptz, timezone=>'UTC') AS hour_bucket, max(value) AS max_value
     FROM temperature
     GROUP BY 1 ORDER BY 1;
-ERROR:  cannot create continuous aggregate with variable-width bucket using offset or origin.
+NOTICE:  refreshing continuous aggregate "cagg_1_hour_variable_bucket_fixed_origin2"
+SELECT * FROM caggs_info WHERE user_view_name = 'cagg_1_hour_variable_bucket_fixed_origin2';
+ user_view_schema |              user_view_name               |                                               bucket_func                                               | bucket_width |        bucket_origin         | bucket_offset | bucket_timezone | bucket_fixed_width 
+------------------+-------------------------------------------+---------------------------------------------------------------------------------------------------------+--------------+------------------------------+---------------+-----------------+--------------------
+ public           | cagg_1_hour_variable_bucket_fixed_origin2 | public.time_bucket(interval,timestamp with time zone,pg_catalog.text,timestamp with time zone,interval) | @ 1 hour     | Fri Dec 31 17:05:00 1999 PST |               | UTC             | f
+(1 row)
+
+DROP MATERIALIZED VIEW cagg_1_hour_variable_bucket_fixed_origin2;
+NOTICE:  drop cascades to 2 other objects
 -- Variable with offset
 CREATE MATERIALIZED VIEW cagg_1_hour_variable_bucket_fixed_origin3
   WITH (timescaledb.continuous) AS
   SELECT time_bucket('1 year', time, "offset"=>'5 minutes'::interval) AS hour_bucket, max(value) AS max_value
     FROM temperature
     GROUP BY 1 ORDER BY 1;
-ERROR:  cannot create continuous aggregate with variable-width bucket using offset or origin.
+NOTICE:  refreshing continuous aggregate "cagg_1_hour_variable_bucket_fixed_origin3"
+SELECT * FROM caggs_info WHERE user_view_name = 'cagg_1_hour_variable_bucket_fixed_origin3';
+ user_view_schema |              user_view_name               |                          bucket_func                           | bucket_width | bucket_origin | bucket_offset | bucket_timezone | bucket_fixed_width 
+------------------+-------------------------------------------+----------------------------------------------------------------+--------------+---------------+---------------+-----------------+--------------------
+ public           | cagg_1_hour_variable_bucket_fixed_origin3 | public.time_bucket(interval,timestamp with time zone,interval) | @ 1 year     |               | @ 5 mins      |                 | f
+(1 row)
+
+DROP MATERIALIZED VIEW cagg_1_hour_variable_bucket_fixed_origin3;
+NOTICE:  drop cascades to 2 other objects
+---
+-- Test with blocking a few broken configurations
+---
+\set ON_ERROR_STOP 0
+-- Unfortunately '\set VERBOSITY verbose' cannot be used here to check the error details
+-- since it also prints the line number of the location, which is depended on the build
 -- Different time origin
 CREATE MATERIALIZED VIEW cagg_1_hour_origin
   WITH (timescaledb.continuous) AS
@@ -2344,12 +2366,24 @@ CREATE MATERIALIZED VIEW cagg_1_hour_offset
     FROM temperature
     GROUP BY 1 ORDER BY 1;
 NOTICE:  refreshing continuous aggregate "cagg_1_hour_offset"
+SELECT * FROM caggs_info WHERE user_view_name = 'cagg_1_hour_offset';
+ user_view_schema |   user_view_name   |                                  bucket_func                                   | bucket_width |        bucket_origin         | bucket_offset | bucket_timezone | bucket_fixed_width 
+------------------+--------------------+--------------------------------------------------------------------------------+--------------+------------------------------+---------------+-----------------+--------------------
+ public           | cagg_1_hour_offset | public.time_bucket(interval,timestamp with time zone,timestamp with time zone) | @ 1 hour     | Sun Jan 02 01:00:00 2000 PST |               |                 | t
+(1 row)
+
 CREATE MATERIALIZED VIEW cagg_1_week_offset
   WITH (timescaledb.continuous) AS
   SELECT time_bucket('1 week', hour_bucket, origin=>'2000-01-02 01:00:00 PST'::timestamptz) AS week_bucket, max(max_value) AS max_value
     FROM cagg_1_hour_offset
     GROUP BY 1 ORDER BY 1;
 NOTICE:  refreshing continuous aggregate "cagg_1_week_offset"
+SELECT * FROM caggs_info WHERE user_view_name = 'cagg_1_week_offset';
+ user_view_schema |   user_view_name   |                                  bucket_func                                   | bucket_width |        bucket_origin         | bucket_offset | bucket_timezone | bucket_fixed_width 
+------------------+--------------------+--------------------------------------------------------------------------------+--------------+------------------------------+---------------+-----------------+--------------------
+ public           | cagg_1_week_offset | public.time_bucket(interval,timestamp with time zone,timestamp with time zone) | @ 7 days     | Sun Jan 02 01:00:00 2000 PST |               |                 | t
+(1 row)
+
 -- Compare output
 SELECT * FROM cagg_1_week_offset;
          week_bucket          | max_value 
@@ -2422,3 +2456,4 @@ SELECT time_bucket('1 week', time, origin=>'2000-01-02 01:00:00 PST'::timestampt
 -------------+-----
 (0 rows)
 
+DROP VIEW caggs_info;

--- a/tsl/test/expected/cagg_usage-13.out
+++ b/tsl/test/expected/cagg_usage-13.out
@@ -444,10 +444,12 @@ SELECT current_setting('timezone');
 
 -- should be blocked because non-immutable expression
 \set ON_ERROR_STOP 0
-CREATE MATERIALIZED VIEW cagg1 WITH (timescaledb.continuous,timescaledb.materialized_only=true) AS SELECT time_bucket('1 day', time, current_setting('timezone')) FROM metrics GROUP BY 1;
+CREATE MATERIALIZED VIEW cagg1 WITH (timescaledb.continuous,timescaledb.materialized_only=true) AS
+SELECT time_bucket('1 day', time, current_setting('timezone')) FROM metrics GROUP BY 1;
 ERROR:  only immutable expressions allowed in time bucket function
 \set ON_ERROR_STOP 1
-CREATE MATERIALIZED VIEW cagg1 WITH (timescaledb.continuous,timescaledb.materialized_only=true) AS SELECT time_bucket('1 day', time, 'PST8PDT') FROM metrics GROUP BY 1;
+CREATE MATERIALIZED VIEW cagg1 WITH (timescaledb.continuous,timescaledb.materialized_only=true) AS
+SELECT time_bucket('1 day', time, 'PST8PDT') FROM metrics GROUP BY 1;
 NOTICE:  refreshing continuous aggregate "cagg1"
 SELECT * FROM cagg1;
          time_bucket          
@@ -458,7 +460,8 @@ SELECT * FROM cagg1;
  Tue Jan 25 00:00:00 2000 PST
 (4 rows)
 
-CREATE MATERIALIZED VIEW cagg2 WITH (timescaledb.continuous,timescaledb.materialized_only=true) AS SELECT time_bucket('1 month', time, 'PST8PDT') FROM metrics GROUP BY 1;
+CREATE MATERIALIZED VIEW cagg2 WITH (timescaledb.continuous,timescaledb.materialized_only=true) AS
+SELECT time_bucket('1 month', time, 'PST8PDT') FROM metrics GROUP BY 1;
 NOTICE:  refreshing continuous aggregate "cagg2"
 SELECT * FROM cagg2;
          time_bucket          
@@ -467,14 +470,28 @@ SELECT * FROM cagg2;
  Sat Jan 01 00:00:00 2000 PST
 (2 rows)
 
--- custom origin - not supported due to variable size
-\set ON_ERROR_STOP 0
-CREATE MATERIALIZED VIEW cagg3 WITH (timescaledb.continuous,timescaledb.materialized_only=true) AS SELECT time_bucket('1 month', time, 'PST8PDT', '2000-01-01'::timestamptz) FROM metrics GROUP BY 1;
-ERROR:  cannot create continuous aggregate with variable-width bucket using offset or origin.
--- offset - not supported due to variable size
-CREATE MATERIALIZED VIEW cagg4 WITH (timescaledb.continuous,timescaledb.materialized_only=true) AS SELECT time_bucket('1 month', time, 'PST8PDT', "offset":= INTERVAL '15 day') FROM metrics GROUP BY 1;
-ERROR:  cannot create continuous aggregate with variable-width bucket using offset or origin.
-\set ON_ERROR_STOP 1
+-- custom origin with variable size
+CREATE MATERIALIZED VIEW cagg3 WITH (timescaledb.continuous,timescaledb.materialized_only=true) AS
+SELECT time_bucket('1 month', time, 'PST8PDT', '2000-01-01'::timestamptz) FROM metrics GROUP BY 1;
+NOTICE:  refreshing continuous aggregate "cagg3"
+SELECT * FROM cagg3;
+         time_bucket          
+------------------------------
+ Wed Dec 01 00:00:00 1999 PST
+ Sat Jan 01 00:00:00 2000 PST
+(2 rows)
+
+-- offset with variable size
+CREATE MATERIALIZED VIEW cagg4 WITH (timescaledb.continuous,timescaledb.materialized_only=true) AS
+SELECT time_bucket('1 month', time, 'PST8PDT', "offset":= INTERVAL '15 day') FROM metrics GROUP BY 1;
+NOTICE:  refreshing continuous aggregate "cagg4"
+SELECT * FROM cagg4;
+         time_bucket          
+------------------------------
+ Thu Dec 16 00:00:00 1999 PST
+ Sun Jan 16 00:00:00 2000 PST
+(2 rows)
+
 --
 -- drop chunks tests
 --
@@ -494,12 +511,14 @@ ORDER BY 1;
 (4 rows)
 
 -- all caggs in the new format (finalized=true)
-SELECT user_view_name, finalized FROM _timescaledb_catalog.continuous_agg WHERE user_view_name in ('cagg1', 'cagg2', 'cagg3') ORDER BY 1;
+SELECT user_view_name, finalized FROM _timescaledb_catalog.continuous_agg WHERE user_view_name in ('cagg1', 'cagg2', 'cagg3', 'cagg4') ORDER BY 1;
  user_view_name | finalized 
 ----------------+-----------
  cagg1          | t
  cagg2          | t
-(2 rows)
+ cagg3          | t
+ cagg4          | t
+(4 rows)
 
 -- dropping chunk should also remove the catalog data
 SELECT drop_chunks('metrics', older_than => '2000-01-01 00:00:00-02'::timestamptz);
@@ -527,12 +546,14 @@ ORDER BY 1;
 UPDATE _timescaledb_catalog.continuous_agg SET finalized=FALSE WHERE user_view_name = 'cagg1';
 \c :TEST_DBNAME :ROLE_DEFAULT_PERM_USER
 -- cagg1 now is a fake old format (finalized=false)
-SELECT user_view_name, finalized FROM _timescaledb_catalog.continuous_agg WHERE user_view_name in ('cagg1', 'cagg2', 'cagg3') ORDER BY 1;
+SELECT user_view_name, finalized FROM _timescaledb_catalog.continuous_agg WHERE user_view_name in ('cagg1', 'cagg2', 'cagg3', 'cagg4') ORDER BY 1;
  user_view_name | finalized 
 ----------------+-----------
  cagg1          | f
  cagg2          | t
-(2 rows)
+ cagg3          | t
+ cagg4          | t
+(4 rows)
 
 -- cagg1 now is in the old format (finalized=false)
 -- dropping chunk should NOT remove the catalog data
@@ -560,11 +581,13 @@ ORDER BY 1;
 DROP MATERIALIZED VIEW cagg1;
 NOTICE:  drop cascades to table _timescaledb_internal._hyper_12_21_chunk
 -- no more old format caggs (finalized=false)
-SELECT user_view_name, finalized FROM _timescaledb_catalog.continuous_agg WHERE user_view_name in ('cagg1', 'cagg2', 'cagg3') ORDER BY 1;
+SELECT user_view_name, finalized FROM _timescaledb_catalog.continuous_agg WHERE user_view_name in ('cagg1', 'cagg2', 'cagg3', 'cagg4') ORDER BY 1;
  user_view_name | finalized 
 ----------------+-----------
  cagg2          | t
-(1 row)
+ cagg3          | t
+ cagg4          | t
+(3 rows)
 
 -- dropping chunk should remove the catalog data
 SELECT drop_chunks('metrics', older_than => '2000-01-25 00:00:00-02'::timestamptz);

--- a/tsl/test/expected/cagg_usage-14.out
+++ b/tsl/test/expected/cagg_usage-14.out
@@ -444,10 +444,12 @@ SELECT current_setting('timezone');
 
 -- should be blocked because non-immutable expression
 \set ON_ERROR_STOP 0
-CREATE MATERIALIZED VIEW cagg1 WITH (timescaledb.continuous,timescaledb.materialized_only=true) AS SELECT time_bucket('1 day', time, current_setting('timezone')) FROM metrics GROUP BY 1;
+CREATE MATERIALIZED VIEW cagg1 WITH (timescaledb.continuous,timescaledb.materialized_only=true) AS
+SELECT time_bucket('1 day', time, current_setting('timezone')) FROM metrics GROUP BY 1;
 ERROR:  only immutable expressions allowed in time bucket function
 \set ON_ERROR_STOP 1
-CREATE MATERIALIZED VIEW cagg1 WITH (timescaledb.continuous,timescaledb.materialized_only=true) AS SELECT time_bucket('1 day', time, 'PST8PDT') FROM metrics GROUP BY 1;
+CREATE MATERIALIZED VIEW cagg1 WITH (timescaledb.continuous,timescaledb.materialized_only=true) AS
+SELECT time_bucket('1 day', time, 'PST8PDT') FROM metrics GROUP BY 1;
 NOTICE:  refreshing continuous aggregate "cagg1"
 SELECT * FROM cagg1;
          time_bucket          
@@ -458,7 +460,8 @@ SELECT * FROM cagg1;
  Tue Jan 25 00:00:00 2000 PST
 (4 rows)
 
-CREATE MATERIALIZED VIEW cagg2 WITH (timescaledb.continuous,timescaledb.materialized_only=true) AS SELECT time_bucket('1 month', time, 'PST8PDT') FROM metrics GROUP BY 1;
+CREATE MATERIALIZED VIEW cagg2 WITH (timescaledb.continuous,timescaledb.materialized_only=true) AS
+SELECT time_bucket('1 month', time, 'PST8PDT') FROM metrics GROUP BY 1;
 NOTICE:  refreshing continuous aggregate "cagg2"
 SELECT * FROM cagg2;
          time_bucket          
@@ -467,14 +470,28 @@ SELECT * FROM cagg2;
  Sat Jan 01 00:00:00 2000 PST
 (2 rows)
 
--- custom origin - not supported due to variable size
-\set ON_ERROR_STOP 0
-CREATE MATERIALIZED VIEW cagg3 WITH (timescaledb.continuous,timescaledb.materialized_only=true) AS SELECT time_bucket('1 month', time, 'PST8PDT', '2000-01-01'::timestamptz) FROM metrics GROUP BY 1;
-ERROR:  cannot create continuous aggregate with variable-width bucket using offset or origin.
--- offset - not supported due to variable size
-CREATE MATERIALIZED VIEW cagg4 WITH (timescaledb.continuous,timescaledb.materialized_only=true) AS SELECT time_bucket('1 month', time, 'PST8PDT', "offset":= INTERVAL '15 day') FROM metrics GROUP BY 1;
-ERROR:  cannot create continuous aggregate with variable-width bucket using offset or origin.
-\set ON_ERROR_STOP 1
+-- custom origin with variable size
+CREATE MATERIALIZED VIEW cagg3 WITH (timescaledb.continuous,timescaledb.materialized_only=true) AS
+SELECT time_bucket('1 month', time, 'PST8PDT', '2000-01-01'::timestamptz) FROM metrics GROUP BY 1;
+NOTICE:  refreshing continuous aggregate "cagg3"
+SELECT * FROM cagg3;
+         time_bucket          
+------------------------------
+ Wed Dec 01 00:00:00 1999 PST
+ Sat Jan 01 00:00:00 2000 PST
+(2 rows)
+
+-- offset with variable size
+CREATE MATERIALIZED VIEW cagg4 WITH (timescaledb.continuous,timescaledb.materialized_only=true) AS
+SELECT time_bucket('1 month', time, 'PST8PDT', "offset":= INTERVAL '15 day') FROM metrics GROUP BY 1;
+NOTICE:  refreshing continuous aggregate "cagg4"
+SELECT * FROM cagg4;
+         time_bucket          
+------------------------------
+ Thu Dec 16 00:00:00 1999 PST
+ Sun Jan 16 00:00:00 2000 PST
+(2 rows)
+
 --
 -- drop chunks tests
 --
@@ -494,12 +511,14 @@ ORDER BY 1;
 (4 rows)
 
 -- all caggs in the new format (finalized=true)
-SELECT user_view_name, finalized FROM _timescaledb_catalog.continuous_agg WHERE user_view_name in ('cagg1', 'cagg2', 'cagg3') ORDER BY 1;
+SELECT user_view_name, finalized FROM _timescaledb_catalog.continuous_agg WHERE user_view_name in ('cagg1', 'cagg2', 'cagg3', 'cagg4') ORDER BY 1;
  user_view_name | finalized 
 ----------------+-----------
  cagg1          | t
  cagg2          | t
-(2 rows)
+ cagg3          | t
+ cagg4          | t
+(4 rows)
 
 -- dropping chunk should also remove the catalog data
 SELECT drop_chunks('metrics', older_than => '2000-01-01 00:00:00-02'::timestamptz);
@@ -527,12 +546,14 @@ ORDER BY 1;
 UPDATE _timescaledb_catalog.continuous_agg SET finalized=FALSE WHERE user_view_name = 'cagg1';
 \c :TEST_DBNAME :ROLE_DEFAULT_PERM_USER
 -- cagg1 now is a fake old format (finalized=false)
-SELECT user_view_name, finalized FROM _timescaledb_catalog.continuous_agg WHERE user_view_name in ('cagg1', 'cagg2', 'cagg3') ORDER BY 1;
+SELECT user_view_name, finalized FROM _timescaledb_catalog.continuous_agg WHERE user_view_name in ('cagg1', 'cagg2', 'cagg3', 'cagg4') ORDER BY 1;
  user_view_name | finalized 
 ----------------+-----------
  cagg1          | f
  cagg2          | t
-(2 rows)
+ cagg3          | t
+ cagg4          | t
+(4 rows)
 
 -- cagg1 now is in the old format (finalized=false)
 -- dropping chunk should NOT remove the catalog data
@@ -560,11 +581,13 @@ ORDER BY 1;
 DROP MATERIALIZED VIEW cagg1;
 NOTICE:  drop cascades to table _timescaledb_internal._hyper_12_21_chunk
 -- no more old format caggs (finalized=false)
-SELECT user_view_name, finalized FROM _timescaledb_catalog.continuous_agg WHERE user_view_name in ('cagg1', 'cagg2', 'cagg3') ORDER BY 1;
+SELECT user_view_name, finalized FROM _timescaledb_catalog.continuous_agg WHERE user_view_name in ('cagg1', 'cagg2', 'cagg3', 'cagg4') ORDER BY 1;
  user_view_name | finalized 
 ----------------+-----------
  cagg2          | t
-(1 row)
+ cagg3          | t
+ cagg4          | t
+(3 rows)
 
 -- dropping chunk should remove the catalog data
 SELECT drop_chunks('metrics', older_than => '2000-01-25 00:00:00-02'::timestamptz);

--- a/tsl/test/expected/cagg_usage-15.out
+++ b/tsl/test/expected/cagg_usage-15.out
@@ -444,10 +444,12 @@ SELECT current_setting('timezone');
 
 -- should be blocked because non-immutable expression
 \set ON_ERROR_STOP 0
-CREATE MATERIALIZED VIEW cagg1 WITH (timescaledb.continuous,timescaledb.materialized_only=true) AS SELECT time_bucket('1 day', time, current_setting('timezone')) FROM metrics GROUP BY 1;
+CREATE MATERIALIZED VIEW cagg1 WITH (timescaledb.continuous,timescaledb.materialized_only=true) AS
+SELECT time_bucket('1 day', time, current_setting('timezone')) FROM metrics GROUP BY 1;
 ERROR:  only immutable expressions allowed in time bucket function
 \set ON_ERROR_STOP 1
-CREATE MATERIALIZED VIEW cagg1 WITH (timescaledb.continuous,timescaledb.materialized_only=true) AS SELECT time_bucket('1 day', time, 'PST8PDT') FROM metrics GROUP BY 1;
+CREATE MATERIALIZED VIEW cagg1 WITH (timescaledb.continuous,timescaledb.materialized_only=true) AS
+SELECT time_bucket('1 day', time, 'PST8PDT') FROM metrics GROUP BY 1;
 NOTICE:  refreshing continuous aggregate "cagg1"
 SELECT * FROM cagg1;
          time_bucket          
@@ -458,7 +460,8 @@ SELECT * FROM cagg1;
  Tue Jan 25 00:00:00 2000 PST
 (4 rows)
 
-CREATE MATERIALIZED VIEW cagg2 WITH (timescaledb.continuous,timescaledb.materialized_only=true) AS SELECT time_bucket('1 month', time, 'PST8PDT') FROM metrics GROUP BY 1;
+CREATE MATERIALIZED VIEW cagg2 WITH (timescaledb.continuous,timescaledb.materialized_only=true) AS
+SELECT time_bucket('1 month', time, 'PST8PDT') FROM metrics GROUP BY 1;
 NOTICE:  refreshing continuous aggregate "cagg2"
 SELECT * FROM cagg2;
          time_bucket          
@@ -467,14 +470,28 @@ SELECT * FROM cagg2;
  Sat Jan 01 00:00:00 2000 PST
 (2 rows)
 
--- custom origin - not supported due to variable size
-\set ON_ERROR_STOP 0
-CREATE MATERIALIZED VIEW cagg3 WITH (timescaledb.continuous,timescaledb.materialized_only=true) AS SELECT time_bucket('1 month', time, 'PST8PDT', '2000-01-01'::timestamptz) FROM metrics GROUP BY 1;
-ERROR:  cannot create continuous aggregate with variable-width bucket using offset or origin.
--- offset - not supported due to variable size
-CREATE MATERIALIZED VIEW cagg4 WITH (timescaledb.continuous,timescaledb.materialized_only=true) AS SELECT time_bucket('1 month', time, 'PST8PDT', "offset":= INTERVAL '15 day') FROM metrics GROUP BY 1;
-ERROR:  cannot create continuous aggregate with variable-width bucket using offset or origin.
-\set ON_ERROR_STOP 1
+-- custom origin with variable size
+CREATE MATERIALIZED VIEW cagg3 WITH (timescaledb.continuous,timescaledb.materialized_only=true) AS
+SELECT time_bucket('1 month', time, 'PST8PDT', '2000-01-01'::timestamptz) FROM metrics GROUP BY 1;
+NOTICE:  refreshing continuous aggregate "cagg3"
+SELECT * FROM cagg3;
+         time_bucket          
+------------------------------
+ Wed Dec 01 00:00:00 1999 PST
+ Sat Jan 01 00:00:00 2000 PST
+(2 rows)
+
+-- offset with variable size
+CREATE MATERIALIZED VIEW cagg4 WITH (timescaledb.continuous,timescaledb.materialized_only=true) AS
+SELECT time_bucket('1 month', time, 'PST8PDT', "offset":= INTERVAL '15 day') FROM metrics GROUP BY 1;
+NOTICE:  refreshing continuous aggregate "cagg4"
+SELECT * FROM cagg4;
+         time_bucket          
+------------------------------
+ Thu Dec 16 00:00:00 1999 PST
+ Sun Jan 16 00:00:00 2000 PST
+(2 rows)
+
 --
 -- drop chunks tests
 --
@@ -494,12 +511,14 @@ ORDER BY 1;
 (4 rows)
 
 -- all caggs in the new format (finalized=true)
-SELECT user_view_name, finalized FROM _timescaledb_catalog.continuous_agg WHERE user_view_name in ('cagg1', 'cagg2', 'cagg3') ORDER BY 1;
+SELECT user_view_name, finalized FROM _timescaledb_catalog.continuous_agg WHERE user_view_name in ('cagg1', 'cagg2', 'cagg3', 'cagg4') ORDER BY 1;
  user_view_name | finalized 
 ----------------+-----------
  cagg1          | t
  cagg2          | t
-(2 rows)
+ cagg3          | t
+ cagg4          | t
+(4 rows)
 
 -- dropping chunk should also remove the catalog data
 SELECT drop_chunks('metrics', older_than => '2000-01-01 00:00:00-02'::timestamptz);
@@ -527,12 +546,14 @@ ORDER BY 1;
 UPDATE _timescaledb_catalog.continuous_agg SET finalized=FALSE WHERE user_view_name = 'cagg1';
 \c :TEST_DBNAME :ROLE_DEFAULT_PERM_USER
 -- cagg1 now is a fake old format (finalized=false)
-SELECT user_view_name, finalized FROM _timescaledb_catalog.continuous_agg WHERE user_view_name in ('cagg1', 'cagg2', 'cagg3') ORDER BY 1;
+SELECT user_view_name, finalized FROM _timescaledb_catalog.continuous_agg WHERE user_view_name in ('cagg1', 'cagg2', 'cagg3', 'cagg4') ORDER BY 1;
  user_view_name | finalized 
 ----------------+-----------
  cagg1          | f
  cagg2          | t
-(2 rows)
+ cagg3          | t
+ cagg4          | t
+(4 rows)
 
 -- cagg1 now is in the old format (finalized=false)
 -- dropping chunk should NOT remove the catalog data
@@ -560,11 +581,13 @@ ORDER BY 1;
 DROP MATERIALIZED VIEW cagg1;
 NOTICE:  drop cascades to table _timescaledb_internal._hyper_12_21_chunk
 -- no more old format caggs (finalized=false)
-SELECT user_view_name, finalized FROM _timescaledb_catalog.continuous_agg WHERE user_view_name in ('cagg1', 'cagg2', 'cagg3') ORDER BY 1;
+SELECT user_view_name, finalized FROM _timescaledb_catalog.continuous_agg WHERE user_view_name in ('cagg1', 'cagg2', 'cagg3', 'cagg4') ORDER BY 1;
  user_view_name | finalized 
 ----------------+-----------
  cagg2          | t
-(1 row)
+ cagg3          | t
+ cagg4          | t
+(3 rows)
 
 -- dropping chunk should remove the catalog data
 SELECT drop_chunks('metrics', older_than => '2000-01-25 00:00:00-02'::timestamptz);

--- a/tsl/test/expected/cagg_usage-16.out
+++ b/tsl/test/expected/cagg_usage-16.out
@@ -444,10 +444,12 @@ SELECT current_setting('timezone');
 
 -- should be blocked because non-immutable expression
 \set ON_ERROR_STOP 0
-CREATE MATERIALIZED VIEW cagg1 WITH (timescaledb.continuous,timescaledb.materialized_only=true) AS SELECT time_bucket('1 day', time, current_setting('timezone')) FROM metrics GROUP BY 1;
+CREATE MATERIALIZED VIEW cagg1 WITH (timescaledb.continuous,timescaledb.materialized_only=true) AS
+SELECT time_bucket('1 day', time, current_setting('timezone')) FROM metrics GROUP BY 1;
 ERROR:  only immutable expressions allowed in time bucket function
 \set ON_ERROR_STOP 1
-CREATE MATERIALIZED VIEW cagg1 WITH (timescaledb.continuous,timescaledb.materialized_only=true) AS SELECT time_bucket('1 day', time, 'PST8PDT') FROM metrics GROUP BY 1;
+CREATE MATERIALIZED VIEW cagg1 WITH (timescaledb.continuous,timescaledb.materialized_only=true) AS
+SELECT time_bucket('1 day', time, 'PST8PDT') FROM metrics GROUP BY 1;
 NOTICE:  refreshing continuous aggregate "cagg1"
 SELECT * FROM cagg1;
          time_bucket          
@@ -458,7 +460,8 @@ SELECT * FROM cagg1;
  Tue Jan 25 00:00:00 2000 PST
 (4 rows)
 
-CREATE MATERIALIZED VIEW cagg2 WITH (timescaledb.continuous,timescaledb.materialized_only=true) AS SELECT time_bucket('1 month', time, 'PST8PDT') FROM metrics GROUP BY 1;
+CREATE MATERIALIZED VIEW cagg2 WITH (timescaledb.continuous,timescaledb.materialized_only=true) AS
+SELECT time_bucket('1 month', time, 'PST8PDT') FROM metrics GROUP BY 1;
 NOTICE:  refreshing continuous aggregate "cagg2"
 SELECT * FROM cagg2;
          time_bucket          
@@ -467,14 +470,28 @@ SELECT * FROM cagg2;
  Sat Jan 01 00:00:00 2000 PST
 (2 rows)
 
--- custom origin - not supported due to variable size
-\set ON_ERROR_STOP 0
-CREATE MATERIALIZED VIEW cagg3 WITH (timescaledb.continuous,timescaledb.materialized_only=true) AS SELECT time_bucket('1 month', time, 'PST8PDT', '2000-01-01'::timestamptz) FROM metrics GROUP BY 1;
-ERROR:  cannot create continuous aggregate with variable-width bucket using offset or origin.
--- offset - not supported due to variable size
-CREATE MATERIALIZED VIEW cagg4 WITH (timescaledb.continuous,timescaledb.materialized_only=true) AS SELECT time_bucket('1 month', time, 'PST8PDT', "offset":= INTERVAL '15 day') FROM metrics GROUP BY 1;
-ERROR:  cannot create continuous aggregate with variable-width bucket using offset or origin.
-\set ON_ERROR_STOP 1
+-- custom origin with variable size
+CREATE MATERIALIZED VIEW cagg3 WITH (timescaledb.continuous,timescaledb.materialized_only=true) AS
+SELECT time_bucket('1 month', time, 'PST8PDT', '2000-01-01'::timestamptz) FROM metrics GROUP BY 1;
+NOTICE:  refreshing continuous aggregate "cagg3"
+SELECT * FROM cagg3;
+         time_bucket          
+------------------------------
+ Wed Dec 01 00:00:00 1999 PST
+ Sat Jan 01 00:00:00 2000 PST
+(2 rows)
+
+-- offset with variable size
+CREATE MATERIALIZED VIEW cagg4 WITH (timescaledb.continuous,timescaledb.materialized_only=true) AS
+SELECT time_bucket('1 month', time, 'PST8PDT', "offset":= INTERVAL '15 day') FROM metrics GROUP BY 1;
+NOTICE:  refreshing continuous aggregate "cagg4"
+SELECT * FROM cagg4;
+         time_bucket          
+------------------------------
+ Thu Dec 16 00:00:00 1999 PST
+ Sun Jan 16 00:00:00 2000 PST
+(2 rows)
+
 --
 -- drop chunks tests
 --
@@ -494,12 +511,14 @@ ORDER BY 1;
 (4 rows)
 
 -- all caggs in the new format (finalized=true)
-SELECT user_view_name, finalized FROM _timescaledb_catalog.continuous_agg WHERE user_view_name in ('cagg1', 'cagg2', 'cagg3') ORDER BY 1;
+SELECT user_view_name, finalized FROM _timescaledb_catalog.continuous_agg WHERE user_view_name in ('cagg1', 'cagg2', 'cagg3', 'cagg4') ORDER BY 1;
  user_view_name | finalized 
 ----------------+-----------
  cagg1          | t
  cagg2          | t
-(2 rows)
+ cagg3          | t
+ cagg4          | t
+(4 rows)
 
 -- dropping chunk should also remove the catalog data
 SELECT drop_chunks('metrics', older_than => '2000-01-01 00:00:00-02'::timestamptz);
@@ -527,12 +546,14 @@ ORDER BY 1;
 UPDATE _timescaledb_catalog.continuous_agg SET finalized=FALSE WHERE user_view_name = 'cagg1';
 \c :TEST_DBNAME :ROLE_DEFAULT_PERM_USER
 -- cagg1 now is a fake old format (finalized=false)
-SELECT user_view_name, finalized FROM _timescaledb_catalog.continuous_agg WHERE user_view_name in ('cagg1', 'cagg2', 'cagg3') ORDER BY 1;
+SELECT user_view_name, finalized FROM _timescaledb_catalog.continuous_agg WHERE user_view_name in ('cagg1', 'cagg2', 'cagg3', 'cagg4') ORDER BY 1;
  user_view_name | finalized 
 ----------------+-----------
  cagg1          | f
  cagg2          | t
-(2 rows)
+ cagg3          | t
+ cagg4          | t
+(4 rows)
 
 -- cagg1 now is in the old format (finalized=false)
 -- dropping chunk should NOT remove the catalog data
@@ -560,11 +581,13 @@ ORDER BY 1;
 DROP MATERIALIZED VIEW cagg1;
 NOTICE:  drop cascades to table _timescaledb_internal._hyper_12_21_chunk
 -- no more old format caggs (finalized=false)
-SELECT user_view_name, finalized FROM _timescaledb_catalog.continuous_agg WHERE user_view_name in ('cagg1', 'cagg2', 'cagg3') ORDER BY 1;
+SELECT user_view_name, finalized FROM _timescaledb_catalog.continuous_agg WHERE user_view_name in ('cagg1', 'cagg2', 'cagg3', 'cagg4') ORDER BY 1;
  user_view_name | finalized 
 ----------------+-----------
  cagg2          | t
-(1 row)
+ cagg3          | t
+ cagg4          | t
+(3 rows)
 
 -- dropping chunk should remove the catalog data
 SELECT drop_chunks('metrics', older_than => '2000-01-25 00:00:00-02'::timestamptz);

--- a/tsl/test/sql/cagg_ddl.sql.in
+++ b/tsl/test/sql/cagg_ddl.sql.in
@@ -1162,10 +1162,8 @@ SELECT * FROM cashflows;
 -- 2. test named timezone
 -- 3. test named ts
 -- 4. test named bucket width
--- named origin
 
--- Currently not supported due to a bug in time_bucket (see comment in cagg_validate_query)
-\set ON_ERROR_STOP 0
+-- named origin
 CREATE MATERIALIZED VIEW cagg_named_origin WITH
 (timescaledb.continuous, timescaledb.materialized_only=false) AS
 SELECT time_bucket('1h', time, 'UTC', origin => '2001-01-03 01:23:45') AS bucket,
@@ -1185,13 +1183,13 @@ CREATE MATERIALIZED VIEW cagg_named_ts_tz_origin WITH
 SELECT time_bucket('1h', ts => time, timezone => 'UTC', origin => '2001-01-03 01:23:45') AS bucket,
 avg(amount) as avg_amount
 FROM transactions GROUP BY 1 WITH NO DATA;
+
 -- named bucket width
 CREATE MATERIALIZED VIEW cagg_named_all WITH
 (timescaledb.continuous, timescaledb.materialized_only=false) AS
 SELECT time_bucket(bucket_width => '1h', ts => time, timezone => 'UTC', origin => '2001-01-03 01:23:45') AS bucket,
 avg(amount) as avg_amount
 FROM transactions GROUP BY 1 WITH NO DATA;
-\set ON_ERROR_STOP 1
 
 -- Refreshing from the beginning (NULL) of a CAGG with variable time bucket and
 -- using an INTERVAL for the end timestamp (issue #5534)

--- a/tsl/test/sql/cagg_query.sql
+++ b/tsl/test/sql/cagg_query.sql
@@ -359,6 +359,10 @@ INSERT INTO table_smallint VALUES(1,2);
 INSERT INTO table_int VALUES(1,2);
 INSERT INTO table_bigint VALUES(1,2);
 
+CREATE VIEW caggs_info AS
+SELECT user_view_schema, user_view_name, bucket_func, bucket_width, bucket_origin, bucket_offset, bucket_timezone, bucket_fixed_width
+FROM _timescaledb_catalog.continuous_aggs_bucket_function NATURAL JOIN _timescaledb_catalog.continuous_agg;
+
 ---
 -- Tests with CAgg creation
 ---
@@ -367,7 +371,7 @@ CREATE MATERIALIZED VIEW cagg_4_hours
   SELECT time_bucket('4 hour', time), max(value)
     FROM temperature
     GROUP BY 1 ORDER BY 1;
-SELECT * FROM _timescaledb_catalog.continuous_aggs_bucket_function ORDER BY 1 DESC LIMIT 1;
+SELECT * FROM caggs_info WHERE user_view_name = 'cagg_4_hours';
 DROP MATERIALIZED VIEW cagg_4_hours;
 
 CREATE MATERIALIZED VIEW cagg_4_hours_offset
@@ -375,7 +379,7 @@ CREATE MATERIALIZED VIEW cagg_4_hours_offset
   SELECT time_bucket('4 hour', time, '30m'::interval), max(value)
     FROM temperature
     GROUP BY 1 ORDER BY 1;
-SELECT * FROM _timescaledb_catalog.continuous_aggs_bucket_function ORDER BY 1 DESC LIMIT 1;
+SELECT * FROM caggs_info WHERE user_view_name = 'cagg_4_hours_offset';
 DROP MATERIALIZED VIEW cagg_4_hours_offset;
 
 CREATE MATERIALIZED VIEW cagg_4_hours_offset2
@@ -383,25 +387,24 @@ CREATE MATERIALIZED VIEW cagg_4_hours_offset2
   SELECT time_bucket('4 hour', time, "offset"=>'30m'::interval), max(value)
     FROM temperature
     GROUP BY 1 ORDER BY 1;
-SELECT * FROM _timescaledb_catalog.continuous_aggs_bucket_function ORDER BY 1 DESC LIMIT 1;
+SELECT * FROM caggs_info WHERE user_view_name = 'cagg_4_hours_offset2';
 DROP MATERIALIZED VIEW cagg_4_hours_offset2;
 
--- Variable buckets (timezone is provided) with offset are not supported at the moment
-\set ON_ERROR_STOP 0
+-- Variable buckets (timezone is provided) with offset
 CREATE MATERIALIZED VIEW cagg_4_hours_offset_ts
   WITH (timescaledb.continuous, timescaledb.materialized_only = false) AS
   SELECT time_bucket('4 hour', time, "offset"=>'30m'::interval, timezone=>'UTC'), max(value)
     FROM temperature
     GROUP BY 1 ORDER BY 1;
-SELECT * FROM _timescaledb_catalog.continuous_aggs_bucket_function ORDER BY 1 DESC LIMIT 1;
-\set ON_ERROR_STOP 1
+SELECT * FROM caggs_info WHERE user_view_name = 'cagg_4_hours_offset_ts';
+DROP MATERIALIZED VIEW cagg_4_hours_offset_ts;
 
 CREATE MATERIALIZED VIEW cagg_4_hours_origin
   WITH (timescaledb.continuous, timescaledb.materialized_only = false) AS
   SELECT time_bucket('4 hour', time, '2000-01-01 01:00:00 PST'::timestamptz), max(value)
     FROM temperature
     GROUP BY 1 ORDER BY 1;
-SELECT * FROM _timescaledb_catalog.continuous_aggs_bucket_function ORDER BY 1 DESC LIMIT 1;
+SELECT * FROM caggs_info WHERE user_view_name = 'cagg_4_hours_origin';
 DROP MATERIALIZED VIEW cagg_4_hours_origin;
 
 -- Using named parameter
@@ -410,17 +413,17 @@ CREATE MATERIALIZED VIEW cagg_4_hours_origin2
   SELECT time_bucket('4 hour', time, origin=>'2000-01-01 01:00:00 PST'::timestamptz), max(value)
     FROM temperature
     GROUP BY 1 ORDER BY 1;
-SELECT * FROM _timescaledb_catalog.continuous_aggs_bucket_function ORDER BY 1 DESC LIMIT 1;
+SELECT * FROM caggs_info WHERE user_view_name = 'cagg_4_hours_origin2';
 DROP MATERIALIZED VIEW cagg_4_hours_origin2;
 
--- Variable buckets (timezone is provided) with origin are not supported at the moment
-\set ON_ERROR_STOP 0
+-- Variable buckets (timezone is provided) with origin
 CREATE MATERIALIZED VIEW cagg_4_hours_origin_ts
   WITH (timescaledb.continuous, timescaledb.materialized_only = false) AS
   SELECT time_bucket('4 hour', time, origin=>'2000-01-01 01:00:00 PST'::timestamptz, timezone=>'UTC'), max(value)
     FROM temperature
     GROUP BY 1 ORDER BY 1;
-SELECT * FROM _timescaledb_catalog.continuous_aggs_bucket_function ORDER BY 1 DESC LIMIT 1;
+SELECT * FROM caggs_info WHERE user_view_name = 'cagg_4_hours_origin_ts';
+DROP MATERIALIZED VIEW cagg_4_hours_origin_ts;
 
 -- Without named parameter
 CREATE MATERIALIZED VIEW cagg_4_hours_origin_ts2
@@ -428,8 +431,8 @@ CREATE MATERIALIZED VIEW cagg_4_hours_origin_ts2
   SELECT time_bucket('4 hour', time, 'UTC', '2000-01-01 01:00:00 PST'::timestamptz), max(value)
     FROM temperature
     GROUP BY 1 ORDER BY 1;
-SELECT * FROM _timescaledb_catalog.continuous_aggs_bucket_function ORDER BY 1 DESC LIMIT 1;
-\set ON_ERROR_STOP 1
+SELECT * FROM caggs_info WHERE user_view_name = 'cagg_4_hours_origin_ts2';
+DROP MATERIALIZED VIEW cagg_4_hours_origin_ts2;
 
 -- Timestamp based CAggs
 CREATE MATERIALIZED VIEW cagg_4_hours_wo_tz
@@ -437,33 +440,33 @@ CREATE MATERIALIZED VIEW cagg_4_hours_wo_tz
   SELECT time_bucket('4 hour', time), max(value)
     FROM temperature_wo_tz
     GROUP BY 1 ORDER BY 1;
-SELECT * FROM _timescaledb_catalog.continuous_aggs_bucket_function ORDER BY 1 DESC LIMIT 1;
+SELECT * FROM caggs_info WHERE user_view_name = 'cagg_4_hours_wo_tz';
 
 CREATE MATERIALIZED VIEW cagg_4_hours_origin_ts_wo_tz
   WITH (timescaledb.continuous, timescaledb.materialized_only = false) AS
   SELECT time_bucket('4 hour', time, '2000-01-01 01:00:00'::timestamp), max(value)
     FROM temperature_wo_tz
     GROUP BY 1 ORDER BY 1;
-SELECT * FROM _timescaledb_catalog.continuous_aggs_bucket_function ORDER BY 1 DESC LIMIT 1;
+SELECT * FROM caggs_info WHERE user_view_name = 'cagg_4_hours_origin_ts_wo_tz';
 DROP MATERIALIZED VIEW cagg_4_hours_origin_ts_wo_tz;
 
--- Variable buckets (timezone is provided) with origin are not supported at the moment
-\set ON_ERROR_STOP 0
+-- Variable buckets (timezone is provided) with origin
 CREATE MATERIALIZED VIEW cagg_4_hours_origin_ts_wo_tz2
   WITH (timescaledb.continuous, timescaledb.materialized_only = false) AS
   SELECT time_bucket('4 hour', time, origin=>'2000-01-01 01:00:00'::timestamp), max(value)
     FROM temperature_wo_tz
     GROUP BY 1 ORDER BY 1;
-SELECT * FROM _timescaledb_catalog.continuous_aggs_bucket_function ORDER BY 1 DESC LIMIT 1;
-\set ON_ERROR_STOP 1
+SELECT * FROM caggs_info WHERE user_view_name = 'cagg_4_hours_origin_ts_wo_tz2';
+DROP MATERIALIZED VIEW cagg_4_hours_origin_ts_wo_tz2;
 
 CREATE MATERIALIZED VIEW cagg_4_hours_offset_wo_tz
   WITH (timescaledb.continuous, timescaledb.materialized_only = false) AS
   SELECT time_bucket('4 hour', time, "offset"=>'30m'::interval), max(value)
     FROM temperature_wo_tz
     GROUP BY 1 ORDER BY 1;
-SELECT * FROM _timescaledb_catalog.continuous_aggs_bucket_function ORDER BY 1 DESC LIMIT 1;
+SELECT * FROM caggs_info WHERE user_view_name = 'cagg_4_hours_offset_wo_tz';
 DROP MATERIALIZED VIEW cagg_4_hours_offset_wo_tz;
+DROP MATERIALIZED VIEW cagg_4_hours_wo_tz;
 
 -- Date based CAggs
 CREATE MATERIALIZED VIEW cagg_4_hours_date
@@ -471,7 +474,7 @@ CREATE MATERIALIZED VIEW cagg_4_hours_date
   SELECT time_bucket('4 days', time), max(value)
     FROM temperature_date
     GROUP BY 1 ORDER BY 1;
-SELECT * FROM _timescaledb_catalog.continuous_aggs_bucket_function ORDER BY 1 DESC LIMIT 1;
+SELECT * FROM caggs_info WHERE user_view_name = 'cagg_4_hours_date';
 DROP MATERIALIZED VIEW cagg_4_hours_date;
 
 CREATE MATERIALIZED VIEW cagg_4_hours_date_origin
@@ -479,7 +482,7 @@ CREATE MATERIALIZED VIEW cagg_4_hours_date_origin
   SELECT time_bucket('4 days', time, '2000-01-01'::date), max(value)
     FROM temperature_date
     GROUP BY 1 ORDER BY 1;
-SELECT * FROM _timescaledb_catalog.continuous_aggs_bucket_function ORDER BY 1 DESC LIMIT 1;
+SELECT * FROM caggs_info WHERE user_view_name = 'cagg_4_hours_date_origin';
 DROP MATERIALIZED VIEW cagg_4_hours_date_origin;
 
 CREATE MATERIALIZED VIEW cagg_4_hours_date_origin2
@@ -487,7 +490,7 @@ CREATE MATERIALIZED VIEW cagg_4_hours_date_origin2
   SELECT time_bucket('4 days', time, origin=>'2000-01-01'::date), max(value)
     FROM temperature_date
     GROUP BY 1 ORDER BY 1;
-SELECT * FROM _timescaledb_catalog.continuous_aggs_bucket_function ORDER BY 1 DESC LIMIT 1;
+SELECT * FROM caggs_info WHERE user_view_name = 'cagg_4_hours_date_origin2';
 DROP MATERIALIZED VIEW cagg_4_hours_date_origin2;
 
 CREATE MATERIALIZED VIEW cagg_4_hours_date_offset
@@ -495,7 +498,7 @@ CREATE MATERIALIZED VIEW cagg_4_hours_date_offset
   SELECT time_bucket('4 days', time, "offset"=>'30m'::interval), max(value)
     FROM temperature_date
     GROUP BY 1 ORDER BY 1;
-SELECT * FROM _timescaledb_catalog.continuous_aggs_bucket_function ORDER BY 1 DESC LIMIT 1;
+SELECT * FROM caggs_info WHERE user_view_name = 'cagg_4_hours_date_offset';
 DROP MATERIALIZED VIEW cagg_4_hours_date_offset;
 
 -- Integer based CAggs
@@ -504,7 +507,7 @@ CREATE MATERIALIZED VIEW cagg_smallint
     AS SELECT time_bucket('2', time), SUM(data) as value
         FROM table_smallint
         GROUP BY 1;
-SELECT * FROM _timescaledb_catalog.continuous_aggs_bucket_function ORDER BY 1 DESC LIMIT 1;
+SELECT * FROM caggs_info WHERE user_view_name = 'cagg_smallint';
 DROP MATERIALIZED VIEW cagg_smallint;
 
 CREATE MATERIALIZED VIEW cagg_smallint_offset
@@ -512,7 +515,7 @@ CREATE MATERIALIZED VIEW cagg_smallint_offset
     AS SELECT time_bucket('2', time, "offset"=>1::smallint), SUM(data) as value
         FROM table_smallint
         GROUP BY 1;
-SELECT * FROM _timescaledb_catalog.continuous_aggs_bucket_function ORDER BY 1 DESC LIMIT 1;
+SELECT * FROM caggs_info WHERE user_view_name = 'cagg_smallint_offset';
 DROP MATERIALIZED VIEW cagg_smallint_offset;
 
 CREATE MATERIALIZED VIEW cagg_int
@@ -520,7 +523,7 @@ CREATE MATERIALIZED VIEW cagg_int
     AS SELECT time_bucket('2', time), SUM(data) as value
         FROM table_int
         GROUP BY 1;
-SELECT * FROM _timescaledb_catalog.continuous_aggs_bucket_function ORDER BY 1 DESC LIMIT 1;
+SELECT * FROM caggs_info WHERE user_view_name = 'cagg_int';
 DROP MATERIALIZED VIEW cagg_int;
 
 CREATE MATERIALIZED VIEW cagg_int_offset
@@ -528,7 +531,7 @@ CREATE MATERIALIZED VIEW cagg_int_offset
     AS SELECT time_bucket('2', time, "offset"=>1::int), SUM(data) as value
         FROM table_int
         GROUP BY 1;
-SELECT * FROM _timescaledb_catalog.continuous_aggs_bucket_function ORDER BY 1 DESC LIMIT 1;
+SELECT * FROM caggs_info WHERE user_view_name = 'cagg_int_offset';
 DROP MATERIALIZED VIEW cagg_int_offset;
 
 CREATE MATERIALIZED VIEW cagg_bigint
@@ -536,7 +539,7 @@ CREATE MATERIALIZED VIEW cagg_bigint
     AS SELECT time_bucket('2', time), SUM(data) as value
         FROM table_bigint
         GROUP BY 1 WITH NO DATA;
-SELECT * FROM _timescaledb_catalog.continuous_aggs_bucket_function ORDER BY 1 DESC LIMIT 1;
+SELECT * FROM caggs_info WHERE user_view_name = 'cagg_bigint';
 DROP MATERIALIZED VIEW cagg_bigint;
 
 CREATE MATERIALIZED VIEW cagg_bigint_offset
@@ -544,7 +547,7 @@ CREATE MATERIALIZED VIEW cagg_bigint_offset
     AS SELECT time_bucket('2', time, "offset"=>1::bigint), SUM(data) as value
         FROM table_bigint
         GROUP BY 1 WITH NO DATA;
-SELECT * FROM _timescaledb_catalog.continuous_aggs_bucket_function ORDER BY 1 DESC LIMIT 1;
+SELECT * FROM caggs_info WHERE user_view_name = 'cagg_bigint_offset';
 DROP MATERIALIZED VIEW cagg_bigint_offset;
 
 -- Without named parameter
@@ -553,7 +556,7 @@ CREATE MATERIALIZED VIEW cagg_bigint_offset2
     AS SELECT time_bucket('2', time, 1::bigint), SUM(data) as value
         FROM table_bigint
         GROUP BY 1 WITH NO DATA;
-SELECT * FROM _timescaledb_catalog.continuous_aggs_bucket_function ORDER BY 1 DESC LIMIT 1;
+SELECT * FROM caggs_info WHERE user_view_name = 'cagg_bigint_offset2';
 
 -- mess with the bucket_func signature to make sure it will raise an exception
 \c :TEST_DBNAME :ROLE_CLUSTER_SUPERUSER
@@ -656,10 +659,11 @@ ALTER MATERIALIZED VIEW cagg_4_hours_offset SET (timescaledb.materialized_only=f
 ALTER MATERIALIZED VIEW cagg_4_hours_origin SET (timescaledb.materialized_only=false);
 
 -- Check watermarks
-SELECT continuous_aggs_watermark.*, _timescaledb_functions.to_timestamp(watermark)
+SELECT continuous_agg.user_view_name, continuous_aggs_watermark.watermark, _timescaledb_functions.to_timestamp(watermark)
   FROM _timescaledb_catalog.continuous_aggs_watermark
   JOIN _timescaledb_catalog.continuous_agg USING (mat_hypertable_id)
-WHERE user_view_name LIKE 'cagg_4_hours%' ORDER BY mat_hypertable_id, watermark;
+WHERE user_view_name LIKE 'cagg_4_hours%'
+ORDER BY mat_hypertable_id, watermark;
 
 -- Insert new data
 INSERT INTO temperature values('2020-01-02 00:10:00 PST', 2222);
@@ -824,20 +828,14 @@ RESET client_min_messages;
 SELECT * FROM cagg_int_offset;
 SELECT time_bucket('10', time, "offset"=>5), SUM(data) FROM table_int GROUP BY 1 ORDER BY 1;
 
----
--- Test with blocking a few broken configurations
----
-\set ON_ERROR_STOP 0
-
--- Unfortunately '\set VERBOSITY verbose' cannot be used here to check the error details
--- since it also prints the line number of the location, which is depended on the build
-
--- Variable sized buckets with origin are known to work incorrect. So, block usage for now.
+-- Variable sized buckets with origin
 CREATE MATERIALIZED VIEW cagg_1_hour_variable_bucket_fixed_origin
   WITH (timescaledb.continuous) AS
   SELECT time_bucket('1 year', time, origin=>'2000-01-01 01:05:00 UTC'::timestamptz, timezone=>'UTC') AS hour_bucket, max(value) AS max_value
     FROM temperature
     GROUP BY 1 ORDER BY 1;
+SELECT * FROM caggs_info WHERE user_view_name = 'cagg_1_hour_variable_bucket_fixed_origin';
+DROP MATERIALIZED VIEW cagg_1_hour_variable_bucket_fixed_origin;
 
 -- Variable due to the used timezone
 CREATE MATERIALIZED VIEW cagg_1_hour_variable_bucket_fixed_origin2
@@ -845,6 +843,8 @@ CREATE MATERIALIZED VIEW cagg_1_hour_variable_bucket_fixed_origin2
   SELECT time_bucket('1 hour', time, origin=>'2000-01-01 01:05:00 UTC'::timestamptz, timezone=>'UTC') AS hour_bucket, max(value) AS max_value
     FROM temperature
     GROUP BY 1 ORDER BY 1;
+SELECT * FROM caggs_info WHERE user_view_name = 'cagg_1_hour_variable_bucket_fixed_origin2';
+DROP MATERIALIZED VIEW cagg_1_hour_variable_bucket_fixed_origin2;
 
 -- Variable with offset
 CREATE MATERIALIZED VIEW cagg_1_hour_variable_bucket_fixed_origin3
@@ -852,7 +852,16 @@ CREATE MATERIALIZED VIEW cagg_1_hour_variable_bucket_fixed_origin3
   SELECT time_bucket('1 year', time, "offset"=>'5 minutes'::interval) AS hour_bucket, max(value) AS max_value
     FROM temperature
     GROUP BY 1 ORDER BY 1;
+SELECT * FROM caggs_info WHERE user_view_name = 'cagg_1_hour_variable_bucket_fixed_origin3';
+DROP MATERIALIZED VIEW cagg_1_hour_variable_bucket_fixed_origin3;
 
+---
+-- Test with blocking a few broken configurations
+---
+\set ON_ERROR_STOP 0
+
+-- Unfortunately '\set VERBOSITY verbose' cannot be used here to check the error details
+-- since it also prints the line number of the location, which is depended on the build
 
 -- Different time origin
 CREATE MATERIALIZED VIEW cagg_1_hour_origin
@@ -907,12 +916,14 @@ CREATE MATERIALIZED VIEW cagg_1_hour_offset
   SELECT time_bucket('1 hour', time, origin=>'2000-01-02 01:00:00 PST'::timestamptz) AS hour_bucket, max(value) AS max_value
     FROM temperature
     GROUP BY 1 ORDER BY 1;
+SELECT * FROM caggs_info WHERE user_view_name = 'cagg_1_hour_offset';
 
 CREATE MATERIALIZED VIEW cagg_1_week_offset
   WITH (timescaledb.continuous) AS
   SELECT time_bucket('1 week', hour_bucket, origin=>'2000-01-02 01:00:00 PST'::timestamptz) AS week_bucket, max(max_value) AS max_value
     FROM cagg_1_hour_offset
     GROUP BY 1 ORDER BY 1;
+SELECT * FROM caggs_info WHERE user_view_name = 'cagg_1_week_offset';
 
 -- Compare output
 SELECT * FROM cagg_1_week_offset;
@@ -943,3 +954,5 @@ TRUNCATE temperature;
 
 SELECT * FROM cagg_1_week_offset;
 SELECT time_bucket('1 week', time, origin=>'2000-01-02 01:00:00 PST'::timestamptz), max(value) FROM temperature GROUP BY 1 ORDER BY 1;
+
+DROP VIEW caggs_info;

--- a/tsl/test/sql/cagg_usage.sql.in
+++ b/tsl/test/sql/cagg_usage.sql.in
@@ -292,22 +292,27 @@ SELECT current_setting('timezone');
 
 -- should be blocked because non-immutable expression
 \set ON_ERROR_STOP 0
-CREATE MATERIALIZED VIEW cagg1 WITH (timescaledb.continuous,timescaledb.materialized_only=true) AS SELECT time_bucket('1 day', time, current_setting('timezone')) FROM metrics GROUP BY 1;
+CREATE MATERIALIZED VIEW cagg1 WITH (timescaledb.continuous,timescaledb.materialized_only=true) AS
+SELECT time_bucket('1 day', time, current_setting('timezone')) FROM metrics GROUP BY 1;
 \set ON_ERROR_STOP 1
 
-CREATE MATERIALIZED VIEW cagg1 WITH (timescaledb.continuous,timescaledb.materialized_only=true) AS SELECT time_bucket('1 day', time, 'PST8PDT') FROM metrics GROUP BY 1;
+CREATE MATERIALIZED VIEW cagg1 WITH (timescaledb.continuous,timescaledb.materialized_only=true) AS
+SELECT time_bucket('1 day', time, 'PST8PDT') FROM metrics GROUP BY 1;
 SELECT * FROM cagg1;
 
-CREATE MATERIALIZED VIEW cagg2 WITH (timescaledb.continuous,timescaledb.materialized_only=true) AS SELECT time_bucket('1 month', time, 'PST8PDT') FROM metrics GROUP BY 1;
+CREATE MATERIALIZED VIEW cagg2 WITH (timescaledb.continuous,timescaledb.materialized_only=true) AS
+SELECT time_bucket('1 month', time, 'PST8PDT') FROM metrics GROUP BY 1;
 SELECT * FROM cagg2;
 
--- custom origin - not supported due to variable size
-\set ON_ERROR_STOP 0
-CREATE MATERIALIZED VIEW cagg3 WITH (timescaledb.continuous,timescaledb.materialized_only=true) AS SELECT time_bucket('1 month', time, 'PST8PDT', '2000-01-01'::timestamptz) FROM metrics GROUP BY 1;
+-- custom origin with variable size
+CREATE MATERIALIZED VIEW cagg3 WITH (timescaledb.continuous,timescaledb.materialized_only=true) AS
+SELECT time_bucket('1 month', time, 'PST8PDT', '2000-01-01'::timestamptz) FROM metrics GROUP BY 1;
+SELECT * FROM cagg3;
 
--- offset - not supported due to variable size
-CREATE MATERIALIZED VIEW cagg4 WITH (timescaledb.continuous,timescaledb.materialized_only=true) AS SELECT time_bucket('1 month', time, 'PST8PDT', "offset":= INTERVAL '15 day') FROM metrics GROUP BY 1;
-\set ON_ERROR_STOP 1
+-- offset with variable size
+CREATE MATERIALIZED VIEW cagg4 WITH (timescaledb.continuous,timescaledb.materialized_only=true) AS
+SELECT time_bucket('1 month', time, 'PST8PDT', "offset":= INTERVAL '15 day') FROM metrics GROUP BY 1;
+SELECT * FROM cagg4;
 
 --
 -- drop chunks tests
@@ -322,7 +327,7 @@ WHERE h.id = c.hypertable_id and h.table_name = 'metrics'
 ORDER BY 1;
 
 -- all caggs in the new format (finalized=true)
-SELECT user_view_name, finalized FROM _timescaledb_catalog.continuous_agg WHERE user_view_name in ('cagg1', 'cagg2', 'cagg3') ORDER BY 1;
+SELECT user_view_name, finalized FROM _timescaledb_catalog.continuous_agg WHERE user_view_name in ('cagg1', 'cagg2', 'cagg3', 'cagg4') ORDER BY 1;
 
 -- dropping chunk should also remove the catalog data
 SELECT drop_chunks('metrics', older_than => '2000-01-01 00:00:00-02'::timestamptz);
@@ -341,7 +346,7 @@ UPDATE _timescaledb_catalog.continuous_agg SET finalized=FALSE WHERE user_view_n
 \c :TEST_DBNAME :ROLE_DEFAULT_PERM_USER
 
 -- cagg1 now is a fake old format (finalized=false)
-SELECT user_view_name, finalized FROM _timescaledb_catalog.continuous_agg WHERE user_view_name in ('cagg1', 'cagg2', 'cagg3') ORDER BY 1;
+SELECT user_view_name, finalized FROM _timescaledb_catalog.continuous_agg WHERE user_view_name in ('cagg1', 'cagg2', 'cagg3', 'cagg4') ORDER BY 1;
 
 -- cagg1 now is in the old format (finalized=false)
 -- dropping chunk should NOT remove the catalog data
@@ -359,7 +364,7 @@ ORDER BY 1;
 DROP MATERIALIZED VIEW cagg1;
 
 -- no more old format caggs (finalized=false)
-SELECT user_view_name, finalized FROM _timescaledb_catalog.continuous_agg WHERE user_view_name in ('cagg1', 'cagg2', 'cagg3') ORDER BY 1;
+SELECT user_view_name, finalized FROM _timescaledb_catalog.continuous_agg WHERE user_view_name in ('cagg1', 'cagg2', 'cagg3', 'cagg4') ORDER BY 1;
 
 -- dropping chunk should remove the catalog data
 SELECT drop_chunks('metrics', older_than => '2000-01-25 00:00:00-02'::timestamptz);


### PR DESCRIPTION
On 2.15.x we added complete support of CAggs using time bucket with origin and/or offset, but we restrict the creating when the bucked size is variable due to some uncertaing regarding monthly buckets.

When bucketing by month we always align with the beginning of the month even defining an origin with day component. So to be consistent with the current implementation we'll not change this behavior and allow it to be used in Continuous Aggregates.

Disable-check: force-changelog-file

### Notes
In order to make less painful the manual backport we also backported #6939