### PR TITLE
Add known flaky tests to linux32bit CI

### DIFF
--- a/.github/workflows/linux-32bit-build-and-test.yaml
+++ b/.github/workflows/linux-32bit-build-and-test.yaml
@@ -44,7 +44,7 @@ jobs:
         CC: clang-14
         CXX: clang++-14
         DEBIAN_FRONTEND: noninteractive
-        IGNORES: "append-* transparent_decompression-* transparent_decompress_chunk-* pg_dump telemetry"
+        IGNORES: "append-* transparent_decompression-* transparent_decompress_chunk-* pg_dump telemetry bgw_db_scheduler*"
         SKIPS: chunk_adaptive histogram_test-*
         EXTENSIONS: "postgres_fdw test_decoding"
     strategy:


### PR DESCRIPTION
The `bgw_db_scheduler*` are known to be a bit flaky and the results are ignored in normal Linux/MacOS CI but currently Linux32bit don't use the gh_matrix_builder.py so those tests are not added by default.

Disable-check: force-changelog-file
