### PR TITLE
Release 2.15.2

### DIFF
--- a/.unreleased/pr_6978
+++ b/.unreleased/pr_6978
@@ -1,1 +1,0 @@
-Fixes: #6978 Fix segfault in compress_chunk with primary space partition

--- a/.unreleased/pr_6992
+++ b/.unreleased/pr_6992
@@ -1,2 +1,0 @@
-Fixes: #6975 Fix sort pushdown for partially compressed chunks
-Thanks: @srieding for reporting an issue with partially compressed chunks and ordering on joined columns

--- a/.unreleased/pr_6993
+++ b/.unreleased/pr_6993
@@ -1,1 +1,0 @@
-Fixes: #6993 Disallow hash partitioning on primary column 

--- a/.unreleased/pr_6996
+++ b/.unreleased/pr_6996
@@ -1,2 +1,0 @@
-Fixes: #6976 Fix removal of metadata function and update script
-Thanks: @gugu for reporting the issue with catalog corruption due to update

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,27 @@
 `psql` with the `-X` flag to prevent any `.psqlrc` commands from
 accidentally triggering the load of a previous DB version.**
 
+## 2.15.2 (2024-06-07)
+
+This release contains bug fixes since the 2.15.1 release. Best
+practice is to upgrade at the next available opportunity.
+
+**Migrating from self-hosted TimescaleDB v2.14.x and earlier**
+
+After you run `ALTER EXTENSION`, you must run [this SQL script](https://github.com/timescale/timescaledb-extras/blob/master/utils/2.15.X-fix_hypertable_foreign_keys.sql). For more details, see the following pull request [#6797](https://github.com/timescale/timescaledb/pull/6797).
+
+If you are migrating from TimescaleDB v2.15.0 or v2.15.1, no changes are required.
+
+**Bugfixes**
+* #6975: Fix sort pushdown for partially compressed chunks.
+* #6976: Fix removal of metadata function and update script.
+* #6978: Fix segfault in `compress_chunk` with a primary space partition.
+* #6993: Disallow hash partitioning on primary column.
+
+**Thanks**
+* @gugu for reporting the issue with catalog corruption due to update.
+* @srieding for reporting an issue with partially compressed chunks and ordering on joined columns.
+
 ## 2.15.1 (2024-05-28)
 
 This release contains bug fixes since the 2.15.0 release.

--- a/sql/CMakeLists.txt
+++ b/sql/CMakeLists.txt
@@ -38,7 +38,8 @@ set(MOD_FILES
     updates/2.14.0--2.14.1.sql
     updates/2.14.1--2.14.2.sql
     updates/2.14.2--2.15.0.sql
-    updates/2.15.0--2.15.1.sql)
+    updates/2.15.0--2.15.1.sql
+    updates/2.15.1--2.15.2.sql)
 
 # The downgrade file to generate a downgrade script for the current version, as
 # specified in version.config

--- a/version.config
+++ b/version.config
@@ -1,3 +1,3 @@
 version = 2.16.0-dev
-update_from_version = 2.15.1
+update_from_version = 2.15.2
 downgrade_to_version = 2.15.1


### PR DESCRIPTION
This release contains performance improvements and bug fixes since the 2.15.0 release. Best practice is to upgrade at the next available opportunity.

**Migrating from self-hosted TimescaleDB v2.14.x and earlier**

After you run `ALTER EXTENSION`, you must run [this SQL script](https://github.com/timescale/timescaledb-extras/blob/master/utils/2.15.X-fix_hypertable_foreign_keys.sql). For more details, see the following pull request [#6797](https://github.com/timescale/timescaledb/pull/6797).

If you are migrating from TimescaleDB v2.15.0 or v2.15.1, no changes are required.

**Bugfixes**
* #6975: Fix sort pushdown for partially compressed chunks.
* #6976: Fix removal of metadata function and update script.
* #6978: Fix segfault in compress_chunk with primary space partition.
* #6993: Disallow hash partitioning on primary column.

**Thanks**
* @gugu for reporting the issue with catalog corruption due to update.
* @srieding for reporting an issue with partially compressed chunks and ordering on joined columns.

Disable-check: force-changelog-file
