### PR TITLE
Reduce drop_extension test flakiness

### DIFF
--- a/test/expected/drop_extension.out
+++ b/test/expected/drop_extension.out
@@ -71,7 +71,22 @@ SELECT * FROM drop_test;
 
 --test drops thru cascades of other objects
 \c :TEST_DBNAME :ROLE_SUPERUSER
-drop schema public cascade;
+-- Stop background workers to prevent them from interfering with the drop public schema
+SELECT _timescaledb_functions.stop_background_workers();
+ stop_background_workers 
+-------------------------
+ t
+(1 row)
+
+SET client_min_messages TO ERROR;
+REVOKE CONNECT ON DATABASE :TEST_DBNAME FROM public;
+SELECT count(pg_terminate_backend(pg_stat_activity.pid)) AS TERMINATED
+FROM pg_stat_activity
+WHERE pg_stat_activity.datname = :'TEST_DBNAME'
+AND pg_stat_activity.pid <> pg_backend_pid() \gset
+RESET client_min_messages;
+-- drop the public schema and all its objects
+DROP SCHEMA public CASCADE;
 NOTICE:  drop cascades to 3 other objects
 \dn
   List of schemas


### PR DESCRIPTION
In this regression test we check the `DROP SCHEMA public CASCADE;` for removing the extension objects stored in that schema. The problem is if at the same moment we're running a background job it will lead to a deadlock because the scheduler maintain information about each execution in the metadata tables that should be part of the cascade schema removal.

Forced stop the background jobs and also terminate any running job.

https://github.com/timescale/timescaledb/actions/runs/9424506293/job/25964852620

Disable-check: force-changelog-file
