### PR TITLE
Reduce bgw_job_stat_history test flakiness

### DIFF
--- a/tsl/test/expected/bgw_job_stat_history.out
+++ b/tsl/test/expected/bgw_job_stat_history.out
@@ -62,12 +62,6 @@ SELECT proc_schema, proc_name, sqlerrcode, err_message FROM timescaledb_informat
  public      | custom_job_error | 22012      | division by zero
 (1 row)
 
-SELECT _timescaledb_functions.stop_background_workers();
- stop_background_workers 
--------------------------
- t
-(1 row)
-
 -- Check current jobs status
 SELECT job_id, job_status, total_runs, total_successes, total_failures
 FROM timescaledb_information.job_stats
@@ -85,19 +79,6 @@ SELECT pg_reload_conf();
  pg_reload_conf 
 ----------------
  t
-(1 row)
-
-\c :TEST_DBNAME :ROLE_SUPERUSER
-SELECT _timescaledb_functions.start_background_workers();
- start_background_workers 
---------------------------
- t
-(1 row)
-
-SELECT pg_sleep(6);
- pg_sleep 
-----------
- 
 (1 row)
 
 SELECT scheduled FROM alter_job(:job_id_1, next_start => now());

--- a/tsl/test/sql/bgw_job_stat_history.sql
+++ b/tsl/test/sql/bgw_job_stat_history.sql
@@ -35,8 +35,6 @@ SELECT test.wait_for_job_to_run(:job_id_2, 1);
 SELECT count(*), succeeded FROM timescaledb_information.job_history WHERE job_id >= 1000 GROUP BY 2 ORDER BY 2;
 SELECT proc_schema, proc_name, sqlerrcode, err_message FROM timescaledb_information.job_history WHERE job_id >= 1000 AND succeeded IS FALSE;
 
-SELECT _timescaledb_functions.stop_background_workers();
-
 -- Check current jobs status
 SELECT job_id, job_status, total_runs, total_successes, total_failures
 FROM timescaledb_information.job_stats
@@ -46,10 +44,6 @@ ORDER BY job_id;
 -- Log all executions
 ALTER SYSTEM SET timescaledb.enable_job_execution_logging TO ON;
 SELECT pg_reload_conf();
-
-\c :TEST_DBNAME :ROLE_SUPERUSER
-SELECT _timescaledb_functions.start_background_workers();
-SELECT pg_sleep(6);
 
 SELECT scheduled FROM alter_job(:job_id_1, next_start => now());
 SELECT scheduled FROM alter_job(:job_id_2, next_start => now());


### PR DESCRIPTION
Removed the unecessary `start/stop` background workers during the test execution to avoid canceling any ongoing job execution leading to non-deterministic status checks.

https://github.com/timescale/timescaledb/actions/runs/9491560936/job/26157244186

Disable-check: force-changelog-file
