### PR TITLE
Relax some JOIN restrictions on CAggs

### DIFF
--- a/tsl/src/continuous_aggs/common.h
+++ b/tsl/src/continuous_aggs/common.h
@@ -100,7 +100,7 @@ typedef enum CaggRefreshCallContext
 		(selquery)->rtable = NULL;                                                                 \
 	} while (0);
 
-extern CAggTimebucketInfo cagg_validate_query(const Query *query, const bool finalized,
+extern CAggTimebucketInfo cagg_validate_query(const Query *orig_query, const bool finalized,
 											  const char *cagg_schema, const char *cagg_name,
 											  const bool is_cagg_create);
 extern Query *destroy_union_query(Query *q);

--- a/tsl/test/expected/cagg_errors.out
+++ b/tsl/test/expected/cagg_errors.out
@@ -37,7 +37,8 @@ CREATE MATERIALIZED VIEW mat_m1 WITH (timescaledb.continuous, timescaledb.materi
 as
 select a, count(*) from mat_t1
 group by a WITH NO DATA;
-ERROR:  table "mat_t1" is not a hypertable
+ERROR:  invalid continuous aggregate view
+DETAIL:  At least one hypertable should be used in the view definition.
 -- no group by
 CREATE MATERIALIZED VIEW mat_m1 WITH (timescaledb.continuous, timescaledb.materialized_only=false)
 as
@@ -119,6 +120,7 @@ from
 from conditions ) q
  group by time_bucket('1week', timec) , location  WITH NO DATA;
 ERROR:  invalid continuous aggregate view
+DETAIL:  Sub-queries are not supported in FROM clause.
 CREATE MATERIALIZED VIEW mat_m1 WITH (timescaledb.continuous, timescaledb.materialized_only=false)
 AS
 select * from
@@ -194,6 +196,7 @@ from conditions tablesample bernoulli(0.2)
  group by time_bucket('1week', timec) , location
  WITH NO DATA;
 ERROR:  invalid continuous aggregate view
+DETAIL:  TABLESAMPLE is not supported in continuous aggregate.
 -- ONLY in from clause
 CREATE MATERIALIZED VIEW mat_m1 WITH (timescaledb.continuous, timescaledb.materialized_only=false)
 AS
@@ -201,6 +204,7 @@ Select sum(humidity), avg(temperature::int4)
 from ONLY conditions
  group by time_bucket('1week', timec) , location  WITH NO DATA;
 ERROR:  invalid continuous aggregate view
+DETAIL:  FROM ONLY is not allowed in continuous aggregate.
 --grouping sets and variants
 CREATE MATERIALIZED VIEW mat_m1 WITH (timescaledb.continuous, timescaledb.materialized_only=false)
 AS
@@ -645,7 +649,7 @@ ERROR:  compression not enabled on "i2980"
 -- cagg on normal view should error out
 CREATE VIEW v1 AS SELECT now() AS time;
 CREATE MATERIALIZED VIEW cagg1 WITH (timescaledb.continuous, timescaledb.materialized_only=false) AS SELECT time_bucket('1h',time) FROM v1 GROUP BY 1;
-ERROR:  invalid continuous aggregate query
+ERROR:  invalid continuous aggregate view
 -- cagg on normal view should error out
 CREATE MATERIALIZED VIEW matv1 AS SELECT now() AS time;
 CREATE MATERIALIZED VIEW cagg1 WITH (timescaledb.continuous, timescaledb.materialized_only=false) AS SELECT time_bucket('1h',time) FROM matv1 GROUP BY 1;

--- a/tsl/test/expected/cagg_joins.out
+++ b/tsl/test/expected/cagg_joins.out
@@ -1,20 +1,17 @@
 -- This file and its contents are licensed under the Timescale License.
 -- Please see the included NOTICE for copyright information and
 -- LICENSE-TIMESCALE for a copy of the license.
-\set ON_ERROR_STOP 0
 \set VERBOSITY default
 CREATE TABLE conditions(
   day TIMESTAMPTZ NOT NULL,
   city text NOT NULL,
   temperature INT NOT NULL,
-device_id int NOT NULL);
-SELECT create_hypertable(
-  'conditions', 'day',
-  chunk_time_interval => INTERVAL '1 day'
+  device_id int NOT NULL
 );
-    create_hypertable    
--------------------------
- (1,public,conditions,t)
+SELECT table_name FROM create_hypertable('conditions', 'day', chunk_time_interval => INTERVAL '1 day');
+ table_name 
+------------
+ conditions
 (1 row)
 
 INSERT INTO conditions (day, city, temperature, device_id) VALUES
@@ -33,25 +30,22 @@ INSERT INTO conditions (day, city, temperature, device_id) VALUES
   ('2021-06-26', 'Moscow', 32,3),
   ('2021-06-27', 'Moscow', 31,3);
 CREATE TABLE conditions_dup AS SELECT * FROM conditions;
-SELECT create_hypertable(
-  'conditions_dup', 'day',
-  chunk_time_interval => INTERVAL '1 day',
-  migrate_data => true
-);
+SELECT table_name FROM create_hypertable('conditions_dup', 'day', chunk_time_interval => INTERVAL '1 day', migrate_data => true);
 NOTICE:  adding not-null constraint to column "day"
 DETAIL:  Dimensions cannot have NULL values.
 NOTICE:  migrating data to chunks
 DETAIL:  Migration might take a while depending on the amount of data.
-      create_hypertable      
------------------------------
- (2,public,conditions_dup,t)
+   table_name   
+----------------
+ conditions_dup
 (1 row)
 
 CREATE TABLE devices ( device_id int not null, name text, location text);
 INSERT INTO devices values (1, 'thermo_1', 'Moscow'), (2, 'thermo_2', 'Berlin'),(3, 'thermo_3', 'London'),(4, 'thermo_4', 'Stockholm');
+CREATE TABLE location (location_id INTEGER, name TEXT);
+INSERT INTO location VALUES (1, 'Moscow'), (2, 'Berlin'), (3, 'London'), (4, 'Stockholm');
 CREATE TABLE devices_dup AS SELECT * FROM devices;
 CREATE VIEW devices_view AS SELECT * FROM devices;
--- Working cases
 -- Cagg with inner join + realtime  aggregate
 CREATE MATERIALIZED VIEW cagg_realtime
 WITH (timescaledb.continuous, timescaledb.materialized_only = FALSE) AS
@@ -289,7 +283,7 @@ SELECT * FROM cagg_realtime_using ORDER BY bucket, name;
 (15 rows)
 
 -- Reorder tables in FROM clause
--- Cagg with inner join + realtime  aggregate
+-- Cagg with inner join + realtime aggregate
 CREATE MATERIALIZED VIEW cagg_realtime_reorder
 WITH (timescaledb.continuous, timescaledb.materialized_only = FALSE) AS
 SELECT time_bucket(INTERVAL '1 day', day) AS bucket,
@@ -730,7 +724,7 @@ SELECT * FROM cagg_reorder_using;
  Wed Jun 30 17:00:00 2021 PDT | 28.0000000000000000 | thermo_3
 (16 rows)
 
---Create CAgg with join and additional WHERE conditions
+-- Create CAgg with join and additional WHERE conditions
 CREATE MATERIALIZED VIEW cagg_more_conds
 WITH (timescaledb.continuous, timescaledb.materialized_only = FALSE) AS
 SELECT time_bucket(INTERVAL '1 day', day) AS bucket,
@@ -749,7 +743,7 @@ SELECT * FROM cagg_more_conds ORDER BY bucket;
  Thu Jun 24 17:00:00 2021 PDT | 32.0000000000000000 | thermo_3
 (2 rows)
 
---Cagg with more conditions and USING clause
+-- Cagg with more conditions and USING clause
 CREATE MATERIALIZED VIEW cagg_more_conds_using
 WITH (timescaledb.continuous, timescaledb.materialized_only = FALSE) AS
 SELECT time_bucket(INTERVAL '1 day', day) AS bucket,
@@ -768,7 +762,7 @@ SELECT * FROM cagg_more_conds_using ORDER BY bucket;
  Thu Jun 24 17:00:00 2021 PDT | 32.0000000000000000 | thermo_3
 (2 rows)
 
--- Nested CAgg over a CAgg with join
+-- Hierarchical CAgg with join
 CREATE MATERIALIZED VIEW cagg_on_cagg
 WITH (timescaledb.continuous, timescaledb.materialized_only=true) AS
 SELECT time_bucket(INTERVAL '1 day', bucket) AS bucket,
@@ -838,7 +832,7 @@ DROP MATERIALIZED VIEW cagg_on_cagg_join CASCADE;
 NOTICE:  drop cascades to 2 other objects
 DETAIL:  drop cascades to table _timescaledb_internal._hyper_18_61_chunk
 drop cascades to table _timescaledb_internal._hyper_18_62_chunk
---Create CAgg with join and ORDER BY
+-- Create CAgg with join and ORDER BY
 CREATE MATERIALIZED VIEW cagg_ordered
 WITH (timescaledb.continuous, timescaledb.materialized_only = FALSE) AS
 SELECT time_bucket(INTERVAL '1 day', day) AS bucket,
@@ -921,8 +915,7 @@ DROP MATERIALIZED VIEW cagg_nested CASCADE;
 NOTICE:  drop cascades to 2 other objects
 DETAIL:  drop cascades to table _timescaledb_internal._hyper_23_71_chunk
 drop cascades to table _timescaledb_internal._hyper_23_72_chunk
---Error cases
---CAgg with multiple join conditions without JOIN clause
+-- CAgg with multiple join conditions without JOIN clause
 CREATE MATERIALIZED VIEW cagg_more_joins_conds
 WITH (timescaledb.continuous, timescaledb.materialized_only = FALSE) AS
 SELECT time_bucket(INTERVAL '1 day', day) AS bucket,
@@ -934,19 +927,19 @@ FROM conditions JOIN devices ON conditions.device_id = devices.device_id
 AND conditions.city = devices.location AND
       conditions.temperature > 28
 GROUP BY name, bucket;
-ERROR:  invalid continuous aggregate view
-DETAIL:  Unsupported expression in join clause.
-HINT:  Only equality conditions are supported in continuous aggregates.
-CREATE  TABLE mat_t1( a integer, b integer,c TEXT);
---With LATERAL multiple tables in new format
+NOTICE:  refreshing continuous aggregate "cagg_more_joins_conds"
+HINT:  Use WITH NO DATA if you do not want to refresh the continuous aggregate on creation.
+-- With LATERAL multiple tables in new format
+CREATE TABLE mat_t1(a integer, b integer, c TEXT);
 CREATE MATERIALIZED VIEW mat_m1 WITH (timescaledb.continuous, timescaledb.materialized_only = FALSE)
-as
-select temperature, count(*) from conditions,
-LATERAL (Select * from mat_t1 where a = conditions.temperature) q
-group by temperature WITH NO DATA;
-ERROR:  invalid continuous aggregate view
-DETAIL:  Lateral joins are not supported in FROM clause.
---With FROM clause has view
+AS
+SELECT time_bucket(INTERVAL '1 day', day) AS bucket, temperature, count(*) from conditions,
+LATERAL (SELECT * FROM mat_t1 WHERE mat_t1.a = conditions.temperature) q
+GROUP BY bucket, temperature;
+NOTICE:  refreshing continuous aggregate "mat_m1"
+HINT:  Use WITH NO DATA if you do not want to refresh the continuous aggregate on creation.
+-- With FROM clause has view
+\set ON_ERROR_STOP 0
 CREATE MATERIALIZED VIEW cagg_view
 WITH (timescaledb.continuous, timescaledb.materialized_only = TRUE) AS
 SELECT time_bucket(INTERVAL '1 day', day) AS bucket,
@@ -957,7 +950,7 @@ FROM conditions, devices_view
 WHERE conditions.device_id = devices_view.device_id
 GROUP BY name, bucket, devices_view.device_id;
 ERROR:  invalid continuous aggregate view
-DETAIL:  Views are not supported in FROM clause.
+DETAIL:  Views are not supported in continuous aggregates.
 CREATE TABLE cities(name text, currency text);
 INSERT INTO cities VALUES ('Berlin', 'EUR'), ('London', 'PND');
 --Error out when FROM clause has sub selects
@@ -1036,7 +1029,7 @@ FROM conditions, conditions_dup
 WHERE conditions.device_id = conditions_dup.device_id
 GROUP BY bucket;
 ERROR:  invalid continuous aggregate view
-DETAIL:  Multiple hypertables or normal tables are not supported in FROM clause.
+DETAIL:  Only one hypertable is allowed in continuous aggregate view.
 --Error out when join is between two normal tables
 CREATE MATERIALIZED VIEW cagg_nt
 WITH (timescaledb.continuous, timescaledb.materialized_only = TRUE) AS
@@ -1047,9 +1040,10 @@ FROM devices, devices_dup
 WHERE devices.device_id = devices_dup.device_id
 GROUP BY devices.name, devices.location;
 ERROR:  invalid continuous aggregate view
-DETAIL:  Multiple hypertables or normal tables are not supported in FROM clause.
---Error out when join is on non-equality condition
-CREATE MATERIALIZED VIEW cagg_unequal
+DETAIL:  At least one hypertable should be used in the view definition.
+\set ON_ERROR_STOP 1
+-- JOIN with non-equality condition
+CREATE MATERIALIZED VIEW cagg_unequal1
 WITH (timescaledb.continuous, timescaledb.materialized_only = TRUE) AS
 SELECT time_bucket(INTERVAL '1 day', day) AS bucket,
    AVG(temperature),
@@ -1057,10 +1051,10 @@ SELECT time_bucket(INTERVAL '1 day', day) AS bucket,
 FROM conditions, devices
 WHERE conditions.device_id <> devices.device_id
 GROUP BY name, bucket;
-ERROR:  invalid continuous aggregate view
-DETAIL:  Only equality conditions are supported in continuous aggregates.
---Unsupported join condition
-CREATE MATERIALIZED VIEW cagg_unequal
+NOTICE:  refreshing continuous aggregate "cagg_unequal1"
+HINT:  Use WITH NO DATA if you do not want to refresh the continuous aggregate on creation.
+-- JOIN with non-equality condition
+CREATE MATERIALIZED VIEW cagg_unequal2
 WITH (timescaledb.continuous, timescaledb.materialized_only = TRUE) AS
 SELECT time_bucket(INTERVAL '1 day', day) AS bucket,
    AVG(temperature),
@@ -1069,23 +1063,21 @@ FROM conditions, devices
 WHERE conditions.device_id = devices.device_id AND
       conditions.city like '%cow*'
 GROUP BY name, bucket;
-ERROR:  invalid continuous aggregate view
-DETAIL:  Unsupported expression in join clause.
-HINT:  Only equality conditions are supported in continuous aggregates.
---Unsupported join condition
-CREATE MATERIALIZED VIEW cagg_unequal
+NOTICE:  refreshing continuous aggregate "cagg_unequal2"
+HINT:  Use WITH NO DATA if you do not want to refresh the continuous aggregate on creation.
+-- JOIN with non-equality condition
+CREATE MATERIALIZED VIEW cagg_unequal3
 WITH (timescaledb.continuous, timescaledb.materialized_only = TRUE) AS
 SELECT time_bucket(INTERVAL '1 day', day) AS bucket,
    AVG(temperature),
    name
-FROM conditions, devices
-WHERE conditions.device_id = devices.device_id OR
-      conditions.city like '%cow*'
+FROM conditions
+JOIN devices ON conditions.device_id = devices.device_id OR conditions.city LIKE '%cow*'
 GROUP BY name, bucket;
-ERROR:  invalid continuous aggregate view
-DETAIL:  Unsupported expression in join clause.
-HINT:  Only equality conditions are supported in continuous aggregates.
---Error out when join type is not inner
+NOTICE:  refreshing continuous aggregate "cagg_unequal3"
+HINT:  Use WITH NO DATA if you do not want to refresh the continuous aggregate on creation.
+-- Error out when join type is not INNER or LEFT
+\set ON_ERROR_STOP 0
 CREATE MATERIALIZED VIEW cagg_outer
 WITH (timescaledb.continuous, timescaledb.materialized_only = TRUE) AS
 SELECT time_bucket(INTERVAL '1 day', day) AS bucket,
@@ -1094,8 +1086,9 @@ SELECT time_bucket(INTERVAL '1 day', day) AS bucket,
 FROM conditions FULL JOIN devices
 ON conditions.device_id = devices.device_id
 GROUP BY name, bucket;
-ERROR:  only inner joins are supported in continuous aggregates
-CREATE MATERIALIZED VIEW cagg_outer
+ERROR:  only INNER or LEFT joins are supported in continuous aggregates
+\set ON_ERROR_STOP 1
+CREATE MATERIALIZED VIEW cagg_left_join
 WITH (timescaledb.continuous, timescaledb.materialized_only = TRUE) AS
 SELECT time_bucket(INTERVAL '1 day', day) AS bucket,
    AVG(temperature),
@@ -1103,8 +1096,10 @@ SELECT time_bucket(INTERVAL '1 day', day) AS bucket,
 FROM conditions LEFT JOIN devices
 ON conditions.device_id = devices.device_id
 GROUP BY name, bucket;
-ERROR:  only inner joins are supported in continuous aggregates
+NOTICE:  refreshing continuous aggregate "cagg_left_join"
+HINT:  Use WITH NO DATA if you do not want to refresh the continuous aggregate on creation.
 --Error out for join between cagg and hypertable
+\set ON_ERROR_STOP 0
 CREATE MATERIALIZED VIEW cagg_nested_ht
 WITH (timescaledb.continuous, timescaledb.materialized_only = TRUE) AS
 SELECT time_bucket(INTERVAL '1 day', cagg.bucket) AS bucket,
@@ -1114,10 +1109,28 @@ FROM cagg_cagg cagg, conditions
 WHERE cagg.device_id = conditions.device_id
 GROUP BY 1,2,3;
 ERROR:  invalid continuous aggregate view
-DETAIL:  Views are not supported in FROM clause.
+DETAIL:  Only one hypertable is allowed in continuous aggregate view.
+\set ON_ERROR_STOP 1
+-- Multiple JOINS are supported
+CREATE MATERIALIZED VIEW conditions_by_day WITH (timescaledb.continuous) AS
+SELECT time_bucket(INTERVAL '1 day', conditions.day) AS bucket,
+   AVG(conditions.temperature),
+   devices.name AS device,
+   location.name AS location
+FROM conditions
+JOIN devices ON conditions.device_id = devices.device_id
+JOIN location ON location.name = devices.location
+GROUP BY bucket, devices.name, location.name;
+NOTICE:  refreshing continuous aggregate "conditions_by_day"
+HINT:  Use WITH NO DATA if you do not want to refresh the continuous aggregate on creation.
 \set VERBOSITY terse
 DROP TABLE conditions CASCADE;
-NOTICE:  drop cascades to 51 other objects
+NOTICE:  drop cascades to 67 other objects
+NOTICE:  drop cascades to 2 other objects
+NOTICE:  drop cascades to 2 other objects
+NOTICE:  drop cascades to 2 other objects
+NOTICE:  drop cascades to 2 other objects
+NOTICE:  drop cascades to 2 other objects
 NOTICE:  drop cascades to 2 other objects
 NOTICE:  drop cascades to 2 other objects
 NOTICE:  drop cascades to 2 other objects
@@ -1147,10 +1160,10 @@ CREATE TABLE conditions(
   value FLOAT8 NOT NULL,
   device_id int NOT NULL
 );
-SELECT create_hypertable('conditions', 'time', chunk_time_interval => INTERVAL '1 day');
-    create_hypertable     
---------------------------
- (24,public,conditions,t)
+SELECT table_name FROM create_hypertable('conditions', 'time', chunk_time_interval => INTERVAL '1 day');
+ table_name 
+------------
+ conditions
 (1 row)
 
 INSERT INTO conditions (time, value, device_id)

--- a/tsl/test/expected/cagg_utils.out
+++ b/tsl/test/expected/cagg_utils.out
@@ -123,9 +123,9 @@ SELECT * FROM cagg_validate_query($$ SELECT 1 FROM pg_catalog.pg_class $$);
 (1 row)
 
 SELECT * FROM cagg_validate_query($$ SELECT relkind, count(*) FROM pg_catalog.pg_class GROUP BY 1 $$);
- is_valid | error_level | error_code |            error_message             | error_detail | error_hint 
-----------+-------------+------------+--------------------------------------+--------------+------------
- f        | ERROR       | TS001      | table "pg_class" is not a hypertable |              | 
+ is_valid | error_level | error_code |           error_message           |                          error_detail                          | error_hint 
+----------+-------------+------------+-----------------------------------+----------------------------------------------------------------+------------
+ f        | ERROR       | 0A000      | invalid continuous aggregate view | At least one hypertable should be used in the view definition. | 
 (1 row)
 
 -- time_bucket with offset is not allowed
@@ -158,33 +158,33 @@ SELECT * FROM cagg_validate_query($$ SELECT time_bucket_gapfill('1 hour', "time"
 
 -- invalid join queries
 SELECT * FROM cagg_validate_query($$ SELECT time_bucket('1 hour', a."time"), count(*) FROM metrics a, metrics b GROUP BY 1 $$);
- is_valid | error_level | error_code |           error_message           |                              error_detail                               | error_hint 
-----------+-------------+------------+-----------------------------------+-------------------------------------------------------------------------+------------
- f        | ERROR       | 0A000      | invalid continuous aggregate view | Multiple hypertables or normal tables are not supported in FROM clause. | 
+ is_valid | error_level | error_code |           error_message           |                         error_detail                         | error_hint 
+----------+-------------+------------+-----------------------------------+--------------------------------------------------------------+------------
+ f        | ERROR       | 0A000      | invalid continuous aggregate view | Only one hypertable is allowed in continuous aggregate view. | 
 (1 row)
 
 SELECT * FROM cagg_validate_query($$ SELECT time_bucket('1 hour', "time"), count(*) FROM metrics, devices a, devices b GROUP BY 1 $$);
- is_valid | error_level | error_code |                                           error_message                                           | error_detail | error_hint 
-----------+-------------+------------+---------------------------------------------------------------------------------------------------+--------------+------------
- f        | ERROR       | 0A000      | only two tables with one hypertable and one normal table are allowed in continuous aggregate view |              | 
+ is_valid | error_level | error_code | error_message | error_detail | error_hint 
+----------+-------------+------------+---------------+--------------+------------
+ t        |             |            |               |              | 
 (1 row)
 
 SELECT * FROM cagg_validate_query($$ SELECT time_bucket('1 hour', "time"), device_id, count(*) FROM metrics LEFT JOIN devices ON id = device_id GROUP BY 1, 2 $$);
- is_valid | error_level | error_code |                      error_message                      | error_detail | error_hint 
-----------+-------------+------------+---------------------------------------------------------+--------------+------------
- f        | ERROR       | 0A000      | only inner joins are supported in continuous aggregates |              | 
+ is_valid | error_level | error_code | error_message | error_detail | error_hint 
+----------+-------------+------------+---------------+--------------+------------
+ t        |             |            |               |              | 
 (1 row)
 
 SELECT * FROM cagg_validate_query($$ SELECT time_bucket('1 hour', "time"), device_id, count(*) FROM metrics JOIN devices ON id = device_id AND name = 'foo' GROUP BY 1, 2 $$);
- is_valid | error_level | error_code |           error_message           |              error_detail              |                            error_hint                            
-----------+-------------+------------+-----------------------------------+----------------------------------------+------------------------------------------------------------------
- f        | ERROR       | 0A000      | invalid continuous aggregate view | Unsupported expression in join clause. | Only equality conditions are supported in continuous aggregates.
+ is_valid | error_level | error_code | error_message | error_detail | error_hint 
+----------+-------------+------------+---------------+--------------+------------
+ t        |             |            |               |              | 
 (1 row)
 
 SELECT * FROM cagg_validate_query($$ SELECT time_bucket('1 hour', "time"), device_id, count(*) FROM metrics JOIN devices ON id < device_id GROUP BY 1, 2 $$);
- is_valid | error_level | error_code |           error_message           |                           error_detail                           | error_hint 
-----------+-------------+------------+-----------------------------------+------------------------------------------------------------------+------------
- f        | ERROR       | 0A000      | invalid continuous aggregate view | Only equality conditions are supported in continuous aggregates. | 
+ is_valid | error_level | error_code | error_message | error_detail | error_hint 
+----------+-------------+------------+---------------+--------------+------------
+ t        |             |            |               |              | 
 (1 row)
 
 -- invalid caggs on caggs


### PR DESCRIPTION
Relax JOIN restrictions on CAggs by allowing
* INNER/LEFT join
* LATERAL join
* Join between 1 hypertable and N regular tables or materialized views
* Remove restriction of only ONE equality operator on JOIN clause

Closes #1446, #1516, #1717, #2400, #3314, #4088

Disable-check: force-changelog-file
