### PR TITLE
Reduce Postgres logs noise on regression tests

### DIFF
--- a/test/runner.sh
+++ b/test/runner.sh
@@ -11,6 +11,7 @@ TEST_PGUSER=${TEST_PGUSER:-postgres}
 TEST_INPUT_DIR=${TEST_INPUT_DIR:-${EXE_DIR}}
 TEST_OUTPUT_DIR=${TEST_OUTPUT_DIR:-${EXE_DIR}}
 TEST_SUPPORT_FILE=${CURRENT_DIR}/sql/utils/testsupport.sql
+TEST_SUPPORT_FILE_INIT=${CURRENT_DIR}/sql/utils/testsupport_init.sql
 
 # PGAPPNAME will be 'pg_regress/test' so we cut off the prefix
 # to get the name of the test
@@ -86,6 +87,13 @@ if mkdir ${TEST_OUTPUT_DIR}/.pg_init 2>/dev/null; then
     ALTER USER ${TEST_ROLE_3} WITH CREATEDB PASSWORD '${TEST_ROLE_3_PASS}';
     ALTER USER ${TEST_ROLE_4} WITH CREATEDB PASSWORD '${TEST_ROLE_4_PASS}';
 EOF
+  ${PSQL} "$@" -U $TEST_ROLE_SUPERUSER -d template1 \
+      -v ECHO=none \
+      -v MODULE_PATHNAME="'timescaledb-${EXT_VERSION}'" \
+      -v TSL_MODULE_PATHNAME="'timescaledb-tsl-${EXT_VERSION}'" \
+      -v TEST_SPINWAIT_ITERS=${TEST_SPINWAIT_ITERS} \
+      -f ${TEST_SUPPORT_FILE} >/dev/null 2>&1
+
   ${PSQL} "$@" -U ${USER} -d postgres -v ECHO=none -c "ALTER USER ${TEST_ROLE_SUPERUSER} WITH SUPERUSER;" >/dev/null
   touch ${TEST_OUTPUT_DIR}/.pg_init/done
 fi
@@ -104,7 +112,7 @@ ${PSQL} "$@" -U $TEST_ROLE_SUPERUSER -d ${TEST_DBNAME} \
     -v MODULE_PATHNAME="'timescaledb-${EXT_VERSION}'" \
     -v TSL_MODULE_PATHNAME="'timescaledb-tsl-${EXT_VERSION}'" \
     -v TEST_SPINWAIT_ITERS=${TEST_SPINWAIT_ITERS} \
-    -f ${TEST_SUPPORT_FILE} >/dev/null 2>&1
+    -f ${TEST_SUPPORT_FILE_INIT} >/dev/null 2>&1
 export TEST_DBNAME
 
 # we strip out any output between <exclude_from_test></exclude_from_test>
@@ -139,6 +147,7 @@ ${PSQL} -U ${TEST_PGUSER} \
      -v MODULE_PATHNAME="'timescaledb-${EXT_VERSION}'" \
      -v TSL_MODULE_PATHNAME="'timescaledb-tsl-${EXT_VERSION}'" \
      -v TEST_SUPPORT_FILE=${TEST_SUPPORT_FILE} \
+     -v TEST_SUPPORT_FILE_INIT=${TEST_SUPPORT_FILE_INIT} \
      "$@" -d ${TEST_DBNAME} 2>&1 | \
           sed  -e '/<exclude_from_test>/,/<\/exclude_from_test>/d' \
                -e 's! Memory: [0-9]\{1,\}kB!!' \

--- a/test/runner_shared.sh
+++ b/test/runner_shared.sh
@@ -11,6 +11,7 @@ TEST_PGUSER=${TEST_PGUSER:-postgres}
 TEST_INPUT_DIR=${TEST_INPUT_DIR:-${EXE_DIR}}
 TEST_OUTPUT_DIR=${TEST_OUTPUT_DIR:-${EXE_DIR}}
 TEST_SUPPORT_FILE=${CURRENT_DIR}/sql/utils/testsupport.sql
+TEST_SUPPORT_FILE_INIT=${CURRENT_DIR}/sql/utils/testsupport_init.sql
 
 # Read the extension version from version.config
 read -r VERSION < ${CURRENT_DIR}/../version.config
@@ -50,6 +51,7 @@ if mkdir ${TEST_OUTPUT_DIR}/.pg_init 2>/dev/null; then
      -v TEST_INPUT_DIR=${TEST_INPUT_DIR} \
      -v TEST_OUTPUT_DIR=${TEST_OUTPUT_DIR} \
      -v TEST_SUPPORT_FILE=${TEST_SUPPORT_FILE} \
+     -v TEST_SUPPORT_FILE_INIT=${TEST_SUPPORT_FILE_INIT} \
      -v TSL_MODULE_PATHNAME="'timescaledb-tsl-${EXT_VERSION}'" \
      "$@" -d ${TEST_DBNAME} < ${TEST_INPUT_DIR}/shared/sql/include/shared_setup.sql >/dev/null
   touch ${TEST_OUTPUT_DIR}/.pg_init/done

--- a/test/sql/utils/testsupport.sql
+++ b/test/sql/utils/testsupport.sql
@@ -2,13 +2,6 @@
 -- Please see the included NOTICE for copyright information and
 -- LICENSE-APACHE for a copy of the license.
 
-
-SELECT _timescaledb_functions.stop_background_workers();
-
--- Cleanup any system job stats that can lead to flaky test
-DELETE FROM _timescaledb_internal.bgw_job_stat_history WHERE job_id < 1000;
-DELETE FROM _timescaledb_internal.bgw_job_stat WHERE job_id < 1000;
-
 CREATE SCHEMA IF NOT EXISTS test;
 GRANT USAGE ON SCHEMA test TO PUBLIC;
 

--- a/test/sql/utils/testsupport_init.sql
+++ b/test/sql/utils/testsupport_init.sql
@@ -1,0 +1,9 @@
+-- This file and its contents are licensed under the Apache License 2.0.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-APACHE for a copy of the license.
+
+SELECT _timescaledb_functions.stop_background_workers();
+
+-- Cleanup any system job stats that can lead to flaky test
+DELETE FROM _timescaledb_internal.bgw_job_stat_history WHERE job_id < 1000;
+DELETE FROM _timescaledb_internal.bgw_job_stat WHERE job_id < 1000;

--- a/tsl/test/expected/exp_cagg_next_gen.out
+++ b/tsl/test/expected/exp_cagg_next_gen.out
@@ -150,16 +150,17 @@ NOTICE:  drop cascades to table _timescaledb_internal._hyper_5_19_chunk
 NOTICE:  drop cascades to table _timescaledb_internal._hyper_6_20_chunk
 -- Experimental functions using different schema for installation than PUBLIC
 \c :TEST_DBNAME :ROLE_SUPERUSER
-CREATE DATABASE test;
-\c test :ROLE_SUPERUSER
-CREATE SCHEMA test;
+\set TEST_DBNAME_2 :TEST_DBNAME _2
+CREATE DATABASE :TEST_DBNAME_2;
+\c :TEST_DBNAME_2 :ROLE_SUPERUSER
+CREATE SCHEMA test1;
 SET client_min_messages TO ERROR;
-CREATE EXTENSION timescaledb SCHEMA test;
+CREATE EXTENSION timescaledb SCHEMA test1;
 CREATE TABLE conditions(
   tstamp TIMESTAMP NOT NULL,
   city text NOT NULL,
   temperature INT NOT NULL);
-SELECT test.create_hypertable(
+SELECT test1.create_hypertable(
   'conditions', 'tstamp',
   chunk_time_interval => INTERVAL '1 day'
 );
@@ -182,7 +183,7 @@ RESET timescaledb.debug_allow_cagg_with_deprecated_funcs;
 CREATE MATERIALIZED VIEW conditions_summary_yearly
 WITH (timescaledb.continuous) AS
 SELECT city,
-       test.time_bucket('1 year', tstamp) AS bucket,
+       test1.time_bucket('1 year', tstamp) AS bucket,
        MIN(temperature),
        MAX(temperature)
 FROM conditions
@@ -192,7 +193,7 @@ SELECT bucket_func, bucket_width, bucket_origin, bucket_timezone, bucket_fixed_w
 FROM _timescaledb_catalog.continuous_aggs_bucket_function ORDER BY 1;
                                   bucket_func                                  | bucket_width | bucket_origin | bucket_timezone | bucket_fixed_width 
 -------------------------------------------------------------------------------+--------------+---------------+-----------------+--------------------
- test.time_bucket(interval,timestamp without time zone)                        | @ 1 year     |               |                 | f
+ test1.time_bucket(interval,timestamp without time zone)                       | @ 1 year     |               |                 | f
  timescaledb_experimental.time_bucket_ng(interval,timestamp without time zone) | @ 1 mon      |               |                 | f
 (2 rows)
 
@@ -200,4 +201,4 @@ FROM _timescaledb_catalog.continuous_aggs_bucket_function ORDER BY 1;
 ALTER MATERIALIZED VIEW conditions_summary_monthly SET (timescaledb.materialized_only=false);
 ALTER MATERIALIZED VIEW conditions_summary_monthly SET (timescaledb.materialized_only=true);
 \c :TEST_DBNAME :ROLE_SUPERUSER
-DROP DATABASE test WITH (FORCE);
+DROP DATABASE :TEST_DBNAME_2 WITH (FORCE);

--- a/tsl/test/sql/exp_cagg_next_gen.sql
+++ b/tsl/test/sql/exp_cagg_next_gen.sql
@@ -121,19 +121,19 @@ DROP TABLE conditions CASCADE;
 -- Experimental functions using different schema for installation than PUBLIC
 \c :TEST_DBNAME :ROLE_SUPERUSER
 
-
-CREATE DATABASE test;
-\c test :ROLE_SUPERUSER
-CREATE SCHEMA test;
+\set TEST_DBNAME_2 :TEST_DBNAME _2
+CREATE DATABASE :TEST_DBNAME_2;
+\c :TEST_DBNAME_2 :ROLE_SUPERUSER
+CREATE SCHEMA test1;
 SET client_min_messages TO ERROR;
-CREATE EXTENSION timescaledb SCHEMA test;
+CREATE EXTENSION timescaledb SCHEMA test1;
 
 CREATE TABLE conditions(
   tstamp TIMESTAMP NOT NULL,
   city text NOT NULL,
   temperature INT NOT NULL);
 
-SELECT test.create_hypertable(
+SELECT test1.create_hypertable(
   'conditions', 'tstamp',
   chunk_time_interval => INTERVAL '1 day'
 );
@@ -153,7 +153,7 @@ RESET timescaledb.debug_allow_cagg_with_deprecated_funcs;
 CREATE MATERIALIZED VIEW conditions_summary_yearly
 WITH (timescaledb.continuous) AS
 SELECT city,
-       test.time_bucket('1 year', tstamp) AS bucket,
+       test1.time_bucket('1 year', tstamp) AS bucket,
        MIN(temperature),
        MAX(temperature)
 FROM conditions
@@ -168,4 +168,4 @@ ALTER MATERIALIZED VIEW conditions_summary_monthly SET (timescaledb.materialized
 ALTER MATERIALIZED VIEW conditions_summary_monthly SET (timescaledb.materialized_only=true);
 
 \c :TEST_DBNAME :ROLE_SUPERUSER
-DROP DATABASE test WITH (FORCE);
+DROP DATABASE :TEST_DBNAME_2 WITH (FORCE);


### PR DESCRIPTION
For each regression database created we execute the `test/sql/utils/testsupport.sql` to setup some test stuff before actually run the tests. Once we config Postgres to emit log for all executed statements we create a log of noise on logs about this setup SQL script.

Change it to run the setup SQL script on the `template1` database so all new created databases will contain all the necessary objects for run the tests.

Disable-check: force-changelog-file
