### PR TITLE
Make reorder_vs_insert deterministic

### DIFF
--- a/.unreleased/fix_7051
+++ b/.unreleased/fix_7051
@@ -1,0 +1,1 @@
+Fixes: #7051 Make reorder_vs_insert deterministic

--- a/tsl/test/isolation/expected/reorder_vs_insert.out
+++ b/tsl/test/isolation/expected/reorder_vs_insert.out
@@ -76,9 +76,9 @@ step Rc: COMMIT;
 starting permutation: R1 I1 Ic Bc Rc
 step R1: SELECT reorder_chunk_i((SELECT show_chunks('ts_reorder_test') LIMIT 1), 'ts_reorder_test_time_idx', wait_on => 'waiter'); <waiting ...>
 step I1: INSERT INTO ts_reorder_test VALUES (1, 19.5, 3); <waiting ...>
-step I1: <... completed>
 step R1: <... completed>
 ERROR:  canceling statement due to lock timeout
+step I1: <... completed>
 step Ic: COMMIT;
 step Bc: COMMIT;
 step Rc: COMMIT;

--- a/tsl/test/isolation/specs/reorder_vs_insert.spec.in
+++ b/tsl/test/isolation/specs/reorder_vs_insert.spec.in
@@ -44,12 +44,12 @@ step "Bc"   { COMMIT; }
 
 permutation "Bc" "I1" "Ic" "R1" "Rc"
 permutation "Bc" "I1" "R1" "Ic" "Rc"
-permutation "Bc" "I1" "R1" "Rc" "Ic"
+permutation "Bc" "I1" "R1"(*) "Rc" "Ic"
 
 permutation "Bc" "R1" "Rc" "I1" "Ic"
 permutation "Bc" "R1" "I1" "Rc" "Ic"
 permutation "Bc" "R1" "I1" "Ic" "Rc"
 
-permutation "R1" "I1" "Ic" "Bc" "Rc"
+permutation "R1" "I1"(R1) "Ic" "Bc" "Rc"
 permutation "R1" "I1" "Bc" "Rc" "Ic"
 permutation "I1" "R1" "Bc" "Rc" "Ic"


### PR DESCRIPTION
Add markers to steps in `reorder_vs_insert` that should be waiting to prevent non-determinsm when running.