### PR TITLE
Make cost-based decision about partial aggregation paths

### DIFF
--- a/src/planner/partialize.c
+++ b/src/planner/partialize.c
@@ -851,6 +851,10 @@ ts_pushdown_partial_agg(PlannerInfo *root, Hypertable *ht, RelOptInfo *input_rel
 	if (partially_grouped_rel->pathlist == NIL)
 		return;
 
+	/* Prefer our paths */
+	output_rel->pathlist = NIL;
+	output_rel->partial_pathlist = NIL;
+
 	/* Finalize the created partially aggregated paths by adding a 'Finalize Aggregate' node on top
 	 * of them. */
 	AggClauseCosts *agg_final_costs = &extra_data->agg_final_costs;

--- a/src/planner/partialize.c
+++ b/src/planner/partialize.c
@@ -851,10 +851,6 @@ ts_pushdown_partial_agg(PlannerInfo *root, Hypertable *ht, RelOptInfo *input_rel
 	if (partially_grouped_rel->pathlist == NIL)
 		return;
 
-	/* Prefer our paths */
-	output_rel->pathlist = NIL;
-	output_rel->partial_pathlist = NIL;
-
 	/* Finalize the created partially aggregated paths by adding a 'Finalize Aggregate' node on top
 	 * of them. */
 	AggClauseCosts *agg_final_costs = &extra_data->agg_final_costs;

--- a/src/planner/planner.c
+++ b/src/planner/planner.c
@@ -1571,11 +1571,11 @@ timescaledb_create_upper_paths_hook(PlannerInfo *root, UpperRelationKind stage,
 		if (parse->hasAggs)
 			ts_preprocess_first_last_aggregates(root, root->processed_tlist);
 
-		if (ts_guc_enable_chunkwise_aggregation)
-			ts_pushdown_partial_agg(root, ht, input_rel, output_rel, extra);
-
 		if (!partials_found)
 			ts_plan_add_hashagg(root, input_rel, output_rel);
+
+		if (ts_guc_enable_chunkwise_aggregation)
+			ts_pushdown_partial_agg(root, ht, input_rel, output_rel, extra);
 	}
 }
 


### PR DESCRIPTION
Currently we just remove all existing paths, but after that we add a hash aggregation path (ts_plan_add_hashagg()) which we can prefer based on the cost, which leads to weird behavior.