### PR TITLE
Fix scankey where consttype is different from var

### DIFF
--- a/.unreleased/fix_7055
+++ b/.unreleased/fix_7055
@@ -1,0 +1,1 @@
+Fixes: #7055 Fix scankey where consttype is different from var

--- a/tsl/test/expected/compression.out
+++ b/tsl/test/expected/compression.out
@@ -2847,3 +2847,31 @@ COPY compressed_table (time,a,b,c) FROM stdin;
 ERROR:  tuple decompression limit exceeded by operation
 \set ON_ERROR_STOP 1
 RESET timescaledb.max_tuples_decompressed_per_dml_transaction;
+-- Test decompression with DML which compares int8 to int4
+CREATE TABLE hyper_84 (time timestamptz, device int8, location int8, temp float8);
+SELECT create_hypertable('hyper_84', 'time', create_default_indexes => false);
+NOTICE:  adding not-null constraint to column "time"
+   create_hypertable    
+------------------------
+ (51,public,hyper_84,t)
+(1 row)
+
+INSERT INTO hyper_84 VALUES ('2024-01-01', 1, 1, 1.0);
+ALTER TABLE hyper_84 SET (timescaledb.compress, timescaledb.compress_segmentby='device');
+NOTICE:  default order by for hypertable "hyper_84" is set to ""time" DESC"
+SELECT compress_chunk(ch) FROM show_chunks('hyper_84') ch;
+              compress_chunk               
+-------------------------------------------
+ _timescaledb_internal._hyper_51_110_chunk
+(1 row)
+
+-- indexscan for decompression: UPDATE
+UPDATE hyper_84 SET temp = 100 where device = 1;
+SELECT compress_chunk(ch) FROM show_chunks('hyper_84') ch;
+              compress_chunk               
+-------------------------------------------
+ _timescaledb_internal._hyper_51_110_chunk
+(1 row)
+
+-- indexscan for decompression: DELETE
+DELETE FROM hyper_84 WHERE device = 1;


### PR DESCRIPTION
When we decide to use an indexscan on the segment-by column for any query for decompression, then it's possible that the RHS constant type is not the same as the variable on the LHS of the comparison.

A typical example is "int8 = int4" comparison. While this works ok on 64 bit instances, it can crash on i386 ones. The issue is in the scankey that we build for segment-by columns. Even though we specify the valid "opcode" for cases where the arguments types don't match we also need to specify the "sk_subtype" appropriately.

Fixes #7039