### PR TITLE
Quell a couple of coverity warnings

### DIFF
--- a/tsl/src/bgw_policy/policies_v2.c
+++ b/tsl/src/bgw_policy/policies_v2.c
@@ -90,7 +90,7 @@ validate_and_create_policies(policies_info all_policies, bool if_exists)
 {
 	int refresh_job_id = 0, compression_job_id = 0, retention_job_id = 0;
 	int64 refresh_interval = 0, compress_after = 0, drop_after = 0, drop_after_HT = 0;
-	int64 start_offset = 0, end_offset = 0, refresh_window_size = 0, refresh_total_interval = 0;
+	int64 start_offset = 0, end_offset = 0, refresh_total_interval = 0;
 	List *jobs = NIL;
 	BgwJob *orig_ht_reten_job = NULL;
 
@@ -157,14 +157,20 @@ validate_and_create_policies(policies_info all_policies, bool if_exists)
 	/* Per policy checks */
 	if (all_policies.refresh && !IS_INTEGER_TYPE(all_policies.partition_type))
 	{
-		/* Check if there are any gaps in the refresh policy */
-		refresh_window_size = (start_offset == ts_time_get_max(all_policies.partition_type) ||
-							   end_offset == ts_time_get_min(all_policies.partition_type)) ?
-								  start_offset :
-								  start_offset - end_offset;
+		/*
+		 * Check if there are any gaps in the refresh policy. The below code is
+		 * a little suspect. But since we are planning to do away with the
+		 * add_policies/remove_policies APIs there's no need to spend a lot
+		 * of time on fixing it below.
+		 */
+		int64 refresh_window_size = (start_offset == ts_time_get_max(all_policies.partition_type) ||
+									 end_offset == ts_time_get_min(all_policies.partition_type)) ?
+										start_offset :
+									end_offset > start_offset ? start_offset :
+																start_offset - end_offset;
 
 		/* if refresh_interval is greater than half of refresh_window_size, then there are gaps */
-		if (refresh_interval > refresh_window_size / 2)
+		if (refresh_interval > (refresh_window_size / 2))
 			emit_error(err_gap_refresh);
 
 		/* Disallow refreshed data to be deleted */

--- a/tsl/src/compression/dictionary.c
+++ b/tsl/src/compression/dictionary.c
@@ -478,8 +478,9 @@ tsl_text_dictionary_decompress_all(Datum compressed, Oid element_type, MemoryCon
 		Simple8bRleBitmap nulls = simple8brle_bitmap_decompress(nulls_serialized);
 		CheckCompressedData(n_notnull + simple8brle_bitmap_num_ones(&nulls) == n_total);
 
-		int current_notnull_element = n_notnull - 1;
-		for (int i = n_total - 1; i >= 0; i--)
+		/* current_notnull_element needs to go below 0, so use signed type */
+		int64 current_notnull_element = n_notnull - 1;
+		for (int64 i = n_total - 1; i >= 0; i--)
 		{
 			Assert(i >= current_notnull_element);
 

--- a/tsl/test/expected/cagg_policy.out
+++ b/tsl/test/expected/cagg_policy.out
@@ -397,7 +397,8 @@ SELECT timescaledb_experimental.remove_policies('continuous_agg_max_mat_date', f
 ERROR:  "continuous_agg_max_mat_date" is not a continuous aggregate
 -- No policy is added if one errors out
 SELECT timescaledb_experimental.add_policies('max_mat_view_date', refresh_start_offset => '1 day'::interval, refresh_end_offset => '2 day'::interval, compress_after => '20 days'::interval, drop_after => '25 days'::interval);
-ERROR:  there are gaps in refresh policy
+ERROR:  policy refresh window too small
+DETAIL:  The start and end offsets must cover at least two buckets in the valid time range of type "date".
 SELECT timescaledb_experimental.show_policies('max_mat_view_date');
  show_policies 
 ---------------


### PR DESCRIPTION
Theoretical overflow calculations fixed in a couple of places.

Disable-check: force-changelog-file