### PR TITLE
Don't assign reviewers for PRs not to main branch

### DIFF
--- a/.github/workflows/pr-handling.yaml
+++ b/.github/workflows/pr-handling.yaml
@@ -24,7 +24,7 @@ jobs:
         run: |
           echo ${{ !github.event.pull_request.draft }}
           echo ${{ github.event.pull_request.base }}
-          echo ${{ toJSON(github.event.pull_request.base) }}
+          echo "${{ toJSON(github.event.pull_request.base) }}"
           echo ${{ github.event.pull_request.base.ref == 'main' }}
           echo ${{ !github.event.pull_request.draft && github.event.pull_request.base.ref == 'main' }}
 

--- a/.github/workflows/pr-handling.yaml
+++ b/.github/workflows/pr-handling.yaml
@@ -11,8 +11,9 @@ name: Assign PR to author and reviewers
 #       committed code should _NOT_ be touched in any case.
 
 "on":
-  pull_request_target:
-    types: [ opened, reopened, ready_for_review ]
+#  pull_request_target:
+#    types: [ opened, reopened, ready_for_review ]
+  pull_request:
 
 jobs:
   assign-pr:

--- a/.github/workflows/pr-handling.yaml
+++ b/.github/workflows/pr-handling.yaml
@@ -11,23 +11,10 @@ name: Assign PR to author and reviewers
 #       committed code should _NOT_ be touched in any case.
 
 "on":
-#  pull_request_target:
-#    types: [ opened, reopened, ready_for_review ]
-  pull_request:
+  pull_request_target:
+    types: [ opened, reopened, ready_for_review ]
 
 jobs:
-  debug:
-    name: Debug job
-    runs-on: ubuntu-latest
-    steps:
-      - name: Debug step
-        run: |
-          echo ${{ !github.event.pull_request.draft }}
-          echo ${{ github.event.pull_request.base }}
-          echo "${{ toJSON(github.event.pull_request.base) }}"
-          echo ${{ github.event.pull_request.base.ref == 'main' }}
-          echo ${{ !github.event.pull_request.draft && github.event.pull_request.base.ref == 'main' }}
-
   assign-pr:
     name: Assign PR to author
     permissions:
@@ -39,7 +26,7 @@ jobs:
   ask-review:
     name: Run pull-review
     runs-on: ubuntu-latest
-    if: ${{ !github.event.pull_request.draft && github.event.pull_request.base == 'main' }}
+    if: ${{ !github.event.pull_request.draft && github.event.pull_request.base.ref == 'main' }}
     steps:
       - uses: actions/checkout@v4
       - name: Run pull-review with docker
@@ -52,9 +39,3 @@ jobs:
         run: |
           PR_URL="https://github.com/${OWNER}/${REPO}/pull/${PULL_REQUEST_NUMBER}"
           docker run ghcr.io/imsky/pull-review "$PR_URL" --github-token "${GITHUB_TOKEN}"
-      - name: Debug
-        run: |
-          echo ${{ !github.event.pull_request.draft }}
-          echo ${{ github.event.pull_request.base }}
-          echo ${{ github.event.pull_request.base == 'main' }}
-          echo ${{ !github.event.pull_request.draft && github.event.pull_request.base == 'main' }}

--- a/.github/workflows/pr-handling.yaml
+++ b/.github/workflows/pr-handling.yaml
@@ -24,8 +24,9 @@ jobs:
         run: |
           echo ${{ !github.event.pull_request.draft }}
           echo ${{ github.event.pull_request.base }}
-          echo ${{ github.event.pull_request.base == 'main' }}
-          echo ${{ !github.event.pull_request.draft && github.event.pull_request.base == 'main' }}
+          echo ${{ toJSON(github.event.pull_request.base) }}
+          echo ${{ github.event.pull_request.base.ref == 'main' }}
+          echo ${{ !github.event.pull_request.draft && github.event.pull_request.base.ref == 'main' }}
 
   assign-pr:
     name: Assign PR to author

--- a/.github/workflows/pr-handling.yaml
+++ b/.github/workflows/pr-handling.yaml
@@ -16,6 +16,16 @@ name: Assign PR to author and reviewers
   pull_request:
 
 jobs:
+  debug:
+    name: Debug job
+    steps:
+      - name: Debug step
+        run: |
+          echo ${{ !github.event.pull_request.draft }}
+          echo ${{ github.event.pull_request.base }}
+          echo ${{ github.event.pull_request.base == 'main' }}
+          echo ${{ !github.event.pull_request.draft && github.event.pull_request.base == 'main' }}
+
   assign-pr:
     name: Assign PR to author
     permissions:

--- a/.github/workflows/pr-handling.yaml
+++ b/.github/workflows/pr-handling.yaml
@@ -18,6 +18,7 @@ name: Assign PR to author and reviewers
 jobs:
   debug:
     name: Debug job
+    runs-on: ubuntu-latest
     steps:
       - name: Debug step
         run: |

--- a/.github/workflows/pr-handling.yaml
+++ b/.github/workflows/pr-handling.yaml
@@ -26,7 +26,7 @@ jobs:
   ask-review:
     name: Run pull-review
     runs-on: ubuntu-latest
-    if: ${{ !github.event.pull_request.draft }}
+    if: ${{ !github.event.pull_request.draft && github.event.pull_request.base == 'main' }}
     steps:
       - uses: actions/checkout@v4
       - name: Run pull-review with docker
@@ -39,3 +39,9 @@ jobs:
         run: |
           PR_URL="https://github.com/${OWNER}/${REPO}/pull/${PULL_REQUEST_NUMBER}"
           docker run ghcr.io/imsky/pull-review "$PR_URL" --github-token "${GITHUB_TOKEN}"
+      - name: Debug
+        run: |
+          echo ${{ !github.event.pull_request.draft }}
+          echo ${{ github.event.pull_request.base }}
+          echo ${{ github.event.pull_request.base == 'main' }}
+          echo ${{ !github.event.pull_request.draft && github.event.pull_request.base == 'main' }}


### PR DESCRIPTION
We don't have the same review requirements for other branches.


Disable-check: force-changelog-file