### PR TITLE
Fix a bug in default orderby calc. in compression

### DIFF
--- a/.unreleased/fix_7064
+++ b/.unreleased/fix_7064
@@ -1,0 +1,1 @@
+Fixes: #7064 Fix a bug in default orderby calc. in compression 

--- a/sql/compression_defaults.sql
+++ b/sql/compression_defaults.sql
@@ -220,7 +220,7 @@ BEGIN
     INNER JOIN pg_namespace n ON (n.oid = c.relnamespace)
     WHERE c.oid = relation;
 
-    SELECT * INTO STRICT _hypertable_row FROM _timescaledb_catalog.hypertable h WHERE h.table_name = _table_name AND h.schema_name = schema_name;
+    SELECT * INTO STRICT _hypertable_row FROM _timescaledb_catalog.hypertable h WHERE h.table_name = _table_name AND h.schema_name = _schema_name;
 
     --start with the unique index columns minus the segment by columns
     with index_attr as (

--- a/tsl/test/expected/compression_defaults.out
+++ b/tsl/test/expected/compression_defaults.out
@@ -410,3 +410,39 @@ ALTER TABLE public.t1 SET (timescaledb.compress, timescaledb.compress_orderby = 
 WARNING:  there was some uncertainty picking the default segment by for the hypertable: You do not have any indexes on columns that can be used for segment_by and thus we are not using segment_by for compression. Please make sure you are not missing any indexes
 NOTICE:  default segment by for hypertable "t1" is set to ""
 RESET search_path;
+-- test same named objects in different schemas with default orderbys
+\c :TEST_DBNAME :ROLE_SUPERUSER
+CREATE SCHEMA schema1;
+CREATE SCHEMA schema2;
+GRANT ALL ON SCHEMA schema1, schema2 to public;
+\c :TEST_DBNAME :ROLE_DEFAULT_PERM_USER
+CREATE TABLE schema1.page_events2 (
+ time        TIMESTAMPTZ         NOT NULL,
+ page        TEXT              NOT NULL
+);
+SELECT create_hypertable('schema1.page_events2', 'time');
+      create_hypertable      
+-----------------------------
+ (15,schema1,page_events2,t)
+(1 row)
+
+ALTER TABLE schema1.page_events2 SET (
+ timescaledb.compress,
+ timescaledb.compress_segmentby = 'page'
+);
+NOTICE:  default order by for hypertable "page_events2" is set to ""time" DESC"
+CREATE TABLE schema2.page_events2 (
+ time        TIMESTAMPTZ         NOT NULL,
+ page        TEXT              NOT NULL
+);
+SELECT create_hypertable('schema2.page_events2', 'time');
+      create_hypertable      
+-----------------------------
+ (17,schema2,page_events2,t)
+(1 row)
+
+ALTER TABLE schema2.page_events2 SET (
+ timescaledb.compress,
+ timescaledb.compress_segmentby = 'page'
+);
+NOTICE:  default order by for hypertable "page_events2" is set to ""time" DESC"

--- a/tsl/test/sql/compression_defaults.sql
+++ b/tsl/test/sql/compression_defaults.sql
@@ -214,3 +214,33 @@ CREATE TABLE public.t1 (time timestamptz NOT NULL, segment_value text NOT NULL);
 SELECT public.create_hypertable('public.t1', 'time');
 ALTER TABLE public.t1 SET (timescaledb.compress, timescaledb.compress_orderby = 'segment_value');
 RESET search_path;
+
+-- test same named objects in different schemas with default orderbys
+\c :TEST_DBNAME :ROLE_SUPERUSER
+
+CREATE SCHEMA schema1;
+CREATE SCHEMA schema2;
+GRANT ALL ON SCHEMA schema1, schema2 to public;
+
+\c :TEST_DBNAME :ROLE_DEFAULT_PERM_USER
+CREATE TABLE schema1.page_events2 (
+ time        TIMESTAMPTZ         NOT NULL,
+ page        TEXT              NOT NULL
+);
+
+SELECT create_hypertable('schema1.page_events2', 'time');
+ALTER TABLE schema1.page_events2 SET (
+ timescaledb.compress,
+ timescaledb.compress_segmentby = 'page'
+);
+
+CREATE TABLE schema2.page_events2 (
+ time        TIMESTAMPTZ         NOT NULL,
+ page        TEXT              NOT NULL
+);
+
+SELECT create_hypertable('schema2.page_events2', 'time');
+ALTER TABLE schema2.page_events2 SET (
+ timescaledb.compress,
+ timescaledb.compress_segmentby = 'page'
+);


### PR DESCRIPTION
There was a "cute" typo in the query used for the calculation of default orderbys in the case of compression. Fixed that.