### PR TITLE
Don't use index column names

### DIFF
--- a/.unreleased/pr_7069
+++ b/.unreleased/pr_7069
@@ -1,0 +1,1 @@
+Fixes: #7069 Fix index column name usage


### PR DESCRIPTION
We must never use index column names to try to match relation column names between different relations as index column names are independent of relation column names and can get out of sync due to column renames.