### PR TITLE
Don't link against openssl directly

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -596,7 +596,10 @@ if(USE_OPENSSL AND (NOT PG_USE_OPENSSL))
   )
 endif(USE_OPENSSL AND (NOT PG_USE_OPENSSL))
 
-if(USE_OPENSSL)
+# While we dont link directly against OpenSSL on non-Windows, doing this on
+# Windows causes linker errors. So on Windows we link directly against the
+# OpenSSL libraries.
+if(USE_OPENSSL AND MSVC)
   # Try to find a local OpenSSL installation
   find_package(OpenSSL)
 
@@ -635,7 +638,7 @@ if(USE_OPENSSL)
     message(STATUS "OpenSSL libraries: ${_path}")
   endforeach()
   message(STATUS "Using OpenSSL version ${OPENSSL_VERSION}")
-endif(USE_OPENSSL)
+endif(USE_OPENSSL AND MSVC)
 
 if(CODECOVERAGE)
   message(STATUS "Code coverage is enabled.")

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -104,7 +104,9 @@ if(USE_OPENSSL)
   set(TS_USE_OPENSSL ${USE_OPENSSL})
   target_include_directories(${PROJECT_NAME} SYSTEM
                              PUBLIC ${OPENSSL_INCLUDE_DIR})
-  target_link_libraries(${PROJECT_NAME} ${OPENSSL_LIBRARIES})
+  if(MSVC)
+    target_link_libraries(${PROJECT_NAME} ${OPENSSL_LIBRARIES})
+  endif(MSVC)
 endif(USE_OPENSSL)
 
 configure_file(config.h.in config.h)

--- a/tsl/src/CMakeLists.txt
+++ b/tsl/src/CMakeLists.txt
@@ -29,9 +29,6 @@ set_target_properties(
   PROPERTIES OUTPUT_NAME ${TSL_LIBRARY_NAME}-${PROJECT_VERSION_MOD} PREFIX "")
 
 target_include_directories(${TSL_LIBRARY_NAME} PRIVATE ${PG_INCLUDEDIR})
-if(USE_OPENSSL)
-  target_include_directories(${TSL_LIBRARY_NAME} PRIVATE ${OPENSSL_INCLUDE_DIR})
-endif(USE_OPENSSL)
 
 target_compile_definitions(${TSL_LIBRARY_NAME} PUBLIC TS_TSL)
 target_compile_definitions(${TSL_LIBRARY_NAME} PUBLIC TS_SUBMODULE)


### PR DESCRIPTION
This patch changes our build process to no longer link against
openssl directly but instead rely on postgres linking it.
Linking to openssl directly is causing problems when the openssl
version we link against does not match the version postgres links
against. While this is easy to prevent where we fully control the
build process it is repeatedly causing problems e.g. in ABI tests.
This patch changes only changes the behaviour for non-Windows as
we are running into linker problems on Windows with this change.
Until we can find a workaround for those problems Windows binaries
we still link OpenSSL directly.

Disable-check: force-changelog-file