### PR TITLE
Fix bug in default segmentby calc. in compression

### DIFF
--- a/.unreleased/fix_7074
+++ b/.unreleased/fix_7074
@@ -1,0 +1,1 @@
+Fixes: #7074 Fix a bug in default segmentby calc. in compression

--- a/sql/compression_defaults.sql
+++ b/sql/compression_defaults.sql
@@ -24,7 +24,7 @@ BEGIN
     INNER JOIN pg_namespace n ON (n.oid = c.relnamespace)
     WHERE c.oid = relation;
 
-    SELECT * INTO STRICT _hypertable_row FROM _timescaledb_catalog.hypertable h WHERE h.table_name = _table_name AND h.schema_name = schema_name;
+    SELECT * INTO STRICT _hypertable_row FROM _timescaledb_catalog.hypertable h WHERE h.table_name = _table_name AND h.schema_name = _schema_name;
 
     --STEP 1 if column stats exist use unique indexes. Pick the column that comes first in any such indexes. Ties are broken arbitrarily.
     --Note: this will only pick a column that is NOT unique in a multi-column unique index.

--- a/tsl/test/expected/compression_defaults.out
+++ b/tsl/test/expected/compression_defaults.out
@@ -410,12 +410,13 @@ ALTER TABLE public.t1 SET (timescaledb.compress, timescaledb.compress_orderby = 
 WARNING:  there was some uncertainty picking the default segment by for the hypertable: You do not have any indexes on columns that can be used for segment_by and thus we are not using segment_by for compression. Please make sure you are not missing any indexes
 NOTICE:  default segment by for hypertable "t1" is set to ""
 RESET search_path;
--- test same named objects in different schemas with default orderbys
+-- test same named objects in different schemas with default orderbys/segmentbys
 \c :TEST_DBNAME :ROLE_SUPERUSER
 CREATE SCHEMA schema1;
 CREATE SCHEMA schema2;
 GRANT ALL ON SCHEMA schema1, schema2 to public;
 \c :TEST_DBNAME :ROLE_DEFAULT_PERM_USER
+-- test the case with default orderbys
 CREATE TABLE schema1.page_events2 (
  time        TIMESTAMPTZ         NOT NULL,
  page        TEXT              NOT NULL
@@ -446,3 +447,40 @@ ALTER TABLE schema2.page_events2 SET (
  timescaledb.compress_segmentby = 'page'
 );
 NOTICE:  default order by for hypertable "page_events2" is set to ""time" DESC"
+DROP TABLE schema1.page_events2;
+DROP TABLE schema2.page_events2;
+-- test the case with default segmentbys
+CREATE TABLE schema1.page_events2 (
+ time        TIMESTAMPTZ         NOT NULL,
+ id          BIGSERIAL           NOT NULL,
+ page        TEXT                NOT NULL
+);
+SELECT create_hypertable('schema1.page_events2', 'time');
+      create_hypertable      
+-----------------------------
+ (19,schema1,page_events2,t)
+(1 row)
+
+ALTER TABLE schema1.page_events2 SET (
+ timescaledb.compress,
+ timescaledb.compress_orderby = 'time desc, id asc'
+);
+WARNING:  there was some uncertainty picking the default segment by for the hypertable: You do not have any indexes on columns that can be used for segment_by and thus we are not using segment_by for compression. Please make sure you are not missing any indexes
+NOTICE:  default segment by for hypertable "page_events2" is set to ""
+CREATE TABLE schema2.page_events2 (
+ time        TIMESTAMPTZ         NOT NULL UNIQUE,
+ id          BIGSERIAL           NOT NULL,
+ page        TEXT                NOT NULL
+);
+SELECT create_hypertable('schema2.page_events2', 'time');
+      create_hypertable      
+-----------------------------
+ (21,schema2,page_events2,t)
+(1 row)
+
+ALTER TABLE schema2.page_events2 SET (
+ timescaledb.compress,
+ timescaledb.compress_orderby = 'time desc'
+);
+WARNING:  there was some uncertainty picking the default segment by for the hypertable: You do not have any indexes on columns that can be used for segment_by and thus we are not using segment_by for compression. Please make sure you are not missing any indexes
+NOTICE:  default segment by for hypertable "page_events2" is set to ""


### PR DESCRIPTION
There was a typo in the query used for the calculation of default segmentbys in the case of compression.