### PR TITLE
Reduce decompression on compressed INSERT

### DIFF
--- a/.unreleased/pr_7075
+++ b/.unreleased/pr_7075
@@ -1,0 +1,1 @@
+Implements: #7075 Reduce decompression on compressed INSERT

--- a/tsl/src/compression/compression.h
+++ b/tsl/src/compression/compression.h
@@ -149,6 +149,7 @@ typedef struct RowDecompressor
 	int64 tuples_decompressed;
 
 	TupleTableSlot **decompressed_slots;
+	int unprocessed_tuples;
 
 	Detoaster detoaster;
 } RowDecompressor;
@@ -368,6 +369,7 @@ extern void segment_info_update(SegmentInfo *segment_info, Datum val, bool is_nu
 
 extern RowDecompressor build_decompressor(Relation in_rel, Relation out_rel);
 
+extern void row_decompressor_reset(RowDecompressor *decompressor);
 extern void row_decompressor_close(RowDecompressor *decompressor);
 extern enum CompressionAlgorithms compress_get_default_algorithm(Oid typeoid);
 /*

--- a/tsl/test/expected/compression.out
+++ b/tsl/test/expected/compression.out
@@ -2844,7 +2844,6 @@ SELECT compress_chunk(i, if_not_compressed => true) FROM show_chunks('compressed
 SET timescaledb.max_tuples_decompressed_per_dml_transaction = 1;
 \set ON_ERROR_STOP 0
 COPY compressed_table (time,a,b,c) FROM stdin;
-ERROR:  tuple decompression limit exceeded by operation
 \set ON_ERROR_STOP 1
 RESET timescaledb.max_tuples_decompressed_per_dml_transaction;
 -- Test decompression with DML which compares int8 to int4

--- a/tsl/test/expected/compression_conflicts.out
+++ b/tsl/test/expected/compression_conflicts.out
@@ -422,7 +422,7 @@ BEGIN;
   SELECT count(*) FROM ONLY :CHUNK;
  count 
 -------
-  1001
+     1
 (1 row)
 
 ROLLBACK;

--- a/tsl/test/expected/compression_insert.out
+++ b/tsl/test/expected/compression_insert.out
@@ -2,6 +2,7 @@
 -- Please see the included NOTICE for copyright information and
 -- LICENSE-TIMESCALE for a copy of the license.
 \set PREFIX 'EXPLAIN (costs off, summary off, timing off) '
+\set ANALYZE  'EXPLAIN (analyze, costs off, summary off, timing off) '
 CREATE TABLE test1 (timec timestamptz , i integer ,
       b bigint, t text);
 SELECT table_name from create_hypertable('test1', 'timec', chunk_time_interval=> INTERVAL '7 days');
@@ -1084,17 +1085,19 @@ SELECT count(compress_chunk(ch)) FROM show_chunks('test_limit') ch;
     11
 (1 row)
 
-SET timescaledb.max_tuples_decompressed_per_dml_transaction = 5000;
+SET timescaledb.max_tuples_decompressed_per_dml_transaction = 1;
 \set VERBOSITY default
 \set ON_ERROR_STOP 0
 -- Inserting in the same period should decompress tuples
-INSERT INTO test_limit SELECT t, 11 FROM generate_series(1,6000,1000) t;
+INSERT INTO test_limit SELECT t, 2 FROM generate_series(1,6000,1000) t;
 ERROR:  tuple decompression limit exceeded by operation
-DETAIL:  current limit: 5000, tuples decompressed: 6000
+DETAIL:  current limit: 1, tuples decompressed: 1000
 HINT:  Consider increasing timescaledb.max_tuples_decompressed_per_dml_transaction or set to 0 (unlimited).
 -- Setting to 0 should remove the limit.
 SET timescaledb.max_tuples_decompressed_per_dml_transaction = 0;
-INSERT INTO test_limit SELECT t, 11 FROM generate_series(1,6000,1000) t;
+INSERT INTO test_limit SELECT t, 2 FROM generate_series(1,6000,1000) t;
+ERROR:  duplicate key value violates unique constraint "_hyper_24_54_chunk_timestamp_id_idx"
+DETAIL:  Key ("timestamp", id)=(1, 2) already exists.
 \set ON_ERROR_STOP 1
 DROP TABLE test_limit;
 RESET timescaledb.max_tuples_decompressed_per_dml_transaction;
@@ -1128,3 +1131,80 @@ ERROR:  duplicate key value violates unique constraint "76_2_multi_unique_time_u
 DETAIL:  Key ("time", u2)=(Mon Jan 01 00:00:00 2024 PST, 0) already exists.
 \set ON_ERROR_STOP 1
 DROP TABLE multi_unique;
+-- test insert with unique constraints and NULLs
+CREATE TABLE unique_null(time timestamptz NOT NULL, u1 int, u2 int, value float, unique(time, u1, u2));
+SELECT table_name FROM create_hypertable('unique_null', 'time');
+ table_name  
+-------------
+ unique_null
+(1 row)
+
+ALTER TABLE unique_null SET (timescaledb.compress, timescaledb.compress_segmentby = 'u1, u2');
+NOTICE:  default order by for hypertable "unique_null" is set to ""time" DESC"
+INSERT INTO unique_null VALUES('2024-01-01', 0, 0, 1.0);
+SELECT count(compress_chunk(c)) FROM show_chunks('unique_null') c;
+ count 
+-------
+     1
+(1 row)
+
+\set ON_ERROR_STOP 0
+-- all INSERTS should fail with constraint violation
+BEGIN; INSERT INTO unique_null VALUES('2024-01-01', 0, 0, 1.0); ROLLBACK;
+ERROR:  duplicate key value violates unique constraint "78_3_unique_null_time_u1_u2_key"
+DETAIL:  Key ("time", u1, u2)=(Mon Jan 01 00:00:00 2024 PST, 0, 0) already exists.
+\set ON_ERROR_STOP 1
+-- neither of these should need to decompress
+:ANALYZE INSERT INTO unique_null VALUES('2024-01-01', NULL, 1, 1.0);
+                           QUERY PLAN                            
+-----------------------------------------------------------------
+ Custom Scan (HypertableModify) (actual rows=0 loops=1)
+   ->  Insert on unique_null (actual rows=0 loops=1)
+         ->  Custom Scan (ChunkDispatch) (actual rows=1 loops=1)
+               ->  Result (actual rows=1 loops=1)
+(4 rows)
+
+SELECT count(*) FROM unique_null;
+ count 
+-------
+     2
+(1 row)
+
+:ANALYZE INSERT INTO unique_null VALUES('2024-01-01', 1, NULL, 1.0);
+                           QUERY PLAN                            
+-----------------------------------------------------------------
+ Custom Scan (HypertableModify) (actual rows=0 loops=1)
+   ->  Insert on unique_null (actual rows=0 loops=1)
+         ->  Custom Scan (ChunkDispatch) (actual rows=1 loops=1)
+               ->  Result (actual rows=1 loops=1)
+(4 rows)
+
+SELECT count(*) FROM unique_null;
+ count 
+-------
+     3
+(1 row)
+
+:ANALYZE INSERT INTO unique_null VALUES('2024-01-01', NULL, NULL, 1.0);
+                           QUERY PLAN                            
+-----------------------------------------------------------------
+ Custom Scan (HypertableModify) (actual rows=0 loops=1)
+   ->  Insert on unique_null (actual rows=0 loops=1)
+         ->  Custom Scan (ChunkDispatch) (actual rows=1 loops=1)
+               ->  Result (actual rows=1 loops=1)
+(4 rows)
+
+SELECT count(*) FROM unique_null;
+ count 
+-------
+     4
+(1 row)
+
+INSERT INTO unique_null VALUES('2024-01-01', NULL, NULL, 1.0);
+SELECT count(*) FROM unique_null;
+ count 
+-------
+     5
+(1 row)
+
+DROP TABLE unique_null;

--- a/tsl/test/shared/expected/compress_unique_index.out
+++ b/tsl/test/shared/expected/compress_unique_index.out
@@ -27,12 +27,10 @@ ERROR:  duplicate key value violates unique constraint "_hyper_X_X_chunk_uniq_ex
 EXPLAIN (analyze,costs off,summary off,timing off) INSERT INTO compress_unique VALUES ('2000-01-01','m1','c2','2000-01-02');
 QUERY PLAN
  Custom Scan (HypertableModify) (actual rows=0 loops=1)
-   Batches decompressed: 1
-   Tuples decompressed: 1
    ->  Insert on compress_unique (actual rows=0 loops=1)
          ->  Custom Scan (ChunkDispatch) (actual rows=1 loops=1)
                ->  Result (actual rows=1 loops=1)
-(6 rows)
+(4 rows)
 
 -- should decompress no batches
 EXPLAIN (analyze,costs off,summary off,timing off) INSERT INTO compress_unique VALUES ('2000-01-01','m1','c3','2000-01-02');

--- a/tsl/test/shared/expected/compression_dml.out
+++ b/tsl/test/shared/expected/compression_dml.out
@@ -1,6 +1,7 @@
 -- This file and its contents are licensed under the Timescale License.
 -- Please see the included NOTICE for copyright information and
 -- LICENSE-TIMESCALE for a copy of the license.
+\set ANALYZE 'EXPLAIN (analyze, costs off, timing off, summary off)'
 -- test constraint exclusion with prepared statements and generic plans
 CREATE TABLE i3719 (time timestamptz NOT NULL,data text);
 SELECT table_name FROM create_hypertable('i3719', 'time');
@@ -161,9 +162,9 @@ ON CONFLICT (source_id, label, time) DO UPDATE SET data = '{"update": true}';
 EXPLAIN (analyze,costs off, timing off, summary off) SELECT * FROM comp_seg_varchar;
 QUERY PLAN
  Append (actual rows=92 loops=1)
-   ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=24 loops=1)
-         ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=8 loops=1)
-   ->  Seq Scan on _hyper_X_X_chunk (actual rows=5 loops=1)
+   ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=27 loops=1)
+         ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=9 loops=1)
+   ->  Seq Scan on _hyper_X_X_chunk (actual rows=2 loops=1)
    ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=63 loops=1)
          ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=9 loops=1)
 (6 rows)
@@ -202,3 +203,58 @@ SELECT FROM row_locks FOR KEY SHARE;
 ERROR:  locking compressed tuples is not supported
 \set ON_ERROR_STOP 1
 DROP TABLE row_locks;
+CREATE TABLE lazy_decompress(time timestamptz not null, device text, value float, primary key (device,time));
+SELECT table_name FROM create_hypertable('lazy_decompress', 'time');
+   table_name    
+ lazy_decompress
+(1 row)
+
+ALTER TABLE lazy_decompress SET (timescaledb.compress, timescaledb.compress_segmentby = 'device');
+NOTICE:  default order by for hypertable "lazy_decompress" is set to ""time" DESC"
+INSERT INTO lazy_decompress SELECT '2024-01-01'::timestamptz + format('%s',i)::interval, 'd1', i FROM generate_series(1,6000) g(i);
+SELECT count(compress_chunk(c)) FROM show_chunks('lazy_decompress') c;
+ count 
+     1
+(1 row)
+
+-- no decompression cause no match in batch
+BEGIN; :ANALYZE INSERT INTO lazy_decompress SELECT '2024-01-01 0:00:00.5','d1',random() ON CONFLICT DO NOTHING; ROLLBACK;
+QUERY PLAN
+ Custom Scan (HypertableModify) (actual rows=0 loops=1)
+   ->  Insert on lazy_decompress (actual rows=0 loops=1)
+         Conflict Resolution: NOTHING
+         Tuples Inserted: 1
+         Conflicting Tuples: 0
+         ->  Custom Scan (ChunkDispatch) (actual rows=1 loops=1)
+               ->  Subquery Scan on "*SELECT*" (actual rows=1 loops=1)
+                     ->  Result (actual rows=1 loops=1)
+(8 rows)
+
+BEGIN; :ANALYZE INSERT INTO lazy_decompress SELECT '2024-01-01 0:00:00.5','d1',random() ON CONFLICT(time,device) DO UPDATE SET value=EXCLUDED.value; ROLLBACK;
+QUERY PLAN
+ Custom Scan (HypertableModify) (actual rows=0 loops=1)
+   ->  Insert on lazy_decompress (actual rows=0 loops=1)
+         Conflict Resolution: UPDATE
+         Conflict Arbiter Indexes: lazy_decompress_pkey
+         Tuples Inserted: 1
+         Conflicting Tuples: 0
+         ->  Custom Scan (ChunkDispatch) (actual rows=1 loops=1)
+               ->  Subquery Scan on "*SELECT*" (actual rows=1 loops=1)
+                     ->  Result (actual rows=1 loops=1)
+(9 rows)
+
+-- should decompress 1 batch cause there is match
+BEGIN; :ANALYZE INSERT INTO lazy_decompress SELECT '2024-01-01 0:00:01','d1',random() ON CONFLICT DO NOTHING; ROLLBACK;
+QUERY PLAN
+ Custom Scan (HypertableModify) (actual rows=0 loops=1)
+   Batches decompressed: 1
+   Tuples decompressed: 1000
+   ->  Insert on lazy_decompress (actual rows=0 loops=1)
+         Conflict Resolution: NOTHING
+         Tuples Inserted: 0
+         Conflicting Tuples: 1
+         ->  Custom Scan (ChunkDispatch) (actual rows=1 loops=1)
+               ->  Subquery Scan on "*SELECT*" (actual rows=1 loops=1)
+                     ->  Result (actual rows=1 loops=1)
+(10 rows)
+

--- a/tsl/test/shared/expected/decompress_tracking.out
+++ b/tsl/test/shared/expected/decompress_tracking.out
@@ -94,13 +94,11 @@ QUERY PLAN
 BEGIN; :EXPLAIN_ANALYZE INSERT INTO decompress_tracking SELECT '2020-01-01 1:30','d1',random(); ROLLBACK;
 QUERY PLAN
  Custom Scan (HypertableModify) (actual rows=0 loops=1)
-   Batches decompressed: 1
-   Tuples decompressed: 10
    ->  Insert on decompress_tracking (actual rows=0 loops=1)
          ->  Custom Scan (ChunkDispatch) (actual rows=1 loops=1)
                ->  Subquery Scan on "*SELECT*" (actual rows=1 loops=1)
                      ->  Result (actual rows=1 loops=1)
-(7 rows)
+(5 rows)
 
 BEGIN; :EXPLAIN_ANALYZE INSERT INTO decompress_tracking SELECT '2020-01-01','d2',random(); ROLLBACK;
 QUERY PLAN
@@ -123,12 +121,10 @@ QUERY PLAN
 BEGIN; :EXPLAIN_ANALYZE INSERT INTO decompress_tracking (VALUES ('2020-01-01 1:30','d1',random()),('2020-01-01 1:30','d2',random())); ROLLBACK;
 QUERY PLAN
  Custom Scan (HypertableModify) (actual rows=0 loops=1)
-   Batches decompressed: 2
-   Tuples decompressed: 25
    ->  Insert on decompress_tracking (actual rows=0 loops=1)
          ->  Custom Scan (ChunkDispatch) (actual rows=2 loops=1)
                ->  Values Scan on "*VALUES*" (actual rows=2 loops=1)
-(6 rows)
+(4 rows)
 
 -- test prepared statements EXPLAIN still works after execution
 SET plan_cache_mode TO force_generic_plan;

--- a/tsl/test/shared/sql/compression_dml.sql
+++ b/tsl/test/shared/sql/compression_dml.sql
@@ -2,6 +2,8 @@
 -- Please see the included NOTICE for copyright information and
 -- LICENSE-TIMESCALE for a copy of the license.
 
+\set ANALYZE 'EXPLAIN (analyze, costs off, timing off, summary off)'
+
 -- test constraint exclusion with prepared statements and generic plans
 CREATE TABLE i3719 (time timestamptz NOT NULL,data text);
 SELECT table_name FROM create_hypertable('i3719', 'time');
@@ -144,4 +146,16 @@ SELECT FROM row_locks FOR KEY SHARE;
 
 DROP TABLE row_locks;
 
+CREATE TABLE lazy_decompress(time timestamptz not null, device text, value float, primary key (device,time));
+SELECT table_name FROM create_hypertable('lazy_decompress', 'time');
+ALTER TABLE lazy_decompress SET (timescaledb.compress, timescaledb.compress_segmentby = 'device');
 
+INSERT INTO lazy_decompress SELECT '2024-01-01'::timestamptz + format('%s',i)::interval, 'd1', i FROM generate_series(1,6000) g(i);
+
+SELECT count(compress_chunk(c)) FROM show_chunks('lazy_decompress') c;
+
+-- no decompression cause no match in batch
+BEGIN; :ANALYZE INSERT INTO lazy_decompress SELECT '2024-01-01 0:00:00.5','d1',random() ON CONFLICT DO NOTHING; ROLLBACK;
+BEGIN; :ANALYZE INSERT INTO lazy_decompress SELECT '2024-01-01 0:00:00.5','d1',random() ON CONFLICT(time,device) DO UPDATE SET value=EXCLUDED.value; ROLLBACK;
+-- should decompress 1 batch cause there is match
+BEGIN; :ANALYZE INSERT INTO lazy_decompress SELECT '2024-01-01 0:00:01','d1',random() ON CONFLICT DO NOTHING; ROLLBACK;

--- a/tsl/test/sql/compression_insert.sql
+++ b/tsl/test/sql/compression_insert.sql
@@ -3,6 +3,7 @@
 -- LICENSE-TIMESCALE for a copy of the license.
 
 \set PREFIX 'EXPLAIN (costs off, summary off, timing off) '
+\set ANALYZE  'EXPLAIN (analyze, costs off, summary off, timing off) '
 CREATE TABLE test1 (timec timestamptz , i integer ,
       b bigint, t text);
 SELECT table_name from create_hypertable('test1', 'timec', chunk_time_interval=> INTERVAL '7 days');
@@ -718,14 +719,14 @@ ALTER TABLE test_limit SET (
 );
 SELECT count(compress_chunk(ch)) FROM show_chunks('test_limit') ch;
 
-SET timescaledb.max_tuples_decompressed_per_dml_transaction = 5000;
+SET timescaledb.max_tuples_decompressed_per_dml_transaction = 1;
 \set VERBOSITY default
 \set ON_ERROR_STOP 0
 -- Inserting in the same period should decompress tuples
-INSERT INTO test_limit SELECT t, 11 FROM generate_series(1,6000,1000) t;
+INSERT INTO test_limit SELECT t, 2 FROM generate_series(1,6000,1000) t;
 -- Setting to 0 should remove the limit.
 SET timescaledb.max_tuples_decompressed_per_dml_transaction = 0;
-INSERT INTO test_limit SELECT t, 11 FROM generate_series(1,6000,1000) t;
+INSERT INTO test_limit SELECT t, 2 FROM generate_series(1,6000,1000) t;
 \set ON_ERROR_STOP 1
 
 DROP TABLE test_limit;
@@ -747,4 +748,28 @@ BEGIN; INSERT INTO multi_unique VALUES('2024-01-01', 1, 0, 1.0); ROLLBACK;
 \set ON_ERROR_STOP 1
 
 DROP TABLE multi_unique;
+
+-- test insert with unique constraints and NULLs
+CREATE TABLE unique_null(time timestamptz NOT NULL, u1 int, u2 int, value float, unique(time, u1, u2));
+SELECT table_name FROM create_hypertable('unique_null', 'time');
+ALTER TABLE unique_null SET (timescaledb.compress, timescaledb.compress_segmentby = 'u1, u2');
+
+INSERT INTO unique_null VALUES('2024-01-01', 0, 0, 1.0);
+SELECT count(compress_chunk(c)) FROM show_chunks('unique_null') c;
+
+\set ON_ERROR_STOP 0
+-- all INSERTS should fail with constraint violation
+BEGIN; INSERT INTO unique_null VALUES('2024-01-01', 0, 0, 1.0); ROLLBACK;
+\set ON_ERROR_STOP 1
+-- neither of these should need to decompress
+:ANALYZE INSERT INTO unique_null VALUES('2024-01-01', NULL, 1, 1.0);
+SELECT count(*) FROM unique_null;
+:ANALYZE INSERT INTO unique_null VALUES('2024-01-01', 1, NULL, 1.0);
+SELECT count(*) FROM unique_null;
+:ANALYZE INSERT INTO unique_null VALUES('2024-01-01', NULL, NULL, 1.0);
+SELECT count(*) FROM unique_null;
+INSERT INTO unique_null VALUES('2024-01-01', NULL, NULL, 1.0);
+SELECT count(*) FROM unique_null;
+
+DROP TABLE unique_null;
 

--- a/tsl/test/t/002_logrepl_decomp_marker.pl
+++ b/tsl/test/t/002_logrepl_decomp_marker.pl
@@ -216,14 +216,13 @@ discard_wal();
 
 query_generates_wal(
 	"insert into compressed chunk with pk forces decompression",
-	qq/INSERT INTO metrics VALUES ('2023-07-01 01:00:00', 1, 5555);/,
+	qq/INSERT INTO metrics VALUES ('2023-07-01 00:00:00Z', 1, 5555) ON CONFLICT DO NOTHING;/,
 	qq/BEGIN
 message: transactional: 1 prefix: ::timescaledb-decompression-start, sz: 0 content:
 table _timescaledb_internal.compress_hyper_3_4_chunk: DELETE: (no-tuple-data)
 table _timescaledb_internal._hyper_1_1_chunk: INSERT: "time"[timestamp with time zone]:'2023-06-30 17:00:00-07' device_id[bigint]:1 value[double precision]:1
 table _timescaledb_internal._hyper_1_1_chunk: INSERT: "time"[timestamp with time zone]:'2023-07-01 05:00:00-07' device_id[bigint]:1 value[double precision]:2
 message: transactional: 1 prefix: ::timescaledb-decompression-end, sz: 0 content:
-table _timescaledb_internal._hyper_1_1_chunk: INSERT: "time"[timestamp with time zone]:'2023-07-01 01:00:00-07' device_id[bigint]:1 value[double precision]:5555
 table _timescaledb_catalog.chunk: UPDATE: id[integer]:1 hypertable_id[integer]:1 schema_name[name]:'_timescaledb_internal' table_name[name]:'_hyper_1_1_chunk' compressed_chunk_id[integer]:4 dropped[boolean]:false status[integer]:9 osm_chunk[boolean]:false
 COMMIT/
 );
@@ -240,8 +239,7 @@ query_generates_wal(
 table _timescaledb_catalog.chunk: UPDATE: id[integer]:1 hypertable_id[integer]:1 schema_name[name]:'_timescaledb_internal' table_name[name]:'_hyper_1_1_chunk' compressed_chunk_id[integer]:4 dropped[boolean]:false status[integer]:1 osm_chunk[boolean]:false
 table _timescaledb_internal._hyper_1_1_chunk: DELETE: "time"[timestamp with time zone]:'2023-06-30 17:00:00-07'
 table _timescaledb_internal._hyper_1_1_chunk: DELETE: "time"[timestamp with time zone]:'2023-07-01 05:00:00-07'
-table _timescaledb_internal._hyper_1_1_chunk: DELETE: "time"[timestamp with time zone]:'2023-07-01 01:00:00-07'
-table _timescaledb_internal.compress_hyper_3_4_chunk: INSERT: _ts_meta_count[integer]:3 _ts_meta_sequence_num[integer]:10 device_id[bigint]:1 _ts_meta_min_1[timestamp with time zone]:'2023-06-30 17:00:00-07' _ts_meta_max_1[timestamp with time zone]:'2023-07-01 05:00:00-07' "time"[_timescaledb_internal.compressed_data]:'BAAAAqJqcQfwAAAAAANaTpAAAAAAAwAAAAMAAAAAAAAO7gAFRMDEOIAAAAVEs1r+P/8AAAAGtJ0f/w==' value[_timescaledb_internal.compressed_data]:'AwBAAAAAAAAAAAAAAAMAAAABAAAAAAAAAAEAAAAAAAAABwAAAAMAAAABAAAAAAAAAAEAAAAAAAAABwAAAAESAAAAAAAAgEIAAAADAAAAAQAAAAAAAAAFAAAAAAAAQuoAAAABMQABa2f9Fs//'
+table _timescaledb_internal.compress_hyper_3_4_chunk: INSERT: _ts_meta_count[integer]:2 _ts_meta_sequence_num[integer]:10 device_id[bigint]:1 _ts_meta_min_1[timestamp with time zone]:'2023-06-30 17:00:00-07' _ts_meta_max_1[timestamp with time zone]:'2023-07-01 05:00:00-07' "time"[_timescaledb_internal.compressed_data]:'BAAAAqJqcQfwAAAAAAoO67AAAAAAAgAAAAIAAAAAAAAA7gAFRMDEOIAAAAVErKZhH/8=' value[_timescaledb_internal.compressed_data]:'AwBAAAAAAAAAAAAAAAIAAAABAAAAAAAAAAEAAAAAAAAAAwAAAAIAAAABAAAAAAAAAAEAAAAAAAAAAwAAAAEMAAAAAAAAAEIAAAACAAAAAQAAAAAAAAAEAAAAAAAAALoAAAABFQAAAAAAH///'
 COMMIT)
 );
 
@@ -250,7 +248,6 @@ query_generates_wal(
 	qq(SELECT decompress_chunk('_timescaledb_internal._hyper_1_1_chunk'::regclass, TRUE);),
 	qq(BEGIN
 table _timescaledb_internal._hyper_1_1_chunk: INSERT: "time"[timestamp with time zone]:'2023-06-30 17:00:00-07' device_id[bigint]:1 value[double precision]:1
-table _timescaledb_internal._hyper_1_1_chunk: INSERT: "time"[timestamp with time zone]:'2023-07-01 01:00:00-07' device_id[bigint]:1 value[double precision]:5555
 table _timescaledb_internal._hyper_1_1_chunk: INSERT: "time"[timestamp with time zone]:'2023-07-01 05:00:00-07' device_id[bigint]:1 value[double precision]:2
 table _timescaledb_catalog.compression_chunk_size: DELETE: chunk_id[integer]:1
 table _timescaledb_catalog.chunk: UPDATE: id[integer]:1 hypertable_id[integer]:1 schema_name[name]:'_timescaledb_internal' table_name[name]:'_hyper_1_1_chunk' compressed_chunk_id[integer]:null dropped[boolean]:false status[integer]:0 osm_chunk[boolean]:false


### PR DESCRIPTION
Previously for INSERTs into compressed chunks with unique constraints we would decompress the batch which would contain the tuple matching according to the constraints. This patch will skip the decompressing if the batch does not contain an actual matching tuples. This patch adds the optimization for INSERT with unique constraints. Similar optimizations for UPDATE and DELETE will be added in followup patches.