### PR TITLE
Fix `corresponding equivalence member not found`

### DIFF
--- a/.unreleased/pr_7080
+++ b/.unreleased/pr_7080
@@ -1,0 +1,1 @@
+Fixes: #7080 Fix `corresponding equivalence member not found` error

--- a/tsl/test/expected/transparent_decompression-14.out
+++ b/tsl/test/expected/transparent_decompression-14.out
@@ -9594,3 +9594,31 @@ SELECT count(*) from motion_table;
 (1 row)
 
 --END of test for page settings
+CREATE TABLE repro(time timestamptz NOT NULL, device_id text, room_id text NOT NULL, score_type int NOT NULL, algorithm_version text NOT NULL, adjusted_score float NOT NULL);
+SELECT create_hypertable('repro','time');
+  create_hypertable  
+---------------------
+ (17,public,repro,t)
+(1 row)
+
+ALTER TABLE repro SET (
+  timescaledb.compress,
+  timescaledb.compress_segmentby = 'device_id, room_id, score_type, algorithm_version',
+  timescaledb.compress_orderby='"time" DESC'
+);
+SELECT _timescaledb_functions.create_chunk('repro','{"time": [1717632000000000,1718236800000000]}');
+                                                create_chunk                                                 
+-------------------------------------------------------------------------------------------------------------
+ (1441,17,_timescaledb_internal,_hyper_17_1441_chunk,r,"{""time"": [1717632000000000, 1718236800000000]}",t)
+(1 row)
+
+select compress_chunk(show_chunks('repro'));
+               compress_chunk               
+--------------------------------------------
+ _timescaledb_internal._hyper_17_1441_chunk
+(1 row)
+
+select from repro where room_id = 'foo' order by device_id, algorithm_version, score_type, time desc;
+--
+(0 rows)
+

--- a/tsl/test/expected/transparent_decompression-15.out
+++ b/tsl/test/expected/transparent_decompression-15.out
@@ -9595,3 +9595,31 @@ SELECT count(*) from motion_table;
 (1 row)
 
 --END of test for page settings
+CREATE TABLE repro(time timestamptz NOT NULL, device_id text, room_id text NOT NULL, score_type int NOT NULL, algorithm_version text NOT NULL, adjusted_score float NOT NULL);
+SELECT create_hypertable('repro','time');
+  create_hypertable  
+---------------------
+ (17,public,repro,t)
+(1 row)
+
+ALTER TABLE repro SET (
+  timescaledb.compress,
+  timescaledb.compress_segmentby = 'device_id, room_id, score_type, algorithm_version',
+  timescaledb.compress_orderby='"time" DESC'
+);
+SELECT _timescaledb_functions.create_chunk('repro','{"time": [1717632000000000,1718236800000000]}');
+                                                create_chunk                                                 
+-------------------------------------------------------------------------------------------------------------
+ (1441,17,_timescaledb_internal,_hyper_17_1441_chunk,r,"{""time"": [1717632000000000, 1718236800000000]}",t)
+(1 row)
+
+select compress_chunk(show_chunks('repro'));
+               compress_chunk               
+--------------------------------------------
+ _timescaledb_internal._hyper_17_1441_chunk
+(1 row)
+
+select from repro where room_id = 'foo' order by device_id, algorithm_version, score_type, time desc;
+--
+(0 rows)
+

--- a/tsl/test/expected/transparent_decompression-16.out
+++ b/tsl/test/expected/transparent_decompression-16.out
@@ -9595,3 +9595,31 @@ SELECT count(*) from motion_table;
 (1 row)
 
 --END of test for page settings
+CREATE TABLE repro(time timestamptz NOT NULL, device_id text, room_id text NOT NULL, score_type int NOT NULL, algorithm_version text NOT NULL, adjusted_score float NOT NULL);
+SELECT create_hypertable('repro','time');
+  create_hypertable  
+---------------------
+ (17,public,repro,t)
+(1 row)
+
+ALTER TABLE repro SET (
+  timescaledb.compress,
+  timescaledb.compress_segmentby = 'device_id, room_id, score_type, algorithm_version',
+  timescaledb.compress_orderby='"time" DESC'
+);
+SELECT _timescaledb_functions.create_chunk('repro','{"time": [1717632000000000,1718236800000000]}');
+                                                create_chunk                                                 
+-------------------------------------------------------------------------------------------------------------
+ (1441,17,_timescaledb_internal,_hyper_17_1441_chunk,r,"{""time"": [1717632000000000, 1718236800000000]}",t)
+(1 row)
+
+select compress_chunk(show_chunks('repro'));
+               compress_chunk               
+--------------------------------------------
+ _timescaledb_internal._hyper_17_1441_chunk
+(1 row)
+
+select from repro where room_id = 'foo' order by device_id, algorithm_version, score_type, time desc;
+--
+(0 rows)
+

--- a/tsl/test/sql/transparent_decompression.sql.in
+++ b/tsl/test/sql/transparent_decompression.sql.in
@@ -310,3 +310,19 @@ FROM ( SELECT chunk_schema || '.' || chunk_name as chunk_table
 SELECT count(*) from motion_table;
 
 --END of test for page settings
+
+
+CREATE TABLE repro(time timestamptz NOT NULL, device_id text, room_id text NOT NULL, score_type int NOT NULL, algorithm_version text NOT NULL, adjusted_score float NOT NULL);
+SELECT create_hypertable('repro','time');
+
+ALTER TABLE repro SET (
+  timescaledb.compress,
+  timescaledb.compress_segmentby = 'device_id, room_id, score_type, algorithm_version',
+  timescaledb.compress_orderby='"time" DESC'
+);
+
+SELECT _timescaledb_functions.create_chunk('repro','{"time": [1717632000000000,1718236800000000]}');
+
+select compress_chunk(show_chunks('repro'));
+select from repro where room_id = 'foo' order by device_id, algorithm_version, score_type, time desc;
+


### PR DESCRIPTION
When querying compressed data we determine whether the requested ORDER
can be applied to the underlying query on the compressed data itself.
This happens twice. The first time we decide whether we can push down
the sort and then we do a recheck when we setup the sort metadata.
Unfortunately those two checks did not agree. The initial check concluded
it is possible but the recheck disagreed.  This was due to a bug when
checking the query properties we mixed up the attnos and used attnos
from uncompressed chunk and compressed chunk in the same bitmapset.
If a segmentby column with equality constraint was present in the WHERE
clause whose attno was identical to a compressed attno of a different
column that was part of the ORDER BY the recheck would fail.
    
This patch removes the recheck and relies on the initial assesment
when building sort metadata.
