### PR TITLE
Fix leaks with functions in DML

### DIFF
--- a/.unreleased/fix_7088
+++ b/.unreleased/fix_7088
@@ -1,0 +1,2 @@
+Fixes: #7088 Fix leaks with functions in DML
+Thanks: @Kazmirchuk for reporting this

--- a/test/expected/copy_memory_usage.out
+++ b/test/expected/copy_memory_usage.out
@@ -59,3 +59,40 @@ select * from portal_memory_log where (
 ----+-------
 (0 rows)
 
+-- Test plpgsql leaks
+CREATE TABLE test_ht(tm timestamptz, val float8);
+SELECT * FROM create_hypertable('test_ht', 'tm');
+NOTICE:  adding not-null constraint to column "tm"
+ hypertable_id | schema_name | table_name | created 
+---------------+-------------+------------+---------
+             2 | public      | test_ht    | t
+(1 row)
+
+-- Use a plpgsql function to insert into the hypertable
+CREATE OR REPLACE FUNCTION to_double(_in text, INOUT _out double precision)
+LANGUAGE plpgsql IMMUTABLE parallel safe
+AS $$
+BEGIN
+    SELECT CAST(_in AS double precision) INTO _out;
+EXCEPTION WHEN others THEN
+    --do nothing: _out already carries default
+END;
+$$;
+-- TopTransactionContext usage needs to remain the same after every insert
+-- There was a leak earlier in the child CurTransactionContext
+BEGIN;
+INSERT INTO test_ht VALUES ('1980-01-01 00:00:00-00', to_double('23.11', 0));
+SELECT sum(total_bytes) from pg_backend_memory_contexts where parent = 'TopTransactionContext';
+  sum  
+-------
+ 16384
+(1 row)
+
+INSERT INTO test_ht VALUES ('1980-02-01 00:00:00-00', to_double('24.11', 0));
+SELECT sum(total_bytes) from pg_backend_memory_contexts where parent = 'TopTransactionContext';
+  sum  
+-------
+ 16384
+(1 row)
+
+COMMIT;


### PR DESCRIPTION
If plpgsql functions are used in DML queries then we were leaking 8KB for every invocation of that function. This can quickly add up.

The issue was that the "CurTransactionContext" was not getting cleaned up after every invocation. The reason was that we were inadvertantly allocating a temporary list in that context. Postgres then thought that this CurTransactionContext needs to be re-used further and kept it around. We now use a proper memory context to avoid this.

Fixes #7053