### PR TITLE
Release 2.15.3

### DIFF
--- a/.unreleased/fix_7088
+++ b/.unreleased/fix_7088
@@ -1,2 +1,0 @@
-Fixes: #7088 Fix leaks with functions in DML
-Thanks: @Kazmirchuk for reporting this

--- a/.unreleased/pr_7061
+++ b/.unreleased/pr_7061
@@ -1,1 +1,0 @@
-Fixes: #7061 Fix handling of multiple unique indexes in compressed INSERT

--- a/.unreleased/pr_7080
+++ b/.unreleased/pr_7080
@@ -1,1 +1,0 @@
-Fixes: #7080 Fix `corresponding equivalence member not found` error

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,8 +16,13 @@ After you run `ALTER EXTENSION`, you must run [this SQL script](https://github.c
 If you are migrating from TimescaleDB v2.15.0, v2.15.1 or v2.15.2, no changes are required.
 
 **Bugfixes**
-* #7061: Fix handling of multiple unique indexes in compressed INSERT.
-* #7080: Fix `corresponding equivalence member not found` error.
+* #7061: Fix the handling of multiple unique indexes in a compressed INSERT.
+* #7080: Fix the `corresponding equivalence member not found` error.
+* #7088: Fix the leaks with the functions in DML.
+* #7035: Fix the error when acquiring a tuple lock on the OSM chunks on the replica.
+
+**Thanks**
+* @Kazmirchuk for reporting the issue with leaks with the functions in DML.
 
 ## 2.15.2 (2024-06-07)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,21 @@
 `psql` with the `-X` flag to prevent any `.psqlrc` commands from
 accidentally triggering the load of a previous DB version.**
 
+## 2.15.3 (2024-07-02)
+
+This release contains bug fixes since the 2.15.2 release.
+Best practice is to upgrade at the next available opportunity.
+
+**Migrating from self-hosted TimescaleDB v2.14.x and earlier**
+
+After you run `ALTER EXTENSION`, you must run [this SQL script](https://github.com/timescale/timescaledb-extras/blob/master/utils/2.15.X-fix_hypertable_foreign_keys.sql). For more details, see the following pull request [#6797](https://github.com/timescale/timescaledb/pull/6797).
+
+If you are migrating from TimescaleDB v2.15.0, v2.15.1 or v2.15.2, no changes are required.
+
+**Bugfixes**
+* #7061: Fix handling of multiple unique indexes in compressed INSERT.
+* #7080: Fix `corresponding equivalence member not found` error.
+
 ## 2.15.2 (2024-06-07)
 
 This release contains bug fixes since the 2.15.1 release. Best

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,11 +18,11 @@ If you are migrating from TimescaleDB v2.15.0, v2.15.1 or v2.15.2, no changes ar
 **Bugfixes**
 * #7061: Fix the handling of multiple unique indexes in a compressed INSERT.
 * #7080: Fix the `corresponding equivalence member not found` error.
-* #7088: Fix the leaks with the functions in DML.
+* #7088: Fix the leaks in the DML functions.
 * #7035: Fix the error when acquiring a tuple lock on the OSM chunks on the replica.
 
 **Thanks**
-* @Kazmirchuk for reporting the issue with leaks with the functions in DML.
+* @Kazmirchuk for reporting the issue about leaks with the functions in DML.
 
 ## 2.15.2 (2024-06-07)
 

--- a/sql/CMakeLists.txt
+++ b/sql/CMakeLists.txt
@@ -39,7 +39,8 @@ set(MOD_FILES
     updates/2.14.1--2.14.2.sql
     updates/2.14.2--2.15.0.sql
     updates/2.15.0--2.15.1.sql
-    updates/2.15.1--2.15.2.sql)
+    updates/2.15.1--2.15.2.sql
+    updates/2.15.2--2.15.3.sql)
 
 # The downgrade file to generate a downgrade script for the current version, as
 # specified in version.config

--- a/version.config
+++ b/version.config
@@ -1,3 +1,3 @@
 version = 2.16.0-dev
-update_from_version = 2.15.2
+update_from_version = 2.15.3
 downgrade_to_version = 2.15.2


### PR DESCRIPTION
This release contains bug fixes since the 2.15.2 release.
Best practice is to upgrade at the next available opportunity.

**Migrating from self-hosted TimescaleDB v2.14.x and earlier**

After you run `ALTER EXTENSION`, you must run [this SQL script](https://github.com/timescale/timescaledb-extras/blob/master/utils/2.15.X-fix_hypertable_foreign_keys.sql). For more details, see the following pull request [#6797](https://github.com/timescale/timescaledb/pull/6797).

If you are migrating from TimescaleDB v2.15.0, v2.15.1 or v2.15.2, no changes are required.

**Bugfixes**
* #7061: Fix the handling of multiple unique indexes in a compressed INSERT.
* #7080: Fix the `corresponding equivalence member not found` error.
* #7088: Fix the leaks in the DML functions.
* #7035: Fix the error when acquiring a tuple lock on the OSM chunks on the replica.

**Thanks**
* @Kazmirchuk for reporting the issue about leaks with the functions in DML.

Disable-check: commit-count
Disable-check: force-changelog-file