### PR TITLE
Reduce decompressions for compressed UPDATE/DELETE

### DIFF
--- a/.unreleased/pr_7101
+++ b/.unreleased/pr_7101
@@ -1,0 +1,1 @@
+Implements: #7101 Reduce decompressions for compressed UPDATE/DELETE

--- a/src/guc.c
+++ b/src/guc.c
@@ -69,6 +69,7 @@ TSDLLEXPORT bool ts_guc_enable_cagg_watermark_constify = true;
 TSDLLEXPORT int ts_guc_cagg_max_individual_materializations = 10;
 bool ts_guc_enable_osm_reads = true;
 TSDLLEXPORT bool ts_guc_enable_dml_decompression = true;
+TSDLLEXPORT bool ts_guc_enable_dml_decompression_tuple_filtering = true;
 TSDLLEXPORT int ts_guc_max_tuples_decompressed_per_dml = 100000;
 TSDLLEXPORT bool ts_guc_enable_transparent_decompression = true;
 TSDLLEXPORT bool ts_guc_enable_compression_wal_markers = false;
@@ -430,6 +431,18 @@ _guc_init(void)
 							 "Enable DML decompression",
 							 "Enable DML decompression when modifying compressed hypertable",
 							 &ts_guc_enable_dml_decompression,
+							 true,
+							 PGC_USERSET,
+							 0,
+							 NULL,
+							 NULL,
+							 NULL);
+
+	DefineCustomBoolVariable(MAKE_EXTOPTION("enable_dml_decompression_tuple_filtering"),
+							 "Enable DML decompression tuple filtering",
+							 "Recheck tuples during DML decompression to only decompress batches "
+							 "with matching tuples",
+							 &ts_guc_enable_dml_decompression_tuple_filtering,
 							 true,
 							 PGC_USERSET,
 							 0,

--- a/src/guc.h
+++ b/src/guc.h
@@ -29,6 +29,7 @@ extern bool ts_guc_enable_now_constify;
 extern TSDLLEXPORT bool ts_guc_enable_cagg_watermark_constify;
 extern bool ts_guc_enable_osm_reads;
 extern TSDLLEXPORT bool ts_guc_enable_dml_decompression;
+extern TSDLLEXPORT bool ts_guc_enable_dml_decompression_tuple_filtering;
 extern TSDLLEXPORT int ts_guc_max_tuples_decompressed_per_dml;
 extern TSDLLEXPORT bool ts_guc_enable_transparent_decompression;
 extern TSDLLEXPORT bool ts_guc_enable_compression_wal_markers;

--- a/tsl/src/compression/compression_dml.h
+++ b/tsl/src/compression/compression_dml.h
@@ -10,9 +10,9 @@
 
 #include "ts_catalog/compression_settings.h"
 
-ScanKeyData *build_scankeys_for_uncompressed(Oid ht_relid, CompressionSettings *settings,
-											 Relation out_rel, Bitmapset *key_columns,
-											 TupleTableSlot *slot, int *num_scankeys);
+ScanKeyData *build_mem_scankeys_from_slot(Oid ht_relid, CompressionSettings *settings,
+										  Relation out_rel, Bitmapset *key_columns,
+										  TupleTableSlot *slot, int *num_scankeys);
 ScanKeyData *build_index_scankeys(Relation index_rel, List *index_filters, int *num_scankeys);
 ScanKeyData *build_index_scankeys_using_slot(Oid hypertable_relid, Relation in_rel,
 											 Relation out_rel, Bitmapset *key_columns,
@@ -23,7 +23,3 @@ ScanKeyData *build_heap_scankeys(Oid hypertable_relid, Relation in_rel, Relation
 								 Bitmapset **null_columns, TupleTableSlot *slot, int *num_scankeys);
 ScanKeyData *build_update_delete_scankeys(Relation in_rel, List *heap_filters, int *num_scankeys,
 										  Bitmapset **null_columns);
-int create_segment_filter_scankey(Relation in_rel, char *segment_filter_col_name,
-								  StrategyNumber strategy, Oid subtype, ScanKeyData *scankeys,
-								  int num_scankeys, Bitmapset **null_columns, Datum value,
-								  bool is_null_check, bool is_array_op);

--- a/tsl/test/expected/compression_update_delete.out
+++ b/tsl/test/expected/compression_update_delete.out
@@ -122,12 +122,13 @@ FROM compressed_chunk_info_view
 WHERE hypertable_name = 'sample_table' ORDER BY chunk_name;
  chunk_status |    CHUNK_NAME    
 --------------+------------------
-            9 | _hyper_1_1_chunk
+            1 | _hyper_1_1_chunk
             9 | _hyper_1_2_chunk
 (2 rows)
 
 -- recompress the partial chunks
 SELECT compress_chunk('_timescaledb_internal._hyper_1_1_chunk');
+NOTICE:  chunk "_hyper_1_1_chunk" is already compressed
              compress_chunk             
 ----------------------------------------
  _timescaledb_internal._hyper_1_1_chunk
@@ -173,12 +174,13 @@ FROM compressed_chunk_info_view
 WHERE hypertable_name = 'sample_table' ORDER BY chunk_name;
  chunk_status |    CHUNK_NAME    
 --------------+------------------
-            9 | _hyper_1_1_chunk
+            1 | _hyper_1_1_chunk
             9 | _hyper_1_2_chunk
 (2 rows)
 
 -- recompress the paritial chunks
 SELECT compress_chunk('_timescaledb_internal._hyper_1_1_chunk');
+NOTICE:  chunk "_hyper_1_1_chunk" is already compressed
              compress_chunk             
 ----------------------------------------
  _timescaledb_internal._hyper_1_1_chunk

--- a/tsl/test/shared/expected/compression_dml.out
+++ b/tsl/test/shared/expected/compression_dml.out
@@ -258,3 +258,152 @@ QUERY PLAN
                      ->  Result (actual rows=1 loops=1)
 (10 rows)
 
+-- no decompression cause no match in batch
+BEGIN; :ANALYZE UPDATE lazy_decompress SET value = 3.14 WHERE value = 0; ROLLBACK;
+QUERY PLAN
+ Custom Scan (HypertableModify) (actual rows=0 loops=1)
+   ->  Update on lazy_decompress (actual rows=0 loops=1)
+         Update on _hyper_X_X_chunk lazy_decompress_1
+         ->  Result (actual rows=0 loops=1)
+               ->  Seq Scan on _hyper_X_X_chunk lazy_decompress_1 (actual rows=0 loops=1)
+                     Filter: (value = '0'::double precision)
+(6 rows)
+
+BEGIN; :ANALYZE UPDATE lazy_decompress SET value = 3.14 WHERE value = 0 AND device='d1'; ROLLBACK;
+QUERY PLAN
+ Custom Scan (HypertableModify) (actual rows=0 loops=1)
+   ->  Update on lazy_decompress (actual rows=0 loops=1)
+         Update on _hyper_X_X_chunk lazy_decompress_1
+         ->  Result (actual rows=0 loops=1)
+               ->  Seq Scan on _hyper_X_X_chunk lazy_decompress_1 (actual rows=0 loops=1)
+                     Filter: ((value = '0'::double precision) AND (device = 'd1'::text))
+(6 rows)
+
+-- 1 batch decompression
+BEGIN; :ANALYZE UPDATE lazy_decompress SET value = 3.14 WHERE value = 2300; ROLLBACK;
+QUERY PLAN
+ Custom Scan (HypertableModify) (actual rows=0 loops=1)
+   Batches decompressed: 1
+   Tuples decompressed: 1000
+   ->  Update on lazy_decompress (actual rows=0 loops=1)
+         Update on _hyper_X_X_chunk lazy_decompress_1
+         ->  Result (actual rows=1 loops=1)
+               ->  Seq Scan on _hyper_X_X_chunk lazy_decompress_1 (actual rows=1 loops=1)
+                     Filter: (value = '2300'::double precision)
+                     Rows Removed by Filter: 999
+(9 rows)
+
+BEGIN; :ANALYZE UPDATE lazy_decompress SET value = 3.14 WHERE value > 3100 AND value < 3200; ROLLBACK;
+QUERY PLAN
+ Custom Scan (HypertableModify) (actual rows=0 loops=1)
+   Batches decompressed: 1
+   Tuples decompressed: 1000
+   ->  Update on lazy_decompress (actual rows=0 loops=1)
+         Update on _hyper_X_X_chunk lazy_decompress_1
+         ->  Result (actual rows=99 loops=1)
+               ->  Seq Scan on _hyper_X_X_chunk lazy_decompress_1 (actual rows=99 loops=1)
+                     Filter: ((value > '3100'::double precision) AND (value < '3200'::double precision))
+                     Rows Removed by Filter: 901
+(9 rows)
+
+BEGIN; :ANALYZE UPDATE lazy_decompress SET value = 3.14 WHERE value BETWEEN 3100 AND 3200; ROLLBACK;
+QUERY PLAN
+ Custom Scan (HypertableModify) (actual rows=0 loops=1)
+   Batches decompressed: 1
+   Tuples decompressed: 1000
+   ->  Update on lazy_decompress (actual rows=0 loops=1)
+         Update on _hyper_X_X_chunk lazy_decompress_1
+         ->  Result (actual rows=101 loops=1)
+               ->  Seq Scan on _hyper_X_X_chunk lazy_decompress_1 (actual rows=101 loops=1)
+                     Filter: ((value >= '3100'::double precision) AND (value <= '3200'::double precision))
+                     Rows Removed by Filter: 899
+(9 rows)
+
+-- check GUC is working, should be 6 batches and 6000 tuples decompresed
+SET timescaledb.enable_dml_decompression_tuple_filtering TO off;
+BEGIN; :ANALYZE UPDATE lazy_decompress SET value = 3.14 WHERE value = 0 AND device='d1'; ROLLBACK;
+QUERY PLAN
+ Custom Scan (HypertableModify) (actual rows=0 loops=1)
+   Batches decompressed: 6
+   Tuples decompressed: 6000
+   ->  Update on lazy_decompress (actual rows=0 loops=1)
+         Update on _hyper_X_X_chunk lazy_decompress_1
+         ->  Result (actual rows=0 loops=1)
+               ->  Seq Scan on _hyper_X_X_chunk lazy_decompress_1 (actual rows=0 loops=1)
+                     Filter: ((value = '0'::double precision) AND (device = 'd1'::text))
+                     Rows Removed by Filter: 6000
+(9 rows)
+
+RESET timescaledb.enable_dml_decompression_tuple_filtering;
+-- no decompression cause no match in batch
+BEGIN; :ANALYZE DELETE FROM lazy_decompress WHERE value = 0; ROLLBACK;
+QUERY PLAN
+ Custom Scan (HypertableModify) (actual rows=0 loops=1)
+   ->  Delete on lazy_decompress (actual rows=0 loops=1)
+         Delete on _hyper_X_X_chunk lazy_decompress_1
+         ->  Seq Scan on _hyper_X_X_chunk lazy_decompress_1 (actual rows=0 loops=1)
+               Filter: (value = '0'::double precision)
+(5 rows)
+
+BEGIN; :ANALYZE DELETE FROM lazy_decompress WHERE value = 0 AND device='d1'; ROLLBACK;
+QUERY PLAN
+ Custom Scan (HypertableModify) (actual rows=0 loops=1)
+   ->  Delete on lazy_decompress (actual rows=0 loops=1)
+         Delete on _hyper_X_X_chunk lazy_decompress_1
+         ->  Seq Scan on _hyper_X_X_chunk lazy_decompress_1 (actual rows=0 loops=1)
+               Filter: ((value = '0'::double precision) AND (device = 'd1'::text))
+(5 rows)
+
+-- 1 batch decompression
+BEGIN; :ANALYZE DELETE FROM lazy_decompress WHERE value = 2300; ROLLBACK;
+QUERY PLAN
+ Custom Scan (HypertableModify) (actual rows=0 loops=1)
+   Batches decompressed: 1
+   Tuples decompressed: 1000
+   ->  Delete on lazy_decompress (actual rows=0 loops=1)
+         Delete on _hyper_X_X_chunk lazy_decompress_1
+         ->  Seq Scan on _hyper_X_X_chunk lazy_decompress_1 (actual rows=1 loops=1)
+               Filter: (value = '2300'::double precision)
+               Rows Removed by Filter: 999
+(8 rows)
+
+BEGIN; :ANALYZE DELETE FROM lazy_decompress WHERE value > 3100 AND value < 3200; ROLLBACK;
+QUERY PLAN
+ Custom Scan (HypertableModify) (actual rows=0 loops=1)
+   Batches decompressed: 1
+   Tuples decompressed: 1000
+   ->  Delete on lazy_decompress (actual rows=0 loops=1)
+         Delete on _hyper_X_X_chunk lazy_decompress_1
+         ->  Seq Scan on _hyper_X_X_chunk lazy_decompress_1 (actual rows=99 loops=1)
+               Filter: ((value > '3100'::double precision) AND (value < '3200'::double precision))
+               Rows Removed by Filter: 901
+(8 rows)
+
+BEGIN; :ANALYZE DELETE FROM lazy_decompress WHERE value BETWEEN 3100 AND 3200; ROLLBACK;
+QUERY PLAN
+ Custom Scan (HypertableModify) (actual rows=0 loops=1)
+   Batches decompressed: 1
+   Tuples decompressed: 1000
+   ->  Delete on lazy_decompress (actual rows=0 loops=1)
+         Delete on _hyper_X_X_chunk lazy_decompress_1
+         ->  Seq Scan on _hyper_X_X_chunk lazy_decompress_1 (actual rows=101 loops=1)
+               Filter: ((value >= '3100'::double precision) AND (value <= '3200'::double precision))
+               Rows Removed by Filter: 899
+(8 rows)
+
+-- check GUC is working, should be 6 batches and 6000 tuples decompresed
+SET timescaledb.enable_dml_decompression_tuple_filtering TO off;
+BEGIN; :ANALYZE DELETE FROM lazy_decompress WHERE value = 0 AND device='d1'; ROLLBACK;
+QUERY PLAN
+ Custom Scan (HypertableModify) (actual rows=0 loops=1)
+   Batches decompressed: 6
+   Tuples decompressed: 6000
+   ->  Delete on lazy_decompress (actual rows=0 loops=1)
+         Delete on _hyper_X_X_chunk lazy_decompress_1
+         ->  Seq Scan on _hyper_X_X_chunk lazy_decompress_1 (actual rows=0 loops=1)
+               Filter: ((value = '0'::double precision) AND (device = 'd1'::text))
+               Rows Removed by Filter: 6000
+(8 rows)
+
+RESET timescaledb.enable_dml_decompression_tuple_filtering;
+DROP TABLE lazy_decompress;


### PR DESCRIPTION
Only decompress batches for compressed UPDATE/DELETE when the batch actually has tuples that match the query constraints. This will work even for columns we have no metadata on.