### PR TITLE
Reduce decompression for INSERT with unique constraints

### DIFF
--- a/.unreleased/pr_7108
+++ b/.unreleased/pr_7108
@@ -1,0 +1,1 @@
+Implements: #7108 Reduce decompressions for INSERTs with UNIQUE constraints

--- a/src/nodes/chunk_dispatch/chunk_dispatch.c
+++ b/src/nodes/chunk_dispatch/chunk_dispatch.c
@@ -173,7 +173,7 @@ ts_chunk_dispatch_decompress_batches_for_insert(ChunkDispatch *dispatch, ChunkIn
 		if (ts_cm_functions->decompress_batches_for_insert)
 		{
 			ts_cm_functions->decompress_batches_for_insert(cis, slot);
-			OnConflictAction onconflict_action = chunk_dispatch_get_on_conflict_action(dispatch);
+			OnConflictAction onconflict_action = ts_chunk_dispatch_get_on_conflict_action(dispatch);
 			/* mark rows visible */
 			if (onconflict_action == ONCONFLICT_UPDATE)
 				dispatch->estate->es_output_cid = GetCurrentCommandId(true);

--- a/src/nodes/chunk_dispatch/chunk_dispatch.h
+++ b/src/nodes/chunk_dispatch/chunk_dispatch.h
@@ -76,6 +76,9 @@ typedef struct ChunkDispatchState
 	bool is_dropped_attr_exists;
 	int64 batches_decompressed;
 	int64 tuples_decompressed;
+
+	/* Should this INSERT be skipped due to ON CONFLICT DO NOTHING */
+	bool skip_current_tuple;
 } ChunkDispatchState;
 
 extern TSDLLEXPORT bool ts_is_chunk_dispatch_state(PlanState *state);

--- a/src/nodes/chunk_dispatch/chunk_insert_state.c
+++ b/src/nodes/chunk_dispatch/chunk_insert_state.c
@@ -80,7 +80,7 @@ chunk_dispatch_get_returning_clauses(const ChunkDispatch *dispatch)
 }
 
 OnConflictAction
-chunk_dispatch_get_on_conflict_action(const ChunkDispatch *dispatch)
+ts_chunk_dispatch_get_on_conflict_action(const ChunkDispatch *dispatch)
 {
 	if (!dispatch->dispatch_state || !dispatch->dispatch_state->mtstate)
 		return ONCONFLICT_NONE;
@@ -265,7 +265,7 @@ setup_on_conflict_state(ChunkInsertState *state, const ChunkDispatch *dispatch,
 	ModifyTableState *mtstate = castNode(ModifyTableState, dispatch->dispatch_state->mtstate);
 	ModifyTable *mt = castNode(ModifyTable, mtstate->ps.plan);
 
-	Assert(chunk_dispatch_get_on_conflict_action(dispatch) == ONCONFLICT_UPDATE);
+	Assert(ts_chunk_dispatch_get_on_conflict_action(dispatch) == ONCONFLICT_UPDATE);
 
 	OnConflictSetState *onconfl = makeNode(OnConflictSetState);
 	memcpy(onconfl, hyper_rri->ri_onConflict, sizeof(OnConflictSetState));
@@ -433,7 +433,7 @@ adjust_projections(ChunkInsertState *cis, const ChunkDispatch *dispatch, Oid row
 	Relation hyper_rel = dispatch->hypertable_result_rel_info->ri_RelationDesc;
 	Relation chunk_rel = cis->rel;
 	TupleConversionMap *chunk_map = NULL;
-	OnConflictAction onconflict_action = chunk_dispatch_get_on_conflict_action(dispatch);
+	OnConflictAction onconflict_action = ts_chunk_dispatch_get_on_conflict_action(dispatch);
 
 	if (chunk_dispatch_has_returning(dispatch))
 	{
@@ -479,7 +479,7 @@ ts_chunk_insert_state_create(Oid chunk_relid, const ChunkDispatch *dispatch)
 	MemoryContext cis_context = AllocSetContextCreate(dispatch->estate->es_query_cxt,
 													  "chunk insert state memory context",
 													  ALLOCSET_DEFAULT_SIZES);
-	OnConflictAction onconflict_action = chunk_dispatch_get_on_conflict_action(dispatch);
+	OnConflictAction onconflict_action = ts_chunk_dispatch_get_on_conflict_action(dispatch);
 	ResultRelInfo *relinfo;
 	const Chunk *chunk;
 

--- a/src/nodes/chunk_dispatch/chunk_insert_state.h
+++ b/src/nodes/chunk_dispatch/chunk_insert_state.h
@@ -65,5 +65,6 @@ extern ChunkInsertState *ts_chunk_insert_state_create(Oid chunk_relid,
 													  const ChunkDispatch *dispatch);
 extern void ts_chunk_insert_state_destroy(ChunkInsertState *state);
 
-OnConflictAction chunk_dispatch_get_on_conflict_action(const ChunkDispatch *dispatch);
+TSDLLEXPORT OnConflictAction
+ts_chunk_dispatch_get_on_conflict_action(const ChunkDispatch *dispatch);
 void ts_set_compression_status(ChunkInsertState *state, const Chunk *chunk);

--- a/src/nodes/hypertable_modify.c
+++ b/src/nodes/hypertable_modify.c
@@ -687,6 +687,14 @@ ExecModifyTable(CustomScanState *cs_node, PlanState *pstate)
 
 		context.planSlot = ExecProcNode(subplanstate);
 
+		if (cds && cds->rri && operation == CMD_INSERT && cds->skip_current_tuple)
+		{
+			cds->skip_current_tuple = false;
+			if (node->ps.instrument)
+				node->ps.instrument->ntuples2++;
+			return NULL;
+		}
+
 		/* No more tuples to process? */
 		if (TupIsNull(context.planSlot))
 			break;

--- a/tsl/src/compression/compression_dml.h
+++ b/tsl/src/compression/compression_dml.h
@@ -7,11 +7,27 @@
 
 #include <postgres.h>
 #include <access/skey.h>
+#include <nodes/nodes.h>
 
 #include "ts_catalog/compression_settings.h"
 
+typedef struct tuple_filtering_constraints
+{
+	Bitmapset *key_columns;
+	/*
+	 * The covered flag is set to true if we have a single constraint that is covered
+	 * by all the columns present in the Bitmapset.
+	 */
+	bool covered;
+	/* further fields only valid when covered is true */
+	OnConflictAction on_conflict;
+	Oid index_relid; /* used for better error messages */
+	bool nullsnotdistinct;
+} tuple_filtering_constraints;
+
 ScanKeyData *build_mem_scankeys_from_slot(Oid ht_relid, CompressionSettings *settings,
-										  Relation out_rel, Bitmapset *key_columns,
+										  Relation out_rel,
+										  tuple_filtering_constraints *constraints,
 										  TupleTableSlot *slot, int *num_scankeys);
 ScanKeyData *build_index_scankeys(Relation index_rel, List *index_filters, int *num_scankeys);
 ScanKeyData *build_index_scankeys_using_slot(Oid hypertable_relid, Relation in_rel,

--- a/tsl/test/expected/compression_conflicts.out
+++ b/tsl/test/expected/compression_conflicts.out
@@ -93,7 +93,7 @@ INSERT INTO comp_conflicts_1 VALUES ('2020-01-01','d1',0.1) ON CONFLICT DO NOTHI
 SELECT count(*) FROM ONLY :CHUNK;
  count 
 -------
-     1
+     0
 (1 row)
 
 -- test 2: multi-column unique without segmentby
@@ -169,7 +169,7 @@ INSERT INTO comp_conflicts_2 VALUES ('2020-01-01','d1',0.1) ON CONFLICT DO NOTHI
 SELECT count(*) FROM ONLY :CHUNK;
  count 
 -------
-     2
+     0
 (1 row)
 
 -- test 3: multi-column primary key with segmentby
@@ -288,7 +288,7 @@ BEGIN;
   SELECT count(*) FROM ONLY :CHUNK;
  count 
 -------
-     2
+     1
 (1 row)
 
 ROLLBACK;
@@ -301,7 +301,7 @@ BEGIN;
   SELECT count(*) FROM ONLY :CHUNK;
  count 
 -------
-     2
+     1
 (1 row)
 
 ROLLBACK;
@@ -388,7 +388,7 @@ INSERT INTO comp_conflicts_3 VALUES ('2020-01-01','d1', 'label', 0.1) ON CONFLIC
 SELECT count(*) FROM ONLY :CHUNK;
  count 
 -------
-     1
+     0
 (1 row)
 
 -- test 4: multi-column primary key with multi-column orderby compression
@@ -488,7 +488,7 @@ INSERT INTO comp_conflicts_4 VALUES ('2020-01-01 0:30:00','d1',0.1) ON CONFLICT 
 SELECT count(*) FROM ONLY :CHUNK;
  count 
 -------
-  2000
+     0
 (1 row)
 
 CREATE OR REPLACE VIEW compressed_chunk_info_view AS

--- a/tsl/test/expected/compression_insert.out
+++ b/tsl/test/expected/compression_insert.out
@@ -1090,14 +1090,11 @@ SET timescaledb.max_tuples_decompressed_per_dml_transaction = 1;
 \set ON_ERROR_STOP 0
 -- Inserting in the same period should decompress tuples
 INSERT INTO test_limit SELECT t, 2 FROM generate_series(1,6000,1000) t;
-ERROR:  tuple decompression limit exceeded by operation
-DETAIL:  current limit: 1, tuples decompressed: 1000
-HINT:  Consider increasing timescaledb.max_tuples_decompressed_per_dml_transaction or set to 0 (unlimited).
+ERROR:  duplicate key value violates unique constraint "_hyper_24_54_chunk_timestamp_id_idx"
 -- Setting to 0 should remove the limit.
 SET timescaledb.max_tuples_decompressed_per_dml_transaction = 0;
 INSERT INTO test_limit SELECT t, 2 FROM generate_series(1,6000,1000) t;
 ERROR:  duplicate key value violates unique constraint "_hyper_24_54_chunk_timestamp_id_idx"
-DETAIL:  Key ("timestamp", id)=(1, 2) already exists.
 \set ON_ERROR_STOP 1
 DROP TABLE test_limit;
 RESET timescaledb.max_tuples_decompressed_per_dml_transaction;
@@ -1152,7 +1149,6 @@ SELECT count(compress_chunk(c)) FROM show_chunks('unique_null') c;
 -- all INSERTS should fail with constraint violation
 BEGIN; INSERT INTO unique_null VALUES('2024-01-01', 0, 0, 1.0); ROLLBACK;
 ERROR:  duplicate key value violates unique constraint "78_3_unique_null_time_u1_u2_key"
-DETAIL:  Key ("time", u1, u2)=(Mon Jan 01 00:00:00 2024 PST, 0, 0) already exists.
 \set ON_ERROR_STOP 1
 -- neither of these should need to decompress
 :ANALYZE INSERT INTO unique_null VALUES('2024-01-01', NULL, 1, 1.0);

--- a/tsl/test/isolation/expected/compression_conflicts_iso.out
+++ b/tsl/test/isolation/expected/compression_conflicts_iso.out
@@ -407,7 +407,7 @@ step Ic: COMMIT;
 step SC1: SELECT (count_chunktable(ch)).* FROM show_chunks('ts_device_table') AS ch LIMIT 1;
 count(*)|count(*) only
 --------+-------------
-      10|           10
+      10|            0
 (1 row)
 
 step SA: SELECT * FROM ts_device_table;
@@ -474,7 +474,7 @@ step Ic: COMMIT;
 step SC1: SELECT (count_chunktable(ch)).* FROM show_chunks('ts_device_table') AS ch LIMIT 1;
 count(*)|count(*) only
 --------+-------------
-      10|           10
+      10|            0
 (1 row)
 
 step SA: SELECT * FROM ts_device_table;
@@ -541,7 +541,7 @@ step Ic: COMMIT;
 step SC1: SELECT (count_chunktable(ch)).* FROM show_chunks('ts_device_table') AS ch LIMIT 1;
 count(*)|count(*) only
 --------+-------------
-      10|           10
+      10|            0
 (1 row)
 
 step SA: SELECT * FROM ts_device_table;

--- a/tsl/test/shared/expected/compression_dml.out
+++ b/tsl/test/shared/expected/compression_dml.out
@@ -247,8 +247,6 @@ QUERY PLAN
 BEGIN; :ANALYZE INSERT INTO lazy_decompress SELECT '2024-01-01 0:00:01','d1',random() ON CONFLICT DO NOTHING; ROLLBACK;
 QUERY PLAN
  Custom Scan (HypertableModify) (actual rows=0 loops=1)
-   Batches decompressed: 1
-   Tuples decompressed: 1000
    ->  Insert on lazy_decompress (actual rows=0 loops=1)
          Conflict Resolution: NOTHING
          Tuples Inserted: 0
@@ -256,7 +254,7 @@ QUERY PLAN
          ->  Custom Scan (ChunkDispatch) (actual rows=1 loops=1)
                ->  Subquery Scan on "*SELECT*" (actual rows=1 loops=1)
                      ->  Result (actual rows=1 loops=1)
-(10 rows)
+(8 rows)
 
 -- no decompression cause no match in batch
 BEGIN; :ANALYZE UPDATE lazy_decompress SET value = 3.14 WHERE value = 0; ROLLBACK;

--- a/tsl/test/t/002_logrepl_decomp_marker.pl
+++ b/tsl/test/t/002_logrepl_decomp_marker.pl
@@ -218,11 +218,6 @@ query_generates_wal(
 	"insert into compressed chunk with pk forces decompression",
 	qq/INSERT INTO metrics VALUES ('2023-07-01 00:00:00Z', 1, 5555) ON CONFLICT DO NOTHING;/,
 	qq/BEGIN
-message: transactional: 1 prefix: ::timescaledb-decompression-start, sz: 0 content:
-table _timescaledb_internal.compress_hyper_3_4_chunk: DELETE: (no-tuple-data)
-table _timescaledb_internal._hyper_1_1_chunk: INSERT: "time"[timestamp with time zone]:'2023-06-30 17:00:00-07' device_id[bigint]:1 value[double precision]:1
-table _timescaledb_internal._hyper_1_1_chunk: INSERT: "time"[timestamp with time zone]:'2023-07-01 05:00:00-07' device_id[bigint]:1 value[double precision]:2
-message: transactional: 1 prefix: ::timescaledb-decompression-end, sz: 0 content:
 table _timescaledb_catalog.chunk: UPDATE: id[integer]:1 hypertable_id[integer]:1 schema_name[name]:'_timescaledb_internal' table_name[name]:'_hyper_1_1_chunk' compressed_chunk_id[integer]:4 dropped[boolean]:false status[integer]:9 osm_chunk[boolean]:false
 COMMIT/
 );
@@ -237,9 +232,6 @@ query_generates_wal(
 	qq(SELECT compress_chunk('_timescaledb_internal._hyper_1_1_chunk'::regclass, TRUE);),
 	qq(BEGIN
 table _timescaledb_catalog.chunk: UPDATE: id[integer]:1 hypertable_id[integer]:1 schema_name[name]:'_timescaledb_internal' table_name[name]:'_hyper_1_1_chunk' compressed_chunk_id[integer]:4 dropped[boolean]:false status[integer]:1 osm_chunk[boolean]:false
-table _timescaledb_internal._hyper_1_1_chunk: DELETE: "time"[timestamp with time zone]:'2023-06-30 17:00:00-07'
-table _timescaledb_internal._hyper_1_1_chunk: DELETE: "time"[timestamp with time zone]:'2023-07-01 05:00:00-07'
-table _timescaledb_internal.compress_hyper_3_4_chunk: INSERT: _ts_meta_count[integer]:2 _ts_meta_sequence_num[integer]:10 device_id[bigint]:1 _ts_meta_min_1[timestamp with time zone]:'2023-06-30 17:00:00-07' _ts_meta_max_1[timestamp with time zone]:'2023-07-01 05:00:00-07' "time"[_timescaledb_internal.compressed_data]:'BAAAAqJqcQfwAAAAAAoO67AAAAAAAgAAAAIAAAAAAAAA7gAFRMDEOIAAAAVErKZhH/8=' value[_timescaledb_internal.compressed_data]:'AwBAAAAAAAAAAAAAAAIAAAABAAAAAAAAAAEAAAAAAAAAAwAAAAIAAAABAAAAAAAAAAEAAAAAAAAAAwAAAAEMAAAAAAAAAEIAAAACAAAAAQAAAAAAAAAEAAAAAAAAALoAAAABFQAAAAAAH///'
 COMMIT)
 );
 


### PR DESCRIPTION
On INSERT into compressed chunks with unique constraints we can
check for conflict without decompressing when no ON CONFLICT clause
is present and we only have one unique constraint. With ON CONFLICT
clause with DO NOTHING we can just skip the INSERT if we detect conflict
and return early. Only for ON CONFLICT DO UPDATE/UPSERT do we need
to decompress when there is a constraint conflict.
Doing the optimization in the presence of multiple constraints is
also possible but not part of this patch.
