### PR TITLE
Use DELETE after compression

### DIFF
--- a/.unreleased/pr_7116
+++ b/.unreleased/pr_7116
@@ -1,0 +1,1 @@
+Implements: #7116 Use DELETE instead of TRUNCATE after compression

--- a/src/guc.c
+++ b/src/guc.c
@@ -85,6 +85,7 @@ static char *ts_guc_default_segmentby_fn = NULL;
 static char *ts_guc_default_orderby_fn = NULL;
 TSDLLEXPORT bool ts_guc_enable_job_execution_logging = false;
 bool ts_guc_enable_tss_callbacks = true;
+TSDLLEXPORT bool ts_guc_enable_delete_after_compression = false;
 
 /* default value of ts_guc_max_open_chunks_per_insert and ts_guc_max_cached_chunks_per_hypertable
  * will be set as their respective boot-value when the GUC mechanism starts up */
@@ -680,6 +681,17 @@ _guc_init(void)
 							 &ts_guc_enable_tss_callbacks,
 							 true,
 							 PGC_SUSET,
+							 0,
+							 NULL,
+							 NULL,
+							 NULL);
+
+	DefineCustomBoolVariable(MAKE_EXTOPTION("enable_delete_after_compression"),
+							 "Delete all rows after compression instead of truncate",
+							 "Delete all rows after compression instead of truncate",
+							 &ts_guc_enable_delete_after_compression,
+							 false,
+							 PGC_USERSET,
 							 0,
 							 NULL,
 							 NULL,

--- a/src/guc.h
+++ b/src/guc.h
@@ -42,6 +42,7 @@ extern int ts_guc_max_open_chunks_per_insert;
 extern int ts_guc_max_cached_chunks_per_hypertable;
 extern TSDLLEXPORT bool ts_guc_enable_job_execution_logging;
 extern bool ts_guc_enable_tss_callbacks;
+extern TSDLLEXPORT bool ts_guc_enable_delete_after_compression;
 
 #ifdef USE_TELEMETRY
 typedef enum TelemetryLevel

--- a/tsl/test/expected/compression.out
+++ b/tsl/test/expected/compression.out
@@ -2874,3 +2874,58 @@ SELECT compress_chunk(ch) FROM show_chunks('hyper_84') ch;
 
 -- indexscan for decompression: DELETE
 DELETE FROM hyper_84 WHERE device = 1;
+-- Test using DELETE instead of TRUNCATE after compression
+CREATE TABLE hyper_delete (time timestamptz, device int, location int, temp float, t text);
+SELECT table_name FROM create_hypertable('hyper_delete', 'time');
+NOTICE:  adding not-null constraint to column "time"
+  table_name  
+--------------
+ hyper_delete
+(1 row)
+
+INSERT INTO hyper_delete VALUES ('2024-07-10', 1, 1, 1.0, repeat('X', 10000));
+ANALYZE hyper_delete;
+SELECT ch AS "CHUNK" FROM show_chunks('hyper_delete') ch \gset
+SELECT relpages, reltuples::int AS reltuples FROM pg_catalog.pg_class WHERE oid = :'CHUNK'::regclass;
+ relpages | reltuples 
+----------+-----------
+        1 |         1
+(1 row)
+
+-- One uncompressed row
+SELECT count(*) FROM :CHUNK;
+ count 
+-------
+     1
+(1 row)
+
+ALTER TABLE hyper_delete SET (timescaledb.compress, timescaledb.compress_segmentby='device');
+NOTICE:  default order by for hypertable "hyper_delete" is set to ""time" DESC"
+SET timescaledb.enable_delete_after_compression TO true;
+SELECT FROM compress_chunk(:'CHUNK');
+--
+(1 row)
+
+-- still have more than one tuple
+SELECT relpages, reltuples::int AS reltuples FROM pg_catalog.pg_class WHERE oid = :'CHUNK'::regclass;
+ relpages | reltuples 
+----------+-----------
+        1 |         1
+(1 row)
+
+ANALYZE hyper_delete;
+-- after ANALYZE we should have no tuples
+SELECT relpages, reltuples::int AS reltuples FROM pg_catalog.pg_class WHERE oid = :'CHUNK'::regclass;
+ relpages | reltuples 
+----------+-----------
+        1 |         0
+(1 row)
+
+-- One compressed row
+SELECT count(*) FROM :CHUNK;
+ count 
+-------
+     1
+(1 row)
+
+RESET timescaledb.enable_delete_after_compression;

--- a/tsl/test/isolation/expected/compression_freeze.out
+++ b/tsl/test/isolation/expected/compression_freeze.out
@@ -11,18 +11,17 @@ count
 
 step s2_select_count_and_stats: 
    SELECT count(*) FROM sensor_data;
-   SELECT chunk_schema, chunk_name, compression_status FROM chunk_compression_stats('sensor_data') ORDER BY 1, 2, 3;
+   SELECT compression_status, count(*) FROM chunk_compression_stats('sensor_data') GROUP BY 1 ORDER BY 1, 2;
 
 count
 -----
 16850
 (1 row)
 
-chunk_schema         |chunk_name          |compression_status
----------------------+--------------------+------------------
-_timescaledb_internal|_hyper_X_X_chunk|Uncompressed      
-_timescaledb_internal|_hyper_X_X_chunk|Uncompressed      
-(2 rows)
+compression_status|count
+------------------+-----
+Uncompressed      |    2
+(1 row)
 
 
 starting permutation: s1_select_count s1_compress s1_select_count s2_select_count_and_stats
@@ -52,18 +51,17 @@ count
 
 step s2_select_count_and_stats: 
    SELECT count(*) FROM sensor_data;
-   SELECT chunk_schema, chunk_name, compression_status FROM chunk_compression_stats('sensor_data') ORDER BY 1, 2, 3;
+   SELECT compression_status, count(*) FROM chunk_compression_stats('sensor_data') GROUP BY 1 ORDER BY 1, 2;
 
 count
 -----
 16850
 (1 row)
 
-chunk_schema         |chunk_name          |compression_status
----------------------+--------------------+------------------
-_timescaledb_internal|_hyper_X_X_chunk|Compressed        
-_timescaledb_internal|_hyper_X_X_chunk|Compressed        
-(2 rows)
+compression_status|count
+------------------+-----
+Compressed        |    2
+(1 row)
 
 
 starting permutation: s2_lock_compression s2_select_count_and_stats s1_compress s2_select_count_and_stats s2_unlock_compression s2_select_count_and_stats
@@ -77,36 +75,34 @@ debug_waitpoint_enable
 
 step s2_select_count_and_stats: 
    SELECT count(*) FROM sensor_data;
-   SELECT chunk_schema, chunk_name, compression_status FROM chunk_compression_stats('sensor_data') ORDER BY 1, 2, 3;
+   SELECT compression_status, count(*) FROM chunk_compression_stats('sensor_data') GROUP BY 1 ORDER BY 1, 2;
 
 count
 -----
 16850
 (1 row)
 
-chunk_schema         |chunk_name          |compression_status
----------------------+--------------------+------------------
-_timescaledb_internal|_hyper_X_X_chunk|Uncompressed      
-_timescaledb_internal|_hyper_X_X_chunk|Uncompressed      
-(2 rows)
+compression_status|count
+------------------+-----
+Uncompressed      |    2
+(1 row)
 
 step s1_compress: 
    SELECT count(*) FROM (SELECT compress_chunk(i, if_not_compressed => true) FROM show_chunks('sensor_data') i) i;
  <waiting ...>
 step s2_select_count_and_stats: 
    SELECT count(*) FROM sensor_data;
-   SELECT chunk_schema, chunk_name, compression_status FROM chunk_compression_stats('sensor_data') ORDER BY 1, 2, 3;
+   SELECT compression_status, count(*) FROM chunk_compression_stats('sensor_data') GROUP BY 1 ORDER BY 1, 2;
 
 count
 -----
 16850
 (1 row)
 
-chunk_schema         |chunk_name          |compression_status
----------------------+--------------------+------------------
-_timescaledb_internal|_hyper_X_X_chunk|Uncompressed      
-_timescaledb_internal|_hyper_X_X_chunk|Uncompressed      
-(2 rows)
+compression_status|count
+------------------+-----
+Uncompressed      |    2
+(1 row)
 
 step s2_unlock_compression: 
     SELECT locktype, mode, granted, objid FROM pg_locks WHERE not granted AND (locktype = 'advisory' or relation::regclass::text LIKE '%chunk') ORDER BY relation, locktype, mode, granted;
@@ -130,16 +126,155 @@ count
 
 step s2_select_count_and_stats: 
    SELECT count(*) FROM sensor_data;
-   SELECT chunk_schema, chunk_name, compression_status FROM chunk_compression_stats('sensor_data') ORDER BY 1, 2, 3;
+   SELECT compression_status, count(*) FROM chunk_compression_stats('sensor_data') GROUP BY 1 ORDER BY 1, 2;
 
 count
 -----
 16850
 (1 row)
 
-chunk_schema         |chunk_name          |compression_status
----------------------+--------------------+------------------
-_timescaledb_internal|_hyper_X_X_chunk|Compressed        
-_timescaledb_internal|_hyper_X_X_chunk|Compressed        
+compression_status|count
+------------------+-----
+Compressed        |    2
+(1 row)
+
+
+starting permutation: s2_lock_compression_after_truncate s2_select_count_and_stats s1_compress s2_unlock_compression_after_truncate s2_select_count_and_stats
+step s2_lock_compression_after_truncate: 
+    SELECT debug_waitpoint_enable('compression_done_after_truncate_uncompressed');
+
+debug_waitpoint_enable
+----------------------
+                      
+(1 row)
+
+step s2_select_count_and_stats: 
+   SELECT count(*) FROM sensor_data;
+   SELECT compression_status, count(*) FROM chunk_compression_stats('sensor_data') GROUP BY 1 ORDER BY 1, 2;
+
+count
+-----
+16850
+(1 row)
+
+compression_status|count
+------------------+-----
+Uncompressed      |    2
+(1 row)
+
+step s1_compress: 
+   SELECT count(*) FROM (SELECT compress_chunk(i, if_not_compressed => true) FROM show_chunks('sensor_data') i) i;
+ <waiting ...>
+step s2_unlock_compression_after_truncate: 
+    SELECT locktype, mode, granted, objid FROM pg_locks WHERE granted AND relation::regclass::text LIKE '%hyper%chunk' ORDER BY relation, locktype, mode, granted;
+    SELECT debug_waitpoint_release('compression_done_after_truncate_uncompressed');
+
+locktype|mode               |granted|objid
+--------+-------------------+-------+-----
+relation|AccessExclusiveLock|t      |     
+relation|ExclusiveLock      |t      |     
+relation|ShareLock          |t      |     
+(3 rows)
+
+debug_waitpoint_release
+-----------------------
+                       
+(1 row)
+
+step s1_compress: <... completed>
+count
+-----
+    2
+(1 row)
+
+step s2_select_count_and_stats: 
+   SELECT count(*) FROM sensor_data;
+   SELECT compression_status, count(*) FROM chunk_compression_stats('sensor_data') GROUP BY 1 ORDER BY 1, 2;
+
+count
+-----
+16850
+(1 row)
+
+compression_status|count
+------------------+-----
+Compressed        |    2
+(1 row)
+
+
+starting permutation: s2_lock_compression_after_delete s2_select_count_and_stats s1_compress_delete s2_select_count_and_stats s2_unlock_compression_after_delete s2_select_count_and_stats
+step s2_lock_compression_after_delete: 
+    SELECT debug_waitpoint_enable('compression_done_after_delete_uncompressed');
+
+debug_waitpoint_enable
+----------------------
+                      
+(1 row)
+
+step s2_select_count_and_stats: 
+   SELECT count(*) FROM sensor_data;
+   SELECT compression_status, count(*) FROM chunk_compression_stats('sensor_data') GROUP BY 1 ORDER BY 1, 2;
+
+count
+-----
+16850
+(1 row)
+
+compression_status|count
+------------------+-----
+Uncompressed      |    2
+(1 row)
+
+step s1_compress_delete: 
+   SET timescaledb.enable_delete_after_compression TO on;
+   SELECT count(*) FROM (SELECT compress_chunk(i, if_not_compressed => true) FROM show_chunks('sensor_data') i) i;
+ <waiting ...>
+step s2_select_count_and_stats: 
+   SELECT count(*) FROM sensor_data;
+   SELECT compression_status, count(*) FROM chunk_compression_stats('sensor_data') GROUP BY 1 ORDER BY 1, 2;
+
+count
+-----
+16850
+(1 row)
+
+compression_status|count
+------------------+-----
+Uncompressed      |    2
+(1 row)
+
+step s2_unlock_compression_after_delete: 
+    SELECT locktype, mode, granted, objid FROM pg_locks WHERE granted AND relation::regclass::text LIKE '%hyper%chunk' ORDER BY relation, locktype, mode, granted;
+    SELECT debug_waitpoint_release('compression_done_after_delete_uncompressed');
+
+locktype|mode            |granted|objid
+--------+----------------+-------+-----
+relation|ExclusiveLock   |t      |     
+relation|RowExclusiveLock|t      |     
 (2 rows)
+
+debug_waitpoint_release
+-----------------------
+                       
+(1 row)
+
+step s1_compress_delete: <... completed>
+count
+-----
+    2
+(1 row)
+
+step s2_select_count_and_stats: 
+   SELECT count(*) FROM sensor_data;
+   SELECT compression_status, count(*) FROM chunk_compression_stats('sensor_data') GROUP BY 1 ORDER BY 1, 2;
+
+count
+-----
+16850
+(1 row)
+
+compression_status|count
+------------------+-----
+Compressed        |    2
+(1 row)
 

--- a/tsl/test/sql/compression.sql
+++ b/tsl/test/sql/compression.sql
@@ -1171,3 +1171,31 @@ UPDATE hyper_84 SET temp = 100 where device = 1;
 SELECT compress_chunk(ch) FROM show_chunks('hyper_84') ch;
 -- indexscan for decompression: DELETE
 DELETE FROM hyper_84 WHERE device = 1;
+
+-- Test using DELETE instead of TRUNCATE after compression
+CREATE TABLE hyper_delete (time timestamptz, device int, location int, temp float, t text);
+SELECT table_name FROM create_hypertable('hyper_delete', 'time');
+INSERT INTO hyper_delete VALUES ('2024-07-10', 1, 1, 1.0, repeat('X', 10000));
+ANALYZE hyper_delete;
+SELECT ch AS "CHUNK" FROM show_chunks('hyper_delete') ch \gset
+SELECT relpages, reltuples::int AS reltuples FROM pg_catalog.pg_class WHERE oid = :'CHUNK'::regclass;
+
+-- One uncompressed row
+SELECT count(*) FROM :CHUNK;
+
+ALTER TABLE hyper_delete SET (timescaledb.compress, timescaledb.compress_segmentby='device');
+
+SET timescaledb.enable_delete_after_compression TO true;
+SELECT FROM compress_chunk(:'CHUNK');
+
+-- still have more than one tuple
+SELECT relpages, reltuples::int AS reltuples FROM pg_catalog.pg_class WHERE oid = :'CHUNK'::regclass;
+ANALYZE hyper_delete;
+
+-- after ANALYZE we should have no tuples
+SELECT relpages, reltuples::int AS reltuples FROM pg_catalog.pg_class WHERE oid = :'CHUNK'::regclass;
+
+-- One compressed row
+SELECT count(*) FROM :CHUNK;
+
+RESET timescaledb.enable_delete_after_compression;


### PR DESCRIPTION
The last step of compressing chunk is cleanup the uncompressed chunk and currently it is done by a `TRUNCATE` that requires an `AccessExclusiveLock` preventing concurrent sessions even `SELECT` data from the hypertable.

With this PR will be possible to execute a `DELETE` instead of a `TRUNCATE` on the uncompressed chunk relaxing the lock to `RowExclusiveLock`. This new behavior is controled by a new GUC `timescaledb.enable_delete_after_compression` that is `false` by default.

The side effect of enabling this behavior will be more WAL generation because we'll delete each row from uncompressed chunk and also bloat due to a lot of dead tuples created.
