### PR TITLE
Fix coverity warning about NULL pointer dereference

### DIFF
--- a/tsl/src/compression/compression_dml.c
+++ b/tsl/src/compression/compression_dml.c
@@ -668,7 +668,7 @@ batch_matches(RowDecompressor *decompressor, ScanKeyData *scankeys, int num_scan
 
 								 ));
 				}
-				if (constraints->on_conflict == ONCONFLICT_NOTHING)
+				if (constraints->on_conflict == ONCONFLICT_NOTHING && skip_current_tuple)
 				{
 					*skip_current_tuple = true;
 				}


### PR DESCRIPTION
In current code skip_current_tuple will never be NULL pointer in ON CONFLICT DO NOTHING case but add an additional check nonetheless to make it safe against future refactoring.

Disable-check: force-changelog-file
