### PR TITLE
Optimize index path generation for ordered append

### DIFF
--- a/tsl/test/expected/transparent_decompression-14.out
+++ b/tsl/test/expected/transparent_decompression-14.out
@@ -1799,6 +1799,64 @@ ORDER BY q1.time;
                                  Rows Removed by Filter: 4
 (41 rows)
 
+:PREFIX WITH q1 AS (
+    SELECT time,
+        v1
+    FROM :TEST_TABLE
+    WHERE device_id = 1
+    ORDER BY time
+	LIMIT 5
+),
+q2 AS (
+    SELECT time,
+        v2
+    FROM :TEST_TABLE
+    WHERE device_id = 2
+    ORDER BY time
+	LIMIT 5
+)
+SELECT *
+FROM q1, q2;
+                                                                 QUERY PLAN                                                                  
+---------------------------------------------------------------------------------------------------------------------------------------------
+ Nested Loop (actual rows=25 loops=1)
+   ->  Limit (actual rows=5 loops=1)
+         ->  Custom Scan (ChunkAppend) on metrics (actual rows=5 loops=1)
+               Order: metrics."time"
+               ->  Sort (actual rows=5 loops=1)
+                     Sort Key: _hyper_1_1_chunk."time"
+                     Sort Method: top-N heapsort 
+                     ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk (actual rows=720 loops=1)
+                           ->  Seq Scan on compress_hyper_5_15_chunk (actual rows=1 loops=1)
+                                 Filter: (device_id = 1)
+                                 Rows Removed by Filter: 4
+               ->  Index Scan Backward using _hyper_1_2_chunk_metrics_time_idx on _hyper_1_2_chunk (never executed)
+                     Filter: (device_id = 1)
+               ->  Sort (never executed)
+                     Sort Key: _hyper_1_3_chunk."time"
+                     ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk (never executed)
+                           ->  Seq Scan on compress_hyper_5_16_chunk (never executed)
+                                 Filter: (device_id = 1)
+   ->  Materialize (actual rows=5 loops=5)
+         ->  Limit (actual rows=5 loops=1)
+               ->  Custom Scan (ChunkAppend) on metrics metrics_1 (actual rows=5 loops=1)
+                     Order: metrics_1."time"
+                     ->  Sort (actual rows=5 loops=1)
+                           Sort Key: _hyper_1_1_chunk_1."time"
+                           Sort Method: top-N heapsort 
+                           ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk _hyper_1_1_chunk_1 (actual rows=720 loops=1)
+                                 ->  Seq Scan on compress_hyper_5_15_chunk compress_hyper_5_15_chunk_1 (actual rows=1 loops=1)
+                                       Filter: (device_id = 2)
+                                       Rows Removed by Filter: 4
+                     ->  Index Scan Backward using _hyper_1_2_chunk_metrics_time_idx on _hyper_1_2_chunk _hyper_1_2_chunk_1 (never executed)
+                           Filter: (device_id = 2)
+                     ->  Sort (never executed)
+                           Sort Key: _hyper_1_3_chunk_1."time"
+                           ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk _hyper_1_3_chunk_1 (never executed)
+                                 ->  Seq Scan on compress_hyper_5_16_chunk compress_hyper_5_16_chunk_1 (never executed)
+                                       Filter: (device_id = 2)
+(36 rows)
+
 -- test prepared statement
 PREPARE prep AS
 SELECT count(time)
@@ -5817,6 +5875,63 @@ ORDER BY q1.time;
                                  Filter: (device_id = 2)
                                  Rows Removed by Filter: 2
 (37 rows)
+
+:PREFIX WITH q1 AS (
+    SELECT time,
+        v1
+    FROM :TEST_TABLE
+    WHERE device_id = 1
+    ORDER BY time
+	LIMIT 5
+),
+q2 AS (
+    SELECT time,
+        v2
+    FROM :TEST_TABLE
+    WHERE device_id = 2
+    ORDER BY time
+	LIMIT 5
+)
+SELECT *
+FROM q1, q2;
+                                                                QUERY PLAN                                                                
+------------------------------------------------------------------------------------------------------------------------------------------
+ Nested Loop (actual rows=25 loops=1)
+   ->  Limit (actual rows=5 loops=1)
+         ->  Custom Scan (ChunkAppend) on metrics_space (actual rows=5 loops=1)
+               Order: metrics_space."time"
+               ->  Sort (actual rows=5 loops=1)
+                     Sort Key: _hyper_2_4_chunk."time"
+                     Sort Method: top-N heapsort 
+                     ->  Custom Scan (DecompressChunk) on _hyper_2_4_chunk (actual rows=720 loops=1)
+                           ->  Seq Scan on compress_hyper_6_17_chunk (actual rows=1 loops=1)
+                                 Filter: (device_id = 1)
+               ->  Index Scan Backward using _hyper_2_7_chunk_metrics_space_time_idx on _hyper_2_7_chunk (never executed)
+                     Filter: (device_id = 1)
+               ->  Sort (never executed)
+                     Sort Key: _hyper_2_10_chunk."time"
+                     ->  Custom Scan (DecompressChunk) on _hyper_2_10_chunk (never executed)
+                           ->  Seq Scan on compress_hyper_6_20_chunk (never executed)
+                                 Filter: (device_id = 1)
+   ->  Materialize (actual rows=5 loops=5)
+         ->  Limit (actual rows=5 loops=1)
+               ->  Custom Scan (ChunkAppend) on metrics_space metrics_space_1 (actual rows=5 loops=1)
+                     Order: metrics_space_1."time"
+                     ->  Sort (actual rows=5 loops=1)
+                           Sort Key: _hyper_2_5_chunk."time"
+                           Sort Method: top-N heapsort 
+                           ->  Custom Scan (DecompressChunk) on _hyper_2_5_chunk (actual rows=720 loops=1)
+                                 ->  Seq Scan on compress_hyper_6_18_chunk (actual rows=1 loops=1)
+                                       Filter: (device_id = 2)
+                                       Rows Removed by Filter: 2
+                     ->  Index Scan Backward using _hyper_2_8_chunk_metrics_space_device_id_time_idx on _hyper_2_8_chunk (never executed)
+                           Index Cond: (device_id = 2)
+                     ->  Sort (never executed)
+                           Sort Key: _hyper_2_11_chunk."time"
+                           ->  Custom Scan (DecompressChunk) on _hyper_2_11_chunk (never executed)
+                                 ->  Seq Scan on compress_hyper_6_21_chunk (never executed)
+                                       Filter: (device_id = 2)
+(35 rows)
 
 -- test prepared statement
 PREPARE prep AS

--- a/tsl/test/expected/transparent_decompression-15.out
+++ b/tsl/test/expected/transparent_decompression-15.out
@@ -1799,6 +1799,64 @@ ORDER BY q1.time;
                                  Rows Removed by Filter: 4
 (41 rows)
 
+:PREFIX WITH q1 AS (
+    SELECT time,
+        v1
+    FROM :TEST_TABLE
+    WHERE device_id = 1
+    ORDER BY time
+	LIMIT 5
+),
+q2 AS (
+    SELECT time,
+        v2
+    FROM :TEST_TABLE
+    WHERE device_id = 2
+    ORDER BY time
+	LIMIT 5
+)
+SELECT *
+FROM q1, q2;
+                                                                 QUERY PLAN                                                                  
+---------------------------------------------------------------------------------------------------------------------------------------------
+ Nested Loop (actual rows=25 loops=1)
+   ->  Limit (actual rows=5 loops=1)
+         ->  Custom Scan (ChunkAppend) on metrics (actual rows=5 loops=1)
+               Order: metrics."time"
+               ->  Sort (actual rows=5 loops=1)
+                     Sort Key: _hyper_1_1_chunk."time"
+                     Sort Method: top-N heapsort 
+                     ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk (actual rows=720 loops=1)
+                           ->  Seq Scan on compress_hyper_5_15_chunk (actual rows=1 loops=1)
+                                 Filter: (device_id = 1)
+                                 Rows Removed by Filter: 4
+               ->  Index Scan Backward using _hyper_1_2_chunk_metrics_time_idx on _hyper_1_2_chunk (never executed)
+                     Filter: (device_id = 1)
+               ->  Sort (never executed)
+                     Sort Key: _hyper_1_3_chunk."time"
+                     ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk (never executed)
+                           ->  Seq Scan on compress_hyper_5_16_chunk (never executed)
+                                 Filter: (device_id = 1)
+   ->  Materialize (actual rows=5 loops=5)
+         ->  Limit (actual rows=5 loops=1)
+               ->  Custom Scan (ChunkAppend) on metrics metrics_1 (actual rows=5 loops=1)
+                     Order: metrics_1."time"
+                     ->  Sort (actual rows=5 loops=1)
+                           Sort Key: _hyper_1_1_chunk_1."time"
+                           Sort Method: top-N heapsort 
+                           ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk _hyper_1_1_chunk_1 (actual rows=720 loops=1)
+                                 ->  Seq Scan on compress_hyper_5_15_chunk compress_hyper_5_15_chunk_1 (actual rows=1 loops=1)
+                                       Filter: (device_id = 2)
+                                       Rows Removed by Filter: 4
+                     ->  Index Scan Backward using _hyper_1_2_chunk_metrics_time_idx on _hyper_1_2_chunk _hyper_1_2_chunk_1 (never executed)
+                           Filter: (device_id = 2)
+                     ->  Sort (never executed)
+                           Sort Key: _hyper_1_3_chunk_1."time"
+                           ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk _hyper_1_3_chunk_1 (never executed)
+                                 ->  Seq Scan on compress_hyper_5_16_chunk compress_hyper_5_16_chunk_1 (never executed)
+                                       Filter: (device_id = 2)
+(36 rows)
+
 -- test prepared statement
 PREPARE prep AS
 SELECT count(time)
@@ -5817,6 +5875,63 @@ ORDER BY q1.time;
                                  Filter: (device_id = 2)
                                  Rows Removed by Filter: 2
 (37 rows)
+
+:PREFIX WITH q1 AS (
+    SELECT time,
+        v1
+    FROM :TEST_TABLE
+    WHERE device_id = 1
+    ORDER BY time
+	LIMIT 5
+),
+q2 AS (
+    SELECT time,
+        v2
+    FROM :TEST_TABLE
+    WHERE device_id = 2
+    ORDER BY time
+	LIMIT 5
+)
+SELECT *
+FROM q1, q2;
+                                                                QUERY PLAN                                                                
+------------------------------------------------------------------------------------------------------------------------------------------
+ Nested Loop (actual rows=25 loops=1)
+   ->  Limit (actual rows=5 loops=1)
+         ->  Custom Scan (ChunkAppend) on metrics_space (actual rows=5 loops=1)
+               Order: metrics_space."time"
+               ->  Sort (actual rows=5 loops=1)
+                     Sort Key: _hyper_2_4_chunk."time"
+                     Sort Method: top-N heapsort 
+                     ->  Custom Scan (DecompressChunk) on _hyper_2_4_chunk (actual rows=720 loops=1)
+                           ->  Seq Scan on compress_hyper_6_17_chunk (actual rows=1 loops=1)
+                                 Filter: (device_id = 1)
+               ->  Index Scan Backward using _hyper_2_7_chunk_metrics_space_time_idx on _hyper_2_7_chunk (never executed)
+                     Filter: (device_id = 1)
+               ->  Sort (never executed)
+                     Sort Key: _hyper_2_10_chunk."time"
+                     ->  Custom Scan (DecompressChunk) on _hyper_2_10_chunk (never executed)
+                           ->  Seq Scan on compress_hyper_6_20_chunk (never executed)
+                                 Filter: (device_id = 1)
+   ->  Materialize (actual rows=5 loops=5)
+         ->  Limit (actual rows=5 loops=1)
+               ->  Custom Scan (ChunkAppend) on metrics_space metrics_space_1 (actual rows=5 loops=1)
+                     Order: metrics_space_1."time"
+                     ->  Sort (actual rows=5 loops=1)
+                           Sort Key: _hyper_2_5_chunk."time"
+                           Sort Method: top-N heapsort 
+                           ->  Custom Scan (DecompressChunk) on _hyper_2_5_chunk (actual rows=720 loops=1)
+                                 ->  Seq Scan on compress_hyper_6_18_chunk (actual rows=1 loops=1)
+                                       Filter: (device_id = 2)
+                                       Rows Removed by Filter: 2
+                     ->  Index Scan Backward using _hyper_2_8_chunk_metrics_space_device_id_time_idx on _hyper_2_8_chunk (never executed)
+                           Index Cond: (device_id = 2)
+                     ->  Sort (never executed)
+                           Sort Key: _hyper_2_11_chunk."time"
+                           ->  Custom Scan (DecompressChunk) on _hyper_2_11_chunk (never executed)
+                                 ->  Seq Scan on compress_hyper_6_21_chunk (never executed)
+                                       Filter: (device_id = 2)
+(35 rows)
 
 -- test prepared statement
 PREPARE prep AS

--- a/tsl/test/expected/transparent_decompression-16.out
+++ b/tsl/test/expected/transparent_decompression-16.out
@@ -1799,6 +1799,64 @@ ORDER BY q1.time;
                                  Rows Removed by Filter: 4
 (41 rows)
 
+:PREFIX WITH q1 AS (
+    SELECT time,
+        v1
+    FROM :TEST_TABLE
+    WHERE device_id = 1
+    ORDER BY time
+	LIMIT 5
+),
+q2 AS (
+    SELECT time,
+        v2
+    FROM :TEST_TABLE
+    WHERE device_id = 2
+    ORDER BY time
+	LIMIT 5
+)
+SELECT *
+FROM q1, q2;
+                                                                 QUERY PLAN                                                                  
+---------------------------------------------------------------------------------------------------------------------------------------------
+ Nested Loop (actual rows=25 loops=1)
+   ->  Limit (actual rows=5 loops=1)
+         ->  Custom Scan (ChunkAppend) on metrics (actual rows=5 loops=1)
+               Order: metrics."time"
+               ->  Sort (actual rows=5 loops=1)
+                     Sort Key: _hyper_1_1_chunk."time"
+                     Sort Method: top-N heapsort 
+                     ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk (actual rows=720 loops=1)
+                           ->  Seq Scan on compress_hyper_5_15_chunk (actual rows=1 loops=1)
+                                 Filter: (device_id = 1)
+                                 Rows Removed by Filter: 4
+               ->  Index Scan Backward using _hyper_1_2_chunk_metrics_time_idx on _hyper_1_2_chunk (never executed)
+                     Filter: (device_id = 1)
+               ->  Sort (never executed)
+                     Sort Key: _hyper_1_3_chunk."time"
+                     ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk (never executed)
+                           ->  Seq Scan on compress_hyper_5_16_chunk (never executed)
+                                 Filter: (device_id = 1)
+   ->  Materialize (actual rows=5 loops=5)
+         ->  Limit (actual rows=5 loops=1)
+               ->  Custom Scan (ChunkAppend) on metrics metrics_1 (actual rows=5 loops=1)
+                     Order: metrics_1."time"
+                     ->  Sort (actual rows=5 loops=1)
+                           Sort Key: _hyper_1_1_chunk_1."time"
+                           Sort Method: top-N heapsort 
+                           ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk _hyper_1_1_chunk_1 (actual rows=720 loops=1)
+                                 ->  Seq Scan on compress_hyper_5_15_chunk compress_hyper_5_15_chunk_1 (actual rows=1 loops=1)
+                                       Filter: (device_id = 2)
+                                       Rows Removed by Filter: 4
+                     ->  Index Scan Backward using _hyper_1_2_chunk_metrics_time_idx on _hyper_1_2_chunk _hyper_1_2_chunk_1 (never executed)
+                           Filter: (device_id = 2)
+                     ->  Sort (never executed)
+                           Sort Key: _hyper_1_3_chunk_1."time"
+                           ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk _hyper_1_3_chunk_1 (never executed)
+                                 ->  Seq Scan on compress_hyper_5_16_chunk compress_hyper_5_16_chunk_1 (never executed)
+                                       Filter: (device_id = 2)
+(36 rows)
+
 -- test prepared statement
 PREPARE prep AS
 SELECT count(time)
@@ -5817,6 +5875,63 @@ ORDER BY q1.time;
                                  Filter: (device_id = 2)
                                  Rows Removed by Filter: 2
 (37 rows)
+
+:PREFIX WITH q1 AS (
+    SELECT time,
+        v1
+    FROM :TEST_TABLE
+    WHERE device_id = 1
+    ORDER BY time
+	LIMIT 5
+),
+q2 AS (
+    SELECT time,
+        v2
+    FROM :TEST_TABLE
+    WHERE device_id = 2
+    ORDER BY time
+	LIMIT 5
+)
+SELECT *
+FROM q1, q2;
+                                                                QUERY PLAN                                                                
+------------------------------------------------------------------------------------------------------------------------------------------
+ Nested Loop (actual rows=25 loops=1)
+   ->  Limit (actual rows=5 loops=1)
+         ->  Custom Scan (ChunkAppend) on metrics_space (actual rows=5 loops=1)
+               Order: metrics_space."time"
+               ->  Sort (actual rows=5 loops=1)
+                     Sort Key: _hyper_2_4_chunk."time"
+                     Sort Method: top-N heapsort 
+                     ->  Custom Scan (DecompressChunk) on _hyper_2_4_chunk (actual rows=720 loops=1)
+                           ->  Seq Scan on compress_hyper_6_17_chunk (actual rows=1 loops=1)
+                                 Filter: (device_id = 1)
+               ->  Index Scan Backward using _hyper_2_7_chunk_metrics_space_time_idx on _hyper_2_7_chunk (never executed)
+                     Filter: (device_id = 1)
+               ->  Sort (never executed)
+                     Sort Key: _hyper_2_10_chunk."time"
+                     ->  Custom Scan (DecompressChunk) on _hyper_2_10_chunk (never executed)
+                           ->  Seq Scan on compress_hyper_6_20_chunk (never executed)
+                                 Filter: (device_id = 1)
+   ->  Materialize (actual rows=5 loops=5)
+         ->  Limit (actual rows=5 loops=1)
+               ->  Custom Scan (ChunkAppend) on metrics_space metrics_space_1 (actual rows=5 loops=1)
+                     Order: metrics_space_1."time"
+                     ->  Sort (actual rows=5 loops=1)
+                           Sort Key: _hyper_2_5_chunk."time"
+                           Sort Method: top-N heapsort 
+                           ->  Custom Scan (DecompressChunk) on _hyper_2_5_chunk (actual rows=720 loops=1)
+                                 ->  Seq Scan on compress_hyper_6_18_chunk (actual rows=1 loops=1)
+                                       Filter: (device_id = 2)
+                                       Rows Removed by Filter: 2
+                     ->  Index Scan Backward using _hyper_2_8_chunk_metrics_space_device_id_time_idx on _hyper_2_8_chunk (never executed)
+                           Index Cond: (device_id = 2)
+                     ->  Sort (never executed)
+                           Sort Key: _hyper_2_11_chunk."time"
+                           ->  Custom Scan (DecompressChunk) on _hyper_2_11_chunk (never executed)
+                                 ->  Seq Scan on compress_hyper_6_21_chunk (never executed)
+                                       Filter: (device_id = 2)
+(35 rows)
 
 -- test prepared statement
 PREPARE prep AS

--- a/tsl/test/sql/include/transparent_decompression_query.sql
+++ b/tsl/test/sql/include/transparent_decompression_query.sql
@@ -506,6 +506,25 @@ FROM q1
     INNER JOIN q2 ON q1.time = q2.time
 ORDER BY q1.time;
 
+:PREFIX WITH q1 AS (
+    SELECT time,
+        v1
+    FROM :TEST_TABLE
+    WHERE device_id = 1
+    ORDER BY time
+	LIMIT 5
+),
+q2 AS (
+    SELECT time,
+        v2
+    FROM :TEST_TABLE
+    WHERE device_id = 2
+    ORDER BY time
+	LIMIT 5
+)
+SELECT *
+FROM q1, q2;
+
 -- test prepared statement
 PREPARE prep AS
 SELECT count(time)


### PR DESCRIPTION
When creating index paths for compressed chunks, root->eq_classes can contain a lot of entries from other relations which slow down plan time. By filtering them to include only ECs which are from that relation, we can improve plan times significantly when lots of chunks are involved in the query.

Offers modest improvement up to 15% in plan times:
https://grafana.ops.savannah-dev.timescale.com/d/fasYic_4z/compare-akuzm?orgId=1&var-branch=All&var-run1=3629&var-run2=3630&var-threshold=0&var-use_historical_thresholds=true&var-threshold_expression=2.5%20%2A%20percentile_cont%280.90%29&var-exact_suite_version=false

Disable-check: force-changelog-file