### PR TITLE
Fix `enable_job_execution_logging` GUC context

### DIFF
--- a/src/guc.c
+++ b/src/guc.c
@@ -668,7 +668,7 @@ _guc_init(void)
 							 "Retain job run status in logging table",
 							 &ts_guc_enable_job_execution_logging,
 							 false,
-							 PGC_USERSET,
+							 PGC_SIGHUP,
 							 0,
 							 NULL,
 							 NULL,

--- a/tsl/test/expected/bgw_job_stat_history.out
+++ b/tsl/test/expected/bgw_job_stat_history.out
@@ -344,6 +344,31 @@ SELECT pg_reload_conf();
 (1 row)
 
 \c :TEST_DBNAME :ROLE_SUPERUSER
+-- The GUC is PGC_SIGHUP context so only ALTER SYSTEM is allowed
+\set ON_ERROR_STOP 0
+SHOW timescaledb.enable_job_execution_logging;
+ timescaledb.enable_job_execution_logging 
+------------------------------------------
+ off
+(1 row)
+
+SET timescaledb.enable_job_execution_logging TO OFF;
+ERROR:  parameter "timescaledb.enable_job_execution_logging" cannot be changed now
+SHOW timescaledb.enable_job_execution_logging;
+ timescaledb.enable_job_execution_logging 
+------------------------------------------
+ off
+(1 row)
+
+ALTER DATABASE :TEST_DBNAME SET timescaledb.enable_job_execution_logging TO ON;
+ERROR:  parameter "timescaledb.enable_job_execution_logging" cannot be changed now
+SHOW timescaledb.enable_job_execution_logging;
+ timescaledb.enable_job_execution_logging 
+------------------------------------------
+ off
+(1 row)
+
+\set ON_ERROR_STOP 1
 SELECT _timescaledb_functions.stop_background_workers();
  stop_background_workers 
 -------------------------

--- a/tsl/test/sql/bgw_job_stat_history.sql
+++ b/tsl/test/sql/bgw_job_stat_history.sql
@@ -157,4 +157,14 @@ ALTER SYSTEM RESET timescaledb.enable_job_execution_logging;
 SELECT pg_reload_conf();
 
 \c :TEST_DBNAME :ROLE_SUPERUSER
+
+-- The GUC is PGC_SIGHUP context so only ALTER SYSTEM is allowed
+\set ON_ERROR_STOP 0
+SHOW timescaledb.enable_job_execution_logging;
+SET timescaledb.enable_job_execution_logging TO OFF;
+SHOW timescaledb.enable_job_execution_logging;
+ALTER DATABASE :TEST_DBNAME SET timescaledb.enable_job_execution_logging TO ON;
+SHOW timescaledb.enable_job_execution_logging;
+\set ON_ERROR_STOP 1
+
 SELECT _timescaledb_functions.stop_background_workers();


### PR DESCRIPTION
In #6767 we allowed users to track job execution history by turning on the new GUC `timescaledb.enable_job_execution_logging`.

Unfortunately we defined this GUC as PGC_USERSET context but the right context should be PGC_SIGHUP since it won't work when setting at session and/or database level so we should restrict it to be used only by `ALTER SYSTEM SET` or changing the config files.

Disable-check: force-changelog-file
