### PR TITLE
Change hypertable foreign key handling

### DIFF
--- a/.unreleased/pr_7134
+++ b/.unreleased/pr_7134
@@ -1,0 +1,1 @@
+Implements: #7134 Refactor foreign key handling for compressed hypertables

--- a/sql/updates/reverse-dev.sql
+++ b/sql/updates/reverse-dev.sql
@@ -5,3 +5,20 @@ DROP FUNCTION IF EXISTS @extschema@.disable_column_stats(REGCLASS, NAME, BOOLEAN
 ALTER EXTENSION timescaledb DROP TABLE _timescaledb_catalog.chunk_column_stats;
 ALTER EXTENSION timescaledb DROP SEQUENCE _timescaledb_catalog.chunk_column_stats_id_seq;
 DROP TABLE IF EXISTS _timescaledb_catalog.chunk_column_stats;
+
+-- Add foreign key constraints back to compressed chunks
+DO $$
+DECLARE
+  chunkrelid regclass;
+  conname name;
+  conoid oid;
+BEGIN
+  FOR chunkrelid, conname, conoid IN
+  SELECT format('%I.%I',ch.schema_name,ch.table_name)::regclass, con.conname, con.oid
+  FROM _timescaledb_catalog.hypertable ht
+  JOIN pg_constraint con ON con.contype = 'f' AND con.conrelid=format('%I.%I',ht.schema_name,ht.table_name)::regclass
+  JOIN _timescaledb_catalog.chunk ch on ch.hypertable_id=ht.compressed_hypertable_id and not ch.dropped
+  LOOP
+    EXECUTE format('ALTER TABLE %s ADD CONSTRAINT %I %s', chunkrelid, conname, pg_get_constraintdef(conoid));
+  END LOOP;
+END $$;

--- a/src/chunk_constraint.c
+++ b/src/chunk_constraint.c
@@ -729,7 +729,7 @@ ts_chunk_constraint_scan_by_dimension_slice_id(int32 dimension_slice_id, ChunkCo
 }
 
 static bool
-chunk_constraint_need_on_chunk(const char chunk_relkind, Form_pg_constraint conform)
+chunk_constraint_need_on_chunk(Form_pg_constraint conform)
 {
 	if (conform->contype == CONSTRAINT_CHECK)
 	{
@@ -753,24 +753,7 @@ chunk_constraint_need_on_chunk(const char chunk_relkind, Form_pg_constraint conf
 	if (conform->contype == CONSTRAINT_FOREIGN && OidIsValid(conform->conparentid))
 		return false;
 
-	/* Foreign tables do not support non-check constraints, so skip them */
-	if (chunk_relkind == RELKIND_FOREIGN_TABLE)
-		return false;
-
 	return true;
-}
-
-static bool
-chunk_constraint_is_check(const char chunk_relkind, Form_pg_constraint conform)
-{
-	if (conform->contype == CONSTRAINT_CHECK)
-	{
-		/*
-		 * check constraints supported on foreign tables (like OSM chunks)
-		 */
-		return true;
-	}
-	return false;
 }
 
 int
@@ -799,7 +782,7 @@ chunk_constraint_add(HeapTuple constraint_tuple, void *arg)
 	ConstraintContext *cc = arg;
 	Form_pg_constraint constraint = (Form_pg_constraint) GETSTRUCT(constraint_tuple);
 
-	if (chunk_constraint_need_on_chunk(cc->chunk_relkind, constraint))
+	if (cc->chunk_relkind != RELKIND_FOREIGN_TABLE && chunk_constraint_need_on_chunk(constraint))
 	{
 		ts_chunk_constraints_add(cc->ccs, cc->chunk_id, 0, NULL, NameStr(constraint->conname));
 		return CONSTR_PROCESSED;
@@ -828,7 +811,7 @@ chunk_constraint_add_check(HeapTuple constraint_tuple, void *arg)
 	ConstraintContext *cc = arg;
 	Form_pg_constraint constraint = (Form_pg_constraint) GETSTRUCT(constraint_tuple);
 
-	if (chunk_constraint_is_check(cc->chunk_relkind, constraint))
+	if (constraint->contype == CONSTRAINT_CHECK)
 	{
 		ts_chunk_constraints_add(cc->ccs,
 								 cc->chunk_id,
@@ -867,7 +850,7 @@ ts_chunk_constraint_create_on_chunk(const Hypertable *ht, const Chunk *chunk, Oi
 
 	con = (Form_pg_constraint) GETSTRUCT(tuple);
 
-	if (chunk_constraint_need_on_chunk(chunk->relkind, con))
+	if (chunk->relkind != RELKIND_FOREIGN_TABLE && chunk_constraint_need_on_chunk(con))
 	{
 		ChunkConstraint *cc = ts_chunk_constraints_add(chunk->constraints,
 													   chunk->fd.id,

--- a/src/process_utility.c
+++ b/src/process_utility.c
@@ -153,6 +153,18 @@ check_chunk_alter_table_operation_allowed(Oid relid, AlterTableStmt *stmt)
 					}
 					break;
 				}
+				case AT_DropConstraint:
+				{
+					/* if this is an OSM chunk, block the operation */
+					Chunk *chunk = ts_chunk_get_by_relid(relid, false /* fail_if_not_found */);
+					if (chunk && chunk->fd.osm_chunk)
+					{
+						ereport(ERROR,
+								(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
+								 errmsg("operation not supported on OSM chunk tables")));
+					}
+					break;
+				}
 				default:
 					/* disable by default */
 					all_allowed = false;

--- a/test/expected/rowsecurity-14.out
+++ b/test/expected/rowsecurity-14.out
@@ -4794,7 +4794,7 @@ ALTER TABLE r2 FORCE ROW LEVEL SECURITY;
 UPDATE r1 SET a = a+5;
 ERROR:  new row for relation "_hyper_28_117_chunk" violates check constraint "constraint_117"
 DETAIL:  Failing row contains (15).
-CONTEXT:  SQL statement "UPDATE ONLY "_timescaledb_internal"."_hyper_28_117_chunk" SET "a" = $1 WHERE $2 OPERATOR(pg_catalog.=) "a""
+CONTEXT:  SQL statement "UPDATE ONLY "regress_rls_schema"."r2" SET "a" = $1 WHERE $2 OPERATOR(pg_catalog.=) "a""
 -- Remove FORCE from r2
 ALTER TABLE r2 NO FORCE ROW LEVEL SECURITY;
 -- As owner, we now bypass RLS

--- a/test/expected/rowsecurity-15.out
+++ b/test/expected/rowsecurity-15.out
@@ -4796,7 +4796,7 @@ ALTER TABLE r2 FORCE ROW LEVEL SECURITY;
 UPDATE r1 SET a = a+5;
 ERROR:  new row for relation "_hyper_28_117_chunk" violates check constraint "constraint_117"
 DETAIL:  Failing row contains (15).
-CONTEXT:  SQL statement "UPDATE ONLY "_timescaledb_internal"."_hyper_28_117_chunk" SET "a" = $1 WHERE $2 OPERATOR(pg_catalog.=) "a""
+CONTEXT:  SQL statement "UPDATE ONLY "regress_rls_schema"."r2" SET "a" = $1 WHERE $2 OPERATOR(pg_catalog.=) "a""
 -- Remove FORCE from r2
 ALTER TABLE r2 NO FORCE ROW LEVEL SECURITY;
 -- As owner, we now bypass RLS

--- a/test/expected/rowsecurity-16.out
+++ b/test/expected/rowsecurity-16.out
@@ -4796,7 +4796,7 @@ ALTER TABLE r2 FORCE ROW LEVEL SECURITY;
 UPDATE r1 SET a = a+5;
 ERROR:  new row for relation "_hyper_28_117_chunk" violates check constraint "constraint_117"
 DETAIL:  Failing row contains (15).
-CONTEXT:  SQL statement "UPDATE ONLY "_timescaledb_internal"."_hyper_28_117_chunk" SET "a" = $1 WHERE $2 OPERATOR(pg_catalog.=) "a""
+CONTEXT:  SQL statement "UPDATE ONLY "regress_rls_schema"."r2" SET "a" = $1 WHERE $2 OPERATOR(pg_catalog.=) "a""
 -- Remove FORCE from r2
 ALTER TABLE r2 NO FORCE ROW LEVEL SECURITY;
 -- As owner, we now bypass RLS

--- a/tsl/test/expected/compression.out
+++ b/tsl/test/expected/compression.out
@@ -1144,10 +1144,9 @@ SELECT create_hypertable('table1','col1', chunk_time_interval => 10);
  (22,public,table1,t)
 (1 row)
 
--- Trying to list an incomplete set of fields of the compound key (should fail with a nice message)
+-- Trying to list an incomplete set of fields of the compound key
 ALTER TABLE table1 SET (timescaledb.compress, timescaledb.compress_segmentby = 'col1');
 NOTICE:  default order by for hypertable "table1" is set to ""
-ERROR:  column "col2" must be used for segmenting
 -- Listing all fields of the compound key should succeed:
 ALTER TABLE table1 SET (timescaledb.compress, timescaledb.compress_segmentby = 'col1,col2');
 NOTICE:  default order by for hypertable "table1" is set to ""

--- a/tsl/test/expected/compression_errors-14.out
+++ b/tsl/test/expected/compression_errors-14.out
@@ -356,10 +356,6 @@ BEGIN;
 ALTER TABLE table_constr set (timescaledb.compress, timescaledb.compress_orderby = 'timec', timescaledb.compress_segmentby = 'device_id');
 WARNING:  column "location" should be used for segmenting or ordering
 ROLLBACK;
-alter table table_constr add constraint table_constr_fk FOREIGN KEY(d) REFERENCES fortable(col) on delete cascade;
-ALTER TABLE table_constr set (timescaledb.compress, timescaledb.compress_orderby = 'timec', timescaledb.compress_segmentby = 'device_id, location');
-ERROR:  column "d" must be used for segmenting
-DETAIL:  The foreign key constraint "table_constr_fk" cannot be enforced with the given compression configuration.
 --exclusion constraints not allowed
 alter table table_constr add constraint table_constr_exclu exclude using btree (timec with = );
 ALTER TABLE table_constr set (timescaledb.compress, timescaledb.compress_orderby = 'timec', timescaledb.compress_segmentby = 'device_id, location, d');
@@ -452,10 +448,7 @@ INSERT INTO fortable VALUES( 99 );
 INSERT INTO table_constr2 VALUES( 1000, 10, 5, 99);
 ALTER TABLE table_constr2 SET (timescaledb.compress, timescaledb.compress_segmentby = 'device_id');
 NOTICE:  default order by for hypertable "table_constr2" is set to "timec DESC"
-ERROR:  column "d" must be used for segmenting
-DETAIL:  The foreign key constraint "table_constr2_d_fkey" cannot be enforced with the given compression configuration.
  ALTER TABLE table_constr2 SET (timescaledb.compress, timescaledb.compress_segmentby = 'device_id, d');
-NOTICE:  default order by for hypertable "table_constr2" is set to "timec DESC"
 --compress a chunk and try to disable compression, it should fail --
 SELECT ch1.schema_name|| '.' || ch1.table_name AS "CHUNK_NAME"
 FROM _timescaledb_catalog.chunk ch1, _timescaledb_catalog.hypertable ht

--- a/tsl/test/expected/compression_errors-15.out
+++ b/tsl/test/expected/compression_errors-15.out
@@ -356,10 +356,6 @@ BEGIN;
 ALTER TABLE table_constr set (timescaledb.compress, timescaledb.compress_orderby = 'timec', timescaledb.compress_segmentby = 'device_id');
 WARNING:  column "location" should be used for segmenting or ordering
 ROLLBACK;
-alter table table_constr add constraint table_constr_fk FOREIGN KEY(d) REFERENCES fortable(col) on delete cascade;
-ALTER TABLE table_constr set (timescaledb.compress, timescaledb.compress_orderby = 'timec', timescaledb.compress_segmentby = 'device_id, location');
-ERROR:  column "d" must be used for segmenting
-DETAIL:  The foreign key constraint "table_constr_fk" cannot be enforced with the given compression configuration.
 --exclusion constraints not allowed
 alter table table_constr add constraint table_constr_exclu exclude using btree (timec with = );
 ALTER TABLE table_constr set (timescaledb.compress, timescaledb.compress_orderby = 'timec', timescaledb.compress_segmentby = 'device_id, location, d');
@@ -452,10 +448,7 @@ INSERT INTO fortable VALUES( 99 );
 INSERT INTO table_constr2 VALUES( 1000, 10, 5, 99);
 ALTER TABLE table_constr2 SET (timescaledb.compress, timescaledb.compress_segmentby = 'device_id');
 NOTICE:  default order by for hypertable "table_constr2" is set to "timec DESC"
-ERROR:  column "d" must be used for segmenting
-DETAIL:  The foreign key constraint "table_constr2_d_fkey" cannot be enforced with the given compression configuration.
  ALTER TABLE table_constr2 SET (timescaledb.compress, timescaledb.compress_segmentby = 'device_id, d');
-NOTICE:  default order by for hypertable "table_constr2" is set to "timec DESC"
 --compress a chunk and try to disable compression, it should fail --
 SELECT ch1.schema_name|| '.' || ch1.table_name AS "CHUNK_NAME"
 FROM _timescaledb_catalog.chunk ch1, _timescaledb_catalog.hypertable ht

--- a/tsl/test/expected/compression_errors-16.out
+++ b/tsl/test/expected/compression_errors-16.out
@@ -356,10 +356,6 @@ BEGIN;
 ALTER TABLE table_constr set (timescaledb.compress, timescaledb.compress_orderby = 'timec', timescaledb.compress_segmentby = 'device_id');
 WARNING:  column "location" should be used for segmenting or ordering
 ROLLBACK;
-alter table table_constr add constraint table_constr_fk FOREIGN KEY(d) REFERENCES fortable(col) on delete cascade;
-ALTER TABLE table_constr set (timescaledb.compress, timescaledb.compress_orderby = 'timec', timescaledb.compress_segmentby = 'device_id, location');
-ERROR:  column "d" must be used for segmenting
-DETAIL:  The foreign key constraint "table_constr_fk" cannot be enforced with the given compression configuration.
 --exclusion constraints not allowed
 alter table table_constr add constraint table_constr_exclu exclude using btree (timec with = );
 ALTER TABLE table_constr set (timescaledb.compress, timescaledb.compress_orderby = 'timec', timescaledb.compress_segmentby = 'device_id, location, d');
@@ -452,10 +448,7 @@ INSERT INTO fortable VALUES( 99 );
 INSERT INTO table_constr2 VALUES( 1000, 10, 5, 99);
 ALTER TABLE table_constr2 SET (timescaledb.compress, timescaledb.compress_segmentby = 'device_id');
 NOTICE:  default order by for hypertable "table_constr2" is set to "timec DESC"
-ERROR:  column "d" must be used for segmenting
-DETAIL:  The foreign key constraint "table_constr2_d_fkey" cannot be enforced with the given compression configuration.
  ALTER TABLE table_constr2 SET (timescaledb.compress, timescaledb.compress_segmentby = 'device_id, d');
-NOTICE:  default order by for hypertable "table_constr2" is set to "timec DESC"
 --compress a chunk and try to disable compression, it should fail --
 SELECT ch1.schema_name|| '.' || ch1.table_name AS "CHUNK_NAME"
 FROM _timescaledb_catalog.chunk ch1, _timescaledb_catalog.hypertable ht

--- a/tsl/test/expected/compression_fks.out
+++ b/tsl/test/expected/compression_fks.out
@@ -37,10 +37,9 @@ INSERT INTO ht_with_fk SELECT '2000-01-01 0:00:01';
 ERROR:  insert or update on table "_hyper_1_2_chunk" violates foreign key constraint "2_2_keys"
 \set ON_ERROR_STOP 1
 SELECT conrelid::regclass,conname,confrelid::regclass FROM pg_constraint WHERE contype = 'f' AND confrelid = 'keys'::regclass ORDER BY conrelid::regclass::text COLLATE "C",conname;
-                    conrelid                    | conname  | confrelid 
-------------------------------------------------+----------+-----------
- _timescaledb_internal._hyper_1_2_chunk         | 2_2_keys | keys
- _timescaledb_internal.compress_hyper_2_3_chunk | keys     | keys
- ht_with_fk                                     | keys     | keys
-(3 rows)
+                conrelid                | conname  | confrelid 
+----------------------------------------+----------+-----------
+ _timescaledb_internal._hyper_1_2_chunk | 2_2_keys | keys
+ ht_with_fk                             | keys     | keys
+(2 rows)
 

--- a/tsl/test/expected/foreign_keys.out
+++ b/tsl/test/expected/foreign_keys.out
@@ -739,11 +739,13 @@ SELECT * FROM ht;
 (2 rows)
 
 EXPLAIN (analyze, costs off, timing off, summary off) SELECT * FROM ht;
-                                 QUERY PLAN                                  
------------------------------------------------------------------------------
- Custom Scan (DecompressChunk) on _hyper_13_14_chunk (actual rows=2 loops=1)
-   ->  Seq Scan on compress_hyper_14_19_chunk (actual rows=2 loops=1)
-(2 rows)
+                                    QUERY PLAN                                     
+-----------------------------------------------------------------------------------
+ Append (actual rows=2 loops=1)
+   ->  Custom Scan (DecompressChunk) on _hyper_13_14_chunk (actual rows=1 loops=1)
+         ->  Seq Scan on compress_hyper_14_19_chunk (actual rows=1 loops=1)
+   ->  Seq Scan on _hyper_13_14_chunk (actual rows=1 loops=1)
+(4 rows)
 
 ROLLBACK;
 -- ON DELETE CASCADE
@@ -778,11 +780,13 @@ SELECT * FROM ht;
 (1 row)
 
 EXPLAIN (analyze, costs off, timing off, summary off) SELECT * FROM ht;
-                                 QUERY PLAN                                  
------------------------------------------------------------------------------
- Custom Scan (DecompressChunk) on _hyper_13_14_chunk (actual rows=1 loops=1)
-   ->  Seq Scan on compress_hyper_14_20_chunk (actual rows=1 loops=1)
-(2 rows)
+                                    QUERY PLAN                                     
+-----------------------------------------------------------------------------------
+ Append (actual rows=1 loops=1)
+   ->  Custom Scan (DecompressChunk) on _hyper_13_14_chunk (actual rows=1 loops=1)
+         ->  Seq Scan on compress_hyper_14_20_chunk (actual rows=1 loops=1)
+   ->  Seq Scan on _hyper_13_14_chunk (actual rows=0 loops=1)
+(4 rows)
 
 ROLLBACK;
 -- SET NULL
@@ -823,11 +827,13 @@ SELECT * FROM ht;
 (2 rows)
 
 EXPLAIN (analyze, costs off, timing off, summary off) SELECT * FROM ht;
-                                 QUERY PLAN                                  
------------------------------------------------------------------------------
- Custom Scan (DecompressChunk) on _hyper_13_14_chunk (actual rows=2 loops=1)
-   ->  Seq Scan on compress_hyper_14_21_chunk (actual rows=2 loops=1)
-(2 rows)
+                                    QUERY PLAN                                     
+-----------------------------------------------------------------------------------
+ Append (actual rows=2 loops=1)
+   ->  Custom Scan (DecompressChunk) on _hyper_13_14_chunk (actual rows=1 loops=1)
+         ->  Seq Scan on compress_hyper_14_21_chunk (actual rows=1 loops=1)
+   ->  Seq Scan on _hyper_13_14_chunk (actual rows=1 loops=1)
+(4 rows)
 
 ROLLBACK;
 -- ON DELETE SET NULL
@@ -864,18 +870,20 @@ SELECT * FROM ht;
 (2 rows)
 
 EXPLAIN (analyze, costs off, timing off, summary off) SELECT * FROM ht;
-                                 QUERY PLAN                                  
------------------------------------------------------------------------------
- Custom Scan (DecompressChunk) on _hyper_13_14_chunk (actual rows=2 loops=1)
-   ->  Seq Scan on compress_hyper_14_22_chunk (actual rows=2 loops=1)
-(2 rows)
+                                    QUERY PLAN                                     
+-----------------------------------------------------------------------------------
+ Append (actual rows=2 loops=1)
+   ->  Custom Scan (DecompressChunk) on _hyper_13_14_chunk (actual rows=1 loops=1)
+         ->  Seq Scan on compress_hyper_14_22_chunk (actual rows=1 loops=1)
+   ->  Seq Scan on _hyper_13_14_chunk (actual rows=1 loops=1)
+(4 rows)
 
 ROLLBACK;
 -- SET DEFAULT
 -- should fail with foreign key violation
 INSERT INTO ht(time, fk_set_default) VALUES ('2020-01-01', 'fk_set_default');
 ERROR:  insert or update on table "_hyper_13_14_chunk" violates foreign key constraint "14_16_ht_fk_set_default_fkey"
--- set default is not supported for hypertables so these will fail
+-- ON UPDATE SET DEFAULT
 BEGIN;
 INSERT INTO fk_set_default(fk_set_default) VALUES ('fk_set_default');
 INSERT INTO ht(time, fk_set_default) VALUES ('2020-01-01', 'fk_set_default');
@@ -887,8 +895,50 @@ SELECT * FROM ht;
 (2 rows)
 
 UPDATE fk_set_default SET fk_set_default = 'fk_set_default_updated' WHERE fk_set_default = 'fk_set_default';
-ERROR:  update or delete on table "fk_set_default" violates foreign key constraint "ht_fk_set_default_fkey" on table "ht"
+SELECT * FROM ht;
+             time             | fk_no_action | fk_restrict | fk_cascade | fk_set_null | fk_set_default 
+------------------------------+--------------+-------------+------------+-------------+----------------
+ Wed Jan 01 00:00:00 2020 PST |              |             |            |             | default
+ Wed Jan 01 00:00:00 2020 PST |              |             |            |             | default
+(2 rows)
+
 ROLLBACK;
+-- ON UPDATE SET DEFAULT with compression
+BEGIN;
+INSERT INTO fk_set_default(fk_set_default) VALUES ('fk_set_default');
+INSERT INTO ht(time, fk_set_default) VALUES ('2020-01-01', 'fk_set_default');
+SELECT count(compress_chunk(ch)) FROM show_chunks('ht') ch;
+ count 
+-------
+     1
+(1 row)
+
+SELECT * FROM ht;
+             time             | fk_no_action | fk_restrict | fk_cascade | fk_set_null | fk_set_default 
+------------------------------+--------------+-------------+------------+-------------+----------------
+ Wed Jan 01 00:00:00 2020 PST |              |             |            |             | default
+ Wed Jan 01 00:00:00 2020 PST |              |             |            |             | fk_set_default
+(2 rows)
+
+UPDATE fk_set_default SET fk_set_default = 'fk_set_default_updated' WHERE fk_set_default = 'fk_set_default';
+SELECT * FROM ht;
+             time             | fk_no_action | fk_restrict | fk_cascade | fk_set_null | fk_set_default 
+------------------------------+--------------+-------------+------------+-------------+----------------
+ Wed Jan 01 00:00:00 2020 PST |              |             |            |             | default
+ Wed Jan 01 00:00:00 2020 PST |              |             |            |             | default
+(2 rows)
+
+EXPLAIN (analyze, costs off, timing off, summary off) SELECT * FROM ht;
+                                    QUERY PLAN                                     
+-----------------------------------------------------------------------------------
+ Append (actual rows=2 loops=1)
+   ->  Custom Scan (DecompressChunk) on _hyper_13_14_chunk (actual rows=1 loops=1)
+         ->  Seq Scan on compress_hyper_14_23_chunk (actual rows=1 loops=1)
+   ->  Seq Scan on _hyper_13_14_chunk (actual rows=1 loops=1)
+(4 rows)
+
+ROLLBACK;
+-- ON DELETE SET DEFAULT
 BEGIN;
 INSERT INTO fk_set_default(fk_set_default) VALUES ('fk_set_default');
 INSERT INTO ht(time, fk_set_default) VALUES ('2020-01-01', 'fk_set_default');
@@ -900,5 +950,39 @@ SELECT * FROM ht;
 (2 rows)
 
 DELETE FROM fk_set_default WHERE fk_set_default = 'fk_set_default';
-ERROR:  update or delete on table "fk_set_default" violates foreign key constraint "ht_fk_set_default_fkey" on table "ht"
+ROLLBACK;
+-- ON DELETE SET DEFAULT with compression
+BEGIN;
+INSERT INTO fk_set_default(fk_set_default) VALUES ('fk_set_default');
+INSERT INTO ht(time, fk_set_default) VALUES ('2020-01-01', 'fk_set_default');
+SELECT count(compress_chunk(ch)) FROM show_chunks('ht') ch;
+ count 
+-------
+     1
+(1 row)
+
+SELECT * FROM ht;
+             time             | fk_no_action | fk_restrict | fk_cascade | fk_set_null | fk_set_default 
+------------------------------+--------------+-------------+------------+-------------+----------------
+ Wed Jan 01 00:00:00 2020 PST |              |             |            |             | default
+ Wed Jan 01 00:00:00 2020 PST |              |             |            |             | fk_set_default
+(2 rows)
+
+DELETE FROM fk_set_default WHERE fk_set_default = 'fk_set_default';
+SELECT * FROM ht;
+             time             | fk_no_action | fk_restrict | fk_cascade | fk_set_null | fk_set_default 
+------------------------------+--------------+-------------+------------+-------------+----------------
+ Wed Jan 01 00:00:00 2020 PST |              |             |            |             | default
+ Wed Jan 01 00:00:00 2020 PST |              |             |            |             | default
+(2 rows)
+
+EXPLAIN (analyze, costs off, timing off, summary off) SELECT * FROM ht;
+                                    QUERY PLAN                                     
+-----------------------------------------------------------------------------------
+ Append (actual rows=2 loops=1)
+   ->  Custom Scan (DecompressChunk) on _hyper_13_14_chunk (actual rows=1 loops=1)
+         ->  Seq Scan on compress_hyper_14_24_chunk (actual rows=1 loops=1)
+   ->  Seq Scan on _hyper_13_14_chunk (actual rows=1 loops=1)
+(4 rows)
+
 ROLLBACK;

--- a/tsl/test/sql/compression.sql
+++ b/tsl/test/sql/compression.sql
@@ -462,7 +462,7 @@ CREATE TABLE table2(col1 INT, col2 int, primary key (col1,col2));
 CREATE TABLE table1(col1 INT NOT NULL, col2 INT);
 ALTER TABLE table1 ADD CONSTRAINT fk_table1 FOREIGN KEY (col1,col2) REFERENCES table2(col1,col2);
 SELECT create_hypertable('table1','col1', chunk_time_interval => 10);
--- Trying to list an incomplete set of fields of the compound key (should fail with a nice message)
+-- Trying to list an incomplete set of fields of the compound key
 ALTER TABLE table1 SET (timescaledb.compress, timescaledb.compress_segmentby = 'col1');
 -- Listing all fields of the compound key should succeed:
 ALTER TABLE table1 SET (timescaledb.compress, timescaledb.compress_segmentby = 'col1,col2');

--- a/tsl/test/sql/compression_errors.sql.in
+++ b/tsl/test/sql/compression_errors.sql.in
@@ -181,9 +181,6 @@ BEGIN;
 ALTER TABLE table_constr set (timescaledb.compress, timescaledb.compress_orderby = 'timec', timescaledb.compress_segmentby = 'device_id');
 ROLLBACK;
 
-alter table table_constr add constraint table_constr_fk FOREIGN KEY(d) REFERENCES fortable(col) on delete cascade;
-ALTER TABLE table_constr set (timescaledb.compress, timescaledb.compress_orderby = 'timec', timescaledb.compress_segmentby = 'device_id, location');
-
 --exclusion constraints not allowed
 alter table table_constr add constraint table_constr_exclu exclude using btree (timec with = );
 ALTER TABLE table_constr set (timescaledb.compress, timescaledb.compress_orderby = 'timec', timescaledb.compress_segmentby = 'device_id, location, d');

--- a/tsl/test/sql/foreign_keys.sql
+++ b/tsl/test/sql/foreign_keys.sql
@@ -590,17 +590,42 @@ ROLLBACK;
 -- should fail with foreign key violation
 INSERT INTO ht(time, fk_set_default) VALUES ('2020-01-01', 'fk_set_default');
 
--- set default is not supported for hypertables so these will fail
+-- ON UPDATE SET DEFAULT
 BEGIN;
 INSERT INTO fk_set_default(fk_set_default) VALUES ('fk_set_default');
 INSERT INTO ht(time, fk_set_default) VALUES ('2020-01-01', 'fk_set_default');
 SELECT * FROM ht;
 UPDATE fk_set_default SET fk_set_default = 'fk_set_default_updated' WHERE fk_set_default = 'fk_set_default';
+SELECT * FROM ht;
 ROLLBACK;
+
+-- ON UPDATE SET DEFAULT with compression
+BEGIN;
+INSERT INTO fk_set_default(fk_set_default) VALUES ('fk_set_default');
+INSERT INTO ht(time, fk_set_default) VALUES ('2020-01-01', 'fk_set_default');
+SELECT count(compress_chunk(ch)) FROM show_chunks('ht') ch;
+SELECT * FROM ht;
+UPDATE fk_set_default SET fk_set_default = 'fk_set_default_updated' WHERE fk_set_default = 'fk_set_default';
+SELECT * FROM ht;
+EXPLAIN (analyze, costs off, timing off, summary off) SELECT * FROM ht;
+ROLLBACK;
+
+-- ON DELETE SET DEFAULT
 BEGIN;
 INSERT INTO fk_set_default(fk_set_default) VALUES ('fk_set_default');
 INSERT INTO ht(time, fk_set_default) VALUES ('2020-01-01', 'fk_set_default');
 SELECT * FROM ht;
 DELETE FROM fk_set_default WHERE fk_set_default = 'fk_set_default';
+ROLLBACK;
+
+-- ON DELETE SET DEFAULT with compression
+BEGIN;
+INSERT INTO fk_set_default(fk_set_default) VALUES ('fk_set_default');
+INSERT INTO ht(time, fk_set_default) VALUES ('2020-01-01', 'fk_set_default');
+SELECT count(compress_chunk(ch)) FROM show_chunks('ht') ch;
+SELECT * FROM ht;
+DELETE FROM fk_set_default WHERE fk_set_default = 'fk_set_default';
+SELECT * FROM ht;
+EXPLAIN (analyze, costs off, timing off, summary off) SELECT * FROM ht;
 ROLLBACK;
 


### PR DESCRIPTION
Don't copy foreign key constraints to the individual chunks and instead modify the lookup query to propagate to individual chunks to mimic how postgres does this for partitioned tables.