### PR TITLE
Fix CAgg watermark constify using CTE

### DIFF
--- a/tsl/test/expected/cagg_watermark-14.out
+++ b/tsl/test/expected/cagg_watermark-14.out
@@ -1820,3 +1820,44 @@ SELECT time_bucket, lead(count) OVER (ORDER BY time_bucket) FROM small_integer_h
                            One-Time Filter: false
 (12 rows)
 
+-- SDC #1905: Using cagg on CTE should be constified
+:EXPLAIN_ANALYZE
+WITH cagg AS (
+    SELECT * FROM small_integer_ht_cagg
+)
+SELECT * FROM cagg WHERE time_bucket > 10;
+                                                             QUERY PLAN                                                              
+-------------------------------------------------------------------------------------------------------------------------------------
+ Append (actual rows=3 loops=1)
+   ->  Index Scan using _hyper_15_64_chunk__materialized_hypertable_15_time_bucket_idx on _hyper_15_64_chunk (actual rows=3 loops=1)
+         Index Cond: ((time_bucket < '30'::bigint) AND (time_bucket > 10))
+   ->  HashAggregate (actual rows=0 loops=1)
+         Group Key: time_bucket('5'::bigint, "time")
+         Batches: 1 
+         ->  Result (actual rows=0 loops=1)
+               One-Time Filter: false
+(8 rows)
+
+:EXPLAIN_ANALYZE
+WITH cagg AS (
+    SELECT * FROM small_integer_ht_cagg
+),
+other AS (
+    SELECT * FROM generate_series(1,10)
+)
+SELECT * FROM cagg, other WHERE time_bucket > 10;
+                                                                   QUERY PLAN                                                                    
+-------------------------------------------------------------------------------------------------------------------------------------------------
+ Nested Loop (actual rows=30 loops=1)
+   ->  Function Scan on generate_series (actual rows=10 loops=1)
+   ->  Materialize (actual rows=3 loops=10)
+         ->  Append (actual rows=3 loops=1)
+               ->  Index Scan using _hyper_15_64_chunk__materialized_hypertable_15_time_bucket_idx on _hyper_15_64_chunk (actual rows=3 loops=1)
+                     Index Cond: ((time_bucket < '30'::bigint) AND (time_bucket > 10))
+               ->  HashAggregate (actual rows=0 loops=1)
+                     Group Key: time_bucket('5'::bigint, "time")
+                     Batches: 1 
+                     ->  Result (actual rows=0 loops=1)
+                           One-Time Filter: false
+(11 rows)
+

--- a/tsl/test/expected/cagg_watermark-15.out
+++ b/tsl/test/expected/cagg_watermark-15.out
@@ -1827,3 +1827,44 @@ SELECT time_bucket, lead(count) OVER (ORDER BY time_bucket) FROM small_integer_h
                            One-Time Filter: false
 (12 rows)
 
+-- SDC #1905: Using cagg on CTE should be constified
+:EXPLAIN_ANALYZE
+WITH cagg AS (
+    SELECT * FROM small_integer_ht_cagg
+)
+SELECT * FROM cagg WHERE time_bucket > 10;
+                                                             QUERY PLAN                                                              
+-------------------------------------------------------------------------------------------------------------------------------------
+ Append (actual rows=3 loops=1)
+   ->  Index Scan using _hyper_15_64_chunk__materialized_hypertable_15_time_bucket_idx on _hyper_15_64_chunk (actual rows=3 loops=1)
+         Index Cond: ((time_bucket < '30'::bigint) AND (time_bucket > 10))
+   ->  HashAggregate (actual rows=0 loops=1)
+         Group Key: time_bucket('5'::bigint, "time")
+         Batches: 1 
+         ->  Result (actual rows=0 loops=1)
+               One-Time Filter: false
+(8 rows)
+
+:EXPLAIN_ANALYZE
+WITH cagg AS (
+    SELECT * FROM small_integer_ht_cagg
+),
+other AS (
+    SELECT * FROM generate_series(1,10)
+)
+SELECT * FROM cagg, other WHERE time_bucket > 10;
+                                                                   QUERY PLAN                                                                    
+-------------------------------------------------------------------------------------------------------------------------------------------------
+ Nested Loop (actual rows=30 loops=1)
+   ->  Function Scan on generate_series (actual rows=10 loops=1)
+   ->  Materialize (actual rows=3 loops=10)
+         ->  Append (actual rows=3 loops=1)
+               ->  Index Scan using _hyper_15_64_chunk__materialized_hypertable_15_time_bucket_idx on _hyper_15_64_chunk (actual rows=3 loops=1)
+                     Index Cond: ((time_bucket < '30'::bigint) AND (time_bucket > 10))
+               ->  HashAggregate (actual rows=0 loops=1)
+                     Group Key: time_bucket('5'::bigint, "time")
+                     Batches: 1 
+                     ->  Result (actual rows=0 loops=1)
+                           One-Time Filter: false
+(11 rows)
+

--- a/tsl/test/expected/cagg_watermark-16.out
+++ b/tsl/test/expected/cagg_watermark-16.out
@@ -1827,3 +1827,44 @@ SELECT time_bucket, lead(count) OVER (ORDER BY time_bucket) FROM small_integer_h
                            One-Time Filter: false
 (12 rows)
 
+-- SDC #1905: Using cagg on CTE should be constified
+:EXPLAIN_ANALYZE
+WITH cagg AS (
+    SELECT * FROM small_integer_ht_cagg
+)
+SELECT * FROM cagg WHERE time_bucket > 10;
+                                                             QUERY PLAN                                                              
+-------------------------------------------------------------------------------------------------------------------------------------
+ Append (actual rows=3 loops=1)
+   ->  Index Scan using _hyper_15_64_chunk__materialized_hypertable_15_time_bucket_idx on _hyper_15_64_chunk (actual rows=3 loops=1)
+         Index Cond: ((time_bucket < '30'::bigint) AND (time_bucket > 10))
+   ->  HashAggregate (actual rows=0 loops=1)
+         Group Key: time_bucket('5'::bigint, "time")
+         Batches: 1 
+         ->  Result (actual rows=0 loops=1)
+               One-Time Filter: false
+(8 rows)
+
+:EXPLAIN_ANALYZE
+WITH cagg AS (
+    SELECT * FROM small_integer_ht_cagg
+),
+other AS (
+    SELECT * FROM generate_series(1,10)
+)
+SELECT * FROM cagg, other WHERE time_bucket > 10;
+                                                                   QUERY PLAN                                                                    
+-------------------------------------------------------------------------------------------------------------------------------------------------
+ Nested Loop (actual rows=30 loops=1)
+   ->  Function Scan on generate_series (actual rows=10 loops=1)
+   ->  Materialize (actual rows=3 loops=10)
+         ->  Append (actual rows=3 loops=1)
+               ->  Index Scan using _hyper_15_64_chunk__materialized_hypertable_15_time_bucket_idx on _hyper_15_64_chunk (actual rows=3 loops=1)
+                     Index Cond: ((time_bucket < '30'::bigint) AND (time_bucket > 10))
+               ->  HashAggregate (actual rows=0 loops=1)
+                     Group Key: time_bucket('5'::bigint, "time")
+                     Batches: 1 
+                     ->  Result (actual rows=0 loops=1)
+                           One-Time Filter: false
+(11 rows)
+

--- a/tsl/test/expected/cagg_watermark-17.out
+++ b/tsl/test/expected/cagg_watermark-17.out
@@ -1827,3 +1827,44 @@ SELECT time_bucket, lead(count) OVER (ORDER BY time_bucket) FROM small_integer_h
                            One-Time Filter: false
 (12 rows)
 
+-- SDC #1905: Using cagg on CTE should be constified
+:EXPLAIN_ANALYZE
+WITH cagg AS (
+    SELECT * FROM small_integer_ht_cagg
+)
+SELECT * FROM cagg WHERE time_bucket > 10;
+                                                             QUERY PLAN                                                              
+-------------------------------------------------------------------------------------------------------------------------------------
+ Append (actual rows=3 loops=1)
+   ->  Index Scan using _hyper_15_64_chunk__materialized_hypertable_15_time_bucket_idx on _hyper_15_64_chunk (actual rows=3 loops=1)
+         Index Cond: ((time_bucket < '30'::bigint) AND (time_bucket > 10))
+   ->  HashAggregate (actual rows=0 loops=1)
+         Group Key: time_bucket('5'::bigint, "time")
+         Batches: 1 
+         ->  Result (actual rows=0 loops=1)
+               One-Time Filter: false
+(8 rows)
+
+:EXPLAIN_ANALYZE
+WITH cagg AS (
+    SELECT * FROM small_integer_ht_cagg
+),
+other AS (
+    SELECT * FROM generate_series(1,10)
+)
+SELECT * FROM cagg, other WHERE time_bucket > 10;
+                                                                   QUERY PLAN                                                                    
+-------------------------------------------------------------------------------------------------------------------------------------------------
+ Nested Loop (actual rows=30 loops=1)
+   ->  Function Scan on generate_series (actual rows=10 loops=1)
+   ->  Materialize (actual rows=3 loops=10)
+         ->  Append (actual rows=3 loops=1)
+               ->  Index Scan using _hyper_15_64_chunk__materialized_hypertable_15_time_bucket_idx on _hyper_15_64_chunk (actual rows=3 loops=1)
+                     Index Cond: ((time_bucket < '30'::bigint) AND (time_bucket > 10))
+               ->  HashAggregate (actual rows=0 loops=1)
+                     Group Key: time_bucket('5'::bigint, "time")
+                     Batches: 1 
+                     ->  Result (actual rows=0 loops=1)
+                           One-Time Filter: false
+(11 rows)
+

--- a/tsl/test/sql/cagg_watermark.sql.in
+++ b/tsl/test/sql/cagg_watermark.sql.in
@@ -569,3 +569,19 @@ TRUNCATE _timescaledb_catalog.continuous_aggs_invalidation_threshold;
 -- Issue #6722: constify cagg_watermark using window func when querying a cagg
 :EXPLAIN_ANALYZE
 SELECT time_bucket, lead(count) OVER (ORDER BY time_bucket) FROM small_integer_ht_cagg;
+
+-- SDC #1905: Using cagg on CTE should be constified
+:EXPLAIN_ANALYZE
+WITH cagg AS (
+    SELECT * FROM small_integer_ht_cagg
+)
+SELECT * FROM cagg WHERE time_bucket > 10;
+
+:EXPLAIN_ANALYZE
+WITH cagg AS (
+    SELECT * FROM small_integer_ht_cagg
+),
+other AS (
+    SELECT * FROM generate_series(1,10)
+)
+SELECT * FROM cagg, other WHERE time_bucket > 10;


### PR DESCRIPTION
Some more complex queries using CAggs on CTEs was not properly applying the `cagg_watermark` constify optimization because we restricted it to more simple queries.

Simplified the code and only restrict SELECT queries to apply the optimization.

Disable-check: force-changelog-file
