### PR TITLE
Block c function definitions in latest-dev.sql

### DIFF
--- a/.github/workflows/catalog-updates-check.yaml
+++ b/.github/workflows/catalog-updates-check.yaml
@@ -20,7 +20,7 @@ jobs:
 
       - name: Check latest-dev contents
         run: |
-          python scripts/check_updates_ast.py "sql/updates/latest-dev.sql"
+          python scripts/check_updates_ast.py --latest "sql/updates/latest-dev.sql"
 
       # To allow fixing previous mistakes we run the check against reverse-dev but don't
       # fail it on errors.

--- a/sql/updates/latest-dev.sql
+++ b/sql/updates/latest-dev.sql
@@ -8,7 +8,7 @@ CREATE FUNCTION @extschema@.enable_column_stats(
     column_name             NAME,
     if_not_exists           BOOLEAN = FALSE
 ) RETURNS TABLE(column_stats_id INT, enabled BOOL)
-AS '@MODULE_PATHNAME@', 'ts_chunk_column_stats_enable' LANGUAGE C VOLATILE;
+AS 'SELECT NULL,NULL' LANGUAGE SQL VOLATILE SET search_path = pg_catalog, pg_temp;
 
 -- Disable tracking of statistics on a column of a hypertable.
 --
@@ -21,7 +21,7 @@ CREATE FUNCTION @extschema@.disable_column_stats(
     column_name             NAME,
     if_not_exists           BOOLEAN = FALSE
 ) RETURNS TABLE(hypertable_id INT, column_name NAME, disabled BOOL)
-AS '@MODULE_PATHNAME@', 'ts_chunk_column_stats_disable' LANGUAGE C VOLATILE;
+AS 'SELECT NULL,NULL,NULL' LANGUAGE SQL VOLATILE SET search_path = pg_catalog, pg_temp;
 
 -- Track statistics for columns of chunks from a hypertable.
 -- Currently, we track the min/max range for a given column across chunks.


### PR DESCRIPTION
Having c function references in the versioned part of the sql
scripts introduces linking requirements to the update script
potentially preventing version updates. To prevent this we can
have a dummy function in latest-dev.sql since it will get over-
written as the final step of the extension update.

Disable-check: force-changelog-file
