### PR TITLE
Fix segfault on CAggs with multiple JOINs

### DIFF
--- a/tsl/src/continuous_aggs/common.h
+++ b/tsl/src/continuous_aggs/common.h
@@ -36,7 +36,6 @@
 #include "ts_catalog/catalog.h"
 #include "ts_catalog/continuous_agg.h"
 
-#define CONTINUOUS_AGG_MAX_JOIN_RELATIONS 2
 #define DEFAULT_MATPARTCOLUMN_NAME "time_partition_col"
 #define CAGG_INVALIDATION_THRESHOLD_NAME "invalidation threshold watermark"
 
@@ -66,6 +65,7 @@ typedef struct CAggTimebucketInfo
 	int32 htid;						/* hypertable id */
 	int32 parent_mat_hypertable_id; /* parent materialization hypertable id */
 	Oid htoid;						/* hypertable oid */
+	Oid htoidparent;				/* parent hypertable oid in case of hierarchical */
 	AttrNumber htpartcolno;			/* primary partitioning column of raw hypertable */
 									/* This should also be the column used by time_bucket */
 	Oid htpartcoltype;				/* The collation type */

--- a/tsl/test/expected/cagg_joins.out
+++ b/tsl/test/expected/cagg_joins.out
@@ -69,7 +69,7 @@ View definition:
 ( SELECT _materialized_hypertable_3.bucket,
     _materialized_hypertable_3.avg,
     _materialized_hypertable_3.name
-   FROM _timescaledb_internal._materialized_hypertable_3 _materialized_hypertable_3
+   FROM _timescaledb_internal._materialized_hypertable_3
   WHERE _materialized_hypertable_3.bucket < COALESCE(_timescaledb_functions.to_timestamp(_timescaledb_functions.cagg_watermark(3)), '-infinity'::timestamp with time zone)
   ORDER BY _materialized_hypertable_3.bucket)
 UNION ALL
@@ -147,7 +147,7 @@ View definition:
 ( SELECT _materialized_hypertable_4.bucket,
     _materialized_hypertable_4.avg,
     _materialized_hypertable_4.name
-   FROM _timescaledb_internal._materialized_hypertable_4 _materialized_hypertable_4
+   FROM _timescaledb_internal._materialized_hypertable_4
   WHERE _materialized_hypertable_4.bucket < COALESCE(_timescaledb_functions.to_timestamp(_timescaledb_functions.cagg_watermark(4)), '-infinity'::timestamp with time zone)
   ORDER BY _materialized_hypertable_4.bucket)
 UNION ALL
@@ -226,7 +226,7 @@ View definition:
 ( SELECT _materialized_hypertable_5.bucket,
     _materialized_hypertable_5.avg,
     _materialized_hypertable_5.name
-   FROM _timescaledb_internal._materialized_hypertable_5 _materialized_hypertable_5
+   FROM _timescaledb_internal._materialized_hypertable_5
   WHERE _materialized_hypertable_5.bucket < COALESCE(_timescaledb_functions.to_timestamp(_timescaledb_functions.cagg_watermark(5)), '-infinity'::timestamp with time zone)
   ORDER BY _materialized_hypertable_5.bucket)
 UNION ALL
@@ -306,7 +306,7 @@ View definition:
 ( SELECT _materialized_hypertable_6.bucket,
     _materialized_hypertable_6.avg,
     _materialized_hypertable_6.name
-   FROM _timescaledb_internal._materialized_hypertable_6 _materialized_hypertable_6
+   FROM _timescaledb_internal._materialized_hypertable_6
   WHERE _materialized_hypertable_6.bucket < COALESCE(_timescaledb_functions.to_timestamp(_timescaledb_functions.cagg_watermark(6)), '-infinity'::timestamp with time zone)
   ORDER BY _materialized_hypertable_6.bucket)
 UNION ALL
@@ -387,7 +387,7 @@ View definition:
 ( SELECT _materialized_hypertable_7.bucket,
     _materialized_hypertable_7.avg,
     _materialized_hypertable_7.name
-   FROM _timescaledb_internal._materialized_hypertable_7 _materialized_hypertable_7
+   FROM _timescaledb_internal._materialized_hypertable_7
   WHERE _materialized_hypertable_7.bucket < COALESCE(_timescaledb_functions.to_timestamp(_timescaledb_functions.cagg_watermark(7)), '-infinity'::timestamp with time zone)
   ORDER BY _materialized_hypertable_7.bucket)
 UNION ALL
@@ -470,7 +470,7 @@ View definition:
 ( SELECT _materialized_hypertable_8.bucket,
     _materialized_hypertable_8.avg,
     _materialized_hypertable_8.name
-   FROM _timescaledb_internal._materialized_hypertable_8 _materialized_hypertable_8
+   FROM _timescaledb_internal._materialized_hypertable_8
   WHERE _materialized_hypertable_8.bucket < COALESCE(_timescaledb_functions.to_timestamp(_timescaledb_functions.cagg_watermark(8)), '-infinity'::timestamp with time zone)
   ORDER BY _materialized_hypertable_8.bucket)
 UNION ALL
@@ -1165,6 +1165,53 @@ JOIN location ON location.name = devices.location
 GROUP BY bucket, devices.name, location.name;
 NOTICE:  refreshing continuous aggregate "conditions_by_day"
 HINT:  Use WITH NO DATA if you do not want to refresh the continuous aggregate on creation.
+SELECT * FROM conditions_by_day ORDER BY bucket, device, location;
+            bucket            |         avg         |  device  | location  
+------------------------------+---------------------+----------+-----------
+ Sun Jun 13 17:00:00 2021 PDT | 26.0000000000000000 | thermo_1 | Moscow
+ Mon Jun 14 17:00:00 2021 PDT | 22.0000000000000000 | thermo_2 | Berlin
+ Tue Jun 15 17:00:00 2021 PDT | 24.0000000000000000 | thermo_3 | London
+ Wed Jun 16 17:00:00 2021 PDT | 24.0000000000000000 | thermo_4 | Stockholm
+ Thu Jun 17 17:00:00 2021 PDT | 27.0000000000000000 | thermo_4 | Stockholm
+ Fri Jun 18 17:00:00 2021 PDT | 28.0000000000000000 | thermo_4 | Stockholm
+ Sat Jun 19 17:00:00 2021 PDT | 30.0000000000000000 | thermo_1 | Moscow
+ Sun Jun 20 17:00:00 2021 PDT | 31.0000000000000000 | thermo_1 | Moscow
+ Mon Jun 21 17:00:00 2021 PDT | 34.0000000000000000 | thermo_1 | Moscow
+ Tue Jun 22 17:00:00 2021 PDT | 34.0000000000000000 | thermo_2 | Berlin
+ Wed Jun 23 17:00:00 2021 PDT | 34.0000000000000000 | thermo_2 | Berlin
+ Thu Jun 24 17:00:00 2021 PDT | 32.0000000000000000 | thermo_3 | London
+ Fri Jun 25 17:00:00 2021 PDT | 32.0000000000000000 | thermo_3 | London
+ Sat Jun 26 17:00:00 2021 PDT | 31.0000000000000000 | thermo_3 | London
+ Tue Jun 29 17:00:00 2021 PDT | 28.0000000000000000 | thermo_3 | London
+ Wed Jun 30 17:00:00 2021 PDT | 28.0000000000000000 | thermo_3 | London
+(16 rows)
+
+ALTER MATERIALIZED VIEW conditions_by_day SET (timescaledb.materialized_only = FALSE);
+-- Insert one more row on conditions and check the result (should have one more row)
+INSERT INTO conditions (day, city, temperature, device_id) VALUES
+  ('2024-07-01', 'Moscow', 28, 3);
+SELECT * FROM conditions_by_day ORDER BY bucket, device, location;
+            bucket            |         avg         |  device  | location  
+------------------------------+---------------------+----------+-----------
+ Sun Jun 13 17:00:00 2021 PDT | 26.0000000000000000 | thermo_1 | Moscow
+ Mon Jun 14 17:00:00 2021 PDT | 22.0000000000000000 | thermo_2 | Berlin
+ Tue Jun 15 17:00:00 2021 PDT | 24.0000000000000000 | thermo_3 | London
+ Wed Jun 16 17:00:00 2021 PDT | 24.0000000000000000 | thermo_4 | Stockholm
+ Thu Jun 17 17:00:00 2021 PDT | 27.0000000000000000 | thermo_4 | Stockholm
+ Fri Jun 18 17:00:00 2021 PDT | 28.0000000000000000 | thermo_4 | Stockholm
+ Sat Jun 19 17:00:00 2021 PDT | 30.0000000000000000 | thermo_1 | Moscow
+ Sun Jun 20 17:00:00 2021 PDT | 31.0000000000000000 | thermo_1 | Moscow
+ Mon Jun 21 17:00:00 2021 PDT | 34.0000000000000000 | thermo_1 | Moscow
+ Tue Jun 22 17:00:00 2021 PDT | 34.0000000000000000 | thermo_2 | Berlin
+ Wed Jun 23 17:00:00 2021 PDT | 34.0000000000000000 | thermo_2 | Berlin
+ Thu Jun 24 17:00:00 2021 PDT | 32.0000000000000000 | thermo_3 | London
+ Fri Jun 25 17:00:00 2021 PDT | 32.0000000000000000 | thermo_3 | London
+ Sat Jun 26 17:00:00 2021 PDT | 31.0000000000000000 | thermo_3 | London
+ Tue Jun 29 17:00:00 2021 PDT | 28.0000000000000000 | thermo_3 | London
+ Wed Jun 30 17:00:00 2021 PDT | 28.0000000000000000 | thermo_3 | London
+ Sun Jun 30 17:00:00 2024 PDT | 28.0000000000000000 | thermo_3 | London
+(17 rows)
+
 -- JOIN with a foreign table
 \c :TEST_DBNAME :ROLE_SUPERUSER
 SELECT current_setting('port') AS "PGPORT", current_database() AS "PGDATABASE" \gset

--- a/tsl/test/expected/cagg_on_cagg.out
+++ b/tsl/test/expected/cagg_on_cagg.out
@@ -92,7 +92,8 @@ SELECT
   SUM(temperature) AS temperature,
   device_id
 FROM conditions
-GROUP BY 1,3
+GROUP BY 1, 3
+ORDER BY 1, 2, 3
 WITH NO DATA;
 -- CAGG on CAGG (2th level)
 CREATE MATERIALIZED VIEW :CAGG_NAME_2TH_LEVEL
@@ -101,31 +102,38 @@ SELECT
   time_bucket(:BUCKET_WIDTH_2TH, "bucket") AS bucket,
   SUM(temperature) AS temperature
 \if :IS_JOIN
-  , :CAGG_NAME_1ST_LEVEL.device_id
-  FROM :CAGG_NAME_1ST_LEVEL, devices
-  WHERE devices.device_id = :CAGG_NAME_1ST_LEVEL.device_id
-  GROUP BY 1,3
+  , devices.device_id
+  , devices.name
+  FROM :CAGG_NAME_1ST_LEVEL
+  JOIN devices ON devices.device_id = :CAGG_NAME_1ST_LEVEL.device_id
+  GROUP BY 1, 3, 4
+  ORDER BY 1, 2, 3, 4
 \else
   FROM :CAGG_NAME_1ST_LEVEL
   GROUP BY 1
+  ORDER BY 1, 2
 \endif
 WITH NO DATA;
 -- CAGG on CAGG (3th level)
 CREATE MATERIALIZED VIEW :CAGG_NAME_3TH_LEVEL
-  WITH (timescaledb.continuous, timescaledb.materialized_only=true) AS
-  SELECT
-    time_bucket(:BUCKET_WIDTH_3TH, "bucket") AS bucket,
-    SUM(temperature) AS temperature
-  \if :IS_JOIN
-    , :CAGG_NAME_2TH_LEVEL.device_id
-    FROM :CAGG_NAME_2TH_LEVEL, devices
-    WHERE devices.device_id = :CAGG_NAME_2TH_LEVEL.device_id
-    GROUP BY 1,3
-  \else
-    FROM :CAGG_NAME_2TH_LEVEL
-    GROUP BY 1
-  \endif
-  WITH NO DATA;
+WITH (timescaledb.continuous, timescaledb.materialized_only=true) AS
+SELECT
+  time_bucket(:BUCKET_WIDTH_3TH, "bucket") AS bucket,
+  SUM(temperature) AS temperature
+\if :IS_JOIN
+  , :CAGG_NAME_2TH_LEVEL.device_id
+  , :CAGG_NAME_2TH_LEVEL.name
+  , devices.location
+  FROM :CAGG_NAME_2TH_LEVEL
+  JOIN devices ON devices.device_id = :CAGG_NAME_2TH_LEVEL.device_id
+  GROUP BY 1, 3, 4, 5
+  ORDER BY 1, 2, 3, 4, 5
+\else
+  FROM :CAGG_NAME_2TH_LEVEL
+  GROUP BY 1
+  ORDER BY 1, 2
+\endif
+WITH NO DATA;
 -- Check chunk_interval
 \if :IS_TIME_DIMENSION
   SELECT h.table_name AS name, _timescaledb_functions.to_interval(d.interval_length) AS chunk_interval
@@ -159,23 +167,27 @@ CREATE MATERIALIZED VIEW :CAGG_NAME_3TH_LEVEL
 
 \endif
 -- No data because the CAGGs are just for materialized data
-SELECT * FROM :CAGG_NAME_1ST_LEVEL ORDER BY bucket;
+SELECT * FROM :CAGG_NAME_1ST_LEVEL;
  bucket | temperature | device_id 
 --------+-------------+-----------
 (0 rows)
 
-SELECT * FROM :CAGG_NAME_2TH_LEVEL ORDER BY bucket, temperature;
+SELECT * FROM :CAGG_NAME_2TH_LEVEL;
  bucket | temperature 
 --------+-------------
 (0 rows)
 
---SELECT * FROM :CAGG_NAME_3TH_LEVEL ORDER BY bucket;
+SELECT * FROM :CAGG_NAME_3TH_LEVEL;
+ bucket | temperature 
+--------+-------------
+(0 rows)
+
 -- Turn CAGGs into Realtime
 ALTER MATERIALIZED VIEW :CAGG_NAME_1ST_LEVEL SET (timescaledb.materialized_only=false);
 ALTER MATERIALIZED VIEW :CAGG_NAME_2TH_LEVEL SET (timescaledb.materialized_only=false);
---ALTER MATERIALIZED VIEW :CAGG_NAME_3TH_LEVEL SET (timescaledb.materialized_only=false);
+ALTER MATERIALIZED VIEW :CAGG_NAME_3TH_LEVEL SET (timescaledb.materialized_only=false);
 -- Realtime data
-SELECT * FROM :CAGG_NAME_1ST_LEVEL ORDER BY bucket;
+SELECT * FROM :CAGG_NAME_1ST_LEVEL;
  bucket | temperature | device_id 
 --------+-------------+-----------
       1 |          10 |         1
@@ -183,14 +195,19 @@ SELECT * FROM :CAGG_NAME_1ST_LEVEL ORDER BY bucket;
       5 |          20 |         3
 (3 rows)
 
-SELECT * FROM :CAGG_NAME_2TH_LEVEL ORDER BY bucket, temperature;
+SELECT * FROM :CAGG_NAME_2TH_LEVEL;
  bucket | temperature 
 --------+-------------
       0 |          15
       5 |          20
 (2 rows)
 
---SELECT * FROM :CAGG_NAME_3TH_LEVEL ORDER BY bucket;
+SELECT * FROM :CAGG_NAME_3TH_LEVEL;
+ bucket | temperature 
+--------+-------------
+      0 |          35
+(1 row)
+
 -- Turn CAGGs into materialized only again
 ALTER MATERIALIZED VIEW :CAGG_NAME_1ST_LEVEL SET (timescaledb.materialized_only=true);
 ALTER MATERIALIZED VIEW :CAGG_NAME_2TH_LEVEL SET (timescaledb.materialized_only=true);
@@ -200,7 +217,7 @@ CALL refresh_continuous_aggregate(:'CAGG_NAME_1ST_LEVEL', NULL, NULL);
 CALL refresh_continuous_aggregate(:'CAGG_NAME_2TH_LEVEL', NULL, NULL);
 CALL refresh_continuous_aggregate(:'CAGG_NAME_3TH_LEVEL', NULL, NULL);
 -- Materialized data
-SELECT * FROM :CAGG_NAME_1ST_LEVEL ORDER BY bucket;
+SELECT * FROM :CAGG_NAME_1ST_LEVEL;
  bucket | temperature | device_id 
 --------+-------------+-----------
       1 |          10 |         1
@@ -208,14 +225,14 @@ SELECT * FROM :CAGG_NAME_1ST_LEVEL ORDER BY bucket;
       5 |          20 |         3
 (3 rows)
 
-SELECT * FROM :CAGG_NAME_2TH_LEVEL ORDER BY bucket, temperature;
+SELECT * FROM :CAGG_NAME_2TH_LEVEL;
  bucket | temperature 
 --------+-------------
       0 |          15
       5 |          20
 (2 rows)
 
-SELECT * FROM :CAGG_NAME_3TH_LEVEL ORDER BY bucket;
+SELECT * FROM :CAGG_NAME_3TH_LEVEL;
  bucket | temperature 
 --------+-------------
       0 |          35
@@ -233,7 +250,7 @@ INSERT INTO conditions ("time", temperature) VALUES (2,  2);
 INSERT INTO conditions ("time", temperature) VALUES (10, 2);
 \endif
 -- No changes
-SELECT * FROM :CAGG_NAME_1ST_LEVEL ORDER BY bucket;
+SELECT * FROM :CAGG_NAME_1ST_LEVEL;
  bucket | temperature | device_id 
 --------+-------------+-----------
       1 |          10 |         1
@@ -241,14 +258,14 @@ SELECT * FROM :CAGG_NAME_1ST_LEVEL ORDER BY bucket;
       5 |          20 |         3
 (3 rows)
 
-SELECT * FROM :CAGG_NAME_2TH_LEVEL ORDER BY bucket, temperature;
+SELECT * FROM :CAGG_NAME_2TH_LEVEL;
  bucket | temperature 
 --------+-------------
       0 |          15
       5 |          20
 (2 rows)
 
-SELECT * FROM :CAGG_NAME_3TH_LEVEL ORDER BY bucket;
+SELECT * FROM :CAGG_NAME_3TH_LEVEL;
  bucket | temperature 
 --------+-------------
       0 |          35
@@ -259,7 +276,7 @@ ALTER MATERIALIZED VIEW :CAGG_NAME_1ST_LEVEL SET (timescaledb.materialized_only=
 ALTER MATERIALIZED VIEW :CAGG_NAME_2TH_LEVEL SET (timescaledb.materialized_only=false);
 ALTER MATERIALIZED VIEW :CAGG_NAME_3TH_LEVEL SET (timescaledb.materialized_only=false);
 -- Realtime changes, just new region
-SELECT * FROM :CAGG_NAME_1ST_LEVEL ORDER BY bucket;
+SELECT * FROM :CAGG_NAME_1ST_LEVEL;
  bucket | temperature | device_id 
 --------+-------------+-----------
       1 |          10 |         1
@@ -268,7 +285,7 @@ SELECT * FROM :CAGG_NAME_1ST_LEVEL ORDER BY bucket;
      10 |           2 |          
 (4 rows)
 
-SELECT * FROM :CAGG_NAME_2TH_LEVEL ORDER BY bucket, temperature;
+SELECT * FROM :CAGG_NAME_2TH_LEVEL;
  bucket | temperature 
 --------+-------------
       0 |          15
@@ -276,7 +293,7 @@ SELECT * FROM :CAGG_NAME_2TH_LEVEL ORDER BY bucket, temperature;
      10 |           2
 (3 rows)
 
-SELECT * FROM :CAGG_NAME_3TH_LEVEL ORDER BY bucket;
+SELECT * FROM :CAGG_NAME_3TH_LEVEL;
  bucket | temperature 
 --------+-------------
       0 |          35
@@ -292,7 +309,7 @@ CALL refresh_continuous_aggregate(:'CAGG_NAME_1ST_LEVEL', NULL, NULL);
 CALL refresh_continuous_aggregate(:'CAGG_NAME_2TH_LEVEL', NULL, NULL);
 CALL refresh_continuous_aggregate(:'CAGG_NAME_3TH_LEVEL', NULL, NULL);
 -- All changes are materialized
-SELECT * FROM :CAGG_NAME_1ST_LEVEL ORDER BY bucket;
+SELECT * FROM :CAGG_NAME_1ST_LEVEL;
  bucket | temperature | device_id 
 --------+-------------+-----------
       1 |          10 |         1
@@ -302,7 +319,7 @@ SELECT * FROM :CAGG_NAME_1ST_LEVEL ORDER BY bucket;
      10 |           2 |          
 (5 rows)
 
-SELECT * FROM :CAGG_NAME_2TH_LEVEL ORDER BY bucket, temperature;
+SELECT * FROM :CAGG_NAME_2TH_LEVEL;
  bucket | temperature 
 --------+-------------
       0 |          17
@@ -310,7 +327,7 @@ SELECT * FROM :CAGG_NAME_2TH_LEVEL ORDER BY bucket, temperature;
      10 |           2
 (3 rows)
 
-SELECT * FROM :CAGG_NAME_3TH_LEVEL ORDER BY bucket;
+SELECT * FROM :CAGG_NAME_3TH_LEVEL;
  bucket | temperature 
 --------+-------------
       0 |          37
@@ -322,12 +339,12 @@ TRUNCATE :CAGG_NAME_2TH_LEVEL;
 -- This full refresh will remove all the data from the 3TH level cagg
 CALL refresh_continuous_aggregate(:'CAGG_NAME_3TH_LEVEL', NULL, NULL);
 -- Should return no rows
-SELECT * FROM :CAGG_NAME_2TH_LEVEL ORDER BY bucket;
+SELECT * FROM :CAGG_NAME_2TH_LEVEL;
  bucket | temperature 
 --------+-------------
 (0 rows)
 
-SELECT * FROM :CAGG_NAME_3TH_LEVEL ORDER BY bucket;
+SELECT * FROM :CAGG_NAME_3TH_LEVEL;
  bucket | temperature 
 --------+-------------
 (0 rows)
@@ -336,7 +353,7 @@ SELECT * FROM :CAGG_NAME_3TH_LEVEL ORDER BY bucket;
 CALL refresh_continuous_aggregate(:'CAGG_NAME_2TH_LEVEL', NULL, NULL);
 CALL refresh_continuous_aggregate(:'CAGG_NAME_3TH_LEVEL', NULL, NULL);
 -- Now we have all the data
-SELECT * FROM :CAGG_NAME_2TH_LEVEL ORDER BY bucket, temperature;
+SELECT * FROM :CAGG_NAME_2TH_LEVEL;
  bucket | temperature 
 --------+-------------
       0 |          17
@@ -344,7 +361,7 @@ SELECT * FROM :CAGG_NAME_2TH_LEVEL ORDER BY bucket, temperature;
      10 |           2
 (3 rows)
 
-SELECT * FROM :CAGG_NAME_3TH_LEVEL ORDER BY bucket;
+SELECT * FROM :CAGG_NAME_3TH_LEVEL;
  bucket | temperature 
 --------+-------------
       0 |          37
@@ -355,38 +372,38 @@ SELECT * FROM :CAGG_NAME_3TH_LEVEL ORDER BY bucket;
 \set ON_ERROR_STOP 0
 -- should error because it depends of other CAGGs
 DROP MATERIALIZED VIEW :CAGG_NAME_1ST_LEVEL;
-psql:include/cagg_on_cagg_common.sql:166: ERROR:  cannot drop view conditions_summary_1_1 because other objects depend on it
+psql:include/cagg_on_cagg_common.sql:172: ERROR:  cannot drop view conditions_summary_1_1 because other objects depend on it
 DROP MATERIALIZED VIEW :CAGG_NAME_2TH_LEVEL;
-psql:include/cagg_on_cagg_common.sql:167: ERROR:  cannot drop view conditions_summary_2_5 because other objects depend on it
+psql:include/cagg_on_cagg_common.sql:173: ERROR:  cannot drop view conditions_summary_2_5 because other objects depend on it
 CALL refresh_continuous_aggregate(:'CAGG_NAME_1ST_LEVEL', NULL, NULL);
-psql:include/cagg_on_cagg_common.sql:168: NOTICE:  continuous aggregate "conditions_summary_1_1" is already up-to-date
+psql:include/cagg_on_cagg_common.sql:174: NOTICE:  continuous aggregate "conditions_summary_1_1" is already up-to-date
 CALL refresh_continuous_aggregate(:'CAGG_NAME_2TH_LEVEL', NULL, NULL);
-psql:include/cagg_on_cagg_common.sql:169: NOTICE:  continuous aggregate "conditions_summary_2_5" is already up-to-date
+psql:include/cagg_on_cagg_common.sql:175: NOTICE:  continuous aggregate "conditions_summary_2_5" is already up-to-date
 \set ON_ERROR_STOP 1
 -- DROP the 3TH level CAGG don't affect others
 DROP MATERIALIZED VIEW :CAGG_NAME_3TH_LEVEL;
-psql:include/cagg_on_cagg_common.sql:173: NOTICE:  drop cascades to table _timescaledb_internal._hyper_4_4_chunk
+psql:include/cagg_on_cagg_common.sql:179: NOTICE:  drop cascades to table _timescaledb_internal._hyper_4_4_chunk
 \set ON_ERROR_STOP 0
 -- should error because it was dropped
-SELECT * FROM :CAGG_NAME_3TH_LEVEL ORDER BY bucket, device_id;
-psql:include/cagg_on_cagg_common.sql:176: ERROR:  relation "conditions_summary_3_10" does not exist at character 15
+SELECT * FROM :CAGG_NAME_3TH_LEVEL;
+psql:include/cagg_on_cagg_common.sql:182: ERROR:  relation "conditions_summary_3_10" does not exist at character 15
 \set ON_ERROR_STOP 1
 -- should work because dropping the top level CAGG
 -- don't affect the down level CAGGs
 TRUNCATE :CAGG_NAME_2TH_LEVEL,:CAGG_NAME_1ST_LEVEL;
 CALL refresh_continuous_aggregate(:'CAGG_NAME_2TH_LEVEL', NULL, NULL);
 CALL refresh_continuous_aggregate(:'CAGG_NAME_1ST_LEVEL', NULL, NULL);
-SELECT * FROM :CAGG_NAME_1ST_LEVEL ORDER BY bucket, device_id;
+SELECT * FROM :CAGG_NAME_1ST_LEVEL;
  bucket | temperature | device_id 
 --------+-------------+-----------
       1 |          10 |         1
-      2 |           5 |         2
       2 |           2 |          
+      2 |           5 |         2
       5 |          20 |         3
      10 |           2 |          
 (5 rows)
 
-SELECT * FROM :CAGG_NAME_2TH_LEVEL ORDER BY bucket, temperature;
+SELECT * FROM :CAGG_NAME_2TH_LEVEL;
  bucket | temperature 
 --------+-------------
 (0 rows)
@@ -395,28 +412,28 @@ SELECT * FROM :CAGG_NAME_2TH_LEVEL ORDER BY bucket, temperature;
 DROP MATERIALIZED VIEW :CAGG_NAME_2TH_LEVEL;
 \set ON_ERROR_STOP 0
 -- should error because it was dropped
-SELECT * FROM :CAGG_NAME_2TH_LEVEL ORDER BY bucket, temperature;
-psql:include/cagg_on_cagg_common.sql:190: ERROR:  relation "conditions_summary_2_5" does not exist at character 15
+SELECT * FROM :CAGG_NAME_2TH_LEVEL;
+psql:include/cagg_on_cagg_common.sql:196: ERROR:  relation "conditions_summary_2_5" does not exist at character 15
 \set ON_ERROR_STOP 1
 -- should work because dropping the top level CAGG
 -- don't affect the down level CAGGs
-SELECT * FROM :CAGG_NAME_1ST_LEVEL ORDER BY bucket, device_id;
+SELECT * FROM :CAGG_NAME_1ST_LEVEL;
  bucket | temperature | device_id 
 --------+-------------+-----------
       1 |          10 |         1
-      2 |           5 |         2
       2 |           2 |          
+      2 |           5 |         2
       5 |          20 |         3
      10 |           2 |          
 (5 rows)
 
 -- DROP the first CAGG should work
 DROP MATERIALIZED VIEW :CAGG_NAME_1ST_LEVEL;
-psql:include/cagg_on_cagg_common.sql:197: NOTICE:  drop cascades to table _timescaledb_internal._hyper_2_7_chunk
+psql:include/cagg_on_cagg_common.sql:203: NOTICE:  drop cascades to table _timescaledb_internal._hyper_2_7_chunk
 \set ON_ERROR_STOP 0
 -- should error because it was dropped
-SELECT * FROM :CAGG_NAME_1ST_LEVEL ORDER BY bucket, device_id;
-psql:include/cagg_on_cagg_common.sql:200: ERROR:  relation "conditions_summary_1_1" does not exist at character 15
+SELECT * FROM :CAGG_NAME_1ST_LEVEL;
+psql:include/cagg_on_cagg_common.sql:206: ERROR:  relation "conditions_summary_1_1" does not exist at character 15
 \set ON_ERROR_STOP 1
 -- Default tests
 \set IS_DEFAULT_COLUMN_ORDER TRUE
@@ -488,7 +505,8 @@ SELECT
   SUM(temperature) AS temperature,
   device_id
 FROM conditions
-GROUP BY 1,3
+GROUP BY 1, 3
+ORDER BY 1, 2, 3
 WITH NO DATA;
 -- CAGG on CAGG (2th level)
 CREATE MATERIALIZED VIEW :CAGG_NAME_2TH_LEVEL
@@ -497,31 +515,38 @@ SELECT
   time_bucket(:BUCKET_WIDTH_2TH, "bucket") AS bucket,
   SUM(temperature) AS temperature
 \if :IS_JOIN
-  , :CAGG_NAME_1ST_LEVEL.device_id
-  FROM :CAGG_NAME_1ST_LEVEL, devices
-  WHERE devices.device_id = :CAGG_NAME_1ST_LEVEL.device_id
-  GROUP BY 1,3
+  , devices.device_id
+  , devices.name
+  FROM :CAGG_NAME_1ST_LEVEL
+  JOIN devices ON devices.device_id = :CAGG_NAME_1ST_LEVEL.device_id
+  GROUP BY 1, 3, 4
+  ORDER BY 1, 2, 3, 4
 \else
   FROM :CAGG_NAME_1ST_LEVEL
   GROUP BY 1
+  ORDER BY 1, 2
 \endif
 WITH NO DATA;
 -- CAGG on CAGG (3th level)
 CREATE MATERIALIZED VIEW :CAGG_NAME_3TH_LEVEL
-  WITH (timescaledb.continuous, timescaledb.materialized_only=true) AS
-  SELECT
-    time_bucket(:BUCKET_WIDTH_3TH, "bucket") AS bucket,
-    SUM(temperature) AS temperature
-  \if :IS_JOIN
-    , :CAGG_NAME_2TH_LEVEL.device_id
-    FROM :CAGG_NAME_2TH_LEVEL, devices
-    WHERE devices.device_id = :CAGG_NAME_2TH_LEVEL.device_id
-    GROUP BY 1,3
-  \else
-    FROM :CAGG_NAME_2TH_LEVEL
-    GROUP BY 1
-  \endif
-  WITH NO DATA;
+WITH (timescaledb.continuous, timescaledb.materialized_only=true) AS
+SELECT
+  time_bucket(:BUCKET_WIDTH_3TH, "bucket") AS bucket,
+  SUM(temperature) AS temperature
+\if :IS_JOIN
+  , :CAGG_NAME_2TH_LEVEL.device_id
+  , :CAGG_NAME_2TH_LEVEL.name
+  , devices.location
+  FROM :CAGG_NAME_2TH_LEVEL
+  JOIN devices ON devices.device_id = :CAGG_NAME_2TH_LEVEL.device_id
+  GROUP BY 1, 3, 4, 5
+  ORDER BY 1, 2, 3, 4, 5
+\else
+  FROM :CAGG_NAME_2TH_LEVEL
+  GROUP BY 1
+  ORDER BY 1, 2
+\endif
+WITH NO DATA;
 -- Check chunk_interval
 \if :IS_TIME_DIMENSION
   SELECT h.table_name AS name, _timescaledb_functions.to_interval(d.interval_length) AS chunk_interval
@@ -555,23 +580,27 @@ CREATE MATERIALIZED VIEW :CAGG_NAME_3TH_LEVEL
 
 \endif
 -- No data because the CAGGs are just for materialized data
-SELECT * FROM :CAGG_NAME_1ST_LEVEL ORDER BY bucket;
+SELECT * FROM :CAGG_NAME_1ST_LEVEL;
  bucket | temperature | device_id 
 --------+-------------+-----------
 (0 rows)
 
-SELECT * FROM :CAGG_NAME_2TH_LEVEL ORDER BY bucket, temperature;
+SELECT * FROM :CAGG_NAME_2TH_LEVEL;
  bucket | temperature 
 --------+-------------
 (0 rows)
 
---SELECT * FROM :CAGG_NAME_3TH_LEVEL ORDER BY bucket;
+SELECT * FROM :CAGG_NAME_3TH_LEVEL;
+ bucket | temperature 
+--------+-------------
+(0 rows)
+
 -- Turn CAGGs into Realtime
 ALTER MATERIALIZED VIEW :CAGG_NAME_1ST_LEVEL SET (timescaledb.materialized_only=false);
 ALTER MATERIALIZED VIEW :CAGG_NAME_2TH_LEVEL SET (timescaledb.materialized_only=false);
---ALTER MATERIALIZED VIEW :CAGG_NAME_3TH_LEVEL SET (timescaledb.materialized_only=false);
+ALTER MATERIALIZED VIEW :CAGG_NAME_3TH_LEVEL SET (timescaledb.materialized_only=false);
 -- Realtime data
-SELECT * FROM :CAGG_NAME_1ST_LEVEL ORDER BY bucket;
+SELECT * FROM :CAGG_NAME_1ST_LEVEL;
  bucket | temperature | device_id 
 --------+-------------+-----------
       1 |          10 |         1
@@ -579,14 +608,19 @@ SELECT * FROM :CAGG_NAME_1ST_LEVEL ORDER BY bucket;
       5 |          20 |         3
 (3 rows)
 
-SELECT * FROM :CAGG_NAME_2TH_LEVEL ORDER BY bucket, temperature;
+SELECT * FROM :CAGG_NAME_2TH_LEVEL;
  bucket | temperature 
 --------+-------------
       0 |          15
       5 |          20
 (2 rows)
 
---SELECT * FROM :CAGG_NAME_3TH_LEVEL ORDER BY bucket;
+SELECT * FROM :CAGG_NAME_3TH_LEVEL;
+ bucket | temperature 
+--------+-------------
+      0 |          35
+(1 row)
+
 -- Turn CAGGs into materialized only again
 ALTER MATERIALIZED VIEW :CAGG_NAME_1ST_LEVEL SET (timescaledb.materialized_only=true);
 ALTER MATERIALIZED VIEW :CAGG_NAME_2TH_LEVEL SET (timescaledb.materialized_only=true);
@@ -596,7 +630,7 @@ CALL refresh_continuous_aggregate(:'CAGG_NAME_1ST_LEVEL', NULL, NULL);
 CALL refresh_continuous_aggregate(:'CAGG_NAME_2TH_LEVEL', NULL, NULL);
 CALL refresh_continuous_aggregate(:'CAGG_NAME_3TH_LEVEL', NULL, NULL);
 -- Materialized data
-SELECT * FROM :CAGG_NAME_1ST_LEVEL ORDER BY bucket;
+SELECT * FROM :CAGG_NAME_1ST_LEVEL;
  bucket | temperature | device_id 
 --------+-------------+-----------
       1 |          10 |         1
@@ -604,14 +638,14 @@ SELECT * FROM :CAGG_NAME_1ST_LEVEL ORDER BY bucket;
       5 |          20 |         3
 (3 rows)
 
-SELECT * FROM :CAGG_NAME_2TH_LEVEL ORDER BY bucket, temperature;
+SELECT * FROM :CAGG_NAME_2TH_LEVEL;
  bucket | temperature 
 --------+-------------
       0 |          15
       5 |          20
 (2 rows)
 
-SELECT * FROM :CAGG_NAME_3TH_LEVEL ORDER BY bucket;
+SELECT * FROM :CAGG_NAME_3TH_LEVEL;
  bucket | temperature 
 --------+-------------
       0 |          35
@@ -629,7 +663,7 @@ INSERT INTO conditions ("time", temperature) VALUES (2,  2);
 INSERT INTO conditions ("time", temperature) VALUES (10, 2);
 \endif
 -- No changes
-SELECT * FROM :CAGG_NAME_1ST_LEVEL ORDER BY bucket;
+SELECT * FROM :CAGG_NAME_1ST_LEVEL;
  bucket | temperature | device_id 
 --------+-------------+-----------
       1 |          10 |         1
@@ -637,14 +671,14 @@ SELECT * FROM :CAGG_NAME_1ST_LEVEL ORDER BY bucket;
       5 |          20 |         3
 (3 rows)
 
-SELECT * FROM :CAGG_NAME_2TH_LEVEL ORDER BY bucket, temperature;
+SELECT * FROM :CAGG_NAME_2TH_LEVEL;
  bucket | temperature 
 --------+-------------
       0 |          15
       5 |          20
 (2 rows)
 
-SELECT * FROM :CAGG_NAME_3TH_LEVEL ORDER BY bucket;
+SELECT * FROM :CAGG_NAME_3TH_LEVEL;
  bucket | temperature 
 --------+-------------
       0 |          35
@@ -655,7 +689,7 @@ ALTER MATERIALIZED VIEW :CAGG_NAME_1ST_LEVEL SET (timescaledb.materialized_only=
 ALTER MATERIALIZED VIEW :CAGG_NAME_2TH_LEVEL SET (timescaledb.materialized_only=false);
 ALTER MATERIALIZED VIEW :CAGG_NAME_3TH_LEVEL SET (timescaledb.materialized_only=false);
 -- Realtime changes, just new region
-SELECT * FROM :CAGG_NAME_1ST_LEVEL ORDER BY bucket;
+SELECT * FROM :CAGG_NAME_1ST_LEVEL;
  bucket | temperature | device_id 
 --------+-------------+-----------
       1 |          10 |         1
@@ -664,7 +698,7 @@ SELECT * FROM :CAGG_NAME_1ST_LEVEL ORDER BY bucket;
      10 |           2 |          
 (4 rows)
 
-SELECT * FROM :CAGG_NAME_2TH_LEVEL ORDER BY bucket, temperature;
+SELECT * FROM :CAGG_NAME_2TH_LEVEL;
  bucket | temperature 
 --------+-------------
       0 |          15
@@ -672,7 +706,7 @@ SELECT * FROM :CAGG_NAME_2TH_LEVEL ORDER BY bucket, temperature;
      10 |           2
 (3 rows)
 
-SELECT * FROM :CAGG_NAME_3TH_LEVEL ORDER BY bucket;
+SELECT * FROM :CAGG_NAME_3TH_LEVEL;
  bucket | temperature 
 --------+-------------
       0 |          35
@@ -688,7 +722,7 @@ CALL refresh_continuous_aggregate(:'CAGG_NAME_1ST_LEVEL', NULL, NULL);
 CALL refresh_continuous_aggregate(:'CAGG_NAME_2TH_LEVEL', NULL, NULL);
 CALL refresh_continuous_aggregate(:'CAGG_NAME_3TH_LEVEL', NULL, NULL);
 -- All changes are materialized
-SELECT * FROM :CAGG_NAME_1ST_LEVEL ORDER BY bucket;
+SELECT * FROM :CAGG_NAME_1ST_LEVEL;
  bucket | temperature | device_id 
 --------+-------------+-----------
       1 |          10 |         1
@@ -698,7 +732,7 @@ SELECT * FROM :CAGG_NAME_1ST_LEVEL ORDER BY bucket;
      10 |           2 |          
 (5 rows)
 
-SELECT * FROM :CAGG_NAME_2TH_LEVEL ORDER BY bucket, temperature;
+SELECT * FROM :CAGG_NAME_2TH_LEVEL;
  bucket | temperature 
 --------+-------------
       0 |          17
@@ -706,7 +740,7 @@ SELECT * FROM :CAGG_NAME_2TH_LEVEL ORDER BY bucket, temperature;
      10 |           2
 (3 rows)
 
-SELECT * FROM :CAGG_NAME_3TH_LEVEL ORDER BY bucket;
+SELECT * FROM :CAGG_NAME_3TH_LEVEL;
  bucket | temperature 
 --------+-------------
       0 |          37
@@ -718,12 +752,12 @@ TRUNCATE :CAGG_NAME_2TH_LEVEL;
 -- This full refresh will remove all the data from the 3TH level cagg
 CALL refresh_continuous_aggregate(:'CAGG_NAME_3TH_LEVEL', NULL, NULL);
 -- Should return no rows
-SELECT * FROM :CAGG_NAME_2TH_LEVEL ORDER BY bucket;
+SELECT * FROM :CAGG_NAME_2TH_LEVEL;
  bucket | temperature 
 --------+-------------
 (0 rows)
 
-SELECT * FROM :CAGG_NAME_3TH_LEVEL ORDER BY bucket;
+SELECT * FROM :CAGG_NAME_3TH_LEVEL;
  bucket | temperature 
 --------+-------------
 (0 rows)
@@ -732,7 +766,7 @@ SELECT * FROM :CAGG_NAME_3TH_LEVEL ORDER BY bucket;
 CALL refresh_continuous_aggregate(:'CAGG_NAME_2TH_LEVEL', NULL, NULL);
 CALL refresh_continuous_aggregate(:'CAGG_NAME_3TH_LEVEL', NULL, NULL);
 -- Now we have all the data
-SELECT * FROM :CAGG_NAME_2TH_LEVEL ORDER BY bucket, temperature;
+SELECT * FROM :CAGG_NAME_2TH_LEVEL;
  bucket | temperature 
 --------+-------------
       0 |          17
@@ -740,7 +774,7 @@ SELECT * FROM :CAGG_NAME_2TH_LEVEL ORDER BY bucket, temperature;
      10 |           2
 (3 rows)
 
-SELECT * FROM :CAGG_NAME_3TH_LEVEL ORDER BY bucket;
+SELECT * FROM :CAGG_NAME_3TH_LEVEL;
  bucket | temperature 
 --------+-------------
       0 |          37
@@ -751,38 +785,38 @@ SELECT * FROM :CAGG_NAME_3TH_LEVEL ORDER BY bucket;
 \set ON_ERROR_STOP 0
 -- should error because it depends of other CAGGs
 DROP MATERIALIZED VIEW :CAGG_NAME_1ST_LEVEL;
-psql:include/cagg_on_cagg_common.sql:166: ERROR:  cannot drop view conditions_summary_1_1 because other objects depend on it
+psql:include/cagg_on_cagg_common.sql:172: ERROR:  cannot drop view conditions_summary_1_1 because other objects depend on it
 DROP MATERIALIZED VIEW :CAGG_NAME_2TH_LEVEL;
-psql:include/cagg_on_cagg_common.sql:167: ERROR:  cannot drop view conditions_summary_2_5 because other objects depend on it
+psql:include/cagg_on_cagg_common.sql:173: ERROR:  cannot drop view conditions_summary_2_5 because other objects depend on it
 CALL refresh_continuous_aggregate(:'CAGG_NAME_1ST_LEVEL', NULL, NULL);
-psql:include/cagg_on_cagg_common.sql:168: NOTICE:  continuous aggregate "conditions_summary_1_1" is already up-to-date
+psql:include/cagg_on_cagg_common.sql:174: NOTICE:  continuous aggregate "conditions_summary_1_1" is already up-to-date
 CALL refresh_continuous_aggregate(:'CAGG_NAME_2TH_LEVEL', NULL, NULL);
-psql:include/cagg_on_cagg_common.sql:169: NOTICE:  continuous aggregate "conditions_summary_2_5" is already up-to-date
+psql:include/cagg_on_cagg_common.sql:175: NOTICE:  continuous aggregate "conditions_summary_2_5" is already up-to-date
 \set ON_ERROR_STOP 1
 -- DROP the 3TH level CAGG don't affect others
 DROP MATERIALIZED VIEW :CAGG_NAME_3TH_LEVEL;
-psql:include/cagg_on_cagg_common.sql:173: NOTICE:  drop cascades to table _timescaledb_internal._hyper_8_11_chunk
+psql:include/cagg_on_cagg_common.sql:179: NOTICE:  drop cascades to table _timescaledb_internal._hyper_8_11_chunk
 \set ON_ERROR_STOP 0
 -- should error because it was dropped
-SELECT * FROM :CAGG_NAME_3TH_LEVEL ORDER BY bucket, device_id;
-psql:include/cagg_on_cagg_common.sql:176: ERROR:  relation "conditions_summary_3_10" does not exist at character 15
+SELECT * FROM :CAGG_NAME_3TH_LEVEL;
+psql:include/cagg_on_cagg_common.sql:182: ERROR:  relation "conditions_summary_3_10" does not exist at character 15
 \set ON_ERROR_STOP 1
 -- should work because dropping the top level CAGG
 -- don't affect the down level CAGGs
 TRUNCATE :CAGG_NAME_2TH_LEVEL,:CAGG_NAME_1ST_LEVEL;
 CALL refresh_continuous_aggregate(:'CAGG_NAME_2TH_LEVEL', NULL, NULL);
 CALL refresh_continuous_aggregate(:'CAGG_NAME_1ST_LEVEL', NULL, NULL);
-SELECT * FROM :CAGG_NAME_1ST_LEVEL ORDER BY bucket, device_id;
+SELECT * FROM :CAGG_NAME_1ST_LEVEL;
  bucket | temperature | device_id 
 --------+-------------+-----------
       1 |          10 |         1
-      2 |           5 |         2
       2 |           2 |          
+      2 |           5 |         2
       5 |          20 |         3
      10 |           2 |          
 (5 rows)
 
-SELECT * FROM :CAGG_NAME_2TH_LEVEL ORDER BY bucket, temperature;
+SELECT * FROM :CAGG_NAME_2TH_LEVEL;
  bucket | temperature 
 --------+-------------
 (0 rows)
@@ -791,28 +825,28 @@ SELECT * FROM :CAGG_NAME_2TH_LEVEL ORDER BY bucket, temperature;
 DROP MATERIALIZED VIEW :CAGG_NAME_2TH_LEVEL;
 \set ON_ERROR_STOP 0
 -- should error because it was dropped
-SELECT * FROM :CAGG_NAME_2TH_LEVEL ORDER BY bucket, temperature;
-psql:include/cagg_on_cagg_common.sql:190: ERROR:  relation "conditions_summary_2_5" does not exist at character 15
+SELECT * FROM :CAGG_NAME_2TH_LEVEL;
+psql:include/cagg_on_cagg_common.sql:196: ERROR:  relation "conditions_summary_2_5" does not exist at character 15
 \set ON_ERROR_STOP 1
 -- should work because dropping the top level CAGG
 -- don't affect the down level CAGGs
-SELECT * FROM :CAGG_NAME_1ST_LEVEL ORDER BY bucket, device_id;
+SELECT * FROM :CAGG_NAME_1ST_LEVEL;
  bucket | temperature | device_id 
 --------+-------------+-----------
       1 |          10 |         1
-      2 |           5 |         2
       2 |           2 |          
+      2 |           5 |         2
       5 |          20 |         3
      10 |           2 |          
 (5 rows)
 
 -- DROP the first CAGG should work
 DROP MATERIALIZED VIEW :CAGG_NAME_1ST_LEVEL;
-psql:include/cagg_on_cagg_common.sql:197: NOTICE:  drop cascades to table _timescaledb_internal._hyper_6_14_chunk
+psql:include/cagg_on_cagg_common.sql:203: NOTICE:  drop cascades to table _timescaledb_internal._hyper_6_14_chunk
 \set ON_ERROR_STOP 0
 -- should error because it was dropped
-SELECT * FROM :CAGG_NAME_1ST_LEVEL ORDER BY bucket, device_id;
-psql:include/cagg_on_cagg_common.sql:200: ERROR:  relation "conditions_summary_1_1" does not exist at character 15
+SELECT * FROM :CAGG_NAME_1ST_LEVEL;
+psql:include/cagg_on_cagg_common.sql:206: ERROR:  relation "conditions_summary_1_1" does not exist at character 15
 \set ON_ERROR_STOP 1
 --
 -- Validation test for non-multiple bucket sizes
@@ -1210,7 +1244,8 @@ SELECT
   SUM(temperature) AS temperature,
   device_id
 FROM conditions
-GROUP BY 1,3
+GROUP BY 1, 3
+ORDER BY 1, 2, 3
 WITH NO DATA;
 -- CAGG on CAGG (2th level)
 CREATE MATERIALIZED VIEW :CAGG_NAME_2TH_LEVEL
@@ -1219,31 +1254,38 @@ SELECT
   time_bucket(:BUCKET_WIDTH_2TH, "bucket") AS bucket,
   SUM(temperature) AS temperature
 \if :IS_JOIN
-  , :CAGG_NAME_1ST_LEVEL.device_id
-  FROM :CAGG_NAME_1ST_LEVEL, devices
-  WHERE devices.device_id = :CAGG_NAME_1ST_LEVEL.device_id
-  GROUP BY 1,3
+  , devices.device_id
+  , devices.name
+  FROM :CAGG_NAME_1ST_LEVEL
+  JOIN devices ON devices.device_id = :CAGG_NAME_1ST_LEVEL.device_id
+  GROUP BY 1, 3, 4
+  ORDER BY 1, 2, 3, 4
 \else
   FROM :CAGG_NAME_1ST_LEVEL
   GROUP BY 1
+  ORDER BY 1, 2
 \endif
 WITH NO DATA;
 -- CAGG on CAGG (3th level)
 CREATE MATERIALIZED VIEW :CAGG_NAME_3TH_LEVEL
-  WITH (timescaledb.continuous, timescaledb.materialized_only=true) AS
-  SELECT
-    time_bucket(:BUCKET_WIDTH_3TH, "bucket") AS bucket,
-    SUM(temperature) AS temperature
-  \if :IS_JOIN
-    , :CAGG_NAME_2TH_LEVEL.device_id
-    FROM :CAGG_NAME_2TH_LEVEL, devices
-    WHERE devices.device_id = :CAGG_NAME_2TH_LEVEL.device_id
-    GROUP BY 1,3
-  \else
-    FROM :CAGG_NAME_2TH_LEVEL
-    GROUP BY 1
-  \endif
-  WITH NO DATA;
+WITH (timescaledb.continuous, timescaledb.materialized_only=true) AS
+SELECT
+  time_bucket(:BUCKET_WIDTH_3TH, "bucket") AS bucket,
+  SUM(temperature) AS temperature
+\if :IS_JOIN
+  , :CAGG_NAME_2TH_LEVEL.device_id
+  , :CAGG_NAME_2TH_LEVEL.name
+  , devices.location
+  FROM :CAGG_NAME_2TH_LEVEL
+  JOIN devices ON devices.device_id = :CAGG_NAME_2TH_LEVEL.device_id
+  GROUP BY 1, 3, 4, 5
+  ORDER BY 1, 2, 3, 4, 5
+\else
+  FROM :CAGG_NAME_2TH_LEVEL
+  GROUP BY 1
+  ORDER BY 1, 2
+\endif
+WITH NO DATA;
 -- Check chunk_interval
 \if :IS_TIME_DIMENSION
   SELECT h.table_name AS name, _timescaledb_functions.to_interval(d.interval_length) AS chunk_interval
@@ -1277,23 +1319,27 @@ CREATE MATERIALIZED VIEW :CAGG_NAME_3TH_LEVEL
   ORDER BY 1, 2;
 \endif
 -- No data because the CAGGs are just for materialized data
-SELECT * FROM :CAGG_NAME_1ST_LEVEL ORDER BY bucket;
+SELECT * FROM :CAGG_NAME_1ST_LEVEL;
  bucket | temperature | device_id 
 --------+-------------+-----------
 (0 rows)
 
-SELECT * FROM :CAGG_NAME_2TH_LEVEL ORDER BY bucket, temperature;
+SELECT * FROM :CAGG_NAME_2TH_LEVEL;
  bucket | temperature 
 --------+-------------
 (0 rows)
 
---SELECT * FROM :CAGG_NAME_3TH_LEVEL ORDER BY bucket;
+SELECT * FROM :CAGG_NAME_3TH_LEVEL;
+ bucket | temperature 
+--------+-------------
+(0 rows)
+
 -- Turn CAGGs into Realtime
 ALTER MATERIALIZED VIEW :CAGG_NAME_1ST_LEVEL SET (timescaledb.materialized_only=false);
 ALTER MATERIALIZED VIEW :CAGG_NAME_2TH_LEVEL SET (timescaledb.materialized_only=false);
---ALTER MATERIALIZED VIEW :CAGG_NAME_3TH_LEVEL SET (timescaledb.materialized_only=false);
+ALTER MATERIALIZED VIEW :CAGG_NAME_3TH_LEVEL SET (timescaledb.materialized_only=false);
 -- Realtime data
-SELECT * FROM :CAGG_NAME_1ST_LEVEL ORDER BY bucket;
+SELECT * FROM :CAGG_NAME_1ST_LEVEL;
           bucket          | temperature | device_id 
 --------------------------+-------------+-----------
  Sat Jan 01 00:00:00 2022 |          10 |         1
@@ -1301,14 +1347,19 @@ SELECT * FROM :CAGG_NAME_1ST_LEVEL ORDER BY bucket;
  Sun Jan 02 01:00:00 2022 |          20 |         3
 (3 rows)
 
-SELECT * FROM :CAGG_NAME_2TH_LEVEL ORDER BY bucket, temperature;
+SELECT * FROM :CAGG_NAME_2TH_LEVEL;
           bucket          | temperature 
 --------------------------+-------------
  Sat Jan 01 00:00:00 2022 |          15
  Sun Jan 02 00:00:00 2022 |          20
 (2 rows)
 
---SELECT * FROM :CAGG_NAME_3TH_LEVEL ORDER BY bucket;
+SELECT * FROM :CAGG_NAME_3TH_LEVEL;
+          bucket          | temperature 
+--------------------------+-------------
+ Mon Dec 27 00:00:00 2021 |          35
+(1 row)
+
 -- Turn CAGGs into materialized only again
 ALTER MATERIALIZED VIEW :CAGG_NAME_1ST_LEVEL SET (timescaledb.materialized_only=true);
 ALTER MATERIALIZED VIEW :CAGG_NAME_2TH_LEVEL SET (timescaledb.materialized_only=true);
@@ -1318,7 +1369,7 @@ CALL refresh_continuous_aggregate(:'CAGG_NAME_1ST_LEVEL', NULL, NULL);
 CALL refresh_continuous_aggregate(:'CAGG_NAME_2TH_LEVEL', NULL, NULL);
 CALL refresh_continuous_aggregate(:'CAGG_NAME_3TH_LEVEL', NULL, NULL);
 -- Materialized data
-SELECT * FROM :CAGG_NAME_1ST_LEVEL ORDER BY bucket;
+SELECT * FROM :CAGG_NAME_1ST_LEVEL;
           bucket          | temperature | device_id 
 --------------------------+-------------+-----------
  Sat Jan 01 00:00:00 2022 |          10 |         1
@@ -1326,14 +1377,14 @@ SELECT * FROM :CAGG_NAME_1ST_LEVEL ORDER BY bucket;
  Sun Jan 02 01:00:00 2022 |          20 |         3
 (3 rows)
 
-SELECT * FROM :CAGG_NAME_2TH_LEVEL ORDER BY bucket, temperature;
+SELECT * FROM :CAGG_NAME_2TH_LEVEL;
           bucket          | temperature 
 --------------------------+-------------
  Sat Jan 01 00:00:00 2022 |          15
  Sun Jan 02 00:00:00 2022 |          20
 (2 rows)
 
-SELECT * FROM :CAGG_NAME_3TH_LEVEL ORDER BY bucket;
+SELECT * FROM :CAGG_NAME_3TH_LEVEL;
           bucket          | temperature 
 --------------------------+-------------
  Mon Dec 27 00:00:00 2021 |          35
@@ -1351,7 +1402,7 @@ INSERT INTO conditions ("time", temperature) VALUES (2,  2);
 INSERT INTO conditions ("time", temperature) VALUES (10, 2);
 \endif
 -- No changes
-SELECT * FROM :CAGG_NAME_1ST_LEVEL ORDER BY bucket;
+SELECT * FROM :CAGG_NAME_1ST_LEVEL;
           bucket          | temperature | device_id 
 --------------------------+-------------+-----------
  Sat Jan 01 00:00:00 2022 |          10 |         1
@@ -1359,14 +1410,14 @@ SELECT * FROM :CAGG_NAME_1ST_LEVEL ORDER BY bucket;
  Sun Jan 02 01:00:00 2022 |          20 |         3
 (3 rows)
 
-SELECT * FROM :CAGG_NAME_2TH_LEVEL ORDER BY bucket, temperature;
+SELECT * FROM :CAGG_NAME_2TH_LEVEL;
           bucket          | temperature 
 --------------------------+-------------
  Sat Jan 01 00:00:00 2022 |          15
  Sun Jan 02 00:00:00 2022 |          20
 (2 rows)
 
-SELECT * FROM :CAGG_NAME_3TH_LEVEL ORDER BY bucket;
+SELECT * FROM :CAGG_NAME_3TH_LEVEL;
           bucket          | temperature 
 --------------------------+-------------
  Mon Dec 27 00:00:00 2021 |          35
@@ -1377,7 +1428,7 @@ ALTER MATERIALIZED VIEW :CAGG_NAME_1ST_LEVEL SET (timescaledb.materialized_only=
 ALTER MATERIALIZED VIEW :CAGG_NAME_2TH_LEVEL SET (timescaledb.materialized_only=false);
 ALTER MATERIALIZED VIEW :CAGG_NAME_3TH_LEVEL SET (timescaledb.materialized_only=false);
 -- Realtime changes, just new region
-SELECT * FROM :CAGG_NAME_1ST_LEVEL ORDER BY bucket;
+SELECT * FROM :CAGG_NAME_1ST_LEVEL;
           bucket          | temperature | device_id 
 --------------------------+-------------+-----------
  Sat Jan 01 00:00:00 2022 |          10 |         1
@@ -1386,7 +1437,7 @@ SELECT * FROM :CAGG_NAME_1ST_LEVEL ORDER BY bucket;
  Mon Jan 03 01:00:00 2022 |           2 |          
 (4 rows)
 
-SELECT * FROM :CAGG_NAME_2TH_LEVEL ORDER BY bucket, temperature;
+SELECT * FROM :CAGG_NAME_2TH_LEVEL;
           bucket          | temperature 
 --------------------------+-------------
  Sat Jan 01 00:00:00 2022 |          15
@@ -1394,7 +1445,7 @@ SELECT * FROM :CAGG_NAME_2TH_LEVEL ORDER BY bucket, temperature;
  Mon Jan 03 00:00:00 2022 |           2
 (3 rows)
 
-SELECT * FROM :CAGG_NAME_3TH_LEVEL ORDER BY bucket;
+SELECT * FROM :CAGG_NAME_3TH_LEVEL;
           bucket          | temperature 
 --------------------------+-------------
  Mon Dec 27 00:00:00 2021 |          35
@@ -1410,7 +1461,7 @@ CALL refresh_continuous_aggregate(:'CAGG_NAME_1ST_LEVEL', NULL, NULL);
 CALL refresh_continuous_aggregate(:'CAGG_NAME_2TH_LEVEL', NULL, NULL);
 CALL refresh_continuous_aggregate(:'CAGG_NAME_3TH_LEVEL', NULL, NULL);
 -- All changes are materialized
-SELECT * FROM :CAGG_NAME_1ST_LEVEL ORDER BY bucket;
+SELECT * FROM :CAGG_NAME_1ST_LEVEL;
           bucket          | temperature | device_id 
 --------------------------+-------------+-----------
  Sat Jan 01 00:00:00 2022 |          10 |         1
@@ -1420,7 +1471,7 @@ SELECT * FROM :CAGG_NAME_1ST_LEVEL ORDER BY bucket;
  Mon Jan 03 01:00:00 2022 |           2 |          
 (5 rows)
 
-SELECT * FROM :CAGG_NAME_2TH_LEVEL ORDER BY bucket, temperature;
+SELECT * FROM :CAGG_NAME_2TH_LEVEL;
           bucket          | temperature 
 --------------------------+-------------
  Sat Jan 01 00:00:00 2022 |          17
@@ -1428,7 +1479,7 @@ SELECT * FROM :CAGG_NAME_2TH_LEVEL ORDER BY bucket, temperature;
  Mon Jan 03 00:00:00 2022 |           2
 (3 rows)
 
-SELECT * FROM :CAGG_NAME_3TH_LEVEL ORDER BY bucket;
+SELECT * FROM :CAGG_NAME_3TH_LEVEL;
           bucket          | temperature 
 --------------------------+-------------
  Mon Dec 27 00:00:00 2021 |          37
@@ -1440,12 +1491,12 @@ TRUNCATE :CAGG_NAME_2TH_LEVEL;
 -- This full refresh will remove all the data from the 3TH level cagg
 CALL refresh_continuous_aggregate(:'CAGG_NAME_3TH_LEVEL', NULL, NULL);
 -- Should return no rows
-SELECT * FROM :CAGG_NAME_2TH_LEVEL ORDER BY bucket;
+SELECT * FROM :CAGG_NAME_2TH_LEVEL;
  bucket | temperature 
 --------+-------------
 (0 rows)
 
-SELECT * FROM :CAGG_NAME_3TH_LEVEL ORDER BY bucket;
+SELECT * FROM :CAGG_NAME_3TH_LEVEL;
  bucket | temperature 
 --------+-------------
 (0 rows)
@@ -1454,7 +1505,7 @@ SELECT * FROM :CAGG_NAME_3TH_LEVEL ORDER BY bucket;
 CALL refresh_continuous_aggregate(:'CAGG_NAME_2TH_LEVEL', NULL, NULL);
 CALL refresh_continuous_aggregate(:'CAGG_NAME_3TH_LEVEL', NULL, NULL);
 -- Now we have all the data
-SELECT * FROM :CAGG_NAME_2TH_LEVEL ORDER BY bucket, temperature;
+SELECT * FROM :CAGG_NAME_2TH_LEVEL;
           bucket          | temperature 
 --------------------------+-------------
  Sat Jan 01 00:00:00 2022 |          17
@@ -1462,7 +1513,7 @@ SELECT * FROM :CAGG_NAME_2TH_LEVEL ORDER BY bucket, temperature;
  Mon Jan 03 00:00:00 2022 |           2
 (3 rows)
 
-SELECT * FROM :CAGG_NAME_3TH_LEVEL ORDER BY bucket;
+SELECT * FROM :CAGG_NAME_3TH_LEVEL;
           bucket          | temperature 
 --------------------------+-------------
  Mon Dec 27 00:00:00 2021 |          37
@@ -1473,38 +1524,38 @@ SELECT * FROM :CAGG_NAME_3TH_LEVEL ORDER BY bucket;
 \set ON_ERROR_STOP 0
 -- should error because it depends of other CAGGs
 DROP MATERIALIZED VIEW :CAGG_NAME_1ST_LEVEL;
-psql:include/cagg_on_cagg_common.sql:166: ERROR:  cannot drop view conditions_summary_1_hourly because other objects depend on it
+psql:include/cagg_on_cagg_common.sql:172: ERROR:  cannot drop view conditions_summary_1_hourly because other objects depend on it
 DROP MATERIALIZED VIEW :CAGG_NAME_2TH_LEVEL;
-psql:include/cagg_on_cagg_common.sql:167: ERROR:  cannot drop view conditions_summary_2_daily because other objects depend on it
+psql:include/cagg_on_cagg_common.sql:173: ERROR:  cannot drop view conditions_summary_2_daily because other objects depend on it
 CALL refresh_continuous_aggregate(:'CAGG_NAME_1ST_LEVEL', NULL, NULL);
-psql:include/cagg_on_cagg_common.sql:168: NOTICE:  continuous aggregate "conditions_summary_1_hourly" is already up-to-date
+psql:include/cagg_on_cagg_common.sql:174: NOTICE:  continuous aggregate "conditions_summary_1_hourly" is already up-to-date
 CALL refresh_continuous_aggregate(:'CAGG_NAME_2TH_LEVEL', NULL, NULL);
-psql:include/cagg_on_cagg_common.sql:169: NOTICE:  continuous aggregate "conditions_summary_2_daily" is already up-to-date
+psql:include/cagg_on_cagg_common.sql:175: NOTICE:  continuous aggregate "conditions_summary_2_daily" is already up-to-date
 \set ON_ERROR_STOP 1
 -- DROP the 3TH level CAGG don't affect others
 DROP MATERIALIZED VIEW :CAGG_NAME_3TH_LEVEL;
-psql:include/cagg_on_cagg_common.sql:173: NOTICE:  drop cascades to table _timescaledb_internal._hyper_16_18_chunk
+psql:include/cagg_on_cagg_common.sql:179: NOTICE:  drop cascades to table _timescaledb_internal._hyper_16_18_chunk
 \set ON_ERROR_STOP 0
 -- should error because it was dropped
-SELECT * FROM :CAGG_NAME_3TH_LEVEL ORDER BY bucket, device_id;
-psql:include/cagg_on_cagg_common.sql:176: ERROR:  relation "conditions_summary_3_weekly" does not exist at character 15
+SELECT * FROM :CAGG_NAME_3TH_LEVEL;
+psql:include/cagg_on_cagg_common.sql:182: ERROR:  relation "conditions_summary_3_weekly" does not exist at character 15
 \set ON_ERROR_STOP 1
 -- should work because dropping the top level CAGG
 -- don't affect the down level CAGGs
 TRUNCATE :CAGG_NAME_2TH_LEVEL,:CAGG_NAME_1ST_LEVEL;
 CALL refresh_continuous_aggregate(:'CAGG_NAME_2TH_LEVEL', NULL, NULL);
 CALL refresh_continuous_aggregate(:'CAGG_NAME_1ST_LEVEL', NULL, NULL);
-SELECT * FROM :CAGG_NAME_1ST_LEVEL ORDER BY bucket, device_id;
+SELECT * FROM :CAGG_NAME_1ST_LEVEL;
           bucket          | temperature | device_id 
 --------------------------+-------------+-----------
  Sat Jan 01 00:00:00 2022 |          10 |         1
- Sat Jan 01 01:00:00 2022 |           5 |         2
  Sat Jan 01 01:00:00 2022 |           2 |          
+ Sat Jan 01 01:00:00 2022 |           5 |         2
  Sun Jan 02 01:00:00 2022 |          20 |         3
  Mon Jan 03 01:00:00 2022 |           2 |          
 (5 rows)
 
-SELECT * FROM :CAGG_NAME_2TH_LEVEL ORDER BY bucket, temperature;
+SELECT * FROM :CAGG_NAME_2TH_LEVEL;
  bucket | temperature 
 --------+-------------
 (0 rows)
@@ -1513,28 +1564,28 @@ SELECT * FROM :CAGG_NAME_2TH_LEVEL ORDER BY bucket, temperature;
 DROP MATERIALIZED VIEW :CAGG_NAME_2TH_LEVEL;
 \set ON_ERROR_STOP 0
 -- should error because it was dropped
-SELECT * FROM :CAGG_NAME_2TH_LEVEL ORDER BY bucket, temperature;
-psql:include/cagg_on_cagg_common.sql:190: ERROR:  relation "conditions_summary_2_daily" does not exist at character 15
+SELECT * FROM :CAGG_NAME_2TH_LEVEL;
+psql:include/cagg_on_cagg_common.sql:196: ERROR:  relation "conditions_summary_2_daily" does not exist at character 15
 \set ON_ERROR_STOP 1
 -- should work because dropping the top level CAGG
 -- don't affect the down level CAGGs
-SELECT * FROM :CAGG_NAME_1ST_LEVEL ORDER BY bucket, device_id;
+SELECT * FROM :CAGG_NAME_1ST_LEVEL;
           bucket          | temperature | device_id 
 --------------------------+-------------+-----------
  Sat Jan 01 00:00:00 2022 |          10 |         1
- Sat Jan 01 01:00:00 2022 |           5 |         2
  Sat Jan 01 01:00:00 2022 |           2 |          
+ Sat Jan 01 01:00:00 2022 |           5 |         2
  Sun Jan 02 01:00:00 2022 |          20 |         3
  Mon Jan 03 01:00:00 2022 |           2 |          
 (5 rows)
 
 -- DROP the first CAGG should work
 DROP MATERIALIZED VIEW :CAGG_NAME_1ST_LEVEL;
-psql:include/cagg_on_cagg_common.sql:197: NOTICE:  drop cascades to table _timescaledb_internal._hyper_14_20_chunk
+psql:include/cagg_on_cagg_common.sql:203: NOTICE:  drop cascades to table _timescaledb_internal._hyper_14_20_chunk
 \set ON_ERROR_STOP 0
 -- should error because it was dropped
-SELECT * FROM :CAGG_NAME_1ST_LEVEL ORDER BY bucket, device_id;
-psql:include/cagg_on_cagg_common.sql:200: ERROR:  relation "conditions_summary_1_hourly" does not exist at character 15
+SELECT * FROM :CAGG_NAME_1ST_LEVEL;
+psql:include/cagg_on_cagg_common.sql:206: ERROR:  relation "conditions_summary_1_hourly" does not exist at character 15
 \set ON_ERROR_STOP 1
 -- Default tests
 \set IS_DEFAULT_COLUMN_ORDER TRUE
@@ -1602,7 +1653,8 @@ SELECT
   SUM(temperature) AS temperature,
   device_id
 FROM conditions
-GROUP BY 1,3
+GROUP BY 1, 3
+ORDER BY 1, 2, 3
 WITH NO DATA;
 -- CAGG on CAGG (2th level)
 CREATE MATERIALIZED VIEW :CAGG_NAME_2TH_LEVEL
@@ -1611,31 +1663,38 @@ SELECT
   time_bucket(:BUCKET_WIDTH_2TH, "bucket") AS bucket,
   SUM(temperature) AS temperature
 \if :IS_JOIN
-  , :CAGG_NAME_1ST_LEVEL.device_id
-  FROM :CAGG_NAME_1ST_LEVEL, devices
-  WHERE devices.device_id = :CAGG_NAME_1ST_LEVEL.device_id
-  GROUP BY 1,3
+  , devices.device_id
+  , devices.name
+  FROM :CAGG_NAME_1ST_LEVEL
+  JOIN devices ON devices.device_id = :CAGG_NAME_1ST_LEVEL.device_id
+  GROUP BY 1, 3, 4
+  ORDER BY 1, 2, 3, 4
 \else
   FROM :CAGG_NAME_1ST_LEVEL
   GROUP BY 1
+  ORDER BY 1, 2
 \endif
 WITH NO DATA;
 -- CAGG on CAGG (3th level)
 CREATE MATERIALIZED VIEW :CAGG_NAME_3TH_LEVEL
-  WITH (timescaledb.continuous, timescaledb.materialized_only=true) AS
-  SELECT
-    time_bucket(:BUCKET_WIDTH_3TH, "bucket") AS bucket,
-    SUM(temperature) AS temperature
-  \if :IS_JOIN
-    , :CAGG_NAME_2TH_LEVEL.device_id
-    FROM :CAGG_NAME_2TH_LEVEL, devices
-    WHERE devices.device_id = :CAGG_NAME_2TH_LEVEL.device_id
-    GROUP BY 1,3
-  \else
-    FROM :CAGG_NAME_2TH_LEVEL
-    GROUP BY 1
-  \endif
-  WITH NO DATA;
+WITH (timescaledb.continuous, timescaledb.materialized_only=true) AS
+SELECT
+  time_bucket(:BUCKET_WIDTH_3TH, "bucket") AS bucket,
+  SUM(temperature) AS temperature
+\if :IS_JOIN
+  , :CAGG_NAME_2TH_LEVEL.device_id
+  , :CAGG_NAME_2TH_LEVEL.name
+  , devices.location
+  FROM :CAGG_NAME_2TH_LEVEL
+  JOIN devices ON devices.device_id = :CAGG_NAME_2TH_LEVEL.device_id
+  GROUP BY 1, 3, 4, 5
+  ORDER BY 1, 2, 3, 4, 5
+\else
+  FROM :CAGG_NAME_2TH_LEVEL
+  GROUP BY 1
+  ORDER BY 1, 2
+\endif
+WITH NO DATA;
 -- Check chunk_interval
 \if :IS_TIME_DIMENSION
   SELECT h.table_name AS name, _timescaledb_functions.to_interval(d.interval_length) AS chunk_interval
@@ -1669,23 +1728,27 @@ CREATE MATERIALIZED VIEW :CAGG_NAME_3TH_LEVEL
   ORDER BY 1, 2;
 \endif
 -- No data because the CAGGs are just for materialized data
-SELECT * FROM :CAGG_NAME_1ST_LEVEL ORDER BY bucket;
+SELECT * FROM :CAGG_NAME_1ST_LEVEL;
  bucket | temperature | device_id 
 --------+-------------+-----------
 (0 rows)
 
-SELECT * FROM :CAGG_NAME_2TH_LEVEL ORDER BY bucket, temperature;
+SELECT * FROM :CAGG_NAME_2TH_LEVEL;
  bucket | temperature 
 --------+-------------
 (0 rows)
 
---SELECT * FROM :CAGG_NAME_3TH_LEVEL ORDER BY bucket;
+SELECT * FROM :CAGG_NAME_3TH_LEVEL;
+ bucket | temperature 
+--------+-------------
+(0 rows)
+
 -- Turn CAGGs into Realtime
 ALTER MATERIALIZED VIEW :CAGG_NAME_1ST_LEVEL SET (timescaledb.materialized_only=false);
 ALTER MATERIALIZED VIEW :CAGG_NAME_2TH_LEVEL SET (timescaledb.materialized_only=false);
---ALTER MATERIALIZED VIEW :CAGG_NAME_3TH_LEVEL SET (timescaledb.materialized_only=false);
+ALTER MATERIALIZED VIEW :CAGG_NAME_3TH_LEVEL SET (timescaledb.materialized_only=false);
 -- Realtime data
-SELECT * FROM :CAGG_NAME_1ST_LEVEL ORDER BY bucket;
+SELECT * FROM :CAGG_NAME_1ST_LEVEL;
           bucket          | temperature | device_id 
 --------------------------+-------------+-----------
  Sat Jan 01 00:00:00 2022 |          10 |         1
@@ -1693,14 +1756,19 @@ SELECT * FROM :CAGG_NAME_1ST_LEVEL ORDER BY bucket;
  Sun Jan 02 01:00:00 2022 |          20 |         3
 (3 rows)
 
-SELECT * FROM :CAGG_NAME_2TH_LEVEL ORDER BY bucket, temperature;
+SELECT * FROM :CAGG_NAME_2TH_LEVEL;
           bucket          | temperature 
 --------------------------+-------------
  Sat Jan 01 00:00:00 2022 |          15
  Sun Jan 02 00:00:00 2022 |          20
 (2 rows)
 
---SELECT * FROM :CAGG_NAME_3TH_LEVEL ORDER BY bucket;
+SELECT * FROM :CAGG_NAME_3TH_LEVEL;
+          bucket          | temperature 
+--------------------------+-------------
+ Mon Dec 27 00:00:00 2021 |          35
+(1 row)
+
 -- Turn CAGGs into materialized only again
 ALTER MATERIALIZED VIEW :CAGG_NAME_1ST_LEVEL SET (timescaledb.materialized_only=true);
 ALTER MATERIALIZED VIEW :CAGG_NAME_2TH_LEVEL SET (timescaledb.materialized_only=true);
@@ -1710,7 +1778,7 @@ CALL refresh_continuous_aggregate(:'CAGG_NAME_1ST_LEVEL', NULL, NULL);
 CALL refresh_continuous_aggregate(:'CAGG_NAME_2TH_LEVEL', NULL, NULL);
 CALL refresh_continuous_aggregate(:'CAGG_NAME_3TH_LEVEL', NULL, NULL);
 -- Materialized data
-SELECT * FROM :CAGG_NAME_1ST_LEVEL ORDER BY bucket;
+SELECT * FROM :CAGG_NAME_1ST_LEVEL;
           bucket          | temperature | device_id 
 --------------------------+-------------+-----------
  Sat Jan 01 00:00:00 2022 |          10 |         1
@@ -1718,14 +1786,14 @@ SELECT * FROM :CAGG_NAME_1ST_LEVEL ORDER BY bucket;
  Sun Jan 02 01:00:00 2022 |          20 |         3
 (3 rows)
 
-SELECT * FROM :CAGG_NAME_2TH_LEVEL ORDER BY bucket, temperature;
+SELECT * FROM :CAGG_NAME_2TH_LEVEL;
           bucket          | temperature 
 --------------------------+-------------
  Sat Jan 01 00:00:00 2022 |          15
  Sun Jan 02 00:00:00 2022 |          20
 (2 rows)
 
-SELECT * FROM :CAGG_NAME_3TH_LEVEL ORDER BY bucket;
+SELECT * FROM :CAGG_NAME_3TH_LEVEL;
           bucket          | temperature 
 --------------------------+-------------
  Mon Dec 27 00:00:00 2021 |          35
@@ -1743,7 +1811,7 @@ INSERT INTO conditions ("time", temperature) VALUES (2,  2);
 INSERT INTO conditions ("time", temperature) VALUES (10, 2);
 \endif
 -- No changes
-SELECT * FROM :CAGG_NAME_1ST_LEVEL ORDER BY bucket;
+SELECT * FROM :CAGG_NAME_1ST_LEVEL;
           bucket          | temperature | device_id 
 --------------------------+-------------+-----------
  Sat Jan 01 00:00:00 2022 |          10 |         1
@@ -1751,14 +1819,14 @@ SELECT * FROM :CAGG_NAME_1ST_LEVEL ORDER BY bucket;
  Sun Jan 02 01:00:00 2022 |          20 |         3
 (3 rows)
 
-SELECT * FROM :CAGG_NAME_2TH_LEVEL ORDER BY bucket, temperature;
+SELECT * FROM :CAGG_NAME_2TH_LEVEL;
           bucket          | temperature 
 --------------------------+-------------
  Sat Jan 01 00:00:00 2022 |          15
  Sun Jan 02 00:00:00 2022 |          20
 (2 rows)
 
-SELECT * FROM :CAGG_NAME_3TH_LEVEL ORDER BY bucket;
+SELECT * FROM :CAGG_NAME_3TH_LEVEL;
           bucket          | temperature 
 --------------------------+-------------
  Mon Dec 27 00:00:00 2021 |          35
@@ -1769,7 +1837,7 @@ ALTER MATERIALIZED VIEW :CAGG_NAME_1ST_LEVEL SET (timescaledb.materialized_only=
 ALTER MATERIALIZED VIEW :CAGG_NAME_2TH_LEVEL SET (timescaledb.materialized_only=false);
 ALTER MATERIALIZED VIEW :CAGG_NAME_3TH_LEVEL SET (timescaledb.materialized_only=false);
 -- Realtime changes, just new region
-SELECT * FROM :CAGG_NAME_1ST_LEVEL ORDER BY bucket;
+SELECT * FROM :CAGG_NAME_1ST_LEVEL;
           bucket          | temperature | device_id 
 --------------------------+-------------+-----------
  Sat Jan 01 00:00:00 2022 |          10 |         1
@@ -1778,7 +1846,7 @@ SELECT * FROM :CAGG_NAME_1ST_LEVEL ORDER BY bucket;
  Mon Jan 03 01:00:00 2022 |           2 |          
 (4 rows)
 
-SELECT * FROM :CAGG_NAME_2TH_LEVEL ORDER BY bucket, temperature;
+SELECT * FROM :CAGG_NAME_2TH_LEVEL;
           bucket          | temperature 
 --------------------------+-------------
  Sat Jan 01 00:00:00 2022 |          15
@@ -1786,7 +1854,7 @@ SELECT * FROM :CAGG_NAME_2TH_LEVEL ORDER BY bucket, temperature;
  Mon Jan 03 00:00:00 2022 |           2
 (3 rows)
 
-SELECT * FROM :CAGG_NAME_3TH_LEVEL ORDER BY bucket;
+SELECT * FROM :CAGG_NAME_3TH_LEVEL;
           bucket          | temperature 
 --------------------------+-------------
  Mon Dec 27 00:00:00 2021 |          35
@@ -1802,7 +1870,7 @@ CALL refresh_continuous_aggregate(:'CAGG_NAME_1ST_LEVEL', NULL, NULL);
 CALL refresh_continuous_aggregate(:'CAGG_NAME_2TH_LEVEL', NULL, NULL);
 CALL refresh_continuous_aggregate(:'CAGG_NAME_3TH_LEVEL', NULL, NULL);
 -- All changes are materialized
-SELECT * FROM :CAGG_NAME_1ST_LEVEL ORDER BY bucket;
+SELECT * FROM :CAGG_NAME_1ST_LEVEL;
           bucket          | temperature | device_id 
 --------------------------+-------------+-----------
  Sat Jan 01 00:00:00 2022 |          10 |         1
@@ -1812,7 +1880,7 @@ SELECT * FROM :CAGG_NAME_1ST_LEVEL ORDER BY bucket;
  Mon Jan 03 01:00:00 2022 |           2 |          
 (5 rows)
 
-SELECT * FROM :CAGG_NAME_2TH_LEVEL ORDER BY bucket, temperature;
+SELECT * FROM :CAGG_NAME_2TH_LEVEL;
           bucket          | temperature 
 --------------------------+-------------
  Sat Jan 01 00:00:00 2022 |          17
@@ -1820,7 +1888,7 @@ SELECT * FROM :CAGG_NAME_2TH_LEVEL ORDER BY bucket, temperature;
  Mon Jan 03 00:00:00 2022 |           2
 (3 rows)
 
-SELECT * FROM :CAGG_NAME_3TH_LEVEL ORDER BY bucket;
+SELECT * FROM :CAGG_NAME_3TH_LEVEL;
           bucket          | temperature 
 --------------------------+-------------
  Mon Dec 27 00:00:00 2021 |          37
@@ -1832,12 +1900,12 @@ TRUNCATE :CAGG_NAME_2TH_LEVEL;
 -- This full refresh will remove all the data from the 3TH level cagg
 CALL refresh_continuous_aggregate(:'CAGG_NAME_3TH_LEVEL', NULL, NULL);
 -- Should return no rows
-SELECT * FROM :CAGG_NAME_2TH_LEVEL ORDER BY bucket;
+SELECT * FROM :CAGG_NAME_2TH_LEVEL;
  bucket | temperature 
 --------+-------------
 (0 rows)
 
-SELECT * FROM :CAGG_NAME_3TH_LEVEL ORDER BY bucket;
+SELECT * FROM :CAGG_NAME_3TH_LEVEL;
  bucket | temperature 
 --------+-------------
 (0 rows)
@@ -1846,7 +1914,7 @@ SELECT * FROM :CAGG_NAME_3TH_LEVEL ORDER BY bucket;
 CALL refresh_continuous_aggregate(:'CAGG_NAME_2TH_LEVEL', NULL, NULL);
 CALL refresh_continuous_aggregate(:'CAGG_NAME_3TH_LEVEL', NULL, NULL);
 -- Now we have all the data
-SELECT * FROM :CAGG_NAME_2TH_LEVEL ORDER BY bucket, temperature;
+SELECT * FROM :CAGG_NAME_2TH_LEVEL;
           bucket          | temperature 
 --------------------------+-------------
  Sat Jan 01 00:00:00 2022 |          17
@@ -1854,7 +1922,7 @@ SELECT * FROM :CAGG_NAME_2TH_LEVEL ORDER BY bucket, temperature;
  Mon Jan 03 00:00:00 2022 |           2
 (3 rows)
 
-SELECT * FROM :CAGG_NAME_3TH_LEVEL ORDER BY bucket;
+SELECT * FROM :CAGG_NAME_3TH_LEVEL;
           bucket          | temperature 
 --------------------------+-------------
  Mon Dec 27 00:00:00 2021 |          37
@@ -1865,38 +1933,38 @@ SELECT * FROM :CAGG_NAME_3TH_LEVEL ORDER BY bucket;
 \set ON_ERROR_STOP 0
 -- should error because it depends of other CAGGs
 DROP MATERIALIZED VIEW :CAGG_NAME_1ST_LEVEL;
-psql:include/cagg_on_cagg_common.sql:166: ERROR:  cannot drop view conditions_summary_1_hourly because other objects depend on it
+psql:include/cagg_on_cagg_common.sql:172: ERROR:  cannot drop view conditions_summary_1_hourly because other objects depend on it
 DROP MATERIALIZED VIEW :CAGG_NAME_2TH_LEVEL;
-psql:include/cagg_on_cagg_common.sql:167: ERROR:  cannot drop view conditions_summary_2_daily because other objects depend on it
+psql:include/cagg_on_cagg_common.sql:173: ERROR:  cannot drop view conditions_summary_2_daily because other objects depend on it
 CALL refresh_continuous_aggregate(:'CAGG_NAME_1ST_LEVEL', NULL, NULL);
-psql:include/cagg_on_cagg_common.sql:168: NOTICE:  continuous aggregate "conditions_summary_1_hourly" is already up-to-date
+psql:include/cagg_on_cagg_common.sql:174: NOTICE:  continuous aggregate "conditions_summary_1_hourly" is already up-to-date
 CALL refresh_continuous_aggregate(:'CAGG_NAME_2TH_LEVEL', NULL, NULL);
-psql:include/cagg_on_cagg_common.sql:169: NOTICE:  continuous aggregate "conditions_summary_2_daily" is already up-to-date
+psql:include/cagg_on_cagg_common.sql:175: NOTICE:  continuous aggregate "conditions_summary_2_daily" is already up-to-date
 \set ON_ERROR_STOP 1
 -- DROP the 3TH level CAGG don't affect others
 DROP MATERIALIZED VIEW :CAGG_NAME_3TH_LEVEL;
-psql:include/cagg_on_cagg_common.sql:173: NOTICE:  drop cascades to table _timescaledb_internal._hyper_20_24_chunk
+psql:include/cagg_on_cagg_common.sql:179: NOTICE:  drop cascades to table _timescaledb_internal._hyper_20_24_chunk
 \set ON_ERROR_STOP 0
 -- should error because it was dropped
-SELECT * FROM :CAGG_NAME_3TH_LEVEL ORDER BY bucket, device_id;
-psql:include/cagg_on_cagg_common.sql:176: ERROR:  relation "conditions_summary_3_weekly" does not exist at character 15
+SELECT * FROM :CAGG_NAME_3TH_LEVEL;
+psql:include/cagg_on_cagg_common.sql:182: ERROR:  relation "conditions_summary_3_weekly" does not exist at character 15
 \set ON_ERROR_STOP 1
 -- should work because dropping the top level CAGG
 -- don't affect the down level CAGGs
 TRUNCATE :CAGG_NAME_2TH_LEVEL,:CAGG_NAME_1ST_LEVEL;
 CALL refresh_continuous_aggregate(:'CAGG_NAME_2TH_LEVEL', NULL, NULL);
 CALL refresh_continuous_aggregate(:'CAGG_NAME_1ST_LEVEL', NULL, NULL);
-SELECT * FROM :CAGG_NAME_1ST_LEVEL ORDER BY bucket, device_id;
+SELECT * FROM :CAGG_NAME_1ST_LEVEL;
           bucket          | temperature | device_id 
 --------------------------+-------------+-----------
  Sat Jan 01 00:00:00 2022 |          10 |         1
- Sat Jan 01 01:00:00 2022 |           5 |         2
  Sat Jan 01 01:00:00 2022 |           2 |          
+ Sat Jan 01 01:00:00 2022 |           5 |         2
  Sun Jan 02 01:00:00 2022 |          20 |         3
  Mon Jan 03 01:00:00 2022 |           2 |          
 (5 rows)
 
-SELECT * FROM :CAGG_NAME_2TH_LEVEL ORDER BY bucket, temperature;
+SELECT * FROM :CAGG_NAME_2TH_LEVEL;
  bucket | temperature 
 --------+-------------
 (0 rows)
@@ -1905,28 +1973,28 @@ SELECT * FROM :CAGG_NAME_2TH_LEVEL ORDER BY bucket, temperature;
 DROP MATERIALIZED VIEW :CAGG_NAME_2TH_LEVEL;
 \set ON_ERROR_STOP 0
 -- should error because it was dropped
-SELECT * FROM :CAGG_NAME_2TH_LEVEL ORDER BY bucket, temperature;
-psql:include/cagg_on_cagg_common.sql:190: ERROR:  relation "conditions_summary_2_daily" does not exist at character 15
+SELECT * FROM :CAGG_NAME_2TH_LEVEL;
+psql:include/cagg_on_cagg_common.sql:196: ERROR:  relation "conditions_summary_2_daily" does not exist at character 15
 \set ON_ERROR_STOP 1
 -- should work because dropping the top level CAGG
 -- don't affect the down level CAGGs
-SELECT * FROM :CAGG_NAME_1ST_LEVEL ORDER BY bucket, device_id;
+SELECT * FROM :CAGG_NAME_1ST_LEVEL;
           bucket          | temperature | device_id 
 --------------------------+-------------+-----------
  Sat Jan 01 00:00:00 2022 |          10 |         1
- Sat Jan 01 01:00:00 2022 |           5 |         2
  Sat Jan 01 01:00:00 2022 |           2 |          
+ Sat Jan 01 01:00:00 2022 |           5 |         2
  Sun Jan 02 01:00:00 2022 |          20 |         3
  Mon Jan 03 01:00:00 2022 |           2 |          
 (5 rows)
 
 -- DROP the first CAGG should work
 DROP MATERIALIZED VIEW :CAGG_NAME_1ST_LEVEL;
-psql:include/cagg_on_cagg_common.sql:197: NOTICE:  drop cascades to table _timescaledb_internal._hyper_18_26_chunk
+psql:include/cagg_on_cagg_common.sql:203: NOTICE:  drop cascades to table _timescaledb_internal._hyper_18_26_chunk
 \set ON_ERROR_STOP 0
 -- should error because it was dropped
-SELECT * FROM :CAGG_NAME_1ST_LEVEL ORDER BY bucket, device_id;
-psql:include/cagg_on_cagg_common.sql:200: ERROR:  relation "conditions_summary_1_hourly" does not exist at character 15
+SELECT * FROM :CAGG_NAME_1ST_LEVEL;
+psql:include/cagg_on_cagg_common.sql:206: ERROR:  relation "conditions_summary_1_hourly" does not exist at character 15
 \set ON_ERROR_STOP 1
 --
 -- Validation test for variable bucket on top of fixed bucket
@@ -2424,7 +2492,8 @@ SELECT
   SUM(temperature) AS temperature,
   device_id
 FROM conditions
-GROUP BY 1,3
+GROUP BY 1, 3
+ORDER BY 1, 2, 3
 WITH NO DATA;
 -- CAGG on CAGG (2th level)
 CREATE MATERIALIZED VIEW :CAGG_NAME_2TH_LEVEL
@@ -2433,31 +2502,38 @@ SELECT
   time_bucket(:BUCKET_WIDTH_2TH, "bucket") AS bucket,
   SUM(temperature) AS temperature
 \if :IS_JOIN
-  , :CAGG_NAME_1ST_LEVEL.device_id
-  FROM :CAGG_NAME_1ST_LEVEL, devices
-  WHERE devices.device_id = :CAGG_NAME_1ST_LEVEL.device_id
-  GROUP BY 1,3
+  , devices.device_id
+  , devices.name
+  FROM :CAGG_NAME_1ST_LEVEL
+  JOIN devices ON devices.device_id = :CAGG_NAME_1ST_LEVEL.device_id
+  GROUP BY 1, 3, 4
+  ORDER BY 1, 2, 3, 4
 \else
   FROM :CAGG_NAME_1ST_LEVEL
   GROUP BY 1
+  ORDER BY 1, 2
 \endif
 WITH NO DATA;
 -- CAGG on CAGG (3th level)
 CREATE MATERIALIZED VIEW :CAGG_NAME_3TH_LEVEL
-  WITH (timescaledb.continuous, timescaledb.materialized_only=true) AS
-  SELECT
-    time_bucket(:BUCKET_WIDTH_3TH, "bucket") AS bucket,
-    SUM(temperature) AS temperature
-  \if :IS_JOIN
-    , :CAGG_NAME_2TH_LEVEL.device_id
-    FROM :CAGG_NAME_2TH_LEVEL, devices
-    WHERE devices.device_id = :CAGG_NAME_2TH_LEVEL.device_id
-    GROUP BY 1,3
-  \else
-    FROM :CAGG_NAME_2TH_LEVEL
-    GROUP BY 1
-  \endif
-  WITH NO DATA;
+WITH (timescaledb.continuous, timescaledb.materialized_only=true) AS
+SELECT
+  time_bucket(:BUCKET_WIDTH_3TH, "bucket") AS bucket,
+  SUM(temperature) AS temperature
+\if :IS_JOIN
+  , :CAGG_NAME_2TH_LEVEL.device_id
+  , :CAGG_NAME_2TH_LEVEL.name
+  , devices.location
+  FROM :CAGG_NAME_2TH_LEVEL
+  JOIN devices ON devices.device_id = :CAGG_NAME_2TH_LEVEL.device_id
+  GROUP BY 1, 3, 4, 5
+  ORDER BY 1, 2, 3, 4, 5
+\else
+  FROM :CAGG_NAME_2TH_LEVEL
+  GROUP BY 1
+  ORDER BY 1, 2
+\endif
+WITH NO DATA;
 -- Check chunk_interval
 \if :IS_TIME_DIMENSION
   SELECT h.table_name AS name, _timescaledb_functions.to_interval(d.interval_length) AS chunk_interval
@@ -2491,23 +2567,27 @@ CREATE MATERIALIZED VIEW :CAGG_NAME_3TH_LEVEL
   ORDER BY 1, 2;
 \endif
 -- No data because the CAGGs are just for materialized data
-SELECT * FROM :CAGG_NAME_1ST_LEVEL ORDER BY bucket;
+SELECT * FROM :CAGG_NAME_1ST_LEVEL;
  bucket | temperature | device_id 
 --------+-------------+-----------
 (0 rows)
 
-SELECT * FROM :CAGG_NAME_2TH_LEVEL ORDER BY bucket, temperature;
+SELECT * FROM :CAGG_NAME_2TH_LEVEL;
  bucket | temperature 
 --------+-------------
 (0 rows)
 
---SELECT * FROM :CAGG_NAME_3TH_LEVEL ORDER BY bucket;
+SELECT * FROM :CAGG_NAME_3TH_LEVEL;
+ bucket | temperature 
+--------+-------------
+(0 rows)
+
 -- Turn CAGGs into Realtime
 ALTER MATERIALIZED VIEW :CAGG_NAME_1ST_LEVEL SET (timescaledb.materialized_only=false);
 ALTER MATERIALIZED VIEW :CAGG_NAME_2TH_LEVEL SET (timescaledb.materialized_only=false);
---ALTER MATERIALIZED VIEW :CAGG_NAME_3TH_LEVEL SET (timescaledb.materialized_only=false);
+ALTER MATERIALIZED VIEW :CAGG_NAME_3TH_LEVEL SET (timescaledb.materialized_only=false);
 -- Realtime data
-SELECT * FROM :CAGG_NAME_1ST_LEVEL ORDER BY bucket;
+SELECT * FROM :CAGG_NAME_1ST_LEVEL;
             bucket            | temperature | device_id 
 ------------------------------+-------------+-----------
  Sat Jan 01 00:00:00 2022 UTC |          10 |         1
@@ -2515,14 +2595,19 @@ SELECT * FROM :CAGG_NAME_1ST_LEVEL ORDER BY bucket;
  Sun Jan 02 01:00:00 2022 UTC |          20 |         3
 (3 rows)
 
-SELECT * FROM :CAGG_NAME_2TH_LEVEL ORDER BY bucket, temperature;
+SELECT * FROM :CAGG_NAME_2TH_LEVEL;
             bucket            | temperature 
 ------------------------------+-------------
  Sat Jan 01 00:00:00 2022 UTC |          15
  Sun Jan 02 00:00:00 2022 UTC |          20
 (2 rows)
 
---SELECT * FROM :CAGG_NAME_3TH_LEVEL ORDER BY bucket;
+SELECT * FROM :CAGG_NAME_3TH_LEVEL;
+            bucket            | temperature 
+------------------------------+-------------
+ Mon Dec 27 00:00:00 2021 UTC |          35
+(1 row)
+
 -- Turn CAGGs into materialized only again
 ALTER MATERIALIZED VIEW :CAGG_NAME_1ST_LEVEL SET (timescaledb.materialized_only=true);
 ALTER MATERIALIZED VIEW :CAGG_NAME_2TH_LEVEL SET (timescaledb.materialized_only=true);
@@ -2532,7 +2617,7 @@ CALL refresh_continuous_aggregate(:'CAGG_NAME_1ST_LEVEL', NULL, NULL);
 CALL refresh_continuous_aggregate(:'CAGG_NAME_2TH_LEVEL', NULL, NULL);
 CALL refresh_continuous_aggregate(:'CAGG_NAME_3TH_LEVEL', NULL, NULL);
 -- Materialized data
-SELECT * FROM :CAGG_NAME_1ST_LEVEL ORDER BY bucket;
+SELECT * FROM :CAGG_NAME_1ST_LEVEL;
             bucket            | temperature | device_id 
 ------------------------------+-------------+-----------
  Sat Jan 01 00:00:00 2022 UTC |          10 |         1
@@ -2540,14 +2625,14 @@ SELECT * FROM :CAGG_NAME_1ST_LEVEL ORDER BY bucket;
  Sun Jan 02 01:00:00 2022 UTC |          20 |         3
 (3 rows)
 
-SELECT * FROM :CAGG_NAME_2TH_LEVEL ORDER BY bucket, temperature;
+SELECT * FROM :CAGG_NAME_2TH_LEVEL;
             bucket            | temperature 
 ------------------------------+-------------
  Sat Jan 01 00:00:00 2022 UTC |          15
  Sun Jan 02 00:00:00 2022 UTC |          20
 (2 rows)
 
-SELECT * FROM :CAGG_NAME_3TH_LEVEL ORDER BY bucket;
+SELECT * FROM :CAGG_NAME_3TH_LEVEL;
             bucket            | temperature 
 ------------------------------+-------------
  Mon Dec 27 00:00:00 2021 UTC |          35
@@ -2565,7 +2650,7 @@ INSERT INTO conditions ("time", temperature) VALUES (2,  2);
 INSERT INTO conditions ("time", temperature) VALUES (10, 2);
 \endif
 -- No changes
-SELECT * FROM :CAGG_NAME_1ST_LEVEL ORDER BY bucket;
+SELECT * FROM :CAGG_NAME_1ST_LEVEL;
             bucket            | temperature | device_id 
 ------------------------------+-------------+-----------
  Sat Jan 01 00:00:00 2022 UTC |          10 |         1
@@ -2573,14 +2658,14 @@ SELECT * FROM :CAGG_NAME_1ST_LEVEL ORDER BY bucket;
  Sun Jan 02 01:00:00 2022 UTC |          20 |         3
 (3 rows)
 
-SELECT * FROM :CAGG_NAME_2TH_LEVEL ORDER BY bucket, temperature;
+SELECT * FROM :CAGG_NAME_2TH_LEVEL;
             bucket            | temperature 
 ------------------------------+-------------
  Sat Jan 01 00:00:00 2022 UTC |          15
  Sun Jan 02 00:00:00 2022 UTC |          20
 (2 rows)
 
-SELECT * FROM :CAGG_NAME_3TH_LEVEL ORDER BY bucket;
+SELECT * FROM :CAGG_NAME_3TH_LEVEL;
             bucket            | temperature 
 ------------------------------+-------------
  Mon Dec 27 00:00:00 2021 UTC |          35
@@ -2591,7 +2676,7 @@ ALTER MATERIALIZED VIEW :CAGG_NAME_1ST_LEVEL SET (timescaledb.materialized_only=
 ALTER MATERIALIZED VIEW :CAGG_NAME_2TH_LEVEL SET (timescaledb.materialized_only=false);
 ALTER MATERIALIZED VIEW :CAGG_NAME_3TH_LEVEL SET (timescaledb.materialized_only=false);
 -- Realtime changes, just new region
-SELECT * FROM :CAGG_NAME_1ST_LEVEL ORDER BY bucket;
+SELECT * FROM :CAGG_NAME_1ST_LEVEL;
             bucket            | temperature | device_id 
 ------------------------------+-------------+-----------
  Sat Jan 01 00:00:00 2022 UTC |          10 |         1
@@ -2600,7 +2685,7 @@ SELECT * FROM :CAGG_NAME_1ST_LEVEL ORDER BY bucket;
  Mon Jan 03 01:00:00 2022 UTC |           2 |          
 (4 rows)
 
-SELECT * FROM :CAGG_NAME_2TH_LEVEL ORDER BY bucket, temperature;
+SELECT * FROM :CAGG_NAME_2TH_LEVEL;
             bucket            | temperature 
 ------------------------------+-------------
  Sat Jan 01 00:00:00 2022 UTC |          15
@@ -2608,7 +2693,7 @@ SELECT * FROM :CAGG_NAME_2TH_LEVEL ORDER BY bucket, temperature;
  Mon Jan 03 00:00:00 2022 UTC |           2
 (3 rows)
 
-SELECT * FROM :CAGG_NAME_3TH_LEVEL ORDER BY bucket;
+SELECT * FROM :CAGG_NAME_3TH_LEVEL;
             bucket            | temperature 
 ------------------------------+-------------
  Mon Dec 27 00:00:00 2021 UTC |          35
@@ -2624,7 +2709,7 @@ CALL refresh_continuous_aggregate(:'CAGG_NAME_1ST_LEVEL', NULL, NULL);
 CALL refresh_continuous_aggregate(:'CAGG_NAME_2TH_LEVEL', NULL, NULL);
 CALL refresh_continuous_aggregate(:'CAGG_NAME_3TH_LEVEL', NULL, NULL);
 -- All changes are materialized
-SELECT * FROM :CAGG_NAME_1ST_LEVEL ORDER BY bucket;
+SELECT * FROM :CAGG_NAME_1ST_LEVEL;
             bucket            | temperature | device_id 
 ------------------------------+-------------+-----------
  Sat Jan 01 00:00:00 2022 UTC |          10 |         1
@@ -2634,7 +2719,7 @@ SELECT * FROM :CAGG_NAME_1ST_LEVEL ORDER BY bucket;
  Mon Jan 03 01:00:00 2022 UTC |           2 |          
 (5 rows)
 
-SELECT * FROM :CAGG_NAME_2TH_LEVEL ORDER BY bucket, temperature;
+SELECT * FROM :CAGG_NAME_2TH_LEVEL;
             bucket            | temperature 
 ------------------------------+-------------
  Sat Jan 01 00:00:00 2022 UTC |          17
@@ -2642,7 +2727,7 @@ SELECT * FROM :CAGG_NAME_2TH_LEVEL ORDER BY bucket, temperature;
  Mon Jan 03 00:00:00 2022 UTC |           2
 (3 rows)
 
-SELECT * FROM :CAGG_NAME_3TH_LEVEL ORDER BY bucket;
+SELECT * FROM :CAGG_NAME_3TH_LEVEL;
             bucket            | temperature 
 ------------------------------+-------------
  Mon Dec 27 00:00:00 2021 UTC |          37
@@ -2654,12 +2739,12 @@ TRUNCATE :CAGG_NAME_2TH_LEVEL;
 -- This full refresh will remove all the data from the 3TH level cagg
 CALL refresh_continuous_aggregate(:'CAGG_NAME_3TH_LEVEL', NULL, NULL);
 -- Should return no rows
-SELECT * FROM :CAGG_NAME_2TH_LEVEL ORDER BY bucket;
+SELECT * FROM :CAGG_NAME_2TH_LEVEL;
  bucket | temperature 
 --------+-------------
 (0 rows)
 
-SELECT * FROM :CAGG_NAME_3TH_LEVEL ORDER BY bucket;
+SELECT * FROM :CAGG_NAME_3TH_LEVEL;
  bucket | temperature 
 --------+-------------
 (0 rows)
@@ -2668,7 +2753,7 @@ SELECT * FROM :CAGG_NAME_3TH_LEVEL ORDER BY bucket;
 CALL refresh_continuous_aggregate(:'CAGG_NAME_2TH_LEVEL', NULL, NULL);
 CALL refresh_continuous_aggregate(:'CAGG_NAME_3TH_LEVEL', NULL, NULL);
 -- Now we have all the data
-SELECT * FROM :CAGG_NAME_2TH_LEVEL ORDER BY bucket, temperature;
+SELECT * FROM :CAGG_NAME_2TH_LEVEL;
             bucket            | temperature 
 ------------------------------+-------------
  Sat Jan 01 00:00:00 2022 UTC |          17
@@ -2676,7 +2761,7 @@ SELECT * FROM :CAGG_NAME_2TH_LEVEL ORDER BY bucket, temperature;
  Mon Jan 03 00:00:00 2022 UTC |           2
 (3 rows)
 
-SELECT * FROM :CAGG_NAME_3TH_LEVEL ORDER BY bucket;
+SELECT * FROM :CAGG_NAME_3TH_LEVEL;
             bucket            | temperature 
 ------------------------------+-------------
  Mon Dec 27 00:00:00 2021 UTC |          37
@@ -2687,38 +2772,38 @@ SELECT * FROM :CAGG_NAME_3TH_LEVEL ORDER BY bucket;
 \set ON_ERROR_STOP 0
 -- should error because it depends of other CAGGs
 DROP MATERIALIZED VIEW :CAGG_NAME_1ST_LEVEL;
-psql:include/cagg_on_cagg_common.sql:166: ERROR:  cannot drop view conditions_summary_1_hourly because other objects depend on it
+psql:include/cagg_on_cagg_common.sql:172: ERROR:  cannot drop view conditions_summary_1_hourly because other objects depend on it
 DROP MATERIALIZED VIEW :CAGG_NAME_2TH_LEVEL;
-psql:include/cagg_on_cagg_common.sql:167: ERROR:  cannot drop view conditions_summary_2_daily because other objects depend on it
+psql:include/cagg_on_cagg_common.sql:173: ERROR:  cannot drop view conditions_summary_2_daily because other objects depend on it
 CALL refresh_continuous_aggregate(:'CAGG_NAME_1ST_LEVEL', NULL, NULL);
-psql:include/cagg_on_cagg_common.sql:168: NOTICE:  continuous aggregate "conditions_summary_1_hourly" is already up-to-date
+psql:include/cagg_on_cagg_common.sql:174: NOTICE:  continuous aggregate "conditions_summary_1_hourly" is already up-to-date
 CALL refresh_continuous_aggregate(:'CAGG_NAME_2TH_LEVEL', NULL, NULL);
-psql:include/cagg_on_cagg_common.sql:169: NOTICE:  continuous aggregate "conditions_summary_2_daily" is already up-to-date
+psql:include/cagg_on_cagg_common.sql:175: NOTICE:  continuous aggregate "conditions_summary_2_daily" is already up-to-date
 \set ON_ERROR_STOP 1
 -- DROP the 3TH level CAGG don't affect others
 DROP MATERIALIZED VIEW :CAGG_NAME_3TH_LEVEL;
-psql:include/cagg_on_cagg_common.sql:173: NOTICE:  drop cascades to table _timescaledb_internal._hyper_29_30_chunk
+psql:include/cagg_on_cagg_common.sql:179: NOTICE:  drop cascades to table _timescaledb_internal._hyper_29_30_chunk
 \set ON_ERROR_STOP 0
 -- should error because it was dropped
-SELECT * FROM :CAGG_NAME_3TH_LEVEL ORDER BY bucket, device_id;
-psql:include/cagg_on_cagg_common.sql:176: ERROR:  relation "conditions_summary_3_weekly" does not exist at character 15
+SELECT * FROM :CAGG_NAME_3TH_LEVEL;
+psql:include/cagg_on_cagg_common.sql:182: ERROR:  relation "conditions_summary_3_weekly" does not exist at character 15
 \set ON_ERROR_STOP 1
 -- should work because dropping the top level CAGG
 -- don't affect the down level CAGGs
 TRUNCATE :CAGG_NAME_2TH_LEVEL,:CAGG_NAME_1ST_LEVEL;
 CALL refresh_continuous_aggregate(:'CAGG_NAME_2TH_LEVEL', NULL, NULL);
 CALL refresh_continuous_aggregate(:'CAGG_NAME_1ST_LEVEL', NULL, NULL);
-SELECT * FROM :CAGG_NAME_1ST_LEVEL ORDER BY bucket, device_id;
+SELECT * FROM :CAGG_NAME_1ST_LEVEL;
             bucket            | temperature | device_id 
 ------------------------------+-------------+-----------
  Sat Jan 01 00:00:00 2022 UTC |          10 |         1
- Sat Jan 01 01:00:00 2022 UTC |           5 |         2
  Sat Jan 01 01:00:00 2022 UTC |           2 |          
+ Sat Jan 01 01:00:00 2022 UTC |           5 |         2
  Sun Jan 02 01:00:00 2022 UTC |          20 |         3
  Mon Jan 03 01:00:00 2022 UTC |           2 |          
 (5 rows)
 
-SELECT * FROM :CAGG_NAME_2TH_LEVEL ORDER BY bucket, temperature;
+SELECT * FROM :CAGG_NAME_2TH_LEVEL;
  bucket | temperature 
 --------+-------------
 (0 rows)
@@ -2727,28 +2812,28 @@ SELECT * FROM :CAGG_NAME_2TH_LEVEL ORDER BY bucket, temperature;
 DROP MATERIALIZED VIEW :CAGG_NAME_2TH_LEVEL;
 \set ON_ERROR_STOP 0
 -- should error because it was dropped
-SELECT * FROM :CAGG_NAME_2TH_LEVEL ORDER BY bucket, temperature;
-psql:include/cagg_on_cagg_common.sql:190: ERROR:  relation "conditions_summary_2_daily" does not exist at character 15
+SELECT * FROM :CAGG_NAME_2TH_LEVEL;
+psql:include/cagg_on_cagg_common.sql:196: ERROR:  relation "conditions_summary_2_daily" does not exist at character 15
 \set ON_ERROR_STOP 1
 -- should work because dropping the top level CAGG
 -- don't affect the down level CAGGs
-SELECT * FROM :CAGG_NAME_1ST_LEVEL ORDER BY bucket, device_id;
+SELECT * FROM :CAGG_NAME_1ST_LEVEL;
             bucket            | temperature | device_id 
 ------------------------------+-------------+-----------
  Sat Jan 01 00:00:00 2022 UTC |          10 |         1
- Sat Jan 01 01:00:00 2022 UTC |           5 |         2
  Sat Jan 01 01:00:00 2022 UTC |           2 |          
+ Sat Jan 01 01:00:00 2022 UTC |           5 |         2
  Sun Jan 02 01:00:00 2022 UTC |          20 |         3
  Mon Jan 03 01:00:00 2022 UTC |           2 |          
 (5 rows)
 
 -- DROP the first CAGG should work
 DROP MATERIALIZED VIEW :CAGG_NAME_1ST_LEVEL;
-psql:include/cagg_on_cagg_common.sql:197: NOTICE:  drop cascades to table _timescaledb_internal._hyper_27_32_chunk
+psql:include/cagg_on_cagg_common.sql:203: NOTICE:  drop cascades to table _timescaledb_internal._hyper_27_32_chunk
 \set ON_ERROR_STOP 0
 -- should error because it was dropped
-SELECT * FROM :CAGG_NAME_1ST_LEVEL ORDER BY bucket, device_id;
-psql:include/cagg_on_cagg_common.sql:200: ERROR:  relation "conditions_summary_1_hourly" does not exist at character 15
+SELECT * FROM :CAGG_NAME_1ST_LEVEL;
+psql:include/cagg_on_cagg_common.sql:206: ERROR:  relation "conditions_summary_1_hourly" does not exist at character 15
 \set ON_ERROR_STOP 1
 -- Default tests
 \set IS_DEFAULT_COLUMN_ORDER TRUE
@@ -2815,7 +2900,8 @@ SELECT
   SUM(temperature) AS temperature,
   device_id
 FROM conditions
-GROUP BY 1,3
+GROUP BY 1, 3
+ORDER BY 1, 2, 3
 WITH NO DATA;
 -- CAGG on CAGG (2th level)
 CREATE MATERIALIZED VIEW :CAGG_NAME_2TH_LEVEL
@@ -2824,31 +2910,38 @@ SELECT
   time_bucket(:BUCKET_WIDTH_2TH, "bucket") AS bucket,
   SUM(temperature) AS temperature
 \if :IS_JOIN
-  , :CAGG_NAME_1ST_LEVEL.device_id
-  FROM :CAGG_NAME_1ST_LEVEL, devices
-  WHERE devices.device_id = :CAGG_NAME_1ST_LEVEL.device_id
-  GROUP BY 1,3
+  , devices.device_id
+  , devices.name
+  FROM :CAGG_NAME_1ST_LEVEL
+  JOIN devices ON devices.device_id = :CAGG_NAME_1ST_LEVEL.device_id
+  GROUP BY 1, 3, 4
+  ORDER BY 1, 2, 3, 4
 \else
   FROM :CAGG_NAME_1ST_LEVEL
   GROUP BY 1
+  ORDER BY 1, 2
 \endif
 WITH NO DATA;
 -- CAGG on CAGG (3th level)
 CREATE MATERIALIZED VIEW :CAGG_NAME_3TH_LEVEL
-  WITH (timescaledb.continuous, timescaledb.materialized_only=true) AS
-  SELECT
-    time_bucket(:BUCKET_WIDTH_3TH, "bucket") AS bucket,
-    SUM(temperature) AS temperature
-  \if :IS_JOIN
-    , :CAGG_NAME_2TH_LEVEL.device_id
-    FROM :CAGG_NAME_2TH_LEVEL, devices
-    WHERE devices.device_id = :CAGG_NAME_2TH_LEVEL.device_id
-    GROUP BY 1,3
-  \else
-    FROM :CAGG_NAME_2TH_LEVEL
-    GROUP BY 1
-  \endif
-  WITH NO DATA;
+WITH (timescaledb.continuous, timescaledb.materialized_only=true) AS
+SELECT
+  time_bucket(:BUCKET_WIDTH_3TH, "bucket") AS bucket,
+  SUM(temperature) AS temperature
+\if :IS_JOIN
+  , :CAGG_NAME_2TH_LEVEL.device_id
+  , :CAGG_NAME_2TH_LEVEL.name
+  , devices.location
+  FROM :CAGG_NAME_2TH_LEVEL
+  JOIN devices ON devices.device_id = :CAGG_NAME_2TH_LEVEL.device_id
+  GROUP BY 1, 3, 4, 5
+  ORDER BY 1, 2, 3, 4, 5
+\else
+  FROM :CAGG_NAME_2TH_LEVEL
+  GROUP BY 1
+  ORDER BY 1, 2
+\endif
+WITH NO DATA;
 -- Check chunk_interval
 \if :IS_TIME_DIMENSION
   SELECT h.table_name AS name, _timescaledb_functions.to_interval(d.interval_length) AS chunk_interval
@@ -2882,23 +2975,27 @@ CREATE MATERIALIZED VIEW :CAGG_NAME_3TH_LEVEL
   ORDER BY 1, 2;
 \endif
 -- No data because the CAGGs are just for materialized data
-SELECT * FROM :CAGG_NAME_1ST_LEVEL ORDER BY bucket;
+SELECT * FROM :CAGG_NAME_1ST_LEVEL;
  bucket | temperature | device_id 
 --------+-------------+-----------
 (0 rows)
 
-SELECT * FROM :CAGG_NAME_2TH_LEVEL ORDER BY bucket, temperature;
+SELECT * FROM :CAGG_NAME_2TH_LEVEL;
  bucket | temperature 
 --------+-------------
 (0 rows)
 
---SELECT * FROM :CAGG_NAME_3TH_LEVEL ORDER BY bucket;
+SELECT * FROM :CAGG_NAME_3TH_LEVEL;
+ bucket | temperature 
+--------+-------------
+(0 rows)
+
 -- Turn CAGGs into Realtime
 ALTER MATERIALIZED VIEW :CAGG_NAME_1ST_LEVEL SET (timescaledb.materialized_only=false);
 ALTER MATERIALIZED VIEW :CAGG_NAME_2TH_LEVEL SET (timescaledb.materialized_only=false);
---ALTER MATERIALIZED VIEW :CAGG_NAME_3TH_LEVEL SET (timescaledb.materialized_only=false);
+ALTER MATERIALIZED VIEW :CAGG_NAME_3TH_LEVEL SET (timescaledb.materialized_only=false);
 -- Realtime data
-SELECT * FROM :CAGG_NAME_1ST_LEVEL ORDER BY bucket;
+SELECT * FROM :CAGG_NAME_1ST_LEVEL;
             bucket            | temperature | device_id 
 ------------------------------+-------------+-----------
  Sat Jan 01 00:00:00 2022 UTC |          10 |         1
@@ -2906,14 +3003,19 @@ SELECT * FROM :CAGG_NAME_1ST_LEVEL ORDER BY bucket;
  Sun Jan 02 01:00:00 2022 UTC |          20 |         3
 (3 rows)
 
-SELECT * FROM :CAGG_NAME_2TH_LEVEL ORDER BY bucket, temperature;
+SELECT * FROM :CAGG_NAME_2TH_LEVEL;
             bucket            | temperature 
 ------------------------------+-------------
  Sat Jan 01 00:00:00 2022 UTC |          15
  Sun Jan 02 00:00:00 2022 UTC |          20
 (2 rows)
 
---SELECT * FROM :CAGG_NAME_3TH_LEVEL ORDER BY bucket;
+SELECT * FROM :CAGG_NAME_3TH_LEVEL;
+            bucket            | temperature 
+------------------------------+-------------
+ Mon Dec 27 00:00:00 2021 UTC |          35
+(1 row)
+
 -- Turn CAGGs into materialized only again
 ALTER MATERIALIZED VIEW :CAGG_NAME_1ST_LEVEL SET (timescaledb.materialized_only=true);
 ALTER MATERIALIZED VIEW :CAGG_NAME_2TH_LEVEL SET (timescaledb.materialized_only=true);
@@ -2923,7 +3025,7 @@ CALL refresh_continuous_aggregate(:'CAGG_NAME_1ST_LEVEL', NULL, NULL);
 CALL refresh_continuous_aggregate(:'CAGG_NAME_2TH_LEVEL', NULL, NULL);
 CALL refresh_continuous_aggregate(:'CAGG_NAME_3TH_LEVEL', NULL, NULL);
 -- Materialized data
-SELECT * FROM :CAGG_NAME_1ST_LEVEL ORDER BY bucket;
+SELECT * FROM :CAGG_NAME_1ST_LEVEL;
             bucket            | temperature | device_id 
 ------------------------------+-------------+-----------
  Sat Jan 01 00:00:00 2022 UTC |          10 |         1
@@ -2931,14 +3033,14 @@ SELECT * FROM :CAGG_NAME_1ST_LEVEL ORDER BY bucket;
  Sun Jan 02 01:00:00 2022 UTC |          20 |         3
 (3 rows)
 
-SELECT * FROM :CAGG_NAME_2TH_LEVEL ORDER BY bucket, temperature;
+SELECT * FROM :CAGG_NAME_2TH_LEVEL;
             bucket            | temperature 
 ------------------------------+-------------
  Sat Jan 01 00:00:00 2022 UTC |          15
  Sun Jan 02 00:00:00 2022 UTC |          20
 (2 rows)
 
-SELECT * FROM :CAGG_NAME_3TH_LEVEL ORDER BY bucket;
+SELECT * FROM :CAGG_NAME_3TH_LEVEL;
             bucket            | temperature 
 ------------------------------+-------------
  Mon Dec 27 00:00:00 2021 UTC |          35
@@ -2956,7 +3058,7 @@ INSERT INTO conditions ("time", temperature) VALUES (2,  2);
 INSERT INTO conditions ("time", temperature) VALUES (10, 2);
 \endif
 -- No changes
-SELECT * FROM :CAGG_NAME_1ST_LEVEL ORDER BY bucket;
+SELECT * FROM :CAGG_NAME_1ST_LEVEL;
             bucket            | temperature | device_id 
 ------------------------------+-------------+-----------
  Sat Jan 01 00:00:00 2022 UTC |          10 |         1
@@ -2964,14 +3066,14 @@ SELECT * FROM :CAGG_NAME_1ST_LEVEL ORDER BY bucket;
  Sun Jan 02 01:00:00 2022 UTC |          20 |         3
 (3 rows)
 
-SELECT * FROM :CAGG_NAME_2TH_LEVEL ORDER BY bucket, temperature;
+SELECT * FROM :CAGG_NAME_2TH_LEVEL;
             bucket            | temperature 
 ------------------------------+-------------
  Sat Jan 01 00:00:00 2022 UTC |          15
  Sun Jan 02 00:00:00 2022 UTC |          20
 (2 rows)
 
-SELECT * FROM :CAGG_NAME_3TH_LEVEL ORDER BY bucket;
+SELECT * FROM :CAGG_NAME_3TH_LEVEL;
             bucket            | temperature 
 ------------------------------+-------------
  Mon Dec 27 00:00:00 2021 UTC |          35
@@ -2982,7 +3084,7 @@ ALTER MATERIALIZED VIEW :CAGG_NAME_1ST_LEVEL SET (timescaledb.materialized_only=
 ALTER MATERIALIZED VIEW :CAGG_NAME_2TH_LEVEL SET (timescaledb.materialized_only=false);
 ALTER MATERIALIZED VIEW :CAGG_NAME_3TH_LEVEL SET (timescaledb.materialized_only=false);
 -- Realtime changes, just new region
-SELECT * FROM :CAGG_NAME_1ST_LEVEL ORDER BY bucket;
+SELECT * FROM :CAGG_NAME_1ST_LEVEL;
             bucket            | temperature | device_id 
 ------------------------------+-------------+-----------
  Sat Jan 01 00:00:00 2022 UTC |          10 |         1
@@ -2991,7 +3093,7 @@ SELECT * FROM :CAGG_NAME_1ST_LEVEL ORDER BY bucket;
  Mon Jan 03 01:00:00 2022 UTC |           2 |          
 (4 rows)
 
-SELECT * FROM :CAGG_NAME_2TH_LEVEL ORDER BY bucket, temperature;
+SELECT * FROM :CAGG_NAME_2TH_LEVEL;
             bucket            | temperature 
 ------------------------------+-------------
  Sat Jan 01 00:00:00 2022 UTC |          15
@@ -2999,7 +3101,7 @@ SELECT * FROM :CAGG_NAME_2TH_LEVEL ORDER BY bucket, temperature;
  Mon Jan 03 00:00:00 2022 UTC |           2
 (3 rows)
 
-SELECT * FROM :CAGG_NAME_3TH_LEVEL ORDER BY bucket;
+SELECT * FROM :CAGG_NAME_3TH_LEVEL;
             bucket            | temperature 
 ------------------------------+-------------
  Mon Dec 27 00:00:00 2021 UTC |          35
@@ -3015,7 +3117,7 @@ CALL refresh_continuous_aggregate(:'CAGG_NAME_1ST_LEVEL', NULL, NULL);
 CALL refresh_continuous_aggregate(:'CAGG_NAME_2TH_LEVEL', NULL, NULL);
 CALL refresh_continuous_aggregate(:'CAGG_NAME_3TH_LEVEL', NULL, NULL);
 -- All changes are materialized
-SELECT * FROM :CAGG_NAME_1ST_LEVEL ORDER BY bucket;
+SELECT * FROM :CAGG_NAME_1ST_LEVEL;
             bucket            | temperature | device_id 
 ------------------------------+-------------+-----------
  Sat Jan 01 00:00:00 2022 UTC |          10 |         1
@@ -3025,7 +3127,7 @@ SELECT * FROM :CAGG_NAME_1ST_LEVEL ORDER BY bucket;
  Mon Jan 03 01:00:00 2022 UTC |           2 |          
 (5 rows)
 
-SELECT * FROM :CAGG_NAME_2TH_LEVEL ORDER BY bucket, temperature;
+SELECT * FROM :CAGG_NAME_2TH_LEVEL;
             bucket            | temperature 
 ------------------------------+-------------
  Sat Jan 01 00:00:00 2022 UTC |          17
@@ -3033,7 +3135,7 @@ SELECT * FROM :CAGG_NAME_2TH_LEVEL ORDER BY bucket, temperature;
  Mon Jan 03 00:00:00 2022 UTC |           2
 (3 rows)
 
-SELECT * FROM :CAGG_NAME_3TH_LEVEL ORDER BY bucket;
+SELECT * FROM :CAGG_NAME_3TH_LEVEL;
             bucket            | temperature 
 ------------------------------+-------------
  Mon Dec 27 00:00:00 2021 UTC |          37
@@ -3045,12 +3147,12 @@ TRUNCATE :CAGG_NAME_2TH_LEVEL;
 -- This full refresh will remove all the data from the 3TH level cagg
 CALL refresh_continuous_aggregate(:'CAGG_NAME_3TH_LEVEL', NULL, NULL);
 -- Should return no rows
-SELECT * FROM :CAGG_NAME_2TH_LEVEL ORDER BY bucket;
+SELECT * FROM :CAGG_NAME_2TH_LEVEL;
  bucket | temperature 
 --------+-------------
 (0 rows)
 
-SELECT * FROM :CAGG_NAME_3TH_LEVEL ORDER BY bucket;
+SELECT * FROM :CAGG_NAME_3TH_LEVEL;
  bucket | temperature 
 --------+-------------
 (0 rows)
@@ -3059,7 +3161,7 @@ SELECT * FROM :CAGG_NAME_3TH_LEVEL ORDER BY bucket;
 CALL refresh_continuous_aggregate(:'CAGG_NAME_2TH_LEVEL', NULL, NULL);
 CALL refresh_continuous_aggregate(:'CAGG_NAME_3TH_LEVEL', NULL, NULL);
 -- Now we have all the data
-SELECT * FROM :CAGG_NAME_2TH_LEVEL ORDER BY bucket, temperature;
+SELECT * FROM :CAGG_NAME_2TH_LEVEL;
             bucket            | temperature 
 ------------------------------+-------------
  Sat Jan 01 00:00:00 2022 UTC |          17
@@ -3067,7 +3169,7 @@ SELECT * FROM :CAGG_NAME_2TH_LEVEL ORDER BY bucket, temperature;
  Mon Jan 03 00:00:00 2022 UTC |           2
 (3 rows)
 
-SELECT * FROM :CAGG_NAME_3TH_LEVEL ORDER BY bucket;
+SELECT * FROM :CAGG_NAME_3TH_LEVEL;
             bucket            | temperature 
 ------------------------------+-------------
  Mon Dec 27 00:00:00 2021 UTC |          37
@@ -3078,38 +3180,38 @@ SELECT * FROM :CAGG_NAME_3TH_LEVEL ORDER BY bucket;
 \set ON_ERROR_STOP 0
 -- should error because it depends of other CAGGs
 DROP MATERIALIZED VIEW :CAGG_NAME_1ST_LEVEL;
-psql:include/cagg_on_cagg_common.sql:166: ERROR:  cannot drop view conditions_summary_1_hourly because other objects depend on it
+psql:include/cagg_on_cagg_common.sql:172: ERROR:  cannot drop view conditions_summary_1_hourly because other objects depend on it
 DROP MATERIALIZED VIEW :CAGG_NAME_2TH_LEVEL;
-psql:include/cagg_on_cagg_common.sql:167: ERROR:  cannot drop view conditions_summary_2_daily because other objects depend on it
+psql:include/cagg_on_cagg_common.sql:173: ERROR:  cannot drop view conditions_summary_2_daily because other objects depend on it
 CALL refresh_continuous_aggregate(:'CAGG_NAME_1ST_LEVEL', NULL, NULL);
-psql:include/cagg_on_cagg_common.sql:168: NOTICE:  continuous aggregate "conditions_summary_1_hourly" is already up-to-date
+psql:include/cagg_on_cagg_common.sql:174: NOTICE:  continuous aggregate "conditions_summary_1_hourly" is already up-to-date
 CALL refresh_continuous_aggregate(:'CAGG_NAME_2TH_LEVEL', NULL, NULL);
-psql:include/cagg_on_cagg_common.sql:169: NOTICE:  continuous aggregate "conditions_summary_2_daily" is already up-to-date
+psql:include/cagg_on_cagg_common.sql:175: NOTICE:  continuous aggregate "conditions_summary_2_daily" is already up-to-date
 \set ON_ERROR_STOP 1
 -- DROP the 3TH level CAGG don't affect others
 DROP MATERIALIZED VIEW :CAGG_NAME_3TH_LEVEL;
-psql:include/cagg_on_cagg_common.sql:173: NOTICE:  drop cascades to table _timescaledb_internal._hyper_33_36_chunk
+psql:include/cagg_on_cagg_common.sql:179: NOTICE:  drop cascades to table _timescaledb_internal._hyper_33_36_chunk
 \set ON_ERROR_STOP 0
 -- should error because it was dropped
-SELECT * FROM :CAGG_NAME_3TH_LEVEL ORDER BY bucket, device_id;
-psql:include/cagg_on_cagg_common.sql:176: ERROR:  relation "conditions_summary_3_weekly" does not exist at character 15
+SELECT * FROM :CAGG_NAME_3TH_LEVEL;
+psql:include/cagg_on_cagg_common.sql:182: ERROR:  relation "conditions_summary_3_weekly" does not exist at character 15
 \set ON_ERROR_STOP 1
 -- should work because dropping the top level CAGG
 -- don't affect the down level CAGGs
 TRUNCATE :CAGG_NAME_2TH_LEVEL,:CAGG_NAME_1ST_LEVEL;
 CALL refresh_continuous_aggregate(:'CAGG_NAME_2TH_LEVEL', NULL, NULL);
 CALL refresh_continuous_aggregate(:'CAGG_NAME_1ST_LEVEL', NULL, NULL);
-SELECT * FROM :CAGG_NAME_1ST_LEVEL ORDER BY bucket, device_id;
+SELECT * FROM :CAGG_NAME_1ST_LEVEL;
             bucket            | temperature | device_id 
 ------------------------------+-------------+-----------
  Sat Jan 01 00:00:00 2022 UTC |          10 |         1
- Sat Jan 01 01:00:00 2022 UTC |           5 |         2
  Sat Jan 01 01:00:00 2022 UTC |           2 |          
+ Sat Jan 01 01:00:00 2022 UTC |           5 |         2
  Sun Jan 02 01:00:00 2022 UTC |          20 |         3
  Mon Jan 03 01:00:00 2022 UTC |           2 |          
 (5 rows)
 
-SELECT * FROM :CAGG_NAME_2TH_LEVEL ORDER BY bucket, temperature;
+SELECT * FROM :CAGG_NAME_2TH_LEVEL;
  bucket | temperature 
 --------+-------------
 (0 rows)
@@ -3118,28 +3220,28 @@ SELECT * FROM :CAGG_NAME_2TH_LEVEL ORDER BY bucket, temperature;
 DROP MATERIALIZED VIEW :CAGG_NAME_2TH_LEVEL;
 \set ON_ERROR_STOP 0
 -- should error because it was dropped
-SELECT * FROM :CAGG_NAME_2TH_LEVEL ORDER BY bucket, temperature;
-psql:include/cagg_on_cagg_common.sql:190: ERROR:  relation "conditions_summary_2_daily" does not exist at character 15
+SELECT * FROM :CAGG_NAME_2TH_LEVEL;
+psql:include/cagg_on_cagg_common.sql:196: ERROR:  relation "conditions_summary_2_daily" does not exist at character 15
 \set ON_ERROR_STOP 1
 -- should work because dropping the top level CAGG
 -- don't affect the down level CAGGs
-SELECT * FROM :CAGG_NAME_1ST_LEVEL ORDER BY bucket, device_id;
+SELECT * FROM :CAGG_NAME_1ST_LEVEL;
             bucket            | temperature | device_id 
 ------------------------------+-------------+-----------
  Sat Jan 01 00:00:00 2022 UTC |          10 |         1
- Sat Jan 01 01:00:00 2022 UTC |           5 |         2
  Sat Jan 01 01:00:00 2022 UTC |           2 |          
+ Sat Jan 01 01:00:00 2022 UTC |           5 |         2
  Sun Jan 02 01:00:00 2022 UTC |          20 |         3
  Mon Jan 03 01:00:00 2022 UTC |           2 |          
 (5 rows)
 
 -- DROP the first CAGG should work
 DROP MATERIALIZED VIEW :CAGG_NAME_1ST_LEVEL;
-psql:include/cagg_on_cagg_common.sql:197: NOTICE:  drop cascades to table _timescaledb_internal._hyper_31_38_chunk
+psql:include/cagg_on_cagg_common.sql:203: NOTICE:  drop cascades to table _timescaledb_internal._hyper_31_38_chunk
 \set ON_ERROR_STOP 0
 -- should error because it was dropped
-SELECT * FROM :CAGG_NAME_1ST_LEVEL ORDER BY bucket, device_id;
-psql:include/cagg_on_cagg_common.sql:200: ERROR:  relation "conditions_summary_1_hourly" does not exist at character 15
+SELECT * FROM :CAGG_NAME_1ST_LEVEL;
+psql:include/cagg_on_cagg_common.sql:206: ERROR:  relation "conditions_summary_1_hourly" does not exist at character 15
 \set ON_ERROR_STOP 1
 --
 -- Validation test for variable bucket on top of fixed bucket

--- a/tsl/test/expected/cagg_on_cagg_joins.out
+++ b/tsl/test/expected/cagg_on_cagg_joins.out
@@ -93,7 +93,8 @@ SELECT
   SUM(temperature) AS temperature,
   device_id
 FROM conditions
-GROUP BY 1,3
+GROUP BY 1, 3
+ORDER BY 1, 2, 3
 WITH NO DATA;
 -- CAGG on CAGG (2th level)
 CREATE MATERIALIZED VIEW :CAGG_NAME_2TH_LEVEL
@@ -102,31 +103,38 @@ SELECT
   time_bucket(:BUCKET_WIDTH_2TH, "bucket") AS bucket,
   SUM(temperature) AS temperature
 \if :IS_JOIN
-  , :CAGG_NAME_1ST_LEVEL.device_id
-  FROM :CAGG_NAME_1ST_LEVEL, devices
-  WHERE devices.device_id = :CAGG_NAME_1ST_LEVEL.device_id
-  GROUP BY 1,3
+  , devices.device_id
+  , devices.name
+  FROM :CAGG_NAME_1ST_LEVEL
+  JOIN devices ON devices.device_id = :CAGG_NAME_1ST_LEVEL.device_id
+  GROUP BY 1, 3, 4
+  ORDER BY 1, 2, 3, 4
 \else
   FROM :CAGG_NAME_1ST_LEVEL
   GROUP BY 1
+  ORDER BY 1, 2
 \endif
 WITH NO DATA;
 -- CAGG on CAGG (3th level)
 CREATE MATERIALIZED VIEW :CAGG_NAME_3TH_LEVEL
-  WITH (timescaledb.continuous, timescaledb.materialized_only=true) AS
-  SELECT
-    time_bucket(:BUCKET_WIDTH_3TH, "bucket") AS bucket,
-    SUM(temperature) AS temperature
-  \if :IS_JOIN
-    , :CAGG_NAME_2TH_LEVEL.device_id
-    FROM :CAGG_NAME_2TH_LEVEL, devices
-    WHERE devices.device_id = :CAGG_NAME_2TH_LEVEL.device_id
-    GROUP BY 1,3
-  \else
-    FROM :CAGG_NAME_2TH_LEVEL
-    GROUP BY 1
-  \endif
-  WITH NO DATA;
+WITH (timescaledb.continuous, timescaledb.materialized_only=true) AS
+SELECT
+  time_bucket(:BUCKET_WIDTH_3TH, "bucket") AS bucket,
+  SUM(temperature) AS temperature
+\if :IS_JOIN
+  , :CAGG_NAME_2TH_LEVEL.device_id
+  , :CAGG_NAME_2TH_LEVEL.name
+  , devices.location
+  FROM :CAGG_NAME_2TH_LEVEL
+  JOIN devices ON devices.device_id = :CAGG_NAME_2TH_LEVEL.device_id
+  GROUP BY 1, 3, 4, 5
+  ORDER BY 1, 2, 3, 4, 5
+\else
+  FROM :CAGG_NAME_2TH_LEVEL
+  GROUP BY 1
+  ORDER BY 1, 2
+\endif
+WITH NO DATA;
 -- Check chunk_interval
 \if :IS_TIME_DIMENSION
   SELECT h.table_name AS name, _timescaledb_functions.to_interval(d.interval_length) AS chunk_interval
@@ -160,23 +168,27 @@ CREATE MATERIALIZED VIEW :CAGG_NAME_3TH_LEVEL
 
 \endif
 -- No data because the CAGGs are just for materialized data
-SELECT * FROM :CAGG_NAME_1ST_LEVEL ORDER BY bucket;
+SELECT * FROM :CAGG_NAME_1ST_LEVEL;
  bucket | temperature | device_id 
 --------+-------------+-----------
 (0 rows)
 
-SELECT * FROM :CAGG_NAME_2TH_LEVEL ORDER BY bucket, temperature;
- bucket | temperature | device_id 
---------+-------------+-----------
+SELECT * FROM :CAGG_NAME_2TH_LEVEL;
+ bucket | temperature | device_id | name 
+--------+-------------+-----------+------
 (0 rows)
 
---SELECT * FROM :CAGG_NAME_3TH_LEVEL ORDER BY bucket;
+SELECT * FROM :CAGG_NAME_3TH_LEVEL;
+ bucket | temperature | device_id | name | location 
+--------+-------------+-----------+------+----------
+(0 rows)
+
 -- Turn CAGGs into Realtime
 ALTER MATERIALIZED VIEW :CAGG_NAME_1ST_LEVEL SET (timescaledb.materialized_only=false);
 ALTER MATERIALIZED VIEW :CAGG_NAME_2TH_LEVEL SET (timescaledb.materialized_only=false);
---ALTER MATERIALIZED VIEW :CAGG_NAME_3TH_LEVEL SET (timescaledb.materialized_only=false);
+ALTER MATERIALIZED VIEW :CAGG_NAME_3TH_LEVEL SET (timescaledb.materialized_only=false);
 -- Realtime data
-SELECT * FROM :CAGG_NAME_1ST_LEVEL ORDER BY bucket;
+SELECT * FROM :CAGG_NAME_1ST_LEVEL;
  bucket | temperature | device_id 
 --------+-------------+-----------
       1 |          10 |         1
@@ -184,15 +196,22 @@ SELECT * FROM :CAGG_NAME_1ST_LEVEL ORDER BY bucket;
       5 |          20 |         3
 (3 rows)
 
-SELECT * FROM :CAGG_NAME_2TH_LEVEL ORDER BY bucket, temperature;
- bucket | temperature | device_id 
---------+-------------+-----------
-      0 |           5 |         2
-      0 |          10 |         1
-      5 |          20 |         3
+SELECT * FROM :CAGG_NAME_2TH_LEVEL;
+ bucket | temperature | device_id |   name   
+--------+-------------+-----------+----------
+      0 |           5 |         2 | thermo_2
+      0 |          10 |         1 | thermo_1
+      5 |          20 |         3 | thermo_3
 (3 rows)
 
---SELECT * FROM :CAGG_NAME_3TH_LEVEL ORDER BY bucket;
+SELECT * FROM :CAGG_NAME_3TH_LEVEL;
+ bucket | temperature | device_id |   name   | location 
+--------+-------------+-----------+----------+----------
+      0 |           5 |         2 | thermo_2 | Berlin
+      0 |          10 |         1 | thermo_1 | Moscow
+      0 |          20 |         3 | thermo_3 | London
+(3 rows)
+
 -- Turn CAGGs into materialized only again
 ALTER MATERIALIZED VIEW :CAGG_NAME_1ST_LEVEL SET (timescaledb.materialized_only=true);
 ALTER MATERIALIZED VIEW :CAGG_NAME_2TH_LEVEL SET (timescaledb.materialized_only=true);
@@ -202,7 +221,7 @@ CALL refresh_continuous_aggregate(:'CAGG_NAME_1ST_LEVEL', NULL, NULL);
 CALL refresh_continuous_aggregate(:'CAGG_NAME_2TH_LEVEL', NULL, NULL);
 CALL refresh_continuous_aggregate(:'CAGG_NAME_3TH_LEVEL', NULL, NULL);
 -- Materialized data
-SELECT * FROM :CAGG_NAME_1ST_LEVEL ORDER BY bucket;
+SELECT * FROM :CAGG_NAME_1ST_LEVEL;
  bucket | temperature | device_id 
 --------+-------------+-----------
       1 |          10 |         1
@@ -210,20 +229,20 @@ SELECT * FROM :CAGG_NAME_1ST_LEVEL ORDER BY bucket;
       5 |          20 |         3
 (3 rows)
 
-SELECT * FROM :CAGG_NAME_2TH_LEVEL ORDER BY bucket, temperature;
- bucket | temperature | device_id 
---------+-------------+-----------
-      0 |           5 |         2
-      0 |          10 |         1
-      5 |          20 |         3
+SELECT * FROM :CAGG_NAME_2TH_LEVEL;
+ bucket | temperature | device_id |   name   
+--------+-------------+-----------+----------
+      0 |           5 |         2 | thermo_2
+      0 |          10 |         1 | thermo_1
+      5 |          20 |         3 | thermo_3
 (3 rows)
 
-SELECT * FROM :CAGG_NAME_3TH_LEVEL ORDER BY bucket;
- bucket | temperature | device_id 
---------+-------------+-----------
-      0 |          20 |         3
-      0 |           5 |         2
-      0 |          10 |         1
+SELECT * FROM :CAGG_NAME_3TH_LEVEL;
+ bucket | temperature | device_id |   name   | location 
+--------+-------------+-----------+----------+----------
+      0 |           5 |         2 | thermo_2 | Berlin
+      0 |          10 |         1 | thermo_1 | Moscow
+      0 |          20 |         3 | thermo_3 | London
 (3 rows)
 
 \if :IS_TIME_DIMENSION
@@ -238,7 +257,7 @@ INSERT INTO conditions ("time", temperature) VALUES (2,  2);
 INSERT INTO conditions ("time", temperature) VALUES (10, 2);
 \endif
 -- No changes
-SELECT * FROM :CAGG_NAME_1ST_LEVEL ORDER BY bucket;
+SELECT * FROM :CAGG_NAME_1ST_LEVEL;
  bucket | temperature | device_id 
 --------+-------------+-----------
       1 |          10 |         1
@@ -246,20 +265,20 @@ SELECT * FROM :CAGG_NAME_1ST_LEVEL ORDER BY bucket;
       5 |          20 |         3
 (3 rows)
 
-SELECT * FROM :CAGG_NAME_2TH_LEVEL ORDER BY bucket, temperature;
- bucket | temperature | device_id 
---------+-------------+-----------
-      0 |           5 |         2
-      0 |          10 |         1
-      5 |          20 |         3
+SELECT * FROM :CAGG_NAME_2TH_LEVEL;
+ bucket | temperature | device_id |   name   
+--------+-------------+-----------+----------
+      0 |           5 |         2 | thermo_2
+      0 |          10 |         1 | thermo_1
+      5 |          20 |         3 | thermo_3
 (3 rows)
 
-SELECT * FROM :CAGG_NAME_3TH_LEVEL ORDER BY bucket;
- bucket | temperature | device_id 
---------+-------------+-----------
-      0 |          20 |         3
-      0 |           5 |         2
-      0 |          10 |         1
+SELECT * FROM :CAGG_NAME_3TH_LEVEL;
+ bucket | temperature | device_id |   name   | location 
+--------+-------------+-----------+----------+----------
+      0 |           5 |         2 | thermo_2 | Berlin
+      0 |          10 |         1 | thermo_1 | Moscow
+      0 |          20 |         3 | thermo_3 | London
 (3 rows)
 
 -- Turn CAGGs into Realtime
@@ -267,7 +286,7 @@ ALTER MATERIALIZED VIEW :CAGG_NAME_1ST_LEVEL SET (timescaledb.materialized_only=
 ALTER MATERIALIZED VIEW :CAGG_NAME_2TH_LEVEL SET (timescaledb.materialized_only=false);
 ALTER MATERIALIZED VIEW :CAGG_NAME_3TH_LEVEL SET (timescaledb.materialized_only=false);
 -- Realtime changes, just new region
-SELECT * FROM :CAGG_NAME_1ST_LEVEL ORDER BY bucket;
+SELECT * FROM :CAGG_NAME_1ST_LEVEL;
  bucket | temperature | device_id 
 --------+-------------+-----------
       1 |          10 |         1
@@ -276,20 +295,20 @@ SELECT * FROM :CAGG_NAME_1ST_LEVEL ORDER BY bucket;
      10 |           2 |          
 (4 rows)
 
-SELECT * FROM :CAGG_NAME_2TH_LEVEL ORDER BY bucket, temperature;
- bucket | temperature | device_id 
---------+-------------+-----------
-      0 |           5 |         2
-      0 |          10 |         1
-      5 |          20 |         3
+SELECT * FROM :CAGG_NAME_2TH_LEVEL;
+ bucket | temperature | device_id |   name   
+--------+-------------+-----------+----------
+      0 |           5 |         2 | thermo_2
+      0 |          10 |         1 | thermo_1
+      5 |          20 |         3 | thermo_3
 (3 rows)
 
-SELECT * FROM :CAGG_NAME_3TH_LEVEL ORDER BY bucket;
- bucket | temperature | device_id 
---------+-------------+-----------
-      0 |          10 |         1
-      0 |           5 |         2
-      0 |          20 |         3
+SELECT * FROM :CAGG_NAME_3TH_LEVEL;
+ bucket | temperature | device_id |   name   | location 
+--------+-------------+-----------+----------+----------
+      0 |           5 |         2 | thermo_2 | Berlin
+      0 |          10 |         1 | thermo_1 | Moscow
+      0 |          20 |         3 | thermo_3 | London
 (3 rows)
 
 -- Turn CAGGs into materialized only again
@@ -301,7 +320,7 @@ CALL refresh_continuous_aggregate(:'CAGG_NAME_1ST_LEVEL', NULL, NULL);
 CALL refresh_continuous_aggregate(:'CAGG_NAME_2TH_LEVEL', NULL, NULL);
 CALL refresh_continuous_aggregate(:'CAGG_NAME_3TH_LEVEL', NULL, NULL);
 -- All changes are materialized
-SELECT * FROM :CAGG_NAME_1ST_LEVEL ORDER BY bucket;
+SELECT * FROM :CAGG_NAME_1ST_LEVEL;
  bucket | temperature | device_id 
 --------+-------------+-----------
       1 |          10 |         1
@@ -311,20 +330,20 @@ SELECT * FROM :CAGG_NAME_1ST_LEVEL ORDER BY bucket;
      10 |           2 |          
 (5 rows)
 
-SELECT * FROM :CAGG_NAME_2TH_LEVEL ORDER BY bucket, temperature;
- bucket | temperature | device_id 
---------+-------------+-----------
-      0 |           5 |         2
-      0 |          10 |         1
-      5 |          20 |         3
+SELECT * FROM :CAGG_NAME_2TH_LEVEL;
+ bucket | temperature | device_id |   name   
+--------+-------------+-----------+----------
+      0 |           5 |         2 | thermo_2
+      0 |          10 |         1 | thermo_1
+      5 |          20 |         3 | thermo_3
 (3 rows)
 
-SELECT * FROM :CAGG_NAME_3TH_LEVEL ORDER BY bucket;
- bucket | temperature | device_id 
---------+-------------+-----------
-      0 |          20 |         3
-      0 |           5 |         2
-      0 |          10 |         1
+SELECT * FROM :CAGG_NAME_3TH_LEVEL;
+ bucket | temperature | device_id |   name   | location 
+--------+-------------+-----------+----------+----------
+      0 |           5 |         2 | thermo_2 | Berlin
+      0 |          10 |         1 | thermo_1 | Moscow
+      0 |          20 |         3 | thermo_3 | London
 (3 rows)
 
 -- TRUNCATE tests
@@ -332,102 +351,102 @@ TRUNCATE :CAGG_NAME_2TH_LEVEL;
 -- This full refresh will remove all the data from the 3TH level cagg
 CALL refresh_continuous_aggregate(:'CAGG_NAME_3TH_LEVEL', NULL, NULL);
 -- Should return no rows
-SELECT * FROM :CAGG_NAME_2TH_LEVEL ORDER BY bucket;
- bucket | temperature | device_id 
---------+-------------+-----------
+SELECT * FROM :CAGG_NAME_2TH_LEVEL;
+ bucket | temperature | device_id | name 
+--------+-------------+-----------+------
 (0 rows)
 
-SELECT * FROM :CAGG_NAME_3TH_LEVEL ORDER BY bucket;
- bucket | temperature | device_id 
---------+-------------+-----------
+SELECT * FROM :CAGG_NAME_3TH_LEVEL;
+ bucket | temperature | device_id | name | location 
+--------+-------------+-----------+------+----------
 (0 rows)
 
 -- If we have all the data in the bottom levels caggs we can rebuild
 CALL refresh_continuous_aggregate(:'CAGG_NAME_2TH_LEVEL', NULL, NULL);
 CALL refresh_continuous_aggregate(:'CAGG_NAME_3TH_LEVEL', NULL, NULL);
 -- Now we have all the data
-SELECT * FROM :CAGG_NAME_2TH_LEVEL ORDER BY bucket, temperature;
- bucket | temperature | device_id 
---------+-------------+-----------
-      0 |           5 |         2
-      0 |          10 |         1
-      5 |          20 |         3
+SELECT * FROM :CAGG_NAME_2TH_LEVEL;
+ bucket | temperature | device_id |   name   
+--------+-------------+-----------+----------
+      0 |           5 |         2 | thermo_2
+      0 |          10 |         1 | thermo_1
+      5 |          20 |         3 | thermo_3
 (3 rows)
 
-SELECT * FROM :CAGG_NAME_3TH_LEVEL ORDER BY bucket;
- bucket | temperature | device_id 
---------+-------------+-----------
-      0 |          20 |         3
-      0 |           5 |         2
-      0 |          10 |         1
+SELECT * FROM :CAGG_NAME_3TH_LEVEL;
+ bucket | temperature | device_id |   name   | location 
+--------+-------------+-----------+----------+----------
+      0 |           5 |         2 | thermo_2 | Berlin
+      0 |          10 |         1 | thermo_1 | Moscow
+      0 |          20 |         3 | thermo_3 | London
 (3 rows)
 
 -- DROP tests
 \set ON_ERROR_STOP 0
 -- should error because it depends of other CAGGs
 DROP MATERIALIZED VIEW :CAGG_NAME_1ST_LEVEL;
-psql:include/cagg_on_cagg_common.sql:166: ERROR:  cannot drop view conditions_summary_1_1 because other objects depend on it
+psql:include/cagg_on_cagg_common.sql:172: ERROR:  cannot drop view conditions_summary_1_1 because other objects depend on it
 DROP MATERIALIZED VIEW :CAGG_NAME_2TH_LEVEL;
-psql:include/cagg_on_cagg_common.sql:167: ERROR:  cannot drop view conditions_summary_2_5 because other objects depend on it
+psql:include/cagg_on_cagg_common.sql:173: ERROR:  cannot drop view conditions_summary_2_5 because other objects depend on it
 CALL refresh_continuous_aggregate(:'CAGG_NAME_1ST_LEVEL', NULL, NULL);
-psql:include/cagg_on_cagg_common.sql:168: NOTICE:  continuous aggregate "conditions_summary_1_1" is already up-to-date
+psql:include/cagg_on_cagg_common.sql:174: NOTICE:  continuous aggregate "conditions_summary_1_1" is already up-to-date
 CALL refresh_continuous_aggregate(:'CAGG_NAME_2TH_LEVEL', NULL, NULL);
-psql:include/cagg_on_cagg_common.sql:169: NOTICE:  continuous aggregate "conditions_summary_2_5" is already up-to-date
+psql:include/cagg_on_cagg_common.sql:175: NOTICE:  continuous aggregate "conditions_summary_2_5" is already up-to-date
 \set ON_ERROR_STOP 1
 -- DROP the 3TH level CAGG don't affect others
 DROP MATERIALIZED VIEW :CAGG_NAME_3TH_LEVEL;
-psql:include/cagg_on_cagg_common.sql:173: NOTICE:  drop cascades to table _timescaledb_internal._hyper_4_4_chunk
+psql:include/cagg_on_cagg_common.sql:179: NOTICE:  drop cascades to table _timescaledb_internal._hyper_4_4_chunk
 \set ON_ERROR_STOP 0
 -- should error because it was dropped
-SELECT * FROM :CAGG_NAME_3TH_LEVEL ORDER BY bucket, device_id;
-psql:include/cagg_on_cagg_common.sql:176: ERROR:  relation "conditions_summary_3_10" does not exist at character 15
+SELECT * FROM :CAGG_NAME_3TH_LEVEL;
+psql:include/cagg_on_cagg_common.sql:182: ERROR:  relation "conditions_summary_3_10" does not exist at character 15
 \set ON_ERROR_STOP 1
 -- should work because dropping the top level CAGG
 -- don't affect the down level CAGGs
 TRUNCATE :CAGG_NAME_2TH_LEVEL,:CAGG_NAME_1ST_LEVEL;
 CALL refresh_continuous_aggregate(:'CAGG_NAME_2TH_LEVEL', NULL, NULL);
 CALL refresh_continuous_aggregate(:'CAGG_NAME_1ST_LEVEL', NULL, NULL);
-SELECT * FROM :CAGG_NAME_1ST_LEVEL ORDER BY bucket, device_id;
+SELECT * FROM :CAGG_NAME_1ST_LEVEL;
  bucket | temperature | device_id 
 --------+-------------+-----------
       1 |          10 |         1
-      2 |           5 |         2
       2 |           2 |          
+      2 |           5 |         2
       5 |          20 |         3
      10 |           2 |          
 (5 rows)
 
-SELECT * FROM :CAGG_NAME_2TH_LEVEL ORDER BY bucket, temperature;
- bucket | temperature | device_id 
---------+-------------+-----------
+SELECT * FROM :CAGG_NAME_2TH_LEVEL;
+ bucket | temperature | device_id | name 
+--------+-------------+-----------+------
 (0 rows)
 
 -- DROP the 2TH level CAGG don't affect others
 DROP MATERIALIZED VIEW :CAGG_NAME_2TH_LEVEL;
 \set ON_ERROR_STOP 0
 -- should error because it was dropped
-SELECT * FROM :CAGG_NAME_2TH_LEVEL ORDER BY bucket, temperature;
-psql:include/cagg_on_cagg_common.sql:190: ERROR:  relation "conditions_summary_2_5" does not exist at character 15
+SELECT * FROM :CAGG_NAME_2TH_LEVEL;
+psql:include/cagg_on_cagg_common.sql:196: ERROR:  relation "conditions_summary_2_5" does not exist at character 15
 \set ON_ERROR_STOP 1
 -- should work because dropping the top level CAGG
 -- don't affect the down level CAGGs
-SELECT * FROM :CAGG_NAME_1ST_LEVEL ORDER BY bucket, device_id;
+SELECT * FROM :CAGG_NAME_1ST_LEVEL;
  bucket | temperature | device_id 
 --------+-------------+-----------
       1 |          10 |         1
-      2 |           5 |         2
       2 |           2 |          
+      2 |           5 |         2
       5 |          20 |         3
      10 |           2 |          
 (5 rows)
 
 -- DROP the first CAGG should work
 DROP MATERIALIZED VIEW :CAGG_NAME_1ST_LEVEL;
-psql:include/cagg_on_cagg_common.sql:197: NOTICE:  drop cascades to table _timescaledb_internal._hyper_2_7_chunk
+psql:include/cagg_on_cagg_common.sql:203: NOTICE:  drop cascades to table _timescaledb_internal._hyper_2_7_chunk
 \set ON_ERROR_STOP 0
 -- should error because it was dropped
-SELECT * FROM :CAGG_NAME_1ST_LEVEL ORDER BY bucket, device_id;
-psql:include/cagg_on_cagg_common.sql:200: ERROR:  relation "conditions_summary_1_1" does not exist at character 15
+SELECT * FROM :CAGG_NAME_1ST_LEVEL;
+psql:include/cagg_on_cagg_common.sql:206: ERROR:  relation "conditions_summary_1_1" does not exist at character 15
 \set ON_ERROR_STOP 1
 -- Default tests
 \set ON_ERROR_STOP 0
@@ -500,7 +519,8 @@ SELECT
   SUM(temperature) AS temperature,
   device_id
 FROM conditions
-GROUP BY 1,3
+GROUP BY 1, 3
+ORDER BY 1, 2, 3
 WITH NO DATA;
 -- CAGG on CAGG (2th level)
 CREATE MATERIALIZED VIEW :CAGG_NAME_2TH_LEVEL
@@ -509,31 +529,38 @@ SELECT
   time_bucket(:BUCKET_WIDTH_2TH, "bucket") AS bucket,
   SUM(temperature) AS temperature
 \if :IS_JOIN
-  , :CAGG_NAME_1ST_LEVEL.device_id
-  FROM :CAGG_NAME_1ST_LEVEL, devices
-  WHERE devices.device_id = :CAGG_NAME_1ST_LEVEL.device_id
-  GROUP BY 1,3
+  , devices.device_id
+  , devices.name
+  FROM :CAGG_NAME_1ST_LEVEL
+  JOIN devices ON devices.device_id = :CAGG_NAME_1ST_LEVEL.device_id
+  GROUP BY 1, 3, 4
+  ORDER BY 1, 2, 3, 4
 \else
   FROM :CAGG_NAME_1ST_LEVEL
   GROUP BY 1
+  ORDER BY 1, 2
 \endif
 WITH NO DATA;
 -- CAGG on CAGG (3th level)
 CREATE MATERIALIZED VIEW :CAGG_NAME_3TH_LEVEL
-  WITH (timescaledb.continuous, timescaledb.materialized_only=true) AS
-  SELECT
-    time_bucket(:BUCKET_WIDTH_3TH, "bucket") AS bucket,
-    SUM(temperature) AS temperature
-  \if :IS_JOIN
-    , :CAGG_NAME_2TH_LEVEL.device_id
-    FROM :CAGG_NAME_2TH_LEVEL, devices
-    WHERE devices.device_id = :CAGG_NAME_2TH_LEVEL.device_id
-    GROUP BY 1,3
-  \else
-    FROM :CAGG_NAME_2TH_LEVEL
-    GROUP BY 1
-  \endif
-  WITH NO DATA;
+WITH (timescaledb.continuous, timescaledb.materialized_only=true) AS
+SELECT
+  time_bucket(:BUCKET_WIDTH_3TH, "bucket") AS bucket,
+  SUM(temperature) AS temperature
+\if :IS_JOIN
+  , :CAGG_NAME_2TH_LEVEL.device_id
+  , :CAGG_NAME_2TH_LEVEL.name
+  , devices.location
+  FROM :CAGG_NAME_2TH_LEVEL
+  JOIN devices ON devices.device_id = :CAGG_NAME_2TH_LEVEL.device_id
+  GROUP BY 1, 3, 4, 5
+  ORDER BY 1, 2, 3, 4, 5
+\else
+  FROM :CAGG_NAME_2TH_LEVEL
+  GROUP BY 1
+  ORDER BY 1, 2
+\endif
+WITH NO DATA;
 -- Check chunk_interval
 \if :IS_TIME_DIMENSION
   SELECT h.table_name AS name, _timescaledb_functions.to_interval(d.interval_length) AS chunk_interval
@@ -567,23 +594,27 @@ CREATE MATERIALIZED VIEW :CAGG_NAME_3TH_LEVEL
 
 \endif
 -- No data because the CAGGs are just for materialized data
-SELECT * FROM :CAGG_NAME_1ST_LEVEL ORDER BY bucket;
+SELECT * FROM :CAGG_NAME_1ST_LEVEL;
  bucket | temperature | device_id 
 --------+-------------+-----------
 (0 rows)
 
-SELECT * FROM :CAGG_NAME_2TH_LEVEL ORDER BY bucket, temperature;
- bucket | temperature | device_id 
---------+-------------+-----------
+SELECT * FROM :CAGG_NAME_2TH_LEVEL;
+ bucket | temperature | device_id | name 
+--------+-------------+-----------+------
 (0 rows)
 
---SELECT * FROM :CAGG_NAME_3TH_LEVEL ORDER BY bucket;
+SELECT * FROM :CAGG_NAME_3TH_LEVEL;
+ bucket | temperature | device_id | name | location 
+--------+-------------+-----------+------+----------
+(0 rows)
+
 -- Turn CAGGs into Realtime
 ALTER MATERIALIZED VIEW :CAGG_NAME_1ST_LEVEL SET (timescaledb.materialized_only=false);
 ALTER MATERIALIZED VIEW :CAGG_NAME_2TH_LEVEL SET (timescaledb.materialized_only=false);
---ALTER MATERIALIZED VIEW :CAGG_NAME_3TH_LEVEL SET (timescaledb.materialized_only=false);
+ALTER MATERIALIZED VIEW :CAGG_NAME_3TH_LEVEL SET (timescaledb.materialized_only=false);
 -- Realtime data
-SELECT * FROM :CAGG_NAME_1ST_LEVEL ORDER BY bucket;
+SELECT * FROM :CAGG_NAME_1ST_LEVEL;
  bucket | temperature | device_id 
 --------+-------------+-----------
       1 |          10 |         1
@@ -591,15 +622,22 @@ SELECT * FROM :CAGG_NAME_1ST_LEVEL ORDER BY bucket;
       5 |          20 |         3
 (3 rows)
 
-SELECT * FROM :CAGG_NAME_2TH_LEVEL ORDER BY bucket, temperature;
- bucket | temperature | device_id 
---------+-------------+-----------
-      0 |           5 |         2
-      0 |          10 |         1
-      5 |          20 |         3
+SELECT * FROM :CAGG_NAME_2TH_LEVEL;
+ bucket | temperature | device_id |   name   
+--------+-------------+-----------+----------
+      0 |           5 |         2 | thermo_2
+      0 |          10 |         1 | thermo_1
+      5 |          20 |         3 | thermo_3
 (3 rows)
 
---SELECT * FROM :CAGG_NAME_3TH_LEVEL ORDER BY bucket;
+SELECT * FROM :CAGG_NAME_3TH_LEVEL;
+ bucket | temperature | device_id |   name   | location 
+--------+-------------+-----------+----------+----------
+      0 |           5 |         2 | thermo_2 | Berlin
+      0 |          10 |         1 | thermo_1 | Moscow
+      0 |          20 |         3 | thermo_3 | London
+(3 rows)
+
 -- Turn CAGGs into materialized only again
 ALTER MATERIALIZED VIEW :CAGG_NAME_1ST_LEVEL SET (timescaledb.materialized_only=true);
 ALTER MATERIALIZED VIEW :CAGG_NAME_2TH_LEVEL SET (timescaledb.materialized_only=true);
@@ -609,7 +647,7 @@ CALL refresh_continuous_aggregate(:'CAGG_NAME_1ST_LEVEL', NULL, NULL);
 CALL refresh_continuous_aggregate(:'CAGG_NAME_2TH_LEVEL', NULL, NULL);
 CALL refresh_continuous_aggregate(:'CAGG_NAME_3TH_LEVEL', NULL, NULL);
 -- Materialized data
-SELECT * FROM :CAGG_NAME_1ST_LEVEL ORDER BY bucket;
+SELECT * FROM :CAGG_NAME_1ST_LEVEL;
  bucket | temperature | device_id 
 --------+-------------+-----------
       1 |          10 |         1
@@ -617,20 +655,20 @@ SELECT * FROM :CAGG_NAME_1ST_LEVEL ORDER BY bucket;
       5 |          20 |         3
 (3 rows)
 
-SELECT * FROM :CAGG_NAME_2TH_LEVEL ORDER BY bucket, temperature;
- bucket | temperature | device_id 
---------+-------------+-----------
-      0 |           5 |         2
-      0 |          10 |         1
-      5 |          20 |         3
+SELECT * FROM :CAGG_NAME_2TH_LEVEL;
+ bucket | temperature | device_id |   name   
+--------+-------------+-----------+----------
+      0 |           5 |         2 | thermo_2
+      0 |          10 |         1 | thermo_1
+      5 |          20 |         3 | thermo_3
 (3 rows)
 
-SELECT * FROM :CAGG_NAME_3TH_LEVEL ORDER BY bucket;
- bucket | temperature | device_id 
---------+-------------+-----------
-      0 |          20 |         3
-      0 |           5 |         2
-      0 |          10 |         1
+SELECT * FROM :CAGG_NAME_3TH_LEVEL;
+ bucket | temperature | device_id |   name   | location 
+--------+-------------+-----------+----------+----------
+      0 |           5 |         2 | thermo_2 | Berlin
+      0 |          10 |         1 | thermo_1 | Moscow
+      0 |          20 |         3 | thermo_3 | London
 (3 rows)
 
 \if :IS_TIME_DIMENSION
@@ -645,7 +683,7 @@ INSERT INTO conditions ("time", temperature) VALUES (2,  2);
 INSERT INTO conditions ("time", temperature) VALUES (10, 2);
 \endif
 -- No changes
-SELECT * FROM :CAGG_NAME_1ST_LEVEL ORDER BY bucket;
+SELECT * FROM :CAGG_NAME_1ST_LEVEL;
  bucket | temperature | device_id 
 --------+-------------+-----------
       1 |          10 |         1
@@ -653,20 +691,20 @@ SELECT * FROM :CAGG_NAME_1ST_LEVEL ORDER BY bucket;
       5 |          20 |         3
 (3 rows)
 
-SELECT * FROM :CAGG_NAME_2TH_LEVEL ORDER BY bucket, temperature;
- bucket | temperature | device_id 
---------+-------------+-----------
-      0 |           5 |         2
-      0 |          10 |         1
-      5 |          20 |         3
+SELECT * FROM :CAGG_NAME_2TH_LEVEL;
+ bucket | temperature | device_id |   name   
+--------+-------------+-----------+----------
+      0 |           5 |         2 | thermo_2
+      0 |          10 |         1 | thermo_1
+      5 |          20 |         3 | thermo_3
 (3 rows)
 
-SELECT * FROM :CAGG_NAME_3TH_LEVEL ORDER BY bucket;
- bucket | temperature | device_id 
---------+-------------+-----------
-      0 |          20 |         3
-      0 |           5 |         2
-      0 |          10 |         1
+SELECT * FROM :CAGG_NAME_3TH_LEVEL;
+ bucket | temperature | device_id |   name   | location 
+--------+-------------+-----------+----------+----------
+      0 |           5 |         2 | thermo_2 | Berlin
+      0 |          10 |         1 | thermo_1 | Moscow
+      0 |          20 |         3 | thermo_3 | London
 (3 rows)
 
 -- Turn CAGGs into Realtime
@@ -674,7 +712,7 @@ ALTER MATERIALIZED VIEW :CAGG_NAME_1ST_LEVEL SET (timescaledb.materialized_only=
 ALTER MATERIALIZED VIEW :CAGG_NAME_2TH_LEVEL SET (timescaledb.materialized_only=false);
 ALTER MATERIALIZED VIEW :CAGG_NAME_3TH_LEVEL SET (timescaledb.materialized_only=false);
 -- Realtime changes, just new region
-SELECT * FROM :CAGG_NAME_1ST_LEVEL ORDER BY bucket;
+SELECT * FROM :CAGG_NAME_1ST_LEVEL;
  bucket | temperature | device_id 
 --------+-------------+-----------
       1 |          10 |         1
@@ -683,20 +721,20 @@ SELECT * FROM :CAGG_NAME_1ST_LEVEL ORDER BY bucket;
      10 |           2 |          
 (4 rows)
 
-SELECT * FROM :CAGG_NAME_2TH_LEVEL ORDER BY bucket, temperature;
- bucket | temperature | device_id 
---------+-------------+-----------
-      0 |           5 |         2
-      0 |          10 |         1
-      5 |          20 |         3
+SELECT * FROM :CAGG_NAME_2TH_LEVEL;
+ bucket | temperature | device_id |   name   
+--------+-------------+-----------+----------
+      0 |           5 |         2 | thermo_2
+      0 |          10 |         1 | thermo_1
+      5 |          20 |         3 | thermo_3
 (3 rows)
 
-SELECT * FROM :CAGG_NAME_3TH_LEVEL ORDER BY bucket;
- bucket | temperature | device_id 
---------+-------------+-----------
-      0 |          10 |         1
-      0 |           5 |         2
-      0 |          20 |         3
+SELECT * FROM :CAGG_NAME_3TH_LEVEL;
+ bucket | temperature | device_id |   name   | location 
+--------+-------------+-----------+----------+----------
+      0 |           5 |         2 | thermo_2 | Berlin
+      0 |          10 |         1 | thermo_1 | Moscow
+      0 |          20 |         3 | thermo_3 | London
 (3 rows)
 
 -- Turn CAGGs into materialized only again
@@ -708,7 +746,7 @@ CALL refresh_continuous_aggregate(:'CAGG_NAME_1ST_LEVEL', NULL, NULL);
 CALL refresh_continuous_aggregate(:'CAGG_NAME_2TH_LEVEL', NULL, NULL);
 CALL refresh_continuous_aggregate(:'CAGG_NAME_3TH_LEVEL', NULL, NULL);
 -- All changes are materialized
-SELECT * FROM :CAGG_NAME_1ST_LEVEL ORDER BY bucket;
+SELECT * FROM :CAGG_NAME_1ST_LEVEL;
  bucket | temperature | device_id 
 --------+-------------+-----------
       1 |          10 |         1
@@ -718,20 +756,20 @@ SELECT * FROM :CAGG_NAME_1ST_LEVEL ORDER BY bucket;
      10 |           2 |          
 (5 rows)
 
-SELECT * FROM :CAGG_NAME_2TH_LEVEL ORDER BY bucket, temperature;
- bucket | temperature | device_id 
---------+-------------+-----------
-      0 |           5 |         2
-      0 |          10 |         1
-      5 |          20 |         3
+SELECT * FROM :CAGG_NAME_2TH_LEVEL;
+ bucket | temperature | device_id |   name   
+--------+-------------+-----------+----------
+      0 |           5 |         2 | thermo_2
+      0 |          10 |         1 | thermo_1
+      5 |          20 |         3 | thermo_3
 (3 rows)
 
-SELECT * FROM :CAGG_NAME_3TH_LEVEL ORDER BY bucket;
- bucket | temperature | device_id 
---------+-------------+-----------
-      0 |          20 |         3
-      0 |           5 |         2
-      0 |          10 |         1
+SELECT * FROM :CAGG_NAME_3TH_LEVEL;
+ bucket | temperature | device_id |   name   | location 
+--------+-------------+-----------+----------+----------
+      0 |           5 |         2 | thermo_2 | Berlin
+      0 |          10 |         1 | thermo_1 | Moscow
+      0 |          20 |         3 | thermo_3 | London
 (3 rows)
 
 -- TRUNCATE tests
@@ -739,102 +777,102 @@ TRUNCATE :CAGG_NAME_2TH_LEVEL;
 -- This full refresh will remove all the data from the 3TH level cagg
 CALL refresh_continuous_aggregate(:'CAGG_NAME_3TH_LEVEL', NULL, NULL);
 -- Should return no rows
-SELECT * FROM :CAGG_NAME_2TH_LEVEL ORDER BY bucket;
- bucket | temperature | device_id 
---------+-------------+-----------
+SELECT * FROM :CAGG_NAME_2TH_LEVEL;
+ bucket | temperature | device_id | name 
+--------+-------------+-----------+------
 (0 rows)
 
-SELECT * FROM :CAGG_NAME_3TH_LEVEL ORDER BY bucket;
- bucket | temperature | device_id 
---------+-------------+-----------
+SELECT * FROM :CAGG_NAME_3TH_LEVEL;
+ bucket | temperature | device_id | name | location 
+--------+-------------+-----------+------+----------
 (0 rows)
 
 -- If we have all the data in the bottom levels caggs we can rebuild
 CALL refresh_continuous_aggregate(:'CAGG_NAME_2TH_LEVEL', NULL, NULL);
 CALL refresh_continuous_aggregate(:'CAGG_NAME_3TH_LEVEL', NULL, NULL);
 -- Now we have all the data
-SELECT * FROM :CAGG_NAME_2TH_LEVEL ORDER BY bucket, temperature;
- bucket | temperature | device_id 
---------+-------------+-----------
-      0 |           5 |         2
-      0 |          10 |         1
-      5 |          20 |         3
+SELECT * FROM :CAGG_NAME_2TH_LEVEL;
+ bucket | temperature | device_id |   name   
+--------+-------------+-----------+----------
+      0 |           5 |         2 | thermo_2
+      0 |          10 |         1 | thermo_1
+      5 |          20 |         3 | thermo_3
 (3 rows)
 
-SELECT * FROM :CAGG_NAME_3TH_LEVEL ORDER BY bucket;
- bucket | temperature | device_id 
---------+-------------+-----------
-      0 |          20 |         3
-      0 |           5 |         2
-      0 |          10 |         1
+SELECT * FROM :CAGG_NAME_3TH_LEVEL;
+ bucket | temperature | device_id |   name   | location 
+--------+-------------+-----------+----------+----------
+      0 |           5 |         2 | thermo_2 | Berlin
+      0 |          10 |         1 | thermo_1 | Moscow
+      0 |          20 |         3 | thermo_3 | London
 (3 rows)
 
 -- DROP tests
 \set ON_ERROR_STOP 0
 -- should error because it depends of other CAGGs
 DROP MATERIALIZED VIEW :CAGG_NAME_1ST_LEVEL;
-psql:include/cagg_on_cagg_common.sql:166: ERROR:  cannot drop view conditions_summary_1_1 because other objects depend on it
+psql:include/cagg_on_cagg_common.sql:172: ERROR:  cannot drop view conditions_summary_1_1 because other objects depend on it
 DROP MATERIALIZED VIEW :CAGG_NAME_2TH_LEVEL;
-psql:include/cagg_on_cagg_common.sql:167: ERROR:  cannot drop view conditions_summary_2_5 because other objects depend on it
+psql:include/cagg_on_cagg_common.sql:173: ERROR:  cannot drop view conditions_summary_2_5 because other objects depend on it
 CALL refresh_continuous_aggregate(:'CAGG_NAME_1ST_LEVEL', NULL, NULL);
-psql:include/cagg_on_cagg_common.sql:168: NOTICE:  continuous aggregate "conditions_summary_1_1" is already up-to-date
+psql:include/cagg_on_cagg_common.sql:174: NOTICE:  continuous aggregate "conditions_summary_1_1" is already up-to-date
 CALL refresh_continuous_aggregate(:'CAGG_NAME_2TH_LEVEL', NULL, NULL);
-psql:include/cagg_on_cagg_common.sql:169: NOTICE:  continuous aggregate "conditions_summary_2_5" is already up-to-date
+psql:include/cagg_on_cagg_common.sql:175: NOTICE:  continuous aggregate "conditions_summary_2_5" is already up-to-date
 \set ON_ERROR_STOP 1
 -- DROP the 3TH level CAGG don't affect others
 DROP MATERIALIZED VIEW :CAGG_NAME_3TH_LEVEL;
-psql:include/cagg_on_cagg_common.sql:173: NOTICE:  drop cascades to table _timescaledb_internal._hyper_8_11_chunk
+psql:include/cagg_on_cagg_common.sql:179: NOTICE:  drop cascades to table _timescaledb_internal._hyper_8_11_chunk
 \set ON_ERROR_STOP 0
 -- should error because it was dropped
-SELECT * FROM :CAGG_NAME_3TH_LEVEL ORDER BY bucket, device_id;
-psql:include/cagg_on_cagg_common.sql:176: ERROR:  relation "conditions_summary_3_10" does not exist at character 15
+SELECT * FROM :CAGG_NAME_3TH_LEVEL;
+psql:include/cagg_on_cagg_common.sql:182: ERROR:  relation "conditions_summary_3_10" does not exist at character 15
 \set ON_ERROR_STOP 1
 -- should work because dropping the top level CAGG
 -- don't affect the down level CAGGs
 TRUNCATE :CAGG_NAME_2TH_LEVEL,:CAGG_NAME_1ST_LEVEL;
 CALL refresh_continuous_aggregate(:'CAGG_NAME_2TH_LEVEL', NULL, NULL);
 CALL refresh_continuous_aggregate(:'CAGG_NAME_1ST_LEVEL', NULL, NULL);
-SELECT * FROM :CAGG_NAME_1ST_LEVEL ORDER BY bucket, device_id;
+SELECT * FROM :CAGG_NAME_1ST_LEVEL;
  bucket | temperature | device_id 
 --------+-------------+-----------
       1 |          10 |         1
-      2 |           5 |         2
       2 |           2 |          
+      2 |           5 |         2
       5 |          20 |         3
      10 |           2 |          
 (5 rows)
 
-SELECT * FROM :CAGG_NAME_2TH_LEVEL ORDER BY bucket, temperature;
- bucket | temperature | device_id 
---------+-------------+-----------
+SELECT * FROM :CAGG_NAME_2TH_LEVEL;
+ bucket | temperature | device_id | name 
+--------+-------------+-----------+------
 (0 rows)
 
 -- DROP the 2TH level CAGG don't affect others
 DROP MATERIALIZED VIEW :CAGG_NAME_2TH_LEVEL;
 \set ON_ERROR_STOP 0
 -- should error because it was dropped
-SELECT * FROM :CAGG_NAME_2TH_LEVEL ORDER BY bucket, temperature;
-psql:include/cagg_on_cagg_common.sql:190: ERROR:  relation "conditions_summary_2_5" does not exist at character 15
+SELECT * FROM :CAGG_NAME_2TH_LEVEL;
+psql:include/cagg_on_cagg_common.sql:196: ERROR:  relation "conditions_summary_2_5" does not exist at character 15
 \set ON_ERROR_STOP 1
 -- should work because dropping the top level CAGG
 -- don't affect the down level CAGGs
-SELECT * FROM :CAGG_NAME_1ST_LEVEL ORDER BY bucket, device_id;
+SELECT * FROM :CAGG_NAME_1ST_LEVEL;
  bucket | temperature | device_id 
 --------+-------------+-----------
       1 |          10 |         1
-      2 |           5 |         2
       2 |           2 |          
+      2 |           5 |         2
       5 |          20 |         3
      10 |           2 |          
 (5 rows)
 
 -- DROP the first CAGG should work
 DROP MATERIALIZED VIEW :CAGG_NAME_1ST_LEVEL;
-psql:include/cagg_on_cagg_common.sql:197: NOTICE:  drop cascades to table _timescaledb_internal._hyper_6_14_chunk
+psql:include/cagg_on_cagg_common.sql:203: NOTICE:  drop cascades to table _timescaledb_internal._hyper_6_14_chunk
 \set ON_ERROR_STOP 0
 -- should error because it was dropped
-SELECT * FROM :CAGG_NAME_1ST_LEVEL ORDER BY bucket, device_id;
-psql:include/cagg_on_cagg_common.sql:200: ERROR:  relation "conditions_summary_1_1" does not exist at character 15
+SELECT * FROM :CAGG_NAME_1ST_LEVEL;
+psql:include/cagg_on_cagg_common.sql:206: ERROR:  relation "conditions_summary_1_1" does not exist at character 15
 \set ON_ERROR_STOP 1
 --
 -- Validation test for non-multiple bucket sizes
@@ -1236,7 +1274,8 @@ SELECT
   SUM(temperature) AS temperature,
   device_id
 FROM conditions
-GROUP BY 1,3
+GROUP BY 1, 3
+ORDER BY 1, 2, 3
 WITH NO DATA;
 -- CAGG on CAGG (2th level)
 CREATE MATERIALIZED VIEW :CAGG_NAME_2TH_LEVEL
@@ -1245,31 +1284,38 @@ SELECT
   time_bucket(:BUCKET_WIDTH_2TH, "bucket") AS bucket,
   SUM(temperature) AS temperature
 \if :IS_JOIN
-  , :CAGG_NAME_1ST_LEVEL.device_id
-  FROM :CAGG_NAME_1ST_LEVEL, devices
-  WHERE devices.device_id = :CAGG_NAME_1ST_LEVEL.device_id
-  GROUP BY 1,3
+  , devices.device_id
+  , devices.name
+  FROM :CAGG_NAME_1ST_LEVEL
+  JOIN devices ON devices.device_id = :CAGG_NAME_1ST_LEVEL.device_id
+  GROUP BY 1, 3, 4
+  ORDER BY 1, 2, 3, 4
 \else
   FROM :CAGG_NAME_1ST_LEVEL
   GROUP BY 1
+  ORDER BY 1, 2
 \endif
 WITH NO DATA;
 -- CAGG on CAGG (3th level)
 CREATE MATERIALIZED VIEW :CAGG_NAME_3TH_LEVEL
-  WITH (timescaledb.continuous, timescaledb.materialized_only=true) AS
-  SELECT
-    time_bucket(:BUCKET_WIDTH_3TH, "bucket") AS bucket,
-    SUM(temperature) AS temperature
-  \if :IS_JOIN
-    , :CAGG_NAME_2TH_LEVEL.device_id
-    FROM :CAGG_NAME_2TH_LEVEL, devices
-    WHERE devices.device_id = :CAGG_NAME_2TH_LEVEL.device_id
-    GROUP BY 1,3
-  \else
-    FROM :CAGG_NAME_2TH_LEVEL
-    GROUP BY 1
-  \endif
-  WITH NO DATA;
+WITH (timescaledb.continuous, timescaledb.materialized_only=true) AS
+SELECT
+  time_bucket(:BUCKET_WIDTH_3TH, "bucket") AS bucket,
+  SUM(temperature) AS temperature
+\if :IS_JOIN
+  , :CAGG_NAME_2TH_LEVEL.device_id
+  , :CAGG_NAME_2TH_LEVEL.name
+  , devices.location
+  FROM :CAGG_NAME_2TH_LEVEL
+  JOIN devices ON devices.device_id = :CAGG_NAME_2TH_LEVEL.device_id
+  GROUP BY 1, 3, 4, 5
+  ORDER BY 1, 2, 3, 4, 5
+\else
+  FROM :CAGG_NAME_2TH_LEVEL
+  GROUP BY 1
+  ORDER BY 1, 2
+\endif
+WITH NO DATA;
 -- Check chunk_interval
 \if :IS_TIME_DIMENSION
   SELECT h.table_name AS name, _timescaledb_functions.to_interval(d.interval_length) AS chunk_interval
@@ -1303,23 +1349,27 @@ CREATE MATERIALIZED VIEW :CAGG_NAME_3TH_LEVEL
   ORDER BY 1, 2;
 \endif
 -- No data because the CAGGs are just for materialized data
-SELECT * FROM :CAGG_NAME_1ST_LEVEL ORDER BY bucket;
+SELECT * FROM :CAGG_NAME_1ST_LEVEL;
  bucket | temperature | device_id 
 --------+-------------+-----------
 (0 rows)
 
-SELECT * FROM :CAGG_NAME_2TH_LEVEL ORDER BY bucket, temperature;
- bucket | temperature | device_id 
---------+-------------+-----------
+SELECT * FROM :CAGG_NAME_2TH_LEVEL;
+ bucket | temperature | device_id | name 
+--------+-------------+-----------+------
 (0 rows)
 
---SELECT * FROM :CAGG_NAME_3TH_LEVEL ORDER BY bucket;
+SELECT * FROM :CAGG_NAME_3TH_LEVEL;
+ bucket | temperature | device_id | name | location 
+--------+-------------+-----------+------+----------
+(0 rows)
+
 -- Turn CAGGs into Realtime
 ALTER MATERIALIZED VIEW :CAGG_NAME_1ST_LEVEL SET (timescaledb.materialized_only=false);
 ALTER MATERIALIZED VIEW :CAGG_NAME_2TH_LEVEL SET (timescaledb.materialized_only=false);
---ALTER MATERIALIZED VIEW :CAGG_NAME_3TH_LEVEL SET (timescaledb.materialized_only=false);
+ALTER MATERIALIZED VIEW :CAGG_NAME_3TH_LEVEL SET (timescaledb.materialized_only=false);
 -- Realtime data
-SELECT * FROM :CAGG_NAME_1ST_LEVEL ORDER BY bucket;
+SELECT * FROM :CAGG_NAME_1ST_LEVEL;
           bucket          | temperature | device_id 
 --------------------------+-------------+-----------
  Sat Jan 01 00:00:00 2022 |          10 |         1
@@ -1327,15 +1377,22 @@ SELECT * FROM :CAGG_NAME_1ST_LEVEL ORDER BY bucket;
  Sun Jan 02 01:00:00 2022 |          20 |         3
 (3 rows)
 
-SELECT * FROM :CAGG_NAME_2TH_LEVEL ORDER BY bucket, temperature;
-          bucket          | temperature | device_id 
---------------------------+-------------+-----------
- Sat Jan 01 00:00:00 2022 |           5 |         2
- Sat Jan 01 00:00:00 2022 |          10 |         1
- Sun Jan 02 00:00:00 2022 |          20 |         3
+SELECT * FROM :CAGG_NAME_2TH_LEVEL;
+          bucket          | temperature | device_id |   name   
+--------------------------+-------------+-----------+----------
+ Sat Jan 01 00:00:00 2022 |           5 |         2 | thermo_2
+ Sat Jan 01 00:00:00 2022 |          10 |         1 | thermo_1
+ Sun Jan 02 00:00:00 2022 |          20 |         3 | thermo_3
 (3 rows)
 
---SELECT * FROM :CAGG_NAME_3TH_LEVEL ORDER BY bucket;
+SELECT * FROM :CAGG_NAME_3TH_LEVEL;
+          bucket          | temperature | device_id |   name   | location 
+--------------------------+-------------+-----------+----------+----------
+ Mon Dec 27 00:00:00 2021 |           5 |         2 | thermo_2 | Berlin
+ Mon Dec 27 00:00:00 2021 |          10 |         1 | thermo_1 | Moscow
+ Mon Dec 27 00:00:00 2021 |          20 |         3 | thermo_3 | London
+(3 rows)
+
 -- Turn CAGGs into materialized only again
 ALTER MATERIALIZED VIEW :CAGG_NAME_1ST_LEVEL SET (timescaledb.materialized_only=true);
 ALTER MATERIALIZED VIEW :CAGG_NAME_2TH_LEVEL SET (timescaledb.materialized_only=true);
@@ -1345,7 +1402,7 @@ CALL refresh_continuous_aggregate(:'CAGG_NAME_1ST_LEVEL', NULL, NULL);
 CALL refresh_continuous_aggregate(:'CAGG_NAME_2TH_LEVEL', NULL, NULL);
 CALL refresh_continuous_aggregate(:'CAGG_NAME_3TH_LEVEL', NULL, NULL);
 -- Materialized data
-SELECT * FROM :CAGG_NAME_1ST_LEVEL ORDER BY bucket;
+SELECT * FROM :CAGG_NAME_1ST_LEVEL;
           bucket          | temperature | device_id 
 --------------------------+-------------+-----------
  Sat Jan 01 00:00:00 2022 |          10 |         1
@@ -1353,20 +1410,20 @@ SELECT * FROM :CAGG_NAME_1ST_LEVEL ORDER BY bucket;
  Sun Jan 02 01:00:00 2022 |          20 |         3
 (3 rows)
 
-SELECT * FROM :CAGG_NAME_2TH_LEVEL ORDER BY bucket, temperature;
-          bucket          | temperature | device_id 
---------------------------+-------------+-----------
- Sat Jan 01 00:00:00 2022 |           5 |         2
- Sat Jan 01 00:00:00 2022 |          10 |         1
- Sun Jan 02 00:00:00 2022 |          20 |         3
+SELECT * FROM :CAGG_NAME_2TH_LEVEL;
+          bucket          | temperature | device_id |   name   
+--------------------------+-------------+-----------+----------
+ Sat Jan 01 00:00:00 2022 |           5 |         2 | thermo_2
+ Sat Jan 01 00:00:00 2022 |          10 |         1 | thermo_1
+ Sun Jan 02 00:00:00 2022 |          20 |         3 | thermo_3
 (3 rows)
 
-SELECT * FROM :CAGG_NAME_3TH_LEVEL ORDER BY bucket;
-          bucket          | temperature | device_id 
---------------------------+-------------+-----------
- Mon Dec 27 00:00:00 2021 |          20 |         3
- Mon Dec 27 00:00:00 2021 |           5 |         2
- Mon Dec 27 00:00:00 2021 |          10 |         1
+SELECT * FROM :CAGG_NAME_3TH_LEVEL;
+          bucket          | temperature | device_id |   name   | location 
+--------------------------+-------------+-----------+----------+----------
+ Mon Dec 27 00:00:00 2021 |           5 |         2 | thermo_2 | Berlin
+ Mon Dec 27 00:00:00 2021 |          10 |         1 | thermo_1 | Moscow
+ Mon Dec 27 00:00:00 2021 |          20 |         3 | thermo_3 | London
 (3 rows)
 
 \if :IS_TIME_DIMENSION
@@ -1381,7 +1438,7 @@ INSERT INTO conditions ("time", temperature) VALUES (2,  2);
 INSERT INTO conditions ("time", temperature) VALUES (10, 2);
 \endif
 -- No changes
-SELECT * FROM :CAGG_NAME_1ST_LEVEL ORDER BY bucket;
+SELECT * FROM :CAGG_NAME_1ST_LEVEL;
           bucket          | temperature | device_id 
 --------------------------+-------------+-----------
  Sat Jan 01 00:00:00 2022 |          10 |         1
@@ -1389,20 +1446,20 @@ SELECT * FROM :CAGG_NAME_1ST_LEVEL ORDER BY bucket;
  Sun Jan 02 01:00:00 2022 |          20 |         3
 (3 rows)
 
-SELECT * FROM :CAGG_NAME_2TH_LEVEL ORDER BY bucket, temperature;
-          bucket          | temperature | device_id 
---------------------------+-------------+-----------
- Sat Jan 01 00:00:00 2022 |           5 |         2
- Sat Jan 01 00:00:00 2022 |          10 |         1
- Sun Jan 02 00:00:00 2022 |          20 |         3
+SELECT * FROM :CAGG_NAME_2TH_LEVEL;
+          bucket          | temperature | device_id |   name   
+--------------------------+-------------+-----------+----------
+ Sat Jan 01 00:00:00 2022 |           5 |         2 | thermo_2
+ Sat Jan 01 00:00:00 2022 |          10 |         1 | thermo_1
+ Sun Jan 02 00:00:00 2022 |          20 |         3 | thermo_3
 (3 rows)
 
-SELECT * FROM :CAGG_NAME_3TH_LEVEL ORDER BY bucket;
-          bucket          | temperature | device_id 
---------------------------+-------------+-----------
- Mon Dec 27 00:00:00 2021 |          20 |         3
- Mon Dec 27 00:00:00 2021 |           5 |         2
- Mon Dec 27 00:00:00 2021 |          10 |         1
+SELECT * FROM :CAGG_NAME_3TH_LEVEL;
+          bucket          | temperature | device_id |   name   | location 
+--------------------------+-------------+-----------+----------+----------
+ Mon Dec 27 00:00:00 2021 |           5 |         2 | thermo_2 | Berlin
+ Mon Dec 27 00:00:00 2021 |          10 |         1 | thermo_1 | Moscow
+ Mon Dec 27 00:00:00 2021 |          20 |         3 | thermo_3 | London
 (3 rows)
 
 -- Turn CAGGs into Realtime
@@ -1410,7 +1467,7 @@ ALTER MATERIALIZED VIEW :CAGG_NAME_1ST_LEVEL SET (timescaledb.materialized_only=
 ALTER MATERIALIZED VIEW :CAGG_NAME_2TH_LEVEL SET (timescaledb.materialized_only=false);
 ALTER MATERIALIZED VIEW :CAGG_NAME_3TH_LEVEL SET (timescaledb.materialized_only=false);
 -- Realtime changes, just new region
-SELECT * FROM :CAGG_NAME_1ST_LEVEL ORDER BY bucket;
+SELECT * FROM :CAGG_NAME_1ST_LEVEL;
           bucket          | temperature | device_id 
 --------------------------+-------------+-----------
  Sat Jan 01 00:00:00 2022 |          10 |         1
@@ -1419,20 +1476,20 @@ SELECT * FROM :CAGG_NAME_1ST_LEVEL ORDER BY bucket;
  Mon Jan 03 01:00:00 2022 |           2 |          
 (4 rows)
 
-SELECT * FROM :CAGG_NAME_2TH_LEVEL ORDER BY bucket, temperature;
-          bucket          | temperature | device_id 
---------------------------+-------------+-----------
- Sat Jan 01 00:00:00 2022 |           5 |         2
- Sat Jan 01 00:00:00 2022 |          10 |         1
- Sun Jan 02 00:00:00 2022 |          20 |         3
+SELECT * FROM :CAGG_NAME_2TH_LEVEL;
+          bucket          | temperature | device_id |   name   
+--------------------------+-------------+-----------+----------
+ Sat Jan 01 00:00:00 2022 |           5 |         2 | thermo_2
+ Sat Jan 01 00:00:00 2022 |          10 |         1 | thermo_1
+ Sun Jan 02 00:00:00 2022 |          20 |         3 | thermo_3
 (3 rows)
 
-SELECT * FROM :CAGG_NAME_3TH_LEVEL ORDER BY bucket;
-          bucket          | temperature | device_id 
---------------------------+-------------+-----------
- Mon Dec 27 00:00:00 2021 |          10 |         1
- Mon Dec 27 00:00:00 2021 |           5 |         2
- Mon Dec 27 00:00:00 2021 |          20 |         3
+SELECT * FROM :CAGG_NAME_3TH_LEVEL;
+          bucket          | temperature | device_id |   name   | location 
+--------------------------+-------------+-----------+----------+----------
+ Mon Dec 27 00:00:00 2021 |           5 |         2 | thermo_2 | Berlin
+ Mon Dec 27 00:00:00 2021 |          10 |         1 | thermo_1 | Moscow
+ Mon Dec 27 00:00:00 2021 |          20 |         3 | thermo_3 | London
 (3 rows)
 
 -- Turn CAGGs into materialized only again
@@ -1444,7 +1501,7 @@ CALL refresh_continuous_aggregate(:'CAGG_NAME_1ST_LEVEL', NULL, NULL);
 CALL refresh_continuous_aggregate(:'CAGG_NAME_2TH_LEVEL', NULL, NULL);
 CALL refresh_continuous_aggregate(:'CAGG_NAME_3TH_LEVEL', NULL, NULL);
 -- All changes are materialized
-SELECT * FROM :CAGG_NAME_1ST_LEVEL ORDER BY bucket;
+SELECT * FROM :CAGG_NAME_1ST_LEVEL;
           bucket          | temperature | device_id 
 --------------------------+-------------+-----------
  Sat Jan 01 00:00:00 2022 |          10 |         1
@@ -1454,20 +1511,20 @@ SELECT * FROM :CAGG_NAME_1ST_LEVEL ORDER BY bucket;
  Mon Jan 03 01:00:00 2022 |           2 |          
 (5 rows)
 
-SELECT * FROM :CAGG_NAME_2TH_LEVEL ORDER BY bucket, temperature;
-          bucket          | temperature | device_id 
---------------------------+-------------+-----------
- Sat Jan 01 00:00:00 2022 |           5 |         2
- Sat Jan 01 00:00:00 2022 |          10 |         1
- Sun Jan 02 00:00:00 2022 |          20 |         3
+SELECT * FROM :CAGG_NAME_2TH_LEVEL;
+          bucket          | temperature | device_id |   name   
+--------------------------+-------------+-----------+----------
+ Sat Jan 01 00:00:00 2022 |           5 |         2 | thermo_2
+ Sat Jan 01 00:00:00 2022 |          10 |         1 | thermo_1
+ Sun Jan 02 00:00:00 2022 |          20 |         3 | thermo_3
 (3 rows)
 
-SELECT * FROM :CAGG_NAME_3TH_LEVEL ORDER BY bucket;
-          bucket          | temperature | device_id 
---------------------------+-------------+-----------
- Mon Dec 27 00:00:00 2021 |          20 |         3
- Mon Dec 27 00:00:00 2021 |           5 |         2
- Mon Dec 27 00:00:00 2021 |          10 |         1
+SELECT * FROM :CAGG_NAME_3TH_LEVEL;
+          bucket          | temperature | device_id |   name   | location 
+--------------------------+-------------+-----------+----------+----------
+ Mon Dec 27 00:00:00 2021 |           5 |         2 | thermo_2 | Berlin
+ Mon Dec 27 00:00:00 2021 |          10 |         1 | thermo_1 | Moscow
+ Mon Dec 27 00:00:00 2021 |          20 |         3 | thermo_3 | London
 (3 rows)
 
 -- TRUNCATE tests
@@ -1475,102 +1532,102 @@ TRUNCATE :CAGG_NAME_2TH_LEVEL;
 -- This full refresh will remove all the data from the 3TH level cagg
 CALL refresh_continuous_aggregate(:'CAGG_NAME_3TH_LEVEL', NULL, NULL);
 -- Should return no rows
-SELECT * FROM :CAGG_NAME_2TH_LEVEL ORDER BY bucket;
- bucket | temperature | device_id 
---------+-------------+-----------
+SELECT * FROM :CAGG_NAME_2TH_LEVEL;
+ bucket | temperature | device_id | name 
+--------+-------------+-----------+------
 (0 rows)
 
-SELECT * FROM :CAGG_NAME_3TH_LEVEL ORDER BY bucket;
- bucket | temperature | device_id 
---------+-------------+-----------
+SELECT * FROM :CAGG_NAME_3TH_LEVEL;
+ bucket | temperature | device_id | name | location 
+--------+-------------+-----------+------+----------
 (0 rows)
 
 -- If we have all the data in the bottom levels caggs we can rebuild
 CALL refresh_continuous_aggregate(:'CAGG_NAME_2TH_LEVEL', NULL, NULL);
 CALL refresh_continuous_aggregate(:'CAGG_NAME_3TH_LEVEL', NULL, NULL);
 -- Now we have all the data
-SELECT * FROM :CAGG_NAME_2TH_LEVEL ORDER BY bucket, temperature;
-          bucket          | temperature | device_id 
---------------------------+-------------+-----------
- Sat Jan 01 00:00:00 2022 |           5 |         2
- Sat Jan 01 00:00:00 2022 |          10 |         1
- Sun Jan 02 00:00:00 2022 |          20 |         3
+SELECT * FROM :CAGG_NAME_2TH_LEVEL;
+          bucket          | temperature | device_id |   name   
+--------------------------+-------------+-----------+----------
+ Sat Jan 01 00:00:00 2022 |           5 |         2 | thermo_2
+ Sat Jan 01 00:00:00 2022 |          10 |         1 | thermo_1
+ Sun Jan 02 00:00:00 2022 |          20 |         3 | thermo_3
 (3 rows)
 
-SELECT * FROM :CAGG_NAME_3TH_LEVEL ORDER BY bucket;
-          bucket          | temperature | device_id 
---------------------------+-------------+-----------
- Mon Dec 27 00:00:00 2021 |          20 |         3
- Mon Dec 27 00:00:00 2021 |           5 |         2
- Mon Dec 27 00:00:00 2021 |          10 |         1
+SELECT * FROM :CAGG_NAME_3TH_LEVEL;
+          bucket          | temperature | device_id |   name   | location 
+--------------------------+-------------+-----------+----------+----------
+ Mon Dec 27 00:00:00 2021 |           5 |         2 | thermo_2 | Berlin
+ Mon Dec 27 00:00:00 2021 |          10 |         1 | thermo_1 | Moscow
+ Mon Dec 27 00:00:00 2021 |          20 |         3 | thermo_3 | London
 (3 rows)
 
 -- DROP tests
 \set ON_ERROR_STOP 0
 -- should error because it depends of other CAGGs
 DROP MATERIALIZED VIEW :CAGG_NAME_1ST_LEVEL;
-psql:include/cagg_on_cagg_common.sql:166: ERROR:  cannot drop view conditions_summary_1_hourly because other objects depend on it
+psql:include/cagg_on_cagg_common.sql:172: ERROR:  cannot drop view conditions_summary_1_hourly because other objects depend on it
 DROP MATERIALIZED VIEW :CAGG_NAME_2TH_LEVEL;
-psql:include/cagg_on_cagg_common.sql:167: ERROR:  cannot drop view conditions_summary_2_daily because other objects depend on it
+psql:include/cagg_on_cagg_common.sql:173: ERROR:  cannot drop view conditions_summary_2_daily because other objects depend on it
 CALL refresh_continuous_aggregate(:'CAGG_NAME_1ST_LEVEL', NULL, NULL);
-psql:include/cagg_on_cagg_common.sql:168: NOTICE:  continuous aggregate "conditions_summary_1_hourly" is already up-to-date
+psql:include/cagg_on_cagg_common.sql:174: NOTICE:  continuous aggregate "conditions_summary_1_hourly" is already up-to-date
 CALL refresh_continuous_aggregate(:'CAGG_NAME_2TH_LEVEL', NULL, NULL);
-psql:include/cagg_on_cagg_common.sql:169: NOTICE:  continuous aggregate "conditions_summary_2_daily" is already up-to-date
+psql:include/cagg_on_cagg_common.sql:175: NOTICE:  continuous aggregate "conditions_summary_2_daily" is already up-to-date
 \set ON_ERROR_STOP 1
 -- DROP the 3TH level CAGG don't affect others
 DROP MATERIALIZED VIEW :CAGG_NAME_3TH_LEVEL;
-psql:include/cagg_on_cagg_common.sql:173: NOTICE:  drop cascades to table _timescaledb_internal._hyper_16_18_chunk
+psql:include/cagg_on_cagg_common.sql:179: NOTICE:  drop cascades to table _timescaledb_internal._hyper_16_18_chunk
 \set ON_ERROR_STOP 0
 -- should error because it was dropped
-SELECT * FROM :CAGG_NAME_3TH_LEVEL ORDER BY bucket, device_id;
-psql:include/cagg_on_cagg_common.sql:176: ERROR:  relation "conditions_summary_3_weekly" does not exist at character 15
+SELECT * FROM :CAGG_NAME_3TH_LEVEL;
+psql:include/cagg_on_cagg_common.sql:182: ERROR:  relation "conditions_summary_3_weekly" does not exist at character 15
 \set ON_ERROR_STOP 1
 -- should work because dropping the top level CAGG
 -- don't affect the down level CAGGs
 TRUNCATE :CAGG_NAME_2TH_LEVEL,:CAGG_NAME_1ST_LEVEL;
 CALL refresh_continuous_aggregate(:'CAGG_NAME_2TH_LEVEL', NULL, NULL);
 CALL refresh_continuous_aggregate(:'CAGG_NAME_1ST_LEVEL', NULL, NULL);
-SELECT * FROM :CAGG_NAME_1ST_LEVEL ORDER BY bucket, device_id;
+SELECT * FROM :CAGG_NAME_1ST_LEVEL;
           bucket          | temperature | device_id 
 --------------------------+-------------+-----------
  Sat Jan 01 00:00:00 2022 |          10 |         1
- Sat Jan 01 01:00:00 2022 |           5 |         2
  Sat Jan 01 01:00:00 2022 |           2 |          
+ Sat Jan 01 01:00:00 2022 |           5 |         2
  Sun Jan 02 01:00:00 2022 |          20 |         3
  Mon Jan 03 01:00:00 2022 |           2 |          
 (5 rows)
 
-SELECT * FROM :CAGG_NAME_2TH_LEVEL ORDER BY bucket, temperature;
- bucket | temperature | device_id 
---------+-------------+-----------
+SELECT * FROM :CAGG_NAME_2TH_LEVEL;
+ bucket | temperature | device_id | name 
+--------+-------------+-----------+------
 (0 rows)
 
 -- DROP the 2TH level CAGG don't affect others
 DROP MATERIALIZED VIEW :CAGG_NAME_2TH_LEVEL;
 \set ON_ERROR_STOP 0
 -- should error because it was dropped
-SELECT * FROM :CAGG_NAME_2TH_LEVEL ORDER BY bucket, temperature;
-psql:include/cagg_on_cagg_common.sql:190: ERROR:  relation "conditions_summary_2_daily" does not exist at character 15
+SELECT * FROM :CAGG_NAME_2TH_LEVEL;
+psql:include/cagg_on_cagg_common.sql:196: ERROR:  relation "conditions_summary_2_daily" does not exist at character 15
 \set ON_ERROR_STOP 1
 -- should work because dropping the top level CAGG
 -- don't affect the down level CAGGs
-SELECT * FROM :CAGG_NAME_1ST_LEVEL ORDER BY bucket, device_id;
+SELECT * FROM :CAGG_NAME_1ST_LEVEL;
           bucket          | temperature | device_id 
 --------------------------+-------------+-----------
  Sat Jan 01 00:00:00 2022 |          10 |         1
- Sat Jan 01 01:00:00 2022 |           5 |         2
  Sat Jan 01 01:00:00 2022 |           2 |          
+ Sat Jan 01 01:00:00 2022 |           5 |         2
  Sun Jan 02 01:00:00 2022 |          20 |         3
  Mon Jan 03 01:00:00 2022 |           2 |          
 (5 rows)
 
 -- DROP the first CAGG should work
 DROP MATERIALIZED VIEW :CAGG_NAME_1ST_LEVEL;
-psql:include/cagg_on_cagg_common.sql:197: NOTICE:  drop cascades to table _timescaledb_internal._hyper_14_20_chunk
+psql:include/cagg_on_cagg_common.sql:203: NOTICE:  drop cascades to table _timescaledb_internal._hyper_14_20_chunk
 \set ON_ERROR_STOP 0
 -- should error because it was dropped
-SELECT * FROM :CAGG_NAME_1ST_LEVEL ORDER BY bucket, device_id;
-psql:include/cagg_on_cagg_common.sql:200: ERROR:  relation "conditions_summary_1_hourly" does not exist at character 15
+SELECT * FROM :CAGG_NAME_1ST_LEVEL;
+psql:include/cagg_on_cagg_common.sql:206: ERROR:  relation "conditions_summary_1_hourly" does not exist at character 15
 \set ON_ERROR_STOP 1
 -- Default tests
 \set IS_DEFAULT_COLUMN_ORDER TRUE
@@ -1638,7 +1695,8 @@ SELECT
   SUM(temperature) AS temperature,
   device_id
 FROM conditions
-GROUP BY 1,3
+GROUP BY 1, 3
+ORDER BY 1, 2, 3
 WITH NO DATA;
 -- CAGG on CAGG (2th level)
 CREATE MATERIALIZED VIEW :CAGG_NAME_2TH_LEVEL
@@ -1647,31 +1705,38 @@ SELECT
   time_bucket(:BUCKET_WIDTH_2TH, "bucket") AS bucket,
   SUM(temperature) AS temperature
 \if :IS_JOIN
-  , :CAGG_NAME_1ST_LEVEL.device_id
-  FROM :CAGG_NAME_1ST_LEVEL, devices
-  WHERE devices.device_id = :CAGG_NAME_1ST_LEVEL.device_id
-  GROUP BY 1,3
+  , devices.device_id
+  , devices.name
+  FROM :CAGG_NAME_1ST_LEVEL
+  JOIN devices ON devices.device_id = :CAGG_NAME_1ST_LEVEL.device_id
+  GROUP BY 1, 3, 4
+  ORDER BY 1, 2, 3, 4
 \else
   FROM :CAGG_NAME_1ST_LEVEL
   GROUP BY 1
+  ORDER BY 1, 2
 \endif
 WITH NO DATA;
 -- CAGG on CAGG (3th level)
 CREATE MATERIALIZED VIEW :CAGG_NAME_3TH_LEVEL
-  WITH (timescaledb.continuous, timescaledb.materialized_only=true) AS
-  SELECT
-    time_bucket(:BUCKET_WIDTH_3TH, "bucket") AS bucket,
-    SUM(temperature) AS temperature
-  \if :IS_JOIN
-    , :CAGG_NAME_2TH_LEVEL.device_id
-    FROM :CAGG_NAME_2TH_LEVEL, devices
-    WHERE devices.device_id = :CAGG_NAME_2TH_LEVEL.device_id
-    GROUP BY 1,3
-  \else
-    FROM :CAGG_NAME_2TH_LEVEL
-    GROUP BY 1
-  \endif
-  WITH NO DATA;
+WITH (timescaledb.continuous, timescaledb.materialized_only=true) AS
+SELECT
+  time_bucket(:BUCKET_WIDTH_3TH, "bucket") AS bucket,
+  SUM(temperature) AS temperature
+\if :IS_JOIN
+  , :CAGG_NAME_2TH_LEVEL.device_id
+  , :CAGG_NAME_2TH_LEVEL.name
+  , devices.location
+  FROM :CAGG_NAME_2TH_LEVEL
+  JOIN devices ON devices.device_id = :CAGG_NAME_2TH_LEVEL.device_id
+  GROUP BY 1, 3, 4, 5
+  ORDER BY 1, 2, 3, 4, 5
+\else
+  FROM :CAGG_NAME_2TH_LEVEL
+  GROUP BY 1
+  ORDER BY 1, 2
+\endif
+WITH NO DATA;
 -- Check chunk_interval
 \if :IS_TIME_DIMENSION
   SELECT h.table_name AS name, _timescaledb_functions.to_interval(d.interval_length) AS chunk_interval
@@ -1705,23 +1770,27 @@ CREATE MATERIALIZED VIEW :CAGG_NAME_3TH_LEVEL
   ORDER BY 1, 2;
 \endif
 -- No data because the CAGGs are just for materialized data
-SELECT * FROM :CAGG_NAME_1ST_LEVEL ORDER BY bucket;
+SELECT * FROM :CAGG_NAME_1ST_LEVEL;
  bucket | temperature | device_id 
 --------+-------------+-----------
 (0 rows)
 
-SELECT * FROM :CAGG_NAME_2TH_LEVEL ORDER BY bucket, temperature;
- bucket | temperature | device_id 
---------+-------------+-----------
+SELECT * FROM :CAGG_NAME_2TH_LEVEL;
+ bucket | temperature | device_id | name 
+--------+-------------+-----------+------
 (0 rows)
 
---SELECT * FROM :CAGG_NAME_3TH_LEVEL ORDER BY bucket;
+SELECT * FROM :CAGG_NAME_3TH_LEVEL;
+ bucket | temperature | device_id | name | location 
+--------+-------------+-----------+------+----------
+(0 rows)
+
 -- Turn CAGGs into Realtime
 ALTER MATERIALIZED VIEW :CAGG_NAME_1ST_LEVEL SET (timescaledb.materialized_only=false);
 ALTER MATERIALIZED VIEW :CAGG_NAME_2TH_LEVEL SET (timescaledb.materialized_only=false);
---ALTER MATERIALIZED VIEW :CAGG_NAME_3TH_LEVEL SET (timescaledb.materialized_only=false);
+ALTER MATERIALIZED VIEW :CAGG_NAME_3TH_LEVEL SET (timescaledb.materialized_only=false);
 -- Realtime data
-SELECT * FROM :CAGG_NAME_1ST_LEVEL ORDER BY bucket;
+SELECT * FROM :CAGG_NAME_1ST_LEVEL;
           bucket          | temperature | device_id 
 --------------------------+-------------+-----------
  Sat Jan 01 00:00:00 2022 |          10 |         1
@@ -1729,15 +1798,22 @@ SELECT * FROM :CAGG_NAME_1ST_LEVEL ORDER BY bucket;
  Sun Jan 02 01:00:00 2022 |          20 |         3
 (3 rows)
 
-SELECT * FROM :CAGG_NAME_2TH_LEVEL ORDER BY bucket, temperature;
-          bucket          | temperature | device_id 
---------------------------+-------------+-----------
- Sat Jan 01 00:00:00 2022 |           5 |         2
- Sat Jan 01 00:00:00 2022 |          10 |         1
- Sun Jan 02 00:00:00 2022 |          20 |         3
+SELECT * FROM :CAGG_NAME_2TH_LEVEL;
+          bucket          | temperature | device_id |   name   
+--------------------------+-------------+-----------+----------
+ Sat Jan 01 00:00:00 2022 |           5 |         2 | thermo_2
+ Sat Jan 01 00:00:00 2022 |          10 |         1 | thermo_1
+ Sun Jan 02 00:00:00 2022 |          20 |         3 | thermo_3
 (3 rows)
 
---SELECT * FROM :CAGG_NAME_3TH_LEVEL ORDER BY bucket;
+SELECT * FROM :CAGG_NAME_3TH_LEVEL;
+          bucket          | temperature | device_id |   name   | location 
+--------------------------+-------------+-----------+----------+----------
+ Mon Dec 27 00:00:00 2021 |           5 |         2 | thermo_2 | Berlin
+ Mon Dec 27 00:00:00 2021 |          10 |         1 | thermo_1 | Moscow
+ Mon Dec 27 00:00:00 2021 |          20 |         3 | thermo_3 | London
+(3 rows)
+
 -- Turn CAGGs into materialized only again
 ALTER MATERIALIZED VIEW :CAGG_NAME_1ST_LEVEL SET (timescaledb.materialized_only=true);
 ALTER MATERIALIZED VIEW :CAGG_NAME_2TH_LEVEL SET (timescaledb.materialized_only=true);
@@ -1747,7 +1823,7 @@ CALL refresh_continuous_aggregate(:'CAGG_NAME_1ST_LEVEL', NULL, NULL);
 CALL refresh_continuous_aggregate(:'CAGG_NAME_2TH_LEVEL', NULL, NULL);
 CALL refresh_continuous_aggregate(:'CAGG_NAME_3TH_LEVEL', NULL, NULL);
 -- Materialized data
-SELECT * FROM :CAGG_NAME_1ST_LEVEL ORDER BY bucket;
+SELECT * FROM :CAGG_NAME_1ST_LEVEL;
           bucket          | temperature | device_id 
 --------------------------+-------------+-----------
  Sat Jan 01 00:00:00 2022 |          10 |         1
@@ -1755,20 +1831,20 @@ SELECT * FROM :CAGG_NAME_1ST_LEVEL ORDER BY bucket;
  Sun Jan 02 01:00:00 2022 |          20 |         3
 (3 rows)
 
-SELECT * FROM :CAGG_NAME_2TH_LEVEL ORDER BY bucket, temperature;
-          bucket          | temperature | device_id 
---------------------------+-------------+-----------
- Sat Jan 01 00:00:00 2022 |           5 |         2
- Sat Jan 01 00:00:00 2022 |          10 |         1
- Sun Jan 02 00:00:00 2022 |          20 |         3
+SELECT * FROM :CAGG_NAME_2TH_LEVEL;
+          bucket          | temperature | device_id |   name   
+--------------------------+-------------+-----------+----------
+ Sat Jan 01 00:00:00 2022 |           5 |         2 | thermo_2
+ Sat Jan 01 00:00:00 2022 |          10 |         1 | thermo_1
+ Sun Jan 02 00:00:00 2022 |          20 |         3 | thermo_3
 (3 rows)
 
-SELECT * FROM :CAGG_NAME_3TH_LEVEL ORDER BY bucket;
-          bucket          | temperature | device_id 
---------------------------+-------------+-----------
- Mon Dec 27 00:00:00 2021 |          20 |         3
- Mon Dec 27 00:00:00 2021 |           5 |         2
- Mon Dec 27 00:00:00 2021 |          10 |         1
+SELECT * FROM :CAGG_NAME_3TH_LEVEL;
+          bucket          | temperature | device_id |   name   | location 
+--------------------------+-------------+-----------+----------+----------
+ Mon Dec 27 00:00:00 2021 |           5 |         2 | thermo_2 | Berlin
+ Mon Dec 27 00:00:00 2021 |          10 |         1 | thermo_1 | Moscow
+ Mon Dec 27 00:00:00 2021 |          20 |         3 | thermo_3 | London
 (3 rows)
 
 \if :IS_TIME_DIMENSION
@@ -1783,7 +1859,7 @@ INSERT INTO conditions ("time", temperature) VALUES (2,  2);
 INSERT INTO conditions ("time", temperature) VALUES (10, 2);
 \endif
 -- No changes
-SELECT * FROM :CAGG_NAME_1ST_LEVEL ORDER BY bucket;
+SELECT * FROM :CAGG_NAME_1ST_LEVEL;
           bucket          | temperature | device_id 
 --------------------------+-------------+-----------
  Sat Jan 01 00:00:00 2022 |          10 |         1
@@ -1791,20 +1867,20 @@ SELECT * FROM :CAGG_NAME_1ST_LEVEL ORDER BY bucket;
  Sun Jan 02 01:00:00 2022 |          20 |         3
 (3 rows)
 
-SELECT * FROM :CAGG_NAME_2TH_LEVEL ORDER BY bucket, temperature;
-          bucket          | temperature | device_id 
---------------------------+-------------+-----------
- Sat Jan 01 00:00:00 2022 |           5 |         2
- Sat Jan 01 00:00:00 2022 |          10 |         1
- Sun Jan 02 00:00:00 2022 |          20 |         3
+SELECT * FROM :CAGG_NAME_2TH_LEVEL;
+          bucket          | temperature | device_id |   name   
+--------------------------+-------------+-----------+----------
+ Sat Jan 01 00:00:00 2022 |           5 |         2 | thermo_2
+ Sat Jan 01 00:00:00 2022 |          10 |         1 | thermo_1
+ Sun Jan 02 00:00:00 2022 |          20 |         3 | thermo_3
 (3 rows)
 
-SELECT * FROM :CAGG_NAME_3TH_LEVEL ORDER BY bucket;
-          bucket          | temperature | device_id 
---------------------------+-------------+-----------
- Mon Dec 27 00:00:00 2021 |          20 |         3
- Mon Dec 27 00:00:00 2021 |           5 |         2
- Mon Dec 27 00:00:00 2021 |          10 |         1
+SELECT * FROM :CAGG_NAME_3TH_LEVEL;
+          bucket          | temperature | device_id |   name   | location 
+--------------------------+-------------+-----------+----------+----------
+ Mon Dec 27 00:00:00 2021 |           5 |         2 | thermo_2 | Berlin
+ Mon Dec 27 00:00:00 2021 |          10 |         1 | thermo_1 | Moscow
+ Mon Dec 27 00:00:00 2021 |          20 |         3 | thermo_3 | London
 (3 rows)
 
 -- Turn CAGGs into Realtime
@@ -1812,7 +1888,7 @@ ALTER MATERIALIZED VIEW :CAGG_NAME_1ST_LEVEL SET (timescaledb.materialized_only=
 ALTER MATERIALIZED VIEW :CAGG_NAME_2TH_LEVEL SET (timescaledb.materialized_only=false);
 ALTER MATERIALIZED VIEW :CAGG_NAME_3TH_LEVEL SET (timescaledb.materialized_only=false);
 -- Realtime changes, just new region
-SELECT * FROM :CAGG_NAME_1ST_LEVEL ORDER BY bucket;
+SELECT * FROM :CAGG_NAME_1ST_LEVEL;
           bucket          | temperature | device_id 
 --------------------------+-------------+-----------
  Sat Jan 01 00:00:00 2022 |          10 |         1
@@ -1821,20 +1897,20 @@ SELECT * FROM :CAGG_NAME_1ST_LEVEL ORDER BY bucket;
  Mon Jan 03 01:00:00 2022 |           2 |          
 (4 rows)
 
-SELECT * FROM :CAGG_NAME_2TH_LEVEL ORDER BY bucket, temperature;
-          bucket          | temperature | device_id 
---------------------------+-------------+-----------
- Sat Jan 01 00:00:00 2022 |           5 |         2
- Sat Jan 01 00:00:00 2022 |          10 |         1
- Sun Jan 02 00:00:00 2022 |          20 |         3
+SELECT * FROM :CAGG_NAME_2TH_LEVEL;
+          bucket          | temperature | device_id |   name   
+--------------------------+-------------+-----------+----------
+ Sat Jan 01 00:00:00 2022 |           5 |         2 | thermo_2
+ Sat Jan 01 00:00:00 2022 |          10 |         1 | thermo_1
+ Sun Jan 02 00:00:00 2022 |          20 |         3 | thermo_3
 (3 rows)
 
-SELECT * FROM :CAGG_NAME_3TH_LEVEL ORDER BY bucket;
-          bucket          | temperature | device_id 
---------------------------+-------------+-----------
- Mon Dec 27 00:00:00 2021 |          10 |         1
- Mon Dec 27 00:00:00 2021 |           5 |         2
- Mon Dec 27 00:00:00 2021 |          20 |         3
+SELECT * FROM :CAGG_NAME_3TH_LEVEL;
+          bucket          | temperature | device_id |   name   | location 
+--------------------------+-------------+-----------+----------+----------
+ Mon Dec 27 00:00:00 2021 |           5 |         2 | thermo_2 | Berlin
+ Mon Dec 27 00:00:00 2021 |          10 |         1 | thermo_1 | Moscow
+ Mon Dec 27 00:00:00 2021 |          20 |         3 | thermo_3 | London
 (3 rows)
 
 -- Turn CAGGs into materialized only again
@@ -1846,7 +1922,7 @@ CALL refresh_continuous_aggregate(:'CAGG_NAME_1ST_LEVEL', NULL, NULL);
 CALL refresh_continuous_aggregate(:'CAGG_NAME_2TH_LEVEL', NULL, NULL);
 CALL refresh_continuous_aggregate(:'CAGG_NAME_3TH_LEVEL', NULL, NULL);
 -- All changes are materialized
-SELECT * FROM :CAGG_NAME_1ST_LEVEL ORDER BY bucket;
+SELECT * FROM :CAGG_NAME_1ST_LEVEL;
           bucket          | temperature | device_id 
 --------------------------+-------------+-----------
  Sat Jan 01 00:00:00 2022 |          10 |         1
@@ -1856,20 +1932,20 @@ SELECT * FROM :CAGG_NAME_1ST_LEVEL ORDER BY bucket;
  Mon Jan 03 01:00:00 2022 |           2 |          
 (5 rows)
 
-SELECT * FROM :CAGG_NAME_2TH_LEVEL ORDER BY bucket, temperature;
-          bucket          | temperature | device_id 
---------------------------+-------------+-----------
- Sat Jan 01 00:00:00 2022 |           5 |         2
- Sat Jan 01 00:00:00 2022 |          10 |         1
- Sun Jan 02 00:00:00 2022 |          20 |         3
+SELECT * FROM :CAGG_NAME_2TH_LEVEL;
+          bucket          | temperature | device_id |   name   
+--------------------------+-------------+-----------+----------
+ Sat Jan 01 00:00:00 2022 |           5 |         2 | thermo_2
+ Sat Jan 01 00:00:00 2022 |          10 |         1 | thermo_1
+ Sun Jan 02 00:00:00 2022 |          20 |         3 | thermo_3
 (3 rows)
 
-SELECT * FROM :CAGG_NAME_3TH_LEVEL ORDER BY bucket;
-          bucket          | temperature | device_id 
---------------------------+-------------+-----------
- Mon Dec 27 00:00:00 2021 |          20 |         3
- Mon Dec 27 00:00:00 2021 |           5 |         2
- Mon Dec 27 00:00:00 2021 |          10 |         1
+SELECT * FROM :CAGG_NAME_3TH_LEVEL;
+          bucket          | temperature | device_id |   name   | location 
+--------------------------+-------------+-----------+----------+----------
+ Mon Dec 27 00:00:00 2021 |           5 |         2 | thermo_2 | Berlin
+ Mon Dec 27 00:00:00 2021 |          10 |         1 | thermo_1 | Moscow
+ Mon Dec 27 00:00:00 2021 |          20 |         3 | thermo_3 | London
 (3 rows)
 
 -- TRUNCATE tests
@@ -1877,102 +1953,102 @@ TRUNCATE :CAGG_NAME_2TH_LEVEL;
 -- This full refresh will remove all the data from the 3TH level cagg
 CALL refresh_continuous_aggregate(:'CAGG_NAME_3TH_LEVEL', NULL, NULL);
 -- Should return no rows
-SELECT * FROM :CAGG_NAME_2TH_LEVEL ORDER BY bucket;
- bucket | temperature | device_id 
---------+-------------+-----------
+SELECT * FROM :CAGG_NAME_2TH_LEVEL;
+ bucket | temperature | device_id | name 
+--------+-------------+-----------+------
 (0 rows)
 
-SELECT * FROM :CAGG_NAME_3TH_LEVEL ORDER BY bucket;
- bucket | temperature | device_id 
---------+-------------+-----------
+SELECT * FROM :CAGG_NAME_3TH_LEVEL;
+ bucket | temperature | device_id | name | location 
+--------+-------------+-----------+------+----------
 (0 rows)
 
 -- If we have all the data in the bottom levels caggs we can rebuild
 CALL refresh_continuous_aggregate(:'CAGG_NAME_2TH_LEVEL', NULL, NULL);
 CALL refresh_continuous_aggregate(:'CAGG_NAME_3TH_LEVEL', NULL, NULL);
 -- Now we have all the data
-SELECT * FROM :CAGG_NAME_2TH_LEVEL ORDER BY bucket, temperature;
-          bucket          | temperature | device_id 
---------------------------+-------------+-----------
- Sat Jan 01 00:00:00 2022 |           5 |         2
- Sat Jan 01 00:00:00 2022 |          10 |         1
- Sun Jan 02 00:00:00 2022 |          20 |         3
+SELECT * FROM :CAGG_NAME_2TH_LEVEL;
+          bucket          | temperature | device_id |   name   
+--------------------------+-------------+-----------+----------
+ Sat Jan 01 00:00:00 2022 |           5 |         2 | thermo_2
+ Sat Jan 01 00:00:00 2022 |          10 |         1 | thermo_1
+ Sun Jan 02 00:00:00 2022 |          20 |         3 | thermo_3
 (3 rows)
 
-SELECT * FROM :CAGG_NAME_3TH_LEVEL ORDER BY bucket;
-          bucket          | temperature | device_id 
---------------------------+-------------+-----------
- Mon Dec 27 00:00:00 2021 |          20 |         3
- Mon Dec 27 00:00:00 2021 |           5 |         2
- Mon Dec 27 00:00:00 2021 |          10 |         1
+SELECT * FROM :CAGG_NAME_3TH_LEVEL;
+          bucket          | temperature | device_id |   name   | location 
+--------------------------+-------------+-----------+----------+----------
+ Mon Dec 27 00:00:00 2021 |           5 |         2 | thermo_2 | Berlin
+ Mon Dec 27 00:00:00 2021 |          10 |         1 | thermo_1 | Moscow
+ Mon Dec 27 00:00:00 2021 |          20 |         3 | thermo_3 | London
 (3 rows)
 
 -- DROP tests
 \set ON_ERROR_STOP 0
 -- should error because it depends of other CAGGs
 DROP MATERIALIZED VIEW :CAGG_NAME_1ST_LEVEL;
-psql:include/cagg_on_cagg_common.sql:166: ERROR:  cannot drop view conditions_summary_1_hourly because other objects depend on it
+psql:include/cagg_on_cagg_common.sql:172: ERROR:  cannot drop view conditions_summary_1_hourly because other objects depend on it
 DROP MATERIALIZED VIEW :CAGG_NAME_2TH_LEVEL;
-psql:include/cagg_on_cagg_common.sql:167: ERROR:  cannot drop view conditions_summary_2_daily because other objects depend on it
+psql:include/cagg_on_cagg_common.sql:173: ERROR:  cannot drop view conditions_summary_2_daily because other objects depend on it
 CALL refresh_continuous_aggregate(:'CAGG_NAME_1ST_LEVEL', NULL, NULL);
-psql:include/cagg_on_cagg_common.sql:168: NOTICE:  continuous aggregate "conditions_summary_1_hourly" is already up-to-date
+psql:include/cagg_on_cagg_common.sql:174: NOTICE:  continuous aggregate "conditions_summary_1_hourly" is already up-to-date
 CALL refresh_continuous_aggregate(:'CAGG_NAME_2TH_LEVEL', NULL, NULL);
-psql:include/cagg_on_cagg_common.sql:169: NOTICE:  continuous aggregate "conditions_summary_2_daily" is already up-to-date
+psql:include/cagg_on_cagg_common.sql:175: NOTICE:  continuous aggregate "conditions_summary_2_daily" is already up-to-date
 \set ON_ERROR_STOP 1
 -- DROP the 3TH level CAGG don't affect others
 DROP MATERIALIZED VIEW :CAGG_NAME_3TH_LEVEL;
-psql:include/cagg_on_cagg_common.sql:173: NOTICE:  drop cascades to table _timescaledb_internal._hyper_20_24_chunk
+psql:include/cagg_on_cagg_common.sql:179: NOTICE:  drop cascades to table _timescaledb_internal._hyper_20_24_chunk
 \set ON_ERROR_STOP 0
 -- should error because it was dropped
-SELECT * FROM :CAGG_NAME_3TH_LEVEL ORDER BY bucket, device_id;
-psql:include/cagg_on_cagg_common.sql:176: ERROR:  relation "conditions_summary_3_weekly" does not exist at character 15
+SELECT * FROM :CAGG_NAME_3TH_LEVEL;
+psql:include/cagg_on_cagg_common.sql:182: ERROR:  relation "conditions_summary_3_weekly" does not exist at character 15
 \set ON_ERROR_STOP 1
 -- should work because dropping the top level CAGG
 -- don't affect the down level CAGGs
 TRUNCATE :CAGG_NAME_2TH_LEVEL,:CAGG_NAME_1ST_LEVEL;
 CALL refresh_continuous_aggregate(:'CAGG_NAME_2TH_LEVEL', NULL, NULL);
 CALL refresh_continuous_aggregate(:'CAGG_NAME_1ST_LEVEL', NULL, NULL);
-SELECT * FROM :CAGG_NAME_1ST_LEVEL ORDER BY bucket, device_id;
+SELECT * FROM :CAGG_NAME_1ST_LEVEL;
           bucket          | temperature | device_id 
 --------------------------+-------------+-----------
  Sat Jan 01 00:00:00 2022 |          10 |         1
- Sat Jan 01 01:00:00 2022 |           5 |         2
  Sat Jan 01 01:00:00 2022 |           2 |          
+ Sat Jan 01 01:00:00 2022 |           5 |         2
  Sun Jan 02 01:00:00 2022 |          20 |         3
  Mon Jan 03 01:00:00 2022 |           2 |          
 (5 rows)
 
-SELECT * FROM :CAGG_NAME_2TH_LEVEL ORDER BY bucket, temperature;
- bucket | temperature | device_id 
---------+-------------+-----------
+SELECT * FROM :CAGG_NAME_2TH_LEVEL;
+ bucket | temperature | device_id | name 
+--------+-------------+-----------+------
 (0 rows)
 
 -- DROP the 2TH level CAGG don't affect others
 DROP MATERIALIZED VIEW :CAGG_NAME_2TH_LEVEL;
 \set ON_ERROR_STOP 0
 -- should error because it was dropped
-SELECT * FROM :CAGG_NAME_2TH_LEVEL ORDER BY bucket, temperature;
-psql:include/cagg_on_cagg_common.sql:190: ERROR:  relation "conditions_summary_2_daily" does not exist at character 15
+SELECT * FROM :CAGG_NAME_2TH_LEVEL;
+psql:include/cagg_on_cagg_common.sql:196: ERROR:  relation "conditions_summary_2_daily" does not exist at character 15
 \set ON_ERROR_STOP 1
 -- should work because dropping the top level CAGG
 -- don't affect the down level CAGGs
-SELECT * FROM :CAGG_NAME_1ST_LEVEL ORDER BY bucket, device_id;
+SELECT * FROM :CAGG_NAME_1ST_LEVEL;
           bucket          | temperature | device_id 
 --------------------------+-------------+-----------
  Sat Jan 01 00:00:00 2022 |          10 |         1
- Sat Jan 01 01:00:00 2022 |           5 |         2
  Sat Jan 01 01:00:00 2022 |           2 |          
+ Sat Jan 01 01:00:00 2022 |           5 |         2
  Sun Jan 02 01:00:00 2022 |          20 |         3
  Mon Jan 03 01:00:00 2022 |           2 |          
 (5 rows)
 
 -- DROP the first CAGG should work
 DROP MATERIALIZED VIEW :CAGG_NAME_1ST_LEVEL;
-psql:include/cagg_on_cagg_common.sql:197: NOTICE:  drop cascades to table _timescaledb_internal._hyper_18_26_chunk
+psql:include/cagg_on_cagg_common.sql:203: NOTICE:  drop cascades to table _timescaledb_internal._hyper_18_26_chunk
 \set ON_ERROR_STOP 0
 -- should error because it was dropped
-SELECT * FROM :CAGG_NAME_1ST_LEVEL ORDER BY bucket, device_id;
-psql:include/cagg_on_cagg_common.sql:200: ERROR:  relation "conditions_summary_1_hourly" does not exist at character 15
+SELECT * FROM :CAGG_NAME_1ST_LEVEL;
+psql:include/cagg_on_cagg_common.sql:206: ERROR:  relation "conditions_summary_1_hourly" does not exist at character 15
 \set ON_ERROR_STOP 1
 --
 -- Validation test for variable bucket on top of fixed bucket
@@ -2475,7 +2551,8 @@ SELECT
   SUM(temperature) AS temperature,
   device_id
 FROM conditions
-GROUP BY 1,3
+GROUP BY 1, 3
+ORDER BY 1, 2, 3
 WITH NO DATA;
 -- CAGG on CAGG (2th level)
 CREATE MATERIALIZED VIEW :CAGG_NAME_2TH_LEVEL
@@ -2484,31 +2561,38 @@ SELECT
   time_bucket(:BUCKET_WIDTH_2TH, "bucket") AS bucket,
   SUM(temperature) AS temperature
 \if :IS_JOIN
-  , :CAGG_NAME_1ST_LEVEL.device_id
-  FROM :CAGG_NAME_1ST_LEVEL, devices
-  WHERE devices.device_id = :CAGG_NAME_1ST_LEVEL.device_id
-  GROUP BY 1,3
+  , devices.device_id
+  , devices.name
+  FROM :CAGG_NAME_1ST_LEVEL
+  JOIN devices ON devices.device_id = :CAGG_NAME_1ST_LEVEL.device_id
+  GROUP BY 1, 3, 4
+  ORDER BY 1, 2, 3, 4
 \else
   FROM :CAGG_NAME_1ST_LEVEL
   GROUP BY 1
+  ORDER BY 1, 2
 \endif
 WITH NO DATA;
 -- CAGG on CAGG (3th level)
 CREATE MATERIALIZED VIEW :CAGG_NAME_3TH_LEVEL
-  WITH (timescaledb.continuous, timescaledb.materialized_only=true) AS
-  SELECT
-    time_bucket(:BUCKET_WIDTH_3TH, "bucket") AS bucket,
-    SUM(temperature) AS temperature
-  \if :IS_JOIN
-    , :CAGG_NAME_2TH_LEVEL.device_id
-    FROM :CAGG_NAME_2TH_LEVEL, devices
-    WHERE devices.device_id = :CAGG_NAME_2TH_LEVEL.device_id
-    GROUP BY 1,3
-  \else
-    FROM :CAGG_NAME_2TH_LEVEL
-    GROUP BY 1
-  \endif
-  WITH NO DATA;
+WITH (timescaledb.continuous, timescaledb.materialized_only=true) AS
+SELECT
+  time_bucket(:BUCKET_WIDTH_3TH, "bucket") AS bucket,
+  SUM(temperature) AS temperature
+\if :IS_JOIN
+  , :CAGG_NAME_2TH_LEVEL.device_id
+  , :CAGG_NAME_2TH_LEVEL.name
+  , devices.location
+  FROM :CAGG_NAME_2TH_LEVEL
+  JOIN devices ON devices.device_id = :CAGG_NAME_2TH_LEVEL.device_id
+  GROUP BY 1, 3, 4, 5
+  ORDER BY 1, 2, 3, 4, 5
+\else
+  FROM :CAGG_NAME_2TH_LEVEL
+  GROUP BY 1
+  ORDER BY 1, 2
+\endif
+WITH NO DATA;
 -- Check chunk_interval
 \if :IS_TIME_DIMENSION
   SELECT h.table_name AS name, _timescaledb_functions.to_interval(d.interval_length) AS chunk_interval
@@ -2542,23 +2626,27 @@ CREATE MATERIALIZED VIEW :CAGG_NAME_3TH_LEVEL
   ORDER BY 1, 2;
 \endif
 -- No data because the CAGGs are just for materialized data
-SELECT * FROM :CAGG_NAME_1ST_LEVEL ORDER BY bucket;
+SELECT * FROM :CAGG_NAME_1ST_LEVEL;
  bucket | temperature | device_id 
 --------+-------------+-----------
 (0 rows)
 
-SELECT * FROM :CAGG_NAME_2TH_LEVEL ORDER BY bucket, temperature;
- bucket | temperature | device_id 
---------+-------------+-----------
+SELECT * FROM :CAGG_NAME_2TH_LEVEL;
+ bucket | temperature | device_id | name 
+--------+-------------+-----------+------
 (0 rows)
 
---SELECT * FROM :CAGG_NAME_3TH_LEVEL ORDER BY bucket;
+SELECT * FROM :CAGG_NAME_3TH_LEVEL;
+ bucket | temperature | device_id | name | location 
+--------+-------------+-----------+------+----------
+(0 rows)
+
 -- Turn CAGGs into Realtime
 ALTER MATERIALIZED VIEW :CAGG_NAME_1ST_LEVEL SET (timescaledb.materialized_only=false);
 ALTER MATERIALIZED VIEW :CAGG_NAME_2TH_LEVEL SET (timescaledb.materialized_only=false);
---ALTER MATERIALIZED VIEW :CAGG_NAME_3TH_LEVEL SET (timescaledb.materialized_only=false);
+ALTER MATERIALIZED VIEW :CAGG_NAME_3TH_LEVEL SET (timescaledb.materialized_only=false);
 -- Realtime data
-SELECT * FROM :CAGG_NAME_1ST_LEVEL ORDER BY bucket;
+SELECT * FROM :CAGG_NAME_1ST_LEVEL;
             bucket            | temperature | device_id 
 ------------------------------+-------------+-----------
  Sat Jan 01 00:00:00 2022 UTC |          10 |         1
@@ -2566,15 +2654,22 @@ SELECT * FROM :CAGG_NAME_1ST_LEVEL ORDER BY bucket;
  Sun Jan 02 01:00:00 2022 UTC |          20 |         3
 (3 rows)
 
-SELECT * FROM :CAGG_NAME_2TH_LEVEL ORDER BY bucket, temperature;
-            bucket            | temperature | device_id 
-------------------------------+-------------+-----------
- Sat Jan 01 00:00:00 2022 UTC |           5 |         2
- Sat Jan 01 00:00:00 2022 UTC |          10 |         1
- Sun Jan 02 00:00:00 2022 UTC |          20 |         3
+SELECT * FROM :CAGG_NAME_2TH_LEVEL;
+            bucket            | temperature | device_id |   name   
+------------------------------+-------------+-----------+----------
+ Sat Jan 01 00:00:00 2022 UTC |           5 |         2 | thermo_2
+ Sat Jan 01 00:00:00 2022 UTC |          10 |         1 | thermo_1
+ Sun Jan 02 00:00:00 2022 UTC |          20 |         3 | thermo_3
 (3 rows)
 
---SELECT * FROM :CAGG_NAME_3TH_LEVEL ORDER BY bucket;
+SELECT * FROM :CAGG_NAME_3TH_LEVEL;
+            bucket            | temperature | device_id |   name   | location 
+------------------------------+-------------+-----------+----------+----------
+ Mon Dec 27 00:00:00 2021 UTC |           5 |         2 | thermo_2 | Berlin
+ Mon Dec 27 00:00:00 2021 UTC |          10 |         1 | thermo_1 | Moscow
+ Mon Dec 27 00:00:00 2021 UTC |          20 |         3 | thermo_3 | London
+(3 rows)
+
 -- Turn CAGGs into materialized only again
 ALTER MATERIALIZED VIEW :CAGG_NAME_1ST_LEVEL SET (timescaledb.materialized_only=true);
 ALTER MATERIALIZED VIEW :CAGG_NAME_2TH_LEVEL SET (timescaledb.materialized_only=true);
@@ -2584,7 +2679,7 @@ CALL refresh_continuous_aggregate(:'CAGG_NAME_1ST_LEVEL', NULL, NULL);
 CALL refresh_continuous_aggregate(:'CAGG_NAME_2TH_LEVEL', NULL, NULL);
 CALL refresh_continuous_aggregate(:'CAGG_NAME_3TH_LEVEL', NULL, NULL);
 -- Materialized data
-SELECT * FROM :CAGG_NAME_1ST_LEVEL ORDER BY bucket;
+SELECT * FROM :CAGG_NAME_1ST_LEVEL;
             bucket            | temperature | device_id 
 ------------------------------+-------------+-----------
  Sat Jan 01 00:00:00 2022 UTC |          10 |         1
@@ -2592,20 +2687,20 @@ SELECT * FROM :CAGG_NAME_1ST_LEVEL ORDER BY bucket;
  Sun Jan 02 01:00:00 2022 UTC |          20 |         3
 (3 rows)
 
-SELECT * FROM :CAGG_NAME_2TH_LEVEL ORDER BY bucket, temperature;
-            bucket            | temperature | device_id 
-------------------------------+-------------+-----------
- Sat Jan 01 00:00:00 2022 UTC |           5 |         2
- Sat Jan 01 00:00:00 2022 UTC |          10 |         1
- Sun Jan 02 00:00:00 2022 UTC |          20 |         3
+SELECT * FROM :CAGG_NAME_2TH_LEVEL;
+            bucket            | temperature | device_id |   name   
+------------------------------+-------------+-----------+----------
+ Sat Jan 01 00:00:00 2022 UTC |           5 |         2 | thermo_2
+ Sat Jan 01 00:00:00 2022 UTC |          10 |         1 | thermo_1
+ Sun Jan 02 00:00:00 2022 UTC |          20 |         3 | thermo_3
 (3 rows)
 
-SELECT * FROM :CAGG_NAME_3TH_LEVEL ORDER BY bucket;
-            bucket            | temperature | device_id 
-------------------------------+-------------+-----------
- Mon Dec 27 00:00:00 2021 UTC |          20 |         3
- Mon Dec 27 00:00:00 2021 UTC |           5 |         2
- Mon Dec 27 00:00:00 2021 UTC |          10 |         1
+SELECT * FROM :CAGG_NAME_3TH_LEVEL;
+            bucket            | temperature | device_id |   name   | location 
+------------------------------+-------------+-----------+----------+----------
+ Mon Dec 27 00:00:00 2021 UTC |           5 |         2 | thermo_2 | Berlin
+ Mon Dec 27 00:00:00 2021 UTC |          10 |         1 | thermo_1 | Moscow
+ Mon Dec 27 00:00:00 2021 UTC |          20 |         3 | thermo_3 | London
 (3 rows)
 
 \if :IS_TIME_DIMENSION
@@ -2620,7 +2715,7 @@ INSERT INTO conditions ("time", temperature) VALUES (2,  2);
 INSERT INTO conditions ("time", temperature) VALUES (10, 2);
 \endif
 -- No changes
-SELECT * FROM :CAGG_NAME_1ST_LEVEL ORDER BY bucket;
+SELECT * FROM :CAGG_NAME_1ST_LEVEL;
             bucket            | temperature | device_id 
 ------------------------------+-------------+-----------
  Sat Jan 01 00:00:00 2022 UTC |          10 |         1
@@ -2628,20 +2723,20 @@ SELECT * FROM :CAGG_NAME_1ST_LEVEL ORDER BY bucket;
  Sun Jan 02 01:00:00 2022 UTC |          20 |         3
 (3 rows)
 
-SELECT * FROM :CAGG_NAME_2TH_LEVEL ORDER BY bucket, temperature;
-            bucket            | temperature | device_id 
-------------------------------+-------------+-----------
- Sat Jan 01 00:00:00 2022 UTC |           5 |         2
- Sat Jan 01 00:00:00 2022 UTC |          10 |         1
- Sun Jan 02 00:00:00 2022 UTC |          20 |         3
+SELECT * FROM :CAGG_NAME_2TH_LEVEL;
+            bucket            | temperature | device_id |   name   
+------------------------------+-------------+-----------+----------
+ Sat Jan 01 00:00:00 2022 UTC |           5 |         2 | thermo_2
+ Sat Jan 01 00:00:00 2022 UTC |          10 |         1 | thermo_1
+ Sun Jan 02 00:00:00 2022 UTC |          20 |         3 | thermo_3
 (3 rows)
 
-SELECT * FROM :CAGG_NAME_3TH_LEVEL ORDER BY bucket;
-            bucket            | temperature | device_id 
-------------------------------+-------------+-----------
- Mon Dec 27 00:00:00 2021 UTC |          20 |         3
- Mon Dec 27 00:00:00 2021 UTC |           5 |         2
- Mon Dec 27 00:00:00 2021 UTC |          10 |         1
+SELECT * FROM :CAGG_NAME_3TH_LEVEL;
+            bucket            | temperature | device_id |   name   | location 
+------------------------------+-------------+-----------+----------+----------
+ Mon Dec 27 00:00:00 2021 UTC |           5 |         2 | thermo_2 | Berlin
+ Mon Dec 27 00:00:00 2021 UTC |          10 |         1 | thermo_1 | Moscow
+ Mon Dec 27 00:00:00 2021 UTC |          20 |         3 | thermo_3 | London
 (3 rows)
 
 -- Turn CAGGs into Realtime
@@ -2649,7 +2744,7 @@ ALTER MATERIALIZED VIEW :CAGG_NAME_1ST_LEVEL SET (timescaledb.materialized_only=
 ALTER MATERIALIZED VIEW :CAGG_NAME_2TH_LEVEL SET (timescaledb.materialized_only=false);
 ALTER MATERIALIZED VIEW :CAGG_NAME_3TH_LEVEL SET (timescaledb.materialized_only=false);
 -- Realtime changes, just new region
-SELECT * FROM :CAGG_NAME_1ST_LEVEL ORDER BY bucket;
+SELECT * FROM :CAGG_NAME_1ST_LEVEL;
             bucket            | temperature | device_id 
 ------------------------------+-------------+-----------
  Sat Jan 01 00:00:00 2022 UTC |          10 |         1
@@ -2658,20 +2753,20 @@ SELECT * FROM :CAGG_NAME_1ST_LEVEL ORDER BY bucket;
  Mon Jan 03 01:00:00 2022 UTC |           2 |          
 (4 rows)
 
-SELECT * FROM :CAGG_NAME_2TH_LEVEL ORDER BY bucket, temperature;
-            bucket            | temperature | device_id 
-------------------------------+-------------+-----------
- Sat Jan 01 00:00:00 2022 UTC |           5 |         2
- Sat Jan 01 00:00:00 2022 UTC |          10 |         1
- Sun Jan 02 00:00:00 2022 UTC |          20 |         3
+SELECT * FROM :CAGG_NAME_2TH_LEVEL;
+            bucket            | temperature | device_id |   name   
+------------------------------+-------------+-----------+----------
+ Sat Jan 01 00:00:00 2022 UTC |           5 |         2 | thermo_2
+ Sat Jan 01 00:00:00 2022 UTC |          10 |         1 | thermo_1
+ Sun Jan 02 00:00:00 2022 UTC |          20 |         3 | thermo_3
 (3 rows)
 
-SELECT * FROM :CAGG_NAME_3TH_LEVEL ORDER BY bucket;
-            bucket            | temperature | device_id 
-------------------------------+-------------+-----------
- Mon Dec 27 00:00:00 2021 UTC |          10 |         1
- Mon Dec 27 00:00:00 2021 UTC |           5 |         2
- Mon Dec 27 00:00:00 2021 UTC |          20 |         3
+SELECT * FROM :CAGG_NAME_3TH_LEVEL;
+            bucket            | temperature | device_id |   name   | location 
+------------------------------+-------------+-----------+----------+----------
+ Mon Dec 27 00:00:00 2021 UTC |           5 |         2 | thermo_2 | Berlin
+ Mon Dec 27 00:00:00 2021 UTC |          10 |         1 | thermo_1 | Moscow
+ Mon Dec 27 00:00:00 2021 UTC |          20 |         3 | thermo_3 | London
 (3 rows)
 
 -- Turn CAGGs into materialized only again
@@ -2683,7 +2778,7 @@ CALL refresh_continuous_aggregate(:'CAGG_NAME_1ST_LEVEL', NULL, NULL);
 CALL refresh_continuous_aggregate(:'CAGG_NAME_2TH_LEVEL', NULL, NULL);
 CALL refresh_continuous_aggregate(:'CAGG_NAME_3TH_LEVEL', NULL, NULL);
 -- All changes are materialized
-SELECT * FROM :CAGG_NAME_1ST_LEVEL ORDER BY bucket;
+SELECT * FROM :CAGG_NAME_1ST_LEVEL;
             bucket            | temperature | device_id 
 ------------------------------+-------------+-----------
  Sat Jan 01 00:00:00 2022 UTC |          10 |         1
@@ -2693,20 +2788,20 @@ SELECT * FROM :CAGG_NAME_1ST_LEVEL ORDER BY bucket;
  Mon Jan 03 01:00:00 2022 UTC |           2 |          
 (5 rows)
 
-SELECT * FROM :CAGG_NAME_2TH_LEVEL ORDER BY bucket, temperature;
-            bucket            | temperature | device_id 
-------------------------------+-------------+-----------
- Sat Jan 01 00:00:00 2022 UTC |           5 |         2
- Sat Jan 01 00:00:00 2022 UTC |          10 |         1
- Sun Jan 02 00:00:00 2022 UTC |          20 |         3
+SELECT * FROM :CAGG_NAME_2TH_LEVEL;
+            bucket            | temperature | device_id |   name   
+------------------------------+-------------+-----------+----------
+ Sat Jan 01 00:00:00 2022 UTC |           5 |         2 | thermo_2
+ Sat Jan 01 00:00:00 2022 UTC |          10 |         1 | thermo_1
+ Sun Jan 02 00:00:00 2022 UTC |          20 |         3 | thermo_3
 (3 rows)
 
-SELECT * FROM :CAGG_NAME_3TH_LEVEL ORDER BY bucket;
-            bucket            | temperature | device_id 
-------------------------------+-------------+-----------
- Mon Dec 27 00:00:00 2021 UTC |          20 |         3
- Mon Dec 27 00:00:00 2021 UTC |           5 |         2
- Mon Dec 27 00:00:00 2021 UTC |          10 |         1
+SELECT * FROM :CAGG_NAME_3TH_LEVEL;
+            bucket            | temperature | device_id |   name   | location 
+------------------------------+-------------+-----------+----------+----------
+ Mon Dec 27 00:00:00 2021 UTC |           5 |         2 | thermo_2 | Berlin
+ Mon Dec 27 00:00:00 2021 UTC |          10 |         1 | thermo_1 | Moscow
+ Mon Dec 27 00:00:00 2021 UTC |          20 |         3 | thermo_3 | London
 (3 rows)
 
 -- TRUNCATE tests
@@ -2714,102 +2809,102 @@ TRUNCATE :CAGG_NAME_2TH_LEVEL;
 -- This full refresh will remove all the data from the 3TH level cagg
 CALL refresh_continuous_aggregate(:'CAGG_NAME_3TH_LEVEL', NULL, NULL);
 -- Should return no rows
-SELECT * FROM :CAGG_NAME_2TH_LEVEL ORDER BY bucket;
- bucket | temperature | device_id 
---------+-------------+-----------
+SELECT * FROM :CAGG_NAME_2TH_LEVEL;
+ bucket | temperature | device_id | name 
+--------+-------------+-----------+------
 (0 rows)
 
-SELECT * FROM :CAGG_NAME_3TH_LEVEL ORDER BY bucket;
- bucket | temperature | device_id 
---------+-------------+-----------
+SELECT * FROM :CAGG_NAME_3TH_LEVEL;
+ bucket | temperature | device_id | name | location 
+--------+-------------+-----------+------+----------
 (0 rows)
 
 -- If we have all the data in the bottom levels caggs we can rebuild
 CALL refresh_continuous_aggregate(:'CAGG_NAME_2TH_LEVEL', NULL, NULL);
 CALL refresh_continuous_aggregate(:'CAGG_NAME_3TH_LEVEL', NULL, NULL);
 -- Now we have all the data
-SELECT * FROM :CAGG_NAME_2TH_LEVEL ORDER BY bucket, temperature;
-            bucket            | temperature | device_id 
-------------------------------+-------------+-----------
- Sat Jan 01 00:00:00 2022 UTC |           5 |         2
- Sat Jan 01 00:00:00 2022 UTC |          10 |         1
- Sun Jan 02 00:00:00 2022 UTC |          20 |         3
+SELECT * FROM :CAGG_NAME_2TH_LEVEL;
+            bucket            | temperature | device_id |   name   
+------------------------------+-------------+-----------+----------
+ Sat Jan 01 00:00:00 2022 UTC |           5 |         2 | thermo_2
+ Sat Jan 01 00:00:00 2022 UTC |          10 |         1 | thermo_1
+ Sun Jan 02 00:00:00 2022 UTC |          20 |         3 | thermo_3
 (3 rows)
 
-SELECT * FROM :CAGG_NAME_3TH_LEVEL ORDER BY bucket;
-            bucket            | temperature | device_id 
-------------------------------+-------------+-----------
- Mon Dec 27 00:00:00 2021 UTC |          20 |         3
- Mon Dec 27 00:00:00 2021 UTC |           5 |         2
- Mon Dec 27 00:00:00 2021 UTC |          10 |         1
+SELECT * FROM :CAGG_NAME_3TH_LEVEL;
+            bucket            | temperature | device_id |   name   | location 
+------------------------------+-------------+-----------+----------+----------
+ Mon Dec 27 00:00:00 2021 UTC |           5 |         2 | thermo_2 | Berlin
+ Mon Dec 27 00:00:00 2021 UTC |          10 |         1 | thermo_1 | Moscow
+ Mon Dec 27 00:00:00 2021 UTC |          20 |         3 | thermo_3 | London
 (3 rows)
 
 -- DROP tests
 \set ON_ERROR_STOP 0
 -- should error because it depends of other CAGGs
 DROP MATERIALIZED VIEW :CAGG_NAME_1ST_LEVEL;
-psql:include/cagg_on_cagg_common.sql:166: ERROR:  cannot drop view conditions_summary_1_hourly because other objects depend on it
+psql:include/cagg_on_cagg_common.sql:172: ERROR:  cannot drop view conditions_summary_1_hourly because other objects depend on it
 DROP MATERIALIZED VIEW :CAGG_NAME_2TH_LEVEL;
-psql:include/cagg_on_cagg_common.sql:167: ERROR:  cannot drop view conditions_summary_2_daily because other objects depend on it
+psql:include/cagg_on_cagg_common.sql:173: ERROR:  cannot drop view conditions_summary_2_daily because other objects depend on it
 CALL refresh_continuous_aggregate(:'CAGG_NAME_1ST_LEVEL', NULL, NULL);
-psql:include/cagg_on_cagg_common.sql:168: NOTICE:  continuous aggregate "conditions_summary_1_hourly" is already up-to-date
+psql:include/cagg_on_cagg_common.sql:174: NOTICE:  continuous aggregate "conditions_summary_1_hourly" is already up-to-date
 CALL refresh_continuous_aggregate(:'CAGG_NAME_2TH_LEVEL', NULL, NULL);
-psql:include/cagg_on_cagg_common.sql:169: NOTICE:  continuous aggregate "conditions_summary_2_daily" is already up-to-date
+psql:include/cagg_on_cagg_common.sql:175: NOTICE:  continuous aggregate "conditions_summary_2_daily" is already up-to-date
 \set ON_ERROR_STOP 1
 -- DROP the 3TH level CAGG don't affect others
 DROP MATERIALIZED VIEW :CAGG_NAME_3TH_LEVEL;
-psql:include/cagg_on_cagg_common.sql:173: NOTICE:  drop cascades to table _timescaledb_internal._hyper_29_30_chunk
+psql:include/cagg_on_cagg_common.sql:179: NOTICE:  drop cascades to table _timescaledb_internal._hyper_29_30_chunk
 \set ON_ERROR_STOP 0
 -- should error because it was dropped
-SELECT * FROM :CAGG_NAME_3TH_LEVEL ORDER BY bucket, device_id;
-psql:include/cagg_on_cagg_common.sql:176: ERROR:  relation "conditions_summary_3_weekly" does not exist at character 15
+SELECT * FROM :CAGG_NAME_3TH_LEVEL;
+psql:include/cagg_on_cagg_common.sql:182: ERROR:  relation "conditions_summary_3_weekly" does not exist at character 15
 \set ON_ERROR_STOP 1
 -- should work because dropping the top level CAGG
 -- don't affect the down level CAGGs
 TRUNCATE :CAGG_NAME_2TH_LEVEL,:CAGG_NAME_1ST_LEVEL;
 CALL refresh_continuous_aggregate(:'CAGG_NAME_2TH_LEVEL', NULL, NULL);
 CALL refresh_continuous_aggregate(:'CAGG_NAME_1ST_LEVEL', NULL, NULL);
-SELECT * FROM :CAGG_NAME_1ST_LEVEL ORDER BY bucket, device_id;
+SELECT * FROM :CAGG_NAME_1ST_LEVEL;
             bucket            | temperature | device_id 
 ------------------------------+-------------+-----------
  Sat Jan 01 00:00:00 2022 UTC |          10 |         1
- Sat Jan 01 01:00:00 2022 UTC |           5 |         2
  Sat Jan 01 01:00:00 2022 UTC |           2 |          
+ Sat Jan 01 01:00:00 2022 UTC |           5 |         2
  Sun Jan 02 01:00:00 2022 UTC |          20 |         3
  Mon Jan 03 01:00:00 2022 UTC |           2 |          
 (5 rows)
 
-SELECT * FROM :CAGG_NAME_2TH_LEVEL ORDER BY bucket, temperature;
- bucket | temperature | device_id 
---------+-------------+-----------
+SELECT * FROM :CAGG_NAME_2TH_LEVEL;
+ bucket | temperature | device_id | name 
+--------+-------------+-----------+------
 (0 rows)
 
 -- DROP the 2TH level CAGG don't affect others
 DROP MATERIALIZED VIEW :CAGG_NAME_2TH_LEVEL;
 \set ON_ERROR_STOP 0
 -- should error because it was dropped
-SELECT * FROM :CAGG_NAME_2TH_LEVEL ORDER BY bucket, temperature;
-psql:include/cagg_on_cagg_common.sql:190: ERROR:  relation "conditions_summary_2_daily" does not exist at character 15
+SELECT * FROM :CAGG_NAME_2TH_LEVEL;
+psql:include/cagg_on_cagg_common.sql:196: ERROR:  relation "conditions_summary_2_daily" does not exist at character 15
 \set ON_ERROR_STOP 1
 -- should work because dropping the top level CAGG
 -- don't affect the down level CAGGs
-SELECT * FROM :CAGG_NAME_1ST_LEVEL ORDER BY bucket, device_id;
+SELECT * FROM :CAGG_NAME_1ST_LEVEL;
             bucket            | temperature | device_id 
 ------------------------------+-------------+-----------
  Sat Jan 01 00:00:00 2022 UTC |          10 |         1
- Sat Jan 01 01:00:00 2022 UTC |           5 |         2
  Sat Jan 01 01:00:00 2022 UTC |           2 |          
+ Sat Jan 01 01:00:00 2022 UTC |           5 |         2
  Sun Jan 02 01:00:00 2022 UTC |          20 |         3
  Mon Jan 03 01:00:00 2022 UTC |           2 |          
 (5 rows)
 
 -- DROP the first CAGG should work
 DROP MATERIALIZED VIEW :CAGG_NAME_1ST_LEVEL;
-psql:include/cagg_on_cagg_common.sql:197: NOTICE:  drop cascades to table _timescaledb_internal._hyper_27_32_chunk
+psql:include/cagg_on_cagg_common.sql:203: NOTICE:  drop cascades to table _timescaledb_internal._hyper_27_32_chunk
 \set ON_ERROR_STOP 0
 -- should error because it was dropped
-SELECT * FROM :CAGG_NAME_1ST_LEVEL ORDER BY bucket, device_id;
-psql:include/cagg_on_cagg_common.sql:200: ERROR:  relation "conditions_summary_1_hourly" does not exist at character 15
+SELECT * FROM :CAGG_NAME_1ST_LEVEL;
+psql:include/cagg_on_cagg_common.sql:206: ERROR:  relation "conditions_summary_1_hourly" does not exist at character 15
 \set ON_ERROR_STOP 1
 -- Default tests
 \set ON_ERROR_STOP 0
@@ -2877,7 +2972,8 @@ SELECT
   SUM(temperature) AS temperature,
   device_id
 FROM conditions
-GROUP BY 1,3
+GROUP BY 1, 3
+ORDER BY 1, 2, 3
 WITH NO DATA;
 -- CAGG on CAGG (2th level)
 CREATE MATERIALIZED VIEW :CAGG_NAME_2TH_LEVEL
@@ -2886,31 +2982,38 @@ SELECT
   time_bucket(:BUCKET_WIDTH_2TH, "bucket") AS bucket,
   SUM(temperature) AS temperature
 \if :IS_JOIN
-  , :CAGG_NAME_1ST_LEVEL.device_id
-  FROM :CAGG_NAME_1ST_LEVEL, devices
-  WHERE devices.device_id = :CAGG_NAME_1ST_LEVEL.device_id
-  GROUP BY 1,3
+  , devices.device_id
+  , devices.name
+  FROM :CAGG_NAME_1ST_LEVEL
+  JOIN devices ON devices.device_id = :CAGG_NAME_1ST_LEVEL.device_id
+  GROUP BY 1, 3, 4
+  ORDER BY 1, 2, 3, 4
 \else
   FROM :CAGG_NAME_1ST_LEVEL
   GROUP BY 1
+  ORDER BY 1, 2
 \endif
 WITH NO DATA;
 -- CAGG on CAGG (3th level)
 CREATE MATERIALIZED VIEW :CAGG_NAME_3TH_LEVEL
-  WITH (timescaledb.continuous, timescaledb.materialized_only=true) AS
-  SELECT
-    time_bucket(:BUCKET_WIDTH_3TH, "bucket") AS bucket,
-    SUM(temperature) AS temperature
-  \if :IS_JOIN
-    , :CAGG_NAME_2TH_LEVEL.device_id
-    FROM :CAGG_NAME_2TH_LEVEL, devices
-    WHERE devices.device_id = :CAGG_NAME_2TH_LEVEL.device_id
-    GROUP BY 1,3
-  \else
-    FROM :CAGG_NAME_2TH_LEVEL
-    GROUP BY 1
-  \endif
-  WITH NO DATA;
+WITH (timescaledb.continuous, timescaledb.materialized_only=true) AS
+SELECT
+  time_bucket(:BUCKET_WIDTH_3TH, "bucket") AS bucket,
+  SUM(temperature) AS temperature
+\if :IS_JOIN
+  , :CAGG_NAME_2TH_LEVEL.device_id
+  , :CAGG_NAME_2TH_LEVEL.name
+  , devices.location
+  FROM :CAGG_NAME_2TH_LEVEL
+  JOIN devices ON devices.device_id = :CAGG_NAME_2TH_LEVEL.device_id
+  GROUP BY 1, 3, 4, 5
+  ORDER BY 1, 2, 3, 4, 5
+\else
+  FROM :CAGG_NAME_2TH_LEVEL
+  GROUP BY 1
+  ORDER BY 1, 2
+\endif
+WITH NO DATA;
 -- Check chunk_interval
 \if :IS_TIME_DIMENSION
   SELECT h.table_name AS name, _timescaledb_functions.to_interval(d.interval_length) AS chunk_interval
@@ -2944,23 +3047,27 @@ CREATE MATERIALIZED VIEW :CAGG_NAME_3TH_LEVEL
   ORDER BY 1, 2;
 \endif
 -- No data because the CAGGs are just for materialized data
-SELECT * FROM :CAGG_NAME_1ST_LEVEL ORDER BY bucket;
+SELECT * FROM :CAGG_NAME_1ST_LEVEL;
  bucket | temperature | device_id 
 --------+-------------+-----------
 (0 rows)
 
-SELECT * FROM :CAGG_NAME_2TH_LEVEL ORDER BY bucket, temperature;
- bucket | temperature | device_id 
---------+-------------+-----------
+SELECT * FROM :CAGG_NAME_2TH_LEVEL;
+ bucket | temperature | device_id | name 
+--------+-------------+-----------+------
 (0 rows)
 
---SELECT * FROM :CAGG_NAME_3TH_LEVEL ORDER BY bucket;
+SELECT * FROM :CAGG_NAME_3TH_LEVEL;
+ bucket | temperature | device_id | name | location 
+--------+-------------+-----------+------+----------
+(0 rows)
+
 -- Turn CAGGs into Realtime
 ALTER MATERIALIZED VIEW :CAGG_NAME_1ST_LEVEL SET (timescaledb.materialized_only=false);
 ALTER MATERIALIZED VIEW :CAGG_NAME_2TH_LEVEL SET (timescaledb.materialized_only=false);
---ALTER MATERIALIZED VIEW :CAGG_NAME_3TH_LEVEL SET (timescaledb.materialized_only=false);
+ALTER MATERIALIZED VIEW :CAGG_NAME_3TH_LEVEL SET (timescaledb.materialized_only=false);
 -- Realtime data
-SELECT * FROM :CAGG_NAME_1ST_LEVEL ORDER BY bucket;
+SELECT * FROM :CAGG_NAME_1ST_LEVEL;
             bucket            | temperature | device_id 
 ------------------------------+-------------+-----------
  Sat Jan 01 00:00:00 2022 UTC |          10 |         1
@@ -2968,15 +3075,22 @@ SELECT * FROM :CAGG_NAME_1ST_LEVEL ORDER BY bucket;
  Sun Jan 02 01:00:00 2022 UTC |          20 |         3
 (3 rows)
 
-SELECT * FROM :CAGG_NAME_2TH_LEVEL ORDER BY bucket, temperature;
-            bucket            | temperature | device_id 
-------------------------------+-------------+-----------
- Sat Jan 01 00:00:00 2022 UTC |           5 |         2
- Sat Jan 01 00:00:00 2022 UTC |          10 |         1
- Sun Jan 02 00:00:00 2022 UTC |          20 |         3
+SELECT * FROM :CAGG_NAME_2TH_LEVEL;
+            bucket            | temperature | device_id |   name   
+------------------------------+-------------+-----------+----------
+ Sat Jan 01 00:00:00 2022 UTC |           5 |         2 | thermo_2
+ Sat Jan 01 00:00:00 2022 UTC |          10 |         1 | thermo_1
+ Sun Jan 02 00:00:00 2022 UTC |          20 |         3 | thermo_3
 (3 rows)
 
---SELECT * FROM :CAGG_NAME_3TH_LEVEL ORDER BY bucket;
+SELECT * FROM :CAGG_NAME_3TH_LEVEL;
+            bucket            | temperature | device_id |   name   | location 
+------------------------------+-------------+-----------+----------+----------
+ Mon Dec 27 00:00:00 2021 UTC |           5 |         2 | thermo_2 | Berlin
+ Mon Dec 27 00:00:00 2021 UTC |          10 |         1 | thermo_1 | Moscow
+ Mon Dec 27 00:00:00 2021 UTC |          20 |         3 | thermo_3 | London
+(3 rows)
+
 -- Turn CAGGs into materialized only again
 ALTER MATERIALIZED VIEW :CAGG_NAME_1ST_LEVEL SET (timescaledb.materialized_only=true);
 ALTER MATERIALIZED VIEW :CAGG_NAME_2TH_LEVEL SET (timescaledb.materialized_only=true);
@@ -2986,7 +3100,7 @@ CALL refresh_continuous_aggregate(:'CAGG_NAME_1ST_LEVEL', NULL, NULL);
 CALL refresh_continuous_aggregate(:'CAGG_NAME_2TH_LEVEL', NULL, NULL);
 CALL refresh_continuous_aggregate(:'CAGG_NAME_3TH_LEVEL', NULL, NULL);
 -- Materialized data
-SELECT * FROM :CAGG_NAME_1ST_LEVEL ORDER BY bucket;
+SELECT * FROM :CAGG_NAME_1ST_LEVEL;
             bucket            | temperature | device_id 
 ------------------------------+-------------+-----------
  Sat Jan 01 00:00:00 2022 UTC |          10 |         1
@@ -2994,20 +3108,20 @@ SELECT * FROM :CAGG_NAME_1ST_LEVEL ORDER BY bucket;
  Sun Jan 02 01:00:00 2022 UTC |          20 |         3
 (3 rows)
 
-SELECT * FROM :CAGG_NAME_2TH_LEVEL ORDER BY bucket, temperature;
-            bucket            | temperature | device_id 
-------------------------------+-------------+-----------
- Sat Jan 01 00:00:00 2022 UTC |           5 |         2
- Sat Jan 01 00:00:00 2022 UTC |          10 |         1
- Sun Jan 02 00:00:00 2022 UTC |          20 |         3
+SELECT * FROM :CAGG_NAME_2TH_LEVEL;
+            bucket            | temperature | device_id |   name   
+------------------------------+-------------+-----------+----------
+ Sat Jan 01 00:00:00 2022 UTC |           5 |         2 | thermo_2
+ Sat Jan 01 00:00:00 2022 UTC |          10 |         1 | thermo_1
+ Sun Jan 02 00:00:00 2022 UTC |          20 |         3 | thermo_3
 (3 rows)
 
-SELECT * FROM :CAGG_NAME_3TH_LEVEL ORDER BY bucket;
-            bucket            | temperature | device_id 
-------------------------------+-------------+-----------
- Mon Dec 27 00:00:00 2021 UTC |          20 |         3
- Mon Dec 27 00:00:00 2021 UTC |           5 |         2
- Mon Dec 27 00:00:00 2021 UTC |          10 |         1
+SELECT * FROM :CAGG_NAME_3TH_LEVEL;
+            bucket            | temperature | device_id |   name   | location 
+------------------------------+-------------+-----------+----------+----------
+ Mon Dec 27 00:00:00 2021 UTC |           5 |         2 | thermo_2 | Berlin
+ Mon Dec 27 00:00:00 2021 UTC |          10 |         1 | thermo_1 | Moscow
+ Mon Dec 27 00:00:00 2021 UTC |          20 |         3 | thermo_3 | London
 (3 rows)
 
 \if :IS_TIME_DIMENSION
@@ -3022,7 +3136,7 @@ INSERT INTO conditions ("time", temperature) VALUES (2,  2);
 INSERT INTO conditions ("time", temperature) VALUES (10, 2);
 \endif
 -- No changes
-SELECT * FROM :CAGG_NAME_1ST_LEVEL ORDER BY bucket;
+SELECT * FROM :CAGG_NAME_1ST_LEVEL;
             bucket            | temperature | device_id 
 ------------------------------+-------------+-----------
  Sat Jan 01 00:00:00 2022 UTC |          10 |         1
@@ -3030,20 +3144,20 @@ SELECT * FROM :CAGG_NAME_1ST_LEVEL ORDER BY bucket;
  Sun Jan 02 01:00:00 2022 UTC |          20 |         3
 (3 rows)
 
-SELECT * FROM :CAGG_NAME_2TH_LEVEL ORDER BY bucket, temperature;
-            bucket            | temperature | device_id 
-------------------------------+-------------+-----------
- Sat Jan 01 00:00:00 2022 UTC |           5 |         2
- Sat Jan 01 00:00:00 2022 UTC |          10 |         1
- Sun Jan 02 00:00:00 2022 UTC |          20 |         3
+SELECT * FROM :CAGG_NAME_2TH_LEVEL;
+            bucket            | temperature | device_id |   name   
+------------------------------+-------------+-----------+----------
+ Sat Jan 01 00:00:00 2022 UTC |           5 |         2 | thermo_2
+ Sat Jan 01 00:00:00 2022 UTC |          10 |         1 | thermo_1
+ Sun Jan 02 00:00:00 2022 UTC |          20 |         3 | thermo_3
 (3 rows)
 
-SELECT * FROM :CAGG_NAME_3TH_LEVEL ORDER BY bucket;
-            bucket            | temperature | device_id 
-------------------------------+-------------+-----------
- Mon Dec 27 00:00:00 2021 UTC |          20 |         3
- Mon Dec 27 00:00:00 2021 UTC |           5 |         2
- Mon Dec 27 00:00:00 2021 UTC |          10 |         1
+SELECT * FROM :CAGG_NAME_3TH_LEVEL;
+            bucket            | temperature | device_id |   name   | location 
+------------------------------+-------------+-----------+----------+----------
+ Mon Dec 27 00:00:00 2021 UTC |           5 |         2 | thermo_2 | Berlin
+ Mon Dec 27 00:00:00 2021 UTC |          10 |         1 | thermo_1 | Moscow
+ Mon Dec 27 00:00:00 2021 UTC |          20 |         3 | thermo_3 | London
 (3 rows)
 
 -- Turn CAGGs into Realtime
@@ -3051,7 +3165,7 @@ ALTER MATERIALIZED VIEW :CAGG_NAME_1ST_LEVEL SET (timescaledb.materialized_only=
 ALTER MATERIALIZED VIEW :CAGG_NAME_2TH_LEVEL SET (timescaledb.materialized_only=false);
 ALTER MATERIALIZED VIEW :CAGG_NAME_3TH_LEVEL SET (timescaledb.materialized_only=false);
 -- Realtime changes, just new region
-SELECT * FROM :CAGG_NAME_1ST_LEVEL ORDER BY bucket;
+SELECT * FROM :CAGG_NAME_1ST_LEVEL;
             bucket            | temperature | device_id 
 ------------------------------+-------------+-----------
  Sat Jan 01 00:00:00 2022 UTC |          10 |         1
@@ -3060,20 +3174,20 @@ SELECT * FROM :CAGG_NAME_1ST_LEVEL ORDER BY bucket;
  Mon Jan 03 01:00:00 2022 UTC |           2 |          
 (4 rows)
 
-SELECT * FROM :CAGG_NAME_2TH_LEVEL ORDER BY bucket, temperature;
-            bucket            | temperature | device_id 
-------------------------------+-------------+-----------
- Sat Jan 01 00:00:00 2022 UTC |           5 |         2
- Sat Jan 01 00:00:00 2022 UTC |          10 |         1
- Sun Jan 02 00:00:00 2022 UTC |          20 |         3
+SELECT * FROM :CAGG_NAME_2TH_LEVEL;
+            bucket            | temperature | device_id |   name   
+------------------------------+-------------+-----------+----------
+ Sat Jan 01 00:00:00 2022 UTC |           5 |         2 | thermo_2
+ Sat Jan 01 00:00:00 2022 UTC |          10 |         1 | thermo_1
+ Sun Jan 02 00:00:00 2022 UTC |          20 |         3 | thermo_3
 (3 rows)
 
-SELECT * FROM :CAGG_NAME_3TH_LEVEL ORDER BY bucket;
-            bucket            | temperature | device_id 
-------------------------------+-------------+-----------
- Mon Dec 27 00:00:00 2021 UTC |          10 |         1
- Mon Dec 27 00:00:00 2021 UTC |           5 |         2
- Mon Dec 27 00:00:00 2021 UTC |          20 |         3
+SELECT * FROM :CAGG_NAME_3TH_LEVEL;
+            bucket            | temperature | device_id |   name   | location 
+------------------------------+-------------+-----------+----------+----------
+ Mon Dec 27 00:00:00 2021 UTC |           5 |         2 | thermo_2 | Berlin
+ Mon Dec 27 00:00:00 2021 UTC |          10 |         1 | thermo_1 | Moscow
+ Mon Dec 27 00:00:00 2021 UTC |          20 |         3 | thermo_3 | London
 (3 rows)
 
 -- Turn CAGGs into materialized only again
@@ -3085,7 +3199,7 @@ CALL refresh_continuous_aggregate(:'CAGG_NAME_1ST_LEVEL', NULL, NULL);
 CALL refresh_continuous_aggregate(:'CAGG_NAME_2TH_LEVEL', NULL, NULL);
 CALL refresh_continuous_aggregate(:'CAGG_NAME_3TH_LEVEL', NULL, NULL);
 -- All changes are materialized
-SELECT * FROM :CAGG_NAME_1ST_LEVEL ORDER BY bucket;
+SELECT * FROM :CAGG_NAME_1ST_LEVEL;
             bucket            | temperature | device_id 
 ------------------------------+-------------+-----------
  Sat Jan 01 00:00:00 2022 UTC |          10 |         1
@@ -3095,20 +3209,20 @@ SELECT * FROM :CAGG_NAME_1ST_LEVEL ORDER BY bucket;
  Mon Jan 03 01:00:00 2022 UTC |           2 |          
 (5 rows)
 
-SELECT * FROM :CAGG_NAME_2TH_LEVEL ORDER BY bucket, temperature;
-            bucket            | temperature | device_id 
-------------------------------+-------------+-----------
- Sat Jan 01 00:00:00 2022 UTC |           5 |         2
- Sat Jan 01 00:00:00 2022 UTC |          10 |         1
- Sun Jan 02 00:00:00 2022 UTC |          20 |         3
+SELECT * FROM :CAGG_NAME_2TH_LEVEL;
+            bucket            | temperature | device_id |   name   
+------------------------------+-------------+-----------+----------
+ Sat Jan 01 00:00:00 2022 UTC |           5 |         2 | thermo_2
+ Sat Jan 01 00:00:00 2022 UTC |          10 |         1 | thermo_1
+ Sun Jan 02 00:00:00 2022 UTC |          20 |         3 | thermo_3
 (3 rows)
 
-SELECT * FROM :CAGG_NAME_3TH_LEVEL ORDER BY bucket;
-            bucket            | temperature | device_id 
-------------------------------+-------------+-----------
- Mon Dec 27 00:00:00 2021 UTC |          20 |         3
- Mon Dec 27 00:00:00 2021 UTC |           5 |         2
- Mon Dec 27 00:00:00 2021 UTC |          10 |         1
+SELECT * FROM :CAGG_NAME_3TH_LEVEL;
+            bucket            | temperature | device_id |   name   | location 
+------------------------------+-------------+-----------+----------+----------
+ Mon Dec 27 00:00:00 2021 UTC |           5 |         2 | thermo_2 | Berlin
+ Mon Dec 27 00:00:00 2021 UTC |          10 |         1 | thermo_1 | Moscow
+ Mon Dec 27 00:00:00 2021 UTC |          20 |         3 | thermo_3 | London
 (3 rows)
 
 -- TRUNCATE tests
@@ -3116,102 +3230,102 @@ TRUNCATE :CAGG_NAME_2TH_LEVEL;
 -- This full refresh will remove all the data from the 3TH level cagg
 CALL refresh_continuous_aggregate(:'CAGG_NAME_3TH_LEVEL', NULL, NULL);
 -- Should return no rows
-SELECT * FROM :CAGG_NAME_2TH_LEVEL ORDER BY bucket;
- bucket | temperature | device_id 
---------+-------------+-----------
+SELECT * FROM :CAGG_NAME_2TH_LEVEL;
+ bucket | temperature | device_id | name 
+--------+-------------+-----------+------
 (0 rows)
 
-SELECT * FROM :CAGG_NAME_3TH_LEVEL ORDER BY bucket;
- bucket | temperature | device_id 
---------+-------------+-----------
+SELECT * FROM :CAGG_NAME_3TH_LEVEL;
+ bucket | temperature | device_id | name | location 
+--------+-------------+-----------+------+----------
 (0 rows)
 
 -- If we have all the data in the bottom levels caggs we can rebuild
 CALL refresh_continuous_aggregate(:'CAGG_NAME_2TH_LEVEL', NULL, NULL);
 CALL refresh_continuous_aggregate(:'CAGG_NAME_3TH_LEVEL', NULL, NULL);
 -- Now we have all the data
-SELECT * FROM :CAGG_NAME_2TH_LEVEL ORDER BY bucket, temperature;
-            bucket            | temperature | device_id 
-------------------------------+-------------+-----------
- Sat Jan 01 00:00:00 2022 UTC |           5 |         2
- Sat Jan 01 00:00:00 2022 UTC |          10 |         1
- Sun Jan 02 00:00:00 2022 UTC |          20 |         3
+SELECT * FROM :CAGG_NAME_2TH_LEVEL;
+            bucket            | temperature | device_id |   name   
+------------------------------+-------------+-----------+----------
+ Sat Jan 01 00:00:00 2022 UTC |           5 |         2 | thermo_2
+ Sat Jan 01 00:00:00 2022 UTC |          10 |         1 | thermo_1
+ Sun Jan 02 00:00:00 2022 UTC |          20 |         3 | thermo_3
 (3 rows)
 
-SELECT * FROM :CAGG_NAME_3TH_LEVEL ORDER BY bucket;
-            bucket            | temperature | device_id 
-------------------------------+-------------+-----------
- Mon Dec 27 00:00:00 2021 UTC |          20 |         3
- Mon Dec 27 00:00:00 2021 UTC |           5 |         2
- Mon Dec 27 00:00:00 2021 UTC |          10 |         1
+SELECT * FROM :CAGG_NAME_3TH_LEVEL;
+            bucket            | temperature | device_id |   name   | location 
+------------------------------+-------------+-----------+----------+----------
+ Mon Dec 27 00:00:00 2021 UTC |           5 |         2 | thermo_2 | Berlin
+ Mon Dec 27 00:00:00 2021 UTC |          10 |         1 | thermo_1 | Moscow
+ Mon Dec 27 00:00:00 2021 UTC |          20 |         3 | thermo_3 | London
 (3 rows)
 
 -- DROP tests
 \set ON_ERROR_STOP 0
 -- should error because it depends of other CAGGs
 DROP MATERIALIZED VIEW :CAGG_NAME_1ST_LEVEL;
-psql:include/cagg_on_cagg_common.sql:166: ERROR:  cannot drop view conditions_summary_1_hourly because other objects depend on it
+psql:include/cagg_on_cagg_common.sql:172: ERROR:  cannot drop view conditions_summary_1_hourly because other objects depend on it
 DROP MATERIALIZED VIEW :CAGG_NAME_2TH_LEVEL;
-psql:include/cagg_on_cagg_common.sql:167: ERROR:  cannot drop view conditions_summary_2_daily because other objects depend on it
+psql:include/cagg_on_cagg_common.sql:173: ERROR:  cannot drop view conditions_summary_2_daily because other objects depend on it
 CALL refresh_continuous_aggregate(:'CAGG_NAME_1ST_LEVEL', NULL, NULL);
-psql:include/cagg_on_cagg_common.sql:168: NOTICE:  continuous aggregate "conditions_summary_1_hourly" is already up-to-date
+psql:include/cagg_on_cagg_common.sql:174: NOTICE:  continuous aggregate "conditions_summary_1_hourly" is already up-to-date
 CALL refresh_continuous_aggregate(:'CAGG_NAME_2TH_LEVEL', NULL, NULL);
-psql:include/cagg_on_cagg_common.sql:169: NOTICE:  continuous aggregate "conditions_summary_2_daily" is already up-to-date
+psql:include/cagg_on_cagg_common.sql:175: NOTICE:  continuous aggregate "conditions_summary_2_daily" is already up-to-date
 \set ON_ERROR_STOP 1
 -- DROP the 3TH level CAGG don't affect others
 DROP MATERIALIZED VIEW :CAGG_NAME_3TH_LEVEL;
-psql:include/cagg_on_cagg_common.sql:173: NOTICE:  drop cascades to table _timescaledb_internal._hyper_33_36_chunk
+psql:include/cagg_on_cagg_common.sql:179: NOTICE:  drop cascades to table _timescaledb_internal._hyper_33_36_chunk
 \set ON_ERROR_STOP 0
 -- should error because it was dropped
-SELECT * FROM :CAGG_NAME_3TH_LEVEL ORDER BY bucket, device_id;
-psql:include/cagg_on_cagg_common.sql:176: ERROR:  relation "conditions_summary_3_weekly" does not exist at character 15
+SELECT * FROM :CAGG_NAME_3TH_LEVEL;
+psql:include/cagg_on_cagg_common.sql:182: ERROR:  relation "conditions_summary_3_weekly" does not exist at character 15
 \set ON_ERROR_STOP 1
 -- should work because dropping the top level CAGG
 -- don't affect the down level CAGGs
 TRUNCATE :CAGG_NAME_2TH_LEVEL,:CAGG_NAME_1ST_LEVEL;
 CALL refresh_continuous_aggregate(:'CAGG_NAME_2TH_LEVEL', NULL, NULL);
 CALL refresh_continuous_aggregate(:'CAGG_NAME_1ST_LEVEL', NULL, NULL);
-SELECT * FROM :CAGG_NAME_1ST_LEVEL ORDER BY bucket, device_id;
+SELECT * FROM :CAGG_NAME_1ST_LEVEL;
             bucket            | temperature | device_id 
 ------------------------------+-------------+-----------
  Sat Jan 01 00:00:00 2022 UTC |          10 |         1
- Sat Jan 01 01:00:00 2022 UTC |           5 |         2
  Sat Jan 01 01:00:00 2022 UTC |           2 |          
+ Sat Jan 01 01:00:00 2022 UTC |           5 |         2
  Sun Jan 02 01:00:00 2022 UTC |          20 |         3
  Mon Jan 03 01:00:00 2022 UTC |           2 |          
 (5 rows)
 
-SELECT * FROM :CAGG_NAME_2TH_LEVEL ORDER BY bucket, temperature;
- bucket | temperature | device_id 
---------+-------------+-----------
+SELECT * FROM :CAGG_NAME_2TH_LEVEL;
+ bucket | temperature | device_id | name 
+--------+-------------+-----------+------
 (0 rows)
 
 -- DROP the 2TH level CAGG don't affect others
 DROP MATERIALIZED VIEW :CAGG_NAME_2TH_LEVEL;
 \set ON_ERROR_STOP 0
 -- should error because it was dropped
-SELECT * FROM :CAGG_NAME_2TH_LEVEL ORDER BY bucket, temperature;
-psql:include/cagg_on_cagg_common.sql:190: ERROR:  relation "conditions_summary_2_daily" does not exist at character 15
+SELECT * FROM :CAGG_NAME_2TH_LEVEL;
+psql:include/cagg_on_cagg_common.sql:196: ERROR:  relation "conditions_summary_2_daily" does not exist at character 15
 \set ON_ERROR_STOP 1
 -- should work because dropping the top level CAGG
 -- don't affect the down level CAGGs
-SELECT * FROM :CAGG_NAME_1ST_LEVEL ORDER BY bucket, device_id;
+SELECT * FROM :CAGG_NAME_1ST_LEVEL;
             bucket            | temperature | device_id 
 ------------------------------+-------------+-----------
  Sat Jan 01 00:00:00 2022 UTC |          10 |         1
- Sat Jan 01 01:00:00 2022 UTC |           5 |         2
  Sat Jan 01 01:00:00 2022 UTC |           2 |          
+ Sat Jan 01 01:00:00 2022 UTC |           5 |         2
  Sun Jan 02 01:00:00 2022 UTC |          20 |         3
  Mon Jan 03 01:00:00 2022 UTC |           2 |          
 (5 rows)
 
 -- DROP the first CAGG should work
 DROP MATERIALIZED VIEW :CAGG_NAME_1ST_LEVEL;
-psql:include/cagg_on_cagg_common.sql:197: NOTICE:  drop cascades to table _timescaledb_internal._hyper_31_38_chunk
+psql:include/cagg_on_cagg_common.sql:203: NOTICE:  drop cascades to table _timescaledb_internal._hyper_31_38_chunk
 \set ON_ERROR_STOP 0
 -- should error because it was dropped
-SELECT * FROM :CAGG_NAME_1ST_LEVEL ORDER BY bucket, device_id;
-psql:include/cagg_on_cagg_common.sql:200: ERROR:  relation "conditions_summary_1_hourly" does not exist at character 15
+SELECT * FROM :CAGG_NAME_1ST_LEVEL;
+psql:include/cagg_on_cagg_common.sql:206: ERROR:  relation "conditions_summary_1_hourly" does not exist at character 15
 \set ON_ERROR_STOP 1
 --
 -- Validation test for variable bucket on top of fixed bucket

--- a/tsl/test/expected/cagg_repair-14.out
+++ b/tsl/test/expected/cagg_repair-14.out
@@ -76,7 +76,7 @@ View definition:
     _materialized_hypertable_2.min,
     _materialized_hypertable_2.max,
     _materialized_hypertable_2.sum
-   FROM _timescaledb_internal._materialized_hypertable_2 _materialized_hypertable_2;
+   FROM _timescaledb_internal._materialized_hypertable_2;
 
 CALL refresh_continuous_aggregate('conditions_summary', NULL, '2021-06-22 00:00:00-00');
 SELECT * FROM conditions_summary ORDER BY bucket, device_name;
@@ -106,7 +106,7 @@ View definition:
     _materialized_hypertable_2.min,
     _materialized_hypertable_2.max,
     _materialized_hypertable_2.sum
-   FROM _timescaledb_internal._materialized_hypertable_2 _materialized_hypertable_2;
+   FROM _timescaledb_internal._materialized_hypertable_2;
 
 SELECT * FROM conditions_summary ORDER BY bucket, device_name;
             bucket            | device_name | min | max | sum 
@@ -134,7 +134,7 @@ View definition:
     _materialized_hypertable_2.min,
     _materialized_hypertable_2.max,
     _materialized_hypertable_2.sum
-   FROM _timescaledb_internal._materialized_hypertable_2 _materialized_hypertable_2;
+   FROM _timescaledb_internal._materialized_hypertable_2;
 
 SELECT * FROM conditions_summary ORDER BY bucket, device_name;
             bucket            | device_name | min | max | sum 
@@ -162,7 +162,7 @@ View definition:
     _materialized_hypertable_2.min,
     _materialized_hypertable_2.max,
     _materialized_hypertable_2.sum
-   FROM _timescaledb_internal._materialized_hypertable_2 _materialized_hypertable_2
+   FROM _timescaledb_internal._materialized_hypertable_2
   WHERE _materialized_hypertable_2.bucket < COALESCE(_timescaledb_functions.to_timestamp(_timescaledb_functions.cagg_watermark(2)), '-infinity'::timestamp with time zone)
 UNION ALL
  SELECT time_bucket('@ 7 days'::interval, conditions."time") AS bucket,
@@ -205,7 +205,7 @@ View definition:
     _materialized_hypertable_2.min,
     _materialized_hypertable_2.max,
     _materialized_hypertable_2.sum
-   FROM _timescaledb_internal._materialized_hypertable_2 _materialized_hypertable_2
+   FROM _timescaledb_internal._materialized_hypertable_2
   WHERE _materialized_hypertable_2.bucket < COALESCE(_timescaledb_functions.to_timestamp(_timescaledb_functions.cagg_watermark(2)), '-infinity'::timestamp with time zone)
 UNION ALL
  SELECT time_bucket('@ 7 days'::interval, conditions."time") AS bucket,
@@ -247,7 +247,7 @@ View definition:
     _materialized_hypertable_2.min,
     _materialized_hypertable_2.max,
     _materialized_hypertable_2.sum
-   FROM _timescaledb_internal._materialized_hypertable_2 _materialized_hypertable_2
+   FROM _timescaledb_internal._materialized_hypertable_2
   WHERE _materialized_hypertable_2.bucket < COALESCE(_timescaledb_functions.to_timestamp(_timescaledb_functions.cagg_watermark(2)), '-infinity'::timestamp with time zone)
 UNION ALL
  SELECT time_bucket('@ 7 days'::interval, conditions."time") AS bucket,

--- a/tsl/test/expected/cagg_repair-15.out
+++ b/tsl/test/expected/cagg_repair-15.out
@@ -76,7 +76,7 @@ View definition:
     _materialized_hypertable_2.min,
     _materialized_hypertable_2.max,
     _materialized_hypertable_2.sum
-   FROM _timescaledb_internal._materialized_hypertable_2 _materialized_hypertable_2;
+   FROM _timescaledb_internal._materialized_hypertable_2;
 
 CALL refresh_continuous_aggregate('conditions_summary', NULL, '2021-06-22 00:00:00-00');
 SELECT * FROM conditions_summary ORDER BY bucket, device_name;
@@ -106,7 +106,7 @@ View definition:
     _materialized_hypertable_2.min,
     _materialized_hypertable_2.max,
     _materialized_hypertable_2.sum
-   FROM _timescaledb_internal._materialized_hypertable_2 _materialized_hypertable_2;
+   FROM _timescaledb_internal._materialized_hypertable_2;
 
 SELECT * FROM conditions_summary ORDER BY bucket, device_name;
             bucket            | device_name | min | max | sum 
@@ -134,7 +134,7 @@ View definition:
     _materialized_hypertable_2.min,
     _materialized_hypertable_2.max,
     _materialized_hypertable_2.sum
-   FROM _timescaledb_internal._materialized_hypertable_2 _materialized_hypertable_2;
+   FROM _timescaledb_internal._materialized_hypertable_2;
 
 SELECT * FROM conditions_summary ORDER BY bucket, device_name;
             bucket            | device_name | min | max | sum 
@@ -162,7 +162,7 @@ View definition:
     _materialized_hypertable_2.min,
     _materialized_hypertable_2.max,
     _materialized_hypertable_2.sum
-   FROM _timescaledb_internal._materialized_hypertable_2 _materialized_hypertable_2
+   FROM _timescaledb_internal._materialized_hypertable_2
   WHERE _materialized_hypertable_2.bucket < COALESCE(_timescaledb_functions.to_timestamp(_timescaledb_functions.cagg_watermark(2)), '-infinity'::timestamp with time zone)
 UNION ALL
  SELECT time_bucket('@ 7 days'::interval, conditions."time") AS bucket,
@@ -205,7 +205,7 @@ View definition:
     _materialized_hypertable_2.min,
     _materialized_hypertable_2.max,
     _materialized_hypertable_2.sum
-   FROM _timescaledb_internal._materialized_hypertable_2 _materialized_hypertable_2
+   FROM _timescaledb_internal._materialized_hypertable_2
   WHERE _materialized_hypertable_2.bucket < COALESCE(_timescaledb_functions.to_timestamp(_timescaledb_functions.cagg_watermark(2)), '-infinity'::timestamp with time zone)
 UNION ALL
  SELECT time_bucket('@ 7 days'::interval, conditions."time") AS bucket,
@@ -247,7 +247,7 @@ View definition:
     _materialized_hypertable_2.min,
     _materialized_hypertable_2.max,
     _materialized_hypertable_2.sum
-   FROM _timescaledb_internal._materialized_hypertable_2 _materialized_hypertable_2
+   FROM _timescaledb_internal._materialized_hypertable_2
   WHERE _materialized_hypertable_2.bucket < COALESCE(_timescaledb_functions.to_timestamp(_timescaledb_functions.cagg_watermark(2)), '-infinity'::timestamp with time zone)
 UNION ALL
  SELECT time_bucket('@ 7 days'::interval, conditions."time") AS bucket,

--- a/tsl/test/expected/cagg_repair-16.out
+++ b/tsl/test/expected/cagg_repair-16.out
@@ -76,7 +76,7 @@ View definition:
     min,
     max,
     sum
-   FROM _timescaledb_internal._materialized_hypertable_2 _materialized_hypertable_2;
+   FROM _timescaledb_internal._materialized_hypertable_2;
 
 CALL refresh_continuous_aggregate('conditions_summary', NULL, '2021-06-22 00:00:00-00');
 SELECT * FROM conditions_summary ORDER BY bucket, device_name;
@@ -106,7 +106,7 @@ View definition:
     min,
     max,
     sum
-   FROM _timescaledb_internal._materialized_hypertable_2 _materialized_hypertable_2;
+   FROM _timescaledb_internal._materialized_hypertable_2;
 
 SELECT * FROM conditions_summary ORDER BY bucket, device_name;
             bucket            | device_name | min | max | sum 
@@ -134,7 +134,7 @@ View definition:
     min,
     max,
     sum
-   FROM _timescaledb_internal._materialized_hypertable_2 _materialized_hypertable_2;
+   FROM _timescaledb_internal._materialized_hypertable_2;
 
 SELECT * FROM conditions_summary ORDER BY bucket, device_name;
             bucket            | device_name | min | max | sum 
@@ -162,7 +162,7 @@ View definition:
     _materialized_hypertable_2.min,
     _materialized_hypertable_2.max,
     _materialized_hypertable_2.sum
-   FROM _timescaledb_internal._materialized_hypertable_2 _materialized_hypertable_2
+   FROM _timescaledb_internal._materialized_hypertable_2
   WHERE _materialized_hypertable_2.bucket < COALESCE(_timescaledb_functions.to_timestamp(_timescaledb_functions.cagg_watermark(2)), '-infinity'::timestamp with time zone)
 UNION ALL
  SELECT time_bucket('@ 7 days'::interval, conditions."time") AS bucket,
@@ -205,7 +205,7 @@ View definition:
     _materialized_hypertable_2.min,
     _materialized_hypertable_2.max,
     _materialized_hypertable_2.sum
-   FROM _timescaledb_internal._materialized_hypertable_2 _materialized_hypertable_2
+   FROM _timescaledb_internal._materialized_hypertable_2
   WHERE _materialized_hypertable_2.bucket < COALESCE(_timescaledb_functions.to_timestamp(_timescaledb_functions.cagg_watermark(2)), '-infinity'::timestamp with time zone)
 UNION ALL
  SELECT time_bucket('@ 7 days'::interval, conditions."time") AS bucket,
@@ -247,7 +247,7 @@ View definition:
     _materialized_hypertable_2.min,
     _materialized_hypertable_2.max,
     _materialized_hypertable_2.sum
-   FROM _timescaledb_internal._materialized_hypertable_2 _materialized_hypertable_2
+   FROM _timescaledb_internal._materialized_hypertable_2
   WHERE _materialized_hypertable_2.bucket < COALESCE(_timescaledb_functions.to_timestamp(_timescaledb_functions.cagg_watermark(2)), '-infinity'::timestamp with time zone)
 UNION ALL
  SELECT time_bucket('@ 7 days'::interval, conditions."time") AS bucket,

--- a/tsl/test/sql/cagg_joins.sql
+++ b/tsl/test/sql/cagg_joins.sql
@@ -564,6 +564,16 @@ JOIN devices ON conditions.device_id = devices.device_id
 JOIN location ON location.name = devices.location
 GROUP BY bucket, devices.name, location.name;
 
+SELECT * FROM conditions_by_day ORDER BY bucket, device, location;
+
+ALTER MATERIALIZED VIEW conditions_by_day SET (timescaledb.materialized_only = FALSE);
+
+-- Insert one more row on conditions and check the result (should have one more row)
+INSERT INTO conditions (day, city, temperature, device_id) VALUES
+  ('2024-07-01', 'Moscow', 28, 3);
+
+SELECT * FROM conditions_by_day ORDER BY bucket, device, location;
+
 -- JOIN with a foreign table
 \c :TEST_DBNAME :ROLE_SUPERUSER
 SELECT current_setting('port') AS "PGPORT", current_database() AS "PGDATABASE" \gset

--- a/tsl/test/sql/include/cagg_on_cagg_common.sql
+++ b/tsl/test/sql/include/cagg_on_cagg_common.sql
@@ -10,7 +10,8 @@ SELECT
   SUM(temperature) AS temperature,
   device_id
 FROM conditions
-GROUP BY 1,3
+GROUP BY 1, 3
+ORDER BY 1, 2, 3
 WITH NO DATA;
 
 -- CAGG on CAGG (2th level)
@@ -20,33 +21,39 @@ SELECT
   time_bucket(:BUCKET_WIDTH_2TH, "bucket") AS bucket,
   SUM(temperature) AS temperature
 \if :IS_JOIN
-  , :CAGG_NAME_1ST_LEVEL.device_id
-  FROM :CAGG_NAME_1ST_LEVEL, devices
-  WHERE devices.device_id = :CAGG_NAME_1ST_LEVEL.device_id
-  GROUP BY 1,3
+  , devices.device_id
+  , devices.name
+  FROM :CAGG_NAME_1ST_LEVEL
+  JOIN devices ON devices.device_id = :CAGG_NAME_1ST_LEVEL.device_id
+  GROUP BY 1, 3, 4
+  ORDER BY 1, 2, 3, 4
 \else
   FROM :CAGG_NAME_1ST_LEVEL
   GROUP BY 1
+  ORDER BY 1, 2
 \endif
-
 WITH NO DATA;
 
 -- CAGG on CAGG (3th level)
 CREATE MATERIALIZED VIEW :CAGG_NAME_3TH_LEVEL
-  WITH (timescaledb.continuous, timescaledb.materialized_only=true) AS
-  SELECT
-    time_bucket(:BUCKET_WIDTH_3TH, "bucket") AS bucket,
-    SUM(temperature) AS temperature
-  \if :IS_JOIN
-    , :CAGG_NAME_2TH_LEVEL.device_id
-    FROM :CAGG_NAME_2TH_LEVEL, devices
-    WHERE devices.device_id = :CAGG_NAME_2TH_LEVEL.device_id
-    GROUP BY 1,3
-  \else
-    FROM :CAGG_NAME_2TH_LEVEL
-    GROUP BY 1
-  \endif
-  WITH NO DATA;
+WITH (timescaledb.continuous, timescaledb.materialized_only=true) AS
+SELECT
+  time_bucket(:BUCKET_WIDTH_3TH, "bucket") AS bucket,
+  SUM(temperature) AS temperature
+\if :IS_JOIN
+  , :CAGG_NAME_2TH_LEVEL.device_id
+  , :CAGG_NAME_2TH_LEVEL.name
+  , devices.location
+  FROM :CAGG_NAME_2TH_LEVEL
+  JOIN devices ON devices.device_id = :CAGG_NAME_2TH_LEVEL.device_id
+  GROUP BY 1, 3, 4, 5
+  ORDER BY 1, 2, 3, 4, 5
+\else
+  FROM :CAGG_NAME_2TH_LEVEL
+  GROUP BY 1
+  ORDER BY 1, 2
+\endif
+WITH NO DATA;
 
 -- Check chunk_interval
 \if :IS_TIME_DIMENSION
@@ -73,21 +80,20 @@ CREATE MATERIALIZED VIEW :CAGG_NAME_3TH_LEVEL
   ORDER BY 1, 2;
 \endif
 
-
 -- No data because the CAGGs are just for materialized data
-SELECT * FROM :CAGG_NAME_1ST_LEVEL ORDER BY bucket;
-SELECT * FROM :CAGG_NAME_2TH_LEVEL ORDER BY bucket, temperature;
---SELECT * FROM :CAGG_NAME_3TH_LEVEL ORDER BY bucket;
+SELECT * FROM :CAGG_NAME_1ST_LEVEL;
+SELECT * FROM :CAGG_NAME_2TH_LEVEL;
+SELECT * FROM :CAGG_NAME_3TH_LEVEL;
 
 -- Turn CAGGs into Realtime
 ALTER MATERIALIZED VIEW :CAGG_NAME_1ST_LEVEL SET (timescaledb.materialized_only=false);
 ALTER MATERIALIZED VIEW :CAGG_NAME_2TH_LEVEL SET (timescaledb.materialized_only=false);
---ALTER MATERIALIZED VIEW :CAGG_NAME_3TH_LEVEL SET (timescaledb.materialized_only=false);
+ALTER MATERIALIZED VIEW :CAGG_NAME_3TH_LEVEL SET (timescaledb.materialized_only=false);
 
 -- Realtime data
-SELECT * FROM :CAGG_NAME_1ST_LEVEL ORDER BY bucket;
-SELECT * FROM :CAGG_NAME_2TH_LEVEL ORDER BY bucket, temperature;
---SELECT * FROM :CAGG_NAME_3TH_LEVEL ORDER BY bucket;
+SELECT * FROM :CAGG_NAME_1ST_LEVEL;
+SELECT * FROM :CAGG_NAME_2TH_LEVEL;
+SELECT * FROM :CAGG_NAME_3TH_LEVEL;
 
 -- Turn CAGGs into materialized only again
 ALTER MATERIALIZED VIEW :CAGG_NAME_1ST_LEVEL SET (timescaledb.materialized_only=true);
@@ -100,9 +106,9 @@ CALL refresh_continuous_aggregate(:'CAGG_NAME_2TH_LEVEL', NULL, NULL);
 CALL refresh_continuous_aggregate(:'CAGG_NAME_3TH_LEVEL', NULL, NULL);
 
 -- Materialized data
-SELECT * FROM :CAGG_NAME_1ST_LEVEL ORDER BY bucket;
-SELECT * FROM :CAGG_NAME_2TH_LEVEL ORDER BY bucket, temperature;
-SELECT * FROM :CAGG_NAME_3TH_LEVEL ORDER BY bucket;
+SELECT * FROM :CAGG_NAME_1ST_LEVEL;
+SELECT * FROM :CAGG_NAME_2TH_LEVEL;
+SELECT * FROM :CAGG_NAME_3TH_LEVEL;
 
 \if :IS_TIME_DIMENSION
 -- Invalidate an old region
@@ -117,9 +123,9 @@ INSERT INTO conditions ("time", temperature) VALUES (10, 2);
 \endif
 
 -- No changes
-SELECT * FROM :CAGG_NAME_1ST_LEVEL ORDER BY bucket;
-SELECT * FROM :CAGG_NAME_2TH_LEVEL ORDER BY bucket, temperature;
-SELECT * FROM :CAGG_NAME_3TH_LEVEL ORDER BY bucket;
+SELECT * FROM :CAGG_NAME_1ST_LEVEL;
+SELECT * FROM :CAGG_NAME_2TH_LEVEL;
+SELECT * FROM :CAGG_NAME_3TH_LEVEL;
 
 -- Turn CAGGs into Realtime
 ALTER MATERIALIZED VIEW :CAGG_NAME_1ST_LEVEL SET (timescaledb.materialized_only=false);
@@ -127,9 +133,9 @@ ALTER MATERIALIZED VIEW :CAGG_NAME_2TH_LEVEL SET (timescaledb.materialized_only=
 ALTER MATERIALIZED VIEW :CAGG_NAME_3TH_LEVEL SET (timescaledb.materialized_only=false);
 
 -- Realtime changes, just new region
-SELECT * FROM :CAGG_NAME_1ST_LEVEL ORDER BY bucket;
-SELECT * FROM :CAGG_NAME_2TH_LEVEL ORDER BY bucket, temperature;
-SELECT * FROM :CAGG_NAME_3TH_LEVEL ORDER BY bucket;
+SELECT * FROM :CAGG_NAME_1ST_LEVEL;
+SELECT * FROM :CAGG_NAME_2TH_LEVEL;
+SELECT * FROM :CAGG_NAME_3TH_LEVEL;
 
 -- Turn CAGGs into materialized only again
 ALTER MATERIALIZED VIEW :CAGG_NAME_1ST_LEVEL SET (timescaledb.materialized_only=true);
@@ -142,23 +148,23 @@ CALL refresh_continuous_aggregate(:'CAGG_NAME_2TH_LEVEL', NULL, NULL);
 CALL refresh_continuous_aggregate(:'CAGG_NAME_3TH_LEVEL', NULL, NULL);
 
 -- All changes are materialized
-SELECT * FROM :CAGG_NAME_1ST_LEVEL ORDER BY bucket;
-SELECT * FROM :CAGG_NAME_2TH_LEVEL ORDER BY bucket, temperature;
-SELECT * FROM :CAGG_NAME_3TH_LEVEL ORDER BY bucket;
+SELECT * FROM :CAGG_NAME_1ST_LEVEL;
+SELECT * FROM :CAGG_NAME_2TH_LEVEL;
+SELECT * FROM :CAGG_NAME_3TH_LEVEL;
 
 -- TRUNCATE tests
 TRUNCATE :CAGG_NAME_2TH_LEVEL;
 -- This full refresh will remove all the data from the 3TH level cagg
 CALL refresh_continuous_aggregate(:'CAGG_NAME_3TH_LEVEL', NULL, NULL);
 -- Should return no rows
-SELECT * FROM :CAGG_NAME_2TH_LEVEL ORDER BY bucket;
-SELECT * FROM :CAGG_NAME_3TH_LEVEL ORDER BY bucket;
+SELECT * FROM :CAGG_NAME_2TH_LEVEL;
+SELECT * FROM :CAGG_NAME_3TH_LEVEL;
 -- If we have all the data in the bottom levels caggs we can rebuild
 CALL refresh_continuous_aggregate(:'CAGG_NAME_2TH_LEVEL', NULL, NULL);
 CALL refresh_continuous_aggregate(:'CAGG_NAME_3TH_LEVEL', NULL, NULL);
 -- Now we have all the data
-SELECT * FROM :CAGG_NAME_2TH_LEVEL ORDER BY bucket, temperature;
-SELECT * FROM :CAGG_NAME_3TH_LEVEL ORDER BY bucket;
+SELECT * FROM :CAGG_NAME_2TH_LEVEL;
+SELECT * FROM :CAGG_NAME_3TH_LEVEL;
 
 -- DROP tests
 \set ON_ERROR_STOP 0
@@ -173,29 +179,29 @@ CALL refresh_continuous_aggregate(:'CAGG_NAME_2TH_LEVEL', NULL, NULL);
 DROP MATERIALIZED VIEW :CAGG_NAME_3TH_LEVEL;
 \set ON_ERROR_STOP 0
 -- should error because it was dropped
-SELECT * FROM :CAGG_NAME_3TH_LEVEL ORDER BY bucket, device_id;
+SELECT * FROM :CAGG_NAME_3TH_LEVEL;
 \set ON_ERROR_STOP 1
 -- should work because dropping the top level CAGG
 -- don't affect the down level CAGGs
 TRUNCATE :CAGG_NAME_2TH_LEVEL,:CAGG_NAME_1ST_LEVEL;
 CALL refresh_continuous_aggregate(:'CAGG_NAME_2TH_LEVEL', NULL, NULL);
 CALL refresh_continuous_aggregate(:'CAGG_NAME_1ST_LEVEL', NULL, NULL);
-SELECT * FROM :CAGG_NAME_1ST_LEVEL ORDER BY bucket, device_id;
-SELECT * FROM :CAGG_NAME_2TH_LEVEL ORDER BY bucket, temperature;
+SELECT * FROM :CAGG_NAME_1ST_LEVEL;
+SELECT * FROM :CAGG_NAME_2TH_LEVEL;
 
 -- DROP the 2TH level CAGG don't affect others
 DROP MATERIALIZED VIEW :CAGG_NAME_2TH_LEVEL;
 \set ON_ERROR_STOP 0
 -- should error because it was dropped
-SELECT * FROM :CAGG_NAME_2TH_LEVEL ORDER BY bucket, temperature;
+SELECT * FROM :CAGG_NAME_2TH_LEVEL;
 \set ON_ERROR_STOP 1
 -- should work because dropping the top level CAGG
 -- don't affect the down level CAGGs
-SELECT * FROM :CAGG_NAME_1ST_LEVEL ORDER BY bucket, device_id;
+SELECT * FROM :CAGG_NAME_1ST_LEVEL;
 
 -- DROP the first CAGG should work
 DROP MATERIALIZED VIEW :CAGG_NAME_1ST_LEVEL;
 \set ON_ERROR_STOP 0
 -- should error because it was dropped
-SELECT * FROM :CAGG_NAME_1ST_LEVEL ORDER BY bucket, device_id;
+SELECT * FROM :CAGG_NAME_1ST_LEVEL;
 \set ON_ERROR_STOP 1


### PR DESCRIPTION
Creating or changing to realtime a Continuous Aggregate with multiple joins was leading to a segfault.

Fixed it by dealing properly with the `varno` when creating the `Quals` for the union view in realtime mode.

Also get rid of some left over when we relaxed the CAggs join restrictions in #7111.

Disable-check: force-changelog-file
Disable-check: commit-count
