### PR TITLE
Fix CAggs partial view dependencies

### DIFF
--- a/scripts/test_pg_upgrade.py
+++ b/scripts/test_pg_upgrade.py
@@ -86,8 +86,10 @@ node_old.safe_psql(query=f"CREATE DATABASE {pg_database_test};")
 node_old.safe_psql(dbname=pg_database_test, query="CREATE EXTENSION timescaledb;")
 node_old.safe_psql(dbname=pg_database_test, filename="test/sql/updates/pre.testing.sql")
 node_old.safe_psql(
-    dbname=pg_database_test,
-    filename=f"test/sql/updates/setup.{test_version}.sql",
+    dbname=pg_database_test, filename=f"test/sql/updates/setup.{test_version}.sql"
+)
+node_old.safe_psql(
+    dbname=pg_database_test, filename="test/sql/updates/setup.pg_upgrade.sql"
 )
 node_old.safe_psql(dbname=pg_database_test, query="CHECKPOINT")
 node_old.safe_psql(dbname=pg_database_test, filename="test/sql/updates/setup.check.sql")

--- a/scripts/test_update_from_version.sh
+++ b/scripts/test_update_from_version.sh
@@ -61,7 +61,7 @@ initdb > "${OUTPUT_DIR}/initdb.log" 2>&1
 pg_ctl -l "${OUTPUT_DIR}/postgres.log" start -o "-c unix_socket_directories='${UNIX_SOCKET_DIR}' -c timezone=GMT -c client_min_messages=warning -c port=${PGPORT} -c max_prepared_transactions=100 -c shared_preload_libraries=timescaledb -c timescaledb.telemetry_level=off -c max_worker_processes=0"
 pg_isready -t 30 > /dev/null
 
-echo -e "\nUpdate test for ${FROM_VERSION} -> ${TO_VERSION}\n"
+echo -e "\nUpdate test version ${TEST_VERSION} for ${FROM_VERSION} -> ${TO_VERSION}\n"
 
 # caller should ensure that the versions are available
 check_version "${FROM_VERSION}"

--- a/test/sql/updates/post.pg_upgrade.sql
+++ b/test/sql/updates/post.pg_upgrade.sql
@@ -8,3 +8,5 @@
 \ir post.catalog.sql
 \ir post.policies.sql
 \ir post.functions.sql
+
+SELECT * FROM cagg_join.measurement_daily ORDER BY 1, 2, 3, 4, 5, 6;

--- a/test/sql/updates/setup.pg_upgrade.sql
+++ b/test/sql/updates/setup.pg_upgrade.sql
@@ -1,0 +1,26 @@
+-- This file and its contents are licensed under the Apache License 2.0.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-APACHE for a copy of the license.
+
+CREATE SCHEMA cagg_join;
+CREATE TABLE cagg_join.sensor(
+    id SERIAL PRIMARY KEY,
+    name TEXT,
+    enabled BOOLEAN
+);
+
+CREATE TABLE cagg_join.measurement(
+    sensor_id INTEGER REFERENCES cagg_join.sensor(id),
+    observed TIMESTAMPTZ,
+    value FLOAT
+);
+
+SELECT create_hypertable('cagg_join.measurement', 'observed');
+
+CREATE MATERIALIZED VIEW cagg_join.measurement_daily
+WITH (timescaledb.continuous) AS
+-- Column s.name is functionally dependent on s.id (primary key)
+SELECT s.id, s.name, time_bucket(interval '1 day', observed) as bucket, avg(value), min(value), max(value)
+FROM cagg_join.sensor s
+JOIN cagg_join.measurement m on (s.id = m.sensor_id)
+GROUP BY s.id, bucket;

--- a/tsl/src/continuous_aggs/create.c
+++ b/tsl/src/continuous_aggs/create.c
@@ -498,25 +498,25 @@ mattablecolumninfo_get_partial_select_query(MatTableColumnInfo *mattblinfo, Quer
 {
 	Query *partial_selquery = NULL;
 
-	CAGG_MAKEQUERY(partial_selquery, userview_query);
-	partial_selquery->rtable = copyObject(userview_query->rtable);
-	partial_selquery->jointree = copyObject(userview_query->jointree);
-#if PG16_GE
-	partial_selquery->rteperminfos = copyObject(userview_query->rteperminfos);
-#endif
-
-	partial_selquery->targetList = mattblinfo->partial_seltlist;
-	partial_selquery->groupClause = mattblinfo->partial_grouplist;
-
-	if (finalized)
+	if (!finalized)
 	{
-		partial_selquery->havingQual = copyObject(userview_query->havingQual);
-		partial_selquery->sortClause = copyObject(userview_query->sortClause);
+		CAGG_MAKEQUERY(partial_selquery, userview_query);
+		partial_selquery->rtable = copyObject(userview_query->rtable);
+		partial_selquery->jointree = copyObject(userview_query->jointree);
+#if PG16_GE
+		partial_selquery->rteperminfos = copyObject(userview_query->rteperminfos);
+#endif
+		partial_selquery->targetList = mattblinfo->partial_seltlist;
+		partial_selquery->groupClause = mattblinfo->partial_grouplist;
+		partial_selquery->havingQual = NULL;
+		partial_selquery->sortClause = NULL;
 	}
 	else
 	{
-		partial_selquery->havingQual = NULL;
-		partial_selquery->sortClause = NULL;
+		partial_selquery = copyObject(userview_query);
+		/* Partial view should always include the time dimension column */
+		partial_selquery->targetList = mattblinfo->partial_seltlist;
+		partial_selquery->groupClause = mattblinfo->partial_grouplist;
 	}
 
 	return partial_selquery;


### PR DESCRIPTION
When creating a CAgg using a column on the projection that is not part of the `GROUP BY` clause but is functionally dependent of the primary key of the referenced table is leading to a problem in dump/restore because the wrong dependencies created changing the order and way dump is generated.

Fixed it by copying the direct view `Query` data structure and changing the necessary properties instead of creating it from scratch.

Disable-check: force-changelog-file
