### PR TITLE
Dont apply sort optimization when interval length is not fixed

### DIFF
--- a/.unreleased/pr_7161
+++ b/.unreleased/pr_7161
@@ -1,0 +1,2 @@
+Implements: #7161 Fix `mergejoin input data is out of order`
+Thanks: @jledentu For reporting a problem with mergejoin input order

--- a/src/sort_transform.c
+++ b/src/sort_transform.c
@@ -99,6 +99,10 @@ transform_time_op_const_interval(OpExpr *op)
 			(left == TIMESTAMPTZOID && right == INTERVALOID) ||
 			(left == DATEOID && right == INTERVALOID))
 		{
+			Interval *interval = DatumGetIntervalP((lsecond_node(Const, op->args))->constvalue);
+			if (interval->month != 0 || interval->day != 0)
+				return (Expr *) op;
+
 			char *name = get_opname(op->opno);
 
 			if (strncmp(name, "-", NAMEDATALEN) == 0 || strncmp(name, "+", NAMEDATALEN) == 0)

--- a/test/expected/sort_optimization.out
+++ b/test/expected/sort_optimization.out
@@ -71,3 +71,38 @@ SELECT time_bucket(10,time),device_id,value FROM order_test ORDER BY 2,1;
    ->  Index Scan using _hyper_1_1_chunk_order_test_device_id_time_idx on _hyper_1_1_chunk
 (2 rows)
 
+-- test sort optimization with interval calculation with non-fixed interval
+-- #7097
+CREATE TABLE i7097_1(time timestamptz NOT NULL, quantity float, "isText" boolean);
+CREATE TABLE i7097_2(time timestamptz NOT NULL, quantity float, "isText" boolean);
+CREATE INDEX ON i7097_1(time) WHERE "isText" IS NULL;
+CREATE INDEX ON i7097_2(time) WHERE "isText" IS NULL;
+SELECT table_name FROM create_hypertable('i7097_1', 'time', create_default_indexes => false);
+ table_name 
+------------
+ i7097_1
+(1 row)
+
+SELECT table_name FROM create_hypertable('i7097_2', 'time', create_default_indexes => false);
+ table_name 
+------------
+ i7097_2
+(1 row)
+
+INSERT INTO i7097_1(time, quantity)
+SELECT time, round((random() * (100-3) + 3)::NUMERIC) AS quantity
+FROM generate_series('2023-01-01T00:00:00+01:00', '2023-05-01T00:00:00+01:00', interval 'PT10M') AS t(time);
+INSERT INTO i7097_2(time, quantity)
+SELECT time, round((random() * (100-3) + 3)::NUMERIC) AS quantity
+FROM generate_series('2023-01-01T00:00:00+01:00', '2023-05-01T00:00:00+01:00', interval 'PT10M') AS t(time);
+VACUUM ANALYZE i7097_1, i7097_2;
+SET TIME ZONE 'Europe/Paris';
+WITH
+"cte1" AS (SELECT time + interval 'P1Y' AS time, avg(quantity) AS quantity FROM i7097_1 WHERE time >= '2024-03-31T00:00:00+01:00'::timestamptz - interval 'P1Y' AND time < '2024-03-31T23:59:59+02:00'::timestamptz + (- interval 'P1Y') AND "isText" IS NULL GROUP BY 1 ORDER BY 1 ASC),
+"cte2" AS (SELECT time + interval 'P1Y' AS time, avg(quantity) AS quantity FROM i7097_2 WHERE time >= '2024-03-31T00:00:00+01:00'::timestamptz - interval 'P1Y' AND time < '2024-03-31T23:59:59+02:00'::timestamptz + (- interval 'P1Y') AND "isText" IS NULL GROUP BY 1 ORDER BY 1 ASC)
+SELECT count(*) FROM (SELECT time, cte1.quantity + cte2.quantity FROM cte1 FULL OUTER JOIN cte2 USING (time)) j;
+ count 
+-------
+   138
+(1 row)
+

--- a/test/sql/sort_optimization.sql
+++ b/test/sql/sort_optimization.sql
@@ -34,3 +34,30 @@ SELECT time_bucket(10,time),device_id,value FROM order_test ORDER BY 2,1;
 -- should use index scan
 :PREFIX SELECT time_bucket(10,time),device_id,value FROM order_test ORDER BY 2,1;
 
+-- test sort optimization with interval calculation with non-fixed interval
+-- #7097
+CREATE TABLE i7097_1(time timestamptz NOT NULL, quantity float, "isText" boolean);
+CREATE TABLE i7097_2(time timestamptz NOT NULL, quantity float, "isText" boolean);
+
+CREATE INDEX ON i7097_1(time) WHERE "isText" IS NULL;
+CREATE INDEX ON i7097_2(time) WHERE "isText" IS NULL;
+
+SELECT table_name FROM create_hypertable('i7097_1', 'time', create_default_indexes => false);
+SELECT table_name FROM create_hypertable('i7097_2', 'time', create_default_indexes => false);
+
+INSERT INTO i7097_1(time, quantity)
+SELECT time, round((random() * (100-3) + 3)::NUMERIC) AS quantity
+FROM generate_series('2023-01-01T00:00:00+01:00', '2023-05-01T00:00:00+01:00', interval 'PT10M') AS t(time);
+
+INSERT INTO i7097_2(time, quantity)
+SELECT time, round((random() * (100-3) + 3)::NUMERIC) AS quantity
+FROM generate_series('2023-01-01T00:00:00+01:00', '2023-05-01T00:00:00+01:00', interval 'PT10M') AS t(time);
+
+VACUUM ANALYZE i7097_1, i7097_2;
+
+SET TIME ZONE 'Europe/Paris';
+WITH
+"cte1" AS (SELECT time + interval 'P1Y' AS time, avg(quantity) AS quantity FROM i7097_1 WHERE time >= '2024-03-31T00:00:00+01:00'::timestamptz - interval 'P1Y' AND time < '2024-03-31T23:59:59+02:00'::timestamptz + (- interval 'P1Y') AND "isText" IS NULL GROUP BY 1 ORDER BY 1 ASC),
+"cte2" AS (SELECT time + interval 'P1Y' AS time, avg(quantity) AS quantity FROM i7097_2 WHERE time >= '2024-03-31T00:00:00+01:00'::timestamptz - interval 'P1Y' AND time < '2024-03-31T23:59:59+02:00'::timestamptz + (- interval 'P1Y') AND "isText" IS NULL GROUP BY 1 ORDER BY 1 ASC)
+SELECT count(*) FROM (SELECT time, cte1.quantity + cte2.quantity FROM cte1 FULL OUTER JOIN cte2 USING (time)) j;
+


### PR DESCRIPTION
We applied our sort transformation for interval calculation too aggressively even in situations where it is not safe to do so, leading to potentially incorrectly sorted output or `mergejoin input data is out of order` error messages.

Fixes #7097