### PR TITLE
Release 2.16.1

### DIFF
--- a/.unreleased/pr_7182
+++ b/.unreleased/pr_7182
@@ -1,1 +1,0 @@
-Fixes: #7182 Fix untier_chunk for hypertables with foreign keys

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@
 `psql` with the `-X` flag to prevent any `.psqlrc` commands from
 accidentally triggering the load of a previous DB version.**
 
+## 2.16.1 (2024-08-06)
+
+This release contains bug fixes since the 2.16.0 release. We recommend
+that you upgrade at the next available opportunity.
+
+**Bugfixes**
+* #7182 Fix untier_chunk for hypertables with foreign keys
+
 ## 2.16.0 (2024-07-31)
 
 This release contains significant performance improvements when working with compressed data, extended join

--- a/sql/CMakeLists.txt
+++ b/sql/CMakeLists.txt
@@ -41,7 +41,8 @@ set(MOD_FILES
     updates/2.15.0--2.15.1.sql
     updates/2.15.1--2.15.2.sql
     updates/2.15.2--2.15.3.sql
-    updates/2.15.3--2.16.0.sql)
+    updates/2.15.3--2.16.0.sql
+    updates/2.16.0--2.16.1.sql)
 
 # The downgrade file to generate a downgrade script for the current version, as
 # specified in version.config

--- a/version.config
+++ b/version.config
@@ -1,3 +1,3 @@
 version = 2.17.0-dev
-update_from_version = 2.16.0
+update_from_version = 2.16.1
 downgrade_to_version = 2.16.0


### PR DESCRIPTION
This release contains bug fixes since the 2.16.0 release. We recommend that you upgrade at the next available opportunity.

**Bugfixes**
* #7182 Fix untier_chunk for hypertables with foreign keys

Disable-check: force-changelog-file
