### PR TITLE
Fix string literal length for compressed_data_info

### DIFF
--- a/.unreleased/pr_7187
+++ b/.unreleased/pr_7187
@@ -1,0 +1,1 @@
+Fixes: #7187 Fix string literal length for compressed_data_info

--- a/tsl/src/compression/compression.c
+++ b/tsl/src/compression/compression.c
@@ -46,16 +46,18 @@ static const CompressionAlgorithmDefinition definitions[_END_COMPRESSION_ALGORIT
 	[COMPRESSION_ALGORITHM_DELTADELTA] = DELTA_DELTA_ALGORITHM_DEFINITION,
 };
 
-static const char *compression_algorithm_name[] = {
-	[_INVALID_COMPRESSION_ALGORITHM] = "INVALID",	   [COMPRESSION_ALGORITHM_ARRAY] = "ARRAY",
-	[COMPRESSION_ALGORITHM_DICTIONARY] = "DICTIONARY", [COMPRESSION_ALGORITHM_GORILLA] = "GORILLA",
-	[COMPRESSION_ALGORITHM_DELTADELTA] = "DELTADELTA",
+static NameData compression_algorithm_name[] = {
+	[_INVALID_COMPRESSION_ALGORITHM] = { "INVALID" },
+	[COMPRESSION_ALGORITHM_ARRAY] = { "ARRAY" },
+	[COMPRESSION_ALGORITHM_DICTIONARY] = { "DICTIONARY" },
+	[COMPRESSION_ALGORITHM_GORILLA] = { "GORILLA" },
+	[COMPRESSION_ALGORITHM_DELTADELTA] = { "DELTADELTA" },
 };
 
-const char *
+Name
 compression_get_algorithm_name(CompressionAlgorithm alg)
 {
-	return compression_algorithm_name[alg];
+	return &compression_algorithm_name[alg];
 }
 
 static Compressor *
@@ -2041,7 +2043,7 @@ tsl_compressed_data_info(PG_FUNCTION_ARGS)
 	bool nulls[Natts_compressed_info] = { false };
 
 	values[AttrNumberGetAttrOffset(Anum_compressed_info_algorithm)] =
-		CStringGetDatum(compression_get_algorithm_name(header->compression_algorithm));
+		NameGetDatum(compression_get_algorithm_name(header->compression_algorithm));
 	values[AttrNumberGetAttrOffset(Anum_compressed_info_has_nulls)] = BoolGetDatum(has_nulls);
 	tuple = heap_form_tuple(tupdesc, values, nulls);
 

--- a/tsl/src/compression/compression.h
+++ b/tsl/src/compression/compression.h
@@ -321,7 +321,7 @@ pg_attribute_unused() assert_num_compression_algorithms_sane(void)
 					 "number of algorithms have changed, the asserts should be updated");
 }
 
-extern const char *compression_get_algorithm_name(CompressionAlgorithm alg);
+extern Name compression_get_algorithm_name(CompressionAlgorithm alg);
 extern CompressionStorage compression_get_toast_storage(CompressionAlgorithm algo);
 extern CompressionAlgorithm compression_get_default_algorithm(Oid typeoid);
 


### PR DESCRIPTION
The function `compressed_data_info` returns a record containing `name`
but copies the data from string literal. Since `heap_form_tuple` expects a
`name` value as source as well, it will copy too much data from the
source, leading to ASAN complaining about copying outside the allocated
range of data.

The problem is fixed by `NameData` for each
source string, ensuring that each of the string literals has sufficient
data for being copied as names.