### PR TITLE
Fix create default indexes on chunks

### DIFF
--- a/.unreleased/pr_7191
+++ b/.unreleased/pr_7191
@@ -1,0 +1,1 @@
+Fixes: #7191 Fix creating default indexes on chunks when migrating data

--- a/src/hypertable.c
+++ b/src/hypertable.c
@@ -2000,6 +2000,9 @@ ts_hypertable_create_from_info(Oid table_relid, int32 hypertable_id, uint32 flag
 		ts_tablespace_attach_internal(&tspc_name, table_relid, false);
 	}
 
+	if ((flags & HYPERTABLE_CREATE_DISABLE_DEFAULT_INDEXES) == 0)
+		ts_indexing_create_default_indexes(ht);
+
 	/*
 	 * Migrate data from the main table to chunks
 	 *
@@ -2018,9 +2021,6 @@ ts_hypertable_create_from_info(Oid table_relid, int32 hypertable_id, uint32 flag
 	}
 
 	insert_blocker_trigger_add(table_relid);
-
-	if ((flags & HYPERTABLE_CREATE_DISABLE_DEFAULT_INDEXES) == 0)
-		ts_indexing_create_default_indexes(ht);
 
 	ts_cache_release(hcache);
 

--- a/test/expected/create_hypertable.out
+++ b/test/expected/create_hypertable.out
@@ -1069,3 +1069,49 @@ select create_hypertable ('test_schema.fk_parent', 'time');
 ERROR:  cannot have FOREIGN KEY constraints to hypertable "fk_parent"
 HINT:  Remove all FOREIGN KEY constraints to table "fk_parent" before making it a hypertable.
 \set ON_ERROR_STOP 1
+-- create default indexes on chunks when migrating data
+CREATE TABLE test(time TIMESTAMPTZ, val BIGINT);
+CREATE INDEX test_val_idx ON test(val);
+INSERT INTO test VALUES('2024-01-01 00:00:00-03', 500);
+SELECT FROM create_hypertable('test', 'time', migrate_data=>TRUE);
+--
+(1 row)
+
+-- should return ALL indexes for hypertable and chunk
+SELECT * FROM test.show_indexes('test') ORDER BY 1;
+     Index     | Columns | Expr | Unique | Primary | Exclusion | Tablespace 
+---------------+---------+------+--------+---------+-----------+------------
+ test_val_idx  | {val}   |      | f      | f       | f         | 
+ test_time_idx | {time}  |      | f      | f       | f         | 
+(2 rows)
+
+SELECT * FROM show_chunks('test') ch, LATERAL test.show_indexes(ch) ORDER BY 1, 2;
+                    ch                    |                         Index                          | Columns | Expr | Unique | Primary | Exclusion | Tablespace 
+------------------------------------------+--------------------------------------------------------+---------+------+--------+---------+-----------+------------
+ _timescaledb_internal._hyper_23_23_chunk | _timescaledb_internal._hyper_23_23_chunk_test_val_idx  | {val}   |      | f      | f       | f         | 
+ _timescaledb_internal._hyper_23_23_chunk | _timescaledb_internal._hyper_23_23_chunk_test_time_idx | {time}  |      | f      | f       | f         | 
+(2 rows)
+
+DROP TABLE test;
+-- don't create default indexes on chunks when migrating data
+CREATE TABLE test(time TIMESTAMPTZ, val BIGINT);
+CREATE INDEX test_val_idx ON test(val);
+INSERT INTO test VALUES('2024-01-01 00:00:00-03', 500);
+SELECT FROM create_hypertable('test', 'time', create_default_indexes => FALSE, migrate_data=>TRUE);
+--
+(1 row)
+
+-- should NOT return default indexes for hypertable and chunk
+-- only user indexes should be returned
+SELECT * FROM test.show_indexes('test') ORDER BY 1;
+    Index     | Columns | Expr | Unique | Primary | Exclusion | Tablespace 
+--------------+---------+------+--------+---------+-----------+------------
+ test_val_idx | {val}   |      | f      | f       | f         | 
+(1 row)
+
+SELECT * FROM show_chunks('test') ch, LATERAL test.show_indexes(ch) ORDER BY 1, 2;
+                    ch                    |                         Index                         | Columns | Expr | Unique | Primary | Exclusion | Tablespace 
+------------------------------------------+-------------------------------------------------------+---------+------+--------+---------+-----------+------------
+ _timescaledb_internal._hyper_24_24_chunk | _timescaledb_internal._hyper_24_24_chunk_test_val_idx | {val}   |      | f      | f       | f         | 
+(1 row)
+


### PR DESCRIPTION
When creating a hypertable with default indexes and migrating data by setting `migrate_data=>true` is not creating the default indexes on chunks.

Fixed it by changing the internal order or operations by first create the default indexes and after it migrate the data.

Fixes #7190