### PR TITLE
Disable CI block of C-functions in latest-dev.sql

### DIFF
--- a/.github/workflows/catalog-updates-check.yaml
+++ b/.github/workflows/catalog-updates-check.yaml
@@ -20,7 +20,7 @@ jobs:
 
       - name: Check latest-dev contents
         run: |
-          python scripts/check_updates_ast.py --latest "sql/updates/latest-dev.sql"
+          python scripts/check_updates_ast.py "sql/updates/latest-dev.sql"
 
       # To allow fixing previous mistakes we run the check against reverse-dev but don't
       # fail it on errors.


### PR DESCRIPTION
The CI check that blocks C-function references in the latest-dev.sql update script file does not work for all kinds of C functions.

The check requires turning C-functions into either SQL or PLPGSQL dummy functions, but that doesn't work for functions with arguments of type "any" since that type is not allowed in non-C functions.

Disable-check: force-changelog-file