### PR TITLE
Fix check when dropping compressed column (#7102)

### DIFF
--- a/.unreleased/pr_7195
+++ b/.unreleased/pr_7195
@@ -1,0 +1,1 @@
+Fixes: #7195 Fix segmentby/orderby check when dropping a column from a compressed hypertable

--- a/tsl/test/expected/compression_ddl.out
+++ b/tsl/test/expected/compression_ddl.out
@@ -2511,3 +2511,40 @@ select compress_chunk(show_chunks('hyper_unique_deferred'));
 begin; insert INTO hyper_unique_deferred values (1257987700000000000, 'dev1', 1); abort;
 ERROR:  duplicate key value violates unique constraint "146_2_hyper_unique_deferred_time_key"
 \set ON_ERROR_STOP 1
+-- tests chunks being compressed using different segmentby settings
+-- github issue #7102
+CREATE TABLE compression_drop(time timestamptz NOT NULL, v0 int, v1 int);
+CREATE INDEX ON compression_drop(time);
+CREATE INDEX ON compression_drop(v0,time);
+SELECT create_hypertable('compression_drop','time',create_default_indexes:=false);
+       create_hypertable        
+--------------------------------
+ (42,public,compression_drop,t)
+(1 row)
+
+ALTER TABLE compression_drop SET (timescaledb.compress, timescaledb.compress_orderby='time DESC', timescaledb.compress_segmentby='v0');
+-- insert data and compress chunk
+INSERT INTO compression_drop(time, v0, v1)
+SELECT time, v0, v0+1
+FROM generate_series('2000-01-01 0:00:00+0'::timestamptz,'2000-01-03 23:55:00+0','2m') gtime(time), generate_series(1,5,1) gv0(v0);
+SELECT compress_chunk(ch, true) AS "CHUNK_NAME" FROM show_chunks('compression_drop') ch ORDER BY ch DESC \gset
+-- change segmentby column
+ALTER TABLE compression_drop SET (timescaledb.compress_segmentby='v1');
+-- insert more data and compress next chunk
+INSERT INTO compression_drop(time, v0, v1)
+SELECT time, v0, v0+1
+FROM generate_series('2000-01-07 0:00:00+0'::timestamptz,'2000-01-09 23:55:00+0','2m') gtime(time), generate_series(1,5,1) gv0(v0);
+SELECT compress_chunk(format('%I.%I',chunk_schema,chunk_name)) AS "CHUNK_NAME"
+FROM timescaledb_information.chunks
+WHERE hypertable_name = 'compression_drop' AND NOT is_compressed;
+                CHUNK_NAME                 
+-------------------------------------------
+ _timescaledb_internal._hyper_42_151_chunk
+(1 row)
+
+-- try dropping column v0, should fail
+\set ON_ERROR_STOP 0
+ALTER TABLE compression_drop DROP COLUMN v0;
+ERROR:  cannot drop orderby or segmentby column from a chunk with compression enabled
+\set ON_ERROR_STOP 1
+DROP TABLE compression_drop;

--- a/tsl/test/sql/compression_ddl.sql
+++ b/tsl/test/sql/compression_ddl.sql
@@ -1003,3 +1003,36 @@ select compress_chunk(show_chunks('hyper_unique_deferred'));
 \set ON_ERROR_STOP 0
 begin; insert INTO hyper_unique_deferred values (1257987700000000000, 'dev1', 1); abort;
 \set ON_ERROR_STOP 1
+-- tests chunks being compressed using different segmentby settings
+-- github issue #7102
+CREATE TABLE compression_drop(time timestamptz NOT NULL, v0 int, v1 int);
+CREATE INDEX ON compression_drop(time);
+CREATE INDEX ON compression_drop(v0,time);
+SELECT create_hypertable('compression_drop','time',create_default_indexes:=false);
+ALTER TABLE compression_drop SET (timescaledb.compress, timescaledb.compress_orderby='time DESC', timescaledb.compress_segmentby='v0');
+
+-- insert data and compress chunk
+INSERT INTO compression_drop(time, v0, v1)
+SELECT time, v0, v0+1
+FROM generate_series('2000-01-01 0:00:00+0'::timestamptz,'2000-01-03 23:55:00+0','2m') gtime(time), generate_series(1,5,1) gv0(v0);
+
+SELECT compress_chunk(ch, true) AS "CHUNK_NAME" FROM show_chunks('compression_drop') ch ORDER BY ch DESC \gset
+
+-- change segmentby column
+ALTER TABLE compression_drop SET (timescaledb.compress_segmentby='v1');
+
+-- insert more data and compress next chunk
+INSERT INTO compression_drop(time, v0, v1)
+SELECT time, v0, v0+1
+FROM generate_series('2000-01-07 0:00:00+0'::timestamptz,'2000-01-09 23:55:00+0','2m') gtime(time), generate_series(1,5,1) gv0(v0);
+
+SELECT compress_chunk(format('%I.%I',chunk_schema,chunk_name)) AS "CHUNK_NAME"
+FROM timescaledb_information.chunks
+WHERE hypertable_name = 'compression_drop' AND NOT is_compressed;
+
+-- try dropping column v0, should fail
+\set ON_ERROR_STOP 0
+ALTER TABLE compression_drop DROP COLUMN v0;
+\set ON_ERROR_STOP 1
+
+DROP TABLE compression_drop;


### PR DESCRIPTION
This fixes segmentby/orderby check when dropping a column from a
compressed hypertable. Currently, only the hypertable compression
settings are checked. This change also checks compression settings
for each chunk.