### PR TITLE
Fix extension comment for generic loader package

### DIFF
--- a/.unreleased/pr_7201
+++ b/.unreleased/pr_7201
@@ -1,0 +1,2 @@
+Fixes: #7201 Use generic extension description when building apt and rpm loader packages
+Thanks: @posuch For reporting misleading extension description in the generic loader package

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -398,10 +398,16 @@ endif(PG_SOURCE_DIR)
 
 set(EXT_CONTROL_FILE ${PROJECT_NAME}.control)
 
-if(APACHE_ONLY)
-  set(LICENSE_EDITION "Apache 2 Edition")
+# When building apt or rpm packages we build a separate loader package that will
+# be used by both the apache and community editions. Having the edition in the
+# description would be misleading so we remove it for these cases.
+set(GENERIC_LOADER_METHOD apt rpm)
+if(PROJECT_INSTALL_METHOD IN_LIST GENERIC_LOADER_METHOD)
+  set(COMMENT_SUFFIX "")
+elseif(APACHE_ONLY)
+  set(COMMENT_SUFFIX " (Apache 2 Edition)")
 else()
-  set(LICENSE_EDITION "Community Edition")
+  set(COMMENT_SUFFIX " (Community Edition)")
 endif()
 configure_file(${EXT_CONTROL_FILE}.in ${EXT_CONTROL_FILE})
 

--- a/timescaledb.control.in
+++ b/timescaledb.control.in
@@ -1,5 +1,5 @@
 # timescaledb extension
-comment = 'Enables scalable inserts and complex queries for time-series data (@LICENSE_EDITION@)'
+comment = 'Enables scalable inserts and complex queries for time-series data@COMMENT_SUFFIX@'
 default_version = '@PROJECT_VERSION_MOD@'
 module_pathname = '$libdir/timescaledb-@PROJECT_VERSION_MOD@'
 #extension cannot be relocatable once installed because it uses multiple schemas and that is forbidden by PG.


### PR DESCRIPTION
When building apt or rpm packages we build a separate loader package that will be used by both the apache and community editions. Having the edition in the description would be misleading so we remove it for these cases.

Fixes #7198
