### PR TITLE
Add ts_update_placeholder function

### DIFF
--- a/scripts/check_updates_ast.py
+++ b/scripts/check_updates_ast.py
@@ -154,8 +154,14 @@ class SQLVisitor(Visitor):
         if args.latest:
             # C functions should only appear in actual function definition but not
             # in latest-dev.sql as that would introduce a dependency on the library.
+            # In that case, we want to use a dedicated placeholder function.
             lang = [elem for elem in node.options if elem.defname == "language"]
-            if lang and lang[0].arg.sval == "c":
+            code = [elem for elem in node.options if elem.defname == "as"][0].arg
+            if (
+                lang
+                and lang[0].arg.sval == "c"
+                and code[-1].sval != "ts_update_placeholder"
+            ):
                 self.errors += 1
                 functype = "procedure" if node.is_procedure else "function"
                 print(

--- a/sql/updates/latest-dev.sql
+++ b/sql/updates/latest-dev.sql
@@ -1,3 +1,4 @@
 CREATE FUNCTION _timescaledb_functions.compressed_data_info(_timescaledb_internal.compressed_data)
     RETURNS TABLE (algorithm name, has_nulls bool)
-    AS 'SELECT NULL,FALSE' LANGUAGE SQL STRICT IMMUTABLE SET search_path = pg_catalog, pg_temp;
+    AS '@MODULE_PATHNAME@', 'ts_update_placeholder'
+    LANGUAGE C STRICT IMMUTABLE SET search_path = pg_catalog, pg_temp;

--- a/src/utils.c
+++ b/src/utils.c
@@ -1729,3 +1729,16 @@ ts_heap_form_tuple(TupleDesc tupleDescriptor, NullableDatum *datums)
 
 	return heap_form_tuple(tupleDescriptor, values, nulls);
 }
+
+/*
+ * To not introduce shared object dependencies on functions in extension update
+ * scripts we use this stub function as placeholder whenever we need to reference
+ * c functions in the update scripts.
+ */
+TS_FUNCTION_INFO_V1(ts_update_placeholder);
+Datum
+ts_update_placeholder(PG_FUNCTION_ARGS)
+{
+	elog(ERROR, "this stub function is used only as placeholder during extension updates");
+	PG_RETURN_NULL();
+}


### PR DESCRIPTION
To not introduce shared object dependencies on functions in extension update scripts we use this stub function as placeholder whenever we need to reference c functions in the update scripts.

Disable-check: force-changelog-file
