### PR TITLE
Track additional extensions in telemetry

### DIFF
--- a/.unreleased/pr_7204
+++ b/.unreleased/pr_7204
@@ -1,0 +1,1 @@
+Implements: #7204 Track additional extensions in telemetry

--- a/src/telemetry/telemetry.c
+++ b/src/telemetry/telemetry.c
@@ -86,6 +86,9 @@
 #define REQ_IS_WAL_RECEIVER "is_wal_receiver"
 
 #define PG_PROMETHEUS "pg_prometheus"
+#define PG_VECTOR "vector"
+#define TS_AI "ai"
+#define TS_VECTORSCALE "vectorscale"
 #define PROMSCALE "promscale"
 #define POSTGIS "postgis"
 #define TIMESCALE_ANALYTICS "timescale_analytics"
@@ -95,7 +98,8 @@
 #define REQ_NUM_ERR_BY_SQLERRCODE "errors_by_sqlerrcode"
 
 static const char *related_extensions[] = {
-	PG_PROMETHEUS, PROMSCALE, POSTGIS, TIMESCALE_ANALYTICS, TIMESCALEDB_TOOLKIT,
+	PG_PROMETHEUS,		 PROMSCALE, POSTGIS, TIMESCALE_ANALYTICS,
+	TIMESCALEDB_TOOLKIT, PG_VECTOR, TS_AI,	 TS_VECTORSCALE,
 };
 
 /* This function counts background worker jobs by type. */


### PR DESCRIPTION
Add information about the existence of `ai`, `vector`, or `vectorbase` extensions to telemetry.