### PR TITLE
Refactor decompress_batches_scan functions

### DIFF
--- a/.unreleased/pr_7207
+++ b/.unreleased/pr_7207
@@ -1,0 +1,1 @@
+Implements: #7207 Refactor decompress_batches_scan functions


### PR DESCRIPTION
The code paths for `decompress_batches_indexscan` and `decompress_batches_seqscan` are mostly duplicated. This unifies the code path by refactoring it into a single function to make it easier to maintain.

Closes #7144.