### PR TITLE
Add function to drop the osm chunk

### DIFF
--- a/.unreleased/pr_7209
+++ b/.unreleased/pr_7209
@@ -1,0 +1,1 @@
+Implements: #7209 Add function to drop the osm chunk

--- a/sql/chunk.sql
+++ b/sql/chunk.sql
@@ -75,3 +75,7 @@ CREATE OR REPLACE FUNCTION _timescaledb_functions.attach_osm_table_chunk(
    hypertable REGCLASS,
    chunk REGCLASS)
 RETURNS BOOL AS '@MODULE_PATHNAME@', 'ts_chunk_attach_osm_table_chunk' LANGUAGE C VOLATILE;
+
+-- internal API used by OSM extension to drop an OSM chunk table from the hypertable
+CREATE OR REPLACE FUNCTION _timescaledb_functions.drop_osm_chunk(hypertable REGCLASS)
+RETURNS BOOL AS '@MODULE_PATHNAME@', 'ts_chunk_drop_osm_chunk' LANGUAGE C VOLATILE;

--- a/sql/updates/latest-dev.sql
+++ b/sql/updates/latest-dev.sql
@@ -4,3 +4,8 @@ CREATE FUNCTION _timescaledb_functions.compressed_data_info(_timescaledb_interna
     LANGUAGE C STRICT IMMUTABLE SET search_path = pg_catalog, pg_temp;
 
 CREATE INDEX compression_chunk_size_idx ON _timescaledb_catalog.compression_chunk_size (compressed_chunk_id);
+
+CREATE FUNCTION _timescaledb_functions.drop_osm_chunk(hypertable REGCLASS)
+	RETURNS BOOL
+	AS '@MODULE_PATHNAME@', 'ts_update_placeholder'
+	LANGUAGE C VOLATILE;

--- a/sql/updates/reverse-dev.sql
+++ b/sql/updates/reverse-dev.sql
@@ -1,2 +1,3 @@
 DROP FUNCTION _timescaledb_functions.compressed_data_info(_timescaledb_internal.compressed_data);
 DROP INDEX _timescaledb_catalog.compression_chunk_size_idx;
+DROP FUNCTION IF EXISTS _timescaledb_functions.drop_osm_chunk(REGCLASS);

--- a/tsl/test/expected/chunk_utils_internal.out
+++ b/tsl/test/expected/chunk_utils_internal.out
@@ -30,6 +30,7 @@ INSERT INTO pg_extension(oid,extname,extowner,extnamespace,extrelocatable,extver
 CREATE SCHEMA test1;
 GRANT CREATE ON SCHEMA test1 TO :ROLE_DEFAULT_PERM_USER;
 GRANT USAGE ON SCHEMA test1 TO :ROLE_DEFAULT_PERM_USER;
+GRANT USAGE ON SCHEMA test1 TO :ROLE_4;
 -- mock hooks for OSM interaction with timescaledb
 CREATE OR REPLACE FUNCTION ts_setup_osm_hook( ) RETURNS VOID
 AS :TSL_MODULE_PATHNAME LANGUAGE C VOLATILE;
@@ -844,6 +845,82 @@ ERROR:  must be owner of hypertable "ht_try"
 CREATE TABLE non_ht (time bigint, temp float);
 SELECT _timescaledb_functions.attach_osm_table_chunk('non_ht', 'child_fdw_table');
 ERROR:  "non_ht" is not a hypertable
+-- TEST drop OSM chunk
+\c :TEST_DBNAME :ROLE_4
+-- We need the OSM chunk for other tests so we run the test in a single
+-- transaction so that we could roll it back in the end
+BEGIN;
+-- get OSM chunk id
+SELECT c.id as osm_chunk_id, c.table_name as osm_chunk_name, ds.id as osm_dimension_slice
+FROM _timescaledb_catalog.chunk c
+JOIN _timescaledb_catalog.hypertable ht ON ht.id = c.hypertable_id
+JOIN _timescaledb_catalog.chunk_constraint cc ON cc.chunk_id = c.id
+JOIN _timescaledb_catalog.dimension_slice ds ON ds.id = cc.dimension_slice_id
+WHERE ht.table_name = 'ht_try' AND osm_chunk = true \gset
+\echo :osm_chunk_id, :osm_chunk_name, :osm_dimension_slice
+11, child_fdw_table, 10
+-- drop OSM chunk
+SELECT _timescaledb_functions.drop_osm_chunk('ht_try');
+ drop_osm_chunk 
+----------------
+ t
+(1 row)
+
+-- status should be 0 meaning hypertable doesn't have an OSM chunk
+SELECT status FROM _timescaledb_catalog.hypertable WHERE table_name = 'ht_try';
+ status 
+--------
+      0
+(1 row)
+
+-- chunk, chunk_constraint and dimension slice should have been cleaned up
+SELECT FROM _timescaledb_catalog.chunk WHERE id = :osm_chunk_id;
+--
+(0 rows)
+
+SELECT FROM _timescaledb_catalog.chunk_constraint WHERE chunk_id = :osm_chunk_id;
+--
+(0 rows)
+
+SELECT FROM _timescaledb_catalog.dimension_slice WHERE id = :osm_dimension_slice;
+--
+(0 rows)
+
+-- foreign chunk no longer appears in the inheritance hierarchy
+\d+ ht_try
+                                           Table "public.ht_try"
+ Column |           Type           | Collation | Nullable | Default | Storage | Stats target | Description 
+--------+--------------------------+-----------+----------+---------+---------+--------------+-------------
+ timec  | timestamp with time zone |           | not null |         | plain   |              | 
+ acq_id | bigint                   |           |          |         | plain   |              | 
+ value  | bigint                   |           |          |         | plain   |              | 
+Indexes:
+    "ht_try_timec_idx" btree (timec DESC)
+Triggers:
+    ts_insert_blocker BEFORE INSERT ON ht_try FOR EACH ROW EXECUTE FUNCTION _timescaledb_functions.insert_blocker()
+Child tables: _timescaledb_internal._hyper_5_10_chunk,
+              _timescaledb_internal._hyper_5_12_chunk
+
+-- verify that still can read from the table after catalog manipulations
+EXPLAIN (ANALYZE, COSTS OFF, TIMING OFF, SUMMARY OFF) SELECT * FROM ht_try;
+                                    QUERY PLAN                                    
+----------------------------------------------------------------------------------
+ Append (actual rows=3 loops=1)
+   ->  Custom Scan (DecompressChunk) on _hyper_5_10_chunk (actual rows=1 loops=1)
+         ->  Seq Scan on compress_hyper_6_13_chunk (actual rows=1 loops=1)
+   ->  Custom Scan (DecompressChunk) on _hyper_5_12_chunk (actual rows=1 loops=1)
+         ->  Seq Scan on compress_hyper_6_14_chunk (actual rows=1 loops=1)
+   ->  Seq Scan on _hyper_5_12_chunk (actual rows=1 loops=1)
+(6 rows)
+
+ROLLBACK;
+-- TEST error out when trying to drop an OSM chunk from a hypertable that
+-- doesn't have it
+SELECT _timescaledb_functions.drop_osm_chunk('test1.hyper1');
+ERROR:  chunk not found
+-- TEST error out when trying to drop an OSM chunk from a regular table
+SELECT _timescaledb_functions.drop_osm_chunk('non_ht');
+ERROR:  "non_ht" is not a hypertable or a continuous aggregate
 \set ON_ERROR_STOP 1
 -- TEST drop the hypertable and make sure foreign chunks are dropped as well --
 \c :TEST_DBNAME :ROLE_4;
@@ -1568,6 +1645,4 @@ psql:include/chunk_utils_internal_orderedappend.sql:178: ERROR:  Cannot insert i
 INSERT INTO osm_slice_update VALUES (1);
 psql:include/chunk_utils_internal_orderedappend.sql:179: ERROR:  Cannot insert into tiered chunk range of public.osm_slice_update - attempt to create new chunk with range  [0 10] failed
 \set ON_ERROR_STOP 1
--- clean up databases created
-\c :TEST_DBNAME :ROLE_SUPERUSER
-DROP DATABASE postgres_fdw_db WITH (FORCE);
+DROP DATABASE postgres_fdw_db;

--- a/tsl/test/isolation/expected/osm_range_updates_iso.out
+++ b/tsl/test/isolation/expected/osm_range_updates_iso.out
@@ -1,4 +1,4 @@
-Parsed test spec with 8 sessions
+Parsed test spec with 10 sessions
 
 starting permutation: LockDimSliceTuple UR1b UR1u UR2b UR2u UnlockDimSliceTuple UR1c UR2c
 step LockDimSliceTuple: 
@@ -204,3 +204,18 @@ f
 (1 row)
 
 step UR1c: COMMIT;
+
+starting permutation: DR1b DR2b DR1drop DR2drop DR1c DR2c
+step DR1b: BEGIN;
+step DR2b: BEGIN;
+step DR1drop: SELECT _timescaledb_functions.drop_osm_chunk('test_drop');
+drop_osm_chunk
+--------------
+t             
+(1 row)
+
+step DR2drop: SELECT _timescaledb_functions.drop_osm_chunk('test_drop'); <waiting ...>
+step DR1c: COMMIT;
+step DR2drop: <... completed>
+ERROR:  chunk deleted by other transaction
+step DR2c: COMMIT;

--- a/tsl/test/isolation/specs/osm_range_updates_iso.spec
+++ b/tsl/test/isolation/specs/osm_range_updates_iso.spec
@@ -15,11 +15,19 @@ setup
   UPDATE _timescaledb_catalog.dimension_slice set range_start = 9223372036854775806, range_end = 9223372036854775807
   WHERE id IN (SELECT cc.dimension_slice_id FROM _timescaledb_catalog.chunk_constraint cc, _timescaledb_catalog.chunk ch,
     _timescaledb_catalog.hypertable ht WHERE ht.id = ch.hypertable_id AND cc.chunk_id = ch.id AND ht.table_name IN ('osm_test', 'osm_test2'));
+
+  CREATE TABLE test_drop(time INTEGER, a INTEGER);
+  SELECT create_hypertable('test_drop', 'time', chunk_time_interval => 10);
+  INSERT INTO test_drop(time, a) VALUES (1,1);
+  UPDATE _timescaledb_catalog.hypertable set status = 1 WHERE table_name = 'test_drop';
+  UPDATE _timescaledb_catalog.chunk set osm_chunk = true WHERE hypertable_id IN (SELECT id FROM _timescaledb_catalog.hypertable WHERE table_name = 'test_drop');
+  INSERT INTO test_drop VALUES (11, 11), (22, 22);
 }
 
 teardown {
   DROP TABLE osm_test;
   DROP TABLE osm_test2;
+  DROP TABLE test_drop;
 }
 
 
@@ -84,6 +92,16 @@ step "Utest2b" { BEGIN; }
 step "Utest2u" { SELECT _timescaledb_functions.hypertable_osm_range_update('osm_test2', 0, 20); }
 step "Utest2c" { COMMIT; }
 
+session "DR1"
+step DR1b { BEGIN; }
+step DR1drop { SELECT _timescaledb_functions.drop_osm_chunk('test_drop'); }
+step DR1c { COMMIT; }
+
+session "DR2"
+step DR2b { BEGIN; }
+step DR2drop { SELECT _timescaledb_functions.drop_osm_chunk('test_drop'); }
+step DR2c { COMMIT; }
+
 # Concurrent updates will block one another
 # this previously deadlocked one of the two transactions
 permutation "LockDimSliceTuple" "UR1b" "UR1u" "UR2b" "UR2u" "UnlockDimSliceTuple" "UR1c" "UR2c"
@@ -104,3 +122,6 @@ permutation "Ab" "UR1b" "Aadd" "UR1u" "UR1c" "Ac"
 
 # test with two hypertables both having osm chunks. Should not block one another. So once tuple of hypertable1 is unlocked, 
 permutation "LHTb" "Utest2b" "UR1b" "LockHypertableTuple" "UR1u" "Utest2u" "Utest2c" "UnlockHypertableTuple" "UR1c"
+
+# test two sessions concurrently dropping the OSM chunk
+permutation "DR1b" "DR2b" "DR1drop" "DR2drop" "DR1c" "DR2c"

--- a/tsl/test/shared/expected/extension.out
+++ b/tsl/test/shared/expected/extension.out
@@ -63,6 +63,7 @@ ORDER BY pronamespace::regnamespace::text COLLATE "C", p.oid::regprocedure::text
  _timescaledb_functions.dimension_info_in(cstring)
  _timescaledb_functions.dimension_info_out(_timescaledb_internal.dimension_info)
  _timescaledb_functions.drop_chunk(regclass)
+ _timescaledb_functions.drop_osm_chunk(regclass)
  _timescaledb_functions.finalize_agg(text,name,name,name[],bytea,anyelement)
  _timescaledb_functions.finalize_agg_ffunc(internal,text,name,name,name[],bytea,anyelement)
  _timescaledb_functions.finalize_agg_sfunc(internal,text,name,name,name[],bytea,anyelement)


### PR DESCRIPTION
Reviving the old Konstantina's PR #6801. OSM requires this for the user API to disable tiering.

I kept the original commits and added mine on top for visibility, will squash them together before merging.