### PR TITLE
Add ts_stat_statements support on Jobs

### DIFF
--- a/src/bgw/job.c
+++ b/src/bgw/job.c
@@ -1067,7 +1067,7 @@ ts_bgw_job_get_funcid(BgwJob *job)
 	return LookupFuncWithArgs(OBJECT_ROUTINE, object, false);
 }
 
-static char *
+const char *
 ts_bgw_job_function_call_string(BgwJob *job)
 {
 	char prokind = get_func_prokind(ts_bgw_job_get_funcid(job));
@@ -1098,7 +1098,8 @@ ts_bgw_job_function_call_string(BgwJob *job)
 			break;
 		default:
 			ereport(ERROR,
-					(errcode(ERRCODE_FEATURE_NOT_SUPPORTED), errmsg("unsupported function type")));
+					(errcode(ERRCODE_WRONG_OBJECT_TYPE),
+					 errmsg("unsupported function type: %c", prokind)));
 			pg_unreachable();
 			break;
 	}
@@ -1263,7 +1264,7 @@ ts_bgw_job_entrypoint(PG_FUNCTION_ARGS)
 
 	if (!job_failed && ts_is_tss_enabled() && scheduler_test_hook == NULL)
 	{
-		char *stmt = ts_bgw_job_function_call_string(job);
+		const char *stmt = ts_bgw_job_function_call_string(job);
 		ts_end_tss_store_callback(stmt, -1, (int) strlen(stmt), 0, 0);
 	}
 

--- a/src/bgw/job.h
+++ b/src/bgw/job.h
@@ -84,3 +84,4 @@ extern TSDLLEXPORT bool ts_is_telemetry_job(BgwJob *job);
 ScanTupleResult ts_bgw_job_change_owner(TupleInfo *ti, void *data);
 
 extern TSDLLEXPORT Oid ts_bgw_job_get_funcid(BgwJob *job);
+extern TSDLLEXPORT const char *ts_bgw_job_function_call_string(BgwJob *job);

--- a/src/bgw/job.h
+++ b/src/bgw/job.h
@@ -82,3 +82,5 @@ extern TSDLLEXPORT char *ts_bgw_job_validate_timezone(Datum timezone);
 
 extern TSDLLEXPORT bool ts_is_telemetry_job(BgwJob *job);
 ScanTupleResult ts_bgw_job_change_owner(TupleInfo *ti, void *data);
+
+extern TSDLLEXPORT Oid ts_bgw_job_get_funcid(BgwJob *job);

--- a/src/tss_callbacks.c
+++ b/src/tss_callbacks.c
@@ -51,8 +51,8 @@ ts_get_tss_store_hook(void)
 	return NULL;
 }
 
-static bool
-is_tss_enabled(void)
+bool
+ts_is_tss_enabled(void)
 {
 	if (ts_guc_enable_tss_callbacks)
 	{
@@ -83,7 +83,7 @@ is_tss_enabled(void)
 void
 ts_begin_tss_store_callback(void)
 {
-	if (!is_tss_enabled())
+	if (!ts_is_tss_enabled())
 		return;
 
 	tss_callback_start_bufusage = pgBufferUsage;
@@ -100,7 +100,7 @@ ts_end_tss_store_callback(const char *query, int query_location, int query_len, 
 	WalUsage walusage;
 	tss_store_hook_type hook;
 
-	if (!is_tss_enabled())
+	if (!ts_is_tss_enabled())
 		return;
 
 	hook = ts_get_tss_store_hook();

--- a/src/tss_callbacks.h
+++ b/src/tss_callbacks.h
@@ -23,6 +23,7 @@ typedef struct TSSCallbacks
 	tss_enabled_hook_type tss_enabled_hook_type;
 } TSSCallbacks;
 
+extern bool ts_is_tss_enabled(void);
 extern void ts_begin_tss_store_callback(void);
 extern void ts_end_tss_store_callback(const char *query, int query_location, int query_len,
 									  uint64 query_id, uint64 rows);

--- a/test/src/bgw/CMakeLists.txt
+++ b/test/src/bgw/CMakeLists.txt
@@ -3,6 +3,7 @@ set(SOURCES
     ${CMAKE_CURRENT_SOURCE_DIR}/timer_mock.c
     ${CMAKE_CURRENT_SOURCE_DIR}/scheduler_mock.c
     ${CMAKE_CURRENT_SOURCE_DIR}/params.c
-    ${CMAKE_CURRENT_SOURCE_DIR}/test_job_refresh.c)
+    ${CMAKE_CURRENT_SOURCE_DIR}/test_job_refresh.c
+    ${CMAKE_CURRENT_SOURCE_DIR}/test_job_utils.c)
 
 target_sources(${TESTS_LIB_NAME} PRIVATE ${SOURCES})

--- a/test/src/bgw/test_job_utils.c
+++ b/test/src/bgw/test_job_utils.c
@@ -1,0 +1,22 @@
+/*
+ * This file and its contents are licensed under the Apache License 2.0.
+ * Please see the included NOTICE for copyright information and
+ * LICENSE-APACHE for a copy of the license.
+ */
+
+#include <postgres.h>
+#include <fmgr.h>
+#include <funcapi.h>
+
+#include "bgw/job.h"
+#include "test_utils.h"
+
+TS_TEST_FN(ts_test_bgw_job_function_call_string)
+{
+	int32 job_id = PG_GETARG_INT32(0);
+	BgwJob *job = ts_bgw_job_find(job_id, CurrentMemoryContext, true);
+
+	const char *stmt = ts_bgw_job_function_call_string(job);
+
+	PG_RETURN_TEXT_P(cstring_to_text(stmt));
+}

--- a/tsl/src/bgw_policy/job.c
+++ b/tsl/src/bgw_policy/job.c
@@ -567,7 +567,6 @@ job_execute(BgwJob *job)
 	bool portal_created = false;
 	char prokind;
 	Oid proc;
-	ObjectWithArgs *object;
 	FuncExpr *funcexpr;
 	MemoryContext parent_ctx = CurrentMemoryContext;
 	StringInfo query;
@@ -615,12 +614,7 @@ job_execute(BgwJob *job)
 	}
 #endif
 
-	object = makeNode(ObjectWithArgs);
-	object->objname = list_make2(makeString(NameStr(job->fd.proc_schema)),
-								 makeString(NameStr(job->fd.proc_name)));
-	object->objargs = list_make2(SystemTypeName("int4"), SystemTypeName("jsonb"));
-	proc = LookupFuncWithArgs(OBJECT_ROUTINE, object, false);
-
+	proc = ts_bgw_job_get_funcid(job);
 	prokind = get_func_prokind(proc);
 
 	/*

--- a/tsl/test/expected/bgw_custom.out
+++ b/tsl/test/expected/bgw_custom.out
@@ -1077,26 +1077,30 @@ SELECT delete_job(:job_proc);
 SELECT add_job('custom_func', '1h', config => '{"type":"function"}'::jsonb) AS job_func \gset
 SELECT add_job('custom_proc', '1h', config => '{"type":"procedure"}'::jsonb) AS job_proc \gset
 SELECT ts_test_bgw_job_function_call_string(:job_func);
-             ts_test_bgw_job_function_call_string              
----------------------------------------------------------------
- SELECT public.custom_func('1020', "{""type"": ""function""}")
+           ts_test_bgw_job_function_call_string            
+-----------------------------------------------------------
+ SELECT public.custom_func('1020', '{"type": "function"}')
 (1 row)
 
 SELECT ts_test_bgw_job_function_call_string(:job_proc);
-             ts_test_bgw_job_function_call_string             
---------------------------------------------------------------
- CALL public.custom_proc('1021', "{""type"": ""procedure""}")
+           ts_test_bgw_job_function_call_string           
+----------------------------------------------------------
+ CALL public.custom_proc('1021', '{"type": "procedure"}')
+(1 row)
+
+-- Remove the procedure and let's check it fallingback to PROKIND_FUNCTION
+DROP PROCEDURE custom_proc(jobid int, args jsonb);
+SELECT ts_test_bgw_job_function_call_string(:job_proc);
+            ts_test_bgw_job_function_call_string            
+------------------------------------------------------------
+ SELECT public.custom_proc('1021', '{"type": "procedure"}')
 (1 row)
 
 \set ON_ERROR_STOP 0
--- Check for on existing function
-DROP FUNCTION custom_func(jobid int, args jsonb);
-SELECT ts_test_bgw_job_function_call_string(:job_func);
-ERROR:  function public.custom_func(integer, jsonb) does not exist
 -- Mess with pg catalog to don't identify the PROKIND
 BEGIN;
-UPDATE pg_catalog.pg_proc SET prokind = 'X' WHERE oid = 'custom_proc(int,jsonb)'::regprocedure;
-SELECT ts_test_bgw_job_function_call_string(:job_proc);
+UPDATE pg_catalog.pg_proc SET prokind = 'X' WHERE oid = 'custom_func(int,jsonb)'::regprocedure;
+SELECT ts_test_bgw_job_function_call_string(:job_func);
 ERROR:  unsupported function type: X
 ROLLBACK;
 \set ON_ERROR_STOP 1

--- a/tsl/test/expected/bgw_custom.out
+++ b/tsl/test/expected/bgw_custom.out
@@ -1042,3 +1042,73 @@ SELECT delete_job(:job_id_3);
  
 (1 row)
 
+CREATE OR REPLACE FUNCTION ts_test_bgw_job_function_call_string(job_id INTEGER) RETURNS text
+AS :MODULE_PATHNAME LANGUAGE C STABLE STRICT;
+\set ON_ERROR_STOP 0
+SELECT ts_test_bgw_job_function_call_string(999999);
+ERROR:  job 999999 not found
+\set ON_ERROR_STOP 1
+SELECT add_job('custom_func', '1h') AS job_func \gset
+SELECT add_job('custom_proc', '1h') AS job_proc \gset
+SELECT ts_test_bgw_job_function_call_string(:job_func);
+  ts_test_bgw_job_function_call_string   
+-----------------------------------------
+ SELECT public.custom_func('1018', NULL)
+(1 row)
+
+SELECT ts_test_bgw_job_function_call_string(:job_proc);
+ ts_test_bgw_job_function_call_string  
+---------------------------------------
+ CALL public.custom_proc('1019', NULL)
+(1 row)
+
+SELECT delete_job(:job_func);
+ delete_job 
+------------
+ 
+(1 row)
+
+SELECT delete_job(:job_proc);
+ delete_job 
+------------
+ 
+(1 row)
+
+SELECT add_job('custom_func', '1h', config => '{"type":"function"}'::jsonb) AS job_func \gset
+SELECT add_job('custom_proc', '1h', config => '{"type":"procedure"}'::jsonb) AS job_proc \gset
+SELECT ts_test_bgw_job_function_call_string(:job_func);
+             ts_test_bgw_job_function_call_string              
+---------------------------------------------------------------
+ SELECT public.custom_func('1020', "{""type"": ""function""}")
+(1 row)
+
+SELECT ts_test_bgw_job_function_call_string(:job_proc);
+             ts_test_bgw_job_function_call_string             
+--------------------------------------------------------------
+ CALL public.custom_proc('1021', "{""type"": ""procedure""}")
+(1 row)
+
+\set ON_ERROR_STOP 0
+-- Check for on existing function
+DROP FUNCTION custom_func(jobid int, args jsonb);
+SELECT ts_test_bgw_job_function_call_string(:job_func);
+ERROR:  function public.custom_func(integer, jsonb) does not exist
+-- Mess with pg catalog to don't identify the PROKIND
+BEGIN;
+UPDATE pg_catalog.pg_proc SET prokind = 'X' WHERE oid = 'custom_proc(int,jsonb)'::regprocedure;
+SELECT ts_test_bgw_job_function_call_string(:job_proc);
+ERROR:  unsupported function type: X
+ROLLBACK;
+\set ON_ERROR_STOP 1
+SELECT delete_job(:job_func);
+ delete_job 
+------------
+ 
+(1 row)
+
+SELECT delete_job(:job_proc);
+ delete_job 
+------------
+ 
+(1 row)
+

--- a/tsl/test/expected/bgw_job_stat_history_errors.out
+++ b/tsl/test/expected/bgw_job_stat_history_errors.out
@@ -109,7 +109,7 @@ SELECT next_start FROM alter_job(3, next_start => '2060-01-01 00:00:00+00'::time
  Wed Dec 31 16:00:00 2059 PST
 (1 row)
 
-TRUNCATE TABLE _timescaledb_internal.bgw_job_stat_history;
+DELETE FROM _timescaledb_internal.bgw_job_stat_history;
 INSERT INTO _timescaledb_internal.bgw_job_stat_history(job_id, pid, succeeded, execution_start, execution_finish, data)
 VALUES (123, 12345, false, '2000-01-01 00:00:00+00'::timestamptz, '2000-01-01 00:00:10+00'::timestamptz, '{}'),
 (456, 45678, false, '2000-01-01 00:00:20+00'::timestamptz, '2000-01-01 00:00:40+00'::timestamptz, '{}'),
@@ -145,11 +145,22 @@ WHERE succeeded IS FALSE;
 (1 row)
 
 -- test failure when starting jobs
-TRUNCATE _timescaledb_internal.bgw_job_stat;
-TRUNCATE _timescaledb_internal.bgw_job_stat_history;
-TRUNCATE _timescaledb_config.bgw_job CASCADE;
-NOTICE:  truncate cascades to table "bgw_job_stat"
-NOTICE:  truncate cascades to table "bgw_policy_chunk_stats"
+\c :TEST_DBNAME :ROLE_SUPERUSER
+SELECT _timescaledb_functions.stop_background_workers();
+ stop_background_workers 
+-------------------------
+ t
+(1 row)
+
+DELETE FROM _timescaledb_internal.bgw_job_stat;
+DELETE FROM _timescaledb_internal.bgw_job_stat_history;
+DELETE FROM _timescaledb_config.bgw_job CASCADE;
+SELECT _timescaledb_functions.start_background_workers();
+ start_background_workers 
+--------------------------
+ t
+(1 row)
+
 \set VERBOSITY default
 -- Setup Jobs
 DO

--- a/tsl/test/sql/bgw_custom.sql
+++ b/tsl/test/sql/bgw_custom.sql
@@ -692,15 +692,15 @@ SELECT add_job('custom_proc', '1h', config => '{"type":"procedure"}'::jsonb) AS 
 SELECT ts_test_bgw_job_function_call_string(:job_func);
 SELECT ts_test_bgw_job_function_call_string(:job_proc);
 
-\set ON_ERROR_STOP 0
--- Check for on existing function
-DROP FUNCTION custom_func(jobid int, args jsonb);
-SELECT ts_test_bgw_job_function_call_string(:job_func);
+-- Remove the procedure and let's check it fallingback to PROKIND_FUNCTION
+DROP PROCEDURE custom_proc(jobid int, args jsonb);
+SELECT ts_test_bgw_job_function_call_string(:job_proc);
 
+\set ON_ERROR_STOP 0
 -- Mess with pg catalog to don't identify the PROKIND
 BEGIN;
-UPDATE pg_catalog.pg_proc SET prokind = 'X' WHERE oid = 'custom_proc(int,jsonb)'::regprocedure;
-SELECT ts_test_bgw_job_function_call_string(:job_proc);
+UPDATE pg_catalog.pg_proc SET prokind = 'X' WHERE oid = 'custom_func(int,jsonb)'::regprocedure;
+SELECT ts_test_bgw_job_function_call_string(:job_func);
 ROLLBACK;
 \set ON_ERROR_STOP 1
 

--- a/tsl/test/sql/bgw_custom.sql
+++ b/tsl/test/sql/bgw_custom.sql
@@ -665,7 +665,44 @@ SELECT _timescaledb_functions.stop_background_workers();
 CALL wait_for_job_status(:job_id_1, 'Scheduled');
 CALL wait_for_job_status(:job_id_2, 'Scheduled');
 CALL wait_for_job_status(:job_id_3, 'Scheduled');
+
 SELECT delete_job(:job_id_1);
 SELECT delete_job(:job_id_2);
 SELECT delete_job(:job_id_3);
 
+CREATE OR REPLACE FUNCTION ts_test_bgw_job_function_call_string(job_id INTEGER) RETURNS text
+AS :MODULE_PATHNAME LANGUAGE C STABLE STRICT;
+
+\set ON_ERROR_STOP 0
+SELECT ts_test_bgw_job_function_call_string(999999);
+\set ON_ERROR_STOP 1
+
+SELECT add_job('custom_func', '1h') AS job_func \gset
+SELECT add_job('custom_proc', '1h') AS job_proc \gset
+
+SELECT ts_test_bgw_job_function_call_string(:job_func);
+SELECT ts_test_bgw_job_function_call_string(:job_proc);
+
+SELECT delete_job(:job_func);
+SELECT delete_job(:job_proc);
+
+SELECT add_job('custom_func', '1h', config => '{"type":"function"}'::jsonb) AS job_func \gset
+SELECT add_job('custom_proc', '1h', config => '{"type":"procedure"}'::jsonb) AS job_proc \gset
+
+SELECT ts_test_bgw_job_function_call_string(:job_func);
+SELECT ts_test_bgw_job_function_call_string(:job_proc);
+
+\set ON_ERROR_STOP 0
+-- Check for on existing function
+DROP FUNCTION custom_func(jobid int, args jsonb);
+SELECT ts_test_bgw_job_function_call_string(:job_func);
+
+-- Mess with pg catalog to don't identify the PROKIND
+BEGIN;
+UPDATE pg_catalog.pg_proc SET prokind = 'X' WHERE oid = 'custom_proc(int,jsonb)'::regprocedure;
+SELECT ts_test_bgw_job_function_call_string(:job_proc);
+ROLLBACK;
+\set ON_ERROR_STOP 1
+
+SELECT delete_job(:job_func);
+SELECT delete_job(:job_proc);

--- a/tsl/test/sql/bgw_job_stat_history_errors.sql
+++ b/tsl/test/sql/bgw_job_stat_history_errors.sql
@@ -67,7 +67,7 @@ SELECT pg_reload_conf();
 
 -- test the retention job
 SELECT next_start FROM alter_job(3, next_start => '2060-01-01 00:00:00+00'::timestamptz);
-TRUNCATE TABLE _timescaledb_internal.bgw_job_stat_history;
+DELETE FROM _timescaledb_internal.bgw_job_stat_history;
 INSERT INTO _timescaledb_internal.bgw_job_stat_history(job_id, pid, succeeded, execution_start, execution_finish, data)
 VALUES (123, 12345, false, '2000-01-01 00:00:00+00'::timestamptz, '2000-01-01 00:00:10+00'::timestamptz, '{}'),
 (456, 45678, false, '2000-01-01 00:00:20+00'::timestamptz, '2000-01-01 00:00:40+00'::timestamptz, '{}'),
@@ -87,9 +87,14 @@ FROM _timescaledb_internal.bgw_job_stat_history
 WHERE succeeded IS FALSE;
 
 -- test failure when starting jobs
-TRUNCATE _timescaledb_internal.bgw_job_stat;
-TRUNCATE _timescaledb_internal.bgw_job_stat_history;
-TRUNCATE _timescaledb_config.bgw_job CASCADE;
+\c :TEST_DBNAME :ROLE_SUPERUSER
+SELECT _timescaledb_functions.stop_background_workers();
+
+DELETE FROM _timescaledb_internal.bgw_job_stat;
+DELETE FROM _timescaledb_internal.bgw_job_stat_history;
+DELETE FROM _timescaledb_config.bgw_job CASCADE;
+
+SELECT _timescaledb_functions.start_background_workers();
 
 \set VERBOSITY default
 -- Setup Jobs


### PR DESCRIPTION
Since our scheduler don't use SQL statements to execute Job procedures but instead we rely on internal Postgres API then `ts_stat_statements` can't record it execution.

Added the callbacks to `ts_stat_staments` on our scheduler to record the job procedure execution sending a query string like this:

```sql
CALL _timescaledb_functions.policy_refresh_continuous_aggregate($1, $2);
```

Disable-check: force-changelog-file
Disable-check: commit-count

