### PR TITLE
Optimize BGW CI tests

### DIFF
--- a/tsl/test/expected/bgw_custom.out
+++ b/tsl/test/expected/bgw_custom.out
@@ -876,7 +876,7 @@ INSERT INTO sensor_data
 		random() AS cpu,
 		random()* 100 AS temperature
 	FROM
-		generate_series(:'start_date_sd'::timestamptz - INTERVAL '1 months', :'start_date_sd'::timestamptz - INTERVAL '1 week', INTERVAL '1 minute') AS g1(time),
+		generate_series(:'start_date_sd'::timestamptz - INTERVAL '1 months', :'start_date_sd'::timestamptz - INTERVAL '1 week', INTERVAL '30 minute') AS g1(time),
 		generate_series(1, 50, 1 ) AS g2(sensor_id)
 	ORDER BY
 		time;
@@ -892,7 +892,7 @@ INSERT INTO sensor_data
 		random() AS cpu,
 		random()* 100 AS temperature
 	FROM
-		generate_series(:'start_date_sd'::timestamptz - INTERVAL '2 months', :'start_date_sd'::timestamptz - INTERVAL '2 week', INTERVAL '2 minute') AS g1(time),
+		generate_series(:'start_date_sd'::timestamptz - INTERVAL '2 months', :'start_date_sd'::timestamptz - INTERVAL '2 week', INTERVAL '60 minute') AS g1(time),
 		generate_series(1, 30, 1 ) AS g2(sensor_id)
 	ORDER BY
 		time;

--- a/tsl/test/expected/bgw_job_stat_history_errors.out
+++ b/tsl/test/expected/bgw_job_stat_history_errors.out
@@ -30,7 +30,7 @@ CREATE OR REPLACE PROCEDURE custom_proc1(jobid int, config jsonb) LANGUAGE PLPGS
 $$
 BEGIN
   UPDATE custom_log set msg = 'msg1' where msg = 'msg0';
-  perform pg_sleep(10);
+  perform pg_sleep(5);
   COMMIT;
 END
 $$;
@@ -38,7 +38,6 @@ CREATE OR REPLACE PROCEDURE custom_proc2(jobid int, config jsonb) LANGUAGE PLPGS
 $$
 BEGIN
   UPDATE custom_log set msg = 'msg2' where msg = 'msg0';
-  perform pg_sleep(10);
   COMMIT;
 END
 $$;
@@ -49,7 +48,7 @@ select add_job('custom_proc1', '2 min', initial_start => now());
 (1 row)
 
 -- to make sure custom_log is first updated by custom_proc_1
-select add_job('custom_proc2', '2 min', initial_start => now() + interval '5 seconds');
+select add_job('custom_proc2', '2 min', initial_start => now() + interval '2 seconds');
  add_job 
 ---------
     1002
@@ -62,7 +61,7 @@ SELECT _timescaledb_functions.start_background_workers();
 (1 row)
 
 -- enough time to for job_fail to fail
-select pg_sleep(10);
+select pg_sleep(5);
  pg_sleep 
 ----------
  
@@ -81,7 +80,7 @@ select delete_job(:jobf_id);
  
 (1 row)
 
-select pg_sleep(20);
+select pg_sleep(5);
  pg_sleep 
 ----------
  

--- a/tsl/test/sql/bgw_custom.sql
+++ b/tsl/test/sql/bgw_custom.sql
@@ -549,7 +549,7 @@ INSERT INTO sensor_data
 		random() AS cpu,
 		random()* 100 AS temperature
 	FROM
-		generate_series(:'start_date_sd'::timestamptz - INTERVAL '1 months', :'start_date_sd'::timestamptz - INTERVAL '1 week', INTERVAL '1 minute') AS g1(time),
+		generate_series(:'start_date_sd'::timestamptz - INTERVAL '1 months', :'start_date_sd'::timestamptz - INTERVAL '1 week', INTERVAL '30 minute') AS g1(time),
 		generate_series(1, 50, 1 ) AS g2(sensor_id)
 	ORDER BY
 		time;
@@ -565,7 +565,7 @@ INSERT INTO sensor_data
 		random() AS cpu,
 		random()* 100 AS temperature
 	FROM
-		generate_series(:'start_date_sd'::timestamptz - INTERVAL '2 months', :'start_date_sd'::timestamptz - INTERVAL '2 week', INTERVAL '2 minute') AS g1(time),
+		generate_series(:'start_date_sd'::timestamptz - INTERVAL '2 months', :'start_date_sd'::timestamptz - INTERVAL '2 week', INTERVAL '60 minute') AS g1(time),
 		generate_series(1, 30, 1 ) AS g2(sensor_id)
 	ORDER BY
 		time;


### PR DESCRIPTION
This change helps optimize two bgw tests, by a) reducing the time a test spends waiting for scheduled jobs and b) decreasing the amount of data inserted into the table. This should have no effect on the efficacy of the tests themselves.

Disable-check: force-changelog-file