### PR TITLE
Add index to compression_chunk_size catalog table

### DIFF
--- a/.unreleased/pr_7227
+++ b/.unreleased/pr_7227
@@ -1,0 +1,1 @@
+Fixes: #7227 Add index to compression_chunk_size catalog table

--- a/sql/pre_install/tables.sql
+++ b/sql/pre_install/tables.sql
@@ -502,6 +502,11 @@ CREATE TABLE _timescaledb_catalog.compression_chunk_size (
   CONSTRAINT compression_chunk_size_compressed_chunk_id_fkey FOREIGN KEY (compressed_chunk_id) REFERENCES _timescaledb_catalog.chunk (id) ON DELETE CASCADE
 );
 
+-- Create index on the compressed_chunk_id to speed up maintainance
+-- operations during upgrades. This is mostly relevant for very large
+-- number of chunks.
+CREATE INDEX compression_chunk_size_idx ON _timescaledb_catalog.compression_chunk_size (compressed_chunk_id);
+
 SELECT pg_catalog.pg_extension_config_dump('_timescaledb_catalog.compression_chunk_size', '');
 
 CREATE TABLE _timescaledb_catalog.continuous_agg_migrate_plan (

--- a/sql/updates/latest-dev.sql
+++ b/sql/updates/latest-dev.sql
@@ -2,3 +2,5 @@ CREATE FUNCTION _timescaledb_functions.compressed_data_info(_timescaledb_interna
     RETURNS TABLE (algorithm name, has_nulls bool)
     AS '@MODULE_PATHNAME@', 'ts_update_placeholder'
     LANGUAGE C STRICT IMMUTABLE SET search_path = pg_catalog, pg_temp;
+
+CREATE INDEX compression_chunk_size_idx ON _timescaledb_catalog.compression_chunk_size (compressed_chunk_id);

--- a/sql/updates/reverse-dev.sql
+++ b/sql/updates/reverse-dev.sql
@@ -1,1 +1,2 @@
 DROP FUNCTION _timescaledb_functions.compressed_data_info(_timescaledb_internal.compressed_data);
+DROP INDEX _timescaledb_catalog.compression_chunk_size_idx;


### PR DESCRIPTION
During upgrade the function `remove_dropped_chunk_metadata` is used to update the metadata tables and remove data for chunks marked as dropped. The function iterates of the chunks of the provided hypertable and internally does a sequence scan of `compression_chunk_size` table to locate the `compressed_chunk_id`, resulting in quadratic execution time. This is usually not noticed for small number of chunks, but for large number of chunks this becomes a problem.

This commit fixes this by adding an index to `compression_chunk_size` catalog table, turning the sequence scan into an index scan.