### PR TITLE
Fix FK constraint where index and constraint column order differ

### DIFF
--- a/.unreleased/pr_7229
+++ b/.unreleased/pr_7229
@@ -1,0 +1,1 @@
+Fixes: #7229 Fix foreign key constraints where index and constraint column order differ

--- a/tsl/test/expected/foreign_keys.out
+++ b/tsl/test/expected/foreign_keys.out
@@ -1014,3 +1014,14 @@ EXPLAIN (analyze, costs off, timing off, summary off) SELECT * FROM ht;
 (4 rows)
 
 ROLLBACK;
+-- #7226
+-- test multi-column fk constraint where constraint column order is different from index column order
+CREATE TABLE i7226(time timestamptz, device_id int, PRIMARY KEY (device_id, time));
+SELECT create_hypertable('i7226', 'time');
+  create_hypertable  
+---------------------
+ (15,public,i7226,t)
+(1 row)
+
+CREATE TABLE i7226_valid(time timestamptz NOT NULL,device_id int NOT NULL, FOREIGN KEY(time, device_id) REFERENCES i7226(time, device_id));
+INSERT INTO i7226 VALUES ('2024-08-29 12:00:00+00', 1);

--- a/tsl/test/sql/foreign_keys.sql
+++ b/tsl/test/sql/foreign_keys.sql
@@ -642,3 +642,11 @@ SELECT * FROM ht;
 EXPLAIN (analyze, costs off, timing off, summary off) SELECT * FROM ht;
 ROLLBACK;
 
+-- #7226
+-- test multi-column fk constraint where constraint column order is different from index column order
+CREATE TABLE i7226(time timestamptz, device_id int, PRIMARY KEY (device_id, time));
+SELECT create_hypertable('i7226', 'time');
+
+CREATE TABLE i7226_valid(time timestamptz NOT NULL,device_id int NOT NULL, FOREIGN KEY(time, device_id) REFERENCES i7226(time, device_id));
+INSERT INTO i7226 VALUES ('2024-08-29 12:00:00+00', 1);
+


### PR DESCRIPTION
The code for finding the constraint index was expecting the index columns to be in the same order as the constraint columns. This patch changes the check to require all columns be present independent of the order.

Fixes #7226