### PR TITLE
Don't propagate fk constraints to osm chunk

### DIFF
--- a/.unreleased/pr_7230
+++ b/.unreleased/pr_7230
@@ -1,0 +1,1 @@
+Fixes: #7230 Don't propagate fk constraints to osm chunk

--- a/src/foreign_key.c
+++ b/src/foreign_key.c
@@ -80,6 +80,9 @@ propagate_fk(Relation ht_rel, HeapTuple fk_tuple, List *chunks)
 	foreach (lc, chunks)
 	{
 		Chunk *chunk = lfirst(lc);
+		if (chunk->fd.osm_chunk)
+			continue;
+
 		clone_constraint_on_chunk(chunk,
 								  ht_rel,
 								  fk,

--- a/tsl/test/expected/chunk_utils_internal.out
+++ b/tsl/test/expected/chunk_utils_internal.out
@@ -1645,4 +1645,56 @@ psql:include/chunk_utils_internal_orderedappend.sql:178: ERROR:  Cannot insert i
 INSERT INTO osm_slice_update VALUES (1);
 psql:include/chunk_utils_internal_orderedappend.sql:179: ERROR:  Cannot insert into tiered chunk range of public.osm_slice_update - attempt to create new chunk with range  [0 10] failed
 \set ON_ERROR_STOP 1
-DROP DATABASE postgres_fdw_db;
+--TEST hypertable with foreign key into it
+\c :TEST_DBNAME :ROLE_4
+CREATE TABLE hyper_fk(ts timestamptz primary key, device text, value float);
+SELECT table_name FROM create_hypertable('hyper_fk', 'ts');
+ table_name 
+------------
+ hyper_fk
+(1 row)
+
+INSERT INTO hyper_fk(ts, device, value) VALUES ('2020-01-01 00:00:00+00', 'd1', 1.0);
+\c postgres_fdw_db :ROLE_4
+CREATE TABLE fdw_hyper_fk(ts timestamptz NOT NULL, device text, value float);
+INSERT INTO fdw_hyper_fk VALUES( '2021-05-05 00:00:00+00', 'd2', 2.0);
+\c :TEST_DBNAME :ROLE_4
+-- this is a stand-in for the OSM table
+CREATE FOREIGN TABLE child_hyper_fk
+(ts timestamptz NOT NULL, device text, value float)
+ SERVER s3_server OPTIONS ( schema_name 'public', table_name 'fdw_hyper_fk');
+SELECT _timescaledb_functions.attach_osm_table_chunk('hyper_fk', 'child_hyper_fk');
+ attach_osm_table_chunk 
+------------------------
+ t
+(1 row)
+
+--create table with fk into hypertable
+CREATE TABLE event(ts timestamptz REFERENCES hyper_fk(ts) , info text);
+-- NOTE: current behavior is to allow inserts/deletes from PG tables when data
+-- references OSM table.
+--insert referencing OSM chunk
+INSERT INTO event VALUES( '2021-05-05 00:00:00+00' , 'osm_chunk_ts');
+--insert referencing non-existent value
+\set ON_ERROR_STOP 0
+INSERT INTO event VALUES( '2020-01-02 00:00:00+00' , 'does_not_exist_ts');
+ERROR:  insert or update on table "event" violates foreign key constraint "event_ts_fkey"
+\set ON_ERROR_STOP 1
+INSERT INTO event VALUES( '2020-01-01 00:00:00+00' , 'chunk_ts');
+SELECT * FROM event ORDER BY ts;
+              ts              |     info     
+------------------------------+--------------
+ Tue Dec 31 16:00:00 2019 PST | chunk_ts
+ Tue May 04 17:00:00 2021 PDT | osm_chunk_ts
+(2 rows)
+
+DELETE FROM event WHERE  info = 'osm_chunk_ts';
+DELETE FROM event WHERE  info = 'chunk_ts';
+SELECT * FROM event ORDER BY ts;
+ ts | info 
+----+------
+(0 rows)
+
+-- clean up databases created
+\c :TEST_DBNAME :ROLE_SUPERUSER
+DROP DATABASE postgres_fdw_db WITH (FORCE);


### PR DESCRIPTION
The osm chunk is a foreign table which does not support constraints so we have to exclude the osm chunk when propagating fk constraints.

Fixes #7188