### PR TITLE
Release cache after accessing the cache entry

### DIFF
--- a/.unreleased/pr_7234
+++ b/.unreleased/pr_7234
@@ -1,0 +1,1 @@
+Fixes: #7234 Release cache after accessing the cache entry

--- a/src/nodes/chunk_dispatch/chunk_dispatch.c
+++ b/src/nodes/chunk_dispatch/chunk_dispatch.c
@@ -4,6 +4,7 @@
  * LICENSE-APACHE for a copy of the license.
  */
 #include <postgres.h>
+#include <access/attnum.h>
 #include <access/xact.h>
 #include <catalog/pg_type.h>
 #include <nodes/extensible.h>
@@ -323,6 +324,32 @@ on_chunk_insert_state_changed(ChunkInsertState *cis, void *data)
 	state->rri = cis->result_relation_info;
 }
 
+#if PG15_GE
+static AttrNumber
+rel_get_natts(Oid relid)
+{
+	HeapTuple tp = SearchSysCache1(RELOID, ObjectIdGetDatum(relid));
+
+	if (!HeapTupleIsValid(tp))
+		elog(ERROR, "cache lookup failed for relation %u", relid);
+	AttrNumber natts = ((Form_pg_class) GETSTRUCT(tp))->relnatts;
+	ReleaseSysCache(tp);
+	return natts;
+}
+
+static bool
+attr_is_dropped_or_missing(Oid relid, AttrNumber attno)
+{
+	HeapTuple tp = SearchSysCache2(ATTNUM, ObjectIdGetDatum(relid), Int16GetDatum(attno));
+	if (!HeapTupleIsValid(tp))
+		return false;
+	Form_pg_attribute att_tup = (Form_pg_attribute) GETSTRUCT(tp);
+	bool result = att_tup->attisdropped || att_tup->atthasmissing;
+	ReleaseSysCache(tp);
+	return result;
+}
+#endif
+
 static TupleTableSlot *
 chunk_dispatch_exec(CustomScanState *node)
 {
@@ -352,28 +379,13 @@ chunk_dispatch_exec(CustomScanState *node)
 	TupleTableSlot *newslot = NULL;
 	if (dispatch->dispatch_state->mtstate->operation == CMD_MERGE)
 	{
-		HeapTuple tp;
-		AttrNumber natts;
-		AttrNumber attno;
-
-		tp = SearchSysCache1(RELOID, ObjectIdGetDatum(ht->main_table_relid));
-		if (!HeapTupleIsValid(tp))
-			elog(ERROR, "cache lookup failed for relation %u", ht->main_table_relid);
-		natts = ((Form_pg_class) GETSTRUCT(tp))->relnatts;
-		ReleaseSysCache(tp);
-		for (attno = 1; attno <= natts; attno++)
+		const AttrNumber natts = rel_get_natts(ht->main_table_relid);
+		for (AttrNumber attno = 1; attno <= natts; attno++)
 		{
-			tp = SearchSysCache2(ATTNUM,
-								 ObjectIdGetDatum(ht->main_table_relid),
-								 Int16GetDatum(attno));
-			if (!HeapTupleIsValid(tp))
-				continue;
-			Form_pg_attribute att_tup = (Form_pg_attribute) GETSTRUCT(tp);
-			ReleaseSysCache(tp);
-			if (att_tup->attisdropped || att_tup->atthasmissing)
+			if (attr_is_dropped_or_missing(ht->main_table_relid, attno))
 			{
 				state->is_dropped_attr_exists = true;
-				continue;
+				break;
 			}
 		}
 		for (int i = 0; i < ht->space->num_dimensions; i++)

--- a/test/expected/merge.out
+++ b/test/expected/merge.out
@@ -7,7 +7,7 @@ CREATE TABLE target (
    time        TIMESTAMPTZ       NOT NULL,
    location    SMALLINT          NOT NULL,
    temperature DOUBLE PRECISION  NULL,
-   val text default 'string -'
+   to_be_dropped text
 );
 SELECT create_hypertable(
   'target',
@@ -26,6 +26,13 @@ FROM generate_series(
     INTERVAL '5 seconds'
   ) as time,
 generate_series(1,4) as location;
+-- This makes sure we have one column with attisdropped and one column
+-- with atthasmissing set to true. These two cases can cause problems
+-- with chunk dispatch execution when merging using a when-clause with
+-- inserts. Unfortunately they are hard to trigger, so this is not a
+-- definitive test.
+ALTER TABLE target DROP COLUMN to_be_dropped;
+ALTER TABLE target ADD COLUMN val text default 'string -';
 -- Create source table with location and temperature
 CREATE TABLE source (
    time        TIMESTAMPTZ       NOT NULL,

--- a/test/sql/merge.sql
+++ b/test/sql/merge.sql
@@ -9,7 +9,7 @@ CREATE TABLE target (
    time        TIMESTAMPTZ       NOT NULL,
    location    SMALLINT          NOT NULL,
    temperature DOUBLE PRECISION  NULL,
-   val text default 'string -'
+   to_be_dropped text
 );
 
 SELECT create_hypertable(
@@ -25,6 +25,14 @@ FROM generate_series(
     INTERVAL '5 seconds'
   ) as time,
 generate_series(1,4) as location;
+
+-- This makes sure we have one column with attisdropped and one column
+-- with atthasmissing set to true. These two cases can cause problems
+-- with chunk dispatch execution when merging using a when-clause with
+-- inserts. Unfortunately they are hard to trigger, so this is not a
+-- definitive test.
+ALTER TABLE target DROP COLUMN to_be_dropped;
+ALTER TABLE target ADD COLUMN val text default 'string -';
 
 -- Create source table with location and temperature
 CREATE TABLE source (


### PR DESCRIPTION
The cache entry is released while a pointer is still pointing into the entry, which can potentially lead to accessing freed memory. The scenario for triggering this is quite complicated, but it requires a MERGE that has an INSERT statement on a table that either has dropped a column or added a column with a non-volatile default value.

Co-authored-by: Gayathri Ayyappan <gayathri@timescale.com>