### PR TITLE
Fix TAP tests for PG17

### DIFF
--- a/.github/gh_matrix_builder.py
+++ b/.github/gh_matrix_builder.py
@@ -187,8 +187,6 @@ m["include"].append(
             "pg": "17",
             "snapshot": "snapshot",
             "tsdb_build_args": "-DEXPERIMENTAL=ON",
-            # @TODO: those skipped tests should be revisited later
-            "skipped_tests": "001_job_crash_log",
         }
     )
 )

--- a/tsl/test/t/001_job_crash_log.pl
+++ b/tsl/test/t/001_job_crash_log.pl
@@ -12,7 +12,7 @@ use Test::More tests => 5;
 # We cannot do that with a regression test because the server will not recover after
 # a crash in that case
 
-my $node = TimescaleNode->create();
+my $node = TimescaleNode->create('job_crash_log');
 
 # by default PostgresNode doesn't doesn't restart after a crash
 # taken from 013_crash_restart.pl


### PR DESCRIPTION
PG17 TAP seems to require explicit node name.

Disable-check: force-changelog-file
