### PR TITLE
PG17: Fix makeaclitem

### DIFF
--- a/.github/gh_matrix_builder.py
+++ b/.github/gh_matrix_builder.py
@@ -188,7 +188,7 @@ m["include"].append(
             "snapshot": "snapshot",
             "tsdb_build_args": "-DEXPERIMENTAL=ON",
             # @TODO: those skipped tests should be revisited later
-            "skipped_tests": "repair 001_job_crash_log",
+            "skipped_tests": "001_job_crash_log",
         }
     )
 )

--- a/src/utils.c
+++ b/src/utils.c
@@ -1697,6 +1697,9 @@ ts_makeaclitem(PG_FUNCTION_ARGS)
 		{ "SET", ACL_SET },
 		{ "ALTER SYSTEM", ACL_ALTER_SYSTEM },
 #endif
+#if PG17_GE
+		{ "MAINTAIN", ACL_MAINTAIN },
+#endif
 		{ "RULE", 0 }, /* ignore old RULE privileges */
 		{ NULL, 0 }
 	};


### PR DESCRIPTION
Postgres 17 introduced the MAINTAIN privilege.

postgres/postgres@ecb0fd33

Disable-check: force-changelog-file
