### PR TITLE
Force english in pg_config command

### DIFF
--- a/.unreleased/pr_7258
+++ b/.unreleased/pr_7258
@@ -1,0 +1,2 @@
+Fixes: #7258 Force English in the pg_config command executed by cmake to avoid unexpected building errors
+Thanks: @MiguelTubio for reporting and fixing a Windows build error

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -41,7 +41,7 @@ function(GET_PG_CONFIG var)
   # Only call pg_config if the variable didn't already have a value.
   if(NOT ${var})
     execute_process(
-      COMMAND ${PG_CONFIG} ${ARGN}
+      COMMAND ${CMAKE_COMMAND} -E env LC_MESSAGES=C ${PG_CONFIG} ${ARGN}
       OUTPUT_VARIABLE _temp
       OUTPUT_STRIP_TRAILING_WHITESPACE)
   endif()


### PR DESCRIPTION
Force English in the pg_config command executed by cmake to avoid unexpected building errors. 
Fixes #7257