### PR TITLE
Fix maintain test output

### DIFF
--- a/tsl/test/expected/privilege_maintain.out
+++ b/tsl/test/expected/privilege_maintain.out
@@ -1,6 +1,6 @@
--- This file and its contents are licensed under the Apache License 2.0.
+-- This file and its contents are licensed under the Timescale License.
 -- Please see the included NOTICE for copyright information and
--- LICENSE-APACHE for a copy of the license.
+-- LICENSE-TIMESCALE for a copy of the license.
 \c :TEST_DBNAME :ROLE_SUPERUSER
 CREATE ROLE r_maintain;
 CREATE TABLE metrics(time timestamptz, device text, value float);


### PR DESCRIPTION
The license was adjusted in the sql file but not in the output file of the MAINTAIN test.