### PR TITLE
Grant USAGE on debug schema

### DIFF
--- a/sql/pre_install/schemas.sql
+++ b/sql/pre_install/schemas.sql
@@ -20,6 +20,7 @@ GRANT USAGE ON SCHEMA
       _timescaledb_internal,
       _timescaledb_config,
       timescaledb_information,
-      timescaledb_experimental
+      timescaledb_experimental,
+      _timescaledb_debug
 TO PUBLIC;
 

--- a/test/expected/debug_utils.out
+++ b/test/expected/debug_utils.out
@@ -2,18 +2,14 @@
 -- Please see the included NOTICE for copyright information and
 -- LICENSE-APACHE for a copy of the license.
 \c :TEST_DBNAME :ROLE_SUPERUSER
+SET ROLE :ROLE_DEFAULT_PERM_USER;
 SELECT _timescaledb_debug.extension_state();
  extension_state 
 -----------------
  created
 (1 row)
 
-SET ROLE :ROLE_DEFAULT_PERM_USER;
-\set ON_ERROR_STOP 0
-SELECT _timescaledb_debug.extension_state();
-ERROR:  permission denied for schema _timescaledb_debug at character 8
-\set ON_ERROR_STOP 1
-\c :TEST_DBNAME :ROLE_SUPERUSER
+RESET ROLE;
 DO $$
 DECLARE
     module text;

--- a/test/sql/CMakeLists.txt
+++ b/test/sql/CMakeLists.txt
@@ -18,8 +18,8 @@ set(TEST_FILES
     ddl.sql
     ddl_errors.sql
     ddl_extra.sql
-    delete.sql
     debug_utils.sql
+    delete.sql
     drop_extension.sql
     drop_hypertable.sql
     drop_rename_hypertable.sql

--- a/test/sql/debug_utils.sql
+++ b/test/sql/debug_utils.sql
@@ -3,15 +3,12 @@
 -- LICENSE-APACHE for a copy of the license.
 
 \c :TEST_DBNAME :ROLE_SUPERUSER
-SELECT _timescaledb_debug.extension_state();
-
 SET ROLE :ROLE_DEFAULT_PERM_USER;
 
-\set ON_ERROR_STOP 0
 SELECT _timescaledb_debug.extension_state();
-\set ON_ERROR_STOP 1
 
-\c :TEST_DBNAME :ROLE_SUPERUSER
+RESET ROLE;
+
 DO $$
 DECLARE
     module text;


### PR DESCRIPTION
Make it possible for regular users to execute functions in the schema `_timescaledb_debug`.

As a consequence, the `extension_state()` function in this schema can now be executed by "public". This is the only function in this schema and there is no security risk in making it accessible.

Disable-check: force-changelog-file