### PR TITLE
Reset per compressed row memory context during tuple filtering

### DIFF
--- a/.unreleased/pr_7270
+++ b/.unreleased/pr_7270
@@ -1,0 +1,1 @@
+Fixes: #7270 Fix memory leak in compressed DML batch filtering

--- a/tsl/src/compression/compression.c
+++ b/tsl/src/compression/compression.c
@@ -1471,6 +1471,7 @@ build_decompressor(Relation in_rel, Relation out_rel)
 void
 row_decompressor_reset(RowDecompressor *decompressor)
 {
+	MemoryContextReset(decompressor->per_compressed_row_ctx);
 	decompressor->unprocessed_tuples = 0;
 	decompressor->batches_decompressed = 0;
 	decompressor->tuples_decompressed = 0;
@@ -1805,8 +1806,6 @@ row_decompressor_decompress_row_to_table(RowDecompressor *decompressor)
 	}
 
 	MemoryContextSwitchTo(old_ctx);
-	MemoryContextReset(decompressor->per_compressed_row_ctx);
-
 	row_decompressor_reset(decompressor);
 
 	return n_batch_rows;
@@ -1826,8 +1825,6 @@ row_decompressor_decompress_row_to_tuplesort(RowDecompressor *decompressor,
 	}
 
 	MemoryContextSwitchTo(old_ctx);
-	MemoryContextReset(decompressor->per_compressed_row_ctx);
-
 	row_decompressor_reset(decompressor);
 }
 


### PR DESCRIPTION
When a batch was skipped due to compression tuple filtering the per compressed row memory context would not be reset leading to memory usage increasing linearly with number of consecutive filtered batches.