### PR TITLE
Add debug functionality

### DIFF
--- a/src/utils.h
+++ b/src/utils.h
@@ -8,6 +8,7 @@
 #include <postgres.h>
 
 #include <access/htup_details.h>
+#include <access/tupdesc.h>
 #include <catalog/namespace.h>
 #include <catalog/pg_proc.h>
 #include <common/int.h>
@@ -20,6 +21,67 @@
 #include <utils/jsonb.h>
 
 #include "compat/compat.h"
+
+/*
+ * Macro for debug messages that should *only* be present in debug builds but
+ * which should be removed in release builds. This is typically used for
+ * debug builds for development purposes.
+ *
+ * Note that some debug messages might be relevant to deploy in release build
+ * for debugging production systems. This macro is *not* for those cases.
+ */
+#ifdef TS_DEBUG
+#define TS_DEBUG_LOG(FMT, ...) elog(DEBUG2, "%s - " FMT, __func__, ##__VA_ARGS__)
+#else
+#define TS_DEBUG_LOG(FMT, ...)
+#endif
+
+#ifdef TS_DEBUG
+
+static inline const char *
+yes_no(bool value)
+{
+	return value ? "yes" : "no";
+}
+
+/* Convert datum to string using the output function. */
+static inline const char *
+datum_as_string(Oid typid, Datum value, bool is_null)
+{
+	Oid typoutput;
+	bool typIsVarlena;
+
+	if (is_null)
+		return "<NULL>";
+
+	getTypeOutputInfo(typid, &typoutput, &typIsVarlena);
+	return OidOutputFunctionCall(typoutput, value);
+}
+
+static inline const char *
+slot_as_string(TupleTableSlot *slot)
+{
+	StringInfoData info;
+	initStringInfo(&info);
+	appendStringInfoString(&info, "{");
+	for (int i = 0; i < slot->tts_tupleDescriptor->natts; i++)
+	{
+		Form_pg_attribute att = TupleDescAttr(slot->tts_tupleDescriptor, i);
+
+		if (att->attisdropped)
+			continue;
+		appendStringInfo(&info,
+						 "%s: %s",
+						 NameStr(att->attname),
+						 datum_as_string(att->atttypid, slot->tts_values[i], slot->tts_isnull[i]));
+		if (i + 1 < slot->tts_tupleDescriptor->natts)
+			appendStringInfoString(&info, ", ");
+	}
+	appendStringInfoString(&info, "}");
+	return info.data;
+}
+
+#endif /* TS_DEBUG */
 
 /*
  * Get the function name in a PG_FUNCTION.


### PR DESCRIPTION
Add macro `TS_DEBUG_LOG` to allow debug-only messages that are not added in release builds. Using `elog` or `ereport` with `DEBUG2` will still run the logging functions in release builds, which is unnecessary for logging messages that are strictly used for development.

Add function `datum_as_string` that converts a datum to a string using the output function. Mainly used for debug outputs.

Add function `slot_as_string` that convers a slot into a string representation for debug output.

Disable-check: force-changelog-file