### PR TITLE
Use explicit timezone in tests

### DIFF
--- a/tsl/test/expected/bgw_db_scheduler_fixed.out
+++ b/tsl/test/expected/bgw_db_scheduler_fixed.out
@@ -5,6 +5,7 @@
 -- Setup
 --
 \c :TEST_DBNAME :ROLE_SUPERUSER
+SET timezone TO PST8PDT;
 -- this mock_start_time doesnt seem to be used anywhere
 CREATE OR REPLACE FUNCTION ts_bgw_db_scheduler_test_run_and_wait_for_scheduler_finish(timeout INT = -1, mock_start_time INT = 0) RETURNS VOID
 AS :MODULE_PATHNAME LANGUAGE C VOLATILE;
@@ -93,6 +94,7 @@ $BODY$;
 DELETE FROM _timescaledb_config.bgw_job WHERE TRUE;
 TRUNCATE _timescaledb_internal.bgw_job_stat;
 \c :TEST_DBNAME :ROLE_DEFAULT_PERM_USER
+SET timezone TO PST8PDT;
 CREATE TABLE public.bgw_log(
     msg_no INT,
     mock_time BIGINT,
@@ -297,6 +299,7 @@ select * from _timescaledb_config.bgw_job;
 (1 row)
 
 \c :TEST_DBNAME :ROLE_DEFAULT_PERM_USER
+SET timezone TO PST8PDT;
 --Tests that the scheduler start a job right away if it's the first time and there is no job_stat entry for it
 SELECT ts_bgw_db_scheduler_test_run_and_wait_for_scheduler_finish(25);
  ts_bgw_db_scheduler_test_run_and_wait_for_scheduler_finish 
@@ -421,6 +424,7 @@ SELECT insert_job('test_job_2', 'bgw_test_job_2_error', INTERVAL '800ms', INTERV
 (1 row)
 
 \c :TEST_DBNAME :ROLE_DEFAULT_PERM_USER
+SET timezone TO PST8PDT;
 --Run the first time and error
 SELECT ts_bgw_db_scheduler_test_run_and_wait_for_scheduler_finish(25);
  ts_bgw_db_scheduler_test_run_and_wait_for_scheduler_finish 
@@ -1244,6 +1248,7 @@ SELECT _timescaledb_functions.stop_background_workers();
  t
 (1 row)
 
+SET timezone TO PST8PDT;
 CREATE OR REPLACE FUNCTION ts_test_job_refresh() RETURNS TABLE(
 id INTEGER,
 application_name NAME,

--- a/tsl/test/expected/cagg_ddl-14.out
+++ b/tsl/test/expected/cagg_ddl-14.out
@@ -22,6 +22,7 @@ SELECT table_name FROM create_hypertable('conditions', 'timec');
 
 -- schema tests
 \c :TEST_DBNAME :ROLE_CLUSTER_SUPERUSER
+SET timezone TO PST8PDT;
 -- drop if the tablespace1 and/or tablespace2 exists
 SET client_min_messages TO error;
 DROP TABLESPACE IF EXISTS tablespace1;

--- a/tsl/test/expected/cagg_ddl-15.out
+++ b/tsl/test/expected/cagg_ddl-15.out
@@ -22,6 +22,7 @@ SELECT table_name FROM create_hypertable('conditions', 'timec');
 
 -- schema tests
 \c :TEST_DBNAME :ROLE_CLUSTER_SUPERUSER
+SET timezone TO PST8PDT;
 -- drop if the tablespace1 and/or tablespace2 exists
 SET client_min_messages TO error;
 DROP TABLESPACE IF EXISTS tablespace1;

--- a/tsl/test/expected/cagg_ddl-16.out
+++ b/tsl/test/expected/cagg_ddl-16.out
@@ -22,6 +22,7 @@ SELECT table_name FROM create_hypertable('conditions', 'timec');
 
 -- schema tests
 \c :TEST_DBNAME :ROLE_CLUSTER_SUPERUSER
+SET timezone TO PST8PDT;
 -- drop if the tablespace1 and/or tablespace2 exists
 SET client_min_messages TO error;
 DROP TABLESPACE IF EXISTS tablespace1;

--- a/tsl/test/expected/cagg_ddl-17.out
+++ b/tsl/test/expected/cagg_ddl-17.out
@@ -22,6 +22,7 @@ SELECT table_name FROM create_hypertable('conditions', 'timec');
 
 -- schema tests
 \c :TEST_DBNAME :ROLE_CLUSTER_SUPERUSER
+SET timezone TO PST8PDT;
 -- drop if the tablespace1 and/or tablespace2 exists
 SET client_min_messages TO error;
 DROP TABLESPACE IF EXISTS tablespace1;

--- a/tsl/test/expected/cagg_drop_chunks.out
+++ b/tsl/test/expected/cagg_drop_chunks.out
@@ -2,6 +2,7 @@
 -- Please see the included NOTICE for copyright information and
 -- LICENSE-TIMESCALE for a copy of the license.
 \c :TEST_DBNAME :ROLE_SUPERUSER
+SET timezone TO PST8PDT;
 --
 -- Check that drop chunks with a unique constraint works as expected.
 --

--- a/tsl/test/expected/cagg_dump.out
+++ b/tsl/test/expected/cagg_dump.out
@@ -1,6 +1,7 @@
 -- This file and its contents are licensed under the Timescale License.
 -- Please see the included NOTICE for copyright information and
 -- LICENSE-TIMESCALE for a copy of the license.
+SET timezone TO PST8PDT;
 CREATE TYPE custom_type AS (high int, low int);
 CREATE TABLE conditions_before (
       timec       TIMESTAMPTZ       NOT NULL,
@@ -158,6 +159,7 @@ SELECT _timescaledb_functions.stop_background_workers();
 (1 row)
 
 \c :TEST_DBNAME :ROLE_DEFAULT_PERM_USER
+SET timezone TO PST8PDT;
 --make sure the appropriate DROP are still blocked.
 \set ON_ERROR_STOP 0
 DROP table :"MAT_SCHEMA_NAME".:"MAT_TABLE_NAME";

--- a/tsl/test/expected/cagg_errors.out
+++ b/tsl/test/expected/cagg_errors.out
@@ -3,6 +3,7 @@
 -- LICENSE-TIMESCALE for a copy of the license.
 \set ON_ERROR_STOP 0
 \set VERBOSITY default
+SET timezone TO PST8PDT;
 --negative tests for query validation
 create table mat_t1( a integer, b integer,c TEXT);
 CREATE TABLE conditions (

--- a/tsl/test/expected/cagg_joins.out
+++ b/tsl/test/expected/cagg_joins.out
@@ -2,6 +2,7 @@
 -- Please see the included NOTICE for copyright information and
 -- LICENSE-TIMESCALE for a copy of the license.
 \set VERBOSITY default
+SET timezone TO PST8PDT;
 CREATE TABLE conditions(
   day TIMESTAMPTZ NOT NULL,
   city text NOT NULL,
@@ -1227,6 +1228,7 @@ ALTER USER MAPPING FOR :ROLE_DEFAULT_PERM_USER
    OPTIONS (ADD password_required 'false');
 GRANT USAGE ON FOREIGN SERVER loopback TO :ROLE_DEFAULT_PERM_USER;
 \c :TEST_DBNAME :ROLE_DEFAULT_PERM_USER;
+SET timezone TO PST8PDT;
 CREATE FOREIGN TABLE devices_fdw (
    device_id int not null,
    name text,

--- a/tsl/test/expected/cagg_policy.out
+++ b/tsl/test/expected/cagg_policy.out
@@ -36,6 +36,7 @@ SELECT a, count(b)
 FROM int_tab
 GROUP BY time_bucket(1, a), a WITH NO DATA;
 \c :TEST_DBNAME :ROLE_SUPERUSER
+SET timezone TO PST8PDT;
 DELETE FROM _timescaledb_config.bgw_job WHERE TRUE;
 SET ROLE :ROLE_DEFAULT_PERM_USER;
 SELECT count(*) FROM _timescaledb_config.bgw_job;
@@ -260,6 +261,7 @@ SELECT hypertable_id as mat_id FROM _timescaledb_config.bgw_job where id = :job_
 \set VERBOSITY terse
 \set ON_ERROR_STOP 1
 \c :TEST_DBNAME :ROLE_SUPERUSER
+SET timezone TO PST8PDT;
 UPDATE _timescaledb_config.bgw_job
 SET config = jsonb_build_object('mat_hypertable_id', :mat_id)
 WHERE id = :job_id;
@@ -822,6 +824,7 @@ WHERE id = :job_id;
 (1 row)
 
 \c :TEST_DBNAME :ROLE_SUPERUSER
+SET timezone TO PST8PDT;
 UPDATE _timescaledb_config.bgw_job
 SET config = jsonb_build_object('mat_hypertable_id', :mat_id)
 WHERE id = :job_id;

--- a/tsl/test/expected/cagg_query.out
+++ b/tsl/test/expected/cagg_query.out
@@ -3,6 +3,7 @@
 -- LICENSE-TIMESCALE for a copy of the license.
 -- Connect as superuser to use SET ROLE later
 \c :TEST_DBNAME :ROLE_CLUSTER_SUPERUSER
+SET timezone TO PST8PDT;
 -- Run tests with default role
 SET ROLE :ROLE_DEFAULT_PERM_USER;
 \set TEST_BASE_NAME cagg_query

--- a/tsl/test/expected/cagg_query_using_merge.out
+++ b/tsl/test/expected/cagg_query_using_merge.out
@@ -3,6 +3,7 @@
 -- LICENSE-TIMESCALE for a copy of the license.
 -- Connect as superuser to use SET ROLE later
 \c :TEST_DBNAME :ROLE_CLUSTER_SUPERUSER
+SET timezone TO PST8PDT;
 -- Run tests with default role
 SET ROLE :ROLE_DEFAULT_PERM_USER;
 -- Enable MERGE statements for continuous aggregate refresh

--- a/tsl/test/expected/cagg_refresh.out
+++ b/tsl/test/expected/cagg_refresh.out
@@ -1,6 +1,7 @@
 -- This file and its contents are licensed under the Timescale License.
 -- Please see the included NOTICE for copyright information and
 -- LICENSE-TIMESCALE for a copy of the license.
+SET timezone TO PST8PDT;
 \ir include/cagg_refresh_common.sql
 -- This file and its contents are licensed under the Timescale License.
 -- Please see the included NOTICE for copyright information and

--- a/tsl/test/expected/cagg_refresh_using_merge.out
+++ b/tsl/test/expected/cagg_refresh_using_merge.out
@@ -3,6 +3,7 @@
 -- LICENSE-TIMESCALE for a copy of the license.
 -- Enable MERGE statements for continuous aggregate refresh
 SET timescaledb.enable_merge_on_cagg_refresh TO ON;
+SET timezone TO PST8PDT;
 \ir include/cagg_refresh_common.sql
 -- This file and its contents are licensed under the Timescale License.
 -- Please see the included NOTICE for copyright information and

--- a/tsl/test/expected/cagg_repair-14.out
+++ b/tsl/test/expected/cagg_repair-14.out
@@ -2,6 +2,7 @@
 -- Please see the included NOTICE for copyright information and
 -- LICENSE-TIMESCALE for a copy of the license.
 \c :TEST_DBNAME :ROLE_SUPERUSER
+SET timezone TO PST8PDT;
 CREATE PROCEDURE _timescaledb_internal.cagg_try_repair (
     cagg_view REGCLASS,
     force_rebuild BOOLEAN

--- a/tsl/test/expected/cagg_repair-15.out
+++ b/tsl/test/expected/cagg_repair-15.out
@@ -2,6 +2,7 @@
 -- Please see the included NOTICE for copyright information and
 -- LICENSE-TIMESCALE for a copy of the license.
 \c :TEST_DBNAME :ROLE_SUPERUSER
+SET timezone TO PST8PDT;
 CREATE PROCEDURE _timescaledb_internal.cagg_try_repair (
     cagg_view REGCLASS,
     force_rebuild BOOLEAN

--- a/tsl/test/expected/cagg_repair-16.out
+++ b/tsl/test/expected/cagg_repair-16.out
@@ -2,6 +2,7 @@
 -- Please see the included NOTICE for copyright information and
 -- LICENSE-TIMESCALE for a copy of the license.
 \c :TEST_DBNAME :ROLE_SUPERUSER
+SET timezone TO PST8PDT;
 CREATE PROCEDURE _timescaledb_internal.cagg_try_repair (
     cagg_view REGCLASS,
     force_rebuild BOOLEAN

--- a/tsl/test/expected/cagg_repair-17.out
+++ b/tsl/test/expected/cagg_repair-17.out
@@ -2,6 +2,7 @@
 -- Please see the included NOTICE for copyright information and
 -- LICENSE-TIMESCALE for a copy of the license.
 \c :TEST_DBNAME :ROLE_SUPERUSER
+SET timezone TO PST8PDT;
 CREATE PROCEDURE _timescaledb_internal.cagg_try_repair (
     cagg_view REGCLASS,
     force_rebuild BOOLEAN

--- a/tsl/test/expected/cagg_union_view-14.out
+++ b/tsl/test/expected/cagg_union_view-14.out
@@ -10,6 +10,7 @@ SELECT _timescaledb_functions.stop_background_workers();
 (1 row)
 
 \c :TEST_DBNAME :ROLE_DEFAULT_PERM_USER
+SET timezone TO PST8PDT;
 \set PREFIX 'EXPLAIN (analyze, costs off, timing off, summary off)'
 CREATE TABLE metrics(f1 int, f2 int, time timestamptz NOT NULL, device_id int, value float);
 SELECT create_hypertable('metrics','time');

--- a/tsl/test/expected/cagg_union_view-15.out
+++ b/tsl/test/expected/cagg_union_view-15.out
@@ -10,6 +10,7 @@ SELECT _timescaledb_functions.stop_background_workers();
 (1 row)
 
 \c :TEST_DBNAME :ROLE_DEFAULT_PERM_USER
+SET timezone TO PST8PDT;
 \set PREFIX 'EXPLAIN (analyze, costs off, timing off, summary off)'
 CREATE TABLE metrics(f1 int, f2 int, time timestamptz NOT NULL, device_id int, value float);
 SELECT create_hypertable('metrics','time');

--- a/tsl/test/expected/cagg_union_view-16.out
+++ b/tsl/test/expected/cagg_union_view-16.out
@@ -10,6 +10,7 @@ SELECT _timescaledb_functions.stop_background_workers();
 (1 row)
 
 \c :TEST_DBNAME :ROLE_DEFAULT_PERM_USER
+SET timezone TO PST8PDT;
 \set PREFIX 'EXPLAIN (analyze, costs off, timing off, summary off)'
 CREATE TABLE metrics(f1 int, f2 int, time timestamptz NOT NULL, device_id int, value float);
 SELECT create_hypertable('metrics','time');

--- a/tsl/test/expected/cagg_union_view-17.out
+++ b/tsl/test/expected/cagg_union_view-17.out
@@ -10,6 +10,7 @@ SELECT _timescaledb_functions.stop_background_workers();
 (1 row)
 
 \c :TEST_DBNAME :ROLE_DEFAULT_PERM_USER
+SET timezone TO PST8PDT;
 \set PREFIX 'EXPLAIN (analyze, costs off, timing off, summary off)'
 CREATE TABLE metrics(f1 int, f2 int, time timestamptz NOT NULL, device_id int, value float);
 SELECT create_hypertable('metrics','time');

--- a/tsl/test/expected/cagg_usage-14.out
+++ b/tsl/test/expected/cagg_usage-14.out
@@ -5,6 +5,7 @@
 \set ON_ERROR_STOP 0
 SET client_min_messages TO NOTICE;
 SET work_mem TO '64MB';
+SET timezone TO PST8PDT;
 -- START OF USAGE TEST --
 --First create your hypertable
 CREATE TABLE device_readings (

--- a/tsl/test/expected/cagg_usage-15.out
+++ b/tsl/test/expected/cagg_usage-15.out
@@ -5,6 +5,7 @@
 \set ON_ERROR_STOP 0
 SET client_min_messages TO NOTICE;
 SET work_mem TO '64MB';
+SET timezone TO PST8PDT;
 -- START OF USAGE TEST --
 --First create your hypertable
 CREATE TABLE device_readings (

--- a/tsl/test/expected/cagg_usage-16.out
+++ b/tsl/test/expected/cagg_usage-16.out
@@ -5,6 +5,7 @@
 \set ON_ERROR_STOP 0
 SET client_min_messages TO NOTICE;
 SET work_mem TO '64MB';
+SET timezone TO PST8PDT;
 -- START OF USAGE TEST --
 --First create your hypertable
 CREATE TABLE device_readings (

--- a/tsl/test/expected/cagg_usage-17.out
+++ b/tsl/test/expected/cagg_usage-17.out
@@ -5,6 +5,7 @@
 \set ON_ERROR_STOP 0
 SET client_min_messages TO NOTICE;
 SET work_mem TO '64MB';
+SET timezone TO PST8PDT;
 -- START OF USAGE TEST --
 --First create your hypertable
 CREATE TABLE device_readings (

--- a/tsl/test/expected/cagg_utils.out
+++ b/tsl/test/expected/cagg_utils.out
@@ -2,6 +2,7 @@
 -- Please see the included NOTICE for copyright information and
 -- LICENSE-TIMESCALE for a copy of the license.
 SET search_path TO public, _timescaledb_functions;
+SET timezone TO PST8PDT;
 CREATE TABLE devices (
     id INTEGER,
     name TEXT
@@ -263,6 +264,7 @@ CREATE OR REPLACE FUNCTION cagg_get_bucket_function(
     mat_hypertable_id INTEGER
 ) RETURNS regprocedure AS :MODULE_PATHNAME, 'ts_continuous_agg_get_bucket_function' LANGUAGE C STRICT VOLATILE;
 \c :TEST_DBNAME :ROLE_DEFAULT_PERM_USER
+SET timezone TO PST8PDT;
 CREATE TABLE timestamp_ht (
   time timestamp NOT NULL,
   value float

--- a/tsl/test/expected/cagg_watermark.out
+++ b/tsl/test/expected/cagg_watermark.out
@@ -1,6 +1,7 @@
 -- This file and its contents are licensed under the Timescale License.
 -- Please see the included NOTICE for copyright information and
 -- LICENSE-TIMESCALE for a copy of the license.
+SET timezone TO PST8PDT;
 \set EXPLAIN_ANALYZE 'EXPLAIN (analyze,costs off,timing off,summary off)'
 CREATE TABLE continuous_agg_test(time int, data int);
 SELECT create_hypertable('continuous_agg_test', 'time', chunk_time_interval=> 10);
@@ -74,6 +75,7 @@ SELECT * from _timescaledb_catalog.continuous_aggs_hypertable_invalidation_log;
 \c :TEST_DBNAME :ROLE_SUPERUSER
 INSERT INTO _timescaledb_catalog.continuous_aggs_invalidation_threshold VALUES (1, 15);
 \c :TEST_DBNAME :ROLE_DEFAULT_PERM_USER
+SET timezone TO PST8PDT;
 INSERT INTO continuous_agg_test VALUES (10, 1), (11, 2), (21, 3), (22, 4);
 SELECT * FROM _timescaledb_catalog.continuous_aggs_invalidation_threshold;
  hypertable_id | watermark 
@@ -347,6 +349,7 @@ UPDATE _timescaledb_catalog.continuous_aggs_invalidation_threshold
 SET watermark = 2
 WHERE hypertable_id = 5;
 \c :TEST_DBNAME :ROLE_DEFAULT_PERM_USER
+SET timezone TO PST8PDT;
 INSERT INTO ts_continuous_test VALUES (1, 1);
 SELECT * FROM _timescaledb_catalog.continuous_aggs_invalidation_threshold;
  hypertable_id | watermark 

--- a/tsl/test/expected/chunk_merge.out
+++ b/tsl/test/expected/chunk_merge.out
@@ -6,6 +6,7 @@ CREATE OR REPLACE FUNCTION _timescaledb_internal.test_merge_chunks_on_dimension(
  RETURNS VOID
     AS :TSL_MODULE_PATHNAME, 'ts_test_merge_chunks_on_dimension' LANGUAGE C VOLATILE;
 \c :TEST_DBNAME :ROLE_DEFAULT_PERM_USER
+SET timezone TO PST8PDT;
 CREATE TABLE test1 ("Time" timestamptz, i integer, value integer);
 SELECT table_name FROM Create_hypertable('test1', 'Time', chunk_time_interval=> INTERVAL '1 hour');
 NOTICE:  adding not-null constraint to column "Time"

--- a/tsl/test/expected/compression.out
+++ b/tsl/test/expected/compression.out
@@ -2,6 +2,7 @@
 -- Please see the included NOTICE for copyright information and
 -- LICENSE-TIMESCALE for a copy of the license.
 SET timescaledb.enable_transparent_decompression to OFF;
+SET timezone TO PST8PDT;
 \set PREFIX 'EXPLAIN (analyze, verbose, costs off, timing off, summary off)'
 \ir include/rand_generator.sql
 -- This file and its contents are licensed under the Timescale License.
@@ -1497,6 +1498,7 @@ SET reltuples = 0, relpages = 0
   WHERE ht.table_name = 'stattest2' AND ch.hypertable_id = ht.id
         AND ch.compressed_chunk_id > 0 );
 \c :TEST_DBNAME :ROLE_DEFAULT_PERM_USER
+SET timezone TO PST8PDT;
 -- reltuples is initially -1 on PG14 before VACUUM/ANALYZE has been run
 SELECT relname, CASE WHEN reltuples > 0 THEN reltuples ELSE 0 END AS reltuples, relpages, relallvisible FROM pg_class
  WHERE relname in ( SELECT ch.table_name FROM

--- a/tsl/test/expected/compression_bgw.out
+++ b/tsl/test/expected/compression_bgw.out
@@ -7,6 +7,7 @@ CREATE ROLE NOLOGIN_ROLE WITH nologin noinherit;
 GRANT CREATE ON SCHEMA public TO NOLOGIN_ROLE;
 GRANT NOLOGIN_ROLE TO :ROLE_DEFAULT_PERM_USER WITH ADMIN OPTION;
 \c :TEST_DBNAME :ROLE_DEFAULT_PERM_USER
+SET timezone TO PST8PDT;
 CREATE TABLE conditions (
       time        TIMESTAMPTZ       NOT NULL,
       location    TEXT              NOT NULL,
@@ -286,6 +287,7 @@ ERROR:  permission denied to start background process as role "nologin_role"
 DROP TABLE test_table_nologin;
 RESET ROLE;
 \c :TEST_DBNAME :ROLE_DEFAULT_PERM_USER
+SET timezone TO PST8PDT;
 CREATE TABLE conditions(
     time TIMESTAMPTZ NOT NULL,
     device INTEGER,

--- a/tsl/test/expected/compression_ddl.out
+++ b/tsl/test/expected/compression_ddl.out
@@ -30,6 +30,7 @@ SET client_min_messages = NOTICE;
 CREATE TABLESPACE tablespace1 OWNER :ROLE_DEFAULT_PERM_USER LOCATION :TEST_TABLESPACE1_PATH;
 CREATE TABLESPACE tablespace2 OWNER :ROLE_DEFAULT_PERM_USER LOCATION :TEST_TABLESPACE2_PATH;
 \c :TEST_DBNAME :ROLE_DEFAULT_PERM_USER
+SET timezone TO PST8PDT;
 CREATE TABLE test1 ("Time" timestamptz, i integer, b bigint, t text);
 SELECT table_name from create_hypertable('test1', 'Time', chunk_time_interval=> INTERVAL '1 day');
 NOTICE:  adding not-null constraint to column "Time"
@@ -562,6 +563,7 @@ SELECT count(*) FROM test1_cont_view;
 (1 row)
 
 \c :TEST_DBNAME :ROLE_SUPERUSER
+SET timezone TO PST8PDT;
 SELECT chunk.schema_name|| '.' || chunk.table_name as "COMPRESSED_CHUNK_NAME"
 FROM _timescaledb_catalog.chunk chunk
 INNER JOIN _timescaledb_catalog.hypertable comp_hyper ON (chunk.hypertable_id = comp_hyper.id)

--- a/tsl/test/expected/compression_insert.out
+++ b/tsl/test/expected/compression_insert.out
@@ -1,6 +1,7 @@
 -- This file and its contents are licensed under the Timescale License.
 -- Please see the included NOTICE for copyright information and
 -- LICENSE-TIMESCALE for a copy of the license.
+SET timezone TO PST8PDT;
 \set PREFIX 'EXPLAIN (costs off, summary off, timing off) '
 \set ANALYZE  'EXPLAIN (analyze, costs off, summary off, timing off) '
 CREATE TABLE test1 (timec timestamptz , i integer ,

--- a/tsl/test/expected/continuous_aggs-14.out
+++ b/tsl/test/expected/continuous_aggs-14.out
@@ -755,6 +755,7 @@ INNER JOIN _timescaledb_catalog.hypertable h ON(h.id = ca.mat_hypertable_id)
 WHERE user_view_name = 'mat_drop_test'
 \gset
 SET client_min_messages TO NOTICE;
+SET timezone TO PST8PDT;
 CALL refresh_continuous_aggregate('mat_drop_test', NULL, NULL);
 --force invalidation
 insert into conditions

--- a/tsl/test/expected/continuous_aggs-15.out
+++ b/tsl/test/expected/continuous_aggs-15.out
@@ -755,6 +755,7 @@ INNER JOIN _timescaledb_catalog.hypertable h ON(h.id = ca.mat_hypertable_id)
 WHERE user_view_name = 'mat_drop_test'
 \gset
 SET client_min_messages TO NOTICE;
+SET timezone TO PST8PDT;
 CALL refresh_continuous_aggregate('mat_drop_test', NULL, NULL);
 --force invalidation
 insert into conditions

--- a/tsl/test/expected/continuous_aggs-16.out
+++ b/tsl/test/expected/continuous_aggs-16.out
@@ -755,6 +755,7 @@ INNER JOIN _timescaledb_catalog.hypertable h ON(h.id = ca.mat_hypertable_id)
 WHERE user_view_name = 'mat_drop_test'
 \gset
 SET client_min_messages TO NOTICE;
+SET timezone TO PST8PDT;
 CALL refresh_continuous_aggregate('mat_drop_test', NULL, NULL);
 --force invalidation
 insert into conditions

--- a/tsl/test/expected/continuous_aggs-17.out
+++ b/tsl/test/expected/continuous_aggs-17.out
@@ -755,6 +755,7 @@ INNER JOIN _timescaledb_catalog.hypertable h ON(h.id = ca.mat_hypertable_id)
 WHERE user_view_name = 'mat_drop_test'
 \gset
 SET client_min_messages TO NOTICE;
+SET timezone TO PST8PDT;
 CALL refresh_continuous_aggregate('mat_drop_test', NULL, NULL);
 --force invalidation
 insert into conditions

--- a/tsl/test/expected/feature_flags.out
+++ b/tsl/test/expected/feature_flags.out
@@ -2,6 +2,7 @@
 -- Please see the included NOTICE for copyright information and
 -- LICENSE-TIMESCALE for a copy of the license.
 \c :TEST_DBNAME :ROLE_SUPERUSER
+SET timezone TO PST8PDT;
 -- hypertable creation
 SHOW timescaledb.enable_hypertable_create;
  timescaledb.enable_hypertable_create 

--- a/tsl/test/expected/information_view_chunk_count.out
+++ b/tsl/test/expected/information_view_chunk_count.out
@@ -1,6 +1,7 @@
 -- This file and its contents are licensed under the Timescale License.
 -- Please see the included NOTICE for copyright information and
 -- LICENSE-TIMESCALE for a copy of the license.
+SET timezone TO PST8PDT;
 CREATE TABLE sensor_data(
 time timestamptz not null,
 sensor_id integer not null,

--- a/tsl/test/expected/jit.out
+++ b/tsl/test/expected/jit.out
@@ -1,6 +1,7 @@
 -- This file and its contents are licensed under the Timescale License.
 -- Please see the included NOTICE for copyright information and
 -- LICENSE-TIMESCALE for a copy of the license.
+SET timezone TO PST8PDT;
 \set TEST_BASE_NAME jit
 SELECT format('include/%s_load.sql', :'TEST_BASE_NAME') as "TEST_LOAD_NAME",
        format('include/%s_query.sql', :'TEST_BASE_NAME') as "TEST_QUERY_NAME",

--- a/tsl/test/expected/size_utils_tsl.out
+++ b/tsl/test/expected/size_utils_tsl.out
@@ -1,6 +1,7 @@
 -- This file and its contents are licensed under the Timescale License.
 -- Please see the included NOTICE for copyright information and
 -- LICENSE-TIMESCALE for a copy of the license.
+SET timezone TO PST8PDT;
 -- Prepare test data for continuous aggregate size function tests
 CREATE TABLE hypersize(time timestamptz, device int);
 SELECT * FROM create_hypertable('hypersize', 'time');

--- a/tsl/test/expected/telemetry_stats.out
+++ b/tsl/test/expected/telemetry_stats.out
@@ -3,6 +3,7 @@
 -- LICENSE-TIMESCALE for a copy of the license.
 --telemetry tests that require a community license
 \c :TEST_DBNAME :ROLE_CLUSTER_SUPERUSER;
+SET timezone TO PST8PDT;
 -- function call info size is too variable for this test, so disable it
 SET timescaledb.telemetry_level='no_functions';
 SELECT setseed(1);

--- a/tsl/test/expected/transparent_decompression-14.out
+++ b/tsl/test/expected/transparent_decompression-14.out
@@ -9,6 +9,7 @@ SELECT format('include/%s_load.sql', :'TEST_BASE_NAME') AS "TEST_LOAD_NAME",
 SELECT format('\! diff %s %s', :'TEST_RESULTS_UNCOMPRESSED', :'TEST_RESULTS_COMPRESSED') AS "DIFF_CMD" \gset
 SET work_mem TO '50MB';
 SET enable_incremental_sort TO off;
+SET timezone TO PST8PDT;
 -- disable memoize node to make EXPLAIN output comparable between PG14 and previous versions
 SELECT CASE WHEN current_setting('server_version_num')::int/10000 >= 14 THEN set_config('enable_memoize','off',false) ELSE 'off' END AS enable_memoize;
  enable_memoize 
@@ -175,6 +176,7 @@ FROM _timescaledb_catalog.hypertable ht
 -- no standard way to create an index on a compressed table.
 -- Once a standard way exists, modify this test to use that method.
 \c :TEST_DBNAME :ROLE_DEFAULT_PERM_USER
+SET timezone TO PST8PDT;
 CREATE INDEX ON metrics_space (device_id, device_id_peer, v0, v1 DESC, time);
 CREATE INDEX ON metrics_space (device_id, device_id_peer DESC, v0, v1 DESC, time);
 CREATE INDEX ON metrics_space (device_id DESC, device_id_peer DESC, v0, v1 DESC, time);

--- a/tsl/test/expected/transparent_decompression-15.out
+++ b/tsl/test/expected/transparent_decompression-15.out
@@ -9,6 +9,7 @@ SELECT format('include/%s_load.sql', :'TEST_BASE_NAME') AS "TEST_LOAD_NAME",
 SELECT format('\! diff %s %s', :'TEST_RESULTS_UNCOMPRESSED', :'TEST_RESULTS_COMPRESSED') AS "DIFF_CMD" \gset
 SET work_mem TO '50MB';
 SET enable_incremental_sort TO off;
+SET timezone TO PST8PDT;
 -- disable memoize node to make EXPLAIN output comparable between PG14 and previous versions
 SELECT CASE WHEN current_setting('server_version_num')::int/10000 >= 14 THEN set_config('enable_memoize','off',false) ELSE 'off' END AS enable_memoize;
  enable_memoize 
@@ -175,6 +176,7 @@ FROM _timescaledb_catalog.hypertable ht
 -- no standard way to create an index on a compressed table.
 -- Once a standard way exists, modify this test to use that method.
 \c :TEST_DBNAME :ROLE_DEFAULT_PERM_USER
+SET timezone TO PST8PDT;
 CREATE INDEX ON metrics_space (device_id, device_id_peer, v0, v1 DESC, time);
 CREATE INDEX ON metrics_space (device_id, device_id_peer DESC, v0, v1 DESC, time);
 CREATE INDEX ON metrics_space (device_id DESC, device_id_peer DESC, v0, v1 DESC, time);

--- a/tsl/test/expected/transparent_decompression-16.out
+++ b/tsl/test/expected/transparent_decompression-16.out
@@ -9,6 +9,7 @@ SELECT format('include/%s_load.sql', :'TEST_BASE_NAME') AS "TEST_LOAD_NAME",
 SELECT format('\! diff %s %s', :'TEST_RESULTS_UNCOMPRESSED', :'TEST_RESULTS_COMPRESSED') AS "DIFF_CMD" \gset
 SET work_mem TO '50MB';
 SET enable_incremental_sort TO off;
+SET timezone TO PST8PDT;
 -- disable memoize node to make EXPLAIN output comparable between PG14 and previous versions
 SELECT CASE WHEN current_setting('server_version_num')::int/10000 >= 14 THEN set_config('enable_memoize','off',false) ELSE 'off' END AS enable_memoize;
  enable_memoize 
@@ -175,6 +176,7 @@ FROM _timescaledb_catalog.hypertable ht
 -- no standard way to create an index on a compressed table.
 -- Once a standard way exists, modify this test to use that method.
 \c :TEST_DBNAME :ROLE_DEFAULT_PERM_USER
+SET timezone TO PST8PDT;
 CREATE INDEX ON metrics_space (device_id, device_id_peer, v0, v1 DESC, time);
 CREATE INDEX ON metrics_space (device_id, device_id_peer DESC, v0, v1 DESC, time);
 CREATE INDEX ON metrics_space (device_id DESC, device_id_peer DESC, v0, v1 DESC, time);

--- a/tsl/test/expected/transparent_decompression-17.out
+++ b/tsl/test/expected/transparent_decompression-17.out
@@ -9,6 +9,7 @@ SELECT format('include/%s_load.sql', :'TEST_BASE_NAME') AS "TEST_LOAD_NAME",
 SELECT format('\! diff %s %s', :'TEST_RESULTS_UNCOMPRESSED', :'TEST_RESULTS_COMPRESSED') AS "DIFF_CMD" \gset
 SET work_mem TO '50MB';
 SET enable_incremental_sort TO off;
+SET timezone TO PST8PDT;
 -- disable memoize node to make EXPLAIN output comparable between PG14 and previous versions
 SELECT CASE WHEN current_setting('server_version_num')::int/10000 >= 14 THEN set_config('enable_memoize','off',false) ELSE 'off' END AS enable_memoize;
  enable_memoize 
@@ -175,6 +176,7 @@ FROM _timescaledb_catalog.hypertable ht
 -- no standard way to create an index on a compressed table.
 -- Once a standard way exists, modify this test to use that method.
 \c :TEST_DBNAME :ROLE_DEFAULT_PERM_USER
+SET timezone TO PST8PDT;
 CREATE INDEX ON metrics_space (device_id, device_id_peer, v0, v1 DESC, time);
 CREATE INDEX ON metrics_space (device_id, device_id_peer DESC, v0, v1 DESC, time);
 CREATE INDEX ON metrics_space (device_id DESC, device_id_peer DESC, v0, v1 DESC, time);

--- a/tsl/test/isolation/specs/cagg_concurrent_invalidation.spec
+++ b/tsl/test/isolation/specs/cagg_concurrent_invalidation.spec
@@ -10,6 +10,8 @@
 #
 setup
 {
+  SET timezone TO PST8PDT;
+
   CREATE TABLE temperature (
     time timestamptz NOT NULL,
     value float

--- a/tsl/test/isolation/specs/cagg_watermark_concurrent_update.spec
+++ b/tsl/test/isolation/specs/cagg_watermark_concurrent_update.spec
@@ -10,6 +10,8 @@
 #
 setup
 {
+  SET timezone TO PST8PDT;
+
   CREATE TABLE temperature (
     time timestamptz NOT NULL,
     value float

--- a/tsl/test/shared/expected/cagg_compression.out
+++ b/tsl/test/shared/expected/cagg_compression.out
@@ -1,6 +1,7 @@
 -- This file and its contents are licensed under the Timescale License.
 -- Please see the included NOTICE for copyright information and
 -- LICENSE-TIMESCALE for a copy of the license.
+SET timezone TO PST8PDT;
 SELECT
        format('include/%s_setup.sql', :'TEST_BASE_NAME') as "TEST_SETUP_NAME",
        format('include/%s_query.sql', :'TEST_BASE_NAME') as "TEST_QUERY_NAME",

--- a/tsl/test/shared/expected/compat.out
+++ b/tsl/test/shared/expected/compat.out
@@ -1,6 +1,7 @@
 -- This file and its contents are licensed under the Timescale License.
 -- Please see the included NOTICE for copyright information and
 -- LICENSE-TIMESCALE for a copy of the license.
+SET timezone TO PST8PDT;
 \set ON_ERROR_STOP 0
 SELECT _timescaledb_internal.alter_job_set_hypertable_id(0,0);
 WARNING:  function _timescaledb_internal.alter_job_set_hypertable_id(integer,regclass) is deprecated and has been moved to _timescaledb_functions schema. this compatibility function will be removed in a future version.

--- a/tsl/test/shared/expected/constify_now.out
+++ b/tsl/test/shared/expected/constify_now.out
@@ -4,6 +4,7 @@
 SET timescaledb.enable_chunk_append TO false;
 SET timescaledb.enable_constraint_aware_append TO false;
 SET timescaledb.current_timestamp_mock TO '1990-01-01';
+SET timezone TO PST8PDT;
 \set PREFIX 'EXPLAIN (COSTS OFF, SUMMARY OFF, TIMING OFF)'
 -- create a test table
 -- any query with successful now_constify will have 1 chunk while

--- a/tsl/test/shared/sql/cagg_compression.sql
+++ b/tsl/test/shared/sql/cagg_compression.sql
@@ -2,6 +2,8 @@
 -- Please see the included NOTICE for copyright information and
 -- LICENSE-TIMESCALE for a copy of the license.
 
+SET timezone TO PST8PDT;
+
 SELECT
        format('include/%s_setup.sql', :'TEST_BASE_NAME') as "TEST_SETUP_NAME",
        format('include/%s_query.sql', :'TEST_BASE_NAME') as "TEST_QUERY_NAME",

--- a/tsl/test/shared/sql/compat.sql
+++ b/tsl/test/shared/sql/compat.sql
@@ -2,6 +2,8 @@
 -- Please see the included NOTICE for copyright information and
 -- LICENSE-TIMESCALE for a copy of the license.
 
+SET timezone TO PST8PDT;
+
 \set ON_ERROR_STOP 0
 
 SELECT _timescaledb_internal.alter_job_set_hypertable_id(0,0);

--- a/tsl/test/shared/sql/constify_now.sql
+++ b/tsl/test/shared/sql/constify_now.sql
@@ -5,6 +5,7 @@
 SET timescaledb.enable_chunk_append TO false;
 SET timescaledb.enable_constraint_aware_append TO false;
 SET timescaledb.current_timestamp_mock TO '1990-01-01';
+SET timezone TO PST8PDT;
 
 \set PREFIX 'EXPLAIN (COSTS OFF, SUMMARY OFF, TIMING OFF)'
 

--- a/tsl/test/sql/bgw_db_scheduler_fixed.sql
+++ b/tsl/test/sql/bgw_db_scheduler_fixed.sql
@@ -6,6 +6,9 @@
 -- Setup
 --
 \c :TEST_DBNAME :ROLE_SUPERUSER
+
+SET timezone TO PST8PDT;
+
 -- this mock_start_time doesnt seem to be used anywhere
 CREATE OR REPLACE FUNCTION ts_bgw_db_scheduler_test_run_and_wait_for_scheduler_finish(timeout INT = -1, mock_start_time INT = 0) RETURNS VOID
 AS :MODULE_PATHNAME LANGUAGE C VOLATILE;
@@ -108,6 +111,8 @@ TRUNCATE _timescaledb_internal.bgw_job_stat;
 
 \c :TEST_DBNAME :ROLE_DEFAULT_PERM_USER
 
+SET timezone TO PST8PDT;
+
 CREATE TABLE public.bgw_log(
     msg_no INT,
     mock_time BIGINT,
@@ -197,6 +202,8 @@ SELECT insert_job('test_job_1', 'bgw_test_job_1', INTERVAL '100ms', INTERVAL '10
 select * from _timescaledb_config.bgw_job;
 \c :TEST_DBNAME :ROLE_DEFAULT_PERM_USER
 
+SET timezone TO PST8PDT;
+
 --Tests that the scheduler start a job right away if it's the first time and there is no job_stat entry for it
 SELECT ts_bgw_db_scheduler_test_run_and_wait_for_scheduler_finish(25);
 SELECT job_id, next_start, last_finish as until_next, last_run_success, total_runs, total_successes, total_failures, total_crashes
@@ -233,6 +240,8 @@ DELETE FROM _timescaledb_config.bgw_job;
 -- schedule_interval, max_runtime, retry_period
 SELECT insert_job('test_job_2', 'bgw_test_job_2_error', INTERVAL '800ms', INTERVAL '100s', INTERVAL '200ms');
 \c :TEST_DBNAME :ROLE_DEFAULT_PERM_USER
+
+SET timezone TO PST8PDT;
 
 --Run the first time and error
 SELECT ts_bgw_db_scheduler_test_run_and_wait_for_scheduler_finish(25);
@@ -538,6 +547,8 @@ SELECT _timescaledb_functions.start_background_workers();
 
 \c :TEST_DBNAME :ROLE_SUPERUSER
 SELECT _timescaledb_functions.stop_background_workers();
+
+SET timezone TO PST8PDT;
 
 CREATE OR REPLACE FUNCTION ts_test_job_refresh() RETURNS TABLE(
 id INTEGER,

--- a/tsl/test/sql/cagg_ddl.sql.in
+++ b/tsl/test/sql/cagg_ddl.sql.in
@@ -24,6 +24,9 @@ SELECT table_name FROM create_hypertable('conditions', 'timec');
 -- schema tests
 
 \c :TEST_DBNAME :ROLE_CLUSTER_SUPERUSER
+
+SET timezone TO PST8PDT;
+
 -- drop if the tablespace1 and/or tablespace2 exists
 SET client_min_messages TO error;
 DROP TABLESPACE IF EXISTS tablespace1;

--- a/tsl/test/sql/cagg_drop_chunks.sql
+++ b/tsl/test/sql/cagg_drop_chunks.sql
@@ -4,6 +4,8 @@
 
 \c :TEST_DBNAME :ROLE_SUPERUSER
 
+SET timezone TO PST8PDT;
+
 --
 -- Check that drop chunks with a unique constraint works as expected.
 --

--- a/tsl/test/sql/cagg_dump.sql
+++ b/tsl/test/sql/cagg_dump.sql
@@ -2,6 +2,8 @@
 -- Please see the included NOTICE for copyright information and
 -- LICENSE-TIMESCALE for a copy of the license.
 
+SET timezone TO PST8PDT;
+
 CREATE TYPE custom_type AS (high int, low int);
 
 CREATE TABLE conditions_before (
@@ -118,6 +120,7 @@ SELECT count(*) FROM conditions_after;
 
 --dump & restore
 \c postgres :ROLE_SUPERUSER
+
 \! utils/pg_dump_aux_dump.sh dump/pg_dump.sql
 
 \c :TEST_DBNAME
@@ -132,6 +135,8 @@ SELECT timescaledb_post_restore();
 SELECT _timescaledb_functions.stop_background_workers();
 
 \c :TEST_DBNAME :ROLE_DEFAULT_PERM_USER
+
+SET timezone TO PST8PDT;
 
 --make sure the appropriate DROP are still blocked.
 \set ON_ERROR_STOP 0

--- a/tsl/test/sql/cagg_errors.sql
+++ b/tsl/test/sql/cagg_errors.sql
@@ -5,6 +5,8 @@
 \set ON_ERROR_STOP 0
 \set VERBOSITY default
 
+SET timezone TO PST8PDT;
+
 --negative tests for query validation
 create table mat_t1( a integer, b integer,c TEXT);
 

--- a/tsl/test/sql/cagg_joins.sql
+++ b/tsl/test/sql/cagg_joins.sql
@@ -4,6 +4,8 @@
 
 \set VERBOSITY default
 
+SET timezone TO PST8PDT;
+
 CREATE TABLE conditions(
   day TIMESTAMPTZ NOT NULL,
   city text NOT NULL,
@@ -576,6 +578,7 @@ SELECT * FROM conditions_by_day ORDER BY bucket, device, location;
 
 -- JOIN with a foreign table
 \c :TEST_DBNAME :ROLE_SUPERUSER
+
 SELECT current_setting('port') AS "PGPORT", current_database() AS "PGDATABASE" \gset
 CREATE EXTENSION postgres_fdw;
 CREATE SERVER loopback
@@ -589,6 +592,8 @@ ALTER USER MAPPING FOR :ROLE_DEFAULT_PERM_USER
    OPTIONS (ADD password_required 'false');
 GRANT USAGE ON FOREIGN SERVER loopback TO :ROLE_DEFAULT_PERM_USER;
 \c :TEST_DBNAME :ROLE_DEFAULT_PERM_USER;
+
+SET timezone TO PST8PDT;
 
 CREATE FOREIGN TABLE devices_fdw (
    device_id int not null,

--- a/tsl/test/sql/cagg_policy.sql
+++ b/tsl/test/sql/cagg_policy.sql
@@ -6,7 +6,6 @@
 
 SET ROLE :ROLE_DEFAULT_PERM_USER;
 
-
 --TEST1 ---
 --basic test with count
 CREATE TABLE int_tab (a integer, b integer, c integer);
@@ -33,6 +32,9 @@ FROM int_tab
 GROUP BY time_bucket(1, a), a WITH NO DATA;
 
 \c :TEST_DBNAME :ROLE_SUPERUSER
+
+SET timezone TO PST8PDT;
+
 DELETE FROM _timescaledb_config.bgw_job WHERE TRUE;
 
 SET ROLE :ROLE_DEFAULT_PERM_USER;
@@ -129,6 +131,9 @@ SELECT hypertable_id as mat_id FROM _timescaledb_config.bgw_job where id = :job_
 \set ON_ERROR_STOP 1
 
 \c :TEST_DBNAME :ROLE_SUPERUSER
+
+SET timezone TO PST8PDT;
+
 UPDATE _timescaledb_config.bgw_job
 SET config = jsonb_build_object('mat_hypertable_id', :mat_id)
 WHERE id = :job_id;
@@ -340,6 +345,9 @@ SELECT config FROM _timescaledb_config.bgw_job
 WHERE id = :job_id;
 
 \c :TEST_DBNAME :ROLE_SUPERUSER
+
+SET timezone TO PST8PDT;
+
 UPDATE _timescaledb_config.bgw_job
 SET config = jsonb_build_object('mat_hypertable_id', :mat_id)
 WHERE id = :job_id;

--- a/tsl/test/sql/cagg_query.sql
+++ b/tsl/test/sql/cagg_query.sql
@@ -5,6 +5,8 @@
 -- Connect as superuser to use SET ROLE later
 \c :TEST_DBNAME :ROLE_CLUSTER_SUPERUSER
 
+SET timezone TO PST8PDT;
+
 -- Run tests with default role
 SET ROLE :ROLE_DEFAULT_PERM_USER;
 

--- a/tsl/test/sql/cagg_query_using_merge.sql
+++ b/tsl/test/sql/cagg_query_using_merge.sql
@@ -5,6 +5,8 @@
 -- Connect as superuser to use SET ROLE later
 \c :TEST_DBNAME :ROLE_CLUSTER_SUPERUSER
 
+SET timezone TO PST8PDT;
+
 -- Run tests with default role
 SET ROLE :ROLE_DEFAULT_PERM_USER;
 

--- a/tsl/test/sql/cagg_refresh.sql
+++ b/tsl/test/sql/cagg_refresh.sql
@@ -2,4 +2,6 @@
 -- Please see the included NOTICE for copyright information and
 -- LICENSE-TIMESCALE for a copy of the license.
 
+SET timezone TO PST8PDT;
+
 \ir include/cagg_refresh_common.sql

--- a/tsl/test/sql/cagg_refresh_using_merge.sql
+++ b/tsl/test/sql/cagg_refresh_using_merge.sql
@@ -4,5 +4,6 @@
 
 -- Enable MERGE statements for continuous aggregate refresh
 SET timescaledb.enable_merge_on_cagg_refresh TO ON;
+SET timezone TO PST8PDT;
 
 \ir include/cagg_refresh_common.sql

--- a/tsl/test/sql/cagg_repair.sql.in
+++ b/tsl/test/sql/cagg_repair.sql.in
@@ -4,6 +4,8 @@
 
 \c :TEST_DBNAME :ROLE_SUPERUSER
 
+SET timezone TO PST8PDT;
+
 CREATE PROCEDURE _timescaledb_internal.cagg_try_repair (
     cagg_view REGCLASS,
     force_rebuild BOOLEAN

--- a/tsl/test/sql/cagg_union_view.sql.in
+++ b/tsl/test/sql/cagg_union_view.sql.in
@@ -7,6 +7,8 @@
 SELECT _timescaledb_functions.stop_background_workers();
 \c :TEST_DBNAME :ROLE_DEFAULT_PERM_USER
 
+SET timezone TO PST8PDT;
+
 \set PREFIX 'EXPLAIN (analyze, costs off, timing off, summary off)'
 
 CREATE TABLE metrics(f1 int, f2 int, time timestamptz NOT NULL, device_id int, value float);

--- a/tsl/test/sql/cagg_usage.sql.in
+++ b/tsl/test/sql/cagg_usage.sql.in
@@ -6,6 +6,7 @@
 \set ON_ERROR_STOP 0
 SET client_min_messages TO NOTICE;
 SET work_mem TO '64MB';
+SET timezone TO PST8PDT;
 
 -- START OF USAGE TEST --
 

--- a/tsl/test/sql/cagg_utils.sql
+++ b/tsl/test/sql/cagg_utils.sql
@@ -3,6 +3,7 @@
 -- LICENSE-TIMESCALE for a copy of the license.
 
 SET search_path TO public, _timescaledb_functions;
+SET timezone TO PST8PDT;
 
 CREATE TABLE devices (
     id INTEGER,
@@ -112,6 +113,8 @@ CREATE OR REPLACE FUNCTION cagg_get_bucket_function(
     mat_hypertable_id INTEGER
 ) RETURNS regprocedure AS :MODULE_PATHNAME, 'ts_continuous_agg_get_bucket_function' LANGUAGE C STRICT VOLATILE;
 \c :TEST_DBNAME :ROLE_DEFAULT_PERM_USER
+
+SET timezone TO PST8PDT;
 
 CREATE TABLE timestamp_ht (
   time timestamp NOT NULL,

--- a/tsl/test/sql/cagg_watermark.sql
+++ b/tsl/test/sql/cagg_watermark.sql
@@ -2,6 +2,8 @@
 -- Please see the included NOTICE for copyright information and
 -- LICENSE-TIMESCALE for a copy of the license.
 
+SET timezone TO PST8PDT;
+
 \set EXPLAIN_ANALYZE 'EXPLAIN (analyze,costs off,timing off,summary off)'
 
 CREATE TABLE continuous_agg_test(time int, data int);
@@ -43,6 +45,8 @@ SELECT * from _timescaledb_catalog.continuous_aggs_hypertable_invalidation_log;
 \c :TEST_DBNAME :ROLE_SUPERUSER
 INSERT INTO _timescaledb_catalog.continuous_aggs_invalidation_threshold VALUES (1, 15);
 \c :TEST_DBNAME :ROLE_DEFAULT_PERM_USER
+
+SET timezone TO PST8PDT;
 
 INSERT INTO continuous_agg_test VALUES (10, 1), (11, 2), (21, 3), (22, 4);
 
@@ -182,6 +186,8 @@ UPDATE _timescaledb_catalog.continuous_aggs_invalidation_threshold
 SET watermark = 2
 WHERE hypertable_id = 5;
 \c :TEST_DBNAME :ROLE_DEFAULT_PERM_USER
+
+SET timezone TO PST8PDT;
 
 INSERT INTO ts_continuous_test VALUES (1, 1);
 

--- a/tsl/test/sql/chunk_merge.sql
+++ b/tsl/test/sql/chunk_merge.sql
@@ -8,6 +8,8 @@ CREATE OR REPLACE FUNCTION _timescaledb_internal.test_merge_chunks_on_dimension(
     AS :TSL_MODULE_PATHNAME, 'ts_test_merge_chunks_on_dimension' LANGUAGE C VOLATILE;
 \c :TEST_DBNAME :ROLE_DEFAULT_PERM_USER
 
+SET timezone TO PST8PDT;
+
 CREATE TABLE test1 ("Time" timestamptz, i integer, value integer);
 SELECT table_name FROM Create_hypertable('test1', 'Time', chunk_time_interval=> INTERVAL '1 hour');
 SELECT table_name FROM  add_dimension('test1', 'i', number_partitions=> 2);

--- a/tsl/test/sql/compression.sql
+++ b/tsl/test/sql/compression.sql
@@ -3,6 +3,7 @@
 -- LICENSE-TIMESCALE for a copy of the license.
 
 SET timescaledb.enable_transparent_decompression to OFF;
+SET timezone TO PST8PDT;
 
 \set PREFIX 'EXPLAIN (analyze, verbose, costs off, timing off, summary off)'
 
@@ -629,6 +630,8 @@ SET reltuples = 0, relpages = 0
   WHERE ht.table_name = 'stattest2' AND ch.hypertable_id = ht.id
         AND ch.compressed_chunk_id > 0 );
 \c :TEST_DBNAME :ROLE_DEFAULT_PERM_USER
+
+SET timezone TO PST8PDT;
 
 -- reltuples is initially -1 on PG14 before VACUUM/ANALYZE has been run
 SELECT relname, CASE WHEN reltuples > 0 THEN reltuples ELSE 0 END AS reltuples, relpages, relallvisible FROM pg_class

--- a/tsl/test/sql/compression_bgw.sql
+++ b/tsl/test/sql/compression_bgw.sql
@@ -11,6 +11,8 @@ GRANT NOLOGIN_ROLE TO :ROLE_DEFAULT_PERM_USER WITH ADMIN OPTION;
 
 \c :TEST_DBNAME :ROLE_DEFAULT_PERM_USER
 
+SET timezone TO PST8PDT;
+
 CREATE TABLE conditions (
       time        TIMESTAMPTZ       NOT NULL,
       location    TEXT              NOT NULL,
@@ -163,6 +165,8 @@ DROP TABLE test_table_nologin;
 RESET ROLE;
 
 \c :TEST_DBNAME :ROLE_DEFAULT_PERM_USER
+
+SET timezone TO PST8PDT;
 
 CREATE TABLE conditions(
     time TIMESTAMPTZ NOT NULL,

--- a/tsl/test/sql/compression_ddl.sql
+++ b/tsl/test/sql/compression_ddl.sql
@@ -15,6 +15,8 @@ CREATE TABLESPACE tablespace2 OWNER :ROLE_DEFAULT_PERM_USER LOCATION :TEST_TABLE
 
 \c :TEST_DBNAME :ROLE_DEFAULT_PERM_USER
 
+SET timezone TO PST8PDT;
+
 CREATE TABLE test1 ("Time" timestamptz, i integer, b bigint, t text);
 SELECT table_name from create_hypertable('test1', 'Time', chunk_time_interval=> INTERVAL '1 day');
 
@@ -355,6 +357,8 @@ CALL refresh_continuous_aggregate('test1_cont_view', NULL, NULL);
 SELECT count(*) FROM test1_cont_view;
 
 \c :TEST_DBNAME :ROLE_SUPERUSER
+
+SET timezone TO PST8PDT;
 
 SELECT chunk.schema_name|| '.' || chunk.table_name as "COMPRESSED_CHUNK_NAME"
 FROM _timescaledb_catalog.chunk chunk

--- a/tsl/test/sql/compression_insert.sql
+++ b/tsl/test/sql/compression_insert.sql
@@ -2,6 +2,8 @@
 -- Please see the included NOTICE for copyright information and
 -- LICENSE-TIMESCALE for a copy of the license.
 
+SET timezone TO PST8PDT;
+
 \set PREFIX 'EXPLAIN (costs off, summary off, timing off) '
 \set ANALYZE  'EXPLAIN (analyze, costs off, summary off, timing off) '
 CREATE TABLE test1 (timec timestamptz , i integer ,

--- a/tsl/test/sql/continuous_aggs.sql.in
+++ b/tsl/test/sql/continuous_aggs.sql.in
@@ -606,6 +606,8 @@ WHERE user_view_name = 'mat_drop_test'
 \gset
 
 SET client_min_messages TO NOTICE;
+SET timezone TO PST8PDT;
+
 CALL refresh_continuous_aggregate('mat_drop_test', NULL, NULL);
 
 --force invalidation

--- a/tsl/test/sql/feature_flags.sql
+++ b/tsl/test/sql/feature_flags.sql
@@ -4,6 +4,8 @@
 
 \c :TEST_DBNAME :ROLE_SUPERUSER
 
+SET timezone TO PST8PDT;
+
 -- hypertable creation
 SHOW timescaledb.enable_hypertable_create;
 SET timescaledb.enable_hypertable_create TO off;

--- a/tsl/test/sql/information_view_chunk_count.sql
+++ b/tsl/test/sql/information_view_chunk_count.sql
@@ -2,6 +2,8 @@
 -- Please see the included NOTICE for copyright information and
 -- LICENSE-TIMESCALE for a copy of the license.
 
+SET timezone TO PST8PDT;
+
 CREATE TABLE sensor_data(
 time timestamptz not null,
 sensor_id integer not null,

--- a/tsl/test/sql/jit.sql
+++ b/tsl/test/sql/jit.sql
@@ -2,6 +2,8 @@
 -- Please see the included NOTICE for copyright information and
 -- LICENSE-TIMESCALE for a copy of the license.
 
+SET timezone TO PST8PDT;
+
 \set TEST_BASE_NAME jit
 SELECT format('include/%s_load.sql', :'TEST_BASE_NAME') as "TEST_LOAD_NAME",
        format('include/%s_query.sql', :'TEST_BASE_NAME') as "TEST_QUERY_NAME",

--- a/tsl/test/sql/size_utils_tsl.sql
+++ b/tsl/test/sql/size_utils_tsl.sql
@@ -2,6 +2,8 @@
 -- Please see the included NOTICE for copyright information and
 -- LICENSE-TIMESCALE for a copy of the license.
 
+SET timezone TO PST8PDT;
+
 -- Prepare test data for continuous aggregate size function tests
 CREATE TABLE hypersize(time timestamptz, device int);
 SELECT * FROM create_hypertable('hypersize', 'time');

--- a/tsl/test/sql/telemetry_stats.sql
+++ b/tsl/test/sql/telemetry_stats.sql
@@ -5,6 +5,8 @@
 --telemetry tests that require a community license
 \c :TEST_DBNAME :ROLE_CLUSTER_SUPERUSER;
 
+SET timezone TO PST8PDT;
+
 -- function call info size is too variable for this test, so disable it
 SET timescaledb.telemetry_level='no_functions';
 

--- a/tsl/test/sql/transparent_decompression.sql.in
+++ b/tsl/test/sql/transparent_decompression.sql.in
@@ -12,6 +12,7 @@ SELECT format('\! diff %s %s', :'TEST_RESULTS_UNCOMPRESSED', :'TEST_RESULTS_COMP
 
 SET work_mem TO '50MB';
 SET enable_incremental_sort TO off;
+SET timezone TO PST8PDT;
 
 -- disable memoize node to make EXPLAIN output comparable between PG14 and previous versions
 SELECT CASE WHEN current_setting('server_version_num')::int/10000 >= 14 THEN set_config('enable_memoize','off',false) ELSE 'off' END AS enable_memoize;
@@ -189,6 +190,9 @@ FROM _timescaledb_catalog.hypertable ht
 -- Once a standard way exists, modify this test to use that method.
 
 \c :TEST_DBNAME :ROLE_DEFAULT_PERM_USER
+
+SET timezone TO PST8PDT;
+
 CREATE INDEX ON metrics_space (device_id, device_id_peer, v0, v1 DESC, time);
 
 CREATE INDEX ON metrics_space (device_id, device_id_peer DESC, v0, v1 DESC, time);


### PR DESCRIPTION
Don't depend on pg_regress timezone in our tests as this is gonna change with the next minor release of postgres.

https://github.com/postgres/postgres/commit/b8ea0f67

Disable-check: force-changelog-file
