### PR TITLE
Share vector qual functionality across scan nodes

### DIFF
--- a/tsl/src/nodes/decompress_chunk/compressed_batch.c
+++ b/tsl/src/nodes/decompress_chunk/compressed_batch.c
@@ -6,6 +6,7 @@
 
 #include <postgres.h>
 
+#include <executor/tuptable.h>
 #include <nodes/bitmapset.h>
 #include <utils/builtins.h>
 #include <utils/date.h>
@@ -17,6 +18,19 @@
 #include "guc.h"
 #include "nodes/decompress_chunk/compressed_batch.h"
 #include "nodes/decompress_chunk/vector_predicates.h"
+#include "nodes/decompress_chunk/vector_quals.h"
+
+/*
+ * VectorQualState for a compressed batch used to pass
+ * DecompressChunk-specific data to vector qual functions that are shared
+ * across scan nodes.
+ */
+typedef struct CompressedBatchVectorQualState
+{
+	VectorQualState vqstate;
+	DecompressBatchState *batch_state;
+	DecompressContext *dcontext;
+} CompressedBatchVectorQualState;
 
 /*
  * Create a single-value ArrowArray of an arithmetic type. This is a specialized
@@ -127,7 +141,7 @@ make_single_value_arrow_text(Datum datum, bool isnull)
  * Create a single value ArrowArray from Postgres Datum. This is used to run
  * the usual vectorized predicates on compressed columns with default values.
  */
-static ArrowArray *
+ArrowArray *
 make_single_value_arrow(Oid pgtype, Datum datum, bool isnull)
 {
 	if (pgtype == TEXTOID)
@@ -289,117 +303,23 @@ decompress_column(DecompressContext *dcontext, DecompressBatchState *batch_state
 }
 
 /*
- * When we have a dictionary-encoded Arrow Array, and have run a predicate on
- * the dictionary, this function is used to translate the dictionary predicate
- * result to the final predicate result.
+ * Get the arrow array for the compressed batch via the VectorQualState.
+ *
+ * This is a DecompressChunk-specific implementation of the
+ * VectorQualState->get_arrow_array() function used to interface with the
+ * vector qual code across different scan nodes.
  */
-static void
-translate_bitmap_from_dictionary(const ArrowArray *arrow, const uint64 *dict_result,
-								 uint64 *restrict final_result)
+static const ArrowArray *
+compressed_batch_get_arrow_array(VectorQualState *vqstate, Expr *expr, bool *is_default_value)
 {
-	Assert(arrow->dictionary != NULL);
-
-	const size_t n = arrow->length;
-	const int16 *indices = (int16 *) arrow->buffers[1];
-	for (size_t outer = 0; outer < n / 64; outer++)
-	{
-		uint64 word = 0;
-		for (size_t inner = 0; inner < 64; inner++)
-		{
-			const size_t row = outer * 64 + inner;
-			const size_t bit_index = inner;
-#define INNER_LOOP                                                                                 \
-	const int16 index = indices[row];                                                              \
-	const bool valid = arrow_row_is_valid(dict_result, index);                                     \
-	word |= ((uint64) valid) << bit_index;
-
-			INNER_LOOP
-		}
-		final_result[outer] &= word;
-	}
-
-	if (n % 64)
-	{
-		uint64 word = 0;
-		for (size_t row = (n / 64) * 64; row < n; row++)
-		{
-			const size_t bit_index = row % 64;
-
-			INNER_LOOP
-		}
-		final_result[n / 64] &= word;
-	}
-#undef INNER_LOOP
-}
-
-static void
-compute_plain_qual(DecompressContext *dcontext, DecompressBatchState *batch_state,
-				   TupleTableSlot *compressed_slot, Node *qual, uint64 *restrict result)
-{
-	/*
-	 * Some predicates can be evaluated to a Const at run time.
-	 */
-	if (IsA(qual, Const))
-	{
-		Const *c = castNode(Const, qual);
-		if (c->constisnull || !DatumGetBool(c->constvalue))
-		{
-			/*
-			 * Some predicates are evaluated to a null Const, like a
-			 * strict comparison with stable expression that evaluates to null.
-			 * No rows pass.
-			 */
-			const size_t n_batch_result_words = (batch_state->total_batch_rows + 63) / 64;
-			for (size_t i = 0; i < n_batch_result_words; i++)
-			{
-				result[i] = 0;
-			}
-		}
-		else
-		{
-			/*
-			 * This is a constant true qual, every row passes and we can
-			 * just ignore it. No idea how it can happen though.
-			 */
-			Assert(false);
-		}
-		return;
-	}
-
-	/*
-	 * For now, we support NullTest, "Var ? Const" predicates and
-	 * ScalarArrayOperations.
-	 */
-	List *args = NULL;
-	RegProcedure vector_const_opcode = InvalidOid;
-	ScalarArrayOpExpr *saop = NULL;
-	OpExpr *opexpr = NULL;
-	NullTest *nulltest = NULL;
-	if (IsA(qual, NullTest))
-	{
-		nulltest = castNode(NullTest, qual);
-		args = list_make1(nulltest->arg);
-	}
-	else if (IsA(qual, ScalarArrayOpExpr))
-	{
-		saop = castNode(ScalarArrayOpExpr, qual);
-		args = saop->args;
-		vector_const_opcode = get_opcode(saop->opno);
-	}
-	else
-	{
-		Ensure(IsA(qual, OpExpr), "expected OpExpr");
-		opexpr = castNode(OpExpr, qual);
-		args = opexpr->args;
-		vector_const_opcode = get_opcode(opexpr->opno);
-	}
-
-	/*
-	 * Find the compressed column referred to by the Var.
-	 */
-	Var *var = castNode(Var, linitial(args));
+	CompressedBatchVectorQualState *cbvqstate = (CompressedBatchVectorQualState *) vqstate;
+	DecompressContext *dcontext = cbvqstate->dcontext;
+	DecompressBatchState *batch_state = cbvqstate->batch_state;
 	CompressionColumnDescription *column_description = NULL;
+	TupleTableSlot *compressed_slot = vqstate->slot;
+	const Var *var = castNode(Var, expr);
 	int column_index = 0;
+
 	for (; column_index < dcontext->num_data_columns; column_index++)
 	{
 		column_description = &dcontext->compressed_chunk_columns[column_index];
@@ -460,8 +380,6 @@ compute_plain_qual(DecompressContext *dcontext, DecompressBatchState *batch_stat
 	 * default values in a special way because they don't produce the usual
 	 * decompressed ArrowArrays.
 	 */
-	uint64 default_value_predicate_result[1];
-	uint64 *predicate_result = result;
 	const ArrowArray *vector = column_values->arrow;
 	if (column_values->arrow == NULL)
 	{
@@ -481,6 +399,135 @@ compute_plain_qual(DecompressContext *dcontext, DecompressBatchState *batch_stat
 										 *column_values->output_value,
 										 *column_values->output_isnull);
 
+		/*
+		 * We start from an all-valid bitmap, because the predicate is
+		 * AND-ed to it.
+		 */
+		*is_default_value = true;
+	}
+	else
+		*is_default_value = false;
+
+	return vector;
+}
+
+/*
+ * When we have a dictionary-encoded Arrow Array, and have run a predicate on
+ * the dictionary, this function is used to translate the dictionary predicate
+ * result to the final predicate result.
+ */
+static void
+translate_bitmap_from_dictionary(const ArrowArray *arrow, const uint64 *dict_result,
+								 uint64 *restrict final_result)
+{
+	Assert(arrow->dictionary != NULL);
+
+	const size_t n = arrow->length;
+	const int16 *indices = (int16 *) arrow->buffers[1];
+	for (size_t outer = 0; outer < n / 64; outer++)
+	{
+		uint64 word = 0;
+		for (size_t inner = 0; inner < 64; inner++)
+		{
+			const size_t row = outer * 64 + inner;
+			const size_t bit_index = inner;
+#define INNER_LOOP                                                                                 \
+	const int16 index = indices[row];                                                              \
+	const bool valid = arrow_row_is_valid(dict_result, index);                                     \
+	word |= ((uint64) valid) << bit_index;
+
+			INNER_LOOP
+		}
+		final_result[outer] &= word;
+	}
+
+	if (n % 64)
+	{
+		uint64 word = 0;
+		for (size_t row = (n / 64) * 64; row < n; row++)
+		{
+			const size_t bit_index = row % 64;
+
+			INNER_LOOP
+		}
+		final_result[n / 64] &= word;
+	}
+#undef INNER_LOOP
+}
+
+static void
+compute_plain_qual(VectorQualState *vqstate, TupleTableSlot *slot, Node *qual,
+				   uint64 *restrict result)
+{
+	/*
+	 * Some predicates can be evaluated to a Const at run time.
+	 */
+	if (IsA(qual, Const))
+	{
+		Const *c = castNode(Const, qual);
+		if (c->constisnull || !DatumGetBool(c->constvalue))
+		{
+			/*
+			 * Some predicates are evaluated to a null Const, like a
+			 * strict comparison with stable expression that evaluates to null.
+			 * No rows pass.
+			 */
+			const size_t n_batch_result_words = (vqstate->num_results + 63) / 64;
+			for (size_t i = 0; i < n_batch_result_words; i++)
+			{
+				result[i] = 0;
+			}
+		}
+		else
+		{
+			/*
+			 * This is a constant true qual, every row passes and we can
+			 * just ignore it. No idea how it can happen though.
+			 */
+			Assert(false);
+		}
+		return;
+	}
+
+	/*
+	 * For now, we support NullTest, "Var ? Const" predicates and
+	 * ScalarArrayOperations.
+	 */
+	List *args = NULL;
+	RegProcedure vector_const_opcode = InvalidOid;
+	ScalarArrayOpExpr *saop = NULL;
+	OpExpr *opexpr = NULL;
+	NullTest *nulltest = NULL;
+	if (IsA(qual, NullTest))
+	{
+		nulltest = castNode(NullTest, qual);
+		args = list_make1(nulltest->arg);
+	}
+	else if (IsA(qual, ScalarArrayOpExpr))
+	{
+		saop = castNode(ScalarArrayOpExpr, qual);
+		args = saop->args;
+		vector_const_opcode = get_opcode(saop->opno);
+	}
+	else
+	{
+		Ensure(IsA(qual, OpExpr), "expected OpExpr");
+		opexpr = castNode(OpExpr, qual);
+		args = opexpr->args;
+		vector_const_opcode = get_opcode(opexpr->opno);
+	}
+
+	/*
+	 * Find the compressed column referred to by the Var.
+	 */
+	Expr *expr = linitial(args);
+	uint64 default_value_predicate_result[1];
+	uint64 *predicate_result = result;
+	bool default_value = false;
+	const ArrowArray *vector = vqstate->get_arrow_array(vqstate, expr, &default_value);
+
+	if (default_value)
+	{
 		/*
 		 * We start from an all-valid bitmap, because the predicate is
 		 * AND-ed to it.
@@ -580,16 +627,15 @@ compute_plain_qual(DecompressContext *dcontext, DecompressBatchState *batch_stat
 	}
 
 	/* Translate the result if the column had a default value. */
-	if (column_values->arrow == NULL)
+	if (default_value)
 	{
-		Assert(column_values->decompression_type == DT_Scalar);
 		if (!(default_value_predicate_result[0] & 1))
 		{
 			/*
 			 * We had a default value for the compressed column, and it
 			 * didn't pass the predicate, so the entire batch didn't pass.
 			 */
-			const size_t n_batch_result_words = (batch_state->total_batch_rows + 63) / 64;
+			const size_t n_batch_result_words = (vqstate->num_results + 63) / 64;
 			for (size_t i = 0; i < n_batch_result_words; i++)
 			{
 				result[i] = 0;
@@ -598,18 +644,17 @@ compute_plain_qual(DecompressContext *dcontext, DecompressBatchState *batch_stat
 	}
 }
 
-static void compute_one_qual(DecompressContext *dcontext, DecompressBatchState *batch_state,
-							 TupleTableSlot *compressed_slot, Node *qual, uint64 *restrict result);
-
+static void compute_one_qual(VectorQualState *vqstate, TupleTableSlot *compressed_slot, Node *qual,
+							 uint64 *restrict result);
 static void
-compute_qual_conjunction(DecompressContext *dcontext, DecompressBatchState *batch_state,
-						 TupleTableSlot *compressed_slot, List *quals, uint64 *restrict result)
+compute_qual_conjunction(VectorQualState *vqstate, TupleTableSlot *compressed_slot, List *quals,
+						 uint64 *restrict result)
 {
 	ListCell *lc;
 	foreach (lc, quals)
 	{
-		compute_one_qual(dcontext, batch_state, compressed_slot, lfirst(lc), result);
-		if (get_vector_qual_summary(result, batch_state->total_batch_rows) == NoRowsPass)
+		compute_one_qual(vqstate, compressed_slot, lfirst(lc), result);
+		if (get_vector_qual_summary(result, vqstate->num_results) == NoRowsPass)
 		{
 			/*
 			 * Exit early if no rows pass already. This might allow us to avoid
@@ -621,10 +666,10 @@ compute_qual_conjunction(DecompressContext *dcontext, DecompressBatchState *batc
 }
 
 static void
-compute_qual_disjunction(DecompressContext *dcontext, DecompressBatchState *batch_state,
-						 TupleTableSlot *compressed_slot, List *quals, uint64 *restrict result)
+compute_qual_disjunction(VectorQualState *vqstate, TupleTableSlot *compressed_slot, List *quals,
+						 uint64 *restrict result)
 {
-	const size_t n_rows = batch_state->total_batch_rows;
+	const size_t n_rows = vqstate->num_results;
 	const size_t n_result_words = (n_rows + 63) / 64;
 	uint64 *or_result = palloc(sizeof(uint64) * n_result_words);
 	for (size_t i = 0; i < n_result_words; i++)
@@ -641,7 +686,7 @@ compute_qual_disjunction(DecompressContext *dcontext, DecompressBatchState *batc
 		{
 			one_qual_result[i] = (uint64) -1;
 		}
-		compute_one_qual(dcontext, batch_state, compressed_slot, lfirst(lc), one_qual_result);
+		compute_one_qual(vqstate, compressed_slot, lfirst(lc), one_qual_result);
 		for (size_t i = 0; i < n_result_words; i++)
 		{
 			or_result[i] |= one_qual_result[i];
@@ -664,19 +709,19 @@ compute_qual_disjunction(DecompressContext *dcontext, DecompressBatchState *batc
 }
 
 static void
-compute_one_qual(DecompressContext *dcontext, DecompressBatchState *batch_state,
-				 TupleTableSlot *compressed_slot, Node *qual, uint64 *restrict result)
+compute_one_qual(VectorQualState *vqstate, TupleTableSlot *compressed_slot, Node *qual,
+				 uint64 *restrict result)
 {
 	if (!IsA(qual, BoolExpr))
 	{
-		compute_plain_qual(dcontext, batch_state, compressed_slot, qual, result);
+		compute_plain_qual(vqstate, compressed_slot, qual, result);
 		return;
 	}
 
 	BoolExpr *boolexpr = castNode(BoolExpr, qual);
 	if (boolexpr->boolop == AND_EXPR)
 	{
-		compute_qual_conjunction(dcontext, batch_state, compressed_slot, boolexpr->args, result);
+		compute_qual_conjunction(vqstate, compressed_slot, boolexpr->args, result);
 		return;
 	}
 
@@ -685,7 +730,7 @@ compute_one_qual(DecompressContext *dcontext, DecompressBatchState *batch_state,
 	 * NOT and consider it non-vectorizable at planning time. So only OR is left.
 	 */
 	Ensure(boolexpr->boolop == OR_EXPR, "expected OR");
-	compute_qual_disjunction(dcontext, batch_state, compressed_slot, boolexpr->args, result);
+	compute_qual_disjunction(vqstate, compressed_slot, boolexpr->args, result);
 }
 
 /*
@@ -693,19 +738,18 @@ compute_one_qual(DecompressContext *dcontext, DecompressBatchState *batch_state,
  * it means the entire batch is filtered out, and we use this for further
  * optimizations.
  */
-static VectorQualSummary
-compute_vector_quals(DecompressContext *dcontext, DecompressBatchState *batch_state,
-					 TupleTableSlot *compressed_slot)
+VectorQualSummary
+vector_qual_compute(VectorQualState *vqstate)
 {
 	/*
 	 * Allocate the bitmap that will hold the vectorized qual results. We will
 	 * initialize it to all ones and AND the individual quals to it.
 	 */
-	const size_t n_rows = batch_state->total_batch_rows;
+	const size_t n_rows = vqstate->num_results;
 	const int bitmap_bytes = sizeof(uint64) * ((n_rows + 63) / 64);
-	batch_state->vector_qual_result =
-		MemoryContextAlloc(batch_state->per_batch_context, bitmap_bytes);
-	memset(batch_state->vector_qual_result, 0xFF, bitmap_bytes);
+	vqstate->vector_qual_result = MemoryContextAlloc(vqstate->per_vector_mcxt, bitmap_bytes);
+	memset(vqstate->vector_qual_result, 0xFF, bitmap_bytes);
+
 	if (n_rows % 64 != 0)
 	{
 		/*
@@ -713,20 +757,19 @@ compute_vector_quals(DecompressContext *dcontext, DecompressBatchState *batch_st
 		 * bitmap word. Since all predicates are ANDed to the result bitmap,
 		 * we can do it here once instead of doing it in each predicate.
 		 */
-		const uint64 mask = ((uint64) -1) >> (64 - batch_state->total_batch_rows % 64);
-		batch_state->vector_qual_result[batch_state->total_batch_rows / 64] = mask;
+		const uint64 mask = ((uint64) -1) >> (64 - vqstate->num_results % 64);
+		vqstate->vector_qual_result[vqstate->num_results / 64] = mask;
 	}
 
 	/*
 	 * Compute the quals.
 	 */
-	compute_qual_conjunction(dcontext,
-							 batch_state,
-							 compressed_slot,
-							 dcontext->vectorized_quals_constified,
-							 batch_state->vector_qual_result);
+	compute_qual_conjunction(vqstate,
+							 vqstate->slot,
+							 vqstate->vectorized_quals_constified,
+							 vqstate->vector_qual_result);
 
-	return get_vector_qual_summary(batch_state->vector_qual_result, n_rows);
+	return get_vector_qual_summary(vqstate->vector_qual_result, n_rows);
 }
 
 /*
@@ -937,10 +980,24 @@ compressed_batch_set_compressed_tuple(DecompressContext *dcontext,
 		}
 	}
 
+	CompressedBatchVectorQualState cbvqstate = {
+		.vqstate = {
+			.vectorized_quals_constified = dcontext->vectorized_quals_constified,
+			.num_results = batch_state->total_batch_rows,
+			.per_vector_mcxt = batch_state->per_batch_context,
+			.slot = compressed_slot,
+			.get_arrow_array = compressed_batch_get_arrow_array,
+		},
+		.batch_state = batch_state,
+		.dcontext = dcontext,
+	};
+	VectorQualState *vqstate = &cbvqstate.vqstate;
+
 	VectorQualSummary vector_qual_summary =
-		dcontext->vectorized_quals_constified != NIL ?
-			compute_vector_quals(dcontext, batch_state, compressed_slot) :
-			AllRowsPass;
+		vqstate->vectorized_quals_constified != NIL ? vector_qual_compute(vqstate) : AllRowsPass;
+
+	batch_state->vector_qual_result = vqstate->vector_qual_result;
+
 	if (vector_qual_summary == NoRowsPass && !dcontext->batch_sorted_merge)
 	{
 		/*
@@ -982,6 +1039,7 @@ compressed_batch_set_compressed_tuple(DecompressContext *dcontext,
 		if (vector_qual_summary == AllRowsPass)
 		{
 			batch_state->vector_qual_result = NULL;
+			vqstate->vector_qual_result = NULL;
 		}
 	}
 }

--- a/tsl/src/nodes/decompress_chunk/compressed_batch.h
+++ b/tsl/src/nodes/decompress_chunk/compressed_batch.h
@@ -7,6 +7,7 @@
 
 #include "compression/compression.h"
 #include "nodes/decompress_chunk/decompress_context.h"
+#include <executor/tuptable.h>
 
 typedef struct ArrowArray ArrowArray;
 

--- a/tsl/src/nodes/decompress_chunk/planner.c
+++ b/tsl/src/nodes/decompress_chunk/planner.c
@@ -34,6 +34,7 @@
 #include "nodes/decompress_chunk/decompress_chunk.h"
 #include "nodes/decompress_chunk/exec.h"
 #include "nodes/decompress_chunk/planner.h"
+#include "nodes/decompress_chunk/vector_quals.h"
 #include "nodes/vector_agg/exec.h"
 #include "ts_catalog/array_utils.h"
 #include "vector_predicates.h"
@@ -144,6 +145,26 @@ typedef struct
 	List *bulk_decompression_column;
 
 } DecompressionMapContext;
+
+typedef struct VectorQualInfoDecompressChunk
+{
+	VectorQualInfo vqinfo;
+	const UncompressedColumnInfo *colinfo;
+} VectorQualInfoDecompressChunk;
+
+static bool *
+build_vector_attrs_array(const UncompressedColumnInfo *colinfo, const CompressionInfo *info)
+{
+	const unsigned short arrlen = info->chunk_rel->max_attr + 1;
+	bool *vector_attrs = palloc(sizeof(bool) * arrlen);
+
+	for (AttrNumber attno = 0; attno < arrlen; attno++)
+	{
+		vector_attrs[attno] = colinfo[attno].bulk_decompression_possible;
+	}
+
+	return vector_attrs;
+}
 
 /*
  * Try to make the custom scan targetlist that follows the order of the
@@ -660,8 +681,8 @@ is_not_runtime_constant(Node *node)
  * Try to check if the current qual is vectorizable, and if needed make a
  * commuted copy. If not, return NULL.
  */
-static Node *
-make_vectorized_qual(DecompressionMapContext *context, DecompressChunkPath *path, Node *qual)
+Node *
+vector_qual_make(Node *qual, const VectorQualInfo *vqinfo)
 {
 	/*
 	 * We can vectorize BoolExpr (AND/OR/NOT).
@@ -685,7 +706,7 @@ make_vectorized_qual(DecompressionMapContext *context, DecompressChunkPath *path
 		foreach (lc, boolexpr->args)
 		{
 			Node *arg = lfirst(lc);
-			Node *vectorized_arg = make_vectorized_qual(context, path, arg);
+			Node *vectorized_arg = vector_qual_make(arg, vqinfo);
 			if (vectorized_arg == NULL)
 			{
 				return NULL;
@@ -781,7 +802,7 @@ make_vectorized_qual(DecompressionMapContext *context, DecompressChunkPath *path
 	}
 
 	Var *var = castNode(Var, arg1);
-	if ((Index) var->varno != path->info->chunk_rel->relid)
+	if ((Index) var->varno != vqinfo->rti)
 	{
 		/*
 		 * We have a Var from other relation (join clause), can't vectorize it
@@ -802,7 +823,7 @@ make_vectorized_qual(DecompressionMapContext *context, DecompressChunkPath *path
 	 * ExecQual is performed before ExecProject and operates on the decompressed
 	 * scan slot, so the qual attnos are the uncompressed chunk attnos.
 	 */
-	if (!context->uncompressed_attno_info[var->varattno].bulk_decompression_possible)
+	if (!vqinfo->vector_attrs[var->varattno])
 	{
 		/* This column doesn't support bulk decompression. */
 		return NULL;
@@ -879,6 +900,7 @@ find_vectorized_quals(DecompressionMapContext *context, DecompressChunkPath *pat
 					  List **vectorized, List **nonvectorized)
 {
 	ListCell *lc;
+
 	foreach (lc, qual_list)
 	{
 		Node *source_qual = lfirst(lc);
@@ -891,8 +913,14 @@ find_vectorized_quals(DecompressionMapContext *context, DecompressChunkPath *pat
 		 */
 		Node *transformed_comparison =
 			(Node *) ts_transform_cross_datatype_comparison((Expr *) source_qual);
-
-		Node *vectorized_qual = make_vectorized_qual(context, path, transformed_comparison);
+		VectorQualInfoDecompressChunk vqidc = {
+			.vqinfo = {
+				.vector_attrs = build_vector_attrs_array(context->uncompressed_attno_info, path->info),
+				.rti = path->info->chunk_rel->relid,
+			},
+			.colinfo = context->uncompressed_attno_info,
+		};
+		Node *vectorized_qual = vector_qual_make(transformed_comparison, &vqidc.vqinfo);
 		if (vectorized_qual)
 		{
 			*vectorized = lappend(*vectorized, vectorized_qual);
@@ -901,6 +929,8 @@ find_vectorized_quals(DecompressionMapContext *context, DecompressChunkPath *pat
 		{
 			*nonvectorized = lappend(*nonvectorized, source_qual);
 		}
+
+		pfree(vqidc.vqinfo.vector_attrs);
 	}
 }
 

--- a/tsl/src/nodes/decompress_chunk/vector_quals.h
+++ b/tsl/src/nodes/decompress_chunk/vector_quals.h
@@ -1,0 +1,57 @@
+/*
+ * This file and its contents are licensed under the Timescale License.
+ * Please see the included NOTICE for copyright information and
+ * LICENSE-TIMESCALE for a copy of the license.
+ */
+#pragma once
+
+#include <postgres.h>
+#include <executor/tuptable.h>
+#include <nodes/primnodes.h>
+
+#include "compression/arrow_c_data_interface.h"
+#include "vector_predicates.h"
+
+/*
+ * VectorQualInfo provides planner time information for extracting
+ * vectorizable quals from regular quals.
+ */
+typedef struct VectorQualInfo
+{
+	/* The range-table index of the relation to compute vectorized quals
+	 * for */
+	Index rti;
+
+	/* AttrNumber-indexed array indicating whether an attribute/column is a
+	 * vectorizable type */
+	bool *vector_attrs;
+} VectorQualInfo;
+
+/*
+ * VectorQualState keeps the necessary state needed for the computation of
+ * vectorized filters in scan nodes.
+ */
+typedef struct VectorQualState
+{
+	List *vectorized_quals_constified;
+	uint16 num_results;
+	uint64 *vector_qual_result;
+	MemoryContext per_vector_mcxt;
+	TupleTableSlot *slot;
+
+	/*
+	 * Interface function to be provided by scan node.
+	 *
+	 * Given a (compressed) tuple/slot, and a column reference (Var), get the
+	 * corresponding arrow array.
+	 *
+	 * Scan-node specific context data can be provided by wrapping this struct
+	 * in a larger one.
+	 */
+	const ArrowArray *(*get_arrow_array)(struct VectorQualState *vqstate, Expr *expr,
+										 bool *is_default_value);
+} VectorQualState;
+
+extern Node *vector_qual_make(Node *qual, const VectorQualInfo *vqinfo);
+extern VectorQualSummary vector_qual_compute(VectorQualState *vqstate);
+extern ArrowArray *make_single_value_arrow(Oid pgtype, Datum datum, bool isnull);


### PR DESCRIPTION
Refactor the code for vectorized filtering over arrow arrays so that the code can be called from different scan nodes.

In the future, it might make sense to move the code to a separate directory for code related to vectorization.

Disable-check: force-changelog-file